### PR TITLE
Add the sentence case version of Darktable UI that can be selected as another UI language

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -4,6 +4,7 @@ cs
 da
 de
 el
+en@truecase
 eo
 es
 fi

--- a/po/en@truecase.po
+++ b/po/en@truecase.po
@@ -1,0 +1,25214 @@
+# Translation of darktable to capitalized (orthographically correct) English.
+# Copyright (C) 2023 darktable's copyright holder.
+# This file is distributed under the same license as the darktable package.
+# Victor Forsiuk <vvforce@gmail.com>, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-04-05 18:51+0200\n"
+"PO-Revision-Date: 2023-04-09 20:40+0300\n"
+"Last-Translator: Victor Forsiuk <vvforce@gmail.com>\n"
+"Language-Team: \n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.2.2\n"
+
+#: ../build/bin/conf_gen.h:172 ../build/bin/preferences_gen.h:7809
+msgctxt "preferences"
+msgid "first instance"
+msgstr "First instance"
+
+#: ../build/bin/conf_gen.h:173 ../build/bin/preferences_gen.h:7814
+#: ../build/bin/preferences_gen.h:7833
+msgctxt "preferences"
+msgid "last instance"
+msgstr "Last instance"
+
+#: ../build/bin/conf_gen.h:240 ../build/bin/conf_gen.h:346
+#: ../build/bin/conf_gen.h:356 ../build/bin/conf_gen.h:1186
+#: ../build/bin/conf_gen.h:1202 ../build/bin/preferences_gen.h:4214
+#: ../build/bin/preferences_gen.h:4233 ../build/bin/preferences_gen.h:4309
+#: ../build/bin/preferences_gen.h:6892 ../build/bin/preferences_gen.h:7020
+#: ../build/bin/preferences_gen.h:7085
+msgctxt "preferences"
+msgid "never"
+msgstr "Never"
+
+#: ../build/bin/conf_gen.h:241 ../build/bin/preferences_gen.h:6897
+msgctxt "preferences"
+msgid "once a month"
+msgstr "Once a month"
+
+#: ../build/bin/conf_gen.h:242 ../build/bin/preferences_gen.h:6902
+#: ../build/bin/preferences_gen.h:6931
+msgctxt "preferences"
+msgid "once a week"
+msgstr "Once a week"
+
+#: ../build/bin/conf_gen.h:243 ../build/bin/preferences_gen.h:6907
+msgctxt "preferences"
+msgid "once a day"
+msgstr "Once a day"
+
+#: ../build/bin/conf_gen.h:244 ../build/bin/preferences_gen.h:6912
+msgctxt "preferences"
+msgid "on close"
+msgstr "On close"
+
+#: ../build/bin/conf_gen.h:280 ../build/bin/conf_gen.h:1179
+#: ../build/bin/conf_gen.h:1195 ../build/bin/preferences_gen.h:4179
+#: ../build/bin/preferences_gen.h:4274 ../build/bin/preferences_gen.h:5952
+msgctxt "preferences"
+msgid "small"
+msgstr "Small"
+
+#: ../build/bin/conf_gen.h:281 ../build/bin/conf_gen.h:393
+#: ../build/bin/preferences_gen.h:5957 ../build/bin/preferences_gen.h:5986
+#: ../build/bin/preferences_gen.h:6173 ../build/bin/preferences_gen.h:6202
+msgctxt "preferences"
+msgid "default"
+msgstr "Default"
+
+#: ../build/bin/conf_gen.h:282 ../build/bin/conf_gen.h:2814
+#: ../build/bin/preferences_gen.h:5962
+msgctxt "preferences"
+msgid "large"
+msgstr "Large"
+
+#: ../build/bin/conf_gen.h:283 ../build/bin/preferences_gen.h:5967
+msgctxt "preferences"
+msgid "unrestricted"
+msgstr "Unrestricted"
+
+#: ../build/bin/conf_gen.h:347 ../build/bin/preferences_gen.h:7025
+msgctxt "preferences"
+msgid "after edit"
+msgstr "After edit"
+
+#: ../build/bin/conf_gen.h:348 ../build/bin/preferences_gen.h:7030
+#: ../build/bin/preferences_gen.h:7049
+msgctxt "preferences"
+msgid "on import"
+msgstr "On import"
+
+#: ../build/bin/conf_gen.h:357 ../build/bin/conf_gen.h:1178
+#: ../build/bin/conf_gen.h:1194 ../build/bin/conf_gen.h:3214
+#: ../build/bin/preferences_gen.h:4174 ../build/bin/preferences_gen.h:4269
+#: ../build/bin/preferences_gen.h:5325 ../build/bin/preferences_gen.h:5379
+#: ../build/bin/preferences_gen.h:7090
+msgctxt "preferences"
+msgid "always"
+msgstr "Always"
+
+#: ../build/bin/conf_gen.h:358 ../build/bin/preferences_gen.h:7095
+#: ../build/bin/preferences_gen.h:7114
+msgctxt "preferences"
+msgid "only large entries"
+msgstr "Only large entries"
+
+#: ../build/bin/conf_gen.h:378 ../build/bin/preferences_gen.h:8237
+msgctxt "preferences"
+msgid "sensitive"
+msgstr "Sensitive"
+
+#: ../build/bin/conf_gen.h:379 ../build/bin/preferences_gen.h:8242
+#: ../build/bin/preferences_gen.h:8261
+msgctxt "preferences"
+msgid "insensitive"
+msgstr "Insensitive"
+
+#: ../build/bin/conf_gen.h:394 ../build/bin/preferences_gen.h:6178
+msgctxt "preferences"
+msgid "multiple GPUs"
+msgstr "Multiple GPUs"
+
+#: ../build/bin/conf_gen.h:395 ../build/bin/preferences_gen.h:6183
+msgctxt "preferences"
+msgid "very fast GPU"
+msgstr "Very fast GPU"
+
+#: ../build/bin/conf_gen.h:403 ../build/bin/preferences_gen.h:6244
+#: ../build/bin/preferences_gen.h:6278
+msgctxt "preferences"
+msgid "nothing"
+msgstr "Nothing"
+
+#: ../build/bin/conf_gen.h:404 ../build/bin/preferences_gen.h:6249
+msgctxt "preferences"
+msgid "memory size"
+msgstr "Memory size"
+
+#: ../build/bin/conf_gen.h:405 ../build/bin/preferences_gen.h:6254
+msgctxt "preferences"
+msgid "memory transfer"
+msgstr "Memory transfer"
+
+#: ../build/bin/conf_gen.h:406 ../build/bin/preferences_gen.h:6259
+msgctxt "preferences"
+msgid "memory size and transfer"
+msgstr "Memory size and transfer"
+
+#: ../build/bin/conf_gen.h:706 ../build/bin/preferences_gen.h:8425
+#: ../build/bin/preferences_gen.h:8449
+msgctxt "preferences"
+msgid "id"
+msgstr "Id"
+
+#: ../build/bin/conf_gen.h:707 ../build/bin/preferences_gen.h:8430
+msgctxt "preferences"
+msgid "folder"
+msgstr "Folder"
+
+#: ../build/bin/conf_gen.h:721
+msgctxt "preferences"
+msgid "RGB"
+msgstr "RGB"
+
+#: ../build/bin/conf_gen.h:722
+msgctxt "preferences"
+msgid "Lab"
+msgstr "Lab"
+
+#: ../build/bin/conf_gen.h:723
+msgctxt "preferences"
+msgid "LCh"
+msgstr "LCh"
+
+#: ../build/bin/conf_gen.h:724
+msgctxt "preferences"
+msgid "HSL"
+msgstr "HSL"
+
+#: ../build/bin/conf_gen.h:725
+msgctxt "preferences"
+msgid "Hex"
+msgstr "Hex"
+
+#: ../build/bin/conf_gen.h:726 ../build/bin/conf_gen.h:1830
+#: ../build/bin/conf_gen.h:2488 ../build/bin/conf_gen.h:2790
+#: ../build/bin/conf_gen.h:3044 ../build/bin/preferences_gen.h:5781
+#: ../build/bin/preferences_gen.h:6756
+msgctxt "preferences"
+msgid "none"
+msgstr "None"
+
+#: ../build/bin/conf_gen.h:734
+msgctxt "preferences"
+msgid "mean"
+msgstr "Mean"
+
+#: ../build/bin/conf_gen.h:735
+msgctxt "preferences"
+msgid "min"
+msgstr "Min"
+
+#: ../build/bin/conf_gen.h:736
+msgctxt "preferences"
+msgid "max"
+msgstr "Max"
+
+#: ../build/bin/conf_gen.h:924
+msgid "select only new pictures"
+msgstr "Select only new pictures"
+
+#: ../build/bin/conf_gen.h:925
+msgid "only select images that have not already been imported"
+msgstr "Only select images that have not already been imported"
+
+#: ../build/bin/conf_gen.h:930
+msgid "ignore JPEG images"
+msgstr "Ignore JPEG images"
+
+#: ../build/bin/conf_gen.h:931
+msgid ""
+"when having raw+JPEG images together in one directory it makes no sense to "
+"import both. with this flag one can ignore all JPEGs found."
+msgstr ""
+"When having raw+JPEG images together in one directory it makes no sense to "
+"import both. With this flag one can ignore all JPEGs found."
+
+#: ../build/bin/conf_gen.h:936
+msgid "apply metadata"
+msgstr "Apply metadata"
+
+#: ../build/bin/conf_gen.h:937
+msgid "apply some metadata to all newly imported images."
+msgstr "Apply some metadata to all newly imported images."
+
+#: ../build/bin/conf_gen.h:942
+msgid "recursive directory"
+msgstr "Recursive directory"
+
+#: ../build/bin/conf_gen.h:943
+msgid "recursive directory traversal when importing filmrolls"
+msgstr "Recursive directory traversal when importing filmrolls"
+
+#: ../build/bin/conf_gen.h:948
+msgid "creator to be applied when importing"
+msgstr "Creator to be applied when importing"
+
+#: ../build/bin/conf_gen.h:954
+msgid "publisher to be applied when importing"
+msgstr "Publisher to be applied when importing"
+
+#: ../build/bin/conf_gen.h:960
+msgid "rights to be applied when importing"
+msgstr "Rights to be applied when importing"
+
+#: ../build/bin/conf_gen.h:966
+msgid "comma separated tags to be applied when importing"
+msgstr "Comma separated tags to be applied when importing"
+
+#: ../build/bin/conf_gen.h:972
+msgid "import tags from XMP"
+msgstr "Import tags from XMP"
+
+#: ../build/bin/conf_gen.h:998
+msgid "initial rating"
+msgstr "Initial rating"
+
+#: ../build/bin/conf_gen.h:999
+msgid "initial star rating for all images when importing a filmroll"
+msgstr "Initial star rating for all images when importing a filmroll"
+
+#: ../build/bin/conf_gen.h:1004
+msgid "ignore EXIF rating"
+msgstr "Ignore EXIF rating"
+
+#: ../build/bin/conf_gen.h:1005
+msgid ""
+"ignore EXIF rating. if not set and EXIF rating is found, it overrides "
+"'initial rating'"
+msgstr ""
+"Ignore EXIF rating. If not set and EXIF rating is found, it overrides "
+"'initial rating'"
+
+#: ../build/bin/conf_gen.h:1010
+msgid "import job"
+msgstr "Import job"
+
+#: ../build/bin/conf_gen.h:1011
+msgid "name of the import job"
+msgstr "Name of the import job"
+
+#: ../build/bin/conf_gen.h:1016
+msgid "override today's date"
+msgstr "Override today's date"
+
+#: ../build/bin/conf_gen.h:1017
+msgid ""
+"type a date in the form: YYYY:MM:DD[ hh:mm:ss[.sss]] if you want to override "
+"the current date/time used when expanding variables:\n"
+"$(YEAR), $(MONTH), $(DAY), $(HOUR), $(MINUTE), $(SECONDS), $(MSEC).\n"
+"let the field empty otherwise"
+msgstr ""
+"Type a date in the form: YYYY:MM:DD[ hh:mm:ss[.sss]] if you want to override "
+"the current date/time used when expanding variables:\n"
+"$(YEAR), $(MONTH), $(DAY), $(HOUR), $(MINUTE), $(SECONDS), $(MSEC).\n"
+"Let the field empty otherwise"
+
+#: ../build/bin/conf_gen.h:1022
+msgid "keep this window open"
+msgstr "Keep this window open"
+
+#: ../build/bin/conf_gen.h:1023
+msgid "keep this window open to run several imports"
+msgstr "Keep this window open to run several imports"
+
+#: ../build/bin/conf_gen.h:1180 ../build/bin/conf_gen.h:1196
+#: ../build/bin/preferences_gen.h:4184 ../build/bin/preferences_gen.h:4279
+msgctxt "preferences"
+msgid "VGA"
+msgstr "VGA"
+
+#: ../build/bin/conf_gen.h:1181 ../build/bin/conf_gen.h:1197
+#: ../build/bin/preferences_gen.h:4189 ../build/bin/preferences_gen.h:4284
+#: ../build/bin/preferences_gen.h:4328
+msgctxt "preferences"
+msgid "720p"
+msgstr "720p"
+
+#: ../build/bin/conf_gen.h:1182 ../build/bin/conf_gen.h:1198
+#: ../build/bin/preferences_gen.h:4194 ../build/bin/preferences_gen.h:4289
+msgctxt "preferences"
+msgid "1080p"
+msgstr "1080p"
+
+#: ../build/bin/conf_gen.h:1183 ../build/bin/conf_gen.h:1199
+#: ../build/bin/preferences_gen.h:4199 ../build/bin/preferences_gen.h:4294
+msgctxt "preferences"
+msgid "WQXGA"
+msgstr "WQXGA"
+
+#: ../build/bin/conf_gen.h:1184 ../build/bin/conf_gen.h:1200
+#: ../build/bin/preferences_gen.h:4204 ../build/bin/preferences_gen.h:4299
+msgctxt "preferences"
+msgid "4K"
+msgstr "4K"
+
+#: ../build/bin/conf_gen.h:1185 ../build/bin/conf_gen.h:1201
+#: ../build/bin/preferences_gen.h:4209 ../build/bin/preferences_gen.h:4304
+msgctxt "preferences"
+msgid "5K"
+msgstr "5K"
+
+#: ../build/bin/conf_gen.h:1228 ../build/bin/preferences_gen.h:4519
+#: ../build/bin/preferences_gen.h:4563
+msgctxt "preferences"
+msgid "off"
+msgstr "Off"
+
+#: ../build/bin/conf_gen.h:1229 ../build/bin/preferences_gen.h:4524
+msgctxt "preferences"
+msgid "hardness (relative)"
+msgstr "Hardness (relative)"
+
+#: ../build/bin/conf_gen.h:1230 ../build/bin/preferences_gen.h:4529
+msgctxt "preferences"
+msgid "hardness (absolute)"
+msgstr "Hardness (absolute)"
+
+#: ../build/bin/conf_gen.h:1231 ../build/bin/preferences_gen.h:4534
+msgctxt "preferences"
+msgid "opacity (relative)"
+msgstr "Opacity (relative)"
+
+#: ../build/bin/conf_gen.h:1232 ../build/bin/preferences_gen.h:4539
+msgctxt "preferences"
+msgid "opacity (absolute)"
+msgstr "Opacity (absolute)"
+
+#: ../build/bin/conf_gen.h:1233 ../build/bin/preferences_gen.h:4544
+msgctxt "preferences"
+msgid "brush size (relative)"
+msgstr "Brush size (relative)"
+
+#: ../build/bin/conf_gen.h:1241 ../build/bin/preferences_gen.h:4599
+msgctxt "preferences"
+msgid "low"
+msgstr "Low"
+
+#: ../build/bin/conf_gen.h:1242 ../build/bin/preferences_gen.h:4604
+#: ../build/bin/preferences_gen.h:4628
+msgctxt "preferences"
+msgid "medium"
+msgstr "Medium"
+
+#: ../build/bin/conf_gen.h:1243 ../build/bin/preferences_gen.h:4609
+msgctxt "preferences"
+msgid "high"
+msgstr "High"
+
+#: ../build/bin/conf_gen.h:1263 ../build/bin/preferences_gen.h:5049
+#: ../build/bin/preferences_gen.h:5073
+msgctxt "preferences"
+msgid "false color"
+msgstr "False color"
+
+#: ../build/bin/conf_gen.h:1264 ../build/bin/preferences_gen.h:5054
+msgctxt "preferences"
+msgid "grayscale"
+msgstr "Grayscale"
+
+#: ../build/bin/conf_gen.h:1278 ../build/bin/preferences_gen.h:4780
+msgctxt "preferences"
+msgid "top left"
+msgstr "Top left"
+
+#: ../build/bin/conf_gen.h:1279 ../build/bin/preferences_gen.h:4785
+msgctxt "preferences"
+msgid "top right"
+msgstr "Top right"
+
+#: ../build/bin/conf_gen.h:1280 ../build/bin/preferences_gen.h:4790
+msgctxt "preferences"
+msgid "top center"
+msgstr "Top center"
+
+#: ../build/bin/conf_gen.h:1281 ../build/bin/preferences_gen.h:4795
+#: ../build/bin/preferences_gen.h:4819
+msgctxt "preferences"
+msgid "bottom"
+msgstr "Bottom"
+
+#: ../build/bin/conf_gen.h:1282 ../build/bin/preferences_gen.h:4800
+msgctxt "preferences"
+msgid "hidden"
+msgstr "Hidden"
+
+#: ../build/bin/conf_gen.h:1792
+msgid "show OSD"
+msgstr "Show OSD"
+
+#: ../build/bin/conf_gen.h:1793
+msgid "toggle the visibility of the map overlays"
+msgstr "Toggle the visibility of the map overlays"
+
+#: ../build/bin/conf_gen.h:1798 ../src/libs/map_settings.c:147
+msgid "filtered images"
+msgstr "Filtered images"
+
+#: ../build/bin/conf_gen.h:1799
+msgid "when set limit the images drawn to the current filmstrip"
+msgstr "When set limit the images drawn to the current filmstrip"
+
+#: ../build/bin/conf_gen.h:1806
+msgid "max images"
+msgstr "Max images"
+
+#: ../build/bin/conf_gen.h:1807
+msgid "the maximum number of image thumbnails drawn on the map"
+msgstr "The maximum number of image thumbnails drawn on the map"
+
+#: ../build/bin/conf_gen.h:1814
+msgid "group size factor"
+msgstr "Group size factor"
+
+#: ../build/bin/conf_gen.h:1815
+msgid ""
+"increase or decrease the spatial size of images groups on the map. can "
+"influence the calculation time"
+msgstr ""
+"Increase or decrease the spatial size of images groups on the map. Can "
+"influence the calculation time"
+
+#: ../build/bin/conf_gen.h:1822
+msgid "min images per group"
+msgstr "Min images per group"
+
+#: ../build/bin/conf_gen.h:1823
+msgid ""
+"the minimum number of images to set up an images group. can influence the "
+"calculation time."
+msgstr ""
+"The minimum number of images to set up an images group. Can influence the "
+"calculation time."
+
+#: ../build/bin/conf_gen.h:1828
+msgctxt "preferences"
+msgid "thumbnail"
+msgstr "Thumbnail"
+
+#: ../build/bin/conf_gen.h:1829
+msgctxt "preferences"
+msgid "count"
+msgstr "Count"
+
+#: ../build/bin/conf_gen.h:1832 ../src/libs/map_settings.c:160
+msgid "thumbnail display"
+msgstr "Thumbnail display"
+
+#: ../build/bin/conf_gen.h:1833
+msgid ""
+"three options are available: images thumbnails, only the count of images of "
+"the group or nothing"
+msgstr ""
+"Three options are available: images thumbnails, only the count of images of "
+"the group or nothing"
+
+#: ../build/bin/conf_gen.h:1844
+msgid "max polygon points"
+msgstr "Max polygon points"
+
+#: ../build/bin/conf_gen.h:1845
+msgid ""
+"limit the number of points imported with polygon in find location module"
+msgstr ""
+"Limit the number of points imported with polygon in find location module"
+
+#: ../build/bin/conf_gen.h:2135 ../build/bin/preferences_gen.h:4935
+#: ../build/bin/preferences_gen.h:4969
+msgctxt "preferences"
+msgid "original"
+msgstr "Original"
+
+#: ../build/bin/conf_gen.h:2136 ../build/bin/preferences_gen.h:4940
+msgctxt "preferences"
+msgid "to 1/2"
+msgstr "To 1/2"
+
+#: ../build/bin/conf_gen.h:2137 ../build/bin/preferences_gen.h:4945
+msgctxt "preferences"
+msgid "to 1/3"
+msgstr "To 1/3"
+
+#: ../build/bin/conf_gen.h:2138 ../build/bin/preferences_gen.h:4950
+msgctxt "preferences"
+msgid "to 1/4"
+msgstr "To 1/4"
+
+#: ../build/bin/conf_gen.h:2152 ../build/bin/conf_gen.h:2162
+#: ../build/bin/preferences_gen.h:5588 ../build/bin/preferences_gen.h:5653
+msgctxt "preferences"
+msgid "bilinear"
+msgstr "Bilinear"
+
+#: ../build/bin/conf_gen.h:2153 ../build/bin/conf_gen.h:2163
+#: ../build/bin/preferences_gen.h:5593 ../build/bin/preferences_gen.h:5617
+#: ../build/bin/preferences_gen.h:5658
+msgctxt "preferences"
+msgid "bicubic"
+msgstr "Bicubic"
+
+#: ../build/bin/conf_gen.h:2154 ../build/bin/conf_gen.h:2164
+#: ../build/bin/preferences_gen.h:5598 ../build/bin/preferences_gen.h:5663
+msgctxt "preferences"
+msgid "lanczos2"
+msgstr "Lanczos2"
+
+#: ../build/bin/conf_gen.h:2165 ../build/bin/preferences_gen.h:5668
+#: ../build/bin/preferences_gen.h:5687
+msgctxt "preferences"
+msgid "lanczos3"
+msgstr "Lanczos3"
+
+#: ../build/bin/conf_gen.h:2487 ../build/bin/conf_gen.h:3217
+#: ../build/bin/preferences_gen.h:5340 ../build/bin/preferences_gen.h:6751
+#: ../build/bin/preferences_gen.h:6787
+msgctxt "preferences"
+msgid "auto"
+msgstr "Auto"
+
+#: ../build/bin/conf_gen.h:2489 ../build/bin/preferences_gen.h:6761
+msgctxt "preferences"
+msgid "libsecret"
+msgstr "libsecret"
+
+#: ../build/bin/conf_gen.h:2490 ../build/bin/preferences_gen.h:6767
+msgctxt "preferences"
+msgid "kwallet"
+msgstr "KWallet"
+
+#: ../build/bin/conf_gen.h:2700
+msgctxt "preferences"
+msgid "vectorscope"
+msgstr "Vectorscope"
+
+#: ../build/bin/conf_gen.h:2701
+msgctxt "preferences"
+msgid "waveform"
+msgstr "Waveform"
+
+#: ../build/bin/conf_gen.h:2702
+msgctxt "preferences"
+msgid "rgb parade"
+msgstr "RGB parade"
+
+#: ../build/bin/conf_gen.h:2703
+msgctxt "preferences"
+msgid "histogram"
+msgstr "Histogram"
+
+#: ../build/bin/conf_gen.h:2711 ../build/bin/preferences_gen.h:7441
+msgctxt "preferences"
+msgid "left"
+msgstr "Left"
+
+#: ../build/bin/conf_gen.h:2712 ../build/bin/preferences_gen.h:7446
+#: ../build/bin/preferences_gen.h:7465
+msgctxt "preferences"
+msgid "right"
+msgstr "Right"
+
+#: ../build/bin/conf_gen.h:2720 ../build/bin/conf_gen.h:2757
+msgctxt "preferences"
+msgid "logarithmic"
+msgstr "Logarithmic"
+
+#: ../build/bin/conf_gen.h:2721 ../build/bin/conf_gen.h:2758
+msgctxt "preferences"
+msgid "linear"
+msgstr "Linear"
+
+#: ../build/bin/conf_gen.h:2729
+msgctxt "preferences"
+msgid "horizontal"
+msgstr "Horizontal"
+
+#: ../build/bin/conf_gen.h:2730
+msgctxt "preferences"
+msgid "vertical"
+msgstr "Vertical"
+
+#: ../build/bin/conf_gen.h:2738
+msgctxt "preferences"
+msgid "overlaid"
+msgstr "Overlaid"
+
+#: ../build/bin/conf_gen.h:2739
+msgctxt "preferences"
+msgid "parade"
+msgstr "Parade"
+
+#: ../build/bin/conf_gen.h:2747
+msgctxt "preferences"
+msgid "u*v*"
+msgstr "u*v*"
+
+#: ../build/bin/conf_gen.h:2748
+msgctxt "preferences"
+msgid "AzBz"
+msgstr "AzBz"
+
+#: ../build/bin/conf_gen.h:2749
+msgctxt "preferences"
+msgid "RYB"
+msgstr "RYB"
+
+#: ../build/bin/conf_gen.h:2791
+msgctxt "preferences"
+msgid "monochromatic"
+msgstr "Monochromatic"
+
+#: ../build/bin/conf_gen.h:2792
+msgctxt "preferences"
+msgid "analogous"
+msgstr "Analogous"
+
+#: ../build/bin/conf_gen.h:2793
+msgctxt "preferences"
+msgid "analogous complementary"
+msgstr "Analogous complementary"
+
+#: ../build/bin/conf_gen.h:2794
+msgctxt "preferences"
+msgid "complementary"
+msgstr "Complementary"
+
+#: ../build/bin/conf_gen.h:2795
+msgctxt "preferences"
+msgid "split complementary"
+msgstr "Split complementary"
+
+#: ../build/bin/conf_gen.h:2796
+msgctxt "preferences"
+msgid "dyad"
+msgstr "Dyad"
+
+#: ../build/bin/conf_gen.h:2797
+msgctxt "preferences"
+msgid "triad"
+msgstr "Triad"
+
+#: ../build/bin/conf_gen.h:2798
+msgctxt "preferences"
+msgid "tetrad"
+msgstr "Tetrad"
+
+#: ../build/bin/conf_gen.h:2799
+msgctxt "preferences"
+msgid "square"
+msgstr "Square"
+
+#: ../build/bin/conf_gen.h:2813
+msgctxt "preferences"
+msgid "normal"
+msgstr "Normal"
+
+#: ../build/bin/conf_gen.h:2815
+msgctxt "preferences"
+msgid "narrow"
+msgstr "Narrow"
+
+#: ../build/bin/conf_gen.h:2816
+msgctxt "preferences"
+msgid "line"
+msgstr "Line"
+
+#: ../build/bin/conf_gen.h:2956
+msgctxt "preferences"
+msgid "mm"
+msgstr "mm"
+
+#: ../build/bin/conf_gen.h:2957
+msgctxt "preferences"
+msgid "cm"
+msgstr "cm"
+
+#: ../build/bin/conf_gen.h:2958
+msgctxt "preferences"
+msgid "inch"
+msgstr "inch"
+
+#: ../build/bin/conf_gen.h:3003 ../build/bin/preferences_gen.h:7501
+#: ../build/bin/preferences_gen.h:7530
+msgctxt "preferences"
+msgid "all"
+msgstr "All"
+
+#: ../build/bin/conf_gen.h:3004 ../build/bin/preferences_gen.h:7506
+msgctxt "preferences"
+msgid "xatom"
+msgstr "Xatom"
+
+#: ../build/bin/conf_gen.h:3005 ../build/bin/preferences_gen.h:7511
+msgctxt "preferences"
+msgid "colord"
+msgstr "colord"
+
+#: ../build/bin/conf_gen.h:3041 ../build/bin/preferences_gen.h:5766
+#: ../build/bin/preferences_gen.h:5800
+msgctxt "preferences"
+msgid "scene-referred (filmic)"
+msgstr "Scene-referred (Filmic)"
+
+#: ../build/bin/conf_gen.h:3042 ../build/bin/preferences_gen.h:5771
+msgctxt "preferences"
+msgid "scene-referred (sigmoid)"
+msgstr "Scene-referred (Sigmoid)"
+
+#: ../build/bin/conf_gen.h:3043 ../build/bin/preferences_gen.h:5776
+msgctxt "preferences"
+msgid "display-referred (legacy)"
+msgstr "Display-referred (legacy)"
+
+#: ../build/bin/conf_gen.h:3144
+msgid "camera time zone"
+msgstr "Camera time zone"
+
+#: ../build/bin/conf_gen.h:3145
+msgid ""
+"most cameras don't store the time zone in EXIF. give the correct time zone "
+"so the GPX data can be correctly matched"
+msgstr ""
+"Most cameras don't store the time zone in EXIF. Give the correct time zone "
+"so the GPX data can be correctly matched"
+
+#: ../build/bin/conf_gen.h:3156
+msgctxt "preferences"
+msgid "no color"
+msgstr "No color"
+
+#: ../build/bin/conf_gen.h:3157
+msgctxt "preferences"
+msgid "illuminant color"
+msgstr "Illuminant color"
+
+#: ../build/bin/conf_gen.h:3158
+msgctxt "preferences"
+msgid "effect emulation"
+msgstr "Effect emulation"
+
+#: ../build/bin/conf_gen.h:3204
+msgctxt "preferences"
+msgid "list"
+msgstr "List"
+
+#: ../build/bin/conf_gen.h:3205
+msgctxt "preferences"
+msgid "tabs"
+msgstr "Tabs"
+
+#: ../build/bin/conf_gen.h:3206
+msgctxt "preferences"
+msgid "columns"
+msgstr "Columns"
+
+#: ../build/bin/conf_gen.h:3215 ../build/bin/preferences_gen.h:5330
+msgctxt "preferences"
+msgid "active"
+msgstr "Active"
+
+#: ../build/bin/conf_gen.h:3216 ../build/bin/preferences_gen.h:5335
+msgctxt "preferences"
+msgid "dim"
+msgstr "Dim"
+
+#: ../build/bin/conf_gen.h:3218 ../build/bin/preferences_gen.h:5345
+msgctxt "preferences"
+msgid "fade"
+msgstr "Fade"
+
+#: ../build/bin/conf_gen.h:3219 ../build/bin/preferences_gen.h:5350
+msgctxt "preferences"
+msgid "fit"
+msgstr "Fit"
+
+#: ../build/bin/conf_gen.h:3220 ../build/bin/preferences_gen.h:5355
+msgctxt "preferences"
+msgid "smooth"
+msgstr "Smooth"
+
+#: ../build/bin/conf_gen.h:3221 ../build/bin/preferences_gen.h:5360
+msgctxt "preferences"
+msgid "glide"
+msgstr "Glide"
+
+#: ../build/bin/preferences_gen.h:81 ../build/bin/preferences_gen.h:3900
+#: ../build/bin/preferences_gen.h:3936 ../build/bin/preferences_gen.h:3972
+#: ../build/bin/preferences_gen.h:4008 ../build/bin/preferences_gen.h:4044
+#: ../build/bin/preferences_gen.h:4080 ../build/bin/preferences_gen.h:4116
+#: ../build/bin/preferences_gen.h:4160 ../build/bin/preferences_gen.h:4255
+#: ../build/bin/preferences_gen.h:4350 ../build/bin/preferences_gen.h:4390
+#: ../build/bin/preferences_gen.h:4433 ../build/bin/preferences_gen.h:4505
+#: ../build/bin/preferences_gen.h:4585 ../build/bin/preferences_gen.h:4650
+#: ../build/bin/preferences_gen.h:4686 ../build/bin/preferences_gen.h:4723
+#: ../build/bin/preferences_gen.h:4766 ../build/bin/preferences_gen.h:4840
+#: ../build/bin/preferences_gen.h:4885 ../build/bin/preferences_gen.h:4921
+#: ../build/bin/preferences_gen.h:4991 ../build/bin/preferences_gen.h:5035
+#: ../build/bin/preferences_gen.h:5095 ../build/bin/preferences_gen.h:5131
+#: ../build/bin/preferences_gen.h:5167 ../build/bin/preferences_gen.h:5203
+#: ../build/bin/preferences_gen.h:5239 ../build/bin/preferences_gen.h:5275
+#: ../build/bin/preferences_gen.h:5311 ../build/bin/preferences_gen.h:5401
+#: ../build/bin/preferences_gen.h:5437 ../build/bin/preferences_gen.h:5473
+#: ../build/bin/preferences_gen.h:5538 ../build/bin/preferences_gen.h:5574
+#: ../build/bin/preferences_gen.h:5639 ../build/bin/preferences_gen.h:5709
+#: ../build/bin/preferences_gen.h:5752 ../build/bin/preferences_gen.h:5822
+#: ../build/bin/preferences_gen.h:5858 ../build/bin/preferences_gen.h:5894
+#: ../build/bin/preferences_gen.h:5938 ../build/bin/preferences_gen.h:6009
+#: ../build/bin/preferences_gen.h:6045 ../build/bin/preferences_gen.h:6081
+#: ../build/bin/preferences_gen.h:6117 ../build/bin/preferences_gen.h:6159
+#: ../build/bin/preferences_gen.h:6230 ../build/bin/preferences_gen.h:6335
+#: ../build/bin/preferences_gen.h:6371 ../build/bin/preferences_gen.h:6407
+#: ../build/bin/preferences_gen.h:6443 ../build/bin/preferences_gen.h:6479
+#: ../build/bin/preferences_gen.h:6515 ../build/bin/preferences_gen.h:6551
+#: ../build/bin/preferences_gen.h:6587 ../build/bin/preferences_gen.h:6622
+#: ../build/bin/preferences_gen.h:6657 ../build/bin/preferences_gen.h:6693
+#: ../build/bin/preferences_gen.h:6737 ../build/bin/preferences_gen.h:6809
+#: ../build/bin/preferences_gen.h:6878 ../build/bin/preferences_gen.h:6953
+#: ../build/bin/preferences_gen.h:7006 ../build/bin/preferences_gen.h:7071
+#: ../build/bin/preferences_gen.h:7136 ../build/bin/preferences_gen.h:7201
+#: ../build/bin/preferences_gen.h:7237 ../build/bin/preferences_gen.h:7273
+#: ../build/bin/preferences_gen.h:7309 ../build/bin/preferences_gen.h:7345
+#: ../build/bin/preferences_gen.h:7381 ../build/bin/preferences_gen.h:7427
+#: ../build/bin/preferences_gen.h:7487 ../build/bin/preferences_gen.h:7552
+#: ../build/bin/preferences_gen.h:7606 ../build/bin/preferences_gen.h:7651
+#: ../build/bin/preferences_gen.h:7687 ../build/bin/preferences_gen.h:7723
+#: ../build/bin/preferences_gen.h:7759 ../build/bin/preferences_gen.h:7795
+#: ../build/bin/preferences_gen.h:7855 ../build/bin/preferences_gen.h:7899
+#: ../build/bin/preferences_gen.h:7943 ../build/bin/preferences_gen.h:8016
+#: ../build/bin/preferences_gen.h:8056 ../build/bin/preferences_gen.h:8096
+#: ../build/bin/preferences_gen.h:8132 ../build/bin/preferences_gen.h:8187
+#: ../build/bin/preferences_gen.h:8223 ../build/bin/preferences_gen.h:8283
+#: ../build/bin/preferences_gen.h:8329 ../build/bin/preferences_gen.h:8365
+#: ../build/bin/preferences_gen.h:8411 ../build/bin/preferences_gen.h:8471
+#: ../build/bin/preferences_gen.h:8523 ../build/bin/preferences_gen.h:8569
+#: ../build/bin/preferences_gen.h:8637 ../build/bin/preferences_gen.h:8684
+msgid "this setting has been modified"
+msgstr "This setting has been modified"
+
+#: ../build/bin/preferences_gen.h:3880 ../src/gui/gtk.c:1185
+#: ../src/gui/preferences.c:537 ../src/libs/tools/lighttable.c:66
+#: ../src/views/lighttable.c:91
+msgid "lighttable"
+msgstr "Lighttable"
+
+#: ../build/bin/preferences_gen.h:3883 ../build/bin/preferences_gen.h:4488
+#: ../build/bin/preferences_gen.h:6318 ../src/gui/preferences.c:270
+msgid "general"
+msgstr "General"
+
+#: ../build/bin/preferences_gen.h:3903
+msgid "hide built-in presets for utility modules"
+msgstr "Hide built-in presets for utility modules"
+
+#: ../build/bin/preferences_gen.h:3914 ../build/bin/preferences_gen.h:3950
+#: ../build/bin/preferences_gen.h:3986 ../build/bin/preferences_gen.h:4022
+#: ../build/bin/preferences_gen.h:4058 ../build/bin/preferences_gen.h:4094
+#: ../build/bin/preferences_gen.h:4130 ../build/bin/preferences_gen.h:4233
+#: ../build/bin/preferences_gen.h:4328 ../build/bin/preferences_gen.h:4368
+#: ../build/bin/preferences_gen.h:4411 ../build/bin/preferences_gen.h:4454
+#: ../build/bin/preferences_gen.h:4563 ../build/bin/preferences_gen.h:4628
+#: ../build/bin/preferences_gen.h:4664 ../build/bin/preferences_gen.h:4700
+#: ../build/bin/preferences_gen.h:4744 ../build/bin/preferences_gen.h:4819
+#: ../build/bin/preferences_gen.h:4899 ../build/bin/preferences_gen.h:4969
+#: ../build/bin/preferences_gen.h:5005 ../build/bin/preferences_gen.h:5073
+#: ../build/bin/preferences_gen.h:5109 ../build/bin/preferences_gen.h:5145
+#: ../build/bin/preferences_gen.h:5181 ../build/bin/preferences_gen.h:5217
+#: ../build/bin/preferences_gen.h:5253 ../build/bin/preferences_gen.h:5289
+#: ../build/bin/preferences_gen.h:5379 ../build/bin/preferences_gen.h:5415
+#: ../build/bin/preferences_gen.h:5451 ../build/bin/preferences_gen.h:5487
+#: ../build/bin/preferences_gen.h:5552 ../build/bin/preferences_gen.h:5617
+#: ../build/bin/preferences_gen.h:5687 ../build/bin/preferences_gen.h:5729
+#: ../build/bin/preferences_gen.h:5800 ../build/bin/preferences_gen.h:5836
+#: ../build/bin/preferences_gen.h:5872 ../build/bin/preferences_gen.h:5908
+#: ../build/bin/preferences_gen.h:5986 ../build/bin/preferences_gen.h:6023
+#: ../build/bin/preferences_gen.h:6059 ../build/bin/preferences_gen.h:6095
+#: ../build/bin/preferences_gen.h:6131 ../build/bin/preferences_gen.h:6202
+#: ../build/bin/preferences_gen.h:6278 ../build/bin/preferences_gen.h:6349
+#: ../build/bin/preferences_gen.h:6385 ../build/bin/preferences_gen.h:6421
+#: ../build/bin/preferences_gen.h:6457 ../build/bin/preferences_gen.h:6493
+#: ../build/bin/preferences_gen.h:6529 ../build/bin/preferences_gen.h:6565
+#: ../build/bin/preferences_gen.h:6601 ../build/bin/preferences_gen.h:6636
+#: ../build/bin/preferences_gen.h:6671 ../build/bin/preferences_gen.h:6707
+#: ../build/bin/preferences_gen.h:6787 ../build/bin/preferences_gen.h:6827
+#: ../build/bin/preferences_gen.h:6931 ../build/bin/preferences_gen.h:7049
+#: ../build/bin/preferences_gen.h:7114 ../build/bin/preferences_gen.h:7150
+#: ../build/bin/preferences_gen.h:7215 ../build/bin/preferences_gen.h:7251
+#: ../build/bin/preferences_gen.h:7287 ../build/bin/preferences_gen.h:7323
+#: ../build/bin/preferences_gen.h:7359 ../build/bin/preferences_gen.h:7465
+#: ../build/bin/preferences_gen.h:7530 ../build/bin/preferences_gen.h:7570
+#: ../build/bin/preferences_gen.h:7620 ../build/bin/preferences_gen.h:7665
+#: ../build/bin/preferences_gen.h:7701 ../build/bin/preferences_gen.h:7737
+#: ../build/bin/preferences_gen.h:7773 ../build/bin/preferences_gen.h:7833
+#: ../build/bin/preferences_gen.h:7869 ../build/bin/preferences_gen.h:7913
+#: ../build/bin/preferences_gen.h:8034 ../build/bin/preferences_gen.h:8074
+#: ../build/bin/preferences_gen.h:8110 ../build/bin/preferences_gen.h:8150
+#: ../build/bin/preferences_gen.h:8201 ../build/bin/preferences_gen.h:8261
+#: ../build/bin/preferences_gen.h:8343 ../build/bin/preferences_gen.h:8449
+#: ../build/bin/preferences_gen.h:8485 ../build/bin/preferences_gen.h:8583
+#, c-format
+msgid "double click to reset to `%s'"
+msgstr "Double click to reset to `%s'"
+
+#: ../build/bin/preferences_gen.h:3914 ../build/bin/preferences_gen.h:3950
+#: ../build/bin/preferences_gen.h:3986 ../build/bin/preferences_gen.h:4022
+#: ../build/bin/preferences_gen.h:4058 ../build/bin/preferences_gen.h:4130
+#: ../build/bin/preferences_gen.h:4664 ../build/bin/preferences_gen.h:4899
+#: ../build/bin/preferences_gen.h:5109 ../build/bin/preferences_gen.h:5253
+#: ../build/bin/preferences_gen.h:5451 ../build/bin/preferences_gen.h:5552
+#: ../build/bin/preferences_gen.h:5836 ../build/bin/preferences_gen.h:5872
+#: ../build/bin/preferences_gen.h:6023 ../build/bin/preferences_gen.h:6095
+#: ../build/bin/preferences_gen.h:6565 ../build/bin/preferences_gen.h:7150
+#: ../build/bin/preferences_gen.h:7323 ../build/bin/preferences_gen.h:7620
+#: ../build/bin/preferences_gen.h:7701 ../build/bin/preferences_gen.h:7737
+#: ../build/bin/preferences_gen.h:7773 ../build/bin/preferences_gen.h:7869
+#: ../build/bin/preferences_gen.h:8110 ../build/bin/preferences_gen.h:8201
+#: ../build/bin/preferences_gen.h:8343
+msgctxt "preferences"
+msgid "FALSE"
+msgstr "FALSE"
+
+#: ../build/bin/preferences_gen.h:3917
+msgid "hides built-in presets of utility modules in presets menu."
+msgstr "Hides built-in presets of utility modules in presets menu."
+
+#: ../build/bin/preferences_gen.h:3939
+msgid "use single-click in the collections module"
+msgstr "Use single-click in the collections module"
+
+#: ../build/bin/preferences_gen.h:3953
+msgid ""
+"check this option to use single-click to select items in the collections "
+"module. this will allow you to do range selections for date-time and numeric "
+"values."
+msgstr ""
+"Check this option to use single-click to select items in the collections "
+"module. This will allow you to do range selections for date-time and numeric "
+"values."
+
+#: ../build/bin/preferences_gen.h:3975
+msgid "expand a single utility module at a time"
+msgstr "Expand a single utility module at a time"
+
+#: ../build/bin/preferences_gen.h:3989
+msgid "this option toggles the behavior of shift clicking in lighttable mode"
+msgstr "This option toggles the behavior of shift clicking in Lighttable mode"
+
+#: ../build/bin/preferences_gen.h:4011
+msgid "scroll utility modules to the top when expanded"
+msgstr "Scroll utility modules to the top when expanded"
+
+#: ../build/bin/preferences_gen.h:4025 ../build/bin/preferences_gen.h:5292
+msgid ""
+"when this option is enabled then darktable will try to scroll the module to "
+"the top of the visible list"
+msgstr ""
+"When this option is enabled then Darktable will try to scroll the module to "
+"the top of the visible list"
+
+#: ../build/bin/preferences_gen.h:4047
+msgid "rating an image one star twice will not zero out the rating"
+msgstr "Rating an image one star twice will not zero out the rating"
+
+#: ../build/bin/preferences_gen.h:4061
+msgid ""
+"defines whether rating an image one star twice will zero out star rating"
+msgstr ""
+"Defines whether rating an image one star twice will zero out star rating"
+
+#: ../build/bin/preferences_gen.h:4083 ../build/bin/preferences_gen.h:4888
+msgid "show scrollbars for central view"
+msgstr "Show scrollbars for central view"
+
+#: ../build/bin/preferences_gen.h:4094 ../build/bin/preferences_gen.h:4700
+#: ../build/bin/preferences_gen.h:5005 ../build/bin/preferences_gen.h:5145
+#: ../build/bin/preferences_gen.h:5181 ../build/bin/preferences_gen.h:5217
+#: ../build/bin/preferences_gen.h:5289 ../build/bin/preferences_gen.h:5415
+#: ../build/bin/preferences_gen.h:5487 ../build/bin/preferences_gen.h:5908
+#: ../build/bin/preferences_gen.h:6059 ../build/bin/preferences_gen.h:6131
+#: ../build/bin/preferences_gen.h:6349 ../build/bin/preferences_gen.h:6385
+#: ../build/bin/preferences_gen.h:6421 ../build/bin/preferences_gen.h:6457
+#: ../build/bin/preferences_gen.h:6493 ../build/bin/preferences_gen.h:6529
+#: ../build/bin/preferences_gen.h:6601 ../build/bin/preferences_gen.h:6636
+#: ../build/bin/preferences_gen.h:6671 ../build/bin/preferences_gen.h:6707
+#: ../build/bin/preferences_gen.h:7215 ../build/bin/preferences_gen.h:7251
+#: ../build/bin/preferences_gen.h:7287 ../build/bin/preferences_gen.h:7359
+#: ../build/bin/preferences_gen.h:7665 ../build/bin/preferences_gen.h:7913
+#: ../build/bin/preferences_gen.h:8485 ../build/bin/preferences_gen.h:8583
+msgctxt "preferences"
+msgid "TRUE"
+msgstr "TRUE"
+
+#: ../build/bin/preferences_gen.h:4097 ../build/bin/preferences_gen.h:4902
+msgid "defines whether scrollbars should be displayed"
+msgstr "Defines whether scrollbars should be displayed"
+
+#: ../build/bin/preferences_gen.h:4119
+msgid "show image time with milliseconds"
+msgstr "Show image time with milliseconds"
+
+#: ../build/bin/preferences_gen.h:4133
+msgid "defines whether time should be displayed with milliseconds"
+msgstr "Defines whether time should be displayed with milliseconds"
+
+#: ../build/bin/preferences_gen.h:4143
+msgid "thumbnails"
+msgstr "Thumbnails"
+
+#: ../build/bin/preferences_gen.h:4163
+msgid "use raw file instead of embedded JPEG from size"
+msgstr "Use raw file instead of embedded JPEG from size"
+
+#: ../build/bin/preferences_gen.h:4236
+msgid ""
+"if the thumbnail size is greater than this value, it will be processed using "
+"raw file instead of the embedded preview JPEG (better but slower).\n"
+"if you want all thumbnails and pre-rendered images in best quality you "
+"should choose the *always* option.\n"
+"(more comments in the manual)"
+msgstr ""
+"If the thumbnail size is greater than this value, it will be processed using "
+"raw file instead of the embedded preview JPEG (better but slower).\n"
+"If you want all thumbnails and pre-rendered images in best quality you "
+"should choose the *always* option.\n"
+"(more comments in the manual)"
+
+#: ../build/bin/preferences_gen.h:4258
+msgid "high quality processing from size"
+msgstr "High quality processing from size"
+
+#: ../build/bin/preferences_gen.h:4331
+msgid ""
+"if the thumbnail size is greater than this value, it will be processed using "
+"the full quality rendering path (better but slower).\n"
+"if you want all thumbnails and pre-rendered images in best quality you "
+"should choose the *always* option.\n"
+"(more comments in the manual)"
+msgstr ""
+"If the thumbnail size is greater than this value, it will be processed using "
+"the full quality rendering path (better but slower).\n"
+"If you want all thumbnails and pre-rendered images in best quality you "
+"should choose the *always* option.\n"
+"(more comments in the manual)"
+
+#: ../build/bin/preferences_gen.h:4353
+msgid "delimiters for size categories"
+msgstr "Delimiters for size categories"
+
+#: ../build/bin/preferences_gen.h:4371
+msgid ""
+"size categories are used to be able to set different overlays and css values "
+"depending of the size of the thumbnail, separated by |.\n"
+"for example, 120|400 means 3 categories of thumbnails: 0px->120px, 120px-"
+">400px and >400px"
+msgstr ""
+"Size categories are used to be able to set different overlays and CSS values "
+"depending of the size of the thumbnail, separated by |.\n"
+"For example, 120|400 means 3 categories of thumbnails: 0px->120px, 120px-"
+">400px and >400px"
+
+#: ../build/bin/preferences_gen.h:4393
+msgid "pattern for the thumbnail extended overlay text"
+msgstr "Pattern for the thumbnail extended overlay text"
+
+#: ../build/bin/preferences_gen.h:4414 ../build/bin/preferences_gen.h:4457
+msgid "see manual to know all the tags you can use."
+msgstr "See manual to know all the tags you can use."
+
+#: ../build/bin/preferences_gen.h:4436
+msgid "pattern for the thumbnail tooltip (empty to disable)"
+msgstr "Pattern for the thumbnail tooltip (empty to disable)"
+
+#: ../build/bin/preferences_gen.h:4485 ../src/gui/gtk.c:1186
+#: ../src/gui/preferences.c:537 ../src/views/darkroom.c:94
+msgid "darkroom"
+msgstr "Darkroom"
+
+#: ../build/bin/preferences_gen.h:4508
+msgid "pen pressure control for brush masks"
+msgstr "Pen pressure control for brush masks"
+
+#: ../build/bin/preferences_gen.h:4566
+msgid ""
+" - 'off': pressure reading ignored,\n"
+" - 'hardness'/'opacity'/'brush size': pressure reading controls specified "
+"attribute,\n"
+" - 'absolute'/'relative': pressure reading is taken directly as attribute "
+"value or multiplied with pre-defined setting."
+msgstr ""
+" - 'Off': pressure reading ignored,\n"
+" - 'Hardness'/'Opacity'/'Brush size': pressure reading controls specified "
+"attribute,\n"
+" - 'Absolute'/'Relative': pressure reading is taken directly as attribute "
+"value or multiplied with pre-defined setting."
+
+#: ../build/bin/preferences_gen.h:4588
+msgid "smoothing of brush strokes"
+msgstr "Smoothing of brush strokes"
+
+#: ../build/bin/preferences_gen.h:4631
+msgid ""
+"sets level for smoothing of brush strokes.\n"
+"stronger smoothing leads to less nodes and easier editing but with lower "
+"control of accuracy."
+msgstr ""
+"Sets level for smoothing of brush strokes.\n"
+"Stronger smoothing leads to less nodes and easier editing but with lower "
+"control of accuracy."
+
+#: ../build/bin/preferences_gen.h:4653
+msgid "scroll down to increase mask parameters"
+msgstr "Scroll down to increase mask parameters"
+
+#: ../build/bin/preferences_gen.h:4667
+msgid ""
+"when using the mouse scroll wheel to change mask parameters, scroll down to "
+"increase the mask size, feather size, opacity, brush hardness and gradient "
+"curvature\n"
+"by default scrolling up increases these parameters"
+msgstr ""
+"When using the mouse scroll wheel to change mask parameters, scroll down to "
+"increase the mask size, feather size, opacity, brush hardness and gradient "
+"curvature\n"
+"By default scrolling up increases these parameters"
+
+#: ../build/bin/preferences_gen.h:4689
+msgid "middle mouse button zooms to 200%"
+msgstr "Middle mouse button zooms to 200%"
+
+#: ../build/bin/preferences_gen.h:4704
+#, no-c-format
+msgid ""
+"when clicking the middle mouse button to zoom, the zoom level will cycle "
+"through 100%, 200% and then back to fit the screen. Otherwise it switches "
+"between fit to screen and 100% and the 'ctrl' key can be used to control the "
+"zoom level."
+msgstr ""
+"When clicking the middle mouse button to zoom, the zoom level will cycle "
+"through 100%, 200% and then back to fit the screen. Otherwise it switches "
+"between fit to screen and 100% and the 'Ctrl' key can be used to control the "
+"zoom level."
+
+#: ../build/bin/preferences_gen.h:4726
+msgid "pattern for the image information line"
+msgstr "Pattern for the image information line"
+
+#: ../build/bin/preferences_gen.h:4747
+msgid "see manual for a list of the tags you can use."
+msgstr "See manual for a list of the tags you can use."
+
+#: ../build/bin/preferences_gen.h:4769
+msgid "position of the image information line"
+msgstr "Position of the image information line"
+
+#: ../build/bin/preferences_gen.h:4843
+msgid "border around image in darkroom mode"
+msgstr "Border around image in Darkroom mode"
+
+#: ../build/bin/preferences_gen.h:4863 ../build/bin/preferences_gen.h:6976
+#: ../build/bin/preferences_gen.h:7405 ../build/bin/preferences_gen.h:7966
+#: ../build/bin/preferences_gen.h:8307 ../build/bin/preferences_gen.h:8389
+#: ../build/bin/preferences_gen.h:8547 ../build/bin/preferences_gen.h:8661
+#: ../build/bin/preferences_gen.h:8708
+#, c-format
+msgid "double click to reset to `%d'"
+msgstr "Double click to reset to `%d'"
+
+#: ../build/bin/preferences_gen.h:4866
+msgid ""
+"process the image in darkroom mode with a small border. set to 0 if you "
+"don't want any border."
+msgstr ""
+"Process the image in Darkroom mode with a small border. Set to 0 if you "
+"don't want any border."
+
+#: ../build/bin/preferences_gen.h:4924
+msgid "reduce resolution of preview image"
+msgstr "Reduce resolution of preview image"
+
+#: ../build/bin/preferences_gen.h:4972
+msgid "decrease to speed up preview rendering, may hinder accurate masking"
+msgstr "Decrease to speed up preview rendering, may hinder accurate masking"
+
+#: ../build/bin/preferences_gen.h:4994
+msgid "show loading screen between images"
+msgstr "Show loading screen between images"
+
+#: ../build/bin/preferences_gen.h:5008
+msgid ""
+"show gray loading screen when navigating between images in the darkroom\n"
+"disable to just show a toast message"
+msgstr ""
+"Show gray loading screen when navigating between images in the Darkroom\n"
+"Disable to just show a toast message"
+
+#: ../build/bin/preferences_gen.h:5018
+msgid "modules"
+msgstr "Modules"
+
+#: ../build/bin/preferences_gen.h:5038
+msgid "display of individual color channels"
+msgstr "Display of individual color channels"
+
+#: ../build/bin/preferences_gen.h:5076
+msgid ""
+"defines how color channels are displayed when activated in the parametric "
+"masks feature."
+msgstr ""
+"Defines how color channels are displayed when activated in the parametric "
+"masks feature."
+
+#: ../build/bin/preferences_gen.h:5098
+msgid "hide built-in presets for processing modules"
+msgstr "Hide built-in presets for processing modules"
+
+#: ../build/bin/preferences_gen.h:5112
+msgid ""
+"hides built-in presets of processing modules in both presets and favourites "
+"menu."
+msgstr ""
+"Hides built-in presets of processing modules in both presets and favourites "
+"menu."
+
+#: ../build/bin/preferences_gen.h:5134 ../build/bin/preferences_gen.h:5148
+msgid "show the guides widget in modules UI"
+msgstr "Show the guides widget in modules UI"
+
+#: ../build/bin/preferences_gen.h:5170
+msgid "expand a single processing module at a time"
+msgstr "Expand a single processing module at a time"
+
+#: ../build/bin/preferences_gen.h:5184
+msgid "this option toggles the behavior of shift clicking in darkroom mode"
+msgstr "This option toggles the behavior of shift clicking in Darkroom mode"
+
+#: ../build/bin/preferences_gen.h:5206
+msgid "only collapse modules in current group"
+msgstr "Only collapse modules in current group"
+
+#: ../build/bin/preferences_gen.h:5220
+msgid ""
+"if only expanding a single module at a time, only collapse other modules in "
+"the current group - ignore modules in other groups"
+msgstr ""
+"If only expanding a single module at a time, only collapse other modules in "
+"the current group - ignore modules in other groups"
+
+#: ../build/bin/preferences_gen.h:5242
+msgid "expand the module when it is activated, and collapse it when disabled"
+msgstr "Expand the module when it is activated, and collapse it when disabled"
+
+#: ../build/bin/preferences_gen.h:5256
+msgid ""
+"this option allows to expand or collapse automatically the module when it is "
+"enabled or disabled."
+msgstr ""
+"This option allows to expand or collapse automatically the module when it is "
+"enabled or disabled."
+
+#: ../build/bin/preferences_gen.h:5278
+msgid "scroll processing modules to the top when expanded"
+msgstr "Scroll processing modules to the top when expanded"
+
+#: ../build/bin/preferences_gen.h:5314
+msgid "show right-side buttons in processing module headers"
+msgstr "Show right-side buttons in processing module headers"
+
+#: ../build/bin/preferences_gen.h:5382
+msgid ""
+"when the mouse is not over a module, the multi-instance, reset and preset "
+"buttons can be hidden:\n"
+" - 'always': always show all buttons,\n"
+" - 'active': only show the buttons when the mouse is over the module,\n"
+" - 'dim': buttons are dimmed when mouse is away,\n"
+" - 'auto': hide the buttons when the panel is narrow,\n"
+" - 'fade': fade out all buttons when panel narrows,\n"
+" - 'fit': hide all the buttons if the module name doesn't fit,\n"
+" - 'smooth': fade out all buttons in one header simultaneously,\n"
+" - 'glide': gradually hide individual buttons as needed"
+msgstr ""
+"When the mouse is not over a module, the multi-instance, reset and preset "
+"buttons can be hidden:\n"
+" - 'Always': always show all buttons,\n"
+" - 'Active': only show the buttons when the mouse is over the module,\n"
+" - 'Dim': buttons are dimmed when mouse is away,\n"
+" - 'Auto': hide the buttons when the panel is narrow,\n"
+" - 'Fade': fade out all buttons when panel narrows,\n"
+" - 'Fit': hide all the buttons if the module name doesn't fit,\n"
+" - 'Smooth': fade out all buttons in one header simultaneously,\n"
+" - 'Glide': gradually hide individual buttons as needed"
+
+#: ../build/bin/preferences_gen.h:5404
+msgid "show mask indicator in module headers"
+msgstr "Show mask indicator in module headers"
+
+#: ../build/bin/preferences_gen.h:5418
+msgid ""
+"if enabled, an icon will be shown in the header of any processing modules "
+"that have a mask applied"
+msgstr ""
+"If enabled, an icon will be shown in the header of any processing modules "
+"that have a mask applied"
+
+#: ../build/bin/preferences_gen.h:5440
+msgid "prompt for name on addition of new instance"
+msgstr "Prompt for name on addition of new instance"
+
+#: ../build/bin/preferences_gen.h:5454
+msgid ""
+"if enabled, a rename prompt will be present for each new module instance "
+"(either new instance or duplicate)"
+msgstr ""
+"If enabled, a rename prompt will be present for each new module instance "
+"(either new instance or duplicate)"
+
+#: ../build/bin/preferences_gen.h:5476
+msgid "automatically update module name"
+msgstr "Automatically update module name"
+
+#: ../build/bin/preferences_gen.h:5490
+msgid ""
+"if enabled, the module name will be automatically updated to match a preset "
+"name or a preset instance name if present."
+msgstr ""
+"If enabled, the module name will be automatically updated to match a preset "
+"name or a preset instance name if present."
+
+#: ../build/bin/preferences_gen.h:5518
+msgid "processing"
+msgstr "Processing"
+
+#: ../build/bin/preferences_gen.h:5521
+msgid "image processing"
+msgstr "Image processing"
+
+#: ../build/bin/preferences_gen.h:5541
+msgid "always use LittleCMS 2 to apply output color profile"
+msgstr "Always use LittleCMS 2 to apply output color profile"
+
+#: ../build/bin/preferences_gen.h:5555
+msgid "this is slower than the default."
+msgstr "This is slower than the default."
+
+#: ../build/bin/preferences_gen.h:5577
+msgid "pixel interpolator (warp)"
+msgstr "Pixel interpolator (warp)"
+
+#: ../build/bin/preferences_gen.h:5620
+msgid ""
+"pixel interpolator used in modules for rotation, lens correction, liquify, "
+"cropping and final scaling (bilinear, bicubic, lanczos2)."
+msgstr ""
+"Pixel interpolator used in modules for rotation, lens correction, liquify, "
+"cropping and final scaling (bilinear, bicubic, lanczos2)."
+
+#: ../build/bin/preferences_gen.h:5642
+msgid "pixel interpolator (scaling)"
+msgstr "Pixel interpolator (scaling)"
+
+#: ../build/bin/preferences_gen.h:5690
+msgid ""
+"pixel interpolator used for scaling (bilinear, bicubic, lanczos2, lanczos3)."
+msgstr ""
+"Pixel interpolator used for scaling (bilinear, bicubic, lanczos2, lanczos3)."
+
+#: ../build/bin/preferences_gen.h:5712
+msgid "LUT 3D root folder"
+msgstr "LUT 3D root folder"
+
+#: ../build/bin/preferences_gen.h:5717 ../src/control/jobs/control_jobs.c:1660
+#: ../src/control/jobs/control_jobs.c:1714 ../src/gui/preferences.c:1071
+#: ../src/gui/presets.c:360 ../src/imageio/storage/disk.c:122
+#: ../src/imageio/storage/disk.c:178 ../src/imageio/storage/gallery.c:109
+#: ../src/imageio/storage/gallery.c:163 ../src/imageio/storage/latex.c:108
+#: ../src/imageio/storage/latex.c:162 ../src/libs/import.c:1507
+#: ../src/libs/import.c:1611 ../src/libs/import.c:1665 ../src/libs/styles.c:392
+#: ../src/lua/preferences.c:667
+msgid "select directory"
+msgstr "Select directory"
+
+#: ../build/bin/preferences_gen.h:5733
+msgid ""
+"this folder (and sub-folders) contains LUT files used by LUT 3D module. "
+"(need a restart)."
+msgstr ""
+"This folder (and sub-folders) contains LUT files used by LUT 3D module. "
+"(need a restart)."
+
+#: ../build/bin/preferences_gen.h:5755
+msgid "auto-apply pixel workflow defaults"
+msgstr "Auto-apply pixel workflow defaults"
+
+#: ../build/bin/preferences_gen.h:5803
+msgid ""
+"scene-referred workflow is based on linear modules and will auto-apply "
+"filmic or sigmoid, color calibration and exposure,\n"
+"display-referred workflow is based on Lab modules and will auto-apply base "
+"curve, white balance and the legacy module pipe order."
+msgstr ""
+"Scene-referred workflow is based on linear modules and will auto-apply "
+"Filmic or Sigmoid, Color calibration and Exposure.\n"
+"Display-referred workflow is based on Lab modules and will auto-apply Base "
+"curve, White balance and the legacy module pipe order."
+
+#: ../build/bin/preferences_gen.h:5825
+msgid "auto-apply per camera basecurve presets"
+msgstr "Auto-apply per camera basecurve presets"
+
+#: ../build/bin/preferences_gen.h:5839
+msgid ""
+"use the per-camera basecurve by default instead of the generic manufacturer "
+"one if there is one available (needs a restart).\n"
+"this option is taken into account when the \"auto-apply pixel workflow "
+"defaults\" is set to \"display-referred\".\n"
+"to prevent auto-apply basecurve presets \"auto-apply pixel workflow "
+"defaults\" should be set to \"none\""
+msgstr ""
+"Use the per-camera basecurve by default instead of the generic manufacturer "
+"one if there is one available (needs a restart).\n"
+"This option is taken into account when the \"Auto-apply pixel workflow "
+"defaults\" is set to \"Display-referred\".\n"
+"To prevent auto-apply basecurve presets \"Auto-apply pixel workflow "
+"defaults\" should be set to \"None\""
+
+#: ../build/bin/preferences_gen.h:5861
+msgid "detect monochrome previews"
+msgstr "Detect monochrome previews"
+
+#: ../build/bin/preferences_gen.h:5875
+msgid ""
+"many monochrome images can be identified via EXIF and preview data. beware: "
+"this slows down imports and reading of EXIF data"
+msgstr ""
+"Many monochrome images can be identified via EXIF and preview data. Beware: "
+"this slows down imports and reading of EXIF data"
+
+#: ../build/bin/preferences_gen.h:5897
+msgid "show warning messages"
+msgstr "Show warning messages"
+
+#: ../build/bin/preferences_gen.h:5911
+msgid ""
+"display messages in modules to warn beginner users when non-standard and "
+"possibly harmful settings are used in the pipeline.\n"
+"these messages can be false-positive and should be disregarded if you know "
+"what you are doing. this option will hide them all the time."
+msgstr ""
+"Display messages in modules to warn beginner users when non-standard and "
+"possibly harmful settings are used in the pipeline.\n"
+"These messages can be false-positive and should be disregarded if you know "
+"what you are doing. This option will hide them all the time."
+
+#: ../build/bin/preferences_gen.h:5921
+msgid "CPU / GPU / memory"
+msgstr "CPU / GPU / Memory"
+
+#: ../build/bin/preferences_gen.h:5941
+msgid "darktable resources"
+msgstr "Darktable resources"
+
+#: ../build/bin/preferences_gen.h:5990
+#, no-c-format
+msgid ""
+"defines how much darktable may take from your system resources:\n"
+" - 'default': darktable takes ~50% of your systems resources and gives "
+"darktable enough to be still performant.\n"
+" - 'small': should be used if you are simultaneously running applications "
+"taking large parts of your systems memory or OpenCL/GL applications like "
+"games or Hugin.\n"
+" - 'large': is the best option if you are mainly using darktable and want it "
+"to take most of your systems resources for performance.\n"
+" - 'unrestricted': should only be used for developing extremely large images "
+"as darktable will take all of your systems resources\n"
+"   and thus might lead to swapping and unexpected performance drops.\n"
+"   use with caution and not recommended for general use!"
+msgstr ""
+"Defines how much darktable may take from your system resources:\n"
+" - 'Default': darktable takes ~50% of your systems resources and gives "
+"darktable enough to be still performant.\n"
+" - 'Small': should be used if you are simultaneously running applications "
+"taking large parts of your systems memory or OpenCL/GL applications like "
+"games or Hugin.\n"
+" - 'Large': is the best option if you are mainly using darktable and want it "
+"to take most of your systems resources for performance.\n"
+" - 'Unrestricted': should only be used for developing extremely large images "
+"as darktable will take all of your systems resources\n"
+"   and thus might lead to swapping and unexpected performance drops.\n"
+"   Use with caution and not recommended for general use!"
+
+#: ../build/bin/preferences_gen.h:6012
+msgid "prefer performance over quality"
+msgstr "Prefer performance over quality"
+
+#: ../build/bin/preferences_gen.h:6026
+msgid ""
+"if switched on, thumbnails and previews are rendered at lower quality but 4 "
+"times faster"
+msgstr ""
+"If switched on, thumbnails and previews are rendered at lower quality but 4 "
+"times faster"
+
+#: ../build/bin/preferences_gen.h:6048
+msgid "enable disk backend for thumbnail cache"
+msgstr "Enable disk backend for thumbnail cache"
+
+#: ../build/bin/preferences_gen.h:6062
+msgid ""
+"if enabled, write thumbnails to disk (.cache/darktable/) when evicted from "
+"the memory cache.\n"
+"note that this can take a lot of memory (several gigabytes for 20k images) "
+"and will never delete cached thumbnails again.\n"
+"it's safe though to delete these manually, if you want. light table "
+"performance will be increased greatly when browsing a lot.\n"
+"to generate all thumbnails of your entire collection offline, run 'darktable-"
+"generate-cache'."
+msgstr ""
+"If enabled, write thumbnails to disk (.cache/darktable/) when evicted from "
+"the memory cache.\n"
+"Note that this can take a lot of memory (several gigabytes for 20k images) "
+"and will never delete cached thumbnails again.\n"
+"It's safe though to delete these manually, if you want. Light table "
+"performance will be increased greatly when browsing a lot.\n"
+"To generate all thumbnails of your entire collection offline, run 'darktable-"
+"generate-cache'."
+
+#: ../build/bin/preferences_gen.h:6084
+msgid "enable disk backend for full preview cache"
+msgstr "Enable disk backend for full preview cache"
+
+#: ../build/bin/preferences_gen.h:6098
+msgid ""
+"if enabled, write full preview to disk (.cache/darktable/) when evicted from "
+"the memory cache.\n"
+"note that this can take a lot of memory (several gigabytes for 20k images) "
+"and will never delete cached thumbnails again.\n"
+"it's safe though to delete these manually, if you want.\n"
+"light table performance will be increased greatly when zooming image in full "
+"preview mode."
+msgstr ""
+"If enabled, write full preview to disk (.cache/darktable/) when evicted from "
+"the memory cache.\n"
+"Note that this can take a lot of memory (several gigabytes for 20k images) "
+"and will never delete cached thumbnails again.\n"
+"It's safe though to delete these manually, if you want.\n"
+"Light table performance will be increased greatly when zooming image in full "
+"preview mode."
+
+#: ../build/bin/preferences_gen.h:6120
+msgid "activate OpenCL support"
+msgstr "Activate OpenCL support"
+
+#: ../build/bin/preferences_gen.h:6134
+msgid ""
+"if found, use OpenCL runtime on your system to speed up processing.\n"
+"can be switched on and off at any time."
+msgstr ""
+"If found, use OpenCL runtime on your system to speed up processing.\n"
+"Can be switched on and off at any time."
+
+#: ../build/bin/preferences_gen.h:6135 ../build/bin/preferences_gen.h:6206
+#: ../build/bin/preferences_gen.h:6282 ../build/bin/preferences_gen.h:7574
+msgid "not available"
+msgstr "Not available"
+
+#: ../build/bin/preferences_gen.h:6138 ../build/bin/preferences_gen.h:6142
+#: ../build/bin/preferences_gen.h:6209 ../build/bin/preferences_gen.h:6213
+#: ../build/bin/preferences_gen.h:6285 ../build/bin/preferences_gen.h:6289
+#: ../build/bin/preferences_gen.h:7577 ../build/bin/preferences_gen.h:7581
+msgid "not available on this system"
+msgstr "Not available on this system"
+
+#: ../build/bin/preferences_gen.h:6162
+msgid "OpenCL scheduling profile"
+msgstr "OpenCL scheduling profile"
+
+#: ../build/bin/preferences_gen.h:6205
+msgid ""
+"defines how preview and full pixelpipe tasks are scheduled on OpenCL enabled "
+"systems:\n"
+" - 'default': GPU processes full and CPU processes preview pipe (adaptable "
+"by config parameters),\n"
+" - 'multiple GPUs': process both pixelpipes in parallel on two different "
+"GPUs,\n"
+" - 'very fast GPU': process both pixelpipes sequentially on the GPU."
+msgstr ""
+"Defines how preview and full pixelpipe tasks are scheduled on OpenCL enabled "
+"systems:\n"
+" - 'Default': GPU processes full and CPU processes preview pipe (adaptable "
+"by config parameters),\n"
+" - 'Multiple GPUs': process both pixelpipes in parallel on two different "
+"GPUs,\n"
+" - 'Very fast GPU': process both pixelpipes sequentially on the GPU."
+
+#: ../build/bin/preferences_gen.h:6233
+msgid "tune OpenCL performance"
+msgstr "Tune OpenCL performance"
+
+#: ../build/bin/preferences_gen.h:6281
+msgid ""
+"allows runtime tuning of OpenCL devices:\n"
+" - 'memory size': uses a fixed headroom (400MB as default),\n"
+" - 'memory transfer': tries a faster memory access mode (pinned memory) used "
+"for tiling."
+msgstr ""
+"Allows runtime tuning of OpenCL devices:\n"
+" - 'Memory size': uses a fixed headroom (400MB as default),\n"
+" - 'Memory transfer': tries a faster memory access mode (pinned memory) used "
+"for tiling."
+
+#: ../build/bin/preferences_gen.h:6315
+msgid "security"
+msgstr "Security"
+
+#: ../build/bin/preferences_gen.h:6338
+msgid "ask before removing images from the library"
+msgstr "Ask before removing images from the library"
+
+#: ../build/bin/preferences_gen.h:6352
+msgid "always ask the user before removing image information from the library"
+msgstr "Always ask the user before removing image information from the library"
+
+#: ../build/bin/preferences_gen.h:6374
+msgid "ask before deleting images from disk"
+msgstr "Ask before deleting images from disk"
+
+#: ../build/bin/preferences_gen.h:6388
+msgid "always ask the user before any image file is deleted"
+msgstr "Always ask the user before any image file is deleted"
+
+#: ../build/bin/preferences_gen.h:6410
+msgid "ask before discarding history stack"
+msgstr "Ask before discarding history stack"
+
+#: ../build/bin/preferences_gen.h:6424
+msgid "always ask the user before history stack is discarded on any image"
+msgstr "Always ask the user before history stack is discarded on any image"
+
+#: ../build/bin/preferences_gen.h:6446
+msgid "try to use trash when deleting images"
+msgstr "Try to use trash when deleting images"
+
+#: ../build/bin/preferences_gen.h:6460
+msgid ""
+"send files to trash instead of permanently deleting files on system that "
+"supports it"
+msgstr ""
+"Send files to trash instead of permanently deleting files on system that "
+"supports it"
+
+#: ../build/bin/preferences_gen.h:6482
+msgid "ask before moving images from film roll folder"
+msgstr "Ask before moving images from film roll folder"
+
+#: ../build/bin/preferences_gen.h:6496
+msgid "always ask the user before any image file is moved."
+msgstr "Always ask the user before any image file is moved."
+
+#: ../build/bin/preferences_gen.h:6518
+msgid "ask before copying images to new film roll folder"
+msgstr "Ask before copying images to new film roll folder"
+
+#: ../build/bin/preferences_gen.h:6532
+msgid "always ask the user before any image file is copied."
+msgstr "Always ask the user before any image file is copied."
+
+#: ../build/bin/preferences_gen.h:6554
+msgid "ask before removing empty folders"
+msgstr "Ask before removing empty folders"
+
+#: ../build/bin/preferences_gen.h:6568
+msgid ""
+"always ask the user before removing any empty folder. this can happen after "
+"moving or deleting images."
+msgstr ""
+"Always ask the user before removing any empty folder. This can happen after "
+"moving or deleting images."
+
+#: ../build/bin/preferences_gen.h:6590
+msgid "ask before deleting a tag"
+msgstr "Ask before deleting a tag"
+
+#: ../build/bin/preferences_gen.h:6625
+msgid "ask before deleting a style"
+msgstr "Ask before deleting a style"
+
+#: ../build/bin/preferences_gen.h:6660
+msgid "ask before deleting a preset"
+msgstr "Ask before deleting a preset"
+
+#: ../build/bin/preferences_gen.h:6674
+msgid "will ask for confirmation before deleting or overwriting a preset"
+msgstr "Will ask for confirmation before deleting or overwriting a preset"
+
+#: ../build/bin/preferences_gen.h:6696
+msgid "ask before exporting in overwrite mode"
+msgstr "Ask before exporting in overwrite mode"
+
+#: ../build/bin/preferences_gen.h:6710
+msgid "will ask for confirmation before exporting files in overwrite mode"
+msgstr "Will ask for confirmation before exporting files in overwrite mode"
+
+#. italic
+#: ../build/bin/preferences_gen.h:6720 ../src/libs/tools/viewswitcher.c:149
+msgid "other"
+msgstr "Other"
+
+#: ../build/bin/preferences_gen.h:6740
+msgid "password storage backend to use"
+msgstr "Password storage backend to use"
+
+#: ../build/bin/preferences_gen.h:6790
+msgid ""
+"the storage backend for password storage: auto, none, libsecret, kwallet"
+msgstr ""
+"The storage backend for password storage: auto, none, libsecret, KWallet"
+
+#: ../build/bin/preferences_gen.h:6812
+msgid "executable for playing audio files"
+msgstr "Executable for playing audio files"
+
+#: ../build/bin/preferences_gen.h:6830
+msgid ""
+"this external program is used to play audio files some cameras record to "
+"keep notes for images"
+msgstr ""
+"This external program is used to play audio files some cameras record to "
+"keep notes for images"
+
+#: ../build/bin/preferences_gen.h:6858
+msgid "storage"
+msgstr "Storage"
+
+#: ../build/bin/preferences_gen.h:6861 ../src/control/crawler.c:724
+msgid "database"
+msgstr "Database"
+
+#: ../build/bin/preferences_gen.h:6881
+msgid "create database snapshot"
+msgstr "Create database snapshot"
+
+#: ../build/bin/preferences_gen.h:6934
+msgid ""
+"database snapshots are created right before closing darktable. options allow "
+"you to choose how often to make snapshots:\n"
+" - 'never': simply don't do snapshots. that way the only snapshots done are "
+"mandatory version-upgrade snapshots\n"
+" - 'once a month': create snapshot if a month has passed since last "
+"snapshot\n"
+" - 'once a week': create snapshot if 7 days had passed since last snapshot\n"
+" - 'once a day': create snapshot if over 24h passed since last snapshot\n"
+" - 'on close': create snapshot every time darktable is closed"
+msgstr ""
+"Database snapshots are created right before closing darktable. Options allow "
+"you to choose how often to make snapshots:\n"
+" - 'Never': simply don't do snapshots. That way the only snapshots done are "
+"mandatory version-upgrade snapshots\n"
+" - 'Once a month': create snapshot if a month has passed since last "
+"snapshot\n"
+" - 'Once a week': create snapshot if 7 days had passed since last snapshot\n"
+" - 'Once a day': create snapshot if over 24h passed since last snapshot\n"
+" - 'On close': create snapshot every time darktable is closed"
+
+#: ../build/bin/preferences_gen.h:6956
+msgid "how many snapshots to keep"
+msgstr "How many snapshots to keep"
+
+#: ../build/bin/preferences_gen.h:6979
+msgid ""
+"after successfully creating snapshot, how many older snapshots to keep "
+"(excluding mandatory version update ones). enter -1 to keep all snapshots\n"
+"keep in mind that snapshots do take some space and you only need the most "
+"recent one for successful restore"
+msgstr ""
+"After successfully creating snapshot, how many older snapshots to keep "
+"(excluding mandatory version update ones). Enter -1 to keep all snapshots\n"
+"Keep in mind that snapshots do take some space and you only need the most "
+"recent one for successful restore"
+
+#: ../build/bin/preferences_gen.h:6989 ../src/control/crawler.c:723
+msgid "XMP"
+msgstr "XMP"
+
+#: ../build/bin/preferences_gen.h:7009
+msgid "write sidecar file for each image"
+msgstr "Write sidecar file for each image"
+
+#: ../build/bin/preferences_gen.h:7052
+msgid ""
+"the sidecar files hold information about all your development steps to allow "
+"flawless re-importing of image files.\n"
+"\n"
+"depending on the selected mode sidecar files will be written:\n"
+" - 'never'\n"
+" - 'on import': immediately after importing the image\n"
+" - 'after edit': after any user change on the image."
+msgstr ""
+"The sidecar files hold information about all your development steps to allow "
+"flawless re-importing of image files.\n"
+"\n"
+"Depending on the selected mode sidecar files will be written:\n"
+" - 'Never'\n"
+" - 'On import': immediately after importing the image\n"
+" - 'After edit': after any user change on the image."
+
+#: ../build/bin/preferences_gen.h:7074
+msgid "store XMP tags in compressed format"
+msgstr "Store XMP tags in compressed format"
+
+#: ../build/bin/preferences_gen.h:7117
+msgid ""
+"entries in XMP tags can get rather large and may exceed the available space "
+"to store the history stack in output files.\n"
+"this option allows XMP tags to be compressed and save space."
+msgstr ""
+"Entries in XMP tags can get rather large and may exceed the available space "
+"to store the history stack in output files.\n"
+"This option allows XMP tags to be compressed and save space."
+
+#: ../build/bin/preferences_gen.h:7139
+msgid "look for updated XMP files on startup"
+msgstr "Look for updated XMP files on startup"
+
+#: ../build/bin/preferences_gen.h:7153
+msgid ""
+"check file modification times of all XMP files on startup to check if any "
+"got updated in the meantime"
+msgstr ""
+"Check file modification times of all XMP files on startup to check if any "
+"got updated in the meantime"
+
+#: ../build/bin/preferences_gen.h:7181
+msgid "miscellaneous"
+msgstr "Miscellaneous"
+
+#: ../build/bin/preferences_gen.h:7184
+msgid "interface"
+msgstr "Interface"
+
+#: ../build/bin/preferences_gen.h:7204
+msgid "load default shortcuts at startup"
+msgstr "Load default shortcuts at startup"
+
+#: ../build/bin/preferences_gen.h:7218
+msgid ""
+"load default shortcuts before user settings. switch off to prevent deleted "
+"defaults returning"
+msgstr ""
+"Load default shortcuts before user settings. Switch off to prevent deleted "
+"defaults returning"
+
+#: ../build/bin/preferences_gen.h:7240
+msgid "scale slider step with min/max"
+msgstr "Scale slider step with min/max"
+
+#: ../build/bin/preferences_gen.h:7254
+msgid "vary slider step size with min/max range"
+msgstr "Vary slider step size with min/max range"
+
+#: ../build/bin/preferences_gen.h:7276
+msgid "sort built-in presets first"
+msgstr "Sort built-in presets first"
+
+#: ../build/bin/preferences_gen.h:7290
+msgid ""
+"whether to show built-in presets first before user's presets in presets menu."
+msgstr ""
+"Whether to show built-in presets first before user's presets in presets menu."
+
+#: ../build/bin/preferences_gen.h:7312
+msgid "mouse wheel scrolls modules side panel by default"
+msgstr "Mouse wheel scrolls modules side panel by default"
+
+#: ../build/bin/preferences_gen.h:7326
+msgid ""
+"when enabled, use mouse wheel to scroll modules side panel.  use ctrl+alt to "
+"use mouse wheel for data entry.  when disabled, this behavior is reversed"
+msgstr ""
+"When enabled, use mouse wheel to scroll modules side panel. Use Ctrl+Alt to "
+"use mouse wheel for data entry. When disabled, this behavior is reversed"
+
+#: ../build/bin/preferences_gen.h:7348
+msgid "always show panels' scrollbars"
+msgstr "Always show panels' scrollbars"
+
+#: ../build/bin/preferences_gen.h:7362
+msgid ""
+"defines whether the panel scrollbars should be always visible or activated "
+"only depending on the content.  (need a restart)"
+msgstr ""
+"Defines whether the panel scrollbars should be always visible or activated "
+"only depending on the content.  (need a restart)"
+
+#: ../build/bin/preferences_gen.h:7384
+msgid "duration of the ui transitions in ms"
+msgstr "Duration of the UI transitions in ms"
+
+#: ../build/bin/preferences_gen.h:7408
+msgid ""
+"how long the transitions take (in ms) for expanding or collapsing modules "
+"and other ui elements"
+msgstr ""
+"How long the transitions take (in ms) for expanding or collapsing modules "
+"and other UI elements"
+
+#: ../build/bin/preferences_gen.h:7430
+msgid "position of the scopes module"
+msgstr "Position of the scopes module"
+
+#: ../build/bin/preferences_gen.h:7468
+msgid "position the scopes at the top-left or top-right of the screen"
+msgstr "Position the scopes at the top-left or top-right of the screen"
+
+#: ../build/bin/preferences_gen.h:7490
+msgid "method to use for getting the display profile"
+msgstr "Method to use for getting the display profile"
+
+#: ../build/bin/preferences_gen.h:7533
+msgid ""
+"this option allows to force a specific means of getting the current display "
+"profile.\n"
+"this is useful when one alternative gives wrong results"
+msgstr ""
+"This option allows to force a specific means of getting the current display "
+"profile.\n"
+"This is useful when one alternative gives wrong results"
+
+#: ../build/bin/preferences_gen.h:7555
+msgid "order or exclude MIDI devices"
+msgstr "Order or exclude MIDI devices"
+
+#: ../build/bin/preferences_gen.h:7573
+msgid ""
+"comma-separated list of device name fragments that if matched load MIDI "
+"device at id given by location in list\n"
+"or if preceded by - prevent matching devices from loading. add encoding and "
+"number of knobs like 'BeatStep:63:16'"
+msgstr ""
+"Comma-separated list of device name fragments that if matched load MIDI "
+"device at Id given by location in list\n"
+"or if preceded by '-' prevent matching devices from loading. Add encoding "
+"and number of knobs like 'BeatStep:63:16'."
+
+#. tags
+#: ../build/bin/preferences_gen.h:7589 ../src/develop/lightroom.c:1516
+#: ../src/gui/import_metadata.c:476 ../src/libs/export_metadata.c:331
+#: ../src/libs/image.c:560 ../src/libs/metadata_view.c:162
+msgid "tags"
+msgstr "Tags"
+
+#: ../build/bin/preferences_gen.h:7609
+msgid "omit hierarchy in simple tag lists"
+msgstr "Omit hierarchy in simple tag lists"
+
+#: ../build/bin/preferences_gen.h:7623
+msgid ""
+"when creating XMP file the hierarchical tags are also added as a simple "
+"list\n"
+"of non-hierarchical ones to make them visible to some other programs.\n"
+"when this option is checked darktable will only include their last part\n"
+"and ignore the rest. so 'foo|bar|baz' will only add 'baz'."
+msgstr ""
+"When creating XMP file the hierarchical tags are also added as a simple "
+"list\n"
+"of non-hierarchical ones to make them visible to some other programs.\n"
+"When this option is checked darktable will only include their last part\n"
+"and ignore the rest. So 'foo|bar|baz' will only add 'baz'."
+
+#: ../build/bin/preferences_gen.h:7633
+msgid "shortcuts with multiple instances"
+msgstr "Shortcuts with multiple instances"
+
+#: ../build/bin/preferences_gen.h:7638
+msgid ""
+"where multiple module instances are present, these preferences control rules "
+"that are applied (in order) to decide which module instance shortcuts will "
+"be applied to"
+msgstr ""
+"Where multiple module instances are present, these preferences control rules "
+"that are applied (in order) to decide which module instance shortcuts will "
+"be applied to"
+
+#: ../build/bin/preferences_gen.h:7654
+msgid "prefer focused instance"
+msgstr "Prefer focused instance"
+
+#: ../build/bin/preferences_gen.h:7668
+msgid ""
+"if an instance of the module has focus, apply shortcut to that instance\n"
+"note: blending shortcuts always apply to the focused instance"
+msgstr ""
+"If an instance of the module has focus, apply shortcut to that instance\n"
+"Note: blending shortcuts always apply to the focused instance"
+
+#: ../build/bin/preferences_gen.h:7690
+msgid "prefer expanded instances"
+msgstr "Prefer expanded instances"
+
+#: ../build/bin/preferences_gen.h:7704
+msgid "if instances of the module are expanded, ignore collapsed instances"
+msgstr "If instances of the module are expanded, ignore collapsed instances"
+
+#: ../build/bin/preferences_gen.h:7726
+msgid "prefer enabled instances"
+msgstr "Prefer enabled instances"
+
+#: ../build/bin/preferences_gen.h:7740
+msgid ""
+"after applying the above rule, if instances of the module are active, ignore "
+"inactive instances"
+msgstr ""
+"After applying the above rule, if instances of the module are active, ignore "
+"inactive instances"
+
+#: ../build/bin/preferences_gen.h:7762
+msgid "prefer unmasked instances"
+msgstr "Prefer unmasked instances"
+
+#: ../build/bin/preferences_gen.h:7776
+msgid ""
+"after applying the above rules, if instances of the module are unmasked, "
+"ignore masked instances"
+msgstr ""
+"After applying the above rules, if instances of the module are unmasked, "
+"ignore masked instances"
+
+#: ../build/bin/preferences_gen.h:7798
+msgid "selection order"
+msgstr "Selection order"
+
+#: ../build/bin/preferences_gen.h:7836
+msgid ""
+"after applying the above rules, apply the shortcut based on its position in "
+"the pixelpipe"
+msgstr ""
+"After applying the above rules, apply the shortcut based on its position in "
+"the pixelpipe"
+
+#: ../build/bin/preferences_gen.h:7858
+msgid "allow visual assignment to specific instances"
+msgstr "Allow visual assignment to specific instances"
+
+#: ../build/bin/preferences_gen.h:7872
+msgid ""
+"when multiple instances are present on an image this allows shortcuts to be "
+"visually assigned to those specific instances\n"
+"otherwise shortcuts will always be assigned to the preferred instance"
+msgstr ""
+"When multiple instances are present on an image this allows shortcuts to be "
+"visually assigned to those specific instances\n"
+"Otherwise shortcuts will always be assigned to the preferred instance"
+
+#: ../build/bin/preferences_gen.h:7882
+msgid "map / geolocalization view"
+msgstr "Map / geolocalization view"
+
+#: ../build/bin/preferences_gen.h:7902
+msgid "pretty print the image location"
+msgstr "Pretty print the image location"
+
+#: ../build/bin/preferences_gen.h:7916
+msgid ""
+"show a more readable representation of the location in the image information "
+"module"
+msgstr ""
+"Show a more readable representation of the location in the image information "
+"module"
+
+#: ../build/bin/preferences_gen.h:7926
+msgid "slideshow view"
+msgstr "Slideshow view"
+
+#: ../build/bin/preferences_gen.h:7946
+msgid "waiting time between each picture in slideshow"
+msgstr "Waiting time between each picture in slideshow"
+
+#: ../build/bin/preferences_gen.h:7996 ../src/control/jobs/control_jobs.c:2319
+#: ../src/libs/import.c:172
+msgid "import"
+msgstr "Import"
+
+#: ../build/bin/preferences_gen.h:7999
+msgid "session options"
+msgstr "Session options"
+
+#: ../build/bin/preferences_gen.h:8019
+msgid "base directory naming pattern"
+msgstr "Base directory naming pattern"
+
+#: ../build/bin/preferences_gen.h:8037 ../build/bin/preferences_gen.h:8077
+msgid "part of full import path for an import session"
+msgstr "Part of full import path for an import session"
+
+#: ../build/bin/preferences_gen.h:8059
+msgid "sub directory naming pattern"
+msgstr "Sub directory naming pattern"
+
+#: ../build/bin/preferences_gen.h:8099
+msgid "keep original filename"
+msgstr "Keep original filename"
+
+#: ../build/bin/preferences_gen.h:8113
+msgid ""
+"keep original filename instead of a pattern while importing from camera or "
+"card"
+msgstr ""
+"Keep original filename instead of a pattern while importing from camera or "
+"card"
+
+#: ../build/bin/preferences_gen.h:8135
+msgid "file naming pattern"
+msgstr "File naming pattern"
+
+#: ../build/bin/preferences_gen.h:8153
+msgid "file naming pattern used for a import session"
+msgstr "File naming pattern used for a import session"
+
+#: ../build/bin/preferences_gen.h:8190
+msgid "do not set the 'uncategorized' entry for tags"
+msgstr "Do not set the 'uncategorized' entry for tags"
+
+#: ../build/bin/preferences_gen.h:8204
+msgid ""
+"do not set the 'uncategorized' entry for tags which do not have children"
+msgstr ""
+"Do not set the 'uncategorized' entry for tags which do not have children"
+
+#: ../build/bin/preferences_gen.h:8226
+msgid "tags case sensitivity"
+msgstr "Tags case sensitivity"
+
+#: ../build/bin/preferences_gen.h:8264
+msgid ""
+"tags case sensitivity. without the Sqlite ICU extension, insensitivity works "
+"only for the 26 latin letters"
+msgstr ""
+"Tags case sensitivity. Without the Sqlite ICU extension, insensitivity works "
+"only for the 26 latin letters"
+
+#: ../build/bin/preferences_gen.h:8286 ../build/bin/preferences_gen.h:8526
+msgid "number of collections to be stored"
+msgstr "Number of collections to be stored"
+
+#: ../build/bin/preferences_gen.h:8310 ../build/bin/preferences_gen.h:8550
+msgid "the number of recent collections to store and show in this list"
+msgstr "The number of recent collections to store and show in this list"
+
+#: ../build/bin/preferences_gen.h:8332
+msgid "hide the history button and show a specific module instead"
+msgstr "Hide the history button and show a specific module instead"
+
+#: ../build/bin/preferences_gen.h:8346
+msgid "hide the history button and show the recent collections module instead"
+msgstr "Hide the history button and show the recent collections module instead"
+
+#: ../build/bin/preferences_gen.h:8368
+msgid "number of folder levels to show in lists"
+msgstr "Number of folder levels to show in lists"
+
+#: ../build/bin/preferences_gen.h:8392
+msgid ""
+"the number of folder levels to show in film roll names, starting from the "
+"right"
+msgstr ""
+"The number of folder levels to show in film roll names, starting from the "
+"right"
+
+#: ../build/bin/preferences_gen.h:8414
+msgid "sort film rolls by"
+msgstr "Sort film rolls by"
+
+#: ../build/bin/preferences_gen.h:8452
+msgid "sets the collections-list order for film rolls"
+msgstr "Sets the collections-list order for film rolls"
+
+#: ../build/bin/preferences_gen.h:8474
+msgid "sort collection descending"
+msgstr "Sort collection descending"
+
+#: ../build/bin/preferences_gen.h:8488
+msgid ""
+"sort the following collections in descending order: 'film roll' by folder, "
+"'folder', 'times' (e.g. 'capture date')"
+msgstr ""
+"Sort the following collections in descending order: 'film roll' by folder, "
+"'folder', 'times' (e.g. 'capture date')"
+
+#: ../build/bin/preferences_gen.h:8572
+msgid "prefer a history button in the collections module"
+msgstr "Prefer a history button in the collections module"
+
+#: ../build/bin/preferences_gen.h:8586
+msgid ""
+"hide this module and instead access collections history with a button in the "
+"collections module"
+msgstr ""
+"Hide this module and instead access collections history with a button in the "
+"collections module"
+
+#: ../build/bin/preferences_gen.h:8640
+msgid "suggested tags level of confidence"
+msgstr "Suggested tags level of confidence"
+
+#: ../build/bin/preferences_gen.h:8665
+#, no-c-format
+msgid ""
+"level of confidence to include the tag in the suggestions list, 0: all "
+"associated tags, 99: 99% matching associated tags, 100: no matching tag to "
+"show only recent tags (faster)"
+msgstr ""
+"Level of confidence to include the tag in the suggestions list, 0: all "
+"associated tags, 99: 99% matching associated tags, 100: no matching tag to "
+"show only recent tags (faster)"
+
+#: ../build/bin/preferences_gen.h:8687
+msgid "number of recently attached tags"
+msgstr "Number of recently attached tags"
+
+#: ../build/bin/preferences_gen.h:8711
+msgid ""
+"number of recently attached tags which are included in the suggestions list. "
+"the value `-1' disables the recent list"
+msgstr ""
+"Number of recently attached tags which are included in the suggestions list. "
+"The value `-1' disables the recent list"
+
+#: ../build/lib/darktable/plugins/introspection_ashift.c:130
+#: ../build/lib/darktable/plugins/introspection_ashift.c:279
+msgid "lens shift (vertical)"
+msgstr "Lens shift (vertical)"
+
+#: ../build/lib/darktable/plugins/introspection_ashift.c:136
+#: ../build/lib/darktable/plugins/introspection_ashift.c:283
+msgid "lens shift (horizontal)"
+msgstr "Lens shift (horizontal)"
+
+#: ../build/lib/darktable/plugins/introspection_ashift.c:142
+#: ../build/lib/darktable/plugins/introspection_ashift.c:287
+msgid "shear"
+msgstr "Shear"
+
+#. focal length
+#: ../build/lib/darktable/plugins/introspection_ashift.c:148
+#: ../build/lib/darktable/plugins/introspection_ashift.c:291
+#: ../src/common/collection.c:666 ../src/gui/preferences.c:839
+#: ../src/gui/presets.c:633 ../src/libs/camera.c:551
+#: ../src/libs/metadata_view.c:143
+msgid "focal length"
+msgstr "Focal length"
+
+#: ../build/lib/darktable/plugins/introspection_ashift.c:154
+#: ../build/lib/darktable/plugins/introspection_ashift.c:295
+msgid "crop factor"
+msgstr "Crop factor"
+
+#: ../build/lib/darktable/plugins/introspection_ashift.c:160
+#: ../build/lib/darktable/plugins/introspection_ashift.c:299
+msgid "lens dependence"
+msgstr "Lens dependence"
+
+#: ../build/lib/darktable/plugins/introspection_ashift.c:166
+#: ../build/lib/darktable/plugins/introspection_ashift.c:303
+msgid "aspect adjust"
+msgstr "Aspect adjust"
+
+#: ../build/lib/darktable/plugins/introspection_ashift.c:172
+#: ../build/lib/darktable/plugins/introspection_ashift.c:307
+#: ../src/iop/lens.cc:3521
+msgid "lens model"
+msgstr "Lens model"
+
+#: ../build/lib/darktable/plugins/introspection_ashift.c:178
+#: ../build/lib/darktable/plugins/introspection_ashift.c:311
+#: ../build/lib/darktable/plugins/introspection_clipping.c:244
+#: ../build/lib/darktable/plugins/introspection_clipping.c:371
+msgid "automatic cropping"
+msgstr "Automatic cropping"
+
+#: ../build/lib/darktable/plugins/introspection_ashift.c:361
+#: ../build/lib/darktable/plugins/introspection_highlights.c:311
+msgid "generic"
+msgstr "Generic"
+
+#: ../build/lib/darktable/plugins/introspection_ashift.c:362
+msgid "specific"
+msgstr "Specific"
+
+#. DEVELOP_MASK_DISABLED
+#: ../build/lib/darktable/plugins/introspection_ashift.c:366
+#: ../build/lib/darktable/plugins/introspection_colorin.c:301
+#: ../build/lib/darktable/plugins/introspection_highlights.c:310
+#: ../build/lib/darktable/plugins/introspection_vignette.c:263
+#: ../src/develop/blend_gui.c:153 ../src/develop/blend_gui.c:182
+#: ../src/develop/blend_gui.c:3414 ../src/gui/accelerators.c:130
+#: ../src/gui/accelerators.c:140 ../src/gui/accelerators.c:224
+#: ../src/imageio/format/avif.c:804 ../src/imageio/format/j2k.c:669
+#: ../src/libs/live_view.c:362
+msgid "off"
+msgstr "Off"
+
+#: ../build/lib/darktable/plugins/introspection_ashift.c:367
+msgid "largest area"
+msgstr "Largest area"
+
+#: ../build/lib/darktable/plugins/introspection_ashift.c:368
+msgid "original format"
+msgstr "Original format"
+
+#: ../build/lib/darktable/plugins/introspection_basecurve.c:134
+#: ../build/lib/darktable/plugins/introspection_basecurve.c:231
+msgid "fusion"
+msgstr "Fusion"
+
+#: ../build/lib/darktable/plugins/introspection_basecurve.c:140
+#: ../build/lib/darktable/plugins/introspection_basecurve.c:235
+msgid "exposure shift"
+msgstr "Exposure shift"
+
+#: ../build/lib/darktable/plugins/introspection_basecurve.c:146
+#: ../build/lib/darktable/plugins/introspection_basecurve.c:239
+#: ../src/libs/metadata_view.c:142
+msgid "exposure bias"
+msgstr "Exposure bias"
+
+#: ../build/lib/darktable/plugins/introspection_basecurve.c:152
+#: ../build/lib/darktable/plugins/introspection_basecurve.c:243
+#: ../build/lib/darktable/plugins/introspection_basicadj.c:122
+#: ../build/lib/darktable/plugins/introspection_basicadj.c:215
+#: ../build/lib/darktable/plugins/introspection_rgbcurve.c:140
+#: ../build/lib/darktable/plugins/introspection_rgbcurve.c:227
+#: ../build/lib/darktable/plugins/introspection_rgblevels.c:57
+#: ../build/lib/darktable/plugins/introspection_rgblevels.c:122
+#: ../build/lib/darktable/plugins/introspection_tonecurve.c:153
+#: ../build/lib/darktable/plugins/introspection_tonecurve.c:244
+msgid "preserve colors"
+msgstr "Preserve colors"
+
+#: ../build/lib/darktable/plugins/introspection_basecurve.c:262
+#: ../build/lib/darktable/plugins/introspection_basicadj.c:249
+#: ../build/lib/darktable/plugins/introspection_colorreconstruction.c:153
+#: ../build/lib/darktable/plugins/introspection_rgbcurve.c:251
+#: ../build/lib/darktable/plugins/introspection_rgblevels.c:153
+#: ../build/lib/darktable/plugins/introspection_tonecurve.c:270
+#: ../src/gui/guides.c:712 ../src/iop/basecurve.c:2176
+#: ../src/iop/channelmixerrgb.c:4637 ../src/iop/clipping.c:1900
+#: ../src/iop/clipping.c:2093 ../src/iop/clipping.c:2108
+#: ../src/iop/lens.cc:3451 ../src/iop/retouch.c:463 ../src/libs/collect.c:1908
+#: ../src/libs/colorpicker.c:51 ../src/libs/export.c:1028
+#: ../src/libs/filters/module_order.c:158 ../src/libs/histogram.c:131
+#: ../src/libs/live_view.c:312 ../src/libs/print_settings.c:2657
+msgid "none"
+msgstr "None"
+
+#: ../build/lib/darktable/plugins/introspection_basecurve.c:263
+#: ../build/lib/darktable/plugins/introspection_basicadj.c:250
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:226
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:244
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:262
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:280
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:461
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:473
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:485
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:497
+#: ../build/lib/darktable/plugins/introspection_rgbcurve.c:252
+#: ../build/lib/darktable/plugins/introspection_rgblevels.c:154
+#: ../build/lib/darktable/plugins/introspection_tonecurve.c:271
+#: ../src/develop/blend_gui.c:2367 ../src/develop/blend_gui.c:2401
+msgid "luminance"
+msgstr "Luminance"
+
+#: ../build/lib/darktable/plugins/introspection_basecurve.c:264
+#: ../build/lib/darktable/plugins/introspection_basicadj.c:251
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:550
+#: ../build/lib/darktable/plugins/introspection_rgbcurve.c:253
+#: ../build/lib/darktable/plugins/introspection_rgblevels.c:155
+#: ../build/lib/darktable/plugins/introspection_tonecurve.c:272
+msgid "max RGB"
+msgstr "Max RGB"
+
+#: ../build/lib/darktable/plugins/introspection_basecurve.c:265
+#: ../build/lib/darktable/plugins/introspection_basicadj.c:252
+#: ../build/lib/darktable/plugins/introspection_rgbcurve.c:254
+#: ../build/lib/darktable/plugins/introspection_rgblevels.c:156
+#: ../build/lib/darktable/plugins/introspection_tonecurve.c:273
+msgid "average RGB"
+msgstr "Average RGB"
+
+#: ../build/lib/darktable/plugins/introspection_basecurve.c:266
+#: ../build/lib/darktable/plugins/introspection_basicadj.c:253
+#: ../build/lib/darktable/plugins/introspection_rgbcurve.c:255
+#: ../build/lib/darktable/plugins/introspection_rgblevels.c:157
+#: ../build/lib/darktable/plugins/introspection_tonecurve.c:274
+msgid "sum RGB"
+msgstr "Sum RGB"
+
+#: ../build/lib/darktable/plugins/introspection_basecurve.c:267
+#: ../build/lib/darktable/plugins/introspection_basicadj.c:254
+#: ../build/lib/darktable/plugins/introspection_rgbcurve.c:256
+#: ../build/lib/darktable/plugins/introspection_rgblevels.c:158
+#: ../build/lib/darktable/plugins/introspection_tonecurve.c:275
+msgid "norm RGB"
+msgstr "Norm RGB"
+
+#: ../build/lib/darktable/plugins/introspection_basecurve.c:268
+#: ../build/lib/darktable/plugins/introspection_basicadj.c:255
+#: ../build/lib/darktable/plugins/introspection_rgbcurve.c:257
+#: ../build/lib/darktable/plugins/introspection_rgblevels.c:159
+#: ../build/lib/darktable/plugins/introspection_tonecurve.c:276
+msgid "basic power"
+msgstr "Basic power"
+
+#: ../build/lib/darktable/plugins/introspection_basicadj.c:92
+#: ../build/lib/darktable/plugins/introspection_basicadj.c:195
+#: ../build/lib/darktable/plugins/introspection_exposure.c:67
+#: ../build/lib/darktable/plugins/introspection_exposure.c:138
+msgid "black level correction"
+msgstr "Black level correction"
+
+#: ../build/lib/darktable/plugins/introspection_basicadj.c:104
+#: ../build/lib/darktable/plugins/introspection_basicadj.c:203
+msgid "highlight compression"
+msgstr "Highlight compression"
+
+#: ../build/lib/darktable/plugins/introspection_basicadj.c:128
+#: ../build/lib/darktable/plugins/introspection_basicadj.c:219
+msgid "middle gray"
+msgstr "Middle gray"
+
+#: ../build/lib/darktable/plugins/introspection_bilat.c:78
+#: ../build/lib/darktable/plugins/introspection_bilat.c:137
+msgid "midtone range"
+msgstr "Midtone range"
+
+#: ../build/lib/darktable/plugins/introspection_bilat.c:151
+msgid "bilateral grid"
+msgstr "Bilateral grid"
+
+#: ../build/lib/darktable/plugins/introspection_bilat.c:152
+msgid "local laplacian filter"
+msgstr "Local laplacian filter"
+
+#: ../build/lib/darktable/plugins/introspection_blurs.c:83
+#: ../build/lib/darktable/plugins/introspection_blurs.c:174
+#: ../build/lib/darktable/plugins/introspection_retouch.c:255
+#: ../build/lib/darktable/plugins/introspection_retouch.c:406
+msgid "blur type"
+msgstr "Blur type"
+
+#: ../build/lib/darktable/plugins/introspection_blurs.c:89
+#: ../build/lib/darktable/plugins/introspection_blurs.c:178
+#: ../build/lib/darktable/plugins/introspection_retouch.c:261
+#: ../build/lib/darktable/plugins/introspection_retouch.c:410
+msgid "blur radius"
+msgstr "Blur radius"
+
+#: ../build/lib/darktable/plugins/introspection_blurs.c:95
+#: ../build/lib/darktable/plugins/introspection_blurs.c:182
+msgid "diaphragm blades"
+msgstr "Diaphragm blades"
+
+#: ../build/lib/darktable/plugins/introspection_blurs.c:101
+#: ../build/lib/darktable/plugins/introspection_blurs.c:186
+msgid "concavity"
+msgstr "Concavity"
+
+#: ../build/lib/darktable/plugins/introspection_blurs.c:107
+#: ../build/lib/darktable/plugins/introspection_blurs.c:190
+msgid "linearity"
+msgstr "Linearity"
+
+#: ../build/lib/darktable/plugins/introspection_blurs.c:113
+#: ../build/lib/darktable/plugins/introspection_blurs.c:194
+#: ../build/lib/darktable/plugins/introspection_graduatednd.c:75
+#: ../build/lib/darktable/plugins/introspection_graduatednd.c:144
+#: ../build/lib/darktable/plugins/introspection_watermark.c:118
+#: ../build/lib/darktable/plugins/introspection_watermark.c:235
+#: ../src/iop/ashift.c:6108 ../src/libs/masks.c:108
+msgid "rotation"
+msgstr "Rotation"
+
+#: ../build/lib/darktable/plugins/introspection_blurs.c:119
+#: ../build/lib/darktable/plugins/introspection_blurs.c:198
+msgid "direction"
+msgstr "Direction"
+
+#: ../build/lib/darktable/plugins/introspection_blurs.c:125
+#: ../build/lib/darktable/plugins/introspection_blurs.c:202
+#: ../src/libs/masks.c:109
+msgid "curvature"
+msgstr "Curvature"
+
+#: ../build/lib/darktable/plugins/introspection_blurs.c:131
+#: ../build/lib/darktable/plugins/introspection_blurs.c:206
+#: ../build/lib/darktable/plugins/introspection_graduatednd.c:81
+#: ../build/lib/darktable/plugins/introspection_graduatednd.c:148
+#: ../src/iop/colorbalancergb.c:1937
+msgid "offset"
+msgstr "Offset"
+
+#: ../build/lib/darktable/plugins/introspection_blurs.c:220
+#: ../src/common/collection.c:664 ../src/gui/preferences.c:823
+#: ../src/gui/presets.c:584 ../src/libs/metadata_view.c:139
+msgid "lens"
+msgstr "Lens"
+
+#: ../build/lib/darktable/plugins/introspection_blurs.c:221
+msgid "motion"
+msgstr "Motion"
+
+#: ../build/lib/darktable/plugins/introspection_blurs.c:222
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:567
+#: ../build/lib/darktable/plugins/introspection_lowpass.c:189
+#: ../build/lib/darktable/plugins/introspection_retouch.c:452
+#: ../build/lib/darktable/plugins/introspection_shadhi.c:267
+msgid "gaussian"
+msgstr "Gaussian"
+
+#: ../build/lib/darktable/plugins/introspection_borders.c:112
+#: ../build/lib/darktable/plugins/introspection_borders.c:253
+#: ../src/common/collection.c:674 ../src/libs/filtering.c:59
+msgid "aspect ratio"
+msgstr "Aspect ratio"
+
+#. // portrait / landscape
+#: ../build/lib/darktable/plugins/introspection_borders.c:130
+#: ../build/lib/darktable/plugins/introspection_borders.c:265
+#: ../src/iop/flip.c:75 ../src/libs/print_settings.c:2360
+msgid "orientation"
+msgstr "Orientation"
+
+#: ../build/lib/darktable/plugins/introspection_borders.c:136
+#: ../build/lib/darktable/plugins/introspection_borders.c:269
+msgid "border size"
+msgstr "Border size"
+
+#: ../build/lib/darktable/plugins/introspection_borders.c:142
+#: ../build/lib/darktable/plugins/introspection_borders.c:273
+msgid "horizontal offset"
+msgstr "Horizontal offset"
+
+#: ../build/lib/darktable/plugins/introspection_borders.c:160
+#: ../build/lib/darktable/plugins/introspection_borders.c:285
+msgid "vertical offset"
+msgstr "Vertical offset"
+
+#: ../build/lib/darktable/plugins/introspection_borders.c:178
+#: ../build/lib/darktable/plugins/introspection_borders.c:297
+msgid "frame line size"
+msgstr "Frame line size"
+
+#: ../build/lib/darktable/plugins/introspection_borders.c:184
+#: ../build/lib/darktable/plugins/introspection_borders.c:301
+msgid "frame line offset"
+msgstr "Frame line offset"
+
+#: ../build/lib/darktable/plugins/introspection_borders.c:327
+#: ../src/gui/preferences.c:844 ../src/iop/ashift.c:6287
+#: ../src/iop/basicadj.c:632 ../src/iop/flip.c:472 ../src/iop/flip.c:474
+#: ../src/iop/levels.c:636 ../src/iop/rgblevels.c:1048
+msgid "auto"
+msgstr "Auto"
+
+#: ../build/lib/darktable/plugins/introspection_borders.c:328
+#: ../src/imageio/format/pdf.c:604 ../src/libs/filtering.c:309
+#: ../src/libs/filters/ratio.c:122 ../src/libs/print_settings.c:2362
+msgid "portrait"
+msgstr "Portrait"
+
+#: ../build/lib/darktable/plugins/introspection_borders.c:329
+#: ../src/imageio/format/pdf.c:604 ../src/libs/filtering.c:305
+#: ../src/libs/filters/ratio.c:124 ../src/libs/print_settings.c:2362
+msgid "landscape"
+msgstr "Landscape"
+
+#: ../build/lib/darktable/plugins/introspection_cacorrect.c:42
+#: ../build/lib/darktable/plugins/introspection_cacorrect.c:91
+msgid "avoid colorshift"
+msgstr "Avoid colorshift"
+
+#: ../build/lib/darktable/plugins/introspection_cacorrect.c:48
+#: ../build/lib/darktable/plugins/introspection_cacorrect.c:95
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:117
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:244
+#: ../build/lib/darktable/plugins/introspection_highlights.c:155
+#: ../build/lib/darktable/plugins/introspection_highlights.c:252
+msgid "iterations"
+msgstr "Iterations"
+
+#: ../build/lib/darktable/plugins/introspection_cacorrect.c:109
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:205
+msgid "once"
+msgstr "Once"
+
+#: ../build/lib/darktable/plugins/introspection_cacorrect.c:110
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:206
+msgid "twice"
+msgstr "Twice"
+
+#: ../build/lib/darktable/plugins/introspection_cacorrect.c:111
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:207
+msgid "three times"
+msgstr "Three times"
+
+#: ../build/lib/darktable/plugins/introspection_cacorrect.c:112
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:208
+msgid "four times"
+msgstr "Four times"
+
+#: ../build/lib/darktable/plugins/introspection_cacorrect.c:113
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:209
+msgid "five times"
+msgstr "Five times"
+
+#: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:61
+#: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:128
+msgid "guide"
+msgstr "Guide"
+
+#: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:67
+#: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:132
+#: ../src/iop/atrous.c:1524 ../src/iop/bilateral.cc:350 ../src/iop/clahe.c:335
+#: ../src/iop/dither.c:662 ../src/iop/lowpass.c:584 ../src/iop/shadhi.c:670
+#: ../src/iop/sharpen.c:440
+msgid "radius"
+msgstr "Radius"
+
+#: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:73
+#: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:136
+#: ../build/lib/darktable/plugins/introspection_highlights.c:137
+#: ../build/lib/darktable/plugins/introspection_highlights.c:240
+#: ../src/iop/bloom.c:376 ../src/iop/denoiseprofile.c:3897
+#: ../src/iop/grain.c:570 ../src/iop/hazeremoval.c:201
+#: ../src/iop/hotpixels.c:388 ../src/iop/nlmeans.c:460 ../src/iop/velvia.c:279
+msgid "strength"
+msgstr "Strength"
+
+#: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:79
+#: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:140
+msgid "correction mode"
+msgstr "Correction mode"
+
+#: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:85
+#: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:144
+msgid "very large chromatic aberration"
+msgstr "Very large chromatic aberration"
+
+#: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:158
+#: ../src/common/collection.c:1418 ../src/common/color_vocabulary.c:232
+#: ../src/common/colorlabels.c:329 ../src/develop/blend_gui.c:2334
+#: ../src/develop/blend_gui.c:2382 ../src/develop/lightroom.c:834
+#: ../src/gui/gtk.c:2957 ../src/gui/guides.c:730 ../src/iop/bilateral.cc:354
+#: ../src/iop/channelmixer.c:618 ../src/iop/channelmixer.c:628
+#: ../src/iop/channelmixerrgb.c:4580 ../src/iop/colorzones.c:2263
+#: ../src/iop/temperature.c:1934 ../src/iop/temperature.c:2128
+#: ../src/libs/collect.c:1792 ../src/libs/filters/colors.c:260
+#: ../src/libs/histogram.c:2397
+msgid "red"
+msgstr "Red"
+
+#: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:159
+#: ../src/common/collection.c:1422 ../src/common/color_vocabulary.c:277
+#: ../src/common/colorlabels.c:331 ../src/develop/blend_gui.c:2340
+#: ../src/develop/blend_gui.c:2388 ../src/develop/lightroom.c:838
+#: ../src/gui/gtk.c:2958 ../src/gui/guides.c:731 ../src/iop/bilateral.cc:359
+#: ../src/iop/channelmixer.c:619 ../src/iop/channelmixer.c:634
+#: ../src/iop/channelmixerrgb.c:4581 ../src/iop/colorzones.c:2266
+#: ../src/iop/temperature.c:1918 ../src/iop/temperature.c:1936
+#: ../src/iop/temperature.c:2129 ../src/libs/collect.c:1792
+#: ../src/libs/filters/colors.c:262 ../src/libs/histogram.c:2389
+msgid "green"
+msgstr "Green"
+
+#: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:160
+#: ../src/common/collection.c:1424 ../src/common/color_vocabulary.c:324
+#: ../src/common/colorlabels.c:332 ../src/develop/blend_gui.c:2346
+#: ../src/develop/blend_gui.c:2394 ../src/develop/lightroom.c:840
+#: ../src/gui/gtk.c:2959 ../src/iop/bilateral.cc:364
+#: ../src/iop/channelmixer.c:620 ../src/iop/channelmixer.c:640
+#: ../src/iop/channelmixerrgb.c:4582 ../src/iop/colorzones.c:2268
+#: ../src/iop/temperature.c:1938 ../src/iop/temperature.c:2130
+#: ../src/libs/collect.c:1792 ../src/libs/filters/colors.c:263
+#: ../src/libs/histogram.c:2381
+msgid "blue"
+msgstr "Blue"
+
+#: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:164
+msgid "standard"
+msgstr "Standard"
+
+#: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:165
+msgid "darken only"
+msgstr "Darken only"
+
+#: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:166
+msgid "brighten only"
+msgstr "Brighten only"
+
+#: ../build/lib/darktable/plugins/introspection_censorize.c:51
+#: ../build/lib/darktable/plugins/introspection_censorize.c:112
+msgid "input blur radius"
+msgstr "Input blur radius"
+
+#: ../build/lib/darktable/plugins/introspection_censorize.c:57
+#: ../build/lib/darktable/plugins/introspection_censorize.c:116
+msgid "pixellation radius"
+msgstr "Pixellation radius"
+
+#: ../build/lib/darktable/plugins/introspection_censorize.c:63
+#: ../build/lib/darktable/plugins/introspection_censorize.c:120
+msgid "output blur radius"
+msgstr "Output blur radius"
+
+#: ../build/lib/darktable/plugins/introspection_censorize.c:69
+#: ../build/lib/darktable/plugins/introspection_censorize.c:124
+#: ../build/lib/darktable/plugins/introspection_highlights.c:149
+#: ../build/lib/darktable/plugins/introspection_highlights.c:248
+msgid "noise level"
+msgstr "Noise level"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:252
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:258
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:264
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:270
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:276
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:282
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:433
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:437
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:441
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:445
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:449
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:453
+msgid "normalize channels"
+msgstr "Normalize channels"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:294
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:461
+msgid "F source"
+msgstr "F source"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:300
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:465
+msgid "LED source"
+msgstr "LED source"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:330
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:485
+msgid "gamut compression"
+msgstr "Gamut compression"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:336
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:489
+msgid "clip negative RGB from gamut"
+msgstr "Clip negative RGB from gamut"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:342
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:493
+msgid "saturation algorithm"
+msgstr "Saturation algorithm"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:507
+msgid "same as pipeline (D50)"
+msgstr "Same as pipeline (D50)"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:508
+msgid "A (incandescent)"
+msgstr "A (incandescent)"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:509
+msgid "D (daylight)"
+msgstr "D (daylight)"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:510
+msgid "E (equi-energy)"
+msgstr "E (equi-energy)"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:511
+msgid "F (fluorescent)"
+msgstr "F (fluorescent)"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:512
+msgid "LED (LED light)"
+msgstr "LED (LED light)"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:513
+msgid "Planckian (black body)"
+msgstr "Planckian (black body)"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:514
+#: ../src/common/iop_order.c:58
+msgid "custom"
+msgstr "Custom"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:515
+msgid "(AI) detect from image surfaces..."
+msgstr "(AI) detect from image surfaces..."
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:516
+msgid "(AI) detect from image edges..."
+msgstr "(AI) detect from image edges..."
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:517
+#: ../src/iop/channelmixerrgb.c:3854
+msgid "as shot in camera"
+msgstr "As shot in camera"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:522
+msgid "F1 (Daylight 6430 K) – medium CRI"
+msgstr "F1 (Daylight 6430 K) – medium CRI"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:523
+msgid "F2 (Cool White 4230 K) – medium CRI"
+msgstr "F2 (Cool White 4230 K) – medium CRI"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:524
+msgid "F3 (White 3450 K) – medium CRI"
+msgstr "F3 (White 3450 K) – medium CRI"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:525
+msgid "F4 (Warm White 2940 K) – medium CRI"
+msgstr "F4 (Warm White 2940 K) – medium CRI"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:526
+msgid "F5 (Daylight 6350 K) – medium CRI"
+msgstr "F5 (Daylight 6350 K) – medium CRI"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:527
+msgid "F6 (Lite White 4150 K) – medium CRI"
+msgstr "F6 (Lite White 4150 K) – medium CRI"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:528
+msgid "F7 (D65 simulator 6500 K) – high CRI"
+msgstr "F7 (D65 simulator 6500 K) – high CRI"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:529
+msgid "F8 (D50 simulator 5000 K) – high CRI"
+msgstr "F8 (D50 simulator 5000 K) – high CRI"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:530
+msgid "F9 (Cool White Deluxe 4150 K) – high CRI"
+msgstr "F9 (Cool White Deluxe 4150 K) – high CRI"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:531
+msgid "F10 (Tuned RGB 5000 K) – low CRI"
+msgstr "F10 (Tuned RGB 5000 K) – low CRI"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:532
+msgid "F11 (Tuned RGB 4000 K) – low CRI"
+msgstr "F11 (Tuned RGB 4000 K) – low CRI"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:533
+msgid "F12 (Tuned RGB 3000 K) – low CRI"
+msgstr "F12 (Tuned RGB 3000 K) – low CRI"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:538
+msgid "B1 (Blue 2733 K)"
+msgstr "B1 (Blue 2733 K)"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:539
+msgid "B2 (Blue 2998 K)"
+msgstr "B2 (Blue 2998 K)"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:540
+msgid "B3 (Blue 4103 K)"
+msgstr "B3 (Blue 4103 K)"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:541
+msgid "B4 (Blue 5109 K)"
+msgstr "B4 (Blue 5109 K)"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:542
+msgid "B5 (Blue 6598 K)"
+msgstr "B5 (Blue 6598 K)"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:543
+msgid "BH1 (Blue-Red hybrid 2851 K)"
+msgstr "BH1 (Blue-Red hybrid 2851 K)"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:544
+msgid "RGB1 (RGB 2840 K)"
+msgstr "RGB1 (RGB 2840 K)"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:545
+msgid "V1 (Violet 2724 K)"
+msgstr "V1 (Violet 2724 K)"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:546
+msgid "V2 (Violet 4070 K)"
+msgstr "V2 (Violet 4070 K)"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:551
+msgid "linear Bradford (ICC v4)"
+msgstr "Linear Bradford (ICC v4)"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:552
+msgid "CAT16 (CIECAM16)"
+msgstr "CAT16 (CIECAM16)"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:553
+msgid "non-linear Bradford"
+msgstr "Non-linear Bradford"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:554
+msgid "XYZ"
+msgstr "XYZ"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:555
+msgid "none (bypass)"
+msgstr "None (bypass)"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:560
+msgid "version 1 (2020)"
+msgstr "Version 1 (2020)"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:561
+msgid "version 2 (2021)"
+msgstr "Version 2 (2021)"
+
+#: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:562
+msgid "version 3 (Apr 2021)"
+msgstr "Version 3 (Apr 2021)"
+
+#: ../build/lib/darktable/plugins/introspection_clipping.c:142
+#: ../build/lib/darktable/plugins/introspection_clipping.c:303
+#: ../build/lib/darktable/plugins/introspection_crop.c:61
+#: ../build/lib/darktable/plugins/introspection_crop.c:134
+#: ../src/gui/gtk.c:1138 ../src/iop/atrous.c:1520
+msgid "left"
+msgstr "Left"
+
+#: ../build/lib/darktable/plugins/introspection_clipping.c:148
+#: ../build/lib/darktable/plugins/introspection_clipping.c:307
+#: ../build/lib/darktable/plugins/introspection_crop.c:67
+#: ../build/lib/darktable/plugins/introspection_crop.c:138
+#: ../src/gui/accelerators.c:113 ../src/gui/gtk.c:1152
+msgid "top"
+msgstr "Top"
+
+#: ../build/lib/darktable/plugins/introspection_clipping.c:154
+#: ../build/lib/darktable/plugins/introspection_clipping.c:311
+#: ../build/lib/darktable/plugins/introspection_crop.c:73
+#: ../build/lib/darktable/plugins/introspection_crop.c:142
+#: ../src/gui/gtk.c:1145 ../src/iop/atrous.c:1519
+msgid "right"
+msgstr "Right"
+
+#: ../build/lib/darktable/plugins/introspection_clipping.c:160
+#: ../build/lib/darktable/plugins/introspection_clipping.c:315
+#: ../build/lib/darktable/plugins/introspection_crop.c:79
+#: ../build/lib/darktable/plugins/introspection_crop.c:146
+#: ../src/gui/accelerators.c:114 ../src/gui/gtk.c:1159
+msgid "bottom"
+msgstr "Bottom"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalance.c:114
+#: ../build/lib/darktable/plugins/introspection_colorbalance.c:203
+msgid "input saturation"
+msgstr "Input saturation"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalance.c:126
+#: ../build/lib/darktable/plugins/introspection_colorbalance.c:211
+msgid "contrast fulcrum"
+msgstr "Contrast fulcrum"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalance.c:132
+#: ../build/lib/darktable/plugins/introspection_colorbalance.c:215
+msgid "output saturation"
+msgstr "Output saturation"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalance.c:229
+msgid "lift, gamma, gain (ProPhoto RGB)"
+msgstr "Lift, gamma, gain (ProPhoto RGB)"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalance.c:230
+msgid "slope, offset, power (ProPhoto RGB)"
+msgstr "Slope, offset, power (ProPhoto RGB)"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalance.c:231
+msgid "lift, gamma, gain (sRGB)"
+msgstr "Lift, gamma, gain (sRGB)"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:232
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:250
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:268
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:286
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:465
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:477
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:489
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:501
+#: ../src/develop/blend_gui.c:2360 ../src/develop/blend_gui.c:2408
+#: ../src/iop/atrous.c:1670 ../src/iop/channelmixerrgb.c:4428
+#: ../src/iop/channelmixerrgb.c:4544 ../src/iop/colorbalancergb.c:1864
+#: ../src/iop/nlmeans.c:468
+msgid "chroma"
+msgstr "Chroma"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:238
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:256
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:274
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:292
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:469
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:481
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:493
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:505
+#: ../build/lib/darktable/plugins/introspection_colorreconstruction.c:155
+#: ../build/lib/darktable/plugins/introspection_colorzones.c:257
+#: ../build/lib/darktable/plugins/introspection_graduatednd.c:87
+#: ../build/lib/darktable/plugins/introspection_graduatednd.c:152
+#: ../build/lib/darktable/plugins/introspection_splittoning.c:61
+#: ../build/lib/darktable/plugins/introspection_splittoning.c:73
+#: ../build/lib/darktable/plugins/introspection_splittoning.c:134
+#: ../build/lib/darktable/plugins/introspection_splittoning.c:142
+#: ../src/develop/blend_gui.c:2319 ../src/develop/blend_gui.c:2353
+#: ../src/develop/blend_gui.c:2415 ../src/iop/channelmixer.c:615
+#: ../src/iop/channelmixerrgb.c:4421 ../src/iop/channelmixerrgb.c:4536
+#: ../src/iop/colorbalance.c:2045 ../src/iop/colorize.c:330
+#: ../src/iop/colorreconstruction.c:1240 ../src/iop/colorzones.c:2405
+msgid "hue"
+msgstr "Hue"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:298
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:509
+msgid "shadows fall-off"
+msgstr "Shadows fall-off"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:304
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:513
+msgid "white fulcrum"
+msgstr "White fulcrum"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:310
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:517
+msgid "highlights fall-off"
+msgstr "Highlights fall-off"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:316
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:358
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:388
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:521
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:549
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:569
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:156
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:297
+#: ../src/iop/bilat.c:469 ../src/iop/colorbalance.c:2102
+#: ../src/iop/shadhi.c:666 ../src/iop/splittoning.c:507
+msgid "shadows"
+msgstr "Shadows"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:322
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:346
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:376
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:525
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:541
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:561
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:180
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:313
+#: ../src/iop/bilat.c:463 ../src/iop/colorbalance.c:2104
+#: ../src/iop/monochrome.c:562 ../src/iop/shadhi.c:667
+#: ../src/iop/splittoning.c:514
+msgid "highlights"
+msgstr "Highlights"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:328
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:529
+msgid "global chroma"
+msgstr "Global chroma"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:334
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:352
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:382
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:533
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:545
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:565
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:168
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:305
+#: ../src/iop/colorbalance.c:2103
+msgid "mid-tones"
+msgstr "Mid-tones"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:340
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:537
+#: ../src/iop/filmic.c:1576
+msgid "global saturation"
+msgstr "Global saturation"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:364
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:553
+msgid "hue shift"
+msgstr "Hue shift"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:370
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:557
+msgid "global brilliance"
+msgstr "Global brilliance"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:394
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:573
+msgid "mask middle-gray fulcrum"
+msgstr "Mask middle-gray fulcrum"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:400
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:577
+msgid "global vibrance"
+msgstr "Global vibrance"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:406
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:581
+msgid "contrast gray fulcrum"
+msgstr "Contrast gray fulcrum"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:412
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:585
+#: ../build/lib/darktable/plugins/introspection_sigmoid.c:64
+#: ../build/lib/darktable/plugins/introspection_sigmoid.c:137
+#: ../src/gui/guides.c:740 ../src/iop/basicadj.c:607 ../src/iop/bilat.c:458
+#: ../src/iop/colisa.c:304 ../src/iop/colorbalance.c:1950
+#: ../src/iop/colorbalance.c:1956 ../src/iop/filmic.c:1548
+#: ../src/iop/filmicrgb.c:4290 ../src/iop/lowpass.c:586
+msgid "contrast"
+msgstr "Contrast"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:418
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:589
+msgid "saturation formula"
+msgstr "Saturation formula"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:603
+msgid "JzAzBz (2021)"
+msgstr "JzAzBz (2021)"
+
+#: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:604
+msgid "darktable UCS (2022)"
+msgstr "Darktable UCS (2022)"
+
+#: ../build/lib/darktable/plugins/introspection_colorcontrast.c:54
+#: ../build/lib/darktable/plugins/introspection_colorcontrast.c:121
+msgid "green-magenta contrast"
+msgstr "Green-magenta contrast"
+
+#: ../build/lib/darktable/plugins/introspection_colorcontrast.c:66
+#: ../build/lib/darktable/plugins/introspection_colorcontrast.c:129
+msgid "blue-yellow contrast"
+msgstr "Blue-yellow contrast"
+
+#: ../build/lib/darktable/plugins/introspection_colorin.c:149
+#: ../build/lib/darktable/plugins/introspection_colorin.c:232
+msgid "gamut clipping"
+msgstr "Gamut clipping"
+
+#: ../build/lib/darktable/plugins/introspection_colorin.c:302
+#: ../build/lib/darktable/plugins/introspection_lut3d.c:201
+#: ../src/common/colorspaces.c:1251 ../src/common/colorspaces.c:1484
+#: ../src/libs/print_settings.c:1284
+msgid "sRGB"
+msgstr "sRGB"
+
+#: ../build/lib/darktable/plugins/introspection_colorin.c:303
+#: ../src/common/colorspaces.c:1260 ../src/common/colorspaces.c:1486
+#: ../src/libs/print_settings.c:1291
+msgid "Adobe RGB (compatible)"
+msgstr "Adobe RGB (compatible)"
+
+#: ../build/lib/darktable/plugins/introspection_colorin.c:304
+#: ../build/lib/darktable/plugins/introspection_lut3d.c:204
+#: ../src/common/colorspaces.c:1265 ../src/common/colorspaces.c:1488
+msgid "linear Rec709 RGB"
+msgstr "Linear Rec709 RGB"
+
+#: ../build/lib/darktable/plugins/introspection_colorin.c:305
+#: ../build/lib/darktable/plugins/introspection_lut3d.c:205
+#: ../src/common/colorspaces.c:1274 ../src/common/colorspaces.c:1490
+msgid "linear Rec2020 RGB"
+msgstr "Linear Rec2020 RGB"
+
+#: ../build/lib/darktable/plugins/introspection_colorize.c:65
+#: ../build/lib/darktable/plugins/introspection_colorize.c:128
+msgid "source mix"
+msgstr "Source mix"
+
+#: ../build/lib/darktable/plugins/introspection_colormapping.c:94
+#: ../build/lib/darktable/plugins/introspection_colormapping.c:249
+msgid "number of clusters"
+msgstr "Number of clusters"
+
+#: ../build/lib/darktable/plugins/introspection_colormapping.c:100
+#: ../build/lib/darktable/plugins/introspection_colormapping.c:253
+msgid "color dominance"
+msgstr "Color dominance"
+
+#: ../build/lib/darktable/plugins/introspection_colormapping.c:106
+#: ../build/lib/darktable/plugins/introspection_colormapping.c:257
+msgid "histogram equalization"
+msgstr "Histogram equalization"
+
+#: ../build/lib/darktable/plugins/introspection_colorreconstruction.c:62
+#: ../build/lib/darktable/plugins/introspection_colorreconstruction.c:127
+#: ../build/lib/darktable/plugins/introspection_tonemap.cc:45
+#: ../build/lib/darktable/plugins/introspection_tonemap.cc:92
+#: ../src/iop/shadhi.c:681
+msgid "spatial extent"
+msgstr "Spatial extent"
+
+#: ../build/lib/darktable/plugins/introspection_colorreconstruction.c:68
+#: ../build/lib/darktable/plugins/introspection_colorreconstruction.c:131
+msgid "range extent"
+msgstr "Range extent"
+
+#: ../build/lib/darktable/plugins/introspection_colorreconstruction.c:154
+#: ../src/iop/channelmixerrgb.c:4639
+msgid "saturated colors"
+msgstr "Saturated colors"
+
+#: ../build/lib/darktable/plugins/introspection_colorzones.c:78
+#: ../build/lib/darktable/plugins/introspection_colorzones.c:193
+msgid "select by"
+msgstr "Select by"
+
+#. mix slider
+#: ../build/lib/darktable/plugins/introspection_colorzones.c:138
+#: ../build/lib/darktable/plugins/introspection_colorzones.c:233
+#: ../build/lib/darktable/plugins/introspection_soften.c:66
+#: ../build/lib/darktable/plugins/introspection_soften.c:121
+#: ../src/iop/atrous.c:1692
+msgid "mix"
+msgstr "Mix"
+
+#: ../build/lib/darktable/plugins/introspection_colorzones.c:144
+#: ../build/lib/darktable/plugins/introspection_colorzones.c:237
+msgid "process mode"
+msgstr "Process mode"
+
+#: ../build/lib/darktable/plugins/introspection_colorzones.c:255
+#: ../src/develop/blend_gui.c:2298 ../src/iop/channelmixer.c:617
+#: ../src/iop/channelmixerrgb.c:4527 ../src/iop/colorchecker.c:1291
+#: ../src/iop/colorize.c:349 ../src/iop/colorzones.c:2403
+#: ../src/iop/exposure.c:1231
+msgid "lightness"
+msgstr "Lightness"
+
+#: ../build/lib/darktable/plugins/introspection_colorzones.c:256
+#: ../build/lib/darktable/plugins/introspection_graduatednd.c:93
+#: ../build/lib/darktable/plugins/introspection_graduatednd.c:156
+#: ../build/lib/darktable/plugins/introspection_splittoning.c:67
+#: ../build/lib/darktable/plugins/introspection_splittoning.c:79
+#: ../build/lib/darktable/plugins/introspection_splittoning.c:138
+#: ../build/lib/darktable/plugins/introspection_splittoning.c:146
+#: ../src/develop/blend_gui.c:2314 ../src/iop/basicadj.c:624
+#: ../src/iop/channelmixer.c:616 ../src/iop/colisa.c:306
+#: ../src/iop/colorbalance.c:2062 ../src/iop/colorbalancergb.c:1888
+#: ../src/iop/colorchecker.c:1309 ../src/iop/colorcontrast.c:90
+#: ../src/iop/colorcorrection.c:275 ../src/iop/colorize.c:343
+#: ../src/iop/colorzones.c:2404 ../src/iop/lowpass.c:588
+#: ../src/iop/soften.c:373 ../src/iop/velvia.c:84 ../src/iop/vibrance.c:72
+#: ../src/iop/vignette.c:970
+msgid "saturation"
+msgstr "Saturation"
+
+#: ../build/lib/darktable/plugins/introspection_colorzones.c:267
+#: ../src/iop/atrous.c:1311 ../src/iop/atrous.c:1315
+#: ../src/iop/denoiseprofile.c:3601 ../src/iop/rawdenoise.c:756
+msgid "smooth"
+msgstr "Smooth"
+
+#: ../build/lib/darktable/plugins/introspection_colorzones.c:268
+msgid "strong"
+msgstr "Strong"
+
+#: ../build/lib/darktable/plugins/introspection_defringe.c:47
+#: ../build/lib/darktable/plugins/introspection_defringe.c:102
+msgid "edge detection radius"
+msgstr "Edge detection radius"
+
+#: ../build/lib/darktable/plugins/introspection_defringe.c:53
+#: ../build/lib/darktable/plugins/introspection_defringe.c:106
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:230
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:435
+#: ../src/iop/atrous.c:1574 ../src/iop/bloom.c:372
+#: ../src/iop/colorreconstruction.c:1236 ../src/iop/hotpixels.c:384
+#: ../src/iop/sharpen.c:449
+msgid "threshold"
+msgstr "Threshold"
+
+#: ../build/lib/darktable/plugins/introspection_defringe.c:59
+#: ../build/lib/darktable/plugins/introspection_defringe.c:110
+msgid "operation mode"
+msgstr "Operation mode"
+
+#: ../build/lib/darktable/plugins/introspection_defringe.c:124
+msgid "global average (fast)"
+msgstr "Global average (fast)"
+
+#: ../build/lib/darktable/plugins/introspection_defringe.c:125
+msgid "local average (slow)"
+msgstr "Local average (slow)"
+
+#: ../build/lib/darktable/plugins/introspection_defringe.c:126
+msgid "static threshold (fast)"
+msgstr "Static threshold (fast)"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:90
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:163
+msgid "match greens"
+msgstr "Match greens"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:96
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:167
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:141
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:260
+msgid "edge threshold"
+msgstr "Edge threshold"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:102
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:171
+msgid "color smoothing"
+msgstr "Color smoothing"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:108
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:175
+#: ../build/lib/darktable/plugins/introspection_dither.c:62
+#: ../build/lib/darktable/plugins/introspection_dither.c:141
+#: ../build/lib/darktable/plugins/introspection_highlights.c:119
+#: ../build/lib/darktable/plugins/introspection_highlights.c:228
+msgid "method"
+msgstr "Method"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:114
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:179
+msgid "LMMSE refine"
+msgstr "LMMSE refine"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:120
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:183
+msgid "dual threshold"
+msgstr "Dual threshold"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:197
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:204
+#: ../build/lib/darktable/plugins/introspection_rawprepare.c:197
+msgid "disabled"
+msgstr "Disabled"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:198
+msgid "local average"
+msgstr "Local average"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:199
+msgid "full average"
+msgstr "Full average"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:200
+msgid "full and local average"
+msgstr "Full and local average"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:213
+msgid "PPG"
+msgstr "PPG"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:214
+msgid "AMaZE"
+msgstr "AMaZE"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:215
+msgid "VNG4"
+msgstr "VNG4"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:216
+msgid "RCD"
+msgstr "RCD"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:217
+msgid "LMMSE"
+msgstr "LMMSE"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:218
+msgid "RCD + VNG4"
+msgstr "RCD + VNG4"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:219
+msgid "AMaZE + VNG4"
+msgstr "AMaZE + VNG4"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:220
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:227
+msgid "passthrough (monochrome)"
+msgstr "Passthrough (monochrome)"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:221
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:228
+msgid "photosite color (debug)"
+msgstr "Photosite color (debug)"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:222
+msgid "VNG"
+msgstr "VNG"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:223
+msgid "Markesteijn 1-pass"
+msgstr "Markesteijn 1-pass"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:224
+msgid "Markesteijn 3-pass"
+msgstr "Markesteijn 3-pass"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:225
+msgid "frequency domain chroma"
+msgstr "Frequency domain chroma"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:226
+msgid "Markesteijn 3-pass + VNG"
+msgstr "Markesteijn 3-pass + VNG"
+
+#. history
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:232
+#: ../src/common/collection.c:1437 ../src/libs/collect.c:1746
+#: ../src/libs/filters/history.c:38
+msgid "basic"
+msgstr "Basic"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:233
+msgid "median"
+msgstr "Median"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:234
+msgid "3x median"
+msgstr "3x median"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:235
+msgid "refine & medians"
+msgstr "Refine & medians"
+
+#: ../build/lib/darktable/plugins/introspection_demosaic.c:236
+msgid "2x refine + medians"
+msgstr "2x refine + medians"
+
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:125
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:300
+#: ../build/lib/darktable/plugins/introspection_nlmeans.c:48
+#: ../build/lib/darktable/plugins/introspection_nlmeans.c:109
+msgid "patch size"
+msgstr "Patch size"
+
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:131
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:304
+msgid "search radius"
+msgstr "Search radius"
+
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:143
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:312
+msgid "preserve shadows"
+msgstr "Preserve shadows"
+
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:149
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:316
+msgid "bias correction"
+msgstr "Bias correction"
+
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:155
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:320
+msgid "scattering"
+msgstr "Scattering"
+
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:161
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:324
+msgid "central pixel weight"
+msgstr "Central pixel weight"
+
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:167
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:328
+msgid "adjust autoset parameters"
+msgstr "Adjust autoset parameters"
+
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:239
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:376
+msgid "whitebalance-adaptive transform"
+msgstr "Whitebalance-adaptive transform"
+
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:245
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:380
+msgid "fix various bugs in algorithm"
+msgstr "Fix various bugs in algorithm"
+
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:251
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:384
+msgid "upgrade profiled transform"
+msgstr "Upgrade profiled transform"
+
+#.
+#. * Color mode combo box
+#.
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:257
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:388
+#: ../src/imageio/format/avif.c:786 ../src/libs/colorpicker.c:585
+msgid "color mode"
+msgstr "Color mode"
+
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:410
+#: ../src/libs/colorpicker.c:51 ../src/libs/colorpicker.c:267
+msgid "RGB"
+msgstr "RGB"
+
+#: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:411
+msgid "Y0U0V0"
+msgstr "Y0U0V0"
+
+#. two more sharpness (standard & strong)
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:123
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:248
+#: ../src/iop/atrous.c:1566 ../src/iop/diffuse.c:630 ../src/iop/highpass.c:373
+msgid "sharpness"
+msgstr "Sharpness"
+
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:129
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:252
+msgid "radius span"
+msgstr "Radius span"
+
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:135
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:256
+msgid "edge sensitivity"
+msgstr "Edge sensitivity"
+
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:147
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:264
+msgid "1st order anisotropy"
+msgstr "1st order anisotropy"
+
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:153
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:268
+msgid "2nd order anisotropy"
+msgstr "2nd order anisotropy"
+
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:159
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:272
+msgid "3rd order anisotropy"
+msgstr "3rd order anisotropy"
+
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:165
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:276
+msgid "4th order anisotropy"
+msgstr "4th order anisotropy"
+
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:171
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:280
+msgid "luminance masking threshold"
+msgstr "Luminance masking threshold"
+
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:177
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:284
+msgid "1st order speed"
+msgstr "1st order speed"
+
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:183
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:288
+msgid "2nd order speed"
+msgstr "2nd order speed"
+
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:189
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:292
+msgid "3rd order speed"
+msgstr "3rd order speed"
+
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:195
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:296
+msgid "4th order speed"
+msgstr "4th order speed"
+
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:201
+#: ../build/lib/darktable/plugins/introspection_diffuse.c:300
+msgid "central radius"
+msgstr "Central radius"
+
+#: ../build/lib/darktable/plugins/introspection_dither.c:92
+#: ../build/lib/darktable/plugins/introspection_dither.c:161
+msgid "damping"
+msgstr "Damping"
+
+#: ../build/lib/darktable/plugins/introspection_dither.c:179
+msgid "random"
+msgstr "Random"
+
+#: ../build/lib/darktable/plugins/introspection_dither.c:180
+msgid "Floyd-Steinberg 1-bit B&W"
+msgstr "Floyd-Steinberg 1-bit B&W"
+
+#: ../build/lib/darktable/plugins/introspection_dither.c:181
+msgid "Floyd-Steinberg 4-bit gray"
+msgstr "Floyd-Steinberg 4-bit gray"
+
+#: ../build/lib/darktable/plugins/introspection_dither.c:182
+msgid "Floyd-Steinberg 8-bit RGB"
+msgstr "Floyd-Steinberg 8-bit RGB"
+
+#: ../build/lib/darktable/plugins/introspection_dither.c:183
+msgid "Floyd-Steinberg 16-bit RGB"
+msgstr "Floyd-Steinberg 16-bit RGB"
+
+#: ../build/lib/darktable/plugins/introspection_dither.c:184
+msgid "Floyd-Steinberg auto"
+msgstr "Floyd-Steinberg auto"
+
+#: ../build/lib/darktable/plugins/introspection_exposure.c:79
+#: ../build/lib/darktable/plugins/introspection_exposure.c:146
+msgid "percentile"
+msgstr "Percentile"
+
+#: ../build/lib/darktable/plugins/introspection_exposure.c:85
+#: ../build/lib/darktable/plugins/introspection_exposure.c:150
+msgid "target level"
+msgstr "Target level"
+
+#: ../build/lib/darktable/plugins/introspection_exposure.c:91
+#: ../build/lib/darktable/plugins/introspection_exposure.c:154
+msgid "compensate exposure bias"
+msgstr "Compensate exposure bias"
+
+#: ../build/lib/darktable/plugins/introspection_exposure.c:168
+#: ../build/lib/darktable/plugins/introspection_levels.c:160
+msgid "manual"
+msgstr "Manual"
+
+#: ../build/lib/darktable/plugins/introspection_exposure.c:169
+#: ../build/lib/darktable/plugins/introspection_levels.c:161
+msgid "automatic"
+msgstr "Automatic"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:212
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:423
+#: ../src/iop/filmic.c:1489
+msgid "middle gray luminance"
+msgstr "Middle gray luminance"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:218
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:427
+#: ../build/lib/darktable/plugins/introspection_profile_gamma.c:97
+#: ../build/lib/darktable/plugins/introspection_profile_gamma.c:166
+#: ../src/iop/filmic.c:1514
+msgid "black relative exposure"
+msgstr "Black relative exposure"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:224
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:431
+#: ../src/iop/filmic.c:1501
+msgid "white relative exposure"
+msgstr "White relative exposure"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:236
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:439
+msgid "transition"
+msgstr "Transition"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:242
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:443
+msgid "bloom ↔ reconstruct"
+msgstr "Bloom ↔ reconstruct"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:248
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:447
+msgid "gray ↔ colorful details"
+msgstr "Gray ↔ colorful details"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:254
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:451
+msgid "structure ↔ texture"
+msgstr "Structure ↔ texture"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:260
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:455
+msgid "dynamic range scaling"
+msgstr "Dynamic range scaling"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:266
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:459
+#: ../src/iop/filmic.c:1646
+msgid "target middle gray"
+msgstr "Target middle gray"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:272
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:463
+#: ../src/iop/filmic.c:1637
+msgid "target black luminance"
+msgstr "Target black luminance"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:278
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:467
+#: ../src/iop/filmic.c:1655
+msgid "target white luminance"
+msgstr "Target white luminance"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:284
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:471
+#: ../build/lib/darktable/plugins/introspection_graduatednd.c:69
+#: ../build/lib/darktable/plugins/introspection_graduatednd.c:140
+#: ../src/libs/masks.c:106
+msgid "hardness"
+msgstr "Hardness"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:302
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:483
+#: ../src/iop/filmic.c:1586 ../src/iop/filmicrgb.c:4466
+msgid "extreme luminance saturation"
+msgstr "Extreme luminance saturation"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:308
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:487
+msgid "shadows ↔ highlights balance"
+msgstr "Shadows ↔ highlights balance"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:314
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:491
+msgid "add noise in highlights"
+msgstr "Add noise in highlights"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:320
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:495
+msgid "preserve chrominance"
+msgstr "Preserve chrominance"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:326
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:499
+msgid "color science"
+msgstr "Color science"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:332
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:503
+msgid "auto adjust hardness"
+msgstr "Auto adjust hardness"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:338
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:507
+msgid "use custom middle-gray values"
+msgstr "Use custom middle-gray values"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:344
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:511
+msgid "iterations of high-quality reconstruction"
+msgstr "Iterations of high-quality reconstruction"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:350
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:515
+msgid "type of noise"
+msgstr "Type of noise"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:356
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:519
+msgid "contrast in shadows"
+msgstr "Contrast in shadows"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:362
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:523
+msgid "contrast in highlights"
+msgstr "Contrast in highlights"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:368
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:527
+msgid "compensate output ICC profile black point"
+msgstr "Compensate output ICC profile black point"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:374
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:531
+msgid "spline handling"
+msgstr "Spline handling"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:380
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:535
+msgid "enable highlight reconstruction"
+msgstr "Enable highlight reconstruction"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:549
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:371
+#: ../src/common/database.c:2785 ../src/common/variables.c:705
+#: ../src/develop/imageop_gui.c:209 ../src/imageio/format/pdf.c:636
+#: ../src/imageio/format/pdf.c:655 ../src/libs/export.c:1194
+#: ../src/libs/export.c:1201 ../src/libs/export.c:1208
+#: ../src/libs/metadata_view.c:678
+msgid "no"
+msgstr "No"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:551
+msgid "luminance Y"
+msgstr "Luminance Y"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:552
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:384
+msgid "RGB power norm"
+msgstr "RGB power norm"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:553
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:383
+msgid "RGB euclidean norm"
+msgstr "RGB euclidean norm"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:554
+#: ../src/iop/filmicrgb.c:2962
+msgid "RGB euclidean norm (legacy)"
+msgstr "RGB euclidean norm (legacy)"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:559
+msgid "v3 (2019)"
+msgstr "V3 (2019)"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:560
+msgid "v4 (2020)"
+msgstr "V4 (2020)"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:561
+msgid "v5 (2021)"
+msgstr "V5 (2021)"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:562
+msgid "v6 (2022)"
+msgstr "V6 (2022)"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:566
+msgid "uniform"
+msgstr "Uniform"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:568
+msgid "poissonian"
+msgstr "Poissonian"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:572
+msgid "hard"
+msgstr "Hard"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:573
+msgid "soft"
+msgstr "Soft"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:574
+msgid "safe"
+msgstr "Safe"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:578
+msgid "v1 (2019)"
+msgstr "V1 (2019)"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:579
+msgid "v2 (2020)"
+msgstr "V2 (2020)"
+
+#: ../build/lib/darktable/plugins/introspection_filmicrgb.c:580
+msgid "v3 (2021)"
+msgstr "V3 (2021)"
+
+#: ../build/lib/darktable/plugins/introspection_globaltonemap.c:60
+#: ../build/lib/darktable/plugins/introspection_globaltonemap.c:125
+msgid "bias"
+msgstr "Bias"
+
+#: ../build/lib/darktable/plugins/introspection_globaltonemap.c:66
+#: ../build/lib/darktable/plugins/introspection_globaltonemap.c:129
+msgid "target"
+msgstr "Target"
+
+#: ../build/lib/darktable/plugins/introspection_globaltonemap.c:151
+#: ../src/iop/sigmoid.c:142
+msgid "reinhard"
+msgstr "Reinhard"
+
+#: ../build/lib/darktable/plugins/introspection_globaltonemap.c:152
+#: ../src/iop/filmic.c:162
+msgid "filmic"
+msgstr "Filmic"
+
+#: ../build/lib/darktable/plugins/introspection_globaltonemap.c:153
+msgid "drago"
+msgstr "Drago"
+
+#: ../build/lib/darktable/plugins/introspection_graduatednd.c:63
+#: ../build/lib/darktable/plugins/introspection_graduatednd.c:136
+msgid "density"
+msgstr "Density"
+
+#: ../build/lib/darktable/plugins/introspection_grain.c:58
+#: ../build/lib/darktable/plugins/introspection_grain.c:117
+#: ../src/iop/bilat.c:450
+msgid "coarseness"
+msgstr "Coarseness"
+
+#: ../build/lib/darktable/plugins/introspection_grain.c:70
+#: ../build/lib/darktable/plugins/introspection_grain.c:125
+#: ../build/lib/darktable/plugins/introspection_velvia.c:44
+#: ../build/lib/darktable/plugins/introspection_velvia.c:91
+msgid "mid-tones bias"
+msgstr "Mid-tones bias"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:143
+#: ../build/lib/darktable/plugins/introspection_highlights.c:244
+#: ../src/views/darkroom.c:2388
+msgid "clipping threshold"
+msgstr "Clipping threshold"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:161
+#: ../build/lib/darktable/plugins/introspection_highlights.c:256
+msgid "diameter of reconstruction"
+msgstr "Diameter of reconstruction"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:167
+#: ../build/lib/darktable/plugins/introspection_highlights.c:260
+msgid "candidating"
+msgstr "Candidating"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:173
+#: ../build/lib/darktable/plugins/introspection_highlights.c:264
+msgid "combine"
+msgstr "Combine"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:179
+#: ../build/lib/darktable/plugins/introspection_highlights.c:268
+msgid "rebuild"
+msgstr "Rebuild"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:185
+#: ../build/lib/darktable/plugins/introspection_highlights.c:272
+msgid "inpaint a flat color"
+msgstr "Inpaint a flat color"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:286
+#: ../src/iop/highlights.c:1036 ../src/iop/highlights.c:1042
+msgid "clip highlights"
+msgstr "Clip highlights"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:287
+#: ../src/iop/highlights.c:1040
+msgid "reconstruct in LCh"
+msgstr "Reconstruct in LCh"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:288
+#: ../src/iop/highlights.c:991 ../src/iop/highlights.c:1052
+msgid "reconstruct color"
+msgstr "Reconstruct color"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:289
+#: ../src/iop/highlights.c:1047
+msgid "guided laplacians"
+msgstr "Guided laplacians"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:290
+#: ../src/iop/highlights.c:1044
+msgid "segmentation based"
+msgstr "Segmentation based"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:291
+#: ../src/iop/highlights.c:1032
+msgid "inpaint opposed"
+msgstr "Inpaint opposed"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:295
+msgid "2 px"
+msgstr "2 px"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:296
+msgid "4 px"
+msgstr "4 px"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:297
+msgid "8 px"
+msgstr "8 px"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:298
+msgid "16 px"
+msgstr "16 px"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:299
+msgid "32 px"
+msgstr "32 px"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:300
+msgid "64 px"
+msgstr "64 px"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:301
+msgid "128 px (slow)"
+msgstr "128 px (slow)"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:302
+msgid "256 px (slow)"
+msgstr "256 px (slow)"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:303
+msgid "512 px (very slow)"
+msgstr "512 px (very slow)"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:304
+msgid "1024 px (very slow)"
+msgstr "1024 px (very slow)"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:305
+msgid "2048 px (insanely slow)"
+msgstr "2048 px (insanely slow)"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:306
+msgid "4096 px (insanely slow)"
+msgstr "4096 px (insanely slow)"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:312
+msgid "flat generic"
+msgstr "Flat generic"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:313
+msgid "small segments"
+msgstr "Small segments"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:314
+msgid "large segments"
+msgstr "Large segments"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:315
+msgid "flat small segments"
+msgstr "Flat small segments"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:316
+msgid "flat large segments"
+msgstr "Flat large segments"
+
+#: ../build/lib/darktable/plugins/introspection_highpass.c:44
+#: ../build/lib/darktable/plugins/introspection_highpass.c:91
+msgid "contrast boost"
+msgstr "Contrast boost"
+
+#: ../build/lib/darktable/plugins/introspection_hotpixels.c:59
+#: ../build/lib/darktable/plugins/introspection_hotpixels.c:116
+msgid "mark fixed pixels"
+msgstr "Mark fixed pixels"
+
+#: ../build/lib/darktable/plugins/introspection_hotpixels.c:65
+#: ../build/lib/darktable/plugins/introspection_hotpixels.c:120
+msgid "detect by 3 neighbors"
+msgstr "Detect by 3 neighbors"
+
+#: ../build/lib/darktable/plugins/introspection_lens.cc:122
+#: ../build/lib/darktable/plugins/introspection_lens.cc:273
+msgid "correction method"
+msgstr "Correction method"
+
+#. Page CORRECTIONS
+#: ../build/lib/darktable/plugins/introspection_lens.cc:128
+#: ../build/lib/darktable/plugins/introspection_lens.cc:277
+#: ../src/iop/lens.cc:3629 ../src/iop/negadoctor.c:899
+msgid "corrections"
+msgstr "Corrections"
+
+#. mode choice
+#. Add check to control whether the style is to replace or append the current module
+#: ../build/lib/darktable/plugins/introspection_lens.cc:134
+#: ../build/lib/darktable/plugins/introspection_lens.cc:281
+#: ../build/lib/darktable/plugins/introspection_rgbcurve.c:128
+#: ../build/lib/darktable/plugins/introspection_rgbcurve.c:219
+#: ../build/lib/darktable/plugins/introspection_rgblevels.c:51
+#: ../build/lib/darktable/plugins/introspection_rgblevels.c:118
+#: ../src/iop/bilat.c:428 ../src/iop/colorbalance.c:1912
+#: ../src/iop/denoiseprofile.c:3881 ../src/iop/exposure.c:1149
+#: ../src/iop/levels.c:679 ../src/iop/profile_gamma.c:668
+#: ../src/libs/copy_history.c:402 ../src/libs/export.c:1277
+#: ../src/libs/image.c:599 ../src/libs/print_settings.c:2696
+#: ../src/libs/styles.c:849 ../src/views/darkroom.c:2369
+msgid "mode"
+msgstr "Mode"
+
+#: ../build/lib/darktable/plugins/introspection_lens.cc:170
+#: ../build/lib/darktable/plugins/introspection_lens.cc:305
+#: ../src/iop/lens.cc:3557
+msgid "geometry"
+msgstr "Geometry"
+
+#: ../build/lib/darktable/plugins/introspection_lens.cc:200
+#: ../build/lib/darktable/plugins/introspection_lens.cc:325
+msgid "TCA overwrite"
+msgstr "TCA overwrite"
+
+#: ../build/lib/darktable/plugins/introspection_lens.cc:206
+#: ../build/lib/darktable/plugins/introspection_lens.cc:329
+msgid "TCA red"
+msgstr "TCA red"
+
+#: ../build/lib/darktable/plugins/introspection_lens.cc:212
+#: ../build/lib/darktable/plugins/introspection_lens.cc:333
+msgid "TCA blue"
+msgstr "TCA blue"
+
+#: ../build/lib/darktable/plugins/introspection_lens.cc:218
+#: ../build/lib/darktable/plugins/introspection_lens.cc:337
+msgid "distortion fine-tune"
+msgstr "Distortion fine-tune"
+
+#: ../build/lib/darktable/plugins/introspection_lens.cc:224
+#: ../build/lib/darktable/plugins/introspection_lens.cc:341
+msgid "vignetting fine-tune"
+msgstr "Vignetting fine-tune"
+
+#: ../build/lib/darktable/plugins/introspection_lens.cc:230
+#: ../build/lib/darktable/plugins/introspection_lens.cc:345
+msgid "scale fine-tune"
+msgstr "Scale fine-tune"
+
+#: ../build/lib/darktable/plugins/introspection_lens.cc:359
+#: ../src/iop/lens.cc:2606
+msgid "embedded metadata"
+msgstr "Embedded metadata"
+
+#: ../build/lib/darktable/plugins/introspection_lens.cc:360
+msgid "lensfun database"
+msgstr "Lensfun database"
+
+#: ../build/lib/darktable/plugins/introspection_liquify.c:428
+msgid "invalidated"
+msgstr "Invalidated"
+
+#. move left/right/up/down
+#: ../build/lib/darktable/plugins/introspection_liquify.c:429
+#: ../src/views/darkroom.c:2264 ../src/views/darkroom.c:2663
+#: ../src/views/darkroom.c:2666 ../src/views/lighttable.c:765
+#: ../src/views/lighttable.c:774 ../src/views/lighttable.c:1253
+#: ../src/views/lighttable.c:1257 ../src/views/lighttable.c:1261
+#: ../src/views/lighttable.c:1265 ../src/views/lighttable.c:1269
+msgid "move"
+msgstr "Move"
+
+#: ../build/lib/darktable/plugins/introspection_liquify.c:430
+msgid "line"
+msgstr "Line"
+
+#: ../build/lib/darktable/plugins/introspection_liquify.c:431
+#: ../src/iop/basecurve.c:2169 ../src/iop/rgbcurve.c:1384
+#: ../src/iop/tonecurve.c:1147
+msgid "curve"
+msgstr "Curve"
+
+#: ../build/lib/darktable/plugins/introspection_lowlight.c:43
+#: ../build/lib/darktable/plugins/introspection_lowlight.c:110
+msgid "blue shift"
+msgstr "Blue shift"
+
+#: ../build/lib/darktable/plugins/introspection_lowpass.c:96
+#: ../build/lib/darktable/plugins/introspection_lowpass.c:165
+#: ../build/lib/darktable/plugins/introspection_shadhi.c:160
+#: ../build/lib/darktable/plugins/introspection_shadhi.c:247
+msgid "soften with"
+msgstr "Soften with"
+
+#: ../build/lib/darktable/plugins/introspection_lowpass.c:183
+#: ../build/lib/darktable/plugins/introspection_shadhi.c:261
+msgid "order 0"
+msgstr "Order 0"
+
+#: ../build/lib/darktable/plugins/introspection_lowpass.c:184
+#: ../build/lib/darktable/plugins/introspection_shadhi.c:262
+msgid "order 1"
+msgstr "Order 1"
+
+#: ../build/lib/darktable/plugins/introspection_lowpass.c:185
+#: ../build/lib/darktable/plugins/introspection_shadhi.c:263
+msgid "order 2"
+msgstr "Order 2"
+
+#: ../build/lib/darktable/plugins/introspection_lowpass.c:190
+#: ../build/lib/darktable/plugins/introspection_shadhi.c:268
+msgid "bilateral filter"
+msgstr "Bilateral filter"
+
+#: ../build/lib/darktable/plugins/introspection_lut3d.c:76
+#: ../build/lib/darktable/plugins/introspection_lut3d.c:163
+msgid "application color space"
+msgstr "Application color space"
+
+#: ../build/lib/darktable/plugins/introspection_lut3d.c:202
+msgid "Adobe RGB"
+msgstr "Adobe RGB"
+
+#: ../build/lib/darktable/plugins/introspection_lut3d.c:203
+msgid "gamma Rec709 RGB"
+msgstr "Gamma Rec709 RGB"
+
+#: ../build/lib/darktable/plugins/introspection_lut3d.c:209
+msgid "tetrahedral"
+msgstr "Tetrahedral"
+
+#: ../build/lib/darktable/plugins/introspection_lut3d.c:210
+msgid "trilinear"
+msgstr "Trilinear"
+
+#: ../build/lib/darktable/plugins/introspection_lut3d.c:211
+msgid "pyramid"
+msgstr "Pyramid"
+
+#: ../build/lib/darktable/plugins/introspection_negadoctor.c:84
+#: ../build/lib/darktable/plugins/introspection_negadoctor.c:199
+msgid "film stock"
+msgstr "Film stock"
+
+#: ../build/lib/darktable/plugins/introspection_negadoctor.c:132
+#: ../build/lib/darktable/plugins/introspection_negadoctor.c:231
+msgid "scan exposure bias"
+msgstr "Scan exposure bias"
+
+#: ../build/lib/darktable/plugins/introspection_negadoctor.c:138
+#: ../build/lib/darktable/plugins/introspection_negadoctor.c:235
+msgid "paper black (density correction)"
+msgstr "Paper black (density correction)"
+
+#: ../build/lib/darktable/plugins/introspection_negadoctor.c:144
+#: ../build/lib/darktable/plugins/introspection_negadoctor.c:239
+#: ../src/iop/negadoctor.c:989
+msgid "paper grade (gamma)"
+msgstr "Paper grade (gamma)"
+
+#: ../build/lib/darktable/plugins/introspection_negadoctor.c:150
+#: ../build/lib/darktable/plugins/introspection_negadoctor.c:243
+msgid "paper gloss (specular highlights)"
+msgstr "Paper gloss (specular highlights)"
+
+#: ../build/lib/darktable/plugins/introspection_negadoctor.c:156
+#: ../build/lib/darktable/plugins/introspection_negadoctor.c:247
+msgid "print exposure adjustment"
+msgstr "Print exposure adjustment"
+
+#: ../build/lib/darktable/plugins/introspection_negadoctor.c:261
+#: ../src/iop/negadoctor.c:417
+msgid "black and white film"
+msgstr "Black and white film"
+
+#: ../build/lib/darktable/plugins/introspection_negadoctor.c:262
+#: ../src/iop/negadoctor.c:402
+msgid "color film"
+msgstr "Color film"
+
+#: ../build/lib/darktable/plugins/introspection_profile_gamma.c:85
+#: ../build/lib/darktable/plugins/introspection_profile_gamma.c:158
+msgid "dynamic range"
+msgstr "Dynamic range"
+
+#: ../build/lib/darktable/plugins/introspection_profile_gamma.c:91
+#: ../build/lib/darktable/plugins/introspection_profile_gamma.c:162
+msgid "middle gray luma"
+msgstr "Middle gray luma"
+
+#: ../build/lib/darktable/plugins/introspection_profile_gamma.c:103
+#: ../build/lib/darktable/plugins/introspection_profile_gamma.c:170
+#: ../src/iop/filmic.c:1526
+msgid "safety factor"
+msgstr "Safety factor"
+
+#: ../build/lib/darktable/plugins/introspection_profile_gamma.c:184
+msgid "logarithmic"
+msgstr "Logarithmic"
+
+#: ../build/lib/darktable/plugins/introspection_profile_gamma.c:185
+#: ../src/iop/profile_gamma.c:625
+msgid "gamma"
+msgstr "Gamma"
+
+#: ../build/lib/darktable/plugins/introspection_rawdenoise.c:43
+#: ../build/lib/darktable/plugins/introspection_rawdenoise.c:122
+msgid "noise threshold"
+msgstr "Noise threshold"
+
+#: ../build/lib/darktable/plugins/introspection_rawprepare.c:70
+#: ../build/lib/darktable/plugins/introspection_rawprepare.c:155
+msgid "crop left"
+msgstr "Crop left"
+
+#: ../build/lib/darktable/plugins/introspection_rawprepare.c:76
+#: ../build/lib/darktable/plugins/introspection_rawprepare.c:159
+msgid "crop top"
+msgstr "Crop top"
+
+#: ../build/lib/darktable/plugins/introspection_rawprepare.c:82
+#: ../build/lib/darktable/plugins/introspection_rawprepare.c:163
+msgid "crop right"
+msgstr "Crop right"
+
+#: ../build/lib/darktable/plugins/introspection_rawprepare.c:88
+#: ../build/lib/darktable/plugins/introspection_rawprepare.c:167
+msgid "crop bottom"
+msgstr "Crop bottom"
+
+#: ../build/lib/darktable/plugins/introspection_rawprepare.c:94
+#: ../build/lib/darktable/plugins/introspection_rawprepare.c:100
+#: ../build/lib/darktable/plugins/introspection_rawprepare.c:171
+#: ../build/lib/darktable/plugins/introspection_rawprepare.c:175
+msgid "black level"
+msgstr "Black level"
+
+#: ../build/lib/darktable/plugins/introspection_rawprepare.c:106
+#: ../build/lib/darktable/plugins/introspection_rawprepare.c:179
+#: ../src/iop/rawprepare.c:926
+msgid "white point"
+msgstr "White point"
+
+#: ../build/lib/darktable/plugins/introspection_rawprepare.c:112
+#: ../build/lib/darktable/plugins/introspection_rawprepare.c:183
+msgid "flat field correction"
+msgstr "Flat field correction"
+
+#: ../build/lib/darktable/plugins/introspection_rawprepare.c:198
+msgid "embedded GainMap"
+msgstr "Embedded GainMap"
+
+#. exposure
+#: ../build/lib/darktable/plugins/introspection_relight.c:43
+#: ../build/lib/darktable/plugins/introspection_relight.c:98
+#: ../src/common/collection.c:672 ../src/gui/preferences.c:831
+#: ../src/gui/presets.c:603 ../src/iop/basicadj.c:598 ../src/iop/exposure.c:121
+#: ../src/iop/exposure.c:1109 ../src/libs/metadata_view.c:141
+msgid "exposure"
+msgstr "Exposure"
+
+#: ../build/lib/darktable/plugins/introspection_retouch.c:267
+#: ../build/lib/darktable/plugins/introspection_retouch.c:414
+msgid "fill mode"
+msgstr "Fill mode"
+
+#: ../build/lib/darktable/plugins/introspection_retouch.c:285
+#: ../build/lib/darktable/plugins/introspection_retouch.c:426
+#: ../src/iop/basicadj.c:620 ../src/iop/channelmixerrgb.c:4588
+#: ../src/iop/colisa.c:305 ../src/iop/lowpass.c:587 ../src/iop/soften.c:377
+#: ../src/iop/vignette.c:969 ../src/libs/history.c:975
+msgid "brightness"
+msgstr "Brightness"
+
+#: ../build/lib/darktable/plugins/introspection_retouch.c:291
+#: ../build/lib/darktable/plugins/introspection_retouch.c:430
+msgid "max_iter"
+msgstr "Max_iter"
+
+#: ../build/lib/darktable/plugins/introspection_retouch.c:444
+#: ../src/libs/metadata_view.c:330
+msgid "unused"
+msgstr "Unused"
+
+#: ../build/lib/darktable/plugins/introspection_retouch.c:445
+msgid "clone"
+msgstr "Clone"
+
+#: ../build/lib/darktable/plugins/introspection_retouch.c:446
+msgid "heal"
+msgstr "Heal"
+
+#: ../build/lib/darktable/plugins/introspection_retouch.c:447
+#: ../src/iop/retouch.c:1867
+msgid "blur"
+msgstr "Blur"
+
+#: ../build/lib/darktable/plugins/introspection_retouch.c:448
+#: ../src/iop/retouch.c:1865
+msgid "fill"
+msgstr "Fill"
+
+#: ../build/lib/darktable/plugins/introspection_retouch.c:453
+msgid "bilateral"
+msgstr "Bilateral"
+
+#: ../build/lib/darktable/plugins/introspection_retouch.c:457
+msgid "erase"
+msgstr "Erase"
+
+#: ../build/lib/darktable/plugins/introspection_retouch.c:458
+#: ../src/gui/presets.c:59 ../src/iop/watermark.c:1111
+#: ../src/libs/colorpicker.c:292 ../src/libs/image.c:614
+#: ../src/libs/modulegroups.c:2319
+msgid "color"
+msgstr "Color"
+
+#: ../build/lib/darktable/plugins/introspection_rgbcurve.c:134
+#: ../build/lib/darktable/plugins/introspection_rgbcurve.c:223
+#: ../src/iop/rgbcurve.c:1420
+msgid "compensate middle gray"
+msgstr "Compensate middle gray"
+
+#: ../build/lib/darktable/plugins/introspection_rgbcurve.c:246
+#: ../build/lib/darktable/plugins/introspection_rgblevels.c:148
+#: ../build/lib/darktable/plugins/introspection_tonecurve.c:266
+msgid "RGB, linked channels"
+msgstr "RGB, linked channels"
+
+#: ../build/lib/darktable/plugins/introspection_rgbcurve.c:247
+#: ../build/lib/darktable/plugins/introspection_rgblevels.c:149
+msgid "RGB, independent channels"
+msgstr "RGB, independent channels"
+
+#: ../build/lib/darktable/plugins/introspection_shadhi.c:112
+#: ../build/lib/darktable/plugins/introspection_shadhi.c:215
+msgid "white point adjustment"
+msgstr "White point adjustment"
+
+#: ../build/lib/darktable/plugins/introspection_shadhi.c:136
+#: ../build/lib/darktable/plugins/introspection_shadhi.c:231
+msgid "shadows color adjustment"
+msgstr "Shadows color adjustment"
+
+#: ../build/lib/darktable/plugins/introspection_shadhi.c:142
+#: ../build/lib/darktable/plugins/introspection_shadhi.c:235
+msgid "highlights color adjustment"
+msgstr "Highlights color adjustment"
+
+#: ../build/lib/darktable/plugins/introspection_sigmoid.c:70
+#: ../build/lib/darktable/plugins/introspection_sigmoid.c:141
+#: ../src/gui/accelerators.c:85
+msgid "skew"
+msgstr "Skew"
+
+#: ../build/lib/darktable/plugins/introspection_sigmoid.c:76
+#: ../build/lib/darktable/plugins/introspection_sigmoid.c:145
+msgid "target white"
+msgstr "Target white"
+
+#: ../build/lib/darktable/plugins/introspection_sigmoid.c:82
+#: ../build/lib/darktable/plugins/introspection_sigmoid.c:149
+msgid "target black"
+msgstr "Target black"
+
+#: ../build/lib/darktable/plugins/introspection_sigmoid.c:88
+#: ../build/lib/darktable/plugins/introspection_sigmoid.c:153
+msgid "color processing"
+msgstr "Color processing"
+
+#: ../build/lib/darktable/plugins/introspection_sigmoid.c:94
+#: ../build/lib/darktable/plugins/introspection_sigmoid.c:157
+msgid "preserve hue"
+msgstr "Preserve hue"
+
+#: ../build/lib/darktable/plugins/introspection_sigmoid.c:171
+msgid "per channel"
+msgstr "Per channel"
+
+#: ../build/lib/darktable/plugins/introspection_sigmoid.c:172
+msgid "rgb ratio"
+msgstr "RGB ratio"
+
+#: ../build/lib/darktable/plugins/introspection_temperature.c:66
+#: ../build/lib/darktable/plugins/introspection_temperature.c:121
+#: ../src/iop/temperature.c:1940
+msgid "emerald"
+msgstr "Emerald"
+
+#: ../build/lib/darktable/plugins/introspection_tonecurve.c:135
+#: ../build/lib/darktable/plugins/introspection_tonecurve.c:232
+msgid "color space"
+msgstr "Color space"
+
+#: ../build/lib/darktable/plugins/introspection_tonecurve.c:263
+msgid "Lab, linked channels"
+msgstr "Lab, linked channels"
+
+#: ../build/lib/darktable/plugins/introspection_tonecurve.c:264
+msgid "Lab, independent channels"
+msgstr "Lab, independent channels"
+
+#: ../build/lib/darktable/plugins/introspection_tonecurve.c:265
+msgid "XYZ, linked channels"
+msgstr "XYZ, linked channels"
+
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:144
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:289
+msgid "blacks"
+msgstr "Blacks"
+
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:150
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:293
+msgid "deep shadows"
+msgstr "Deep shadows"
+
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:162
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:301
+msgid "light shadows"
+msgstr "Light shadows"
+
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:174
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:309
+msgid "dark highlights"
+msgstr "Dark highlights"
+
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:186
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:317
+msgid "whites"
+msgstr "Whites"
+
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:192
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:321
+msgid "speculars"
+msgstr "Speculars"
+
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:198
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:325
+msgid "smoothing diameter"
+msgstr "Smoothing diameter"
+
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:210
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:333
+msgid "edges refinement/feathering"
+msgstr "Edges refinement/feathering"
+
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:216
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:337
+msgid "mask quantization"
+msgstr "Mask quantization"
+
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:222
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:341
+msgid "mask contrast compensation"
+msgstr "Mask contrast compensation"
+
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:228
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:345
+msgid "mask exposure compensation"
+msgstr "Mask exposure compensation"
+
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:240
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:353
+msgid "luminance estimator"
+msgstr "Luminance estimator"
+
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:246
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:357
+msgid "filter diffusion"
+msgstr "Filter diffusion"
+
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:372
+msgid "averaged guided filter"
+msgstr "Averaged guided filter"
+
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:373
+msgid "guided filter"
+msgstr "Guided filter"
+
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:374
+msgid "averaged EIGF"
+msgstr "Averaged EIGF"
+
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:375
+msgid "EIGF"
+msgstr "EIGF"
+
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:379
+msgid "RGB average"
+msgstr "RGB average"
+
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:380
+msgid "HSL lightness"
+msgstr "HSL lightness"
+
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:381
+msgid "HSV value / RGB max"
+msgstr "HSV value / RGB max"
+
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:382
+msgid "RGB sum"
+msgstr "RGB sum"
+
+#: ../build/lib/darktable/plugins/introspection_toneequal.c:385
+msgid "RGB geometric mean"
+msgstr "RGB geometric mean"
+
+#: ../build/lib/darktable/plugins/introspection_tonemap.cc:39
+#: ../build/lib/darktable/plugins/introspection_tonemap.cc:88
+#: ../src/iop/rgbcurve.c:184 ../src/iop/tonecurve.c:539
+msgid "contrast compression"
+msgstr "Contrast compression"
+
+#: ../build/lib/darktable/plugins/introspection_vibrance.c:33
+#: ../build/lib/darktable/plugins/introspection_vibrance.c:76
+#: ../src/iop/basicadj.c:627 ../src/iop/vibrance.c:67
+msgid "vibrance"
+msgstr "Vibrance"
+
+#: ../build/lib/darktable/plugins/introspection_vignette.c:97
+#: ../build/lib/darktable/plugins/introspection_vignette.c:204
+msgid "fall-off strength"
+msgstr "Fall-off strength"
+
+#: ../build/lib/darktable/plugins/introspection_vignette.c:115
+#: ../build/lib/darktable/plugins/introspection_vignette.c:216
+msgid "horizontal center"
+msgstr "Horizontal center"
+
+#: ../build/lib/darktable/plugins/introspection_vignette.c:121
+#: ../build/lib/darktable/plugins/introspection_vignette.c:220
+msgid "vertical center"
+msgstr "Vertical center"
+
+#: ../build/lib/darktable/plugins/introspection_vignette.c:133
+#: ../build/lib/darktable/plugins/introspection_vignette.c:228
+msgid "automatic ratio"
+msgstr "Automatic ratio"
+
+#: ../build/lib/darktable/plugins/introspection_vignette.c:139
+#: ../build/lib/darktable/plugins/introspection_vignette.c:232
+msgid "width/height ratio"
+msgstr "Width/height ratio"
+
+#: ../build/lib/darktable/plugins/introspection_vignette.c:145
+#: ../build/lib/darktable/plugins/introspection_vignette.c:236
+#: ../src/iop/vignette.c:977
+msgid "shape"
+msgstr "Shape"
+
+#: ../build/lib/darktable/plugins/introspection_vignette.c:264
+msgid "8-bit output"
+msgstr "8-bit output"
+
+#: ../build/lib/darktable/plugins/introspection_vignette.c:265
+msgid "16-bit output"
+msgstr "16-bit output"
+
+#: ../build/lib/darktable/plugins/introspection_watermark.c:100
+#: ../build/lib/darktable/plugins/introspection_watermark.c:223
+msgid "x offset"
+msgstr "X offset"
+
+#: ../build/lib/darktable/plugins/introspection_watermark.c:106
+#: ../build/lib/darktable/plugins/introspection_watermark.c:227
+msgid "y offset"
+msgstr "Y offset"
+
+#: ../build/lib/darktable/plugins/introspection_watermark.c:124
+#: ../build/lib/darktable/plugins/introspection_watermark.c:239
+msgid "scale on"
+msgstr "Scale on"
+
+#: ../build/lib/darktable/plugins/introspection_watermark.c:285
+#: ../src/imageio/format/tiff.c:125 ../src/imageio/format/xcf.c:159
+#: ../src/iop/borders.c:940
+msgid "image"
+msgstr "Image"
+
+#: ../build/lib/darktable/plugins/introspection_watermark.c:286
+msgid "larger border"
+msgstr "Larger border"
+
+#: ../build/lib/darktable/plugins/introspection_watermark.c:287
+msgid "smaller border"
+msgstr "Smaller border"
+
+#: ../build/lib/darktable/plugins/lighttable/tools/darktable_authors.h:6
+msgid "developers"
+msgstr "Developers"
+
+#: ../build/lib/darktable/plugins/lighttable/tools/darktable_authors.h:11
+msgid "translators"
+msgstr "Translators"
+
+#: ../build/lib/darktable/plugins/lighttable/tools/darktable_authors.h:16
+msgid "contributors"
+msgstr "Contributors"
+
+#: ../build/lib/darktable/plugins/lighttable/tools/darktable_authors.h:21
+msgid "rawspeed contributors"
+msgstr "Rawspeed contributors"
+
+#: ../build/lib/darktable/plugins/lighttable/tools/darktable_authors.h:26
+msgid "integration contributors"
+msgstr "Integration contributors"
+
+#: ../build/share/darktable/org.darktable.darktable.desktop.in.h:1
+#: ../data/org.darktable.darktable.desktop.in.h:1
+msgid "Virtual Lighttable and Darkroom"
+msgstr "Virtual Lighttable and Darkroom"
+
+#: ../build/share/darktable/org.darktable.darktable.desktop.in.h:2
+#: ../data/org.darktable.darktable.appdata.xml.in.h:1
+#: ../data/org.darktable.darktable.desktop.in.h:2
+msgid "Organize and develop images from digital cameras"
+msgstr "Organize and develop images from digital cameras"
+
+#. TRANSLATORS: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: ../build/share/darktable/org.darktable.darktable.desktop.in.h:4
+#: ../data/org.darktable.darktable.desktop.in.h:4
+msgid "graphics;photography;raw;"
+msgstr "graphics;photography;raw;"
+
+#: ../data/org.darktable.darktable.appdata.xml.in.h:2
+msgid ""
+"darktable manages your digital negatives in a database and lets you view "
+"them through a lighttable. It also enables you to develop raw images and "
+"enhance them in a darkroom."
+msgstr ""
+"Darktable manages your digital negatives in a database and lets you view "
+"them through a Lighttable. It also enables you to develop raw images and "
+"enhance them in a Darkroom."
+
+#: ../data/org.darktable.darktable.appdata.xml.in.h:3
+msgid ""
+"Other modes besides lighttable and darkroom are a map for geotagging, "
+"tethering, print and a slideshow."
+msgstr ""
+"Other modes besides Lighttable and Darkroom are a Map for geotagging, "
+"Tethering, Print and a Slideshow."
+
+#: ../data/org.darktable.darktable.appdata.xml.in.h:4
+msgid ""
+"darktable supports most modern cameras' raw formats, and does all of its "
+"processing at very high precision."
+msgstr ""
+"Darktable supports most modern cameras' raw formats, and does all of its "
+"processing at very high precision."
+
+#: ../data/org.darktable.darktable.appdata.xml.in.h:5
+msgid "Virtual light table, showing a collection"
+msgstr "Virtual light table, showing a collection"
+
+#: ../data/org.darktable.darktable.appdata.xml.in.h:6
+msgid "Virtual dark room with an opened image"
+msgstr "Virtual dark room with an opened image"
+
+#: ../data/org.darktable.darktable.appdata.xml.in.h:7
+msgid "Virtual dark room, sharpening an image"
+msgstr "Virtual dark room, sharpening an image"
+
+#: ../data/org.darktable.darktable.appdata.xml.in.h:8
+msgid "Show images on a map"
+msgstr "Show images on a map"
+
+#: ../data/org.darktable.darktable.appdata.xml.in.h:9
+msgid "Print your images"
+msgstr "Print your images"
+
+#: ../src/bauhaus/bauhaus.c:750 ../src/bauhaus/bauhaus.c:3657
+msgid "sliders"
+msgstr "Sliders"
+
+#: ../src/bauhaus/bauhaus.c:751 ../src/bauhaus/bauhaus.c:3662
+msgid "dropdowns"
+msgstr "Dropdowns"
+
+#: ../src/bauhaus/bauhaus.c:752 ../src/bauhaus/bauhaus.c:3667
+msgid "buttons"
+msgstr "Buttons"
+
+#: ../src/bauhaus/bauhaus.c:3378
+msgid "button on"
+msgstr "Button on"
+
+#: ../src/bauhaus/bauhaus.c:3378
+msgid "button off"
+msgstr "Button off"
+
+#: ../src/bauhaus/bauhaus.c:3379
+msgid "button pressed"
+msgstr "Button pressed"
+
+#: ../src/bauhaus/bauhaus.c:3591
+msgid "not that many sliders"
+msgstr "Not that many sliders"
+
+#: ../src/bauhaus/bauhaus.c:3601
+msgid "not that many dropdowns"
+msgstr "Not that many dropdowns"
+
+#: ../src/bauhaus/bauhaus.c:3616
+msgid "not that many buttons"
+msgstr "Not that many buttons"
+
+#: ../src/bauhaus/bauhaus.c:3621 ../src/gui/accelerators.c:335
+msgid "value"
+msgstr "Value"
+
+#: ../src/bauhaus/bauhaus.c:3622 ../src/bauhaus/bauhaus.c:3628
+#: ../src/gui/accelerators.c:313
+msgid "button"
+msgstr "Button"
+
+#: ../src/bauhaus/bauhaus.c:3623
+msgid "force"
+msgstr "Force"
+
+#: ../src/bauhaus/bauhaus.c:3624 ../src/libs/navigation.c:188
+#: ../src/libs/navigation.c:200
+msgid "zoom"
+msgstr "Zoom"
+
+#: ../src/bauhaus/bauhaus.c:3627
+msgid "selection"
+msgstr "Selection"
+
+#: ../src/bauhaus/bauhaus.c:3646
+msgid "slider"
+msgstr "Slider"
+
+#: ../src/bauhaus/bauhaus.c:3651
+msgid "dropdown"
+msgstr "Dropdown"
+
+#: ../src/chart/main.c:504 ../src/control/jobs/control_jobs.c:1661
+#: ../src/control/jobs/control_jobs.c:1715 ../src/gui/accelerators.c:2150
+#: ../src/gui/accelerators.c:2226 ../src/gui/accelerators.c:2277
+#: ../src/gui/accelerators.c:2305 ../src/gui/accelerators.c:2364
+#: ../src/gui/hist_dialog.c:224 ../src/gui/preferences.c:1033
+#: ../src/gui/preferences.c:1072 ../src/gui/presets.c:361
+#: ../src/gui/presets.c:498 ../src/gui/styles_dialog.c:517
+#: ../src/imageio/storage/disk.c:123 ../src/imageio/storage/gallery.c:110
+#: ../src/imageio/storage/latex.c:109 ../src/iop/lut3d.c:1546
+#: ../src/libs/collect.c:409 ../src/libs/copy_history.c:117
+#: ../src/libs/geotagging.c:929 ../src/libs/import.c:1507
+#: ../src/libs/import.c:1611 ../src/libs/styles.c:393 ../src/libs/styles.c:528
+#: ../src/libs/tagging.c:2486 ../src/libs/tagging.c:2522
+msgid "_cancel"
+msgstr "_Cancel"
+
+#: ../src/chart/main.c:504 ../src/gui/preferences.c:1072
+#: ../src/gui/styles_dialog.c:520 ../src/libs/styles.c:393
+msgid "_save"
+msgstr "_Save"
+
+#. TODO: is the rank interesting, too?
+#: ../src/chart/main.c:1064
+#, c-format
+msgid ""
+"average dE: %.02f\n"
+"max dE: %.02f"
+msgstr ""
+"Average dE: %.02f\n"
+"Max dE: %.02f"
+
+#: ../src/cli/main.c:247
+msgid "TODO: sorry, due to API restrictions we currently cannot set the BPP to"
+msgstr ""
+"TODO: sorry, due to API restrictions we currently cannot set the BPP to"
+
+#: ../src/cli/main.c:259
+msgid "unknown option for --hq"
+msgstr "Unknown option for --hq"
+
+#: ../src/cli/main.c:275
+msgid "unknown option for --export_masks"
+msgstr "Unknown option for --export_masks"
+
+#: ../src/cli/main.c:291
+msgid "unknown option for --upscale"
+msgstr "Unknown option for --upscale"
+
+#: ../src/cli/main.c:316
+msgid "unknown option for --apply-custom-presets"
+msgstr "Unknown option for --apply-custom-presets"
+
+#: ../src/cli/main.c:327
+msgid "too long ext for --out-ext"
+msgstr "Too long ext for --out-ext"
+
+#: ../src/cli/main.c:344
+#, c-format
+msgid "notice: input file or dir '%s' doesn't exist, skipping\n"
+msgstr "Notice: input file or dir '%s' doesn't exist, skipping\n"
+
+#: ../src/cli/main.c:353
+#, c-format
+msgid "incorrect ICC type for --icc-type: '%s'\n"
+msgstr "Incorrect ICC type for --icc-type: '%s'\n"
+
+#: ../src/cli/main.c:369
+#, c-format
+msgid "notice: ICC file '%s' doesn't exist, skipping\n"
+msgstr "Notice: ICC file '%s' doesn't exist, skipping\n"
+
+#: ../src/cli/main.c:378
+#, c-format
+msgid "incorrect ICC intent for --icc-intent: '%s'\n"
+msgstr "Incorrect ICC intent for --icc-intent: '%s'\n"
+
+#: ../src/cli/main.c:396
+#, c-format
+msgid "warning: unknown option '%s'\n"
+msgstr "Warning: unknown option '%s'\n"
+
+#: ../src/cli/main.c:454
+#, c-format
+msgid "error: input file and import opts specified! that's not supported!\n"
+msgstr "Error: input file and import opts specified! That's not supported!\n"
+
+#: ../src/cli/main.c:487
+#, c-format
+msgid ""
+"notice: output location is a directory. assuming '%s/$(FILE_NAME).%s' output "
+"pattern"
+msgstr ""
+"Notice: output location is a directory. Assuming '%s/$(FILE_NAME).%s' output "
+"pattern"
+
+#. output file exists or there's output ext specified and it's same as file...
+#: ../src/cli/main.c:502
+msgid "output file already exists, it will get renamed"
+msgstr "Output file already exists, it will get renamed"
+
+#. one of inputs was a failure, no prob
+#: ../src/cli/main.c:532
+#, c-format
+msgid "error: can't open folder %s"
+msgstr "Error: can't open folder %s"
+
+#: ../src/cli/main.c:549
+#, c-format
+msgid "error: can't open file %s"
+msgstr "Error: can't open file %s"
+
+#: ../src/cli/main.c:566
+#, c-format
+msgid "no images to export, aborting\n"
+msgstr "No images to export, aborting\n"
+
+#: ../src/cli/main.c:583
+#, c-format
+msgid "error: can't open XMP file %s"
+msgstr "Error: can't open XMP file %s"
+
+#: ../src/cli/main.c:604
+msgid "empty history stack"
+msgstr "Empty history stack"
+
+#. too long ext, no point in wasting time
+#: ../src/cli/main.c:616
+#, c-format
+msgid "too long output file extension: %s\n"
+msgstr "Too long output file extension: %s\n"
+
+#. no ext or empty ext, no point in wasting time
+#: ../src/cli/main.c:624
+#, c-format
+msgid "no output file extension given\n"
+msgstr "No output file extension given\n"
+
+#: ../src/cli/main.c:663
+msgid ""
+"cannot find disk storage module. please check your installation, something "
+"seems to be broken."
+msgstr ""
+"Cannot find disk storage module. Please check your installation, something "
+"seems to be broken."
+
+#: ../src/cli/main.c:673
+msgid "failed to get parameters from storage module, aborting export ..."
+msgstr "Failed to get parameters from storage module, aborting export ..."
+
+#: ../src/cli/main.c:689
+#, c-format
+msgid "unknown extension '.%s'"
+msgstr "Unknown extension '.%s'"
+
+#: ../src/cli/main.c:699
+msgid "failed to get parameters from format module, aborting export ..."
+msgstr "Failed to get parameters from format module, aborting export ..."
+
+#: ../src/common/camera_control.c:190
+#, c-format
+msgid ""
+"camera `%s' on port `%s' error %s\n"
+"\n"
+"make sure your camera allows access and is not mounted otherwise"
+msgstr ""
+"Camera `%s' on port `%s' error %s\n"
+"\n"
+"Make sure your camera allows access and is not mounted otherwise"
+
+#: ../src/common/camera_control.c:892
+#, c-format
+msgid ""
+"failed to initialize `%s' on port `%s', likely causes are: locked by another "
+"application, no access to devices etc"
+msgstr ""
+"Failed to initialize `%s' on port `%s', likely causes are: locked by another "
+"application, no access to devices etc"
+
+#: ../src/common/camera_control.c:905
+#, c-format
+msgid ""
+"`%s' on port `%s' is not interesting because it supports neither tethering "
+"nor import"
+msgstr ""
+"`%s' on port `%s' is not interesting because it supports neither tethering "
+"nor import"
+
+#: ../src/common/camera_control.c:959
+#, c-format
+msgid "camera `%s' on port `%s' disconnected while mounted"
+msgstr "Camera `%s' on port `%s' disconnected while mounted"
+
+#: ../src/common/camera_control.c:967
+#, c-format
+msgid ""
+"camera `%s' on port `%s' needs to be remounted\n"
+"make sure it allows access and is not mounted otherwise"
+msgstr ""
+"Camera `%s' on port `%s' needs to be remounted\n"
+"Make sure it allows access and is not mounted otherwise"
+
+#: ../src/common/collection.c:625
+msgid "too much time to update aspect ratio for the collection"
+msgstr "Too much time to update aspect ratio for the collection"
+
+#: ../src/common/collection.c:640
+msgid "film roll"
+msgstr "Film roll"
+
+#: ../src/common/collection.c:642
+msgid "folder"
+msgstr "Folder"
+
+#: ../src/common/collection.c:644
+msgid "camera"
+msgstr "Camera"
+
+#: ../src/common/collection.c:646 ../src/libs/export_metadata.c:189
+#: ../src/libs/tagging.c:3280
+msgid "tag"
+msgstr "Tag"
+
+#: ../src/common/collection.c:648
+msgid "capture date"
+msgstr "Capture date"
+
+#: ../src/common/collection.c:650 ../src/libs/filtering.c:61
+msgid "capture time"
+msgstr "Capture time"
+
+#: ../src/common/collection.c:652 ../src/libs/filtering.c:62
+msgid "import time"
+msgstr "Import time"
+
+#: ../src/common/collection.c:654 ../src/libs/filtering.c:63
+msgid "modification time"
+msgstr "Modification time"
+
+#: ../src/common/collection.c:656 ../src/libs/filtering.c:64
+msgid "export time"
+msgstr "Export time"
+
+#: ../src/common/collection.c:658 ../src/libs/filtering.c:65
+msgid "print time"
+msgstr "Print time"
+
+#: ../src/common/collection.c:660 ../src/libs/collect.c:3297
+#: ../src/libs/filtering.c:2164 ../src/libs/filtering.c:2184
+#: ../src/libs/filters/history.c:153 ../src/libs/history.c:99
+msgid "history"
+msgstr "History"
+
+#: ../src/common/collection.c:662 ../src/common/colorlabels.c:337
+#: ../src/develop/lightroom.c:1550 ../src/dtgtk/thumbnail.c:1388
+#: ../src/libs/filtering.c:68 ../src/libs/filters/colors.c:301
+#: ../src/libs/filters/colors.c:312 ../src/libs/tools/colorlabels.c:94
+msgid "color label"
+msgstr "Color label"
+
+#. iso
+#: ../src/common/collection.c:668 ../src/gui/preferences.c:827
+#: ../src/gui/presets.c:590 ../src/libs/camera.c:559
+#: ../src/libs/metadata_view.c:145
+msgid "ISO"
+msgstr "ISO"
+
+#. aperture
+#: ../src/common/collection.c:670 ../src/gui/preferences.c:835
+#: ../src/gui/presets.c:618 ../src/libs/camera.c:546 ../src/libs/camera.c:548
+#: ../src/libs/metadata_view.c:140
+msgid "aperture"
+msgstr "Aperture"
+
+#: ../src/common/collection.c:676 ../src/libs/filtering.c:57
+#: ../src/libs/filters/filename.c:364 ../src/libs/metadata_view.c:126
+msgid "filename"
+msgstr "Filename"
+
+#: ../src/common/collection.c:678 ../src/develop/lightroom.c:1541
+#: ../src/libs/geotagging.c:141
+msgid "geotagging"
+msgstr "Geotagging"
+
+#: ../src/common/collection.c:680 ../src/libs/filters/grouping.c:167
+#: ../src/libs/tools/global_toolbox.c:396
+msgid "grouping"
+msgstr "Grouping"
+
+#: ../src/common/collection.c:682 ../src/dtgtk/thumbnail.c:1400
+#: ../src/libs/filters/local_copy.c:142 ../src/libs/metadata_view.c:129
+#: ../src/libs/metadata_view.c:338
+msgid "local copy"
+msgstr "Local copy"
+
+#: ../src/common/collection.c:684 ../src/gui/preferences.c:803
+msgid "module"
+msgstr "Module"
+
+#: ../src/common/collection.c:686 ../src/gui/hist_dialog.c:344
+#: ../src/gui/styles_dialog.c:720 ../src/gui/styles_dialog.c:769
+#: ../src/libs/filters/module_order.c:161 ../src/libs/ioporder.c:40
+msgid "module order"
+msgstr "Module order"
+
+#: ../src/common/collection.c:688
+msgid "range rating"
+msgstr "Range rating"
+
+#: ../src/common/collection.c:690 ../src/common/ratings.c:322
+#: ../src/develop/lightroom.c:1525 ../src/libs/filtering.c:67
+#: ../src/libs/tools/ratings.c:111
+msgid "rating"
+msgstr "Rating"
+
+#: ../src/common/collection.c:692
+msgid "search"
+msgstr "Search"
+
+#: ../src/common/collection.c:1420 ../src/common/colorlabels.c:330
+#: ../src/develop/lightroom.c:836 ../src/gui/guides.c:732
+#: ../src/iop/colorzones.c:2265 ../src/iop/temperature.c:1924
+#: ../src/libs/collect.c:1792 ../src/libs/filters/colors.c:261
+msgid "yellow"
+msgstr "Yellow"
+
+#: ../src/common/collection.c:1426 ../src/common/color_vocabulary.c:339
+#: ../src/common/colorlabels.c:333 ../src/iop/colorzones.c:2269
+#: ../src/libs/collect.c:1792 ../src/libs/filters/colors.c:264
+msgid "purple"
+msgstr "Purple"
+
+#: ../src/common/collection.c:1443 ../src/libs/collect.c:1746
+#: ../src/libs/filters/history.c:38
+msgid "auto applied"
+msgstr "Auto applied"
+
+#: ../src/common/collection.c:1447 ../src/libs/collect.c:1746
+#: ../src/libs/filters/history.c:38
+msgid "altered"
+msgstr "Altered"
+
+#: ../src/common/collection.c:1464 ../src/common/collection.c:1560
+#: ../src/libs/collect.c:1167 ../src/libs/collect.c:1331
+#: ../src/libs/collect.c:1355 ../src/libs/collect.c:1474
+#: ../src/libs/collect.c:2504
+msgid "not tagged"
+msgstr "Not tagged"
+
+#: ../src/common/collection.c:1465 ../src/libs/collect.c:1355
+#: ../src/libs/map_locations.c:743
+msgid "tagged"
+msgstr "Tagged"
+
+#: ../src/common/collection.c:1466
+msgid "tagged*"
+msgstr "Tagged*"
+
+#. local copy
+#: ../src/common/collection.c:1499 ../src/libs/collect.c:1760
+#: ../src/libs/filters/local_copy.c:38
+msgid "not copied locally"
+msgstr "Not copied locally"
+
+#: ../src/common/collection.c:1503 ../src/libs/collect.c:1760
+#: ../src/libs/filters/local_copy.c:38
+msgid "copied locally"
+msgstr "Copied locally"
+
+#: ../src/common/collection.c:1878 ../src/libs/collect.c:1880
+#: ../src/libs/filters/grouping.c:147 ../src/libs/filters/grouping.c:170
+msgid "group leaders"
+msgstr "Group leaders"
+
+#: ../src/common/collection.c:1882 ../src/libs/collect.c:1880
+#: ../src/libs/filters/grouping.c:150 ../src/libs/filters/grouping.c:170
+msgid "group followers"
+msgstr "Group followers"
+
+#: ../src/common/collection.c:2022 ../src/libs/collect.c:1960
+msgid "not defined"
+msgstr "Not defined"
+
+#: ../src/common/collection.c:2458
+#, c-format
+msgid "<b>%d</b> image (#<b>%d</b>) selected of <b>%d</b>"
+msgstr "<b>%d</b> image (#<b>%d</b>) selected of <b>%d</b>"
+
+#: ../src/common/collection.c:2464
+#, c-format
+msgid "<b>%d</b> image selected of <b>%d</b>"
+msgid_plural "<b>%d</b> images selected of <b>%d</b>"
+msgstr[0] "<b>%d</b> image selected of <b>%d</b>"
+msgstr[1] "<b>%d</b> images selected of <b>%d</b>"
+
+#: ../src/common/color_vocabulary.c:38 ../src/develop/blend_gui.c:2328
+#: ../src/develop/blend_gui.c:2376 ../src/gui/guides.c:729
+#: ../src/iop/channelmixerrgb.c:4591 ../src/iop/levels.c:666
+#: ../src/iop/rgblevels.c:935
+msgid "gray"
+msgstr "Gray"
+
+#: ../src/common/color_vocabulary.c:92
+msgid "Chinese"
+msgstr "Chinese"
+
+#: ../src/common/color_vocabulary.c:93
+msgid "Thai"
+msgstr "Thai"
+
+#: ../src/common/color_vocabulary.c:94
+msgid "Kurdish"
+msgstr "Kurdish"
+
+#: ../src/common/color_vocabulary.c:95
+msgid "Caucasian"
+msgstr "Caucasian"
+
+#: ../src/common/color_vocabulary.c:96
+msgid "African-american"
+msgstr "African-american"
+
+#: ../src/common/color_vocabulary.c:97
+msgid "Mexican"
+msgstr "Mexican"
+
+#: ../src/common/color_vocabulary.c:100 ../src/common/color_vocabulary.c:105
+#: ../src/common/color_vocabulary.c:110 ../src/common/color_vocabulary.c:115
+msgid "forearm"
+msgstr "Forearm"
+
+#: ../src/common/color_vocabulary.c:120 ../src/common/color_vocabulary.c:125
+#: ../src/common/color_vocabulary.c:130 ../src/common/color_vocabulary.c:135
+#: ../src/common/color_vocabulary.c:140 ../src/common/color_vocabulary.c:145
+msgid "forehead"
+msgstr "Forehead"
+
+#: ../src/common/color_vocabulary.c:150 ../src/common/color_vocabulary.c:155
+#: ../src/common/color_vocabulary.c:160 ../src/common/color_vocabulary.c:165
+#: ../src/common/color_vocabulary.c:170 ../src/common/color_vocabulary.c:175
+msgid "cheek"
+msgstr "Cheek"
+
+#: ../src/common/color_vocabulary.c:202
+#, c-format
+msgid "average %s skin tone\n"
+msgstr "Average %s skin tone\n"
+
+#. 0° - pinkish red
+#: ../src/common/color_vocabulary.c:222
+msgid "deep purple"
+msgstr "Deep purple"
+
+#. L = 10 %
+#: ../src/common/color_vocabulary.c:223
+msgid "fuchsia"
+msgstr "Fuchsia"
+
+#. L = 30 %
+#: ../src/common/color_vocabulary.c:224
+msgid "medium magenta"
+msgstr "Medium magenta"
+
+#. L = 50 %
+#: ../src/common/color_vocabulary.c:225
+msgid "violet pink"
+msgstr "Violet pink"
+
+#. L = 70 %
+#: ../src/common/color_vocabulary.c:226
+msgid "plum violet"
+msgstr "Plum violet"
+
+#. 24° - red
+#: ../src/common/color_vocabulary.c:231
+msgid "dark red"
+msgstr "Dark red"
+
+#: ../src/common/color_vocabulary.c:233
+msgid "crimson"
+msgstr "Crimson"
+
+#: ../src/common/color_vocabulary.c:234
+msgid "salmon"
+msgstr "Salmon"
+
+#: ../src/common/color_vocabulary.c:235
+msgid "pink"
+msgstr "Pink"
+
+#. 48° - orangy red
+#: ../src/common/color_vocabulary.c:240
+msgid "maroon"
+msgstr "Maroon"
+
+#: ../src/common/color_vocabulary.c:241
+msgid "dark orange red"
+msgstr "Dark orange red"
+
+#: ../src/common/color_vocabulary.c:242
+msgid "orange red"
+msgstr "Orange red"
+
+#: ../src/common/color_vocabulary.c:243
+msgid "coral"
+msgstr "Coral"
+
+#: ../src/common/color_vocabulary.c:244 ../src/common/color_vocabulary.c:261
+msgid "khaki"
+msgstr "Khaki"
+
+#. 72° - orange
+#: ../src/common/color_vocabulary.c:249
+msgid "brown"
+msgstr "Brown"
+
+#: ../src/common/color_vocabulary.c:250
+msgid "chocolate"
+msgstr "Chocolate"
+
+#: ../src/common/color_vocabulary.c:251
+msgid "dark gold"
+msgstr "Dark gold"
+
+#: ../src/common/color_vocabulary.c:252
+msgid "gold"
+msgstr "Gold"
+
+#: ../src/common/color_vocabulary.c:253
+msgid "sandy brown"
+msgstr "Sandy brown"
+
+#. 96° - yellow olive
+#. 120° - green
+#. 144° - blueish green
+#: ../src/common/color_vocabulary.c:258 ../src/common/color_vocabulary.c:267
+#: ../src/common/color_vocabulary.c:276
+msgid "dark green"
+msgstr "Dark green"
+
+#: ../src/common/color_vocabulary.c:259
+msgid "dark olive green"
+msgstr "Dark olive green"
+
+#: ../src/common/color_vocabulary.c:260
+msgid "olive"
+msgstr "Olive"
+
+#: ../src/common/color_vocabulary.c:262
+msgid "beige"
+msgstr "Beige"
+
+#: ../src/common/color_vocabulary.c:268 ../src/common/color_vocabulary.c:278
+msgid "forest green"
+msgstr "Forest green"
+
+#: ../src/common/color_vocabulary.c:269
+msgid "olive drab"
+msgstr "Olive drab"
+
+#: ../src/common/color_vocabulary.c:270
+msgid "yellow green"
+msgstr "Yellow green"
+
+#: ../src/common/color_vocabulary.c:271 ../src/common/color_vocabulary.c:280
+msgid "pale green"
+msgstr "Pale green"
+
+#: ../src/common/color_vocabulary.c:279
+msgid "lime green"
+msgstr "Lime green"
+
+#. 168° - greenish cyian
+#: ../src/common/color_vocabulary.c:285
+msgid "dark sea green"
+msgstr "Dark sea green"
+
+#: ../src/common/color_vocabulary.c:286
+msgid "sea green"
+msgstr "Sea green"
+
+#: ../src/common/color_vocabulary.c:287 ../src/common/color_vocabulary.c:304
+msgid "teal"
+msgstr "Teal"
+
+#: ../src/common/color_vocabulary.c:288
+msgid "light sea green"
+msgstr "Light sea green"
+
+#: ../src/common/color_vocabulary.c:289
+msgid "turquoise"
+msgstr "Turquoise"
+
+#. 192° - cyan
+#: ../src/common/color_vocabulary.c:294
+msgid "dark slate gray"
+msgstr "Dark slate gray"
+
+#: ../src/common/color_vocabulary.c:295
+msgid "light slate gray"
+msgstr "Light slate gray"
+
+#: ../src/common/color_vocabulary.c:296 ../src/common/color_vocabulary.c:305
+msgid "dark cyan"
+msgstr "Dark cyan"
+
+#: ../src/common/color_vocabulary.c:297 ../src/common/color_vocabulary.c:317
+#: ../src/iop/colorzones.c:2267
+msgid "aqua"
+msgstr "Aqua"
+
+#: ../src/common/color_vocabulary.c:298 ../src/gui/guides.c:733
+#: ../src/iop/temperature.c:1922
+msgid "cyan"
+msgstr "Cyan"
+
+#. 216° - medium blue
+#: ../src/common/color_vocabulary.c:303
+msgid "navy blue"
+msgstr "Navy blue"
+
+#: ../src/common/color_vocabulary.c:306 ../src/common/color_vocabulary.c:316
+msgid "deep sky blue"
+msgstr "Deep sky blue"
+
+#: ../src/common/color_vocabulary.c:307
+msgid "aquamarine blue"
+msgstr "Aquamarine blue"
+
+#. 240° - blue and 264° - bluer than blue
+#. these are collapsed because CIE Lab 1976 sucks for blues
+#. 288° - more blue
+#: ../src/common/color_vocabulary.c:313 ../src/common/color_vocabulary.c:322
+msgid "dark blue"
+msgstr "Dark blue"
+
+#: ../src/common/color_vocabulary.c:314 ../src/common/color_vocabulary.c:323
+msgid "medium blue"
+msgstr "Medium blue"
+
+#: ../src/common/color_vocabulary.c:315
+msgid "azure blue"
+msgstr "Azure blue"
+
+#: ../src/common/color_vocabulary.c:325
+msgid "light sky blue"
+msgstr "Light sky blue"
+
+#: ../src/common/color_vocabulary.c:326
+msgid "light blue"
+msgstr "Light blue"
+
+#. 312° - violet
+#: ../src/common/color_vocabulary.c:331
+msgid "indigo"
+msgstr "Indigo"
+
+#: ../src/common/color_vocabulary.c:332
+msgid "dark violet"
+msgstr "Dark violet"
+
+#: ../src/common/color_vocabulary.c:333
+msgid "blue violet"
+msgstr "Blue violet"
+
+#: ../src/common/color_vocabulary.c:334 ../src/common/color_vocabulary.c:342
+msgid "violet"
+msgstr "Violet"
+
+#: ../src/common/color_vocabulary.c:335
+msgid "plum"
+msgstr "Plum"
+
+#: ../src/common/color_vocabulary.c:340
+msgid "dark magenta"
+msgstr "Dark magenta"
+
+#: ../src/common/color_vocabulary.c:341 ../src/gui/guides.c:734
+#: ../src/iop/colorzones.c:2270 ../src/iop/temperature.c:1920
+msgid "magenta"
+msgstr "Magenta"
+
+#: ../src/common/color_vocabulary.c:343
+msgid "lavender"
+msgstr "Lavender"
+
+#: ../src/common/color_vocabulary.c:346
+msgid "color not found"
+msgstr "Color not found"
+
+#: ../src/common/colorlabels.c:305
+#, c-format
+msgid "colorlabels set to %s"
+msgstr "Colorlabels set to %s"
+
+#: ../src/common/colorlabels.c:307
+msgid "all colorlabels removed"
+msgstr "All colorlabels removed"
+
+#: ../src/common/colorlabels.c:328 ../src/gui/accelerators.c:170
+#: ../src/libs/image.c:594
+msgid "clear"
+msgstr "Clear"
+
+#. init the category profile with NULL profile, the actual profile must be retrieved dynamically by the caller
+#: ../src/common/colorspaces.c:1229 ../src/common/colorspaces.c:1518
+msgid "work profile"
+msgstr "Work profile"
+
+#: ../src/common/colorspaces.c:1232 ../src/common/colorspaces.c:1514
+#: ../src/iop/colorout.c:891
+msgid "export profile"
+msgstr "Export profile"
+
+#: ../src/common/colorspaces.c:1236 ../src/common/colorspaces.c:1516
+#: ../src/views/darkroom.c:2528
+msgid "softproof profile"
+msgstr "Softproof profile"
+
+#: ../src/common/colorspaces.c:1242 ../src/common/colorspaces.c:1498
+msgid "system display profile"
+msgstr "System display profile"
+
+#: ../src/common/colorspaces.c:1245 ../src/common/colorspaces.c:1520
+msgid "system display profile (second window)"
+msgstr "System display profile (second window)"
+
+#: ../src/common/colorspaces.c:1255
+msgid "sRGB (web-safe)"
+msgstr "sRGB (web-safe)"
+
+#: ../src/common/colorspaces.c:1269 ../src/common/colorspaces.c:1522
+msgid "Rec709 RGB"
+msgstr "Rec709 RGB"
+
+#: ../src/common/colorspaces.c:1279
+msgid "PQ Rec2020 RGB"
+msgstr "PQ Rec2020 RGB"
+
+#: ../src/common/colorspaces.c:1284
+msgid "HLG Rec2020 RGB"
+msgstr "HLG Rec2020 RGB"
+
+#: ../src/common/colorspaces.c:1289
+msgid "PQ P3 RGB"
+msgstr "PQ P3 RGB"
+
+#: ../src/common/colorspaces.c:1294
+msgid "HLG P3 RGB"
+msgstr "HLG P3 RGB"
+
+#: ../src/common/colorspaces.c:1299 ../src/common/colorspaces.c:1524
+msgid "linear ProPhoto RGB"
+msgstr "Linear ProPhoto RGB"
+
+#: ../src/common/colorspaces.c:1304 ../src/common/colorspaces.c:1492
+msgid "linear XYZ"
+msgstr "Linear XYZ"
+
+#: ../src/common/colorspaces.c:1308 ../src/common/colorspaces.c:1494
+#: ../src/develop/blend_gui.c:144 ../src/develop/blend_gui.c:2005
+#: ../src/libs/colorpicker.c:51 ../src/libs/colorpicker.c:268
+msgid "Lab"
+msgstr "Lab"
+
+#: ../src/common/colorspaces.c:1313 ../src/common/colorspaces.c:1496
+msgid "linear infrared BGR"
+msgstr "Linear infrared BGR"
+
+#: ../src/common/colorspaces.c:1317
+msgid "BRG (for testing)"
+msgstr "BRG (for testing)"
+
+#: ../src/common/colorspaces.c:1409
+#, c-format
+msgid ""
+"profile `%s' not usable as histogram profile. it has been replaced by sRGB!"
+msgstr ""
+"Profile `%s' not usable as histogram profile. It has been replaced by sRGB!"
+
+#: ../src/common/colorspaces.c:1500
+msgid "embedded ICC profile"
+msgstr "Embedded ICC profile"
+
+#: ../src/common/colorspaces.c:1502
+msgid "embedded matrix"
+msgstr "Embedded matrix"
+
+#: ../src/common/colorspaces.c:1504
+msgid "standard color matrix"
+msgstr "Standard color matrix"
+
+#: ../src/common/colorspaces.c:1506
+msgid "enhanced color matrix"
+msgstr "Enhanced color matrix"
+
+#: ../src/common/colorspaces.c:1508
+msgid "vendor color matrix"
+msgstr "Vendor color matrix"
+
+#: ../src/common/colorspaces.c:1510
+msgid "alternate color matrix"
+msgstr "Alternate color matrix"
+
+#: ../src/common/colorspaces.c:1512
+msgid "BRG (experimental)"
+msgstr "BRG (experimental)"
+
+#: ../src/common/colorspaces.c:1526
+msgid "PQ Rec2020"
+msgstr "PQ Rec2020"
+
+#: ../src/common/colorspaces.c:1528
+msgid "HLG Rec2020"
+msgstr "HLG Rec2020"
+
+#: ../src/common/colorspaces.c:1530
+msgid "PQ P3"
+msgstr "PQ P3"
+
+#: ../src/common/colorspaces.c:1532
+msgid "HLG P3"
+msgstr "HLG P3"
+
+#: ../src/common/cups_print.c:420
+#, c-format
+msgid "file `%s' to print not found for image %d on `%s'"
+msgstr "File `%s' to print not found for image %d on `%s'"
+
+#: ../src/common/cups_print.c:439
+msgid "failed to create temporary file for printing options"
+msgstr "Failed to create temporary file for printing options"
+
+#: ../src/common/cups_print.c:508
+#, c-format
+msgid "printing on `%s' cancelled"
+msgstr "Printing on `%s' cancelled"
+
+#: ../src/common/cups_print.c:572
+#, c-format
+msgid "error while printing `%s' on `%s'"
+msgstr "Error while printing `%s' on `%s'"
+
+#: ../src/common/cups_print.c:574
+#, c-format
+msgid "printing `%s' on `%s'"
+msgstr "Printing `%s' on `%s'"
+
+#: ../src/common/darktable.c:244
+#, c-format
+msgid "found strange path `%s'"
+msgstr "Found strange path `%s'"
+
+#: ../src/common/darktable.c:259
+#, c-format
+msgid "error loading directory `%s'"
+msgstr "Error loading directory `%s'"
+
+#: ../src/common/darktable.c:282
+#, c-format
+msgid "file `%s' has unknown format!"
+msgstr "File `%s' has unknown format!"
+
+#: ../src/common/darktable.c:295 ../src/control/jobs/control_jobs.c:2090
+#: ../src/control/jobs/control_jobs.c:2149
+#, c-format
+msgid "error loading file `%s'"
+msgstr "Error loading file `%s'"
+
+#: ../src/common/darktable.c:1463
+msgid "configuration information"
+msgstr "Configuration information"
+
+#: ../src/common/darktable.c:1465
+msgid "show this information again"
+msgstr "Show this information again"
+
+#: ../src/common/darktable.c:1465
+msgid "understood"
+msgstr "Understood"
+
+#: ../src/common/darktable.c:1885
+msgid ""
+"the RCD demosaicer has been defined as default instead of PPG because of "
+"better quality and performance."
+msgstr ""
+"The RCD demosaicer has been defined as default instead of PPG because of "
+"better quality and performance."
+
+#: ../src/common/darktable.c:1887
+msgid "see preferences/darkroom/demosaicing for zoomed out darkroom mode"
+msgstr "See Preferences/Darkroom/Demosaicing for zoomed out Darkroom mode"
+
+#: ../src/common/darktable.c:1893
+msgid ""
+"the user interface and the underlying internals for tuning darktable "
+"performance have changed."
+msgstr ""
+"The user interface and the underlying internals for tuning Darktable "
+"performance have changed."
+
+#: ../src/common/darktable.c:1895
+msgid ""
+"you won't find headroom and friends any longer, instead in preferences/"
+"processing use:"
+msgstr ""
+"You won't find headroom and friends any longer, instead in Preferences/"
+"Processing use:"
+
+#: ../src/common/darktable.c:1897
+msgid "1) darktable resources"
+msgstr "1) Darktable resources"
+
+#: ../src/common/darktable.c:1899
+msgid "2) tune OpenCL performance"
+msgstr "2) Tune OpenCL performance"
+
+#: ../src/common/darktable.c:1906
+msgid ""
+"some global config parameters relevant for OpenCL performance are not used "
+"any longer."
+msgstr ""
+"Some global config parameters relevant for OpenCL performance are not used "
+"any longer."
+
+#: ../src/common/darktable.c:1908
+msgid ""
+"instead you will find 'per device' data in 'cl_device_v4_canonical-name'. "
+"content is:"
+msgstr ""
+"Instead you will find 'per device' data in 'cl_device_v4_canonical-name'. "
+"Content is:"
+
+#: ../src/common/darktable.c:1910
+msgid ""
+" 'avoid_atomics' 'micro_nap' 'pinned_memory' 'roundupwd' 'roundupht' "
+"'eventhandles' 'async' 'disable' 'magic'"
+msgstr ""
+" 'avoid_atomics' 'micro_nap' 'pinned_memory' 'roundupwd' 'roundupht' "
+"'eventhandles' 'async' 'disable' 'magic'"
+
+#: ../src/common/darktable.c:1912
+msgid "you may tune as before except 'magic'"
+msgstr "You may tune as before except 'magic'"
+
+#: ../src/common/darktable.c:1918
+msgid ""
+"your OpenCL compiler settings for all devices have been reset to default."
+msgstr ""
+"Your OpenCL compiler settings for all devices have been reset to default."
+
+#: ../src/common/database.c:2756
+#, c-format
+msgid ""
+"\n"
+"  Sorry, darktable could not be started (database is locked)\n"
+"\n"
+"  How to solve this problem?\n"
+"\n"
+"  1 - If another darktable instance is already open, \n"
+"      click cancel and either use that instance or close it before "
+"attempting to rerun darktable \n"
+"      (process ID <i><b>%d</b></i> created the database locks)\n"
+"\n"
+"  2 - If you can't find a running instance of darktable, try restarting your "
+"session or your computer. \n"
+"      This will close all running programs and hopefully close the databases "
+"correctly. \n"
+"\n"
+"  3 - If you have done this or are certain that no other instances of "
+"darktable are running, \n"
+"      this probably means that the last instance was ended abnormally. \n"
+"      Click on the \"delete database lock files\" button to remove the files "
+"<i>data.db.lock</i> and <i>library.db.lock</i>.  \n"
+"\n"
+"\n"
+"      <i><u>Caution!</u> Do not delete these files without first undertaking "
+"the above checks, \n"
+"      otherwise you risk generating serious inconsistencies in your database."
+"</i>\n"
+msgstr ""
+"\n"
+"  Sorry, Darktable could not be started (database is locked)\n"
+"\n"
+"  How to solve this problem?\n"
+"\n"
+"  1 - If another Darktable instance is already open, \n"
+"      click Cancel and either use that instance or close it before "
+"attempting to rerun Darktable \n"
+"      (process ID <i><b>%d</b></i> created the database locks)\n"
+"\n"
+"  2 - If you can't find a running instance of Darktable, try restarting your "
+"session or your computer. \n"
+"      This will close all running programs and hopefully close the databases "
+"correctly. \n"
+"\n"
+"  3 - If you have done this or are certain that no other instances of "
+"Darktable are running, \n"
+"      this probably means that the last instance was ended abnormally. \n"
+"      Click on the \"Delete database lock files\" button to remove the files "
+"<i>data.db.lock</i> and <i>library.db.lock</i>.  \n"
+"\n"
+"\n"
+"      <i><u>Caution!</u> Do not delete these files without first undertaking "
+"the above checks, \n"
+"      otherwise you risk generating serious inconsistencies in your database."
+"</i>\n"
+
+#. clang-format on
+#: ../src/common/database.c:2777
+msgid "error starting darktable"
+msgstr "Error starting Darktable"
+
+#: ../src/common/database.c:2778 ../src/libs/collect.c:2995
+#: ../src/libs/export_metadata.c:288 ../src/libs/import.c:1703
+#: ../src/libs/metadata.c:574 ../src/libs/metadata_view.c:1193
+#: ../src/libs/recentcollect.c:295 ../src/libs/modulegroups.c:3466
+#: ../src/libs/styles.c:439 ../src/libs/styles.c:622 ../src/libs/tagging.c:1481
+#: ../src/libs/tagging.c:1569 ../src/libs/tagging.c:1650
+#: ../src/libs/tagging.c:1780 ../src/libs/tagging.c:2054
+#: ../src/libs/tagging.c:3471
+msgid "cancel"
+msgstr "Cancel"
+
+#: ../src/common/database.c:2778
+msgid "delete database lock files"
+msgstr "Delete database lock files"
+
+#: ../src/common/database.c:2784
+msgid "are you sure?"
+msgstr "Are you sure?"
+
+#: ../src/common/database.c:2785
+msgid ""
+"\n"
+"do you really want to delete the lock files?\n"
+msgstr ""
+"\n"
+"Do you really want to delete the lock files?\n"
+
+#: ../src/common/database.c:2785 ../src/common/variables.c:703
+#: ../src/develop/imageop_gui.c:210 ../src/imageio/format/pdf.c:636
+#: ../src/imageio/format/pdf.c:655 ../src/libs/export.c:1194
+#: ../src/libs/export.c:1201 ../src/libs/export.c:1208
+#: ../src/libs/metadata_view.c:678
+msgid "yes"
+msgstr "Yes"
+
+#: ../src/common/database.c:2801 ../src/libs/export_metadata.c:164
+#: ../src/libs/geotagging.c:812
+msgid "done"
+msgstr "Done"
+
+#: ../src/common/database.c:2802
+msgid ""
+"\n"
+"successfully deleted the lock files.\n"
+"you can now restart darktable\n"
+msgstr ""
+"\n"
+"Successfully deleted the lock files.\n"
+"You can now restart Darktable\n"
+
+#. the button to close the popup
+#: ../src/common/database.c:2803 ../src/common/database.c:2810
+#: ../src/libs/filters/filename.c:452
+msgid "ok"
+msgstr "OK"
+
+#: ../src/common/database.c:2806
+msgid "error"
+msgstr "Error"
+
+#: ../src/common/database.c:2807
+#, c-format
+msgid ""
+"\n"
+"at least one file could not be removed.\n"
+"you may try to manually delete the files <i>data.db.lock</i> and <i>library."
+"db.lock</i>\n"
+"in folder <a href=\"file:///%s\">%s</a>.\n"
+msgstr ""
+"\n"
+"At least one file could not be removed.\n"
+"You may try to manually delete the files <i>data.db.lock</i> and <i>library."
+"db.lock</i>\n"
+"in folder <a href=\"file:///%s\">%s</a>.\n"
+
+#: ../src/common/database.c:2924
+#, c-format
+msgid ""
+"the database lock file contains a pid that seems to be alive in your system: "
+"%d"
+msgstr ""
+"The database lock file contains a PID that seems to be alive in your system: "
+"%d"
+
+#: ../src/common/database.c:2931
+#, c-format
+msgid "the database lock file seems to be empty"
+msgstr "The database lock file seems to be empty"
+
+#: ../src/common/database.c:2941
+#, c-format
+msgid "error opening the database lock file for reading: %s"
+msgstr "Error opening the database lock file for reading: %s"
+
+#. the database has to be upgraded, let's ask user
+#: ../src/common/database.c:2978
+#, c-format
+msgid ""
+"the database schema has to be upgraded for\n"
+"\n"
+"<span style='italic'>%s</span>\n"
+"\n"
+"this might take a long time in case of a large database\n"
+"\n"
+"do you want to proceed or quit now to do a backup\n"
+msgstr ""
+"The database schema has to be upgraded for\n"
+"\n"
+"<span style='italic'>%s</span>\n"
+"\n"
+"This might take a long time in case of a large database\n"
+"\n"
+"Do you want to proceed or quit now to do a backup\n"
+
+#: ../src/common/database.c:2986
+msgid "darktable - schema migration"
+msgstr "Darktable - schema migration"
+
+#: ../src/common/database.c:2987 ../src/common/database.c:3306
+#: ../src/common/database.c:3324 ../src/common/database.c:3491
+#: ../src/common/database.c:3509
+msgid "close darktable"
+msgstr "Close Darktable"
+
+#: ../src/common/database.c:2987
+msgid "upgrade database"
+msgstr "Upgrade database"
+
+#: ../src/common/database.c:3286 ../src/common/database.c:3471
+#, c-format
+msgid ""
+"quick_check said:\n"
+"%s \n"
+msgstr ""
+"Quick_check said:\n"
+"%s \n"
+
+#: ../src/common/database.c:3303 ../src/common/database.c:3321
+#: ../src/common/database.c:3488 ../src/common/database.c:3506
+msgid "darktable - error opening database"
+msgstr "Darktable - error opening database"
+
+#: ../src/common/database.c:3308 ../src/common/database.c:3493
+msgid "attempt restore"
+msgstr "Attempt restore"
+
+#: ../src/common/database.c:3310 ../src/common/database.c:3326
+#: ../src/common/database.c:3495 ../src/common/database.c:3511
+msgid "delete database"
+msgstr "Delete database"
+
+#: ../src/common/database.c:3314 ../src/common/database.c:3499
+msgid ""
+"do you want to close darktable now to manually restore\n"
+"the database from a backup, attempt an automatic restore\n"
+"from the most recent snapshot or delete the corrupted database\n"
+"and start with a new one?"
+msgstr ""
+"Do you want to close Darktable now to manually restore\n"
+"the database from a backup, attempt an automatic restore\n"
+"from the most recent snapshot or delete the corrupted database\n"
+"and start with a new one?"
+
+#: ../src/common/database.c:3330 ../src/common/database.c:3515
+msgid ""
+"do you want to close darktable now to manually restore\n"
+"the database from a backup or delete the corrupted database\n"
+"and start with a new one?"
+msgstr ""
+"Do you want to close Darktable now to manually restore\n"
+"the database from a backup or delete the corrupted database\n"
+"and start with a new one?"
+
+#: ../src/common/database.c:3337 ../src/common/database.c:3520
+#, c-format
+msgid ""
+"an error has occurred while trying to open the database from\n"
+"\n"
+"<span style='italic'>%s</span>\n"
+"\n"
+"it seems that the database is corrupted.\n"
+"%s%s"
+msgstr ""
+"An error has occurred while trying to open the database from\n"
+"\n"
+"<span style='italic'>%s</span>\n"
+"\n"
+"It seems that the database is corrupted.\n"
+"%s%s"
+
+#: ../src/common/eigf.h:288
+msgid ""
+"fast exposure independent guided filter failed to allocate memory, check "
+"your RAM settings"
+msgstr ""
+"Fast exposure independent guided filter failed to allocate memory, check "
+"your RAM settings"
+
+#: ../src/common/exif.cc:5106
+#, c-format
+msgid "cannot read XMP file '%s': '%s'"
+msgstr "Cannot read XMP file '%s': '%s'"
+
+#: ../src/common/exif.cc:5160
+#, c-format
+msgid "cannot write XMP file '%s': '%s'"
+msgstr "Cannot write XMP file '%s': '%s'"
+
+#: ../src/common/fast_guided_filter.h:316
+msgid "fast guided filter failed to allocate memory, check your RAM settings"
+msgstr "Fast guided filter failed to allocate memory, check your RAM settings"
+
+#: ../src/common/film.c:345
+msgid "do you want to remove this empty directory?"
+msgid_plural "do you want to remove these empty directories?"
+msgstr[0] "Do you want to remove this empty directory?"
+msgstr[1] "Do you want to remove these empty directories?"
+
+#: ../src/common/film.c:352
+msgid "remove empty directory?"
+msgid_plural "remove empty directories?"
+msgstr[0] "Remove empty directory?"
+msgstr[1] "Remove empty directories?"
+
+#: ../src/common/film.c:371 ../src/gui/preferences.c:811
+#: ../src/gui/styles_dialog.c:546 ../src/libs/geotagging.c:830
+#: ../src/libs/import.c:1552
+msgid "name"
+msgstr "Name"
+
+#: ../src/common/film.c:477
+msgid ""
+"cannot remove film roll having local copies with non accessible originals"
+msgstr ""
+"Cannot remove film roll having local copies with non accessible originals"
+
+#: ../src/common/history.c:827
+msgid "you need to copy history from an image before you paste it onto another"
+msgstr ""
+"You need to copy history from an image before you paste it onto another"
+
+#: ../src/common/image.c:326
+msgid "orphaned image"
+msgstr "Orphaned image"
+
+#: ../src/common/image.c:621
+#, c-format
+msgid "geo-location undone for %d image"
+msgid_plural "geo-location undone for %d images"
+msgstr[0] "Geo-location undone for %d image"
+msgstr[1] "Geo-location undone for %d images"
+
+#: ../src/common/image.c:623
+#, c-format
+msgid "geo-location re-applied to %d image"
+msgid_plural "geo-location re-applied to %d images"
+msgstr[0] "Geo-location re-applied to %d image"
+msgstr[1] "Geo-location re-applied to %d images"
+
+#: ../src/common/image.c:646
+#, c-format
+msgid "date/time undone for %d image"
+msgid_plural "date/time undone for %d images"
+msgstr[0] "Date/time undone for %d image"
+msgstr[1] "Date/time undone for %d images"
+
+#: ../src/common/image.c:648
+#, c-format
+msgid "date/time re-applied to %d image"
+msgid_plural "date/time re-applied to %d images"
+msgstr[0] "Date/time re-applied to %d image"
+msgstr[1] "Date/time re-applied to %d images"
+
+#: ../src/common/image.c:2188
+#, c-format
+msgid "cannot access local copy `%s'"
+msgstr "Cannot access local copy `%s'"
+
+#: ../src/common/image.c:2195
+#, c-format
+msgid "cannot write local copy `%s'"
+msgstr "Cannot write local copy `%s'"
+
+#: ../src/common/image.c:2202
+#, c-format
+msgid "error moving local copy `%s' -> `%s'"
+msgstr "Error moving local copy `%s' -> `%s'"
+
+#: ../src/common/image.c:2219
+#, c-format
+msgid "error moving `%s': file not found"
+msgstr "Error moving `%s': file not found"
+
+#: ../src/common/image.c:2229
+#, c-format
+msgid "error moving `%s' -> `%s': file exists"
+msgstr "Error moving `%s' -> `%s': file exists"
+
+#: ../src/common/image.c:2233
+#, c-format
+msgid "error moving `%s' -> `%s'"
+msgstr "Error moving `%s' -> `%s'"
+
+#: ../src/common/image.c:2561
+msgid "cannot create local copy when the original file is not accessible."
+msgstr "Cannot create local copy when the original file is not accessible."
+
+#: ../src/common/image.c:2575
+msgid "cannot create local copy."
+msgstr "Cannot create local copy."
+
+#: ../src/common/image.c:2655 ../src/control/jobs/control_jobs.c:777
+msgid "cannot remove local copy when the original file is not accessible."
+msgstr "Cannot remove local copy when the original file is not accessible."
+
+#: ../src/common/image.c:2820
+#, c-format
+msgid "%d local copy has been synchronized"
+msgid_plural "%d local copies have been synchronized"
+msgstr[0] "%d local copy has been synchronized"
+msgstr[1] "%d local copies have been synchronized"
+
+#: ../src/common/image.c:3022
+msgid "<b>WARNING</b>: camera is missing samples!"
+msgstr "<b>WARNING</b>: camera is missing samples!"
+
+#: ../src/common/image.c:3023
+msgid ""
+"You must provide samples in <a href='https://raw.pixls.us/'>https://raw."
+"pixls.us/</a>"
+msgstr ""
+"You must provide samples in <a href='https://raw.pixls.us/'>https://raw."
+"pixls.us/</a>"
+
+#: ../src/common/image.c:3024
+#, c-format
+msgid ""
+"for `%s' `%s'\n"
+"in as many format/compression/bit depths as possible"
+msgstr ""
+"for `%s' `%s'\n"
+"in as many format/compression/bit depths as possible"
+
+#: ../src/common/image.c:3027
+msgid "or the <b>RAW won't be readable</b> in next version."
+msgstr "or the <b>RAW won't be readable</b> in next version."
+
+#: ../src/common/image.h:207 ../src/common/ratings.c:284
+#: ../src/libs/history.c:855 ../src/libs/snapshots.c:780
+msgid "unknown"
+msgstr "Unknown"
+
+#. EMPTY_FIELD
+#: ../src/common/image.h:208
+msgid "tiff"
+msgstr "Tiff"
+
+#: ../src/common/image.h:209
+msgid "png"
+msgstr "Png"
+
+#: ../src/common/image.h:210 ../src/imageio/format/j2k.c:652
+msgid "j2k"
+msgstr "J2k"
+
+#: ../src/common/image.h:211
+msgid "jpeg"
+msgstr "Jpeg"
+
+#: ../src/common/image.h:212
+msgid "exr"
+msgstr "Exr"
+
+#: ../src/common/image.h:213
+msgid "rgbe"
+msgstr "Rgbe"
+
+#: ../src/common/image.h:214
+msgid "pfm"
+msgstr "Pfm"
+
+#: ../src/common/image.h:215
+msgid "GraphicsMagick"
+msgstr "GraphicsMagick"
+
+#: ../src/common/image.h:216
+msgid "rawspeed"
+msgstr "Rawspeed"
+
+#: ../src/common/image.h:217
+msgid "netpnm"
+msgstr "Netpnm"
+
+#: ../src/common/image.h:218
+msgid "avif"
+msgstr "Avif"
+
+#: ../src/common/image.h:219
+msgid "ImageMagick"
+msgstr "ImageMagick"
+
+#: ../src/common/image.h:220
+msgid "heif"
+msgstr "Heif"
+
+#: ../src/common/image.h:221
+msgid "libraw"
+msgstr "Libraw"
+
+#: ../src/common/image.h:222
+msgid "webp"
+msgstr "WebP"
+
+#: ../src/common/image.h:223
+msgid "jpeg xl"
+msgstr "JPEG XL"
+
+#: ../src/common/image.h:224
+msgid "QOI"
+msgstr "QOI"
+
+#: ../src/common/imagebuf.c:131
+msgid "insufficient memory"
+msgstr "Insufficient memory"
+
+#: ../src/common/imagebuf.c:132
+msgid ""
+"this module was unable to allocate\n"
+"all of the memory required to process\n"
+"the image.  some or all processing\n"
+"has been skipped."
+msgstr ""
+"This module was unable to allocate\n"
+"all of the memory required to process\n"
+"the image. Some or all processing\n"
+"has been skipped."
+
+#: ../src/common/import_session.c:308
+msgid ""
+"couldn't expand to a unique filename for session, please check your import "
+"session settings."
+msgstr ""
+"Couldn't expand to a unique filename for session, please check your import "
+"session settings."
+
+#: ../src/common/import_session.c:401
+msgid "requested session path not available. device not mounted?"
+msgstr "Requested session path not available. Device not mounted?"
+
+#: ../src/common/iop_order.c:59 ../src/libs/ioporder.c:198
+msgid "legacy"
+msgstr "Legacy"
+
+#: ../src/common/iop_order.c:60
+msgid "v3.0 RAW"
+msgstr "V3.0 RAW"
+
+#: ../src/common/iop_order.c:61
+msgid "v3.0 JPEG"
+msgstr "V3.0 JPEG"
+
+#. clang-format off
+#: ../src/common/metadata.c:46
+msgid "creator"
+msgstr "Creator"
+
+#: ../src/common/metadata.c:47
+msgid "publisher"
+msgstr "Publisher"
+
+#. title
+#: ../src/common/metadata.c:48 ../src/imageio/format/pdf.c:574
+#: ../src/imageio/format/pdf.c:576 ../src/imageio/storage/gallery.c:169
+#: ../src/imageio/storage/gallery.c:170 ../src/imageio/storage/latex.c:169
+#: ../src/imageio/storage/piwigo.c:1008 ../src/libs/filtering.c:69
+msgid "title"
+msgstr "Title"
+
+#: ../src/common/metadata.c:49 ../src/gui/styles_dialog.c:550
+#: ../src/libs/filtering.c:70
+msgid "description"
+msgstr "Description"
+
+#: ../src/common/metadata.c:50
+msgid "rights"
+msgstr "Rights"
+
+#: ../src/common/metadata.c:51
+msgid "notes"
+msgstr "Notes"
+
+#: ../src/common/metadata.c:52
+msgid "version name"
+msgstr "Version name"
+
+#: ../src/common/metadata.c:53 ../src/libs/live_view.c:320
+#: ../src/libs/metadata_view.c:124
+msgid "image id"
+msgstr "Image id"
+
+#: ../src/common/mipmap_cache.c:1065 ../src/imageio/imageio.c:727
+#, c-format
+msgid "image `%s' is not available!"
+msgstr "Image `%s' is not available!"
+
+#: ../src/common/noiseprofiles.c:26
+msgid "generic poissonian"
+msgstr "Generic poissonian"
+
+#: ../src/common/noiseprofiles.c:61
+#, c-format
+msgid "noiseprofile file `%s' is not valid"
+msgstr "Noiseprofile file `%s' is not valid"
+
+#: ../src/common/opencl.c:1344
+#, c-format
+msgid ""
+"OpenCL initializing problem:\n"
+"%s"
+msgstr ""
+"OpenCL initializing problem:\n"
+"%s"
+
+#: ../src/common/opencl.c:1407
+msgid ""
+"due to a slow GPU hardware acceleration using OpenCL has been deactivated"
+msgstr ""
+"Due to a slow GPU hardware acceleration using OpenCL has been deactivated"
+
+#: ../src/common/opencl.c:1417
+msgid ""
+"multiple GPUs detected - OpenCL scheduling profile has been set accordingly"
+msgstr ""
+"Multiple GPUs detected - OpenCL scheduling profile has been set accordingly"
+
+#: ../src/common/opencl.c:1430
+msgid ""
+"very fast GPU detected - OpenCL scheduling profile has been set accordingly"
+msgstr ""
+"Very fast GPU detected - OpenCL scheduling profile has been set accordingly"
+
+#: ../src/common/opencl.c:1439
+msgid "OpenCL scheduling profile set to default"
+msgstr "OpenCL scheduling profile set to default"
+
+#: ../src/common/pdf.h:88 ../src/iop/lens.cc:3090
+#: ../src/libs/filters/focal.c:74 ../src/libs/print_settings.c:83
+msgid "mm"
+msgstr "mm"
+
+#: ../src/common/pdf.h:89 ../src/libs/export.c:525 ../src/libs/export.c:1151
+#: ../src/libs/print_settings.c:83
+msgid "cm"
+msgstr "cm"
+
+#: ../src/common/pdf.h:90 ../src/libs/print_settings.c:83
+msgid "inch"
+msgstr "inch"
+
+#: ../src/common/pdf.h:91
+msgid "\""
+msgstr "\""
+
+#: ../src/common/pdf.h:104 ../src/iop/borders.c:947
+msgid "A4"
+msgstr "A4"
+
+#: ../src/common/pdf.h:105
+msgid "A3"
+msgstr "A3"
+
+#: ../src/common/pdf.h:106
+msgid "Letter"
+msgstr "Letter"
+
+#: ../src/common/pdf.h:107
+msgid "Legal"
+msgstr "Legal"
+
+#: ../src/common/pwstorage/pwstorage.c:85
+msgid "GNOME Keyring backend is no longer supported. configure a different one"
+msgstr ""
+"GNOME Keyring backend is no longer supported. Configure a different one"
+
+#: ../src/common/ratings.c:205
+#, c-format
+msgid "rejecting %d image"
+msgid_plural "rejecting %d images"
+msgstr[0] "Rejecting %d image"
+msgstr[1] "Rejecting %d images"
+
+#: ../src/common/ratings.c:207
+#, c-format
+msgid "applying rating %d to %d image"
+msgid_plural "applying rating %d to %d images"
+msgstr[0] "Applying rating %d to %d image"
+msgstr[1] "Applying rating %d to %d images"
+
+#: ../src/common/ratings.c:221
+msgid "no images selected to apply rating"
+msgstr "No images selected to apply rating"
+
+#: ../src/common/ratings.c:275 ../src/libs/metadata_view.c:353
+msgid "image rejected"
+msgstr "Image rejected"
+
+#: ../src/common/ratings.c:277
+msgid "image rated to 0 star"
+msgstr "Image rated to 0 star"
+
+#: ../src/common/ratings.c:279
+#, c-format
+msgid "image rated to %s"
+msgstr "Image rated to %s"
+
+#: ../src/common/ratings.c:306 ../src/libs/select.c:39
+#: ../src/views/lighttable.c:766
+msgid "select"
+msgstr "Select"
+
+#: ../src/common/ratings.c:307
+msgid "upgrade"
+msgstr "Upgrade"
+
+#: ../src/common/ratings.c:308
+msgid "downgrade"
+msgstr "Downgrade"
+
+#: ../src/common/ratings.c:312
+msgid "zero"
+msgstr "Zero"
+
+#: ../src/common/ratings.c:313 ../src/libs/filters/rating_range.c:277
+msgid "one"
+msgstr "One"
+
+#: ../src/common/ratings.c:314 ../src/libs/filters/rating_range.c:278
+msgid "two"
+msgstr "Two"
+
+#: ../src/common/ratings.c:315 ../src/libs/filters/rating_range.c:279
+msgid "three"
+msgstr "Three"
+
+#: ../src/common/ratings.c:316 ../src/libs/filters/rating_range.c:280
+msgid "four"
+msgstr "Four"
+
+#: ../src/common/ratings.c:317 ../src/libs/filters/rating_range.c:281
+msgid "five"
+msgstr "Five"
+
+#: ../src/common/ratings.c:318
+msgid "reject"
+msgstr "Reject"
+
+#: ../src/common/styles.c:244
+#, c-format
+msgid "style with name '%s' already exists"
+msgstr "Style with name '%s' already exists"
+
+#: ../src/common/styles.c:270 ../src/common/styles.c:1773
+#: ../src/libs/styles.c:54
+msgid "styles"
+msgstr "Styles"
+
+#: ../src/common/styles.c:548 ../src/gui/styles_dialog.c:239
+#, c-format
+msgid "style named '%s' successfully created"
+msgstr "Style named '%s' successfully created"
+
+#: ../src/common/styles.c:689 ../src/common/styles.c:719
+#: ../src/common/styles.c:759 ../src/dtgtk/culling.c:994
+msgid "no image selected!"
+msgstr "No images selected!"
+
+#: ../src/common/styles.c:693
+#, c-format
+msgid "style %s successfully applied!"
+msgstr "Style %s successfully applied!"
+
+#: ../src/common/styles.c:709
+msgid "no images nor styles selected!"
+msgstr "No images nor styles selected!"
+
+#: ../src/common/styles.c:714
+msgid "no styles selected!"
+msgstr "No styles selected!"
+
+#: ../src/common/styles.c:744
+msgid "style successfully applied!"
+msgid_plural "styles successfully applied!"
+msgstr[0] "Style successfully applied!"
+msgstr[1] "Styles successfully applied!"
+
+#: ../src/common/styles.c:840
+#, c-format
+msgid "module `%s' version mismatch: %d != %d"
+msgstr "Module `%s' version mismatch: %d != %d"
+
+#: ../src/common/styles.c:1121
+#, c-format
+msgid "applied style `%s' on current image"
+msgstr "Applied style `%s' on current image"
+
+#: ../src/common/styles.c:1375
+#, c-format
+msgid "failed to overwrite style file for %s"
+msgstr "Failed to overwrite style file for %s"
+
+#: ../src/common/styles.c:1381
+#, c-format
+msgid "style file for %s exists"
+msgstr "Style file for %s exists"
+
+#: ../src/common/styles.c:1664
+#, c-format
+msgid "style %s was successfully imported"
+msgstr "Style %s was successfully imported"
+
+#. Failed to open file, clean up.
+#: ../src/common/styles.c:1708
+#, c-format
+msgid "could not read file `%s'"
+msgstr "Could not read file `%s'"
+
+#: ../src/common/utility.c:505
+msgid "above sea level"
+msgstr "Above sea level"
+
+#: ../src/common/utility.c:506
+msgid "below sea level"
+msgstr "Below sea level"
+
+#: ../src/common/utility.c:557 ../src/libs/metadata_view.c:882
+msgid "m"
+msgstr "m"
+
+#: ../src/control/control.c:66 ../src/gui/accelerators.c:138
+#: ../src/views/darkroom.c:2144
+msgid "hold"
+msgstr "Hold"
+
+#: ../src/control/control.c:102 ../src/control/control.c:207
+msgid "modifiers"
+msgstr "Modifiers"
+
+#: ../src/control/control.c:111
+msgctxt "accel"
+msgid "global"
+msgstr "Global"
+
+#: ../src/control/control.c:118
+msgctxt "accel"
+msgid "views"
+msgstr "Views"
+
+#: ../src/control/control.c:125
+msgctxt "accel"
+msgid "thumbtable"
+msgstr "Thumbtable"
+
+#: ../src/control/control.c:132
+msgctxt "accel"
+msgid "utility modules"
+msgstr "Utility modules"
+
+#: ../src/control/control.c:139
+msgctxt "accel"
+msgid "format"
+msgstr "Format"
+
+#: ../src/control/control.c:146
+msgctxt "accel"
+msgid "storage"
+msgstr "Storage"
+
+#: ../src/control/control.c:153
+msgctxt "accel"
+msgid "processing modules"
+msgstr "Processing modules"
+
+#: ../src/control/control.c:160
+msgctxt "accel"
+msgid "<blending>"
+msgstr "<blending>"
+
+#: ../src/control/control.c:167
+msgctxt "accel"
+msgid "lua scripts"
+msgstr "Lua scripts"
+
+#: ../src/control/control.c:174
+msgctxt "accel"
+msgid "fallbacks"
+msgstr "Fallbacks"
+
+#: ../src/control/control.c:183
+msgctxt "accel"
+msgid "<focused>"
+msgstr "<focused>"
+
+#: ../src/control/control.c:204
+msgid "show accels window"
+msgstr "Show accels window"
+
+#: ../src/control/control.c:365
+msgid "working..."
+msgstr "Working..."
+
+#: ../src/control/crawler.c:425
+#, c-format
+msgid "ERROR: %s NOT synced XMP → DB"
+msgstr "ERROR: %s NOT synced XMP → DB"
+
+#: ../src/control/crawler.c:426 ../src/control/crawler.c:492
+#: ../src/control/crawler.c:561
+msgid ""
+"ERROR: cannot write the database. the destination may be full, offline or "
+"read-only."
+msgstr ""
+"ERROR: cannot write the database. The destination may be full, offline or "
+"read-only."
+
+#: ../src/control/crawler.c:433
+#, c-format
+msgid "SUCCESS: %s synced XMP → DB"
+msgstr "SUCCESS: %s synced XMP → DB"
+
+#: ../src/control/crawler.c:455
+#, c-format
+msgid "ERROR: %s NOT synced DB → XMP"
+msgstr "ERROR: %s NOT synced DB → XMP"
+
+#: ../src/control/crawler.c:457 ../src/control/crawler.c:516
+#: ../src/control/crawler.c:582
+#, c-format
+msgid ""
+"ERROR: cannot write %s \n"
+"the destination may be full, offline or read-only."
+msgstr ""
+"ERROR: cannot write %s \n"
+"The destination may be full, offline or read-only."
+
+#: ../src/control/crawler.c:463
+#, c-format
+msgid "SUCCESS: %s synced DB → XMP"
+msgstr "SUCCESS: %s synced DB → XMP"
+
+#: ../src/control/crawler.c:489
+#, c-format
+msgid "ERROR: %s NOT synced new (XMP) → old (DB)"
+msgstr "ERROR: %s NOT synced new (XMP) → old (DB)"
+
+#: ../src/control/crawler.c:499
+#, c-format
+msgid "SUCCESS: %s synced new (XMP) → old (DB)"
+msgstr "SUCCESS: %s synced new (XMP) → old (DB)"
+
+#: ../src/control/crawler.c:513
+#, c-format
+msgid "ERROR: %s NOT synced new (DB) → old (XMP)"
+msgstr "ERROR: %s NOT synced new (DB) → old (XMP)"
+
+#: ../src/control/crawler.c:521
+#, c-format
+msgid "SUCCESS: %s synced new (DB) → old (XMP)"
+msgstr "SUCCESS: %s synced new (DB) → old (XMP)"
+
+#: ../src/control/crawler.c:530 ../src/control/crawler.c:598
+#, c-format
+msgid "EXCEPTION: %s has inconsistent timestamps"
+msgstr "EXCEPTION: %s has inconsistent timestamps"
+
+#: ../src/control/crawler.c:558
+#, c-format
+msgid "ERROR: %s NOT synced old (XMP) → new (DB)"
+msgstr "ERROR: %s NOT synced old (XMP) → new (DB)"
+
+#: ../src/control/crawler.c:567
+#, c-format
+msgid "SUCCESS: %s synced old (XMP) → new (DB)"
+msgstr "SUCCESS: %s synced old (XMP) → new (DB)"
+
+#: ../src/control/crawler.c:579
+#, c-format
+msgid "ERROR: %s NOT synced old (DB) → new (XMP)"
+msgstr "ERROR: %s NOT synced old (DB) → new (XMP)"
+
+#: ../src/control/crawler.c:588
+#, c-format
+msgid "SUCCESS: %s synced old (DB) → new (XMP)"
+msgstr "SUCCESS: %s synced old (DB) → new (XMP)"
+
+#: ../src/control/crawler.c:670
+#, c-format
+msgid "%id %02dh %02dm %02ds"
+msgstr "%id %02dh %02dm %02ds"
+
+#: ../src/control/crawler.c:740 ../src/imageio/storage/disk.c:168
+#: ../src/imageio/storage/gallery.c:154 ../src/imageio/storage/latex.c:153
+#: ../src/imageio/storage/latex.c:171
+msgid "path"
+msgstr "Path"
+
+#: ../src/control/crawler.c:749
+msgid "XMP timestamp"
+msgstr "XMP timestamp"
+
+#: ../src/control/crawler.c:754
+msgid "database timestamp"
+msgstr "Database timestamp"
+
+#: ../src/control/crawler.c:759
+msgid "newest"
+msgstr "Newest"
+
+#: ../src/control/crawler.c:765
+msgid "time difference"
+msgstr "Time difference"
+
+#: ../src/control/crawler.c:777
+msgid "updated XMP sidecar files found"
+msgstr "Updated XMP sidecar files found"
+
+#: ../src/control/crawler.c:778
+msgid "_close"
+msgstr "_Close"
+
+#. setup selection accelerators
+#. action-box
+#: ../src/control/crawler.c:793 ../src/dtgtk/thumbtable.c:2344
+#: ../src/libs/import.c:1722 ../src/libs/select.c:133
+msgid "select all"
+msgstr "Select all"
+
+#: ../src/control/crawler.c:794 ../src/dtgtk/thumbtable.c:2345
+#: ../src/libs/import.c:1726 ../src/libs/select.c:137
+msgid "select none"
+msgstr "Select none"
+
+#: ../src/control/crawler.c:795 ../src/dtgtk/thumbtable.c:2346
+#: ../src/libs/select.c:141
+msgid "invert selection"
+msgstr "Invert selection"
+
+#: ../src/control/crawler.c:807
+msgid "on the selection:"
+msgstr "On the selection:"
+
+#: ../src/control/crawler.c:808
+msgid "keep the XMP edit"
+msgstr "Keep the XMP edit"
+
+#: ../src/control/crawler.c:809
+msgid "keep the database edit"
+msgstr "Keep the database edit"
+
+#: ../src/control/crawler.c:810
+msgid "keep the newest edit"
+msgstr "Keep the newest edit"
+
+#: ../src/control/crawler.c:811
+msgid "keep the oldest edit"
+msgstr "Keep the oldest edit"
+
+#: ../src/control/crawler.c:836
+msgid "synchronization log"
+msgstr "Synchronization log"
+
+#: ../src/control/jobs/camera_jobs.c:80
+#, c-format
+msgid "capturing %d image"
+msgid_plural "capturing %d images"
+msgstr[0] "Capturing %d image"
+msgstr[1] "Capturing %d images"
+
+#: ../src/control/jobs/camera_jobs.c:114
+msgid "please set your camera to manual mode first!"
+msgstr "Please set your camera to manual mode first!"
+
+#: ../src/control/jobs/camera_jobs.c:211
+msgid "capture images"
+msgstr "Capture images"
+
+#: ../src/control/jobs/camera_jobs.c:245
+#, c-format
+msgid "%d/%d imported to %s"
+msgid_plural "%d/%d imported to %s"
+msgstr[0] "%d/%d imported to %s"
+msgstr[1] "%d/%d imported to %s"
+
+#: ../src/control/jobs/camera_jobs.c:298
+msgid "starting to import images from camera"
+msgstr "Starting to import images from camera"
+
+#: ../src/control/jobs/camera_jobs.c:309
+#, c-format
+msgid "importing %d image from camera"
+msgid_plural "importing %d images from camera"
+msgstr[0] "Importing %d image from camera"
+msgstr[1] "Importing %d images from camera"
+
+#: ../src/control/jobs/camera_jobs.c:369
+msgid "import images from camera"
+msgstr "Import images from camera"
+
+#: ../src/control/jobs/control_jobs.c:145
+msgid "failed to create film roll for destination directory, aborting move.."
+msgstr "Failed to create film roll for destination directory, aborting move.."
+
+#: ../src/control/jobs/control_jobs.c:388
+msgid "exposure bracketing only works on raw images."
+msgstr "Exposure bracketing only works on raw images."
+
+#: ../src/control/jobs/control_jobs.c:395
+msgid "images have to be of same size and orientation!"
+msgstr "Images have to be of same size and orientation!"
+
+#: ../src/control/jobs/control_jobs.c:490
+#, c-format
+msgid "merging %d image"
+msgid_plural "merging %d images"
+msgstr[0] "Merging %d image"
+msgstr[1] "Merging %d images"
+
+#: ../src/control/jobs/control_jobs.c:561
+#, c-format
+msgid "wrote merged HDR `%s'"
+msgstr "Wrote merged HDR `%s'"
+
+#: ../src/control/jobs/control_jobs.c:593
+#, c-format
+msgid "duplicating %d image"
+msgid_plural "duplicating %d images"
+msgstr[0] "Duplicating %d image"
+msgstr[1] "Duplicating %d images"
+
+#: ../src/control/jobs/control_jobs.c:634
+#, c-format
+msgid "flipping %d image"
+msgid_plural "flipping %d images"
+msgstr[0] "Flipping %d image"
+msgstr[1] "Flipping %d images"
+
+#: ../src/control/jobs/control_jobs.c:665
+#, c-format
+msgid "set %d color image"
+msgid_plural "setting %d color images"
+msgstr[0] "Set %d color image"
+msgstr[1] "Setting %d color images"
+
+#: ../src/control/jobs/control_jobs.c:667
+#, c-format
+msgid "set %d monochrome image"
+msgid_plural "setting %d monochrome images"
+msgstr[0] "Set %d monochrome image"
+msgstr[1] "Setting %d monochrome images"
+
+#: ../src/control/jobs/control_jobs.c:753
+#, c-format
+msgid "removing %d image"
+msgid_plural "removing %d images"
+msgstr[0] "Removing %d image"
+msgstr[1] "Removing %d images"
+
+#: ../src/control/jobs/control_jobs.c:857
+#, c-format
+msgid "could not send %s to trash%s%s"
+msgstr "Could not send %s to trash%s%s"
+
+#: ../src/control/jobs/control_jobs.c:858
+#, c-format
+msgid "could not physically delete %s%s%s"
+msgstr "Could not physically delete %s%s%s"
+
+#: ../src/control/jobs/control_jobs.c:868
+msgid "physically delete"
+msgstr "Physically delete"
+
+#: ../src/control/jobs/control_jobs.c:869
+msgid "physically delete all files"
+msgstr "Physically delete all files"
+
+#: ../src/control/jobs/control_jobs.c:871
+msgid "only remove from the image library"
+msgstr "Only remove from the image library"
+
+#: ../src/control/jobs/control_jobs.c:872
+msgid "skip to next file"
+msgstr "Skip to next file"
+
+#: ../src/control/jobs/control_jobs.c:873
+msgid "stop process"
+msgstr "Stop process"
+
+#: ../src/control/jobs/control_jobs.c:878
+msgid "trashing error"
+msgstr "Trashing error"
+
+#: ../src/control/jobs/control_jobs.c:879
+msgid "deletion error"
+msgstr "Deletion error"
+
+#: ../src/control/jobs/control_jobs.c:1021
+#, c-format
+msgid "trashing %d image"
+msgid_plural "trashing %d images"
+msgstr[0] "Trashing %d image"
+msgstr[1] "Trashing %d images"
+
+#: ../src/control/jobs/control_jobs.c:1023
+#, c-format
+msgid "deleting %d image"
+msgid_plural "deleting %d images"
+msgstr[0] "Deleting %d image"
+msgstr[1] "Deleting %d images"
+
+#: ../src/control/jobs/control_jobs.c:1149
+msgid "failed to parse GPX file"
+msgstr "Failed to parse GPX file"
+
+#: ../src/control/jobs/control_jobs.c:1196
+#, c-format
+msgid "applied matched GPX location onto %d image"
+msgid_plural "applied matched GPX location onto %d images"
+msgstr[0] "Applied matched GPX location onto %d image"
+msgstr[1] "Applied matched GPX location onto %d images"
+
+#: ../src/control/jobs/control_jobs.c:1213
+#, c-format
+msgid "moving %d image"
+msgstr "Moving %d image"
+
+#: ../src/control/jobs/control_jobs.c:1214
+#, c-format
+msgid "moving %d images"
+msgstr "Moving %d images"
+
+#: ../src/control/jobs/control_jobs.c:1219
+#, c-format
+msgid "copying %d image"
+msgstr "Copying %d image"
+
+#: ../src/control/jobs/control_jobs.c:1220
+#, c-format
+msgid "copying %d images"
+msgstr "Copying %d images"
+
+#: ../src/control/jobs/control_jobs.c:1235
+#, c-format
+msgid "creating local copy of %d image"
+msgid_plural "creating local copies of %d images"
+msgstr[0] "Creating local copy of %d image"
+msgstr[1] "Creating local copies of %d images"
+
+#: ../src/control/jobs/control_jobs.c:1238
+#, c-format
+msgid "removing local copy of %d image"
+msgid_plural "removing local copies of %d images"
+msgstr[0] "Removing local copy of %d image"
+msgstr[1] "Removing local copies of %d images"
+
+#: ../src/control/jobs/control_jobs.c:1285
+#, c-format
+msgid "refreshing info for %d image"
+msgid_plural "refreshing info for %d images"
+msgstr[0] "Refreshing info for %d image"
+msgstr[1] "Refreshing info for %d images"
+
+#: ../src/control/jobs/control_jobs.c:1370
+#, c-format
+msgid "exporting %d image.."
+msgid_plural "exporting %d images.."
+msgstr[0] "Exporting %d image.."
+msgstr[1] "Exporting %d images.."
+
+#: ../src/control/jobs/control_jobs.c:1372
+msgid "no image to export"
+msgstr "No image to export"
+
+#: ../src/control/jobs/control_jobs.c:1410
+#, c-format
+msgid "exporting %d / %d to %s"
+msgstr "Exporting %d / %d to %s"
+
+#: ../src/control/jobs/control_jobs.c:1431 ../src/views/darkroom.c:792
+#: ../src/views/print.c:342
+#, c-format
+msgid "image `%s' is currently unavailable"
+msgstr "Image `%s' is currently unavailable"
+
+#: ../src/control/jobs/control_jobs.c:1523
+msgid "merge HDR image"
+msgstr "Merge HDR image"
+
+#: ../src/control/jobs/control_jobs.c:1537
+msgid "duplicate images"
+msgstr "Duplicate images"
+
+#: ../src/control/jobs/control_jobs.c:1543
+msgid "flip images"
+msgstr "Flip images"
+
+#: ../src/control/jobs/control_jobs.c:1550
+msgid "set monochrome images"
+msgstr "Set monochrome images"
+
+#. get all selected images now, to avoid the set changing during ui interaction
+#: ../src/control/jobs/control_jobs.c:1557
+msgid "remove images"
+msgstr "Remove images"
+
+#: ../src/control/jobs/control_jobs.c:1570
+msgid "remove image?"
+msgstr "Remove image?"
+
+#: ../src/control/jobs/control_jobs.c:1570
+msgid "remove images?"
+msgstr "Remove images?"
+
+#: ../src/control/jobs/control_jobs.c:1571
+#, c-format
+msgid ""
+"do you really want to remove %d image from darktable\n"
+"(without deleting file on disk)?"
+msgid_plural ""
+"do you really want to remove %d images from darktable\n"
+"(without deleting files on disk)?"
+msgstr[0] ""
+"Do you really want to remove %d image from Darktable\n"
+"(without deleting file on disk)?"
+msgstr[1] ""
+"Do you really want to remove %d images from Darktable\n"
+"(without deleting files on disk)?"
+
+#. first get all selected images, to avoid the set changing during ui interaction
+#: ../src/control/jobs/control_jobs.c:1586
+#: ../src/control/jobs/control_jobs.c:1619
+msgid "delete images"
+msgstr "Delete images"
+
+#: ../src/control/jobs/control_jobs.c:1602
+#: ../src/control/jobs/control_jobs.c:1632
+msgid "delete image?"
+msgstr "Delete image?"
+
+#: ../src/control/jobs/control_jobs.c:1602
+msgid "delete images?"
+msgstr "Delete images?"
+
+#: ../src/control/jobs/control_jobs.c:1603
+#, c-format
+msgid ""
+"do you really want to physically delete %d image\n"
+"(using trash if possible)?"
+msgid_plural ""
+"do you really want to physically delete %d images\n"
+"(using trash if possible)?"
+msgstr[0] ""
+"Do you really want to physically delete %d image\n"
+"(using trash if possible)?"
+msgstr[1] ""
+"Do you really want to physically delete %d images\n"
+"(using trash if possible)?"
+
+#: ../src/control/jobs/control_jobs.c:1605
+#, c-format
+msgid "do you really want to physically delete %d image from disk?"
+msgid_plural "do you really want to physically delete %d images from disk?"
+msgstr[0] "Do you really want to physically delete %d image from disk?"
+msgstr[1] "Do you really want to physically delete %d images from disk?"
+
+#: ../src/control/jobs/control_jobs.c:1633
+msgid ""
+"do you really want to physically delete selected image (using trash if "
+"possible)?"
+msgstr ""
+"Do you really want to physically delete selected image (using trash if "
+"possible)?"
+
+#: ../src/control/jobs/control_jobs.c:1634
+msgid "do you really want to physically delete selected image from disk?"
+msgstr "Do you really want to physically delete selected image from disk?"
+
+#: ../src/control/jobs/control_jobs.c:1649
+msgid "move images"
+msgstr "Move images"
+
+#: ../src/control/jobs/control_jobs.c:1661
+#: ../src/control/jobs/control_jobs.c:1715
+msgid "_select as destination"
+msgstr "_Select as destination"
+
+#: ../src/control/jobs/control_jobs.c:1680
+msgid "move image?"
+msgid_plural "move images?"
+msgstr[0] "Move image?"
+msgstr[1] "Move images?"
+
+#: ../src/control/jobs/control_jobs.c:1681
+#, c-format
+msgid ""
+"do you really want to physically move %d image to %s?\n"
+"(all duplicates will be moved along)"
+msgid_plural ""
+"do you really want to physically move %d images to %s?\n"
+"(all duplicates will be moved along)"
+msgstr[0] ""
+"Do you really want to physically move %d image to %s?\n"
+"(all duplicates will be moved along)"
+msgstr[1] ""
+"Do you really want to physically move %d images to %s?\n"
+"(all duplicates will be moved along)"
+
+#: ../src/control/jobs/control_jobs.c:1703
+msgid "copy images"
+msgstr "Copy images"
+
+#: ../src/control/jobs/control_jobs.c:1734
+msgid "copy image?"
+msgid_plural "copy images?"
+msgstr[0] "Copy image?"
+msgstr[1] "Copy images?"
+
+#: ../src/control/jobs/control_jobs.c:1735
+#, c-format
+msgid "do you really want to physically copy %d image to %s?"
+msgid_plural "do you really want to physically copy %d images to %s?"
+msgstr[0] "Do you really want to physically copy %d image to %s?"
+msgstr[1] "Do you really want to physically copy %d images to %s?"
+
+#: ../src/control/jobs/control_jobs.c:1753
+#: ../src/control/jobs/control_jobs.c:1761
+msgid "local copy images"
+msgstr "Local copy images"
+
+#: ../src/control/jobs/control_jobs.c:1768 ../src/libs/image.c:606
+msgid "refresh EXIF"
+msgstr "Refresh EXIF"
+
+#: ../src/control/jobs/control_jobs.c:1832
+#, c-format
+msgid "failed to get parameters from storage module `%s', aborting export.."
+msgstr "Failed to get parameters from storage module `%s', aborting export.."
+
+#: ../src/control/jobs/control_jobs.c:1848
+msgid "export images"
+msgstr "Export images"
+
+#: ../src/control/jobs/control_jobs.c:1898
+#, c-format
+msgid "adding time offset to %d image"
+msgstr "Adding time offset to %d image"
+
+#: ../src/control/jobs/control_jobs.c:1898
+#, c-format
+msgid "setting date/time of %d image"
+msgstr "Setting date/time of %d image"
+
+#: ../src/control/jobs/control_jobs.c:1899
+#, c-format
+msgid "adding time offset to %d images"
+msgstr "Adding time offset to %d images"
+
+#: ../src/control/jobs/control_jobs.c:1899
+#, c-format
+msgid "setting date/time of %d images"
+msgstr "Setting date/time of %d images"
+
+#: ../src/control/jobs/control_jobs.c:1944
+#, c-format
+msgid "added time offset to %d image"
+msgstr "Added time offset to %d image"
+
+#: ../src/control/jobs/control_jobs.c:1944
+#, c-format
+msgid "set date/time of %d image"
+msgstr "Set date/time of %d image"
+
+#: ../src/control/jobs/control_jobs.c:1945
+#, c-format
+msgid "added time offset to %d images"
+msgstr "Added time offset to %d images"
+
+#: ../src/control/jobs/control_jobs.c:1945
+#, c-format
+msgid "set date/time of %d images"
+msgstr "Set date/time of %d images"
+
+#: ../src/control/jobs/control_jobs.c:1986
+msgid "time offset"
+msgstr "Time offset"
+
+#: ../src/control/jobs/control_jobs.c:2014 ../src/libs/copy_history.c:417
+msgid "write sidecar files"
+msgstr "Write sidecar files"
+
+#: ../src/control/jobs/control_jobs.c:2228 ../src/control/jobs/film_jobs.c:297
+#, c-format
+msgid "importing %d image"
+msgid_plural "importing %d images"
+msgstr[0] "Importing %d image"
+msgstr[1] "Importing %d images"
+
+#: ../src/control/jobs/control_jobs.c:2264
+#, c-format
+msgid "importing %d/%d image"
+msgid_plural "importing %d/%d images"
+msgstr[0] "Importing %d/%d image"
+msgstr[1] "Importing %d/%d images"
+
+#: ../src/control/jobs/control_jobs.c:2272
+#, c-format
+msgid "imported %d image"
+msgid_plural "imported %d images"
+msgstr[0] "Imported %d image"
+msgstr[1] "Imported %d images"
+
+#: ../src/control/jobs/film_jobs.c:73 ../src/control/jobs/film_jobs.c:109
+msgid "import images"
+msgstr "Import images"
+
+#: ../src/control/jobs/film_jobs.c:239
+msgid "no supported images were found to be imported"
+msgstr "No supported images were found to be imported"
+
+#: ../src/control/jobs/image_jobs.c:76
+#, c-format
+msgid "importing image %s"
+msgstr "Importing image %s"
+
+#: ../src/control/jobs/image_jobs.c:110
+msgid "import image"
+msgstr "Import image"
+
+#: ../src/develop/blend.c:295
+msgid "detail mask blending error"
+msgstr "Detail mask blending error"
+
+#: ../src/develop/blend.c:463 ../src/develop/blend.c:861
+#, c-format
+msgid "skipped blending in module '%s': working area mismatch"
+msgstr "Skipped blending in module '%s': working area mismatch"
+
+#: ../src/develop/blend.c:494 ../src/develop/blend.c:896
+msgid "could not allocate buffer for blending"
+msgstr "Could not allocate buffer for blending"
+
+#: ../src/develop/blend.c:812
+msgid "detail mask CL blending problem"
+msgstr "Detail mask CL blending problem"
+
+#: ../src/develop/blend_gui.c:47 ../src/libs/live_view.c:336
+msgctxt "blendmode"
+msgid "normal"
+msgstr "Normal"
+
+#: ../src/develop/blend_gui.c:49
+msgctxt "blendmode"
+msgid "average"
+msgstr "Average"
+
+#: ../src/develop/blend_gui.c:51 ../src/libs/live_view.c:349
+msgctxt "blendmode"
+msgid "difference"
+msgstr "Difference"
+
+#: ../src/develop/blend_gui.c:54
+msgctxt "blendmode"
+msgid "normal bounded"
+msgstr "Normal bounded"
+
+#: ../src/develop/blend_gui.c:56 ../src/libs/live_view.c:344
+msgctxt "blendmode"
+msgid "lighten"
+msgstr "Lighten"
+
+#: ../src/develop/blend_gui.c:58 ../src/libs/live_view.c:343
+msgctxt "blendmode"
+msgid "darken"
+msgstr "Darken"
+
+#: ../src/develop/blend_gui.c:60 ../src/libs/live_view.c:341
+msgctxt "blendmode"
+msgid "screen"
+msgstr "Screen"
+
+#: ../src/develop/blend_gui.c:63 ../src/libs/live_view.c:340
+msgctxt "blendmode"
+msgid "multiply"
+msgstr "Multiply"
+
+#: ../src/develop/blend_gui.c:65
+msgctxt "blendmode"
+msgid "divide"
+msgstr "Divide"
+
+#: ../src/develop/blend_gui.c:67
+msgctxt "blendmode"
+msgid "addition"
+msgstr "Addition"
+
+#: ../src/develop/blend_gui.c:69
+msgctxt "blendmode"
+msgid "subtract"
+msgstr "Subtract"
+
+#: ../src/develop/blend_gui.c:71
+msgctxt "blendmode"
+msgid "geometric mean"
+msgstr "Geometric mean"
+
+#: ../src/develop/blend_gui.c:73
+msgctxt "blendmode"
+msgid "harmonic mean"
+msgstr "Harmonic mean"
+
+#: ../src/develop/blend_gui.c:76 ../src/libs/live_view.c:342
+msgctxt "blendmode"
+msgid "overlay"
+msgstr "Overlay"
+
+#: ../src/develop/blend_gui.c:78
+msgctxt "blendmode"
+msgid "softlight"
+msgstr "Softlight"
+
+#: ../src/develop/blend_gui.c:80
+msgctxt "blendmode"
+msgid "hardlight"
+msgstr "Hardlight"
+
+#: ../src/develop/blend_gui.c:82
+msgctxt "blendmode"
+msgid "vividlight"
+msgstr "Vividlight"
+
+#: ../src/develop/blend_gui.c:84
+msgctxt "blendmode"
+msgid "linearlight"
+msgstr "Linearlight"
+
+#: ../src/develop/blend_gui.c:86
+msgctxt "blendmode"
+msgid "pinlight"
+msgstr "Pinlight"
+
+#: ../src/develop/blend_gui.c:89
+msgctxt "blendmode"
+msgid "lightness"
+msgstr "Lightness"
+
+#: ../src/develop/blend_gui.c:91
+msgctxt "blendmode"
+msgid "chromaticity"
+msgstr "Chromaticity"
+
+#: ../src/develop/blend_gui.c:94
+msgctxt "blendmode"
+msgid "Lab lightness"
+msgstr "Lab lightness"
+
+#: ../src/develop/blend_gui.c:96
+msgctxt "blendmode"
+msgid "Lab a-channel"
+msgstr "Lab a-channel"
+
+#: ../src/develop/blend_gui.c:98
+msgctxt "blendmode"
+msgid "Lab b-channel"
+msgstr "Lab b-channel"
+
+#: ../src/develop/blend_gui.c:100
+msgctxt "blendmode"
+msgid "Lab color"
+msgstr "Lab color"
+
+#: ../src/develop/blend_gui.c:103
+msgctxt "blendmode"
+msgid "RGB red channel"
+msgstr "RGB red channel"
+
+#: ../src/develop/blend_gui.c:105
+msgctxt "blendmode"
+msgid "RGB green channel"
+msgstr "RGB green channel"
+
+#: ../src/develop/blend_gui.c:107
+msgctxt "blendmode"
+msgid "RGB blue channel"
+msgstr "RGB blue channel"
+
+#: ../src/develop/blend_gui.c:109
+msgctxt "blendmode"
+msgid "HSV value"
+msgstr "HSV value"
+
+#: ../src/develop/blend_gui.c:111
+msgctxt "blendmode"
+msgid "HSV color"
+msgstr "HSV color"
+
+#: ../src/develop/blend_gui.c:114
+msgctxt "blendmode"
+msgid "hue"
+msgstr "Hue"
+
+#: ../src/develop/blend_gui.c:116
+msgctxt "blendmode"
+msgid "color"
+msgstr "Color"
+
+#: ../src/develop/blend_gui.c:118
+msgctxt "blendmode"
+msgid "coloradjustment"
+msgstr "Coloradjustment"
+
+#. * deprecated blend modes: make them available as legacy
+#. * history stacks might want them
+#: ../src/develop/blend_gui.c:124
+msgctxt "blendmode"
+msgid "difference (deprecated)"
+msgstr "Difference (deprecated)"
+
+#: ../src/develop/blend_gui.c:126
+msgctxt "blendmode"
+msgid "subtract inverse (deprecated)"
+msgstr "Subtract inverse (deprecated)"
+
+#: ../src/develop/blend_gui.c:128
+msgctxt "blendmode"
+msgid "divide inverse (deprecated)"
+msgstr "Divide inverse (deprecated)"
+
+#: ../src/develop/blend_gui.c:130
+msgctxt "blendmode"
+msgid "Lab L-channel (deprecated)"
+msgstr "Lab L-channel (deprecated)"
+
+#: ../src/develop/blend_gui.c:135
+msgctxt "blendoperation"
+msgid "normal"
+msgstr "Normal"
+
+#: ../src/develop/blend_gui.c:136
+msgctxt "blendoperation"
+msgid "reverse"
+msgstr "Reverse"
+
+#: ../src/develop/blend_gui.c:140 ../src/imageio/format/webp.c:413
+#: ../src/libs/metadata.c:573 ../src/libs/metadata_view.c:1192
+msgid "default"
+msgstr "Default"
+
+#: ../src/develop/blend_gui.c:142
+msgid "RAW"
+msgstr "RAW"
+
+#: ../src/develop/blend_gui.c:146 ../src/develop/blend_gui.c:2019
+msgid "RGB (display)"
+msgstr "RGB (display)"
+
+#: ../src/develop/blend_gui.c:148 ../src/develop/blend_gui.c:2032
+msgid "RGB (scene)"
+msgstr "RGB (scene)"
+
+#. DEVELOP_MASK_ENABLED
+#: ../src/develop/blend_gui.c:155 ../src/develop/blend_gui.c:3423
+msgid "uniformly"
+msgstr "Uniformly"
+
+#: ../src/develop/blend_gui.c:157 ../src/develop/blend_gui.c:2742
+#: ../src/develop/blend_gui.c:3433 ../src/develop/imageop.c:2574
+msgid "drawn mask"
+msgstr "Drawn mask"
+
+#: ../src/develop/blend_gui.c:159 ../src/develop/blend_gui.c:2516
+#: ../src/develop/blend_gui.c:3444 ../src/develop/imageop.c:2576
+msgid "parametric mask"
+msgstr "Parametric mask"
+
+#: ../src/develop/blend_gui.c:161 ../src/develop/blend_gui.c:2950
+#: ../src/develop/blend_gui.c:3471 ../src/develop/imageop.c:2578
+msgid "raster mask"
+msgstr "Raster mask"
+
+#: ../src/develop/blend_gui.c:163 ../src/develop/blend_gui.c:3458
+msgid "drawn & parametric mask"
+msgstr "Drawn & parametric mask"
+
+#: ../src/develop/blend_gui.c:168
+msgid "exclusive"
+msgstr "Exclusive"
+
+#: ../src/develop/blend_gui.c:169
+msgid "inclusive"
+msgstr "Inclusive"
+
+#: ../src/develop/blend_gui.c:170
+msgid "exclusive & inverted"
+msgstr "Exclusive & inverted"
+
+#: ../src/develop/blend_gui.c:171
+msgid "inclusive & inverted"
+msgstr "Inclusive & inverted"
+
+#: ../src/develop/blend_gui.c:175
+msgid "output before blur"
+msgstr "Output before blur"
+
+#: ../src/develop/blend_gui.c:176
+msgid "input before blur"
+msgstr "Input before blur"
+
+#: ../src/develop/blend_gui.c:177
+msgid "output after blur"
+msgstr "Output after blur"
+
+#: ../src/develop/blend_gui.c:178
+msgid "input after blur"
+msgstr "Input after blur"
+
+#: ../src/develop/blend_gui.c:183 ../src/gui/accelerators.c:129
+#: ../src/gui/accelerators.c:139 ../src/gui/accelerators.c:224
+#: ../src/imageio/format/avif.c:804 ../src/libs/live_view.c:363
+msgid "on"
+msgstr "On"
+
+#: ../src/develop/blend_gui.c:1001 ../src/develop/blend_gui.c:2592
+#: ../src/develop/imageop.c:2703
+msgid "input"
+msgstr "Input"
+
+#: ../src/develop/blend_gui.c:1001 ../src/develop/blend_gui.c:2592
+#: ../src/develop/imageop.c:2703
+msgid "output"
+msgstr "Output"
+
+#: ../src/develop/blend_gui.c:1015
+msgid " (zoom)"
+msgstr " (zoom)"
+
+#: ../src/develop/blend_gui.c:1023
+msgid " (log)"
+msgstr " (log)"
+
+#: ../src/develop/blend_gui.c:1993
+msgid "reset to default blend colorspace"
+msgstr "Reset to default blend colorspace"
+
+#: ../src/develop/blend_gui.c:2049
+msgid "reset and hide output channels"
+msgstr "Reset and hide output channels"
+
+#: ../src/develop/blend_gui.c:2056
+msgid "show output channels"
+msgstr "Show output channels"
+
+#: ../src/develop/blend_gui.c:2294 ../src/develop/blend_gui.c:2361
+#: ../src/iop/tonecurve.c:1133
+msgid "L"
+msgstr "L"
+
+#: ../src/develop/blend_gui.c:2294
+msgid "sliders for L channel"
+msgstr "Sliders for L channel"
+
+#: ../src/develop/blend_gui.c:2299 ../src/iop/tonecurve.c:1134
+msgid "a"
+msgstr "a"
+
+#: ../src/develop/blend_gui.c:2299
+msgid "sliders for a channel"
+msgstr "Sliders for a channel"
+
+#: ../src/develop/blend_gui.c:2303
+msgid "green/red"
+msgstr "Green/red"
+
+#: ../src/develop/blend_gui.c:2304 ../src/iop/tonecurve.c:1135
+msgid "b"
+msgstr "b"
+
+#: ../src/develop/blend_gui.c:2304
+msgid "sliders for b channel"
+msgstr "Sliders for b channel"
+
+#: ../src/develop/blend_gui.c:2308
+msgid "blue/yellow"
+msgstr "Blue/yellow"
+
+#: ../src/develop/blend_gui.c:2309
+msgid "C"
+msgstr "C"
+
+#: ../src/develop/blend_gui.c:2309
+msgid "sliders for chroma channel (of LCh)"
+msgstr "Sliders for chroma channel (of LCh)"
+
+#: ../src/develop/blend_gui.c:2315
+msgid "h"
+msgstr "h"
+
+#: ../src/develop/blend_gui.c:2315
+msgid "sliders for hue channel (of LCh)"
+msgstr "Sliders for hue channel (of LCh)"
+
+#: ../src/develop/blend_gui.c:2323 ../src/develop/blend_gui.c:2371
+msgid "g"
+msgstr "g"
+
+#: ../src/develop/blend_gui.c:2323 ../src/develop/blend_gui.c:2371
+msgid "sliders for gray value"
+msgstr "Sliders for gray value"
+
+#: ../src/develop/blend_gui.c:2329 ../src/develop/blend_gui.c:2377
+#: ../src/iop/channelmixerrgb.c:4580 ../src/iop/denoiseprofile.c:3784
+#: ../src/iop/rawdenoise.c:895 ../src/iop/rgbcurve.c:1357
+#: ../src/iop/rgblevels.c:1001 ../src/libs/filters/colors.c:137
+msgid "R"
+msgstr "R"
+
+#: ../src/develop/blend_gui.c:2329 ../src/develop/blend_gui.c:2377
+msgid "sliders for red channel"
+msgstr "Sliders for red channel"
+
+#: ../src/develop/blend_gui.c:2335 ../src/develop/blend_gui.c:2383
+#: ../src/iop/channelmixerrgb.c:4581 ../src/iop/denoiseprofile.c:3785
+#: ../src/iop/rawdenoise.c:896 ../src/iop/rgbcurve.c:1358
+#: ../src/iop/rgblevels.c:1002 ../src/libs/filters/colors.c:143
+msgid "G"
+msgstr "G"
+
+#: ../src/develop/blend_gui.c:2335 ../src/develop/blend_gui.c:2383
+msgid "sliders for green channel"
+msgstr "Sliders for green channel"
+
+#: ../src/develop/blend_gui.c:2341 ../src/develop/blend_gui.c:2389
+#: ../src/iop/channelmixerrgb.c:4582 ../src/iop/denoiseprofile.c:3786
+#: ../src/iop/rawdenoise.c:897 ../src/iop/rgbcurve.c:1359
+#: ../src/iop/rgblevels.c:1003 ../src/libs/filters/colors.c:146
+msgid "B"
+msgstr "B"
+
+#: ../src/develop/blend_gui.c:2341 ../src/develop/blend_gui.c:2389
+msgid "sliders for blue channel"
+msgstr "Sliders for blue channel"
+
+#: ../src/develop/blend_gui.c:2347
+msgid "H"
+msgstr "H"
+
+#: ../src/develop/blend_gui.c:2347
+msgid "sliders for hue channel (of HSL)"
+msgstr "Sliders for hue channel (of HSL)"
+
+#: ../src/develop/blend_gui.c:2354
+msgid "S"
+msgstr "S"
+
+#: ../src/develop/blend_gui.c:2354
+msgid "sliders for chroma channel (of HSL)"
+msgstr "Sliders for chroma channel (of HSL)"
+
+#: ../src/develop/blend_gui.c:2361
+msgid "sliders for value channel (of HSL)"
+msgstr "Sliders for value channel (of HSL)"
+
+#: ../src/develop/blend_gui.c:2395
+msgid "Jz"
+msgstr "Jz"
+
+#: ../src/develop/blend_gui.c:2395
+msgid "sliders for value channel (of JzCzhz)"
+msgstr "Sliders for value channel (of JzCzhz)"
+
+#: ../src/develop/blend_gui.c:2402
+msgid "Cz"
+msgstr "Cz"
+
+#: ../src/develop/blend_gui.c:2402
+msgid "sliders for chroma channel (of JzCzhz)"
+msgstr "Sliders for chroma channel (of JzCzhz)"
+
+#: ../src/develop/blend_gui.c:2409
+msgid "hz"
+msgstr "hz"
+
+#: ../src/develop/blend_gui.c:2409
+msgid "sliders for hue channel (of JzCzhz)"
+msgstr "Sliders for hue channel (of JzCzhz)"
+
+#: ../src/develop/blend_gui.c:2419
+msgid ""
+"adjustment based on input received by this module:\n"
+"* range defined by upper markers: blend fully\n"
+"* range defined by lower markers: do not blend at all\n"
+"* range between adjacent upper/lower markers: blend gradually"
+msgstr ""
+"Adjustment based on input received by this module:\n"
+"* range defined by upper markers: blend fully\n"
+"* range defined by lower markers: do not blend at all\n"
+"* range between adjacent upper/lower markers: blend gradually"
+
+#: ../src/develop/blend_gui.c:2423
+msgid ""
+"adjustment based on unblended output of this module:\n"
+"* range defined by upper markers: blend fully\n"
+"* range defined by lower markers: do not blend at all\n"
+"* range between adjacent upper/lower markers: blend gradually"
+msgstr ""
+"Adjustment based on unblended output of this module:\n"
+"* range defined by upper markers: blend fully\n"
+"* range defined by lower markers: do not blend at all\n"
+"* range between adjacent upper/lower markers: blend gradually"
+
+#: ../src/develop/blend_gui.c:2520
+msgid "reset blend mask settings"
+msgstr "Reset blend mask settings"
+
+#: ../src/develop/blend_gui.c:2531 ../src/iop/atrous.c:1668
+#: ../src/iop/colorzones.c:2401 ../src/iop/denoiseprofile.c:3781
+#: ../src/iop/rawdenoise.c:892 ../src/iop/rgbcurve.c:1356
+#: ../src/iop/rgblevels.c:1000 ../src/iop/tonecurve.c:1132
+msgid "channel"
+msgstr "Channel"
+
+#: ../src/develop/blend_gui.c:2546 ../src/iop/colorzones.c:2415
+#: ../src/iop/rgbcurve.c:1366 ../src/iop/tonecurve.c:1141
+msgid ""
+"pick GUI color from image\n"
+"ctrl+click or right-click to select an area"
+msgstr ""
+"Pick GUI color from image\n"
+"Ctrl+click or right-click to select an area"
+
+#: ../src/develop/blend_gui.c:2557
+msgid ""
+"set the range based on an area from the image\n"
+"drag to use the input image\n"
+"ctrl+drag to use the output image"
+msgstr ""
+"Set the range based on an area from the image\n"
+"Drag to use the input image\n"
+"Ctrl+drag to use the output image"
+
+#: ../src/develop/blend_gui.c:2562
+msgid "invert all channel's polarities"
+msgstr "Invert all channel's polarities"
+
+#: ../src/develop/blend_gui.c:2586
+msgid "toggle polarity. best seen by enabling 'display mask'"
+msgstr "Toggle polarity. Best seen by enabling 'display mask'"
+
+#: ../src/develop/blend_gui.c:2615
+msgid ""
+"double-click to reset.\n"
+"press 'a' to toggle available slider modes.\n"
+"press 'c' to toggle view of channel data.\n"
+"press 'm' to toggle mask view."
+msgstr ""
+"Double-click to reset.\n"
+"Press 'a' to toggle available slider modes.\n"
+"Press 'c' to toggle view of channel data.\n"
+"Press 'm' to toggle mask view."
+
+#: ../src/develop/blend_gui.c:2642 ../src/develop/blend_gui.c:3535
+#: ../src/iop/basicadj.c:600 ../src/iop/colorbalancergb.c:2059
+#: ../src/iop/exposure.c:1112 ../src/iop/exposure.c:1127
+#: ../src/iop/filmic.c:1503 ../src/iop/filmic.c:1516 ../src/iop/filmic.c:1558
+#: ../src/iop/filmicrgb.c:4179 ../src/iop/filmicrgb.c:4190
+#: ../src/iop/filmicrgb.c:4224 ../src/iop/filmicrgb.c:4234
+#: ../src/iop/graduatednd.c:1113 ../src/iop/negadoctor.c:1008
+#: ../src/iop/profile_gamma.c:643 ../src/iop/profile_gamma.c:649
+#: ../src/iop/relight.c:262 ../src/iop/soften.c:378 ../src/iop/toneequal.c:3342
+#: ../src/iop/toneequal.c:3345 ../src/iop/toneequal.c:3348
+#: ../src/iop/toneequal.c:3351 ../src/iop/toneequal.c:3354
+#: ../src/iop/toneequal.c:3357 ../src/iop/toneequal.c:3360
+#: ../src/iop/toneequal.c:3363 ../src/iop/toneequal.c:3366
+#: ../src/iop/toneequal.c:3489 ../src/iop/toneequal.c:3498
+#: ../src/iop/toneequal.c:3511 ../src/views/darkroom.c:2435
+msgid " EV"
+msgstr " EV"
+
+#: ../src/develop/blend_gui.c:2644 ../src/develop/blend_gui.c:2742
+#: ../src/develop/blend_gui.c:2950 ../src/develop/blend_gui.c:3013
+#: ../src/develop/blend_gui.c:3503 ../src/develop/blend_gui.c:3533
+#: ../src/develop/blend_gui.c:3546 ../src/develop/blend_gui.c:3571
+#: ../src/develop/blend_gui.c:3595 ../src/develop/blend_gui.c:3605
+#: ../src/develop/blend_gui.c:3614 ../src/develop/blend_gui.c:3625
+msgid "blend"
+msgstr "Blend"
+
+#: ../src/develop/blend_gui.c:2644
+msgid "boost factor"
+msgstr "Boost factor"
+
+#: ../src/develop/blend_gui.c:2647
+msgid "adjust the boost factor of the channel mask"
+msgstr "Adjust the boost factor of the channel mask"
+
+#: ../src/develop/blend_gui.c:2684
+#, c-format
+msgid "%d shape used"
+msgid_plural "%d shapes used"
+msgstr[0] "%d shape used"
+msgstr[1] "%d shapes used"
+
+#: ../src/develop/blend_gui.c:2689 ../src/develop/blend_gui.c:2745
+#: ../src/develop/blend_gui.c:2833 ../src/develop/blend_gui.c:2951
+msgid "no mask used"
+msgstr "No mask used"
+
+#: ../src/develop/blend_gui.c:2753
+msgid "toggle polarity of drawn mask"
+msgstr "Toggle polarity of drawn mask"
+
+#: ../src/develop/blend_gui.c:2762
+msgid "show and edit mask elements"
+msgstr "Show and edit mask elements"
+
+#: ../src/develop/blend_gui.c:2763
+msgid "show and edit in restricted mode"
+msgstr "Show and edit in restricted mode"
+
+#: ../src/develop/blend_gui.c:2770 ../src/libs/masks.c:1167
+#: ../src/libs/masks.c:1932 ../src/libs/masks.c:1936
+msgid "add gradient"
+msgstr "Add gradient"
+
+#: ../src/develop/blend_gui.c:2771
+msgid "add multiple gradients"
+msgstr "Add multiple gradients"
+
+#: ../src/develop/blend_gui.c:2778 ../src/iop/retouch.c:2238
+#: ../src/libs/masks.c:1147 ../src/libs/masks.c:1968 ../src/libs/masks.c:1972
+msgid "add brush"
+msgstr "Add brush"
+
+#: ../src/develop/blend_gui.c:2779 ../src/iop/retouch.c:2238
+msgid "add multiple brush strokes"
+msgstr "Add multiple brush strokes"
+
+#: ../src/develop/blend_gui.c:2786 ../src/iop/retouch.c:2242
+#: ../src/iop/spots.c:884 ../src/libs/masks.c:1162 ../src/libs/masks.c:1941
+#: ../src/libs/masks.c:1945
+msgid "add path"
+msgstr "Add path"
+
+#: ../src/develop/blend_gui.c:2787 ../src/iop/retouch.c:2242
+#: ../src/iop/spots.c:884
+msgid "add multiple paths"
+msgstr "Add multiple paths"
+
+#: ../src/develop/blend_gui.c:2794 ../src/iop/retouch.c:2246
+#: ../src/iop/spots.c:889 ../src/libs/masks.c:1157 ../src/libs/masks.c:1950
+#: ../src/libs/masks.c:1954
+msgid "add ellipse"
+msgstr "Add ellipse"
+
+#: ../src/develop/blend_gui.c:2795 ../src/iop/retouch.c:2246
+#: ../src/iop/spots.c:889
+msgid "add multiple ellipses"
+msgstr "Add multiple ellipses"
+
+#: ../src/develop/blend_gui.c:2802 ../src/iop/retouch.c:2250
+#: ../src/iop/spots.c:894 ../src/libs/masks.c:1152 ../src/libs/masks.c:1959
+#: ../src/libs/masks.c:1963
+msgid "add circle"
+msgstr "Add circle"
+
+#: ../src/develop/blend_gui.c:2803 ../src/iop/retouch.c:2250
+#: ../src/iop/spots.c:894
+msgid "add multiple circles"
+msgstr "Add multiple circles"
+
+#: ../src/develop/blend_gui.c:2960
+msgid "toggle polarity of raster mask"
+msgstr "Toggle polarity of raster mask"
+
+#: ../src/develop/blend_gui.c:3100
+msgid "normal & difference"
+msgstr "Normal & difference"
+
+#: ../src/develop/blend_gui.c:3105
+msgid "lighten"
+msgstr "Lighten"
+
+#: ../src/develop/blend_gui.c:3112
+msgid "darken"
+msgstr "Darken"
+
+#: ../src/develop/blend_gui.c:3119
+msgid "contrast enhancing"
+msgstr "Contrast enhancing"
+
+#: ../src/develop/blend_gui.c:3126 ../src/develop/blend_gui.c:3149
+msgid "color channel"
+msgstr "Color channel"
+
+#: ../src/develop/blend_gui.c:3137 ../src/develop/blend_gui.c:3152
+msgid "chromaticity & lightness"
+msgstr "Chromaticity & lightness"
+
+#: ../src/develop/blend_gui.c:3144
+msgid "normal & arithmetic"
+msgstr "Normal & arithmetic"
+
+#. add deprecated blend mode
+#: ../src/develop/blend_gui.c:3165
+msgid "deprecated"
+msgstr "Deprecated"
+
+#: ../src/develop/blend_gui.c:3482
+msgid "blending options"
+msgstr "Blending options"
+
+#: ../src/develop/blend_gui.c:3504 ../src/libs/history.c:961
+msgid "blend mode"
+msgstr "Blend mode"
+
+#: ../src/develop/blend_gui.c:3507
+msgid "choose blending mode"
+msgstr "Choose blending mode"
+
+#: ../src/develop/blend_gui.c:3517
+msgid "toggle blend order"
+msgstr "Toggle blend order"
+
+#: ../src/develop/blend_gui.c:3523
+msgid ""
+"toggle the blending order between the input and the output of the module,\n"
+"by default the output will be blended on top of the input,\n"
+"order can be reversed by clicking on the icon (input on top of output)"
+msgstr ""
+"Toggle the blending order between the input and the output of the module,\n"
+"By default the output will be blended on top of the input,\n"
+"Order can be reversed by clicking on the icon (input on top of output)"
+
+#: ../src/develop/blend_gui.c:3534 ../src/libs/history.c:965
+msgid "blend fulcrum"
+msgstr "Blend fulcrum"
+
+#: ../src/develop/blend_gui.c:3538
+msgid "adjust the fulcrum used by some blending operations"
+msgstr "Adjust the fulcrum used by some blending operations"
+
+#. Add opacity/scale sliders to table
+#: ../src/develop/blend_gui.c:3546 ../src/iop/watermark.c:1126
+#: ../src/libs/masks.c:104
+msgid "opacity"
+msgstr "Opacity"
+
+#: ../src/develop/blend_gui.c:3550
+msgid "set the opacity of the blending"
+msgstr "Set the opacity of the blending"
+
+#: ../src/develop/blend_gui.c:3554 ../src/libs/history.c:968
+msgid "combine masks"
+msgstr "Combine masks"
+
+#: ../src/develop/blend_gui.c:3556
+msgid ""
+"how to combine individual drawn mask and different channels of parametric "
+"mask"
+msgstr ""
+"How to combine individual drawn mask and different channels of parametric "
+"mask"
+
+#: ../src/develop/blend_gui.c:3564 ../src/libs/history.c:978
+msgid "invert mask"
+msgstr "Invert mask"
+
+#: ../src/develop/blend_gui.c:3566
+msgid "apply mask in normal or inverted mode"
+msgstr "Apply mask in normal or inverted mode"
+
+#: ../src/develop/blend_gui.c:3571
+msgid "details threshold"
+msgstr "Details threshold"
+
+#: ../src/develop/blend_gui.c:3575
+msgid ""
+"adjust the threshold for the details mask (using raw data),\n"
+"positive values selects areas with strong details,\n"
+"negative values select flat areas"
+msgstr ""
+"Adjust the threshold for the details mask (using raw data),\n"
+"Positive values selects areas with strong details,\n"
+"Negative values select flat areas"
+
+#: ../src/develop/blend_gui.c:3583 ../src/libs/history.c:971
+msgid "feathering guide"
+msgstr "Feathering guide"
+
+#: ../src/develop/blend_gui.c:3586
+msgid ""
+"choose to guide mask by input or output image and\n"
+"choose to apply feathering before or after mask blur"
+msgstr ""
+"Choose to guide mask by input or output image and\n"
+"choose to apply feathering before or after mask blur"
+
+#: ../src/develop/blend_gui.c:3595 ../src/libs/history.c:970
+msgid "feathering radius"
+msgstr "Feathering radius"
+
+#: ../src/develop/blend_gui.c:3598
+msgid "spatial radius of feathering"
+msgstr "Spatial radius of feathering"
+
+#: ../src/develop/blend_gui.c:3605
+msgid "blurring radius"
+msgstr "Blurring radius"
+
+#: ../src/develop/blend_gui.c:3608
+msgid "radius for gaussian blur of blend mask"
+msgstr "Radius for gaussian blur of blend mask"
+
+#: ../src/develop/blend_gui.c:3614 ../src/iop/retouch.c:2452
+#: ../src/libs/history.c:966
+msgid "mask opacity"
+msgstr "Mask opacity"
+
+#: ../src/develop/blend_gui.c:3618
+msgid ""
+"shifts and tilts the tone curve of the blend mask to adjust its brightness\n"
+"without affecting fully transparent/fully opaque regions"
+msgstr ""
+"Shifts and tilts the tone curve of the blend mask to adjust its brightness\n"
+"without affecting fully transparent/fully opaque regions"
+
+#: ../src/develop/blend_gui.c:3625 ../src/libs/history.c:974
+msgid "mask contrast"
+msgstr "Mask contrast"
+
+#: ../src/develop/blend_gui.c:3629
+msgid ""
+"gives the tone curve of the blend mask an s-like shape to adjust its contrast"
+msgstr ""
+"Gives the tone curve of the blend mask an S-like shape to adjust its contrast"
+
+#: ../src/develop/blend_gui.c:3633
+msgid "mask refinement"
+msgstr "Mask refinement"
+
+#: ../src/develop/blend_gui.c:3637
+msgid "display mask and/or color channel"
+msgstr "Display mask and/or color channel"
+
+#: ../src/develop/blend_gui.c:3642
+msgid ""
+"display mask and/or color channel.\n"
+"ctrl+click to display mask,\n"
+"shift+click to display channel.\n"
+"hover over parametric mask slider to select channel for display"
+msgstr ""
+"Display mask and/or color channel.\n"
+"Ctrl+click to display mask,\n"
+"Shift+click to display channel.\n"
+"Hover over parametric mask slider to select channel for display"
+
+#: ../src/develop/blend_gui.c:3649
+msgid "temporarily switch off blend mask"
+msgstr "Temporarily switch off blend mask"
+
+#: ../src/develop/blend_gui.c:3654
+msgid ""
+"temporarily switch off blend mask.\n"
+"only for module in focus"
+msgstr ""
+"Temporarily switch off blend mask.\n"
+"Only for module in focus"
+
+#: ../src/develop/develop.c:2265
+#, c-format
+msgid "%s: module `%s' version mismatch: %d != %d"
+msgstr "%s: module `%s' version mismatch: %d != %d"
+
+#: ../src/develop/develop.c:2792
+msgid "module duplicate, can't move new instance after the base one\n"
+msgstr "Module duplicate, can't move new instance after the base one\n"
+
+#: ../src/develop/imageop.c:1002
+msgid "new instance"
+msgstr "New instance"
+
+#: ../src/develop/imageop.c:1008
+msgid "duplicate instance"
+msgstr "Duplicate instance"
+
+#: ../src/develop/imageop.c:1014 ../src/develop/imageop.c:3686
+#: ../src/libs/masks.c:1311
+msgid "move up"
+msgstr "Move up"
+
+#: ../src/develop/imageop.c:1020 ../src/develop/imageop.c:3687
+#: ../src/libs/masks.c:1316
+msgid "move down"
+msgstr "Move down"
+
+#. delete button label and tooltip will be updated based on trash pref
+#: ../src/develop/imageop.c:1026 ../src/develop/imageop.c:3689
+#: ../src/gui/accelerators.c:155 ../src/gui/presets.c:499
+#: ../src/libs/image.c:286 ../src/libs/image.c:482 ../src/libs/tagging.c:1481
+#: ../src/libs/tagging.c:1569
+msgid "delete"
+msgstr "Delete"
+
+#: ../src/develop/imageop.c:1033 ../src/develop/imageop.c:3690
+#: ../src/libs/modulegroups.c:3466 ../src/libs/modulegroups.c:3817
+msgid "rename"
+msgstr "Rename"
+
+#: ../src/develop/imageop.c:1101 ../src/develop/imageop.c:2864
+#, c-format
+msgid "'%s' is switched on"
+msgstr "'%s' is switched on"
+
+#: ../src/develop/imageop.c:1101 ../src/develop/imageop.c:2864
+#, c-format
+msgid "'%s' is switched off"
+msgstr "'%s' is switched off"
+
+#: ../src/develop/imageop.c:2568
+msgid "unknown mask"
+msgstr "Unknown mask"
+
+#: ../src/develop/imageop.c:2572
+msgid "drawn + parametric mask"
+msgstr "Drawn + parametric mask"
+
+#: ../src/develop/imageop.c:2581
+#, c-format
+msgid "this module has a `%s'"
+msgstr "This module has a `%s'"
+
+#: ../src/develop/imageop.c:2586
+#, c-format
+msgid "taken from module %s"
+msgstr "Taken from module %s"
+
+#: ../src/develop/imageop.c:2591
+msgid "click to display (module must be activated first)"
+msgstr "Click to display (module must be activated first)"
+
+#: ../src/develop/imageop.c:2703
+msgid "purpose"
+msgstr "Purpose"
+
+#: ../src/develop/imageop.c:2703
+msgid "process"
+msgstr "Process"
+
+#: ../src/develop/imageop.c:2820
+msgid ""
+"multiple instance actions\n"
+"right-click creates new instance"
+msgstr ""
+"Multiple instance actions\n"
+"Right-click creates new instance"
+
+#: ../src/develop/imageop.c:2835
+msgid ""
+"reset parameters\n"
+"ctrl+click to reapply any automatic presets"
+msgstr ""
+"Reset parameters\n"
+"Ctrl+click to reapply any automatic presets"
+
+#: ../src/develop/imageop.c:2847
+msgid ""
+"presets\n"
+"right-click to apply on new instance"
+msgstr ""
+"Presets\n"
+"Right-click to apply on new instance"
+
+#: ../src/develop/imageop.c:3097 ../src/develop/imageop.c:3119
+msgid "ERROR"
+msgstr "ERROR"
+
+#: ../src/develop/imageop.c:3570
+msgid "unsupported input"
+msgstr "Unsupported input"
+
+#: ../src/develop/imageop.c:3571
+msgid ""
+"you have placed this module at\n"
+"a position in the pipeline where\n"
+"the data format does not match\n"
+"its requirements."
+msgstr ""
+"You have placed this module at\n"
+"a position in the pipeline where\n"
+"the data format does not match\n"
+"its requirements."
+
+#: ../src/develop/imageop.c:3685 ../src/develop/imageop.c:3695
+#: ../src/gui/accelerators.c:151 ../src/libs/lib.c:1252
+msgid "show"
+msgstr "Show"
+
+#: ../src/develop/imageop.c:3688 ../src/libs/modulegroups.c:3312
+#: ../src/libs/modulegroups.c:3438 ../src/libs/modulegroups.c:3819
+#: ../src/libs/tagging.c:3246
+msgid "new"
+msgstr "New"
+
+#: ../src/develop/imageop.c:3691 ../src/libs/duplicate.c:403
+#: ../src/libs/image.c:497 ../src/libs/modulegroups.c:3815
+msgid "duplicate"
+msgstr "Duplicate"
+
+#: ../src/develop/imageop.c:3696
+msgid "enable"
+msgstr "Enable"
+
+#: ../src/develop/imageop.c:3697 ../src/gui/accelerators.c:167
+msgid "focus"
+msgstr "Focus"
+
+#: ../src/develop/imageop.c:3698 ../src/gui/accelerators.c:2486
+msgid "instance"
+msgstr "Instance"
+
+#: ../src/develop/imageop.c:3699 ../src/gui/accelerators.c:112
+#: ../src/gui/accelerators.c:122 ../src/gui/gtk.c:2829 ../src/gui/gtk.c:2876
+#: ../src/gui/hist_dialog.c:268 ../src/gui/styles_dialog.c:601
+#: ../src/gui/styles_dialog.c:623 ../src/iop/atrous.c:1514
+#: ../src/libs/lib.c:1253 ../src/libs/modulegroups.c:3883
+msgid "reset"
+msgstr "Reset"
+
+#. Adding the outer container
+#: ../src/develop/imageop.c:3700 ../src/gui/preferences.c:793
+#: ../src/libs/lib.c:1254
+msgid "presets"
+msgstr "Presets"
+
+#: ../src/develop/imageop.c:3720
+msgid "processing module"
+msgstr "Processing module"
+
+#: ../src/develop/imageop_gui.c:293
+#, c-format
+msgid ""
+"%s\n"
+"ctrl+click to %s"
+msgstr ""
+"%s\n"
+"Ctrl+click to %s"
+
+#: ../src/develop/lightroom.c:1083
+msgid "cannot find lightroom XMP!"
+msgstr "Cannot find Lightroom XMP!"
+
+#: ../src/develop/lightroom.c:1115 ../src/develop/lightroom.c:1137
+#: ../src/develop/lightroom.c:1157
+#, c-format
+msgid "`%s' is not a Lightroom XMP!"
+msgstr "`%s' is not a Lightroom XMP!"
+
+#: ../src/develop/lightroom.c:1556
+#, c-format
+msgid "%s has been imported"
+msgid_plural "%s have been imported"
+msgstr[0] "%s has been imported"
+msgstr[1] "%s have been imported"
+
+#: ../src/develop/masks/brush.c:1332 ../src/develop/masks/brush.c:1386
+#, c-format
+msgid "hardness: %3.2f%%"
+msgstr "Hardness: %3.2f%%"
+
+#: ../src/develop/masks/brush.c:1348 ../src/develop/masks/brush.c:1446
+#: ../src/develop/masks/circle.c:140 ../src/develop/masks/circle.c:185
+#: ../src/develop/masks/ellipse.c:546 ../src/develop/masks/ellipse.c:608
+#: ../src/develop/masks/path.c:1266
+#, c-format
+msgid "size: %3.2f%%"
+msgstr "Size: %3.2f%%"
+
+#: ../src/develop/masks/brush.c:3256
+msgid "[BRUSH] change size"
+msgstr "[BRUSH] change size"
+
+#: ../src/develop/masks/brush.c:3258
+msgid "[BRUSH] change hardness"
+msgstr "[BRUSH] change hardness"
+
+#: ../src/develop/masks/brush.c:3260
+msgid "[BRUSH] change opacity"
+msgstr "[BRUSH] change opacity"
+
+#: ../src/develop/masks/brush.c:3272
+#, c-format
+msgid "brush #%d"
+msgstr "Brush #%d"
+
+#: ../src/develop/masks/brush.c:3285
+#, c-format
+msgid ""
+"<b>size</b>: scroll, <b>hardness</b>: shift+scroll\n"
+"<b>opacity</b>: ctrl+scroll (%d%%)"
+msgstr ""
+"<b>Size</b>: scroll, <b>Hardness</b>: Shift+scroll\n"
+"<b>Opacity</b>: Ctrl+scroll (%d%%)"
+
+#: ../src/develop/masks/brush.c:3288
+msgid "<b>size</b>: scroll"
+msgstr "<b>Size</b>: scroll"
+
+#: ../src/develop/masks/circle.c:129 ../src/develop/masks/circle.c:173
+#: ../src/develop/masks/ellipse.c:532 ../src/develop/masks/ellipse.c:593
+#: ../src/develop/masks/path.c:1198
+#, c-format
+msgid "feather size: %3.2f%%"
+msgstr "Feather size: %3.2f%%"
+
+#: ../src/develop/masks/circle.c:1510
+msgid "[CIRCLE] change size"
+msgstr "[CIRCLE] change size"
+
+#: ../src/develop/masks/circle.c:1512
+msgid "[CIRCLE] change feather size"
+msgstr "[CIRCLE] change feather size"
+
+#: ../src/develop/masks/circle.c:1514
+msgid "[CIRCLE] change opacity"
+msgstr "[CIRCLE] change opacity"
+
+#: ../src/develop/masks/circle.c:1527
+#, c-format
+msgid "circle #%d"
+msgstr "Circle #%d"
+
+#: ../src/develop/masks/circle.c:1538 ../src/develop/masks/path.c:3522
+#, c-format
+msgid ""
+"<b>size</b>: scroll, <b>feather size</b>: shift+scroll\n"
+"<b>opacity</b>: ctrl+scroll (%d%%)"
+msgstr ""
+"<b>Size</b>: scroll, <b>Feather size</b>: Shift+scroll\n"
+"<b>Opacity</b>: Ctrl+scroll (%d%%)"
+
+#: ../src/develop/masks/ellipse.c:518 ../src/develop/masks/ellipse.c:577
+#, c-format
+msgid "rotation: %3.f°"
+msgstr "Rotation: %3.f°"
+
+#: ../src/develop/masks/ellipse.c:2130
+msgid "[ELLIPSE] change size"
+msgstr "[ELLIPSE] change size"
+
+#: ../src/develop/masks/ellipse.c:2133
+msgid "[ELLIPSE] change feather size"
+msgstr "[ELLIPSE] change feather size"
+
+#: ../src/develop/masks/ellipse.c:2136 ../src/develop/masks/ellipse.c:2145
+msgid "[ELLIPSE] rotate shape"
+msgstr "[ELLIPSE] rotate shape"
+
+#: ../src/develop/masks/ellipse.c:2139
+msgid "[ELLIPSE] change opacity"
+msgstr "[ELLIPSE] change opacity"
+
+#: ../src/develop/masks/ellipse.c:2142
+msgid "[ELLIPSE] switch feathering mode"
+msgstr "[ELLIPSE] switch feathering mode"
+
+#: ../src/develop/masks/ellipse.c:2152
+#, c-format
+msgid "ellipse #%d"
+msgstr "Ellipse #%d"
+
+#: ../src/develop/masks/ellipse.c:2190
+#, c-format
+msgid ""
+"<b>size</b>: scroll, <b>feather size</b>: shift+scroll\n"
+"<b>rotation</b>: ctrl+shift+scroll, <b>opacity</b>: ctrl+scroll (%d%%)"
+msgstr ""
+"<b>Size</b>: scroll, <b>Feather size</b>: Shift+scroll\n"
+"<b>Rotation</b>: Ctrl+Shift+scroll, <b>Opacity</b>: Ctrl+scroll (%d%%)"
+
+#: ../src/develop/masks/ellipse.c:2194
+msgid "<b>rotate</b>: ctrl+drag"
+msgstr "<b>Rotate</b>: Ctrl+drag"
+
+#: ../src/develop/masks/ellipse.c:2197
+#, c-format
+msgid ""
+"<b>feather mode</b>: shift+click, <b>rotate</b>: ctrl+drag\n"
+"<b>size</b>: scroll, <b>feather size</b>: shift+scroll, <b>opacity</b>: "
+"ctrl+scroll (%d%%)"
+msgstr ""
+"<b>Feather mode</b>: Shift+click, <b>Rotate</b>: Ctrl+drag\n"
+"<b>Size</b>: scroll, <b>Feather size</b>: Shift+scroll, <b>Opacity</b>: "
+"Ctrl+scroll (%d%%)"
+
+#: ../src/develop/masks/gradient.c:119 ../src/develop/masks/gradient.c:163
+#, c-format
+msgid "compression: %3.2f%%"
+msgstr "Compression: %3.2f%%"
+
+#: ../src/develop/masks/gradient.c:131 ../src/develop/masks/gradient.c:174
+#, c-format
+msgid "curvature: %3.2f%%"
+msgstr "Curvature: %3.2f%%"
+
+#: ../src/develop/masks/gradient.c:1616
+msgid "[GRADIENT on pivot] rotate shape"
+msgstr "[GRADIENT on pivot] rotate shape"
+
+#: ../src/develop/masks/gradient.c:1618
+msgid "[GRADIENT creation] set rotation"
+msgstr "[GRADIENT creation] set rotation"
+
+#: ../src/develop/masks/gradient.c:1620
+msgid "[GRADIENT] change curvature"
+msgstr "[GRADIENT] change curvature"
+
+#: ../src/develop/masks/gradient.c:1622
+msgid "[GRADIENT] change compression"
+msgstr "[GRADIENT] change compression"
+
+#: ../src/develop/masks/gradient.c:1624
+msgid "[GRADIENT] change opacity"
+msgstr "[GRADIENT] change opacity"
+
+#: ../src/develop/masks/gradient.c:1637
+#, c-format
+msgid "gradient #%d"
+msgstr "Gradient #%d"
+
+#: ../src/develop/masks/gradient.c:1648
+#, c-format
+msgid ""
+"<b>curvature</b>: scroll, <b>compression</b>: shift+scroll\n"
+"<b>rotation</b>: click+drag, <b>opacity</b>: ctrl+scroll (%d%%)"
+msgstr ""
+"<b>Curvature</b>: scroll, <b>Compression</b>: Shift+scroll\n"
+"<b>Rotation</b>: click+drag, <b>Opacity</b>: Ctrl+scroll (%d%%)"
+
+#: ../src/develop/masks/gradient.c:1653
+#, c-format
+msgid ""
+"<b>curvature</b>: scroll, <b>compression</b>: shift+scroll\n"
+"<b>opacity</b>: ctrl+scroll (%d%%)"
+msgstr ""
+"<b>Curvature</b>: scroll, <b>Compression</b>: Shift+scroll\n"
+"<b>Opacity</b>: Ctrl+scroll (%d%%)"
+
+#: ../src/develop/masks/gradient.c:1656
+msgid "<b>rotate</b>: drag"
+msgstr "<b>Rotate</b>: drag"
+
+#: ../src/develop/masks/masks.c:139
+msgid "[SHAPE] remove shape"
+msgstr "[SHAPE] remove shape"
+
+#: ../src/develop/masks/masks.c:415
+#, c-format
+msgid "copy of %s"
+msgstr "Copy of %s"
+
+#: ../src/develop/masks/masks.c:974
+#, c-format
+msgid "%s: mask version mismatch: %d != %d"
+msgstr "%s: mask version mismatch: %d != %d"
+
+#: ../src/develop/masks/masks.c:1229 ../src/develop/masks/masks.c:1896
+#, c-format
+msgid "opacity: %.0f%%"
+msgstr "Opacity: %.0f%%"
+
+#: ../src/develop/masks/masks.c:1640 ../src/libs/masks.c:1237
+msgid "add existing shape"
+msgstr "Add existing shape"
+
+#: ../src/develop/masks/masks.c:1667
+msgid "use same shapes as"
+msgstr "Use same shapes as"
+
+#: ../src/develop/masks/masks.c:1980
+msgid "masks can not contain themselves"
+msgstr "Masks can not contain themselves"
+
+#: ../src/develop/masks/path.c:3465
+msgid "[PATH creation] add a smooth node"
+msgstr "[PATH creation] add a smooth node"
+
+#: ../src/develop/masks/path.c:3467
+msgid "[PATH creation] add a sharp node"
+msgstr "[PATH creation] add a sharp node"
+
+#: ../src/develop/masks/path.c:3469
+msgid "[PATH creation] terminate path creation"
+msgstr "[PATH creation] terminate path creation"
+
+#: ../src/develop/masks/path.c:3471
+msgid "[PATH on node] switch between smooth/sharp node"
+msgstr "[PATH on node] switch between smooth/sharp node"
+
+#: ../src/develop/masks/path.c:3473
+msgid "[PATH on node] remove the node"
+msgstr "[PATH on node] remove the node"
+
+#: ../src/develop/masks/path.c:3475
+msgid "[PATH on feather] reset curvature"
+msgstr "[PATH on feather] reset curvature"
+
+#: ../src/develop/masks/path.c:3477
+msgid "[PATH on segment] add node"
+msgstr "[PATH on segment] add node"
+
+#: ../src/develop/masks/path.c:3479
+msgid "[PATH] change size"
+msgstr "[PATH] change size"
+
+#: ../src/develop/masks/path.c:3481
+msgid "[PATH] change feather size"
+msgstr "[PATH] change feather size"
+
+#: ../src/develop/masks/path.c:3483
+msgid "[PATH] change opacity"
+msgstr "[PATH] change opacity"
+
+#: ../src/develop/masks/path.c:3495
+#, c-format
+msgid "path #%d"
+msgstr "Path #%d"
+
+#: ../src/develop/masks/path.c:3505
+msgid ""
+"<b>add node</b>: click, <b>add sharp node</b>:ctrl+click\n"
+"<b>cancel</b>: right-click"
+msgstr ""
+"<b>Add node</b>: click, <b>Add sharp node</b>:Ctrl+click\n"
+"<b>Cancel</b>: right-click"
+
+#: ../src/develop/masks/path.c:3508
+msgid ""
+"<b>add node</b>: click, <b>add sharp node</b>:ctrl+click\n"
+"<b>finish path</b>: right-click"
+msgstr ""
+"<b>Add node</b>: click, <b>Add sharp node</b>:Ctrl+click\n"
+"<b>Finish path</b>: right-click"
+
+#: ../src/develop/masks/path.c:3511
+msgid ""
+"<b>move node</b>: drag, <b>remove node</b>: right-click\n"
+"<b>switch smooth/sharp mode</b>: ctrl+click"
+msgstr ""
+"<b>Move node</b>: drag, <b>Remove node</b>: right-click\n"
+"<b>Switch smooth/sharp mode</b>: Ctrl+click"
+
+#: ../src/develop/masks/path.c:3515
+msgid ""
+"<b>node curvature</b>: drag\n"
+"<b>reset curvature</b>: right-click"
+msgstr ""
+"<b>Node curvature</b>: drag\n"
+"<b>Reset curvature</b>: right-click"
+
+#: ../src/develop/masks/path.c:3519
+msgid ""
+"<b>move segment</b>: drag\n"
+"<b>add node</b>: ctrl+click"
+msgstr ""
+"<b>Move segment</b>: drag\n"
+"<b>Add node</b>: Ctrl+click"
+
+#: ../src/develop/pixelpipe_hb.c:499
+msgid "enabled as required"
+msgstr "Enabled as required"
+
+#: ../src/develop/pixelpipe_hb.c:500
+msgid ""
+"history had module disabled but it is required for this type of image.\n"
+"likely introduced by applying a preset, style or history copy&paste"
+msgstr ""
+"History had module disabled but it is required for this type of image.\n"
+"Likely introduced by applying a preset, style or history copy&paste"
+
+#: ../src/develop/pixelpipe_hb.c:507
+msgid "disabled as not appropriate"
+msgstr "Disabled as not appropriate"
+
+#: ../src/develop/pixelpipe_hb.c:508
+msgid ""
+"history had module enabled but it is not allowed for this type of image.\n"
+"likely introduced by applying a preset, style or history copy&paste"
+msgstr ""
+"History had module enabled but it is not allowed for this type of image.\n"
+"Likely introduced by applying a preset, style or history copy&paste"
+
+#: ../src/develop/pixelpipe_hb.c:2732
+msgid ""
+"darktable discovered problems with your OpenCL setup; disabling OpenCL for "
+"this session!"
+msgstr ""
+"Darktable discovered problems with your OpenCL setup; disabling OpenCL for "
+"this session!"
+
+#: ../src/develop/tiling.c:818 ../src/develop/tiling.c:1169
+#, c-format
+msgid "tiling failed for module '%s'. output might be garbled."
+msgstr "Tiling failed for module '%s'. Output might be garbled."
+
+#: ../src/dtgtk/culling.c:232
+msgid "you have reached the start of your selection"
+msgstr "You have reached the start of your selection"
+
+#: ../src/dtgtk/culling.c:241
+msgid "you have reached the start of your collection"
+msgstr "You have reached the start of your collection"
+
+#: ../src/dtgtk/culling.c:286
+msgid "you have reached the end of your selection"
+msgstr "You have reached the end of your selection"
+
+#: ../src/dtgtk/culling.c:311
+msgid "you have reached the end of your collection"
+msgstr "You have reached the end of your collection"
+
+#: ../src/dtgtk/culling.c:405
+#, c-format
+msgid "zooming is limited to %d images"
+msgstr "Zooming is limited to %d images"
+
+#: ../src/dtgtk/range.c:214 ../src/dtgtk/range.c:219
+msgid "invalid"
+msgstr "Invalid"
+
+#: ../src/dtgtk/range.c:327
+#, c-format
+msgid "year %s"
+msgstr "Year %s"
+
+#: ../src/dtgtk/range.c:405
+msgid ""
+"enter the minimal value\n"
+"use 'min' if no bound\n"
+"right-click to select from existing values"
+msgstr ""
+"Enter the minimal value\n"
+"Use 'Min' if no bound\n"
+"Right-click to select from existing values"
+
+#: ../src/dtgtk/range.c:411
+msgid ""
+"enter the maximal value\n"
+"use 'max' if no bound\n"
+"right-click to select from existing values"
+msgstr ""
+"Enter the maximal value\n"
+"Use 'Max' if no bound\n"
+"Right-click to select from existing values"
+
+#: ../src/dtgtk/range.c:417
+msgid ""
+"enter the value\n"
+"right-click to select from existing values"
+msgstr ""
+"Enter the value\n"
+"Right-click to select from existing values"
+
+#: ../src/dtgtk/range.c:422
+msgid ""
+"enter the minimal date\n"
+"in the form YYYY:MM:DD hh:mm:ss.sss (only the year is mandatory)\n"
+"use 'min' if no bound\n"
+"use '-' prefix for relative date\n"
+"right-click to select from calendar or existing values"
+msgstr ""
+"Enter the minimal date\n"
+"in the form YYYY:MM:DD hh:mm:ss.sss (only the year is mandatory)\n"
+"Use 'Min' if no bound\n"
+"Use '-' prefix for relative date\n"
+"Right-click to select from calendar or existing values"
+
+#: ../src/dtgtk/range.c:430
+msgid ""
+"enter the maximal date\n"
+"in the form YYYY:MM:DD hh:mm:ss.sss (only the year is mandatory)\n"
+"use 'max' if no bound\n"
+"'now' keyword is handled\n"
+"use '-' prefix for relative date\n"
+"right-click to select from calendar or existing values"
+msgstr ""
+"Enter the maximal date\n"
+"in the form YYYY:MM:DD hh:mm:ss.sss (only the year is mandatory)\n"
+"Use 'Max' if no bound\n"
+"'Now' keyword is handled\n"
+"Use '-' prefix for relative date\n"
+"Right-click to select from calendar or existing values"
+
+#: ../src/dtgtk/range.c:439
+msgid ""
+"enter the date\n"
+"in the form YYYY:MM:DD hh:mm:ss.sss (only the year is mandatory)\n"
+"right-click to select from calendar or existing values"
+msgstr ""
+"Enter the date\n"
+"in the form YYYY:MM:DD hh:mm:ss.sss (only the year is mandatory)\n"
+"Right-click to select from calendar or existing values"
+
+#: ../src/dtgtk/range.c:461
+msgid "date-time interval to subtract from the max value"
+msgstr "Date-time interval to subtract from the max value"
+
+#: ../src/dtgtk/range.c:465
+msgid "date-time interval to add to the min value"
+msgstr "Date-time interval to add to the min value"
+
+#: ../src/dtgtk/range.c:486
+msgid "fixed"
+msgstr "Fixed"
+
+#: ../src/dtgtk/range.c:487 ../src/iop/colorchecker.c:1315
+msgid "relative"
+msgstr "Relative"
+
+#: ../src/dtgtk/range.c:577
+msgid "selected"
+msgstr "Selected"
+
+#: ../src/dtgtk/range.c:624 ../src/dtgtk/range.c:1768 ../src/dtgtk/range.c:1819
+#: ../src/libs/colorpicker.c:53
+msgid "min"
+msgstr "Min"
+
+#: ../src/dtgtk/range.c:630 ../src/dtgtk/range.c:1780 ../src/dtgtk/range.c:1831
+#: ../src/libs/colorpicker.c:53 ../src/libs/filters/rating_range.c:282
+msgid "max"
+msgstr "Max"
+
+#: ../src/dtgtk/range.c:944
+msgid "date type"
+msgstr "Date type"
+
+#. the date section
+#: ../src/dtgtk/range.c:955 ../src/libs/geotagging.c:1502
+msgid "date"
+msgstr "Date"
+
+#: ../src/dtgtk/range.c:962 ../src/dtgtk/range.c:1028
+msgid ""
+"click to select date\n"
+"double-click to use the date directly"
+msgstr ""
+"Click to select date\n"
+"Double-click to use the date directly"
+
+#: ../src/dtgtk/range.c:973
+msgid "years: "
+msgstr "Years: "
+
+#: ../src/dtgtk/range.c:981
+msgid "months: "
+msgstr "Months: "
+
+#: ../src/dtgtk/range.c:989
+msgid "days: "
+msgstr "Days: "
+
+#. the time section
+#: ../src/dtgtk/range.c:1001 ../src/libs/geotagging.c:1502
+msgid "time"
+msgstr "Time"
+
+#: ../src/dtgtk/range.c:1049
+msgid "current date: "
+msgstr "Current date: "
+
+#: ../src/dtgtk/range.c:1053 ../src/dtgtk/range.c:1787
+#: ../src/dtgtk/range.c:1838
+msgid "now"
+msgstr "Now"
+
+#: ../src/dtgtk/range.c:1055
+msgid "set the value to always match current datetime"
+msgstr "Set the value to always match current datetime"
+
+#. apply button
+#: ../src/dtgtk/range.c:1058 ../src/gui/accelerators.c:162
+#: ../src/libs/metadata.c:827 ../src/libs/styles.c:900
+msgid "apply"
+msgstr "Apply"
+
+#: ../src/dtgtk/range.c:1059
+msgid "set the range bound with this value"
+msgstr "Set the range bound with this value"
+
+#. get nice text for bounds
+#. Side-border hide/show
+#: ../src/dtgtk/range.c:1763 ../src/gui/accelerators.c:2237
+#: ../src/gui/accelerators.c:2316 ../src/gui/gtk.c:1201 ../src/gui/gtk.c:2956
+#: ../src/imageio/format/pdf.c:645 ../src/iop/denoiseprofile.c:3783
+#: ../src/iop/lens.cc:3457 ../src/iop/rawdenoise.c:894
+#: ../src/libs/collect.c:3141 ../src/libs/filtering.c:1460
+#: ../src/libs/filters/colors.c:157 ../src/libs/filters/colors.c:265
+#: ../src/libs/filters/rating.c:211
+msgid "all"
+msgstr "All"
+
+#: ../src/dtgtk/resetlabel.c:59
+msgid "double-click to reset"
+msgstr "Double-click to reset"
+
+#: ../src/dtgtk/thumbnail.c:142 ../src/dtgtk/thumbnail.c:172
+msgid "current"
+msgstr "Current"
+
+#: ../src/dtgtk/thumbnail.c:142 ../src/dtgtk/thumbnail.c:148
+msgid "leader"
+msgstr "Leader"
+
+#: ../src/dtgtk/thumbnail.c:148
+msgid ""
+"\n"
+"click here to set this image as group leader\n"
+msgstr ""
+"\n"
+"Click here to set this image as group leader\n"
+
+#. and the number of grouped images
+#: ../src/dtgtk/thumbnail.c:183 ../src/libs/filters/grouping.c:144
+#: ../src/libs/filters/grouping.c:169
+msgid "grouped images"
+msgstr "Grouped images"
+
+#: ../src/dtgtk/thumbnail.c:762 ../src/dtgtk/thumbnail.c:1449
+#: ../src/iop/ashift.c:6187 ../src/iop/ashift.c:6276 ../src/iop/ashift.c:6278
+#: ../src/iop/ashift.c:6280 ../src/libs/navigation.c:111
+#: ../src/libs/navigation.c:191
+msgid "fit"
+msgstr "Fit"
+
+#: ../src/dtgtk/thumbtable.c:984 ../src/views/slideshow.c:421
+msgid "there are no images in this collection"
+msgstr "There are no images in this collection"
+
+#: ../src/dtgtk/thumbtable.c:991
+msgid "if you have not imported any images yet"
+msgstr "If you have not imported any images yet"
+
+#: ../src/dtgtk/thumbtable.c:995
+msgid "you can do so in the import module"
+msgstr "you can do so in the import module"
+
+#: ../src/dtgtk/thumbtable.c:1003
+msgid "try to relax the filter settings in the top panel"
+msgstr "Try to relax the filter settings in the top panel"
+
+#: ../src/dtgtk/thumbtable.c:1012
+msgid "or add images in the collections module in the left panel"
+msgstr "or add images in the collections module in the left panel"
+
+#: ../src/dtgtk/thumbtable.c:1252
+msgid ""
+"you have changed the settings related to how thumbnails are generated.\n"
+msgstr ""
+"You have changed the settings related to how thumbnails are generated.\n"
+
+#: ../src/dtgtk/thumbtable.c:1254
+msgid ""
+"all cached thumbnails need to be invalidated.\n"
+"\n"
+msgstr ""
+"All cached thumbnails need to be invalidated.\n"
+"\n"
+
+#: ../src/dtgtk/thumbtable.c:1256
+#, c-format
+msgid ""
+"cached thumbnails starting from level %d need to be invalidated.\n"
+"\n"
+msgstr ""
+"Cached thumbnails starting from level %d need to be invalidated.\n"
+"\n"
+
+#: ../src/dtgtk/thumbtable.c:1259
+#, c-format
+msgid ""
+"cached thumbnails below level %d need to be invalidated.\n"
+"\n"
+msgstr ""
+"Cached thumbnails below level %d need to be invalidated.\n"
+"\n"
+
+#: ../src/dtgtk/thumbtable.c:1261
+#, c-format
+msgid ""
+"cached thumbnails between level %d and %d need to be invalidated.\n"
+"\n"
+msgstr ""
+"Cached thumbnails between level %d and %d need to be invalidated.\n"
+"\n"
+
+#: ../src/dtgtk/thumbtable.c:1264
+msgid "do you want to do that now?"
+msgstr "Do you want to do that now?"
+
+#: ../src/dtgtk/thumbtable.c:1266
+msgid "cached thumbnails invalidation"
+msgstr "Cached thumbnails invalidation"
+
+#. setup history key accelerators
+#: ../src/dtgtk/thumbtable.c:2334
+msgid "copy history"
+msgstr "Copy history"
+
+#: ../src/dtgtk/thumbtable.c:2335
+msgid "copy history parts"
+msgstr "Copy history parts"
+
+#: ../src/dtgtk/thumbtable.c:2336
+msgid "paste history"
+msgstr "Paste history"
+
+#: ../src/dtgtk/thumbtable.c:2337
+msgid "paste history parts"
+msgstr "Paste history parts"
+
+#: ../src/dtgtk/thumbtable.c:2338 ../src/libs/copy_history.c:397
+msgid "discard history"
+msgstr "Discard history"
+
+#: ../src/dtgtk/thumbtable.c:2340
+msgid "duplicate image"
+msgstr "Duplicate image"
+
+#: ../src/dtgtk/thumbtable.c:2341
+msgid "duplicate image virgin"
+msgstr "Duplicate image virgin"
+
+#: ../src/dtgtk/thumbtable.c:2347 ../src/libs/select.c:145
+msgid "select film roll"
+msgstr "Select film roll"
+
+#: ../src/dtgtk/thumbtable.c:2348 ../src/libs/select.c:149
+msgid "select untouched"
+msgstr "Select untouched"
+
+#: ../src/generate-cache/main.c:50
+#, c-format
+msgid "creating cache directories\n"
+msgstr "Creating cache directories\n"
+
+#: ../src/generate-cache/main.c:56
+#, c-format
+msgid "creating cache directory '%s'\n"
+msgstr "Creating cache directory '%s'\n"
+
+#: ../src/generate-cache/main.c:59
+#, c-format
+msgid "could not create directory '%s'!\n"
+msgstr "Could not create directory '%s'!\n"
+
+#: ../src/generate-cache/main.c:83
+#, c-format
+msgid "warning: no images are matching the requested image id range\n"
+msgstr "Warning: no images are matching the requested image id range\n"
+
+#: ../src/generate-cache/main.c:86
+#, c-format
+msgid "warning: did you want to swap these boundaries?\n"
+msgstr "Warning: did you want to swap these boundaries?\n"
+
+#: ../src/generate-cache/main.c:227
+#, c-format
+msgid ""
+"warning: disk backend for thumbnail cache is disabled (cache_disk_backend)\n"
+"if you want to pre-generate thumbnails and for darktable to use them, you "
+"need to enable disk backend for thumbnail cache\n"
+"no thumbnails to be generated, done.\n"
+msgstr ""
+"Warning: disk backend for thumbnail cache is disabled (cache_disk_backend)\n"
+"If you want to pre-generate thumbnails and for Darktable to use them, you "
+"need to enable disk backend for thumbnail cache\n"
+"No thumbnails to be generated, done.\n"
+
+#: ../src/generate-cache/main.c:238
+#, c-format
+msgid ""
+"warning: disk backend for full preview cache is disabled "
+"(cache_disk_backend_full)\n"
+"if you want to pre-generate full previews and for darktable to use them, you "
+"need to enable disk backend for full preview cache\n"
+"no full previews to be generated, done.\n"
+msgstr ""
+"Warning: disk backend for full preview cache is disabled "
+"(cache_disk_backend_full)\n"
+"If you want to pre-generate full previews and for Darktable to use them, you "
+"need to enable disk backend for full preview cache\n"
+"No full previews to be generated, done.\n"
+
+#: ../src/generate-cache/main.c:248
+#, c-format
+msgid "error: ensure that min_mip <= max_mip\n"
+msgstr "Error: ensure that min_mip <= max_mip\n"
+
+#: ../src/generate-cache/main.c:253
+#, c-format
+msgid "creating complete lighttable thumbnail cache\n"
+msgstr "Creating complete Lighttable thumbnail cache\n"
+
+#: ../src/gui/accelerators.c:61
+msgid "active view"
+msgstr "Active view"
+
+#: ../src/gui/accelerators.c:62
+msgid "other views"
+msgstr "Other views"
+
+#: ../src/gui/accelerators.c:63
+msgid "fallbacks"
+msgstr "Fallbacks"
+
+#: ../src/gui/accelerators.c:64 ../src/gui/accelerators.c:697
+#: ../src/gui/accelerators.c:2476 ../src/gui/accelerators.c:3323
+msgid "speed"
+msgstr "Speed"
+
+#: ../src/gui/accelerators.c:80 ../src/views/view.c:1202
+msgid "scroll"
+msgstr "Scroll"
+
+#: ../src/gui/accelerators.c:81
+msgid "pan"
+msgstr "Pan"
+
+#: ../src/gui/accelerators.c:82 ../src/iop/ashift.c:5848
+#: ../src/iop/ashift.c:5850 ../src/iop/ashift.c:5955 ../src/iop/ashift.c:5957
+#: ../src/iop/ashift.c:6279 ../src/iop/clipping.c:1902
+#: ../src/iop/clipping.c:2094 ../src/iop/clipping.c:2110
+#: ../src/views/darkroom.c:2663 ../src/views/lighttable.c:1257
+msgid "horizontal"
+msgstr "Horizontal"
+
+#: ../src/gui/accelerators.c:83 ../src/iop/ashift.c:5848
+#: ../src/iop/ashift.c:5850 ../src/iop/ashift.c:5955 ../src/iop/ashift.c:5957
+#: ../src/iop/ashift.c:6277 ../src/iop/clipping.c:1901
+#: ../src/iop/clipping.c:2095 ../src/iop/clipping.c:2109
+#: ../src/views/darkroom.c:2666 ../src/views/lighttable.c:1261
+msgid "vertical"
+msgstr "Vertical"
+
+#: ../src/gui/accelerators.c:84
+msgid "diagonal"
+msgstr "Diagonal"
+
+#: ../src/gui/accelerators.c:86
+msgid "leftright"
+msgstr "LeftRight"
+
+#: ../src/gui/accelerators.c:87
+msgid "updown"
+msgstr "UpDown"
+
+#: ../src/gui/accelerators.c:88
+msgid "pgupdown"
+msgstr "PgUpDown"
+
+#: ../src/gui/accelerators.c:96 ../src/views/view.c:1186
+msgid "shift"
+msgstr "Shift"
+
+#: ../src/gui/accelerators.c:97 ../src/views/view.c:1187
+msgid "ctrl"
+msgstr "Ctrl"
+
+#: ../src/gui/accelerators.c:98 ../src/views/view.c:1188
+msgid "alt"
+msgstr "Alt"
+
+#: ../src/gui/accelerators.c:99
+msgid "cmd"
+msgstr "Cmd"
+
+#: ../src/gui/accelerators.c:100
+msgid "altgr"
+msgstr "AltGr"
+
+#: ../src/gui/accelerators.c:109 ../src/gui/accelerators.c:156
+#: ../src/libs/tagging.c:1779
+msgid "edit"
+msgstr "Edit"
+
+#: ../src/gui/accelerators.c:110 ../src/gui/accelerators.c:657
+msgid "up"
+msgstr "Up"
+
+#: ../src/gui/accelerators.c:111 ../src/gui/accelerators.c:657
+msgid "down"
+msgstr "Down"
+
+#: ../src/gui/accelerators.c:115
+msgid "set"
+msgstr "Set"
+
+#: ../src/gui/accelerators.c:119
+msgid "popup"
+msgstr "Popup"
+
+#: ../src/gui/accelerators.c:120 ../src/gui/accelerators.c:153
+#: ../src/gui/gtk.c:2874 ../src/views/lighttable.c:760
+msgid "next"
+msgstr "Next"
+
+#: ../src/gui/accelerators.c:121 ../src/gui/accelerators.c:152
+#: ../src/gui/gtk.c:2875 ../src/views/lighttable.c:761
+msgid "previous"
+msgstr "Previous"
+
+#: ../src/gui/accelerators.c:123 ../src/gui/accelerators.c:1394
+msgid "last"
+msgstr "Last"
+
+#: ../src/gui/accelerators.c:124 ../src/gui/accelerators.c:1393
+msgid "first"
+msgstr "First"
+
+#: ../src/gui/accelerators.c:128 ../src/gui/accelerators.c:141
+#: ../src/gui/accelerators.c:301 ../src/libs/filters/rating_range.c:268
+#: ../src/libs/tagging.c:3117 ../src/views/darkroom.c:2351
+#: ../src/views/darkroom.c:2401 ../src/views/darkroom.c:2635
+msgid "toggle"
+msgstr "Toggle"
+
+#: ../src/gui/accelerators.c:131
+msgid "ctrl-toggle"
+msgstr "Ctrl-toggle"
+
+#: ../src/gui/accelerators.c:132
+msgid "ctrl-on"
+msgstr "Ctrl-on"
+
+#: ../src/gui/accelerators.c:133
+msgid "right-toggle"
+msgstr "Right-toggle"
+
+#: ../src/gui/accelerators.c:134
+msgid "right-on"
+msgstr "Right-on"
+
+#: ../src/gui/accelerators.c:145 ../src/gui/gtk.c:2873
+msgid "activate"
+msgstr "Activate"
+
+#: ../src/gui/accelerators.c:146
+msgid "ctrl-activate"
+msgstr "Ctrl-activate"
+
+#: ../src/gui/accelerators.c:147
+msgid "right-activate"
+msgstr "Right-activate"
+
+#: ../src/gui/accelerators.c:154
+msgid "store"
+msgstr "Store"
+
+#: ../src/gui/accelerators.c:157 ../src/gui/styles_dialog.c:637
+msgid "update"
+msgstr "Update"
+
+#: ../src/gui/accelerators.c:158 ../src/libs/tools/global_toolbox.c:61
+#: ../src/libs/tools/global_toolbox.c:512
+msgid "preferences"
+msgstr "Preferences"
+
+#: ../src/gui/accelerators.c:163
+msgid "apply on new instance"
+msgstr "Apply on new instance"
+
+#: ../src/gui/accelerators.c:168
+msgid "start"
+msgstr "Start"
+
+#: ../src/gui/accelerators.c:169
+msgid "end"
+msgstr "End"
+
+#: ../src/gui/accelerators.c:319
+msgid "entry"
+msgstr "Entry"
+
+#: ../src/gui/accelerators.c:394
+msgid "combo effect not found"
+msgstr "Combo effect not found"
+
+#: ../src/gui/accelerators.c:553
+msgid "(keypad)"
+msgstr "(keypad)"
+
+#: ../src/gui/accelerators.c:562
+msgid "tablet button"
+msgstr "Tablet button"
+
+#: ../src/gui/accelerators.c:571
+msgid "unknown driver"
+msgstr "Unknown driver"
+
+#: ../src/gui/accelerators.c:638
+msgid "long"
+msgstr "Long"
+
+#: ../src/gui/accelerators.c:639
+msgid "double-press"
+msgstr "Double-press"
+
+#: ../src/gui/accelerators.c:640
+msgid "triple-press"
+msgstr "Triple-press"
+
+#: ../src/gui/accelerators.c:641
+msgid "press"
+msgstr "Press"
+
+#: ../src/gui/accelerators.c:645
+msgctxt "accel"
+msgid "left"
+msgstr "Left"
+
+#: ../src/gui/accelerators.c:646
+msgctxt "accel"
+msgid "right"
+msgstr "Right"
+
+#: ../src/gui/accelerators.c:647
+msgctxt "accel"
+msgid "middle"
+msgstr "Middle"
+
+#: ../src/gui/accelerators.c:648
+msgctxt "accel"
+msgid "long"
+msgstr "Long"
+
+#: ../src/gui/accelerators.c:649
+msgctxt "accel"
+msgid "double-click"
+msgstr "Double-click"
+
+#: ../src/gui/accelerators.c:650
+msgctxt "accel"
+msgid "triple-click"
+msgstr "Triple-click"
+
+#: ../src/gui/accelerators.c:651
+msgid "click"
+msgstr "Click"
+
+#: ../src/gui/accelerators.c:679
+msgid "first instance"
+msgstr "First instance"
+
+#: ../src/gui/accelerators.c:681
+msgid "last instance"
+msgstr "Last instance"
+
+#: ../src/gui/accelerators.c:683
+msgid "relative instance"
+msgstr "Relative instance"
+
+#: ../src/gui/accelerators.c:831
+#, c-format
+msgid ""
+"lua script command copied to clipboard:\n"
+"\n"
+"<tt>%s</tt>"
+msgstr ""
+"Lua script command copied to clipboard:\n"
+"\n"
+"<tt>%s</tt>"
+
+#: ../src/gui/accelerators.c:915
+msgid "press Delete to delete selected shortcut"
+msgstr "Press Delete to delete selected shortcut"
+
+#: ../src/gui/accelerators.c:916
+msgid "double-click to add new shortcut"
+msgstr "Double-click to add new shortcut"
+
+#: ../src/gui/accelerators.c:917 ../src/gui/accelerators.c:930
+msgid "start typing for incremental search"
+msgstr "Start typing for incremental search"
+
+#: ../src/gui/accelerators.c:927
+msgid "click to filter shortcut list"
+msgstr "Click to filter shortcut list"
+
+#: ../src/gui/accelerators.c:928
+msgid "right click to show action of selected shortcut\n"
+msgstr "Right click to show action of selected shortcut\n"
+
+#: ../src/gui/accelerators.c:929
+msgid "double-click to define new shortcut"
+msgstr "Double-click to define new shortcut"
+
+#: ../src/gui/accelerators.c:952
+msgid "shift+alt+scroll to change height"
+msgstr "Shift+Alt+scroll to change height"
+
+#: ../src/gui/accelerators.c:972
+msgid ""
+"press keys with mouse click and scroll or move combinations to create a "
+"shortcut"
+msgstr ""
+"Press keys with mouse click and scroll or move combinations to create a "
+"shortcut"
+
+#: ../src/gui/accelerators.c:973
+msgid "click to open shortcut configuration"
+msgstr "Click to open shortcut configuration"
+
+#: ../src/gui/accelerators.c:974
+msgid "ctrl+click to add to quick access panel\n"
+msgstr "Ctrl+click to add to quick access panel\n"
+
+#: ../src/gui/accelerators.c:975
+msgid "ctrl+click to remove from quick access panel\n"
+msgstr "Ctrl+click to remove from quick access panel\n"
+
+#: ../src/gui/accelerators.c:976
+msgid "scroll to change default speed"
+msgstr "Scroll to change default speed"
+
+#: ../src/gui/accelerators.c:977
+msgid "right click to exit mapping mode"
+msgstr "Right click to exit mapping mode"
+
+#: ../src/gui/accelerators.c:1033
+msgid "ctrl+v"
+msgstr "Ctrl+v"
+
+#: ../src/gui/accelerators.c:1033
+msgid "right long click"
+msgstr "Right long click"
+
+#: ../src/gui/accelerators.c:1033
+msgid "to copy lua command"
+msgstr "to copy lua command"
+
+#: ../src/gui/accelerators.c:1277
+msgid "shortcut for move exists with single effect"
+msgstr "Shortcut for move exists with single effect"
+
+#: ../src/gui/accelerators.c:1278
+msgid "create separate shortcuts for up and down move?"
+msgstr "Create separate shortcuts for up and down move?"
+
+#: ../src/gui/accelerators.c:1301
+#, c-format
+msgid "%s, speed reset"
+msgstr "%s, speed reset"
+
+#: ../src/gui/accelerators.c:1310
+msgid "shortcut exists with different settings"
+msgstr "Shortcut exists with different settings"
+
+#: ../src/gui/accelerators.c:1311
+msgid "reset the settings of the shortcut?"
+msgstr "Reset the settings of the shortcut?"
+
+#: ../src/gui/accelerators.c:1322
+msgid "shortcut already exists"
+msgstr "Shortcut already exists"
+
+#: ../src/gui/accelerators.c:1323
+msgid "remove the shortcut?"
+msgstr "Remove the shortcut?"
+
+#: ../src/gui/accelerators.c:1355
+msgid "clashing shortcuts exist"
+msgstr "Clashing shortcuts exist"
+
+#: ../src/gui/accelerators.c:1356
+msgid "remove these existing shortcuts?"
+msgstr "Remove these existing shortcuts?"
+
+#. or 3, but change char relative[] = "-2" to "-1"
+#. NUM_INSTANCES
+#: ../src/gui/accelerators.c:1392
+msgid "preferred"
+msgstr "Preferred"
+
+#: ../src/gui/accelerators.c:1395
+msgid "second"
+msgstr "Second"
+
+#: ../src/gui/accelerators.c:1396
+msgid "last but one"
+msgstr "Last but one"
+
+#: ../src/gui/accelerators.c:1528 ../src/gui/accelerators.c:1582
+msgid "(unchanged)"
+msgstr "(unchanged)"
+
+#: ../src/gui/accelerators.c:1677
+msgid ""
+"define a shortcut by pressing a key, optionally combined with modifier keys "
+"(ctrl/shift/alt)\n"
+"a key can be double or triple pressed, with a long last press\n"
+"while the key is held, a combination of mouse buttons can be (double/triple/"
+"long) clicked\n"
+"still holding the key (and modifiers and/or buttons) a scroll or mouse move "
+"can be added\n"
+"connected devices can send keys or moves using their physical controllers\n"
+"\n"
+"right-click to cancel"
+msgstr ""
+"Define a shortcut by pressing a key, optionally combined with modifier keys "
+"(Ctrl/Shift/Alt)\n"
+"A key can be double or triple pressed, with a long last press\n"
+"While the key is held, a combination of mouse buttons can be (double/triple/"
+"long) clicked\n"
+"Still holding the key (and modifiers and/or buttons) a scroll or mouse move "
+"can be added\n"
+"Connected devices can send keys or moves using their physical controllers\n"
+"\n"
+"Right-click to cancel"
+
+#: ../src/gui/accelerators.c:1745
+msgid "removing shortcut"
+msgstr "Removing shortcut"
+
+#: ../src/gui/accelerators.c:1746
+msgid "remove the selected shortcut?"
+msgstr "Remove the selected shortcut?"
+
+#: ../src/gui/accelerators.c:2147
+msgid "restore shortcuts"
+msgstr "Restore shortcuts"
+
+#: ../src/gui/accelerators.c:2151
+msgid "_defaults"
+msgstr "_Defaults"
+
+#: ../src/gui/accelerators.c:2152
+msgid "_startup"
+msgstr "_Startup"
+
+#: ../src/gui/accelerators.c:2153
+msgid "_edits"
+msgstr "_Edits"
+
+#: ../src/gui/accelerators.c:2158
+msgid ""
+"restore shortcuts from one of these states:\n"
+"  - default\n"
+"  - as at startup\n"
+"  - as when opening this dialog\n"
+msgstr ""
+"Restore shortcuts from one of these states:\n"
+"  - default\n"
+"  - as at startup\n"
+"  - as when opening this dialog\n"
+
+#: ../src/gui/accelerators.c:2161
+msgid ""
+"clear all newer shortcuts\n"
+"(instead of just restoring changed ones)"
+msgstr ""
+"Clear all newer shortcuts\n"
+"(instead of just restoring changed ones)"
+
+#: ../src/gui/accelerators.c:2215 ../src/gui/preferences.c:896
+#: ../src/libs/tools/global_toolbox.c:496
+#: ../src/libs/tools/global_toolbox.c:809
+msgid "shortcuts"
+msgstr "Shortcuts"
+
+#: ../src/gui/accelerators.c:2224
+msgid "export shortcuts"
+msgstr "Export shortcuts"
+
+#: ../src/gui/accelerators.c:2227 ../src/gui/accelerators.c:2306
+#: ../src/gui/hist_dialog.c:227 ../src/gui/presets.c:499
+msgid "_ok"
+msgstr "_OK"
+
+#: ../src/gui/accelerators.c:2232
+msgid ""
+"export all shortcuts to a file\n"
+"or just for one selected device\n"
+msgstr ""
+"Export all shortcuts to a file\n"
+"or just for one selected device\n"
+
+#: ../src/gui/accelerators.c:2238 ../src/gui/accelerators.c:2317
+msgid "keyboard"
+msgstr "Keyboard"
+
+#: ../src/gui/accelerators.c:2250
+msgid "device id"
+msgstr "Device id"
+
+#: ../src/gui/accelerators.c:2276
+msgid "select file to export"
+msgstr "Select file to export"
+
+#: ../src/gui/accelerators.c:2277 ../src/libs/tagging.c:2522
+msgid "_export"
+msgstr "_Export"
+
+#: ../src/gui/accelerators.c:2303
+msgid "import shortcuts"
+msgstr "Import shortcuts"
+
+#: ../src/gui/accelerators.c:2311
+msgid ""
+"import all shortcuts from a file\n"
+"or just for one selected device\n"
+msgstr ""
+"Import all shortcuts from a file\n"
+"or just for one selected device\n"
+
+#: ../src/gui/accelerators.c:2329
+msgid "id in file"
+msgstr "Id in file"
+
+#: ../src/gui/accelerators.c:2335
+msgid "id when loaded"
+msgstr "Id when loaded"
+
+#: ../src/gui/accelerators.c:2339
+msgid "clear device first"
+msgstr "Clear device first"
+
+#: ../src/gui/accelerators.c:2363
+msgid "select file to import"
+msgstr "Select file to import"
+
+#: ../src/gui/accelerators.c:2364 ../src/libs/tagging.c:2486
+msgid "_import"
+msgstr "_Import"
+
+#: ../src/gui/accelerators.c:2437
+msgid "search shortcuts list"
+msgstr "Search shortcuts list"
+
+#: ../src/gui/accelerators.c:2438
+msgid ""
+"incrementally search the list of shortcuts\n"
+"press up or down keys to cycle through matches"
+msgstr ""
+"Incrementally search the list of shortcuts\n"
+"Press up or down keys to cycle through matches"
+
+#. Setting up the cell renderers
+#: ../src/gui/accelerators.c:2452 ../src/views/view.c:1383
+msgid "shortcut"
+msgstr "Shortcut"
+
+#: ../src/gui/accelerators.c:2454 ../src/gui/accelerators.c:2545
+#: ../src/views/view.c:1385
+msgid "action"
+msgstr "Action"
+
+#: ../src/gui/accelerators.c:2463
+msgid "element"
+msgstr "Element"
+
+#: ../src/gui/accelerators.c:2470
+msgid "effect"
+msgstr "Effect"
+
+#: ../src/gui/accelerators.c:2527
+msgid "search actions list"
+msgstr "Search actions list"
+
+#: ../src/gui/accelerators.c:2528
+msgid ""
+"incrementally search the list of actions\n"
+"press up or down keys to cycle through matches"
+msgstr ""
+"Incrementally search the list of actions\n"
+"Press up or down keys to cycle through matches"
+
+#: ../src/gui/accelerators.c:2551 ../src/gui/guides.c:719
+#: ../src/libs/export_metadata.c:192
+msgid "type"
+msgstr "Type"
+
+#: ../src/gui/accelerators.c:2586
+msgid "enable fallbacks"
+msgstr "Enable fallbacks"
+
+#: ../src/gui/accelerators.c:2587
+msgid ""
+"enables default meanings for additional buttons, modifiers or moves\n"
+"when used in combination with a base shortcut"
+msgstr ""
+"Enables default meanings for additional buttons, modifiers or moves\n"
+"when used in combination with a base shortcut"
+
+#: ../src/gui/accelerators.c:2593
+msgid "restore..."
+msgstr "Restore..."
+
+#: ../src/gui/accelerators.c:2594
+msgid "restore default shortcuts or previous state"
+msgstr "Restore default shortcuts or previous state"
+
+#: ../src/gui/accelerators.c:2598 ../src/libs/styles.c:886
+#: ../src/libs/tagging.c:3249
+msgid "import..."
+msgstr "Import..."
+
+#: ../src/gui/accelerators.c:2599
+msgid "fully or partially import shortcuts from file"
+msgstr "Fully or partially import shortcuts from file"
+
+#: ../src/gui/accelerators.c:2603 ../src/libs/styles.c:893
+#: ../src/libs/tagging.c:3252
+msgid "export..."
+msgstr "Export..."
+
+#: ../src/gui/accelerators.c:2604
+msgid "fully or partially export shortcuts to file"
+msgstr "Fully or partially export shortcuts to file"
+
+#: ../src/gui/accelerators.c:3019
+msgid "input devices reinitialised"
+msgstr "Input devices reinitialised"
+
+#: ../src/gui/accelerators.c:3201
+msgid "fallback to move"
+msgstr "Fallback to move"
+
+#: ../src/gui/accelerators.c:3424
+#, c-format
+msgid "%s not assigned"
+msgstr "%s not assigned"
+
+#: ../src/gui/accelerators.c:3592
+#, c-format
+msgid "%s assigned to %s"
+msgstr "%s assigned to %s"
+
+#: ../src/gui/gtk.c:172 ../src/views/darkroom.c:4642
+msgid "darktable - darkroom preview"
+msgstr "Darktable - Darkroom preview"
+
+#: ../src/gui/gtk.c:183
+msgid "tooltips off"
+msgstr "Tooltips off"
+
+#: ../src/gui/gtk.c:185
+msgid "tooltips on"
+msgstr "Tooltips on"
+
+#: ../src/gui/gtk.c:190
+msgid ""
+"tooltip visibility can only be toggled if compositing is enabled in your "
+"window manager"
+msgstr ""
+"Tooltip visibility can only be toggled if compositing is enabled in your "
+"window manager"
+
+#: ../src/gui/gtk.c:813
+msgid "closing darktable..."
+msgstr "Closing Darktable..."
+
+#: ../src/gui/gtk.c:1132
+msgid "panels"
+msgstr "Panels"
+
+#. an action that does nothing - used for overriding/removing default shortcuts
+#: ../src/gui/gtk.c:1181
+msgid "no-op"
+msgstr "No-op"
+
+#: ../src/gui/gtk.c:1183
+msgid "switch views"
+msgstr "Switch views"
+
+#: ../src/gui/gtk.c:1184 ../src/views/tethering.c:102
+msgid "tethering"
+msgstr "Tethering"
+
+#: ../src/gui/gtk.c:1187 ../src/views/map.c:197
+msgid "map"
+msgstr "Map"
+
+#: ../src/gui/gtk.c:1188 ../src/views/slideshow.c:389
+msgid "slideshow"
+msgstr "Slideshow"
+
+#. Print button
+#: ../src/gui/gtk.c:1189 ../src/libs/print_settings.c:2706
+msgid "print"
+msgstr "Print"
+
+#. register ctrl-q to quit:
+#: ../src/gui/gtk.c:1195
+msgid "quit"
+msgstr "Quit"
+
+#. Full-screen accelerator (no ESC handler here to enable quit-slideshow using ESC)
+#: ../src/gui/gtk.c:1198
+msgid "fullscreen"
+msgstr "Fullscreen"
+
+#: ../src/gui/gtk.c:1202
+msgid "collapsing controls"
+msgstr "Collapsing controls"
+
+#. specific top/bottom toggles
+#: ../src/gui/gtk.c:1204
+msgid "header"
+msgstr "Header"
+
+#: ../src/gui/gtk.c:1205
+msgid "filmstrip and timeline"
+msgstr "Filmstrip and timeline"
+
+#: ../src/gui/gtk.c:1206
+msgid "top toolbar"
+msgstr "Top toolbar"
+
+#: ../src/gui/gtk.c:1207
+msgid "bottom toolbar"
+msgstr "Bottom toolbar"
+
+#: ../src/gui/gtk.c:1208
+msgid "all top"
+msgstr "All top"
+
+#: ../src/gui/gtk.c:1209
+msgid "all bottom"
+msgstr "All bottom"
+
+#: ../src/gui/gtk.c:1211
+msgid "toggle tooltip visibility"
+msgstr "Toggle tooltip visibility"
+
+#: ../src/gui/gtk.c:1212
+msgid "reinitialise input devices"
+msgstr "Reinitialise input devices"
+
+#: ../src/gui/gtk.c:1250
+msgid "toggle focus-peaking mode"
+msgstr "Toggle focus-peaking mode"
+
+#. toggle focus peaking everywhere
+#: ../src/gui/gtk.c:1255
+msgid "toggle focus peaking"
+msgstr "Toggle focus peaking"
+
+#: ../src/gui/gtk.c:1591 ../src/gui/gtk.c:2963 ../src/gui/gtk.c:2968
+#: ../src/gui/gtk.c:2973 ../src/gui/gtk.c:2978
+msgid "tabs"
+msgstr "Tabs"
+
+#: ../src/gui/gtk.c:2532
+msgid "_yes"
+msgstr "_Yes"
+
+#: ../src/gui/gtk.c:2533
+msgid "_no"
+msgstr "_No"
+
+#. font name can only use period as decimal separator
+#. but printf format strings use comma for some locales, so replace comma with period
+#: ../src/gui/gtk.c:2572
+#, c-format
+msgid "%.1f"
+msgstr "%.1f"
+
+#: ../src/gui/gtk.c:2574
+#, c-format
+msgid "Sans %s"
+msgstr "Sans %s"
+
+#: ../src/gui/gtk.c:2868
+msgid "does not contain pages"
+msgstr "Does not contain pages"
+
+#: ../src/gui/gtk.c:3085
+#, c-format
+msgid "never show more than %d lines"
+msgstr "Never show more than %d lines"
+
+#: ../src/gui/gtkentry.c:172
+msgid "$(ROLL.NAME) - roll of the input image"
+msgstr "$(ROLL.NAME) - roll of the input image"
+
+#: ../src/gui/gtkentry.c:173
+msgid "$(FILE.FOLDER) - folder containing the input image"
+msgstr "$(FILE.FOLDER) - folder containing the input image"
+
+#: ../src/gui/gtkentry.c:174
+msgid "$(FILE.NAME) - basename of the input image"
+msgstr "$(FILE.NAME) - basename of the input image"
+
+#: ../src/gui/gtkentry.c:175
+msgid "$(FILE.EXTENSION) - extension of the input image"
+msgstr "$(FILE.EXTENSION) - extension of the input image"
+
+#: ../src/gui/gtkentry.c:176
+msgid "$(VERSION) - duplicate version"
+msgstr "$(VERSION) - duplicate version"
+
+#: ../src/gui/gtkentry.c:177
+msgid ""
+"$(VERSION.IF_MULTI) - same as $(VERSION) but null string if only one version "
+"exists"
+msgstr ""
+"$(VERSION.IF_MULTI) - same as $(VERSION) but null string if only one version "
+"exists"
+
+#: ../src/gui/gtkentry.c:178
+msgid "$(VERSION.NAME) - version name from metadata"
+msgstr "$(VERSION.NAME) - version name from metadata"
+
+#: ../src/gui/gtkentry.c:179
+msgid "$(JOBCODE) - job code for import"
+msgstr "$(JOBCODE) - job code for import"
+
+#: ../src/gui/gtkentry.c:180
+msgid "$(SEQUENCE) - sequence number"
+msgstr "$(SEQUENCE) - sequence number"
+
+#: ../src/gui/gtkentry.c:181
+msgid "$(WIDTH.MAX) - maximum image export width"
+msgstr "$(WIDTH.MAX) - maximum image export width"
+
+#: ../src/gui/gtkentry.c:182
+msgid "$(WIDTH.SENSOR) - image sensor width"
+msgstr "$(WIDTH.SENSOR) - image sensor width"
+
+#: ../src/gui/gtkentry.c:183
+msgid "$(WIDTH.RAW) - RAW image width"
+msgstr "$(WIDTH.RAW) - RAW image width"
+
+#: ../src/gui/gtkentry.c:184
+msgid "$(WIDTH.CROP) - image width after crop"
+msgstr "$(WIDTH.CROP) - image width after crop"
+
+#: ../src/gui/gtkentry.c:185
+msgid "$(WIDTH.EXPORT) - exported image width"
+msgstr "$(WIDTH.EXPORT) - exported image width"
+
+#: ../src/gui/gtkentry.c:186
+msgid "$(HEIGHT.MAX) - maximum image export height"
+msgstr "$(HEIGHT.MAX) - maximum image export height"
+
+#: ../src/gui/gtkentry.c:187
+msgid "$(HEIGHT.SENSOR) - image sensor height"
+msgstr "$(HEIGHT.SENSOR) - image sensor height"
+
+#: ../src/gui/gtkentry.c:188
+msgid "$(HEIGHT.RAW) - RAW image height"
+msgstr "$(HEIGHT.RAW) - RAW image height"
+
+#: ../src/gui/gtkentry.c:189
+msgid "$(HEIGHT.CROP) - image height after crop"
+msgstr "$(HEIGHT.CROP) - image height after crop"
+
+#: ../src/gui/gtkentry.c:190
+msgid "$(HEIGHT.EXPORT) - exported image height"
+msgstr "$(HEIGHT.EXPORT) - exported image height"
+
+#: ../src/gui/gtkentry.c:191
+msgid "$(YEAR) - year"
+msgstr "$(YEAR) - year"
+
+#: ../src/gui/gtkentry.c:192
+msgid "$(YEAR.SHORT) - year without century"
+msgstr "$(YEAR.SHORT) - year without century"
+
+#: ../src/gui/gtkentry.c:193
+msgid "$(MONTH) - month"
+msgstr "$(MONTH) - month"
+
+#: ../src/gui/gtkentry.c:194
+msgid "$(MONTH.SHORT) - abbreviated month name according to the current locale"
+msgstr ""
+"$(MONTH.SHORT) - abbreviated month name according to the current locale"
+
+#: ../src/gui/gtkentry.c:195
+msgid "$(MONTH.LONG) - full month name according to the current locale"
+msgstr "$(MONTH.LONG) - full month name according to the current locale"
+
+#: ../src/gui/gtkentry.c:196
+msgid "$(DAY) - day"
+msgstr "$(DAY) - day"
+
+#: ../src/gui/gtkentry.c:197
+msgid "$(HOUR) - hour"
+msgstr "$(HOUR) - hour"
+
+#: ../src/gui/gtkentry.c:198
+msgid "$(HOUR.AMPM) - hour, 12-hour clock"
+msgstr "$(HOUR.AMPM) - hour, 12-hour clock"
+
+#: ../src/gui/gtkentry.c:199
+msgid "$(MINUTE) - minute"
+msgstr "$(MINUTE) - minute"
+
+#: ../src/gui/gtkentry.c:200
+msgid "$(SECOND) - second"
+msgstr "$(SECOND) - second"
+
+#: ../src/gui/gtkentry.c:201
+msgid "$(MSEC) - millisecond"
+msgstr "$(MSEC) - millisecond"
+
+#: ../src/gui/gtkentry.c:202
+msgid "$(EXIF.YEAR) - EXIF year"
+msgstr "$(EXIF.YEAR) - EXIF year"
+
+#: ../src/gui/gtkentry.c:203
+msgid "$(EXIF.YEAR.SHORT) - EXIF year without century"
+msgstr "$(EXIF.YEAR.SHORT) - EXIF year without century"
+
+#: ../src/gui/gtkentry.c:204
+msgid "$(EXIF.MONTH) - EXIF month"
+msgstr "$(EXIF.MONTH) - EXIF month"
+
+#: ../src/gui/gtkentry.c:205
+msgid ""
+"$(EXIF.MONTH.SHORT) - abbreviated EXIF month name according to the current "
+"locale"
+msgstr ""
+"$(EXIF.MONTH.SHORT) - abbreviated EXIF month name according to the current "
+"locale"
+
+#: ../src/gui/gtkentry.c:206
+msgid ""
+"$(EXIF.MONTH.LONG) - full EXIF month name according to the current locale"
+msgstr ""
+"$(EXIF.MONTH.LONG) - full EXIF month name according to the current locale"
+
+#: ../src/gui/gtkentry.c:207
+msgid "$(EXIF.DAY) - EXIF day"
+msgstr "$(EXIF.DAY) - EXIF day"
+
+#: ../src/gui/gtkentry.c:208
+msgid "$(EXIF.HOUR) - EXIF hour"
+msgstr "$(EXIF.HOUR) - EXIF hour"
+
+#: ../src/gui/gtkentry.c:209
+msgid "$(EXIF.HOUR.AMPM) - EXIF hour, 12-hour clock"
+msgstr "$(EXIF.HOUR.AMPM) - EXIF hour, 12-hour clock"
+
+#: ../src/gui/gtkentry.c:210
+msgid "$(EXIF.MINUTE) - EXIF minute"
+msgstr "$(EXIF.MINUTE) - EXIF minute"
+
+#: ../src/gui/gtkentry.c:211
+msgid "$(EXIF.SECOND) - EXIF second"
+msgstr "$(EXIF.SECOND) - EXIF second"
+
+#: ../src/gui/gtkentry.c:212
+msgid "$(EXIF.MSEC) - EXIF millisecond"
+msgstr "$(EXIF.MSEC) - EXIF millisecond"
+
+#: ../src/gui/gtkentry.c:213
+msgid "$(EXIF.ISO) - ISO value"
+msgstr "$(EXIF.ISO) - ISO value"
+
+#: ../src/gui/gtkentry.c:214
+msgid "$(EXIF.EXPOSURE) - EXIF exposure"
+msgstr "$(EXIF.EXPOSURE) - EXIF exposure"
+
+#: ../src/gui/gtkentry.c:215
+msgid "$(EXIF.EXPOSURE.BIAS) - EXIF exposure bias"
+msgstr "$(EXIF.EXPOSURE.BIAS) - EXIF exposure bias"
+
+#: ../src/gui/gtkentry.c:216
+msgid "$(EXIF.APERTURE) - EXIF aperture"
+msgstr "$(EXIF.APERTURE) - EXIF aperture"
+
+#: ../src/gui/gtkentry.c:217
+msgid "$(EXIF.FOCAL.LENGTH) - EXIF focal length"
+msgstr "$(EXIF.FOCAL.LENGTH) - EXIF focal length"
+
+#: ../src/gui/gtkentry.c:218
+msgid "$(EXIF.FOCUS.DISTANCE) - EXIF focal distance"
+msgstr "$(EXIF.FOCUS.DISTANCE) - EXIF focal distance"
+
+#: ../src/gui/gtkentry.c:219
+msgid "$(EXIF.MAKER) - camera maker"
+msgstr "$(EXIF.MAKER) - camera maker"
+
+#: ../src/gui/gtkentry.c:220
+msgid "$(EXIF.MODEL) - camera model"
+msgstr "$(EXIF.MODEL) - camera model"
+
+#: ../src/gui/gtkentry.c:221
+msgid "$(EXIF.LENS) - lens"
+msgstr "$(EXIF.LENS) - lens"
+
+#: ../src/gui/gtkentry.c:222
+msgid "$(LONGITUDE) - longitude"
+msgstr "$(LONGITUDE) - longitude"
+
+#: ../src/gui/gtkentry.c:223
+msgid "$(LATITUDE) - latitude"
+msgstr "$(LATITUDE) - latitude"
+
+#: ../src/gui/gtkentry.c:224
+msgid "$(ELEVATION) - elevation"
+msgstr "$(ELEVATION) - elevation"
+
+#: ../src/gui/gtkentry.c:225
+msgid "$(STARS) - star rating as number (-1 for rejected)"
+msgstr "$(STARS) - star rating as number (-1 for rejected)"
+
+#: ../src/gui/gtkentry.c:226
+msgid "$(RATING.ICONS) - star/reject rating in icon form"
+msgstr "$(RATING.ICONS) - star/reject rating in icon form"
+
+#: ../src/gui/gtkentry.c:227
+msgid "$(LABELS) - color labels as text"
+msgstr "$(LABELS) - color labels as text"
+
+#: ../src/gui/gtkentry.c:228
+msgid "$(LABELS.ICONS) - color labels as icons"
+msgstr "$(LABELS.ICONS) - color labels as icons"
+
+#: ../src/gui/gtkentry.c:229
+msgid "$(ID) - image ID"
+msgstr "$(ID) - image ID"
+
+#: ../src/gui/gtkentry.c:230
+msgid "$(TITLE) - title from metadata"
+msgstr "$(TITLE) - title from metadata"
+
+#: ../src/gui/gtkentry.c:231
+msgid "$(DESCRIPTION) - description from metadata"
+msgstr "$(DESCRIPTION) - description from metadata"
+
+#: ../src/gui/gtkentry.c:232
+msgid "$(CREATOR) - creator from metadata"
+msgstr "$(CREATOR) - creator from metadata"
+
+#: ../src/gui/gtkentry.c:233
+msgid "$(PUBLISHER) - publisher from metadata"
+msgstr "$(PUBLISHER) - publisher from metadata"
+
+#: ../src/gui/gtkentry.c:234
+msgid "$(RIGHTS) - rights from metadata"
+msgstr "$(RIGHTS) - rights from metadata"
+
+#: ../src/gui/gtkentry.c:235
+msgid "$(USERNAME) - login name"
+msgstr "$(USERNAME) - login name"
+
+#: ../src/gui/gtkentry.c:236
+msgid "$(FOLDER.PICTURES) - pictures folder"
+msgstr "$(FOLDER.PICTURES) - pictures folder"
+
+#: ../src/gui/gtkentry.c:237
+msgid "$(FOLDER.HOME) - home folder"
+msgstr "$(FOLDER.HOME) - home folder"
+
+#: ../src/gui/gtkentry.c:238
+msgid "$(FOLDER.DESKTOP) - desktop folder"
+msgstr "$(FOLDER.DESKTOP) - desktop folder"
+
+#: ../src/gui/gtkentry.c:239
+msgid "$(OPENCL.ACTIVATED) - whether OpenCL is activated"
+msgstr "$(OPENCL.ACTIVATED) - whether OpenCL is activated"
+
+#: ../src/gui/gtkentry.c:240
+msgid "$(CATEGORY0(category)) - subtag of level 0 in hierarchical tags"
+msgstr "$(CATEGORY0(category)) - subtag of level 0 in hierarchical tags"
+
+#: ../src/gui/gtkentry.c:241
+msgid "$(TAGS) - tags as set in metadata settings"
+msgstr "$(TAGS) - tags as set in metadata settings"
+
+#: ../src/gui/gtkentry.c:242
+msgid "$(DARKTABLE.NAME) - darktable name"
+msgstr "$(DARKTABLE.NAME) - Darktable name"
+
+#: ../src/gui/gtkentry.c:243
+msgid "$(DARKTABLE.VERSION) - current darktable version"
+msgstr "$(DARKTABLE.VERSION) - current Darktable version"
+
+#: ../src/gui/guides.c:30 ../src/iop/colorcorrection.c:255
+msgid "grid"
+msgstr "Grid"
+
+#: ../src/gui/guides.c:31
+msgid "rules of thirds"
+msgstr "Rules of thirds"
+
+#: ../src/gui/guides.c:32
+msgid "metering"
+msgstr "Metering"
+
+#: ../src/gui/guides.c:33
+msgid "perspective"
+msgstr "Perspective"
+
+#: ../src/gui/guides.c:34
+msgid "diagonal method"
+msgstr "Diagonal method"
+
+#: ../src/gui/guides.c:35
+msgid "harmonious triangles"
+msgstr "Harmonious triangles"
+
+#: ../src/gui/guides.c:36
+msgid "golden sections"
+msgstr "Golden sections"
+
+#: ../src/gui/guides.c:37
+msgid "golden spiral"
+msgstr "Golden spiral"
+
+#: ../src/gui/guides.c:38
+msgid "golden spiral sections"
+msgstr "Golden spiral sections"
+
+#: ../src/gui/guides.c:39
+msgid "golden mean (all guides)"
+msgstr "Golden mean (all guides)"
+
+#: ../src/gui/guides.c:218
+msgid "horizontal lines"
+msgstr "Horizontal lines"
+
+#: ../src/gui/guides.c:219
+msgid "number of horizontal guide lines"
+msgstr "Number of horizontal guide lines"
+
+#: ../src/gui/guides.c:228
+msgid "vertical lines"
+msgstr "Vertical lines"
+
+#: ../src/gui/guides.c:229
+msgid "number of vertical guide lines"
+msgstr "Number of vertical guide lines"
+
+#: ../src/gui/guides.c:238
+msgid "subdivisions"
+msgstr "Subdivisions"
+
+#: ../src/gui/guides.c:239
+msgid "number of subdivisions per grid rectangle"
+msgstr "Number of subdivisions per grid rectangle"
+
+#. title
+#: ../src/gui/guides.c:700
+msgid "global guide overlay settings"
+msgstr "Global guide overlay settings"
+
+#: ../src/gui/guides.c:710 ../src/gui/guides.c:719 ../src/gui/guides.c:727
+#: ../src/gui/guides.c:740 ../src/views/darkroom.c:2635
+msgid "guide lines"
+msgstr "Guide lines"
+
+#: ../src/gui/guides.c:710 ../src/iop/clipping.c:2092
+msgid "flip"
+msgstr "Flip"
+
+#: ../src/gui/guides.c:710
+msgid "flip guides"
+msgstr "Flip guides"
+
+#: ../src/gui/guides.c:713
+msgid "horizontally"
+msgstr "Horizontally"
+
+#: ../src/gui/guides.c:714
+msgid "vertically"
+msgstr "Vertically"
+
+#: ../src/gui/guides.c:715 ../src/iop/ashift.c:6281 ../src/iop/clipping.c:2096
+#: ../src/iop/colorbalance.c:1920
+msgid "both"
+msgstr "Both"
+
+#: ../src/gui/guides.c:720
+msgid "setup guide lines"
+msgstr "Setup guide lines"
+
+#: ../src/gui/guides.c:727
+msgid "overlay color"
+msgstr "Overlay color"
+
+#: ../src/gui/guides.c:727
+msgid "set overlay color"
+msgstr "Set overlay color"
+
+#: ../src/gui/guides.c:741
+msgid ""
+"set the contrast between the lightest and darkest part of the guide overlays"
+msgstr ""
+"Set the contrast between the lightest and darkest part of the guide overlays"
+
+#: ../src/gui/guides.c:847 ../src/gui/guides.c:893
+msgid "show guides"
+msgstr "Show guides"
+
+#: ../src/gui/guides.c:902
+msgid "show guide overlay when this module has focus"
+msgstr "Show guide overlay when this module has focus"
+
+#: ../src/gui/guides.c:904
+msgid ""
+"change global guide settings\n"
+"note that these settings are applied globally and will impact any module "
+"that shows guide overlays"
+msgstr ""
+"Change global guide settings\n"
+"Note that these settings are applied globally and will impact any module "
+"that shows guide overlays"
+
+#: ../src/gui/hist_dialog.c:222
+msgid "select parts to copy"
+msgstr "Select parts to copy"
+
+#: ../src/gui/hist_dialog.c:222
+msgid "select parts to paste"
+msgstr "Select parts to paste"
+
+#: ../src/gui/hist_dialog.c:225 ../src/gui/styles_dialog.c:518
+msgid "select _all"
+msgstr "Select _all"
+
+#: ../src/gui/hist_dialog.c:226 ../src/gui/styles_dialog.c:519
+msgid "select _none"
+msgstr "Select _none"
+
+#: ../src/gui/hist_dialog.c:259 ../src/gui/styles_dialog.c:591
+#: ../src/gui/styles_dialog.c:613
+msgid "include"
+msgstr "Include"
+
+#: ../src/gui/hist_dialog.c:287 ../src/gui/styles_dialog.c:667
+#: ../src/gui/styles_dialog.c:673
+msgid "item"
+msgstr "Item"
+
+#: ../src/gui/hist_dialog.c:293 ../src/gui/styles_dialog.c:680
+#: ../src/gui/styles_dialog.c:689
+msgid "mask"
+msgstr "Mask"
+
+#: ../src/gui/hist_dialog.c:358
+msgid "can't copy history out of unaltered image"
+msgstr "Can't copy history out of unaltered image"
+
+#. grid headers
+#: ../src/gui/import_metadata.c:417
+msgid "metadata presets"
+msgstr "Metadata presets"
+
+#: ../src/gui/import_metadata.c:420
+msgid ""
+"metadata to be applied per default\n"
+"double-click on a label to clear the corresponding entry\n"
+"double-click on 'preset' to clear all entries"
+msgstr ""
+"Metadata to be applied per default\n"
+"Double-click on a label to clear the corresponding entry\n"
+"Double-click on 'preset' to clear all entries"
+
+#: ../src/gui/import_metadata.c:430
+msgid "from XMP"
+msgstr "From XMP"
+
+#: ../src/gui/import_metadata.c:433
+msgid ""
+"selected metadata are imported from image and override the default value\n"
+" this drives also the 'look for updated XMP files' and 'load sidecar file' "
+"actions\n"
+" CAUTION: not selected metadata are cleaned up when XMP file is updated"
+msgstr ""
+"Selected metadata are imported from image and override the default value\n"
+" This drives also the 'Look for updated XMP files' and 'Load sidecar file' "
+"actions\n"
+" CAUTION: not selected metadata are cleaned up when XMP file is updated"
+
+#. tags
+#: ../src/gui/import_metadata.c:469
+msgid "tag presets"
+msgstr "Tag presets"
+
+#: ../src/gui/import_metadata.c:483
+msgid "comma separated list of tags"
+msgstr "Comma separated list of tags"
+
+#. language
+#: ../src/gui/preferences.c:274
+msgid "interface language"
+msgstr "Interface language"
+
+#: ../src/gui/preferences.c:289
+msgid "double-click to reset to the system language"
+msgstr "Double-click to reset to the system language"
+
+#: ../src/gui/preferences.c:291
+msgid ""
+"set the language of the user interface. the system default is marked with an "
+"* (needs a restart)"
+msgstr ""
+"Set the language of the user interface. The system default is marked with an "
+"* (needs a restart)"
+
+#: ../src/gui/preferences.c:300
+msgid "theme"
+msgstr "Theme"
+
+#: ../src/gui/preferences.c:328
+msgid "set the theme for the user interface"
+msgstr "Set the theme for the user interface"
+
+#: ../src/gui/preferences.c:341 ../src/gui/preferences.c:348
+msgid "use system font size"
+msgstr "Use system font size"
+
+#: ../src/gui/preferences.c:357 ../src/gui/preferences.c:364
+msgid "font size in points"
+msgstr "Font size in points"
+
+#: ../src/gui/preferences.c:369
+msgid "GUI controls and text DPI"
+msgstr "GUI controls and text DPI"
+
+#: ../src/gui/preferences.c:376
+msgid ""
+"adjust the global GUI resolution to rescale controls, buttons, labels, etc.\n"
+"increase for a magnified GUI, decrease to fit more content in window.\n"
+"set to -1 to use the system-defined global resolution.\n"
+"default is 96 DPI on most systems.\n"
+"(needs a restart)."
+msgstr ""
+"Adjust the global GUI resolution to rescale controls, buttons, labels, etc.\n"
+"Increase for a magnified GUI, decrease to fit more content in window.\n"
+"Set to -1 to use the system-defined global resolution.\n"
+"Default is 96 DPI on most systems.\n"
+"(needs a restart)."
+
+#. checkbox to allow user to modify theme with user.css
+#: ../src/gui/preferences.c:385
+msgid "modify selected theme with CSS tweaks below"
+msgstr "Modify selected theme with CSS tweaks below"
+
+#: ../src/gui/preferences.c:393
+msgid "modify theme with CSS keyed below (saved to user.css)"
+msgstr "Modify theme with CSS keyed below (saved to user.css)"
+
+#: ../src/gui/preferences.c:414
+msgctxt "usercss"
+msgid "save CSS and apply"
+msgstr "Save CSS and apply"
+
+#: ../src/gui/preferences.c:420
+msgid "click to save and apply the CSS tweaks entered in this editor"
+msgstr "Click to save and apply the CSS tweaks entered in this editor"
+
+#. load default text with some pointers
+#: ../src/gui/preferences.c:438
+msgid "ERROR Loading user.css"
+msgstr "ERROR Loading user.css"
+
+#. load default text
+#: ../src/gui/preferences.c:447
+msgid "Enter CSS theme tweaks here"
+msgstr "Enter CSS theme tweaks here"
+
+#: ../src/gui/preferences.c:483
+msgid "darktable preferences"
+msgstr "Darktable preferences"
+
+#: ../src/gui/preferences.c:556
+msgid "darktable needs to be restarted for settings to take effect"
+msgstr "Darktable needs to be restarted for settings to take effect"
+
+#. exif
+#: ../src/gui/preferences.c:815 ../src/gui/presets.c:568
+#: ../src/libs/metadata_view.c:137
+msgid "model"
+msgstr "Model"
+
+#: ../src/gui/preferences.c:819 ../src/gui/presets.c:576
+#: ../src/libs/metadata_view.c:138
+msgid "maker"
+msgstr "Maker"
+
+#: ../src/gui/preferences.c:856
+msgid "search presets list"
+msgstr "Search presets list"
+
+#: ../src/gui/preferences.c:857
+msgid ""
+"incrementally search the list of presets\n"
+"press up or down keys to cycle through matches"
+msgstr ""
+"Incrementally search the list of presets\n"
+"Press up or down keys to cycle through matches"
+
+#: ../src/gui/preferences.c:863
+msgctxt "preferences"
+msgid "import..."
+msgstr "Import..."
+
+#: ../src/gui/preferences.c:867
+msgctxt "preferences"
+msgid "export..."
+msgstr "Export..."
+
+#: ../src/gui/preferences.c:1021
+#, c-format
+msgid "failed to import preset %s"
+msgstr "Failed to import preset %s"
+
+#: ../src/gui/preferences.c:1032
+msgid "select preset(s) to import"
+msgstr "Select preset(s) to import"
+
+#: ../src/gui/preferences.c:1033 ../src/libs/collect.c:409
+#: ../src/libs/copy_history.c:117 ../src/libs/geotagging.c:930
+#: ../src/libs/import.c:1507 ../src/libs/import.c:1611 ../src/libs/styles.c:528
+msgid "_open"
+msgstr "_Open"
+
+#: ../src/gui/preferences.c:1042
+msgid "darktable preset files"
+msgstr "Darktable preset files"
+
+#: ../src/gui/preferences.c:1047 ../src/iop/lut3d.c:1577
+#: ../src/libs/copy_history.c:156 ../src/libs/geotagging.c:946
+#: ../src/libs/styles.c:542
+msgid "all files"
+msgstr "All files"
+
+#: ../src/gui/presets.c:59
+msgid "non-raw"
+msgstr "Non-raw"
+
+#: ../src/gui/presets.c:59 ../src/libs/metadata_view.c:333
+msgid "raw"
+msgstr "Raw"
+
+#: ../src/gui/presets.c:59 ../src/libs/metadata_view.c:334
+msgid "HDR"
+msgstr "HDR"
+
+#: ../src/gui/presets.c:59 ../src/iop/monochrome.c:77 ../src/libs/image.c:610
+#: ../src/libs/metadata_view.c:341
+msgid "monochrome"
+msgstr "Monochrome"
+
+#: ../src/gui/presets.c:130
+#, c-format
+msgid "preset `%s' is write-protected, can't delete!"
+msgstr "Preset `%s' is write-protected, can't delete!"
+
+#: ../src/gui/presets.c:136 ../src/gui/presets.c:400 ../src/libs/lib.c:230
+#: ../src/libs/modulegroups.c:3703
+msgid "delete preset?"
+msgstr "Delete preset?"
+
+#: ../src/gui/presets.c:137 ../src/gui/presets.c:401 ../src/libs/lib.c:231
+#: ../src/libs/modulegroups.c:3704
+#, c-format
+msgid "do you really want to delete the preset `%s'?"
+msgstr "Do you really want to delete the preset `%s'?"
+
+#. add new preset
+#. create a shortcut for the new entry
+#. then show edit dialog
+#. clang-format on
+#. create a shortcut for the new entry
+#. then show edit dialog
+#: ../src/gui/presets.c:179 ../src/gui/presets.c:908 ../src/gui/presets.c:911
+#: ../src/gui/presets.c:914 ../src/libs/lib.c:183 ../src/libs/lib.c:200
+#: ../src/libs/lib.c:208 ../src/libs/lib.c:211
+msgid "new preset"
+msgstr "New preset"
+
+#: ../src/gui/presets.c:184
+msgid "please give preset a name"
+msgstr "Please give preset a name"
+
+#: ../src/gui/presets.c:189
+msgid "unnamed preset"
+msgstr "Unnamed preset"
+
+#. if result is BUTTON_NO or ESCAPE keypress exit without
+#. destroying dialog, to permit other name
+#: ../src/gui/presets.c:217
+msgid "overwrite preset?"
+msgstr "Overwrite preset?"
+
+#: ../src/gui/presets.c:218
+#, c-format
+msgid ""
+"preset `%s' already exists.\n"
+"do you want to overwrite?"
+msgstr ""
+"Preset `%s' already exists.\n"
+"Do you want to overwrite?"
+
+#: ../src/gui/presets.c:361 ../src/imageio/storage/disk.c:123
+#: ../src/imageio/storage/gallery.c:110 ../src/imageio/storage/latex.c:109
+msgid "_select as output destination"
+msgstr "_Select as output destination"
+
+#: ../src/gui/presets.c:369
+#, c-format
+msgid "preset %s was successfully exported"
+msgstr "Preset %s was successfully exported"
+
+#: ../src/gui/presets.c:495
+#, c-format
+msgid "edit `%s' for module `%s'"
+msgstr "Edit `%s' for module `%s'"
+
+#: ../src/gui/presets.c:498
+msgid "_export..."
+msgstr "_Export..."
+
+#: ../src/gui/presets.c:518
+msgid "name of the preset"
+msgstr "Name of the preset"
+
+#: ../src/gui/presets.c:526
+msgid "description or further information"
+msgstr "Description or further information"
+
+#: ../src/gui/presets.c:529
+msgid "reset all module parameters to their default values"
+msgstr "Reset all module parameters to their default values"
+
+#: ../src/gui/presets.c:532
+msgid ""
+"the parameters will be reset to their default values, which may be "
+"automatically set based on image metadata"
+msgstr ""
+"The parameters will be reset to their default values, which may be "
+"automatically set based on image metadata"
+
+#: ../src/gui/presets.c:536
+msgid "auto apply this preset to matching images"
+msgstr "Auto apply this preset to matching images"
+
+#: ../src/gui/presets.c:539
+msgid "only show this preset for matching images"
+msgstr "Only show this preset for matching images"
+
+#: ../src/gui/presets.c:540
+msgid ""
+"be very careful with this option. this might be the last time you see your "
+"preset."
+msgstr ""
+"Be very careful with this option. This might be the last time you see your "
+"preset."
+
+#: ../src/gui/presets.c:567
+#, no-c-format
+msgid "string to match model (use % as wildcard)"
+msgstr "String to match model (use % as wildcard)"
+
+#: ../src/gui/presets.c:575
+#, no-c-format
+msgid "string to match maker (use % as wildcard)"
+msgstr "String to match maker (use % as wildcard)"
+
+#: ../src/gui/presets.c:583
+#, no-c-format
+msgid "string to match lens (use % as wildcard)"
+msgstr "String to match lens (use % as wildcard)"
+
+#: ../src/gui/presets.c:593
+msgid "minimum ISO value"
+msgstr "Minimum ISO value"
+
+#: ../src/gui/presets.c:596
+msgid "maximum ISO value"
+msgstr "Maximum ISO value"
+
+#: ../src/gui/presets.c:607
+msgid "minimum exposure time"
+msgstr "Minimum exposure time"
+
+#: ../src/gui/presets.c:608
+msgid "maximum exposure time"
+msgstr "Maximum exposure time"
+
+#: ../src/gui/presets.c:622
+msgid "minimum aperture value"
+msgstr "Minimum aperture value"
+
+#: ../src/gui/presets.c:623
+msgid "maximum aperture value"
+msgstr "Maximum aperture value"
+
+#: ../src/gui/presets.c:639
+msgid "minimum focal length"
+msgstr "Minimum focal length"
+
+#: ../src/gui/presets.c:640
+msgid "maximum focal length"
+msgstr "Maximum focal length"
+
+#. raw/hdr/ldr/mono/color
+#: ../src/gui/presets.c:646 ../src/imageio/format/j2k.c:650
+msgid "format"
+msgstr "Format"
+
+#: ../src/gui/presets.c:649
+msgid "select image types you want this preset to be available for"
+msgstr "Select image types you want this preset to be available for"
+
+#: ../src/gui/presets.c:661 ../src/libs/filtering.c:1201
+msgid "and"
+msgstr "and"
+
+#: ../src/gui/presets.c:857
+#, c-format
+msgid "preset `%s' is write-protected! can't edit it!"
+msgstr "Preset `%s' is write-protected! Can't edit it!"
+
+#: ../src/gui/presets.c:881 ../src/libs/lib.c:157
+msgid "update preset?"
+msgstr "Update preset?"
+
+#: ../src/gui/presets.c:881 ../src/libs/lib.c:158
+#, c-format
+msgid "do you really want to update the preset `%s'?"
+msgstr "Do you really want to update the preset `%s'?"
+
+#: ../src/gui/presets.c:1003
+msgid "(first)"
+msgstr "(first)"
+
+#: ../src/gui/presets.c:1003
+msgid "(last)"
+msgstr "(last)"
+
+#: ../src/gui/presets.c:1035
+#, c-format
+msgid ""
+"preset %s\n"
+"%s"
+msgstr ""
+"Preset %s\n"
+"%s"
+
+#: ../src/gui/presets.c:1036
+msgid "no presets"
+msgstr "No presets"
+
+#: ../src/gui/presets.c:1069
+msgid "display-referred default"
+msgstr "Display-referred default"
+
+#: ../src/gui/presets.c:1071 ../src/iop/exposure.c:291
+#: ../src/iop/exposure.c:300
+msgid "scene-referred default"
+msgstr "Scene-referred default"
+
+#: ../src/gui/presets.c:1246 ../src/libs/modulegroups.c:3783
+#: ../src/libs/modulegroups.c:3792
+msgid "manage module layouts"
+msgstr "Manage module layouts"
+
+#: ../src/gui/presets.c:1254
+msgid "manage quick presets"
+msgstr "Manage quick presets"
+
+#: ../src/gui/presets.c:1425
+msgid "manage quick presets list..."
+msgstr "Manage quick presets list..."
+
+#: ../src/gui/presets.c:1564
+msgid "(default)"
+msgstr "(default)"
+
+#: ../src/gui/presets.c:1590
+msgid "disabled: wrong module version"
+msgstr "Disabled: wrong module version"
+
+#: ../src/gui/presets.c:1611 ../src/libs/lib.c:523
+msgid "edit this preset.."
+msgstr "Edit this preset.."
+
+#: ../src/gui/presets.c:1615 ../src/libs/lib.c:527
+msgid "delete this preset"
+msgstr "Delete this preset"
+
+#: ../src/gui/presets.c:1621 ../src/libs/lib.c:535
+msgid "store new preset.."
+msgstr "Store new preset.."
+
+#: ../src/gui/presets.c:1628 ../src/libs/lib.c:547
+msgid "update preset"
+msgstr "Update preset"
+
+#: ../src/gui/styles_dialog.c:221 ../src/libs/styles.c:438
+#: ../src/libs/styles.c:621
+msgid "overwrite style?"
+msgstr "Overwrite style?"
+
+#: ../src/gui/styles_dialog.c:222
+#, c-format
+msgid ""
+"style `%s' already exists.\n"
+"do you want to overwrite?"
+msgstr ""
+"Style `%s' already exists.\n"
+"Do you want to overwrite?"
+
+#: ../src/gui/styles_dialog.c:251 ../src/gui/styles_dialog.c:323
+msgid "please give style a name"
+msgstr "Please give style a name"
+
+#: ../src/gui/styles_dialog.c:255 ../src/gui/styles_dialog.c:327
+msgid "unnamed style"
+msgstr "Unnamed style"
+
+#: ../src/gui/styles_dialog.c:312
+#, c-format
+msgid "style %s was successfully saved"
+msgstr "Style %s was successfully saved"
+
+#: ../src/gui/styles_dialog.c:505
+msgid "edit style"
+msgstr "Edit style"
+
+#: ../src/gui/styles_dialog.c:506
+msgid "duplicate style"
+msgstr "Duplicate style"
+
+#: ../src/gui/styles_dialog.c:507
+msgid "creates a duplicate of the style before applying changes"
+msgstr "Creates a duplicate of the style before applying changes"
+
+#: ../src/gui/styles_dialog.c:511
+msgid "create new style"
+msgstr "Create new style"
+
+#: ../src/gui/styles_dialog.c:547
+msgid "enter a name for the new style"
+msgstr "Enter a name for the new style"
+
+#: ../src/gui/styles_dialog.c:552
+msgid "enter a description for the new style, this description is searchable"
+msgstr "Enter a description for the new style, this description is searchable"
+
+#: ../src/gui/styles_dialog.c:591
+msgid "keep"
+msgstr "Keep"
+
+#: ../src/gui/styles_dialog.c:818
+msgid "can't create style out of unaltered image"
+msgstr "Can't create style out of unaltered image"
+
+#: ../src/imageio/imageio.c:743
+#, c-format
+msgid ""
+"failed to allocate memory for %s, please lower the threads used for export "
+"or buy more memory."
+msgstr ""
+"Failed to allocate memory for %s, please lower the threads used for export "
+"or buy more memory."
+
+#: ../src/imageio/imageio.c:744
+msgctxt "noun"
+msgid "thumbnail export"
+msgstr "Thumbnail export"
+
+#: ../src/imageio/imageio.c:744
+msgctxt "noun"
+msgid "export"
+msgstr "Export"
+
+#: ../src/imageio/imageio.c:757
+#, c-format
+msgid "cannot find the style '%s' to apply during export."
+msgstr "Cannot find the style '%s' to apply during export."
+
+#: ../src/imageio/format/avif.c:89 ../src/imageio/format/jxl.c:556
+#: ../src/imageio/format/pdf.c:80 ../src/imageio/format/png.c:536
+#: ../src/imageio/format/tiff.c:847 ../src/imageio/format/xcf.c:361
+msgid "8 bit"
+msgstr "8 bit"
+
+#: ../src/imageio/format/avif.c:93 ../src/imageio/format/jxl.c:556
+msgid "10 bit"
+msgstr "10 bit"
+
+#: ../src/imageio/format/avif.c:97 ../src/imageio/format/jxl.c:556
+msgid "12 bit"
+msgstr "12 bit"
+
+#: ../src/imageio/format/avif.c:431
+msgid "invalid AVIF bit depth!"
+msgstr "Invalid AVIF bit depth!"
+
+#: ../src/imageio/format/avif.c:694
+msgid "AVIF"
+msgstr "AVIF"
+
+#. Bit depth combo box
+#: ../src/imageio/format/avif.c:766 ../src/imageio/format/exr.cc:569
+#: ../src/imageio/format/jxl.c:555 ../src/imageio/format/pdf.c:661
+#: ../src/imageio/format/png.c:534 ../src/imageio/format/tiff.c:843
+#: ../src/imageio/format/xcf.c:358
+msgid "bit depth"
+msgstr "Bit depth"
+
+#: ../src/imageio/format/avif.c:779
+msgid "color information stored in an image, higher is better"
+msgstr "Color information stored in an image, higher is better"
+
+#: ../src/imageio/format/avif.c:787
+msgid "saving as grayscale will reduce the size for black & white images"
+msgstr "Saving as grayscale will reduce the size for black & white images"
+
+#: ../src/imageio/format/avif.c:789
+msgid "rgb colors"
+msgstr "RGB colors"
+
+#: ../src/imageio/format/avif.c:789
+msgid "grayscale"
+msgstr "Grayscale"
+
+#.
+#. * Tiling combo box
+#.
+#: ../src/imageio/format/avif.c:799
+msgid "tiling"
+msgstr "Tiling"
+
+#: ../src/imageio/format/avif.c:800
+msgid ""
+"tile an image into segments.\n"
+"\n"
+"makes encoding faster. the impact on quality reduction is negligible, but "
+"increases the file size."
+msgstr ""
+"Tile an image into segments.\n"
+"\n"
+"Makes encoding faster. The impact on quality reduction is negligible, but "
+"increases the file size."
+
+#: ../src/imageio/format/avif.c:817 ../src/imageio/format/webp.c:383
+msgid "compression type"
+msgstr "Compression type"
+
+#: ../src/imageio/format/avif.c:825
+msgid "the compression for the image"
+msgstr "The compression for the image"
+
+#. min
+#. max
+#. step
+#. default
+#. digits
+#: ../src/imageio/format/avif.c:842 ../src/imageio/format/j2k.c:661
+#: ../src/imageio/format/jpeg.c:587 ../src/imageio/format/jxl.c:579
+#: ../src/imageio/format/webp.c:394 ../src/libs/camera.c:565
+msgid "quality"
+msgstr "Quality"
+
+#: ../src/imageio/format/avif.c:847
+msgid ""
+"the quality of an image, less quality means fewer details.\n"
+"\n"
+"the following applies only to lossy setting\n"
+"\n"
+"pixelformat based on quality:\n"
+"\n"
+"    91% - 100% -> YUV444\n"
+"    81% -  90% -> YUV422\n"
+"     5% -  80% -> YUV420\n"
+msgstr ""
+"The quality of an image, less quality means fewer details.\n"
+"\n"
+"The following applies only to lossy setting.\n"
+"\n"
+"Pixelformat based on quality:\n"
+"\n"
+"    91% - 100% -> YUV444\n"
+"    81% -  90% -> YUV422\n"
+"     5% -  80% -> YUV420\n"
+
+#: ../src/imageio/format/copy.c:109 ../src/libs/copy_history.c:373
+#: ../src/libs/image.c:585
+msgid "copy"
+msgstr "Copy"
+
+#: ../src/imageio/format/copy.c:124
+msgid ""
+"do a 1:1 copy of the selected files.\n"
+"the global options below do not apply!"
+msgstr ""
+"Do a 1:1 copy of the selected files.\n"
+"The global options below do not apply!"
+
+#: ../src/imageio/format/exr.cc:217
+msgid "the selected output profile doesn't work well with EXR"
+msgstr "The selected output profile doesn't work well with EXR"
+
+#: ../src/imageio/format/exr.cc:544
+msgid "OpenEXR"
+msgstr "OpenEXR"
+
+#: ../src/imageio/format/exr.cc:571
+msgid "16 bit (float)"
+msgstr "16 bit (float)"
+
+#: ../src/imageio/format/exr.cc:571 ../src/imageio/format/jxl.c:556
+#: ../src/imageio/format/tiff.c:847 ../src/imageio/format/xcf.c:361
+msgid "32 bit (float)"
+msgstr "32 bit (float)"
+
+#. compression
+#. Compression method combo box
+#: ../src/imageio/format/exr.cc:579 ../src/imageio/format/pdf.c:676
+#: ../src/imageio/format/png.c:548 ../src/imageio/format/tiff.c:866
+#: ../src/libs/masks.c:110
+msgid "compression"
+msgstr "Compression"
+
+#: ../src/imageio/format/exr.cc:581 ../src/imageio/format/pdf.c:682
+#: ../src/imageio/format/tiff.c:867
+msgid "uncompressed"
+msgstr "Uncompressed"
+
+#: ../src/imageio/format/exr.cc:582
+msgid "RLE"
+msgstr "RLE"
+
+#: ../src/imageio/format/exr.cc:583
+msgid "ZIPS"
+msgstr "ZIPS"
+
+#: ../src/imageio/format/exr.cc:584
+msgid "ZIP"
+msgstr "ZIP"
+
+#: ../src/imageio/format/exr.cc:585
+msgid "PIZ"
+msgstr "PIZ"
+
+#: ../src/imageio/format/exr.cc:586
+msgid "PXR24"
+msgstr "PXR24"
+
+#: ../src/imageio/format/exr.cc:587
+msgid "B44"
+msgstr "B44"
+
+#: ../src/imageio/format/exr.cc:588
+msgid "B44A"
+msgstr "B44A"
+
+#: ../src/imageio/format/exr.cc:589
+msgid "DWAA"
+msgstr "DWAA"
+
+#: ../src/imageio/format/exr.cc:590
+msgid "DWAB"
+msgstr "DWAB"
+
+#: ../src/imageio/format/j2k.c:618
+msgid "JPEG 2000 (12-bit)"
+msgstr "JPEG 2000 (12-bit)"
+
+#: ../src/imageio/format/j2k.c:652
+msgid "jp2"
+msgstr "jp2"
+
+#: ../src/imageio/format/j2k.c:667
+msgid "DCP mode"
+msgstr "DCP mode"
+
+#: ../src/imageio/format/j2k.c:670
+msgid "Cinema2K, 24FPS"
+msgstr "Cinema2K, 24FPS"
+
+#: ../src/imageio/format/j2k.c:671
+msgid "Cinema2K, 48FPS"
+msgstr "Cinema2K, 48FPS"
+
+#: ../src/imageio/format/j2k.c:672
+msgid "Cinema4K, 24FPS"
+msgstr "Cinema4K, 24FPS"
+
+#: ../src/imageio/format/jpeg.c:564
+msgid "JPEG (8-bit)"
+msgstr "JPEG (8-bit)"
+
+#: ../src/imageio/format/jxl.c:471
+msgid "JPEG XL"
+msgstr "JPEG XL"
+
+#: ../src/imageio/format/jxl.c:556 ../src/imageio/format/pdf.c:81
+#: ../src/imageio/format/png.c:536 ../src/imageio/format/tiff.c:847
+#: ../src/imageio/format/xcf.c:361
+msgid "16 bit"
+msgstr "16 bit"
+
+#. Pixel format combo box
+#: ../src/imageio/format/jxl.c:562 ../src/imageio/format/tiff.c:852
+msgid "pixel type"
+msgstr "Pixel type"
+
+#: ../src/imageio/format/jxl.c:563 ../src/imageio/format/tiff.c:853
+msgid "unsigned integer"
+msgstr "Unsigned integer"
+
+#: ../src/imageio/format/jxl.c:563 ../src/imageio/format/tiff.c:853
+msgid "floating point"
+msgstr "Floating point"
+
+#: ../src/imageio/format/jxl.c:580
+msgid ""
+"the quality of the output image\n"
+"0-29 = very lossy\n"
+"30-99 = JPEG quality comparable\n"
+"100 = lossless (integer bit depth only)"
+msgstr ""
+"The quality of the output image\n"
+"0-29 = very lossy\n"
+"30-99 = JPEG quality comparable\n"
+"100 = lossless (integer bit depth only)"
+
+#: ../src/imageio/format/jxl.c:589
+msgid "encoding color profile"
+msgstr "Encoding color profile"
+
+#: ../src/imageio/format/jxl.c:590
+msgid ""
+"the color profile used by the encoder\n"
+"permit internal XYB color space conversion for more efficient lossy "
+"compression,\n"
+"or ensure no conversion to keep original image color space (implied for "
+"lossless)"
+msgstr ""
+"The color profile used by the encoder\n"
+"Permit internal XYB color space conversion for more efficient lossy "
+"compression,\n"
+"or ensure no conversion to keep original image color space (implied for "
+"lossless)"
+
+#: ../src/imageio/format/jxl.c:593
+msgid "internal"
+msgstr "Internal"
+
+#: ../src/imageio/format/jxl.c:593 ../src/libs/duplicate.c:397
+#: ../src/libs/history.c:1132 ../src/libs/snapshots.c:783
+msgid "original"
+msgstr "Original"
+
+#: ../src/imageio/format/jxl.c:607
+msgid "encoding effort"
+msgstr "Encoding effort"
+
+#: ../src/imageio/format/jxl.c:608
+msgid ""
+"the effort used to encode the image, higher efforts will have better results "
+"at the expense of longer encoding times"
+msgstr ""
+"The effort used to encode the image, higher efforts will have better results "
+"at the expense of longer encoding times"
+
+#: ../src/imageio/format/jxl.c:619
+msgid "decoding speed"
+msgstr "Decoding speed"
+
+#: ../src/imageio/format/jxl.c:620
+msgid "the preferred decoding speed with some sacrifice of quality"
+msgstr "The preferred decoding speed with some sacrifice of quality"
+
+#: ../src/imageio/format/pdf.c:200 ../src/imageio/format/pdf.c:480
+msgid "invalid paper size"
+msgstr "Invalid paper size"
+
+#: ../src/imageio/format/pdf.c:207
+msgid "invalid border size, using 0"
+msgstr "Invalid border size, using 0"
+
+#: ../src/imageio/format/pdf.c:257 ../src/imageio/storage/disk.c:316
+#: ../src/imageio/storage/email.c:137 ../src/imageio/storage/gallery.c:331
+#: ../src/imageio/storage/gallery.c:370 ../src/imageio/storage/piwigo.c:1137
+#, c-format
+msgid "could not export to file `%s'!"
+msgstr "Could not export to file `%s'!"
+
+#: ../src/imageio/format/pdf.c:409
+msgid "PDF"
+msgstr "PDF"
+
+#: ../src/imageio/format/pdf.c:577
+msgid "enter the title of the PDF"
+msgstr "Enter the title of the PDF"
+
+#. paper size
+#. // papers
+#: ../src/imageio/format/pdf.c:585 ../src/libs/print_settings.c:2353
+msgid "paper size"
+msgstr "Paper size"
+
+#: ../src/imageio/format/pdf.c:586
+msgid ""
+"paper size of the PDF\n"
+"either one from the list or \"<width> [unit] x <height> <unit>\n"
+"example: 210 mm x 2.97 cm"
+msgstr ""
+"Paper size of the PDF\n"
+"Either one from the list or \"<width> [unit] x <height> <unit>\n"
+"Example: 210 mm x 2.97 cm"
+
+#. orientation
+#: ../src/imageio/format/pdf.c:600
+msgid "page orientation"
+msgstr "Page orientation"
+
+#: ../src/imageio/format/pdf.c:601
+msgid "paper orientation of the PDF"
+msgstr "Paper orientation of the PDF"
+
+#. border
+#: ../src/imageio/format/pdf.c:609 ../src/imageio/format/pdf.c:611
+msgid "border"
+msgstr "Border"
+
+#: ../src/imageio/format/pdf.c:612
+msgid ""
+"empty space around the PDF\n"
+"format: size + unit\n"
+"examples: 10 mm, 1 inch"
+msgstr ""
+"Empty space around the PDF\n"
+"Format: size + unit\n"
+"Examples: 10 mm, 1 inch"
+
+#. dpi
+#: ../src/imageio/format/pdf.c:621 ../src/libs/export.c:1133
+#: ../src/libs/export.c:1156
+msgid "dpi"
+msgstr "dpi"
+
+#: ../src/imageio/format/pdf.c:625
+msgid "dpi of the images inside the PDF"
+msgstr "dpi of the images inside the PDF"
+
+#. rotate images yes|no
+#: ../src/imageio/format/pdf.c:631
+msgid "rotate images"
+msgstr "Rotate images"
+
+#: ../src/imageio/format/pdf.c:632
+msgid ""
+"images can be rotated to match the PDF orientation to waste less space when "
+"printing"
+msgstr ""
+"Images can be rotated to match the PDF orientation to waste less space when "
+"printing"
+
+#. pages all|single images|contact sheet
+#: ../src/imageio/format/pdf.c:641
+msgid "TODO: pages"
+msgstr "TODO: pages"
+
+#: ../src/imageio/format/pdf.c:642
+msgid "what pages should be added to the PDF"
+msgstr "What pages should be added to the PDF"
+
+#: ../src/imageio/format/pdf.c:645
+msgid "single images"
+msgstr "Single images"
+
+#: ../src/imageio/format/pdf.c:645
+msgid "contact sheet"
+msgstr "Contact sheet"
+
+#. TODO
+#. embedded icc profile yes|no
+#: ../src/imageio/format/pdf.c:651
+msgid "embed ICC profiles"
+msgstr "Embed ICC profiles"
+
+#: ../src/imageio/format/pdf.c:652
+msgid "images can be tagged with their ICC profile"
+msgstr "Images can be tagged with their ICC profile"
+
+#: ../src/imageio/format/pdf.c:671
+msgid "bits per channel of the embedded images"
+msgstr "Bits per channel of the embedded images"
+
+#: ../src/imageio/format/pdf.c:677
+msgid ""
+"method used for image compression\n"
+"uncompressed -- fast but big files\n"
+"deflate -- smaller files but slower"
+msgstr ""
+"Method used for image compression\n"
+"Uncompressed -- fast but big files\n"
+"Deflate -- smaller files but slower"
+
+#: ../src/imageio/format/pdf.c:682 ../src/imageio/format/tiff.c:867
+msgid "deflate"
+msgstr "Deflate"
+
+#. image mode normal|draft|debug
+#: ../src/imageio/format/pdf.c:687
+msgid "image mode"
+msgstr "Image mode"
+
+#: ../src/imageio/format/pdf.c:688
+msgid ""
+"normal -- just put the images into the PDF\n"
+"draft -- images are replaced with boxes\n"
+"debug -- only show the outlines and bounding boxes"
+msgstr ""
+"Normal -- just put the images into the PDF\n"
+"Draft -- images are replaced with boxes\n"
+"Debug -- only show the outlines and bounding boxes"
+
+#: ../src/imageio/format/pdf.c:693
+msgid "normal"
+msgstr "Normal"
+
+#: ../src/imageio/format/pdf.c:693
+msgid "draft"
+msgstr "Draft"
+
+#: ../src/imageio/format/pdf.c:693
+msgid "debug"
+msgstr "Debug"
+
+#: ../src/imageio/format/pfm.c:120
+msgid "PFM"
+msgstr "PFM"
+
+#: ../src/imageio/format/png.c:493
+msgid "PNG"
+msgstr "PNG"
+
+#: ../src/imageio/format/ppm.c:111
+msgid "PPM (16-bit)"
+msgstr "PPM (16-bit)"
+
+#: ../src/imageio/format/tiff.c:228
+msgid "will export as a grayscale image"
+msgstr "Will export as a grayscale image"
+
+#: ../src/imageio/format/tiff.c:774
+msgid "TIFF"
+msgstr "TIFF"
+
+#: ../src/imageio/format/tiff.c:868
+msgid "deflate with predictor"
+msgstr "Deflate with predictor"
+
+#: ../src/imageio/format/tiff.c:878
+msgid "compression level"
+msgstr "Compression level"
+
+#. shortfile option combo box
+#: ../src/imageio/format/tiff.c:887
+msgid "b&w image"
+msgstr "B&W image"
+
+#: ../src/imageio/format/tiff.c:888
+msgid "write rgb colors"
+msgstr "Write RGB colors"
+
+#: ../src/imageio/format/tiff.c:888
+msgid "write grayscale"
+msgstr "Write grayscale"
+
+#: ../src/imageio/format/webp.c:349
+msgid "WebP"
+msgstr "WebP"
+
+#: ../src/imageio/format/webp.c:385
+msgid "lossy"
+msgstr "Lossy"
+
+#: ../src/imageio/format/webp.c:385
+msgid "lossless"
+msgstr "Lossless"
+
+#: ../src/imageio/format/webp.c:397
+msgid ""
+"for lossy, 0 gives the smallest size and 100 the best quality.\n"
+"for lossless, 0 is the fastest but gives larger files compared\n"
+"to the slowest 100."
+msgstr ""
+"For lossy, 0 gives the smallest size and 100 the best quality.\n"
+"For lossless, 0 is the fastest but gives larger files compared\n"
+"to the slowest 100."
+
+#: ../src/imageio/format/webp.c:407
+msgid "image hint"
+msgstr "Image hint"
+
+#: ../src/imageio/format/webp.c:408
+msgid ""
+"image characteristics hint for the underlying encoder.\n"
+"picture: digital picture, like portrait, inner shot\n"
+"photo: outdoor photograph, with natural lighting\n"
+"graphic: discrete tone image (graph, map-tile etc)"
+msgstr ""
+"Image characteristics hint for the underlying encoder.\n"
+"Picture: digital picture, like portrait, inner shot\n"
+"Photo: outdoor photograph, with natural lighting\n"
+"Graphic: discrete tone image (graph, map-tile etc)"
+
+#: ../src/imageio/format/webp.c:413
+msgid "picture"
+msgstr "Picture"
+
+#: ../src/imageio/format/webp.c:413
+msgid "photo"
+msgstr "Photo"
+
+#: ../src/imageio/format/webp.c:413
+msgid "graphic"
+msgstr "Graphic"
+
+#: ../src/imageio/format/xcf.c:318
+msgid "XCF"
+msgstr "XCF"
+
+#: ../src/imageio/storage/disk.c:71 ../src/libs/export.c:1045
+msgid "file on disk"
+msgstr "File on disk"
+
+#: ../src/imageio/storage/disk.c:169 ../src/imageio/storage/gallery.c:155
+#: ../src/imageio/storage/latex.c:154
+msgid ""
+"enter the path where to put exported images\n"
+"variables support bash like string manipulation\n"
+"type '$(' to activate the completion and see the list of variables"
+msgstr ""
+"Enter the path where to put exported images\n"
+"Variables support bash like string manipulation\n"
+"Type '$(' to activate the completion and see the list of variables"
+
+#: ../src/imageio/storage/disk.c:182 ../src/imageio/storage/piwigo.c:1029
+msgid "on conflict"
+msgstr "On conflict"
+
+#: ../src/imageio/storage/disk.c:185
+msgid "create unique filename"
+msgstr "Create unique filename"
+
+#. DT_COPY_HISTORY_APPEND
+#: ../src/imageio/storage/disk.c:186 ../src/imageio/storage/piwigo.c:1033
+#: ../src/libs/copy_history.c:407 ../src/libs/image.c:603
+#: ../src/libs/styles.c:441 ../src/libs/styles.c:624 ../src/libs/styles.c:853
+msgid "overwrite"
+msgstr "Overwrite"
+
+#: ../src/imageio/storage/disk.c:187 ../src/imageio/storage/piwigo.c:1031
+#: ../src/libs/styles.c:440 ../src/libs/styles.c:623
+msgid "skip"
+msgstr "Skip"
+
+#: ../src/imageio/storage/disk.c:265 ../src/imageio/storage/gallery.c:253
+#: ../src/imageio/storage/latex.c:252
+#, c-format
+msgid "could not create directory `%s'!"
+msgstr "Could not create directory `%s'!"
+
+#: ../src/imageio/storage/disk.c:272
+#, c-format
+msgid "could not write to directory `%s'!"
+msgstr "Could not write to directory `%s'!"
+
+#: ../src/imageio/storage/disk.c:302
+#, c-format
+msgid "%d/%d skipping `%s'"
+msgid_plural "%d/%d skipping `%s'"
+msgstr[0] "%d/%d skipping `%s'"
+msgstr[1] "%d/%d skipping `%s'"
+
+#: ../src/imageio/storage/disk.c:321 ../src/imageio/storage/email.c:144
+#: ../src/imageio/storage/gallery.c:378 ../src/imageio/storage/latex.c:340
+#, c-format
+msgid "%d/%d exported to `%s'"
+msgid_plural "%d/%d exported to `%s'"
+msgstr[0] "%d/%d exported to `%s'"
+msgstr[1] "%d/%d exported to `%s'"
+
+#: ../src/imageio/storage/disk.c:380
+msgid ""
+"you are going to export in overwrite mode, this will overwrite any existing "
+"images\n"
+"\n"
+"do you really want to continue?"
+msgstr ""
+"You are going to export in overwrite mode, this will overwrite any existing "
+"images\n"
+"\n"
+"Do you really want to continue?"
+
+#: ../src/imageio/storage/email.c:52
+msgid "send as email"
+msgstr "Send as email"
+
+#: ../src/imageio/storage/email.c:198
+msgid "images exported from darktable"
+msgstr "Images exported from Darktable"
+
+#: ../src/imageio/storage/email.c:251
+msgid "could not launch email client!"
+msgstr "Could not launch email client!"
+
+#: ../src/imageio/storage/gallery.c:73
+msgid "website gallery"
+msgstr "Website gallery"
+
+#: ../src/imageio/storage/gallery.c:171
+msgid "enter the title of the website"
+msgstr "Enter the title of the website"
+
+#: ../src/imageio/storage/latex.c:72
+msgid "LaTeX book template"
+msgstr "LaTeX book template"
+
+#: ../src/imageio/storage/latex.c:172
+msgid "enter the title of the book"
+msgstr "Enter the title of the book"
+
+#: ../src/imageio/storage/piwigo.c:500
+msgid "authenticated"
+msgstr "Authenticated"
+
+#: ../src/imageio/storage/piwigo.c:508 ../src/imageio/storage/piwigo.c:523
+#: ../src/imageio/storage/piwigo.c:535
+msgid "not authenticated"
+msgstr "Not authenticated"
+
+#: ../src/imageio/storage/piwigo.c:514
+msgid "not authenticated, cannot reach server"
+msgstr "Not authenticated, cannot reach server"
+
+#: ../src/imageio/storage/piwigo.c:563 ../src/imageio/storage/piwigo.c:650
+msgid "create new album"
+msgstr "Create new album"
+
+#: ../src/imageio/storage/piwigo.c:651
+msgid "---"
+msgstr "---"
+
+#: ../src/imageio/storage/piwigo.c:693
+msgid "cannot refresh albums"
+msgstr "Cannot refresh albums"
+
+#: ../src/imageio/storage/piwigo.c:891
+msgid "piwigo"
+msgstr "Piwigo"
+
+#: ../src/imageio/storage/piwigo.c:916
+msgid "accounts"
+msgstr "Accounts"
+
+#: ../src/imageio/storage/piwigo.c:931 ../src/imageio/storage/piwigo.c:935
+msgid "server"
+msgstr "Server"
+
+#: ../src/imageio/storage/piwigo.c:932 ../src/imageio/storage/piwigo.c:943
+msgid ""
+"the server name\n"
+"default protocol is https\n"
+"specify http:// if non secure server"
+msgstr ""
+"The server name\n"
+"Default protocol is https\n"
+"Specify http:// if not secure server"
+
+#: ../src/imageio/storage/piwigo.c:942 ../src/imageio/storage/piwigo.c:946
+msgid "user"
+msgstr "User"
+
+#: ../src/imageio/storage/piwigo.c:952 ../src/imageio/storage/piwigo.c:956
+msgid "password"
+msgstr "Password"
+
+#. login button
+#: ../src/imageio/storage/piwigo.c:961
+msgid "login"
+msgstr "Login"
+
+#: ../src/imageio/storage/piwigo.c:962
+msgid "piwigo login"
+msgstr "Piwigo login"
+
+#. permissions list
+#: ../src/imageio/storage/piwigo.c:976
+msgid "visible to"
+msgstr "Visible to"
+
+#: ../src/imageio/storage/piwigo.c:978
+msgid "everyone"
+msgstr "Everyone"
+
+#: ../src/imageio/storage/piwigo.c:979
+msgid "contacts"
+msgstr "Contacts"
+
+#: ../src/imageio/storage/piwigo.c:980
+msgid "friends"
+msgstr "Friends"
+
+#: ../src/imageio/storage/piwigo.c:981
+msgid "family"
+msgstr "Family"
+
+#: ../src/imageio/storage/piwigo.c:982
+msgid "you"
+msgstr "You"
+
+#. Available albums
+#: ../src/imageio/storage/piwigo.c:989
+msgid "album"
+msgstr "Album"
+
+#: ../src/imageio/storage/piwigo.c:995
+msgid "refresh album list"
+msgstr "Refresh album list"
+
+#. Album title
+#: ../src/imageio/storage/piwigo.c:1013
+msgid "new album"
+msgstr "New album"
+
+#. parent album list
+#. Available albums
+#: ../src/imageio/storage/piwigo.c:1021
+msgid "parent album"
+msgstr "Parent album"
+
+#: ../src/imageio/storage/piwigo.c:1025
+msgid "click login button to start"
+msgstr "Click login button to start"
+
+#: ../src/imageio/storage/piwigo.c:1030
+msgid "don't check"
+msgstr "Don't check"
+
+#: ../src/imageio/storage/piwigo.c:1032
+msgid "update metadata"
+msgstr "Update metadata"
+
+#: ../src/imageio/storage/piwigo.c:1156
+msgid "cannot create a new piwigo album!"
+msgstr "Cannot create a new Piwigo album!"
+
+#: ../src/imageio/storage/piwigo.c:1174
+msgid "could not update to piwigo!"
+msgstr "Could not update to Piwigo!"
+
+#: ../src/imageio/storage/piwigo.c:1188
+msgid "could not upload to piwigo!"
+msgstr "Could not upload to Piwigo!"
+
+#: ../src/imageio/storage/piwigo.c:1217
+#, c-format
+msgid "%d/%d skipped (already exists)"
+msgstr "%d/%d skipped (already exists)"
+
+#. this makes sense only if the export was successful
+#: ../src/imageio/storage/piwigo.c:1222
+#, c-format
+msgid "%d/%d exported to piwigo webalbum"
+msgid_plural "%d/%d exported to piwigo webalbum"
+msgstr[0] "%d/%d exported to Piwigo webalbum"
+msgstr[1] "%d/%d exported to Piwigo webalbum"
+
+#: ../src/iop/ashift.c:120
+msgid "rotate and perspective"
+msgstr "Rotate and perspective"
+
+#: ../src/iop/ashift.c:125
+msgid "rotation|keystone|distortion|crop|reframe"
+msgstr "rotation|keystone|distortion|crop|reframe"
+
+#: ../src/iop/ashift.c:130
+msgid "rotate or distort perspective"
+msgstr "Rotate or distort perspective"
+
+#: ../src/iop/ashift.c:131 ../src/iop/channelmixer.c:139
+#: ../src/iop/channelmixerrgb.c:232 ../src/iop/clipping.c:320
+#: ../src/iop/colorbalance.c:161 ../src/iop/colorbalancergb.c:185
+#: ../src/iop/colorchecker.c:126 ../src/iop/colorcorrection.c:77
+#: ../src/iop/crop.c:144 ../src/iop/lut3d.c:141
+msgid "corrective or creative"
+msgstr "Corrective or creative"
+
+#: ../src/iop/ashift.c:132 ../src/iop/ashift.c:134 ../src/iop/basicadj.c:148
+#: ../src/iop/bilateral.cc:101 ../src/iop/bilateral.cc:103
+#: ../src/iop/blurs.c:93 ../src/iop/blurs.c:94 ../src/iop/channelmixerrgb.c:233
+#: ../src/iop/channelmixerrgb.c:235 ../src/iop/clipping.c:321
+#: ../src/iop/clipping.c:323 ../src/iop/colorbalancergb.c:186
+#: ../src/iop/colorin.c:137 ../src/iop/crop.c:145 ../src/iop/crop.c:147
+#: ../src/iop/demosaic.c:292 ../src/iop/denoiseprofile.c:726
+#: ../src/iop/denoiseprofile.c:728 ../src/iop/diffuse.c:146
+#: ../src/iop/diffuse.c:148 ../src/iop/exposure.c:131 ../src/iop/exposure.c:133
+#: ../src/iop/flip.c:111 ../src/iop/flip.c:112 ../src/iop/hazeremoval.c:113
+#: ../src/iop/hazeremoval.c:115 ../src/iop/lens.cc:212 ../src/iop/lens.cc:214
+#: ../src/iop/liquify.c:297 ../src/iop/liquify.c:299 ../src/iop/retouch.c:210
+#: ../src/iop/retouch.c:212 ../src/iop/sigmoid.c:102
+#: ../src/iop/splittoning.c:104 ../src/iop/splittoning.c:106
+#: ../src/iop/spots.c:70 ../src/iop/spots.c:72 ../src/iop/toneequal.c:325
+#: ../src/iop/velvia.c:106 ../src/iop/velvia.c:108
+msgid "linear, RGB, scene-referred"
+msgstr "Linear, RGB, scene-referred"
+
+#: ../src/iop/ashift.c:133 ../src/iop/borders.c:194 ../src/iop/clipping.c:322
+#: ../src/iop/crop.c:146 ../src/iop/flip.c:111 ../src/iop/liquify.c:298
+msgid "geometric, RGB"
+msgstr "Geometric, RGB"
+
+#: ../src/iop/ashift.c:2819
+msgid "automatic cropping failed"
+msgstr "Automatic cropping failed"
+
+#: ../src/iop/ashift.c:3233 ../src/iop/ashift.c:3285 ../src/iop/ashift.c:3333
+msgid "data pending - please repeat"
+msgstr "Data pending - please repeat"
+
+#: ../src/iop/ashift.c:3242
+msgid "could not detect structural data in image"
+msgstr "Could not detect structural data in image"
+
+#: ../src/iop/ashift.c:3254
+msgid "could not run outlier removal"
+msgstr "Could not run outlier removal"
+
+#: ../src/iop/ashift.c:3433
+#, c-format
+msgid ""
+"not enough structure for automatic correction\n"
+"minimum %d lines in each relevant direction"
+msgstr ""
+"Not enough structure for automatic correction\n"
+"Minimum %d lines in each relevant direction"
+
+#: ../src/iop/ashift.c:3439
+msgid "automatic correction failed, please correct manually"
+msgstr "Automatic correction failed, please correct manually"
+
+#: ../src/iop/ashift.c:5095
+#, c-format
+msgid "only %d lines can be saved in parameters"
+msgstr "Only %d lines can be saved in parameters"
+
+#: ../src/iop/ashift.c:5200
+#, c-format
+msgid "rotation adjusted by %3.1f° to %3.1f°"
+msgstr "Rotation adjusted by %3.1f° to %3.1f°"
+
+#: ../src/iop/ashift.c:5848 ../src/iop/ashift.c:5850 ../src/iop/ashift.c:5955
+#: ../src/iop/ashift.c:5957
+#, c-format
+msgid "lens shift (%s)"
+msgstr "Lens shift (%s)"
+
+#: ../src/iop/ashift.c:6121
+msgid "manual perspective"
+msgstr "Manual perspective"
+
+#: ../src/iop/ashift.c:6166
+msgctxt "section"
+msgid "perspective"
+msgstr "Perspective"
+
+#: ../src/iop/ashift.c:6173 ../src/iop/ashift.c:6282 ../src/iop/ashift.c:6284
+#: ../src/iop/ashift.c:6286
+msgid "structure"
+msgstr "Structure"
+
+#: ../src/iop/ashift.c:6208
+msgid ""
+"rotate image\n"
+"right-click and drag to define a horizontal or vertical line by drawing on "
+"the image"
+msgstr ""
+"Rotate image\n"
+"Right-click and drag to define a horizontal or vertical line by drawing on "
+"the image"
+
+#: ../src/iop/ashift.c:6211 ../src/iop/ashift.c:6213
+msgid "apply lens shift correction in one direction"
+msgstr "Apply lens shift correction in one direction"
+
+#: ../src/iop/ashift.c:6215
+msgid "shear the image along one diagonal"
+msgstr "Shear the image along one diagonal"
+
+#: ../src/iop/ashift.c:6216 ../src/iop/clipping.c:2117
+msgid "automatically crop to avoid black edges"
+msgstr "Automatically crop to avoid black edges"
+
+#: ../src/iop/ashift.c:6217
+msgid ""
+"lens model of the perspective correction: generic or according to the focal "
+"length"
+msgstr ""
+"Lens model of the perspective correction: generic or according to the focal "
+"length"
+
+#: ../src/iop/ashift.c:6220
+msgid "focal length of the lens, default value set from EXIF data if available"
+msgstr ""
+"Focal length of the lens, default value set from EXIF data if available"
+
+#: ../src/iop/ashift.c:6223
+msgid ""
+"crop factor of the camera sensor, default value set from EXIF data if "
+"available, manual setting is often required"
+msgstr ""
+"Crop factor of the camera sensor, default value set from EXIF data if "
+"available, manual setting is often required"
+
+#: ../src/iop/ashift.c:6227
+msgid ""
+"the level of lens dependent correction, set to maximum for full lens "
+"dependency, set to zero for the generic case"
+msgstr ""
+"The level of lens dependent correction, set to maximum for full lens "
+"dependency, set to zero for the generic case"
+
+#: ../src/iop/ashift.c:6231
+msgid "adjust aspect ratio of image by horizontal and vertical scaling"
+msgstr "Adjust aspect ratio of image by horizontal and vertical scaling"
+
+#: ../src/iop/ashift.c:6233
+msgid ""
+"automatically correct for vertical perspective distortion\n"
+"ctrl+click to only fit rotation\n"
+"shift+click to only fit lens shift"
+msgstr ""
+"Automatically correct for vertical perspective distortion\n"
+"Ctrl+click to only fit rotation\n"
+"Shift+click to only fit lens shift"
+
+#: ../src/iop/ashift.c:6237
+msgid ""
+"automatically correct for horizontal perspective distortion\n"
+"ctrl+click to only fit rotation\n"
+"shift+click to only fit lens shift"
+msgstr ""
+"Automatically correct for horizontal perspective distortion\n"
+"Ctrl+click to only fit rotation\n"
+"Shift+click to only fit lens shift"
+
+#: ../src/iop/ashift.c:6241
+msgid ""
+"automatically correct for vertical and horizontal perspective distortions, "
+"fitting rotation, lens shift in both directions, and shear\n"
+"ctrl+click to only fit rotation\n"
+"shift+click to only fit lens shift\n"
+"ctrl+shift+click to only fit rotation and lens shift"
+msgstr ""
+"Automatically correct for vertical and horizontal perspective distortions, "
+"fitting rotation, lens shift in both directions, and shear\n"
+"Ctrl+click to only fit rotation\n"
+"Shift+click to only fit lens shift\n"
+"Ctrl+Shift+click to only fit rotation and lens shift"
+
+#: ../src/iop/ashift.c:6248
+msgid ""
+"automatically analyse line structure in image\n"
+"ctrl+click for an additional edge enhancement\n"
+"shift+click for an additional detail enhancement\n"
+"ctrl+shift+click for a combination of both methods"
+msgstr ""
+"Automatically analyse line structure in image\n"
+"Ctrl+click for an additional edge enhancement\n"
+"Shift+click for an additional detail enhancement\n"
+"Ctrl+Shift+click for a combination of both methods"
+
+#: ../src/iop/ashift.c:6253
+msgid "manually define perspective rectangle"
+msgstr "Manually define perspective rectangle"
+
+#: ../src/iop/ashift.c:6254
+msgid "manually draw structure lines"
+msgstr "Manually draw structure lines"
+
+#: ../src/iop/ashift.c:6283
+msgid "rectangle"
+msgstr "Rectangle"
+
+#: ../src/iop/ashift.c:6285
+msgid "lines"
+msgstr "Lines"
+
+#: ../src/iop/ashift.c:6319 ../src/iop/clipping.c:3343
+#, c-format
+msgid "[%s] define/rotate horizon"
+msgstr "[%s] define/rotate horizon"
+
+#: ../src/iop/ashift.c:6322
+#, c-format
+msgid "[%s on segment] select segment"
+msgstr "[%s on segment] select segment"
+
+#: ../src/iop/ashift.c:6326
+#, c-format
+msgid "[%s on segment] unselect segment"
+msgstr "[%s on segment] unselect segment"
+
+#: ../src/iop/ashift.c:6330
+#, c-format
+msgid "[%s] select all segments from zone"
+msgstr "[%s] select all segments from zone"
+
+#: ../src/iop/ashift.c:6334
+#, c-format
+msgid "[%s] unselect all segments from zone"
+msgstr "[%s] unselect all segments from zone"
+
+#: ../src/iop/atrous.c:123 ../src/iop/atrous.c:1640
+msgid "contrast equalizer"
+msgstr "Contrast equalizer"
+
+#: ../src/iop/atrous.c:128
+msgid "sharpness|acutance|local contrast"
+msgstr "sharpness|acutance|local contrast"
+
+#: ../src/iop/atrous.c:133
+msgid "add or remove local contrast, sharpness, acutance"
+msgstr "Add or remove local contrast, sharpness, acutance"
+
+#: ../src/iop/atrous.c:134 ../src/iop/bilateral.cc:100 ../src/iop/diffuse.c:145
+#: ../src/iop/exposure.c:130 ../src/iop/filmicrgb.c:358
+#: ../src/iop/graduatednd.c:146 ../src/iop/negadoctor.c:146
+#: ../src/iop/rgbcurve.c:143 ../src/iop/rgblevels.c:123 ../src/iop/shadhi.c:197
+#: ../src/iop/sigmoid.c:101 ../src/iop/tonecurve.c:211
+#: ../src/iop/toneequal.c:324
+msgid "corrective and creative"
+msgstr "Corrective and creative"
+
+#: ../src/iop/atrous.c:135 ../src/iop/atrous.c:137
+#: ../src/iop/colorbalance.c:162
+msgid "linear, Lab, scene-referred"
+msgstr "Linear, Lab, scene-referred"
+
+#: ../src/iop/atrous.c:136 ../src/iop/censorize.c:85
+#: ../src/iop/hazeremoval.c:114
+msgid "frequential, RGB"
+msgstr "Frequential, RGB"
+
+#: ../src/iop/atrous.c:728
+msgctxt "eq_preset"
+msgid "coarse"
+msgstr "Coarse"
+
+#: ../src/iop/atrous.c:743
+msgid "denoise & sharpen"
+msgstr "Denoise & sharpen"
+
+#: ../src/iop/atrous.c:758
+msgctxt "atrous"
+msgid "sharpen"
+msgstr "Sharpen"
+
+#: ../src/iop/atrous.c:773
+msgid "denoise chroma"
+msgstr "Denoise chroma"
+
+#: ../src/iop/atrous.c:788
+msgid "denoise"
+msgstr "Denoise"
+
+#: ../src/iop/atrous.c:804 ../src/iop/bloom.c:75 ../src/iop/diffuse.c:421
+msgid "bloom"
+msgstr "Bloom"
+
+#: ../src/iop/atrous.c:819 ../src/iop/bilat.c:169
+msgid "clarity"
+msgstr "Clarity"
+
+#: ../src/iop/atrous.c:839
+msgid "deblur: large blur, strength 3"
+msgstr "Deblur: large blur, strength 3"
+
+#: ../src/iop/atrous.c:856
+msgid "deblur: medium blur, strength 3"
+msgstr "Deblur: medium blur, strength 3"
+
+#: ../src/iop/atrous.c:872
+msgid "deblur: fine blur, strength 3"
+msgstr "Deblur: fine blur, strength 3"
+
+#: ../src/iop/atrous.c:890
+msgid "deblur: large blur, strength 2"
+msgstr "Deblur: large blur, strength 2"
+
+#: ../src/iop/atrous.c:907
+msgid "deblur: medium blur, strength 2"
+msgstr "Deblur: medium blur, strength 2"
+
+#: ../src/iop/atrous.c:923
+msgid "deblur: fine blur, strength 2"
+msgstr "Deblur: fine blur, strength 2"
+
+#: ../src/iop/atrous.c:941
+msgid "deblur: large blur, strength 1"
+msgstr "Deblur: large blur, strength 1"
+
+#: ../src/iop/atrous.c:958
+msgid "deblur: medium blur, strength 1"
+msgstr "Deblur: medium blur, strength 1"
+
+#: ../src/iop/atrous.c:974
+msgid "deblur: fine blur, strength 1"
+msgstr "Deblur: fine blur, strength 1"
+
+#: ../src/iop/atrous.c:1291 ../src/iop/atrous.c:1527
+#: ../src/iop/denoiseprofile.c:3584 ../src/iop/rawdenoise.c:739
+msgid "coarse"
+msgstr "Coarse"
+
+#: ../src/iop/atrous.c:1298 ../src/iop/atrous.c:1528
+#: ../src/iop/denoiseprofile.c:3592 ../src/iop/rawdenoise.c:747
+msgid "fine"
+msgstr "Fine"
+
+#: ../src/iop/atrous.c:1310
+msgid "contrasty"
+msgstr "Contrasty"
+
+#: ../src/iop/atrous.c:1316 ../src/iop/denoiseprofile.c:3606
+#: ../src/iop/rawdenoise.c:761
+msgid "noisy"
+msgstr "Noisy"
+
+#. case atrous_s:
+#: ../src/iop/atrous.c:1319
+msgid "bold"
+msgstr "Bold"
+
+#: ../src/iop/atrous.c:1320
+msgid "dull"
+msgstr "Dull"
+
+#: ../src/iop/atrous.c:1515 ../src/iop/atrous.c:1566
+msgid "boost"
+msgstr "Boost"
+
+#: ../src/iop/atrous.c:1516
+msgid "reduce"
+msgstr "Reduce"
+
+#: ../src/iop/atrous.c:1517
+msgid "raise"
+msgstr "Raise"
+
+#: ../src/iop/atrous.c:1518
+msgid "lower"
+msgstr "Lower"
+
+#: ../src/iop/atrous.c:1525
+msgid "coarsest"
+msgstr "Coarsest"
+
+#: ../src/iop/atrous.c:1526
+msgid "coarser"
+msgstr "Coarser"
+
+#: ../src/iop/atrous.c:1529
+msgid "finer"
+msgstr "Finer"
+
+#: ../src/iop/atrous.c:1530
+msgid "finest"
+msgstr "Finest"
+
+#: ../src/iop/atrous.c:1588 ../src/libs/export.c:1149 ../src/libs/export.c:1164
+msgid "x"
+msgstr "x"
+
+#: ../src/iop/atrous.c:1669 ../src/iop/nlmeans.c:465
+msgid "luma"
+msgstr "Luma"
+
+#: ../src/iop/atrous.c:1669
+msgid "change lightness at each feature size"
+msgstr "Change lightness at each feature size"
+
+#: ../src/iop/atrous.c:1670
+msgid "change color saturation at each feature size"
+msgstr "Change color saturation at each feature size"
+
+#: ../src/iop/atrous.c:1671
+msgid "edges"
+msgstr "Edges"
+
+#: ../src/iop/atrous.c:1671
+msgid ""
+"change edge halos at each feature size\n"
+"only changes results of luma and chroma tabs"
+msgstr ""
+"Change edge halos at each feature size\n"
+"Only changes results of luma and chroma tabs"
+
+#: ../src/iop/atrous.c:1682 ../src/iop/colorbalancergb.c:2027
+#: ../src/iop/colorzones.c:2474 ../src/iop/denoiseprofile.c:3817
+#: ../src/iop/filmicrgb.c:4146 ../src/iop/lowlight.c:825
+#: ../src/iop/rawdenoise.c:921 ../src/iop/toneequal.c:3387
+msgid "graph"
+msgstr "Graph"
+
+#: ../src/iop/atrous.c:1693 ../src/iop/colorzones.c:2471
+msgid "make effect stronger or weaker"
+msgstr "Make effect stronger or weaker"
+
+#: ../src/iop/basecurve.c:213
+msgid "neutral"
+msgstr "Neutral"
+
+#: ../src/iop/basecurve.c:214
+msgid "canon eos like"
+msgstr "Canon EOS like"
+
+#: ../src/iop/basecurve.c:215
+msgid "canon eos like alternate"
+msgstr "Canon EOS like alternate"
+
+#: ../src/iop/basecurve.c:216
+msgid "nikon like"
+msgstr "Nikon like"
+
+#: ../src/iop/basecurve.c:217
+msgid "nikon like alternate"
+msgstr "Nikon like alternate"
+
+#: ../src/iop/basecurve.c:218
+msgid "sony alpha like"
+msgstr "Sony Alpha like"
+
+#: ../src/iop/basecurve.c:219
+msgid "pentax like"
+msgstr "Pentax like"
+
+#: ../src/iop/basecurve.c:220
+msgid "ricoh like"
+msgstr "Ricoh like"
+
+#: ../src/iop/basecurve.c:221
+msgid "olympus like"
+msgstr "Olympus like"
+
+#: ../src/iop/basecurve.c:222
+msgid "olympus like alternate"
+msgstr "Olympus like alternate"
+
+#: ../src/iop/basecurve.c:223
+msgid "panasonic like"
+msgstr "Panasonic like"
+
+#: ../src/iop/basecurve.c:224
+msgid "leica like"
+msgstr "Leica like"
+
+#: ../src/iop/basecurve.c:225
+msgid "kodak easyshare like"
+msgstr "Kodak Easyshare like"
+
+#: ../src/iop/basecurve.c:226
+msgid "konica minolta like"
+msgstr "Konica Minolta like"
+
+#: ../src/iop/basecurve.c:227
+msgid "samsung like"
+msgstr "Samsung like"
+
+#: ../src/iop/basecurve.c:228
+msgid "fujifilm like"
+msgstr "Fujifilm like"
+
+#: ../src/iop/basecurve.c:229
+msgid "nokia like"
+msgstr "Nokia like"
+
+#. clang-format off
+#. smoother cubic spline curve
+#: ../src/iop/basecurve.c:284 ../src/iop/colorzones.c:2496
+#: ../src/iop/rgbcurve.c:1408 ../src/iop/tonecurve.c:1171
+msgid "cubic spline"
+msgstr "Cubic spline"
+
+#: ../src/iop/basecurve.c:343
+msgid "base curve"
+msgstr "Base curve"
+
+#: ../src/iop/basecurve.c:350
+msgid ""
+"apply a view transform based on personal or camera manufacturer look,\n"
+"for corrective purposes, to prepare images for display"
+msgstr ""
+"Apply a view transform based on personal or camera manufacturer look\n"
+"for corrective purposes, to prepare images for display"
+
+#: ../src/iop/basecurve.c:352 ../src/iop/cacorrect.c:78
+#: ../src/iop/cacorrectrgb.c:170 ../src/iop/colorreconstruction.c:135
+#: ../src/iop/defringe.c:82 ../src/iop/denoiseprofile.c:725
+#: ../src/iop/dither.c:100 ../src/iop/flip.c:110 ../src/iop/hazeremoval.c:112
+#: ../src/iop/highlights.c:179 ../src/iop/hotpixels.c:73
+#: ../src/iop/invert.c:119 ../src/iop/lens.cc:211 ../src/iop/nlmeans.c:95
+#: ../src/iop/profile_gamma.c:102 ../src/iop/rawdenoise.c:130
+#: ../src/iop/retouch.c:209 ../src/iop/sharpen.c:94 ../src/iop/spots.c:69
+#: ../src/iop/temperature.c:212
+msgid "corrective"
+msgstr "Corrective"
+
+#: ../src/iop/basecurve.c:353 ../src/iop/channelmixer.c:140
+#: ../src/iop/channelmixer.c:142 ../src/iop/lut3d.c:142
+#: ../src/iop/negadoctor.c:147 ../src/iop/profile_gamma.c:103
+#: ../src/iop/rgbcurve.c:144 ../src/iop/rgbcurve.c:146
+#: ../src/iop/rgblevels.c:124 ../src/iop/sigmoid.c:104 ../src/iop/soften.c:102
+#: ../src/iop/soften.c:104
+msgid "linear, RGB, display-referred"
+msgstr "Linear, RGB, display-referred"
+
+#: ../src/iop/basecurve.c:354 ../src/iop/basicadj.c:149
+#: ../src/iop/colorbalance.c:163 ../src/iop/colorbalancergb.c:187
+#: ../src/iop/dither.c:102 ../src/iop/filmicrgb.c:360
+#: ../src/iop/graduatednd.c:148 ../src/iop/negadoctor.c:148
+#: ../src/iop/profile_gamma.c:104 ../src/iop/rgbcurve.c:145
+#: ../src/iop/rgblevels.c:125 ../src/iop/sigmoid.c:103
+#: ../src/iop/vignette.c:160 ../src/iop/watermark.c:299
+msgid "non-linear, RGB"
+msgstr "Non-linear, RGB"
+
+#: ../src/iop/basecurve.c:355 ../src/iop/dither.c:101 ../src/iop/dither.c:103
+#: ../src/iop/filmicrgb.c:361 ../src/iop/graduatednd.c:149
+#: ../src/iop/negadoctor.c:149 ../src/iop/profile_gamma.c:105
+#: ../src/iop/rgblevels.c:126 ../src/iop/vignette.c:159
+#: ../src/iop/vignette.c:161 ../src/iop/watermark.c:298
+#: ../src/iop/watermark.c:300
+msgid "non-linear, RGB, display-referred"
+msgstr "Non-linear, RGB, display-referred"
+
+#: ../src/iop/basecurve.c:2167
+msgid "abscissa: input, ordinate: output. works on RGB channels"
+msgstr "Abscissa: input, ordinate: output. Works on RGB channels"
+
+#: ../src/iop/basecurve.c:2173 ../src/iop/basicadj.c:612
+#: ../src/iop/rgbcurve.c:1423 ../src/iop/rgblevels.c:1070
+#: ../src/iop/tonecurve.c:1182
+msgid "method to preserve colors when applying contrast"
+msgstr "Method to preserve colors when applying contrast"
+
+#: ../src/iop/basecurve.c:2177
+msgid "two exposures"
+msgstr "Two exposures"
+
+#: ../src/iop/basecurve.c:2178
+msgid "three exposures"
+msgstr "Three exposures"
+
+#: ../src/iop/basecurve.c:2179
+msgid ""
+"fuse this image stopped up/down a couple of times with itself, to compress "
+"high dynamic range. expose for the highlights before use."
+msgstr ""
+"Fuse this image stopped up/down a couple of times with itself, to compress "
+"high dynamic range. Expose for the highlights before use."
+
+#: ../src/iop/basecurve.c:2184
+msgid "how many stops to shift the individual exposures apart"
+msgstr "How many stops to shift the individual exposures apart"
+
+#: ../src/iop/basecurve.c:2193
+msgid ""
+"whether to shift exposure up or down (-1: reduce highlight, +1: reduce "
+"shadows)"
+msgstr ""
+"Whether to shift exposure up or down (-1: reduce highlight, +1: reduce "
+"shadows)"
+
+#: ../src/iop/basecurve.c:2198 ../src/iop/tonecurve.c:1185
+msgid "scale for graph"
+msgstr "Scale for graph"
+
+#: ../src/iop/basicadj.c:136
+msgid "this module is deprecated. please use the quick access panel instead."
+msgstr "This module is deprecated. Please use the quick access panel instead."
+
+#: ../src/iop/basicadj.c:141
+msgid "basic adjustments"
+msgstr "Basic adjustments"
+
+#: ../src/iop/basicadj.c:146
+msgid "apply usual image adjustments"
+msgstr "Apply usual image adjustments"
+
+#: ../src/iop/basicadj.c:147 ../src/iop/bilat.c:102 ../src/iop/bloom.c:81
+#: ../src/iop/blurs.c:93 ../src/iop/borders.c:192 ../src/iop/censorize.c:83
+#: ../src/iop/colisa.c:90 ../src/iop/colorcontrast.c:97
+#: ../src/iop/colorize.c:105 ../src/iop/colormapping.c:153
+#: ../src/iop/colorzones.c:145 ../src/iop/grain.c:425 ../src/iop/highpass.c:78
+#: ../src/iop/levels.c:135 ../src/iop/liquify.c:296 ../src/iop/lowlight.c:92
+#: ../src/iop/lowpass.c:134 ../src/iop/monochrome.c:98 ../src/iop/soften.c:101
+#: ../src/iop/splittoning.c:103 ../src/iop/velvia.c:105
+#: ../src/iop/vibrance.c:95 ../src/iop/vignette.c:158
+#: ../src/iop/watermark.c:297
+msgid "creative"
+msgstr "Creative"
+
+#: ../src/iop/basicadj.c:150 ../src/iop/colorbalancergb.c:188
+msgid "non-linear, RGB, scene-referred"
+msgstr "Non-linear, RGB, scene-referred"
+
+#: ../src/iop/basicadj.c:593
+msgid ""
+"adjust the black level to unclip negative RGB values.\n"
+"you should never use it to add more density in blacks!\n"
+"if poorly set, it will clip near-black colors out of gamut\n"
+"by pushing RGB values into negatives"
+msgstr ""
+"Adjust the black level to unclip negative RGB values.\n"
+"You should never use it to add more density in blacks!\n"
+"If poorly set, it will clip near-black colors out of gamut\n"
+"by pushing RGB values into negatives"
+
+#: ../src/iop/basicadj.c:601 ../src/iop/exposure.c:1110
+msgid "adjust the exposure correction"
+msgstr "Adjust the exposure correction"
+
+#: ../src/iop/basicadj.c:605
+msgid "highlight compression adjustment"
+msgstr "Highlight compression adjustment"
+
+#: ../src/iop/basicadj.c:609 ../src/iop/colisa.c:308
+msgid "contrast adjustment"
+msgstr "Contrast adjustment"
+
+#: ../src/iop/basicadj.c:617
+msgid "middle gray adjustment"
+msgstr "Middle gray adjustment"
+
+#: ../src/iop/basicadj.c:622 ../src/iop/colisa.c:309
+msgid "brightness adjustment"
+msgstr "Brightness adjustment"
+
+#: ../src/iop/basicadj.c:625
+msgid "saturation adjustment"
+msgstr "Saturation adjustment"
+
+#: ../src/iop/basicadj.c:628
+msgid "vibrance adjustment"
+msgstr "Vibrance adjustment"
+
+#: ../src/iop/basicadj.c:632
+msgid "apply auto exposure based on the entire image"
+msgstr "Apply auto exposure based on the entire image"
+
+#: ../src/iop/basicadj.c:639
+msgid ""
+"apply auto exposure based on a region defined by the user\n"
+"click and drag to draw the area\n"
+"right click to cancel"
+msgstr ""
+"Apply auto exposure based on a region defined by the user\n"
+"Click and drag to draw the area\n"
+"Right click to cancel"
+
+#: ../src/iop/basicadj.c:647
+msgid "clip"
+msgstr "Clip"
+
+#: ../src/iop/basicadj.c:649
+msgid "adjusts clipping value for auto exposure calculation"
+msgstr "Adjusts clipping value for auto exposure calculation"
+
+#. local contrast
+#: ../src/iop/bilat.c:96 ../src/iop/clahe.c:64 ../src/iop/diffuse.c:551
+msgid "local contrast"
+msgstr "Local contrast"
+
+#: ../src/iop/bilat.c:101
+msgid "manipulate local and global contrast separately"
+msgstr "Manipulate local and global contrast separately"
+
+#: ../src/iop/bilat.c:103 ../src/iop/bilat.c:105 ../src/iop/bloom.c:82
+#: ../src/iop/bloom.c:84 ../src/iop/colisa.c:91 ../src/iop/colisa.c:93
+#: ../src/iop/colorcontrast.c:98 ../src/iop/colorcontrast.c:100
+#: ../src/iop/colorcorrection.c:78 ../src/iop/colorcorrection.c:80
+#: ../src/iop/colorize.c:108 ../src/iop/colormapping.c:156
+#: ../src/iop/colorreconstruction.c:138 ../src/iop/colorzones.c:148
+#: ../src/iop/defringe.c:85 ../src/iop/grain.c:426 ../src/iop/grain.c:428
+#: ../src/iop/levels.c:138 ../src/iop/lowlight.c:93 ../src/iop/lowlight.c:95
+#: ../src/iop/monochrome.c:101 ../src/iop/nlmeans.c:96 ../src/iop/nlmeans.c:98
+#: ../src/iop/shadhi.c:200 ../src/iop/tonecurve.c:214 ../src/iop/vibrance.c:98
+msgid "non-linear, Lab, display-referred"
+msgstr "Non-linear, Lab, display-referred"
+
+#: ../src/iop/bilat.c:104 ../src/iop/bloom.c:83 ../src/iop/colisa.c:92
+#: ../src/iop/colorcontrast.c:99 ../src/iop/colorcorrection.c:79
+#: ../src/iop/colorize.c:107 ../src/iop/colormapping.c:155
+#: ../src/iop/colorreconstruction.c:137 ../src/iop/colorzones.c:147
+#: ../src/iop/defringe.c:84 ../src/iop/grain.c:427 ../src/iop/levels.c:137
+#: ../src/iop/monochrome.c:100 ../src/iop/nlmeans.c:97 ../src/iop/shadhi.c:199
+#: ../src/iop/tonecurve.c:213 ../src/iop/vibrance.c:97
+msgid "non-linear, Lab"
+msgstr "Non-linear, Lab"
+
+#: ../src/iop/bilat.c:178
+msgid "HDR local tone-mapping"
+msgstr "HDR local tone-mapping"
+
+#: ../src/iop/bilat.c:431
+msgid ""
+"the filter used for local contrast enhancement. bilateral is faster but can "
+"lead to artifacts around edges for extreme settings."
+msgstr ""
+"The filter used for local contrast enhancement. Bilateral is faster but can "
+"lead to artifacts around edges for extreme settings."
+
+#: ../src/iop/bilat.c:435 ../src/iop/globaltonemap.c:635
+msgid "detail"
+msgstr "Detail"
+
+#: ../src/iop/bilat.c:438
+msgid "changes the local contrast"
+msgstr "Changes the local contrast"
+
+#: ../src/iop/bilat.c:453
+msgid "feature size of local details (spatial sigma of bilateral filter)"
+msgstr "Feature size of local details (spatial sigma of bilateral filter)"
+
+#: ../src/iop/bilat.c:461
+msgid "L difference to detect edges (range sigma of bilateral filter)"
+msgstr "L difference to detect edges (range sigma of bilateral filter)"
+
+#: ../src/iop/bilat.c:467
+msgid "changes the local contrast of highlights"
+msgstr "Changes the local contrast of highlights"
+
+#: ../src/iop/bilat.c:473
+msgid "changes the local contrast of shadows"
+msgstr "Changes the local contrast of shadows"
+
+#: ../src/iop/bilat.c:479
+msgid ""
+"defines what counts as mid-tones. lower for better dynamic range compression "
+"(reduce shadow and highlight contrast), increase for more powerful local "
+"contrast"
+msgstr ""
+"Defines what counts as mid-tones. Lower for better dynamic range compression "
+"(reduce shadow and highlight contrast), increase for more powerful local "
+"contrast"
+
+#: ../src/iop/bilateral.cc:74 ../src/iop/diffuse.c:396
+msgid "surface blur"
+msgstr "Surface blur"
+
+#: ../src/iop/bilateral.cc:79
+msgid "denoise (bilateral filter)"
+msgstr "Denoise (bilateral filter)"
+
+#: ../src/iop/bilateral.cc:99
+msgid "apply edge-aware surface blur to denoise or smoothen textures"
+msgstr "Apply edge-aware surface blur to denoise or smoothen textures"
+
+#: ../src/iop/bilateral.cc:102 ../src/iop/blurs.c:93
+#: ../src/iop/channelmixer.c:141 ../src/iop/denoiseprofile.c:727
+#: ../src/iop/diffuse.c:147 ../src/iop/exposure.c:132 ../src/iop/soften.c:103
+#: ../src/iop/splittoning.c:105 ../src/iop/velvia.c:107
+msgid "linear, RGB"
+msgstr "Linear, RGB"
+
+#: ../src/iop/bilateral.cc:136
+msgid "image too large"
+msgstr "Image too large"
+
+#: ../src/iop/bilateral.cc:137
+msgid ""
+"this module is unable to process\n"
+"images with more than 2 gigapixels.\n"
+"processing has been skipped."
+msgstr ""
+"This module is unable to process\n"
+"images with more than 2 gigapixels.\n"
+"Processing has been skipped."
+
+#: ../src/iop/bilateral.cc:351
+msgid "spatial extent of the gaussian"
+msgstr "Spatial extent of the gaussian"
+
+#: ../src/iop/bilateral.cc:355
+msgid "how much to blur red"
+msgstr "How much to blur red"
+
+#: ../src/iop/bilateral.cc:360
+msgid "how much to blur green"
+msgstr "How much to blur green"
+
+#: ../src/iop/bilateral.cc:365
+msgid "how much to blur blue"
+msgstr "How much to blur blue"
+
+#: ../src/iop/bloom.c:80
+msgid "apply Orton effect for a dreamy aetherical look"
+msgstr "Apply Orton effect for a dreamy aetherical look"
+
+#: ../src/iop/bloom.c:368 ../src/iop/soften.c:369 ../src/libs/camera.c:568
+#: ../src/libs/masks.c:105
+msgid "size"
+msgstr "Size"
+
+#: ../src/iop/bloom.c:370
+msgid "the size of bloom"
+msgstr "The size of bloom"
+
+#: ../src/iop/bloom.c:374
+msgid "the threshold of light"
+msgstr "The threshold of light"
+
+#: ../src/iop/bloom.c:378
+msgid "the strength of bloom"
+msgstr "The strength of bloom"
+
+#: ../src/iop/blurs.c:81
+msgid "blurs"
+msgstr "Blurs"
+
+#: ../src/iop/blurs.c:86
+msgid "blur|lens|motion"
+msgstr "blur|lens|motion"
+
+#: ../src/iop/blurs.c:92
+msgid "simulate physically-accurate lens and motion blurs"
+msgstr "Simulate physically-accurate lens and motion blurs"
+
+#: ../src/iop/borders.c:186
+msgid "framing"
+msgstr "Framing"
+
+#: ../src/iop/borders.c:191
+msgid "add solid borders or margins around the picture"
+msgstr "Add solid borders or margins around the picture"
+
+#: ../src/iop/borders.c:193 ../src/iop/borders.c:195 ../src/iop/lut3d.c:144
+msgid "linear or non-linear, RGB, display-referred"
+msgstr "Linear or non-linear, RGB, display-referred"
+
+#: ../src/iop/borders.c:720
+msgid "15:10 postcard white"
+msgstr "15:10 postcard white"
+
+#: ../src/iop/borders.c:725
+msgid "15:10 postcard black"
+msgstr "15:10 postcard black"
+
+#: ../src/iop/borders.c:935
+msgid "size of the border in percent of the full image"
+msgstr "Size of the border in percent of the full image"
+
+#: ../src/iop/borders.c:937 ../src/iop/clipping.c:2218 ../src/iop/crop.c:1224
+msgid "aspect"
+msgstr "Aspect"
+
+#: ../src/iop/borders.c:938
+msgid "select the aspect ratio or right click and type your own (w:h)"
+msgstr "Select the aspect ratio or right click and type your own (w:h)"
+
+#: ../src/iop/borders.c:941
+msgid "3:1"
+msgstr "3:1"
+
+#: ../src/iop/borders.c:942
+msgid "95:33"
+msgstr "95:33"
+
+#: ../src/iop/borders.c:943
+msgid "2:1"
+msgstr "2:1"
+
+#: ../src/iop/borders.c:944
+msgid "16:9"
+msgstr "16:9"
+
+#: ../src/iop/borders.c:945 ../src/iop/clipping.c:2131 ../src/iop/crop.c:1128
+msgid "golden cut"
+msgstr "Golden cut"
+
+#: ../src/iop/borders.c:946
+msgid "3:2"
+msgstr "3:2"
+
+#: ../src/iop/borders.c:948
+msgid "DIN"
+msgstr "DIN"
+
+#: ../src/iop/borders.c:949
+msgid "4:3"
+msgstr "4:3"
+
+#: ../src/iop/borders.c:950 ../src/iop/clipping.c:2121 ../src/iop/crop.c:1118
+#: ../src/libs/filtering.c:301 ../src/libs/filters/ratio.c:126
+#: ../src/libs/histogram.c:140
+msgid "square"
+msgstr "Square"
+
+#: ../src/iop/borders.c:951
+msgid "constant border"
+msgstr "Constant border"
+
+#: ../src/iop/borders.c:952 ../src/iop/borders.c:966 ../src/iop/borders.c:977
+msgid "custom..."
+msgstr "Custom..."
+
+#: ../src/iop/borders.c:957
+msgid "set the custom aspect ratio"
+msgstr "Set the custom aspect ratio"
+
+#: ../src/iop/borders.c:960
+msgid "aspect ratio orientation of the image with border"
+msgstr "Aspect ratio orientation of the image with border"
+
+#: ../src/iop/borders.c:962
+msgid "horizontal position"
+msgstr "Horizontal position"
+
+#: ../src/iop/borders.c:963
+msgid ""
+"select the horizontal position ratio relative to top or right click and type "
+"your own (y:h)"
+msgstr ""
+"Select the horizontal position ratio relative to top or right click and type "
+"your own (y:h)"
+
+#: ../src/iop/borders.c:966 ../src/iop/borders.c:977
+msgid "center"
+msgstr "Center"
+
+#: ../src/iop/borders.c:966 ../src/iop/borders.c:977
+msgid "1/3"
+msgstr "1/3"
+
+#: ../src/iop/borders.c:966 ../src/iop/borders.c:977
+msgid "3/8"
+msgstr "3/8"
+
+#: ../src/iop/borders.c:966 ../src/iop/borders.c:977
+msgid "5/8"
+msgstr "5/8"
+
+#: ../src/iop/borders.c:966 ../src/iop/borders.c:977
+msgid "2/3"
+msgstr "2/3"
+
+#: ../src/iop/borders.c:971
+msgid "custom horizontal position"
+msgstr "Custom horizontal position"
+
+#: ../src/iop/borders.c:973
+msgid "vertical position"
+msgstr "Vertical position"
+
+#: ../src/iop/borders.c:974
+msgid ""
+"select the vertical position ratio relative to left or right click and type "
+"your own (x:w)"
+msgstr ""
+"Select the vertical position ratio relative to left or right click and type "
+"your own (x:w)"
+
+#: ../src/iop/borders.c:982
+msgid "custom vertical position"
+msgstr "Custom vertical position"
+
+#: ../src/iop/borders.c:987
+msgid "size of the frame line in percent of min border width"
+msgstr "Size of the frame line in percent of min border width"
+
+#: ../src/iop/borders.c:992
+msgid "offset of the frame line beginning on picture side"
+msgstr "Offset of the frame line beginning on picture side"
+
+#: ../src/iop/borders.c:999
+msgid "border color"
+msgstr "Border color"
+
+#: ../src/iop/borders.c:1003
+msgid "select border color"
+msgstr "Select border color"
+
+#: ../src/iop/borders.c:1007
+msgid "pick border color from image"
+msgstr "Pick border color from image"
+
+#: ../src/iop/borders.c:1011
+msgid "frame line color"
+msgstr "Frame line color"
+
+#: ../src/iop/borders.c:1015
+msgid "select frame line color"
+msgstr "Select frame line color"
+
+#: ../src/iop/borders.c:1019
+msgid "pick frame line color from image"
+msgstr "Pick frame line color from image"
+
+#. make sure you put all your translatable strings into _() !
+#: ../src/iop/cacorrect.c:72
+msgid "raw chromatic aberrations"
+msgstr "Raw chromatic aberrations"
+
+#: ../src/iop/cacorrect.c:77
+msgid "correct chromatic aberrations for Bayer sensors"
+msgstr "Correct chromatic aberrations for Bayer sensors"
+
+#: ../src/iop/cacorrect.c:79 ../src/iop/cacorrect.c:81
+#: ../src/iop/cacorrectrgb.c:171 ../src/iop/cacorrectrgb.c:173
+#: ../src/iop/demosaic.c:290 ../src/iop/highlights.c:180
+#: ../src/iop/highlights.c:182 ../src/iop/hotpixels.c:74
+#: ../src/iop/hotpixels.c:76 ../src/iop/rawdenoise.c:131
+#: ../src/iop/rawdenoise.c:133 ../src/iop/rawprepare.c:159
+#: ../src/iop/rawprepare.c:161 ../src/iop/temperature.c:213
+#: ../src/iop/temperature.c:215
+msgid "linear, raw, scene-referred"
+msgstr "Linear, raw, scene-referred"
+
+#: ../src/iop/cacorrect.c:80 ../src/iop/cacorrectrgb.c:172
+#: ../src/iop/demosaic.c:291 ../src/iop/invert.c:121
+#: ../src/iop/rawdenoise.c:132 ../src/iop/rawprepare.c:160
+#: ../src/iop/temperature.c:214
+msgid "linear, raw"
+msgstr "Linear, raw"
+
+#: ../src/iop/cacorrect.c:1405
+msgid "iteration runs, default is twice"
+msgstr "Iteration runs, default is twice"
+
+#: ../src/iop/cacorrect.c:1408
+msgid "activate colorshift correction for blue & red channels"
+msgstr "Activate colorshift correction for blue & red channels"
+
+#: ../src/iop/cacorrect.c:1415
+msgid ""
+"automatic chromatic aberration correction\n"
+"only for Bayer raw files"
+msgstr ""
+"Automatic chromatic aberration correction\n"
+"Only for Bayer raw files"
+
+#: ../src/iop/cacorrectrgb.c:164 ../src/iop/defringe.c:76
+msgid "chromatic aberrations"
+msgstr "Chromatic aberrations"
+
+#: ../src/iop/cacorrectrgb.c:169
+msgid "correct chromatic aberrations"
+msgstr "Correct chromatic aberrations"
+
+#: ../src/iop/cacorrectrgb.c:743
+msgid ""
+"channel used as a reference to\n"
+"correct the other channels.\n"
+"use sharpest channel if some\n"
+"channels are blurry.\n"
+"try changing guide channel if you\n"
+"have artifacts."
+msgstr ""
+"Channel used as a reference to\n"
+"correct the other channels.\n"
+"Use sharpest channel if some\n"
+"channels are blurry.\n"
+"Try changing guide channel if you\n"
+"have artifacts."
+
+#: ../src/iop/cacorrectrgb.c:750
+msgid "increase for stronger correction"
+msgstr "Increase for stronger correction"
+
+#: ../src/iop/cacorrectrgb.c:752
+msgid ""
+"balance between smoothing colors\n"
+"and preserving them.\n"
+"high values can lead to overshooting\n"
+"and edge bleeding."
+msgstr ""
+"Balance between smoothing colors\n"
+"and preserving them.\n"
+"High values can lead to overshooting\n"
+"and edge bleeding."
+
+#: ../src/iop/cacorrectrgb.c:757
+msgctxt "section"
+msgid "advanced parameters"
+msgstr "Advanced parameters"
+
+#: ../src/iop/cacorrectrgb.c:759
+msgid ""
+"correction mode to use.\n"
+"can help with multiple\n"
+"instances for very damaged\n"
+"images.\n"
+"darken only is particularly\n"
+"efficient to correct blue\n"
+"chromatic aberration."
+msgstr ""
+"Correction mode to use.\n"
+"Can help with multiple\n"
+"instances for very damaged\n"
+"images.\n"
+"Darken only is particularly\n"
+"efficient to correct blue\n"
+"chromatic aberration."
+
+#: ../src/iop/cacorrectrgb.c:767
+msgid ""
+"runs an iterative approach\n"
+"with several radii.\n"
+"improves result on images\n"
+"with very large chromatic\n"
+"aberrations, but can smooth\n"
+"colors too much on other\n"
+"images."
+msgstr ""
+"Runs an iterative approach\n"
+"with several radii.\n"
+"Improves result on images\n"
+"with very large chromatic\n"
+"aberrations, but can smooth\n"
+"colors too much on other\n"
+"images."
+
+#: ../src/iop/censorize.c:77
+msgid "censorize"
+msgstr "Censorize"
+
+#: ../src/iop/censorize.c:82
+msgid "censorize license plates and body parts for privacy"
+msgstr "Censorize license plates and body parts for privacy"
+
+#: ../src/iop/censorize.c:84 ../src/iop/colorin.c:135
+#: ../src/iop/filmicrgb.c:359 ../src/iop/graduatednd.c:147
+msgid "linear or non-linear, RGB, scene-referred"
+msgstr "Linear or non-linear, RGB, scene-referred"
+
+#: ../src/iop/censorize.c:86
+msgid "special, RGB, scene-referred"
+msgstr "Special, RGB, scene-referred"
+
+#: ../src/iop/censorize.c:412
+msgid "radius_1"
+msgstr "Radius_1"
+
+#: ../src/iop/censorize.c:414
+msgid "pixelate"
+msgstr "Pixelate"
+
+#: ../src/iop/censorize.c:416
+msgid "radius_2"
+msgstr "Radius_2"
+
+#: ../src/iop/censorize.c:418
+msgid "noise"
+msgstr "Noise"
+
+#: ../src/iop/censorize.c:420
+msgid "radius of gaussian blur before pixellation"
+msgstr "Radius of gaussian blur before pixellation"
+
+#: ../src/iop/censorize.c:421
+msgid "radius of gaussian blur after pixellation"
+msgstr "Radius of gaussian blur after pixellation"
+
+#: ../src/iop/censorize.c:422
+msgid "radius of the intermediate pixellation"
+msgstr "Radius of the intermediate pixellation"
+
+#: ../src/iop/censorize.c:423
+msgid "amount of noise to add at the end"
+msgstr "Amount of noise to add at the end"
+
+#: ../src/iop/channelmixer.c:126
+msgid "channel mixer"
+msgstr "Channel mixer"
+
+#: ../src/iop/channelmixer.c:131
+msgid ""
+"this module is deprecated. please use the color calibration module instead."
+msgstr ""
+"This module is deprecated. Please use the color calibration module instead."
+
+#: ../src/iop/channelmixer.c:136 ../src/iop/channelmixerrgb.c:229
+msgid ""
+"perform color space corrections\n"
+"such as white balance, channels mixing\n"
+"and conversions to monochrome emulating film"
+msgstr ""
+"Perform color space corrections\n"
+"such as white balance, channels mixing\n"
+"and conversions to monochrome emulating film"
+
+#: ../src/iop/channelmixer.c:614
+msgid "destination"
+msgstr "Destination"
+
+#: ../src/iop/channelmixer.c:621
+msgctxt "channelmixer"
+msgid "gray"
+msgstr "Gray"
+
+#: ../src/iop/channelmixer.c:627
+msgid "amount of red channel in the output channel"
+msgstr "Amount of red channel in the output channel"
+
+#: ../src/iop/channelmixer.c:633
+msgid "amount of green channel in the output channel"
+msgstr "Amount of green channel in the output channel"
+
+#: ../src/iop/channelmixer.c:639
+msgid "amount of blue channel in the output channel"
+msgstr "Amount of blue channel in the output channel"
+
+#: ../src/iop/channelmixer.c:655 ../src/iop/channelmixerrgb.c:503
+msgid "swap R and B"
+msgstr "Swap R and B"
+
+#: ../src/iop/channelmixer.c:661 ../src/iop/channelmixerrgb.c:477
+msgid "swap G and B"
+msgstr "Swap G and B"
+
+#: ../src/iop/channelmixer.c:667
+msgid "color contrast boost"
+msgstr "Color contrast boost"
+
+#: ../src/iop/channelmixer.c:673
+msgid "color details boost"
+msgstr "Color details boost"
+
+#: ../src/iop/channelmixer.c:679
+msgid "color artifacts boost"
+msgstr "Color artifacts boost"
+
+#: ../src/iop/channelmixer.c:685
+msgid "B/W luminance-based"
+msgstr "B/W luminance-based"
+
+#: ../src/iop/channelmixer.c:691
+msgid "B/W artifacts boost"
+msgstr "B/W artifacts boost"
+
+#: ../src/iop/channelmixer.c:697
+msgid "B/W smooth skin"
+msgstr "B/W smooth skin"
+
+#: ../src/iop/channelmixer.c:703
+msgid "B/W blue artifacts reduce"
+msgstr "B/W blue artifacts reduce"
+
+#: ../src/iop/channelmixer.c:710
+msgid "B/W Ilford Delta 100-400"
+msgstr "B/W Ilford Delta 100-400"
+
+#: ../src/iop/channelmixer.c:717
+msgid "B/W Ilford Delta 3200"
+msgstr "B/W Ilford Delta 3200"
+
+#: ../src/iop/channelmixer.c:724
+msgid "B/W Ilford FP4"
+msgstr "B/W Ilford FP4"
+
+#: ../src/iop/channelmixer.c:731
+msgid "B/W Ilford HP5"
+msgstr "B/W Ilford HP5"
+
+#: ../src/iop/channelmixer.c:738
+msgid "B/W Ilford SFX"
+msgstr "B/W Ilford SFX"
+
+#: ../src/iop/channelmixer.c:745
+msgid "B/W Kodak T-Max 100"
+msgstr "B/W Kodak T-Max 100"
+
+#: ../src/iop/channelmixer.c:752
+msgid "B/W Kodak T-max 400"
+msgstr "B/W Kodak T-max 400"
+
+#: ../src/iop/channelmixer.c:759
+msgid "B/W Kodak Tri-X 400"
+msgstr "B/W Kodak Tri-X 400"
+
+#: ../src/iop/channelmixerrgb.c:219
+msgid "color calibration"
+msgstr "Color calibration"
+
+#: ../src/iop/channelmixerrgb.c:224
+msgid "channel mixer|white balance|monochrome"
+msgstr "channel mixer|white balance|monochrome"
+
+#: ../src/iop/channelmixerrgb.c:234
+msgid "linear, RGB or XYZ"
+msgstr "Linear, RGB or XYZ"
+
+#: ../src/iop/channelmixerrgb.c:375
+msgid "B&W: luminance-based"
+msgstr "B&W: luminance-based"
+
+#: ../src/iop/channelmixerrgb.c:410
+msgid "B&W: ILFORD HP5+"
+msgstr "B&W: ILFORD HP5+"
+
+#: ../src/iop/channelmixerrgb.c:419
+msgid "B&W: ILFORD DELTA 100"
+msgstr "B&W: ILFORD DELTA 100"
+
+#: ../src/iop/channelmixerrgb.c:429
+msgid "B&W: ILFORD DELTA 400 - 3200"
+msgstr "B&W: ILFORD DELTA 400 - 3200"
+
+#: ../src/iop/channelmixerrgb.c:438
+msgid "B&W: ILFORD FP4+"
+msgstr "B&W: ILFORD FP4+"
+
+#: ../src/iop/channelmixerrgb.c:447
+msgid "B&W: Fuji Acros 100"
+msgstr "B&W: Fuji Acros 100"
+
+#: ../src/iop/channelmixerrgb.c:464
+msgid "basic channel mixer"
+msgstr "Basic channel mixer"
+
+#: ../src/iop/channelmixerrgb.c:490
+msgid "swap G and R"
+msgstr "Swap G and R"
+
+#: ../src/iop/channelmixerrgb.c:1853
+msgid "(daylight)"
+msgstr "(daylight)"
+
+#: ../src/iop/channelmixerrgb.c:1855
+msgid "(black body)"
+msgstr "(black body)"
+
+#: ../src/iop/channelmixerrgb.c:1857
+msgid "(invalid)"
+msgstr "(invalid)"
+
+#: ../src/iop/channelmixerrgb.c:1861 ../src/iop/channelmixerrgb.c:1919
+msgid "very good"
+msgstr "Very good"
+
+#: ../src/iop/channelmixerrgb.c:1863 ../src/iop/channelmixerrgb.c:1921
+msgid "good"
+msgstr "Good"
+
+#: ../src/iop/channelmixerrgb.c:1865 ../src/iop/channelmixerrgb.c:1923
+msgid "passable"
+msgstr "Passable"
+
+#: ../src/iop/channelmixerrgb.c:1867 ../src/iop/channelmixerrgb.c:1925
+msgid "bad"
+msgstr "Bad"
+
+#: ../src/iop/channelmixerrgb.c:1874
+#, c-format
+msgid ""
+"\n"
+"<b>Profile quality report: %s</b>\n"
+"input ΔE: \tavg. %.2f ; \tmax. %.2f\n"
+"WB ΔE: \tavg. %.2f; \tmax. %.2f\n"
+"output ΔE: \tavg. %.2f; \tmax. %.2f\n"
+"\n"
+"<b>Profile data</b>\n"
+"illuminant:  \t%.0f K \t%s\n"
+"matrix in adaptation space:\n"
+"<tt>%+.4f \t%+.4f \t%+.4f\n"
+"%+.4f \t%+.4f \t%+.4f\n"
+"%+.4f \t%+.4f \t%+.4f</tt>\n"
+"\n"
+"<b>Normalization values</b>\n"
+"exposure compensation: \t%+.2f EV\n"
+"black offset: \t%+.4f"
+msgstr ""
+"\n"
+"<b>Profile quality report: %s</b>\n"
+"Input ΔE: \tavg. %.2f ; \tmax. %.2f\n"
+"WB ΔE: \tavg. %.2f; \tmax. %.2f\n"
+"Output ΔE: \tavg. %.2f; \tmax. %.2f\n"
+"\n"
+"<b>Profile data</b>\n"
+"Illuminant:  \t%.0f K \t%s\n"
+"Matrix in adaptation space:\n"
+"<tt>%+.4f \t%+.4f \t%+.4f\n"
+"%+.4f \t%+.4f \t%+.4f\n"
+"%+.4f \t%+.4f \t%+.4f</tt>\n"
+"\n"
+"<b>Normalization values</b>\n"
+"Exposure compensation: \t%+.2f EV\n"
+"Black offset: \t%+.4f"
+
+#: ../src/iop/channelmixerrgb.c:1930
+#, c-format
+msgid ""
+"\n"
+"<b>Profile quality report: %s</b>\n"
+"output ΔE: \tavg. %.2f; \tmax. %.2f\n"
+"\n"
+"<b>Normalization values</b>\n"
+"exposure compensation: \t%+.2f EV\n"
+"black offset: \t%+.4f"
+msgstr ""
+"\n"
+"<b>Profile quality report: %s</b>\n"
+"Output ΔE: \tavg. %.2f; \tmax. %.2f\n"
+"\n"
+"<b>Normalization values</b>\n"
+"Exposure compensation: \t%+.2f EV\n"
+"Black offset: \t%+.4f"
+
+#: ../src/iop/channelmixerrgb.c:1955
+msgid "double CAT applied"
+msgstr "Double CAT applied"
+
+#: ../src/iop/channelmixerrgb.c:1956
+msgid ""
+"you have 2 instances or more of color calibration,\n"
+"all performing chromatic adaptation.\n"
+"this can lead to inconsistencies, unless you\n"
+"use them with masks or know what you are doing."
+msgstr ""
+"You have 2 instances or more of color calibration,\n"
+"all performing chromatic adaptation.\n"
+"This can lead to inconsistencies, unless you\n"
+"use them with masks or know what you are doing."
+
+#: ../src/iop/channelmixerrgb.c:1968
+msgid "white balance module error"
+msgstr "White balance module error"
+
+#: ../src/iop/channelmixerrgb.c:1969
+msgid ""
+"the white balance module is not using the camera\n"
+"reference illuminant, which will cause issues here\n"
+"with chromatic adaptation. either set it to reference\n"
+"or disable chromatic adaptation here."
+msgstr ""
+"The white balance module is not using the camera\n"
+"reference illuminant, which will cause issues here\n"
+"with chromatic adaptation. Either set it to reference\n"
+"or disable chromatic adaptation here."
+
+#: ../src/iop/channelmixerrgb.c:2056
+msgid "auto-detection of white balance completed"
+msgstr "Auto-detection of white balance completed"
+
+#: ../src/iop/channelmixerrgb.c:2209
+msgid "channelmixerrgb works only on RGB input"
+msgstr "Channelmixerrgb works only on RGB input"
+
+#: ../src/iop/channelmixerrgb.c:3594
+#, c-format
+msgid "CCT: %.0f K (daylight)"
+msgstr "CCT: %.0f K (daylight)"
+
+#: ../src/iop/channelmixerrgb.c:3597
+msgid ""
+"approximated correlated color temperature.\n"
+"this illuminant can be accurately modeled by a daylight spectrum,\n"
+"so its temperature is relevant and meaningful with a D illuminant."
+msgstr ""
+"Approximated correlated color temperature.\n"
+"This illuminant can be accurately modeled by a daylight spectrum,\n"
+"so its temperature is relevant and meaningful with a D illuminant."
+
+#: ../src/iop/channelmixerrgb.c:3603
+#, c-format
+msgid "CCT: %.0f K (black body)"
+msgstr "CCT: %.0f K (black body)"
+
+#: ../src/iop/channelmixerrgb.c:3606
+msgid ""
+"approximated correlated color temperature.\n"
+"this illuminant can be accurately modeled by a black body spectrum,\n"
+"so its temperature is relevant and meaningful with a Planckian illuminant."
+msgstr ""
+"Approximated correlated color temperature.\n"
+"This illuminant can be accurately modeled by a black body spectrum,\n"
+"so its temperature is relevant and meaningful with a Planckian illuminant."
+
+#: ../src/iop/channelmixerrgb.c:3612
+#, c-format
+msgid "CCT: %.0f K (invalid)"
+msgstr "CCT: %.0f K (invalid)"
+
+#: ../src/iop/channelmixerrgb.c:3615
+msgid ""
+"approximated correlated color temperature.\n"
+"this illuminant cannot be accurately modeled by a daylight or black body "
+"spectrum,\n"
+"so its temperature is not relevant and meaningful and you need to use a "
+"custom illuminant."
+msgstr ""
+"Approximated correlated color temperature.\n"
+"This illuminant cannot be accurately modeled by a daylight or black body "
+"spectrum,\n"
+"so its temperature is not relevant and meaningful and you need to use a "
+"custom illuminant."
+
+#: ../src/iop/channelmixerrgb.c:3624
+#, c-format
+msgid "CCT: undefined"
+msgstr "CCT: undefined"
+
+#: ../src/iop/channelmixerrgb.c:3627
+msgid ""
+"the approximated correlated color temperature\n"
+"cannot be computed at all so you need to use a custom illuminant."
+msgstr ""
+"The approximated correlated color temperature\n"
+"cannot be computed at all so you need to use a custom illuminant."
+
+#: ../src/iop/channelmixerrgb.c:3939
+msgid "white balance successfully extracted from raw image"
+msgstr "White balance successfully extracted from raw image"
+
+#. We need to recompute only the full preview
+#: ../src/iop/channelmixerrgb.c:3945
+msgid "auto-detection of white balance started…"
+msgstr "Auto-detection of white balance started…"
+
+#: ../src/iop/channelmixerrgb.c:4050
+msgid ""
+"color calibration: the sum of the gray channel parameters is zero, "
+"normalization will be disabled."
+msgstr ""
+"Color calibration: the sum of the gray channel parameters is zero, "
+"normalization will be disabled."
+
+#. Write report in GUI
+#: ../src/iop/channelmixerrgb.c:4097
+#, c-format
+msgid ""
+"L: \t%.1f %%\n"
+"h: \t%.1f °\n"
+"c: \t%.1f"
+msgstr ""
+"L: \t%.1f %%\n"
+"h: \t%.1f °\n"
+"c: \t%.1f"
+
+#: ../src/iop/channelmixerrgb.c:4365 ../src/iop/clipping.c:2087
+#: ../src/iop/colorbalancergb.c:1842 ../src/iop/filmicrgb.c:4158
+#: ../src/iop/negadoctor.c:829 ../src/iop/toneequal.c:3335
+#: ../src/libs/image.c:462 ../src/views/lighttable.c:1265
+msgid "page"
+msgstr "Page"
+
+#. Page CAT
+#: ../src/iop/channelmixerrgb.c:4368
+msgid "CAT"
+msgstr "CAT"
+
+#: ../src/iop/channelmixerrgb.c:4369
+msgid "chromatic adaptation transform"
+msgstr "Chromatic adaptation transform"
+
+#: ../src/iop/channelmixerrgb.c:4371
+msgid "adaptation"
+msgstr "Adaptation"
+
+#: ../src/iop/channelmixerrgb.c:4374
+msgid ""
+"choose the method to adapt the illuminant\n"
+"and the colorspace in which the module works: \n"
+"• Linear Bradford (1985) is consistent with ICC v4 toolchain.\n"
+"• CAT16 (2016) is more robust and accurate.\n"
+"• Non-linear Bradford (1985) is the original Bradford,\n"
+"it can produce better results than the linear version, but is unreliable.\n"
+"• XYZ is a simple scaling in XYZ space. It is not recommended in general.\n"
+"• none disables any adaptation and uses pipeline working RGB."
+msgstr ""
+"Choose the method to adapt the illuminant\n"
+"and the colorspace in which the module works: \n"
+"• Linear Bradford (1985) is consistent with ICC v4 toolchain.\n"
+"• CAT16 (2016) is more robust and accurate.\n"
+"• Non-linear Bradford (1985) is the original Bradford,\n"
+"it can produce better results than the linear version, but is unreliable.\n"
+"• XYZ is a simple scaling in XYZ space. It is not recommended in general.\n"
+"• None disables any adaptation and uses pipeline working RGB."
+
+#: ../src/iop/channelmixerrgb.c:4394
+msgid ""
+"this is the color of the scene illuminant before chromatic adaptation\n"
+"this color will be turned into pure white by the adaptation."
+msgstr ""
+"This is the color of the scene illuminant before chromatic adaptation\n"
+"This color will be turned into pure white by the adaptation."
+
+#: ../src/iop/channelmixerrgb.c:4402
+msgid "picker"
+msgstr "Picker"
+
+#: ../src/iop/channelmixerrgb.c:4404 ../src/iop/temperature.c:2046
+msgid "set white balance to detected from area"
+msgstr "Set white balance to detected from area"
+
+#: ../src/iop/channelmixerrgb.c:4408
+msgid "illuminant"
+msgstr "Illuminant"
+
+#: ../src/iop/channelmixerrgb.c:4414 ../src/iop/temperature.c:2106
+msgid "temperature"
+msgstr "Temperature"
+
+#: ../src/iop/channelmixerrgb.c:4445
+msgid "spot color mapping"
+msgstr "Spot color mapping"
+
+#: ../src/iop/channelmixerrgb.c:4451
+msgid ""
+"define a target chromaticity (hue and chroma) for a particular region of the "
+"image (the control sample), which you then match against the same target "
+"chromaticity in other images. the control sample can either be a critical "
+"part of your subject or a non-moving and consistently-lit surface over your "
+"series of images."
+msgstr ""
+"Define a target chromaticity (hue and chroma) for a particular region of the "
+"image (the control sample), which you then match against the same target "
+"chromaticity in other images. The control sample can either be a critical "
+"part of your subject or a non-moving and consistently-lit surface over your "
+"series of images."
+
+#: ../src/iop/channelmixerrgb.c:4458 ../src/iop/channelmixerrgb.c:4473
+#: ../src/iop/channelmixerrgb.c:4527 ../src/iop/channelmixerrgb.c:4536
+#: ../src/iop/channelmixerrgb.c:4544
+msgid "mapping"
+msgstr "Mapping"
+
+#: ../src/iop/channelmixerrgb.c:4458 ../src/iop/exposure.c:1180
+msgid "spot mode"
+msgstr "Spot mode"
+
+#: ../src/iop/channelmixerrgb.c:4459
+msgid ""
+"\"correction\" automatically adjust the illuminant\n"
+"such that the input color is mapped to the target.\n"
+"\"measure\" simply shows how an input color is mapped by the CAT\n"
+"and can be used to sample a target."
+msgstr ""
+"\"Correction\" automatically adjust the illuminant\n"
+"such that the input color is mapped to the target.\n"
+"\"Measure\" simply shows how an input color is mapped by the CAT\n"
+"and can be used to sample a target."
+
+#: ../src/iop/channelmixerrgb.c:4464 ../src/iop/exposure.c:1186
+msgid "correction"
+msgstr "Correction"
+
+#: ../src/iop/channelmixerrgb.c:4465 ../src/iop/exposure.c:1187
+msgid "measure"
+msgstr "Measure"
+
+#: ../src/iop/channelmixerrgb.c:4471
+msgid "take channel mixing into account"
+msgstr "Take channel mixing into account"
+
+#: ../src/iop/channelmixerrgb.c:4478
+msgid ""
+"compute the target by taking the channel mixing into account.\n"
+"if disabled, only the CAT is considered."
+msgstr ""
+"Compute the target by taking the channel mixing into account.\n"
+"If disabled, only the CAT is considered."
+
+#: ../src/iop/channelmixerrgb.c:4490 ../src/iop/exposure.c:1194
+msgctxt "section"
+msgid "input"
+msgstr "Input"
+
+#: ../src/iop/channelmixerrgb.c:4497 ../src/iop/exposure.c:1202
+msgid "the input color that should be mapped to the target"
+msgstr "The input color that should be mapped to the target"
+
+#: ../src/iop/channelmixerrgb.c:4503
+msgid ""
+"L: \tN/A\n"
+"h: \tN/A\n"
+"c: \tN/A"
+msgstr ""
+"L: \tN/A\n"
+"h: \tN/A\n"
+"c: \tN/A"
+
+#: ../src/iop/channelmixerrgb.c:4506 ../src/iop/exposure.c:1210
+msgid "these LCh coordinates are computed from CIE Lab 1976 coordinates"
+msgstr "These LCh coordinates are computed from CIE Lab 1976 coordinates"
+
+#: ../src/iop/channelmixerrgb.c:4514 ../src/iop/exposure.c:1217
+msgctxt "section"
+msgid "target"
+msgstr "Target"
+
+#: ../src/iop/channelmixerrgb.c:4521
+msgid "the desired target color after mapping"
+msgstr "The desired target color after mapping"
+
+#: ../src/iop/channelmixerrgb.c:4560
+msgid "input R"
+msgstr "Input R"
+
+#: ../src/iop/channelmixerrgb.c:4565
+msgid "input G"
+msgstr "Input G"
+
+#: ../src/iop/channelmixerrgb.c:4570
+msgid "input B"
+msgstr "Input B"
+
+#: ../src/iop/channelmixerrgb.c:4580
+msgid "output R"
+msgstr "Output R"
+
+#: ../src/iop/channelmixerrgb.c:4581
+msgid "output G"
+msgstr "Output G"
+
+#: ../src/iop/channelmixerrgb.c:4582
+msgid "output B"
+msgstr "Output B"
+
+#: ../src/iop/channelmixerrgb.c:4584
+msgid "colorfulness"
+msgstr "Colorfulness"
+
+#: ../src/iop/channelmixerrgb.c:4584
+msgid "output colorfulness"
+msgstr "Output colorfulness"
+
+#: ../src/iop/channelmixerrgb.c:4588
+msgid "output brightness"
+msgstr "Output brightness"
+
+#: ../src/iop/channelmixerrgb.c:4591
+msgid "output gray"
+msgstr "Output gray"
+
+#: ../src/iop/channelmixerrgb.c:4606
+msgid "calibrate with a color checker"
+msgstr "Calibrate with a color checker"
+
+#: ../src/iop/channelmixerrgb.c:4611
+msgid "use a color checker target to autoset CAT and channels"
+msgstr "Use a color checker target to autoset CAT and channels"
+
+#: ../src/iop/channelmixerrgb.c:4618 ../src/iop/channelmixerrgb.c:4630
+#: ../src/iop/channelmixerrgb.c:4648 ../src/iop/channelmixerrgb.c:4666
+#: ../src/iop/channelmixerrgb.c:4675 ../src/iop/channelmixerrgb.c:4683
+msgid "calibrate"
+msgstr "Calibrate"
+
+#: ../src/iop/channelmixerrgb.c:4618
+msgid "chart"
+msgstr "Chart"
+
+#: ../src/iop/channelmixerrgb.c:4619
+msgid "choose the vendor and the type of your chart"
+msgstr "Choose the vendor and the type of your chart"
+
+#: ../src/iop/channelmixerrgb.c:4621
+msgid "Xrite ColorChecker 24 pre-2014"
+msgstr "Xrite ColorChecker 24 pre-2014"
+
+#: ../src/iop/channelmixerrgb.c:4622
+msgid "Xrite ColorChecker 24 post-2014"
+msgstr "Xrite ColorChecker 24 post-2014"
+
+#: ../src/iop/channelmixerrgb.c:4623
+msgid "Datacolor SpyderCheckr 24 pre-2018"
+msgstr "Datacolor SpyderCheckr 24 pre-2018"
+
+#: ../src/iop/channelmixerrgb.c:4624
+msgid "Datacolor SpyderCheckr 24 post-2018"
+msgstr "Datacolor SpyderCheckr 24 post-2018"
+
+#: ../src/iop/channelmixerrgb.c:4625
+msgid "Datacolor SpyderCheckr 48 pre-2018"
+msgstr "Datacolor SpyderCheckr 48 pre-2018"
+
+#: ../src/iop/channelmixerrgb.c:4626
+msgid "Datacolor SpyderCheckr 48 post-2018"
+msgstr "Datacolor SpyderCheckr 48 post-2018"
+
+#: ../src/iop/channelmixerrgb.c:4630
+msgid "optimize for"
+msgstr "Optimize for"
+
+#: ../src/iop/channelmixerrgb.c:4631
+msgid ""
+"choose the colors that will be optimized with higher priority.\n"
+"neutral colors gives the lowest average delta E but a high maximum delta E\n"
+"saturated colors gives the lowest maximum delta E but a high average delta "
+"E\n"
+"none is a trade-off between both\n"
+"the others are special behaviors to protect some hues"
+msgstr ""
+"Choose the colors that will be optimized with higher priority.\n"
+"Neutral colors gives the lowest average delta E but a high maximum delta E\n"
+"Saturated colors gives the lowest maximum delta E but a high average delta "
+"E\n"
+"None is a trade-off between both\n"
+"The others are special behaviors to protect some hues"
+
+#: ../src/iop/channelmixerrgb.c:4638
+msgid "neutral colors"
+msgstr "Neutral colors"
+
+#: ../src/iop/channelmixerrgb.c:4640
+msgid "skin and soil colors"
+msgstr "Skin and soil colors"
+
+#: ../src/iop/channelmixerrgb.c:4641
+msgid "foliage colors"
+msgstr "Foliage colors"
+
+#: ../src/iop/channelmixerrgb.c:4642
+msgid "sky and water colors"
+msgstr "Sky and water colors"
+
+#: ../src/iop/channelmixerrgb.c:4643
+msgid "average delta E"
+msgstr "Average delta E"
+
+#: ../src/iop/channelmixerrgb.c:4644
+msgid "maximum delta E"
+msgstr "Maximum delta E"
+
+#: ../src/iop/channelmixerrgb.c:4648
+msgid "patch scale"
+msgstr "Patch scale"
+
+#: ../src/iop/channelmixerrgb.c:4651
+msgid ""
+"reduce the radius of the patches to select the more or less central part.\n"
+"useful when the perspective correction is sloppy or\n"
+"the patches frame cast a shadows on the edges of the patch."
+msgstr ""
+"Reduce the radius of the patches to select the more or less central part.\n"
+"Useful when the perspective correction is sloppy or\n"
+"the patches frame cast a shadows on the edges of the patch."
+
+#: ../src/iop/channelmixerrgb.c:4661
+msgid "the delta E is using the CIE 2000 formula"
+msgstr "The delta E is using the CIE 2000 formula"
+
+#: ../src/iop/channelmixerrgb.c:4666
+msgid "accept"
+msgstr "Accept"
+
+#: ../src/iop/channelmixerrgb.c:4672
+msgid "accept the computed profile and set it in the module"
+msgstr "Accept the computed profile and set it in the module"
+
+#: ../src/iop/channelmixerrgb.c:4675
+msgid "recompute"
+msgstr "Recompute"
+
+#: ../src/iop/channelmixerrgb.c:4679
+msgid "recompute the profile"
+msgstr "Recompute the profile"
+
+#: ../src/iop/channelmixerrgb.c:4683
+msgid "validate"
+msgstr "Validate"
+
+#: ../src/iop/channelmixerrgb.c:4687
+msgid "check the output delta E"
+msgstr "Check the output delta E"
+
+#: ../src/iop/choleski.h:290 ../src/iop/choleski.h:390
+msgid ""
+"Choleski decomposition failed to allocate memory, check your RAM settings"
+msgstr ""
+"Choleski decomposition failed to allocate memory, check your RAM settings"
+
+#: ../src/iop/clahe.c:74
+msgid ""
+"this module is deprecated. better use new local contrast module instead."
+msgstr ""
+"This module is deprecated. Better use new local contrast module instead."
+
+#: ../src/iop/clahe.c:337 ../src/iop/sharpen.c:445
+msgid "amount"
+msgstr "Amount"
+
+#: ../src/iop/clahe.c:346
+msgid "size of features to preserve"
+msgstr "Size of features to preserve"
+
+#: ../src/iop/clahe.c:347 ../src/iop/nlmeans.c:464
+msgid "strength of the effect"
+msgstr "Strength of the effect"
+
+#: ../src/iop/clipping.c:304
+msgid ""
+"this module is deprecated. please use the crop, orientation and/or rotate "
+"and perspective modules instead."
+msgstr ""
+"This module is deprecated. Please use the crop, orientation and/or rotate "
+"and perspective modules instead."
+
+#: ../src/iop/clipping.c:309
+msgid "crop and rotate"
+msgstr "Crop and rotate"
+
+#: ../src/iop/clipping.c:314
+msgid "reframe|perspective|keystone|distortion"
+msgstr "reframe|perspective|keystone|distortion"
+
+#: ../src/iop/clipping.c:319
+msgid "change the framing and correct the perspective"
+msgstr "Change the framing and correct the perspective"
+
+#: ../src/iop/clipping.c:1394 ../src/iop/clipping.c:2120 ../src/iop/crop.c:517
+#: ../src/iop/crop.c:1117
+msgid "original image"
+msgstr "Original image"
+
+#: ../src/iop/clipping.c:1698 ../src/iop/crop.c:824
+msgid "invalid ratio format. it should be \"number:number\""
+msgstr "Invalid ratio format. It should be \"number:number\""
+
+#: ../src/iop/clipping.c:1714 ../src/iop/crop.c:840
+msgid "invalid ratio format. it should be a positive number"
+msgstr "Invalid ratio format. It should be a positive number"
+
+#: ../src/iop/clipping.c:1903 ../src/iop/clipping.c:2111
+msgid "full"
+msgstr "Full"
+
+#: ../src/iop/clipping.c:1904
+msgid "old system"
+msgstr "Old system"
+
+#: ../src/iop/clipping.c:1905
+msgid "correction applied"
+msgstr "Correction applied"
+
+#: ../src/iop/clipping.c:2089
+msgid "main"
+msgstr "Main"
+
+#: ../src/iop/clipping.c:2098
+msgid "mirror image horizontally and/or vertically"
+msgstr "Mirror image horizontally and/or vertically"
+
+#: ../src/iop/clipping.c:2101
+msgid "angle"
+msgstr "Angle"
+
+#: ../src/iop/clipping.c:2104
+msgid "right-click and drag a line on the image to drag a straight line"
+msgstr "Right-click and drag a line on the image to drag a straight line"
+
+#: ../src/iop/clipping.c:2107
+msgid "keystone"
+msgstr "Keystone"
+
+#: ../src/iop/clipping.c:2112
+msgid "set perspective correction for your image"
+msgstr "Set perspective correction for your image"
+
+#: ../src/iop/clipping.c:2119 ../src/iop/crop.c:1116
+msgid "freehand"
+msgstr "Freehand"
+
+#: ../src/iop/clipping.c:2122 ../src/iop/crop.c:1119
+msgid "10:8 in print"
+msgstr "10:8 in print"
+
+#: ../src/iop/clipping.c:2123 ../src/iop/crop.c:1120
+msgid "5:4, 4x5, 8x10"
+msgstr "5:4, 4x5, 8x10"
+
+#: ../src/iop/clipping.c:2124 ../src/iop/crop.c:1121
+msgid "11x14"
+msgstr "11x14"
+
+#: ../src/iop/clipping.c:2125 ../src/iop/crop.c:1122
+msgid "8.5x11, letter"
+msgstr "8.5x11, letter"
+
+#: ../src/iop/clipping.c:2126 ../src/iop/crop.c:1123
+msgid "4:3, VGA, TV"
+msgstr "4:3, VGA, TV"
+
+#: ../src/iop/clipping.c:2127 ../src/iop/crop.c:1124
+msgid "5x7"
+msgstr "5x7"
+
+#: ../src/iop/clipping.c:2128 ../src/iop/crop.c:1125
+msgid "ISO 216, DIN 476, A4"
+msgstr "ISO 216, DIN 476, A4"
+
+#: ../src/iop/clipping.c:2129 ../src/iop/crop.c:1126
+msgid "3:2, 4x6, 35mm"
+msgstr "3:2, 4x6, 35mm"
+
+#: ../src/iop/clipping.c:2130 ../src/iop/crop.c:1127
+msgid "16:10, 8x5"
+msgstr "16:10, 8x5"
+
+#: ../src/iop/clipping.c:2132 ../src/iop/crop.c:1129
+msgid "16:9, HDTV"
+msgstr "16:9, HDTV"
+
+#: ../src/iop/clipping.c:2133 ../src/iop/crop.c:1130
+msgid "widescreen"
+msgstr "Widescreen"
+
+#: ../src/iop/clipping.c:2134 ../src/iop/crop.c:1131
+msgid "2:1, univisium"
+msgstr "2:1, univisium"
+
+#: ../src/iop/clipping.c:2135 ../src/iop/crop.c:1132
+msgid "cinemascope"
+msgstr "Cinemascope"
+
+#: ../src/iop/clipping.c:2136 ../src/iop/crop.c:1133
+msgid "21:9"
+msgstr "21:9"
+
+#: ../src/iop/clipping.c:2137 ../src/iop/crop.c:1134
+msgid "anamorphic"
+msgstr "Anamorphic"
+
+#: ../src/iop/clipping.c:2138 ../src/iop/crop.c:1135
+msgid "3:1, panorama"
+msgstr "3:1, panorama"
+
+#: ../src/iop/clipping.c:2170 ../src/iop/clipping.c:2182 ../src/iop/crop.c:1171
+#: ../src/iop/crop.c:1187
+#, c-format
+msgid "invalid ratio format for `%s'. it should be \"number:number\""
+msgstr "Invalid ratio format for `%s'. It should be \"number:number\""
+
+#: ../src/iop/clipping.c:2229 ../src/iop/crop.c:1238
+msgid ""
+"set the aspect ratio\n"
+"the list is sorted: from most square to least square\n"
+"to enter custom aspect ratio open the combobox and type ratio in x:y or "
+"decimal format"
+msgstr ""
+"Set the aspect ratio\n"
+"The list is sorted: from most square to least square\n"
+"To enter custom aspect ratio open the combobox and type ratio in x:y or "
+"decimal format"
+
+#: ../src/iop/clipping.c:2236 ../src/iop/crop.c:1252
+msgid "margins"
+msgstr "Margins"
+
+#: ../src/iop/clipping.c:2241 ../src/iop/crop.c:1262
+msgid "the left margin cannot overlap with the right margin"
+msgstr "The left margin cannot overlap with the right margin"
+
+#: ../src/iop/clipping.c:2248 ../src/iop/crop.c:1270
+msgid "the right margin cannot overlap with the left margin"
+msgstr "The right margin cannot overlap with the left margin"
+
+#: ../src/iop/clipping.c:2253 ../src/iop/crop.c:1276
+msgid "the top margin cannot overlap with the bottom margin"
+msgstr "The top margin cannot overlap with the bottom margin"
+
+#: ../src/iop/clipping.c:2260 ../src/iop/crop.c:1284
+msgid "the bottom margin cannot overlap with the top margin"
+msgstr "The bottom margin cannot overlap with the top margin"
+
+#: ../src/iop/clipping.c:3019
+msgid "<b>commit</b>: double-click, <b>straighten</b>: right-drag"
+msgstr "<b>Commit</b>: double-click, <b>Straighten</b>: right-drag"
+
+#: ../src/iop/clipping.c:3023
+msgid ""
+"<b>resize</b>: drag, <b>keep aspect ratio</b>: shift+drag\n"
+"<b>straighten</b>: right-drag"
+msgstr ""
+"<b>Resize</b>: drag, <b>Keep aspect ratio</b>: Shift+drag\n"
+"<b>Straighten</b>: right-drag"
+
+#: ../src/iop/clipping.c:3066
+msgid "<b>move control point</b>: drag"
+msgstr "<b>Move control point</b>: drag"
+
+#: ../src/iop/clipping.c:3071
+msgid "<b>move line</b>: drag, <b>toggle symmetry</b>: click ꝏ"
+msgstr "<b>Move line</b>: drag, <b>Toggle symmetry</b>: click ꝏ"
+
+#: ../src/iop/clipping.c:3076
+msgid ""
+"<b>apply</b>: click <tt>ok</tt>, <b>toggle symmetry</b>: click ꝏ\n"
+"<b>move line/control point</b>: drag"
+msgstr ""
+"<b>Apply</b>: click <tt>ok</tt>, <b>Toggle symmetry</b>: click ꝏ\n"
+"<b>Move line/control point</b>: drag"
+
+#: ../src/iop/clipping.c:3083
+msgid ""
+"<b>move</b>: drag, <b>move vertically</b>: shift+drag, <b>move horizontally</"
+"b>: ctrl+drag\n"
+"<b>straighten</b>: right-drag, <b>commit</b>: double-click"
+msgstr ""
+"<b>Move</b>: drag, <b>Move vertically</b>: Shift+drag, <b>Move horizontally</"
+"b>: Ctrl+drag\n"
+"<b>Straighten</b>: right-drag, <b>Commit</b>: double-click"
+
+#: ../src/iop/clipping.c:3340 ../src/iop/crop.c:1796
+#, c-format
+msgid "[%s on borders] crop"
+msgstr "[%s on borders] crop"
+
+#: ../src/iop/clipping.c:3342 ../src/iop/crop.c:1798
+#, c-format
+msgid "[%s on borders] crop keeping ratio"
+msgstr "[%s on borders] crop keeping ratio"
+
+#: ../src/iop/colisa.c:79
+msgid "this module is deprecated. please use colorbalance RGB module instead."
+msgstr "This module is deprecated. Please use colorbalance RGB module instead."
+
+#: ../src/iop/colisa.c:84
+msgid "contrast brightness saturation"
+msgstr "Contrast brightness saturation"
+
+#: ../src/iop/colisa.c:89
+msgid "adjust the look of the image"
+msgstr "Adjust the look of the image"
+
+#: ../src/iop/colisa.c:310
+msgid "color saturation adjustment"
+msgstr "Color saturation adjustment"
+
+#: ../src/iop/colorbalance.c:150
+msgid "color balance"
+msgstr "Color balance"
+
+#: ../src/iop/colorbalance.c:155
+msgid "lift gamma gain|cdl|color grading|contrast|saturation|hue"
+msgstr "lift gamma gain|cdl|color grading|contrast|saturation|hue"
+
+#: ../src/iop/colorbalance.c:160
+msgid "shift colors selectively by luminance range"
+msgstr "Shift colors selectively by luminance range"
+
+#: ../src/iop/colorbalance.c:164
+msgid "non-linear, Lab, scene-referred"
+msgstr "Non-linear, Lab, scene-referred"
+
+#. these blobs were exported as dtstyle and copied from there:
+#: ../src/iop/colorbalance.c:275
+msgid "split-toning teal-orange (2nd instance)"
+msgstr "Split-toning teal-orange (2nd instance)"
+
+#: ../src/iop/colorbalance.c:278
+msgid "split-toning teal-orange (1st instance)"
+msgstr "Split-toning teal-orange (1st instance)"
+
+#: ../src/iop/colorbalance.c:282
+msgid "generic film"
+msgstr "Generic film"
+
+#: ../src/iop/colorbalance.c:286
+msgid "similar to Kodak Portra"
+msgstr "Similar to Kodak Portra"
+
+#: ../src/iop/colorbalance.c:290
+msgid "similar to Kodak Ektar"
+msgstr "Similar to Kodak Ektar"
+
+#: ../src/iop/colorbalance.c:294
+msgid "similar to Kodachrome"
+msgstr "Similar to Kodachrome"
+
+#: ../src/iop/colorbalance.c:993
+msgid "optimize luma from patches"
+msgstr "Optimize luma from patches"
+
+#: ../src/iop/colorbalance.c:995 ../src/iop/colorbalance.c:2113
+msgid "optimize luma"
+msgstr "Optimize luma"
+
+#: ../src/iop/colorbalance.c:999
+msgid "neutralize colors from patches"
+msgstr "Neutralize colors from patches"
+
+#: ../src/iop/colorbalance.c:1001 ../src/iop/colorbalance.c:2119
+msgid "neutralize colors"
+msgstr "Neutralize colors"
+
+#: ../src/iop/colorbalance.c:1786
+msgctxt "color"
+msgid "offset"
+msgstr "Offset"
+
+#: ../src/iop/colorbalance.c:1786
+msgctxt "color"
+msgid "power"
+msgstr "Power"
+
+#: ../src/iop/colorbalance.c:1786
+msgctxt "color"
+msgid "slope"
+msgstr "Slope"
+
+#: ../src/iop/colorbalance.c:1787
+msgctxt "color"
+msgid "lift"
+msgstr "Lift"
+
+#: ../src/iop/colorbalance.c:1787
+msgctxt "color"
+msgid "gamma"
+msgstr "Gamma"
+
+#: ../src/iop/colorbalance.c:1787
+msgctxt "color"
+msgid "gain"
+msgstr "Gain"
+
+#: ../src/iop/colorbalance.c:1790
+msgctxt "section"
+msgid "shadows: lift / offset"
+msgstr "Shadows: lift / offset"
+
+#: ../src/iop/colorbalance.c:1791
+msgctxt "section"
+msgid "mid-tones: gamma / power"
+msgstr "Mid-tones: gamma / power"
+
+#: ../src/iop/colorbalance.c:1792
+msgctxt "section"
+msgid "highlights: gain / slope"
+msgstr "Highlights: gain / slope"
+
+#: ../src/iop/colorbalance.c:1816
+msgid "shadows / mid-tones / highlights"
+msgstr "Shadows / mid-tones / highlights"
+
+#: ../src/iop/colorbalance.c:1913 ../src/iop/colorbalance.c:1922
+msgid "color-grading mapping method"
+msgstr "Color-grading mapping method"
+
+#: ../src/iop/colorbalance.c:1917
+msgid "color control sliders"
+msgstr "Color control sliders"
+
+#: ../src/iop/colorbalance.c:1918 ../src/libs/colorpicker.c:51
+msgid "HSL"
+msgstr "HSL"
+
+#: ../src/iop/colorbalance.c:1919
+msgid "RGBL"
+msgstr "RGBL"
+
+#: ../src/iop/colorbalance.c:1931
+msgctxt "section"
+msgid "master"
+msgstr "Master"
+
+#: ../src/iop/colorbalance.c:1937
+msgid "saturation correction before the color balance"
+msgstr "Saturation correction before the color balance"
+
+#: ../src/iop/colorbalance.c:1943
+msgid "saturation correction after the color balance"
+msgstr "Saturation correction after the color balance"
+
+#: ../src/iop/colorbalance.c:1948
+msgid "adjust to match a neutral tone"
+msgstr "Adjust to match a neutral tone"
+
+#. is set in _configure_slider_blocks
+#: ../src/iop/colorbalance.c:2006
+msgid "click to cycle layout"
+msgstr "Click to cycle layout"
+
+#: ../src/iop/colorbalance.c:2040
+msgid "factor"
+msgstr "Factor"
+
+#: ../src/iop/colorbalance.c:2054
+msgid "select the hue"
+msgstr "Select the hue"
+
+#: ../src/iop/colorbalance.c:2066
+msgid "select the saturation"
+msgstr "Select the saturation"
+
+#: ../src/iop/colorbalance.c:2085
+msgid "factor of lift/offset"
+msgstr "Factor of lift/offset"
+
+#: ../src/iop/colorbalance.c:2086
+msgid "factor of red for lift/offset"
+msgstr "Factor of red for lift/offset"
+
+#: ../src/iop/colorbalance.c:2087
+msgid "factor of green for lift/offset"
+msgstr "Factor of green for lift/offset"
+
+#: ../src/iop/colorbalance.c:2088
+msgid "factor of blue for lift/offset"
+msgstr "Factor of blue for lift/offset"
+
+#: ../src/iop/colorbalance.c:2091
+msgid "factor of gamma/power"
+msgstr "Factor of gamma/power"
+
+#: ../src/iop/colorbalance.c:2092
+msgid "factor of red for gamma/power"
+msgstr "Factor of red for gamma/power"
+
+#: ../src/iop/colorbalance.c:2093
+msgid "factor of green for gamma/power"
+msgstr "Factor of green for gamma/power"
+
+#: ../src/iop/colorbalance.c:2094
+msgid "factor of blue for gamma/power"
+msgstr "Factor of blue for gamma/power"
+
+#: ../src/iop/colorbalance.c:2097
+msgid "factor of gain/slope"
+msgstr "Factor of gain/slope"
+
+#: ../src/iop/colorbalance.c:2098
+msgid "factor of red for gain/slope"
+msgstr "Factor of red for gain/slope"
+
+#: ../src/iop/colorbalance.c:2099
+msgid "factor of green for gain/slope"
+msgstr "Factor of green for gain/slope"
+
+#: ../src/iop/colorbalance.c:2100
+msgid "factor of blue for gain/slope"
+msgstr "Factor of blue for gain/slope"
+
+#: ../src/iop/colorbalance.c:2109
+msgctxt "section"
+msgid "auto optimizers"
+msgstr "Auto optimizers"
+
+#: ../src/iop/colorbalance.c:2114
+msgid "fit the whole histogram and center the average luma"
+msgstr "Fit the whole histogram and center the average luma"
+
+#: ../src/iop/colorbalance.c:2120
+msgid "optimize the RGB curves to remove color casts"
+msgstr "Optimize the RGB curves to remove color casts"
+
+#: ../src/iop/colorbalancergb.c:173
+msgid "color balance rgb"
+msgstr "Color balance rgb"
+
+#: ../src/iop/colorbalancergb.c:178
+msgid ""
+"offset power slope|cdl|color grading|contrast|chroma_highlights|hue|vibrance|"
+"saturation"
+msgstr ""
+"offset power slope|cdl|color grading|contrast|chroma_highlights|hue|vibrance|"
+"saturation"
+
+#: ../src/iop/colorbalancergb.c:183
+msgid ""
+"color grading tools using alpha masks to separate\n"
+"shadows, mid-tones and highlights"
+msgstr ""
+"Color grading tools using alpha masks to separate\n"
+"shadows, mid-tones and highlights"
+
+#: ../src/iop/colorbalancergb.c:443
+msgid "add basic colorfulness (legacy)"
+msgstr "Add basic colorfulness (legacy)"
+
+#: ../src/iop/colorbalancergb.c:452
+msgid "basic colorfulness: natural skin"
+msgstr "Basic colorfulness: natural skin"
+
+#: ../src/iop/colorbalancergb.c:458
+msgid "basic colorfulness: vibrant colors"
+msgstr "Basic colorfulness: vibrant colors"
+
+#: ../src/iop/colorbalancergb.c:464
+msgid "basic colorfulness: standard"
+msgstr "Basic colorfulness: standard"
+
+#: ../src/iop/colorbalancergb.c:906
+msgid "colorbalance works only on RGB input"
+msgstr "Colorbalance works only on RGB input"
+
+#: ../src/iop/colorbalancergb.c:1475 ../src/iop/colorzones.c:2164
+#: ../src/iop/retouch.c:1884 ../src/iop/toneequal.c:1982
+msgid "cannot display masks when the blending mask is displayed"
+msgstr "Cannot display masks when the blending mask is displayed"
+
+#. Page master
+#: ../src/iop/colorbalancergb.c:1845
+msgid "master"
+msgstr "Master"
+
+#: ../src/iop/colorbalancergb.c:1845
+msgid "global grading"
+msgstr "Global grading"
+
+#: ../src/iop/colorbalancergb.c:1849
+msgid "rotate all hues by an angle, at the same luminance"
+msgstr "Rotate all hues by an angle, at the same luminance"
+
+#: ../src/iop/colorbalancergb.c:1855
+msgid "increase colorfulness mostly on low-chroma colors"
+msgstr "Increase colorfulness mostly on low-chroma colors"
+
+#: ../src/iop/colorbalancergb.c:1861
+msgid "increase the contrast at constant chromaticity"
+msgstr "Increase the contrast at constant chromaticity"
+
+#: ../src/iop/colorbalancergb.c:1863
+msgctxt "section"
+msgid "linear chroma grading"
+msgstr "Linear chroma grading"
+
+#: ../src/iop/colorbalancergb.c:1870
+msgid "increase colorfulness at same luminance globally"
+msgstr "Increase colorfulness at same luminance globally"
+
+#: ../src/iop/colorbalancergb.c:1875
+msgid "increase colorfulness at same luminance mostly in shadows"
+msgstr "Increase colorfulness at same luminance mostly in shadows"
+
+#: ../src/iop/colorbalancergb.c:1880
+msgid "increase colorfulness at same luminance mostly in mid-tones"
+msgstr "Increase colorfulness at same luminance mostly in mid-tones"
+
+#: ../src/iop/colorbalancergb.c:1885
+msgid "increase colorfulness at same luminance mostly in highlights"
+msgstr "Increase colorfulness at same luminance mostly in highlights"
+
+#: ../src/iop/colorbalancergb.c:1887
+msgctxt "section"
+msgid "perceptual saturation grading"
+msgstr "Perceptual saturation grading"
+
+#: ../src/iop/colorbalancergb.c:1893
+msgid "add or remove saturation by an absolute amount"
+msgstr "Add or remove saturation by an absolute amount"
+
+#: ../src/iop/colorbalancergb.c:1898 ../src/iop/colorbalancergb.c:1903
+#: ../src/iop/colorbalancergb.c:1908
+msgid ""
+"increase or decrease saturation proportionally to the original pixel "
+"saturation"
+msgstr ""
+"Increase or decrease saturation proportionally to the original pixel "
+"saturation"
+
+#: ../src/iop/colorbalancergb.c:1910
+msgctxt "section"
+msgid "perceptual brilliance grading"
+msgstr "Perceptual brilliance grading"
+
+#: ../src/iop/colorbalancergb.c:1911
+msgid "brilliance"
+msgstr "Brilliance"
+
+#: ../src/iop/colorbalancergb.c:1916
+msgid "add or remove brilliance by an absolute amount"
+msgstr "Add or remove brilliance by an absolute amount"
+
+#: ../src/iop/colorbalancergb.c:1921 ../src/iop/colorbalancergb.c:1926
+#: ../src/iop/colorbalancergb.c:1931
+msgid ""
+"increase or decrease brilliance proportionally to the original pixel "
+"brilliance"
+msgstr ""
+"Increase or decrease brilliance proportionally to the original pixel "
+"brilliance"
+
+#. Page 4-ways
+#: ../src/iop/colorbalancergb.c:1934
+msgid "4 ways"
+msgstr "4 ways"
+
+#: ../src/iop/colorbalancergb.c:1934
+msgid "selective color grading"
+msgstr "Selective color grading"
+
+#: ../src/iop/colorbalancergb.c:1936
+msgctxt "section"
+msgid "global offset"
+msgstr "Global offset"
+
+#: ../src/iop/colorbalancergb.c:1943
+msgid "global luminance offset"
+msgstr "Global luminance offset"
+
+#: ../src/iop/colorbalancergb.c:1948
+msgid "hue of the global color offset"
+msgstr "Hue of the global color offset"
+
+#: ../src/iop/colorbalancergb.c:1954
+msgid "chroma of the global color offset"
+msgstr "Chroma of the global color offset"
+
+#: ../src/iop/colorbalancergb.c:1956
+msgctxt "section"
+msgid "shadows lift"
+msgstr "Shadows lift"
+
+#: ../src/iop/colorbalancergb.c:1957
+msgid "lift"
+msgstr "Lift"
+
+#: ../src/iop/colorbalancergb.c:1963
+msgid "luminance gain in shadows"
+msgstr "Luminance gain in shadows"
+
+#: ../src/iop/colorbalancergb.c:1968
+msgid "hue of the color gain in shadows"
+msgstr "Hue of the color gain in shadows"
+
+#: ../src/iop/colorbalancergb.c:1974
+msgid "chroma of the color gain in shadows"
+msgstr "Chroma of the color gain in shadows"
+
+#: ../src/iop/colorbalancergb.c:1976
+msgctxt "section"
+msgid "highlights gain"
+msgstr "Highlights gain"
+
+#: ../src/iop/colorbalancergb.c:1977
+msgid "gain"
+msgstr "Gain"
+
+#: ../src/iop/colorbalancergb.c:1983
+msgid "luminance gain in highlights"
+msgstr "Luminance gain in highlights"
+
+#: ../src/iop/colorbalancergb.c:1988
+msgid "hue of the color gain in highlights"
+msgstr "Hue of the color gain in highlights"
+
+#: ../src/iop/colorbalancergb.c:1994
+msgid "chroma of the color gain in highlights"
+msgstr "Chroma of the color gain in highlights"
+
+#: ../src/iop/colorbalancergb.c:1996
+msgctxt "section"
+msgid "power"
+msgstr "Power"
+
+#: ../src/iop/colorbalancergb.c:1997
+msgid "power"
+msgstr "Power"
+
+#: ../src/iop/colorbalancergb.c:2003
+msgid "luminance exponent in mid-tones"
+msgstr "Luminance exponent in mid-tones"
+
+#: ../src/iop/colorbalancergb.c:2008
+msgid "hue of the color exponent in mid-tones"
+msgstr "Hue of the color exponent in mid-tones"
+
+#: ../src/iop/colorbalancergb.c:2014
+msgid "chroma of the color exponent in mid-tones"
+msgstr "Chroma of the color exponent in mid-tones"
+
+#. Page masks
+#: ../src/iop/colorbalancergb.c:2017
+msgid "masks"
+msgstr "Masks"
+
+#: ../src/iop/colorbalancergb.c:2017
+msgid "isolate luminances"
+msgstr "Isolate luminances"
+
+#: ../src/iop/colorbalancergb.c:2021
+msgid "choose in which uniform color space the saturation is computed"
+msgstr "Choose in which uniform color space the saturation is computed"
+
+#: ../src/iop/colorbalancergb.c:2023
+msgctxt "section"
+msgid "luminance ranges"
+msgstr "Luminance ranges"
+
+#: ../src/iop/colorbalancergb.c:2034
+msgid "weight of the shadows over the whole tonal range"
+msgstr "Weight of the shadows over the whole tonal range"
+
+#: ../src/iop/colorbalancergb.c:2042
+msgid "position of the middle-gray reference for masking"
+msgstr "Position of the middle-gray reference for masking"
+
+#: ../src/iop/colorbalancergb.c:2050
+msgid "weights of highlights over the whole tonal range"
+msgstr "Weights of highlights over the whole tonal range"
+
+#: ../src/iop/colorbalancergb.c:2055
+msgctxt "section"
+msgid "threshold"
+msgstr "Threshold"
+
+#: ../src/iop/colorbalancergb.c:2060
+msgid "peak white luminance value used to normalize the power function"
+msgstr "Peak white luminance value used to normalize the power function"
+
+#: ../src/iop/colorbalancergb.c:2066
+msgid "peak gray luminance value used to normalize the power function"
+msgstr "Peak gray luminance value used to normalize the power function"
+
+#: ../src/iop/colorbalancergb.c:2068
+msgctxt "section"
+msgid "mask preview settings"
+msgstr "Mask preview settings"
+
+#: ../src/iop/colorbalancergb.c:2071
+msgid "checkerboard color 1"
+msgstr "Checkerboard color 1"
+
+#: ../src/iop/colorbalancergb.c:2074 ../src/iop/colorbalancergb.c:2083
+msgid "select color of the checkerboard from a swatch"
+msgstr "Select color of the checkerboard from a swatch"
+
+#: ../src/iop/colorbalancergb.c:2080
+msgid "checkerboard color 2"
+msgstr "Checkerboard color 2"
+
+#: ../src/iop/colorbalancergb.c:2090
+msgid "checkerboard size"
+msgstr "Checkerboard size"
+
+#: ../src/iop/colorchecker.c:115
+msgid "color look up table"
+msgstr "Color look up table"
+
+#: ../src/iop/colorchecker.c:120
+msgid "profile|lut|color grading"
+msgstr "profile|lut|color grading"
+
+#: ../src/iop/colorchecker.c:125
+msgid "perform color space corrections and apply looks"
+msgstr "Perform color space corrections and apply looks"
+
+#: ../src/iop/colorchecker.c:127 ../src/iop/colorchecker.c:129
+#: ../src/iop/colorize.c:106 ../src/iop/colormapping.c:154
+#: ../src/iop/colorout.c:91 ../src/iop/colorreconstruction.c:136
+#: ../src/iop/colorzones.c:146 ../src/iop/defringe.c:83 ../src/iop/levels.c:136
+#: ../src/iop/monochrome.c:99 ../src/iop/shadhi.c:198
+#: ../src/iop/tonecurve.c:212 ../src/iop/vibrance.c:96
+msgid "linear or non-linear, Lab, display-referred"
+msgstr "Linear or non-linear, Lab, display-referred"
+
+#: ../src/iop/colorchecker.c:128
+msgid "defined by profile, Lab"
+msgstr "Defined by profile, Lab"
+
+#: ../src/iop/colorchecker.c:289
+msgid "it8 skin tones"
+msgstr "It8 skin tones"
+
+#: ../src/iop/colorchecker.c:303
+msgid "helmholtz/kohlrausch monochrome"
+msgstr "Helmholtz/Kohlrausch monochrome"
+
+#: ../src/iop/colorchecker.c:319
+msgid "Fuji Astia emulation"
+msgstr "Fuji Astia emulation"
+
+#: ../src/iop/colorchecker.c:332
+msgid "Fuji Classic Chrome emulation"
+msgstr "Fuji Classic Chrome emulation"
+
+#: ../src/iop/colorchecker.c:345
+msgid "Fuji Monochrome emulation"
+msgstr "Fuji Monochrome emulation"
+
+#: ../src/iop/colorchecker.c:358
+msgid "Fuji Provia emulation"
+msgstr "Fuji Provia emulation"
+
+#: ../src/iop/colorchecker.c:371
+msgid "Fuji Velvia emulation"
+msgstr "Fuji Velvia emulation"
+
+#: ../src/iop/colorchecker.c:777 ../src/iop/colorchecker.c:1283
+#, c-format
+msgid "patch #%d"
+msgstr "Patch #%d"
+
+#: ../src/iop/colorchecker.c:1147
+#, c-format
+msgid ""
+"(%2.2f %2.2f %2.2f)\n"
+"altered patches are marked with an outline\n"
+"click to select\n"
+"double-click to reset\n"
+"right click to delete patch\n"
+"shift+click while color picking to replace patch"
+msgstr ""
+"(%2.2f %2.2f %2.2f)\n"
+"Altered patches are marked with an outline\n"
+"Click to select\n"
+"Double-click to reset\n"
+"Right click to delete patch\n"
+"Shift+click while color picking to replace patch"
+
+#: ../src/iop/colorchecker.c:1278
+msgid "patch"
+msgstr "Patch"
+
+#: ../src/iop/colorchecker.c:1279
+msgid "color checker patch"
+msgstr "Color checker patch"
+
+#: ../src/iop/colorchecker.c:1290
+msgid ""
+"adjust target color Lab 'L' channel\n"
+"lower values darken target color while higher brighten it"
+msgstr ""
+"Adjust target color Lab 'L' channel\n"
+"Lower values darken target color while higher brighten it"
+
+#: ../src/iop/colorchecker.c:1294
+msgid ""
+"adjust target color Lab 'a' channel\n"
+"lower values shift target color towards greens while higher shift towards "
+"magentas"
+msgstr ""
+"Adjust target color Lab 'a' channel\n"
+"Lower values shift target color towards greens while higher shift towards "
+"magentas"
+
+#: ../src/iop/colorchecker.c:1295
+msgid "green-magenta offset"
+msgstr "Green-magenta offset"
+
+#: ../src/iop/colorchecker.c:1301
+msgid ""
+"adjust target color Lab 'b' channel\n"
+"lower values shift target color towards blues while higher shift towards "
+"yellows"
+msgstr ""
+"Adjust target color Lab 'b' channel\n"
+"Lower values shift target color towards blues while higher shift towards "
+"yellows"
+
+#: ../src/iop/colorchecker.c:1302
+msgid "blue-yellow offset"
+msgstr "Blue-yellow offset"
+
+#: ../src/iop/colorchecker.c:1308
+msgid ""
+"adjust target color saturation\n"
+"adjusts 'a' and 'b' channels of target color in Lab space simultaneously\n"
+"lower values scale towards lower saturation while higher scale towards "
+"higher saturation"
+msgstr ""
+"Adjust target color saturation\n"
+"Adjusts 'a' and 'b' channels of target color in Lab space simultaneously\n"
+"Lower values scale towards lower saturation while higher scale towards "
+"higher saturation"
+
+#: ../src/iop/colorchecker.c:1313
+msgid "target color"
+msgstr "Target color"
+
+#: ../src/iop/colorchecker.c:1314
+msgid ""
+"control target color of the patches\n"
+"relative - target color is relative from the patch original color\n"
+"absolute - target color is absolute Lab value"
+msgstr ""
+"Control target color of the patches\n"
+"Relative - target color is relative from the patch original color\n"
+"Absolute - target color is absolute Lab value"
+
+#: ../src/iop/colorchecker.c:1316
+msgid "absolute"
+msgstr "Absolute"
+
+#: ../src/iop/colorcontrast.c:85
+msgid "color contrast"
+msgstr "Color contrast"
+
+#: ../src/iop/colorcontrast.c:95
+msgid ""
+"increase saturation and separation between\n"
+"opposite colors"
+msgstr ""
+"Increase saturation and separation between\n"
+"opposite colors"
+
+#: ../src/iop/colorcontrast.c:324
+msgid ""
+"steepness of the a* curve in Lab\n"
+"lower values desaturate greens and magenta while higher saturate them"
+msgstr ""
+"Steepness of the a* curve in Lab\n"
+"Lower values desaturate greens and magenta while higher saturate them"
+
+#: ../src/iop/colorcontrast.c:331
+msgid ""
+"steepness of the b* curve in Lab\n"
+"lower values desaturate blues and yellows while higher saturate them"
+msgstr ""
+"Steepness of the b* curve in Lab\n"
+"Lower values desaturate blues and yellows while higher saturate them"
+
+#: ../src/iop/colorcorrection.c:71
+msgid "color correction"
+msgstr "Color correction"
+
+#: ../src/iop/colorcorrection.c:76
+msgid "correct white balance selectively for blacks and whites"
+msgstr "Correct white balance selectively for blacks and whites"
+
+#: ../src/iop/colorcorrection.c:107
+msgid "warm tone"
+msgstr "Warm tone"
+
+#: ../src/iop/colorcorrection.c:115
+msgid "warming filter"
+msgstr "Warming filter"
+
+#: ../src/iop/colorcorrection.c:123
+msgid "cooling filter"
+msgstr "Cooling filter"
+
+#: ../src/iop/colorcorrection.c:257
+msgid ""
+"drag the line for split-toning. bright means highlights, dark means shadows. "
+"use mouse wheel to change saturation."
+msgstr ""
+"Drag the line for split-toning. Bright means highlights, dark means shadows. "
+"Use mouse wheel to change saturation."
+
+#: ../src/iop/colorcorrection.c:276
+msgid "set the global saturation"
+msgstr "Set the global saturation"
+
+#: ../src/iop/colorin.c:127
+msgid "input color profile"
+msgstr "Input color profile"
+
+#: ../src/iop/colorin.c:132
+msgid ""
+"convert any RGB input to pipeline reference RGB\n"
+"using color profiles to remap RGB values"
+msgstr ""
+"Convert any RGB input to pipeline reference RGB\n"
+"using color profiles to remap RGB values"
+
+#: ../src/iop/colorin.c:134 ../src/iop/colorout.c:90 ../src/iop/demosaic.c:289
+#: ../src/iop/rawprepare.c:158
+msgid "mandatory"
+msgstr "Mandatory"
+
+#: ../src/iop/colorin.c:136 ../src/iop/colorout.c:92
+msgid "defined by profile"
+msgstr "Defined by profile"
+
+#: ../src/iop/colorin.c:541
+#, c-format
+msgid ""
+"can't extract matrix from colorspace `%s', it will be replaced by Rec2020 "
+"RGB!"
+msgstr ""
+"Can't extract matrix from colorspace `%s', it will be replaced by Rec2020 "
+"RGB!"
+
+#: ../src/iop/colorin.c:1450
+#, c-format
+msgid "`%s' color matrix not found!"
+msgstr "`%s' color matrix not found!"
+
+#: ../src/iop/colorin.c:1489
+msgid "input profile could not be generated!"
+msgstr "Input profile could not be generated!"
+
+#: ../src/iop/colorin.c:1585
+msgid "unsupported input profile has been replaced by linear Rec709 RGB!"
+msgstr "Unsupported input profile has been replaced by linear Rec709 RGB!"
+
+#: ../src/iop/colorin.c:2023
+msgid "input profile"
+msgstr "Input profile"
+
+#: ../src/iop/colorin.c:2027
+msgid "working profile"
+msgstr "Working profile"
+
+#: ../src/iop/colorin.c:2034 ../src/iop/colorin.c:2046
+#: ../src/iop/colorout.c:901
+#, c-format
+msgid "ICC profiles in %s or %s"
+msgstr "ICC profiles in %s or %s"
+
+#: ../src/iop/colorin.c:2061
+msgid "confine Lab values to gamut of RGB color space"
+msgstr "Confine Lab values to gamut of RGB color space"
+
+#: ../src/iop/colorize.c:84
+msgid "colorize"
+msgstr "Colorize"
+
+#: ../src/iop/colorize.c:104
+msgid "overlay a solid color on the image"
+msgstr "Overlay a solid color on the image"
+
+#: ../src/iop/colorize.c:341 ../src/iop/splittoning.c:485
+msgid "select the hue tone"
+msgstr "Select the hue tone"
+
+#: ../src/iop/colorize.c:347
+msgid "select the saturation shadow tone"
+msgstr "Select the saturation shadow tone"
+
+#: ../src/iop/colorize.c:351
+msgid "lightness of color"
+msgstr "Lightness of color"
+
+#: ../src/iop/colorize.c:355
+msgid "mix value of source lightness"
+msgstr "Mix value of source lightness"
+
+#: ../src/iop/colormapping.c:147
+msgid "color mapping"
+msgstr "Color mapping"
+
+#: ../src/iop/colormapping.c:152
+msgid ""
+"transfer a color palette and tonal repartition from one image to another"
+msgstr ""
+"Transfer a color palette and tonal repartition from one image to another"
+
+#: ../src/iop/colormapping.c:1016
+msgid "source clusters:"
+msgstr "Source clusters:"
+
+#: ../src/iop/colormapping.c:1022
+msgid "target clusters:"
+msgstr "Target clusters:"
+
+#: ../src/iop/colormapping.c:1031
+msgid "acquire as source"
+msgstr "Acquire as source"
+
+#: ../src/iop/colormapping.c:1035
+msgid "analyze this image as a source image"
+msgstr "Analyze this image as a source image"
+
+#: ../src/iop/colormapping.c:1037
+msgid "acquire as target"
+msgstr "Acquire as target"
+
+#: ../src/iop/colormapping.c:1041
+msgid "analyze this image as a target image"
+msgstr "Analyze this image as a target image"
+
+#: ../src/iop/colormapping.c:1044
+msgid "number of clusters to find in image. value change resets all clusters"
+msgstr "Number of clusters to find in image. Value change resets all clusters"
+
+#: ../src/iop/colormapping.c:1047
+msgid ""
+"how clusters are mapped. low values: based on color proximity, high values: "
+"based on color dominance"
+msgstr ""
+"How clusters are mapped. Low values: based on color proximity, high values: "
+"based on color dominance"
+
+#: ../src/iop/colormapping.c:1052
+msgid "level of histogram equalization"
+msgstr "Level of histogram equalization"
+
+#: ../src/iop/colorout.c:82
+msgid "output color profile"
+msgstr "Output color profile"
+
+#: ../src/iop/colorout.c:88
+msgid ""
+"convert pipeline reference RGB to any display RGB\n"
+"using color profiles to remap RGB values"
+msgstr ""
+"Convert pipeline reference RGB to any display RGB\n"
+"using color profiles to remap RGB values"
+
+#: ../src/iop/colorout.c:93
+msgid "non-linear, RGB or Lab, display-referred"
+msgstr "Non-linear, RGB or Lab, display-referred"
+
+#: ../src/iop/colorout.c:680
+msgid "missing output profile has been replaced by sRGB!"
+msgstr "Missing output profile has been replaced by sRGB!"
+
+#: ../src/iop/colorout.c:702
+msgid "missing softproof profile has been replaced by sRGB!"
+msgstr "Missing softproof profile has been replaced by sRGB!"
+
+#: ../src/iop/colorout.c:745
+msgid "unsupported output profile has been replaced by sRGB!"
+msgstr "Unsupported output profile has been replaced by sRGB!"
+
+#: ../src/iop/colorout.c:875
+msgid "output intent"
+msgstr "Output intent"
+
+#: ../src/iop/colorout.c:876
+msgid "rendering intent"
+msgstr "Rendering intent"
+
+#: ../src/iop/colorout.c:878 ../src/libs/export.c:1261
+#: ../src/libs/print_settings.c:2325 ../src/libs/print_settings.c:2646
+#: ../src/views/darkroom.c:2504 ../src/views/lighttable.c:1180
+msgid "perceptual"
+msgstr "Perceptual"
+
+#: ../src/iop/colorout.c:879 ../src/libs/export.c:1262
+#: ../src/libs/print_settings.c:2326 ../src/libs/print_settings.c:2647
+#: ../src/views/darkroom.c:2505 ../src/views/lighttable.c:1181
+msgid "relative colorimetric"
+msgstr "Relative colorimetric"
+
+#: ../src/iop/colorout.c:880 ../src/libs/export.c:1263
+#: ../src/libs/print_settings.c:2327 ../src/libs/print_settings.c:2648
+#: ../src/views/darkroom.c:2506 ../src/views/lighttable.c:1182
+msgctxt "rendering intent"
+msgid "saturation"
+msgstr "Saturation"
+
+#: ../src/iop/colorout.c:881 ../src/libs/export.c:1264
+#: ../src/libs/print_settings.c:2328 ../src/libs/print_settings.c:2649
+#: ../src/views/darkroom.c:2507 ../src/views/lighttable.c:1183
+msgid "absolute colorimetric"
+msgstr "Absolute colorimetric"
+
+#: ../src/iop/colorreconstruction.c:129
+msgid "color reconstruction"
+msgstr "Color reconstruction"
+
+#: ../src/iop/colorreconstruction.c:134
+msgid "recover clipped highlights by propagating surrounding colors"
+msgstr "Recover clipped highlights by propagating surrounding colors"
+
+#: ../src/iop/colorreconstruction.c:628 ../src/iop/colorreconstruction.c:1040
+#: ../src/iop/globaltonemap.c:193 ../src/iop/globaltonemap.c:362
+#: ../src/iop/hazeremoval.c:553 ../src/iop/hazeremoval.c:787
+#: ../src/iop/levels.c:332
+msgid "inconsistent output"
+msgstr "Inconsistent output"
+
+#: ../src/iop/colorreconstruction.c:666
+msgid "module `color reconstruction' failed"
+msgstr "Module `color reconstruction' failed"
+
+#: ../src/iop/colorreconstruction.c:1237
+msgid "spatial"
+msgstr "Spatial"
+
+#: ../src/iop/colorreconstruction.c:1238
+msgid "range"
+msgstr "Range"
+
+#: ../src/iop/colorreconstruction.c:1239
+msgid "precedence"
+msgstr "Precedence"
+
+#: ../src/iop/colorreconstruction.c:1255
+msgid "pixels with lightness values above this threshold are corrected"
+msgstr "Pixels with lightness values above this threshold are corrected"
+
+#: ../src/iop/colorreconstruction.c:1256
+msgid "how far to look for replacement colors in spatial dimensions"
+msgstr "How far to look for replacement colors in spatial dimensions"
+
+#: ../src/iop/colorreconstruction.c:1257
+msgid "how far to look for replacement colors in the luminance dimension"
+msgstr "How far to look for replacement colors in the luminance dimension"
+
+#: ../src/iop/colorreconstruction.c:1258
+msgid "if and how to give precedence to specific replacement colors"
+msgstr "If and how to give precedence to specific replacement colors"
+
+#: ../src/iop/colorreconstruction.c:1259
+msgid "the hue tone which should be given precedence over other hue tones"
+msgstr "The hue tone which should be given precedence over other hue tones"
+
+#: ../src/iop/colorreconstruction.c:1261 ../src/iop/demosaic.c:1270
+#: ../src/iop/highlights.c:1199
+msgid "not applicable"
+msgstr "Not applicable"
+
+#: ../src/iop/colorreconstruction.c:1262
+msgid "no highlights reconstruction for monochrome images"
+msgstr "No highlights reconstruction for monochrome images"
+
+#: ../src/iop/colortransfer.c:103
+msgid "color transfer"
+msgstr "Color transfer"
+
+#: ../src/iop/colortransfer.c:118
+msgid "this module is deprecated. better use color mapping module instead."
+msgstr "This module is deprecated. Better use color mapping module instead."
+
+#: ../src/iop/colortransfer.c:439
+msgid ""
+"this module will be removed in the future\n"
+"and is only here so you can switch it off\n"
+"and move to the new color mapping module."
+msgstr ""
+"This module will be removed in the future\n"
+"and is only here so you can switch it off\n"
+"and move to the new color mapping module."
+
+#: ../src/iop/colorzones.c:139 ../src/iop/colorzones.c:2332
+msgid "color zones"
+msgstr "Color zones"
+
+#: ../src/iop/colorzones.c:144
+msgid "selectively shift hues, saturation and brightness of pixels"
+msgstr "Selectively shift hues, saturation and brightness of pixels"
+
+#: ../src/iop/colorzones.c:606
+msgid "B&W: with red"
+msgstr "B&W: with red"
+
+#: ../src/iop/colorzones.c:629
+msgid "B&W: with skin tones"
+msgstr "B&W: with skin tones"
+
+#: ../src/iop/colorzones.c:652
+msgid "polarizing filter"
+msgstr "Polarizing filter"
+
+#: ../src/iop/colorzones.c:673
+msgid "natural skin tones"
+msgstr "Natural skin tones"
+
+#: ../src/iop/colorzones.c:704
+msgid "B&W: film"
+msgstr "B&W: film"
+
+#: ../src/iop/colorzones.c:724
+msgid "HSL base setting"
+msgstr "HSL base setting"
+
+#: ../src/iop/colorzones.c:2264
+msgid "orange"
+msgstr "Orange"
+
+#: ../src/iop/colorzones.c:2422 ../src/iop/rgbcurve.c:1373
+msgid ""
+"create a curve based on an area from the image\n"
+"drag to create a flat curve\n"
+"ctrl+drag to create a positive curve\n"
+"shift+drag to create a negative curve"
+msgstr ""
+"Create a curve based on an area from the image\n"
+"Drag to create a flat curve\n"
+"Ctrl+drag to create a positive curve\n"
+"Shift+drag to create a negative curve"
+
+#. edit by area
+#: ../src/iop/colorzones.c:2442
+msgid "edit by area"
+msgstr "Edit by area"
+
+#: ../src/iop/colorzones.c:2447
+msgid "edit the curve nodes by area"
+msgstr "Edit the curve nodes by area"
+
+#: ../src/iop/colorzones.c:2454
+msgid "display selection"
+msgstr "Display selection"
+
+#: ../src/iop/colorzones.c:2464
+msgid "choose selection criterion, will be the abscissa in the graph"
+msgstr "Choose selection criterion, will be the abscissa in the graph"
+
+#: ../src/iop/colorzones.c:2467
+msgid "choose between a smoother or stronger effect"
+msgstr "Choose between a smoother or stronger effect"
+
+#: ../src/iop/colorzones.c:2495 ../src/iop/rgbcurve.c:1407
+#: ../src/iop/tonecurve.c:1170
+msgid "interpolation method"
+msgstr "Interpolation method"
+
+#: ../src/iop/colorzones.c:2497 ../src/iop/rgbcurve.c:1409
+#: ../src/iop/tonecurve.c:1172
+msgid "centripetal spline"
+msgstr "Centripetal spline"
+
+#: ../src/iop/colorzones.c:2498 ../src/iop/rgbcurve.c:1410
+#: ../src/iop/tonecurve.c:1173
+msgid "monotonic spline"
+msgstr "Monotonic spline"
+
+#: ../src/iop/colorzones.c:2501 ../src/iop/rgbcurve.c:1413
+#: ../src/iop/tonecurve.c:1175
+msgid ""
+"change this method if you see oscillations or cusps in the curve\n"
+"- cubic spline is better to produce smooth curves but oscillates when nodes "
+"are too close\n"
+"- centripetal is better to avoids cusps and oscillations with close nodes "
+"but is less smooth\n"
+"- monotonic is better for accuracy of pure analytical functions (log, gamma, "
+"exp)"
+msgstr ""
+"Change this method if you see oscillations or cusps in the curve\n"
+"- Cubic spline is better to produce smooth curves but oscillates when nodes "
+"are too close\n"
+"- Centripetal is better to avoids cusps and oscillations with close nodes "
+"but is less smooth\n"
+"- Monotonic is better for accuracy of pure analytical functions (log, gamma, "
+"exp)"
+
+#: ../src/iop/crop.c:132
+msgid "crop"
+msgstr "Crop"
+
+#: ../src/iop/crop.c:137
+msgid "reframe|distortion"
+msgstr "reframe|distortion"
+
+#: ../src/iop/crop.c:143
+msgid "change the framing"
+msgstr "Change the framing"
+
+#: ../src/iop/crop.c:1667
+msgid "<b>resize</b>: drag, <b>keep aspect ratio</b>: shift+drag"
+msgstr "<b>Resize</b>: drag, <b>Keep aspect ratio</b>: Shift+drag"
+
+#: ../src/iop/crop.c:1676
+msgid ""
+"<b>move</b>: drag, <b>move vertically</b>: shift+drag, <b>move horizontally</"
+"b>: ctrl+drag"
+msgstr ""
+"<b>Move</b>: drag, <b>Move vertically</b>: Shift+drag, <b>Move horizontally</"
+"b>: Ctrl+drag"
+
+#: ../src/iop/defringe.c:71
+msgid "defringe"
+msgstr "Defringe"
+
+#: ../src/iop/defringe.c:81
+msgid "attenuate chromatic aberration by desaturating edges"
+msgstr "Attenuate chromatic aberration by desaturating edges"
+
+#: ../src/iop/defringe.c:101
+msgid ""
+"this module is deprecated. please use the chromatic aberration module "
+"instead."
+msgstr ""
+"This module is deprecated. Please use the chromatic aberration module "
+"instead."
+
+#: ../src/iop/defringe.c:415
+msgid ""
+"method for color protection:\n"
+" - global average: fast, might show slightly wrong previews in high "
+"magnification; might sometimes protect saturation too much or too low in "
+"comparison to local average\n"
+" - local average: slower, might protect saturation better than global "
+"average by using near pixels as color reference, so it can still allow for "
+"more desaturation where required\n"
+" - static: fast, only uses the threshold as a static limit"
+msgstr ""
+"Method for color protection:\n"
+" - global average: fast, might show slightly wrong previews in high "
+"magnification; might sometimes protect saturation too much or too low in "
+"comparison to local average\n"
+" - local average: slower, might protect saturation better than global "
+"average by using near pixels as color reference, so it can still allow for "
+"more desaturation where required\n"
+" - static: fast, only uses the threshold as a static limit"
+
+#: ../src/iop/defringe.c:422
+msgid "radius for detecting fringe"
+msgstr "Radius for detecting fringe"
+
+#: ../src/iop/defringe.c:425
+msgid "threshold for defringe, higher values mean less defringing"
+msgstr "Threshold for defringe, higher values mean less defringing"
+
+#: ../src/iop/demosaic.c:283
+msgid "demosaic"
+msgstr "Demosaic"
+
+#: ../src/iop/demosaic.c:288
+msgid "reconstruct full RGB pixels from a sensor color filter array reading"
+msgstr "Reconstruct full RGB pixels from a sensor color filter array reading"
+
+#: ../src/iop/demosaic.c:866
+msgid "[dual demosaic_cl] internal problem"
+msgstr "[dual demosaic_cl] internal problem"
+
+#: ../src/iop/demosaic.c:1105
+#, c-format
+msgid "`%s' color matrix not found for 4bayer image!"
+msgstr "`%s' color matrix not found for 4bayer image!"
+
+#: ../src/iop/demosaic.c:1237
+msgid ""
+"Bayer sensor demosaicing method, PPG and RCD are fast, AMaZE and LMMSE are "
+"slow.\n"
+"LMMSE is suited best for high ISO images.\n"
+"dual demosaicers double processing time."
+msgstr ""
+"Bayer sensor demosaicing method, PPG and RCD are fast, AMaZE and LMMSE are "
+"slow.\n"
+"LMMSE is suited best for high ISO images.\n"
+"Dual demosaicers double processing time."
+
+#: ../src/iop/demosaic.c:1241
+msgid ""
+"X-Trans sensor demosaicing method, Markesteijn 3-pass and frequency domain "
+"chroma are slow.\n"
+"dual demosaicers double processing time."
+msgstr ""
+"X-Trans sensor demosaicing method, Markesteijn 3-pass and frequency domain "
+"chroma are slow.\n"
+"Dual demosaicers double processing time."
+
+#: ../src/iop/demosaic.c:1245
+msgid ""
+"threshold for edge-aware median.\n"
+"set to 0.0 to switch off\n"
+"set to 1.0 to ignore edges"
+msgstr ""
+"Threshold for edge-aware median.\n"
+"Set to 0.0 to switch off\n"
+"Set to 1.0 to ignore edges"
+
+#: ../src/iop/demosaic.c:1250
+msgid ""
+"contrast threshold for dual demosaic.\n"
+"set to 0.0 for high frequency content\n"
+"set to 1.0 for flat content\n"
+"toggle to visualize the mask"
+msgstr ""
+"Contrast threshold for dual demosaic.\n"
+"Set to 0.0 for high frequency content\n"
+"Set to 1.0 for flat content\n"
+"Toggle to visualize the mask"
+
+#: ../src/iop/demosaic.c:1258
+msgid ""
+"LMMSE refinement steps. the median steps average the output,\n"
+"refine adds some recalculation of red & blue channels"
+msgstr ""
+"LMMSE refinement steps. The median steps average the output,\n"
+"refine adds some recalculation of red & blue channels"
+
+#: ../src/iop/demosaic.c:1261
+msgid "how many color smoothing median steps after demosaicing"
+msgstr "How many color smoothing median steps after demosaicing"
+
+#: ../src/iop/demosaic.c:1264
+msgid "green channels matching method"
+msgstr "Green channels matching method"
+
+#: ../src/iop/demosaic.c:1271
+msgid "demosaicing is only used for color raw images"
+msgstr "Demosaicing is only used for color raw images"
+
+#: ../src/iop/denoiseprofile.c:712
+msgid "wavelets: chroma only"
+msgstr "Wavelets: chroma only"
+
+#: ../src/iop/denoiseprofile.c:718
+msgid "denoise (profiled)"
+msgstr "Denoise (profiled)"
+
+#: ../src/iop/denoiseprofile.c:724
+msgid "denoise using noise statistics profiled on sensors"
+msgstr "Denoise using noise statistics profiled on sensors"
+
+#: ../src/iop/denoiseprofile.c:2818
+#, c-format
+msgid "found match for ISO %d"
+msgstr "Found match for ISO %d"
+
+#: ../src/iop/denoiseprofile.c:2827
+#, c-format
+msgid "interpolated from ISO %d and %d"
+msgstr "Interpolated from ISO %d and %d"
+
+#: ../src/iop/denoiseprofile.c:3247 ../src/iop/denoiseprofile.c:3888
+msgid "compute variance"
+msgstr "Compute variance"
+
+#: ../src/iop/denoiseprofile.c:3793
+msgid "Y0"
+msgstr "Y0"
+
+#: ../src/iop/denoiseprofile.c:3794
+msgid "U0V0"
+msgstr "U0V0"
+
+#: ../src/iop/denoiseprofile.c:3834
+msgid ""
+"use only with a perfectly\n"
+"uniform image if you want to\n"
+"estimate the noise variance."
+msgstr ""
+"Use only with a perfectly\n"
+"uniform image if you want to\n"
+"estimate the noise variance."
+
+#: ../src/iop/denoiseprofile.c:3840
+msgid "variance red: "
+msgstr "Variance red: "
+
+#: ../src/iop/denoiseprofile.c:3844
+msgid "variance computed on the red channel"
+msgstr "Variance computed on the red channel"
+
+#: ../src/iop/denoiseprofile.c:3849
+msgid "variance green: "
+msgstr "Variance green: "
+
+#: ../src/iop/denoiseprofile.c:3853
+msgid "variance computed on the green channel"
+msgstr "Variance computed on the green channel"
+
+#: ../src/iop/denoiseprofile.c:3858
+msgid "variance blue: "
+msgstr "Variance blue: "
+
+#: ../src/iop/denoiseprofile.c:3862
+msgid "variance computed on the blue channel"
+msgstr "Variance computed on the blue channel"
+
+#: ../src/iop/denoiseprofile.c:3873 ../src/libs/export.c:1219
+#: ../src/libs/print_settings.c:2272 ../src/libs/print_settings.c:2597
+msgid "profile"
+msgstr "Profile"
+
+#: ../src/iop/denoiseprofile.c:3882
+msgid "non-local means"
+msgstr "Non-local means"
+
+#: ../src/iop/denoiseprofile.c:3883
+msgid "non-local means auto"
+msgstr "Non-local means auto"
+
+#: ../src/iop/denoiseprofile.c:3884
+msgid "wavelets"
+msgstr "Wavelets"
+
+#: ../src/iop/denoiseprofile.c:3885
+msgid "wavelets auto"
+msgstr "Wavelets auto"
+
+#: ../src/iop/denoiseprofile.c:3912
+msgid ""
+"adapt denoising according to the\n"
+"white balance coefficients.\n"
+"should be enabled on a first instance\n"
+"for better denoising.\n"
+"should be disabled if an earlier instance\n"
+"has been used with a color blending mode."
+msgstr ""
+"Adapt denoising according to the\n"
+"white balance coefficients.\n"
+"Should be enabled on a first instance\n"
+"for better denoising.\n"
+"Should be disabled if an earlier instance\n"
+"has been used with a color blending mode."
+
+#: ../src/iop/denoiseprofile.c:3919
+msgid ""
+"fix bugs in anscombe transform resulting\n"
+"in undersmoothing of the green channel in\n"
+"wavelets mode, combined with a bad handling\n"
+"of white balance coefficients, and a bug in\n"
+"non local means normalization resulting in\n"
+"undersmoothing when patch size was increased.\n"
+"enabling this option will change the denoising\n"
+"you get. once enabled, you won't be able to\n"
+"return back to old algorithm."
+msgstr ""
+"Fix bugs in anscombe transform resulting\n"
+"in undersmoothing of the green channel in\n"
+"wavelets mode, combined with a bad handling\n"
+"of white balance coefficients, and a bug in\n"
+"non local means normalization resulting in\n"
+"undersmoothing when patch size was increased.\n"
+"Enabling this option will change the denoising\n"
+"you get. Once enabled, you won't be able to\n"
+"return back to old algorithm."
+
+#: ../src/iop/denoiseprofile.c:3929
+msgid "profile used for variance stabilization"
+msgstr "Profile used for variance stabilization"
+
+#: ../src/iop/denoiseprofile.c:3931
+msgid ""
+"method used in the denoising core.\n"
+"non-local means works best for `lightness' blending,\n"
+"wavelets work best for `color' blending"
+msgstr ""
+"Method used in the denoising core.\n"
+"Non-local means works best for `lightness' blending,\n"
+"wavelets work best for `color' blending"
+
+#: ../src/iop/denoiseprofile.c:3935
+msgid ""
+"color representation used within the algorithm.\n"
+"RGB keeps the RGB channels separated,\n"
+"while Y0U0V0 combine the channels to\n"
+"denoise chroma and luma separately."
+msgstr ""
+"Color representation used within the algorithm.\n"
+"RGB keeps the RGB channels separated,\n"
+"while Y0U0V0 combine the channels to\n"
+"denoise chroma and luma separately."
+
+#: ../src/iop/denoiseprofile.c:3940
+msgid ""
+"radius of the patches to match.\n"
+"increase for more sharpness on strong edges, and better denoising of smooth "
+"areas.\n"
+"if details are oversmoothed, reduce this value or increase the central pixel "
+"weight slider."
+msgstr ""
+"Radius of the patches to match.\n"
+"Increase for more sharpness on strong edges, and better denoising of smooth "
+"areas.\n"
+"If details are oversmoothed, reduce this value or increase the central pixel "
+"weight slider."
+
+#: ../src/iop/denoiseprofile.c:3946
+msgid ""
+"emergency use only: radius of the neighborhood to search patches in. "
+"increase for better denoising performance, but watch the long runtimes! "
+"large radii can be very slow. you have been warned"
+msgstr ""
+"Emergency use only: radius of the neighborhood to search patches in. "
+"Increase for better denoising performance, but watch the long runtimes! "
+"Large radii can be very slow. You have been warned"
+
+#: ../src/iop/denoiseprofile.c:3952
+msgid ""
+"scattering of the neighborhood to search patches in.\n"
+"increase for better coarse-grain noise reduction.\n"
+"does not affect execution time."
+msgstr ""
+"Scattering of the neighborhood to search patches in.\n"
+"Increase for better coarse-grain noise reduction.\n"
+"Does not affect execution time."
+
+#: ../src/iop/denoiseprofile.c:3956
+msgid ""
+"increase the weight of the central pixel\n"
+"of the patch in the patch comparison.\n"
+"useful to recover details when patch size\n"
+"is quite big."
+msgstr ""
+"Increase the weight of the central pixel\n"
+"of the patch in the patch comparison.\n"
+"Useful to recover details when patch size\n"
+"is quite big."
+
+#: ../src/iop/denoiseprofile.c:3960
+msgid "finetune denoising strength"
+msgstr "Finetune denoising strength"
+
+#: ../src/iop/denoiseprofile.c:3962
+msgid ""
+"controls the way parameters are autoset\n"
+"increase if shadows are not denoised enough\n"
+"or if chroma noise remains.\n"
+"this can happen if your picture is underexposed."
+msgstr ""
+"Controls the way parameters are autoset.\n"
+"Increase if shadows are not denoised enough\n"
+"or if chroma noise remains.\n"
+"This can happen if your picture is underexposed."
+
+#: ../src/iop/denoiseprofile.c:3967
+msgid ""
+"finetune shadows denoising.\n"
+"decrease to denoise more aggressively\n"
+"dark areas of the image."
+msgstr ""
+"Finetune shadows denoising.\n"
+"Decrease to denoise more aggressively\n"
+"dark areas of the image."
+
+#: ../src/iop/denoiseprofile.c:3971
+msgid ""
+"correct color cast in shadows.\n"
+"decrease if shadows are too purple.\n"
+"increase if shadows are too green."
+msgstr ""
+"Correct color cast in shadows.\n"
+"Decrease if shadows are too purple.\n"
+"Increase if shadows are too green."
+
+#: ../src/iop/denoiseprofile.c:3975
+msgid ""
+"upgrade the variance stabilizing algorithm.\n"
+"new algorithm extends the current one.\n"
+"it is more flexible but could give small\n"
+"differences in the images already processed."
+msgstr ""
+"Upgrade the variance stabilizing algorithm.\n"
+"New algorithm extends the current one.\n"
+"It is more flexible but could give small\n"
+"differences in the images already processed."
+
+#: ../src/iop/diffuse.c:129
+msgid "diffuse or sharpen"
+msgstr "Diffuse or sharpen"
+
+#: ../src/iop/diffuse.c:134
+msgid "diffusion|deconvolution|blur|sharpening"
+msgstr "diffusion|deconvolution|blur|sharpening"
+
+#: ../src/iop/diffuse.c:141
+msgid ""
+"simulate directional diffusion of light with heat transfer model\n"
+"to apply an iterative edge-oriented blur,\n"
+"inpaint damaged parts of the image, or to remove blur with blind "
+"deconvolution."
+msgstr ""
+"Simulate directional diffusion of light with heat transfer model\n"
+"to apply an iterative edge-oriented blur,\n"
+"inpaint damaged parts of the image, or to remove blur with blind "
+"deconvolution."
+
+#. deblurring presets
+#: ../src/iop/diffuse.c:219
+msgid "lens deblur: soft"
+msgstr "Lens deblur: soft"
+
+#: ../src/iop/diffuse.c:244
+msgid "lens deblur: medium"
+msgstr "Lens deblur: medium"
+
+#: ../src/iop/diffuse.c:269
+msgid "lens deblur: hard"
+msgstr "Lens deblur: hard"
+
+#: ../src/iop/diffuse.c:295
+msgid "dehaze"
+msgstr "Dehaze"
+
+#: ../src/iop/diffuse.c:321
+msgid "denoise: fine"
+msgstr "Denoise: fine"
+
+#: ../src/iop/diffuse.c:346
+msgid "denoise: medium"
+msgstr "Denoise: medium"
+
+#: ../src/iop/diffuse.c:371
+msgid "denoise: coarse"
+msgstr "Denoise: coarse"
+
+#: ../src/iop/diffuse.c:446
+msgid "sharpen demosaicing: no AA filter"
+msgstr "Sharpen demosaicing: no AA filter"
+
+#: ../src/iop/diffuse.c:472
+msgid "sharpen demosaicing: AA filter"
+msgstr "Sharpen demosaicing: AA filter"
+
+#: ../src/iop/diffuse.c:499
+msgid "simulate watercolor"
+msgstr "Simulate watercolor"
+
+#: ../src/iop/diffuse.c:524
+msgid "simulate line drawing"
+msgstr "Simulate line drawing"
+
+#: ../src/iop/diffuse.c:576
+msgid "inpaint highlights"
+msgstr "Inpaint highlights"
+
+#. fast presets for slow hardware
+#: ../src/iop/diffuse.c:603
+msgid "sharpness: fast"
+msgstr "Sharpness: fast"
+
+#: ../src/iop/diffuse.c:655
+msgid "sharpness: strong"
+msgstr "Sharpness: strong"
+
+#: ../src/iop/diffuse.c:680
+msgid "local contrast: fast"
+msgstr "Local contrast: fast"
+
+#: ../src/iop/diffuse.c:1395 ../src/iop/diffuse.c:1673
+msgid "diffuse/sharpen failed to allocate memory, check your RAM settings"
+msgstr "Diffuse/sharpen failed to allocate memory, check your RAM settings"
+
+#. Additional parameters
+#. Camera settings
+#: ../src/iop/diffuse.c:1789 ../src/iop/splittoning.c:537
+#: ../src/libs/camera.c:487
+msgctxt "section"
+msgid "properties"
+msgstr "Properties"
+
+#: ../src/iop/diffuse.c:1795
+msgid ""
+"more iterations make the effect stronger but the module slower.\n"
+"this is analogous to giving more time to the diffusion reaction.\n"
+"if you plan on sharpening or inpainting, \n"
+"more iterations help reconstruction."
+msgstr ""
+"More iterations make the effect stronger but the module slower.\n"
+"This is analogous to giving more time to the diffusion reaction.\n"
+"If you plan on sharpening or inpainting, \n"
+"more iterations help reconstruction."
+
+#: ../src/iop/diffuse.c:1804
+msgid ""
+"main scale of the diffusion.\n"
+"zero makes diffusion act on the finest details more heavily.\n"
+"non-zero defines the size of the details to diffuse heavily.\n"
+"for deblurring and denoising, set to zero.\n"
+"increase to act on local contrast instead."
+msgstr ""
+"Main scale of the diffusion.\n"
+"Zero makes diffusion act on the finest details more heavily.\n"
+"Non-zero defines the size of the details to diffuse heavily.\n"
+"For deblurring and denoising, set to zero.\n"
+"Increase to act on local contrast instead."
+
+#: ../src/iop/diffuse.c:1814
+msgid ""
+"width of the diffusion around the central radius.\n"
+"high values diffuse on a large band of radii.\n"
+"low values diffuse closer to the central radius.\n"
+"if you plan on deblurring, \n"
+"the radius should be around the width of your lens blur."
+msgstr ""
+"Width of the diffusion around the central radius.\n"
+"High values diffuse on a large band of radii.\n"
+"Low values diffuse closer to the central radius.\n"
+"If you plan on deblurring, \n"
+"the radius should be around the width of your lens blur."
+
+#: ../src/iop/diffuse.c:1821
+msgctxt "section"
+msgid "speed (sharpen ↔ diffuse)"
+msgstr "Speed (sharpen ↔ diffuse)"
+
+#: ../src/iop/diffuse.c:1828
+msgid ""
+"diffusion speed of low-frequency wavelet layers\n"
+"in the direction of 1st order anisotropy (set below).\n"
+"\n"
+"negative values sharpen, \n"
+"positive values diffuse and blur, \n"
+"zero does nothing."
+msgstr ""
+"Diffusion speed of low-frequency wavelet layers\n"
+"in the direction of 1st order anisotropy (set below).\n"
+"\n"
+"Negative values sharpen, \n"
+"positive values diffuse and blur, \n"
+"zero does nothing."
+
+#: ../src/iop/diffuse.c:1838
+msgid ""
+"diffusion speed of low-frequency wavelet layers\n"
+"in the direction of 2nd order anisotropy (set below).\n"
+"\n"
+"negative values sharpen, \n"
+"positive values diffuse and blur, \n"
+"zero does nothing."
+msgstr ""
+"Diffusion speed of low-frequency wavelet layers\n"
+"in the direction of 2nd order anisotropy (set below).\n"
+"\n"
+"Negative values sharpen, \n"
+"positive values diffuse and blur, \n"
+"zero does nothing."
+
+#: ../src/iop/diffuse.c:1848
+msgid ""
+"diffusion speed of high-frequency wavelet layers\n"
+"in the direction of 3rd order anisotropy (set below).\n"
+"\n"
+"negative values sharpen, \n"
+"positive values diffuse and blur, \n"
+"zero does nothing."
+msgstr ""
+"Diffusion speed of high-frequency wavelet layers\n"
+"in the direction of 3rd order anisotropy (set below).\n"
+"\n"
+"Negative values sharpen, \n"
+"positive values diffuse and blur, \n"
+"zero does nothing."
+
+#: ../src/iop/diffuse.c:1858
+msgid ""
+"diffusion speed of high-frequency wavelet layers\n"
+"in the direction of 4th order anisotropy (set below).\n"
+"\n"
+"negative values sharpen, \n"
+"positive values diffuse and blur, \n"
+"zero does nothing."
+msgstr ""
+"Diffusion speed of high-frequency wavelet layers\n"
+"in the direction of 4th order anisotropy (set below).\n"
+"\n"
+"Negative values sharpen, \n"
+"positive values diffuse and blur, \n"
+"zero does nothing."
+
+#: ../src/iop/diffuse.c:1864
+msgctxt "section"
+msgid "direction"
+msgstr "Direction"
+
+#: ../src/iop/diffuse.c:1871
+msgid ""
+"direction of 1st order speed (set above).\n"
+"\n"
+"negative values follow gradients more closely, \n"
+"positive values rather avoid edges (isophotes), \n"
+"zero affects both equally (isotropic)."
+msgstr ""
+"Direction of 1st order speed (set above).\n"
+"\n"
+"Negative values follow gradients more closely, \n"
+"positive values rather avoid edges (isophotes), \n"
+"zero affects both equally (isotropic)."
+
+#: ../src/iop/diffuse.c:1880
+msgid ""
+"direction of 2nd order speed (set above).\n"
+"\n"
+"negative values follow gradients more closely, \n"
+"positive values rather avoid edges (isophotes), \n"
+"zero affects both equally (isotropic)."
+msgstr ""
+"Direction of 2nd order speed (set above).\n"
+"\n"
+"Negative values follow gradients more closely, \n"
+"positive values rather avoid edges (isophotes), \n"
+"zero affects both equally (isotropic)."
+
+#: ../src/iop/diffuse.c:1889
+msgid ""
+"direction of 3rd order speed (set above).\n"
+"\n"
+"negative values follow gradients more closely, \n"
+"positive values rather avoid edges (isophotes), \n"
+"zero affects both equally (isotropic)."
+msgstr ""
+"Direction of 3rd order speed (set above).\n"
+"\n"
+"Negative values follow gradients more closely, \n"
+"positive values rather avoid edges (isophotes), \n"
+"zero affects both equally (isotropic)."
+
+#: ../src/iop/diffuse.c:1898
+msgid ""
+"direction of 4th order speed (set above).\n"
+"\n"
+"negative values follow gradients more closely, \n"
+"positive values rather avoid edges (isophotes), \n"
+"zero affects both equally (isotropic)."
+msgstr ""
+"Direction of 4th order speed (set above).\n"
+"\n"
+"Negative values follow gradients more closely, \n"
+"positive values rather avoid edges (isophotes), \n"
+"zero affects both equally (isotropic)."
+
+#: ../src/iop/diffuse.c:1904
+msgctxt "section"
+msgid "edge management"
+msgstr "Edge management"
+
+#: ../src/iop/diffuse.c:1911
+msgid ""
+"increase or decrease the sharpness of the highest frequencies.\n"
+"can be used to keep details after blooming,\n"
+"for standalone sharpening set speed to negative values."
+msgstr ""
+"Increase or decrease the sharpness of the highest frequencies.\n"
+"Can be used to keep details after blooming,\n"
+"for standalone sharpening set speed to negative values."
+
+#: ../src/iop/diffuse.c:1918
+msgid ""
+"define the sensitivity of the variance penalty for edges.\n"
+"increase to exclude more edges from diffusion,\n"
+"if fringes or halos appear."
+msgstr ""
+"Define the sensitivity of the variance penalty for edges.\n"
+"Increase to exclude more edges from diffusion,\n"
+"if fringes or halos appear."
+
+#: ../src/iop/diffuse.c:1925
+msgid ""
+"define the variance threshold between edge amplification and penalty.\n"
+"decrease if you want pixels on smooth surfaces get a boost,\n"
+"increase if you see noise appear on smooth surfaces or\n"
+"if dark areas seem oversharpened compared to bright areas."
+msgstr ""
+"Define the variance threshold between edge amplification and penalty.\n"
+"Decrease if you want pixels on smooth surfaces get a boost,\n"
+"increase if you see noise appear on smooth surfaces or\n"
+"if dark areas seem oversharpened compared to bright areas."
+
+#: ../src/iop/diffuse.c:1931
+msgctxt "section"
+msgid "diffusion spatiality"
+msgstr "Diffusion spatiality"
+
+#: ../src/iop/diffuse.c:1938
+msgid ""
+"luminance threshold for the mask.\n"
+"0. disables the luminance masking and applies the module on the whole "
+"image.\n"
+"any higher value excludes pixels with luminance lower than the threshold.\n"
+"this can be used to inpaint highlights."
+msgstr ""
+"Luminance threshold for the mask.\n"
+"0. Disables the luminance masking and applies the module on the whole "
+"image.\n"
+"Any higher value excludes pixels with luminance lower than the threshold.\n"
+"This can be used to inpaint highlights."
+
+#: ../src/iop/dither.c:94 ../src/iop/vignette.c:980
+msgid "dithering"
+msgstr "Dithering"
+
+#: ../src/iop/dither.c:99
+msgid ""
+"reduce banding and posterization effects in output JPEGs by adding random "
+"noise"
+msgstr ""
+"Reduce banding and posterization effects in output JPEGs by adding random "
+"noise"
+
+#. add the preset.
+#: ../src/iop/dither.c:128
+msgid "dither"
+msgstr "Dither"
+
+#: ../src/iop/dither.c:661
+msgid "radius for blurring step"
+msgstr "Radius for blurring step"
+
+#: ../src/iop/dither.c:673
+msgid "the gradient range where to apply random dither"
+msgstr "The gradient range where to apply random dither"
+
+#: ../src/iop/dither.c:674
+msgid "gradient range"
+msgstr "Gradient range"
+
+#: ../src/iop/dither.c:682
+msgid "damping level of random dither"
+msgstr "Damping level of random dither"
+
+#: ../src/iop/equalizer.c:89
+msgid "legacy equalizer"
+msgstr "Legacy equalizer"
+
+#: ../src/iop/equalizer.c:110
+msgid ""
+"this module is deprecated. better use contrast equalizer module instead."
+msgstr ""
+"This module is deprecated. Better use contrast equalizer module instead."
+
+#: ../src/iop/equalizer.c:238
+msgid ""
+"this module will be removed in the future\n"
+"and is only here so you can switch it off\n"
+"and move to the new equalizer."
+msgstr ""
+"This module will be removed in the future\n"
+"and is only here so you can switch it off\n"
+"and move to the new equalizer."
+
+#: ../src/iop/exposure.c:128
+msgid ""
+"redo the exposure of the shot as if you were still in-camera\n"
+"using a color-safe brightening similar to increasing ISO setting"
+msgstr ""
+"Redo the exposure of the shot as if you were still in-camera\n"
+"using a color-safe brightening similar to increasing ISO setting"
+
+#: ../src/iop/exposure.c:276
+msgid "magic lantern defaults"
+msgstr "Magic lantern defaults"
+
+#: ../src/iop/exposure.c:343 ../src/iop/rawoverexposed.c:135
+#: ../src/iop/rawoverexposed.c:254
+#, c-format
+msgid "failed to get raw buffer from image `%s'"
+msgstr "Failed to get raw buffer from image `%s'"
+
+#: ../src/iop/exposure.c:621
+#, no-c-format
+msgid "compensate camera exposure (%+.1f EV)"
+msgstr "Compensate camera exposure (%+.1f EV)"
+
+#. Write report in GUI
+#: ../src/iop/exposure.c:805
+#, c-format
+msgid "L : \t%.1f %%"
+msgstr "L : \t%.1f %%"
+
+#: ../src/iop/exposure.c:937 ../src/libs/history.c:965
+#, c-format
+msgid "%.2f EV"
+msgstr "%.2f EV"
+
+#: ../src/iop/exposure.c:1105
+msgid ""
+"automatically remove the camera exposure bias\n"
+"this is useful if you exposed the image to the right."
+msgstr ""
+"Automatically remove the camera exposure bias.\n"
+"This is useful if you exposed the image to the right."
+
+#: ../src/iop/exposure.c:1124
+#, no-c-format
+msgid "where in the histogram to meter for deflicking. E.g. 50% is median"
+msgstr "Where in the histogram to meter for deflicking. E.g. 50% is median"
+
+#: ../src/iop/exposure.c:1130
+msgid ""
+"where to place the exposure level for processed pics, EV below overexposure."
+msgstr ""
+"Where to place the exposure level for processed pics, EV below overexposure."
+
+#: ../src/iop/exposure.c:1134
+msgid "computed EC: "
+msgstr "Computed EC: "
+
+#: ../src/iop/exposure.c:1137
+msgid "what exposure correction has actually been used"
+msgstr "What exposure correction has actually been used"
+
+#: ../src/iop/exposure.c:1156
+msgid ""
+"adjust the black level to unclip negative RGB values.\n"
+"you should never use it to add more density in blacks!\n"
+"if poorly set, it will clip near-black colors out of gamut\n"
+"by pushing RGB values into negatives."
+msgstr ""
+"Adjust the black level to unclip negative RGB values.\n"
+"You should never use it to add more density in blacks!\n"
+"If poorly set, it will clip near-black colors out of gamut\n"
+"by pushing RGB values into negatives."
+
+#: ../src/iop/exposure.c:1166
+msgid "spot exposure mapping"
+msgstr "Spot exposure mapping"
+
+#: ../src/iop/exposure.c:1172
+msgid ""
+"define a target brightness, in terms of exposure,\n"
+"for a selected region of the image (the control sample),\n"
+"which you then match against the same target brightness\n"
+"in other images. the control sample can either\n"
+"be a critical part of your subject or a non-moving and\n"
+"consistently-lit surface over your series of images."
+msgstr ""
+"Define a target brightness, in terms of exposure,\n"
+"for a selected region of the image (the control sample),\n"
+"which you then match against the same target brightness\n"
+"in other images. The control sample can either\n"
+"be a critical part of your subject or a non-moving and\n"
+"consistently-lit surface over your series of images."
+
+#: ../src/iop/exposure.c:1181
+msgid ""
+"\"correction\" automatically adjust exposure\n"
+"such that the input lightness is mapped to the target.\n"
+"\"measure\" simply shows how an input color is mapped by\n"
+" the exposure compensation and can be used to define a target."
+msgstr ""
+"\"Correction\" automatically adjust exposure\n"
+"such that the input lightness is mapped to the target.\n"
+"\"Measure\" simply shows how an input color is mapped by\n"
+"the exposure compensation and can be used to define a target."
+
+#: ../src/iop/exposure.c:1207
+msgid "L : \tN/A"
+msgstr "L : \tN/A"
+
+#: ../src/iop/exposure.c:1225
+msgid "the desired target exposure after mapping"
+msgstr "The desired target exposure after mapping"
+
+#: ../src/iop/filmic.c:177
+msgid "this module is deprecated. better use filmic rgb module instead."
+msgstr "This module is deprecated. Better use filmic rgb module instead."
+
+#: ../src/iop/filmic.c:304
+msgid "09 EV (low-key)"
+msgstr "09 EV (low-key)"
+
+#: ../src/iop/filmic.c:312
+msgid "10 EV (indoors)"
+msgstr "10 EV (indoors)"
+
+#: ../src/iop/filmic.c:320
+msgid "11 EV (dim outdoors)"
+msgstr "11 EV (dim outdoors)"
+
+#: ../src/iop/filmic.c:328
+msgid "12 EV (outdoors)"
+msgstr "12 EV (outdoors)"
+
+#: ../src/iop/filmic.c:336
+msgid "13 EV (bright outdoors)"
+msgstr "13 EV (bright outdoors)"
+
+#: ../src/iop/filmic.c:344
+msgid "14 EV (backlighting)"
+msgstr "14 EV (backlighting)"
+
+#: ../src/iop/filmic.c:352
+msgid "15 EV (sunset)"
+msgstr "15 EV (sunset)"
+
+#: ../src/iop/filmic.c:360
+msgid "16 EV (HDR)"
+msgstr "16 EV (HDR)"
+
+#: ../src/iop/filmic.c:368
+msgid "18 EV (HDR++)"
+msgstr "18 EV (HDR++)"
+
+#: ../src/iop/filmic.c:1480
+msgid "read-only graph, use the parameters below to set the nodes"
+msgstr "Read-only graph, use the parameters below to set the nodes"
+
+#: ../src/iop/filmic.c:1484
+msgctxt "section"
+msgid "logarithmic shaper"
+msgstr "Logarithmic shaper"
+
+#: ../src/iop/filmic.c:1492
+msgid ""
+"adjust to match the average luminance of the subject.\n"
+"except in back-lighting situations, this should be around 18%."
+msgstr ""
+"Adjust to match the average luminance of the subject.\n"
+"Except in back-lighting situations, this should be around 18%."
+
+#: ../src/iop/filmic.c:1504 ../src/iop/filmicrgb.c:4181
+msgid ""
+"number of stops between middle gray and pure white.\n"
+"this is a reading a lightmeter would give you on the scene.\n"
+"adjust so highlights clipping is avoided"
+msgstr ""
+"Number of stops between middle gray and pure white.\n"
+"This is a reading a lightmeter would give you on the scene.\n"
+"Adjust so highlights clipping is avoided"
+
+#: ../src/iop/filmic.c:1517 ../src/iop/filmicrgb.c:4192
+msgid ""
+"number of stops between middle gray and pure black.\n"
+"this is a reading a lightmeter would give you on the scene.\n"
+"increase to get more contrast.\n"
+"decrease to recover more details in low-lights."
+msgstr ""
+"Number of stops between middle gray and pure black.\n"
+"This is a reading a lightmeter would give you on the scene.\n"
+"Increase to get more contrast.\n"
+"Decrease to recover more details in low-lights."
+
+#: ../src/iop/filmic.c:1529
+msgid ""
+"enlarge or shrink the computed dynamic range.\n"
+"useful in conjunction with \"auto tune levels\"."
+msgstr ""
+"Enlarge or shrink the computed dynamic range.\n"
+"Useful in conjunction with \"auto tune levels\"."
+
+#: ../src/iop/filmic.c:1535 ../src/iop/filmicrgb.c:4206
+#: ../src/iop/profile_gamma.c:659
+msgid "auto tune levels"
+msgstr "Auto tune levels"
+
+#: ../src/iop/filmic.c:1538
+msgid ""
+"try to optimize the settings with some guessing.\n"
+"this will fit the luminance range inside the histogram bounds.\n"
+"works better for landscapes and evenly-lit pictures\n"
+"but fails for high-keys and low-keys."
+msgstr ""
+"Try to optimize the settings with some guessing.\n"
+"This will fit the luminance range inside the histogram bounds.\n"
+"Works better for landscapes and evenly-lit pictures\n"
+"but fails for high-keys and low-keys."
+
+#: ../src/iop/filmic.c:1543
+msgctxt "section"
+msgid "filmic S curve"
+msgstr "Filmic S curve"
+
+#: ../src/iop/filmic.c:1550 ../src/iop/filmicrgb.c:4293
+msgid ""
+"slope of the linear part of the curve\n"
+"affects mostly the mid-tones"
+msgstr ""
+"Slope of the linear part of the curve\n"
+"Affects mostly the mid-tones"
+
+#. geotagging
+#: ../src/iop/filmic.c:1557 ../src/iop/filmicrgb.c:4302
+#: ../src/libs/metadata_view.c:157
+msgid "latitude"
+msgstr "Latitude"
+
+#: ../src/iop/filmic.c:1560
+msgid ""
+"width of the linear domain in the middle of the curve.\n"
+"increase to get more contrast at the extreme luminances.\n"
+"this has no effect on mid-tones."
+msgstr ""
+"Width of the linear domain in the middle of the curve.\n"
+"Increase to get more contrast at the extreme luminances.\n"
+"This has no effect on mid-tones."
+
+#: ../src/iop/filmic.c:1567
+msgid "shadows/highlights balance"
+msgstr "Shadows/highlights balance"
+
+#: ../src/iop/filmic.c:1570 ../src/iop/filmicrgb.c:4313
+msgid ""
+"slides the latitude along the slope\n"
+"to give more room to shadows or highlights.\n"
+"use it if you need to protect the details\n"
+"at one extremity of the histogram."
+msgstr ""
+"Slides the latitude along the slope\n"
+"to give more room to shadows or highlights.\n"
+"Use it if you need to protect the details\n"
+"at one extremity of the histogram."
+
+#: ../src/iop/filmic.c:1580
+msgid ""
+"desaturates the input of the module globally.\n"
+"you need to set this value below 100%\n"
+"if the chrominance preservation is enabled."
+msgstr ""
+"Desaturates the input of the module globally.\n"
+"You need to set this value below 100%\n"
+"if the chrominance preservation is enabled."
+
+#: ../src/iop/filmic.c:1590
+msgid ""
+"desaturates the output of the module\n"
+"specifically at extreme luminances.\n"
+"decrease if shadows and/or highlights are over-saturated."
+msgstr ""
+"Desaturates the output of the module\n"
+"specifically at extreme luminances.\n"
+"Decrease if shadows and/or highlights are over-saturated."
+
+#. Add export intent combo
+#: ../src/iop/filmic.c:1600 ../src/libs/export.c:1242
+#: ../src/libs/print_settings.c:2323 ../src/libs/print_settings.c:2642
+#: ../src/views/darkroom.c:2510 ../src/views/lighttable.c:1186
+msgid "intent"
+msgstr "Intent"
+
+#: ../src/iop/filmic.c:1601
+msgid "contrasted"
+msgstr "Contrasted"
+
+#. cubic spline
+#: ../src/iop/filmic.c:1602
+msgid "faded"
+msgstr "Faded"
+
+#. centripetal spline
+#: ../src/iop/filmic.c:1603 ../src/iop/profile_gamma.c:621
+msgid "linear"
+msgstr "Linear"
+
+#. monotonic spline
+#: ../src/iop/filmic.c:1604
+msgid "optimized"
+msgstr "Optimized"
+
+#: ../src/iop/filmic.c:1606
+msgid "change this method if you see reversed contrast or faded blacks"
+msgstr "Change this method if you see reversed contrast or faded blacks"
+
+#. Preserve color
+#: ../src/iop/filmic.c:1610
+msgid "preserve the chrominance"
+msgstr "Preserve the chrominance"
+
+#: ../src/iop/filmic.c:1612
+msgid ""
+"ensure the original color are preserved.\n"
+"may reinforce chromatic aberrations.\n"
+"you need to manually tune the saturation when using this mode."
+msgstr ""
+"Ensure the original color are preserved.\n"
+"May reinforce chromatic aberrations.\n"
+"You need to manually tune the saturation when using this mode."
+
+#: ../src/iop/filmic.c:1622
+msgctxt "section"
+msgid "destination/display"
+msgstr "Destination/display"
+
+#: ../src/iop/filmic.c:1640 ../src/iop/filmicrgb.c:4332
+msgid ""
+"luminance of output pure black, this should be 0%\n"
+"except if you want a faded look"
+msgstr ""
+"Luminance of output pure black, this should be 0%\n"
+"except if you want a faded look"
+
+#: ../src/iop/filmic.c:1649 ../src/iop/filmicrgb.c:4339
+msgid ""
+"middle gray value of the target display or color space.\n"
+"you should never touch that unless you know what you are doing."
+msgstr ""
+"Middle gray value of the target display or color space.\n"
+"You should never touch that unless you know what you are doing."
+
+#: ../src/iop/filmic.c:1658 ../src/iop/filmicrgb.c:4346
+msgid ""
+"luminance of output pure white, this should be 100%\n"
+"except if you want a faded look"
+msgstr ""
+"Luminance of output pure white, this should be 100%\n"
+"except if you want a faded look"
+
+#: ../src/iop/filmic.c:1664
+msgid "target gamma"
+msgstr "Target gamma"
+
+#: ../src/iop/filmic.c:1666
+msgid ""
+"power or gamma of the transfer function\n"
+"of the display or color space.\n"
+"you should never touch that unless you know what you are doing."
+msgstr ""
+"Power or gamma of the transfer function\n"
+"of the display or color space.\n"
+"You should never touch that unless you know what you are doing."
+
+#: ../src/iop/filmicrgb.c:345
+msgid "filmic rgb"
+msgstr "Filmic rgb"
+
+#: ../src/iop/filmicrgb.c:350
+msgid "tone mapping|curve|view transform|contrast|saturation|highlights"
+msgstr "tone mapping|curve|view transform|contrast|saturation|highlights"
+
+#: ../src/iop/filmicrgb.c:355
+msgid ""
+"apply a view transform to prepare the scene-referred pipeline\n"
+"for display on SDR screens and paper prints\n"
+"while preventing clipping in non-destructive ways"
+msgstr ""
+"Apply a view transform to prepare the scene-referred pipeline\n"
+"for display on SDR screens and paper prints\n"
+"while preventing clipping in non-destructive ways"
+
+#: ../src/iop/filmicrgb.c:1289
+msgid ""
+"filmic highlights reconstruction failed to allocate memory, check your RAM "
+"settings"
+msgstr ""
+"Filmic highlights reconstruction failed to allocate memory, check your RAM "
+"settings"
+
+#: ../src/iop/filmicrgb.c:1921 ../src/iop/filmicrgb.c:2182
+msgid "filmic works only on RGB input"
+msgstr "Filmic works only on RGB input"
+
+#: ../src/iop/filmicrgb.c:2067
+msgid "filmic highlights reconstruction failed to allocate memory on GPU"
+msgstr "Filmic highlights reconstruction failed to allocate memory on GPU"
+
+#: ../src/iop/filmicrgb.c:3223
+msgid "look only"
+msgstr "Look only"
+
+#: ../src/iop/filmicrgb.c:3225
+msgid "look + mapping (lin)"
+msgstr "Look + mapping (lin)"
+
+#: ../src/iop/filmicrgb.c:3227
+msgid "look + mapping (log)"
+msgstr "Look + mapping (log)"
+
+#: ../src/iop/filmicrgb.c:3229
+msgid "dynamic range mapping"
+msgstr "Dynamic range mapping"
+
+#: ../src/iop/filmicrgb.c:3596
+#, c-format
+msgid "(%.0f %%)"
+msgstr "(%.0f %%)"
+
+#: ../src/iop/filmicrgb.c:3612
+#, no-c-format
+msgid "% display"
+msgstr "% display"
+
+#: ../src/iop/filmicrgb.c:3624
+msgid "EV scene"
+msgstr "EV scene"
+
+#: ../src/iop/filmicrgb.c:3628
+#, no-c-format
+msgid "% camera"
+msgstr "% camera"
+
+#. Page DISPLAY
+#: ../src/iop/filmicrgb.c:3664 ../src/iop/filmicrgb.c:4326
+msgid "display"
+msgstr "Display"
+
+#. axis legend
+#: ../src/iop/filmicrgb.c:3673
+msgid "(%)"
+msgstr "(%)"
+
+#. Page SCENE
+#: ../src/iop/filmicrgb.c:3682 ../src/iop/filmicrgb.c:4161
+msgid "scene"
+msgstr "Scene"
+
+#. axis legend
+#: ../src/iop/filmicrgb.c:3691
+msgid "(EV)"
+msgstr "(EV)"
+
+#. we are over the graph area
+#: ../src/iop/filmicrgb.c:4103
+msgid ""
+"use the parameters below to set the nodes.\n"
+"the bright curve is the filmic tone mapping curve\n"
+"the dark curve is the desaturation curve."
+msgstr ""
+"Use the parameters below to set the nodes.\n"
+"The bright curve is the filmic tone mapping curve.\n"
+"The dark curve is the desaturation curve."
+
+#: ../src/iop/filmicrgb.c:4109
+msgid "toggle axis labels and values display"
+msgstr "Toggle axis labels and values display"
+
+#: ../src/iop/filmicrgb.c:4113
+msgid ""
+"cycle through graph views.\n"
+"left click: cycle forward.\n"
+"right click: cycle backward.\n"
+"double-click: reset to look view."
+msgstr ""
+"Cycle through graph views.\n"
+"Left click: cycle forward.\n"
+"Right click: cycle backward.\n"
+"Double-click: reset to look view."
+
+#: ../src/iop/filmicrgb.c:4170
+#, no-c-format
+msgid ""
+"adjust to match the average luminance of the image's subject.\n"
+"the value entered here will then be remapped to 18.45%.\n"
+"decrease the value to increase the overall brightness."
+msgstr ""
+"Adjust to match the average luminance of the image's subject.\n"
+"The value entered here will then be remapped to 18.45%.\n"
+"Decrease the value to increase the overall brightness."
+
+#: ../src/iop/filmicrgb.c:4200
+msgid ""
+"symmetrically enlarge or shrink the computed dynamic range.\n"
+"useful to give a safety margin to extreme luminances."
+msgstr ""
+"Symmetrically enlarge or shrink the computed dynamic range.\n"
+"Useful to give a safety margin to extreme luminances."
+
+#: ../src/iop/filmicrgb.c:4207
+msgid ""
+"try to optimize the settings with some statistical assumptions.\n"
+"this will fit the luminance range inside the histogram bounds.\n"
+"works better for landscapes and evenly-lit pictures\n"
+"but fails for high-keys, low-keys and high-ISO pictures.\n"
+"this is not an artificial intelligence, but a simple guess.\n"
+"ensure you understand its assumptions before using it."
+msgstr ""
+"Try to optimize the settings with some statistical assumptions.\n"
+"This will fit the luminance range inside the histogram bounds.\n"
+"Works better for landscapes and evenly-lit pictures\n"
+"but fails for high-keys, low-keys and high-ISO pictures.\n"
+"This is not an artificial intelligence, but a simple guess.\n"
+"Ensure you understand its assumptions before using it."
+
+#. Page RECONSTRUCT
+#: ../src/iop/filmicrgb.c:4216
+msgid "reconstruct"
+msgstr "Reconstruct"
+
+#: ../src/iop/filmicrgb.c:4218
+msgctxt "section"
+msgid "highlights clipping"
+msgstr "Highlights clipping"
+
+#: ../src/iop/filmicrgb.c:4226
+msgid ""
+"set the exposure threshold upon which\n"
+"clipped highlights get reconstructed.\n"
+"values are relative to the scene white point.\n"
+"0 EV means the threshold is the same as the scene white point.\n"
+"decrease to include more areas,\n"
+"increase to exclude more areas."
+msgstr ""
+"Set the exposure threshold upon which\n"
+"clipped highlights get reconstructed.\n"
+"Values are relative to the scene white point.\n"
+"0 EV means the threshold is the same as the scene white point.\n"
+"Decrease to include more areas,\n"
+"increase to exclude more areas."
+
+#: ../src/iop/filmicrgb.c:4236
+msgid ""
+"soften the transition between clipped highlights and valid pixels.\n"
+"decrease to make the transition harder and sharper,\n"
+"increase to make the transition softer and blurrier."
+msgstr ""
+"Soften the transition between clipped highlights and valid pixels.\n"
+"Decrease to make the transition harder and sharper,\n"
+"increase to make the transition softer and blurrier."
+
+#: ../src/iop/filmicrgb.c:4242 ../src/iop/filmicrgb.c:4243
+msgid "display highlight reconstruction mask"
+msgstr "Display highlight reconstruction mask"
+
+#: ../src/iop/filmicrgb.c:4250
+msgctxt "section"
+msgid "balance"
+msgstr "Balance"
+
+#: ../src/iop/filmicrgb.c:4257
+#, no-c-format
+msgid ""
+"decide which reconstruction strategy to favor,\n"
+"between inpainting a smooth color gradient,\n"
+"or trying to recover the textured details.\n"
+"0% is an equal mix of both.\n"
+"increase if at least one RGB channel is not clipped.\n"
+"decrease if all RGB channels are clipped over large areas."
+msgstr ""
+"Decide which reconstruction strategy to favor,\n"
+"between inpainting a smooth color gradient,\n"
+"or trying to recover the textured details.\n"
+"0% is an equal mix of both.\n"
+"Increase if at least one RGB channel is not clipped.\n"
+"Decrease if all RGB channels are clipped over large areas."
+
+#: ../src/iop/filmicrgb.c:4268
+#, no-c-format
+msgid ""
+"decide which reconstruction strategy to favor,\n"
+"between blooming highlights like film does,\n"
+"or trying to recover sharp details.\n"
+"0% is an equal mix of both.\n"
+"increase if you want more details.\n"
+"decrease if you want more blur."
+msgstr ""
+"Decide which reconstruction strategy to favor,\n"
+"between blooming highlights like film does,\n"
+"or trying to recover sharp details.\n"
+"0% is an equal mix of both.\n"
+"Increase if you want more details.\n"
+"Decrease if you want more blur."
+
+#: ../src/iop/filmicrgb.c:4280
+#, no-c-format
+msgid ""
+"decide which reconstruction strategy to favor,\n"
+"between recovering monochromatic highlights,\n"
+"or trying to recover colorful highlights.\n"
+"0% is an equal mix of both.\n"
+"increase if you want more color.\n"
+"decrease if you see magenta or out-of-gamut highlights."
+msgstr ""
+"Decide which reconstruction strategy to favor,\n"
+"between recovering monochromatic highlights,\n"
+"or trying to recover colorful highlights.\n"
+"0% is an equal mix of both.\n"
+"Increase if you want more color.\n"
+"Decrease if you see magenta or out-of-gamut highlights."
+
+#. Page LOOK
+#: ../src/iop/filmicrgb.c:4288
+msgid "look"
+msgstr "Look"
+
+#: ../src/iop/filmicrgb.c:4298
+msgid ""
+"equivalent to paper grade in analog.\n"
+"increase to make highlights brighter and less compressed.\n"
+"decrease to mute highlights."
+msgstr ""
+"Equivalent to paper grade in analog.\n"
+"Increase to make highlights brighter and less compressed.\n"
+"Decrease to mute highlights."
+
+#: ../src/iop/filmicrgb.c:4306
+msgid ""
+"width of the linear domain in the middle of the curve,\n"
+"increase to get more contrast and less desaturation at extreme luminances,\n"
+"decrease otherwise. no desaturation happens in the latitude range.\n"
+"this has no effect on mid-tones."
+msgstr ""
+"Width of the linear domain in the middle of the curve,\n"
+"increase to get more contrast and less desaturation at extreme luminances,\n"
+"decrease otherwise. No desaturation happens in the latitude range.\n"
+"This has no effect on mid-tones."
+
+#: ../src/iop/filmicrgb.c:4321 ../src/iop/filmicrgb.c:4467
+msgid ""
+"desaturates the output of the module\n"
+"specifically at extreme luminances.\n"
+"increase if shadows and/or highlights are under-saturated."
+msgstr ""
+"Desaturates the output of the module\n"
+"specifically at extreme luminances.\n"
+"Increase if shadows and/or highlights are under-saturated."
+
+#. Page OPTIONS
+#: ../src/iop/filmicrgb.c:4350
+msgid "options"
+msgstr "Options"
+
+#: ../src/iop/filmicrgb.c:4355
+msgid ""
+"v3 is darktable 3.0 desaturation method, same as color balance.\n"
+"v4 is a newer desaturation method, based on spectral purity of light."
+msgstr ""
+"V3 is Darktable 3.0 desaturation method, same as color balance.\n"
+"V4 is a newer desaturation method, based on spectral purity of light."
+
+#: ../src/iop/filmicrgb.c:4359
+msgid ""
+"ensure the original colors are preserved.\n"
+"may reinforce chromatic aberrations and chroma noise,\n"
+"so ensure they are properly corrected elsewhere."
+msgstr ""
+"Ensure the original colors are preserved.\n"
+"May reinforce chromatic aberrations and chroma noise,\n"
+"so ensure they are properly corrected elsewhere."
+
+#: ../src/iop/filmicrgb.c:4366
+msgid ""
+"choose the desired curvature of the filmic spline in highlights.\n"
+"hard uses a high curvature resulting in more tonal compression.\n"
+"soft uses a low curvature resulting in less tonal compression."
+msgstr ""
+"Choose the desired curvature of the filmic spline in highlights.\n"
+"Hard uses a high curvature resulting in more tonal compression.\n"
+"Soft uses a low curvature resulting in less tonal compression."
+
+#: ../src/iop/filmicrgb.c:4371
+msgid ""
+"choose the desired curvature of the filmic spline in shadows.\n"
+"hard uses a high curvature resulting in more tonal compression.\n"
+"soft uses a low curvature resulting in less tonal compression."
+msgstr ""
+"Choose the desired curvature of the filmic spline in shadows.\n"
+"Hard uses a high curvature resulting in more tonal compression.\n"
+"Soft uses a low curvature resulting in less tonal compression."
+
+#: ../src/iop/filmicrgb.c:4378
+#, no-c-format
+msgid ""
+"enable to input custom middle-gray values.\n"
+"this is not recommended in general.\n"
+"fix the global exposure in the exposure module instead.\n"
+"disable to use standard 18.45% middle gray."
+msgstr ""
+"Enable to input custom middle-gray values.\n"
+"This is not recommended in general.\n"
+"Fix the global exposure in the Exposure module instead.\n"
+"Disable to use standard 18.45% middle gray."
+
+#: ../src/iop/filmicrgb.c:4385
+msgid ""
+"enable to auto-set the look hardness depending on the scene white and black "
+"points.\n"
+"this keeps the middle gray on the identity line and improves fast tuning.\n"
+"disable if you want a manual control."
+msgstr ""
+"Enable to auto-set the look hardness depending on the scene white and black "
+"points.\n"
+"This keeps the middle gray on the identity line and improves fast tuning.\n"
+"Disable if you want a manual control."
+
+#: ../src/iop/filmicrgb.c:4391
+msgid ""
+"run extra passes of chromaticity reconstruction.\n"
+"more iterations means more color propagation from neighborhood.\n"
+"this will be slower but will yield more neutral highlights.\n"
+"it also helps with difficult cases of magenta highlights."
+msgstr ""
+"Run extra passes of chromaticity reconstruction.\n"
+"More iterations means more color propagation from neighborhood.\n"
+"This will be slower but will yield more neutral highlights.\n"
+"It also helps with difficult cases of magenta highlights."
+
+#: ../src/iop/filmicrgb.c:4398
+msgid ""
+"add statistical noise in reconstructed highlights.\n"
+"this avoids highlights to look too smooth\n"
+"when the picture is noisy overall,\n"
+"so they blend with the rest of the picture."
+msgstr ""
+"Add statistical noise in reconstructed highlights.\n"
+"This avoids highlights to look too smooth\n"
+"when the picture is noisy overall,\n"
+"so they blend with the rest of the picture."
+
+#: ../src/iop/filmicrgb.c:4405
+msgid ""
+"choose the statistical distribution of noise.\n"
+"this is useful to match natural sensor noise pattern."
+msgstr ""
+"Choose the statistical distribution of noise.\n"
+"This is useful to match natural sensor noise pattern."
+
+#: ../src/iop/filmicrgb.c:4473
+msgid "mid-tones saturation"
+msgstr "Mid-tones saturation"
+
+#: ../src/iop/filmicrgb.c:4474
+msgid ""
+"desaturates the output of the module\n"
+"specifically at medium luminances.\n"
+"increase if midtones are under-saturated."
+msgstr ""
+"Desaturates the output of the module\n"
+"specifically at medium luminances.\n"
+"Increase if midtones are under-saturated."
+
+#: ../src/iop/finalscale.c:39
+msgctxt "modulename"
+msgid "scale into final size"
+msgstr "Scale into final size"
+
+#: ../src/iop/flip.c:80
+msgid "rotation|flip"
+msgstr "rotation|flip"
+
+#: ../src/iop/flip.c:110
+msgid "flip or rotate image by step of 90 degrees"
+msgstr "Flip or rotate image by step of 90 degrees"
+
+#: ../src/iop/flip.c:477
+msgid "no rotation"
+msgstr "No rotation"
+
+#: ../src/iop/flip.c:481 ../src/iop/flip.c:624
+msgid "flip horizontally"
+msgstr "Flip horizontally"
+
+#: ../src/iop/flip.c:485 ../src/iop/flip.c:628
+msgid "flip vertically"
+msgstr "Flip vertically"
+
+#: ../src/iop/flip.c:489
+msgid "rotate by -90 degrees"
+msgstr "Rotate by -90 degrees"
+
+#: ../src/iop/flip.c:493
+msgid "rotate by  90 degrees"
+msgstr "Rotate by  90 degrees"
+
+#: ../src/iop/flip.c:497
+msgid "rotate by 180 degrees"
+msgstr "Rotate by 180 degrees"
+
+#: ../src/iop/flip.c:612
+msgid "transform"
+msgstr "Transform"
+
+#: ../src/iop/flip.c:616
+msgid "rotate 90 degrees CCW"
+msgstr "Rotate 90 degrees CCW"
+
+#: ../src/iop/flip.c:620
+msgid "rotate 90 degrees CW"
+msgstr "Rotate 90 degrees CW"
+
+#: ../src/iop/gamma.c:44
+msgctxt "modulename"
+msgid "display encoding"
+msgstr "Display encoding"
+
+#: ../src/iop/globaltonemap.c:100
+msgid "global tonemap"
+msgstr "Global tonemap"
+
+#: ../src/iop/globaltonemap.c:105
+msgid "this module is deprecated. please use the filmic rgb module instead."
+msgstr "This module is deprecated. Please use the filmic rgb module instead."
+
+#: ../src/iop/globaltonemap.c:625 ../src/libs/filters/colors.c:259
+msgid "operator"
+msgstr "Operator"
+
+#: ../src/iop/globaltonemap.c:626
+msgid "the global tonemap operator"
+msgstr "The global tonemap operator"
+
+#: ../src/iop/globaltonemap.c:629
+msgid ""
+"the bias for tonemapper controls the linearity, the higher the more details "
+"in blacks"
+msgstr ""
+"The bias for tonemapper controls the linearity, the higher the more details "
+"in blacks"
+
+#: ../src/iop/globaltonemap.c:633
+msgid "the target light for tonemapper specified as cd/m2"
+msgstr "The target light for tonemapper specified as cd/m2"
+
+#: ../src/iop/graduatednd.c:67
+msgid "neutral gray ND2 (soft)"
+msgstr "Neutral gray ND2 (soft)"
+
+#: ../src/iop/graduatednd.c:70
+msgid "neutral gray ND4 (soft)"
+msgstr "Neutral gray ND4 (soft)"
+
+#: ../src/iop/graduatednd.c:73
+msgid "neutral gray ND8 (soft)"
+msgstr "Neutral gray ND8 (soft)"
+
+#: ../src/iop/graduatednd.c:76
+msgid "neutral gray ND2 (hard)"
+msgstr "Neutral gray ND2 (hard)"
+
+#: ../src/iop/graduatednd.c:80
+msgid "neutral gray ND4 (hard)"
+msgstr "Neutral gray ND4 (hard)"
+
+#: ../src/iop/graduatednd.c:83
+msgid "neutral gray ND8 (hard)"
+msgstr "Neutral gray ND8 (hard)"
+
+#: ../src/iop/graduatednd.c:87
+msgid "orange ND2 (soft)"
+msgstr "Orange ND2 (soft)"
+
+#: ../src/iop/graduatednd.c:90
+msgid "yellow ND2 (soft)"
+msgstr "Yellow ND2 (soft)"
+
+#: ../src/iop/graduatednd.c:94
+msgid "purple ND2 (soft)"
+msgstr "Purple ND2 (soft)"
+
+#: ../src/iop/graduatednd.c:98
+msgid "green ND2 (soft)"
+msgstr "Green ND2 (soft)"
+
+#: ../src/iop/graduatednd.c:102
+msgid "red ND2 (soft)"
+msgstr "Red ND2 (soft)"
+
+#: ../src/iop/graduatednd.c:105
+msgid "blue ND2 (soft)"
+msgstr "Blue ND2 (soft)"
+
+#: ../src/iop/graduatednd.c:109
+msgid "brown ND4 (soft)"
+msgstr "Brown ND4 (soft)"
+
+#: ../src/iop/graduatednd.c:140
+msgid "graduated density"
+msgstr "Graduated density"
+
+#: ../src/iop/graduatednd.c:145
+msgid "simulate an optical graduated neutral density filter"
+msgstr "Simulate an optical graduated neutral density filter"
+
+#: ../src/iop/graduatednd.c:1114
+msgid "the density in EV for the filter"
+msgstr "The density in EV for the filter"
+
+#: ../src/iop/graduatednd.c:1119
+#, no-c-format
+msgid ""
+"hardness of graduation:\n"
+"0% = soft, 100% = hard"
+msgstr ""
+"Hardness of graduation:\n"
+"0% = soft, 100% = hard"
+
+#: ../src/iop/graduatednd.c:1123
+msgid "rotation of filter -180 to 180 degrees"
+msgstr "Rotation of filter -180 to 180 degrees"
+
+#: ../src/iop/graduatednd.c:1136
+msgid "select the hue tone of filter"
+msgstr "Select the hue tone of filter"
+
+#: ../src/iop/graduatednd.c:1142
+msgid "select the saturation of filter"
+msgstr "Select the saturation of filter"
+
+#: ../src/iop/graduatednd.c:1153
+#, c-format
+msgid "[%s on nodes] change line rotation"
+msgstr "[%s on nodes] change line rotation"
+
+#: ../src/iop/graduatednd.c:1154
+#, c-format
+msgid "[%s on line] move line"
+msgstr "[%s on line] move line"
+
+#: ../src/iop/graduatednd.c:1156
+#, c-format
+msgid "[%s on line] change density"
+msgstr "[%s on line] change density"
+
+#: ../src/iop/graduatednd.c:1158
+#, c-format
+msgid "[%s on line] change hardness"
+msgstr "[%s on line] change hardness"
+
+#: ../src/iop/grain.c:419
+msgid "grain"
+msgstr "Grain"
+
+#: ../src/iop/grain.c:424
+msgid "simulate silver grains from film"
+msgstr "Simulate silver grains from film"
+
+#: ../src/iop/grain.c:568
+msgid "the grain size (~ISO of the film)"
+msgstr "The grain size (~ISO of the film)"
+
+#: ../src/iop/grain.c:572
+msgid "the strength of applied grain"
+msgstr "The strength of applied grain"
+
+#: ../src/iop/grain.c:576
+msgid ""
+"amount of mid-tones bias from the photographic paper response modeling. the "
+"greater the bias, the more pronounced the fall off of the grain in shadows "
+"and highlights"
+msgstr ""
+"Amount of mid-tones bias from the photographic paper response modeling. The "
+"greater the bias, the more pronounced the fall off of the grain in shadows "
+"and highlights"
+
+#: ../src/iop/hazeremoval.c:100
+msgid "haze removal"
+msgstr "Haze removal"
+
+#: ../src/iop/hazeremoval.c:106
+msgid "dehaze|defog|smoke|smog"
+msgstr "dehaze|defog|smoke|smog"
+
+#: ../src/iop/hazeremoval.c:111
+msgid "remove fog and atmospheric hazing from pictures"
+msgstr "Remove fog and atmospheric hazing from pictures"
+
+#: ../src/iop/hazeremoval.c:202
+msgid "amount of haze reduction"
+msgstr "Amount of haze reduction"
+
+#: ../src/iop/hazeremoval.c:204
+msgid "distance"
+msgstr "Distance"
+
+#: ../src/iop/hazeremoval.c:206
+msgid "limit haze removal up to a specific spatial depth"
+msgstr "Limit haze removal up to a specific spatial depth"
+
+#: ../src/iop/highlights.c:173
+msgid "highlight reconstruction"
+msgstr "Highlight reconstruction"
+
+#: ../src/iop/highlights.c:178
+msgid "avoid magenta highlights and try to recover highlights colors"
+msgstr "Avoid magenta highlights and try to recover highlights colors"
+
+#: ../src/iop/highlights.c:181 ../src/iop/hotpixels.c:75
+msgid "reconstruction, raw"
+msgstr "Reconstruction, raw"
+
+#: ../src/iop/highlights.c:935
+msgid ""
+"highlights: mode not available for this type of image. falling back to "
+"inpaint opposed."
+msgstr ""
+"Highlights: mode not available for this type of image. Falling back to "
+"inpaint opposed."
+
+#: ../src/iop/highlights.c:1132
+msgid "highlight reconstruction method"
+msgstr "Highlight reconstruction method"
+
+#: ../src/iop/highlights.c:1137
+msgid ""
+"manually adjust the clipping threshold mostly used against magenta "
+"highlights\n"
+"the mask icon shows the clipped areas.\n"
+"you might use this for tuning 'laplacian', 'inpaint opposed' or "
+"'segmentation' modes,\n"
+"especially if camera white point is incorrect."
+msgstr ""
+"Manually adjust the clipping threshold mostly used against magenta "
+"highlights.\n"
+"The mask icon shows the clipped areas.\n"
+"You might use this for tuning 'laplacian', 'inpaint opposed' or "
+"'segmentation' modes,\n"
+"especially if camera white point is incorrect."
+
+#: ../src/iop/highlights.c:1148
+msgid ""
+"combine closely related clipped segments by morphological operations.\n"
+"the mask button shows the exact positions of resulting segment borders."
+msgstr ""
+"Combine closely related clipped segments by morphological operations.\n"
+"The mask button shows the exact positions of resulting segment borders."
+
+#: ../src/iop/highlights.c:1156
+msgid ""
+"select inpainting after segmentation analysis.\n"
+"increase to favour candidates found in segmentation analysis, decrease for "
+"opposed means inpainting.\n"
+"the mask button shows segments that are considered to have a good candidate."
+msgstr ""
+"Select inpainting after segmentation analysis.\n"
+"Increase to favour candidates found in segmentation analysis, decrease for "
+"opposed means inpainting.\n"
+"The mask button shows segments that are considered to have a good candidate."
+
+#: ../src/iop/highlights.c:1167
+msgid ""
+"approximate lost data in regions with all photosites clipped, the effect "
+"depends on segment size and border gradients.\n"
+"choose a mode tuned for segment size or the generic mode that tries to find "
+"best settings for every segment.\n"
+"small means areas with a diameter less than 25 pixels, large is best for "
+"greater than 100.\n"
+"the flat modes ignore narrow unclipped structures (like powerlines) to keep "
+"highlights rebuilt and avoid gradients."
+msgstr ""
+"Approximate lost data in regions with all photosites clipped, the effect "
+"depends on segment size and border gradients.\n"
+"Choose a mode tuned for segment size or the generic mode that tries to find "
+"best settings for every segment.\n"
+"Small means areas with a diameter less than 25 pixels, large is best for "
+"greater than 100.\n"
+"The flat modes ignore narrow unclipped structures (like powerlines) to keep "
+"highlights rebuilt and avoid gradients."
+
+#: ../src/iop/highlights.c:1173
+msgid ""
+"set strength of rebuilding in regions with all photosites clipped.\n"
+"the mask buttons shows the effect that is added to already reconstructed "
+"data."
+msgstr ""
+"Set strength of rebuilding in regions with all photosites clipped.\n"
+"The mask buttons shows the effect that is added to already reconstructed "
+"data."
+
+#: ../src/iop/highlights.c:1183
+msgid ""
+"add noise to visually blend the reconstructed areas\n"
+"into the rest of the noisy image. useful at high ISO."
+msgstr ""
+"Add noise to visually blend the reconstructed areas\n"
+"into the rest of the noisy image. Useful at high ISO."
+
+#: ../src/iop/highlights.c:1187
+msgid ""
+"increase if magenta highlights don't get fully corrected\n"
+"each new iteration brings a performance penalty."
+msgstr ""
+"Increase if magenta highlights don't get fully corrected\n"
+"Each new iteration brings a performance penalty."
+
+#: ../src/iop/highlights.c:1192
+msgid ""
+"increase if magenta highlights don't get fully corrected.\n"
+"this may produce non-smooth boundaries between valid and clipped regions."
+msgstr ""
+"Increase if magenta highlights don't get fully corrected.\n"
+"This may produce non-smooth boundaries between valid and clipped regions."
+
+#: ../src/iop/highlights.c:1196
+msgid ""
+"increase to correct larger clipped areas.\n"
+"large values bring huge performance penalties"
+msgstr ""
+"Increase to correct larger clipped areas.\n"
+"Large values bring huge performance penalties"
+
+#: ../src/iop/highlights.c:1200
+msgid "this module only works with non-monochrome RAW and sRAW"
+msgstr "This module only works with non-monochrome RAW and sRAW"
+
+#: ../src/iop/highpass.c:72
+msgid "highpass"
+msgstr "Highpass"
+
+#: ../src/iop/highpass.c:77
+msgid "isolate high frequencies in the image"
+msgstr "Isolate high frequencies in the image"
+
+#: ../src/iop/highpass.c:79 ../src/iop/lowpass.c:135
+msgid "linear or non-linear, Lab, scene-referred"
+msgstr "Linear or non-linear, Lab, scene-referred"
+
+#: ../src/iop/highpass.c:80 ../src/iop/lowpass.c:136 ../src/iop/sharpen.c:96
+msgid "frequential, Lab"
+msgstr "Frequential, Lab"
+
+#: ../src/iop/highpass.c:81 ../src/iop/lowpass.c:137
+msgid "special, Lab, scene-referred"
+msgstr "Special, Lab, scene-referred"
+
+#: ../src/iop/highpass.c:375
+msgid "the sharpness of highpass filter"
+msgstr "The sharpness of highpass filter"
+
+#: ../src/iop/highpass.c:379
+msgid "the contrast of highpass filter"
+msgstr "The contrast of highpass filter"
+
+#: ../src/iop/hotpixels.c:67
+msgid "hot pixels"
+msgstr "Hot pixels"
+
+#: ../src/iop/hotpixels.c:72
+msgid "remove abnormally bright pixels by dampening them with neighbors"
+msgstr "Remove abnormally bright pixels by dampening them with neighbors"
+
+#: ../src/iop/hotpixels.c:363
+#, c-format
+msgid "fixed %d pixel"
+msgid_plural "fixed %d pixels"
+msgstr[0] "Fixed %d pixel"
+msgstr[1] "Fixed %d pixels"
+
+#: ../src/iop/hotpixels.c:386
+msgid "lower threshold for hot pixel"
+msgstr "Lower threshold for hot pixel"
+
+#: ../src/iop/hotpixels.c:390
+msgid "strength of hot pixel correction"
+msgstr "Strength of hot pixel correction"
+
+#: ../src/iop/hotpixels.c:406
+msgid ""
+"hot pixel correction\n"
+"only works for raw images."
+msgstr ""
+"Hot pixel correction\n"
+"Only works for raw images."
+
+#: ../src/iop/invert.c:92 ../src/iop/invert.c:427
+#, c-format
+msgid "`%s' color matrix not found for 4bayer image"
+msgstr "`%s' color matrix not found for 4bayer image"
+
+#: ../src/iop/invert.c:108
+msgid "invert"
+msgstr "Invert"
+
+#: ../src/iop/invert.c:113
+msgid "this module is deprecated. please use the negadoctor module instead."
+msgstr "This module is deprecated. Please use the negadoctor module instead."
+
+#: ../src/iop/invert.c:118
+msgid "invert film negatives"
+msgstr "Invert film negatives"
+
+#: ../src/iop/invert.c:120 ../src/iop/invert.c:122
+msgid "linear, raw, display-referred"
+msgstr "Linear, raw, display-referred"
+
+#. Here we could provide more for monochrome special cases. As no monochrome camera
+#. has a bayer sensor we don't need g->RGB_to_CAM and g->CAM_to_RGB corrections
+#: ../src/iop/invert.c:412
+msgid "brightness of film material"
+msgstr "Brightness of film material"
+
+#: ../src/iop/invert.c:416
+msgid "color of film material"
+msgstr "Color of film material"
+
+#: ../src/iop/invert.c:500 ../src/iop/negadoctor.c:847
+msgid "pick color of film material from image"
+msgstr "Pick color of film material from image"
+
+#: ../src/iop/invert.c:502
+msgid "select color of film material"
+msgstr "Select color of film material"
+
+#: ../src/iop/lens.cc:200
+msgid "lens correction"
+msgstr "Lens correction"
+
+#: ../src/iop/lens.cc:205
+msgid "vignette|chromatic aberrations|distortion"
+msgstr "vignette|chromatic aberrations|distortion"
+
+#: ../src/iop/lens.cc:210
+msgid "correct lenses optical flaws"
+msgstr "Correct lenses optical flaws"
+
+#: ../src/iop/lens.cc:213
+msgid "geometric and reconstruction, RGB"
+msgstr "Geometric and reconstruction, RGB"
+
+#: ../src/iop/lens.cc:2611
+msgid "lensfun"
+msgstr "Lensfun"
+
+#: ../src/iop/lens.cc:2797
+#, c-format
+msgid ""
+"maker:\t\t%s\n"
+"model:\t\t%s%s\n"
+"mount:\t\t%s\n"
+"crop factor:\t%.1f"
+msgstr ""
+"Maker:\t\t%s\n"
+"Model:\t\t%s%s\n"
+"Mount:\t\t%s\n"
+"Crop factor:\t%.1f"
+
+#: ../src/iop/lens.cc:3045
+#, c-format
+msgid ""
+"maker:\t\t%s\n"
+"model:\t\t%s\n"
+"focal range:\t%s\n"
+"aperture:\t%s\n"
+"crop factor:\t%.1f\n"
+"type:\t\t%s\n"
+"mounts:\t%s"
+msgstr ""
+"Maker:\t\t%s\n"
+"Model:\t\t%s\n"
+"Focal range:\t%s\n"
+"Aperture:\t%s\n"
+"Crop factor:\t%.1f\n"
+"Type:\t\t%s\n"
+"Mounts:\t%s"
+
+#: ../src/iop/lens.cc:3091
+msgid "focal length (mm)"
+msgstr "Focal length (mm)"
+
+#: ../src/iop/lens.cc:3117
+msgid "f/"
+msgstr "F/"
+
+#: ../src/iop/lens.cc:3118
+msgid "f-number (aperture)"
+msgstr "F-number (aperture)"
+
+#: ../src/iop/lens.cc:3134
+msgid "d"
+msgstr "D"
+
+#: ../src/iop/lens.cc:3135
+msgid "distance to subject"
+msgstr "Distance to subject"
+
+#: ../src/iop/lens.cc:3303
+msgid "camera/lens not found"
+msgstr "Camera/lens not found"
+
+#: ../src/iop/lens.cc:3304
+msgid ""
+"please select your lens manually\n"
+"you might also want to check if your lensfun database is up-to-date\n"
+"by running lensfun-update-data"
+msgstr ""
+"Please select your lens manually\n"
+"You might also want to check if your Lensfun database is up-to-date\n"
+"by running lensfun-update-data"
+
+#: ../src/iop/lens.cc:3463
+msgid "distortion & TCA"
+msgstr "Distortion & TCA"
+
+#: ../src/iop/lens.cc:3469
+msgid "distortion & vignetting"
+msgstr "Distortion & vignetting"
+
+#: ../src/iop/lens.cc:3475
+msgid "TCA & vignetting"
+msgstr "TCA & vignetting"
+
+#: ../src/iop/lens.cc:3481
+msgid "only distortion"
+msgstr "Only distortion"
+
+#: ../src/iop/lens.cc:3487
+msgid "only TCA"
+msgstr "Only TCA"
+
+#: ../src/iop/lens.cc:3493
+msgid "only vignetting"
+msgstr "Only vignetting"
+
+#: ../src/iop/lens.cc:3506
+msgid "camera model"
+msgstr "Camera model"
+
+#: ../src/iop/lens.cc:3511
+msgid "find camera"
+msgstr "Find camera"
+
+#: ../src/iop/lens.cc:3526
+msgid "find lens"
+msgstr "Find lens"
+
+#: ../src/iop/lens.cc:3559
+msgid "target geometry"
+msgstr "Target geometry"
+
+#: ../src/iop/lens.cc:3560
+msgid "rectilinear"
+msgstr "Rectilinear"
+
+#: ../src/iop/lens.cc:3561
+msgid "fish-eye"
+msgstr "Fish-eye"
+
+#: ../src/iop/lens.cc:3562
+msgid "panoramic"
+msgstr "Panoramic"
+
+#: ../src/iop/lens.cc:3563
+msgid "equirectangular"
+msgstr "Equirectangular"
+
+#: ../src/iop/lens.cc:3565
+msgid "orthographic"
+msgstr "Orthographic"
+
+#: ../src/iop/lens.cc:3566
+msgid "stereographic"
+msgstr "Stereographic"
+
+#: ../src/iop/lens.cc:3567
+msgid "equisolid angle"
+msgstr "Equisolid angle"
+
+#: ../src/iop/lens.cc:3568
+msgid "thoby fish-eye"
+msgstr "Thoby fish-eye"
+
+#. scale
+#: ../src/iop/lens.cc:3575 ../src/iop/vignette.c:967
+#: ../src/iop/watermark.c:1136 ../src/libs/export.c:1171
+msgid "scale"
+msgstr "Scale"
+
+#: ../src/iop/lens.cc:3580
+msgid "auto scale"
+msgstr "Auto scale"
+
+#: ../src/iop/lens.cc:3584 ../src/libs/modulegroups.c:2320
+msgid "correct"
+msgstr "Correct"
+
+#: ../src/iop/lens.cc:3585
+msgid "distort"
+msgstr "Distort"
+
+#: ../src/iop/lens.cc:3586
+msgid "correct distortions or apply them"
+msgstr "Correct distortions or apply them"
+
+#: ../src/iop/lens.cc:3593
+msgid "transversal chromatic aberration red"
+msgstr "Transversal Chromatic Aberration red"
+
+#: ../src/iop/lens.cc:3597
+msgid "transversal chromatic aberration blue"
+msgstr "Transversal Chromatic Aberration blue"
+
+#: ../src/iop/lens.cc:3606
+msgid "tune the warp and chromatic aberration correction"
+msgstr "Tune the warp and chromatic aberration correction"
+
+#: ../src/iop/lens.cc:3610
+msgid "tune the vignette correction"
+msgstr "Tune the vignette correction"
+
+#: ../src/iop/lens.cc:3617
+msgid "override automatic scale"
+msgstr "Override automatic scale"
+
+#: ../src/iop/lens.cc:3631
+msgid "which corrections to apply"
+msgstr "Which corrections to apply"
+
+#: ../src/iop/lens.cc:3655
+msgid "corrections done: "
+msgstr "Corrections done: "
+
+#: ../src/iop/lens.cc:3657
+msgid "which corrections have actually been done"
+msgstr "Which corrections have actually been done"
+
+#: ../src/iop/levels.c:109
+msgid "this module is deprecated. please use the RGB levels module instead."
+msgstr "This module is deprecated. Please use the RGB levels module instead."
+
+#: ../src/iop/levels.c:114 ../src/iop/levels.c:625 ../src/iop/rgblevels.c:982
+#: ../src/iop/rgblevels.c:1012
+msgid "levels"
+msgstr "Levels"
+
+#: ../src/iop/levels.c:134
+msgid "adjust black, white and mid-gray points"
+msgstr "Adjust black, white and mid-gray points"
+
+#: ../src/iop/levels.c:623 ../src/iop/rgblevels.c:1014
+msgid ""
+"drag handles to set black, gray, and white points. operates on L channel."
+msgstr ""
+"Drag handles to set black, gray, and white points. Operates on L channel."
+
+#: ../src/iop/levels.c:637 ../src/iop/rgblevels.c:1050
+msgid "apply auto levels"
+msgstr "Apply auto levels"
+
+#: ../src/iop/levels.c:641 ../src/iop/rgblevels.c:1025
+msgid "pick black point from image"
+msgstr "Pick black point from image"
+
+#: ../src/iop/levels.c:645 ../src/iop/rgblevels.c:1031
+msgid "pick medium gray point from image"
+msgstr "Pick medium gray point from image"
+
+#: ../src/iop/levels.c:649 ../src/iop/rgblevels.c:1037
+msgid "pick white point from image"
+msgstr "Pick white point from image"
+
+#: ../src/iop/levels.c:662 ../src/iop/rgblevels.c:934
+msgid "black"
+msgstr "Black"
+
+#: ../src/iop/levels.c:663
+msgid "black percentile"
+msgstr "Black percentile"
+
+#: ../src/iop/levels.c:667
+msgid "gray percentile"
+msgstr "Gray percentile"
+
+#: ../src/iop/levels.c:670 ../src/iop/rgblevels.c:936
+msgid "white"
+msgstr "White"
+
+#: ../src/iop/levels.c:671
+msgid "white percentile"
+msgstr "White percentile"
+
+#: ../src/iop/liquify.c:290
+msgid "liquify"
+msgstr "Liquify"
+
+#: ../src/iop/liquify.c:295
+msgid "distort parts of the image"
+msgstr "Distort parts of the image"
+
+#: ../src/iop/liquify.c:3014
+msgid "click to edit nodes"
+msgstr "Click to edit nodes"
+
+#: ../src/iop/liquify.c:3717
+msgid ""
+"<b>add point</b>: click and drag\n"
+"<b>size</b>: scroll - <b>strength</b>: shift+scroll - <b>direction</b>: "
+"ctrl+scroll"
+msgstr ""
+"<b>Add point</b>: click and drag\n"
+"<b>Size</b>: scroll - <b>Strength</b>: Shift+scroll - <b>Direction</b>: "
+"Ctrl+scroll"
+
+#: ../src/iop/liquify.c:3720
+msgid ""
+"<b>add line</b>: click\n"
+"<b>size</b>: scroll - <b>strength</b>: shift+scroll - <b>direction</b>: "
+"ctrl+scroll"
+msgstr ""
+"<b>Add line</b>: click\n"
+"<b>Size</b>: scroll - <b>Strength</b>: Shift+scroll - <b>Direction</b>: "
+"Ctrl+scroll"
+
+#: ../src/iop/liquify.c:3723
+msgid ""
+"<b>add curve</b>: click\n"
+"<b>size</b>: scroll - <b>strength</b>: shift+scroll - <b>direction</b>: "
+"ctrl+scroll"
+msgstr ""
+"<b>Add curve</b>: click\n"
+"<b>Size</b>: scroll - <b>Strength</b>: Shift+scroll - <b>Direction</b>: "
+"Ctrl+scroll"
+
+#: ../src/iop/liquify.c:3774
+msgid ""
+"use a tool to add warps\n"
+"<b>remove a warp</b>: right-click"
+msgstr ""
+"Use a tool to add warps\n"
+"<b>Remove a warp</b>: right-click"
+
+#: ../src/iop/liquify.c:3777
+msgid "warps|nodes count:"
+msgstr "Warps|nodes count:"
+
+#: ../src/iop/liquify.c:3786
+msgid "edit, add and delete nodes"
+msgstr "Edit, add and delete nodes"
+
+#: ../src/iop/liquify.c:3791 ../src/iop/liquify.c:3797
+#: ../src/iop/liquify.c:3803 ../src/iop/retouch.c:2238
+#: ../src/iop/retouch.c:2242 ../src/iop/retouch.c:2246
+#: ../src/iop/retouch.c:2250 ../src/iop/spots.c:883 ../src/iop/spots.c:888
+#: ../src/iop/spots.c:893 ../src/libs/masks.c:1932 ../src/libs/masks.c:1941
+#: ../src/libs/masks.c:1950 ../src/libs/masks.c:1959 ../src/libs/masks.c:1968
+msgid "shapes"
+msgstr "Shapes"
+
+#: ../src/iop/liquify.c:3792
+msgid "draw curves"
+msgstr "Draw curves"
+
+#: ../src/iop/liquify.c:3792
+msgid "draw multiple curves"
+msgstr "Draw multiple curves"
+
+#: ../src/iop/liquify.c:3798
+msgid "draw lines"
+msgstr "Draw lines"
+
+#: ../src/iop/liquify.c:3798
+msgid "draw multiple lines"
+msgstr "Draw multiple lines"
+
+#: ../src/iop/liquify.c:3804
+msgid "draw points"
+msgstr "Draw points"
+
+#: ../src/iop/liquify.c:3804
+msgid "draw multiple points"
+msgstr "Draw multiple points"
+
+#: ../src/iop/liquify.c:3810
+msgid ""
+"<b>add node</b>: ctrl+click - <b>remove path</b>: right click\n"
+"<b>toggle line/curve</b>: ctrl+alt+click"
+msgstr ""
+"<b>Add node</b>: Ctrl+click - <b>Remove path</b>: right click\n"
+"<b>Toggle line/curve</b>: Ctrl+Alt+click"
+
+#: ../src/iop/liquify.c:3813
+msgid ""
+"<b>move</b>: click and drag - <b>show/hide feathering controls</b>: click\n"
+"<b>autosmooth, cusp, smooth, symmetrical</b>: ctrl+click - <b>remove</b>: "
+"right click"
+msgstr ""
+"<b>Move</b>: click and drag - <b>Show/hide feathering controls</b>: click\n"
+"<b>Autosmooth, cusp, smooth, symmetrical</b>: Ctrl+click - <b>Remove</b>: "
+"right click"
+
+#: ../src/iop/liquify.c:3817 ../src/iop/liquify.c:3819
+msgid "<b>shape of path</b>: drag"
+msgstr "<b>Shape of path</b>: drag"
+
+#: ../src/iop/liquify.c:3821
+msgid "<b>radius</b>: drag"
+msgstr "<b>Radius</b>: drag"
+
+#: ../src/iop/liquify.c:3823
+msgid "<b>hardness (center)</b>: drag"
+msgstr "<b>Hardness (center)</b>: drag"
+
+#: ../src/iop/liquify.c:3825
+msgid "<b>hardness (feather)</b>: drag"
+msgstr "<b>Hardness (feather)</b>: drag"
+
+#: ../src/iop/liquify.c:3827
+msgid ""
+"<b>strength</b>: drag\n"
+"<b>linear, grow, and shrink</b>: ctrl+click"
+msgstr ""
+"<b>Strength</b>: drag\n"
+"<b>Linear, grow, and shrink</b>: Ctrl+click"
+
+#: ../src/iop/lowlight.c:86
+msgid "lowlight vision"
+msgstr "Lowlight vision"
+
+#: ../src/iop/lowlight.c:91
+msgid "simulate human night vision"
+msgstr "Simulate human night vision"
+
+#: ../src/iop/lowlight.c:94
+msgid "linear, XYZ"
+msgstr "Linear, XYZ"
+
+#: ../src/iop/lowlight.c:324
+msgid "daylight"
+msgstr "Daylight"
+
+#: ../src/iop/lowlight.c:342
+msgid "indoor bright"
+msgstr "Indoor bright"
+
+#: ../src/iop/lowlight.c:360
+msgid "indoor dim"
+msgstr "Indoor dim"
+
+#: ../src/iop/lowlight.c:378
+msgid "indoor dark"
+msgstr "Indoor dark"
+
+#: ../src/iop/lowlight.c:396
+msgid "twilight"
+msgstr "Twilight"
+
+#: ../src/iop/lowlight.c:414
+msgid "night street lit"
+msgstr "Night street lit"
+
+#: ../src/iop/lowlight.c:432
+msgid "night street"
+msgstr "Night street"
+
+#: ../src/iop/lowlight.c:450
+msgid "night street dark"
+msgstr "Night street dark"
+
+#: ../src/iop/lowlight.c:469
+msgid "night"
+msgstr "Night"
+
+#: ../src/iop/lowlight.c:642
+msgid "dark"
+msgstr "Dark"
+
+#: ../src/iop/lowlight.c:650
+msgid "bright"
+msgstr "Bright"
+
+#: ../src/iop/lowlight.c:659
+msgid "day vision"
+msgstr "Day vision"
+
+#: ../src/iop/lowlight.c:664
+msgid "night vision"
+msgstr "Night vision"
+
+#: ../src/iop/lowlight.c:837
+msgid "blueness in shadows"
+msgstr "Blueness in shadows"
+
+#: ../src/iop/lowpass.c:128
+msgid "lowpass"
+msgstr "Lowpass"
+
+#: ../src/iop/lowpass.c:133
+msgid "isolate low frequencies in the image"
+msgstr "Isolate low frequencies in the image"
+
+#: ../src/iop/lowpass.c:565
+msgid "local contrast mask"
+msgstr "Local contrast mask"
+
+#: ../src/iop/lowpass.c:590
+msgid "radius of gaussian/bilateral blur"
+msgstr "Radius of gaussian/bilateral blur"
+
+#: ../src/iop/lowpass.c:591
+msgid "contrast of lowpass filter"
+msgstr "Contrast of lowpass filter"
+
+#: ../src/iop/lowpass.c:592
+msgid "brightness adjustment of lowpass filter"
+msgstr "Brightness adjustment of lowpass filter"
+
+#: ../src/iop/lowpass.c:593
+msgid "color saturation of lowpass filter"
+msgstr "Color saturation of lowpass filter"
+
+#: ../src/iop/lowpass.c:594
+msgid "which filter to use for blurring"
+msgstr "Which filter to use for blurring"
+
+#: ../src/iop/lut3d.c:135
+msgid "LUT 3D"
+msgstr "LUT 3D"
+
+#: ../src/iop/lut3d.c:140
+msgid "perform color space corrections and apply look"
+msgstr "Perform color space corrections and apply look"
+
+#: ../src/iop/lut3d.c:143
+msgid "defined by profile, RGB"
+msgstr "Defined by profile, RGB"
+
+#: ../src/iop/lut3d.c:468
+msgid "error allocating buffer for gmz LUT"
+msgstr "Error allocating buffer for gmz LUT"
+
+#: ../src/iop/lut3d.c:494
+#, c-format
+msgid "invalid png file %s"
+msgstr "Invalid PNG file %s"
+
+#: ../src/iop/lut3d.c:502
+#, c-format
+msgid "png bit-depth %d not supported"
+msgstr "PNG bit-depth %d not supported"
+
+#: ../src/iop/lut3d.c:516 ../src/iop/lut3d.c:526
+#, c-format
+msgid "invalid level in png file %d %d"
+msgstr "Invalid level in PNG file %d %d"
+
+#: ../src/iop/lut3d.c:521
+msgid "this darktable build is not compatible with compressed CLUT"
+msgstr "This Darktable build is not compatible with compressed CLUT"
+
+#: ../src/iop/lut3d.c:538 ../src/iop/lut3d.c:788
+#, c-format
+msgid "error - LUT 3D size %d exceeds the maximum supported"
+msgstr "Error - LUT 3D size %d exceeds the maximum supported"
+
+#: ../src/iop/lut3d.c:550
+msgid "error allocating buffer for png LUT"
+msgstr "Error allocating buffer for PNG LUT"
+
+#: ../src/iop/lut3d.c:558
+#, c-format
+msgid "error - could not read png image %s"
+msgstr "Error - could not read PNG image %s"
+
+#: ../src/iop/lut3d.c:568
+msgid "error - allocating buffer for png LUT"
+msgstr "Error - allocating buffer for PNG LUT"
+
+#: ../src/iop/lut3d.c:743
+#, c-format
+msgid "error - invalid cube file: %s"
+msgstr "Error - invalid cube file: %s"
+
+#: ../src/iop/lut3d.c:757
+msgid "DOMAIN MIN <> 0.0 is not supported"
+msgstr "DOMAIN MIN <> 0.0 is not supported"
+
+#: ../src/iop/lut3d.c:768
+msgid "DOMAIN MAX <> 1.0 is not supported"
+msgstr "DOMAIN MAX <> 1.0 is not supported"
+
+#: ../src/iop/lut3d.c:777
+msgid "1D cube LUT is not supported"
+msgstr "1D cube LUT is not supported"
+
+#: ../src/iop/lut3d.c:799
+msgid "error - allocating buffer for cube LUT"
+msgstr "Error - allocating buffer for cube LUT"
+
+#: ../src/iop/lut3d.c:810
+msgid "error - cube LUT size is not defined"
+msgstr "Error - cube LUT size is not defined"
+
+#: ../src/iop/lut3d.c:821
+#, c-format
+msgid "error - cube LUT invalid number line %d"
+msgstr "Error - cube LUT invalid number line %d"
+
+#: ../src/iop/lut3d.c:837
+#, c-format
+msgid "error - cube LUT lines number %d is not correct, should be %d"
+msgstr "Error - cube LUT lines number %d is not correct, should be %d"
+
+#: ../src/iop/lut3d.c:847
+#, c-format
+msgid "warning - cube LUT has %d values out of range [0,1]"
+msgstr "Warning - cube LUT has %d values out of range [0,1]"
+
+#: ../src/iop/lut3d.c:872
+#, c-format
+msgid "error - invalid 3dl file: %s"
+msgstr "Error - invalid 3dl file: %s"
+
+#: ../src/iop/lut3d.c:893
+#, c-format
+msgid "error - the maximum shaper LUT value %d is too low"
+msgstr "Error - the maximum shaper LUT value %d is too low"
+
+#: ../src/iop/lut3d.c:904
+msgid "error - allocating buffer for 3dl LUT"
+msgstr "Error - allocating buffer for 3dl LUT"
+
+#: ../src/iop/lut3d.c:917
+msgid "error - 3dl LUT size is not defined"
+msgstr "Error - 3dl LUT size is not defined"
+
+#: ../src/iop/lut3d.c:945
+msgid "error - 3dl LUT lines number is not correct"
+msgstr "Error - 3dl LUT lines number is not correct"
+
+#: ../src/iop/lut3d.c:961
+msgid "error - the maximum LUT value does not match any valid bit depth"
+msgstr "Error - the maximum LUT value does not match any valid bit depth"
+
+#: ../src/iop/lut3d.c:1539
+msgid "LUT root folder not defined"
+msgstr "LUT root folder not defined"
+
+#: ../src/iop/lut3d.c:1545
+msgid "select LUT file"
+msgstr "Select LUT file"
+
+#: ../src/iop/lut3d.c:1546
+msgid "_select"
+msgstr "_Select"
+
+#: ../src/iop/lut3d.c:1566
+msgid "hald CLUT (png), 3D LUT (cube or 3dl) or gmic compressed LUT (gmz)"
+msgstr "Hald CLUT (png), 3D LUT (cube or 3dl) or gmic compressed LUT (gmz)"
+
+#: ../src/iop/lut3d.c:1568
+msgid "hald CLUT (png) or 3D LUT (cube or 3dl)"
+msgstr "Hald CLUT (png) or 3D LUT (cube or 3dl)"
+
+#: ../src/iop/lut3d.c:1592
+msgid "select file outside LUT root folder is not allowed"
+msgstr "Select file outside LUT root folder is not allowed"
+
+#: ../src/iop/lut3d.c:1663
+msgid ""
+"select a png (haldclut), a cube, a 3dl or a gmz (compressed LUT) file "
+"CAUTION: 3D LUT folder must be set in preferences/processing before choosing "
+"the LUT file"
+msgstr ""
+"Select a png (haldclut), a cube, a 3dl or a gmz (compressed LUT) file "
+"CAUTION: 3D LUT folder must be set in Preferences/Processing before choosing "
+"the LUT file"
+
+#: ../src/iop/lut3d.c:1667
+msgid ""
+"select a png (haldclut), a cube or a 3dl file CAUTION: 3D LUT folder must be "
+"set in preferences/processing before choosing the LUT file"
+msgstr ""
+"Select a png (haldclut), a cube or a 3dl file CAUTION: 3D LUT folder must be "
+"set in Preferences/Processing before choosing the LUT file"
+
+#: ../src/iop/lut3d.c:1679
+msgid ""
+"the file path (relative to LUT folder) is saved with image along with the "
+"LUT data if it's a compressed LUT (gmz)"
+msgstr ""
+"The file path (relative to LUT folder) is saved with image along with the "
+"LUT data if it's a compressed LUT (gmz)"
+
+#: ../src/iop/lut3d.c:1682
+msgid ""
+"the file path (relative to LUT folder) is saved with image (and not the LUT "
+"data themselves)"
+msgstr ""
+"The file path (relative to LUT folder) is saved with image (and not the LUT "
+"data themselves)"
+
+#: ../src/iop/lut3d.c:1691
+msgid "enter LUT name"
+msgstr "Enter LUT name"
+
+#: ../src/iop/lut3d.c:1712
+msgid "select the LUT"
+msgstr "Select the LUT"
+
+#: ../src/iop/lut3d.c:1725
+msgid "select the color space in which the LUT has to be applied"
+msgstr "Select the color space in which the LUT has to be applied"
+
+#: ../src/iop/lut3d.c:1727
+msgid "interpolation"
+msgstr "Interpolation"
+
+#: ../src/iop/lut3d.c:1728
+msgid "select the interpolation method"
+msgstr "Select the interpolation method"
+
+#: ../src/iop/mask_manager.c:46 ../src/libs/masks.c:61
+msgid "mask manager"
+msgstr "Mask manager"
+
+#: ../src/iop/monochrome.c:97
+msgid "quickly convert an image to black & white using a variable color filter"
+msgstr ""
+"Quickly convert an image to black & white using a variable color filter"
+
+#: ../src/iop/monochrome.c:127
+msgid "red filter"
+msgstr "Red filter"
+
+#: ../src/iop/monochrome.c:547
+msgid "drag and scroll mouse wheel to adjust the virtual color filter"
+msgstr "Drag and scroll mouse wheel to adjust the virtual color filter"
+
+#: ../src/iop/monochrome.c:563
+msgid "how much to keep highlights"
+msgstr "How much to keep highlights"
+
+#: ../src/iop/negadoctor.c:135
+msgid "negadoctor"
+msgstr "Negadoctor"
+
+#: ../src/iop/negadoctor.c:140
+msgid "film|invert|negative|scan"
+msgstr "film|invert|negative|scan"
+
+#: ../src/iop/negadoctor.c:145
+msgid "invert film negative scans and simulate printing on paper"
+msgstr "Invert film negative scans and simulate printing on paper"
+
+#: ../src/iop/negadoctor.c:469
+msgid "D min"
+msgstr "D min"
+
+#: ../src/iop/negadoctor.c:475 ../src/iop/negadoctor.c:855
+msgid "D min red component"
+msgstr "D min red component"
+
+#. Page FILM PROPERTIES
+#: ../src/iop/negadoctor.c:832
+msgid "film properties"
+msgstr "Film properties"
+
+#. Dmin
+#: ../src/iop/negadoctor.c:836
+msgctxt "section"
+msgid "color of the film base"
+msgstr "Color of the film base"
+
+#: ../src/iop/negadoctor.c:842
+msgid "select color of film material from a swatch"
+msgstr "Select color of film material from a swatch"
+
+#: ../src/iop/negadoctor.c:856 ../src/iop/negadoctor.c:866
+#: ../src/iop/negadoctor.c:876
+msgid ""
+"adjust the color and shade of the film transparent base.\n"
+"this value depends on the film material, \n"
+"the chemical fog produced while developing the film,\n"
+"and the scanner white balance."
+msgstr ""
+"Adjust the color and shade of the film transparent base.\n"
+"This value depends on the film material, \n"
+"the chemical fog produced while developing the film,\n"
+"and the scanner white balance."
+
+#: ../src/iop/negadoctor.c:865
+msgid "D min green component"
+msgstr "D min green component"
+
+#: ../src/iop/negadoctor.c:875
+msgid "D min blue component"
+msgstr "D min blue component"
+
+#. D max and scanner bias
+#: ../src/iop/negadoctor.c:883
+msgctxt "section"
+msgid "dynamic range of the film"
+msgstr "Dynamic range of the film"
+
+#: ../src/iop/negadoctor.c:887
+msgid ""
+"maximum density of the film, corresponding to white after inversion.\n"
+"this value depends on the film specifications, the developing process,\n"
+"the dynamic range of the scene and the scanner exposure settings."
+msgstr ""
+"Maximum density of the film, corresponding to white after inversion.\n"
+"This value depends on the film specifications, the developing process,\n"
+"the dynamic range of the scene and the scanner exposure settings."
+
+#: ../src/iop/negadoctor.c:891
+msgctxt "section"
+msgid "scanner exposure settings"
+msgstr "Scanner exposure settings"
+
+#: ../src/iop/negadoctor.c:895
+msgid ""
+"correct the exposure of the scanner, for all RGB channels,\n"
+"before the inversion, so blacks are neither clipped or too pale."
+msgstr ""
+"Correct the exposure of the scanner, for all RGB channels,\n"
+"before the inversion, so blacks are neither clipped or too pale."
+
+#. WB shadows
+#: ../src/iop/negadoctor.c:902
+msgctxt "section"
+msgid "shadows color cast"
+msgstr "Shadows color cast"
+
+#: ../src/iop/negadoctor.c:908
+msgid "select color of shadows from a swatch"
+msgstr "Select color of shadows from a swatch"
+
+#: ../src/iop/negadoctor.c:913
+msgid "pick shadows color from image"
+msgstr "Pick shadows color from image"
+
+#: ../src/iop/negadoctor.c:918
+msgid "shadows red offset"
+msgstr "Shadows red offset"
+
+#: ../src/iop/negadoctor.c:919 ../src/iop/negadoctor.c:926
+#: ../src/iop/negadoctor.c:933
+msgid ""
+"correct the color cast in shadows so blacks are\n"
+"truly achromatic. Setting this value before\n"
+"the highlights illuminant white balance will help\n"
+"recovering the global white balance in difficult cases."
+msgstr ""
+"Correct the color cast in shadows so blacks are\n"
+"truly achromatic. Setting this value before\n"
+"the highlights illuminant white balance will help\n"
+"recovering the global white balance in difficult cases."
+
+#: ../src/iop/negadoctor.c:925
+msgid "shadows green offset"
+msgstr "Shadows green offset"
+
+#: ../src/iop/negadoctor.c:932
+msgid "shadows blue offset"
+msgstr "Shadows blue offset"
+
+#. WB highlights
+#: ../src/iop/negadoctor.c:939
+msgctxt "section"
+msgid "highlights white balance"
+msgstr "Highlights white balance"
+
+#: ../src/iop/negadoctor.c:945
+msgid "select color of illuminant from a swatch"
+msgstr "Select color of illuminant from a swatch"
+
+#: ../src/iop/negadoctor.c:950
+msgid "pick illuminant color from image"
+msgstr "Pick illuminant color from image"
+
+#: ../src/iop/negadoctor.c:955
+msgid "illuminant red gain"
+msgstr "Illuminant red gain"
+
+#: ../src/iop/negadoctor.c:956 ../src/iop/negadoctor.c:963
+#: ../src/iop/negadoctor.c:970
+msgid ""
+"correct the color of the illuminant so whites are\n"
+"truly achromatic. Setting this value after\n"
+"the shadows color cast will help\n"
+"recovering the global white balance in difficult cases."
+msgstr ""
+"Correct the color of the illuminant so whites are\n"
+"truly achromatic. Setting this value after\n"
+"the shadows color cast will help\n"
+"recovering the global white balance in difficult cases."
+
+#: ../src/iop/negadoctor.c:962
+msgid "illuminant green gain"
+msgstr "Illuminant green gain"
+
+#: ../src/iop/negadoctor.c:969
+msgid "illuminant blue gain"
+msgstr "Illuminant blue gain"
+
+#. Page PRINT PROPERTIES
+#: ../src/iop/negadoctor.c:976
+msgid "print properties"
+msgstr "Print properties"
+
+#. print corrections
+#: ../src/iop/negadoctor.c:979
+msgctxt "section"
+msgid "virtual paper properties"
+msgstr "Virtual paper properties"
+
+#: ../src/iop/negadoctor.c:985
+msgid ""
+"correct the density of black after the inversion,\n"
+"to adjust the global contrast while avoiding clipping shadows."
+msgstr ""
+"Correct the density of black after the inversion,\n"
+"to adjust the global contrast while avoiding clipping shadows."
+
+#: ../src/iop/negadoctor.c:990
+msgid ""
+"select the grade of the virtual paper, which is actually\n"
+"equivalent to applying a gamma. it compensates the film D max\n"
+"and recovers the contrast. use a high grade for high D max."
+msgstr ""
+"Select the grade of the virtual paper, which is actually\n"
+"equivalent to applying a gamma. It compensates the film D max\n"
+"and recovers the contrast. Use a high grade for high D max."
+
+#: ../src/iop/negadoctor.c:998
+msgid ""
+"gradually compress specular highlights past this value\n"
+"to avoid clipping while pushing the exposure for mid-tones.\n"
+"this somewhat reproduces the behavior of matte paper."
+msgstr ""
+"Gradually compress specular highlights past this value\n"
+"to avoid clipping while pushing the exposure for mid-tones.\n"
+"This somewhat reproduces the behavior of matte paper."
+
+#: ../src/iop/negadoctor.c:1002
+msgctxt "section"
+msgid "virtual print emulation"
+msgstr "Virtual print emulation"
+
+#: ../src/iop/negadoctor.c:1009
+msgid ""
+"correct the printing exposure after inversion to adjust\n"
+"the global contrast and avoid clipping highlights."
+msgstr ""
+"Correct the printing exposure after inversion to adjust\n"
+"the global contrast and avoid clipping highlights."
+
+#: ../src/iop/negadoctor.c:1017
+msgid "toggle on or off the color controls"
+msgstr "Toggle on or off the color controls"
+
+#: ../src/iop/nlmeans.c:84
+msgid "astrophoto denoise"
+msgstr "Astrophoto denoise"
+
+#: ../src/iop/nlmeans.c:89
+msgid "denoise (non-local means)"
+msgstr "Denoise (non-local means)"
+
+#: ../src/iop/nlmeans.c:94
+msgid "apply a poisson noise removal best suited for astrophotography"
+msgstr "Apply a poisson noise removal best suited for astrophotography"
+
+#: ../src/iop/nlmeans.c:459
+msgid "radius of the patches to match"
+msgstr "Radius of the patches to match"
+
+#: ../src/iop/nlmeans.c:467
+msgid "how much to smooth brightness"
+msgstr "How much to smooth brightness"
+
+#: ../src/iop/nlmeans.c:470
+msgid "how much to smooth colors"
+msgstr "How much to smooth colors"
+
+#. * let's fill the encapsulating widgets
+#. preview mode
+#. color scheme
+#: ../src/iop/overexposed.c:71 ../src/views/darkroom.c:2401
+#: ../src/views/darkroom.c:2419 ../src/views/darkroom.c:2426
+#: ../src/views/darkroom.c:2436 ../src/views/darkroom.c:2453
+msgid "overexposed"
+msgstr "Overexposed"
+
+#: ../src/iop/overexposed.c:130 ../src/iop/overexposed.c:360
+msgid "module overexposed failed in buffer allocation"
+msgstr "Module overexposed failed in buffer allocation"
+
+#: ../src/iop/overexposed.c:156 ../src/iop/overexposed.c:370
+msgid "module overexposed failed in color conversion"
+msgstr "Module overexposed failed in color conversion"
+
+#: ../src/iop/profile_gamma.c:96
+msgid "unbreak input profile"
+msgstr "Unbreak input profile"
+
+#: ../src/iop/profile_gamma.c:101
+msgid "correct input color profiles meant to be applied on non-linear RGB"
+msgstr "Correct input color profiles meant to be applied on non-linear RGB"
+
+#: ../src/iop/profile_gamma.c:136
+msgid "16 EV dynamic range (generic)"
+msgstr "16 EV dynamic range (generic)"
+
+#: ../src/iop/profile_gamma.c:142
+msgid "14 EV dynamic range (generic)"
+msgstr "14 EV dynamic range (generic)"
+
+#: ../src/iop/profile_gamma.c:148
+msgid "12 EV dynamic range (generic)"
+msgstr "12 EV dynamic range (generic)"
+
+#: ../src/iop/profile_gamma.c:154
+msgid "10 EV dynamic range (generic)"
+msgstr "10 EV dynamic range (generic)"
+
+#: ../src/iop/profile_gamma.c:160
+msgid "08 EV dynamic range (generic)"
+msgstr "08 EV dynamic range (generic)"
+
+#: ../src/iop/profile_gamma.c:623
+msgid "linear part"
+msgstr "Linear part"
+
+#: ../src/iop/profile_gamma.c:627
+msgid "gamma exponential factor"
+msgstr "Gamma exponential factor"
+
+#: ../src/iop/profile_gamma.c:638
+msgid "adjust to match the average luma of the subject"
+msgstr "Adjust to match the average luma of the subject"
+
+#: ../src/iop/profile_gamma.c:644
+msgid ""
+"number of stops between middle gray and pure black\n"
+"this is a reading a posemeter would give you on the scene"
+msgstr ""
+"Number of stops between middle gray and pure black\n"
+"This is a reading a posemeter would give you on the scene"
+
+#: ../src/iop/profile_gamma.c:650
+msgid ""
+"number of stops between pure black and pure white\n"
+"this is a reading a posemeter would give you on the scene"
+msgstr ""
+"Number of stops between pure black and pure white\n"
+"This is a reading a posemeter would give you on the scene"
+
+#: ../src/iop/profile_gamma.c:652
+msgctxt "section"
+msgid "optimize automatically"
+msgstr "Optimize automatically"
+
+#: ../src/iop/profile_gamma.c:656
+msgid ""
+"enlarge or shrink the computed dynamic range\n"
+"this is useful when noise perturbates the measurements"
+msgstr ""
+"Enlarge or shrink the computed dynamic range\n"
+"This is useful when noise perturbates the measurements"
+
+#: ../src/iop/profile_gamma.c:660
+msgid "make an optimization with some guessing"
+msgstr "Make an optimization with some guessing"
+
+#: ../src/iop/profile_gamma.c:669
+msgid "tone mapping method"
+msgstr "Tone mapping method"
+
+#: ../src/iop/rawdenoise.c:124
+msgid "raw denoise"
+msgstr "Raw denoise"
+
+#: ../src/iop/rawdenoise.c:129
+msgid "denoise the raw picture early in the pipeline"
+msgstr "Denoise the raw picture early in the pipeline"
+
+#: ../src/iop/rawdenoise.c:941
+msgid ""
+"raw denoising\n"
+"only works for raw images."
+msgstr ""
+"Raw denoising\n"
+"Only works for raw images."
+
+#. * let's fill the encapsulating widgets
+#. mode of operation
+#: ../src/iop/rawoverexposed.c:69 ../src/views/darkroom.c:2351
+#: ../src/views/darkroom.c:2369 ../src/views/darkroom.c:2375
+#: ../src/views/darkroom.c:2388
+msgid "raw overexposed"
+msgstr "Raw overexposed"
+
+#: ../src/iop/rawprepare.c:99
+msgctxt "modulename"
+msgid "raw black/white point"
+msgstr "Raw black/white point"
+
+#: ../src/iop/rawprepare.c:156
+msgid ""
+"sets technical specificities of the raw sensor.\n"
+"touch with great care!"
+msgstr ""
+"Sets technical specificities of the raw sensor.\n"
+"Touch with great care!"
+
+#: ../src/iop/rawprepare.c:168
+msgid "passthrough"
+msgstr "Passthrough"
+
+#: ../src/iop/rawprepare.c:654
+msgid "invalid crop parameters"
+msgstr "Invalid crop parameters"
+
+#: ../src/iop/rawprepare.c:655
+msgid ""
+"please reset to defaults, update your preset or set to something correct"
+msgstr ""
+"Please reset to defaults, update your preset or set to something correct"
+
+#: ../src/iop/rawprepare.c:902
+msgid "black level 0"
+msgstr "Black level 0"
+
+#: ../src/iop/rawprepare.c:903
+msgid "black level 1"
+msgstr "Black level 1"
+
+#: ../src/iop/rawprepare.c:904
+msgid "black level 2"
+msgstr "Black level 2"
+
+#: ../src/iop/rawprepare.c:905
+msgid "black level 3"
+msgstr "Black level 3"
+
+#: ../src/iop/rawprepare.c:932
+msgid "raw flat field correction to compensate for lens shading"
+msgstr "Raw flat field correction to compensate for lens shading"
+
+#: ../src/iop/rawprepare.c:937
+msgctxt "section"
+msgid "crop"
+msgstr "Crop"
+
+#: ../src/iop/rawprepare.c:940
+msgid "crop left border"
+msgstr "Crop left border"
+
+#: ../src/iop/rawprepare.c:944
+msgid "crop top border"
+msgstr "Crop top border"
+
+#: ../src/iop/rawprepare.c:948
+msgid "crop right border"
+msgstr "Crop right border"
+
+#: ../src/iop/rawprepare.c:952
+msgid "crop bottom border"
+msgstr "Crop bottom border"
+
+#: ../src/iop/rawprepare.c:961
+msgid ""
+"raw black/white point correction\n"
+"only works for the sensors that need it."
+msgstr ""
+"Raw black/white point correction\n"
+"Only works for the sensors that need it."
+
+#: ../src/iop/relight.c:53
+msgid "fill-light 0.25EV with 4 zones"
+msgstr "Fill-light 0.25EV with 4 zones"
+
+#: ../src/iop/relight.c:57
+msgid "fill-shadow -0.25EV with 4 zones"
+msgstr "Fill-shadow -0.25EV with 4 zones"
+
+#: ../src/iop/relight.c:86
+msgid "fill light"
+msgstr "Fill light"
+
+#: ../src/iop/relight.c:96 ../src/iop/zonesystem.c:122
+msgid ""
+"this module is deprecated. please use the tone equalizer module instead."
+msgstr ""
+"This module is deprecated. Please use the tone equalizer module instead."
+
+#: ../src/iop/relight.c:263
+msgid "the fill-light in EV"
+msgstr "The fill-light in EV"
+
+#: ../src/iop/relight.c:272
+msgid ""
+"select the center of fill-light\n"
+"ctrl+click to select an area"
+msgstr ""
+"Select the center of fill-light\n"
+"Ctrl+click to select an area"
+
+#: ../src/iop/relight.c:276
+msgid "toggle tool for picking median lightness in image"
+msgstr "Toggle tool for picking median lightness in image"
+
+#: ../src/iop/relight.c:279 ../src/libs/export.c:1137
+#: ../src/libs/metadata_view.c:147 ../src/libs/print_settings.c:2378
+msgid "width"
+msgstr "Width"
+
+#: ../src/iop/relight.c:280
+msgid "width of fill-light area defined in zones"
+msgstr "Width of fill-light area defined in zones"
+
+#: ../src/iop/retouch.c:197
+msgid "retouch"
+msgstr "Retouch"
+
+#: ../src/iop/retouch.c:202
+msgid "split-frequency|healing|cloning|stamp"
+msgstr "split-frequency|healing|cloning|stamp"
+
+#: ../src/iop/retouch.c:208
+msgid "remove and clone spots, perform split-frequency skin editing"
+msgstr "Remove and clone spots, perform split-frequency skin editing"
+
+#: ../src/iop/retouch.c:211
+msgid "geometric and frequential, RGB"
+msgstr "Geometric and frequential, RGB"
+
+#: ../src/iop/retouch.c:1539
+msgid "cannot display scales when the blending mask is displayed"
+msgstr "Cannot display scales when the blending mask is displayed"
+
+#: ../src/iop/retouch.c:1861 ../src/iop/retouch.c:1863
+#: ../src/iop/retouch.c:1865 ../src/iop/retouch.c:1867
+#, c-format
+msgid "default tool changed to %s"
+msgstr "Default tool changed to %s"
+
+#: ../src/iop/retouch.c:1861
+msgid "cloning"
+msgstr "Cloning"
+
+#: ../src/iop/retouch.c:1863
+msgid "healing"
+msgstr "Healing"
+
+#: ../src/iop/retouch.c:2226
+msgid "shapes:"
+msgstr "Shapes:"
+
+#: ../src/iop/retouch.c:2230
+msgid ""
+"to add a shape select an algorithm and a shape type and click on the image.\n"
+"shapes are added to the current scale"
+msgstr ""
+"To add a shape select an algorithm and a shape type and click on the image.\n"
+"Shapes are added to the current scale"
+
+#. display & suppress masks
+#. copy/paste shapes
+#. display final image/current scale
+#. auto-levels button
+#: ../src/iop/retouch.c:2233 ../src/iop/retouch.c:2334
+#: ../src/iop/retouch.c:2339 ../src/iop/retouch.c:2347
+#: ../src/iop/retouch.c:2351 ../src/iop/retouch.c:2358
+#: ../src/iop/retouch.c:2392
+msgid "editing"
+msgstr "Editing"
+
+#: ../src/iop/retouch.c:2233
+msgid "show and edit shapes on the current scale"
+msgstr "Show and edit shapes on the current scale"
+
+#: ../src/iop/retouch.c:2234
+msgid "show and edit shapes in restricted mode"
+msgstr "Show and edit shapes in restricted mode"
+
+#: ../src/iop/retouch.c:2257
+msgid "algorithms:"
+msgstr "Algorithms:"
+
+#: ../src/iop/retouch.c:2260 ../src/iop/retouch.c:2264
+#: ../src/iop/retouch.c:2268 ../src/iop/retouch.c:2272
+msgid "tools"
+msgstr "Tools"
+
+#: ../src/iop/retouch.c:2260 ../src/iop/retouch.c:2278
+msgid "activate blur tool"
+msgstr "Activate blur tool"
+
+#: ../src/iop/retouch.c:2260 ../src/iop/retouch.c:2264
+#: ../src/iop/retouch.c:2268 ../src/iop/retouch.c:2272
+msgid "change algorithm for current form"
+msgstr "Change algorithm for current form"
+
+#: ../src/iop/retouch.c:2264 ../src/iop/retouch.c:2281
+msgid "activate fill tool"
+msgstr "Activate fill tool"
+
+#: ../src/iop/retouch.c:2268 ../src/iop/retouch.c:2284
+msgid "activate cloning tool"
+msgstr "Activate cloning tool"
+
+#: ../src/iop/retouch.c:2272 ../src/iop/retouch.c:2287
+msgid "activate healing tool"
+msgstr "Activate healing tool"
+
+#. overwrite tooltip ourself to handle shift+click
+#: ../src/iop/retouch.c:2276
+msgid "ctrl+click to change tool for current form"
+msgstr "Ctrl+click to change tool for current form"
+
+#: ../src/iop/retouch.c:2277
+msgid "shift+click to set the tool as default"
+msgstr "Shift+click to set the tool as default"
+
+#: ../src/iop/retouch.c:2296
+msgid "scales:"
+msgstr "Scales:"
+
+#: ../src/iop/retouch.c:2301
+msgid "current:"
+msgstr "Current:"
+
+#: ../src/iop/retouch.c:2306
+msgid "merge from:"
+msgstr "Merge from:"
+
+#: ../src/iop/retouch.c:2314
+msgid ""
+"top slider adjusts where the merge scales start\n"
+"bottom slider adjusts the number of scales\n"
+"dot indicates the current scale\n"
+"top line indicates that the scale is visible at current zoom level\n"
+"bottom line indicates that the scale has shapes on it"
+msgstr ""
+"Top slider adjusts where the merge scales start\n"
+"Bottom slider adjusts the number of scales\n"
+"Dot indicates the current scale\n"
+"Top line indicates that the scale is visible at current zoom level\n"
+"Bottom line indicates that the scale has shapes on it"
+
+#: ../src/iop/retouch.c:2334
+msgid "display masks"
+msgstr "Display masks"
+
+#: ../src/iop/retouch.c:2339
+msgid "temporarily switch off shapes"
+msgstr "Temporarily switch off shapes"
+
+#: ../src/iop/retouch.c:2347
+msgid "paste cut shapes to current scale"
+msgstr "Paste cut shapes to current scale"
+
+#: ../src/iop/retouch.c:2351
+msgid "cut shapes from current scale"
+msgstr "Cut shapes from current scale"
+
+#: ../src/iop/retouch.c:2358
+msgid "display wavelet scale"
+msgstr "Display wavelet scale"
+
+#: ../src/iop/retouch.c:2366
+msgctxt "section"
+msgid "preview single scale"
+msgstr "Preview single scale"
+
+#: ../src/iop/retouch.c:2377
+msgid "adjust preview levels"
+msgstr "Adjust preview levels"
+
+#: ../src/iop/retouch.c:2392
+msgid "auto levels"
+msgstr "Auto levels"
+
+#: ../src/iop/retouch.c:2400
+msgid "shape selected:"
+msgstr "Shape selected:"
+
+#: ../src/iop/retouch.c:2405
+msgid ""
+"click on a shape to select it,\n"
+"to unselect click on an empty space"
+msgstr ""
+"Click on a shape to select it,\n"
+"to unselect click on an empty space"
+
+#: ../src/iop/retouch.c:2412
+msgid "erase the detail or fills with chosen color"
+msgstr "Erase the detail or fills with chosen color"
+
+#: ../src/iop/retouch.c:2419
+msgid "fill color: "
+msgstr "Fill color: "
+
+#: ../src/iop/retouch.c:2424 ../src/iop/retouch.c:2425
+msgid "select fill color"
+msgstr "Select fill color"
+
+#: ../src/iop/retouch.c:2430
+msgid "pick fill color from image"
+msgstr "Pick fill color from image"
+
+#: ../src/iop/retouch.c:2438
+msgid "adjusts color brightness to fine-tune it. works with erase as well"
+msgstr "Adjusts color brightness to fine-tune it. Works with erase as well"
+
+#: ../src/iop/retouch.c:2444
+msgid "type for the blur algorithm"
+msgstr "Type for the blur algorithm"
+
+#: ../src/iop/retouch.c:2448
+msgid "radius of the selected blur type"
+msgstr "Radius of the selected blur type"
+
+#: ../src/iop/retouch.c:2454
+msgid "set the opacity on the selected shape"
+msgstr "Set the opacity on the selected shape"
+
+#: ../src/iop/retouch.c:2460
+msgctxt "section"
+msgid "retouch tools"
+msgstr "Retouch tools"
+
+#. wavelet decompose
+#: ../src/iop/retouch.c:2469
+msgctxt "section"
+msgid "wavelet decompose"
+msgstr "Wavelet decompose"
+
+#. shapes
+#: ../src/iop/retouch.c:2483
+msgctxt "section"
+msgid "shapes"
+msgstr "Shapes"
+
+#: ../src/iop/retouch.c:3588 ../src/iop/retouch.c:4426
+#, c-format
+msgid "max scale is %i for this image size"
+msgstr "Max scale is %i for this image size"
+
+#: ../src/iop/rgbcurve.c:122
+msgid "rgb curve"
+msgstr "RGB curve"
+
+#: ../src/iop/rgbcurve.c:142
+msgid "alter an image’s tones using curves in RGB color space"
+msgstr "Alter an image’s tones using curves in RGB color space"
+
+#: ../src/iop/rgbcurve.c:193 ../src/iop/tonecurve.c:548
+msgid "gamma 1.0 (linear)"
+msgstr "Gamma 1.0 (linear)"
+
+#: ../src/iop/rgbcurve.c:203 ../src/iop/tonecurve.c:558
+msgid "contrast - med (linear)"
+msgstr "Contrast - med (linear)"
+
+#: ../src/iop/rgbcurve.c:212 ../src/iop/tonecurve.c:567
+msgid "contrast - high (linear)"
+msgstr "Contrast - high (linear)"
+
+#: ../src/iop/rgbcurve.c:226 ../src/iop/tonecurve.c:579
+msgid "contrast - med (gamma 2.2)"
+msgstr "Contrast - med (gamma 2.2)"
+
+#: ../src/iop/rgbcurve.c:239 ../src/iop/tonecurve.c:590
+msgid "contrast - high (gamma 2.2)"
+msgstr "Contrast - high (gamma 2.2)"
+
+#: ../src/iop/rgbcurve.c:251 ../src/iop/tonecurve.c:602
+msgid "gamma 2.0"
+msgstr "Gamma 2.0"
+
+#: ../src/iop/rgbcurve.c:256 ../src/iop/tonecurve.c:607
+msgid "gamma 0.5"
+msgstr "Gamma 0.5"
+
+#: ../src/iop/rgbcurve.c:261 ../src/iop/tonecurve.c:612
+msgid "logarithm (base 2)"
+msgstr "Logarithm (base 2)"
+
+#: ../src/iop/rgbcurve.c:266 ../src/iop/tonecurve.c:617
+msgid "exponential (base 2)"
+msgstr "Exponential (base 2)"
+
+#: ../src/iop/rgbcurve.c:1351 ../src/iop/rgblevels.c:997
+msgid "choose between linked and independent channels."
+msgstr "Choose between linked and independent channels."
+
+#: ../src/iop/rgbcurve.c:1357 ../src/iop/rgblevels.c:1001
+msgid "curve nodes for r channel"
+msgstr "Curve nodes for R channel"
+
+#: ../src/iop/rgbcurve.c:1358 ../src/iop/rgblevels.c:1002
+msgid "curve nodes for g channel"
+msgstr "Curve nodes for G channel"
+
+#: ../src/iop/rgbcurve.c:1359 ../src/iop/rgblevels.c:1003
+msgid "curve nodes for b channel"
+msgstr "Curve nodes for B channel"
+
+#: ../src/iop/rgblevels.c:102
+msgid "rgb levels"
+msgstr "RGB levels"
+
+#: ../src/iop/rgblevels.c:122
+msgid "adjust black, white and mid-gray points in RGB color space"
+msgstr "Adjust black, white and mid-gray points in RGB color space"
+
+#: ../src/iop/rgblevels.c:1056
+msgid ""
+"apply auto levels based on a region defined by the user\n"
+"click and drag to draw the area\n"
+"right click to cancel"
+msgstr ""
+"Apply auto levels based on a region defined by the user\n"
+"Click and drag to draw the area\n"
+"Right click to cancel"
+
+#: ../src/iop/rotatepixels.c:70
+msgctxt "modulename"
+msgid "rotate pixels"
+msgstr "Rotate pixels"
+
+#: ../src/iop/rotatepixels.c:97 ../src/iop/scalepixels.c:82
+msgid ""
+"internal module to setup technical specificities of raw sensor.\n"
+"\n"
+"you should not touch values here!"
+msgstr ""
+"Internal module to setup technical specificities of raw sensor.\n"
+"\n"
+"You should not touch values here!"
+
+#: ../src/iop/rotatepixels.c:366
+msgid "automatic pixel rotation"
+msgstr "Automatic pixel rotation"
+
+#: ../src/iop/rotatepixels.c:367
+msgid ""
+"automatic pixel rotation\n"
+"only works for the sensors that need it."
+msgstr ""
+"Automatic pixel rotation\n"
+"Only works for the sensors that need it."
+
+#: ../src/iop/scalepixels.c:55
+msgctxt "modulename"
+msgid "scale pixels"
+msgstr "Scale pixels"
+
+#: ../src/iop/scalepixels.c:271
+msgid "automatic pixel scaling"
+msgstr "Automatic pixel scaling"
+
+#: ../src/iop/scalepixels.c:272
+msgid ""
+"automatic pixel scaling\n"
+"only works for the sensors that need it."
+msgstr ""
+"Automatic pixel scaling\n"
+"Only works for the sensors that need it."
+
+#: ../src/iop/shadhi.c:175
+msgid "shadows and highlights"
+msgstr "Shadows and highlights"
+
+#: ../src/iop/shadhi.c:195
+msgid ""
+"modify the tonal range of the shadows and highlights\n"
+"of an image by enhancing local contrast."
+msgstr ""
+"Modify the tonal range of the shadows and highlights\n"
+"of an image by enhancing local contrast."
+
+#: ../src/iop/shadhi.c:671 ../src/iop/splittoning.c:548
+msgid "compress"
+msgstr "Compress"
+
+#: ../src/iop/shadhi.c:678
+msgid "correct shadows"
+msgstr "Correct shadows"
+
+#: ../src/iop/shadhi.c:679
+msgid "correct highlights"
+msgstr "Correct highlights"
+
+#: ../src/iop/shadhi.c:680
+msgid "shift white point"
+msgstr "Shift white point"
+
+#: ../src/iop/shadhi.c:682
+msgid "filter to use for softening. bilateral avoids halos"
+msgstr "Filter to use for softening. Bilateral avoids halos"
+
+#: ../src/iop/shadhi.c:683
+msgid ""
+"compress the effect on shadows/highlights and\n"
+"preserve mid-tones"
+msgstr ""
+"Compress the effect on shadows/highlights and\n"
+"preserve mid-tones"
+
+#: ../src/iop/shadhi.c:684
+msgid "adjust saturation of shadows"
+msgstr "Adjust saturation of shadows"
+
+#: ../src/iop/shadhi.c:685
+msgid "adjust saturation of highlights"
+msgstr "Adjust saturation of highlights"
+
+#: ../src/iop/sharpen.c:73
+msgctxt "modulename"
+msgid "sharpen"
+msgstr "Sharpen"
+
+#: ../src/iop/sharpen.c:93
+msgid "sharpen the details in the image using a standard UnSharp Mask (USM)"
+msgstr "Sharpen the details in the image using a standard UnSharp Mask (USM)"
+
+#: ../src/iop/sharpen.c:95
+msgid "linear or non-linear, Lab, display or scene-referred"
+msgstr "Linear or non-linear, Lab, display or scene-referred"
+
+#: ../src/iop/sharpen.c:97
+msgid "quasi-linear, Lab, display or scene-referred"
+msgstr "Quasi-linear, Lab, display or scene-referred"
+
+#. add the preset.
+#. restrict to raw images
+#: ../src/iop/sharpen.c:104 ../src/iop/sharpen.c:108
+msgid "sharpen"
+msgstr "Sharpen"
+
+#: ../src/iop/sharpen.c:443
+msgid "spatial extent of the unblurring"
+msgstr "Spatial extent of the unblurring"
+
+#: ../src/iop/sharpen.c:447
+msgid "strength of the sharpen"
+msgstr "Strength of the sharpen"
+
+#: ../src/iop/sharpen.c:451
+msgid "threshold to activate sharpen"
+msgstr "Threshold to activate sharpen"
+
+#: ../src/iop/sigmoid.c:88
+msgid "sigmoid"
+msgstr "Sigmoid"
+
+#: ../src/iop/sigmoid.c:93
+msgid "tone mapping|view transform|display transform"
+msgstr "tone mapping|view transform|display transform"
+
+#: ../src/iop/sigmoid.c:98
+msgid ""
+"apply a view transform to make a image displayable\n"
+"on a screen or print. uses a robust and smooth\n"
+"tone curve with optional color preservation methods."
+msgstr ""
+"Apply a view transform to make a image displayable\n"
+"on a screen or print. Uses a robust and smooth\n"
+"tone curve with optional color preservation methods."
+
+#: ../src/iop/sigmoid.c:132
+msgid "neutral gray"
+msgstr "Neutral gray"
+
+#: ../src/iop/sigmoid.c:137
+msgid "ACES 100-nit like"
+msgstr "ACES 100-nit like"
+
+#: ../src/iop/sigmoid.c:660
+msgid ""
+"compression of the applied curve\n"
+"implicitly defines the supported input dynamic range"
+msgstr ""
+"Compression of the applied curve\n"
+"Implicitly defines the supported input dynamic range"
+
+#: ../src/iop/sigmoid.c:663
+msgid ""
+"shift the compression towards shadows or highlights.\n"
+"negative values increase contrast in shadows.\n"
+"positive values increase contrast in highlights.\n"
+"the opposite end will see a reduction in contrast."
+msgstr ""
+"Shift the compression towards shadows or highlights.\n"
+"Negative values increase contrast in shadows.\n"
+"Positive values increase contrast in highlights.\n"
+"The opposite end will see a reduction in contrast."
+
+#: ../src/iop/sigmoid.c:672
+msgid ""
+"optional correction of the hue twist introduced by\n"
+"the per-channel processing method."
+msgstr ""
+"Optional correction of the hue twist introduced by\n"
+"the per-channel processing method."
+
+#: ../src/iop/sigmoid.c:679
+msgid "display luminance"
+msgstr "Display luminance"
+
+#: ../src/iop/sigmoid.c:683
+msgid "set display black/white targets"
+msgstr "Set display black/white targets"
+
+#: ../src/iop/sigmoid.c:691
+msgid ""
+"the black luminance of the target display or print.\n"
+"can be used creatively for a faded look."
+msgstr ""
+"The black luminance of the target display or print.\n"
+"Can be used creatively for a faded look."
+
+#: ../src/iop/sigmoid.c:696
+msgid ""
+"the white luminance of the target display or print.\n"
+"can be used creatively for a faded look or blowing out whites earlier."
+msgstr ""
+"The white luminance of the target display or print.\n"
+"Can be used creatively for a faded look or blowing out whites earlier."
+
+#: ../src/iop/soften.c:80
+msgid "soften"
+msgstr "Soften"
+
+#: ../src/iop/soften.c:100
+msgid "create a softened image using the Orton effect"
+msgstr "Create a softened image using the Orton effect"
+
+#: ../src/iop/soften.c:371
+msgid "the size of blur"
+msgstr "The size of blur"
+
+#: ../src/iop/soften.c:375
+msgid "the saturation of blur"
+msgstr "The saturation of blur"
+
+#: ../src/iop/soften.c:379
+msgid "the brightness of blur"
+msgstr "The brightness of blur"
+
+#: ../src/iop/soften.c:383
+msgid "the mix of effect"
+msgstr "The mix of effect"
+
+#: ../src/iop/splittoning.c:81
+msgid "split-toning"
+msgstr "Split-toning"
+
+#: ../src/iop/splittoning.c:101
+msgid ""
+"use two specific colors for shadows and highlights and\n"
+"create a linear toning effect between them up to a pivot."
+msgstr ""
+"Use two specific colors for shadows and highlights and\n"
+"create a linear toning effect between them up to a pivot."
+
+#: ../src/iop/splittoning.c:118
+msgid "authentic sepia"
+msgstr "Authentic sepia"
+
+#: ../src/iop/splittoning.c:127
+msgid "authentic cyanotype"
+msgstr "Authentic cyanotype"
+
+#: ../src/iop/splittoning.c:136
+msgid "authentic platinotype"
+msgstr "Authentic platinotype"
+
+#: ../src/iop/splittoning.c:145
+msgid "chocolate brown"
+msgstr "Chocolate brown"
+
+#: ../src/iop/splittoning.c:490
+msgid "select the saturation tone"
+msgstr "Select the saturation tone"
+
+#: ../src/iop/splittoning.c:494
+msgid "select tone color"
+msgstr "Select tone color"
+
+#: ../src/iop/splittoning.c:524
+msgctxt "section"
+msgid "shadows"
+msgstr "Shadows"
+
+#: ../src/iop/splittoning.c:530
+msgctxt "section"
+msgid "highlights"
+msgstr "Highlights"
+
+#: ../src/iop/splittoning.c:539
+msgid "balance"
+msgstr "Balance"
+
+#: ../src/iop/splittoning.c:546
+msgid "the balance of center of split-toning"
+msgstr "The balance of center of split-toning"
+
+#: ../src/iop/splittoning.c:550
+msgid ""
+"compress the effect on highlights/shadows and\n"
+"preserve mid-tones"
+msgstr ""
+"Compress the effect on highlights/shadows and\n"
+"preserve mid-tones"
+
+#: ../src/iop/spots.c:58
+msgid "spot removal"
+msgstr "Spot removal"
+
+#: ../src/iop/spots.c:63
+msgid "this module is deprecated. please use the retouch module instead."
+msgstr "This module is deprecated. Please use the retouch module instead."
+
+#: ../src/iop/spots.c:68
+msgid "remove sensor dust spots"
+msgstr "Remove sensor dust spots"
+
+#: ../src/iop/spots.c:71
+msgid "geometric, raw"
+msgstr "Geometric, raw"
+
+#: ../src/iop/spots.c:226
+msgid "spot module is limited to 64 shapes. please add a new instance!"
+msgstr "Spot module is limited to 64 shapes. Please add a new instance!"
+
+#: ../src/iop/spots.c:872
+msgid "number of strokes:"
+msgstr "Number of strokes:"
+
+#: ../src/iop/spots.c:876
+msgid ""
+"click on a shape and drag on canvas.\n"
+"use the mouse wheel to adjust size.\n"
+"right click to remove a shape."
+msgstr ""
+"Click on a shape and drag on canvas.\n"
+"Use the mouse wheel to adjust size.\n"
+"Right click to remove a shape."
+
+#: ../src/iop/spots.c:879
+msgid "show and edit shapes"
+msgstr "Show and edit shapes"
+
+#: ../src/iop/temperature.c:204
+msgctxt "modulename"
+msgid "white balance"
+msgstr "White balance"
+
+#: ../src/iop/temperature.c:211
+msgid "scale raw RGB channels to balance white and help demosaicing"
+msgstr "Scale raw RGB channels to balance white and help demosaicing"
+
+#: ../src/iop/temperature.c:1149
+msgid "white balance applied twice"
+msgstr "White balance applied twice"
+
+#: ../src/iop/temperature.c:1150
+msgid ""
+"the color calibration module is enabled,\n"
+"and performing chromatic adaptation.\n"
+"set the white balance here to camera reference (D65)\n"
+"or disable chromatic adaptation in color calibration."
+msgstr ""
+"The color calibration module is enabled,\n"
+"and performing chromatic adaptation.\n"
+"Set the white balance here to camera reference (D65)\n"
+"or disable chromatic adaptation in color calibration."
+
+#: ../src/iop/temperature.c:1430
+#, c-format
+msgid "`%s' color matrix not found for image"
+msgstr "`%s' color matrix not found for image"
+
+#: ../src/iop/temperature.c:1459
+#, c-format
+msgid "failed to read camera white balance information from `%s'!"
+msgstr "Failed to read camera white balance information from `%s'!"
+
+#: ../src/iop/temperature.c:1630
+msgctxt "white balance"
+msgid "as shot"
+msgstr "As shot"
+
+#. old "spot", reason: describes exactly what'll happen
+#: ../src/iop/temperature.c:1633
+msgctxt "white balance"
+msgid "from image area"
+msgstr "From image area"
+
+#: ../src/iop/temperature.c:1634
+msgctxt "white balance"
+msgid "user modified"
+msgstr "User modified"
+
+#. old "camera neutral", reason: better matches intent
+#: ../src/iop/temperature.c:1636
+msgctxt "white balance"
+msgid "camera reference"
+msgstr "Camera reference"
+
+#: ../src/iop/temperature.c:1919 ../src/iop/temperature.c:1937
+msgid "green channel coefficient"
+msgstr "Green channel coefficient"
+
+#: ../src/iop/temperature.c:1921
+msgid "magenta channel coefficient"
+msgstr "Magenta channel coefficient"
+
+#: ../src/iop/temperature.c:1923
+msgid "cyan channel coefficient"
+msgstr "Cyan channel coefficient"
+
+#: ../src/iop/temperature.c:1925
+msgid "yellow channel coefficient"
+msgstr "Yellow channel coefficient"
+
+#: ../src/iop/temperature.c:1935
+msgid "red channel coefficient"
+msgstr "Red channel coefficient"
+
+#: ../src/iop/temperature.c:1939
+msgid "blue channel coefficient"
+msgstr "Blue channel coefficient"
+
+#: ../src/iop/temperature.c:1941
+msgid "emerald channel coefficient"
+msgstr "Emerald channel coefficient"
+
+#. relabel to settings to remove confusion between module presets
+#. and white balance settings
+#: ../src/iop/temperature.c:2028 ../src/iop/temperature.c:2041
+#: ../src/iop/temperature.c:2048 ../src/iop/temperature.c:2054
+#: ../src/iop/temperature.c:2073
+msgid "settings"
+msgstr "Settings"
+
+#: ../src/iop/temperature.c:2028
+msgid "as shot"
+msgstr "As shot"
+
+#: ../src/iop/temperature.c:2031
+msgid "set white balance to as shot"
+msgstr "Set white balance to as shot"
+
+#: ../src/iop/temperature.c:2041
+msgid "from image area"
+msgstr "From image area"
+
+#: ../src/iop/temperature.c:2048
+msgid "user modified"
+msgstr "User modified"
+
+#: ../src/iop/temperature.c:2051
+msgid "set white balance to user modified"
+msgstr "Set white balance to user modified"
+
+#: ../src/iop/temperature.c:2054
+msgid "camera reference"
+msgstr "Camera reference"
+
+#: ../src/iop/temperature.c:2059
+msgid ""
+"set white balance to camera reference point\n"
+"in most cases it should be D65"
+msgstr ""
+"Set white balance to camera reference point\n"
+"In most cases it should be D65"
+
+#: ../src/iop/temperature.c:2074
+msgid "choose white balance setting"
+msgstr "Choose white balance setting"
+
+#: ../src/iop/temperature.c:2079
+msgid "finetune"
+msgstr "Finetune"
+
+#: ../src/iop/temperature.c:2081
+msgid "fine tune camera's white balance setting"
+msgstr "Fine tune camera's white balance setting"
+
+#: ../src/iop/temperature.c:2092
+msgctxt "section"
+msgid "scene illuminant temp"
+msgstr "Scene illuminant temp"
+
+#: ../src/iop/temperature.c:2093
+msgid "click to cycle color mode on sliders"
+msgstr "Click to cycle color mode on sliders"
+
+#: ../src/iop/temperature.c:2107
+msgid "color temperature (in Kelvin)"
+msgstr "Color temperature (in Kelvin)"
+
+#: ../src/iop/temperature.c:2113
+msgid "tint"
+msgstr "Tint"
+
+#: ../src/iop/temperature.c:2116
+msgid "color tint of the image, from magenta (value < 1) to green (value > 1)"
+msgstr "Color tint of the image, from magenta (value < 1) to green (value > 1)"
+
+#: ../src/iop/temperature.c:2122
+msgid "channel coefficients"
+msgstr "Channel coefficients"
+
+#: ../src/iop/temperature.c:2157
+msgid "white balance disabled for camera"
+msgstr "White balance disabled for camera"
+
+#: ../src/iop/tonecurve.c:190
+msgid "tone curve"
+msgstr "Tone curve"
+
+#: ../src/iop/tonecurve.c:210
+msgid "alter an image’s tones using curves"
+msgstr "Alter an image’s tones using curves"
+
+#: ../src/iop/tonecurve.c:1124
+msgid ""
+"if set to auto, a and b curves have no effect and are not displayed. chroma "
+"values (a and b) of each pixel are then adjusted based on L curve data. auto "
+"XYZ is similar but applies the saturation changes in XYZ space."
+msgstr ""
+"If set to auto, a and b curves have no effect and are not displayed. Chroma "
+"values (a and b) of each pixel are then adjusted based on L curve data. Auto "
+"XYZ is similar but applies the saturation changes in XYZ space."
+
+#: ../src/iop/tonecurve.c:1133
+msgid "tonecurve for L channel"
+msgstr "Tonecurve for L channel"
+
+#: ../src/iop/tonecurve.c:1134
+msgid "tonecurve for a channel"
+msgstr "Tonecurve for a channel"
+
+#: ../src/iop/tonecurve.c:1135
+msgid "tonecurve for b channel"
+msgstr "Tonecurve for b channel"
+
+#: ../src/iop/toneequal.c:311
+msgid "tone equalizer"
+msgstr "Tone equalizer"
+
+#: ../src/iop/toneequal.c:316
+msgid "tone curve|tone mapping|relight|background light|shadows highlights"
+msgstr "tone curve|tone mapping|relight|background light|shadows highlights"
+
+#: ../src/iop/toneequal.c:323
+msgid "relight the scene as if the lighting was done directly on the scene"
+msgstr "Relight the scene as if the lighting was done directly on the scene"
+
+#: ../src/iop/toneequal.c:326
+msgid "quasi-linear, RGB"
+msgstr "Quasi-linear, RGB"
+
+#: ../src/iop/toneequal.c:327
+msgid "quasi-linear, RGB, scene-referred"
+msgstr "Quasi-linear, RGB, scene-referred"
+
+#: ../src/iop/toneequal.c:458
+msgid "simple tone curve"
+msgstr "Simple tone curve"
+
+#: ../src/iop/toneequal.c:472
+msgid "mask blending: all purposes"
+msgstr "Mask blending: all purposes"
+
+#: ../src/iop/toneequal.c:479
+msgid "mask blending: people with backlight"
+msgstr "Mask blending: people with backlight"
+
+#: ../src/iop/toneequal.c:496
+msgid "compress shadows/highlights (EIGF): strong"
+msgstr "Compress shadows/highlights (EIGF): strong"
+
+#: ../src/iop/toneequal.c:501
+msgid "compress shadows/highlights (GF): strong"
+msgstr "Compress shadows/highlights (GF): strong"
+
+#: ../src/iop/toneequal.c:510
+msgid "compress shadows/highlights (EIGF): medium"
+msgstr "Compress shadows/highlights (EIGF): medium"
+
+#: ../src/iop/toneequal.c:515
+msgid "compress shadows/highlights (GF): medium"
+msgstr "Compress shadows/highlights (GF): medium"
+
+#: ../src/iop/toneequal.c:524
+msgid "compress shadows/highlights (EIGF): soft"
+msgstr "Compress shadows/highlights (EIGF): soft"
+
+#: ../src/iop/toneequal.c:529
+msgid "compress shadows/highlights (GF): soft"
+msgstr "Compress shadows/highlights (GF): soft"
+
+#: ../src/iop/toneequal.c:537
+msgid "contrast tone curve: soft"
+msgstr "Contrast tone curve: soft"
+
+#: ../src/iop/toneequal.c:542
+msgid "contrast tone curve: medium"
+msgstr "Contrast tone curve: medium"
+
+#: ../src/iop/toneequal.c:547
+msgid "contrast tone curve: strong"
+msgstr "Contrast tone curve: strong"
+
+#: ../src/iop/toneequal.c:570
+msgid "relight: fill-in"
+msgstr "Relight: fill-in"
+
+#: ../src/iop/toneequal.c:627
+msgid ""
+"tone equalizer needs to be after distortion modules in the pipeline – "
+"disabled"
+msgstr ""
+"Tone equalizer needs to be after distortion modules in the pipeline – "
+"disabled"
+
+#. Pointers are not 64-bits aligned, and SSE code will segfault
+#: ../src/iop/toneequal.c:997
+msgid ""
+"tone equalizer in/out buffer are ill-aligned, please report the bug to the "
+"developers"
+msgstr ""
+"Tone equalizer in/out buffer are ill-aligned, please report the bug to the "
+"developers"
+
+#: ../src/iop/toneequal.c:1102
+msgid "tone equalizer failed to allocate memory, check your RAM settings"
+msgstr "Tone equalizer failed to allocate memory, check your RAM settings"
+
+#: ../src/iop/toneequal.c:1811 ../src/iop/toneequal.c:2196
+msgid "the interpolation is unstable, decrease the curve smoothing"
+msgstr "The interpolation is unstable, decrease the curve smoothing"
+
+#: ../src/iop/toneequal.c:1846 ../src/iop/toneequal.c:1913
+msgid "wait for the preview to finish recomputing"
+msgstr "Wait for the preview to finish recomputing"
+
+#: ../src/iop/toneequal.c:2053 ../src/iop/toneequal.c:2603
+msgid ""
+"scroll over image to change tone exposure\n"
+"shift+scroll for large steps; ctrl+scroll for small steps"
+msgstr ""
+"Scroll over image to change tone exposure\n"
+"Shift+scroll for large steps; ctrl+scroll for small steps"
+
+#: ../src/iop/toneequal.c:2201
+msgid "some parameters are out-of-bounds"
+msgstr "Some parameters are out-of-bounds"
+
+#: ../src/iop/toneequal.c:2540
+#, c-format
+msgid "%+.1f EV"
+msgstr "%+.1f EV"
+
+#: ../src/iop/toneequal.c:3252
+#, c-format
+msgid "[%s over image] change tone exposure"
+msgstr "[%s over image] change tone exposure"
+
+#: ../src/iop/toneequal.c:3255
+#, c-format
+msgid "[%s over image] change tone exposure in large steps"
+msgstr "[%s over image] change tone exposure in large steps"
+
+#: ../src/iop/toneequal.c:3258
+#, c-format
+msgid "[%s over image] change tone exposure in small steps"
+msgstr "[%s over image] change tone exposure in small steps"
+
+#. Simple view
+#: ../src/iop/toneequal.c:3339 ../src/iop/toneequal.c:3368
+#: ../src/iop/toneequal.c:3369 ../src/iop/toneequal.c:3370
+#: ../src/iop/toneequal.c:3371 ../src/iop/toneequal.c:3372
+#: ../src/iop/toneequal.c:3373 ../src/iop/toneequal.c:3374
+#: ../src/iop/toneequal.c:3375 ../src/iop/toneequal.c:3376
+msgid "simple"
+msgstr "Simple"
+
+#: ../src/iop/toneequal.c:3368
+msgid "-8 EV"
+msgstr "-8 EV"
+
+#: ../src/iop/toneequal.c:3369
+msgid "-7 EV"
+msgstr "-7 EV"
+
+#: ../src/iop/toneequal.c:3370
+msgid "-6 EV"
+msgstr "-6 EV"
+
+#: ../src/iop/toneequal.c:3371
+msgid "-5 EV"
+msgstr "-5 EV"
+
+#: ../src/iop/toneequal.c:3372
+msgid "-4 EV"
+msgstr "-4 EV"
+
+#: ../src/iop/toneequal.c:3373
+msgid "-3 EV"
+msgstr "-3 EV"
+
+#: ../src/iop/toneequal.c:3374
+msgid "-2 EV"
+msgstr "-2 EV"
+
+#: ../src/iop/toneequal.c:3375
+msgid "-1 EV"
+msgstr "-1 EV"
+
+#: ../src/iop/toneequal.c:3376
+msgid "+0 EV"
+msgstr "+0 EV"
+
+#. Advanced view
+#: ../src/iop/toneequal.c:3380
+msgid "advanced"
+msgstr "Advanced"
+
+#: ../src/iop/toneequal.c:3407
+msgid "double-click to reset the curve"
+msgstr "Double-click to reset the curve"
+
+#: ../src/iop/toneequal.c:3411
+msgid "curve smoothing"
+msgstr "Curve smoothing"
+
+#: ../src/iop/toneequal.c:3414
+msgid ""
+"positive values will produce more progressive tone transitions\n"
+"but the curve might become oscillatory in some settings.\n"
+"negative values will avoid oscillations and behave more robustly\n"
+"but may produce brutal tone transitions and damage local contrast."
+msgstr ""
+"Positive values will produce more progressive tone transitions\n"
+"but the curve might become oscillatory in some settings.\n"
+"Negative values will avoid oscillations and behave more robustly\n"
+"but may produce brutal tone transitions and damage local contrast."
+
+#. Masking options
+#: ../src/iop/toneequal.c:3424
+msgid "masking"
+msgstr "Masking"
+
+#: ../src/iop/toneequal.c:3430
+msgid ""
+"preview the mask and chose the estimator that gives you the\n"
+"higher contrast between areas to dodge and areas to burn"
+msgstr ""
+"Preview the mask and chose the estimator that gives you the\n"
+"higher contrast between areas to dodge and areas to burn"
+
+#: ../src/iop/toneequal.c:3433
+msgid "details"
+msgstr "Details"
+
+#: ../src/iop/toneequal.c:3434
+msgid "preserve details"
+msgstr "Preserve details"
+
+#: ../src/iop/toneequal.c:3437
+msgid ""
+"'no' affects global and local contrast (safe if you only add contrast)\n"
+"'guided filter' only affects global contrast and tries to preserve local "
+"contrast\n"
+"'averaged guided filter' is a geometric mean of 'no' and 'guided filter' "
+"methods\n"
+"'EIGF' (exposure-independent guided filter) is a guided filter that is "
+"exposure-independent, it smooths shadows and highlights the same way "
+"(contrary to guided filter which smooths less the highlights)\n"
+"'averaged EIGF' is a geometric mean of 'no' and 'exposure-independent guided "
+"filter' methods"
+msgstr ""
+"'No' affects global and local contrast (safe if you only add contrast)\n"
+"'Guided filter' only affects global contrast and tries to preserve local "
+"contrast\n"
+"'Averaged guided filter' is a geometric mean of 'No' and 'Guided filter' "
+"methods\n"
+"'EIGF' (exposure-independent guided filter) is a guided filter that is "
+"exposure-independent, it smooths shadows and highlights the same way "
+"(contrary to guided filter which smooths less the highlights)\n"
+"'Averaged EIGF' is a geometric mean of 'No' and 'Exposure-independent guided "
+"filter' methods"
+
+#: ../src/iop/toneequal.c:3450
+msgid ""
+"number of passes of guided filter to apply\n"
+"helps diffusing the edges of the filter at the expense of speed"
+msgstr ""
+"Number of passes of guided filter to apply\n"
+"Helps diffusing the edges of the filter at the expense of speed"
+
+#: ../src/iop/toneequal.c:3458
+msgid ""
+"diameter of the blur in percent of the largest image size\n"
+"warning: big values of this parameter can make the darkroom\n"
+"preview much slower if denoise profiled is used."
+msgstr ""
+"Diameter of the blur in percent of the largest image size\n"
+"Warning: big values of this parameter can make the Darkroom\n"
+"preview much slower if denoise profiled is used."
+
+#: ../src/iop/toneequal.c:3466
+msgid ""
+"precision of the feathering:\n"
+"higher values force the mask to follow edges more closely\n"
+"but may void the effect of the smoothing\n"
+"lower values give smoother gradients and better smoothing\n"
+"but may lead to inaccurate edges taping and halos"
+msgstr ""
+"Precision of the feathering:\n"
+"Higher values force the mask to follow edges more closely\n"
+"but may void the effect of the smoothing\n"
+"Lower values give smoother gradients and better smoothing\n"
+"but may lead to inaccurate edges taping and halos"
+
+#: ../src/iop/toneequal.c:3473
+msgctxt "section"
+msgid "mask post-processing"
+msgstr "Mask post-processing"
+
+#: ../src/iop/toneequal.c:3484
+msgid ""
+"mask histogram span between the first and last deciles.\n"
+"the central line shows the average. orange bars appear at extrema if "
+"clipping occurs."
+msgstr ""
+"Mask histogram span between the first and last deciles.\n"
+"The central line shows the average. Orange bars appear at extrema if "
+"clipping occurs."
+
+#: ../src/iop/toneequal.c:3492
+msgid ""
+"0 disables the quantization.\n"
+"higher values posterize the luminance mask to help the guiding\n"
+"produce piece-wise smooth areas when using high feathering values"
+msgstr ""
+"0 disables the quantization.\n"
+"Higher values posterize the luminance mask to help the guiding\n"
+"Produce piece-wise smooth areas when using high feathering values"
+
+#: ../src/iop/toneequal.c:3501
+msgid ""
+"use this to slide the mask average exposure along channels\n"
+"for a better control of the exposure correction with the available nodes.\n"
+"the magic wand will auto-adjust the average exposure"
+msgstr ""
+"Use this to slide the mask average exposure along channels\n"
+"for a better control of the exposure correction with the available nodes.\n"
+"The magic wand will auto-adjust the average exposure"
+
+#: ../src/iop/toneequal.c:3514
+msgid ""
+"use this to counter the averaging effect of the guided filter\n"
+"and dilate the mask contrast around -4EV\n"
+"this allows to spread the exposure histogram over more channels\n"
+"for a better control of the exposure correction.\n"
+"the magic wand will auto-adjust the contrast"
+msgstr ""
+"Use this to counter the averaging effect of the guided filter\n"
+"and dilate the mask contrast around -4EV\n"
+"This allows to spread the exposure histogram over more channels\n"
+"for a better control of the exposure correction.\n"
+"The magic wand will auto-adjust the contrast"
+
+#: ../src/iop/toneequal.c:3537 ../src/iop/toneequal.c:3540
+msgid "display exposure mask"
+msgstr "Display exposure mask"
+
+#: ../src/iop/tonemap.cc:71
+msgid "tone mapping"
+msgstr "Tone mapping"
+
+#: ../src/iop/tonemap.cc:87
+msgid ""
+"this module is deprecated. please use the local contrast or tone equalizer "
+"module instead."
+msgstr ""
+"This module is deprecated. Please use the local contrast or tone equalizer "
+"module instead."
+
+#: ../src/iop/velvia.c:79
+msgid "velvia"
+msgstr "Velvia"
+
+#: ../src/iop/velvia.c:104
+msgid ""
+"resaturate giving more weight to blacks, whites and low-saturation pixels"
+msgstr ""
+"Resaturate giving more weight to blacks, whites and low-saturation pixels"
+
+#: ../src/iop/velvia.c:281
+msgid "the strength of saturation boost"
+msgstr "The strength of saturation boost"
+
+#: ../src/iop/velvia.c:284
+msgid "how much to spare highlights and shadows"
+msgstr "How much to spare highlights and shadows"
+
+#: ../src/iop/vibrance.c:62
+msgid ""
+"this module is deprecated. please use the vibrance slider in the color "
+"balance rgb module instead."
+msgstr ""
+"This module is deprecated. Please use the vibrance slider in the color "
+"balance rgb module instead."
+
+#: ../src/iop/vibrance.c:93
+msgid ""
+"saturate and reduce the lightness of the most saturated pixels\n"
+"to make the colors more vivid."
+msgstr ""
+"Saturate and reduce the lightness of the most saturated pixels\n"
+"to make the colors more vivid."
+
+#: ../src/iop/vibrance.c:217
+msgid "the amount of vibrance"
+msgstr "The amount of vibrance"
+
+#: ../src/iop/vignette.c:152
+msgid "vignetting"
+msgstr "Vignetting"
+
+#: ../src/iop/vignette.c:157
+msgid "simulate a lens fall-off close to edges"
+msgstr "Simulate a lens fall-off close to edges"
+
+#: ../src/iop/vignette.c:939
+msgid "lomo"
+msgstr "Lomo"
+
+#: ../src/iop/vignette.c:973
+msgctxt "section"
+msgid "position / form"
+msgstr "Position / form"
+
+#: ../src/iop/vignette.c:991
+msgid "the radii scale of vignette for start of fall-off"
+msgstr "The radii scale of vignette for start of fall-off"
+
+#: ../src/iop/vignette.c:992
+msgid "the radii scale of vignette for end of fall-off"
+msgstr "The radii scale of vignette for end of fall-off"
+
+#: ../src/iop/vignette.c:993
+msgid "strength of effect on brightness"
+msgstr "Strength of effect on brightness"
+
+#: ../src/iop/vignette.c:994
+msgid "strength of effect on saturation"
+msgstr "Strength of effect on saturation"
+
+#: ../src/iop/vignette.c:995
+msgid "horizontal offset of center of the effect"
+msgstr "Horizontal offset of center of the effect"
+
+#: ../src/iop/vignette.c:996
+msgid "vertical offset of center of the effect"
+msgstr "Vertical offset of center of the effect"
+
+#: ../src/iop/vignette.c:997
+msgid ""
+"shape factor\n"
+"0 produces a rectangle\n"
+"1 produces a circle or ellipse\n"
+"2 produces a diamond"
+msgstr ""
+"Shape factor\n"
+"0 produces a rectangle\n"
+"1 produces a circle or ellipse\n"
+"2 produces a diamond"
+
+#: ../src/iop/vignette.c:999
+msgid "enable to have the ratio automatically follow the image size"
+msgstr "Enable to have the ratio automatically follow the image size"
+
+#: ../src/iop/vignette.c:1000
+msgid "width-to-height ratio"
+msgstr "Width-to-height ratio"
+
+#: ../src/iop/vignette.c:1001
+msgid "add some level of random noise to prevent banding"
+msgstr "Add some level of random noise to prevent banding"
+
+#: ../src/iop/vignette.c:1008
+#, c-format
+msgid "[%s on node] change vignette/feather size"
+msgstr "[%s on node] change vignette/feather size"
+
+#: ../src/iop/vignette.c:1010
+#, c-format
+msgid "[%s on node] change vignette/feather size keeping ratio"
+msgstr "[%s on node] change vignette/feather size keeping ratio"
+
+#: ../src/iop/vignette.c:1012
+#, c-format
+msgid "[%s on center] move vignette"
+msgstr "[%s on center] move vignette"
+
+#: ../src/iop/watermark.c:291
+msgid "watermark"
+msgstr "Watermark"
+
+#: ../src/iop/watermark.c:296
+msgid "overlay an SVG watermark like a signature on the picture"
+msgstr "Overlay an SVG watermark like a signature on the picture"
+
+#: ../src/iop/watermark.c:1071
+msgid "marker"
+msgstr "Marker"
+
+#: ../src/iop/watermark.c:1074
+#, c-format
+msgid "SVG watermarks in %s/watermarks or %s/watermarks"
+msgstr "SVG watermarks in %s/watermarks or %s/watermarks"
+
+#. Simple text
+#: ../src/iop/watermark.c:1084 ../src/iop/watermark.c:1085
+msgid "text"
+msgstr "Text"
+
+#: ../src/iop/watermark.c:1086
+msgid ""
+"text string, tag:\n"
+"$(WATERMARK_TEXT)"
+msgstr ""
+"Text string, tag:\n"
+"$(WATERMARK_TEXT)"
+
+#: ../src/iop/watermark.c:1088
+msgid "content"
+msgstr "Content"
+
+#. Text font
+#: ../src/iop/watermark.c:1093
+msgid "font"
+msgstr "Font"
+
+#: ../src/iop/watermark.c:1098
+msgid ""
+"text font, tags:\n"
+"$(WATERMARK_FONT_FAMILY)\n"
+"$(WATERMARK_FONT_STYLE)\n"
+"$(WATERMARK_FONT_WEIGHT)"
+msgstr ""
+"Text font, tags:\n"
+"$(WATERMARK_FONT_FAMILY)\n"
+"$(WATERMARK_FONT_STYLE)\n"
+"$(WATERMARK_FONT_WEIGHT)"
+
+#: ../src/iop/watermark.c:1113
+msgid ""
+"watermark color, tag:\n"
+"$(WATERMARK_COLOR)"
+msgstr ""
+"Watermark color, tag:\n"
+"$(WATERMARK_COLOR)"
+
+#: ../src/iop/watermark.c:1115
+msgid "select watermark color"
+msgstr "Select watermark color"
+
+#: ../src/iop/watermark.c:1117
+msgid "pick color from image"
+msgstr "Pick color from image"
+
+#: ../src/iop/watermark.c:1129
+msgctxt "section"
+msgid "placement"
+msgstr "Placement"
+
+#: ../src/iop/watermark.c:1142
+msgid "size is relative to"
+msgstr "Size is relative to"
+
+#: ../src/iop/watermark.c:1146 ../src/libs/print_settings.c:2508
+msgid "alignment"
+msgstr "Alignment"
+
+#. Let's add some tooltips and hook up some signals...
+#: ../src/iop/watermark.c:1167
+msgid "the opacity of the watermark"
+msgstr "The opacity of the watermark"
+
+#: ../src/iop/watermark.c:1168
+msgid "the scale of the watermark"
+msgstr "The scale of the watermark"
+
+#: ../src/iop/watermark.c:1169
+msgid "the rotation of the watermark"
+msgstr "The rotation of the watermark"
+
+#: ../src/iop/zonesystem.c:111
+msgid "zone system"
+msgstr "Zone system"
+
+#: ../src/iop/zonesystem.c:490
+msgid ""
+"lightness zones\n"
+"use mouse scrollwheel to change the number of zones\n"
+"left-click on a border to create a marker\n"
+"right-click on a marker to delete it"
+msgstr ""
+"Lightness zones\n"
+"Use mouse scrollwheel to change the number of zones\n"
+"Left-click on a border to create a marker\n"
+"Right-click on a marker to delete it"
+
+#: ../src/libs/backgroundjobs.c:52
+msgid "background jobs"
+msgstr "Background jobs"
+
+#: ../src/libs/camera.c:78
+msgid "camera settings"
+msgstr "Camera settings"
+
+#: ../src/libs/camera.c:132
+msgid "toggle view property in center view"
+msgstr "Toggle view property in center view"
+
+#: ../src/libs/camera.c:202
+msgid "connection with camera lost, exiting tethering mode"
+msgstr "Connection with camera lost, exiting tethering mode"
+
+#: ../src/libs/camera.c:343
+msgid "battery"
+msgstr "Battery"
+
+#: ../src/libs/camera.c:343
+msgid "n/a"
+msgstr "n/a"
+
+#. Camera control
+#: ../src/libs/camera.c:418
+msgctxt "section"
+msgid "camera control"
+msgstr "Camera control"
+
+#: ../src/libs/camera.c:422 ../src/libs/histogram.c:2360
+msgid "modes"
+msgstr "Modes"
+
+#: ../src/libs/camera.c:423
+msgid "timer (s)"
+msgstr "Timer (s)"
+
+#: ../src/libs/camera.c:424
+msgid "count"
+msgstr "Count"
+
+#: ../src/libs/camera.c:425
+msgid "brackets"
+msgstr "Brackets"
+
+#: ../src/libs/camera.c:426
+msgid "bkt. steps"
+msgstr "Bkt. steps"
+
+#: ../src/libs/camera.c:459
+msgid "capture image(s)"
+msgstr "Capture image(s)"
+
+#: ../src/libs/camera.c:462
+msgid "toggle delayed capture mode"
+msgstr "Toggle delayed capture mode"
+
+#: ../src/libs/camera.c:463
+msgid "toggle sequenced capture mode"
+msgstr "Toggle sequenced capture mode"
+
+#: ../src/libs/camera.c:464
+msgid "toggle bracketed capture mode"
+msgstr "Toggle bracketed capture mode"
+
+#: ../src/libs/camera.c:465
+msgid "the count of seconds before actually doing a capture"
+msgstr "The count of seconds before actually doing a capture"
+
+#: ../src/libs/camera.c:467
+msgid ""
+"the amount of images to capture in a sequence,\n"
+"you can use this in conjunction with delayed mode to create stop-motion "
+"sequences"
+msgstr ""
+"The amount of images to capture in a sequence,\n"
+"You can use this in conjunction with delayed mode to create stop-motion "
+"sequences"
+
+#: ../src/libs/camera.c:470
+msgid ""
+"the amount of brackets on each side of centered shoot, amount of images = "
+"(brackets*2) + 1"
+msgstr ""
+"The amount of brackets on each side of centered shoot, amount of images = "
+"(brackets*2) + 1"
+
+#: ../src/libs/camera.c:472
+msgid ""
+"the amount of steps per bracket, steps is camera configurable and usually 3 "
+"steps per stop\n"
+"with other words, 3 steps is 1EV exposure step between brackets"
+msgstr ""
+"The amount of steps per bracket, steps is camera configurable and usually 3 "
+"steps per stop\n"
+"With other words, 3 steps is 1EV exposure step between brackets"
+
+#. user specified properties
+#: ../src/libs/camera.c:495
+msgctxt "section"
+msgid "additional properties"
+msgstr "Additional properties"
+
+#: ../src/libs/camera.c:498
+msgid "label"
+msgstr "Label"
+
+#: ../src/libs/camera.c:506
+msgid "property"
+msgstr "Property"
+
+#: ../src/libs/camera.c:518
+msgid "add user property"
+msgstr "Add user property"
+
+#: ../src/libs/camera.c:538
+msgid "program"
+msgstr "Program"
+
+#: ../src/libs/camera.c:541 ../src/libs/camera.c:543
+msgid "focus mode"
+msgstr "Focus mode"
+
+#: ../src/libs/camera.c:554
+msgid "shutterspeed2"
+msgstr "Shutterspeed2"
+
+#: ../src/libs/camera.c:556
+msgid "shutterspeed"
+msgstr "Shutterspeed"
+
+#: ../src/libs/camera.c:562
+msgid "WB"
+msgstr "WB"
+
+#: ../src/libs/collect.c:151
+msgid "collections"
+msgstr "Collections"
+
+#: ../src/libs/collect.c:408
+msgid "search filmroll"
+msgstr "Search filmroll"
+
+#: ../src/libs/collect.c:491
+#, c-format
+msgid "problem selecting new path for the filmroll in %s"
+msgstr "Problem selecting new path for the filmroll in %s"
+
+#: ../src/libs/collect.c:554
+msgid "search filmroll..."
+msgstr "Search filmroll..."
+
+#: ../src/libs/collect.c:558
+msgid "remove..."
+msgstr "Remove..."
+
+#: ../src/libs/collect.c:1226
+msgid "uncategorized"
+msgstr "Uncategorized"
+
+#: ../src/libs/collect.c:2139
+msgid "use <, <=, >, >=, <>, =, [;] as operators"
+msgstr "Use <, <=, >, >=, <>, =, [;] as operators"
+
+#: ../src/libs/collect.c:2143
+msgid ""
+"use <, <=, >, >=, <>, =, [;] as operators\n"
+"star rating: 0-5\n"
+"rejected images: -1"
+msgstr ""
+"Use <, <=, >, >=, <>, =, [;] as operators\n"
+"Star rating: 0-5\n"
+"Rejected images: -1"
+
+#: ../src/libs/collect.c:2150
+msgid ""
+"use <, <=, >, >=, <>, =, [;] as operators\n"
+"type dates in the form: YYYY:MM:DD hh:mm:ss.sss (only the year is mandatory)"
+msgstr ""
+"Use <, <=, >, >=, <>, =, [;] as operators\n"
+"Type dates in the form: YYYY:MM:DD hh:mm:ss.sss (only the year is mandatory)"
+
+#: ../src/libs/collect.c:2157
+#, no-c-format
+msgid "use `%' as wildcard and `,' to separate values"
+msgstr "Use `%' as wildcard and `,' to separate values"
+
+#: ../src/libs/collect.c:2163
+#, no-c-format
+msgid ""
+"use `%' as wildcard\n"
+"click to include hierarchy + sub-hierarchies (suffix `*')\n"
+"shift+click to include only the current hierarchy (no suffix)\n"
+"ctrl+click to include only sub-hierarchies (suffix `|%')"
+msgstr ""
+"Use `%' as wildcard\n"
+"Click to include hierarchy + sub-hierarchies (suffix `*')\n"
+"Shift+click to include only the current hierarchy (no suffix)\n"
+"Ctrl+click to include only sub-hierarchies (suffix `|%')"
+
+#: ../src/libs/collect.c:2175
+#, no-c-format
+msgid ""
+"use `%' as wildcard\n"
+"click to include location + sub-locations (suffix `*')\n"
+"shift+click to include only the current location (no suffix)\n"
+"ctrl+click to include only sub-locations (suffix `|%')"
+msgstr ""
+"Use `%' as wildcard\n"
+"Click to include location + sub-locations (suffix `*')\n"
+"Shift+click to include only the current location (no suffix)\n"
+"Ctrl+click to include only sub-locations (suffix `|%')"
+
+#: ../src/libs/collect.c:2187
+#, no-c-format
+msgid ""
+"use `%' as wildcard\n"
+"click to include current + sub-folders (suffix `*')\n"
+"shift+click to include only the current folder (no suffix)\n"
+"ctrl+click to include only sub-folders (suffix `|%')"
+msgstr ""
+"Use `%' as wildcard\n"
+"Click to include current + sub-folders (suffix `*')\n"
+"Shift+click to include only the current folder (no suffix)\n"
+"Ctrl+click to include only sub-folders (suffix `|%')"
+
+#: ../src/libs/collect.c:2198
+#, no-c-format
+msgid "use `%' as wildcard"
+msgstr "Use `%' as wildcard"
+
+#: ../src/libs/collect.c:2257 ../src/libs/collect.c:2271
+#: ../src/libs/collect.c:2880
+msgid "clear this rule"
+msgstr "Clear this rule"
+
+#: ../src/libs/collect.c:2261
+msgid "clear this rule or add new rules"
+msgstr "Clear this rule or add new rules"
+
+#: ../src/libs/collect.c:2886
+msgid "narrow down search"
+msgstr "Narrow down search"
+
+#: ../src/libs/collect.c:2891
+msgid "add more images"
+msgstr "Add more images"
+
+#: ../src/libs/collect.c:2896
+msgid "exclude images"
+msgstr "Exclude images"
+
+#: ../src/libs/collect.c:2903
+msgid "change to: and"
+msgstr "Change to: and"
+
+#: ../src/libs/collect.c:2908
+msgid "change to: or"
+msgstr "Change to: or"
+
+#: ../src/libs/collect.c:2913
+msgid "change to: except"
+msgstr "Change to: except"
+
+#. the different categories
+#: ../src/libs/collect.c:2939 ../src/libs/filtering.c:858
+#: ../src/libs/filtering.c:925 ../src/libs/filtering.c:1559
+#: ../src/libs/filtering.c:1891
+msgid "files"
+msgstr "Files"
+
+#: ../src/libs/collect.c:2944 ../src/libs/export_metadata.c:310
+#: ../src/libs/filtering.c:863 ../src/libs/filtering.c:930
+#: ../src/libs/filtering.c:1567 ../src/libs/filtering.c:1895
+#: ../src/libs/image.c:466 ../src/libs/image.c:576 ../src/libs/image.c:584
+#: ../src/libs/metadata.c:615 ../src/libs/metadata_view.c:1225
+msgid "metadata"
+msgstr "Metadata"
+
+#: ../src/libs/collect.c:2963 ../src/libs/filtering.c:884
+#: ../src/libs/filtering.c:951 ../src/libs/filtering.c:1893
+msgid "times"
+msgstr "Times"
+
+#: ../src/libs/collect.c:2971 ../src/libs/filtering.c:892
+#: ../src/libs/filtering.c:959 ../src/libs/filtering.c:1591
+msgid "capture details"
+msgstr "Capture details"
+
+#: ../src/libs/collect.c:2980 ../src/libs/filtering.c:901
+#: ../src/libs/filtering.c:968 ../src/libs/filtering.c:1603
+#: ../src/libs/filtering.c:1897 ../src/libs/tools/darktable.c:65
+msgid "darktable"
+msgstr "Darktable"
+
+#: ../src/libs/collect.c:2993
+msgid "collections settings"
+msgstr "Collections settings"
+
+#: ../src/libs/collect.c:2996 ../src/libs/export_metadata.c:288
+#: ../src/libs/metadata.c:574 ../src/libs/metadata_view.c:1193
+#: ../src/libs/recentcollect.c:296 ../src/libs/tagging.c:1650
+#: ../src/libs/tagging.c:1780 ../src/libs/tagging.c:2054
+#: ../src/libs/tagging.c:3472
+msgid "save"
+msgstr "Save"
+
+#: ../src/libs/collect.c:3016 ../src/libs/export.c:1051
+#: ../src/libs/metadata.c:709 ../src/libs/metadata_view.c:1305
+#: ../src/libs/recentcollect.c:363 ../src/libs/tagging.c:3494
+msgid "preferences..."
+msgstr "Preferences..."
+
+#: ../src/libs/collect.c:3116 ../src/libs/filtering.c:1433
+msgid "AND"
+msgstr "AND"
+
+#: ../src/libs/collect.c:3121 ../src/libs/filtering.c:1438
+msgid "OR"
+msgstr "OR"
+
+#. case DT_LIB_COLLECT_MODE_AND_NOT:
+#: ../src/libs/collect.c:3126 ../src/libs/filtering.c:1443
+msgid "BUT NOT"
+msgstr "BUT NOT"
+
+#: ../src/libs/collect.c:3298 ../src/libs/filtering.c:2165
+msgid "revert to a previous set of rules"
+msgstr "Revert to a previous set of rules"
+
+#: ../src/libs/collect.c:3355
+msgid "jump back to previous collection"
+msgstr "Jump back to previous collection"
+
+#: ../src/libs/colorpicker.c:51
+msgid "LCh"
+msgstr "LCh"
+
+#: ../src/libs/colorpicker.c:51
+msgid "HSV"
+msgstr "HSV"
+
+#: ../src/libs/colorpicker.c:51
+msgid "Hex"
+msgstr "Hex"
+
+#: ../src/libs/colorpicker.c:53
+msgid "mean"
+msgstr "Mean"
+
+#: ../src/libs/colorpicker.c:71
+msgid "color picker"
+msgstr "Color picker"
+
+#: ../src/libs/colorpicker.c:464
+msgid ""
+"hover to highlight sample on canvas,\n"
+"click to lock sample,\n"
+"right-click to load sample area into active color picker"
+msgstr ""
+"Hover to highlight sample on canvas,\n"
+"Click to lock sample,\n"
+"Right-click to load sample area into active color picker"
+
+#: ../src/libs/colorpicker.c:562 ../src/libs/colorpicker.c:613
+msgid "click to (un)hide large color patch"
+msgstr "Click to (un)hide large color patch"
+
+#: ../src/libs/colorpicker.c:576
+msgid "statistic"
+msgstr "Statistic"
+
+#: ../src/libs/colorpicker.c:577
+msgid "select which statistic to show"
+msgstr "Select which statistic to show"
+
+#: ../src/libs/colorpicker.c:586
+msgid "select which color mode to use"
+msgstr "Select which color mode to use"
+
+#: ../src/libs/colorpicker.c:595
+msgid ""
+"turn on color picker\n"
+"ctrl+click or right-click to select an area"
+msgstr ""
+"Turn on color picker\n"
+"Ctrl+click or right-click to select an area"
+
+#: ../src/libs/colorpicker.c:598
+msgid "pick color"
+msgstr "Pick color"
+
+#: ../src/libs/colorpicker.c:637
+msgid "add sample"
+msgstr "Add sample"
+
+#. Adding the live samples section
+#: ../src/libs/colorpicker.c:641
+msgctxt "section"
+msgid "live samples"
+msgstr "Live samples"
+
+#: ../src/libs/colorpicker.c:649
+msgid "display samples on image/vectorscope"
+msgstr "Display samples on image/vectorscope"
+
+#: ../src/libs/colorpicker.c:658
+msgid "restrict scope to selection"
+msgstr "Restrict scope to selection"
+
+#: ../src/libs/copy_history.c:61
+msgid "history stack"
+msgstr "History stack"
+
+#: ../src/libs/copy_history.c:116
+msgid "open sidecar file"
+msgstr "Open sidecar file"
+
+#: ../src/libs/copy_history.c:151
+msgid "XMP sidecar files"
+msgstr "XMP sidecar files"
+
+#: ../src/libs/copy_history.c:168
+#, c-format
+msgid "error loading file '%s'"
+msgstr "Error loading file '%s'"
+
+#: ../src/libs/copy_history.c:208
+#, c-format
+msgid "no history compression of %d image"
+msgid_plural "no history compression of %d images"
+msgstr[0] "No history compression of %d image"
+msgstr[1] "No history compression of %d images"
+
+#: ../src/libs/copy_history.c:249
+msgid "delete images' history?"
+msgstr "Delete images' history?"
+
+#: ../src/libs/copy_history.c:250
+#, c-format
+msgid "do you really want to clear history of %d selected image?"
+msgid_plural "do you really want to clear history of %d selected images?"
+msgstr[0] "Do you really want to clear history of %d selected image?"
+msgstr[1] "Do you really want to clear history of %d selected images?"
+
+#: ../src/libs/copy_history.c:367
+msgid "selective copy..."
+msgstr "Selective copy..."
+
+#: ../src/libs/copy_history.c:368
+msgid "choose which modules to copy from the source image"
+msgstr "Choose which modules to copy from the source image"
+
+#: ../src/libs/copy_history.c:374
+msgid ""
+"copy history stack of\n"
+"first selected image"
+msgstr ""
+"Copy history stack of\n"
+"first selected image"
+
+#: ../src/libs/copy_history.c:379
+msgid "selective paste..."
+msgstr "Selective paste..."
+
+#: ../src/libs/copy_history.c:380
+msgid "choose which modules to paste to the target image(s)"
+msgstr "Choose which modules to paste to the target image(s)"
+
+#: ../src/libs/copy_history.c:385 ../src/libs/image.c:590
+msgid "paste"
+msgstr "Paste"
+
+#: ../src/libs/copy_history.c:386
+msgid ""
+"paste history stack to\n"
+"all selected images"
+msgstr ""
+"Paste history stack to\n"
+"all selected images"
+
+#: ../src/libs/copy_history.c:392
+msgid "compress history"
+msgstr "Compress history"
+
+#: ../src/libs/copy_history.c:393
+msgid ""
+"compress history stack of\n"
+"all selected images"
+msgstr ""
+"Compress history stack of\n"
+"all selected images"
+
+#: ../src/libs/copy_history.c:398
+msgid ""
+"discard history stack of\n"
+"all selected images"
+msgstr ""
+"Discard history stack of\n"
+"all selected images"
+
+#: ../src/libs/copy_history.c:403 ../src/libs/styles.c:850
+msgid "how to handle existing history"
+msgstr "How to handle existing history"
+
+#: ../src/libs/copy_history.c:406 ../src/libs/styles.c:853
+msgid "append"
+msgstr "Append"
+
+#: ../src/libs/copy_history.c:412
+msgid "load sidecar file..."
+msgstr "Load sidecar file..."
+
+#: ../src/libs/copy_history.c:413
+msgid ""
+"open an XMP sidecar file\n"
+"and apply it to selected images"
+msgstr ""
+"Open an XMP sidecar file\n"
+"and apply it to selected images"
+
+#: ../src/libs/copy_history.c:418
+msgid "write history stack and tags to XMP sidecar files"
+msgstr "Write history stack and tags to XMP sidecar files"
+
+#: ../src/libs/duplicate.c:56
+msgid "duplicate manager"
+msgstr "Duplicate manager"
+
+#: ../src/libs/duplicate.c:399
+msgid "create a 'virgin' duplicate of the image without any development"
+msgstr "Create a 'virgin' duplicate of the image without any development"
+
+#: ../src/libs/duplicate.c:404
+msgid "create a duplicate of the image with same history stack"
+msgstr "Create a duplicate of the image with same history stack"
+
+#. Export button
+#: ../src/libs/export.c:154 ../src/libs/export.c:1296
+msgid "export"
+msgstr "Export"
+
+#: ../src/libs/export.c:311
+msgid "export to disk"
+msgstr "Export to disk"
+
+#: ../src/libs/export.c:490
+#, c-format
+msgid "which is equal to %s × %s px"
+msgstr "Which is equal to %s × %s px"
+
+#: ../src/libs/export.c:525
+msgctxt "unit"
+msgid "in"
+msgstr "in"
+
+#: ../src/libs/export.c:1066
+msgctxt "section"
+msgid "storage options"
+msgstr "Storage options"
+
+#: ../src/libs/export.c:1070
+msgid "target storage"
+msgstr "Target storage"
+
+#: ../src/libs/export.c:1092
+msgctxt "section"
+msgid "format options"
+msgstr "Format options"
+
+#: ../src/libs/export.c:1096
+msgid "file format"
+msgstr "File format"
+
+#: ../src/libs/export.c:1113
+msgctxt "section"
+msgid "global options"
+msgstr "Global options"
+
+#: ../src/libs/export.c:1116
+msgid "set size"
+msgstr "Set size"
+
+#: ../src/libs/export.c:1117
+msgid "choose a method for setting the output size"
+msgstr "Choose a method for setting the output size"
+
+#: ../src/libs/export.c:1120
+msgid "in pixels (for file)"
+msgstr "In pixels (for file)"
+
+#: ../src/libs/export.c:1121
+msgid "in cm (for print)"
+msgstr "In cm (for print)"
+
+#: ../src/libs/export.c:1122
+msgid "in inch (for print)"
+msgstr "In inch (for print)"
+
+#: ../src/libs/export.c:1123
+msgid "by scale (for file)"
+msgstr "By scale (for file)"
+
+#: ../src/libs/export.c:1125
+msgid "print width"
+msgstr "Print width"
+
+#: ../src/libs/export.c:1126 ../src/libs/export.c:1138
+msgid ""
+"maximum output width limit.\n"
+"click middle mouse button to reset to 0."
+msgstr ""
+"Maximum output width limit.\n"
+"Click middle mouse button to reset to 0."
+
+#: ../src/libs/export.c:1129
+msgid "print height"
+msgstr "Print height"
+
+#: ../src/libs/export.c:1130 ../src/libs/export.c:1142
+msgid ""
+"maximum output height limit.\n"
+"click middle mouse button to reset to 0."
+msgstr ""
+"Maximum output height limit.\n"
+"Click middle mouse button to reset to 0."
+
+#: ../src/libs/export.c:1134
+msgid "resolution in dot per inch"
+msgstr "Resolution in dot per inch"
+
+#: ../src/libs/export.c:1141 ../src/libs/metadata_view.c:148
+#: ../src/libs/print_settings.c:2382
+msgid "height"
+msgstr "Height"
+
+#: ../src/libs/export.c:1154
+msgid "@"
+msgstr "@"
+
+#: ../src/libs/export.c:1167 ../src/libs/tools/global_toolbox.c:219
+msgid "px"
+msgstr "px"
+
+#: ../src/libs/export.c:1172
+msgid ""
+"it can be an integer, decimal number or simple fraction.\n"
+"zero or empty values are equal to 1.\n"
+"click middle mouse button to reset to 1."
+msgstr ""
+"It can be an integer, decimal number or simple fraction.\n"
+"Zero or empty values are equal to 1.\n"
+"Click middle mouse button to reset to 1."
+
+#: ../src/libs/export.c:1191
+msgid "allow upscaling"
+msgstr "Allow upscaling"
+
+#: ../src/libs/export.c:1197
+msgid "high quality resampling"
+msgstr "High quality resampling"
+
+#: ../src/libs/export.c:1198
+msgid "do high quality resampling during export"
+msgstr "Do high quality resampling during export"
+
+#: ../src/libs/export.c:1204
+msgid "store masks"
+msgstr "Store masks"
+
+#: ../src/libs/export.c:1205
+msgid "store masks as layers in exported images. only works for some formats."
+msgstr "Store masks as layers in exported images. Only works for some formats."
+
+#: ../src/libs/export.c:1221 ../src/libs/export.c:1260
+#: ../src/libs/print_settings.c:2600 ../src/libs/print_settings.c:2645
+msgid "image settings"
+msgstr "Image settings"
+
+#: ../src/libs/export.c:1233 ../src/libs/print_settings.c:2634
+#, c-format
+msgid "output ICC profiles in %s or %s"
+msgstr "Output ICC profiles in %s or %s"
+
+#: ../src/libs/export.c:1243
+msgid ""
+"• perceptual: smoothly moves out-of-gamut colors into gamut, preserving "
+"gradations,\n"
+"but distorts in-gamut colors in the process.\n"
+"note that perceptual is often a proprietary LUT that depends on the "
+"destination space.\n"
+"\n"
+"• relative colorimetric: keeps luminance while reducing as little as "
+"possible\n"
+"saturation until colors fit in gamut.\n"
+"\n"
+"• saturation: designed to present eye-catching business graphics\n"
+"by preserving the saturation. (not suited for photography).\n"
+"\n"
+"• absolute colorimetric: adapt white point of the image to the white point "
+"of the\n"
+"destination medium and do nothing else. mainly used when proofing colors.\n"
+"(not suited for photography)."
+msgstr ""
+"• Perceptual: smoothly moves out-of-gamut colors into gamut, preserving "
+"gradations,\n"
+"but distorts in-gamut colors in the process.\n"
+"Note that perceptual is often a proprietary LUT that depends on the "
+"destination space.\n"
+"\n"
+"• Relative colorimetric: keeps luminance while reducing as little as "
+"possible\n"
+"saturation until colors fit in gamut.\n"
+"\n"
+"• Saturation: designed to present eye-catching business graphics\n"
+"by preserving the saturation. (not suited for photography).\n"
+"\n"
+"• Absolute colorimetric: adapt white point of the image to the white point "
+"of the\n"
+"destination medium and do nothing else. Mainly used when proofing colors.\n"
+"(not suited for photography)."
+
+#: ../src/libs/export.c:1270 ../src/libs/print_settings.c:2655
+msgid "style"
+msgstr "Style"
+
+#: ../src/libs/export.c:1273
+msgid "temporary style to use while exporting"
+msgstr "Temporary style to use while exporting"
+
+#: ../src/libs/export.c:1278 ../src/libs/print_settings.c:2697
+msgid ""
+"whether the style items are appended to the history or replacing the history"
+msgstr ""
+"Whether the style items are appended to the history or replacing the history"
+
+#: ../src/libs/export.c:1281 ../src/libs/print_settings.c:2699
+msgid "replace history"
+msgstr "Replace history"
+
+#: ../src/libs/export.c:1281 ../src/libs/print_settings.c:2699
+msgid "append history"
+msgstr "Append history"
+
+#: ../src/libs/export.c:1297
+msgid "export with current settings"
+msgstr "Export with current settings"
+
+#: ../src/libs/export_metadata.c:163
+msgid "select tag"
+msgstr "Select tag"
+
+#: ../src/libs/export_metadata.c:164
+msgid "add"
+msgstr "Add"
+
+#: ../src/libs/export_metadata.c:175
+msgid "list filter"
+msgstr "List filter"
+
+#: ../src/libs/export_metadata.c:186
+msgid ""
+"list of available tags. click 'add' button or double-click on tag to add the "
+"selected one"
+msgstr ""
+"List of available tags. Click 'add' button or double-click on tag to add the "
+"selected one"
+
+#: ../src/libs/export_metadata.c:287
+msgid "edit metadata exportation"
+msgstr "Edit metadata exportation"
+
+#: ../src/libs/export_metadata.c:302
+msgid "general settings"
+msgstr "General settings"
+
+#: ../src/libs/export_metadata.c:307
+msgid "EXIF data"
+msgstr "EXIF data"
+
+#: ../src/libs/export_metadata.c:308
+msgid "export EXIF metadata"
+msgstr "Export EXIF metadata"
+
+#: ../src/libs/export_metadata.c:311
+msgid "export darktable XMP metadata (from metadata editor module)"
+msgstr "Export darktable XMP metadata (from metadata editor module)"
+
+#: ../src/libs/export_metadata.c:321
+msgid "only embedded"
+msgstr "Only embedded"
+
+#: ../src/libs/export_metadata.c:322
+msgid ""
+"per default the interface sends some (limited) metadata beside the image to "
+"remote storage.\n"
+"to avoid this and let only image embedded darktable XMP metadata, check this "
+"flag.\n"
+"if remote storage doesn't understand darktable XMP metadata, you can use "
+"calculated metadata instead"
+msgstr ""
+"Per default the interface sends some (limited) metadata beside the image to "
+"remote storage.\n"
+"To avoid this and let only image embedded darktable XMP metadata, check this "
+"flag.\n"
+"If remote storage doesn't understand darktable XMP metadata, you can use "
+"calculated metadata instead"
+
+#: ../src/libs/export_metadata.c:328 ../src/libs/image.c:568
+msgid "geo tags"
+msgstr "Geo tags"
+
+#: ../src/libs/export_metadata.c:329
+msgid "export geo tags"
+msgstr "Export geo tags"
+
+#: ../src/libs/export_metadata.c:332
+msgid "export tags (to Xmp.dc.Subject)"
+msgstr "Export tags (to Xmp.dc.Subject)"
+
+#: ../src/libs/export_metadata.c:340
+msgid "private tags"
+msgstr "Private tags"
+
+#: ../src/libs/export_metadata.c:341
+msgid "export private tags"
+msgstr "Export private tags"
+
+#: ../src/libs/export_metadata.c:343
+msgid "synonyms"
+msgstr "Synonyms"
+
+#: ../src/libs/export_metadata.c:344
+msgid "export tags synonyms"
+msgstr "Export tags synonyms"
+
+#: ../src/libs/export_metadata.c:346
+msgid "omit hierarchy"
+msgstr "Omit hierarchy"
+
+#: ../src/libs/export_metadata.c:347
+msgid ""
+"only the last part of the hierarchical tags is included. can be useful if "
+"categories are not used"
+msgstr ""
+"Only the last part of the hierarchical tags is included. Can be useful if "
+"categories are not used"
+
+#: ../src/libs/export_metadata.c:350
+msgid "hierarchical tags"
+msgstr "Hierarchical tags"
+
+#: ../src/libs/export_metadata.c:351
+msgid "export hierarchical tags (to Xmp.lr.Hierarchical Subject)"
+msgstr "Export hierarchical tags (to Xmp.lr.Hierarchical Subject)"
+
+#: ../src/libs/export_metadata.c:353
+msgid "develop history"
+msgstr "Develop history"
+
+#: ../src/libs/export_metadata.c:354
+msgid ""
+"export darktable development data (recovery purpose in case of loss of "
+"database or XMP file)"
+msgstr ""
+"Export darktable development data (recovery purpose in case of loss of "
+"database or XMP file)"
+
+#: ../src/libs/export_metadata.c:361
+msgid "per metadata settings"
+msgstr "Per metadata settings"
+
+#: ../src/libs/export_metadata.c:374
+msgid "redefined tag"
+msgstr "Redefined tag"
+
+#: ../src/libs/export_metadata.c:380
+msgid "formula"
+msgstr "Formula"
+
+#: ../src/libs/export_metadata.c:383
+msgid ""
+"list of calculated metadata\n"
+"click on '+' button to select and add new metadata\n"
+"if formula is empty, the corresponding metadata is removed from exported "
+"file,\n"
+"if formula is '=', the EXIF metadata is exported even if EXIF data are "
+"disabled\n"
+"otherwise the corresponding metadata is calculated and added to exported "
+"file\n"
+"click on formula cell to edit\n"
+"type '$(' to activate the completion and see the list of variables"
+msgstr ""
+"List of calculated metadata\n"
+"Click on '+' button to select and add new metadata\n"
+"If formula is empty, the corresponding metadata is removed from exported "
+"file,\n"
+"If formula is '=', the EXIF metadata is exported even if EXIF data are "
+"disabled\n"
+"Otherwise the corresponding metadata is calculated and added to exported "
+"file\n"
+"Click on formula cell to edit\n"
+"Type '$(' to activate the completion and see the list of variables"
+
+#: ../src/libs/export_metadata.c:440
+msgid "add an output metadata tag"
+msgstr "Add an output metadata tag"
+
+#: ../src/libs/export_metadata.c:445
+msgid "delete metadata tag"
+msgstr "Delete metadata tag"
+
+#: ../src/libs/filtering.c:58 ../src/libs/metadata_view.c:128
+msgid "full path"
+msgstr "Full path"
+
+#: ../src/libs/filtering.c:72
+msgid "group"
+msgstr "Group"
+
+#: ../src/libs/filtering.c:73 ../src/libs/live_view.c:314
+msgid "id"
+msgstr "Id"
+
+#: ../src/libs/filtering.c:74
+msgid "custom sort"
+msgstr "Custom sort"
+
+#: ../src/libs/filtering.c:75
+msgid "shuffle"
+msgstr "Shuffle"
+
+#: ../src/libs/filtering.c:263
+msgid "collection filters"
+msgstr "Collection filters"
+
+#: ../src/libs/filtering.c:296
+msgid "initial setting"
+msgstr "Initial setting"
+
+#: ../src/libs/filtering.c:315
+msgid "imported: last 24h"
+msgstr "Imported: last 24h"
+
+#: ../src/libs/filtering.c:320
+msgid "imported: last 30 days"
+msgstr "Imported: last 30 days"
+
+#: ../src/libs/filtering.c:326
+msgid "taken: last 24h"
+msgstr "Taken: last 24h"
+
+#: ../src/libs/filtering.c:330
+msgid "taken: last 30 days"
+msgstr "Taken: last 30 days"
+
+#: ../src/libs/filtering.c:703
+msgid "click or click&#38;drag to select one or multiple values"
+msgstr "Click or click&#38;drag to select one or multiple values"
+
+#: ../src/libs/filtering.c:704
+msgid "right-click opens a menu to select the available values"
+msgstr "Right-click opens a menu to select the available values"
+
+#: ../src/libs/filtering.c:801
+#, c-format
+msgid "you can't have more than %d rules"
+msgstr "You can't have more than %d rules"
+
+#: ../src/libs/filtering.c:923 ../src/libs/filtering.c:1557
+msgid "rule property"
+msgstr "Rule property"
+
+#: ../src/libs/filtering.c:988
+msgid ""
+"rule property\n"
+"this can't be changed as the rule is pinned to the toolbar"
+msgstr ""
+"Rule property\n"
+"This can't be changed as the rule is pinned to the toolbar"
+
+#: ../src/libs/filtering.c:1036
+msgctxt "quickfilter"
+msgid "filter"
+msgstr "Filter"
+
+#: ../src/libs/filtering.c:1063
+msgid ""
+"this rule is pinned to the top toolbar\n"
+"click to un-pin"
+msgstr ""
+"This rule is pinned to the top toolbar\n"
+"Click to un-pin"
+
+#: ../src/libs/filtering.c:1064
+msgid "you can't disable the rule as it is pinned to the toolbar"
+msgstr "You can't disable the rule as it is pinned to the toolbar"
+
+#: ../src/libs/filtering.c:1065
+msgid "you can't remove the rule as it is pinned to the toolbar"
+msgstr "You can't remove the rule as it is pinned to the toolbar"
+
+#: ../src/libs/filtering.c:1069
+msgid "click to pin this rule to the top toolbar"
+msgstr "Click to pin this rule to the top toolbar"
+
+#: ../src/libs/filtering.c:1070
+msgid "remove this collect rule"
+msgstr "Remove this collect rule"
+
+#: ../src/libs/filtering.c:1072
+msgid "this rule is enabled"
+msgstr "This rule is enabled"
+
+#: ../src/libs/filtering.c:1074
+msgid "this rule is disabled"
+msgstr "This rule is disabled"
+
+#: ../src/libs/filtering.c:1202
+msgid "or"
+msgstr "or"
+
+#: ../src/libs/filtering.c:1203
+msgid "and not"
+msgstr "and not"
+
+#: ../src/libs/filtering.c:1205
+msgid "define how this rule should interact with the previous one"
+msgstr "Define how this rule should interact with the previous one"
+
+#: ../src/libs/filtering.c:1467
+msgid " (off)"
+msgstr " (off)"
+
+#: ../src/libs/filtering.c:1664
+msgid "you can't add more rules."
+msgstr "You can't add more rules."
+
+#. fill the popover with all pinned rules
+#: ../src/libs/filtering.c:1697
+msgid "shown filters"
+msgstr "Shown filters"
+
+#: ../src/libs/filtering.c:1712
+msgid "new filter"
+msgstr "New filter"
+
+#: ../src/libs/filtering.c:1885
+msgid "sort order"
+msgstr "Sort order"
+
+#: ../src/libs/filtering.c:1887
+msgid "determine the sort order of shown images"
+msgstr "Determine the sort order of shown images"
+
+#: ../src/libs/filtering.c:1907
+msgid "sort direction"
+msgstr "Sort direction"
+
+#: ../src/libs/filtering.c:1912
+msgid "remove this sort order"
+msgstr "Remove this sort order"
+
+#: ../src/libs/filtering.c:1996
+#, c-format
+msgid "you can't have more than %d sort orders"
+msgstr "You can't have more than %d sort orders"
+
+#: ../src/libs/filtering.c:2050
+msgid "DESC"
+msgstr "DESC"
+
+#: ../src/libs/filtering.c:2050
+msgid "ASC"
+msgstr "ASC"
+
+#: ../src/libs/filtering.c:2161
+msgid "new rule"
+msgstr "New rule"
+
+#: ../src/libs/filtering.c:2162
+msgid "append new rule to collect images"
+msgstr "Append new rule to collect images"
+
+#: ../src/libs/filtering.c:2173 ../src/libs/tools/filter.c:117
+msgid "sort by"
+msgstr "Sort by"
+
+#: ../src/libs/filtering.c:2181
+msgid "new sort"
+msgstr "New sort"
+
+#: ../src/libs/filtering.c:2182
+msgid "append new sort to order images"
+msgstr "Append new sort to order images"
+
+#: ../src/libs/filtering.c:2185
+msgid "revert to a previous set of sort orders"
+msgstr "Revert to a previous set of sort orders"
+
+#. we change the tooltip of the reset button here, as we are sure the header is defined now
+#: ../src/libs/filtering.c:2235
+msgid ""
+"reset\n"
+"ctrl+click to remove pinned rules too"
+msgstr ""
+"Reset\n"
+"Ctrl+click to remove pinned rules too"
+
+#: ../src/libs/filters/colors.c:140
+msgid "Y"
+msgstr "Y"
+
+#: ../src/libs/filters/colors.c:149
+msgid "P"
+msgstr "P"
+
+#: ../src/libs/filters/colors.c:269
+msgid "color filter"
+msgstr "Color filter"
+
+#: ../src/libs/filters/colors.c:294
+msgid ""
+"filter by images color label\n"
+"click to toggle the color label selection\n"
+"ctrl+click to exclude the color label\n"
+"the gray button affects all color labels"
+msgstr ""
+"Filter by images color label\n"
+"Click to toggle the color label selection\n"
+"Ctrl+click to exclude the color label\n"
+"The gray button affects all color labels"
+
+#. create the filter combobox
+#: ../src/libs/filters/colors.c:301 ../src/libs/filters/colors.c:312
+#: ../src/libs/filters/grouping.c:167 ../src/libs/filters/history.c:153
+#: ../src/libs/filters/local_copy.c:142 ../src/libs/filters/module_order.c:161
+#: ../src/libs/filters/rating.c:199 ../src/libs/filters/rating.c:210
+#: ../src/libs/filters/rating_range.c:325
+msgid "rules"
+msgstr "Rules"
+
+#: ../src/libs/filters/colors.c:306
+msgid ""
+"filter by images color label\n"
+"and (∩): images having all selected color labels\n"
+"or (∪): images with at least one of the selected color labels"
+msgstr ""
+"Filter by images color label\n"
+"And (∩): images having all selected color labels\n"
+"Or (∪): images with at least one of the selected color labels"
+
+#: ../src/libs/filters/filename.c:365
+msgid ""
+"enter filename to search.\n"
+"multiple values can be separated by ','\n"
+"\n"
+"right-click to get existing filenames"
+msgstr ""
+"Enter filename to search.\n"
+"Multiple values can be separated by ','\n"
+"\n"
+"Right-click to get existing filenames"
+
+#: ../src/libs/filters/filename.c:376
+msgid "extension"
+msgstr "Extension"
+
+#: ../src/libs/filters/filename.c:377
+msgid ""
+"enter extension to search with starting dot\n"
+"multiple values can be separated by ','\n"
+"handled keywords: 'RAW', 'NOT RAW', 'LDR', 'HDR'\n"
+"\n"
+"right-click to get existing extensions"
+msgstr ""
+"Enter extension to search with starting dot\n"
+"Multiple values can be separated by ','\n"
+"Handled keywords: 'RAW', 'NOT RAW', 'LDR', 'HDR'\n"
+"\n"
+"Right-click to get existing extensions"
+
+#: ../src/libs/filters/filename.c:405
+msgid ""
+"click to select filename\n"
+"ctrl+click to select multiple values"
+msgstr ""
+"Click to select filename\n"
+"Ctrl+click to select multiple values"
+
+#: ../src/libs/filters/filename.c:432
+msgid ""
+"click to select extension\n"
+"ctrl+click to select multiple values"
+msgstr ""
+"Click to select extension\n"
+"Ctrl+click to select multiple values"
+
+#: ../src/libs/filters/grouping.c:141 ../src/libs/filters/grouping.c:169
+msgid "ungrouped images"
+msgstr "Ungrouped images"
+
+#: ../src/libs/filters/grouping.c:168
+msgid "select the type of grouped image to filter"
+msgstr "Select the type of grouped image to filter"
+
+#. predefined selections
+#: ../src/libs/filters/grouping.c:169 ../src/libs/filters/history.c:38
+#: ../src/libs/filters/local_copy.c:38 ../src/libs/filters/module_order.c:155
+#: ../src/libs/filters/rating_range.c:56 ../src/libs/filters/rating_range.c:72
+#: ../src/libs/filters/rating_range.c:109 ../src/libs/filters/ratio.c:68
+#: ../src/libs/filters/ratio.c:81
+msgid "all images"
+msgstr "All images"
+
+#: ../src/libs/filters/history.c:153
+msgid "filter on history state"
+msgstr "Filter on history state"
+
+#: ../src/libs/filters/local_copy.c:142
+msgid "local copied state filter"
+msgstr "Local copied state filter"
+
+#: ../src/libs/filters/module_order.c:161
+msgid "filter images based on their module order"
+msgstr "Filter images based on their module order"
+
+#: ../src/libs/filters/rating.c:199
+msgid "comparator"
+msgstr "Comparator"
+
+#: ../src/libs/filters/rating.c:200 ../src/libs/filters/rating.c:210
+msgid "filter by images rating"
+msgstr "Filter by images rating"
+
+#: ../src/libs/filters/rating.c:210 ../src/libs/image.c:544
+#: ../src/libs/tools/ratings.c:56
+msgid "ratings"
+msgstr "Ratings"
+
+#: ../src/libs/filters/rating.c:211
+msgid "unstarred only"
+msgstr "Unstarred only"
+
+#: ../src/libs/filters/rating.c:212 ../src/libs/filters/rating_range.c:60
+#: ../src/libs/filters/rating_range.c:75
+msgid "rejected only"
+msgstr "Rejected only"
+
+#: ../src/libs/filters/rating.c:212 ../src/libs/filters/rating_range.c:58
+#: ../src/libs/filters/rating_range.c:73 ../src/libs/filters/rating_range.c:138
+msgid "all except rejected"
+msgstr "All except rejected"
+
+#: ../src/libs/filters/rating_range.c:61 ../src/libs/filters/rating_range.c:76
+msgid "not rated only"
+msgstr "Not rated only"
+
+#: ../src/libs/filters/rating_range.c:99 ../src/libs/filters/rating_range.c:126
+#: ../src/libs/filters/rating_range.c:131
+#: ../src/libs/filters/rating_range.c:275
+msgid "rejected"
+msgstr "Rejected"
+
+#: ../src/libs/filters/rating_range.c:101
+#: ../src/libs/filters/rating_range.c:126
+#: ../src/libs/filters/rating_range.c:276
+msgid "not rated"
+msgstr "Not rated"
+
+#: ../src/libs/filters/rating_range.c:117
+msgid "only"
+msgstr "Only"
+
+#: ../src/libs/filters/rating_range.c:269
+msgid "better"
+msgstr "Better"
+
+#: ../src/libs/filters/rating_range.c:270
+msgid "worse"
+msgstr "Worse"
+
+#: ../src/libs/filters/rating_range.c:271
+msgid "cap"
+msgstr "Cap"
+
+#: ../src/libs/filters/rating_range.c:286
+msgid "rating filter"
+msgstr "Rating filter"
+
+#: ../src/libs/filters/ratio.c:70 ../src/libs/filters/ratio.c:82
+msgid "portrait images"
+msgstr "Portrait images"
+
+#: ../src/libs/filters/ratio.c:71 ../src/libs/filters/ratio.c:83
+msgid "square images"
+msgstr "Square images"
+
+#: ../src/libs/filters/ratio.c:72 ../src/libs/filters/ratio.c:84
+msgid "landscape images"
+msgstr "Landscape images"
+
+#: ../src/libs/filters/search.c:179
+#, no-c-format
+msgid ""
+"filter by text from images metadata, camera brand/model, tags, file path and "
+"name\n"
+"`%' is the wildcard character\n"
+"by default start and end wildcards are auto-applied\n"
+"starting or ending with a double quote disables the corresponding wildcard\n"
+"is dimmed during the search execution"
+msgstr ""
+"Filter by text from images metadata, camera brand/model, tags, file path and "
+"name\n"
+"`%' is the wildcard character\n"
+"By default start and end wildcards are auto-applied\n"
+"Starting or ending with a double quote disables the corresponding wildcard\n"
+"Is dimmed during the search execution"
+
+#: ../src/libs/geotagging.c:369
+msgid "apply offset and geo-location"
+msgstr "Apply offset and geo-location"
+
+#: ../src/libs/geotagging.c:370 ../src/libs/geotagging.c:1910
+msgid "apply geo-location"
+msgstr "Apply geo-location"
+
+#: ../src/libs/geotagging.c:372
+msgid ""
+"apply offset and geo-location to matching images\n"
+"double operation: two ctrl-Z to undo"
+msgstr ""
+"Apply offset and geo-location to matching images\n"
+"Double operation: two ctrl-Z to undo"
+
+#: ../src/libs/geotagging.c:374 ../src/libs/geotagging.c:1911
+msgid "apply geo-location to matching images"
+msgstr "Apply geo-location to matching images"
+
+#: ../src/libs/geotagging.c:811
+msgid "GPX file track segments"
+msgstr "GPX file track segments"
+
+#: ../src/libs/geotagging.c:831 ../src/libs/geotagging.c:1869
+msgid "start time"
+msgstr "Start time"
+
+#: ../src/libs/geotagging.c:832
+msgid "end time"
+msgstr "End time"
+
+#: ../src/libs/geotagging.c:833 ../src/libs/geotagging.c:1871
+msgid "points"
+msgstr "Points"
+
+#: ../src/libs/geotagging.c:834 ../src/libs/geotagging.c:1873
+#: ../src/libs/image.c:465
+msgid "images"
+msgstr "Images"
+
+#: ../src/libs/geotagging.c:927
+msgid "open GPX file"
+msgstr "Open GPX file"
+
+#: ../src/libs/geotagging.c:928 ../src/libs/tools/lighttable.c:332
+#: ../src/libs/tools/lighttable.c:400 ../src/views/darkroom.c:2214
+msgid "preview"
+msgstr "Preview"
+
+#: ../src/libs/geotagging.c:941
+msgid "GPS data exchange format"
+msgstr "GPS data exchange format"
+
+#: ../src/libs/geotagging.c:1739
+msgid "date/time"
+msgstr "Date/time"
+
+#: ../src/libs/geotagging.c:1740
+msgid ""
+"enter the new date/time (YYYY:MM:DD hh:mm:ss[.sss])\n"
+"key in the new numbers or scroll over the cell"
+msgstr ""
+"Enter the new date/time (YYYY:MM:DD hh:mm:ss[.sss])\n"
+"Key in the new numbers or scroll over the cell"
+
+#: ../src/libs/geotagging.c:1744
+msgid "original date/time"
+msgstr "Original date/time"
+
+#: ../src/libs/geotagging.c:1748
+msgid "lock date/time offset value to apply it onto another selection"
+msgstr "Lock date/time offset value to apply it onto another selection"
+
+#: ../src/libs/geotagging.c:1752
+msgid "date/time offset"
+msgstr "Date/time offset"
+
+#: ../src/libs/geotagging.c:1753
+msgid "offset or difference ([-]dd hh:mm:ss[.sss])"
+msgstr "Offset or difference ([-]dd hh:mm:ss[.sss])"
+
+#. apply
+#: ../src/libs/geotagging.c:1757
+msgid "apply offset"
+msgstr "Apply offset"
+
+#: ../src/libs/geotagging.c:1758
+msgid "apply offset to selected images"
+msgstr "Apply offset to selected images"
+
+#: ../src/libs/geotagging.c:1761
+msgid "apply date/time"
+msgstr "Apply date/time"
+
+#: ../src/libs/geotagging.c:1762
+msgid "apply the same date/time to selected images"
+msgstr "Apply the same date/time to selected images"
+
+#: ../src/libs/geotagging.c:1772
+msgid ""
+"start typing to show a list of permitted values and select your timezone.\n"
+"press enter to confirm, so that the asterisk * disappears"
+msgstr ""
+"Start typing to show a list of permitted values and select your timezone.\n"
+"Press enter to confirm, so that the asterisk * disappears"
+
+#. gpx
+#: ../src/libs/geotagging.c:1815
+msgid "apply GPX track file..."
+msgstr "Apply GPX track file..."
+
+#: ../src/libs/geotagging.c:1816
+msgid "parses a GPX file and updates location of selected images"
+msgstr "Parses a GPX file and updates location of selected images"
+
+#: ../src/libs/geotagging.c:1827
+msgctxt "section"
+msgid "GPX file"
+msgstr "GPX file"
+
+#: ../src/libs/geotagging.c:1834
+msgid "select a GPX track file..."
+msgstr "Select a GPX track file..."
+
+#: ../src/libs/geotagging.c:1851
+msgid ""
+"list of track segments in the GPX file, for each segment:\n"
+"- the start date/time in local time (LT)\n"
+"- the number of track points\n"
+"- the number of matching images based on images date/time, offset and time "
+"zone\n"
+"- more detailed time information hovering the row"
+msgstr ""
+"List of track segments in the GPX file, for each segment:\n"
+"- the start date/time in local time (LT)\n"
+"- the number of track points\n"
+"- the number of matching images based on images date/time, offset and time "
+"zone\n"
+"- more detailed time information hovering the row"
+
+#: ../src/libs/geotagging.c:1890
+msgid "preview images"
+msgstr "Preview images"
+
+#: ../src/libs/geotagging.c:1895
+msgid "show on map matching images"
+msgstr "Show on map matching images"
+
+#: ../src/libs/geotagging.c:1898
+msgid "select images"
+msgstr "Select images"
+
+#: ../src/libs/geotagging.c:1899
+msgid "select matching images"
+msgstr "Select matching images"
+
+#: ../src/libs/geotagging.c:1907
+msgid "number of matching images versus selected images"
+msgstr "Number of matching images versus selected images"
+
+#: ../src/libs/histogram.c:132
+msgid "monochromatic"
+msgstr "Monochromatic"
+
+#: ../src/libs/histogram.c:133
+msgid "analogous"
+msgstr "Analogous"
+
+#: ../src/libs/histogram.c:134
+msgid "analogous complementary"
+msgstr "Analogous complementary"
+
+#: ../src/libs/histogram.c:135
+msgid "complementary"
+msgstr "Complementary"
+
+#: ../src/libs/histogram.c:136
+msgid "split complementary"
+msgstr "Split complementary"
+
+#: ../src/libs/histogram.c:137
+msgid "dyad"
+msgstr "Dyad"
+
+#: ../src/libs/histogram.c:138
+msgid "triad"
+msgstr "Triad"
+
+#: ../src/libs/histogram.c:139
+msgid "tetrad"
+msgstr "Tetrad"
+
+#: ../src/libs/histogram.c:145
+msgid "vectorscope"
+msgstr "Vectorscope"
+
+#: ../src/libs/histogram.c:146
+msgid "waveform"
+msgstr "Waveform"
+
+#: ../src/libs/histogram.c:147
+msgid "rgb parade"
+msgstr "RGB parade"
+
+#: ../src/libs/histogram.c:148 ../src/libs/histogram.c:2309
+msgid "histogram"
+msgstr "Histogram"
+
+#: ../src/libs/histogram.c:242
+msgid "scopes"
+msgstr "Scopes"
+
+#: ../src/libs/histogram.c:1542
+msgid "scroll to coarse-rotate"
+msgstr "Scroll to coarse-rotate"
+
+#: ../src/libs/histogram.c:1543
+msgid "ctrl+scroll to fine rotate"
+msgstr "Ctrl+scroll to fine rotate"
+
+#: ../src/libs/histogram.c:1544
+msgid "shift+scroll to change width"
+msgstr "Shift+scroll to change width"
+
+#: ../src/libs/histogram.c:1545
+msgid "alt+scroll to cycle"
+msgstr "Alt+scroll to cycle"
+
+#: ../src/libs/histogram.c:1556
+msgid "drag to change black point"
+msgstr "Drag to change black point"
+
+#: ../src/libs/histogram.c:1557 ../src/libs/histogram.c:1564
+msgid "double-click resets"
+msgstr "Double-click resets"
+
+#: ../src/libs/histogram.c:1563
+msgid "drag to change exposure"
+msgstr "Drag to change exposure"
+
+#: ../src/libs/histogram.c:1725 ../src/libs/histogram.c:1765
+msgid "set scale to linear"
+msgstr "Set scale to linear"
+
+#: ../src/libs/histogram.c:1730 ../src/libs/histogram.c:1770
+msgid "set scale to logarithmic"
+msgstr "Set scale to logarithmic"
+
+#: ../src/libs/histogram.c:1746
+msgid "set scope to vertical"
+msgstr "Set scope to vertical"
+
+#: ../src/libs/histogram.c:1751
+msgid "set scope to horizontal"
+msgstr "Set scope to horizontal"
+
+#: ../src/libs/histogram.c:1780
+msgid "set view to AzBz"
+msgstr "Set view to AzBz"
+
+#: ../src/libs/histogram.c:1786
+msgid "set view to RYB"
+msgstr "Set view to RYB"
+
+#: ../src/libs/histogram.c:1792
+msgid "set view to u*v*"
+msgstr "Set view to u*v*"
+
+#: ../src/libs/histogram.c:2312 ../src/libs/histogram.c:2370
+msgid "cycle histogram modes"
+msgstr "Cycle histogram modes"
+
+#: ../src/libs/histogram.c:2316 ../src/libs/histogram.c:2371
+msgid "hide histogram"
+msgstr "Hide histogram"
+
+#: ../src/libs/histogram.c:2372 ../src/libs/histogram.c:2401
+msgid "switch histogram view"
+msgstr "Switch histogram view"
+
+#: ../src/libs/histogram.c:2379
+msgid "toggle blue channel"
+msgstr "Toggle blue channel"
+
+#: ../src/libs/histogram.c:2381 ../src/libs/histogram.c:2389
+#: ../src/libs/histogram.c:2397
+msgid "toggle colors"
+msgstr "Toggle colors"
+
+#: ../src/libs/histogram.c:2387
+msgid "toggle green channel"
+msgstr "Toggle green channel"
+
+#: ../src/libs/histogram.c:2395
+msgid "toggle red channel"
+msgstr "Toggle red channel"
+
+#: ../src/libs/histogram.c:2405
+msgid "cycle vectorscope types"
+msgstr "Cycle vectorscope types"
+
+#: ../src/libs/histogram.c:2413
+msgid "color harmonies"
+msgstr "Color harmonies"
+
+#: ../src/libs/histogram.c:2425
+msgid "cycle color harmonies"
+msgstr "Cycle color harmonies"
+
+#: ../src/libs/history.c:138
+msgid "compress history stack"
+msgstr "Compress history stack"
+
+#: ../src/libs/history.c:139
+msgid ""
+"create a minimal history stack which produces the same image\n"
+"ctrl+click to truncate history to the selected item"
+msgstr ""
+"Create a minimal history stack which produces the same image\n"
+"Ctrl+click to truncate history to the selected item"
+
+#: ../src/libs/history.c:150
+msgid "create a style from the current history stack"
+msgstr "Create a style from the current history stack"
+
+#: ../src/libs/history.c:152
+msgid "create style from history"
+msgstr "Create style from history"
+
+#: ../src/libs/history.c:222
+msgid "always-on module"
+msgstr "Always-on module"
+
+#: ../src/libs/history.c:228
+msgid "default enabled module"
+msgstr "Default enabled module"
+
+#: ../src/libs/history.c:235
+msgid "deprecated module"
+msgstr "Deprecated module"
+
+#: ../src/libs/history.c:957
+msgid "colorspace"
+msgstr "Colorspace"
+
+#: ../src/libs/history.c:959
+msgid "mask mode"
+msgstr "Mask mode"
+
+#: ../src/libs/history.c:963
+msgid "blend operation"
+msgstr "Blend operation"
+
+#: ../src/libs/history.c:973
+msgid "mask blur"
+msgstr "Mask blur"
+
+#: ../src/libs/history.c:976
+msgid "raster mask instance"
+msgstr "Raster mask instance"
+
+#: ../src/libs/history.c:977
+msgid "raster mask id"
+msgstr "Raster mask id"
+
+#: ../src/libs/history.c:983
+msgid "drawn mask polarity"
+msgstr "Drawn mask polarity"
+
+#: ../src/libs/history.c:987
+#, c-format
+msgid "a drawn mask was added"
+msgstr "A drawn mask was added"
+
+#: ../src/libs/history.c:989
+#, c-format
+msgid "the drawn mask was removed"
+msgstr "The drawn mask was removed"
+
+#: ../src/libs/history.c:990
+#, c-format
+msgid "the drawn mask was changed"
+msgstr "The drawn mask was changed"
+
+#: ../src/libs/history.c:1022
+msgid "parametric output mask:"
+msgstr "Parametric output mask:"
+
+#: ../src/libs/history.c:1023
+msgid "parametric input mask:"
+msgstr "Parametric input mask:"
+
+#: ../src/libs/history.c:1353
+msgid "delete image's history?"
+msgstr "Delete image's history?"
+
+#: ../src/libs/history.c:1354
+msgid "do you really want to clear history of current image?"
+msgstr "Do you really want to clear history of current image?"
+
+#: ../src/libs/image.c:72
+msgid "selected image[s]"
+msgstr "Selected image[s]"
+
+#: ../src/libs/image.c:285
+msgid "delete (trash)"
+msgstr "Delete (trash)"
+
+#: ../src/libs/image.c:288
+msgid "physically delete from disk (using trash if possible)"
+msgstr "Physically delete from disk (using trash if possible)"
+
+#: ../src/libs/image.c:289
+msgid "physically delete from disk immediately"
+msgstr "Physically delete from disk immediately"
+
+#: ../src/libs/image.c:476 ../src/libs/modulegroups.c:3813
+#: ../src/libs/styles.c:879
+msgid "remove"
+msgstr "Remove"
+
+#: ../src/libs/image.c:477
+msgid "remove images from the image library, without deleting"
+msgstr "Remove images from the image library, without deleting"
+
+#: ../src/libs/image.c:485
+msgid "move..."
+msgstr "Move..."
+
+#: ../src/libs/image.c:486
+msgid "move to other folder"
+msgstr "Move to other folder"
+
+#: ../src/libs/image.c:489
+msgid "copy..."
+msgstr "Copy..."
+
+#: ../src/libs/image.c:490
+msgid "copy to other folder"
+msgstr "Copy to other folder"
+
+#: ../src/libs/image.c:493
+msgid "create HDR"
+msgstr "Create HDR"
+
+#: ../src/libs/image.c:494
+msgid "create a high dynamic range image from selected shots"
+msgstr "Create a high dynamic range image from selected shots"
+
+#: ../src/libs/image.c:498
+msgid "add a duplicate to the image library, including its history stack"
+msgstr "Add a duplicate to the image library, including its history stack"
+
+#: ../src/libs/image.c:504 ../src/libs/image.c:507
+msgid "rotate selected images 90 degrees CCW"
+msgstr "Rotate selected images 90 degrees CCW"
+
+#: ../src/libs/image.c:511 ../src/libs/image.c:514
+msgid "rotate selected images 90 degrees CW"
+msgstr "Rotate selected images 90 degrees CW"
+
+#: ../src/libs/image.c:516
+msgid "reset rotation"
+msgstr "Reset rotation"
+
+#: ../src/libs/image.c:517
+msgid "reset rotation to EXIF data"
+msgstr "Reset rotation to EXIF data"
+
+#: ../src/libs/image.c:520
+msgid "copy locally"
+msgstr "Copy locally"
+
+#: ../src/libs/image.c:521
+msgid "copy the image locally"
+msgstr "Copy the image locally"
+
+#: ../src/libs/image.c:524
+msgid "resync local copy"
+msgstr "Resync local copy"
+
+#: ../src/libs/image.c:525
+msgid "synchronize the image's XMP and remove the local copy"
+msgstr "Synchronize the image's XMP and remove the local copy"
+
+#: ../src/libs/image.c:528
+msgctxt "selected images action"
+msgid "group"
+msgstr "Group"
+
+#: ../src/libs/image.c:529
+msgid "add selected images to expanded group or create a new one"
+msgstr "Add selected images to expanded group or create a new one"
+
+#: ../src/libs/image.c:533
+msgid "ungroup"
+msgstr "Ungroup"
+
+#: ../src/libs/image.c:534
+msgid "remove selected images from the group"
+msgstr "Remove selected images from the group"
+
+#: ../src/libs/image.c:546
+msgid "select ratings metadata"
+msgstr "Select ratings metadata"
+
+#: ../src/libs/image.c:552
+msgid "colors"
+msgstr "Colors"
+
+#: ../src/libs/image.c:554
+msgid "select colors metadata"
+msgstr "Select colors metadata"
+
+#: ../src/libs/image.c:562
+msgid "select tags metadata"
+msgstr "Select tags metadata"
+
+#: ../src/libs/image.c:570
+msgid "select geo tags metadata"
+msgstr "Select geo tags metadata"
+
+#: ../src/libs/image.c:578
+msgid "select darktable metadata (from metadata editor module)"
+msgstr "Select darktable metadata (from metadata editor module)"
+
+#: ../src/libs/image.c:586
+msgid "set the selected image as source of metadata"
+msgstr "Set the selected image as source of metadata"
+
+#: ../src/libs/image.c:591
+msgid "paste selected metadata on selected images"
+msgstr "Paste selected metadata on selected images"
+
+#: ../src/libs/image.c:595
+msgid "clear selected metadata on selected images"
+msgstr "Clear selected metadata on selected images"
+
+#: ../src/libs/image.c:600
+msgid "how to handle existing metadata"
+msgstr "How to handle existing metadata"
+
+#: ../src/libs/image.c:603
+msgid "merge"
+msgstr "Merge"
+
+#: ../src/libs/image.c:607
+msgid "update image information to match changes to file"
+msgstr "Update image information to match changes to file"
+
+#: ../src/libs/image.c:611
+msgid "set selection as monochrome images and activate monochrome workflow"
+msgstr "Set selection as monochrome images and activate monochrome workflow"
+
+#: ../src/libs/image.c:615
+msgid "set selection as color images"
+msgstr "Set selection as color images"
+
+#: ../src/libs/image.c:627
+msgid "duplicate virgin"
+msgstr "Duplicate virgin"
+
+#: ../src/libs/import.c:264
+#, c-format
+msgid "device \"%s\" connected on port \"%s\"."
+msgstr "Device \"%s\" connected on port \"%s\"."
+
+#: ../src/libs/import.c:274 ../src/libs/import.c:335 ../src/libs/import.c:1693
+msgid "copy & import from camera"
+msgstr "Copy & import from camera"
+
+#: ../src/libs/import.c:285 ../src/libs/import.c:337
+msgid "tethered shoot"
+msgstr "Tethered shoot"
+
+#: ../src/libs/import.c:292 ../src/libs/import.c:338
+msgid "unmount camera"
+msgstr "Unmount camera"
+
+#: ../src/libs/import.c:313
+msgid ""
+"camera is locked by another application\n"
+"make sure it is no longer mounted\n"
+"or quit the locking application"
+msgstr ""
+"Camera is locked by another application\n"
+"Make sure it is no longer mounted\n"
+"or quit the locking application"
+
+#: ../src/libs/import.c:316
+msgid "tethering and importing is disabled for this camera"
+msgstr "Tethering and importing is disabled for this camera"
+
+#: ../src/libs/import.c:318 ../src/libs/import.c:336
+msgid "mount camera"
+msgstr "Mount camera"
+
+#: ../src/libs/import.c:748
+#, c-format
+msgid "%d image out of %d selected"
+msgid_plural "%d images out of %d selected"
+msgstr[0] "%d image out of %d selected"
+msgstr[1] "%d images out of %d selected"
+
+#: ../src/libs/import.c:1040
+msgid "you can't delete the selected place"
+msgstr "You can't delete the selected place"
+
+#: ../src/libs/import.c:1154
+msgid "choose the root of the folder tree below"
+msgstr "Choose the root of the folder tree below"
+
+#: ../src/libs/import.c:1157
+msgid "places"
+msgstr "Places"
+
+#: ../src/libs/import.c:1163
+msgid "restore all default places you have removed by right-click"
+msgstr "Restore all default places you have removed by right-click"
+
+#: ../src/libs/import.c:1168
+msgid ""
+"add a custom place\n"
+"\n"
+"right-click on a place to remove it"
+msgstr ""
+"Add a custom place\n"
+"\n"
+"Right-click on a place to remove it"
+
+#: ../src/libs/import.c:1175
+msgid "you can add custom places using the plus icon"
+msgstr "You can add custom places using the plus icon"
+
+#: ../src/libs/import.c:1200
+msgid "select a folder to see the content"
+msgstr "Select a folder to see the content"
+
+#: ../src/libs/import.c:1203
+msgid "folders"
+msgstr "Folders"
+
+#: ../src/libs/import.c:1273
+msgid "home"
+msgstr "Home"
+
+#: ../src/libs/import.c:1285
+msgid "pictures"
+msgstr "Pictures"
+
+#: ../src/libs/import.c:1549
+msgid "mark already imported pictures"
+msgstr "Mark already imported pictures"
+
+#: ../src/libs/import.c:1563
+msgid "modified"
+msgstr "Modified"
+
+#: ../src/libs/import.c:1568
+msgid "file 'modified date/time', may be different from 'Exif date/time'"
+msgstr "File 'modified date/time', may be different from 'Exif date/time'"
+
+#: ../src/libs/import.c:1580
+msgid "show/hide thumbnails"
+msgstr "Show/hide thumbnails"
+
+#: ../src/libs/import.c:1650
+msgid "naming rules"
+msgstr "Naming rules"
+
+#: ../src/libs/import.c:1691
+msgid "add to library"
+msgstr "Add to library"
+
+#: ../src/libs/import.c:1692
+msgid "copy & import"
+msgstr "Copy & import"
+
+#: ../src/libs/import.c:1730
+msgid "select new"
+msgstr "Select new"
+
+#: ../src/libs/import.c:1773
+msgid "please wait while prefetching the list of images from camera..."
+msgstr "Please wait while prefetching the list of images from camera..."
+
+#: ../src/libs/import.c:1907
+msgid "invalid override date/time format"
+msgstr "Invalid override date/time format"
+
+#: ../src/libs/import.c:2010
+msgid "add to library..."
+msgstr "Add to library..."
+
+#: ../src/libs/import.c:2011
+msgid "add existing images to the library"
+msgstr "Add existing images to the library"
+
+#: ../src/libs/import.c:2017
+msgid "copy & import..."
+msgstr "Copy & import..."
+
+#: ../src/libs/import.c:2018
+msgid ""
+"copy and optionally rename images before adding them to the library\n"
+"patterns can be defined to rename the images and specify the destination "
+"folders"
+msgstr ""
+"Copy and optionally rename images before adding them to the library\n"
+"Patterns can be defined to rename the images and specify the destination "
+"folders"
+
+#. collapsible section
+#: ../src/libs/import.c:2041
+msgid "parameters"
+msgstr "Parameters"
+
+#: ../src/libs/ioporder.c:203
+msgid "v3.0 for RAW input (default)"
+msgstr "V3.0 for RAW input (default)"
+
+#: ../src/libs/ioporder.c:208
+msgid "v3.0 for JPEG/non-RAW input"
+msgstr "V3.0 for JPEG/non-RAW input"
+
+#: ../src/libs/lib.c:361
+msgid "deleting preset for obsolete module"
+msgstr "Deleting preset for obsolete module"
+
+#: ../src/libs/lib.c:514
+msgid "manage presets..."
+msgstr "Manage presets..."
+
+#: ../src/libs/lib.c:539
+msgid "nothing to save"
+msgstr "Nothing to save"
+
+#: ../src/libs/lib.c:979
+msgid "show module"
+msgstr "Show module"
+
+#: ../src/libs/lib.c:1264
+msgid "utility module"
+msgstr "Utility module"
+
+#: ../src/libs/live_view.c:107
+msgid "live view"
+msgstr "Live view"
+
+#: ../src/libs/live_view.c:290 ../src/libs/live_view.c:291
+msgid "toggle live view"
+msgstr "Toggle live view"
+
+#. TODO: see _zoom_live_view_clicked
+#: ../src/libs/live_view.c:292 ../src/libs/live_view.c:293
+msgid "zoom live view"
+msgstr "Zoom live view"
+
+#: ../src/libs/live_view.c:294
+msgid "rotate 90 degrees ccw"
+msgstr "Rotate 90 degrees ccw"
+
+#: ../src/libs/live_view.c:295
+msgid "rotate 90 degrees cw"
+msgstr "Rotate 90 degrees cw"
+
+#: ../src/libs/live_view.c:296
+msgid "flip live view horizontally"
+msgstr "Flip live view horizontally"
+
+#: ../src/libs/live_view.c:302
+msgid "move focus point in (big steps)"
+msgstr "Move focus point in (big steps)"
+
+#: ../src/libs/live_view.c:303
+msgid "move focus point in (small steps)"
+msgstr "Move focus point in (small steps)"
+
+#. TODO icon not centered
+#: ../src/libs/live_view.c:304
+msgid "run autofocus"
+msgstr "Run autofocus"
+
+#: ../src/libs/live_view.c:305
+msgid "move focus point out (small steps)"
+msgstr "Move focus point out (small steps)"
+
+#. TODO same here
+#: ../src/libs/live_view.c:306
+msgid "move focus point out (big steps)"
+msgstr "Move focus point out (big steps)"
+
+#: ../src/libs/live_view.c:311
+msgid "overlay"
+msgstr "Overlay"
+
+#: ../src/libs/live_view.c:313
+msgid "selected image"
+msgstr "Selected image"
+
+#: ../src/libs/live_view.c:315
+msgid "overlay another image over the live view"
+msgstr "Overlay another image over the live view"
+
+#: ../src/libs/live_view.c:324
+msgid "enter image id of the overlay manually"
+msgstr "Enter image id of the overlay manually"
+
+#: ../src/libs/live_view.c:335
+msgid "overlay mode"
+msgstr "Overlay mode"
+
+#: ../src/libs/live_view.c:337
+msgctxt "blendmode"
+msgid "xor"
+msgstr "Xor"
+
+#: ../src/libs/live_view.c:338
+msgctxt "blendmode"
+msgid "add"
+msgstr "Add"
+
+#: ../src/libs/live_view.c:339
+msgctxt "blendmode"
+msgid "saturate"
+msgstr "Saturate"
+
+#: ../src/libs/live_view.c:345
+msgctxt "blendmode"
+msgid "color dodge"
+msgstr "Color dodge"
+
+#: ../src/libs/live_view.c:346
+msgctxt "blendmode"
+msgid "color burn"
+msgstr "Color burn"
+
+#: ../src/libs/live_view.c:347
+msgctxt "blendmode"
+msgid "hard light"
+msgstr "Hard light"
+
+#: ../src/libs/live_view.c:348
+msgctxt "blendmode"
+msgid "soft light"
+msgstr "Soft light"
+
+#: ../src/libs/live_view.c:350
+msgctxt "blendmode"
+msgid "exclusion"
+msgstr "Exclusion"
+
+#: ../src/libs/live_view.c:351
+msgctxt "blendmode"
+msgid "HSL hue"
+msgstr "HSL hue"
+
+#: ../src/libs/live_view.c:352
+msgctxt "blendmode"
+msgid "HSL saturation"
+msgstr "HSL saturation"
+
+#: ../src/libs/live_view.c:353
+msgctxt "blendmode"
+msgid "HSL color"
+msgstr "HSL color"
+
+#: ../src/libs/live_view.c:354
+msgctxt "blendmode"
+msgid "HSL luminosity"
+msgstr "HSL luminosity"
+
+#: ../src/libs/live_view.c:355
+msgid "mode of the overlay"
+msgstr "Mode of the overlay"
+
+#: ../src/libs/live_view.c:361
+msgid "split line"
+msgstr "Split line"
+
+#: ../src/libs/live_view.c:364
+msgid "only draw part of the overlay"
+msgstr "Only draw part of the overlay"
+
+#: ../src/libs/location.c:100
+msgid "find location"
+msgstr "Find location"
+
+#: ../src/libs/map_locations.c:36
+msgid "locations"
+msgstr "Locations"
+
+#: ../src/libs/map_locations.c:235
+msgid "new sub-location"
+msgstr "New sub-location"
+
+#: ../src/libs/map_locations.c:239 ../src/libs/map_locations.c:287
+#: ../src/libs/map_locations.c:961
+msgid "new location"
+msgstr "New location"
+
+#: ../src/libs/map_locations.c:588
+#, c-format
+msgid "location name '%s' already exists"
+msgstr "Location name '%s' already exists"
+
+#: ../src/libs/map_locations.c:779
+msgid "edit location"
+msgstr "Edit location"
+
+#: ../src/libs/map_locations.c:782
+msgid "delete location"
+msgstr "Delete location"
+
+#: ../src/libs/map_locations.c:792
+msgid "update filmstrip"
+msgstr "Update filmstrip"
+
+#: ../src/libs/map_locations.c:799
+msgid "go to collection (lighttable)"
+msgstr "Go to collection (Lighttable)"
+
+#: ../src/libs/map_locations.c:845
+msgid ""
+"terminate edit (press enter or escape) before selecting another location"
+msgstr ""
+"Terminate edit (press enter or escape) before selecting another location"
+
+#: ../src/libs/map_locations.c:932
+msgid ""
+"list of user locations,\n"
+"click to show or hide a location on the map:\n"
+" - wheel scroll inside the shape to resize it\n"
+" - <shift> or <ctrl> scroll to modify the width or the height\n"
+" - click inside the shape and drag it to change its position\n"
+" - ctrl+click to move an image from inside the location\n"
+"ctrl+click to edit a location name\n"
+" - a pipe '|' symbol breaks the name into several levels\n"
+" - to remove a group of locations clear its name\n"
+" - press enter to validate the new name, escape to cancel the edit\n"
+"right-click for other actions: delete location and go to collection"
+msgstr ""
+"List of user locations.\n"
+"Click to show or hide a location on the map:\n"
+" - wheel scroll inside the shape to resize it\n"
+" - <Shift> or <Ctrl> scroll to modify the width or the height\n"
+" - click inside the shape and drag it to change its position\n"
+" - Ctrl+click to move an image from inside the location\n"
+"Ctrl+click to edit a location name\n"
+" - a pipe '|' symbol breaks the name into several levels\n"
+" - to remove a group of locations clear its name\n"
+" - press Enter to validate the new name, Escape to cancel the edit\n"
+"Right-click for other actions: delete location and go to collection"
+
+#: ../src/libs/map_locations.c:958
+msgid ""
+"select the shape of the location's limits on the map, circle or rectangle\n"
+"or even polygon if available (select first a polygon place in 'find "
+"location' module)"
+msgstr ""
+"Select the shape of the location's limits on the map, circle or rectangle\n"
+"or even polygon if available (select first a polygon place in 'find "
+"location' module)"
+
+#: ../src/libs/map_locations.c:962
+msgid "add a new location on the center of the visible map"
+msgstr "Add a new location on the center of the visible map"
+
+#: ../src/libs/map_locations.c:966
+msgid "show all"
+msgstr "Show all"
+
+#: ../src/libs/map_locations.c:969
+msgid "show all locations which are on the visible map"
+msgstr "Show all locations which are on the visible map"
+
+#: ../src/libs/map_settings.c:39
+msgid "map settings"
+msgstr "Map settings"
+
+#: ../src/libs/map_settings.c:108
+msgid "map source"
+msgstr "Map source"
+
+#: ../src/libs/map_settings.c:113
+msgid "select the source of the map. some entries might not work"
+msgstr "Select the source of the map. Some entries might not work"
+
+#: ../src/libs/masks.c:107
+msgid "feather"
+msgstr "Feather"
+
+#: ../src/libs/masks.c:350
+#, c-format
+msgid "group #%d"
+msgstr "Group #%d"
+
+#: ../src/libs/masks.c:1250
+msgid "duplicate this shape"
+msgstr "Duplicate this shape"
+
+#: ../src/libs/masks.c:1254
+msgid "delete this shape"
+msgstr "Delete this shape"
+
+#: ../src/libs/masks.c:1260
+msgid "delete group"
+msgstr "Delete group"
+
+#: ../src/libs/masks.c:1267
+msgid "remove from group"
+msgstr "Remove from group"
+
+#: ../src/libs/masks.c:1275
+msgid "group the forms"
+msgstr "Group the forms"
+
+#: ../src/libs/masks.c:1283
+msgid "use inverted shape"
+msgstr "Use inverted shape"
+
+#: ../src/libs/masks.c:1290
+msgid "mode: union"
+msgstr "Mode: union"
+
+#: ../src/libs/masks.c:1295
+msgid "mode: intersection"
+msgstr "Mode: intersection"
+
+#: ../src/libs/masks.c:1300
+msgid "mode: difference"
+msgstr "Mode: difference"
+
+#: ../src/libs/masks.c:1305
+msgid "mode: exclusion"
+msgstr "Mode: exclusion"
+
+#: ../src/libs/masks.c:1323
+msgid "cleanup unused shapes"
+msgstr "Cleanup unused shapes"
+
+#: ../src/libs/masks.c:1927
+msgid "created shapes"
+msgstr "Created shapes"
+
+#: ../src/libs/masks.c:2020 ../src/libs/masks.c:2035
+msgid "properties"
+msgstr "Properties"
+
+#: ../src/libs/masks.c:2023
+msgid "no shapes selected"
+msgstr "No shapes selected"
+
+#: ../src/libs/metadata.c:63
+msgid "metadata editor"
+msgstr "Metadata editor"
+
+#: ../src/libs/metadata.c:193 ../src/libs/metadata.c:459
+msgid "<leave unchanged>"
+msgstr "<leave unchanged>"
+
+#: ../src/libs/metadata.c:572 ../src/libs/metadata_view.c:1191
+msgid "metadata settings"
+msgstr "Metadata settings"
+
+#: ../src/libs/metadata.c:621 ../src/libs/metadata_view.c:1236
+msgid "visible"
+msgstr "Visible"
+
+#: ../src/libs/metadata.c:626
+msgid ""
+"tick if the corresponding metadata is of interest for you\n"
+"it will be visible from metadata editor, collection and import module\n"
+"it will be also exported"
+msgstr ""
+"Tick if the corresponding metadata is of interest for you\n"
+"It will be visible from metadata editor, collection and import module\n"
+"It will be also exported"
+
+#: ../src/libs/metadata.c:631 ../src/libs/tagging.c:1680
+#: ../src/libs/tagging.c:1824
+msgid "private"
+msgstr "Private"
+
+#: ../src/libs/metadata.c:636
+msgid ""
+"tick if you want to keep this information private (not exported with images)"
+msgstr ""
+"Tick if you want to keep this information private (not exported with images)"
+
+#: ../src/libs/metadata.c:783
+msgid ""
+"metadata text\n"
+"ctrl+enter inserts a new line (caution, may not be compatible with standard "
+"metadata)\n"
+"if <leave unchanged> selected images have different metadata\n"
+"in that case, right-click gives the possibility to choose one of them\n"
+"escape to exit the popup window"
+msgstr ""
+"Metadata text\n"
+"Ctrl+enter inserts a new line (caution, may not be compatible with standard "
+"metadata)\n"
+"If <leave unchanged> selected images have different metadata\n"
+"In that case, right-click gives the possibility to choose one of them\n"
+"Escape to exit the popup window"
+
+#: ../src/libs/metadata.c:828
+msgid "write metadata for selected images"
+msgstr "Write metadata for selected images"
+
+#. <title>\0<description>\0<rights>\0<creator>\0<publisher>
+#: ../src/libs/metadata.c:885
+msgid "CC BY"
+msgstr "CC BY"
+
+#: ../src/libs/metadata.c:885
+msgid "Creative Commons Attribution (CC BY)"
+msgstr "Creative Commons Attribution (CC BY)"
+
+#: ../src/libs/metadata.c:886
+msgid "CC BY-SA"
+msgstr "CC BY-SA"
+
+#: ../src/libs/metadata.c:886
+msgid "Creative Commons Attribution-ShareAlike (CC BY-SA)"
+msgstr "Creative Commons Attribution-ShareAlike (CC BY-SA)"
+
+#: ../src/libs/metadata.c:887
+msgid "CC BY-ND"
+msgstr "CC BY-ND"
+
+#: ../src/libs/metadata.c:887
+msgid "Creative Commons Attribution-NoDerivs (CC BY-ND)"
+msgstr "Creative Commons Attribution-NoDerivs (CC BY-ND)"
+
+#: ../src/libs/metadata.c:888
+msgid "CC BY-NC"
+msgstr "CC BY-NC"
+
+#: ../src/libs/metadata.c:888
+msgid "Creative Commons Attribution-NonCommercial (CC BY-NC)"
+msgstr "Creative Commons Attribution-NonCommercial (CC BY-NC)"
+
+#: ../src/libs/metadata.c:889
+msgid "CC BY-NC-SA"
+msgstr "CC BY-NC-SA"
+
+#: ../src/libs/metadata.c:890
+msgid "Creative Commons Attribution-NonCommercial-ShareAlike (CC BY-NC-SA)"
+msgstr "Creative Commons Attribution-NonCommercial-ShareAlike (CC BY-NC-SA)"
+
+#: ../src/libs/metadata.c:891
+msgid "CC BY-NC-ND"
+msgstr "CC BY-NC-ND"
+
+#: ../src/libs/metadata.c:892
+msgid "Creative Commons Attribution-NonCommercial-NoDerivs (CC BY-NC-ND)"
+msgstr "Creative Commons Attribution-NonCommercial-NoDerivs (CC BY-NC-ND)"
+
+#: ../src/libs/metadata.c:893
+msgid "all rights reserved"
+msgstr "All rights reserved"
+
+#. internal
+#: ../src/libs/metadata_view.c:123
+msgid "filmroll"
+msgstr "Filmroll"
+
+#: ../src/libs/metadata_view.c:125
+msgid "group id"
+msgstr "Group id"
+
+#: ../src/libs/metadata_view.c:127
+msgid "version"
+msgstr "Version"
+
+#: ../src/libs/metadata_view.c:130
+msgid "import timestamp"
+msgstr "Import timestamp"
+
+#: ../src/libs/metadata_view.c:131
+msgid "change timestamp"
+msgstr "Change timestamp"
+
+#: ../src/libs/metadata_view.c:132
+msgid "export timestamp"
+msgstr "Export timestamp"
+
+#: ../src/libs/metadata_view.c:133
+msgid "print timestamp"
+msgstr "Print timestamp"
+
+#: ../src/libs/metadata_view.c:134
+msgid "flags"
+msgstr "Flags"
+
+#: ../src/libs/metadata_view.c:144
+msgid "focus distance"
+msgstr "Focus distance"
+
+#: ../src/libs/metadata_view.c:146
+msgid "datetime"
+msgstr "Datetime"
+
+#: ../src/libs/metadata_view.c:149
+msgid "export width"
+msgstr "Export width"
+
+#: ../src/libs/metadata_view.c:150
+msgid "export height"
+msgstr "Export height"
+
+#: ../src/libs/metadata_view.c:158
+msgid "longitude"
+msgstr "Longitude"
+
+#: ../src/libs/metadata_view.c:159
+msgid "elevation"
+msgstr "Elevation"
+
+#: ../src/libs/metadata_view.c:163
+msgid "categories"
+msgstr "Categories"
+
+#: ../src/libs/metadata_view.c:170
+msgid "image information"
+msgstr "Image information"
+
+#: ../src/libs/metadata_view.c:331
+msgid "unused/deprecated"
+msgstr "Unused/deprecated"
+
+#: ../src/libs/metadata_view.c:332
+msgid "LDR"
+msgstr "LDR"
+
+#: ../src/libs/metadata_view.c:335
+msgid "marked for deletion"
+msgstr "Marked for deletion"
+
+#: ../src/libs/metadata_view.c:336
+msgid "auto-applying presets applied"
+msgstr "Auto-applying presets applied"
+
+#: ../src/libs/metadata_view.c:337
+msgid "legacy flag. set for all new images"
+msgstr "Legacy flag. Set for all new images"
+
+#: ../src/libs/metadata_view.c:339
+msgid "has .txt"
+msgstr "Has .txt"
+
+#: ../src/libs/metadata_view.c:340
+msgid "has .wav"
+msgstr "Has .wav"
+
+#: ../src/libs/metadata_view.c:358
+#, c-format
+msgid "image has %d star"
+msgid_plural "image has %d stars"
+msgstr[0] "Image has %d star"
+msgstr[1] "Image has %d stars"
+
+#: ../src/libs/metadata_view.c:440
+#, c-format
+msgid "loader: %s"
+msgstr "Loader: %s"
+
+#: ../src/libs/metadata_view.c:631
+msgid "<various values>"
+msgstr "<Various values>"
+
+#: ../src/libs/metadata_view.c:644
+#, c-format
+msgid ""
+"double-click to jump to film roll\n"
+"%s"
+msgstr ""
+"Double-click to jump to film roll\n"
+"%s"
+
+#: ../src/libs/metadata_view.c:736
+#, c-format
+msgid "%+.2f EV"
+msgstr "%+.2f EV"
+
+#: ../src/libs/metadata_view.c:753
+#, c-format
+msgid "infinity"
+msgstr "infinity"
+
+#: ../src/libs/metadata_view.c:757
+#, c-format
+msgid "%.2f m"
+msgstr "%.2f m"
+
+#: ../src/libs/metadata_view.c:1231
+msgid ""
+"drag and drop one row at a time until you get the desired order\n"
+"untick to hide metadata which are not of interest for you\n"
+"if different settings are needed, use presets"
+msgstr ""
+"Drag and drop one row at a time until you get the desired order\n"
+"Untick to hide metadata which are not of interest for you\n"
+"If different settings are needed, use presets"
+
+#: ../src/libs/metadata_view.c:1387
+msgid "jump to film roll"
+msgstr "Jump to film roll"
+
+#: ../src/libs/recentcollect.c:67
+msgid "recently used collections"
+msgstr "Recently used collections"
+
+#: ../src/libs/recentcollect.c:109
+msgid " and "
+msgstr " and "
+
+#: ../src/libs/recentcollect.c:114
+msgid " or "
+msgstr " or "
+
+#. case DT_LIB_COLLECT_MODE_AND_NOT:
+#: ../src/libs/recentcollect.c:119
+msgid " but not "
+msgstr " but not "
+
+#: ../src/libs/recentcollect.c:294
+msgid "recent collections settings"
+msgstr "Recent collections settings"
+
+#: ../src/libs/modulegroups.c:42 ../src/libs/modulegroups.c:1771
+msgid "workflow: scene-referred"
+msgstr "Workflow: scene-referred"
+
+#: ../src/libs/modulegroups.c:45
+msgid "modules: deprecated"
+msgstr "Modules: deprecated"
+
+#: ../src/libs/modulegroups.c:48
+msgid "last modified layout"
+msgstr "Last modified layout"
+
+#: ../src/libs/modulegroups.c:192
+msgid "modulegroups"
+msgstr "Modulegroups"
+
+#. FIXME don't check here if on/off is enabled, because it depends on image (reload_defaults)
+#. respond later to image changed signal
+#: ../src/libs/modulegroups.c:307 ../src/libs/modulegroups.c:319
+#: ../src/libs/modulegroups.c:2429 ../src/libs/modulegroups.c:2431
+msgid "on-off"
+msgstr "On-off"
+
+#: ../src/libs/modulegroups.c:499 ../src/libs/modulegroups.c:502
+msgid ""
+"this quick access widget is disabled as there are multiple instances of this "
+"module present. Please use the full module to access this widget..."
+msgstr ""
+"This quick access widget is disabled as there are multiple instances of this "
+"module present. Please use the full module to access this widget..."
+
+#: ../src/libs/modulegroups.c:592
+msgid "(some features may only be available in the full module interface)"
+msgstr "(some features may only be available in the full module interface)"
+
+#: ../src/libs/modulegroups.c:636
+#, c-format
+msgid "go to the full version of the %s module"
+msgstr "Go to the full version of the %s module"
+
+#: ../src/libs/modulegroups.c:1558 ../src/libs/modulegroups.c:1643
+#: ../src/libs/modulegroups.c:1679 ../src/libs/modulegroups.c:1729
+#: ../src/libs/modulegroups.c:1819
+msgctxt "modulegroup"
+msgid "base"
+msgstr "Base"
+
+#: ../src/libs/modulegroups.c:1577
+msgctxt "modulegroup"
+msgid "tone"
+msgstr "Tone"
+
+#: ../src/libs/modulegroups.c:1586 ../src/libs/modulegroups.c:1693
+#: ../src/libs/modulegroups.c:1743
+msgctxt "modulegroup"
+msgid "color"
+msgstr "Color"
+
+#: ../src/libs/modulegroups.c:1601 ../src/libs/modulegroups.c:1701
+#: ../src/libs/modulegroups.c:1748
+msgctxt "modulegroup"
+msgid "correct"
+msgstr "Correct"
+
+#: ../src/libs/modulegroups.c:1619 ../src/libs/modulegroups.c:1713
+#: ../src/libs/modulegroups.c:1760 ../src/libs/modulegroups.c:2323
+msgctxt "modulegroup"
+msgid "effect"
+msgstr "Effect"
+
+#: ../src/libs/modulegroups.c:1637
+msgid "modules: all"
+msgstr "Modules: all"
+
+#: ../src/libs/modulegroups.c:1658
+msgctxt "modulegroup"
+msgid "grading"
+msgstr "Grading"
+
+#: ../src/libs/modulegroups.c:1666 ../src/libs/modulegroups.c:2327
+msgctxt "modulegroup"
+msgid "effects"
+msgstr "Effects"
+
+#: ../src/libs/modulegroups.c:1674
+msgid "workflow: beginner"
+msgstr "Workflow: beginner"
+
+#: ../src/libs/modulegroups.c:1723
+msgid "workflow: display-referred"
+msgstr "Workflow: display-referred"
+
+#: ../src/libs/modulegroups.c:1775
+msgid "search only"
+msgstr "Search only"
+
+#: ../src/libs/modulegroups.c:1781 ../src/libs/modulegroups.c:2092
+#: ../src/libs/modulegroups.c:2601
+msgctxt "modulegroup"
+msgid "deprecated"
+msgstr "Deprecated"
+
+#: ../src/libs/modulegroups.c:1794
+msgid "previous config"
+msgstr "Previous config"
+
+#: ../src/libs/modulegroups.c:1795
+msgid "previous layout"
+msgstr "Previous layout"
+
+#: ../src/libs/modulegroups.c:1799
+msgid "previous config with new layout"
+msgstr "Previous config with new layout"
+
+#: ../src/libs/modulegroups.c:1959 ../src/libs/modulegroups.c:2474
+#: ../src/libs/modulegroups.c:2486
+msgid "remove this widget"
+msgstr "Remove this widget"
+
+#: ../src/libs/modulegroups.c:2109 ../src/libs/modulegroups.c:2349
+msgid "remove this module"
+msgstr "Remove this module"
+
+#. does it belong to recommended modules ?
+#: ../src/libs/modulegroups.c:2318
+msgid "base"
+msgstr "Base"
+
+#: ../src/libs/modulegroups.c:2321
+msgid "tone"
+msgstr "Tone"
+
+#: ../src/libs/modulegroups.c:2324
+msgid "technical"
+msgstr "Technical"
+
+#: ../src/libs/modulegroups.c:2325
+msgid "grading"
+msgstr "Grading"
+
+#: ../src/libs/modulegroups.c:2331 ../src/libs/modulegroups.c:2339
+msgid "add this module"
+msgstr "Add this module"
+
+#. show the submenu with all the modules
+#: ../src/libs/modulegroups.c:2361 ../src/libs/modulegroups.c:2561
+msgid "all available modules"
+msgstr "All available modules"
+
+#: ../src/libs/modulegroups.c:2369
+msgid "add module"
+msgstr "Add module"
+
+#: ../src/libs/modulegroups.c:2374
+msgid "remove module"
+msgstr "Remove module"
+
+#: ../src/libs/modulegroups.c:2480
+msgid "header needed for other widgets"
+msgstr "Header needed for other widgets"
+
+#: ../src/libs/modulegroups.c:2496 ../src/libs/modulegroups.c:2503
+msgid "add this widget"
+msgstr "Add this widget"
+
+#: ../src/libs/modulegroups.c:2516
+msgid "currently invisible"
+msgstr "Currently invisible"
+
+#: ../src/libs/modulegroups.c:2545
+msgid "add widget"
+msgstr "Add widget"
+
+#: ../src/libs/modulegroups.c:2550
+msgid "remove widget"
+msgstr "Remove widget"
+
+#: ../src/libs/modulegroups.c:2655
+msgid "show all history modules"
+msgstr "Show all history modules"
+
+#: ../src/libs/modulegroups.c:2658 ../src/libs/modulegroups.c:3836
+msgid ""
+"show modules that are present in the history stack, regardless of whether or "
+"not they are currently enabled"
+msgstr ""
+"Show modules that are present in the history stack, regardless of whether or "
+"not they are currently enabled"
+
+#: ../src/libs/modulegroups.c:2749 ../src/libs/modulegroups.c:2818
+msgid ""
+"the following modules are deprecated because they have internal design "
+"mistakes that can't be corrected and alternative modules that correct them.\n"
+"they will be removed for new edits in the next release."
+msgstr ""
+"The following modules are deprecated because they have internal design "
+"mistakes which can't be corrected and alternative modules that correct "
+"them.\n"
+"They will be removed for new edits in the next release."
+
+#: ../src/libs/modulegroups.c:2777 ../src/libs/modulegroups.c:2778
+msgid "quick access panel"
+msgstr "Quick access panel"
+
+#: ../src/libs/modulegroups.c:2788
+msgid "show only active modules"
+msgstr "Show only active modules"
+
+#: ../src/libs/modulegroups.c:2789
+msgid "active modules"
+msgstr "Active modules"
+
+#: ../src/libs/modulegroups.c:2794
+msgid ""
+"presets\n"
+"ctrl+click to manage"
+msgstr ""
+"Presets\n"
+"Ctrl+click to manage"
+
+#: ../src/libs/modulegroups.c:2800
+msgid "search modules"
+msgstr "Search modules"
+
+#: ../src/libs/modulegroups.c:2801
+msgid "search modules by name or tag"
+msgstr "Search modules by name or tag"
+
+#: ../src/libs/modulegroups.c:2811
+msgid "clear text"
+msgstr "Clear text"
+
+#: ../src/libs/modulegroups.c:3053
+msgid "basic icon"
+msgstr "Basic icon"
+
+#: ../src/libs/modulegroups.c:3063
+msgid "active icon"
+msgstr "Active icon"
+
+#: ../src/libs/modulegroups.c:3073
+msgid "color icon"
+msgstr "Color icon"
+
+#: ../src/libs/modulegroups.c:3083
+msgid "correct icon"
+msgstr "Correct icon"
+
+#: ../src/libs/modulegroups.c:3093
+msgid "effect icon"
+msgstr "Effect icon"
+
+#: ../src/libs/modulegroups.c:3103
+msgid "favorites icon"
+msgstr "Favorites icon"
+
+#: ../src/libs/modulegroups.c:3113
+msgid "tone icon"
+msgstr "Tone icon"
+
+#: ../src/libs/modulegroups.c:3123
+msgid "grading icon"
+msgstr "Grading icon"
+
+#: ../src/libs/modulegroups.c:3133
+msgid "technical icon"
+msgstr "Technical icon"
+
+#: ../src/libs/modulegroups.c:3166
+msgid "quick access panel widgets"
+msgstr "Quick access panel widgets"
+
+#: ../src/libs/modulegroups.c:3168
+msgid "quick access"
+msgstr "Quick access"
+
+#: ../src/libs/modulegroups.c:3188
+msgid "add widget to the quick access panel"
+msgstr "Add widget to the quick access panel"
+
+#: ../src/libs/modulegroups.c:3220
+msgid "group icon"
+msgstr "Group icon"
+
+#: ../src/libs/modulegroups.c:3229
+msgid "group name"
+msgstr "Group name"
+
+#: ../src/libs/modulegroups.c:3240
+msgid "remove group"
+msgstr "Remove group"
+
+#: ../src/libs/modulegroups.c:3266
+msgid "move group to the left"
+msgstr "Move group to the left"
+
+#: ../src/libs/modulegroups.c:3274
+msgid "add module to the group"
+msgstr "Add module to the group"
+
+#: ../src/libs/modulegroups.c:3285
+msgid "move group to the right"
+msgstr "Move group to the right"
+
+#: ../src/libs/modulegroups.c:3465
+msgid "rename preset"
+msgstr "Rename preset"
+
+#: ../src/libs/modulegroups.c:3472
+msgid "new preset name:"
+msgstr "New preset name:"
+
+#: ../src/libs/modulegroups.c:3473
+msgid "a preset with this name already exists!"
+msgstr "A preset with this name already exists!"
+
+#: ../src/libs/modulegroups.c:3806
+msgid "preset: "
+msgstr "Preset: "
+
+#: ../src/libs/modulegroups.c:3813
+msgid "remove the preset"
+msgstr "Remove the preset"
+
+#: ../src/libs/modulegroups.c:3815
+msgid "duplicate the preset"
+msgstr "Duplicate the preset"
+
+#: ../src/libs/modulegroups.c:3817
+msgid "rename the preset"
+msgstr "Rename the preset"
+
+#: ../src/libs/modulegroups.c:3819
+msgid "create a new empty preset"
+msgstr "Create a new empty preset"
+
+#: ../src/libs/modulegroups.c:3827
+msgid "show search line"
+msgstr "Show search line"
+
+#: ../src/libs/modulegroups.c:3830
+msgid "show quick access panel"
+msgstr "Show quick access panel"
+
+#: ../src/libs/modulegroups.c:3833
+msgid "show all history modules in active group"
+msgstr "Show all history modules in active group"
+
+#: ../src/libs/modulegroups.c:3845
+msgid "auto-apply this preset"
+msgstr "Auto-apply this preset"
+
+#: ../src/libs/modulegroups.c:3860
+msgid "module groups"
+msgstr "Module groups"
+
+#: ../src/libs/modulegroups.c:3877
+msgid ""
+"this is a built-in read-only preset. duplicate it if you want to make changes"
+msgstr ""
+"This is a built-in read-only preset. Duplicate it if you want to make changes"
+
+#: ../src/libs/navigation.c:74
+msgid "navigation"
+msgstr "Navigation"
+
+#: ../src/libs/navigation.c:112 ../src/libs/navigation.c:192
+msgctxt "navigationbox"
+msgid "fill"
+msgstr "Fill"
+
+#: ../src/libs/navigation.c:115 ../src/libs/navigation.c:190
+msgid "small"
+msgstr "Small"
+
+#: ../src/libs/navigation.c:152
+msgid ""
+"navigation\n"
+"click or drag to position zoomed area in center view"
+msgstr ""
+"Navigation\n"
+"Click or drag to position zoomed area in center view"
+
+#: ../src/libs/navigation.c:174
+msgid "hide navigation thumbnail"
+msgstr "Hide navigation thumbnail"
+
+#: ../src/libs/navigation.c:188
+msgid "image zoom level"
+msgstr "Image zoom level"
+
+#: ../src/libs/navigation.c:193
+msgid "50%"
+msgstr "50%"
+
+#: ../src/libs/navigation.c:194
+msgid "100%"
+msgstr "100%"
+
+#: ../src/libs/navigation.c:195
+msgid "200%"
+msgstr "200%"
+
+#: ../src/libs/navigation.c:196
+msgid "400%"
+msgstr "400%"
+
+#: ../src/libs/navigation.c:197
+msgid "800%"
+msgstr "800%"
+
+#: ../src/libs/navigation.c:198
+msgid "1600%"
+msgstr "1600%"
+
+#: ../src/libs/print_settings.c:46
+msgid "print settings"
+msgstr "Print settings"
+
+#. FIXME: ellipsize title/printer as the export completed message is ellipsized
+#: ../src/libs/print_settings.c:335 ../src/libs/print_settings.c:712
+#, c-format
+msgid "processing `%s' for `%s'"
+msgstr "Processing `%s' for `%s'"
+
+#: ../src/libs/print_settings.c:363
+#, c-format
+msgid "cannot open printer profile `%s'"
+msgstr "Cannot open printer profile `%s'"
+
+#: ../src/libs/print_settings.c:372
+#, c-format
+msgid "error getting output profile for image %d"
+msgstr "Error getting output profile for image %d"
+
+#: ../src/libs/print_settings.c:381
+#, c-format
+msgid "cannot apply printer profile `%s'"
+msgstr "Cannot apply printer profile `%s'"
+
+#: ../src/libs/print_settings.c:534
+msgid "failed to create temporary PDF for printing"
+msgstr "Failed to create temporary PDF for printing"
+
+#: ../src/libs/print_settings.c:580
+msgid "maximum image per page reached"
+msgstr "Maximum image per page reached"
+
+#: ../src/libs/print_settings.c:667
+msgid "cannot print until a picture is selected"
+msgstr "Cannot print until a picture is selected"
+
+#: ../src/libs/print_settings.c:672
+msgid "cannot print until a printer is selected"
+msgstr "Cannot print until a printer is selected"
+
+#: ../src/libs/print_settings.c:677
+msgid "cannot print until a paper is selected"
+msgstr "Cannot print until a paper is selected"
+
+#. in this case no need to release from cache what we couldn't get
+#: ../src/libs/print_settings.c:704
+#, c-format
+msgid "cannot get image %d for printing"
+msgstr "Cannot get image %d for printing"
+
+#: ../src/libs/print_settings.c:874
+#, c-format
+msgid "%3.2f (dpi:%d)"
+msgstr "%3.2f (dpi:%d)"
+
+#: ../src/libs/print_settings.c:2252
+msgctxt "section"
+msgid "printer"
+msgstr "Printer"
+
+#: ../src/libs/print_settings.c:2264 ../src/libs/print_settings.c:2272
+#: ../src/libs/print_settings.c:2323
+msgid "printer"
+msgstr "Printer"
+
+#: ../src/libs/print_settings.c:2264
+msgid "media"
+msgstr "Media"
+
+#: ../src/libs/print_settings.c:2282
+msgid "color management in printer driver"
+msgstr "Color management in printer driver"
+
+#: ../src/libs/print_settings.c:2314
+#, c-format
+msgid "printer ICC profiles in %s or %s"
+msgstr "Printer ICC profiles in %s or %s"
+
+#: ../src/libs/print_settings.c:2333
+msgid "black point compensation"
+msgstr "Black point compensation"
+
+#: ../src/libs/print_settings.c:2341
+msgid "activate black point compensation when applying the printer profile"
+msgstr "Activate black point compensation when applying the printer profile"
+
+#. //////////////////////// PAGE SETTINGS
+#: ../src/libs/print_settings.c:2347
+msgctxt "section"
+msgid "page"
+msgstr "Page"
+
+#: ../src/libs/print_settings.c:2368
+msgid "measurement units"
+msgstr "Measurement units"
+
+#: ../src/libs/print_settings.c:2376
+msgid "image width/height"
+msgstr "Image width/height"
+
+#: ../src/libs/print_settings.c:2380
+msgid " x "
+msgstr " x "
+
+#: ../src/libs/print_settings.c:2388
+msgid "scale factor"
+msgstr "Scale factor"
+
+#: ../src/libs/print_settings.c:2393
+msgid ""
+"image scale factor from native printer DPI:\n"
+" < 1 means that it is downscaled (best quality)\n"
+" > 1 means that the image is upscaled\n"
+" a too large value may result in poor print quality"
+msgstr ""
+"Image scale factor from native printer DPI:\n"
+" < 1 means that it is downscaled (best quality)\n"
+" > 1 means that the image is upscaled\n"
+" a too large value may result in poor print quality"
+
+#. d->b_top  = gtk_spin_button_new_with_range(0, 10000, 1);
+#: ../src/libs/print_settings.c:2407
+msgid "top margin"
+msgstr "Top margin"
+
+#. d->b_left  = gtk_spin_button_new_with_range(0, 10000, 1);
+#: ../src/libs/print_settings.c:2411
+msgid "left margin"
+msgstr "Left margin"
+
+#: ../src/libs/print_settings.c:2414
+msgid "lock"
+msgstr "Lock"
+
+#: ../src/libs/print_settings.c:2415
+msgid "change all margins uniformly"
+msgstr "Change all margins uniformly"
+
+#. d->b_right  = gtk_spin_button_new_with_range(0, 10000, 1);
+#: ../src/libs/print_settings.c:2419
+msgid "right margin"
+msgstr "Right margin"
+
+#. d->b_bottom  = gtk_spin_button_new_with_range(0, 10000, 1);
+#: ../src/libs/print_settings.c:2423
+msgid "bottom margin"
+msgstr "Bottom margin"
+
+#: ../src/libs/print_settings.c:2456
+msgid "display grid"
+msgstr "Display grid"
+
+#: ../src/libs/print_settings.c:2466
+msgid "snap to grid"
+msgstr "Snap to grid"
+
+#: ../src/libs/print_settings.c:2476
+msgid "borderless mode required"
+msgstr "Borderless mode required"
+
+#: ../src/libs/print_settings.c:2479
+msgid ""
+"indicates that the borderless mode should be activated\n"
+"in the printer driver because the selected margins are\n"
+"below the printer hardware margins"
+msgstr ""
+"Indicates that the borderless mode should be activated\n"
+"in the printer driver because the selected margins are\n"
+"below the printer hardware margins"
+
+#. pack image dimension hbox here
+#: ../src/libs/print_settings.c:2486
+msgctxt "section"
+msgid "image layout"
+msgstr "Image layout"
+
+#: ../src/libs/print_settings.c:2524
+msgid "new image area"
+msgstr "New image area"
+
+#: ../src/libs/print_settings.c:2525
+msgid ""
+"add a new image area on the page\n"
+"click and drag on the page to place the area\n"
+"drag and drop image from film strip on it"
+msgstr ""
+"Add a new image area on the page\n"
+"Click and drag on the page to place the area\n"
+"Drag and drop image from film strip on it"
+
+#: ../src/libs/print_settings.c:2529
+msgid "delete image area"
+msgstr "Delete image area"
+
+#: ../src/libs/print_settings.c:2530
+msgid "delete the currently selected image area"
+msgstr "Delete the currently selected image area"
+
+#: ../src/libs/print_settings.c:2533
+msgid "clear layout"
+msgstr "Clear layout"
+
+#: ../src/libs/print_settings.c:2534
+msgid "remove all image areas from the page"
+msgstr "Remove all image areas from the page"
+
+#. d->b_x = gtk_spin_button_new_with_range(0, 1000, 1);
+#: ../src/libs/print_settings.c:2549
+msgid "image area x origin (in current unit)"
+msgstr "Image area x origin (in current unit)"
+
+#. d->b_y = gtk_spin_button_new_with_range(0, 1000, 1);
+#: ../src/libs/print_settings.c:2553
+msgid "image area y origin (in current unit)"
+msgstr "Image area y origin (in current unit)"
+
+#. d->b_width = gtk_spin_button_new_with_range(0, 1000, 1);
+#: ../src/libs/print_settings.c:2564
+msgid "image area width (in current unit)"
+msgstr "Image area width (in current unit)"
+
+#. d->b_height = gtk_spin_button_new_with_range(0, 1000, 1);
+#: ../src/libs/print_settings.c:2568
+msgid "image area height (in current unit)"
+msgstr "Image area height (in current unit)"
+
+#. //////////////////////// PRINT SETTINGS
+#: ../src/libs/print_settings.c:2590
+msgctxt "section"
+msgid "print settings"
+msgstr "Print settings"
+
+#: ../src/libs/print_settings.c:2677
+msgid "temporary style to use while printing"
+msgstr "Temporary style to use while printing"
+
+#: ../src/libs/print_settings.c:2707
+msgid "print with current settings"
+msgstr "Print with current settings"
+
+#: ../src/libs/select.c:134
+msgid "select all images in current collection"
+msgstr "Select all images in current collection"
+
+#: ../src/libs/select.c:138
+msgid "clear selection"
+msgstr "Clear selection"
+
+#: ../src/libs/select.c:142
+msgid ""
+"select unselected images\n"
+"in current collection"
+msgstr ""
+"Select unselected images\n"
+"in current collection"
+
+#: ../src/libs/select.c:146
+msgid ""
+"select all images which are in the same\n"
+"film roll as the selected images"
+msgstr ""
+"Select all images which are in the same\n"
+"film roll as the selected images"
+
+#: ../src/libs/select.c:150
+msgid ""
+"select untouched images in\n"
+"current collection"
+msgstr ""
+"Select untouched images in\n"
+"current collection"
+
+#: ../src/libs/session.c:47
+msgid "session"
+msgstr "Session"
+
+#: ../src/libs/session.c:99
+msgid "jobcode"
+msgstr "Jobcode"
+
+#: ../src/libs/session.c:107
+msgid "create"
+msgstr "Create"
+
+#: ../src/libs/snapshots.c:92
+msgid "snapshots"
+msgstr "Snapshots"
+
+#: ../src/libs/snapshots.c:142
+msgctxt "snapshot sign"
+msgid "S"
+msgstr "S"
+
+#: ../src/libs/snapshots.c:575
+#, c-format
+msgid "↗ %s '%s'"
+msgstr "↗ %s '%s'"
+
+#: ../src/libs/snapshots.c:575
+msgid "this snapshot was taken from"
+msgstr "This snapshot was taken from"
+
+#: ../src/libs/snapshots.c:664
+msgid "take snapshot"
+msgstr "Take snapshot"
+
+#: ../src/libs/snapshots.c:666
+msgid ""
+"take snapshot to compare with another image or the same image at another "
+"stage of development"
+msgstr ""
+"Take snapshot to compare with another image or the same image at another "
+"stage of development"
+
+#: ../src/libs/snapshots.c:735
+msgid "toggle last snapshot"
+msgstr "Toggle last snapshot"
+
+#: ../src/libs/styles.c:327
+msgid "remove style?"
+msgid_plural "remove styles?"
+msgstr[0] "Remove style?"
+msgstr[1] "Remove styles?"
+
+#: ../src/libs/styles.c:328
+#, c-format
+msgid "do you really want to remove %d style?"
+msgid_plural "do you really want to remove %d styles?"
+msgstr[0] "Do you really want to remove %d style?"
+msgstr[1] "Do you really want to remove %d styles?"
+
+#: ../src/libs/styles.c:445 ../src/libs/styles.c:628
+#, c-format
+msgid ""
+"style `%s' already exists.\n"
+"do you want to overwrite existing style?\n"
+msgstr ""
+"Style `%s' already exists.\n"
+"Do you want to overwrite existing style?\n"
+
+#: ../src/libs/styles.c:447 ../src/libs/styles.c:630
+msgid "apply this option to all existing styles"
+msgstr "Apply this option to all existing styles"
+
+#: ../src/libs/styles.c:510
+#, c-format
+msgid "style %s was successfully exported"
+msgstr "Style %s was successfully exported"
+
+#: ../src/libs/styles.c:527
+msgid "select style"
+msgstr "Select style"
+
+#: ../src/libs/styles.c:537
+msgid "darktable style files"
+msgstr "Darktable style files"
+
+#: ../src/libs/styles.c:818
+msgid ""
+"available styles,\n"
+"double-click to apply"
+msgstr ""
+"Available styles,\n"
+"double-click to apply"
+
+#: ../src/libs/styles.c:827 ../src/libs/styles.c:828
+msgid "filter style names"
+msgstr "Filter style names"
+
+#: ../src/libs/styles.c:840
+msgid "create duplicate"
+msgstr "Create duplicate"
+
+#: ../src/libs/styles.c:847
+msgid "creates a duplicate of the image before applying style"
+msgstr "Creates a duplicate of the image before applying style"
+
+#: ../src/libs/styles.c:865
+msgid "create..."
+msgstr "Create..."
+
+#: ../src/libs/styles.c:867
+msgid "create styles from history stack of selected images"
+msgstr "Create styles from history stack of selected images"
+
+#: ../src/libs/styles.c:872 ../src/libs/tagging.c:2249
+msgid "edit..."
+msgstr "Edit..."
+
+#: ../src/libs/styles.c:874
+msgid "edit the selected styles in list above"
+msgstr "Edit the selected styles in list above"
+
+#: ../src/libs/styles.c:881
+msgid "removes the selected styles in list above"
+msgstr "Removes the selected styles in list above"
+
+#: ../src/libs/styles.c:888
+msgid "import styles from a style files"
+msgstr "Import styles from a style files"
+
+#: ../src/libs/styles.c:895
+msgid "export the selected styles into a style files"
+msgstr "Export the selected styles into a style files"
+
+#: ../src/libs/styles.c:902
+msgid "apply the selected styles in list above to selected images"
+msgstr "Apply the selected styles in list above to selected images"
+
+#: ../src/libs/tagging.c:104
+msgid "tagging"
+msgstr "Tagging"
+
+#: ../src/libs/tagging.c:1252
+msgid "attach tag to all"
+msgstr "Attach tag to all"
+
+#: ../src/libs/tagging.c:1260 ../src/libs/tagging.c:2222
+msgid "detach tag"
+msgstr "Detach tag"
+
+#: ../src/libs/tagging.c:1480
+msgid "delete tag?"
+msgstr "Delete tag?"
+
+#: ../src/libs/tagging.c:1487 ../src/libs/tagging.c:1575
+#: ../src/libs/tagging.c:1786 ../src/libs/tagging.c:2060
+#, c-format
+msgid "selected: %s"
+msgstr "Selected: %s"
+
+#: ../src/libs/tagging.c:1494
+#, c-format
+msgid ""
+"do you really want to delete the tag `%s'?\n"
+"%d image is assigned this tag!"
+msgid_plural ""
+"do you really want to delete the tag `%s'?\n"
+"%d images are assigned this tag!"
+msgstr[0] ""
+"Do you really want to delete the tag `%s'?\n"
+"%d image is assigned this tag!"
+msgstr[1] ""
+"Do you really want to delete the tag `%s'?\n"
+"%d images are assigned this tag!"
+
+#: ../src/libs/tagging.c:1528
+#, c-format
+msgid "tag %s removed"
+msgstr "Tag %s removed"
+
+#: ../src/libs/tagging.c:1568
+msgid "delete node?"
+msgstr "Delete node?"
+
+#: ../src/libs/tagging.c:1582
+#, c-format
+msgid "<u>%d</u> tag will be deleted"
+msgid_plural "<u>%d</u> tags will be deleted"
+msgstr[0] "<u>%d</u> tag will be deleted"
+msgstr[1] "<u>%d</u> tags will be deleted"
+
+#: ../src/libs/tagging.c:1587 ../src/libs/tagging.c:1798
+#: ../src/libs/tagging.c:2072
+#, c-format
+msgid "<u>%d</u> image will be updated"
+msgid_plural "<u>%d</u> images will be updated"
+msgstr[0] "<u>%d</u> image will be updated"
+msgstr[1] "<u>%d</u> images will be updated"
+
+#: ../src/libs/tagging.c:1613
+#, c-format
+msgid "%d tags removed"
+msgstr "%d tags removed"
+
+#: ../src/libs/tagging.c:1649
+msgid "create tag"
+msgstr "Create tag"
+
+#: ../src/libs/tagging.c:1659 ../src/libs/tagging.c:1806
+msgid "name: "
+msgstr "Name: "
+
+#: ../src/libs/tagging.c:1671
+#, c-format
+msgid "add to: \"%s\" "
+msgstr "Add to: \"%s\" "
+
+#: ../src/libs/tagging.c:1677 ../src/libs/tagging.c:1821
+msgid "category"
+msgstr "Category"
+
+#: ../src/libs/tagging.c:1686 ../src/libs/tagging.c:1830
+msgid "synonyms: "
+msgstr "Synonyms: "
+
+#: ../src/libs/tagging.c:1703 ../src/libs/tagging.c:1852
+#: ../src/libs/tagging.c:2094
+msgid "empty tag is not allowed, aborting"
+msgstr "Empty tag is not allowed, aborting"
+
+#: ../src/libs/tagging.c:1714
+msgid "tag name already exists. aborting."
+msgstr "Tag name already exists. Aborting."
+
+#: ../src/libs/tagging.c:1793 ../src/libs/tagging.c:2067
+#, c-format
+msgid "<u>%d</u> tag will be updated"
+msgid_plural "<u>%d</u> tags will be updated"
+msgstr[0] "<u>%d</u> tag will be updated"
+msgstr[1] "<u>%d</u> tags will be updated"
+
+#: ../src/libs/tagging.c:1854
+msgid ""
+"'|' character is not allowed for renaming tag.\n"
+"to modify the hierarchy use rename path instead. Aborting."
+msgstr ""
+"'|' character is not allowed for renaming tag.\n"
+"To modify the hierarchy use rename path instead. Aborting."
+
+#: ../src/libs/tagging.c:1893 ../src/libs/tagging.c:2001
+#, c-format
+msgid "at least one new tag name (%s) already exists, aborting"
+msgstr "At least one new tag name (%s) already exists, aborting"
+
+#: ../src/libs/tagging.c:2053
+msgid "change path"
+msgstr "Change path"
+
+#: ../src/libs/tagging.c:2096
+msgid "'|' misplaced, empty tag is not allowed, aborting"
+msgstr "'|' misplaced, empty tag is not allowed, aborting"
+
+#: ../src/libs/tagging.c:2192
+#, c-format
+msgid "tag %s created"
+msgstr "Tag %s created"
+
+#: ../src/libs/tagging.c:2218
+msgid "attach tag"
+msgstr "Attach tag"
+
+#: ../src/libs/tagging.c:2231
+msgid "create tag..."
+msgstr "Create tag..."
+
+#: ../src/libs/tagging.c:2237
+msgid "delete tag"
+msgstr "Delete tag"
+
+#: ../src/libs/tagging.c:2244
+msgid "delete node"
+msgstr "Delete node"
+
+#: ../src/libs/tagging.c:2257
+msgid "change path..."
+msgstr "Change path..."
+
+#: ../src/libs/tagging.c:2267
+msgid "set as a tag"
+msgstr "Set as a tag"
+
+#: ../src/libs/tagging.c:2278
+msgid "copy to entry"
+msgstr "Copy to entry"
+
+#: ../src/libs/tagging.c:2295
+msgid "go to tag collection"
+msgstr "Go to tag collection"
+
+#: ../src/libs/tagging.c:2301
+msgid "go back to work"
+msgstr "Go back to work"
+
+#: ../src/libs/tagging.c:2458
+#, c-format
+msgid "%s"
+msgstr "%s"
+
+#: ../src/libs/tagging.c:2459
+msgid "(private)"
+msgstr "(private)"
+
+#: ../src/libs/tagging.c:2485
+msgid "select a keyword file"
+msgstr "Select a keyword file"
+
+#: ../src/libs/tagging.c:2498
+msgid "error importing tags"
+msgstr "Error importing tags"
+
+#: ../src/libs/tagging.c:2500
+#, c-format
+msgid "%zd tags imported"
+msgstr "%zd tags imported"
+
+#: ../src/libs/tagging.c:2521
+msgid "select file to export to"
+msgstr "Select file to export to"
+
+#: ../src/libs/tagging.c:2535
+msgid "error exporting tags"
+msgstr "Error exporting tags"
+
+#: ../src/libs/tagging.c:2537
+#, c-format
+msgid "%zd tags exported"
+msgstr "%zd tags exported"
+
+#: ../src/libs/tagging.c:2961
+msgid "drop to root"
+msgstr "Drop to root"
+
+#: ../src/libs/tagging.c:3098
+msgid ""
+"attached tags\n"
+"press Delete or double-click to detach\n"
+"right-click for other actions on attached tag,\n"
+"Tab to give the focus to entry"
+msgstr ""
+"Attached tags\n"
+"Press Delete or double-click to detach\n"
+"Right-click for other actions on attached tag,\n"
+"Tab to give the focus to entry"
+
+#: ../src/libs/tagging.c:3109
+msgid "attach"
+msgstr "Attach"
+
+#: ../src/libs/tagging.c:3110
+msgid "attach tag to all selected images"
+msgstr "Attach tag to all selected images"
+
+#: ../src/libs/tagging.c:3113
+msgid "detach"
+msgstr "Detach"
+
+#: ../src/libs/tagging.c:3114
+msgid "detach tag from all selected images"
+msgstr "Detach tag from all selected images"
+
+#: ../src/libs/tagging.c:3127
+msgid "toggle list with / without hierarchy"
+msgstr "Toggle list with / without hierarchy"
+
+#: ../src/libs/tagging.c:3127
+msgid "hide"
+msgstr "Hide"
+
+#: ../src/libs/tagging.c:3129
+msgid "toggle sort by name or by count"
+msgstr "Toggle sort by name or by count"
+
+#: ../src/libs/tagging.c:3129
+msgid "sort"
+msgstr "Sort"
+
+#: ../src/libs/tagging.c:3131
+msgid "toggle show or not darktable tags"
+msgstr "Toggle show or not Darktable tags"
+
+#: ../src/libs/tagging.c:3131
+msgid "dttags"
+msgstr "dttags"
+
+#: ../src/libs/tagging.c:3147
+msgid ""
+"enter tag name\n"
+"press Enter to create a new tag and attach it on selected images\n"
+"press Tab or Down key to go to the first matching tag\n"
+"press shift+Tab to select the first attached user tag"
+msgstr ""
+"Enter tag name\n"
+"Press Enter to create a new tag and attach it on selected images\n"
+"Press Tab or Down key to go to the first matching tag\n"
+"Press shift+Tab to select the first attached user tag"
+
+#: ../src/libs/tagging.c:3158 ../src/libs/tagging.c:3164
+msgid "clear entry"
+msgstr "Clear entry"
+
+#: ../src/libs/tagging.c:3211
+msgid ""
+"tag dictionary,\n"
+"Enter or double-click to attach selected tag on selected images\n"
+"shift+Enter idem plus gives the focus to entry\n"
+"shift+click to fully expand the selected tag\n"
+"right-click for other actions on selected tag\n"
+"shift+Tab to give the focus to entry"
+msgstr ""
+"Tag dictionary,\n"
+"Enter or double-click to attach selected tag on selected images\n"
+"Shift+Enter idem plus gives the focus to entry\n"
+"Shift+click to fully expand the selected tag\n"
+"Right-click for other actions on selected tag\n"
+"Shift+Tab to give the focus to entry"
+
+#: ../src/libs/tagging.c:3246
+msgid ""
+"create a new tag with the\n"
+"name you entered"
+msgstr ""
+"Create a new tag with the\n"
+"name you entered"
+
+#: ../src/libs/tagging.c:3249
+msgid "import tags from a Lightroom keyword file"
+msgstr "Import tags from a Lightroom keyword file"
+
+#: ../src/libs/tagging.c:3252
+msgid "export all tags to a Lightroom keyword file"
+msgstr "Export all tags to a Lightroom keyword file"
+
+#: ../src/libs/tagging.c:3256
+msgid "toggle list / tree view"
+msgstr "Toggle list / tree view"
+
+#: ../src/libs/tagging.c:3256
+msgid "tree"
+msgstr "Tree"
+
+#: ../src/libs/tagging.c:3258
+msgid "toggle list with / without suggestion"
+msgstr "Toggle list with / without suggestion"
+
+#: ../src/libs/tagging.c:3258
+msgid "suggestion"
+msgstr "Suggestion"
+
+#: ../src/libs/tagging.c:3281
+msgid "redo last tag"
+msgstr "Redo last tag"
+
+#: ../src/libs/tagging.c:3365
+msgid ""
+"tag shortcut is not active with tag tree view. please switch to list view"
+msgstr ""
+"Tag shortcut is not active with tag tree view. Please switch to list view"
+
+#: ../src/libs/tagging.c:3469
+msgid "tagging settings"
+msgstr "Tagging settings"
+
+#: ../src/libs/tools/battery_indicator.c:38
+#: ../src/libs/tools/battery_indicator.c:71
+msgid "battery indicator"
+msgstr "Battery indicator"
+
+#: ../src/libs/tools/colorlabels.c:42
+msgid "colorlabels"
+msgstr "Colorlabels"
+
+#: ../src/libs/tools/colorlabels.c:88
+msgid "toggle color label of selected images"
+msgstr "Toggle color label of selected images"
+
+#: ../src/libs/tools/darktable.c:285
+#, c-format
+msgid "copyright (c) the authors 2009-%s"
+msgstr "Copyright (c) the authors 2009-%s"
+
+#: ../src/libs/tools/darktable.c:289
+msgid "organize and develop images from digital cameras"
+msgstr "Organize and develop images from digital cameras"
+
+#: ../src/libs/tools/darktable.c:301
+msgid "all those of you that made previous releases possible"
+msgstr "All those of you that made previous releases possible"
+
+#: ../src/libs/tools/darktable.c:306
+msgid "and..."
+msgstr "And..."
+
+#: ../src/libs/tools/darktable.c:308
+msgid "translator-credits"
+msgstr "Victor Forsiuk <vvforce@gmail.com>"
+
+#: ../src/libs/tools/filmstrip.c:45
+msgid "filmstrip"
+msgstr "Filmstrip"
+
+#: ../src/libs/tools/filter.c:42
+msgid "filter"
+msgstr "Filter"
+
+#: ../src/libs/tools/filter.c:105
+msgid "filter preferences"
+msgstr "Filter preferences"
+
+#: ../src/libs/tools/gamepad.c:37
+msgid "gamepad"
+msgstr "Gamepad"
+
+#: ../src/libs/tools/gamepad.c:71
+msgid "button a"
+msgstr "Button a"
+
+#: ../src/libs/tools/gamepad.c:71
+msgid "button b"
+msgstr "Button b"
+
+#: ../src/libs/tools/gamepad.c:71
+msgid "button x"
+msgstr "Button x"
+
+#: ../src/libs/tools/gamepad.c:71
+msgid "button y"
+msgstr "Button y"
+
+#: ../src/libs/tools/gamepad.c:72
+msgid "button back"
+msgstr "Button back"
+
+#: ../src/libs/tools/gamepad.c:72
+msgid "button guide"
+msgstr "Button guide"
+
+#: ../src/libs/tools/gamepad.c:72
+msgid "button start"
+msgstr "Button start"
+
+#: ../src/libs/tools/gamepad.c:73
+msgid "left stick"
+msgstr "Left stick"
+
+#: ../src/libs/tools/gamepad.c:73
+msgid "right stick"
+msgstr "Right stick"
+
+#: ../src/libs/tools/gamepad.c:73
+msgid "left shoulder"
+msgstr "Left shoulder"
+
+#: ../src/libs/tools/gamepad.c:73
+msgid "right shoulder"
+msgstr "Right shoulder"
+
+#: ../src/libs/tools/gamepad.c:74
+msgid "dpad up"
+msgstr "Dpad up"
+
+#: ../src/libs/tools/gamepad.c:74
+msgid "dpad down"
+msgstr "Dpad down"
+
+#: ../src/libs/tools/gamepad.c:74
+msgid "dpad left"
+msgstr "Dpad left"
+
+#: ../src/libs/tools/gamepad.c:74
+msgid "dpad right"
+msgstr "Dpad right"
+
+#: ../src/libs/tools/gamepad.c:75
+msgid "button misc1"
+msgstr "Button misc1"
+
+#: ../src/libs/tools/gamepad.c:75
+msgid "paddle1"
+msgstr "Paddle1"
+
+#: ../src/libs/tools/gamepad.c:75
+msgid "paddle2"
+msgstr "Paddle2"
+
+#: ../src/libs/tools/gamepad.c:75
+msgid "paddle3"
+msgstr "Paddle3"
+
+#: ../src/libs/tools/gamepad.c:75
+msgid "paddle4"
+msgstr "Paddle4"
+
+#: ../src/libs/tools/gamepad.c:75
+msgid "touchpad"
+msgstr "Touchpad"
+
+#: ../src/libs/tools/gamepad.c:76
+msgid "left trigger"
+msgstr "Left trigger"
+
+#: ../src/libs/tools/gamepad.c:76
+msgid "right trigger"
+msgstr "Right trigger"
+
+#: ../src/libs/tools/gamepad.c:81
+msgid "invalid gamepad button"
+msgstr "Invalid gamepad button"
+
+#: ../src/libs/tools/gamepad.c:98
+msgid "left x"
+msgstr "Left x"
+
+#: ../src/libs/tools/gamepad.c:98
+msgid "left y"
+msgstr "Left y"
+
+#: ../src/libs/tools/gamepad.c:98
+msgid "right x"
+msgstr "Right x"
+
+#: ../src/libs/tools/gamepad.c:98
+msgid "right y"
+msgstr "Right y"
+
+#: ../src/libs/tools/gamepad.c:99
+msgid "left diagonal"
+msgstr "Left diagonal"
+
+#: ../src/libs/tools/gamepad.c:99
+msgid "left skew"
+msgstr "Left skew"
+
+#: ../src/libs/tools/gamepad.c:99
+msgid "right diagonal"
+msgstr "Right diagonal"
+
+#: ../src/libs/tools/gamepad.c:99
+msgid "right skew"
+msgstr "Right skew"
+
+#. diagonals
+#: ../src/libs/tools/gamepad.c:104
+msgid "invalid gamepad axis"
+msgstr "Invalid gamepad axis"
+
+#. we write the label with the size category
+#: ../src/libs/tools/global_toolbox.c:217
+msgid "thumbnails overlays for size"
+msgstr "Thumbnails overlays for size"
+
+#: ../src/libs/tools/global_toolbox.c:251
+#: ../src/libs/tools/global_toolbox.c:314
+msgid ""
+"duration before the block overlay is hidden after each mouse movement on the "
+"image\n"
+"set -1 to never hide the overlay"
+msgstr ""
+"Duration before the block overlay is hidden after each mouse movement on the "
+"image\n"
+"Set -1 to never hide the overlay"
+
+#: ../src/libs/tools/global_toolbox.c:256
+#: ../src/libs/tools/global_toolbox.c:319
+msgid "timeout only available for block overlay"
+msgstr "Timeout only available for block overlay"
+
+#: ../src/libs/tools/global_toolbox.c:279
+#: ../src/libs/tools/global_toolbox.c:465
+msgid "culling overlays"
+msgstr "Culling overlays"
+
+#: ../src/libs/tools/global_toolbox.c:281
+msgid "preview overlays"
+msgstr "Preview overlays"
+
+#: ../src/libs/tools/global_toolbox.c:355
+msgid "overlays not available here..."
+msgstr "Overlays not available here..."
+
+#: ../src/libs/tools/global_toolbox.c:399
+#: ../src/libs/tools/global_toolbox.c:535
+msgid "expand grouped images"
+msgstr "Expand grouped images"
+
+#: ../src/libs/tools/global_toolbox.c:401
+#: ../src/libs/tools/global_toolbox.c:537
+msgid "collapse grouped images"
+msgstr "Collapse grouped images"
+
+#: ../src/libs/tools/global_toolbox.c:408
+msgid "thumbnail overlays options"
+msgstr "Thumbnail overlays options"
+
+#: ../src/libs/tools/global_toolbox.c:409
+msgid "click to change the type of overlays shown on thumbnails"
+msgstr "Click to change the type of overlays shown on thumbnails"
+
+#: ../src/libs/tools/global_toolbox.c:432
+#: ../src/libs/tools/global_toolbox.c:461
+msgid "overlay mode for size"
+msgstr "Overlay mode for size"
+
+#: ../src/libs/tools/global_toolbox.c:436
+msgid "thumbnail overlays"
+msgstr "Thumbnail overlays"
+
+#: ../src/libs/tools/global_toolbox.c:438
+#: ../src/libs/tools/global_toolbox.c:467
+msgid "no overlays"
+msgstr "No overlays"
+
+#: ../src/libs/tools/global_toolbox.c:439
+msgid "overlays on mouse hover"
+msgstr "Overlays on mouse hover"
+
+#: ../src/libs/tools/global_toolbox.c:440
+msgid "extended overlays on mouse hover"
+msgstr "Extended overlays on mouse hover"
+
+#: ../src/libs/tools/global_toolbox.c:441
+#: ../src/libs/tools/global_toolbox.c:468
+msgid "permanent overlays"
+msgstr "Permanent overlays"
+
+#: ../src/libs/tools/global_toolbox.c:442
+#: ../src/libs/tools/global_toolbox.c:469
+msgid "permanent extended overlays"
+msgstr "Permanent extended overlays"
+
+#: ../src/libs/tools/global_toolbox.c:443
+msgid "permanent overlays extended on mouse hover"
+msgstr "Permanent overlays extended on mouse hover"
+
+#: ../src/libs/tools/global_toolbox.c:445
+#: ../src/libs/tools/global_toolbox.c:471
+msgid "overlays block on mouse hover"
+msgstr "Overlays block on mouse hover"
+
+#: ../src/libs/tools/global_toolbox.c:446
+#: ../src/libs/tools/global_toolbox.c:472
+msgid "during (s)"
+msgstr "during (s)"
+
+#: ../src/libs/tools/global_toolbox.c:451
+#: ../src/libs/tools/global_toolbox.c:477
+msgid "show tooltip"
+msgstr "Show tooltip"
+
+#: ../src/libs/tools/global_toolbox.c:489
+msgid "help"
+msgstr "Help"
+
+#: ../src/libs/tools/global_toolbox.c:491
+msgid "enable this, then click on a control element to see its online help"
+msgstr "Enable this, then click on a control element to see its online help"
+
+#: ../src/libs/tools/global_toolbox.c:498
+msgid ""
+"define shortcuts\n"
+"ctrl+click to switch off overwrite confirmations\n"
+"\n"
+"hover over a widget and press keys with mouse click and scroll or move "
+"combinations\n"
+"repeat same combination again to delete mapping\n"
+"click on a widget, module or screen area to open the dialog for further "
+"configuration"
+msgstr ""
+"Define shortcuts\n"
+"Ctrl+click to switch off overwrite confirmations\n"
+"\n"
+"Hover over a widget and press keys with mouse click and scroll or move "
+"combinations\n"
+"Repeat same combination again to delete mapping\n"
+"Click on a widget, module or screen area to open the dialog for further "
+"configuration"
+
+#: ../src/libs/tools/global_toolbox.c:514
+msgid "show global preferences"
+msgstr "Show global preferences"
+
+#. ask the user if darktable.org may be accessed
+#: ../src/libs/tools/global_toolbox.c:643
+msgid "access the online usermanual?"
+msgstr "Access the online usermanual?"
+
+#: ../src/libs/tools/global_toolbox.c:644
+#, c-format
+msgid "do you want to access `%s'?"
+msgstr "Do you want to access `%s'?"
+
+#: ../src/libs/tools/global_toolbox.c:713
+msgid "help url opened in web browser"
+msgstr "Help URL opened in web browser"
+
+#: ../src/libs/tools/global_toolbox.c:717
+msgid "error while opening help url in web browser"
+msgstr "Error while opening help URL in web browser"
+
+#: ../src/libs/tools/global_toolbox.c:728
+msgid "there is no help available for this element"
+msgstr "There is no help available for this element"
+
+#: ../src/libs/tools/hinter.c:42
+msgid "hinter"
+msgstr "Hinter"
+
+#: ../src/libs/tools/hinter.c:99
+#, c-format
+msgid "%s in current collection"
+msgstr "%s in current collection"
+
+#: ../src/libs/tools/image_infos.c:40
+msgid "image infos"
+msgstr "Image infos"
+
+#: ../src/libs/tools/lighttable.c:117
+msgid "click to exit from full preview layout."
+msgstr "Click to exit from full preview layout."
+
+#: ../src/libs/tools/lighttable.c:119
+msgid "click to enter full preview layout."
+msgstr "Click to enter full preview layout."
+
+#: ../src/libs/tools/lighttable.c:122
+msgid "click to enter culling layout in fixed mode."
+msgstr "Click to enter culling layout in fixed mode."
+
+#: ../src/libs/tools/lighttable.c:124 ../src/libs/tools/lighttable.c:129
+msgid "click to exit culling layout."
+msgstr "Click to exit culling layout."
+
+#: ../src/libs/tools/lighttable.c:127
+msgid "click to enter culling layout in dynamic mode."
+msgstr "Click to enter culling layout in dynamic mode."
+
+#: ../src/libs/tools/lighttable.c:366
+msgid "toggle filemanager layout"
+msgstr "Toggle filemanager layout"
+
+#: ../src/libs/tools/lighttable.c:369
+msgid "click to enter filemanager layout."
+msgstr "Click to enter filemanager layout."
+
+#: ../src/libs/tools/lighttable.c:375
+msgid "toggle zoomable lighttable layout"
+msgstr "Toggle zoomable Lighttable layout"
+
+#: ../src/libs/tools/lighttable.c:378
+msgid "click to enter zoomable lighttable layout."
+msgstr "Click to enter zoomable Lighttable layout."
+
+#: ../src/libs/tools/lighttable.c:384
+msgid "toggle culling mode"
+msgstr "Toggle culling mode"
+
+#: ../src/libs/tools/lighttable.c:392
+msgid "toggle culling dynamic mode"
+msgstr "Toggle culling dynamic mode"
+
+#: ../src/libs/tools/lighttable.c:439
+msgid "toggle culling zoom mode"
+msgstr "Toggle culling zoom mode"
+
+#: ../src/libs/tools/lighttable.c:441
+msgid "exit current layout"
+msgstr "Exit current layout"
+
+#: ../src/libs/tools/midi.c:41
+msgid "midi"
+msgstr "MIDI"
+
+#: ../src/libs/tools/midi.c:205
+msgid "using absolute encoding; reinitialise to switch to relative"
+msgstr "Using absolute encoding; reinitialise to switch to relative"
+
+#: ../src/libs/tools/midi.c:209
+#, c-format
+msgid "%d more identical (down) moves before switching to relative encoding"
+msgstr "%d more identical (down) moves before switching to relative encoding"
+
+#: ../src/libs/tools/midi.c:212
+#, c-format
+msgid "switching encoding to relative (down = %d)"
+msgstr "Switching encoding to relative (down = %d)"
+
+#: ../src/libs/tools/module_toolbox.c:46
+msgid "module toolbox"
+msgstr "Module toolbox"
+
+#. connect callbacks
+#: ../src/libs/tools/ratings.c:98
+msgid "set star rating for selected images"
+msgstr "Set star rating for selected images"
+
+#: ../src/libs/tools/timeline.c:102
+msgid "timeline"
+msgstr "Timeline"
+
+#: ../src/libs/tools/timeline.c:1434
+msgid "start selection"
+msgstr "Start selection"
+
+#: ../src/libs/tools/timeline.c:1435
+msgid "stop selection"
+msgstr "Stop selection"
+
+#: ../src/libs/tools/view_toolbox.c:46
+msgid "view toolbox"
+msgstr "View toolbox"
+
+#: ../src/libs/tools/viewswitcher.c:60
+msgid "viewswitcher"
+msgstr "Viewswitcher"
+
+#: ../src/lua/preferences.c:655 ../src/lua/preferences.c:670
+#: ../src/lua/preferences.c:682 ../src/lua/preferences.c:694
+#: ../src/lua/preferences.c:710 ../src/lua/preferences.c:774
+#, c-format
+msgid "double-click to reset to `%s'"
+msgstr "Double-click to reset to `%s'"
+
+#: ../src/lua/preferences.c:680
+msgid "select file"
+msgstr "Select file"
+
+#: ../src/lua/preferences.c:733
+#, c-format
+msgid "double-click to reset to `%d'"
+msgstr "Double-click to reset to `%d'"
+
+#: ../src/lua/preferences.c:760
+#, c-format
+msgid "double-click to reset to `%f'"
+msgstr "Double-click to reset to `%f'"
+
+#: ../src/lua/preferences.c:836
+msgid "lua options"
+msgstr "Lua options"
+
+#: ../src/views/darkroom.c:607
+#, c-format
+msgid ""
+"darktable could not load `%s', switching to lighttable now.\n"
+"\n"
+"please check that the camera model that produced the image is supported in "
+"darktable\n"
+"(list of supported cameras is at https://www.darktable.org/resources/camera-"
+"support/).\n"
+"if you are sure that the camera model is supported, please consider opening "
+"an issue\n"
+"at https://github.com/darktable-org/darktable"
+msgstr ""
+"Darktable could not load `%s', switching to Lighttable now.\n"
+"\n"
+"Please check that the camera model that produced the image is supported in "
+"Darktable\n"
+"(list of supported cameras is at https://www.darktable.org/resources/camera-"
+"support/).\n"
+"If you are sure that the camera model is supported, please consider opening "
+"an issue\n"
+"at https://github.com/darktable-org/darktable"
+
+#: ../src/views/darkroom.c:625
+#, c-format
+msgctxt "darkroom"
+msgid "loading `%s' ..."
+msgstr "Loading `%s' ..."
+
+#: ../src/views/darkroom.c:741 ../src/views/darkroom.c:2478
+msgid "gamut check"
+msgstr "Gamut check"
+
+#: ../src/views/darkroom.c:741
+msgid "soft proof"
+msgstr "Soft proof"
+
+#. fail :(
+#: ../src/views/darkroom.c:779 ../src/views/print.c:329
+msgid "no image to open!"
+msgstr "No image to open!"
+
+#: ../src/views/darkroom.c:1313
+msgid "no userdefined presets for favorite modules were found"
+msgstr "No userdefined presets for favorite modules were found"
+
+#: ../src/views/darkroom.c:1458
+msgid "no styles have been created yet"
+msgstr "No styles have been created yet"
+
+#: ../src/views/darkroom.c:2313 ../src/views/darkroom.c:2314
+msgid "quick access to presets"
+msgstr "Quick access to presets"
+
+#: ../src/views/darkroom.c:2322
+msgid "quick access to styles"
+msgstr "Quick access to styles"
+
+#: ../src/views/darkroom.c:2324
+msgid "quick access for applying any of your styles"
+msgstr "Quick access for applying any of your styles"
+
+#: ../src/views/darkroom.c:2330
+msgid "second window"
+msgstr "Second window"
+
+#: ../src/views/darkroom.c:2333
+msgid "display a second darkroom image window"
+msgstr "Display a second Darkroom image window"
+
+#: ../src/views/darkroom.c:2338
+msgid "color assessment"
+msgstr "Color assessment"
+
+#: ../src/views/darkroom.c:2341
+msgid "toggle ISO 12646 color assessment conditions"
+msgstr "Toggle ISO 12646 color assessment conditions"
+
+#: ../src/views/darkroom.c:2354
+msgid ""
+"toggle raw over exposed indication\n"
+"right click for options"
+msgstr ""
+"Toggle raw over exposed indication\n"
+"Right click for options"
+
+#: ../src/views/darkroom.c:2370
+msgid "select how to mark the clipped pixels"
+msgstr "Select how to mark the clipped pixels"
+
+#: ../src/views/darkroom.c:2372
+msgid "mark with CFA color"
+msgstr "Mark with CFA color"
+
+#: ../src/views/darkroom.c:2372
+msgid "mark with solid color"
+msgstr "Mark with solid color"
+
+#: ../src/views/darkroom.c:2372
+msgid "false color"
+msgstr "False color"
+
+#: ../src/views/darkroom.c:2375 ../src/views/darkroom.c:2426
+msgid "color scheme"
+msgstr "Color scheme"
+
+#: ../src/views/darkroom.c:2376
+msgid ""
+"select the solid color to indicate over exposure.\n"
+"will only be used if mode = mark with solid color"
+msgstr ""
+"Select the solid color to indicate over exposure.\n"
+"Will only be used if mode = mark with solid color"
+
+#: ../src/views/darkroom.c:2379
+msgctxt "solidcolor"
+msgid "red"
+msgstr "Red"
+
+#: ../src/views/darkroom.c:2380
+msgctxt "solidcolor"
+msgid "green"
+msgstr "Green"
+
+#: ../src/views/darkroom.c:2381
+msgctxt "solidcolor"
+msgid "blue"
+msgstr "Blue"
+
+#: ../src/views/darkroom.c:2382
+msgctxt "solidcolor"
+msgid "black"
+msgstr "Black"
+
+#: ../src/views/darkroom.c:2390
+msgid ""
+"threshold of what shall be considered overexposed\n"
+"1.0 - white level\n"
+"0.0 - black level"
+msgstr ""
+"Threshold of what shall be considered overexposed\n"
+"1.0 - white level\n"
+"0.0 - black level"
+
+#: ../src/views/darkroom.c:2404
+msgid ""
+"toggle clipping indication\n"
+"right click for options"
+msgstr ""
+"Toggle clipping indication\n"
+"Right click for options"
+
+#: ../src/views/darkroom.c:2419
+msgid "clipping preview mode"
+msgstr "Clipping preview mode"
+
+#: ../src/views/darkroom.c:2420
+msgid ""
+"select the metric you want to preview\n"
+"full gamut is the combination of all other modes"
+msgstr ""
+"Select the metric you want to preview\n"
+"Full gamut is the combination of all other modes"
+
+#: ../src/views/darkroom.c:2422
+msgid "full gamut"
+msgstr "Full gamut"
+
+#: ../src/views/darkroom.c:2422
+msgid "any RGB channel"
+msgstr "Any RGB channel"
+
+#: ../src/views/darkroom.c:2422
+msgid "luminance only"
+msgstr "Luminance only"
+
+#: ../src/views/darkroom.c:2422
+msgid "saturation only"
+msgstr "Saturation only"
+
+#: ../src/views/darkroom.c:2427
+msgid "select colors to indicate clipping"
+msgstr "Select colors to indicate clipping"
+
+#: ../src/views/darkroom.c:2429
+msgid "black & white"
+msgstr "Black & white"
+
+#: ../src/views/darkroom.c:2429
+msgid "red & blue"
+msgstr "Red & blue"
+
+#: ../src/views/darkroom.c:2429
+msgid "purple & green"
+msgstr "Purple & green"
+
+#: ../src/views/darkroom.c:2436
+msgid "lower threshold"
+msgstr "Lower threshold"
+
+#: ../src/views/darkroom.c:2437
+msgid ""
+"clipping threshold for the black point,\n"
+"in EV, relatively to white (0 EV).\n"
+"8 bits sRGB clips blacks at -12.69 EV,\n"
+"8 bits Adobe RGB clips blacks at -19.79 EV,\n"
+"16 bits sRGB clips blacks at -20.69 EV,\n"
+"typical fine-art mat prints produce black at -5.30 EV,\n"
+"typical color glossy prints produce black at -8.00 EV,\n"
+"typical B&W glossy prints produce black at -9.00 EV."
+msgstr ""
+"Clipping threshold for the black point,\n"
+"in EV, relative to white (0 EV).\n"
+"8 bits sRGB clips blacks at -12.69 EV,\n"
+"8 bits Adobe RGB clips blacks at -19.79 EV,\n"
+"16 bits sRGB clips blacks at -20.69 EV,\n"
+"Typical fine-art mat prints produce black at -5.30 EV,\n"
+"Typical color glossy prints produce black at -8.00 EV,\n"
+"Typical B&W glossy prints produce black at -9.00 EV."
+
+#: ../src/views/darkroom.c:2453
+msgid "upper threshold"
+msgstr "Upper threshold"
+
+#: ../src/views/darkroom.c:2455
+#, no-c-format
+msgid ""
+"clipping threshold for the white point.\n"
+"100% is peak medium luminance."
+msgstr ""
+"Clipping threshold for the white point.\n"
+"100% is peak medium luminance."
+
+#: ../src/views/darkroom.c:2467
+msgid "softproof"
+msgstr "Softproof"
+
+#: ../src/views/darkroom.c:2470
+msgid ""
+"toggle softproofing\n"
+"right click for profile options"
+msgstr ""
+"Toggle softproofing\n"
+"Right click for profile options"
+
+#: ../src/views/darkroom.c:2481
+msgid ""
+"toggle gamut checking\n"
+"right click for profile options"
+msgstr ""
+"Toggle gamut checking\n"
+"Right click for profile options"
+
+#: ../src/views/darkroom.c:2510 ../src/views/darkroom.c:2512
+#: ../src/views/darkroom.c:2526 ../src/views/darkroom.c:2527
+#: ../src/views/darkroom.c:2528 ../src/views/darkroom.c:2529
+#: ../src/views/lighttable.c:1186 ../src/views/lighttable.c:1188
+msgid "profiles"
+msgstr "Profiles"
+
+#: ../src/views/darkroom.c:2512 ../src/views/lighttable.c:1188
+msgid "preview intent"
+msgstr "Preview intent"
+
+#: ../src/views/darkroom.c:2526 ../src/views/lighttable.c:1192
+msgid "display profile"
+msgstr "Display profile"
+
+#: ../src/views/darkroom.c:2527 ../src/views/lighttable.c:1195
+msgid "preview display profile"
+msgstr "Preview display profile"
+
+#: ../src/views/darkroom.c:2529
+msgid "histogram profile"
+msgstr "Histogram profile"
+
+#: ../src/views/darkroom.c:2593 ../src/views/lighttable.c:1231
+#, c-format
+msgid "display ICC profiles in %s or %s"
+msgstr "Display ICC profiles in %s or %s"
+
+#: ../src/views/darkroom.c:2596 ../src/views/lighttable.c:1234
+#, c-format
+msgid "preview display ICC profiles in %s or %s"
+msgstr "Preview display ICC profiles in %s or %s"
+
+#: ../src/views/darkroom.c:2599
+#, c-format
+msgid "softproof ICC profiles in %s or %s"
+msgstr "Softproof ICC profiles in %s or %s"
+
+#: ../src/views/darkroom.c:2602
+#, c-format
+msgid "histogram and color picker ICC profiles in %s or %s"
+msgstr "Histogram and color picker ICC profiles in %s or %s"
+
+#: ../src/views/darkroom.c:2638
+msgid ""
+"toggle guide lines\n"
+"right click for guides options"
+msgstr ""
+"Toggle guide lines\n"
+"Right click for guides options"
+
+#. Fullscreen preview key
+#: ../src/views/darkroom.c:2655
+msgid "full preview"
+msgstr "Full preview"
+
+#. add an option to allow skip mouse events while other overlays are consuming mouse actions
+#: ../src/views/darkroom.c:2659
+msgid "force pan/zoom/rotate with mouse"
+msgstr "Force pan/zoom/rotate with mouse"
+
+#. Zoom shortcuts
+#: ../src/views/darkroom.c:2671
+msgid "zoom close-up"
+msgstr "Zoom close-up"
+
+#. zoom in/out
+#. zoom in/out/min/max
+#: ../src/views/darkroom.c:2674 ../src/views/lighttable.c:1290
+msgid "zoom in"
+msgstr "Zoom in"
+
+#: ../src/views/darkroom.c:2675 ../src/views/lighttable.c:1292
+msgid "zoom out"
+msgstr "Zoom out"
+
+#. Shortcut to skip images
+#: ../src/views/darkroom.c:2678
+msgid "image forward"
+msgstr "Image forward"
+
+#: ../src/views/darkroom.c:2679
+msgid "image back"
+msgstr "Image back"
+
+#. cycle overlay colors
+#: ../src/views/darkroom.c:2682
+msgid "cycle overlay colors"
+msgstr "Cycle overlay colors"
+
+#. toggle visibility of drawn masks for current gui module
+#: ../src/views/darkroom.c:2685
+msgid "show drawn masks"
+msgstr "Show drawn masks"
+
+#. brush size +/-
+#: ../src/views/darkroom.c:2688
+msgid "increase brush size"
+msgstr "Increase brush size"
+
+#: ../src/views/darkroom.c:2689
+msgid "decrease brush size"
+msgstr "Decrease brush size"
+
+#. brush hardness +/-
+#: ../src/views/darkroom.c:2692
+msgid "increase brush hardness"
+msgstr "Increase brush hardness"
+
+#: ../src/views/darkroom.c:2693
+msgid "decrease brush hardness"
+msgstr "Decrease brush hardness"
+
+#. brush opacity +/-
+#: ../src/views/darkroom.c:2696
+msgid "increase brush opacity"
+msgstr "Increase brush opacity"
+
+#: ../src/views/darkroom.c:2697
+msgid "decrease brush opacity"
+msgstr "Decrease brush opacity"
+
+#. undo/redo
+#: ../src/views/darkroom.c:2700 ../src/views/lighttable.c:1282
+#: ../src/views/map.c:2115
+msgid "undo"
+msgstr "Undo"
+
+#: ../src/views/darkroom.c:2701 ../src/views/lighttable.c:1283
+#: ../src/views/map.c:2116
+msgid "redo"
+msgstr "Redo"
+
+#. change the precision for adjusting sliders with keyboard shortcuts
+#: ../src/views/darkroom.c:2704
+msgid "change keyboard shortcut slider precision"
+msgstr "Change keyboard shortcut slider precision"
+
+#: ../src/views/darkroom.c:3981
+msgid "keyboard shortcut slider precision: fine"
+msgstr "Keyboard shortcut slider precision: fine"
+
+#: ../src/views/darkroom.c:3983
+msgid "keyboard shortcut slider precision: normal"
+msgstr "Keyboard shortcut slider precision: normal"
+
+#: ../src/views/darkroom.c:3985
+msgid "keyboard shortcut slider precision: coarse"
+msgstr "Keyboard shortcut slider precision: coarse"
+
+#: ../src/views/darkroom.c:4001
+msgid "switch to lighttable"
+msgstr "Switch to Lighttable"
+
+#: ../src/views/darkroom.c:4002 ../src/views/lighttable.c:882
+msgid "zoom in the image"
+msgstr "Zoom in the image"
+
+#: ../src/views/darkroom.c:4003
+msgid "unbounded zoom in the image"
+msgstr "Unbounded zoom in the image"
+
+#: ../src/views/darkroom.c:4004
+msgid "zoom to 100% 200% and back"
+msgstr "Zoom to 100% 200% and back"
+
+#: ../src/views/darkroom.c:4005 ../src/views/lighttable.c:885
+msgid "pan a zoomed image"
+msgstr "Pan a zoomed image"
+
+#: ../src/views/darkroom.c:4007 ../src/views/lighttable.c:927
+msgid "[modules] expand module without closing others"
+msgstr "[modules] expand module without closing others"
+
+#: ../src/views/darkroom.c:4008 ../src/views/lighttable.c:928
+msgid "[modules] expand module and close others"
+msgstr "[modules] expand module and close others"
+
+#: ../src/views/darkroom.c:4010
+msgid "[modules] rename module"
+msgstr "[modules] rename module"
+
+#: ../src/views/darkroom.c:4012
+msgid "[modules] change module position in pipe"
+msgstr "[modules] change module position in pipe"
+
+#: ../src/views/knight.c:334
+msgid "good knight"
+msgstr "Good knight"
+
+#. Show infos key
+#: ../src/views/lighttable.c:656 ../src/views/lighttable.c:1273
+msgid "show infos"
+msgstr "Show infos"
+
+#: ../src/views/lighttable.c:759
+msgid "middle"
+msgstr "Middle"
+
+#: ../src/views/lighttable.c:877
+msgid "open image in darkroom"
+msgstr "Open image in Darkroom"
+
+#: ../src/views/lighttable.c:881
+msgid "switch to next/previous image"
+msgstr "Switch to next/previous image"
+
+#: ../src/views/lighttable.c:884 ../src/views/lighttable.c:915
+#, no-c-format
+msgid "zoom to 100% and back"
+msgstr "Zoom to 100% and back"
+
+#: ../src/views/lighttable.c:889 ../src/views/lighttable.c:908
+msgid "scroll the collection"
+msgstr "Scroll the collection"
+
+#: ../src/views/lighttable.c:891
+msgid "change number of images per row"
+msgstr "Change number of images per row"
+
+#: ../src/views/lighttable.c:894
+msgid "select an image"
+msgstr "Select an image"
+
+#: ../src/views/lighttable.c:896
+msgid "select range from last image"
+msgstr "Select range from last image"
+
+#: ../src/views/lighttable.c:898
+msgid "add image to or remove it from a selection"
+msgstr "Add image to or remove it from a selection"
+
+#: ../src/views/lighttable.c:902
+msgid "change image order"
+msgstr "Change image order"
+
+#: ../src/views/lighttable.c:909
+msgid "zoom all the images"
+msgstr "Zoom all the images"
+
+#: ../src/views/lighttable.c:910
+msgid "pan inside all the images"
+msgstr "Pan inside all the images"
+
+#: ../src/views/lighttable.c:912
+msgid "zoom current image"
+msgstr "Zoom current image"
+
+#: ../src/views/lighttable.c:913
+msgid "pan inside current image"
+msgstr "Pan inside current image"
+
+#: ../src/views/lighttable.c:918
+#, no-c-format
+msgid "zoom current image to 100% and back"
+msgstr "Zoom current image to 100% and back"
+
+#: ../src/views/lighttable.c:922
+msgid "zoom the main view"
+msgstr "Zoom the main view"
+
+#: ../src/views/lighttable.c:923
+msgid "pan inside the main view"
+msgstr "Pan inside the main view"
+
+#: ../src/views/lighttable.c:1160
+msgid "set display profile"
+msgstr "Set display profile"
+
+#: ../src/views/lighttable.c:1253
+msgid "whole"
+msgstr "Whole"
+
+#: ../src/views/lighttable.c:1269
+msgid "leave"
+msgstr "Leave"
+
+#: ../src/views/lighttable.c:1276
+msgid "align images to grid"
+msgstr "Align images to grid"
+
+#: ../src/views/lighttable.c:1277
+msgid "reset first image offset"
+msgstr "Reset first image offset"
+
+#: ../src/views/lighttable.c:1278
+msgid "select toggle image"
+msgstr "Select toggle image"
+
+#: ../src/views/lighttable.c:1279
+msgid "select single image"
+msgstr "Select single image"
+
+#. zoom for full culling & preview
+#: ../src/views/lighttable.c:1286
+msgid "preview zoom 100%"
+msgstr "Preview zoom 100%"
+
+#: ../src/views/lighttable.c:1287
+msgid "preview zoom fit"
+msgstr "Preview zoom fit"
+
+#: ../src/views/lighttable.c:1291
+msgid "zoom max"
+msgstr "Zoom max"
+
+#: ../src/views/lighttable.c:1293
+msgid "zoom min"
+msgstr "Zoom min"
+
+#: ../src/views/map.c:2809
+msgid "[on image] open in darkroom"
+msgstr "[on image] open in Darkroom"
+
+#: ../src/views/map.c:2810
+msgid "[on map] zoom map"
+msgstr "[on map] zoom map"
+
+#: ../src/views/map.c:2811
+msgid "move image location"
+msgstr "Move image location"
+
+#: ../src/views/print.c:55
+msgctxt "view"
+msgid "print"
+msgstr "Print"
+
+#: ../src/views/slideshow.c:353
+msgid "end of images"
+msgstr "End of images"
+
+#: ../src/views/slideshow.c:374
+msgid "end of images. press any key to return to lighttable mode"
+msgstr "End of images. Press any key to return to Lighttable mode"
+
+#: ../src/views/slideshow.c:504
+msgid "waiting to start slideshow"
+msgstr "Waiting to start slideshow"
+
+#: ../src/views/slideshow.c:640 ../src/views/slideshow.c:661
+#: ../src/views/slideshow.c:669
+msgid "slideshow paused"
+msgstr "Slideshow paused"
+
+#: ../src/views/slideshow.c:648 ../src/views/slideshow.c:655
+#, c-format
+msgid "slideshow delay set to %d second"
+msgid_plural "slideshow delay set to %d seconds"
+msgstr[0] "Slideshow delay set to %d second"
+msgstr[1] "Slideshow delay set to %d seconds"
+
+#: ../src/views/slideshow.c:684
+msgid "start and stop"
+msgstr "Start and stop"
+
+#: ../src/views/slideshow.c:685
+msgid "exit slideshow"
+msgstr "Exit slideshow"
+
+#: ../src/views/slideshow.c:688
+msgid "slow down"
+msgstr "Slow down"
+
+#: ../src/views/slideshow.c:691
+msgid "speed up"
+msgstr "Speed up"
+
+#: ../src/views/slideshow.c:695
+msgid "step forward"
+msgstr "Step forward"
+
+#: ../src/views/slideshow.c:696
+msgid "step back"
+msgstr "Step back"
+
+#: ../src/views/slideshow.c:702
+msgid "go to next image"
+msgstr "Go to next image"
+
+#: ../src/views/slideshow.c:703
+msgid "go to previous image"
+msgstr "Go to previous image"
+
+#: ../src/views/tethering.c:157
+#, c-format
+msgid "new session initiated '%s'"
+msgstr "New session initiated '%s'"
+
+#: ../src/views/tethering.c:448
+msgid "no camera with tethering support available for use..."
+msgstr "No camera with tethering support available for use..."
+
+#: ../src/views/view.c:1193
+msgid "left click"
+msgstr "Left click"
+
+#: ../src/views/view.c:1196
+msgid "right click"
+msgstr "Right click"
+
+#: ../src/views/view.c:1199
+msgid "middle click"
+msgstr "Middle click"
+
+#: ../src/views/view.c:1205
+msgid "left double-click"
+msgstr "Left double-click"
+
+#: ../src/views/view.c:1208
+msgid "right double-click"
+msgstr "Right double-click"
+
+#: ../src/views/view.c:1211
+msgid "drag and drop"
+msgstr "Drag and drop"
+
+#: ../src/views/view.c:1214
+msgid "left click+drag"
+msgstr "Left click+drag"
+
+#: ../src/views/view.c:1217
+msgid "right click+drag"
+msgstr "Right click+drag"
+
+#: ../src/views/view.c:1237
+msgid "darktable - accels window"
+msgstr "Darktable - accels window"
+
+#: ../src/views/view.c:1285
+msgid "switch to a classic window which will stay open after key release"
+msgstr "Switch to a classic window which will stay open after key release"
+
+#. we add the mouse actions too
+#: ../src/views/view.c:1344
+msgid "mouse actions"
+msgstr "Mouse actions"
+
+#~ msgctxt "preferences"
+#~ msgid "on startup"
+#~ msgstr "On startup"
+
+#~ msgctxt "preferences"
+#~ msgid "on both"
+#~ msgstr "On both"
+
+#~ msgctxt "preferences"
+#~ msgid "on startup (don't ask)"
+#~ msgstr "On startup (don't ask)"
+
+#~ msgctxt "preferences"
+#~ msgid "on close (don't ask)"
+#~ msgstr "On close (don't ask)"
+
+#~ msgctxt "preferences"
+#~ msgid "on both (don't ask)"
+#~ msgstr "On both (don't ask)"
+
+#~ msgctxt "preferences"
+#~ msgid "true"
+#~ msgstr "True"
+
+#~ msgctxt "preferences"
+#~ msgid "false"
+#~ msgstr "False"
+
+#~ msgctxt "preferences"
+#~ msgid "always bilinear (fast)"
+#~ msgstr "Always bilinear (fast)"
+
+#~ msgctxt "preferences"
+#~ msgid "at most RCD (reasonable)"
+#~ msgstr "At most RCD (reasonable)"
+
+#~ msgctxt "preferences"
+#~ msgid "full (possibly slow)"
+#~ msgstr "Full (possibly slow)"
+
+#~ msgctxt "preferences"
+#~ msgid "modern"
+#~ msgstr "Modern"
+
+#~ msgctxt "preferences"
+#~ msgid "legacy"
+#~ msgstr "Legacy"
+
+#~ msgid "demosaicing for zoomed out darkroom mode"
+#~ msgstr "Demosaicing for zoomed out Darkroom mode"
+
+#~ msgid ""
+#~ "interpolation when not viewing 1:1 in darkroom mode: bilinear is fastest, "
+#~ "but not as sharp. middle ground is using RCD + interpolation modes "
+#~ "specified on the 'pixel interpolator' option (processing tab), full will "
+#~ "use exactly the settings for full-size export. X-Trans sensors use VNG "
+#~ "rather than RCD as middle ground."
+#~ msgstr ""
+#~ "Interpolation when not viewing 1:1 in Darkroom mode: bilinear is fastest, "
+#~ "but not as sharp. Middle ground is using RCD + interpolation modes "
+#~ "specified on the 'pixel interpolator' option (processing tab), full will "
+#~ "use exactly the settings for full-size export. X-Trans sensors use VNG "
+#~ "rather than RCD as middle ground."
+
+#~ msgid "white balance slider colors"
+#~ msgstr "White balance slider colors"
+
+#~ msgid ""
+#~ "visual indication of temperature adjustments.\n"
+#~ "in 'illuminant color' mode slider colors represent the color of the light "
+#~ "source,\n"
+#~ "in 'effect emulation' slider colors represent the effect the adjustment "
+#~ "would have on the scene"
+#~ msgstr ""
+#~ "Visual indication of temperature adjustments.\n"
+#~ "In 'illuminant color' mode slider colors represent the color of the light "
+#~ "source,\n"
+#~ "In 'effect emulation' slider colors represent the effect the adjustment "
+#~ "would have on the scene"
+
+#~ msgid "color balance slider block layout"
+#~ msgstr "Color balance slider block layout"
+
+#~ msgid ""
+#~ "choose how to organise the slider blocks for lift, gamma and gain:\n"
+#~ "list - all sliders are shown in one long list (with headers),\n"
+#~ "tabs - use tabs to switch between the blocks of sliders,\n"
+#~ "columns - the blocks of sliders are shown next to each other (in narrow "
+#~ "columns)"
+#~ msgstr ""
+#~ "Choose how to organise the slider blocks for lift, gamma and gain:\n"
+#~ "List - all sliders are shown in one long list (with headers),\n"
+#~ "Tabs - use tabs to switch between the blocks of sliders,\n"
+#~ "Columns - the blocks of sliders are shown next to each other (in narrow "
+#~ "columns)"
+
+#~ msgid "auto-apply chromatic adaptation defaults"
+#~ msgstr "Auto-apply chromatic adaptation defaults"
+
+#~ msgid ""
+#~ "legacy performs a basic chromatic adaptation using only the white balance "
+#~ "module\n"
+#~ "modern uses a combination of white balance module and color calibration "
+#~ "module, with improved color science for chromatic adaptation"
+#~ msgstr ""
+#~ "Legacy performs a basic chromatic adaptation using only the white balance "
+#~ "module\n"
+#~ "Modern uses a combination of white balance module and color calibration "
+#~ "module, with improved color science for chromatic adaptation"
+
+#~ msgid "auto-apply sharpen"
+#~ msgstr "Auto-apply sharpen"
+
+#~ msgid ""
+#~ "this added sharpen is not recommended on cameras without a low-pass "
+#~ "filter. you should disable this option if you use one of those more "
+#~ "recent cameras or sharpen your images with other means."
+#~ msgstr ""
+#~ "This added sharpen is not recommended on cameras without a low-pass "
+#~ "filter. You should disable this option if you use one of those more "
+#~ "recent cameras or sharpen your images with other means."
+
+#~ msgid "check for database maintenance"
+#~ msgstr "Check for database maintenance"
+
+#~ msgid ""
+#~ "this option indicates when to check database fragmentation and perform "
+#~ "maintenance"
+#~ msgstr ""
+#~ "This option indicates when to check database fragmentation and perform "
+#~ "maintenance"
+
+#~ msgid "database fragmentation ratio threshold"
+#~ msgstr "Database fragmentation ratio threshold"
+
+#~ msgid ""
+#~ "fragmentation ratio above which to ask or carry out automatically "
+#~ "database maintenance"
+#~ msgstr ""
+#~ "Fragmentation ratio above which to ask or carry out automatically "
+#~ "database maintenance"
+
+#~ msgid "xmp"
+#~ msgstr "XMP"
+
+#~ msgid "lift luminance"
+#~ msgstr "Lift luminance"
+
+#~ msgid "lift chroma"
+#~ msgstr "Lift chroma"
+
+#~ msgid "lift hue"
+#~ msgstr "Lift hue"
+
+#~ msgid "power luminance"
+#~ msgstr "Power luminance"
+
+#~ msgid "power chroma"
+#~ msgstr "Power chroma"
+
+#~ msgid "power hue"
+#~ msgstr "Power hue"
+
+#~ msgid "gain luminance"
+#~ msgstr "Gain luminance"
+
+#~ msgid "gain chroma"
+#~ msgstr "Gain chroma"
+
+#~ msgid "gain hue"
+#~ msgstr "Gain hue"
+
+#~ msgid "offset luminance"
+#~ msgstr "Offset luminance"
+
+#~ msgid "offset chroma"
+#~ msgstr "Offset chroma"
+
+#~ msgid "offset hue"
+#~ msgstr "Offset hue"
+
+#~ msgid "chroma shadows"
+#~ msgstr "Chroma shadows"
+
+#~ msgid "chroma highlights"
+#~ msgstr "Chroma highlights"
+
+#~ msgid "chroma global"
+#~ msgstr "Chroma global"
+
+#~ msgid "chroma mid-tones"
+#~ msgstr "Chroma mid-tones"
+
+#~ msgid "saturation global"
+#~ msgstr "Saturation global"
+
+#~ msgid "saturation highlights"
+#~ msgstr "Saturation highlights"
+
+#~ msgid "saturation mid-tones"
+#~ msgstr "Saturation mid-tones"
+
+#~ msgid "saturation shadows"
+#~ msgstr "Saturation shadows"
+
+#~ msgid "brilliance global"
+#~ msgstr "Brilliance global"
+
+#~ msgid "brilliance highlights"
+#~ msgstr "Brilliance highlights"
+
+#~ msgid "brilliance mid-tones"
+#~ msgstr "Brilliance mid-tones"
+
+#~ msgid "brilliance shadows"
+#~ msgstr "Brilliance shadows"
+
+#~ msgid "demosaicing method"
+#~ msgstr "Demosaicing method"
+
+#~ msgid "cast balance"
+#~ msgstr "Cast balance"
+
+#~ msgid "128 px"
+#~ msgstr "128 px"
+
+#~ msgid "averaged eigf"
+#~ msgstr "Averaged EIGF"
+
+#~ msgid "eigf"
+#~ msgstr "EIGF"
+
+#, c-format
+#~ msgid "error: can't open xmp file %s"
+#~ msgstr "Error: can't open xmp file %s"
+
+#, c-format
+#~ msgid "%d image of %d (#%d) in current collection is selected"
+#~ msgstr "%d image of %d (#%d) in current collection is selected"
+
+#, c-format
+#~ msgid "%d image of %d in current collection is selected"
+#~ msgid_plural "%d images of %d in current collection are selected"
+#~ msgstr[0] "%d image of %d in current collection is selected"
+#~ msgstr[1] "%d images of %d in current collection are selected"
+
+#~ msgid "sRGB (e.g. JPG)"
+#~ msgstr "sRGB (e.g. JPG)"
+
+#~ msgid "click later to be asked on next startup"
+#~ msgstr "Click later to be asked on next startup"
+
+#~ msgid "click later to be asked when closing darktable"
+#~ msgstr "Click later to be asked when closing Darktable"
+
+#~ msgid "click later to be asked next time when closing darktable"
+#~ msgstr "Click later to be asked next time when closing Darktable"
+
+#, c-format
+#~ msgid ""
+#~ "the database could use some maintenance\n"
+#~ "\n"
+#~ "there's <span style='italic'>%s</span> to be freed\n"
+#~ "\n"
+#~ "do you want to proceed now?\n"
+#~ "\n"
+#~ "%s\n"
+#~ "you can always change maintenance preferences in core options"
+#~ msgstr ""
+#~ "The database could use some maintenance\n"
+#~ "\n"
+#~ "There's <span style='italic'>%s</span> to be freed\n"
+#~ "\n"
+#~ "Do you want to proceed now?\n"
+#~ "\n"
+#~ "%s\n"
+#~ "You can always change maintenance preferences in core options"
+
+#~ msgid "darktable - schema maintenance"
+#~ msgstr "Darktable - schema maintenance"
+
+#~ msgid "later"
+#~ msgstr "Later"
+
+#, c-format
+#~ msgid "darktable » %s"
+#~ msgstr "Darktable » %s"
+
+#~ msgid "<h1>Sorry,</h1><p>something went wrong. Please try again.</p>"
+#~ msgstr "<h1>Sorry,</h1><p>something went wrong. Please try again.</p>"
+
+#~ msgid ""
+#~ "<h1>Thank you,</h1><p>everything should have worked, you can <b>close</b> "
+#~ "your browser now and <b>go back</b> to darktable.</p>"
+#~ msgstr ""
+#~ "<h1>Thank you,</h1><p>everything should have worked, you can <b>close</b> "
+#~ "your browser now and <b>go back</b> to Darktable.</p>"
+
+#, c-format
+#~ msgid "unsupported working profile %s has been replaced by Rec2020 RGB!\n"
+#~ msgstr "Unsupported working profile %s has been replaced by Rec2020 RGB!\n"
+
+#~ msgid "a4"
+#~ msgstr "A4"
+
+#~ msgid "a3"
+#~ msgstr "A3"
+
+#~ msgid "lighten modes"
+#~ msgstr "Lighten modes"
+
+#~ msgid "darken modes"
+#~ msgstr "Darken modes"
+
+#~ msgid "deprecated modes"
+#~ msgstr "Deprecated modes"
+
+#~ msgid "[BRUSH creation] change size"
+#~ msgstr "[BRUSH creation] change size"
+
+#~ msgid "[BRUSH creation] change hardness"
+#~ msgstr "[BRUSH creation] change hardness"
+
+#~ msgid "no image selected !"
+#~ msgstr "No image selected!"
+
+#~ msgid "direct sunlight"
+#~ msgstr "Direct sunlight"
+
+#~ msgid "cloudy"
+#~ msgstr "Cloudy"
+
+#~ msgid "shade"
+#~ msgstr "Shade"
+
+#~ msgid "incandescent"
+#~ msgstr "Incandescent"
+
+#~ msgid "incandescent warm"
+#~ msgstr "Incandescent warm"
+
+#~ msgid "tungsten"
+#~ msgstr "Tungsten"
+
+#~ msgid "fluorescent"
+#~ msgstr "Fluorescent"
+
+#~ msgid "fluorescent high"
+#~ msgstr "Fluorescent high"
+
+#~ msgid "cool white fluorescent"
+#~ msgstr "Cool white fluorescent"
+
+#~ msgid "warm white fluorescent"
+#~ msgstr "Warm white fluorescent"
+
+#~ msgid "daylight fluorescent"
+#~ msgstr "Daylight fluorescent"
+
+#~ msgid "neutral fluorescent"
+#~ msgstr "Neutral fluorescent"
+
+#~ msgid "white fluorescent"
+#~ msgstr "White fluorescent"
+
+#~ msgid "sodium-vapor fluorescent"
+#~ msgstr "Sodium-vapor fluorescent"
+
+#~ msgid "day white fluorescent"
+#~ msgstr "Day white fluorescent"
+
+#~ msgid "high temp. mercury-vapor fluorescent"
+#~ msgstr "High temp. mercury-vapor fluorescent"
+
+#~ msgid "high temp. mercury-vapor"
+#~ msgstr "High temp. mercury-vapor"
+
+#~ msgid "D55"
+#~ msgstr "D55"
+
+#~ msgid "flash"
+#~ msgstr "Flash"
+
+#~ msgid "flash (auto mode)"
+#~ msgstr "Flash (auto mode)"
+
+#~ msgid "evening sun"
+#~ msgstr "Evening sun"
+
+#~ msgid "underwater"
+#~ msgstr "Underwater"
+
+#~ msgid "spot WB"
+#~ msgstr "Spot WB"
+
+#~ msgid "manual WB"
+#~ msgstr "Manual WB"
+
+#~ msgid "camera WB"
+#~ msgstr "Camera WB"
+
+#~ msgid "auto WB"
+#~ msgstr "Auto WB"
+
+#~ msgid ""
+#~ "press Del to delete selected shortcut\n"
+#~ "double-click to add new shortcut\n"
+#~ "start typing for incremental search"
+#~ msgstr ""
+#~ "Press Del to delete selected shortcut\n"
+#~ "Double-click to add new shortcut\n"
+#~ "Start typing for incremental search"
+
+#~ msgid ""
+#~ "restore default shortcuts\n"
+#~ "  or as at startup\n"
+#~ "  or when the configuration dialog was opened\n"
+#~ msgstr ""
+#~ "Restore default shortcuts\n"
+#~ "  either as at startup\n"
+#~ "  or when the configuration dialog was opened\n"
+
+#~ msgid "AVIF (8/10/12-bit)"
+#~ msgstr "AVIF (8/10/12-bit)"
+
+#~ msgid "OpenEXR (16/32-bit float)"
+#~ msgstr "OpenEXR (16/32-bit float)"
+
+#~ msgid "32 bit"
+#~ msgstr "32 bit"
+
+#~ msgid "J2K"
+#~ msgstr "j2k"
+
+#~ msgid "embed icc profiles"
+#~ msgstr "Embed ICC profiles"
+
+#~ msgid "PFM (float)"
+#~ msgstr "PFM (float)"
+
+#~ msgid "PNG (8/16-bit)"
+#~ msgstr "PNG (8/16-bit)"
+
+#~ msgid "TIFF (8/16/32-bit)"
+#~ msgstr "TIFF (8/16/32-bit)"
+
+#~ msgid "WebP (8-bit)"
+#~ msgstr "WebP (8-bit)"
+
+#~ msgid "applies only to lossy setting"
+#~ msgstr "Applies only to lossy setting"
+
+#~ msgid "xcf"
+#~ msgstr "XCF"
+
+#~ msgid "raw CA correction supports only standard RGB Bayer filter arrays"
+#~ msgstr "Raw CA correction supports only standard RGB Bayer filter arrays"
+
+#~ msgid "bypassed while zooming in"
+#~ msgstr "Bypassed while zooming in"
+
+#~ msgid ""
+#~ "while calculating the correction parameters the internal maths failed so "
+#~ "module is bypassed.\n"
+#~ "you can get more info by running dt via the console."
+#~ msgstr ""
+#~ "While calculating the correction parameters the internal maths failed so "
+#~ "module is bypassed.\n"
+#~ "You can get more info by running Darktable via the console."
+
+#~ msgid ""
+#~ "internals maths found too few data points so restricted the order of the "
+#~ "fit to linear.\n"
+#~ "you might view bad correction results."
+#~ msgstr ""
+#~ "Internals maths found too few data points so restricted the order of the "
+#~ "fit to linear.\n"
+#~ "You might view bad correction results."
+
+#~ msgid ""
+#~ "to calculate good parameters for raw CA correction we want full sensor "
+#~ "data or at least a sensible part of that.\n"
+#~ "the image shown in darkroom would look vastly different from developed "
+#~ "files so effect is bypassed now."
+#~ msgstr ""
+#~ "To calculate good parameters for raw CA correction we want full sensor "
+#~ "data or at least a sensible part of that.\n"
+#~ "The image shown in Darkroom would look vastly different from developed "
+#~ "files so effect is bypassed now."
+
+#~ msgid "affect color, brightness and contrast"
+#~ msgstr "Affect color, brightness and contrast"
+
+#~ msgctxt "accel"
+#~ msgid "acquire"
+#~ msgstr "Acquire"
+
+#~ msgctxt "accel"
+#~ msgid "apply"
+#~ msgstr "Apply"
+
+#~ msgid "number of clusters to find in image"
+#~ msgstr "Number of clusters to find in image"
+
+#~ msgid "acquire"
+#~ msgstr "Acquire"
+
+#~ msgid "analyze this image"
+#~ msgstr "Analyze this image"
+
+#~ msgid "apply previously analyzed image look to this image"
+#~ msgstr "Apply previously analyzed image look to this image"
+
+#~ msgid "red black white"
+#~ msgstr "Red black white"
+
+#~ msgid "black white and skin tones"
+#~ msgstr "Black white and skin tones"
+
+#~ msgid "black & white film"
+#~ msgstr "Black & white film"
+
+#~ msgid "commit"
+#~ msgstr "Commit"
+
+#~ msgid "commit changes"
+#~ msgstr "Commit changes"
+
+#~ msgid "add local contrast"
+#~ msgstr "Add local contrast"
+
+#~ msgid "fast sharpness"
+#~ msgstr "Fast sharpness"
+
+#~ msgid "fast local contrast"
+#~ msgstr "Fast local contrast"
+
+#~ msgid "[dual demosaic] can't allocate internal buffers"
+#~ msgstr "[dual demosaic] can't allocate internal buffers"
+
+#~ msgctxt "equalizer"
+#~ msgid "sharpen"
+#~ msgstr "Sharpen"
+
+#~ msgid "null"
+#~ msgstr "Null"
+
+#~ msgid "denoise (strong)"
+#~ msgstr "Denoise (strong)"
+
+#~ msgid "autodetect"
+#~ msgstr "Autodetect"
+
+#~ msgid ""
+#~ "click and drag to add point\n"
+#~ "scroll to change size - shift+scroll to change strength - ctrl+scroll to "
+#~ "change direction"
+#~ msgstr ""
+#~ "Click and drag to add point\n"
+#~ "Scroll to change size - shift+scroll to change strength - ctrl+scroll to "
+#~ "change direction"
+
+#~ msgid ""
+#~ "click to add line\n"
+#~ "scroll to change size - shift+scroll to change strength - ctrl+scroll to "
+#~ "change direction"
+#~ msgstr ""
+#~ "Click to add line\n"
+#~ "Scroll to change size - shift+scroll to change strength - ctrl+scroll to "
+#~ "change direction"
+
+#~ msgid ""
+#~ "click to add curve\n"
+#~ "scroll to change size - shift+scroll to change strength - ctrl+scroll to "
+#~ "change direction"
+#~ msgstr ""
+#~ "Click to add curve\n"
+#~ "Scroll to change size - shift+scroll to change strength - ctrl+scroll to "
+#~ "change direction"
+
+#~ msgid ""
+#~ "ctrl+click: add node - right click: remove path\n"
+#~ "ctrl+alt+click: toggle line/curve"
+#~ msgstr ""
+#~ "Ctrl+click: add node - right click: remove path\n"
+#~ "Ctrl+alt+click: toggle line/curve"
+
+#~ msgid "drag to adjust warp radius"
+#~ msgstr "Drag to adjust warp radius"
+
+#~ msgid "drag to adjust hardness (center)"
+#~ msgstr "Drag to adjust hardness (center)"
+
+#~ msgid "drag to adjust hardness (feather)"
+#~ msgstr "Drag to adjust hardness (feather)"
+
+#~ msgid ""
+#~ "drag to adjust warp strength\n"
+#~ "ctrl+click: linear, grow, and shrink"
+#~ msgstr ""
+#~ "Drag to adjust warp strength\n"
+#~ "Ctrl+click: linear, grow, and shrink"
+
+#~ msgid "[lmmse_demosaic] too small area"
+#~ msgstr "[lmmse_demosaic] too small area"
+
+#~ msgid "crop from top"
+#~ msgstr "Crop from top"
+
+#~ msgid "crop from bottom"
+#~ msgstr "Crop from bottom"
+
+#~ msgid "[rcd_demosaic] too small area"
+#~ msgstr "[rcd_demosaic] too small area"
+
+#~ msgid "compress shadows/highlights (eigf): strong"
+#~ msgstr "Compress shadows/highlights (eigf): strong"
+
+#~ msgid "compress shadows/highlights (eigf): medium"
+#~ msgstr "Compress shadows/highlights (eigf): medium"
+
+#~ msgid "compress shadows/highlights (eigf): soft"
+#~ msgstr "Compress shadows/highlights (eigf): soft"
+
+#, no-c-format
+#~ msgid "preview is only possible for zoom lower than 200%%"
+#~ msgstr "Preview is only possible for zoom lower than 200%%"
+
+#~ msgid "actual selection"
+#~ msgstr "Actual selection"
+
+#~ msgid "grouping filter"
+#~ msgstr "Grouping filter"
+
+#~ msgid "history filter"
+#~ msgstr "History filter"
+
+#~ msgid "local_copy filter"
+#~ msgstr "Local_copy filter"
+
+#~ msgid "module order filter"
+#~ msgstr "Module order filter"
+
+#~ msgid ""
+#~ "drag to change black point,\n"
+#~ "doubleclick resets\n"
+#~ "ctrl+scroll to change display height"
+#~ msgstr ""
+#~ "Drag to change black point,\n"
+#~ "Doubleclick resets\n"
+#~ "Ctrl+scroll to change display height"
+
+#~ msgid ""
+#~ "drag to change exposure,\n"
+#~ "doubleclick resets\n"
+#~ "ctrl+scroll to change display height"
+#~ msgstr ""
+#~ "Drag to change exposure,\n"
+#~ "Doubleclick resets\n"
+#~ "Ctrl+scroll to change display height"
+
+#~ msgid "set mode to waveform"
+#~ msgstr "Set mode to waveform"
+
+#~ msgid "set mode to rgb parade"
+#~ msgstr "Set mode to rgb parade"
+
+#~ msgid "set mode to vectorscope"
+#~ msgstr "Set mode to vectorscope"
+
+#~ msgid "set mode to histogram"
+#~ msgstr "Set mode to histogram"
+
+#~ msgid "click to hide red channel"
+#~ msgstr "Click to hide red channel"
+
+#~ msgid "click to show red channel"
+#~ msgstr "Click to show red channel"
+
+#~ msgid "click to hide green channel"
+#~ msgstr "Click to hide green channel"
+
+#~ msgid "click to show green channel"
+#~ msgstr "Click to show green channel"
+
+#~ msgid "click to hide blue channel"
+#~ msgstr "Click to hide blue channel"
+
+#~ msgid "click to show blue channel"
+#~ msgstr "Click to show blue channel"
+
+#~ msgid "switch histogram type"
+#~ msgstr "Switch histogram type"
+
+#~ msgid "v3.0"
+#~ msgstr "V3.0"
+
+#~ msgid "ldr"
+#~ msgstr "LDR"
+
+#~ msgid "hdr"
+#~ msgstr "HDR"
+
+#~ msgid "modules: default"
+#~ msgstr "Modules: default"
+
+#~ msgid ""
+#~ "this quick access widget is disabled as it's hidden in the actual module "
+#~ "configuration. Please use the full module to access this widget..."
+#~ msgstr ""
+#~ "This quick access widget is disabled as it's hidden in the actual module "
+#~ "configuration. Please use the full module to access this widget..."
+
+#~ msgctxt "modulegroup"
+#~ msgid "technical"
+#~ msgstr "Technical"
+
+#~ msgid ""
+#~ "the following modules are deprecated because they have internal design "
+#~ "mistakes which can't be solved and alternative modules which solve them.\n"
+#~ " they will be removed for new edits in the next release."
+#~ msgstr ""
+#~ "The following modules are deprecated because they have internal design "
+#~ "mistakes which can't be solved and alternative modules which solve them.\n"
+#~ "They will be removed for new edits in the next release."
+
+#~ msgid "fit to screen"
+#~ msgstr "Fit to screen"
+
+#, c-format
+#~ msgid "at least one new tagname (%s) already exists, aborting."
+#~ msgstr "At least one new tagname (%s) already exists, aborting."
+
+#~ msgid "toggle sticky preview mode"
+#~ msgstr "Toggle sticky preview mode"
+
+#~ msgid "toggle sticky preview mode with focus detection"
+#~ msgstr "Toggle sticky preview mode with focus detection"
+
+#, c-format
+#~ msgid "double click to reset to `%f'"
+#~ msgstr "Double click to reset to `%f'"
+
+#~ msgid "allow to pan & zoom while editing masks"
+#~ msgstr "Allow to pan & zoom while editing masks"
+
+#~ msgid "zoom fill"
+#~ msgstr "Zoom fill"
+
+#~ msgid "zoom fit"
+#~ msgstr "Zoom fit"
+
+#~ msgid "lmmse refine"
+#~ msgstr "LMMSE refine"
+
+#~ msgid "lut 3D"
+#~ msgstr "LUT 3D"
+
+#~ msgid "select lut file"
+#~ msgstr "Select LUT file"
+
+#~ msgid "gpx file"
+#~ msgstr "GPX file"


### PR DESCRIPTION
For many years there has been a request to get rid of the exotic "no-caps" darktable style, in which everything possible was converted into lower case.

There were those who, over the long history of darktable existence, got used to this style and even consider it more pleasant.

But just as many, if not more, people find this style very annoying.

What can be done in this situation? The right solution must meet the following requirements:
- Users should be able to choose the style of the interface (old "no-caps" or normal casing, as in other programs). That is, it should not be an irreversible change of style.
- If possible, it should be done with minimal effort.
- This decision should not impose extra work on translators.

The only solution that meets these requirements is to add a pseudo-translation, which will be in the same original language, but with the corrected case of the words.

This "translation" was created and completely reviewed and corrected manually. I can say with a large degree of confidence that it is 100% (ok, 99.9% due to human factor) free of errors related to the shortcomings of automatic case conversion.

I expect everything regarding the fate of this PR from being included in 4.0.1 to being frozen forever due to fruitless discussions, but I hope that it will not be rejected. :)

So I'm keeping my fingers crossed and hit the "Create pull request" button.
