### PR TITLE
thumbtable: Avoid a signed integer overflow when no thumb are present.

### DIFF
--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2019-2021 darktable developers.
+    Copyright (C) 2019-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -244,22 +244,33 @@ static int _thumb_get_rowid(int imgid)
 // get the coordinate of the rectangular area used by all the loaded thumbs
 static void _pos_compute_area(dt_thumbtable_t *table)
 {
-  int x1 = INT_MAX;
-  int y1 = INT_MAX;
-  int x2 = INT_MIN;
-  int y2 = INT_MIN;
-  for(const GList *l = table->list; l; l = g_list_next(l))
+  if(table->list)
   {
-    const dt_thumbnail_t *th = (const dt_thumbnail_t *)l->data;
-    x1 = MIN(x1, th->x);
-    y1 = MIN(y1, th->y);
-    x2 = MAX(x2, th->x);
-    y2 = MAX(y2, th->y);
+    int x1 = INT_MAX;
+    int y1 = INT_MAX;
+    int x2 = INT_MIN;
+    int y2 = INT_MIN;
+    for(const GList *l = table->list; l; l = g_list_next(l))
+    {
+      const dt_thumbnail_t *th = (const dt_thumbnail_t *)l->data;
+      x1 = MIN(x1, th->x);
+      y1 = MIN(y1, th->y);
+      x2 = MAX(x2, th->x);
+      y2 = MAX(y2, th->y);
+    }
+
+    table->thumbs_area.x = x1;
+    table->thumbs_area.y = y1;
+    table->thumbs_area.width = x2 + table->thumb_size - x1;
+    table->thumbs_area.height = y2 + table->thumb_size - y1;
   }
-  table->thumbs_area.x = x1;
-  table->thumbs_area.y = y1;
-  table->thumbs_area.width = x2 + table->thumb_size - x1;
-  table->thumbs_area.height = y2 + table->thumb_size - y1;
+  else
+  {
+    table->thumbs_area.x = 0;
+    table->thumbs_area.y = 0;
+    table->thumbs_area.width = 0;
+    table->thumbs_area.height = 0;
+  }
 }
 
 // get the position of the next image after the one at (x,y)
@@ -2693,4 +2704,3 @@ gboolean dt_thumbtable_reset_first_offset(dt_thumbtable_t *table)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-


### PR DESCRIPTION
Fixes #12196.