### PR TITLE
remove unused macros

### DIFF
--- a/src/common/bspline.h
+++ b/src/common/bspline.h
@@ -21,7 +21,6 @@ static inline float normalize_laplacian(const float sigma)
 // Normalization scaling of the wavelet to approximate a laplacian
 // from the function above for sigma = B_SPLINE_SIGMA as a constant
 #define B_SPLINE_TO_LAPLACIAN 3.182727439285017f
-#define B_SPLINE_TO_LAPLACIAN_2 10.129753952777762f // square
 
 static inline float equivalent_sigma_at_step(const float sigma, const unsigned int s)
 {

--- a/src/common/curve_tools.c
+++ b/src/common/curve_tools.c
@@ -27,7 +27,6 @@
 #include <stdlib.h>
 
 #define EPSILON 2 * FLT_MIN
-#define MAX_ITER 10
 
 static const int curvedata_anchors_max = 20;
 

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -30,8 +30,6 @@
 #include <strings.h>
 #include <unistd.h>
 
-#define CLAMPI(a, mn, mx) ((a) < (mn) ? (mn) : ((a) > (mx) ? (mx) : (a)))
-
 
 /* this defines an additional alignment requirement for opencl image width.
    It can have strong effects on processing speed. Reasonable values are a
@@ -186,7 +184,6 @@ static double _nm_fitness(double x[], void *rest[])
  *
  */
 
-#define MAX_IT 1000 /* maximum number of iterations */
 #define ALPHA 1.0   /* reflection coefficient */
 #define BETA 0.5    /* contraction coefficient */
 #define GAMMA 2.0   /* expansion coefficient */

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -876,7 +876,6 @@ const gchar *category_label[NUM_CATEGORIES]
       N_("other views"),
       N_("fallbacks"),
       N_("speed") };
-#define CATEGORY_FALLBACKS 2
 
 static void _shortcuts_store_category(GtkTreeIter *category, dt_shortcut_t *s, dt_view_type_flags_t view)
 {

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -44,8 +44,6 @@
 //#define USE_NEW_CL  //uncomment to use the new, more memory-efficient OpenCL code (not yet finished)
 
 #define INSET DT_PIXEL_APPLY_DPI(5)
-#define INFL .3f
-
 
 DT_MODULE_INTROSPECTION(2, dt_iop_atrous_params_t)
 

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -44,7 +44,6 @@
 #include <string.h>
 
 #define DT_GUI_CURVE_EDITOR_INSET DT_PIXEL_APPLY_DPI(5)
-#define DT_GUI_CURVE_INFL .3f
 #define DT_IOP_TONECURVE_RES 256
 #define MAXNODES 20
 

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -42,7 +42,6 @@
 #include "libs/colorpicker.h"
 
 #define DT_GUI_CURVE_EDITOR_INSET DT_PIXEL_APPLY_DPI(5)
-#define DT_GUI_CURVE_INFL .3f
 
 DT_MODULE_INTROSPECTION(2, dt_iop_levels_params_t)
 

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -44,7 +44,6 @@
 #include "libs/colorpicker.h"
 
 #define DT_GUI_CURVE_EDITOR_INSET DT_PIXEL_APPLY_DPI(1)
-#define DT_GUI_CURVE_INFL .3f
 
 #define DT_IOP_TONECURVE_RES 256
 #define DT_IOP_TONECURVE_MAXNODES 20

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -51,8 +51,6 @@
 #include <string.h>
 #include <strings.h>
 
-#define DECORATION_SIZE_LIMIT 40
-
 static void dt_view_manager_load_modules(dt_view_manager_t *vm);
 static int dt_view_load_module(void *v, const char *libname, const char *module_name);
 static void dt_view_unload_module(dt_view_t *view);


### PR DESCRIPTION
The static analyzer of my IDE complains about unused macros. Let's get rid of some of them.