### PR TITLE
sharpen: fix memory overrun

### DIFF
--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -337,7 +337,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     const size_t start_row = j-rad;
     const size_t end_row = j+rad;
     // do the bulk of the row four at a time
-    for(int i = 0; i < width; i += 4)
+    for(int i = 0; i < (width & ~3); i += 4)
     {
       dt_aligned_pixel_t sum = { 0.0f };
       for(int k = start_row; k <= end_row; k++)

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -336,13 +336,14 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     // vertically blur the pixels of the current row into the temp buffer
     const size_t start_row = j-rad;
     const size_t end_row = j+rad;
+    const size_t end_bulk = width & ~(size_t)3;
     // do the bulk of the row four at a time
-    for(int i = 0; i < (width & ~3); i += 4)
+    for(size_t i = 0; i < end_bulk; i += 4)
     {
       dt_aligned_pixel_t sum = { 0.0f };
-      for(int k = start_row; k <= end_row; k++)
+      for(size_t k = start_row; k <= end_row; k++)
       {
-        const int k_adj = k - (j-rad);
+        const size_t k_adj = k - start_row;
         for_four_channels(c,aligned(in))
           sum[c] += mat[k_adj] * in[4*(k*width+i+c)];
       }
@@ -351,12 +352,12 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         vblurred[c] = sum[c];
     }
     // do the leftover 0-3 pixels of the row
-    for(int i = width & ~3; i < width; i++)
+    for(size_t i = end_bulk; i < width; i++)
     {
       float sum = 0.0f;
-      for(int k = start_row; k <= end_row; k++)
+      for(size_t k = start_row; k <= end_row; k++)
       {
-        const int k_adj = k - (j-rad);
+        const size_t k_adj = k - start_row;
         sum += mat[k_adj] * in[4*(k*width+i)];
       }
       temp_buf[i] = sum;


### PR DESCRIPTION
Fix #12198 by eliminating the "use after poison".

Running all four integration tests involving the sharpen module gives same results (0035 fails, but so does master, with the same dE).
