### PR TITLE
closedir when we have to exit scandir due to a memory allocation error

### DIFF
--- a/src/win/scandir.c
+++ b/src/win/scandir.c
@@ -57,7 +57,11 @@ int scandir(const char *directory_name,
   if(directory == NULL) return -1;
 
   array = (struct dirent **) malloc(allocated * sizeof(struct dirent *));
-  if(array == NULL) return -1;
+  if(array == NULL)
+  {
+    closedir(directory);
+    return -1;
+  }
 
   /* Read entries in the directory.  */
 


### PR DESCRIPTION
This is a rather minor bug, because if we can't allocate even a very small amount of memory for reading the directory, then we are already in big trouble and darktable will most likely not be able to continue working. But it would still be correct to close the directory before exiting.