### PR TITLE
colorspaces: add ACES2065-1 and ACEScg profiles

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -119,6 +119,8 @@ static void icc_types()
   fprintf(stderr, " HLG_REC2020\n");
   fprintf(stderr, " PQ_P3\n");
   fprintf(stderr, " HLG_P3\n");
+  fprintf(stderr, " ACES\n");
+  fprintf(stderr, " ACESCG\n");
 }
 
 #define ICC_FROM_STR(name) if(!strcmp(option, #name)) return DT_COLORSPACE_ ## name;
@@ -151,6 +153,8 @@ static dt_colorspaces_color_profile_type_t get_icc_type(const char* option)
   ICC_FROM_STR(HLG_REC2020);
   ICC_FROM_STR(PQ_P3);
   ICC_FROM_STR(HLG_P3);
+  ICC_FROM_STR(ACES);
+  ICC_FROM_STR(ACESCG);
   return DT_COLORSPACE_LAST;
 }
 #undef ICC_FROM_STR
@@ -775,4 +779,3 @@ int main(int argc, char *arg[])
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -80,7 +80,9 @@ typedef enum dt_colorspaces_color_profile_type_t
   DT_COLORSPACE_HLG_REC2020 = 23,
   DT_COLORSPACE_PQ_P3 = 24,
   DT_COLORSPACE_HLG_P3 = 25,
-  DT_COLORSPACE_LAST = 26
+  DT_COLORSPACE_ACES = 26,
+  DT_COLORSPACE_ACESCG = 27,
+  DT_COLORSPACE_LAST
 } dt_colorspaces_color_profile_type_t;
 
 typedef enum dt_colorspaces_color_mode_t
@@ -298,4 +300,3 @@ void dt_colorspaces_rgb_to_cygm(float *out, int num, double RGB_to_CAM[4][3]);
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -59,6 +59,7 @@ typedef enum dt_iop_lut3d_colorspace_t
   DT_IOP_REC709,      // $DESCRIPTION: "gamma Rec709 RGB"
   DT_IOP_LIN_REC709,  // $DESCRIPTION: "linear Rec709 RGB"
   DT_IOP_LIN_REC2020, // $DESCRIPTION: "linear Rec2020 RGB"
+  DT_IOP_ACESCG,      // $DESCRIPTION: "ACEScg RGB"
 } dt_iop_lut3d_colorspace_t;
 
 typedef enum dt_iop_lut3d_interpolation_t
@@ -984,6 +985,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     : (d->params.colorspace == DT_IOP_REC709) ? DT_COLORSPACE_REC709
     : (d->params.colorspace == DT_IOP_ARGB) ? DT_COLORSPACE_ADOBERGB
     : (d->params.colorspace == DT_IOP_LIN_REC709) ? DT_COLORSPACE_LIN_REC709
+    : (d->params.colorspace == DT_IOP_ACESCG) ? DT_COLORSPACE_ACESCG
     : DT_COLORSPACE_LIN_REC2020;
   const dt_iop_order_iccprofile_info_t *const lut_profile
     = dt_ioppr_add_profile_info_to_list(self->dev, colorspace, "", INTENT_PERCEPTUAL);
@@ -1063,6 +1065,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     : (d->params.colorspace == DT_IOP_REC709) ? DT_COLORSPACE_REC709
     : (d->params.colorspace == DT_IOP_ARGB) ? DT_COLORSPACE_ADOBERGB
     : (d->params.colorspace == DT_IOP_LIN_REC709) ? DT_COLORSPACE_LIN_REC709
+    : (d->params.colorspace == DT_IOP_ACESCG) ? DT_COLORSPACE_ACESCG
     : DT_COLORSPACE_LIN_REC2020;
   const dt_iop_order_iccprofile_info_t *const lut_profile
     = dt_ioppr_add_profile_info_to_list(self->dev, colorspace, "", INTENT_PERCEPTUAL);
@@ -1746,4 +1749,3 @@ void gui_cleanup(dt_iop_module_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-


### PR DESCRIPTION
Addresses part of https://github.com/darktable-org/darktable/issues/10709

This is a pre-requisite before adding a lut3d "application" profile (I'm thinking ACEScg only?)... Although still not clear if perhaps ACEScc/ACEScct are actually needed there as well (or instead?) in which case it's better to work on implementing the "file" profile type support in the lut3d module anyway...

@UsernameDaniel @maximoremedios @crepererum @Tylius Please keep clarifying the specification

@parafin @jenshannoschwalm @MStraeten Please provide feedback on the wip