### PR TITLE
Fix crash in LaTeX export

### DIFF
--- a/src/imageio/storage/latex.c
+++ b/src/imageio/storage/latex.c
@@ -343,7 +343,6 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
     // g_list_free_full(res_subj, &g_free);
     // g_free(tags);
     d->l = g_list_insert_sorted(d->l, pair, (GCompareFunc)sort_pos);
-    free(pair);
   } // end of critical block
   dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
 


### PR DESCRIPTION
The second reincarnation of the bug fixed in #12279, this time in export to LaTeX: an unnecessary free() call, which at the end leads to a double free and crash.
