### PR TITLE
colorspace regression fix

### DIFF
--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -221,6 +221,7 @@ static inline void dt_XYZ_to_Lab(const dt_aligned_pixel_t XYZ, dt_aligned_pixel_
   Lab[0] = 116.0f * f[1] - 16.0f;
   Lab[1] = 500.0f * (f[0] - f[1]);
   Lab[2] = 200.0f * (f[1] - f[2]);
+  Lab[3] = 0.0f;
 }
 
 #ifdef _OPENMP
@@ -823,6 +824,7 @@ static inline void dt_Lab_2_LCH(const dt_aligned_pixel_t Lab, dt_aligned_pixel_t
   LCH[0] = Lab[0];
   LCH[1] = hypotf(Lab[1], Lab[2]);
   LCH[2] = var_H;
+  LCH[3] = Lab[3];
 }
 
 
@@ -834,6 +836,7 @@ static inline void dt_LCH_2_Lab(const dt_aligned_pixel_t LCH, dt_aligned_pixel_t
   Lab[0] = LCH[0];
   Lab[1] = cosf(2.0f * DT_M_PI_F * LCH[2]) * LCH[1];
   Lab[2] = sinf(2.0f * DT_M_PI_F * LCH[2]) * LCH[1];
+  Lab[3] = LCH[3];
 }
 
 static inline float dt_camera_rgb_luminance(const dt_aligned_pixel_t rgb)

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -1468,7 +1468,7 @@ static gboolean _bottom_area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_i
     const float ii = _mouse_to_curve(((float)i + .5f) / (float)(cellsi - 1), c->zoom_factor, c->offset_x);
     const float iih = _mouse_to_curve((float)i / (float)(cellsi - 1), c->zoom_factor, c->offset_x);
 
-    dt_aligned_pixel_t LCh;
+    dt_aligned_pixel_t LCh = { 50.0f };
 
     switch(p.channel)
     {


### PR DESCRIPTION
Working to fix #12304 

Should fix gcc7 regression mentioned in https://github.com/darktable-org/darktable/pull/12210?notification_referrer_id=NT_kwDOAE5ZCrI0MDMxMTk1NDAwOjUxMzQ2MDI#issuecomment-1212468148
