### PR TITLE
preset and style shortcut fixes

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -941,8 +941,8 @@ void dt_bauhaus_widget_set_label(GtkWidget *widget, const char *section, const c
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   memset(w->label, 0, sizeof(w->label)); // keep valgrind happy
-  if(label) g_strlcpy(w->label, _(label), sizeof(w->label));
-  if(section) w->section = g_strdup(_(section));
+  if(label) g_strlcpy(w->label, Q_(label), sizeof(w->label));
+  if(section) w->section = g_strdup(Q_(section));
 
   if(w->module)
   {
@@ -1275,7 +1275,7 @@ void dt_bauhaus_combobox_add_list(GtkWidget *widget, dt_action_t *action, const 
     g_hash_table_insert(darktable.control->combo_list, action, texts);
 
   while(texts && *texts)
-    dt_bauhaus_combobox_add_full(widget, _(*(texts++)), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, NULL, NULL, TRUE);
+    dt_bauhaus_combobox_add_full(widget, Q_(*(texts++)), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, NULL, NULL, TRUE);
 }
 
 void dt_bauhaus_combobox_add(GtkWidget *widget, const char *text)

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -335,10 +335,11 @@ GtkWidget *dt_bauhaus_combobox_new(dt_iop_module_t *self);
 GtkWidget *dt_bauhaus_combobox_new_action(dt_action_t *self);
 GtkWidget *dt_bauhaus_combobox_new_full(dt_action_t *action, const char *section, const char *label, const char *tip,
                                         int pos, GtkCallback callback, gpointer data, const char **texts);
-#define DT_BAUHAUS_COMBOBOX_NEW_FULL(widget, action, section, label, tip, pos, callback, data, ...)          \
-{                                                                                                            \
-  static const gchar *texts[] = { __VA_ARGS__, NULL };                                                       \
-  widget = dt_bauhaus_combobox_new_full(DT_ACTION(action), section, label, tip, pos, callback, data, texts); \
+#define DT_BAUHAUS_COMBOBOX_NEW_FULL(widget, action, section, label, tip, pos, callback, data, ...) \
+{                                                                                                   \
+  static const gchar *texts[] = { __VA_ARGS__, NULL };                                              \
+  widget = dt_bauhaus_combobox_new_full(DT_ACTION(action), section, label, tip, pos,                \
+                                        (GtkCallback)callback, data, texts);                        \
 }
 
 void dt_bauhaus_combobox_add(GtkWidget *widget, const char *text);

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -664,6 +664,34 @@ static inline void dt_unreachable_codepath_with_caller(const char *description, 
  */
 #define DT_MAX_PATH_FOR_PARAMS 4096
 
+/*
+ * Helper functions for transition to gnome style xgettext translation context marking
+ *
+ * Many calls expect untranslated strings because they need to store them as ids in a language independent way.
+ * They then internally before displaying call Q_ to translate, which allows an embedded translation context to be specified.
+ * The qnome format "context|string" is used.
+ * Intltool does not support this format when it scans N_, so NC_("context","string") has to be used.
+ * But the standard NC_ does not propagate the context with the string. So here it is overridden to combine both parts.
+ *
+ * A better solution would be to switch to a modern xgettext https://wiki.gnome.org/MigratingFromIntltoolToGettext
+ *
+ *    xgettext --keyword=Q_:1g --keyword=N_:1g would allow using standard N_("context|string") to mark and pass on unchanged.
+ *
+ * This would also enable contextualised strings in introspection markups, like
+ *
+ *    DT_INTENT_SATURATION = INTENT_SATURATION, // $DESCRIPTION: "rendering intent|saturation"
+ *
+ * Before storing in a language-indpendent format, like shortcutsrc, NQ_ should be used to strip any context from the string.
+ */
+#undef NC_
+#define NC_(Context, String) (Context "|" String)
+
+static inline const gchar *NQ_(const gchar *String)
+{
+  const gchar *context_end = strchr(String, '|');
+  return context_end ? context_end + 1 : String;
+}
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -272,7 +272,7 @@ typedef struct dt_iop_gui_blendif_filter_t
 
 typedef struct dt_iop_blend_name_value_t
 {
-  char name[32];
+  char name[40];
   int value;
 } dt_develop_name_value_t;
 

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2545,7 +2545,7 @@ static gboolean _add_blendmode_combo(GtkWidget *combobox, dt_develop_blend_mode_
   {
     if(bm->value == mode)
     {
-      dt_bauhaus_combobox_add_full(combobox, g_dpgettext2(NULL, "blendmode", bm->name), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, GUINT_TO_POINTER(bm->value), NULL, TRUE);
+      dt_bauhaus_combobox_add_full(combobox, Q_(bm->name), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, GUINT_TO_POINTER(bm->value), NULL, TRUE);
 
       return TRUE;
     }

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -300,11 +300,11 @@ GtkWidget *dt_iop_button_new(dt_iop_module_t *self, const gchar *label,
   if(paint)
   {
     button = dtgtk_button_new(paint, paintflags, NULL);
-    gtk_widget_set_tooltip_text(button, _(label));
+    gtk_widget_set_tooltip_text(button, Q_(label));
   }
   else
   {
-    button = gtk_button_new_with_label(_(label));
+    button = gtk_button_new_with_label(Q_(label));
     gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button))), PANGO_ELLIPSIZE_END);
   }
 

--- a/src/gui/guides.c
+++ b/src/gui/guides.c
@@ -708,7 +708,7 @@ GtkWidget *dt_guides_popover(dt_view_t *self, GtkWidget *button)
   gtk_widget_set_no_show_all(gw->g_widgets, TRUE);
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL(gw->g_flip, self, N_("guide lines"), N_("flip"), _("flip guides"),
-                               0, (GtkCallback)_settings_flip_changed, gw,
+                               0, _settings_flip_changed, gw,
                                N_("none"),
                                N_("horizontally"),
                                N_("vertically"),
@@ -725,7 +725,7 @@ GtkWidget *dt_guides_popover(dt_view_t *self, GtkWidget *button)
   gtk_box_pack_start(GTK_BOX(vbox), gtk_separator_new(GTK_ORIENTATION_HORIZONTAL), TRUE, TRUE, 0);
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL(darktable.view_manager->guides_colors, self, N_("guide lines"), N_("overlay color"), _("set overlay color"),
-                               dt_conf_get_int("darkroom/ui/overlay_color"), (GtkCallback)_settings_colors_changed, gw,
+                               dt_conf_get_int("darkroom/ui/overlay_color"), _settings_colors_changed, gw,
                                N_("gray"),
                                N_("red"),
                                N_("green"),

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -860,14 +860,14 @@ void gui_init(struct dt_iop_module_t *self)
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
-  // TODO:
-  g->output_intent = dt_bauhaus_combobox_new(self);
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(g->output_intent, self, NULL, N_("output intent"),
+                               _("rendering intent"),
+                               0, intent_changed, self,
+                               N_("perceptual"),
+                               N_("relative colorimetric"),
+                               NC_("rendering intent", "saturation"),
+                               N_("absolute colorimetric"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->output_intent, TRUE, TRUE, 0);
-  dt_bauhaus_widget_set_label(g->output_intent, NULL, N_("output intent"));
-  dt_bauhaus_combobox_add(g->output_intent, _("perceptual"));
-  dt_bauhaus_combobox_add(g->output_intent, _("relative colorimetric"));
-  dt_bauhaus_combobox_add(g->output_intent, C_("rendering intent", "saturation"));
-  dt_bauhaus_combobox_add(g->output_intent, _("absolute colorimetric"));
 
   if(!force_lcms2)
   {
@@ -884,7 +884,6 @@ void gui_init(struct dt_iop_module_t *self)
     if(prof->out_pos > -1) dt_bauhaus_combobox_add(g->output_profile, prof->name);
   }
 
-  gtk_widget_set_tooltip_text(g->output_intent, _("rendering intent"));
   char *system_profile_dir = g_build_filename(datadir, "color", "out", NULL);
   char *user_profile_dir = g_build_filename(confdir, "color", "out", NULL);
   char *tooltip = g_strdup_printf(_("ICC profiles in %s or %s"), user_profile_dir, system_profile_dir);
@@ -893,7 +892,6 @@ void gui_init(struct dt_iop_module_t *self)
   g_free(user_profile_dir);
   g_free(tooltip);
 
-  g_signal_connect(G_OBJECT(g->output_intent), "value-changed", G_CALLBACK(intent_changed), (gpointer)self);
   g_signal_connect(G_OBJECT(g->output_profile), "value-changed", G_CALLBACK(output_profile_changed), (gpointer)self);
 
   // reload the profiles when the display or softproof profile changed!

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -1121,7 +1121,7 @@ void gui_init(dt_lib_module_t *self)
   DT_BAUHAUS_COMBOBOX_NEW_FULL(d->dimensions_type, self, NULL, N_("set size"),
                                _("choose a method for setting the output size"),
                                dt_conf_get_int(CONFIG_PREFIX "dimensions_type"),
-                               (GtkCallback)_dimensions_type_changed, d,
+                               _dimensions_type_changed, d,
                                N_("in pixels (for file)"),
                                N_("in cm (for print)"),
                                N_("in inch (for print)"),

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -590,7 +590,7 @@ void gui_reset(dt_lib_module_t *self)
   // style mode to overwrite as it was the initial behavior
   dt_bauhaus_combobox_set(d->style_mode, dt_confgen_get_bool(CONFIG_PREFIX "style_append", DT_DEFAULT));
 
-  gtk_widget_set_sensitive(GTK_WIDGET(d->style_mode), dt_bauhaus_combobox_get(d->style)==0?FALSE:TRUE);
+  gtk_widget_set_visible(GTK_WIDGET(d->style_mode), dt_bauhaus_combobox_get(d->style)==0?FALSE:TRUE);
 
   // export metadata presets
   g_free(d->metadata_export);
@@ -968,13 +968,13 @@ static void _style_changed(GtkWidget *widget, dt_lib_export_t *d)
   if(dt_bauhaus_combobox_get(d->style) == 0)
   {
     dt_conf_set_string(CONFIG_PREFIX "style", "");
-    gtk_widget_set_sensitive(GTK_WIDGET(d->style_mode), FALSE);
+    gtk_widget_set_visible(GTK_WIDGET(d->style_mode), FALSE);
   }
   else
   {
     const gchar *style = dt_bauhaus_combobox_get_text(d->style);
     dt_conf_set_string(CONFIG_PREFIX "style", style);
-    gtk_widget_set_sensitive(GTK_WIDGET(d->style_mode), TRUE);
+    gtk_widget_set_visible(GTK_WIDGET(d->style_mode), TRUE);
   }
 }
 
@@ -1203,24 +1203,24 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->scale), FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->size_in_px), FALSE, FALSE, 0);
 
-  d->upscale = dt_bauhaus_combobox_new_action(DT_ACTION(self));
-  dt_bauhaus_widget_set_label(d->upscale, NULL, N_("allow upscaling"));
-  dt_bauhaus_combobox_add(d->upscale, _("no"));
-  dt_bauhaus_combobox_add(d->upscale, _("yes"));
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(d->upscale, self, NULL, N_("allow upscaling"), NULL,
+                               dt_conf_get_bool(CONFIG_PREFIX "upscale") ? 1 : 0, _callback_bool,
+                               (gpointer)CONFIG_PREFIX "upscale",
+                               N_("no"), N_("yes"));
   gtk_box_pack_start(GTK_BOX(self->widget), d->upscale, FALSE, TRUE, 0);
 
-  d->high_quality = dt_bauhaus_combobox_new_action(DT_ACTION(self));
-  dt_bauhaus_widget_set_label(d->high_quality, NULL, N_("high quality resampling"));
-  dt_bauhaus_combobox_add(d->high_quality, _("no"));
-  dt_bauhaus_combobox_add(d->high_quality, _("yes"));
-  gtk_widget_set_tooltip_text(d->high_quality, _("do high quality resampling during export"));
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(d->high_quality, self, NULL, N_("high quality resampling"),
+                               _("do high quality resampling during export"),
+                               dt_conf_get_bool(CONFIG_PREFIX "high_quality_processing") ? 1 : 0, _callback_bool,
+                               (gpointer)CONFIG_PREFIX "high_quality_processing",
+                               N_("no"), N_("yes"));
   gtk_box_pack_start(GTK_BOX(self->widget), d->high_quality, FALSE, TRUE, 0);
 
-  d->export_masks = dt_bauhaus_combobox_new_action(DT_ACTION(self));
-  dt_bauhaus_widget_set_label(d->export_masks, NULL, N_("store masks"));
-  dt_bauhaus_combobox_add(d->export_masks, _("no"));
-  dt_bauhaus_combobox_add(d->export_masks, _("yes"));
-  gtk_widget_set_tooltip_text(d->export_masks, _("store masks as layers in exported images. only works for some formats."));
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(d->export_masks, self, NULL, N_("store masks"),
+                               _("store masks as layers in exported images. only works for some formats."),
+                               dt_conf_get_bool(CONFIG_PREFIX "export_masks") ? 1 : 0, _callback_bool,
+                               (gpointer)CONFIG_PREFIX "export_masks",
+                               N_("no"), N_("yes"));
   gtk_box_pack_start(GTK_BOX(self->widget), d->export_masks, FALSE, TRUE, 0);
 
   //  Add profile combo
@@ -1253,23 +1253,15 @@ void gui_init(dt_lib_module_t *self)
 
   //  Add intent combo
 
-  d->intent = dt_bauhaus_combobox_new_action(DT_ACTION(self));
-  dt_bauhaus_widget_set_label(d->intent, NULL, N_("intent"));
-  dt_bauhaus_combobox_add(d->intent, _("image settings"));
-  dt_bauhaus_combobox_add(d->intent, _("perceptual"));
-  dt_bauhaus_combobox_add(d->intent, _("relative colorimetric"));
-  dt_bauhaus_combobox_add(d->intent, C_("rendering intent", "saturation"));
-  dt_bauhaus_combobox_add(d->intent, _("absolute colorimetric"));
-  gtk_box_pack_start(GTK_BOX(self->widget), d->intent, FALSE, TRUE, 0);
-
-  tooltip = g_strdup_printf(_("• perceptual: "
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(d->intent, self, NULL, N_("intent"),
+                               _("• perceptual: "
                               "smoothly moves out-of-gamut colors into gamut,"
                               " preserving gradations, but distorts in-gamut colors in the process."
                               " note that perceptual is often a proprietary LUT that depends"
                               " on the destination space."
                               "\n\n"
 
-                              "• relative colorimetric: "
+                              "• relative colorimetric:"
                               "keeps luminance while reducing as little as possible saturation"
                               " until colors fit in gamut."
                               "\n\n"
@@ -1282,11 +1274,14 @@ void gui_init(dt_lib_module_t *self)
                               "• absolute colorimetric: "
                               "adapt white point of the image to the white point of the"
                               " destination medium and do nothing else. mainly used when"
-                              " proofing colors. (not suited for photography)."
-                              ""
-                              ));
-  gtk_widget_set_tooltip_text(d->intent, tooltip);
-  g_free(tooltip);
+                              " proofing colors. (not suited for photography)."),
+                               0, _intent_changed, self,
+                               N_("image settings"),
+                               N_("perceptual"),
+                               N_("relative colorimetric"),
+                               NC_("rendering intent", "saturation"),
+                               N_("absolute colorimetric"));
+  gtk_box_pack_start(GTK_BOX(self->widget), d->intent, FALSE, TRUE, 0);
 
   //  Add style combo
 
@@ -1298,32 +1293,17 @@ void gui_init(dt_lib_module_t *self)
 
   //  Add check to control whether the style is to replace or append the current module
 
-  d->style_mode = dt_bauhaus_combobox_new_action(DT_ACTION(self));
-  dt_bauhaus_widget_set_label(d->style_mode, NULL, N_("mode"));
-
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(d->style_mode, self, NULL, N_("mode"),
+                               _("whether the style items are appended to the history or replacing the history"),
+                               dt_conf_get_bool(CONFIG_PREFIX "style_append") ? 1 : 0, _callback_bool,
+                               (gpointer)CONFIG_PREFIX "style_append",
+                               N_("replace history"), N_("append history"));
   gtk_box_pack_start(GTK_BOX(self->widget), d->style_mode, FALSE, TRUE, 0);
-
-  dt_bauhaus_combobox_add(d->style_mode, _("replace history"));
-  dt_bauhaus_combobox_add(d->style_mode, _("append history"));
-
-  dt_bauhaus_combobox_set(d->style_mode, 0);
-
-  gtk_widget_set_tooltip_text(d->style_mode,
-                              _("whether the style items are appended to the history or replacing the history"));
 
   //  Set callback signals
 
-  g_signal_connect(G_OBJECT(d->upscale), "value-changed", G_CALLBACK(_callback_bool),
-                   (gpointer)CONFIG_PREFIX "upscale");
-  g_signal_connect(G_OBJECT(d->high_quality), "value-changed", G_CALLBACK(_callback_bool),
-                   (gpointer)CONFIG_PREFIX "high_quality_processing");
-  g_signal_connect(G_OBJECT(d->export_masks), "value-changed", G_CALLBACK(_callback_bool),
-                   (gpointer)CONFIG_PREFIX "export_masks");
-  g_signal_connect(G_OBJECT(d->intent), "value-changed", G_CALLBACK(_intent_changed), (gpointer)d);
   g_signal_connect(G_OBJECT(d->profile), "value-changed", G_CALLBACK(_profile_changed), (gpointer)d);
   g_signal_connect(G_OBJECT(d->style), "value-changed", G_CALLBACK(_style_changed), (gpointer)d);
-  g_signal_connect(G_OBJECT(d->style_mode), "value-changed", G_CALLBACK(_callback_bool),
-                   (gpointer)CONFIG_PREFIX "style_append");
 
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_STYLE_CHANGED,
                             G_CALLBACK(_lib_export_styles_changed_callback), self);
@@ -1369,10 +1349,6 @@ void gui_init(dt_lib_module_t *self)
   const int storage_index = dt_imageio_get_index_of_storage(dt_imageio_get_storage_by_name(setting));
   dt_bauhaus_combobox_set(d->storage, storage_index);
 
-  dt_bauhaus_combobox_set(d->upscale, dt_conf_get_bool(CONFIG_PREFIX "upscale") ? 1 : 0);
-  dt_bauhaus_combobox_set(d->high_quality, dt_conf_get_bool(CONFIG_PREFIX "high_quality_processing") ? 1 : 0);
-  dt_bauhaus_combobox_set(d->export_masks, dt_conf_get_bool(CONFIG_PREFIX "export_masks") ? 1 : 0);
-
   dt_bauhaus_combobox_set(d->intent, dt_conf_get_int(CONFIG_PREFIX "iccintent") + 1);
 
   // iccprofile
@@ -1410,9 +1386,8 @@ void gui_init(dt_lib_module_t *self)
     dt_bauhaus_combobox_set(d->style, 0);
 
   // style mode to overwrite as it was the initial behavior
-  dt_bauhaus_combobox_set(d->style_mode, dt_conf_get_bool(CONFIG_PREFIX "style_append"));
-
-  gtk_widget_set_sensitive(GTK_WIDGET(d->style_mode), dt_bauhaus_combobox_get(d->style)==0?FALSE:TRUE);
+  gtk_widget_set_no_show_all(d->style_mode, TRUE);
+  gtk_widget_set_visible(d->style_mode, dt_bauhaus_combobox_get(d->style)==0?FALSE:TRUE);
 
   // export metadata presets
   d->metadata_export = dt_lib_export_metadata_get_conf();

--- a/src/libs/filters/grouping.c
+++ b/src/libs/filters/grouping.c
@@ -165,7 +165,7 @@ static void _grouping_widget_init(dt_lib_filtering_rule_t *rule, const dt_collec
   grouping->rule = rule;
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL(grouping->combo, self, NULL, N_("grouping filter"),
-                               _("select the type of grouped image to filter"), 0, (GtkCallback)_grouping_changed,
+                               _("select the type of grouped image to filter"), 0, _grouping_changed,
                                grouping, N_("all images"), N_("ungrouped images"), N_("grouped images"),
                                N_("group leaders"), N_("group followers"));
   DT_BAUHAUS_WIDGET(grouping->combo)->show_label = FALSE;

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -850,8 +850,8 @@ static gboolean _changes_tooltip_callback(GtkWidget *widget, gint x, gint y, gbo
                                   ? g_strdup_printf("%s\t%d\t\u2192\t%d", label,                 \
                                                     old_blend->field, hitem->blend_params->field)\
                                   : g_strdup_printf("%s\t%s\t\u2192\t%s", label,                 \
-                                                    _(g_dpgettext2(NULL, "blendmode", old_str)), \
-                                                    _(g_dpgettext2(NULL, "blendmode", new_str)));\
+                                                    Q_(old_str),                                 \
+                                                    Q_(new_str));                                \
       }
 
     add_blend_history_change_enum(blend_cst, _("colorspace"), dt_develop_blend_colorspace_names);

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -525,7 +525,7 @@ void gui_init(dt_lib_module_t *self)
                                            _("synchronize the image's XMP and remove the local copy"), 0, 0);
   gtk_grid_attach(grid, d->uncache_button, 2, line++, 2, 1);
 
-  d->group_button = dt_action_button_new(self, C_("selected images action", "group"), button_clicked, GINT_TO_POINTER(10),
+  d->group_button = dt_action_button_new(self, NC_("selected images action", "group"), button_clicked, GINT_TO_POINTER(10),
                                          _("add selected images to expanded group or create a new one"),
                                          GDK_KEY_g, GDK_CONTROL_MASK);
   gtk_grid_attach(grid, d->group_button, 0, line, 2, 1);

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -595,14 +595,13 @@ void gui_init(dt_lib_module_t *self)
                                                   _("clear selected metadata on selected images"), 0, 0);
   gtk_grid_attach(grid, d->clear_metadata_button, 4, line++, 2, 1);
 
-  GtkWidget *pastemode = dt_bauhaus_combobox_new_action(DT_ACTION(meta));
-  dt_bauhaus_widget_set_label(pastemode, NULL, N_("mode"));
-  dt_bauhaus_combobox_add(pastemode, _("merge"));
-  dt_bauhaus_combobox_add(pastemode, _("overwrite"));
-  gtk_widget_set_tooltip_text(pastemode, _("how to handle existing metadata"));
+  GtkWidget *pastemode = NULL;
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(pastemode, self, NULL, N_("mode"),
+                               _("how to handle existing metadata"),
+                               dt_conf_get_int("plugins/lighttable/copy_metadata/pastemode"),
+                               pastemode_combobox_changed, self,
+                               N_("merge"), N_("overwrite"));
   gtk_grid_attach(grid, pastemode, 0, line++, 6, 1);
-  dt_bauhaus_combobox_set(pastemode, dt_conf_get_int("plugins/lighttable/copy_metadata/pastemode"));
-  g_signal_connect(G_OBJECT(pastemode), "value-changed", G_CALLBACK(pastemode_combobox_changed), self);
 
   d->refresh_button = dt_action_button_new(self, N_("refresh EXIF"), button_clicked, GINT_TO_POINTER(14),
                                            _("update image information to match changes to file"), 0, 0);

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -217,7 +217,7 @@ static void menuitem_new_preset(GtkMenuItem *menuitem, dt_lib_module_info_t *min
   sqlite3_finalize(stmt);
   // create a shortcut for the new entry
 
-  dt_action_define_preset(&minfo->module->actions, "new preset");
+  dt_action_define_preset(&minfo->module->actions, _("new preset"));
 
   // then show edit dialog
   edit_preset(_("new preset"), minfo);

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -2320,18 +2320,15 @@ void gui_init(dt_lib_module_t *self)
 
   //  Add printer intent combo
 
-  d->pintent = dt_bauhaus_combobox_new_action(DT_ACTION(self));
-  dt_bauhaus_widget_set_label(d->pintent, N_("printer"), N_("intent"));
-  dt_bauhaus_combobox_add(d->pintent, _("perceptual"));
-  dt_bauhaus_combobox_add(d->pintent, _("relative colorimetric"));
-  dt_bauhaus_combobox_add(d->pintent, C_("rendering intent", "saturation"));
-  dt_bauhaus_combobox_add(d->pintent, _("absolute colorimetric"));
+  d->v_pintent = dt_conf_get_int("plugins/print/printer/iccintent");
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(d->pintent, self, N_("printer"), N_("intent"), NULL,
+                               d->v_pintent, _printer_intent_callback, self,
+                               N_("perceptual"),
+                               N_("relative colorimetric"),
+                               NC_("rendering intent", "saturation"),
+                               N_("absolute colorimetric"));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->pintent), TRUE, TRUE, 0);
 
-  d->v_pintent = dt_conf_get_int("plugins/print/printer/iccintent");
-  dt_bauhaus_combobox_set(d->pintent, d->v_pintent);
-
-  g_signal_connect (G_OBJECT (d->pintent), "value-changed", G_CALLBACK (_printer_intent_callback), (gpointer)self);
   d->prt.printer.intent = d->v_pintent;
 
   d->black_point_compensation = gtk_check_button_new_with_label(_("black point compensation"));
@@ -2361,12 +2358,9 @@ void gui_init(dt_lib_module_t *self)
 
   //// portrait / landscape
 
-  d->orientation = dt_bauhaus_combobox_new_action(DT_ACTION(self));
-  dt_bauhaus_widget_set_label(d->orientation, NULL, N_("orientation"));
-  dt_bauhaus_combobox_add(d->orientation, _("portrait"));
-  dt_bauhaus_combobox_add(d->orientation, _("landscape"));
-  g_signal_connect(G_OBJECT(d->orientation), "value-changed", G_CALLBACK(_orientation_changed), self);
-  dt_bauhaus_combobox_set(d->orientation, d->prt.page.landscape?1:0);
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(d->orientation, self, NULL, N_("orientation"), NULL,
+                               d->prt.page.landscape?1:0, _orientation_changed, self,
+                               N_("portrait"), N_("landscape"));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->orientation), TRUE, TRUE, 0);
 
   // NOTE: units has no label, which makes for cleaner UI but means that no action can be assigned
@@ -2646,19 +2640,15 @@ void gui_init(dt_lib_module_t *self)
 
   //  Add export intent combo
 
-  d->intent = dt_bauhaus_combobox_new_action(DT_ACTION(self));
-  dt_bauhaus_widget_set_label(d->intent, NULL, N_("intent"));
-
-  dt_bauhaus_combobox_add(d->intent, _("image settings"));
-  dt_bauhaus_combobox_add(d->intent, _("perceptual"));
-  dt_bauhaus_combobox_add(d->intent, _("relative colorimetric"));
-  dt_bauhaus_combobox_add(d->intent, C_("rendering intent", "saturation"));
-  dt_bauhaus_combobox_add(d->intent, _("absolute colorimetric"));
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(d->intent, self, NULL, N_("intent"), NULL,
+                               dt_conf_get_int("plugins/print/print/iccintent") + 1,
+                               _intent_callback, self,
+                               N_("image settings"),
+                               N_("perceptual"),
+                               N_("relative colorimetric"),
+                               NC_("rendering intent", "saturation"),
+                               N_("absolute colorimetric"));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->intent), TRUE, TRUE, 0);
-
-  dt_bauhaus_combobox_set(d->intent, dt_conf_get_int("plugins/print/print/iccintent") + 1);
-
-  g_signal_connect (G_OBJECT (d->intent), "value-changed", G_CALLBACK (_intent_callback), (gpointer)self);
 
   //  Add export style combo
 
@@ -2703,22 +2693,14 @@ void gui_init(dt_lib_module_t *self)
 
   //  Whether to add/replace style items
 
-  d->style_mode = dt_bauhaus_combobox_new_action(DT_ACTION(self));
-  dt_bauhaus_widget_set_label(d->style_mode, NULL, N_("mode"));
-
-  dt_bauhaus_combobox_add(d->style_mode, _("replace history"));
-  dt_bauhaus_combobox_add(d->style_mode, _("append history"));
-
   d->v_style_append = dt_conf_get_bool("plugins/print/print/style_append");
-  dt_bauhaus_combobox_set(d->style_mode, d->v_style_append?1:0);
-
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(d->style_mode, self, NULL, N_("mode"),
+                               _("whether the style items are appended to the history or replacing the history"),
+                               d->v_style_append?1:0, _style_mode_changed, self,
+                               N_("replace history"), N_("append history"));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->style_mode), TRUE, TRUE, 0);
-  gtk_widget_set_tooltip_text(d->style_mode,
-                              _("whether the style items are appended to the history or replacing the history"));
 
   gtk_widget_set_sensitive(GTK_WIDGET(d->style_mode), combo_idx==0?FALSE:TRUE);
-
-  g_signal_connect(G_OBJECT(d->style_mode), "value-changed", G_CALLBACK(_style_mode_changed), (gpointer)self);
 
   // Print button
 

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -822,13 +822,12 @@ void gui_init(dt_lib_module_t *self)
                                dt_conf_get_bool("ui_last/styles_create_duplicate"));
   gtk_widget_set_tooltip_text(d->duplicate, _("creates a duplicate of the image before applying style"));
 
-  d->applymode = dt_bauhaus_combobox_new_action(DT_ACTION(self));
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(d->applymode, self, NULL, N_("mode"),
+                               _("how to handle existing history"),
+                               dt_conf_get_int("plugins/lighttable/style/applymode"),
+                               applymode_combobox_changed, self,
+                               N_("append"), N_("overwrite"));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->applymode), TRUE, FALSE, 0);
-  dt_bauhaus_widget_set_label(d->applymode, NULL, N_("mode"));
-  dt_bauhaus_combobox_add(d->applymode, _("append"));
-  dt_bauhaus_combobox_add(d->applymode, _("overwrite"));
-  gtk_widget_set_tooltip_text(d->applymode, _("how to handle existing history"));
-  dt_bauhaus_combobox_set(d->applymode, dt_conf_get_int("plugins/lighttable/style/applymode"));
 
   GtkWidget *hbox1 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   GtkWidget *hbox2 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
@@ -879,8 +878,6 @@ void gui_init(dt_lib_module_t *self)
                             G_CALLBACK(_mouse_over_image_callback), self);
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
                             G_CALLBACK(_collection_updated_callback), self);
-
-  g_signal_connect(G_OBJECT(d->applymode), "value-changed", G_CALLBACK(applymode_combobox_changed), (gpointer)self);
 
   _update(self);
 }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2316,19 +2316,14 @@ void gui_init(dt_view_t *self)
                                  N_("mark with CFA color"), N_("mark with solid color"), N_("false color"));
     gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(mode), TRUE, TRUE, 0);
 
-    /* color scheme */
-    // FIXME can't use DT_BAUHAUS_COMBOBOX_NEW_FULL because of (unnecessary?) translation context
-    colorscheme = dt_bauhaus_combobox_new_action(DT_ACTION(self));
-    dt_bauhaus_widget_set_label(colorscheme, N_("raw overexposed"), N_("color scheme"));
-    dt_bauhaus_combobox_add(colorscheme, C_("solidcolor", "red"));
-    dt_bauhaus_combobox_add(colorscheme, C_("solidcolor", "green"));
-    dt_bauhaus_combobox_add(colorscheme, C_("solidcolor", "blue"));
-    dt_bauhaus_combobox_add(colorscheme, C_("solidcolor", "black"));
-    dt_bauhaus_combobox_set(colorscheme, dev->rawoverexposed.colorscheme);
-    gtk_widget_set_tooltip_text(
-        colorscheme,
-        _("select the solid color to indicate over exposure.\nwill only be used if mode = mark with solid color"));
-    g_signal_connect(G_OBJECT(colorscheme), "value-changed", G_CALLBACK(rawoverexposed_colorscheme_callback), dev);
+    DT_BAUHAUS_COMBOBOX_NEW_FULL(colorscheme, self, N_("raw overexposed"), N_("color scheme"),
+                                _("select the solid color to indicate over exposure.\nwill only be used if mode = mark with solid color"),
+                                dev->rawoverexposed.colorscheme,
+                                rawoverexposed_colorscheme_callback, dev,
+                                NC_("solidcolor", "red"),
+                                NC_("solidcolor", "green"),
+                                NC_("solidcolor", "blue"),
+                                NC_("solidcolor", "black"));
     gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(colorscheme), TRUE, TRUE, 0);
 
     /* threshold */
@@ -2449,26 +2444,22 @@ void gui_init(dt_view_t *self)
     dt_loc_get_datadir(datadir, sizeof(datadir));
     const int force_lcms2 = dt_conf_get_bool("plugins/lighttable/export/force_lcms2");
 
-    GtkWidget *display_intent = dt_bauhaus_combobox_new_action(DT_ACTION(self));
-    dt_bauhaus_widget_set_label(display_intent, N_("profiles"), N_("intent"));
-    dt_bauhaus_combobox_add(display_intent, _("perceptual"));
-    dt_bauhaus_combobox_add(display_intent, _("relative colorimetric"));
-    dt_bauhaus_combobox_add(display_intent, C_("rendering intent", "saturation"));
-    dt_bauhaus_combobox_add(display_intent, _("absolute colorimetric"));
+    static const gchar *intents_list[]
+      = { N_("perceptual"),
+          N_("relative colorimetric"),
+          NC_("rendering intent", "saturation"),
+          N_("absolute colorimetric"),
+          NULL };
 
-    GtkWidget *display2_intent = dt_bauhaus_combobox_new_action(DT_ACTION(self));
-    dt_bauhaus_widget_set_label(display2_intent, N_("profiles"), N_("preview intent"));
-    dt_bauhaus_combobox_add(display2_intent, _("perceptual"));
-    dt_bauhaus_combobox_add(display2_intent, _("relative colorimetric"));
-    dt_bauhaus_combobox_add(display2_intent, C_("rendering intent", "saturation"));
-    dt_bauhaus_combobox_add(display2_intent, _("absolute colorimetric"));
+    GtkWidget *display_intent = dt_bauhaus_combobox_new_full(DT_ACTION(self), N_("profiles"), N_("intent"),
+                                                             "", 0, display_intent_callback, dev, intents_list);
+    GtkWidget *display2_intent = dt_bauhaus_combobox_new_full(DT_ACTION(self), N_("profiles"), N_("preview intent"),
+                                                              "", 0, display2_intent_callback, dev, intents_list);
 
     if(!force_lcms2)
     {
       gtk_widget_set_no_show_all(display_intent, TRUE);
-      gtk_widget_set_visible(display_intent, FALSE);
       gtk_widget_set_no_show_all(display2_intent, TRUE);
-      gtk_widget_set_visible(display2_intent, FALSE);
     }
 
     GtkWidget *display_profile = dt_bauhaus_combobox_new_action(DT_ACTION(self));
@@ -2558,9 +2549,7 @@ void gui_init(dt_view_t *self)
     g_free(system_profile_dir);
     g_free(user_profile_dir);
 
-    g_signal_connect(G_OBJECT(display_intent), "value-changed", G_CALLBACK(display_intent_callback), dev);
     g_signal_connect(G_OBJECT(display_profile), "value-changed", G_CALLBACK(display_profile_callback), dev);
-    g_signal_connect(G_OBJECT(display2_intent), "value-changed", G_CALLBACK(display2_intent_callback), dev);
     g_signal_connect(G_OBJECT(display2_profile), "value-changed", G_CALLBACK(display2_profile_callback), dev);
     g_signal_connect(G_OBJECT(softproof_profile), "value-changed", G_CALLBACK(softproof_profile_callback), dev);
     g_signal_connect(G_OBJECT(histogram_profile), "value-changed", G_CALLBACK(histogram_profile_callback), dev);

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1150,19 +1150,17 @@ void gui_init(dt_view_t *self)
   dt_loc_get_user_config_dir(confdir, sizeof(confdir));
   dt_loc_get_datadir(datadir, sizeof(datadir));
 
-  GtkWidget *display_intent = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(display_intent, NULL, N_("intent"));
-  dt_bauhaus_combobox_add(display_intent, _("perceptual"));
-  dt_bauhaus_combobox_add(display_intent, _("relative colorimetric"));
-  dt_bauhaus_combobox_add(display_intent, C_("rendering intent", "saturation"));
-  dt_bauhaus_combobox_add(display_intent, _("absolute colorimetric"));
+  static const gchar *intents_list[]
+    = { N_("perceptual"),
+        N_("relative colorimetric"),
+        NC_("rendering intent", "saturation"),
+        N_("absolute colorimetric"),
+        NULL };
 
-  GtkWidget *display2_intent = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(display2_intent, NULL, N_("intent"));
-  dt_bauhaus_combobox_add(display2_intent, _("perceptual"));
-  dt_bauhaus_combobox_add(display2_intent, _("relative colorimetric"));
-  dt_bauhaus_combobox_add(display2_intent, C_("rendering intent", "saturation"));
-  dt_bauhaus_combobox_add(display2_intent, _("absolute colorimetric"));
+  GtkWidget *display_intent = dt_bauhaus_combobox_new_full(DT_ACTION(self), N_("profiles"), N_("intent"),
+                                                            "", 0, _profile_display_intent_callback, NULL, intents_list);
+  GtkWidget *display2_intent = dt_bauhaus_combobox_new_full(DT_ACTION(self), N_("profiles"), N_("preview intent"),
+                                                            "", 0, _profile_display2_intent_callback, NULL, intents_list);
 
   GtkWidget *display_profile = dt_bauhaus_combobox_new(NULL);
   dt_bauhaus_widget_set_label(display_profile, NULL, N_("display profile"));
@@ -1213,10 +1211,8 @@ void gui_init(dt_view_t *self)
   g_free(system_profile_dir);
   g_free(user_profile_dir);
 
-  g_signal_connect(G_OBJECT(display_intent), "value-changed", G_CALLBACK(_profile_display_intent_callback), NULL);
   g_signal_connect(G_OBJECT(display_profile), "value-changed", G_CALLBACK(_profile_display_profile_callback), NULL);
 
-  g_signal_connect(G_OBJECT(display2_intent), "value-changed", G_CALLBACK(_profile_display2_intent_callback), NULL);
   g_signal_connect(G_OBJECT(display2_profile), "value-changed", G_CALLBACK(_profile_display2_profile_callback),
                    NULL);
 


### PR DESCRIPTION
fixes #12139
fixes #11502
fixes #11926
corrects #12208

Solves thee issues:
Issue 1:
Defining or renaming presets for lib modules would previously not correctly manage the associated actions (they'd still be called "new preset") so shortcuts could only be defined after a restart. This should now work correctly.

Issue 2:
preset and style names containing a pipe ("|"). There was "some" initial support in inputng for the new gnome "contexted translations" style, which broke these presets/styles. Since preset/style names are internally already stored in translated form, they are now not translated again when setting up the corresponding actions.

Issue 3:
The recently introduced `N_("selected images action", "group")` breaks shortcuts to that button when switching languages.

Previously the translation context was separately supplied to `g_dpgettext2` (which requires either storing a context for each string or specific contexts per use case, like "blendmode" for `dt_develop_blend_mode_names`, which then forces a separate translation for _all_ strings in that context even if they don't deviate from the normal meaning).
 
The "new" gnome way is to _only_ specify a context, in the string itself, for strings that _require_ a separate context , using "context|string". These are then translated using `Q_()` instead of `_()`.

To fully switch to this new way, we should switch from _intltool_ to _gettext_ (https://wiki.gnome.org/MigratingFromIntltoolToGettext). We could then instruct it to parse the new format when used in `N_()`. Instead, I have here redefined `NC_()`, which is used in only a few locations (for example to correct #12208),  to pass the combined string and process it at the other end using `Q_()`. Doing the full _gettext_ migration would allow supporting this functionality in introspection as well.

I have not yet implemented _full_ contextual translation support _everywhere_ that `N_` is used. Obviously button labels work (for the _group_ button). `dt_bauhaus_widget_set_label` should fully work, as well as combobox items, but since none of these have existing cases with contexted translations, actually using `NC_` here might uncover issues (that should be easy to fix). Testing is hard if there are no use cases...

`dt_develop_blend_mode_names` could be cleaned up (meaning the "blendmode" context removed) except for those modes where the translation should actually deviate from the non-contexted version (if there are any; this is not a quick check).

Edit: this allows more comboboxes to be set up using `dt_bauhaus_combobox_new_full` which exposes their possible values as _effects_ in shortcuts and lua calls to _dt.gui.action_, so that they can be directly activated.
Specifically this applies to display intents, where `NC_("rendering intent", "saturation")` previous prevented this.