### PR TITLE
diffuse: support the fast pixelpipe mode.

### DIFF
--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1059,10 +1059,20 @@ static inline void inpaint_mask(float *const restrict inpainted, const float *co
 void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const restrict ivoid,
              void *const restrict ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
+  const gboolean fastmode = (piece->pipe->type & DT_DEV_PIXELPIPE_FAST) == DT_DEV_PIXELPIPE_FAST;
+
   const dt_iop_diffuse_data_t *const data = (dt_iop_diffuse_data_t *)piece->data;
 
   const size_t width = roi_out->width;
   const size_t height = roi_out->height;
+
+  // allow fast mode, just copy input to ouput
+  if(fastmode)
+  {
+    const size_t ch = piece->colors;
+    dt_iop_copy_image_roi(ovoid, ivoid, ch, roi_in, roi_out, TRUE);
+    return;
+  }
 
   float *restrict in = DT_IS_ALIGNED((float *const restrict)ivoid);
   float *const restrict out = DT_IS_ALIGNED((float *const restrict)ovoid);
@@ -1316,6 +1326,8 @@ static inline cl_int wavelets_process_cl(const int devid, cl_mem in, cl_mem reco
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
                const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
+  const gboolean fastmode = (piece->pipe->type & DT_DEV_PIXELPIPE_FAST) == DT_DEV_PIXELPIPE_FAST;
+
   const dt_iop_diffuse_data_t *const data = (dt_iop_diffuse_data_t *)piece->data;
   dt_iop_diffuse_global_data_t *const gd = (dt_iop_diffuse_global_data_t *)self->global_data;
 
@@ -1326,6 +1338,15 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const int devid = piece->pipe->devid;
   const int width = roi_in->width;
   const int height = roi_in->height;
+
+  // allow fast mode, just copy input to ouput
+  if(fastmode)
+  {
+    size_t origin[] = { 0, 0, 0 };
+    size_t region[] = { width, height, 1 };
+    err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
+    return err == CL_SUCCESS;
+  }
 
   size_t sizes[] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid), 1 };
 


### PR DESCRIPTION
This makes some modules like crop bearable when using diffuse with
lot of iterations. The current situation is that there is some lag
and freeze when moving or resizing the cropped area.

As we don't need the diffuse output for cropping properly or whatever
other actions like perspective corrections better to bypass this
module.