### PR TITLE
Fix crash after failed camera tethering

### DIFF
--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -607,7 +607,10 @@ static void _camctl_unlock(const dt_camctl_t *c)
   const dt_camera_t *cam = camctl->active_camera;
   camctl->active_camera = NULL;
   dt_pthread_mutex_BAD_unlock(&camctl->lock);
-  dt_print(DT_DEBUG_CAMCTL, "[camera_control] camera control un-locked for %s\n", cam->model);
+  if(cam)
+    dt_print(DT_DEBUG_CAMCTL, "[camera_control] camera control un-locked for %s\n", cam->model);
+  else
+    dt_print(DT_DEBUG_CAMCTL, "[camera_control] camera control un-locked for unknown camera\n");
   _dispatch_control_status(c, CAMERA_CONTROL_AVAILABLE);
 }
 


### PR DESCRIPTION
As can be seen from the excellent (in terms of information completeness) bug report #10638, there is a scenario in which at the moment of unlocking the camera after failed tethering we can lose the reference to the data block of the active camera. Therefore, a check is needed to avoid NULL dereference.

Should resolve #10638.
