### PR TITLE
graphicsmagick: use new API to not install signal handlers

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1131,10 +1131,14 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 
 #ifdef HAVE_GRAPHICSMAGICK
   /* GraphicsMagick init */
+#ifndef MAGICK_OPT_NO_SIGNAL_HANDER
   InitializeMagick(darktable.progname);
 
   // *SIGH*
   dt_set_signal_handlers();
+#else
+  InitializeMagickEx(darktable.progname, MAGICK_OPT_NO_SIGNAL_HANDER, NULL);
+#endif
 #elif defined HAVE_IMAGEMAGICK
   /* ImageMagick init */
   MagickWandGenesis();


### PR DESCRIPTION
Since release 1.3.35 there is a possibility in graphicsmagick to disable its annoying signal handler. Especially relevant for macOS to remove graphicsmagick from all and every produced backtrace.

Tentative fix, not tested at all currently on any platform.