### PR TITLE
CI: don't cancel if lensfun update fails

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -89,6 +89,7 @@ jobs:
           path: src
       - name: Update lensfun data
         if: ${{ success() && matrix.btype == 'Release' && matrix.target == 'skiptest' }}
+        continue-on-error: true
         run: |
           lensfun-update-data
       - name: Build and Install


### PR DESCRIPTION
The lensfun server is currently offline, and it kills our nightly builds - better have one even with an outdated lens db.