### PR TITLE
show lua command in action tooltip

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -3199,6 +3199,10 @@ static float _action_process(gpointer target, dt_action_element_t element, dt_ac
       }
       break;
     case DT_ACTION_ELEMENT_PRESETS:
+      // FIXME
+      if(effect)
+        fprintf(stderr, "[imageop::_action_process] effects for presets not yet implemented\n");
+
       if(module->presets_button) _presets_popup_callback(NULL, module);
       break;
     }

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1498,13 +1498,13 @@ static gboolean _shortcut_key_pressed(GtkWidget *widget, GdkEventKey *event, gpo
     if(GPOINTER_TO_UINT(shortcut_iter) >= NUM_CATEGORIES)
     {
 #ifdef USE_LUA
-      // if control key pressed, copy lua command to clipboard (CTRL+C will work)
-      if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
-      {
-        dt_shortcut_t *s = g_sequence_get(shortcut_iter);
+      dt_shortcut_t *s = g_sequence_get(shortcut_iter);
 
+      // if control key pressed, copy lua command to clipboard (CTRL+C will work)
+      if(dt_modifier_is(event->state, GDK_CONTROL_MASK) && s->views)
+      {
         const dt_action_element_def_t *elements = _action_find_elements(s->action);
-        const gchar *cef = _action_find_effect_combo(s->action, &elements[s->element], s->effect);
+        const gchar *cef = elements ? _action_find_effect_combo(s->action, &elements[s->element], s->effect) : NULL;
         const gchar *el = elements ? elements[s->element].name : NULL;
         const gchar **ef = elements && s->effect >= 0 ? elements[s->element].effects : NULL;
 

--- a/src/lua/gui.c
+++ b/src/lua/gui.c
@@ -381,6 +381,7 @@ int dt_lua_init_gui(lua_State *L)
     lua_pushcclosure(L, dt_lua_type_member_common, 1);
     dt_lua_type_register_const_type(L, type_id, "current_view");
     lua_pushcfunction(L, _action_cb);
+    dt_lua_gtk_wrap(L);
     lua_pushcclosure(L, dt_lua_type_member_common, 1);
     dt_lua_type_register_const_type(L, type_id, "action");
     lua_pushcfunction(L, _panel_visible_cb);


### PR DESCRIPTION
This adds a line "lua: darktable.gui.action()" with the appropriate parameters to the tooltip for widgets (in mapping mode) or actions (in the preferences dialog).

This assumes that your script contains a line
`local darktable = require "darktable"`

The intend is to advertise more widely that all actions can be called from lua, but also to show the full, untranslated, action path which otherwise might be a little bit cumbersome to find.

![image](https://user-images.githubusercontent.com/1549490/185235803-6395968e-c41b-46c4-b348-48f115411b54.png)

Edit: Selecting a shortcut in the bottom half of the shortcuts dialog and pressing CTRL+C copies the corresponding lua script line to the clipboard, including the selected element, effect, instance and speed settings.

Edit 2: fixes #12348 by calling dt_action_process in the main thread.