### PR TITLE
don't map default rating shortcuts to numeric keypad

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -305,6 +305,11 @@ static const dt_action_element_def_t *_action_find_elements(dt_action_t *action)
     return definition->elements;
 }
 
+static gboolean _is_kp_key(guint keycode)
+{
+  return keycode >= GDK_KEY_KP_Space && keycode <= GDK_KEY_KP_Equal;
+}
+
 static gboolean _shortcut_is_speed(const dt_shortcut_t *s)
 {
   return !s->key_device && !s->key && !s->press && !s->move_device && !s->move && !s->button && !s->click && !s->mods;
@@ -446,7 +451,7 @@ static gchar *_shortcut_key_move_name(dt_input_device_t id, guint key_or_move, g
       {
         gchar *key_name = gtk_accelerator_get_label(key_or_move, 0);
         post_name = g_utf8_strdown(key_name, -1);
-        if(strlen(post_name) == 1 && key_or_move >= GDK_KEY_KP_Space && key_or_move <= GDK_KEY_KP_9)
+        if(strlen(post_name) == 1 && _is_kp_key(key_or_move))
           post_name = dt_util_dstrcat(post_name, " %s", _("(keypad)"));
         g_free(key_name);
       }
@@ -4053,7 +4058,7 @@ void dt_shortcut_register(dt_action_t *owner, guint element, guint effect, guint
     {
       gdk_keymap_translate_keyboard_state(keymap, keys[j].keycode, 0, 0, &keys[j].keycode, NULL, NULL, NULL);
 
-      if(keys[j].keycode >= GDK_KEY_KP_Space && keys[j].keycode <= GDK_KEY_KP_9)
+      if(_is_kp_key(keys[j].keycode))
         keys[j].group = 10;
 
       if(keys[j].group < keys[i].group || (keys[j].group == keys[i].group && keys[j].level < keys[i].level))


### PR DESCRIPTION
Under Windows, inputng mapped default shortcuts for assigning ratings (0-5) to the numpad keys, which wasn't made explicit in the key name when pressing _h_, making it seem like they simply did not work. This may have been due to recent gtk/gdk changes "fixing" keyboard handling under Win32 or this may always have been the case.

Now, try to avoid numpad keys and if used, add " (numpad)" (like gtk does for some, but not all, numpad keys) so the distinction is visible.

Before inputng both sets of numeric keys used to be treated identically, but that meant fewer separate keys were available for shortcuts. If a user still wants "1" and "1 (keypad)" to do the same thing, it is fairly simple to set up the duplicate mappings:

1. switch to key mapping mode by clicking the "define shortcuts" button (left of preferences)
2. click on a star rating (this will open the shortcuts dialog with the "rating" action selected)
3. in the bottom half of the screen, double click on the existing shortcut for the "0" key
4. press the "0" key on the numpad. This should add a second shortcut for views/thumbtable/rating, zero to the list.
5. go to step 3 for each of 1, 2, 3, 4, 5

fixes https://github.com/Aurelien-Pierre/R-Darktable/issues/8

![image](https://user-images.githubusercontent.com/1549490/185635886-440d8fba-9e1d-4f2c-998c-febdf47906f9.png)
