### PR TITLE
Correctly display infinity focus in image information

### DIFF
--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -745,7 +745,11 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
 
       case md_exif_focus_distance:
         (void)g_strlcpy(text, NODATA_STRING, sizeof(text));
-        if(!(isnan(img->exif_focus_distance) || (fpclassify(img->exif_focus_distance) == FP_ZERO) ))
+        if(img->exif_focus_distance == UINT32_MAX)
+        {
+          (void)g_snprintf(text, sizeof(text), _("infinity"));
+        }
+        else if(!(isnan(img->exif_focus_distance) || (fpclassify(img->exif_focus_distance) == FP_ZERO) ))
         {
           (void)g_snprintf(text, sizeof(text), _("%.2f m"), (double)img->exif_focus_distance);
         }


### PR DESCRIPTION
UINT32_MAX is a ridiculously large focal length value. If it occurs in the EXIF data, it is an indication of infinity focus.
Can be tested on https://raw.pixls.us/getfile.php/3874/nice/Hasselblad%20-%20X1DM2-50c%20-%2016bit%20(4:3).fff, where the focus is clearly on infinity.
