### PR TITLE
curve-tool: cmake: enable/disable OpenMP use, via USE_OPENMP

### DIFF
--- a/tools/basecurve/CMakeLists.txt
+++ b/tools/basecurve/CMakeLists.txt
@@ -1,4 +1,8 @@
-find_package(OpenMP)
+if (USE_OPENMP)
+    find_package(OpenMP)
+else()
+    set(OPENMP_FOUND FALSE)
+endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/modules")
 find_library(M_LIBRARY m)


### PR DESCRIPTION
Proposed change, allowing explicit control over whether OpenMP is enabled for the curve-tool.

This was necessary for MacPorts, as the curve-tool build will opportunistically use OpenMP, regardless of global flag `USE_OPENMP`. And if we've otherwise disabled OpenMP, link errors occur due to missing libs.

Of note, this dovetails with past PR:
* [3608 - Use OpenMP flags for entire build](https://github.com/darktable-org/darktable/pull/3608)

For more specifics regarding the issue, it's tracked here:
* [65683 - darktable: curve-tool: opportunistic use of OpenMP](https://trac.macports.org/ticket/65683)

Finally, we included status output, to validate that `USE_OPENMP` is truly in play. But I'm happy to remove those - or use a lower level, like `VERBOSE` - if folks would prefer they not appear for normal CMake runs.

Thoughts on this proposed change?

CC: @parafin
CC: @MarcusCalhoun-Lopez