### PR TITLE
re-translate zh_TW.po

### DIFF
--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1,210 +1,207 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
+"Project-Id-Version: darktable 4.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-20 19:37+0200\n"
-"PO-Revision-Date: 2022-07-24 17:25+0800\n"
-"Last-Translator: Jin-shea Kuo <d8807302@gmail.com>\n"
+"POT-Creation-Date: 2022-08-18 08:34+0200\n"
+"PO-Revision-Date: 2022-08-20 00:58+0800\n"
+"Last-Translator: Hsu Kang-Wei <beblue.shi@gmail.com>\n"
 "Language-Team: \n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.0.1\n"
+"X-Generator: Poedit 3.1\n"
 
-#: ../build/bin/conf_gen.h:158 ../build/bin/preferences_gen.h:8286
+#: ../build/bin/conf_gen.h:158 ../build/bin/preferences_gen.h:7998
 msgctxt "preferences"
 msgid "first instance"
-msgstr "第一個實例"
+msgstr "第一個模組實例"
 
-#: ../build/bin/conf_gen.h:159 ../build/bin/preferences_gen.h:8291
-#: ../build/bin/preferences_gen.h:8310
+#: ../build/bin/conf_gen.h:159 ../build/bin/preferences_gen.h:8003
+#: ../build/bin/preferences_gen.h:8022
 msgctxt "preferences"
 msgid "last instance"
-msgstr "最後一個實例"
+msgstr "最後一個模組實例"
 
 #: ../build/bin/conf_gen.h:214 ../build/bin/conf_gen.h:234
 #: ../build/bin/conf_gen.h:346 ../build/bin/conf_gen.h:356
 #: ../build/bin/conf_gen.h:1196 ../build/bin/conf_gen.h:1212
-#: ../build/bin/preferences_gen.h:4394 ../build/bin/preferences_gen.h:4413
-#: ../build/bin/preferences_gen.h:4489 ../build/bin/preferences_gen.h:7285
-#: ../build/bin/preferences_gen.h:7415 ../build/bin/preferences_gen.h:7543
-#: ../build/bin/preferences_gen.h:7608
+#: ../build/bin/preferences_gen.h:4272 ../build/bin/preferences_gen.h:4291
+#: ../build/bin/preferences_gen.h:4367 ../build/bin/preferences_gen.h:6997
+#: ../build/bin/preferences_gen.h:7127 ../build/bin/preferences_gen.h:7255
+#: ../build/bin/preferences_gen.h:7320
 msgctxt "preferences"
 msgid "never"
-msgstr "從不"
+msgstr "絕不"
 
-#: ../build/bin/conf_gen.h:215 ../build/bin/preferences_gen.h:7290
+#: ../build/bin/conf_gen.h:215 ../build/bin/preferences_gen.h:7002
 msgctxt "preferences"
 msgid "on startup"
-msgstr "啓動時"
+msgstr "開啟時"
 
 #: ../build/bin/conf_gen.h:216 ../build/bin/conf_gen.h:238
-#: ../build/bin/preferences_gen.h:7295 ../build/bin/preferences_gen.h:7334
-#: ../build/bin/preferences_gen.h:7435
+#: ../build/bin/preferences_gen.h:7007 ../build/bin/preferences_gen.h:7046
+#: ../build/bin/preferences_gen.h:7147
 msgctxt "preferences"
 msgid "on close"
 msgstr "關閉時"
 
-#: ../build/bin/conf_gen.h:217 ../build/bin/preferences_gen.h:7300
+#: ../build/bin/conf_gen.h:217 ../build/bin/preferences_gen.h:7012
 msgctxt "preferences"
 msgid "on both"
-msgstr "啓動和關閉時"
+msgstr "開啟及關閉時"
 
-#: ../build/bin/conf_gen.h:218 ../build/bin/preferences_gen.h:7305
+#: ../build/bin/conf_gen.h:218 ../build/bin/preferences_gen.h:7017
 msgctxt "preferences"
 msgid "on startup (don't ask)"
-msgstr "啓動時(不詢問)"
+msgstr "開啟時（不詢問）"
 
-#: ../build/bin/conf_gen.h:219 ../build/bin/preferences_gen.h:7310
+#: ../build/bin/conf_gen.h:219 ../build/bin/preferences_gen.h:7022
 msgctxt "preferences"
 msgid "on close (don't ask)"
-msgstr "關閉時(不詢問)"
+msgstr "關閉時（不詢問）"
 
-#: ../build/bin/conf_gen.h:220 ../build/bin/preferences_gen.h:7315
+#: ../build/bin/conf_gen.h:220 ../build/bin/preferences_gen.h:7027
 msgctxt "preferences"
 msgid "on both (don't ask)"
-msgstr "啓動和關閉時(不詢問)"
+msgstr "開啟及關閉時（不詢問）"
 
-#: ../build/bin/conf_gen.h:235 ../build/bin/preferences_gen.h:7420
+#: ../build/bin/conf_gen.h:235 ../build/bin/preferences_gen.h:7132
 msgctxt "preferences"
 msgid "once a month"
 msgstr "每月一次"
 
-#: ../build/bin/conf_gen.h:236 ../build/bin/preferences_gen.h:7425
-#: ../build/bin/preferences_gen.h:7454
+#: ../build/bin/conf_gen.h:236 ../build/bin/preferences_gen.h:7137
+#: ../build/bin/preferences_gen.h:7166
 msgctxt "preferences"
 msgid "once a week"
 msgstr "每週一次"
 
-#: ../build/bin/conf_gen.h:237 ../build/bin/preferences_gen.h:7430
+#: ../build/bin/conf_gen.h:237 ../build/bin/preferences_gen.h:7142
 msgctxt "preferences"
 msgid "once a day"
 msgstr "每天一次"
 
 #: ../build/bin/conf_gen.h:286 ../build/bin/conf_gen.h:1189
-#: ../build/bin/conf_gen.h:1205 ../build/bin/preferences_gen.h:4359
-#: ../build/bin/preferences_gen.h:4454 ../build/bin/preferences_gen.h:6345
+#: ../build/bin/conf_gen.h:1205 ../build/bin/preferences_gen.h:4237
+#: ../build/bin/preferences_gen.h:4332 ../build/bin/preferences_gen.h:6057
 msgctxt "preferences"
 msgid "small"
-msgstr "小"
+msgstr "低"
 
 #: ../build/bin/conf_gen.h:287 ../build/bin/conf_gen.h:393
-#: ../build/bin/preferences_gen.h:6350 ../build/bin/preferences_gen.h:6379
-#: ../build/bin/preferences_gen.h:6566 ../build/bin/preferences_gen.h:6595
+#: ../build/bin/conf_gen.h:2110 ../build/bin/preferences_gen.h:4961
+#: ../build/bin/preferences_gen.h:4985 ../build/bin/preferences_gen.h:6062
+#: ../build/bin/preferences_gen.h:6091 ../build/bin/preferences_gen.h:6278
+#: ../build/bin/preferences_gen.h:6307
 msgctxt "preferences"
 msgid "default"
-msgstr "預設"
+msgstr "中"
 
-#: ../build/bin/conf_gen.h:288 ../build/bin/preferences_gen.h:6355
+#: ../build/bin/conf_gen.h:288 ../build/bin/preferences_gen.h:6067
 msgctxt "preferences"
 msgid "large"
-msgstr "大"
+msgstr "高"
 
-#: ../build/bin/conf_gen.h:289 ../build/bin/preferences_gen.h:6360
+#: ../build/bin/conf_gen.h:289 ../build/bin/preferences_gen.h:6072
 msgctxt "preferences"
 msgid "unrestricted"
-msgstr "沒限制"
+msgstr "無上限"
 
-#: ../build/bin/conf_gen.h:347 ../build/bin/preferences_gen.h:7548
+#: ../build/bin/conf_gen.h:347 ../build/bin/preferences_gen.h:7260
 msgctxt "preferences"
 msgid "after edit"
 msgstr "編輯後"
 
-#: ../build/bin/conf_gen.h:348 ../build/bin/preferences_gen.h:7553
-#: ../build/bin/preferences_gen.h:7572
+#: ../build/bin/conf_gen.h:348 ../build/bin/preferences_gen.h:7265
+#: ../build/bin/preferences_gen.h:7284
 msgctxt "preferences"
 msgid "on import"
-msgstr "輸入時"
+msgstr "匯入時"
 
 #: ../build/bin/conf_gen.h:357 ../build/bin/conf_gen.h:1188
-#: ../build/bin/conf_gen.h:1204 ../build/bin/conf_gen.h:3102
-#: ../build/bin/preferences_gen.h:4354 ../build/bin/preferences_gen.h:4449
-#: ../build/bin/preferences_gen.h:5663 ../build/bin/preferences_gen.h:5717
-#: ../build/bin/preferences_gen.h:7613
+#: ../build/bin/conf_gen.h:1204 ../build/bin/conf_gen.h:3096
+#: ../build/bin/preferences_gen.h:4232 ../build/bin/preferences_gen.h:4327
+#: ../build/bin/preferences_gen.h:5411 ../build/bin/preferences_gen.h:5465
+#: ../build/bin/preferences_gen.h:7325
 msgctxt "preferences"
 msgid "always"
-msgstr "總是"
+msgstr "一律"
 
-#: ../build/bin/conf_gen.h:358 ../build/bin/preferences_gen.h:7618
-#: ../build/bin/preferences_gen.h:7637
+#: ../build/bin/conf_gen.h:358 ../build/bin/preferences_gen.h:7330
+#: ../build/bin/preferences_gen.h:7349
 msgctxt "preferences"
 msgid "only large entries"
-msgstr "只有大的條目"
+msgstr "僅大型文件"
 
-#: ../build/bin/conf_gen.h:378 ../build/bin/preferences_gen.h:8714
+#: ../build/bin/conf_gen.h:378 ../build/bin/preferences_gen.h:8426
 msgctxt "preferences"
 msgid "sensitive"
-msgstr "區分大小寫"
+msgstr "大小寫視為不同"
 
-#: ../build/bin/conf_gen.h:379 ../build/bin/preferences_gen.h:8719
-#: ../build/bin/preferences_gen.h:8738
+#: ../build/bin/conf_gen.h:379 ../build/bin/preferences_gen.h:8431
+#: ../build/bin/preferences_gen.h:8450
 msgctxt "preferences"
 msgid "insensitive"
-msgstr "不分大小寫"
+msgstr "大小寫視作相同"
 
-#: ../build/bin/conf_gen.h:394 ../build/bin/preferences_gen.h:6571
+#: ../build/bin/conf_gen.h:394 ../build/bin/preferences_gen.h:6283
 msgctxt "preferences"
 msgid "multiple GPUs"
-msgstr "多個 GPU"
+msgstr "多張顯示卡"
 
-#: ../build/bin/conf_gen.h:395 ../build/bin/preferences_gen.h:6576
+#: ../build/bin/conf_gen.h:395 ../build/bin/preferences_gen.h:6288
 msgctxt "preferences"
 msgid "very fast GPU"
-msgstr "非常快的 GPU"
+msgstr "高階的顯示卡"
 
-#: ../build/bin/conf_gen.h:403 ../build/bin/preferences_gen.h:6637
-#: ../build/bin/preferences_gen.h:6671
+#: ../build/bin/conf_gen.h:403 ../build/bin/preferences_gen.h:6349
+#: ../build/bin/preferences_gen.h:6383
 msgctxt "preferences"
 msgid "nothing"
-msgstr "什麼都沒有"
+msgstr "不調整（預設）"
 
-#: ../build/bin/conf_gen.h:404 ../build/bin/preferences_gen.h:6642
+#: ../build/bin/conf_gen.h:404 ../build/bin/preferences_gen.h:6354
 msgctxt "preferences"
 msgid "memory size"
-msgstr "記憶體大小"
+msgstr "記憶體容量"
 
-#: ../build/bin/conf_gen.h:405 ../build/bin/preferences_gen.h:6647
+#: ../build/bin/conf_gen.h:405 ../build/bin/preferences_gen.h:6359
 msgctxt "preferences"
 msgid "memory transfer"
-msgstr "記憶體移轉"
+msgstr "記憶體傳輸"
 
-#: ../build/bin/conf_gen.h:406 ../build/bin/preferences_gen.h:6652
+#: ../build/bin/conf_gen.h:406 ../build/bin/preferences_gen.h:6364
 msgctxt "preferences"
 msgid "memory size and transfer"
-msgstr "記憶體大小及移轉"
+msgstr "記憶體空間和傳輸"
 
 #: ../build/bin/conf_gen.h:414
 msgctxt "preferences"
 msgid "true"
-msgstr "是"
+msgstr "啟用"
 
 #: ../build/bin/conf_gen.h:415
 msgctxt "preferences"
 msgid "active module"
-msgstr "使用中模組"
+msgstr "使用中的模組"
 
 #: ../build/bin/conf_gen.h:416
 msgctxt "preferences"
 msgid "false"
-msgstr "否"
+msgstr "不啟用"
 
-#: ../build/bin/conf_gen.h:716 ../build/bin/preferences_gen.h:8902
-#: ../build/bin/preferences_gen.h:8926
+#: ../build/bin/conf_gen.h:716 ../build/bin/preferences_gen.h:8614
+#: ../build/bin/preferences_gen.h:8638
 msgctxt "preferences"
 msgid "id"
-msgstr "id"
+msgstr "識別碼"
 
-#: ../build/bin/conf_gen.h:717 ../build/bin/preferences_gen.h:8907
+#: ../build/bin/conf_gen.h:717 ../build/bin/preferences_gen.h:8619
 msgctxt "preferences"
 msgid "folder"
-msgstr "目錄"
+msgstr "資料夾"
 
 #: ../build/bin/conf_gen.h:731
 msgctxt "preferences"
@@ -214,7 +211,7 @@ msgstr "RGB"
 #: ../build/bin/conf_gen.h:732
 msgctxt "preferences"
 msgid "Lab"
-msgstr "Lab"
+msgstr "L*a*b*"
 
 #: ../build/bin/conf_gen.h:733
 msgctxt "preferences"
@@ -229,11 +226,11 @@ msgstr "HSL"
 #: ../build/bin/conf_gen.h:735
 msgctxt "preferences"
 msgid "Hex"
-msgstr "十六進位"
+msgstr "十六進位值"
 
 #: ../build/bin/conf_gen.h:736 ../build/bin/conf_gen.h:1834
 #: ../build/bin/conf_gen.h:2413 ../build/bin/conf_gen.h:2917
-#: ../build/bin/preferences_gen.h:6078 ../build/bin/preferences_gen.h:7149
+#: ../build/bin/preferences_gen.h:5826 ../build/bin/preferences_gen.h:6861
 msgctxt "preferences"
 msgid "none"
 msgstr "無"
@@ -241,25 +238,25 @@ msgstr "無"
 #: ../build/bin/conf_gen.h:744
 msgctxt "preferences"
 msgid "mean"
-msgstr "平均值"
+msgstr "平均"
 
 #: ../build/bin/conf_gen.h:745
 msgctxt "preferences"
 msgid "min"
-msgstr "最小值"
+msgstr "最小"
 
 #: ../build/bin/conf_gen.h:746
 msgctxt "preferences"
 msgid "max"
-msgstr "最大值"
+msgstr "最大"
 
 #: ../build/bin/conf_gen.h:934
 msgid "select only new pictures"
-msgstr "僅選擇新照片"
+msgstr "只選取新的影像"
 
 #: ../build/bin/conf_gen.h:935
 msgid "only select images that have not already been imported"
-msgstr "僅選定尚未輸入的影像"
+msgstr "只選取尚未匯入過的影像"
 
 #: ../build/bin/conf_gen.h:940
 msgid "ignore JPEG images"
@@ -270,8 +267,8 @@ msgid ""
 "when having raw+JPEG images together in one directory it makes no sense to "
 "import both. with this flag one can ignore all JPEGs found."
 msgstr ""
-"在目錄中同時有 raw 和 JPEG 格式時，兩者都輸入是沒有意義的。此選項可忽略發現的"
-"所有 JPEG 檔。"
+"忽略所有的 JPEG 檔案，不會顯示在檔案列表上\n"
+"因為資料夾內若同時有 RAW + JPEG 時，同時匯入兩個檔案是沒有意義的"
 
 #: ../build/bin/conf_gen.h:946
 msgid "apply metadata"
@@ -279,65 +276,65 @@ msgstr "套用詮釋資料"
 
 #: ../build/bin/conf_gen.h:947
 msgid "apply some metadata to all newly imported images."
-msgstr "對所有新輸入的影像套用詮釋資料。"
+msgstr "套用詮釋資料到所有新匯入的影像"
 
 #: ../build/bin/conf_gen.h:952
 msgid "recursive directory"
-msgstr "遞歸目錄"
+msgstr "搜尋子資料夾"
 
 #: ../build/bin/conf_gen.h:953
 msgid "recursive directory traversal when importing filmrolls"
-msgstr "輸入軟片捲時遞歸式走訪目錄"
+msgstr "匯入時包含下層子資料夾內的影像"
 
 #: ../build/bin/conf_gen.h:958
 msgid "creator to be applied when importing"
-msgstr "輸入影像時套用作者資訊"
+msgstr "匯入時同步設定創作者"
 
 #: ../build/bin/conf_gen.h:964
 msgid "publisher to be applied when importing"
-msgstr "輸入影像時套用的發行者資訊"
+msgstr "匯入時同步設定發布者"
 
 #: ../build/bin/conf_gen.h:970
 msgid "rights to be applied when importing"
-msgstr "輸入影像時套用的版權資訊"
+msgstr "匯入時同步設定版權"
 
 #: ../build/bin/conf_gen.h:976
 msgid "comma separated tags to be applied when importing"
-msgstr "輸入影像時套用標籤資訊(逗號分隔)"
+msgstr "匯入時同步設定標籤"
 
 #: ../build/bin/conf_gen.h:982
 msgid "import tags from xmp"
-msgstr "從 xmp 輸入標籤資訊"
+msgstr "從 XMP 匯入標籤"
 
 #: ../build/bin/conf_gen.h:1008
 msgid "initial rating"
-msgstr "初始評分"
+msgstr "預設評分"
 
 #: ../build/bin/conf_gen.h:1009
 msgid "initial star rating for all images when importing a filmroll"
-msgstr "輸入一個軟片捲時對所有影像的初始星等"
+msgstr "所有影像匯入的預設評分（星級）"
 
 #: ../build/bin/conf_gen.h:1014
 msgid "ignore EXIF rating"
-msgstr "忽略EXIF評分"
+msgstr "忽略 EXIF 的評分"
 
 #: ../build/bin/conf_gen.h:1015
 msgid ""
 "ignore EXIF rating. if not set and EXIF rating is found, it overrides "
 "'initial rating'"
-msgstr "忽略EXIF評分。如果沒設定而且有EXIF評分，則覆蓋初始評分"
+msgstr "如未勾選且 EXIF 內有評分資料，會以 EXIF 的評分取代預設評分設定"
 
 #: ../build/bin/conf_gen.h:1020
 msgid "import job"
-msgstr "輸入任務"
+msgstr "匯入作業"
 
 #: ../build/bin/conf_gen.h:1021
 msgid "name of the import job"
-msgstr "輸入任務名稱"
+msgstr "匯入作業的名稱"
 
 #: ../build/bin/conf_gen.h:1026
 msgid "override today's date"
-msgstr "覆蓋本日日期"
+msgstr "替換為今天的日期"
 
 #: ../build/bin/conf_gen.h:1027
 msgid ""
@@ -346,183 +343,183 @@ msgid ""
 "$(YEAR), $(MONTH), $(DAY), $(HOUR), $(MINUTE), $(SECONDS), $(MSEC).\n"
 "let the field empty otherwise"
 msgstr ""
-"以 YYYY:MM:DD[ hh:mm:ss[.sss]]格式，輸入日期，如果要覆寫現有的日期/時間，當展"
-"開變數時使用:\n"
-"$(YEAR), $(MONTH), $(DAY), $(HOUR), $(MINUTE), $(SECONDS), $(MSEC).\n"
-"否則此欄位留白"
+"如果要替換為指定的日期和時間，格式如下：YYYY-MM-DD[hh:mm:ss[.sss]]\n"
+"依序為「年：月：日[時：分：秒[毫秒]]"
+"如不更動則讓欄位留空"
 
 #: ../build/bin/conf_gen.h:1032
 msgid "keep this window open"
-msgstr "保持視窗打開"
+msgstr "保持視窗開啟"
 
 #: ../build/bin/conf_gen.h:1033
 msgid "keep this window open to run several imports"
-msgstr "保持視窗打開以執行多次輸入"
+msgstr "讓視窗保持開啟狀態以執行多個匯入作業"
 
 #: ../build/bin/conf_gen.h:1190 ../build/bin/conf_gen.h:1206
-#: ../build/bin/preferences_gen.h:4364 ../build/bin/preferences_gen.h:4459
+#: ../build/bin/preferences_gen.h:4242 ../build/bin/preferences_gen.h:4337
 msgctxt "preferences"
 msgid "VGA"
-msgstr "VGA"
+msgstr "VGA (480P - 640x480)"
 
 #: ../build/bin/conf_gen.h:1191 ../build/bin/conf_gen.h:1207
-#: ../build/bin/preferences_gen.h:4369 ../build/bin/preferences_gen.h:4464
-#: ../build/bin/preferences_gen.h:4508
+#: ../build/bin/preferences_gen.h:4247 ../build/bin/preferences_gen.h:4342
+#: ../build/bin/preferences_gen.h:4386
 msgctxt "preferences"
 msgid "720p"
-msgstr "720p"
+msgstr "HD (720p - 1280x720)"
 
 #: ../build/bin/conf_gen.h:1192 ../build/bin/conf_gen.h:1208
-#: ../build/bin/preferences_gen.h:4374 ../build/bin/preferences_gen.h:4469
+#: ../build/bin/preferences_gen.h:4252 ../build/bin/preferences_gen.h:4347
 msgctxt "preferences"
 msgid "1080p"
-msgstr "1080p"
+msgstr "FHD (1080p - 1920x1080)"
 
 #: ../build/bin/conf_gen.h:1193 ../build/bin/conf_gen.h:1209
-#: ../build/bin/preferences_gen.h:4379 ../build/bin/preferences_gen.h:4474
+#: ../build/bin/preferences_gen.h:4257 ../build/bin/preferences_gen.h:4352
 msgctxt "preferences"
 msgid "WQXGA"
-msgstr "WQXGA"
+msgstr "WQXGA (2560x1600)"
 
 #: ../build/bin/conf_gen.h:1194 ../build/bin/conf_gen.h:1210
-#: ../build/bin/preferences_gen.h:4384 ../build/bin/preferences_gen.h:4479
+#: ../build/bin/preferences_gen.h:4262 ../build/bin/preferences_gen.h:4357
 msgctxt "preferences"
 msgid "4K"
-msgstr "4K"
+msgstr "4K UHD (3840×2160)"
 
 #: ../build/bin/conf_gen.h:1195 ../build/bin/conf_gen.h:1211
-#: ../build/bin/preferences_gen.h:4389 ../build/bin/preferences_gen.h:4484
+#: ../build/bin/preferences_gen.h:4267 ../build/bin/preferences_gen.h:4362
 msgctxt "preferences"
 msgid "5K"
-msgstr "5K"
+msgstr "5K (5120x2880)"
 
-#: ../build/bin/conf_gen.h:1238 ../build/bin/preferences_gen.h:4699
-#: ../build/bin/preferences_gen.h:4743
+#: ../build/bin/conf_gen.h:1238 ../build/bin/preferences_gen.h:4577
+#: ../build/bin/preferences_gen.h:4621
 msgctxt "preferences"
 msgid "off"
-msgstr "關"
+msgstr "關閉"
 
-#: ../build/bin/conf_gen.h:1239 ../build/bin/preferences_gen.h:4704
+#: ../build/bin/conf_gen.h:1239 ../build/bin/preferences_gen.h:4582
 msgctxt "preferences"
 msgid "hardness (relative)"
-msgstr "硬度 (相對值)"
+msgstr "硬度（相對值）"
 
-#: ../build/bin/conf_gen.h:1240 ../build/bin/preferences_gen.h:4709
+#: ../build/bin/conf_gen.h:1240 ../build/bin/preferences_gen.h:4587
 msgctxt "preferences"
 msgid "hardness (absolute)"
-msgstr "硬度 (絕對值)"
+msgstr "硬度（絕對值）"
 
-#: ../build/bin/conf_gen.h:1241 ../build/bin/preferences_gen.h:4714
+#: ../build/bin/conf_gen.h:1241 ../build/bin/preferences_gen.h:4592
 msgctxt "preferences"
 msgid "opacity (relative)"
-msgstr "不透明度 (相對值)"
+msgstr "透明度（相對值）"
 
-#: ../build/bin/conf_gen.h:1242 ../build/bin/preferences_gen.h:4719
+#: ../build/bin/conf_gen.h:1242 ../build/bin/preferences_gen.h:4597
 msgctxt "preferences"
 msgid "opacity (absolute)"
-msgstr "不透明度 (絕對值)"
+msgstr "透明度（絕對值）"
 
-#: ../build/bin/conf_gen.h:1243 ../build/bin/preferences_gen.h:4724
+#: ../build/bin/conf_gen.h:1243 ../build/bin/preferences_gen.h:4602
 msgctxt "preferences"
 msgid "brush size (relative)"
-msgstr "筆刷大小 (相對值)"
+msgstr "筆刷尺寸（相對值）"
 
-#: ../build/bin/conf_gen.h:1251 ../build/bin/preferences_gen.h:4779
+#: ../build/bin/conf_gen.h:1251 ../build/bin/preferences_gen.h:4657
 msgctxt "preferences"
 msgid "low"
 msgstr "低"
 
-#: ../build/bin/conf_gen.h:1252 ../build/bin/preferences_gen.h:4784
-#: ../build/bin/preferences_gen.h:4808
+#: ../build/bin/conf_gen.h:1252 ../build/bin/preferences_gen.h:4662
+#: ../build/bin/preferences_gen.h:4686
 msgctxt "preferences"
 msgid "medium"
 msgstr "中"
 
-#: ../build/bin/conf_gen.h:1253 ../build/bin/preferences_gen.h:4789
+#: ../build/bin/conf_gen.h:1253 ../build/bin/preferences_gen.h:4667
 msgctxt "preferences"
 msgid "high"
 msgstr "高"
 
-#: ../build/bin/conf_gen.h:1267 ../build/bin/preferences_gen.h:5257
-#: ../build/bin/preferences_gen.h:5281
+#: ../build/bin/conf_gen.h:1267 ../build/bin/preferences_gen.h:5135
+#: ../build/bin/preferences_gen.h:5159
 msgctxt "preferences"
 msgid "false color"
-msgstr "僞色"
+msgstr "偽色"
 
-#: ../build/bin/conf_gen.h:1268 ../build/bin/preferences_gen.h:5262
+#: ../build/bin/conf_gen.h:1268 ../build/bin/preferences_gen.h:5140
 msgctxt "preferences"
 msgid "grayscale"
-msgstr "灰度"
+msgstr "灰階"
 
-#: ../build/bin/conf_gen.h:1282 ../build/bin/preferences_gen.h:4923
+#: ../build/bin/conf_gen.h:1282 ../build/bin/preferences_gen.h:4801
 msgctxt "preferences"
 msgid "top left"
 msgstr "左上"
 
-#: ../build/bin/conf_gen.h:1283 ../build/bin/preferences_gen.h:4928
+#: ../build/bin/conf_gen.h:1283 ../build/bin/preferences_gen.h:4806
 msgctxt "preferences"
 msgid "top right"
 msgstr "右上"
 
-#: ../build/bin/conf_gen.h:1284 ../build/bin/preferences_gen.h:4933
+#: ../build/bin/conf_gen.h:1284 ../build/bin/preferences_gen.h:4811
 msgctxt "preferences"
 msgid "top center"
-msgstr "上中"
+msgstr "中上"
 
-#: ../build/bin/conf_gen.h:1285 ../build/bin/preferences_gen.h:4938
-#: ../build/bin/preferences_gen.h:4962
+#: ../build/bin/conf_gen.h:1285 ../build/bin/preferences_gen.h:4816
+#: ../build/bin/preferences_gen.h:4840
 msgctxt "preferences"
 msgid "bottom"
-msgstr "底部"
+msgstr "下方"
 
-#: ../build/bin/conf_gen.h:1286 ../build/bin/preferences_gen.h:4943
+#: ../build/bin/conf_gen.h:1286 ../build/bin/preferences_gen.h:4821
 msgctxt "preferences"
 msgid "hidden"
 msgstr "隱藏"
 
 #: ../build/bin/conf_gen.h:1796
 msgid "show OSD"
-msgstr "顯示螢幕顯示設定(OSD)"
+msgstr "顯示地圖控制鈕"
 
 #: ../build/bin/conf_gen.h:1797
 msgid "toggle the visibility of the map overlays"
-msgstr "切換地圖疊加層的能見性"
+msgstr "控制是否在地圖的左上角顯示地圖控制鈕"
 
 #: ../build/bin/conf_gen.h:1802 ../src/libs/map_settings.c:147
 msgid "filtered images"
-msgstr "已過濾影像"
+msgstr "篩選影像"
 
 #: ../build/bin/conf_gen.h:1803
 msgid "when set limit the images drawn to the current filmstrip"
-msgstr "當設定限制目前軟片捲內的影像"
+msgstr ""
+"啟用時僅在地圖上顯示符合目前篩選條件的影像，未勾選時顯示所有已匯入的影像"
 
 #: ../build/bin/conf_gen.h:1810
 msgid "max images"
-msgstr "最大影像數"
+msgstr "最多影像數量"
 
 #: ../build/bin/conf_gen.h:1811
 msgid "the maximum number of image thumbnails drawn on the map"
-msgstr "在地圖上顯示影像縮圖的最大數量"
+msgstr "地圖上顯示的縮圖數量上限"
 
 #: ../build/bin/conf_gen.h:1818
 msgid "group size factor"
-msgstr "分組大小因子"
+msgstr "群組縮放比例"
 
 #: ../build/bin/conf_gen.h:1819
 msgid ""
 "increase or decrease the spatial size of images groups on the map. can "
 "influence the calculation time"
-msgstr "增加/減少影像分組在地圖上的空間大小。此選項會影響計算所需時間"
+msgstr "調整群組影像顯示的大小"
 
 #: ../build/bin/conf_gen.h:1826
 msgid "min images per group"
-msgstr "每群最小影像數"
+msgstr "群組最少影像數"
 
 #: ../build/bin/conf_gen.h:1827
 msgid ""
 "the minimum number of images to set up an images group. can influence the "
 "calculation time."
-msgstr "可爲一群的最小影像數。此選項會影響計算所需時間。"
+msgstr "單一影像群組包含的最少影像數量"
 
 #: ../build/bin/conf_gen.h:1832
 msgctxt "preferences"
@@ -532,7 +529,7 @@ msgstr "縮圖"
 #: ../build/bin/conf_gen.h:1833
 msgctxt "preferences"
 msgid "count"
-msgstr "計數"
+msgstr "數量"
 
 #: ../build/bin/conf_gen.h:1836 ../src/libs/map_settings.c:160
 msgid "thumbnail display"
@@ -542,92 +539,86 @@ msgstr "縮圖顯示"
 msgid ""
 "three options are available: images thumbnails, only the count of images of "
 "the group or nothing"
-msgstr "三種選擇可選: 影像縮圖、分組內影像數或不顯示"
+msgstr "選擇縮圖的顯示方式"
 
 #: ../build/bin/conf_gen.h:1848
 msgid "max polygon points"
-msgstr "最大多邊形節點數"
+msgstr "最高多邊形點數"
 
 #: ../build/bin/conf_gen.h:1849
 msgid ""
 "limit the number of points imported with polygon in find location module"
-msgstr "限制地點尋找模組中輸入多邊形時最大的節點數"
+msgstr "限制顯示的多邊形點數以獲取較高效能"
 
-#: ../build/bin/conf_gen.h:2109 ../build/bin/preferences_gen.h:5078
+#: ../build/bin/conf_gen.h:2109 ../build/bin/preferences_gen.h:4956
 msgctxt "preferences"
 msgid "always bilinear (fast)"
-msgstr "總是雙線性(快速)"
+msgstr "總是使用雙線性（快速）"
 
-#: ../build/bin/conf_gen.h:2110 ../build/bin/preferences_gen.h:5083
-#: ../build/bin/preferences_gen.h:5107
-msgctxt "preferences"
-msgid "at most RCD (reasonable)"
-msgstr "最多使用 RCD(合理的)"
-
-#: ../build/bin/conf_gen.h:2111 ../build/bin/preferences_gen.h:5088
+#: ../build/bin/conf_gen.h:2111 ../build/bin/preferences_gen.h:4966
 msgctxt "preferences"
 msgid "full (possibly slow)"
-msgstr "全部(可能較慢)"
+msgstr "完整算法（可能較慢）"
 
-#: ../build/bin/conf_gen.h:2119 ../build/bin/preferences_gen.h:5143
-#: ../build/bin/preferences_gen.h:5177
+#: ../build/bin/conf_gen.h:2119 ../build/bin/preferences_gen.h:5021
+#: ../build/bin/preferences_gen.h:5055
 msgctxt "preferences"
 msgid "original"
-msgstr "原始"
+msgstr "完整解析度"
 
-#: ../build/bin/conf_gen.h:2120 ../build/bin/preferences_gen.h:5148
+#: ../build/bin/conf_gen.h:2120 ../build/bin/preferences_gen.h:5026
 msgctxt "preferences"
 msgid "to 1/2"
-msgstr "至 1/2"
+msgstr "降至 1/2"
 
-#: ../build/bin/conf_gen.h:2121 ../build/bin/preferences_gen.h:5153
+#: ../build/bin/conf_gen.h:2121 ../build/bin/preferences_gen.h:5031
 msgctxt "preferences"
 msgid "to 1/3"
-msgstr "至 1/3"
+msgstr "降至 1/3"
 
-#: ../build/bin/conf_gen.h:2122 ../build/bin/preferences_gen.h:5158
+#: ../build/bin/conf_gen.h:2122 ../build/bin/preferences_gen.h:5036
 msgctxt "preferences"
 msgid "to 1/4"
-msgstr "至 1/4"
+msgstr "降至 1/4"
 
 #: ../build/bin/conf_gen.h:2136 ../build/bin/conf_gen.h:2146
-#: ../build/bin/preferences_gen.h:5890 ../build/bin/preferences_gen.h:5955
+#: ../build/bin/preferences_gen.h:5638 ../build/bin/preferences_gen.h:5703
 msgctxt "preferences"
 msgid "bilinear"
-msgstr "雙線性"
+msgstr "雙線性 bilinear"
 
 #: ../build/bin/conf_gen.h:2137 ../build/bin/conf_gen.h:2147
-#: ../build/bin/preferences_gen.h:5895 ../build/bin/preferences_gen.h:5919
-#: ../build/bin/preferences_gen.h:5960
+#: ../build/bin/preferences_gen.h:5643 ../build/bin/preferences_gen.h:5667
+#: ../build/bin/preferences_gen.h:5708
 msgctxt "preferences"
 msgid "bicubic"
-msgstr "雙立方"
+msgstr "雙三次 bicubic"
 
 #: ../build/bin/conf_gen.h:2138 ../build/bin/conf_gen.h:2148
-#: ../build/bin/preferences_gen.h:5900 ../build/bin/preferences_gen.h:5965
+#: ../build/bin/preferences_gen.h:5648 ../build/bin/preferences_gen.h:5713
 msgctxt "preferences"
 msgid "lanczos2"
 msgstr "lanczos2"
 
-#: ../build/bin/conf_gen.h:2149 ../build/bin/preferences_gen.h:5970
-#: ../build/bin/preferences_gen.h:5989
+#: ../build/bin/conf_gen.h:2149 ../build/bin/preferences_gen.h:5718
+#: ../build/bin/preferences_gen.h:5737
 msgctxt "preferences"
 msgid "lanczos3"
 msgstr "lanczos3"
 
-#: ../build/bin/conf_gen.h:2412 ../build/bin/conf_gen.h:3105
-#: ../build/bin/preferences_gen.h:5678 ../build/bin/preferences_gen.h:7144
-#: ../build/bin/preferences_gen.h:7180
+#: ../build/bin/conf_gen.h:2412 ../build/bin/conf_gen.h:3099
+#: ../build/bin/preferences_gen.h:5426 ../build/bin/preferences_gen.h:6856
+#: ../build/bin/preferences_gen.h:6892
 msgctxt "preferences"
 msgid "auto"
 msgstr "自動"
 
-#: ../build/bin/conf_gen.h:2414 ../build/bin/preferences_gen.h:7154
+#: ../build/bin/conf_gen.h:2414 ../build/bin/preferences_gen.h:6866
 msgctxt "preferences"
 msgid "libsecret"
 msgstr "libsecret"
 
-#: ../build/bin/conf_gen.h:2415 ../build/bin/preferences_gen.h:7160
+#: ../build/bin/conf_gen.h:2415 ../build/bin/preferences_gen.h:6872
 msgctxt "preferences"
 msgid "kwallet"
 msgstr "kwallet"
@@ -640,38 +631,38 @@ msgstr "直方圖"
 #: ../build/bin/conf_gen.h:2618
 msgctxt "preferences"
 msgid "waveform"
-msgstr "波形"
+msgstr "波形圖"
 
 #: ../build/bin/conf_gen.h:2619
 msgctxt "preferences"
 msgid "rgb parade"
-msgstr "rgb色彩檢視"
+msgstr "RGB 並列波形圖"
 
 #: ../build/bin/conf_gen.h:2620
 msgctxt "preferences"
 msgid "vectorscope"
-msgstr "向量示波器"
+msgstr "彩度投影圖"
 
-#: ../build/bin/conf_gen.h:2628 ../build/bin/preferences_gen.h:7918
+#: ../build/bin/conf_gen.h:2628 ../build/bin/preferences_gen.h:7630
 msgctxt "preferences"
 msgid "left"
-msgstr "左"
+msgstr "左側欄"
 
-#: ../build/bin/conf_gen.h:2629 ../build/bin/preferences_gen.h:7923
-#: ../build/bin/preferences_gen.h:7942
+#: ../build/bin/conf_gen.h:2629 ../build/bin/preferences_gen.h:7635
+#: ../build/bin/preferences_gen.h:7654
 msgctxt "preferences"
 msgid "right"
-msgstr "右"
+msgstr "右側欄"
 
 #: ../build/bin/conf_gen.h:2637 ../build/bin/conf_gen.h:2673
 msgctxt "preferences"
 msgid "logarithmic"
-msgstr "對數"
+msgstr "對數（感知）"
 
 #: ../build/bin/conf_gen.h:2638 ../build/bin/conf_gen.h:2674
 msgctxt "preferences"
 msgid "linear"
-msgstr "線性"
+msgstr "線性（強度）"
 
 #: ../build/bin/conf_gen.h:2646
 msgctxt "preferences"
@@ -686,377 +677,380 @@ msgstr "垂直"
 #: ../build/bin/conf_gen.h:2655
 msgctxt "preferences"
 msgid "overlaid"
-msgstr "疊加層"
+msgstr "覆蓋"
 
 #: ../build/bin/conf_gen.h:2656
 msgctxt "preferences"
 msgid "parade"
-msgstr "色彩檢視"
+msgstr "並列"
 
 #: ../build/bin/conf_gen.h:2664
 msgctxt "preferences"
 msgid "u*v*"
-msgstr "u*v*"
+msgstr "CIELUV 色彩空間"
 
 #: ../build/bin/conf_gen.h:2665
 msgctxt "preferences"
 msgid "AzBz"
-msgstr "AzBz"
+msgstr "JzAzBz 色彩空間"
 
 #: ../build/bin/conf_gen.h:2830
 msgctxt "preferences"
 msgid "mm"
-msgstr "毫米"
+msgstr "公釐 mm"
 
 #: ../build/bin/conf_gen.h:2831
 msgctxt "preferences"
 msgid "cm"
-msgstr "釐米"
+msgstr "公分 cm"
 
 #: ../build/bin/conf_gen.h:2832
 msgctxt "preferences"
 msgid "inch"
-msgstr "英寸"
+msgstr "英寸 inch"
 
-#: ../build/bin/conf_gen.h:2877 ../build/bin/preferences_gen.h:7978
-#: ../build/bin/preferences_gen.h:8007
+#: ../build/bin/conf_gen.h:2877 ../build/bin/preferences_gen.h:7690
+#: ../build/bin/preferences_gen.h:7719
 msgctxt "preferences"
 msgid "all"
 msgstr "全部"
 
-#: ../build/bin/conf_gen.h:2878 ../build/bin/preferences_gen.h:7983
+#: ../build/bin/conf_gen.h:2878 ../build/bin/preferences_gen.h:7695
 msgctxt "preferences"
 msgid "xatom"
 msgstr "xatom"
 
-#: ../build/bin/conf_gen.h:2879 ../build/bin/preferences_gen.h:7988
+#: ../build/bin/conf_gen.h:2879 ../build/bin/preferences_gen.h:7700
 msgctxt "preferences"
 msgid "colord"
 msgstr "colord"
 
-#: ../build/bin/conf_gen.h:2915 ../build/bin/preferences_gen.h:6068
-#: ../build/bin/preferences_gen.h:6097
+#: ../build/bin/conf_gen.h:2915 ../build/bin/preferences_gen.h:5816
+#: ../build/bin/preferences_gen.h:5845
 msgctxt "preferences"
 msgid "scene-referred"
-msgstr "場景工作流程"
+msgstr "場景參照"
 
-#: ../build/bin/conf_gen.h:2916 ../build/bin/preferences_gen.h:6073
+#: ../build/bin/conf_gen.h:2916 ../build/bin/preferences_gen.h:5821
 msgctxt "preferences"
 msgid "display-referred"
-msgstr "顯示工作流程"
+msgstr "顯示參照"
 
-#: ../build/bin/conf_gen.h:2925 ../build/bin/preferences_gen.h:6133
+#: ../build/bin/conf_gen.h:2925 ../build/bin/preferences_gen.h:5881
 msgctxt "preferences"
 msgid "modern"
 msgstr "現代"
 
-#: ../build/bin/conf_gen.h:2926 ../build/bin/preferences_gen.h:6138
-#: ../build/bin/preferences_gen.h:6157
+#: ../build/bin/conf_gen.h:2926 ../build/bin/preferences_gen.h:5886
+#: ../build/bin/preferences_gen.h:5905
 msgctxt "preferences"
 msgid "legacy"
 msgstr "傳統"
 
-#: ../build/bin/conf_gen.h:3032
+#: ../build/bin/conf_gen.h:3026
 msgid "camera time zone"
 msgstr "相機時區"
 
-#: ../build/bin/conf_gen.h:3033
+#: ../build/bin/conf_gen.h:3027
 msgid ""
 "most cameras don't store the time zone in EXIF. give the correct time zone "
 "so the GPX data can be correctly matched"
 msgstr ""
-"大多數相機不在 exif 檔案中儲存時區。指定正確的時區以便得到正確的 GPX資料"
+"大多數的相機不會在 EXIF 裡儲存時區資料，指定正確的時區以便 GPX 資料與實際相符"
 
-#: ../build/bin/conf_gen.h:3044 ../build/bin/preferences_gen.h:5533
-#: ../build/bin/preferences_gen.h:5562
+#: ../build/bin/conf_gen.h:3038
 msgctxt "preferences"
 msgid "no color"
-msgstr "無色"
+msgstr "沒有顏色"
 
-#: ../build/bin/conf_gen.h:3045 ../build/bin/preferences_gen.h:5538
+#: ../build/bin/conf_gen.h:3039
 msgctxt "preferences"
 msgid "illuminant color"
-msgstr "照明顏色"
+msgstr "光源顏色"
 
-#: ../build/bin/conf_gen.h:3046 ../build/bin/preferences_gen.h:5543
+#: ../build/bin/conf_gen.h:3040
 msgctxt "preferences"
 msgid "effect emulation"
 msgstr "效果模擬"
 
-#: ../build/bin/conf_gen.h:3092 ../build/bin/preferences_gen.h:5598
-#: ../build/bin/preferences_gen.h:5627
+#: ../build/bin/conf_gen.h:3086
 msgctxt "preferences"
 msgid "list"
-msgstr "列表"
+msgstr "垂直清單"
 
-#: ../build/bin/conf_gen.h:3093 ../build/bin/preferences_gen.h:5603
+#: ../build/bin/conf_gen.h:3087
 msgctxt "preferences"
 msgid "tabs"
-msgstr "分頁"
+msgstr "標籤切換"
 
-#: ../build/bin/conf_gen.h:3094 ../build/bin/preferences_gen.h:5608
+#: ../build/bin/conf_gen.h:3088
 msgctxt "preferences"
 msgid "columns"
-msgstr "行"
+msgstr "水平並列"
 
-#: ../build/bin/conf_gen.h:3103 ../build/bin/preferences_gen.h:5668
+#: ../build/bin/conf_gen.h:3097 ../build/bin/preferences_gen.h:5416
 msgctxt "preferences"
 msgid "active"
 msgstr "使用中"
 
-#: ../build/bin/conf_gen.h:3104 ../build/bin/preferences_gen.h:5673
+#: ../build/bin/conf_gen.h:3098 ../build/bin/preferences_gen.h:5421
 msgctxt "preferences"
 msgid "dim"
-msgstr "暗淡"
+msgstr "變暗"
 
-#: ../build/bin/conf_gen.h:3106 ../build/bin/preferences_gen.h:5683
+#: ../build/bin/conf_gen.h:3100 ../build/bin/preferences_gen.h:5431
 msgctxt "preferences"
 msgid "fade"
 msgstr "淡出"
 
-#: ../build/bin/conf_gen.h:3107 ../build/bin/preferences_gen.h:5688
+#: ../build/bin/conf_gen.h:3101 ../build/bin/preferences_gen.h:5436
 msgctxt "preferences"
 msgid "fit"
-msgstr "符合"
+msgstr "適合"
 
-#: ../build/bin/conf_gen.h:3108 ../build/bin/preferences_gen.h:5693
+#: ../build/bin/conf_gen.h:3102 ../build/bin/preferences_gen.h:5441
 msgctxt "preferences"
 msgid "smooth"
-msgstr "平滑"
+msgstr "滑順"
 
-#: ../build/bin/conf_gen.h:3109 ../build/bin/preferences_gen.h:5698
+#: ../build/bin/conf_gen.h:3103 ../build/bin/preferences_gen.h:5446
 msgctxt "preferences"
 msgid "glide"
 msgstr "滑動"
 
-#: ../build/bin/preferences_gen.h:81 ../build/bin/preferences_gen.h:4080
-#: ../build/bin/preferences_gen.h:4116 ../build/bin/preferences_gen.h:4152
-#: ../build/bin/preferences_gen.h:4188 ../build/bin/preferences_gen.h:4224
-#: ../build/bin/preferences_gen.h:4260 ../build/bin/preferences_gen.h:4296
-#: ../build/bin/preferences_gen.h:4340 ../build/bin/preferences_gen.h:4435
-#: ../build/bin/preferences_gen.h:4530 ../build/bin/preferences_gen.h:4570
-#: ../build/bin/preferences_gen.h:4613 ../build/bin/preferences_gen.h:4685
-#: ../build/bin/preferences_gen.h:4765 ../build/bin/preferences_gen.h:4830
-#: ../build/bin/preferences_gen.h:4866 ../build/bin/preferences_gen.h:4909
-#: ../build/bin/preferences_gen.h:4983 ../build/bin/preferences_gen.h:5028
-#: ../build/bin/preferences_gen.h:5064 ../build/bin/preferences_gen.h:5129
-#: ../build/bin/preferences_gen.h:5199 ../build/bin/preferences_gen.h:5243
-#: ../build/bin/preferences_gen.h:5303 ../build/bin/preferences_gen.h:5339
-#: ../build/bin/preferences_gen.h:5375 ../build/bin/preferences_gen.h:5411
-#: ../build/bin/preferences_gen.h:5447 ../build/bin/preferences_gen.h:5483
-#: ../build/bin/preferences_gen.h:5519 ../build/bin/preferences_gen.h:5584
-#: ../build/bin/preferences_gen.h:5649 ../build/bin/preferences_gen.h:5739
-#: ../build/bin/preferences_gen.h:5775 ../build/bin/preferences_gen.h:5840
-#: ../build/bin/preferences_gen.h:5876 ../build/bin/preferences_gen.h:5941
-#: ../build/bin/preferences_gen.h:6011 ../build/bin/preferences_gen.h:6054
-#: ../build/bin/preferences_gen.h:6119 ../build/bin/preferences_gen.h:6179
-#: ../build/bin/preferences_gen.h:6215 ../build/bin/preferences_gen.h:6251
-#: ../build/bin/preferences_gen.h:6287 ../build/bin/preferences_gen.h:6331
-#: ../build/bin/preferences_gen.h:6402 ../build/bin/preferences_gen.h:6438
-#: ../build/bin/preferences_gen.h:6474 ../build/bin/preferences_gen.h:6510
-#: ../build/bin/preferences_gen.h:6552 ../build/bin/preferences_gen.h:6623
-#: ../build/bin/preferences_gen.h:6728 ../build/bin/preferences_gen.h:6764
-#: ../build/bin/preferences_gen.h:6800 ../build/bin/preferences_gen.h:6836
-#: ../build/bin/preferences_gen.h:6872 ../build/bin/preferences_gen.h:6908
-#: ../build/bin/preferences_gen.h:6944 ../build/bin/preferences_gen.h:6980
-#: ../build/bin/preferences_gen.h:7015 ../build/bin/preferences_gen.h:7050
-#: ../build/bin/preferences_gen.h:7086 ../build/bin/preferences_gen.h:7130
-#: ../build/bin/preferences_gen.h:7202 ../build/bin/preferences_gen.h:7271
-#: ../build/bin/preferences_gen.h:7356 ../build/bin/preferences_gen.h:7401
-#: ../build/bin/preferences_gen.h:7476 ../build/bin/preferences_gen.h:7529
-#: ../build/bin/preferences_gen.h:7594 ../build/bin/preferences_gen.h:7659
-#: ../build/bin/preferences_gen.h:7724 ../build/bin/preferences_gen.h:7760
-#: ../build/bin/preferences_gen.h:7796 ../build/bin/preferences_gen.h:7832
-#: ../build/bin/preferences_gen.h:7868 ../build/bin/preferences_gen.h:7904
-#: ../build/bin/preferences_gen.h:7964 ../build/bin/preferences_gen.h:8029
-#: ../build/bin/preferences_gen.h:8083 ../build/bin/preferences_gen.h:8128
-#: ../build/bin/preferences_gen.h:8164 ../build/bin/preferences_gen.h:8200
-#: ../build/bin/preferences_gen.h:8236 ../build/bin/preferences_gen.h:8272
-#: ../build/bin/preferences_gen.h:8332 ../build/bin/preferences_gen.h:8376
-#: ../build/bin/preferences_gen.h:8420 ../build/bin/preferences_gen.h:8493
-#: ../build/bin/preferences_gen.h:8533 ../build/bin/preferences_gen.h:8573
-#: ../build/bin/preferences_gen.h:8609 ../build/bin/preferences_gen.h:8664
-#: ../build/bin/preferences_gen.h:8700 ../build/bin/preferences_gen.h:8760
-#: ../build/bin/preferences_gen.h:8806 ../build/bin/preferences_gen.h:8842
-#: ../build/bin/preferences_gen.h:8888 ../build/bin/preferences_gen.h:8948
-#: ../build/bin/preferences_gen.h:9000 ../build/bin/preferences_gen.h:9046
-#: ../build/bin/preferences_gen.h:9114 ../build/bin/preferences_gen.h:9161
+#: ../build/bin/preferences_gen.h:81 ../build/bin/preferences_gen.h:3958
+#: ../build/bin/preferences_gen.h:3994 ../build/bin/preferences_gen.h:4030
+#: ../build/bin/preferences_gen.h:4066 ../build/bin/preferences_gen.h:4102
+#: ../build/bin/preferences_gen.h:4138 ../build/bin/preferences_gen.h:4174
+#: ../build/bin/preferences_gen.h:4218 ../build/bin/preferences_gen.h:4313
+#: ../build/bin/preferences_gen.h:4408 ../build/bin/preferences_gen.h:4448
+#: ../build/bin/preferences_gen.h:4491 ../build/bin/preferences_gen.h:4563
+#: ../build/bin/preferences_gen.h:4643 ../build/bin/preferences_gen.h:4708
+#: ../build/bin/preferences_gen.h:4744 ../build/bin/preferences_gen.h:4787
+#: ../build/bin/preferences_gen.h:4861 ../build/bin/preferences_gen.h:4906
+#: ../build/bin/preferences_gen.h:4942 ../build/bin/preferences_gen.h:5007
+#: ../build/bin/preferences_gen.h:5077 ../build/bin/preferences_gen.h:5121
+#: ../build/bin/preferences_gen.h:5181 ../build/bin/preferences_gen.h:5217
+#: ../build/bin/preferences_gen.h:5253 ../build/bin/preferences_gen.h:5289
+#: ../build/bin/preferences_gen.h:5325 ../build/bin/preferences_gen.h:5361
+#: ../build/bin/preferences_gen.h:5397 ../build/bin/preferences_gen.h:5487
+#: ../build/bin/preferences_gen.h:5523 ../build/bin/preferences_gen.h:5588
+#: ../build/bin/preferences_gen.h:5624 ../build/bin/preferences_gen.h:5689
+#: ../build/bin/preferences_gen.h:5759 ../build/bin/preferences_gen.h:5802
+#: ../build/bin/preferences_gen.h:5867 ../build/bin/preferences_gen.h:5927
+#: ../build/bin/preferences_gen.h:5963 ../build/bin/preferences_gen.h:5999
+#: ../build/bin/preferences_gen.h:6043 ../build/bin/preferences_gen.h:6114
+#: ../build/bin/preferences_gen.h:6150 ../build/bin/preferences_gen.h:6186
+#: ../build/bin/preferences_gen.h:6222 ../build/bin/preferences_gen.h:6264
+#: ../build/bin/preferences_gen.h:6335 ../build/bin/preferences_gen.h:6440
+#: ../build/bin/preferences_gen.h:6476 ../build/bin/preferences_gen.h:6512
+#: ../build/bin/preferences_gen.h:6548 ../build/bin/preferences_gen.h:6584
+#: ../build/bin/preferences_gen.h:6620 ../build/bin/preferences_gen.h:6656
+#: ../build/bin/preferences_gen.h:6692 ../build/bin/preferences_gen.h:6727
+#: ../build/bin/preferences_gen.h:6762 ../build/bin/preferences_gen.h:6798
+#: ../build/bin/preferences_gen.h:6842 ../build/bin/preferences_gen.h:6914
+#: ../build/bin/preferences_gen.h:6983 ../build/bin/preferences_gen.h:7068
+#: ../build/bin/preferences_gen.h:7113 ../build/bin/preferences_gen.h:7188
+#: ../build/bin/preferences_gen.h:7241 ../build/bin/preferences_gen.h:7306
+#: ../build/bin/preferences_gen.h:7371 ../build/bin/preferences_gen.h:7436
+#: ../build/bin/preferences_gen.h:7472 ../build/bin/preferences_gen.h:7508
+#: ../build/bin/preferences_gen.h:7544 ../build/bin/preferences_gen.h:7580
+#: ../build/bin/preferences_gen.h:7616 ../build/bin/preferences_gen.h:7676
+#: ../build/bin/preferences_gen.h:7741 ../build/bin/preferences_gen.h:7795
+#: ../build/bin/preferences_gen.h:7840 ../build/bin/preferences_gen.h:7876
+#: ../build/bin/preferences_gen.h:7912 ../build/bin/preferences_gen.h:7948
+#: ../build/bin/preferences_gen.h:7984 ../build/bin/preferences_gen.h:8044
+#: ../build/bin/preferences_gen.h:8088 ../build/bin/preferences_gen.h:8132
+#: ../build/bin/preferences_gen.h:8205 ../build/bin/preferences_gen.h:8245
+#: ../build/bin/preferences_gen.h:8285 ../build/bin/preferences_gen.h:8321
+#: ../build/bin/preferences_gen.h:8376 ../build/bin/preferences_gen.h:8412
+#: ../build/bin/preferences_gen.h:8472 ../build/bin/preferences_gen.h:8518
+#: ../build/bin/preferences_gen.h:8554 ../build/bin/preferences_gen.h:8600
+#: ../build/bin/preferences_gen.h:8660 ../build/bin/preferences_gen.h:8712
+#: ../build/bin/preferences_gen.h:8758 ../build/bin/preferences_gen.h:8826
+#: ../build/bin/preferences_gen.h:8873
 msgid "this setting has been modified"
-msgstr "此設定已被更改"
+msgstr "設定已修改"
 
-#: ../build/bin/preferences_gen.h:4060 ../src/gui/gtk.c:1176
+#: ../build/bin/preferences_gen.h:3938 ../src/gui/gtk.c:1176
 #: ../src/gui/preferences.c:538 ../src/libs/tools/lighttable.c:68
 #: ../src/views/lighttable.c:91
 msgid "lighttable"
-msgstr "映繪桌"
+msgstr "燈箱 LightTable"
 
-#: ../build/bin/preferences_gen.h:4063 ../build/bin/preferences_gen.h:4668
-#: ../build/bin/preferences_gen.h:6711 ../src/gui/preferences.c:271
+#: ../build/bin/preferences_gen.h:3941 ../build/bin/preferences_gen.h:4546
+#: ../build/bin/preferences_gen.h:6423 ../src/gui/preferences.c:271
 msgid "general"
-msgstr "一般"
+msgstr "一般設定"
 
-#: ../build/bin/preferences_gen.h:4083
+#: ../build/bin/preferences_gen.h:3961
 msgid "hide built-in presets for utility modules"
-msgstr "隱藏工具模組的內建預設"
+msgstr "隱藏工具模組的內建預設集"
 
-#: ../build/bin/preferences_gen.h:4094 ../build/bin/preferences_gen.h:4130
-#: ../build/bin/preferences_gen.h:4166 ../build/bin/preferences_gen.h:4202
-#: ../build/bin/preferences_gen.h:4238 ../build/bin/preferences_gen.h:4274
-#: ../build/bin/preferences_gen.h:4310 ../build/bin/preferences_gen.h:4413
-#: ../build/bin/preferences_gen.h:4508 ../build/bin/preferences_gen.h:4548
-#: ../build/bin/preferences_gen.h:4591 ../build/bin/preferences_gen.h:4634
-#: ../build/bin/preferences_gen.h:4743 ../build/bin/preferences_gen.h:4808
-#: ../build/bin/preferences_gen.h:4844 ../build/bin/preferences_gen.h:4887
-#: ../build/bin/preferences_gen.h:4962 ../build/bin/preferences_gen.h:5042
-#: ../build/bin/preferences_gen.h:5107 ../build/bin/preferences_gen.h:5177
-#: ../build/bin/preferences_gen.h:5213 ../build/bin/preferences_gen.h:5281
-#: ../build/bin/preferences_gen.h:5317 ../build/bin/preferences_gen.h:5353
-#: ../build/bin/preferences_gen.h:5389 ../build/bin/preferences_gen.h:5425
-#: ../build/bin/preferences_gen.h:5461 ../build/bin/preferences_gen.h:5497
-#: ../build/bin/preferences_gen.h:5562 ../build/bin/preferences_gen.h:5627
-#: ../build/bin/preferences_gen.h:5717 ../build/bin/preferences_gen.h:5753
-#: ../build/bin/preferences_gen.h:5789 ../build/bin/preferences_gen.h:5854
-#: ../build/bin/preferences_gen.h:5919 ../build/bin/preferences_gen.h:5989
-#: ../build/bin/preferences_gen.h:6031 ../build/bin/preferences_gen.h:6097
-#: ../build/bin/preferences_gen.h:6157 ../build/bin/preferences_gen.h:6193
-#: ../build/bin/preferences_gen.h:6229 ../build/bin/preferences_gen.h:6265
-#: ../build/bin/preferences_gen.h:6301 ../build/bin/preferences_gen.h:6379
-#: ../build/bin/preferences_gen.h:6416 ../build/bin/preferences_gen.h:6452
-#: ../build/bin/preferences_gen.h:6488 ../build/bin/preferences_gen.h:6524
-#: ../build/bin/preferences_gen.h:6595 ../build/bin/preferences_gen.h:6671
-#: ../build/bin/preferences_gen.h:6742 ../build/bin/preferences_gen.h:6778
-#: ../build/bin/preferences_gen.h:6814 ../build/bin/preferences_gen.h:6850
-#: ../build/bin/preferences_gen.h:6886 ../build/bin/preferences_gen.h:6922
-#: ../build/bin/preferences_gen.h:6958 ../build/bin/preferences_gen.h:6994
-#: ../build/bin/preferences_gen.h:7029 ../build/bin/preferences_gen.h:7064
-#: ../build/bin/preferences_gen.h:7100 ../build/bin/preferences_gen.h:7180
-#: ../build/bin/preferences_gen.h:7220 ../build/bin/preferences_gen.h:7334
-#: ../build/bin/preferences_gen.h:7454 ../build/bin/preferences_gen.h:7572
-#: ../build/bin/preferences_gen.h:7637 ../build/bin/preferences_gen.h:7673
-#: ../build/bin/preferences_gen.h:7738 ../build/bin/preferences_gen.h:7774
-#: ../build/bin/preferences_gen.h:7810 ../build/bin/preferences_gen.h:7846
-#: ../build/bin/preferences_gen.h:7882 ../build/bin/preferences_gen.h:7942
-#: ../build/bin/preferences_gen.h:8007 ../build/bin/preferences_gen.h:8047
-#: ../build/bin/preferences_gen.h:8097 ../build/bin/preferences_gen.h:8142
-#: ../build/bin/preferences_gen.h:8178 ../build/bin/preferences_gen.h:8214
-#: ../build/bin/preferences_gen.h:8250 ../build/bin/preferences_gen.h:8310
-#: ../build/bin/preferences_gen.h:8346 ../build/bin/preferences_gen.h:8390
-#: ../build/bin/preferences_gen.h:8511 ../build/bin/preferences_gen.h:8551
-#: ../build/bin/preferences_gen.h:8587 ../build/bin/preferences_gen.h:8627
-#: ../build/bin/preferences_gen.h:8678 ../build/bin/preferences_gen.h:8738
-#: ../build/bin/preferences_gen.h:8820 ../build/bin/preferences_gen.h:8926
-#: ../build/bin/preferences_gen.h:8962 ../build/bin/preferences_gen.h:9060
-#: ../src/lua/preferences.c:682 ../src/lua/preferences.c:710
+#: ../build/bin/preferences_gen.h:3972 ../build/bin/preferences_gen.h:4008
+#: ../build/bin/preferences_gen.h:4044 ../build/bin/preferences_gen.h:4080
+#: ../build/bin/preferences_gen.h:4116 ../build/bin/preferences_gen.h:4152
+#: ../build/bin/preferences_gen.h:4188 ../build/bin/preferences_gen.h:4291
+#: ../build/bin/preferences_gen.h:4386 ../build/bin/preferences_gen.h:4426
+#: ../build/bin/preferences_gen.h:4469 ../build/bin/preferences_gen.h:4512
+#: ../build/bin/preferences_gen.h:4621 ../build/bin/preferences_gen.h:4686
+#: ../build/bin/preferences_gen.h:4722 ../build/bin/preferences_gen.h:4765
+#: ../build/bin/preferences_gen.h:4840 ../build/bin/preferences_gen.h:4920
+#: ../build/bin/preferences_gen.h:4985 ../build/bin/preferences_gen.h:5055
+#: ../build/bin/preferences_gen.h:5091 ../build/bin/preferences_gen.h:5159
+#: ../build/bin/preferences_gen.h:5195 ../build/bin/preferences_gen.h:5231
+#: ../build/bin/preferences_gen.h:5267 ../build/bin/preferences_gen.h:5303
+#: ../build/bin/preferences_gen.h:5339 ../build/bin/preferences_gen.h:5375
+#: ../build/bin/preferences_gen.h:5465 ../build/bin/preferences_gen.h:5501
+#: ../build/bin/preferences_gen.h:5537 ../build/bin/preferences_gen.h:5602
+#: ../build/bin/preferences_gen.h:5667 ../build/bin/preferences_gen.h:5737
+#: ../build/bin/preferences_gen.h:5779 ../build/bin/preferences_gen.h:5845
+#: ../build/bin/preferences_gen.h:5905 ../build/bin/preferences_gen.h:5941
+#: ../build/bin/preferences_gen.h:5977 ../build/bin/preferences_gen.h:6013
+#: ../build/bin/preferences_gen.h:6091 ../build/bin/preferences_gen.h:6128
+#: ../build/bin/preferences_gen.h:6164 ../build/bin/preferences_gen.h:6200
+#: ../build/bin/preferences_gen.h:6236 ../build/bin/preferences_gen.h:6307
+#: ../build/bin/preferences_gen.h:6383 ../build/bin/preferences_gen.h:6454
+#: ../build/bin/preferences_gen.h:6490 ../build/bin/preferences_gen.h:6526
+#: ../build/bin/preferences_gen.h:6562 ../build/bin/preferences_gen.h:6598
+#: ../build/bin/preferences_gen.h:6634 ../build/bin/preferences_gen.h:6670
+#: ../build/bin/preferences_gen.h:6706 ../build/bin/preferences_gen.h:6741
+#: ../build/bin/preferences_gen.h:6776 ../build/bin/preferences_gen.h:6812
+#: ../build/bin/preferences_gen.h:6892 ../build/bin/preferences_gen.h:6932
+#: ../build/bin/preferences_gen.h:7046 ../build/bin/preferences_gen.h:7166
+#: ../build/bin/preferences_gen.h:7284 ../build/bin/preferences_gen.h:7349
+#: ../build/bin/preferences_gen.h:7385 ../build/bin/preferences_gen.h:7450
+#: ../build/bin/preferences_gen.h:7486 ../build/bin/preferences_gen.h:7522
+#: ../build/bin/preferences_gen.h:7558 ../build/bin/preferences_gen.h:7594
+#: ../build/bin/preferences_gen.h:7654 ../build/bin/preferences_gen.h:7719
+#: ../build/bin/preferences_gen.h:7759 ../build/bin/preferences_gen.h:7809
+#: ../build/bin/preferences_gen.h:7854 ../build/bin/preferences_gen.h:7890
+#: ../build/bin/preferences_gen.h:7926 ../build/bin/preferences_gen.h:7962
+#: ../build/bin/preferences_gen.h:8022 ../build/bin/preferences_gen.h:8058
+#: ../build/bin/preferences_gen.h:8102 ../build/bin/preferences_gen.h:8223
+#: ../build/bin/preferences_gen.h:8263 ../build/bin/preferences_gen.h:8299
+#: ../build/bin/preferences_gen.h:8339 ../build/bin/preferences_gen.h:8390
+#: ../build/bin/preferences_gen.h:8450 ../build/bin/preferences_gen.h:8532
+#: ../build/bin/preferences_gen.h:8638 ../build/bin/preferences_gen.h:8674
+#: ../build/bin/preferences_gen.h:8772 ../src/lua/preferences.c:682
+#: ../src/lua/preferences.c:710
 #, c-format
 msgid "double click to reset to `%s'"
-msgstr "雙擊以重置到“%s”"
+msgstr "雙擊以重設回「%s」"
 
-#: ../build/bin/preferences_gen.h:4094 ../build/bin/preferences_gen.h:4130
-#: ../build/bin/preferences_gen.h:4166 ../build/bin/preferences_gen.h:4202
-#: ../build/bin/preferences_gen.h:4238 ../build/bin/preferences_gen.h:4310
-#: ../build/bin/preferences_gen.h:4844 ../build/bin/preferences_gen.h:5042
-#: ../build/bin/preferences_gen.h:5317 ../build/bin/preferences_gen.h:5461
-#: ../build/bin/preferences_gen.h:5789 ../build/bin/preferences_gen.h:5854
-#: ../build/bin/preferences_gen.h:6193 ../build/bin/preferences_gen.h:6265
-#: ../build/bin/preferences_gen.h:6416 ../build/bin/preferences_gen.h:6488
-#: ../build/bin/preferences_gen.h:6958 ../build/bin/preferences_gen.h:7673
-#: ../build/bin/preferences_gen.h:7846 ../build/bin/preferences_gen.h:8097
-#: ../build/bin/preferences_gen.h:8178 ../build/bin/preferences_gen.h:8214
-#: ../build/bin/preferences_gen.h:8250 ../build/bin/preferences_gen.h:8346
-#: ../build/bin/preferences_gen.h:8587 ../build/bin/preferences_gen.h:8678
-#: ../build/bin/preferences_gen.h:8820
+#: ../build/bin/preferences_gen.h:3972 ../build/bin/preferences_gen.h:4008
+#: ../build/bin/preferences_gen.h:4044 ../build/bin/preferences_gen.h:4080
+#: ../build/bin/preferences_gen.h:4116 ../build/bin/preferences_gen.h:4188
+#: ../build/bin/preferences_gen.h:4722 ../build/bin/preferences_gen.h:4920
+#: ../build/bin/preferences_gen.h:5195 ../build/bin/preferences_gen.h:5339
+#: ../build/bin/preferences_gen.h:5537 ../build/bin/preferences_gen.h:5602
+#: ../build/bin/preferences_gen.h:5941 ../build/bin/preferences_gen.h:5977
+#: ../build/bin/preferences_gen.h:6128 ../build/bin/preferences_gen.h:6200
+#: ../build/bin/preferences_gen.h:6670 ../build/bin/preferences_gen.h:7385
+#: ../build/bin/preferences_gen.h:7558 ../build/bin/preferences_gen.h:7809
+#: ../build/bin/preferences_gen.h:7890 ../build/bin/preferences_gen.h:7926
+#: ../build/bin/preferences_gen.h:7962 ../build/bin/preferences_gen.h:8058
+#: ../build/bin/preferences_gen.h:8299 ../build/bin/preferences_gen.h:8390
+#: ../build/bin/preferences_gen.h:8532
 msgctxt "preferences"
 msgid "FALSE"
 msgstr "否"
 
-#: ../build/bin/preferences_gen.h:4097
+#: ../build/bin/preferences_gen.h:3975
 msgid "hides built-in presets of utility modules in presets menu."
-msgstr "在預設選單中隱藏工具模組的內建預設。"
+msgstr ""
+"預設集選單只顯示用戶自定義的預設集\n"
+"隱藏工具模組內建的預設集"
 
-#: ../build/bin/preferences_gen.h:4119
+#: ../build/bin/preferences_gen.h:3997
 msgid "use single-click in the collections module"
-msgstr "在集合模組中使用單擊"
+msgstr "在相冊模組中啟用單擊選取"
 
-#: ../build/bin/preferences_gen.h:4133
+#: ../build/bin/preferences_gen.h:4011
 msgid ""
 "check this option to use single-click to select items in the collections "
 "module. this will allow you to do range selections for date-time and numeric "
 "values."
 msgstr ""
-"選取此選項以使用單擊選擇“收集”模組中的項目。這將允許您做日期時間和數值的區間"
-"選擇。"
+"開啟此選項可在相冊模組中以滑鼠左鍵單擊選擇\n"
+"以便可以一次選擇多個日期或數據範圍"
 
-#: ../build/bin/preferences_gen.h:4155
+#: ../build/bin/preferences_gen.h:4033
 msgid "expand a single utility module at a time"
-msgstr "一次展開一個工具模組"
+msgstr "一次只展開一個工具模組"
 
-#: ../build/bin/preferences_gen.h:4169
+#: ../build/bin/preferences_gen.h:4047
 msgid "this option toggles the behavior of shift clicking in lighttable mode"
-msgstr "這個選項可以切換在映繪桌模式下shift的點擊行爲"
+msgstr ""
+"啟用此選項時，單擊展開一個模組的同時會收合其他模組\n"
+"如果想在不折疊其他面板的情況下展開面板，可以按住 Shift+單擊"
 
-#: ../build/bin/preferences_gen.h:4191
+#: ../build/bin/preferences_gen.h:4069
 msgid "scroll utility modules to the top when expanded"
-msgstr "當展開時滾動工具模組至頂端"
+msgstr "展開工具模組時畫面滾動至模組標題"
 
-#: ../build/bin/preferences_gen.h:4205 ../build/bin/preferences_gen.h:5500
+#: ../build/bin/preferences_gen.h:4083 ../build/bin/preferences_gen.h:5378
 msgid ""
 "when this option is enabled then darktable will try to scroll the module to "
 "the top of the visible list"
-msgstr "當啓用該選項時，darktable將嘗試將模組滾動到可見列表的頂部"
+msgstr "啟用此選項後，在展開模組時自動調整卷軸位置讓將該模組置頂"
 
-#: ../build/bin/preferences_gen.h:4227
+#: ../build/bin/preferences_gen.h:4105
 msgid "rating an image one star twice will not zero out the rating"
-msgstr "一張圖片被評爲一星兩次不會清空評分"
+msgstr "對影像評兩次一星不使評分歸零"
 
-#: ../build/bin/preferences_gen.h:4241
+#: ../build/bin/preferences_gen.h:4119
 msgid ""
 "defines whether rating an image one star twice will zero out star rating"
-msgstr "定義對一張圖片兩次評爲一星時是否清空評分"
+msgstr ""
+"預設情況下，對評分一顆星的影像再次評一星，會將該影像評分歸零\n"
+"開啟此選項可停用此功能，需以「0」將評分歸零"
 
-#: ../build/bin/preferences_gen.h:4263 ../build/bin/preferences_gen.h:5031
+#: ../build/bin/preferences_gen.h:4141 ../build/bin/preferences_gen.h:4909
 msgid "show scrollbars for central view"
-msgstr "顯示中心視角的滾動條"
+msgstr "顯示中央視窗的卷軸"
 
-#: ../build/bin/preferences_gen.h:4274 ../build/bin/preferences_gen.h:5213
-#: ../build/bin/preferences_gen.h:5353 ../build/bin/preferences_gen.h:5389
-#: ../build/bin/preferences_gen.h:5425 ../build/bin/preferences_gen.h:5497
-#: ../build/bin/preferences_gen.h:5753 ../build/bin/preferences_gen.h:6229
-#: ../build/bin/preferences_gen.h:6301 ../build/bin/preferences_gen.h:6452
-#: ../build/bin/preferences_gen.h:6524 ../build/bin/preferences_gen.h:6742
-#: ../build/bin/preferences_gen.h:6778 ../build/bin/preferences_gen.h:6814
-#: ../build/bin/preferences_gen.h:6850 ../build/bin/preferences_gen.h:6886
-#: ../build/bin/preferences_gen.h:6922 ../build/bin/preferences_gen.h:6994
-#: ../build/bin/preferences_gen.h:7029 ../build/bin/preferences_gen.h:7064
-#: ../build/bin/preferences_gen.h:7100 ../build/bin/preferences_gen.h:7738
-#: ../build/bin/preferences_gen.h:7774 ../build/bin/preferences_gen.h:7810
-#: ../build/bin/preferences_gen.h:7882 ../build/bin/preferences_gen.h:8142
-#: ../build/bin/preferences_gen.h:8390 ../build/bin/preferences_gen.h:8962
-#: ../build/bin/preferences_gen.h:9060
+#: ../build/bin/preferences_gen.h:4152 ../build/bin/preferences_gen.h:5091
+#: ../build/bin/preferences_gen.h:5231 ../build/bin/preferences_gen.h:5267
+#: ../build/bin/preferences_gen.h:5303 ../build/bin/preferences_gen.h:5375
+#: ../build/bin/preferences_gen.h:5501 ../build/bin/preferences_gen.h:6013
+#: ../build/bin/preferences_gen.h:6164 ../build/bin/preferences_gen.h:6236
+#: ../build/bin/preferences_gen.h:6454 ../build/bin/preferences_gen.h:6490
+#: ../build/bin/preferences_gen.h:6526 ../build/bin/preferences_gen.h:6562
+#: ../build/bin/preferences_gen.h:6598 ../build/bin/preferences_gen.h:6634
+#: ../build/bin/preferences_gen.h:6706 ../build/bin/preferences_gen.h:6741
+#: ../build/bin/preferences_gen.h:6776 ../build/bin/preferences_gen.h:6812
+#: ../build/bin/preferences_gen.h:7450 ../build/bin/preferences_gen.h:7486
+#: ../build/bin/preferences_gen.h:7522 ../build/bin/preferences_gen.h:7594
+#: ../build/bin/preferences_gen.h:7854 ../build/bin/preferences_gen.h:8102
+#: ../build/bin/preferences_gen.h:8674 ../build/bin/preferences_gen.h:8772
 msgctxt "preferences"
 msgid "TRUE"
 msgstr "是"
 
-#: ../build/bin/preferences_gen.h:4277 ../build/bin/preferences_gen.h:5045
+#: ../build/bin/preferences_gen.h:4155 ../build/bin/preferences_gen.h:4923
 msgid "defines whether scrollbars should be displayed"
-msgstr "定義是否應顯示滾動條"
+msgstr "選擇是否在中央視窗顯示卷軸"
 
-#: ../build/bin/preferences_gen.h:4299
+#: ../build/bin/preferences_gen.h:4177
 msgid "show image time with milliseconds"
-msgstr "以毫秒為影像顯示時間單位"
+msgstr "以毫秒為單位顯示影像時間"
 
-#: ../build/bin/preferences_gen.h:4313
+#: ../build/bin/preferences_gen.h:4191
 msgid "defines whether time should be displayed with milliseconds"
-msgstr "定義顯示時間是否以毫秒單位"
+msgstr ""
+"自訂時間顯示是否包括毫秒\n"
+"開啟時毫秒會顯示在影像資訊模組裡，以及地理標籤模組中"
 
-#: ../build/bin/preferences_gen.h:4323
+#: ../build/bin/preferences_gen.h:4201
 msgid "thumbnails"
-msgstr "縮圖"
+msgstr "縮圖顯示"
 
-#: ../build/bin/preferences_gen.h:4343
+#: ../build/bin/preferences_gen.h:4221
 msgid "use raw file instead of embedded JPEG from size"
-msgstr "按影像大小決定使用RAW檔而不使用內嵌JPEG檔"
+msgstr "使用 RAW 檔而非嵌入的 JPEG"
 
-#: ../build/bin/preferences_gen.h:4416
+#: ../build/bin/preferences_gen.h:4294
 msgid ""
 "if the thumbnail size is greater than this value, it will be processed using "
 "raw file instead of the embedded preview JPEG (better but slower).\n"
@@ -1064,15 +1058,17 @@ msgid ""
 "should choose the *always* option.\n"
 "(more comments in the manual)"
 msgstr ""
-"若縮圖大小大於設定值，縮圖時將會使用 RAW檔而不是內嵌的 JPEG 預覽圖，較慢但品"
-"質更好。\n"
-"若您希望使用最高品質的縮圖與預先產生影像，您應選擇*總是* (參閱手冊有更多資訊)"
+"顯示未經解馬賽克處理的影像縮圖時，如果縮圖尺寸大於設定值，則處理 RAW 檔生成縮"
+"圖\n"
+"如果縮圖低於設定值，則使用嵌入在 RAW 檔裡的 JPEG 預覽圖\n"
+"經過暗房（Darkroom）編輯處理的影像，預設皆使用 RAW 檔生成的縮圖\n"
+"若希望所有縮圖和放大顯示都有最佳品質，應選擇「一律」"
 
-#: ../build/bin/preferences_gen.h:4438
+#: ../build/bin/preferences_gen.h:4316
 msgid "high quality processing from size"
-msgstr "按大小處理高品質縮圖"
+msgstr "高品質渲染尺寸設定"
 
-#: ../build/bin/preferences_gen.h:4511
+#: ../build/bin/preferences_gen.h:4389
 msgid ""
 "if the thumbnail size is greater than this value, it will be processed using "
 "the full quality rendering path (better but slower).\n"
@@ -1080,247 +1076,223 @@ msgid ""
 "should choose the *always* option.\n"
 "(more comments in the manual)"
 msgstr ""
-"若縮圖大小大於設定值，產生縮圖時將會使用高品質的渲染方式，較慢但品質更好。\n"
-"若您希望使用最高品質的縮圖與預渲染影像，您應在此選擇“總是”。(參閱手冊有更多資"
-"訊)"
+"如果 RAW 圖檔的縮圖顯示尺寸大於此值，會以完整品質的影像編輯調整運算\n"
+"此方法效果較佳但速度較慢，要以最高品質渲染所有影像縮圖，應選擇「一律」選項"
 
-#: ../build/bin/preferences_gen.h:4533
+#: ../build/bin/preferences_gen.h:4411
 msgid "delimiters for size categories"
-msgstr "大小類別的分隔符號"
+msgstr "縮圖尺寸分組"
 
-#: ../build/bin/preferences_gen.h:4551
+#: ../build/bin/preferences_gen.h:4429
 msgid ""
 "size categories are used to be able to set different overlays and css values "
 "depending of the size of the thumbnail, separated by |. for example, 120|400 "
 "means 3 categories of thumbnails: 0px->120px, 120px->400px and >400px"
 msgstr ""
-"依據縮圖大小類型用來設定不同的疊加層和CSS值。以|分隔，如120|400 表示三種縮圖"
-"類型 0px->120px, 120px->400px and >400px"
+"尺寸分組設定用於根據縮圖大小顯示不同的縮圖\n"
+"一組以豎線分隔的值定義更改分組的縮圖尺寸\n"
+"預設值「120|400」表示縮圖被分為三組：0-120px、120-400px 和 >400px"
 
-#: ../build/bin/preferences_gen.h:4573
+#: ../build/bin/preferences_gen.h:4451
 msgid "pattern for the thumbnail extended overlay text"
-msgstr "縮圖擴展覆蓋文字之樣式"
+msgstr "縮圖上顯示的額外文字訊息"
 
-#: ../build/bin/preferences_gen.h:4594 ../build/bin/preferences_gen.h:4637
+#: ../build/bin/preferences_gen.h:4472 ../build/bin/preferences_gen.h:4515
 msgid "see manual to know all the tags you can use."
-msgstr "參閱手冊以瞭解所有可用的標籤。"
+msgstr ""
+"如果開啟縮圖上顯示額外文字訊息，此設置可定義要顯示的內容\n"
+"可以使用 darktable 變數中定義的任何參數，詳細參數設定請見說明文件"
 
-#: ../build/bin/preferences_gen.h:4616
+#: ../build/bin/preferences_gen.h:4494
 msgid "pattern for the thumbnail tooltip (empty to disable)"
-msgstr "縮圖工具提示之樣式(空白表示不使用)"
+msgstr "滑鼠移至縮圖的額外文字訊息"
 
-#: ../build/bin/preferences_gen.h:4665 ../src/gui/gtk.c:1177
+#: ../build/bin/preferences_gen.h:4543 ../src/gui/gtk.c:1177
 #: ../src/gui/preferences.c:538 ../src/views/darkroom.c:91
 msgid "darkroom"
-msgstr "暗房"
+msgstr "暗房 Darkroom"
 
-#: ../build/bin/preferences_gen.h:4688
+#: ../build/bin/preferences_gen.h:4566
 msgid "pen pressure control for brush masks"
-msgstr "筆壓控制之筆刷遮罩"
+msgstr "筆刷遮罩的筆壓控制"
 
-#: ../build/bin/preferences_gen.h:4746
+#: ../build/bin/preferences_gen.h:4624
 msgid ""
 "off - pressure reading ignored, hardness/opacity/brush size - pressure "
 "reading controls specified attribute, absolute/relative - pressure reading "
 "is taken directly as attribute value or multiplied with pre-defined setting."
-msgstr ""
-"關閉-忽略壓力讀數，硬度/不透明度/筆刷大小-壓力讀數控制特定屬性，絕對/相對-壓"
-"力讀數直接作爲屬性值或與預先設定值相乘。"
+msgstr "控制繪圖板的壓力在繪製筆刷遮罩時的控制方式"
 
-#: ../build/bin/preferences_gen.h:4768
+#: ../build/bin/preferences_gen.h:4646
 msgid "smoothing of brush strokes"
-msgstr "筆刷筆劃平滑"
+msgstr "筆觸平滑化"
 
-#: ../build/bin/preferences_gen.h:4811
+#: ../build/bin/preferences_gen.h:4689
 msgid ""
 "sets level for smoothing of brush strokes. stronger smoothing leads to less "
 "nodes and easier editing but with lower control of accuracy."
 msgstr ""
-"設置筆刷筆劃平滑度，強的平滑會導致更少的節點並更容易編輯，但精準度控制會降"
-"低。"
+"設定筆刷平滑的等級\n"
+"越平滑會產生較少的節點以方便編輯，但也會降低控制性與精準度"
 
-#: ../build/bin/preferences_gen.h:4833
+#: ../build/bin/preferences_gen.h:4711
 msgid "scroll down to increase mask parameters"
-msgstr "向下滾動以增加遮罩值"
+msgstr "滑鼠滾輪向下增加遮罩參數"
 
-#: ../build/bin/preferences_gen.h:4847
+#: ../build/bin/preferences_gen.h:4725
 msgid ""
 "when using the mouse scroll wheel to change mask parameters, scroll down to "
 "increase the mask size, feather size, opacity, brush hardness and gradient "
 "curvature\n"
 "by default scrolling up increases these parameters"
 msgstr ""
-"使用滑鼠滾輪調整遮罩參數時，向下滾動以增加遮罩大小、羽化大小、不透明度、筆刷"
-"硬度或漸層曲率\n"
-"預設為向上滾動為增加參數值"
+"使用滑鼠滾輪更改遮罩參數時，向下滾動增加參數\n"
+"預設情況下（選項未勾選），向上滾動增加參數，勾選後動作相反\n"
+"適用於遮罩尺寸、羽化程度、不透明度、筆刷硬度和漸變曲度等等"
 
-#: ../build/bin/preferences_gen.h:4869
+#: ../build/bin/preferences_gen.h:4747
 msgid "pattern for the image information line"
-msgstr "影像資訊線之樣式"
+msgstr "影像訊息列的顯示資訊"
 
-#: ../build/bin/preferences_gen.h:4890
+#: ../build/bin/preferences_gen.h:4768
 msgid "see manual for a list of the tags you can use."
-msgstr "可用標籤列表 可參閱手冊。"
+msgstr ""
+"設定影像訊息列要顯示的資訊內容\n"
+"可以使用 darktable 變數中定義的任何參數，詳細參數設定請見說明文件"
 
-#: ../build/bin/preferences_gen.h:4912
+#: ../build/bin/preferences_gen.h:4790
 msgid "position of the image information line"
-msgstr "影像資訊線之位置"
+msgstr "影像訊息列的位置"
 
-#: ../build/bin/preferences_gen.h:4986
+#: ../build/bin/preferences_gen.h:4864
 msgid "border around image in darkroom mode"
-msgstr "暗房模式下之影像邊框"
+msgstr "在預覽影像周圍加上邊框"
 
-#: ../build/bin/preferences_gen.h:5006 ../build/bin/preferences_gen.h:7379
-#: ../build/bin/preferences_gen.h:7499 ../build/bin/preferences_gen.h:8443
-#: ../build/bin/preferences_gen.h:8784 ../build/bin/preferences_gen.h:8866
-#: ../build/bin/preferences_gen.h:9024 ../build/bin/preferences_gen.h:9138
-#: ../build/bin/preferences_gen.h:9185
+#: ../build/bin/preferences_gen.h:4884 ../build/bin/preferences_gen.h:7091
+#: ../build/bin/preferences_gen.h:7211 ../build/bin/preferences_gen.h:8155
+#: ../build/bin/preferences_gen.h:8496 ../build/bin/preferences_gen.h:8578
+#: ../build/bin/preferences_gen.h:8736 ../build/bin/preferences_gen.h:8850
+#: ../build/bin/preferences_gen.h:8897
 #, c-format
 msgid "double click to reset to `%d'"
-msgstr "雙擊以重置到 `%d'"
+msgstr "雙擊重設回「%d」"
 
-#: ../build/bin/preferences_gen.h:5009
+#: ../build/bin/preferences_gen.h:4887
 msgid ""
 "process the image in darkroom mode with a small border. set to 0 if you "
 "don't want any border."
-msgstr "暗房模式下的影像增加小邊框，設爲 0 為不使用。"
+msgstr "暗房畫面下，在影像周圍周圍顯示邊框"
 
-#: ../build/bin/preferences_gen.h:5067
+#: ../build/bin/preferences_gen.h:4945
 msgid "demosaicing for zoomed out darkroom mode"
-msgstr "爲暗房模式下縮小影像去馬賽克"
+msgstr "縮小預覽顯示的去馬賽克方式"
 
-#: ../build/bin/preferences_gen.h:5110
+#: ../build/bin/preferences_gen.h:4988
 msgid ""
-"interpolation when not viewing 1:1 in darkroom mode: bilinear is fastest, "
-"but not as sharp. middle ground is using RCD + interpolation modes specified "
-"on the 'pixel interpolator' option (processing tab), full will use exactly "
-"the settings for full-size export. X-Trans sensors use VNG rather than RCD "
-"as middle ground."
+"demosaicer when not viewing 1:1 in darkroom mode: 'bilinear' is fast but "
+"slightly blurry. 'default' uses the default demosaicer for the used sensor "
+"(RCD or Markesteijn). 'full' will use exactly the settings as for full-size "
+"export."
 msgstr ""
-"暗房模式下以非 1:1 比例顯示影像時使用的像素插值算法:雙線性(bilinear)最快，但"
-"銳度較低。中間(middle) 為折衷選項，為 RCD + 指定的像素插值模式。全大小(full)"
-"將使用全大小輸出。注意富士 X-Trans 傳感器在中間(middle)使用 VNG 算法而不使用 "
-"RCD。"
+"在暗房內非 1:1 查看影像時的去馬賽克算法\n"
+"此設定僅影響編輯中檢視，不影響實際導出的影像\n"
+"\n"
+"「雙線性」是最快的，但稍微模糊\n"
+"「預設」使用 RCD 去馬賽克，X-Trans 感光元件使用 Markesteijn\n"
+"「完整」使用去馬賽克模組的實際設定"
 
-#: ../build/bin/preferences_gen.h:5132
+#: ../build/bin/preferences_gen.h:5010
 msgid "reduce resolution of preview image"
 msgstr "降低預覽影像的解析度"
 
-#: ../build/bin/preferences_gen.h:5180
+#: ../build/bin/preferences_gen.h:5058
 msgid "decrease to speed up preview rendering, may hinder accurate masking"
-msgstr "減少以加速預覽產生，可能會影響精確遮罩"
+msgstr "降低預覽圖像的分辨率以加快速度，但也可能降低顏色選擇和遮罩的準確性"
 
-#: ../build/bin/preferences_gen.h:5202
+#: ../build/bin/preferences_gen.h:5080
 msgid "show loading screen between images"
-msgstr "切換影像時顯示載入畫面"
+msgstr "在影像切換之間顯示載入畫面"
 
-#: ../build/bin/preferences_gen.h:5216
+#: ../build/bin/preferences_gen.h:5094
 msgid ""
 "show gray loading screen when navigating between images in the darkroom\n"
 "disable to just show a toast message"
 msgstr ""
-"暗房模式下在影像之間切換時顯示灰色的載入畫面\n"
-"不使用此選項時再切換影像時僅顯示通知消息"
+"在暗房中切換影像時顯示灰色的載入畫面\n"
+"關閉此功能則在載入時仍顯示前一張影像與「讀取中」的訊息\n"
+"這樣對比較相似影像很有用，但可能因載入過久造成誤解，以為已切換至下一張影像"
 
-#: ../build/bin/preferences_gen.h:5226
+#: ../build/bin/preferences_gen.h:5104
 msgid "modules"
-msgstr "模組"
+msgstr "編輯模組"
 
-#: ../build/bin/preferences_gen.h:5246
+#: ../build/bin/preferences_gen.h:5124
 msgid "display of individual color channels"
-msgstr "顯示單獨的顏色通道"
+msgstr "遮罩的色彩通道顯示"
 
-#: ../build/bin/preferences_gen.h:5284
+#: ../build/bin/preferences_gen.h:5162
 msgid ""
 "defines how color channels are displayed when activated in the parametric "
 "masks feature."
-msgstr "定義在啓用參數遮罩功能時如何顯示色彩通道。"
+msgstr "自訂在遮罩功能中色彩的顯示方式"
 
-#: ../build/bin/preferences_gen.h:5306
+#: ../build/bin/preferences_gen.h:5184
 msgid "hide built-in presets for processing modules"
-msgstr "隱藏處理模組的內建預設配置"
+msgstr "隱藏編輯模組的內建預設集"
 
-#: ../build/bin/preferences_gen.h:5320
+#: ../build/bin/preferences_gen.h:5198
 msgid ""
 "hides built-in presets of processing modules in both presets and favourites "
 "menu."
-msgstr "隱藏預設和最愛中的內建處理模組之預設配置。"
+msgstr ""
+"隱藏編輯模組內建的預設集\n"
+"預設集選單只顯示用戶自定義的預設集"
 
-#: ../build/bin/preferences_gen.h:5342 ../build/bin/preferences_gen.h:5356
+#: ../build/bin/preferences_gen.h:5220 ../build/bin/preferences_gen.h:5234
 msgid "show the guides widget in modules UI"
-msgstr "在模組 UI 內顯示參考線組件"
+msgstr "在模組介面中顯示參照框線工具"
 
-#: ../build/bin/preferences_gen.h:5378
+#: ../build/bin/preferences_gen.h:5256
 msgid "expand a single processing module at a time"
-msgstr "一次展開一個處理模組"
+msgstr "一次只展開一個編輯模組"
 
-#: ../build/bin/preferences_gen.h:5392
+#: ../build/bin/preferences_gen.h:5270
 msgid "this option toggles the behavior of shift clicking in darkroom mode"
-msgstr "此選項切換shift+單擊在暗房模式下的行爲"
+msgstr ""
+"啟用此選項時，單擊展開一個模組的同時會收合其他模組\n"
+"如果想在不收合其他面板的情況下展開面板，可以按住 Shift+單擊"
 
-#: ../build/bin/preferences_gen.h:5414
+#: ../build/bin/preferences_gen.h:5292
 msgid "only collapse modules in current group"
-msgstr "僅摺疊目前分組的模組"
+msgstr "只收合目前群組中的模組"
 
-#: ../build/bin/preferences_gen.h:5428
+#: ../build/bin/preferences_gen.h:5306
 msgid ""
 "if only expanding a single module at a time, only collapse other modules in "
 "the current group - ignore modules in other groups"
 msgstr ""
-"如果一次只展開一個模組，則只摺疊當目前分組中的其他模組-忽略其他分組的模組"
+"如果上項開啟，自動收合僅限於當下群組中的其他模組\n"
+"其他群組中的模組不會被收合"
 
-#: ../build/bin/preferences_gen.h:5450
+#: ../build/bin/preferences_gen.h:5328
 msgid "expand the module when it is activated, and collapse it when disabled"
-msgstr "啟用時展開模組，不啟用時摺疊模組"
+msgstr "啟用模組時展開，停用時收合"
 
-#: ../build/bin/preferences_gen.h:5464
+#: ../build/bin/preferences_gen.h:5342
 msgid ""
 "this option allows to expand or collapse automatically the module when it is "
 "enabled or disabled."
-msgstr "此選項可讓模組自動展開或摺疊，不管模組是否啓用。"
+msgstr "開啟此選項會在模組啟用時自動展開，停用時自動收合"
 
-#: ../build/bin/preferences_gen.h:5486
+#: ../build/bin/preferences_gen.h:5364
 msgid "scroll processing modules to the top when expanded"
-msgstr "當展開時，滾動處理模組至頂端"
+msgstr "展開編輯模組時畫面滾動至模組標題"
 
-#: ../build/bin/preferences_gen.h:5522
-msgid "white balance slider colors"
-msgstr "白平衡滑動條顏色"
-
-#: ../build/bin/preferences_gen.h:5565
-msgid ""
-"visual indication of temperature adjustments.\n"
-"in 'illuminant color' mode slider colors represent the color of the light "
-"source,\n"
-"in 'effect emulation' slider colors represent the effect the adjustment "
-"would have on the scene"
-msgstr ""
-"溫度調整的視覺指示\n"
-"在“照明顏色”模式下，滑動條顏色表示光的顏色\n"
-"在“效果模擬”中，滑動條顏色表示調整將對場景產生的效果"
-
-#: ../build/bin/preferences_gen.h:5587
-msgid "color balance slider block layout"
-msgstr "色彩平衡滾動條區塊布局"
-
-#: ../build/bin/preferences_gen.h:5630
-msgid ""
-"choose how to organise the slider blocks for lift, gamma and gain:\n"
-"list - all sliders are shown in one long list (with headers),\n"
-"tabs - use tabs to switch between the blocks of sliders,\n"
-"columns - the blocks of sliders are shown next to each other (in narrow "
-"columns)"
-msgstr ""
-"選擇如何組織提升、伽瑪和增益滑動條::\n"
-"列表-所有滑動條都顯示在一個長列表中(帶標題)\n"
-"分頁-使用分頁在滑動條區塊之間切換\n"
-"列-滑動條區塊彼此相鄰顯示(在窄列中)"
-
-#: ../build/bin/preferences_gen.h:5652
+#: ../build/bin/preferences_gen.h:5400
 msgid "show right-side buttons in processing module headers"
-msgstr "在處理模組標題中顯示右側按鈕"
+msgstr "在編輯模組標題右側顯示快速按鈕"
 
-#: ../build/bin/preferences_gen.h:5720
+#: ../build/bin/preferences_gen.h:5468
 msgid ""
 "when the mouse is not over a module, the multi-instance, reset and preset "
 "buttons can be hidden:\n"
@@ -1333,78 +1305,87 @@ msgid ""
 "smooth - fade out all buttons in one header simultaneously,\n"
 "glide - gradually hide individual buttons as needed"
 msgstr ""
-"當滑鼠不在模組上時，可以隱藏多實例、重置和預設按鈕:\n"
-"總是-總是顯示所有按鈕\n"
-"使用中-僅當滑鼠位於模組上方時顯示按鈕\n"
-"暗淡-滑鼠離開時按鈕變暗\n"
-"自動-面板窄時隱藏按鈕\n"
-"淡出-面板變窄時淡出所有按鈕\n"
-"符合-如果模組名稱不符合，則隱藏所有按鈕\n"
-"平滑-同時淡出一個標題中的所有按鈕\n"
-"滑動-根據需要逐漸隱藏各個按鈕"
+"選擇如何在編輯模組的標題右側顯示以下四個快速按鈕\n"
+"遮罩指示器、多模組實例、重設、預設集\n"
+"\n"
+"一率：永遠顯示所有按鈕\n"
+"啟用：滑鼠移至該模組時才顯示按鈕\n"
+"變暗 : 滑鼠不在模組上時按鈕變暗\n"
+"自動 : 模組面板過窄時隱藏所有按鈕\n"
+"淡出：模組面板過窄時淡出所有按鈕\n"
+"適合：模組名稱過長時隱藏所有按鈕\n"
+"滑順：模組名稱過長時淡出所有按鈕\n"
+"滑動：模組名稱過長時逐一淡出按鈕"
 
-#: ../build/bin/preferences_gen.h:5742
+#: ../build/bin/preferences_gen.h:5490
 msgid "show mask indicator in module headers"
-msgstr "在模組標題欄中顯示遮罩指示"
+msgstr "在模組標題中顯示遮罩圖示"
 
-#: ../build/bin/preferences_gen.h:5756
+#: ../build/bin/preferences_gen.h:5504
 msgid ""
 "if enabled, an icon will be shown in the header of any processing modules "
 "that have a mask applied"
-msgstr "啓用後，處理模組使用遮罩時將會在模組標題欄內顯示圖示"
+msgstr "勾選後將在任何有使用遮罩的編輯模組的標題右側顯示遮罩圖示"
 
-#: ../build/bin/preferences_gen.h:5778
+#: ../build/bin/preferences_gen.h:5526
 msgid "prompt for name on addition of new instance"
-msgstr "增加新實例時提示輸入模組名稱"
+msgstr "添加新的編輯模組實例時提示輸入名稱"
 
-#: ../build/bin/preferences_gen.h:5792
+#: ../build/bin/preferences_gen.h:5540
 msgid ""
 "if enabled, a rename prompt will be present for each new module instance "
 "(either new instance or duplicate)"
-msgstr "啓用後，每一個新的模組實例(無論是新例還是重複增加)都會提示輸入實例名稱"
+msgstr "啟用此功能後，每個新的模組實例或複製模組實例時都會出現命名提示"
 
-#: ../build/bin/preferences_gen.h:5820
+#: ../build/bin/preferences_gen.h:5568
 msgid "processing"
-msgstr "處理中"
+msgstr "運算方法"
 
-#: ../build/bin/preferences_gen.h:5823
+#: ../build/bin/preferences_gen.h:5571
 msgid "image processing"
-msgstr "影像處理中"
+msgstr "影像處理"
 
-#: ../build/bin/preferences_gen.h:5843
+#: ../build/bin/preferences_gen.h:5591
 msgid "always use LittleCMS 2 to apply output color profile"
-msgstr "總是使用LittleCMS 2輸出顏色配置檔案"
+msgstr "使用 LittleCMS 2 來處理匯出檔案的色彩描述檔"
 
-#: ../build/bin/preferences_gen.h:5857
+#: ../build/bin/preferences_gen.h:5605
 msgid "this is slower than the default."
-msgstr "比預設慢。"
+msgstr ""
+"使用 LittleCMS 2 色彩管理核心取代原有的內部程式來轉換輸出色彩\n"
+"速度會比預設值慢很多，但在某些情況下色彩可能會更準確\n"
+"\n"
+"如果匯出的 ICC 是基於 LUT 或同時包含 LUT 與矩陣\n"
+"那麼無論此設定是否啟用 darktable 都會使用 LittleCMS 2 來轉換顏色"
 
-#: ../build/bin/preferences_gen.h:5879
+#: ../build/bin/preferences_gen.h:5627
 msgid "pixel interpolator (warp)"
-msgstr "像素內差器"
+msgstr "像素內插法（變形時）"
 
-#: ../build/bin/preferences_gen.h:5922
+#: ../build/bin/preferences_gen.h:5670
 msgid ""
 "pixel interpolator used in modules for rotation, lens correction, liquify, "
 "cropping and final scaling (bilinear, bicubic, lanczos2)."
 msgstr ""
-"用於旋轉、鏡頭校正、液化、裁剪及最終縮放(雙線性，雙立方，lanczos2)的像素內插"
-"器。"
+"用於旋轉、鏡頭校正、液化、裁剪等變形模組的像素內插方法\n"
+"一般來說雙三次在大多數情況下是一個安全的選項"
 
-#: ../build/bin/preferences_gen.h:5944
+#: ../build/bin/preferences_gen.h:5692
 msgid "pixel interpolator (scaling)"
-msgstr "像素內插器(縮放)"
+msgstr "像素內插法（縮放時）"
 
-#: ../build/bin/preferences_gen.h:5992
+#: ../build/bin/preferences_gen.h:5740
 msgid ""
 "pixel interpolator used for scaling (bilinear, bicubic, lanczos2, lanczos3)."
-msgstr "用於縮放的像素內插器(雙線性，雙三次，lanczos2，lanczos3)。"
+msgstr ""
+"用於縮放的像素內插方法，lanczos3 大部分時候可以提供更清晰的結果\n"
+"但有可能導致邊緣偽影，所以此算法只限於縮放使用"
 
-#: ../build/bin/preferences_gen.h:6014
+#: ../build/bin/preferences_gen.h:5762
 msgid "3D lut root folder"
-msgstr "3D lut 根目錄"
+msgstr "色彩查找表（LUT）資料夾"
 
-#: ../build/bin/preferences_gen.h:6019 ../src/control/jobs/control_jobs.c:1685
+#: ../build/bin/preferences_gen.h:5767 ../src/control/jobs/control_jobs.c:1685
 #: ../src/control/jobs/control_jobs.c:1747 ../src/gui/preferences.c:1035
 #: ../src/gui/presets.c:375 ../src/imageio/storage/disk.c:121
 #: ../src/imageio/storage/disk.c:188 ../src/imageio/storage/gallery.c:108
@@ -1413,108 +1394,111 @@ msgstr "3D lut 根目錄"
 #: ../src/libs/import.c:1601 ../src/libs/import.c:1655 ../src/libs/styles.c:376
 #: ../src/lua/preferences.c:667
 msgid "select directory"
-msgstr "選擇目錄"
+msgstr "選擇資料夾"
 
-#: ../build/bin/preferences_gen.h:6035
+#: ../build/bin/preferences_gen.h:5783
 msgid ""
 "this folder (and sub-folders) contains Lut files used by lut3d modules. "
 "(need a restart)."
-msgstr "此目錄應包含 lut3d 模組使用的 LUT 檔案。(更改需重啓後才生效)"
+msgstr ""
+"此資料夾及其子資料夾為立體色彩查找表（LUT 3D）模組使用的 LUT 檔預設位置"
 
-#: ../build/bin/preferences_gen.h:6057
+#: ../build/bin/preferences_gen.h:5805
 msgid "auto-apply pixel workflow defaults"
-msgstr "自動套用像素工作流程預設值"
+msgstr "內部運算工作流程預設值"
 
-#: ../build/bin/preferences_gen.h:6100
+#: ../build/bin/preferences_gen.h:5848
 msgid ""
 "scene-referred workflow is based on linear modules and will auto-apply "
 "filmic and exposure,\n"
 "display-referred workflow is based on Lab modules and will auto-apply base "
 "curve and the legacy module pipe order."
 msgstr ""
-"場景工作流程基於線型編輯模組，自動套用filmic及 曝光模組，\n"
-"顯示工作流程基於 Lab 模組，自動套用 基本曲線 和傳統模組處理順序。"
+"選擇預設的工作流程和相應的編輯模組\n"
+"\n"
+"場景參照（scene-referred）工作流程\n"
+"在影像從相機訊號轉換為顯示色彩空間之前對其進行操作的工作流程，大多數處理都在"
+"線性 RGB 空間中執行。選擇此選項會自動啟用「電影式階調映射」和「曝光」模組，並"
+"自動調整曝光模組的參數以便符合大多數相機。像素通道的模組運算順序被設為 V3.0，"
+"這是為 darktable 3.0 及更高版本定義的順序。\n"
+"\n"
+"顯示參照（display-referred）工作流程\n"
+"在影像從相機訊號轉換為顯示顏色空間之後對其進行操作的工作流程，顯示參照基於 "
+"Lab 空間，並自動啟用「基礎曲線」和舊的模組運算順序。\n"
+"\n"
+"選擇無，在預設情況下不會啟用任何模組，並將模組運算順序設置為和場景參照相同的 "
+"V3.0 順序"
 
-#: ../build/bin/preferences_gen.h:6122
+#: ../build/bin/preferences_gen.h:5870
 msgid "auto-apply chromatic adaptation defaults"
-msgstr "自動套用顏色調適預設值"
+msgstr "白平衡校正預設模組"
 
-#: ../build/bin/preferences_gen.h:6160
+#: ../build/bin/preferences_gen.h:5908
 msgid ""
 "legacy performs a basic chromatic adaptation using only the white balance "
 "module\n"
 "modern uses a combination of white balance module and color calibration "
 "module, with improved color science for chromatic adaptation"
 msgstr ""
-"傳統色彩調適只使用白平衡模組\n"
-"現代色彩調適同時使用白平衡與色彩校準模組來改善色彩調適"
+"選擇負責執行 白平衡-色彩適應（chromatic adaptation）的模組\n"
+"\n"
+"選擇「現代」會自動啟用「白平衡」和「色彩校正」模組，以現代的色彩科學執行全部"
+"顏色的光源適應轉換計算（chromatic adaptation transform）\n"
+"\n"
+"選擇「傳統」僅使用「白平衡」模組執行基本的白點和灰階對應"
 
-#: ../build/bin/preferences_gen.h:6182
+#: ../build/bin/preferences_gen.h:5930
 msgid "auto-apply per camera basecurve presets"
-msgstr "自動套用每個攝影機的基本曲線預設配置"
+msgstr "自動套用相機的基礎曲線"
 
-#: ../build/bin/preferences_gen.h:6196
+#: ../build/bin/preferences_gen.h:5944
 msgid ""
 "use the per-camera basecurve by default instead of the generic manufacturer "
 "one if there is one available (needs a restart).\n"
 "this option is taken into account when the \"auto-apply pixel workflow "
 "defaults\" is set to \"display-referred\".\n"
-"to prevent auto-apply basecurve presets \"auto-apply pixel workflow "
-"defaults\" should be set to \"none\""
+"to prevent auto-apply basecurve presets \"auto-apply pixel workflow defaults"
+"\" should be set to \"none\""
 msgstr ""
-"預設使用每台攝像機的基本曲線(如果有的話)，而不是通用製造商的基本曲線(需要重新"
-"啓動)\n"
-"當‘自動套用像素工作流程預設為‘顯示工作流程’時，將選項生效\n"
-"爲防止自動套用基本曲線預設配置，像素工作流程中之自動套用應預設為“無”"
+"預設套用相機專屬的基礎曲線，而不是通用的曲線\n"
+"當內部運算工作流程為「顯示參照」時，可自動套用相應的基礎曲線設定"
 
-#: ../build/bin/preferences_gen.h:6218
-msgid "auto-apply sharpen"
-msgstr "自動套用銳利化"
-
-#: ../build/bin/preferences_gen.h:6232
-msgid ""
-"this added sharpen is not recommended on cameras without a low-pass filter. "
-"you should disable this option if you use one of those more recent cameras "
-"or sharpen your images with other means."
-msgstr ""
-"在沒有低通濾鏡的相機上不推薦使用此選項增加銳利化效果。若您使用較新的相機或已"
-"經啓用其他銳利化方式，則應不使用此選項。"
-
-#: ../build/bin/preferences_gen.h:6254
+#: ../build/bin/preferences_gen.h:5966
 msgid "detect monochrome previews"
-msgstr "偵測單色預覽"
+msgstr "偵測黑白影像"
 
-#: ../build/bin/preferences_gen.h:6268
+#: ../build/bin/preferences_gen.h:5980
 msgid ""
 "many monochrome images can be identified via EXIF and preview data. beware: "
 "this slows down imports and reading of EXIF data"
 msgstr ""
-"許多黑白影像可經由EXIF及預覽資料識別，注意，這會使得輸入及讀取EXIF資料變慢"
+"在導入期間分析 EXIF 資料和預覽縮圖來識別影像是否為黑白\n"
+"發現黑白影像自動對其標記，讓黑白影像的工作流程更方便，但會減慢匯入的速度"
 
-#: ../build/bin/preferences_gen.h:6290
+#: ../build/bin/preferences_gen.h:6002
 msgid "show warning messages"
-msgstr "顯示警告資訊"
+msgstr "顯示警告訊息"
 
-#: ../build/bin/preferences_gen.h:6304
+#: ../build/bin/preferences_gen.h:6016
 msgid ""
 "display messages in modules to warn beginner users when non-standard and "
 "possibly harmful settings are used in the pipeline.\n"
 "these messages can be false-positive and should be disregarded if you know "
 "what you are doing. this option will hide them all the time."
 msgstr ""
-"在模組中顯示警告資訊，以提示初學者可能啓用了非標準或潛在有害的管線設置。\n"
-"這些資訊有可能誤判，若您確定您需要使用這些設置，可以忽略警告資訊。啓用此選項"
-"後，警告資訊將不再顯示。"
+"使用非標準的模組設定並且可能造成影像處理錯誤時跳出警告訊息提醒初學者\n"
+"如果確實知道設定的目的，並有意採用非標準設定，可忽略警告訊息\n"
+"或是使用此選項，不再顯示任何警告"
 
-#: ../build/bin/preferences_gen.h:6314
+#: ../build/bin/preferences_gen.h:6026
 msgid "cpu / gpu / memory"
-msgstr "中央處理器/圖形處理器/記憶體"
+msgstr "處理器 / 顯示卡 / 記憶體"
 
-#: ../build/bin/preferences_gen.h:6334
+#: ../build/bin/preferences_gen.h:6046
 msgid "darktable resources"
-msgstr "darktable資源"
+msgstr "darktable 效能設定"
 
-#: ../build/bin/preferences_gen.h:6383
+#: ../build/bin/preferences_gen.h:6095
 #, no-c-format
 msgid ""
 "defines how much darktable may take from your system resources.\n"
@@ -1530,29 +1514,43 @@ msgid ""
 "swapping and unexpected performance drops. use with caution and not "
 "recommended for general use!"
 msgstr ""
-"定義darktable可使用多少系統資源\n"
-"預設:darktable使用50%系統資源，並讓darktable仍可以高效率\n"
-"小: 應該要使用，如果同時跑多個程式而且使用大部分的系統記憶體或像遊戲或hugin的"
-"opencl/gl 應用程式\n"
-"大:最好選項，如果你主要使用darktable 而且為了效能，讓它使用大部分的系統資源\n"
-"沒限制: 應該要使用，當編輯超大影像時darktable將使用所有的系統資源，所以這將導"
-"致檔案交換及無法預期的效能降低，請小心使用，並不建議日常使用！"
+"自訂 darktable 可以使用多少系統資源\n"
+"\n"
+"低\n"
+"需要同時執行其他使用大量記憶體的程式時可以使用\n"
+"darktable 只會占用大約 20% 的記憶體\n"
+"\n"
+"中（預設）\n"
+"此設定可確保 darktable 和其他軟體同時順暢執行\n"
+"darktable 約使用一半的資源\n"
+"\n"
+"高\n"
+"專心修圖工作的設定，讓 darktable 使用大部分系統資源以提高性能\n"
+"會佔用大約 75% 的主記憶體和 90% 的顯示卡記憶體\n"
+"\n"
+"無上限\n"
+"一般情況不推薦，除非以上設定不敷 darktable 匯出非常大的影像時才使用\n"
+"此模式將佔用所有的系統資源，並可能會使用超出系統可用的記憶體空間\n"
+"\n"
+"更多詳細內容及自行修改系統參數，請閱讀操作手冊的「memory & performance "
+"tuning」章節"
 
-#: ../build/bin/preferences_gen.h:6405
+#: ../build/bin/preferences_gen.h:6117
 msgid "prefer performance over quality"
-msgstr "偏好效能甚於品質"
+msgstr "執行性能高於顯示品質"
 
-#: ../build/bin/preferences_gen.h:6419
+#: ../build/bin/preferences_gen.h:6131
 msgid ""
 "if switched on, thumbnails and previews are rendered at lower quality but 4 "
 "times faster"
-msgstr "如果打開，縮圖和預覽圖會以較低品質產生，但速度會提高4倍"
+msgstr ""
+"啟用此選項後以較低品質顯示縮圖和預覽，速度可提高四倍，在低階電腦上非常實用"
 
-#: ../build/bin/preferences_gen.h:6441
+#: ../build/bin/preferences_gen.h:6153
 msgid "enable disk backend for thumbnail cache"
-msgstr "爲縮圖快取啓用硬碟後援"
+msgstr "儲存縮圖快取檔案至硬碟"
 
-#: ../build/bin/preferences_gen.h:6455
+#: ../build/bin/preferences_gen.h:6167
 msgid ""
 "if enabled, write thumbnails to disk (.cache/darktable/) when evicted from "
 "the memory cache. note that this can take a lot of memory (several gigabytes "
@@ -1561,16 +1559,18 @@ msgid ""
 "be increased greatly when browsing a lot. to generate all thumbnails of your "
 "entire collection offline, run 'darktable-generate-cache'."
 msgstr ""
-"啓用後，當縮圖從記憶體快取移除時將被寫入硬碟(.cache/darktable/)。注意這可能會"
-"使用大量記憶體(兩萬張圖片可能佔用數 GB)。硬碟上的縮圖不會被自動刪除，但需要時"
-"您可以手動刪除該目錄內的檔案。此選項可以大幅提高瀏覽時的性能。您可以通"
-"過“darktable-generate-cache”離線產生整個照片庫的縮圖。"
+"啟用此選項將縮圖儲存至硬碟，讀取快取檔案可免去每次重新運算縮圖\n"
+"加快在燈箱模式內瀏覽大量影像時的運作速度\n"
+"\n"
+"這些縮圖不會被刪除，可以手動至 .cache\\darktable\\ 資料夾刪除以釋出硬碟空間\n"
+"\n"
+"可執行 bin\\darktable-generate-cache.exe 一次生成所有縮圖"
 
-#: ../build/bin/preferences_gen.h:6477
+#: ../build/bin/preferences_gen.h:6189
 msgid "enable disk backend for full preview cache"
-msgstr "爲全預覽快取啓用硬碟後援"
+msgstr "儲存完整預覽快取檔案至硬碟"
 
-#: ../build/bin/preferences_gen.h:6491
+#: ../build/bin/preferences_gen.h:6203
 msgid ""
 "if enabled, write full preview to disk (.cache/darktable/) when evicted from "
 "the memory cache. note that this can take a lot of memory (several gigabytes "
@@ -1578,40 +1578,41 @@ msgid ""
 "though to delete these manually, if you want. light table performance will "
 "be increased greatly when zooming image in full preview mode."
 msgstr ""
-"啓用後，當完整預覽圖從記憶體快取移除時將被寫入硬碟(.cache/darktable/)。注意這"
-"可能會使用大量記憶體(兩萬張圖片可能佔用數 GB)。硬碟上的預覽圖不會被自動刪除，"
-"但需要時您可以手動刪除該目錄內的檔案。此選項可以顯著提升在完整預覽模式下縮放"
-"影像時的性能。"
+"啟用此選項將完整預覽圖檔儲存至硬碟\n"
+"可以大幅提升燈箱（lighttable）模式放大影像瀏覽的速度\n"
+"\n"
+"這些快取檔案不會被刪除，且可能占用數 GB 的空間\n"
+"可手動至 .cache/darktable/ 資料夾刪除檔案以釋出硬碟空間"
 
-#: ../build/bin/preferences_gen.h:6513
+#: ../build/bin/preferences_gen.h:6225
 msgid "activate OpenCL support"
-msgstr "啓用 OpenCL 支援"
+msgstr "開啟 OpenCL 支援"
 
-#: ../build/bin/preferences_gen.h:6527
+#: ../build/bin/preferences_gen.h:6239
 msgid ""
 "if found, use OpenCL runtime on your system for improved processing speed. "
 "can be switched on and off at any time."
 msgstr ""
-"若您的系統上已安裝 OpenCL 執行程式時，將使用 OpenCL 提高處理速度。這一功能能"
-"夠隨時開啓或關閉。"
+"藉由 OpenCL 使用顯示卡運算來提高速度\n"
+"此功能需要支援的顯示卡和驅動程式，如果電腦不支援則此選項無法開啟"
 
-#: ../build/bin/preferences_gen.h:6528 ../build/bin/preferences_gen.h:6599
-#: ../build/bin/preferences_gen.h:6675 ../build/bin/preferences_gen.h:8051
+#: ../build/bin/preferences_gen.h:6240 ../build/bin/preferences_gen.h:6311
+#: ../build/bin/preferences_gen.h:6387 ../build/bin/preferences_gen.h:7763
 msgid "not available"
-msgstr "無法使用"
+msgstr "不支援"
 
-#: ../build/bin/preferences_gen.h:6531 ../build/bin/preferences_gen.h:6535
-#: ../build/bin/preferences_gen.h:6602 ../build/bin/preferences_gen.h:6606
-#: ../build/bin/preferences_gen.h:6678 ../build/bin/preferences_gen.h:6682
-#: ../build/bin/preferences_gen.h:8054 ../build/bin/preferences_gen.h:8058
+#: ../build/bin/preferences_gen.h:6243 ../build/bin/preferences_gen.h:6247
+#: ../build/bin/preferences_gen.h:6314 ../build/bin/preferences_gen.h:6318
+#: ../build/bin/preferences_gen.h:6390 ../build/bin/preferences_gen.h:6394
+#: ../build/bin/preferences_gen.h:7766 ../build/bin/preferences_gen.h:7770
 msgid "not available on this system"
-msgstr "在此系統無法使用"
+msgstr "沒有此功能需要的顯示卡和驅動程式"
 
-#: ../build/bin/preferences_gen.h:6555
+#: ../build/bin/preferences_gen.h:6267
 msgid "OpenCL scheduling profile"
-msgstr "OpenCL 排程配置"
+msgstr "OpenCL 設定"
 
-#: ../build/bin/preferences_gen.h:6598
+#: ../build/bin/preferences_gen.h:6310
 msgid ""
 "defines how preview and full pixelpipe tasks are scheduled on OpenCL enabled "
 "systems. default - GPU processes full and CPU processes preview pipe "
@@ -1619,169 +1620,188 @@ msgid ""
 "parallel on two different GPUs; very fast GPU - process both pixelpipes "
 "sequentially on the GPU."
 msgstr ""
-"此選項定義預覽及全影像任務在啓用 OpenCL 的系統上的排程模式。預設- GPU 處理全"
-"影像任務，CPU 處理預覽任務(可在設置中調整參數)；多個 GPU- 在多個 GPU 上並行處"
-"理兩種任務；非常快的 GPU - 在單個 GPU 上順序處理兩種任務。"
+"定義如何使用顯示卡執行影像預覽和編輯運算任務\n"
+"\n"
+"預設：顯示卡負責處理編輯運算，CPU 處理預覽縮圖\n"
+"多張顯示卡：在不同的顯示卡上並行處理兩種任務\n"
+"高階的顯示卡：兩種工作都交由顯示卡依序處理\n"
+"\n"
+"更多詳細內容及修改系統參數，請閱讀操作手冊的「multiple devices」章節"
 
-#: ../build/bin/preferences_gen.h:6626
+#: ../build/bin/preferences_gen.h:6338
 msgid "tune OpenCL performance"
-msgstr "調整 OpenCL 效能"
+msgstr "調整 OpenCL 性能"
 
-#: ../build/bin/preferences_gen.h:6674
+#: ../build/bin/preferences_gen.h:6386
 msgid ""
 "allows runtime tuning of OpenCL devices. 'memory size' tests for available "
 "graphics ram, 'memory transfer' tries a faster memory access mode (pinned "
 "memory) used for tiling."
 msgstr ""
-"允許執行時調整OpenCL裝置，記憶體大小測試可使用的繪圖卡記憶體，記憶體轉移嘗試"
-"更快的記憶體存取模式(鎖定記憶體)以平舖."
+"調整 OpenCL 性能\n"
+"\n"
+"不調整（預設）：\n"
+"不改變 OpenCL 的運作方式\n"
+"\n"
+"記憶體空間：\n"
+"對所有顯示卡記憶體保留 400MB 的空間，剩餘記憶體預設用於 OpenCL 運算\n"
+"\n"
+"記憶體傳輸：\n"
+"運算需要的紀體超過可用空間時，使用特殊模式將影像分解為多個區塊分開處理\n"
+"\n"
+"記憶體空間和傳輸：\n"
+"同時使用以上兩種機制\n"
+"\n"
+"不同調整方法可能提升或降低性能，甚至耗用更多記憶體，必須自行在安裝的電腦上進"
+"行測試。可以透過編輯 darktablerc 文件修改預設數值和多張顯示卡的獨立設定，或是"
+"設定自動檢查顯示卡可用記憶體空間，更多詳細內容請閱讀操作手冊的「memory & "
+"performance tuning」章節。"
 
-#: ../build/bin/preferences_gen.h:6708
+#: ../build/bin/preferences_gen.h:6420
 msgid "security"
-msgstr "安全性"
+msgstr "檔案安全"
 
-#: ../build/bin/preferences_gen.h:6731
+#: ../build/bin/preferences_gen.h:6443
 msgid "ask before removing images from the library"
-msgstr "從照片庫移除影像前詢問"
+msgstr "移除已匯入圖庫的影像前要求確認"
 
-#: ../build/bin/preferences_gen.h:6745
+#: ../build/bin/preferences_gen.h:6457
 msgid "always ask the user before removing image information from the library"
-msgstr "在從影像資料庫移除影像資訊前總是詢問使用者"
+msgstr "從圖庫中移除任何影像之前詢問使用者"
 
-#: ../build/bin/preferences_gen.h:6767
+#: ../build/bin/preferences_gen.h:6479
 msgid "ask before deleting images from disk"
-msgstr "從硬碟刪除影像前詢問"
+msgstr "刪除硬碟裡的影像檔案前要求確認"
 
-#: ../build/bin/preferences_gen.h:6781
+#: ../build/bin/preferences_gen.h:6493
 msgid "always ask the user before any image file is deleted"
-msgstr "在刪除任何影像檔案之前，總是詢問使用者"
+msgstr "在從硬碟裡刪除任何影像檔案之前詢問使用者"
 
-#: ../build/bin/preferences_gen.h:6803
+#: ../build/bin/preferences_gen.h:6515
 msgid "ask before discarding history stack"
-msgstr "丟棄歷史堆疊前詢問"
+msgstr "刪除影像編輯紀錄之前要求確認"
 
-#: ../build/bin/preferences_gen.h:6817
+#: ../build/bin/preferences_gen.h:6529
 msgid "always ask the user before history stack is discarded on any image"
-msgstr "在任何影像上丟棄歷史堆疊之前，總是詢問使用者"
+msgstr "在刪除任何影像編輯紀錄之前詢問使用者"
 
-#: ../build/bin/preferences_gen.h:6839
+#: ../build/bin/preferences_gen.h:6551
 msgid "try to use trash when deleting images"
-msgstr "刪除影像時嘗試使用回收桶"
+msgstr "刪除影像檔案時優先移至回收桶"
 
-#: ../build/bin/preferences_gen.h:6853
+#: ../build/bin/preferences_gen.h:6565
 msgid ""
 "send files to trash instead of permanently deleting files on system that "
 "supports it"
-msgstr "將檔案發送到回收桶，而不是永久刪除系統上的檔案"
+msgstr "在支援此功能的系統上嘗試將檔案丟到回收桶，而不是從硬碟中永遠刪除檔案"
 
-#: ../build/bin/preferences_gen.h:6875
+#: ../build/bin/preferences_gen.h:6587
 msgid "ask before moving images from film roll folder"
-msgstr "從軟片捲目錄中移除影像前詢問"
+msgstr "從底片卷中移動影像之前要求確認"
 
-#: ../build/bin/preferences_gen.h:6889
+#: ../build/bin/preferences_gen.h:6601
 msgid "always ask the user before any image file is moved."
-msgstr "移動任何影像前總是詢問使用者。"
+msgstr "在移動任何影像之前詢問使用者"
 
-#: ../build/bin/preferences_gen.h:6911
+#: ../build/bin/preferences_gen.h:6623
 msgid "ask before copying images to new film roll folder"
-msgstr "複製影像到新的軟片捲目錄前詢問"
+msgstr "複製影像到新的底片卷前要求確認"
 
-#: ../build/bin/preferences_gen.h:6925
+#: ../build/bin/preferences_gen.h:6637
 msgid "always ask the user before any image file is copied."
-msgstr "複製任何影像前總是詢問使用者。"
+msgstr "在複製任何影像前詢問使用者"
 
-#: ../build/bin/preferences_gen.h:6947
+#: ../build/bin/preferences_gen.h:6659
 msgid "ask before removing empty folders"
-msgstr "移除空目錄前詢問"
+msgstr "移除空的資料夾之前要求確認"
 
-#: ../build/bin/preferences_gen.h:6961
+#: ../build/bin/preferences_gen.h:6673
 msgid ""
 "always ask the user before removing any empty folder. this can happen after "
 "moving or deleting images."
-msgstr ""
-"在硬碟中刪除任何空目錄前總是詢問使用者。這可能發生在移動或刪除影像之後。"
+msgstr "在移除空的資料夾前詢問使用者，空的資料夾可能肇因於影像已被移動或刪除"
 
-#: ../build/bin/preferences_gen.h:6983
+#: ../build/bin/preferences_gen.h:6695
 msgid "ask before deleting a tag"
-msgstr "刪除標籤前詢問"
+msgstr "刪除標籤之前要求確認"
 
-#: ../build/bin/preferences_gen.h:7018
+#: ../build/bin/preferences_gen.h:6730
 msgid "ask before deleting a style"
-msgstr "刪除樣式前詢問"
+msgstr "刪除風格檔之前要求確認"
 
-#: ../build/bin/preferences_gen.h:7053
+#: ../build/bin/preferences_gen.h:6765
 msgid "ask before deleting a preset"
-msgstr "刪除預設配置前詢問"
+msgstr "刪除預設集之前要求確認"
 
-#: ../build/bin/preferences_gen.h:7067
+#: ../build/bin/preferences_gen.h:6779
 msgid "will ask for confirmation before deleting or overwriting a preset"
-msgstr "將在刪除或覆蓋預設配置前請求確認"
+msgstr "刪除或覆寫預設集之前詢問使用者"
 
-#: ../build/bin/preferences_gen.h:7089
+#: ../build/bin/preferences_gen.h:6801
 msgid "ask before exporting in overwrite mode"
-msgstr "在以覆蓋模式輸出前詢問"
+msgstr "匯出影像使用覆寫既有檔案模式時要求確認"
 
-#: ../build/bin/preferences_gen.h:7103
+#: ../build/bin/preferences_gen.h:6815
 msgid "will ask for confirmation before exporting files in overwrite mode"
-msgstr "將在以覆蓋模式輸出前請求確認"
+msgstr "在覆寫既有檔案模式下，要匯出檔案之前會詢問使用者"
 
 #. italic
-#: ../build/bin/preferences_gen.h:7113 ../src/libs/tools/viewswitcher.c:149
+#: ../build/bin/preferences_gen.h:6825 ../src/libs/tools/viewswitcher.c:149
 msgid "other"
 msgstr "其他"
 
-#: ../build/bin/preferences_gen.h:7133
+#: ../build/bin/preferences_gen.h:6845
 msgid "password storage backend to use"
-msgstr "要使用的密碼儲存後端"
+msgstr "儲存密碼使用的服務"
 
-#: ../build/bin/preferences_gen.h:7183
+#: ../build/bin/preferences_gen.h:6895
 msgid ""
 "the storage backend for password storage: auto, none, libsecret, kwallet"
-msgstr "用於保存密碼的儲存後端服務:自動，無，libsecret, kwallet"
+msgstr "用於密碼儲存的後端服務"
 
-#: ../build/bin/preferences_gen.h:7205
+#: ../build/bin/preferences_gen.h:6917
 msgid "executable for playing audio files"
-msgstr "用於播放音檔的可執行檔"
+msgstr "播放錄音檔案的程式"
 
-#: ../build/bin/preferences_gen.h:7223
+#: ../build/bin/preferences_gen.h:6935
 msgid ""
 "this external program is used to play audio files some cameras record to "
 "keep notes for images"
-msgstr "使用此外部程式播放相機記錄的影像備忘音檔"
+msgstr "使用此外部程式播放相機記錄的音訊檔案"
 
-#: ../build/bin/preferences_gen.h:7251
+#: ../build/bin/preferences_gen.h:6963
 msgid "storage"
-msgstr "儲存"
+msgstr "資料儲存"
 
-#: ../build/bin/preferences_gen.h:7254 ../src/control/crawler.c:609
+#: ../build/bin/preferences_gen.h:6966 ../src/control/crawler.c:609
 msgid "database"
 msgstr "資料庫"
 
-#: ../build/bin/preferences_gen.h:7274
+#: ../build/bin/preferences_gen.h:6986
 msgid "check for database maintenance"
-msgstr "檢查以維護資料庫"
+msgstr "檢查資料庫的時機"
 
-#: ../build/bin/preferences_gen.h:7337
+#: ../build/bin/preferences_gen.h:7049
 msgid ""
 "this option indicates when to check database fragmentation and perform "
 "maintenance"
-msgstr "此選項指示何時檢查資料庫破碎並執行維護"
+msgstr "指定什麼時候檢查 darktable 資料庫並執行維護"
 
-#: ../build/bin/preferences_gen.h:7359
+#: ../build/bin/preferences_gen.h:7071
 msgid "database fragmentation ratio threshold"
-msgstr "資料庫破碎比率臨界值"
+msgstr "資料庫破碎比例門檻"
 
-#: ../build/bin/preferences_gen.h:7382
+#: ../build/bin/preferences_gen.h:7094
 msgid ""
 "fragmentation ratio above which to ask or carry out automatically database "
 "maintenance"
-msgstr "要求或執行自動資料庫維護的破碎最低比率"
+msgstr "當破碎率高於這個設定，自動執行資料庫的維護"
 
-#: ../build/bin/preferences_gen.h:7404
+#: ../build/bin/preferences_gen.h:7116
 msgid "create database snapshot"
-msgstr "建立資料庫快照"
+msgstr "資料庫備份頻率"
 
-#: ../build/bin/preferences_gen.h:7457
+#: ../build/bin/preferences_gen.h:7169
 msgid ""
 "database snapshots are created right before closing darktable. options allow "
 "you to choose how often to make snapshots:\n"
@@ -1792,37 +1812,39 @@ msgid ""
 "once a day - create snapshot if over 24h passed since last snapshot\n"
 "on close - create snapshot every time darktable is closed"
 msgstr ""
-"資料庫快照會在 darktable 退出前建立。此選項可選擇建立快照的頻率:\n"
-"從不 —— 不要定期建立快照，只在每次版本更新時強制建立快照。\n"
-"每月 —— 距離上次快照超過一個月時建立快照\n"
-"每週 —— 距離上次快照超過 7 天時建立快照\n"
-"每天 —— 距離上次快照超過 24 小時時建立快照\n"
-"關閉時 —— 每次關閉 darktable 都建立快照"
+"darktable 關閉之前會建立資料庫備份，可以選擇備份的頻率\n"
+"\n"
+"絕不：不做任何備份，唯一製作的備份是強制性的版本升級備份\n"
+"每月一次：如果自上次備份以來已過去一個月，則建立備份\n"
+"每週一次：如果自上次備份以來已過去 7 天，則建立備份\n"
+"每天一次：如果自上次備份以來超過 24 小時，則建立備份\n"
+"關閉時：每次關閉 darktable 時建立備份"
 
-#: ../build/bin/preferences_gen.h:7479
+#: ../build/bin/preferences_gen.h:7191
 msgid "how many snapshots to keep"
-msgstr "要保留多少份快照"
+msgstr "資料庫備份數量"
 
-#: ../build/bin/preferences_gen.h:7502
+#: ../build/bin/preferences_gen.h:7214
 msgid ""
 "after successfully creating snapshot, how many older snapshots to keep "
 "(excluding mandatory version update ones). enter -1 to keep all snapshots\n"
 "keep in mind that snapshots do take some space and you only need the most "
 "recent one for successful restore"
 msgstr ""
-"每次建立快照後保留的舊快照數(不包括版本更新時的強制快照)。輸入 -1 以保留所有"
-"快照。\n"
-"注意:快照會佔用一定的硬碟空間。您只需要最近的快照即可完成恢復"
+"要保留的備份數量（不包括版本更新的強制性快照）\n"
+"輸入「-1」會保留所有備份，不自動刪除舊的備份\n"
+"備份儲存於 \\Users\\username\\AppData\\Local\\darktable\\ \n"
+"備份檔案會佔用一些硬碟空間，而且只需要最新的備份即可成功還原"
 
-#: ../build/bin/preferences_gen.h:7512 ../src/control/crawler.c:608
+#: ../build/bin/preferences_gen.h:7224 ../src/control/crawler.c:608
 msgid "xmp"
-msgstr "xmp資料"
+msgstr "XMP"
 
-#: ../build/bin/preferences_gen.h:7532
+#: ../build/bin/preferences_gen.h:7244
 msgid "write sidecar file for each image"
-msgstr "爲每個圖片寫入附屬檔案"
+msgstr "為每張影像儲存附屬檔案"
 
-#: ../build/bin/preferences_gen.h:7575
+#: ../build/bin/preferences_gen.h:7287
 msgid ""
 "the sidecar files hold information about all your development steps to allow "
 "flawless re-importing of image files.\n"
@@ -1832,398 +1854,417 @@ msgid ""
 " - on import: immediately after importing the image\n"
 " - after edit: after any user change on the image"
 msgstr ""
-"附屬檔案記錄了您在輸入後的照片處理步驟，讓您可以正確的重新輸入影像檔。\n"
+"附屬檔案包含所有編輯步驟的資訊，儲存 XMP 檔案可以在日後完整重新匯入影像\n"
 "\n"
-"根據在此選擇的模式\n"
-" - 從不:從不寫入附屬檔案\n"
-" - 輸入時:輸入影像時立即寫入附屬檔案\n"
-" - 編輯後:在更改任何影像後寫入附屬檔案"
+"絕不：\n"
+"不要儲存 XMP，如果只是要短暫測試可以使用這個設定，但通常不推薦使用\n"
+"匯入時：\n"
+"影像匯入到 darktable 圖庫後立即儲存 XMP，每次編輯時都會進行更新\n"
+"編輯後 : \n"
+"導入影像不儲存 XMP，第一次對影像執行編輯時才儲存，並在每次後續編輯更新\n"
+"\n"
+"強烈建議選擇「匯入時」或「編輯後」，避免在資料庫損壞時遺失數據。只要同時備份 "
+"RAW 和隨附的 XMP 檔案，便可以將完整的影像編輯紀錄重新匯入 darktable，完全恢復"
+"之前的工作。"
 
-#: ../build/bin/preferences_gen.h:7597
+#: ../build/bin/preferences_gen.h:7309
 msgid "store xmp tags in compressed format"
-msgstr "以壓縮格式存儲 xmp 標記"
+msgstr "壓縮附屬檔案"
 
-#: ../build/bin/preferences_gen.h:7640
+#: ../build/bin/preferences_gen.h:7352
 msgid ""
 "entries in xmp tags can get rather large and may exceed the available space "
 "to store the history stack in output files. this option allows xmp tags to "
 "be compressed and save space."
 msgstr ""
-"xmp 標籤中的條目相當大，可能會超過輸出檔案中存儲歷史堆疊的可用空間。此選項允"
-"許壓縮 xmp 標籤以節約空間。"
+"附屬檔案隨著影像編輯可能會變得很大\n"
+"此選項可以壓縮 XMP 以節省空間"
 
-#: ../build/bin/preferences_gen.h:7662
+#: ../build/bin/preferences_gen.h:7374
 msgid "look for updated xmp files on startup"
-msgstr "啓動時搜尋更新過的 xmp 檔案"
+msgstr "在啟動時檢查 XMP 檔案更新"
 
-#: ../build/bin/preferences_gen.h:7676
+#: ../build/bin/preferences_gen.h:7388
 msgid ""
 "check file modification times of all xmp files on startup to check if any "
 "got updated in the meantime"
-msgstr "啓動時檢查所有 xmp 檔案的變更時間以判斷檔案是否已更新"
+msgstr ""
+"在 darktable 啟動時檢查所有 XMP\n"
+"如果找到更新的 XMP 文件會詢問要載入哪個 XMP 檔案"
 
-#: ../build/bin/preferences_gen.h:7704
+#: ../build/bin/preferences_gen.h:7416
 msgid "miscellaneous"
-msgstr "雜項"
+msgstr "其他設定"
 
-#: ../build/bin/preferences_gen.h:7707
+#: ../build/bin/preferences_gen.h:7419
 msgid "interface"
-msgstr "介面"
+msgstr "介面配置"
 
-#: ../build/bin/preferences_gen.h:7727
+#: ../build/bin/preferences_gen.h:7439
 msgid "load default shortcuts at startup"
-msgstr "啟動時載入預設捷徑"
+msgstr "啟動時載入預設快速鍵"
 
-#: ../build/bin/preferences_gen.h:7741
+#: ../build/bin/preferences_gen.h:7453
 msgid ""
 "load default shortcuts before user settings. switch off to prevent deleted "
 "defaults returning"
-msgstr "在使用者設定前載入預設捷徑，關掉以預防已刪除的預設值回復"
+msgstr ""
+"先載入預設的快速鍵，然後載入使用者設定\n"
+"可以避免預設快速鍵被刪除後無法啟用，尤其是在版本更新之後新加入的快速鍵\n"
+"若要關閉已手動刪除的預設快速鍵，則不應啟用此選項"
 
-#: ../build/bin/preferences_gen.h:7763
+#: ../build/bin/preferences_gen.h:7475
 msgid "scale slider step with min/max"
-msgstr "以最小值/最大值設定滑動條縮放級數"
+msgstr "自動調整滑桿精度"
 
-#: ../build/bin/preferences_gen.h:7777
+#: ../build/bin/preferences_gen.h:7489
 msgid "vary bauhaus slider step size with min/max range"
-msgstr "以最小值/最大值為範圍，改變包浩斯滑動條級數"
+msgstr "依據要調整數值的最小值 / 最大值範圍，改變滑桿調整時的每步精度"
 
-#: ../build/bin/preferences_gen.h:7799
+#: ../build/bin/preferences_gen.h:7511
 msgid "sort built-in presets first"
-msgstr "先對內建配置排序"
+msgstr "內建預設集排列在前"
 
-#: ../build/bin/preferences_gen.h:7813
+#: ../build/bin/preferences_gen.h:7525
 msgid ""
 "whether to show built-in presets first before user's presets in presets menu."
-msgstr "是否先顯示內建配置，然後在預設配置選單中顯示使用者預設配置。"
+msgstr ""
+"預設集的排列方式\n"
+"勾選時先顯示內建預設集然後才是使用者自訂的預設集\n"
+"若取消則使用者自訂的預設集顯示在前"
 
-#: ../build/bin/preferences_gen.h:7835
+#: ../build/bin/preferences_gen.h:7547
 msgid "mouse wheel scrolls modules side panel by default"
-msgstr "預設滑鼠滾輪滾動模組側面板"
+msgstr "使用滑鼠滾輪滾動模組面板"
 
-#: ../build/bin/preferences_gen.h:7849
+#: ../build/bin/preferences_gen.h:7561
 msgid ""
 "when enabled, use mouse wheel to scroll modules side panel.  use ctrl+alt to "
 "use mouse wheel for data entry.  when disabled, this behavior is reversed"
 msgstr ""
-"啓用時，使用滑鼠滾輪滾動模組側面版。按住 控制鍵 + alt 時滑鼠滾輪用於資料輸"
-"入。不使用時滾動行爲相反"
+"不啟用（預設）：滑鼠滾輪用於調整參數，滑鼠移至最外側卷軸處以捲動整個面板\n"
+"啟用此選項：使用滑鼠滾輪上下捲動模組面板，以組合按鍵進行模組內的參數修改\n"
+"\n"
+"   alt + 滑鼠滾輪 = 調整模組參數\n"
+"  ctrl + 滑鼠滾輪 = 微調模組參數\n"
+"shift + 滑鼠滾輪 = 快調模組參數"
 
-#: ../build/bin/preferences_gen.h:7871
+#: ../build/bin/preferences_gen.h:7583
 msgid "always show panels' scrollbars"
-msgstr "總是顯示面板滾動條"
+msgstr "顯示模組面板的卷軸"
 
-#: ../build/bin/preferences_gen.h:7885
+#: ../build/bin/preferences_gen.h:7597
 msgid ""
 "defines whether the panel scrollbars should be always visible or activated "
 "only depending on the content.  (need a restart)"
-msgstr ""
-"此選項控制面板滾動條是否始終可見或者根據內容自動隱藏。此選項在重啓後生效。"
+msgstr "自訂是否永遠顯示模組面板的卷軸，或僅根據內容自動隱藏與顯示"
 
-#: ../build/bin/preferences_gen.h:7907
+#: ../build/bin/preferences_gen.h:7619
 msgid "position of the scopes module"
-msgstr "範圍模組的位置"
+msgstr "色彩分布顯示器的位置"
 
-#: ../build/bin/preferences_gen.h:7945
+#: ../build/bin/preferences_gen.h:7657
 msgid "position the scopes at the top-left or top-right of the screen"
-msgstr "將範圍放置於屏幕左上角或右上角"
+msgstr "將「色彩分布顯示器」放在螢幕左上角或右上角"
 
-#: ../build/bin/preferences_gen.h:7967
+#: ../build/bin/preferences_gen.h:7679
 msgid "method to use for getting the display profile"
-msgstr "用於獲取顯示配置檔案的方法"
+msgstr "取得螢幕描述檔的方式"
 
-#: ../build/bin/preferences_gen.h:8010
+#: ../build/bin/preferences_gen.h:7722
 msgid ""
 "this option allows to force a specific means of getting the current display "
 "profile. this is useful when one alternative gives wrong results"
 msgstr ""
-"此選項可以強制使用特定方式獲取顯示器的色彩管理配置。特別有用當其中一個方式返"
-"回錯誤結果時"
+"允許用戶強制 darktable 使用特定方法取得螢幕的色彩描述檔以進行顏色管理\n"
+"若不同方法獲得的描述檔不一致，可以手動指定其中一個方法以強制執行"
 
-#: ../build/bin/preferences_gen.h:8032
+#: ../build/bin/preferences_gen.h:7744
 msgid "order or exclude midi devices"
-msgstr "順序或不含midi裝置"
+msgstr "排序或排除 MIDI 控制設備"
 
-#: ../build/bin/preferences_gen.h:8050
+#: ../build/bin/preferences_gen.h:7762
 msgid ""
 "comma-separated list of device name fragments that if matched load midi "
 "device at id given by location in list or if preceded by - prevent matching "
 "devices from loading. add encoding and number of knobs like 'BeatStep:63:16'"
 msgstr ""
-"比對到以逗號分隔裝置名稱片段的列表時載入midi裝置，id為列表中的位置，如果裝置"
-"名稱之前有- 則比對到的裝置不載入\n"
-"加上編碼及旋鈕數如'BeatStep:63:16'"
+"以「;」分隔 MIDI 設備的名稱列表，如果有符合的設備會以列表中位置指定識別碼\n"
+"在設備名稱前加上「-」，則不使用該設備\n"
+"\n"
+"更多詳細內容及參數，請閱讀操作手冊的「midi device support」章節"
 
 #. tags
-#: ../build/bin/preferences_gen.h:8066 ../src/develop/lightroom.c:1516
+#: ../build/bin/preferences_gen.h:7778 ../src/develop/lightroom.c:1516
 #: ../src/gui/import_metadata.c:476 ../src/libs/export_metadata.c:331
 #: ../src/libs/image.c:560 ../src/libs/metadata_view.c:162
 msgid "tags"
 msgstr "標籤"
 
-#: ../build/bin/preferences_gen.h:8086
+#: ../build/bin/preferences_gen.h:7798
 msgid "omit hierarchy in simple tag lists"
-msgstr "省略簡單標籤列表中的層次結構"
+msgstr "省略簡單標籤清單中的層次結構"
 
-#: ../build/bin/preferences_gen.h:8100
+#: ../build/bin/preferences_gen.h:7812
 msgid ""
 "when creating XMP file the hierarchical tags are also added as a simple list "
 "of non-hierarchical ones to make them visible to some other programs. when "
 "this option is checked darktable will only include their last part and "
 "ignore the rest. so 'foo|bar|baz' will only add 'baz'."
 msgstr ""
-"建立 xmp 檔案時，層級標籤也會以無結構列表插入，以允許其他程序使用這些標籤。當"
-"此選項啓用時，darktable 將只會插入層級標籤最後的部分。例如“foo|bar|baz”會"
-"以“baz”增加。"
+"建立 XMP 檔案時使用無樹狀結構的簡單標籤，增加其他軟體的相容性\n"
+"開啟此選項後，darktable 只儲存底層標籤而忽略其上層標籤結構\n"
+"例如：City|Taiwan|Taipei，只會儲存 Taipei 單一個標籤"
 
-#: ../build/bin/preferences_gen.h:8110
+#: ../build/bin/preferences_gen.h:7822
 msgid "shortcuts with multiple instances"
-msgstr "具有多個實例的鍵盤快捷鍵"
+msgstr "多個模組實例快速鍵控制"
 
-#: ../build/bin/preferences_gen.h:8115
+#: ../build/bin/preferences_gen.h:7827
 msgid ""
 "where multiple module instances are present, these preferences control rules "
 "that are applied (in order) to decide which module instance shortcuts will "
 "be applied to"
-msgstr "當模組有多個實例時，此選項控制快捷鍵應用於多個模組時的優先順序"
+msgstr "有多個相同的模組實例時，以下規則依序決定快速鍵應該作用到那些模組中"
 
-#: ../build/bin/preferences_gen.h:8131
+#: ../build/bin/preferences_gen.h:7843
 msgid "prefer focused instance"
-msgstr "偏好焦點程式"
+msgstr "選取中的模組優先"
 
-#: ../build/bin/preferences_gen.h:8145
+#: ../build/bin/preferences_gen.h:7857
 msgid ""
 "if an instance of the module has focus, apply shortcut to that instance\n"
 "note: blending shortcuts always apply to the focused instance"
 msgstr ""
-"如果模組成為焦點，套用捷徑到此程式\n"
-"注意，混合捷徑總是套用到焦點程式"
+"快速鍵套用在目前選取的模組，並忽略其他相同的模組\n"
+"備註： 混合快速鍵永遠作用於選取的模組"
 
-#: ../build/bin/preferences_gen.h:8167
+#: ../build/bin/preferences_gen.h:7879
 msgid "prefer expanded instances"
-msgstr "優先應用於展開的實例"
+msgstr "已展開的模組優先"
 
-#: ../build/bin/preferences_gen.h:8181
+#: ../build/bin/preferences_gen.h:7893
 msgid "if instances of the module are expanded, ignore collapsed instances"
-msgstr "當部分實例已展開時，快捷鍵將忽略已摺疊的實例"
+msgstr "如果模組實例中有已展開的，快速鍵將套用在該模組，並忽略未展開的模組"
 
-#: ../build/bin/preferences_gen.h:8203
+#: ../build/bin/preferences_gen.h:7915
 msgid "prefer enabled instances"
-msgstr "優先應用於啓用的實例"
+msgstr "已啟用的模組優先"
 
-#: ../build/bin/preferences_gen.h:8217
+#: ../build/bin/preferences_gen.h:7929
 msgid ""
 "after applying the above rule, if instances of the module are active, ignore "
 "inactive instances"
-msgstr "當套用以上規則後，當模組已啓用時，將忽略不使用的"
+msgstr "當有模組實例處於啟用狀態，快速鍵會忽略其他未啟用的相同模組"
 
-#: ../build/bin/preferences_gen.h:8239
+#: ../build/bin/preferences_gen.h:7951
 msgid "prefer unmasked instances"
-msgstr "優先套用於未遮罩的實例"
+msgstr "無遮罩控制的模組優先"
 
-#: ../build/bin/preferences_gen.h:8253
+#: ../build/bin/preferences_gen.h:7965
 msgid ""
 "after applying the above rules, if instances of the module are unmasked, "
 "ignore masked instances"
-msgstr "當套用以上規則後，如果使用的模組未遮罩，處於遮罩狀態的將被忽略"
+msgstr "當有模組實例未使用遮罩，快速鍵會忽略其他有使用遮罩範圍的相同模組"
 
-#: ../build/bin/preferences_gen.h:8275
+#: ../build/bin/preferences_gen.h:7987
 msgid "selection order"
-msgstr "選擇順序"
+msgstr "依模組順序"
 
-#: ../build/bin/preferences_gen.h:8313
+#: ../build/bin/preferences_gen.h:8025
 msgid ""
 "after applying the above rules, apply the shortcut based on its position in "
 "the pixelpipe"
-msgstr "當套用以上規則後，根據處理管線中的位置套用快捷鍵"
+msgstr "根據模組的處理順序套用快速鍵"
 
-#: ../build/bin/preferences_gen.h:8335
+#: ../build/bin/preferences_gen.h:8047
 msgid "allow visual assignment to specific instances"
-msgstr "允許對特定實例進行可視化分配"
+msgstr "手動控制特定模組"
 
-#: ../build/bin/preferences_gen.h:8349
+#: ../build/bin/preferences_gen.h:8061
 msgid ""
 "when multiple instances are present on an image this allows shortcuts to be "
 "visually assigned to those specific instances\n"
 "otherwise shortcuts will always be assigned to the preferred instance"
 msgstr ""
-"當影像上有同一模組的多個實例時，允許快捷鍵以可視方式分配到特定模組\n"
-"否則快捷鍵將被分配到偏好的實例上"
+"允許將快速鍵直接分配給某些特定的模組實例\n"
+"未勾選時快速鍵將依以上設定套用"
 
-#: ../build/bin/preferences_gen.h:8359
+#: ../build/bin/preferences_gen.h:8071
 msgid "map / geolocalization view"
-msgstr "地圖與地理定位視角"
+msgstr "地圖 / 地理位置檢視"
 
-#: ../build/bin/preferences_gen.h:8379
+#: ../build/bin/preferences_gen.h:8091
 msgid "pretty print the image location"
-msgstr "列印影像的位置"
+msgstr "顯示美觀的影像位置"
 
-#: ../build/bin/preferences_gen.h:8393
+#: ../build/bin/preferences_gen.h:8105
 msgid ""
 "show a more readable representation of the location in the image information "
 "module"
-msgstr "在影像資訊模組中顯示更具可讀性的位置標示"
+msgstr "在「影像資訊」模組中顯示更易辨讀的地理位置"
 
-#: ../build/bin/preferences_gen.h:8403
+#: ../build/bin/preferences_gen.h:8115
 msgid "slideshow view"
-msgstr "幻燈片視角"
+msgstr "影像輪播"
 
-#: ../build/bin/preferences_gen.h:8423
+#: ../build/bin/preferences_gen.h:8135
 msgid "waiting time between each picture in slideshow"
-msgstr "幻燈片放映中每張圖片之間的等待時間"
+msgstr "每張影像之間的間隔時間"
 
-#: ../build/bin/preferences_gen.h:8473 ../src/control/jobs/control_jobs.c:2338
+#: ../build/bin/preferences_gen.h:8185 ../src/control/jobs/control_jobs.c:2338
 #: ../src/libs/import.c:172
 msgid "import"
-msgstr "輸入"
+msgstr "影像匯入"
 
-#: ../build/bin/preferences_gen.h:8476
+#: ../build/bin/preferences_gen.h:8188
 msgid "session options"
-msgstr "期間選項"
+msgstr "工作階段選項"
 
-#: ../build/bin/preferences_gen.h:8496
+#: ../build/bin/preferences_gen.h:8208
 msgid "base directory naming pattern"
-msgstr "基本目錄命名樣式"
+msgstr "根目錄命名方式"
 
-#: ../build/bin/preferences_gen.h:8514 ../build/bin/preferences_gen.h:8554
+#: ../build/bin/preferences_gen.h:8226 ../build/bin/preferences_gen.h:8266
 msgid "part of full import path for an import session"
-msgstr "影像輸入期間的部分整體輸入路徑"
+msgstr "匯入作業的儲存路徑"
 
-#: ../build/bin/preferences_gen.h:8536
+#: ../build/bin/preferences_gen.h:8248
 msgid "sub directory naming pattern"
-msgstr "子目錄命名樣式"
+msgstr "子資料夾命名方式"
 
-#: ../build/bin/preferences_gen.h:8576
+#: ../build/bin/preferences_gen.h:8288
 msgid "keep original filename"
-msgstr "保留原始檔案名"
+msgstr "保留原始檔名"
 
-#: ../build/bin/preferences_gen.h:8590
+#: ../build/bin/preferences_gen.h:8302
 msgid ""
 "keep original filename instead of a pattern while importing from camera or "
 "card"
-msgstr "從相機或記憶卡輸入時保留原始檔案名而非樣式"
+msgstr "從相機或記憶卡匯入時保留原始檔名而不依下項方式重命名"
 
-#: ../build/bin/preferences_gen.h:8612
+#: ../build/bin/preferences_gen.h:8324
 msgid "file naming pattern"
-msgstr "檔案命名樣式"
+msgstr "檔案命名方式"
 
-#: ../build/bin/preferences_gen.h:8630
+#: ../build/bin/preferences_gen.h:8342
 msgid "file naming pattern used for a import session"
-msgstr "輸入期間使用之檔案命名樣式"
+msgstr "匯入作業的檔案命名方式"
 
-#: ../build/bin/preferences_gen.h:8667
+#: ../build/bin/preferences_gen.h:8379
 msgid "do not set the 'uncategorized' entry for tags"
-msgstr "不設定“不分類(uncategorized)”標籤"
+msgstr "不要設定未分類標籤"
 
-#: ../build/bin/preferences_gen.h:8681
+#: ../build/bin/preferences_gen.h:8393
 msgid ""
 "do not set the 'uncategorized' entry for tags which do not have children"
-msgstr "當標籤沒有子標籤時不設定“不分類(uncategorized)”標籤"
+msgstr "不要為沒有子標籤的標籤設定「未分類」類別"
 
-#: ../build/bin/preferences_gen.h:8703
+#: ../build/bin/preferences_gen.h:8415
 msgid "tags case sensitivity"
-msgstr "標籤是否區分大小寫"
+msgstr "標籤區分大小寫"
 
-#: ../build/bin/preferences_gen.h:8741
+#: ../build/bin/preferences_gen.h:8453
 msgid ""
 "tags case sensitivity. without the Sqlite ICU extension, insensitivity works "
 "only for the 26 latin letters"
-msgstr ""
-"標籤是否區分大小寫。在沒有 SQLite ICU 擴充的情況下，不區分大小寫僅適用於 26 "
-"個拉丁字母"
+msgstr "設定標籤是否區分大小寫，僅限於 26 個英文字母"
 
-#: ../build/bin/preferences_gen.h:8763 ../build/bin/preferences_gen.h:9003
+#: ../build/bin/preferences_gen.h:8475 ../build/bin/preferences_gen.h:8715
 msgid "number of collections to be stored"
-msgstr "要保存的集合數量"
+msgstr "紀錄的相冊數量"
 
-#: ../build/bin/preferences_gen.h:8787 ../build/bin/preferences_gen.h:9027
+#: ../build/bin/preferences_gen.h:8499 ../build/bin/preferences_gen.h:8739
 msgid "the number of recent collections to store and show in this list"
-msgstr "此列表中最近使用集合的顯示數量"
+msgstr "要在最近用過的相冊中記錄和顯示的數量"
 
-#: ../build/bin/preferences_gen.h:8809
+#: ../build/bin/preferences_gen.h:8521
 msgid "hide the history button and show a specific module instead"
-msgstr "隱藏歷史按鈕而顯示特定模組"
+msgstr "顯示「最近用過的相冊」模組"
 
-#: ../build/bin/preferences_gen.h:8823
+#: ../build/bin/preferences_gen.h:8535
 msgid "hide the history button and show the recent collections module instead"
-msgstr "隱藏歷史按鈕而顯示最近的集合模組"
+msgstr "隱藏歷史紀錄按鈕，顯示舊版「最近用過的相冊」模組"
 
-#: ../build/bin/preferences_gen.h:8845
+#: ../build/bin/preferences_gen.h:8557
 msgid "number of folder levels to show in lists"
-msgstr "列表中要顯示的目錄層級數"
+msgstr "顯示的資料夾層數"
 
-#: ../build/bin/preferences_gen.h:8869
+#: ../build/bin/preferences_gen.h:8581
 msgid ""
 "the number of folder levels to show in film roll names, starting from the "
 "right"
-msgstr "指定軟片捲名稱中要顯示的檔案目錄層數，從右邊開始"
+msgstr "指定底片卷名稱之前要顯示的資料夾層數"
 
-#: ../build/bin/preferences_gen.h:8891
+#: ../build/bin/preferences_gen.h:8603
 msgid "sort film rolls by"
-msgstr "軟片捲排序依據"
+msgstr "底片卷排列順序"
 
-#: ../build/bin/preferences_gen.h:8929
+#: ../build/bin/preferences_gen.h:8641
 msgid "sets the collections-list order for film rolls"
-msgstr "設置軟片捲的集合列表順序"
+msgstr ""
+"設置底片卷的順序依「資料夾」（檔案路徑）或「影像識別碼」（匯入底片的日期）"
 
-#: ../build/bin/preferences_gen.h:8951
+#: ../build/bin/preferences_gen.h:8663
 msgid "sort collection descending"
-msgstr "降序排列影像集合"
+msgstr "降序排列相冊"
 
-#: ../build/bin/preferences_gen.h:8965
+#: ../build/bin/preferences_gen.h:8677
 msgid ""
 "sort the following collections in descending order: 'film roll' by folder, "
 "'folder', 'times' (e.g. 'capture date')"
-msgstr "以降序方式來排序下列集合: 軟片捲依據目錄，目錄，時間(如拍攝時間)"
+msgstr "以降序方式排列以下項目：「底片卷」、「資料夾」、「時間」"
 
-#: ../build/bin/preferences_gen.h:9049
+#: ../build/bin/preferences_gen.h:8761
 msgid "prefer a history button in the collections module"
-msgstr "偏好集合模組中的歷史按鈕"
+msgstr "使用「歷史紀錄」按鈕"
 
-#: ../build/bin/preferences_gen.h:9063
+#: ../build/bin/preferences_gen.h:8775
 msgid ""
 "hide this module and instead access collections history with a button in the "
 "collections module"
-msgstr "隱藏此模組而在集合模組內使用按鈕以以存取集合歷史"
+msgstr "隱藏這個模組，使用相冊模組裡的「歷史紀錄」按鈕來套用過去的設定"
 
-#: ../build/bin/preferences_gen.h:9117
+#: ../build/bin/preferences_gen.h:8829
 msgid "suggested tags level of confidence"
-msgstr "建議信賴度標籤"
+msgstr "建議標籤的可信度"
 
-#: ../build/bin/preferences_gen.h:9142
+#: ../build/bin/preferences_gen.h:8854
 #, no-c-format
 msgid ""
 "level of confidence to include the tag in the suggestions list, 0: all "
 "associated tags, 99: 99% matching associated tags, 100: no matching tag to "
 "show only recent tags (faster)"
 msgstr ""
-"包含此標籤在建議表列的信賴度，0:所有相關標籤，99: 99%比對到的相關標籤，100:沒"
-"有比對標籤只顯示最近標籤(較快)"
+"自動建議標籤清單的可信度\n"
+"0：顯示所有關聯的標籤\n"
+"99：以 99% 的可信度匹配標籤\n"
+"100：不可能達到的水準，因此不會顯示符合的標籤，而是最近使用的標籤"
 
-#: ../build/bin/preferences_gen.h:9164
+#: ../build/bin/preferences_gen.h:8876
 msgid "number of recently attached tags"
-msgstr "最近附加的標籤數"
+msgstr "最近使用的標籤數量"
 
-#: ../build/bin/preferences_gen.h:9188
+#: ../build/bin/preferences_gen.h:8900
 msgid ""
 "number of recently attached tags which are included in the suggestions list. "
 "the value `-1' disables the recent list"
-msgstr "最近附加在建議表列的標籤數，-1:不使用最近表列"
+msgstr "建議標籤列表要顯示的最近使用標籤數量，「-1」會停用此功能"
 
 #: ../build/lib/darktable/plugins/introspection_ashift.c:130
 #: ../build/lib/darktable/plugins/introspection_ashift.c:279
 msgid "lens shift (vertical)"
-msgstr "鏡頭平移(垂直)"
+msgstr "鏡頭垂直平移"
 
 #: ../build/lib/darktable/plugins/introspection_ashift.c:136
 #: ../build/lib/darktable/plugins/introspection_ashift.c:283
 msgid "lens shift (horizontal)"
-msgstr "鏡頭平移(水平)"
+msgstr "鏡頭水平平移"
 
 #: ../build/lib/darktable/plugins/introspection_ashift.c:142
 #: ../build/lib/darktable/plugins/introspection_ashift.c:287
 msgid "shear"
-msgstr "剪切"
+msgstr "對角剪切變形"
 
 #. focal length
 #: ../build/lib/darktable/plugins/introspection_ashift.c:148
@@ -2237,12 +2278,12 @@ msgstr "鏡頭焦距"
 #: ../build/lib/darktable/plugins/introspection_ashift.c:154
 #: ../build/lib/darktable/plugins/introspection_ashift.c:295
 msgid "crop factor"
-msgstr "裁剪係數"
+msgstr "裁切係數"
 
 #: ../build/lib/darktable/plugins/introspection_ashift.c:160
 #: ../build/lib/darktable/plugins/introspection_ashift.c:299
 msgid "lens dependence"
-msgstr "鏡頭相關"
+msgstr "依賴於鏡頭特性"
 
 #: ../build/lib/darktable/plugins/introspection_ashift.c:166
 #: ../build/lib/darktable/plugins/introspection_ashift.c:303
@@ -2260,7 +2301,7 @@ msgstr "鏡頭型號"
 #: ../build/lib/darktable/plugins/introspection_clipping.c:244
 #: ../build/lib/darktable/plugins/introspection_clipping.c:371
 msgid "automatic cropping"
-msgstr "自動剪裁"
+msgstr "自動裁切"
 
 #: ../build/lib/darktable/plugins/introspection_ashift.c:361
 msgid "generic"
@@ -2275,12 +2316,12 @@ msgstr "特定"
 #: ../build/lib/darktable/plugins/introspection_colorin.c:301
 #: ../build/lib/darktable/plugins/introspection_vignette.c:263
 #: ../src/develop/blend_gui.c:101 ../src/develop/blend_gui.c:124
-#: ../src/develop/blend_gui.c:2974 ../src/develop/develop.c:2248
+#: ../src/develop/blend_gui.c:2974 ../src/develop/develop.c:2246
 #: ../src/gui/accelerators.c:121 ../src/gui/accelerators.c:130
 #: ../src/gui/accelerators.c:198 ../src/imageio/format/avif.c:825
 #: ../src/imageio/format/j2k.c:672 ../src/libs/live_view.c:361
 msgid "off"
-msgstr "關"
+msgstr "關閉"
 
 #: ../build/lib/darktable/plugins/introspection_ashift.c:367
 msgid "largest area"
@@ -2288,12 +2329,12 @@ msgstr "最大面積"
 
 #: ../build/lib/darktable/plugins/introspection_ashift.c:368
 msgid "original format"
-msgstr "原始格式"
+msgstr "原始比例"
 
 #: ../build/lib/darktable/plugins/introspection_basecurve.c:134
 #: ../build/lib/darktable/plugins/introspection_basecurve.c:231
 msgid "fusion"
-msgstr "融合"
+msgstr "曝光融合"
 
 #: ../build/lib/darktable/plugins/introspection_basecurve.c:140
 #: ../build/lib/darktable/plugins/introspection_basecurve.c:235
@@ -2304,7 +2345,7 @@ msgstr "曝光偏移"
 #: ../build/lib/darktable/plugins/introspection_basecurve.c:239
 #: ../src/libs/metadata_view.c:142
 msgid "exposure bias"
-msgstr "曝光偏差"
+msgstr "曝光補償"
 
 #: ../build/lib/darktable/plugins/introspection_basecurve.c:152
 #: ../build/lib/darktable/plugins/introspection_basecurve.c:243
@@ -2317,7 +2358,7 @@ msgstr "曝光偏差"
 #: ../build/lib/darktable/plugins/introspection_tonecurve.c:153
 #: ../build/lib/darktable/plugins/introspection_tonecurve.c:244
 msgid "preserve colors"
-msgstr "保留顏色"
+msgstr "保留色彩"
 
 #: ../build/lib/darktable/plugins/introspection_basecurve.c:262
 #: ../build/lib/darktable/plugins/introspection_basicadj.c:249
@@ -2325,7 +2366,7 @@ msgstr "保留顏色"
 #: ../build/lib/darktable/plugins/introspection_rgbcurve.c:251
 #: ../build/lib/darktable/plugins/introspection_rgblevels.c:153
 #: ../build/lib/darktable/plugins/introspection_tonecurve.c:270
-#: ../src/gui/guides.c:712 ../src/iop/basecurve.c:2082
+#: ../src/gui/guides.c:712 ../src/iop/basecurve.c:2081
 #: ../src/iop/channelmixerrgb.c:4229 ../src/iop/clipping.c:1918
 #: ../src/iop/clipping.c:2111 ../src/iop/clipping.c:2126
 #: ../src/iop/lens.cc:2268 ../src/iop/retouch.c:460 ../src/libs/collect.c:1905
@@ -2341,8 +2382,8 @@ msgstr "無"
 #: ../build/lib/darktable/plugins/introspection_rgblevels.c:154
 #: ../build/lib/darktable/plugins/introspection_tonecurve.c:271
 #: ../src/develop/blend_gui.c:2007 ../src/develop/blend_gui.c:2026
-#: ../src/iop/colorbalancergb.c:2153 ../src/iop/colorbalancergb.c:2154
-#: ../src/iop/colorbalancergb.c:2155 ../src/iop/colorbalancergb.c:2156
+#: ../src/iop/colorbalancergb.c:2150 ../src/iop/colorbalancergb.c:2151
+#: ../src/iop/colorbalancergb.c:2152 ../src/iop/colorbalancergb.c:2153
 msgid "luminance"
 msgstr "亮度"
 
@@ -2353,7 +2394,7 @@ msgstr "亮度"
 #: ../build/lib/darktable/plugins/introspection_rgblevels.c:155
 #: ../build/lib/darktable/plugins/introspection_tonecurve.c:272
 msgid "max RGB"
-msgstr "最大 RGB"
+msgstr "RGB 最大值"
 
 #: ../build/lib/darktable/plugins/introspection_basecurve.c:265
 #: ../build/lib/darktable/plugins/introspection_basicadj.c:252
@@ -2361,7 +2402,7 @@ msgstr "最大 RGB"
 #: ../build/lib/darktable/plugins/introspection_rgblevels.c:156
 #: ../build/lib/darktable/plugins/introspection_tonecurve.c:273
 msgid "average RGB"
-msgstr "平均 RGB"
+msgstr "RGB 平均值"
 
 #: ../build/lib/darktable/plugins/introspection_basecurve.c:266
 #: ../build/lib/darktable/plugins/introspection_basicadj.c:253
@@ -2369,7 +2410,7 @@ msgstr "平均 RGB"
 #: ../build/lib/darktable/plugins/introspection_rgblevels.c:157
 #: ../build/lib/darktable/plugins/introspection_tonecurve.c:274
 msgid "sum RGB"
-msgstr "總和 RGB"
+msgstr "RGB 加總值"
 
 #: ../build/lib/darktable/plugins/introspection_basecurve.c:267
 #: ../build/lib/darktable/plugins/introspection_basicadj.c:254
@@ -2377,7 +2418,7 @@ msgstr "總和 RGB"
 #: ../build/lib/darktable/plugins/introspection_rgblevels.c:158
 #: ../build/lib/darktable/plugins/introspection_tonecurve.c:275
 msgid "norm RGB"
-msgstr "正規化 RGB"
+msgstr "RGB 範數"
 
 #: ../build/lib/darktable/plugins/introspection_basecurve.c:268
 #: ../build/lib/darktable/plugins/introspection_basicadj.c:255
@@ -2385,29 +2426,29 @@ msgstr "正規化 RGB"
 #: ../build/lib/darktable/plugins/introspection_rgblevels.c:159
 #: ../build/lib/darktable/plugins/introspection_tonecurve.c:276
 msgid "basic power"
-msgstr "基礎乘方"
+msgstr "基礎乘冪"
 
 #: ../build/lib/darktable/plugins/introspection_basicadj.c:92
 #: ../build/lib/darktable/plugins/introspection_basicadj.c:195
 #: ../build/lib/darktable/plugins/introspection_exposure.c:67
 #: ../build/lib/darktable/plugins/introspection_exposure.c:138
 msgid "black level correction"
-msgstr "黑色階修正"
+msgstr "黒點修正"
 
 #: ../build/lib/darktable/plugins/introspection_basicadj.c:104
 #: ../build/lib/darktable/plugins/introspection_basicadj.c:203
 msgid "highlight compression"
-msgstr "高光壓縮"
+msgstr "亮部壓縮"
 
 #: ../build/lib/darktable/plugins/introspection_basicadj.c:128
 #: ../build/lib/darktable/plugins/introspection_basicadj.c:219
 msgid "middle gray"
-msgstr "中間灰"
+msgstr "中灰"
 
 #: ../build/lib/darktable/plugins/introspection_bilat.c:78
 #: ../build/lib/darktable/plugins/introspection_bilat.c:137
 msgid "midtone range"
-msgstr "中階範圍"
+msgstr "中間調範圍"
 
 #: ../build/lib/darktable/plugins/introspection_bilat.c:151
 msgid "bilateral grid"
@@ -2415,7 +2456,7 @@ msgstr "雙邊網格"
 
 #: ../build/lib/darktable/plugins/introspection_bilat.c:152
 msgid "local laplacian filter"
-msgstr "局部拉普拉斯濾鏡"
+msgstr "局部拉普拉斯"
 
 #: ../build/lib/darktable/plugins/introspection_blurs.c:83
 #: ../build/lib/darktable/plugins/introspection_blurs.c:174
@@ -2434,17 +2475,17 @@ msgstr "模糊半徑"
 #: ../build/lib/darktable/plugins/introspection_blurs.c:95
 #: ../build/lib/darktable/plugins/introspection_blurs.c:182
 msgid "diaphragm blades"
-msgstr "光圈葉片"
+msgstr "光圈葉片數量"
 
 #: ../build/lib/darktable/plugins/introspection_blurs.c:101
 #: ../build/lib/darktable/plugins/introspection_blurs.c:186
 msgid "concavity"
-msgstr "凹性"
+msgstr "凹性（光圈形狀）"
 
 #: ../build/lib/darktable/plugins/introspection_blurs.c:107
 #: ../build/lib/darktable/plugins/introspection_blurs.c:190
 msgid "linearity"
-msgstr "線性"
+msgstr "線性（光圈形狀）"
 
 #: ../build/lib/darktable/plugins/introspection_blurs.c:113
 #: ../build/lib/darktable/plugins/introspection_blurs.c:194
@@ -2458,21 +2499,21 @@ msgstr "旋轉"
 
 #: ../build/lib/darktable/plugins/introspection_blurs.c:119
 #: ../build/lib/darktable/plugins/introspection_blurs.c:198
-#: ../src/iop/diffuse.c:1545
+#: ../src/iop/diffuse.c:1549
 msgid "direction"
 msgstr "方向"
 
 #: ../build/lib/darktable/plugins/introspection_blurs.c:125
 #: ../build/lib/darktable/plugins/introspection_blurs.c:202
 msgid "curvature"
-msgstr "曲率"
+msgstr "運動軌跡曲率"
 
 #: ../build/lib/darktable/plugins/introspection_blurs.c:131
 #: ../build/lib/darktable/plugins/introspection_blurs.c:206
 #: ../build/lib/darktable/plugins/introspection_graduatednd.c:81
 #: ../build/lib/darktable/plugins/introspection_graduatednd.c:148
-#: ../src/iop/colorbalancergb.c:2148 ../src/iop/colorbalancergb.c:2152
-#: ../src/iop/colorbalancergb.c:2156
+#: ../src/iop/colorbalancergb.c:2145 ../src/iop/colorbalancergb.c:2149
+#: ../src/iop/colorbalancergb.c:2153
 msgid "offset"
 msgstr "偏移"
 
@@ -2484,7 +2525,7 @@ msgstr "鏡頭"
 
 #: ../build/lib/darktable/plugins/introspection_blurs.c:221
 msgid "motion"
-msgstr "動作"
+msgstr "動態模糊"
 
 #: ../build/lib/darktable/plugins/introspection_blurs.c:222
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:550
@@ -2498,7 +2539,7 @@ msgstr "高斯"
 #: ../build/lib/darktable/plugins/introspection_borders.c:251
 #: ../src/common/collection.c:638 ../src/common/collection.c:691
 msgid "aspect ratio"
-msgstr "長寬比"
+msgstr "寬高比"
 
 #: ../build/lib/darktable/plugins/introspection_borders.c:128
 #: ../build/lib/darktable/plugins/introspection_borders.c:263
@@ -2509,7 +2550,7 @@ msgstr "方向"
 #: ../build/lib/darktable/plugins/introspection_borders.c:134
 #: ../build/lib/darktable/plugins/introspection_borders.c:267
 msgid "border size"
-msgstr "邊框大小"
+msgstr "外框尺寸"
 
 #: ../build/lib/darktable/plugins/introspection_borders.c:140
 #: ../build/lib/darktable/plugins/introspection_borders.c:271
@@ -2524,7 +2565,7 @@ msgstr "垂直偏移"
 #: ../build/lib/darktable/plugins/introspection_borders.c:176
 #: ../build/lib/darktable/plugins/introspection_borders.c:295
 msgid "frame line size"
-msgstr "框線大小"
+msgstr "框線尺寸"
 
 #: ../build/lib/darktable/plugins/introspection_borders.c:182
 #: ../build/lib/darktable/plugins/introspection_borders.c:299
@@ -2534,14 +2575,14 @@ msgstr "框線偏移"
 #: ../build/lib/darktable/plugins/introspection_cacorrect.c:42
 #: ../build/lib/darktable/plugins/introspection_cacorrect.c:91
 msgid "avoid colorshift"
-msgstr "避免色彩偏移"
+msgstr "避免色偏"
 
 #: ../build/lib/darktable/plugins/introspection_cacorrect.c:48
 #: ../build/lib/darktable/plugins/introspection_cacorrect.c:95
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:117
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:244
-#: ../build/lib/darktable/plugins/introspection_highlights.c:143
-#: ../build/lib/darktable/plugins/introspection_highlights.c:240
+#: ../build/lib/darktable/plugins/introspection_highlights.c:144
+#: ../build/lib/darktable/plugins/introspection_highlights.c:241
 msgid "iterations"
 msgstr "迭代次數"
 
@@ -2553,7 +2594,7 @@ msgstr "一次"
 #: ../build/lib/darktable/plugins/introspection_cacorrect.c:110
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:206
 msgid "twice"
-msgstr "兩次"
+msgstr "二次"
 
 #: ../build/lib/darktable/plugins/introspection_cacorrect.c:111
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:207
@@ -2573,13 +2614,13 @@ msgstr "五次"
 #: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:61
 #: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:128
 msgid "guide"
-msgstr "參考線"
+msgstr "參考色版"
 
 #: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:67
 #: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:132
-#: ../src/iop/atrous.c:1591 ../src/iop/bilateral.cc:301 ../src/iop/clahe.c:335
+#: ../src/iop/atrous.c:1589 ../src/iop/bilateral.cc:301 ../src/iop/clahe.c:335
 #: ../src/iop/dither.c:886 ../src/iop/lowpass.c:571 ../src/iop/shadhi.c:684
-#: ../src/iop/sharpen.c:448
+#: ../src/iop/sharpen.c:449
 msgid "radius"
 msgstr "半徑"
 
@@ -2594,12 +2635,12 @@ msgstr "強度"
 #: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:79
 #: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:140
 msgid "correction mode"
-msgstr "修正模式"
+msgstr "校正模式"
 
 #: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:85
 #: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:144
 msgid "very large chromatic aberration"
-msgstr "嚴重色差"
+msgstr "非常嚴重的色像差"
 
 #: ../build/lib/darktable/plugins/introspection_cacorrectrgb.c:158
 #: ../src/common/collection.c:1429 ../src/common/color_vocabulary.c:232
@@ -2608,7 +2649,7 @@ msgstr "嚴重色差"
 #: ../src/gui/gtk.c:2918 ../src/gui/guides.c:730 ../src/iop/bilateral.cc:305
 #: ../src/iop/channelmixer.c:625 ../src/iop/channelmixer.c:635
 #: ../src/iop/channelmixerrgb.c:4181 ../src/iop/colorzones.c:2302
-#: ../src/iop/temperature.c:1819 ../src/iop/temperature.c:1992
+#: ../src/iop/temperature.c:1764 ../src/iop/temperature.c:1937
 #: ../src/libs/collect.c:1789 ../src/libs/filters/colors.c:260
 msgid "red"
 msgstr "紅"
@@ -2620,8 +2661,8 @@ msgstr "紅"
 #: ../src/gui/gtk.c:2919 ../src/gui/guides.c:731 ../src/iop/bilateral.cc:310
 #: ../src/iop/channelmixer.c:626 ../src/iop/channelmixer.c:641
 #: ../src/iop/channelmixerrgb.c:4182 ../src/iop/colorzones.c:2305
-#: ../src/iop/temperature.c:1803 ../src/iop/temperature.c:1821
-#: ../src/iop/temperature.c:1993 ../src/libs/collect.c:1789
+#: ../src/iop/temperature.c:1748 ../src/iop/temperature.c:1766
+#: ../src/iop/temperature.c:1938 ../src/libs/collect.c:1789
 #: ../src/libs/filters/colors.c:262
 msgid "green"
 msgstr "綠"
@@ -2633,7 +2674,7 @@ msgstr "綠"
 #: ../src/gui/gtk.c:2920 ../src/iop/bilateral.cc:315
 #: ../src/iop/channelmixer.c:627 ../src/iop/channelmixer.c:647
 #: ../src/iop/channelmixerrgb.c:4183 ../src/iop/colorzones.c:2307
-#: ../src/iop/temperature.c:1823 ../src/iop/temperature.c:1994
+#: ../src/iop/temperature.c:1768 ../src/iop/temperature.c:1939
 #: ../src/libs/collect.c:1789 ../src/libs/filters/colors.c:263
 msgid "blue"
 msgstr "藍"
@@ -2658,7 +2699,7 @@ msgstr "輸入模糊半徑"
 #: ../build/lib/darktable/plugins/introspection_censorize.c:57
 #: ../build/lib/darktable/plugins/introspection_censorize.c:116
 msgid "pixellation radius"
-msgstr "像素化半徑"
+msgstr "馬賽克尺寸"
 
 #: ../build/lib/darktable/plugins/introspection_censorize.c:63
 #: ../build/lib/darktable/plugins/introspection_censorize.c:120
@@ -2667,10 +2708,10 @@ msgstr "輸出模糊半徑"
 
 #: ../build/lib/darktable/plugins/introspection_censorize.c:69
 #: ../build/lib/darktable/plugins/introspection_censorize.c:124
-#: ../build/lib/darktable/plugins/introspection_highlights.c:137
-#: ../build/lib/darktable/plugins/introspection_highlights.c:236
+#: ../build/lib/darktable/plugins/introspection_highlights.c:138
+#: ../build/lib/darktable/plugins/introspection_highlights.c:237
 msgid "noise level"
-msgstr "噪點級別"
+msgstr "雜訊強度"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:252
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:258
@@ -2685,12 +2726,12 @@ msgstr "噪點級別"
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:449
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:453
 msgid "normalize channels"
-msgstr "通道正規化"
+msgstr "歸一化色版"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:294
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:461
 msgid "F source"
-msgstr "F 光源"
+msgstr "螢光燈光源（CIE F ）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:300
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:465
@@ -2705,154 +2746,154 @@ msgstr "色域壓縮"
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:336
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:489
 msgid "clip negative RGB from gamut"
-msgstr "將負數 RGB 值從色域中截去"
+msgstr "裁切 RGB 負值"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:342
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:493
 msgid "saturation algorithm"
-msgstr "飽和度演算法"
+msgstr "飽和度算法"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:507
 msgid "same as pipeline (D50)"
-msgstr "與管線保持一致(D50)"
+msgstr "不做色彩適應轉換"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:508
 msgid "A (incandescent)"
-msgstr "A(白熾燈)"
+msgstr "CIE A（鎢絲燈）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:509
 msgid "D (daylight)"
-msgstr "D(日光)"
+msgstr "CIE D（日光）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:510
 msgid "E (equi-energy)"
-msgstr "E(等光度照明)"
+msgstr "CIE E（等能光源）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:511
 msgid "F (fluorescent)"
-msgstr "F(螢光燈)"
+msgstr "CIE F（螢光燈）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:512
 msgid "LED (LED light)"
-msgstr "LED(LED 照明)"
+msgstr "LED"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:513
 msgid "Planckian (black body)"
-msgstr "普朗克(黑體)"
+msgstr "普朗克（黑體輻射）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:514
 #: ../src/common/iop_order.c:58
 msgid "custom"
-msgstr "自定義"
+msgstr "自訂"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:515
 msgid "(AI) detect from image surfaces..."
-msgstr "(人工智慧)從影像內的表面偵測..."
+msgstr "（智慧偵測）從影像的平滑區域偵測"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:516
 msgid "(AI) detect from image edges..."
-msgstr "(人工智慧)從影像內的邊緣偵測..."
+msgstr "（智慧偵測）從影像的邊緣區域偵測"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:517
 #: ../src/iop/channelmixerrgb.c:3554
 msgid "as shot in camera"
-msgstr "拍攝時相機設定"
+msgstr "相機的白平衡設定"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:522
 msgid "F1 (Daylight 6430 K) – medium CRI"
-msgstr "F1 (日光 6430 K) — 中顯色性"
+msgstr "F1 （6430 K – 中演色性）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:523
 msgid "F2 (Cool White 4230 K) – medium CRI"
-msgstr "F2 (冷白光 4230 K) — 中顯色性"
+msgstr "F2 （4230 K – 中演色性）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:524
 msgid "F3 (White 3450 K) – medium CRI"
-msgstr "F3 (白色 3450 K) — 中顯色性"
+msgstr "F3 （3450 K – 中演色性）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:525
 msgid "F4 (Warm White 2940 K) – medium CRI"
-msgstr "F4 (暖白光 2940 K) — 中顯色性"
+msgstr "F4 （2940 K – 中演色性）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:526
 msgid "F5 (Daylight 6350 K) – medium CRI"
-msgstr "F5 (日光 6350 K) — 中顯色性"
+msgstr "F5 （6350 K – 中演色性）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:527
 msgid "F6 (Lite White 4150 K) – medium CRI"
-msgstr "F6 (螢光 4150 K) — 中顯色性"
+msgstr "F6 （4150 K – 中演色性）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:528
 msgid "F7 (D65 simulator 6500 K) – high CRI"
-msgstr "F7 (D65 模擬光源 6500 K) — 高顯色性"
+msgstr "F7 （D65 人造日光 – 高演色性）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:529
 msgid "F8 (D50 simulator 5000 K) – high CRI"
-msgstr "F8 (D50 模擬光源 5000 K) — 高顯色性"
+msgstr "F8 （D50 人造日光 – 高演色性）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:530
 msgid "F9 (Cool White Deluxe 4150 K) – high CRI"
-msgstr "F9 (冷白光 4150 K) — 高顯色性"
+msgstr "F9 （4150 K – 高演色性）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:531
 msgid "F10 (Tuned RGB 5000 K) – low CRI"
-msgstr "F10 (調和 RGB 5000K) — 低顯色性"
+msgstr "F10 （5000K – 低演色性）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:532
 msgid "F11 (Tuned RGB 4000 K) – low CRI"
-msgstr "F11 (調和 RGB 4000K) — 低顯色性"
+msgstr "F11 （4000K – 低演色性）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:533
 msgid "F12 (Tuned RGB 3000 K) – low CRI"
-msgstr "F12 (調和 RGB 3000K) — 低顯色性"
+msgstr "F12 （3000K – 低演色性）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:538
 msgid "B1 (Blue 2733 K)"
-msgstr "B1 (藍光 2733 K)"
+msgstr "LED B1 （藍光 2733 K）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:539
 msgid "B2 (Blue 2998 K)"
-msgstr "B2 (藍光 2998 K)"
+msgstr "LED B2 （藍光 2998 K）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:540
 msgid "B3 (Blue 4103 K)"
-msgstr "B3 (藍光 4103 K)"
+msgstr "LED B3 （藍光 4103 K）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:541
 msgid "B4 (Blue 5109 K)"
-msgstr "B4(藍光 5109 K)"
+msgstr "LED B4 （藍光 5109 K）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:542
 msgid "B5 (Blue 6598 K)"
-msgstr "B1(藍光 6598 K)"
+msgstr "LED B5 （藍光 6598 K）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:543
 msgid "BH1 (Blue-Red hybrid 2851 K)"
-msgstr "BH1 (藍紅雙色混光 2851 K)"
+msgstr "LED BH1 （紅藍混合 2851 K）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:544
 msgid "RGB1 (RGB 2840 K)"
-msgstr "RGB1 (RGB 2840 K)"
+msgstr "LED RGB1（三色光 2840 K）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:545
 msgid "V1 (Violet 2724 K)"
-msgstr "V1 (紫羅蘭色 2724 K)"
+msgstr "LED V1（紫光 2724 K）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:546
 msgid "V2 (Violet 4070 K)"
-msgstr "V1 (紫羅蘭色 4070 K)"
+msgstr "LED V2（紫光 4070 K）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:551
 msgid "linear Bradford (ICC v4)"
-msgstr "線性布拉德福算法(ICC v4)"
+msgstr "線性 Bradford（ICC 標準）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:552
 msgid "CAT16 (CIECAM16)"
-msgstr "CAT16(CIECAM16)"
+msgstr "CAT16（CIECAM16）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:553
 msgid "non-linear Bradford"
-msgstr "非線性布拉德福算法"
+msgstr "非線性 Bradford"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:554
 msgid "XYZ"
@@ -2860,25 +2901,25 @@ msgstr "XYZ"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:555
 msgid "none (bypass)"
-msgstr "無(旁通)"
+msgstr "無（不轉換）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:560
 msgid "version 1 (2020)"
-msgstr "版本 1(2020)"
+msgstr "版本 1（2020）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:561
 msgid "version 2 (2021)"
-msgstr "版本 2(2021)"
+msgstr "版本 2（2021）"
 
 #: ../build/lib/darktable/plugins/introspection_channelmixerrgb.c:562
 msgid "version 3 (Apr 2021)"
-msgstr "版本 3(2021 四月)"
+msgstr "版本 3（2021 四月）"
 
 #: ../build/lib/darktable/plugins/introspection_clipping.c:142
 #: ../build/lib/darktable/plugins/introspection_clipping.c:303
 #: ../build/lib/darktable/plugins/introspection_crop.c:61
 #: ../build/lib/darktable/plugins/introspection_crop.c:134
-#: ../src/gui/gtk.c:1129 ../src/iop/atrous.c:1587
+#: ../src/gui/gtk.c:1129 ../src/iop/atrous.c:1585
 msgid "left"
 msgstr "左"
 
@@ -2888,13 +2929,13 @@ msgstr "左"
 #: ../build/lib/darktable/plugins/introspection_crop.c:138
 #: ../src/gui/accelerators.c:106 ../src/gui/gtk.c:1143
 msgid "top"
-msgstr "頂"
+msgstr "上"
 
 #: ../build/lib/darktable/plugins/introspection_clipping.c:154
 #: ../build/lib/darktable/plugins/introspection_clipping.c:311
 #: ../build/lib/darktable/plugins/introspection_crop.c:73
 #: ../build/lib/darktable/plugins/introspection_crop.c:142
-#: ../src/gui/gtk.c:1136 ../src/iop/atrous.c:1586
+#: ../src/gui/gtk.c:1136 ../src/iop/atrous.c:1584
 msgid "right"
 msgstr "右"
 
@@ -2904,7 +2945,7 @@ msgstr "右"
 #: ../build/lib/darktable/plugins/introspection_crop.c:146
 #: ../src/gui/accelerators.c:107 ../src/gui/gtk.c:1150
 msgid "bottom"
-msgstr "底部"
+msgstr "下"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalance.c:114
 #: ../build/lib/darktable/plugins/introspection_colorbalance.c:203
@@ -2914,7 +2955,7 @@ msgstr "輸入飽和度"
 #: ../build/lib/darktable/plugins/introspection_colorbalance.c:126
 #: ../build/lib/darktable/plugins/introspection_colorbalance.c:211
 msgid "contrast fulcrum"
-msgstr "對比支點"
+msgstr "對比度中心點"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalance.c:132
 #: ../build/lib/darktable/plugins/introspection_colorbalance.c:215
@@ -2923,130 +2964,130 @@ msgstr "輸出飽和度"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalance.c:229
 msgid "lift, gamma, gain (ProPhoto RGB)"
-msgstr "提升，伽瑪，增益 (ProPhoto RGB)"
+msgstr "提升、伽瑪、增益（ProPhoto 線性）"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalance.c:230
 msgid "slope, offset, power (ProPhoto RGB)"
-msgstr "斜率，偏移，冪方 (ProPhoto RGB)"
+msgstr "斜率、偏移、乘冪（ProPhoto 線性）"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalance.c:231
 msgid "lift, gamma, gain (sRGB)"
-msgstr "提升、伽馬、增益(sRGB)"
+msgstr "提升、伽瑪、增益（sRGB）"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:226
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:461
 msgid "lift luminance"
-msgstr "提升亮度"
+msgstr "亮度提升"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:232
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:465
 msgid "lift chroma"
-msgstr "提升色度"
+msgstr "色度提升"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:238
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:469
 msgid "lift hue"
-msgstr "提升色調"
+msgstr "色相提升"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:244
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:473
 msgid "power luminance"
-msgstr "乘方亮度"
+msgstr "亮度乘冪"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:250
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:477
 msgid "power chroma"
-msgstr "乘方色度"
+msgstr "色度乘冪"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:256
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:481
 msgid "power hue"
-msgstr "乘方色調"
+msgstr "色相乘冪"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:262
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:485
 msgid "gain luminance"
-msgstr "增益亮度"
+msgstr "亮度增益"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:268
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:489
 msgid "gain chroma"
-msgstr "增益色度"
+msgstr "色度增益"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:274
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:493
 msgid "gain hue"
-msgstr "增益色調"
+msgstr "色相增益"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:280
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:497
 msgid "offset luminance"
-msgstr "偏移亮度"
+msgstr "亮度偏移"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:286
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:501
 msgid "offset chroma"
-msgstr "偏移色度"
+msgstr "色度偏移"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:292
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:505
 msgid "offset hue"
-msgstr "偏移色調"
+msgstr "色相偏移"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:298
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:509
 msgid "shadows fall-off"
-msgstr "陰影衰減強度"
+msgstr "暗部過渡"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:304
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:513
 msgid "white fulcrum"
-msgstr "白色支點"
+msgstr "參考白色點"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:310
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:517
 msgid "highlights fall-off"
-msgstr "高光衰減強度"
+msgstr "亮部過渡"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:316
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:521
 msgid "chroma shadows"
-msgstr "色度陰影"
+msgstr "暗部色度"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:322
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:525
 msgid "chroma highlights"
-msgstr "色度高光"
+msgstr "亮部色度"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:328
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:529
 msgid "chroma global"
-msgstr "色度全局"
+msgstr "整體色度"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:334
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:533
 msgid "chroma mid-tones"
-msgstr "色度中間調"
+msgstr "中間調色度"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:340
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:537
 msgid "saturation global"
-msgstr "全域飽和度"
+msgstr "整體飽和度"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:346
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:541
 msgid "saturation highlights"
-msgstr "飽和度高光"
+msgstr "亮部飽和度"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:352
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:545
 msgid "saturation mid-tones"
-msgstr "飽和度中間調"
+msgstr "中間調飽和度"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:358
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:549
 msgid "saturation shadows"
-msgstr "飽和度陰影"
+msgstr "暗部飽和度"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:364
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:553
@@ -3056,44 +3097,44 @@ msgstr "色相偏移"
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:370
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:557
 msgid "brilliance global"
-msgstr "亮度全局"
+msgstr "整體明亮度"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:376
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:561
 msgid "brilliance highlights"
-msgstr "亮度高光"
+msgstr "亮部明亮度"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:382
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:565
 msgid "brilliance mid-tones"
-msgstr "亮度中間調"
+msgstr "中間調明亮度"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:388
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:569
 msgid "brilliance shadows"
-msgstr "亮度陰影"
+msgstr "暗部明亮度"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:394
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:573
 msgid "mask middle-gray fulcrum"
-msgstr "遮罩中間灰支點"
+msgstr "遮罩中灰點"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:400
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:577
 msgid "global vibrance"
-msgstr "全局鮮豔度"
+msgstr "整體自然飽和度"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:406
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:581
 msgid "contrast gray fulcrum"
-msgstr "對比度灰色支點"
+msgstr "對比度中灰點"
 
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:412
 #: ../build/lib/darktable/plugins/introspection_colorbalancergb.c:585
 #: ../src/gui/guides.c:740 ../src/iop/basicadj.c:607 ../src/iop/bilat.c:451
 #: ../src/iop/colisa.c:305 ../src/iop/colorbalance.c:1895
 #: ../src/iop/colorbalance.c:1901 ../src/iop/filmic.c:1649
-#: ../src/iop/filmicrgb.c:4337 ../src/iop/lowpass.c:573
+#: ../src/iop/filmicrgb.c:4338 ../src/iop/lowpass.c:573
 msgid "contrast"
 msgstr "對比"
 
@@ -3113,12 +3154,12 @@ msgstr "darktable UCS (2022)"
 #: ../build/lib/darktable/plugins/introspection_colorcontrast.c:54
 #: ../build/lib/darktable/plugins/introspection_colorcontrast.c:121
 msgid "green-magenta contrast"
-msgstr "綠色-洋紅對比"
+msgstr "綠色 - 紅色 對比"
 
 #: ../build/lib/darktable/plugins/introspection_colorcontrast.c:66
 #: ../build/lib/darktable/plugins/introspection_colorcontrast.c:129
 msgid "blue-yellow contrast"
-msgstr "藍色-黃色對比"
+msgstr "藍色 - 黃色 對比"
 
 #: ../build/lib/darktable/plugins/introspection_colorin.c:149
 #: ../build/lib/darktable/plugins/introspection_colorin.c:232
@@ -3135,39 +3176,39 @@ msgstr "sRGB"
 #: ../src/common/colorspaces.c:1431 ../src/common/colorspaces.c:1657
 #: ../src/libs/print_settings.c:1292
 msgid "Adobe RGB (compatible)"
-msgstr "Adobe RGB(兼容)"
+msgstr "Adobe RGB（相容）"
 
 #: ../build/lib/darktable/plugins/introspection_colorin.c:304
 #: ../build/lib/darktable/plugins/introspection_lut3d.c:204
 #: ../src/common/colorspaces.c:1436 ../src/common/colorspaces.c:1659
 msgid "linear Rec709 RGB"
-msgstr "線性 Rec709 RGB"
+msgstr "線性 Rec. 709"
 
 #: ../build/lib/darktable/plugins/introspection_colorin.c:305
 #: ../build/lib/darktable/plugins/introspection_lut3d.c:205
 #: ../src/common/colorspaces.c:1445 ../src/common/colorspaces.c:1661
 msgid "linear Rec2020 RGB"
-msgstr "線性 Rec2020 RGB"
+msgstr "線性 Rec. 2020"
 
 #: ../build/lib/darktable/plugins/introspection_colorize.c:65
 #: ../build/lib/darktable/plugins/introspection_colorize.c:128
 msgid "source mix"
-msgstr "來源混合"
+msgstr "原始影像混合"
 
 #: ../build/lib/darktable/plugins/introspection_colormapping.c:94
 #: ../build/lib/darktable/plugins/introspection_colormapping.c:249
 msgid "number of clusters"
-msgstr "群集數量"
+msgstr "色板數量"
 
 #: ../build/lib/darktable/plugins/introspection_colormapping.c:100
 #: ../build/lib/darktable/plugins/introspection_colormapping.c:253
 msgid "color dominance"
-msgstr "顏色支配"
+msgstr "色彩強度"
 
 #: ../build/lib/darktable/plugins/introspection_colormapping.c:106
 #: ../build/lib/darktable/plugins/introspection_colormapping.c:257
 msgid "histogram equalization"
-msgstr "直方圖等化"
+msgstr "亮度調整"
 
 #: ../build/lib/darktable/plugins/introspection_colorreconstruction.c:62
 #: ../build/lib/darktable/plugins/introspection_colorreconstruction.c:127
@@ -3175,17 +3216,17 @@ msgstr "直方圖等化"
 #: ../build/lib/darktable/plugins/introspection_tonemap.cc:92
 #: ../src/iop/shadhi.c:695
 msgid "spatial extent"
-msgstr "空間範圍"
+msgstr "距離範圍"
 
 #: ../build/lib/darktable/plugins/introspection_colorreconstruction.c:68
 #: ../build/lib/darktable/plugins/introspection_colorreconstruction.c:131
 msgid "range extent"
-msgstr "動態範圍"
+msgstr "亮度範圍"
 
 #: ../build/lib/darktable/plugins/introspection_colorreconstruction.c:154
 #: ../src/iop/channelmixerrgb.c:4231
 msgid "saturated colors"
-msgstr "飽和色"
+msgstr "飽和色彩"
 
 #: ../build/lib/darktable/plugins/introspection_colorreconstruction.c:155
 #: ../build/lib/darktable/plugins/introspection_colorzones.c:257
@@ -3198,9 +3239,9 @@ msgstr "飽和色"
 #: ../src/develop/blend_gui.c:1980 ../src/develop/blend_gui.c:1999
 #: ../src/develop/blend_gui.c:2034 ../src/iop/channelmixer.c:622
 #: ../src/iop/channelmixerrgb.c:4053 ../src/iop/channelmixerrgb.c:4143
-#: ../src/iop/colorbalance.c:1990 ../src/iop/colorbalancergb.c:2145
-#: ../src/iop/colorbalancergb.c:2146 ../src/iop/colorbalancergb.c:2147
-#: ../src/iop/colorbalancergb.c:2148 ../src/iop/colorize.c:344
+#: ../src/iop/colorbalance.c:1990 ../src/iop/colorbalancergb.c:2142
+#: ../src/iop/colorbalancergb.c:2143 ../src/iop/colorbalancergb.c:2144
+#: ../src/iop/colorbalancergb.c:2145 ../src/iop/colorize.c:344
 #: ../src/iop/colorreconstruction.c:1288 ../src/iop/colorzones.c:2433
 #: ../src/iop/splittoning.c:471
 msgid "hue"
@@ -3209,14 +3250,14 @@ msgstr "色相"
 #: ../build/lib/darktable/plugins/introspection_colorzones.c:78
 #: ../build/lib/darktable/plugins/introspection_colorzones.c:193
 msgid "select by"
-msgstr "依據選擇"
+msgstr "橫坐標選項"
 
 #. mix slider
 #: ../build/lib/darktable/plugins/introspection_colorzones.c:138
 #: ../build/lib/darktable/plugins/introspection_colorzones.c:233
 #: ../build/lib/darktable/plugins/introspection_soften.c:66
 #: ../build/lib/darktable/plugins/introspection_soften.c:121
-#: ../src/iop/atrous.c:1765
+#: ../src/iop/atrous.c:1763
 msgid "mix"
 msgstr "混合"
 
@@ -3227,11 +3268,11 @@ msgstr "處理模式"
 
 #: ../build/lib/darktable/plugins/introspection_colorzones.c:255
 #: ../src/develop/blend_gui.c:1966 ../src/iop/channelmixer.c:624
-#: ../src/iop/channelmixerrgb.c:4136 ../src/iop/colorchecker.c:1358
+#: ../src/iop/channelmixerrgb.c:4136 ../src/iop/colorchecker.c:1361
 #: ../src/iop/colorize.c:363 ../src/iop/colorzones.c:2431
 #: ../src/iop/exposure.c:1129
 msgid "lightness"
-msgstr "亮度"
+msgstr "明度"
 
 #: ../build/lib/darktable/plugins/introspection_colorzones.c:256
 #: ../build/lib/darktable/plugins/introspection_graduatednd.c:93
@@ -3242,9 +3283,9 @@ msgstr "亮度"
 #: ../build/lib/darktable/plugins/introspection_splittoning.c:146
 #: ../src/develop/blend_gui.c:1976 ../src/iop/basicadj.c:624
 #: ../src/iop/channelmixer.c:623 ../src/iop/colisa.c:307
-#: ../src/iop/colorbalance.c:2007 ../src/iop/colorbalancergb.c:2163
-#: ../src/iop/colorbalancergb.c:2164 ../src/iop/colorbalancergb.c:2165
-#: ../src/iop/colorchecker.c:1376 ../src/iop/colorcontrast.c:94
+#: ../src/iop/colorbalance.c:2007 ../src/iop/colorbalancergb.c:2160
+#: ../src/iop/colorbalancergb.c:2161 ../src/iop/colorbalancergb.c:2162
+#: ../src/iop/colorchecker.c:1379 ../src/iop/colorcontrast.c:94
 #: ../src/iop/colorcorrection.c:283 ../src/iop/colorize.c:357
 #: ../src/iop/colorzones.c:2432 ../src/iop/lowpass.c:575
 #: ../src/iop/soften.c:399 ../src/iop/splittoning.c:483 ../src/iop/velvia.c:84
@@ -3253,7 +3294,7 @@ msgid "saturation"
 msgstr "飽和度"
 
 #: ../build/lib/darktable/plugins/introspection_colorzones.c:267
-#: ../src/iop/atrous.c:1368 ../src/iop/atrous.c:1372
+#: ../src/iop/atrous.c:1366 ../src/iop/atrous.c:1370
 #: ../src/iop/denoiseprofile.c:3410 ../src/iop/rawdenoise.c:756
 msgid "smooth"
 msgstr "平滑"
@@ -3265,34 +3306,34 @@ msgstr "強烈"
 #: ../build/lib/darktable/plugins/introspection_defringe.c:47
 #: ../build/lib/darktable/plugins/introspection_defringe.c:102
 msgid "edge detection radius"
-msgstr "邊緣偵測的半徑"
+msgstr "邊緣偵測半徑"
 
 #: ../build/lib/darktable/plugins/introspection_defringe.c:53
 #: ../build/lib/darktable/plugins/introspection_defringe.c:106
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:224
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:423
-#: ../src/iop/atrous.c:1641 ../src/iop/bloom.c:394
-#: ../src/iop/colorbalancergb.c:2106 ../src/iop/colorreconstruction.c:1284
-#: ../src/iop/hotpixels.c:385 ../src/iop/sharpen.c:457
+#: ../src/iop/atrous.c:1639 ../src/iop/bloom.c:394
+#: ../src/iop/colorbalancergb.c:2103 ../src/iop/colorreconstruction.c:1284
+#: ../src/iop/hotpixels.c:385 ../src/iop/sharpen.c:458
 msgid "threshold"
 msgstr "臨界值"
 
 #: ../build/lib/darktable/plugins/introspection_defringe.c:59
 #: ../build/lib/darktable/plugins/introspection_defringe.c:110
 msgid "operation mode"
-msgstr "工作模式"
+msgstr "操作模式"
 
 #: ../build/lib/darktable/plugins/introspection_defringe.c:124
 msgid "global average (fast)"
-msgstr "全局平均(快)"
+msgstr "全體平均（快速）"
 
 #: ../build/lib/darktable/plugins/introspection_defringe.c:125
 msgid "local average (slow)"
-msgstr "局部平均(較慢)"
+msgstr "局部平均（緩慢）"
 
 #: ../build/lib/darktable/plugins/introspection_defringe.c:126
 msgid "static threshold (fast)"
-msgstr "靜態臨界值(快)"
+msgstr "固定門檻（快）"
 
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:90
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:163
@@ -3304,33 +3345,33 @@ msgstr "匹配綠色"
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:141
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:260
 msgid "edge threshold"
-msgstr "邊緣臨界值"
+msgstr "邊緣偵測門檻"
 
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:102
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:171
 msgid "color smoothing"
-msgstr "顏色平滑"
+msgstr "色彩平滑"
 
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:108
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:175
 msgid "demosaicing method"
-msgstr "去馬賽克方法"
+msgstr "去馬賽克方式"
 
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:114
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:179
 msgid "LMMSE refine"
-msgstr "LMMSE 精煉"
+msgstr "LMMSE 加強"
 
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:120
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:183
 msgid "dual threshold"
-msgstr "雙重臨界值"
+msgstr "雙演算法門檻"
 
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:197
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:204
 #: ../build/lib/darktable/plugins/introspection_rawprepare.c:197
 msgid "disabled"
-msgstr "不啟用"
+msgstr "不使用"
 
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:198
 msgid "local average"
@@ -3366,21 +3407,21 @@ msgstr "LMMSE"
 
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:218
 msgid "RCD + VNG4"
-msgstr "RCD + VNG4"
+msgstr "雙算法：RCD + VNG4"
 
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:219
 msgid "AMaZE + VNG4"
-msgstr "AMaZE + VNG4"
+msgstr "雙算法：AMaZE + VNG4"
 
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:220
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:227
 msgid "passthrough (monochrome)"
-msgstr "轉移(單色)"
+msgstr "直通不去馬賽克"
 
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:221
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:228
 msgid "photosite color (debug)"
-msgstr "傳感器色彩(除錯)"
+msgstr "感光元件濾片色彩"
 
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:222
 msgid "VNG"
@@ -3396,7 +3437,7 @@ msgstr "Markesteijn 3-pass"
 
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:225
 msgid "frequency domain chroma"
-msgstr "頻域色度"
+msgstr "frequency domain chroma"
 
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:226
 msgid "Markesteijn 3-pass + VNG"
@@ -3415,62 +3456,62 @@ msgstr "中位數"
 
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:234
 msgid "3x median"
-msgstr "3x 中位數"
+msgstr "三次中位數"
 
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:235
 msgid "refine & medians"
-msgstr "精鏈 + 中位數"
+msgstr "改良和中位數"
 
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:236
 msgid "2x refine + medians"
-msgstr "2x 精鍊 + 中位數"
+msgstr "二次改良與中位數"
 
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:125
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:300
 #: ../build/lib/darktable/plugins/introspection_nlmeans.c:48
 #: ../build/lib/darktable/plugins/introspection_nlmeans.c:109
 msgid "patch size"
-msgstr "色塊大小"
+msgstr "色塊尺寸"
 
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:131
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:304
 msgid "search radius"
-msgstr "搜尋半徑"
+msgstr "搜尋距離"
 
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:143
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:312
 msgid "preserve shadows"
-msgstr "保留陰影"
+msgstr "保留暗部"
 
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:149
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:316
 msgid "bias correction"
-msgstr "偏差修正"
+msgstr "色偏修正"
 
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:155
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:320
 msgid "scattering"
-msgstr "分散"
+msgstr "分散色塊"
 
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:161
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:324
 msgid "central pixel weight"
-msgstr "中心像素權重"
+msgstr "中央像素加權"
 
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:167
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:328
 msgid "adjust autoset parameters"
-msgstr "調整自動設置參數"
+msgstr "調整自動設定參數"
 
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:239
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:376
 msgid "whitebalance-adaptive transform"
-msgstr "白平衡調適轉換"
+msgstr "白平衡適應轉換"
 
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:245
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:380
 msgid "fix various bugs in algorithm"
-msgstr "修正演算法內的各種臭蟲"
+msgstr "修復演算法中的各種錯誤"
 
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:251
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:384
@@ -3494,81 +3535,81 @@ msgstr "Y0U0V0"
 
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:123
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:248
-#: ../src/iop/atrous.c:1633 ../src/iop/highpass.c:394
+#: ../src/iop/atrous.c:1631 ../src/iop/highpass.c:394
 msgid "sharpness"
 msgstr "銳利度"
 
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:129
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:252
 msgid "radius span"
-msgstr "半徑跨度"
+msgstr "延伸半徑"
 
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:135
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:256
 msgid "edge sensitivity"
-msgstr "邊緣敏感度"
+msgstr "邊緣偵測靈敏度"
 
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:147
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:264
 msgid "1st order anisotropy"
-msgstr "1 階各向異性"
+msgstr "一階異向性"
 
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:153
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:268
 msgid "2nd order anisotropy"
-msgstr "2 階各向異性"
+msgstr "二階異向性"
 
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:159
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:272
 msgid "3rd order anisotropy"
-msgstr "3 階各向異性"
+msgstr "三階異向性"
 
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:165
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:276
 msgid "4th order anisotropy"
-msgstr "4 階各向異性"
+msgstr "四階異向性"
 
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:171
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:280
 msgid "luminance masking threshold"
-msgstr "亮度遮罩臨界值"
+msgstr "亮度遮罩門檻"
 
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:177
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:284
 msgid "1st order speed"
-msgstr "1 階速度"
+msgstr "一階速度"
 
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:183
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:288
 msgid "2nd order speed"
-msgstr "2 階速度"
+msgstr "二階速度"
 
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:189
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:292
 msgid "3rd order speed"
-msgstr "3 階速度"
+msgstr "三階速度"
 
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:195
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:296
 msgid "4th order speed"
-msgstr "4 階速度"
+msgstr "四階速度"
 
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:201
 #: ../build/lib/darktable/plugins/introspection_diffuse.c:300
 msgid "central radius"
-msgstr "中央半徑"
+msgstr "中心半徑"
 
 #: ../build/lib/darktable/plugins/introspection_dither.c:62
 #: ../build/lib/darktable/plugins/introspection_dither.c:141
-#: ../build/lib/darktable/plugins/introspection_highlights.c:107
-#: ../build/lib/darktable/plugins/introspection_highlights.c:216
+#: ../build/lib/darktable/plugins/introspection_highlights.c:108
+#: ../build/lib/darktable/plugins/introspection_highlights.c:217
 msgid "method"
 msgstr "方法"
 
 #: ../build/lib/darktable/plugins/introspection_dither.c:92
 #: ../build/lib/darktable/plugins/introspection_dither.c:161
 msgid "damping"
-msgstr "阻尼"
+msgstr "減震"
 
 #: ../build/lib/darktable/plugins/introspection_dither.c:179
 msgid "random"
@@ -3576,19 +3617,19 @@ msgstr "隨機"
 
 #: ../build/lib/darktable/plugins/introspection_dither.c:180
 msgid "Floyd-Steinberg 1-bit B&W"
-msgstr "Floyd-Steinberg 1-bit 黑白"
+msgstr "Floyd-Steinberg 1 位元 黑白"
 
 #: ../build/lib/darktable/plugins/introspection_dither.c:181
 msgid "Floyd-Steinberg 4-bit gray"
-msgstr "Floyd-Steinberg 4-bit 灰階"
+msgstr "Floyd-Steinberg 4 位元 灰階"
 
 #: ../build/lib/darktable/plugins/introspection_dither.c:182
 msgid "Floyd-Steinberg 8-bit RGB"
-msgstr "Floyd-Steinberg 8-bit RGB"
+msgstr "Floyd-Steinberg 8 位元 RGB"
 
 #: ../build/lib/darktable/plugins/introspection_dither.c:183
 msgid "Floyd-Steinberg 16-bit RGB"
-msgstr "Floyd-Steinberg 16-bit RGB"
+msgstr "Floyd-Steinberg 16 位元 RGB"
 
 #: ../build/lib/darktable/plugins/introspection_dither.c:184
 msgid "Floyd-Steinberg auto"
@@ -3602,12 +3643,12 @@ msgstr "百分位數"
 #: ../build/lib/darktable/plugins/introspection_exposure.c:85
 #: ../build/lib/darktable/plugins/introspection_exposure.c:150
 msgid "target level"
-msgstr "目標色階"
+msgstr "目標曝光"
 
 #: ../build/lib/darktable/plugins/introspection_exposure.c:91
 #: ../build/lib/darktable/plugins/introspection_exposure.c:154
 msgid "compensate exposure bias"
-msgstr "曝光偏移補償"
+msgstr "補償曝光修正"
 
 #: ../build/lib/darktable/plugins/introspection_exposure.c:168
 #: ../build/lib/darktable/plugins/introspection_levels.c:160
@@ -3623,7 +3664,7 @@ msgstr "自動"
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:411
 #: ../src/iop/filmic.c:1594
 msgid "middle gray luminance"
-msgstr "中間灰亮度"
+msgstr "中灰亮度"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:212
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:415
@@ -3631,13 +3672,13 @@ msgstr "中間灰亮度"
 #: ../build/lib/darktable/plugins/introspection_profile_gamma.c:166
 #: ../src/iop/filmic.c:1617
 msgid "black relative exposure"
-msgstr "黑色相對曝光"
+msgstr "黑點相對曝光"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:218
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:419
 #: ../src/iop/filmic.c:1605
 msgid "white relative exposure"
-msgstr "白色相對曝光"
+msgstr "白點相對曝光"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:230
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:427
@@ -3647,17 +3688,17 @@ msgstr "過渡"
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:236
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:431
 msgid "bloom ↔ reconstruct"
-msgstr "輝光 ↔ 重建"
+msgstr "模糊 ↔ 清晰"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:242
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:435
 msgid "gray ↔ colorful details"
-msgstr "灰色 ↔ 色彩細節"
+msgstr "灰階 ↔ 彩色"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:248
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:439
 msgid "structure ↔ texture"
-msgstr "結構 ↔ 紋理"
+msgstr "色塊 ↔ 紋理"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:254
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:443
@@ -3668,47 +3709,47 @@ msgstr "動態範圍縮放"
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:447
 #: ../src/iop/filmic.c:1747
 msgid "target middle gray"
-msgstr "目標中間灰"
+msgstr "輸出中灰色亮度"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:266
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:451
 #: ../src/iop/filmic.c:1738
 msgid "target black luminance"
-msgstr "目標黑亮度"
+msgstr "輸出黑點亮度"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:272
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:455
 #: ../src/iop/filmic.c:1756
 msgid "target white luminance"
-msgstr "目標白亮度"
+msgstr "輸出白點亮度"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:278
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:459
 #: ../build/lib/darktable/plugins/introspection_graduatednd.c:69
 #: ../build/lib/darktable/plugins/introspection_graduatednd.c:140
 msgid "hardness"
-msgstr "硬度"
+msgstr "冪函數曲線硬度"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:296
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:471
-#: ../src/iop/filmic.c:1687 ../src/iop/filmicrgb.c:4510
+#: ../src/iop/filmic.c:1687 ../src/iop/filmicrgb.c:4513
 msgid "extreme luminance saturation"
-msgstr "極端亮度飽和度"
+msgstr "極端亮度的飽和度"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:302
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:475
 msgid "shadows ↔ highlights balance"
-msgstr "陰影 ↔ 高光平衡"
+msgstr "陰影 ↔ 亮部平衡"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:308
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:479
 msgid "add noise in highlights"
-msgstr "在高光區中增加噪點"
+msgstr "增加亮部的雜訊"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:314
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:483
 msgid "preserve chrominance"
-msgstr "保持色度"
+msgstr "保留彩度"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:320
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:487
@@ -3718,37 +3759,37 @@ msgstr "色彩科學"
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:326
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:491
 msgid "auto adjust hardness"
-msgstr "自動調整硬度"
+msgstr "自動調整曲線硬度"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:332
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:495
 msgid "use custom middle-gray values"
-msgstr "使用自定中間灰色值"
+msgstr "使用自訂的中灰階調"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:338
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:499
 msgid "iterations of high-quality reconstruction"
-msgstr "高品質重建的迭代次數"
+msgstr "高品質迭代運算亮部重建"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:344
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:503
 msgid "type of noise"
-msgstr "噪點類型"
+msgstr "雜訊類型"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:350
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:507
 msgid "contrast in shadows"
-msgstr "陰影中的對比度"
+msgstr "暗部對比"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:356
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:511
 msgid "contrast in highlights"
-msgstr "高光中的對比度"
+msgstr "亮部對比"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:362
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:515
 msgid "compensate output ICC profile black point"
-msgstr "輸出 ICC 配置黑點補償"
+msgstr "補償輸出 ICC 描述檔的黑點"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:368
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:519
@@ -3757,13 +3798,13 @@ msgstr "平滑曲線處理"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:533
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:371
-#: ../src/common/database.c:2751 ../src/common/variables.c:592
+#: ../src/common/database.c:2749 ../src/common/variables.c:592
 #: ../src/develop/imageop_gui.c:196 ../src/imageio/format/pdf.c:647
 #: ../src/imageio/format/pdf.c:672 ../src/libs/export.c:1208
 #: ../src/libs/export.c:1214 ../src/libs/export.c:1221
 #: ../src/libs/metadata_view.c:678
 msgid "no"
-msgstr "不"
+msgstr "否"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:535
 msgid "luminance Y"
@@ -3772,16 +3813,16 @@ msgstr "亮度 Y"
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:536
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:384
 msgid "RGB power norm"
-msgstr "RGB 乘方範數"
+msgstr "RGB 乘冪範數"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:537
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:383
 msgid "RGB euclidean norm"
-msgstr "RGB 歐幾里德範數"
+msgstr "RGB 歐基里德距離"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:538
 msgid "RGB euclidean norm (legacy)"
-msgstr "RGB 歐幾里德範數(傳統)"
+msgstr "RGB 歐基里德距離（舊版）"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:542
 msgid "v3 (2019)"
@@ -3801,11 +3842,11 @@ msgstr "v6 (2022)"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:549
 msgid "uniform"
-msgstr "均勻"
+msgstr "均勻分布"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:551
 msgid "poissonian"
-msgstr "卜松"
+msgstr "帕松"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:555
 msgid "hard"
@@ -3834,7 +3875,7 @@ msgstr "v3 (2021)"
 #: ../build/lib/darktable/plugins/introspection_globaltonemap.c:60
 #: ../build/lib/darktable/plugins/introspection_globaltonemap.c:125
 msgid "bias"
-msgstr "偏差"
+msgstr "偏移"
 
 #: ../build/lib/darktable/plugins/introspection_globaltonemap.c:66
 #: ../build/lib/darktable/plugins/introspection_globaltonemap.c:129
@@ -3844,21 +3885,21 @@ msgstr "目標"
 
 #: ../build/lib/darktable/plugins/introspection_globaltonemap.c:151
 msgid "reinhard"
-msgstr "reinhard"
+msgstr "萊茵哈德"
 
 #: ../build/lib/darktable/plugins/introspection_globaltonemap.c:152
 #: ../src/iop/filmic.c:164
 msgid "filmic"
-msgstr "filmic"
+msgstr "電影式階調"
 
 #: ../build/lib/darktable/plugins/introspection_globaltonemap.c:153
 msgid "drago"
-msgstr "drago"
+msgstr "Drago"
 
 #: ../build/lib/darktable/plugins/introspection_graduatednd.c:63
 #: ../build/lib/darktable/plugins/introspection_graduatednd.c:136
 msgid "density"
-msgstr "密度"
+msgstr "濃度"
 
 #: ../build/lib/darktable/plugins/introspection_grain.c:58
 #: ../build/lib/darktable/plugins/introspection_grain.c:117
@@ -3871,90 +3912,94 @@ msgstr "粗糙度"
 #: ../build/lib/darktable/plugins/introspection_velvia.c:44
 #: ../build/lib/darktable/plugins/introspection_velvia.c:91
 msgid "mid-tones bias"
-msgstr "中間調偏移"
+msgstr "中間調修正"
 
-#: ../build/lib/darktable/plugins/introspection_highlights.c:131
-#: ../build/lib/darktable/plugins/introspection_highlights.c:232
-#: ../src/views/darkroom.c:2336
+#: ../build/lib/darktable/plugins/introspection_highlights.c:132
+#: ../build/lib/darktable/plugins/introspection_highlights.c:233
+#: ../src/views/darkroom.c:2337
 msgid "clipping threshold"
-msgstr "截取臨界值"
+msgstr "過曝剪裁門檻"
 
-#: ../build/lib/darktable/plugins/introspection_highlights.c:149
-#: ../build/lib/darktable/plugins/introspection_highlights.c:244
+#: ../build/lib/darktable/plugins/introspection_highlights.c:150
+#: ../build/lib/darktable/plugins/introspection_highlights.c:245
 msgid "diameter of reconstruction"
 msgstr "重建直徑"
 
-#: ../build/lib/darktable/plugins/introspection_highlights.c:155
-#: ../build/lib/darktable/plugins/introspection_highlights.c:248
-msgid "cast balance"
-msgstr "平衡"
+#: ../build/lib/darktable/plugins/introspection_highlights.c:156
+#: ../build/lib/darktable/plugins/introspection_highlights.c:249
+msgid "candidating"
+msgstr "候選"
 
-#: ../build/lib/darktable/plugins/introspection_highlights.c:161
-#: ../build/lib/darktable/plugins/introspection_highlights.c:252
-msgid "combine segments"
-msgstr "結合片段"
+#: ../build/lib/darktable/plugins/introspection_highlights.c:162
+#: ../build/lib/darktable/plugins/introspection_highlights.c:253
+msgid "combine"
+msgstr "合併"
 
-#: ../build/lib/darktable/plugins/introspection_highlights.c:173
-#: ../build/lib/darktable/plugins/introspection_highlights.c:260
+#: ../build/lib/darktable/plugins/introspection_highlights.c:174
+#: ../build/lib/darktable/plugins/introspection_highlights.c:261
 msgid "inpaint a flat color"
-msgstr "修復單色"
-
-#: ../build/lib/darktable/plugins/introspection_highlights.c:274
-msgid "clip highlights"
-msgstr "截取高光"
+msgstr "單色修復"
 
 #: ../build/lib/darktable/plugins/introspection_highlights.c:275
-msgid "reconstruct in LCh"
-msgstr "使用 LCh 色彩空間重建"
+msgid "clip highlights"
+msgstr "裁切亮部"
 
 #: ../build/lib/darktable/plugins/introspection_highlights.c:276
-msgid "reconstruct color"
-msgstr "重建顏色"
+msgid "reconstruct in LCh"
+msgstr "LCh 重建亮部"
 
 #: ../build/lib/darktable/plugins/introspection_highlights.c:277
-#: ../src/iop/highlights.c:2149
+msgid "reconstruct color"
+msgstr "重建亮部色彩"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:278
+#: ../src/iop/highlights.c:2198
 msgid "guided laplacians"
 msgstr "導引拉普拉斯運算"
 
-#: ../build/lib/darktable/plugins/introspection_highlights.c:281
-msgid "4 px"
-msgstr "4像素"
-
-#: ../build/lib/darktable/plugins/introspection_highlights.c:282
-msgid "8 px"
-msgstr "8像素"
+#: ../build/lib/darktable/plugins/introspection_highlights.c:279
+msgid "segmentation based"
+msgstr "基於分段"
 
 #: ../build/lib/darktable/plugins/introspection_highlights.c:283
-msgid "16 px"
-msgstr "16像素"
+msgid "4 px"
+msgstr "4 像素"
 
 #: ../build/lib/darktable/plugins/introspection_highlights.c:284
-msgid "32 px"
-msgstr "32像素"
+msgid "8 px"
+msgstr "8 像素"
 
 #: ../build/lib/darktable/plugins/introspection_highlights.c:285
-msgid "64 px"
-msgstr "64像素"
+msgid "16 px"
+msgstr "16 像素"
 
 #: ../build/lib/darktable/plugins/introspection_highlights.c:286
-msgid "128 px"
-msgstr "128像素"
+msgid "32 px"
+msgstr "32 像素"
 
 #: ../build/lib/darktable/plugins/introspection_highlights.c:287
-msgid "256 px (slow)"
-msgstr "256像素(慢)"
+msgid "64 px"
+msgstr "64 像素"
 
 #: ../build/lib/darktable/plugins/introspection_highlights.c:288
-msgid "512 px (slow)"
-msgstr "512像素(慢)"
+msgid "128 px"
+msgstr "128 像素"
 
 #: ../build/lib/darktable/plugins/introspection_highlights.c:289
-msgid "1024 px (very slow)"
-msgstr "1024像素(很慢)"
+msgid "256 px (slow)"
+msgstr "256 像素（慢）"
 
 #: ../build/lib/darktable/plugins/introspection_highlights.c:290
+msgid "512 px (slow)"
+msgstr "512 像素（很慢）"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:291
+msgid "1024 px (very slow)"
+msgstr "1024 像素（非常慢）"
+
+#: ../build/lib/darktable/plugins/introspection_highlights.c:292
 msgid "2048 px (insanely slow)"
-msgstr "2048像素(超級慢)"
+msgstr "2048 像素（非常慢）"
 
 #: ../build/lib/darktable/plugins/introspection_highpass.c:44
 #: ../build/lib/darktable/plugins/introspection_highpass.c:91
@@ -3964,12 +4009,12 @@ msgstr "對比度增強"
 #: ../build/lib/darktable/plugins/introspection_hotpixels.c:59
 #: ../build/lib/darktable/plugins/introspection_hotpixels.c:116
 msgid "mark fixed pixels"
-msgstr "標記修復像素"
+msgstr "在影像上標示被修復的像素"
 
 #: ../build/lib/darktable/plugins/introspection_hotpixels.c:65
 #: ../build/lib/darktable/plugins/introspection_hotpixels.c:120
 msgid "detect by 3 neighbors"
-msgstr "使用 3 個相鄰像素偵測"
+msgstr "熱壞點的標準由 4 個減至 3 個周邊像素"
 
 #. mode choice
 #: ../build/lib/darktable/plugins/introspection_lens.cc:106
@@ -3980,10 +4025,10 @@ msgstr "使用 3 個相鄰像素偵測"
 #: ../build/lib/darktable/plugins/introspection_rgblevels.c:118
 #: ../src/iop/bilat.c:427 ../src/iop/colorbalance.c:1857
 #: ../src/iop/denoiseprofile.c:3665 ../src/iop/exposure.c:1065
-#: ../src/iop/levels.c:680 ../src/iop/profile_gamma.c:676
+#: ../src/iop/levels.c:679 ../src/iop/profile_gamma.c:676
 #: ../src/libs/copy_history.c:374 ../src/libs/export.c:1302
 #: ../src/libs/image.c:599 ../src/libs/print_settings.c:2707
-#: ../src/libs/styles.c:827 ../src/views/darkroom.c:2312
+#: ../src/libs/styles.c:827 ../src/views/darkroom.c:2313
 msgid "mode"
 msgstr "模式"
 
@@ -3991,31 +4036,31 @@ msgstr "模式"
 #: ../build/lib/darktable/plugins/introspection_lens.cc:261
 #: ../src/iop/lens.cc:2380
 msgid "geometry"
-msgstr "幾何"
+msgstr "幾何校正"
 
 #: ../build/lib/darktable/plugins/introspection_lens.cc:172
 #: ../build/lib/darktable/plugins/introspection_lens.cc:281
 msgid "TCA overwrite"
-msgstr "TCA 覆蓋"
+msgstr "橫向色差覆寫"
 
 #: ../build/lib/darktable/plugins/introspection_lens.cc:178
 #: ../build/lib/darktable/plugins/introspection_lens.cc:285
 msgid "TCA red"
-msgstr "TCA 紅色"
+msgstr "紅色橫向色差"
 
 #: ../build/lib/darktable/plugins/introspection_lens.cc:184
 #: ../build/lib/darktable/plugins/introspection_lens.cc:289
 msgid "TCA blue"
-msgstr "TCA 藍色"
+msgstr "藍色橫向色差"
 
 #: ../build/lib/darktable/plugins/introspection_liquify.c:428
 msgid "invalidated"
-msgstr "無效化"
+msgstr "清除"
 
 #. move left/right/up/down
 #: ../build/lib/darktable/plugins/introspection_liquify.c:429
-#: ../src/views/darkroom.c:2211 ../src/views/darkroom.c:2617
-#: ../src/views/darkroom.c:2620 ../src/views/lighttable.c:754
+#: ../src/views/darkroom.c:2212 ../src/views/darkroom.c:2618
+#: ../src/views/darkroom.c:2621 ../src/views/lighttable.c:754
 #: ../src/views/lighttable.c:763 ../src/views/lighttable.c:1231
 #: ../src/views/lighttable.c:1235 ../src/views/lighttable.c:1239
 #: ../src/views/lighttable.c:1243 ../src/views/lighttable.c:1247
@@ -4024,18 +4069,18 @@ msgstr "移動"
 
 #: ../build/lib/darktable/plugins/introspection_liquify.c:430
 msgid "line"
-msgstr "直線"
+msgstr "線條"
 
 #: ../build/lib/darktable/plugins/introspection_liquify.c:431
-#: ../src/iop/basecurve.c:2075 ../src/iop/rgbcurve.c:1396
-#: ../src/iop/tonecurve.c:1173
+#: ../src/iop/basecurve.c:2074 ../src/iop/rgbcurve.c:1396
+#: ../src/iop/tonecurve.c:1172
 msgid "curve"
 msgstr "曲線"
 
 #: ../build/lib/darktable/plugins/introspection_lowlight.c:43
 #: ../build/lib/darktable/plugins/introspection_lowlight.c:110
 msgid "blue shift"
-msgstr "藍色飄移"
+msgstr "藍色偏移"
 
 #: ../build/lib/darktable/plugins/introspection_lowpass.c:96
 #: ../build/lib/darktable/plugins/introspection_lowpass.c:165
@@ -4062,12 +4107,12 @@ msgstr "2 階"
 #: ../build/lib/darktable/plugins/introspection_lowpass.c:190
 #: ../build/lib/darktable/plugins/introspection_shadhi.c:268
 msgid "bilateral filter"
-msgstr "降噪(雙邊濾鏡)"
+msgstr "雙邊濾波器"
 
 #: ../build/lib/darktable/plugins/introspection_lut3d.c:76
 #: ../build/lib/darktable/plugins/introspection_lut3d.c:163
 msgid "application color space"
-msgstr "應用程式色彩空間"
+msgstr "執行轉換的色彩空間"
 
 #: ../build/lib/darktable/plugins/introspection_lut3d.c:202
 msgid "Adobe RGB"
@@ -4075,7 +4120,7 @@ msgstr "Adobe RGB"
 
 #: ../build/lib/darktable/plugins/introspection_lut3d.c:203
 msgid "gamma Rec709 RGB"
-msgstr "伽瑪 Rec709 RGB"
+msgstr "非線性 Rec. 709"
 
 #: ../build/lib/darktable/plugins/introspection_lut3d.c:209
 msgid "tetrahedral"
@@ -4083,7 +4128,7 @@ msgstr "四面體"
 
 #: ../build/lib/darktable/plugins/introspection_lut3d.c:210
 msgid "trilinear"
-msgstr "三線性"
+msgstr "三次線性"
 
 #: ../build/lib/darktable/plugins/introspection_lut3d.c:211
 msgid "pyramid"
@@ -4092,28 +4137,28 @@ msgstr "金字塔"
 #: ../build/lib/darktable/plugins/introspection_negadoctor.c:84
 #: ../build/lib/darktable/plugins/introspection_negadoctor.c:199
 msgid "film stock"
-msgstr "底片"
+msgstr "底片種類"
 
 #: ../build/lib/darktable/plugins/introspection_negadoctor.c:132
 #: ../build/lib/darktable/plugins/introspection_negadoctor.c:231
 msgid "scan exposure bias"
-msgstr "掃描曝光偏差"
+msgstr "掃描 / 翻拍曝光偏差"
 
 #: ../build/lib/darktable/plugins/introspection_negadoctor.c:138
 #: ../build/lib/darktable/plugins/introspection_negadoctor.c:235
 msgid "paper black (density correction)"
-msgstr "紙的黑度(密度修正)"
+msgstr "紙張黑點（濃度修正）"
 
 #: ../build/lib/darktable/plugins/introspection_negadoctor.c:144
 #: ../build/lib/darktable/plugins/introspection_negadoctor.c:239
 #: ../src/iop/negadoctor.c:963
 msgid "paper grade (gamma)"
-msgstr "紙的等級(伽馬)"
+msgstr "紙張階調（伽馬）"
 
 #: ../build/lib/darktable/plugins/introspection_negadoctor.c:150
 #: ../build/lib/darktable/plugins/introspection_negadoctor.c:243
 msgid "paper gloss (specular highlights)"
-msgstr "紙的光澤度(鏡面高光)"
+msgstr "紙張光澤（亮部剪裁）"
 
 #: ../build/lib/darktable/plugins/introspection_negadoctor.c:156
 #: ../build/lib/darktable/plugins/introspection_negadoctor.c:247
@@ -4123,12 +4168,12 @@ msgstr "列印曝光調整"
 #: ../build/lib/darktable/plugins/introspection_negadoctor.c:261
 #: ../src/iop/negadoctor.c:390
 msgid "black and white film"
-msgstr "黑白軟片"
+msgstr "黑白底片"
 
 #: ../build/lib/darktable/plugins/introspection_negadoctor.c:262
 #: ../src/iop/negadoctor.c:375
 msgid "color film"
-msgstr "彩色軟片"
+msgstr "彩色底片"
 
 #: ../build/lib/darktable/plugins/introspection_profile_gamma.c:85
 #: ../build/lib/darktable/plugins/introspection_profile_gamma.c:158
@@ -4138,69 +4183,69 @@ msgstr "動態範圍"
 #: ../build/lib/darktable/plugins/introspection_profile_gamma.c:91
 #: ../build/lib/darktable/plugins/introspection_profile_gamma.c:162
 msgid "middle gray luma"
-msgstr "中間灰亮度"
+msgstr "中灰亮度"
 
 #: ../build/lib/darktable/plugins/introspection_profile_gamma.c:103
 #: ../build/lib/darktable/plugins/introspection_profile_gamma.c:170
 #: ../src/iop/filmic.c:1628
 msgid "safety factor"
-msgstr "安全因子"
+msgstr "安全係數"
 
 #: ../build/lib/darktable/plugins/introspection_profile_gamma.c:184
 msgid "logarithmic"
-msgstr "對數"
+msgstr "對數（log）"
 
 #: ../build/lib/darktable/plugins/introspection_profile_gamma.c:185
 #: ../src/iop/profile_gamma.c:633
 msgid "gamma"
-msgstr "伽馬"
+msgstr "伽瑪（gamma）"
 
 #: ../build/lib/darktable/plugins/introspection_rawdenoise.c:43
 #: ../build/lib/darktable/plugins/introspection_rawdenoise.c:122
 msgid "noise threshold"
-msgstr "噪點臨界值"
+msgstr "雜訊門檻"
 
 #: ../build/lib/darktable/plugins/introspection_rawprepare.c:70
 #: ../build/lib/darktable/plugins/introspection_rawprepare.c:155
 msgid "crop left"
-msgstr "從左邊緣剪裁"
+msgstr "裁切左側"
 
 #: ../build/lib/darktable/plugins/introspection_rawprepare.c:76
 #: ../build/lib/darktable/plugins/introspection_rawprepare.c:159
 msgid "crop top"
-msgstr "從頂部剪裁"
+msgstr "裁切上方"
 
 #: ../build/lib/darktable/plugins/introspection_rawprepare.c:82
 #: ../build/lib/darktable/plugins/introspection_rawprepare.c:163
 msgid "crop right"
-msgstr "從右邊緣剪裁"
+msgstr "裁切右側"
 
 #: ../build/lib/darktable/plugins/introspection_rawprepare.c:88
 #: ../build/lib/darktable/plugins/introspection_rawprepare.c:167
 msgid "crop bottom"
-msgstr "從底部裁剪"
+msgstr "裁切下方"
 
 #: ../build/lib/darktable/plugins/introspection_rawprepare.c:94
 #: ../build/lib/darktable/plugins/introspection_rawprepare.c:100
 #: ../build/lib/darktable/plugins/introspection_rawprepare.c:171
 #: ../build/lib/darktable/plugins/introspection_rawprepare.c:175
 msgid "black level"
-msgstr "黑色階"
+msgstr "黑色位準"
 
 #: ../build/lib/darktable/plugins/introspection_rawprepare.c:106
 #: ../build/lib/darktable/plugins/introspection_rawprepare.c:179
 #: ../src/iop/rawprepare.c:847
 msgid "white point"
-msgstr "白點"
+msgstr "白色位準"
 
 #: ../build/lib/darktable/plugins/introspection_rawprepare.c:112
 #: ../build/lib/darktable/plugins/introspection_rawprepare.c:183
 msgid "flat field correction"
-msgstr "平場修正"
+msgstr "平場校正"
 
 #: ../build/lib/darktable/plugins/introspection_rawprepare.c:198
 msgid "embedded GainMap"
-msgstr "嵌入GainMap"
+msgstr "已嵌入 GainMap"
 
 #. exposure
 #: ../build/lib/darktable/plugins/introspection_relight.c:43
@@ -4214,7 +4259,7 @@ msgstr "曝光"
 #: ../build/lib/darktable/plugins/introspection_retouch.c:267
 #: ../build/lib/darktable/plugins/introspection_retouch.c:414
 msgid "fill mode"
-msgstr "填充模式"
+msgstr "填色模式"
 
 #: ../build/lib/darktable/plugins/introspection_retouch.c:285
 #: ../build/lib/darktable/plugins/introspection_retouch.c:426
@@ -4227,7 +4272,7 @@ msgstr "亮度"
 #: ../build/lib/darktable/plugins/introspection_retouch.c:291
 #: ../build/lib/darktable/plugins/introspection_retouch.c:430
 msgid "max_iter"
-msgstr "最大迭代"
+msgstr "最高迭代次數"
 
 #: ../build/lib/darktable/plugins/introspection_retouch.c:444
 #: ../src/libs/metadata_view.c:330
@@ -4240,7 +4285,7 @@ msgstr "複製"
 
 #: ../build/lib/darktable/plugins/introspection_retouch.c:446
 msgid "heal"
-msgstr "重建"
+msgstr "修復"
 
 #: ../build/lib/darktable/plugins/introspection_retouch.c:447
 #: ../src/iop/retouch.c:1834
@@ -4250,39 +4295,39 @@ msgstr "模糊"
 #: ../build/lib/darktable/plugins/introspection_retouch.c:448
 #: ../src/iop/retouch.c:1836
 msgid "fill"
-msgstr "填充"
+msgstr "填色"
 
 #: ../build/lib/darktable/plugins/introspection_retouch.c:453
 msgid "bilateral"
-msgstr "雙邊"
+msgstr "雙邊濾波"
 
 #: ../build/lib/darktable/plugins/introspection_retouch.c:457
 msgid "erase"
-msgstr "移除"
+msgstr "擦除"
 
 #: ../build/lib/darktable/plugins/introspection_retouch.c:458
 #: ../src/gui/presets.c:59 ../src/iop/watermark.c:1107
 #: ../src/libs/colorpicker.c:285 ../src/libs/image.c:615
 #: ../src/libs/modulegroups.c:2409
 msgid "color"
-msgstr "顏色"
+msgstr "色彩"
 
 #: ../build/lib/darktable/plugins/introspection_rgbcurve.c:134
 #: ../build/lib/darktable/plugins/introspection_rgbcurve.c:223
 #: ../src/iop/rgbcurve.c:1434
 msgid "compensate middle gray"
-msgstr "補償中間灰"
+msgstr "顯示符合視覺感知的灰階亮度座標"
 
 #: ../build/lib/darktable/plugins/introspection_rgbcurve.c:246
 #: ../build/lib/darktable/plugins/introspection_rgblevels.c:148
 #: ../build/lib/darktable/plugins/introspection_tonecurve.c:266
 msgid "RGB, linked channels"
-msgstr "RGB，鏈接通道"
+msgstr "RGB 連動調整"
 
 #: ../build/lib/darktable/plugins/introspection_rgbcurve.c:247
 #: ../build/lib/darktable/plugins/introspection_rgblevels.c:149
 msgid "RGB, independent channels"
-msgstr "RGB, 獨立通道"
+msgstr "RGB 獨立調整"
 
 #: ../build/lib/darktable/plugins/introspection_shadhi.c:112
 #: ../build/lib/darktable/plugins/introspection_shadhi.c:215
@@ -4292,16 +4337,16 @@ msgstr "白點調整"
 #: ../build/lib/darktable/plugins/introspection_shadhi.c:136
 #: ../build/lib/darktable/plugins/introspection_shadhi.c:231
 msgid "shadows color adjustment"
-msgstr "陰影顏色調整"
+msgstr "暗部色彩調整"
 
 #: ../build/lib/darktable/plugins/introspection_shadhi.c:142
 #: ../build/lib/darktable/plugins/introspection_shadhi.c:235
 msgid "highlights color adjustment"
-msgstr "高光色彩調整"
+msgstr "亮部色彩調整"
 
 #: ../build/lib/darktable/plugins/introspection_temperature.c:66
 #: ../build/lib/darktable/plugins/introspection_temperature.c:121
-#: ../src/iop/temperature.c:1825
+#: ../src/iop/temperature.c:1770
 msgid "emerald"
 msgstr "祖母綠"
 
@@ -4312,15 +4357,15 @@ msgstr "色彩空間"
 
 #: ../build/lib/darktable/plugins/introspection_tonecurve.c:263
 msgid "Lab, linked channels"
-msgstr "Lab, 鏈接通道"
+msgstr "L*a*b* 連動調整"
 
 #: ../build/lib/darktable/plugins/introspection_tonecurve.c:264
 msgid "Lab, independent channels"
-msgstr "Lab, 獨立通道"
+msgstr "L*a*b* 獨立調整"
 
 #: ../build/lib/darktable/plugins/introspection_tonecurve.c:265
 msgid "XYZ, linked channels"
-msgstr "XYZ，鏈接通道"
+msgstr "XYZ 連動調整"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:144
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:289
@@ -4330,42 +4375,42 @@ msgstr "黑色"
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:150
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:293
 msgid "deep shadows"
-msgstr "深色陰影"
+msgstr "深陰影"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:156
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:297
 #: ../src/iop/bilat.c:459 ../src/iop/colorbalance.c:2047
-#: ../src/iop/colorbalancergb.c:2161 ../src/iop/colorbalancergb.c:2165
-#: ../src/iop/colorbalancergb.c:2169 ../src/iop/shadhi.c:680
+#: ../src/iop/colorbalancergb.c:2158 ../src/iop/colorbalancergb.c:2162
+#: ../src/iop/colorbalancergb.c:2166 ../src/iop/shadhi.c:680
 #: ../src/iop/splittoning.c:520
 msgid "shadows"
-msgstr "陰影"
+msgstr "暗部"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:162
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:301
 msgid "light shadows"
-msgstr "淺色陰影"
+msgstr "淺陰影"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:168
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:305
-#: ../src/iop/colorbalance.c:2048 ../src/iop/colorbalancergb.c:2160
-#: ../src/iop/colorbalancergb.c:2164 ../src/iop/colorbalancergb.c:2168
+#: ../src/iop/colorbalance.c:2048 ../src/iop/colorbalancergb.c:2157
+#: ../src/iop/colorbalancergb.c:2161 ../src/iop/colorbalancergb.c:2165
 msgid "mid-tones"
 msgstr "中間調"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:174
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:309
 msgid "dark highlights"
-msgstr "深色高光"
+msgstr "中亮部"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:180
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:313
 #: ../src/iop/bilat.c:454 ../src/iop/colorbalance.c:2049
-#: ../src/iop/colorbalancergb.c:2159 ../src/iop/colorbalancergb.c:2163
-#: ../src/iop/colorbalancergb.c:2167 ../src/iop/monochrome.c:576
+#: ../src/iop/colorbalancergb.c:2156 ../src/iop/colorbalancergb.c:2160
+#: ../src/iop/colorbalancergb.c:2164 ../src/iop/monochrome.c:576
 #: ../src/iop/shadhi.c:681 ../src/iop/splittoning.c:522
 msgid "highlights"
-msgstr "高光"
+msgstr "亮部"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:186
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:317
@@ -4375,17 +4420,17 @@ msgstr "白色"
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:192
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:321
 msgid "speculars"
-msgstr "鏡面反射"
+msgstr "反射光點"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:198
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:325
 msgid "smoothing diameter"
-msgstr "平滑直徑"
+msgstr "模糊直徑"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:210
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:333
 msgid "edges refinement/feathering"
-msgstr "邊緣精鍊/羽化"
+msgstr "邊緣追蹤或羽化"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:216
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:337
@@ -4395,64 +4440,64 @@ msgstr "遮罩量化"
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:222
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:341
 msgid "mask contrast compensation"
-msgstr "遮罩對比度補償"
+msgstr "階調遮罩亮度調整"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:228
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:345
 msgid "mask exposure compensation"
-msgstr "遮罩曝光補償"
+msgstr "階調遮罩對比調整"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:240
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:353
 msgid "luminance estimator"
-msgstr "亮度估計量"
+msgstr "亮度評估法"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:246
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:357
 msgid "filter diffusion"
-msgstr "濾波擴散"
+msgstr "迭代濾波"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:372
 msgid "averaged guided filter"
-msgstr "平均導引過濾器"
+msgstr "導引濾波器平均"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:373
 msgid "guided filter"
-msgstr "導引過濾器"
+msgstr "導引濾波器"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:374
 msgid "averaged eigf"
-msgstr "平均eigf"
+msgstr "無關曝光的導引濾波器平均"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:375
 msgid "eigf"
-msgstr "eigf"
+msgstr "無關曝光的導引濾波器"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:379
 msgid "RGB average"
-msgstr "RGB平均"
+msgstr "RGB 平均"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:380
 msgid "HSL lightness"
-msgstr "HSL亮度"
+msgstr "HSL 明度"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:381
 msgid "HSV value / RGB max"
-msgstr "HSV明度/RGB最大"
+msgstr "HSV 亮度 / RGB 最大"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:382
 msgid "RGB sum"
-msgstr "RGB總和"
+msgstr "RGB 總和"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:385
 msgid "RGB geometric mean"
-msgstr "RGB幾何平均"
+msgstr "RGB 幾何平均"
 
 #: ../build/lib/darktable/plugins/introspection_tonemap.cc:39
 #: ../build/lib/darktable/plugins/introspection_tonemap.cc:88
-#: ../src/iop/rgbcurve.c:183 ../src/iop/tonecurve.c:554
+#: ../src/iop/rgbcurve.c:183 ../src/iop/tonecurve.c:553
 msgid "contrast compression"
-msgstr "對比度壓縮"
+msgstr "壓縮對比"
 
 #: ../build/lib/darktable/plugins/introspection_vibrance.c:33
 #: ../build/lib/darktable/plugins/introspection_vibrance.c:76
@@ -4463,17 +4508,17 @@ msgstr "自然飽和度"
 #: ../build/lib/darktable/plugins/introspection_vignette.c:97
 #: ../build/lib/darktable/plugins/introspection_vignette.c:204
 msgid "fall-off strength"
-msgstr "光衰減強度"
+msgstr "光衰程度"
 
 #: ../build/lib/darktable/plugins/introspection_vignette.c:115
 #: ../build/lib/darktable/plugins/introspection_vignette.c:216
 msgid "horizontal center"
-msgstr "水平中心"
+msgstr "水平中心點"
 
 #: ../build/lib/darktable/plugins/introspection_vignette.c:121
 #: ../build/lib/darktable/plugins/introspection_vignette.c:220
 msgid "vertical center"
-msgstr "垂直中心"
+msgstr "垂直中心點"
 
 #: ../build/lib/darktable/plugins/introspection_vignette.c:133
 #: ../build/lib/darktable/plugins/introspection_vignette.c:228
@@ -4483,7 +4528,7 @@ msgstr "自動比例"
 #: ../build/lib/darktable/plugins/introspection_vignette.c:139
 #: ../build/lib/darktable/plugins/introspection_vignette.c:232
 msgid "width/height ratio"
-msgstr "寬/高比例"
+msgstr "寬 / 高比例"
 
 #: ../build/lib/darktable/plugins/introspection_vignette.c:145
 #: ../build/lib/darktable/plugins/introspection_vignette.c:236
@@ -4493,40 +4538,40 @@ msgstr "形狀"
 
 #: ../build/lib/darktable/plugins/introspection_vignette.c:264
 msgid "8-bit output"
-msgstr "8-位元 輸出"
+msgstr "8 位元輸出"
 
 #: ../build/lib/darktable/plugins/introspection_vignette.c:265
 msgid "16-bit output"
-msgstr "16-位元輸出"
+msgstr "16 位元輸出"
 
 #: ../build/lib/darktable/plugins/introspection_watermark.c:100
 #: ../build/lib/darktable/plugins/introspection_watermark.c:223
 msgid "x offset"
-msgstr "x 偏移"
+msgstr "水平偏移"
 
 #: ../build/lib/darktable/plugins/introspection_watermark.c:106
 #: ../build/lib/darktable/plugins/introspection_watermark.c:227
 msgid "y offset"
-msgstr "y 偏移"
+msgstr "垂直偏移"
 
 #: ../build/lib/darktable/plugins/introspection_watermark.c:124
 #: ../build/lib/darktable/plugins/introspection_watermark.c:239
 msgid "scale on"
-msgstr "縮放於"
+msgstr "縮放依"
 
 #: ../build/lib/darktable/plugins/introspection_watermark.c:285
 #: ../src/imageio/format/tiff.c:121 ../src/imageio/format/xcf.c:149
 #: ../src/iop/borders.c:960
 msgid "image"
-msgstr "圖片"
+msgstr "影像"
 
 #: ../build/lib/darktable/plugins/introspection_watermark.c:286
 msgid "larger border"
-msgstr "更大的邊"
+msgstr "粗邊框"
 
 #: ../build/lib/darktable/plugins/introspection_watermark.c:287
 msgid "smaller border"
-msgstr "更小的邊"
+msgstr "細邊框"
 
 #: ../build/lib/darktable/plugins/lighttable/tools/darktable_authors.h:6
 msgid "developers"
@@ -4534,7 +4579,7 @@ msgstr "開發者"
 
 #: ../build/lib/darktable/plugins/lighttable/tools/darktable_authors.h:11
 msgid "translators"
-msgstr "翻譯人員"
+msgstr "翻譯者"
 
 #: ../build/lib/darktable/plugins/lighttable/tools/darktable_authors.h:16
 msgid "contributors"
@@ -4546,23 +4591,23 @@ msgstr "rawspeed 貢獻者"
 
 #: ../build/lib/darktable/plugins/lighttable/tools/darktable_authors.h:26
 msgid "integration contributors"
-msgstr "整合貢獻者"
+msgstr "integration 貢獻者"
 
 #: ../build/share/darktable/darktable.desktop.in.h:1
 #: ../data/darktable.desktop.in.h:1
 msgid "Virtual Lighttable and Darkroom"
-msgstr "虛擬的映繪桌和暗房"
+msgstr "虛擬燈箱與暗房"
 
 #: ../build/share/darktable/darktable.desktop.in.h:2
 #: ../data/darktable.appdata.xml.in.h:1 ../data/darktable.desktop.in.h:2
 msgid "Organize and develop images from digital cameras"
-msgstr "組織並編修來自數位相機的圖片"
+msgstr "整理和顯影來自數位相機的影像"
 
 #. TRANSLATORS: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: ../build/share/darktable/darktable.desktop.in.h:4
 #: ../data/darktable.desktop.in.h:4
 msgid "graphics;photography;raw;"
-msgstr "圖片;攝影;數位底片;"
+msgstr "圖形、攝影、RAW 檔"
 
 #: ../data/darktable.appdata.xml.in.h:2
 msgid ""
@@ -4570,38 +4615,39 @@ msgid ""
 "them through a lighttable. It also enables you to develop raw images and "
 "enhance them in a darkroom."
 msgstr ""
-"使用 darktable 管理您的數位底片，在映繪桌瀏覽照片，在暗房中處理 RAW 影像。"
+"darktable 使用資料庫管理影像圖庫，並透過「燈箱 LighTable」模式檢視，和「暗房 "
+"Darkroom」模式編輯調整影像。"
 
 #: ../data/darktable.appdata.xml.in.h:3
 msgid ""
 "Other modes besides lighttable and darkroom are a map for geotagging, "
 "tethering, print and a slideshow."
 msgstr ""
-"除了映繪桌和暗房模式，您可以使用地圖爲照片增加地理位置標籤、連接相機拍攝、列"
-"印照片及放映幻燈片。"
+"除了「燈箱 LightTable」和「暗房 Darkroom」這兩個主要模式之外，還有地圖、連機拍"
+"攝、列印（不適用於 windows）和影像輪播等功能。"
 
 #: ../data/darktable.appdata.xml.in.h:4
 msgid ""
 "darktable supports most modern cameras' raw formats, and does all of its "
 "processing at very high precision."
 msgstr ""
-"darktable 支持絕大多數現代相機的 RAW 檔案格式，並以極高精確度處理影像。"
+"darktable 支援大多數現代相機的 RAW 格式，並以 32 bit float 精度執行內部運算"
 
 #: ../data/darktable.appdata.xml.in.h:5
 msgid "Virtual light table, showing a collection"
-msgstr "虛擬映繪桌，用於展示照片集"
+msgstr "虛擬燈箱，顯示相冊"
 
 #: ../data/darktable.appdata.xml.in.h:6
 msgid "Virtual dark room with an opened image"
-msgstr "虛擬暗房，打開單張影像"
+msgstr "虛擬暗房，含一開啟影像"
 
 #: ../data/darktable.appdata.xml.in.h:7
 msgid "Virtual dark room, sharpening an image"
-msgstr "虛擬暗房，對影像進行銳利化"
+msgstr "虛擬暗房，銳化影像"
 
 #: ../data/darktable.appdata.xml.in.h:8
 msgid "Show images on a map"
-msgstr "在地圖上顯示影像"
+msgstr "在地圖中顯示影像"
 
 #: ../data/darktable.appdata.xml.in.h:9
 msgid "Print your images"
@@ -4609,11 +4655,11 @@ msgstr "列印影像"
 
 #: ../src/bauhaus/bauhaus.c:3273
 msgid "button on"
-msgstr "按鈕開"
+msgstr "按鈕開啟"
 
 #: ../src/bauhaus/bauhaus.c:3273
 msgid "button off"
-msgstr "按鈕關"
+msgstr "按鈕關閉"
 
 #: ../src/bauhaus/bauhaus.c:3442 ../src/gui/accelerators.c:270
 msgid "value"
@@ -4634,36 +4680,36 @@ msgstr "縮放"
 
 #: ../src/bauhaus/bauhaus.c:3448
 msgid "selection"
-msgstr "選擇"
+msgstr "勾選"
 
 #: ../src/bauhaus/bauhaus.c:3467
 msgid "slider"
-msgstr "滑動條"
+msgstr "滑桿"
 
 #: ../src/bauhaus/bauhaus.c:3472
 msgid "dropdown"
 msgstr "下拉選單"
 
 #: ../src/chart/main.c:504 ../src/control/jobs/control_jobs.c:1686
-#: ../src/control/jobs/control_jobs.c:1748 ../src/gui/accelerators.c:1891
-#: ../src/gui/accelerators.c:1967 ../src/gui/accelerators.c:2018
-#: ../src/gui/accelerators.c:2046 ../src/gui/accelerators.c:2105
+#: ../src/control/jobs/control_jobs.c:1748 ../src/gui/accelerators.c:1890
+#: ../src/gui/accelerators.c:1966 ../src/gui/accelerators.c:2017
+#: ../src/gui/accelerators.c:2045 ../src/gui/accelerators.c:2104
 #: ../src/gui/hist_dialog.c:195 ../src/gui/preferences.c:997
 #: ../src/gui/preferences.c:1036 ../src/gui/presets.c:376
 #: ../src/gui/presets.c:476 ../src/gui/styles_dialog.c:420
 #: ../src/imageio/storage/disk.c:122 ../src/imageio/storage/gallery.c:109
-#: ../src/imageio/storage/latex.c:108 ../src/iop/lut3d.c:1557
+#: ../src/imageio/storage/latex.c:108 ../src/iop/lut3d.c:1551
 #: ../src/libs/collect.c:409 ../src/libs/copy_history.c:107
 #: ../src/libs/geotagging.c:929 ../src/libs/import.c:1497
 #: ../src/libs/import.c:1601 ../src/libs/styles.c:377 ../src/libs/styles.c:512
 #: ../src/libs/tagging.c:2485 ../src/libs/tagging.c:2521
 msgid "_cancel"
-msgstr "取消"
+msgstr "取消（_C）"
 
 #: ../src/chart/main.c:504 ../src/gui/preferences.c:1036
 #: ../src/gui/styles_dialog.c:423 ../src/libs/styles.c:377
 msgid "_save"
-msgstr "保存 (_s)"
+msgstr "儲存（_S）"
 
 #. TODO: is the rank interesting, too?
 #: ../src/chart/main.c:1063
@@ -4672,130 +4718,154 @@ msgid ""
 "average dE: %.02f\n"
 "max dE: %.02f"
 msgstr ""
-"平均 dE: %.02f\n"
-"最大 dE: %.02f"
+"平均 dE：%.02f\n"
+"最大 dE：%.02f"
 
 #: ../src/cli/main.c:247
 msgid "TODO: sorry, due to API restrictions we currently cannot set the BPP to"
-msgstr "TODO:很抱歉，由於API的限制，我們目前無法將 BPP 設置爲"
+msgstr "TODO：抱歉，由於 API 的限制，我們目前無法將 BPP 設為"
 
 #: ../src/cli/main.c:259
 msgid "unknown option for --hq"
-msgstr "在 --hq 指定了未知選項"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"在 --hq 使用未知的選項"
 
 #: ../src/cli/main.c:275
 msgid "unknown option for --export_masks"
-msgstr "在 --export 指定了未知輸出遮罩"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"在 --export_masks 使用未知的選項"
 
 #: ../src/cli/main.c:291
 msgid "unknown option for --upscale"
-msgstr "在 --upscale 指定了未知選項"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"在 --upscale 使用未知的選項"
 
 #: ../src/cli/main.c:316
 msgid "unknown option for --apply-custom-presets"
-msgstr "在 --apply-custom-presets 指定了未知預置"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"在 --apply-custom-presets 使用未知的選項"
 
 #: ../src/cli/main.c:327
 msgid "too long ext for --out-ext"
-msgstr "--out-ext 的附檔名過長"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"在 --out-ext 使用過長的附檔名"
 
 #: ../src/cli/main.c:344
 #, c-format
 msgid "notice: input file or dir '%s' doesn't exist, skipping\n"
-msgstr "注意:輸入檔案或目錄“%s”不存在，已跳過\n"
+msgstr ""
+"⚠️ 注意 ⚠️\n"
+"匯入的檔案或資料夾「%s」不存在，正在略過\n"
 
 #: ../src/cli/main.c:353
 #, c-format
 msgid "incorrect ICC type for --icc-type: '%s'\n"
-msgstr "--icc-type 傳入了不正確的 ICC 類型:“%s”\n"
+msgstr "⚠️ 錯誤的 ICC 類型「%s」⚠️\n"
 
 #: ../src/cli/main.c:369
 #, c-format
 msgid "notice: ICC file '%s' doesn't exist, skipping\n"
-msgstr "注意:ICC 檔案“%s”不存在，已跳過\n"
+msgstr ""
+"⚠️ 注意 ⚠️\n"
+"ICC 檔案「%s」不存在，正在略過\n"
 
 #: ../src/cli/main.c:378
 #, c-format
 msgid "incorrect ICC intent for --icc-intent: '%s'\n"
-msgstr "--icc-intent 傳入了不正確的 ICC 渲染意圖:“%s”\n"
+msgstr "⚠️ 錯誤的 ICC 轉換方式「%s」⚠️\n"
 
 #: ../src/cli/main.c:396
 #, c-format
 msgid "warning: unknown option '%s'\n"
-msgstr "警告:未知選項“%s”\n"
+msgstr ""
+"⚠️ 警告 ⚠️\n"
+"未知選項「%s」\n"
 
 #: ../src/cli/main.c:454
 #, c-format
 msgid "error: input file and import opts specified! that's not supported!\n"
-msgstr "錯誤:輸入檔案和輸入選項皆已指定，不支援此選項組合！\n"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"不支援指定的輸入檔案和選項\n"
 
 #: ../src/cli/main.c:487
 #, c-format
 msgid ""
 "notice: output location is a directory. assuming '%s/$(FILE_NAME).%s' output "
 "pattern"
-msgstr "注意:輸出位置是一個目錄。預設使用“%s/$(FILE_NAME).%s”作爲輸出樣式"
+msgstr ""
+"⚠️ 注意 ⚠️\n"
+"匯出位置是一個目錄，預設使用「%s/$(FILE_NAME).%s」作為檔案名稱"
 
 #. output file exists or there's output ext specified and it's same as file...
 #: ../src/cli/main.c:502
 msgid "output file already exists, it will get renamed"
-msgstr "輸出檔案已經存在,它將會被重新命名"
+msgstr "輸出檔案已經存在，將重新命名"
 
 #. one of inputs was a failure, no prob
 #: ../src/cli/main.c:532
 #, c-format
 msgid "error: can't open folder %s"
-msgstr "錯誤:無法打開目錄 %s"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"無法開啟「%s」資料夾"
 
 #: ../src/cli/main.c:549
 #, c-format
 msgid "error: can't open file %s"
-msgstr "錯誤:無法打開檔案 %s"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"無法打開「%s」檔案"
 
 #: ../src/cli/main.c:566
 #, c-format
 msgid "no images to export, aborting\n"
-msgstr "沒有影像要輸出，取消\n"
+msgstr "沒有影像可以匯出，正在中止\n"
 
 #: ../src/cli/main.c:583
 #, c-format
 msgid "error: can't open xmp file %s"
-msgstr "錯誤:無法打開 xmp 檔案 %s"
+msgstr "⚠️ 錯誤 ⚠️\v無法打開 XMP 檔案「%s」"
 
 #: ../src/cli/main.c:604
 msgid "empty history stack"
-msgstr "清空歷史記錄堆棧"
+msgstr "刪除影像編輯紀錄"
 
 #. too long ext, no point in wasting time
 #: ../src/cli/main.c:616
 #, c-format
 msgid "too long output file extension: %s\n"
-msgstr "輸出檔案副檔名過長:%s\n"
+msgstr "輸出檔案的副檔名「.%s」過長\n"
 
 #. no ext or empty ext, no point in wasting time
 #: ../src/cli/main.c:624
 #, c-format
 msgid "no output file extension given\n"
-msgstr "未指定輸出檔案副檔名\n"
+msgstr "未指定輸出影像的副檔名\n"
 
 #: ../src/cli/main.c:663
 msgid ""
 "cannot find disk storage module. please check your installation, something "
 "seems to be broken."
-msgstr "無法找到硬碟儲存模組。請檢查您的安裝，有些部分似乎被損壞。"
+msgstr "找不到磁碟儲存模組，請檢查軟體安裝是否正確，似乎有些東西壞了。"
 
 #: ../src/cli/main.c:673
 msgid "failed to get parameters from storage module, aborting export ..."
-msgstr "從儲存模組獲取參數失敗，輸出中斷……"
+msgstr "無法取得模組參數，正在中止匯出"
 
 #: ../src/cli/main.c:689
 #, c-format
 msgid "unknown extension '.%s'"
-msgstr "未知副檔名“.%s”"
+msgstr "未知的副檔名「.%s」"
 
 #: ../src/cli/main.c:699
 msgid "failed to get parameters from format module, aborting export ..."
-msgstr "從格式模組獲取參數失敗，輸出中斷……"
+msgstr "無法取得檔案格式參數，正在中止匯出"
 
 #: ../src/common/camera_control.c:173
 #, c-format
@@ -4804,68 +4874,67 @@ msgid ""
 "\n"
 "make sure your camera allows access and is not mounted otherwise"
 msgstr ""
-"連接於連接埠“%s”的相機“%s”發生錯誤 %s\n"
+"相機「%s」在連接埠「%s」上發生錯誤「%s」\n"
 "\n"
-"請確認您的相機允許電腦存取，並且未被其他程式掛載"
+"確定已正確連接相機，並允許操作使用"
 
-#: ../src/common/camera_control.c:855
+#: ../src/common/camera_control.c:858
 #, c-format
 msgid ""
 "failed to initialize `%s' on port `%s', likely causes are: locked by another "
 "application, no access to devices etc"
-msgstr ""
-"無法初始化“%s”上連接埠的“%s”。可能的原因爲設備被其他程序鎖定或者無權訪問設備"
-"等"
+msgstr "無法初始化「%s」在連接埠「%s」上，設備無法存取，可能已被其他程式使用"
 
-#: ../src/common/camera_control.c:866
+#: ../src/common/camera_control.c:869
 #, c-format
 msgid ""
 "`%s' on port `%s' is not interesting because it supports neither tethering "
 "nor import"
-msgstr "無法使用“%s”上的“%s”。此設備既不支援連機拍攝也不支援影像輸入"
+msgstr "「%s」使用連接埠「%s」，不支援連機拍攝與匯入影像"
 
-#: ../src/common/camera_control.c:916
+#: ../src/common/camera_control.c:919
 #, c-format
 msgid "camera `%s' on port `%s' disconnected while mounted"
-msgstr "連接埠“%s”上的相機“%s”在使用時被斷開"
+msgstr "相機「%s」的連接埠「%s」中斷"
 
-#: ../src/common/camera_control.c:923
+#: ../src/common/camera_control.c:926
 #, c-format
 msgid ""
 "camera `%s' on port `%s' needs to be remounted\n"
 "make sure it allows access and is not mounted otherwise"
 msgstr ""
-"您需要重新掛載連接埠“%s”上的相機“%s”\n"
-"請確認您的相機允許電腦存取，並且未被其他程式掛載"
+"相機「%s」需要重新安裝在連接埠「%s」上\n"
+"\n"
+"確定已正確連接相機，並允許操作使用"
 
 #: ../src/common/collection.c:596
 msgid "too much time to update aspect ratio for the collection"
-msgstr "更新影像集長寬比操作時間過長"
+msgstr "更新相冊長寬比例的時間太長"
 
 #: ../src/common/collection.c:610 ../src/common/collection.c:693
 #: ../src/libs/filters/filename.c:364 ../src/libs/metadata_view.c:126
 msgid "filename"
-msgstr "檔案名"
+msgstr "檔名"
 
 #: ../src/common/collection.c:612 ../src/common/collection.c:667
 msgid "capture time"
-msgstr "拍攝時間"
+msgstr "拍攝日期"
 
 #: ../src/common/collection.c:614 ../src/common/collection.c:669
 msgid "import time"
-msgstr "輸入時間"
+msgstr "匯入日期"
 
 #: ../src/common/collection.c:616 ../src/common/collection.c:671
 msgid "modification time"
-msgstr "修改時間"
+msgstr "修改日期"
 
 #: ../src/common/collection.c:618 ../src/common/collection.c:673
 msgid "export time"
-msgstr "輸出時間"
+msgstr "匯出日期"
 
 #: ../src/common/collection.c:620 ../src/common/collection.c:675
 msgid "print time"
-msgstr "列印時間"
+msgstr "列印日期"
 
 #: ../src/common/collection.c:622 ../src/common/collection.c:707
 #: ../src/common/ratings.c:321 ../src/develop/lightroom.c:1525
@@ -4875,26 +4944,26 @@ msgstr "評分"
 
 #: ../src/common/collection.c:624 ../src/libs/live_view.c:313
 msgid "id"
-msgstr "id"
+msgstr "識別碼"
 
 #: ../src/common/collection.c:626 ../src/common/collection.c:679
 #: ../src/common/colorlabels.c:337 ../src/develop/lightroom.c:1550
 #: ../src/dtgtk/thumbnail.c:1387 ../src/libs/filters/colors.c:301
 #: ../src/libs/filters/colors.c:312 ../src/libs/tools/colorlabels.c:94
 msgid "color label"
-msgstr "色彩標識"
+msgstr "色彩標籤"
 
 #: ../src/common/collection.c:628
 msgid "group"
-msgstr "分組"
+msgstr "群組"
 
 #: ../src/common/collection.c:630 ../src/libs/metadata_view.c:128
 msgid "full path"
-msgstr "全路徑"
+msgstr "檔案位置"
 
 #: ../src/common/collection.c:632
 msgid "custom sort"
-msgstr "自定義排序"
+msgstr "自訂排序"
 
 #. title
 #: ../src/common/collection.c:634 ../src/common/metadata.c:48
@@ -4910,15 +4979,15 @@ msgstr "描述"
 
 #: ../src/common/collection.c:640
 msgid "shuffle"
-msgstr "洗牌"
+msgstr "隨機"
 
 #: ../src/common/collection.c:657
 msgid "film roll"
-msgstr "軟片捲"
+msgstr "底片卷"
 
 #: ../src/common/collection.c:659
 msgid "folder"
-msgstr "目錄"
+msgstr "資料夾"
 
 #: ../src/common/collection.c:661
 msgid "camera"
@@ -4937,14 +5006,14 @@ msgstr "拍攝日期"
 #: ../src/libs/filtering.c:1986 ../src/libs/filtering.c:2006
 #: ../src/libs/history.c:85
 msgid "history"
-msgstr "歷史"
+msgstr "歷史紀錄"
 
 #. iso
 #: ../src/common/collection.c:685 ../src/gui/preferences.c:808
 #: ../src/gui/presets.c:557 ../src/libs/camera.c:559
 #: ../src/libs/metadata_view.c:145
 msgid "ISO"
-msgstr "ISO"
+msgstr "ISO 感光度"
 
 #. aperture
 #: ../src/common/collection.c:687 ../src/gui/preferences.c:816
@@ -4960,12 +5029,12 @@ msgstr "地理標籤"
 
 #: ../src/common/collection.c:697 ../src/libs/tools/global_toolbox.c:396
 msgid "grouping"
-msgstr "分組"
+msgstr "群組"
 
 #: ../src/common/collection.c:699 ../src/dtgtk/thumbnail.c:1399
 #: ../src/libs/metadata_view.c:129 ../src/libs/metadata_view.c:338
 msgid "local copy"
-msgstr "本地副本"
+msgstr "本機備份"
 
 #: ../src/common/collection.c:701 ../src/gui/preferences.c:784
 msgid "module"
@@ -4979,24 +5048,24 @@ msgstr "模組順序"
 
 #: ../src/common/collection.c:705
 msgid "range rating"
-msgstr "範圍等第"
+msgstr "評分範圍"
 
 #: ../src/common/collection.c:709
 msgid "search"
-msgstr "搜尋"
+msgstr "關鍵字搜尋"
 
 #: ../src/common/collection.c:1431 ../src/common/colorlabels.c:330
 #: ../src/develop/lightroom.c:836 ../src/gui/guides.c:732
-#: ../src/iop/colorzones.c:2304 ../src/iop/temperature.c:1809
+#: ../src/iop/colorzones.c:2304 ../src/iop/temperature.c:1754
 #: ../src/libs/collect.c:1789 ../src/libs/filters/colors.c:261
 msgid "yellow"
-msgstr "黃"
+msgstr "黃色"
 
 #: ../src/common/collection.c:1437 ../src/common/color_vocabulary.c:339
 #: ../src/common/colorlabels.c:333 ../src/iop/colorzones.c:2308
 #: ../src/libs/collect.c:1789 ../src/libs/filters/colors.c:264
 msgid "purple"
-msgstr "紫"
+msgstr "紫色"
 
 #: ../src/common/collection.c:1454 ../src/libs/collect.c:1743
 #: ../src/libs/filters/history.c:38
@@ -5006,44 +5075,44 @@ msgstr "已自動套用"
 #: ../src/common/collection.c:1458 ../src/libs/collect.c:1743
 #: ../src/libs/filters/history.c:38
 msgid "altered"
-msgstr "已改變"
+msgstr "已修改"
 
 #: ../src/common/collection.c:1475 ../src/common/collection.c:1571
 #: ../src/libs/collect.c:1164 ../src/libs/collect.c:1328
 #: ../src/libs/collect.c:1352 ../src/libs/collect.c:1471
 #: ../src/libs/collect.c:2501
 msgid "not tagged"
-msgstr "未標定"
+msgstr "無標籤"
 
 #: ../src/common/collection.c:1476 ../src/libs/collect.c:1352
 #: ../src/libs/map_locations.c:765
 msgid "tagged"
-msgstr "已加標籤"
+msgstr "有標籤"
 
 #: ../src/common/collection.c:1477
 msgid "tagged*"
-msgstr "已加標籤*"
+msgstr "有標籤*"
 
 #. local copy
 #: ../src/common/collection.c:1510 ../src/libs/collect.c:1757
 #: ../src/libs/filters/local_copy.c:38
 msgid "not copied locally"
-msgstr "沒有本地複製"
+msgstr "無本機備份副本"
 
 #: ../src/common/collection.c:1514 ../src/libs/collect.c:1757
 #: ../src/libs/filters/local_copy.c:38
 msgid "copied locally"
-msgstr "有本地副本"
+msgstr "有本機備份副本"
 
 #: ../src/common/collection.c:1889 ../src/libs/collect.c:1877
 #: ../src/libs/filters/grouping.c:147 ../src/libs/filters/grouping.c:170
 msgid "group leaders"
-msgstr "分組首張影像"
+msgstr "群組封面影像"
 
 #: ../src/common/collection.c:1893 ../src/libs/collect.c:1877
 #: ../src/libs/filters/grouping.c:150 ../src/libs/filters/grouping.c:170
 msgid "group followers"
-msgstr "分組成員"
+msgstr "群組影像"
 
 #: ../src/common/collection.c:2033 ../src/libs/collect.c:1957
 msgid "not defined"
@@ -5052,44 +5121,44 @@ msgstr "未定義"
 #: ../src/common/collection.c:2441
 #, c-format
 msgid "%d image of %d (#%d) in current collection is selected"
-msgstr "已選 %d 張影像，目前集合共 %d  (#%d)張影像"
+msgstr "已選擇 %d 張影像，目前相冊共有 %d 張影像，選擇的是第 %d 張"
 
 #: ../src/common/collection.c:2447
 #, c-format
 msgid "%d image of %d in current collection is selected"
 msgid_plural "%d images of %d in current collection are selected"
-msgstr[0] "已選 %d 張影像，目前集合共 %d 張影像"
+msgstr[0] "已選擇 %d 張影像，目前相冊共有 %d 張影像"
 
 #: ../src/common/color_vocabulary.c:38 ../src/develop/blend_gui.c:1986
 #: ../src/develop/blend_gui.c:2013 ../src/gui/guides.c:729
-#: ../src/iop/channelmixerrgb.c:4187 ../src/iop/levels.c:667
+#: ../src/iop/channelmixerrgb.c:4187 ../src/iop/levels.c:666
 #: ../src/iop/rgblevels.c:947
 msgid "gray"
-msgstr "灰"
+msgstr "灰階"
 
 #: ../src/common/color_vocabulary.c:92
 msgid "Chinese"
-msgstr "中文"
+msgstr "華人"
 
 #: ../src/common/color_vocabulary.c:93
 msgid "Thai"
-msgstr "泰文"
+msgstr "泰國人"
 
 #: ../src/common/color_vocabulary.c:94
 msgid "Kurdish"
-msgstr "庫德文"
+msgstr "庫德族人"
 
 #: ../src/common/color_vocabulary.c:95
 msgid "Caucasian"
-msgstr "高加索的"
+msgstr "白種人"
 
 #: ../src/common/color_vocabulary.c:96
 msgid "African-american"
-msgstr "非裔美國的"
+msgstr "非裔美國人"
 
 #: ../src/common/color_vocabulary.c:97
 msgid "Mexican"
-msgstr "墨西哥的"
+msgstr "墨西哥人"
 
 #: ../src/common/color_vocabulary.c:100 ../src/common/color_vocabulary.c:105
 #: ../src/common/color_vocabulary.c:110 ../src/common/color_vocabulary.c:115
@@ -5100,18 +5169,18 @@ msgstr "前臂"
 #: ../src/common/color_vocabulary.c:130 ../src/common/color_vocabulary.c:135
 #: ../src/common/color_vocabulary.c:140 ../src/common/color_vocabulary.c:145
 msgid "forehead"
-msgstr "前額"
+msgstr "額頭"
 
 #: ../src/common/color_vocabulary.c:150 ../src/common/color_vocabulary.c:155
 #: ../src/common/color_vocabulary.c:160 ../src/common/color_vocabulary.c:165
 #: ../src/common/color_vocabulary.c:170 ../src/common/color_vocabulary.c:175
 msgid "cheek"
-msgstr "頰"
+msgstr "臉頰"
 
 #: ../src/common/color_vocabulary.c:202
 #, c-format
 msgid "average %s skin tone\n"
-msgstr "平均 %s 皮膚色\n"
+msgstr "平均「%s」膚色\n"
 
 #. 0° - pinkish red
 #: ../src/common/color_vocabulary.c:222
@@ -5121,22 +5190,22 @@ msgstr "深紫色"
 #. L = 10 %
 #: ../src/common/color_vocabulary.c:223
 msgid "fuchsia"
-msgstr "吊鐘花"
+msgstr "紫紅色"
 
 #. L = 30 %
 #: ../src/common/color_vocabulary.c:224
 msgid "medium magenta"
-msgstr "中洋紅"
+msgstr "洋紅色"
 
 #. L = 50 %
 #: ../src/common/color_vocabulary.c:225
 msgid "violet pink"
-msgstr "紫羅蘭粉紅"
+msgstr "粉紫色"
 
 #. L = 70 %
 #: ../src/common/color_vocabulary.c:226
 msgid "plum violet"
-msgstr "梅紅紫色"
+msgstr "深紫紅色"
 
 #. 24° - red
 #: ../src/common/color_vocabulary.c:231
@@ -5145,28 +5214,28 @@ msgstr "深紅色"
 
 #: ../src/common/color_vocabulary.c:233
 msgid "crimson"
-msgstr "赤紅"
+msgstr "緋紅色"
 
 #: ../src/common/color_vocabulary.c:234
 msgid "salmon"
-msgstr "鲑鱼"
+msgstr "粉橘色"
 
 #: ../src/common/color_vocabulary.c:235
 msgid "pink"
-msgstr "粉紅"
+msgstr "粉紅色"
 
 #. 48° - orangy red
 #: ../src/common/color_vocabulary.c:240
 msgid "maroon"
-msgstr "栗色"
+msgstr "深紅色"
 
 #: ../src/common/color_vocabulary.c:241
 msgid "dark orange red"
-msgstr "深橘紅"
+msgstr "深橘紅色"
 
 #: ../src/common/color_vocabulary.c:242
 msgid "orange red"
-msgstr "橘紅"
+msgstr "橙紅色"
 
 #: ../src/common/color_vocabulary.c:243
 msgid "coral"
@@ -5187,7 +5256,7 @@ msgstr "巧克力色"
 
 #: ../src/common/color_vocabulary.c:251
 msgid "dark gold"
-msgstr "深金色"
+msgstr "淺棕色"
 
 #: ../src/common/color_vocabulary.c:252
 msgid "gold"
@@ -5195,7 +5264,7 @@ msgstr "金色"
 
 #: ../src/common/color_vocabulary.c:253
 msgid "sandy brown"
-msgstr "沙棕色"
+msgstr "淺橘色"
 
 #. 96° - yellow olive
 #. 120° - green
@@ -5211,11 +5280,11 @@ msgstr "深橄欖綠"
 
 #: ../src/common/color_vocabulary.c:260
 msgid "olive"
-msgstr "橄欖色"
+msgstr "橄欖綠"
 
 #: ../src/common/color_vocabulary.c:262
 msgid "beige"
-msgstr "淺褐色"
+msgstr "米色"
 
 #: ../src/common/color_vocabulary.c:268 ../src/common/color_vocabulary.c:278
 msgid "forest green"
@@ -5223,7 +5292,7 @@ msgstr "森林綠"
 
 #: ../src/common/color_vocabulary.c:269
 msgid "olive drab"
-msgstr "橄欖色"
+msgstr "橄欖黃"
 
 #: ../src/common/color_vocabulary.c:270
 msgid "yellow green"
@@ -5231,20 +5300,20 @@ msgstr "黃綠色"
 
 #: ../src/common/color_vocabulary.c:271 ../src/common/color_vocabulary.c:280
 msgid "pale green"
-msgstr "淡綠色"
+msgstr "淺綠色"
 
 #: ../src/common/color_vocabulary.c:279
 msgid "lime green"
-msgstr "石灰綠"
+msgstr "萊姆綠"
 
 #. 168° - greenish cyian
 #: ../src/common/color_vocabulary.c:285
 msgid "dark sea green"
-msgstr "深海綠"
+msgstr "深湖水綠"
 
 #: ../src/common/color_vocabulary.c:286
 msgid "sea green"
-msgstr "海綠色"
+msgstr "湖水綠"
 
 #: ../src/common/color_vocabulary.c:287 ../src/common/color_vocabulary.c:304
 msgid "teal"
@@ -5252,32 +5321,32 @@ msgstr "藍綠色"
 
 #: ../src/common/color_vocabulary.c:288
 msgid "light sea green"
-msgstr "淺海綠色"
+msgstr "淺湖水綠"
 
 #: ../src/common/color_vocabulary.c:289
 msgid "turquoise"
-msgstr "綠松石"
+msgstr "淺藍綠色"
 
 #. 192° - cyan
 #: ../src/common/color_vocabulary.c:294
 msgid "dark slate gray"
-msgstr "深石板灰"
+msgstr "冷灰色"
 
 #: ../src/common/color_vocabulary.c:295
 msgid "light slate gray"
-msgstr "淺石板灰"
+msgstr "淺冷灰色"
 
 #: ../src/common/color_vocabulary.c:296 ../src/common/color_vocabulary.c:305
 msgid "dark cyan"
-msgstr "深青色"
+msgstr "暗青色"
 
 #: ../src/common/color_vocabulary.c:297 ../src/common/color_vocabulary.c:317
 #: ../src/iop/colorzones.c:2306
 msgid "aqua"
-msgstr "水藍"
+msgstr "水藍色"
 
 #: ../src/common/color_vocabulary.c:298 ../src/gui/guides.c:733
-#: ../src/iop/temperature.c:1807
+#: ../src/iop/temperature.c:1752
 msgid "cyan"
 msgstr "青色"
 
@@ -5292,18 +5361,18 @@ msgstr "深天空藍"
 
 #: ../src/common/color_vocabulary.c:307
 msgid "aquamarine blue"
-msgstr "海藍寶石藍"
+msgstr "海藍色"
 
 #. 240° - blue and 264° - bluer than blue
 #. these are collapsed because CIE Lab 1976 sucks for blues
 #. 288° - more blue
 #: ../src/common/color_vocabulary.c:313 ../src/common/color_vocabulary.c:322
 msgid "dark blue"
-msgstr "深藍"
+msgstr "深藍色"
 
 #: ../src/common/color_vocabulary.c:314 ../src/common/color_vocabulary.c:323
 msgid "medium blue"
-msgstr "中藍色"
+msgstr "藍色"
 
 #: ../src/common/color_vocabulary.c:315
 msgid "azure blue"
@@ -5315,12 +5384,12 @@ msgstr "淺天空藍"
 
 #: ../src/common/color_vocabulary.c:326
 msgid "light blue"
-msgstr "淺藍"
+msgstr "淺藍色"
 
 #. 312° - violet
 #: ../src/common/color_vocabulary.c:331
 msgid "indigo"
-msgstr "靛青"
+msgstr "靛藍色"
 
 #: ../src/common/color_vocabulary.c:332
 msgid "dark violet"
@@ -5328,7 +5397,7 @@ msgstr "深紫色"
 
 #: ../src/common/color_vocabulary.c:333
 msgid "blue violet"
-msgstr "紫羅蘭色"
+msgstr "藍紫色"
 
 #: ../src/common/color_vocabulary.c:334 ../src/common/color_vocabulary.c:342
 msgid "violet"
@@ -5336,88 +5405,88 @@ msgstr "紫色"
 
 #: ../src/common/color_vocabulary.c:335
 msgid "plum"
-msgstr "紫紅色"
+msgstr "深紫色"
 
 #: ../src/common/color_vocabulary.c:340
 msgid "dark magenta"
-msgstr "深洋紅"
+msgstr "暗洋紅色"
 
 #: ../src/common/color_vocabulary.c:341 ../src/gui/guides.c:734
-#: ../src/iop/colorzones.c:2309 ../src/iop/temperature.c:1805
+#: ../src/iop/colorzones.c:2309 ../src/iop/temperature.c:1750
 msgid "magenta"
-msgstr "洋紅"
+msgstr "洋紅色"
 
 #: ../src/common/color_vocabulary.c:343
 msgid "lavender"
-msgstr "薰衣草"
+msgstr "粉紫色"
 
 #: ../src/common/color_vocabulary.c:346
 msgid "color not found"
-msgstr "顏色未找到"
+msgstr "找不到這個顏色"
 
 #: ../src/common/colorlabels.c:305
 #, c-format
 msgid "colorlabels set to %s"
-msgstr "色彩標籤設為%s"
+msgstr "設定色彩標籤為「%s」"
 
 #: ../src/common/colorlabels.c:307
 msgid "all colorlabels removed"
-msgstr "移除所有色彩標籤"
+msgstr "色彩標籤已刪除"
 
 #: ../src/common/colorlabels.c:328 ../src/libs/image.c:594
 msgid "clear"
-msgstr "清空"
+msgstr "刪除"
 
 #. init the category profile with NULL profile, the actual profile must be retrieved dynamically by the caller
 #: ../src/common/colorspaces.c:1400 ../src/common/colorspaces.c:1689
 msgid "work profile"
-msgstr "工作配置檔案"
+msgstr "工作空間描述檔"
 
 #: ../src/common/colorspaces.c:1403 ../src/common/colorspaces.c:1685
 #: ../src/iop/colorout.c:879
 msgid "export profile"
-msgstr "輸出工作配置"
+msgstr "匯出用描述檔"
 
 #: ../src/common/colorspaces.c:1407 ../src/common/colorspaces.c:1687
-#: ../src/views/darkroom.c:2480
+#: ../src/views/darkroom.c:2481
 msgid "softproof profile"
-msgstr "軟打樣設定"
+msgstr "軟打樣描述檔"
 
 #: ../src/common/colorspaces.c:1413 ../src/common/colorspaces.c:1669
 msgid "system display profile"
-msgstr "系統顯示設定"
+msgstr "系統顯示描述檔"
 
 #: ../src/common/colorspaces.c:1416 ../src/common/colorspaces.c:1691
 msgid "system display profile (second window)"
-msgstr "系統顯示設定(第二視窗)"
+msgstr "系統顯示描述檔（第二個視窗）"
 
 #: ../src/common/colorspaces.c:1422
 msgid "sRGB (e.g. JPG)"
-msgstr "sRGB(例如 JPG)"
+msgstr "sRGB（例如 JPG）"
 
 #: ../src/common/colorspaces.c:1426 ../src/libs/print_settings.c:1285
 msgid "sRGB (web-safe)"
-msgstr "sRGB(網頁兼容)"
+msgstr "sRGB（網路保險設定）"
 
 #: ../src/common/colorspaces.c:1440 ../src/common/colorspaces.c:1693
 msgid "Rec709 RGB"
-msgstr "Rec709 RGB"
+msgstr "Rec. 709"
 
 #: ../src/common/colorspaces.c:1450
 msgid "PQ Rec2020 RGB"
-msgstr "感知型量化(PQ)Rec2020 RGB"
+msgstr "PQ - Rec. 2020"
 
 #: ../src/common/colorspaces.c:1455
 msgid "HLG Rec2020 RGB"
-msgstr "混合對數伽馬(HLG)Rec2020 RGB"
+msgstr "HLG - Rec. 2020"
 
 #: ../src/common/colorspaces.c:1460
 msgid "PQ P3 RGB"
-msgstr "感知型量化(PQ)P3 RGB"
+msgstr "PQ - P3"
 
 #: ../src/common/colorspaces.c:1465
 msgid "HLG P3 RGB"
-msgstr "混合對數伽馬(HLG)P3 RGB"
+msgstr "HLG - P3"
 
 #: ../src/common/colorspaces.c:1470 ../src/common/colorspaces.c:1695
 msgid "linear ProPhoto RGB"
@@ -5431,7 +5500,7 @@ msgstr "線性 XYZ"
 #: ../src/develop/blend_gui.c:95 ../src/develop/blend_gui.c:1713
 #: ../src/libs/colorpicker.c:51 ../src/libs/colorpicker.c:261
 msgid "Lab"
-msgstr "Lab"
+msgstr "CIELAB"
 
 #: ../src/common/colorspaces.c:1484 ../src/common/colorspaces.c:1667
 msgid "linear infrared BGR"
@@ -5439,171 +5508,171 @@ msgstr "線性紅外線 BGR"
 
 #: ../src/common/colorspaces.c:1488
 msgid "BRG (for testing)"
-msgstr "BRG(測試用)"
+msgstr "BRG（測試用）"
 
 #: ../src/common/colorspaces.c:1580
 #, c-format
 msgid ""
 "profile `%s' not usable as histogram profile. it has been replaced by sRGB!"
-msgstr "色彩配置“%s”不如直方圖配置有用。已使用 sRGB 代替！"
+msgstr "描述檔「%s」無法用於直方圖顯示，已使用 sRGB 取代"
 
 #: ../src/common/colorspaces.c:1671
 msgid "embedded ICC profile"
-msgstr "嵌入 ICC 配置"
+msgstr "嵌入的 ICC 描述檔"
 
 #: ../src/common/colorspaces.c:1673
 msgid "embedded matrix"
-msgstr "嵌入矩陣"
+msgstr "嵌入的矩陣"
 
 #: ../src/common/colorspaces.c:1675
 msgid "standard color matrix"
-msgstr "標準顏色矩陣"
+msgstr "標準色彩矩陣"
 
 #: ../src/common/colorspaces.c:1677
 msgid "enhanced color matrix"
-msgstr "增強顏色矩陣"
+msgstr "符合相機特性的增強色彩矩陣"
 
 #: ../src/common/colorspaces.c:1679
 msgid "vendor color matrix"
-msgstr "供應商顏色矩陣"
+msgstr "相機廠商提供的色彩矩陣"
 
 #: ../src/common/colorspaces.c:1681
 msgid "alternate color matrix"
-msgstr "備用顏色矩陣"
+msgstr "備用色彩矩陣"
 
 #: ../src/common/colorspaces.c:1683
 msgid "BRG (experimental)"
-msgstr "BRG(實驗性的)"
+msgstr "BRG（實驗性質）"
 
 #: ../src/common/colorspaces.c:1697
 msgid "PQ Rec2020"
-msgstr "感知型量化(PQ)Rec2020"
+msgstr "PQ - Rec. 2020"
 
 #: ../src/common/colorspaces.c:1699
 msgid "HLG Rec2020"
-msgstr "混合對數伽馬(HLG)Rec2020"
+msgstr "HLG - Rec. 2020"
 
 #: ../src/common/colorspaces.c:1701
 msgid "PQ P3"
-msgstr "感知型量化(PQ)P3"
+msgstr "PQ - P3"
 
 #: ../src/common/colorspaces.c:1703
 msgid "HLG P3"
-msgstr "混合對數伽馬(HLG)P3"
+msgstr "HLG - P3"
 
 #: ../src/common/cups_print.c:420
 #, c-format
 msgid "file `%s' to print not found for image %d on `%s'"
-msgstr "找不到檔案 %s，無法列印 %d 張影像到 `%s'"
+msgstr "找不到列印檔案「%s」， 無法列印「%d」到「%s」"
 
 #: ../src/common/cups_print.c:439
 msgid "failed to create temporary file for printing options"
-msgstr "爲列印選項建立臨時檔案失敗"
+msgstr "建立列印暫存檔失敗"
 
 #: ../src/common/cups_print.c:508
 #, c-format
 msgid "printing on `%s' cancelled"
-msgstr "在“%s”上的列印 已取消"
+msgstr "「%s」的列印工作已取消"
 
 #: ../src/common/cups_print.c:572
 #, c-format
 msgid "error while printing `%s' on `%s'"
-msgstr "列印“%s”到“%s”時發生錯誤"
+msgstr "列印「%s」至「%s」時發生錯誤"
 
 #: ../src/common/cups_print.c:574
 #, c-format
 msgid "printing `%s' on `%s'"
-msgstr "列印“%s”至“%s”"
+msgstr "列印「%s」至「%s」"
 
 #: ../src/common/darktable.c:240
 #, c-format
 msgid "found strange path `%s'"
-msgstr "發現異常路徑“%s”"
+msgstr "發現異常路徑「%s」"
 
 #: ../src/common/darktable.c:255
 #, c-format
 msgid "error loading directory `%s'"
-msgstr "載入目錄“%s”發生錯誤"
+msgstr "載入資料夾「%s」時發生錯誤"
 
 #: ../src/common/darktable.c:278
 #, c-format
 msgid "file `%s' has unknown format!"
-msgstr "檔案“%s”使用了未知格式！"
+msgstr "檔案「%s」使用未知的格式"
 
 #: ../src/common/darktable.c:291 ../src/control/jobs/control_jobs.c:2109
 #: ../src/control/jobs/control_jobs.c:2168
 #, c-format
 msgid "error loading file `%s'"
-msgstr "載入檔案“%s”發生錯誤"
+msgstr "載入檔案「%s」時發生錯誤"
 
-#: ../src/common/darktable.c:1298
+#: ../src/common/darktable.c:1303
 msgid "configuration information"
 msgstr "配置資訊"
 
-#: ../src/common/darktable.c:1300
+#: ../src/common/darktable.c:1305
 msgid "show this information again"
-msgstr "再次顯示此資訊"
+msgstr "下次仍顯示這個資訊"
 
-#: ../src/common/darktable.c:1300
+#: ../src/common/darktable.c:1305
 msgid "understood"
 msgstr "了解"
 
-#: ../src/common/darktable.c:1729
+#: ../src/common/darktable.c:1751
 msgid ""
 "the RCD demosaicer has been defined as default instead of PPG because of "
 "better quality and performance."
-msgstr ".RCD去馬賽克因為有更好效果及效能被定為預設處理而非PPG."
+msgstr "預設的去馬賽克演算法為 RCD，取代舊的 PPG，因為它具有更好的品質和性能"
 
-#: ../src/common/darktable.c:1731
+#: ../src/common/darktable.c:1753
 msgid "see preferences/darkroom/demosaicing for zoomed out darkroom mode"
-msgstr "縮小暗房模式詳見偏好/暗房/去馬賽克"
+msgstr "請至「偏好設定 / 暗房 Darkroom」中查看縮小預覽的去馬賽克方式"
 
-#: ../src/common/darktable.c:1737
+#: ../src/common/darktable.c:1759
 msgid ""
 "the user interface and the underlying internals for tuning darktable "
 "performance have changed."
-msgstr "使用者介面及調整darktable效能的底層已經改變."
+msgstr "用於調整 darktable 性能的使用者介面和底層內部元件已更改"
 
-#: ../src/common/darktable.c:1739
+#: ../src/common/darktable.c:1761
 msgid ""
 "you won't find headroom and friends any longer, instead in preferences/"
 "processing use:"
-msgstr "你不再找得到頂部空間及朋友，請改用偏好/處理:"
+msgstr "請改由「偏好設定 / 運算方法」中調整："
 
-#: ../src/common/darktable.c:1741
+#: ../src/common/darktable.c:1763
 msgid "1) darktable resources"
-msgstr "1)darktable資源"
+msgstr "1） darktable 效能設定"
 
-#: ../src/common/darktable.c:1743
+#: ../src/common/darktable.c:1765
 msgid "2) tune OpenCL performance"
-msgstr "2)調整 OpenCL 效能"
+msgstr "2）調整 OpenCL 性能"
 
-#: ../src/common/darktable.c:1750
+#: ../src/common/darktable.c:1772
 msgid ""
 "some global config values relevant for OpenCL performance are not used any "
 "longer."
-msgstr "某些跟OpenCL效能相關的全域配置值不再使用."
+msgstr "某些與 OpenCL 性能相關的設定值已經不再使用"
 
-#: ../src/common/darktable.c:1752
+#: ../src/common/darktable.c:1774
 msgid ""
 "instead you will find 'per device' data in 'cl_device_v4_canonical-name'. "
 "content is:"
 msgstr ""
-"相反的，你將發現在 'cl_device_v4_canonical-name'. content內每個裝置的資料是:"
+"相對地，可以在「cl_device_v4_canonical-name」中找到「per device」數據如下："
 
-#: ../src/common/darktable.c:1754
+#: ../src/common/darktable.c:1776
 msgid ""
 " 'avoid_atomics' 'micro_nap' 'pinned_memory' 'roundupwd' 'roundupht' "
 "'eventhandles' 'async' 'disable' 'magic'"
 msgstr ""
-" 'avoid_atomics' '微睡眠' '鎖定記憶體' 'roundupwd' 'roundupht' '事件處理器' "
-"'非同步' '停用' '神奇'"
+"「avoid_atomics」「micro_nap」「pinned_memory」「roundupwd」「roundupht」"
+"「eventhandles」「async」「disable」「magic」"
 
-#: ../src/common/darktable.c:1756
+#: ../src/common/darktable.c:1778
 msgid "you may tune as before except 'magic'"
-msgstr "除 'magic'外，你可如以前調整"
+msgstr "除了「magic」之外，可以像以前一樣調整參數"
 
-#: ../src/common/database.c:2722
+#: ../src/common/database.c:2720
 #, c-format
 msgid ""
 "\n"
@@ -5634,33 +5703,30 @@ msgid ""
 "</i>\n"
 msgstr ""
 "\n"
-"  實在對不起，darktable 無法啓動(資料庫被鎖定)\n"
+"抱歉，darktable 無法啟動，因為資料庫被鎖定，如何解決這個問題：\n"
 "\n"
-"  如何解決此問題？\n"
+"　一、如果已開啟另一個 darktable\n"
+"　　　取消並使用已開啟的 darktable，或是關閉後再重啟。\n"
+"　　　（處理程序 <i><b>%d</b></i> 造成資料庫鎖定）\n"
 "\n"
-"  1 - 若有另一個 darktable 已在執行，\n"
-"      點擊取消以使用已執行的程式或退出後再嘗試啓動\n"
-"      (程序編號 <i><b>%d</b></i> 已建立資料庫鎖)\n"
+"　二、如果找不到已執行的 darktable\n"
+"　　　嘗試登出或重開機，這會關閉所有正在執行的程式，並應能夠正確地關閉資料"
+"庫。\n"
 "\n"
-"  2 - 若您找不到另一個 darktable 程式，請嘗試重新登入或重新啓動電腦。\n"
-"      這將關閉所有執行程式，希望能夠正確關閉資料庫。\n"
-"\n"
-"  3 - 若已完成上述步驟，並確定沒有其他正在執行的 darktable 程式，\n"
-"      上次 darktable 可能不正常結束。\n"
-"      點擊“刪除資料庫鎖檔案”按鈕以移除檔案 <i>data.db.lock</i> 及 <i>library."
-"db.lock</i>。\n"
+"　三、如果已完成以上動作並確定沒有其他 darktable 正在執行\n"
+"　　　這可能是因為上一次darktable 異常關閉，點擊「刪除資料庫鎖定檔案」按鈕以"
+"刪除「<i>data.db.lock</i>」和「<i>library.db.lock</i>」檔案。\n"
 "\n"
 "\n"
-"      <i><u>注意:</u>在尚未完成上述檢查時請勿刪除資料庫鎖，否則產生嚴重資料庫"
-"的不一致可能\n"
-"      </i>\n"
+"<i><u>⚠️ 注意！在未進行檢查前請勿刪除這些檔案，否則可能出現嚴重的資料庫不一致"
+"問題 ⚠️</u></i>\n"
 
 #. clang-format on
-#: ../src/common/database.c:2743
+#: ../src/common/database.c:2741
 msgid "error starting darktable"
-msgstr "darktable 啓動錯誤"
+msgstr "啟動 darktable 時發生錯誤"
 
-#: ../src/common/database.c:2744 ../src/libs/collect.c:3007
+#: ../src/common/database.c:2742 ../src/libs/collect.c:3007
 #: ../src/libs/export_metadata.c:288 ../src/libs/import.c:1693
 #: ../src/libs/metadata.c:507 ../src/libs/metadata_view.c:1186
 #: ../src/libs/recentcollect.c:295 ../src/libs/modulegroups.c:3507
@@ -5671,23 +5737,23 @@ msgstr "darktable 啓動錯誤"
 msgid "cancel"
 msgstr "取消"
 
-#: ../src/common/database.c:2744
+#: ../src/common/database.c:2742
 msgid "delete database lock files"
-msgstr "刪除資料庫鎖檔"
+msgstr "刪除資料庫鎖定檔案"
 
-#: ../src/common/database.c:2750
+#: ../src/common/database.c:2748
 msgid "are you sure?"
 msgstr "確定？"
 
-#: ../src/common/database.c:2751
+#: ../src/common/database.c:2749
 msgid ""
 "\n"
 "do you really want to delete the lock files?\n"
 msgstr ""
 "\n"
-"確定要刪除資料庫鎖檔案？\n"
+"確定要刪除鎖定檔案？\n"
 
-#: ../src/common/database.c:2751 ../src/common/database.c:3811
+#: ../src/common/database.c:2749 ../src/common/database.c:3809
 #: ../src/common/variables.c:590 ../src/develop/imageop_gui.c:197
 #: ../src/imageio/format/pdf.c:648 ../src/imageio/format/pdf.c:673
 #: ../src/libs/export.c:1209 ../src/libs/export.c:1215
@@ -5695,32 +5761,32 @@ msgstr ""
 msgid "yes"
 msgstr "是"
 
-#: ../src/common/database.c:2766 ../src/libs/export_metadata.c:164
+#: ../src/common/database.c:2764 ../src/libs/export_metadata.c:164
 #: ../src/libs/geotagging.c:812
 msgid "done"
 msgstr "完成"
 
-#: ../src/common/database.c:2767
+#: ../src/common/database.c:2765
 msgid ""
 "\n"
 "successfully deleted the lock files.\n"
 "you can now restart darktable\n"
 msgstr ""
 "\n"
-"成功刪除資料庫鎖檔案。\n"
-"請重新啓動 darktable\n"
+"已成功刪除鎖定檔案\n"
+"現在可以重新啟動 darktable\n"
 
 #. the button to close the popup
-#: ../src/common/database.c:2768 ../src/common/database.c:2775
+#: ../src/common/database.c:2766 ../src/common/database.c:2773
 #: ../src/libs/filters/filename.c:452
 msgid "ok"
-msgstr "ok"
+msgstr "確定"
 
-#: ../src/common/database.c:2771 ../src/iop/cacorrect.c:1336
+#: ../src/common/database.c:2769 ../src/iop/cacorrect.c:1336
 msgid "error"
 msgstr "錯誤"
 
-#: ../src/common/database.c:2772
+#: ../src/common/database.c:2770
 #, c-format
 msgid ""
 "\n"
@@ -5730,29 +5796,30 @@ msgid ""
 "in folder <a href=\"file:///%s\">%s</a>.\n"
 msgstr ""
 "\n"
-"至少一個檔案無法被移除。\n"
-"請嘗試手動刪除 <a href=\"file:///%s\">%s</a> 目錄中的\n"
-"檔案 <i>data.db.lock</i> 和 <i>library.db.lock</i>。\n"
+"至少有一個檔案無法刪除。\n"
+"嘗試手動刪除「<i>data.db.lock</i>」和「<i>library.db.lock</i>」，\n"
+"檔案位置 %s>%s，\n"
+"windows 路徑：「\\Users\\username\\AppData\\Local\\darktable\\」。\n"
 
-#: ../src/common/database.c:2889
+#: ../src/common/database.c:2887
 #, c-format
 msgid ""
 "the database lock file contains a pid that seems to be alive in your system: "
 "%d"
-msgstr "資料庫鎖檔案包含了一個似乎正在使用的程序:%d"
+msgstr "資料庫鎖定檔案裡包含一個仍在運作中的程序：%d"
 
-#: ../src/common/database.c:2895
+#: ../src/common/database.c:2893
 #, c-format
 msgid "the database lock file seems to be empty"
-msgstr "資料庫鎖檔案似乎是空的"
+msgstr "資料庫鎖定檔案內容似乎是空白的"
 
-#: ../src/common/database.c:2903
+#: ../src/common/database.c:2901
 #, c-format
 msgid "error opening the database lock file for reading: %s"
-msgstr "讀取資料庫鎖檔錯誤:%s"
+msgstr "開啟資料庫鎖定檔案內容時讀取錯誤： 「%s」"
 
 #. the database has to be upgraded, let's ask user
-#: ../src/common/database.c:2940
+#: ../src/common/database.c:2938
 #, c-format
 msgid ""
 "the database schema has to be upgraded for\n"
@@ -5763,69 +5830,70 @@ msgid ""
 "\n"
 "do you want to proceed or quit now to do a backup\n"
 msgstr ""
-"需要升級資料庫資料綱要以使用 darktable <span style='italic'>%s</span>\n"
+"必須更新資料庫「%s」綱目\n"
 "\n"
-"若資料庫較大，此操作可能需要較長時間\n"
+"資料庫內容較多時可能需要很長時間\n"
 "\n"
-"是否要繼續？若要備份資料庫，請先退出\n"
+"是否要繼續執行？或是關閉以手動進行備份\n"
 
-#: ../src/common/database.c:2948
+#: ../src/common/database.c:2946
 msgid "darktable - schema migration"
-msgstr "darktable - 資料庫資料綱要遷移"
+msgstr "darktable 資料庫綱目遷移"
 
-#: ../src/common/database.c:2949 ../src/common/database.c:3262
-#: ../src/common/database.c:3280 ../src/common/database.c:3442
-#: ../src/common/database.c:3460
+#: ../src/common/database.c:2947 ../src/common/database.c:3260
+#: ../src/common/database.c:3278 ../src/common/database.c:3440
+#: ../src/common/database.c:3458
 msgid "close darktable"
 msgstr "關閉 darktable"
 
-#: ../src/common/database.c:2949
+#: ../src/common/database.c:2947
 msgid "upgrade database"
-msgstr "升級資料庫"
+msgstr "更新資料庫"
 
-#: ../src/common/database.c:3242 ../src/common/database.c:3422
+#: ../src/common/database.c:3240 ../src/common/database.c:3420
 #, c-format
 msgid ""
 "quick_check said:\n"
 "%s \n"
 msgstr ""
-"快速檢查結果:\n"
-"%s \n"
+"快速檢查結果：\n"
+"「%s」\n"
 
-#: ../src/common/database.c:3259 ../src/common/database.c:3277
-#: ../src/common/database.c:3439 ../src/common/database.c:3457
+#: ../src/common/database.c:3257 ../src/common/database.c:3275
+#: ../src/common/database.c:3437 ../src/common/database.c:3455
 msgid "darktable - error opening database"
-msgstr "darktable - 打開資料庫失敗"
+msgstr "darktable 開啟資料庫時發生錯誤"
 
-#: ../src/common/database.c:3264 ../src/common/database.c:3444
+#: ../src/common/database.c:3262 ../src/common/database.c:3442
 msgid "attempt restore"
 msgstr "嘗試恢復"
 
-#: ../src/common/database.c:3266 ../src/common/database.c:3282
-#: ../src/common/database.c:3446 ../src/common/database.c:3462
+#: ../src/common/database.c:3264 ../src/common/database.c:3280
+#: ../src/common/database.c:3444 ../src/common/database.c:3460
 msgid "delete database"
 msgstr "刪除資料庫"
 
-#: ../src/common/database.c:3270 ../src/common/database.c:3450
+#: ../src/common/database.c:3268 ../src/common/database.c:3448
 msgid ""
 "do you want to close darktable now to manually restore\n"
 "the database from a backup, attempt an automatic restore\n"
 "from the most recent snapshot or delete the corrupted database\n"
 "and start with a new one?"
 msgstr ""
-"需要關閉 darktable 以手動從備份恢復資料庫？\n"
-"還是嘗試自動從最近快照恢復資料庫，或刪除損壞的資料庫並從頭開始？"
+"是否要關閉 darktable 從備份檔案中手動恢復資料庫？\n"
+"還是使用最近的資料庫備份自動恢復，\n"
+"或刪除已損壞的資料庫檔案並從頭開始？"
 
-#: ../src/common/database.c:3286 ../src/common/database.c:3466
+#: ../src/common/database.c:3284 ../src/common/database.c:3464
 msgid ""
 "do you want to close darktable now to manually restore\n"
 "the database from a backup or delete the corrupted database\n"
 "and start with a new one?"
 msgstr ""
-"需要現在關閉 darktable 並手動從備份恢復資料庫\n"
-"還是刪除損壞的資料庫重新開始？"
+"是否要關閉 darktable 從備份檔案中手動恢復資料庫？\n"
+"或是刪除已損壞的資料庫檔案並從頭開始？"
 
-#: ../src/common/database.c:3293 ../src/common/database.c:3471
+#: ../src/common/database.c:3291 ../src/common/database.c:3469
 #, c-format
 msgid ""
 "an error has occurred while trying to open the database from\n"
@@ -5835,26 +5903,24 @@ msgid ""
 "it seems that the database is corrupted.\n"
 "%s%s"
 msgstr ""
-"從以下位置打開資料庫時發生錯誤:\n"
+"嘗試開啟資料庫「%s」時出錯\n"
 "\n"
-"<span style=\"italic\">%s</span>\n"
-"\n"
-"資料庫可能已經損壞。\n"
+"資料庫似乎已損壞\n"
 "%s%s"
 
-#: ../src/common/database.c:3789
+#: ../src/common/database.c:3787
 msgid "click later to be asked on next startup"
-msgstr "點擊“以後”下次啓動時將再詢問"
+msgstr "點擊「之後再詢問」以在下次啟動時詢問"
 
-#: ../src/common/database.c:3793
+#: ../src/common/database.c:3791
 msgid "click later to be asked when closing darktable"
-msgstr "點擊“以後”關閉 darktable 時將再詢問"
+msgstr "點擊「之後再詢問」以在關閉 darktable 時詢問"
 
-#: ../src/common/database.c:3797
+#: ../src/common/database.c:3795
 msgid "click later to be asked next time when closing darktable"
-msgstr "點擊“以後”下次關閉 darktable 時將再詢問"
+msgstr "點擊「之後再詢問」以在下次關閉 darktable 時詢問"
 
-#: ../src/common/database.c:3800
+#: ../src/common/database.c:3798
 #, c-format
 msgid ""
 "the database could use some maintenance\n"
@@ -5866,50 +5932,54 @@ msgid ""
 "%s\n"
 "you can always change maintenance preferences in core options"
 msgstr ""
-"資料庫維護可以釋放 <span style=\"italic\">%s</span> 空間。\n"
+"資料庫可維護釋放「%s」的空間\n"
 "\n"
-"希望現在開始嗎？\n"
+"是否要繼續？\n"
 "\n"
 "%s\n"
-"請在核心選項中更改資料庫維護偏好"
+"可以在偏好設定中更改資料庫維護的設定"
 
-#: ../src/common/database.c:3810
+#: ../src/common/database.c:3808
 msgid "darktable - schema maintenance"
-msgstr "darktable - 資料庫綱要維護"
+msgstr "darktable 資料庫綱目維護"
 
-#: ../src/common/database.c:3811
+#: ../src/common/database.c:3809
 msgid "later"
-msgstr "以後"
+msgstr "之後再詢問"
 
 #: ../src/common/eigf.h:288
 msgid ""
 "fast exposure independent guided filter failed to allocate memory, check "
 "your RAM settings"
-msgstr "快速曝光獨立引導濾鏡無法配置記憶體，請檢查記憶體設定"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"「快速無關曝光的導引濾波器」（fast EIGF）無法配置記憶體，請檢查記憶體設定"
 
-#: ../src/common/exif.cc:4332
+#: ../src/common/exif.cc:4329
 #, c-format
 msgid "cannot read xmp file '%s': '%s'"
-msgstr "無法讀取 xmp 檔案“%s”:“%s”"
+msgstr "無法讀取 XMP 檔案「%s」：「%s」"
 
-#: ../src/common/exif.cc:4384
+#: ../src/common/exif.cc:4381
 #, c-format
 msgid "cannot write xmp file '%s': '%s'"
-msgstr "無法寫入 xmp 檔案“%s”:“%s”"
+msgstr "無法寫入 XMP 檔案「%s」：「%s」"
 
 #: ../src/common/fast_guided_filter.h:316
 msgid "fast guided filter failed to allocate memory, check your RAM settings"
-msgstr "快速引導過濾器無法配置記憶體，請檢查 RAM 設置"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"「快速導引濾波器」（fast guided filter）無法配置記憶體，請檢查記憶體設定"
 
 #: ../src/common/film.c:342
 msgid "do you want to remove this empty directory?"
 msgid_plural "do you want to remove these empty directories?"
-msgstr[0] "你確定要刪除此空目錄嗎？"
+msgstr[0] "是否要刪除此空白資料夾？"
 
 #: ../src/common/film.c:349
 msgid "remove empty directory?"
 msgid_plural "remove empty directories?"
-msgstr[0] "刪除空目錄？"
+msgstr[0] "刪除空白資料夾？"
 
 #: ../src/common/film.c:368 ../src/gui/preferences.c:792
 #: ../src/gui/styles_dialog.c:447 ../src/libs/geotagging.c:830
@@ -5920,112 +5990,114 @@ msgstr "名稱"
 #: ../src/common/film.c:474
 msgid ""
 "cannot remove film roll having local copies with non accessible originals"
-msgstr "無法移除有本地副本但無法存取原始檔案的軟片捲"
+msgstr "不能移除此底片卷，因其含有無法存取原檔的本機備份副本"
 
 #: ../src/common/history.c:755
 msgid "you need to copy history from an image before you paste it onto another"
-msgstr "需要複製一張圖片的歷史資料，才能用在另一張上"
+msgstr "需要先複製一張影像的編輯紀錄，然後才能套用在另一張影像上"
 
 #: ../src/common/http_server.c:95
 #, c-format
 msgid "darktable » %s"
-msgstr "darktable » %s"
+msgstr "darktable » 「%s」"
 
 #: ../src/common/http_server.c:97
 msgid "<h1>Sorry,</h1><p>something went wrong. Please try again.</p>"
-msgstr "<h1>實在對不起，</h1><p>似乎發生了錯誤。請重試。</p>"
+msgstr "<h1>抱歉，</h1><p>出了點問題。請重試。</p>"
 
 #: ../src/common/http_server.c:102
 msgid ""
 "<h1>Thank you,</h1><p>everything should have worked, you can <b>close</b> "
 "your browser now and <b>go back</b> to darktable.</p>"
 msgstr ""
-"<h1>謝謝，</h1><p>已恢復正常。您現在可以<b>關閉</b>瀏覽器並<b>回到</b> "
+"<h1>謝謝，</h1><p>一切應該都正常了，現在可以<b>關閉</b>瀏覽器並<b>返回</b>到 "
 "darktable。</p>"
 
 #: ../src/common/image.c:296
 msgid "orphaned image"
-msgstr "孤立影像"
+msgstr "獨立影像"
 
 #: ../src/common/image.c:541
 #, c-format
 msgid "geo-location undone for %d images"
-msgstr "已爲 %d 張影像移除套用的定位資訊"
+msgstr "已復原 %d 張影像的地理位置"
 
 #: ../src/common/image.c:542
 #, c-format
 msgid "geo-location re-applied to %d images"
-msgstr "已爲 %d 張影像套用定位資訊"
+msgstr "已重新套用 %d 張影像的地理位置"
 
 #: ../src/common/image.c:561
 #, c-format
 msgid "date/time undone for %d images"
-msgstr "已爲 %d 張影像移除套用日期/時間資訊"
+msgstr "復原 %d 張影像的日期與時間"
 
 #: ../src/common/image.c:562
 #, c-format
 msgid "date/time re-applied to %d images"
-msgstr "已爲 %d 張影像套用日期/時間資訊"
+msgstr "重新套用 %d 張影像的日期與時間"
 
 #: ../src/common/image.c:1992
 #, c-format
 msgid "cannot access local copy `%s'"
-msgstr "無法存取本地副本“%s”"
+msgstr "無法存取本機備份副本「%s」"
 
 #: ../src/common/image.c:1999
 #, c-format
 msgid "cannot write local copy `%s'"
-msgstr "無法寫入本地副本“%s”！"
+msgstr "無法寫入本機備份副本「%s」"
 
 #: ../src/common/image.c:2006
 #, c-format
 msgid "error moving local copy `%s' -> `%s'"
-msgstr "錯誤 無法移動本地副本“%s”至“%s”"
+msgstr "移動本機備份副本「%s」至「%s」時出錯"
 
 #: ../src/common/image.c:2022
 #, c-format
 msgid "error moving `%s': file not found"
-msgstr "錯誤 無法移動“%s”:檔案未找到"
+msgstr "移動「%s」時出錯：找不到檔案"
 
 #: ../src/common/image.c:2032
 #, c-format
 msgid "error moving `%s' -> `%s': file exists"
-msgstr "錯誤 無法移動“%s”至“%s”:檔案已存在"
+msgstr "移動「%s」至「%s」時出錯：已存在同名檔案"
 
 #: ../src/common/image.c:2036
 #, c-format
 msgid "error moving `%s' -> `%s'"
-msgstr "無法移動“%s”至“%s”"
+msgstr "移動「%s」至「%s」時出錯"
 
 #: ../src/common/image.c:2350
 msgid "cannot create local copy when the original file is not accessible."
-msgstr "當原件無法存取時無法建立本地副本。"
+msgstr "無法存取原始檔案時，不能建立本機備份副本"
 
 #: ../src/common/image.c:2364
 msgid "cannot create local copy."
-msgstr "無法建立本地副本。"
+msgstr "無法建立本機備份副本"
 
 #: ../src/common/image.c:2438 ../src/control/jobs/control_jobs.c:768
 msgid "cannot remove local copy when the original file is not accessible."
-msgstr "當原始檔案無法存取時無法刪除本地副本。"
+msgstr "無法存取原始檔案時，不能移除本機備份副本"
 
 #: ../src/common/image.c:2603
 #, c-format
 msgid "%d local copy has been synchronized"
 msgid_plural "%d local copies have been synchronized"
-msgstr[0] "已同步 %d 件本地副本"
+msgstr[0] "%d 張本機備份副本已同步"
 
 #: ../src/common/image.c:2792
 msgid "<b>WARNING</b>: camera is missing samples!"
-msgstr "<b>警告</b>: 相機正失去照片樣本!"
+msgstr ""
+"⚠️ 警告 ⚠️\n"
+"缺少相機樣本"
 
 #: ../src/common/image.c:2793
 msgid ""
 "You must provide samples in <a href='https://raw.pixls.us/'>https://raw."
 "pixls.us/</a>"
 msgstr ""
-"你必須在 <a href='https://raw.pixls.us/'>https://raw.pixls.us/</a>提供照片樣"
-"本"
+"必須在 <a href=‘https://raw.pixls.us/‘>https://raw.pixls.us/</a> 上提供相機圖"
+"檔"
 
 #: ../src/common/image.c:2794
 #, c-format
@@ -6033,12 +6105,11 @@ msgid ""
 "for `%s' `%s'\n"
 "in as many format/compression/bit depths as possible"
 msgstr ""
-"對於 `%s' `%s'\n"
-"儘可能提供越多格式/壓縮/位元景深"
+"盡可能提供更多「%s」「%s」不同格式 / 壓縮 / 位元深度的樣本圖檔"
 
 #: ../src/common/image.c:2797
 msgid "or the <b>RAW won't be readable</b> in next version."
-msgstr "或下個版本 <b>RAW不可讀</b>."
+msgstr "否則將無法在下一版本中讀取 RAW 檔"
 
 #: ../src/common/image.h:169 ../src/common/ratings.c:283
 #: ../src/libs/history.c:763 ../src/libs/snapshots.c:455
@@ -6048,31 +6119,31 @@ msgstr "未知"
 #. EMPTY_FIELD
 #: ../src/common/image.h:170
 msgid "tiff"
-msgstr "tiff"
+msgstr "TIFF"
 
 #: ../src/common/image.h:171
 msgid "png"
-msgstr "png"
+msgstr "PNG"
 
 #: ../src/common/image.h:172
 msgid "j2k"
-msgstr "j2k"
+msgstr "JPEG 2000"
 
 #: ../src/common/image.h:173
 msgid "jpeg"
-msgstr "jpeg"
+msgstr "JPEG"
 
 #: ../src/common/image.h:174
 msgid "exr"
-msgstr "exr檔案格式"
+msgstr "OpenEXR"
 
 #: ../src/common/image.h:175
 msgid "rgbe"
-msgstr "rgbe"
+msgstr "RGBE（Radiance HDR）"
 
 #: ../src/common/image.h:176
 msgid "pfm"
-msgstr "pfm"
+msgstr "PFM"
 
 #: ../src/common/image.h:177
 msgid "GraphicsMagick"
@@ -6088,7 +6159,7 @@ msgstr "netpnm"
 
 #: ../src/common/image.h:180
 msgid "avif"
-msgstr "avif"
+msgstr "AVIF"
 
 #: ../src/common/image.h:181
 msgid "ImageMagick"
@@ -6096,7 +6167,7 @@ msgstr "ImageMagick"
 
 #: ../src/common/image.h:182
 msgid "heif"
-msgstr "heif"
+msgstr "HEIF"
 
 #: ../src/common/image.h:183
 msgid "libraw"
@@ -6113,46 +6184,47 @@ msgid ""
 "the image.  some or all processing\n"
 "has been skipped."
 msgstr ""
-"此模組無法配置\n"
-"所有需要處理影像的記憶體\n"
-"部份或全部處理模組可能會跳過."
+"此模組運算所需的記憶體不足\n"
+"部分或全部影像處理已略過"
 
 #: ../src/common/imageio.c:740 ../src/common/mipmap_cache.c:1074
 #, c-format
 msgid "image `%s' is not available!"
-msgstr "影像“%s”無法使用！"
+msgstr "影像「%s」無法使用"
 
 #: ../src/common/imageio.c:758
 #, c-format
 msgid ""
 "failed to allocate memory for %s, please lower the threads used for export "
 "or buy more memory."
-msgstr "爲 %s 配置記憶體失敗，請減少用於輸出的線程數，或者擴充您的記憶體。"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"無法為「%s」配置記憶體，請關閉其他程式或加裝更多記憶體"
 
 #: ../src/common/imageio.c:759
 msgctxt "noun"
 msgid "thumbnail export"
-msgstr "縮圖輸出"
+msgstr "縮圖匯出"
 
 #: ../src/common/imageio.c:759
 msgctxt "noun"
 msgid "export"
-msgstr "輸出"
+msgstr "匯出"
 
 #: ../src/common/imageio.c:771
 #, c-format
 msgid "cannot find the style '%s' to apply during export."
-msgstr "無法找到樣式 '%s' 用於輸出時套用。"
+msgstr "找不到要在匯出時套用的風格檔「%s」"
 
 #: ../src/common/import_session.c:294
 msgid ""
 "couldn't expand to a unique filename for session, please check your import "
 "session settings."
-msgstr "無法擴展至一個不重複的檔案名，請檢查您的輸入設定。"
+msgstr "無法為此工作分配不重複的檔案名稱，請檢查匯入影像的設定"
 
 #: ../src/common/import_session.c:373
 msgid "requested session path not available. device not mounted?"
-msgstr "請求的期間路徑不可用。設備尚未掛載？"
+msgstr "資料夾無法存取，請設備確認是否已正確連接"
 
 #: ../src/common/iop_order.c:59 ../src/libs/ioporder.c:208
 msgid "legacy"
@@ -6169,16 +6241,16 @@ msgstr "v3.0 JPEG"
 #: ../src/common/iop_profile.c:105
 #, c-format
 msgid "unsupported working profile %s has been replaced by Rec2020 RGB!\n"
-msgstr "未支援的工作設定 %s，已使用 Rec2020 RGB 替代！\n"
+msgstr "不支援 「%s」 作為工作空間，已使用 Rec. 2020 取代\n"
 
 #. clang-format off
 #: ../src/common/metadata.c:46
 msgid "creator"
-msgstr "作者"
+msgstr "創作者"
 
 #: ../src/common/metadata.c:47
 msgid "publisher"
-msgstr "發行者"
+msgstr "發布者"
 
 #: ../src/common/metadata.c:50
 msgid "rights"
@@ -6186,7 +6258,7 @@ msgstr "版權"
 
 #: ../src/common/metadata.c:51
 msgid "notes"
-msgstr "註解"
+msgstr "註釋"
 
 #: ../src/common/metadata.c:52
 msgid "version name"
@@ -6195,45 +6267,53 @@ msgstr "版本名稱"
 #: ../src/common/metadata.c:53 ../src/libs/live_view.c:319
 #: ../src/libs/metadata_view.c:124
 msgid "image id"
-msgstr "圖片 id"
+msgstr "影像識別碼"
 
 #: ../src/common/noiseprofiles.c:26
 msgid "generic poissonian"
-msgstr "通用卜松"
+msgstr "通用帕松分布"
 
 #: ../src/common/noiseprofiles.c:61
 #, c-format
 msgid "noiseprofile file `%s' is not valid"
-msgstr "噪點配置檔案“%s”無效"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"「%s」雜訊描述檔無效"
 
 #: ../src/common/opencl.c:1111
 msgid ""
 "due to a slow GPU hardware acceleration via opencl has been de-activated"
-msgstr "由於 GPU 性能不足，OpenCL 硬體加速停止使用"
+msgstr ""
+"⚠️ 注意 ⚠️\n"
+"由於顯示卡速度過慢， OpenCL 加速功能已停用"
 
 #: ../src/common/opencl.c:1118
 msgid ""
 "multiple GPUs detected - opencl scheduling profile has been set accordingly"
-msgstr "偵測到多個 GPU - 已設定opencl排程配置"
+msgstr ""
+"⚠️ 注意 ⚠️\n"
+"偵測到多張顯示卡，已自動調整 OpenCL 至相應設定"
 
 #: ../src/common/opencl.c:1126
 msgid ""
 "very fast GPU detected - opencl scheduling profile has been set accordingly"
-msgstr "偵測到高性能 GPU - 已設定opencl排程配置"
+msgstr ""
+"⚠️ 注意 ⚠️\n"
+"偵測到高階的顯示卡，已自動調整 OpenCL 至相應設定"
 
 #: ../src/common/opencl.c:1133
 msgid "opencl scheduling profile set to default"
-msgstr "opencl排程配置已設定爲預設值"
+msgstr "恢復 OpenCL 設定成預設值"
 
 #: ../src/common/pdf.h:88 ../src/iop/lens.cc:1916
 #: ../src/libs/filters/focal.c:74 ../src/libs/print_settings.c:83
 msgid "mm"
-msgstr "毫米"
+msgstr "公釐"
 
 #: ../src/common/pdf.h:89 ../src/libs/export.c:533 ../src/libs/export.c:1164
 #: ../src/libs/print_settings.c:83
 msgid "cm"
-msgstr "釐米"
+msgstr "公分"
 
 #: ../src/common/pdf.h:90 ../src/libs/print_settings.c:83
 msgid "inch"
@@ -6245,65 +6325,65 @@ msgstr "\""
 
 #: ../src/common/pdf.h:104
 msgid "a4"
-msgstr "a4"
+msgstr "A4 - 21.0 x 29.7 公分"
 
 #: ../src/common/pdf.h:105
 msgid "a3"
-msgstr "a3"
+msgstr "A3 - 29.7 x 42.0 公分"
 
 #: ../src/common/pdf.h:106
 msgid "letter"
-msgstr "letter"
+msgstr "Letter - 8.5 x 11 英寸"
 
 #: ../src/common/pdf.h:107
 msgid "legal"
-msgstr "合法的"
+msgstr "Legal - 8.5 x 14 英寸"
 
 #: ../src/common/pwstorage/pwstorage.c:83
 msgid "GNOME Keyring backend is no longer supported. configure a different one"
-msgstr "不再支援Gnome 密鑰環。請配置其他種"
+msgstr "不再支援 GNOME Keyring 後端，請設定其他程式"
 
 #: ../src/common/ratings.c:205
 #, c-format
 msgid "rejecting %d image"
 msgid_plural "rejecting %d images"
-msgstr[0] "丟棄 %d 張影像"
+msgstr[0] "正在將 %d 張影像評分為不合格"
 
 #: ../src/common/ratings.c:207
 #, c-format
 msgid "applying rating %d to %d image"
 msgid_plural "applying rating %d to %d images"
-msgstr[0] "套用評分 %d 到 %d 張影像"
+msgstr[0] "套用評分 %d 給 %d 張影像"
 
 #: ../src/common/ratings.c:221
 msgid "no images selected to apply rating"
-msgstr "沒有選定任何圖片以套用評分"
+msgstr "沒有選取的影像可以套用評分"
 
 #: ../src/common/ratings.c:274 ../src/libs/metadata_view.c:353
 msgid "image rejected"
-msgstr "影像已被丟棄"
+msgstr "影像已評分為不合格"
 
 #: ../src/common/ratings.c:276
 msgid "image rated to 0 star"
-msgstr "影像已評分爲 0 顆星"
+msgstr "影像已評分為 0 顆星"
 
 #: ../src/common/ratings.c:278
 #, c-format
 msgid "image rated to %s"
-msgstr "影像已評分爲 %s"
+msgstr "影像已評分為「%s」顆星"
 
 #: ../src/common/ratings.c:305 ../src/libs/select.c:39
 #: ../src/views/lighttable.c:755
 msgid "select"
-msgstr "選擇"
+msgstr "選取影像"
 
 #: ../src/common/ratings.c:306
 msgid "upgrade"
-msgstr "升級"
+msgstr "評分升級"
 
 #: ../src/common/ratings.c:307
 msgid "downgrade"
-msgstr "降級"
+msgstr "評分降級"
 
 #: ../src/common/ratings.c:311
 msgid "zero"
@@ -6331,107 +6411,107 @@ msgstr "五"
 
 #: ../src/common/ratings.c:317
 msgid "reject"
-msgstr "丟棄"
+msgstr "不合格"
 
 #: ../src/common/styles.c:225
 #, c-format
 msgid "style with name '%s' already exists"
-msgstr "名爲“%s”的樣式已經存在"
+msgstr "風格檔「%s」已存在"
 
 #: ../src/common/styles.c:485 ../src/common/styles.c:562
 #: ../src/common/styles.c:1563 ../src/libs/styles.c:52
 msgid "styles"
-msgstr "風格"
+msgstr "風格檔"
 
 #: ../src/common/styles.c:488 ../src/gui/styles_dialog.c:233
 #, c-format
 msgid "style named '%s' successfully created"
-msgstr "樣式“%s”建立成功"
+msgstr "已建立風格檔「%s」"
 
 #: ../src/common/styles.c:620 ../src/common/styles.c:648
 #: ../src/common/styles.c:687
 msgid "no image selected!"
-msgstr "沒有選定圖片！"
+msgstr "尚未選取影像"
 
 #: ../src/common/styles.c:624
 #, c-format
 msgid "style %s successfully applied!"
-msgstr "成功套用樣式 %s！"
+msgstr "風格檔「%s」已成功套用！"
 
 #: ../src/common/styles.c:638
 msgid "no images nor styles selected!"
-msgstr "未選定圖片或樣式！"
+msgstr "尚未選取影像或風格檔"
 
 #: ../src/common/styles.c:643
 msgid "no styles selected!"
-msgstr "沒選定樣式！"
+msgstr "尚未選取風格檔"
 
 #: ../src/common/styles.c:673
 msgid "style successfully applied!"
 msgid_plural "styles successfully applied!"
-msgstr[0] "成功套用樣式！"
+msgstr[0] "風格檔套用成功"
 
 #: ../src/common/styles.c:744
 #, c-format
 msgid "module `%s' version mismatch: %d != %d"
-msgstr "模組“%s”版本不匹配: %d != %d"
+msgstr "模組「 %s 」版本不匹配：%d≠%d"
 
 #: ../src/common/styles.c:1199
 #, c-format
 msgid "failed to overwrite style file for %s"
-msgstr "覆蓋 %s 的樣式檔案失敗"
+msgstr "無法覆寫風格檔「%s」"
 
 #: ../src/common/styles.c:1205
 #, c-format
 msgid "style file for %s exists"
-msgstr "%s 的樣式檔案已存在"
+msgstr "風格檔「%s」已存在"
 
 #: ../src/common/styles.c:1457
 #, c-format
 msgid "style %s was successfully imported"
-msgstr "樣式 %s 輸入成功"
+msgstr "風格檔「%s」已匯入"
 
 #. Failed to open file, clean up.
 #: ../src/common/styles.c:1501
 #, c-format
 msgid "could not read file `%s'"
-msgstr "無法讀取檔案“%s”！"
+msgstr "無法讀取檔案「%s」"
 
 #: ../src/common/utility.c:503
 msgid "above sea level"
-msgstr "海拔以上"
+msgstr "海拔"
 
 #: ../src/common/utility.c:504
 msgid "below sea level"
-msgstr "海平面以下"
+msgstr "海平面下"
 
 #: ../src/common/utility.c:555 ../src/libs/metadata_view.c:875
 msgid "m"
-msgstr "米"
+msgstr "公尺"
 
 #: ../src/control/control.c:66 ../src/gui/accelerators.c:128
-#: ../src/views/darkroom.c:2097
+#: ../src/views/darkroom.c:2098
 msgid "hold"
-msgstr "保持"
+msgstr "保持按壓"
 
 #: ../src/control/control.c:102 ../src/control/control.c:136
 msgid "modifiers"
-msgstr "修飾詞"
+msgstr "更改"
 
 #: ../src/control/control.c:109
 msgctxt "accel"
 msgid "global"
-msgstr "全局"
+msgstr "全體"
 
 #: ../src/control/control.c:110
 msgctxt "accel"
 msgid "views"
-msgstr "視角"
+msgstr "檢視"
 
 #: ../src/control/control.c:111
 msgctxt "accel"
 msgid "thumbtable"
-msgstr "縮圖"
+msgstr "縮圖視窗"
 
 #: ../src/control/control.c:112
 msgctxt "accel"
@@ -6441,7 +6521,7 @@ msgstr "工具模組"
 #: ../src/control/control.c:113
 msgctxt "accel"
 msgid "processing modules"
-msgstr "處理模組"
+msgstr "編輯模組"
 
 #: ../src/control/control.c:114
 msgctxt "accel"
@@ -6451,42 +6531,48 @@ msgstr "混合"
 #: ../src/control/control.c:115
 msgctxt "accel"
 msgid "lua scripts"
-msgstr "lua 腳本"
+msgstr "Lua 腳本"
 
 #: ../src/control/control.c:116
 msgctxt "accel"
 msgid "fallbacks"
-msgstr "後備"
+msgstr "通用擴展快速鍵"
 
 #: ../src/control/control.c:133
 msgid "show accels window"
-msgstr "顯示快捷鍵視窗"
+msgstr "顯示快速鍵視窗"
 
 #: ../src/control/control.c:294
 msgid "working..."
-msgstr "工作中……"
+msgstr "處理中..."
 
 #: ../src/control/crawler.c:359
 #, c-format
 msgid "ERROR: %s NOT synced XMP → DB"
-msgstr "錯誤:%s沒同步XMP → 資料庫"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"無法將「%s」的 XMP 附屬檔案同步至資料庫"
 
 #: ../src/control/crawler.c:360 ../src/control/crawler.c:411
 #: ../src/control/crawler.c:463
 msgid ""
 "ERROR: cannot write the database. the destination may be full, offline or "
 "read-only."
-msgstr "錯誤:無法寫入資料庫。目標位置可能已滿、離線或處於只讀狀態。"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"無法寫入資料庫，硬碟空間可能不足、無法存取或是被設為唯讀"
 
 #: ../src/control/crawler.c:365
 #, c-format
 msgid "SUCCESS: %s synced XMP → DB"
-msgstr "成功:%s同步XMP → 資料庫"
+msgstr "成功：已從 XMP 附屬檔案同步「%s」的資料至資料庫"
 
 #: ../src/control/crawler.c:382
 #, c-format
 msgid "ERROR: %s NOT synced DB → XMP"
-msgstr "錯誤:%s沒同步資料庫 → XMP"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"無法將「%s」的資料庫同步至 XMP 附屬檔案"
 
 #: ../src/control/crawler.c:383 ../src/control/crawler.c:426
 #: ../src/control/crawler.c:477
@@ -6495,63 +6581,72 @@ msgid ""
 "ERROR: cannot write %s \n"
 "the destination may be full, offline or read-only."
 msgstr ""
-"錯誤:無法寫入 %s 張影像。\n"
-"目標位置可能已滿、離線或處於只讀狀態。"
+"⚠️ 錯誤 ⚠️\n"
+"無法寫入「%s」\n"
+"硬碟空間可能不足、無法存取或是被設為唯讀"
 
 #: ../src/control/crawler.c:388
 #, c-format
 msgid "SUCCESS: %s synced DB → XMP"
-msgstr "成功:%s同步資料庫 → XMP"
+msgstr "成功：已從資料庫同步「%s」的資料至 XMP 附屬檔案"
 
 #: ../src/control/crawler.c:410
 #, c-format
 msgid "ERROR: %s NOT synced new (XMP) → old (DB)"
-msgstr "錯誤:%s沒同步新XMP → 舊資料庫"
+msgstr "⚠️ 錯誤 ⚠️\v無法將「%s」新的 XMP 附屬檔案同步至舊的資料庫"
 
 #: ../src/control/crawler.c:415
 #, c-format
 msgid "SUCCESS: %s synced new (XMP) → old (DB)"
-msgstr "成功:%s同步新XMP → 舊資料庫"
+msgstr "成功：已從新的 XMP 附屬檔案同步「%s」的資料至舊資料庫"
 
 #: ../src/control/crawler.c:425
 #, c-format
 msgid "ERROR: %s NOT synced new (DB) → old (XMP)"
-msgstr "錯誤:%s沒同步新資料庫 → 舊XMP"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"無法將「%s」的新資料庫同步至舊 XMP 附屬檔案"
 
 #: ../src/control/crawler.c:430
 #, c-format
 msgid "SUCCESS: %s synced new (DB) → old (XMP)"
-msgstr "成功:%s沒同步新資料庫 → 舊XMP"
+msgstr "成功：已從新資料庫同步「%s」的資料至舊的 XMP 附屬檔案"
 
 #: ../src/control/crawler.c:438 ../src/control/crawler.c:489
 #, c-format
 msgid "EXCEPTION: %s has inconsistent timestamps"
-msgstr "例外:%s  時戳不一致"
+msgstr ""
+"⚠️ 異常 ⚠️\n"
+"「%s」具有不同的時間"
 
 #: ../src/control/crawler.c:462
 #, c-format
 msgid "ERROR: %s NOT synced old (XMP) → new (DB)"
-msgstr "錯誤:%s沒同步舊XMP → 新資料庫"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"無法將「%s」的舊 XMP 附屬檔案同步至新資料庫"
 
 #: ../src/control/crawler.c:467
 #, c-format
 msgid "SUCCESS: %s synced old (XMP) → new (DB)"
-msgstr "成功:%s同步舊XMP → 新資料庫"
+msgstr "成功：已從舊的 XMP 附屬檔案同步「%s」的資料至新資料庫"
 
 #: ../src/control/crawler.c:476
 #, c-format
 msgid "ERROR: %s NOT synced old (DB) → new (XMP)"
-msgstr "錯誤:%s沒同步舊資料庫 → 新XMP"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"無法將「%s」的舊資料庫同步至新的 XMP 附屬檔案"
 
 #: ../src/control/crawler.c:481
 #, c-format
 msgid "SUCCESS: %s synced old (DB) → new (XMP)"
-msgstr "成功:%s同步舊資料庫 → 新XMP"
+msgstr "成功：已從舊的資料庫同步「%s」的資料至新的 XMP 附屬檔案"
 
 #: ../src/control/crawler.c:560
 #, c-format
 msgid "%id %02dh %02dm %02ds"
-msgstr "%i 天 %02d 小時 %02d 分鐘 %02d 秒"
+msgstr "%i 天 %02d 小時 %02d 分 %02d 秒"
 
 #: ../src/control/crawler.c:625
 msgid "path"
@@ -6559,11 +6654,11 @@ msgstr "路徑"
 
 #: ../src/control/crawler.c:633
 msgid "xmp timestamp"
-msgstr "xmp 時間戳"
+msgstr "XMP 日期"
 
 #: ../src/control/crawler.c:637
 msgid "database timestamp"
-msgstr "資料庫時間戳"
+msgstr "資料庫日期"
 
 #: ../src/control/crawler.c:641
 msgid "newest"
@@ -6571,44 +6666,44 @@ msgstr "最新"
 
 #: ../src/control/crawler.c:646
 msgid "time difference"
-msgstr "時間差"
+msgstr "時間差異"
 
 #: ../src/control/crawler.c:656
 msgid "updated xmp sidecar files found"
-msgstr "發現較新的 xmp 附屬檔案"
+msgstr "找到已更新的 XMP 附屬檔案"
 
 #: ../src/control/crawler.c:657
 msgid "_close"
-msgstr "關閉"
+msgstr "關閉（_C）"
 
 #. setup selection accelerators
 #. action-box
-#: ../src/control/crawler.c:671 ../src/dtgtk/thumbtable.c:2339
+#: ../src/control/crawler.c:671 ../src/dtgtk/thumbtable.c:2351
 #: ../src/libs/import.c:1712 ../src/libs/select.c:133
 msgid "select all"
-msgstr "全選"
+msgstr "全部選取"
 
-#: ../src/control/crawler.c:672 ../src/dtgtk/thumbtable.c:2340
+#: ../src/control/crawler.c:672 ../src/dtgtk/thumbtable.c:2352
 #: ../src/libs/import.c:1716 ../src/libs/select.c:137
 msgid "select none"
-msgstr "全不選"
+msgstr "取消選取"
 
-#: ../src/control/crawler.c:673 ../src/dtgtk/thumbtable.c:2341
+#: ../src/control/crawler.c:673 ../src/dtgtk/thumbtable.c:2353
 #: ../src/libs/select.c:141
 msgid "invert selection"
-msgstr "反轉選擇"
+msgstr "反轉選取"
 
 #: ../src/control/crawler.c:685
 msgid "on the selection:"
-msgstr "在選擇時:"
+msgstr "選擇的："
 
 #: ../src/control/crawler.c:686
 msgid "keep the xmp edit"
-msgstr "保留 xmp 中的編輯"
+msgstr "保留 xmp 編輯"
 
 #: ../src/control/crawler.c:687
 msgid "keep the database edit"
-msgstr "保留資料庫中的編輯"
+msgstr "保留資料庫編輯"
 
 #: ../src/control/crawler.c:688
 msgid "keep the newest edit"
@@ -6620,17 +6715,17 @@ msgstr "保留最舊的編輯"
 
 #: ../src/control/crawler.c:711
 msgid "synchronization log"
-msgstr "同步日誌"
+msgstr "同步紀錄"
 
 #: ../src/control/jobs/camera_jobs.c:80
 #, c-format
 msgid "capturing %d image"
 msgid_plural "capturing %d images"
-msgstr[0] "拍攝 %d 張影像"
+msgstr[0] "正在拍攝 %d 張影像"
 
 #: ../src/control/jobs/camera_jobs.c:114
 msgid "please set your camera to manual mode first!"
-msgstr "請首先將您的相機設定爲手動模式！"
+msgstr "請先將相機設為手動模式"
 
 #: ../src/control/jobs/camera_jobs.c:211
 msgid "capture images"
@@ -6640,33 +6735,33 @@ msgstr "拍攝影像"
 #, c-format
 msgid "%d/%d imported to %s"
 msgid_plural "%d/%d imported to %s"
-msgstr[0] "%d/%d 輸入至 %s"
+msgstr[0] "%d / %d 張影像已匯入到「%s」"
 
 #: ../src/control/jobs/camera_jobs.c:300
 msgid "starting to import images from camera"
-msgstr "開始從相機輸入影像"
+msgstr "開始從相機匯入影像"
 
 #: ../src/control/jobs/camera_jobs.c:311
 #, c-format
 msgid "importing %d image from camera"
 msgid_plural "importing %d images from camera"
-msgstr[0] "從相機輸入 %d 張影像"
+msgstr[0] "從相機匯入 %d 張影像"
 
 #: ../src/control/jobs/camera_jobs.c:371
 msgid "import images from camera"
-msgstr "從相機輸入影像"
+msgstr "從相機匯入影像"
 
 #: ../src/control/jobs/control_jobs.c:144
 msgid "failed to create film roll for destination directory, aborting move.."
-msgstr "目標目錄建立軟片捲失敗，移動中斷。"
+msgstr "在資料夾建立底片卷失敗，正在終止移動..."
 
 #: ../src/control/jobs/control_jobs.c:377
 msgid "exposure bracketing only works on raw images."
-msgstr "包圍曝光只能用於RAW影像。"
+msgstr "曝光包圍僅適用於 RAW 檔"
 
 #: ../src/control/jobs/control_jobs.c:384
 msgid "images have to be of same size and orientation!"
-msgstr "影像大小和方向必須相同！"
+msgstr "影像大小和方向必須相同"
 
 #: ../src/control/jobs/control_jobs.c:479
 #, c-format
@@ -6677,7 +6772,7 @@ msgstr[0] "合併 %d 張影像"
 #: ../src/control/jobs/control_jobs.c:553
 #, c-format
 msgid "wrote merged HDR `%s'"
-msgstr "寫入合併的 HDR “%s”"
+msgstr "寫入合併的 HDR 影像「%s」"
 
 #: ../src/control/jobs/control_jobs.c:585
 #, c-format
@@ -6695,13 +6790,13 @@ msgstr[0] "翻轉 %d 張影像"
 #, c-format
 msgid "set %d color image"
 msgid_plural "setting %d color images"
-msgstr[0] "將 %d 張影像設置爲彩色"
+msgstr[0] "將 %d 張影像設為彩色"
 
 #: ../src/control/jobs/control_jobs.c:659
 #, c-format
 msgid "set %d monochrome image"
 msgid_plural "setting %d monochrome images"
-msgstr[0] "將 %d 張影像設置爲黑白"
+msgstr[0] "將 %d 張影像設為黑白"
 
 #: ../src/control/jobs/control_jobs.c:744
 #, c-format
@@ -6712,28 +6807,28 @@ msgstr[0] "移除 %d 張影像"
 #: ../src/control/jobs/control_jobs.c:848
 #, c-format
 msgid "could not send %s to trash%s%s"
-msgstr "無法把 %s 放到回收桶 %s%s"
+msgstr "無法將「%s」丟進回收桶 %s%s"
 
 #: ../src/control/jobs/control_jobs.c:849
 #, c-format
 msgid "could not physically delete %s%s%s"
-msgstr "無法實質刪除 %s%s%s"
+msgstr "無法刪除「%s」%s%s"
 
 #: ../src/control/jobs/control_jobs.c:859
 msgid "physically delete"
-msgstr "實質性刪除"
+msgstr "刪除實體檔案"
 
 #: ../src/control/jobs/control_jobs.c:860
 msgid "physically delete all files"
-msgstr "實質性刪除全部檔案"
+msgstr "刪除所有實體檔案"
 
 #: ../src/control/jobs/control_jobs.c:862
 msgid "only remove from the image library"
-msgstr "僅從集合中移除"
+msgstr "僅從圖庫中移除"
 
 #: ../src/control/jobs/control_jobs.c:863
 msgid "skip to next file"
-msgstr "跳到下一個檔案"
+msgstr "跳過至下一個檔案"
 
 #: ../src/control/jobs/control_jobs.c:864
 msgid "stop process"
@@ -6741,17 +6836,17 @@ msgstr "停止處理"
 
 #: ../src/control/jobs/control_jobs.c:869
 msgid "trashing error"
-msgstr "清空回收桶時遇到問題"
+msgstr "丟進回收桶時發生錯誤"
 
 #: ../src/control/jobs/control_jobs.c:870
 msgid "deletion error"
-msgstr "刪除錯誤"
+msgstr "刪除時發生錯誤"
 
 #: ../src/control/jobs/control_jobs.c:1012
 #, c-format
 msgid "trashing %d image"
 msgid_plural "trashing %d images"
-msgstr[0] "將 %d 張圖片移動至回收桶"
+msgstr[0] "將 %d 張影像丟進回收桶"
 
 #: ../src/control/jobs/control_jobs.c:1014
 #, c-format
@@ -6767,7 +6862,7 @@ msgstr "無法解析 GPX 檔案"
 #, c-format
 msgid "applied matched GPX location onto %d image"
 msgid_plural "applied matched GPX location onto %d images"
-msgstr[0] "套用匹配的 GPX 位置到 %d 張影像"
+msgstr[0] "已套用符合的 GPX 位置至 %d 張影像"
 
 #: ../src/control/jobs/control_jobs.c:1204
 #, c-format
@@ -6793,13 +6888,13 @@ msgstr "複製 %d 張影像"
 #, c-format
 msgid "creating local copy of %d image"
 msgid_plural "creating local copies of %d images"
-msgstr[0] "建立 %d 張影像的本地副本"
+msgstr[0] "建立 %d 張影像的本機備份副本"
 
 #: ../src/control/jobs/control_jobs.c:1229
 #, c-format
 msgid "removing local copy of %d image"
 msgid_plural "removing local copies of %d images"
-msgstr[0] "刪除 %d 張影像的本地副本"
+msgstr[0] "刪除 %d 張影像的本機備份副本"
 
 #: ../src/control/jobs/control_jobs.c:1276
 #, c-format
@@ -6811,26 +6906,26 @@ msgstr[0] "更新 %d 張影像的資訊"
 #, c-format
 msgid "exporting %d image.."
 msgid_plural "exporting %d images.."
-msgstr[0] "正在輸出 %d 張影像.."
+msgstr[0] "匯出 %d 張影像..."
 
 #: ../src/control/jobs/control_jobs.c:1364
 msgid "no image to export"
-msgstr "沒影像輸出"
+msgstr "沒有要匯出的影像"
 
 #: ../src/control/jobs/control_jobs.c:1402
 #, c-format
 msgid "exporting %d / %d to %s"
-msgstr "正在輸出 %d 張(共 %d 張)影像到 %s"
+msgstr "匯出 %d 張（共 %d 張）影像到「%s」"
 
 #: ../src/control/jobs/control_jobs.c:1423 ../src/views/darkroom.c:818
 #: ../src/views/print.c:337
 #, c-format
 msgid "image `%s' is currently unavailable"
-msgstr "影像“%s”目前不使用"
+msgstr "影像「%s」目前無法使用"
 
 #: ../src/control/jobs/control_jobs.c:1515
 msgid "merge hdr image"
-msgstr "合併 hdr 影像"
+msgstr "合併 HDR 影像"
 
 #: ../src/control/jobs/control_jobs.c:1529
 msgid "duplicate images"
@@ -6842,7 +6937,7 @@ msgstr "翻轉影像"
 
 #: ../src/control/jobs/control_jobs.c:1542
 msgid "set monochrome images"
-msgstr "將影像設置爲黑白"
+msgstr "將影像設為黑白"
 
 #. get all selected images now, to avoid the set changing during ui interaction
 #: ../src/control/jobs/control_jobs.c:1549
@@ -6857,15 +6952,17 @@ msgid ""
 msgid_plural ""
 "do you really want to remove %d images from darktable\n"
 "(without deleting files on disk)?"
-msgstr[0] "是否要從 darktable 中移除 %d 個影像而不從硬碟上刪除檔案？"
+msgstr[0] ""
+"確定從 darktable 中移除選取的 %d 張影像？\n"
+"（僅從圖庫中移除，不刪除硬碟裡的檔案）"
 
 #: ../src/control/jobs/control_jobs.c:1573
 msgid "remove image?"
-msgstr "移除影像？"
+msgstr "是否要移除影像？"
 
 #: ../src/control/jobs/control_jobs.c:1573
 msgid "remove images?"
-msgstr "移除影像？"
+msgstr "是否要移除影像？"
 
 #. first get all selected images, to avoid the set changing during ui interaction
 #: ../src/control/jobs/control_jobs.c:1589
@@ -6881,32 +6978,34 @@ msgid ""
 msgid_plural ""
 "do you really want to physically delete %d images\n"
 "(using trash if possible)?"
-msgstr[0] "確定要從硬碟實質刪除 %d 張已選影像嗎(儘可能使用回收桶)？"
+msgstr[0] ""
+"確定要刪除選取的 %d 張影像？\n"
+"（從硬碟中刪除實體檔案）"
 
 #: ../src/control/jobs/control_jobs.c:1611
 #, c-format
 msgid "do you really want to physically delete %d image from disk?"
 msgid_plural "do you really want to physically delete %d images from disk?"
-msgstr[0] "你確定要從硬碟實質刪除 %d 張已選影像嗎？"
+msgstr[0] "確定要從硬碟中刪除選取的 %d 張影像檔案？"
 
 #: ../src/control/jobs/control_jobs.c:1618
 #: ../src/control/jobs/control_jobs.c:1656
 msgid "delete image?"
-msgstr "刪除影像？"
+msgstr "是否要刪除影像？"
 
 #: ../src/control/jobs/control_jobs.c:1618
 msgid "delete images?"
-msgstr "刪除影像？"
+msgstr "是否要刪除影像？"
 
 #: ../src/control/jobs/control_jobs.c:1650
 msgid ""
 "do you really want to physically delete selected image (using trash if "
 "possible)?"
-msgstr "確定要從硬碟實質刪除已選取影像嗎(儘可能使用回收桶)？"
+msgstr "確定要從硬碟中刪除選取的影像檔案？"
 
 #: ../src/control/jobs/control_jobs.c:1651
 msgid "do you really want to physically delete selected image from disk?"
-msgstr "確定要從硬碟實質刪除已選取影像嗎？"
+msgstr "確定要從硬碟中刪除選取的影像檔案？"
 
 #: ../src/control/jobs/control_jobs.c:1674
 msgid "move images"
@@ -6915,7 +7014,7 @@ msgstr "移動影像"
 #: ../src/control/jobs/control_jobs.c:1686
 #: ../src/control/jobs/control_jobs.c:1748
 msgid "_select as destination"
-msgstr "選擇目的地"
+msgstr "選擇資料夾（_S）"
 
 #: ../src/control/jobs/control_jobs.c:1706
 #, c-format
@@ -6926,13 +7025,13 @@ msgid_plural ""
 "do you really want to physically move %d images to %s?\n"
 "(all duplicates will be moved along)"
 msgstr[0] ""
-"確定要實質移動 %d 張已選影像至 %s 嗎？\n"
-"(所有重複影像將一併移動)"
+"是否要將 %d 張影像實體移動到「%s」？\n"
+"（所有複本都會被移動）"
 
 #: ../src/control/jobs/control_jobs.c:1715
 msgid "move image?"
 msgid_plural "move images?"
-msgstr[0] "移動影像？"
+msgstr[0] "是否要移動影像？"
 
 #: ../src/control/jobs/control_jobs.c:1736
 msgid "copy images"
@@ -6942,74 +7041,74 @@ msgstr "複製影像"
 #, c-format
 msgid "do you really want to physically copy %d image to %s?"
 msgid_plural "do you really want to physically copy %d images to %s?"
-msgstr[0] "確定要實質複製 %d 張已選取影像至 %s 嗎？"
+msgstr[0] "是否要將 %d 張影像實體複製到「%s」？"
 
 #: ../src/control/jobs/control_jobs.c:1774
 msgid "copy image?"
 msgid_plural "copy images?"
-msgstr[0] "複製影像？"
+msgstr[0] "是否要複製影像？"
 
 #: ../src/control/jobs/control_jobs.c:1794
 #: ../src/control/jobs/control_jobs.c:1802
 msgid "local copy images"
-msgstr "本地複製影像"
+msgstr "本機備份影像"
 
 #: ../src/control/jobs/control_jobs.c:1809 ../src/libs/image.c:607
 msgid "refresh EXIF"
-msgstr "更新EXIF"
+msgstr "更新 EXIF 資料"
 
 #: ../src/control/jobs/control_jobs.c:1873
 #, c-format
 msgid "failed to get parameters from storage module `%s', aborting export.."
-msgstr "從儲存模組“%s”獲取參數失敗，輸出中斷.."
+msgstr "從儲存模組「%s」取得獲取參數失敗，正在中止匯出"
 
 #: ../src/control/jobs/control_jobs.c:1889
 msgid "export images"
-msgstr "輸出影像"
+msgstr "匯出影像"
 
 #: ../src/control/jobs/control_jobs.c:1939
 #, c-format
 msgid "adding time offset to %d image"
-msgstr "對 %d 張影像增加時間偏移"
+msgstr "寫入 %d 張影像的時間偏差補償"
 
 #: ../src/control/jobs/control_jobs.c:1939
 #, c-format
 msgid "setting date/time of %d image"
-msgstr "爲 %d 張影像設定拍攝日期/時間"
+msgstr "設定 %d 張影像的拍攝日期和時間"
 
 #: ../src/control/jobs/control_jobs.c:1940
 #, c-format
 msgid "adding time offset to %d images"
-msgstr "對%d 張影像增加時間偏移"
+msgstr "寫入 %d 張影像的時間偏差補償"
 
 #: ../src/control/jobs/control_jobs.c:1940
 #, c-format
 msgid "setting date/time of %d images"
-msgstr "爲 %d 張影像設定拍攝日期/時間"
+msgstr "設定 %d 張影像的拍攝日期和時間"
 
 #: ../src/control/jobs/control_jobs.c:1985
 #, c-format
 msgid "added time offset to %d image"
-msgstr "已向 %d 張影像增加時間偏移"
+msgstr "已修正 %d 張影像的時間偏差"
 
 #: ../src/control/jobs/control_jobs.c:1985
 #, c-format
 msgid "set date/time of %d image"
-msgstr "已爲 %d 張影像設定拍攝日期與時間"
+msgstr "已設定 %d 張影像的日期與時間"
 
 #: ../src/control/jobs/control_jobs.c:1986
 #, c-format
 msgid "added time offset to %d images"
-msgstr "已向 %d 張影像增加時間偏移"
+msgstr "已修正 %d 張影像的時間偏差"
 
 #: ../src/control/jobs/control_jobs.c:1986
 #, c-format
 msgid "set date/time of %d images"
-msgstr "已爲 %d 張影像設定拍攝日期與時間"
+msgstr "已設定 %d 張影像的日期與時間"
 
 #: ../src/control/jobs/control_jobs.c:2027
 msgid "time offset"
-msgstr "時間偏移"
+msgstr "時間偏差補償"
 
 #: ../src/control/jobs/control_jobs.c:2055 ../src/libs/copy_history.c:386
 msgid "write sidecar files"
@@ -7019,239 +7118,245 @@ msgstr "寫入附屬檔案"
 #, c-format
 msgid "importing %d image"
 msgid_plural "importing %d images"
-msgstr[0] "輸入 %d 張影像"
+msgstr[0] "匯入 %d 張影像"
 
 #: ../src/control/jobs/control_jobs.c:2283
 #, c-format
 msgid "importing %d/%d image"
 msgid_plural "importing %d/%d images"
-msgstr[0] "正在輸入 %d 張影像(共 %d 張)"
+msgstr[0] "正在匯入第 %d / %d 張影像"
 
 #: ../src/control/jobs/control_jobs.c:2291
 #, c-format
 msgid "imported %d image"
 msgid_plural "imported %d images"
-msgstr[0] "已輸入 %d 張影像"
+msgstr[0] "已匯入 %d 張影像"
 
 #: ../src/control/jobs/film_jobs.c:73 ../src/control/jobs/film_jobs.c:109
 msgid "import images"
-msgstr "輸入影像"
+msgstr "匯入影像"
 
 #: ../src/control/jobs/film_jobs.c:239
 msgid "no supported images were found to be imported"
-msgstr "沒有發現可以輸入的支援影像"
+msgstr "沒有支援的影像格式可匯入"
 
 #: ../src/control/jobs/image_jobs.c:76
 #, c-format
 msgid "importing image %s"
-msgstr "正在輸入影像 %s"
+msgstr "匯入影像「%s」"
 
 #: ../src/control/jobs/image_jobs.c:110
 msgid "import image"
-msgstr "輸入影像"
+msgstr "匯入影像"
 
 #: ../src/develop/blend.c:293
 msgid "detail mask blending error"
-msgstr "細節遮罩混合出現錯誤"
+msgstr "細節遮罩混合錯誤"
 
 #: ../src/develop/blend.c:461 ../src/develop/blend.c:849
 #, c-format
 msgid "skipped blending in module '%s': roi's do not match"
-msgstr "在模組“%s”中跳過混合:著重區域不匹配"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"跳過模組「%s」中的混合，因 roi 不相符"
 
 #: ../src/develop/blend.c:492 ../src/develop/blend.c:884
 msgid "could not allocate buffer for blending"
-msgstr "無法配置混合緩衝區"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"遮罩混合無法配置緩衝區"
 
 #: ../src/develop/blend.c:800
 msgid "detail mask CL blending problem"
-msgstr "細節遮罩 CL 混合出現錯誤"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"細節遮罩 CL 混合出現問題"
 
 #: ../src/develop/blend_gui.c:46 ../src/libs/live_view.c:335
 msgctxt "blendmode"
 msgid "normal"
-msgstr "正常"
+msgstr "一般（normal）"
 
 #: ../src/develop/blend_gui.c:47
 msgctxt "blendmode"
 msgid "normal bounded"
-msgstr "有界的正常"
+msgstr "限制值域（normal bounded）"
 
 #: ../src/develop/blend_gui.c:48 ../src/libs/live_view.c:343
 msgctxt "blendmode"
 msgid "lighten"
-msgstr "變亮(lighten)"
+msgstr "變亮（lighten）"
 
 #: ../src/develop/blend_gui.c:49 ../src/libs/live_view.c:342
 msgctxt "blendmode"
 msgid "darken"
-msgstr "變暗(darken)"
+msgstr "變暗（darken）"
 
 #: ../src/develop/blend_gui.c:50 ../src/libs/live_view.c:339
 msgctxt "blendmode"
 msgid "multiply"
-msgstr "正片疊加(multiply)"
+msgstr "色彩增值（multiply）"
 
 #: ../src/develop/blend_gui.c:51
 msgctxt "blendmode"
 msgid "average"
-msgstr "平均(average)"
+msgstr "平均（average）"
 
 #: ../src/develop/blend_gui.c:52
 msgctxt "blendmode"
 msgid "addition"
-msgstr "增加(addition)"
+msgstr "增加（addition）"
 
 #: ../src/develop/blend_gui.c:53
 msgctxt "blendmode"
 msgid "subtract"
-msgstr "減去(subtract)"
+msgstr "減去（subtract）"
 
 #: ../src/develop/blend_gui.c:54 ../src/libs/live_view.c:348
 msgctxt "blendmode"
 msgid "difference"
-msgstr "差異(difference)"
+msgstr "差異化（difference）"
 
 #: ../src/develop/blend_gui.c:55 ../src/libs/live_view.c:340
 msgctxt "blendmode"
 msgid "screen"
-msgstr "濾色(screen)"
+msgstr "濾色（screen）"
 
 #: ../src/develop/blend_gui.c:56 ../src/libs/live_view.c:341
 msgctxt "blendmode"
 msgid "overlay"
-msgstr "疊加層"
+msgstr "覆蓋（overlay）"
 
 #: ../src/develop/blend_gui.c:57
 msgctxt "blendmode"
 msgid "softlight"
-msgstr "柔光(softlight)"
+msgstr "柔光（soft light）"
 
 #: ../src/develop/blend_gui.c:58
 msgctxt "blendmode"
 msgid "hardlight"
-msgstr "硬光(hardlight)"
+msgstr "實光（hard light）"
 
 #: ../src/develop/blend_gui.c:59
 msgctxt "blendmode"
 msgid "vividlight"
-msgstr "亮光(vividlight)"
+msgstr "強烈光源（vivid light）"
 
 #: ../src/develop/blend_gui.c:60
 msgctxt "blendmode"
 msgid "linearlight"
-msgstr "線性光(linearlight)"
+msgstr "線性光源（linear light）"
 
 #: ../src/develop/blend_gui.c:61
 msgctxt "blendmode"
 msgid "pinlight"
-msgstr "個性光(pinlight)"
+msgstr "小光源（pin light）"
 
 #: ../src/develop/blend_gui.c:62
 msgctxt "blendmode"
 msgid "lightness"
-msgstr "亮度"
+msgstr "明度（lightness）"
 
 #: ../src/develop/blend_gui.c:63
 msgctxt "blendmode"
 msgid "chromaticity"
-msgstr "色度"
+msgstr "色度（chromaticity）"
 
 #: ../src/develop/blend_gui.c:64
 msgctxt "blendmode"
 msgid "hue"
-msgstr "色相"
+msgstr "色相（hue）"
 
 #: ../src/develop/blend_gui.c:65
 msgctxt "blendmode"
 msgid "color"
-msgstr "顏色"
+msgstr "顏色（color）"
 
 #: ../src/develop/blend_gui.c:66
 msgctxt "blendmode"
 msgid "coloradjustment"
-msgstr "色彩調整"
+msgstr "色彩調整（color adjustment）"
 
 #: ../src/develop/blend_gui.c:67
 msgctxt "blendmode"
 msgid "Lab lightness"
-msgstr "Lab 亮度"
+msgstr "Lab 明度（Lab lightness）"
 
 #: ../src/develop/blend_gui.c:68
 msgctxt "blendmode"
 msgid "Lab color"
-msgstr "Lab 顏色"
+msgstr "Lab 色彩（Lab color）"
 
 #: ../src/develop/blend_gui.c:69
 msgctxt "blendmode"
 msgid "Lab L-channel"
-msgstr "Lab L 通道"
+msgstr "L* 色版（Lab L* channel）"
 
 #: ../src/develop/blend_gui.c:70
 msgctxt "blendmode"
 msgid "Lab a-channel"
-msgstr "Lab a 通道"
+msgstr "a* 色版（Lab a* channel）"
 
 #: ../src/develop/blend_gui.c:71
 msgctxt "blendmode"
 msgid "Lab b-channel"
-msgstr "Lab b 通道"
+msgstr "b* 色版（Lab b* channel）"
 
 #: ../src/develop/blend_gui.c:72
 msgctxt "blendmode"
 msgid "HSV value"
-msgstr "HSV 亮度值"
+msgstr "HSV 亮度（HSV value）"
 
 #: ../src/develop/blend_gui.c:73
 msgctxt "blendmode"
 msgid "HSV color"
-msgstr "HSV 顏色"
+msgstr "HSV 色彩（HSV color）"
 
 #: ../src/develop/blend_gui.c:74
 msgctxt "blendmode"
 msgid "RGB red channel"
-msgstr "RGB 紅色通道"
+msgstr "紅色色版（RGB red channel）"
 
 #: ../src/develop/blend_gui.c:75
 msgctxt "blendmode"
 msgid "RGB green channel"
-msgstr "RGB 綠色通道"
+msgstr "綠色色版（RGB green channel）"
 
 #: ../src/develop/blend_gui.c:76
 msgctxt "blendmode"
 msgid "RGB blue channel"
-msgstr "RGB 藍色通道"
+msgstr "藍色色版（RGB blue channel）"
 
 #: ../src/develop/blend_gui.c:77
 msgctxt "blendmode"
 msgid "divide"
-msgstr "相除"
+msgstr "分割（divide）"
 
 #: ../src/develop/blend_gui.c:78
 msgctxt "blendmode"
 msgid "geometric mean"
-msgstr "幾何平均數"
+msgstr "幾何平均（geometric mean）"
 
 #: ../src/develop/blend_gui.c:79
 msgctxt "blendmode"
 msgid "harmonic mean"
-msgstr "調和平均數"
+msgstr "調和平均（harmonic mean）"
 
 #. * deprecated blend modes: make them available as legacy history stacks might want them
 #: ../src/develop/blend_gui.c:82
 msgctxt "blendmode"
 msgid "difference (deprecated)"
-msgstr "差值(已廢棄)"
+msgstr "差值（已汰除）"
 
 #: ../src/develop/blend_gui.c:83
 msgctxt "blendmode"
 msgid "subtract inverse (deprecated)"
-msgstr "逆減(已廢棄)"
+msgstr "加二補數（已汰除）"
 
 #: ../src/develop/blend_gui.c:84
 msgctxt "blendmode"
 msgid "divide inverse (deprecated)"
-msgstr "逆除(已廢棄)"
+msgstr "除二補數（已汰除）"
 
 #: ../src/develop/blend_gui.c:88
 msgctxt "blendoperation"
@@ -7274,138 +7379,138 @@ msgstr "RAW"
 
 #: ../src/develop/blend_gui.c:96 ../src/develop/blend_gui.c:1725
 msgid "RGB (display)"
-msgstr "RGB(顯示)"
+msgstr "RGB（顯示參照）"
 
 #: ../src/develop/blend_gui.c:97 ../src/develop/blend_gui.c:1736
 msgid "RGB (scene)"
-msgstr "RGB(場景)"
+msgstr "RGB（場景參照）"
 
 #. DEVELOP_MASK_ENABLED
 #: ../src/develop/blend_gui.c:102 ../src/develop/blend_gui.c:2980
 msgid "uniformly"
-msgstr "均勻"
+msgstr "均勻混合"
 
 #: ../src/develop/blend_gui.c:103 ../src/develop/blend_gui.c:2321
-#: ../src/develop/blend_gui.c:2987 ../src/develop/imageop.c:2272
+#: ../src/develop/blend_gui.c:2987 ../src/develop/imageop.c:2273
 msgid "drawn mask"
-msgstr "繪製遮罩"
+msgstr "繪製範圍遮罩"
 
 #: ../src/develop/blend_gui.c:104 ../src/develop/blend_gui.c:2129
-#: ../src/develop/blend_gui.c:2994 ../src/develop/imageop.c:2274
+#: ../src/develop/blend_gui.c:2994 ../src/develop/imageop.c:2275
 msgid "parametric mask"
-msgstr "參數遮罩"
+msgstr "設定色版遮罩"
 
 #: ../src/develop/blend_gui.c:105 ../src/develop/blend_gui.c:2501
-#: ../src/develop/blend_gui.c:3012 ../src/develop/imageop.c:2276
+#: ../src/develop/blend_gui.c:3012 ../src/develop/imageop.c:2277
 msgid "raster mask"
-msgstr "網格圖像遮罩"
+msgstr "點陣遮罩"
 
 #: ../src/develop/blend_gui.c:106 ../src/develop/blend_gui.c:3003
 msgid "drawn & parametric mask"
-msgstr "繪製 及 參數遮罩"
+msgstr "結合範圍和色版遮罩"
 
 #: ../src/develop/blend_gui.c:110
 msgid "exclusive"
-msgstr "不包括"
+msgstr "並且"
 
 #: ../src/develop/blend_gui.c:111
 msgid "inclusive"
-msgstr "包括"
+msgstr "包含"
 
 #: ../src/develop/blend_gui.c:112
 msgid "exclusive & inverted"
-msgstr "不包括&反轉"
+msgstr "並且和反轉"
 
 #: ../src/develop/blend_gui.c:113
 msgid "inclusive & inverted"
-msgstr "包括&反轉"
+msgstr "包含和反轉"
 
 #: ../src/develop/blend_gui.c:117
 msgid "output before blur"
-msgstr "模糊前的輸出"
+msgstr "先柔化後模糊 / 輸出"
 
 #: ../src/develop/blend_gui.c:118
 msgid "input before blur"
-msgstr "模糊前的輸入"
+msgstr "先柔化後模糊 / 輸入"
 
 #: ../src/develop/blend_gui.c:119
 msgid "output after blur"
-msgstr "模糊後的輸出"
+msgstr "先模糊後柔化 / 輸出"
 
 #: ../src/develop/blend_gui.c:120
 msgid "input after blur"
-msgstr "模糊後的輸入"
+msgstr "先模糊後柔化 / 輸入"
 
-#: ../src/develop/blend_gui.c:125 ../src/develop/develop.c:2248
+#: ../src/develop/blend_gui.c:125 ../src/develop/develop.c:2246
 #: ../src/gui/accelerators.c:120 ../src/gui/accelerators.c:129
 #: ../src/gui/accelerators.c:198 ../src/imageio/format/avif.c:823
 #: ../src/libs/live_view.c:362
 msgid "on"
-msgstr "開"
+msgstr "開啟"
 
 #: ../src/develop/blend_gui.c:856 ../src/develop/blend_gui.c:2190
-#: ../src/develop/imageop.c:2379 ../src/iop/channelmixerrgb.c:4104
+#: ../src/develop/imageop.c:2380 ../src/iop/channelmixerrgb.c:4104
 #: ../src/iop/exposure.c:1097
 msgid "input"
 msgstr "輸入"
 
 #: ../src/develop/blend_gui.c:856 ../src/develop/blend_gui.c:2190
-#: ../src/develop/imageop.c:2379
+#: ../src/develop/imageop.c:2380
 msgid "output"
 msgstr "輸出"
 
 #: ../src/develop/blend_gui.c:867
 msgid " (zoom)"
-msgstr " (縮放)"
+msgstr "（縮放）"
 
 #: ../src/develop/blend_gui.c:872
 msgid " (log)"
-msgstr " (對數)"
+msgstr "（對數）"
 
 #: ../src/develop/blend_gui.c:1704
 msgid "reset to default blend colorspace"
-msgstr "重置爲預設混合顏色空間"
+msgstr "重設為預設色彩空間"
 
 #: ../src/develop/blend_gui.c:1751
 msgid "reset and hide output channels"
-msgstr "重置和隱藏輸出通道"
+msgstr "隱藏輸出色版"
 
 #: ../src/develop/blend_gui.c:1757
 msgid "show output channels"
-msgstr "顯示輸出通道"
+msgstr "顯示輸出色版"
 
 #: ../src/develop/blend_gui.c:1964 ../src/develop/blend_gui.c:2004
-#: ../src/iop/tonecurve.c:1159
+#: ../src/iop/tonecurve.c:1158
 msgid "L"
-msgstr "L"
+msgstr "L*"
 
 #: ../src/develop/blend_gui.c:1964
 msgid "sliders for L channel"
-msgstr "滑動條 - L 通道"
+msgstr "以 Lab 的 L* 明度參數控制混合"
 
-#: ../src/develop/blend_gui.c:1967 ../src/iop/tonecurve.c:1160
+#: ../src/develop/blend_gui.c:1967 ../src/iop/tonecurve.c:1159
 msgid "a"
-msgstr "a"
+msgstr "a*"
 
 #: ../src/develop/blend_gui.c:1967
 msgid "sliders for a channel"
-msgstr "滑動條 - a 通道"
+msgstr "以 Lab 的 a* 紅綠參數控制混合"
 
 #: ../src/develop/blend_gui.c:1969
 msgid "green/red"
-msgstr "綠/紅"
+msgstr "綠色 / 紅色"
 
-#: ../src/develop/blend_gui.c:1970 ../src/iop/tonecurve.c:1161
+#: ../src/develop/blend_gui.c:1970 ../src/iop/tonecurve.c:1160
 msgid "b"
-msgstr "b"
+msgstr "b*"
 
 #: ../src/develop/blend_gui.c:1970
 msgid "sliders for b channel"
-msgstr "滑動條 - b 通道"
+msgstr "以 Lab 的 b* 黃藍參數控制混合"
 
 #: ../src/develop/blend_gui.c:1972
 msgid "blue/yellow"
-msgstr "藍/黃"
+msgstr "藍色 / 黃色"
 
 #: ../src/develop/blend_gui.c:1973
 msgid "C"
@@ -7413,7 +7518,7 @@ msgstr "C"
 
 #: ../src/develop/blend_gui.c:1973
 msgid "sliders for chroma channel (of LCh)"
-msgstr "色度通道滑動條(LCh)"
+msgstr "以 LCh 的 C 色度參數控制混合"
 
 #: ../src/develop/blend_gui.c:1977
 msgid "h"
@@ -7421,48 +7526,48 @@ msgstr "h"
 
 #: ../src/develop/blend_gui.c:1977
 msgid "sliders for hue channel (of LCh)"
-msgstr "色相通道滑動條(LCh)"
+msgstr "以 LCh 的 h 色相參數控制混合"
 
 #: ../src/develop/blend_gui.c:1984 ../src/develop/blend_gui.c:2011
 msgid "g"
-msgstr "g"
+msgstr "gray"
 
 #: ../src/develop/blend_gui.c:1984 ../src/develop/blend_gui.c:2011
 msgid "sliders for gray value"
-msgstr "灰度值滑動條"
+msgstr "以灰階參數控制混合"
 
 #: ../src/develop/blend_gui.c:1987 ../src/develop/blend_gui.c:2014
 #: ../src/iop/channelmixerrgb.c:4181 ../src/iop/denoiseprofile.c:3582
 #: ../src/iop/rawdenoise.c:905 ../src/iop/rgbcurve.c:1369
 #: ../src/iop/rgblevels.c:1013 ../src/libs/filters/colors.c:137
 msgid "R"
-msgstr "紅"
+msgstr "R"
 
 #: ../src/develop/blend_gui.c:1987 ../src/develop/blend_gui.c:2014
 msgid "sliders for red channel"
-msgstr "紅色通道滑動條"
+msgstr "以紅色色版參數控制混合"
 
 #: ../src/develop/blend_gui.c:1990 ../src/develop/blend_gui.c:2017
 #: ../src/iop/channelmixerrgb.c:4182 ../src/iop/denoiseprofile.c:3583
 #: ../src/iop/rawdenoise.c:906 ../src/iop/rgbcurve.c:1370
 #: ../src/iop/rgblevels.c:1014 ../src/libs/filters/colors.c:143
 msgid "G"
-msgstr "綠"
+msgstr "G"
 
 #: ../src/develop/blend_gui.c:1990 ../src/develop/blend_gui.c:2017
 msgid "sliders for green channel"
-msgstr "綠色通道滑動條"
+msgstr "以綠色色版參數控制混合"
 
 #: ../src/develop/blend_gui.c:1993 ../src/develop/blend_gui.c:2020
 #: ../src/iop/channelmixerrgb.c:4183 ../src/iop/denoiseprofile.c:3584
 #: ../src/iop/rawdenoise.c:907 ../src/iop/rgbcurve.c:1371
 #: ../src/iop/rgblevels.c:1015 ../src/libs/filters/colors.c:146
 msgid "B"
-msgstr "藍"
+msgstr "B"
 
 #: ../src/develop/blend_gui.c:1993 ../src/develop/blend_gui.c:2020
 msgid "sliders for blue channel"
-msgstr "藍色通道滑動條"
+msgstr "以藍色色版參數控制混合"
 
 #: ../src/develop/blend_gui.c:1996
 msgid "H"
@@ -7470,7 +7575,7 @@ msgstr "H"
 
 #: ../src/develop/blend_gui.c:1996
 msgid "sliders for hue channel (of HSL)"
-msgstr "色相通道滑動條(HSL)"
+msgstr "以 HSL 的 H 色相參數控制混合"
 
 #: ../src/develop/blend_gui.c:2000
 msgid "S"
@@ -7478,21 +7583,21 @@ msgstr "S"
 
 #: ../src/develop/blend_gui.c:2000
 msgid "sliders for chroma channel (of HSL)"
-msgstr "彩度通道滑動條(HSL)"
+msgstr "以 HSL 的 S 飽和度參數控制混合"
 
 #: ../src/develop/blend_gui.c:2003 ../src/develop/blend_gui.c:2030
-#: ../src/iop/atrous.c:1737 ../src/iop/channelmixerrgb.c:4059
-#: ../src/iop/channelmixerrgb.c:4150 ../src/iop/colorbalancergb.c:2149
-#: ../src/iop/colorbalancergb.c:2150 ../src/iop/colorbalancergb.c:2151
-#: ../src/iop/colorbalancergb.c:2152 ../src/iop/colorbalancergb.c:2159
-#: ../src/iop/colorbalancergb.c:2160 ../src/iop/colorbalancergb.c:2161
+#: ../src/iop/atrous.c:1735 ../src/iop/channelmixerrgb.c:4059
+#: ../src/iop/channelmixerrgb.c:4150 ../src/iop/colorbalancergb.c:2146
+#: ../src/iop/colorbalancergb.c:2147 ../src/iop/colorbalancergb.c:2148
+#: ../src/iop/colorbalancergb.c:2149 ../src/iop/colorbalancergb.c:2156
+#: ../src/iop/colorbalancergb.c:2157 ../src/iop/colorbalancergb.c:2158
 #: ../src/iop/equalizer.c:391 ../src/iop/nlmeans.c:522
 msgid "chroma"
 msgstr "色度"
 
 #: ../src/develop/blend_gui.c:2004
 msgid "sliders for value channel (of HSL)"
-msgstr "明度通道滑動條(HSL)"
+msgstr "以 HSL 的 L 亮度參數控制混合"
 
 #: ../src/develop/blend_gui.c:2023
 msgid "Jz"
@@ -7500,7 +7605,7 @@ msgstr "Jz"
 
 #: ../src/develop/blend_gui.c:2023
 msgid "sliders for value channel (of JzCzhz)"
-msgstr "明度通道滑動條(JzCzhz)"
+msgstr "以 JzCzhz 的 Jz 明度參數控制混合"
 
 #: ../src/develop/blend_gui.c:2027
 msgid "Cz"
@@ -7508,7 +7613,7 @@ msgstr "Cz"
 
 #: ../src/develop/blend_gui.c:2027
 msgid "sliders for chroma channel (of JzCzhz)"
-msgstr "彩度通道滑動條(JzCzhz)"
+msgstr "以 JzCzhz 的 Cz 色度參數控制混合"
 
 #: ../src/develop/blend_gui.c:2031
 msgid "hz"
@@ -7516,7 +7621,7 @@ msgstr "hz"
 
 #: ../src/develop/blend_gui.c:2031
 msgid "sliders for hue channel (of JzCzhz)"
-msgstr "色調通道滑動條(JzCzhz)"
+msgstr "以 JzCzhz 的 hz 色相參數控制混合"
 
 #: ../src/develop/blend_gui.c:2037
 msgid ""
@@ -7525,10 +7630,10 @@ msgid ""
 "* range defined by lower markers: do not blend at all\n"
 "* range between adjacent upper/lower markers: blend gradually"
 msgstr ""
-"基於這個模組收到的輸入的調整:\n"
-"*由上標定義的範圍:完全混合\n"
-"*由下標定義的範圍:完全不混合\n"
-"*相鄰的上/下標之間的範圍:逐漸混合"
+"基於此模組的輸入影像調整混合：\n"
+"上標定義的範圍完全混合\n"
+"下標定義的範圍完全不混合\n"
+"同側的上下標之間的範圍逐步混合"
 
 #: ../src/develop/blend_gui.c:2040
 msgid ""
@@ -7537,30 +7642,31 @@ msgid ""
 "* range defined by lower markers: do not blend at all\n"
 "* range between adjacent upper/lower markers: blend gradually"
 msgstr ""
-"基於這個模組未混合的輸出的調整:\n"
-"*由上標定義的範圍:完全混合\n"
-"*由下標定義的範圍:完全不混合\n"
-"*相鄰的上/下標之間的範圍:逐漸混合"
+"基於此模組調整後但尚未混合的影像混合：\n"
+"上標定義的範圍完全混合\n"
+"下標定義的範圍完全不混合\n"
+"同側的上下標之間的範圍逐步混合"
 
 #: ../src/develop/blend_gui.c:2132
 msgid "reset blend mask settings"
-msgstr "重置混合遮罩設定"
+msgstr "重設色版遮罩設定"
 
-#: ../src/develop/blend_gui.c:2143 ../src/iop/atrous.c:1735
+#: ../src/develop/blend_gui.c:2143 ../src/iop/atrous.c:1733
 #: ../src/iop/colorzones.c:2429 ../src/iop/denoiseprofile.c:3580
 #: ../src/iop/rawdenoise.c:902 ../src/iop/rgbcurve.c:1368
-#: ../src/iop/rgblevels.c:1012 ../src/iop/tonecurve.c:1158
+#: ../src/iop/rgblevels.c:1012 ../src/iop/tonecurve.c:1157
 msgid "channel"
-msgstr "通道"
+msgstr "色版"
 
 #: ../src/develop/blend_gui.c:2153 ../src/iop/colorzones.c:2443
-#: ../src/iop/rgbcurve.c:1378 ../src/iop/tonecurve.c:1167
+#: ../src/iop/rgbcurve.c:1378 ../src/iop/tonecurve.c:1166
 msgid ""
 "pick GUI color from image\n"
 "ctrl+click or right-click to select an area"
 msgstr ""
-"從影像中選取 GUI 顏色\n"
-"控制鍵 + 點擊或右鍵選擇區域"
+"在控制介面上顯示影像中指定像素的顏色位置，以便協助判斷控制節點\n"
+"點擊啟用會顯示一條垂直線，使用滑鼠拖曳像素在影像上的位置\n"
+"ctrl + 點擊或右鍵點擊可選擇區域，該區域像素的顏色範圍在介面中變亮顯示"
 
 #: ../src/develop/blend_gui.c:2160
 msgid ""
@@ -7568,16 +7674,16 @@ msgid ""
 "drag to use the input image\n"
 "ctrl+drag to use the output image"
 msgstr ""
-"依據輸入影像區域來設置範圍\n"
-"控制鍵 + 拖拉 以輸出影像"
+"選取影像中的區域來設定滑桿範圍\n"
+"拖曳以輸入影像的色彩來設定，ctrl + 拖曳使用輸出影像的色彩"
 
 #: ../src/develop/blend_gui.c:2164
 msgid "invert all channel's polarities"
-msgstr "反向所有通道的極性"
+msgstr "反轉所有色版（輸入和輸出）的不透明度設定"
 
 #: ../src/develop/blend_gui.c:2184
 msgid "toggle polarity. best seen by enabling 'display mask'"
-msgstr "正反極性切換。啓用“顯示遮罩”以顯示最好效果"
+msgstr "反轉不透明度設定，建議透過顯示遮罩範圍來確認"
 
 #: ../src/develop/blend_gui.c:2211
 msgid ""
@@ -7586,17 +7692,23 @@ msgid ""
 "press 'c' to toggle view of channel data.\n"
 "press 'm' to toggle mask view."
 msgstr ""
-"雙擊已重置\n"
-"按a 以切換可用的滑動條模式\n"
-"按c 以切換通道資料視角\n"
-"按m以切換遮罩角."
+"使用使用四個三角形節點控制遮罩的不透明度\n"
+"\n"
+"上方實心三角形為不透明度 100% 的位置，中間範圍會套用完全的模組效果\n"
+"下方空心三角形為不透明度 0% 的位置，與實心三角形間的不透明度依比例提升\n"
+"點擊右方的反轉按鈕可切換不透明度定義，實心和空心三角形位置互換作為提示\n"
+"\n"
+"雙擊可重設三角形節點位置\n"
+"按「a」切換為對數或線性座標\n"
+"按「c」切換影像預覽顯示為色版\n"
+"按「m」切換顯示遮罩不透明度"
 
 #: ../src/develop/blend_gui.c:2228 ../src/develop/blend_gui.c:3056
-#: ../src/iop/basicadj.c:600 ../src/iop/colorbalancergb.c:2110
+#: ../src/iop/basicadj.c:600 ../src/iop/colorbalancergb.c:2107
 #: ../src/iop/exposure.c:1033 ../src/iop/exposure.c:1046
 #: ../src/iop/filmic.c:1607 ../src/iop/filmic.c:1619 ../src/iop/filmic.c:1659
-#: ../src/iop/filmicrgb.c:4226 ../src/iop/filmicrgb.c:4236
-#: ../src/iop/filmicrgb.c:4271 ../src/iop/filmicrgb.c:4281
+#: ../src/iop/filmicrgb.c:4227 ../src/iop/filmicrgb.c:4237
+#: ../src/iop/filmicrgb.c:4272 ../src/iop/filmicrgb.c:4282
 #: ../src/iop/graduatednd.c:1098 ../src/iop/negadoctor.c:983
 #: ../src/iop/profile_gamma.c:651 ../src/iop/profile_gamma.c:657
 #: ../src/iop/relight.c:267 ../src/iop/soften.c:404 ../src/iop/toneequal.c:3117
@@ -7605,9 +7717,9 @@ msgstr ""
 #: ../src/iop/toneequal.c:3132 ../src/iop/toneequal.c:3135
 #: ../src/iop/toneequal.c:3138 ../src/iop/toneequal.c:3141
 #: ../src/iop/toneequal.c:3235 ../src/iop/toneequal.c:3242
-#: ../src/iop/toneequal.c:3252 ../src/views/darkroom.c:2383
+#: ../src/iop/toneequal.c:3252 ../src/views/darkroom.c:2384
 msgid " EV"
-msgstr " 曝光值(EV)"
+msgstr " EV"
 
 #: ../src/develop/blend_gui.c:2229 ../src/develop/blend_gui.c:2321
 #: ../src/develop/blend_gui.c:2501 ../src/develop/blend_gui.c:2564
@@ -7620,11 +7732,13 @@ msgstr "混合"
 
 #: ../src/develop/blend_gui.c:2229
 msgid "boost factor"
-msgstr "強化係數"
+msgstr "提升係數"
 
 #: ../src/develop/blend_gui.c:2231
 msgid "adjust the boost factor of the channel mask"
-msgstr "調整通道遮罩的強化係數"
+msgstr ""
+"提高色版遮罩的數值範圍\n"
+"可針對場景參考色彩空間中亮度超過 100% 的範圍調整"
 
 #: ../src/develop/blend_gui.c:2263
 #, c-format
@@ -7635,78 +7749,78 @@ msgstr[0] "已使用 %d 個形狀"
 #: ../src/develop/blend_gui.c:2268 ../src/develop/blend_gui.c:2324
 #: ../src/develop/blend_gui.c:2390 ../src/develop/blend_gui.c:2502
 msgid "no mask used"
-msgstr "沒有使用的遮罩"
+msgstr "沒有使用任何遮罩"
 
 #: ../src/develop/blend_gui.c:2330
 msgid "toggle polarity of drawn mask"
-msgstr "切換繪製遮罩的正反選擇"
+msgstr "反轉範圍遮罩"
 
 #: ../src/develop/blend_gui.c:2337
 msgid "show and edit mask elements"
-msgstr "顯示和編輯遮罩元素"
+msgstr "顯示和編輯遮罩"
 
 #: ../src/develop/blend_gui.c:2337
 msgid "show and edit in restricted mode"
-msgstr "在受限模式中顯示並編輯"
+msgstr "在受限模式下編輯，遮罩的位置和大小被保護避免變更"
 
 #: ../src/develop/blend_gui.c:2342 ../src/libs/masks.c:940
 #: ../src/libs/masks.c:968 ../src/libs/masks.c:1634
 msgid "add gradient"
-msgstr "增加漸層"
+msgstr "增加漸層遮罩"
 
 #: ../src/develop/blend_gui.c:2342
 msgid "add multiple gradients"
-msgstr "增加多個漸層"
+msgstr "增加多個漸層遮罩"
 
 #: ../src/develop/blend_gui.c:2347 ../src/iop/retouch.c:2199
 #: ../src/libs/masks.c:952 ../src/libs/masks.c:1658
 msgid "add brush"
-msgstr "增加筆刷"
+msgstr "增加筆刷遮罩"
 
 #: ../src/develop/blend_gui.c:2347 ../src/iop/retouch.c:2199
 msgid "add multiple brush strokes"
-msgstr "增加多個筆刷筆劃"
+msgstr "增加多個筆刷遮罩"
 
 #: ../src/develop/blend_gui.c:2352 ../src/iop/retouch.c:2203
 #: ../src/iop/spots.c:822 ../src/libs/masks.c:936 ../src/libs/masks.c:964
 #: ../src/libs/masks.c:1640
 msgid "add path"
-msgstr "增加路徑"
+msgstr "增加路徑遮罩"
 
 #: ../src/develop/blend_gui.c:2352 ../src/iop/retouch.c:2203
 #: ../src/iop/spots.c:822
 msgid "add multiple paths"
-msgstr "增加多個路徑"
+msgstr "增加多個路徑遮罩"
 
 #: ../src/develop/blend_gui.c:2357 ../src/iop/retouch.c:2207
 #: ../src/iop/spots.c:826 ../src/libs/masks.c:932 ../src/libs/masks.c:960
 #: ../src/libs/masks.c:1646
 msgid "add ellipse"
-msgstr "增加橢圓"
+msgstr "增加橢圓遮罩"
 
 #: ../src/develop/blend_gui.c:2357 ../src/iop/retouch.c:2207
 #: ../src/iop/spots.c:826
 msgid "add multiple ellipses"
-msgstr "增加多個橢圓"
+msgstr "增加多個橢圓遮罩"
 
 #: ../src/develop/blend_gui.c:2362 ../src/iop/retouch.c:2211
 #: ../src/iop/spots.c:830 ../src/libs/masks.c:928 ../src/libs/masks.c:956
 #: ../src/libs/masks.c:1652
 msgid "add circle"
-msgstr "增加圓圈"
+msgstr "增加圓形遮罩"
 
 #: ../src/develop/blend_gui.c:2362 ../src/iop/retouch.c:2211
 #: ../src/iop/spots.c:830
 msgid "add multiple circles"
-msgstr "增加多個圓圈"
+msgstr "增加多個圓形遮罩"
 
 #: ../src/develop/blend_gui.c:2510
 msgid "toggle polarity of raster mask"
-msgstr "切換網格圖像遮罩的正反選擇"
+msgstr "反轉光柵遮罩"
 
 #: ../src/develop/blend_gui.c:2644
 msgid "normal & difference modes"
-msgstr "正常 和 差分模式"
+msgstr "正常和差異模式"
 
 #: ../src/develop/blend_gui.c:2649
 msgid "lighten modes"
@@ -7723,24 +7837,24 @@ msgstr "對比增強模式"
 #: ../src/develop/blend_gui.c:2667 ../src/develop/blend_gui.c:2680
 #: ../src/develop/blend_gui.c:2705
 msgid "color channel modes"
-msgstr "色彩通道模式"
+msgstr "色版模式"
 
 #: ../src/develop/blend_gui.c:2695
 msgid "normal & arithmetic modes"
-msgstr "正常/算術模式"
+msgstr "正常和計算模式"
 
 #: ../src/develop/blend_gui.c:2709
 msgid "chromaticity & lightness modes"
-msgstr "色度與亮度模式"
+msgstr "色度和明度模式"
 
 #. add deprecated blend mode
 #: ../src/develop/blend_gui.c:2720
 msgid "deprecated modes"
-msgstr "已廢棄模式"
+msgstr "已被汰除的模式"
 
 #: ../src/develop/blend_gui.c:3020
 msgid "blending options"
-msgstr "混合選項"
+msgstr "混合色彩空間"
 
 #: ../src/develop/blend_gui.c:3038 ../src/libs/history.c:859
 msgid "blend mode"
@@ -7748,7 +7862,10 @@ msgstr "混合模式"
 
 #: ../src/develop/blend_gui.c:3039
 msgid "choose blending mode"
-msgstr "選擇混合模式"
+msgstr ""
+"選擇要使用的混合模式，不同模組和混合色彩空間會有不同的選項\n"
+"詳細說明請見操作手冊「Darkroom → masking & blending → blend-modes」章節\n"
+"混合模式中文翻譯後方括弧內保留英文，以便使用者對照查詢"
 
 #: ../src/develop/blend_gui.c:3046
 msgid "toggle blend order"
@@ -7760,17 +7877,20 @@ msgid ""
 "by default the output will be blended on top of the input,\n"
 "order can be reversed by clicking on the icon (input on top of output)"
 msgstr ""
-"切換模組的輸入和輸出之間的混合順序，\n"
-"預設情況下，輸出將在輸入之上混合，\n"
-"順序可以通過點擊圖示逆轉(輸入在輸出之上)。"
+"改變模組的輸入和輸出影像的混合順序\n"
+"預設經過模組效果調整的輸出影像在混合的上層\n"
+"點選圖示可反轉順序，將輸入的影像調整至上層來混合"
 
 #: ../src/develop/blend_gui.c:3055 ../src/libs/history.c:861
 msgid "blend fulcrum"
-msgstr "混合支點"
+msgstr "混合中灰點"
 
 #: ../src/develop/blend_gui.c:3058
 msgid "adjust the fulcrum used by some blending operations"
-msgstr "調整部分混合操作的支點"
+msgstr ""
+"調整某些混合模式操作需要的中灰點\n"
+"傳統混合模式是為了顯示參照流程設計，隱含值域為 0~100% 和中間值 50% 的定義\n"
+"但場景參照流程不受標準動態範圍限制，所以必須由使用者定義中灰點"
 
 #. Add opacity/scale sliders to table
 #: ../src/develop/blend_gui.c:3064 ../src/iop/watermark.c:1122
@@ -7779,17 +7899,26 @@ msgstr "不透明度"
 
 #: ../src/develop/blend_gui.c:3067
 msgid "set the opacity of the blending"
-msgstr "設置混合模式的不透明度"
+msgstr ""
+"設定混合的不透明度\n"
+"若使用一般混合模式，則可藉由此滑桿調整模組的效果強度"
 
 #: ../src/develop/blend_gui.c:3069 ../src/libs/history.c:863
 msgid "combine masks"
-msgstr "結合遮罩"
+msgstr "遮罩合併"
 
 #: ../src/develop/blend_gui.c:3070
 msgid ""
 "how to combine individual drawn mask and different channels of parametric "
 "mask"
-msgstr "如何組合單一的繪製遮罩和不同頻道的參數遮罩"
+msgstr ""
+"選擇如何組合不同色版遮罩與範圍遮罩\n"
+"也可以混合使用每個遮罩設定旁的反轉按鈕改變個別遮罩的設定\n"
+"\n"
+"並且：所有遮罩都有的範圍才會套用效果（遮罩的不透明度相乘）\n"
+"包含：包含所有遮罩的範圍（遮罩轉為透明度後相乘再轉回不透明度）\n"
+"並且和反轉：等同並且模式，但在最後反轉遮罩\n"
+"包含和反轉：等同包含模式，但在最後反轉遮罩"
 
 #: ../src/develop/blend_gui.c:3075 ../src/libs/history.c:871
 msgid "invert mask"
@@ -7797,11 +7926,11 @@ msgstr "反轉遮罩"
 
 #: ../src/develop/blend_gui.c:3076
 msgid "apply mask in normal or inverted mode"
-msgstr "套用正常或反轉模式遮罩"
+msgstr "正常套用遮罩或反轉遮罩"
 
 #: ../src/develop/blend_gui.c:3081
 msgid "details threshold"
-msgstr "細節臨界值"
+msgstr "細節門檻"
 
 #: ../src/develop/blend_gui.c:3083
 msgid ""
@@ -7809,29 +7938,46 @@ msgid ""
 "positive values selects areas with strong details, \n"
 "negative values select flat areas"
 msgstr ""
-"調整細節屏蔽的臨界值(使用 raw 資料)，\n"
-"正值選擇具有強烈細節的區域，\n"
-"負值選擇平坦的區域"
+"依據影像的細節數量來調整遮罩的不透明度\n"
+"數值越大，遮罩適用於細節豐富的區域\n"
+"數值越小，遮罩適用於平坦無細節的區域\n"
+"預設值 0% 代表不使用此功能\n"
+"\n"
+"此功能對於位置靠近的物體分離非常有用，例如主體和散景分離\n"
+"但細節數值取自「去馬賽克」模組，而非使用小波分解\n"
+"所以任何影像編輯模組都不會影響細節判斷，此功能也不適用於非 RAW 檔影像"
 
 #: ../src/develop/blend_gui.c:3088 ../src/libs/history.c:865
 msgid "feathering guide"
-msgstr "羽化導引"
+msgstr "調整遮罩邊緣"
 
 #: ../src/develop/blend_gui.c:3090
 msgid ""
 "choose to guide mask by input or output image and\n"
 "choose to apply feathering before or after mask blur"
 msgstr ""
-"選擇輸入或輸出影像來導引遮罩\n"
-"選擇在遮罩模糊之前或之後套用羽化"
+"柔化遮罩範圍以自動偵測對齊影像中的物體邊緣\n"
+"調整以下參數時建議開啟顯示遮罩範圍功能，以更容易了解效果\n"
+"\n"
+"選項控制判斷物體邊緣的依據\n"
+"是由輸入的影像，或是經此模組調整後（尚未混合前）輸出的影像來導引遮罩\n"
+"\n"
+"並可選擇調整柔化遮罩偵測範圍的時機\n"
+"先柔化後模糊，偵測邊緣之後再套用模糊讓遮罩邊緣平整\n"
+"先模糊後柔化，先模糊原始遮罩再偵測邊緣以保留邊緣細節"
 
 #: ../src/develop/blend_gui.c:3095 ../src/libs/history.c:864
 msgid "feathering radius"
-msgstr "羽化半徑"
+msgstr "柔化半徑"
 
 #: ../src/develop/blend_gui.c:3097
 msgid "spatial radius of feathering"
-msgstr "羽化的空間半徑"
+msgstr ""
+"調整遮罩偵測邊緣的範圍\n"
+"柔化半徑越大，能對齊距離原始遮罩更遠的物體邊緣\n"
+"但如果半徑太大，有可能會納入原本不希望出現的區域\n"
+"原始遮罩與影像中的物體形狀大致符合時才有最好的效果\n"
+"設定為 0 時停用邊緣偵測功能，但下方三項調整仍然有效"
 
 #: ../src/develop/blend_gui.c:3101
 msgid "blurring radius"
@@ -7839,7 +7985,10 @@ msgstr "模糊半徑"
 
 #: ../src/develop/blend_gui.c:3103
 msgid "radius for gaussian blur of blend mask"
-msgstr "混合遮罩的高斯模糊半徑"
+msgstr ""
+"遮罩的高斯模糊半徑\n"
+"越大的半徑可創造更柔和的邊緣過渡，避免邊緣不自然感\n"
+"在邊緣偵測後使用模糊，則可修飾過於生硬的遮罩邊緣"
 
 #: ../src/develop/blend_gui.c:3107 ../src/iop/retouch.c:2413
 #: ../src/libs/history.c:862
@@ -7851,7 +8000,13 @@ msgid ""
 "shifts and tilts the tone curve of the blend mask to adjust its brightness "
 "without affecting fully transparent/fully opaque regions"
 msgstr ""
-"移動和傾斜混合遮罩的色調曲線以調整亮度，而不影響完全透明/完全不透明區域"
+"重新調整補償可能被邊緣偵測和模糊功能改變的遮罩不透明度\n"
+"此參數不影響完全透明和完全不透明的遮罩區域，僅調整中間的半透明區域\n"
+"這是為了確保已完全排除或包含在遮罩裡的區域保持不變\n"
+"\n"
+"實際的內部計算方式是調整遮罩的黑白點\n"
+"如此可把更多的範圍轉變為完全透明或完全不透明，同時讓過渡更強烈\n"
+"就如同以色階或曲線工具左右移動遮罩色版的兩側黑白點"
 
 #: ../src/develop/blend_gui.c:3115 ../src/libs/history.c:867
 msgid "mask contrast"
@@ -7860,15 +8015,21 @@ msgstr "遮罩對比度"
 #: ../src/develop/blend_gui.c:3117
 msgid ""
 "gives the tone curve of the blend mask an s-like shape to adjust its contrast"
-msgstr "將混合遮罩的色調曲線設置爲s形以調整對比"
+msgstr ""
+"調整遮罩的對比，讓完全透明至不透明間的過渡更柔和或強烈\n"
+"\n"
+"實際的內部計算方式是調整遮罩的反差\n"
+"就如同使用曲線工具以 S 形調整遮罩色版的對比度"
 
 #: ../src/develop/blend_gui.c:3121
 msgid "mask refinement"
-msgstr "遮罩精進"
+msgstr "調整遮罩範圍"
 
 #: ../src/develop/blend_gui.c:3124
 msgid "display mask and/or color channel"
-msgstr "顯示遮罩及顏色通道"
+msgstr ""
+"顯示遮罩範圍或色版\n"
+"單擊檢視遮罩並將影像顯示為灰階，黃色代表遮罩不透明度"
 
 #: ../src/develop/blend_gui.c:3126
 msgid ""
@@ -7876,48 +8037,53 @@ msgid ""
 "to display channel. hover over parametric mask slider to select channel for "
 "display"
 msgstr ""
-"顯示遮罩及顏色通道。控制鍵+點擊 可顯示遮罩，shift+點擊 可顯示通道。將滑鼠停"
-"在“參數遮罩”滑動條上以選擇要顯示的通道"
+"顯示遮罩範圍或色版\n"
+"單擊檢視遮罩並將影像顯示為灰階，黃色代表遮罩不透明度\n"
+"shift + 點擊顯示色版，開啟功能後點選要檢視的色版並將滑鼠移至參數滑桿上"
 
 #: ../src/develop/blend_gui.c:3131
 msgid "temporarily switch off blend mask"
-msgstr "臨時關閉混合遮罩"
+msgstr ""
+"暫時關閉遮罩以在不使用遮罩的情況下檢視模組效果\n"
+"混合模式和整體不透明度仍然有效"
 
 #: ../src/develop/blend_gui.c:3133
 msgid "temporarily switch off blend mask. only for module in focus"
-msgstr "臨時關閉混合遮罩。只對目前模組有效"
+msgstr ""
+"暫時關閉遮罩以在不使用遮罩的情況下檢視模組效果\n"
+"混合模式和整體不透明度仍然有效，僅限於使用中的模組"
 
-#: ../src/develop/develop.c:1521 ../src/gui/presets.c:960
+#: ../src/develop/develop.c:1519 ../src/gui/presets.c:960
 msgid "display-referred default"
-msgstr "顯示工作流程預設值"
+msgstr "顯示參照流程預設值"
 
 #. For scene-referred workflow, since filmic doesn't brighten as base curve does,
 #. we need an initial exposure boost. This might be too much in some cases but…
 #. (the preset name is used in develop.c)
-#: ../src/develop/develop.c:1523 ../src/gui/presets.c:962
+#: ../src/develop/develop.c:1521 ../src/gui/presets.c:962
 #: ../src/iop/exposure.c:278 ../src/iop/exposure.c:287
 msgid "scene-referred default"
-msgstr "場景工作流程預設值"
+msgstr "場景參照流程預設值"
 
-#: ../src/develop/develop.c:2002
+#: ../src/develop/develop.c:2000
 #, c-format
 msgid "%s: module `%s' version mismatch: %d != %d"
-msgstr "%s:模組“%s”版本不匹配: %d != %d"
+msgstr "%s：模組「%s」版本不符：%d≠%d"
 
-#: ../src/develop/imageop.c:927
+#: ../src/develop/imageop.c:928
 msgid "new instance"
-msgstr "新實例"
+msgstr "新的模組實例"
 
-#: ../src/develop/imageop.c:933
+#: ../src/develop/imageop.c:934
 msgid "duplicate instance"
-msgstr "複製實例"
+msgstr "複製模組實例"
 
-#: ../src/develop/imageop.c:939 ../src/develop/imageop.c:3220
+#: ../src/develop/imageop.c:940 ../src/develop/imageop.c:3221
 #: ../src/libs/masks.c:1098
 msgid "move up"
 msgstr "向上移動"
 
-#: ../src/develop/imageop.c:945 ../src/develop/imageop.c:3221
+#: ../src/develop/imageop.c:946 ../src/develop/imageop.c:3222
 #: ../src/libs/masks.c:1101
 msgid "move down"
 msgstr "向下移動"
@@ -7925,143 +8091,145 @@ msgstr "向下移動"
 #. delete button label and tooltip will be updated based on trash pref
 #. TODO??? this SHOULD be named "delete group" but because of string freeze for 3.8
 #. we can only do that after 3.8 is released.
-#: ../src/develop/imageop.c:951 ../src/develop/imageop.c:3223
+#: ../src/develop/imageop.c:952 ../src/develop/imageop.c:3224
 #: ../src/gui/accelerators.c:143 ../src/gui/presets.c:477
 #: ../src/libs/image.c:286 ../src/libs/image.c:482 ../src/libs/masks.c:1055
 #: ../src/libs/tagging.c:1480 ../src/libs/tagging.c:1568
 msgid "delete"
 msgstr "刪除"
 
-#: ../src/develop/imageop.c:958 ../src/develop/imageop.c:3224
+#: ../src/develop/imageop.c:959 ../src/develop/imageop.c:3225
 #: ../src/libs/modulegroups.c:3507 ../src/libs/modulegroups.c:3870
 msgid "rename"
 msgstr "重新命名"
 
-#: ../src/develop/imageop.c:1024 ../src/develop/imageop.c:2508
+#: ../src/develop/imageop.c:1025 ../src/develop/imageop.c:2509
 #, c-format
 msgid "%s is switched on"
-msgstr "%s 已打開"
+msgstr "「%s」模組正在使用中"
 
-#: ../src/develop/imageop.c:1024 ../src/develop/imageop.c:2508
+#: ../src/develop/imageop.c:1025 ../src/develop/imageop.c:2509
 #, c-format
 msgid "%s is switched off"
-msgstr "%s 已關"
+msgstr "「%s」模組效果已關閉"
 
-#: ../src/develop/imageop.c:2266
+#: ../src/develop/imageop.c:2267
 msgid "unknown mask"
 msgstr "未知遮罩"
 
-#: ../src/develop/imageop.c:2270
+#: ../src/develop/imageop.c:2271
 msgid "drawn + parametric mask"
-msgstr "繪製 + 參數遮罩"
+msgstr "繪製 + 色版遮罩"
 
-#: ../src/develop/imageop.c:2279
+#: ../src/develop/imageop.c:2280
 #, c-format
 msgid "this module has a `%s'"
-msgstr "此模組有 `%s'"
+msgstr "此模組包含「%s」"
 
-#: ../src/develop/imageop.c:2284
+#: ../src/develop/imageop.c:2285
 #, c-format
 msgid "taken from module %s"
-msgstr "取自模組 %s"
+msgstr "取自「%s」模組"
 
-#: ../src/develop/imageop.c:2289
+#: ../src/develop/imageop.c:2290
 msgid "click to display (module must be activated first)"
-msgstr "點擊顯示(模組必須先啟動)"
+msgstr "點擊顯示（須先啟用模組）"
 
-#: ../src/develop/imageop.c:2379
+#: ../src/develop/imageop.c:2380
 msgid "purpose"
 msgstr "用途"
 
-#: ../src/develop/imageop.c:2379
+#: ../src/develop/imageop.c:2380
 msgid "process"
-msgstr "流程"
+msgstr "運算"
 
-#: ../src/develop/imageop.c:2477
+#: ../src/develop/imageop.c:2478
 msgid ""
 "multiple instance actions\n"
 "right-click creates new instance"
 msgstr ""
-"多個實例行爲\n"
-"右鍵點擊建立新的實例"
+"多個模組實例\n"
+"左鍵選擇操作方式，右鍵快速建立新的實例"
 
-#: ../src/develop/imageop.c:2488
+#: ../src/develop/imageop.c:2489
 msgid ""
 "reset parameters\n"
 "ctrl+click to reapply any automatic presets"
 msgstr ""
-"重置參數\n"
-"控制鍵+單擊 可重新套用任何自動預置"
+"重設參數\n"
+"ctrl + 點擊 重新套用在任何自動預設集上"
 
-#: ../src/develop/imageop.c:2497
+#: ../src/develop/imageop.c:2498
 msgid ""
 "presets\n"
 "right-click to apply on new instance"
 msgstr ""
-"預設\n"
-"單擊滑鼠右鍵可套用於新實例"
+"預設集\n"
+"點擊以選擇預設集套用，或是儲存目前設定為預設集"
 
-#: ../src/develop/imageop.c:2719 ../src/develop/imageop.c:2741
+#: ../src/develop/imageop.c:2720 ../src/develop/imageop.c:2742
 msgid "ERROR"
-msgstr "錯誤"
-
-#: ../src/develop/imageop.c:3124
-msgid "unsupported input"
-msgstr "不支援的輸入"
+msgstr "⚠️ 錯誤 ⚠️"
 
 #: ../src/develop/imageop.c:3125
+msgid "unsupported input"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"不支援的輸入資料"
+
+#: ../src/develop/imageop.c:3126
 msgid ""
 "you have placed this module at\n"
 "a position in the pipeline where\n"
 "the data format does not match\n"
 "its requirements."
 msgstr ""
-"此模組在管線中的位置於此\n"
-"模組的資料格式要求並不匹配。"
+"⚠️ 警告 ⚠️\n"
+"此模組的運算順序（排列位置）不符合資料格式的要求"
 
-#: ../src/develop/imageop.c:3219 ../src/develop/imageop.c:3229
+#: ../src/develop/imageop.c:3220 ../src/develop/imageop.c:3230
 #: ../src/gui/accelerators.c:139 ../src/libs/lib.c:1289
 msgid "show"
 msgstr "顯示"
 
-#: ../src/develop/imageop.c:3222 ../src/libs/modulegroups.c:3353
+#: ../src/develop/imageop.c:3223 ../src/libs/modulegroups.c:3353
 #: ../src/libs/modulegroups.c:3479 ../src/libs/modulegroups.c:3872
 #: ../src/libs/tagging.c:3247
 msgid "new"
-msgstr "新的"
+msgstr "新增"
 
-#: ../src/develop/imageop.c:3225 ../src/libs/duplicate.c:543
+#: ../src/develop/imageop.c:3226 ../src/libs/duplicate.c:543
 #: ../src/libs/image.c:497 ../src/libs/modulegroups.c:3868
 msgid "duplicate"
 msgstr "複製"
 
-#: ../src/develop/imageop.c:3230
-msgid "enable"
-msgstr "啓用"
-
 #: ../src/develop/imageop.c:3231
+msgid "enable"
+msgstr "啟用"
+
+#: ../src/develop/imageop.c:3232
 msgid "focus"
-msgstr "聚焦"
+msgstr "使用中"
 
-#: ../src/develop/imageop.c:3232 ../src/gui/accelerators.c:2228
+#: ../src/develop/imageop.c:3233 ../src/gui/accelerators.c:2227
 msgid "instance"
-msgstr "實例"
+msgstr "多模組實例"
 
-#: ../src/develop/imageop.c:3233 ../src/gui/accelerators.c:105
-#: ../src/gui/accelerators.c:114 ../src/iop/atrous.c:1581
+#: ../src/develop/imageop.c:3234 ../src/gui/accelerators.c:105
+#: ../src/gui/accelerators.c:114 ../src/iop/atrous.c:1579
 #: ../src/libs/lib.c:1290 ../src/libs/modulegroups.c:3936
 msgid "reset"
-msgstr "重置"
+msgstr "重設"
 
 #. Adding the outer container
-#: ../src/develop/imageop.c:3234 ../src/gui/preferences.c:774
+#: ../src/develop/imageop.c:3235 ../src/gui/preferences.c:774
 #: ../src/libs/lib.c:1291
 msgid "presets"
-msgstr "預置"
+msgstr "預設集"
 
-#: ../src/develop/imageop.c:3246
+#: ../src/develop/imageop.c:3247
 msgid "processing module"
-msgstr "處理模組"
+msgstr "編輯模組"
 
 #: ../src/develop/imageop_gui.c:281
 #, c-format
@@ -8069,29 +8237,29 @@ msgid ""
 "%s\n"
 "ctrl+click to %s"
 msgstr ""
-"%s\n"
-"Ctrl+單擊 %s"
+"「%s」\n"
+"ctrl + 點擊以「%s」"
 
 #: ../src/develop/lightroom.c:1083
 msgid "cannot find lightroom XMP!"
-msgstr "找不到 lightroom XMP！"
+msgstr "找不到 lightroom XMP"
 
 #: ../src/develop/lightroom.c:1115 ../src/develop/lightroom.c:1137
 #: ../src/develop/lightroom.c:1157
 #, c-format
 msgid "`%s' not a lightroom XMP!"
-msgstr "“%s”不是 lightroom XMP！"
+msgstr "「%s」 不是有效的 lightroom XMP"
 
 #: ../src/develop/lightroom.c:1556
 #, c-format
 msgid "%s has been imported"
 msgid_plural "%s have been imported"
-msgstr[0] "%s 輸入成功"
+msgstr[0] "「%s」已匯入"
 
 #: ../src/develop/masks/brush.c:1117 ../src/develop/masks/brush.c:1174
 #, c-format
 msgid "hardness: %3.2f%%"
-msgstr "硬度:%3.2f%%"
+msgstr "筆刷硬度：%3.2f%%"
 
 #: ../src/develop/masks/brush.c:1141 ../src/develop/masks/brush.c:1222
 #: ../src/develop/masks/brush.c:1229 ../src/develop/masks/circle.c:122
@@ -8099,23 +8267,23 @@ msgstr "硬度:%3.2f%%"
 #: ../src/develop/masks/ellipse.c:642 ../src/develop/masks/path.c:1107
 #, c-format
 msgid "size: %3.2f%%"
-msgstr "大小:%3.2f%%"
+msgstr "筆刷大小：%3.2f%%"
 
 #: ../src/develop/masks/brush.c:2936
 msgid "[BRUSH creation] change size"
-msgstr "[筆刷建立]更改大小"
+msgstr "[筆刷建立] 變更尺寸"
 
 #: ../src/develop/masks/brush.c:2938
 msgid "[BRUSH creation] change hardness"
-msgstr "[筆刷建立]更改硬度"
+msgstr "[筆刷建立] 變更硬度"
 
 #: ../src/develop/masks/brush.c:2939
 msgid "[BRUSH] change opacity"
-msgstr "[筆刷]更改不透明度"
+msgstr "[筆刷] 變更不透明度"
 
 #: ../src/develop/masks/brush.c:2940
 msgid "[BRUSH] change hardness"
-msgstr "[筆刷]更改硬度"
+msgstr "[筆刷] 變更硬度"
 
 #: ../src/develop/masks/brush.c:2951
 #, c-format
@@ -8128,31 +8296,31 @@ msgid ""
 "<b>size</b>: scroll, <b>hardness</b>: shift+scroll\n"
 "<b>opacity</b>: ctrl+scroll (%d%%)"
 msgstr ""
-"<b>大小</b>:滑鼠滾輪，<b>硬度</b>:shift + 滾輪\n"
-"<b>不透明度</b>:控制鍵 + 滾輪 (%d%%)"
+"拖曳以移動，滑鼠滾輪調整尺寸，a + 滾輪回復縮放預覽比例\n"
+"shift + 滾輪調整硬度，ctrl + 滾輪調整不透明度（%d%%）"
 
 #: ../src/develop/masks/brush.c:2963
 msgid "<b>size</b>: scroll"
-msgstr "<b>大小</b>:滑鼠滾輪"
+msgstr "滑鼠滾輪調整尺寸"
 
 #: ../src/develop/masks/circle.c:109 ../src/develop/masks/circle.c:159
 #: ../src/develop/masks/ellipse.c:527 ../src/develop/masks/ellipse.c:612
 #: ../src/develop/masks/path.c:1044 ../src/develop/masks/path.c:1051
 #, c-format
 msgid "feather size: %3.2f%%"
-msgstr "羽化大小:%3.2f%%"
+msgstr "羽化範圍： %3.2f%%"
 
 #: ../src/develop/masks/circle.c:1331
 msgid "[CIRCLE] change size"
-msgstr "[圓形]更改大小"
+msgstr "[圓形] 變更尺寸"
 
 #: ../src/develop/masks/circle.c:1332
 msgid "[CIRCLE] change opacity"
-msgstr "[圓形]更改不透明度"
+msgstr "[圓形] 變更不透明度"
 
 #: ../src/develop/masks/circle.c:1333
 msgid "[CIRCLE] change feather size"
-msgstr "[圓形]更改羽化大小"
+msgstr "[圓形] 變更羽化範圍"
 
 #: ../src/develop/masks/circle.c:1353
 #, c-format
@@ -8165,29 +8333,29 @@ msgid ""
 "<b>size</b>: scroll, <b>feather size</b>: shift+scroll\n"
 "<b>opacity</b>: ctrl+scroll (%d%%)"
 msgstr ""
-"<b>大小</b>:滑鼠滾輪，<b>羽化大小</b>:shift + 滾輪\n"
-"<b>不透明度</b>:控制鍵 + 滾輪 (%d%%)"
+"拖曳以移動，滑鼠滾輪調整尺寸，a + 滾輪回復縮放預覽比例\n"
+"shift + 滾輪調整羽化範圍，ctrl + 滾輪調整不透明度（%d%%）"
 
 #: ../src/develop/masks/ellipse.c:491 ../src/develop/masks/ellipse.c:593
 #, c-format
 msgid "rotation: %3.f°"
-msgstr "旋轉角度:%3.f°"
+msgstr "旋轉角度： %3.f°"
 
 #: ../src/develop/masks/ellipse.c:2148
 msgid "[ELLIPSE] change size"
-msgstr "[橢圓形]更改大小"
+msgstr "[橢圓] 變更尺寸"
 
 #: ../src/develop/masks/ellipse.c:2149
 msgid "[ELLIPSE] change opacity"
-msgstr "[橢圓形]更改不透明度"
+msgstr "[橢圓] 變更不透明度"
 
 #: ../src/develop/masks/ellipse.c:2150
 msgid "[ELLIPSE] switch feathering mode"
-msgstr "[橢圓形]切換羽化模式"
+msgstr "[橢圓] 變更羽化模式"
 
 #: ../src/develop/masks/ellipse.c:2151
 msgid "[ELLIPSE] rotate shape"
-msgstr "[橢圓形]旋轉形狀"
+msgstr "[橢圓] 旋轉形狀"
 
 #: ../src/develop/masks/ellipse.c:2157
 #, c-format
@@ -8200,53 +8368,53 @@ msgid ""
 "<b>size</b>: scroll, <b>feather size</b>: shift+scroll\n"
 "<b>rotation</b>: ctrl+shift+scroll, <b>opacity</b>: ctrl+scroll (%d%%)"
 msgstr ""
-"<b>大小</b>:滑鼠滾輪，<b>羽化大小</b>:shift + 滾輪\n"
-"<b>旋轉</b>:控制鍵 + shift + 滾輪，<b>不透明度</b>:控制鍵 + 滾輪 (%d%%)"
+"拖曳以移動，滑鼠滾輪調整尺寸，a + 滾輪回復縮放預覽比例\n"
+"shift + 滾輪調整羽化範圍，ctrl + 滾輪調整不透明度（%d%%），ctrl + shift + 滾"
+"輪旋轉角度"
 
 #: ../src/develop/masks/ellipse.c:2189
 msgid "<b>rotate</b>: ctrl+drag"
-msgstr "<b>旋轉</b>:控制鍵 + 拖拉"
+msgstr "ctrl + 拖曳以旋轉"
 
 #: ../src/develop/masks/ellipse.c:2192
 #, c-format
 msgid ""
 "<b>feather mode</b>: shift+click, <b>rotate</b>: ctrl+drag\n"
-"<b>size</b>: scroll, <b>feather size</b>: shift+scroll, <b>opacity</b>: "
-"ctrl+scroll (%d%%)"
+"<b>size</b>: scroll, <b>feather size</b>: shift+scroll, <b>opacity</b>: ctrl"
+"+scroll (%d%%)"
 msgstr ""
-"<b>羽化模式</b>:shift + 單擊，<b>旋轉</b>:控制鍵 + 拖拉\n"
-"<b>大小</b>:滑鼠滾輪，<b>羽化大小</b>:shift + 滾動，<b>不透明度</b>:控制鍵 + "
-"滾輪 (%d%%)"
+"shift + 點擊變更羽化模式，ctrl + 拖曳旋轉角度\n"
+"滑鼠滾輪調整尺寸，shift + 滾輪調整羽化範圍，ctrl + 滾輪調整不透明度（%d%%）"
 
 #: ../src/develop/masks/gradient.c:101 ../src/develop/masks/gradient.c:140
 #, c-format
 msgid "compression: %3.2f%%"
-msgstr "壓縮:%3.2f%%"
+msgstr "羽化：%3.2f%%"
 
 #: ../src/develop/masks/gradient.c:111 ../src/develop/masks/gradient.c:150
 #, c-format
 msgid "curvature: %3.2f%%"
-msgstr "曲率:%3.2f%%"
+msgstr "曲率： %3.2f%%"
 
 #: ../src/develop/masks/gradient.c:1439
 msgid "[GRADIENT on pivot] rotate shape"
-msgstr "[漸層樞紐上]旋轉形狀"
+msgstr "[漸層樞紐] 旋轉"
 
 #: ../src/develop/masks/gradient.c:1440
 msgid "[GRADIENT creation] set rotation"
-msgstr "[漸層產生]設定旋轉角度"
+msgstr "[漸層建立] 設定旋轉"
 
 #: ../src/develop/masks/gradient.c:1441
 msgid "[GRADIENT] change curvature"
-msgstr "[漸層]更改曲率"
+msgstr "[漸層] 改變曲率"
 
 #: ../src/develop/masks/gradient.c:1442
 msgid "[GRADIENT] change compression"
-msgstr "[漸層]更改壓縮"
+msgstr "[漸變] 改變羽化範圍"
 
 #: ../src/develop/masks/gradient.c:1443
 msgid "[GRADIENT] change opacity"
-msgstr "[漸層]更改不透明度"
+msgstr "[漸變] 改變不透明度"
 
 #: ../src/develop/masks/gradient.c:1455
 #, c-format
@@ -8259,8 +8427,8 @@ msgid ""
 "<b>curvature</b>: scroll, <b>compression</b>: shift+scroll\n"
 "<b>rotation</b>: click+drag, <b>opacity</b>: ctrl+scroll (%d%%)"
 msgstr ""
-"<b>曲率</b>:滾輪，<b>壓縮</b>:shift + 滾輪\n"
-"<b>旋轉</b>:單擊並拖拉，<b>不透明度</b>:控制鍵 + 滾輪 (%d%%)"
+"滑鼠滾輪調整曲率，拖曳以旋轉角度\n"
+"shift + 滾輪調整羽化範圍，ctrl + 滾輪調整不透明度（%d%%）"
 
 #: ../src/develop/masks/gradient.c:1467
 #, c-format
@@ -8268,83 +8436,83 @@ msgid ""
 "<b>curvature</b>: scroll, <b>compression</b>: shift+scroll\n"
 "<b>opacity</b>: ctrl+scroll (%d%%)"
 msgstr ""
-"<b>曲率</b>:滾輪，<b>壓縮</b>:shift + 滾輪\n"
-"<b>不透明度</b>:控制鍵 + 滾輪 (%d%%)"
+"滑鼠滾輪調整曲率\n"
+"shift + 滾輪調整羽化範圍，ctrl + 滾輪調整不透明度（%d%%）"
 
 #: ../src/develop/masks/gradient.c:1470
 msgid "<b>rotate</b>: drag"
-msgstr "<b>旋轉</b>:拖拉"
+msgstr "拖曳以旋轉"
 
 #: ../src/develop/masks/masks.c:132
 msgid "[SHAPE] remove shape"
-msgstr "[形狀]移除形狀"
+msgstr "[形狀] 刪除形狀"
 
 #: ../src/develop/masks/masks.c:391
 #, c-format
 msgid "copy of %s"
-msgstr "%s 的副本"
+msgstr "「%s」的複本"
 
 #: ../src/develop/masks/masks.c:918
 #, c-format
 msgid "%s: mask version mismatch: %d != %d"
-msgstr "%s:遮罩版本不匹配:%d != %d"
+msgstr "「%s」： 遮罩版本不符合： %d ！= %d"
 
 #: ../src/develop/masks/masks.c:1150 ../src/develop/masks/masks.c:1762
 #, c-format
 msgid "opacity: %d%%"
-msgstr "不透明度: %d%%"
+msgstr "不透明度： %d%%"
 
 #: ../src/develop/masks/masks.c:1520 ../src/libs/masks.c:1029
 msgid "add existing shape"
-msgstr "增加現有形狀"
+msgstr "增加現有的遮罩"
 
 #: ../src/develop/masks/masks.c:1542
 msgid "use same shapes as"
-msgstr "使用與...相同的形狀"
+msgstr "使用與其他模組相同的遮罩"
 
 #: ../src/develop/masks/masks.c:1840
 msgid "masks can not contain themselves"
-msgstr "遮罩不能包括自身"
+msgstr "遮罩不能包含自己本身"
 
 #: ../src/develop/masks/path.c:3131
 msgid "[PATH creation] add a smooth node"
-msgstr "[路徑建立]增加平滑節點"
+msgstr "[路徑建立] 增加平滑節點"
 
 #: ../src/develop/masks/path.c:3133
 msgid "[PATH creation] add a sharp node"
-msgstr "[路徑建立]增加尖銳節點"
+msgstr "[路徑建立] 增加轉角節點"
 
 #: ../src/develop/masks/path.c:3134
 msgid "[PATH creation] terminate path creation"
-msgstr "[路徑建立]終止建立路徑"
+msgstr "[路徑建立] 終止路徑建立"
 
 #: ../src/develop/masks/path.c:3136
 msgid "[PATH on node] switch between smooth/sharp node"
-msgstr "[路徑節點]切換平滑/尖銳節點"
+msgstr "[路徑節點] 切換平滑 / 轉角節點"
 
 #: ../src/develop/masks/path.c:3137
 msgid "[PATH on node] remove the node"
-msgstr "[路徑節點]刪除節點"
+msgstr "[節點節點] 刪除節點"
 
 #: ../src/develop/masks/path.c:3138
 msgid "[PATH on feather] reset curvature"
-msgstr "[路徑羽化]重置曲率"
+msgstr "[路徑羽化] 重設曲率"
 
 #: ../src/develop/masks/path.c:3140
 msgid "[PATH on segment] add node"
-msgstr "[路徑線段]增加節點"
+msgstr "[路徑線段] 增加節點"
 
 #: ../src/develop/masks/path.c:3141
 msgid "[PATH] change size"
-msgstr "[路徑]更改大小"
+msgstr "[路徑] 變更尺寸"
 
 #: ../src/develop/masks/path.c:3142
 msgid "[PATH] change opacity"
-msgstr "[路徑]更改不透明度"
+msgstr "[路徑] 變更不透明度"
 
 #: ../src/develop/masks/path.c:3143
 msgid "[PATH] change feather size"
-msgstr "[路徑]更改羽化大小"
+msgstr "[路徑] 變更羽化範圍"
 
 #: ../src/develop/masks/path.c:3154
 #, c-format
@@ -8356,100 +8524,102 @@ msgid ""
 "<b>add node</b>: click, <b>add sharp node</b>:ctrl+click\n"
 "<b>cancel</b>: right-click"
 msgstr ""
-"<b>增加節點</b>:單擊，<b>增加尖銳節點</b>:控制鍵 + 單擊\n"
-"<b>取消</b>:右鍵單擊"
+"點擊以增加平滑節點，ctrl + 點擊增加轉角節點\n"
+"右鍵完成路徑"
 
 #: ../src/develop/masks/path.c:3164
 msgid ""
 "<b>add node</b>: click, <b>add sharp node</b>:ctrl+click\n"
 "<b>finish path</b>: right-click"
 msgstr ""
-"<b>增加節點</b>:單擊，<b>增加尖銳節點</b>:控制鍵 + 單擊\n"
-"<b>完成路徑</b>:右鍵單擊"
+"點擊以增加平滑節點，ctrl + 點擊增加轉角節點\n"
+"右鍵完成路徑"
 
 #: ../src/develop/masks/path.c:3167
 msgid ""
 "<b>move node</b>: drag, <b>remove node</b>: right-click\n"
 "<b>switch smooth/sharp mode</b>: ctrl+click"
 msgstr ""
-"<b>移動節點</b>:拖拉，<b>移除節點</b>:右鍵單擊\n"
-"<b>切換平滑/尖銳模式</b>:控制鍵 + 單擊"
+"拖曳以移動節點，右鍵刪除節點\n"
+"ctrl + 點擊切換平滑或轉角節點"
 
 #: ../src/develop/masks/path.c:3170
 msgid ""
 "<b>node curvature</b>: drag\n"
 "<b>reset curvature</b>: right-click"
 msgstr ""
-"<b>節點曲率</b>:拖拉\n"
-"<b>重置曲率</b>:右鍵單擊"
+"拖曳以調整節點曲率\n"
+"右鍵重設曲率"
 
 #: ../src/develop/masks/path.c:3172
 msgid ""
 "<b>move segment</b>: drag\n"
 "<b>add node</b>: ctrl+click"
 msgstr ""
-"<b>移動區段</b>:拖拉\n"
-"<b>增加節點</b>:控制鍵 + 單擊"
+"拖曳以移動線段\n"
+"ctrl + 點擊增加節點"
 
-#: ../src/develop/pixelpipe_hb.c:394
+#: ../src/develop/pixelpipe_hb.c:395
 msgid "enabled as required"
-msgstr "由於處理要求必須啓用"
+msgstr "由於影像處理必須，強制啟用此模組"
 
-#: ../src/develop/pixelpipe_hb.c:394
+#: ../src/develop/pixelpipe_hb.c:395
 msgid ""
 "history had module disabled but it is required for this type of image.\n"
 "likely introduced by applying a preset, style or history copy&paste"
 msgstr ""
-"根據歷史資訊此模組未啓用，但對此影像此模組必須啓用。\n"
-"此問題可能由預置，樣式或複製及貼上歷史資訊導致"
+"歷史記錄中停用此模組，但對此類型的影像是必須的處理步驟\n"
+"錯誤有可能是透過套用預設集，或是貼上影像編輯歷史記錄而導致"
 
-#: ../src/develop/pixelpipe_hb.c:396
+#: ../src/develop/pixelpipe_hb.c:397
 msgid "disabled as not appropriate"
-msgstr "由於不適用而不啟用"
+msgstr "影像不適用此模組故不啟用"
 
-#: ../src/develop/pixelpipe_hb.c:396
+#: ../src/develop/pixelpipe_hb.c:397
 msgid ""
 "history had module enabled but it is not allowed for this type of image.\n"
 "likely introduced by applying a preset, style or history copy&paste"
 msgstr ""
-"根據歷史資訊此模組已啓用，但對此影像而言此模組不可用。\n"
-"此問題可能由預置，樣式或複製及貼上歷史資訊導致"
+"歷史記錄中啟用此模組，但模組不適用於此類型的影像\n"
+"錯誤有可能是透過套用預設集，或是貼上影像編輯歷史記錄而導致"
 
-#: ../src/develop/pixelpipe_hb.c:2231
+#: ../src/develop/pixelpipe_hb.c:2265
 msgid ""
 "darktable discovered problems with your OpenCL setup; disabling OpenCL for "
 "this session!"
-msgstr "darktable 偵測到 OpenCL 設定問題； 此期間中不使用OpenCL！"
+msgstr "darktable 發現 OpenCL 存在問題，正在為這個工作階段停用 OpenCL"
 
-#: ../src/develop/tiling.c:833 ../src/develop/tiling.c:1167
+#: ../src/develop/tiling.c:830 ../src/develop/tiling.c:1164
 #, c-format
 msgid "tiling failed for module '%s'. output might be garbled."
-msgstr "模組“%s”分塊失敗。輸出可能會出現混亂。"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"模組「%s」平舖失敗，匯出影像可能會出現錯誤"
 
 #: ../src/dtgtk/culling.c:232
 msgid "you have reached the start of your selection"
-msgstr "你已到達所選內容開頭"
+msgstr "已是選取影像的第一張"
 
 #: ../src/dtgtk/culling.c:241
 msgid "you have reached the start of your collection"
-msgstr "你已到達該集合開頭"
+msgstr "已是相冊的第一張"
 
 #: ../src/dtgtk/culling.c:286
 msgid "you have reached the end of your selection"
-msgstr "你已到達所選內容終點"
+msgstr "已是選取影像的最後一張"
 
 #: ../src/dtgtk/culling.c:311
 msgid "you have reached the end of your collection"
-msgstr "你已到達該集合終點"
+msgstr "已是相冊的最後一張"
 
 #: ../src/dtgtk/culling.c:405
 #, c-format
 msgid "zooming is limited to %d images"
-msgstr "縮放僅在 %d 張影像以下可用"
+msgstr "縮放預覽僅限 %d 張影像"
 
-#: ../src/dtgtk/culling.c:999
+#: ../src/dtgtk/culling.c:1000
 msgid "no image selected !"
-msgstr "沒有選定圖片！"
+msgstr "請先選擇欲比較的影像"
 
 #: ../src/dtgtk/range.c:211 ../src/dtgtk/range.c:216
 msgid "invalid"
@@ -8458,7 +8628,7 @@ msgstr "無效"
 #: ../src/dtgtk/range.c:328
 #, c-format
 msgid "year %s"
-msgstr "%s年"
+msgstr "%s 年"
 
 #: ../src/dtgtk/range.c:406
 msgid ""
@@ -8467,8 +8637,8 @@ msgid ""
 "right-click to select from existing values"
 msgstr ""
 "輸入最小值\n"
-"使用最小如果沒有限制\n"
-"右擊以選擇已存在數值"
+"「min」代表不限制\n"
+"右鍵點擊從現有數值中選取"
 
 #: ../src/dtgtk/range.c:412
 msgid ""
@@ -8477,8 +8647,8 @@ msgid ""
 "right-click to select from existing values"
 msgstr ""
 "輸入最大值\n"
-"使用最大如果沒有限制\n"
-"右擊以選擇已存在數值"
+"「max」代表不限制\n"
+"右鍵點擊從現有數值中選取"
 
 #: ../src/dtgtk/range.c:418
 msgid ""
@@ -8486,7 +8656,7 @@ msgid ""
 "right-click to select from existing values"
 msgstr ""
 "輸入數值\n"
-"右擊以選擇已存在數值"
+"右鍵從現有數值中選取"
 
 #: ../src/dtgtk/range.c:423
 msgid ""
@@ -8496,10 +8666,11 @@ msgid ""
 "use '-' prefix for relative date\n"
 "right-click to select from calendar or existing values"
 msgstr ""
-"輸入以YYYY:MM:DD hh:mm:ss.sss格式最小日期(年份是必須的)\n"
-"使用最小如果沒有限制\n"
-"對相對日期使用前綴 - \n"
-"右擊以選擇自行事曆或已存在數值"
+"以此格式輸入起始時間\n"
+"YYYY:MM:DD hh:mm:ss（只有年份是絕對必要的）\n"
+"輸入「min」不限制起始時間\n"
+"前綴「-」符號設定相對時間\n"
+"右鍵點擊可從日曆選擇"
 
 #: ../src/dtgtk/range.c:431
 msgid ""
@@ -8510,11 +8681,12 @@ msgid ""
 "use '-' prefix for relative date\n"
 "right-click to select from calendar or existing values"
 msgstr ""
-"輸入以YYYY:MM:DD hh:mm:ss.sss格式最大日期(年份是必須的)\n"
-"使用最大如果沒有限制\n"
-"現在(now)系統可以處理 \n"
-"對相對日期使用前綴 - \n"
-"右擊以選擇自行事曆或已存在數值"
+"以此格式輸入結束時間\n"
+"YYYY:MM:DD hh:mm:ss（只有年份是絕對必要的）\n"
+"輸入「max」不限制結束時間\n"
+"支援「now」指定現在時間\n"
+"前綴「-」符號設定相對時間\n"
+"右鍵點擊可從日曆選擇"
 
 #: ../src/dtgtk/range.c:440
 msgid ""
@@ -8522,24 +8694,25 @@ msgid ""
 "in the form YYYY:MM:DD hh:mm:ss.sss (only the year is mandatory)\n"
 "right-click to select from calendar or existing values"
 msgstr ""
-"輸入以YYYY:MM:DD hh:mm:ss.sss格式日期(年份是必須的)\n"
-"右擊以選擇自行事曆或已存在數值"
+"以此格式輸入日期\n"
+"YYYY:MM:DD hh:mm:ss（只有年份是絕對必要的）\n"
+"右鍵點擊可從日曆選擇"
 
 #: ../src/dtgtk/range.c:462
 msgid "date-time interval to subtract from the max value"
-msgstr "日期-時間區間為從最大值減去"
+msgstr "從開始時間（最小值）往後加的時間"
 
 #: ../src/dtgtk/range.c:466
 msgid "date-time interval to add to the min value"
-msgstr "日期-時間區間為自加上最小值"
+msgstr "從結束時間（最大值）往回算的時間"
 
 #: ../src/dtgtk/range.c:487
 msgid "fixed"
-msgstr "修正"
+msgstr "絕對"
 
-#: ../src/dtgtk/range.c:488 ../src/iop/colorchecker.c:1382
+#: ../src/dtgtk/range.c:488 ../src/iop/colorchecker.c:1385
 msgid "relative"
-msgstr "相對的"
+msgstr "相對"
 
 #: ../src/dtgtk/range.c:611 ../src/dtgtk/range.c:1723 ../src/dtgtk/range.c:1774
 #: ../src/libs/colorpicker.c:53
@@ -8553,7 +8726,7 @@ msgstr "最大"
 
 #: ../src/dtgtk/range.c:931
 msgid "date type"
-msgstr "日期型態"
+msgstr "日期格式"
 
 #. the date section
 #: ../src/dtgtk/range.c:942
@@ -8566,19 +8739,19 @@ msgid ""
 "double click to use the date directly"
 msgstr ""
 "單擊以選擇日期\n"
-"雙擊直接使用日期"
+"雙擊直接套用該日期"
 
 #: ../src/dtgtk/range.c:960
 msgid "years: "
-msgstr "年 "
+msgstr "年："
 
 #: ../src/dtgtk/range.c:968
 msgid "months: "
-msgstr "月 "
+msgstr "月："
 
 #: ../src/dtgtk/range.c:976
 msgid "days: "
-msgstr "日 "
+msgstr "日："
 
 #. the time section
 #: ../src/dtgtk/range.c:988
@@ -8587,7 +8760,7 @@ msgstr "時間"
 
 #: ../src/dtgtk/range.c:1036
 msgid "current date: "
-msgstr "目前時間 "
+msgstr "目前： "
 
 #: ../src/dtgtk/range.c:1040 ../src/dtgtk/range.c:1742
 #: ../src/dtgtk/range.c:1793
@@ -8596,7 +8769,7 @@ msgstr "現在"
 
 #: ../src/dtgtk/range.c:1042
 msgid "set the value to always match current datetime"
-msgstr "設定此數值以比對現在日期及時間"
+msgstr "將數值設定為目前時間"
 
 #. apply button
 #: ../src/dtgtk/range.c:1045 ../src/gui/accelerators.c:149
@@ -8607,12 +8780,12 @@ msgstr "套用"
 
 #: ../src/dtgtk/range.c:1046
 msgid "set the range bound with this value"
-msgstr "以此值設定範圍限制"
+msgstr "設定為目前的選取時間"
 
 #. get nice text for bounds
 #. Side-border hide/show
-#: ../src/dtgtk/range.c:1718 ../src/gui/accelerators.c:1978
-#: ../src/gui/accelerators.c:2057 ../src/gui/gtk.c:1192 ../src/gui/gtk.c:2917
+#: ../src/dtgtk/range.c:1718 ../src/gui/accelerators.c:1977
+#: ../src/gui/accelerators.c:2056 ../src/gui/gtk.c:1192 ../src/gui/gtk.c:2917
 #: ../src/imageio/format/pdf.c:659 ../src/iop/denoiseprofile.c:3581
 #: ../src/iop/lens.cc:2274 ../src/iop/rawdenoise.c:904
 #: ../src/libs/collect.c:3153 ../src/libs/filtering.c:1424
@@ -8623,7 +8796,7 @@ msgstr "全部"
 
 #: ../src/dtgtk/resetlabel.c:59
 msgid "double-click to reset"
-msgstr "雙擊以重置"
+msgstr "雙擊以重設"
 
 #: ../src/dtgtk/thumbnail.c:92 ../src/dtgtk/thumbnail.c:122
 msgid "current"
@@ -8631,7 +8804,7 @@ msgstr "目前"
 
 #: ../src/dtgtk/thumbnail.c:92 ../src/dtgtk/thumbnail.c:98
 msgid "leader"
-msgstr "第一張"
+msgstr "群組封面圖"
 
 #: ../src/dtgtk/thumbnail.c:98
 msgid ""
@@ -8639,124 +8812,124 @@ msgid ""
 "click here to set this image as group leader\n"
 msgstr ""
 "\n"
-"在此單擊以設定此影像為分組裡首張\n"
+"點擊這裡將這個影像設置為群組封面\n"
 
 #. and the number of grouped images
 #: ../src/dtgtk/thumbnail.c:133 ../src/libs/filters/grouping.c:144
 #: ../src/libs/filters/grouping.c:169
 msgid "grouped images"
-msgstr "分組影像"
+msgstr "群組影像"
 
 #: ../src/dtgtk/thumbnail.c:714 ../src/dtgtk/thumbnail.c:1448
 #: ../src/iop/ashift.c:5768 ../src/iop/ashift.c:5835 ../src/iop/ashift.c:5836
 #: ../src/iop/ashift.c:5837
 msgid "fit"
-msgstr "符合"
+msgstr "校正"
 
-#: ../src/dtgtk/thumbtable.c:972 ../src/views/slideshow.c:376
+#: ../src/dtgtk/thumbtable.c:983 ../src/views/slideshow.c:376
 msgid "there are no images in this collection"
-msgstr "目前集合中無影像"
+msgstr "這個相冊中沒有任何影像"
 
-#: ../src/dtgtk/thumbtable.c:979
+#: ../src/dtgtk/thumbtable.c:990
 msgid "if you have not imported any images yet"
-msgstr "若尚未輸入任何影像"
+msgstr "如果尚未匯入任何影像"
 
-#: ../src/dtgtk/thumbtable.c:983
+#: ../src/dtgtk/thumbtable.c:994
 msgid "you can do so in the import module"
-msgstr "可在輸入模組做這些"
+msgstr "可以在「影像匯入」模組中執行此操作"
 
-#: ../src/dtgtk/thumbtable.c:991
+#: ../src/dtgtk/thumbtable.c:1002
 msgid "try to relax the filter settings in the top panel"
-msgstr "使用頂部面板的過濾器設定"
+msgstr "使用上方面板的篩選設定"
 
-#: ../src/dtgtk/thumbtable.c:1000
+#: ../src/dtgtk/thumbtable.c:1011
 msgid "or add images in the collections module in the left panel"
-msgstr "或者增加影像至左面板的集合模組"
+msgstr "或從左側面板的相冊模組中加入影像"
 
-#: ../src/dtgtk/thumbtable.c:1241
+#: ../src/dtgtk/thumbtable.c:1252
 msgid ""
 "you have changed the settings related to how thumbnails are generated.\n"
-msgstr "你已經改變了如何產生縮圖有關的設定。\n"
+msgstr "您已改變生成縮圖的設定\n"
 
-#: ../src/dtgtk/thumbtable.c:1243
+#: ../src/dtgtk/thumbtable.c:1254
 msgid ""
 "all cached thumbnails need to be invalidated.\n"
 "\n"
 msgstr ""
-"所有快取縮圖都要被清除。\n"
+"所有的快取縮圖都會失效。\n"
 "\n"
 
-#: ../src/dtgtk/thumbtable.c:1245
+#: ../src/dtgtk/thumbtable.c:1256
 #, c-format
 msgid ""
 "cached thumbnails starting from level %d need to be invalidated.\n"
 "\n"
 msgstr ""
-"從第 %d 級開始的快取縮圖要被清除。\n"
+"需要清除從第 %d 級開始的快取縮圖。\n"
 "\n"
 
-#: ../src/dtgtk/thumbtable.c:1248
+#: ../src/dtgtk/thumbtable.c:1259
 #, c-format
 msgid ""
 "cached thumbnails below level %d need to be invalidated.\n"
 "\n"
 msgstr ""
-"低於第 %d 級的快取縮圖被清除。\n"
+"需要清除低於 %d 級的快取縮圖。\n"
 "\n"
 
-#: ../src/dtgtk/thumbtable.c:1250
+#: ../src/dtgtk/thumbtable.c:1261
 #, c-format
 msgid ""
 "cached thumbnails between level %d and %d need to be invalidated.\n"
 "\n"
 msgstr ""
-"級別爲 %d 和 %d 之間的快取縮圖要被清除。\n"
+"需要清除第 %d 至第 %d 級之間的快取縮圖。\n"
 "\n"
 
-#: ../src/dtgtk/thumbtable.c:1253
+#: ../src/dtgtk/thumbtable.c:1264
 msgid "do you want to do that now?"
-msgstr "現在要進行此操作嗎？"
+msgstr "確定要現在執行嗎？"
 
-#: ../src/dtgtk/thumbtable.c:1261
+#: ../src/dtgtk/thumbtable.c:1272
 msgid "cached thumbnails invalidation"
-msgstr "清除縮圖快取"
+msgstr "清除快取縮圖"
 
 #. setup history key accelerators
-#: ../src/dtgtk/thumbtable.c:2329
+#: ../src/dtgtk/thumbtable.c:2341
 msgid "copy history"
-msgstr "複製歷史資訊"
+msgstr "複製編輯紀錄"
 
-#: ../src/dtgtk/thumbtable.c:2330
+#: ../src/dtgtk/thumbtable.c:2342
 msgid "copy history parts"
-msgstr "複製歷史資訊的多個部分"
+msgstr "複製部分編輯記錄"
 
-#: ../src/dtgtk/thumbtable.c:2331
+#: ../src/dtgtk/thumbtable.c:2343
 msgid "paste history"
-msgstr "貼上歷史資訊"
+msgstr "套用編輯紀錄"
 
-#: ../src/dtgtk/thumbtable.c:2332
+#: ../src/dtgtk/thumbtable.c:2344
 msgid "paste history parts"
-msgstr "貼上歷史資訊的多個部分"
+msgstr "套用部分編輯紀錄"
 
-#: ../src/dtgtk/thumbtable.c:2333 ../src/libs/copy_history.c:370
+#: ../src/dtgtk/thumbtable.c:2345 ../src/libs/copy_history.c:370
 msgid "discard history"
-msgstr "丟棄歷史記錄"
+msgstr "刪除編輯記錄"
 
-#: ../src/dtgtk/thumbtable.c:2335
+#: ../src/dtgtk/thumbtable.c:2347
 msgid "duplicate image"
 msgstr "複製影像"
 
-#: ../src/dtgtk/thumbtable.c:2336
+#: ../src/dtgtk/thumbtable.c:2348
 msgid "duplicate image virgin"
 msgstr "複製原始影像"
 
-#: ../src/dtgtk/thumbtable.c:2342 ../src/libs/select.c:145
+#: ../src/dtgtk/thumbtable.c:2354 ../src/libs/select.c:145
 msgid "select film roll"
-msgstr "選擇軟片捲"
+msgstr "選取底片卷"
 
-#: ../src/dtgtk/thumbtable.c:2343 ../src/libs/select.c:149
+#: ../src/dtgtk/thumbtable.c:2355 ../src/libs/select.c:149
 msgid "select untouched"
-msgstr "選擇未編修的"
+msgstr "選取未編修過的影像"
 
 #. Column 1 - "make" of the camera.
 #. * Column 2 - "model" (use the "make" and "model" as provided by DCRaw).
@@ -8772,12 +8945,12 @@ msgstr "選擇未編修的"
 #. "Sunlight" and other variation should be switched to this:
 #: ../src/external/wb_presets.c:45 ../src/iop/lowlight.c:324
 msgid "daylight"
-msgstr "日光"
+msgstr "晴天"
 
 #. Probably same as above:
 #: ../src/external/wb_presets.c:47
 msgid "direct sunlight"
-msgstr "日光直射"
+msgstr "陽光"
 
 #: ../src/external/wb_presets.c:48
 msgid "cloudy"
@@ -8786,7 +8959,7 @@ msgstr "多雲"
 #. "Shadows" should be switched to this:
 #: ../src/external/wb_presets.c:50
 msgid "shade"
-msgstr "陰影"
+msgstr "陰天"
 
 #: ../src/external/wb_presets.c:51
 msgid "incandescent"
@@ -8794,7 +8967,7 @@ msgstr "白熾燈"
 
 #: ../src/external/wb_presets.c:52
 msgid "incandescent warm"
-msgstr "暖白熾燈"
+msgstr "暖調白熾燈"
 
 #. Same as "Incandescent":
 #: ../src/external/wb_presets.c:54
@@ -8812,71 +8985,71 @@ msgstr "高色溫螢光燈"
 
 #: ../src/external/wb_presets.c:58
 msgid "cool white fluorescent"
-msgstr "冷白螢光燈"
+msgstr "冷調螢光燈"
 
 #: ../src/external/wb_presets.c:59
 msgid "warm white fluorescent"
-msgstr "暖白螢光燈"
+msgstr "暖調螢光燈"
 
 #: ../src/external/wb_presets.c:60
 msgid "daylight fluorescent"
-msgstr "日光燈"
+msgstr "日光螢光燈"
 
 #: ../src/external/wb_presets.c:61
 msgid "neutral fluorescent"
-msgstr "中性螢光燈"
+msgstr "自然光螢光燈"
 
 #: ../src/external/wb_presets.c:62
 msgid "white fluorescent"
-msgstr "白螢光燈"
+msgstr "白光螢光燈"
 
 #. In some newer Nikon cameras:
 #: ../src/external/wb_presets.c:64
 msgid "sodium-vapor fluorescent"
-msgstr "鈉蒸氣螢光燈"
+msgstr "鈉氣燈"
 
 #: ../src/external/wb_presets.c:65
 msgid "day white fluorescent"
-msgstr "晝白螢光燈"
+msgstr "晝光色螢光燈"
 
 #: ../src/external/wb_presets.c:66
 msgid "high temp. mercury-vapor fluorescent"
-msgstr "高溫汞蒸氣螢光燈"
+msgstr "汞蒸氣放電螢光燈"
 
 #. Found in Nikon Coolpix P1000
 #: ../src/external/wb_presets.c:68
 msgid "high temp. mercury-vapor"
-msgstr "高溫汞蒸氣燈"
+msgstr "汞蒸氣放電燈"
 
 #. On Some Panasonic
 #: ../src/external/wb_presets.c:70
 msgid "D55"
-msgstr "D55"
+msgstr "CIE D55"
 
 #: ../src/external/wb_presets.c:72
 msgid "flash"
-msgstr "閃光"
+msgstr "閃光燈"
 
 #. For Olympus with no real "Flash" preset:
 #: ../src/external/wb_presets.c:74
 msgid "flash (auto mode)"
-msgstr "閃光(自動)"
+msgstr "閃光燈（自動模式）"
 
 #: ../src/external/wb_presets.c:75
 msgid "evening sun"
-msgstr "夕陽"
+msgstr "傍晚的陽光"
 
 #: ../src/external/wb_presets.c:76
 msgid "underwater"
 msgstr "水下"
 
-#: ../src/external/wb_presets.c:77 ../src/views/darkroom.c:2377
+#: ../src/external/wb_presets.c:77 ../src/views/darkroom.c:2378
 msgid "black & white"
 msgstr "黑白"
 
 #: ../src/external/wb_presets.c:79
 msgid "spot WB"
-msgstr "點測白平衡"
+msgstr "點測量白平衡"
 
 #: ../src/external/wb_presets.c:80
 msgid "manual WB"
@@ -8893,27 +9066,31 @@ msgstr "自動白平衡"
 #: ../src/generate-cache/main.c:50
 #, c-format
 msgid "creating cache directories\n"
-msgstr "正在建立快取目錄\n"
+msgstr "建立快取目錄\n"
 
 #: ../src/generate-cache/main.c:56
 #, c-format
 msgid "creating cache directory '%s'\n"
-msgstr "正在建立快取目錄“%s”\n"
+msgstr "建立快取目錄 「%s」\n"
 
 #: ../src/generate-cache/main.c:59 ../src/lua/image.c:122
 #, c-format
 msgid "could not create directory '%s'!\n"
-msgstr "無法建立目錄“%s”！\n"
+msgstr "無法建立目錄「%s」\n"
 
 #: ../src/generate-cache/main.c:83
 #, c-format
 msgid "warning: no images are matching the requested image id range\n"
-msgstr "警告:請求的影像 id 範圍沒有匹配到任何影像\n"
+msgstr ""
+"⚠️ 警告 ⚠️\n"
+"沒有與識別碼範圍符合的影像\n"
 
 #: ../src/generate-cache/main.c:86
 #, c-format
 msgid "warning: did you want to swap these boundaries?\n"
-msgstr "警告:是否交換邊界？\n"
+msgstr ""
+"⚠️ 警告 ⚠️\n"
+"是否要交換這些邊界？\n"
 
 #: ../src/generate-cache/main.c:227
 #, c-format
@@ -8923,9 +9100,10 @@ msgid ""
 "need to enable disk backend for thumbnail cache\n"
 "no thumbnails to be generated, done.\n"
 msgstr ""
-"警告:縮圖硬碟快取後端處於不使用狀態(cache_disk_backend)\n"
-"若您想要預產生縮圖以供 darktable 使用，則需要啓用縮圖硬碟快取後端\n"
-"操作完成，未產生任何縮圖。\n"
+"⚠️ 警告 ⚠️\n"
+"用於縮圖快取的磁碟已關閉\n"
+"如果要預先產生縮圖需要啟用磁碟\n"
+"操作完成，沒有製作任何縮圖\n"
 
 #: ../src/generate-cache/main.c:238
 #, c-format
@@ -8936,24 +9114,26 @@ msgid ""
 "need to enable disk backend for full preview cache\n"
 "no full previews to be generated, done.\n"
 msgstr ""
-"警告:完整預覽圖硬碟快取後端處於不使用狀態(cache_disk_backend)\n"
-"若您想要預產生完整預覽圖以供 darktable 使用，則需要啓用完整預覽圖硬碟快取後"
-"端\n"
-"操作完成，未產生任何縮圖。\n"
+"⚠️ 警告 ⚠️\n"
+"用於完整預覽圖的磁碟已關閉\n"
+"如果要預先產生完整預覽圖需要啟用磁碟\n"
+"操作完成，沒有製作任何縮圖\n"
 
 #: ../src/generate-cache/main.c:248
 #, c-format
 msgid "error: ensure that min_mip <= max_mip\n"
-msgstr "錯誤:請確保 min_mip <= max_mip\n"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"確認 min_mip < max_mip\n"
 
 #: ../src/generate-cache/main.c:253
 #, c-format
 msgid "creating complete lighttable thumbnail cache\n"
-msgstr "正在建立完整的映繪桌縮圖快取\n"
+msgstr "正在建立完整的燈箱預覽快取縮圖\n"
 
-#: ../src/gui/accelerators.c:73 ../src/views/view.c:1203
+#: ../src/gui/accelerators.c:73 ../src/views/view.c:1201
 msgid "scroll"
-msgstr "滾輪"
+msgstr "捲動"
 
 #: ../src/gui/accelerators.c:74
 msgid "pan"
@@ -8963,7 +9143,7 @@ msgstr "平移"
 #: ../src/iop/ashift.c:5424 ../src/iop/ashift.c:5526 ../src/iop/ashift.c:5527
 #: ../src/iop/ashift.c:5836 ../src/iop/clipping.c:1920
 #: ../src/iop/clipping.c:2112 ../src/iop/clipping.c:2128
-#: ../src/views/darkroom.c:2617 ../src/views/lighttable.c:1235
+#: ../src/views/darkroom.c:2618 ../src/views/lighttable.c:1235
 msgid "horizontal"
 msgstr "水平"
 
@@ -8971,13 +9151,13 @@ msgstr "水平"
 #: ../src/iop/ashift.c:5424 ../src/iop/ashift.c:5526 ../src/iop/ashift.c:5527
 #: ../src/iop/ashift.c:5835 ../src/iop/clipping.c:1919
 #: ../src/iop/clipping.c:2113 ../src/iop/clipping.c:2127
-#: ../src/views/darkroom.c:2620 ../src/views/lighttable.c:1239
+#: ../src/views/darkroom.c:2621 ../src/views/lighttable.c:1239
 msgid "vertical"
 msgstr "垂直"
 
 #: ../src/gui/accelerators.c:77
 msgid "diagonal"
-msgstr "對角線"
+msgstr "對角"
 
 #: ../src/gui/accelerators.c:78
 msgid "skew"
@@ -8995,15 +9175,15 @@ msgstr "上下"
 msgid "pgupdown"
 msgstr "上下翻頁"
 
-#: ../src/gui/accelerators.c:89 ../src/views/view.c:1187
+#: ../src/gui/accelerators.c:89 ../src/views/view.c:1185
 msgid "shift"
 msgstr "shift"
 
-#: ../src/gui/accelerators.c:90 ../src/views/view.c:1188
+#: ../src/gui/accelerators.c:90 ../src/views/view.c:1186
 msgid "ctrl"
-msgstr "控制鍵"
+msgstr "ctrl"
 
-#: ../src/gui/accelerators.c:91 ../src/views/view.c:1189
+#: ../src/gui/accelerators.c:91 ../src/views/view.c:1187
 msgid "alt"
 msgstr "alt"
 
@@ -9013,7 +9193,7 @@ msgstr "cmd"
 
 #: ../src/gui/accelerators.c:93
 msgid "altgr"
-msgstr "altgr"
+msgstr "alt（右）"
 
 #: ../src/gui/accelerators.c:102 ../src/gui/accelerators.c:144
 #: ../src/libs/tagging.c:1778
@@ -9034,7 +9214,7 @@ msgstr "設定"
 
 #: ../src/gui/accelerators.c:111
 msgid "popup"
-msgstr "彈出視窗"
+msgstr "彈出式視窗"
 
 #: ../src/gui/accelerators.c:112 ../src/gui/accelerators.c:141
 #: ../src/gui/gtk.c:2845 ../src/views/lighttable.c:749
@@ -9046,29 +9226,29 @@ msgstr "下一個"
 msgid "previous"
 msgstr "前一個"
 
-#: ../src/gui/accelerators.c:115 ../src/gui/accelerators.c:1148
+#: ../src/gui/accelerators.c:115 ../src/gui/accelerators.c:1147
 msgid "last"
 msgstr "最後一個"
 
-#: ../src/gui/accelerators.c:116 ../src/gui/accelerators.c:1147
+#: ../src/gui/accelerators.c:116 ../src/gui/accelerators.c:1146
 msgid "first"
 msgstr "第一個"
 
 #: ../src/gui/accelerators.c:119 ../src/gui/accelerators.c:131
 #: ../src/gui/accelerators.c:241 ../src/libs/filtering.c:1712
 #: ../src/libs/filters/rating_range.c:285 ../src/libs/tagging.c:3117
-#: ../src/views/darkroom.c:2294 ../src/views/darkroom.c:2349
-#: ../src/views/darkroom.c:2589
+#: ../src/views/darkroom.c:2295 ../src/views/darkroom.c:2350
+#: ../src/views/darkroom.c:2590
 msgid "toggle"
 msgstr "切換"
 
 #: ../src/gui/accelerators.c:122
 msgid "ctrl-toggle"
-msgstr "控制鍵 切換"
+msgstr "ctrl 切換"
 
 #: ../src/gui/accelerators.c:123
 msgid "ctrl-on"
-msgstr "控制鍵 打開"
+msgstr "ctrl 開啟"
 
 #: ../src/gui/accelerators.c:124
 msgid "right-toggle"
@@ -9076,23 +9256,23 @@ msgstr "右鍵切換"
 
 #: ../src/gui/accelerators.c:125
 msgid "right-on"
-msgstr "右鍵打開"
+msgstr "右鍵開啟"
 
 #: ../src/gui/accelerators.c:134 ../src/gui/gtk.c:2844
 msgid "activate"
-msgstr "啓用"
+msgstr "啟用"
 
 #: ../src/gui/accelerators.c:135
 msgid "ctrl-activate"
-msgstr "控制鍵 啓用"
+msgstr "ctrl 啟用"
 
 #: ../src/gui/accelerators.c:136
 msgid "right-activate"
-msgstr "右鍵啓用"
+msgstr "右鍵啟用"
 
 #: ../src/gui/accelerators.c:142
 msgid "store"
-msgstr "存儲"
+msgstr "儲存"
 
 #: ../src/gui/accelerators.c:145 ../src/gui/styles_dialog.c:509
 msgid "update"
@@ -9101,11 +9281,11 @@ msgstr "更新"
 #: ../src/gui/accelerators.c:146 ../src/libs/tools/global_toolbox.c:61
 #: ../src/libs/tools/global_toolbox.c:512
 msgid "preferences"
-msgstr "偏好"
+msgstr "偏好設定"
 
 #: ../src/gui/accelerators.c:150
 msgid "apply on new instance"
-msgstr "套用於新實例"
+msgstr "套用在新的模組實例"
 
 #: ../src/gui/accelerators.c:457
 msgid "tablet button"
@@ -9113,72 +9293,72 @@ msgstr "平板按鈕"
 
 #: ../src/gui/accelerators.c:466
 msgid "unknown driver"
-msgstr "未知驅動"
+msgstr "未知裝置"
 
 #: ../src/gui/accelerators.c:533
 msgid "long"
-msgstr "長"
+msgstr "長按"
 
 #: ../src/gui/accelerators.c:534
 msgid "double-press"
-msgstr "雙按"
+msgstr "雙擊"
 
 #: ../src/gui/accelerators.c:535
 msgid "triple-press"
-msgstr "三擊"
+msgstr "按三次"
 
 #: ../src/gui/accelerators.c:536
 msgid "press"
-msgstr "按"
+msgstr "點擊"
 
 #: ../src/gui/accelerators.c:540
 msgctxt "accel"
 msgid "left"
-msgstr "[加速]左"
+msgstr "左鍵"
 
 #: ../src/gui/accelerators.c:541
 msgctxt "accel"
 msgid "right"
-msgstr "[加速]右"
+msgstr "右鍵"
 
 #: ../src/gui/accelerators.c:542
 msgctxt "accel"
 msgid "middle"
-msgstr "[加速]中鍵"
+msgstr "中鍵"
 
 #: ../src/gui/accelerators.c:543
 msgctxt "accel"
 msgid "long"
-msgstr "[加速]長"
+msgstr "長按"
 
 #: ../src/gui/accelerators.c:544
 msgctxt "accel"
 msgid "double-click"
-msgstr "[加速]雙擊"
+msgstr "雙擊"
 
 #: ../src/gui/accelerators.c:545
 msgctxt "accel"
 msgid "triple-click"
-msgstr "[加速]三擊"
+msgstr "按三下"
 
 #: ../src/gui/accelerators.c:546
 msgid "click"
-msgstr "單擊"
+msgstr "點擊"
 
 #: ../src/gui/accelerators.c:574
 msgid "first instance"
-msgstr "第一個實例"
+msgstr "第一個模組實例"
 
 #: ../src/gui/accelerators.c:576
 msgid "last instance"
-msgstr "最後一個實例"
+msgstr "最後一個模組實例"
 
 #: ../src/gui/accelerators.c:578
 msgid "relative instance"
-msgstr "相對的實例"
+msgstr "相對的模組實例"
 
 #: ../src/gui/accelerators.c:605 ../src/gui/accelerators.c:878
-#: ../src/gui/accelerators.c:2218 ../src/gui/accelerators.c:3088
+#: ../src/gui/accelerators.c:2217 ../src/gui/accelerators.c:3087
 msgid "speed"
 msgstr "速度"
 
@@ -9188,120 +9368,120 @@ msgid ""
 "double-click to add new shortcut\n"
 "start typing for incremental search"
 msgstr ""
-"按 Del 鍵刪除所選快捷\n"
-"雙擊來增加新的快捷\n"
-"開始輸入以進行漸進式搜尋"
+"按「Del」刪除選取的快速鍵\n"
+"雙擊以添加新的快速鍵\n"
+"直接輸入搜尋快速鍵"
 
 #: ../src/gui/accelerators.c:680
 msgid "click to filter shortcut list\n"
-msgstr "點擊以過濾快捷列表\n"
+msgstr "點擊可篩選快速鍵\n"
 
 #: ../src/gui/accelerators.c:681
 msgid "right click to show action of selected shortcut\n"
-msgstr "右擊以顯示選定快捷鍵行為\n"
+msgstr "右鍵展開選擇的快速鍵清單\n"
 
 #: ../src/gui/accelerators.c:682
 msgid ""
 "double-click to define new shortcut\n"
 "start typing for incremental search"
 msgstr ""
-"雙擊來定義新的快捷\n"
-"開始輸入以進行漸進式搜尋"
+"雙擊以自訂新的快速鍵\n"
+"直接輸入搜尋動作"
 
 #: ../src/gui/accelerators.c:701
 msgid ""
 "press keys with mouse click and scroll or move combinations to create a "
 "shortcut"
-msgstr "使用鍵盤按鍵、滑鼠按鈕、滾輪或拖拉組合以建立快捷鍵"
+msgstr "按鍵和滑鼠動作組合以建立快速鍵"
 
 #: ../src/gui/accelerators.c:702
 msgid "click to open shortcut configuration"
-msgstr "點擊以打開快捷鍵配置"
+msgstr "滑鼠點擊打開此功能的快速鍵設定視窗"
 
 #: ../src/gui/accelerators.c:703
 msgid "ctrl+click to add to quick access panel\n"
-msgstr "控制鍵 + 單擊以增加至快訪面板\n"
+msgstr "ctrl + 左鍵添加到快速存取面板\n"
 
 #: ../src/gui/accelerators.c:704
 msgid "ctrl+click to remove from quick access panel\n"
-msgstr "控制鍵 + 單擊以從快訪面板移除\n"
+msgstr "ctrl + 左鍵從快速存取面板中刪除\n"
 
 #: ../src/gui/accelerators.c:705
 msgid "scroll to change default speed"
-msgstr "滾動滾輪以更改預設速度"
+msgstr "滑鼠滾輪可改變快速鍵速度"
 
 #: ../src/gui/accelerators.c:706
 msgid "right click to exit mapping mode"
-msgstr "點擊右鍵，退出映射模式"
+msgstr "滑鼠右鍵退出快速鍵錄製模式"
 
 #: ../src/gui/accelerators.c:875
 msgid "active view"
-msgstr "活動視角"
+msgstr "目前的模式"
 
 #: ../src/gui/accelerators.c:876
 msgid "other views"
-msgstr "其他視角"
+msgstr "其他檢視模式"
 
 #: ../src/gui/accelerators.c:877
 msgid "fallbacks"
-msgstr "後備"
+msgstr "通用擴展快速鍵"
+
+#: ../src/gui/accelerators.c:1027
+msgid "shortcut for move exists with single effect"
+msgstr "已經有同樣效果的移動快捷鍵"
 
 #: ../src/gui/accelerators.c:1028
-msgid "shortcut for move exists with single effect"
-msgstr "有同樣效果的移動快捷鍵"
-
-#: ../src/gui/accelerators.c:1029
 msgid "create separate shortcuts for up and down move?"
-msgstr "分別建立向上和向下移動的快捷鍵？"
+msgstr "為上下移動建立單獨的快速鍵？"
 
-#: ../src/gui/accelerators.c:1052
+#: ../src/gui/accelerators.c:1051
 #, c-format
 msgid "%s, speed reset"
-msgstr "%s, 速度重置"
+msgstr "「%s」，速度重設"
+
+#: ../src/gui/accelerators.c:1060
+msgid "shortcut exists with different settings"
+msgstr "已經有不同設定的快速鍵"
 
 #: ../src/gui/accelerators.c:1061
-msgid "shortcut exists with different settings"
-msgstr "不同設定的同一快捷鍵"
-
-#: ../src/gui/accelerators.c:1062
 msgid "reset the settings of the shortcut?"
-msgstr "重置快捷鍵設定?"
+msgstr "是否重設快速鍵的配置？"
+
+#: ../src/gui/accelerators.c:1072
+msgid "shortcut already exists"
+msgstr "快速鍵已存在"
 
 #: ../src/gui/accelerators.c:1073
-msgid "shortcut already exists"
-msgstr "快捷鍵已存在"
-
-#: ../src/gui/accelerators.c:1074
 msgid "remove the shortcut?"
-msgstr "移除快捷鍵？"
+msgstr "刪除此快速鍵？"
 
-#: ../src/gui/accelerators.c:1107
+#: ../src/gui/accelerators.c:1106
 msgid "remove these existing shortcuts?"
-msgstr "刪除已有的快捷鍵？"
+msgstr "刪除這些已有的快速鍵？"
 
-#: ../src/gui/accelerators.c:1109
+#: ../src/gui/accelerators.c:1108
 msgid "clashing shortcuts exist"
-msgstr "有衝突的快捷鍵"
+msgstr "與現有快速鍵衝突"
 
 #. or 3, but change char relative[] = "-2" to "-1"
 #. NUM_INSTANCES
-#: ../src/gui/accelerators.c:1146
+#: ../src/gui/accelerators.c:1145
 msgid "preferred"
-msgstr "偏好"
+msgstr "優先"
 
-#: ../src/gui/accelerators.c:1149
+#: ../src/gui/accelerators.c:1148
 msgid "second"
 msgstr "第二"
 
-#: ../src/gui/accelerators.c:1150
+#: ../src/gui/accelerators.c:1149
 msgid "last but one"
-msgstr "最後一個"
+msgstr "倒數第二"
 
-#: ../src/gui/accelerators.c:1292 ../src/gui/accelerators.c:1346
+#: ../src/gui/accelerators.c:1291 ../src/gui/accelerators.c:1345
 msgid "(unchanged)"
-msgstr "(未更改)"
+msgstr "（未更改）"
 
-#: ../src/gui/accelerators.c:1441
+#: ../src/gui/accelerators.c:1440
 msgid ""
 "define a shortcut by pressing a key, optionally combined with modifier keys "
 "(ctrl/shift/alt)\n"
@@ -9314,245 +9494,248 @@ msgid ""
 "\n"
 "right-click to cancel"
 msgstr ""
-"通過按鍵來定義一個快捷方式，可與 控制鍵/shift/alt 等鍵結合使用\n"
-"按鍵可以雙擊或三擊，最後點擊可以長按\n"
-"在按住按鍵的同時，滑鼠按鈕可以雙擊/三擊/長按\n"
-"在按住按鍵同時，可以繼續使用滑鼠滾動或移動\n"
-"連接的設備可以使用其實質控制器發送按鍵或動作\n"
+"透過按鍵自訂快速鍵，按鍵可 ctrl / shift / alt 鍵組合使用\n"
+"按鍵可以雙擊甚至三擊與長按，可與滑鼠按鈕組合\n"
+"還按著按鍵時，可再加上滑鼠滾輪或移動\n"
+"外接控制設備可以使用物理控制器按鍵和移動\n"
 "\n"
-"單擊右鍵以取消"
+"點擊右鍵取消"
+
+#: ../src/gui/accelerators.c:1487
+msgid "removing shortcut"
+msgstr "移除快速鍵"
 
 #: ../src/gui/accelerators.c:1488
-msgid "removing shortcut"
-msgstr "正在移除快捷鍵"
-
-#: ../src/gui/accelerators.c:1489
 msgid "remove the selected shortcut?"
-msgstr "移除選定的快捷鍵？"
+msgstr "是否要移除選取的快速鍵 ？"
 
-#: ../src/gui/accelerators.c:1888
+#: ../src/gui/accelerators.c:1887
 msgid "restore shortcuts"
-msgstr "回復快捷鍵設定"
+msgstr "復原快速鍵"
+
+#: ../src/gui/accelerators.c:1891
+msgid "_defaults"
+msgstr "預設（_D）"
 
 #: ../src/gui/accelerators.c:1892
-msgid "_defaults"
-msgstr "預設"
+msgid "_startup"
+msgstr "啟動（_S）"
 
 #: ../src/gui/accelerators.c:1893
-msgid "_startup"
-msgstr "啓動"
-
-#: ../src/gui/accelerators.c:1894
 msgid "_edits"
-msgstr "編輯"
+msgstr "編輯（_E）"
 
-#: ../src/gui/accelerators.c:1899
+#: ../src/gui/accelerators.c:1898
 msgid ""
 "restore default shortcuts\n"
 "  or as at startup\n"
 "  or when the configuration dialog was opened\n"
 msgstr ""
-"回復預設快捷鍵\n"
-"  或程式啓動時的快捷鍵設定\n"
-"  或打開配置對話框時的設定\n"
+"預設：恢復至軟體出廠預設快速鍵\n"
+"啟動：恢復這次開啟軟體前的設定\n"
+"編輯：恢復前一次編輯的設定\n"
 
-#: ../src/gui/accelerators.c:1902
+#: ../src/gui/accelerators.c:1901
 msgid ""
 "clear all newer shortcuts\n"
 "(instead of just restoring changed ones)"
-msgstr "清除所有更新的快捷鍵(而不是僅恢復已變更的快捷鍵)"
+msgstr ""
+"清除所有更新的快速鍵\n"
+"（而不僅是恢復已更改的）"
 
-#: ../src/gui/accelerators.c:1956 ../src/gui/preferences.c:877
+#: ../src/gui/accelerators.c:1955 ../src/gui/preferences.c:877
 #: ../src/libs/tools/global_toolbox.c:496
 #: ../src/libs/tools/global_toolbox.c:819
 msgid "shortcuts"
-msgstr "快捷鍵"
+msgstr "快速鍵"
 
-#: ../src/gui/accelerators.c:1965
+#: ../src/gui/accelerators.c:1964
 msgid "export shortcuts"
-msgstr "輸出快捷鍵設定"
+msgstr "匯出快速鍵"
 
-#: ../src/gui/accelerators.c:1968 ../src/gui/accelerators.c:2047
+#: ../src/gui/accelerators.c:1967 ../src/gui/accelerators.c:2046
 #: ../src/gui/hist_dialog.c:198 ../src/gui/presets.c:477
 msgid "_ok"
-msgstr "_ok"
+msgstr "確定(_O）"
 
-#: ../src/gui/accelerators.c:1973
+#: ../src/gui/accelerators.c:1972
 msgid ""
 "export all shortcuts to a file\n"
 "or just for one selected device\n"
 msgstr ""
-"將所有快捷鍵輸出到檔案\n"
-"或僅輸出特定設備的快捷鍵\n"
+"選擇要匯出全部的快速鍵\n"
+"或是特定裝置的快速鍵設定\n"
 
-#: ../src/gui/accelerators.c:1979 ../src/gui/accelerators.c:2058
+#: ../src/gui/accelerators.c:1978 ../src/gui/accelerators.c:2057
 msgid "keyboard"
 msgstr "鍵盤"
 
-#: ../src/gui/accelerators.c:1991
+#: ../src/gui/accelerators.c:1990
 msgid "device id"
-msgstr "設備 id"
+msgstr "裝置識別碼"
 
-#: ../src/gui/accelerators.c:2017
+#: ../src/gui/accelerators.c:2016
 msgid "select file to export"
-msgstr "選擇輸出檔案"
+msgstr "選擇要匯出的檔案"
 
-#: ../src/gui/accelerators.c:2018 ../src/libs/tagging.c:2521
+#: ../src/gui/accelerators.c:2017 ../src/libs/tagging.c:2521
 msgid "_export"
-msgstr "輸出"
+msgstr "匯出（_E）"
 
-#: ../src/gui/accelerators.c:2044
+#: ../src/gui/accelerators.c:2043
 msgid "import shortcuts"
-msgstr "輸入快捷鍵設定"
+msgstr "匯入快速鍵"
 
-#: ../src/gui/accelerators.c:2052
+#: ../src/gui/accelerators.c:2051
 msgid ""
 "import all shortcuts from a file\n"
 "or just for one selected device\n"
 msgstr ""
-"從檔案輸入所有快捷鍵\n"
-"或僅輸入特定設備的快捷鍵\n"
+"選擇要匯入全部的快速鍵\n"
+"或是特定裝置的快速鍵設定\n"
 
-#: ../src/gui/accelerators.c:2070
+#: ../src/gui/accelerators.c:2069
 msgid "id in file"
-msgstr "檔案中的 id"
+msgstr "檔案識別碼"
 
-#: ../src/gui/accelerators.c:2076
+#: ../src/gui/accelerators.c:2075
 msgid "id when loaded"
-msgstr "載入時的 id"
+msgstr "載入時的識別碼"
 
-#: ../src/gui/accelerators.c:2080
+#: ../src/gui/accelerators.c:2079
 msgid "clear device first"
-msgstr "首先清除設備"
+msgstr "先刪除原有的設備快速鍵"
 
-#: ../src/gui/accelerators.c:2104
+#: ../src/gui/accelerators.c:2103
 msgid "select file to import"
-msgstr "選擇輸入檔案"
+msgstr "選擇要匯入的檔案"
 
-#: ../src/gui/accelerators.c:2105 ../src/libs/tagging.c:2485
+#: ../src/gui/accelerators.c:2104 ../src/libs/tagging.c:2485
 msgid "_import"
-msgstr "輸入"
+msgstr "匯入（_I）"
+
+#: ../src/gui/accelerators.c:2177
+msgid "search shortcuts list"
+msgstr "搜尋快速鍵"
 
 #: ../src/gui/accelerators.c:2178
-msgid "search shortcuts list"
-msgstr "搜尋快捷鍵列表"
-
-#: ../src/gui/accelerators.c:2179
 msgid ""
 "incrementally search the list of shortcuts\n"
 "press up or down keys to cycle through matches"
 msgstr ""
-"漸進式搜尋快捷鍵列表\n"
-"按上或下鍵來循環查看匹配的內容"
+"輸入關鍵字搜尋快速鍵\n"
+"使用上下鍵在符合的快速鍵中切換"
 
 #. Setting up the cell renderers
-#: ../src/gui/accelerators.c:2194 ../src/views/view.c:1384
+#: ../src/gui/accelerators.c:2193 ../src/views/view.c:1382
 msgid "shortcut"
-msgstr "快捷鍵"
+msgstr "快速鍵"
 
-#: ../src/gui/accelerators.c:2196 ../src/gui/accelerators.c:2287
-#: ../src/views/view.c:1386
+#: ../src/gui/accelerators.c:2195 ../src/gui/accelerators.c:2286
+#: ../src/views/view.c:1384
 msgid "action"
 msgstr "動作"
 
-#: ../src/gui/accelerators.c:2205
+#: ../src/gui/accelerators.c:2204
 msgid "element"
 msgstr "元素"
 
-#: ../src/gui/accelerators.c:2212
+#: ../src/gui/accelerators.c:2211
 msgid "effect"
 msgstr "效果"
 
-#: ../src/gui/accelerators.c:2269
+#: ../src/gui/accelerators.c:2268
 msgid "search actions list"
-msgstr "搜尋動作列表"
+msgstr "搜尋動作"
 
-#: ../src/gui/accelerators.c:2270
+#: ../src/gui/accelerators.c:2269
 msgid ""
 "incrementally search the list of actions\n"
 "press up or down keys to cycle through matches"
 msgstr ""
-"漸進式搜尋動作列表\n"
-"按上或下鍵來循環查看匹配的內容"
+"輸入關鍵字搜尋動作\n"
+"使用上下鍵在符合的動作中切換"
 
-#: ../src/gui/accelerators.c:2293 ../src/gui/guides.c:719
+#: ../src/gui/accelerators.c:2292 ../src/gui/guides.c:719
 #: ../src/libs/export_metadata.c:192
 msgid "type"
-msgstr "類型"
+msgstr "類別"
+
+#: ../src/gui/accelerators.c:2327
+msgid "enable fallbacks"
+msgstr "啟用更多通用擴展快速鍵"
 
 #: ../src/gui/accelerators.c:2328
-msgid "enable fallbacks"
-msgstr "啓用後備設定"
-
-#: ../src/gui/accelerators.c:2329
 msgid ""
 "enables default meanings for additional buttons, modifiers or moves\n"
 "when used in combination with a base shortcut"
-msgstr "啓用基本快捷鍵下額外按鈕、修飾鍵或動作的預設行爲"
+msgstr ""
+"在基本快速鍵之上啟用更多附加按鈕、調整或移動的效果\n"
+"更多詳細內容及參數，請閱讀操作手冊的「shortcuts」章節"
+
+#: ../src/gui/accelerators.c:2334
+msgid "restore..."
+msgstr "重設"
 
 #: ../src/gui/accelerators.c:2335
-msgid "restore..."
-msgstr "回復..."
-
-#: ../src/gui/accelerators.c:2336
 msgid "restore default shortcuts or previous state"
-msgstr "回復預設快捷鍵或之前的狀態"
+msgstr "恢復預設快速鍵或之前的狀態"
 
 #. import button
-#: ../src/gui/accelerators.c:2340 ../src/libs/styles.c:853
+#: ../src/gui/accelerators.c:2339 ../src/libs/styles.c:853
 #: ../src/libs/tagging.c:3250
 msgid "import..."
-msgstr "輸入…"
+msgstr "匯入"
 
-#: ../src/gui/accelerators.c:2341
+#: ../src/gui/accelerators.c:2340
 msgid "fully or partially import shortcuts from file"
-msgstr "從檔案輸入全部或部分快捷鍵"
+msgstr "從檔案匯入快速鍵"
 
 #. export button
-#: ../src/gui/accelerators.c:2345 ../src/libs/styles.c:857
+#: ../src/gui/accelerators.c:2344 ../src/libs/styles.c:857
 #: ../src/libs/tagging.c:3253
 msgid "export..."
-msgstr "輸出..."
+msgstr "匯出"
 
-#: ../src/gui/accelerators.c:2346
+#: ../src/gui/accelerators.c:2345
 msgid "fully or partially export shortcuts to file"
-msgstr "向檔案輸出全部或部分快捷鍵"
+msgstr "匯出快速鍵成檔案"
 
-#: ../src/gui/accelerators.c:2756
+#: ../src/gui/accelerators.c:2755
 msgid "input devices reinitialised"
-msgstr "輸入設備已重新初始化"
+msgstr "重新初始化輸入裝置"
 
-#: ../src/gui/accelerators.c:2971
+#: ../src/gui/accelerators.c:2970
 msgid "fallback to move"
-msgstr "退回到移動"
+msgstr "回復上一動"
 
-#: ../src/gui/accelerators.c:3160
+#: ../src/gui/accelerators.c:3159
 #, c-format
 msgid "%s not assigned"
-msgstr "%s 未分配"
+msgstr "「%s」未指定"
 
-#: ../src/gui/accelerators.c:3312
+#: ../src/gui/accelerators.c:3311
 #, c-format
 msgid "%s assigned to %s"
-msgstr "%s 已分配至 %s"
+msgstr "「%s」指定給「%s」"
 
-#: ../src/gui/gtk.c:171 ../src/views/darkroom.c:4517
+#: ../src/gui/gtk.c:171 ../src/views/darkroom.c:4518
 msgid "darktable - darkroom preview"
-msgstr "darktable - 暗房預覽"
+msgstr "darktable 暗房預覽"
 
 #: ../src/gui/gtk.c:182
 msgid "tooltips off"
-msgstr "不使用提示資訊"
+msgstr "關閉影像懸浮資訊"
 
 #: ../src/gui/gtk.c:184
 msgid "tooltips on"
-msgstr "顯示提示資訊"
+msgstr "開啟影像懸浮資訊"
 
 #: ../src/gui/gtk.c:189
 msgid ""
 "tooltip visibility can only be toggled if compositing is enabled in your "
 "window manager"
-msgstr "切換提示資訊是否顯示只能在目前視窗管理器開啓合成時使用"
+msgstr "只有在視窗管理中開啟混合模式，才能切換懸浮資訊要不要顯示"
 
 #: ../src/gui/gtk.c:808
 msgid "closing darktable..."
@@ -9560,7 +9743,7 @@ msgstr "正在關閉 darktable..."
 
 #: ../src/gui/gtk.c:1123
 msgid "panels"
-msgstr "面板"
+msgstr "版面"
 
 #. an action that does nothing - used for overriding/removing default shortcuts
 #: ../src/gui/gtk.c:1172
@@ -9569,7 +9752,7 @@ msgstr "無操作"
 
 #: ../src/gui/gtk.c:1174
 msgid "switch views"
-msgstr "切換視角"
+msgstr "切換檢視"
 
 #: ../src/gui/gtk.c:1175 ../src/views/tethering.c:102
 msgid "tethering"
@@ -9581,7 +9764,7 @@ msgstr "地圖"
 
 #: ../src/gui/gtk.c:1179 ../src/views/slideshow.c:344
 msgid "slideshow"
-msgstr "幻燈片放映"
+msgstr "影像輪播"
 
 #. Print button
 #: ../src/gui/gtk.c:1180 ../src/libs/print_settings.c:2725
@@ -9591,7 +9774,7 @@ msgstr "列印"
 #. register ctrl-q to quit:
 #: ../src/gui/gtk.c:1186
 msgid "quit"
-msgstr "退出"
+msgstr "關閉"
 
 #. Full-screen accelerator (no ESC handler here to enable quit-slideshow using ESC)
 #: ../src/gui/gtk.c:1189
@@ -9600,49 +9783,49 @@ msgstr "全螢幕"
 
 #: ../src/gui/gtk.c:1193
 msgid "collapsing controls"
-msgstr "摺疊控制"
+msgstr "版面收合控制"
 
 #. specific top/bottom toggles
 #: ../src/gui/gtk.c:1195
 msgid "header"
-msgstr "頭部"
+msgstr "標題列"
 
 #: ../src/gui/gtk.c:1196
 msgid "filmstrip and timeline"
-msgstr "條狀底片與時間線"
+msgstr "「幻燈片」和「時間軸」模組"
 
 #: ../src/gui/gtk.c:1197
 msgid "top toolbar"
-msgstr "頂部工具欄"
+msgstr "上方工具列"
 
 #: ../src/gui/gtk.c:1198
 msgid "bottom toolbar"
-msgstr "面板/底部工具欄"
+msgstr "下方工具列"
 
 #: ../src/gui/gtk.c:1199
 msgid "all top"
-msgstr "面板/所有頂部"
+msgstr "所有上方版面"
 
 #: ../src/gui/gtk.c:1200
 msgid "all bottom"
-msgstr "面板/所有底部"
+msgstr "所有下方版面"
 
 #: ../src/gui/gtk.c:1202
 msgid "toggle tooltip visibility"
-msgstr "切換提示的可見性"
+msgstr "切換工具提示是否顯示"
 
 #: ../src/gui/gtk.c:1203
 msgid "reinitialise input devices"
-msgstr "重新初始化輸入設備"
+msgstr "重新初始化輸入裝置"
 
 #: ../src/gui/gtk.c:1241
 msgid "toggle focus-peaking mode"
-msgstr "切換焦點峯值模式"
+msgstr "切換對焦峰值模式"
 
 #. toggle focus peaking everywhere
 #: ../src/gui/gtk.c:1246
 msgid "toggle focus peaking"
-msgstr "切換焦點峯值"
+msgstr "切換對焦峰值"
 
 #. font name can only use period as decimal separator
 #. but printf format strings use comma for some locales, so replace comma with period
@@ -9654,45 +9837,45 @@ msgstr "%.1f"
 #: ../src/gui/gtk.c:2591
 #, c-format
 msgid "Sans %s"
-msgstr "Sans %s"
+msgstr "無襯線字體「%s」"
 
 #: ../src/gui/gtk.c:2924 ../src/gui/gtk.c:2929 ../src/gui/gtk.c:2934
 msgid "tabs"
-msgstr "分頁"
+msgstr "選項"
 
 #: ../src/gui/gtkentry.c:172
 msgid "$(ROLL.NAME) - roll of the input image"
-msgstr "$(ROLL_NAME) - 輸入軟片捲名稱"
+msgstr "$(ROLL.NAME) - 匯入影像的底片卷名稱"
 
 #: ../src/gui/gtkentry.c:173
 msgid "$(FILE.FOLDER) - folder containing the input image"
-msgstr "$(FILE_FOLDER) - 包含輸入影像檔的目錄"
+msgstr "$(FILE.FOLDER) - 匯入影像的資料夾"
 
 #: ../src/gui/gtkentry.c:174
 msgid "$(FILE.NAME) - basename of the input image"
-msgstr "$(FILE_NAME) - 輸入影像的主檔名"
+msgstr "$(FILE.NAME) - 匯入影像的名稱"
 
 #: ../src/gui/gtkentry.c:175
 msgid "$(FILE.EXTENSION) - extension of the input image"
-msgstr "$(FILE_EXTENSION) - 輸入影像的副檔名"
+msgstr "$(FILE.EXTENSION) - 匯入影像的副檔名"
 
 #: ../src/gui/gtkentry.c:176
 msgid "$(VERSION) - duplicate version"
-msgstr "$(VERSION) - 副本版本號"
+msgstr "$(VERSION) - 複本版本"
 
 #: ../src/gui/gtkentry.c:177
 msgid ""
 "$(VERSION.IF_MULTI) - same as $(VERSION) but null string if only one version "
 "exists"
-msgstr "$(VERSION.IF.MULTI) - 等同於 $(VERSION) 如只有一個版本，則爲空字串"
+msgstr "$(VERSION.IF_MULTI) - 第二個複本版本編號，如果只有一個編號則為空白"
 
 #: ../src/gui/gtkentry.c:178
 msgid "$(VERSION.NAME) - version name from metadata"
-msgstr "$(VERSION.NAME) - 來自詮釋資料的版本名"
+msgstr "$(VERSION.NAME) - 詮釋資料中的版本編號"
 
 #: ../src/gui/gtkentry.c:179
 msgid "$(JOBCODE) - job code for import"
-msgstr "$(JOBCODE) -輸入任務名稱"
+msgstr "$(JOBCODE) - 匯入工作的名稱"
 
 #: ../src/gui/gtkentry.c:180
 msgid "$(SEQUENCE) - sequence number"
@@ -9700,43 +9883,43 @@ msgstr "$(SEQUENCE) - 序號"
 
 #: ../src/gui/gtkentry.c:181
 msgid "$(WIDTH.MAX) - maximum image export width"
-msgstr "$(WIDTH.MAX) - 影像輸出最大寬度"
+msgstr "$(WIDTH.MAX) - 影像匯出的最大寬度"
 
 #: ../src/gui/gtkentry.c:182
 msgid "$(WIDTH.SENSOR) - image sensor width"
-msgstr "$(WIDTH.SENSOR) - 影像傳感器寬度"
+msgstr "$(WIDTH.SENSOR) - 感光元件的寬度"
 
 #: ../src/gui/gtkentry.c:183
 msgid "$(WIDTH.RAW) - RAW image width"
-msgstr "$(WIDTH.RAW) - RAW 影像寬度"
+msgstr "$(WIDTH.RAW) - RAW 檔的影像寬度"
 
 #: ../src/gui/gtkentry.c:184
 msgid "$(WIDTH.CROP) - image width after crop"
-msgstr "$(WIDTH.CROP) - 裁剪後的影像寬度"
+msgstr "$(WIDTH.CROP) - 裁切後的影像寬度"
 
 #: ../src/gui/gtkentry.c:185
 msgid "$(WIDTH.EXPORT) - exported image width"
-msgstr "$(WIDTH.EXPORT) - 輸出影像的寬度"
+msgstr "$(WIDTH.EXPORT) - 匯出影像的寬度"
 
 #: ../src/gui/gtkentry.c:186
 msgid "$(HEIGHT.MAX) - maximum image export height"
-msgstr "$(HEIGHT.MAX) - 影像輸出最大高度"
+msgstr "$(HEIGHT.MAX) - 影像匯出的最大高度"
 
 #: ../src/gui/gtkentry.c:187
 msgid "$(HEIGHT.SENSOR) - image sensor height"
-msgstr "$(HEIGHT.SENSOR) - 影像傳感器高度"
+msgstr "$(HEIGHT.SENSOR) - 感光元件的高度"
 
 #: ../src/gui/gtkentry.c:188
 msgid "$(HEIGHT.RAW) - RAW image height"
-msgstr "$(HEIGHT.RAW) - RAW 影像高度"
+msgstr "$(HEIGHT.RAW) - RAW 檔的影像高度"
 
 #: ../src/gui/gtkentry.c:189
 msgid "$(HEIGHT.CROP) - image height after crop"
-msgstr "$(HEIGHT.CROP) - 裁剪後的影像高度"
+msgstr "$(HEIGHT.CROP) - 裁切後的影像高度"
 
 #: ../src/gui/gtkentry.c:190
 msgid "$(HEIGHT.EXPORT) - exported image height"
-msgstr "$(HEIGHT.EXPORT) - 輸出的影像高度"
+msgstr "$(HEIGHT.EXPORT) - 匯出的影像高度"
 
 #: ../src/gui/gtkentry.c:191
 msgid "$(YEAR) - year"
@@ -9744,7 +9927,7 @@ msgstr "$(YEAR) - 年"
 
 #: ../src/gui/gtkentry.c:192
 msgid "$(YEAR.SHORT) - year without century"
-msgstr "$(YEAR.SHORT) - 沒有世紀數的年份"
+msgstr "$(YEAR.SHORT) - 沒有標示世紀的年份"
 
 #: ../src/gui/gtkentry.c:193
 msgid "$(MONTH) - month"
@@ -9752,11 +9935,11 @@ msgstr "$(MONTH) - 月"
 
 #: ../src/gui/gtkentry.c:194
 msgid "$(MONTH.SHORT) - abbreviated month name according to the current locale"
-msgstr "$(MONTH.SHORT) -依據語系的月份簡稱"
+msgstr "$(MONTH.SHORT) - 目前使用語系的月份縮寫"
 
 #: ../src/gui/gtkentry.c:195
 msgid "$(MONTH.LONG) - full month name according to the current locale"
-msgstr "$(MONTH.LONG) -現有語系的月份全名"
+msgstr "$(MONTH.LONG) - 目前使用語系的完整月份名稱"
 
 #: ../src/gui/gtkentry.c:196
 msgid "$(DAY) - day"
@@ -9768,7 +9951,7 @@ msgstr "$(HOUR) - 時"
 
 #: ../src/gui/gtkentry.c:198
 msgid "$(HOUR.AMPM) - hour, 12-hour clock"
-msgstr "$(HOUR.AMPM) - 12小時制的小時數"
+msgstr "$(HOUR.AMPM) - 12 時制的小時數"
 
 #: ../src/gui/gtkentry.c:199
 msgid "$(MINUTE) - minute"
@@ -9788,22 +9971,22 @@ msgstr "$(EXIF.YEAR) - EXIF 年份"
 
 #: ../src/gui/gtkentry.c:203
 msgid "$(EXIF.YEAR.SHORT) - EXIF year without century"
-msgstr "$(EXIF.YEAR.SHORT) - 沒有世紀數的EXIF 年份"
+msgstr "$(EXIF.YEAR.SHORT) - EXIF 沒有標示世紀的年份"
 
 #: ../src/gui/gtkentry.c:204
 msgid "$(EXIF.MONTH) - EXIF month"
-msgstr "$(EXIF.MONTH) - EXIF 月份"
+msgstr "$(EXIF.MONTH) - EXIF 月"
 
 #: ../src/gui/gtkentry.c:205
 msgid ""
 "$(EXIF.MONTH.SHORT) - abbreviated EXIF month name according to the current "
 "locale"
-msgstr "$(EXIF.MONTH.SHORT) - 依據現有語系的EXIF月份簡稱"
+msgstr "$(EXIF.MONTH.SHORT) - 目前使用語系的 EXIF 縮寫月份名稱"
 
 #: ../src/gui/gtkentry.c:206
 msgid ""
 "$(EXIF.MONTH.LONG) - full EXIF month name according to the current locale"
-msgstr "$(MONTH.LONG) -依據現有語系的月份全名"
+msgstr "$(EXIF.MONTH.LONG) - 目前使用語系的 EXIF 完整月份名稱"
 
 #: ../src/gui/gtkentry.c:207
 msgid "$(EXIF.DAY) - EXIF day"
@@ -9811,11 +9994,11 @@ msgstr "$(EXIF.DAY) - EXIF 日"
 
 #: ../src/gui/gtkentry.c:208
 msgid "$(EXIF.HOUR) - EXIF hour"
-msgstr "$(EXIF.HOUR) - EXIF 小時"
+msgstr "$(EXIF.HOUR) - EXIF 時"
 
 #: ../src/gui/gtkentry.c:209
 msgid "$(EXIF.HOUR.AMPM) - EXIF hour, 12-hour clock"
-msgstr "$(HOUR.AMPM) - 12小時制的小時數"
+msgstr "$(EXIF.HOUR.AMPM) - EXIF 12 時制的小時數"
 
 #: ../src/gui/gtkentry.c:210
 msgid "$(EXIF.MINUTE) - EXIF minute"
@@ -9827,11 +10010,11 @@ msgstr "$(EXIF.SECOND) - EXIF 秒"
 
 #: ../src/gui/gtkentry.c:212
 msgid "$(EXIF.MSEC) - EXIF millisecond"
-msgstr "$(EXIF.MSEC) - EXIF毫秒"
+msgstr "$(EXIF.MSEC) - EXIF 毫秒"
 
 #: ../src/gui/gtkentry.c:213
 msgid "$(EXIF.ISO) - ISO value"
-msgstr "$(EXIF.ISO) - 感光度"
+msgstr "$(EXIF.ISO) - 感光度 ISO 值"
 
 #: ../src/gui/gtkentry.c:214
 msgid "$(EXIF.EXPOSURE) - EXIF exposure"
@@ -9839,7 +10022,7 @@ msgstr "$(EXIF.EXPOSURE) - EXIF 曝光"
 
 #: ../src/gui/gtkentry.c:215
 msgid "$(EXIF.EXPOSURE.BIAS) - EXIF exposure bias"
-msgstr "$(EXIF.EXPOSURE.BIAS) - EXIF 曝光偏差"
+msgstr "$(EXIF.EXPOSURE.BIAS) - EXIF 曝光補償"
 
 #: ../src/gui/gtkentry.c:216
 msgid "$(EXIF.APERTURE) - EXIF aperture"
@@ -9851,11 +10034,11 @@ msgstr "$(EXIF.FOCAL.LENGTH) - EXIF 鏡頭焦距"
 
 #: ../src/gui/gtkentry.c:218
 msgid "$(EXIF.FOCUS.DISTANCE) - EXIF focal distance"
-msgstr "$(EXIF.FOCUS.DISTANCE) - EXIF 焦距"
+msgstr "$(EXIF.FOCUS.DISTANCE) - EXIF 對焦距離"
 
 #: ../src/gui/gtkentry.c:219
 msgid "$(EXIF.MAKER) - camera maker"
-msgstr "$(EXIF.MAKER) - 相機制造商"
+msgstr "$(EXIF.MAKER) - 相機品牌"
 
 #: ../src/gui/gtkentry.c:220
 msgid "$(EXIF.MODEL) - camera model"
@@ -9863,7 +10046,7 @@ msgstr "$(EXIF.MODEL) - 相機型號"
 
 #: ../src/gui/gtkentry.c:221
 msgid "$(EXIF.LENS) - lens"
-msgstr "$(EXIF.LENS) - 鏡頭"
+msgstr "$(EXIF.LENS) - EXIF 鏡頭型號"
 
 #: ../src/gui/gtkentry.c:222
 msgid "$(LONGITUDE) - longitude"
@@ -9879,51 +10062,51 @@ msgstr "$(ELEVATION) - 海拔"
 
 #: ../src/gui/gtkentry.c:225
 msgid "$(STARS) - star rating as number (-1 for rejected)"
-msgstr "$(STARS) -給定星級 (-1 棄用)"
+msgstr "$(STARS) - 星級評分（-1 表示不合格）"
 
 #: ../src/gui/gtkentry.c:226
 msgid "$(RATING.ICONS) - star/reject rating in icon form"
-msgstr "$(RATING.ICONS) - 星等/棄用圖示"
+msgstr "$(RATING.ICONS) - 評分圖示"
 
 #: ../src/gui/gtkentry.c:227
 msgid "$(LABELS) - color labels as text"
-msgstr "$(LABELS) - 色彩標籤為文字"
+msgstr "$(LABELS) - 文字形式的色彩標籤"
 
 #: ../src/gui/gtkentry.c:228
 msgid "$(LABELS.ICONS) - color labels as icons"
-msgstr "$(LABELS.ICONS) - 色彩標籤為圖示"
+msgstr "$(LABELS.ICONS) - 圖示形式的色彩標籤"
 
 #: ../src/gui/gtkentry.c:229
 msgid "$(ID) - image ID"
-msgstr "$(ID) -影像編號"
+msgstr "$(ID) - 影像識別碼"
 
 #: ../src/gui/gtkentry.c:230
 msgid "$(TITLE) - title from metadata"
-msgstr "$(TITLE) - 來自詮釋資料的標題"
+msgstr "$(TITLE)- 詮釋資料中的標題"
 
 #: ../src/gui/gtkentry.c:231
 msgid "$(DESCRIPTION) - description from metadata"
-msgstr "$(DESCRIPTION) - 來自詮釋資料的描述"
+msgstr "$(DESCRIPTION) - 詮釋資料中的描述"
 
 #: ../src/gui/gtkentry.c:232
 msgid "$(CREATOR) - creator from metadata"
-msgstr "$(CREATOR) - 來自詮釋資料的創作者"
+msgstr "$(CREATOR) - 詮釋資料中的創作者"
 
 #: ../src/gui/gtkentry.c:233
 msgid "$(PUBLISHER) - publisher from metadata"
-msgstr "$(PUBLISHER) - 來自詮釋資料的發佈者"
+msgstr "$(PUBLISHER) - 詮釋資料中的發布者"
 
 #: ../src/gui/gtkentry.c:234
 msgid "$(RIGHTS) - rights from metadata"
-msgstr "$(RIGHTS) - 來自詮釋資料的版權"
+msgstr "$(RIGHTS) - 詮釋資料中的版權"
 
 #: ../src/gui/gtkentry.c:235
 msgid "$(USERNAME) - login name"
-msgstr "$(USERNAME) - 登錄名稱"
+msgstr "$(USERNAME) - 使用者名稱"
 
 #: ../src/gui/gtkentry.c:236
 msgid "$(FOLDER.PICTURES) - pictures folder"
-msgstr "$(FOLDER.PICTURES) - 圖片目錄"
+msgstr "$(FOLDER.PICTURES) - 影像資料夾"
 
 #: ../src/gui/gtkentry.c:237
 msgid "$(FOLDER.HOME) - home folder"
@@ -9931,19 +10114,19 @@ msgstr "$(FOLDER.HOME) - 家目錄"
 
 #: ../src/gui/gtkentry.c:238
 msgid "$(FOLDER.DESKTOP) - desktop folder"
-msgstr "$(FOLDER.DESKTOP) - 桌面目錄"
+msgstr "$(FOLDER.DESKTOP) - 桌面資料夾"
 
 #: ../src/gui/gtkentry.c:239
 msgid "$(OPENCL.ACTIVATED) - whether OpenCL is activated"
-msgstr "$(OPENCL.ACTIVATED) - OpenCL 是否啓用"
+msgstr "$(OPENCL.ACTIVATED) - OpenCL 是否啟用"
 
 #: ../src/gui/gtkentry.c:240
 msgid "$(CATEGORY0(category)) - subtag of level 0 in hierarchical tags"
-msgstr "$(CATEGORY0(category)) - 結構化標籤中的 0 級子標籤"
+msgstr "$(CATEGORY0(category)) - 樹狀標籤裡級別為 0 的子標籤"
 
 #: ../src/gui/gtkentry.c:241
 msgid "$(TAGS) - tags as set in metadata settings"
-msgstr "$(TAGS) - 詮釋資料設定中的標籤"
+msgstr "$(TAGS) - 詮釋資料中的標籤"
 
 #: ../src/gui/gtkentry.c:242
 msgid "$(DARKTABLE.NAME) - darktable name"
@@ -9951,11 +10134,11 @@ msgstr "$(DARKTABLE.NAME) - darktable 名稱"
 
 #: ../src/gui/gtkentry.c:243
 msgid "$(DARKTABLE.VERSION) - current darktable version"
-msgstr "$(DARKTABLE.VERSION) - 目前 darktable 版本"
+msgstr "$(DARKTABLE.VERSION) - 目前的 darktable 版本"
 
 #: ../src/gui/guides.c:30 ../src/iop/colorcorrection.c:263
 msgid "grid"
-msgstr "網格"
+msgstr "格線"
 
 #: ../src/gui/guides.c:31
 msgid "rules of thirds"
@@ -9963,7 +10146,7 @@ msgstr "三分法"
 
 #: ../src/gui/guides.c:32
 msgid "metering"
-msgstr "測光"
+msgstr "測量"
 
 #: ../src/gui/guides.c:33 ../src/iop/ashift.c:5747
 msgid "perspective"
@@ -9971,27 +10154,27 @@ msgstr "透視"
 
 #: ../src/gui/guides.c:34
 msgid "diagonal method"
-msgstr "對角線法"
+msgstr "對角線"
 
 #: ../src/gui/guides.c:35
 msgid "harmonious triangles"
-msgstr "和諧三角"
+msgstr "和諧三角形"
 
 #: ../src/gui/guides.c:36
 msgid "golden sections"
-msgstr "黃金分割部分"
+msgstr "黃金比例分割"
 
 #: ../src/gui/guides.c:37
 msgid "golden spiral"
-msgstr "黃金螺線"
+msgstr "黃金比例螺旋"
 
 #: ../src/gui/guides.c:38
 msgid "golden spiral sections"
-msgstr "黃金螺線分割"
+msgstr "黃金比例螺旋分割"
 
 #: ../src/gui/guides.c:39
 msgid "golden mean (all guides)"
-msgstr "黃金比例(所有參考線)"
+msgstr "黃金比例（所有參考線）"
 
 #: ../src/gui/guides.c:218
 msgid "horizontal lines"
@@ -9999,7 +10182,7 @@ msgstr "水平線"
 
 #: ../src/gui/guides.c:219
 msgid "number of horizontal guide lines"
-msgstr "水平參考線的數量"
+msgstr "水平參考線數量"
 
 #: ../src/gui/guides.c:228
 msgid "vertical lines"
@@ -10007,23 +10190,23 @@ msgstr "垂直線"
 
 #: ../src/gui/guides.c:229
 msgid "number of vertical guide lines"
-msgstr "垂直參考線的數量"
+msgstr "垂直參考線數量"
 
 #: ../src/gui/guides.c:238
 msgid "subdivisions"
-msgstr "分部"
+msgstr "次要格線"
 
 #: ../src/gui/guides.c:239
 msgid "number of subdivisions per grid rectangle"
-msgstr "每一網格正方形細分的數量"
+msgstr "次要格線數量"
 
 #. title
 #: ../src/gui/guides.c:700
 msgid "global guide overlay settings"
-msgstr "全局參考線疊加層設定"
+msgstr "全體參考線設定"
 
 #: ../src/gui/guides.c:710 ../src/gui/guides.c:719 ../src/gui/guides.c:727
-#: ../src/gui/guides.c:740 ../src/views/darkroom.c:2589
+#: ../src/gui/guides.c:740 ../src/views/darkroom.c:2590
 msgid "guide lines"
 msgstr "參考線"
 
@@ -10037,16 +10220,16 @@ msgstr "翻轉參考線"
 
 #: ../src/gui/guides.c:713
 msgid "horizontally"
-msgstr "水平的"
+msgstr "水平翻轉"
 
 #: ../src/gui/guides.c:714
 msgid "vertically"
-msgstr "垂直的"
+msgstr "垂直翻轉"
 
 #: ../src/gui/guides.c:715 ../src/iop/ashift.c:5837 ../src/iop/clipping.c:2114
 #: ../src/iop/colorbalance.c:1865
 msgid "both"
-msgstr "兩者"
+msgstr "全部"
 
 #: ../src/gui/guides.c:720
 msgid "setup guide lines"
@@ -10054,16 +10237,16 @@ msgstr "設定參考線"
 
 #: ../src/gui/guides.c:727
 msgid "overlay color"
-msgstr "疊加的顏色"
+msgstr "參考線顏色"
 
 #: ../src/gui/guides.c:727
 msgid "set overlay color"
-msgstr "設定疊加的顏色"
+msgstr "設定參考線的顏色"
 
 #: ../src/gui/guides.c:741
 msgid ""
 "set the contrast between the lightest and darkest part of the guide overlays"
-msgstr "設定引導疊加層最亮與最暗的對比度"
+msgstr "設定參考線亮暗線段的對比"
 
 #: ../src/gui/guides.c:847 ../src/gui/guides.c:893
 msgid "show guides"
@@ -10071,7 +10254,7 @@ msgstr "顯示參考線"
 
 #: ../src/gui/guides.c:902
 msgid "show guide overlay when this module has focus"
-msgstr "在焦點模組上顯示參考線疊加層"
+msgstr "當此模組被選取時自動顯示參考線"
 
 #: ../src/gui/guides.c:904
 msgid ""
@@ -10079,43 +10262,43 @@ msgid ""
 "note that these settings are applied globally and will impact any module "
 "that shows guide overlays"
 msgstr ""
-"更改全局參考線設定\n"
-"注意:此全局設定會套用於所有顯示參考線層的模組"
+"更改參考線全體設定\n"
+"這些設定是共用的，會影響所有模組顯示的參考線"
 
 #: ../src/gui/hist_dialog.c:193
 msgid "select parts to copy"
-msgstr "選擇要複製的部分"
+msgstr "選擇要複製的項目"
 
 #: ../src/gui/hist_dialog.c:193
 msgid "select parts to paste"
-msgstr "選擇要貼上的部分"
+msgstr "選擇要貼上的項目"
 
 #: ../src/gui/hist_dialog.c:196 ../src/gui/styles_dialog.c:421
 msgid "select _all"
-msgstr "全選 (_a)"
+msgstr "選取全部（_A）"
 
 #: ../src/gui/hist_dialog.c:197 ../src/gui/styles_dialog.c:422
 msgid "select _none"
-msgstr "全不選 (_n)"
+msgstr "取消選取（_N）"
 
 #: ../src/gui/hist_dialog.c:225 ../src/gui/styles_dialog.c:488
 #: ../src/gui/styles_dialog.c:497
 msgid "include"
-msgstr "包含"
+msgstr "包括"
 
 #: ../src/gui/hist_dialog.c:241 ../src/gui/styles_dialog.c:536
 #: ../src/gui/styles_dialog.c:541
 msgid "item"
-msgstr "品項"
+msgstr "項目"
 
 #: ../src/gui/hist_dialog.c:293
 msgid "can't copy history out of unaltered image"
-msgstr "對未編修的影像不能複製操作歷史"
+msgstr "無法從未經後製的影像中複製編輯紀錄"
 
 #. grid headers
 #: ../src/gui/import_metadata.c:417
 msgid "metadata presets"
-msgstr "詮釋資料預置"
+msgstr "詮釋資料預設集"
 
 #: ../src/gui/import_metadata.c:420
 msgid ""
@@ -10123,13 +10306,13 @@ msgid ""
 "double-click on a label to clear the corresponding entry\n"
 "double-click on 'preset' to clear all entries"
 msgstr ""
-"預設套用的詮釋資料\n"
-"雙擊一個標籤，清除相應的條目\n"
-"雙擊“預置”以清除所有條目"
+"選擇要套用的詮釋資料（metadata）\n"
+"雙擊標籤可清除相對應的項目\n"
+"雙擊預設集可清除所有項目"
 
 #: ../src/gui/import_metadata.c:430
 msgid "from xmp"
-msgstr "從 xmp"
+msgstr "從 XMP 匯入"
 
 #: ../src/gui/import_metadata.c:433
 msgid ""
@@ -10138,18 +10321,18 @@ msgid ""
 "actions\n"
 " CAUTION: not selected metadata are cleaned up when xmp file is updated"
 msgstr ""
-"從影像中輸入選擇的詮釋資料並覆蓋預設值\n"
-"此操作將觸發查找已更新的 xmp 檔案並載入附屬 xmp 檔案\n"
-"注意:未選擇的詮釋資料將在 xmp 檔案更新時被刪除"
+"從影像中匯入選擇的詮釋資料，並覆蓋預設值\n"
+"此動作將尋找更新的 XMP 檔並載入標籤\n"
+"⚠️ 警告：未選取的資料欄位將被清除 ⚠️"
 
 #. tags
 #: ../src/gui/import_metadata.c:469
 msgid "tag presets"
-msgstr "標籤預置"
+msgstr "標籤預設集"
 
 #: ../src/gui/import_metadata.c:483
 msgid "comma separated list of tags"
-msgstr "逗號分隔的標籤列表"
+msgstr "以逗號分隔的標籤列表"
 
 #. language
 #: ../src/gui/preferences.c:275
@@ -10158,33 +10341,34 @@ msgstr "介面語言"
 
 #: ../src/gui/preferences.c:290
 msgid "double-click to reset to the system language"
-msgstr "雙擊以重置爲系統語言"
+msgstr "雙擊以重設為系統語言"
 
 #: ../src/gui/preferences.c:292
 msgid ""
 "set the language of the user interface. the system default is marked with an "
 "* (needs a restart)"
-msgstr "設置使用者介面的語言。系統預設值標記爲*(需要重新啓動)"
+msgstr "設置使用者介面的語言，系統預設值標示為 *\n"
+"更改設定後需要重新啟動程式才會生效"
 
 #: ../src/gui/preferences.c:301
 msgid "theme"
-msgstr "主題"
+msgstr "佈景主題"
 
 #: ../src/gui/preferences.c:329
 msgid "set the theme for the user interface"
-msgstr "設定使用者介面的主題"
+msgstr "設置使用者介面的主題"
 
 #: ../src/gui/preferences.c:342 ../src/gui/preferences.c:349
 msgid "use system font size"
-msgstr "使用系統字體大小"
+msgstr "使用系統字型大小"
 
 #: ../src/gui/preferences.c:358 ../src/gui/preferences.c:365
 msgid "font size in points"
-msgstr "字體大小(點)"
+msgstr "字型大小（以 pt 為單位）"
 
 #: ../src/gui/preferences.c:370
 msgid "GUI controls and text DPI"
-msgstr "GUI控件和文字DPI"
+msgstr "界面和文字解析度"
 
 #: ../src/gui/preferences.c:377
 msgid ""
@@ -10194,107 +10378,109 @@ msgid ""
 "default is 96 DPI on most systems.\n"
 "(needs a restart)."
 msgstr ""
-"調整全局GUI解析度以重新縮放控件元件、按鈕、標籤，等.\n"
-"增加對於放大的GUI，減少以符合更多的視窗內容.\n"
-"設定爲-1使用系統定義的全局解析度.\n"
-"預設值在大多數系統上爲96 DPI.\n"
-"(需要重新啓動)"
+"調整使用者介面解析度以縮放控制、按鈕、標籤等。\n"
+"增加數值以放大，減少可縮小以在容納更多內容。\n"
+"設置為 -1 則使用作業系統的解析度。"
 
 #. checkbox to allow user to modify theme with user.css
 #: ../src/gui/preferences.c:386
 msgid "modify selected theme with CSS tweaks below"
-msgstr "使用下面的CSS微調編輯選定的主題"
+msgstr "使用 CSS 調整目前選取的佈景主題"
 
 #: ../src/gui/preferences.c:394
 msgid "modify theme with CSS keyed below (saved to user.css)"
-msgstr "使用下面的CSS輸入內容修改主題(保存到user.css)"
+msgstr ""
+"修改主題，並在下面輸入 CSS\n"
+"會儲存到 C:\\Users\\username\\AppData\\Local\\darktable\\user.css"
 
 #: ../src/gui/preferences.c:415
 msgctxt "usercss"
 msgid "save CSS and apply"
-msgstr "保存 css 並套用"
+msgstr "保存 CSS 並套用"
 
 #: ../src/gui/preferences.c:421
 msgid "click to save and apply the CSS tweaks entered in this editor"
-msgstr "點擊以保存並套用在此編輯器中輸入的 CSS 微調"
+msgstr "儲存並套用此 CSS 調整"
 
 #. load default text with some pointers
 #: ../src/gui/preferences.c:439
 msgid "ERROR Loading user.css"
-msgstr "載入 user.css 時發生錯誤"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"載入使用者自訂 CSS 時出錯"
 
 #. load default text
 #: ../src/gui/preferences.c:448
 msgid "Enter CSS theme tweaks here"
-msgstr "在此處輸入 CSS 主題微調"
+msgstr "在此處輸入 CSS 來調整目前選取的佈景主題"
 
 #: ../src/gui/preferences.c:484
 msgid "darktable preferences"
-msgstr "darktable 偏好"
+msgstr "darktable 偏好設定"
 
 #: ../src/gui/preferences.c:557
 msgid "darktable needs to be restarted for settings to take effect"
-msgstr "darktable 需要重新啓動設定才能生效"
+msgstr "需要重新啟動 darktable 才能讓變更的設定生效"
 
 #. exif
 #: ../src/gui/preferences.c:796 ../src/gui/presets.c:535
 #: ../src/libs/metadata_view.c:137
 msgid "model"
-msgstr "型號"
+msgstr "相機型號"
 
 #: ../src/gui/preferences.c:800 ../src/gui/presets.c:543
 #: ../src/libs/metadata_view.c:138
 msgid "maker"
-msgstr "製造商"
+msgstr "相機品牌"
 
 #: ../src/gui/preferences.c:825 ../src/iop/ashift.c:5840
-#: ../src/iop/basicadj.c:632 ../src/iop/borders.c:1041 ../src/iop/levels.c:637
+#: ../src/iop/basicadj.c:632 ../src/iop/borders.c:1041 ../src/iop/levels.c:636
 #: ../src/iop/rgblevels.c:1066
 msgid "auto"
 msgstr "自動"
 
 #: ../src/gui/preferences.c:837
 msgid "search presets list"
-msgstr "搜尋預置表列"
+msgstr "搜尋預設集"
 
 #: ../src/gui/preferences.c:838
 msgid ""
 "incrementally search the list of presets\n"
 "press up or down keys to cycle through matches"
 msgstr ""
-"漸進式搜尋預置列表\n"
-"按上或下鍵來循環查看匹配的內容"
+"搜尋預設集清單，可局部即時顯示結果\n"
+"使用上下鍵從符合的預設集名稱中選擇"
 
 #: ../src/gui/preferences.c:844
 msgctxt "preferences"
 msgid "import..."
-msgstr "輸入…"
+msgstr "匯入"
 
 #: ../src/gui/preferences.c:848
 msgctxt "preferences"
 msgid "export..."
-msgstr "輸出..."
+msgstr "匯出"
 
 #: ../src/gui/preferences.c:985
 #, c-format
 msgid "failed to import preset %s"
-msgstr "輸入預置 %s 失敗"
+msgstr "無法匯入預設集「%s」"
 
 #: ../src/gui/preferences.c:996
 msgid "select preset(s) to import"
-msgstr "選擇要輸入的預置"
+msgstr "選擇要匯入的預設集"
 
 #: ../src/gui/preferences.c:997 ../src/libs/collect.c:409
 #: ../src/libs/copy_history.c:107 ../src/libs/geotagging.c:930
 #: ../src/libs/import.c:1497 ../src/libs/import.c:1601 ../src/libs/styles.c:512
 msgid "_open"
-msgstr "打開 (_o)"
+msgstr "開啟（_O）"
 
 #: ../src/gui/preferences.c:1006
 msgid "darktable preset files"
-msgstr "darktable 預置檔案"
+msgstr "darktable 預設集檔案"
 
-#: ../src/gui/preferences.c:1011 ../src/iop/lut3d.c:1588
+#: ../src/gui/preferences.c:1011 ../src/iop/lut3d.c:1582
 #: ../src/libs/copy_history.c:144 ../src/libs/geotagging.c:946
 #: ../src/libs/styles.c:526
 msgid "all files"
@@ -10302,36 +10488,36 @@ msgstr "全部檔案"
 
 #: ../src/gui/presets.c:59
 msgid "non-raw"
-msgstr "非 raw"
+msgstr "非 RAW 的檔案"
 
 #: ../src/gui/presets.c:59 ../src/libs/metadata_view.c:333
 msgid "raw"
-msgstr "raw"
+msgstr "RAW 原始檔"
 
 #: ../src/gui/presets.c:59
 msgid "HDR"
-msgstr "HDR"
+msgstr "高動態範圍影像"
 
 #: ../src/gui/presets.c:59 ../src/iop/monochrome.c:77 ../src/libs/image.c:611
 #: ../src/libs/metadata_view.c:341
 msgid "monochrome"
-msgstr "單色"
+msgstr "黑白濾鏡"
 
 #: ../src/gui/presets.c:165
 #, c-format
 msgid "preset `%s' is write-protected, can't delete!"
-msgstr "樣式“%s”有寫入保護，無法刪除！"
+msgstr "預設集「%s」有寫入保護，無法刪除"
 
 #: ../src/gui/presets.c:177 ../src/gui/presets.c:413 ../src/libs/lib.c:248
 #: ../src/libs/modulegroups.c:3748
 #, c-format
 msgid "do you really want to delete the preset `%s'?"
-msgstr "確定要刪除預設配置“%s”？"
+msgstr "是否要刪除預設集「%s」？"
 
 #: ../src/gui/presets.c:181 ../src/gui/presets.c:418 ../src/libs/lib.c:252
 #: ../src/libs/modulegroups.c:3752
 msgid "delete preset?"
-msgstr "刪除預置？"
+msgstr "是否要刪除預設集？"
 
 #. add new preset
 #. then show edit dialog
@@ -10340,114 +10526,116 @@ msgstr "刪除預置？"
 #: ../src/gui/presets.c:210 ../src/gui/presets.c:856 ../src/gui/presets.c:862
 #: ../src/libs/lib.c:195 ../src/libs/lib.c:212 ../src/libs/lib.c:223
 msgid "new preset"
-msgstr "新預置"
+msgstr "新建預設集"
 
 #: ../src/gui/presets.c:215
 msgid "please give preset a name"
-msgstr "請命名該預置"
+msgstr "輸入預設集的名稱"
 
 #: ../src/gui/presets.c:220
 msgid "unnamed preset"
-msgstr "未命名預置"
+msgstr "未命名的預設集"
 
 #: ../src/gui/presets.c:249
 #, c-format
 msgid ""
 "preset `%s' already exists.\n"
 "do you want to overwrite?"
-msgstr "預置“%s”已存在。想覆蓋它嗎？"
+msgstr ""
+"預設集「%s」已存在\n"
+"是否要取代既有設定？"
 
 #: ../src/gui/presets.c:254
 msgid "overwrite preset?"
-msgstr "覆蓋預置？"
+msgstr "是否要覆寫預設集？"
 
 #: ../src/gui/presets.c:376 ../src/imageio/storage/disk.c:122
 #: ../src/imageio/storage/gallery.c:109 ../src/imageio/storage/latex.c:108
 msgid "_select as output destination"
-msgstr "選爲輸出目錄"
+msgstr "選擇輸出資料夾（_S）"
 
 #: ../src/gui/presets.c:384
 #, c-format
 msgid "preset %s was successfully exported"
-msgstr "預置 %s 輸出成功"
+msgstr "預設集「%s」已成功匯出"
 
 #: ../src/gui/presets.c:473
 #, c-format
 msgid "edit `%s' for module `%s'"
-msgstr "編輯模組“%s”中的“%s”"
+msgstr "編輯預設集「%s」（供模組「%s」使用）"
 
 #: ../src/gui/presets.c:476
 msgid "_export..."
-msgstr "輸出…"
+msgstr "匯出（_E）"
 
 #: ../src/gui/presets.c:494
 msgid "name of the preset"
-msgstr "預置名稱"
+msgstr "預設集的名稱"
 
 #: ../src/gui/presets.c:502
 msgid "description or further information"
-msgstr "描述或進一步的資訊"
+msgstr "預設集描述或說明"
 
 #: ../src/gui/presets.c:505
 msgid "auto apply this preset to matching images"
-msgstr "自動套用此預置至匹配影像"
+msgstr "自動套用這個預設集在符合的影像上"
 
 #: ../src/gui/presets.c:508
 msgid "only show this preset for matching images"
-msgstr "只對匹配的影像顯示此預置"
+msgstr "在符合的影像上只顯示這個預設集"
 
 #: ../src/gui/presets.c:509
 msgid ""
 "be very careful with this option. this might be the last time you see your "
 "preset."
-msgstr "請格外小心此選項。這可能是你最後一次看到你的預置。"
+msgstr "啟用此選項時要非常小心，這可能是最後一次看到這個模組的預設集"
 
 #: ../src/gui/presets.c:534
 #, no-c-format
 msgid "string to match model (use % as wildcard)"
-msgstr "匹配型號的字串(使用 % 做爲萬用字元)"
+msgstr "比對相機型號（使用 % 作為萬用字元）"
 
 #: ../src/gui/presets.c:542
 #, no-c-format
 msgid "string to match maker (use % as wildcard)"
-msgstr "匹配製造商的字串(使用 % 作爲萬用字元)"
+msgstr "比對相機品牌（使用 % 作為萬用字元）"
 
 #: ../src/gui/presets.c:550
 #, no-c-format
 msgid "string to match lens (use % as wildcard)"
-msgstr "匹配鏡頭的字串(使用 % 作爲萬用字元)"
+msgstr "比對鏡頭型號（使用 % 作為萬用字元）"
 
 #: ../src/gui/presets.c:560
 msgid "minimum ISO value"
-msgstr "最小 ISO 值"
+msgstr "最低感光度（ISO）"
 
 #: ../src/gui/presets.c:563
 msgid "maximum ISO value"
-msgstr "最大 ISO 值"
+msgstr "最高感光度（ISO）"
 
 #: ../src/gui/presets.c:574
 msgid "minimum exposure time"
-msgstr "最小曝光時間"
+msgstr "最短曝光時間"
 
 #: ../src/gui/presets.c:575
 msgid "maximum exposure time"
-msgstr "最大曝光時間"
+msgstr "最長曝光時間"
 
 #: ../src/gui/presets.c:589
 msgid "minimum aperture value"
-msgstr "最小光圈值"
+msgstr "最大光圈（最小數值）"
 
 #: ../src/gui/presets.c:590
 msgid "maximum aperture value"
-msgstr "最大光圈值"
+msgstr "最小光圈（最大數值）"
 
 #: ../src/gui/presets.c:606
 msgid "minimum focal length"
-msgstr "最小焦距"
+msgstr "最短鏡頭焦距"
 
 #: ../src/gui/presets.c:607
 msgid "maximum focal length"
-msgstr "最大焦距"
+msgstr "最長鏡頭焦距"
 
 #. raw/hdr/ldr/mono/color
 #: ../src/gui/presets.c:613 ../src/imageio/format/j2k.c:651
@@ -10456,111 +10644,113 @@ msgstr "格式"
 
 #: ../src/gui/presets.c:616
 msgid "select image types you want this preset to be available for"
-msgstr "選擇此預置可以使用的影像類型"
+msgstr "勾選這個預設集適用的影像類型"
 
 #: ../src/gui/presets.c:791
 #, c-format
 msgid "preset `%s' is write-protected! can't edit it!"
-msgstr "預置“%s”有寫入保護，無法編輯！"
+msgstr "預設集「%s」有寫入保護，無法編輯"
 
 #: ../src/gui/presets.c:820 ../src/libs/lib.c:161
 #, c-format
 msgid "do you really want to update the preset `%s'?"
-msgstr "確定要更新預配置“%s”？"
+msgstr "要更新預設集「%s」嗎？"
 
 #: ../src/gui/presets.c:824 ../src/libs/lib.c:165
 msgid "update preset?"
-msgstr "更新預置？"
+msgstr "是否要更新預設集？"
 
 #: ../src/gui/presets.c:1097 ../src/libs/modulegroups.c:3836
 #: ../src/libs/modulegroups.c:3845
 msgid "manage module layouts"
-msgstr "管理模組佈局"
+msgstr "模組布局管理"
 
 #: ../src/gui/presets.c:1105
 msgid "manage quick presets"
-msgstr "管理快速預置"
+msgstr "勾選要顯示的快速預設集"
 
 #: ../src/gui/presets.c:1277
 msgid "manage quick presets list..."
-msgstr "管理快速預置列表..."
+msgstr "管理快速預設集列表"
 
 #: ../src/gui/presets.c:1412
 msgid "(default)"
-msgstr "(預設)"
+msgstr "（預設）"
 
 #: ../src/gui/presets.c:1433
 msgid "disabled: wrong module version"
-msgstr "不啟用:錯誤的模組版本"
+msgstr "模組版本錯誤，已停用"
 
 #: ../src/gui/presets.c:1458 ../src/libs/lib.c:531
 msgid "edit this preset.."
-msgstr "編輯此預置.."
+msgstr "編輯這個預設集"
 
 #: ../src/gui/presets.c:1462 ../src/libs/lib.c:535
 msgid "delete this preset"
-msgstr "刪除此預置"
+msgstr "刪除這個預設集"
 
 #: ../src/gui/presets.c:1468 ../src/libs/lib.c:543
 msgid "store new preset.."
-msgstr "存爲新的預設.."
+msgstr "儲存新的預設集"
 
 #: ../src/gui/presets.c:1474 ../src/libs/lib.c:555
 msgid "update preset"
-msgstr "更新預置"
+msgstr "更新預設集"
 
 #: ../src/gui/styles_dialog.c:208
 #, c-format
 msgid ""
 "style `%s' already exists.\n"
 "do you want to overwrite?"
-msgstr "樣式“%s”已存在。您想覆蓋它嗎？"
+msgstr ""
+"風格檔「%s」已存在\n"
+"是否要取代它？"
 
 #: ../src/gui/styles_dialog.c:213 ../src/libs/styles.c:422
 #: ../src/libs/styles.c:605
 msgid "overwrite style?"
-msgstr "覆蓋樣式？"
+msgstr "是否要覆寫風格檔？"
 
 #: ../src/gui/styles_dialog.c:242 ../src/gui/styles_dialog.c:301
 msgid "please give style a name"
-msgstr "請命名該樣式"
+msgstr "請為風格檔命名"
 
 #: ../src/gui/styles_dialog.c:246 ../src/gui/styles_dialog.c:305
 msgid "unnamed style"
-msgstr "未命名樣式"
+msgstr "未命名的風格檔"
 
 #: ../src/gui/styles_dialog.c:293
 #, c-format
 msgid "style %s was successfully saved"
-msgstr "樣式 %s 保存成功"
+msgstr "風格檔「%s」已儲存"
 
 #: ../src/gui/styles_dialog.c:408
 msgid "edit style"
-msgstr "編輯樣式"
+msgstr "編輯風格檔"
 
 #: ../src/gui/styles_dialog.c:409
 msgid "duplicate style"
-msgstr "複製樣式"
+msgstr "複製風格檔"
 
 #: ../src/gui/styles_dialog.c:410
 msgid "creates a duplicate of the style before applying changes"
-msgstr "套用改變前先複製此樣式"
+msgstr "套用改變前建立一個此風格檔的複本"
 
 #: ../src/gui/styles_dialog.c:414
 msgid "create new style"
-msgstr "建立新樣式"
+msgstr "建立新的風格檔"
 
 #: ../src/gui/styles_dialog.c:448
 msgid "enter a name for the new style"
-msgstr "輸入新樣式的名稱"
+msgstr "輸入新的風格檔名稱"
 
 #: ../src/gui/styles_dialog.c:453
 msgid "enter a description for the new style, this description is searchable"
-msgstr "輸入新樣式描述，該描述可被搜尋到"
+msgstr "輸入風格檔的說明，該描述文字可用於搜尋"
 
 #: ../src/gui/styles_dialog.c:656
 msgid "can't create style out of unaltered image"
-msgstr "不能為未編修的影像建立樣式"
+msgstr "不能從未改變的影像建立風格檔"
 
 #: ../src/imageio/format/avif.c:89 ../src/imageio/format/pdf.c:79
 #: ../src/imageio/format/png.c:546 ../src/imageio/format/tiff.c:803
@@ -10578,37 +10768,37 @@ msgstr "12 位元"
 
 #: ../src/imageio/format/avif.c:450
 msgid "invalid AVIF bit depth!"
-msgstr "無效的 AVIF 位景深！"
+msgstr "無效的 AVIF 位元深度！"
 
 #: ../src/imageio/format/avif.c:697
 msgid "AVIF (8/10/12-bit)"
-msgstr "AVIF (8/10/12-位元)"
+msgstr "AVIF（8/10/12 位元）"
 
 #: ../src/imageio/format/avif.c:777 ../src/imageio/format/exr.cc:472
 #: ../src/imageio/format/pdf.c:682 ../src/imageio/format/png.c:545
 #: ../src/imageio/format/tiff.c:802 ../src/imageio/format/xcf.c:340
 msgid "bit depth"
-msgstr "位景深"
+msgstr "色彩深度"
 
 #: ../src/imageio/format/avif.c:790
 msgid "color information stored in an image, higher is better"
-msgstr "影像中儲存的色彩資料，越高越好"
+msgstr "影像中的色彩儲存位元精度，越高越細膩"
 
 #: ../src/imageio/format/avif.c:802
 msgid "rgb colors"
-msgstr "rgb 顏色"
+msgstr "彩色"
 
 #: ../src/imageio/format/avif.c:804
 msgid "grayscale"
-msgstr "灰度"
+msgstr "灰階"
 
 #: ../src/imageio/format/avif.c:808
 msgid "saving as grayscale will reduce the size for black & white images"
-msgstr "以灰度存儲可以降低黑白影像的大小"
+msgstr "選擇色彩模式，儲存為灰階檔案可以縮小黑白影像的尺寸"
 
 #: ../src/imageio/format/avif.c:821
 msgid "tiling"
-msgstr "分塊"
+msgstr "分塊平鋪"
 
 #: ../src/imageio/format/avif.c:829
 msgid ""
@@ -10617,8 +10807,8 @@ msgid ""
 "makes encoding faster. the impact on quality reduction is negligible, but "
 "increases the file size."
 msgstr ""
-"將影像拆分成區段以加速編碼。\n"
-"對影像品質影響可以忽略不計，但是檔案大小會有所增加。"
+"把影像分成數個區塊儲存\n"
+"編碼速度更快，對影像品質的影響極小，但會增加檔案尺寸"
 
 #: ../src/imageio/format/avif.c:846 ../src/imageio/format/webp.c:334
 msgid "compression type"
@@ -10626,7 +10816,7 @@ msgstr "壓縮方式"
 
 #: ../src/imageio/format/avif.c:854
 msgid "the compression for the image"
-msgstr "影像壓縮方式"
+msgstr "影像的壓縮方式"
 
 #. min
 #. max
@@ -10637,7 +10827,7 @@ msgstr "影像壓縮方式"
 #: ../src/imageio/format/jpeg.c:587 ../src/imageio/format/webp.c:346
 #: ../src/iop/cacorrect.c:1343 ../src/libs/camera.c:565
 msgid "quality"
-msgstr "品質"
+msgstr "影像品質"
 
 #: ../src/imageio/format/avif.c:876
 msgid ""
@@ -10651,15 +10841,13 @@ msgid ""
 "    81% -  90% -> YUV422\n"
 "     5% -  80% -> YUV420\n"
 msgstr ""
-"影像品質，較低的值意味着較少的細節。\n"
+"影像的品質，品質越低代表細節越少\n"
+"以下內容僅適用於有損壓縮的設定\n"
+"品質設定與像素格式關係：\n"
 "\n"
-"以下資訊僅適用於有損壓縮\n"
-"\n"
-"根據品質選擇像素格式\n"
-"\n"
-"    91% - 100% -> YUV444\n"
-"    81% -  90% -> YUV422\n"
-"     5% -  80% -> YUV420\n"
+"91% - 100% -> YUV444\n"
+" 81% - 90% -> YUV422\n"
+"   5% - 80% -> YUV420\n"
 
 #: ../src/imageio/format/copy.c:109 ../src/libs/copy_history.c:349
 #: ../src/libs/image.c:585
@@ -10671,16 +10859,16 @@ msgid ""
 "do a 1:1 copy of the selected files.\n"
 "the global options below do not apply!"
 msgstr ""
-"1:1 複製選定的影像。\n"
-"以下全局選項在此不適用！"
+"儲存完全相同的一比一複製\n"
+"以下選項皆不會被使用"
 
 #: ../src/imageio/format/exr.cc:214
 msgid "the selected output profile doesn't work well with exr"
-msgstr "選擇的輸出色彩配置不適合 exr"
+msgstr "選取的輸出描述檔與 EXR 不相容"
 
 #: ../src/imageio/format/exr.cc:446
 msgid "OpenEXR (16/32-bit float)"
-msgstr "OpenEXR(16/32-位元浮點)"
+msgstr "OpenEXR（16/32 位元浮點）"
 
 #: ../src/imageio/format/exr.cc:474 ../src/imageio/format/pdf.c:80
 #: ../src/imageio/format/png.c:547 ../src/imageio/format/tiff.c:804
@@ -10700,11 +10888,11 @@ msgstr "壓縮"
 #: ../src/imageio/format/exr.cc:486 ../src/imageio/format/pdf.c:699
 #: ../src/imageio/format/tiff.c:818
 msgid "uncompressed"
-msgstr "未壓縮"
+msgstr "無壓縮"
 
 #: ../src/imageio/format/exr.cc:487
 msgid "RLE"
-msgstr "長度變動編碼壓縮法"
+msgstr "RLE"
 
 #: ../src/imageio/format/exr.cc:488
 msgid "ZIPS"
@@ -10736,19 +10924,19 @@ msgstr "DWAA"
 
 #: ../src/imageio/format/exr.cc:495
 msgid "DWAB"
-msgstr "DWAA"
+msgstr "DWAB"
 
 #: ../src/imageio/format/j2k.c:618
 msgid "JPEG 2000 (12-bit)"
-msgstr "JPEG 2000 (12-位元)"
+msgstr "JPEG 2000（12 位元）"
 
 #: ../src/imageio/format/j2k.c:652
 msgid "J2K"
-msgstr "J2K"
+msgstr ".j2k（JPEG 2000）"
 
 #: ../src/imageio/format/j2k.c:653
 msgid "jp2"
-msgstr "jp2"
+msgstr ".jp2（JPEG 2000）"
 
 #: ../src/imageio/format/j2k.c:671
 msgid "DCP mode"
@@ -10756,34 +10944,34 @@ msgstr "DCP 模式"
 
 #: ../src/imageio/format/j2k.c:673
 msgid "Cinema2K, 24FPS"
-msgstr "Cinema2K, 24FPS"
+msgstr "Cinema 2K 24FPS"
 
 #: ../src/imageio/format/j2k.c:674
 msgid "Cinema2K, 48FPS"
-msgstr "Cinema2K, 48FPS"
+msgstr "Cinema 2K 48FPS"
 
 #: ../src/imageio/format/j2k.c:675
 msgid "Cinema4K, 24FPS"
-msgstr "Cinema4K, 24FPS"
+msgstr "Cinema 4K 24FPS"
 
 #: ../src/imageio/format/jpeg.c:564
 msgid "JPEG (8-bit)"
-msgstr "JPEG (8-位元)"
+msgstr "JPEG（8 位元）"
 
 #: ../src/imageio/format/pdf.c:199 ../src/imageio/format/pdf.c:479
 msgid "invalid paper size"
-msgstr "無效的紙張大小"
+msgstr "無效的紙張尺寸"
 
 #: ../src/imageio/format/pdf.c:206
 msgid "invalid border size, using 0"
-msgstr "無效的邊距大小，使用0"
+msgstr "無效的邊界尺寸，不可為 0"
 
 #: ../src/imageio/format/pdf.c:256 ../src/imageio/storage/disk.c:327
 #: ../src/imageio/storage/email.c:137 ../src/imageio/storage/gallery.c:346
-#: ../src/imageio/storage/gallery.c:386 ../src/imageio/storage/piwigo.c:1019
+#: ../src/imageio/storage/gallery.c:385 ../src/imageio/storage/piwigo.c:1019
 #, c-format
 msgid "could not export to file `%s'!"
-msgstr "無法輸出至檔案“%s”！"
+msgstr "無法匯出至檔案「%s」"
 
 #: ../src/imageio/format/pdf.c:408
 msgid "PDF"
@@ -10791,12 +10979,12 @@ msgstr "PDF"
 
 #: ../src/imageio/format/pdf.c:580
 msgid "enter the title of the pdf"
-msgstr "輸入 pdf 的標題"
+msgstr "輸入 PDF 文件標題"
 
 #. // papers
 #: ../src/imageio/format/pdf.c:592 ../src/libs/print_settings.c:2357
 msgid "paper size"
-msgstr "紙張大小"
+msgstr "紙張尺寸"
 
 #: ../src/imageio/format/pdf.c:597
 msgid ""
@@ -10804,9 +10992,8 @@ msgid ""
 "either one from the list or \"<width> [unit] x <height> <unit>\n"
 "example: 210 mm x 2.97 cm"
 msgstr ""
-"pdf 的紙張大小\n"
-"請從列表中選擇或以“<寬度> [單位] x <高度> <單位>”的形式指定\n"
-"例如:“210 mm x 2.97 cm”"
+"從列表中選擇 PDF 的紙張尺寸，或輸入指定尺寸\n"
+"「<寬> <單位> x <高> <單位>」，如：210 mm x 2.97 cm"
 
 #: ../src/imageio/format/pdf.c:607
 msgid "page orientation"
@@ -10816,22 +11003,22 @@ msgstr "頁面方向"
 #: ../src/libs/filtering.c:286 ../src/libs/filters/ratio.c:122
 #: ../src/libs/print_settings.c:2366
 msgid "portrait"
-msgstr "人像"
+msgstr "直式"
 
 #: ../src/imageio/format/pdf.c:609 ../src/iop/borders.c:1043
 #: ../src/libs/filtering.c:282 ../src/libs/filters/ratio.c:124
 #: ../src/libs/print_settings.c:2367
 msgid "landscape"
-msgstr "風景"
+msgstr "橫式"
 
 #: ../src/imageio/format/pdf.c:612
 msgid "paper orientation of the pdf"
-msgstr "pdf 的紙張方向"
+msgstr "PDF 的紙張方向"
 
 #. border
 #: ../src/imageio/format/pdf.c:617
 msgid "border"
-msgstr "邊框"
+msgstr "邊距"
 
 #: ../src/imageio/format/pdf.c:624
 msgid ""
@@ -10839,18 +11026,18 @@ msgid ""
 "format: size + unit\n"
 "examples: 10 mm, 1 inch"
 msgstr ""
-"清除 pdf 頁面四周留白\n"
-"格式:“<數值> <單位>”\n"
-"例如:“10 mm”或“1 inch”"
+"PDF 四周的留白空間\n"
+"格式：尺寸 + 單位\n"
+"如：10 mm、0.5 cm、1 inch"
 
 #. dpi
 #: ../src/imageio/format/pdf.c:635 ../src/libs/export.c:1169
 msgid "dpi"
-msgstr "dpi"
+msgstr "DPI"
 
 #: ../src/imageio/format/pdf.c:639
 msgid "dpi of the images inside the pdf"
-msgstr "pdf 內影像 dpi"
+msgstr "PDF 內影像的 DPI 設定"
 
 #: ../src/imageio/format/pdf.c:646
 msgid "rotate images"
@@ -10860,11 +11047,11 @@ msgstr "旋轉影像"
 msgid ""
 "images can be rotated to match the pdf orientation to waste less space when "
 "printing"
-msgstr "影像可以旋轉以符合 PDF 的方向，以減少列印時的空間浪費"
+msgstr "旋轉影像以符合 PDF 的方向"
 
 #: ../src/imageio/format/pdf.c:658
 msgid "TODO: pages"
-msgstr "待辦事項:頁"
+msgstr "設定多頁"
 
 #: ../src/imageio/format/pdf.c:660
 msgid "single images"
@@ -10878,23 +11065,23 @@ msgstr "聯絡清單"
 #. g_signal_connect(G_OBJECT(d->pages), "value-changed", G_CALLBACK(pages_toggle_callback), self);
 #: ../src/imageio/format/pdf.c:664
 msgid "what pages should be added to the pdf"
-msgstr "要增加至 pdf 的頁面"
+msgstr "哪些頁面要加入到 PDF 中"
 
 #: ../src/imageio/format/pdf.c:671
 msgid "embed icc profiles"
-msgstr "嵌入 icc 配置"
+msgstr "內嵌 ICC 描述檔"
 
 #: ../src/imageio/format/pdf.c:676
 msgid "images can be tagged with their icc profile"
-msgstr "影像可以標記 icc 配置"
+msgstr "儲存影像的 ICC 描述檔"
 
 #: ../src/imageio/format/pdf.c:692
 msgid "bits per channel of the embedded images"
-msgstr "內嵌影像每個通道的位元數"
+msgstr "影像的每通道位元數"
 
 #: ../src/imageio/format/pdf.c:700 ../src/imageio/format/tiff.c:819
 msgid "deflate"
-msgstr "緊縮"
+msgstr "DEFLATE（ZIP）壓縮"
 
 #: ../src/imageio/format/pdf.c:703
 msgid ""
@@ -10902,9 +11089,8 @@ msgid ""
 "uncompressed -- fast but big files\n"
 "deflate -- smaller files but slower"
 msgstr ""
-"影像壓縮方式\n"
-"不壓縮 —快但檔案大\n"
-"緊縮(deflate) —檔案小但較慢"
+"無壓縮：快速但文件大\n"
+"　壓縮：較慢但文件小"
 
 #: ../src/imageio/format/pdf.c:711
 msgid "image mode"
@@ -10928,73 +11114,73 @@ msgid ""
 "draft -- images are replaced with boxes\n"
 "debug -- only show the outlines and bounding boxen"
 msgstr ""
-"正常 —— 在 pdf 中放入影像\n"
-"草稿 —— 把影像換成方框\n"
-"除錯 —— 只顯示輪廓和邊界框"
+"一般 — 影像正常置入 PDF\n"
+"草稿 — 把影像替換為方框\n"
+"除錯 — 只顯示輪廓和邊界框"
 
 #: ../src/imageio/format/pfm.c:118
 msgid "PFM (float)"
-msgstr "PFM(浮點)"
+msgstr "PFM（浮點）"
 
 #: ../src/imageio/format/png.c:503
 msgid "PNG (8/16-bit)"
-msgstr "PNG(8/16-位元)"
+msgstr "PNG（8/16 位元）"
 
 #: ../src/imageio/format/ppm.c:109
 msgid "PPM (16-bit)"
-msgstr "PPM(16-位元)"
+msgstr "PPM（16 位元）"
 
 #: ../src/imageio/format/tiff.c:228
 msgid "will export as a grayscale image"
-msgstr "將以灰階影像輸出"
+msgstr "將匯出為灰階影像"
 
 #: ../src/imageio/format/tiff.c:724
 msgid "TIFF (8/16/32-bit)"
-msgstr "TIFF(8/16/32-位元)"
+msgstr "TIFF（8/16/32 位元）"
 
 #: ../src/imageio/format/tiff.c:805 ../src/imageio/format/xcf.c:343
 msgid "32 bit (float)"
-msgstr "32 bit(浮點)"
+msgstr "32 位元（浮點）"
 
 #: ../src/imageio/format/tiff.c:820
 msgid "deflate with predictor"
-msgstr "以預測器緊縮"
+msgstr "預測壓縮法（有利漸層影像）"
 
 #: ../src/imageio/format/tiff.c:831
 msgid "compression level"
-msgstr "壓縮級數"
+msgstr "壓縮程度"
 
 #: ../src/imageio/format/tiff.c:843
 msgid "b&w image"
-msgstr "黑白圖片"
+msgstr "黑白影像"
 
 #: ../src/imageio/format/tiff.c:844
 msgid "write rgb colors"
-msgstr "寫入 rgb 顏色"
+msgstr "儲存 RGB 彩色影像"
 
 #: ../src/imageio/format/tiff.c:845
 msgid "write grayscale"
-msgstr "寫入灰階"
+msgstr "儲存成灰階影像"
 
 #: ../src/imageio/format/webp.c:297
 msgid "WebP (8-bit)"
-msgstr "WebP(8-位元)"
+msgstr "WebP（8 位元）"
 
 #: ../src/imageio/format/webp.c:335
 msgid "lossy"
-msgstr "有損"
+msgstr "有損壓縮"
 
 #: ../src/imageio/format/webp.c:336
 msgid "lossless"
-msgstr "無損"
+msgstr "無失真壓縮"
 
 #: ../src/imageio/format/webp.c:349
 msgid "applies only to lossy setting"
-msgstr "僅套用於有損壓縮設定"
+msgstr "僅對有損壓縮有用"
 
 #: ../src/imageio/format/webp.c:360
 msgid "image hint"
-msgstr "圖片類型提示"
+msgstr "影像類別提示"
 
 #: ../src/imageio/format/webp.c:362
 msgid ""
@@ -11003,10 +11189,10 @@ msgid ""
 "photo   : outdoor photograph, with natural lighting\n"
 "graphic : discrete tone image (graph, map-tile etc)"
 msgstr ""
-"傳遞給編碼器的圖片類型提示:\n"
-"圖片:數位照片，如人像、室內拍攝照片\n"
-"照片:使用自然光之戶外照片\n"
-"圖形:離散色調影像，如圖形、地圖塊等"
+"提供給編碼器的影像類別提示\n"
+"圖片：數位圖片，如：肖像、室內照\n"
+"照片：自然陽光的影像，如：風景照\n"
+"圖形：色調較少的影像，如：地圖"
 
 #: ../src/imageio/format/webp.c:367
 msgid "picture"
@@ -11022,11 +11208,11 @@ msgstr "圖形"
 
 #: ../src/imageio/format/xcf.c:299
 msgid "xcf"
-msgstr "xcf"
+msgstr "XCF（GIMP 格式）"
 
 #: ../src/imageio/storage/disk.c:70 ../src/libs/export.c:1053
 msgid "file on disk"
-msgstr "硬碟上的檔案"
+msgstr "硬碟裡的檔案"
 
 #: ../src/imageio/storage/disk.c:182 ../src/imageio/storage/gallery.c:166
 #: ../src/imageio/storage/latex.c:165
@@ -11035,52 +11221,51 @@ msgid ""
 "variables support bash like string manipulation\n"
 "type '$(' to activate the completion and see the list of variables"
 msgstr ""
-"輸入存放輸出影像的路徑名稱\n"
-"變數支援bash式的字串操作\n"
-"輸入 '$('可啟用自動補全並觀看變數列表"
+"輸入匯出影像的位置\n"
+"可使用 darktable 變數，輸入「$(」會顯示變數列表"
 
 #: ../src/imageio/storage/disk.c:193
 msgid "on conflict"
-msgstr "當衝突時"
+msgstr "檔名衝突時"
 
 #: ../src/imageio/storage/disk.c:194
 msgid "create unique filename"
-msgstr "建立不重複的檔名"
+msgstr "另存新檔案"
 
 #: ../src/imageio/storage/disk.c:195 ../src/libs/copy_history.c:378
 #: ../src/libs/image.c:601 ../src/libs/styles.c:425 ../src/libs/styles.c:608
 #: ../src/libs/styles.c:829
 msgid "overwrite"
-msgstr "覆蓋"
+msgstr "覆寫既有檔案"
 
 #: ../src/imageio/storage/disk.c:196 ../src/libs/styles.c:424
 #: ../src/libs/styles.c:607
 msgid "skip"
-msgstr "跳過"
+msgstr "略過而不儲存"
 
 #: ../src/imageio/storage/disk.c:276 ../src/imageio/storage/gallery.c:268
 #: ../src/imageio/storage/latex.c:266
 #, c-format
 msgid "could not create directory `%s'!"
-msgstr "無法建立目錄“%s”！"
+msgstr "無法建立「%s」資料夾"
 
 #: ../src/imageio/storage/disk.c:283
 #, c-format
 msgid "could not write to directory `%s'!"
-msgstr "無法寫入目錄“%s”！"
+msgstr "無法寫入「%s」資料夾"
 
 #: ../src/imageio/storage/disk.c:313
 #, c-format
 msgid "%d/%d skipping `%s'"
 msgid_plural "%d/%d skipping `%s'"
-msgstr[0] "%d/%d，先跳過“%s”"
+msgstr[0] "%d/%d 正在略過「%s」"
 
 #: ../src/imageio/storage/disk.c:332 ../src/imageio/storage/email.c:144
-#: ../src/imageio/storage/gallery.c:394 ../src/imageio/storage/latex.c:355
+#: ../src/imageio/storage/gallery.c:393 ../src/imageio/storage/latex.c:354
 #, c-format
 msgid "%d/%d exported to `%s'"
 msgid_plural "%d/%d exported to `%s'"
-msgstr[0] "%d/%d 輸出到 `%s'"
+msgstr[0] "%d/%d 匯出至「%s」"
 
 #: ../src/imageio/storage/disk.c:391
 msgid ""
@@ -11089,9 +11274,9 @@ msgid ""
 "\n"
 "do you really want to continue?"
 msgstr ""
-"即將在覆蓋模式下輸出，這將覆蓋任何現有的影像。\n"
+"以覆寫模式匯出，將會取代所有已經存在的同名影像\n"
 "\n"
-"是否繼續？"
+"是否要繼續？"
 
 #: ../src/imageio/storage/email.c:52
 msgid "send as email"
@@ -11099,15 +11284,15 @@ msgstr "以郵件發送"
 
 #: ../src/imageio/storage/email.c:198
 msgid "images exported from darktable"
-msgstr "從 darktable 輸出的影像"
+msgstr "darktable 匯出的影像"
 
 #: ../src/imageio/storage/email.c:251
 msgid "could not launch email client!"
-msgstr "無法啓動電子郵件程式！"
+msgstr "無法啟動電子郵件程式"
 
 #: ../src/imageio/storage/gallery.c:72
 msgid "website gallery"
-msgstr "網站畫廊"
+msgstr "網路相簿"
 
 #: ../src/imageio/storage/gallery.c:182
 msgid "enter the title of the website"
@@ -11120,24 +11305,24 @@ msgstr "LaTeX 書籍模板"
 #. TODO: support title, author, subject, keywords (collect tags?)
 #: ../src/imageio/storage/latex.c:184
 msgid "enter the title of the book"
-msgstr "輸入書籍標題"
+msgstr "輸入書籍名稱"
 
 #: ../src/imageio/storage/piwigo.c:477
 msgid "authenticated"
-msgstr "已認證"
+msgstr "已驗證帳號"
 
 #: ../src/imageio/storage/piwigo.c:485 ../src/imageio/storage/piwigo.c:500
 #: ../src/imageio/storage/piwigo.c:512
 msgid "not authenticated"
-msgstr "未認證"
+msgstr "未驗證帳號"
 
 #: ../src/imageio/storage/piwigo.c:491
 msgid "not authenticated, cannot reach server"
-msgstr "未認證，無法連接至伺服器"
+msgstr "未經驗證，無法連接伺服器"
 
 #: ../src/imageio/storage/piwigo.c:540 ../src/imageio/storage/piwigo.c:622
 msgid "create new album"
-msgstr "建立新相簿"
+msgstr "建立新的相簿"
 
 #: ../src/imageio/storage/piwigo.c:623
 msgid "---"
@@ -11149,7 +11334,7 @@ msgstr "無法更新相簿列表"
 
 #: ../src/imageio/storage/piwigo.c:769
 msgid "piwigo"
-msgstr "piwigo"
+msgstr "Piwigo 線上相簿"
 
 #: ../src/imageio/storage/piwigo.c:794
 msgid "accounts"
@@ -11162,8 +11347,7 @@ msgid ""
 "specify http:// if non secure server"
 msgstr ""
 "伺服器名稱\n"
-"預設協議爲 https\n"
-"非加密連接伺服器需指定“http://”"
+"預設協定為 https，如果沒有安全伺服器請指明 http: //"
 
 #: ../src/imageio/storage/piwigo.c:816
 msgid "server"
@@ -11184,11 +11368,11 @@ msgstr "登入"
 
 #: ../src/imageio/storage/piwigo.c:846
 msgid "piwigo login"
-msgstr "登入 piwigo"
+msgstr "登入 Piwigo"
 
 #: ../src/imageio/storage/piwigo.c:861
 msgid "visible to"
-msgstr "可見性"
+msgstr "隱私設定"
 
 #: ../src/imageio/storage/piwigo.c:862
 msgid "everyone"
@@ -11208,7 +11392,7 @@ msgstr "家庭"
 
 #: ../src/imageio/storage/piwigo.c:866
 msgid "you"
-msgstr "你"
+msgstr "僅限自己"
 
 #. Available albums
 #: ../src/imageio/storage/piwigo.c:874
@@ -11222,32 +11406,32 @@ msgstr "更新相簿列表"
 #. Album title
 #: ../src/imageio/storage/piwigo.c:898
 msgid "new album"
-msgstr "新相簿"
+msgstr "新的相簿"
 
 #. parent album list
 #. Available albums
 #: ../src/imageio/storage/piwigo.c:906
 msgid "parent album"
-msgstr "父相簿"
+msgstr "上一層相簿"
 
 #: ../src/imageio/storage/piwigo.c:910
 msgid "click login button to start"
-msgstr "點擊“登錄”按鈕以開始"
+msgstr "點擊「登入」按鈕開始作業"
 
 #: ../src/imageio/storage/piwigo.c:1038
 msgid "cannot create a new piwigo album!"
-msgstr "無法建立新piwigo相簿！"
+msgstr "無法建立新的 Piwigo 相簿"
 
 #: ../src/imageio/storage/piwigo.c:1047
 msgid "could not upload to piwigo!"
-msgstr "無法上傳到 piwigo！"
+msgstr "無法上傳至 Piwigo"
 
 #. this makes sense only if the export was successful
 #: ../src/imageio/storage/piwigo.c:1076
 #, c-format
 msgid "%d/%d exported to piwigo webalbum"
 msgid_plural "%d/%d exported to piwigo webalbum"
-msgstr[0] "%d/%d 輸出到 piwigo 網絡相簿"
+msgstr[0] "%d/%d 已匯出至 Piwigo 網路相簿"
 
 #: ../src/iop/ashift.c:121
 msgid "rotate and perspective"
@@ -11255,19 +11439,24 @@ msgstr "旋轉與透視"
 
 #: ../src/iop/ashift.c:126
 msgid "rotation|keystone|distortion|crop|reframe"
-msgstr "旋轉|梯形失真|扭曲|裁剪|再構造"
+msgstr "梯形校正|變形|裁切|rotate|perspective"
 
 #: ../src/iop/ashift.c:131
 msgid "rotate or distort perspective"
-msgstr "旋轉或扭曲透視"
+msgstr ""
+"旋轉與透視 | rotate and perspective\n"
+"\n"
+"旋轉校正影像角度或是校正透視變形\n"
+"繪製水平與垂直結構線後自動校正\n"
+"或是使用手動調整數值校正"
 
 #: ../src/iop/ashift.c:132 ../src/iop/channelmixer.c:139
 #: ../src/iop/channelmixerrgb.c:233 ../src/iop/clipping.c:320
 #: ../src/iop/colorbalance.c:159 ../src/iop/colorbalancergb.c:184
 #: ../src/iop/colorchecker.c:126 ../src/iop/colorcorrection.c:77
-#: ../src/iop/crop.c:138 ../src/iop/lut3d.c:139
+#: ../src/iop/crop.c:138 ../src/iop/lut3d.c:140
 msgid "corrective or creative"
-msgstr "修正或創作"
+msgstr "修正或創意"
 
 #: ../src/iop/ashift.c:133 ../src/iop/ashift.c:135 ../src/iop/basicadj.c:148
 #: ../src/iop/bilateral.cc:100 ../src/iop/bilateral.cc:102
@@ -11285,7 +11474,7 @@ msgstr "修正或創作"
 #: ../src/iop/splittoning.c:106 ../src/iop/spots.c:68 ../src/iop/spots.c:70
 #: ../src/iop/toneequal.c:307 ../src/iop/velvia.c:106 ../src/iop/velvia.c:108
 msgid "linear, RGB, scene-referred"
-msgstr "線性、RGB、場景工作流程"
+msgstr "線性、RGB、場景參照"
 
 #: ../src/iop/ashift.c:134 ../src/iop/borders.c:189 ../src/iop/clipping.c:322
 #: ../src/iop/crop.c:139 ../src/iop/flip.c:106 ../src/iop/liquify.c:298
@@ -11294,19 +11483,25 @@ msgstr "幾何、RGB"
 
 #: ../src/iop/ashift.c:2670
 msgid "automatic cropping failed"
-msgstr "自動剪裁失敗"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"自動裁切失敗"
 
 #: ../src/iop/ashift.c:3037 ../src/iop/ashift.c:3087 ../src/iop/ashift.c:3134
 msgid "data pending - please repeat"
-msgstr "資料待定 - 請重複"
+msgstr "資料處理中，請重試"
 
 #: ../src/iop/ashift.c:3046
 msgid "could not detect structural data in image"
-msgstr "無法偵測出影像中的結構資料"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"無法偵測影像中的結構"
 
 #: ../src/iop/ashift.c:3057
 msgid "could not run outlier removal"
-msgstr "無法移除離群值"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"無法移除離群數值"
 
 #: ../src/iop/ashift.c:3219
 #, c-format
@@ -11314,29 +11509,32 @@ msgid ""
 "not enough structure for automatic correction\n"
 "minimum %d lines in each relevant direction"
 msgstr ""
-"沒有足夠的結構進行自動修正\n"
-"每個相關方向上最少需要 %d 條直線"
+"⚠️ 錯誤 ⚠️\n"
+"沒有足夠的結構進行自動校正\n"
+"每個方向最少必須有 %d 條直線"
 
 #: ../src/iop/ashift.c:3224
 msgid "automatic correction failed, please correct manually"
-msgstr "自動修正失敗，請手動修正"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"自動校正失敗，請以手動校正"
 
 #. if count > MAX_SAVED_LINES we alert that the next lines won't be saved in params
 #. but they still may be used for the current section (that's why we still allow them)
 #: ../src/iop/ashift.c:4746
 #, c-format
 msgid "only %d lines can be saved in parameters"
-msgstr "參數內僅可保存 %d 行"
+msgstr "只能儲存 %d 條直線"
 
 #: ../src/iop/ashift.c:5423 ../src/iop/ashift.c:5424 ../src/iop/ashift.c:5526
 #: ../src/iop/ashift.c:5527
 #, c-format
 msgid "lens shift (%s)"
-msgstr "鏡頭平移(%s)"
+msgstr "鏡頭平移 %s"
 
 #: ../src/iop/ashift.c:5704
 msgid "manual perspective"
-msgstr "手動透視"
+msgstr "手動校正透視"
 
 #: ../src/iop/ashift.c:5754 ../src/iop/ashift.c:5838 ../src/iop/ashift.c:5839
 #: ../src/iop/ashift.c:5840
@@ -11349,47 +11547,63 @@ msgid ""
 "right-click and drag to define a horizontal or vertical line by drawing on "
 "the image"
 msgstr ""
-"旋轉影像\n"
-"按住右鍵並拖拉以在影像上繪製水平或垂直線"
+"影像旋轉角度\n"
+"未繪製結構線時，右鍵於影像上點擊拖曳水平線可自動旋轉"
 
 #: ../src/iop/ashift.c:5788 ../src/iop/ashift.c:5789
 msgid "apply lens shift correction in one direction"
-msgstr "在一個方向上套用鏡頭偏移校正"
+msgstr "調整透視變形校正量"
 
 #: ../src/iop/ashift.c:5790
 msgid "shear the image along one diagonal"
-msgstr "沿一條對角線剪切影像"
+msgstr ""
+"對角線剪切校正影像\n"
+"若同時處理水平和垂直透視校正就必須使用使功能"
 
 #: ../src/iop/ashift.c:5791 ../src/iop/clipping.c:2135
 msgid "automatically crop to avoid black edges"
-msgstr "自動裁剪以避免黑邊"
+msgstr ""
+"自動裁切掉因透視與旋轉校正造成的周圍黑色區域\n"
+"\n"
+"關閉：不裁切，保留全部影像範圍\n"
+"最大面積：保留裁切後可用的最大面積區域\n"
+"原始比例：保持影像的長寬比例，此選項可以手動移動調整影像上的裁切區域"
 
 #: ../src/iop/ashift.c:5792
 msgid ""
 "lens model of the perspective correction: generic or according to the focal "
 "length"
-msgstr "透視校正的鏡頭模組:通用還是按焦距"
+msgstr ""
+"依鏡頭焦距執行透視校正，影響校正算法\n"
+"\n"
+"通用：假設使用 135 片幅相機 28mm 的視角\n"
+"特定：依據特定的鏡頭焦距和視角計算透視校正"
 
 #: ../src/iop/ashift.c:5794
 msgid "focal length of the lens, default value set from EXIF data if available"
-msgstr "鏡頭的焦距，以exif資料為預設值(如果有的話)"
+msgstr "鏡頭的焦長，從 EXIF 中讀取資料作為預設值"
 
 #: ../src/iop/ashift.c:5796
 msgid ""
 "crop factor of the camera sensor, default value set from EXIF data if "
 "available, manual setting is often required"
 msgstr ""
-"相機傳感器的剪裁係數，以 exif 資料為預設值(如果有的話)。通常需要手動設置"
+"相機感光元件相對 135 相機的裁剪係數\n"
+"若 EXIF 內有資料設定會自動使用，但通常需要手動設定"
 
 #: ../src/iop/ashift.c:5799
 msgid ""
 "the level of lens dependent correction, set to maximum for full lens "
 "dependency, set to zero for the generic case"
-msgstr "與鏡頭相關的校正程度，全鏡頭相關設定爲最大，一般情況設定爲零"
+msgstr ""
+"透視校正與鏡頭相關的程度\n"
+"設定最大值校正完全與鏡頭相依，設置為零作為通用選項"
 
 #: ../src/iop/ashift.c:5801
 msgid "adjust aspect ratio of image by horizontal and vertical scaling"
-msgstr "通過水平和垂直縮放調整影像的長寬比"
+msgstr ""
+"調整鏡頭的縮放比例\n"
+"此參數可自由調整影像比例，對使用變形鏡頭拍攝的照片特別有用"
 
 #: ../src/iop/ashift.c:5802
 msgid ""
@@ -11397,9 +11611,9 @@ msgid ""
 "ctrl+click to only fit rotation\n"
 "shift+click to only fit lens shift"
 msgstr ""
-"自動修正垂直透視失真\n"
-"控制鍵 + 單擊僅符合旋轉\n"
-"shift + 單擊僅符合鏡頭偏移"
+"自動依據結構線校正垂直透視變形\n"
+"ctrl + 點擊只作旋轉校正，不校正透視變形\n"
+"shift + 點擊只作透視變形校正，不旋轉影像"
 
 #: ../src/iop/ashift.c:5805
 msgid ""
@@ -11407,9 +11621,9 @@ msgid ""
 "ctrl+click to only fit rotation\n"
 "shift+click to only fit lens shift"
 msgstr ""
-"自動修正水平透視失真\n"
-"控制鍵 + 單擊僅符合旋轉\n"
-"shift + 單擊僅符合鏡頭偏移"
+"自動依據結構線校正水平透視變形\n"
+"ctrl + 點擊只作旋轉校正，不校正透視變形\n"
+"shift + 點擊只作透視變形校正，不旋轉影像"
 
 #: ../src/iop/ashift.c:5808
 msgid ""
@@ -11419,10 +11633,10 @@ msgid ""
 "shift+click to only fit lens shift\n"
 "ctrl+shift+click to only fit rotation and lens shift"
 msgstr ""
-"自動修正垂直/水平透視失真符合旋轉、剪切、鏡頭的垂直/水平方向偏移\n"
-"控制鍵 + 單擊僅符合旋轉\n"
-"shift + 單擊僅符合鏡頭偏移\n"
-"控制鍵 + shift + 單擊僅符合旋轉和鏡頭偏移"
+"自動依據結構線校正所有透視變形\n"
+"ctrl + 點擊只作旋轉校正，不校正透視變形\n"
+"shift + 點擊只作透視變形校正，不旋轉影像\n"
+"ctrl + shift + 點擊執行透視和旋轉校正，但不作剪切校正"
 
 #: ../src/iop/ashift.c:5814
 msgid ""
@@ -11431,18 +11645,41 @@ msgid ""
 "shift+click for an additional detail enhancement\n"
 "ctrl+shift+click for a combination of both methods"
 msgstr ""
-"自動分析影像中的直線結構\n"
-"控制鍵 + 單擊獲得額外的邊緣增強\n"
-"shift + 單擊可獲得額外的細節增強\n"
-"控制鍵 + shift + 單擊可同時獲得額外的邊緣和細節增強"
+"分析影像並自動繪製結構線\n"
+"\n"
+"點擊此選項自動分析並繪製結構線，如果無法找到足夠的結構線可使用增強分析\n"
+"ctrl + 點擊加強邊緣偵測，shift + 點擊加強對比偵測，ctrl + shift + 點擊兩者並"
+"用\n"
+"水平結構線標示為藍色，垂直結構線標示為綠色，用於自動校正\n"
+"不收斂匯聚的水平線標示為黃色，垂直線標示為紅色，不會被用於校正\n"
+"\n"
+"可手動以左鍵點擊線條將其啟用，線條將變更為藍色或綠色\n"
+"右鍵點擊手動取消結構線，線條將變更為黃色或紅色\n"
+"按著滑鼠不放以畫筆的方式連續執行結構線啟用或取消，滑鼠滾輪控制筆刷大小\n"
+"shift + 滑鼠左鍵或右鍵可圈選範圍內的線段一次啟用或取消\n"
+"完成結構線編輯之後，點擊下方的校正選項以自動完成透視校正"
 
 #: ../src/iop/ashift.c:5818
 msgid "manually define perspective rectangle"
-msgstr "手動定義透視矩形"
+msgstr ""
+"手動繪製透視矩形\n"
+"\n"
+"在影像上顯示一個矩形，調整矩形的四角以符合影像中希望保持水平和垂直的物體\n"
+"完成之後點擊下方的三個校正選項之一，以自動完成透視校正\n"
+"\n"
+"矩形形狀與位置可以隨時重新調整，完成變更後再次點擊校正重新計算"
 
 #: ../src/iop/ashift.c:5819
 msgid "manually draw structure lines"
-msgstr "手動繪製結構線"
+msgstr ""
+"手動繪製結構線\n"
+"\n"
+"在影像上單擊拖曳繪製水平和垂直線條，盡可能繪製更多的線條以利校正\n"
+"此模組會自動將水平線標示為藍色，垂直線標示為綠色\n"
+"完成之後點擊下方的三個校正選項之一，以自動完成透視校正\n"
+"\n"
+"結構線可以隨時重新調整，單擊線條或端點以移動，或是右鍵刪除線條\n"
+"完成變更後再次點擊校正，即可重新計算透視校正效果"
 
 #: ../src/iop/ashift.c:5838
 msgid "rectangle"
@@ -11450,334 +11687,353 @@ msgstr "矩形"
 
 #: ../src/iop/ashift.c:5839
 msgid "lines"
-msgstr "線條"
+msgstr "線"
 
 #: ../src/iop/ashift.c:5863 ../src/iop/clipping.c:3361
 #, c-format
 msgid "[%s] define/rotate horizon"
-msgstr "[%s] 定義/旋轉水平線"
+msgstr "[%s] 自訂 / 旋轉水平線"
 
 #: ../src/iop/ashift.c:5864
 #, c-format
 msgid "[%s on segment] select segment"
-msgstr "[線段上 %s] 選擇線段"
+msgstr "[線段 %s] 選取線段"
 
 #: ../src/iop/ashift.c:5866
 #, c-format
 msgid "[%s on segment] unselect segment"
-msgstr "[線段上 %s] 取消選擇線段"
+msgstr "[線段 %s] 取消選取線段"
 
 #: ../src/iop/ashift.c:5868
 #, c-format
 msgid "[%s] select all segments from zone"
-msgstr "[%s] 選擇區域內所有線段"
+msgstr "[%s] 選擇區域內的所有線段"
 
 #: ../src/iop/ashift.c:5870
 #, c-format
 msgid "[%s] unselect all segments from zone"
-msgstr "[%s] 取消選擇區域內所有線段"
+msgstr "[%s] 取消選擇區域內的所有線段"
 
-#: ../src/iop/atrous.c:128 ../src/iop/atrous.c:1707
+#: ../src/iop/atrous.c:126 ../src/iop/atrous.c:1705
 msgid "contrast equalizer"
-msgstr "對比均衡器"
+msgstr "對比度等化器"
 
-#: ../src/iop/atrous.c:133
+#: ../src/iop/atrous.c:131
 msgid "sharpness|acutance|local contrast"
-msgstr "銳利度|鮮明度|局部對比"
+msgstr "銳利度|局部對比|contrast|equalizer"
 
-#: ../src/iop/atrous.c:138
+#: ../src/iop/atrous.c:136
 msgid "add or remove local contrast, sharpness, acutance"
-msgstr "增加或消除局部對比、銳利度、銳度"
+msgstr ""
+"對比度等化器 | contrast equalizer\n"
+"\n"
+"依據影像的高低頻區域分別調整對比\n"
+"橫軸表示經小波分析的影像不同細節頻率\n"
+"縱軸表示不同細節頻率的亮度和色度對比\n"
+"這個功能強大的模組可以達成多種效果，可藉由套用預設集了解控制邏輯"
 
-#: ../src/iop/atrous.c:139 ../src/iop/bilateral.cc:99 ../src/iop/diffuse.c:147
+#: ../src/iop/atrous.c:137 ../src/iop/bilateral.cc:99 ../src/iop/diffuse.c:147
 #: ../src/iop/exposure.c:131 ../src/iop/filmicrgb.c:355
 #: ../src/iop/graduatednd.c:150 ../src/iop/negadoctor.c:156
 #: ../src/iop/rgbcurve.c:142 ../src/iop/rgblevels.c:122 ../src/iop/shadhi.c:197
-#: ../src/iop/tonecurve.c:213 ../src/iop/toneequal.c:306
+#: ../src/iop/tonecurve.c:212 ../src/iop/toneequal.c:306
 msgid "corrective and creative"
-msgstr "修正和創作"
+msgstr "修正與創意"
 
-#: ../src/iop/atrous.c:140 ../src/iop/atrous.c:142
+#: ../src/iop/atrous.c:138 ../src/iop/atrous.c:140
 #: ../src/iop/colorbalance.c:160
 msgid "linear, Lab, scene-referred"
-msgstr "線性、Lab、場景工作流程"
+msgstr "線性、Lab、場景參照"
 
-#: ../src/iop/atrous.c:141 ../src/iop/censorize.c:85
+#: ../src/iop/atrous.c:139 ../src/iop/censorize.c:85
 #: ../src/iop/hazeremoval.c:114
 msgid "frequential, RGB"
 msgstr "頻率、RGB"
 
-#: ../src/iop/atrous.c:776
+#: ../src/iop/atrous.c:774
 msgctxt "eq_preset"
 msgid "coarse"
 msgstr "粗糙"
 
-#: ../src/iop/atrous.c:791
+#: ../src/iop/atrous.c:789
 msgid "denoise & sharpen"
-msgstr "降噪 及 銳利化"
+msgstr "除雜訊並鋭化"
 
-#: ../src/iop/atrous.c:806
+#: ../src/iop/atrous.c:804
 msgctxt "atrous"
 msgid "sharpen"
 msgstr "銳利化"
 
-#: ../src/iop/atrous.c:821
+#: ../src/iop/atrous.c:819
 msgid "denoise chroma"
-msgstr "色度降噪"
+msgstr "降低彩色雜訊"
 
-#: ../src/iop/atrous.c:836 ../src/iop/equalizer.c:332
+#: ../src/iop/atrous.c:834 ../src/iop/equalizer.c:332
 msgid "denoise"
-msgstr "降噪"
+msgstr "減少雜訊"
 
-#: ../src/iop/atrous.c:852 ../src/iop/bloom.c:75 ../src/iop/diffuse.c:342
+#: ../src/iop/atrous.c:850 ../src/iop/bloom.c:75 ../src/iop/diffuse.c:342
 msgid "bloom"
-msgstr "輝光"
+msgstr "朦朧光暈"
 
-#: ../src/iop/atrous.c:867 ../src/iop/bilat.c:163
+#: ../src/iop/atrous.c:865 ../src/iop/bilat.c:163
 msgid "clarity"
-msgstr "清晰度"
+msgstr "清晰"
 
-#: ../src/iop/atrous.c:887
+#: ../src/iop/atrous.c:885
 msgid "deblur: large blur, strength 3"
-msgstr "去模糊: 大型模糊，強度 3"
+msgstr "去除模糊：大型模糊，強度高"
 
-#: ../src/iop/atrous.c:904
+#: ../src/iop/atrous.c:902
 msgid "deblur: medium blur, strength 3"
-msgstr "去模糊: 中等模糊，強度 3"
+msgstr "去除模糊：中等模糊，強度高"
 
-#: ../src/iop/atrous.c:920
+#: ../src/iop/atrous.c:918
 msgid "deblur: fine blur, strength 3"
-msgstr "去模糊: 精細模糊，強度 3"
+msgstr "去除模糊：細微模糊，強度高"
 
-#: ../src/iop/atrous.c:938
+#: ../src/iop/atrous.c:936
 msgid "deblur: large blur, strength 2"
-msgstr "去模糊: 大型模糊，強度 2"
+msgstr "去除模糊：大型模糊，強度中"
 
-#: ../src/iop/atrous.c:955
+#: ../src/iop/atrous.c:953
 msgid "deblur: medium blur, strength 2"
-msgstr "去模糊: 中等模糊，強度 2"
+msgstr "去除模糊：中等模糊，強度中"
 
-#: ../src/iop/atrous.c:971
+#: ../src/iop/atrous.c:969
 msgid "deblur: fine blur, strength 2"
-msgstr "去模糊: 精細模糊，強度 2"
+msgstr "去除模糊：細微模糊，強度中"
 
-#: ../src/iop/atrous.c:989
+#: ../src/iop/atrous.c:987
 msgid "deblur: large blur, strength 1"
-msgstr "去模糊: 大型模糊，強度 1"
+msgstr "去除模糊：大型模糊，強度低"
 
-#: ../src/iop/atrous.c:1006
+#: ../src/iop/atrous.c:1004
 msgid "deblur: medium blur, strength 1"
-msgstr "去模糊: 中等模糊，強度 1"
+msgstr "去除模糊：中等模糊，強度低"
 
-#: ../src/iop/atrous.c:1022
+#: ../src/iop/atrous.c:1020
 msgid "deblur: fine blur, strength 1"
-msgstr "去模糊: 精細模糊，強度 1"
+msgstr "去除模糊：細微模糊，強度低"
 
-#: ../src/iop/atrous.c:1348 ../src/iop/atrous.c:1594
+#: ../src/iop/atrous.c:1346 ../src/iop/atrous.c:1592
 #: ../src/iop/denoiseprofile.c:3393 ../src/iop/rawdenoise.c:739
 msgid "coarse"
 msgstr "粗糙"
 
-#: ../src/iop/atrous.c:1355 ../src/iop/atrous.c:1595
+#: ../src/iop/atrous.c:1353 ../src/iop/atrous.c:1593
 #: ../src/iop/denoiseprofile.c:3401 ../src/iop/rawdenoise.c:747
 msgid "fine"
 msgstr "精細"
 
-#: ../src/iop/atrous.c:1367
+#: ../src/iop/atrous.c:1365
 msgid "contrasty"
-msgstr "對比鮮明"
+msgstr "鮮明對比"
 
-#: ../src/iop/atrous.c:1373 ../src/iop/denoiseprofile.c:3415
+#: ../src/iop/atrous.c:1371 ../src/iop/denoiseprofile.c:3415
 #: ../src/iop/rawdenoise.c:761
 msgid "noisy"
-msgstr "多噪點"
+msgstr "高雜訊"
 
 #. case atrous_s:
-#: ../src/iop/atrous.c:1376
+#: ../src/iop/atrous.c:1374
 msgid "bold"
-msgstr "加重(bold)"
+msgstr "加強"
 
-#: ../src/iop/atrous.c:1377
+#: ../src/iop/atrous.c:1375
 msgid "dull"
-msgstr "減輕(dull)"
+msgstr "減低"
 
-#: ../src/iop/atrous.c:1582 ../src/iop/atrous.c:1633
+#: ../src/iop/atrous.c:1580 ../src/iop/atrous.c:1631
 msgid "boost"
-msgstr "增強"
+msgstr "加強"
 
-#: ../src/iop/atrous.c:1583
+#: ../src/iop/atrous.c:1581
 msgid "reduce"
 msgstr "減少"
 
-#: ../src/iop/atrous.c:1584
+#: ../src/iop/atrous.c:1582
 msgid "raise"
-msgstr "提出"
+msgstr "提升"
 
-#: ../src/iop/atrous.c:1585
+#: ../src/iop/atrous.c:1583
 msgid "lower"
-msgstr "更低"
+msgstr "降低"
 
-#: ../src/iop/atrous.c:1592
+#: ../src/iop/atrous.c:1590
 msgid "coarsest"
 msgstr "最粗糙"
 
-#: ../src/iop/atrous.c:1593
+#: ../src/iop/atrous.c:1591
 msgid "coarser"
-msgstr "較粗糙"
+msgstr "更粗糙"
 
-#: ../src/iop/atrous.c:1596
+#: ../src/iop/atrous.c:1594
 msgid "finer"
-msgstr "精細"
+msgstr "更精細"
 
-#: ../src/iop/atrous.c:1597
+#: ../src/iop/atrous.c:1595
 msgid "finest"
 msgstr "最精細"
 
-#: ../src/iop/atrous.c:1655 ../src/libs/export.c:1162 ../src/libs/export.c:1177
+#: ../src/iop/atrous.c:1653 ../src/libs/export.c:1162 ../src/libs/export.c:1177
 msgid "x"
 msgstr "x"
 
-#: ../src/iop/atrous.c:1736 ../src/iop/equalizer.c:390 ../src/iop/nlmeans.c:519
+#: ../src/iop/atrous.c:1734 ../src/iop/equalizer.c:390 ../src/iop/nlmeans.c:519
 msgid "luma"
-msgstr "亮度(luma)"
+msgstr "亮度"
+
+#: ../src/iop/atrous.c:1734
+msgid "change lightness at each feature size"
+msgstr ""
+"調整不同影像細節區域的亮度對比，以白色曲線顯示\n"
+"執行精細的局部對比度控制，升降曲線左側調整低頻的亮度對比，右側控制高頻區域\n"
+"圖表底部第二條曲線調整雜訊抑制，拉高曲線增加去除亮度雜訊的強度"
+
+#: ../src/iop/atrous.c:1735
+msgid "change color saturation at each feature size"
+msgstr ""
+"調整不同影像細節區域的彩度對比，以棕色曲線顯示\n"
+"精細的顏色對比度（飽和度）控制，左側調整低頻的彩度對比，右側控制高頻區域\n"
+"圖表底部第二條曲線調整雜訊抑制，拉高曲線增加去除色度雜訊的強度"
 
 #: ../src/iop/atrous.c:1736
-msgid "change lightness at each feature size"
-msgstr "在每個特性大小改變明度"
-
-#: ../src/iop/atrous.c:1737
-msgid "change color saturation at each feature size"
-msgstr "在每個特性大小改變顏色飽和度"
-
-#: ../src/iop/atrous.c:1738
 msgid "edges"
-msgstr "邊緣"
+msgstr "邊緣修正"
 
-#: ../src/iop/atrous.c:1738
+#: ../src/iop/atrous.c:1736
 msgid ""
 "change edge halos at each feature size\n"
 "only changes results of luma and chroma tabs"
-msgstr "在每個特徵大小更改邊緣光暈，只當改變亮度和色度分頁"
+msgstr ""
+"調整影像高低頻分析的邊緣感知，以藍色曲線顯示\n"
+"此功能不直接調整影像，而是調整邊緣計算方法，以避免產生邊緣光暈的偽影\n"
+"亮度和彩度對比出現不自然的邊緣時可以使用，調整數值因影像而異必須自行嘗試"
 
-#: ../src/iop/atrous.c:1755 ../src/iop/colorbalancergb.c:2076
+#: ../src/iop/atrous.c:1753 ../src/iop/colorbalancergb.c:2073
 #: ../src/iop/colorzones.c:2507 ../src/iop/filmicrgb.c:4193
 #: ../src/iop/lowlight.c:836 ../src/iop/rawdenoise.c:932
 #: ../src/iop/toneequal.c:3162
 msgid "graph"
 msgstr "圖表"
 
-#: ../src/iop/atrous.c:1766 ../src/iop/colorzones.c:2500
+#: ../src/iop/atrous.c:1764 ../src/iop/colorzones.c:2500
 msgid "make effect stronger or weaker"
-msgstr "使得效果增強或削弱"
+msgstr "調整效果的強弱"
+
+#: ../src/iop/basecurve.c:200
+msgid "neutral"
+msgstr "中性"
 
 #: ../src/iop/basecurve.c:201
-msgid "neutral"
-msgstr "中性的"
+msgid "canon eos like"
+msgstr "Canon 風格一"
 
 #: ../src/iop/basecurve.c:202
-msgid "canon eos like"
-msgstr "佳能 EOS 系列"
+msgid "canon eos like alternate"
+msgstr "Canon 風格二"
 
 #: ../src/iop/basecurve.c:203
-msgid "canon eos like alternate"
-msgstr "佳能 EOS 系列替代方案"
+msgid "nikon like"
+msgstr "Nikon 風格一"
 
 #: ../src/iop/basecurve.c:204
-msgid "nikon like"
-msgstr "尼康系列"
+msgid "nikon like alternate"
+msgstr "Nikon 風格二"
 
 #: ../src/iop/basecurve.c:205
-msgid "nikon like alternate"
-msgstr "尼康系列替代方案"
+msgid "sony alpha like"
+msgstr "SONY 風格"
 
 #: ../src/iop/basecurve.c:206
-msgid "sony alpha like"
-msgstr "索尼 alpha 系列"
+msgid "pentax like"
+msgstr "PENTAX 風格"
 
 #: ../src/iop/basecurve.c:207
-msgid "pentax like"
-msgstr "賓得系列"
+msgid "ricoh like"
+msgstr "RICOH 風格"
 
 #: ../src/iop/basecurve.c:208
-msgid "ricoh like"
-msgstr "理光系列"
+msgid "olympus like"
+msgstr "OLYMPUS 風格一"
 
 #: ../src/iop/basecurve.c:209
-msgid "olympus like"
-msgstr "奧林巴斯系列"
+msgid "olympus like alternate"
+msgstr "OLYMPUS 風格二"
 
 #: ../src/iop/basecurve.c:210
-msgid "olympus like alternate"
-msgstr "奧林巴斯系列替代方案"
+msgid "panasonic like"
+msgstr "Panasonic 風格"
 
 #: ../src/iop/basecurve.c:211
-msgid "panasonic like"
-msgstr "松下系列"
+msgid "leica like"
+msgstr "Leica 風格"
 
 #: ../src/iop/basecurve.c:212
-msgid "leica like"
-msgstr "徠卡系列"
+msgid "kodak easyshare like"
+msgstr "Kodak 風格"
 
 #: ../src/iop/basecurve.c:213
-msgid "kodak easyshare like"
-msgstr "柯達 easyshare 系列"
+msgid "konica minolta like"
+msgstr "KONICA MINOLTA 風格"
 
 #: ../src/iop/basecurve.c:214
-msgid "konica minolta like"
-msgstr "柯尼卡 minolta 系列"
+msgid "samsung like"
+msgstr "SAMSUNG 風格"
 
 #: ../src/iop/basecurve.c:215
-msgid "samsung like"
-msgstr "三星系列"
+msgid "fujifilm like"
+msgstr "FUJIFILM 風格"
 
 #: ../src/iop/basecurve.c:216
-msgid "fujifilm like"
-msgstr "富士系列"
-
-#: ../src/iop/basecurve.c:217
 msgid "nokia like"
-msgstr "諾基亞系列"
+msgstr "NOKIA 風格"
 
 #. clang-format off
 #. smoother cubic spline curve
-#: ../src/iop/basecurve.c:273 ../src/iop/colorzones.c:2531
-#: ../src/iop/rgbcurve.c:1422 ../src/iop/tonecurve.c:1199
+#: ../src/iop/basecurve.c:272 ../src/iop/colorzones.c:2531
+#: ../src/iop/rgbcurve.c:1422 ../src/iop/tonecurve.c:1198
 msgid "cubic spline"
-msgstr "立方曲線"
+msgstr "三次擬合曲線"
 
-#: ../src/iop/basecurve.c:332
+#: ../src/iop/basecurve.c:331
 msgid "base curve"
-msgstr "基本曲線"
+msgstr "基礎曲線"
 
-#: ../src/iop/basecurve.c:337
+#: ../src/iop/basecurve.c:336
 msgid ""
 "apply a view transform based on personal or camera manufacturer look,\n"
 "for corrective purposes, to prepare images for display"
 msgstr ""
-"套用基於個人或相機製造商的影像視角轉換，\n"
-"為達到修正目的，以便準備顯示照片"
+"基礎曲線 | base curve\n"
+"\n"
+"套用相機廠商的特性曲線來模擬相機直出 JPEG\n"
+"如果工作流程為「顯示參照」會自動啟用此模組\n"
+"並依 EXIF 資料自動套用相機曲線，以便修正影像符合顯示\n"
+"若使用「場景參照」工作流程則無需使用此模組"
 
-#: ../src/iop/basecurve.c:339 ../src/iop/cacorrect.c:88
+#: ../src/iop/basecurve.c:338 ../src/iop/cacorrect.c:88
 #: ../src/iop/cacorrectrgb.c:170 ../src/iop/colorreconstruction.c:135
 #: ../src/iop/defringe.c:81 ../src/iop/denoiseprofile.c:720
 #: ../src/iop/dither.c:103 ../src/iop/flip.c:105 ../src/iop/hazeremoval.c:112
-#: ../src/iop/highlights.c:147 ../src/iop/hotpixels.c:73
+#: ../src/iop/highlights.c:151 ../src/iop/hotpixels.c:73
 #: ../src/iop/invert.c:122 ../src/iop/lens.cc:159 ../src/iop/nlmeans.c:99
 #: ../src/iop/profile_gamma.c:101 ../src/iop/rawdenoise.c:130
 #: ../src/iop/retouch.c:209 ../src/iop/sharpen.c:94 ../src/iop/spots.c:67
-#: ../src/iop/temperature.c:199
+#: ../src/iop/temperature.c:196
 msgid "corrective"
 msgstr "修正"
 
-#: ../src/iop/basecurve.c:340 ../src/iop/channelmixer.c:140
-#: ../src/iop/channelmixer.c:142 ../src/iop/lut3d.c:140
+#: ../src/iop/basecurve.c:339 ../src/iop/channelmixer.c:140
+#: ../src/iop/channelmixer.c:142 ../src/iop/lut3d.c:141
 #: ../src/iop/negadoctor.c:157 ../src/iop/profile_gamma.c:102
 #: ../src/iop/rgbcurve.c:143 ../src/iop/rgbcurve.c:145
 #: ../src/iop/rgblevels.c:123 ../src/iop/soften.c:106 ../src/iop/soften.c:108
 msgid "linear, RGB, display-referred"
-msgstr "線性、RGB、顯示工作流程"
+msgstr "線性、RGB、顯示參照"
 
-#: ../src/iop/basecurve.c:341 ../src/iop/basicadj.c:149
+#: ../src/iop/basecurve.c:340 ../src/iop/basicadj.c:149
 #: ../src/iop/colorbalance.c:161 ../src/iop/colorbalancergb.c:186
 #: ../src/iop/dither.c:105 ../src/iop/filmicrgb.c:357
 #: ../src/iop/graduatednd.c:152 ../src/iop/negadoctor.c:158
@@ -11787,58 +12043,79 @@ msgstr "線性、RGB、顯示工作流程"
 msgid "non-linear, RGB"
 msgstr "非線性、RGB"
 
-#: ../src/iop/basecurve.c:342 ../src/iop/dither.c:104 ../src/iop/dither.c:106
+#: ../src/iop/basecurve.c:341 ../src/iop/dither.c:104 ../src/iop/dither.c:106
 #: ../src/iop/filmicrgb.c:358 ../src/iop/graduatednd.c:153
 #: ../src/iop/negadoctor.c:159 ../src/iop/profile_gamma.c:104
 #: ../src/iop/rgblevels.c:125 ../src/iop/vignette.c:159
 #: ../src/iop/vignette.c:161 ../src/iop/watermark.c:298
 #: ../src/iop/watermark.c:300
 msgid "non-linear, RGB, display-referred"
-msgstr "非線性、RGB、顯示工作流程"
+msgstr "非線性、RGB、顯示參照"
 
-#: ../src/iop/basecurve.c:2073
+#: ../src/iop/basecurve.c:2072
 msgid "abscissa: input, ordinate: output. works on RGB channels"
-msgstr "橫軸:輸入，縱軸:輸出。工作於RGB通道"
+msgstr ""
+"橫座標：輸入\n"
+"縱座標：輸出"
 
-#: ../src/iop/basecurve.c:2079 ../src/iop/basicadj.c:612
+#: ../src/iop/basecurve.c:2078 ../src/iop/basicadj.c:612
 #: ../src/iop/rgbcurve.c:1437 ../src/iop/rgblevels.c:1088
-#: ../src/iop/tonecurve.c:1210
+#: ../src/iop/tonecurve.c:1209
 msgid "method to preserve colors when applying contrast"
-msgstr "套用對比度時保留顏色的方法"
+msgstr ""
+"套用曲線時維持顏色色相不變的方法\n"
+"\n"
+"如果直接套用曲線至 RGB 色版，由於每個色版調整後的顏色比例可能會發生變化，從而"
+"導致色調改變。選擇以下方法來對 RGB 色版進行不同程度的調整，以保留 RGB 之間的"
+"關係減少色調變化的影響。不同影像可能會產生不同的效果，選項適合與否會因影像內"
+"容而異，沒有所謂正確的選擇。建議自行嘗試後決定哪個設定效果最令人滿意。\n"
+"\n"
+"無：這是大部分軟體的運作方式，會讓暗部更飽和但降低亮部的飽和度\n"
+"亮度：依 RGB 總和亮度來調整，偏向增加局部對比度，高飽和顏色可能表現不佳\n"
+"RGB 最大值：偏向降低藍色的亮度，並讓局部對比度變小\n"
+"RGB 平均值：官方沒有提供效果說明，請自行嘗試\n"
+"RGB 加總值：官方沒有提供效果說明，請自行嘗試\n"
+"RGB 乘冪範數：使用 RGB 的立方和除以平方和加權計算，通常是良好的折衷算法\n"
+"基礎乘冪：以 RGB 的幾何距離計算，特色是任何 RGB 空間都可以獲得一致的效果"
+
+#: ../src/iop/basecurve.c:2082
+msgid "two exposures"
+msgstr "曝光兩次"
 
 #: ../src/iop/basecurve.c:2083
-msgid "two exposures"
-msgstr "兩次曝光"
+msgid "three exposures"
+msgstr "曝光三次"
 
 #: ../src/iop/basecurve.c:2084
-msgid "three exposures"
-msgstr "三次曝光"
-
-#: ../src/iop/basecurve.c:2085
 msgid ""
 "fuse this image stopped up/down a couple of times with itself, to compress "
 "high dynamic range. expose for the highlights before use."
 msgstr ""
-"對影像與自己進行幾次不同的曝光進行融合，以壓縮高動態範圍。\n"
-"使用前先對高光區的曝光作出合適的調整。"
+"與自身增加曝光的影像副本融合以提升動態範圍\n"
+"可設定與兩張或三張的提高曝光副本合併\n"
+"為獲得最佳效果，先在「曝光」模組裡調整正確的曝光"
 
-#: ../src/iop/basecurve.c:2090
+#: ../src/iop/basecurve.c:2089
 msgid "how many stops to shift the individual exposures apart"
-msgstr "使用多少曝光檔以偏移各別曝光"
+msgstr "以 EV 為單位調整每張要融合的影像副本之間曝光要提高多少"
 
-#: ../src/iop/basecurve.c:2099
+#: ../src/iop/basecurve.c:2098
 msgid ""
 "whether to shift exposure up or down (-1: reduce highlight, +1: reduce "
 "shadows)"
-msgstr "是否要將曝光上下偏移(-1:降低高光，+1:降低陰影)"
+msgstr ""
+"調整融合後的曝光\n"
+"-1：減少亮部\n"
+"+1：減少暗部\n"
+"0：維持整體的亮度"
 
-#: ../src/iop/basecurve.c:2104 ../src/iop/tonecurve.c:1213
+#: ../src/iop/basecurve.c:2103 ../src/iop/tonecurve.c:1212
 msgid "scale for graph"
-msgstr "圖形縮放"
+msgstr "圖表座標顯示比例（線性 ↔ 對數）"
 
 #: ../src/iop/basicadj.c:136
 msgid "this module is deprecated. please use the quick access panel instead."
-msgstr "此模組已棄用。請使用快訪面板替代。"
+msgstr "此模組已被汰除，建議使用「快速存取面板」替代"
 
 #: ../src/iop/basicadj.c:141
 msgid "basic adjustments"
@@ -11846,24 +12123,24 @@ msgstr "基本調整"
 
 #: ../src/iop/basicadj.c:146
 msgid "apply usual image adjustments"
-msgstr "套用一般影像調整"
+msgstr "套用一般的影像調整"
 
 #: ../src/iop/basicadj.c:147 ../src/iop/bilat.c:100 ../src/iop/bloom.c:81
 #: ../src/iop/blurs.c:93 ../src/iop/borders.c:187 ../src/iop/censorize.c:83
 #: ../src/iop/colisa.c:85 ../src/iop/colorcontrast.c:101
 #: ../src/iop/colorize.c:105 ../src/iop/colormapping.c:153
 #: ../src/iop/colorzones.c:145 ../src/iop/grain.c:425 ../src/iop/highpass.c:81
-#: ../src/iop/levels.c:131 ../src/iop/liquify.c:296 ../src/iop/lowlight.c:92
+#: ../src/iop/levels.c:130 ../src/iop/liquify.c:296 ../src/iop/lowlight.c:92
 #: ../src/iop/lowpass.c:133 ../src/iop/monochrome.c:98 ../src/iop/soften.c:105
 #: ../src/iop/splittoning.c:103 ../src/iop/velvia.c:105
 #: ../src/iop/vibrance.c:95 ../src/iop/vignette.c:158
 #: ../src/iop/watermark.c:297
 msgid "creative"
-msgstr "創作"
+msgstr "創意"
 
 #: ../src/iop/basicadj.c:150 ../src/iop/colorbalancergb.c:187
 msgid "non-linear, RGB, scene-referred"
-msgstr "非線性、RGB、場景工作流程"
+msgstr "非線性、RGB、場景參照"
 
 #: ../src/iop/basicadj.c:593
 msgid ""
@@ -11872,18 +12149,18 @@ msgid ""
 "if poorly set, it will clip near-black colors out of gamut\n"
 "by pushing RGB values into negatives"
 msgstr ""
-"調整黑階以保留超出色域的負 RGB 值。\n"
-"你不應該用它來增加黑色密度！\n"
-"如果設定不當，它將會將 RGB 值推入負數中，\n"
-"以裁剪顏色色域中近黑顏色"
+"調整黑點以保留負的 RGB 值，不應用此設定來增加黑色濃度\n"
+"如果設定不當將會把近黑點的顏色推出色域，並造成 RGB 負值"
 
 #: ../src/iop/basicadj.c:601 ../src/iop/exposure.c:1031
 msgid "adjust the exposure correction"
-msgstr "調整曝光修正"
+msgstr ""
+"調整曝光校正，向右增加或向左減少曝光值（EV）\n"
+"使用右側色彩選取工具選擇影像上的區域，以執行「點測光曝光對應」"
 
 #: ../src/iop/basicadj.c:605
 msgid "highlight compression adjustment"
-msgstr "調整高光壓縮"
+msgstr "亮部壓縮調整"
 
 #: ../src/iop/basicadj.c:609 ../src/iop/colisa.c:309
 msgid "contrast adjustment"
@@ -11907,7 +12184,7 @@ msgstr "自然飽和度調整"
 
 #: ../src/iop/basicadj.c:632
 msgid "apply auto exposure based on the entire image"
-msgstr "基於整個影像套用自動曝光"
+msgstr "根據整個影像來套用自動曝光"
 
 #: ../src/iop/basicadj.c:639
 msgid ""
@@ -11915,16 +12192,16 @@ msgid ""
 "click and drag to draw the area\n"
 "right click to cancel"
 msgstr ""
-"根據使用者定義的區域套用自動曝光。\n"
-"單擊並拖拉滑鼠以繪製區域，右擊取消"
+"根據使用者自訂的範圍套用自動曝光\n"
+"點擊並拖曳以繪製區域，右鍵點擊取消"
 
 #: ../src/iop/basicadj.c:647
 msgid "clip"
-msgstr "截取"
+msgstr "剪裁"
 
 #: ../src/iop/basicadj.c:649
 msgid "adjusts clipping value for auto exposure calculation"
-msgstr "調整自動曝光計算的剪裁值"
+msgstr "調整自動計算曝光的剪裁臨界值"
 
 #: ../src/iop/bilat.c:94 ../src/iop/clahe.c:64
 msgid "local contrast"
@@ -11932,7 +12209,12 @@ msgstr "局部對比度"
 
 #: ../src/iop/bilat.c:99
 msgid "manipulate local and global contrast separately"
-msgstr "分別調整局部和全域對比度"
+msgstr ""
+"局部對比度 | local contrast\n"
+"\n"
+"提高影像的局部對比度而不影響整體對比\n"
+"在 CIELAB 的 L* 色版中執行對比度調整\n"
+"可用來取代傳統的 UnSharp Mask 銳利化"
 
 #: ../src/iop/bilat.c:101 ../src/iop/bilat.c:103 ../src/iop/bloom.c:82
 #: ../src/iop/bloom.c:84 ../src/iop/colisa.c:86 ../src/iop/colisa.c:88
@@ -11941,58 +12223,67 @@ msgstr "分別調整局部和全域對比度"
 #: ../src/iop/colorize.c:108 ../src/iop/colormapping.c:156
 #: ../src/iop/colorreconstruction.c:138 ../src/iop/colorzones.c:148
 #: ../src/iop/defringe.c:84 ../src/iop/grain.c:426 ../src/iop/grain.c:428
-#: ../src/iop/levels.c:134 ../src/iop/lowlight.c:93 ../src/iop/lowlight.c:95
+#: ../src/iop/levels.c:133 ../src/iop/lowlight.c:93 ../src/iop/lowlight.c:95
 #: ../src/iop/monochrome.c:101 ../src/iop/nlmeans.c:100
-#: ../src/iop/nlmeans.c:102 ../src/iop/shadhi.c:200 ../src/iop/tonecurve.c:216
+#: ../src/iop/nlmeans.c:102 ../src/iop/shadhi.c:200 ../src/iop/tonecurve.c:215
 #: ../src/iop/vibrance.c:98
 msgid "non-linear, Lab, display-referred"
-msgstr "非線性、Lab、顯示工作流程"
+msgstr "非線性、Lab、顯示參照"
 
 #: ../src/iop/bilat.c:102 ../src/iop/bloom.c:83 ../src/iop/colisa.c:87
 #: ../src/iop/colorcontrast.c:103 ../src/iop/colorcorrection.c:79
 #: ../src/iop/colorize.c:107 ../src/iop/colormapping.c:155
 #: ../src/iop/colorreconstruction.c:137 ../src/iop/colorzones.c:147
-#: ../src/iop/defringe.c:83 ../src/iop/grain.c:427 ../src/iop/levels.c:133
+#: ../src/iop/defringe.c:83 ../src/iop/grain.c:427 ../src/iop/levels.c:132
 #: ../src/iop/monochrome.c:100 ../src/iop/nlmeans.c:101 ../src/iop/shadhi.c:199
-#: ../src/iop/tonecurve.c:215 ../src/iop/vibrance.c:97
+#: ../src/iop/tonecurve.c:214 ../src/iop/vibrance.c:97
 msgid "non-linear, Lab"
 msgstr "非線性、Lab"
 
 #: ../src/iop/bilat.c:172
 msgid "HDR local tone-mapping"
-msgstr "HDR局部色調映射"
+msgstr "HDR 局部階調映射"
 
 #: ../src/iop/bilat.c:428
 msgid ""
 "the filter used for local contrast enhancement. bilateral is faster but can "
 "lead to artifacts around edges for extreme settings."
 msgstr ""
-"用於局部對比度增強的濾鏡。\n"
-"雙邊比較快，但在極端設定下會導致邊緣周圍出現瑕疵。"
+"用於偵測影像邊緣以增加局部對比度的濾鏡\n"
+"雙邊濾波速度較快，但在某些極端參數設定下會導致邊緣偽影\n"
+"局部拉普拉斯被設計成不易產生光暈和階調反轉等瑕疵"
 
 #: ../src/iop/bilat.c:430 ../src/iop/globaltonemap.c:647
 msgid "detail"
-msgstr "細節"
+msgstr "影像細節"
 
 #: ../src/iop/bilat.c:433
 msgid "changes the local contrast"
-msgstr "更改局部對比度"
+msgstr "調整局部對比度"
 
 #: ../src/iop/bilat.c:446
 msgid "feature size of local details (spatial sigma of bilateral filter)"
-msgstr "局部細節的特徵大小(雙邊濾鏡的空間 Sigma)"
+msgstr ""
+"調整影像細節的尺寸\n"
+"等同雙邊濾波的空間標準差設定"
 
 #: ../src/iop/bilat.c:452
 msgid "L difference to detect edges (range sigma of bilateral filter)"
-msgstr "用於偵測邊緣的光差(雙邊濾波的值域 Sigma)"
+msgstr ""
+"調整影像細節的 L* 差異\n"
+"等同雙邊濾波的值域標準差設定"
 
 #: ../src/iop/bilat.c:457
 msgid "changes the local contrast of highlights"
-msgstr "更改高光區域的局部對比度"
+msgstr ""
+"調整局部對比的亮部\n"
+"這會影響局部對比中的亮部強度，較低的值可以拉低亮部"
 
 #: ../src/iop/bilat.c:462
 msgid "changes the local contrast of shadows"
-msgstr "更改陰影區域的局部對比度"
+msgstr ""
+"調整局部對比的暗部\n"
+"這會影響局部對比中的暗部強度，較低的值可以提升暗部"
 
 #: ../src/iop/bilat.c:466
 msgid ""
@@ -12000,8 +12291,8 @@ msgid ""
 "(reduce shadow and highlight contrast), increase for more powerful local "
 "contrast"
 msgstr ""
-"定義中間調。較低值可得得較好的動態範圍壓縮(減少陰影和高光對比度)，增加可獲得"
-"更強的局部對比度"
+"自定義局部對比度的中間調範圍，這會影響動態範圍壓縮\n"
+"較低的值可以獲得較好的動態範圍壓縮，較高的值有更強的局部對比度"
 
 #: ../src/iop/bilateral.cc:73 ../src/iop/diffuse.c:324
 msgid "surface blur"
@@ -12009,11 +12300,17 @@ msgstr "表面模糊"
 
 #: ../src/iop/bilateral.cc:78
 msgid "denoise (bilateral filter)"
-msgstr "降噪(雙邊濾鏡)"
+msgstr "雙邊濾波除雜訊"
 
 #: ../src/iop/bilateral.cc:98
 msgid "apply edge-aware surface blur to denoise or smoothen textures"
-msgstr "利用邊緣感知表面模糊進行去噪或平滑紋理"
+msgstr ""
+"表面模糊 | surface blur\n"
+"\n"
+"保留邊緣的同時消除雜訊或模糊紋理\n"
+"雖然此模組可以用於除雜訊，但推薦以下其他模組功能更佳\n"
+"「天文攝影除雜訊」或「相機特性除雜訊」\n"
+"此模組還可用作創意濾鏡以創造卡通般的外觀效果"
 
 #: ../src/iop/bilateral.cc:101 ../src/iop/blurs.c:93
 #: ../src/iop/channelmixer.c:141 ../src/iop/denoiseprofile.c:722
@@ -12024,39 +12321,44 @@ msgstr "線性、RGB"
 
 #: ../src/iop/bilateral.cc:302
 msgid "spatial extent of the gaussian"
-msgstr "高斯空間範圍"
+msgstr "高斯模糊的尺寸"
 
 #: ../src/iop/bilateral.cc:306
 msgid "how much to blur red"
-msgstr "模糊紅色的量"
+msgstr "紅色色版模糊量"
 
 #: ../src/iop/bilateral.cc:311
 msgid "how much to blur green"
-msgstr "模糊綠色的量"
+msgstr "綠色色版模糊量"
 
 #: ../src/iop/bilateral.cc:316
 msgid "how much to blur blue"
-msgstr "模糊藍色的量"
+msgstr "藍色色版模糊量"
 
 #: ../src/iop/bloom.c:80
 msgid "apply Orton effect for a dreamy aetherical look"
-msgstr "套用奧頓效果(Orton Effect)，以得到夢幻的效果"
+msgstr ""
+"朦朧光暈 | bloom\n"
+"\n"
+"利用亮部模糊混合原圖來創造夢幻的效果\n"
+"此模組在 Lab 空間中執行模糊所以不再推薦使用\n"
+"可嘗試以「柔焦」模組替代"
 
 #: ../src/iop/bloom.c:390 ../src/iop/soften.c:395 ../src/libs/camera.c:568
 msgid "size"
-msgstr "大小"
+msgstr "尺寸"
 
 #: ../src/iop/bloom.c:392
 msgid "the size of bloom"
-msgstr "輝光的大小"
+msgstr "光暈的大小"
 
 #: ../src/iop/bloom.c:396
 msgid "the threshold of light"
-msgstr "光臨界值"
+msgstr "亮度門檻"
 
 #: ../src/iop/bloom.c:400
 msgid "the strength of bloom"
-msgstr "輝光的強度"
+msgstr "光暈的強度"
 
 #: ../src/iop/blurs.c:81
 msgid "blurs"
@@ -12064,31 +12366,39 @@ msgstr "模糊"
 
 #: ../src/iop/blurs.c:86
 msgid "blur|lens|motion"
-msgstr "模糊|鏡頭|運動模糊"
+msgstr "散景|鏡頭|動態|blur"
 
 #: ../src/iop/blurs.c:92
 msgid "simulate physically-accurate lens and motion blurs"
-msgstr "模擬物理準確的鏡頭模糊和運動模糊"
+msgstr ""
+"模糊 | blurs\n"
+"\n"
+"可使用三種不同的方式模糊影像\n"
+"模擬物理上精確的鏡頭或動態模糊以及高斯模糊\n"
+"模組中顯示的圖形表示模糊的形狀"
 
 #: ../src/iop/borders.c:181
 msgid "framing"
-msgstr "加相框"
+msgstr "外框"
 
 #: ../src/iop/borders.c:186
 msgid "add solid borders or margins around the picture"
-msgstr "在圖片周圍增加實心邊框或邊距"
+msgstr ""
+"外框 | framing\n"
+"\n"
+"在影像周圍增加外框，由實心的外框和框線兩部分組成"
 
-#: ../src/iop/borders.c:188 ../src/iop/borders.c:190 ../src/iop/lut3d.c:142
+#: ../src/iop/borders.c:188 ../src/iop/borders.c:190 ../src/iop/lut3d.c:143
 msgid "linear or non-linear, RGB, display-referred"
-msgstr "線性或非線性、RGB、顯示工作流程"
+msgstr "線性或非線性、RGB、顯示參照"
 
 #: ../src/iop/borders.c:724
 msgid "15:10 postcard white"
-msgstr "15:10 明信片 白色"
+msgstr "15:10 白色明信片"
 
 #: ../src/iop/borders.c:729
 msgid "15:10 postcard black"
-msgstr "15:10 明信片 黑色"
+msgstr "15:10 黑色明信片"
 
 #: ../src/iop/borders.c:961
 msgid "3:1"
@@ -12108,7 +12418,7 @@ msgstr "16:9"
 
 #: ../src/iop/borders.c:965 ../src/iop/clipping.c:2149 ../src/iop/crop.c:1061
 msgid "golden cut"
-msgstr "黃金分割"
+msgstr "黃金比例"
 
 #: ../src/iop/borders.c:966
 msgid "3:2"
@@ -12120,7 +12430,7 @@ msgstr "A4"
 
 #: ../src/iop/borders.c:968
 msgid "DIN"
-msgstr "德國工業標準(DIN)"
+msgstr "DIN"
 
 #: ../src/iop/borders.c:969
 msgid "4:3"
@@ -12133,15 +12443,15 @@ msgstr "正方形"
 
 #: ../src/iop/borders.c:971
 msgid "constant border"
-msgstr "固定邊框"
+msgstr "四邊外框等大"
 
 #: ../src/iop/borders.c:972 ../src/iop/borders.c:998 ../src/iop/borders.c:1004
 msgid "custom..."
-msgstr "自定義..."
+msgstr "自訂比例"
 
 #: ../src/iop/borders.c:993 ../src/iop/borders.c:999
 msgid "center"
-msgstr "中心"
+msgstr "置中"
 
 #: ../src/iop/borders.c:994 ../src/iop/borders.c:1000
 msgid "1/3"
@@ -12161,23 +12471,27 @@ msgstr "2/3"
 
 #: ../src/iop/borders.c:1028
 msgid "size of the border in percent of the full image"
-msgstr "邊框大小(以全圖百分比表示)"
+msgstr "設定外框尺寸（相對於影像的百分比）"
 
 #: ../src/iop/borders.c:1032 ../src/iop/clipping.c:2236 ../src/iop/crop.c:1147
 msgid "aspect"
-msgstr "長寬比"
+msgstr "影像長寬比"
 
 #: ../src/iop/borders.c:1036
 msgid "select the aspect ratio or right click and type your own (w:h)"
-msgstr "選擇長寬比或右鍵單擊輸入(w:h)"
+msgstr ""
+"模組完成後的最終影像比例，也就是包含原始影像與外框之後的比例\n"
+"從右側快速選取比例，或使用以下滑桿自訂"
 
 #: ../src/iop/borders.c:1038
 msgid "set the custom aspect ratio"
-msgstr "設定自定義長寬比"
+msgstr "自訂寬高比例"
 
 #: ../src/iop/borders.c:1044
 msgid "aspect ratio orientation of the image with border"
-msgstr "包含邊框的影像長寬比取向"
+msgstr ""
+"影像加上外框後的方向，可選擇直式或橫式\n"
+"或使用自動，會自動符合原始影像方向"
 
 #: ../src/iop/borders.c:1048
 msgid "horizontal position"
@@ -12187,11 +12501,14 @@ msgstr "水平位置"
 msgid ""
 "select the horizontal position ratio relative to top or right click and type "
 "your own (y:h)"
-msgstr "選擇相對於頂部的水平位置比或右鍵單擊輸入(y:h)"
+msgstr ""
+"設定原始影像在整個完成影像中的水平位置\n"
+"從右側快速選取比例，或使用以下滑桿自訂\n"
+"數值代表原始影像距離左側邊界的相對大小"
 
 #: ../src/iop/borders.c:1054
 msgid "custom horizontal position"
-msgstr "自定義水平位置"
+msgstr "自訂水平位置"
 
 #: ../src/iop/borders.c:1058
 msgid "vertical position"
@@ -12201,78 +12518,94 @@ msgstr "垂直位置"
 msgid ""
 "select the vertical position ratio relative to left or right click and type "
 "your own (x:w)"
-msgstr "選擇相對於頂部的垂直位置比或右鍵單擊輸入(x:w)"
+msgstr ""
+"設定原始影像在整個完成影像中的垂直位置\n"
+"從右側快速選取比例，或使用以下滑桿自訂\n"
+"數值代表原始影像距離上方邊界的相對大小"
 
 #: ../src/iop/borders.c:1064
 msgid "custom vertical position"
-msgstr "自定義垂直位置"
+msgstr "自定垂直位置"
 
 #: ../src/iop/borders.c:1071
 msgid "size of the frame line in percent of min border width"
-msgstr "分框線的大小(以全圖大小百分比表示)"
+msgstr "設定框線尺寸（相對於外框尺寸的百分比）"
 
 #: ../src/iop/borders.c:1076
 msgid "offset of the frame line beginning on picture side"
-msgstr "分框線偏移(從圖片一側開始計算)"
+msgstr ""
+"框線相對於原始影像的位置\n"
+"數值代表框線距離原始影像的相對位置\n"
+"0% 時框線緊貼原始影像，100% 時位於外框最外側\n"
+"若外框四邊大小不同，框線可能無法每邊都緊貼到最外側"
 
 #: ../src/iop/borders.c:1083
 msgid "border color"
-msgstr "邊框顏色"
+msgstr "外框顏色"
 
 #: ../src/iop/borders.c:1087
 msgid "select border color"
-msgstr "選擇邊框顏色"
+msgstr "選擇外框顏色"
 
 #: ../src/iop/borders.c:1091
 msgid "pick border color from image"
-msgstr "從圖片選取邊框顏色"
+msgstr "從影像中選取外框顏色"
 
 #: ../src/iop/borders.c:1095
 msgid "frame line color"
-msgstr "分框線顏色"
+msgstr "邊框顏色"
 
 #: ../src/iop/borders.c:1099
 msgid "select frame line color"
-msgstr "選擇分框線顏色"
+msgstr "選擇邊框顏色"
 
 #: ../src/iop/borders.c:1103
 msgid "pick frame line color from image"
-msgstr "從圖片選取分框線顏色"
+msgstr "從影像中選擇邊框顏色"
 
 #. make sure you put all your translatable strings into _() !
 #: ../src/iop/cacorrect.c:82
 msgid "raw chromatic aberrations"
-msgstr "raw 色差"
+msgstr "RAW 檔色像差校正"
 
 #: ../src/iop/cacorrect.c:87
 msgid "correct chromatic aberrations for Bayer sensors"
-msgstr "修正拜耳傳感器(Bayer sensors)的色差"
+msgstr ""
+"RAW 檔色像差校正 | raw chromatic aberrations\n"
+"\n"
+"校正拜耳排列感光元件的色像差\n"
+"此模組在去馬賽克前對原始資料進行操作，理論上效果最好\n"
+"對於非拜耳感光元件 RAW 檔的影像改用「色像差校正」模組"
 
 #: ../src/iop/cacorrect.c:89 ../src/iop/cacorrect.c:91
 #: ../src/iop/cacorrectrgb.c:171 ../src/iop/cacorrectrgb.c:173
-#: ../src/iop/demosaic.c:228 ../src/iop/highlights.c:148
-#: ../src/iop/highlights.c:150 ../src/iop/hotpixels.c:74
+#: ../src/iop/demosaic.c:228 ../src/iop/highlights.c:152
+#: ../src/iop/highlights.c:154 ../src/iop/hotpixels.c:74
 #: ../src/iop/hotpixels.c:76 ../src/iop/rawdenoise.c:131
 #: ../src/iop/rawdenoise.c:133 ../src/iop/rawprepare.c:154
-#: ../src/iop/rawprepare.c:156 ../src/iop/temperature.c:200
-#: ../src/iop/temperature.c:202
+#: ../src/iop/rawprepare.c:156 ../src/iop/temperature.c:197
+#: ../src/iop/temperature.c:199
 msgid "linear, raw, scene-referred"
-msgstr "線性、RAW、場景工作流程"
+msgstr "線性、RAW、場景參照"
 
 #: ../src/iop/cacorrect.c:90 ../src/iop/cacorrectrgb.c:172
 #: ../src/iop/demosaic.c:229 ../src/iop/invert.c:124
 #: ../src/iop/rawdenoise.c:132 ../src/iop/rawprepare.c:155
-#: ../src/iop/temperature.c:201
+#: ../src/iop/temperature.c:198
 msgid "linear, raw"
 msgstr "線性、RAW"
 
 #: ../src/iop/cacorrect.c:1337
 msgid "raw CA correction supports only standard RGB Bayer filter arrays"
-msgstr "raw CA 校正只支援標準拜爾 RGB 濾波器陣列"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"RAW 檔色像差校正只支援標準 RGB Bayer 濾鏡排列方式"
 
 #: ../src/iop/cacorrect.c:1339 ../src/iop/cacorrect.c:1347
 msgid "bypassed while zooming in"
-msgstr "在放大時被跳過"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"放大檢視圖像時略過效果預覽，不會影響最終匯出影像"
 
 #: ../src/iop/cacorrect.c:1340
 msgid ""
@@ -12280,8 +12613,9 @@ msgid ""
 "module is bypassed.\n"
 "you can get more info by running dt via the console."
 msgstr ""
-"在計算修正參數時，內部數學運算髮生錯誤，因此模組被跳過了。\n"
-"你可以在終端機上直接執行darktable 以獲得更多資訊。"
+"⚠️ 錯誤 ⚠️\n"
+"計算校正參數時內部運算發生錯誤，因此模組被略過不執行\n"
+"可以藉由終端機執行 darktable 以獲得更多資訊"
 
 #: ../src/iop/cacorrect.c:1344
 msgid ""
@@ -12289,8 +12623,9 @@ msgid ""
 "to linear.\n"
 "you might view bad correction results."
 msgstr ""
-"內部數學運算發現資料點太少，限制使用線性符合順序。\n"
-"你可能會看到差的修正結果。"
+"⚠️ 警告 ⚠️\n"
+"計算時發現資料太少，因此限制迭代次數\n"
+"看到的修正結果可能會不如預期"
 
 #: ../src/iop/cacorrect.c:1348
 msgid ""
@@ -12299,33 +12634,44 @@ msgid ""
 "the image shown in darkroom would look vastly different from developed files "
 "so effect is bypassed now."
 msgstr ""
-"爲了正確計算 raw CA 校正的參數，我們需要完整的傳感器資料，或至少是一部分合理"
-"的資料。\n"
-"在暗房中顯示的影像看起來與沖洗後的有很大的不同，此效果已被跳過。"
+"⚠️ 錯誤 ⚠️\n"
+"修正 RAW 檔色像差需要完整的感光元件資料\n"
+"暗房模式編輯的影像與內嵌 JPG 差異很大\n"
+"所以模組已被略過不執行"
 
 #: ../src/iop/cacorrect.c:1455
 msgid "iteration runs, default is twice"
-msgstr "迭代運行，預設爲兩次"
+msgstr ""
+"反覆執行運算次數\n"
+"預設值兩次通常可以提供理想的效果\n"
+"有時候增加次數可以產生更好的結果"
 
 #: ../src/iop/cacorrect.c:1458
 msgid "activate colorshift correction for blue & red channels"
-msgstr "啟用藍色和紅色通道的色彩飄移修正"
+msgstr ""
+"開啟藍色和紅色通道的色彩偏移修正\n"
+"如果校正效果產生紫色色偏，可啟用此選像以修正"
 
 #: ../src/iop/cacorrect.c:1465
 msgid ""
 "automatic chromatic aberration correction\n"
 "only for Bayer raw files"
 msgstr ""
-"自動色差修正\n"
-"只用於拜爾 RAW 影像"
+"自動校正色像差\n"
+"僅適用於 Bayer 排列的感光元件 RAW 檔"
 
 #: ../src/iop/cacorrectrgb.c:164 ../src/iop/defringe.c:75
 msgid "chromatic aberrations"
-msgstr "色差"
+msgstr "色像差校正"
 
 #: ../src/iop/cacorrectrgb.c:169
 msgid "correct chromatic aberrations"
-msgstr "修正色差"
+msgstr ""
+"色像差校正 | chromatic aberrations\n"
+"\n"
+"校正色像差\n"
+"與「RAW 檔色像差校正」相比\n"
+"此模組可應用於各種影像類別"
 
 #: ../src/iop/cacorrectrgb.c:743
 msgid ""
@@ -12336,13 +12682,15 @@ msgid ""
 "try changing guide channel if you\n"
 "have artifacts."
 msgstr ""
-"通道做爲參考，以修正其他通道。\n"
-"如果某些通道模糊不清，則使用最清晰的通道。\n"
-"如出現僞影，請嘗試改變參考通道。"
+"作為校正其他顏色的參考色版\n"
+"暫時將半徑與修正強度調至最高，切換不同色版比較\n"
+"選擇銳利度最高和邊緣偽影最少的色版做為參考色版"
 
 #: ../src/iop/cacorrectrgb.c:750
 msgid "increase for stronger correction"
-msgstr "增加以加強修正"
+msgstr ""
+"校正色校差的效果半徑\n"
+"這是此模組中最重要的參數，緩慢提高直到消除色像差"
 
 #: ../src/iop/cacorrectrgb.c:752
 msgid ""
@@ -12351,12 +12699,12 @@ msgid ""
 "high values can lead to overshooting\n"
 "and edge bleeding."
 msgstr ""
-"在平滑顏色和保留顏色之間取得平衡。\n"
-"高值會導致超量和邊緣滲出。"
+"調整修正色彩和保留色彩之間的平衡\n"
+"越高的值校正效果越強，但可能導致其他顏色變灰"
 
 #: ../src/iop/cacorrectrgb.c:757
 msgid "advanced parameters"
-msgstr "高級參數"
+msgstr "進階參數"
 
 #: ../src/iop/cacorrectrgb.c:759
 msgid ""
@@ -12368,9 +12716,10 @@ msgid ""
 "efficient to correct blue\n"
 "chromatic aberration."
 msgstr ""
-"使用的修正模式。\n"
-"增加多個實例有助於嚴重受損的影像處理。\n"
-"“僅變暗”對糾色差來說特別有效。"
+"可以將校正效果限制為僅使像素變亮或變暗\n"
+"僅變暗對於校正藍色色像差特別有效\n"
+"可以結合多個模組實例與校正模式來修復特別嚴重的影像\n"
+"或是與色版遮罩混合使用，獲得更精細的完整控制"
 
 #: ../src/iop/cacorrectrgb.c:767
 msgid ""
@@ -12382,29 +12731,35 @@ msgid ""
 "colors too much on other\n"
 "images."
 msgstr ""
-"在迭代方法中使用數種半徑執行。\n"
-"在具有非常大色差的影像上有改善效果，但在其他影像上會使顏色過於平滑。"
+"使用不同半徑的多次迭代算法改善具有巨大色像差影像的結果\n"
+"但可能會過度平滑化其他顏色，導致整體影像看似被刷白"
 
 #: ../src/iop/censorize.c:77
 msgid "censorize"
-msgstr "審查"
+msgstr "馬賽克模糊"
 
 #: ../src/iop/censorize.c:82
 msgid "censorize license plates and body parts for privacy"
-msgstr "審查車牌或人體部分以保護隱私"
+msgstr ""
+"馬賽克模糊 | censorize\n"
+"\n"
+"將重要資訊區域模糊以保護隱私\n"
+"此模組可以一併執行高斯模糊和馬賽克像素化效果\n"
+"模糊後的影像無法確保日後被重建內容，尤其是車牌這類簡單文字\n"
+"如果要完整刪除任何隱私資訊，唯一方法是用純色遮蓋"
 
 #: ../src/iop/censorize.c:84 ../src/iop/colorin.c:137
 #: ../src/iop/filmicrgb.c:356 ../src/iop/graduatednd.c:151
 msgid "linear or non-linear, RGB, scene-referred"
-msgstr "線性或非線性、RGB、場景工作流程"
+msgstr "線性或非線性、RGB、場景參照"
 
 #: ../src/iop/censorize.c:86
 msgid "special, RGB, scene-referred"
-msgstr "特殊、RGB、場景工作流程"
+msgstr "特殊、RGB、場景參照"
 
 #: ../src/iop/censorize.c:419
 msgid "radius_1"
-msgstr "半徑 1"
+msgstr "半徑一"
 
 #: ../src/iop/censorize.c:421
 msgid "pixelate"
@@ -12412,36 +12767,44 @@ msgstr "像素化"
 
 #: ../src/iop/censorize.c:423
 msgid "radius_2"
-msgstr "半徑 2"
+msgstr "半徑二"
 
 #: ../src/iop/censorize.c:425
 msgid "noise"
-msgstr "噪點"
+msgstr "雜訊"
 
 #: ../src/iop/censorize.c:427
 msgid "radius of gaussian blur before pixellation"
-msgstr "像素化前的高斯模糊半徑"
+msgstr ""
+"第一次高斯模糊的半徑\n"
+"在馬賽克效果之前執行"
 
 #: ../src/iop/censorize.c:428
 msgid "radius of gaussian blur after pixellation"
-msgstr "像素化後的高斯模糊半徑"
+msgstr ""
+"第二次高斯模糊的半徑\n"
+"在馬賽克效果之後執行"
 
 #: ../src/iop/censorize.c:429
 msgid "radius of the intermediate pixellation"
-msgstr "中間像素化的半徑"
+msgstr ""
+"馬賽克效果的尺寸\n"
+"在兩次高斯模糊中間執行"
 
 #: ../src/iop/censorize.c:430
 msgid "amount of noise to add at the end"
-msgstr "最後加入的噪點量"
+msgstr ""
+"在最後一步增加雜訊的數量\n"
+"使用高斯分布的亮度雜訊，偽造模糊區域的細節讓 AI 不易分辨"
 
 #: ../src/iop/channelmixer.c:126
 msgid "channel mixer"
-msgstr "通道混合"
+msgstr "色版混合器"
 
 #: ../src/iop/channelmixer.c:131
 msgid ""
 "this module is deprecated. please use the color calibration module instead."
-msgstr "此模組已棄用。請使用顏色校準模組。"
+msgstr "此模組已被汰除，建議使用「色彩校正」模組替代"
 
 #: ../src/iop/channelmixer.c:136 ../src/iop/channelmixerrgb.c:230
 msgid ""
@@ -12449,8 +12812,13 @@ msgid ""
 "such as white balance, channels mixing\n"
 "and conversions to monochrome emulating film"
 msgstr ""
-"執行顏色空間修正，\n"
-"如白平衡，通道混合以及轉換成單色軟片效果"
+"色彩校正 | color calibration\n"
+"\n"
+"功能完整的色彩空間校正、白平衡調整和色版混合器模組\n"
+"使用色彩適應轉換調整白平衡，或是使用標準色卡校正顏色\n"
+"灰階色版混合器功能可調整 RGB 色版的相對強度產生灰階影像\n"
+"RGB 色版混合可以調整輸入色版強度執行串擾調色\n"
+"或是依據像素的 RGB 色版強度來調整影像的飽和度和亮度"
 
 #: ../src/iop/channelmixer.c:621
 msgid "destination"
@@ -12459,27 +12827,27 @@ msgstr "目的地"
 #: ../src/iop/channelmixer.c:628
 msgctxt "channelmixer"
 msgid "gray"
-msgstr "灰"
+msgstr "灰色"
 
 #: ../src/iop/channelmixer.c:634
 msgid "amount of red channel in the output channel"
-msgstr "輸出通道中紅色通道量"
+msgstr "輸出色版中紅色色版的強度"
 
 #: ../src/iop/channelmixer.c:640
 msgid "amount of green channel in the output channel"
-msgstr "輸出通道中綠色通道量"
+msgstr "輸出色版中綠色色版的強度"
 
 #: ../src/iop/channelmixer.c:646
 msgid "amount of blue channel in the output channel"
-msgstr "輸出通道中藍色通道量"
+msgstr "輸出色版中藍色色版的強度"
 
 #: ../src/iop/channelmixer.c:662 ../src/iop/channelmixerrgb.c:490
 msgid "swap R and B"
-msgstr "對調 紅和藍"
+msgstr "紅藍色版對調"
 
 #: ../src/iop/channelmixer.c:668 ../src/iop/channelmixerrgb.c:464
 msgid "swap G and B"
-msgstr "對調 綠和藍"
+msgstr "藍綠色版對調"
 
 #: ../src/iop/channelmixer.c:674
 msgid "color contrast boost"
@@ -12491,111 +12859,112 @@ msgstr "色彩細節增強"
 
 #: ../src/iop/channelmixer.c:686
 msgid "color artifacts boost"
-msgstr "色彩僞影增加"
+msgstr "色彩偽影增強"
 
 #: ../src/iop/channelmixer.c:692
 msgid "B/W luminance-based"
-msgstr "黑白基於亮度"
+msgstr "黑白 基於亮度"
 
 #: ../src/iop/channelmixer.c:698
 msgid "B/W artifacts boost"
-msgstr "黑白人工增強"
+msgstr "黑白 偽影提升"
 
 #: ../src/iop/channelmixer.c:704
 msgid "B/W smooth skin"
-msgstr "黑白平滑皮膚"
+msgstr "黑白 平滑皮膚"
 
 #: ../src/iop/channelmixer.c:710
 msgid "B/W blue artifacts reduce"
-msgstr "黑白藍色人工減少"
+msgstr "黑白 藍色偽影降低"
 
 #: ../src/iop/channelmixer.c:717
 msgid "B/W Ilford Delta 100-400"
-msgstr "黑白 伊爾福Delta 100-400"
+msgstr "黑白 Ilford Delta 100-400"
 
 #: ../src/iop/channelmixer.c:724
 msgid "B/W Ilford Delta 3200"
-msgstr "黑白伊爾福Delta 3200"
+msgstr "黑白 Ilford Delta 3200"
 
 #: ../src/iop/channelmixer.c:731
 msgid "B/W Ilford FP4"
-msgstr "黑白伊爾福FP4"
+msgstr "黑白 Ilford FP4"
 
 #: ../src/iop/channelmixer.c:738
 msgid "B/W Ilford HP5"
-msgstr "黑白伊爾福HP5"
+msgstr "黑白 Ilford HP5"
 
 #: ../src/iop/channelmixer.c:745
 msgid "B/W Ilford SFX"
-msgstr "黑白伊爾福SFX"
+msgstr "黑白 Ilford SFX"
 
 #: ../src/iop/channelmixer.c:752
 msgid "B/W Kodak T-Max 100"
-msgstr "黑白柯達T-Max 100"
+msgstr "黑白 Kodak T-Max 100"
 
 #: ../src/iop/channelmixer.c:759
 msgid "B/W Kodak T-max 400"
-msgstr "黑白柯達T-max 400"
+msgstr "黑白 Kodak T-max 400"
 
 #: ../src/iop/channelmixer.c:766
 msgid "B/W Kodak Tri-X 400"
-msgstr "黑白柯達Tri-X 400"
+msgstr "黑白 Kodak Tri-X 400"
 
 #: ../src/iop/channelmixerrgb.c:220
 msgid "color calibration"
-msgstr "顏色校準"
+msgstr "色彩校正"
 
 #: ../src/iop/channelmixerrgb.c:225
 msgid "channel mixer|white balance|monochrome"
-msgstr "通道混合器|白平衡|黑白"
+msgstr ""
+"色版混合|白平衡|黑白|色彩適應|color|calibration|CAT|chromatic|adaptation"
 
 #: ../src/iop/channelmixerrgb.c:235
 msgid "linear, RGB or XYZ"
-msgstr "線性、RGB或XYZ"
+msgstr "線性、RGB 或 XYZ"
 
 #: ../src/iop/channelmixerrgb.c:368
 msgid "B&W: luminance-based"
-msgstr "黑白:基於亮度"
+msgstr "黑白：基於亮度"
 
 #: ../src/iop/channelmixerrgb.c:397
 msgid "B&W: ILFORD HP5+"
-msgstr "黑白:伊爾福 HP5+"
+msgstr "黑白：ILFORD HP5+"
 
 #: ../src/iop/channelmixerrgb.c:406
 msgid "B&W: ILFORD DELTA 100"
-msgstr "黑白:伊爾福 DELTA 100"
+msgstr "黑白：ILFORD DELTA 100"
 
 #: ../src/iop/channelmixerrgb.c:416
 msgid "B&W: ILFORD DELTA 400 - 3200"
-msgstr "黑白:伊爾福 DELTA 400 - 3200"
+msgstr "黑白：ILFORD DELTA 400 - 3200"
 
 #: ../src/iop/channelmixerrgb.c:425
 msgid "B&W: ILFORD FP4+"
-msgstr "黑白:伊爾福 FP4+"
+msgstr "黑白：ILFORD FP4+"
 
 #: ../src/iop/channelmixerrgb.c:434
 msgid "B&W: Fuji Acros 100"
-msgstr "黑白:富士 Acros 100"
+msgstr "黑白：Fujifilm Acros 100"
 
 #: ../src/iop/channelmixerrgb.c:451
 msgid "basic channel mixer"
-msgstr "基本通道混合器"
+msgstr "基本色版混合器"
 
 #: ../src/iop/channelmixerrgb.c:477
 msgid "swap G and R"
-msgstr "對調 綠和紅"
+msgstr "紅綠色版對調"
 
 #: ../src/iop/channelmixerrgb.c:1741
 msgid "(daylight)"
-msgstr "(日光)"
+msgstr "（日光）"
 
 #: ../src/iop/channelmixerrgb.c:1743
 msgid "(black body)"
-msgstr "(黑體)"
+msgstr "（黑體）"
 
 #: ../src/iop/channelmixerrgb.c:1745
 msgid "(invalid)"
-msgstr "(無效)"
+msgstr "（無效）"
 
 #: ../src/iop/channelmixerrgb.c:1749 ../src/iop/channelmixerrgb.c:1798
 msgid "very good"
@@ -12611,7 +12980,7 @@ msgstr "尚可"
 
 #: ../src/iop/channelmixerrgb.c:1755 ../src/iop/channelmixerrgb.c:1804
 msgid "bad"
-msgstr "差"
+msgstr "糟糕"
 
 #: ../src/iop/channelmixerrgb.c:1762
 #, c-format
@@ -12634,21 +13003,21 @@ msgid ""
 "black offset: \t%+.4f"
 msgstr ""
 "\n"
-"<b>色彩配置品質報告:%s</b>\n"
-"輸入 ΔE:\t平均 %.2f；\t最大 %.2f\n"
-"白平衡 ΔE:\t平均 %.2f；\t最大 %.2f\n"
-"輸出 ΔE:\t平均 %.2f；\t最大 %.2f\n"
+"描述檔品質報告：%s\n"
+"　輸入 ΔE：　平均 %.2f　最高 %.2f\n"
+"白平衡 ΔE：　平均 %.2f　最高 %.2f\n"
+"　輸出 ΔE：　平均 %.2f　最高 %.2f\n"
 "\n"
-"<b>色彩配置資料</b>\n"
-"照明:\t%.0f K \t%s \n"
-"調適空間中的矩陣:\n"
-"<tt>%+.4f \t%+.4f \t%+.4f\n"
-"%+.4f \t%+.4f \t%+.4f\n"
-"%+.4f \t%+.4f \t%+.4f</tt>\n"
+"描述檔資料\n"
+"光源：　%.0f K %s\n"
+"色彩適應轉換矩陣：\n"
+"<tt>%+.4f %+.4f %+.4f\n"
+"%+.4f %+.4f %+.4f\n"
+"%+.4f %+.4f %+.4f</tt>\n"
 "\n"
-"<b>正規化值</b>\n"
-"曝光補償:\t%+.2f EV\n"
-"黑色位移\t%+.4f"
+"歸一化參數\n"
+"曝光補償：　%+.2f EV\n"
+"黑點偏移：　%+.4f"
 
 #: ../src/iop/channelmixerrgb.c:1808
 #, c-format
@@ -12662,18 +13031,18 @@ msgid ""
 "black offset: \t%+.4f"
 msgstr ""
 "\n"
-"<b>色彩配置品質報告:%s</b>\n"
-"輸出 ΔE:\t平均 %.2f；\t最大 %.2f\n"
+"描述檔品質報告：%s\n"
+"　輸出 ΔE：　平均 %.2f　最高 %.2f\n"
 "\n"
-"<b>正規化值</b>\n"
-"曝光補償:\t%+.2f EV\n"
-"黑色位移\t%+.4f"
+"歸一化參數\n"
+"曝光補償：　%+.2f EV\n"
+"黑點偏移：　%+.4f"
 
 #. our second biggest problem : another channelmixerrgb instance is doing CAT
 #. earlier in the pipe.
 #: ../src/iop/channelmixerrgb.c:1830
 msgid "double CAT applied"
-msgstr "套用了雙重 CAT"
+msgstr "套用了兩次色彩適應"
 
 #: ../src/iop/channelmixerrgb.c:1831
 msgid ""
@@ -12682,9 +13051,10 @@ msgid ""
 "this can lead to inconsistencies, unless you\n"
 "use them with masks or know what you are doing."
 msgstr ""
-"你有兩個或更多的色彩校準實例，都在進行色度調適。\n"
-"這可能會導致輸出不一致，除非你使用遮罩或你\n"
-"確定知道你在做什麼。"
+"有兩個以上的「色彩校正」模組正在使用中\n"
+"這可能會導致色彩適應不一致\n"
+"請確認已了解這些步驟執行的目的\n"
+"或是將不同模組與遮罩搭配使用"
 
 #. our first and biggest problem : white balance module is being clever with WB coeffs
 #: ../src/iop/channelmixerrgb.c:1841
@@ -12698,21 +13068,22 @@ msgid ""
 "with chromatic adaptation. either set it to reference\n"
 "or disable chromatic adaptation here."
 msgstr ""
-"白平衡模組沒有使用相機的參考光源，\n"
-"這將導致這裏的色度調適問題解決方法:設定為參考值或不使用色度調適。"
+"「白平衡」模組不是使用相機基準白點\n"
+"這會導致本模組的色彩適應問題\n"
+"更改「白平衡」模組設定或關閉色彩適應"
 
 #: ../src/iop/channelmixerrgb.c:1918
 msgid "auto-detection of white balance completed"
-msgstr "白平衡的自動偵測已完成"
+msgstr "白平衡自動檢測完成"
 
 #: ../src/iop/channelmixerrgb.c:2056
 msgid "channelmixerrgb works only on RGB input"
-msgstr "rgb 通道混色器僅對 rgb 輸入有效"
+msgstr "RGB 色版混合器僅適用於 RGB 輸入訊號"
 
 #: ../src/iop/channelmixerrgb.c:3313
 #, c-format
 msgid "CCT: %.0f K (daylight)"
-msgstr "CCT:%.0f K(日光)"
+msgstr "色溫：%.0f K（日光）"
 
 #: ../src/iop/channelmixerrgb.c:3315
 msgid ""
@@ -12720,13 +13091,14 @@ msgid ""
 "this illuminant can be accurately modeled by a daylight spectrum,\n"
 "so its temperature is relevant and meaningful with a D illuminant."
 msgstr ""
-"近似相關的色溫。\n"
-"這種光源可以通過日光光譜準確地建模，因此它的溫度與 D 型光源相關。"
+"近似相關色溫（CCT）\n"
+"所選擇的光源色彩可使用標準日光光譜分布描述\n"
+"所以色溫與 CIE Daylight 相關聯"
 
 #: ../src/iop/channelmixerrgb.c:3321
 #, c-format
 msgid "CCT: %.0f K (black body)"
-msgstr "CCT:%.0f K(黑體)"
+msgstr "色溫：%.0f K（黑體）"
 
 #: ../src/iop/channelmixerrgb.c:3323
 msgid ""
@@ -12734,13 +13106,14 @@ msgid ""
 "this illuminant can be accurately modeled by a black body spectrum,\n"
 "so its temperature is relevant and meaningful with a Planckian illuminant."
 msgstr ""
-"近似相關的色溫。\n"
-"這種光源可以通過黑體光譜準確地建模，因此它的溫度與黑體光源相關。"
+"近似相關色溫（CCT）\n"
+"所選擇的光源色彩可使用理想黑體光譜分布描述\n"
+"所以色溫與普朗克黑體輻射相關聯"
 
 #: ../src/iop/channelmixerrgb.c:3329
 #, c-format
 msgid "CCT: %.0f K (invalid)"
-msgstr "CCT:%.0f K(無效)"
+msgstr "色溫：%.0f K（無效）"
 
 #: ../src/iop/channelmixerrgb.c:3331
 msgid ""
@@ -12750,37 +13123,37 @@ msgid ""
 "so its temperature is not relevant and meaningful and you need to use a "
 "custom illuminant."
 msgstr ""
-"近似相關的色溫。\n"
-"這種光源無法以日光或黑體光譜準確地建模。\n"
-"所以它的溫度是不相關的，也是沒有意義的，你需要使用一個自定義光源。"
+"近似相關色溫（CCT）\n"
+"所選擇的光源色彩無法使用日光或黑體光譜描述\n"
+"所以色溫不具有實質意義，需要使用自訂光源"
 
 #: ../src/iop/channelmixerrgb.c:3338
 #, c-format
 msgid "CCT: undefined"
-msgstr "CCT:未定義"
+msgstr "色溫：未定義"
 
 #: ../src/iop/channelmixerrgb.c:3340
 msgid ""
 "the approximated correlated color temperature\n"
 "cannot be computed at all so you need to use a custom illuminant."
 msgstr ""
-"近似的相關色溫\n"
-"無法計算，你需要使用一個自定義光源。"
+"無法計算相關色溫（CCT）\n"
+"需要使用自定光源"
 
 #: ../src/iop/channelmixerrgb.c:3630
 msgid "white balance successfully extracted from raw image"
-msgstr "成功從 raw 影像中提取白平衡"
+msgstr "成功從 RAW 檔案中取得白平衡"
 
 #. We need to recompute only the full preview
 #: ../src/iop/channelmixerrgb.c:3636
 msgid "auto-detection of white balance started…"
-msgstr "開始自動偵測白平衡……"
+msgstr "正在自動偵測白平衡"
 
 #: ../src/iop/channelmixerrgb.c:3702
 msgid ""
 "color calibration: the sum of the gray channel parameters is zero, "
 "normalization will be disabled."
-msgstr "顏色校準:灰度通道參數之和爲零，正規化將被不使用。"
+msgstr "色彩校正中的灰階色版參數總和為零，歸一化將被停用"
 
 #: ../src/iop/channelmixerrgb.c:3748
 #, c-format
@@ -12789,13 +13162,13 @@ msgid ""
 "h: \t%.1f °\n"
 "c: \t%.1f"
 msgstr ""
-"L: \t%.1f %%\n"
-"h: \t%.1f °\n"
-"c: \t%.1f"
+"L：\t%.1f %%\n"
+"h：\t%.1f °\n"
+"C：\t%.1f"
 
 #. //////////////////////// PAGE SETTINGS
 #: ../src/iop/channelmixerrgb.c:4004 ../src/iop/clipping.c:2105
-#: ../src/iop/colorbalancergb.c:1893 ../src/iop/filmicrgb.c:4208
+#: ../src/iop/colorbalancergb.c:1890 ../src/iop/filmicrgb.c:4208
 #: ../src/iop/negadoctor.c:802 ../src/iop/toneequal.c:3110
 #: ../src/libs/image.c:462 ../src/libs/print_settings.c:2351
 #: ../src/views/lighttable.c:1243
@@ -12805,15 +13178,22 @@ msgstr "頁面"
 #. Page CAT
 #: ../src/iop/channelmixerrgb.c:4007
 msgid "CAT"
-msgstr "色度調適轉換"
+msgstr "色彩適應轉換"
 
 #: ../src/iop/channelmixerrgb.c:4007
 msgid "chromatic adaptation transform"
-msgstr "色度調適轉換"
+msgstr ""
+"控制色彩適應轉換的方式和光源設定\n"
+"開啟此功能時需要設定「白平衡」模組為相機基準白點以執行基本的色版操作\n"
+"真正的色彩白平衡工作則交由本「色彩校正」模組執行\n"
+"\n"
+"首先選擇色彩適應方法，接著設定場景的光源顏色\n"
+"色域壓縮參數用於將經過色彩適應轉換後超出色域的顏色飽和度降低\n"
+"裁切 RGB 負值可以確保輸出數值有效性，避免純色 LED 或雷射光點顏色產生問題"
 
 #: ../src/iop/channelmixerrgb.c:4009
 msgid "adaptation"
-msgstr "調適"
+msgstr "色彩適應"
 
 #: ../src/iop/channelmixerrgb.c:4011
 msgid ""
@@ -12826,49 +13206,63 @@ msgid ""
 "• XYZ is a simple scaling in XYZ space. It is not recommended in general.\n"
 "• none disables any adaptation and uses pipeline working RGB."
 msgstr ""
-"選擇調適光照的方式，以及模組工作的顏色空間:\n"
-"• Linear Bradford(1985)與ICC v4 工具鏈一致\n"
-"• CAT16(2016)更強健及準確。\n"
-"• Non-linear Bradford(1985)是 Bradford 的原始版本，它可以產生比線性版本更好的"
-"結果，但不可靠。\n"
-"• XYZ 是 XYZ 空間的簡單縮放。一般不推薦使用。\n"
-"• none 不啟用任何自調適並使用 RGB 管線工作。"
+"選擇色彩適應轉換的方法與使用的色彩空間\n"
+"\n"
+"線性 Bradford\n"
+"ICC 規範的標準方式，也是大多數色彩管理軟體使用的方法\n"
+"對於接近日光的光源準確度高，但對非標準光源的色域控制不佳\n"
+"\n"
+"CAT16（CIECAM16）\n"
+"最新的 CIE 標準模型，色彩轉換更可靠，通常也比 Bradford 準確\n"
+"對於色彩非常鮮豔或高飽和的藍紫色表現比其他方式穩定\n"
+"\n"
+"非線性 Bradford\n"
+"原始的 Bradford 轉換方式，比線性簡化版本的效果更好\n"
+"但非線性轉換導致無法逆轉換，轉換方式也較不穩定\n"
+"\n"
+"XYZ 使用最原始的 XYZ 色彩空間縮放，會導致較大的色彩偏差，一般不推薦使用\n"
+"\n"
+"無（不轉換）\n"
+"不執行色彩適應轉換，此選項必須使用「白平衡」模組執行色彩轉換"
 
 #: ../src/iop/channelmixerrgb.c:4029
 msgid ""
 "this is the color of the scene illuminant before chromatic adaptation\n"
 "this color will be turned into pure white by the adaptation."
 msgstr ""
-"這是色度調適前的場景照明物顏色\n"
-"這個顏色將通過調適變成純白色。"
+"色彩適應使用的場景光源顏色\n"
+"此顏色會經由色彩適應計算成為純白\n"
+"其他所有顏色會由色彩適應轉換矩陣轉換成相對應的正確顏色"
 
 #: ../src/iop/channelmixerrgb.c:4036
 msgid "picker"
-msgstr "顏色選取工具"
+msgstr "色彩選取工具"
 
-#: ../src/iop/channelmixerrgb.c:4037 ../src/iop/temperature.c:1922
+#: ../src/iop/channelmixerrgb.c:4037 ../src/iop/temperature.c:1867
 msgid "set white balance to detected from area"
-msgstr "將白平衡設定爲從區域偵測"
+msgstr ""
+"在影像上選取範圍做為白平衡的參考光源顏色\n"
+"應該選取影像中應該為中灰色的區域"
 
 #: ../src/iop/channelmixerrgb.c:4041
 msgid "illuminant"
-msgstr "光照"
+msgstr "光源"
 
-#: ../src/iop/channelmixerrgb.c:4047 ../src/iop/temperature.c:1974
+#: ../src/iop/channelmixerrgb.c:4047 ../src/iop/temperature.c:1919
 msgid "temperature"
 msgstr "色溫"
 
 #: ../src/iop/channelmixerrgb.c:4075
 msgid "spot color mapping"
-msgstr "點顏色映射"
+msgstr "點測色色彩對應"
 
 #: ../src/iop/channelmixerrgb.c:4078 ../src/iop/channelmixerrgb.c:4206
 msgid "use a color checker target to autoset CAT and channels"
-msgstr "使用顏色檢查器目標來自動設定色調適轉換和通道"
+msgstr "使用校色卡自動計算調整色彩適應轉換和色版"
 
 #: ../src/iop/channelmixerrgb.c:4080 ../src/iop/exposure.c:1083
 msgid "spot mode"
-msgstr "點模式"
+msgstr "點測對應模式"
 
 #: ../src/iop/channelmixerrgb.c:4081
 msgid ""
@@ -12877,14 +13271,16 @@ msgid ""
 "\"measure\" simply shows how an input color is mapped by the CAT\n"
 "and can be used to sample a target."
 msgstr ""
-"修正:自動調整亮度\n"
-"使得輸入顏色可對應到目標\n"
-"量測: 僅顯示輸入顏色如何經由CAT對應到\n"
-"及使用於抽樣目標."
+"點測色色彩對應模式用於整批調整同系列影像的色彩\n"
+"依據上方選擇的影像範圍對應目標顏色，然後將此顏色對應至其他影像\n"
+"藉由選擇一系列影像中顏色應保持不變的區域，批次調整多張影像的顏色一致性\n"
+"\n"
+"「測量」模式用於定義所選範圍的目標顏色\n"
+"「校正」模式將目標顏色映射至所選範圍"
 
 #: ../src/iop/channelmixerrgb.c:4086 ../src/iop/exposure.c:1089
 msgid "correction"
-msgstr "修正"
+msgstr "校正"
 
 #: ../src/iop/channelmixerrgb.c:4087 ../src/iop/exposure.c:1090
 msgid "measure"
@@ -12892,19 +13288,19 @@ msgstr "測量"
 
 #: ../src/iop/channelmixerrgb.c:4091
 msgid "take channel mixing into account"
-msgstr "考慮通道混合"
+msgstr "考量色版混合"
 
 #: ../src/iop/channelmixerrgb.c:4096
 msgid ""
 "compute the target by taking the channel mixing into account.\n"
 "if disabled, only the CAT is considered."
 msgstr ""
-"計算目標時考慮通道混合\n"
-"如果不啟用，只有CAT可用."
+"計算顏色時將色版混合納入考量\n"
+"如果沒有選取，則僅則僅考慮色彩適應轉換"
 
 #: ../src/iop/channelmixerrgb.c:4110 ../src/iop/exposure.c:1103
 msgid "the input color that should be mapped to the target"
-msgstr "輸入色彩應對應到目標色彩"
+msgstr "要對應到目標顏色的輸入顏色"
 
 #: ../src/iop/channelmixerrgb.c:4115
 msgid ""
@@ -12912,97 +13308,97 @@ msgid ""
 "h: \tN/A\n"
 "c: \tN/A"
 msgstr ""
-"L: \tN/A\n"
-"h: \tN/A\n"
-"c: \tN/A"
+"L：\tN/A \n"
+"h：\tN/A\n"
+"C：\tN/A"
 
 #: ../src/iop/channelmixerrgb.c:4117 ../src/iop/exposure.c:1110
 msgid "these LCh coordinates are computed from CIE Lab 1976 coordinates"
-msgstr "這些LCh座標是從CIE Lab 1976 計算得到"
+msgstr "這些 LCh 座標是從 CIELAB 1976 座標計算出來的"
 
 #: ../src/iop/channelmixerrgb.c:4130
 msgid "the desired target color after mapping"
-msgstr "映射後想要的目標顏色"
+msgstr "選取範圍要對應的目標顏色"
 
 #: ../src/iop/channelmixerrgb.c:4165
 msgid "input R"
-msgstr "輸入 R"
+msgstr "紅色色版的輸入強度係數"
 
 #: ../src/iop/channelmixerrgb.c:4169
 msgid "input G"
-msgstr "輸入 G"
+msgstr "綠色色版的輸入強度係數"
 
 #: ../src/iop/channelmixerrgb.c:4173
 msgid "input B"
-msgstr "輸入 B"
+msgstr "藍色色版的輸入強度係數"
 
 #: ../src/iop/channelmixerrgb.c:4181
 msgid "output R"
-msgstr "輸出 R"
+msgstr "紅色色版的輸出矩陣係數"
 
 #: ../src/iop/channelmixerrgb.c:4182
 msgid "output G"
-msgstr "輸出 G"
+msgstr "綠色色版的輸出矩陣係數"
 
 #: ../src/iop/channelmixerrgb.c:4183
 msgid "output B"
-msgstr "輸出 B"
+msgstr "藍色色版的輸出矩陣係數"
 
 #: ../src/iop/channelmixerrgb.c:4184
 msgid "colorfulness"
-msgstr "彩度"
+msgstr "鮮豔度"
 
 #: ../src/iop/channelmixerrgb.c:4184
 msgid "output colorfulness"
-msgstr "輸出彩度"
+msgstr "依據不同色版調整輸出的鮮豔度"
 
 #: ../src/iop/channelmixerrgb.c:4186
 msgid "output brightness"
-msgstr "輸出亮度"
+msgstr "依據不同色版調整輸出的亮度"
 
 #: ../src/iop/channelmixerrgb.c:4187
 msgid "output gray"
-msgstr "輸出灰色"
+msgstr "使用不同強度的色版混合輸出灰階影像"
 
 #: ../src/iop/channelmixerrgb.c:4202
 msgid "calibrate with a color checker"
-msgstr "用顏色檢查器進行校準"
+msgstr "使用校色卡校正"
 
 #: ../src/iop/channelmixerrgb.c:4211
 msgid "chart"
-msgstr "圖表"
+msgstr "色卡"
 
 #: ../src/iop/channelmixerrgb.c:4212
 msgid "choose the vendor and the type of your chart"
-msgstr "選擇廠商和圖表類型"
+msgstr "選擇廠商和色卡"
 
 #: ../src/iop/channelmixerrgb.c:4214
 msgid "Xrite ColorChecker 24 pre-2014"
-msgstr "Xrite ColorChecker 24 (2014 前的型號)"
+msgstr "Xrite ColorChecker 24 （2014 之前）"
 
 #: ../src/iop/channelmixerrgb.c:4215
 msgid "Xrite ColorChecker 24 post-2014"
-msgstr "Xrite ColorChecker 24 (2014 後的型號)"
+msgstr "Xrite ColorChecker 24 （2014 之後）"
 
 #: ../src/iop/channelmixerrgb.c:4216
 msgid "Datacolor SpyderCheckr 24 pre-2018"
-msgstr "Datacolor SpyderCheckr 24 (2018 前的型號)"
+msgstr "Datacolor SpyderCheckr 24 （2018 之前）"
 
 #: ../src/iop/channelmixerrgb.c:4217
 msgid "Datacolor SpyderCheckr 24 post-2018"
-msgstr "Datacolor SpyderCheckr 24 (2018 後的型號)"
+msgstr "Datacolor SpyderCheckr 24 （2018 之後）"
 
 #: ../src/iop/channelmixerrgb.c:4218
 msgid "Datacolor SpyderCheckr 48 pre-2018"
-msgstr "Datacolor SpyderCheckr 48 (2018 前的型號)"
+msgstr "Datacolor SpyderCheckr 48 （2018 之前）"
 
 #: ../src/iop/channelmixerrgb.c:4219
 msgid "Datacolor SpyderCheckr 48 post-2018"
-msgstr "Datacolor SpyderCheckr 48 (2018 後的型號)"
+msgstr "Datacolor SpyderCheckr 48 （2018 之後）"
 
 #: ../src/iop/channelmixerrgb.c:4222
 msgid "optimize for"
-msgstr "優化用於"
+msgstr "最佳化目標"
 
 #: ../src/iop/channelmixerrgb.c:4223
 msgid ""
@@ -13013,11 +13409,22 @@ msgid ""
 "none is a trade-off between both\n"
 "the others are special behaviours to protect some hues"
 msgstr ""
-"選擇將被優先優化的顏色。\n"
-"中性色的平均 delta E 最低，但最大 delta E 較高。\n"
-"飽和色給出了最低的最大 delta E，但平均delta E 較高。\n"
-"無是兩者折衷\n"
-"其他選項是保護某些色調的特殊行爲"
+"色彩校正的優先目標，權衡並犧牲其他顏色來提高優先目標的顏色準確度\n"
+"\n"
+"無：均等考量色卡內的所有顏色，如果色卡以膚色為主則膚色就會較準確\n"
+"中性色：優先考量灰色和飽和度較低的顏色，對低演色值的廉價燈源非常有效\n"
+"飽和色：優先考慮高飽和色，這對商業攝影獲得正確的品牌色很有用\n"
+"皮膚和土壤的顏色：黃紅色調的顏色準確度優先\n"
+"樹葉的顏色：綠色調的顏色準確度優先\n"
+"天空和水的顏色：藍色調的顏色準確度優先\n"
+"平均色差（ΔE）：盡量讓所有顏色的色差接近，主要用於通用設定\n"
+"最大色差（ΔE）：降低大的色差值，這對於高度飽和的螢光色彩很有用\n"
+"\n"
+"校色卡上色塊的對角線表示在校正後的色差值\n"
+"無對角線標示的色塊：ΔE < 2.3，一般人無法察覺到色偏\n"
+"有一條對角線的色塊：2.3 < ΔE < 4.6，色彩稍微有些不準確\n"
+"有兩條對角線的色塊：ΔE > 4.6，顏色非常不準確\n"
+"這樣的標示有助於直覺反應，並調整最佳化的策略目標"
 
 #: ../src/iop/channelmixerrgb.c:4230
 msgid "neutral colors"
@@ -13029,23 +13436,23 @@ msgstr "皮膚和土壤顏色"
 
 #: ../src/iop/channelmixerrgb.c:4233
 msgid "foliage colors"
-msgstr "葉子顏色"
+msgstr "樹葉的顏色"
 
 #: ../src/iop/channelmixerrgb.c:4234
 msgid "sky and water colors"
-msgstr "天空和水顏色"
+msgstr "天空和水的顏色"
 
 #: ../src/iop/channelmixerrgb.c:4235
 msgid "average delta E"
-msgstr "平均 delta E"
+msgstr "平均色差（ΔE）"
 
 #: ../src/iop/channelmixerrgb.c:4236
 msgid "maximum delta E"
-msgstr "最大 delta E"
+msgstr "最大色差（ΔE）"
 
 #: ../src/iop/channelmixerrgb.c:4240
 msgid "patch scale"
-msgstr "色塊大小"
+msgstr "色塊尺寸"
 
 #: ../src/iop/channelmixerrgb.c:4241
 msgid ""
@@ -13053,64 +13460,66 @@ msgid ""
 "useful when the perspective correction is sloppy or\n"
 "the patches frame cast a shadows on the edges of the patch."
 msgstr ""
-"縮小色塊的半徑以選擇或多或少的中心部分。\n"
-"當透視校正不嚴謹或色塊框架在色塊邊緣投下陰影時，這個方法很有效。"
+"調整色塊的半徑以選擇更多或更少的的中央部分\n"
+"當透視校正不正確或色塊框架在色塊上留下陰影時非常有用"
 
 #: ../src/iop/channelmixerrgb.c:4249
 msgid "the delta E is using the CIE 2000 formula"
-msgstr "delta E 使用CIE 2000公式"
+msgstr "色差（ΔE）使用 CIE 2000 公式計算"
 
 #: ../src/iop/channelmixerrgb.c:4255
 msgid "accept the computed profile and set it in the module"
-msgstr "接受計算出的配置檔案並將其設定在模組中"
+msgstr "接受目前計算的描述檔，並將其設定到色彩轉換中"
 
 #: ../src/iop/channelmixerrgb.c:4260
 msgid "recompute the profile"
-msgstr "重新計算配置"
+msgstr "重新計算描述檔"
 
 #: ../src/iop/channelmixerrgb.c:4265
 msgid "check the output delta E"
-msgstr "檢查輸出 delta E"
+msgstr "檢查輸出色差（ΔE）"
 
 #: ../src/iop/choleski.h:288 ../src/iop/choleski.h:386
 msgid ""
 "Choleski decomposition failed to allocate memory, check your RAM settings"
-msgstr "Choleski 分解未能配置記憶體，請檢查 RAM 設定"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"科列斯基分解無法配置記憶體，請檢查記憶體設定"
 
 #: ../src/iop/clahe.c:74
 msgid ""
 "this module is deprecated. better use new local contrast module instead."
-msgstr "此模組已棄用。最好改用新的‘局部對比度’模組。"
+msgstr "此模組已被汰除，建議使用「局部對比度」模組替代"
 
-#: ../src/iop/clahe.c:337 ../src/iop/sharpen.c:453
+#: ../src/iop/clahe.c:337 ../src/iop/sharpen.c:454
 msgid "amount"
 msgstr "總量"
 
 #: ../src/iop/clahe.c:346
 msgid "size of features to preserve"
-msgstr "保持特性大小"
+msgstr "要保留的特性大小"
 
 #: ../src/iop/clahe.c:347 ../src/iop/nlmeans.c:518
 msgid "strength of the effect"
-msgstr "效果強度"
+msgstr "調整去除雜訊的強度"
 
 #: ../src/iop/clipping.c:304
 msgid ""
 "this module is deprecated. please use the crop, orientation and/or rotate "
 "and perspective modules instead."
-msgstr "此模組已棄用。請使用裁剪、方向及/或旋轉與透視模組替代。"
+msgstr "此模組已被汰除，建議使用「裁切」或「方向」或模組替代"
 
 #: ../src/iop/clipping.c:309
 msgid "crop and rotate"
-msgstr "裁剪和旋轉"
+msgstr "裁剪與旋轉"
 
 #: ../src/iop/clipping.c:314
 msgid "reframe|perspective|keystone|distortion"
-msgstr "再構造|透視|梯形失真|失真"
+msgstr "透視|梯形校正|裁切|變形"
 
 #: ../src/iop/clipping.c:319
 msgid "change the framing and correct the perspective"
-msgstr "改變邊框比例及修正透視"
+msgstr "變更邊界與修正透視"
 
 #: ../src/iop/clipping.c:1412 ../src/iop/clipping.c:2138 ../src/iop/crop.c:454
 #: ../src/iop/crop.c:1050
@@ -13119,15 +13528,15 @@ msgstr "原始影像"
 
 #: ../src/iop/clipping.c:1716 ../src/iop/crop.c:758
 msgid "invalid ratio format. it should be \"number:number\""
-msgstr "無效的比例格式。請以“數字:數字”輸入"
+msgstr "無效的比例格式，必須使用「數字 : 數字」"
 
 #: ../src/iop/clipping.c:1732 ../src/iop/crop.c:774
 msgid "invalid ratio format. it should be a positive number"
-msgstr "無效的比例格式。應該要一個正數"
+msgstr "無效的比例格式，只能使用正值"
 
 #: ../src/iop/clipping.c:1921 ../src/iop/clipping.c:2129
 msgid "full"
-msgstr "完整"
+msgstr "全部"
 
 #: ../src/iop/clipping.c:1922
 msgid "old system"
@@ -13135,7 +13544,7 @@ msgstr "舊系統"
 
 #: ../src/iop/clipping.c:1923
 msgid "correction applied"
-msgstr "修正已套用"
+msgstr "已套用校正"
 
 #: ../src/iop/clipping.c:2107
 msgid "main"
@@ -13143,7 +13552,7 @@ msgstr "主要"
 
 #: ../src/iop/clipping.c:2116
 msgid "mirror image horizontally and/or vertically"
-msgstr "鏡射影像水平 及/或 垂直"
+msgstr "水平或垂直鏡像"
 
 #: ../src/iop/clipping.c:2119
 msgid "angle"
@@ -13151,15 +13560,15 @@ msgstr "角度"
 
 #: ../src/iop/clipping.c:2122
 msgid "right-click and drag a line on the image to drag a straight line"
-msgstr "在影像上右擊及拖拉可以得到一條直線"
+msgstr "在影像用滑鼠右鍵拖曳水平線校正"
 
 #: ../src/iop/clipping.c:2125
 msgid "keystone"
-msgstr "梯形失真"
+msgstr "梯形校正"
 
 #: ../src/iop/clipping.c:2130
 msgid "set perspective correction for your image"
-msgstr "爲您的影像設置透視校正"
+msgstr "調整影像的透視校正"
 
 #: ../src/iop/clipping.c:2137 ../src/iop/crop.c:1049
 msgid "freehand"
@@ -13167,51 +13576,51 @@ msgstr "手繪"
 
 #: ../src/iop/clipping.c:2140 ../src/iop/crop.c:1052
 msgid "10:8 in print"
-msgstr "列印(10:8)"
+msgstr "10 : 8 - 傳統相紙"
 
 #: ../src/iop/clipping.c:2141 ../src/iop/crop.c:1053
 msgid "5:4, 4x5, 8x10"
-msgstr "5:4, 4x5, 8x10"
+msgstr "5 : 4 - 4 x 5、8 x 10 大型相機"
 
 #: ../src/iop/clipping.c:2142 ../src/iop/crop.c:1054
 msgid "11x14"
-msgstr "11x14"
+msgstr "11 : 14 - 傳統相紙"
 
 #: ../src/iop/clipping.c:2143 ../src/iop/crop.c:1055
 msgid "8.5x11, letter"
-msgstr "8.5x11, 信紙"
+msgstr "8.5 x 11 - 北美書信用紙"
 
 #: ../src/iop/clipping.c:2144 ../src/iop/crop.c:1056
 msgid "4:3, VGA, TV"
-msgstr "4:3, VGA, 電視"
+msgstr "4 : 3 - 傳統電視"
 
 #: ../src/iop/clipping.c:2145 ../src/iop/crop.c:1057
 msgid "5x7"
-msgstr "5x7"
+msgstr "5 : 7 - 傳統相紙"
 
 #: ../src/iop/clipping.c:2146 ../src/iop/crop.c:1058
 msgid "ISO 216, DIN 476, A4"
-msgstr "ISO 216、DIN 476、A4"
+msgstr "A4 - ISO 216、DIN 476"
 
 #: ../src/iop/clipping.c:2147 ../src/iop/crop.c:1059
 msgid "3:2, 4x6, 35mm"
-msgstr "3:2、4x6、35mm"
+msgstr "3 : 2 - 35mm 底片及數位相機"
 
 #: ../src/iop/clipping.c:2148 ../src/iop/crop.c:1060
 msgid "16:10, 8x5"
-msgstr "16:10, 8x5"
+msgstr "16 : 10 - 螢幕"
 
 #: ../src/iop/clipping.c:2150 ../src/iop/crop.c:1062
 msgid "16:9, HDTV"
-msgstr "16:9,高解析度電視"
+msgstr "16 : 9 - 電視寬螢幕"
 
 #: ../src/iop/clipping.c:2151 ../src/iop/crop.c:1063
 msgid "widescreen"
-msgstr "寬螢幕(widescreen)"
+msgstr "寬螢幕"
 
 #: ../src/iop/clipping.c:2152 ../src/iop/crop.c:1064
 msgid "2:1, univisium"
-msgstr "2:1，影像一體化(univisium)"
+msgstr "2 : 1 - Univisium 電影格式"
 
 #: ../src/iop/clipping.c:2153 ../src/iop/crop.c:1065
 msgid "cinemascope"
@@ -13219,21 +13628,21 @@ msgstr "寬螢幕電影鏡頭"
 
 #: ../src/iop/clipping.c:2154 ../src/iop/crop.c:1066
 msgid "21:9"
-msgstr "21:9"
+msgstr "21 : 9"
 
 #: ../src/iop/clipping.c:2155 ../src/iop/crop.c:1067
 msgid "anamorphic"
-msgstr "變形寬銀幕(anamorphic)"
+msgstr "電影變形鏡頭"
 
 #: ../src/iop/clipping.c:2156 ../src/iop/crop.c:1068
 msgid "3:1, panorama"
-msgstr "3:1、全景"
+msgstr "3 : 1 - 全景"
 
 #: ../src/iop/clipping.c:2188 ../src/iop/clipping.c:2200 ../src/iop/crop.c:1100
 #: ../src/iop/crop.c:1112
 #, c-format
 msgid "invalid ratio format for `%s'. it should be \"number:number\""
-msgstr "無效的比例格式“%s”。請以“數字:數字”輸入"
+msgstr "比例格式「%s」無效，只能使用「數字:數字」"
 
 #: ../src/iop/clipping.c:2247 ../src/iop/crop.c:1158
 msgid ""
@@ -13242,57 +13651,69 @@ msgid ""
 "to enter custom aspect ratio open the combobox and type ratio in x:y or "
 "decimal format"
 msgstr ""
-"設置長寬比。\n"
-"列表排序:按照從最接近正方形到最不接近的\n"
-"要使用自定義的長寬比，請打開選擇框並以 x:y 或十進制格式輸入"
+"設定長寬比\n"
+"排列順序：從最接近正方形到最長形\n"
+"開啟下拉選單後可直接輸入自訂比例，使用「寬 : 高」或寬高比數值"
 
 #: ../src/iop/clipping.c:2254 ../src/iop/crop.c:1172
 msgid "margins"
-msgstr "邊距"
+msgstr "邊界"
 
 #: ../src/iop/clipping.c:2259 ../src/iop/crop.c:1180
 msgid "the left margin cannot overlap with the right margin"
-msgstr "左邊距不能與右邊距重疊"
+msgstr ""
+"左側裁剪掉的大小，以影像寬度百分比表示\n"
+"使用滑鼠直接操作影像上的裁切區域會自動更新此數值\n"
+"左側邊界不能重疊至右側邊界"
 
 #: ../src/iop/clipping.c:2266 ../src/iop/crop.c:1187
 msgid "the right margin cannot overlap with the left margin"
-msgstr "右邊距不能與左邊距重疊"
+msgstr ""
+"右側裁剪掉的大小，以影像寬度百分比表示\n"
+"使用滑鼠直接操作影像上的裁切區域會自動更新此數值\n"
+"右側邊界不能重疊至左側邊界"
 
 #: ../src/iop/clipping.c:2271 ../src/iop/crop.c:1192
 msgid "the top margin cannot overlap with the bottom margin"
-msgstr "頂邊距不能與底邊距重疊"
+msgstr ""
+"上方裁剪掉的大小，以影像高度百分比表示\n"
+"使用滑鼠直接操作影像上的裁切區域會自動更新此數值\n"
+"上方邊界不能重疊至下方邊界"
 
 #: ../src/iop/clipping.c:2278 ../src/iop/crop.c:1199
 msgid "the bottom margin cannot overlap with the top margin"
-msgstr "底邊距不能與頂邊距重疊"
+msgstr ""
+"下方裁剪掉的大小，以影像高度百分比表示\n"
+"使用滑鼠直接操作影像上的裁切區域會自動更新此數值\n"
+"下方邊界不能重疊至上方邊界"
 
 #: ../src/iop/clipping.c:3037
 msgid "<b>commit</b>: double-click, <b>straighten</b>: right-drag"
-msgstr "<b>提交</b>:雙擊，<b>拉直</b>:右鍵拖拉"
+msgstr "右鍵拖曳：拉水平線，雙擊：完成"
 
 #: ../src/iop/clipping.c:3041
 msgid ""
 "<b>resize</b>: drag, <b>keep aspect ratio</b>: shift+drag\n"
 "<b>straighten</b>: right-drag"
 msgstr ""
-"<b>調整大小</b>:拖拉，<b>保持長寬比</b>:shift + 拖拉\n"
-"<b>拉直</b>:右鍵拖拉"
+"拖曳：調整大小，shift + 拖曳：保持長寬比\n"
+"右鍵拖曳：拉水平線"
 
 #: ../src/iop/clipping.c:3084
 msgid "<b>move control point</b>: drag"
-msgstr "<b>移動控制點</b>:拖拉"
+msgstr "拖曳：移動控制點"
 
 #: ../src/iop/clipping.c:3089
 msgid "<b>move line</b>: drag, <b>toggle symmetry</b>: click <tt>ꝏ</tt>"
-msgstr "<b>移動線條</b>:拖拉，<b>切換對稱</b>:單擊 <tt>ꝏ</tt>"
+msgstr "拖曳：移動線、控制點，點擊 ꝏ：啟動對稱邊"
 
 #: ../src/iop/clipping.c:3094
 msgid ""
 "<b>apply</b>: click <tt>ok</tt>, <b>toggle symmetry</b>: click <tt>ꝏ</tt>\n"
 "<b>move line/control point</b>: drag"
 msgstr ""
-"<b>套用</b>:單擊 <tt>ok</tt>，<b>切換對稱</b>:單擊 <tt>ꝏ</tt>\n"
-"<b>移動直線和控制點</b>:拖拉"
+"點擊 ok：完成確定，點擊 ꝏ：啟動對稱邊\n"
+"拖曳：移動線、控制點"
 
 #: ../src/iop/clipping.c:3101
 msgid ""
@@ -13300,27 +13721,31 @@ msgid ""
 "b>: ctrl+drag\n"
 "<b>straighten</b>: right-drag, <b>commit</b>: double-click"
 msgstr ""
-"<b>移動</b>:拖拉，<b>垂直移動</b>:shift + 拖拉，<b>水平移動</b>:控制鍵 + 拖"
-"動\n"
-"<b>拉直</b>:右鍵拖拉，<b>提交</b>:雙擊"
+"拖曳：移動，shift + 拖曳：垂直移動，ctrl + 拖曳：水平移動\n"
+"右鍵拖曳：拉水平線，雙擊：完成"
 
 #: ../src/iop/clipping.c:3358 ../src/iop/crop.c:1638
 #, c-format
 msgid "[%s on borders] crop"
-msgstr "[在邊緣 %s] 裁剪"
+msgstr "邊界 %s：裁切"
 
 #: ../src/iop/clipping.c:3360 ../src/iop/crop.c:1640
 #, c-format
 msgid "[%s on borders] crop keeping ratio"
-msgstr "[在邊緣 %s] 保持長寬比裁剪"
+msgstr "邊界 %s：保持比例裁切"
 
 #: ../src/iop/colisa.c:79
 msgid "contrast brightness saturation"
-msgstr "對比度，亮度，飽和度"
+msgstr "亮度、對比、飽和度"
 
 #: ../src/iop/colisa.c:84
 msgid "adjust the look of the image"
-msgstr "調整影像的外觀"
+msgstr ""
+"亮度、對比、飽和度 | contrast brightness saturation\n"
+"\n"
+"非常基本的傳統影像調整工具\n"
+"還有許多模組提供更強大的類似功能\n"
+"更現代的 RGB 工具請使用「色彩平衡 RGB」模組"
 
 #: ../src/iop/colisa.c:311
 msgid "color saturation adjustment"
@@ -13332,56 +13757,64 @@ msgstr "色彩平衡"
 
 #: ../src/iop/colorbalance.c:153
 msgid "lift gamma gain|cdl|color grading|contrast|saturation|hue"
-msgstr "提升伽瑪增益|CDL|調色|對比度|飽和度|色調"
+msgstr ""
+"提升伽瑪增益|偏移乘冪斜率|色彩分級|調色|對比度|飽和度|色相|CDL|lift|gamma|"
+"gain|offset|slope|power"
 
 #: ../src/iop/colorbalance.c:158 ../src/iop/colorbalancergb.c:183
 msgid "affect color, brightness and contrast"
-msgstr "影響顏色、亮度和對比度"
+msgstr ""
+"色彩平衡（RGB）| color balance (rgb)\n"
+"\n"
+"調整影像的亮暗部與中間調色彩\n"
+"使用電影調色的技術，支援美國電影攝影師協會顏色決策列表 ASC CDL\n"
+"「色彩平衡 RGB」是 darktable 的修改版本，使用遮罩控制亮暗部分離\n"
+"並在 JzAzBz 或 darktable UCS 色彩空間中計算符合感知的飽和度"
 
 #: ../src/iop/colorbalance.c:162
 msgid "non-linear, Lab, scene-referred"
-msgstr "非線性、Lab、場景工作流程"
+msgstr "非線性、Lab、場景參照"
 
 #. these blobs were exported as dtstyle and copied from there:
 #: ../src/iop/colorbalance.c:273
 msgid "split-toning teal-orange (2nd instance)"
-msgstr "色調分離:青橙色(實例 2)"
+msgstr "色調分割：青 - 橘（二）"
 
 #: ../src/iop/colorbalance.c:276
 msgid "split-toning teal-orange (1st instance)"
-msgstr "色調分離:青橙色(實例 1)"
+msgstr "色調分割：青 - 橘（一）"
 
 #: ../src/iop/colorbalance.c:280
 msgid "generic film"
-msgstr "通用軟片捲"
+msgstr "一般底片"
 
 #: ../src/iop/colorbalance.c:284
 msgid "similar to Kodak Portra"
-msgstr "類似柯達 Portra"
+msgstr "模擬 Kodak Portra"
 
 #: ../src/iop/colorbalance.c:288
 msgid "similar to Kodak Ektar"
-msgstr "類似柯達 Ektar"
+msgstr "模擬 Kodak Ektar"
 
 #: ../src/iop/colorbalance.c:292
 msgid "similar to Kodachrome"
-msgstr "類似柯達克羅姆軟片捲"
+msgstr "模擬 Kodachrome"
 
 #: ../src/iop/colorbalance.c:943
 msgid "optimize luma from patches"
-msgstr "從色塊優化亮度"
+msgstr "從選取色塊自動最佳化亮度"
 
 #: ../src/iop/colorbalance.c:945 ../src/iop/colorbalance.c:2058
 msgid "optimize luma"
-msgstr "優化亮度"
+msgstr "自動最佳化亮度"
 
 #: ../src/iop/colorbalance.c:949
 msgid "neutralize colors from patches"
-msgstr "從色塊中和顏色"
+msgstr "從選取色塊自動平衡色彩"
 
 #: ../src/iop/colorbalance.c:951 ../src/iop/colorbalance.c:2064
 msgid "neutralize colors"
-msgstr "中和顏色"
+msgstr "自動平衡色彩"
 
 #: ../src/iop/colorbalance.c:1731
 msgctxt "color"
@@ -13391,7 +13824,7 @@ msgstr "偏移"
 #: ../src/iop/colorbalance.c:1731
 msgctxt "color"
 msgid "power"
-msgstr "乘方"
+msgstr "乘冪"
 
 #: ../src/iop/colorbalance.c:1731
 msgctxt "color"
@@ -13406,7 +13839,7 @@ msgstr "提升"
 #: ../src/iop/colorbalance.c:1732
 msgctxt "color"
 msgid "gamma"
-msgstr "伽馬"
+msgstr "伽瑪"
 
 #: ../src/iop/colorbalance.c:1732
 msgctxt "color"
@@ -13415,27 +13848,42 @@ msgstr "增益"
 
 #: ../src/iop/colorbalance.c:1735
 msgid "shadows: lift / offset"
-msgstr "陰影:提升/偏移"
+msgstr "調整暗部：提升 / 偏移"
 
 #: ../src/iop/colorbalance.c:1736
 msgid "mid-tones: gamma / power"
-msgstr "中間調:伽馬/乘方"
+msgstr "調整中間調：伽瑪 / 乘冪"
 
 #: ../src/iop/colorbalance.c:1737
 msgid "highlights: gain / slope"
-msgstr "高光:增益/斜率"
+msgstr "調整亮部：增益 / 斜率"
 
 #: ../src/iop/colorbalance.c:1761
 msgid "shadows / mid-tones / highlights"
-msgstr "陰影/中間調/高光"
+msgstr "暗部 / 中間調 / 亮部"
 
 #: ../src/iop/colorbalance.c:1858 ../src/iop/colorbalance.c:1867
 msgid "color-grading mapping method"
-msgstr "色彩分級映射法"
+msgstr ""
+"色彩調整的模式，決定使用的色彩空間和 RGB 數值映射公式\n"
+"\n"
+"「提升、伽瑪、增益（sRGB）」\n"
+"舊版 darktable 的模式，在 sRGB 色彩空間中使用 sRGB 曲線計算\n"
+"調整效果類似一般編輯軟體的傳統色彩平衡工具，亮暗部的控制比較不會互相影響\n"
+"\n"
+"「提升、伽瑪、增益（ProPhoto 線性）」\n"
+"使用舊的映射方式，但在線性 ProPhoto 色彩空間中計算\n"
+"RGB 數值先經過 XYZ 的 Y 校正，所以調整色彩時不會影響亮度\n"
+"\n"
+"「斜率、偏移、乘冪（ProPhoto 線性）」\n"
+"使用最新的美國電影攝影師協會建議，適合場景參照的工作流程使用\n"
+"斜率主要控制亮部，偏移主要影響暗部，乘冪主要影響中間調\n"
+"但三個參數都會對整個亮度範圍產生部分影響，建議設定順序為斜率→偏移→乘冪\n"
+"此模式對陰影的調整效果遠大於舊的映射方式，切換模式後應該重新調整參數"
 
 #: ../src/iop/colorbalance.c:1862
 msgid "color control sliders"
-msgstr "顏色控制滑動條"
+msgstr "色彩控制滑桿選項"
 
 #: ../src/iop/colorbalance.c:1863 ../src/libs/colorpicker.c:51
 msgid "HSL"
@@ -13446,417 +13894,493 @@ msgid "RGBL"
 msgstr "RGBL"
 
 #. Page master
-#: ../src/iop/colorbalance.c:1876 ../src/iop/colorbalancergb.c:1896
+#: ../src/iop/colorbalance.c:1876 ../src/iop/colorbalancergb.c:1893
 msgid "master"
-msgstr "主控"
+msgstr "主要選項"
 
 #: ../src/iop/colorbalance.c:1882
 msgid "saturation correction before the color balance"
-msgstr "色彩平衡前的飽和度修正"
+msgstr ""
+"在執行色彩平衡之前的飽和度校正\n"
+"主要用於抑制原始影像的色彩，讓光源複雜難以處理的畫面更好調整"
 
 #: ../src/iop/colorbalance.c:1888
 msgid "saturation correction after the color balance"
-msgstr "色彩平衡後的飽和度修正"
+msgstr ""
+"在色彩平衡運算之後的飽和度校正\n"
+"可一次調整所有色彩平衡效果的飽和度，當色調已經調整正確但效果太重時使用"
 
 #: ../src/iop/colorbalance.c:1893
 msgid "adjust to match a neutral tone"
-msgstr "調整出中性調"
+msgstr ""
+"設定不受下項對比調整影響的亮度，預設符合 18% 中灰階調\n"
+"高於此值的亮度將幾乎線性放大，低於此值的亮度將通過函數壓縮"
 
 #. is set in _configure_slider_blocks
 #: ../src/iop/colorbalance.c:1951
 msgid "click to cycle layout"
-msgstr "單擊以循環佈局"
+msgstr "點擊可循環切換暗部、中間調、亮部滑桿布局"
 
 #: ../src/iop/colorbalance.c:1985
 msgid "factor"
-msgstr "因子"
+msgstr "亮度係數"
 
 #: ../src/iop/colorbalance.c:1999
 msgid "select the hue"
-msgstr "選擇色相"
+msgstr "選擇欲調整的色彩平衡色相"
 
 #: ../src/iop/colorbalance.c:2011
 msgid "select the saturation"
-msgstr "選擇飽和度"
+msgstr "選擇上項色彩平衡色相的飽和度"
 
 #: ../src/iop/colorbalance.c:2030
 msgid "factor of lift/offset"
-msgstr "提升/偏移因子"
+msgstr "暗部（提升 / 偏移）亮度調整係數"
 
 #: ../src/iop/colorbalance.c:2031
 msgid "factor of red for lift/offset"
-msgstr "紅色的提升/偏移因子"
+msgstr "紅色的暗部（提升 / 偏移）調整係數"
 
 #: ../src/iop/colorbalance.c:2032
 msgid "factor of green for lift/offset"
-msgstr "綠色的提升/偏移因子"
+msgstr "綠色的暗部（提升 / 偏移）調整係數"
 
 #: ../src/iop/colorbalance.c:2033
 msgid "factor of blue for lift/offset"
-msgstr "藍色的提升/偏移因子"
+msgstr "藍色的暗部（提升 / 偏移）調整係數"
 
 #: ../src/iop/colorbalance.c:2036
 msgid "factor of gamma/power"
-msgstr "伽馬/乘方的因子"
+msgstr "中間調（伽馬 / 乘冪）亮度調整係數"
 
 #: ../src/iop/colorbalance.c:2037
 msgid "factor of red for gamma/power"
-msgstr "紅色的伽馬/乘方因子"
+msgstr "紅色的中間調（伽馬 / 乘冪）調整係數"
 
 #: ../src/iop/colorbalance.c:2038
 msgid "factor of green for gamma/power"
-msgstr "綠色的伽馬/乘方因子"
+msgstr "綠色的中間調（伽馬 / 乘冪）調整係數"
 
 #: ../src/iop/colorbalance.c:2039
 msgid "factor of blue for gamma/power"
-msgstr "藍色的伽馬/乘方因子"
+msgstr "藍色的中間調（伽馬 / 乘冪）調整係數"
 
 #: ../src/iop/colorbalance.c:2042
 msgid "factor of gain/slope"
-msgstr "增益/斜率的因子"
+msgstr "亮部（增益 / 斜率）亮度調整係數"
 
 #: ../src/iop/colorbalance.c:2043
 msgid "factor of red for gain/slope"
-msgstr "紅色的增益/斜率因子"
+msgstr "紅色的亮部（增益 / 斜率）調整係數"
 
 #: ../src/iop/colorbalance.c:2044
 msgid "factor of green for gain/slope"
-msgstr "綠色的增益/斜率因子"
+msgstr "綠色的亮部（增益 / 斜率）調整係數"
 
 #: ../src/iop/colorbalance.c:2045
 msgid "factor of blue for gain/slope"
-msgstr "藍色的增益/斜率因子"
+msgstr "藍色的亮部（增益 / 斜率）調整係數"
 
 #: ../src/iop/colorbalance.c:2054
 msgid "auto optimizers"
-msgstr "自動優化器"
+msgstr "自動最佳化"
 
 #: ../src/iop/colorbalance.c:2059
 msgid "fit the whole histogram and center the average luma"
-msgstr "符合整個直方圖並將平均亮度居中"
+msgstr "點擊右方色彩選取，分析整個影像並自動調整亮度"
 
 #: ../src/iop/colorbalance.c:2065
 msgid "optimize the RGB curves to remove color casts"
-msgstr "優化RGB曲線以移除色偏"
+msgstr "點擊右方色彩選取，分析整個影像並自動調整色彩平衡"
 
 #: ../src/iop/colorbalancergb.c:173
 msgid "color balance rgb"
-msgstr "rgb 色彩平衡"
+msgstr "色彩平衡 RGB"
 
 #: ../src/iop/colorbalancergb.c:178
 msgid ""
 "offset power slope|cdl|color grading|contrast|chroma_highlights|hue|vibrance|"
 "saturation"
-msgstr "偏移乘方斜率|CDL|顏色分級|對比度|色度_高光|色調|自然飽和度|飽和度"
+msgstr ""
+"提升伽瑪增益|偏移乘冪斜率|色彩分級|調色|對比度|自然飽和度|色相|遮罩|CDL|lift|"
+"gamma|gain|offset|slope|power|masking"
 
 #: ../src/iop/colorbalancergb.c:442
 msgid "add basic colorfulness (legacy)"
-msgstr "增加基本的色彩(傳統)"
+msgstr "增加基礎鮮豔度（舊方法）"
 
 #: ../src/iop/colorbalancergb.c:451
 msgid "basic colorfulness: natural skin"
-msgstr "基本的色彩:自然肌膚"
+msgstr "基礎鮮豔度：自然膚色"
 
 #: ../src/iop/colorbalancergb.c:457
 msgid "basic colorfulness: vibrant colors"
-msgstr "基本的色彩:鮮豔的色彩"
+msgstr "基礎鮮豔度：鮮豔色彩"
 
 #: ../src/iop/colorbalancergb.c:463
 msgid "basic colorfulness: standard"
-msgstr "基本的色彩:標準"
+msgstr "基礎鮮豔度：標準"
 
-#: ../src/iop/colorbalancergb.c:903
+#: ../src/iop/colorbalancergb.c:905
 msgid "colorbalance works only on RGB input"
-msgstr "顏色平衡僅適用於 RGB 輸入"
+msgstr "色彩平衡僅適用於 RGB 輸入"
 
-#: ../src/iop/colorbalancergb.c:1505 ../src/iop/colorzones.c:2203
+#: ../src/iop/colorbalancergb.c:1502 ../src/iop/colorzones.c:2203
 #: ../src/iop/retouch.c:1851 ../src/iop/toneequal.c:1871
 msgid "cannot display masks when the blending mask is displayed"
-msgstr "顯示混合遮罩時不能顯示其他遮罩"
+msgstr "顯示混合遮罩時無法顯示其他遮罩"
 
-#: ../src/iop/colorbalancergb.c:1896
+#: ../src/iop/colorbalancergb.c:1893
 msgid "global grading"
-msgstr "全局調色"
+msgstr "快速調整整體顏色和彩度"
 
-#: ../src/iop/colorbalancergb.c:1900
+#: ../src/iop/colorbalancergb.c:1897
 msgid "rotate all hues by an angle, at the same luminance"
-msgstr "在相同的亮度下，將所有色調旋轉一個角度"
+msgstr "旋轉所有顏色的色相，而不影響亮度和色度"
 
-#: ../src/iop/colorbalancergb.c:1906
+#: ../src/iop/colorbalancergb.c:1903
 msgid "increase colorfulness mostly on low-chroma colors"
-msgstr "增加大多在低色度的色彩度"
+msgstr "主要調整低彩度顏色的鮮豔度，而不過度影響已經很鮮豔的顏色"
 
-#: ../src/iop/colorbalancergb.c:1912
+#: ../src/iop/colorbalancergb.c:1909
 msgid "increase the contrast at constant chromaticity"
-msgstr "在固定色度下增加對比度"
+msgstr ""
+"改變亮度以調整對比，但不影響色相和色度\n"
+"需要更精細地調整對比應該使用「階調等化器」模組"
 
-#: ../src/iop/colorbalancergb.c:1916
+#: ../src/iop/colorbalancergb.c:1913
 msgid "linear chroma grading"
 msgstr "線性色度調整"
 
-#: ../src/iop/colorbalancergb.c:1922
+#: ../src/iop/colorbalancergb.c:1919
 msgid "increase colorfulness at same luminance globally"
-msgstr "在相同的亮度下，增加全局的色彩度"
+msgstr ""
+"調整整體的色度而不影響色相和亮度\n"
+"類似於操作 CIE LCh 中的 C - chroma，但在更先進且符合感知的空間中執行"
 
-#: ../src/iop/colorbalancergb.c:1927
+#: ../src/iop/colorbalancergb.c:1924
 msgid "increase colorfulness at same luminance mostly in shadows"
-msgstr "在相同的亮度下，增加大多在陰影區域的色彩度"
+msgstr ""
+"調整暗部的色度而不影響色相和亮度，暗部的範圍可在「亮度遮罩」選項中調整\n"
+"類似於操作 CIE LCh 中的 C - chroma，但在更先進且符合感知的空間中執行"
 
-#: ../src/iop/colorbalancergb.c:1932
+#: ../src/iop/colorbalancergb.c:1929
 msgid "increase colorfulness at same luminance mostly in mid-tones"
-msgstr "在相同的亮度下，增加大多在中間調的色彩度"
+msgstr ""
+"調整中間調的色度而不影響色相和亮度，中間調的範圍可在「亮度遮罩」選項中調整\n"
+"類似於操作 CIE LCh 中的 C - chroma，但在更先進且符合感知的空間中執行"
 
-#: ../src/iop/colorbalancergb.c:1937
+#: ../src/iop/colorbalancergb.c:1934
 msgid "increase colorfulness at same luminance mostly in highlights"
-msgstr "在相同的亮度下，增加大多在高光的色彩度"
+msgstr ""
+"調整亮部的色度而不影響色相和亮度，亮部的範圍可在「亮度遮罩」選項中調整\n"
+"類似於操作 CIE LCh 中的 C - chroma，但在更先進且符合感知的空間中執行"
 
-#: ../src/iop/colorbalancergb.c:1939
+#: ../src/iop/colorbalancergb.c:1936
 msgid "perceptual saturation grading"
-msgstr "感知飽和度分級"
+msgstr "感知飽和度調整"
 
-#: ../src/iop/colorbalancergb.c:1944
+#: ../src/iop/colorbalancergb.c:1941
 msgid "add or remove saturation by an absolute amount"
-msgstr "以絕對數量增加或減少飽和度"
+msgstr ""
+"調整整體的色彩飽和度\n"
+"變更飽和度會稍微影響明度，完整說明請查詢基礎色彩學書籍"
 
-#: ../src/iop/colorbalancergb.c:1949 ../src/iop/colorbalancergb.c:1954
-#: ../src/iop/colorbalancergb.c:1959
+#: ../src/iop/colorbalancergb.c:1946 ../src/iop/colorbalancergb.c:1951
+#: ../src/iop/colorbalancergb.c:1956
 msgid ""
 "increase or decrease saturation proportionally to the original pixel "
 "saturation"
-msgstr "根據原始像素的飽和度按比例增加或減少飽和度"
+msgstr ""
+"調整不同階調範圍的色彩飽和度，範圍可在「亮度遮罩」選項中調整\n"
+"變更飽和度會稍微影響明度，完整說明請查詢基礎色彩學書籍"
 
-#: ../src/iop/colorbalancergb.c:1961
+#: ../src/iop/colorbalancergb.c:1958
 msgid "perceptual brilliance grading"
-msgstr "感知亮度分級"
+msgstr "感知明亮度調整"
 
-#: ../src/iop/colorbalancergb.c:1966
+#: ../src/iop/colorbalancergb.c:1963
 msgid "add or remove brilliance by an absolute amount"
-msgstr "以絕對數量增加或減少亮度"
+msgstr ""
+"調整整體的色彩明亮度，其效果接近於符合感知的曝光調整\n"
+"變更明亮度會影響色度和明度，完整說明請查詢基礎色彩學書籍"
 
-#: ../src/iop/colorbalancergb.c:1971 ../src/iop/colorbalancergb.c:1976
-#: ../src/iop/colorbalancergb.c:1981
+#: ../src/iop/colorbalancergb.c:1968 ../src/iop/colorbalancergb.c:1973
+#: ../src/iop/colorbalancergb.c:1978
 msgid ""
 "increase or decrease brilliance proportionally to the original pixel "
 "brilliance"
-msgstr "根據原始像素的亮度按比例增加或減少亮度"
+msgstr ""
+"調整不同階調範圍的色彩明亮度，範圍可在「亮度遮罩」選項中調整\n"
+"變更明亮度會影響色度和明度，完整說明請查詢基礎色彩學書籍"
 
 #. Page 4-ways
-#: ../src/iop/colorbalancergb.c:1984
+#: ../src/iop/colorbalancergb.c:1981
 msgid "4 ways"
-msgstr "4 個方向"
+msgstr "四向調整"
 
-#: ../src/iop/colorbalancergb.c:1984
+#: ../src/iop/colorbalancergb.c:1981
 msgid "selective color grading"
-msgstr "選擇性色彩分級"
+msgstr "依亮部、暗部、中間調等區域分別調整色彩平衡"
 
-#: ../src/iop/colorbalancergb.c:1986
+#: ../src/iop/colorbalancergb.c:1983
 msgid "global offset"
-msgstr "全局偏移"
+msgstr "整體（偏移）"
 
-#: ../src/iop/colorbalancergb.c:1992
+#: ../src/iop/colorbalancergb.c:1989
 msgid "global luminance offset"
-msgstr "全局亮度偏移"
+msgstr ""
+"整體亮度調整\n"
+"調整方式相當於 ASC CDL 的偏移，此區塊不使用亮度遮罩"
 
-#: ../src/iop/colorbalancergb.c:1997
+#: ../src/iop/colorbalancergb.c:1994
 msgid "hue of the global color offset"
-msgstr "全局顏色偏移的色調"
+msgstr ""
+"整體色彩平衡調整的色相\n"
+"調整方式相當於 ASC CDL 的偏移，此區塊不使用亮度遮罩"
 
-#: ../src/iop/colorbalancergb.c:2003
+#: ../src/iop/colorbalancergb.c:2000
 msgid "chroma of the global color offset"
-msgstr "全局顏色偏移的色度"
+msgstr "選擇上項色彩平衡色相的色度"
 
-#: ../src/iop/colorbalancergb.c:2005
+#: ../src/iop/colorbalancergb.c:2002
 msgid "shadows lift"
-msgstr "陰影提升"
+msgstr "暗部（提升）"
 
-#: ../src/iop/colorbalancergb.c:2011
+#: ../src/iop/colorbalancergb.c:2008
 msgid "luminance gain in shadows"
-msgstr "陰影區域的亮度增益"
+msgstr ""
+"變更暗部的亮度\n"
+"調整方式類似傳統的電影調色 lift 選項，但在此使用亮度遮罩控制"
 
-#: ../src/iop/colorbalancergb.c:2016
+#: ../src/iop/colorbalancergb.c:2013
 msgid "hue of the color gain in shadows"
-msgstr "陰影區域中顏色增益的色調"
+msgstr ""
+"暗部色彩平衡調整的色相\n"
+"調整方式類似傳統的電影調色 lift 選項，但在此使用亮度遮罩控制"
 
-#: ../src/iop/colorbalancergb.c:2022
+#: ../src/iop/colorbalancergb.c:2019
 msgid "chroma of the color gain in shadows"
-msgstr "陰影區域中顏色增益的色度"
+msgstr "選擇上項色彩平衡色相的色度"
 
-#: ../src/iop/colorbalancergb.c:2024
+#: ../src/iop/colorbalancergb.c:2021
 msgid "highlights gain"
-msgstr "高光增益"
+msgstr "亮部（增益）"
 
-#: ../src/iop/colorbalancergb.c:2030
+#: ../src/iop/colorbalancergb.c:2027
 msgid "luminance gain in highlights"
-msgstr "高光區域的亮度增益"
+msgstr ""
+"變更亮部的亮度\n"
+"調整方式類似 ASC CDL 的斜率，但在此使用亮度遮罩控制"
 
-#: ../src/iop/colorbalancergb.c:2035
+#: ../src/iop/colorbalancergb.c:2032
 msgid "hue of the color gain in highlights"
-msgstr "高光區域中顏色增益的色調"
+msgstr ""
+"亮部色彩平衡調整的色相\n"
+"調整方式類似 ASC CDL 的斜率，但在此使用亮度遮罩控制"
 
-#: ../src/iop/colorbalancergb.c:2041
+#: ../src/iop/colorbalancergb.c:2038
 msgid "chroma of the color gain in highlights"
-msgstr "高光區域中顏色增益的色度"
+msgstr "選擇上項色彩平衡色相的色度"
 
-#: ../src/iop/colorbalancergb.c:2043 ../src/iop/colorbalancergb.c:2146
-#: ../src/iop/colorbalancergb.c:2150 ../src/iop/colorbalancergb.c:2154
+#: ../src/iop/colorbalancergb.c:2040 ../src/iop/colorbalancergb.c:2143
+#: ../src/iop/colorbalancergb.c:2147 ../src/iop/colorbalancergb.c:2151
 msgid "power"
-msgstr "乘方"
+msgstr "中間調（乘冪）"
 
-#: ../src/iop/colorbalancergb.c:2049
+#: ../src/iop/colorbalancergb.c:2046
 msgid "luminance exponent in mid-tones"
-msgstr "中間調的亮度指數"
+msgstr ""
+"變更中間調的亮度\n"
+"調整方式類似 ASC CDL 的乘冪，但在此使用亮度遮罩控制"
 
-#: ../src/iop/colorbalancergb.c:2054
+#: ../src/iop/colorbalancergb.c:2051
 msgid "hue of the color exponent in mid-tones"
-msgstr "中間調的色相指數"
+msgstr ""
+"中間調色彩平衡調整的色相\n"
+"調整方式類似 ASC CDL 的乘冪，但在此使用亮度遮罩控制"
 
-#: ../src/iop/colorbalancergb.c:2060
+#: ../src/iop/colorbalancergb.c:2057
 msgid "chroma of the color exponent in mid-tones"
-msgstr "中間調的色度指數"
+msgstr "選擇上項色彩平衡色相的色度"
 
 #. Page masks
-#: ../src/iop/colorbalancergb.c:2065
+#: ../src/iop/colorbalancergb.c:2062
 msgid "masks"
-msgstr "遮罩"
+msgstr "亮度遮罩"
 
-#: ../src/iop/colorbalancergb.c:2065
+#: ../src/iop/colorbalancergb.c:2062
 msgid "isolate luminances"
-msgstr "分離亮度"
+msgstr "以遮罩方式調整區隔亮暗部和中間調的範圍"
 
-#: ../src/iop/colorbalancergb.c:2069
+#: ../src/iop/colorbalancergb.c:2066
 msgid "choose in which uniform color space the saturation is computed"
-msgstr "選擇飽和度計算的均匀色彩空間"
+msgstr ""
+"選擇使用哪一個色彩空間執行飽和度計算\n"
+"\n"
+"JzAzBz（2021）\n"
+"舊版的飽和度計算方法，使用 JzAzBz 色彩空間\n"
+"這是基於羅明教授於中國浙江大學現代光學儀器國家重點實驗室提出的論文\n"
+"使用類似 CIELAB 的 Jz az bz 座標，目的是開發適用高動態範圍的色彩均勻空間\n"
+"\n"
+"darktable UCS（2022）\n"
+"darktable 開發者之一 Aurélien Pierre 設計的色彩空間\n"
+"主要差異是考量 Helmholtz-Kohlrausch 效應，能更準確預測感知飽和度\n"
+"\n"
+"此選項和遮罩控制無關，放在這是因為模組作者想節省介面空間"
 
-#: ../src/iop/colorbalancergb.c:2071
+#: ../src/iop/colorbalancergb.c:2068
 msgid "luminance ranges"
 msgstr "亮度範圍"
 
-#: ../src/iop/colorbalancergb.c:2085
+#: ../src/iop/colorbalancergb.c:2082
 msgid "weight of the shadows over the whole tonal range"
-msgstr "整個色調範圍內的陰影權重"
+msgstr ""
+"控制暗部範圍遮罩過渡的曲線斜率\n"
+"數值越大過渡越劇烈，暗部的範圍就結束得越快\n"
+"數值越小過渡越平緩，暗部的範圍就拓展得越遠\n"
+"點擊右側遮罩按鈕可顯示暗部區域，非暗部區域以方格顯示"
 
-#: ../src/iop/colorbalancergb.c:2093
+#: ../src/iop/colorbalancergb.c:2090
 msgid "position of the middle-gray reference for masking"
-msgstr "用於遮罩的中間灰參考位置"
+msgstr ""
+"亮度置中的中灰色位置，此亮度值下亮部、暗部和中間調的遮罩透明度都是 50%\n"
+"在實際使用中，高於此值的被認定為亮部，低於此值的則為暗部\n"
+"點擊右側遮罩按鈕可顯示中間調區域，非中間調區域以方格顯示"
 
-#: ../src/iop/colorbalancergb.c:2101
+#: ../src/iop/colorbalancergb.c:2098
 msgid "weights of highlights over the whole tonal range"
-msgstr "整個色調範圍內的高光權重"
+msgstr ""
+"控制亮部範圍遮罩過渡的曲線斜率\n"
+"數值越大過渡越劇烈，亮部的範圍就結束得越快\n"
+"數值越小過渡越平緩，亮部的範圍就拓展得越遠\n"
+"點擊右側遮罩按鈕可顯示亮部區域，非亮部區域以方格顯示"
 
-#: ../src/iop/colorbalancergb.c:2111
+#: ../src/iop/colorbalancergb.c:2108
 msgid "peak white luminance value used to normalize the power function"
-msgstr "用於正規化冪函數的白色亮度尖峯值"
+msgstr ""
+"設置白點亮度，以標準化四向調整中的乘冪函數\n"
+"使用右側色彩選取工具自動設置為框選範圍最大亮度，大多數情況下這樣就可以了"
 
-#: ../src/iop/colorbalancergb.c:2117
+#: ../src/iop/colorbalancergb.c:2114
 msgid "peak gray luminance value used to normalize the power function"
-msgstr "用於正規化冪函數的灰色亮度尖峯值"
+msgstr ""
+"設置對比中灰點，以標準化主要選項中的對比\n"
+"這代表對比度的中間點，調高對比度時高於此值亮度增加，低於此值亮度降低\n"
+"數值通常與 18~20% 中灰相同，但也可以手動設定\n"
+"右側色彩選取工具可自動設定為框選範圍的平均亮度，適合亮度分布均勻的影像"
 
-#: ../src/iop/colorbalancergb.c:2119
+#: ../src/iop/colorbalancergb.c:2116
 msgid "mask preview settings"
 msgstr "遮罩預覽設定"
 
-#: ../src/iop/colorbalancergb.c:2122
+#: ../src/iop/colorbalancergb.c:2119
 msgid "checkerboard color 1"
-msgstr "棋盤格顏色 1"
+msgstr "方格顏色一"
 
-#: ../src/iop/colorbalancergb.c:2125 ../src/iop/colorbalancergb.c:2134
+#: ../src/iop/colorbalancergb.c:2122 ../src/iop/colorbalancergb.c:2131
 msgid "select color of the checkerboard from a swatch"
-msgstr "從色表中選擇棋盤格顏色"
+msgstr "從色板中選擇方格的顏色"
 
-#: ../src/iop/colorbalancergb.c:2131
+#: ../src/iop/colorbalancergb.c:2128
 msgid "checkerboard color 2"
-msgstr "棋盤格顏色 2"
+msgstr "方格顏色二"
 
-#: ../src/iop/colorbalancergb.c:2141
+#: ../src/iop/colorbalancergb.c:2138
 msgid "checkerboard size"
-msgstr "棋盤格大小"
+msgstr "方格尺寸"
 
-#: ../src/iop/colorbalancergb.c:2145 ../src/iop/colorbalancergb.c:2149
-#: ../src/iop/colorbalancergb.c:2153
+#: ../src/iop/colorbalancergb.c:2142 ../src/iop/colorbalancergb.c:2146
+#: ../src/iop/colorbalancergb.c:2150
 msgid "lift"
 msgstr "提升"
 
-#: ../src/iop/colorbalancergb.c:2147 ../src/iop/colorbalancergb.c:2151
-#: ../src/iop/colorbalancergb.c:2155
+#: ../src/iop/colorbalancergb.c:2144 ../src/iop/colorbalancergb.c:2148
+#: ../src/iop/colorbalancergb.c:2152
 msgid "gain"
 msgstr "增益"
 
-#: ../src/iop/colorbalancergb.c:2158
+#: ../src/iop/colorbalancergb.c:2155
 msgid "global chroma"
-msgstr "全局色度"
+msgstr "整體色度"
 
-#: ../src/iop/colorbalancergb.c:2162 ../src/iop/filmic.c:1677
+#: ../src/iop/colorbalancergb.c:2159 ../src/iop/filmic.c:1677
 msgid "global saturation"
-msgstr "全局飽和度"
+msgstr "整體飽和度"
 
-#: ../src/iop/colorbalancergb.c:2166
+#: ../src/iop/colorbalancergb.c:2163
 msgid "global brilliance"
-msgstr "全局鮮豔度"
+msgstr "整體明亮度"
 
-#: ../src/iop/colorbalancergb.c:2167 ../src/iop/colorbalancergb.c:2168
-#: ../src/iop/colorbalancergb.c:2169
+#: ../src/iop/colorbalancergb.c:2164 ../src/iop/colorbalancergb.c:2165
+#: ../src/iop/colorbalancergb.c:2166
 msgid "brilliance"
-msgstr "鮮豔度"
+msgstr "明亮度"
 
 #: ../src/iop/colorchecker.c:115
 msgid "color look up table"
-msgstr "顏色查找表"
+msgstr "色彩查找表"
 
 #: ../src/iop/colorchecker.c:120
 msgid "profile|lut|color grading"
-msgstr "色彩配置|lut|色彩分級"
+msgstr "調色|LUT|色彩調整|色卡|colorchcker"
 
 #: ../src/iop/colorchecker.c:125
 msgid "perform color space corrections and apply looks"
-msgstr "執行顏色空間修正並套用外觀"
+msgstr ""
+"色彩查找表 | color look up table\n"
+"\n"
+"使用色卡創建色彩查找表並套用外觀\n"
+"要套用現有的色彩查找表請使用「立體色彩查找表」模組\n"
+"要使用色卡效正色偏請使用「色彩校正」模組"
 
 #: ../src/iop/colorchecker.c:127 ../src/iop/colorchecker.c:129
 #: ../src/iop/colorize.c:106 ../src/iop/colormapping.c:154
 #: ../src/iop/colorout.c:93 ../src/iop/colorreconstruction.c:136
-#: ../src/iop/colorzones.c:146 ../src/iop/defringe.c:82 ../src/iop/levels.c:132
+#: ../src/iop/colorzones.c:146 ../src/iop/defringe.c:82 ../src/iop/levels.c:131
 #: ../src/iop/monochrome.c:99 ../src/iop/shadhi.c:198
-#: ../src/iop/tonecurve.c:214 ../src/iop/vibrance.c:96
+#: ../src/iop/tonecurve.c:213 ../src/iop/vibrance.c:96
 msgid "linear or non-linear, Lab, display-referred"
-msgstr "線性或非線性、Lab、顯示工作流程"
+msgstr "線性或非線性、Lab、顯示參照"
 
 #: ../src/iop/colorchecker.c:128
 msgid "defined by profile, Lab"
-msgstr "定義Lab配置檔案"
+msgstr "由描述檔定義、Lab"
 
 #: ../src/iop/colorchecker.c:286
 msgid "it8 skin tones"
-msgstr "it8 膚色調"
+msgstr "IT8 色卡膚色調"
 
 #: ../src/iop/colorchecker.c:300
 msgid "helmholtz/kohlrausch monochrome"
-msgstr "海爾默茲-科耳洛希單色照片"
+msgstr "helmholtz / kohlrausch 黑白"
 
 #: ../src/iop/colorchecker.c:316
 msgid "Fuji Astia emulation"
-msgstr "模擬富士 Astia軟片"
+msgstr "模擬 Fujifilm Astia"
 
 #: ../src/iop/colorchecker.c:329
 msgid "Fuji Classic Chrome emulation"
-msgstr "模擬:富士經典正片軟片"
+msgstr "模擬 Fujifilm Classic Chrome"
 
 #: ../src/iop/colorchecker.c:342
 msgid "Fuji Monochrome emulation"
-msgstr "模擬:富士黑白軟片"
+msgstr "模擬 Fujifilm Monochrome"
 
 #: ../src/iop/colorchecker.c:355
 msgid "Fuji Provia emulation"
-msgstr "模擬:富士 Provia軟片"
+msgstr "模擬 Fujifilm Provia"
 
 #: ../src/iop/colorchecker.c:368
 msgid "Fuji Velvia emulation"
-msgstr "模擬:富士 Velvia軟片"
+msgstr "模擬 Fujifilm Velvia"
 
-#: ../src/iop/colorchecker.c:844 ../src/iop/colorchecker.c:1350
+#: ../src/iop/colorchecker.c:844 ../src/iop/colorchecker.c:1353
 #, c-format
 msgid "patch #%d"
-msgstr "色塊 #%d"
+msgstr "第 %d 個色塊"
 
-#: ../src/iop/colorchecker.c:1208
+#: ../src/iop/colorchecker.c:1211
 #, c-format
 msgid ""
 "(%2.2f %2.2f %2.2f)\n"
@@ -13866,115 +14390,126 @@ msgid ""
 "right click to delete patch\n"
 "shift+click while color picking to replace patch"
 msgstr ""
-"(%2.2f %2.2f %2.2f)\n"
-"改變的色塊會用輪廓標出。\n"
-"單擊以選取，雙擊以重置，右擊以刪除\n"
-"shift + 單擊，將色塊顏色替換為選取顏色"
+"L*: %2.2f  a*: %2.2f  b*: %2.2f\n"
+"\n"
+"點擊選擇色塊\n"
+"雙擊重設色塊\n"
+"右鍵刪除色塊\n"
+"右下方色彩選取工具啟用時，shift + 點擊以影像中的顏色替換色塊"
 
-#: ../src/iop/colorchecker.c:1345
+#: ../src/iop/colorchecker.c:1348
 msgid "patch"
 msgstr "色塊"
 
-#: ../src/iop/colorchecker.c:1346
+#: ../src/iop/colorchecker.c:1349
 msgid "color checker patch"
-msgstr "色卡塊"
+msgstr "ColorChecker 色塊"
 
-#: ../src/iop/colorchecker.c:1357
+#: ../src/iop/colorchecker.c:1360
 msgid ""
 "adjust target color Lab 'L' channel\n"
 "lower values darken target color while higher brighten it"
 msgstr ""
-"調節 Lab 空間目標顏色的 L 通道\n"
-"低值將使顏色變暗，高值將使顏色變亮"
+"調整目標顏色在 CIELAB 中的 L* 色版數值\n"
+"較低的值會讓顏色變暗，較高的值則把顏色變亮"
 
-#: ../src/iop/colorchecker.c:1361
+#: ../src/iop/colorchecker.c:1364
 msgid ""
 "adjust target color Lab 'a' channel\n"
 "lower values shift target color towards greens while higher shift towards "
 "magentas"
 msgstr ""
-"調節 Lab 空間目標顏色的 a 通道\n"
-"低值將使顏色偏綠，高值將使顏色偏洋紅"
+"調整目標顏色在 CIELAB 中的 a* 色版數值\n"
+"較低的值會讓顏色偏向綠色，較高的值則讓顏色偏紅"
 
-#: ../src/iop/colorchecker.c:1362
+#: ../src/iop/colorchecker.c:1365
 msgid "green-magenta offset"
-msgstr "綠色-洋紅對比"
+msgstr "綠色 - 紅色偏移"
 
-#: ../src/iop/colorchecker.c:1368
+#: ../src/iop/colorchecker.c:1371
 msgid ""
 "adjust target color Lab 'b' channel\n"
 "lower values shift target color towards blues while higher shift towards "
 "yellows"
 msgstr ""
-"調節 Lab 空間下目標顏色的 b 通道\n"
-"低值將使顏色偏藍，高值將使顏色偏黃"
+"調整目標顏色在 CIELAB 中的 b* 色版數值\n"
+"較低的值會讓顏色偏向藍色，較高的值則讓顏色偏黃"
 
-#: ../src/iop/colorchecker.c:1369
+#: ../src/iop/colorchecker.c:1372
 msgid "blue-yellow offset"
-msgstr "藍色-黃色對比"
+msgstr "藍色 - 黃色偏移"
 
-#: ../src/iop/colorchecker.c:1375
+#: ../src/iop/colorchecker.c:1378
 msgid ""
 "adjust target color saturation\n"
 "adjusts 'a' and 'b' channels of target color in Lab space simultaneously\n"
 "lower values scale towards lower saturation while higher scale towards "
 "higher saturation"
 msgstr ""
-"調節目標顏色飽和度\n"
-"同時調節 Lab 空間目標顏色的 a 和 b 通道\n"
-"低值將減少飽和度，高值將增加飽和度"
+"調整目標顏色在 CIELCh 中的色度，同步影響 a*、b* 色版\n"
+"較低的值降低色度，而較高的值讓色度變高"
 
-#: ../src/iop/colorchecker.c:1380
+#: ../src/iop/colorchecker.c:1383
 msgid "target color"
 msgstr "目標顏色"
 
-#: ../src/iop/colorchecker.c:1381
+#: ../src/iop/colorchecker.c:1384
 msgid ""
 "control target color of the patches\n"
 "relative - target color is relative from the patch original color\n"
 "absolute - target color is absolute Lab value"
 msgstr ""
-"控制色塊的目標顏色\n"
-"相對 - 目標顏色為色塊原始顏色的相對值\n"
-"絕對 - 目標顏色為絕對 Lab 值"
+"控制色塊調整的顯示方式\n"
+"相對：目標顏色相對於原始色塊顏色的調整數值\n"
+"絕對：目標顏色的絕對 L*a*b* 值"
 
-#: ../src/iop/colorchecker.c:1383
+#: ../src/iop/colorchecker.c:1386
 msgid "absolute"
-msgstr "絕對的"
+msgstr "絕對"
 
 #: ../src/iop/colorcontrast.c:89
 msgid "color contrast"
-msgstr "色彩對比度"
+msgstr "色彩對比"
 
 #: ../src/iop/colorcontrast.c:99
 msgid ""
 "increase saturation and separation between\n"
 "opposite colors"
-msgstr "增加對比色之間的飽和度和分離度"
+msgstr ""
+"色彩對比 | color contrast\n"
+"\n"
+"快速調整對比色的飽和度與分離度的簡易模組\n"
+"實際上是操作 CIELAB 空間 a* 與 b* 色版的對比\n"
+"更精細的控制建議使用「階調曲線」模組中的 L*a*b* 獨立調整功能"
 
 #: ../src/iop/colorcontrast.c:351
 msgid ""
 "steepness of the a* curve in Lab\n"
 "lower values desaturate greens and magenta while higher saturate them"
 msgstr ""
-"lab 中 a* 曲線的陡度。\n"
-"值越低，綠色和洋紅就越不飽和;值越高，綠色和洋紅就越飽和"
+"調整 CIELAB 空間裡 a* 色版的斜率\n"
+"影響綠色至洋紅色的彩度，數值越低彩度越低，數值越高彩度越高"
 
 #: ../src/iop/colorcontrast.c:354
 msgid ""
 "steepness of the b* curve in Lab\n"
 "lower values desaturate blues and yellows while higher saturate them"
 msgstr ""
-"lab 中 b* 曲線的陡度。\n"
-"值越低，藍色和黃色就越不飽和;值越高，藍色和黃色就越飽和"
+"調整 CIELAB 空間裡 b* 色版的斜率\n"
+"影響藍色至黃色的彩度，數值越低彩度越低，數值越高彩度越高"
 
 #: ../src/iop/colorcorrection.c:71
 msgid "color correction"
-msgstr "色彩矯正"
+msgstr "色調修改"
 
 #: ../src/iop/colorcorrection.c:76
 msgid "correct white balance selectively for blacks and whites"
-msgstr "選擇性的修正黑與白的白平衡"
+msgstr ""
+"色調修改 | color correction\n"
+"\n"
+"針對黑白點分別調整色調\n"
+"修改整體色度和色調分割的替代模組\n"
+"使用「色調分割」模組執行更完整的控制"
 
 #: ../src/iop/colorcorrection.c:107
 msgid "warm tone"
@@ -13993,195 +14528,225 @@ msgid ""
 "drag the line for split-toning. bright means highlights, dark means shadows. "
 "use mouse wheel to change saturation."
 msgstr ""
-"拖拉線條進行色調分離。\n"
-"白點指高光區域，黑點指陰影區域。\n"
-"使用滑鼠滾輪更改飽和度。"
+"拖曳黑白點控制色調，白點代表亮部，黑點代表暗部\n"
+"使用滑鼠滾輪更改飽和度"
 
 #: ../src/iop/colorcorrection.c:284
 msgid "set the global saturation"
-msgstr "設定全域飽和度"
+msgstr "設定整體飽和度"
 
 #: ../src/iop/colorin.c:129
 msgid "input color profile"
-msgstr "輸入色彩配置檔案"
+msgstr "輸入色彩描述檔"
 
 #: ../src/iop/colorin.c:134
 msgid ""
 "convert any RGB input to pipeline reference RGB\n"
 "using color profiles to remap RGB values"
 msgstr ""
-"將任何 RGB 輸入轉換爲管線參考 RGB 色域，\n"
-"使用色彩配置檔案重新映射 RGB 值"
+"輸入色彩描述檔 | input color profile\n"
+"\n"
+"輸入色彩空間與工作色彩空間設定\n"
+"使用所選的色彩描述檔重新映射影像 RGB 數值\n"
+"預設 RAW 檔會套用相機特性，點陣圖檔使用影像內嵌的 ICC\n"
+"然後將其轉入工作色彩空間，以 32 位元單精度浮點數進行內部運算"
 
 #: ../src/iop/colorin.c:136 ../src/iop/colorout.c:92 ../src/iop/demosaic.c:227
 #: ../src/iop/rawprepare.c:153
 msgid "mandatory"
-msgstr "必要的"
+msgstr "必要"
 
 #: ../src/iop/colorin.c:138 ../src/iop/colorout.c:94
 msgid "defined by profile"
-msgstr "由配置檔案定義"
+msgstr "由描述檔定義"
 
 #: ../src/iop/colorin.c:530
 #, c-format
 msgid ""
 "can't extract matrix from colorspace `%s', it will be replaced by Rec2020 "
 "RGB!"
-msgstr "無法從色彩空間“%s”提取色彩矩陣，將使用 Rec2020 RGB 替換！"
+msgstr "無法讀入色彩空間「%s」內的矩陣資料，將以 Rec. 2020 取代"
 
 #: ../src/iop/colorin.c:1543
 #, c-format
 msgid "`%s' color matrix not found!"
-msgstr "未找到“%s”色彩矩陣！"
+msgstr "找不到「%s」色彩空間"
 
 #: ../src/iop/colorin.c:1578
 msgid "input profile could not be generated!"
-msgstr "無法產生輸入的色彩配置！"
+msgstr "無法生成輸入描述檔"
 
 #: ../src/iop/colorin.c:1661
 msgid "unsupported input profile has been replaced by linear Rec709 RGB!"
-msgstr "不支援的輸入色彩配置已被線性 Rec709 RGB 取代！"
+msgstr "不支援的輸入描述檔，已使用現性 Rec. 709 取代"
 
 #: ../src/iop/colorin.c:2047
 msgid "input profile"
-msgstr "輸入配置檔案"
+msgstr "影像輸入描述檔"
 
 #: ../src/iop/colorin.c:2051
 msgid "working profile"
-msgstr "工作中的配置檔案"
+msgstr "工作空間描述檔"
 
 #: ../src/iop/colorin.c:2058 ../src/iop/colorin.c:2069
 #: ../src/iop/colorout.c:890
 #, c-format
 msgid "ICC profiles in %s or %s"
-msgstr "ICC 檔案在 %s 或 %s"
+msgstr ""
+"選擇描述檔，可在以下兩個資料夾新增更多描述檔：\n"
+"%s\n"
+"%s"
 
 #: ../src/iop/colorin.c:2080
 msgid "confine Lab values to gamut of RGB color space"
-msgstr "將 Lab 值限制爲 RGB 顏色空間的色域"
+msgstr ""
+"將顏色限制在所選色彩空間描述檔的色域中\n"
+"大多數情況下不需要啟用此功能，以保留無邊際編輯的優點\n"
+"只在影像出現不正常的色彩映射或偽色時才考慮開啟此功能\n"
+"例如高飽和的舞台雷射光源，尤其是藍色雷射光束特別容易引發此問題"
 
 #: ../src/iop/colorize.c:84
 msgid "colorize"
-msgstr "彩色化"
+msgstr "上色"
 
 #: ../src/iop/colorize.c:104
 msgid "overlay a solid color on the image"
-msgstr "在影像上覆蓋純色"
+msgstr ""
+"上色 | colorize\n"
+"\n"
+"在影像上覆蓋一層純色\n"
+"可配合遮罩與混合模式打造創意效果"
 
 #: ../src/iop/colorize.c:355 ../src/iop/splittoning.c:480
 msgid "select the hue tone"
-msgstr "選擇色相調"
+msgstr "設定覆蓋純色的色相"
 
 #: ../src/iop/colorize.c:361
 msgid "select the saturation shadow tone"
-msgstr "選擇陰影色調的飽和度"
+msgstr "設定覆蓋純色的飽和度"
 
 #: ../src/iop/colorize.c:365
 msgid "lightness of color"
-msgstr "色彩亮度"
+msgstr "設定覆蓋純色的明度"
 
 #: ../src/iop/colorize.c:369
 msgid "mix value of source lightness"
-msgstr "源亮度的混合值"
+msgstr ""
+"控制原始影像的明度如何與純色混合\n"
+"0% 代表不使用原始影像明度，結果為單一純色"
 
 #: ../src/iop/colormapping.c:147
 msgid "color mapping"
-msgstr "顏色映射"
+msgstr "色彩映射"
 
 #: ../src/iop/colormapping.c:152
 msgid ""
 "transfer a color palette and tonal repartition from one image to another"
-msgstr "將色版和色調重新劃分從一個影像轉移到另一個影像"
+msgstr ""
+"色彩映射 | color mapping\n"
+"\n"
+"把來源影像的顏色特徵映射到目標影像上以創造相似的外觀\n"
+"先開啟要複製色彩的影像，然後點選「分析來源影像」\n"
+"接著開啟要套用的影像，然後點選「套用目的影像」\n"
+"可使用下方滑桿調整效果，或使用透明度與混合模式來更改"
 
 #: ../src/iop/colormapping.c:1041
 msgid "source clusters:"
-msgstr "來源分群:"
+msgstr "來源影像色板："
 
 #: ../src/iop/colormapping.c:1047
 msgid "target clusters:"
-msgstr "目標分群:"
+msgstr "目標影像色板："
 
 #: ../src/iop/colormapping.c:1056
 msgid "acquire as source"
-msgstr "做爲來源"
+msgstr "分析來源影像"
 
 #: ../src/iop/colormapping.c:1060
 msgid "analyze this image as a source image"
-msgstr "分析此影像做爲來源影像"
+msgstr "使用目前影像作為來源，分析影像的色彩與亮度分布製作色板"
 
 #: ../src/iop/colormapping.c:1062
 msgid "acquire as target"
-msgstr "做爲目標"
+msgstr "套用目的影像"
 
 #: ../src/iop/colormapping.c:1066
 msgid "analyze this image as a target image"
-msgstr "分析此影像做爲目標影像"
+msgstr "將目前影像當作調整目標，分析影像製作色板後套用來源色彩"
 
 #: ../src/iop/colormapping.c:1069
 msgid "number of clusters to find in image. value change resets all clusters"
-msgstr "影像中發現的分組數量:更改值將使所有分組重置"
+msgstr ""
+"依據影像分析製作的色板數量，設定值應該與影像中的主要色彩數量相符\n"
+"色板是由隨機採樣統計產生的，代表影像中最常出現的顏色，更改設定會重設色板"
 
 #: ../src/iop/colormapping.c:1072
 msgid ""
 "how clusters are mapped. low values: based on color proximity, high values: "
 "based on color dominance"
 msgstr ""
-"分群映射方式。低階值:基於顏色近似(color proximity)，高階值:基於顏色支配"
-"(color dominance)"
+"調整色彩映射的方式與強度\n"
+"越低的值映射趨向改變接近的顏色，效果越不明顯\n"
+"越高的值映射基於色板所佔的權重， 效果更為強烈"
 
 #: ../src/iop/colormapping.c:1077
 msgid "level of histogram equalization"
-msgstr "直方圖量化級別"
+msgstr ""
+"依據來源影像的亮度分配重新調整目標影像的亮度\n"
+"越大的值符合程度越高，設為 0% 保留目標影像亮度不調整"
 
 #: ../src/iop/colorout.c:84
 msgid "output color profile"
-msgstr "輸出色彩檔案"
+msgstr "輸出色彩描述檔"
 
 #: ../src/iop/colorout.c:90
 msgid ""
 "convert pipeline reference RGB to any display RGB\n"
 "using color profiles to remap RGB values"
 msgstr ""
-"將管線參考 RGB 轉換至任意顯示用 RGB 色域，\n"
-"使用顏色配置檔案重新映射 RGB 值"
+"輸出色彩描述檔 | module name\n"
+"\n"
+"匯出影像使用的色彩空間與渲染意圖\n"
+"從工作空間重新映射 RGB 數值\n"
+"也可以在「匯出」模組中修改設定"
 
 #: ../src/iop/colorout.c:95
 msgid "non-linear, RGB or Lab, display-referred"
-msgstr "非線性、RGB 或 Lab、顯示工作流程"
+msgstr "非線性、RGB 或 Lab、顯示參照"
 
 #: ../src/iop/colorout.c:672
 msgid "missing output profile has been replaced by sRGB!"
-msgstr "未找到的輸出色彩檔案，使用 sRGB 替代！"
+msgstr "遺失的輸出描述檔已被 sRGB 取代"
 
 #: ../src/iop/colorout.c:694
 msgid "missing softproof profile has been replaced by sRGB!"
-msgstr "未找到的軟打樣色彩檔案，使用 sRGB 替代！"
+msgstr "遺失的軟打樣描述檔已被 sRGB 取代"
 
 #: ../src/iop/colorout.c:737
 msgid "unsupported output profile has been replaced by sRGB!"
-msgstr "不支援的輸出色彩檔案，使用 sRGB 替代！"
+msgstr "不支援的輸出描述檔案已被 sRGB 取代"
 
 #: ../src/iop/colorout.c:866
 msgid "output intent"
-msgstr "輸出目的"
+msgstr "輸出轉換方式"
 
 #: ../src/iop/colorout.c:867 ../src/libs/export.c:1259
 #: ../src/libs/print_settings.c:2325 ../src/libs/print_settings.c:2653
-#: ../src/views/darkroom.c:2453 ../src/views/darkroom.c:2460
+#: ../src/views/darkroom.c:2454 ../src/views/darkroom.c:2461
 #: ../src/views/lighttable.c:1155 ../src/views/lighttable.c:1162
 msgid "perceptual"
-msgstr "可感知的"
+msgstr "感知"
 
 #: ../src/iop/colorout.c:868 ../src/libs/export.c:1260
 #: ../src/libs/print_settings.c:2326 ../src/libs/print_settings.c:2654
-#: ../src/views/darkroom.c:2454 ../src/views/darkroom.c:2461
+#: ../src/views/darkroom.c:2455 ../src/views/darkroom.c:2462
 #: ../src/views/lighttable.c:1156 ../src/views/lighttable.c:1163
 msgid "relative colorimetric"
 msgstr "相對色度"
 
 #: ../src/iop/colorout.c:869 ../src/libs/export.c:1261
 #: ../src/libs/print_settings.c:2327 ../src/libs/print_settings.c:2655
-#: ../src/views/darkroom.c:2455 ../src/views/darkroom.c:2462
+#: ../src/views/darkroom.c:2456 ../src/views/darkroom.c:2463
 #: ../src/views/lighttable.c:1157 ../src/views/lighttable.c:1164
 msgctxt "rendering intent"
 msgid "saturation"
@@ -14189,87 +14754,104 @@ msgstr "飽和度"
 
 #: ../src/iop/colorout.c:870 ../src/libs/export.c:1262
 #: ../src/libs/print_settings.c:2328 ../src/libs/print_settings.c:2656
-#: ../src/views/darkroom.c:2456 ../src/views/darkroom.c:2463
+#: ../src/views/darkroom.c:2457 ../src/views/darkroom.c:2464
 #: ../src/views/lighttable.c:1158 ../src/views/lighttable.c:1165
 msgid "absolute colorimetric"
-msgstr "絕對色度"
+msgstr "絶對色度"
 
 #: ../src/iop/colorout.c:887
 msgid "rendering intent"
-msgstr "產生目的"
+msgstr "色彩轉換方式"
 
 #: ../src/iop/colorreconstruction.c:129
 msgid "color reconstruction"
-msgstr "色彩重建"
+msgstr "過曝色彩重建"
 
 #: ../src/iop/colorreconstruction.c:134
 msgid "recover clipped highlights by propagating surrounding colors"
-msgstr "通過傳播周圍顏色來恢復被剪裁高光"
+msgstr ""
+"過曝色彩重建 | color reconstruction\n"
+"\n"
+"利用周圍的色彩來恢復過度曝光的顏色資訊\n"
+"取代原本可能顯示為純白的像素\n"
+"類似的功能也可以在「電影式階調映射」模組中找到"
 
 #: ../src/iop/colorreconstruction.c:632 ../src/iop/colorreconstruction.c:1088
 #: ../src/iop/globaltonemap.c:193 ../src/iop/globaltonemap.c:364
 #: ../src/iop/hazeremoval.c:470 ../src/iop/hazeremoval.c:735
-#: ../src/iop/levels.c:328
+#: ../src/iop/levels.c:327
 msgid "inconsistent output"
-msgstr "輸出不一致"
+msgstr "輸出結果不一致"
 
 #: ../src/iop/colorreconstruction.c:670
 msgid "module `color reconstruction' failed"
-msgstr "模組“色彩重建”出現錯誤"
+msgstr "「過曝色彩重建」模組發生錯誤"
 
 #: ../src/iop/colorreconstruction.c:1285
 msgid "spatial"
-msgstr "空間的"
+msgstr "距離範圍"
 
 #: ../src/iop/colorreconstruction.c:1286
 msgid "range"
-msgstr "範圍"
+msgstr "亮度範圍"
 
 #: ../src/iop/colorreconstruction.c:1287
 msgid "precedence"
-msgstr "優先"
+msgstr "優先色彩"
 
 #: ../src/iop/colorreconstruction.c:1303
 msgid "pixels with lightness values above this threshold are corrected"
-msgstr "亮度值高於此臨界值的像素將被修正"
+msgstr ""
+"修復亮度高於此值的像素顏色，低於此值的像素作為顏色重建的參考\n"
+"這個參數的最佳設定可能每幅影像都不相同，必須手動判斷"
 
 #: ../src/iop/colorreconstruction.c:1304
 msgid "how far to look for replacement colors in spatial dimensions"
-msgstr "怎樣才能在空間維度中尋找替換顏色"
+msgstr "重建色彩的參考距離，設定要尋找距離過曝亮點多遠的像素顏色作為來源"
 
 #: ../src/iop/colorreconstruction.c:1305
 msgid "how far to look for replacement colors in the luminance dimension"
-msgstr "怎樣才能在亮度維度中尋找替換顏色"
+msgstr "重建色彩的參考亮度，設定要尋找和過曝亮點亮度差異多大的像素顏色作為來源"
 
 #: ../src/iop/colorreconstruction.c:1306
 msgid "if and how to give precedence to specific replacement colors"
-msgstr "是否或如何給予特定替換顏色優先權"
+msgstr ""
+"右側選項定義是否優先考慮使用某些顏色來重建過曝像素色彩\n"
+"\n"
+"無：所有參考像素的顏色都占均等權重\n"
+"飽和色彩：優先考慮高飽和度的參考像素\n"
+"色相：在參考像素中指定尋找特定的色調"
 
 #: ../src/iop/colorreconstruction.c:1307
 msgid "the hue tone which should be given precedence over other hue tones"
-msgstr "此色調應優先於其他色調"
+msgstr ""
+"優先使用以下色調來重建色彩，只有當設定為色相時，才會顯示這個滑桿\n"
+"此色調必須存在於上方距離和亮度範圍設定內的參考像素中才有作用\n"
+"\n"
+"此選項典型的用法是做為修復皮膚的高反光區域\n"
+"選擇膚色系的色相可以避免附近高亮度的其他顏色混入造成不自然感"
 
 #: ../src/iop/colorreconstruction.c:1309 ../src/iop/demosaic.c:5820
-#: ../src/iop/highlights.c:2214
+#: ../src/iop/highlights.c:2318
 msgid "not applicable"
-msgstr "不可用"
+msgstr "不適用"
 
-#: ../src/iop/colorreconstruction.c:1310 ../src/iop/highlights.c:2215
+#: ../src/iop/colorreconstruction.c:1310 ../src/iop/highlights.c:2319
 msgid "no highlights reconstruction for monochrome images"
-msgstr "黑白影像無高光重建"
+msgstr "黑白影像無法重建亮部色彩"
 
 #: ../src/iop/colortransfer.c:103
 msgid "color transfer"
-msgstr "顏色移轉"
+msgstr "色彩轉換"
 
 #: ../src/iop/colortransfer.c:118
 msgid "this module is deprecated. better use color mapping module instead."
-msgstr "此模組已棄用。最好改用‘顏色映射’模組。"
+msgstr "此模組已被汰除，建議使用「色彩映射」模組替代"
 
 #: ../src/iop/colortransfer.c:129
 msgctxt "accel"
 msgid "acquire"
-msgstr "獲得"
+msgstr "取得"
 
 #: ../src/iop/colortransfer.c:130
 msgctxt "accel"
@@ -14282,57 +14864,61 @@ msgid ""
 "and is only here so you can switch it off\n"
 "and move to the new color mapping module."
 msgstr ""
-"此模組未來將被移除\n"
-"目前尚可使用，但可關掉該模組\n"
-"並使用新的“顏色映射”模組。"
+"此模組將在未來移除，僅在此處可用\n"
+"可以將其關閉，並改用新的「色彩映射」模組"
 
 #: ../src/iop/colortransfer.c:660
 msgid "number of clusters to find in image"
-msgstr "影像中發現的分組數量"
+msgstr "要在影像中尋找的色板數量"
 
 #: ../src/iop/colortransfer.c:664
 msgid "acquire"
-msgstr "獲得"
+msgstr "分析"
 
 #: ../src/iop/colortransfer.c:666
 msgid "analyze this image"
-msgstr "分析該影像"
+msgstr "分析這張影像"
 
 #: ../src/iop/colortransfer.c:671
 msgid "apply previously analyzed image look to this image"
-msgstr "套用之前分析的影像至此影像"
+msgstr "套用之前分析的影像外觀到這個影像"
 
 #: ../src/iop/colorzones.c:139 ../src/iop/colorzones.c:2369
 msgid "color zones"
-msgstr "色區"
+msgstr "色彩分區調整"
 
 #: ../src/iop/colorzones.c:144
 msgid "selectively shift hues, saturation and brightness of pixels"
-msgstr "選擇地像素的偏移色相、飽和度和亮度"
+msgstr ""
+"色彩分區調整 | color zones\n"
+"\n"
+"依 CIE LCh 的明度、彩度、色相選擇性地調整色彩\n"
+"先選擇橫坐標根據明度、彩度或色相控制範圍\n"
+"接著以曲線控制像素的明度、彩度和色相"
 
 #: ../src/iop/colorzones.c:613
 msgid "red black white"
-msgstr "紅 黑 白"
+msgstr "保留紅色的黑白影像"
 
 #: ../src/iop/colorzones.c:636
 msgid "black white and skin tones"
-msgstr "黑白和皮膚色調"
+msgstr "保留膚色的黑白影像"
 
 #: ../src/iop/colorzones.c:659
 msgid "polarizing filter"
-msgstr "偏光鏡"
+msgstr "仿偏光鏡"
 
 #: ../src/iop/colorzones.c:680
 msgid "natural skin tones"
-msgstr "自然皮膚色調"
+msgstr "自然膚色"
 
 #: ../src/iop/colorzones.c:711
 msgid "black & white film"
-msgstr "黑白軟片"
+msgstr "黑白底片"
 
 #: ../src/iop/colorzones.c:731
 msgid "HSL base setting"
-msgstr "HSL基本設定"
+msgstr "HSL 基本設定"
 
 #: ../src/iop/colorzones.c:2303
 msgid "orange"
@@ -14345,49 +14931,54 @@ msgid ""
 "ctrl+drag to create a positive curve\n"
 "shift+drag to create a negative curve"
 msgstr ""
-"基於影像區域建立曲線\n"
-"拖拉以建立平坦的曲線\n"
-"控制鍵 + 拖拉建立正曲線\n"
-"shift + 拖拉建立負曲線"
+"選取影像上的區域，並自動建立控制點\n"
+"點擊以在影像上選取範圍，自動建立該範圍的曲線控制點\n"
+"ctrl + 點擊除了建立控制點之外，同時調整曲線向上\n"
+"shift + 點擊除了建立控制點之外，同時調整曲線向下"
 
 #. edit by area
 #: ../src/iop/colorzones.c:2471
 msgid "edit by area"
-msgstr "按區域編輯"
+msgstr "以區域調整"
 
 #: ../src/iop/colorzones.c:2476
 msgid "edit the curve nodes by area"
-msgstr "按區域編輯曲線節點"
+msgstr ""
+"開啟區域編輯模式\n"
+"以滑鼠拖動區域內的曲線，而非直接控制曲線節點"
 
 #: ../src/iop/colorzones.c:2483
 msgid "display selection"
-msgstr "顯示選取"
+msgstr "顯示選取範圍"
 
 #: ../src/iop/colorzones.c:2493
 msgid "choose selection criterion, will be the abscissa in the graph"
-msgstr "選擇選取標準做爲圖中的橫座標"
+msgstr ""
+"定義水平橫座標，也就是控制如何選取要處理的像素範圍\n"
+"可切換依據明度、飽和度、色相選取控制範圍\n"
+"更改此設定會重設曲線，如果要同時使用不同控制方式請建立新的模組實例"
 
 #: ../src/iop/colorzones.c:2496
 msgid "choose between a smoother or stronger effect"
-msgstr "選擇更平滑或更強烈的效果"
+msgstr "選擇調整效果的方式"
 
 #: ../src/iop/colorzones.c:2530 ../src/iop/rgbcurve.c:1421
-#: ../src/iop/tonecurve.c:1198
+#: ../src/iop/tonecurve.c:1197
 msgid "interpolation method"
-msgstr "內插法"
+msgstr "曲線內插法"
 
 #: ../src/iop/colorzones.c:2532 ../src/iop/rgbcurve.c:1423
-#: ../src/iop/tonecurve.c:1200
+#: ../src/iop/tonecurve.c:1199
 msgid "centripetal spline"
-msgstr "向心曲線"
+msgstr "向心擬合曲線"
 
 #: ../src/iop/colorzones.c:2533 ../src/iop/rgbcurve.c:1424
-#: ../src/iop/tonecurve.c:1201
+#: ../src/iop/tonecurve.c:1200
 msgid "monotonic spline"
-msgstr "單調曲線"
+msgstr "單調擬合曲線"
 
 #: ../src/iop/colorzones.c:2536 ../src/iop/rgbcurve.c:1427
-#: ../src/iop/tonecurve.c:1203
+#: ../src/iop/tonecurve.c:1202
 msgid ""
 "change this method if you see oscillations or cusps in the curve\n"
 "- cubic spline is better to produce smooth curves but oscillates when nodes "
@@ -14397,55 +14988,68 @@ msgid ""
 "- monotonic is better for accuracy of pure analytical functions (log, gamma, "
 "exp)\n"
 msgstr ""
-"如果在曲線中看到振盪或尖點，請改變此方法。\n"
-"- 三次曲線更適合於產生平滑曲線，但當節點太近時會出現振盪。\n"
-"- 向心曲線是最好是避免尖點，以及密切節點的振盪，但不太平滑。\n"
-"- 對於純解析函數(log，gamma，exp)的精度，單調曲線更好。\n"
+"變更由控制點內插擬合曲線的方法，如果曲線出現上下震盪可以嘗試更改\n"
+"\n"
+"三次擬合曲線（cubic）：\n"
+"適合少量分散的節點，曲線最為平滑，但節點太靠近時可能產生曲線震盪\n"
+"\n"
+"向心擬合曲線（centripetal）：\n"
+"適合局部調整使用，為避免曲線震盪設計的內插方法，但平滑度較低\n"
+"\n"
+"單調擬合曲線（centripetal）：\n"
+"適合單純函數型態的調整曲線，如 log 與 gamma\n"
 
 #: ../src/iop/crop.c:128 ../src/iop/rawprepare.c:856
 msgid "crop"
-msgstr "裁剪"
+msgstr "裁切"
 
 #: ../src/iop/crop.c:133
 msgid "reframe|distortion"
-msgstr "再構造|失真"
+msgstr "邊框|crop"
 
 #: ../src/iop/crop.c:138
 msgid "change the framing"
-msgstr "更改邊框"
+msgstr ""
+"裁切 | crop\n"
+"\n"
+"以螢幕顯示直覺地操作裁切影像\n"
+"選取此模組時會顯示完整未裁切影像"
 
 #: ../src/iop/crop.c:1165
 msgid "commit"
-msgstr "提交"
+msgstr "確認裁切"
 
 #: ../src/iop/crop.c:1165
 msgid "commit changes"
-msgstr "提交改變"
+msgstr "確認變更"
 
 #: ../src/iop/crop.c:1524
 msgid "<b>resize</b>: drag, <b>keep aspect ratio</b>: shift+drag"
-msgstr "<b>調整大小</b>:拖拉，<b>保持長寬比</b>:shift + 拖拉"
+msgstr ""
+"拖曳邊界改變尺寸\n"
+"shift + 拖曳維持寬高比"
 
 #: ../src/iop/crop.c:1531
 msgid ""
 "<b>move</b>: drag, <b>move vertically</b>: shift+drag, <b>move horizontally</"
 "b>: ctrl+drag"
 msgstr ""
-"<b>移動</b>:拖拉，<b>縱向拖拉</b>:shift + 拖拉，<b>水平拖拉</b>:控制鍵 + 拖動"
+"拖曳以移動\n"
+"shift + 拖曳：垂直移動，ctrl + 拖曳：水平移動"
 
 #: ../src/iop/defringe.c:70
 msgid "defringe"
-msgstr "去邊"
+msgstr "去除紫邊"
 
 #: ../src/iop/defringe.c:80
 msgid "attenuate chromatic aberration by desaturating edges"
-msgstr "通過邊緣去飽和以減弱色差"
+msgstr "藉由降低邊緣的彩度來減少色像差"
 
 #: ../src/iop/defringe.c:100
 msgid ""
 "this module is deprecated. please use the chromatic aberration module "
 "instead."
-msgstr "此模組已棄用。請使用色差校準模組。"
+msgstr "此模組已被汰除，建議使用「色像差校正」模組替代"
 
 #: ../src/iop/defringe.c:417
 msgid ""
@@ -14458,20 +15062,25 @@ msgid ""
 "more desaturation where required\n"
 " - static: fast, only uses the threshold as a static limit"
 msgstr ""
-"保護顏色的方式:\n"
-" - 全域平均:較快，在高倍放大時，預覽可能會顯示略有錯誤。與局部平均相比，有時"
-"可能會過度保護飽和度或保護不足。\n"
-" - 局部平均:較慢，通過使用鄰近像素作爲顏色參考。可能比整體平均有更好的保護飽"
-"和度，但需要時，仍可去更多飽和度。\n"
-" - 靜態:較快，僅使用臨界值作爲靜態分界點"
+"色彩保護方法，控制那些顏色不被視為色像差的計算方法\n"
+"\n"
+"全體平均：通常最快，與局部平均相比可能會沒那麼準確\n"
+"局部平均：較慢，使用每個像素周遭的像素作為色彩參考計算，可以更好地保護色彩\n"
+"固定門檻：不考慮影像中的色彩計算，直接使用使用者自訂的色差門檻"
 
 #: ../src/iop/defringe.c:424
 msgid "radius for detecting fringe"
-msgstr "偵測色差去邊的半徑"
+msgstr ""
+"邊緣偵測的範圍\n"
+"邏輯是以原始影像和經過高斯模糊版本比對差異來偵測邊緣\n"
+"若色像差很明顯或是紫邊太寬時可以調高這個數值"
 
 #: ../src/iop/defringe.c:427
 msgid "threshold for defringe, higher values mean less defringing"
-msgstr "去邊的臨界值，較高的值意味着更少的去邊緣效果"
+msgstr ""
+"邊緣偵測的門檻\n"
+"邏輯是判斷邊緣範圍的色差，以決定是否要視為色相差的臨界值\n"
+"如果有太多像素被去飽和，可以增加此數值以排除更多邊緣"
 
 #: ../src/iop/demosaic.c:221
 msgid "demosaic"
@@ -14479,16 +15088,21 @@ msgstr "去馬賽克"
 
 #: ../src/iop/demosaic.c:226
 msgid "reconstruct full RGB pixels from a sensor color filter array reading"
-msgstr "依照傳感器色彩濾波器陣列讀數來重建完整的RGB像素"
+msgstr ""
+"去馬賽克 | demosaic\n"
+"\n"
+"從感光元件的原始數據重建完整的 RGB 像素"
 
 #: ../src/iop/demosaic.c:5288
 msgid "[dual demosaic_cl] internal problem"
-msgstr "[dual demosaic_cl] 內部錯誤"
+msgstr "雙重去馬賽克內部錯誤"
 
 #: ../src/iop/demosaic.c:5661
 #, c-format
 msgid "`%s' color matrix not found for 4bayer image!"
-msgstr "未找到 4bayer 影像的“%s”顏色矩陣！"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"找不到拜耳影像「%s」的色彩矩陣"
 
 #: ../src/iop/demosaic.c:5787
 msgid ""
@@ -14497,9 +15111,20 @@ msgid ""
 "LMMSE is suited best for high ISO images.\n"
 "dual demosaicers double processing time."
 msgstr ""
-"拜爾傳感器去馬賽克方法，PPG 和 RCD 速度較快，AMaZE 和 LMMSE 速度較慢。\n"
-"LMMSE 最適合於高 ISO 影像。\n"
-"雙重去馬賽克會使處理時間加倍。"
+"選擇拜耳（Bayer）濾鏡排列感光元件的去馬賽克方式\n"
+"運算速度：PPG＞RCD＞VNG4＞LMMSE＞AMaZE，雙重去馬賽克會花費兩倍的時間\n"
+"\n"
+"PPG：過去的 darktable 預設演算法，速度非常快，但現在其他演算法的效果更好\n"
+"AMaZE：重建高頻細節最好的演算法，但較容易出現彩色斑紋，是速度最慢的演算法\n"
+"VNG4：適合低頻漸層的影像，例如天空等低對比度的內容，通常會損失一些高頻細節\n"
+"RCD：可以很好地重建高頻細節，不容易出現彩色斑紋，效果均衡且速度快\n"
+"LMMSE：最適合用於高感光度的嘈雜影像，在其他演算法出現莫爾紋的時候也很有用\n"
+"\n"
+"RCD + VNG4：去馬賽克兩次，RCD 用於細節內容，VNG4 用於平滑區域\n"
+"AMaZE + VNG4：去馬賽克兩次，AMaZE 用於細節內容，VNG4 用於平滑區域\n"
+"\n"
+"直通不去馬賽克：直接把 RGB 色版填入相同數值，適用於沒有色彩濾鏡的感光元件\n"
+"感光元件濾片色彩：呈現 RGB 濾色片，這是為了除錯而設計的，不適用於影像處理"
 
 #: ../src/iop/demosaic.c:5791
 msgid ""
@@ -14507,8 +15132,18 @@ msgid ""
 "chroma are slow.\n"
 "dual demosaicers double processing time."
 msgstr ""
-"X-Trans 傳感器的去馬賽克方法，Markesteijn 3-pass 和頻域色度都很慢。\n"
-"雙重去馬賽克器會使處理時間加倍。"
+"選擇富士 X-Trans 感光元件的去馬賽克方式\n"
+"運算速度：VNG＞Markesteijn＞FDC，雙重去馬賽克會花費兩倍的時間\n"
+"\n"
+"VNG：最快速的演算法，但對富士特殊排列的感光元件容易產生偽影\n"
+"Markesteijn 1-pass：品質均衡，X-Trans 感光元件的預設算法\n"
+"Markesteijn 3-pass：品質最高的演算法，但速度相對較慢\n"
+"frequency domain chroma：強化邊緣清晰度但容易有色彩斑紋\n"
+"\n"
+"Markesteijn + VNG：去馬賽克兩次，分別於高低頻區域使用\n"
+"\n"
+"直通不去馬賽克：直接把 RGB 色版填入相同數值，適用於沒有色彩濾鏡的感光元件\n"
+"感光元件濾片色彩：呈現 RGB 濾色片，這是為了除錯而設計的，不適用於影像處理"
 
 #: ../src/iop/demosaic.c:5795
 msgid ""
@@ -14516,9 +15151,9 @@ msgid ""
 "set to 0.0 to switch off\n"
 "set to 1.0 to ignore edges"
 msgstr ""
-"邊緣偵測中位數的臨界值。\n"
-"設爲 0.0 以關閉\n"
-"設爲 1.0 以忽略邊緣"
+"設定邊緣偵測的臨界值\n"
+"數值越高略過越多邊緣，1.0 完全忽略邊緣\n"
+"設定 0 會關閉此功能"
 
 #: ../src/iop/demosaic.c:5800
 msgid ""
@@ -14527,121 +15162,135 @@ msgid ""
 "set to 1.0 for flat content\n"
 "toggle to visualize the mask"
 msgstr ""
-"雙重去馬賽克的對比度臨界值\n"
-"處理高頻內容設為0.0 \n"
-"處理平面内容設為1.0 \n"
-"切換視覺化遮罩"
+"雙重去馬賽克演算法的對比度門檻\n"
+"較低的值使用更多高頻去馬賽克算法，較高的值使用較多低頻算法\n"
+"設為 0 代表只使用高頻算法數值，設為 1 代表只使用低頻算法數值\n"
+"\n"
+"右側按鈕開啟遮罩預覽模式，以便精確控制參數\n"
+"遮罩亮度越高，高頻演算法的權重越高，純白的像素代表只使用高頻數據\n"
+"遮罩亮度越低，低頻演算法的權重越高，純黑的像素代表只使用低頻數據\n"
+"雙重去馬賽克功能會逐像素計算高低頻數據的權重，然後計算最終 RGB 數值"
 
 #: ../src/iop/demosaic.c:5808
 msgid ""
 "LMMSE refinement steps. the median steps average the output,\n"
 "refine adds some recalculation of red & blue channels"
 msgstr ""
-"LMMSE 精鍊步驟數。中位數步驟平均輸出，\n"
-"精鍊步驟會增加一些紅色和藍色通道的重新計算"
+"LMMSE 最佳化步驟\n"
+"增加了紅色和藍色色版的重新計算數值以平均輸出\n"
+"對亮度雜訊效果很好，但可能會降低具有嚴重色彩雜訊影像的品質"
 
 #: ../src/iop/demosaic.c:5811
 msgid "how many color smoothing median steps after demosaicing"
-msgstr "計算去馬賽克後色彩平滑的中間步驟"
+msgstr ""
+"啟用去馬賽克後的顏色平滑處理\n"
+"可能可以解決一些邊緣色彩偽影的問題"
 
 #: ../src/iop/demosaic.c:5814
 msgid "green channels matching method"
-msgstr "綠色通道匹配方法"
+msgstr ""
+"綠色色版匹配方式\n"
+"某些相機 RGBG 中的兩個綠色濾片略有不同\n"
+"調整此設定以額外均勻化步驟來抑制偽影"
 
 #: ../src/iop/demosaic.c:5821
 msgid "demosaicing is only used for color raw images"
-msgstr "去馬賽克只能用於彩色 raw 影像"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"去馬賽克功能只限用於彩色 RAW 檔"
 
 #: ../src/iop/denoiseprofile.c:707
 msgid "wavelets: chroma only"
-msgstr "小波:僅色度(chroma)"
+msgstr "小波：僅彩度"
 
 #: ../src/iop/denoiseprofile.c:713
 msgid "denoise (profiled)"
-msgstr "降噪(依據影像分析)"
+msgstr "相機特性除雜訊"
 
 #: ../src/iop/denoiseprofile.c:719
 msgid "denoise using noise statistics profiled on sensors"
-msgstr "依據傳感器的噪點統計分析降噪"
+msgstr ""
+"相機特性除雜訊 | denoise (profiled)\n"
+"\n"
+"使用感光元件的雜訊分析資料降低雜訊\n"
+"藉由分析相機在不同感光度的特性調整算法以更好地消除雜訊"
 
 #: ../src/iop/denoiseprofile.c:2714
 #, c-format
 msgid "found match for ISO %d"
-msgstr "已發現匹配 ISO %d"
+msgstr "找到符合 ISO %d 的資料"
 
 #: ../src/iop/denoiseprofile.c:2723
 #, c-format
 msgid "interpolated from ISO %d and %d"
-msgstr "從 ISO %d 與 %d 內插獲得"
+msgstr "由 ISO %d 和 %d 資料內插"
 
 #: ../src/iop/denoiseprofile.c:3092 ../src/iop/denoiseprofile.c:3671
 msgid "compute variance"
-msgstr "計算方差"
+msgstr "計算變異數"
 
 #: ../src/iop/denoiseprofile.c:3589
 msgid "Y0"
-msgstr "Y0"
+msgstr "亮度（Y0）"
 
 #: ../src/iop/denoiseprofile.c:3590
 msgid "U0V0"
-msgstr "U0V0"
+msgstr "色彩（U0V0）"
 
 #: ../src/iop/denoiseprofile.c:3623
 msgid ""
 "use only with a perfectly\n"
 "uniform image if you want to\n"
 "estimate the noise variance."
-msgstr ""
-"計算噪點方差時請\n"
-"只使用完全均勻的影像。"
+msgstr "如果要估計雜訊變異數，必須使用完全均勻的影像"
 
 #: ../src/iop/denoiseprofile.c:3629
 msgid "variance red: "
-msgstr "紅色方差: "
+msgstr "紅色變異數："
 
 #. This gets filled in by process
 #: ../src/iop/denoiseprofile.c:3632
 msgid "variance computed on the red channel"
-msgstr "基於紅色通道計算的方差"
+msgstr "紅色色版計算的變異數"
 
 #: ../src/iop/denoiseprofile.c:3637
 msgid "variance green: "
-msgstr "綠色方差: "
+msgstr "綠色變異數："
 
 #. This gets filled in by process
 #: ../src/iop/denoiseprofile.c:3640
 msgid "variance computed on the green channel"
-msgstr "基於綠色通道計算的方差"
+msgstr "綠色色版計算的變異數"
 
 #: ../src/iop/denoiseprofile.c:3645
 msgid "variance blue: "
-msgstr "藍色方差: "
+msgstr "藍色變異數："
 
 #. This gets filled in by process
 #: ../src/iop/denoiseprofile.c:3648
 msgid "variance computed on the blue channel"
-msgstr "基於藍色通道計算的方差"
+msgstr "藍色色版計算的變異數"
 
 #: ../src/iop/denoiseprofile.c:3658 ../src/libs/export.c:1234
 #: ../src/libs/print_settings.c:2273 ../src/libs/print_settings.c:2604
 msgid "profile"
-msgstr "配置檔案"
+msgstr "描述檔"
 
 #: ../src/iop/denoiseprofile.c:3666
 msgid "non-local means"
-msgstr "非局部均值"
+msgstr "非局部平均值（進階手動）"
 
 #: ../src/iop/denoiseprofile.c:3667
 msgid "non-local means auto"
-msgstr "非局部均值 自動"
+msgstr "非局部平均值（精簡自動）"
 
 #: ../src/iop/denoiseprofile.c:3668
 msgid "wavelets"
-msgstr "小波"
+msgstr "小波變換（進階手動）"
 
 #: ../src/iop/denoiseprofile.c:3669
 msgid "wavelets auto"
-msgstr "小波 自動"
+msgstr "小波變換（精簡自動）"
 
 #: ../src/iop/denoiseprofile.c:3693
 msgid ""
@@ -14652,9 +15301,9 @@ msgid ""
 "should be disabled if an earlier instance\n"
 "has been used with a color blending mode."
 msgstr ""
-"根據白平衡係數調適降噪。\n"
-"應在第一個實例上啓用，以便更好地去噪。\n"
-"如果早期實例已與顏色混合模式一起使用，則應不使用。"
+"根據白平衡係數調整除雜訊\n"
+"若有多個模組實例，應在第一個模組實例上啟用以獲得較好的效果\n"
+"如果有較早的模組實例配合色彩混合模式一起使用，則應停用此功能"
 
 #: ../src/iop/denoiseprofile.c:3699
 msgid ""
@@ -14668,16 +15317,19 @@ msgid ""
 "you get. once enabled, you won't be able to\n"
 "return back to old algorithm."
 msgstr ""
-"在安斯康姆轉換修復錯誤導致\n"
-"在小波模式下的綠色通道平滑化不足\n"
-"結合白平衡係數的不良處理及當色塊大小增加時，非區域方法正規劃化的一個錯誤導致"
-"平滑化不足\n"
-"啟用此選項將會改變降噪\n"
-"一旦啟用，將無法在使用舊演算法."
+"修復安斯康柏轉換中的錯誤\n"
+"\n"
+"這些錯誤會導致在小波模式下綠色色版的平滑度過低與白平衡係數不當\n"
+"以及非局部平均值模式下色塊尺寸增加時平滑度過低的錯誤\n"
+"啟用此選項將改變除雜訊的效果，一旦啟用就無法再回復到舊的演算法"
 
 #: ../src/iop/denoiseprofile.c:3708
 msgid "profile used for variance stabilization"
-msgstr "用於方差穩定的配置檔案"
+msgstr ""
+"用於除雜訊的相機特性描述檔\n"
+"根據 EXIF 資料確認相機和感光度設定，自動搜尋相對應的內建描述檔\n"
+"如果感光值介於兩個描述檔之間，則會自動使用最接近的兩個描述檔內插\n"
+"darktabke 沒有支援的相機則顯示使用通用的設定"
 
 #: ../src/iop/denoiseprofile.c:3709
 msgid ""
@@ -14685,9 +15337,16 @@ msgid ""
 "non-local means works best for `lightness' blending,\n"
 "wavelets work best for `color' blending"
 msgstr ""
-"降噪核心採用的算法。\n"
-"非局部均值對於“亮度”混成效果最好, \n"
-"小波對於“顏色”混成效果最好"
+"選擇要使用的除雜訊演算法，以及是否顯示進階手動選項或精簡自動控制\n"
+"\n"
+"非局部平均值：\n"
+"和「天文攝影除雜訊」模組的計算方法大致相同，但應用了相機特性\n"
+"由於計算每個像素與周圍像素的相似性和權重，此算法非常耗費資源\n"
+"\n"
+"小波變換：\n"
+"藉由小波分析可達到根據影像雜訊的粒子大小分別調整除雜訊強度\n"
+"此模式可使用 YUV 色彩模式，達到分別控制亮度和色彩雜訊的功能\n"
+"小波分析比非局部算法佔用的資源要少"
 
 #: ../src/iop/denoiseprofile.c:3712
 msgid ""
@@ -14696,9 +15355,13 @@ msgid ""
 "while Y0U0V0 combine the channels to\n"
 "denoise chroma and luma separately."
 msgstr ""
-"算法中使用的色彩表示法。\n"
-"RGB保持RGB通道分離，\n"
-"Y0U0V0組合通道分別以色度和亮度進行去噪。"
+"小波演算法中使用的色版控制\n"
+"\n"
+"RGB 模式可針對全部色版或是 R、G、B 單一色版獨立調整\n"
+"獨立調整藉由建立三個模組實例來分開處理，這會得到最好的成果但非常耗時\n"
+"\n"
+"YUV 模式把小波層分為亮度（Y0）和顏色（U0V0）色版分開處理雜訊\n"
+"通常人眼感覺不適的是顏色偏差的雜訊，對亮度雜訊的接受度較高"
 
 #: ../src/iop/denoiseprofile.c:3716
 msgid ""
@@ -14708,9 +15371,9 @@ msgid ""
 "if details are oversmoothed, reduce this value or increase the central pixel "
 "weight slider."
 msgstr ""
-"要匹配的色塊半徑。\n"
-"增加以使強邊緣更銳利，以及更好的平滑區域去噪。\n"
-"如果細節過度平滑，減小此值或增加中央像素權重滑動條。"
+"平均匹配像素時的色塊大小，代表平均多少半徑的周邊像素\n"
+"增加參數獲得更強的除雜訊效果，並獲得更好的邊緣銳利度\n"
+"如果細節過度平滑化，可降低此參數或增加中央像素的權重"
 
 #: ../src/iop/denoiseprofile.c:3719
 msgid ""
@@ -14718,9 +15381,9 @@ msgid ""
 "increase for better denoising performance, but watch the long runtimes! "
 "large radii can be very slow. you have been warned"
 msgstr ""
-"僅用於緊急情況:搜尋鄰近色塊的半徑範圍。\n"
-"增加該值以獲得更好的降噪性能，但要注意運行時間會更長！\n"
-"警告:大的半徑可能會很慢"
+"調整演算法在離原始像素多遠的地方尋找類似的色塊\n"
+"如果較大的粗糙雜訊非常明顯時，增加此參數可以提供更好的結果\n"
+"但處理時間會以設定值的平方等比增加，可改用效果類似的分散搜尋"
 
 #: ../src/iop/denoiseprofile.c:3722
 msgid ""
@@ -14728,9 +15391,10 @@ msgid ""
 "increase for better coarse-grain noise reduction.\n"
 "does not affect execution time."
 msgstr ""
-"分散鄰近區域以搜尋色塊。\n"
-"增加該值以更好的去除粗顆粒噪點。\n"
-"此選項不影響執行時間。"
+"增加參數以減少較大的粗糙雜訊，對降低色彩雜訊特別有效\n"
+"效果與搜尋距離類似，調整在距離像素多遠的地方尋找相似的色塊\n"
+"但是此參數維持原有的色塊數量只是將其分散在更大的半徑範圍\n"
+"所以運算時間不會受到影響"
 
 #: ../src/iop/denoiseprofile.c:3725
 msgid ""
@@ -14739,12 +15403,14 @@ msgid ""
 "useful to recover details when patch size\n"
 "is quite big."
 msgstr ""
-"在色塊比較中增加色塊中心像素的權重。\n"
-"當色塊大小很大時，對恢復細節非常有用。"
+"增加色塊中心像素的權重，當色塊尺寸很大時可以有效保留細節\n"
+"調高參數會減少亮度除雜訊強度，使演算法偏重於處理色彩雜訊"
 
 #: ../src/iop/denoiseprofile.c:3729
 msgid "finetune denoising strength"
-msgstr "微調降噪強度"
+msgstr ""
+"微調除雜訊的強度，預設值以最大信噪比為目標\n"
+"強度調整取決於個人喜好，犧牲細節換取低雜訊，或是較多雜訊但更好的細節"
 
 #: ../src/iop/denoiseprofile.c:3730
 msgid ""
@@ -14753,16 +15419,18 @@ msgid ""
 "or if chroma noise remains.\n"
 "this can happen if your picture is underexposed."
 msgstr ""
-"控制參數自動設定的方式。\n"
-"增加數值:如果陰影降噪不夠或色度噪點還存在。\n"
-"假如照片曝光不足，可能會發生這種情況。"
+"使用單一參數自動調整目前演算法的其他進階參數\n"
+"如果暗部雜訊過高或顏色雜訊太過明顯時可以調高數值\n"
+"或是在精簡自動模式下調整此值，再切換至進階手動模式微調"
 
 #: ../src/iop/denoiseprofile.c:3734
 msgid ""
 "finetune shadows denoising.\n"
 "decrease to denoise more aggressively\n"
 "dark areas of the image."
-msgstr "微調陰影降噪。減少:對影像中較暗區域的更強的降噪。"
+msgstr ""
+"微調暗部除雜訊的強度\n"
+"更高的值保留較多暗部細節，降低以對暗部執行更強的除雜訊處理"
 
 #: ../src/iop/denoiseprofile.c:3737
 msgid ""
@@ -14770,8 +15438,9 @@ msgid ""
 "decrease if shadows are too purple.\n"
 "increase if shadows are too green."
 msgstr ""
-"修正陰影區域的顏色。\n"
-"減小:如果陰影太紫。增加:如果陰影太綠。"
+"修正暗部的色偏\n"
+"如果暗部偏紫，降低此值\n"
+"如果暗部偏綠，增加此值"
 
 #: ../src/iop/denoiseprofile.c:3740
 msgid ""
@@ -14780,17 +15449,17 @@ msgid ""
 "it is more flexible but could give small\n"
 "differences in the images already processed."
 msgstr ""
-"升級方差穩定算法。\n"
-"新算法是基於舊算法的擴充，比舊算法更靈活，\n"
-"與已處理結果有微小不同。"
+"升級穩定變異值的演算法\n"
+"新的演算法基於舊演算法的擴充，比舊算法更為靈活\n"
+"但可能會與已經舊算法處理的結果有些微差異"
 
 #: ../src/iop/diffuse.c:132
 msgid "diffuse or sharpen"
-msgstr "擴散或銳利化"
+msgstr "漫射或反捲積銳化"
 
 #: ../src/iop/diffuse.c:137
 msgid "diffusion|deconvolution|blur|sharpening"
-msgstr "擴散|去卷積|模糊|銳利化"
+msgstr "反捲積|模糊|銳化"
 
 #: ../src/iop/diffuse.c:143
 msgid ""
@@ -14799,62 +15468,63 @@ msgid ""
 "inpaint damaged parts of the image,or to remove blur with blind "
 "deconvolution."
 msgstr ""
-"通過熱傳導模型模擬方向性的光擴散\n"
-"可以套用迭代式邊緣模糊，\n"
-"重建畫面上損壞的區域或\n"
-"通過盲目的反捲積以減少模糊。"
+"漫射或反捲積銳化 | diffuse or sharpen\n"
+"\n"
+"藉由物理模擬光的漫射或反向計算以消除模糊\n"
+"這是一個很技術性的模組，建議使用預設集微調參數使用\n"
+"反捲積銳化效果勝過傳統的銳利化方式是這個模組的最大用處"
 
 #: ../src/iop/diffuse.c:236
 msgid "lens deblur: soft"
-msgstr "鏡頭去模糊:柔軟"
+msgstr "恢復鏡頭模糊：輕度"
 
 #: ../src/iop/diffuse.c:241
 msgid "lens deblur: medium"
-msgstr "鏡頭去模糊:中等"
+msgstr "恢復鏡頭模糊：中度"
 
 #: ../src/iop/diffuse.c:246
 msgid "lens deblur: hard"
-msgstr "鏡頭去模糊:強烈"
+msgstr "恢復鏡頭模糊：強烈"
 
 #: ../src/iop/diffuse.c:265
 msgid "dehaze"
-msgstr "去朦朧"
+msgstr "除霧霾"
 
 #: ../src/iop/diffuse.c:286
 msgid "denoise: fine"
-msgstr "降噪:精細"
+msgstr "去除雜訊：精細"
 
 #: ../src/iop/diffuse.c:295
 msgid "denoise: medium"
-msgstr "降噪:中等"
+msgstr "去除雜訊：中等"
 
 #: ../src/iop/diffuse.c:304
 msgid "denoise: coarse"
-msgstr "降噪:粗糙"
+msgstr "去除雜訊：粗糙"
 
 #: ../src/iop/diffuse.c:360
 msgid "sharpen demosaicing (no AA filter)"
-msgstr "銳利化去馬賽克(無抗鋸齒濾鏡)"
+msgstr "恢復去馬賽克模糊（無低通濾鏡）"
 
 #: ../src/iop/diffuse.c:364
 msgid "sharpen demosaicing (AA filter)"
-msgstr "銳利化去馬賽克(使用抗鋸齒濾鏡)"
+msgstr "恢復去馬賽克模糊（有低通濾鏡）"
 
 #: ../src/iop/diffuse.c:383
 msgid "simulate watercolor"
-msgstr "模擬水彩效果"
+msgstr "模擬水彩畫"
 
 #: ../src/iop/diffuse.c:401
 msgid "simulate line drawing"
-msgstr "模擬線條繪製效果"
+msgstr "模擬線條畫"
 
 #: ../src/iop/diffuse.c:422
 msgid "add local contrast"
-msgstr "增加局部對比度"
+msgstr "增加局部對比"
 
 #: ../src/iop/diffuse.c:442
 msgid "inpaint highlights"
-msgstr "修復高光"
+msgstr "修復反光亮點"
 
 #: ../src/iop/diffuse.c:463
 msgid "fast sharpness"
@@ -14862,31 +15532,34 @@ msgstr "快速銳利化"
 
 #: ../src/iop/diffuse.c:485
 msgid "fast local contrast"
-msgstr "快速局部對比度"
+msgstr "快速局部對比"
 
-#: ../src/iop/diffuse.c:1104 ../src/iop/diffuse.c:1364
+#: ../src/iop/diffuse.c:1106 ../src/iop/diffuse.c:1368
 msgid "diffuse/sharpen failed to allocate memory, check your RAM settings"
-msgstr "擴散與銳利化模組未能配置記憶體，請檢查 RAM 設定"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"「漫射或反捲積銳化」模組無法配置記憶體，請檢查記憶體設定"
 
 #. Additional parameters
 #. Camera settings
-#: ../src/iop/diffuse.c:1476 ../src/iop/splittoning.c:525
+#: ../src/iop/diffuse.c:1480 ../src/iop/splittoning.c:525
 #: ../src/libs/camera.c:487
 msgid "properties"
 msgstr "屬性"
 
-#: ../src/iop/diffuse.c:1481
+#: ../src/iop/diffuse.c:1485
 msgid ""
 "more iterations make the effect stronger but the module slower.\n"
 "this is analogous to giving more time to the diffusion reaction.\n"
 "if you plan on sharpening or inpainting, \n"
 "more iterations help reconstruction."
 msgstr ""
-"更多迭代次數可以增強效果，但會減慢模組處理速度。\n"
-"這類似於允許更長時間的擴散反應。\n"
-"若您需要銳利化或重建影像，增加迭代次數有助於重建。"
+"重複運算的次數\n"
+"數值越高運算越準確，但會大幅減慢運算速度\n"
+"高迭代次數配合較低的速度，有助於重建細節與去除模糊\n"
+"在物理上的意義類似於更長的漫射擴散時間，時間越久範圍越大"
 
-#: ../src/iop/diffuse.c:1490
+#: ../src/iop/diffuse.c:1494
 msgid ""
 "main scale of the diffusion.\n"
 "zero makes diffusion act on the finest details more heavily.\n"
@@ -14894,13 +15567,12 @@ msgid ""
 "for deblurring and denoising, set to zero.\n"
 "increase to act on local contrast instead."
 msgstr ""
-"擴散的主要範圍。\n"
-"0:使得擴散效果更強作用於最精細的細節。\n"
-"非 0 :定義使得擴散更強細節的大小。\n"
-"去模糊或降噪時請設定爲 0。\n"
-"增加:處理局部對比度時。"
+"漫射的主要範圍\n"
+"數值越小影響越精細的細節，數值越大作用類似於局部對比\n"
+"若要重建因去馬賽克或鏡頭引起的模糊細節，請使用 0\n"
+"自然漫射只應影響最接近的像素，為了計算效率在此使用小波分析以應用在更大範圍"
 
-#: ../src/iop/diffuse.c:1500
+#: ../src/iop/diffuse.c:1504
 msgid ""
 "width of the diffusion around the central radius.\n"
 "high values diffuse on a large band of radii.\n"
@@ -14908,16 +15580,16 @@ msgid ""
 "if you plan on deblurring, \n"
 "the radius should be around the width of your lens blur."
 msgstr ""
-"圍繞中央半徑的擴散寬度。\n"
-"高數值:將以更大的半徑擴散。\n"
-"低數值:將使擴散區域更靠近中央半徑。\n"
-"若打算去模糊，半徑應為鏡頭模糊寬度左右。"
+"在中心半徑之外的漫射範圍\n"
+"如果要反捲積修復鏡頭模糊，數值應使用鏡頭模糊的寬度\n"
+"如果是增加局部對比度，最佳數值應為中心半徑的 3/4\n"
+"自然漫射只應影響最接近的像素，為了計算效率在此使用小波分析以應用在更大範圍"
 
-#: ../src/iop/diffuse.c:1506
+#: ../src/iop/diffuse.c:1510
 msgid "speed (sharpen ↔ diffuse)"
-msgstr "速度(銳利化↔擴散)"
+msgstr "速度（銳利 ↔ 漫射）"
 
-#: ../src/iop/diffuse.c:1512
+#: ../src/iop/diffuse.c:1516
 msgid ""
 "diffusion speed of low-frequency wavelet layers\n"
 "in the direction of 1st order anisotropy (set below).\n"
@@ -14926,14 +15598,13 @@ msgid ""
 "positive values diffuse and blur, \n"
 "zero does nothing."
 msgstr ""
-"低頻小波圖層的擴散速度\n"
-"在各向異性一階的方向(設定如下)\n"
+"對應下方一階異向性低頻小波空間的漫射速度\n"
 "\n"
-"負值:銳利化\n"
-"正值:擴散及模糊\n"
-"0: 不處理."
+"正值：增加漫射速度，讓影像更模糊\n"
+"負值：反轉漫射，修復影像細節\n"
+"　零：不執行任何操作"
 
-#: ../src/iop/diffuse.c:1521
+#: ../src/iop/diffuse.c:1525
 msgid ""
 "diffusion speed of low-frequency wavelet layers\n"
 "in the direction of 2nd order anisotropy (set below).\n"
@@ -14942,14 +15613,13 @@ msgid ""
 "positive values diffuse and blur, \n"
 "zero does nothing."
 msgstr ""
-"低頻小波圖層的擴散速度\n"
-"在各向異性二階的方向(設定如下)\n"
+"對應下方二階異向性低頻小波空間的漫射速度\n"
 "\n"
-"負值:銳利化\n"
-"正值:擴散及模糊\n"
-"0: 不處理."
+"正值：增加漫射速度，讓影像更模糊\n"
+"負值：反轉漫射，修復影像細節\n"
+"　零：不執行任何操作"
 
-#: ../src/iop/diffuse.c:1530
+#: ../src/iop/diffuse.c:1534
 msgid ""
 "diffusion speed of high-frequency wavelet layers\n"
 "in the direction of 3rd order anisotropy (set below).\n"
@@ -14958,14 +15628,13 @@ msgid ""
 "positive values diffuse and blur, \n"
 "zero does nothing."
 msgstr ""
-"低頻小波圖層的擴散速度\n"
-"在各向異性三階的方向(設定如下)\n"
+"對應下方三階異向性高頻小波空間的漫射速度\n"
 "\n"
-"負值:銳利化\n"
-"正值:擴散及模糊\n"
-"0: 不處理."
+"正值：增加漫射速度，讓影像更模糊\n"
+"負值：反轉漫射，修復影像細節\n"
+"　零：不執行任何操作"
 
-#: ../src/iop/diffuse.c:1539
+#: ../src/iop/diffuse.c:1543
 msgid ""
 "diffusion speed of high-frequency wavelet layers\n"
 "in the direction of 4th order anisotropy (set below).\n"
@@ -14974,14 +15643,13 @@ msgid ""
 "positive values diffuse and blur, \n"
 "zero does nothing."
 msgstr ""
-"低頻小波圖層的擴散速度\n"
-"在各向異性四階的方向(設定如下)\n"
+"對應下方四階異向性高頻小波空間的漫射速度\n"
 "\n"
-"負值:銳利化\n"
-"正值:擴散及模糊\n"
-"0: 不處理."
+"正值：增加漫射速度，讓影像更模糊\n"
+"負值：反轉漫射，修復影像細節\n"
+"　零：不執行任何操作"
 
-#: ../src/iop/diffuse.c:1551
+#: ../src/iop/diffuse.c:1555
 msgid ""
 "direction of 1st order speed (set above).\n"
 "\n"
@@ -14989,13 +15657,13 @@ msgid ""
 "positive values rather avoid edges (isophotes), \n"
 "zero affects both equally (isotropic)."
 msgstr ""
-"在一階的方向速度(設定如下)\n"
+"對應上方一階速度的方向性，模擬自然擴散的方向\n"
 "\n"
-"負值:跟漸層更密切\n"
-"正值:避免邊緣(等光強線)\n"
-"0: 一樣影響兩者(等光線)"
+"正值：漫射方向避開等亮度線圍起的邊緣\n"
+"負值：強制漫射方向穿越邊緣\n"
+"　零：各向同性，所有方向具有相同的權重"
 
-#: ../src/iop/diffuse.c:1559
+#: ../src/iop/diffuse.c:1563
 msgid ""
 "direction of 2nd order speed (set above).\n"
 "\n"
@@ -15003,13 +15671,13 @@ msgid ""
 "positive values rather avoid edges (isophotes), \n"
 "zero affects both equally (isotropic)."
 msgstr ""
-"在二階的方向速度(設定如下)\n"
+"對應上方二階速度的方向性，模擬自然擴散的方向\n"
 "\n"
-"負值:跟漸層更密切\n"
-"正值:避免邊緣(等光強線)\n"
-"0: 一樣影響兩者(等光線)"
+"正值：漫射方向避開等亮度線圍起的邊緣\n"
+"負值：強制漫射方向穿越邊緣\n"
+"　零：各向同性，所有方向具有相同的權重"
 
-#: ../src/iop/diffuse.c:1567
+#: ../src/iop/diffuse.c:1571
 msgid ""
 "direction of 3rd order speed (set above).\n"
 "\n"
@@ -15017,13 +15685,13 @@ msgid ""
 "positive values rather avoid edges (isophotes), \n"
 "zero affects both equally (isotropic)."
 msgstr ""
-"在三階的方向速度(設定如下)\n"
+"對應上方三階速度的方向性，模擬自然擴散的方向\n"
 "\n"
-"負值:跟漸層更密切\n"
-"正值:避免邊緣(等光強線)\n"
-"0: 一樣影響兩者(等光線)"
+"正值：漫射方向避開等亮度線圍起的邊緣\n"
+"負值：強制漫射方向穿越邊緣\n"
+"　零：各向同性，所有方向具有相同的權重"
 
-#: ../src/iop/diffuse.c:1575
+#: ../src/iop/diffuse.c:1579
 msgid ""
 "direction of 4th order speed (set above).\n"
 "\n"
@@ -15031,51 +15699,52 @@ msgid ""
 "positive values rather avoid edges (isophotes), \n"
 "zero affects both equally (isotropic)."
 msgstr ""
-"在四階的方向速度(設定如下)\n"
+"對應上方四階速度的方向性，模擬自然擴散的方向\n"
 "\n"
-"負值:跟漸層更密切\n"
-"正值:避免邊緣(等光強線)\n"
-"0: 一樣影響兩者(等光線)"
+"正值：漫射方向避開等亮度線圍起的邊緣\n"
+"負值：強制漫射方向穿越邊緣\n"
+"　零：各向同性，所有方向具有相同的權重"
 
-#: ../src/iop/diffuse.c:1580
+#: ../src/iop/diffuse.c:1584
 msgid "edge management"
 msgstr "邊緣管理"
 
-#: ../src/iop/diffuse.c:1585
+#: ../src/iop/diffuse.c:1589
 msgid ""
 "increase or decrease the sharpness of the highest frequencies.\n"
 "can be used to keep details after blooming,\n"
 "for standalone sharpening set speed to negative values."
 msgstr ""
-"增加或減少最高頻的銳利度\n"
-"可用來保有細節當高光溢出時\n"
-"對於單獨銳利化時設定速度為負值."
+"提高或降低最高頻細節的銳利度，預設零不做任何處理\n"
+"可用於在漫射後保留一些邊緣對比，並在邊緣增加光暈\n"
+"不建議單獨使用此設定做銳化，因為可能出現明顯的邊緣偽影"
 
-#: ../src/iop/diffuse.c:1591
+#: ../src/iop/diffuse.c:1595
 msgid ""
 "define the sensitivity of the variance penalty for edges.\n"
 "increase to exclude more edges from diffusion,\n"
 "if fringes or halos appear."
 msgstr ""
-"定義邊緣方差損失的靈敏度。\n"
-"增加:如果出現流蘇或光環時，移除更多邊緣擴散。"
+"自訂邊緣偵測的靈敏度\n"
+"偵測到邊緣時降低漫射速度以避免邊緣光暈\n"
+"如果出現邊緣偽影，如光暈時，可調高此設定值"
 
-#: ../src/iop/diffuse.c:1597
+#: ../src/iop/diffuse.c:1601
 msgid ""
 "define the variance threshold between edge amplification and penalty.\n"
 "decrease if you want pixels on smooth surfaces get a boost,\n"
 "increase if you see noise appear on smooth surfaces or\n"
 "if dark areas seem oversharpened compared to bright areas."
 msgstr ""
-"定義邊緣放大/損失的方差臨界值。\n"
-"減少:增強平滑表面上的像素，\n"
-"增加:若平滑表面上出現噪點或暗部相較於亮部被過度銳利化。"
+"自訂邊緣偵測的門檻\n"
+"降低數值讓更多區域被視為邊緣，有利於恢復細節或增加局部對比度\n"
+"提高數值有利於去噪或模糊，如果平滑區域出現雜訊或暗部比亮部銳化過多時使用"
 
-#: ../src/iop/diffuse.c:1603
+#: ../src/iop/diffuse.c:1607
 msgid "diffusion spatiality"
-msgstr "擴散空間性"
+msgstr "漫射空間"
 
-#: ../src/iop/diffuse.c:1608
+#: ../src/iop/diffuse.c:1612
 msgid ""
 "luminance threshold for the mask.\n"
 "0. disables the luminance masking and applies the module on the whole "
@@ -15083,25 +15752,30 @@ msgid ""
 "any higher value excludes pixels with luminance lower than the threshold.\n"
 "this can be used to inpaint highlights."
 msgstr ""
-"遮罩的亮度臨界值。\n"
-"0:將不使用亮度遮罩並將此模組套用於整個影像。\n"
-"任何正值將會排除亮度小於該值的像素。\n"
-"此功能可用於修正高光區域。"
+"遮罩的亮度門檻\n"
+"排除低於此亮度的像素，漫射只會存在更亮的區域中\n"
+"並在其中添加高斯雜訊模擬光粒子以修復亮點\n"
+"設定零會停用亮度遮罩，並且對全影像模擬漫射"
 
 #: ../src/iop/dither.c:97 ../src/iop/vignette.c:992
 msgid "dithering"
-msgstr "抖動(不連續色調混色)"
+msgstr "遞色"
 
 #: ../src/iop/dither.c:102
 msgid ""
 "reduce banding and posterization effects in output JPEGs by adding random "
 "noise"
-msgstr "通過增加隨機噪點來減少輸出JPEG影像時的多色調分色效果"
+msgstr ""
+"遞色 | dithering\n"
+"\n"
+"以色彩抖動減少匯出至 JPEG 漸層斷階的問題\n"
+"可以消除部分轉換至 8 位元時產生的斷階\n"
+"尤其是對天空使用「漸層濾鏡」模組或漸層遮罩時"
 
 #. add the preset.
 #: ../src/iop/dither.c:131
 msgid "dither"
-msgstr "抖動(不連續色調混色)"
+msgstr "遞色抖動"
 
 #: ../src/iop/dither.c:885
 msgid "radius for blurring step"
@@ -15109,7 +15783,7 @@ msgstr "模糊半徑"
 
 #: ../src/iop/dither.c:897
 msgid "the gradient range where to apply random dither"
-msgstr "套用隨機抖動的漸層範圍"
+msgstr "隨機遞色的漸層範圍"
 
 #: ../src/iop/dither.c:898
 msgid "gradient range"
@@ -15117,24 +15791,26 @@ msgstr "漸層範圍"
 
 #: ../src/iop/dither.c:906
 msgid "damping level of random dither"
-msgstr "隨機抖動的阻尼值"
+msgstr "隨機遞色的阻尼強度"
 
 #: ../src/iop/dual_demosaic.c:50
 msgid "[dual demosaic] can't allocate internal buffers"
-msgstr "[雙重去馬賽克] 無法配置內部緩衝區"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"雙重去馬賽克無法配置內部緩衝區"
 
 #: ../src/iop/equalizer.c:89
 msgid "legacy equalizer"
-msgstr "舊版均衡器"
+msgstr "傳統等化器"
 
 #: ../src/iop/equalizer.c:110
 msgid ""
 "this module is deprecated. better use contrast equalizer module instead."
-msgstr "此模組已棄用。最好改用‘對比度均衡器’模組。"
+msgstr "此模組已被汰除，建議使用「對比度等化器」模組替代"
 
 #: ../src/iop/equalizer.c:306
 msgid "sharpen (strong)"
-msgstr "銳利化(強)"
+msgstr "銳利化（強）"
 
 #: ../src/iop/equalizer.c:316
 msgctxt "equalizer"
@@ -15143,11 +15819,11 @@ msgstr "銳利化"
 
 #: ../src/iop/equalizer.c:322
 msgid "null"
-msgstr "null"
+msgstr "無"
 
 #: ../src/iop/equalizer.c:342
 msgid "denoise (strong)"
-msgstr "降噪(強)"
+msgstr "除雜訊（強）"
 
 #: ../src/iop/equalizer.c:351
 msgid ""
@@ -15155,32 +15831,36 @@ msgid ""
 "and is only here so you can switch it off\n"
 "and move to the new equalizer."
 msgstr ""
-"此模組未來將被移除\n"
-"建議不使用該模組\n"
-"改用新的均衡器。"
+"此模組未來將被汰除\n"
+"建議關閉此模組，並使用新的等化器"
 
 #: ../src/iop/exposure.c:129
 msgid ""
 "redo the exposure of the shot as if you were still in-camera\n"
 "using a color-safe brightening similar to increasing ISO setting"
 msgstr ""
-"如同在相機內一樣，使用保色亮化以重做影像曝光\n"
-"類似增加相機內的ISO設定"
+"曝光 | exposure\n"
+"\n"
+"增加或減少影像的整體亮度\n"
+"保持色彩同時調整亮度，就如同在相機裡調整感光度設定\n"
+"有手動和自動模式，自動模式特別適用縮時攝影一致化亮度"
 
 #: ../src/iop/exposure.c:264
 msgid "magic lantern defaults"
-msgstr "魔燈預設值"
+msgstr "Magic Lantern 魔燈預設值"
 
 #: ../src/iop/exposure.c:305 ../src/iop/rawoverexposed.c:135
 #: ../src/iop/rawoverexposed.c:254
 #, c-format
 msgid "failed to get raw buffer from image `%s'"
-msgstr "無法從影像“%s”獲得 RAW 緩衝區"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"無法從影像「%s」取得 RAW 緩衝區"
 
 #: ../src/iop/exposure.c:564
 #, no-c-format
 msgid "compensate camera exposure (%+.1f EV)"
-msgstr "補償相機曝光(%+.1f EV)"
+msgstr "補償相機曝光（%+.1f EV）"
 
 #: ../src/iop/exposure.c:739
 #, c-format
@@ -15197,27 +15877,29 @@ msgid ""
 "automatically remove the camera exposure bias\n"
 "this is useful if you exposed the image to the right."
 msgstr ""
-"自動消除相機曝光偏差\n"
-"如果使用向右曝光，將非常有用。"
+"自動取消相機曝光補償設定\n"
+"這對遵循向右曝光（Exposing To The Right）的影像非常有用"
 
 #: ../src/iop/exposure.c:1043
 #, no-c-format
 msgid "where in the histogram to meter for deflicking. E.g. 50% is median"
-msgstr "定義直方圖中用於去閃光的量測數值。例如:設爲 50% 則爲中位數"
+msgstr ""
+"定義目標曝光在直方圖中的位置\n"
+"直方圖中高於此值的像素曝光高於目標，設爲 50% 代表中位數"
 
 #: ../src/iop/exposure.c:1048
 msgid ""
 "where to place the exposure level for processed pics, EV below overexposure."
-msgstr "設定處理照片時不過曝的曝光級數(EV)。"
+msgstr "上項百分位數對應的曝光，數值代表相對於過曝白點的曝光級數（EV）"
 
 #: ../src/iop/exposure.c:1051
 msgid "computed EC: "
-msgstr "計算曝光補償(EC): "
+msgstr "曝光補償："
 
 #. This gets filled in by process
 #: ../src/iop/exposure.c:1053
 msgid "what exposure correction has actually been used"
-msgstr "實際套用的曝光修正"
+msgstr "實際套用的曝光校正數值"
 
 #: ../src/iop/exposure.c:1070
 msgid ""
@@ -15226,14 +15908,12 @@ msgid ""
 "if poorly set, it will clip near-black colors out of gamut\n"
 "by pushing RGB values into negatives."
 msgstr ""
-"調整黑色階以恢復超出色域的負 RGB 值。\n"
-"你不應該用它來增加黑階密度！\n"
-"如果設定不當，它會將 RGB 值計為負數\n"
-"以從色域中裁剪接近黑色的顏色."
+"調整黑點以保留負的 RGB 值，不應用此設定來增加黑色濃度\n"
+"如果設定不當將會把近黑點的顏色推出色域，並造成 RGB 負值"
 
 #: ../src/iop/exposure.c:1080
 msgid "spot exposure mapping"
-msgstr "點曝光映射"
+msgstr "點測光曝光對應"
 
 #: ../src/iop/exposure.c:1084
 msgid ""
@@ -15243,109 +15923,116 @@ msgid ""
 "compensation\n"
 "and can be used to define a target."
 msgstr ""
-"修正:自動調整曝光\n"
-"使得輸入亮度可以對應到目標值\n"
-"測量:只顯示輸入顏色經由曝光補償對應\n"
-"即可用來定義目標值."
+"點測光曝光對應模式用於整批調整同系列的影像曝光\n"
+"依據上方選擇的影像範圍對應目標亮度，然後將此亮度對應至其他影像\n"
+"藉由選擇一系列影像中亮度應保持不變的區域，批次調整多張影像的亮度一致性\n"
+"\n"
+"「測量」模式用於定義所選範圍的亮度目標\n"
+"「校正」模式將亮度目標映射至所選範圍"
 
 #: ../src/iop/exposure.c:1108
 msgid "L : \tN/A"
-msgstr "L : \t不能使用的"
+msgstr "L : \t無"
 
 #: ../src/iop/exposure.c:1123
 msgid "the desired target exposure after mapping"
-msgstr "映射後想要的目標曝光值"
+msgstr "選取範圍要對應的曝光目標"
 
 #: ../src/iop/filmic.c:179
 msgid "this module is deprecated. better use filmic rgb module instead."
-msgstr "此模組已棄用，請改用“filmic RGB”模組。"
+msgstr "此模組已被汰除，建議使用「電影式階調映射」模組替代"
 
 #: ../src/iop/filmic.c:306
 msgid "09 EV (low-key)"
-msgstr "09 EV(暗調)"
+msgstr "  9 EV（低反差）"
 
 #: ../src/iop/filmic.c:314
 msgid "10 EV (indoors)"
-msgstr "10 EV(室內)"
+msgstr "10 EV（室內）"
 
 #: ../src/iop/filmic.c:322
 msgid "11 EV (dim outdoors)"
-msgstr "11 EV(昏暗的戶外)"
+msgstr "11 EV（戶外陰天）"
 
 #: ../src/iop/filmic.c:330
 msgid "12 EV (outdoors)"
-msgstr "12 EV(戶外)"
+msgstr "12 EV（戶外）"
 
 #: ../src/iop/filmic.c:338
 msgid "13 EV (bright outdoors)"
-msgstr "13 EV(明亮的戶外)"
+msgstr "13 EV（戶外烈日)"
 
 #: ../src/iop/filmic.c:346
 msgid "14 EV (backlighting)"
-msgstr "14 EV(背光)"
+msgstr "14 EV（背光）"
 
 #: ../src/iop/filmic.c:354
 msgid "15 EV (sunset)"
-msgstr "15 EV(日落)"
+msgstr "15 EV（日落）"
 
 #: ../src/iop/filmic.c:362
 msgid "16 EV (HDR)"
-msgstr "16 EV(HDR)"
+msgstr "16 EV（HDR）"
 
 #: ../src/iop/filmic.c:370
 msgid "18 EV (HDR++)"
-msgstr "18 EV(HDR++)"
+msgstr "18 EV（HDR++）"
 
 #: ../src/iop/filmic.c:1585
 msgid "read-only graph, use the parameters below to set the nodes"
-msgstr "唯讀圖表，使用以下參數來設定節點"
+msgstr "唯讀圖表，使用下方參數來設定節點"
 
 #: ../src/iop/filmic.c:1589
 msgid "logarithmic shaper"
-msgstr "對數整形器"
+msgstr "對數調整器"
 
 #: ../src/iop/filmic.c:1597
 msgid ""
 "adjust to match the average luminance of the subject.\n"
 "except in back-lighting situations, this should be around 18%."
 msgstr ""
-"調整以匹配主體的平均亮度。\n"
-"除了在背光的情況下，此值應該18%左右。"
+"藉由指定場景的中灰色階，來改變整體的平均亮度\n"
+"如果畫面中有標準灰卡等標的物，可使用右側的色彩選取工具圈選範圍自動設定\n"
+"此參數的效果類似於曝光調整，修改之後白點曝光和黑點曝光會自動相應調整\n"
+"一般建議在較早期的「曝光」模組調整亮度，所以此滑桿預設為隱藏"
 
-#: ../src/iop/filmic.c:1608 ../src/iop/filmicrgb.c:4228
+#: ../src/iop/filmic.c:1608 ../src/iop/filmicrgb.c:4229
 msgid ""
 "number of stops between middle gray and pure white.\n"
 "this is a reading a lightmeter would give you on the scene.\n"
 "adjust so highlights clipping is avoided"
 msgstr ""
-"中間灰和純白色之間的曝光階數。\n"
-"此為拍攝現場使用的測光表讀數。\n"
-"調整以避免高光過曝"
+"白點和中灰色階之間的曝光差異級數\n"
+"超過此設定數值的場景動態範圍會被裁切，並映射為純白色\n"
+"降低數值獲得更大的對比，或是調高數值保留更多亮部細節\n"
+"可在拍攝現場以測光表測量，或使用右側顏色選取工具\n"
+"自動設定選取範圍內的最亮點為映射後的純白色點"
 
-#: ../src/iop/filmic.c:1620 ../src/iop/filmicrgb.c:4238
+#: ../src/iop/filmic.c:1620 ../src/iop/filmicrgb.c:4239
 msgid ""
 "number of stops between middle gray and pure black.\n"
 "this is a reading a lightmeter would give you on the scene.\n"
 "increase to get more contrast.\n"
 "decrease to recover more details in low-lights."
 msgstr ""
-"中間灰和純黑色之間的曝光階數。\n"
-"此為拍攝現場使用的測光表讀數。\n"
-"增加:以獲得更大對比。\n"
-"降低:以恢復低光照區域的細節。"
+"黑點和中灰色階之間的曝光差異級數\n"
+"低於此設定數值的場景動態範圍會被裁切，並映射為純黑色\n"
+"提高數值獲得更大的對比，或是降低數值保留更多暗部細節\n"
+"可在拍攝現場以測光表測量，或使用右側顏色選取工具\n"
+"自動設定選取範圍內的最暗點為映射後的純黑色點"
 
 #: ../src/iop/filmic.c:1631
 msgid ""
 "enlarge or shrink the computed dynamic range.\n"
 "useful in conjunction with \"auto tune levels\"."
 msgstr ""
-"放大或縮小計算的動態範圍。\n"
-"與“自動調整色階”一同使用非常有用。"
+"放大或縮小動態範圍\n"
+"與「自動調整階調」功能結合使用時很有用處"
 
-#: ../src/iop/filmic.c:1637 ../src/iop/filmicrgb.c:4251
-#: ../src/iop/filmicrgb.c:4254 ../src/iop/profile_gamma.c:667
+#: ../src/iop/filmic.c:1637 ../src/iop/filmicrgb.c:4252
+#: ../src/iop/filmicrgb.c:4255 ../src/iop/profile_gamma.c:667
 msgid "auto tune levels"
-msgstr "自動調整色階"
+msgstr "自動調整階調"
 
 #: ../src/iop/filmic.c:1639
 msgid ""
@@ -15354,24 +16041,23 @@ msgid ""
 "works better for landscapes and evenly-lit pictures\n"
 "but fails for high-keys and low-keys."
 msgstr ""
-"嘗試不同設定以優化設置。\n"
-"這將使亮度範圍符合直方圖的界限。\n"
-"對風景畫和光線均勻的照片效果較好，但對高色調和暗調的照片則無效。"
+"透過選取區域內的亮度自動設定動態範圍\n"
+"適合風景和亮度均勻分布的影像，但不適用於高亮或低亮場景"
 
 #: ../src/iop/filmic.c:1644
 msgid "filmic S curve"
-msgstr "軟片 S 曲線"
+msgstr "電影 S 曲線"
 
-#: ../src/iop/filmic.c:1651 ../src/iop/filmicrgb.c:4340
+#: ../src/iop/filmic.c:1651 ../src/iop/filmicrgb.c:4341
 msgid ""
 "slope of the linear part of the curve\n"
 "affects mostly the mid-tones"
 msgstr ""
-"曲線線性部分的斜率\n"
-"主要影響中間調"
+"控制曲線中間線性部分的斜率，主要影響中間調\n"
+"數值越大對比越高，以補償大動態範圍映射後的平淡影像"
 
 #. geotagging
-#: ../src/iop/filmic.c:1658 ../src/iop/filmicrgb.c:4349
+#: ../src/iop/filmic.c:1658 ../src/iop/filmicrgb.c:4350
 #: ../src/libs/metadata_view.c:157
 msgid "latitude"
 msgstr "緯度"
@@ -15382,24 +16068,22 @@ msgid ""
 "increase to get more contrast at the extreme luminances.\n"
 "this has no effect on mid-tones."
 msgstr ""
-"曲線中間的線性域寬度。\n"
-"增加:以在極亮下獲得更多對比度。\n"
-"這對中間調沒有影響。"
+"曲線中間的線性區段的長度\n"
+"調高可保留更多區域的整體對比，對大多數中間調沒有影響"
 
 #: ../src/iop/filmic.c:1668
 msgid "shadows/highlights balance"
-msgstr "陰影/高光平衡"
+msgstr "暗部 / 亮部平衡"
 
-#: ../src/iop/filmic.c:1671 ../src/iop/filmicrgb.c:4360
+#: ../src/iop/filmic.c:1671 ../src/iop/filmicrgb.c:4361
 msgid ""
 "slides the latitude along the slope\n"
 "to give more room to shadows or highlights.\n"
 "use it if you need to protect the details\n"
 "at one extremity of the histogram."
 msgstr ""
-"沿坡度滑動緯度。\n"
-"給陰影或高光部份更多空間。\n"
-"使用它，如果需要在直方圖一端保護其細節。"
+"調整由緯度定義的亮度範圍位置，以避免在暗部或亮部任一端發生裁切\n"
+"沿著中間斜率左右調整位置，不讓亮部和暗部線段觸底"
 
 #: ../src/iop/filmic.c:1681
 msgid ""
@@ -15407,8 +16091,8 @@ msgid ""
 "you need to set this value below 100%\n"
 "if the chrominance preservation is enabled."
 msgstr ""
-"對此模組的輸入進行全局去飽和。\n"
-"如果啓用了色度保護，則需要將此值設置爲低於100%。"
+"對輸入顏色執行整體去飽和度\n"
+"如果啟用了保留色度，此值設定需要低於 100%"
 
 #: ../src/iop/filmic.c:1691
 msgid ""
@@ -15416,15 +16100,15 @@ msgid ""
 "specifically at extreme luminances.\n"
 "decrease if shadows and/or highlights are over-saturated."
 msgstr ""
-"特別是在極端的亮度下，去模組的輸出飽和度。\n"
-"降低:如果陰影和/或高光部分過飽和。"
+"降低輸出顏色飽和度，尤其是在極亮暗部的範圍\n"
+"如果啟用了保留色度，此值設定需要低於 100%"
 
 #: ../src/iop/filmic.c:1701 ../src/libs/export.c:1257
 #: ../src/libs/print_settings.c:2324 ../src/libs/print_settings.c:2650
-#: ../src/views/darkroom.c:2452 ../src/views/lighttable.c:1154
+#: ../src/views/darkroom.c:2453 ../src/views/lighttable.c:1154
 #: ../src/views/lighttable.c:1161
 msgid "intent"
-msgstr "意圖"
+msgstr "轉換方式"
 
 #: ../src/iop/filmic.c:1702
 msgid "contrasted"
@@ -15433,7 +16117,7 @@ msgstr "對比"
 #. cubic spline
 #: ../src/iop/filmic.c:1703
 msgid "faded"
-msgstr "逐漸消失"
+msgstr "褪色"
 
 #. centripetal spline
 #: ../src/iop/filmic.c:1704 ../src/iop/profile_gamma.c:629
@@ -15443,16 +16127,16 @@ msgstr "線性"
 #. monotonic spline
 #: ../src/iop/filmic.c:1705
 msgid "optimized"
-msgstr "優化"
+msgstr "最佳化"
 
 #: ../src/iop/filmic.c:1707
 msgid "change this method if you see reversed contrast or faded blacks"
-msgstr "更改此方法設定，如果你看到相反的對比度或褪色的黑色"
+msgstr "如果發現對比度反轉或黑色變淡，請改變這個設定"
 
 #. Preserve color
 #: ../src/iop/filmic.c:1711
 msgid "preserve the chrominance"
-msgstr "保持色度"
+msgstr "保留色度"
 
 #: ../src/iop/filmic.c:1713
 msgid ""
@@ -15460,37 +16144,42 @@ msgid ""
 "may reinforce chromatic aberrations.\n"
 "you need to manually tune the saturation when using this mode."
 msgstr ""
-"確認保原始顏色得到保留。\n"
-"可能會加強色差。\n"
-"使用此模式時，需要手動調整飽和度。"
+"確保原始色彩被保留\n"
+"可能會因此增強色像差，使用此模式需要手動調整飽和度"
 
 #: ../src/iop/filmic.c:1723
 msgid "destination/display"
-msgstr "目的地/顯示器"
+msgstr "目的地 / 顯示"
 
-#: ../src/iop/filmic.c:1741 ../src/iop/filmicrgb.c:4379
+#: ../src/iop/filmic.c:1741 ../src/iop/filmicrgb.c:4380
 msgid ""
 "luminance of output pure black, this should be 0%\n"
 "except if you want a faded look"
-msgstr "輸出純黑色的亮度應為 0%，除非希望產生褪色效果"
+msgstr ""
+"映射後的純黑點亮度值，參數會自動調整以符合工作空間，通常不需要調整此設定\n"
+"預設為輸出色彩空間可用編碼位數的最小非零值，以避免裁切任何階調\n"
+"手動調降至 0 確保純黑，但可能失去極細微的階調\n"
+"調高數值把黑點變灰，會進一步壓縮動態範圍，創造復古的外觀"
 
-#: ../src/iop/filmic.c:1750 ../src/iop/filmicrgb.c:4386
+#: ../src/iop/filmic.c:1750 ../src/iop/filmicrgb.c:4387
 msgid ""
 "middle gray value of the target display or color space.\n"
 "you should never touch that unless you know what you are doing."
 msgstr ""
-"目標顯示或顏色空間的中間灰度值。\n"
-"請勿更改此數值，除非你知道自己在做什麼。"
+"目的地或顯示空間的中灰色亮度\n"
+"背後運算自動經過伽馬校正，除非了解數值背後含意，否則不應該更動設定"
 
-#: ../src/iop/filmic.c:1759 ../src/iop/filmicrgb.c:4393
+#: ../src/iop/filmic.c:1759 ../src/iop/filmicrgb.c:4394
 msgid ""
 "luminance of output pure white, this should be 100%\n"
 "except if you want a faded look"
-msgstr "輸出純白色的亮度應為 0%，除非希望產生褪色效果"
+msgstr ""
+"映射後的純白點亮度值，預設使用 100%，通常不需要調整\n"
+"調降數值會導致沒有白點的褪色復古外觀"
 
 #: ../src/iop/filmic.c:1765
 msgid "target gamma"
-msgstr "目標伽馬"
+msgstr "目標伽瑪值"
 
 #: ../src/iop/filmic.c:1767
 msgid ""
@@ -15498,16 +16187,16 @@ msgid ""
 "of the display or color space.\n"
 "you should never touch that unless you know what you are doing."
 msgstr ""
-"顯示或顏色空間的傳輸函數乘方或伽馬。\n"
-"請勿更改此數值，除非你知道自己在做什麼。"
+"螢幕或色彩空間的轉移函數\n"
+"除非你了解其中含意，否則不應任意更改此數值"
 
 #: ../src/iop/filmicrgb.c:342
 msgid "filmic rgb"
-msgstr "filmic RGB"
+msgstr "電影式階調映射"
 
 #: ../src/iop/filmicrgb.c:347
 msgid "tone mapping|curve|view transform|contrast|saturation|highlights"
-msgstr "色調映射|曲線|視角轉換|對比度|飽和度|高光"
+msgstr "曲線|對比度|飽和度|亮部|暗部|filmicrgb"
 
 #: ../src/iop/filmicrgb.c:352
 msgid ""
@@ -15515,34 +16204,43 @@ msgid ""
 "for display on SDR screens and paper prints\n"
 "while preventing clipping in non-destructive ways"
 msgstr ""
-"套用視角變換，以將場景化管線的輸出顯示到 SDR 屏幕或列印至紙張，\n"
-"同時以無損方式防止產生剪裁"
+"電影式階調映射 | filmic rgb\n"
+"\n"
+"以電影調色的邏輯重新映射拍攝場景的整體亮度範圍\n"
+"模組作用和階調曲線類似，但在完整的場景動態範圍中運作\n"
+"可拓展或壓縮動態範圍，同時保護中間調的對比，並防止破壞性裁切動態範圍\n"
+"建議由左至右調整「場景」→「外觀」→「顯示」三個主要選項\n"
+"雖然模組介面看似複雜，但建議直接以肉眼觀看調整效果評估參數是最好的方法"
 
 #: ../src/iop/filmicrgb.c:1212
 msgid ""
 "filmic highlights reconstruction failed to allocate memory, check your RAM "
 "settings"
-msgstr "filmic 高光重建未能配置記憶體，請檢查 RAM 設定"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"「電影式階調映射」無法配置記憶體，請檢查記憶體設定"
 
 #: ../src/iop/filmicrgb.c:1844 ../src/iop/filmicrgb.c:2133
 msgid "filmic works only on RGB input"
-msgstr "filmic 僅適用於 RGB 輸入"
+msgstr "「電影式階調映射」只適用於 RGB 影像"
 
 #: ../src/iop/filmicrgb.c:1988
 msgid "filmic highlights reconstruction failed to allocate memory on GPU"
-msgstr "filmic 高光重建未能在 GPU 上分配記憶體"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"「電影式階調映射」無法配置顯示卡記憶體"
 
 #: ../src/iop/filmicrgb.c:3232
 msgid "look only"
-msgstr "僅外觀"
+msgstr "示意圖"
 
 #: ../src/iop/filmicrgb.c:3234
 msgid "look + mapping (lin)"
-msgstr "外觀 + 映射(線性)"
+msgstr "線性映射圖"
 
 #: ../src/iop/filmicrgb.c:3236
 msgid "look + mapping (log)"
-msgstr "外觀 + 映射(對數)"
+msgstr "對數映射圖"
 
 #: ../src/iop/filmicrgb.c:3238
 msgid "dynamic range mapping"
@@ -15551,24 +16249,24 @@ msgstr "動態範圍映射"
 #: ../src/iop/filmicrgb.c:3605
 #, c-format
 msgid "(%.0f %%)"
-msgstr "(%.0f %%)"
+msgstr "(%.0f %%）"
 
 #: ../src/iop/filmicrgb.c:3621
 #, no-c-format
 msgid "% display"
-msgstr "% 顯示"
+msgstr "輸出數值（%）"
 
 #: ../src/iop/filmicrgb.c:3633
 msgid "EV scene"
-msgstr "EV 值場景"
+msgstr "場景亮度（EV）"
 
 #: ../src/iop/filmicrgb.c:3637
 #, no-c-format
 msgid "% camera"
-msgstr "% 相機"
+msgstr "相機數值（%）"
 
 #. Page DISPLAY
-#: ../src/iop/filmicrgb.c:3673 ../src/iop/filmicrgb.c:4373
+#: ../src/iop/filmicrgb.c:3673 ../src/iop/filmicrgb.c:4374
 msgid "display"
 msgstr "顯示"
 
@@ -15585,7 +16283,7 @@ msgstr "場景"
 #. axis legend
 #: ../src/iop/filmicrgb.c:3700
 msgid "(EV)"
-msgstr "(曝光值)"
+msgstr "(EV)"
 
 #. we are over the graph area
 #: ../src/iop/filmicrgb.c:4129
@@ -15594,13 +16292,19 @@ msgid ""
 "the bright curve is the filmic tone mapping curve\n"
 "the dark curve is the desaturation curve."
 msgstr ""
-"使用以下參數設定節點。\n"
-"亮曲線是軟片色調映射曲線。\n"
-"暗曲線是去飽和曲線。"
+"圖表僅作為觀看用途無法直接操作，由下方參數調整來變更設定\n"
+"白線表示場景的動態範圍如何映射成輸出的數值\n"
+"橘色點代表中灰色位置，兩側的白點標示中間調對比度不變區域\n"
+"若底部或頂部曲線顯示為橘色，代表有階調反轉問題\n"
+"灰色線顯示飽和度在極端亮暗部中降低的趨勢，此線條在新版 V6 中不顯示\n"
+"\n"
+"在映射圖表中，由於可以處理來自相機的原始曝光資料和高動態範圍\n"
+"橫座標實際上是無界的，為了易於和標準動態範圍的圖表比較所以僅顯示至 100%\n"
+"真正的純白點數值以 (XXX %) 顯示在座標軸最大值 100 的下方"
 
 #: ../src/iop/filmicrgb.c:4135
 msgid "toggle axis labels and values display"
-msgstr "切換軸標籤和值顯示"
+msgstr "顯示或隱藏座標軸標題與數值"
 
 #: ../src/iop/filmicrgb.c:4139
 msgid ""
@@ -15609,30 +16313,34 @@ msgid ""
 "right click: cycle backward.\n"
 "double-click: reset to look view."
 msgstr ""
-"循環切換圖表的視角。\n"
-"左鍵單擊:循環前進。\n"
-"右鍵單擊:循環向後。\n"
-"雙擊:重置爲查看視角。"
+"循環瀏覽顯示圖表類別\n"
+"僅示意圖 ↔ 線性映射圖 ↔ 對數映射圖 ↔ 動態範圍映射\n"
+"左鍵：向右循環，右鍵：向左循環，雙擊：重設\n"
+"\n"
+"「僅示意圖」最適合一般編輯使用，易於瞭解階調映射狀況\n"
+"「動態範圍映射」概念取自安瑟‧亞當斯的分區曝光系統"
 
-#: ../src/iop/filmicrgb.c:4218
+#: ../src/iop/filmicrgb.c:4219
+#, no-c-format
 msgid ""
 "adjust to match the average luminance of the image's subject.\n"
 "the value entered here will then be remapped to 18.45%.\n"
 "decrease the value to increase the overall brightness."
 msgstr ""
-"調整以匹配影像題材的平均亮度。\n"
-"此處輸入的值將重新映射爲18.45%。\n"
-"減小該值可增加整體亮度。"
+"藉由指定場景的中灰色階，來改變整體的平均亮度\n"
+"如果畫面中有標準灰卡等標的物，可使用右側的色彩選取工具圈選範圍自動設定\n"
+"此參數的效果類似於曝光調整，修改之後白點曝光和黑點曝光會自動相應調整\n"
+"一般建議在較早期的「曝光」模組調整亮度，所以此滑桿預設為隱藏"
 
-#: ../src/iop/filmicrgb.c:4246
+#: ../src/iop/filmicrgb.c:4247
 msgid ""
 "symmetrically enlarge or shrink the computed dynamic range.\n"
 "useful to give a safety margin to extreme luminances."
 msgstr ""
-"對稱地放大或縮小計算動態範圍。\n"
-"有助於爲極端亮度提供安全邊界。"
+"對稱性地同時擴張或縮減目前的黑白點相對曝光設定數值\n"
+"有助於為極端的亮度提供安全剩餘量，或是修改自動階調的效果"
 
-#: ../src/iop/filmicrgb.c:4256
+#: ../src/iop/filmicrgb.c:4257
 msgid ""
 "try to optimize the settings with some statistical assumptions.\n"
 "this will fit the luminance range inside the histogram bounds.\n"
@@ -15641,22 +16349,25 @@ msgid ""
 "this is not an artificial intelligence, but a simple guess.\n"
 "ensure you understand its assumptions before using it."
 msgstr ""
-"嘗試使用一些統計假設來優化設定。\n"
-"這將符合直方圖界限內的亮度範圍。\n"
-"適用於風景和光線均勻的圖片，但不適用於高光調、暗調和高ISO圖片。\n"
-"這不是人工智能，而是簡單的推測。\n"
-"確認在使用之前瞭解這些假設。"
+"結合黑點和白點的曝光設定，設定選取範圍內最暗點為黑色，最亮點為白色\n"
+"適合亮度分布均勻的影像，例如戶外風景照片，但室內非控光場景通常效果不佳\n"
+"這類似於自動色階功能，請勿誤解為人工智慧最佳化設定\n"
+"\n"
+"⚠️ 注意 ⚠️\n"
+"此模組中的動態範圍（純白至純黑曝光的 EV）不代表感光元件的性能\n"
+"在此模組運作之前影像已經過許多處理步驟，使其在理論上可能擁有更高的動態範圍\n"
+"這僅是因為在軟體中的編碼和運算結果，與實際的感光元件性能無關"
 
 #. Page RECONSTRUCT
-#: ../src/iop/filmicrgb.c:4265
+#: ../src/iop/filmicrgb.c:4266
 msgid "reconstruct"
 msgstr "重建"
 
-#: ../src/iop/filmicrgb.c:4267
+#: ../src/iop/filmicrgb.c:4268
 msgid "highlights clipping"
-msgstr "高光剪裁"
+msgstr "亮部剪裁"
 
-#: ../src/iop/filmicrgb.c:4273
+#: ../src/iop/filmicrgb.c:4274
 msgid ""
 "set the exposure threshold upon which\n"
 "clipped highlights get reconstructed.\n"
@@ -15665,32 +16376,29 @@ msgid ""
 "decrease to include more areas,\n"
 "increase to exclude more areas."
 msgstr ""
-"設定曝光臨界值。\n"
-"被裁剪的高光得到重建。\n"
-"數值是相對於場景白點。\n"
-"0 EV表示臨界值與場景白點相同。\n"
-"減少以包含更多區域，\n"
-"增加以排除更多區域。"
+"設置曝光臨界值，超過此值的像素會被重建亮部計算影響\n"
+"數值相對於場景白點，0 EV 表示臨界值與白點相同\n"
+"預設數值為 +3 EV，實際上代表幾乎沒有亮部重建效果，讓使用者視情況開啟\n"
+"建議開啟右下方的遮罩檢視，然後逐步降低參數值至可以看見要重建的區域"
 
-#: ../src/iop/filmicrgb.c:4283
+#: ../src/iop/filmicrgb.c:4284
 msgid ""
 "soften the transition between clipped highlights and valid pixels.\n"
 "decrease to make the transition harder and sharper,\n"
 "increase to make the transition softer and blurrier."
 msgstr ""
-"柔化被裁剪高光和有效像素之間的過渡。\n"
-"減少以使過渡更加強烈和銳利，\n"
-"增加以使過渡更加柔和和模糊。"
+"柔化要被重建的裁切亮部和有效亮度之間的過渡\n"
+"向右移動滑桿增加數值使過渡更柔和，反之讓過渡更快速"
 
-#: ../src/iop/filmicrgb.c:4289 ../src/iop/filmicrgb.c:4290
+#: ../src/iop/filmicrgb.c:4290 ../src/iop/filmicrgb.c:4291
 msgid "display highlight reconstruction mask"
-msgstr "顯示高光重建遮罩"
+msgstr "顯示亮部重建遮罩"
 
-#: ../src/iop/filmicrgb.c:4297 ../src/iop/splittoning.c:527
+#: ../src/iop/filmicrgb.c:4298 ../src/iop/splittoning.c:527
 msgid "balance"
 msgstr "平衡"
 
-#: ../src/iop/filmicrgb.c:4304
+#: ../src/iop/filmicrgb.c:4305
 #, no-c-format
 msgid ""
 "decide which reconstruction strategy to favor,\n"
@@ -15700,13 +16408,13 @@ msgid ""
 "increase if at least one RGB channel is not clipped.\n"
 "decrease if all RGB channels are clipped over large areas."
 msgstr ""
-"決定使用哪種重建策略\n"
-"介於重建平滑的顏色漸層或試圖恢復紋理細節之間。\n"
-"0%是兩者的相等混合。\n"
-"增加:如果至少有一個RGB通道未被裁剪。\n"
-"減小:如果所有RGB通道有大面積被裁剪。"
+"控制亮部重建的策略，在平滑的色彩和恢復紋理細節之間調整\n"
+"如果重建區域大部分三個色版都過曝被裁切，則偏向使用色塊設定\n"
+"因為已經沒有任何可供重建亮部區域的細節\n"
+"若是大部分區域只有一至兩個色版被裁切，則可以偏向紋理的設定\n"
+"未剪裁的色版可能有一些細節可以用來重建其他色版"
 
-#: ../src/iop/filmicrgb.c:4315
+#: ../src/iop/filmicrgb.c:4316
 #, no-c-format
 msgid ""
 "decide which reconstruction strategy to favor,\n"
@@ -15716,13 +16424,11 @@ msgid ""
 "increase if you want more details.\n"
 "decrease if you want more blur."
 msgstr ""
-"決定偏好哪種重建策略\n"
-"介於像軟片一樣的高光光暈或者試圖恢復銳利細節之間。\n"
-"0%是兩者的相等混合。\n"
-"增加:如果你想要更多細節。\n"
-"減少:如果你想要更多朦朧。"
+"控制亮部重建的策略，在朦朧模糊和銳利清晰之間調整\n"
+"預設 100% 會盡量試圖重建亮部裁切範圍中的細節\n"
+"0% 代表均衡設定，調至負值套用類似傳統底片的光暈模糊效果"
 
-#: ../src/iop/filmicrgb.c:4327
+#: ../src/iop/filmicrgb.c:4328
 #, no-c-format
 msgid ""
 "decide which reconstruction strategy to favor,\n"
@@ -15732,162 +16438,187 @@ msgid ""
 "increase if you want more color.\n"
 "decrease if you see magenta or out-of-gamut highlights."
 msgstr ""
-"決定偏好哪種重建策略:\n"
-"介於恢復單色高光或嘗試恢復多彩高光之間。\n"
-"0%是兩者的相等混合。\n"
-"增加:如果你想要更多的顏色。\n"
-"減少:如果你看到洋紅或色域外的高光。"
+"控制亮部重建的策略，在修復灰階或重建亮部色彩之間調整\n"
+"希望亮部中有更多的色彩則增加數值，若出現洋紅偽色則降低數值"
 
 #. Page LOOK
-#: ../src/iop/filmicrgb.c:4335
+#: ../src/iop/filmicrgb.c:4336
 msgid "look"
 msgstr "外觀"
 
-#: ../src/iop/filmicrgb.c:4345
+#: ../src/iop/filmicrgb.c:4346
 msgid ""
 "equivalent to paper grade in analog.\n"
 "increase to make highlights brighter and less compressed.\n"
 "decrease to mute highlights."
 msgstr ""
-"相當於類比的紙張等級。\n"
-"增加:以使高光更亮和更少壓縮。\n"
-"減少:以減少高光。"
+"輸出的冪函數設定，通常被（錯誤地）直接稱為伽瑪\n"
+"用於提升或壓縮中間色調，類似傳統暗房相紙的號數\n"
+"增加以提升亮部並減少階調壓縮，降低以消減亮部並壓縮暗部\n"
+"此設定預設自動依動態範圍調整並隱藏，關閉自動調整曲線硬度以顯示此滑桿"
 
-#: ../src/iop/filmicrgb.c:4353
+#: ../src/iop/filmicrgb.c:4354
 msgid ""
 "width of the linear domain in the middle of the curve,\n"
 "increase to get more contrast and less desaturation at extreme luminances,\n"
 "decrease otherwise. no desaturation happens in the latitude range.\n"
 "this has no effect on mid-tones."
 msgstr ""
-"曲線中間的線性區域寬度，\n"
-"增加:在極端亮度下，可獲得更高的對比度和更少的去飽和，。\n"
-"減小:則相反，在緯度範圍內不會發生去飽和現象。\n"
-"這對中間調沒有影響。"
+"曲線中兩個白點之間的線性區段的長度\n"
+"數值定義是白點減去黑點的動態範圍的百分比\n"
+"調高可保留更多區域的整體對比，並減少去飽和的效果範圍\n"
+"一般建議使用更大的數值，若出現曲線反轉或裁切再加以調整\n"
+"例如藉由調整上方的「對比」或下方「陰影 ↔ 亮部平衡」"
 
-#: ../src/iop/filmicrgb.c:4368 ../src/iop/filmicrgb.c:4511
+#: ../src/iop/filmicrgb.c:4369 ../src/iop/filmicrgb.c:4514
 msgid ""
 "desaturates the output of the module\n"
 "specifically at extreme luminances.\n"
 "increase if shadows and/or highlights are under-saturated."
 msgstr ""
-"在極端亮度下降低模組輸出的飽和度，\n"
-"增加:如果陰影或高光是飽和度不足。"
+"由於此模組會自動調降接近全黑和全白的像素飽和度\n"
+"以便顏色漸層更自然地融入全黑和全白點中\n"
+"如果覺得亮暗部的色彩飽和度不足，可以嘗試調高此值"
 
 #. Page OPTIONS
-#: ../src/iop/filmicrgb.c:4397
+#: ../src/iop/filmicrgb.c:4398
 msgid "options"
 msgstr "選項"
 
-#: ../src/iop/filmicrgb.c:4402
+#: ../src/iop/filmicrgb.c:4403
 msgid ""
 "v3 is darktable 3.0 desaturation method, same as color balance.\n"
 "v4 is a newer desaturation method, based on spectral purity of light."
 msgstr ""
-"v3 是 darktable 3.0 去飽和方法，和色彩平衡相同。\n"
-"v4 是一種新的去飽和方法，基於光的光譜純度。"
+"模組的色彩映射方式，以及極端亮暗部的自然去飽和方式\n"
+"新開啟的影像預設使用最新的 V6 方式，仍保留舊版算法以向下相容"
 
-#: ../src/iop/filmicrgb.c:4406
+#: ../src/iop/filmicrgb.c:4407
 msgid ""
-"ensure the original color are preserved.\n"
+"ensure the original colors are preserved.\n"
 "may reinforce chromatic aberrations and chroma noise,\n"
-"so ensure they are properly corrected elsewhere.\n"
+"so ensure they are properly corrected elsewhere."
 msgstr ""
-"確認原始顏色得到保留。\n"
-"可能會加強色差和色度噪音。\n"
-"請確認它們在其他地方得到適當的修正。\n"
+"選擇要如何處理映射後色彩變更的問題，並試圖保留原始色彩\n"
+"不同影像和色彩空間會有不同結果，建議自己嘗試後決定效果最好的設定\n"
+"\n"
+"否：\n"
+"這是大部分軟體的運作方式，不考慮 RGB 色板之間的比率\n"
+"這會讓暗部更飽和但降低亮部的飽和度，在有色域外的藍色或紅色時會很有幫助\n"
+"\n"
+"RGB 最大值：\n"
+"模組預設值，偏向降低藍色的亮度，並讓局部對比度變小\n"
+"容易在天空產生光暈或斷階，尤其是在某些色板被裁切時\n"
+"\n"
+"亮度：\n"
+"依亮度 Y 來調整，往往會使紅色變暗，並傾向增加局部對比度\n"
+"在高飽和度或是超出色域的藍色中表現不佳\n"
+"\n"
+"RGB 乘冪範數：\n"
+"使用 RGB 的立方和除以平方和加權計算，通常是良好的折衷算法\n"
+"效果介於「亮度」和「RGB 最大值」之間\n"
+"\n"
+"RGB 歐基里德距離：\n"
+"以 RGB 的幾何距離計算加權，因此工作間為何都能得到一致的效果\n"
+"與「RGB 乘冪範數」相比，對亮部去飽和度更明顯，可能是最接近底片外觀的方法\n"
+"\n"
+"RGB 歐基里德距離（舊版）：\n"
+"使用 RGB 的立方和除以平方和加權計算，通常是良好的折衷算法"
 
-#: ../src/iop/filmicrgb.c:4412
+#: ../src/iop/filmicrgb.c:4413
 msgid ""
 "choose the desired curvature of the filmic spline in highlights.\n"
 "hard uses a high curvature resulting in more tonal compression.\n"
 "soft uses a low curvature resulting in less tonal compression."
 msgstr ""
-"選擇所需的軟片曲線曲率應用到高光區中。\n"
-"‘強烈’使用高曲率，產生更多的色調壓縮。\n"
-"‘柔和’使用低曲率，從而減少色調壓縮。"
+"選擇階調映射曲線的亮部曲率\n"
+"預設「安全」避免不會產生階調反轉，但相對較柔和且對比度低\n"
+"選擇「強烈」增加曲率和色調壓縮程度，「柔和」則反之"
 
-#: ../src/iop/filmicrgb.c:4417
+#: ../src/iop/filmicrgb.c:4418
 msgid ""
 "choose the desired curvature of the filmic spline in shadows.\n"
 "hard uses a high curvature resulting in more tonal compression.\n"
 "soft uses a low curvature resulting in less tonal compression."
 msgstr ""
-"選擇所需的軟片曲線曲率應用到陰影區中。\n"
-"‘強烈:使用高曲率，產生更多的色調壓縮。\n"
-"‘柔和:使用低曲率，從而減少色調壓縮。"
+"選擇階調映射曲線的暗部曲率\n"
+"預設「安全」避免不會產生階調反轉，但相對較柔和且對比度低\n"
+"選擇「強烈」增加曲率和色調壓縮程度，「柔和」則反之"
 
-#: ../src/iop/filmicrgb.c:4422
-#, c-format
+#: ../src/iop/filmicrgb.c:4425
+#, no-c-format
 msgid ""
 "enable to input custom middle-gray values.\n"
 "this is not recommended in general.\n"
 "fix the global exposure in the exposure module instead.\n"
-"disable to use standard 18.45 %% middle gray."
+"disable to use standard 18.45% middle gray."
 msgstr ""
-"啟用可輸入自定義中間灰色值。\n"
-"一般不建議調整此值，應使用曝光模組以修正全局曝光。\n"
-"不啟用此選項則使用標準 18.45 %% 中間灰。"
+"開啟場景中的中灰亮度，以及顯示中的輸出中灰色亮度控制滑桿\n"
+"目前已不推薦使用此模組這樣操作，建議使用「曝光」模組來調整中灰亮度\n"
+"因此預設不啟用此選項，並且使用標準的 18.45 % 中間灰"
 
-#: ../src/iop/filmicrgb.c:4429
+#: ../src/iop/filmicrgb.c:4432
 msgid ""
 "enable to auto-set the look hardness depending on the scene white and black "
 "points.\n"
 "this keeps the middle gray on the identity line and improves fast tuning.\n"
 "disable if you want a manual control."
 msgstr ""
-"啓用此選項以根據場景的白點和黑點自動設定外觀強烈度。\n"
-"這將使中間灰色保持在識別線上，並改進快速調整。\n"
-"不使用:如果需要手動控制。"
+"開啟外觀中的冪函數曲線硬度滑桿，以自行控制輸出曲線伽瑪值\n"
+"預設啟用此設定，以便自動計算最適合的函數參數"
 
-#: ../src/iop/filmicrgb.c:4435
+#: ../src/iop/filmicrgb.c:4438
 msgid ""
 "run extra passes of chromaticity reconstruction.\n"
 "more iterations means more color propagation from neighbourhood.\n"
 "this will be slower but will yield more neutral highlights.\n"
 "it also helps with difficult cases of magenta highlights."
 msgstr ""
-"進行額外的色度重建。\n"
-"更多的迭代意味着更多的顏色從鄰域傳播。\n"
-"這將會變慢，但會產生更多的中和高光。\n"
-"它也有助於解決洋紅高光的疑難問題。"
+"增加亮部重建的額外計算次數，以取得更多周圍像素的色彩訊息\n"
+"預設重建算法只單獨計算 RGB 色版一次，高品質迭代算法使用 RGB 比例和多次計算\n"
+"可能可以產生更自然的亮部外觀，但也會降低運算速度\n"
+"若有明顯的色版裁切造成洋紅色光點，使用此功能可能會有幫助\n"
+"但如果迭代次數過多，亮部重建可能會導致遠處的顏色被不正確地引入到光點中"
 
-#: ../src/iop/filmicrgb.c:4442
+#: ../src/iop/filmicrgb.c:4445
 msgid ""
 "add statistical noise in reconstructed highlights.\n"
 "this avoids highlights to look too smooth\n"
 "when the picture is noisy overall,\n"
 "so they blend with the rest of the picture."
 msgstr ""
-"在重建的高光中增加統計噪點。\n"
-"這樣可以避免高光看起來過於平滑，\n"
-"當圖片整體有噪點時，它們會與圖片的其他部分混合。"
+"在重建的亮部中添加人造雜訊\n"
+"這樣可使亮部看起來和其他區域更接近，避免過度平滑的不自然感"
 
-#: ../src/iop/filmicrgb.c:4449
+#: ../src/iop/filmicrgb.c:4452
 msgid ""
 "choose the statistical distribution of noise.\n"
 "this is useful to match natural sensor noise pattern.\n"
 msgstr ""
-"選擇噪點的統計分佈。\n"
-"這有助於匹配自然傳感器噪點樣式。\n"
+"選擇加入亮部雜訊的分布模式\n"
+"帕松分布通常最接近感光元件的原始雜訊分布模式，高斯分布更像是類比底片\n"
+"但大多數除雜訊功能的模組會把帕松分布的雜訊轉變為更接近高斯分布\n"
+"應該選擇能夠更好地融入影像中實際雜訊外觀的選項，以自然融入原始影像\n"
 
-#: ../src/iop/filmicrgb.c:4517
+#: ../src/iop/filmicrgb.c:4520
 msgid "mid-tones saturation"
-msgstr "中間調飽和度"
+msgstr "中間調的飽和度"
 
-#: ../src/iop/filmicrgb.c:4518
+#: ../src/iop/filmicrgb.c:4521
 msgid ""
 "desaturates the output of the module\n"
 "specifically at medium luminances.\n"
 "increase if midtones are under-saturated."
 msgstr ""
-"在中亮度下降低模組輸出的飽和度\n"
-"增加如果中階調是飽和度不足。"
+"由於此模組會自動調降接近全黑和全白的像素飽和度\n"
+"以便顏色漸層更自然地融入全黑和全白點中\n"
+"中間色調在同時也會受到一部分去飽和度影響，可使用此設定補償飽和度\n"
+"如果中間調的色彩飽和度不足，可以嘗試調高此值"
 
 #: ../src/iop/finalscale.c:39
 msgctxt "modulename"
 msgid "scale into final size"
-msgstr "縮放到最終大小"
+msgstr "調整到最終尺寸"
 
 #: ../src/iop/flip.c:79
 msgid "rotation|flip"
@@ -15895,7 +16626,12 @@ msgstr "旋轉|翻轉"
 
 #: ../src/iop/flip.c:105
 msgid "flip or rotate image by step of 90 degrees"
-msgstr "以 90 度爲單位翻轉或旋轉影像"
+msgstr ""
+"方向 | orientation\n"
+"\n"
+"旋轉影像或水平 / 垂直翻轉\n"
+"此模組預設開啟，並依據 EXIF 資料自動設定\n"
+"模組設定和燈箱模式下的影像旋轉控制連動"
 
 #: ../src/iop/flip.c:421 ../src/iop/flip.c:423
 msgid "autodetect"
@@ -15919,7 +16655,7 @@ msgstr "旋轉 -90 度"
 
 #: ../src/iop/flip.c:442
 msgid "rotate by  90 degrees"
-msgstr "旋轉  90 度"
+msgstr "旋轉 90 度"
 
 #: ../src/iop/flip.c:446
 msgid "rotate by 180 degrees"
@@ -15944,93 +16680,105 @@ msgstr "顯示編碼"
 
 #: ../src/iop/globaltonemap.c:100
 msgid "global tonemap"
-msgstr "全局色調映射"
+msgstr "整體階調映射"
 
 #: ../src/iop/globaltonemap.c:105
 msgid "this module is deprecated. please use the filmic rgb module instead."
-msgstr "此模組已棄用，請改用filmic RGB 模組。"
+msgstr "此模組已被汰除，建議使用「電影式階調映射」模組替代"
 
 #: ../src/iop/globaltonemap.c:637 ../src/libs/filters/colors.c:259
 msgid "operator"
-msgstr "操作"
+msgstr "操作方式"
 
 #: ../src/iop/globaltonemap.c:638
 msgid "the global tonemap operator"
-msgstr "全域色調映射操作"
+msgstr ""
+"選擇映射使用的運算方式\n"
+"依據所選的方式會有不同的可調參數"
 
 #: ../src/iop/globaltonemap.c:641
 msgid ""
 "the bias for tonemapper controls the linearity, the higher the more details "
 "in blacks"
-msgstr "色調映射器的偏差爲線性，越高則越多細節位於黑色區域"
+msgstr "控制階調映射的線性度，影響影像的對比，數值越高暗部中的細節越多"
 
 #: ../src/iop/globaltonemap.c:645
 msgid "the target light for tonemapper specified as cd/m2"
-msgstr "色調映射器的目標光單位爲 cd/m2"
+msgstr "階調映射的明度單位為 cd/m2"
 
 #: ../src/iop/graduatednd.c:71
 msgid "neutral gray ND2 (soft)"
-msgstr "中性灰 ND2(軟)"
+msgstr "軟調中性灰 ND2"
 
 #: ../src/iop/graduatednd.c:74
 msgid "neutral gray ND4 (soft)"
-msgstr "中性灰 ND4(軟)"
+msgstr "軟調中性灰 ND4"
 
 #: ../src/iop/graduatednd.c:77
 msgid "neutral gray ND8 (soft)"
-msgstr "中性灰 ND8(軟)"
+msgstr "軟調中性灰 ND8"
 
 #: ../src/iop/graduatednd.c:80
 msgid "neutral gray ND2 (hard)"
-msgstr "中性灰 ND2(硬)"
+msgstr "硬調中性灰 ND2"
 
 #: ../src/iop/graduatednd.c:84
 msgid "neutral gray ND4 (hard)"
-msgstr "中性灰 ND4(硬)"
+msgstr "硬調中性灰 ND4"
 
 #: ../src/iop/graduatednd.c:87
 msgid "neutral gray ND8 (hard)"
-msgstr "中性灰 ND8(硬)"
+msgstr "硬調中性灰 ND8"
 
 #: ../src/iop/graduatednd.c:91
 msgid "orange ND2 (soft)"
-msgstr "橘色 ND2(軟)"
+msgstr "軟調橘色 ND2"
 
 #: ../src/iop/graduatednd.c:94
 msgid "yellow ND2 (soft)"
-msgstr "黃色 ND2(黃)"
+msgstr "軟調黃色 ND2"
 
 #: ../src/iop/graduatednd.c:98
 msgid "purple ND2 (soft)"
-msgstr "紫色 ND2(軟)"
+msgstr "軟調紫色 ND2"
 
 #: ../src/iop/graduatednd.c:102
 msgid "green ND2 (soft)"
-msgstr "綠色 ND2(軟)"
+msgstr "軟調綠色 ND2"
 
 #: ../src/iop/graduatednd.c:106
 msgid "red ND2 (soft)"
-msgstr "紅色 ND2(軟)"
+msgstr "軟調紅色 ND2"
 
 #: ../src/iop/graduatednd.c:109
 msgid "blue ND2 (soft)"
-msgstr "藍色 ND2(軟)"
+msgstr "軟調藍色 ND2"
 
 #: ../src/iop/graduatednd.c:113
 msgid "brown ND4 (soft)"
-msgstr "灰色 ND4(軟)"
+msgstr "軟調褐色 ND4"
 
 #: ../src/iop/graduatednd.c:144
 msgid "graduated density"
-msgstr "漸層密度"
+msgstr "漸層濾鏡"
 
 #: ../src/iop/graduatednd.c:149
 msgid "simulate an optical graduated neutral density filter"
-msgstr "模擬光學漸層減光鏡"
+msgstr ""
+"漸層濾鏡 | graduated density\n"
+"\n"
+"模擬漸層減光鏡的效果\n"
+"影像上會顯示一條線以直覺地使用滑鼠控制濾鏡位置和角度\n"
+"此模組可能讓天空產生斷階，可使用「遞色」模組來減緩問題"
 
 #: ../src/iop/graduatednd.c:1099
 msgid "the density in EV for the filter"
-msgstr "濾鏡的密度(EV)"
+msgstr ""
+"漸層濾鏡的濃度\n"
+"+1 EV = ND2\n"
+"+2 EV = ND4\n"
+"+3 EV = ND8\n"
+"+6 EV = ND64"
 
 #: ../src/iop/graduatednd.c:1104
 #, no-c-format
@@ -16038,79 +16786,101 @@ msgid ""
 "hardness of graduation:\n"
 "0% = soft, 100% = hard"
 msgstr ""
-"漸層強度:\n"
-"0% = 柔和, 100% = 強烈"
+"漸層濾鏡濃度漸變的平滑度\n"
+"0% 代表最柔和，100% 代表最強烈"
 
 #: ../src/iop/graduatednd.c:1108
 msgid "rotation of filter -180 to 180 degrees"
-msgstr "濾鏡可旋轉角度 -180 至 180度"
+msgstr ""
+"漸層濾鏡的旋轉角度\n"
+"可以直接拖動影像上的直線和端點來改變位置與角度\n"
+"直線兩側箭頭代表濾鏡濃度較低的方向"
 
 #: ../src/iop/graduatednd.c:1121
 msgid "select the hue tone of filter"
-msgstr "選擇濾鏡的色相調"
+msgstr ""
+"漸層濾鏡的顏色\n"
+"可使用右側色彩選取工具從影像中選擇，會一次設定色相和飽和度"
 
 #: ../src/iop/graduatednd.c:1127
 msgid "select the saturation of filter"
-msgstr "選擇濾鏡的飽和度"
+msgstr ""
+"漸層濾鏡顏色的飽和度\n"
+"預設值 0 代表中性灰漸層濾鏡"
 
 #: ../src/iop/graduatednd.c:1138
 #, c-format
 msgid "[%s on nodes] change line rotation"
-msgstr "[節點上 %s] 更改線旋轉角度"
+msgstr "節點 %s：改變濾鏡角度"
 
 #: ../src/iop/graduatednd.c:1139
 #, c-format
 msgid "[%s on line] move line"
-msgstr "[線上 %s] 移動直線"
+msgstr "線條 %s：移動濾鏡位置"
 
 #: ../src/iop/graduatednd.c:1141
 #, c-format
 msgid "[%s on line] change density"
-msgstr "[線上 %s] 更改密度"
+msgstr "線條 %s：改變濾鏡密度"
 
 #: ../src/iop/graduatednd.c:1143
 #, c-format
 msgid "[%s on line] change hardness"
-msgstr "[線上 %s] 更改硬度"
+msgstr "線條 %s：改變濾鏡平滑度"
 
 #: ../src/iop/grain.c:419
 msgid "grain"
-msgstr "顆粒"
+msgstr "底片顆粒"
 
 #: ../src/iop/grain.c:424
 msgid "simulate silver grains from film"
-msgstr "模擬電影的銀鹽顆粒效果"
+msgstr ""
+"底片顆粒 | grain\n"
+"\n"
+"模擬底片的顆粒效果\n"
+"顆粒在 Lab 空間的 L* 中進行運算"
 
 #: ../src/iop/grain.c:568
 msgid "the grain size (~ISO of the film)"
-msgstr "顆粒大小(約等於軟片的 ISO 感光度)"
+msgstr "模擬不同感光度的底片顆粒大小"
 
 #: ../src/iop/grain.c:572
 msgid "the strength of applied grain"
-msgstr "套用顆粒的強度"
+msgstr "底片顆粒效果的明顯程度"
 
 #: ../src/iop/grain.c:576
 msgid ""
 "amount of mid-tones bias from the photographic paper response modeling. the "
 "greater the bias, the more pronounced the fall off of the grain in shadows "
 "and highlights"
-msgstr "通過相紙反應建模模擬中間調偏差。偏差越大，陰影和高光中的顆粒弱化越明顯"
+msgstr ""
+"利用相紙的曝光與顯影反應模擬顆粒分布\n"
+"數值越大，顆粒越集中於中間調，暗部和亮部的顆粒變少\n"
+"也可以使用色版遮罩做更精細的控制"
 
 #: ../src/iop/hazeremoval.c:100
 msgid "haze removal"
-msgstr "去朦朧"
+msgstr "去除霧霾"
 
 #: ../src/iop/hazeremoval.c:106
 msgid "dehaze|defog|smoke|smog"
-msgstr "去朦朧|去霧|加煙|加霧"
+msgstr "除霾|煙霧|水氣"
 
 #: ../src/iop/hazeremoval.c:111
 msgid "remove fog and atmospheric hazing from pictures"
-msgstr "去除圖片中的霧和氣氛朦朧"
+msgstr ""
+"去除霧霾 | haze removal\n"
+"\n"
+"自動降低影像中霧氣和霧霾的影響\n"
+"此模組為每個區域評估漫反射量，然後降低漫射光強度恢復物體顏色\n"
+"也可用於提升影像低對比度區域的色彩飽和度"
 
 #: ../src/iop/hazeremoval.c:202
 msgid "amount of haze reduction"
-msgstr "朦朧減少量"
+msgstr ""
+"去除霧霾量\n"
+"設置到最高時會去除所有設定距離內偵測到的漫射光\n"
+"負值可以反向增加影像中的漫射光，讓影像更朦朧"
 
 #: ../src/iop/hazeremoval.c:204
 msgid "distance"
@@ -16118,71 +16888,122 @@ msgstr "距離"
 
 #: ../src/iop/hazeremoval.c:206
 msgid "limit haze removal up to a specific spatial depth"
-msgstr "將去朦朧限制在特定的空間深度"
-
-#: ../src/iop/highlights.c:141
-msgid "highlight reconstruction"
-msgstr "高光重建"
-
-#: ../src/iop/highlights.c:146
-msgid "avoid magenta highlights and try to recover highlights colors"
-msgstr "避免洋紅色高光，並嘗試恢復高光顏色"
-
-#: ../src/iop/highlights.c:149 ../src/iop/hotpixels.c:75
-msgid "reconstruction, raw"
-msgstr "重建、raw"
-
-#: ../src/iop/highlights.c:2111
-msgid ""
-"highlights: guided laplacian mode not available for X-Trans sensors. falling "
-"back to clip."
-msgstr "高光:對X-Trans 傳感器使用引導拉普拉斯模式不可用時 退回至剪裁."
-
-#: ../src/iop/highlights.c:2184
-msgid "highlight reconstruction method"
-msgstr "高光重建方法"
-
-#: ../src/iop/highlights.c:2189
-msgid ""
-"manually adjust the clipping threshold against magenta highlights\n"
-"the mask icon shows the clipped area\n"
-"(you shouldn't ever need to touch this)"
 msgstr ""
-"對洋紅高光手動調整剪裁臨界值\n"
-"遮罩圖示顯示剪裁區域\n"
-"(你不需改變此值)"
+"限制去除霧霾距離\n"
+"越小的值偵測霧霾的距離越短，設定到最大則會偵測整個影像範圍"
 
-#: ../src/iop/highlights.c:2198
+#: ../src/iop/highlights.c:145
+msgid "highlight reconstruction"
+msgstr "亮部重建"
+
+#: ../src/iop/highlights.c:150
+msgid "avoid magenta highlights and try to recover highlights colors"
+msgstr ""
+"亮部重建 | highlight reconstruction\n"
+"\n"
+"嘗試修復亮點顏色避免過曝區域顯示洋紅色\n"
+"可與「電影式階調映射」的重建功能搭配使用"
+
+#: ../src/iop/highlights.c:153 ../src/iop/hotpixels.c:75
+msgid "reconstruction, raw"
+msgstr "修復、RAW"
+
+#: ../src/iop/highlights.c:2156
+msgid ""
+"highlights: guided laplacian and recovery modes not available for X-Trans "
+"sensors. falling back to clip."
+msgstr ""
+"⚠️ 警告 ⚠️\n"
+"X-Trans 感光元件不適用導引拉普拉斯和亮部修復模式，恢復使用裁切亮部方法"
+
+#: ../src/iop/highlights.c:2200
+msgid "highlights recovery"
+msgstr "亮部修復"
+
+#: ../src/iop/highlights.c:2269
+msgid "highlight reconstruction method"
+msgstr ""
+"選擇亮部重建方式\n"
+"\n"
+"裁切亮部：\n"
+"把所有像素限制為白色，也就是剪裁其他較高的色版資料\n"
+"對於不飽和的自然區域最為實用，例如天空的雲朵\n"
+"\n"
+"LCh 重建亮部\n"
+"使用同組 3 個 Bayer 像素或 8 個 X-Trans 像素來校正被剪裁的像素\n"
+"重建後的亮部仍然沒有色彩，但會比「裁切亮度」更亮，細節更多\n"
+"\n"
+"重建亮部色彩\n"
+"把顏色從未剪裁的區域套用到剪裁的亮部\n"
+"對顏色均勻的區域非常有效，尤其適用於具有平順過曝的皮膚\n"
+"但這方法可能會在高對比邊緣產生偽影，像是背景過曝但前景清楚的髮絲\n"
+"\n"
+"導引拉普拉斯運算\n"
+"使用類似「漫射或反卷積銳化」模組的演算法把細節複製到被裁切的色版\n"
+"這是一種緩慢且耗用大量計算資源的方法，主要用於重建聚光燈和鏡面反射\n"
+"\n"
+"亮部修復\n"
+"最新加入的亮部重建方法，藉由區段分析最適合的修復內容\n"
+"減去相對色版來消除偽色，一般情況下能獲得最好的效果"
+
+#: ../src/iop/highlights.c:2274
+msgid ""
+"manually adjust the clipping threshold mostly used against magenta "
+"highlights\n"
+"the mask icon shows the clipped areas.\n"
+"you might use this for tuning 'laplacian' or 'recovery' modes,\n"
+"especially if camera white point is incorrect."
+msgstr ""
+"手動調整亮部裁切門檻以消除過曝區域的洋紅色色偏\n"
+"右側遮罩按鈕可顯示目前被裁切的影像範圍\n"
+"可以用此參數微調拉普拉斯或亮部修復模式，尤其是當相機白點錯誤時"
+
+#: ../src/iop/highlights.c:2284
 msgid ""
 "add noise to visually blend the reconstructed areas\n"
 "into the rest of the noisy image. useful at high ISO."
 msgstr ""
-"增加雜訊以視覺化的將重建區域\n"
-"與其餘的雜訊影像混合 對於高iso有用."
+"在被剪裁重建的亮部區域加入帕松分布的雜訊\n"
+"效果和感光元件中的雜訊類似，以塑造更為自然的視覺效果"
 
-#: ../src/iop/highlights.c:2202
+#: ../src/iop/highlights.c:2288
 msgid ""
 "increase if magenta highlights don't get fully corrected\n"
 "each new iteration brings a performance penalty."
 msgstr ""
-"增加如果洋紅高光沒有完全修正\n"
-"每次新迭代會帶來效能損失."
+"每次的導引拉普拉斯計算都可改進前一次的效果\n"
+"如果剪裁亮點無法完全修復可以調高此值，但相對地犧牲處理速度"
 
-#: ../src/iop/highlights.c:2207
+#: ../src/iop/highlights.c:2293
 msgid ""
 "increase if magenta highlights don't get fully corrected.\n"
 "this may produce non-smooth boundaries between valid and clipped regions."
 msgstr ""
-"增加如果洋紅高光沒有完全修正\n"
-"可能產生有效及剪裁區域間的不平滑邊界."
+"利用平滑 RGB 比例來恢復亮部顏色，調高數值以消除難以處理的洋紅色澤\n"
+"然而這會使重建不太準確，可能導致正常及裁切區域間的不平滑邊界"
 
-#: ../src/iop/highlights.c:2211
+#: ../src/iop/highlights.c:2297
 msgid ""
 "increase to correct larger clipped areas.\n"
 "large values bring huge performance penalties"
 msgstr ""
-"增加以修正較大的剪裁區域\n"
-"大數值帶來巨大效能損失"
+"調整導引拉普拉斯運算的尺度，建議設定被剪裁區域的兩倍大小\n"
+"越大的數值將造成速度明顯變慢，並可能導致錯誤的色彩滲入重建區域中\n"
+"如果有多個裁切區域尺寸不一，建議利用多個模組實例並配合遮罩使用"
+
+#: ../src/iop/highlights.c:2302
+msgid "combine closely related clipped segments by morphological operations."
+msgstr "藉由型態分析組合密切相關的剪切分段"
+
+#: ../src/iop/highlights.c:2309
+msgid ""
+"dealing with isolated clipped segments in dark regions.\n"
+"increase to favour candidates found in segmentation analysis,\n"
+"decrease for simple inpainting.\n"
+msgstr ""
+"調整如何處理暗部的孤立剪切分段\n"
+"提高數值有利於納入更多候選片段\n"
+"調低數值使用單純的修復\n"
 
 #: ../src/iop/highpass.c:75
 msgid "highpass"
@@ -16190,11 +17011,15 @@ msgstr "高通濾鏡"
 
 #: ../src/iop/highpass.c:80
 msgid "isolate high frequencies in the image"
-msgstr "分離出影像中的高頻"
+msgstr ""
+"高通濾鏡 | highpass\n"
+"\n"
+"分離出影像中的高頻訊號（細節）\n"
+"主要用於與混合模式搭配使用創造特殊效果"
 
 #: ../src/iop/highpass.c:82 ../src/iop/lowpass.c:134
 msgid "linear or non-linear, Lab, scene-referred"
-msgstr "線性或非線性、Lab、場景工作流程"
+msgstr "線性或非線性、Lab、場景參照"
 
 #: ../src/iop/highpass.c:83 ../src/iop/lowpass.c:135 ../src/iop/sharpen.c:96
 msgid "frequential, Lab"
@@ -16202,7 +17027,7 @@ msgstr "頻率、Lab"
 
 #: ../src/iop/highpass.c:84 ../src/iop/lowpass.c:136
 msgid "special, Lab, scene-referred"
-msgstr "特殊、Lab、場景工作流程"
+msgstr "特殊、Lab、場景參照"
 
 #: ../src/iop/highpass.c:396
 msgid "the sharpness of highpass filter"
@@ -16214,46 +17039,50 @@ msgstr "高通濾鏡的對比度"
 
 #: ../src/iop/hotpixels.c:67
 msgid "hot pixels"
-msgstr "熱像素"
+msgstr "去除熱壞點"
 
 #: ../src/iop/hotpixels.c:72
 msgid "remove abnormally bright pixels by dampening them with neighbours"
-msgstr "通過用相鄰的像素來消除異常明亮的像素"
+msgstr ""
+"去除熱壞點 | hot pixels\n"
+"\n"
+"自動偵測和消除可能的熱壞點\n"
+"以相鄰的像素平均來替換異常過亮的像素"
 
 #: ../src/iop/hotpixels.c:364
 #, c-format
 msgid "fixed %d pixel"
 msgid_plural "fixed %d pixels"
-msgstr[0] "修復 %d 個像素"
+msgstr[0] "修復 %d 個壞點"
 
 #: ../src/iop/hotpixels.c:387
 msgid "lower threshold for hot pixel"
-msgstr "降低熱像素的臨界值"
+msgstr "設定像素的值偏離其周邊像素多少才被視為熱壞點"
 
 #: ../src/iop/hotpixels.c:391
 msgid "strength of hot pixel correction"
-msgstr "熱像素修正強度"
+msgstr "調整熱壞點的校正強度，代表其與周邊像素的平均權重"
 
 #: ../src/iop/hotpixels.c:407
 msgid ""
 "hot pixel correction\n"
 "only works for raw images."
 msgstr ""
-"熱像素修正\n"
-"只作用於RAW影像。"
+"⚠️ 錯誤 ⚠️\n"
+"「去除熱壞點」僅適用於 RAW 檔"
 
 #: ../src/iop/invert.c:95 ../src/iop/invert.c:527
 #, c-format
 msgid "`%s' color matrix not found for 4bayer image"
-msgstr "未找到 4bayer 影像的“%s”顏色矩陣"
+msgstr "找不到 4bayer 影像的色彩模型「%s」"
 
 #: ../src/iop/invert.c:111
 msgid "invert"
-msgstr "反轉"
+msgstr "色調反轉"
 
 #: ../src/iop/invert.c:116
 msgid "this module is deprecated. please use the negadoctor module instead."
-msgstr "此模組已棄用。請改用 負片博士(negadoctor) 模組。"
+msgstr "此模組已被汰除，建議使用「負片反轉」模組替代"
 
 #: ../src/iop/invert.c:121
 msgid "invert film negatives"
@@ -16261,25 +17090,27 @@ msgstr "反轉負片"
 
 #: ../src/iop/invert.c:123 ../src/iop/invert.c:125
 msgid "linear, raw, display-referred"
-msgstr "線性、raw、顯示工作流程"
+msgstr "線性、RAW、顯示參照"
 
 #. Here we could provide more for monochrome special cases. As no monochrome camera
 #. has a bayer sensor we don't need g->RGB_to_CAM and g->CAM_to_RGB corrections
 #: ../src/iop/invert.c:512
 msgid "brightness of film material"
-msgstr "軟片材料亮度"
+msgstr "片基的亮度"
 
 #: ../src/iop/invert.c:516
 msgid "color of film material"
-msgstr "軟片材料顏色"
+msgstr "片基的顏色"
 
 #: ../src/iop/invert.c:600 ../src/iop/negadoctor.c:820
 msgid "pick color of film material from image"
-msgstr "從影像中選取軟片材料的顏色"
+msgstr ""
+"從影像上選取底片片基的顏色\n"
+"點擊色彩選取從影像上拖曳選取一塊未曝光的區域，以下參數會自動計算完成"
 
 #: ../src/iop/invert.c:602
 msgid "select color of film material"
-msgstr "選擇軟片材料顏色"
+msgstr "選擇底片片基的顏色"
 
 #: ../src/iop/lens.cc:148
 msgid "lens correction"
@@ -16287,15 +17118,21 @@ msgstr "鏡頭校正"
 
 #: ../src/iop/lens.cc:153
 msgid "vignette|chromatic aberrations|distortion"
-msgstr "漸暈|色差|失真"
+msgstr ""
+"暗角|色像差|變形|失光|vignette|chromatic aberrations|distortion|lensfun"
 
 #: ../src/iop/lens.cc:158
 msgid "correct lenses optical flaws"
-msgstr "修正鏡片光學缺陷"
+msgstr ""
+"鏡頭校正 | lens correction\n"
+"\n"
+"自動修正鏡頭的變形、暗角、橫向色差等光學缺陷\n"
+"使用 EXIF 資料辨識相機和鏡頭型號，並自動取得 lensfun 校正參數\n"
+"如果 lensfun 資料庫中沒有你的鏡頭，請考慮成為資料貢獻者"
 
 #: ../src/iop/lens.cc:161
 msgid "geometric and reconstruction, RGB"
-msgstr "幾何與重建、RGB"
+msgstr "幾何與修復、RGB"
 
 #: ../src/iop/lens.cc:1587
 #, c-format
@@ -16305,14 +17142,16 @@ msgid ""
 "mount:\t\t%s\n"
 "crop factor:\t%.1f"
 msgstr ""
-"製造商:\t%s\n"
-"型號:\t\t%s%s\n"
-"掛載:\t\t%s\n"
-"裁切因子:\t%.1f"
+"品牌： %s\n"
+"型號： %s%s\n"
+"接環： %s\n"
+"裁切係數： %.1fx"
 
 #: ../src/iop/lens.cc:1768
 msgid "camera/lens not found"
-msgstr "未找到相機/鏡頭"
+msgstr ""
+"⚠️ 警告 ⚠️\n"
+"找不到相機和鏡頭的資料"
 
 #: ../src/iop/lens.cc:1769
 msgid ""
@@ -16320,8 +17159,8 @@ msgid ""
 "you might also want to check if your lensfun database is up-to-date\n"
 "by running lensfun_update_data"
 msgstr ""
-"請手動選擇您的鏡頭\n"
-"您也可以執行 lensfun_update_data 檢查 lensfun 資料庫是否是最新"
+"無法自動偵測鏡頭型號，請手動選擇\n"
+"並請檢查 lensfun 資料庫是否為最新版本"
 
 #: ../src/iop/lens.cc:1871
 #, c-format
@@ -16334,17 +17173,17 @@ msgid ""
 "type:\t\t%s\n"
 "mounts:\t%s"
 msgstr ""
-"製造商:\t%s\n"
-"型號:\t\t%s\n"
-"對焦範圍:\t%s\n"
-"光圈:\t\t%s\n"
-"裁切因子:\t%.1f\n"
-"類型:\t\t%s\n"
-"掛載:\t\t%s"
+"品牌： %s\n"
+"型號： %s\n"
+"焦距： %s\n"
+"光圈： %s\n"
+"裁切： %.1fx\n"
+"類型： %s\n"
+"接環： %s"
 
 #: ../src/iop/lens.cc:1917
 msgid "focal length (mm)"
-msgstr "鏡頭焦距 (mm)"
+msgstr "鏡頭焦距（mm）"
 
 #: ../src/iop/lens.cc:1941
 msgid "f/"
@@ -16352,31 +17191,31 @@ msgstr "f/"
 
 #: ../src/iop/lens.cc:1942
 msgid "f-number (aperture)"
-msgstr "f 值(光圈)"
+msgstr "f 值（光圈）"
 
 #: ../src/iop/lens.cc:1956
 msgid "d"
-msgstr "d"
+msgstr "距離"
 
 #: ../src/iop/lens.cc:1957
 msgid "distance to subject"
-msgstr "到主體的距離"
+msgstr "相機到主體的對焦距離"
 
 #: ../src/iop/lens.cc:2280
 msgid "distortion & TCA"
-msgstr "失真和橫向色差"
+msgstr "變形和橫向色差"
 
 #: ../src/iop/lens.cc:2286
 msgid "distortion & vignetting"
-msgstr "失真和漸暈"
+msgstr "變形和暗角"
 
 #: ../src/iop/lens.cc:2292
 msgid "TCA & vignetting"
-msgstr "橫向色差和漸暈"
+msgstr "橫向色差和暗角"
 
 #: ../src/iop/lens.cc:2298
 msgid "only distortion"
-msgstr "僅失真"
+msgstr "僅變形"
 
 #: ../src/iop/lens.cc:2304
 msgid "only TCA"
@@ -16384,7 +17223,7 @@ msgstr "僅橫向色差"
 
 #: ../src/iop/lens.cc:2310
 msgid "only vignetting"
-msgstr "僅漸暈"
+msgstr "僅暗角"
 
 #: ../src/iop/lens.cc:2320
 msgid "camera model"
@@ -16401,19 +17240,21 @@ msgstr "尋找鏡頭"
 #. Page CORRECTIONS
 #: ../src/iop/lens.cc:2365 ../src/iop/negadoctor.c:873
 msgid "corrections"
-msgstr "修正方式"
+msgstr "修正項目"
 
 #: ../src/iop/lens.cc:2367
 msgid "which corrections to apply"
-msgstr "套用哪個修正"
+msgstr "要套用的校正項目"
 
 #: ../src/iop/lens.cc:2382
 msgid "target geometry"
-msgstr "目標幾何"
+msgstr ""
+"幾何校正方式\n"
+"除了校正鏡頭缺陷外，此模組還可以更改光學投影方式模擬特殊效果"
 
 #: ../src/iop/lens.cc:2383
 msgid "rectilinear"
-msgstr "直線性"
+msgstr "拉直"
 
 #: ../src/iop/lens.cc:2384
 msgid "fish-eye"
@@ -16425,23 +17266,23 @@ msgstr "全景"
 
 #: ../src/iop/lens.cc:2386
 msgid "equirectangular"
-msgstr "等距柱形"
+msgstr "等距長方投影（球形全景圖）"
 
 #: ../src/iop/lens.cc:2388
 msgid "orthographic"
-msgstr "正交"
+msgstr "正投影"
 
 #: ../src/iop/lens.cc:2389
 msgid "stereographic"
-msgstr "立體"
+msgstr "立體投影"
 
 #: ../src/iop/lens.cc:2390
 msgid "equisolid angle"
-msgstr "等立體角度"
+msgstr "等立體角投影"
 
 #: ../src/iop/lens.cc:2391
 msgid "thoby fish-eye"
-msgstr "thoby 魚眼"
+msgstr "河豚魚眼"
 
 #. scale
 #: ../src/iop/lens.cc:2397 ../src/iop/vignette.c:979
@@ -16451,85 +17292,105 @@ msgstr "縮放"
 
 #: ../src/iop/lens.cc:2401
 msgid "auto scale"
-msgstr "自動縮放"
+msgstr ""
+"調整影像的縮放倍率避免校正後出現黑邊\n"
+"使用右側的自動縮放按鈕由 darktable 自動尋找最適合的設定"
 
 #: ../src/iop/lens.cc:2405 ../src/libs/modulegroups.c:2410
 msgid "correct"
-msgstr "修正"
+msgstr "校正"
 
 #: ../src/iop/lens.cc:2406
 msgid "distort"
-msgstr "失真"
+msgstr "變形"
 
 #: ../src/iop/lens.cc:2407
 msgid "correct distortions or apply them"
-msgstr "修正失真或套用它們"
+msgstr ""
+"此模組的預設目的是校正鏡頭缺陷\n"
+"但也可以切換為變形，模擬特定鏡頭的光學變形和色像差效果"
 
 #: ../src/iop/lens.cc:2414
 msgid "Transversal Chromatic Aberration red"
-msgstr "橫向色差紅色"
+msgstr "手動設定紅色橫向色差（red TCA）參數取代鏡頭資料庫數值"
 
 #: ../src/iop/lens.cc:2418
 msgid "Transversal Chromatic Aberration blue"
-msgstr "橫向色差藍色"
+msgstr "手動設定藍色橫向色差（blue TCA）參數取代鏡頭資料庫數值"
 
 #: ../src/iop/lens.cc:2423
 msgid "corrections done: "
-msgstr "已套用修正: "
+msgstr "已校正："
 
 #: ../src/iop/lens.cc:2425
 msgid "which corrections have actually been done"
-msgstr "已經完成的修正"
+msgstr "實際進行了哪些更正"
 
-#: ../src/iop/levels.c:110 ../src/iop/rgblevels.c:994
+#: ../src/iop/levels.c:109 ../src/iop/rgblevels.c:994
 #: ../src/iop/rgblevels.c:1025
 msgid "levels"
 msgstr "色階"
 
-#: ../src/iop/levels.c:130
+#: ../src/iop/levels.c:129
 msgid "adjust black, white and mid-gray points"
-msgstr "調整黑、白和中間灰的的位置"
+msgstr ""
+"色階 | levels\n"
+"\n"
+"調整黑點、白點和中灰點的位置\n"
+"這個模組在 CIELAB 空間中調整 L* 色版\n"
+"需要調整 RGB 色版請使用「RGB 色階」模組"
 
-#: ../src/iop/levels.c:622 ../src/iop/rgblevels.c:1027
+#: ../src/iop/levels.c:621 ../src/iop/rgblevels.c:1027
 msgid ""
 "drag handles to set black, gray, and white points. operates on L channel."
-msgstr "拖拉滑動條以設定黑色、灰色、白色點。 在L通道上操作。"
+msgstr ""
+"拖曳調整黑點、白點和中灰點的位置\n"
+"也可以使用下方色彩選取工具從影像中選取"
 
-#: ../src/iop/levels.c:638 ../src/iop/rgblevels.c:1068
+#: ../src/iop/levels.c:637 ../src/iop/rgblevels.c:1068
 msgid "apply auto levels"
-msgstr "套用自動色階"
+msgstr "偵測影像亮度分布自動調整黑白點位置，並將中灰點置於黑白點正中心"
 
-#: ../src/iop/levels.c:642 ../src/iop/rgblevels.c:1043
+#: ../src/iop/levels.c:641 ../src/iop/rgblevels.c:1043
 msgid "pick black point from image"
-msgstr "從圖片選取黑點"
+msgstr "從影像中選取黑點"
 
-#: ../src/iop/levels.c:646 ../src/iop/rgblevels.c:1049
+#: ../src/iop/levels.c:645 ../src/iop/rgblevels.c:1049
 msgid "pick medium gray point from image"
-msgstr "從圖片選取中灰點"
+msgstr "從影像中選取中灰點"
 
-#: ../src/iop/levels.c:650 ../src/iop/rgblevels.c:1055
+#: ../src/iop/levels.c:649 ../src/iop/rgblevels.c:1055
 msgid "pick white point from image"
-msgstr "從圖片選取白點"
+msgstr "從影像中選取白點"
 
-#: ../src/iop/levels.c:663 ../src/iop/rgblevels.c:946
+#: ../src/iop/levels.c:662 ../src/iop/rgblevels.c:946
 msgid "black"
 msgstr "黑"
 
-#: ../src/iop/levels.c:664
+#: ../src/iop/levels.c:663
 msgid "black percentile"
-msgstr "黑色百分位"
+msgstr ""
+"黑色的百分位數\n"
+"黑點位於直方圖左邊界的位置\n"
+"數值越大會裁減掉越多暗部階調"
 
-#: ../src/iop/levels.c:668
+#: ../src/iop/levels.c:667
 msgid "gray percentile"
-msgstr "灰色百分位"
+msgstr ""
+"中灰點的百分位數\n"
+"黑點和白點調整後，中灰點在直方圖中的相對位置\n"
+"數值越小整體越亮，因越多像素被調整為亮部，反之亦同"
 
-#: ../src/iop/levels.c:671 ../src/iop/rgblevels.c:948
+#: ../src/iop/levels.c:670 ../src/iop/rgblevels.c:948
 msgid "white"
-msgstr "白色"
+msgstr "白"
 
-#: ../src/iop/levels.c:672
+#: ../src/iop/levels.c:671
 msgid "white percentile"
-msgstr "白色百分位"
+msgstr ""
+"白點的百分位數\n"
+"白點位於直方圖左邊界的位置\n"
+"數值越小會裁減掉越多亮部階調"
 
 #: ../src/iop/liquify.c:290
 msgid "liquify"
@@ -16537,7 +17398,13 @@ msgstr "液化"
 
 #: ../src/iop/liquify.c:295
 msgid "distort parts of the image"
-msgstr "扭曲部分影像"
+msgstr ""
+"液化 | liquify\n"
+"\n"
+"自由扭曲變形影像的某些部分\n"
+"液化變形控制基於節點，節點上限為 100 個\n"
+"節點半徑表示變形的範圍，箭頭表示變形方向，箭頭長度代表變形的強度\n"
+"如何操作節點請見影像上方顯示的說明文字"
 
 #: ../src/iop/liquify.c:3598
 msgid ""
@@ -16545,9 +17412,8 @@ msgid ""
 "scroll to change size - shift+scroll to change strength - ctrl+scroll to "
 "change direction"
 msgstr ""
-"單擊並拖拉以增加點\n"
-"滾輪以更改大小\n"
-"shift + 滾輪更改強度，控制鍵 + 滾輪更改方向"
+"點擊並拖曳以增加變形點\n"
+"滑鼠滾輪調整變形範圍，shift + 滾輪調整變形強度，ctrl + 滾輪調整變形方向"
 
 #: ../src/iop/liquify.c:3602
 msgid ""
@@ -16555,9 +17421,8 @@ msgid ""
 "scroll to change size - shift+scroll to change strength - ctrl+scroll to "
 "change direction"
 msgstr ""
-"單擊以增加直線\n"
-"滾輪以更改大小\n"
-"shift + 滾輪更改強度，控制鍵 + 滾輪更改方向"
+"點擊以增加直線變形節點，按右鍵結束\n"
+"滑鼠滾輪調整變形範圍，shift + 滾輪調整變形強度，ctrl + 滾輪調整變形方向"
 
 #: ../src/iop/liquify.c:3606
 msgid ""
@@ -16565,25 +17430,24 @@ msgid ""
 "scroll to change size - shift+scroll to change strength - ctrl+scroll to "
 "change direction"
 msgstr ""
-"單擊以增加曲線\n"
-"滾輪以輪更改大小\n"
-"shift + 滾輪更改強度，控制鍵 + 滾輪更改方向"
+"點擊以增加曲線變形節點，按右鍵結束\n"
+"滑鼠滾輪調整變形範圍，shift + 滾輪調整變形強度，ctrl + 滾輪調整變形方向"
 
 #: ../src/iop/liquify.c:3609
 msgid "click to edit nodes"
-msgstr "單擊以編輯節點"
+msgstr "點擊以編輯節點"
 
 #: ../src/iop/liquify.c:3656
 msgid ""
 "use a tool to add warps.\n"
 "right-click to remove a warp."
 msgstr ""
-"使用工具來增加變形扭曲。\n"
-"右鍵單擊以刪除變形扭曲。"
+"點選要使用的變形工具\n"
+"右鍵點擊影像上的節點可刪除該變形效果"
 
 #: ../src/iop/liquify.c:3659
 msgid "warps|nodes count:"
-msgstr "扭曲|節點計數:"
+msgstr "變形 | 節點數量："
 
 #: ../src/iop/liquify.c:3667
 msgid "edit, add and delete nodes"
@@ -16600,81 +17464,87 @@ msgstr "形狀"
 
 #: ../src/iop/liquify.c:3671
 msgid "draw curves"
-msgstr "繪製曲線"
+msgstr "曲線變形"
 
 #: ../src/iop/liquify.c:3671
 msgid "draw multiple curves"
-msgstr "繪製多條曲線"
+msgstr "連續繪製多條曲線變形"
 
 #: ../src/iop/liquify.c:3675
 msgid "draw lines"
-msgstr "繪製直線"
+msgstr "直線變形"
 
 #: ../src/iop/liquify.c:3675
 msgid "draw multiple lines"
-msgstr "繪製多條直線"
+msgstr "連續繪製多條直線變形"
 
 #: ../src/iop/liquify.c:3679
 msgid "draw points"
-msgstr "繪製點"
+msgstr "點變形"
 
 #: ../src/iop/liquify.c:3679
 msgid "draw multiple points"
-msgstr "繪製多點"
+msgstr "連續繪製多個變形點"
 
 #: ../src/iop/liquify.c:3683
 msgid ""
 "ctrl+click: add node - right click: remove path\n"
 "ctrl+alt+click: toggle line/curve"
 msgstr ""
-"控制鍵 + 單擊:增加節點\n"
-"右鍵單擊:刪除路徑\n"
-"控制鍵 + alt + 單擊:切換直線/曲線"
+"ctrl + 點擊在路徑上增加節點，右鍵刪除整條路徑\n"
+"ctrl + alt + 點擊切換直線或曲線"
 
 #: ../src/iop/liquify.c:3685
 msgid ""
 "click and drag to move - click: show/hide feathering controls\n"
 "ctrl+click: autosmooth, cusp, smooth, symmetrical - right click to remove"
 msgstr ""
-"單擊並拖拉以移動。\n"
-"單擊:顯示/隱藏羽化控件\n"
-"控制鍵 + 單擊:切換自動平滑、尖點、平滑、對稱，單擊右鍵可刪除"
+"拖曳節點以移動，點擊節點顯示羽化半徑，右鍵點擊刪除節點\n"
+"ctrl + 點擊切換節點連接方式（僅限曲線變型有作用）：自動平滑（圓點）、"
+"尖銳轉折（三角形）、手動平滑（菱形）、對稱（方形點）"
 
 #: ../src/iop/liquify.c:3688 ../src/iop/liquify.c:3689
 msgid "drag to change shape of path"
-msgstr "拖拉以更改路徑形狀"
+msgstr "拖曳以改變節點的轉折方向"
 
 #: ../src/iop/liquify.c:3690
 msgid "drag to adjust warp radius"
-msgstr "拖拉以調整扭曲半徑"
+msgstr "拖曳以調整變形半徑"
 
 #: ../src/iop/liquify.c:3691
 msgid "drag to adjust hardness (center)"
-msgstr "拖拉以調整硬度(中央)"
+msgstr "拖曳三角形調整羽化半徑（中心）"
 
 #: ../src/iop/liquify.c:3692
 msgid "drag to adjust hardness (feather)"
-msgstr "拖拉以調整硬度(羽化)"
+msgstr "拖曳三角形調整羽化半徑（外側）"
 
 #: ../src/iop/liquify.c:3693
 msgid ""
 "drag to adjust warp strength\n"
 "ctrl+click: linear, grow, and shrink"
 msgstr ""
-"拖拉以調整扭曲強度\n"
-"控制鍵 + 單擊:在線性、增大和縮小之間切換"
+"拖曳以調整變形強度\n"
+"ctrl + 點擊切換變形方向（通常用於單點變形）：箭頭方向、擴張、內縮"
 
 #: ../src/iop/lmmse_demosaic.c:142
 msgid "[lmmse_demosaic] too small area"
-msgstr "[lmmse_demosaic] 區域太小"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"LMMSE 去馬賽克區域太小"
 
 #: ../src/iop/lowlight.c:86
 msgid "lowlight vision"
-msgstr "低光成像"
+msgstr "夜間視覺"
 
 #: ../src/iop/lowlight.c:91
 msgid "simulate human night vision"
-msgstr "模擬人眼夜視效果"
+msgstr ""
+"夜間視覺 | lowlight vision\n"
+"\n"
+"模擬人眼視桿細胞主導的夜間視覺效果\n"
+"還可用於模擬晝夜混合轉換\n"
+"建議開啟幾個預設集以了解模組的設定方式"
 
 #: ../src/iop/lowlight.c:94
 msgid "linear, XYZ"
@@ -16682,31 +17552,31 @@ msgstr "線性、XYZ"
 
 #: ../src/iop/lowlight.c:342
 msgid "indoor bright"
-msgstr "室內:明亮"
+msgstr "明亮室內"
 
 #: ../src/iop/lowlight.c:360
 msgid "indoor dim"
-msgstr "室內:陰暗"
+msgstr "陰暗室內"
 
 #: ../src/iop/lowlight.c:378
 msgid "indoor dark"
-msgstr "室內:黑暗"
+msgstr "黑暗室內"
 
 #: ../src/iop/lowlight.c:396
 msgid "twilight"
-msgstr "日出/日落"
+msgstr "晨昏"
 
 #: ../src/iop/lowlight.c:414
 msgid "night street lit"
-msgstr "夜景:街燈"
+msgstr "夜晚街燈"
 
 #: ../src/iop/lowlight.c:432
 msgid "night street"
-msgstr "夜景:街道"
+msgstr "夜晚街道"
 
 #: ../src/iop/lowlight.c:450
 msgid "night street dark"
-msgstr "夜景:黑暗街道"
+msgstr "夜晚暗巷"
 
 #: ../src/iop/lowlight.c:469
 msgid "night"
@@ -16718,11 +17588,11 @@ msgstr "黑暗"
 
 #: ../src/iop/lowlight.c:650
 msgid "bright"
-msgstr "亮處"
+msgstr "明亮"
 
 #: ../src/iop/lowlight.c:659
 msgid "day vision"
-msgstr "日間成像"
+msgstr "白天視覺"
 
 #: ../src/iop/lowlight.c:664
 msgid "night vision"
@@ -16730,7 +17600,7 @@ msgstr "夜間視覺"
 
 #: ../src/iop/lowlight.c:851
 msgid "blueness in shadows"
-msgstr "藍色陰影"
+msgstr "在暗部中增加一些藍色調來模擬 Purkinje 效應"
 
 #: ../src/iop/lowpass.c:127
 msgid "lowpass"
@@ -16738,7 +17608,11 @@ msgstr "低通濾鏡"
 
 #: ../src/iop/lowpass.c:132
 msgid "isolate low frequencies in the image"
-msgstr "分離出影像中的低頻資訊"
+msgstr ""
+"低通濾鏡 | lowpass\n"
+"\n"
+"分離出影像中的低頻訊號（色彩）\n"
+"主要用於與混合模式搭配使用創造特殊效果"
 
 #: ../src/iop/lowpass.c:552
 msgid "local contrast mask"
@@ -16746,7 +17620,7 @@ msgstr "局部對比遮罩"
 
 #: ../src/iop/lowpass.c:577
 msgid "radius of gaussian/bilateral blur"
-msgstr "高斯/雙邊模糊半徑"
+msgstr "套用高斯或雙邊濾波器模糊的半徑"
 
 #: ../src/iop/lowpass.c:578
 msgid "contrast of lowpass filter"
@@ -16758,196 +17632,244 @@ msgstr "低通濾鏡的亮度調整"
 
 #: ../src/iop/lowpass.c:580
 msgid "color saturation of lowpass filter"
-msgstr "低通濾鏡的顏色飽和度"
+msgstr "低通濾鏡的飽和度"
 
 #: ../src/iop/lowpass.c:581
 msgid "which filter to use for blurring"
-msgstr "模糊影像的濾鏡"
+msgstr "模糊效果使用的濾鏡"
 
-#: ../src/iop/lut3d.c:133
+#: ../src/iop/lut3d.c:134
 msgid "LUT 3D"
-msgstr "LUT 3D"
+msgstr "立體色彩查找表"
 
-#: ../src/iop/lut3d.c:138
+#: ../src/iop/lut3d.c:139
 msgid "perform color space corrections and apply look"
-msgstr "執行顏色空間修正並套用外觀"
+msgstr ""
+"立體色彩查找表 | LUT 3D\n"
+"\n"
+"載入 LUT 文件轉換 RGB 值以套用色彩外觀\n"
+"通常用於套用底片模擬效果和調色\n"
+"此模組會剪裁亮度範圍至 [0,1]，請確保輸入數據沒有要保留的超出範圍數值"
 
-#: ../src/iop/lut3d.c:141
+#: ../src/iop/lut3d.c:142
 msgid "defined by profile, RGB"
-msgstr "定義RGB配置檔案"
+msgstr "由描述檔定義、RGB"
 
-#: ../src/iop/lut3d.c:466
+#: ../src/iop/lut3d.c:467
 msgid "error allocating buffer for gmz LUT"
-msgstr "無法為gmz LUT配置緩衝區"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"為 gmz LUT 分配緩衝區時出現錯誤"
 
-#: ../src/iop/lut3d.c:492
+#: ../src/iop/lut3d.c:493
 #, c-format
 msgid "invalid png file %s"
-msgstr "無效的png 檔案 %s"
+msgstr "無效的 PNG 檔案「%s」"
 
-#: ../src/iop/lut3d.c:500
+#: ../src/iop/lut3d.c:501
 #, c-format
 msgid "png bit-depth %d not supported"
-msgstr "不支援png位元景深 %d"
+msgstr "不支援 %d 位元的 PNG 檔案"
 
-#: ../src/iop/lut3d.c:514 ../src/iop/lut3d.c:524
+#: ../src/iop/lut3d.c:515 ../src/iop/lut3d.c:525
 #, c-format
 msgid "invalid level in png file %d %d"
-msgstr "png 檔案 %d %d使用了無效色階"
+msgstr "PNG 檔案中的色階 %d %d 無效"
 
-#: ../src/iop/lut3d.c:519
+#: ../src/iop/lut3d.c:520
 msgid "this darktable build is not compatible with compressed CLUT"
-msgstr "此darktable建立版本不相容於壓縮的CLUT"
+msgstr "這個 darktable 版本與壓縮的 CLUT 不相容"
 
-#: ../src/iop/lut3d.c:536 ../src/iop/lut3d.c:785
+#: ../src/iop/lut3d.c:537 ../src/iop/lut3d.c:787
 #, c-format
 msgid "error - LUT 3D size %d exceeds the maximum supported"
-msgstr "錯誤 - LUT 3D 大小 %d 超過可支援的最大值"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"3D LUT 大小 %d 超過上限"
 
-#: ../src/iop/lut3d.c:548
+#: ../src/iop/lut3d.c:549
 msgid "error allocating buffer for png LUT"
-msgstr "錯誤 - 無法為png LUT配置緩衝區"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"分配 PNG LUT 緩衝區時出錯"
 
-#: ../src/iop/lut3d.c:556
+#: ../src/iop/lut3d.c:557
 #, c-format
 msgid "error - could not read png image %s"
-msgstr "錯誤 - 無法讀取 png 影像 %s"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"無法讀取 PNG 影像「%s」"
 
-#: ../src/iop/lut3d.c:566
+#: ../src/iop/lut3d.c:567
 msgid "error - allocating buffer for png LUT"
-msgstr "無法爲 png LUT 配置緩衝區"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"分配 PNG LUT 緩衝區時出錯"
 
-#: ../src/iop/lut3d.c:740
+#: ../src/iop/lut3d.c:742
 #, c-format
 msgid "error - invalid cube file: %s"
-msgstr "錯誤 - 無效的 立方  檔案 %s"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"無效的 cube 檔案「%s」"
 
-#: ../src/iop/lut3d.c:754
+#: ../src/iop/lut3d.c:756
 msgid "DOMAIN MIN <> 0.0 is not supported"
-msgstr "不支援DOMAIN MIN <> 0.0"
+msgstr "最小值必須為 0"
 
-#: ../src/iop/lut3d.c:765
+#: ../src/iop/lut3d.c:767
 msgid "DOMAIN MAX <> 1.0 is not supported"
-msgstr "不支援DOMAIN MIN <> 1.0"
+msgstr "最大值必須為 1"
 
-#: ../src/iop/lut3d.c:774
+#: ../src/iop/lut3d.c:776
 msgid "[1D cube LUT is not supported"
 msgstr "不支援一維 cube LUT"
 
-#: ../src/iop/lut3d.c:796 ../src/iop/lut3d.c:900
+#: ../src/iop/lut3d.c:798 ../src/iop/lut3d.c:903
 msgid "error - allocating buffer for cube LUT"
-msgstr "錯誤 - 爲 立方 LUT 配置緩衝區"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"分配 cube LUT「%s」緩衝區時出錯"
 
-#: ../src/iop/lut3d.c:807 ../src/iop/lut3d.c:913
+#: ../src/iop/lut3d.c:809 ../src/iop/lut3d.c:916
 msgid "error - cube LUT size is not defined"
-msgstr "錯誤 - 未定義立方 LUT 大小"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"未定義 LUT 尺寸"
 
-#: ../src/iop/lut3d.c:818
+#: ../src/iop/lut3d.c:820
 #, c-format
 msgid "error - cube LUT invalid number line %d"
-msgstr "錯誤 - 立方 LUT 第 %d 行出現無效數值"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"cube LUT 第 %d 行數值無效"
 
-#: ../src/iop/lut3d.c:834
+#: ../src/iop/lut3d.c:836
 #, c-format
 msgid "error - cube LUT lines number %d is not correct, should be %d"
-msgstr "錯誤 - 立方 LUT 第 %d 行出現無效數值，應爲 %d"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"cube LUT 第 %d 行數值無效，應為 %d"
 
-#: ../src/iop/lut3d.c:844
+#: ../src/iop/lut3d.c:846
 #, c-format
 msgid "warning - cube LUT %d out of range values [0,1]"
-msgstr "錯誤 - cube lut 中 %d 超出取值範圍 [0,1]"
+msgstr ""
+"⚠️ 警告 ⚠️\n"
+"cube LUT 中 %d 超出數值範圍範圍 0 ~ 1"
 
-#: ../src/iop/lut3d.c:868
+#: ../src/iop/lut3d.c:871
 #, c-format
 msgid "error - invalid 3dl file: %s"
-msgstr "錯誤 - 無效的 3dl 檔案:%s"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"無效的 3DL 檔案「%s」"
 
-#: ../src/iop/lut3d.c:889
+#: ../src/iop/lut3d.c:892
 #, c-format
 msgid "error - the maximum shaper LUT value %d is too low"
-msgstr "錯誤 - 最大塑形器 LUT 值 %d 過低"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"LUT 最大值 %d 過低"
 
-#: ../src/iop/lut3d.c:941
+#: ../src/iop/lut3d.c:944
 msgid "error - cube LUT lines number is not correct"
-msgstr "錯誤 - 立方 LUT 行數不正確"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"cube LUT 行數不正確"
 
-#: ../src/iop/lut3d.c:957
+#: ../src/iop/lut3d.c:960
 msgid "error - the maximum LUT value does not match any valid bit depth"
-msgstr "錯誤 - 最大 LUT 值沒有匹配任何有效的位元景深"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"LUT 最大值不符合任何有效的色彩深度"
+
+#: ../src/iop/lut3d.c:1544
+msgid "LUT root folder not defined"
+msgstr "未定義 LUT 根目錄，請至「偏好設定」〉「運算方法」中定義"
 
 #: ../src/iop/lut3d.c:1550
-msgid "LUT root folder not defined"
-msgstr "未定義 LUT 根目錄"
-
-#: ../src/iop/lut3d.c:1556
 msgid "select LUT file"
 msgstr "選擇 LUT 檔案"
 
-#: ../src/iop/lut3d.c:1557
+#: ../src/iop/lut3d.c:1551
 msgid "_select"
-msgstr "選擇"
+msgstr "選擇（_S）"
 
-#: ../src/iop/lut3d.c:1577
+#: ../src/iop/lut3d.c:1571
 msgid "hald CLUT (png), 3D LUT (cube or 3dl) or gmic compressed LUT (gmz)"
-msgstr "hald CLUT(png)、3D LUT(cube 或 3dl)或者 GMIC 壓縮 LUT(gmz)"
+msgstr "hald CLUT, 3D LUT, gmic LUT"
 
-#: ../src/iop/lut3d.c:1579
+#: ../src/iop/lut3d.c:1573
 msgid "hald CLUT (png) or 3D LUT (cube or 3dl)"
-msgstr "hald CLUT(png)或者 3D LUT(cube 或 3dl)"
+msgstr "hald CLUT, 3D LUT"
 
-#: ../src/iop/lut3d.c:1603
+#: ../src/iop/lut3d.c:1597
 msgid "select file outside LUT root folder is not allowed"
-msgstr "不允許在 Lut 根目錄外選擇檔案"
+msgstr "不能選擇 LUT 根目錄之外的檔案"
 
-#: ../src/iop/lut3d.c:1674
+#: ../src/iop/lut3d.c:1668
 msgid ""
 "select a png (haldclut), a cube, a 3dl or a gmz (compressed LUT) file "
 "CAUTION: 3D LUT folder must be set in preferences/processing before choosing "
 "the LUT file"
 msgstr ""
-"選擇一個 png(hald clut)、cube、3dl 或 gmz(壓縮 lut)檔案。注意:在選擇 lut 檔案"
-"之前，必須在偏好/處理中設定 3D lut 檔案目錄"
+"選擇 LUT 檔案\n"
+"\n"
+"支援 hald CLUT（png）、3D LUT（cube 或 3dl）、gmic 壓縮 LUT（gmz）\n"
+"在選擇 LUT 檔之前，請至「偏好設定」〉「運算方法」中定義 LUT 根目錄\n"
+"LUT 資料不會儲存在資料庫或 XMP 中，而是從 3D LUT 根目錄引用\n"
+"僅有 gmic 壓縮 LUT（gmz）格式可以儲存完整數據在 XMP 文件裡\n"
+"因此，自行正確備份 3D LUT 檔案非常重要"
 
-#: ../src/iop/lut3d.c:1678
+#: ../src/iop/lut3d.c:1672
 msgid ""
 "select a png (haldclut), a cube or a 3dl file CAUTION: 3D LUT folder must be "
 "set in preferences/processing before choosing the LUT file"
 msgstr ""
-"選擇一個 png(hald clut)、cube 或 3dl 檔案。\n"
-"注意:在選擇 lut 檔案之前，必須在偏好/處理中設定 3D lut 檔案目錄"
+"選擇 LUT 檔案\n"
+"\n"
+"支援 hald CLUT（png）、3D LUT（cube 或 3dl）\n"
+"在選擇 LUT 檔之前，請至「偏好設定」〉「運算方法」中定義 LUT 根目錄\n"
+"LUT 資料不會儲存在資料庫或 XMP 中，而是從 3D LUT 根目錄引用\n"
+"僅有 gmic 壓縮 LUT（gmz）格式可以儲存完整數據在 XMP 文件裡\n"
+"因此，自行正確備份 3D LUT 檔案非常重要"
 
-#: ../src/iop/lut3d.c:1690
+#: ../src/iop/lut3d.c:1684
 msgid ""
 "the file path (relative to LUT folder) is saved with image along with the "
 "LUT data if it's a compressed LUT (gmz)"
-msgstr ""
-"若為壓縮 lut(gmz)，相對於 lut 目錄的檔案路徑和 lut 資料將與影像一起保存"
+msgstr "若使用 gmic 壓縮 LUT，將 gmz 檔案路徑與影像一併儲存"
 
-#: ../src/iop/lut3d.c:1693
+#: ../src/iop/lut3d.c:1687
 msgid ""
 "the file path (relative to LUT folder) is saved with image (and not the LUT "
 "data themselves)"
-msgstr "相對於 lut 目錄的檔案路徑將與影像一起保存(不是 lut 資料本身)"
+msgstr "僅儲存 gmz 的檔案路徑（相對於 LUT 根目錄），而非 LUT 資料本身"
 
-#: ../src/iop/lut3d.c:1702
+#: ../src/iop/lut3d.c:1696
 msgid "enter LUT name"
 msgstr "輸入 LUT 名稱"
 
-#: ../src/iop/lut3d.c:1723
+#: ../src/iop/lut3d.c:1717
 msgid "select the LUT"
-msgstr "選擇 LUT"
+msgstr "選取 LUT"
 
-#: ../src/iop/lut3d.c:1736
+#: ../src/iop/lut3d.c:1730
 msgid "select the color space in which the LUT has to be applied"
-msgstr "選擇該 LUT 套用的色彩空間"
+msgstr ""
+"選擇套用 LUT 時使用的色彩空間\n"
+"LUT 是在特定色彩空間中定義的，選擇對應的色彩空間才能呈現正確外觀"
 
-#: ../src/iop/lut3d.c:1738
+#: ../src/iop/lut3d.c:1732
 msgid "interpolation"
-msgstr "內插"
+msgstr "內插法"
 
-#: ../src/iop/lut3d.c:1739
+#: ../src/iop/lut3d.c:1733
 msgid "select the interpolation method"
-msgstr "選擇內插方法"
+msgstr ""
+"選擇 LUT 使用的內插計算方法\n"
+"決定介於 RGB 立方體網格間的數據如何計算，不同算法通常差異很小"
 
 #: ../src/iop/mask_manager.c:46 ../src/libs/masks.c:55
 msgid "mask manager"
@@ -16955,7 +17877,12 @@ msgstr "遮罩管理器"
 
 #: ../src/iop/monochrome.c:97
 msgid "quickly convert an image to black & white using a variable color filter"
-msgstr "使用可變濾鏡將影像快速轉換爲黑白"
+msgstr ""
+"黑白濾鏡 | monochrome\n"
+"\n"
+"模擬傳統黑白底片使用的彩色濾鏡效果\n"
+"快速將影像轉換成黑白\n"
+"也可以使用「色彩校正」模組中的底片模擬預設集"
 
 #: ../src/iop/monochrome.c:127
 msgid "red filter"
@@ -16963,45 +17890,53 @@ msgstr "紅色濾鏡"
 
 #: ../src/iop/monochrome.c:561
 msgid "drag and scroll mouse wheel to adjust the virtual color filter"
-msgstr "拖拉並滾動滑鼠滾輪調整虛擬色彩濾鏡"
+msgstr ""
+"拖曳移動改變濾鏡顏色，滑鼠滾輪調整濾鏡色彩範圍\n"
+"建議先縮小濾鏡顏色範圍，以看出不同顏色的效果\n"
+"找到最適合的色相之後再逐步擴大濾鏡範圍，以獲得較自然的階調"
 
 #: ../src/iop/monochrome.c:577
 msgid "how much to keep highlights"
-msgstr "保存高光的數量"
+msgstr "控制亮部的保留程度"
 
 #: ../src/iop/negadoctor.c:145
 msgid "negadoctor"
-msgstr "負片博士(negadoctor)"
+msgstr "負片反轉"
 
 #: ../src/iop/negadoctor.c:150
 msgid "film|invert|negative|scan"
-msgstr "軟片|反轉|負片|掃描"
+msgstr "底片|掃描|翻拍|film|invert|negative|scan"
 
 #: ../src/iop/negadoctor.c:155
 msgid "invert film negative scans and simulate printing on paper"
-msgstr "反轉軟片爲負片並模擬紙上列印效果"
+msgstr ""
+"負片反轉 | negadoctor\n"
+"\n"
+"反轉掃描或翻拍的負片並模擬感光相紙效果\n"
+"使用此模組從真正的負片反轉影像時建議關閉其他任何階調調整模組\n"
+"並強烈建議依照介面中的「上→下」「左→右」順序設定各項參數"
 
 #: ../src/iop/negadoctor.c:442
 msgid "D min"
-msgstr "最低密度區"
+msgstr "最低濃度"
 
 #: ../src/iop/negadoctor.c:448 ../src/iop/negadoctor.c:828
 msgid "D min red component"
-msgstr "最低密度區紅色量"
+msgstr "最低濃度區域紅色量"
 
 #. Page FILM PROPERTIES
 #: ../src/iop/negadoctor.c:805
 msgid "film properties"
-msgstr "軟片特性"
+msgstr "底片特性"
 
 #. Dmin
 #: ../src/iop/negadoctor.c:809
 msgid "color of the film base"
-msgstr "軟片基底顏色"
+msgstr "底片片基的顏色"
 
 #: ../src/iop/negadoctor.c:815
 msgid "select color of film material from a swatch"
-msgstr "從色表中選擇軟片材料顏色"
+msgstr "從色樣中選擇底片片基的顏色"
 
 #: ../src/iop/negadoctor.c:829 ../src/iop/negadoctor.c:839
 #: ../src/iop/negadoctor.c:849
@@ -17011,23 +17946,25 @@ msgid ""
 "the chemical fog produced while developing the film,\n"
 "and the scanner white balance."
 msgstr ""
-"調整軟片透明基底的顏色和陰影。\n"
-"這個值取決於軟片材料、\n"
-"沖洗時產生的化學霧\n"
-"和掃描器白平衡。"
+"手動調整底片片基的顏色和濃度\n"
+"參數設定會和底片種類、沖洗、掃描或翻拍設定等因素相關"
 
 #: ../src/iop/negadoctor.c:838
 msgid "D min green component"
-msgstr "最低密度區綠色量"
+msgstr "最低濃度區域綠色量"
 
 #: ../src/iop/negadoctor.c:848
 msgid "D min blue component"
-msgstr "最低密度區藍色量"
+msgstr "最低濃度區域藍色量"
 
 #. D max and scanner bias
 #: ../src/iop/negadoctor.c:856
 msgid "dynamic range of the film"
-msgstr "軟片動態範圍"
+msgstr "底片的動態範圍"
+
+#: ../src/iop/negadoctor.c:858
+msgid "D max"
+msgstr "最高濃度"
 
 #: ../src/iop/negadoctor.c:860
 msgid ""
@@ -17035,34 +17972,39 @@ msgid ""
 "this value depends on the film specifications, the developing process,\n"
 "the dynamic range of the scene and the scanner exposure settings."
 msgstr ""
-"軟片的最大密度，等同於反轉後的白色。\n"
-"這個值取決於軟片規格，沖洗過程，\n"
-"場景的動態範圍和掃描儀曝光設定。"
+"底片的最高濃度，對應到反轉後的純白點\n"
+"使用右方的色彩選取工具，拖曳選取影像區域可自動計算\n"
+"注意勿選取到影像範圍外的部分，如片基和底片碼，以免造成誤判\n"
+"手動調整向左讓底片更亮，向右拖動會讓底片變暗"
 
 #: ../src/iop/negadoctor.c:864
 msgid "scanner exposure settings"
-msgstr "掃描器曝光設定"
+msgstr "掃描機曝光設定"
 
 #: ../src/iop/negadoctor.c:869
 msgid ""
 "correct the exposure of the scanner, for all RGB channels,\n"
 "before the inversion, so blacks are neither clipped or too pale."
 msgstr ""
-"在倒轉之前修正掃描儀曝光的所有 RGB 通道，\n"
-"以便黑色不會過高或過低。"
+"在反轉負片之前修正掃描機或翻拍的曝光\n"
+"使用右方的色彩選取工具，拖曳選取影像區域可自動計算\n"
+"注意勿選取到影像範圍外的部分，如片基和底片碼，以免造成誤判\n"
+"手動調整向左讓底片更亮，向右拖動會讓底片變暗"
 
 #. WB shadows
 #: ../src/iop/negadoctor.c:876
 msgid "shadows color cast"
-msgstr "陰影顏色映射"
+msgstr "陰影偏色"
 
 #: ../src/iop/negadoctor.c:882
 msgid "select color of shadows from a swatch"
-msgstr "從色表中選擇陰影顏色"
+msgstr "從色樣中選擇陰影的顏色"
 
 #: ../src/iop/negadoctor.c:887
 msgid "pick shadows color from image"
-msgstr "從影像中選取陰影顏色"
+msgstr ""
+"從影像中選擇陰影顏色\n"
+"使用色彩選取工具拖曳選擇影像中的暗部中灰色區域，以下參數會自動計算完成"
 
 #: ../src/iop/negadoctor.c:892
 msgid "shadows red offset"
@@ -17076,8 +18018,8 @@ msgid ""
 "the highlights illuminant white balance will help\n"
 "recovering the global white balance in difficult cases."
 msgstr ""
-"修正陰影中的顏色映射，使黑色變成沒有色彩。\n"
-"在高光光照白平衡之前設定此值，將有助於在有問題狀況下恢復全局白平衡。"
+"校正陰影中的色偏，讓黑色真正不帶任何偏色\n"
+"陰影偏色參數也會影響亮部的顏色，務必先設定陰影偏色然後才是亮部白平衡"
 
 #: ../src/iop/negadoctor.c:899
 msgid "shadows green offset"
@@ -17090,19 +18032,21 @@ msgstr "陰影藍色偏移"
 #. WB highlights
 #: ../src/iop/negadoctor.c:913
 msgid "highlights white balance"
-msgstr "高光區白平衡"
+msgstr "亮部白平衡"
 
 #: ../src/iop/negadoctor.c:919
 msgid "select color of illuminant from a swatch"
-msgstr "從色表中選擇光照顏色"
+msgstr "從色樣中選擇光源的顏色"
 
 #: ../src/iop/negadoctor.c:924
 msgid "pick illuminant color from image"
-msgstr "從影像中選取光照顏色"
+msgstr ""
+"從影像中選取光源顏色\n"
+"使用色彩選取工具拖曳選擇影像中的亮部中灰色區域，以下參數會自動計算完成"
 
 #: ../src/iop/negadoctor.c:929
 msgid "illuminant red gain"
-msgstr "光照紅色增益"
+msgstr "光源紅光增益"
 
 #: ../src/iop/negadoctor.c:930 ../src/iop/negadoctor.c:937
 #: ../src/iop/negadoctor.c:944
@@ -17112,34 +18056,34 @@ msgid ""
 "the shadows color cast will help\n"
 "recovering the global white balance in difficult cases."
 msgstr ""
-"修正光照的顏色，使得白色變成沒有色彩。\n"
-"在陰影顏色映射後設定此值，將有助於在有問題狀況下恢復全局白平衡。"
+"校正光源的顏色，讓白色真正不帶任何偏色\n"
+"陰影偏色參數也會影響亮部的顏色，務必先設定陰影偏色然後才是亮部白平衡"
 
 #: ../src/iop/negadoctor.c:936
 msgid "illuminant green gain"
-msgstr "光照綠色增益"
+msgstr "光源綠光增益"
 
 #: ../src/iop/negadoctor.c:943
 msgid "illuminant blue gain"
-msgstr "光照藍色增益"
+msgstr "光源藍光增益"
 
 #. Page PRINT PROPERTIES
 #: ../src/iop/negadoctor.c:950
 msgid "print properties"
-msgstr "列印屬性"
+msgstr "相紙特性"
 
 #. print corrections
 #: ../src/iop/negadoctor.c:953
 msgid "virtual paper properties"
-msgstr "虛擬紙張屬性"
+msgstr "模擬紙張特性"
 
 #: ../src/iop/negadoctor.c:959
 msgid ""
 "correct the density of black after the inversion,\n"
 "to adjust the global contrast while avoiding clipping shadows."
 msgstr ""
-"修正反轉後黑色的密度，\n"
-"以避免在裁剪陰影的時調整全局對比度。"
+"修正反轉後的黑色濃度，以調整對比度同時避免裁切暗部階調\n"
+"使用右方色彩選取工具選擇底片曝光區域以自動計算"
 
 #: ../src/iop/negadoctor.c:964
 msgid ""
@@ -17147,9 +18091,8 @@ msgid ""
 "equivalent to applying a gamma. it compensates the film D max\n"
 "and recovers the contrast. use a high grade for high D max."
 msgstr ""
-"選擇虛擬紙張的等級，這實際上相當於套用伽馬。\n"
-"它補償軟片最高密度區，並恢復對比度。\n"
-"高的等級對應高的最高密度區值。"
+"選擇虛擬紙張的階調，實際上是套用伽瑪指數\n"
+"補償底片的最高濃度並恢復對比度"
 
 #: ../src/iop/negadoctor.c:972
 msgid ""
@@ -17157,264 +18100,291 @@ msgid ""
 "to avoid clipping while pushing the exposure for mid-tones.\n"
 "this somewhat reproduces the behaviour of matte paper."
 msgstr ""
-"逐漸壓縮鏡面反射高光，使其超過此值\n"
-"以避免在將曝光推到中間調時產生裁剪。\n"
-"這在某種程度上再現了亞光紙的特性。"
+"調整數值以避免提高中間調曝光時發生亮部剪裁\n"
+"本質上是一個高光壓縮工具，可用來模擬低對比度的霧面相紙"
 
 #: ../src/iop/negadoctor.c:976
 msgid "virtual print emulation"
-msgstr "虛擬印表機模擬"
+msgstr "虛擬列印模擬"
 
 #: ../src/iop/negadoctor.c:984
 msgid ""
 "correct the printing exposure after inversion to adjust\n"
 "the global contrast and avoid clipping highlights."
 msgstr ""
-"修正反轉後的列印曝光，\n"
-"以調整全局對比度並避免裁剪高光。"
+"修正反轉之後的曝光，以調整對比度同時避免裁切亮部階調\n"
+"使用右側色彩選取工具選擇應該要是最亮的地方，以便自動設定影像白點\n"
+"如果前項參數都有正確設定，理應不需要調整這項設定"
 
 #: ../src/iop/negadoctor.c:992
 msgid "toggle on or off the color controls"
-msgstr "切換開或關顏色控制"
+msgstr "選擇底片種類，如果選擇黑白底片，則不會顯示底片片基顏色的滑桿"
 
 #: ../src/iop/nlmeans.c:88
 msgid "astrophoto denoise"
-msgstr "天文照片降噪"
+msgstr "天文攝影除雜訊"
 
 #: ../src/iop/nlmeans.c:93
 msgid "denoise (non-local means)"
-msgstr "降噪(非局部平均)"
+msgstr "非局部平均除雜訊非局部平均"
 
 #: ../src/iop/nlmeans.c:98
 msgid "apply a poisson noise removal best suited for astrophotography"
-msgstr "套用最適合天文攝影的卜松噪點消除"
+msgstr ""
+"天文攝影除雜訊 | astrophoto denoise\n"
+"\n"
+"使用最適合天文照片的帕松偏微分方程去除雜訊\n"
+"以便在去除雜訊的同時保留影像中的細節結構\n"
+"這會耗用大量運算資源，若處理速度過慢可以先完成其他調整最後再啟用此模組"
 
 #: ../src/iop/nlmeans.c:513
 msgid "radius of the patches to match"
-msgstr "匹配的色塊半徑"
+msgstr "評估雜訊色塊的半徑"
 
 #: ../src/iop/nlmeans.c:521
 msgid "how much to smooth brightness"
-msgstr "平滑亮度的程度"
+msgstr "降低亮度雜訊的程度"
 
 #: ../src/iop/nlmeans.c:524
 msgid "how much to smooth colors"
-msgstr "平滑色彩的程度"
+msgstr "降低彩色雜訊的程度"
 
 #. * let's fill the encapsulating widgets
 #. preview mode
 #. color scheme
-#: ../src/iop/overexposed.c:73 ../src/views/darkroom.c:2349
-#: ../src/views/darkroom.c:2367 ../src/views/darkroom.c:2374
-#: ../src/views/darkroom.c:2384 ../src/views/darkroom.c:2401
+#: ../src/iop/overexposed.c:73 ../src/views/darkroom.c:2350
+#: ../src/views/darkroom.c:2368 ../src/views/darkroom.c:2375
+#: ../src/views/darkroom.c:2385 ../src/views/darkroom.c:2402
 msgid "overexposed"
 msgstr "過曝"
 
 #: ../src/iop/overexposed.c:132 ../src/iop/overexposed.c:369
 msgid "module overexposed failed in buffer allocation"
-msgstr "過曝處理模組無法配置緩衝區"
+msgstr "過曝模組配置緩衝區失敗"
 
 #: ../src/iop/overexposed.c:158 ../src/iop/overexposed.c:379
 msgid "module overexposed failed in color conversion"
-msgstr "過曝處理模組無法顏色轉換"
+msgstr "過曝模組轉換顏色失敗"
 
 #: ../src/iop/profile_gamma.c:95
 msgid "unbreak input profile"
-msgstr "修復輸入配置檔案"
+msgstr "修復輸入描述檔"
 
 #: ../src/iop/profile_gamma.c:100
 msgid "correct input color profiles meant to be applied on non-linear RGB"
-msgstr "修正輸入顏色配置檔案，以套用於非線性RGB"
+msgstr ""
+"修復輸入描述檔 | unbreak input profile\n"
+"\n"
+"修正輸入色彩曲線以便套用在自選的色彩描述檔\n"
+"只有在「輸入色彩描述檔」模組選擇了自訂的色彩空間才需要使用此模組\n"
+"使用 darktable 預設的相機色彩矩陣不需要此額外處理"
 
 #: ../src/iop/profile_gamma.c:135
 msgid "16 EV dynamic range (generic)"
-msgstr "16 EV 動態範圍(通用)"
+msgstr "16 EV 動態範圍（通用）"
 
 #: ../src/iop/profile_gamma.c:141
 msgid "14 EV dynamic range (generic)"
-msgstr "14 EV 動態範圍(通用)"
+msgstr "14 EV 動態範圍（通用）"
 
 #: ../src/iop/profile_gamma.c:147
 msgid "12 EV dynamic range (generic)"
-msgstr "12 EV 動態範圍(通用)"
+msgstr "12 EV 動態範圍（通用）"
 
 #: ../src/iop/profile_gamma.c:153
 msgid "10 EV dynamic range (generic)"
-msgstr "10 EV 動態範圍(通用)"
+msgstr "10 EV 動態範圍（通用）"
 
 #: ../src/iop/profile_gamma.c:159
 msgid "08 EV dynamic range (generic)"
-msgstr "08 EV 動態範圍(通用)"
+msgstr "  8 EV 動態範圍（通用）"
 
 #: ../src/iop/profile_gamma.c:631
 msgid "linear part"
-msgstr "線性部分"
+msgstr ""
+"暗部線性段\n"
+"在暗部以線性處理而不套用伽馬曲線的部分，通常介於 0.0 ~ 0.1"
 
 #: ../src/iop/profile_gamma.c:635
 msgid "gamma exponential factor"
-msgstr "伽馬指數係數"
+msgstr ""
+"伽瑪指數\n"
+"補償輸入描述檔的伽瑪值，一般設定是 0.45"
 
 #: ../src/iop/profile_gamma.c:646
 msgid "adjust to match the average luma of the subject"
-msgstr "調整以匹配主題的正常亮度"
+msgstr ""
+"調整中灰色的亮度以符合物體的平均亮度\n"
+"可手動調整或使用右側色彩選取工具從影像上拖曳選取代表中間調的區域"
 
 #: ../src/iop/profile_gamma.c:652
 msgid ""
 "number of stops between middle gray and pure black\n"
 "this is a reading a posemeter would give you on the scene"
 msgstr ""
-"中間灰和純黑色之間的級數。\n"
-"在拍攝現場使用測光表得到的曝光值"
+"純黑點至中性灰之間的曝光級數\n"
+"在拍攝現場使用測光表確認數值\n"
+"也可手動調整或使用右側色彩選取工具從影像上拖曳選取代表純黑色的區域"
 
 #: ../src/iop/profile_gamma.c:658
 msgid ""
 "number of stops between pure black and pure white\n"
 "this is a reading a posemeter would give you on the scene"
 msgstr ""
-"純黑色和純白色之間的級數。\n"
-"在拍攝現場使用測光表得到的曝光值"
+"純黑點至純白點之間的曝光級數\n"
+"在拍攝現場使用測光表確認數值\n"
+"也可手動調整或使用右側色彩選取工具從影像上拖曳選取代表純白色的區域"
 
 #: ../src/iop/profile_gamma.c:660
 msgid "optimize automatically"
-msgstr "自動優化"
+msgstr "自動最佳化"
 
 #: ../src/iop/profile_gamma.c:664
 msgid ""
 "enlarge or shrink the computed dynamic range\n"
 "this is useful when noise perturbates the measurements"
 msgstr ""
-"擴大或縮小計算的動態範圍\n"
-"有助於在噪點擾亂測量的場合"
+"放大或縮小自動計算的動態範圍\n"
+"有助於影像雜訊干擾判讀的情況"
 
 #: ../src/iop/profile_gamma.c:668
 msgid "make an optimization with some guessing"
-msgstr "通過猜測來進行優化"
+msgstr ""
+"使用右側色彩選取工具選取全畫面推測最佳數值\n"
+"用法類似於自動色階"
 
 #: ../src/iop/profile_gamma.c:677
 msgid "tone mapping method"
-msgstr "色調映射方式"
+msgstr ""
+"選擇階調映射方式\n"
+"補償自訂輸入色彩描述檔的 EOTF 特性"
 
 #: ../src/iop/rawdenoise.c:124
 msgid "raw denoise"
-msgstr "raw 降噪"
+msgstr "RAW 檔除雜訊"
 
 #: ../src/iop/rawdenoise.c:129
 msgid "denoise the raw picture early in the pipeline"
-msgstr "在管線流程前期對 raw 檔進行降噪"
+msgstr ""
+"RAW 檔除雜訊 | raw denoise\n"
+"\n"
+"在去馬賽克之前對原始影像數據進行除雜訊處理\n"
+"控制方法和「相機特性除雜訊」的小波模式類似\n"
+"但沒有使用相機感光元件的特性描述資料"
 
 #: ../src/iop/rawdenoise.c:955
 msgid ""
 "raw denoising\n"
 "only works for raw images."
 msgstr ""
-"raw 降噪\n"
-"只對 raw 影像有效。"
+"⚠️ 錯誤 ⚠️\n"
+"「RAW 檔除雜訊」僅適用於 RAW"
 
 #. * let's fill the encapsulating widgets
 #. mode of operation
-#: ../src/iop/rawoverexposed.c:69 ../src/views/darkroom.c:2294
-#: ../src/views/darkroom.c:2312 ../src/views/darkroom.c:2321
-#: ../src/views/darkroom.c:2336
+#: ../src/iop/rawoverexposed.c:69 ../src/views/darkroom.c:2295
+#: ../src/views/darkroom.c:2313 ../src/views/darkroom.c:2322
+#: ../src/views/darkroom.c:2337
 msgid "raw overexposed"
-msgstr "raw 過曝"
+msgstr "RAW 檔曝光過度"
 
 #: ../src/iop/rawprepare.c:99
 msgctxt "modulename"
 msgid "raw black/white point"
-msgstr "raw 黑/白點"
+msgstr "RAW 檔黑、白點"
 
 #: ../src/iop/rawprepare.c:151
 msgid ""
 "sets technical specificities of the raw sensor.\n"
 "touch with great care!"
 msgstr ""
-"設定傳感器技術特性。\n"
-"請謹慎編輯！"
+"RAW 檔黑、白點 | raw black/white point\n"
+"\n"
+"設定基於特定相機感光元件的黑白訊號位準\n"
+"此為感光元件的技術特性，通常不需要更改預設值"
 
 #: ../src/iop/rawprepare.c:163
 msgid "passthrough"
-msgstr "轉移"
+msgstr "直通"
 
 #: ../src/iop/rawprepare.c:823
 msgid "black level 0"
-msgstr "黑階 0"
+msgstr "黑色位準 0（R）"
 
 #: ../src/iop/rawprepare.c:824
 msgid "black level 1"
-msgstr "黑階 1"
+msgstr "黑色位準 1（G）"
 
 #: ../src/iop/rawprepare.c:825
 msgid "black level 2"
-msgstr "黑階 2"
+msgstr "黑色位準 2（G）"
 
 #: ../src/iop/rawprepare.c:826
 msgid "black level 3"
-msgstr "黑階 3"
+msgstr "黑色位準 3（B）"
 
 #: ../src/iop/rawprepare.c:851
 msgid "flat field correction to compensate for lens shading"
-msgstr "為鏡頭暗角做平場修正補償"
+msgstr "使用平場校正來補償鏡頭陰影"
 
 #: ../src/iop/rawprepare.c:859
 msgid "crop from left border"
-msgstr "從左邊緣剪裁"
+msgstr "從左側裁切"
 
 #: ../src/iop/rawprepare.c:863
 msgid "crop from top"
-msgstr "從頂部剪裁"
+msgstr "從上方裁切"
 
 #: ../src/iop/rawprepare.c:867
 msgid "crop from right border"
-msgstr "從右邊緣剪裁"
+msgstr "從右側裁切"
 
 #: ../src/iop/rawprepare.c:871
 msgid "crop from bottom"
-msgstr "從底部剪裁"
+msgstr "從下方裁切"
 
 #: ../src/iop/rawprepare.c:879
 msgid ""
 "raw black/white point correction\n"
 "only works for the sensors that need it."
-msgstr ""
-"raw 黑/白點修正\n"
-"只對需要它的傳感器起作用。"
+msgstr "「RAW 檔黑、白點」僅適用於需要的感光元件"
 
 #: ../src/iop/rcd_demosaic.c:310
 msgid "[rcd_demosaic] too small area"
-msgstr "[rcd_demosaic] 區域太小"
+msgstr "RCD 去馬賽克區域過小"
 
 #: ../src/iop/relight.c:54
 msgid "fill-light 0.25EV with 4 zones"
-msgstr "4 區域加光 0.25EV"
+msgstr "四區曝光補償 +0.25 EV"
 
 #: ../src/iop/relight.c:58
 msgid "fill-shadow -0.25EV with 4 zones"
-msgstr "4 區域加陰影 -0.25EV"
+msgstr "四區曝光補償 -0.25 EV"
 
 #: ../src/iop/relight.c:87
 msgid "fill light"
-msgstr "加光"
+msgstr "補光"
 
 #: ../src/iop/relight.c:97 ../src/iop/zonesystem.c:122
 msgid ""
 "this module is deprecated. please use the tone equalizer module instead."
-msgstr "此模組已棄用。請改使用色調均衡器替代。"
+msgstr "此模組已被汰除，建議使用「階調等化器」模組替代"
 
 #: ../src/iop/relight.c:268
 msgid "the fill-light in EV"
-msgstr "曝光補償(單位爲 EV)"
+msgstr "補光亮度（EV）"
 
 #: ../src/iop/relight.c:277
 msgid ""
 "select the center of fill-light\n"
 "ctrl+click to select an area"
 msgstr ""
-"選擇補光的中心位置\n"
-"按住 控制鍵 點擊以選取區域"
+"選擇補光燈的中心點\n"
+"ctrl + 左鍵選擇區域"
 
 #: ../src/iop/relight.c:281
 msgid "toggle tool for picking median lightness in image"
-msgstr "用於選取影像明度中值的切換工具"
+msgstr "切換在影像上選擇中間亮度的工具"
 
 #: ../src/iop/relight.c:284 ../src/libs/metadata_view.c:147
 #: ../src/libs/print_settings.c:2385
@@ -17423,19 +18393,23 @@ msgstr "寬度"
 
 #: ../src/iop/relight.c:285
 msgid "width of fill-light area defined in zones"
-msgstr "補光區域之寬度"
+msgstr "補光階調範圍"
 
 #: ../src/iop/retouch.c:197
 msgid "retouch"
-msgstr "修補(retouch)"
+msgstr "細節修飾"
 
 #: ../src/iop/retouch.c:202
 msgid "split-frequency|healing|cloning|stamp"
-msgstr "分頻|重建|複製|蓋章"
+msgstr "高低頻分離|修復|複製|印章|小波|汙點|髒點"
 
 #: ../src/iop/retouch.c:208
 msgid "remove and clone spots, perform split-frequency skin editing"
-msgstr "清除/複製斑點，執行分頻皮膚編輯"
+msgstr ""
+"細節修飾 | retouch\n"
+"\n"
+"繪製形狀遮罩執行修復或移除影像中不需要的斑點\n"
+"並且可以利用小波分解，進行頻率分離的皮膚精修"
 
 #: ../src/iop/retouch.c:211
 msgid "geometric and frequential, RGB"
@@ -17443,13 +18417,13 @@ msgstr "幾何與頻率、RGB"
 
 #: ../src/iop/retouch.c:1513
 msgid "cannot display scales when the blending mask is displayed"
-msgstr "當混合遮罩顯示時不能顯示比例尺"
+msgstr "顯示混合遮罩時無法顯示小波尺度"
 
 #: ../src/iop/retouch.c:1830 ../src/iop/retouch.c:1832
 #: ../src/iop/retouch.c:1834 ../src/iop/retouch.c:1836
 #, c-format
 msgid "default tool changed to %s"
-msgstr "預設工具更換為 %s"
+msgstr "預設工具變更為「%s」"
 
 #: ../src/iop/retouch.c:1830
 msgid "cloning"
@@ -17457,19 +18431,19 @@ msgstr "複製"
 
 #: ../src/iop/retouch.c:1832
 msgid "healing"
-msgstr "重建"
+msgstr "修復"
 
 #: ../src/iop/retouch.c:2187
 msgid "shapes:"
-msgstr "形狀:"
+msgstr "遮罩形狀："
 
 #: ../src/iop/retouch.c:2191
 msgid ""
 "to add a shape select an algorithm and a shape type and click on the image.\n"
 "shapes are added to the current scale"
 msgstr ""
-"要增加一個形狀，選擇一個演算法和一個形狀類型，然後點擊影像。\n"
-"形狀將被增加到目前的大小上"
+"選擇遮罩形狀和修飾方法，然後在影像上點擊欲修飾的地方\n"
+"修飾形狀遮罩會作用於目前選定的小波尺度（細節頻率）上"
 
 #. display & suppress masks
 #. copy/paste shapes
@@ -17484,15 +18458,15 @@ msgstr "編輯"
 
 #: ../src/iop/retouch.c:2194
 msgid "show and edit shapes on the current scale"
-msgstr "在目前大小上顯示和編輯形狀"
+msgstr "顯示目前小波尺度中的形狀以編輯"
 
 #: ../src/iop/retouch.c:2195
 msgid "show and edit shapes in restricted mode"
-msgstr "在限制模式下顯示和編輯形狀"
+msgstr "在受限模式下編輯，遮罩形狀的位置和大小被保護避免變更"
 
 #: ../src/iop/retouch.c:2218
 msgid "algorithms:"
-msgstr "演算法:"
+msgstr "修飾方法："
 
 #: ../src/iop/retouch.c:2221 ../src/iop/retouch.c:2225
 #: ../src/iop/retouch.c:2229 ../src/iop/retouch.c:2233
@@ -17506,11 +18480,11 @@ msgstr "啟用模糊工具"
 #: ../src/iop/retouch.c:2221 ../src/iop/retouch.c:2225
 #: ../src/iop/retouch.c:2229 ../src/iop/retouch.c:2233
 msgid "change algorithm for current form"
-msgstr "爲目前形態更改演算法"
+msgstr "將選擇的形狀更改為此工具"
 
 #: ../src/iop/retouch.c:2225 ../src/iop/retouch.c:2242
 msgid "activate fill tool"
-msgstr "啟用填充工具"
+msgstr "啟用填色工具"
 
 #: ../src/iop/retouch.c:2229 ../src/iop/retouch.c:2245
 msgid "activate cloning tool"
@@ -17518,28 +18492,28 @@ msgstr "啟用複製工具"
 
 #: ../src/iop/retouch.c:2233 ../src/iop/retouch.c:2248
 msgid "activate healing tool"
-msgstr "啟用重建工具"
+msgstr "啟用修復工具"
 
 #. overwrite tooltip ourself to handle shift+click
 #: ../src/iop/retouch.c:2237
 msgid "ctrl+click to change tool for current form"
-msgstr "控制鍵 + 單擊爲目前形態更改演算法"
+msgstr "ctrl + 點擊將選擇的形狀更改為此工具"
 
 #: ../src/iop/retouch.c:2238
 msgid "shift+click to set the tool as default"
-msgstr "shift + 單擊將工具設置爲預設"
+msgstr "shift + 點擊將此工具設為預設值"
 
 #: ../src/iop/retouch.c:2257
 msgid "scales:"
-msgstr "縮放級數:"
+msgstr "小波尺度（頻率分離層數）："
 
 #: ../src/iop/retouch.c:2262
 msgid "current:"
-msgstr "目前的:"
+msgstr "目前使用的小波尺度："
 
 #: ../src/iop/retouch.c:2267
 msgid "merge from:"
-msgstr "合併自:"
+msgstr "合併編輯效果至小波層："
 
 #: ../src/iop/retouch.c:2275
 msgid ""
@@ -17549,11 +18523,26 @@ msgid ""
 "top line indicates that the scale is visible at current zoom level\n"
 "bottom line indicates that the scale has shapes on it"
 msgstr ""
-"頂部滑動條調整合併比例的開始位置\n"
-"底部的滑動條調整刻度的數量\n"
-"點表示目前的比例\n"
-"頂線表示在目前的縮放級別上，比例尺可見\n"
-"底線表示該比例尺上有形狀"
+"小波分解示意圖表\n"
+"\n"
+"小波分析將圖像分解為多個不同細節等級的圖層，稱為小波尺度，得以在每個細節層中"
+"獨立調整細節修飾效果。這對人像攝影特別有用，可將皮膚瑕疵在其所屬的小波層中處"
+"理，而不抹平皮膚紋理，或是影響低頻的顏色資訊。\n"
+"\n"
+"長條示意圖最左側的黑色方塊代表未經小波處理的原始影像層\n"
+"示意圖最右側的白色方塊代表小波處理後剩下的無細節影像\n"
+"中間的灰色方塊代表各個不同細節等級的圖層，越往左細節越精細，往右是粗糙輪廓\n"
+"\n"
+"長條圖中的灰圓點代表目前選擇的小波尺度，修飾效果會作用在此層上\n"
+"點擊可選擇，若選擇最左方的黑色方塊，修飾效果會直接作用在原始影像上\n"
+"\n"
+"下方橘色條代表該小波尺度有修飾效果的形狀遮罩\n"
+"長條圖上方的灰色條顯示在目前的影像縮放比例下可以看到哪些小波層\n"
+"若無法辨識欲修飾的小波尺度細節，則必須放大顯示比例\n"
+"\n"
+"下方的三角形控制目前的小波分解數量，拖曳可改變小波層數量\n"
+"上方的三角形控制小波層合併效果，高層數的修飾會套用至低層上\n"
+"選擇 0 為不合併效果，每個修飾遮罩只作用在所屬的小波尺度中"
 
 #: ../src/iop/retouch.c:2295
 msgid "display masks"
@@ -17561,157 +18550,167 @@ msgstr "顯示遮罩"
 
 #: ../src/iop/retouch.c:2300
 msgid "temporarily switch off shapes"
-msgstr "暫時不顯示形狀"
+msgstr "暫時不顯示修飾效果"
 
 #: ../src/iop/retouch.c:2308
 msgid "paste cut shapes to current scale"
-msgstr "將剪切形狀貼到目前刻度"
+msgstr "貼上剪下的修飾遮罩到目前選取的小波尺度"
 
 #: ../src/iop/retouch.c:2312
 msgid "cut shapes from current scale"
-msgstr "從目前刻度剪切形狀"
+msgstr "從目前小波尺度中剪下修飾遮罩"
 
 #: ../src/iop/retouch.c:2319
 msgid "display wavelet scale"
-msgstr "顯示小波刻度"
+msgstr "切換顯示小波尺度 / 整體影像"
 
 #: ../src/iop/retouch.c:2327
 msgid "preview single scale"
-msgstr "預覽單一刻度"
+msgstr "單一小波尺度預覽效果"
 
 #: ../src/iop/retouch.c:2338
 msgid "adjust preview levels"
-msgstr "調整預覽色階"
+msgstr "調整小波預覽色階"
 
 #: ../src/iop/retouch.c:2353
 msgid "auto levels"
-msgstr "自動色階"
+msgstr "自動調整預覽效果"
 
 #: ../src/iop/retouch.c:2361
 msgid "shape selected:"
-msgstr "已選擇之形狀:"
+msgstr "目前選取的形狀遮罩："
 
 #: ../src/iop/retouch.c:2366
 msgid ""
 "click on a shape to select it,\n"
 "to unselect click on an empty space"
 msgstr ""
-"點擊一個形狀以選擇，\n"
-"取消選擇，點擊一個空白區域"
+"點擊形狀遮罩以選取\n"
+"點擊空白區域取消選取"
 
 #: ../src/iop/retouch.c:2373
 msgid "erase the detail or fills with chosen color"
-msgstr "擦除細節或用選色填充"
+msgstr "抹除細節或用選取的色彩來填滿"
 
 #: ../src/iop/retouch.c:2380
 msgid "fill color: "
-msgstr "填充顏色: "
+msgstr "填充色彩： "
 
 #: ../src/iop/retouch.c:2385 ../src/iop/retouch.c:2386
 msgid "select fill color"
-msgstr "選擇填充顏色"
+msgstr "選擇填充色彩"
 
 #: ../src/iop/retouch.c:2391
 msgid "pick fill color from image"
-msgstr "從影像中選取填充顏色"
+msgstr "從影像上選擇要填滿的色彩"
 
 #: ../src/iop/retouch.c:2399
 msgid "adjusts color brightness to fine-tune it. works with erase as well"
-msgstr "調整顏色亮度以微調，也適用於擦除"
+msgstr "調整填色的亮度，也適用於擦除模式"
 
 #: ../src/iop/retouch.c:2405
 msgid "type for the blur algorithm"
-msgstr "模糊演算法類型"
+msgstr "選擇模糊演算法"
 
 #: ../src/iop/retouch.c:2409
 msgid "radius of the selected blur type"
-msgstr "選定模糊類型半徑"
+msgstr "選取模糊的半徑尺寸"
 
 #: ../src/iop/retouch.c:2415
 msgid "set the opacity on the selected shape"
-msgstr "設定選定形狀的不透明度"
+msgstr "調整選取形狀遮罩的不透明度"
 
 #: ../src/iop/retouch.c:2421
 msgid "retouch tools"
-msgstr "修補工具"
+msgstr "修飾工具"
 
 #. wavelet decompose
 #: ../src/iop/retouch.c:2430
 msgid "wavelet decompose"
-msgstr "小波分解"
+msgstr "小波分解（高低頻分離）"
 
 #: ../src/iop/retouch.c:3526 ../src/iop/retouch.c:4361
 #, c-format
 msgid "max scale is %i for this image size"
-msgstr "此影像最大比例爲 %i"
+msgstr "這個影像尺寸的最高小波尺度為 %i"
 
 #: ../src/iop/rgbcurve.c:121
 msgid "rgb curve"
-msgstr "rgb 曲線"
+msgstr "RGB 曲線"
 
 #: ../src/iop/rgbcurve.c:141
 msgid "alter an image’s tones using curves in RGB color space"
-msgstr "在 RGB 色彩空間中使用曲線改變影像的色調"
+msgstr ""
+"RGB 曲線 | rgb curve\n"
+"\n"
+"使用曲線調整影像階調的經典工具\n"
+"和「階調曲線」模組類似，但在 RGB 空間中執行\n"
+"移動曲線的兩側端點可變更黑白點，效果等同「RGB 色階」模組"
 
-#: ../src/iop/rgbcurve.c:192 ../src/iop/tonecurve.c:563
+#: ../src/iop/rgbcurve.c:192 ../src/iop/tonecurve.c:562
 msgid "gamma 1.0 (linear)"
-msgstr "gamma 1.0(線性)"
+msgstr "伽瑪 1.0（線性）"
 
-#: ../src/iop/rgbcurve.c:202 ../src/iop/tonecurve.c:573
+#: ../src/iop/rgbcurve.c:202 ../src/iop/tonecurve.c:572
 msgid "contrast - med (linear)"
-msgstr "對比度 - 中(線性)"
+msgstr "對比度中（線性）"
 
-#: ../src/iop/rgbcurve.c:211 ../src/iop/tonecurve.c:582
+#: ../src/iop/rgbcurve.c:211 ../src/iop/tonecurve.c:581
 msgid "contrast - high (linear)"
-msgstr "對比度 - 高(線性)"
+msgstr "對比度高（線性）"
 
-#: ../src/iop/rgbcurve.c:225 ../src/iop/tonecurve.c:594
+#: ../src/iop/rgbcurve.c:225 ../src/iop/tonecurve.c:593
 msgid "contrast - med (gamma 2.2)"
-msgstr "對比度 - 中(gamma 2.2)"
+msgstr "對比度中（伽瑪 2.2）"
 
-#: ../src/iop/rgbcurve.c:238 ../src/iop/tonecurve.c:605
+#: ../src/iop/rgbcurve.c:238 ../src/iop/tonecurve.c:604
 msgid "contrast - high (gamma 2.2)"
-msgstr "對比度 - 高(gamma 2.2)"
+msgstr "對比度高（伽瑪 2.2）"
 
-#: ../src/iop/rgbcurve.c:250 ../src/iop/tonecurve.c:617
+#: ../src/iop/rgbcurve.c:250 ../src/iop/tonecurve.c:616
 msgid "gamma 2.0"
-msgstr "gamma 2.0"
+msgstr "伽瑪（gamma）2.0"
 
-#: ../src/iop/rgbcurve.c:255 ../src/iop/tonecurve.c:622
+#: ../src/iop/rgbcurve.c:255 ../src/iop/tonecurve.c:621
 msgid "gamma 0.5"
-msgstr "gamma 0.5"
+msgstr "伽瑪（gamma）0.5"
 
-#: ../src/iop/rgbcurve.c:260 ../src/iop/tonecurve.c:627
+#: ../src/iop/rgbcurve.c:260 ../src/iop/tonecurve.c:626
 msgid "logarithm (base 2)"
-msgstr "對數(以 2 爲底)"
+msgstr "對數（底數為 2）"
 
-#: ../src/iop/rgbcurve.c:265 ../src/iop/tonecurve.c:632
+#: ../src/iop/rgbcurve.c:265 ../src/iop/tonecurve.c:631
 msgid "exponential (base 2)"
-msgstr "指數(以 2 爲底)"
+msgstr "指數（底數為2）"
 
 #: ../src/iop/rgbcurve.c:1363 ../src/iop/rgblevels.c:1009
 msgid "choose between linked and independent channels."
-msgstr "選擇鏈接或獨立通道。"
+msgstr "選擇一併調整全部色版，或是分開調整 R、G、B 色版"
 
 #: ../src/iop/rgbcurve.c:1369 ../src/iop/rgblevels.c:1013
 msgid "curve nodes for r channel"
-msgstr "色調曲線 - r 通道"
+msgstr "紅色色版的色階控制點"
 
 #: ../src/iop/rgbcurve.c:1370 ../src/iop/rgblevels.c:1014
 msgid "curve nodes for g channel"
-msgstr "色調曲線 - g 通道"
+msgstr "綠色色版的色階控制點"
 
 #: ../src/iop/rgbcurve.c:1371 ../src/iop/rgblevels.c:1015
 msgid "curve nodes for b channel"
-msgstr "色調曲線 - b 通道"
+msgstr "藍色色版的色階控制點"
 
 #: ../src/iop/rgblevels.c:101
 msgid "rgb levels"
-msgstr "rgb 色階"
+msgstr "RGB 色階"
 
 #: ../src/iop/rgblevels.c:121
 msgid "adjust black, white and mid-gray points in RGB color space"
-msgstr "調整 RGB 色彩空間中的黑、白和中間灰點位置"
+msgstr ""
+"RGB 色階 | rgb levels\n"
+"\n"
+"在 RGB 空間中調整黑點、白點和中灰點的位置\n"
+"此模組類似在 Lab 空間中運算的「色階」模組\n"
+"但是可依 R、G、B 色版獨立調整"
 
 #: ../src/iop/rgblevels.c:1074
 msgid ""
@@ -17719,9 +18718,8 @@ msgid ""
 "click and drag to draw the area\n"
 "right click to cancel"
 msgstr ""
-"根據使用者定義的區域來套用自動色階\n"
-"點擊並拖拉以繪製區域\n"
-"右鍵單擊取消"
+"選擇影像上的一塊區域計算自動色階\n"
+"開啟後在影像上點擊拖曳範圍，滑鼠右鍵取消"
 
 #: ../src/iop/rotatepixels.c:70
 msgctxt "modulename"
@@ -17734,21 +18732,22 @@ msgid ""
 "\n"
 "you should not touch values here !"
 msgstr ""
-"用於設置傳感器技術特性的內部模組。\n"
-"\n"
-"您不應該更改這裏的數值！"
+"因應感光元件特性所需的內部設定校正模組\n"
+"在需要時模組會自動啟用，平時永遠保持關閉\n"
+"不需要調整參數，模組也不具備控制選項"
 
 #: ../src/iop/rotatepixels.c:366
 msgid "automatic pixel rotation"
-msgstr "自動像素旋轉"
+msgstr "自動旋轉像素"
 
 #: ../src/iop/rotatepixels.c:367
 msgid ""
 "automatic pixel rotation\n"
 "only works for the sensors that need it."
 msgstr ""
-"自動像素旋轉。\n"
-"只適用於需要它的傳感器。"
+"自動旋轉像素\n"
+"某些相機的感光元件具有斜線排列的拜耳濾鏡\n"
+"此模組僅適用於這種情況的影像傾斜校正"
 
 #: ../src/iop/scalepixels.c:54
 msgctxt "modulename"
@@ -17757,27 +18756,31 @@ msgstr "縮放像素"
 
 #: ../src/iop/scalepixels.c:270
 msgid "automatic pixel scaling"
-msgstr "自動像素縮放"
+msgstr "自動縮放像素"
 
 #: ../src/iop/scalepixels.c:271
 msgid ""
 "automatic pixel scaling\n"
 "only works for the sensors that need it."
 msgstr ""
-"自動像素縮放。\n"
-"只適用於需要它的傳感器。"
+"自動縮放像素\n"
+"某些相機的感光元件像素為長方形而非正方形\n"
+"此模組僅適用於這種情況的影像失真校正"
 
 #: ../src/iop/shadhi.c:175
 msgid "shadows and highlights"
-msgstr "陰影和高光"
+msgstr "亮部與暗部"
 
 #: ../src/iop/shadhi.c:195
 msgid ""
 "modify the tonal range of the shadows and highlights\n"
 "of an image by enhancing local contrast."
 msgstr ""
-"通過增強局部對比度來編輯影像\n"
-"的陰影和高光部分的色調範圍。"
+"亮部與暗部 | shadows and highlights\n"
+"\n"
+"修改影像的亮部和暗部來調整階調\n"
+"此模組在 Lab 空間執行模糊可能導致光暈和色相藍移\n"
+"建議改用「階調等化器」模組"
 
 #: ../src/iop/shadhi.c:685 ../src/iop/splittoning.c:536
 msgid "compress"
@@ -17785,35 +18788,50 @@ msgstr "壓縮"
 
 #: ../src/iop/shadhi.c:692
 msgid "correct shadows"
-msgstr "修正陰影"
+msgstr ""
+"修正陰影\n"
+"正值讓暗部變亮，負值讓暗部更暗"
 
 #: ../src/iop/shadhi.c:693
 msgid "correct highlights"
-msgstr "修正高光"
+msgstr ""
+"修正亮部\n"
+"正值讓亮部更亮，負值讓亮部變暗"
 
 #: ../src/iop/shadhi.c:694
 msgid "shift white point"
-msgstr "移動白點"
+msgstr ""
+"移動白點\n"
+"一般情況下此模組不會影響黑白點，但某些情況下，影像最亮點可能超出範圍\n"
+"使用白點調整至負值可以校正這些錯誤，讓亮部中的細節恢復"
 
 #: ../src/iop/shadhi.c:696
 msgid "filter to use for softening. bilateral avoids halos"
-msgstr "柔化使用的濾鏡。雙向避免光暈"
+msgstr ""
+"柔化使用的濾鏡\n"
+"如果高斯模糊產生光暈，改用雙邊濾波器"
 
 #: ../src/iop/shadhi.c:697
 msgid ""
 "compress the effect on shadows/highlights and\n"
 "preserve mid-tones"
 msgstr ""
-"壓縮在陰影/高光處的效果\n"
-"並保留中間調"
+"保留中間調不變的範圍，壓縮模組的效果範圍\n"
+"越高的值會把效果限制到極端的亮部和暗部區域\n"
+"100% 時代表沒有效果，因為只作用在絕對黑色和白色上"
 
 #: ../src/iop/shadhi.c:698
 msgid "adjust saturation of shadows"
-msgstr "調整陰影的飽和度"
+msgstr ""
+"調整暗部的飽和度\n"
+"預設值 100% 模擬暗部接收更多光線後，變亮同時飽和度也會提升的自然效果"
 
 #: ../src/iop/shadhi.c:699
 msgid "adjust saturation of highlights"
-msgstr "調整高光的飽和度"
+msgstr ""
+"調整亮部的飽和度\n"
+"通常亮部的色彩訊息不夠豐富，在調整後可能產生不自然的顏色\n"
+"此時可以改變參數獲得較好的效果，但不見得能夠令人完全滿意"
 
 #: ../src/iop/sharpen.c:73
 msgctxt "modulename"
@@ -17822,117 +18840,136 @@ msgstr "銳利化"
 
 #: ../src/iop/sharpen.c:93
 msgid "sharpen the details in the image using a standard UnSharp Mask (USM)"
-msgstr "使用標準USM銳利遮罩來強化影像細節"
+msgstr ""
+"銳利化 | sharpen\n"
+"\n"
+"經典的傳統 UnSharp Mask 銳化功能\n"
+"實際上是提高邊緣的對比度造成銳化的感覺\n"
+"可以改用「對比度等化器」和「局部對比度」等進階的模組\n"
+"或是「漫射或反捲積銳化」模組以真正提高銳利度"
 
 #: ../src/iop/sharpen.c:95
 msgid "linear or non-linear, Lab, display or scene-referred"
-msgstr "線性或非線性、Lab、顯示或場景工作流程"
+msgstr "線性或非線性、Lab、場景或顯示參照"
 
 #: ../src/iop/sharpen.c:97
 msgid "quasi-linear, Lab, display or scene-referred"
-msgstr "準線性、Lab、顯示或場景工作流程"
+msgstr "類線性、Lab、場景或顯示參照"
 
 #. add the preset.
 #. restrict to raw images
 #: ../src/iop/sharpen.c:104 ../src/iop/sharpen.c:108
 msgid "sharpen"
-msgstr "銳利化"
+msgstr "銳化化"
 
-#: ../src/iop/sharpen.c:451
+#: ../src/iop/sharpen.c:452
 msgid "spatial extent of the unblurring"
-msgstr "去模糊的空間範圍"
+msgstr ""
+"銳利化的尺寸\n"
+"控制邊緣對比度提升的範圍大小，過高的值會導致難看的過度銳化"
 
-#: ../src/iop/sharpen.c:455
+#: ../src/iop/sharpen.c:456
 msgid "strength of the sharpen"
-msgstr "銳利化強度"
+msgstr ""
+"銳利化的強度\n"
+"控制邊緣對比度提升的程度，過高的值會產生光暈偽影"
 
-#: ../src/iop/sharpen.c:459
+#: ../src/iop/sharpen.c:460
 msgid "threshold to activate sharpen"
-msgstr "啟用銳利化的臨界值"
+msgstr ""
+"銳利化的門檻\n"
+"高於此對比度才會被視為細節邊緣，調高數值可以避免雜訊或斑點被放大"
 
 #: ../src/iop/soften.c:84
 msgid "soften"
-msgstr "柔化"
+msgstr "柔焦"
 
 #: ../src/iop/soften.c:104
 msgid "create a softened image using the Orton effect"
-msgstr "使用奧頓效果(Orton Effect)建立柔和影像"
+msgstr ""
+"柔焦 | soften\n"
+"\n"
+"使用 Orton 效果建立夢幻朦朧的柔和影像\n"
+"原理是把增加曝光的影像副本模糊化，再疊合回原始影像上"
 
 #: ../src/iop/soften.c:397
 msgid "the size of blur"
-msgstr "模糊大小"
+msgstr "增加曝光影像副本的模糊尺寸，尺寸越大效果越柔和"
 
 #: ../src/iop/soften.c:401
 msgid "the saturation of blur"
-msgstr "模糊的飽和度"
+msgstr "增加曝光影像副本的飽和度，100% 表示不變"
 
 #: ../src/iop/soften.c:405
 msgid "the brightness of blur"
-msgstr "亮度模糊"
+msgstr "增加曝光影像副本的亮度，數值越高物體會有發光似的效果"
 
 #: ../src/iop/soften.c:409
 msgid "the mix of effect"
-msgstr "混合效果"
+msgstr "過曝副本和原始影像的混合比例，數值越高效果越強烈"
 
 #: ../src/iop/splittoning.c:81
 msgid "split-toning"
-msgstr "色調分離"
+msgstr "色調分割"
 
 #: ../src/iop/splittoning.c:101
 msgid ""
 "use two specific colors for shadows and highlights and\n"
 "create a linear toning effect between them up to a pivot."
 msgstr ""
-"對陰影和高光使用兩種指定的顏色，\n"
-"並在它們之間經由支點建立一個線性的色調效果。"
+"色調分割 | split-toning\n"
+"\n"
+"分別對亮部和暗部套用指定的顏色\n"
+"並建立兩色之間線性漸層的色調效果\n"
+"要製作電影調色效果建議使用進階的「色彩平衡 RGB」模組"
 
 #: ../src/iop/splittoning.c:118
 msgid "authentic sepia"
-msgstr "懷舊照片褪色效果"
+msgstr "sepia 調色"
 
 #: ../src/iop/splittoning.c:127
 msgid "authentic cyanotype"
-msgstr "懷舊藍印色效果"
+msgstr "氰版"
 
 #: ../src/iop/splittoning.c:136
 msgid "authentic platinotype"
-msgstr "懷舊單色效果"
+msgstr "白金印樣"
 
 #: ../src/iop/splittoning.c:145
 msgid "chocolate brown"
-msgstr "巧克力棕"
+msgstr "巧克力棕色調"
 
 #: ../src/iop/splittoning.c:486
 msgid "select the saturation tone"
-msgstr "選擇飽和度"
+msgstr "調整飽和度"
 
 #: ../src/iop/splittoning.c:490
 msgid "select tone color"
-msgstr "選擇色調色彩"
+msgstr "選擇顏色"
 
 #: ../src/iop/splittoning.c:534
 msgid "the balance of center of split-toning"
-msgstr "分割色調中心的平衡"
+msgstr "亮暗部色調的比例"
 
 #: ../src/iop/splittoning.c:538
 msgid ""
 "compress the effect on highlights/shadows and\n"
 "preserve mid-tones"
 msgstr ""
-"壓縮在高光/陰影處的效果\n"
-"並保留中間調"
+"縮小色調分割的範圍，增加保留原始色調的區域\n"
+"數值代表不受影響的中間調範圍的百分比"
 
 #: ../src/iop/spots.c:56
 msgid "spot removal"
-msgstr "去污點"
+msgstr "髒點去除"
 
 #: ../src/iop/spots.c:61
 msgid "this module is deprecated. please use the retouch module instead."
-msgstr "此模組已棄用。請改用修補(retouch)模組."
+msgstr "此模組已被汰除，建議使用「細節修飾」模組替代"
 
 #: ../src/iop/spots.c:66
 msgid "remove sensor dust spots"
-msgstr "清除傳感器灰塵點"
+msgstr "去除感光元件上的灰塵髒點"
 
 #: ../src/iop/spots.c:69
 msgid "geometric, raw"
@@ -17940,11 +18977,11 @@ msgstr "幾何、RAW"
 
 #: ../src/iop/spots.c:220
 msgid "spot module is limited to 64 shapes. please add a new instance !"
-msgstr "污點去除模組最大只能處理 64 個形狀。請增加新的實例！"
+msgstr "「髒點去除」模組只能使用 64 個形狀，要清除更多區域請增加另一個模組實例"
 
 #: ../src/iop/spots.c:813
 msgid "number of strokes:"
-msgstr "筆畫數目:"
+msgstr "筆刷數量："
 
 #: ../src/iop/spots.c:815
 msgid ""
@@ -17952,315 +18989,362 @@ msgid ""
 "use the mouse wheel to adjust size.\n"
 "right click to remove a shape."
 msgstr ""
-"單擊形狀並在畫布上拖拉。\n"
-"滾輪滑鼠以調整大小。\n"
-"右鍵單擊以刪除形狀。"
+"點擊形狀並在畫布上拖曳位置\n"
+"使用滑鼠滾動調整大小\n"
+"點擊右鍵刪除形狀"
 
 #: ../src/iop/spots.c:818
 msgid "show and edit shapes"
 msgstr "顯示和編輯形狀"
 
-#: ../src/iop/temperature.c:193
+#: ../src/iop/temperature.c:190
 msgctxt "modulename"
 msgid "white balance"
 msgstr "白平衡"
 
-#: ../src/iop/temperature.c:198
+#: ../src/iop/temperature.c:195
 msgid "scale raw RGB channels to balance white and help demosaicing"
-msgstr "縮放RAW RGB通道以平衡白色並幫助去馬賽克"
+msgstr ""
+"白平衡 | white balance\n"
+"\n"
+"選擇色溫和色調以獲得正確的白平衡\n"
+"此模組背後以整體縮放原始 RGB 色版的方式運算\n"
+"「色彩校正」模組用更現代的色彩適應算法調整顏色"
 
 #. our second biggest problem : another module is doing CAT elsewhere in the pipe
-#: ../src/iop/temperature.c:1113
+#: ../src/iop/temperature.c:1058
 msgid "white balance applied twice"
-msgstr "白平衡被套用了兩次"
+msgstr "白平衡被重複套用兩次"
 
-#: ../src/iop/temperature.c:1114
+#: ../src/iop/temperature.c:1059
 msgid ""
 "the color calibration module is enabled,\n"
 "and performing chromatic adaptation.\n"
 "set the white balance here to camera reference (D65)\n"
 "or disable chromatic adaptation in color calibration."
 msgstr ""
-"色彩校準模組已啓用，並執行色調調適\n"
-"請將白平衡設置爲相機基準點(D65)或在色彩校準模組中不使用色彩調適。"
+"「色彩校正」模組已啟用，並執行色彩適應\n"
+"白平衡應設定為相機基準白點\n"
+"或在「色彩校正」中停用色彩適應"
 
-#: ../src/iop/temperature.c:1370
+#: ../src/iop/temperature.c:1315
 #, c-format
 msgid "`%s' color matrix not found for image"
-msgstr "未找到影像的“%s”色彩矩陣"
+msgstr "找不到影像「%s」的色彩矩陣"
 
-#: ../src/iop/temperature.c:1398
+#: ../src/iop/temperature.c:1343
 #, c-format
 msgid "failed to read camera white balance information from `%s'!"
-msgstr "無法從“%s”讀取相機白平衡資訊！"
+msgstr "無法從「%s」讀取相機白平衡資訊"
 
-#: ../src/iop/temperature.c:1544
+#: ../src/iop/temperature.c:1489
 msgctxt "white balance"
 msgid "as shot"
 msgstr "拍攝時的設定"
 
 #. old "camera". reason for change: all other RAW development tools use "As Shot" or "shot"
-#: ../src/iop/temperature.c:1545
+#: ../src/iop/temperature.c:1490
 msgctxt "white balance"
 msgid "from image area"
-msgstr "從影像區域"
+msgstr "從影像範圍分析"
 
 #. old "spot", reason: describes exactly what'll happen
-#: ../src/iop/temperature.c:1546
+#: ../src/iop/temperature.c:1491
 msgctxt "white balance"
 msgid "user modified"
-msgstr "使用者修改"
+msgstr "使用者自訂"
 
-#: ../src/iop/temperature.c:1547
+#: ../src/iop/temperature.c:1492
 msgctxt "white balance"
 msgid "camera reference"
-msgstr "相機參考"
+msgstr "相機基準白點"
 
-#: ../src/iop/temperature.c:1804 ../src/iop/temperature.c:1822
+#: ../src/iop/temperature.c:1749 ../src/iop/temperature.c:1767
 msgid "green channel coefficient"
-msgstr "綠色通道係數"
+msgstr "綠色色版係數"
 
-#: ../src/iop/temperature.c:1806
+#: ../src/iop/temperature.c:1751
 msgid "magenta channel coefficient"
-msgstr "洋紅通道係數"
+msgstr "洋紅色色版係數"
 
-#: ../src/iop/temperature.c:1808
+#: ../src/iop/temperature.c:1753
 msgid "cyan channel coefficient"
-msgstr "青色通道係數"
+msgstr "青色色版係數"
 
-#: ../src/iop/temperature.c:1810
+#: ../src/iop/temperature.c:1755
 msgid "yellow channel coefficient"
-msgstr "黃色通道係數"
+msgstr "黃色色版係數"
 
-#: ../src/iop/temperature.c:1820
+#: ../src/iop/temperature.c:1765
 msgid "red channel coefficient"
-msgstr "紅色通道係數"
+msgstr "紅色色版係數"
 
-#: ../src/iop/temperature.c:1824
+#: ../src/iop/temperature.c:1769
 msgid "blue channel coefficient"
-msgstr "藍色通道係數"
+msgstr "藍色色版係數"
 
-#: ../src/iop/temperature.c:1826
+#: ../src/iop/temperature.c:1771
 msgid "emerald channel coefficient"
-msgstr "青綠色通道係數"
+msgstr "祖母綠色版係數"
 
-#: ../src/iop/temperature.c:1909 ../src/iop/temperature.c:1919
-#: ../src/iop/temperature.c:1924 ../src/iop/temperature.c:1930
-#: ../src/iop/temperature.c:1944
+#: ../src/iop/temperature.c:1854 ../src/iop/temperature.c:1864
+#: ../src/iop/temperature.c:1869 ../src/iop/temperature.c:1875
+#: ../src/iop/temperature.c:1889
 msgid "settings"
 msgstr "設定"
 
-#: ../src/iop/temperature.c:1909
+#: ../src/iop/temperature.c:1854
 msgid "as shot"
 msgstr "拍攝時的設定"
 
-#: ../src/iop/temperature.c:1912
+#: ../src/iop/temperature.c:1857
 msgid "set white balance to as shot"
-msgstr "將白平衡設定爲拍攝時"
+msgstr "將白平衡設為拍攝時的設定"
 
-#: ../src/iop/temperature.c:1919
+#: ../src/iop/temperature.c:1864
 msgid "from image area"
 msgstr "從影像區域"
 
-#: ../src/iop/temperature.c:1924
+#: ../src/iop/temperature.c:1869
 msgid "user modified"
-msgstr "使用者修改"
+msgstr "使用者自訂"
 
-#: ../src/iop/temperature.c:1927
+#: ../src/iop/temperature.c:1872
 msgid "set white balance to user modified"
-msgstr "將白平衡設定爲使用者修改"
+msgstr "將白平衡設為使用者自訂"
 
-#: ../src/iop/temperature.c:1930
+#: ../src/iop/temperature.c:1875
 msgid "camera reference"
-msgstr "相機參考"
+msgstr "相機基準白點"
 
-#: ../src/iop/temperature.c:1933
+#: ../src/iop/temperature.c:1878
 msgid ""
 "set white balance to camera reference point\n"
 "in most cases it should be D65"
 msgstr ""
-"將白平衡設置爲相機基準點\n"
-"絕大多數情況下都是 D65 光源"
+"將白平衡設為相機原始基準白點\n"
+"絕大多數相機廠商都使用 D65 光源"
 
 #. relabel to settings to remove confusion between module presets and white balance settings
-#: ../src/iop/temperature.c:1945
+#: ../src/iop/temperature.c:1890
 msgid "choose white balance setting"
-msgstr "選擇白平衡設定"
+msgstr "選擇白平衡設定方式"
 
-#: ../src/iop/temperature.c:1949
+#: ../src/iop/temperature.c:1894
 msgid "finetune"
 msgstr "微調"
 
-#: ../src/iop/temperature.c:1951
+#: ../src/iop/temperature.c:1896
 msgid "fine tune camera's white balance setting"
-msgstr "微調相機白平衡設定"
+msgstr "微調相機的白平衡設定"
 
-#: ../src/iop/temperature.c:1962
+#: ../src/iop/temperature.c:1907
 msgid "scene illuminant temp"
-msgstr "場景光照色溫"
+msgstr "場景光源色溫"
 
-#: ../src/iop/temperature.c:1963
+#: ../src/iop/temperature.c:1908
 msgid "click to cycle color mode on sliders"
-msgstr "單擊以循環切換滑動條上的色彩模式"
+msgstr ""
+"點擊可循環切換滑桿色彩顯示方式\n"
+"沒有顏色 → 光源顏色 → 效果模擬"
 
-#: ../src/iop/temperature.c:1975
+#: ../src/iop/temperature.c:1920
 msgid "color temperature (in Kelvin)"
-msgstr "色溫(。K)"
+msgstr ""
+"以凱氏溫標（K）設定色溫\n"
+"數值越大影像越黃，數值越小影像越藍"
 
-#: ../src/iop/temperature.c:1980
+#: ../src/iop/temperature.c:1925
 msgid "tint"
 msgstr "色調"
 
-#: ../src/iop/temperature.c:1981
+#: ../src/iop/temperature.c:1926
 msgid "color tint of the image, from magenta (value < 1) to green (value > 1)"
-msgstr "影像的色調，從洋紅(值<1)到綠色(值>1)"
+msgstr ""
+"調整色調偏移\n"
+"數值小於 1 偏向洋紅色，大於 1 偏向綠色"
 
-#: ../src/iop/temperature.c:1987
+#: ../src/iop/temperature.c:1932
 msgid "channel coefficients"
-msgstr "通道係數"
+msgstr "直接調整色版縮放係數"
 
-#: ../src/iop/temperature.c:2017
+#: ../src/iop/temperature.c:1962
 msgid "white balance disabled for camera"
-msgstr "不使用此相機的白平衡設置"
+msgstr "相機白平衡已關閉"
 
-#: ../src/iop/tonecurve.c:192
+#: ../src/iop/tonecurve.c:191
 msgid "tone curve"
-msgstr "色調曲線"
+msgstr "階調曲線"
 
-#: ../src/iop/tonecurve.c:212
+#: ../src/iop/tonecurve.c:211
 msgid "alter an image’s tones using curves"
-msgstr "使用曲線改變影像的色調"
+msgstr ""
+"階調曲線 | tone curve\n"
+"\n"
+"使用曲線調整影像階調的經典工具\n"
+"移動曲線的兩側端點可變更黑白點，效果等同「色階」模組\n"
+"此模組在 CIELAB 空間中運算，可分別調整 a* b* 色版"
 
-#: ../src/iop/tonecurve.c:1150
+#: ../src/iop/tonecurve.c:1149
 msgid ""
 "if set to auto, a and b curves have no effect and are not displayed. chroma "
 "values (a and b) of each pixel are then adjusted based on L curve data. auto "
 "XYZ is similar but applies the saturation changes in XYZ space."
 msgstr ""
-"設爲自動時 a 和 b 通道曲線沒作用且不顯示。每個像素的色度值(a 和 b)會根據 L 曲"
-"線資料調整。自動XYZ類似，但套用XYZ空間的飽和度改變."
+"選擇曲線應用的色彩空間\n"
+"\n"
+"L*a*b* 連動調整：\n"
+"只有單一曲線調整，主要直接控制 L* 色版。但會因應對比度改變自動調整顏色，這對"
+"輕微調整的效果很好，但大幅調整時可能不太自然。\n"
+"\n"
+"L*a*b* 獨立調整：\n"
+"以個別曲線分開調整 L*、a*、b* 三個色版，可分別控制明度以及色度。改變 a*、b* "
+"色版的曲線斜率而不更動中心點，可以精細控制顏色。\n"
+"\n"
+"XYZ 連動調整：\n"
+"使用單一曲線同時調整 XYZ，但 XYZ 與大腦視覺感知並不相同，很難說使用這個空間調"
+"整有什麼實際的用途。\n"
+"\n"
+"RGB 連動調整：\n"
+"這個模式在 ProPhoto RGB 中運算，並將曲線套用在 RGB 三個色版。這是大部分軟體使"
+"用的方法，只是其他軟體大多在工作空間中執行。\n"
+"\n"
+"不論選擇哪一個色彩空間，此模組的曲線控制和背景階調直方圖都顯示 L* 色版，所以"
+"座標中央永遠代表 50% 中間調以符合感知。在實際套用曲線運算時才會把控制點轉換至"
+"所選的色彩空間，包括 XYZ 和 RGB 空間。"
+
+#: ../src/iop/tonecurve.c:1158
+msgid "tonecurve for L channel"
+msgstr "L* 色版的曲線"
 
 #: ../src/iop/tonecurve.c:1159
-msgid "tonecurve for L channel"
-msgstr "色調曲線 - L 通道"
+msgid "tonecurve for a channel"
+msgstr "a* 色版的曲線"
 
 #: ../src/iop/tonecurve.c:1160
-msgid "tonecurve for a channel"
-msgstr "色調曲線 - a 通道"
-
-#: ../src/iop/tonecurve.c:1161
 msgid "tonecurve for b channel"
-msgstr "色調曲線 - b 通道"
+msgstr "b* 色版的曲線"
 
 #: ../src/iop/toneequal.c:294
 msgid "tone equalizer"
-msgstr "色調均衡器"
+msgstr "階調等化器"
 
 #: ../src/iop/toneequal.c:299
 msgid "tone curve|tone mapping|relight|background light|shadows highlights"
-msgstr "色調曲線|色調映射|重新打光|背景光照|陰影高光"
+msgstr "色調曲線|色調映射|亮部|暗部|遮罩|masking"
 
 #: ../src/iop/toneequal.c:305
 msgid "relight the scene as if the lighting was done directly on the scene"
-msgstr "重新照亮場景，就像直接在場景裏進行照明一樣"
+msgstr ""
+"階調等化器 | tone equalizer\n"
+"\n"
+"調整影像階調的同時不影響局部對比度\n"
+"利用可自訂的階調遮罩分離影像的不同階調區域\n"
+"與「RGB 曲線」模組最大差異在於遮罩的模糊設定有助於保持局部對比"
 
 #: ../src/iop/toneequal.c:308
 msgid "quasi-linear, RGB"
-msgstr "準線性、RGB"
+msgstr "類線性、RGB"
 
 #: ../src/iop/toneequal.c:309
 msgid "quasi-linear, RGB, scene-referred"
-msgstr "準線性、RGB、場景工作流程"
+msgstr "類線性、RGB、場景參照"
 
 #. No blending
 #: ../src/iop/toneequal.c:425
 msgid "simple tone curve"
-msgstr "簡單色調曲線"
+msgstr "簡易階調曲線"
 
 #: ../src/iop/toneequal.c:438
 msgid "mask blending: all purposes"
-msgstr "遮罩混合:所有用途"
+msgstr "通用遮罩設定"
 
 #: ../src/iop/toneequal.c:444
 msgid "mask blending: people with backlight"
-msgstr "遮罩混合:人物背光"
+msgstr "逆光人像遮罩"
 
 #: ../src/iop/toneequal.c:460
 msgid "compress shadows/highlights (eigf): strong"
-msgstr "壓縮陰影/高光(eigf):強烈"
+msgstr "階調壓縮：強（無關曝光的引導濾波器）"
 
 #: ../src/iop/toneequal.c:464
 msgid "compress shadows/highlights (gf): strong"
-msgstr "壓縮陰影/高光(gf):強烈"
+msgstr "階調壓縮：強（引導濾波器）"
 
 #: ../src/iop/toneequal.c:472
 msgid "compress shadows/highlights (eigf): medium"
-msgstr "壓縮陰影/高光(eigf):中等"
+msgstr "階調壓縮：中（無關曝光的引導濾波器）"
 
 #: ../src/iop/toneequal.c:476
 msgid "compress shadows/highlights (gf): medium"
-msgstr "壓縮陰影/高光(gf):中等"
+msgstr "階調壓縮：中（引導濾波器）"
 
 #: ../src/iop/toneequal.c:484
 msgid "compress shadows/highlights (eigf): soft"
-msgstr "壓縮陰影/高光(eigf):柔和"
+msgstr "階調壓縮：弱（無關曝光的引導濾波器）"
 
 #: ../src/iop/toneequal.c:488
 msgid "compress shadows/highlights (gf): soft"
-msgstr "壓縮陰影/高光(gf):柔和"
+msgstr "階調壓縮：弱（引導濾波器）"
 
 #: ../src/iop/toneequal.c:494
 msgid "contrast tone curve: soft"
-msgstr "對比度曲線:柔和"
+msgstr "增加對比：弱"
 
 #: ../src/iop/toneequal.c:498
 msgid "contrast tone curve: medium"
-msgstr "對比度曲線:中等"
+msgstr "增加對比：中"
 
 #: ../src/iop/toneequal.c:502
 msgid "contrast tone curve: strong"
-msgstr "對比度曲線:強烈"
+msgstr "增加對比：強"
 
 #: ../src/iop/toneequal.c:524
 msgid "relight: fill-in"
-msgstr "重新打光:填充"
+msgstr "重新補光"
 
 #: ../src/iop/toneequal.c:576
 msgid ""
 "tone equalizer needs to be after distortion modules in the pipeline – "
 "disabled"
-msgstr "在處理管線中，色調均衡器需要置於失真模組之後 - 已不使用"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"「階調等化器」模組必須在變形模組之後執行"
 
 #. Pointers are not 64-bits aligned, and SSE code will segfault
 #: ../src/iop/toneequal.c:920
 msgid ""
 "tone equalizer in/out buffer are ill-aligned, please report the bug to the "
 "developers"
-msgstr "色調均衡器輸入/輸出緩衝區未正確對齊，請向開發者報告問題"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"「階調等化器」在輸入 / 輸出緩衝區時沒有對齊，請向開發人員回報"
 
 #: ../src/iop/toneequal.c:1019
 msgid "tone equalizer failed to allocate memory, check your RAM settings"
-msgstr "色調均衡器未能分配記憶體，請檢查 RAM 設置"
+msgstr ""
+"⚠️ 錯誤 ⚠️\n"
+"「色調等化器」無法配置記憶體，請檢查記憶體設定"
 
 #: ../src/iop/toneequal.c:1703 ../src/iop/toneequal.c:2066
 msgid "the interpolation is unstable, decrease the curve smoothing"
-msgstr "內插不穩定，減少曲線平滑度"
+msgstr "曲線內插不穩定，降低曲線平滑度設定"
 
 #: ../src/iop/toneequal.c:1738 ../src/iop/toneequal.c:1805
 msgid "wait for the preview to finish recomputing"
-msgstr "等待預覽圖以完成重新計算"
+msgstr "等待預覽以完成重新計算"
 
 #: ../src/iop/toneequal.c:1939 ../src/iop/toneequal.c:2420
 msgid ""
 "scroll over image to change tone exposure\n"
 "shift+scroll for large steps; ctrl+scroll for small steps"
 msgstr ""
-"在影像上滾動滾輪以更改曝光色調，\n"
-"shift + 滾輪大幅度變化；控制鍵 + 滾輪小幅度變化"
+"滑鼠位置顯示該區階調，使用滾輪直接調整階調\n"
+"ctrl + 滾輪微調，shift + 滾輪大幅度調整，a + 滾輪回復縮放預覽比例"
 
 #: ../src/iop/toneequal.c:2071
 msgid "some parameters are out-of-bounds"
-msgstr "部分參數超出範圍"
+msgstr "部分參數設定超出範圍"
 
 #: ../src/iop/toneequal.c:2358
 #, c-format
@@ -18270,17 +19354,17 @@ msgstr "%+.1f EV"
 #: ../src/iop/toneequal.c:3031
 #, c-format
 msgid "[%s over image] change tone exposure"
-msgstr "[影像上 %s] 更改色調曝光"
+msgstr "%s 在影像上調整階調"
 
 #: ../src/iop/toneequal.c:3033
 #, c-format
 msgid "[%s over image] change tone exposure in large steps"
-msgstr "[影像上 %s] 大幅度更改色調曝光"
+msgstr "%s 在影像上大幅度調整階調"
 
 #: ../src/iop/toneequal.c:3035
 #, c-format
 msgid "[%s over image] change tone exposure in small steps"
-msgstr "[影像上 %s] 小幅度更改色調曝光"
+msgstr "%s 在影像上小幅微調階調"
 
 #. Simple view
 #: ../src/iop/toneequal.c:3114 ../src/iop/toneequal.c:3143
@@ -18289,7 +19373,7 @@ msgstr "[影像上 %s] 小幅度更改色調曝光"
 #: ../src/iop/toneequal.c:3148 ../src/iop/toneequal.c:3149
 #: ../src/iop/toneequal.c:3150 ../src/iop/toneequal.c:3151
 msgid "simple"
-msgstr "簡單"
+msgstr "簡易"
 
 #: ../src/iop/toneequal.c:3143
 msgid "-8 EV"
@@ -18330,15 +19414,23 @@ msgstr "+0 EV"
 #. Advanced view
 #: ../src/iop/toneequal.c:3155
 msgid "advanced"
-msgstr "高級"
+msgstr "進階"
 
 #: ../src/iop/toneequal.c:3174
 msgid "double-click to reset the curve"
-msgstr "雙擊重置曲線"
+msgstr ""
+"進階功能控制和簡易模式相同，但以真實的控制曲線顯示\n"
+"左側代表暗部，右側代表亮部，拉高曲線提高亮度，降低曲線壓低亮度\n"
+"也可以使用滑鼠滾輪直接在影像上調整相對應的階調\n"
+"\n"
+"底圖是階調遮罩的直方圖，並非影像實際階調分布\n"
+"建議調整階調遮罩設定讓直方圖分布到整個範圍以利更精細的控制\n"
+"\n"
+"雙擊可重設曲線"
 
 #: ../src/iop/toneequal.c:3178
 msgid "curve smoothing"
-msgstr "曲線平滑"
+msgstr "曲線平滑化"
 
 #: ../src/iop/toneequal.c:3179
 msgid ""
@@ -18347,22 +19439,22 @@ msgid ""
 "negative values will avoid oscillations and behave more robustly\n"
 "but may produce brutal tone transitions and damage local contrast."
 msgstr ""
-"正值將產生更漸進的色調過渡，但曲線在某些設置中可能會出現振盪。\n"
-"負值將避免振盪，表現更爲穩健，但可能會產生變化激烈的色調過渡，並破壞局部對比"
-"度。"
+"控制階調曲線的平滑方式，一般情況下不需要更改此設定\n"
+"調高數值產生更貼合控制點的漸進曲線，但可能產生曲線振盪\n"
+"降低數值讓曲線更平順，但可能影響局部對比度"
 
 #. Masking options
 #: ../src/iop/toneequal.c:3188
 msgid "masking"
-msgstr "遮罩"
+msgstr "階調遮罩"
 
 #: ../src/iop/toneequal.c:3192
 msgid ""
 "preview the mask and chose the estimator that gives you the\n"
 "higher contrast between areas to dodge and areas to burn"
 msgstr ""
-"預覽遮罩並選擇使得\n"
-"在變暗/變亮的區域之間提供較大對比度"
+"製作階調遮罩時估計像素 RGB 值亮度的方法\n"
+"可開啟下方的「顯示階調遮罩」選擇需要調整階調的區域分離度較好的方法"
 
 #: ../src/iop/toneequal.c:3195
 msgid "details"
@@ -18385,18 +19477,36 @@ msgid ""
 "'averaged eigf' is a geometric mean of 'no' and 'exposure-independent guided "
 "filter' methods"
 msgstr ""
-"‘否’影響全局和局部對比度(如果只增加對比度，則安全)。\n"
-"‘引導式過濾’只影響全局對比度，並試圖保持局部對比度。\n"
-"‘平均引導式過濾’是‘否’和‘引導式過濾’兩者的幾何平均值。\n"
-"‘曝光獨立的引導式濾波(eigf)’是一種不依賴於曝光的引導式濾波，它平滑化陰影和高"
-"光的方式是相同的，相反的，‘引導式過濾’在高光部份平滑較少的的方式)。\n"
-"‘平均獨立於曝光的引導式濾波’是‘否’和‘曝光獨立的引導式濾波’兩者的幾何平均值"
+"選擇用於模糊階調遮罩的算法，以保留局部對比度\n"
+"\n"
+"否：\n"
+"不模糊遮罩，效果與直接使用曲線調整相同，一起調整整體和局部對比度\n"
+"\n"
+"導引濾波器（GF，guided filter）：\n"
+"使用導引濾波可以保留邊緣，但此算法會受亮度影響\n"
+"暗部的模糊程度會比亮度高，適合想要大幅提升暗部時使用\n"
+"\n"
+"導引濾波器平均（averaged GF）：\n"
+"將導引濾波器和不模糊遮罩的結果平均\n"
+"若導引濾波器的效果太強時可以使用此選項\n"
+"\n"
+"無關曝光的導引濾波器（EIGF，exposure-independent guided filter）：\n"
+"和導引濾波器類似，但改進了遮罩模糊程度受亮度影響的問題\n"
+"亮暗部的模糊程度應該大致相同，最為泛用所以是預設方法\n"
+"\n"
+"無關曝光的導引濾波器平均（averaged EIGF）：\n"
+"將無關曝光的導引濾波器和不模糊遮罩的結果平均\n"
+"可以快速降低階調遮罩的模糊程度"
 
 #: ../src/iop/toneequal.c:3205
 msgid ""
 "number of passes of guided filter to apply\n"
 "helps diffusing the edges of the filter at the expense of speed"
-msgstr "套用引導過濾器的次數，有助於以犧牲速度爲代價擴散過濾的邊緣"
+msgstr ""
+"套用的導引濾波器的次數\n"
+"預設 1 代表僅在原始影像上計算一次生成階調遮罩\n"
+"調高至 2 會把階調遮罩作為中間遮罩，在其上再計算一次生成要使用的遮罩\n"
+"越高的參數運算越多次，會將模糊範圍向外擴散，執行速度也會顯著降低"
 
 #: ../src/iop/toneequal.c:3211
 msgid ""
@@ -18404,8 +19514,10 @@ msgid ""
 "warning: big values of this parameter can make the darkroom\n"
 "preview much slower if denoise profiled is used."
 msgstr ""
-"模糊的直徑佔最大影像大小的百分比。\n"
-"警告:如果使用了“降噪配置”，若此值過大可能使得暗房模式的預覽變得很慢。"
+"調整階調遮罩模糊的直徑，定義為影像長邊的百分比\n"
+"較低的值遮罩的亮暗部之間分別更明顯，值越高過渡更平滑\n"
+"無關曝光的導引濾波器建議參數為 1-10%\n"
+"傳統導引濾波器建議參數大約 1-25%"
 
 #: ../src/iop/toneequal.c:3217
 msgid ""
@@ -18415,13 +19527,13 @@ msgid ""
 "lower values give smoother gradients and better smoothing\n"
 "but may lead to inaccurate edges taping and halos"
 msgstr ""
-"羽化精確度:\n"
-"較高的值會強制讓遮罩邊緣更緊密貼合，但可能會使平滑效果無效\n"
-"較低的值可提供更平滑漸層和更好的平滑，但可能會導致邊緣貼合不準確和光暈"
+"調整模糊範圍跟隨邊緣的強度\n"
+"較高的值會強制遮罩更緊密地跟隨邊緣，過高可能會讓模糊效果不明顯\n"
+"較低的值可提供更平滑的漸變效果，過低會導致邊緣產生光暈"
 
 #: ../src/iop/toneequal.c:3223
 msgid "mask post-processing"
-msgstr "遮罩後處理"
+msgstr "階調遮罩調整"
 
 #: ../src/iop/toneequal.c:3230
 msgid ""
@@ -18429,9 +19541,10 @@ msgid ""
 "the central line shows the average. orange bars appear at extrema if "
 "clipping occurs."
 msgstr ""
-"遮罩直方圖跨度介於第一個和最後一個十分位數之間。\n"
-"中線顯示平均值。\n"
-"如果陰影或高光發生裁剪，橙色條狀會出現在左右兩端。"
+"階調遮罩的分布範圍\n"
+"顯示階調遮罩中間的 80% 區域，排除頭尾兩個十分位數的資料以免異常數值影響判斷\n"
+"調整以下參數讓灰色範圍居中並左右延展至接近邊界，以獲得最好的階調分區控制\n"
+"如果左右邊緣出現橘色，代表階調遮罩超過範圍，需要調整進一步調整"
 
 #: ../src/iop/toneequal.c:3236
 msgid ""
@@ -18439,9 +19552,9 @@ msgid ""
 "higher values posterize the luminance mask to help the guiding\n"
 "produce piece-wise smooth areas when using high feathering values"
 msgstr ""
-"0:不啟用量化。\n"
-"較高的值會對亮度遮罩分色處理，有助於引導\n"
-"當使用高羽化值時，能幫助引導產生分段的平滑區域"
+"對階調遮罩進行量化處理以便更好地分離階調\n"
+"0 代表沒有量化處理，較高的值能對高羽化的遮罩生成分段平滑區域\n"
+"在某些情況下，這可能有助於將影像分離為不同的階調區域"
 
 #: ../src/iop/toneequal.c:3243
 msgid ""
@@ -18449,9 +19562,9 @@ msgid ""
 "for a better control of the exposure correction with the available nodes.\n"
 "the magic wand will auto-adjust the average exposure"
 msgstr ""
-"此選項可以沿通道滑動改變遮罩平均曝光，以便可\n"
-"用可用節點的曝光修正得到更好的控制。\n"
-"點擊魔法棒以自動調整平均曝光"
+"左右調整遮罩的直方圖位置\n"
+"原理是透過調整遮罩色版的曝光度，使中間值居中獲得更好的階調控制位置\n"
+"使用右側的魔術棒工具自動偵測，以此作為設定起點"
 
 #: ../src/iop/toneequal.c:3253
 msgid ""
@@ -18461,96 +19574,114 @@ msgid ""
 "for a better control of the exposure correction.\n"
 "the magic wand will auto-adjust the contrast"
 msgstr ""
-"此項可用於抵消引導過濾器的平均效應，並將遮罩對比度減弱到 -4EV 左右\n"
-"這允許將曝光直方圖分佈在更多通道上，以便更好地控制曝光修正。\n"
-"點擊魔法棒可以自動調整對比度"
+"調整遮罩的直方圖分布範圍\n"
+"原理是透過調整遮罩色版的對比度，使直方圖分布在整個範圍獲得更好的階調控制\n"
+"使用右側的魔術棒工具自動偵測，以此作為設定起點"
 
 #: ../src/iop/toneequal.c:3273 ../src/iop/toneequal.c:3274
 msgid "display exposure mask"
-msgstr "顯示曝光遮罩"
+msgstr "顯示階調遮罩"
 
 #: ../src/iop/tonemap.cc:74
 msgid "tone mapping"
-msgstr "色調映射"
+msgstr "階調映射"
 
 #: ../src/iop/tonemap.cc:90
 msgid ""
 "this module is deprecated. please use the local contrast or tone equalizer "
 "module instead."
-msgstr "此模組已棄用。請改用局部對比度或色調均衡器模組。"
+msgstr "此模組已被汰除，建議使用「局部對比度」或「階調等化器」模組替代"
 
 #: ../src/iop/velvia.c:79
 msgid "velvia"
-msgstr "velvia 正片"
+msgstr "Velvia 正片"
 
 #: ../src/iop/velvia.c:104
 msgid ""
 "resaturate giving more weight to blacks, whites and low-saturation pixels"
-msgstr "再飽和:給予黑，白和低飽和度像素區域更多權重"
+msgstr ""
+"Velvia 正片 | velvia\n"
+"\n"
+"為灰階和低飽和度的顏色提升更多飽和度\n"
+"以富士的經典正片 Velvia 命名\n"
+"效果非常強烈，可能會造成難以控管的色彩變化"
 
 #: ../src/iop/velvia.c:268
 msgid "the strength of saturation boost"
-msgstr "增加飽和度強度"
+msgstr "飽和度提升的強度"
 
 #: ../src/iop/velvia.c:271
 msgid "how much to spare highlights and shadows"
-msgstr "高光和陰影可用量"
+msgstr ""
+"減少對中間調的影響以避開膚色，降低不自然的皮膚曬傷效果\n"
+"數值越低，中間調修正越弱，則整體飽和度增加效果越強"
 
 #: ../src/iop/vibrance.c:62
 msgid ""
 "this module is deprecated. please use the vibrance slider in the color "
 "balance rgb module instead."
-msgstr "此模組已棄用。請改用 rgb 色彩平衡模組中的鮮豔度滑動條。"
+msgstr "此模組已被汰除，建議使用「色彩平衡 RGB」模組中的自然飽和度替代"
 
 #: ../src/iop/vibrance.c:93
 msgid ""
 "saturate and reduce the lightness of the most saturated pixels\n"
 "to make the colors more vivid."
-msgstr "增加飽和度及減少最飽和像素的亮度，以使顏色生動。"
+msgstr "增加飽和度，同時降低高飽和度色彩的亮度，讓顏色更加生動"
 
 #: ../src/iop/vibrance.c:223
 msgid "the amount of vibrance"
-msgstr "自然飽和度"
+msgstr "自然飽和度的強度"
 
 #: ../src/iop/vignette.c:152
 msgid "vignetting"
-msgstr "漸暈"
+msgstr "暗角"
 
 #: ../src/iop/vignette.c:157
 msgid "simulate a lens fall-off close to edges"
-msgstr "模擬鏡頭邊緣的光衰減"
+msgstr ""
+"暗角 | vignetting\n"
+"\n"
+"模擬鏡頭周圍進光量下降的效果\n"
+"暗角範圍可以使用滑鼠在影像上視覺化地拖動修改\n"
+"也可以使用「曝光」模組和圓形遮罩達到類似的效果"
 
 #: ../src/iop/vignette.c:951
 msgid "lomo"
-msgstr "lomo"
+msgstr "lomo 玩具相機"
 
 #: ../src/iop/vignette.c:985
 msgid "position / form"
-msgstr "位置/形式"
+msgstr "位置 / 形狀"
 
 #: ../src/iop/vignette.c:1003
 msgid "the radii scale of vignette for start of fall-off"
-msgstr "漸暈起始光衰減的比例半徑"
+msgstr ""
+"亮度開始衰減的區域大小\n"
+"數值是相對於影像長邊的比例，範圍內保持亮度不變"
 
 #: ../src/iop/vignette.c:1004
 msgid "the radii scale of vignette for end of fall-off"
-msgstr "漸暈結束光衰減的半徑大小"
+msgstr ""
+"亮度衰減至最低的區域大小\n"
+"數值是相對於影像長邊的比例，範圍外亮度降為以下設定"
 
 #: ../src/iop/vignette.c:1005
 msgid "strength of effect on brightness"
-msgstr "亮度效果的強度"
+msgstr ""
+"暗角效果的強度\n"
+"數值越低越暗，但也可以使用正值反向變亮"
 
 #: ../src/iop/vignette.c:1006
 msgid "strength of effect on saturation"
-msgstr "飽和度效果的強度"
+msgstr "控制暗角區域的飽和度"
 
 #: ../src/iop/vignette.c:1007
 msgid "horizontal offset of center of the effect"
-msgstr "效果中心的橫向偏移量"
+msgstr "暗角中心點的水平位置"
 
 #: ../src/iop/vignette.c:1008
 msgid "vertical offset of center of the effect"
-msgstr "效果中心的縱向偏移量"
+msgstr "暗角中心點的垂直位置"
 
 #: ../src/iop/vignette.c:1009
 msgid ""
@@ -18559,37 +19690,38 @@ msgid ""
 "1 produces a circle or ellipse\n"
 "2 produces a diamond"
 msgstr ""
-"形狀係數\n"
-"0 產生長方形\n"
-"1 產生圓或橢圓\n"
-"2 產生菱形"
+"暗角效果的形狀\n"
+"數值越小越外凸，形狀趨近方形\n"
+"數值越大月內凹，形狀偏向十字形"
 
 #: ../src/iop/vignette.c:1011
 msgid "enable to have the ratio automatically follow the image size"
-msgstr "啓用以圖片大小自動得到的比例"
+msgstr "自動調整暗角形狀的長寬比和影像相同"
 
 #: ../src/iop/vignette.c:1012
 msgid "width-to-height ratio"
-msgstr "寬高比例"
+msgstr "手動調整暗角形狀的寬高比例"
 
 #: ../src/iop/vignette.c:1013
 msgid "add some level of random noise to prevent banding"
-msgstr "增加一些隨機噪點以防止斷層"
+msgstr ""
+"以色彩抖動方法添加隨機雜訊以降低斷階問題\n"
+"也可以改用「遞色」模組來處理整個影像"
 
 #: ../src/iop/vignette.c:1020
 #, c-format
 msgid "[%s on node] change vignette/feather size"
-msgstr "[節點上 %s] 更改漸暈/羽化大小"
+msgstr "[節點 %s] 拖動調整暗角和羽化尺寸"
 
 #: ../src/iop/vignette.c:1022
 #, c-format
 msgid "[%s on node] change vignette/feather size keeping ratio"
-msgstr "[節點上 %s] 更改漸暈/羽化大小-保持長寬比"
+msgstr "[節點 %s] ctrl + 拖動調整暗角和羽化尺寸（保持比例）"
 
 #: ../src/iop/vignette.c:1024
 #, c-format
 msgid "[%s on center] move vignette"
-msgstr "[中央 %s] 移動漸暈暗角"
+msgstr "[中心點 %s] 移動暗角的中心位置"
 
 #: ../src/iop/watermark.c:291
 msgid "watermark"
@@ -18597,7 +19729,12 @@ msgstr "浮水印"
 
 #: ../src/iop/watermark.c:296
 msgid "overlay an SVG watermark like a signature on the picture"
-msgstr "在圖片上套疊SVG浮水印當作簽名"
+msgstr ""
+"浮水印 | watermark\n"
+"\n"
+"在影像上套疊浮水印，例如簽名\n"
+"採用 SVG 向量格式，但也可以接受 PNG 點陣圖檔\n"
+"SVG 可使用 darktable 的變數以顯示影像或編輯訊息"
 
 #: ../src/iop/watermark.c:1065
 msgid "marker"
@@ -18606,7 +19743,10 @@ msgstr "標記"
 #: ../src/iop/watermark.c:1068
 #, c-format
 msgid "SVG watermarks in %s/watermarks or %s/watermarks"
-msgstr "在 %s/watermarks 或 %s/watermarks 中查找 SVG 浮水印"
+msgstr ""
+"選擇儲存於以下資料夾內的浮水印檔案\n"
+"%s\\watermarks\n"
+"%s\\watermarks"
 
 #. Simple text
 #: ../src/iop/watermark.c:1078
@@ -18618,13 +19758,13 @@ msgid ""
 "text string, tag:\n"
 "$(WATERMARK_TEXT)"
 msgstr ""
-"文字串，標籤:\n"
+"文字字串，在 SVG 中使用以下變數，即可由此變更編輯\n"
 "$(WATERMARK_TEXT)"
 
 #. Text font
 #: ../src/iop/watermark.c:1089
 msgid "font"
-msgstr "字體"
+msgstr "字型"
 
 #: ../src/iop/watermark.c:1094
 msgid ""
@@ -18633,7 +19773,7 @@ msgid ""
 "$(WATERMARK_FONT_STYLE)\n"
 "$(WATERMARK_FONT_WEIGHT)"
 msgstr ""
-"文字字體，標籤:\n"
+"文字字型，在 SVG 中使用以下變數，即可由此變更編輯\n"
 "$(WATERMARK_FONT_FAMILY)\n"
 "$(WATERMARK_FONT_STYLE)\n"
 "$(WATERMARK_FONT_WEIGHT)"
@@ -18643,20 +19783,20 @@ msgid ""
 "watermark color, tag:\n"
 "$(WATERMARK_COLOR)"
 msgstr ""
-"浮水印顏色，標籤:\n"
+"文字顏色，在 SVG 中使用以下變數，即可由此變更編輯\n"
 "$(WATERMARK_COLOR)"
 
 #: ../src/iop/watermark.c:1111
 msgid "select watermark color"
-msgstr "選擇浮水印顏色"
+msgstr "選擇浮水印文字顏色"
 
 #: ../src/iop/watermark.c:1113
 msgid "pick color from image"
-msgstr "從影像中選擇顏色"
+msgstr "選擇影像中的色彩"
 
 #: ../src/iop/watermark.c:1125
 msgid "placement"
-msgstr "安置"
+msgstr "位置"
 
 #: ../src/iop/watermark.c:1138
 msgid "size is relative to"
@@ -18669,7 +19809,7 @@ msgstr "對齊"
 #. Let's add some tooltips and hook up some signals...
 #: ../src/iop/watermark.c:1163
 msgid "the opacity of the watermark"
-msgstr "浮水印的不透明度"
+msgstr "浮水印的透明度"
 
 #: ../src/iop/watermark.c:1164
 msgid "the scale of the watermark"
@@ -18677,11 +19817,11 @@ msgstr "浮水印的大小"
 
 #: ../src/iop/watermark.c:1165
 msgid "the rotation of the watermark"
-msgstr "浮水印的旋轉"
+msgstr "浮水印的旋轉角度"
 
 #: ../src/iop/zonesystem.c:111
 msgid "zone system"
-msgstr "分區系統"
+msgstr "分區曝光顯影系統"
 
 #: ../src/iop/zonesystem.c:498
 msgid ""
@@ -18690,10 +19830,10 @@ msgid ""
 "left-click on a border to create a marker\n"
 "right-click on a marker to delete it"
 msgstr ""
-"亮度區域\n"
-"使用滑鼠滾輪以改變區域數量\n"
-"在邊框左擊建立一個標記\n"
-"右擊刪除標記"
+"亮度分區\n"
+"使用滑鼠滾輪更改區域數量\n"
+"左鍵點擊邊框以建立標籤\n"
+"右鍵點擊標籤以將它刪除"
 
 #: ../src/libs/backgroundjobs.c:52
 msgid "background jobs"
@@ -18705,11 +19845,11 @@ msgstr "相機設定"
 
 #: ../src/libs/camera.c:132
 msgid "toggle view property in center view"
-msgstr "切換視角屬性到中心視角"
+msgstr "切換至中心視角"
 
 #: ../src/libs/camera.c:202
 msgid "connection with camera lost, exiting tethering mode"
-msgstr "失去與相機的連接，退出連機拍攝模式"
+msgstr "相機連線中斷，關閉連機拍攝模式"
 
 #: ../src/libs/camera.c:343
 msgid "battery"
@@ -18717,7 +19857,7 @@ msgstr "電池"
 
 #: ../src/libs/camera.c:343
 msgid "n/a"
-msgstr "不可用"
+msgstr "無法使用"
 
 #. Camera control
 #: ../src/libs/camera.c:418
@@ -18730,11 +19870,11 @@ msgstr "模式"
 
 #: ../src/libs/camera.c:423
 msgid "timer (s)"
-msgstr "定時器(秒)"
+msgstr "倒數計時器（秒）"
 
 #: ../src/libs/camera.c:424
 msgid "count"
-msgstr "計數"
+msgstr "數量"
 
 #: ../src/libs/camera.c:425
 msgid "brackets"
@@ -18742,11 +19882,11 @@ msgstr "包圍曝光"
 
 #: ../src/libs/camera.c:426
 msgid "bkt. steps"
-msgstr "包圍曝光階數"
+msgstr "包圍曝光級數"
 
 #: ../src/libs/camera.c:459
 msgid "capture image(s)"
-msgstr "拍攝影像"
+msgstr "拍攝照片"
 
 #: ../src/libs/camera.c:462
 msgid "toggle delayed capture mode"
@@ -18762,7 +19902,7 @@ msgstr "切換包圍曝光拍攝模式"
 
 #: ../src/libs/camera.c:465
 msgid "the count of seconds before actually doing a capture"
-msgstr "實際拍照前等待秒數"
+msgstr "實際拍照前等待的秒數"
 
 #: ../src/libs/camera.c:467
 msgid ""
@@ -18770,14 +19910,16 @@ msgid ""
 "you can use this in conjunction with delayed mode to create stop-motion "
 "sequences"
 msgstr ""
-"連續拍攝圖片張數，\n"
-"結合延遲拍攝模式可以建立定格動畫序列"
+"連續拍攝的照片數量\n"
+"與延遲模式一起使用可創作定格動畫"
 
 #: ../src/libs/camera.c:470
 msgid ""
 "the amount of brackets on each side of centered shoot, amount of images = "
 "(brackets*2) + 1"
-msgstr "中心影像每邊的包圍曝光數量，相片總數 = (包圍曝光量數*2)+1"
+msgstr ""
+"包圍曝光每側的拍攝數量\n"
+"總影像數量為包圍曝光數量 x2+1"
 
 #: ../src/libs/camera.c:472
 msgid ""
@@ -18785,8 +19927,8 @@ msgid ""
 "steps per stop\n"
 "with other words, 3 steps is 1EV exposure step between brackets"
 msgstr ""
-"包圍曝光級數，級數可在相機中設定，通常每階 3 級\n"
-"也就是說，3 級的包圍曝光範圍爲 1EV"
+"包圍曝光級數，可在相機中設定，通常每級內有三階\n"
+"換句話說，每三張照片的曝光範圍是 1 EV"
 
 #. user specified properties
 #: ../src/libs/camera.c:495
@@ -18795,7 +19937,7 @@ msgstr "額外屬性"
 
 #: ../src/libs/camera.c:498
 msgid "label"
-msgstr "標識"
+msgstr "標籤"
 
 #: ../src/libs/camera.c:506
 msgid "property"
@@ -18803,11 +19945,11 @@ msgstr "屬性"
 
 #: ../src/libs/camera.c:518
 msgid "add user property"
-msgstr "增加使用者屬性"
+msgstr "增加自訂屬性"
 
 #: ../src/libs/camera.c:538
 msgid "program"
-msgstr "程式"
+msgstr "自動曝光模式"
 
 #: ../src/libs/camera.c:541 ../src/libs/camera.c:543
 msgid "focus mode"
@@ -18815,7 +19957,7 @@ msgstr "對焦模式"
 
 #: ../src/libs/camera.c:554
 msgid "shutterspeed2"
-msgstr "快門速度 2"
+msgstr "快門速度二"
 
 #: ../src/libs/camera.c:556
 msgid "shutterspeed"
@@ -18827,24 +19969,24 @@ msgstr "白平衡"
 
 #: ../src/libs/collect.c:151
 msgid "collections"
-msgstr "集合"
+msgstr "相冊"
 
 #: ../src/libs/collect.c:408
 msgid "search filmroll"
-msgstr "搜尋軟片捲"
+msgstr "搜尋底片卷"
 
 #: ../src/libs/collect.c:491
 #, c-format
 msgid "problem selecting new path for the filmroll in %s"
-msgstr "爲 %s 中的軟片捲選擇新的路徑時有問題"
+msgstr "為底片卷選取的新路徑「%s」有問題"
 
 #: ../src/libs/collect.c:554
 msgid "search filmroll..."
-msgstr "搜尋軟片捲..."
+msgstr "重新定位底片卷所在的資料夾位置"
 
 #: ../src/libs/collect.c:558
 msgid "remove..."
-msgstr "移除..."
+msgstr "從圖庫中移除這卷底片"
 
 #: ../src/libs/collect.c:1223
 msgid "uncategorized"
@@ -18852,7 +19994,8 @@ msgstr "未分類"
 
 #: ../src/libs/collect.c:2136
 msgid "use <, <=, >, >=, <>, =, [;] as operators"
-msgstr "可以使用以下運算子:<、<=、>、>=、<>、=、[;]"
+msgstr ""
+"從所有已匯入的圖庫選擇，右側欄位可使用 <、<=、>、>=、<>、=、; 為控制字元"
 
 #: ../src/libs/collect.c:2140
 msgid ""
@@ -18860,22 +20003,22 @@ msgid ""
 "star rating: 0-5\n"
 "rejected images: -1"
 msgstr ""
-"可以使用以下運算子:<、<=、>、>=、<>、=、[;]\n"
-"星級:0-5\n"
-"拋棄影像:-1"
+"從所有已匯入的圖庫選擇，右側欄位可使用 <、<=、>、>=、<>、=、; 為控制字元\n"
+"星級：0 - 5\n"
+"不合格的影像：-1"
 
 #: ../src/libs/collect.c:2147
 msgid ""
 "use <, <=, >, >=, <>, =, [;] as operators\n"
 "type dates in the form: YYYY:MM:DD hh:mm:ss.sss (only the year is mandatory)"
 msgstr ""
-"可以使用以下運算子:<、<=、>、>=、<>、=、[;]\n"
-"請以 YYYY:MM:DD HH:MM:SS 的形式輸入日期，其中年份必須填寫"
+"從所有已匯入的圖庫選擇，右側欄位可使用 <、<=、>、>=、<>、=、; 為控制字元\n"
+"以此格式輸入日期：YYYY:MM:DD hh:mm:ss.sss，年份是必填項目"
 
 #: ../src/libs/collect.c:2154
 #, no-c-format
 msgid "use `%' as wildcard and `,' to separate values"
-msgstr "使用“%”作爲萬用字元，使用“,”分割多個值"
+msgstr "從所有已匯入的圖庫選擇，右側欄位可使用「%」作為萬用字元，使用「,」分隔"
 
 #: ../src/libs/collect.c:2160
 #, no-c-format
@@ -18885,10 +20028,10 @@ msgid ""
 "shift+click to include only the current hierarchy (no suffix)\n"
 "ctrl+click to include only sub-hierarchies (suffix `|%')"
 msgstr ""
-"使用“%”作爲萬用字元\n"
-"單擊以包含目前階層及其子階層(使用“*”後綴)\n"
-"控制鍵 + 單擊以包含目前階層(無後綴)\n"
-"shift + 單擊以包含子階層(使用\"|%\"後綴)"
+"從所有已匯入的圖庫選擇，右側欄位可使用「%」作為萬用字元\n"
+"左鍵點擊以包含目前位置與次層位置\n"
+"shift + 點擊僅包含目前的位置\n"
+"ctrl + 點擊僅包含次層位置"
 
 #: ../src/libs/collect.c:2172
 #, no-c-format
@@ -18898,10 +20041,10 @@ msgid ""
 "shift+click to include only the current location (no suffix)\n"
 "ctrl+click to include only sub-locations (suffix `|%')"
 msgstr ""
-"使用“%”作爲萬用字元\n"
-"單擊以包含目前位置及其子位置(使用“*”後綴)\n"
-"控制鍵 + 單擊以包含目前位置(無後綴)\n"
-"shift + 單擊以包含子位置(使用\"|%\"後綴)"
+"從所有已匯入的圖庫選擇，右側欄位可使用「%」作為萬用字元\n"
+"左鍵點擊以包含目前位置與次層位置\n"
+"shift + 點擊僅包含目前的位置\n"
+"ctrl + 點擊僅包含次層位置"
 
 #: ../src/libs/collect.c:2184
 #, no-c-format
@@ -18911,48 +20054,48 @@ msgid ""
 "shift+click to include only the current folder (no suffix)\n"
 "ctrl+click to include only sub-folders (suffix `|%')"
 msgstr ""
-"使用“%”作爲萬用字元\n"
-"單擊以包含目前目錄及其子目錄(使用“*”後綴)\n"
-"控制鍵 + 單擊以包含目前目錄(無後綴)\n"
-"shift + 單擊以包含子目錄(使用\"|%\"後綴)"
+"從所有已匯入的圖庫選擇，右側欄位可使用「%」作為萬用字元\n"
+"左鍵點擊以包含目前資料夾與子資料夾\n"
+"shift + 點擊僅包含目前的資料夾\n"
+"ctrl + 點擊僅包含子資料夾"
 
 #: ../src/libs/collect.c:2195
 #, no-c-format
 msgid "use `%' as wildcard"
-msgstr "使用“%”作爲萬用字元"
+msgstr "從所有已匯入的圖庫選擇，右側欄位可使用「%」作為萬用字元"
 
 #: ../src/libs/collect.c:2254 ../src/libs/collect.c:2268
 #: ../src/libs/collect.c:2892
 msgid "clear this rule"
-msgstr "清除規則"
+msgstr "刪除此條件"
 
 #: ../src/libs/collect.c:2258
 msgid "clear this rule or add new rules"
-msgstr "清除此規則或增加新規則"
+msgstr "刪除或增加條件"
 
 #: ../src/libs/collect.c:2898
 msgid "narrow down search"
-msgstr "縮小搜尋範圍"
+msgstr "增加「並且...」條件（交集）"
 
 #: ../src/libs/collect.c:2903
 msgid "add more images"
-msgstr "增加更多照片"
+msgstr "增加「或是...」條件（聯集）"
 
 #: ../src/libs/collect.c:2908
 msgid "exclude images"
-msgstr "排除圖片"
+msgstr "增加「不含...」條件（差集）"
 
 #: ../src/libs/collect.c:2915
 msgid "change to: and"
-msgstr "更改爲:及"
+msgstr "改為「並且...」條件（交集）"
 
 #: ../src/libs/collect.c:2920
 msgid "change to: or"
-msgstr "更改爲:或"
+msgstr "改為「或是...」條件（聯集）"
 
 #: ../src/libs/collect.c:2925
 msgid "change to: except"
-msgstr "更爲:排除"
+msgstr "改為「不含...」條件（差集）"
 
 #. the different categories
 #: ../src/libs/collect.c:2951 ../src/libs/filtering.c:845
@@ -18975,7 +20118,7 @@ msgstr "時間"
 #: ../src/libs/collect.c:2983 ../src/libs/filtering.c:879
 #: ../src/libs/filtering.c:961
 msgid "capture details"
-msgstr "拍攝細節"
+msgstr "拍攝詳細資訊"
 
 #: ../src/libs/collect.c:2992 ../src/libs/filtering.c:888
 #: ../src/libs/filtering.c:970 ../src/libs/tools/darktable.c:65
@@ -18984,7 +20127,7 @@ msgstr "darktable"
 
 #: ../src/libs/collect.c:3005
 msgid "collections settings"
-msgstr "圖片集合設定"
+msgstr "相冊設定"
 
 #: ../src/libs/collect.c:3008 ../src/libs/export_metadata.c:288
 #: ../src/libs/metadata.c:507 ../src/libs/metadata_view.c:1186
@@ -18992,34 +20135,34 @@ msgstr "圖片集合設定"
 #: ../src/libs/tagging.c:1779 ../src/libs/tagging.c:2053
 #: ../src/libs/tagging.c:3473
 msgid "save"
-msgstr "保存"
+msgstr "儲存"
 
 #: ../src/libs/collect.c:3028 ../src/libs/export.c:1059
 #: ../src/libs/metadata.c:642 ../src/libs/metadata_view.c:1298
 #: ../src/libs/recentcollect.c:363 ../src/libs/tagging.c:3495
 msgid "preferences..."
-msgstr "偏好……"
+msgstr "模組設定"
 
 #: ../src/libs/collect.c:3128 ../src/libs/filtering.c:1397
 msgid "AND"
-msgstr "及"
+msgstr "並且"
 
 #: ../src/libs/collect.c:3133 ../src/libs/filtering.c:1402
 msgid "OR"
-msgstr "或"
+msgstr "或是"
 
 #. case DT_LIB_COLLECT_MODE_AND_NOT:
 #: ../src/libs/collect.c:3138 ../src/libs/filtering.c:1407
 msgid "BUT NOT"
-msgstr "但不"
+msgstr "不包括"
 
 #: ../src/libs/collect.c:3310 ../src/libs/filtering.c:1987
 msgid "revert to a previous set of rules"
-msgstr "回復至以前規則"
+msgstr "使用過去的篩選設定"
 
 #: ../src/libs/collect.c:3367
 msgid "jump back to previous collection"
-msgstr "回到上一個集合"
+msgstr "回到上一個相冊"
 
 #: ../src/libs/colorpicker.c:51
 msgid "LCh"
@@ -19035,11 +20178,11 @@ msgstr "Hex"
 
 #: ../src/libs/colorpicker.c:53
 msgid "mean"
-msgstr "平均值"
+msgstr "平均"
 
 #: ../src/libs/colorpicker.c:71
 msgid "color picker"
-msgstr "選取顏色工具"
+msgstr "色彩選取工具"
 
 #: ../src/libs/colorpicker.c:457
 msgid ""
@@ -19047,13 +20190,13 @@ msgid ""
 "click to lock sample,\n"
 "right-click to load sample area into active color picker"
 msgstr ""
-"旋懸在畫布上的高光樣本\n"
-"點擊以鎖定樣本\n"
-"右鍵點擊以載入樣本區域至使用中的顏色選擇器中"
+"啟用色彩選取工具時，滑鼠停在色樣上會顯示色樣所在的位置\n"
+"左鍵可鎖定色樣，不隨後續的影像編輯改變，以作為編輯前後比較使用\n"
+"右鍵點擊可將色樣區域載入到新的色彩選取工具中"
 
 #: ../src/libs/colorpicker.c:554 ../src/libs/colorpicker.c:605
 msgid "click to (un)hide large color patch"
-msgstr "單擊以顯示或隱藏大色塊"
+msgstr "點擊顯示 / 隱藏上方大型色塊"
 
 #: ../src/libs/colorpicker.c:568
 msgid "statistic"
@@ -19061,48 +20204,49 @@ msgstr "統計資料"
 
 #: ../src/libs/colorpicker.c:569
 msgid "select which statistic to show"
-msgstr "選擇要顯示的統計資料"
+msgstr "選擇要顯示的統計數值"
 
 #: ../src/libs/colorpicker.c:578
 msgid "select which color mode to use"
-msgstr "選擇要使用的顏色模式"
+msgstr "選擇要使用的色彩模式"
 
 #: ../src/libs/colorpicker.c:587
 msgid ""
 "turn on color picker\n"
 "ctrl+click or right-click to select an area"
 msgstr ""
-"啓用顏色選擇器\n"
-"控制鍵+單擊或右鍵以選擇區域"
+"開啟色彩選取工具\n"
+"單擊和拖曳選擇位置\n"
+"ctrl + 左鍵 或 右鍵 可選擇區域"
 
 #: ../src/libs/colorpicker.c:590
 msgid "pick color"
-msgstr "選取顏色"
+msgstr "選取色彩"
 
 #: ../src/libs/colorpicker.c:629
 msgid "add sample"
-msgstr "增加樣本"
+msgstr "增加色樣"
 
 #. Adding the live samples section
 #: ../src/libs/colorpicker.c:633
 msgid "live samples"
-msgstr "即時樣本"
+msgstr "目前色樣"
 
 #: ../src/libs/colorpicker.c:641
 msgid "display samples on image/vectorscope"
-msgstr "在影像和向量示波器上顯示樣本"
+msgstr "在影像和彩度投影圖上顯示色樣位置"
 
 #: ../src/libs/colorpicker.c:650
 msgid "restrict scope to selection"
-msgstr "限制區域以選擇範圍"
+msgstr "限制直方圖和波形圖只顯示選取範圍"
 
 #: ../src/libs/copy_history.c:53
 msgid "history stack"
-msgstr "歷史記錄堆棧"
+msgstr "影像編輯紀錄"
 
 #: ../src/libs/copy_history.c:106
 msgid "open sidecar file"
-msgstr "打開附屬檔案"
+msgstr "開啟附屬檔案"
 
 #: ../src/libs/copy_history.c:139
 msgid "XMP sidecar files"
@@ -19111,45 +20255,48 @@ msgstr "XMP 附屬檔案"
 #: ../src/libs/copy_history.c:154
 #, c-format
 msgid "error loading file '%s'"
-msgstr "載入檔案“%s”發生錯誤"
+msgstr "載入檔案「%s」時發生錯誤"
 
 #: ../src/libs/copy_history.c:191
 #, c-format
 msgid "no history compression of %d image"
 msgid_plural "no history compression of %d images"
-msgstr[0] "無 %d 影像的歷史記錄壓縮"
+msgstr[0] "沒有 %d 張影像的編輯紀錄"
 
 #: ../src/libs/copy_history.c:235
 #, c-format
 msgid "do you really want to clear history of %d selected image?"
 msgid_plural "do you really want to clear history of %d selected images?"
-msgstr[0] "確定要清除 %d 張已選影像的歷史記錄嗎？"
+msgstr[0] "是否要刪除 %d 個已選取影像的編輯記錄？"
 
 #: ../src/libs/copy_history.c:241
 msgid "delete images' history?"
-msgstr "刪除影像歷史記錄？"
+msgstr "是否要刪除影像的編輯記錄？"
 
 #: ../src/libs/copy_history.c:344
 msgid "selective copy..."
-msgstr "選擇性複製..."
+msgstr "選擇性複製"
 
 #: ../src/libs/copy_history.c:345
 msgid "choose which modules to copy from the source image"
-msgstr "選擇複製來源影像的模組"
+msgstr "選擇要複製的模組"
 
 #: ../src/libs/copy_history.c:350
 msgid ""
 "copy history stack of\n"
 "first selected image"
-msgstr "複製首先選取圖片的歷史記錄"
+msgstr ""
+"複製所選影像的編輯紀錄\n"
+"和影像內容相關及遮罩不會被複製，例如：方向、鏡頭校正、白平衡等等模組\n"
+"可以使用「選擇性複製」自訂要複製的模組"
 
 #: ../src/libs/copy_history.c:354
 msgid "selective paste..."
-msgstr "選擇性貼上..."
+msgstr "選擇性貼上"
 
 #: ../src/libs/copy_history.c:355
 msgid "choose which modules to paste to the target image(s)"
-msgstr "選擇要貼上目標影像的模組"
+msgstr "選擇要套用哪些模組"
 
 #: ../src/libs/copy_history.c:360 ../src/libs/image.c:590
 msgid "paste"
@@ -19159,86 +20306,103 @@ msgstr "貼上"
 msgid ""
 "paste history stack to\n"
 "all selected images"
-msgstr "貼上歷史記錄到全部選定的圖片"
+msgstr "套用編輯紀錄至所有選取的影像"
 
 #: ../src/libs/copy_history.c:366
 msgid "compress history"
-msgstr "壓縮歷史記錄"
+msgstr "壓縮影像編輯記錄"
 
 #: ../src/libs/copy_history.c:367
 msgid ""
 "compress history stack of\n"
 "all selected images"
-msgstr "壓縮所有選定影像的歷史記錄"
+msgstr ""
+"壓縮選取影像的編輯紀錄，可簡化編輯記錄並縮小儲存空間\n"
+"如果同一模組有多次編輯記錄，此功能可將其整合至同一個步驟"
 
 #: ../src/libs/copy_history.c:371
 msgid ""
 "discard history stack of\n"
 "all selected images"
-msgstr "丟棄所有選取圖片的歷史記錄"
+msgstr ""
+"刪除所有選取影像的編輯紀錄\n"
+"⚠️ 警告：此動作無法復原 ⚠️"
 
 #: ../src/libs/copy_history.c:375 ../src/libs/styles.c:830
 msgid "how to handle existing history"
-msgstr "如何處理現有的歷史紀錄"
+msgstr ""
+"如何處理已存在的影像編輯紀錄\n"
+"\n"
+"附加：\n"
+"替換目標影像中相同的模組，如果沒有相同模組則建立一個新的。如果某模組有多個編"
+"輯紀錄，只會處理該模組的最後一次編輯\n"
+"\n"
+"覆寫：\n"
+"在套用之前刪除目標影像的歷史記錄，使其在套用之後和原始複製的編輯紀錄完全相同"
 
 #: ../src/libs/copy_history.c:378 ../src/libs/styles.c:828
 msgid "append"
-msgstr "附加"
+msgstr "附加到現有檔案上"
 
 #: ../src/libs/copy_history.c:382
 msgid "load sidecar file..."
-msgstr "載入附屬檔案…"
+msgstr "從 XMP 載入"
 
 #: ../src/libs/copy_history.c:383
 msgid ""
 "open an XMP sidecar file\n"
 "and apply it to selected images"
-msgstr "打開 XMP 附屬檔案並套用到已選影像"
+msgstr ""
+"打開一個 XMP 附屬檔案\n"
+"並將編輯紀錄套用到選擇的影像"
 
 #: ../src/libs/copy_history.c:387
 msgid "write history stack and tags to XMP sidecar files"
-msgstr "將歷史記錄和標籤寫入 xmp 附屬檔案"
+msgstr ""
+"將影像編輯紀錄和標籤寫入 XMP 附屬檔案\n"
+"預設情況下，darktable 在每次編輯動作時都會自動更新 XMP，無須手動儲存\n"
+"除非手動關閉「偏好設定」中的「資料儲存」設定，一般不建議這樣操作"
 
 #: ../src/libs/duplicate.c:60
 msgid "duplicate manager"
-msgstr "副本管理器"
+msgstr "複本管理器"
 
 #: ../src/libs/duplicate.c:263
 #, no-c-format
 msgid "preview is only possible for zoom lower than 200%%"
-msgstr "只能在縮小於 200%% 的狀況下使用預覽"
+msgstr "預覽放大尺寸最高至 200%"
 
 #: ../src/libs/duplicate.c:540 ../src/libs/history.c:998
 #: ../src/libs/snapshots.c:447
 msgid "original"
-msgstr "原始"
+msgstr "原始影像"
 
 #: ../src/libs/duplicate.c:541
 msgid "create a 'virgin' duplicate of the image without any development"
-msgstr "建立一個沒有任何修改的初始影像副本"
+msgstr "建立一個沒有經過任何編輯的原始影像複本"
 
 #: ../src/libs/duplicate.c:544
 msgid "create a duplicate of the image with same history stack"
-msgstr "建立一個具有相同歷史記錄的影像副本"
+msgstr "建立一個和目前編輯完全相同的複本"
 
 #. Export button
 #: ../src/libs/export.c:154 ../src/libs/export.c:1335
 msgid "export"
-msgstr "輸出"
+msgstr "匯出"
 
 #: ../src/libs/export.c:318
 msgid "export to disk"
-msgstr "輸出至硬碟"
+msgstr "匯出到硬碟"
 
 #: ../src/libs/export.c:498
 #, c-format
 msgid "which is equal to %s × %s px"
-msgstr "相當於 %s × %s 像素"
+msgstr "等於 %s x %s 像素"
 
 #: ../src/libs/export.c:533
 msgctxt "unit"
 msgid "in"
-msgstr "以[單位]"
+msgstr "英寸"
 
 #: ../src/libs/export.c:1071
 msgid "storage options"
@@ -19246,7 +20410,7 @@ msgstr "儲存選項"
 
 #: ../src/libs/export.c:1075
 msgid "target storage"
-msgstr "輸出目的地"
+msgstr "儲存目的"
 
 #: ../src/libs/export.c:1097
 msgid "format options"
@@ -19258,51 +20422,53 @@ msgstr "檔案格式"
 
 #: ../src/libs/export.c:1118
 msgid "global options"
-msgstr "全局選項"
+msgstr "整體選項"
 
 #: ../src/libs/export.c:1121
 msgid "set size"
-msgstr "設定大小"
+msgstr "設定影像尺寸"
 
 #: ../src/libs/export.c:1122
 msgid "choose a method for setting the output size"
-msgstr "選擇設定輸出大小的方法"
+msgstr "選擇設定匯出影像尺寸的方式"
 
 #: ../src/libs/export.c:1125
 msgid "in pixels (for file)"
-msgstr "像素(檔案)"
+msgstr "像素"
 
 #: ../src/libs/export.c:1126
 msgid "in cm (for print)"
-msgstr "釐米(列印)"
+msgstr "公分"
 
 #: ../src/libs/export.c:1127
 msgid "in inch (for print)"
-msgstr "英寸(列印)"
+msgstr "英寸"
 
 #: ../src/libs/export.c:1128
 msgid "by scale (for file)"
-msgstr "縮放(檔案)"
+msgstr "比例"
 
 #: ../src/libs/export.c:1131 ../src/libs/export.c:1146
 msgid ""
 "maximum output width limit.\n"
 "click middle mouse button to reset to 0."
 msgstr ""
-"最大輸出寬度限制。\n"
-"單擊滑鼠中鍵以重置爲 0。"
+"最大寬度限制\n"
+"0 代表原始影像尺寸\n"
+"按壓滑鼠中鍵以重設"
 
 #: ../src/libs/export.c:1135 ../src/libs/export.c:1150
 msgid ""
 "maximum output height limit.\n"
 "click middle mouse button to reset to 0."
 msgstr ""
-"最大輸出高度限制。\n"
-"單擊滑鼠中鍵以重置爲 0。"
+"最大高度限制\n"
+"0 代表原始影像尺寸\n"
+"按壓滑鼠中鍵以重設"
 
 #: ../src/libs/export.c:1139
 msgid "resolution in dot per inch"
-msgstr "解析度，以 DPI 爲單位"
+msgstr "解析度（像素 / 英寸）"
 
 #: ../src/libs/export.c:1167
 msgid "@"
@@ -19318,9 +20484,9 @@ msgid ""
 "zero or empty values are equal to 1.\n"
 "click middle mouse button to reset to 1."
 msgstr ""
-"可以是整數、小數或簡單分數。\n"
-"0 或空值將被視爲 1。\n"
-"中鍵點擊以重置爲 1。"
+"可以使用整數、小數和分數\n"
+"0 或留白代表使用原始影像尺寸\n"
+"按壓滑鼠中鍵重設為 1"
 
 #: ../src/libs/export.c:1207
 msgid "allow upscaling"
@@ -19332,25 +20498,31 @@ msgstr "高品質重新採樣"
 
 #: ../src/libs/export.c:1216
 msgid "do high quality resampling during export"
-msgstr "在輸出時進行高品質重新採樣"
+msgstr ""
+"在匯出過程中使用高品質的像素採樣算法\n"
+"影像會以完整尺寸運算模組效果，僅在最後一步縮小至設定的匯出尺寸，這可以產生更"
+"好的品質但會較慢"
 
 #: ../src/libs/export.c:1220
 msgid "store masks"
-msgstr "保存遮罩"
+msgstr "儲存遮罩"
 
 #: ../src/libs/export.c:1223
 msgid "store masks as layers in exported images. only works for some formats."
-msgstr "將遮罩做爲圖層儲存在輸出的影像中。僅適用於某些格式。"
+msgstr "將遮罩儲存為圖層，目前僅 TIFF 和 XCF 格式支援此功能"
 
 #: ../src/libs/export.c:1236 ../src/libs/export.c:1258
 #: ../src/libs/print_settings.c:2607 ../src/libs/print_settings.c:2652
 msgid "image settings"
-msgstr "影像設定"
+msgstr "遵循影像中模組的設定"
 
 #: ../src/libs/export.c:1248 ../src/libs/print_settings.c:2641
 #, c-format
 msgid "output ICC profiles in %s or %s"
-msgstr "輸出 icc 配置到 %s/color/out 或 %s/color/out"
+msgstr ""
+"選擇匯出影像的描述檔，可在以下兩個資料夾新增：\n"
+"%s\n"
+"%s"
 
 #: ../src/libs/export.c:1265
 #, c-format
@@ -19370,37 +20542,44 @@ msgid ""
 "of the destination medium and do nothing else. mainly used when proofing "
 "colors. (not suited for photography)."
 msgstr ""
-"• 感知的:平滑地從色域外移到色域中，保持漸層，但在此過程中色域中的顏色會發生扭"
-"曲。注意，感知通常是一個依賴於目的空間的專有 LUT。\n"
-"• 相對比色法:保持亮度，同時儘可能減少飽和度，直到顏色符合色域。\n"
-"• 飽和度:通過保持飽和度來呈現引人注目的商業圖形。(不適合攝影)\n"
-"• 絕對比色法:將影像的白點調適為目的介質的白點，而不做其他任何事情。主要用於打"
-"樣時的顏色。(不適合於攝影)"
+"感知：\n"
+"最適合照片使用，將超出目的地色域的顏色漸進地移動至色域中，同時保持顏色間的相"
+"對關係以維持漸層平順。\n"
+"\n"
+"相對色度：\n"
+"維持色域內的色彩不變，色域外的顏色調整至同亮度下最接近的顏色，可保持色彩正確"
+"性但可能在高彩度區域產生斷階。\n"
+"\n"
+"飽和度：\n"
+"盡量維持色彩的飽和度，儘管可能因此改變影像的亮度，不建議使用。\n"
+"\n"
+"絕對色度：\n"
+"不進行亮度和彩度對應，只適用於色彩打樣，不適合攝影用途。"
 
 #: ../src/libs/export.c:1294 ../src/libs/print_settings.c:2666
 msgid "style"
-msgstr "樣式"
+msgstr "風格檔"
 
 #: ../src/libs/export.c:1297
 msgid "temporary style to use while exporting"
-msgstr "輸出時要使用的臨時樣式"
+msgstr "僅在匯出時暫時套用的風格檔"
 
 #: ../src/libs/export.c:1306 ../src/libs/print_settings.c:2709
 msgid "replace history"
-msgstr "取代歷史記錄"
+msgstr "替換原有的編輯記錄"
 
 #: ../src/libs/export.c:1307 ../src/libs/print_settings.c:2710
 msgid "append history"
-msgstr "附加歷史記錄"
+msgstr "新增在原有的編輯記錄之上"
 
 #: ../src/libs/export.c:1312 ../src/libs/print_settings.c:2717
 msgid ""
 "whether the style items are appended to the history or replacing the history"
-msgstr "樣式項是附加到歷史記錄還是取代歷史記錄"
+msgstr "風格檔要附加編輯記錄還是替換編輯記錄"
 
 #: ../src/libs/export.c:1336
 msgid "export with current settings"
-msgstr "輸出目前設定"
+msgstr "使用以上的設定匯出影像"
 
 #: ../src/libs/export_metadata.c:163
 msgid "select tag"
@@ -19412,17 +20591,19 @@ msgstr "增加"
 
 #: ../src/libs/export_metadata.c:175
 msgid "list filter"
-msgstr "列出濾鏡"
+msgstr "篩選標籤"
 
 #: ../src/libs/export_metadata.c:186
 msgid ""
 "list of available tags. click 'add' button or double-click on tag to add the "
 "selected one"
-msgstr "可用標籤的列表。在標籤上點擊“增加”按鈕或雙擊以增加選取標籤"
+msgstr ""
+"可用標籤的清單\n"
+"點擊「增加」按鈕或雙擊貼上所選標籤"
 
 #: ../src/libs/export_metadata.c:287
 msgid "edit metadata exportation"
-msgstr "編輯詮釋資料輸出"
+msgstr "編輯詮釋資料匯出設定"
 
 #: ../src/libs/export_metadata.c:302
 msgid "general settings"
@@ -19430,19 +20611,19 @@ msgstr "一般設定"
 
 #: ../src/libs/export_metadata.c:307
 msgid "EXIF data"
-msgstr "EXIF資料"
+msgstr "EXIF 資料"
 
 #: ../src/libs/export_metadata.c:308
 msgid "export EXIF metadata"
-msgstr "輸出 exif 詮釋資料"
+msgstr "匯出 EXIF 詮釋資料"
 
 #: ../src/libs/export_metadata.c:311
 msgid "export dt xmp metadata (from metadata editor module)"
-msgstr "從編輯器模組輸出 dt xmp詮釋資料"
+msgstr "匯出 XMP 詮釋資料（從詮釋資料編輯模組）"
 
 #: ../src/libs/export_metadata.c:321
 msgid "only embedded"
-msgstr "僅限已嵌入的資料"
+msgstr "僅已嵌入的資料"
 
 #: ../src/libs/export_metadata.c:322
 msgid ""
@@ -19452,9 +20633,12 @@ msgid ""
 "if remote storage doesn't understand dt xmp metadata, you can use calculated "
 "metadata instead"
 msgstr ""
-"預設情況下，通過介面傳送影像的有限詮釋資料至遠端儲存。\n"
-"為避免如此，若希望僅傳送影像嵌入 dt xmp 詮釋資料，請勾選此項。\n"
-"若遠端儲存無法識別 dt xmp 詮釋資料，可以使用計算詮釋資料代替"
+"在預設情況下，儲存至遠端空間時會同時額外發送一部份詮釋資料\n"
+"勾選此項之後將不會發送單獨資料，而是將 XMP 全部嵌入在影像檔案中\n"
+"\n"
+"會將影像旁邊的一些有限的詮釋資料發送到遠端存儲。\n"
+"若要避免這種情況並僅允許影像嵌入 XMP 詮釋資料，請選此標誌。\n"
+"如果遠端存儲不理解 darktable 的 XMP 詮釋資料，則可以改用計算的詮釋資料"
 
 #: ../src/libs/export_metadata.c:328 ../src/libs/image.c:568
 msgid "geo tags"
@@ -19462,19 +20646,19 @@ msgstr "地理標籤"
 
 #: ../src/libs/export_metadata.c:329
 msgid "export geo tags"
-msgstr "輸出地理標籤"
+msgstr "匯出地理標籤"
 
 #: ../src/libs/export_metadata.c:332
 msgid "export tags (to Xmp.dc.Subject)"
-msgstr "輸出標籤(到 Xmp.dc.Subject)"
+msgstr "匯出標籤至 Xmp.dc.Subject"
 
 #: ../src/libs/export_metadata.c:340
 msgid "private tags"
-msgstr "私有標籤"
+msgstr "私人標籤"
 
 #: ../src/libs/export_metadata.c:341
 msgid "export private tags"
-msgstr "輸出私有標籤"
+msgstr "匯出私人標籤"
 
 #: ../src/libs/export_metadata.c:343
 msgid "synonyms"
@@ -19482,39 +20666,41 @@ msgstr "同義詞"
 
 #: ../src/libs/export_metadata.c:344
 msgid "export tags synonyms"
-msgstr "輸出標籤同義詞"
+msgstr "匯出標籤同義詞"
 
 #: ../src/libs/export_metadata.c:346
 msgid "omit hierarchy"
-msgstr "忽略層次結構"
+msgstr "省略階層"
 
 #: ../src/libs/export_metadata.c:347
 msgid ""
 "only the last part of the hierarchical tags is included. can be useful if "
 "categories are not used"
-msgstr "只包括多層標籤的最後一部分。若不使用類別，此選項將非常有用"
+msgstr "僅匯出標籤的最後一部分，省略樹狀結構"
 
 #: ../src/libs/export_metadata.c:350
 msgid "hierarchical tags"
-msgstr "層次標籤"
+msgstr "樹狀標籤"
 
 #: ../src/libs/export_metadata.c:351
 msgid "export hierarchical tags (to Xmp.lr.Hierarchical Subject)"
-msgstr "輸出層次標籤(到 Xmp.lr.Hierarchical Subject)"
+msgstr "匯出樹狀標籤到 Xmp.lr.Hierarchical Subject"
 
 #: ../src/libs/export_metadata.c:353
 msgid "develop history"
-msgstr "影像編修紀錄"
+msgstr "編輯記錄"
 
 #: ../src/libs/export_metadata.c:354
 msgid ""
 "export dt development data (recovery purpose in case of loss of database or "
 "xmp file)"
-msgstr "輸出 dt 影像編修資料(以便資料庫或 xmp 檔案損壞時能恢復)"
+msgstr ""
+"匯出全部編輯紀錄以及遮罩，儲存至 XMP 檔案中\n"
+"可用於之後若資料庫和附屬檔案遺失時復原原始編輯設定使用"
 
 #: ../src/libs/export_metadata.c:361
 msgid "per metadata settings"
-msgstr "按詮釋資料設定"
+msgstr "依詮釋資料設定"
 
 #: ../src/libs/export_metadata.c:374
 msgid "redefined tag"
@@ -19522,7 +20708,7 @@ msgstr "重新定義標籤"
 
 #: ../src/libs/export_metadata.c:380
 msgid "formula"
-msgstr "公式"
+msgstr "變更方式"
 
 #: ../src/libs/export_metadata.c:383
 msgid ""
@@ -19537,17 +20723,20 @@ msgid ""
 "click on formula cell to edit\n"
 "type '$(' to activate the completion and see the list of variables"
 msgstr ""
-"計算的詮釋資料列表\n"
-"點擊 '+'  按鈕以設定及增加新的詮釋資料\n"
-"如果公式是空的，相對應的詮釋資料可自輸出檔案中移除\n"
-"如果公式是'=' EXIF 詮釋資料可被輸出即使EXIF資料不能使用\n"
-"否則相對應的詮釋資料可被計算及增加置輸出檔案\n"
-"點擊在公式格上可編輯\n"
-"輸入 '$(' 以啟動自動補全及觀看變數表列"
+"詮釋資料變更清單\n"
+"\n"
+"左側是要編輯變更的資料，右側是可自定義變更資料的方式\n"
+"點擊「+」按鈕選擇從列表中選擇詮釋資料加入\n"
+"點擊「-」按鈕刪除已加入的詮釋資料\n"
+"\n"
+"右側變更方式可使用 darktable 的變數，匯出時會依此計算相應的詮釋資料\n"
+"點擊欄位即可編輯，輸入「$(」會跳出變數清單以便直接選擇\n"
+"如果欄位留空，則從匯出檔案中刪除該項元資料\n"
+"如果欄位為「=」，則強制匯出元資料，即便在一般設定中設定不匯出"
 
 #: ../src/libs/export_metadata.c:440
 msgid "add an output metadata tag"
-msgstr "增加輸出的詮釋資料標籤"
+msgstr "增加詮釋資料標籤"
 
 #: ../src/libs/export_metadata.c:445
 msgid "delete metadata tag"
@@ -19555,7 +20744,7 @@ msgstr "刪除詮釋資料標籤"
 
 #: ../src/libs/filtering.c:240
 msgid "collection filters"
-msgstr "集合過濾器"
+msgstr "相冊篩選條件"
 
 #: ../src/libs/filtering.c:273
 msgid "initial setting"
@@ -19563,109 +20752,116 @@ msgstr "初始設定"
 
 #: ../src/libs/filtering.c:292
 msgid "imported: last 24h"
-msgstr "輸入時間:最近 24 小時"
+msgstr "匯入時間：最近 24 小時"
 
 #: ../src/libs/filtering.c:297
 msgid "imported: last 30 days"
-msgstr "輸入時間:最近 30 天"
+msgstr "匯入日期：最近 30 天"
 
 #: ../src/libs/filtering.c:303
 msgid "taken: last 24h"
-msgstr "拍攝時間:最近 24 小時"
+msgstr "拍攝時間：最近 24 小時"
 
 #: ../src/libs/filtering.c:307
 msgid "taken: last 30 days"
-msgstr "拍攝時間:最近 30 天"
+msgstr "拍攝日期： 最近 30 天"
 
 #: ../src/libs/filtering.c:653
 msgid "click or click&#38;drag to select one or multiple values"
-msgstr "點擊 or 點擊&#38;拖拉以選擇一個或多個值"
+msgstr "點擊以選取單一數值，拖曳可選取數值範圍"
 
 #: ../src/libs/filtering.c:654
 msgid "right-click opens a menu to select the available values"
-msgstr "右擊打開選單以選擇可用值"
+msgstr "右鍵開啟可使用的數值清單"
 
 #: ../src/libs/filtering.c:657
 msgid "actual selection"
-msgstr "實際選取"
+msgstr "目前範圍"
+
+#: ../src/libs/filtering.c:789
+#, c-format
+msgid "you can't have more than %d rules"
+msgstr "篩選條件上限是 %d 個"
 
 #: ../src/libs/filtering.c:918
 msgid ""
 "rule property\n"
 "this can't be changed as the rule is pinned into the toolbar"
-msgstr ""
-"規則屬性\n"
-"當規則釘在工具欄時不能改變"
+msgstr "已釘選至工具列的篩選條件不能更改"
 
 #. otherwise we add all implemented rules
 #: ../src/libs/filtering.c:925
 msgid "rule property"
-msgstr "規則屬性"
+msgstr ""
+"篩選方式\n"
+"點擊可變更，或使用滑鼠滾輪快速切換"
 
 #: ../src/libs/filtering.c:1018
 msgctxt "quickfilter"
 msgid "filter"
-msgstr "過濾器"
+msgstr "篩選"
 
 #: ../src/libs/filtering.c:1044
 msgid ""
 "this rule is pinned into the top toolbar\n"
 "click to un-pin"
 msgstr ""
-"此規則釘在頂端工具欄時\n"
-"單擊以解除"
+"已釘選至上方工具列\n"
+"點擊以取消"
 
 #: ../src/libs/filtering.c:1045
 msgid "you can't disable the rule as it is pinned into the toolbar"
-msgstr "你不能不啟用此規則當它釘在工具欄時"
+msgstr "不能停用已釘選的篩選條件"
 
 #: ../src/libs/filtering.c:1046
 msgid "you can't remove the rule as it is pinned into the toolbar"
-msgstr "你不能移除此規則當它釘在工具欄時"
+msgstr "不能刪除已釘選的篩選條件"
 
 #: ../src/libs/filtering.c:1050
 msgid "click to pin this rule into the top toolbar"
-msgstr "單擊以釘在頂端工具欄"
+msgstr "釘選到上方工具列"
 
 #: ../src/libs/filtering.c:1051
 msgid "remove this collect rule"
-msgstr "移除此集合規則"
+msgstr "刪除這個篩選條件"
 
 #: ../src/libs/filtering.c:1053
 msgid "this rule is enabled"
-msgstr "啟用此規則"
+msgstr "已啟用的篩選條件"
 
 #: ../src/libs/filtering.c:1055
 msgid "this rule is disabled"
-msgstr "不啟用此規則"
+msgstr "已停用的篩選條件"
 
 #: ../src/libs/filtering.c:1168
 msgid "and"
-msgstr "及"
+msgstr "以及"
 
 #: ../src/libs/filtering.c:1169
 msgid "or"
-msgstr "或"
+msgstr "或是"
 
 #: ../src/libs/filtering.c:1170
 msgid "and not"
-msgstr "而且不"
+msgstr "排除"
 
 #: ../src/libs/filtering.c:1172
 msgid "define how this rule should interact with the previous one"
-msgstr "定義此規則如何與前一規則相互作用"
+msgstr "定義此條件如何與上一項交互作用"
 
 #: ../src/libs/filtering.c:1431
 msgid " (off)"
-msgstr " (關)"
+msgstr " （關閉）"
 
 #: ../src/libs/filtering.c:1654
 msgid "sort order"
-msgstr "排序順序"
+msgstr "排列順序"
 
 #: ../src/libs/filtering.c:1656
 msgid "determine the sort order of shown images"
-msgstr "決定影像顯示的排序"
+msgstr ""
+"影像排列順序的方式\n"
+"點擊可變更，或使用滑鼠滾輪快速切換"
 
 #: ../src/libs/filtering.c:1713
 msgid "sort direction"
@@ -19673,39 +20869,44 @@ msgstr "排序方向"
 
 #: ../src/libs/filtering.c:1719
 msgid "remove this sort order"
-msgstr "移除此排序順序"
+msgstr "移除這個排序條件"
+
+#: ../src/libs/filtering.c:1803
+#, c-format
+msgid "you can't have more than %d sort orders"
+msgstr "排序條件上限是 %d 個"
 
 #: ../src/libs/filtering.c:1872
 msgid "DESC"
-msgstr "降序"
+msgstr "降序排列"
 
 #: ../src/libs/filtering.c:1872
 msgid "ASC"
-msgstr "升序"
+msgstr "升序排列"
 
 #: ../src/libs/filtering.c:1983
 msgid "new rule"
-msgstr "新規則"
+msgstr "新增篩選條件"
 
 #: ../src/libs/filtering.c:1984
 msgid "append new rule to collect images"
-msgstr "附加此規則至集合影像上"
+msgstr "新增條件到目前的相冊上"
 
 #: ../src/libs/filtering.c:1995 ../src/libs/tools/filter.c:100
 msgid "sort by"
-msgstr "排序方式"
+msgstr "排列方式"
 
 #: ../src/libs/filtering.c:2003
 msgid "new sort"
-msgstr "新排序"
+msgstr "新增排序條件"
 
 #: ../src/libs/filtering.c:2004
 msgid "append new sort to order images"
-msgstr "附加新排序以排序影像"
+msgstr "新增排序方式到目前的相冊上"
 
 #: ../src/libs/filtering.c:2007
 msgid "revert to a previous set of sort orders"
-msgstr "回復至前一排序順序集合"
+msgstr "使用過去的排序設定"
 
 #. we change the tooltip of the reset button here, as we are sure the header is defined now
 #: ../src/libs/filtering.c:2056
@@ -19713,12 +20914,12 @@ msgid ""
 "reset\n"
 "ctrl-click to remove pinned rules too"
 msgstr ""
-"重置\n"
-"控制鍵-單擊以移除已釘住的規則"
+"重設\n"
+"ctrl + 左鍵 移除所有規則，包括釘選至上方工具列的規則"
 
 #: ../src/libs/filters/colors.c:140
 msgid "Y"
-msgstr "是"
+msgstr "Y"
 
 #: ../src/libs/filters/colors.c:149
 msgid "P"
@@ -19726,7 +20927,7 @@ msgstr "P"
 
 #: ../src/libs/filters/colors.c:269
 msgid "color filter"
-msgstr "顏色濾鏡"
+msgstr "色彩標籤篩選"
 
 #: ../src/libs/filters/colors.c:294
 msgid ""
@@ -19735,10 +20936,10 @@ msgid ""
 "ctrl+click to exclude the color label\n"
 "the gray button affects all color labels"
 msgstr ""
-"使用影像色彩標籤過濾\n"
-"點擊以切換色彩標籤選取\n"
-"控制鍵+點擊 以排除色彩標籤\n"
-"灰色按鈕影響所有色彩標籤"
+"依色彩標籤篩選\n"
+"點擊切換色彩標籤選項\n"
+"ctrl + 點擊以排除色彩標籤\n"
+"灰色會影響所有色彩標籤"
 
 #: ../src/libs/filters/colors.c:301 ../src/libs/filters/colors.c:312
 #: ../src/libs/filters/rating_range.c:339
@@ -19751,9 +20952,9 @@ msgid ""
 "and (∩): images having all selected color labels\n"
 "or (∪): images with at least one of the selected color labels"
 msgstr ""
-"使用影像色彩標籤過濾\n"
-"交集 (∩): 有所有選取色彩標籤的影像\n"
-" 聯集(∪): 有最少一個選取色彩標籤的影像"
+"依影像的色彩標籤過濾\n"
+"和（∩）：具有所有選定色彩標籤的影像\n"
+"或（∪）：至少具有一個選定色彩標籤的影像"
 
 #: ../src/libs/filters/filename.c:365
 msgid ""
@@ -19762,10 +20963,10 @@ msgid ""
 "\n"
 "right-click to get existing filenames"
 msgstr ""
-"輸入檔名以搜尋\n"
-"多個值以','分隔開來\n"
+"輸入檔名搜尋\n"
+"多個關鍵字可以「,」分隔\n"
 "\n"
-"右擊以取得現有檔名"
+"右鍵點擊可查看所有檔案名稱並選取"
 
 #: ../src/libs/filters/filename.c:376
 msgid "extension"
@@ -19779,39 +20980,39 @@ msgid ""
 "\n"
 "right-click to get existing extensions"
 msgstr ""
-"輸入副檔名以起始點搜尋\n"
-"多個值以','分隔開來\n"
-"能處理關鍵詞:'RAW', 'NOT RAW', 'LDR', 'HDR'\n"
+"輸入副檔名搜尋\n"
+"多個關鍵字可以「,」分隔\n"
+"可使用以下關鍵字「RAW」、「NOT RAW」、「LDR」、「HDR」\n"
 "\n"
-"右擊以取得現有副檔名"
+"右鍵點擊可查看所有檔案名稱並選取"
 
 #: ../src/libs/filters/filename.c:405
 msgid ""
 "simple click to select filename\n"
 "ctrl-click to select multiple values"
 msgstr ""
-"點擊以選擇檔名\n"
-"控制鍵-點擊以選擇多個值"
+"單擊選擇檔案名稱\n"
+"ctrl + 點擊可複選"
 
 #: ../src/libs/filters/filename.c:432
 msgid ""
 "simple click to select extension\n"
 "ctrl-click to select multiple values"
 msgstr ""
-"點擊以選擇副檔名\n"
-"控制鍵-點擊以選擇多個值"
+"單擊選擇副檔名\n"
+"ctrl + 點擊可複選"
 
 #: ../src/libs/filters/grouping.c:141 ../src/libs/filters/grouping.c:169
 msgid "ungrouped images"
-msgstr "未分組影像"
+msgstr "無群組的影像"
 
 #: ../src/libs/filters/grouping.c:167
 msgid "grouping filter"
-msgstr "分組過濾器"
+msgstr "群組篩選"
 
 #: ../src/libs/filters/grouping.c:168
 msgid "select the type of grouped image to filter"
-msgstr "選擇分組影像的型態以過濾"
+msgstr "選擇影像的群組狀態"
 
 #. predefined selections
 #: ../src/libs/filters/grouping.c:169 ../src/libs/filters/history.c:38
@@ -19820,39 +21021,39 @@ msgstr "選擇分組影像的型態以過濾"
 #: ../src/libs/filters/rating_range.c:109 ../src/libs/filters/ratio.c:68
 #: ../src/libs/filters/ratio.c:81
 msgid "all images"
-msgstr "所有影像"
+msgstr "全部影像"
 
 #: ../src/libs/filters/history.c:153
 msgid "history filter"
-msgstr "歷史過濾器"
+msgstr "編輯紀錄篩選"
 
 #: ../src/libs/filters/history.c:153
 msgid "filter on history state"
-msgstr "依歷史狀態過濾"
+msgstr "依影像編輯紀錄篩選"
 
 #: ../src/libs/filters/local_copy.c:142
 msgid "local_copy filter"
-msgstr "本地副本過濾器"
+msgstr "本機備份篩選"
 
 #: ../src/libs/filters/local_copy.c:142
 msgid "local copied state filter"
-msgstr "本地複製的狀態過濾器"
+msgstr "本機備份狀態"
 
 #: ../src/libs/filters/module_order.c:161
 msgid "module order filter"
-msgstr "模組順序過濾器"
+msgstr "模組順序篩選"
 
 #: ../src/libs/filters/module_order.c:161
 msgid "filter images based on their module order"
-msgstr "依據模組順序過濾影像"
+msgstr "依影像的模組運算順序篩選"
 
 #: ../src/libs/filters/rating.c:199
 msgid "comparator"
-msgstr "比較器"
+msgstr "比較字串"
 
 #: ../src/libs/filters/rating.c:200 ../src/libs/filters/rating.c:210
 msgid "filter by images rating"
-msgstr "以影像星等過濾"
+msgstr "依影像評分篩選"
 
 #. create the filter combobox
 #: ../src/libs/filters/rating.c:210 ../src/libs/image.c:544
@@ -19862,41 +21063,41 @@ msgstr "評分"
 
 #: ../src/libs/filters/rating.c:211
 msgid "unstarred only"
-msgstr "僅限未評星等者"
+msgstr "僅限尚未評分的影像"
 
 #: ../src/libs/filters/rating.c:212 ../src/libs/filters/rating_range.c:60
 #: ../src/libs/filters/rating_range.c:75
 msgid "rejected only"
-msgstr "僅限拋棄影像"
+msgstr "僅限不合格的影像"
 
 #: ../src/libs/filters/rating.c:212 ../src/libs/filters/rating_range.c:58
 #: ../src/libs/filters/rating_range.c:73 ../src/libs/filters/rating_range.c:140
 msgid "all except rejected"
-msgstr "全部，除拋棄影像外"
+msgstr "除了不合格之外的全部影像"
 
 #: ../src/libs/filters/rating_range.c:61 ../src/libs/filters/rating_range.c:76
 msgid "not rated only"
-msgstr "只有未評定者"
+msgstr "僅限尚未評分的影像"
 
 #: ../src/libs/filters/rating_range.c:99 ../src/libs/filters/rating_range.c:128
 #: ../src/libs/filters/rating_range.c:133
 #: ../src/libs/filters/rating_range.c:292
 msgid "rejected"
-msgstr "影像已被丟棄"
+msgstr "不合格"
 
 #: ../src/libs/filters/rating_range.c:101
 #: ../src/libs/filters/rating_range.c:128
 #: ../src/libs/filters/rating_range.c:293
 msgid "not rated"
-msgstr "未評定"
+msgstr "未評分"
 
 #: ../src/libs/filters/rating_range.c:119
 msgid "only"
-msgstr "僅"
+msgstr "僅包含"
 
 #: ../src/libs/filters/rating_range.c:168
 msgid "selected"
-msgstr "已選定"
+msgstr "已選擇"
 
 #: ../src/libs/filters/rating_range.c:286
 msgid "better"
@@ -19904,27 +21105,27 @@ msgstr "更好"
 
 #: ../src/libs/filters/rating_range.c:287
 msgid "worse"
-msgstr "變差"
+msgstr "更差"
 
 #: ../src/libs/filters/rating_range.c:288
 msgid "cap"
-msgstr "cap"
+msgstr "最大值"
 
 #: ../src/libs/filters/rating_range.c:303
 msgid "rating filter"
-msgstr "星等過濾器"
+msgstr "評分篩選"
 
 #: ../src/libs/filters/ratio.c:70 ../src/libs/filters/ratio.c:82
 msgid "portrait images"
-msgstr "人像"
+msgstr "直式影像"
 
 #: ../src/libs/filters/ratio.c:71 ../src/libs/filters/ratio.c:83
 msgid "square images"
-msgstr "方形影像"
+msgstr "正方形影像"
 
 #: ../src/libs/filters/ratio.c:72 ../src/libs/filters/ratio.c:84
 msgid "landscape images"
-msgstr "風景照片"
+msgstr "橫式影像"
 
 #: ../src/libs/filters/search.c:180
 #, no-c-format
@@ -19935,35 +21136,35 @@ msgid ""
 "starting or ending with a double quote disables the corresponding wildcard\n"
 "is dimmed during the search execution"
 msgstr ""
-"使用影像詮釋資料文字，標籤，檔案路徑及名稱過濾\n"
-"`%'是萬用字元\n"
-"起始及結束萬用字元預設自動套用\n"
-"起始及結束的雙引號使得相對應的萬用字元失效\n"
-"在搜尋執行時無效"
+"搜尋影像詮釋資料、標籤、檔案路徑和名稱中的文字\n"
+"「%」是萬用字元\n"
+"在預設情況下，字頭和字尾會自動套用萬用字元\n"
+"以雙引號開頭或結尾的關鍵字將停用相應的萬用字元\n"
+"在搜索時輸入欄位會暫時變暗"
 
 #: ../src/libs/geotagging.c:369
 msgid "apply offset and geo-location"
-msgstr "套用偏移及地理定位資訊"
+msgstr "套用地理位置和偏差補償"
 
 #: ../src/libs/geotagging.c:370 ../src/libs/geotagging.c:1905
 msgid "apply geo-location"
-msgstr "套用地理定位資訊"
+msgstr "套用地理位置"
 
 #: ../src/libs/geotagging.c:372
 msgid ""
 "apply offset and geo-location to matching images\n"
 "double operation: two ctrl-Z to undo"
 msgstr ""
-"套用偏移及地理定位資訊以匹配影像\n"
-"連按兩次 控制鍵 + z 撤銷"
+"套用地理位置和偏差補償到符合的影像上\n"
+"連按兩次 ctrl + z 回復"
 
 #: ../src/libs/geotagging.c:374 ../src/libs/geotagging.c:1906
 msgid "apply geo-location to matching images"
-msgstr "套用地理定位資訊以匹配影像"
+msgstr "套用地理位置在符合的影像上"
 
 #: ../src/libs/geotagging.c:811
 msgid "GPX file track segments"
-msgstr "GPX 檔案軌跡區段"
+msgstr "GPX 檔案軌跡線"
 
 #: ../src/libs/geotagging.c:831 ../src/libs/geotagging.c:1864
 msgid "start time"
@@ -19984,10 +21185,10 @@ msgstr "影像"
 
 #: ../src/libs/geotagging.c:927
 msgid "open GPX file"
-msgstr "打開 GPX 檔案"
+msgstr "開啟 GPX 檔案"
 
 #. Preview key
-#: ../src/libs/geotagging.c:928 ../src/views/darkroom.c:2164
+#: ../src/libs/geotagging.c:928 ../src/views/darkroom.c:2165
 #: ../src/views/lighttable.c:646 ../src/views/lighttable.c:1251
 msgid "preview"
 msgstr "預覽"
@@ -20005,8 +21206,11 @@ msgid ""
 "enter the new date/time (YYYY:MM:DD hh:mm:ss[.sss])\n"
 "key in the new numbers or scroll over the cell"
 msgstr ""
-"以“yyyy:mm:dd hh:mm:ss”格式輸入新的日期與時間\n"
-"可以輸入數字或在輸入框內使用滑鼠滾輪"
+"輸入選取影像的日期與時間\n"
+"格式為 YYYY:MM:DD hh:mm:ss[.sss]，也可以使用滑鼠滾輪調整數值\n"
+"任一欄位的數值達到上下限，會自動進位 / 退位相鄰的欄位\n"
+"例如分鐘數值達到 60，欄位將自動歸零並將小時進位\n"
+"如果在偏好設定中開啟「以毛秒為單位顯示時間」，則可以在此模塊中使用毫秒"
 
 #: ../src/libs/geotagging.c:1733
 msgid "original date/time"
@@ -20014,57 +21218,57 @@ msgstr "原始日期與時間"
 
 #: ../src/libs/geotagging.c:1739
 msgid "date/time offset"
-msgstr "日期與時間偏移"
+msgstr "日期與時間偏差"
 
 #: ../src/libs/geotagging.c:1741
 msgid "offset or difference ([-]dd hh:mm:ss[.sss])"
-msgstr "時間偏移或差異([-]dd hh:mm:ss)"
+msgstr "偏差或差異 （[±] 日 時：分：秒）"
 
 #: ../src/libs/geotagging.c:1744
 msgid "lock date/time offset value to apply it onto another selection"
-msgstr "鎖定日期/時間偏移值，以套用到其他選擇的圖片上"
+msgstr "鎖定日期與時間偏差值，以將其套用在其他影像上"
 
 #. apply
 #: ../src/libs/geotagging.c:1753
 msgid "apply offset"
-msgstr "套用偏移"
+msgstr "套用偏差補償"
 
 #: ../src/libs/geotagging.c:1754
 msgid "apply offset to selected images"
-msgstr "套用時間偏移至選取的影像"
+msgstr "套用偏差補償數值到選取的影像"
 
 #: ../src/libs/geotagging.c:1757
 msgid "apply date/time"
-msgstr "套用拍攝日期與時間"
+msgstr "套用日期與時間"
 
 #: ../src/libs/geotagging.c:1758
 msgid "apply the same date/time to selected images"
-msgstr "套用拍攝日期與時間至選取影像"
+msgstr "將相同的日期與時間套用到選取的影像"
 
 #: ../src/libs/geotagging.c:1768
 msgid ""
 "start typing to show a list of permitted values and select your timezone.\n"
 "press enter to confirm, so that the asterisk * disappears"
 msgstr ""
-"開始鍵入以顯示允許值的列表並選擇您的時區。\n"
-"按 enter 確認，這樣星號 * 就會消失"
+"輸入以顯示清單並選擇時區\n"
+"按 enter 鍵確認後星號 * 就會消失"
 
 #. gpx
 #: ../src/libs/geotagging.c:1810
 msgid "apply GPX track file..."
-msgstr "套用 GPX 跟蹤檔案…"
+msgstr "套用 GPX 軌跡檔案"
 
 #: ../src/libs/geotagging.c:1811
 msgid "parses a GPX file and updates location of selected images"
-msgstr "解析 gpx 檔案並更新選取影像的位置"
+msgstr "解析 GPX 檔案並更新選取影像的位置"
 
 #: ../src/libs/geotagging.c:1822
 msgid "GPX file"
-msgstr "GPX 檔案"
+msgstr "開啟 GPX 檔案"
 
 #: ../src/libs/geotagging.c:1829
 msgid "select a GPX track file..."
-msgstr "選擇 GPX 軌跡檔案..."
+msgstr "選擇 GPX 軌跡檔案"
 
 #: ../src/libs/geotagging.c:1846
 msgid ""
@@ -20075,11 +21279,11 @@ msgid ""
 "zone\n"
 "- more detailed time information hovering the row"
 msgstr ""
-"列出 GPX 檔案內的軌跡分段，每個分段包含:\n"
-"- 當地時區的開始與結束時間\n"
+"GPX 中的軌跡列表，顯示資訊如下：\n"
+"- 當地時區的開始日期與時間\n"
 "- 軌跡點數量\n"
-"- 依據影像日期/時間所匹配的影像數量，偏移和時區\n"
-"- 滑鼠懸浮時顯示更多詳細時間資訊"
+"- 符合日期、時間、時間偏差、時區的影像數量\n"
+"- 滑鼠經過時顯示更詳細的時間資訊"
 
 #: ../src/libs/geotagging.c:1885
 msgid "preview images"
@@ -20087,7 +21291,7 @@ msgstr "預覽影像"
 
 #: ../src/libs/geotagging.c:1890
 msgid "show on map matching images"
-msgstr "在地圖上顯示匹配的影像"
+msgstr "在地圖上顯示符合的影像"
 
 #: ../src/libs/geotagging.c:1893
 msgid "select images"
@@ -20095,165 +21299,163 @@ msgstr "選擇影像"
 
 #: ../src/libs/geotagging.c:1894
 msgid "select matching images"
-msgstr "選擇匹配的影像"
+msgstr "選擇符合的影像"
 
 #: ../src/libs/geotagging.c:1902
 msgid "number of matching images versus selected images"
-msgstr "對比匹配影像的數量與選定影像"
+msgstr "比較符合的影像數量與已選取的影像數量"
 
 #: ../src/libs/histogram.c:151
 msgid "scopes"
-msgstr "範圍"
+msgstr "色彩分布顯示器"
 
-#: ../src/libs/histogram.c:1304 ../src/libs/histogram.c:1953
+#: ../src/libs/histogram.c:1305 ../src/libs/histogram.c:1954
 msgid "ctrl+scroll to change display height"
-msgstr "控制鍵 + 滾輪以更改顯示高度"
+msgstr "ctrl + 滑鼠滾輪改變顯示高度"
 
-#: ../src/libs/histogram.c:1313
+#: ../src/libs/histogram.c:1314
 msgid ""
 "drag to change black point,\n"
 "doubleclick resets\n"
 "ctrl+scroll to change display height"
 msgstr ""
-"拖拉滑鼠以改變黑點\n"
-"雙擊以重置\n"
-"控制鍵 + 滾輪以改變顯示高度"
+"滑鼠拖曳變更黑點，雙擊可重設\n"
+"ctrl + 滑鼠滾輪更改顯示高度"
 
-#: ../src/libs/histogram.c:1318
+#: ../src/libs/histogram.c:1319
 msgid ""
 "drag to change exposure,\n"
 "doubleclick resets\n"
 "ctrl+scroll to change display height"
 msgstr ""
-"拖拉滑鼠以更改曝光，\n"
-"雙擊以重置。\n"
-"控制鍵 + 滾輪以更改顯示高度"
+"滑鼠拖曳調整曝光，雙擊可重設\n"
+"ctrl + 滑鼠滾輪更改顯示高度"
 
-#: ../src/libs/histogram.c:1431 ../src/libs/histogram.c:1471
+#: ../src/libs/histogram.c:1432 ../src/libs/histogram.c:1472
 msgid "set scale to linear"
-msgstr "將縮放比例設定爲線性"
+msgstr "顯示線性座標"
 
-#: ../src/libs/histogram.c:1436 ../src/libs/histogram.c:1476
+#: ../src/libs/histogram.c:1437 ../src/libs/histogram.c:1477
 msgid "set scale to logarithmic"
-msgstr "將縮放比例設定爲對數"
+msgstr "顯示對數座標"
 
-#: ../src/libs/histogram.c:1452
+#: ../src/libs/histogram.c:1453
 msgid "set scope to vertical"
-msgstr "顯示範圍設定為縱向"
+msgstr "顯示垂直座標"
 
-#: ../src/libs/histogram.c:1457
+#: ../src/libs/histogram.c:1458
 msgid "set scope to horizontal"
-msgstr "顯示範圍設定為水平"
+msgstr "顯示水平座標"
 
-#: ../src/libs/histogram.c:1486
+#: ../src/libs/histogram.c:1487
 msgid "set view to AzBz"
-msgstr "設定視角爲 AzBz"
+msgstr "顯示 AzBz 座標"
 
-#: ../src/libs/histogram.c:1491
+#: ../src/libs/histogram.c:1492
 msgid "set view to RYB"
-msgstr "設定視角爲 RYB"
+msgstr "顯示 RYB 座標"
 
-#: ../src/libs/histogram.c:1496
+#: ../src/libs/histogram.c:1497
 msgid "set view to u*v*"
-msgstr "設定視角爲 u*v*"
+msgstr "顯示 u*v* 座標"
 
-#: ../src/libs/histogram.c:1510
+#: ../src/libs/histogram.c:1511
 msgid "set mode to waveform"
-msgstr "設定模式爲波形"
+msgstr "將模式改為波形圖"
 
-#: ../src/libs/histogram.c:1520
+#: ../src/libs/histogram.c:1521
 msgid "set mode to rgb parade"
-msgstr "設定模式爲 RGB色彩檢視"
+msgstr "將模式改為 RGB 並列波形圖"
 
-#: ../src/libs/histogram.c:1530
+#: ../src/libs/histogram.c:1531
 msgid "set mode to vectorscope"
-msgstr "設定模式爲向量示波器"
+msgstr "將模式改為彩度投影圖"
 
-#: ../src/libs/histogram.c:1540
+#: ../src/libs/histogram.c:1541
 msgid "set mode to histogram"
-msgstr "設定模式爲直方圖"
+msgstr "將模式改為直方圖"
 
-#: ../src/libs/histogram.c:1633 ../src/libs/histogram.c:1669
-#: ../src/libs/histogram.c:2000
+#: ../src/libs/histogram.c:1634 ../src/libs/histogram.c:1670
+#: ../src/libs/histogram.c:2001
 msgid "click to hide red channel"
-msgstr "單擊以隱藏紅色通道"
+msgstr "點擊隱藏紅色色版"
 
-#: ../src/libs/histogram.c:1633 ../src/libs/histogram.c:1669
-#: ../src/libs/histogram.c:2000
+#: ../src/libs/histogram.c:1634 ../src/libs/histogram.c:1670
+#: ../src/libs/histogram.c:2001
 msgid "click to show red channel"
-msgstr "單擊以顯示紅色通道"
+msgstr "點擊顯示紅色色版"
 
-#: ../src/libs/histogram.c:1641 ../src/libs/histogram.c:1667
-#: ../src/libs/histogram.c:2007
+#: ../src/libs/histogram.c:1642 ../src/libs/histogram.c:1668
+#: ../src/libs/histogram.c:2008
 msgid "click to hide green channel"
-msgstr "單擊以隱藏綠色通道"
+msgstr "點擊隱藏綠色色版"
 
-#: ../src/libs/histogram.c:1641 ../src/libs/histogram.c:1667
-#: ../src/libs/histogram.c:2007
+#: ../src/libs/histogram.c:1642 ../src/libs/histogram.c:1668
+#: ../src/libs/histogram.c:2008
 msgid "click to show green channel"
-msgstr "單擊以顯示綠色通道"
+msgstr "點擊顯示綠色色版"
 
-#: ../src/libs/histogram.c:1649 ../src/libs/histogram.c:1668
-#: ../src/libs/histogram.c:2013
+#: ../src/libs/histogram.c:1650 ../src/libs/histogram.c:1669
+#: ../src/libs/histogram.c:2014
 msgid "click to hide blue channel"
-msgstr "單擊以隱藏藍色通道"
+msgstr "點擊隱藏藍色色版"
 
-#: ../src/libs/histogram.c:1649 ../src/libs/histogram.c:1668
-#: ../src/libs/histogram.c:2013
+#: ../src/libs/histogram.c:1650 ../src/libs/histogram.c:1669
+#: ../src/libs/histogram.c:2014
 msgid "click to show blue channel"
-msgstr "單擊以顯示藍色通道"
+msgstr "點擊顯示藍色色版"
 
-#: ../src/libs/histogram.c:1946
+#: ../src/libs/histogram.c:1947
 msgid "histogram"
 msgstr "直方圖"
 
-#: ../src/libs/histogram.c:1949 ../src/libs/histogram.c:1986
+#: ../src/libs/histogram.c:1950 ../src/libs/histogram.c:1987
 msgid "cycle histogram modes"
-msgstr "循環直方圖模式"
+msgstr "循環顯示直方圖模式"
 
-#: ../src/libs/histogram.c:1954 ../src/libs/histogram.c:1987
+#: ../src/libs/histogram.c:1955 ../src/libs/histogram.c:1988
 msgid "hide histogram"
 msgstr "隱藏直方圖"
 
-#: ../src/libs/histogram.c:1975 ../src/libs/histogram.c:1988
+#: ../src/libs/histogram.c:1976 ../src/libs/histogram.c:1989
 msgid "switch histogram mode"
 msgstr "切換直方圖模式"
 
-#: ../src/libs/histogram.c:1979 ../src/libs/histogram.c:1989
+#: ../src/libs/histogram.c:1980 ../src/libs/histogram.c:1990
 msgid "switch histogram type"
 msgstr "切換直方圖類型"
 
 #: ../src/libs/history.c:123
 msgid "compress history stack"
-msgstr "壓縮歷史紀錄堆棧"
+msgstr "壓縮影像編輯紀錄"
 
 #: ../src/libs/history.c:124
 msgid ""
 "create a minimal history stack which produces the same image\n"
 "ctrl+click to truncate history to the selected item"
 msgstr ""
-"建立產生相同影像的最小歷史記錄。\n"
-"控制鍵 + 單擊以截斷選取項的歷史記錄"
+"建立生成相同影像的最小影像編輯紀錄\n"
+"ctrl + 點擊將影像編輯紀錄截斷至選取的項目"
 
 #: ../src/libs/history.c:133
 msgid "create a style from the current history stack"
-msgstr "從目前歷史紀錄建立一個樣式"
+msgstr "從目前的影像編輯紀錄建立一個風格檔"
 
 #: ../src/libs/history.c:134
 msgid "create style from history"
-msgstr "從歷史紀錄中建立樣式"
+msgstr "以影像編輯紀錄建立風格檔"
 
 #: ../src/libs/history.c:190
 msgid "always-on module"
-msgstr "常用模組"
+msgstr "始終啟用的模組"
 
 #: ../src/libs/history.c:196
 msgid "default enabled module"
-msgstr "預設啓用模組"
+msgstr "預設啟用的模組"
 
 #: ../src/libs/history.c:203
 msgid "deprecated module"
-msgstr "廢棄模組"
+msgstr "已被汰除的模組"
 
 #: ../src/libs/history.c:857
 msgid "colorspace"
@@ -20273,62 +21475,65 @@ msgstr "遮罩模糊"
 
 #: ../src/libs/history.c:869
 msgid "raster mask instance"
-msgstr "網格圖像遮罩實例"
+msgstr "點陣遮罩實例"
 
 #: ../src/libs/history.c:870
 msgid "raster mask id"
-msgstr "網格圖像遮罩 id"
+msgstr "點陣遮罩識別碼"
 
 #: ../src/libs/history.c:873
 msgid "drawn mask polarity"
-msgstr "繪製遮罩極性"
+msgstr "繪製遮罩的極性"
 
 #: ../src/libs/history.c:877
 #, c-format
 msgid "a drawn mask was added"
-msgstr "增加繪製的遮罩"
+msgstr "已增加繪製遮罩"
 
 #: ../src/libs/history.c:879
 #, c-format
 msgid "the drawn mask was removed"
-msgstr "刪除繪製的遮罩"
+msgstr "已移除繪製遮罩"
 
 #: ../src/libs/history.c:880
 #, c-format
 msgid "the drawn mask was changed"
-msgstr "變更繪製遮罩"
+msgstr "已變更繪製遮罩"
 
 #: ../src/libs/history.c:910
 msgid "parametric output mask:"
-msgstr "參數輸出遮罩:"
+msgstr "色版輸出遮罩："
 
 #: ../src/libs/history.c:910
 msgid "parametric input mask:"
-msgstr "參數輸入遮罩:"
+msgstr "色版輸入遮罩："
 
 #: ../src/libs/history.c:1209
 msgid "do you really want to clear history of current image?"
-msgstr "是否確定要清除目前影像的歷史記錄？"
+msgstr "是否要刪除目前影像的編輯紀錄？"
 
 #: ../src/libs/history.c:1214
 msgid "delete image's history?"
-msgstr "刪除影像的歷史記錄？"
+msgstr "是否要刪除影像的編輯記錄？"
 
 #: ../src/libs/image.c:72
 msgid "selected image[s]"
-msgstr "選取的圖片"
+msgstr "已選取的影像"
 
 #: ../src/libs/image.c:285
 msgid "delete (trash)"
-msgstr "刪除(移至回收桶)"
+msgstr "刪除"
 
 #: ../src/libs/image.c:288
 msgid "physically delete from disk (using trash if possible)"
-msgstr "從硬碟中實質刪除(儘量使用回收桶)"
+msgstr ""
+"從硬碟中刪除實體檔案\n"
+"不僅從 darktable 圖庫中刪除，同時也刪除硬碟中的 XMP 附屬檔案\n"
+"如果圖庫中該影像的所有複本都被刪除，則影像檔案本身也會被刪除"
 
 #: ../src/libs/image.c:289
 msgid "physically delete from disk immediately"
-msgstr "立即從硬碟中實質刪除"
+msgstr "立即從硬碟刪除實體檔案"
 
 #. delete
 #: ../src/libs/image.c:476 ../src/libs/modulegroups.c:3866
@@ -20338,23 +21543,31 @@ msgstr "移除"
 
 #: ../src/libs/image.c:477
 msgid "remove images from the image library, without deleting"
-msgstr "從照片庫中移除而不刪除影像"
+msgstr ""
+"從圖庫中移除影像\n"
+"移除的影像不會再顯示在 darktable 中\n"
+"但影像檔案和 XMP 附屬檔案仍存在於硬碟中\n"
+"之後可以重新匯入恢復所有工作"
 
 #: ../src/libs/image.c:485
 msgid "move..."
-msgstr "移動..."
+msgstr "移動至"
 
 #: ../src/libs/image.c:486
 msgid "move to other folder"
-msgstr "移到其他目錄"
+msgstr ""
+"把影像檔案及其 XMP 附屬檔案移動到硬碟裡的另一個資料夾\n"
+"但如果目標資料夾中有相同名稱的檔案則不會移動"
 
 #: ../src/libs/image.c:489
 msgid "copy..."
-msgstr "複製..."
+msgstr "複製到"
 
 #: ../src/libs/image.c:490
 msgid "copy to other folder"
-msgstr "複製到其他目錄"
+msgstr ""
+"把影像檔案及其 XMP 附屬檔案複製到硬碟裡的另一個資料夾\n"
+"如果目標資料夾中有相同名稱的檔案時不會覆寫，而是會生成影像編輯紀錄的複本"
 
 #: ../src/libs/image.c:493
 msgid "create HDR"
@@ -20362,96 +21575,105 @@ msgstr "建立 HDR"
 
 #: ../src/libs/image.c:494
 msgid "create a high dynamic range image from selected shots"
-msgstr "從選取的圖片中製作 HDR 高動態範圍影像"
+msgstr ""
+"從已選擇的影像製作 HDR 高動態範圍影像，並將合成結果以 DNG 格式的新影像加到圖"
+"庫中"
 
 #: ../src/libs/image.c:498
 msgid "add a duplicate to the image library, including its history stack"
-msgstr "在影像資料庫中增加一張複製圖片，包括它的歷史記錄"
+msgstr ""
+"製作一份僅在 darktable 圖庫中的複本，包括影像編輯紀錄\n"
+"多個複本版本使用共同的實際影像檔案，但擁有自己獨立的 XMP 附屬檔案\n"
+"以便做同一影像、不同編輯方式的比較使用"
 
 #: ../src/libs/image.c:504 ../src/libs/image.c:507
 msgid "rotate selected images 90 degrees CCW"
-msgstr "逆時針 90 度旋轉選取的影像"
+msgstr "逆時針旋轉 90 度，此操作與「方向」模組連動"
 
 #: ../src/libs/image.c:511 ../src/libs/image.c:514
 msgid "rotate selected images 90 degrees CW"
-msgstr "順時針 90 度旋轉選取的影像"
+msgstr "順時針旋轉 90 度，此操作與「方向」模組連動"
 
 #: ../src/libs/image.c:516
 msgid "reset rotation"
-msgstr "重置旋轉"
+msgstr "重設旋轉"
 
 #: ../src/libs/image.c:517
 msgid "reset rotation to EXIF data"
-msgstr "使用exif 資料重置 旋轉資訊"
+msgstr "重設方向為 EXIF 中紀錄的數值，此操作與「方向」模組連動"
 
 #: ../src/libs/image.c:520
 msgid "copy locally"
-msgstr "建立本地副本"
+msgstr "本機備份"
 
 #: ../src/libs/image.c:521
 msgid "copy the image locally"
-msgstr "建立影像本地副本"
+msgstr ""
+"在本機磁碟製作一份備份，當無法連接原始外接設備時使用\n"
+"詳細內容請閱讀操作手冊的「local copies」章節"
 
 #: ../src/libs/image.c:524
 msgid "resync local copy"
-msgstr "重新同步本地副本"
+msgstr "同步備份"
 
 #: ../src/libs/image.c:525
 msgid "synchronize the image's XMP and remove the local copy"
-msgstr "同步影像的 XMP 並移除本地副本"
+msgstr ""
+"同步本機備份與外接磁碟的 XMP 附屬檔案，並刪除本機備份副本\n"
+"若無法連接外接磁碟，則此操作不會刪除本機備份檔案"
 
 #: ../src/libs/image.c:528
 msgctxt "selected images action"
 msgid "group"
-msgstr "分組"
+msgstr "群組"
 
 #: ../src/libs/image.c:529
 msgid "add selected images to expanded group or create a new one"
-msgstr "增加選取的影像至展開分組或新建分組"
+msgstr "將選擇的影像組成群組"
 
 #: ../src/libs/image.c:533
 msgid "ungroup"
-msgstr "取消分組"
+msgstr "解散群組"
 
 #: ../src/libs/image.c:534
 msgid "remove selected images from the group"
-msgstr "移除群中的選取圖片"
+msgstr "將選擇的影像移出群組"
 
 #: ../src/libs/image.c:546
 msgid "select ratings metadata"
-msgstr "選定評分詮釋資料"
+msgstr "選取評分的詮釋資料"
 
 #: ../src/libs/image.c:552
 msgid "colors"
-msgstr "顏色"
+msgstr "色彩"
 
 #: ../src/libs/image.c:554
 msgid "select colors metadata"
-msgstr "選取顏色詮釋資料"
+msgstr "選取色彩的詮釋資料"
 
 #: ../src/libs/image.c:562
 msgid "select tags metadata"
-msgstr "選取標籤詮釋資料"
+msgstr "選取標籤的詮釋資料"
 
 #: ../src/libs/image.c:570
 msgid "select geo tags metadata"
-msgstr "選取地理標籤詮釋資料"
+msgstr "選取地理標籤的詮釋資料"
 
 #: ../src/libs/image.c:578
 msgid "select dt metadata (from metadata editor module)"
-msgstr "選取 dt 詮釋資料(來自詮釋資料編輯模組)"
+msgstr "選擇 darktable 詮釋資料（來自詮釋資料編輯模組）"
 
 #: ../src/libs/image.c:586
 msgid "set the selected image as source of metadata"
-msgstr "設定選取圖片當做詮釋資料來源"
+msgstr "從選取的影像複製詮釋資料"
 
 #: ../src/libs/image.c:591
 msgid "paste selected metadata on selected images"
-msgstr "在選定的影像上貼上選取的詮釋資料"
+msgstr "將選取的詮釋資料貼到選取影像上"
 
 #: ../src/libs/image.c:595
 msgid "clear selected metadata on selected images"
-msgstr "清除選取影像上的選取詮釋資料"
+msgstr "刪除影像中已選取的詮釋資料"
 
 #: ../src/libs/image.c:600
 msgid "merge"
@@ -20459,32 +21681,34 @@ msgstr "合併"
 
 #: ../src/libs/image.c:602
 msgid "how to handle existing metadata"
-msgstr "如何處理現有詮釋資料"
+msgstr "如何處理現有的詮釋資料"
 
 #: ../src/libs/image.c:608
 msgid "update image information to match changes to file"
-msgstr "更新影像資訊以與更改後的檔案保持一致"
+msgstr ""
+"讀取影像中的 EXIF 資料\n"
+"⚠️ 警告：這可能會覆蓋 darktable 中更改的標籤和詮釋資料 ⚠️"
 
 #: ../src/libs/image.c:612
 msgid "set selection as monochrome images and activate monochrome workflow"
-msgstr "將選取影像設定爲黑白並使用黑白照片工作流"
+msgstr "把影像標記為黑白，可能情況下會啟用黑白影像工作流程的編輯模組"
 
 #: ../src/libs/image.c:616
 msgid "set selection as color images"
-msgstr "將選取影像設定爲彩色"
+msgstr "把影像標記為彩色，也就是刪除黑白影像的標記"
 
 #: ../src/libs/image.c:628
 msgid "duplicate virgin"
-msgstr "複製原始影像"
+msgstr "複製原圖"
 
 #: ../src/libs/import.c:264
 #, c-format
 msgid "device \"%s\" connected on port \"%s\"."
-msgstr "設備“%s”已連接到“%s”。"
+msgstr "裝置「%s」已連接到「%s」"
 
 #: ../src/libs/import.c:274 ../src/libs/import.c:335 ../src/libs/import.c:1683
 msgid "copy & import from camera"
-msgstr "從相機複製及輸入"
+msgstr "從相機複製和匯入"
 
 #: ../src/libs/import.c:285 ../src/libs/import.c:337
 msgid "tethered shoot"
@@ -20492,7 +21716,7 @@ msgstr "連機拍攝"
 
 #: ../src/libs/import.c:292 ../src/libs/import.c:338
 msgid "unmount camera"
-msgstr "卸載相機"
+msgstr "移除相機"
 
 #: ../src/libs/import.c:313
 msgid ""
@@ -20500,38 +21724,39 @@ msgid ""
 "make sure it is no longer mounted\n"
 "or quit the locking application"
 msgstr ""
-"相機正被其他應用程式佔用\n"
-"請確認相機未被掛載，或退出佔用相機的應用程式"
+"相機被其他應用程式鎖定\n"
+"確認相機沒有被其他程式連接\n"
+"或關閉占用的程式"
 
 #: ../src/libs/import.c:316
 msgid "tethering and importing is disabled for this camera"
-msgstr "此相機不使用連機拍攝和輸入功能"
+msgstr "已停止此相機的連機拍攝和匯入"
 
 #: ../src/libs/import.c:318 ../src/libs/import.c:336
 msgid "mount camera"
-msgstr "掛載相機"
+msgstr "連接相機"
 
 #: ../src/libs/import.c:741
 #, c-format
 msgid "%d image out of %d selected"
 msgid_plural "%d images out of %d selected"
-msgstr[0] "已選取 %d 張影像，從 %d 張影像中"
+msgstr[0] "已選擇 %d 張，總共 %d 張影像"
 
 #: ../src/libs/import.c:1030
 msgid "you can't delete the selected place"
-msgstr "您不能刪除選取地點"
+msgstr "不能刪除使用中的位置"
 
 #: ../src/libs/import.c:1144
 msgid "choose the root of the folder tree below"
-msgstr "選擇以下目錄樹的根目錄"
+msgstr "選擇要顯示在下方資料夾的位置"
 
 #: ../src/libs/import.c:1147
 msgid "places"
-msgstr "地點"
+msgstr "快速存取位置"
 
 #: ../src/libs/import.c:1153
 msgid "restore all default places you have removed by right-click"
-msgstr "右鍵單擊以回復被刪除的預設地點"
+msgstr "點擊恢復被移除的預設位置"
 
 #: ../src/libs/import.c:1158
 msgid ""
@@ -20539,45 +21764,44 @@ msgid ""
 "\n"
 "right-click on a place to remove it"
 msgstr ""
-"增加自定義地點\n"
-"\n"
-"右鍵點擊以刪除地點"
+"添加自訂位置\n"
+"右鍵點擊可將其移除"
 
 #: ../src/libs/import.c:1165
 msgid "you can add custom places using the plus icon"
-msgstr "使用加號圖示增加自定義地點"
+msgstr "使用加號圖示來添加自訂位置"
 
 #: ../src/libs/import.c:1190
 msgid "select a folder to see the content"
-msgstr "選擇一個目錄以觀看內容"
+msgstr "選擇資料夾以查看內容"
 
 #: ../src/libs/import.c:1193
 msgid "folders"
-msgstr "目錄"
+msgstr "資料夾排序"
 
 #: ../src/libs/import.c:1263
 msgid "home"
-msgstr "家"
+msgstr "家目錄"
 
 #: ../src/libs/import.c:1275
 msgid "pictures"
-msgstr "圖片"
+msgstr "影像"
 
 #: ../src/libs/import.c:1539
 msgid "mark already imported pictures"
-msgstr "標記已輸入的圖片"
+msgstr "已匯入的影像標示"
 
 #: ../src/libs/import.c:1553
 msgid "modified"
-msgstr "已更改"
+msgstr "修改日期"
 
 #: ../src/libs/import.c:1558
 msgid "file 'modified date/time', may be different from 'Exif date/time'"
-msgstr "檔案內的“修改日期與時間”，可能與 EXIF 的日期時間不同"
+msgstr "檔案修改日期可能與 EXIF 紀錄的日期不同"
 
 #: ../src/libs/import.c:1570
 msgid "show/hide thumbnails"
-msgstr "顯示/隱藏縮圖"
+msgstr "顯示 / 隱藏縮圖"
 
 #: ../src/libs/import.c:1640
 msgid "naming rules"
@@ -20585,35 +21809,35 @@ msgstr "命名規則"
 
 #: ../src/libs/import.c:1681
 msgid "add to library"
-msgstr "增加到照片庫"
+msgstr "匯入影像"
 
 #: ../src/libs/import.c:1682
 msgid "copy & import"
-msgstr "複製及輸入"
+msgstr "複製和匯入"
 
 #: ../src/libs/import.c:1720
 msgid "select new"
-msgstr "選擇新影像"
+msgstr "選取新影像"
 
 #: ../src/libs/import.c:1763
 msgid "please wait while prefetching the list of images from camera..."
-msgstr "正在從相機預讀取影像列表，請稍等……"
+msgstr "正在從相機中讀取影像，請稍候..."
 
 #: ../src/libs/import.c:1887
 msgid "invalid override date/time format"
-msgstr "覆寫的日期/時間格式無效"
+msgstr "無效的日期 / 時間格式"
 
 #: ../src/libs/import.c:1990
 msgid "add to library..."
-msgstr "增加到照片庫..."
+msgstr "匯入影像"
 
 #: ../src/libs/import.c:1991
 msgid "add existing images to the library"
-msgstr "將現有照片增加至照片庫"
+msgstr "將硬碟中現有的影像匯入"
 
 #: ../src/libs/import.c:1997
 msgid "copy & import..."
-msgstr "複製及輸入..."
+msgstr "複製並匯入"
 
 #: ../src/libs/import.c:1998
 msgid ""
@@ -20621,37 +21845,37 @@ msgid ""
 "patterns can be defined to rename the images and specify the destination "
 "folders"
 msgstr ""
-"在將圖片增加至照片庫前複製或選擇性更名\n"
-"可以使用命名樣式去更名行爲並指定目標目錄"
+"複製並重命名影像，然後再將其匯入\n"
+"可以自訂檔案命名規則，並指定要儲存的資料夾位置"
 
 #. collapsible section
 #: ../src/libs/import.c:2021
 msgid "parameters"
-msgstr "參數"
+msgstr "匯入參數設定"
 
 #: ../src/libs/ioporder.c:195
 msgid "v3.0"
-msgstr "v3.0"
+msgstr "V3.0"
 
 #: ../src/libs/ioporder.c:213
 msgid "v3.0 for RAW input (default)"
-msgstr "v3.0 用於 RAW 輸入(預設)"
+msgstr "V3.0 適用於 RAW 檔（預設）"
 
 #: ../src/libs/ioporder.c:218
 msgid "v3.0 for JPEG/non-RAW input"
-msgstr "v3.0 用於 JPEG / 非 RAW 輸入"
+msgstr "V3.0 適用於 JPEG 與非 RAW 檔影像"
 
 #: ../src/libs/lib.c:387
 msgid "deleting preset for obsolete module"
-msgstr "正在刪除廢棄模組的預置"
+msgstr "刪除已淘汰模組的預設集"
 
 #: ../src/libs/lib.c:522
 msgid "manage presets..."
-msgstr "管理預置..."
+msgstr "管理模組布局"
 
 #: ../src/libs/lib.c:547
 msgid "nothing to save"
-msgstr "無需保存"
+msgstr "沒有東西可以儲存"
 
 #: ../src/libs/lib.c:1023
 msgid "show module"
@@ -20663,35 +21887,35 @@ msgstr "工具模組"
 
 #: ../src/libs/live_view.c:106
 msgid "live view"
-msgstr "即時預覽"
+msgstr "實時取景"
 
 #: ../src/libs/live_view.c:289
 msgid "toggle live view"
-msgstr "切換即時預覽"
+msgstr "切換實時取景"
 
 #: ../src/libs/live_view.c:291
 msgid "zoom live view"
-msgstr "縮放即時預覽"
+msgstr "縮放實時取景"
 
 #: ../src/libs/live_view.c:293
 msgid "rotate 90 degrees ccw"
-msgstr "逆時針旋轉90度"
+msgstr "逆時針旋轉 90 度"
 
 #: ../src/libs/live_view.c:294
 msgid "rotate 90 degrees cw"
-msgstr "順時針旋轉90度"
+msgstr "順時針旋轉 90 度"
 
 #: ../src/libs/live_view.c:295
 msgid "flip live view horizontally"
-msgstr "水平翻轉即時預覽"
+msgstr "水平翻轉實時取景"
 
 #: ../src/libs/live_view.c:301
 msgid "move focus point in (big steps)"
-msgstr "移入焦點(大步)"
+msgstr "移近對焦點（快速）"
 
 #: ../src/libs/live_view.c:302
 msgid "move focus point in (small steps)"
-msgstr "移入焦點(小步)"
+msgstr "移近對焦點（微調）"
 
 #. TODO icon not centered
 #: ../src/libs/live_view.c:303
@@ -20700,28 +21924,28 @@ msgstr "自動對焦"
 
 #: ../src/libs/live_view.c:304
 msgid "move focus point out (small steps)"
-msgstr "移出焦點(小步)"
+msgstr "拉遠對焦點（微調）"
 
 #. TODO same here
 #: ../src/libs/live_view.c:305
 msgid "move focus point out (big steps)"
-msgstr "移出焦點(大步)"
+msgstr "拉遠對焦點（快速）"
 
 #: ../src/libs/live_view.c:310
 msgid "overlay"
-msgstr "疊加層"
+msgstr "套疊"
 
 #: ../src/libs/live_view.c:312
 msgid "selected image"
-msgstr "選取的圖片"
+msgstr "已選取的影像"
 
 #: ../src/libs/live_view.c:314
 msgid "overlay another image over the live view"
-msgstr "在即時取景覆蓋另一張影像"
+msgstr "在即時預覽上覆蓋另一張影像"
 
 #: ../src/libs/live_view.c:323
 msgid "enter image id of the overlay manually"
-msgstr "手動輸入覆蓋的圖片id"
+msgstr "手動輸入覆蓋影像的識別碼"
 
 #: ../src/libs/live_view.c:334
 msgid "overlay mode"
@@ -20740,32 +21964,32 @@ msgstr "增加"
 #: ../src/libs/live_view.c:338
 msgctxt "blendmode"
 msgid "saturate"
-msgstr "飽和"
+msgstr "飽和度"
 
 #: ../src/libs/live_view.c:344
 msgctxt "blendmode"
 msgid "color dodge"
-msgstr "顏色減淡"
+msgstr "加亮顏色"
 
 #: ../src/libs/live_view.c:345
 msgctxt "blendmode"
 msgid "color burn"
-msgstr "顏色加深"
+msgstr "加深顏色"
 
 #: ../src/libs/live_view.c:346
 msgctxt "blendmode"
 msgid "hard light"
-msgstr "硬光(hardlight)"
+msgstr "實光"
 
 #: ../src/libs/live_view.c:347
 msgctxt "blendmode"
 msgid "soft light"
-msgstr "柔光(softlight)"
+msgstr "柔光"
 
 #: ../src/libs/live_view.c:349
 msgctxt "blendmode"
 msgid "exclusion"
-msgstr "排除"
+msgstr "差異化"
 
 #: ../src/libs/live_view.c:350
 msgctxt "blendmode"
@@ -20780,7 +22004,7 @@ msgstr "HSL 飽和度"
 #: ../src/libs/live_view.c:352
 msgctxt "blendmode"
 msgid "HSL color"
-msgstr "HSL 顏色"
+msgstr "HSL 色彩"
 
 #: ../src/libs/live_view.c:353
 msgctxt "blendmode"
@@ -20789,7 +22013,7 @@ msgstr "HSL 亮度"
 
 #: ../src/libs/live_view.c:354
 msgid "mode of the overlay"
-msgstr "疊加層模式"
+msgstr "覆蓋模式"
 
 #: ../src/libs/live_view.c:360
 msgid "split line"
@@ -20797,50 +22021,50 @@ msgstr "分割線"
 
 #: ../src/libs/live_view.c:363
 msgid "only draw part of the overlay"
-msgstr "只繪製疊加層部分區域"
+msgstr "只繪製疊加的區域"
 
 #: ../src/libs/location.c:100
 msgid "find location"
-msgstr "尋找位置"
+msgstr "尋找地點"
 
 #: ../src/libs/map_locations.c:36
 msgid "locations"
-msgstr "位置"
+msgstr "地點"
 
 #: ../src/libs/map_locations.c:257
 msgid "new sub-location"
-msgstr "新建子位置"
+msgstr "新增次級位置"
 
 #: ../src/libs/map_locations.c:261 ../src/libs/map_locations.c:309
 #: ../src/libs/map_locations.c:991
 msgid "new location"
-msgstr "新位置"
+msgstr "新增地點"
 
 #: ../src/libs/map_locations.c:610
 #, c-format
 msgid "location name '%s' already exists"
-msgstr "名爲“%s”的位置已經存在"
+msgstr "位置名稱「%s」已存在"
 
 #: ../src/libs/map_locations.c:801
 msgid "edit location"
-msgstr "編輯位置"
+msgstr "編輯地點"
 
 #: ../src/libs/map_locations.c:804
 msgid "delete location"
-msgstr "刪除位置"
+msgstr "刪除地點"
 
 #: ../src/libs/map_locations.c:814
 msgid "update filmstrip"
-msgstr "更新軟片條"
+msgstr "更新幻燈片"
 
 #: ../src/libs/map_locations.c:821
 msgid "go to collection (lighttable)"
-msgstr "前往集合(映繪桌)"
+msgstr "跳至相冊（燈箱）"
 
 #: ../src/libs/map_locations.c:867
 msgid ""
 "terminate edit (press enter or escape) before selecting another location"
-msgstr "在選擇另一地點前，請先結束編輯(按下 Enter 或 Escape)"
+msgstr "在選擇另一地點前，請先按 enter 完成或 esc 取消編輯"
 
 #: ../src/libs/map_locations.c:961
 msgid ""
@@ -20857,17 +22081,20 @@ msgid ""
 "right-click for other actions: delete location and go to collection,\n"
 "ctrl-wheel scroll to resize the window"
 msgstr ""
-"使用者位置列表。\n"
-"單擊以顯示或隱藏地圖上的位置:\n"
-" - 在形狀內使用滾輪來調整區域大小\n"
-" - 長方形可以按住 <shift> 或 <控制鍵> 並使用滾輪來調整寬度或高度\n"
-" - 在區域內單擊並拖拉以改變位置\n"
-"按住 控制鍵 單擊可以編輯位置名稱\n"
-" - “|”可用以將名稱拆分爲多個層級\n"
-" - 清除名稱以刪除一群地點\n"
-" - 按下 Enter 以確認該新名稱，按下 Escape 取消編輯\n"
-"右鍵單擊可進行其他操作:刪除位置、轉到集合\n"
-"控制鍵滾輪:以調整視窗的大小"
+"自訂地點列表\n"
+"\n"
+"點擊可在地圖上顯示位置\n"
+"- 在地點形狀內用滑鼠滾輪調整大小\n"
+"- 按著 shift 單獨調整寬度，按 ctrl 單獨修改高度\n"
+"- 拖曳範圍改變地點位置\n"
+"- ctrl + 拖曳可移動地圖\n"
+"\n"
+"ctrl + 點擊地點列表可編輯名稱\n"
+"- 用「|」符號分隔把地點分成數個級別\n"
+"- 位置清空之後群組名稱也會隨之消失\n"
+"- 按 enter 完成編輯，按 esc 取消編輯\n"
+"\n"
+"右鍵開啟其他動作，ctrl + 滑鼠滾輪可以調整視窗大小"
 
 #: ../src/libs/map_locations.c:988
 msgid ""
@@ -20875,20 +22102,20 @@ msgid ""
 "or even polygon if available (select first a polygon place in 'find "
 "location' module)"
 msgstr ""
-"選擇地圖上的位置極限形狀:圓形或長方形甚至多邊形如果有\n"
-"在“尋找地點”模組中選取多邊形地點"
+"自訂位置的形狀，預設可選擇圓形和矩形\n"
+"在「尋找地點」模組中搜尋並選擇想要使用的地點，即可使用精確的多邊形位置"
 
 #: ../src/libs/map_locations.c:992
 msgid "add a new location on the center of the visible map"
-msgstr "在可見的地圖中心增加新位置"
+msgstr "在地圖中心點新增一個位置"
 
 #: ../src/libs/map_locations.c:996
 msgid "show all"
-msgstr "全部顯示"
+msgstr "顯示全部"
 
 #: ../src/libs/map_locations.c:999
 msgid "show all locations which are on the visible map"
-msgstr "顯示可見地圖上的所有位置"
+msgstr "顯示所有自訂地點"
 
 #: ../src/libs/map_settings.c:39
 msgid "map settings"
@@ -20900,56 +22127,56 @@ msgstr "地圖來源"
 
 #: ../src/libs/map_settings.c:113
 msgid "select the source of the map. some entries might not work"
-msgstr "選擇地圖來源。有些項目可能無法正常工作"
+msgstr "選擇地圖資訊的提供者"
 
 #: ../src/libs/masks.c:279
 #, c-format
 msgid "group #%d"
-msgstr "分組 #%d"
+msgstr "群組 #%d"
 
 #: ../src/libs/masks.c:1043
 msgid "duplicate this shape"
-msgstr "複製此形狀"
+msgstr "複製這個遮罩"
 
 #: ../src/libs/masks.c:1047
 msgid "delete this shape"
-msgstr "刪除此形狀"
+msgstr "刪除這個遮罩"
 
 #: ../src/libs/masks.c:1062
 msgid "remove from group"
-msgstr "從分組中移除"
+msgstr "從群組中移除"
 
 #: ../src/libs/masks.c:1070
 msgid "group the forms"
-msgstr "分組樣子"
+msgstr "把遮罩組成群組"
 
 #: ../src/libs/masks.c:1078
 msgid "use inverted shape"
-msgstr "使用反轉形狀"
+msgstr "反轉遮罩"
 
 #: ../src/libs/masks.c:1084
 msgid "mode: union"
-msgstr "模式:聯集"
+msgstr "模式：聯集（或是）"
 
 #: ../src/libs/masks.c:1087
 msgid "mode: intersection"
-msgstr "模式:交集"
+msgstr "模式：交集（並且）"
 
 #: ../src/libs/masks.c:1090
 msgid "mode: difference"
-msgstr "模式:差集"
+msgstr "模式：差集（減去）"
 
 #: ../src/libs/masks.c:1093
 msgid "mode: exclusion"
-msgstr "模式:排除"
+msgstr "模式：互斥（兩者不含交集）"
 
 #: ../src/libs/masks.c:1107
 msgid "cleanup unused shapes"
-msgstr "清理未使用的形狀"
+msgstr "清除未使用的遮罩"
 
 #: ../src/libs/masks.c:1628
 msgid "created shapes"
-msgstr "已建立形狀"
+msgstr "已建立的遮罩"
 
 #: ../src/libs/metadata.c:61
 msgid "metadata editor"
@@ -20957,7 +22184,7 @@ msgstr "詮釋資料編輯器"
 
 #: ../src/libs/metadata.c:128 ../src/libs/metadata.c:401
 msgid "<leave unchanged>"
-msgstr "<保持不改變>"
+msgstr "<保持不變>"
 
 #: ../src/libs/metadata.c:505 ../src/libs/metadata_view.c:1184
 msgid "metadata settings"
@@ -20965,7 +22192,7 @@ msgstr "詮釋資料設定"
 
 #: ../src/libs/metadata.c:554 ../src/libs/metadata_view.c:1229
 msgid "visible"
-msgstr "可見"
+msgstr "顯示"
 
 #: ../src/libs/metadata.c:559
 msgid ""
@@ -20973,19 +22200,20 @@ msgid ""
 "it will be visible from metadata editor, collection and import module\n"
 "it will be also exported"
 msgstr ""
-"勾選有興趣的詮釋資料\n"
-"這些資料將在詮釋資料編輯器、集合和輸入模組中顯示\n"
-"也會隨影像一併輸出"
+"勾選要顯示的詮釋資料欄位\n"
+"欄位同時也會包含在匯出的檔案中"
 
 #: ../src/libs/metadata.c:564 ../src/libs/tagging.c:1679
 #: ../src/libs/tagging.c:1823
 msgid "private"
-msgstr "私有"
+msgstr "隱私"
 
 #: ../src/libs/metadata.c:569
 msgid ""
 "tick if you want to keep this information private (not exported with images)"
-msgstr "勾選如果您想將此資訊保密(不隨影像輸出)。"
+msgstr ""
+"勾選後設定為私人欄位\n"
+"私人欄位不會隨著影像匯出"
 
 #: ../src/libs/metadata.c:713
 msgid ""
@@ -20996,14 +22224,14 @@ msgid ""
 "in that case, right-click gives the possibility to choose one of them.\n"
 "press escape to exit the popup window"
 msgstr ""
-"詮釋資料文字。按住 控制鍵 滾動以調整文字框大小\n"
-"按下 控制鍵-enter 以插入新行(注意，這可能與標準詮釋資料格式不兼容)。\n"
-"若 <保持不改變>已選取的影像含有不同的詮釋資料，右鍵可以從中選擇一個。\n"
-"按下 escape 關閉彈出視窗"
+"ctrl + 滑鼠滾輪調整欄位行數\n"
+"ctrl + enter 分行（可能與標準詮釋資料不相容）\n"
+"如果 <保持不變> 所選影像具有不同的詮釋資料，右鍵點擊可以從其中選擇\n"
+"按 esc 鍵退出彈出視窗"
 
 #: ../src/libs/metadata.c:759
 msgid "write metadata for selected images"
-msgstr "寫入詮釋資料至選取的圖片"
+msgstr "寫入詮釋資料至選取的影像"
 
 #. <title>\0<description>\0<rights>\0<creator>\0<publisher>
 #: ../src/libs/metadata.c:815
@@ -21012,7 +22240,7 @@ msgstr "CC BY"
 
 #: ../src/libs/metadata.c:815
 msgid "Creative Commons Attribution (CC BY)"
-msgstr "創作共用、姓名標示(CC-BY)"
+msgstr "創用CC授權條款 - 姓名標示 (CC BY)"
 
 #: ../src/libs/metadata.c:816
 msgid "CC BY-SA"
@@ -21020,7 +22248,7 @@ msgstr "CC BY-SA"
 
 #: ../src/libs/metadata.c:816
 msgid "Creative Commons Attribution-ShareAlike (CC BY-SA)"
-msgstr "創作共用、姓名標示、相同方式分享(CC-BY-SA)"
+msgstr "創用CC授權條款 - 姓名標示 - 相同方式分享（CC BY-SA）"
 
 #: ../src/libs/metadata.c:817
 msgid "CC BY-ND"
@@ -21028,7 +22256,7 @@ msgstr "CC BY-ND"
 
 #: ../src/libs/metadata.c:817
 msgid "Creative Commons Attribution-NoDerivs (CC BY-ND)"
-msgstr "創作共用、姓名標示-禁止改作(CC-BY-ND)"
+msgstr "創用CC授權條款 - 姓名標示 - 禁止改作（CC BY-ND）"
 
 #: ../src/libs/metadata.c:818
 msgid "CC BY-NC"
@@ -21036,7 +22264,7 @@ msgstr "CC BY-NC"
 
 #: ../src/libs/metadata.c:818
 msgid "Creative Commons Attribution-NonCommercial (CC BY-NC)"
-msgstr "創作共用、姓名標示-非商業性使用(CC-BY-NC)"
+msgstr "創用CC授權條款 - 姓名標示 - 非商業性（CC BY-NC）"
 
 #: ../src/libs/metadata.c:819
 msgid "CC BY-NC-SA"
@@ -21044,7 +22272,7 @@ msgstr "CC BY-NC-SA"
 
 #: ../src/libs/metadata.c:820
 msgid "Creative Commons Attribution-NonCommercial-ShareAlike (CC BY-NC-SA)"
-msgstr "創作共用、姓名標示-非商業性使用-相同方式共享(CC-BY-NC-SA)"
+msgstr "創用CC授權條款 - 姓名標示 - 非商業性 - 相同方式分享（CC BY-NC-SA）"
 
 #: ../src/libs/metadata.c:821
 msgid "CC BY-NC-ND"
@@ -21052,52 +22280,52 @@ msgstr "CC BY-NC-ND"
 
 #: ../src/libs/metadata.c:822
 msgid "Creative Commons Attribution-NonCommercial-NoDerivs (CC BY-NC-ND)"
-msgstr "創作共用、姓名標示-非商業性使用-禁止改作(CC-BY-NC-ND)"
+msgstr "創用CC授權條款 - 姓名標示 - 非商業性 - 禁止改作（CC BY-NC-ND）"
 
 #: ../src/libs/metadata.c:823
 msgid "all rights reserved"
-msgstr "版權所有"
+msgstr "保留所有權利"
 
 #. internal
 #: ../src/libs/metadata_view.c:123
 msgid "filmroll"
-msgstr "軟片捲"
+msgstr "底片卷"
 
 #: ../src/libs/metadata_view.c:125
 msgid "group id"
-msgstr "分組 id"
+msgstr "群組識別碼"
 
 #: ../src/libs/metadata_view.c:127
 msgid "version"
-msgstr "版本"
+msgstr "複本版本"
 
 #: ../src/libs/metadata_view.c:130
 msgid "import timestamp"
-msgstr "輸入時戳"
+msgstr "匯入日期"
 
 #: ../src/libs/metadata_view.c:131
 msgid "change timestamp"
-msgstr "編輯時間"
+msgstr "編輯日期"
 
 #: ../src/libs/metadata_view.c:132
 msgid "export timestamp"
-msgstr "輸出時戳"
+msgstr "匯出日期"
 
 #: ../src/libs/metadata_view.c:133
 msgid "print timestamp"
-msgstr "列印時戳"
+msgstr "列印日期"
 
 #: ../src/libs/metadata_view.c:134
 msgid "flags"
-msgstr "旗標"
+msgstr "旗幟"
 
 #: ../src/libs/metadata_view.c:144
 msgid "focus distance"
-msgstr "焦距"
+msgstr "對焦距離"
 
 #: ../src/libs/metadata_view.c:146
 msgid "datetime"
-msgstr "拍攝時間"
+msgstr "拍攝日期"
 
 #: ../src/libs/metadata_view.c:148 ../src/libs/print_settings.c:2389
 msgid "height"
@@ -21105,11 +22333,11 @@ msgstr "高度"
 
 #: ../src/libs/metadata_view.c:149
 msgid "export width"
-msgstr "輸出寬度"
+msgstr "匯出寬度"
 
 #: ../src/libs/metadata_view.c:150
 msgid "export height"
-msgstr "輸出高度"
+msgstr "匯出高度"
 
 #: ../src/libs/metadata_view.c:158
 msgid "longitude"
@@ -21121,35 +22349,35 @@ msgstr "海拔"
 
 #: ../src/libs/metadata_view.c:163
 msgid "categories"
-msgstr "類別"
+msgstr "分類"
 
 #: ../src/libs/metadata_view.c:170
 msgid "image information"
-msgstr "圖片資訊"
+msgstr "影像資訊"
 
 #: ../src/libs/metadata_view.c:331
 msgid "unused/deprecated"
-msgstr "未使用/已廢棄"
+msgstr "未使用 / 已被汰除"
 
 #: ../src/libs/metadata_view.c:332
 msgid "ldr"
-msgstr "ldr"
+msgstr "LDR"
 
 #: ../src/libs/metadata_view.c:334
 msgid "hdr"
-msgstr "hdr"
+msgstr "HDR"
 
 #: ../src/libs/metadata_view.c:335
 msgid "marked for deletion"
-msgstr "標記刪除"
+msgstr "已標記刪除"
 
 #: ../src/libs/metadata_view.c:336
 msgid "auto-applying presets applied"
-msgstr "自動套用已套用的預置"
+msgstr "已啟用自動套用的預設集"
 
 #: ../src/libs/metadata_view.c:337
 msgid "legacy flag. set for all new images"
-msgstr "所有新影像設定爲舊旗標"
+msgstr "傳統標籤，已為所有新的影像設置"
 
 #: ../src/libs/metadata_view.c:339
 msgid "has .txt"
@@ -21163,23 +22391,25 @@ msgstr "含有 .wav"
 #, c-format
 msgid "image has %d star"
 msgid_plural "image has %d stars"
-msgstr[0] "影像被評爲 %d 顆星"
+msgstr[0] "影像評分為 %d 顆星"
 
 #: ../src/libs/metadata_view.c:440
 #, c-format
 msgid "loader: %s"
-msgstr "載入器:%s"
+msgstr "載入：「%s」"
 
 #: ../src/libs/metadata_view.c:631
 msgid "<various values>"
-msgstr "<各種值>"
+msgstr "<多種數值>"
 
 #: ../src/libs/metadata_view.c:644
 #, c-format
 msgid ""
 "double-click to jump to film roll\n"
 "%s"
-msgstr "雙擊以跳轉到軟片捲 %s"
+msgstr ""
+"雙擊跳到底片卷\n"
+"「%s」"
 
 #: ../src/libs/metadata_view.c:736
 #, c-format
@@ -21189,7 +22419,7 @@ msgstr "%+.2f EV"
 #: ../src/libs/metadata_view.c:750
 #, c-format
 msgid "%.2f m"
-msgstr "%.2f 米"
+msgstr "%.2f 公尺"
 
 #: ../src/libs/metadata_view.c:1224
 msgid ""
@@ -21197,202 +22427,201 @@ msgid ""
 "untick to hide metadata which are not of interest for you\n"
 "if different settings are needed, use presets"
 msgstr ""
-"每次拖放一列，直到得到您所需的順序。\n"
-"取消勾選以隱藏不感興趣的詮釋資料\n"
-"如果需要不同的設定，請使用預置"
+"拖曳以重新排列顯示順序\n"
+"取消勾選可隱藏不希望顯示的詮釋資料\n"
+"可儲存成不同設定的預設集"
 
 #: ../src/libs/metadata_view.c:1380
 msgid "jump to film roll"
-msgstr "跳到軟片捲"
+msgstr "跳到底片卷"
 
 #: ../src/libs/recentcollect.c:67
 msgid "recently used collections"
-msgstr "最近用過的集合"
+msgstr "最近用過的相冊"
 
 #: ../src/libs/recentcollect.c:109
 msgid " and "
-msgstr " 及 "
+msgstr " 以及 "
 
 #: ../src/libs/recentcollect.c:114
 msgid " or "
-msgstr " 或 "
+msgstr " 或是 "
 
 #. case DT_LIB_COLLECT_MODE_AND_NOT:
 #: ../src/libs/recentcollect.c:119
 msgid " but not "
-msgstr " 但不 "
+msgstr " 但不是 "
 
 #: ../src/libs/recentcollect.c:294
 msgid "recent collections settings"
-msgstr "最近集合設定"
+msgstr "最近用過的相冊設定"
 
 #: ../src/libs/modulegroups.c:42
 msgid "modules: default"
-msgstr "模組:預設"
+msgstr "模組：預設"
 
 #: ../src/libs/modulegroups.c:45
 msgid "modules: deprecated"
-msgstr "模組:已廢棄"
+msgstr "模組：已被汰除"
 
 #: ../src/libs/modulegroups.c:48
 msgid "last modified layout"
-msgstr "上次修改的佈局"
+msgstr "上次修改的模組布局"
 
 #: ../src/libs/modulegroups.c:199
 msgid "modulegroups"
-msgstr "模組群"
+msgstr "編輯模組布局"
 
 #. FIXME don't check here if on/off is enabled, because it depends on image (reload_defaults)
 #. respond later to image changed signal
 #: ../src/libs/modulegroups.c:314 ../src/libs/modulegroups.c:326
 #: ../src/libs/modulegroups.c:2512 ../src/libs/modulegroups.c:2514
 msgid "on-off"
-msgstr "開關"
+msgstr "開 / 關"
 
 #: ../src/libs/modulegroups.c:495 ../src/libs/modulegroups.c:498
 #: ../src/libs/modulegroups.c:592
 msgid ""
 "this quick access widget is disabled as there are multiple instances of this "
 "module present. Please use the full module to access this widget..."
-msgstr "此快速訪問部件當有多個實例時不使用。請使用完整版模組存取部件……"
+msgstr "此快速存取小工具被停用，因為此模組有的多個實例，請使用完整的模組"
 
 #: ../src/libs/modulegroups.c:599
 msgid ""
 "this quick access widget is disabled as it's hidden in the actual module "
 "configuration. Please use the full module to access this widget..."
-msgstr ""
-"此快速訪問部件隱藏在實際的模組配置中時不使用。需使用完整版模組存取部件……"
+msgstr "此快速存取小工具被停用，因為實際的模組被設定隱藏，請使用完整的模組"
 
 #: ../src/libs/modulegroups.c:606
 msgid "(some features may only be available in the full module interface)"
-msgstr "(一些功能可能僅在完整版模組介面時可用)"
+msgstr "（某些功能可能只有在完整的模組裡才能使用）"
 
 #: ../src/libs/modulegroups.c:633
 #, c-format
 msgid "go to the full version of the %s module"
-msgstr "前往完整版本模組 %s"
+msgstr "前往「%s」模組的完整版本"
 
 #: ../src/libs/modulegroups.c:1579 ../src/libs/modulegroups.c:1663
 #: ../src/libs/modulegroups.c:1699 ../src/libs/modulegroups.c:1749
 #: ../src/libs/modulegroups.c:1914
 msgctxt "modulegroup"
 msgid "base"
-msgstr "基礎"
+msgstr "基本模組"
 
 #: ../src/libs/modulegroups.c:1598
 msgctxt "modulegroup"
 msgid "tone"
-msgstr "色調"
+msgstr "階調模組"
 
 #: ../src/libs/modulegroups.c:1606 ../src/libs/modulegroups.c:1713
 #: ../src/libs/modulegroups.c:1759
 msgctxt "modulegroup"
 msgid "color"
-msgstr "顏色"
+msgstr "色彩模組"
 
 #: ../src/libs/modulegroups.c:1621 ../src/libs/modulegroups.c:1721
 #: ../src/libs/modulegroups.c:1764
 msgctxt "modulegroup"
 msgid "correct"
-msgstr "修正"
+msgstr "校正模組"
 
 #: ../src/libs/modulegroups.c:1639 ../src/libs/modulegroups.c:1733
 #: ../src/libs/modulegroups.c:1776 ../src/libs/modulegroups.c:2413
 msgctxt "modulegroup"
 msgid "effect"
-msgstr "效果"
+msgstr "效果模組"
 
 #: ../src/libs/modulegroups.c:1657
 msgid "modules: all"
-msgstr "模組:全部"
+msgstr "模組：全部"
 
 #: ../src/libs/modulegroups.c:1678 ../src/libs/modulegroups.c:1825
 msgctxt "modulegroup"
 msgid "grading"
-msgstr "分級"
+msgstr "調色模組"
 
 #: ../src/libs/modulegroups.c:1686 ../src/libs/modulegroups.c:1843
 #: ../src/libs/modulegroups.c:2417
 msgctxt "modulegroup"
 msgid "effects"
-msgstr "效果"
+msgstr "效果模組"
 
 #: ../src/libs/modulegroups.c:1694
 msgid "workflow: beginner"
-msgstr "工作流:入門"
+msgstr "工作流程：初學者"
 
 #: ../src/libs/modulegroups.c:1743
 msgid "workflow: display-referred"
-msgstr "工作流:顯示工作流程"
+msgstr "工作流程：顯示參照"
 
 #: ../src/libs/modulegroups.c:1786
 msgid "workflow: scene-referred"
-msgstr "工作流:場景工作流程"
+msgstr "工作流程：場景參照"
 
 #: ../src/libs/modulegroups.c:1792
 msgctxt "modulegroup"
 msgid "technical"
-msgstr "技術"
+msgstr "技術性模組"
 
 #: ../src/libs/modulegroups.c:1868
 msgid "search only"
-msgstr "僅搜尋"
+msgstr "只有搜尋欄"
 
 #: ../src/libs/modulegroups.c:1874 ../src/libs/modulegroups.c:2182
 #: ../src/libs/modulegroups.c:2665
 msgctxt "modulegroup"
 msgid "deprecated"
-msgstr "廢棄"
+msgstr "已被汰除"
 
 #: ../src/libs/modulegroups.c:1889
 msgid "previous config"
-msgstr "舊配置"
+msgstr "之前的設定"
 
 #: ../src/libs/modulegroups.c:1890
 msgid "previous layout"
-msgstr "舊佈局"
+msgstr "之前的布局"
 
 #: ../src/libs/modulegroups.c:1894
 msgid "previous config with new layout"
-msgstr "舊設置，新佈局"
+msgstr "套用舊設定的新布局"
 
 #: ../src/libs/modulegroups.c:2049 ../src/libs/modulegroups.c:2565
 msgid "remove this widget"
-msgstr "移除此部件"
+msgstr "移除這個小工具"
 
 #: ../src/libs/modulegroups.c:2199 ../src/libs/modulegroups.c:2439
 msgid "remove this module"
-msgstr "移除此模組"
+msgstr "移除這個模組"
 
 #. does it belong to recommended modules ?
 #: ../src/libs/modulegroups.c:2408
 msgid "base"
-msgstr "基本"
+msgstr "基本模組"
 
 #: ../src/libs/modulegroups.c:2411
 msgid "tone"
-msgstr "色調"
+msgstr "階調模組"
 
 #: ../src/libs/modulegroups.c:2414
 msgid "technical"
-msgstr "技術"
+msgstr "技術性模組"
 
 #: ../src/libs/modulegroups.c:2415
 msgid "grading"
-msgstr "分級"
+msgstr "色調模組"
 
 #: ../src/libs/modulegroups.c:2421 ../src/libs/modulegroups.c:2429
 msgid "add this module"
-msgstr "增加此模組"
+msgstr "新增這個模組"
 
 #. show the submenu with all the modules
 #: ../src/libs/modulegroups.c:2451 ../src/libs/modulegroups.c:2625
 msgid "all available modules"
-msgstr "全部可用模組"
+msgstr "所有可用的模組"
 
 #: ../src/libs/modulegroups.c:2459
 msgid "add module"
-msgstr "增加模組"
+msgstr "新增模組"
 
 #: ../src/libs/modulegroups.c:2464
 msgid "remove module"
@@ -21400,25 +22629,25 @@ msgstr "移除模組"
 
 #: ../src/libs/modulegroups.c:2574 ../src/libs/modulegroups.c:2581
 msgid "add this widget"
-msgstr "增加此部件"
+msgstr "新增這個小工具"
 
 #: ../src/libs/modulegroups.c:2609
 msgid "add widget"
-msgstr "增加部件"
+msgstr "新增小工具"
 
 #: ../src/libs/modulegroups.c:2614
 msgid "remove widget"
-msgstr "移除部件"
+msgstr "移除小工具"
 
 #: ../src/libs/modulegroups.c:2700
 msgid "show all history modules"
-msgstr "顯示所有歷史模組"
+msgstr "顯示所有使用過的模組"
 
 #: ../src/libs/modulegroups.c:2703 ../src/libs/modulegroups.c:3889
 msgid ""
 "show modules that are present in the history stack, regardless of whether or "
 "not they are currently enabled"
-msgstr "顯示所有存在於歷史記錄中的模組，不管它們目前是否啓用"
+msgstr "顯示所有影像編輯紀錄中使用過的模組，不論目前是否有被啟用"
 
 #: ../src/libs/modulegroups.c:2794
 msgid ""
@@ -21426,33 +22655,36 @@ msgid ""
 "mistakes which can't be solved and alternative modules which solve them.\n"
 " they will be removed for new edits in the next release."
 msgstr ""
-"以下模組已被棄用，\n"
-"因爲它們有無法解決的內部設計錯誤，而其他替代方案可以解決這些問題。\n"
-"在下一版本中將移除。"
+"⚠️ 以下模組已被汰除 ⚠️\n"
+"\n"
+"因為它們具有無法解決的內部設計錯誤\n"
+"並且已有可解決這些錯誤的新模組可取代\n"
+"這些模組將從下一版的 darktable 中移除\n"
+"僅供舊影像延續使用，無法用於編輯新的影像"
 
 #: ../src/libs/modulegroups.c:2822
 msgid "quick access panel"
-msgstr "快速訪問面板"
+msgstr "顯示快速存取面板"
 
 #: ../src/libs/modulegroups.c:2832
 msgid "show only active modules"
-msgstr "僅顯示使用中模組"
+msgstr "只顯示使用中的模組"
 
 #: ../src/libs/modulegroups.c:2837
 msgid ""
 "presets\n"
 "ctrl+click to manage"
 msgstr ""
-"預置\n"
-"控制鍵 + 單擊以管理預置"
+"預設集\n"
+"ctrl + 點擊以管理"
 
 #: ../src/libs/modulegroups.c:2844
 msgid "search modules by name or tag"
-msgstr "按名稱或標籤搜尋模組"
+msgstr "依名稱或標籤來搜尋模組"
 
 #: ../src/libs/modulegroups.c:2849
 msgid "clear text"
-msgstr "清空文字"
+msgstr "清除文字"
 
 #: ../src/libs/modulegroups.c:2856
 msgid ""
@@ -21460,9 +22692,9 @@ msgid ""
 "mistakes which can't be solved and alternative modules which solve them.\n"
 "they will be removed for new edits in the next release."
 msgstr ""
-"以下模組已被棄用，\n"
-"因爲它們有無法解決的內部設計錯誤，而其他替代方案可以解決這些問題。\n"
-"在下一版本中將移除。"
+"以下模組已被汰除\n"
+"因為它們具有無法解決的內部設計錯誤，並且已被新模組取代\n"
+"這些模組將在下一個版本的 darktable 中被移除，不能用於編輯新的影像"
 
 #: ../src/libs/modulegroups.c:3094
 msgid "basic icon"
@@ -21478,136 +22710,136 @@ msgstr "色彩圖示"
 
 #: ../src/libs/modulegroups.c:3124
 msgid "correct icon"
-msgstr "修正圖示"
+msgstr "校正圖示"
 
 #: ../src/libs/modulegroups.c:3134
 msgid "effect icon"
-msgstr "特效圖示"
+msgstr "效果圖示"
 
 #: ../src/libs/modulegroups.c:3144
 msgid "favorites icon"
-msgstr "最愛圖示"
+msgstr "常用圖示"
 
 #: ../src/libs/modulegroups.c:3154
 msgid "tone icon"
-msgstr "色調圖示"
+msgstr "階調圖示"
 
 #: ../src/libs/modulegroups.c:3164
 msgid "grading icon"
-msgstr "分級圖示"
+msgstr "色調圖示"
 
 #: ../src/libs/modulegroups.c:3174
 msgid "technical icon"
-msgstr "技術圖示"
+msgstr "技術性圖示"
 
 #: ../src/libs/modulegroups.c:3207
 msgid "quick access panel widgets"
-msgstr "快速訪問面板部件"
+msgstr "快速存取面板小工具"
 
 #: ../src/libs/modulegroups.c:3209
 msgid "quick access"
-msgstr "快速訪問"
+msgstr "快速存取面板"
 
 #: ../src/libs/modulegroups.c:3229
 msgid "add widget to the quick access panel"
-msgstr "將部件增加至快訪面板"
+msgstr "新增小工具到快速存取面板"
 
 #: ../src/libs/modulegroups.c:3261
 msgid "group icon"
-msgstr "組圖示"
+msgstr "群組圖示"
 
 #: ../src/libs/modulegroups.c:3270
 msgid "group name"
-msgstr "組名"
+msgstr "群組名稱"
 
 #: ../src/libs/modulegroups.c:3281
 msgid "remove group"
-msgstr "移除分組"
+msgstr "刪除群組"
 
 #: ../src/libs/modulegroups.c:3307
 msgid "move group to the left"
-msgstr "將分組向左移動"
+msgstr "向左移動群組"
 
 #: ../src/libs/modulegroups.c:3315
 msgid "add module to the group"
-msgstr "在分組增加模組"
+msgstr "新增模組至群組中"
 
 #: ../src/libs/modulegroups.c:3326
 msgid "move group to the right"
-msgstr "將分組向右移動"
+msgstr "向右移動群組"
 
 #: ../src/libs/modulegroups.c:3506
 msgid "rename preset"
-msgstr "重新命名預置"
+msgstr "重新命名模組布局"
 
 #: ../src/libs/modulegroups.c:3513
 msgid "new preset name:"
-msgstr "新預置名稱:"
+msgstr "新的模組布局名稱："
 
 #: ../src/libs/modulegroups.c:3514
 msgid "a preset with this name already exists!"
-msgstr "預置名稱已存在 !"
+msgstr "這個模組布局名稱已被使用"
 
 #: ../src/libs/modulegroups.c:3859
 msgid "preset: "
-msgstr "預置: "
+msgstr "模組布局："
 
 #: ../src/libs/modulegroups.c:3866
 msgid "remove the preset"
-msgstr "移除此預置"
+msgstr "刪除模組布局"
 
 #: ../src/libs/modulegroups.c:3868
 msgid "duplicate the preset"
-msgstr "複製此預置"
+msgstr "複製模組布局"
 
 #: ../src/libs/modulegroups.c:3870
 msgid "rename the preset"
-msgstr "重新命名此預置"
+msgstr "重新命名模組布局"
 
 #: ../src/libs/modulegroups.c:3872
 msgid "create a new empty preset"
-msgstr "增加新的空預置"
+msgstr "建立新的空白模組布局"
 
 #: ../src/libs/modulegroups.c:3880
 msgid "show search line"
-msgstr "顯示搜尋行"
+msgstr "顯示搜尋欄位"
 
 #: ../src/libs/modulegroups.c:3883
 msgid "show quick access panel"
-msgstr "顯示快速訪問面板"
+msgstr "顯示快速存取面板"
 
 #: ../src/libs/modulegroups.c:3886
 msgid "show all history modules in active group"
-msgstr "顯示啟用中分組內所有歷史模組"
+msgstr "顯示所有使用過的模組"
 
 #: ../src/libs/modulegroups.c:3898
 msgid "auto-apply this preset"
-msgstr "自動套用此預置"
+msgstr "自動套用這個預設集"
 
 #: ../src/libs/modulegroups.c:3913
 msgid "module groups"
-msgstr "模組群組"
+msgstr "新增模組群組"
 
 #: ../src/libs/modulegroups.c:3930
 msgid ""
 "this is a built-in read-only preset. duplicate it if you want to make changes"
-msgstr "這是一個內建的唯讀預置。如果要進行變更，請先複製一份"
+msgstr "唯讀的內建模組布局，想進行更改請複製另存為新布局"
 
 #: ../src/libs/navigation.c:62
 msgid "navigation"
-msgstr "導航"
+msgstr "導覽"
 
 #: ../src/libs/navigation.c:134
 msgid "hide navigation thumbnail"
-msgstr "隱藏導航縮圖"
+msgstr "隱藏導覽縮圖"
 
 #: ../src/libs/navigation.c:509
 msgid "small"
-msgstr "小"
+msgstr "縮小顯示"
 
 #: ../src/libs/navigation.c:513
 msgid "fit to screen"
-msgstr "符合屏幕"
+msgstr "符合螢幕"
 
 #: ../src/libs/navigation.c:517
 msgid "50%"
@@ -21642,53 +22874,53 @@ msgstr "列印設定"
 #: ../src/libs/print_settings.c:336 ../src/libs/print_settings.c:713
 #, c-format
 msgid "processing `%s' for `%s'"
-msgstr "正在處理“%s”用於“%s”"
+msgstr "正在處理「%s」用於「%s」"
 
 #: ../src/libs/print_settings.c:364
 #, c-format
 msgid "cannot open printer profile `%s'"
-msgstr "無法打開印表機色彩配置“%s”"
+msgstr "無法開啟印表機描述檔「%s」"
 
 #: ../src/libs/print_settings.c:373
 #, c-format
 msgid "error getting output profile for image %d"
-msgstr "無法獲取影像 %d 的輸出色彩配置"
+msgstr "獲取影像「%d」的輸出描述檔時發生錯誤"
 
 #: ../src/libs/print_settings.c:382
 #, c-format
 msgid "cannot apply printer profile `%s'"
-msgstr "無法套應印表機色彩配置“%s”！"
+msgstr "無法套用印表機描述檔「%s」"
 
 #: ../src/libs/print_settings.c:535
 msgid "failed to create temporary pdf for printing"
-msgstr "無法建立列印用的臨時 pdf"
+msgstr "無法建立用於列印的暫時 PDF"
 
 #: ../src/libs/print_settings.c:581
 msgid "maximum image per page reached"
-msgstr "已達到每頁最大影像數"
+msgstr "已達到每頁最大影像數量"
 
 #: ../src/libs/print_settings.c:668
 msgid "cannot print until a picture is selected"
-msgstr "列印前請先選擇要列印的影像"
+msgstr "列印前必須先選擇影像"
 
 #: ../src/libs/print_settings.c:673
 msgid "cannot print until a printer is selected"
-msgstr "列印前請先選擇印表機"
+msgstr "列印前必須先選擇印表機"
 
 #: ../src/libs/print_settings.c:678
 msgid "cannot print until a paper is selected"
-msgstr "列印前請先選擇紙張類型"
+msgstr "列印前必須先選擇紙張類型"
 
 #. in this case no need to release from cache what we couldn't get
 #: ../src/libs/print_settings.c:705
 #, c-format
 msgid "cannot get image %d for printing"
-msgstr "無法獲取影像 %d以列印"
+msgstr "無法取得要列印的影像「%d」"
 
 #: ../src/libs/print_settings.c:875
 #, c-format
 msgid "%3.2f (dpi:%d)"
-msgstr "%3.2f (dpi: %d)"
+msgstr "%3.2f (DPI：%d)"
 
 #: ../src/libs/print_settings.c:2253 ../src/libs/print_settings.c:2265
 #: ../src/libs/print_settings.c:2273 ../src/libs/print_settings.c:2324
@@ -21697,16 +22929,19 @@ msgstr "印表機"
 
 #: ../src/libs/print_settings.c:2265
 msgid "media"
-msgstr "紙張類型"
+msgstr "紙材"
 
 #: ../src/libs/print_settings.c:2283
 msgid "color management in printer driver"
-msgstr "印表機驅動的色彩管理"
+msgstr "印表機驅動程式的色彩管理"
 
 #: ../src/libs/print_settings.c:2315
 #, c-format
 msgid "printer ICC profiles in %s or %s"
-msgstr "將印表機的 ICC 配置設定爲 %s 或 %s"
+msgstr ""
+"選擇印表機的描述檔，可在以下兩個資料夾新增：\n"
+"%s\n"
+"%s"
 
 #: ../src/libs/print_settings.c:2337
 msgid "black point compensation"
@@ -21714,7 +22949,7 @@ msgstr "黑點補償"
 
 #: ../src/libs/print_settings.c:2345
 msgid "activate black point compensation when applying the printer profile"
-msgstr "套用印表機色彩配置時啓用黑點補償"
+msgstr "套用印表機描述檔時啟用黑點補償"
 
 #: ../src/libs/print_settings.c:2375
 msgid "measurement units"
@@ -21722,7 +22957,7 @@ msgstr "測量單位"
 
 #: ../src/libs/print_settings.c:2383
 msgid "image width/height"
-msgstr "影像寬度和高度"
+msgstr "影像寬度與高度"
 
 #: ../src/libs/print_settings.c:2387
 msgid " x "
@@ -21730,7 +22965,7 @@ msgstr " x "
 
 #: ../src/libs/print_settings.c:2395
 msgid "scale factor"
-msgstr "縮放因子"
+msgstr "縮放係數"
 
 #: ../src/libs/print_settings.c:2400
 msgid ""
@@ -21739,50 +22974,50 @@ msgid ""
 " > 1 means that the image is upscaled\n"
 " a too large value may result in poor print quality"
 msgstr ""
-"基於印表機原生 DPI 的影像縮放比例:\n"
-" < 1 意味着影像被縮小(品質最好)\n"
-" > 1 意味着影像被放大\n"
-"太大的值可能導致較差的列印品質"
+"相對於印表機原生 DPI 的影像縮放係數：\n"
+"< 1 表示被縮小（品質較佳）\n"
+"> 1 表示影像被放大\n"
+"太大的值可能導致列印品質不佳"
 
 #. d->b_top  = gtk_spin_button_new_with_range(0, 10000, 1);
 #: ../src/libs/print_settings.c:2414
 msgid "top margin"
-msgstr "上邊距"
+msgstr "上邊界"
 
 #. d->b_left  = gtk_spin_button_new_with_range(0, 10000, 1);
 #: ../src/libs/print_settings.c:2418
 msgid "left margin"
-msgstr "左邊距"
+msgstr "左邊界"
 
 #: ../src/libs/print_settings.c:2421
 msgid "lock"
-msgstr "鎖"
+msgstr "鎖定"
 
 #: ../src/libs/print_settings.c:2422
 msgid "change all margins uniformly"
-msgstr "同時更改所有頁邊距"
+msgstr "同時更改全部邊界"
 
 #. d->b_right  = gtk_spin_button_new_with_range(0, 10000, 1);
 #: ../src/libs/print_settings.c:2426
 msgid "right margin"
-msgstr "右邊距"
+msgstr "右邊界"
 
 #. d->b_bottom  = gtk_spin_button_new_with_range(0, 10000, 1);
 #: ../src/libs/print_settings.c:2430
 msgid "bottom margin"
-msgstr "下邊距"
+msgstr "下邊界"
 
 #: ../src/libs/print_settings.c:2463
 msgid "display grid"
-msgstr "顯示網格"
+msgstr "顯示格線"
 
 #: ../src/libs/print_settings.c:2473
 msgid "snap to grid"
-msgstr "對齊到網格"
+msgstr "對齊格線"
 
 #: ../src/libs/print_settings.c:2483
 msgid "borderless mode required"
-msgstr "需要無邊框模式"
+msgstr "需要滿版列印模式"
 
 #: ../src/libs/print_settings.c:2486
 msgid ""
@@ -21790,13 +23025,13 @@ msgid ""
 "in the printer driver because the selected margins are\n"
 "below the printer hardware margins"
 msgstr ""
-"顯示印表機驅動程式內須啓用無邊框模式\n"
-"因爲選擇的邊距要小於印表機的硬體邊距"
+"因為設定的邊界尺寸小於印表機的限制\n"
+"必須啟動印表機驅動程式中的滿版列印或無邊界列印功能"
 
 #. pack image dimension hbox here
 #: ../src/libs/print_settings.c:2493
 msgid "image layout"
-msgstr "影像佈局"
+msgstr "影像布局"
 
 #: ../src/libs/print_settings.c:2531
 msgid "new image area"
@@ -21808,9 +23043,8 @@ msgid ""
 "click and drag on the page to place the area\n"
 "drag&drop image from film strip on it"
 msgstr ""
-"在頁面上增加一個新的影像區域\n"
-"在頁面上點擊並拖拉以放置該區域\n"
-"從軟片條上拖放影像到該區域"
+"在頁面上點擊並拖曳以設定區域\n"
+"再拖曳影像至影像區域上"
 
 #: ../src/libs/print_settings.c:2536
 msgid "delete image area"
@@ -21822,69 +23056,69 @@ msgstr "刪除目前選取的影像區域"
 
 #: ../src/libs/print_settings.c:2540
 msgid "clear layout"
-msgstr "清除佈局"
+msgstr "清除影像布局"
 
 #: ../src/libs/print_settings.c:2541
 msgid "remove all image areas from the page"
-msgstr "刪除頁面上的所有影像區域"
+msgstr "移除頁面上所有的影像區域"
 
 #. d->b_x = gtk_spin_button_new_with_range(0, 1000, 1);
 #: ../src/libs/print_settings.c:2556
 msgid "image area x origin (in current unit)"
-msgstr "影像區域 x 原點(以目前單位)"
+msgstr "影像左側起點（以目前的單位表示）"
 
 #. d->b_y = gtk_spin_button_new_with_range(0, 1000, 1);
 #: ../src/libs/print_settings.c:2560
 msgid "image area y origin (in current unit)"
-msgstr "影像區域 y 原點(以目前單位)"
+msgstr "影像上方起點（以目前的單位表示）"
 
 #. d->b_width = gtk_spin_button_new_with_range(0, 1000, 1);
 #: ../src/libs/print_settings.c:2571
 msgid "image area width (in current unit)"
-msgstr "影像區域寬度(以目前單位)"
+msgstr "影像寬度（以目前的單位表示）"
 
 #. d->b_height = gtk_spin_button_new_with_range(0, 1000, 1);
 #: ../src/libs/print_settings.c:2575
 msgid "image area height (in current unit)"
-msgstr "影像區域高度(以目前單位)"
+msgstr "影像高度（以目前的單位表示）"
 
 #: ../src/libs/print_settings.c:2688
 msgid "temporary style to use while printing"
-msgstr "列印時的臨時樣式"
+msgstr "列印時暫時套用的風格檔"
 
 #: ../src/libs/print_settings.c:2726
 msgid "print with current settings"
-msgstr "以目前設定列印"
+msgstr "以目前的設定列印"
 
 #: ../src/libs/select.c:134
 msgid "select all images in current collection"
-msgstr "選擇目前集合中的所有圖片"
+msgstr "選取目前相冊中的所有影像"
 
 #: ../src/libs/select.c:138
 msgid "clear selection"
-msgstr "清除選取"
+msgstr "取消選取"
 
 #: ../src/libs/select.c:142
 msgid ""
 "select unselected images\n"
 "in current collection"
-msgstr "選擇目前集合中未選定的圖片"
+msgstr "選取目前相冊中未選取的影像"
 
 #: ../src/libs/select.c:146
 msgid ""
 "select all images which are in the same\n"
 "film roll as the selected images"
-msgstr "選擇與所選圖片同一軟片捲中的所有圖片"
+msgstr "選取和目前已選取影像在同卷底片中的所有影像"
 
 #: ../src/libs/select.c:150
 msgid ""
 "select untouched images in\n"
 "current collection"
-msgstr "選擇目前集合中未編修的圖片"
+msgstr "選取目前的相冊中未編修過的影像"
 
 #: ../src/libs/session.c:47
 msgid "session"
-msgstr "期間"
+msgstr "工作階段"
 
 #: ../src/libs/session.c:99
 msgid "jobcode"
@@ -21906,128 +23140,135 @@ msgstr "S"
 #. create take snapshot button
 #: ../src/libs/snapshots.c:369
 msgid "take snapshot"
-msgstr "快照"
+msgstr "建立快照"
 
 #: ../src/libs/snapshots.c:370
 msgid ""
 "take snapshot to compare with another image or the same image at another "
 "stage of development"
-msgstr "取快照以與另一個影像或編修階段的相同影像比較"
+msgstr ""
+"建立一個目前編輯狀態的快照，以便與其他不同的編輯階段進行比較\n"
+"點擊已建立的快照可與當下狀態並排比較，預設左方為快照，右側為當下狀態\n"
+"可以使用滑鼠拖移改變分割線的位置，滑鼠停在分割線上時會出現旋轉圖示，點擊圖示"
+"可切換水平或垂直分割\n"
+"每次點擊都會把位置逆時針旋轉 90 度，以便選擇快照要顯示在左、下、右、上方"
 
 #: ../src/libs/snapshots.c:411
 msgid "toggle last snapshot"
-msgstr "切換上次快照"
+msgstr "切換到上一個快照"
 
 #: ../src/libs/styles.c:302
 #, c-format
 msgid "do you really want to remove %d style?"
 msgid_plural "do you really want to remove %d styles?"
-msgstr[0] "確定要刪除 %d 個樣式？"
+msgstr[0] "確定要刪除 %d 個風格檔？"
 
 #: ../src/libs/styles.c:308
 msgid "remove style?"
 msgid_plural "remove styles?"
-msgstr[0] "刪除樣式？"
+msgstr[0] "是否要刪除風格檔？"
 
 #: ../src/libs/styles.c:429 ../src/libs/styles.c:612
 #, c-format
 msgid ""
 "style `%s' already exists.\n"
 "do you want to overwrite existing style?\n"
-msgstr "樣式“%s”已存在。確定要覆蓋？\n"
+msgstr ""
+"風格檔「%s」已存在\n"
+"是否要取代現有風格檔？\n"
 
 #: ../src/libs/styles.c:431 ../src/libs/styles.c:614
 msgid "apply this option to all existing styles"
-msgstr "將此選項套用到所有現存樣式"
+msgstr "套用此選項到所有的風格檔"
 
 #: ../src/libs/styles.c:494
 #, c-format
 msgid "style %s was successfully exported"
-msgstr "樣式 %s 輸出成功"
+msgstr "風格檔「%s」已成功匯出"
 
 #: ../src/libs/styles.c:511
 msgid "select style"
-msgstr "選擇風格"
+msgstr "選擇風格檔"
 
 #: ../src/libs/styles.c:521
 msgid "darktable style files"
-msgstr "darktable 樣式檔案"
+msgstr "darktable 風格檔"
 
 #: ../src/libs/styles.c:798
 msgid ""
 "available styles,\n"
 "doubleclick to apply"
 msgstr ""
-"可用樣式，\n"
-"雙擊套用"
+"可用的風格檔清單\n"
+"雙擊直接套用"
 
 #: ../src/libs/styles.c:805 ../src/libs/styles.c:806
 msgid "filter style names"
-msgstr "濾鏡樣式名稱"
+msgstr "搜尋風格檔"
 
 #: ../src/libs/styles.c:817
 msgid "create duplicate"
-msgstr "建立複製品"
+msgstr "建立複本"
 
 #: ../src/libs/styles.c:823
 msgid "creates a duplicate of the image before applying style"
-msgstr "在套用樣式前先複製圖片"
+msgstr "套用風格檔前先建立一個影像複本"
 
 #. create
 #: ../src/libs/styles.c:841
 msgid "create..."
-msgstr "建立…"
+msgstr "建立"
 
 #: ../src/libs/styles.c:841
 msgid "create styles from history stack of selected images"
-msgstr "從選取的圖片歷史紀錄中建立新風格"
+msgstr "從選取影像的編輯紀錄建立風格檔"
 
 #. edit
 #: ../src/libs/styles.c:845 ../src/libs/tagging.c:2248
 msgid "edit..."
-msgstr "編輯…"
+msgstr "編輯"
 
 #: ../src/libs/styles.c:845
 msgid "edit the selected styles in list above"
-msgstr "編輯上面列表中的選定樣式"
+msgstr "編輯選取的風格檔"
 
 #: ../src/libs/styles.c:849
 msgid "removes the selected styles in list above"
-msgstr "刪除上面列表中的選定樣式"
+msgstr "移除選取的風格檔"
 
 #: ../src/libs/styles.c:853
 msgid "import styles from a style files"
-msgstr "從樣式檔案輸入樣式"
+msgstr "從檔案匯入風格檔"
 
 #: ../src/libs/styles.c:857
 msgid "export the selected styles into a style files"
-msgstr "輸出樣式到一個樣式檔案"
+msgstr "將風格檔匯出成檔案"
 
 #: ../src/libs/styles.c:861
 msgid "apply the selected styles in list above to selected images"
-msgstr "將上面列表中選定的樣式套用於選定的影像"
+msgstr "將所選的風格檔套用到選取的影像中"
 
 #: ../src/libs/tagging.c:103
 msgid "tagging"
-msgstr "標記"
+msgstr "標籤管理"
 
 #: ../src/libs/tagging.c:1251
 msgid "attach tag to all"
-msgstr "給所有圖片附加標籤"
+msgstr "把標籤貼到全部影像"
 
 #: ../src/libs/tagging.c:1259 ../src/libs/tagging.c:2221
 msgid "detach tag"
-msgstr "分離標籤"
+msgstr "撕除標籤"
 
 #: ../src/libs/tagging.c:1479
 msgid "delete tag?"
-msgstr "刪除標籤？"
+msgstr "是否要刪除標籤？"
 
 #: ../src/libs/tagging.c:1486 ../src/libs/tagging.c:1574
 #: ../src/libs/tagging.c:1785 ../src/libs/tagging.c:2059
 #, c-format
 msgid "selected: %s"
-msgstr "已選擇:%s"
+msgstr "已選取：「%s」"
 
 #: ../src/libs/tagging.c:1493
 #, c-format
@@ -22038,35 +23279,36 @@ msgid_plural ""
 "do you really want to delete the tag `%s'?\n"
 "%d images are assigned this tag!"
 msgstr[0] ""
-"確定要刪除標籤`%s'？\n"
-"%d 張圖片賦予此標籤！"
+"是否要刪除標籤「%s」？\n"
+"\n"
+"有 %d 張影像使用了此標籤"
 
 #: ../src/libs/tagging.c:1527
 #, c-format
 msgid "tag %s removed"
-msgstr "標籤 %s 已刪除"
+msgstr "標籤「%s」已刪除"
 
 #: ../src/libs/tagging.c:1567
 msgid "delete node?"
-msgstr "刪除節點？"
+msgstr "是否要刪除整個結構？"
 
 #: ../src/libs/tagging.c:1581
 #, c-format
 msgid "<u>%d</u> tag will be deleted"
 msgid_plural "<u>%d</u> tags will be deleted"
-msgstr[0] "將移除 <u>%d</u> 個標籤"
+msgstr[0] "%d 個標籤將被刪除"
 
 #: ../src/libs/tagging.c:1586 ../src/libs/tagging.c:1797
 #: ../src/libs/tagging.c:2071
 #, c-format
 msgid "<u>%d</u> image will be updated"
 msgid_plural "<u>%d</u> images will be updated"
-msgstr[0] "將更新 <u>%d</u> 張影像"
+msgstr[0] "%d 張影像將被更新"
 
 #: ../src/libs/tagging.c:1612
 #, c-format
 msgid "%d tags removed"
-msgstr "已移除%d 個標籤"
+msgstr "%d 個標籤已移除"
 
 #: ../src/libs/tagging.c:1648
 msgid "create tag"
@@ -22074,12 +23316,12 @@ msgstr "建立標籤"
 
 #: ../src/libs/tagging.c:1658 ../src/libs/tagging.c:1805
 msgid "name: "
-msgstr "名稱: "
+msgstr "名稱："
 
 #: ../src/libs/tagging.c:1670
 #, c-format
 msgid "add to: \"%s\" "
-msgstr "增加到:“%s” "
+msgstr "加到：「%s」"
 
 #: ../src/libs/tagging.c:1676 ../src/libs/tagging.c:1820
 msgid "category"
@@ -22087,61 +23329,61 @@ msgstr "類別"
 
 #: ../src/libs/tagging.c:1685 ../src/libs/tagging.c:1829
 msgid "synonyms: "
-msgstr "同義詞: "
+msgstr "同義詞："
 
 #: ../src/libs/tagging.c:1702 ../src/libs/tagging.c:1851
 #: ../src/libs/tagging.c:2093
 msgid "empty tag is not allowed, aborting"
-msgstr "不能增加空標籤，操作已取消"
+msgstr "不允許使用空白標籤，操作取消"
 
 #: ../src/libs/tagging.c:1713
 msgid "tag name already exists. aborting."
-msgstr "標籤名已經存在，操作已取消。"
+msgstr "標籤名稱已存在，操作取消"
 
 #: ../src/libs/tagging.c:1792 ../src/libs/tagging.c:2066
 #, c-format
 msgid "<u>%d</u> tag will be updated"
 msgid_plural "<u>%d</u> tags will be updated"
-msgstr[0] "將更新 <u>%d</u> 個標籤"
+msgstr[0] "將更新 %d 個標籤"
 
 #: ../src/libs/tagging.c:1853
 msgid ""
 "'|' character is not allowed for renaming tag.\n"
 "to modify the hierarchy use rename path instead. Aborting."
 msgstr ""
-"“|”字元不可用於重新命名標籤。\n"
-"使用路徑重新命名以更改標籤階層關係。操作取消。"
+"「|」字元不允許用於重命名標籤，操作取消\n"
+"若要修改樹狀結構，請改用「更改結構」"
 
 #: ../src/libs/tagging.c:1892
 #, c-format
 msgid "at least one new tag name (%s) already exists, aborting"
-msgstr "至少有一個新增的標籤名(%s)已經存在，操作已取消"
+msgstr "至少有一個標籤名稱「%s」已存在，操作取消"
 
 #: ../src/libs/tagging.c:2000
 #, c-format
 msgid "at least one new tagname (%s) already exists, aborting."
-msgstr "至少有一個新增的標籤名(%s)已經存在，操作已取消。"
+msgstr "至少有一個標籤名稱「%s」已存在，操作取消"
 
 #: ../src/libs/tagging.c:2052
 msgid "change path"
-msgstr "更改路徑"
+msgstr "變更路徑"
 
 #: ../src/libs/tagging.c:2095
 msgid "'|' misplaced, empty tag is not allowed, aborting"
-msgstr "“|”位置錯誤，不能增加空標籤，操作取消"
+msgstr "「|」位置錯誤，不能使用空白標籤，操作取消"
 
 #: ../src/libs/tagging.c:2191
 #, c-format
 msgid "tag %s created"
-msgstr "標籤 %s 已建立"
+msgstr "標籤「%s」已建立"
 
 #: ../src/libs/tagging.c:2217
 msgid "attach tag"
-msgstr "附加標籤"
+msgstr "貼上標籤"
 
 #: ../src/libs/tagging.c:2230
 msgid "create tag..."
-msgstr "建立標籤..."
+msgstr "建立標籤"
 
 #: ../src/libs/tagging.c:2236
 msgid "delete tag"
@@ -22149,66 +23391,66 @@ msgstr "刪除標籤"
 
 #: ../src/libs/tagging.c:2243
 msgid "delete node"
-msgstr "刪除節點"
+msgstr "刪除結構"
 
 #: ../src/libs/tagging.c:2256
 msgid "change path..."
-msgstr "更改路徑..."
+msgstr "更改結構"
 
 #: ../src/libs/tagging.c:2266
 msgid "set as a tag"
-msgstr "設定爲標籤"
+msgstr "設為標籤"
 
 #: ../src/libs/tagging.c:2277
 msgid "copy to entry"
-msgstr "複製到輸入"
+msgstr "複製到輸入欄位"
 
 #: ../src/libs/tagging.c:2294
 msgid "go to tag collection"
-msgstr "回到標籤集"
+msgstr "含有此標籤的相冊"
 
 #: ../src/libs/tagging.c:2300
 msgid "go back to work"
-msgstr "回到工作流"
+msgstr "回到原本的相冊"
 
 #: ../src/libs/tagging.c:2457
 #, c-format
 msgid "%s"
-msgstr "%s"
+msgstr "「%s」"
 
 #: ../src/libs/tagging.c:2458
 msgid "(private)"
-msgstr "(私有)"
+msgstr "（私人）"
 
 #: ../src/libs/tagging.c:2484
 msgid "select a keyword file"
-msgstr "選擇關鍵字檔案"
+msgstr "選擇關鍵字標籤檔案"
 
 #: ../src/libs/tagging.c:2497
 msgid "error importing tags"
-msgstr "輸入標籤錯誤"
+msgstr "匯入標籤時發生錯誤"
 
 #: ../src/libs/tagging.c:2499
 #, c-format
 msgid "%zd tags imported"
-msgstr "已輸入 %zd 個標籤"
+msgstr "已匯入 %zd 個標籤"
 
 #: ../src/libs/tagging.c:2520
 msgid "select file to export to"
-msgstr "選擇輸出檔案"
+msgstr "匯出關鍵字檔案到"
 
 #: ../src/libs/tagging.c:2534
 msgid "error exporting tags"
-msgstr "輸出標籤錯誤"
+msgstr "匯出標籤時發生錯誤"
 
 #: ../src/libs/tagging.c:2536
 #, c-format
 msgid "%zd tags exported"
-msgstr "已輸出 %zd 個標籤"
+msgstr "已匯出 %zd 個標籤"
 
 #: ../src/libs/tagging.c:2960
 msgid "drop to root"
-msgstr "下降到根節點"
+msgstr "拖放到根目錄"
 
 #: ../src/libs/tagging.c:3097
 msgid ""
@@ -22218,31 +23460,31 @@ msgid ""
 "press Tab to give the focus to entry,\n"
 "ctrl-wheel scroll to resize the window"
 msgstr ""
-"附加標籤\n"
-"按Delete或雙即已移除\n"
-"右擊在附加標籤上執行其他功能\n"
-"按Tab 以輸入\n"
-"控制鍵-滾輪 滾動以調整大小視窗"
+"已貼上的標籤\n"
+"按「去除」按紐或雙擊滑鼠左鍵撕除標籤\n"
+"點擊滑鼠右鍵查看其他動作\n"
+"按 tab 移至輸入欄位\n"
+"ctrl + 滑鼠滾輪可調整視窗大小"
 
 #: ../src/libs/tagging.c:3109
 msgid "attach"
-msgstr "附加"
+msgstr "貼上"
 
 #: ../src/libs/tagging.c:3110
 msgid "attach tag to all selected images"
-msgstr "給所有選取的圖片加上標籤"
+msgstr "把標籤附加到選取的影像上"
 
 #: ../src/libs/tagging.c:3113
 msgid "detach"
-msgstr "分離"
+msgstr "撕除"
 
 #: ../src/libs/tagging.c:3114
 msgid "detach tag from all selected images"
-msgstr "從所有選取的圖片去除標籤"
+msgstr "從選取的影像上去除標籤"
 
 #: ../src/libs/tagging.c:3127
 msgid "toggle list with / without hierarchy"
-msgstr "切換有/無階層結構列表"
+msgstr "切換是否顯示樹狀結構層次"
 
 #: ../src/libs/tagging.c:3127
 msgid "hide"
@@ -22250,7 +23492,7 @@ msgstr "隱藏"
 
 #: ../src/libs/tagging.c:3129
 msgid "toggle sort by name or by count"
-msgstr "切換按名稱或按數量排序"
+msgstr "切換標籤排列方式依標籤名稱或數量"
 
 #: ../src/libs/tagging.c:3129
 msgid "sort"
@@ -22258,11 +23500,11 @@ msgstr "排序方式"
 
 #: ../src/libs/tagging.c:3131
 msgid "toggle show or not darktable tags"
-msgstr "切換是否顯示 darktable 標籤"
+msgstr "切換顯示 darktable 標籤與否"
 
 #: ../src/libs/tagging.c:3131
 msgid "dttags"
-msgstr "dt標籤"
+msgstr "darktable 標籤"
 
 #: ../src/libs/tagging.c:3147
 msgid ""
@@ -22272,13 +23514,13 @@ msgid ""
 "press shift+Tab to select the first attached user tag"
 msgstr ""
 "輸入標籤名稱\n"
-"按Enter以建立新標籤及附加在選取影像上\n"
-"按Tab 或 Down鍵以得到第一個匹配到的標籤\n"
-"按shift+Tab 以選取第一個附加的使用者標籤"
+"按 enter 建立一個新標籤並附加到選取的影像上\n"
+"按 tab 搜尋符合的標籤\n"
+"按 shift + tab 選擇第一個貼上的使用者標籤"
 
 #: ../src/libs/tagging.c:3158 ../src/libs/tagging.c:3164
 msgid "clear entry"
-msgstr "清除輸入資料"
+msgstr "清除輸入欄位"
 
 #: ../src/libs/tagging.c:3211
 msgid ""
@@ -22290,41 +23532,39 @@ msgid ""
 "press shift+Tab to give the focus to entry,\n"
 "ctrl-scroll to resize the window"
 msgstr ""
-"標籤詞典\n"
-"按Enter或雙擊以將選取標籤附加在選取影像上\n"
-"同樣的 shift+Enter聚焦條目上 \n"
-"shift+點擊以全部展開選取標籤\n"
-"右擊 在選取的標籤上執行其他功能\n"
-"按shift+Tab 以聚焦條目\n"
-"控制鍵-滾輪以改變視窗大小"
+"標籤目錄\n"
+"按 enter 或點兩下把標籤貼上選取的影像\n"
+"shift + 左鍵展開標籤的所有樹狀結構\n"
+"點擊滑鼠右鍵查看其他動作\n"
+"shift + tab 移至輸入欄位\n"
+"shift + enter 貼上標籤之外同時移至輸入欄位\n"
+"ctrl + 滑鼠滾輪可調整視窗大小"
 
 #: ../src/libs/tagging.c:3247
 msgid ""
 "create a new tag with the\n"
 "name you entered"
-msgstr ""
-"輸入名稱以建立\n"
-"一個新標籤"
+msgstr "使用輸入的名稱建立新的標籤，並貼至選取的影像上"
 
 #: ../src/libs/tagging.c:3250
 msgid "import tags from a Lightroom keyword file"
-msgstr "從 Lighttoom 關鍵字檔案輸入標籤"
+msgstr "從 Lightroom 關鍵字檔案裡匯入標籤"
 
 #: ../src/libs/tagging.c:3253
 msgid "export all tags to a Lightroom keyword file"
-msgstr "將所有標籤輸出到Lightroom關鍵字檔案"
+msgstr "將所有標籤匯出到 Lightroom 關鍵字檔案"
 
 #: ../src/libs/tagging.c:3257
 msgid "toggle list / tree view"
-msgstr "切換列表/樹視角"
+msgstr "切換清單或樹狀結構顯示"
 
 #: ../src/libs/tagging.c:3257
 msgid "tree"
-msgstr "樹狀"
+msgstr "樹狀結構"
 
 #: ../src/libs/tagging.c:3259
 msgid "toggle list with / without suggestion"
-msgstr "切換有/無建議列表"
+msgstr "切換顯示建議標籤與全部標籤"
 
 #: ../src/libs/tagging.c:3259
 msgid "suggestion"
@@ -22332,38 +23572,38 @@ msgstr "建議"
 
 #: ../src/libs/tagging.c:3282
 msgid "redo last tag"
-msgstr "重做上一個標籤"
+msgstr "重做前一個標籤"
 
 #: ../src/libs/tagging.c:3366
 msgid ""
 "tag shortcut is not active with tag tree view. please switch to list view"
-msgstr "標記快捷不可鍵標籤樹狀視角內使用。如要，請切換至列表視角"
+msgstr "標籤快速鍵在不能在標籤樹狀圖中使用，請切換到清單檢視"
 
 #: ../src/libs/tagging.c:3470
 msgid "tagging settings"
-msgstr "標記選定"
+msgstr "標籤設定"
 
 #: ../src/libs/tools/battery_indicator.c:38
 #: ../src/libs/tools/battery_indicator.c:71
 msgid "battery indicator"
-msgstr "電池電量指示"
+msgstr "電池電量"
 
 #: ../src/libs/tools/colorlabels.c:42
 msgid "colorlabels"
-msgstr "色彩標識"
+msgstr "色彩標籤"
 
 #: ../src/libs/tools/colorlabels.c:88
 msgid "toggle color label of selected images"
-msgstr "切換所選影像的顏色標籤"
+msgstr "切換選取影像的色彩標籤"
 
 #: ../src/libs/tools/darktable.c:285
 #, c-format
 msgid "copyright (c) the authors 2009-%s"
-msgstr "版權所有 (c) 作者 2009-%s"
+msgstr "版權所有 © 作者 2009 - %s"
 
 #: ../src/libs/tools/darktable.c:289
 msgid "organize and develop images from digital cameras"
-msgstr "組織並編修數位相機的圖片"
+msgstr "整理和編輯數位相機的影像"
 
 #: ../src/libs/tools/darktable.c:301
 msgid "all those of you that made previous releases possible"
@@ -22371,103 +23611,104 @@ msgstr "所有過去版本的貢獻者"
 
 #: ../src/libs/tools/darktable.c:306
 msgid "and..."
-msgstr "及..."
+msgstr "以及…"
 
 #: ../src/libs/tools/darktable.c:308
 msgid "translator-credits"
-msgstr "翻譯貢獻者"
+msgstr ""
+"<a href=\"https://www.facebook.com/HSUfineprint/\">言午印藝</a> - 許剛維"
 
 #: ../src/libs/tools/filmstrip.c:45
 msgid "filmstrip"
-msgstr "條狀底片"
+msgstr "幻燈片"
 
 #: ../src/libs/tools/filter.c:41
 msgid "filter"
-msgstr "過濾器"
+msgstr "篩選"
 
 #: ../src/libs/tools/gamepad.c:37
 msgid "gamepad"
-msgstr "遊戲鍵盤"
+msgstr "遊戲把手"
 
 #: ../src/libs/tools/gamepad.c:71
 msgid "button a"
-msgstr "按鈕a"
+msgstr "按鈕「A」"
 
 #: ../src/libs/tools/gamepad.c:71
 msgid "button b"
-msgstr "按鈕b"
+msgstr "按鈕「B」"
 
 #: ../src/libs/tools/gamepad.c:71
 msgid "button x"
-msgstr "按鈕x"
+msgstr "按鈕「X」"
 
 #: ../src/libs/tools/gamepad.c:71
 msgid "button y"
-msgstr "按鈕y"
+msgstr "按鈕「Y」"
 
 #: ../src/libs/tools/gamepad.c:72
 msgid "button back"
-msgstr "按鈕返回"
+msgstr "按鈕「back」"
 
 #: ../src/libs/tools/gamepad.c:72
 msgid "button guide"
-msgstr "按鈕指引"
+msgstr "按鈕「guide」"
 
 #: ../src/libs/tools/gamepad.c:72
 msgid "button start"
-msgstr "按鈕開始"
+msgstr "按鈕「start」"
 
 #: ../src/libs/tools/gamepad.c:73
 msgid "left stick"
-msgstr "左摇杆"
+msgstr "左搖桿"
 
 #: ../src/libs/tools/gamepad.c:73
 msgid "right stick"
-msgstr "右摇杆"
+msgstr "右搖桿"
 
 #: ../src/libs/tools/gamepad.c:73
 msgid "left shoulder"
-msgstr "左肩"
+msgstr "左肩按鈕「LB/L1」"
 
 #: ../src/libs/tools/gamepad.c:73
 msgid "right shoulder"
-msgstr "右肩"
+msgstr "右肩按鈕「RB/R1」"
 
 #: ../src/libs/tools/gamepad.c:74
 msgid "dpad up"
-msgstr "向上移動"
+msgstr "十字鍵「上」"
 
 #: ../src/libs/tools/gamepad.c:74
 msgid "dpad down"
-msgstr "向下移動"
+msgstr "十字鍵「下」"
 
 #: ../src/libs/tools/gamepad.c:74
 msgid "dpad left"
-msgstr "向左移動"
+msgstr "十字鍵「左」"
 
 #: ../src/libs/tools/gamepad.c:74
 msgid "dpad right"
-msgstr "向右移動"
+msgstr "十字鍵「右」"
 
 #: ../src/libs/tools/gamepad.c:75
 msgid "button misc1"
-msgstr "按鈕misc1"
+msgstr "按鈕「misc1」"
 
 #: ../src/libs/tools/gamepad.c:75
 msgid "paddle1"
-msgstr "槳1"
+msgstr "撥片一"
 
 #: ../src/libs/tools/gamepad.c:75
 msgid "paddle2"
-msgstr "槳2"
+msgstr "撥片二"
 
 #: ../src/libs/tools/gamepad.c:75
 msgid "paddle3"
-msgstr "槳3"
+msgstr "撥片三"
 
 #: ../src/libs/tools/gamepad.c:75
 msgid "paddle4"
-msgstr "槳4"
+msgstr "撥片四"
 
 #: ../src/libs/tools/gamepad.c:75
 msgid "touchpad"
@@ -22475,57 +23716,57 @@ msgstr "觸控板"
 
 #: ../src/libs/tools/gamepad.c:76
 msgid "left trigger"
-msgstr "左觸發器"
+msgstr "左板機「LT/L2」"
 
 #: ../src/libs/tools/gamepad.c:76
 msgid "right trigger"
-msgstr "右觸發器"
+msgstr "右板機「RT/R2」"
 
 #: ../src/libs/tools/gamepad.c:81
 msgid "invalid gamepad button"
-msgstr "無效遊戲鍵盤按鈕"
+msgstr "無效的控制器按鈕"
 
 #: ../src/libs/tools/gamepad.c:98
 msgid "left x"
-msgstr "左x"
+msgstr "左搖桿 X"
 
 #: ../src/libs/tools/gamepad.c:98
 msgid "left y"
-msgstr "左y"
+msgstr "左搖桿 Y"
 
 #: ../src/libs/tools/gamepad.c:98
 msgid "right x"
-msgstr "右x"
+msgstr "右搖桿 X"
 
 #: ../src/libs/tools/gamepad.c:98
 msgid "right y"
-msgstr "右y"
+msgstr "右搖桿 Y"
 
 #: ../src/libs/tools/gamepad.c:99
 msgid "left diagonal"
-msgstr "左對角線"
+msgstr "左搖桿斜角"
 
 #: ../src/libs/tools/gamepad.c:99
 msgid "left skew"
-msgstr "左偏斜"
+msgstr "左搖桿偏斜"
 
 #: ../src/libs/tools/gamepad.c:99
 msgid "right diagonal"
-msgstr "右對角線"
+msgstr "右搖桿斜角"
 
 #: ../src/libs/tools/gamepad.c:99
 msgid "right skew"
-msgstr "右偏斜"
+msgstr "右搖桿偏斜"
 
 #. diagonals
 #: ../src/libs/tools/gamepad.c:104
 msgid "invalid gamepad axis"
-msgstr "無效遊戲鍵盤軸"
+msgstr "無效的控制器搖桿"
 
 #. we write the label with the size category
 #: ../src/libs/tools/global_toolbox.c:217
 msgid "thumbnails overlays for size"
-msgstr "縮圖疊加層大小"
+msgstr "額外文字訊息的大小"
 
 #: ../src/libs/tools/global_toolbox.c:251
 #: ../src/libs/tools/global_toolbox.c:314
@@ -22534,103 +23775,105 @@ msgid ""
 "image\n"
 "set -1 to never hide the overlay"
 msgstr ""
-"滑鼠在影像上每次移動後，塊狀覆蓋物被隱藏前的時間。\n"
-"設定爲 -1 時，從不隱藏覆蓋層"
+"滑鼠停留在影像上後隱藏懸浮資訊的時間\n"
+"設定為「-1」則永不隱藏"
 
 #: ../src/libs/tools/global_toolbox.c:256
 #: ../src/libs/tools/global_toolbox.c:319
 msgid "timeout only available for block overlay"
-msgstr "逾時僅適用於區塊覆蓋"
+msgstr "時間設定僅適用於懸浮資訊欄"
 
 #: ../src/libs/tools/global_toolbox.c:279
 #: ../src/libs/tools/global_toolbox.c:465
 msgid "culling overlays"
-msgstr "刪減視角疊加層"
+msgstr "選擇透明套疊資訊"
 
 #: ../src/libs/tools/global_toolbox.c:281
 msgid "preview overlays"
-msgstr "預覽覆蓋層"
+msgstr "預覽套疊資訊"
 
 #: ../src/libs/tools/global_toolbox.c:355
 msgid "overlays not available here..."
-msgstr "疊加層在此不可用……"
+msgstr "套疊資訊無法用在此處"
 
 #: ../src/libs/tools/global_toolbox.c:399
 #: ../src/libs/tools/global_toolbox.c:535
 msgid "expand grouped images"
-msgstr "展開分組的影像"
+msgstr "展開群組影像"
 
 #: ../src/libs/tools/global_toolbox.c:401
 #: ../src/libs/tools/global_toolbox.c:537
 msgid "collapse grouped images"
-msgstr "摺疊分組影像"
+msgstr "收合群組影像"
 
 #: ../src/libs/tools/global_toolbox.c:408
 msgid "thumbnail overlays options"
-msgstr "縮圖疊加層選項"
+msgstr "縮圖資訊選項"
 
 #: ../src/libs/tools/global_toolbox.c:409
 msgid "click to change the type of overlays shown on thumbnails"
-msgstr "單擊以更改在縮圖上顯示的覆蓋層類型"
+msgstr "設定縮圖上套疊顯示的資訊"
 
 #: ../src/libs/tools/global_toolbox.c:432
 #: ../src/libs/tools/global_toolbox.c:461
 msgid "overlay mode for size"
-msgstr "疊加層模式的大小"
+msgstr "尺寸的套疊模式"
 
 #: ../src/libs/tools/global_toolbox.c:436
 msgid "thumbnail overlays"
-msgstr "縮圖疊加層"
+msgstr "縮圖套疊資訊"
 
 #: ../src/libs/tools/global_toolbox.c:438
 #: ../src/libs/tools/global_toolbox.c:467
 msgid "no overlays"
-msgstr "無疊加層"
+msgstr "不顯示任何額外資訊"
 
 #: ../src/libs/tools/global_toolbox.c:439
 msgid "overlays on mouse hover"
-msgstr "滑鼠懸停時顯示疊加層"
+msgstr "滑鼠經過時顯示基本資訊"
 
 #: ../src/libs/tools/global_toolbox.c:440
 msgid "extended overlays on mouse hover"
-msgstr "滑鼠懸停時顯示(更多)疊加層"
+msgstr "滑鼠經過時顯示額外資訊"
 
 #: ../src/libs/tools/global_toolbox.c:441
 #: ../src/libs/tools/global_toolbox.c:468
 msgid "permanent overlays"
-msgstr "一直顯示疊加層"
+msgstr "常態顯示基本資訊"
 
 #: ../src/libs/tools/global_toolbox.c:442
 #: ../src/libs/tools/global_toolbox.c:469
 msgid "permanent extended overlays"
-msgstr "一直顯示擴充疊加層"
+msgstr "常態顯示額外資訊"
 
 #: ../src/libs/tools/global_toolbox.c:443
 msgid "permanent overlays extended on mouse hover"
-msgstr "滑鼠懸停時，一直顯示擴充疊加層"
+msgstr "常態顯示基本資訊，滑鼠經過時顯示額外資訊"
 
 #: ../src/libs/tools/global_toolbox.c:445
 #: ../src/libs/tools/global_toolbox.c:471
 msgid "overlays block on mouse hover"
-msgstr "滑鼠懸停時，疊加層區塊"
+msgstr "滑鼠經過顯示懸浮資訊欄"
 
 #: ../src/libs/tools/global_toolbox.c:446
 #: ../src/libs/tools/global_toolbox.c:472
 msgid "during (s)"
-msgstr "期間(s)"
+msgstr "持續時間（秒）"
 
 #: ../src/libs/tools/global_toolbox.c:451
 #: ../src/libs/tools/global_toolbox.c:477
 msgid "show tooltip"
-msgstr "顯示工具提示"
+msgstr "顯示懸浮資訊（可在偏好設定中自訂顯示內容）"
 
 #: ../src/libs/tools/global_toolbox.c:489
 msgid "help"
-msgstr "協助"
+msgstr "說明"
 
 #: ../src/libs/tools/global_toolbox.c:491
 msgid "enable this, then click on a control element to see its online help"
-msgstr "啓用此選項，然後單擊控件元素以查看線上文件"
+msgstr ""
+"快速說明\n"
+"開啟後點擊任何控制項目可直接連至相關的線上說明頁面"
 
 #: ../src/libs/tools/global_toolbox.c:498
 msgid ""
@@ -22643,41 +23886,39 @@ msgid ""
 "click on a widget, module or screen area to open the dialog for further "
 "configuration"
 msgstr ""
-"定義捷徑\n"
-"控制鍵+點擊 以關掉覆寫確認\n"
-"\n"
-"懸停於部件及以滑鼠點擊及滾動或移動組合輸入按鍵\n"
-"再次重複相同組合以移除映射\n"
-"點擊在部件、模組或螢幕區域為進一步設定打開對話框"
+"錄製快速鍵\n"
+"開啟後將滑鼠停在欲自訂的控制項目上，即可以按鍵自訂該功能的快速鍵\n"
+"再次重複相同的操作會刪除該快速鍵\n"
+"在任何控制項目上點擊滑鼠左鍵，會自動開啟該功能對應的完整快速鍵設定視窗"
 
 #: ../src/libs/tools/global_toolbox.c:514
 msgid "show global preferences"
-msgstr "顯示全域偏好"
+msgstr "顯示偏好設定"
 
 #: ../src/libs/tools/global_toolbox.c:646
 #, c-format
 msgid "do you want to access `%s'?"
-msgstr "確定要存取“%s”？"
+msgstr "是否要存取「%s」？"
 
 #: ../src/libs/tools/global_toolbox.c:651
 msgid "access the online usermanual?"
-msgstr "查看線上使用手冊？"
+msgstr "是否要查看線上使用手冊？"
 
 #: ../src/libs/tools/global_toolbox.c:723
 msgid "help url opened in web browser"
-msgstr "在網頁瀏覽器中打開的協助網址"
+msgstr "在網頁瀏覽器中開啟説明網址"
 
 #: ../src/libs/tools/global_toolbox.c:727
 msgid "error while opening help url in web browser"
-msgstr "錯誤 無法在瀏覽器中打開協助鏈接"
+msgstr "錯誤：無法在網頁瀏覽器開啟説明網址"
 
 #: ../src/libs/tools/global_toolbox.c:738
 msgid "there is no help available for this element"
-msgstr "此元素沒有可用的協助"
+msgstr "沒有可用的説明"
 
 #: ../src/libs/tools/hinter.c:42
 msgid "hinter"
-msgstr "意圖"
+msgstr "操作提示"
 
 #: ../src/libs/tools/image_infos.c:40
 msgid "image infos"
@@ -22685,81 +23926,81 @@ msgstr "影像資訊"
 
 #: ../src/libs/tools/lighttable.c:117
 msgid "click to exit from full preview layout."
-msgstr "單擊以退出全預覽佈局。"
+msgstr "點擊退出全螢幕預覽"
 
 #: ../src/libs/tools/lighttable.c:119
 msgid "click to enter full preview layout."
-msgstr "單擊以進入全預覽佈局。"
+msgstr "全螢幕預覽布局"
 
 #: ../src/libs/tools/lighttable.c:122
 msgid "click to enter culling layout in fixed mode."
-msgstr "單擊以進入固定模式的刪減佈局。"
+msgstr "並排比較布局（固定數量）"
 
 #: ../src/libs/tools/lighttable.c:124 ../src/libs/tools/lighttable.c:129
 msgid "click to exit culling layout."
-msgstr "單擊以退出刪減佈局。"
+msgstr "點擊並排比較布局"
 
 #: ../src/libs/tools/lighttable.c:127
 msgid "click to enter culling layout in dynamic mode."
-msgstr "單擊以進入動態模式的刪減佈局。"
+msgstr "並排比較布局（動態數量）"
 
 #: ../src/libs/tools/lighttable.c:352
 msgid "toggle filemanager layout"
-msgstr "切換檔案管理佈局"
+msgstr "切換檔案管理布局"
 
 #: ../src/libs/tools/lighttable.c:355
 msgid "click to enter filemanager layout."
-msgstr "單擊以進入檔案管理佈局。"
+msgstr "檔案管理布局"
 
 #: ../src/libs/tools/lighttable.c:361
 msgid "toggle zoomable lighttable layout"
-msgstr "切換縮放映繪台佈局"
+msgstr "切換縮放燈箱布局"
 
 #: ../src/libs/tools/lighttable.c:364
 msgid "click to enter zoomable lighttable layout."
-msgstr "單擊以進入縮放映繪台佈局。"
+msgstr "縮放燈箱布局"
 
 #: ../src/libs/tools/lighttable.c:370
 msgid "toggle culling mode"
-msgstr "開啓和關閉‘挑選’模式(固定縮放)"
+msgstr "切換並排比較布局"
 
 #: ../src/libs/tools/lighttable.c:378
 msgid "toggle culling dynamic mode"
-msgstr "開啓和關閉‘挑選’模式(動態縮放)"
+msgstr "切換動態並排比較布局"
 
 #: ../src/libs/tools/lighttable.c:386
 msgid "toggle sticky preview mode"
-msgstr "切換黏性的預覽模式"
+msgstr "切換大圖預覽布局"
 
 #: ../src/libs/tools/lighttable.c:427
 msgid "toggle culling zoom mode"
-msgstr "切換‘挑選’的縮放模式"
+msgstr "切換縮放並排比較布局"
 
 #: ../src/libs/tools/lighttable.c:429
 msgid "toggle sticky preview mode with focus detection"
-msgstr "切換焦點偵測的黏性預覽模式"
+msgstr "切換具有對焦檢測的大圖預覽布局"
 
 #: ../src/libs/tools/lighttable.c:431
 msgid "exit current layout"
-msgstr "退出目前佈局"
+msgstr "退出目前布局"
 
 #: ../src/libs/tools/midi.c:41
 msgid "midi"
-msgstr "電子樂器數位介面"
+msgstr "MIDI 控制器"
 
 #: ../src/libs/tools/midi.c:202
 msgid "using absolute encoding; reinitialise to switch to relative"
-msgstr "使用絕對編碼 重新起始為相對"
+msgstr "使用絕對編碼，重新初始化可切換回相對編碼"
 
 #: ../src/libs/tools/midi.c:206
 #, c-format
 msgid "%d more identical (down) moves before switching to relative encoding"
-msgstr "在切換成相對編碼前 有 %d 更多相同(下) 移動"
+msgstr "切換至相對編碼前再做 %d 次一樣的動作（down）"
 
 #: ../src/libs/tools/midi.c:209
 #, c-format
 msgid "switching encoding to relative (down = %d)"
-msgstr "切換編碼至相對 (下 = %d)"
+msgstr "切換至相對編碼（down = %d）"
 
 #: ../src/libs/tools/module_toolbox.c:46
 msgid "module toolbox"
@@ -22768,11 +24009,11 @@ msgstr "模組工具箱"
 #. connect callbacks
 #: ../src/libs/tools/ratings.c:98
 msgid "set star rating for selected images"
-msgstr "為選定影像設定星等"
+msgstr "設定影像的評分"
 
 #: ../src/libs/tools/timeline.c:102
 msgid "timeline"
-msgstr "時間線"
+msgstr "時間軸"
 
 #: ../src/libs/tools/timeline.c:1433
 msgid "start selection"
@@ -22788,13 +24029,13 @@ msgstr "查看工具箱"
 
 #: ../src/libs/tools/viewswitcher.c:60
 msgid "viewswitcher"
-msgstr "視角切換工具"
+msgstr "視角切換"
 
 #: ../src/lua/preferences.c:655 ../src/lua/preferences.c:670
 #: ../src/lua/preferences.c:694 ../src/lua/preferences.c:774
 #, c-format
 msgid "double-click to reset to `%s'"
-msgstr "雙擊以重置為 `%s'"
+msgstr "雙擊重設回「%s」"
 
 #: ../src/lua/preferences.c:680
 msgid "select file"
@@ -22803,16 +24044,16 @@ msgstr "選擇檔案"
 #: ../src/lua/preferences.c:733
 #, c-format
 msgid "double-click to reset to `%d'"
-msgstr "雙擊以重置為 `%d'"
+msgstr "雙擊重設回「%d」"
 
 #: ../src/lua/preferences.c:760
 #, c-format
 msgid "double click to reset to `%f'"
-msgstr "雙擊以重置到“%f”"
+msgstr "雙擊重設回「%f」"
 
 #: ../src/lua/preferences.c:836
 msgid "lua options"
-msgstr "lua 選項"
+msgstr "Lua 選項"
 
 #: ../src/views/darkroom.c:624
 #, c-format
@@ -22827,20 +24068,20 @@ msgid ""
 "an issue\n"
 "at https://github.com/darktable-org/darktable"
 msgstr ""
-"darktable 無法載入“%s”，切換回映繪桌模式。\n"
+"darktable 無法載入「%s」，切換回燈箱。\n"
 "\n"
-"請確認 darktable 支援此相機型號及影像檔案格式，參考 https://www.darktable."
-"org/resources/camera-support/\n"
-"若 darktable 確實支援此相機，請考慮在 https://github.com/darktable-org/"
-"darktable 提交問題"
+"請確認 darktable 支援此相機型號的影像格式\n"
+"支援的相機請見 https://www.darktable.org/resources/camera-support/\n"
+"如果確認此相機檔案有支援，請考慮在 GitHub 上回報問題\n"
+"https://github.com/darktable-org/darktable"
 
 #: ../src/views/darkroom.c:641
 #, c-format
 msgctxt "darkroom"
 msgid "loading `%s' ..."
-msgstr "載入“%s”……"
+msgstr "正在載入「%s」"
 
-#: ../src/views/darkroom.c:767 ../src/views/darkroom.c:2426
+#: ../src/views/darkroom.c:767 ../src/views/darkroom.c:2427
 msgid "gamut check"
 msgstr "色域檢查"
 
@@ -22851,164 +24092,163 @@ msgstr "軟打樣"
 #. fail :(
 #: ../src/views/darkroom.c:805 ../src/views/print.c:324
 msgid "no image to open !"
-msgstr "沒有影像要打開！"
+msgstr "沒有要開啟的影像"
 
 #: ../src/views/darkroom.c:1311
 msgid "no userdefined presets for favorite modules were found"
-msgstr "沒有發現使用者自訂的最愛模組預置"
+msgstr "找不到給常用模組使用的使用者自訂預設集"
 
 #: ../src/views/darkroom.c:1316
 #, c-format
 msgid "applied style `%s' on current image"
-msgstr "套用目前照片使用的樣式 `%s'"
+msgstr "對目前影像套用風格檔「%s」"
 
 #: ../src/views/darkroom.c:1441
 msgid "no styles have been created yet"
-msgstr "還沒有建立的樣式"
+msgstr "還沒有已建立的風格檔"
 
-#: ../src/views/darkroom.c:2258
+#: ../src/views/darkroom.c:2259
 msgid "quick access to presets"
-msgstr "快速訪問預置"
+msgstr "快速存取預設集"
 
-#: ../src/views/darkroom.c:2267
+#: ../src/views/darkroom.c:2268
 msgid "quick access for applying any of your styles"
-msgstr "快速訪問並套用您的樣式"
+msgstr "快速存取並套用自訂風格檔"
 
-#: ../src/views/darkroom.c:2273
+#: ../src/views/darkroom.c:2274
 msgid "second window"
-msgstr "第二視窗"
+msgstr "第二個視窗"
 
-#: ../src/views/darkroom.c:2276
+#: ../src/views/darkroom.c:2277
 msgid "display a second darkroom image window"
 msgstr "顯示第二個暗房影像視窗"
 
-#: ../src/views/darkroom.c:2281
+#: ../src/views/darkroom.c:2282
 msgid "color assessment"
 msgstr "色彩評估"
 
-#: ../src/views/darkroom.c:2284
+#: ../src/views/darkroom.c:2285
 msgid "toggle ISO 12646 color assessment conditions"
-msgstr "切換ISO 12646顏色評估條件"
+msgstr "切換 ISO 12646 色彩評估模式"
 
-#: ../src/views/darkroom.c:2297
+#: ../src/views/darkroom.c:2298
 msgid ""
 "toggle raw over exposed indication\n"
 "right click for options"
 msgstr ""
-"切換RAW過曝的指示\n"
-"右鍵查看選項"
+"切換 RAW 過曝提示模式\n"
+"右鍵點擊以查看和修改選項"
 
-#: ../src/views/darkroom.c:2313
+#: ../src/views/darkroom.c:2314
 msgid "select how to mark the clipped pixels"
-msgstr "選擇如何標記剪裁的像素"
+msgstr "選擇過曝像素的顯示方式"
 
-#: ../src/views/darkroom.c:2315
+#: ../src/views/darkroom.c:2316
 msgid "mark with CFA color"
-msgstr "用色彩濾波陣列來標記"
+msgstr "以感光元件濾鏡 RGB 標示"
 
-#: ../src/views/darkroom.c:2315
+#: ../src/views/darkroom.c:2316
 msgid "mark with solid color"
-msgstr "用純色來標記"
+msgstr "以純色標示"
 
-#: ../src/views/darkroom.c:2315
+#: ../src/views/darkroom.c:2316
 msgid "false color"
-msgstr "用僞色來標記"
+msgstr "以相反偽色標示"
 
-#: ../src/views/darkroom.c:2321 ../src/views/darkroom.c:2374
+#: ../src/views/darkroom.c:2322 ../src/views/darkroom.c:2375
 msgid "color scheme"
-msgstr "配色方案"
+msgstr "顯示顏色"
 
-#: ../src/views/darkroom.c:2322
+#: ../src/views/darkroom.c:2323
 msgctxt "solidcolor"
 msgid "red"
 msgstr "紅"
 
-#: ../src/views/darkroom.c:2323
+#: ../src/views/darkroom.c:2324
 msgctxt "solidcolor"
 msgid "green"
 msgstr "綠"
 
-#: ../src/views/darkroom.c:2324
+#: ../src/views/darkroom.c:2325
 msgctxt "solidcolor"
 msgid "blue"
 msgstr "藍"
 
-#: ../src/views/darkroom.c:2325
+#: ../src/views/darkroom.c:2326
 msgctxt "solidcolor"
 msgid "black"
 msgstr "黑"
 
-#: ../src/views/darkroom.c:2329
+#: ../src/views/darkroom.c:2330
 msgid ""
 "select the solid color to indicate over exposure.\n"
 "will only be used if mode = mark with solid color"
 msgstr ""
-"選擇以純色指示過曝\n"
-"僅當模式爲‘用純色標記’時才會使用"
+"選取標示曝光過度的顏色\n"
+"僅模式選擇為「以純色標示」時才有作用"
 
-#: ../src/views/darkroom.c:2338
+#: ../src/views/darkroom.c:2339
 msgid ""
 "threshold of what shall be considered overexposed\n"
 "1.0 - white level\n"
 "0.0 - black level"
 msgstr ""
-"被視為過曝臨界值\n"
-"1.0 - 白階\n"
-"0.0 - 黑階"
+"過度曝光的臨界值，定義哪些值應該被標示為過度曝光\n"
+"在大多數情況下，可以放心地使用預設值 1.0"
 
-#: ../src/views/darkroom.c:2352
+#: ../src/views/darkroom.c:2353
 msgid ""
 "toggle clipping indication\n"
 "right click for options"
 msgstr ""
-"切換剪裁指示\n"
-"右鍵查看選項"
-
-#: ../src/views/darkroom.c:2367
-msgid "clipping preview mode"
-msgstr "截取預覽模式"
+"切換色域及曝光警告模式\n"
+"右鍵點擊以查看和修改選項"
 
 #: ../src/views/darkroom.c:2368
+msgid "clipping preview mode"
+msgstr "色域裁切預覽模式"
+
+#: ../src/views/darkroom.c:2369
 msgid ""
 "select the metric you want to preview\n"
 "full gamut is the combination of all other modes"
 msgstr ""
-"選擇要預覽計量\n"
-"“全色域”是所有其他模式的組合"
+"選擇要突出顯示的指標\n"
+"全色域包含其他所有選項，提供最完整指示"
 
-#: ../src/views/darkroom.c:2370
+#: ../src/views/darkroom.c:2371
 msgid "full gamut"
 msgstr "全色域"
 
-#: ../src/views/darkroom.c:2370
+#: ../src/views/darkroom.c:2371
 msgid "any RGB channel"
-msgstr "任何RGB通道"
+msgstr "任何 RGB 色版"
 
-#: ../src/views/darkroom.c:2370
+#: ../src/views/darkroom.c:2371
 msgid "luminance only"
 msgstr "僅亮度"
 
-#: ../src/views/darkroom.c:2370
+#: ../src/views/darkroom.c:2371
 msgid "saturation only"
 msgstr "僅飽和度"
 
-#: ../src/views/darkroom.c:2375
+#: ../src/views/darkroom.c:2376
 msgid "select colors to indicate clipping"
-msgstr "選擇顯示剪裁的的顏色"
+msgstr "選擇顯示警告的色彩"
 
-#: ../src/views/darkroom.c:2377
+#: ../src/views/darkroom.c:2378
 msgid "red & blue"
-msgstr "紅藍"
+msgstr "紅色和藍色"
 
-#: ../src/views/darkroom.c:2377
+#: ../src/views/darkroom.c:2378
 msgid "purple & green"
-msgstr "紫綠"
-
-#: ../src/views/darkroom.c:2384
-msgid "lower threshold"
-msgstr "降低臨界值"
+msgstr "紫色和綠色"
 
 #: ../src/views/darkroom.c:2385
+msgid "lower threshold"
+msgstr "黑點下限"
+
+#: ../src/views/darkroom.c:2386
 msgid ""
 "clipping threshold for the black point,\n"
 "in EV, relatively to white (0 EV).\n"
@@ -23019,298 +24259,312 @@ msgid ""
 "typical color glossy prints produce black at -8.00 EV,\n"
 "typical B&W glossy prints produce black at -9.00 EV."
 msgstr ""
-"以 EV 爲單位，相對於白色(0 EV)，來調整黑點的截取臨界值。\n"
-"8位 sRGB，黑色定位爲 -12.69 EV；\n"
-"8位 Adobe RGB，黑色截取爲 -19.79 EV；\n"
-"16位 sRGB，黑色截取爲 -20.69 EV；\n"
-"典型的藝術塗料印刷品，黑色定位爲 -5.30 EV；\n"
-"典型的彩色光面印刷品，黑色定位爲 -8.00 EV；\n"
-"典型的黑白光面印刷品，黑色定位爲 -9.00 EV。"
+"黑點的裁切門檻，以相對於 EV = 0 的白點來表示\n"
+"如果 RGB 色版都低於此值，則警告該像素最終可能會被剪裁至黑色，可使用以下參考設"
+"定：\n"
+"8 位元 sRGB：-12.69 EV\n"
+"8 位元 Adobe RGB：-19.79 EV\n"
+"16 位元 sRGB 裁切黑色：-20.69 EV\n"
+"列印美術紙：-5.30 EV\n"
+"列印相紙：-8.00 EV"
 
-#: ../src/views/darkroom.c:2401
+#: ../src/views/darkroom.c:2402
 msgid "upper threshold"
-msgstr "上臨界值"
+msgstr "數值上限"
 
-#: ../src/views/darkroom.c:2403
+#: ../src/views/darkroom.c:2404
 #, no-c-format
 msgid ""
 "clipping threshold for the white point.\n"
 "100% is peak medium luminance."
 msgstr ""
-"調整白點的截取臨界值。\n"
-"100%爲峯值中等亮度。"
+"像素的數值可逼近上限的程度，以百分比表示，超過即會標示剪裁警告\n"
+"對於色域警告，代表的是像素的飽和度與色彩空間邊界的接近程度\n"
+"對於亮度警告，代表的是像素相對於最高亮度的比例"
 
-#: ../src/views/darkroom.c:2415
+#: ../src/views/darkroom.c:2416
 msgid "softproof"
 msgstr "軟打樣"
 
-#: ../src/views/darkroom.c:2418
+#: ../src/views/darkroom.c:2419
 msgid ""
 "toggle softproofing\n"
 "right click for profile options"
 msgstr ""
-"切換軟打樣\n"
-"右鍵查看配置檔案選項"
+"切換軟打樣模式\n"
+"右鍵點擊以查看和修改描述檔選項"
 
-#: ../src/views/darkroom.c:2429
+#: ../src/views/darkroom.c:2430
 msgid ""
 "toggle gamut checking\n"
 "right click for profile options"
 msgstr ""
-"切換色域檢查\n"
-"右鍵查看配置檔案選項"
+"切換色域檢查模式\n"
+"右鍵點擊以查看和修改描述檔選項"
 
-#: ../src/views/darkroom.c:2452 ../src/views/darkroom.c:2459
-#: ../src/views/darkroom.c:2478 ../src/views/darkroom.c:2479
-#: ../src/views/darkroom.c:2480 ../src/views/darkroom.c:2481
+#: ../src/views/darkroom.c:2453 ../src/views/darkroom.c:2460
+#: ../src/views/darkroom.c:2479 ../src/views/darkroom.c:2480
+#: ../src/views/darkroom.c:2481 ../src/views/darkroom.c:2482
 msgid "profiles"
-msgstr "色彩配置檔案"
+msgstr "ICC 描述檔"
 
-#: ../src/views/darkroom.c:2459
+#: ../src/views/darkroom.c:2460
 msgid "preview intent"
-msgstr "預覽目的"
+msgstr "第二視窗轉換方式"
 
-#: ../src/views/darkroom.c:2478 ../src/views/lighttable.c:1168
+#: ../src/views/darkroom.c:2479 ../src/views/lighttable.c:1168
 msgid "display profile"
-msgstr "顯示配置檔案"
+msgstr "螢幕描述檔"
 
-#: ../src/views/darkroom.c:2479 ../src/views/lighttable.c:1171
+#: ../src/views/darkroom.c:2480 ../src/views/lighttable.c:1171
 msgid "preview display profile"
-msgstr "預覽顯示配置檔案"
+msgstr "第二視窗螢幕描述檔"
 
-#: ../src/views/darkroom.c:2481
+#: ../src/views/darkroom.c:2482
 msgid "histogram profile"
-msgstr "直方圖配置"
+msgstr "直方圖描述檔"
 
-#: ../src/views/darkroom.c:2545 ../src/views/lighttable.c:1207
+#: ../src/views/darkroom.c:2546 ../src/views/lighttable.c:1207
 #, c-format
 msgid "display ICC profiles in %s or %s"
-msgstr "顯示的ICC配置檔案在%s 或者 %s裏"
+msgstr ""
+"選擇螢幕的描述檔，可在以下兩個資料夾新增：\n"
+"%s\n"
+"%s"
 
-#: ../src/views/darkroom.c:2548 ../src/views/lighttable.c:1210
+#: ../src/views/darkroom.c:2549 ../src/views/lighttable.c:1210
 #, c-format
 msgid "preview display ICC profiles in %s or %s"
-msgstr "預覽顯示的ICC配置檔案在%s 或 %s裏"
+msgstr ""
+"選擇第二視窗的螢幕的描述檔，可在以下兩個資料夾新增：\n"
+"%s\n"
+"%s"
 
-#: ../src/views/darkroom.c:2551
+#: ../src/views/darkroom.c:2552
 #, c-format
 msgid "softproof ICC profiles in %s or %s"
-msgstr "軟打樣的ICC配置檔案在%s 或 %s裏"
+msgstr ""
+"選擇軟打樣的描述檔，可在以下兩個資料夾新增：\n"
+"%s\n"
+"%s"
 
-#: ../src/views/darkroom.c:2554
+#: ../src/views/darkroom.c:2555
 #, c-format
 msgid "histogram and color picker ICC profiles in %s or %s"
-msgstr "直方圖和顏色選擇器的ICC配置檔案在%s 或者 %s裏"
+msgstr ""
+"選擇直方圖和的色彩選取工具使用的描述檔，可在以下兩個資料夾新增：\n"
+"%s\n"
+"%s"
 
-#: ../src/views/darkroom.c:2592
+#: ../src/views/darkroom.c:2593
 msgid ""
 "toggle guide lines\n"
 "right click for guides options"
 msgstr ""
-"切換參考線\n"
-"右鍵查看參考線選項"
+"顯示 / 隱藏參考線\n"
+"右鍵點擊以查看和修改參考線選項"
 
 #. Fullscreen preview key
-#: ../src/views/darkroom.c:2609
+#: ../src/views/darkroom.c:2610
 msgid "full preview"
 msgstr "全螢幕預覽"
 
 #. add an option to allow skip mouse events while editing masks
-#: ../src/views/darkroom.c:2613
+#: ../src/views/darkroom.c:2614
 msgid "allow to pan & zoom while editing masks"
 msgstr "允許在編輯遮罩時平移和縮放"
 
 #. Zoom shortcuts
-#: ../src/views/darkroom.c:2625
-msgid "zoom close-up"
-msgstr "拉近縮放"
-
 #: ../src/views/darkroom.c:2626
-msgid "zoom fill"
-msgstr "填充縮放"
+msgid "zoom close-up"
+msgstr "縮放至特寫"
 
 #: ../src/views/darkroom.c:2627
+msgid "zoom fill"
+msgstr "縮放至填滿"
+
+#: ../src/views/darkroom.c:2628
 msgid "zoom fit"
-msgstr "符合縮放"
+msgstr "縮放至符合"
 
 #. zoom in/out
 #. zoom in/out/min/max
-#: ../src/views/darkroom.c:2630 ../src/views/lighttable.c:1269
+#: ../src/views/darkroom.c:2631 ../src/views/lighttable.c:1269
 msgid "zoom in"
-msgstr "視角拉近"
+msgstr "放大"
 
-#: ../src/views/darkroom.c:2631 ../src/views/lighttable.c:1271
+#: ../src/views/darkroom.c:2632 ../src/views/lighttable.c:1271
 msgid "zoom out"
-msgstr "視角拉遠"
+msgstr "縮小"
 
 #. Shortcut to skip images
-#: ../src/views/darkroom.c:2634
-msgid "image forward"
-msgstr "前進一個"
-
 #: ../src/views/darkroom.c:2635
+msgid "image forward"
+msgstr "下一張影像"
+
+#: ../src/views/darkroom.c:2636
 msgid "image back"
-msgstr "後退一個"
+msgstr "前一張影像"
 
 #. cycle overlay colors
-#: ../src/views/darkroom.c:2638
+#: ../src/views/darkroom.c:2639
 msgid "cycle overlay colors"
-msgstr "循環覆蓋顏色"
+msgstr "循環疊加色彩"
 
 #. toggle visibility of drawn masks for current gui module
-#: ../src/views/darkroom.c:2641
+#: ../src/views/darkroom.c:2642
 msgid "show drawn masks"
-msgstr "顯示繪製遮罩"
+msgstr "顯示繪製的遮罩"
 
 #. brush size +/-
-#: ../src/views/darkroom.c:2644
-msgid "increase brush size"
-msgstr "增加筆刷大小"
-
 #: ../src/views/darkroom.c:2645
+msgid "increase brush size"
+msgstr "增加筆刷尺寸"
+
+#: ../src/views/darkroom.c:2646
 msgid "decrease brush size"
-msgstr "減少筆刷大小"
+msgstr "縮小筆刷尺寸"
 
 #. brush hardness +/-
-#: ../src/views/darkroom.c:2648
-msgid "increase brush hardness"
-msgstr "增加筆刷硬度"
-
 #: ../src/views/darkroom.c:2649
+msgid "increase brush hardness"
+msgstr "提高筆刷硬度"
+
+#: ../src/views/darkroom.c:2650
 msgid "decrease brush hardness"
-msgstr "減少筆刷硬度"
+msgstr "降低筆刷硬度"
 
 #. brush opacity +/-
-#: ../src/views/darkroom.c:2652
-msgid "increase brush opacity"
-msgstr "增加筆刷不透明度"
-
 #: ../src/views/darkroom.c:2653
+msgid "increase brush opacity"
+msgstr "提升畫刷不透明度"
+
+#: ../src/views/darkroom.c:2654
 msgid "decrease brush opacity"
-msgstr "減少筆刷不透明度"
+msgstr "降低畫刷不透明度"
 
 #. undo/redo
-#: ../src/views/darkroom.c:2656 ../src/views/lighttable.c:1261
+#: ../src/views/darkroom.c:2657 ../src/views/lighttable.c:1261
 #: ../src/views/map.c:2115
 msgid "undo"
-msgstr "回復設定"
+msgstr "復原"
 
-#: ../src/views/darkroom.c:2657 ../src/views/lighttable.c:1262
+#: ../src/views/darkroom.c:2658 ../src/views/lighttable.c:1262
 #: ../src/views/map.c:2116
 msgid "redo"
-msgstr "重做"
+msgstr "重作"
 
 #. set focus to the search modules text box
-#: ../src/views/darkroom.c:2660
+#: ../src/views/darkroom.c:2661
 msgid "search modules"
 msgstr "搜尋模組"
 
 #. change the precision for adjusting sliders with keyboard shortcuts
-#: ../src/views/darkroom.c:2663
+#: ../src/views/darkroom.c:2664
 msgid "change keyboard shortcut slider precision"
-msgstr "變更鍵盤快捷鍵滑動條精確度"
+msgstr "改變鍵盤快速鍵滑桿的精準度"
 
-#: ../src/views/darkroom.c:3845
+#: ../src/views/darkroom.c:3846
 msgid "keyboard shortcut slider precision: fine"
-msgstr "鍵盤快捷鍵滑動條的精度:細緻"
+msgstr "鍵盤快速鍵滑桿的精準度：精細"
 
-#: ../src/views/darkroom.c:3847
+#: ../src/views/darkroom.c:3848
 msgid "keyboard shortcut slider precision: normal"
-msgstr "鍵盤快捷鍵滑動條的精度:正常"
+msgstr "鍵盤快速鍵滑桿的精準度：中等"
 
-#: ../src/views/darkroom.c:3849
+#: ../src/views/darkroom.c:3850
 msgid "keyboard shortcut slider precision: coarse"
-msgstr "鍵盤快捷鍵滑動條的精度:粗略"
+msgstr "鍵盤快速鍵滑桿的精準度：粗糙"
 
-#: ../src/views/darkroom.c:3864
+#: ../src/views/darkroom.c:3865
 msgid "switch to lighttable"
-msgstr "切換到映繪桌"
+msgstr "切換到燈箱"
 
-#: ../src/views/darkroom.c:3865 ../src/views/lighttable.c:871
+#: ../src/views/darkroom.c:3866 ../src/views/lighttable.c:871
 msgid "zoom in the image"
 msgstr "放大影像"
 
-#: ../src/views/darkroom.c:3866
-msgid "unbounded zoom in the image"
-msgstr "無限放大影像"
-
 #: ../src/views/darkroom.c:3867
+msgid "unbounded zoom in the image"
+msgstr "不限制放大比例"
+
+#: ../src/views/darkroom.c:3868
 msgid "zoom to 100% 200% and back"
-msgstr "縮放到 100% 200% 然後返回"
+msgstr "縮放至 100% 200% 並返回"
 
-#: ../src/views/darkroom.c:3869
+#: ../src/views/darkroom.c:3870
 msgid "[modules] expand module without closing others"
-msgstr "[模組]展開模組時不關閉其他模組"
+msgstr "展開模組時不收合其他模組"
 
-#: ../src/views/darkroom.c:3871
+#: ../src/views/darkroom.c:3872
 msgid "[modules] change module position in pipe"
-msgstr "[模組]更改模組在處理管線中的位置"
+msgstr "改變模組的位置（運算順序）"
 
 #: ../src/views/knight.c:334
 msgid "good knight"
-msgstr "暗夜騎士"
+msgstr "darktable 團隊的愚人節惡作劇"
 
 #: ../src/views/lighttable.c:748
 msgid "middle"
-msgstr "中鍵"
+msgstr "滑鼠中鍵"
 
 #: ../src/views/lighttable.c:866
 msgid "open image in darkroom"
-msgstr "在暗房中打開影像"
+msgstr "在暗房中開啟影像"
 
 #: ../src/views/lighttable.c:870
 msgid "switch to next/previous image"
-msgstr "切換到下/上一張影像"
+msgstr "切換至下一張 / 上一張影像"
 
 #: ../src/views/lighttable.c:873 ../src/views/lighttable.c:896
 #, no-c-format
 msgid "zoom to 100% and back"
-msgstr "縮放至 100% 再返回"
+msgstr "縮放到 100% 並返回"
 
 #: ../src/views/lighttable.c:877 ../src/views/lighttable.c:889
 msgid "scroll the collection"
-msgstr "滾動影像集合"
+msgstr "瀏覽相冊"
 
 #: ../src/views/lighttable.c:879
 msgid "change number of images per row"
-msgstr "變更每列顯示的影像數量"
+msgstr "改變每行顯示的影像數量"
 
 #: ../src/views/lighttable.c:883
 msgid "change image order"
-msgstr "變更影像順序"
+msgstr "改變影像順序"
 
 #: ../src/views/lighttable.c:890
 msgid "zoom all the images"
-msgstr "縮放所有影像"
+msgstr "縮放所有的影像"
 
 #: ../src/views/lighttable.c:891
 msgid "pan inside all the images"
-msgstr "在所有影像內平移"
+msgstr "在所有的影像內平移"
 
 #: ../src/views/lighttable.c:893
 msgid "zoom current image"
-msgstr "縮放目前影像"
+msgstr "縮放目前的影像"
 
 #: ../src/views/lighttable.c:894
 msgid "pan inside current image"
-msgstr "在目前影像內平移"
+msgstr "在目前的影像內平移"
 
 #: ../src/views/lighttable.c:899
 #, no-c-format
 msgid "zoom current image to 100% and back"
-msgstr "將目前影像縮放至 100% 再恢復原有縮放"
+msgstr "將目前的影像縮放到 100% 並返回"
 
 #: ../src/views/lighttable.c:903
 msgid "zoom the main view"
-msgstr "縮放主視角"
+msgstr "縮放主視窗"
 
 #: ../src/views/lighttable.c:904
 msgid "pan inside the main view"
-msgstr "在主視角內平移"
+msgstr "在主視窗內平移"
 
 #: ../src/views/lighttable.c:1134
 msgid "set display profile"
-msgstr "設定顯示色彩配置"
+msgstr "設定螢幕描述檔"
 
 #: ../src/views/lighttable.c:1231
 msgid "whole"
@@ -23318,15 +24572,15 @@ msgstr "全部"
 
 #: ../src/views/lighttable.c:1247
 msgid "leave"
-msgstr "離開"
+msgstr "退出"
 
 #: ../src/views/lighttable.c:1255
 msgid "align images to grid"
-msgstr "將影像與網格對齊"
+msgstr "將影像與格線對齊"
 
 #: ../src/views/lighttable.c:1256
 msgid "reset first image offset"
-msgstr "重置第一個影像偏移"
+msgstr "重設第一張影像偏差"
 
 #: ../src/views/lighttable.c:1257
 msgid "select toggle image"
@@ -23334,32 +24588,32 @@ msgstr "選擇切換影像"
 
 #: ../src/views/lighttable.c:1258
 msgid "select single image"
-msgstr "選擇單個影像"
+msgstr "選擇單張影像"
 
 #. zoom for full culling & preview
 #: ../src/views/lighttable.c:1265
 msgid "preview zoom 100%"
-msgstr "預覽縮放100%"
+msgstr "預覽縮放至 100%"
 
 #: ../src/views/lighttable.c:1266
 msgid "preview zoom fit"
-msgstr "符合預覽縮放"
+msgstr "預覽縮放至符合螢幕"
 
 #: ../src/views/lighttable.c:1270
 msgid "zoom max"
-msgstr "最大縮放"
+msgstr "放到最大"
 
 #: ../src/views/lighttable.c:1272
 msgid "zoom min"
-msgstr "最小縮放"
+msgstr "縮到最小"
 
 #: ../src/views/map.c:2812
 msgid "[on image] open in darkroom"
-msgstr "[影像]在暗房中打開"
+msgstr "在暗房中開啟"
 
 #: ../src/views/map.c:2813
 msgid "[on map] zoom map"
-msgstr "[地圖]縮放地圖"
+msgstr "縮放地圖"
 
 #: ../src/views/map.c:2814
 msgid "move image location"
@@ -23372,34 +24626,34 @@ msgstr "列印"
 
 #: ../src/views/slideshow.c:314
 msgid "end of images"
-msgstr "影像放映結束"
+msgstr "影像輪播結束"
 
 #: ../src/views/slideshow.c:330
 msgid "end of images. press any key to return to lighttable mode"
-msgstr "結束全部影像。按任意按鍵回到映繪桌模式"
+msgstr "輪播結束，按任意鍵回到燈箱"
 
 #: ../src/views/slideshow.c:452
 msgid "waiting to start slideshow"
-msgstr "等待幻燈片開始"
+msgstr "等待影像輪播開始"
 
 #: ../src/views/slideshow.c:567 ../src/views/slideshow.c:588
 #: ../src/views/slideshow.c:596
 msgid "slideshow paused"
-msgstr "幻燈播放已暫停"
+msgstr "影像輪播暫停"
 
 #: ../src/views/slideshow.c:575 ../src/views/slideshow.c:582
 #, c-format
 msgid "slideshow delay set to %d second"
 msgid_plural "slideshow delay set to %d seconds"
-msgstr[0] "幻燈片延時設定爲 %d 秒"
+msgstr[0] "影像輪播間隔時間為 %d 秒"
 
 #: ../src/views/slideshow.c:611
 msgid "start and stop"
-msgstr "開始/停止"
+msgstr "開始與停止"
 
 #: ../src/views/slideshow.c:612
 msgid "exit slideshow"
-msgstr "退出幻燈片"
+msgstr "關閉影像輪播"
 
 #: ../src/views/slideshow.c:615
 msgid "slow down"
@@ -23411,70 +24665,131 @@ msgstr "加速"
 
 #: ../src/views/slideshow.c:622
 msgid "step forward"
-msgstr "前進"
+msgstr "下一張"
 
 #: ../src/views/slideshow.c:623
 msgid "step back"
-msgstr "後退"
+msgstr "前一張"
 
 #: ../src/views/slideshow.c:629
 msgid "go to next image"
-msgstr "下一張影像"
+msgstr "前往下一張影像"
 
 #: ../src/views/slideshow.c:630
 msgid "go to previous image"
-msgstr "前一張影像"
+msgstr "回到上一張影像"
 
 #: ../src/views/tethering.c:157
 #, c-format
 msgid "new session initiated '%s'"
-msgstr "已起始新期間“%s”"
+msgstr "已啟動新的工作階段「%s」"
 
 #: ../src/views/tethering.c:448
 msgid "no camera with tethering support available for use..."
-msgstr "未找到支援連機拍攝的相機……"
+msgstr "沒有支援連機拍攝的相機"
 
-#: ../src/views/view.c:1194
+#: ../src/views/view.c:1192
 msgid "left click"
-msgstr "單擊左鍵"
+msgstr "左鍵點擊"
 
-#: ../src/views/view.c:1197
+#: ../src/views/view.c:1195
 msgid "right click"
-msgstr "單擊右鍵"
+msgstr "右鍵點擊"
 
-#: ../src/views/view.c:1200
+#: ../src/views/view.c:1198
 msgid "middle click"
-msgstr "單擊滑鼠中鍵"
+msgstr "中鍵點擊"
 
-#: ../src/views/view.c:1206
+#: ../src/views/view.c:1204
 msgid "left double-click"
 msgstr "左鍵雙擊"
 
-#: ../src/views/view.c:1209
+#: ../src/views/view.c:1207
 msgid "right double-click"
 msgstr "右鍵雙擊"
 
-#: ../src/views/view.c:1212
+#: ../src/views/view.c:1210
 msgid "drag and drop"
-msgstr "拖放"
+msgstr "拖曳"
 
-#: ../src/views/view.c:1215
+#: ../src/views/view.c:1213
 msgid "left click+drag"
-msgstr "左鍵單擊 + 拖拉"
+msgstr "左鍵點擊+拖曳"
 
-#: ../src/views/view.c:1218
+#: ../src/views/view.c:1216
 msgid "right click+drag"
-msgstr "右鍵單擊 + 拖拉"
+msgstr "右鍵點擊+拖曳"
 
-#: ../src/views/view.c:1238
+#: ../src/views/view.c:1236
 msgid "darktable - accels window"
-msgstr "darktable - 快捷鍵視窗"
+msgstr "darktable 快速鍵視窗"
 
-#: ../src/views/view.c:1286
+#: ../src/views/view.c:1284
 msgid "switch to a classic window which will stay open after key release"
-msgstr "切換至經典視窗，此視窗在放開按鍵後保持顯示"
+msgstr "切換回傳統視窗，在按鍵放開後仍保持開啟"
 
 #. we add the mouse actions too
-#: ../src/views/view.c:1345
+#: ../src/views/view.c:1343
 msgid "mouse actions"
-msgstr "滑鼠行爲"
+msgstr "滑鼠動作"
+
+#~ msgctxt "preferences"
+#~ msgid "at most RCD (reasonable)"
+#~ msgstr "大部分使用 RCD（合理效能）"
+
+#~ msgid "white balance slider colors"
+#~ msgstr "白平衡模組的滑桿色彩"
+
+#~ msgid ""
+#~ "visual indication of temperature adjustments.\n"
+#~ "in 'illuminant color' mode slider colors represent the color of the light "
+#~ "source,\n"
+#~ "in 'effect emulation' slider colors represent the effect the adjustment "
+#~ "would have on the scene"
+#~ msgstr ""
+#~ "控制白平衡模組裡溫度和色調滑桿的外觀\n"
+#~ "\n"
+#~ "沒有顏色：滑桿沒有顏色\n"
+#~ "光源顏色：滑桿顏色代表光源的顏色，也就是畫面中應該為中性白的顏色\n"
+#~ "效果模擬：滑桿顏色代表調整的效果，這是大部分軟體顯示色溫/白平衡滑桿的方式"
+
+#~ msgid "color balance slider block layout"
+#~ msgstr "色彩平衡模組介面布局"
+
+#~ msgid ""
+#~ "choose how to organise the slider blocks for lift, gamma and gain:\n"
+#~ "list - all sliders are shown in one long list (with headers),\n"
+#~ "tabs - use tabs to switch between the blocks of sliders,\n"
+#~ "columns - the blocks of sliders are shown next to each other (in narrow "
+#~ "columns)"
+#~ msgstr ""
+#~ "控制色彩平衡模組中 陰影/中間調/高光 部分的介面。\n"
+#~ "\n"
+#~ "垂直清單：所有滑桿依序垂直排列\n"
+#~ "標籤切換：使用標籤在 陰影/中間調/高光 之間切換\n"
+#~ "水平並列：三組滑桿水平緊鄰排列"
+
+#~ msgid "auto-apply sharpen"
+#~ msgstr "自動套用銳利化"
+
+#~ msgid ""
+#~ "this added sharpen is not recommended on cameras without a low-pass "
+#~ "filter. you should disable this option if you use one of those more "
+#~ "recent cameras or sharpen your images with other means."
+#~ msgstr ""
+#~ "自動套用「銳利化」模組在每張新影像上\n"
+#~ "不建議在沒有低通濾鏡的相機上開啟，如果有使用其他銳化方法也應關閉此選項"
+
+#~ msgid "cast balance"
+#~ msgstr "色偏平衡"
+
+#~ msgid "combine segments"
+#~ msgstr "組合區域"
+
+#~ msgid "gray scale"
+#~ msgstr "灰階"
+
+#~ msgid ""
+#~ "if switched on, darktable tunes OpenCL for best performance, overrides "
+#~ "static settings"
+#~ msgstr "如果打開，darktable 將會調節 OpenCL 以獲得最佳性能，取代靜態設置"


### PR DESCRIPTION
It's a brand new re-translation of zh_TW.po, update to POT date: 2022-08-18 08:34+0200.

Purpose & Improvement:

1. Fix long-lasting wrong translations in past .po files.
   _by double-checking translations in most module and function_
2. Use right proper nouns.
   _referring to "Taiwan National Academy for Educational Research" for vocabulary_
3. Use the words and syntax that Taiwanese people use.
   _exclusively for Taiwanese people, makes this translation fluent and colloquial_
4. Beginners-friendly
   _adding annotations translated from the user manual_
5. Experts-friendly
   _showing English module name in module title tooltip, so that users could browse user manual in English without misunderstand_