### PR TITLE
Negadoctor: remove a line that initalize offset's color picker again

### DIFF
--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -865,7 +865,6 @@ void gui_init(dt_iop_module_t *self)
 
   g->offset = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "offset"));
   dt_bauhaus_slider_set_format(g->offset, " dB");
-  dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->offset);
   gtk_widget_set_tooltip_text(g->offset, _("correct the exposure of the scanner, for all RGB channels,\n"
                                            "before the inversion, so blacks are neither clipped or too pale."));
 


### PR DESCRIPTION
A small bug correction for my first PR:
 
On the first panel of negadoctor module, there is a bug where one cannot deactivate the color picker of the "scan exposure bias" parameter.

After reading the code, I noticed that line `868` initialize the color picker while the color picker was already initialized at line `866`.

Deleting that line corrects the issue and doesn't affect the use of the module on my side.



