### PR TITLE
Corrected the advice in the README on how to avoid a startup crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ sudo ln -s /opt/darktable/share/applications/darktable.desktop /usr/share/applic
 ```
 
 You may find darktable configuration files in `~/.config/darktable`.
-If you experience crashes at startup, try launching darktable without OpenCL, from a terminal, with `darktable --conf opencl=FALSE`.
+If you experience crashes at startup, try launching darktable from a terminal with OpenCL disabled using `darktable --disable-opencl`.
 
 ### Further reading
 


### PR DESCRIPTION
The advice given in the text did not work. Crashes at startup related to OpenCL cannot be avoided in this way. At startup, only OpenCL device initialization is performed and no OpenCL execution paths are started, so `--conf opencl=FALSE` does not affect anything at this stage. Startup crashes occur during device initialization stage, so only completely disabling this process (via `--disable-opencl`) will prevent the crash.