### PR TITLE
BUGFIXES new iop cache issues

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1670,9 +1670,9 @@ size_t dt_get_singlebuffer_mem()
 
 size_t dt_get_iopcache_mem()
 {
-  dt_sys_resources_t *res = &darktable.dtresources;
-  const size_t cachemb = res->total_memory / 1024lu / 1024lu / 20lu;
-  return MIN(6000lu, MAX(400lu, cachemb)) * 1024lu * 1024lu;
+  // use ~half of mipmap size
+  const size_t cachemb = _get_mipmap_size() / 2048lu / 1024lu ;
+  return MIN(3000lu, MAX(300lu, cachemb)) * 1024lu * 1024lu;
 }
 
 void dt_configure_runtime_performance(const int old, char *info)

--- a/src/common/focus.h
+++ b/src/common/focus.h
@@ -264,7 +264,7 @@ static void dt_focus_draw_clusters(cairo_t *cr, int width, int height, int imgid
     dt_dev_init(&dev, 0);
     dt_dev_load_image(&dev, imgid);
     dt_dev_pixelpipe_t pipe;
-    const int res = dt_dev_pixelpipe_init_dummy(&pipe, wd, ht);
+    const gboolean res = dt_dev_pixelpipe_init_dummy(&pipe, wd, ht);
     if(res)
     {
       // set mem pointer to 0, won't be used.

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -727,7 +727,7 @@ gboolean dt_image_get_final_size(const int32_t imgid, int *width, int *height)
 
   dt_dev_pixelpipe_t pipe;
   int wd = dev.image_storage.width, ht = dev.image_storage.height;
-  int res = dt_dev_pixelpipe_init_dummy(&pipe, wd, ht);
+  gboolean res = dt_dev_pixelpipe_init_dummy(&pipe, wd, ht);
   if(res)
   {
     // set mem pointer to 0, won't be used.

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -744,13 +744,10 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
   const int wd = img->width;
   const int ht = img->height;
 
-
-  int res = 0;
-
   dt_times_t start;
   dt_get_times(&start);
   dt_dev_pixelpipe_t pipe;
-  res = thumbnail_export ? dt_dev_pixelpipe_init_thumbnail(&pipe, wd, ht)
+  gboolean res = thumbnail_export ? dt_dev_pixelpipe_init_thumbnail(&pipe, wd, ht)
                          : dt_dev_pixelpipe_init_export(&pipe, wd, ht, format->levels(format_params), export_masks);
   if(!res)
   {

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -255,7 +255,7 @@ gboolean dt_dev_pixelpipe_cache_get(dt_dev_pixelpipe_cache_t *cache, const uint6
       *data = cache->data[k];
       *dsc = &cache->dsc[k];
       // in case of a hit its always good to keep the cachline as important
-      cache->used[k] = -cache->entries; // this is the MRU entry
+      cache->used[k] = -cache->entries;
       ASAN_POISON_MEMORY_REGION(*data, cache->size[k]);
       ASAN_UNPOISON_MEMORY_REGION(*data, size);
       return FALSE;
@@ -317,19 +317,12 @@ void dt_dev_pixelpipe_cache_flush_all_but(dt_dev_pixelpipe_cache_t *cache, uint6
   }
 }
 
-void dt_dev_pixelpipe_cache_reweight(dt_dev_pixelpipe_cache_t *cache, void *data, char *modname)
+void dt_dev_pixelpipe_cache_reweight(dt_dev_pixelpipe_cache_t *cache, void *data)
 {
   for(int k = 0; k < cache->entries; k++)
   {
     if(cache->data[k] == data)
-    {
-      dt_vprint(DT_DEBUG_DEV, "[dt_dev_pixelpipe_cache_reweight] %i->%i, `%s'->`%s'\n",
-        cache->used[k], -cache->entries,
-        cache->modname[k] ? cache->modname[k] : "??",
-        modname ? modname : "??");
       cache->used[k] = -cache->entries;
-      cache->modname[k] = modname;
-    }
   }
 }
 
@@ -354,7 +347,7 @@ void dt_dev_pixelpipe_cache_print(dt_dev_pixelpipe_cache_t *cache, char *pipetyp
     for(int k = 0; k < cache->entries; k++)
     {
       if(cache->size[k])
-        fprintf(stderr, " [%s]%3d,%4luMB, weight%4d, `%s', hash %" PRIu64 " (%" PRIu64 ")\n",
+        fprintf(stderr, " [%s]%3d,%4luMB, weight%5d, %16s, hash %22" PRIu64 ", basic %22" PRIu64 "\n",
           pipetype, k, cache->size[k] / 1024lu / 1024lu, cache->used[k], cache->modname[k] ? cache->modname[k] : "no module name", cache->hash[k], cache->basichash[k]);
     }
   }

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2021 darktable developers.
+    Copyright (C) 2009-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -25,18 +25,11 @@
 
 
 // TODO: make cache global (needs to be thread safe then)
-// plan:
-// - look at mipmap_cache.c, for the full buffer allocs
-// - do that, but for `large' and `regular' buffers (full + export/dr mode), so 2 caches
-//   (in fact, maybe 3, one for preview pipes?)
-// - have at most 3 read locks all the time per pipe, get them at create time
-//   ping, pong, and priority buffer (focused plugin)
-// - drop read by the time another is requested (with priority, drop that, or alternating ping and pong?)
 
 gboolean dt_dev_pixelpipe_cache_init(dt_dev_pixelpipe_cache_t *cache, int entries, size_t size, size_t limit)
 {
   cache->entries = entries;
-  cache->allmem = 0;
+  cache->allmem = cache->queries = cache->misses = 0;
   cache->memlimit = limit;
   cache->data = (void **)calloc(entries, sizeof(void *));
   cache->size = (size_t *)calloc(entries, sizeof(size_t));
@@ -48,26 +41,29 @@ gboolean dt_dev_pixelpipe_cache_init(dt_dev_pixelpipe_cache_t *cache, int entrie
   cache->hash = (uint64_t *)calloc(entries, sizeof(uint64_t));
   cache->used = (int32_t *)calloc(entries, sizeof(int32_t));
   cache->modname = (char **)calloc(entries, sizeof(char *));
+
+  for(int k = 0; k < entries; k++)
+  {
+    cache->size[k] = 0;
+    cache->data[k] = NULL;
+    cache->basichash[k] = -1;
+    cache->hash[k] = -1;
+    cache->used[k] = 1;
+    cache->modname[k] = NULL;
+  }
+  if(!size) return TRUE;
+
   for(int k = 0; k < entries; k++)
   {
     cache->size[k] = size;
-    if(size)
-    { // allow 0 initial buffer size (yet unknown dimensions)
-      cache->data[k] = (void *)dt_alloc_align(64, size);
-      if(!cache->data[k]) goto alloc_memory_fail;
+    cache->data[k] = (void *)dt_alloc_align(64, size);
+    if(!cache->data[k]) goto alloc_memory_fail;
 #ifdef _DEBUG
-      memset(cache->data[k], 0x5d, size);
+    memset(cache->data[k], 0x5d, size);
 #endif
-      ASAN_POISON_MEMORY_REGION(cache->data[k], cache->size[k]);
-    }
-    else cache->data[k] = NULL;
+    ASAN_POISON_MEMORY_REGION(cache->data[k], cache->size[k]);
     cache->allmem += size;
-    cache->basichash[k] = -1;
-    cache->hash[k] = -1;
-    cache->used[k] = 0;
-    cache->modname[k] = NULL;
   }
-  cache->queries = cache->misses = 0;
   return TRUE;
 
 alloc_memory_fail:
@@ -182,23 +178,11 @@ gboolean dt_dev_pixelpipe_cache_available(dt_dev_pixelpipe_cache_t *cache, const
   return FALSE;
 }
 
-gboolean dt_dev_pixelpipe_cache_get_important(dt_dev_pixelpipe_cache_t *cache, const uint64_t basichash,
-                                         const uint64_t hash, const size_t size,
-                                         void **data, dt_iop_buffer_dsc_t **dsc, char *modname)
-{
-  return dt_dev_pixelpipe_cache_get_weighted(cache, basichash, hash, size, data, dsc, -cache->entries, modname);
-}
-
-gboolean dt_dev_pixelpipe_cache_get(dt_dev_pixelpipe_cache_t *cache, const uint64_t basichash, const uint64_t hash,
-                               const size_t size, void **data, dt_iop_buffer_dsc_t **dsc, char *modname)
-{
-  return dt_dev_pixelpipe_cache_get_weighted(cache, basichash, hash, size, data, dsc, 0, modname);
-}
-
 static int _get_oldest_cacheline(dt_dev_pixelpipe_cache_t *cache)
 {
-  int weight = -1;
-  int id = -1;
+  // we never want the latest used cacheline! It was <= 0 and the weight has increased just now
+  int weight = 1;
+  int id = 0;
   for(int k = 0; k < cache->entries; k++)
   {
     if(cache->used[k] > weight)
@@ -210,87 +194,101 @@ static int _get_oldest_cacheline(dt_dev_pixelpipe_cache_t *cache)
   return id;
 }
 
+static int _get_oldest_used_cacheline(dt_dev_pixelpipe_cache_t *cache)
+{
+  int weight = 16;
+  int id = -1;
+  for(int k = 0; k < cache->entries; k++)
+  {
+    if((cache->used[k] > weight) && (cache->size[k] != 0))
+    {
+      weight = cache->used[k];
+      id = k;
+    }
+  }
+  return id;
+}
+
 static int _get_free_cacheline(dt_dev_pixelpipe_cache_t *cache, size_t size)
 {
   int oldest = _get_oldest_cacheline(cache);
-  if((cache->memlimit == 0) || ((cache->memlimit - cache->allmem) >= size))
+  if((cache->memlimit == 0) || (cache->memlimit > cache->allmem))
     return oldest;
 
-  int cnt = 0;
-   while(((cache->memlimit - cache->allmem) < size) && (cnt < cache->entries))
+  // we have to free & invalidate cachelines until there is enough mem available
+  size_t freed = 0;
+  oldest = _get_oldest_used_cacheline(cache);
+  while((cache->memlimit < cache->allmem) && (oldest >= 0))
   {
-    cnt++;
-    // we have to free & invalidate cachelines until there is enough mem available
     dt_free_align(cache->data[oldest]);
     cache->allmem -= cache->size[oldest];
- 
+    freed += cache->size[oldest];
     cache->size[oldest] = 0;
     cache->data[oldest] = NULL;
     cache->hash[oldest] = -1;
     cache->basichash[oldest] = -1;
-    cache->used[oldest] = 1;
-    oldest = _get_oldest_cacheline(cache);
+    cache->used[oldest] = 1000;
+    oldest = _get_oldest_used_cacheline(cache);
   }
 
-  dt_print(DT_DEBUG_DEV, "[get_free_cachelines] removed %i, ->line %i, cachemem=%luMB, limit=%luMB\n",
-    cnt, oldest, cache->allmem / 1024lu / 1024lu, cache->memlimit / 1024lu / 1024lu); 
+  oldest = _get_oldest_used_cacheline(cache);
+  if(oldest < 0) oldest = _get_oldest_cacheline(cache);
+
+  if(freed) dt_print(DT_DEBUG_DEV, "[get_free_cachelines] freed %luMB\n", freed / 1024lu / 1024lu);
   return oldest;
 }
 
-gboolean dt_dev_pixelpipe_cache_get_weighted(dt_dev_pixelpipe_cache_t *cache, const uint64_t basichash, const uint64_t hash,
-                                        const size_t size, void **data, dt_iop_buffer_dsc_t **dsc, int weight, char *name)
+gboolean dt_dev_pixelpipe_cache_get(dt_dev_pixelpipe_cache_t *cache, const uint64_t basichash, const uint64_t hash,
+                                        const size_t size, void **data, dt_iop_buffer_dsc_t **dsc, char *name, const gboolean important)
 {
+  const int weight = important ? -cache->entries : 0;
   cache->queries++;
-  *data = NULL;
-  size_t sz = 0;
+  for(int k = 0; k < cache->entries; k++)
+    cache->used[k]++; // age all entries
 
   for(int k = 0; k < cache->entries; k++)
   {
-    // search for hash in cache
-    cache->used[k]++; // age all entries
     if(cache->hash[k] == hash)
     {
       *data = cache->data[k];
       *dsc = &cache->dsc[k];
-      sz = cache->size[k];
-      cache->used[k] = weight; // this is the MRU entry
-
-      ASAN_POISON_MEMORY_REGION(*data, sz);
+      // in case of a hit its always good to keep the cachline as important
+      cache->used[k] = -cache->entries; // this is the MRU entry
+      ASAN_POISON_MEMORY_REGION(*data, cache->size[k]);
       ASAN_UNPOISON_MEMORY_REGION(*data, size);
+      return FALSE;
     }
   }
 
-  if(!*data || sz < size)
+  // We need a fresh buffer as there was no hit.
+  // Either we just toggle cachelines 0/1 in case of cache->entries == 2
+  // or we get an old/free cacheline. As that might have no or not enough memory allocated we have to make sure.
+  const int cline = (cache->entries == 2) ? cache->queries & 1 : _get_free_cacheline(cache, size);
+  if(cache->size[cline] < size)
   {
-    // kill LRU entry
-    const int max = _get_free_cacheline(cache, size);
-    if(cache->size[max] < size)
-    {
-      dt_free_align(cache->data[max]);
-      cache->allmem -= cache->size[max];
-      cache->data[max] = (void *)dt_alloc_align(64, size);
-      cache->size[max] = size;
-      cache->allmem += cache->size[max];
-    }
-    *data = cache->data[max];
-    sz = cache->size[max];
+    dt_free_align(cache->data[cline]);
+    cache->allmem -= cache->size[cline];
 
-    ASAN_POISON_MEMORY_REGION(*data, sz);
-    ASAN_UNPOISON_MEMORY_REGION(*data, size);
-
-    // first, update our copy, then update the pointer to point at our copy
-    cache->dsc[max] = **dsc;
-    *dsc = &cache->dsc[max];
-
-    cache->basichash[max] = basichash;
-    cache->hash[max] = hash;
-    cache->used[max] = weight;
-    cache->modname[max] = name;
-    cache->misses++;
-    return TRUE;
+    cache->data[cline] = (void *)dt_alloc_align(64, size);
+    cache->size[cline] = size;
+    cache->allmem += cache->size[cline];
   }
-  else
-    return FALSE;
+
+  *data = cache->data[cline];
+
+//    ASAN_POISON_MEMORY_REGION(*data, sz);
+  ASAN_UNPOISON_MEMORY_REGION(*data, size);
+
+  // first, update our copy, then update the pointer to point at our copy
+  cache->dsc[cline] = **dsc;
+  *dsc = &cache->dsc[cline];
+
+  cache->basichash[cline] = basichash;
+  cache->hash[cline] = hash;
+  cache->used[cline] = weight;
+  cache->modname[cline] = name;
+  cache->misses++;
+  return TRUE;
 }
 
 void dt_dev_pixelpipe_cache_flush(dt_dev_pixelpipe_cache_t *cache)
@@ -299,7 +297,7 @@ void dt_dev_pixelpipe_cache_flush(dt_dev_pixelpipe_cache_t *cache)
   {
     cache->basichash[k] = -1;
     cache->hash[k] = -1;
-    cache->used[k] = 0;
+    cache->used[k] = 1000;
     ASAN_POISON_MEMORY_REGION(cache->data[k], cache->size[k]);
   }
 }
@@ -312,7 +310,7 @@ void dt_dev_pixelpipe_cache_flush_all_but(dt_dev_pixelpipe_cache_t *cache, uint6
       continue;
     cache->basichash[k] = -1;
     cache->hash[k] = -1;
-    cache->used[k] = 0;
+    cache->used[k] = 1000;
     ASAN_POISON_MEMORY_REGION(cache->data[k], cache->size[k]);
   }
 }
@@ -341,6 +339,7 @@ void dt_dev_pixelpipe_cache_invalidate(dt_dev_pixelpipe_cache_t *cache, void *da
     {
       cache->basichash[k] = -1;
       cache->hash[k] = -1;
+      cache->used[k] = 1000;
       ASAN_POISON_MEMORY_REGION(cache->data[k], cache->size[k]);
     }
   }

--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -84,7 +84,7 @@ void dt_dev_pixelpipe_cache_flush(dt_dev_pixelpipe_cache_t *cache);
 void dt_dev_pixelpipe_cache_flush_all_but(dt_dev_pixelpipe_cache_t *cache, uint64_t basichash);
 
 /** makes this buffer very important after it has been pulled from the cache. */
-void dt_dev_pixelpipe_cache_reweight(dt_dev_pixelpipe_cache_t *cache, void *data, char *modname);
+void dt_dev_pixelpipe_cache_reweight(dt_dev_pixelpipe_cache_t *cache, void *data);
 
 /** mark the given cache line pointer as invalid. */
 void dt_dev_pixelpipe_cache_invalidate(dt_dev_pixelpipe_cache_t *cache, void *data);

--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2020 darktable developers.
+    Copyright (C) 2009-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -27,9 +27,9 @@ struct dt_iop_roi_t;
 /**
  * implements a simple pixel cache suitable for caching float images
  * corresponding to history items and zoom/pan settings in the develop module.
- * it is optimized for very few entries (~5), so most operations are O(N).
+ * correctness is secured via the hash so make sure everything is included here.
+ * No caching if cl_mem, instead copied cache buffers are used.
  */
-
 typedef struct dt_dev_pixelpipe_cache_t
 {
   int32_t entries;
@@ -41,9 +41,6 @@ typedef struct dt_dev_pixelpipe_cache_t
   uint64_t *basichash;
   uint64_t *hash;
   int32_t *used;
-#ifdef HAVE_OPENCL
-  void **gpu_mem;
-#endif
   // debugging helpers
   char **modname; 
   // profiling:
@@ -69,20 +66,13 @@ void dt_dev_pixelpipe_cache_fullhash(int imgid, const dt_iop_roi_t *roi, struct 
 uint64_t dt_dev_pixelpipe_cache_basichash_prior(int imgid, struct dt_dev_pixelpipe_t *pipe,
                                                 const struct dt_iop_module_t *const module);
 
-/** returns a float data buffer in 'data' for the given hash from the cache.
-  If the hash does not match any cache line, the line with lowest weight will be cleared and an empty buffer is returned.
+/** returns a float data buffer in 'data' for the given hash from the cache, dsc is updated too.
+  If the hash does not match any cache line, use an old buffer or allocate a fresh one.
+  The size of the buffer in 'data' will be at least of size bytes.
   Returned flag is TRUE for a new buffer
 */
 gboolean dt_dev_pixelpipe_cache_get(dt_dev_pixelpipe_cache_t *cache, const uint64_t basichash, const uint64_t hash,
-                               const size_t size, void **data, struct dt_iop_buffer_dsc_t **dsc, char *modname);
-
-gboolean dt_dev_pixelpipe_cache_get_important(dt_dev_pixelpipe_cache_t *cache, const uint64_t basichash,
-                                         const uint64_t hash, const size_t size,
-                                         void **data, struct dt_iop_buffer_dsc_t **dsc, char *modname);
-
-gboolean dt_dev_pixelpipe_cache_get_weighted(dt_dev_pixelpipe_cache_t *cache, const uint64_t basichash,
-                                        const uint64_t hash, const size_t size,
-                                        void **data, struct dt_iop_buffer_dsc_t **dsc, int weight, char *modname);
+                               const size_t size, void **data, struct dt_iop_buffer_dsc_t **dsc, char *modname, const gboolean important);
 
 /** test availability of a cache line without destroying another, if it is not found. */
 gboolean dt_dev_pixelpipe_cache_available(dt_dev_pixelpipe_cache_t *cache, const uint64_t hash);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -106,55 +106,55 @@ static char *_pipe_type_to_str(int pipe_type)
   return r;
 }
 
-int dt_dev_pixelpipe_init_export(dt_dev_pixelpipe_t *pipe, int32_t width, int32_t height, int levels,
+gboolean dt_dev_pixelpipe_init_export(dt_dev_pixelpipe_t *pipe, int32_t width, int32_t height, int levels,
                                  gboolean store_masks)
 {
-  const int res = dt_dev_pixelpipe_init_cached(pipe, sizeof(float) * 4 * width * height, 2, 0);
+  const gboolean res = dt_dev_pixelpipe_init_cached(pipe, sizeof(float) * 4 * width * height, 2, 0);
   pipe->type = DT_DEV_PIXELPIPE_EXPORT;
   pipe->levels = levels;
   pipe->store_all_raster_masks = store_masks;
   return res;
 }
 
-int dt_dev_pixelpipe_init_thumbnail(dt_dev_pixelpipe_t *pipe, int32_t width, int32_t height)
+gboolean dt_dev_pixelpipe_init_thumbnail(dt_dev_pixelpipe_t *pipe, int32_t width, int32_t height)
 {
-  const int res = dt_dev_pixelpipe_init_cached(pipe, sizeof(float) * 4 * width * height, 2, 0);
+  const gboolean res = dt_dev_pixelpipe_init_cached(pipe, sizeof(float) * 4 * width * height, 2, 0);
   pipe->type = DT_DEV_PIXELPIPE_THUMBNAIL;
   return res;
 }
 
-int dt_dev_pixelpipe_init_dummy(dt_dev_pixelpipe_t *pipe, int32_t width, int32_t height)
+gboolean dt_dev_pixelpipe_init_dummy(dt_dev_pixelpipe_t *pipe, int32_t width, int32_t height)
 {
-  const int res = dt_dev_pixelpipe_init_cached(pipe, sizeof(float) * 4 * width * height, 0, 0);
+  const gboolean res = dt_dev_pixelpipe_init_cached(pipe, sizeof(float) * 4 * width * height, 0, 0);
   pipe->type = DT_DEV_PIXELPIPE_THUMBNAIL;
   return res;
 }
 
-int dt_dev_pixelpipe_init_preview(dt_dev_pixelpipe_t *pipe)
+gboolean dt_dev_pixelpipe_init_preview(dt_dev_pixelpipe_t *pipe)
 {
   // don't know which buffer size we're going to need, set to 0 (will be alloced on demand)
-  const int res = dt_dev_pixelpipe_init_cached(pipe, 0, 32, dt_get_iopcache_mem() / 5lu);
+  const gboolean res = dt_dev_pixelpipe_init_cached(pipe, 0, 32, dt_get_iopcache_mem() / 5lu);
   pipe->type = DT_DEV_PIXELPIPE_PREVIEW;
   return res;
 }
 
-int dt_dev_pixelpipe_init_preview2(dt_dev_pixelpipe_t *pipe)
+gboolean dt_dev_pixelpipe_init_preview2(dt_dev_pixelpipe_t *pipe)
 {
   // don't know which buffer size we're going to need, set to 0 (will be alloced on demand)
-  const int res = dt_dev_pixelpipe_init_cached(pipe, 0, 5, 0);
+  const gboolean res = dt_dev_pixelpipe_init_cached(pipe, 0, 5, 0);
   pipe->type = DT_DEV_PIXELPIPE_PREVIEW2;
   return res;
 }
 
-int dt_dev_pixelpipe_init(dt_dev_pixelpipe_t *pipe)
+gboolean dt_dev_pixelpipe_init(dt_dev_pixelpipe_t *pipe)
 {
   // don't know which buffer size we're going to need, set to 0 (will be alloced on demand)
-  const int res = dt_dev_pixelpipe_init_cached(pipe, 0, 64, dt_get_iopcache_mem() * 4lu / 5lu);
+  const gboolean res = dt_dev_pixelpipe_init_cached(pipe, 0, 64, dt_get_iopcache_mem() * 4lu / 5lu);
   pipe->type = DT_DEV_PIXELPIPE_FULL;
   return res;
 }
 
-int dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe, size_t size, int32_t entries, size_t memlimit)
+gboolean dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe, size_t size, int32_t entries, size_t memlimit)
 {
   pipe->devid = -1;
   pipe->changed = DT_DEV_PIPE_UNCHANGED;
@@ -162,7 +162,6 @@ int dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe, size_t size, int32_t 
   pipe->processed_height = pipe->backbuf_height = pipe->iheight = 0;
   pipe->nodes = NULL;
   pipe->backbuf_size = size;
-  if(!dt_dev_pixelpipe_cache_init(&(pipe->cache), entries, pipe->backbuf_size, memlimit)) return 0;
   pipe->cache_obsolete = 0;
   pipe->backbuf = NULL;
   pipe->backbuf_scale = 0.0f;
@@ -198,7 +197,7 @@ int dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe, size_t size, int32_t 
   pipe->input_profile_info = NULL;
   pipe->output_profile_info = NULL;
 
-  return 1;
+  return dt_dev_pixelpipe_cache_init(&(pipe->cache), entries, size, memlimit);
 }
 
 void dt_dev_pixelpipe_set_input(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, float *input, int width, int height,
@@ -1139,7 +1138,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
     dt_print(DT_DEBUG_DEV, "[dt_dev_pixelpipe_process_rec] [%s], cache available for `%s' with hash %lu\n",
        _pipe_type_to_str(pipe->type), (module) ? module->so->op : "buffer", (long unsigned int)hash);
 
-    (void)dt_dev_pixelpipe_cache_get(&(pipe->cache), basichash, hash, bufsize, output, out_format, (module) ? module->so->op : NULL);
+    dt_dev_pixelpipe_cache_get(&(pipe->cache), basichash, hash, bufsize, output, out_format, (module) ? module->so->op : NULL, FALSE);
 
     if(dt_atomic_get_int(&pipe->shutdown))
       return 1;
@@ -1176,7 +1175,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
       {
         *output = pipe->input;
       }
-      else if(dt_dev_pixelpipe_cache_get(&(pipe->cache), basichash, hash, bufsize, output, out_format, NULL))
+      else if(dt_dev_pixelpipe_cache_get(&(pipe->cache), basichash, hash, bufsize, output, out_format, NULL, FALSE))
       {
         if(roi_in.scale == 1.0f)
         {
@@ -1278,10 +1277,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
     input_important |= check_module_now_important(pipe, module);
 
   important |= input_important;
-  if(important)
-    (void)dt_dev_pixelpipe_cache_get_important(&(pipe->cache), basichash, hash, bufsize, output, out_format, module ? module->so->op : NULL);
-  else
-    (void)dt_dev_pixelpipe_cache_get(&(pipe->cache), basichash, hash, bufsize, output, out_format, module ? module->so->op : NULL);
+  dt_dev_pixelpipe_cache_get(&(pipe->cache), basichash, hash, bufsize, output, out_format, module ? module->so->op : NULL, important);
 
   if(important && module)
     dt_print(DT_DEBUG_DEV, "[dev_pixelpipe] [%s] reserving high priority cacheline for `%s' (%luMB)\n",

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1966,7 +1966,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
   {
     // give the input buffer to the currently focused plugin more weight.
     // the user is likely to change that one soon, so keep it in cache.
-    dt_dev_pixelpipe_cache_reweight(&(pipe->cache), input, module->so->op);
+    dt_dev_pixelpipe_cache_reweight(&(pipe->cache), input);
   }
 
   // we check for an important hint after processing the module as we want to track a runtime hint too.

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -181,21 +181,21 @@ typedef struct dt_dev_pixelpipe_t
 struct dt_develop_t;
 
 // inits the pixelpipe with plain passthrough input/output and empty input and default caching settings.
-int dt_dev_pixelpipe_init(dt_dev_pixelpipe_t *pipe);
+gboolean dt_dev_pixelpipe_init(dt_dev_pixelpipe_t *pipe);
 // inits the preview pixelpipe with plain passthrough input/output and empty input and default caching
 // settings.
-int dt_dev_pixelpipe_init_preview(dt_dev_pixelpipe_t *pipe);
-int dt_dev_pixelpipe_init_preview2(dt_dev_pixelpipe_t *pipe);
+gboolean dt_dev_pixelpipe_init_preview(dt_dev_pixelpipe_t *pipe);
+gboolean dt_dev_pixelpipe_init_preview2(dt_dev_pixelpipe_t *pipe);
 // inits the pixelpipe with settings optimized for full-image export (no history stack cache)
-int dt_dev_pixelpipe_init_export(dt_dev_pixelpipe_t *pipe, int32_t width, int32_t height, int levels,
+gboolean dt_dev_pixelpipe_init_export(dt_dev_pixelpipe_t *pipe, int32_t width, int32_t height, int levels,
                                  gboolean store_masks);
 // inits the pixelpipe with settings optimized for thumbnail export (no history stack cache)
-int dt_dev_pixelpipe_init_thumbnail(dt_dev_pixelpipe_t *pipe, int32_t width, int32_t height);
+gboolean dt_dev_pixelpipe_init_thumbnail(dt_dev_pixelpipe_t *pipe, int32_t width, int32_t height);
 // inits all but the pixel caches, so you can't actually process an image (just get dimensions and
 // distortions)
-int dt_dev_pixelpipe_init_dummy(dt_dev_pixelpipe_t *pipe, int32_t width, int32_t height);
-// inits the pixelpipe with given cacheline size and number of entries.
-int dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe, size_t size, int32_t entries, size_t memlimit);
+gboolean dt_dev_pixelpipe_init_dummy(dt_dev_pixelpipe_t *pipe, int32_t width, int32_t height);
+// inits the pixelpipe with given cacheline size and number of entries. returns TRUE in case of sucess
+gboolean dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe, size_t size, int32_t entries, size_t memlimit);
 // constructs a new input buffer from given RGB float array.
 void dt_dev_pixelpipe_set_input(dt_dev_pixelpipe_t *pipe, struct dt_develop_t *dev, float *input, int width,
                                 int height, float iscale);


### PR DESCRIPTION
As mentioned in #12364 the used memory in the cache could grow substancially.
This was due to wrong arithmetics on size_t data.
One more problem related to cache memory was in `dt_get_iopcache_mem()`, it now takes the
limit to half of mipmap size.

`dt_dev_pixelpipe_init_cached()` and `dt_dev_pixelpipe_cache_init()` could have left not fully initialized
cache structs in cases of problems. Fixed now.

We now only have one function to get the cacheline, `dt_dev_pixelpipe_cache_get()`.
The new version takes an additional const gboolean argument `important`

The observed crashes in #12336 were very likely related to two problems:
  1. `_get_oldest_cacheline` could return a cacheline index of -1
  2. `_get_free_cacheline` could return a wrong cacheline because of bad testing while cleaning up memory
  3. Issue 2 was very unlikely to happen with CL enabled - only with "always syncing" or two consecutive syncing modules - so it was not observed.  

All `dt_dev_pixelpipe_init` variants return proper gbooleans.

Fixes #12364
Fixes #12336


I have tested here for some hours and could not get a single crash any more - with cl enabled or not.
