### PR TITLE
fix color filtering in Windows

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1381,7 +1381,7 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
         // test the "mask" case (used by filters)
         if(g_str_has_prefix(text, "0x"))
         {
-          const int val = strtol(&escaped_text[2], NULL, 16);
+          const int val = strtoll(&escaped_text[2], NULL, 16);
           const int colors_set = val & 0xFFF;
           const int colors_unset = (val & 0xFFF000) >> 12;
           const gboolean op = val & 0x80000000;

--- a/src/libs/filters/colors.c
+++ b/src/libs/filters/colors.c
@@ -40,7 +40,7 @@ static gboolean _colors_update(dt_lib_filtering_rule_t *rule);
 static int _get_mask(const char *text)
 {
   if(g_str_has_prefix(text, "0x"))
-    return strtol(&text[2], NULL, 16);
+    return strtoll(&text[2], NULL, 16);
   else
     return 0;
 }

--- a/src/libs/filters/filename.c
+++ b/src/libs/filters/filename.c
@@ -57,7 +57,7 @@ static void _filename_decode(const gchar *txt, gchar **name, gchar **ext)
   if(!txt || strlen(txt) == 0) return;
 
   // split the path to find filename and extension parts
-  gchar **elems = g_strsplit(txt, "/", -1);
+  gchar **elems = g_strsplit(txt, G_DIR_SEPARATOR_S, -1);
   const unsigned int size = g_strv_length(elems);
   if(size == 2)
   {


### PR DESCRIPTION
Fixes #12179, by using `strtoll()` instead of `strtol()`, which gives incorrect results in Windows, due to the different sizes of int types.
Also use the correct cross platform folder separator
