### PR TITLE
Fix copy of iop-order in merge mode.

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -770,6 +770,18 @@ gboolean dt_history_copy_and_paste_on_image(const int32_t imgid, const int32_t d
   if(copy_iop_order)
   {
     GList *iop_list = dt_ioppr_get_iop_order_list(imgid, FALSE);
+
+    // but we also want to keep the multi-instance on the destination if merge is active
+    if(merge)
+    {
+      GList *dest_iop_list = dt_ioppr_get_iop_order_list(dest_imgid, FALSE);
+      GList *mi_iop_list = dt_ioppr_extract_multi_instances_list(dest_iop_list);
+
+      if(mi_iop_list) dt_ioppr_merge_multi_instance_iop_order_list(iop_list, mi_iop_list);
+
+      g_list_free_full(dest_iop_list, g_free);
+      g_list_free_full(mi_iop_list, g_free);
+    }
     dt_ioppr_write_iop_order_list(iop_list, dest_imgid);
     g_list_free_full(iop_list, g_free);
   }

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -948,9 +948,11 @@ void dt_ioppr_change_iop_order(struct dt_develop_t *dev, const int32_t imgid, GL
 
   if(mi) iop_list = dt_ioppr_merge_multi_instance_iop_order_list(iop_list, mi);
 
+  g_list_free_full(mi, g_free);
+
   dt_dev_write_history(darktable.develop);
   dt_ioppr_write_iop_order(DT_IOP_ORDER_CUSTOM, iop_list, imgid);
-  g_list_free_full(iop_list, free);
+  g_list_free_full(iop_list, g_free);
 
   dt_ioppr_migrate_iop_order(darktable.develop, imgid);
 }

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -837,6 +837,7 @@ void dt_styles_apply_to_image(const char *name, const gboolean duplicate, const 
       dt_ioppr_write_iop_order_list(iop_list, newimgid);
       g_list_free_full(iop_list, g_free);
       g_list_free_full(img_iop_order_list, g_free);
+      g_list_free_full(mi, g_free);
     }
 
     dt_dev_read_history_ext(dev_dest, newimgid, TRUE);


### PR DESCRIPTION
When copying a single module instance into a destination having more than
one instance of the same module we want to keep the iop-order entries for
the multi-instance. Not doing so was letting the module without a proper
order into the pixelpipe and was producing a corrupted image.

Fixes #12346.