### PR TITLE
fix problems with widget visibility in QAP

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -2822,12 +2822,12 @@ static void _lookup_mapping_widget()
     _sc.element = darktable.control->element;
 }
 
-static gboolean _widget_invisible(GtkWidget *w)
+gboolean dt_action_widget_invisible(GtkWidget *w)
 {
   GtkWidget *p = gtk_widget_get_parent(w);
   GtkStyleContext *context = gtk_widget_get_style_context(p);
   return (!GTK_IS_WIDGET(w) || !gtk_widget_get_visible(w)
-          || (gtk_style_context_has_class(context, "plugin-ui-main") && !gtk_widget_get_visible(p)));
+          || (!gtk_style_context_has_class(context, "dt_plugin_ui_main") && !gtk_widget_get_visible(p)));
 }
 
 gboolean _shortcut_closest_match(GSequenceIter **current, dt_shortcut_t *s, gboolean *fully_matched, const dt_action_def_t *def, char **fb_log)
@@ -3070,7 +3070,7 @@ static float _process_action(dt_action_t *action, int instance,
     if(definition && definition->process
         && (action->type < DT_ACTION_TYPE_WIDGET
             || definition->no_widget
-            || (action_target && !_widget_invisible(action_target))))
+            || (action_target && !dt_action_widget_invisible(action_target))))
     {
       if(!isnan(move_size) &&
          (definition->elements[element].effects != dt_action_effect_value || effect != DT_ACTION_EFFECT_SET))

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -184,6 +184,9 @@ void dt_action_cleanup_instance_iop(dt_iop_module_t *module);
 // UX miscellaneous functions
 void dt_action_widget_toast(dt_action_t *action, GtkWidget *widget, const gchar *text);
 
+// check if widget intentionally hidden (to disable it)
+gboolean dt_action_widget_invisible(GtkWidget *w);
+
 // Get the speed multiplier for adjusting sliders and other widgets
 float dt_accel_get_speed_multiplier(GtkWidget *widget, guint state);
 

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2820,6 +2820,7 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(d->basic_btn, "button-press-event", G_CALLBACK(_manage_direct_basic_popup), self);
   g_signal_connect(d->basic_btn, "toggled", G_CALLBACK(_lib_modulegroups_toggle), self);
   gtk_widget_set_tooltip_text(d->basic_btn, _("quick access panel"));
+  dt_action_define(DT_ACTION(self), NULL, N_("quick access panel"), d->basic_btn, &dt_action_def_toggle);
   gtk_box_pack_start(GTK_BOX(d->hbox_groups), d->basic_btn, TRUE, TRUE, 0);
 
   d->vbox_basic = NULL;
@@ -2830,6 +2831,7 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(d->active_btn, "button-press-event", G_CALLBACK(_manage_direct_active_popup), self);
   g_signal_connect(d->active_btn, "toggled", G_CALLBACK(_lib_modulegroups_toggle), self);
   gtk_widget_set_tooltip_text(d->active_btn, _("show only active modules"));
+  dt_action_define(DT_ACTION(self), NULL, N_("active modules"), d->active_btn, &dt_action_def_toggle);
   gtk_box_pack_start(GTK_BOX(d->hbox_groups), d->active_btn, TRUE, TRUE, 0);
 
   // we load now the presets btn


### PR DESCRIPTION
When the Quick Access Panel is shown, selected widgets are moved from their original module UI into the QAP structure. Their current visibility and sensitivity are stored and they are forcibly shown, but made insensitive if the module had hidden them to make them inaccessible. When the QAP is torn down, all the widgets are put back into their correct places and their original visibility and sensitivity are restored.

This causes problems when their visibility changes during their stay in the QAP. For example, add "denoise (profiled)" _mode_ and _patch size_ widgets to the QAP. Change the _mode_ from nlm to wavelets. The _patch size_ widget is hidden directly by the module gui code (even though the QAP would have wanted to still show it, but only make it insensitive). Now when moving away from the QAP, the original visibility of patch size is restored, even though it should still be invisible in wavelets mode.

This PR gets rid of the hidden->insensitive transformation in QAP and makes sure the sensitivity of the original widget and parent are always synced with their QAP versions, so that gui code that hides/unhides the widget (either directly, or by hiding/show(all)ing its parent) has its intended effect and the visibility of all widgets is still correct after moving away from the QAP. This also correctly disables shortcuts for hidden widgets.

@AlicVB I understand the intend of the choice to have all widgets in QAP always visible to avoid confusion when a user adds one and nothing shows up because it is currently invisible. So I tried hard to replicate this behavior. However, forcing the widget to always be visible makes it impossible to monitor current gui code; gtk_widget_show doesn't trigger a signal if the widget was already shown (but insensitive). An alternative could be to put an indicator in the header, similar to the red warning triangle some modules use.