### PR TITLE
Remove mention of deactivated (deprecated) mailing list in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,5 @@ Wiki
 Mailing lists
 -------------
 
-* Users [[subscribe](mailto:darktable-user+subscribe@lists.darktable.org) | [archive](https://www.mail-archive.com/darktable-user@lists.darktable.org/)]
-* Developer [[subscribe](mailto:darktable-dev+subscribe@lists.darktable.org) | [archive](https://www.mail-archive.com/darktable-dev@lists.darktable.org/)]
-* CI (read-only, high traffic!) [[subscribe](mailto:darktable-ci+subscribe@lists.darktable.org) | [archive](https://www.mail-archive.com/darktable-ci@lists.darktable.org/)]
+* User's [[subscribe](mailto:darktable-user+subscribe@lists.darktable.org) | [archive](https://www.mail-archive.com/darktable-user@lists.darktable.org/)]
+* Developer's [[subscribe](mailto:darktable-dev+subscribe@lists.darktable.org) | [archive](https://www.mail-archive.com/darktable-dev@lists.darktable.org/)]


### PR DESCRIPTION
CI mailing list archive link is 404. Subscription to the list is working (so it's still configured on the server) and I've successfully subscribed to it, but I'm not seeing any traffic. So this list is definitely deactivated and there is no point in announcing it in the README.