### PR TITLE
scroll through presets using shortcut

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -362,9 +362,7 @@ static void _slider_zoom_toast(dt_bauhaus_widget_t *w)
 
   gchar *min_text = dt_bauhaus_slider_get_text(GTK_WIDGET(w), d->factor > 0 ? d->min : d->max);
   gchar *max_text = dt_bauhaus_slider_get_text(GTK_WIDGET(w), d->factor > 0 ? d->max : d->min);
-  gchar *text = g_strdup_printf(("\n[%s , %s]"), min_text, max_text);
-  dt_action_widget_toast(w->module, GTK_WIDGET(w), text);
-  g_free(text);
+  dt_action_widget_toast(w->module, GTK_WIDGET(w), "\n[%s , %s]", min_text, max_text);
   g_free(min_text);
   g_free(max_text);
 }
@@ -3427,9 +3425,7 @@ static float _action_process_combo(gpointer target, dt_action_element_t element,
       break;
     }
 
-    gchar *text = g_strdup_printf("\n%s", dt_bauhaus_combobox_get_text(widget));
-    dt_action_widget_toast(w->module, widget, text);
-    g_free(text);
+    dt_action_widget_toast(w->module, widget, "\n%s", dt_bauhaus_combobox_get_text(widget));
   }
 
   if(element == DT_ACTION_ELEMENT_BUTTON)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -3215,10 +3215,9 @@ static float _action_process(gpointer target, dt_action_element_t element, dt_ac
       }
     }
 
-    gchar *text = g_strdup_printf("%s, %s", dt_action_def_iop.elements[element].name,
-                                  dt_action_def_iop.elements[element].effects[effect]);
-    dt_action_widget_toast(target, NULL, text);
-    g_free(text);
+    dt_action_widget_toast(target, NULL, "%s, %s",
+                           dt_action_def_iop.elements[element].name,
+                           dt_action_def_iop.elements[element].effects[effect]);
   }
 
   return element == DT_ACTION_ELEMENT_FOCUS ? darktable.develop->gui_module == module

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -3199,12 +3199,20 @@ static float _action_process(gpointer target, dt_action_element_t element, dt_ac
       }
       break;
     case DT_ACTION_ELEMENT_PRESETS:
-      // FIXME
-      if(effect)
-        fprintf(stderr, "[imageop::_action_process] effects for presets not yet implemented\n");
-
-      if(module->presets_button) _presets_popup_callback(NULL, module);
-      break;
+      switch(effect)
+      {
+      case DT_ACTION_EFFECT_ACTIVATE:
+        if(module->presets_button) _presets_popup_callback(NULL, module);
+        break;
+      case DT_ACTION_EFFECT_NEXT:
+        move_size *= -1;
+      case DT_ACTION_EFFECT_PREVIOUS:
+        dt_gui_presets_apply_adjacent_preset(module, move_size);
+        return 0; // don't overwrite toast below
+      default:
+        fprintf(stderr, "[imageop::_action_process] effect %d for presets not yet implemented\n", effect);
+        break;
+      }
     }
 
     gchar *text = g_strdup_printf("%s, %s", dt_action_def_iop.elements[element].name,

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -3076,9 +3076,7 @@ static float _process_action(dt_action_t *action, int instance,
     }
     else if(owner->type == DT_ACTION_TYPE_IOP)
     {
-      gchar *text = g_strdup_printf("\napplying preset '%s'", action->label);
-      dt_action_widget_toast(action_target, NULL, text);
-      g_free(text);
+      dt_action_widget_toast(action_target, NULL, "\napplying preset '%s'", action->label);
 
       dt_gui_presets_apply_preset(action->label, action_target);
     }
@@ -4175,10 +4173,14 @@ void dt_action_rename_preset(dt_action_t *action, const gchar *old_name, const g
   }
 }
 
-void dt_action_widget_toast(dt_action_t *action, GtkWidget *widget, const gchar *text)
+void dt_action_widget_toast(dt_action_t *action, GtkWidget *widget, const gchar *msg, ...)
 {
   if(!darktable.gui->reset)
   {
+    va_list ap;
+    va_start(ap, msg);
+    char *text = g_strdup_vprintf(msg, ap);
+
     if(!action)
       action = g_hash_table_lookup(darktable.control->widgets, widget);
     if(action)
@@ -4215,6 +4217,9 @@ void dt_action_widget_toast(dt_action_t *action, GtkWidget *widget, const gchar 
     }
     else
       dt_toast_log("%s", text);
+
+    g_free(text);
+    va_end(ap);
   }
 }
 

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -3567,6 +3567,13 @@ static void _delay_for_double_triple(guint time, guint is_key)
          (is_key ? m->press >= _sc.press :
                    m->press == _sc.press && m->button == _sc.button && m->click >= _sc.click))
         break;
+
+      if(_sc.click && darktable.control->enable_fallbacks)
+      {
+        const dt_action_def_t *def = _action_find_definition(m->action);
+        if(def && def->fallbacks)
+          break;
+      }
     }
     if(!multi) passed_time += delay;
 

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -182,7 +182,7 @@ void dt_accel_connect_instance_iop(dt_iop_module_t *module);
 void dt_action_cleanup_instance_iop(dt_iop_module_t *module);
 
 // UX miscellaneous functions
-void dt_action_widget_toast(dt_action_t *action, GtkWidget *widget, const gchar *text);
+void dt_action_widget_toast(dt_action_t *action, GtkWidget *widget, const gchar *msg, ...);
 
 // Get the speed multiplier for adjusting sliders and other widgets
 float dt_accel_get_speed_multiplier(GtkWidget *widget, guint state);

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -925,6 +925,7 @@ void dt_gui_presets_apply_adjacent_preset(dt_iop_module_t *module, int direction
 {
   int writeprotect;
   gchar *name = _get_active_preset_name(module, &writeprotect);
+  gchar *extreme = direction < 0 ? _("(first)") : _("(last)");
 
   sqlite3_stmt *stmt;
   // clang-format off
@@ -949,11 +950,15 @@ void dt_gui_presets_apply_adjacent_preset(dt_iop_module_t *module, int direction
   {
     g_free(name);
     name = g_strdup((gchar *)sqlite3_column_text(stmt, 0));
-    dt_gui_presets_apply_preset(name, module);
+    extreme = "";
   }
   sqlite3_finalize(stmt);
 
-  dt_action_widget_toast(DT_ACTION(module), NULL, name ? name : _("no presets"));
+  if(!*extreme)
+    dt_gui_presets_apply_preset(name, module);
+
+  dt_action_widget_toast(DT_ACTION(module), NULL, _("preset %s\n%s"),
+                         extreme, name ? name : _("no presets"));
   g_free(name);
 }
 

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -921,6 +921,43 @@ void dt_gui_presets_apply_preset(const gchar* name, dt_iop_module_t *module)
   }
 }
 
+void dt_gui_presets_apply_adjacent_preset(dt_iop_module_t *module, int direction)
+{
+  int writeprotect;
+  gchar *name = _get_active_preset_name(module, &writeprotect);
+
+  sqlite3_stmt *stmt;
+  // clang-format off
+  gchar *query = g_strdup_printf("SELECT name"
+                                 " FROM data.presets"
+                                 " WHERE operation=?1 AND op_version=?2 AND"
+                                 "       (?3='' OR LOWER(name) %s LOWER(?3))"
+                                 " ORDER BY writeprotect %s, LOWER(name) %s"
+                                 " LIMIT ?4",
+                                 direction < 0 ? "<" : ">",
+                                 direction < 0 ? "ASC" : "DESC",
+                                 direction < 0 ? "DESC" : "ASC");
+  // clang-format on
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, module->op, -1, SQLITE_STATIC);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, module->version());
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 3, name ? name : "", -1, SQLITE_STATIC);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 4, abs(direction));
+  g_free(query);
+
+  while(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    g_free(name);
+    name = g_strdup((gchar *)sqlite3_column_text(stmt, 0));
+    dt_gui_presets_apply_preset(name, module);
+  }
+  sqlite3_finalize(stmt);
+
+  dt_action_widget_toast(DT_ACTION(module), NULL, name ? name : _("no presets"));
+  g_free(name);
+}
+
+
 static void _menuitem_pick_preset(GtkMenuItem *menuitem, dt_iop_module_t *module)
 {
   gchar *name = g_object_get_data(G_OBJECT(menuitem), "dt-preset-name");

--- a/src/gui/presets.h
+++ b/src/gui/presets.h
@@ -121,6 +121,9 @@ void dt_gui_favorite_presets_menu_show();
 /** apply a preset to the current module **/
 void dt_gui_presets_apply_preset(const gchar* name, dt_iop_module_t *module);
 
+/** apply next or previous preset to the current module **/
+void dt_gui_presets_apply_adjacent_preset(dt_iop_module_t *module, int direction);
+
 /** apply any auto presets that are appropriate for the current module **/
 gboolean dt_gui_presets_autoapply_for_module(dt_iop_module_t *module);
 


### PR DESCRIPTION
fixes #6651

In mapping mode, hover above the presets button of an iop header and press a key (or press a key and scroll if you have disabled fallbacks). Now pressing the key and scrolling moves through all the available presets for the module.

You can also explicitly, via the preferences/shortcuts dialog, assign buttons to the _previous_/_next_ effects of the _presets_ element of a module.