### PR TITLE
culling : force size recompute on init

### DIFF
--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -920,6 +920,7 @@ void dt_culling_init(dt_culling_t *table, int fallback_offset)
   table->navigate_inside_selection = FALSE;
   table->selection_sync = FALSE;
   table->zoom_ratio = IMG_TO_FIT;
+  table->view_width = 0; // in order to force a full redraw
 
   // reset remaining zooming values if any
   for(GList *l = table->list; l; l = g_list_next(l))


### PR DESCRIPTION
this fix #12406 

when reentering culling, we want to be sure the size are recomputed, as the last nb of images shown may be different.