### PR TITLE
code maintenance for detail mask code

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -258,7 +258,7 @@ static void _refine_with_detail_mask(struct dt_iop_module_t *self, struct dt_dev
   const int oheight = roi_out->height;
   if(info) fprintf(stderr, "[_refine_with_detail_mask] in module %s %ix%i --> %ix%i\n", self->op, iwidth, iheight, owidth, oheight);
 
-  const int bufsize = MAX(iwidth * iheight, owidth * oheight);
+  const size_t bufsize = (size_t)MAX(iwidth * iheight, owidth * oheight);
 
   tmp = dt_alloc_align_float(bufsize);
   lum = dt_alloc_align_float(bufsize);
@@ -275,16 +275,14 @@ static void _refine_with_detail_mask(struct dt_iop_module_t *self, struct dt_dev
 
   if(warp_mask == NULL) goto error;
 
-  const int msize = owidth * oheight;
+  const size_t msize = (size_t)owidth * oheight;
 #ifdef _OPENMP
   #pragma omp parallel for simd default(none) \
   dt_omp_firstprivate(mask, warp_mask, msize) \
   schedule(simd:static) aligned(mask, warp_mask : 64)
  #endif
-  for(int idx =0; idx < msize; idx++)
-  {
+  for(size_t idx =0; idx < msize; idx++)
     mask[idx] = mask[idx] * warp_mask[idx];
-  }
   dt_free_align(warp_mask);
 
   return;

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -437,8 +437,6 @@ void dt_masks_calc_rawdetail_mask(float *const src, float *const out, float *con
                                   const int height, const dt_aligned_pixel_t wb);
 void dt_masks_calc_detail_mask(float *const src, float *const out, float *const tmp, const int width, const int height, const float threshold, const gboolean detail);
 
-void dt_masks_blur_approx_weighed(float *const src, float *const out, float *const weight, const int width, const int height);
-
 /** the output data are blurred-val * gain and are clipped to be within 0 to clip
     The returned int might be used to expand the border as this depends on sigma */
 int dt_masks_blur_fast(float *const src, float *const out, const int width, const int height, const float sigma, const float gain, const float clip);


### PR DESCRIPTION
- underscore leading static functions
- using size_t instead of int for loop indexes or buff size
- getting rid of unused function code `void dt_masks_blur_approx_weighed()`