### PR TITLE
[CI] Fix macOS build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,7 +504,7 @@ jobs:
           brew update > /dev/null || true
           brew unlink python@3.8
           sudo rm '/usr/local/bin/2to3'
-          brew link --overwrite python@3.9 # workaround introduced 30.12.2020, replace asap.
+          # brew link --overwrite python@3.9 # workaround introduced 30.12.2020, replace asap.
           # brew upgrade --ignore-pinned # workaround introduced 18.07.2021, replace asap
           brew tap Homebrew/bundle
           cd src/.ci


### PR DESCRIPTION
I don't know exactly what problem this old workaround (fiddling with python versions) was solving and why it recently started generating an error. But it looks like it's pretty obvious from the CI log which command was causing CI to fail, so it's commented out. In any case, this is a fix that needs to be done. It remains to be hoped that this will be enough for normal work.