### PR TITLE
Update for pixelpipe cache size

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1363,7 +1363,6 @@ void dt_get_sysresource_level()
     fprintf(stderr,"  mipmap cache:    %luMB\n", _get_mipmap_size() / 1024lu / 1024lu);
     fprintf(stderr,"  available mem:   %luMB\n", dt_get_available_mem() / 1024lu / 1024lu);
     fprintf(stderr,"  singlebuff:      %luMB\n", dt_get_singlebuffer_mem() / 1024lu / 1024lu);
-    fprintf(stderr,"  iop cache:       %luMB\n", dt_get_iopcache_mem() / 1024lu / 1024lu);
 #ifdef HAVE_OPENCL
     fprintf(stderr,"  OpenCL tune mem: %s\n", ((tunecl & DT_OPENCL_TUNE_MEMSIZE) && (level >= 0)) ? "WANTED" : "OFF");
     fprintf(stderr,"  OpenCL pinned:   %s\n", ((tunecl & DT_OPENCL_TUNE_PINNED) && (level >= 0)) ? "WANTED" : "OFF");
@@ -1668,13 +1667,6 @@ size_t dt_get_singlebuffer_mem()
 
   const int fraction = res->fractions[res->group + 1];
   return MAX(2lu * 1024lu * 1024lu, total_mem / 1024lu * fraction);
-}
-
-size_t dt_get_iopcache_mem()
-{
-  // use ~half of mipmap size
-  const size_t cachemb = _get_mipmap_size() / 2048lu / 1024lu ;
-  return MIN(3000lu, MAX(300lu, cachemb)) * 1024lu * 1024lu;
 }
 
 void dt_configure_runtime_performance(const int old, char *info)

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -370,7 +370,6 @@ void dt_vprint(dt_debug_thread_t thread, const char *msg, ...) __attribute__((fo
 int dt_worker_threads();
 size_t dt_get_available_mem();
 size_t dt_get_singlebuffer_mem();
-size_t dt_get_iopcache_mem();
 
 void *dt_alloc_align(size_t alignment, size_t size);
 static inline void* dt_calloc_align(size_t alignment, size_t size)

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -146,7 +146,8 @@ gboolean dt_dev_pixelpipe_init_preview2(dt_dev_pixelpipe_t *pipe)
 
 gboolean dt_dev_pixelpipe_init(dt_dev_pixelpipe_t *pipe)
 {
-  const gboolean res = dt_dev_pixelpipe_init_cached(pipe, 0, 64, dt_get_iopcache_mem());
+  size_t csize = MAX(64*1024*1024, darktable.dtresources.mipmap_memory / 4);
+  const gboolean res = dt_dev_pixelpipe_init_cached(pipe, 0, 64, csize);
   pipe->type = DT_DEV_PIXELPIPE_FULL;
   return res;
 }


### PR DESCRIPTION
As there is only one pixelpipe (full) using a limit there is no need for a specific function telling the desired limit.

Also no need to report when starting as it's shown in every pixelpipe report.

For very small systems the hint for 300MB was too large, testing with a minimum size of 64MB on a mini system. Cache rate drops but working fully stable.

No change in cache managing code so an easy one :-)