### PR TITLE
Make darktable version string in the UI less transparent

### DIFF
--- a/src/libs/tools/darktable.c
+++ b/src/libs/tools/darktable.c
@@ -254,7 +254,7 @@ static gboolean _lib_darktable_draw_callback(GtkWidget *widget, cairo_t *cr, gpo
   pango_layout_set_font_description(layout, font_desc);
   pango_layout_set_text(layout, darktable_package_version, -1);
   cairo_move_to(cr, d->image_width + DT_PIXEL_APPLY_DPI(4.0), DT_PIXEL_APPLY_DPI(32.0));
-  cairo_set_source_rgba(cr, tmpcolor->red, tmpcolor->green, tmpcolor->blue, 0.3);
+  cairo_set_source_rgba(cr, tmpcolor->red, tmpcolor->green, tmpcolor->blue, 0.7);
   pango_cairo_show_layout(cr, layout);
 
   /* cleanup */


### PR DESCRIPTION
The darktable version string in the UI is so transparent it's almost unreadable. My eyes tire quickly when I try to read this.

For an ordinary user, this may not be so noticeable, because such a user does not often pay attention to this string. But when you often check the version (for example, test new development builds of darktable, or are a contributor), then this practical unreadability is annoying and tiring for the eyes.

This change sets the opacity of the version number string to the same value as the program name string just above it.
