### PR TITLE
Don't restore panels when toggling iso_12646 mode

### DIFF
--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -289,7 +289,7 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
     cairo_save(cri);
     // force middle grey in background
     if(dev->iso_12646.enabled)
-      cairo_set_source_rgb(cri, 0.5, 0.5, 0.5);
+      cairo_set_source_rgb(cri, 0.4663, 0.4663, 0.4663);
     else
       dt_gui_gtk_set_source_rgb(cri, DT_GUI_COLOR_DARKROOM_BG);
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -541,7 +541,7 @@ void expose(
     if(dev->iso_12646.enabled)
     {
       // draw the white frame around picture
-      const double tbw = (float)(tb >> closeup) * 2.0 / 2.5;  
+      const double tbw = (float)(tb >> closeup) * 2.0 / 3.0;  
       cairo_rectangle(cr, -tbw, -tbw, wd + 2.0 * tbw, ht + 2.0 * tbw);
       cairo_set_source_rgb(cr, 1., 1., 1.);
       cairo_fill(cr);
@@ -591,7 +591,7 @@ void expose(
     if(dev->iso_12646.enabled)
     {
       // draw the white frame around picture
-      const double tbw = (float)(tb >> closeup) / 2.5;
+      const double tbw = (float)(tb >> closeup) / 3.0;
       cairo_rectangle(cr, tbw, tbw, width - 2.0 * tbw, height - 2.0 * tbw);
       cairo_set_source_rgb(cr, 1., 1., 1.);
       cairo_fill(cr);
@@ -1493,8 +1493,7 @@ static int _iso_12646_get_border(dt_develop_t *d)
 {
   if(d->iso_12646.enabled)
   {
-    // normally the width is defined by dpi, reduced for small monitors or windows
-    return MIN(1.75 * darktable.gui->dpi, 0.4 * MIN(d->width, d->height));
+    return MIN(1.75 * darktable.gui->dpi, 0.3 * MIN(d->width, d->height));
   }
   else
   {

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -541,7 +541,8 @@ void expose(
     if(dev->iso_12646.enabled)
     {
       // draw the white frame around picture
-      cairo_rectangle(cr, -tb / 3., -tb / 3.0, wd + 2. * tb / 3., ht + 2. * tb / 3.);
+      const double tbw = (float)(tb >> closeup) / 3.0;  
+      cairo_rectangle(cr, -tbw, -tbw, wd + 2.0 * tbw, ht + 2.0 * tbw);
       cairo_set_source_rgb(cr, 1., 1., 1.);
       cairo_fill(cr);
     }
@@ -590,7 +591,8 @@ void expose(
     if(dev->iso_12646.enabled)
     {
       // draw the white frame around picture
-      cairo_rectangle(cr, 2 * tb / 3., 2 * tb / 3.0, width - 4. * tb / 3., height - 4. * tb / 3.);
+      const double tbw = (float)(tb >> closeup) / 3.0;  
+      cairo_rectangle(cr, 2.0 * tbw, 2.0 * tbw, width - 4.0 * tbw, height - 4.0 * tbw);
       cairo_set_source_rgb(cr, 1., 1., 1.);
       cairo_fill(cr);
     }
@@ -598,8 +600,7 @@ void expose(
     cairo_rectangle(cr, tb, tb, width-2*tb, height-2*tb);
     cairo_clip(cr);
     stride = cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, wd);
-    surface
-        = cairo_image_surface_create_for_data(dev->preview_pipe->output_backbuf, CAIRO_FORMAT_RGB24, wd, ht, stride);
+    surface = cairo_image_surface_create_for_data(dev->preview_pipe->output_backbuf, CAIRO_FORMAT_RGB24, wd, ht, stride);
     cairo_translate(cr, width / 2.0, height / 2.0f);
     cairo_scale(cr, zoom_scale, zoom_scale);
     cairo_translate(cr, -.5f * wd - zoom_x * wd, -.5f * ht - zoom_y * ht);
@@ -1499,7 +1500,7 @@ static void _iso_12646_quickbutton_clicked(GtkWidget *w, gpointer user_data)
 
   if(d->iso_12646.enabled)
   {
-    d->border_size = 0.125 * d->width;
+    d->border_size = 0.125 * MIN(d->width, d->height);
   }
   else
   {

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -541,7 +541,7 @@ void expose(
     if(dev->iso_12646.enabled)
     {
       // draw the white frame around picture
-      const double tbw = (float)(tb >> closeup) / 3.0;  
+      const double tbw = (float)(tb >> closeup) * 2.0 / 2.5;  
       cairo_rectangle(cr, -tbw, -tbw, wd + 2.0 * tbw, ht + 2.0 * tbw);
       cairo_set_source_rgb(cr, 1., 1., 1.);
       cairo_fill(cr);
@@ -591,8 +591,8 @@ void expose(
     if(dev->iso_12646.enabled)
     {
       // draw the white frame around picture
-      const double tbw = (float)(tb >> closeup) / 3.0;  
-      cairo_rectangle(cr, 2.0 * tbw, 2.0 * tbw, width - 4.0 * tbw, height - 4.0 * tbw);
+      const double tbw = (float)(tb >> closeup) / 2.5;
+      cairo_rectangle(cr, tbw, tbw, width - 2.0 * tbw, height - 2.0 * tbw);
       cairo_set_source_rgb(cr, 1., 1., 1.);
       cairo_fill(cr);
     }
@@ -1489,6 +1489,20 @@ static gboolean _toolbar_show_popup(gpointer user_data)
 }
 
 /* colour assessment */
+static int _iso_12646_get_border(dt_develop_t *d)
+{
+  if(d->iso_12646.enabled)
+  {
+    // normally the width is defined by dpi, reduced for small monitors or windows
+    return MIN(1.75 * darktable.gui->dpi, 0.4 * MIN(d->width, d->height));
+  }
+  else
+  {
+    // Reset border size from config
+    return DT_PIXEL_APPLY_DPI(dt_conf_get_int("plugins/darkroom/ui/border_size"));
+  }
+}
+
 static void _iso_12646_quickbutton_clicked(GtkWidget *w, gpointer user_data)
 {
   dt_develop_t *d = (dt_develop_t *)user_data;
@@ -1497,17 +1511,7 @@ static void _iso_12646_quickbutton_clicked(GtkWidget *w, gpointer user_data)
   d->iso_12646.enabled = !d->iso_12646.enabled;
   d->width = d->orig_width;
   d->height = d->orig_height;
-
-  if(d->iso_12646.enabled)
-  {
-    d->border_size = 0.125 * MIN(d->width, d->height);
-  }
-  else
-  {
-    // Reset border size from config
-    d->border_size = DT_PIXEL_APPLY_DPI(dt_conf_get_int("plugins/darkroom/ui/border_size"));
-  }
-
+  d->border_size = _iso_12646_get_border(d);
   dt_dev_configure(d, d->width, d->height);
 
   dt_dev_reprocess_center(d);
@@ -3844,6 +3848,7 @@ void configure(dt_view_t *self, int wd, int ht)
   dt_develop_t *dev = (dt_develop_t *)self->data;
   dev->orig_width = wd;
   dev->orig_height = ht;
+  dev->border_size = _iso_12646_get_border(dev);
   dt_dev_configure(dev, wd, ht);
 }
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1509,7 +1509,6 @@ static void _iso_12646_quickbutton_clicked(GtkWidget *w, gpointer user_data)
 
   dt_dev_configure(d, d->width, d->height);
 
-  dt_ui_restore_panels(darktable.gui->ui);
   dt_dev_reprocess_center(d);
 }
 


### PR DESCRIPTION
There seems to be no need to update the panel state after toggling of the iso_12646.enabled flag.

The issue in question was #12417 