### PR TITLE
Bugfix both overexposed indicators

### DIFF
--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -460,8 +460,8 @@ void cleanup_global(dt_iop_module_so_t *module)
 void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
-  if(pipe->type != DT_DEV_PIXELPIPE_FULL || !self->dev->overexposed.enabled || !self->dev->gui_attached)
-    piece->enabled = 0;
+  const gboolean fullpipe = (piece->pipe->type & DT_DEV_PIXELPIPE_FULL) == DT_DEV_PIXELPIPE_FULL;
+  piece->enabled = self->dev->overexposed.enabled && fullpipe && self->dev->gui_attached;
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -460,7 +460,7 @@ void cleanup_global(dt_iop_module_so_t *module)
 void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
-  const gboolean fullpipe = (piece->pipe->type & DT_DEV_PIXELPIPE_FULL) == DT_DEV_PIXELPIPE_FULL;
+  const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
   piece->enabled = self->dev->overexposed.enabled && fullpipe && self->dev->gui_attached;
 }
 

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -431,7 +431,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   dt_develop_t *dev = self->dev;
 
   const dt_image_t *const image = &(dev->image_storage);
-  const gboolean fullpipe = (piece->pipe->type & DT_DEV_PIXELPIPE_FULL) == DT_DEV_PIXELPIPE_FULL;
+  const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
   const gboolean sensorok = (image->flags & DT_IMAGE_4BAYER) == 0;
   
   piece->enabled = dev->rawoverexposed.enabled && fullpipe && dev->gui_attached && sensorok;

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -430,11 +430,11 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
 {
   dt_develop_t *dev = self->dev;
 
-  if(pipe->type != DT_DEV_PIXELPIPE_FULL || !dev->rawoverexposed.enabled || !dev->gui_attached) piece->enabled = 0;
-
   const dt_image_t *const image = &(dev->image_storage);
-
-  if(image->flags & DT_IMAGE_4BAYER) piece->enabled = 0;
+  const gboolean fullpipe = (piece->pipe->type & DT_DEV_PIXELPIPE_FULL) == DT_DEV_PIXELPIPE_FULL;
+  const gboolean sensorok = (image->flags & DT_IMAGE_4BAYER) == 0;
+  
+  piece->enabled = dev->rawoverexposed.enabled && fullpipe && dev->gui_attached && sensorok;
 
   if(image->buf_dsc.datatype != TYPE_UINT16 || !image->buf_dsc.filters) piece->enabled = 0;
 }


### PR DESCRIPTION
As reported in #12359 the overexposed visual is not always shown if activated.

This is due to improper testing for a full pixelpipe in both modules.

Fixes #12359