### PR TITLE
don't disable widgets in a collapsed section

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -937,8 +937,9 @@ float dt_bauhaus_slider_get_default(GtkWidget *widget)
 extern const dt_action_def_t dt_action_def_slider;
 extern const dt_action_def_t dt_action_def_combo;
 
-void dt_bauhaus_widget_set_label(GtkWidget *widget, const char *section, const char *label)
+dt_action_t *dt_bauhaus_widget_set_label(GtkWidget *widget, const char *section, const char *label)
 {
+  dt_action_t *ac = NULL;
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   memset(w->label, 0, sizeof(w->label)); // keep valgrind happy
   if(label) g_strlcpy(w->label, Q_(label), sizeof(w->label));
@@ -948,8 +949,8 @@ void dt_bauhaus_widget_set_label(GtkWidget *widget, const char *section, const c
   {
     if(!darktable.bauhaus->skip_accel || w->module->type != DT_ACTION_TYPE_IOP_INSTANCE)
     {
-      dt_action_t *ac = dt_action_define(w->module, section, label, widget,
-                                         w->type == DT_BAUHAUS_SLIDER ? &dt_action_def_slider : &dt_action_def_combo);
+      ac = dt_action_define(w->module, section, label, widget,
+                            w->type == DT_BAUHAUS_SLIDER ? &dt_action_def_slider : &dt_action_def_combo);
       if(w->module->type != DT_ACTION_TYPE_IOP_INSTANCE) w->module = ac;
     }
 
@@ -980,6 +981,7 @@ void dt_bauhaus_widget_set_label(GtkWidget *widget, const char *section, const c
 
     gtk_widget_queue_draw(GTK_WIDGET(w));
   }
+  return ac;
 }
 
 const char* dt_bauhaus_widget_get_label(GtkWidget *widget)
@@ -1221,8 +1223,8 @@ GtkWidget *dt_bauhaus_combobox_new_full(dt_action_t *action, const char *section
                                         int pos, GtkCallback callback, gpointer data, const char **texts)
 {
   GtkWidget *combo = dt_bauhaus_combobox_new_action(action);
-  dt_bauhaus_widget_set_label(combo, section, label);
-  dt_bauhaus_combobox_add_list(combo, (dt_action_t *)(DT_BAUHAUS_WIDGET(combo)->module), texts);
+  dt_action_t *ac = dt_bauhaus_widget_set_label(combo, section, label);
+  dt_bauhaus_combobox_add_list(combo, ac, texts);
   dt_bauhaus_combobox_set(combo, pos);
   gtk_widget_set_tooltip_text(combo, tip ? tip : _(label));
   if(callback) g_signal_connect(G_OBJECT(combo), "value-changed", G_CALLBACK(callback), data);

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -260,7 +260,7 @@ void dt_bauhaus_widget_set_section(GtkWidget *w, const gboolean is_section);
 
 // common functions:
 // set the label text:
-void dt_bauhaus_widget_set_label(GtkWidget *w, const char *section, const char *label);
+dt_action_t *dt_bauhaus_widget_set_label(GtkWidget *w, const char *section, const char *label);
 const char* dt_bauhaus_widget_get_label(GtkWidget *w);
 // attach a custom painted quad to the space at the right side (overwriting the default icon if any):
 void dt_bauhaus_widget_set_quad_paint(GtkWidget *w, dt_bauhaus_quad_paint_f f, int paint_flags, void *paint_data);

--- a/src/common/action.h
+++ b/src/common/action.h
@@ -32,6 +32,7 @@ typedef enum dt_action_type_t
   DT_ACTION_TYPE_SECTION,
   // ==== all above split off chains
   DT_ACTION_TYPE_IOP_INSTANCE,
+  DT_ACTION_TYPE_IOP_SECTION,
   DT_ACTION_TYPE_COMMAND,
   DT_ACTION_TYPE_PRESET,
   DT_ACTION_TYPE_FALLBACK,

--- a/src/common/introspection.h
+++ b/src/common/introspection.h
@@ -243,6 +243,7 @@ typedef struct dt_introspection_t
   dt_introspection_field_t           *field;           // the type of the params. should always be a DT_INTROSPECTION_TYPE_STRUCT
   size_t                              self_size;       // size of dt_iop_module_t. useful to not need dt headers
   size_t                              default_params;  // offset of the default_params in dt_iop_module_t. useful to not need dt headers
+  GHashTable                         *sections;        // section names associated with parameter offsets
 } dt_introspection_t;
 
 // clang-format on

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -59,8 +59,29 @@ static void _iop_toggle_callback(GtkWidget *togglebutton, dt_module_param_t *dat
   }
 }
 
+static gchar *_section_from_package(dt_iop_module_t **self)
+{
+  if((*self)->actions != DT_ACTION_TYPE_IOP_SECTION) return NULL;
+
+  dt_iop_module_section_t *package = (dt_iop_module_section_t *)*self;
+  *self = package->self;
+  return package->section;
+}
+
+static void _store_intro_section(const dt_introspection_field_t *f, gchar *section)
+{
+  if(section)
+  {
+    GHashTable **sections = &f->header.so->get_introspection()->sections;
+    if(!*sections) *sections = g_hash_table_new(NULL, NULL);
+    g_hash_table_insert(*sections, GINT_TO_POINTER(f->header.offset), section);
+  }
+}
+
 GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *param)
 {
+  gchar *section = _section_from_package(&self);
+
   dt_iop_params_t *p = (dt_iop_params_t *)self->params;
   dt_iop_params_t *d = (dt_iop_params_t *)self->default_params;
 
@@ -73,7 +94,7 @@ GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *para
   if(sscanf(param, "%[^[][%zu]", base_name, &param_index) == 2)
   {
     sprintf(param_name, "%s[0]", base_name);
-    skip_label = TRUE;
+    skip_label = !section;
   }
   else
   {
@@ -124,6 +145,7 @@ GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *para
   if(f)
   {
     dt_bauhaus_widget_set_field(slider, (uint8_t *)p + offset, f->header.type);
+    _store_intro_section(f, section);
 
     if(!skip_label)
     {
@@ -131,13 +153,13 @@ GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *para
       {
         // we do not want to support a context as it break all translations see #5498
         // dt_bauhaus_widget_set_label(slider, NULL, g_dpgettext2(NULL, "introspection description", f->header.description));
-        dt_bauhaus_widget_set_label(slider, NULL, f->header.description);
+        dt_bauhaus_widget_set_label(slider, section, f->header.description);
       }
       else
       {
         gchar *str = dt_util_str_replace(f->header.field_name, "_", " ");
 
-        dt_bauhaus_widget_set_label(slider,  NULL, str);
+        dt_bauhaus_widget_set_label(slider,  section, str);
 
         g_free(str);
       }
@@ -163,6 +185,8 @@ GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *para
 
 GtkWidget *dt_bauhaus_combobox_from_params(dt_iop_module_t *self, const char *param)
 {
+  gchar *section = _section_from_package(&self);
+
   dt_iop_params_t *p = (dt_iop_params_t *)self->params;
   dt_introspection_field_t *f = self->so->get_f(param);
 
@@ -175,21 +199,12 @@ GtkWidget *dt_bauhaus_combobox_from_params(dt_iop_module_t *self, const char *pa
             f->header.type == DT_INTROSPECTION_TYPE_BOOL ))
   {
     dt_bauhaus_widget_set_field(combobox, (uint8_t *)p + f->header.offset, f->header.type);
+    _store_intro_section(f, section);
 
-    if(*f->header.description)
-    {
-      // we do not want to support a context as it break all translations see #5498
-      // dt_bauhaus_widget_set_label(combobox, NULL, g_dpgettext2(NULL, "introspection description", f->header.description));
-      dt_bauhaus_widget_set_label(combobox, NULL, f->header.description);
-    }
-    else
-    {
-      str = dt_util_str_replace(f->header.field_name, "_", " ");
+    str = *f->header.description ? g_strdup(f->header.description)
+                                 : dt_util_str_replace(f->header.field_name, "_", " ");
 
-      dt_bauhaus_widget_set_label(combobox,  NULL, str);
-
-      g_free(str);
-    }
+    dt_action_t *action = dt_bauhaus_widget_set_label(combobox, section, str);
 
     if(f->header.type == DT_INTROSPECTION_TYPE_BOOL)
     {
@@ -206,7 +221,6 @@ GtkWidget *dt_bauhaus_combobox_from_params(dt_iop_module_t *self, const char *pa
           dt_bauhaus_combobox_add_full(combobox, gettext(iter->description), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, GINT_TO_POINTER(iter->value), NULL, TRUE);
       }
 
-      dt_action_t *action = dt_action_section(&self->so->actions, *f->header.description ? f->header.description : f->header.field_name);
       if(action && f->Enum.values)
         g_hash_table_insert(darktable.control->combo_introspection, action, f->Enum.values);
     }
@@ -215,10 +229,10 @@ GtkWidget *dt_bauhaus_combobox_from_params(dt_iop_module_t *self, const char *pa
   {
     str = g_strdup_printf("'%s' is not an enum/int/bool/combobox parameter", param);
 
-    dt_bauhaus_widget_set_label(combobox, NULL, str);
-
-    g_free(str);
+    dt_bauhaus_widget_set_label(combobox, section, str);
   }
+
+  g_free(str);
 
   if(!self->widget) self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
   gtk_box_pack_start(GTK_BOX(self->widget), combobox, FALSE, FALSE, 0);
@@ -228,6 +242,8 @@ GtkWidget *dt_bauhaus_combobox_from_params(dt_iop_module_t *self, const char *pa
 
 GtkWidget *dt_bauhaus_toggle_from_params(dt_iop_module_t *self, const char *param)
 {
+  gchar *section = _section_from_package(&self);
+
   dt_iop_params_t *p = (dt_iop_params_t *)self->params;
   dt_introspection_field_t *f = self->so->get_f(param);
 
@@ -251,7 +267,8 @@ GtkWidget *dt_bauhaus_toggle_from_params(dt_iop_module_t *self, const char *para
     module_param->param = (uint8_t *)p + f->header.offset;
     g_signal_connect_data(G_OBJECT(button), "toggled", G_CALLBACK(_iop_toggle_callback), module_param, (GClosureNotify)g_free, 0);
 
-    dt_action_define_iop(self, NULL, str, button, &dt_action_def_toggle);
+    _store_intro_section(f, section);
+    dt_action_define_iop(self, section, str, button, &dt_action_def_toggle);
   }
   else
   {

--- a/src/develop/imageop_gui.h
+++ b/src/develop/imageop_gui.h
@@ -26,6 +26,20 @@ GtkWidget *dt_bauhaus_combobox_from_params(dt_iop_module_t *self, const char *pa
 
 GtkWidget *dt_bauhaus_toggle_from_params(dt_iop_module_t *self, const char *param);
 
+typedef struct dt_iop_module_section_t
+{
+  dt_action_type_t actions; // !!! NEEDS to be FIRST (to be able to cast convert)
+  dt_iop_module_t *self;
+  gchar *section;
+} dt_iop_module_section_t;
+
+/*
+ * package dt_iop_module_t pointer and section name to pass to a _from_params function
+ * it will then create a widget action in a section, rather than top level in the module
+ */
+#define DT_IOP_SECTION_FOR_PARAMS(self, section) \
+    (dt_iop_module_t *)&(dt_iop_module_section_t){DT_ACTION_TYPE_IOP_SECTION, self, section}
+
 GtkWidget *dt_iop_togglebutton_new(dt_iop_module_t *self, const char *section, const gchar *label, const gchar *ctrl_label,
                                    GCallback callback, gboolean local, guint accel_key, GdkModifierType mods,
                                    DTGTKCairoPaintIconFunc paint, GtkWidget *box);

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -2847,9 +2847,9 @@ static void _lookup_mapping_widget()
 gboolean dt_action_widget_invisible(GtkWidget *w)
 {
   GtkWidget *p = gtk_widget_get_parent(w);
-  GtkStyleContext *context = gtk_widget_get_style_context(p);
-  return (!GTK_IS_WIDGET(w) || !gtk_widget_get_visible(w)
-          || (!gtk_style_context_has_class(context, "dt_plugin_ui_main") && !gtk_widget_get_visible(p)));
+  return (!GTK_IS_WIDGET(w) || !gtk_widget_get_visible(w) || (!gtk_widget_get_visible(p)
+          && strcmp(gtk_widget_get_name(p), "collapsible")
+          && !gtk_style_context_has_class(gtk_widget_get_style_context(p), "dt_plugin_ui_main")));
 }
 
 gboolean _shortcut_closest_match(GSequenceIter **current, dt_shortcut_t *s, gboolean *fully_matched, const dt_action_def_t *def, char **fb_log)

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3194,7 +3194,7 @@ void dt_gui_search_stop(GtkSearchEntry *entry, GtkWidget *widget)
   }
 }
 
-static void _coeffs_button_changed(GtkDarktableToggleButton *widget, gpointer user_data)
+static void _collapse_button_changed(GtkDarktableToggleButton *widget, gpointer user_data)
 {
   dt_gui_collapsible_section_t *cs = (dt_gui_collapsible_section_t *)user_data;
 
@@ -3205,7 +3205,7 @@ static void _coeffs_button_changed(GtkDarktableToggleButton *widget, gpointer us
   dt_conf_set_bool(cs->confname, active);
 }
 
-static void _coeffs_expander_click(GtkWidget *widget, GdkEventButton *e, gpointer user_data)
+static void _collapse_expander_click(GtkWidget *widget, GdkEventButton *e, gpointer user_data)
 {
   if(e->type == GDK_2BUTTON_PRESS || e->type == GDK_3BUTTON_PRESS) return;
 
@@ -3222,10 +3222,7 @@ void dt_gui_update_collapsible_section(dt_gui_collapsible_section_t *cs)
                                (active ? CPF_DIRECTION_DOWN : CPF_DIRECTION_LEFT), NULL);
   dtgtk_expander_set_expanded(DTGTK_EXPANDER(cs->expander), active);
 
-  if(active)
-    gtk_widget_show(GTK_WIDGET(cs->container));
-  else
-    gtk_widget_hide(GTK_WIDGET(cs->container));
+  gtk_widget_set_visible(GTK_WIDGET(cs->container), active);
 }
 
 void dt_gui_hide_collapsible_section(dt_gui_collapsible_section_t *cs)
@@ -3266,11 +3263,10 @@ void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
   gtk_widget_set_name(cs->expander, "collapse-block");
 
   g_signal_connect(G_OBJECT(cs->toggle), "toggled",
-                   G_CALLBACK(_coeffs_button_changed),  (gpointer)cs);
+                   G_CALLBACK(_collapse_button_changed), cs);
 
   g_signal_connect(G_OBJECT(header_evb), "button-release-event",
-                   G_CALLBACK(_coeffs_expander_click),
-                   (gpointer)cs);
+                   G_CALLBACK(_collapse_expander_click), cs);
 }
 
 // clang-format off

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -4089,7 +4089,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_widget_set_tooltip_text(g->csspot.expander, _("define a target chromaticity (hue and chroma) for a particular region of the image (the control sample), which you then match against the same target chromaticity in other images. the control sample can either be a critical part of your subject or a non-moving and consistently-lit surface over your series of images."));
 
-  DT_BAUHAUS_COMBOBOX_NEW_FULL(g->spot_mode, self, NULL, N_("spot mode"),
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(g->spot_mode, self, N_("mapping"), N_("spot mode"),
                                 _("\"correction\" automatically adjust the illuminant\n"
                                   "such that the input color is mapped to the target.\n"
                                   "\"measure\" simply shows how an input color is mapped by the CAT\n"
@@ -4102,7 +4102,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   gchar *label = N_("take channel mixing into account");
   g->use_mixing = gtk_check_button_new_with_label(_(label));
-  dt_action_define_iop(self, NULL, label, g->use_mixing, &dt_action_def_toggle);
+  dt_action_define_iop(self, N_("mapping"), label, g->use_mixing, &dt_action_def_toggle);
   gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->use_mixing))), PANGO_ELLIPSIZE_END);
   gtk_widget_set_tooltip_text(g->use_mixing,
                               _("compute the target by taking the channel mixing into account.\n"
@@ -4145,21 +4145,21 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(vvbox), g->target_spot, TRUE, TRUE, 0);
 
   g->lightness_spot = dt_bauhaus_slider_new_with_range(self, 0., LIGHTNESS_MAX, 0, 0, 1);
-  dt_bauhaus_widget_set_label(g->lightness_spot, NULL, N_("lightness"));
+  dt_bauhaus_widget_set_label(g->lightness_spot, N_("mapping"), N_("lightness"));
   dt_bauhaus_slider_set_format(g->lightness_spot, "%");
   dt_bauhaus_slider_set_default(g->lightness_spot, 50.f);
   gtk_box_pack_start(GTK_BOX(vvbox), GTK_WIDGET(g->lightness_spot), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->lightness_spot), "value-changed", G_CALLBACK(_spot_settings_changed_callback), self);
 
   g->hue_spot = dt_bauhaus_slider_new_with_range_and_feedback(self, 0., HUE_MAX, 0, 0, 1, 0);
-  dt_bauhaus_widget_set_label(g->hue_spot, NULL, N_("hue"));
+  dt_bauhaus_widget_set_label(g->hue_spot, N_("mapping"), N_("hue"));
   dt_bauhaus_slider_set_format(g->hue_spot, "°");
   dt_bauhaus_slider_set_default(g->hue_spot, 0.f);
   gtk_box_pack_start(GTK_BOX(vvbox), GTK_WIDGET(g->hue_spot), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->hue_spot), "value-changed", G_CALLBACK(_spot_settings_changed_callback), self);
 
   g->chroma_spot = dt_bauhaus_slider_new_with_range(self, 0., CHROMA_MAX, 0, 0, 1);
-  dt_bauhaus_widget_set_label(g->chroma_spot, NULL, N_("chroma"));
+  dt_bauhaus_widget_set_label(g->chroma_spot, N_("mapping"), N_("chroma"));
   dt_bauhaus_slider_set_default(g->chroma_spot, 0.f);
   gtk_box_pack_start(GTK_BOX(vvbox), GTK_WIDGET(g->chroma_spot), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->chroma_spot), "value-changed", G_CALLBACK(_spot_settings_changed_callback), self);
@@ -4188,7 +4188,8 @@ void gui_init(struct dt_iop_module_t *self)
   g->scale_##var##_G = second;                                                \
   g->scale_##var##_B = swap ? first : third;                                  \
                                                                               \
-  g->normalize_##short = dt_bauhaus_toggle_from_params(self, "normalize_" #short);
+  g->normalize_##short = dt_bauhaus_toggle_from_params                        \
+               (DT_IOP_SECTION_FOR_PARAMS(self, section), "normalize_" #short);
 
   NOTEBOOK_PAGE(red, R, N_("R"), N_("output R"), N_("red"), FALSE)
   NOTEBOOK_PAGE(green, G, N_("G"), N_("output G"), N_("green"), FALSE)
@@ -4220,7 +4221,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   GtkWidget *collapsible = GTK_WIDGET(g->cs.container);
 
-  DT_BAUHAUS_COMBOBOX_NEW_FULL(g->checkers_list, self, NULL, N_("chart"),
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(g->checkers_list, self, N_("calibrate"), N_("chart"),
                                 _("choose the vendor and the type of your chart"),
                                 0, checker_changed_callback, self,
                                 N_("Xrite ColorChecker 24 pre-2014"),
@@ -4231,7 +4232,7 @@ void gui_init(struct dt_iop_module_t *self)
                                 N_("Datacolor SpyderCheckr 48 post-2018"));
   gtk_box_pack_start(GTK_BOX(collapsible), GTK_WIDGET(g->checkers_list), TRUE, TRUE, 0);
 
-  DT_BAUHAUS_COMBOBOX_NEW_FULL(g->optimize, self, NULL, N_("optimize for"),
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(g->optimize, self, N_("calibrate"), N_("optimize for"),
                                 _("choose the colors that will be optimized with higher priority.\n"
                                   "neutral colors gives the lowest average delta E but a high maximum delta E\n"
                                   "saturated colors gives the lowest maximum delta E but a high average delta E\n"
@@ -4249,7 +4250,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(collapsible), GTK_WIDGET(g->optimize), TRUE, TRUE, 0);
 
   g->safety = dt_bauhaus_slider_new_with_range_and_feedback(self, 0., 1., 0, 0.5, 3, TRUE);
-  dt_bauhaus_widget_set_label(g->safety, NULL, N_("patch scale"));
+  dt_bauhaus_widget_set_label(g->safety, N_("calibrate"), N_("patch scale"));
   gtk_widget_set_tooltip_text(g->safety, _("reduce the radius of the patches to select the more or less central part.\n"
                                            "useful when the perspective correction is sloppy or\n"
                                            "the patches frame cast a shadows on the edges of the patch." ));
@@ -4263,16 +4264,19 @@ void gui_init(struct dt_iop_module_t *self)
   GtkWidget *toolbar = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_BAUHAUS_SPACE);
 
   g->button_commit = dtgtk_button_new(dtgtk_cairo_paint_check_mark, 0, NULL);
+  dt_action_define_iop(self, N_("calibrate"), N_("accept"), g->button_commit, &dt_action_def_button);
+  g_signal_connect(G_OBJECT(g->button_commit), "button-press-event", G_CALLBACK(commit_profile_callback), (gpointer)self);
   gtk_box_pack_end(GTK_BOX(toolbar), GTK_WIDGET(g->button_commit), FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(g->button_commit, _("accept the computed profile and set it in the module"));
-  g_signal_connect(G_OBJECT(g->button_commit), "button-press-event", G_CALLBACK(commit_profile_callback), (gpointer)self);
 
   g->button_profile = dtgtk_button_new(dtgtk_cairo_paint_refresh, 0, NULL);
+  dt_action_define_iop(self, N_("calibrate"), N_("recompute"), g->button_profile, &dt_action_def_button);
   g_signal_connect(G_OBJECT(g->button_profile), "button-press-event", G_CALLBACK(run_profile_callback), (gpointer)self);
   gtk_widget_set_tooltip_text(g->button_profile, _("recompute the profile"));
   gtk_box_pack_end(GTK_BOX(toolbar), GTK_WIDGET(g->button_profile), FALSE, FALSE, 0);
 
   g->button_validate = dtgtk_button_new(dtgtk_cairo_paint_softproof, 0, NULL);
+  dt_action_define_iop(self, N_("calibrate"), N_("validate"), g->button_validate, &dt_action_def_button);
   g_signal_connect(G_OBJECT(g->button_validate), "button-press-event", G_CALLBACK(run_validation_callback), (gpointer)self);
   gtk_widget_set_tooltip_text(g->button_validate, _("check the output delta E"));
   gtk_box_pack_end(GTK_BOX(toolbar), GTK_WIDGET(g->button_validate), FALSE, FALSE, 0);

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -63,36 +63,36 @@ typedef enum dt_iop_colorbalancrgb_saturation_t
 typedef struct dt_iop_colorbalancergb_params_t
 {
   /* params of v1 */
-  float shadows_Y;             // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "lift luminance"
-  float shadows_C;             // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "lift chroma"
-  float shadows_H;             // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "lift hue"
-  float midtones_Y;            // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "power luminance"
-  float midtones_C;            // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "power chroma"
-  float midtones_H;            // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "power hue"
-  float highlights_Y;          // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "gain luminance"
-  float highlights_C;          // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "gain chroma"
-  float highlights_H;          // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "gain hue"
-  float global_Y;              // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "offset luminance"
-  float global_C;              // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "offset chroma"
-  float global_H;              // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "offset hue"
+  float shadows_Y;             // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
+  float shadows_C;             // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
+  float shadows_H;             // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
+  float midtones_Y;            // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
+  float midtones_C;            // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
+  float midtones_H;            // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
+  float highlights_Y;          // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
+  float highlights_C;          // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
+  float highlights_H;          // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
+  float global_Y;              // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
+  float global_C;              // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
+  float global_H;              // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
   float shadows_weight;        // $MIN:  0.0 $MAX:   3.0 $DEFAULT: 1.0 $DESCRIPTION: "shadows fall-off"
   float white_fulcrum;         // $MIN: -16.0 $MAX: 16.0 $DEFAULT: 0.0 $DESCRIPTION: "white fulcrum"
   float highlights_weight;     // $MIN:  0.0 $MAX:   3.0 $DEFAULT: 1.0 $DESCRIPTION: "highlights fall-off"
-  float chroma_shadows;        // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma shadows"
-  float chroma_highlights;     // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma highlights"
-  float chroma_global;         // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma global"
-  float chroma_midtones;       // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma mid-tones"
-  float saturation_global;     // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "saturation global"
-  float saturation_highlights; // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "saturation highlights"
-  float saturation_midtones;   // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "saturation mid-tones"
-  float saturation_shadows;    // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "saturation shadows"
+  float chroma_shadows;        // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "shadows"
+  float chroma_highlights;     // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "highlights"
+  float chroma_global;         // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "global chroma"
+  float chroma_midtones;       // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "mid-tones"
+  float saturation_global;     // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "global saturation"
+  float saturation_highlights; // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "highlights"
+  float saturation_midtones;   // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "mid-tones"
+  float saturation_shadows;    // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "shadows"
   float hue_angle;             // $MIN: -180. $MAX: 180. $DEFAULT: 0.0 $DESCRIPTION: "hue shift"
 
   /* params of v2 */
-  float brilliance_global;     // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "brilliance global"
-  float brilliance_highlights; // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "brilliance highlights"
-  float brilliance_midtones;   // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "brilliance mid-tones"
-  float brilliance_shadows;    // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "brilliance shadows"
+  float brilliance_global;     // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "global brilliance"
+  float brilliance_highlights; // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "highlights"
+  float brilliance_midtones;   // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "mid-tones"
+  float brilliance_shadows;    // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "shadows"
 
   /* params of v3 */
   float mask_grey_fulcrum;     // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.1845 $DESCRIPTION: "mask middle-gray fulcrum"
@@ -552,7 +552,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       = dt_ioppr_get_pipe_current_profile_info(self, piece->pipe);
   if(work_profile == NULL) return; // no point
 
-  self->cache_next_important = TRUE; // The cpu code is pretty heavy stuff so an importance hint 
+  self->cache_next_important = TRUE; // The cpu code is pretty heavy stuff so an importance hint
 
   // work profile can't be fetched in commit_params since it is not yet initialised
   // work_profile->matrix_in === RGB_to_XYZ
@@ -1883,6 +1883,7 @@ void gui_init(dt_iop_module_t *self)
 {
   dt_iop_colorbalancergb_gui_data_t *g = IOP_GUI_ALLOC(colorbalancergb);
   g->mask_display = FALSE;
+  dt_iop_module_t *sect = NULL;
 
   // start building top level widget
   static dt_action_def_t notebook_def = { };
@@ -1908,9 +1909,8 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->contrast, "%");
   gtk_widget_set_tooltip_text(g->contrast, _("increase the contrast at constant chromaticity"));
 
-  ++darktable.bauhaus->skip_accel;
-
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("linear chroma grading")), FALSE, FALSE, 0);
+  sect = DT_IOP_SECTION_FOR_PARAMS(self, N_("chroma"));
 
   g->chroma_global = dt_bauhaus_slider_from_params(self, "chroma_global");
   dt_bauhaus_slider_set_soft_range(g->chroma_global, -0.5, 0.5);
@@ -1918,61 +1918,63 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->chroma_global, "%");
   gtk_widget_set_tooltip_text(g->chroma_global, _("increase colorfulness at same luminance globally"));
 
-  g->chroma_shadows = dt_bauhaus_slider_from_params(self, "chroma_shadows");
+  g->chroma_shadows = dt_bauhaus_slider_from_params(sect, "chroma_shadows");
   dt_bauhaus_slider_set_digits(g->chroma_shadows, 4);
   dt_bauhaus_slider_set_format(g->chroma_shadows, "%");
   gtk_widget_set_tooltip_text(g->chroma_shadows, _("increase colorfulness at same luminance mostly in shadows"));
 
-  g->chroma_midtones = dt_bauhaus_slider_from_params(self, "chroma_midtones");
+  g->chroma_midtones = dt_bauhaus_slider_from_params(sect, "chroma_midtones");
   dt_bauhaus_slider_set_digits(g->chroma_midtones, 4);
   dt_bauhaus_slider_set_format(g->chroma_midtones, "%");
   gtk_widget_set_tooltip_text(g->chroma_midtones, _("increase colorfulness at same luminance mostly in mid-tones"));
 
-  g->chroma_highlights = dt_bauhaus_slider_from_params(self, "chroma_highlights");
+  g->chroma_highlights = dt_bauhaus_slider_from_params(sect, "chroma_highlights");
   dt_bauhaus_slider_set_digits(g->chroma_highlights, 4);
   dt_bauhaus_slider_set_format(g->chroma_highlights, "%");
   gtk_widget_set_tooltip_text(g->chroma_highlights, _("increase colorfulness at same luminance mostly in highlights"));
 
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("perceptual saturation grading")), FALSE, FALSE, 0);
+  sect = DT_IOP_SECTION_FOR_PARAMS(self, N_("saturation"));
 
   g->saturation_global = dt_bauhaus_slider_from_params(self, "saturation_global");
   dt_bauhaus_slider_set_digits(g->saturation_global, 4);
   dt_bauhaus_slider_set_format(g->saturation_global, "%");
   gtk_widget_set_tooltip_text(g->saturation_global, _("add or remove saturation by an absolute amount"));
 
-  g->saturation_shadows = dt_bauhaus_slider_from_params(self, "saturation_shadows");
+  g->saturation_shadows = dt_bauhaus_slider_from_params(sect, "saturation_shadows");
   dt_bauhaus_slider_set_digits(g->saturation_shadows, 4);
   dt_bauhaus_slider_set_format(g->saturation_shadows, "%");
   gtk_widget_set_tooltip_text(g->saturation_shadows, _("increase or decrease saturation proportionally to the original pixel saturation"));
 
-  g->saturation_midtones= dt_bauhaus_slider_from_params(self, "saturation_midtones");
+  g->saturation_midtones= dt_bauhaus_slider_from_params(sect, "saturation_midtones");
   dt_bauhaus_slider_set_digits(g->saturation_midtones, 4);
   dt_bauhaus_slider_set_format(g->saturation_midtones, "%");
   gtk_widget_set_tooltip_text(g->saturation_midtones, _("increase or decrease saturation proportionally to the original pixel saturation"));
 
-  g->saturation_highlights = dt_bauhaus_slider_from_params(self, "saturation_highlights");
+  g->saturation_highlights = dt_bauhaus_slider_from_params(sect, "saturation_highlights");
   dt_bauhaus_slider_set_digits(g->saturation_highlights, 4);
   dt_bauhaus_slider_set_format(g->saturation_highlights, "%");
   gtk_widget_set_tooltip_text(g->saturation_highlights, _("increase or decrease saturation proportionally to the original pixel saturation"));
 
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("perceptual brilliance grading")), FALSE, FALSE, 0);
+  sect = DT_IOP_SECTION_FOR_PARAMS(self, N_("brilliance"));
 
   g->brilliance_global = dt_bauhaus_slider_from_params(self, "brilliance_global");
   dt_bauhaus_slider_set_digits(g->brilliance_global, 4);
   dt_bauhaus_slider_set_format(g->brilliance_global, "%");
   gtk_widget_set_tooltip_text(g->brilliance_global, _("add or remove brilliance by an absolute amount"));
 
-  g->brilliance_shadows = dt_bauhaus_slider_from_params(self, "brilliance_shadows");
+  g->brilliance_shadows = dt_bauhaus_slider_from_params(sect, "brilliance_shadows");
   dt_bauhaus_slider_set_digits(g->brilliance_shadows, 4);
   dt_bauhaus_slider_set_format(g->brilliance_shadows, "%");
   gtk_widget_set_tooltip_text(g->brilliance_shadows, _("increase or decrease brilliance proportionally to the original pixel brilliance"));
 
-  g->brilliance_midtones= dt_bauhaus_slider_from_params(self, "brilliance_midtones");
+  g->brilliance_midtones= dt_bauhaus_slider_from_params(sect, "brilliance_midtones");
   dt_bauhaus_slider_set_digits(g->brilliance_midtones, 4);
   dt_bauhaus_slider_set_format(g->brilliance_midtones, "%");
   gtk_widget_set_tooltip_text(g->brilliance_midtones, _("increase or decrease brilliance proportionally to the original pixel brilliance"));
 
-  g->brilliance_highlights = dt_bauhaus_slider_from_params(self, "brilliance_highlights");
+  g->brilliance_highlights = dt_bauhaus_slider_from_params(sect, "brilliance_highlights");
   dt_bauhaus_slider_set_digits(g->brilliance_highlights, 4);
   dt_bauhaus_slider_set_format(g->brilliance_highlights, "%");
   gtk_widget_set_tooltip_text(g->brilliance_highlights, _("increase or decrease brilliance proportionally to the original pixel brilliance"));
@@ -1981,82 +1983,84 @@ void gui_init(dt_iop_module_t *self)
   self->widget = dt_ui_notebook_page(g->notebook, N_("4 ways"), _("selective color grading"));
 
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("global offset")), FALSE, FALSE, 0);
+  sect = DT_IOP_SECTION_FOR_PARAMS(self, N_("offset"));
 
-  g->global_Y = dt_bauhaus_slider_from_params(self, "global_Y");
+  g->global_Y = dt_bauhaus_slider_from_params(sect, "global_Y");
   dt_bauhaus_slider_set_soft_range(g->global_Y, -0.05, 0.05);
   dt_bauhaus_slider_set_digits(g->global_Y, 4);
   dt_bauhaus_slider_set_format(g->global_Y, "%");
   gtk_widget_set_tooltip_text(g->global_Y, _("global luminance offset"));
 
-  g->global_H = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "global_H"));
+  g->global_H = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(sect, "global_H"));
   dt_bauhaus_slider_set_feedback(g->global_H, 0);
   dt_bauhaus_slider_set_format(g->global_H, "°");
   gtk_widget_set_tooltip_text(g->global_H, _("hue of the global color offset"));
 
-  g->global_C = dt_bauhaus_slider_from_params(self, "global_C");
+  g->global_C = dt_bauhaus_slider_from_params(sect, "global_C");
   dt_bauhaus_slider_set_soft_range(g->global_C, 0., 0.01);
   dt_bauhaus_slider_set_digits(g->global_C, 4);
   dt_bauhaus_slider_set_format(g->global_C, "%");
   gtk_widget_set_tooltip_text(g->global_C, _("chroma of the global color offset"));
 
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("shadows lift")), FALSE, FALSE, 0);
+  sect = DT_IOP_SECTION_FOR_PARAMS(self, N_("lift"));
 
-  g->shadows_Y = dt_bauhaus_slider_from_params(self, "shadows_Y");
+  g->shadows_Y = dt_bauhaus_slider_from_params(sect, "shadows_Y");
   dt_bauhaus_slider_set_soft_range(g->shadows_Y, -1.0, 1.0);
   dt_bauhaus_slider_set_digits(g->shadows_Y, 4);
   dt_bauhaus_slider_set_format(g->shadows_Y, "%");
   gtk_widget_set_tooltip_text(g->shadows_Y, _("luminance gain in shadows"));
 
-  g->shadows_H = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "shadows_H"));
+  g->shadows_H = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(sect, "shadows_H"));
   dt_bauhaus_slider_set_feedback(g->shadows_H, 0);
   dt_bauhaus_slider_set_format(g->shadows_H, "°");
   gtk_widget_set_tooltip_text(g->shadows_H, _("hue of the color gain in shadows"));
 
-  g->shadows_C = dt_bauhaus_slider_from_params(self, "shadows_C");
+  g->shadows_C = dt_bauhaus_slider_from_params(sect, "shadows_C");
   dt_bauhaus_slider_set_soft_range(g->shadows_C, 0., 0.5);
   dt_bauhaus_slider_set_digits(g->shadows_C, 4);
   dt_bauhaus_slider_set_format(g->shadows_C, "%");
   gtk_widget_set_tooltip_text(g->shadows_C, _("chroma of the color gain in shadows"));
 
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("highlights gain")), FALSE, FALSE, 0);
+  sect = DT_IOP_SECTION_FOR_PARAMS(self, N_("gain"));
 
-  g->highlights_Y = dt_bauhaus_slider_from_params(self, "highlights_Y");
+  g->highlights_Y = dt_bauhaus_slider_from_params(sect, "highlights_Y");
   dt_bauhaus_slider_set_soft_range(g->highlights_Y, -0.5, 0.5);
   dt_bauhaus_slider_set_digits(g->highlights_Y, 4);
   dt_bauhaus_slider_set_format(g->highlights_Y, "%");
   gtk_widget_set_tooltip_text(g->highlights_Y, _("luminance gain in highlights"));
 
-  g->highlights_H = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "highlights_H"));
+  g->highlights_H = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(sect, "highlights_H"));
   dt_bauhaus_slider_set_feedback(g->highlights_H, 0);
   dt_bauhaus_slider_set_format(g->highlights_H, "°");
   gtk_widget_set_tooltip_text(g->highlights_H, _("hue of the color gain in highlights"));
 
-  g->highlights_C = dt_bauhaus_slider_from_params(self, "highlights_C");
+  g->highlights_C = dt_bauhaus_slider_from_params(sect, "highlights_C");
   dt_bauhaus_slider_set_soft_range(g->highlights_C, 0., 0.2);
   dt_bauhaus_slider_set_digits(g->highlights_C, 4);
   dt_bauhaus_slider_set_format(g->highlights_C, "%");
   gtk_widget_set_tooltip_text(g->highlights_C, _("chroma of the color gain in highlights"));
 
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("power")), FALSE, FALSE, 0);
+  sect = DT_IOP_SECTION_FOR_PARAMS(self, N_("power"));
 
-  g->midtones_Y = dt_bauhaus_slider_from_params(self, "midtones_Y");
+  g->midtones_Y = dt_bauhaus_slider_from_params(sect, "midtones_Y");
   dt_bauhaus_slider_set_soft_range(g->midtones_Y, -0.25, 0.25);
   dt_bauhaus_slider_set_digits(g->midtones_Y, 4);
   dt_bauhaus_slider_set_format(g->midtones_Y, "%");
   gtk_widget_set_tooltip_text(g->midtones_Y, _("luminance exponent in mid-tones"));
 
-  g->midtones_H = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "midtones_H"));
+  g->midtones_H = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(sect, "midtones_H"));
   dt_bauhaus_slider_set_feedback(g->midtones_H, 0);
   dt_bauhaus_slider_set_format(g->midtones_H, "°");
   gtk_widget_set_tooltip_text(g->midtones_H, _("hue of the color exponent in mid-tones"));
 
-  g->midtones_C = dt_bauhaus_slider_from_params(self, "midtones_C");
+  g->midtones_C = dt_bauhaus_slider_from_params(sect, "midtones_C");
   dt_bauhaus_slider_set_soft_range(g->midtones_C, 0., 0.1);
   dt_bauhaus_slider_set_digits(g->midtones_C, 4);
   dt_bauhaus_slider_set_format(g->midtones_C, "%");
   gtk_widget_set_tooltip_text(g->midtones_C, _("chroma of the color exponent in mid-tones"));
-
-  --darktable.bauhaus->skip_accel;
 
   // Page masks
   self->widget = dt_ui_notebook_page(g->notebook, N_("masks"), _("isolate luminances"));
@@ -2138,32 +2142,6 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->checker_size,  NULL, _("checkerboard size"));
   g_signal_connect(G_OBJECT(g->checker_size), "value-changed", G_CALLBACK(checker_size_callback), self);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->checker_size), FALSE, FALSE, 0);
-
-  dt_bauhaus_widget_set_label(g->shadows_H, N_("lift"), N_("hue"));
-  dt_bauhaus_widget_set_label(g->midtones_H, N_("power"), N_("hue"));
-  dt_bauhaus_widget_set_label(g->highlights_H, N_("gain"), N_("hue"));
-  dt_bauhaus_widget_set_label(g->global_H, N_("offset"), N_("hue"));
-  dt_bauhaus_widget_set_label(g->shadows_C, N_("lift"), N_("chroma"));
-  dt_bauhaus_widget_set_label(g->midtones_C, N_("power"), N_("chroma"));
-  dt_bauhaus_widget_set_label(g->highlights_C, N_("gain"), N_("chroma"));
-  dt_bauhaus_widget_set_label(g->global_C, N_("offset"), N_("chroma"));
-  dt_bauhaus_widget_set_label(g->shadows_Y, N_("lift"), N_("luminance"));
-  dt_bauhaus_widget_set_label(g->midtones_Y, N_("power"), N_("luminance"));
-  dt_bauhaus_widget_set_label(g->highlights_Y, N_("gain"), N_("luminance"));
-  dt_bauhaus_widget_set_label(g->global_Y, N_("offset"), N_("luminance"));
-
-  dt_bauhaus_widget_set_label(g->chroma_global, NULL, N_("global chroma"));
-  dt_bauhaus_widget_set_label(g->chroma_highlights, N_("chroma"), N_("highlights"));
-  dt_bauhaus_widget_set_label(g->chroma_midtones, N_("chroma"), N_("mid-tones"));
-  dt_bauhaus_widget_set_label(g->chroma_shadows, N_("chroma"), N_("shadows"));
-  dt_bauhaus_widget_set_label(g->saturation_global, NULL, N_("global saturation"));
-  dt_bauhaus_widget_set_label(g->saturation_highlights, N_("saturation"), N_("highlights"));
-  dt_bauhaus_widget_set_label(g->saturation_midtones, N_("saturation"), N_("mid-tones"));
-  dt_bauhaus_widget_set_label(g->saturation_shadows, N_("saturation"), N_("shadows"));
-  dt_bauhaus_widget_set_label(g->brilliance_global, NULL, N_("global brilliance"));
-  dt_bauhaus_widget_set_label(g->brilliance_highlights, N_("brilliance"), N_("highlights"));
-  dt_bauhaus_widget_set_label(g->brilliance_midtones, N_("brilliance"), N_("mid-tones"));
-  dt_bauhaus_widget_set_label(g->brilliance_shadows, N_("brilliance"), N_("shadows"));
 
   // Init the conf keys if they don't exist
   if(!dt_conf_key_exists("plugins/darkroom/colorbalancergb/checker1/red"))

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -468,7 +468,6 @@ static inline void gui_init_section(struct dt_iop_module_t *self, char *section,
 
   gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, FALSE, 0);
 
-  dt_bauhaus_widget_set_label(hue, section, N_("hue"));
   dt_bauhaus_slider_set_feedback(hue, 0);
   dt_bauhaus_slider_set_stop(hue, 0.0f  , 1.0f, 0.0f, 0.0f);
   dt_bauhaus_slider_set_stop(hue, 0.166f, 1.0f, 1.0f, 0.0f);
@@ -480,7 +479,6 @@ static inline void gui_init_section(struct dt_iop_module_t *self, char *section,
   gtk_widget_set_tooltip_text(hue, _("select the hue tone"));
   dt_color_picker_new(self, DT_COLOR_PICKER_POINT, hue);
 
-  dt_bauhaus_widget_set_label(saturation, section, N_("saturation"));
   dt_bauhaus_slider_set_stop(saturation, 0.0f, 0.2f, 0.2f, 0.2f);
   dt_bauhaus_slider_set_stop(saturation, 1.0f, 1.0f, 1.0f, 1.0f);
   gtk_widget_set_tooltip_text(saturation, _("select the saturation tone"));
@@ -500,19 +498,19 @@ void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_splittoning_gui_data_t *g = IOP_GUI_ALLOC(splittoning);
 
-  ++darktable.bauhaus->skip_accel;
+  dt_iop_module_t *sect = DT_IOP_SECTION_FOR_PARAMS(self, N_("shadows"));
   GtkWidget *shadows_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  g->shadow_hue_gslider = dt_bauhaus_slider_from_params(self, "shadow_hue");
+  g->shadow_hue_gslider = dt_bauhaus_slider_from_params(sect, "shadow_hue");
   dt_bauhaus_slider_set_factor(g->shadow_hue_gslider, 360.0f);
   dt_bauhaus_slider_set_format(g->shadow_hue_gslider, "°");
-  g->shadow_sat_gslider = dt_bauhaus_slider_from_params(self, "shadow_saturation");
+  g->shadow_sat_gslider = dt_bauhaus_slider_from_params(sect, "shadow_saturation");
 
+  sect = DT_IOP_SECTION_FOR_PARAMS(self, N_("highlights"));
   GtkWidget *highlights_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  g->highlight_hue_gslider = dt_bauhaus_slider_from_params(self, "highlight_hue");
+  g->highlight_hue_gslider = dt_bauhaus_slider_from_params(sect, "highlight_hue");
   dt_bauhaus_slider_set_factor(g->highlight_hue_gslider, 360.0f);
   dt_bauhaus_slider_set_format(g->highlight_hue_gslider, "°");
-  g->highlight_sat_gslider = dt_bauhaus_slider_from_params(self, "highlight_saturation");
-  --darktable.bauhaus->skip_accel;
+  g->highlight_sat_gslider = dt_bauhaus_slider_from_params(sect, "highlight_saturation");
 
   // start building top level widget
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -676,8 +676,19 @@ static gchar *_lib_history_change_text(dt_introspection_field_t *field, const ch
 
         if(d) description = g_strdup_printf("%s.%s", d, description);
 
-        if((change_parts[num_parts] = _lib_history_change_text(entry, description, params, oldpar)))
-          num_parts++;
+        gchar *part, *sect = NULL;
+        if((part = _lib_history_change_text(entry, description, params, oldpar)))
+        {
+          GHashTable *sections = field->header.so->get_introspection()->sections;
+          if(sections && (sect = g_hash_table_lookup(sections, GINT_TO_POINTER(entry->header.offset))))
+          {
+            sect = g_strdup_printf("%s/%s", Q_(sect), part);
+            g_free(part);
+            part = sect;
+          }
+
+          change_parts[num_parts++] = part;
+        }
 
         if(d) g_free(description);
       }

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -440,12 +440,12 @@ static void _basics_on_off_callback2(GtkWidget *widget, GdkEventButton *e, dt_li
 
 static void _sync_visibility(GtkWidget *widget, dt_lib_modulegroups_basic_item_t *item)
 {
-  gtk_widget_set_visible(item->box, gtk_widget_get_visible(item->old_parent));
-
   if(widget == item->temp_widget)
     gtk_widget_set_visible(item->widget, gtk_widget_get_visible(item->temp_widget));
   if(widget == item->widget)
     gtk_widget_set_visible(item->temp_widget, gtk_widget_get_visible(item->widget));
+
+  gtk_widget_set_visible(item->box, !dt_action_widget_invisible(item->temp_widget));
 }
 
 static gboolean _manage_direct_module_popup(GtkWidget *widget, GdkEventButton *event, dt_lib_module_t *self);


### PR DESCRIPTION
This started as a simple enough enhancement to `dt_action_widget_invisible` to not disable widgets from shortcuts/lua/qap just because they are in a currently collapsed collapsible section (like those in exposure/calibration/crop etc).

But some widgets still didn't work, which turned out to be because their actions were overwritten be identically names widgets in the "main" section of the module. Which was solved by putting the collapsible widgets in their own, named, action sections, "mapping" and "calibrate" (and turning a few buttons into actions as well, so they can be triggered from lua).

But then the same issue was happening with the "normalize channels" checkboxes in the color calibration module. They all "shared" one action directly under the module rather than separate ones in their own sections/tabs. To solve this, the `_from_params` calls, that set up iop widgets based on introspection markup, now accept a section, using `DT_IOP_SECTION_FOR_PARAMS`. This helped simplify the `gui_init` for colorbalancergb as well.

But also made now identically described fields indistinguishable in history tooltips. So the _section_ needed to be saved alongside the introspection data to make it available to history. Which also fixed a similar issue in splittoning:
![image](https://user-images.githubusercontent.com/1549490/189550899-6b00ff42-4ece-4884-b9b5-0af7a497673b.png)
![image](https://user-images.githubusercontent.com/1549490/189550844-ec878c45-3876-4a94-a9af-66032dc18bdd.png)
