### PR TITLE
RFC: move filmic graph to within the notebook to save space

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2878,7 +2878,7 @@
   </dtconfig>
   <dtconfig>
     <name>plugins/darkroom/filmicrgb/aspect_percent</name>
-    <type min="50" max="100">int</type>
+    <type min="30" max="100">int</type>
     <default>56</default>
     <shortdescription>aspect ratio of filmic rgb graph in per cent</shortdescription>
     <longdescription>aspect ratio of filmic rgb graph in per cent</longdescription>

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -4176,6 +4176,17 @@ static gboolean area_scroll_callback(GtkWidget *widget, GdkEventScroll *event, g
   return FALSE;
 }
 
+static void _tab_switch(GtkNotebook *notebook, GtkWidget *page, guint page_num, dt_iop_filmicrgb_gui_data_t *g)
+{
+  if(page_num == 1 || page_num == 4) return;
+
+  GtkWidget *w = GTK_WIDGET(g->area);
+  g_object_ref(w);
+  gtk_container_remove(GTK_CONTAINER(gtk_widget_get_parent(w)), w);
+  gtk_box_pack_end(GTK_BOX(page), GTK_WIDGET(g->area), TRUE, TRUE, 0);
+  g_object_unref(w);
+}
+
 void gui_init(dt_iop_module_t *self)
 {
   dt_iop_filmicrgb_gui_data_t *g = IOP_GUI_ALLOC(filmicrgb);
@@ -4209,6 +4220,8 @@ void gui_init(dt_iop_module_t *self)
 
   // Page SCENE
   self->widget = dt_ui_notebook_page(g->notebook, N_("scene"), NULL);
+
+  gtk_box_pack_end(GTK_BOX(self->widget), GTK_WIDGET(g->area), TRUE, TRUE, 0);
 
   g->grey_point_source
       = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "grey_point_source"));
@@ -4453,10 +4466,9 @@ void gui_init(dt_iop_module_t *self)
                                                        "this is useful to match natural sensor noise pattern.\n"));
 
   // start building top level widget
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  self->widget = GTK_WIDGET(g->notebook);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->area), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->notebook), FALSE, FALSE, 0);
+  g_signal_connect(G_OBJECT(g->notebook), "switch_page", G_CALLBACK(_tab_switch), g);
 }
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)


### PR DESCRIPTION
The filmic rgb module has a lot of wasted space in the 1st, 3rd and 4th tab, because the 2nd and 5th tab are much more populated. This PR move the graph from the top of the module, `above `the row of tabs, to `within `the notebook and hides it in the 2nd and 5th tab, where the graph is much less relevant anyway, so it doesn't force the module to grow. One drawback is that the module slightly jumps up and down when scrolling tabs. This _should_ have been fixable by using dummy containers in a GtkSizeGroup with the real graph, but that doesn't work because gtk notebooks are a pile of steaming.

There will probably be lovers and haters for this, so I'll be happy to close if controversial.

before
![image](https://user-images.githubusercontent.com/1549490/189781197-c30f182f-92f4-432f-bfa3-c4bf79de3a6e.png)

after
![image](https://user-images.githubusercontent.com/1549490/189898682-7e3f5492-629c-44cc-b92d-a24f001963e0.png)
![image](https://user-images.githubusercontent.com/1549490/189898791-6cbd2f8e-1bbe-40e9-9934-f1037621f490.png)
![image](https://user-images.githubusercontent.com/1549490/189898839-a7d99822-2187-4760-b63e-957f885c8db3.png)
![image](https://user-images.githubusercontent.com/1549490/189898903-a3c84b3d-eb9c-499d-bc4c-be3d0d294012.png)
![image](https://user-images.githubusercontent.com/1549490/189898942-5453d427-d93e-4492-b697-772bc6332ab9.png)
