### PR TITLE
fix bauhaus popup positioning on wayland

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -735,6 +735,8 @@ void dt_bauhaus_init()
 
   gtk_window_set_resizable(GTK_WINDOW(darktable.bauhaus->popup_window), FALSE);
   gtk_window_set_default_size(GTK_WINDOW(darktable.bauhaus->popup_window), 260, 260);
+  gtk_window_set_transient_for(GTK_WINDOW(darktable.bauhaus->popup_window),
+                               GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)));
   // gtk_window_set_modal(GTK_WINDOW(c->popup_window), TRUE);
   // gtk_window_set_decorated(GTK_WINDOW(c->popup_window), FALSE);
 


### PR DESCRIPTION
fixes https://github.com/darktable-org/darktable/issues/12478

Seems to work for me under wayland and X11. Haven't tested any other platforms.