### PR TITLE
Highlights segmentation code maintenance (4)

### DIFF
--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -272,7 +272,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const int width = roi_in->width;
   const int height = roi_in->height;
 
-  const gboolean fullpipe = (piece->pipe->type & DT_DEV_PIXELPIPE_FULL) == DT_DEV_PIXELPIPE_FULL;
+  const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
   const gboolean visualizing = (g != NULL) ? g->show_visualize && fullpipe : FALSE;
 
   cl_int err = DT_OPENCL_DEFAULT_ERROR;
@@ -474,16 +474,16 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
     return;
   }
 
-  if(d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS && filters && filters != 9u)
+  if(d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS)
   {
     // even if the algorithm can't tile we want to calculate memory for pixelpipe checks and a possible warning
+    const int segments = roi_out->width * roi_out->height / 2000; // segments per mpix
     tiling->xalign = 2;
     tiling->yalign = 2;
     tiling->overlap = 0;
-    tiling->overhead = 0x4000 * 5 * 10 * sizeof(int);
-    tiling->factor = 5.6f; // in & out plus plane buffers including some border safety plus segment planes
+    tiling->overhead = segments * 5 * 5 * sizeof(int); // segmentation stuff
+    tiling->factor = 2.0f + 3.3f; // in & out plus planes plus segmentation
     tiling->maxbuf = 1.0f;
-    tiling->overhead = 0;
 
     return;
   }
@@ -1942,7 +1942,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   dt_iop_highlights_data_t *data = (dt_iop_highlights_data_t *)piece->data;
   dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
 
-  const gboolean fullpipe = (piece->pipe->type & DT_DEV_PIXELPIPE_FULL) == DT_DEV_PIXELPIPE_FULL;
+  const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
   const gboolean visualizing = (g != NULL) ? g->show_visualize && fullpipe : FALSE;
 
   if(visualizing)

--- a/src/iop/hlrecovery.c
+++ b/src/iop/hlrecovery.c
@@ -97,8 +97,7 @@ The chosen segmentation algorithm works like this:
 #define HL_SENSOR_PLANES 4
 #define HL_REF_PLANES 4
 #define HL_FLOAT_PLANES (HL_SENSOR_PLANES + HL_REF_PLANES)
-#define HLMAXSEGMENTS 0x4000
-#define HLBORDER 8
+#define HL_BORDER 8
 
 static size_t plane_size(size_t width, size_t height)
 {
@@ -168,9 +167,9 @@ static void _prepare_smooth_singles(char *lmask, float * restrict src, const flo
   dt_omp_sharedconst(width, height, clipval) \
   schedule(static)
 #endif
-  for(size_t row = HLBORDER; row < height - HLBORDER; row++)
+  for(size_t row = HL_BORDER; row < height - HL_BORDER; row++)
   {
-    for(size_t col = HLBORDER; col < width - HLBORDER; col++)
+    for(size_t col = HL_BORDER; col < width - HL_BORDER; col++)
     {
       const size_t ix = row * width + col;
       if(lmask[ix] == 1) // we only take care of clipped locations
@@ -201,12 +200,12 @@ static void _prepare_smooth_singles(char *lmask, float * restrict src, const flo
   memcpy(lmask, mtmp, width * height * sizeof(char));
   dt_iop_image_copy(src, tmp, width * height);
 
-  dt_masks_extend_border(src, width, height, HLBORDER);
+  dt_masks_extend_border(src, width, height, HL_BORDER);
   dt_free_align(tmp);
   dt_free_align(mtmp);
 }
 
-static void _calc_plane_candidates(const float * restrict s, char *lmask, const float * restrict ref, dt_iop_segmentation_t *seg, const int width, const int height, const float clipval, const float refval)
+static void _calc_plane_candidates(const float * restrict s, char *lmask, const float * restrict ref, dt_iop_segmentation_t *seg, const float clipval, const float refval)
 {
   for(int id = 2; id < seg->nr + 2; id++)
   {
@@ -217,15 +216,15 @@ static void _calc_plane_candidates(const float * restrict s, char *lmask, const 
   // if we disable the candidating by using a high refval we can just keep segment pseudo-candidates right now for performance
   if(refval >= 1.0f) return;
 
+  const int width = seg->width;
 #ifdef _OPENMP
   #pragma omp parallel for default(none) \
   dt_omp_firstprivate(s, lmask, ref, seg) \
-  dt_omp_sharedconst(width, height, clipval, refval) \
+  dt_omp_sharedconst(width, clipval, refval) \
   schedule(dynamic)
 #endif
   for(int id = 2; id < seg->nr + 2; id++)
   {
-    int *segmap    = seg->data;
     size_t testref = 0;
     float testweight = 0.0f;
     for(int row = seg->ymin[id] -2 ; row < seg->ymax[id] + 3; row++)
@@ -233,7 +232,7 @@ static void _calc_plane_candidates(const float * restrict s, char *lmask, const 
       for(int col = seg->xmin[id] -2; col < seg->xmax[id] + 3; col++)
       {
         const size_t pos = row * width + col;
-        const int sid = segmap[pos] & (HLMAXSEGMENTS-1);
+        const int sid = _get_segment_id(seg, pos);
         if((sid == id) && (lmask[pos] == 0)) // we test for a) being in segment and b) unclipped
         {
           const float wht = _calc_weight(s, lmask, pos, width, clipval);
@@ -249,7 +248,6 @@ static void _calc_plane_candidates(const float * restrict s, char *lmask, const 
     if(testref && (testweight > refval)) // We have found a reference location
     {
       seg->ref[id] = testref;
-      segmap[testref] = 2*HLMAXSEGMENTS + id;
       float sum  = 0.0f;
       float pix = 0.0f;
       const float weights[5][5] = {
@@ -290,9 +288,9 @@ static void _initial_gradients(const size_t w, const size_t height, float *restr
   dt_omp_sharedconst(w, height) \
   schedule(simd:static) collapse(2)
 #endif
-  for(size_t row = HLBORDER; row < height - HLBORDER; row++)
+  for(size_t row = HL_BORDER; row < height - HL_BORDER; row++)
   {
-    for(size_t col = HLBORDER; col < w - HLBORDER; col++)
+    for(size_t col = HL_BORDER; col < w - HL_BORDER; col++)
     {
       const size_t v = row * w + col;
       float g = 0.0f;
@@ -352,10 +350,10 @@ static void _calc_distance_ring(const int width, const int xmin, const int xmax,
 
 static void add_poisson_noise(const int width, const int height, float *restrict lum, dt_iop_segmentation_t *seg, const int id, const float noise_level)
 {
-  const int xmin = MAX(seg->xmin[id], HLBORDER);
-  const int xmax = MIN(seg->xmax[id]+1, width - HLBORDER);
-  const int ymin = MAX(seg->ymin[id], HLBORDER);
-  const int ymax = MIN(seg->ymax[id]+1, height - HLBORDER);
+  const int xmin = MAX(seg->xmin[id], HL_BORDER);
+  const int xmax = MIN(seg->xmax[id]+1, width - HL_BORDER);
+  const int ymin = MAX(seg->ymin[id], HL_BORDER);
+  const int ymax = MIN(seg->ymax[id]+1, height - HL_BORDER);
   uint32_t DT_ALIGNED_ARRAY state[4] = { splitmix32(ymin), splitmix32(xmin), splitmix32(1337), splitmix32(666) };
   xoshiro128plus(state);
   xoshiro128plus(state);
@@ -377,10 +375,10 @@ static void add_poisson_noise(const int width, const int height, float *restrict
 
 static float _segment_maxdistance(const int width, const int height, float *restrict distance, dt_iop_segmentation_t *seg, const int id)
 {
-  const int xmin = MAX(seg->xmin[id]-2, HLBORDER);
-  const int xmax = MIN(seg->xmax[id]+3, width - HLBORDER);
-  const int ymin = MAX(seg->ymin[id]-2, HLBORDER);
-  const int ymax = MIN(seg->ymax[id]+3, height - HLBORDER);
+  const int xmin = MAX(seg->xmin[id]-2, HL_BORDER);
+  const int xmax = MIN(seg->xmax[id]+3, width - HL_BORDER);
+  const int ymin = MAX(seg->ymin[id]-2, HL_BORDER);
+  const int ymax = MIN(seg->ymax[id]+3, height - HL_BORDER);
   float max_distance = 0.0f;
 
 #ifdef _OPENMP
@@ -422,10 +420,10 @@ static float _segment_correction(dt_iop_segmentation_t *seg, const int id, const
 
 static void _segment_gradients(const int width, const int height, float *restrict distance, float *restrict gradient, float *restrict tmp, const int mode, dt_iop_segmentation_t *seg, const int id, const int seg_border)
 {
-  const int xmin = MAX(seg->xmin[id]-1, HLBORDER);
-  const int xmax = MIN(seg->xmax[id]+2, width - HLBORDER);
-  const int ymin = MAX(seg->ymin[id]-1, HLBORDER);
-  const int ymax = MIN(seg->ymax[id]+2, height - HLBORDER);
+  const int xmin = MAX(seg->xmin[id]-1, HL_BORDER);
+  const int xmax = MIN(seg->xmax[id]+2, width - HL_BORDER);
+  const int ymin = MAX(seg->ymin[id]-1, HL_BORDER);
+  const int ymax = MIN(seg->ymax[id]+2, height - HL_BORDER);
   const float attenuate = _segment_attenuation(seg, id, mode);
   const float strength = _segment_correction(seg, id, mode, seg_border);
 
@@ -495,15 +493,17 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
 
   const int width = roi_out->width;
   const int height = roi_out->height;
-  const int pwidth  = ((width + 1 ) / 2) + (2 * HLBORDER);
-  const int pheight = ((height + 1) / 2) + (2 * HLBORDER);
+  const int pwidth  = ((width + 1 ) / 2) + (2 * HL_BORDER);
+  const int pheight = ((height + 1) / 2) + (2 * HL_BORDER);
   const size_t p_size = plane_size(pwidth, pheight);
-
-  const int p_off  = (HLBORDER * pwidth) + HLBORDER;
+  const size_t p_off  = (HL_BORDER * pwidth) + HL_BORDER;
 
   dt_iop_image_copy(out, in, width * height);
 
-  if(filters == 0 || filters == 9u) return;
+  dt_aligned_pixel_t icoeffs = { piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1], piece->pipe->dsc.temperature.coeffs[2], 0.0f};
+
+  // doesn't work with incorrect coeffs or no defined filter
+  if((filters == 0) || (filters == 9u) || (icoeffs[0] < 0.1f) || (icoeffs[1] < 0.1f) || (icoeffs[2] < 0.1f)) return;
 
   float *fbuffer = dt_alloc_align_float((HL_FLOAT_PLANES+1) * p_size);
   char *mbuffer = dt_alloc_align(16, (HL_SENSOR_PLANES+1) * p_size * sizeof(char));
@@ -519,15 +519,6 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
   dt_times_t time0 = { 0 }, time1 = { 0 }, time2 = { 0 }, time3 = { 0 };
   dt_get_times(&time0);
 
-  dt_aligned_pixel_t icoeffs = { piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1], piece->pipe->dsc.temperature.coeffs[2], 0.0f};
-  // make sure we have wb coeffs
-  if((icoeffs[0] < 0.1f) || (icoeffs[1] < 0.1f) || (icoeffs[2] < 0.1f))
-  {
-    fprintf(stderr, "[highlights reconstruction in segmentation based mode] no white balance coeffs found, choosing stupid defaults\n");
-    icoeffs[0] = 2.0f;
-    icoeffs[1] = 1.0f;
-    icoeffs[2] = 1.5f;
-  }
   const dt_aligned_pixel_t coeffs = { powf(clipval * icoeffs[0], 1.0f / 3.0f), powf(clipval * icoeffs[1], 1.0f / 3.0f), powf(clipval * icoeffs[1], 1.0f / 3.0f), powf(clipval * icoeffs[2], 1.0f / 3.0f)};
 
   float *plane[HL_FLOAT_PLANES+1];
@@ -573,11 +564,11 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
   }
 
   for(int i = 0; i < HL_SENSOR_PLANES; i++)
-    dt_masks_extend_border(plane[i], pwidth, pheight, HLBORDER);
+    dt_masks_extend_border(plane[i], pwidth, pheight, HL_BORDER);
 
   dt_iop_segmentation_t isegments[HL_SENSOR_PLANES +1];
   for(int i = 0; i < HL_SENSOR_PLANES+1; i++)
-    dt_segmentation_init_struct(&isegments[i], pwidth, pheight, HLMAXSEGMENTS);
+    dt_segmentation_init_struct(&isegments[i], pwidth, pheight, HL_BORDER, 25000);
 
   gboolean has_clipped = FALSE;
   gboolean has_allclipped = FALSE;
@@ -621,9 +612,9 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
   dt_omp_sharedconst(pwidth, pheight) \
   schedule(static) collapse(2)
 #endif
-  for(int row = 4; row < pheight - 4; row++)
+  for(size_t row = 4; row < pheight - 4; row++)
   {
-    for(int col = 4; col < pwidth - 4; col++)
+    for(size_t col = 4; col < pwidth - 4; col++)
     {
       const size_t i = row * pwidth + col;
       for(int p = 0; p < HL_REF_PLANES; p++)
@@ -646,9 +637,9 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
     // We prefer to have slightly wider segment borders for a possibly better chosen candidate
     if(combining > 0)
     {
-      dt_image_transform_dilate(isegments[p].data, pwidth, pheight, combining, HLBORDER);
+      dt_segments_transform_dilate(&isegments[p], combining);
       if(combining > 1)
-        dt_image_transform_erode(isegments[p].data, pwidth, pheight, combining-1, HLBORDER);
+        dt_segments_transform_erode(&isegments[p], combining-1);
     }
   }
   if(dt_get_num_threads() >= HL_SENSOR_PLANES)
@@ -657,17 +648,17 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
   #pragma omp parallel num_threads(HL_SENSOR_PLANES)
 #endif
     {
-      _segmentize_plane(&isegments[dt_get_thread_num()], pwidth, pheight);
+      dt_segmentize_plane(&isegments[dt_get_thread_num()]);
     }
   }
   else
   {
     for(int p = 0; p < HL_SENSOR_PLANES; p++)
-      _segmentize_plane(&isegments[p], pwidth, pheight);
+      dt_segmentize_plane(&isegments[p]);
   }
 
   for(int p = 0; p < HL_SENSOR_PLANES; p++)
-    _calc_plane_candidates(plane[p], cmask[p], refavg[p], &isegments[p], pwidth, pheight, coeffs[p], 1.0f - sqf(data->candidating));
+    _calc_plane_candidates(plane[p], cmask[p], refavg[p], &isegments[p], coeffs[p], 1.0f - sqf(data->candidating));
 
 #ifdef _OPENMP
   #pragma omp parallel for default(none) \
@@ -675,9 +666,9 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
   dt_omp_sharedconst(pheight, pwidth, p_size, vmode) \
   schedule(static)
 #endif
-  for(size_t row = HLBORDER; row < pheight - HLBORDER; row++)
+  for(size_t row = HL_BORDER; row < pheight - HL_BORDER; row++)
   {
-    for(size_t col = HLBORDER; col < pwidth - HLBORDER; col++)
+    for(size_t col = HL_BORDER; col < pwidth - HL_BORDER; col++)
     {
       const size_t ix = row * pwidth + col;
 
@@ -688,7 +679,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
       {
         if(cmask[p][ix] == 1)
         {
-          const int pid = isegments[p].data[ix] & (HLMAXSEGMENTS-1);
+          const int pid = _get_segment_id(&isegments[p], ix);
           if((pid > 1) && (pid < isegments[p].nr+2)) // segmented
           {
             candidates[p]   = isegments[p].val1[pid];
@@ -791,7 +782,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
 
   if(do_recovery || (vmode != DT_SEGMENTS_MASK_OFF))
   {
-    dt_image_transform_closing(isegments[DT_IO_PLANNE_ALL].data, pwidth, pheight, seg_border, HLBORDER);
+    dt_segments_transform_closing(&isegments[DT_IO_PLANNE_ALL], seg_border);
     dt_iop_image_fill(gradient, 0.0f, pwidth, pheight, 1);
     dt_iop_image_fill(distance, 0.0f, pwidth, pheight, 1);
     // normalize luminance for 1.0
@@ -804,9 +795,9 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
   dt_omp_sharedconst(pheight, pwidth, corr0, corr1, corr2) \
   schedule(static) collapse(2)
 #endif
-    for(size_t row = HLBORDER; row < pheight - HLBORDER; row++)
+    for(size_t row = HL_BORDER; row < pheight - HL_BORDER; row++)
     {
-      for(size_t col = HLBORDER; col < pwidth - HLBORDER; col++)
+      for(size_t col = HL_BORDER; col < pwidth - HL_BORDER; col++)
       {
         const size_t i = row * pwidth + col;
         // prepare the temporary luminance
@@ -814,9 +805,9 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
         distance[i] = (isegments[DT_IO_PLANNE_ALL].data[i] == 1) ? DT_DISTANCE_TRANSFORM_MAX : 0.0f;
       }
     }
-    dt_masks_extend_border(tmp, pwidth, pheight, HLBORDER);
+    dt_masks_extend_border(tmp, pwidth, pheight, HL_BORDER);
     dt_masks_blur_fast(tmp, luminance, pwidth, pheight, 1.5f, 1.0f, 20.0f);
-    dt_masks_extend_border(luminance, pwidth, pheight, HLBORDER);
+    dt_masks_extend_border(luminance, pwidth, pheight, HL_BORDER);
   }
 
   if(do_recovery)
@@ -825,9 +816,9 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
 
     if(max_distance > 4.0f)
     {
-      _segmentize_plane(&isegments[DT_IO_PLANNE_ALL], pwidth, pheight);
+      dt_segmentize_plane(&isegments[DT_IO_PLANNE_ALL]);
       _initial_gradients(pwidth, pheight, luminance, distance, recout);
-      dt_masks_extend_border(recout, pwidth, pheight, HLBORDER);
+      dt_masks_extend_border(recout, pwidth, pheight, HL_BORDER);
 
       // now we check for significant all-clipped-segments and reconstruct data
       for(int id = 2; id < isegments[DT_IO_PLANNE_ALL].nr+2; id++)
@@ -857,9 +848,9 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
   dt_omp_sharedconst(pheight, pwidth, strength, dshift) \
   schedule(static) collapse(2)
 #endif
-      for(int row = HLBORDER; row < pheight - HLBORDER; row++)
+      for(size_t row = HL_BORDER; row < pheight - HL_BORDER; row++)
       {
-        for(int col = HLBORDER; col < pwidth - HLBORDER; col++)
+        for(size_t col = HL_BORDER; col < pwidth - HL_BORDER; col++)
         {
           const size_t i = row * pwidth + col;
           gradient[i] *= strength / (1.0f + expf(-(distance[i] - dshift)));
@@ -901,9 +892,9 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
         const size_t i = (row/2)*pwidth + (col/2) + p_off;
         const size_t o = row * width + col;
         const int p = _pos2plane(row, col, filters);
-        const int pid = isegments[p].data[i] & (HLMAXSEGMENTS-1);
+        const int pid = _get_segment_id(&isegments[p], i);
         const gboolean iclipped = (cmask[p][i] == 1);
-        const gboolean isegment = ((pid > 1) && (pid < isegments[p].nr+2));
+        const gboolean isegment = ((pid > 1) && (pid <= isegments[p].nr));
         const gboolean badseg = isegment && (isegments[p].ref[pid] == 0);
 
         out[o] = 0.1f * in[o];
@@ -930,9 +921,3 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
   dt_free_align(mbuffer);
 }
 
-#undef HL_SENSOR_PLANES
-#undef HL_REF_PLANES
-#undef HL_FLOAT_PLANES
-#undef HLFPLANES
-#undef HLMAXSEGMENTS
-#undef HLBORDER

--- a/src/iop/segmentation.h
+++ b/src/iop/segmentation.h
@@ -647,7 +647,7 @@ void dt_segmentation_init_struct(dt_iop_segmentation_t *seg, const int width, co
   seg->ref =    dt_alloc_align(64, slots * sizeof(size_t));
   seg->val1 =   dt_alloc_align_float(slots);
   seg->val2 =   dt_alloc_align_float(slots);
-  seg->border = border;
+  seg->border = MAX(border, 8);
   seg->slots = slots;
   seg->width = width;
   seg->height = height;

--- a/src/iop/segmentation.h
+++ b/src/iop/segmentation.h
@@ -28,6 +28,8 @@
    Hanno Schwalm 2022/05
 */
 
+#define DT_SEG_ID_MASK 0x40000
+
 typedef struct dt_pos_t
 {
   int xpos;
@@ -37,15 +39,20 @@ typedef struct dt_pos_t
 typedef struct dt_iop_segmentation_t
 {
   int *data;      // holding segment id's for every location
-  int *size;      // size of segment      
+  int *size;      // size of each segment      
   int *xmin;      // bounding rectangle for each segment
   int *xmax;
   int *ymin;
   int *ymax;
-  size_t *ref;    // possibly a reference point for location
+  size_t *ref;    // ref, val1 and val2 are free to be used by the segmentation user
   float *val1;
-  float *val2;  
+  float *val2;
   int nr;         // number of found segments
+  int border;     // while segmentizing we have a border region not used by the algo
+  int slots;      // available segment id's
+  int width;
+  int height;
+  int *tmp;       // pointer to temporary buffer used for morphological operations
 } dt_iop_segmentation_t;
 
 typedef struct dt_ff_stack_t
@@ -54,7 +61,7 @@ typedef struct dt_ff_stack_t
   dt_pos_t *el;
 } dt_ff_stack_t;
 
-static inline void push_stack(int xpos, int ypos, dt_ff_stack_t *stack)
+static inline void _push_stack(int xpos, int ypos, dt_ff_stack_t *stack)
 {
   const int i = stack->pos;
   stack->el[i].xpos = xpos;
@@ -62,40 +69,18 @@ static inline void push_stack(int xpos, int ypos, dt_ff_stack_t *stack)
   stack->pos++;
 }
 
-static inline dt_pos_t * pop_stack(dt_ff_stack_t *stack)
+static inline dt_pos_t * _pop_stack(dt_ff_stack_t *stack)
 {
   if(stack->pos > 0) stack->pos--;  
   return &stack->el[stack->pos];
 }
 
-void dt_segmentation_init_struct(dt_iop_segmentation_t *seg, const int width, const int height, const int segments)
+static inline int _get_segment_id(dt_iop_segmentation_t *seg, const size_t loc)
 {
-  seg->nr = 0;
-  seg->data =   dt_alloc_align(64, width * height * sizeof(int));
-  seg->size =   dt_alloc_align(64, segments * sizeof(int));
-  seg->xmin =   dt_alloc_align(64, segments * sizeof(int));
-  seg->xmax =   dt_alloc_align(64, segments * sizeof(int));
-  seg->ymin =   dt_alloc_align(64, segments * sizeof(int));
-  seg->ymax =   dt_alloc_align(64, segments * sizeof(int));
-  seg->ref =    dt_alloc_align(64, segments * sizeof(size_t));
-  seg->val1 =   dt_alloc_align_float(segments);
-  seg->val2 =   dt_alloc_align_float(segments);
+  return seg->data[loc] & (DT_SEG_ID_MASK-1);
 }
 
-void dt_segmentation_free_struct(dt_iop_segmentation_t *seg)
-{
-  dt_free_align(seg->data);
-  dt_free_align(seg->size);
-  dt_free_align(seg->xmin);
-  dt_free_align(seg->ymin);
-  dt_free_align(seg->xmax);
-  dt_free_align(seg->ymax);
-  dt_free_align(seg->ref);
-  dt_free_align(seg->val1);
-  dt_free_align(seg->val2);
-}
-
-static inline int _test_dilate(const int *img, const int i, const int w1, const int radius)
+static inline int _test_dilate(const int *img, const size_t i, const size_t w1, const int radius)
 {
   int retval = 0;
   retval = img[i-w1-1] | img[i-w1] | img[i-w1+1] |
@@ -103,7 +88,7 @@ static inline int _test_dilate(const int *img, const int i, const int w1, const 
            img[i+w1-1] | img[i+w1] | img[i+w1+1];
   if(retval || (radius < 2)) return retval;
 
-  const int w2 = 2*w1;
+  const size_t w2 = 2*w1;
   retval = img[i-w2-1] | img[i-w2]   | img[i-w2+1] |
            img[i-w1-2] | img[i-w1+2] | 
            img[i-2]    | img[i+2] |
@@ -111,7 +96,7 @@ static inline int _test_dilate(const int *img, const int i, const int w1, const 
            img[i+w2-1] | img[i+w2]   | img[i+w2+1];
   if(retval || (radius < 3)) return retval;
 
-  const int w3 = 3*w1;
+  const size_t w3 = 3*w1;
   retval = img[i-w3-2] | img[i-w3-1] | img[i-w3] | img[i-w3+1] | img[i-w3+2] |
            img[i-w2-3] | img[i-w2-2] | img[i-w2+2] | img[i-w2+3] |
            img[i-w1-3] | img[i-w1+3] | 
@@ -121,7 +106,7 @@ static inline int _test_dilate(const int *img, const int i, const int w1, const 
            img[i+w3-2] | img[i+w3-1] | img[i+w3] | img[i+w3+1] | img[i+w3+2]; 
   if(retval || (radius < 4)) return retval;
 
-  const int w4 = 4*w1;
+  const size_t w4 = 4*w1;
   retval = img[i-w4-2] | img[i-w4-1] | img[i-w4] | img[i-w4+1] | img[i-w4+2] |
            img[i-w3-3] | img[i-w3+3] |
            img[i-w2-4] | img[i-w2+4] | 
@@ -133,7 +118,7 @@ static inline int _test_dilate(const int *img, const int i, const int w1, const 
            img[i+w4-2] | img[i+w4-1] | img[i+w4] | img[i+w4+1] | img[i+w4+2]; 
   if(retval || (radius < 5)) return retval;
 
-  const int w5 = 5*w1;
+  const size_t w5 = 5*w1;
   retval = img[i-w5-2] | img[i-w5-1] | img[i-w5] | img[i-w5+1] | img[i-w5+2] |
            img[i-w4-4] | img[i-w4+4] |
            img[i-w3-4] | img[i-w3+4] |
@@ -147,7 +132,7 @@ static inline int _test_dilate(const int *img, const int i, const int w1, const 
            img[i+w5-2] | img[i+w5-1] | img[i+w5] | img[i+w5+1] | img[i+w5+2]; 
   if(retval || (radius < 6)) return retval;
 
-  const int w6 = 6*w1;
+  const size_t w6 = 6*w1;
   retval = img[i-w6-2] | img[i-w6-1] | img[i-w6] | img[i-w6+1] | img[i-w6+2] |
            img[i-w5-4] | img[i-w5-3] | img[i-w5+3] | img[i-w5+4] |
            img[i-w4-5] | img[i-w4+5] |
@@ -163,7 +148,7 @@ static inline int _test_dilate(const int *img, const int i, const int w1, const 
            img[i+w6-2] | img[i+w6-1] | img[i+w6] | img[i+w6+1] | img[i+w6+2] ;
   if(retval || (radius < 7)) return retval;
 
-  const int w7 = 7*w1;
+  const size_t w7 = 7*w1;
   retval = img[i-w7-3] | img[i-w7-2] | img[i-w7-1] | img[i-w7] | img[i-w7+1] | img[i-w7+2] | img[i-w7+3] | 
            img[i-w6-4] | img[i-w6-3] | img[i-w6+3] | img[i-w6+4] | 
            img[i-w5-5] | img[i-w5+5] |
@@ -181,7 +166,7 @@ static inline int _test_dilate(const int *img, const int i, const int w1, const 
            img[i+w7-3] | img[i+w7-2] | img[i+w7-1] | img[i+w7] | img[i+w7+1] | img[i+w7+2] | img[i+w7+3];
   if(retval || (radius < 8)) return retval;
 
-  const int w8 = 8*w1;
+  const size_t w8 = 8*w1;
   retval = img[i-w8-3] | img[i-w8-2] | img[i-w8-1] | img[i-w8] | img[i-w8+1] | img[i-w8+2] | img[i-w8-3] | 
            img[i-w7-5] | img[i-w7-4] | img[i-w7+4] | img[i-w7+5] | 
            img[i-w6-6] | img[i-w6-5] | img[i-w6+5] | img[i-w6+6] | 
@@ -209,16 +194,16 @@ static inline void _dilating(const int *img, int *o, const int w1, const int hei
   #pragma omp parallel for simd default(none) \
   dt_omp_firstprivate(img, o) \
   dt_omp_sharedconst(height, w1, border, radius) \
-  schedule(simd:static) aligned(o, img : 64)
+  schedule(static) aligned(o, img : 64)
 #endif
-  for(int row = border; row < height - border; row++)
+  for(size_t row = border; row < height - border; row++)
   {
-    for(int col = border, i = row*w1 + col; col < w1 - border; col++, i++)
+    for(size_t col = border, i = row*w1 + col; col < w1 - border; col++, i++)
       o[i] = _test_dilate(img, i, w1, radius);
   }
 }
 
-static inline int _test_erode(const int *img, const int i, const int w1, const int radius)
+static inline int _test_erode(const int *img, const size_t i, const size_t w1, const int radius)
 {
   int retval = 1;
   retval =     img[i-w1-1] & img[i-w1] & img[i-w1+1] &
@@ -226,7 +211,7 @@ static inline int _test_erode(const int *img, const int i, const int w1, const i
                img[i+w1-1] & img[i+w1] & img[i+w1+1];
   if((retval == 0) || (radius < 2)) return retval;
 
-  const int w2 = 2*w1;
+  const size_t w2 = 2*w1;
   retval = img[i-w2-1] & img[i-w2]   & img[i-w2+1] &
            img[i-w1-2] & img[i-w1+2] & 
            img[i-2]    & img[i+2] &
@@ -235,7 +220,7 @@ static inline int _test_erode(const int *img, const int i, const int w1, const i
 
   if((retval == 0) || (radius < 3)) return retval;
 
-  const int w3 = 3*w1;
+  const size_t w3 = 3*w1;
   retval = img[i-w3-2] & img[i-w3-1] & img[i-w3] & img[i-w3+1] & img[i-w3+2] &
            img[i-w2-3] & img[i-w2-2] & img[i-w2+2] & img[i-w2+3] &
            img[i-w1-3] & img[i-w1+3] & 
@@ -245,7 +230,7 @@ static inline int _test_erode(const int *img, const int i, const int w1, const i
            img[i+w3-2] & img[i+w3-1] & img[i+w3] & img[i+w3+1] & img[i+w3+2]; 
   if((retval == 0) || (radius < 4)) return retval;
 
-  const int w4 = 4*w1;
+  const size_t w4 = 4*w1;
   retval = img[i-w4-2] & img[i-w4-1] & img[i-w4] & img[i-w4+1] & img[i-w4+2] &
            img[i-w3-3] & img[i-w3+3] &
            img[i-w2-4] & img[i-w2+4] & 
@@ -257,7 +242,7 @@ static inline int _test_erode(const int *img, const int i, const int w1, const i
            img[i+w4-2] & img[i+w4-1] & img[i+w4] & img[i+w4+1] & img[i+w4+2]; 
   if((retval == 0) || (radius < 5)) return retval;
 
-  const int w5 = 5*w1;
+  const size_t w5 = 5*w1;
   retval = img[i-w5-2] & img[i-w5-1] & img[i-w5] & img[i-w5+1] & img[i-w5+2] &
            img[i-w4-4] & img[i-w4+4] &
            img[i-w3-4] & img[i-w3+4] &
@@ -271,7 +256,7 @@ static inline int _test_erode(const int *img, const int i, const int w1, const i
            img[i+w5-2] & img[i+w5-1] & img[i+w5] & img[i+w5+1] & img[i+w5+2]; 
   if((retval == 0) || (radius < 6)) return retval;
 
-  const int w6 = 6*w1;
+  const size_t w6 = 6*w1;
   retval = img[i-w6-2] & img[i-w6-1] & img[i-w6] & img[i-w6+1] & img[i-w6+2] &
            img[i-w5-4] & img[i-w5-3] & img[i-w5+3] & img[i-w5+4] &
            img[i-w4-5] & img[i-w4+5] &
@@ -287,7 +272,7 @@ static inline int _test_erode(const int *img, const int i, const int w1, const i
            img[i+w6-2] & img[i+w6-1] & img[i+w6] & img[i+w6+1] & img[i+w6+2] ;
   if((retval == 0) || (radius < 7)) return retval;
 
-  const int w7 = 7*w1;
+  const size_t w7 = 7*w1;
   retval = img[i-w7-3] & img[i-w7-2] & img[i-w7-1] & img[i-w7] & img[i-w7+1] & img[i-w7+2] & img[i-w7+3] & 
            img[i-w6-4] & img[i-w6-3] & img[i-w6+3] & img[i-w6+4] & 
            img[i-w5-5] & img[i-w5+5] &
@@ -305,7 +290,7 @@ static inline int _test_erode(const int *img, const int i, const int w1, const i
            img[i+w7-3] & img[i+w7-2] & img[i+w7-1] & img[i+w7] & img[i+w7+1] & img[i+w7+2] & img[i+w7+3];
   if((retval == 0) || (radius < 8)) return retval;
 
-  const int w8 = 8*w1;
+  const size_t w8 = 8*w1;
   retval = img[i-w8-3] & img[i-w8-2] & img[i-w8-1] & img[i-w8] & img[i-w8+1] & img[i-w8+2] & img[i-w8-3] & 
            img[i-w7-5] & img[i-w7-4] & img[i-w7+4] & img[i-w7+5] & 
            img[i-w6-6] & img[i-w6-5] & img[i-w6+5] & img[i-w6+6] & 
@@ -333,23 +318,22 @@ static inline void _eroding(const int *img, int *o, const int w1, const int heig
   #pragma omp parallel for simd default(none) \
   dt_omp_firstprivate(img, o) \
   dt_omp_sharedconst(height, w1, border, radius) \
-  schedule(simd:static) aligned(o, img : 64)
+  schedule(static) aligned(o, img : 64)
 #endif
-  for(int row = border; row < height - border; row++)
+  for(size_t row = border; row < height - border; row++)
   {
-    for(int col = border, i = row*w1 + col; col < w1 - border; col++, i++)
+    for(size_t col = border, i = row*w1 + col; col < w1 - border; col++, i++)
       o[i] = _test_erode(img, i, w1, radius);
   }
 }
 
-
 static inline void _intimage_borderfill(int *d, const int width, const int height, const int val, const int border)
 {
-  for(int i = 0; i < border * width; i++)                            
+  for(size_t i = 0; i < border * width; i++)                            
     d[i] = val;
-  for(int i = (height - border - 1) * width; i < width*height; i++)
+  for(size_t i = (height - border - 1) * width; i < width*height; i++)
     d[i] = val;
-  for(int row = border; row < height - border; row++)
+  for(size_t row = border; row < height - border; row++)
   {
     int *p1 = d + row*width;
     int *p2 = d + (row+1)*width - border;
@@ -358,48 +342,11 @@ static inline void _intimage_borderfill(int *d, const int width, const int heigh
   }
 }
 
-void dt_image_transform_dilate(int *img, const int width, const int height, const int radius, const int border)
-{
-  if(radius < 1) return;
-  int *tmp = dt_alloc_align(64, width * height * sizeof(int));
-  if(!tmp) return;
-
-  _intimage_borderfill(img, width, height, 0, border);
-  _dilating(img, tmp, width, height, border, radius);
-  memcpy(img, tmp, width*height * sizeof(int));
-  dt_free_align(tmp);
-}
-  
-void dt_image_transform_erode(int *img, const int width, const int height, const int radius, const int border)
-{
-  if(radius < 1) return;
-  int *tmp = dt_alloc_align(64, width * height * sizeof(int));
-  if(!tmp) return;
-
-  _intimage_borderfill(img, width, height, 1, border);
-  _eroding(img, tmp, width, height, border, radius);
-  memcpy(img, tmp, width*height * sizeof(int));
-  dt_free_align(tmp);
-}
-  
-void dt_image_transform_closing(int *img, const int width, const int height, const int radius, const int border)
-{
-  if(radius < 1) return;
-  int *tmp = dt_alloc_align(64, width * height * sizeof(int));
-  if(!tmp) return;
-
-  _intimage_borderfill(img, width, height, 0, border);
-  _dilating(img, tmp, width, height, border, radius);
- 
-  _intimage_borderfill(tmp, width, height, 1, border);
-  _eroding(tmp, img, width, height, border, radius);
-  dt_free_align(tmp);
-}
-
 static int _floodfill_segmentize(int yin, int xin, dt_iop_segmentation_t *seg, const int w, const int h, const int id, dt_ff_stack_t *stack)
 {
-  if((id < 2) || (id >= HLMAXSEGMENTS - 1)) return 0;
+  if(id >= seg->slots - 1) return 0;
 
+  const int border = seg->border;
   int *d = seg->data;
 
   int xp = 0;
@@ -422,10 +369,10 @@ static int _floodfill_segmentize(int yin, int xin, dt_iop_segmentation_t *seg, c
   seg->ymin[id] = min_y;
   seg->ymax[id] = max_y;
 
-  push_stack(xin, yin, stack);
+  _push_stack(xin, yin, stack);
   while(stack->pos)
   {
-    dt_pos_t *coord = pop_stack(stack);
+    dt_pos_t *coord = _pop_stack(stack);
     const int x = coord->xpos;
     const int y = coord->ypos;
     if(d[y*w+x] == 1)
@@ -434,85 +381,85 @@ static int _floodfill_segmentize(int yin, int xin, dt_iop_segmentation_t *seg, c
       gboolean lastXUp = FALSE, lastXDown = FALSE, firstXUp = FALSE, firstXDown = FALSE;
       d[y*w+x] = id;
       cnt++;
-      if(yUp >= HLBORDER && d[yUp*w+x] == 1)
+      if(yUp >= border && d[yUp*w+x] == 1)
       {
-        push_stack(x, yUp, stack); firstXUp = lastXUp = TRUE;
+        _push_stack(x, yUp, stack); firstXUp = lastXUp = TRUE;
       }
       else
       {
         xp = x;
         yp = yUp;
         rp = yp*w + xp;
-        if(xp > HLBORDER+2 && d[rp] == 0)
+        if(xp > border+2 && d[rp] == 0)
         {
           min_x = MIN(min_x, xp);
           max_x = MAX(max_x, xp);
           min_y = MIN(min_y, yp);
           max_y = MAX(max_y, yp);
-          d[rp] = HLMAXSEGMENTS+id;
+          d[rp] = DT_SEG_ID_MASK + id;
         }
       }
       
-      if(yDown < h-HLBORDER && d[yDown*w+x] == 1)
+      if(yDown < h-border && d[yDown*w+x] == 1)
       {
-        push_stack(x, yDown, stack); firstXDown = lastXDown = TRUE;
+        _push_stack(x, yDown, stack); firstXDown = lastXDown = TRUE;
       }
       else
       {
         xp = x;
         yp = yDown;
         rp = yp*w + xp;
-        if(yp < h-HLBORDER-3 && d[rp] == 0)
+        if(yp < h-border-3 && d[rp] == 0)
         {
           min_x = MIN(min_x, xp);
           max_x = MAX(max_x, xp);
           min_y = MIN(min_y, yp);
           max_y = MAX(max_y, yp);
-          d[rp] = HLMAXSEGMENTS+id;
+          d[rp] = DT_SEG_ID_MASK + id;
         }
       }
       
       int xr = x + 1;
-      while(xr < w-HLBORDER && d[y*w+xr] == 1)
+      while(xr < w-border && d[y*w+xr] == 1)
       {
         d[y*w+xr] = id;
         cnt++;
-        if(yUp >= HLBORDER && d[yUp*w + xr] == 1)
+        if(yUp >= border && d[yUp*w + xr] == 1)
         {
-          if(!lastXUp) { push_stack(xr, yUp, stack); lastXUp = TRUE; }
+          if(!lastXUp) { _push_stack(xr, yUp, stack); lastXUp = TRUE; }
         }
         else
         {
           xp = xr;
           yp = yUp;
           rp = yp*w + xp;
-          if(yp > HLBORDER+2 && d[rp] == 0)
+          if(yp > border+2 && d[rp] == 0)
           {
             min_x = MIN(min_x, xp);
             max_x = MAX(max_x, xp);
             min_y = MIN(min_y, yp);
             max_y = MAX(max_y, yp);
-            d[rp] = HLMAXSEGMENTS+id;
+            d[rp] = DT_SEG_ID_MASK + id;
           }
           lastXUp = FALSE;
         }
 
-        if(yDown < h-HLBORDER && d[yDown*w+xr] == 1)
+        if(yDown < h-border && d[yDown*w+xr] == 1)
         {
-          if(!lastXDown) { push_stack(xr, yDown, stack); lastXDown = TRUE; }
+          if(!lastXDown) { _push_stack(xr, yDown, stack); lastXDown = TRUE; }
         }
         else
         {
           xp = xr;
           yp = yDown;
           rp = yp*w + xp;
-          if(yp < h-HLBORDER-3 && d[rp] == 0)
+          if(yp < h-border-3 && d[rp] == 0)
           {
             min_x = MIN(min_x, xp);
             max_x = MAX(max_x, xp);
             min_y = MIN(min_y, yp);
             max_y = MAX(max_y, yp);
-            d[rp] = HLMAXSEGMENTS+id;
+            d[rp] = DT_SEG_ID_MASK + id;
           }
           lastXDown = FALSE;
         }
@@ -522,58 +469,58 @@ static int _floodfill_segmentize(int yin, int xin, dt_iop_segmentation_t *seg, c
       xp = xr;
       yp = y;
       rp = yp*w + xp;
-      if(xp < w-HLBORDER-3 && d[rp] == 0) 
+      if(xp < w-border-3 && d[rp] == 0) 
       {
         min_x = MIN(min_x, xp);
         max_x = MAX(max_x, xp);
         min_y = MIN(min_y, yp);
         max_y = MAX(max_y, yp);
-        d[rp] = HLMAXSEGMENTS+id;
+        d[rp] = DT_SEG_ID_MASK + id;
       }
 
       int xl = x - 1;
       lastXUp = firstXUp;
       lastXDown = firstXDown;
-      while(xl >= HLBORDER && d[y*w+xl] == 1)
+      while(xl >= border && d[y*w+xl] == 1)
       {
         d[y*w+xl] = id;
         cnt++;
-        if(yUp >= HLBORDER && d[yUp*w+xl] == 1)
+        if(yUp >= border && d[yUp*w+xl] == 1)
         {
-          if(!lastXUp) { push_stack(xl, yUp, stack); lastXUp = TRUE; }
+          if(!lastXUp) { _push_stack(xl, yUp, stack); lastXUp = TRUE; }
         }
         else
         {
           xp = xl;
           yp = yUp;
           rp = yp*w + xp;
-          if(yp > HLBORDER+2 && d[rp] == 0)
+          if(yp > border+2 && d[rp] == 0)
           {
             min_x = MIN(min_x, xp);
             max_x = MAX(max_x, xp);
             min_y = MIN(min_y, yp);
             max_y = MAX(max_y, yp);
-            d[rp] = HLMAXSEGMENTS+id;
+            d[rp] = DT_SEG_ID_MASK + id;
           }
           lastXUp = FALSE;
         }
 
-        if(yDown < h-HLBORDER && d[yDown*w+xl] == 1)
+        if(yDown < h-border && d[yDown*w+xl] == 1)
         {
-          if(!lastXDown) { push_stack(xl, yDown, stack); lastXDown = TRUE; }
+          if(!lastXDown) { _push_stack(xl, yDown, stack); lastXDown = TRUE; }
         }
         else
         {
           xp = xl;
           yp = yDown;
           rp = yp*w + xp;
-          if(yp < h-HLBORDER-3 && d[rp] == 0)
+          if(yp < h-border-3 && d[rp] == 0)
           {
             min_x = MIN(min_x, xp);
             max_x = MAX(max_x, xp);
             min_y = MIN(min_y, yp);
             max_y = MAX(max_y, yp);
-            d[rp] = HLMAXSEGMENTS+id;
+            d[rp] = DT_SEG_ID_MASK + id;
           }
           lastXDown = FALSE;
         }
@@ -585,13 +532,13 @@ static int _floodfill_segmentize(int yin, int xin, dt_iop_segmentation_t *seg, c
       xp = xl;
       yp = y;
       rp = yp*w + xp;
-      if(xp > HLBORDER+2 && d[rp] == 0)
+      if(xp > border+2 && d[rp] == 0)
       {
         min_x = MIN(min_x, xp);
         max_x = MAX(max_x, xp);
         min_y = MIN(min_y, yp);
         max_y = MAX(max_y, yp);
-        d[rp] = HLMAXSEGMENTS+id;
+        d[rp] = DT_SEG_ID_MASK + id;
       }
       cnt++;
     }
@@ -606,18 +553,22 @@ static int _floodfill_segmentize(int yin, int xin, dt_iop_segmentation_t *seg, c
   return cnt;
 }
 
-static void _segmentize_plane(dt_iop_segmentation_t *seg, const int width, const int height)
+// User interface
+void dt_segmentize_plane(dt_iop_segmentation_t *seg)
 {
   dt_ff_stack_t stack;  
+  const size_t width = seg->width;
+  const size_t height = seg->height;
   stack.el = dt_alloc_align(16, width * height * sizeof(int));
   if(!stack.el) return;
- 
+
+  const size_t border = seg->border;
   int id = 2;
-  for(int row = HLBORDER; row < height - HLBORDER; row++)
+  for(size_t row = border; row < height - border; row++)
   {
-    for(int col = HLBORDER; col < width - HLBORDER; col++)
+    for(size_t col = border; col < width - border; col++)
     {
-      if(id >= HLMAXSEGMENTS-1) goto finish;
+      if(id >= (seg->slots - 1)) goto finish;
       if(seg->data[width * row + col] == 1)
       {
         if(_floodfill_segmentize(row, col, seg, width, height, id, &stack) > 0) id++;
@@ -626,6 +577,94 @@ static void _segmentize_plane(dt_iop_segmentation_t *seg, const int width, const
   }
 
   finish:
+
+  if((darktable.unmuted & DT_DEBUG_VERBOSE) && (id >= (seg->slots - 2)))
+    fprintf(stderr, "[segmentize_plane] number of segments exceed maximum\n");
+
   dt_free_align(stack.el);
+}
+
+void dt_segments_transform_dilate(dt_iop_segmentation_t *seg, const int radius)
+{
+  if(radius < 1) return;
+  int *img = seg->data;
+  const int width = seg->width;
+  const int height = seg->height;
+  const int border = seg->border;
+  if(!seg->tmp) seg->tmp = dt_alloc_align(64, width * height * sizeof(int));
+  if(!seg->tmp) return;
+
+  _intimage_borderfill(img, width, height, 0, border);
+  _dilating(img, seg->tmp, width, height, border, radius);
+  memcpy(img, seg->tmp, width*height * sizeof(int));
+}
+  
+void dt_segments_transform_erode(dt_iop_segmentation_t *seg, const int radius)
+{
+  if(radius < 1) return;
+  int *img = seg->data;
+  const int width = seg->width;
+  const int height = seg->height;
+  const int border = seg->border;
+  if(!seg->tmp) seg->tmp = dt_alloc_align(64, width * height * sizeof(int));
+  if(!seg->tmp) return;
+
+  _intimage_borderfill(img, width, height, 1, border);
+  _eroding(img, seg->tmp, width, height, border, radius);
+  memcpy(img, seg->tmp, width*height * sizeof(int));
+}
+  
+void dt_segments_transform_closing(dt_iop_segmentation_t *seg, const int radius)
+{
+  if(radius < 1) return;
+  int *img = seg->data;
+  const int width = seg->width;
+  const int height = seg->height;
+  const int border = seg->border;
+  if(!seg->tmp) seg->tmp = dt_alloc_align(64, width * height * sizeof(int));
+  if(!seg->tmp) return;
+
+  _intimage_borderfill(img, width, height, 0, border);
+  _dilating(img, seg->tmp, width, height, border, radius);
+ 
+  _intimage_borderfill(seg->tmp, width, height, 1, border);
+  _eroding(seg->tmp, img, width, height, border, radius);
+}
+
+void dt_segmentation_init_struct(dt_iop_segmentation_t *seg, const int width, const int height, const int border, const int wanted_slots)
+{
+  const int slots = MIN(wanted_slots, DT_SEG_ID_MASK - 1);
+  if(slots != wanted_slots)
+    fprintf(stderr, "number of wanted seg slots %i exceeds maximum %i\n", wanted_slots, DT_SEG_ID_MASK - 1);
+
+  seg->nr = 0;
+  seg->data =   dt_alloc_align(64, width * height * sizeof(int));
+  seg->size =   dt_alloc_align(64, slots * sizeof(int));
+  seg->xmin =   dt_alloc_align(64, slots * sizeof(int));
+  seg->xmax =   dt_alloc_align(64, slots * sizeof(int));
+  seg->ymin =   dt_alloc_align(64, slots * sizeof(int));
+  seg->ymax =   dt_alloc_align(64, slots * sizeof(int));
+  seg->ref =    dt_alloc_align(64, slots * sizeof(size_t));
+  seg->val1 =   dt_alloc_align_float(slots);
+  seg->val2 =   dt_alloc_align_float(slots);
+  seg->border = border;
+  seg->slots = slots;
+  seg->width = width;
+  seg->height = height;
+  seg->tmp = NULL;
+}
+
+void dt_segmentation_free_struct(dt_iop_segmentation_t *seg)
+{
+  dt_free_align(seg->data);
+  dt_free_align(seg->size);
+  dt_free_align(seg->xmin);
+  dt_free_align(seg->ymin);
+  dt_free_align(seg->xmax);
+  dt_free_align(seg->ymax);
+  dt_free_align(seg->ref);
+  dt_free_align(seg->val1);
+  dt_free_align(seg->val2);
+  dt_free_align(seg->tmp);
 }
 


### PR DESCRIPTION
No changes that can be of relevance for user developed images or UI.

Two fixes:
1. For very large and highlights-noisy images the fixed maximum number of segments was slightly too small.
2. If the are no valid white balance coeffs found the algo is just bypassed

The segmentation functions and morphological operations now all use const data found in the segments struct like width, height, border size and maximum number of segments leading to a simpler interface.

Some macro and function renaming, a few int -> size_t changes for extremely large images A subtle performance gain