### PR TITLE
Remove the `opencl_synch_cache` conf option

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -346,19 +346,6 @@
     <longdescription>allows runtime tuning of OpenCL devices. 'memory size' uses a fixed headroom (400MB as default), 'memory transfer' tries a faster memory access mode (pinned memory) used for tiling.</longdescription>
   </dtconfig>
   <dtconfig>
-    <name>opencl_synch_cache</name>
-    <type>
-      <enum>
-        <option>true</option>
-        <option>active module</option>
-        <option>false</option>
-      </enum>
-    </type>
-    <default>active module</default>
-    <shortdescription>cache intermediate OpenCL output</shortdescription>
-    <longdescription>active module (default) - cache the input to the currently focused module, which allows for faster response time when making multiple adjustments to that module (though the whole pipeline may need to be reprocessed when another module is changed); true - cache the output after each module, which may improve speed, as the whole pixelpipe won't be reprocessed on every parameter change, though will require more memory transfers from the GPU; false - do not sync the pixelpipe cache from OpenCL, which avoids memory transfers from GPUs fast enough to smoothly reprocess the whole pixelpipe.</longdescription>
-  </dtconfig>
-  <dtconfig>
     <name>opencl_library</name>
     <type>string</type>
     <default/>

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -61,8 +61,6 @@ static void dt_opencl_priorities_parse(dt_opencl_t *cl, const char *configstr);
 static void dt_opencl_update_priorities(const char *configstr);
 /** read scheduling profile for config variables */
 static dt_opencl_scheduling_profile_t dt_opencl_get_scheduling_profile(void);
-/** read config of when/if to sync to cache */
-static dt_opencl_sync_cache_t dt_opencl_get_sync_cache(void);
 /** adjust opencl subsystem according to scheduling profile */
 static void dt_opencl_apply_scheduling_profile(dt_opencl_scheduling_profile_t profile);
 /** set opencl specific synchronization timeout */
@@ -856,7 +854,6 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboole
   char *locale = strdup(setlocale(LC_ALL, NULL));
   setlocale(LC_ALL, "C");
 
-  cl->sync_cache = dt_opencl_get_sync_cache();
   cl->crc = 5781;
   cl->dlocl = NULL;
   cl->dev_priority_image = NULL;
@@ -896,8 +893,6 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboole
   dt_print_nts(DT_DEBUG_OPENCL, "[opencl_init] opencl_device_priority: '%s'\n", str);
   dt_print_nts(DT_DEBUG_OPENCL, "[opencl_init] opencl_mandatory_timeout: %d\n",
            dt_conf_get_int("opencl_mandatory_timeout"));
-  str = dt_conf_get_string_const("opencl_synch_cache");
-  dt_print_nts(DT_DEBUG_OPENCL, "[opencl_init] opencl_synch_cache: %s\n", str);
 
   // dynamically load opencl runtime
   if((cl->dlocl = dt_dlopencl_init(library)) == NULL)
@@ -2958,22 +2953,6 @@ int dt_opencl_get_tuning_mode(void)
     else if(!strcmp(pstr, "memory size and transfer")) res = DT_OPENCL_TUNE_MEMSIZE | DT_OPENCL_TUNE_PINNED;
   }
   return res;  
-}
-
-/** read config of when/if to synch to cache */
-static dt_opencl_sync_cache_t dt_opencl_get_sync_cache(void)
-{
-  const char *pstr = dt_conf_get_string_const("opencl_synch_cache");
-  if(!pstr) return OPENCL_SYNC_ACTIVE_MODULE;
-
-  dt_opencl_sync_cache_t sync = OPENCL_SYNC_ACTIVE_MODULE;
-
-  if(!strcmp(pstr, "true"))
-    sync = OPENCL_SYNC_TRUE;
-  else if(!strcmp(pstr, "false"))
-    sync = OPENCL_SYNC_FALSE;
-
-  return sync;
 }
 
 /** set opencl specific synchronization timeout */

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -77,13 +77,6 @@ typedef enum dt_opencl_scheduling_profile_t
   OPENCL_PROFILE_VERYFAST_GPU
 } dt_opencl_scheduling_profile_t;
 
-typedef enum dt_opencl_sync_cache_t
-{
-  OPENCL_SYNC_TRUE,
-  OPENCL_SYNC_ACTIVE_MODULE,
-  OPENCL_SYNC_FALSE
-} dt_opencl_sync_cache_t;
-
 /**
  * Accounting information used for OpenCL events.
  */
@@ -221,7 +214,6 @@ typedef struct dt_opencl_t
   dt_pthread_mutex_t lock;
   int inited;
   int print_statistics;
-  dt_opencl_sync_cache_t sync_cache;
   int enabled;
   int stopped;
   int num_devs;


### PR DESCRIPTION
The conf option intended to improve the user interface responsiveness in darkroom by opting for writing cl_mem to cache line buffers.

With the new iop cache this can only degrade UI performance
1. if set to OFF the whole pixelpipe is reprocessed in all cases, with the modules like laplacian highlights, diffuse&sharpen and others the amount of processing might be very heavy even on the fastest cards.
2. ALWAYS_ON would just pollute the cache leading to a significant drop in hit rate.

So - let's trust the iop cache for full & preview pipes in all cases if
1. module is expanded or
2. there is an `important` hint
