### PR TITLE
Inpaint opposed highlights reconstruction [WIP] [RFC]

### DIFF
--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -111,7 +111,7 @@ typedef struct dt_iop_highlights_params_t
   // params of v1
   dt_iop_highlights_mode_t mode; // $DEFAULT: DT_IOP_HIGHLIGHTS_CLIP $DESCRIPTION: "method"
   float blendL; // unused $DEFAULT: 1.0
-  float chrominance; // $MIN: -0.5 $MAX: 0.5 $DEFAULT: 0.0 $DESCRIPTION: "cast control"
+  float chrominance; // $MIN: -0.2 $MAX: 0.2 $DEFAULT: 0.0 $DESCRIPTION: "cast control"
   float strength; // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "strength"
   // params of v2
   float clip; // $MIN: 0.0 $MAX: 2.0 $DEFAULT: 1.0 $DESCRIPTION: "clipping threshold"
@@ -503,8 +503,8 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
     }
     else
     {
-      tiling->xalign = 3;
-      tiling->yalign = 3;
+      tiling->xalign = 6;
+      tiling->yalign = 6;
       tiling->factor = 2.7f; // in & out plus plane buffers including some border safety
       tiling->overlap = 6;
     }
@@ -2395,6 +2395,11 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_widget_set_quad_active(g->candidating, FALSE);
   g_signal_connect(G_OBJECT(g->candidating), "quad-pressed", G_CALLBACK(_candidating_callback), self);
 
+  g->chrominance = dt_bauhaus_slider_from_params(self, "chrominance");
+  dt_bauhaus_slider_set_digits(g->chrominance, 2);
+  gtk_widget_set_tooltip_text(g->chrominance, _("tune the color casting via global averaged chrominance means.\n"
+                                                "might be necessary especially for images with strong global contrast or bad white balance"));
+ 
   g->recovery = dt_bauhaus_combobox_from_params(self, "recovery");
   gtk_widget_set_tooltip_text(g->recovery, _("approximate lost data in regions with all photosites clipped, the effect depends on segment size and border gradients.\n"
                                              "choose a mode tuned for segment size or the generic mode that tries to find best settings for every segment.\n"
@@ -2410,11 +2415,6 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_widget_set_quad_active(g->strength, FALSE);
   g_signal_connect(G_OBJECT(g->strength), "quad-pressed", G_CALLBACK(_strength_callback), self);
 
-  g->chrominance = dt_bauhaus_slider_from_params(self, "chrominance");
-  dt_bauhaus_slider_set_format(g->chrominance, "%");
-  dt_bauhaus_slider_set_step(g->candidating, 0.05f);
-  gtk_widget_set_tooltip_text(g->chrominance, _("reduce a color cast by global averaged chrominance means"));
- 
   g->noise_level = dt_bauhaus_slider_from_params(self, "noise_level");
   gtk_widget_set_tooltip_text(g->noise_level, _("add noise to visually blend the reconstructed areas\n"
                                                 "into the rest of the noisy image. useful at high ISO."));

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -498,14 +498,16 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
     {
       tiling->xalign = 2;
       tiling->yalign = 2;
+      tiling->factor = 3.1f; // in & out plus plane buffers including some border safety
+      tiling->overlap = 4;
     }
     else
     {
       tiling->xalign = 3;
       tiling->yalign = 3;
+      tiling->factor = 2.7f; // in & out plus plane buffers including some border safety
+      tiling->overlap = 6;
     }
-    tiling->overlap = 6;
-    tiling->factor = 3.0f; // in & out plus plane buffers including some border safety
     tiling->maxbuf = 1.0f;
     tiling->overhead = 0;
     return;
@@ -2077,7 +2079,11 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
     case DT_IOP_HIGHLIGHTS_OPPOSED:
     {
-      _process_opposed(piece, ivoid, ovoid, roi_in, roi_out, filters, data);
+      if(filters == 9u)
+        _process_opposed_xtrans(piece, ivoid, ovoid, roi_in, roi_out, data);
+      else
+        _process_opposed_bayer(piece, ivoid, ovoid, roi_in, roi_out, data);
+
       break;
     }
 

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -2201,7 +2201,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   const gboolean use_laplacian = bayer && mode == DT_IOP_HIGHLIGHTS_LAPLACIAN;
   const gboolean use_segmentation = bayer && (mode == DT_IOP_HIGHLIGHTS_SEGMENTS);
   const gboolean use_recovery = use_segmentation && (p->recovery != DT_RECOVERY_MODE_OFF);
-  const gboolean use_balance = (mode == DT_IOP_HIGHLIGHTS_OPPOSED);
+  const gboolean use_balance = FALSE; // (mode == DT_IOP_HIGHLIGHTS_OPPOSED);
   gtk_widget_set_visible(g->noise_level, use_laplacian || use_recovery);
   gtk_widget_set_visible(g->iterations, use_laplacian);
   gtk_widget_set_visible(g->scales, use_laplacian);

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -1,0 +1,154 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2022 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define HL_OPP_SENSOR_PLANES 4
+static void _process_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+                         const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
+                         const uint32_t filters, dt_iop_highlights_data_t *data)
+{
+  const float *const in = (const float *const)ivoid;
+  float *const out = (float *const)ovoid;
+
+  const float clipval = 0.987f * data->clip;
+
+  const int width = roi_out->width;
+  const int height = roi_out->height;
+  const int pwidth  = ((width + 1 ) / 2) + (2 * HL_BORDER);
+  const int pheight = ((height + 1) / 2) + (2 * HL_BORDER);
+  const size_t p_size = plane_size(pwidth, pheight);
+
+  const size_t p_off  = (HL_BORDER * pwidth) + HL_BORDER;
+
+  dt_iop_image_copy(out, in, width * height);
+
+  dt_aligned_pixel_t icoeffs = { piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1], piece->pipe->dsc.temperature.coeffs[2], 0.0f};
+  // doesn't work with incorrect coeffs or no defined filter
+  if((filters == 0) || (icoeffs[0] < 0.1f) || (icoeffs[1] < 0.1f) || (icoeffs[2] < 0.1f)) return;
+
+  dt_times_t time0 = { 0 }, time1 = { 0 };
+  dt_get_times(&time0);
+
+  float *fbuffer = dt_alloc_align_float(HL_OPP_SENSOR_PLANES * 2 * p_size);
+
+  const dt_aligned_pixel_t clips = { clipval * icoeffs[0], clipval * icoeffs[1], clipval * icoeffs[1], clipval * icoeffs[2]}; 
+  const dt_aligned_pixel_t coeffs = { powf(clips[0], 1.0f / 3.0f), powf(clips[1], 1.0f / 3.0f), powf(clips[2], 1.0f / 3.0f), powf(clips[3], 1.0f / 3.0f)};
+
+  float *plane[HL_OPP_SENSOR_PLANES];
+  float *refavg[HL_OPP_SENSOR_PLANES];
+
+  for(int i = 0; i < HL_OPP_SENSOR_PLANES; i++)
+  {
+    plane[i]  = fbuffer + i * p_size;
+    refavg[i] = plane[i] + HL_OPP_SENSOR_PLANES * p_size; 
+  }
+
+/*
+  We fill the planes [0-3] by the data from the photosites.
+  These will be modified by the reconstruction algorithm and eventually written to out.
+  The size of input rectangle can be odd meaning the planes might be not exactly of equal size
+  so we possibly fill latest row/col by previous.
+*/
+
+  int has_clipped = 0;
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  reduction( | : has_clipped) \
+  dt_omp_firstprivate(in, plane, clips) \
+  dt_omp_sharedconst(width, p_off, height, pwidth, filters) \
+  schedule(static) aligned(in, plane : 64)
+#endif
+  for(size_t row = 0; row < height; row++)
+  {
+    for(size_t col = 0, i = row*width; col < width; col++, i++)
+    {
+      const int p = _pos2plane(row, col, filters);
+      const size_t o = (row/2)*pwidth + (col/2) + p_off;
+      const float ival = fmaxf(0.0f, in[i]);
+      if(ival > clips[p]) has_clipped |= 1;
+      const float val = powf(ival, 1.0f / 3.0f);
+      plane[p][o] = val;
+
+      if(col >= width-2)      plane[p][o+1] = val;
+      if(row >= height-2)     plane[p][o+pwidth] = val;
+    }
+  }
+
+  if(!has_clipped) goto finish;
+
+  for(int i = 0; i < HL_OPP_SENSOR_PLANES; i++)
+    dt_masks_extend_border(plane[i], pwidth, pheight, HL_BORDER);
+
+
+  // Calculate opponent channel weighted means
+  const float weights[4][4] = {
+    { 0.0f, 0.25f, 0.25f, 0.5f },
+    { 0.5f,  0.0f,  0.0f, 0.5f },
+    { 0.5f,  0.0f,  0.0f, 0.5f },
+    { 0.5f, 0.25f, 0.25f, 0.0f },
+  };
+#ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+  dt_omp_firstprivate(plane, refavg, weights) \
+  dt_omp_sharedconst(pwidth, pheight) \
+  schedule(static) collapse(2)
+#endif
+  for(size_t row = 0; row < pheight; row++)
+  {
+    for(size_t col = 0; col < pwidth; col++)
+    {
+      const size_t i = row * pwidth + col;
+      for(int p = 0; p < HL_REF_PLANES; p++)
+      {
+        refavg[p][i] =
+          weights[p][0] * plane[0][i] +
+          weights[p][1] * plane[1][i] +
+          weights[p][2] * plane[2][i] +
+          weights[p][3] * plane[3][i];
+      }
+    }
+  }
+
+#ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+  dt_omp_firstprivate(out, in, plane, clips, coeffs, refavg) \
+  dt_omp_sharedconst(width, height, pwidth, p_off, filters) \
+  schedule(static)
+#endif
+  for(size_t row = 0; row < height; row++)
+  {
+    for(size_t col = 0, o = row * width; col < width; col++, o++)
+    {
+      const int p = _pos2plane(row, col, filters);
+      const float ival = fmaxf(0.0f, in[o]);
+      if(ival > clips[p])
+      {
+        const size_t i = (row/2)*pwidth + (col/2) + p_off;
+        const float oval = fmaxf(coeffs[p], refavg[p][i]);
+        out[o] = powf(oval, 3.0f);
+      }
+    }
+  }
+
+  finish:
+  dt_get_times(&time1);
+  dt_print(DT_DEBUG_PERF, "[inpaint opposed] %.1fMpix. Tim3: %.3fs.%s\n",
+       (float) (width * height) / 1.0e6f, time1.clock - time0.clock, (!has_clipped) ? " no clipped data" : "");
+
+  dt_free_align(fbuffer);
+}
+

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -16,11 +16,123 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#define HL_OPP_SENSOR_PLANES 4
-static void _process_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+#define HL_OPP_SENSOR_PLANES 3
+static void _process_opposed_xtrans(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
                          const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
-                         const uint32_t filters, dt_iop_highlights_data_t *data)
+                         dt_iop_highlights_data_t *data)
 {
+  const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
+
+  const float *const in = (const float *const)ivoid;
+  float *const out = (float *const)ovoid;
+
+  const float clipval = 0.987f * data->clip;
+
+  const int width = roi_out->width;
+  const int height = roi_out->height;
+  const int pwidth  = ((width + 2 ) / 3) + (2 * HL_BORDER);
+  const int pheight = ((height + 2) / 3) + (2 * HL_BORDER);
+  const size_t p_size = plane_size(pwidth, pheight);
+
+  const size_t p_off  = (HL_BORDER * pwidth) + HL_BORDER;
+
+  dt_iop_image_copy(out, in, width * height);
+
+  dt_aligned_pixel_t icoeffs = { piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1], piece->pipe->dsc.temperature.coeffs[2], 0.0f};
+  // doesn't work with incorrect coeffs or no defined filter
+  if((icoeffs[0] < 0.1f) || (icoeffs[1] < 0.1f) || (icoeffs[2] < 0.1f)) return;
+
+  dt_times_t time0 = { 0 }, time1 = { 0 };
+  dt_get_times(&time0);
+
+  float *fbuffer = dt_alloc_align_float(HL_OPP_SENSOR_PLANES * 2 * p_size);
+
+  const dt_aligned_pixel_t clips = { clipval * icoeffs[0], clipval * icoeffs[1], clipval * icoeffs[2], 0.0f}; 
+  const dt_aligned_pixel_t coeffs = { powf(clips[0], 1.0f / 3.0f), powf(clips[1], 1.0f / 3.0f), powf(clips[2], 1.0f / 3.0f), 0.0f};
+
+  float *plane[HL_OPP_SENSOR_PLANES];
+  float *refavg[HL_OPP_SENSOR_PLANES];
+
+  for(int i = 0; i < HL_OPP_SENSOR_PLANES; i++)
+  {
+    plane[i]  = fbuffer + i * p_size;
+    dt_iop_image_fill(plane[i], 0.0f, pwidth, pheight, 1);
+    refavg[i] = plane[i] + HL_OPP_SENSOR_PLANES * p_size; 
+  }
+
+  const float corrections[3] = { 0.5f, 0.2f, 0.5f };  
+  int has_clipped = 0;
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  reduction( | : has_clipped) \
+  dt_omp_firstprivate(in, plane, clips, corrections, roi_in) \
+  dt_omp_sharedconst(width, p_off, height, pwidth, xtrans) \
+  schedule(static) aligned(in, plane : 64)
+#endif
+  for(size_t row = 0; row < height; row++)
+  {
+    for(size_t col = 0, i = row*width; col < width; col++, i++)
+    {
+      const int c = FCxtrans(row, col, roi_in, xtrans);
+      const size_t o = (row/3)*pwidth + (col/3) + p_off;
+      const float ival = fmaxf(0.0f, in[i]);
+      if(ival > clips[c]) has_clipped |= 1;
+      const float val = corrections[c] * powf(ival, 1.0f / 3.0f);
+      plane[c][o] += val;
+
+      if(col >= width-2)      plane[c][o+1] += val;
+      if(row >= height-2)     plane[c][o+pwidth] += val;
+    }
+  }
+
+  if(!has_clipped) goto finish;
+
+#ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+  dt_omp_firstprivate(plane, refavg) \
+  dt_omp_sharedconst(pwidth, pheight) \
+  schedule(static)
+#endif
+  for(size_t i = 0; i < pwidth * pheight; i++)
+  {
+    refavg[0][i] = 0.5f * (plane[1][i] + plane[2][i]);
+    refavg[1][i] = 0.5f * (plane[0][i] + plane[2][i]);
+    refavg[2][i] = 0.5f * (plane[0][i] + plane[1][i]);
+  }
+
+#ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+  dt_omp_firstprivate(out, in, plane, clips, coeffs, refavg, roi_in) \
+  dt_omp_sharedconst(width, height, pwidth, p_off, xtrans) \
+  schedule(static)
+#endif
+  for(size_t row = 0; row < height; row++)
+  {
+    for(size_t col = 0, o = row * width; col < width; col++, o++)
+    {
+      const int c = FCxtrans(row, col, roi_in, xtrans);
+      const float ival = fmaxf(0.0f, in[o]);
+      if(ival > clips[c])
+      {
+        const size_t i = (row/3)*pwidth + (col/3) + p_off;
+        const float oval = fmaxf(coeffs[c], refavg[c][i]);
+        out[o] = powf(oval, 3.0f);
+      }
+    }
+  }
+
+  finish:
+  dt_get_times(&time1);
+  dt_print(DT_DEBUG_PERF, "[inpaint opposed report] %.1fMpix in %.3fs%s\n",
+       (float) (width * height) / 1.0e6f, time1.clock - time0.clock, (!has_clipped) ? ", no clipped data." : ".");
+
+  dt_free_align(fbuffer);
+}
+static void _process_opposed_bayer(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+                         const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
+                         dt_iop_highlights_data_t *data)
+{
+  const uint32_t filters = piece->pipe->dsc.filters;
   const float *const in = (const float *const)ivoid;
   float *const out = (float *const)ovoid;
 
@@ -38,15 +150,15 @@ static void _process_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const iv
 
   dt_aligned_pixel_t icoeffs = { piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1], piece->pipe->dsc.temperature.coeffs[2], 0.0f};
   // doesn't work with incorrect coeffs or no defined filter
-  if((filters == 0) || (icoeffs[0] < 0.1f) || (icoeffs[1] < 0.1f) || (icoeffs[2] < 0.1f)) return;
+  if((icoeffs[0] < 0.1f) || (icoeffs[1] < 0.1f) || (icoeffs[2] < 0.1f)) return;
 
   dt_times_t time0 = { 0 }, time1 = { 0 };
   dt_get_times(&time0);
 
   float *fbuffer = dt_alloc_align_float(HL_OPP_SENSOR_PLANES * 2 * p_size);
 
-  const dt_aligned_pixel_t clips = { clipval * icoeffs[0], clipval * icoeffs[1], clipval * icoeffs[1], clipval * icoeffs[2]}; 
-  const dt_aligned_pixel_t coeffs = { powf(clips[0], 1.0f / 3.0f), powf(clips[1], 1.0f / 3.0f), powf(clips[2], 1.0f / 3.0f), powf(clips[3], 1.0f / 3.0f)};
+  const dt_aligned_pixel_t clips = { clipval * icoeffs[0], clipval * icoeffs[1], clipval * icoeffs[2], 0.0f}; 
+  const dt_aligned_pixel_t coeffs = { powf(clips[0], 1.0f / 3.0f), powf(clips[1], 1.0f / 3.0f), powf(clips[2], 1.0f / 3.0f), 0.0f};
 
   float *plane[HL_OPP_SENSOR_PLANES];
   float *refavg[HL_OPP_SENSOR_PLANES];
@@ -54,21 +166,16 @@ static void _process_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const iv
   for(int i = 0; i < HL_OPP_SENSOR_PLANES; i++)
   {
     plane[i]  = fbuffer + i * p_size;
+    dt_iop_image_fill(plane[i], 0.0f, pwidth, pheight, 1);
     refavg[i] = plane[i] + HL_OPP_SENSOR_PLANES * p_size; 
   }
 
-/*
-  We fill the planes [0-3] by the data from the photosites.
-  These will be modified by the reconstruction algorithm and eventually written to out.
-  The size of input rectangle can be odd meaning the planes might be not exactly of equal size
-  so we possibly fill latest row/col by previous.
-*/
-
+  const float corrections[3] = { 1.0f, 0.5f, 1.0f };  
   int has_clipped = 0;
 #ifdef _OPENMP
   #pragma omp parallel for simd default(none) \
   reduction( | : has_clipped) \
-  dt_omp_firstprivate(in, plane, clips) \
+  dt_omp_firstprivate(in, plane, clips, corrections) \
   dt_omp_sharedconst(width, p_off, height, pwidth, filters) \
   schedule(static) aligned(in, plane : 64)
 #endif
@@ -76,51 +183,31 @@ static void _process_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const iv
   {
     for(size_t col = 0, i = row*width; col < width; col++, i++)
     {
-      const int p = _pos2plane(row, col, filters);
+      const int c = FC(row, col, filters);
       const size_t o = (row/2)*pwidth + (col/2) + p_off;
       const float ival = fmaxf(0.0f, in[i]);
-      if(ival > clips[p]) has_clipped |= 1;
-      const float val = powf(ival, 1.0f / 3.0f);
-      plane[p][o] = val;
+      if(ival > clips[c]) has_clipped |= 1;
+      const float val = corrections[c] * powf(ival, 1.0f / 3.0f);
+      plane[c][o] += val;
 
-      if(col >= width-2)      plane[p][o+1] = val;
-      if(row >= height-2)     plane[p][o+pwidth] = val;
+      if(col >= width-2)      plane[c][o+1] += val;
+      if(row >= height-2)     plane[c][o+pwidth] += val;
     }
   }
 
   if(!has_clipped) goto finish;
 
-  for(int i = 0; i < HL_OPP_SENSOR_PLANES; i++)
-    dt_masks_extend_border(plane[i], pwidth, pheight, HL_BORDER);
-
-
-  // Calculate opponent channel weighted means
-  const float weights[4][4] = {
-    { 0.0f, 0.25f, 0.25f, 0.5f },
-    { 0.5f,  0.0f,  0.0f, 0.5f },
-    { 0.5f,  0.0f,  0.0f, 0.5f },
-    { 0.5f, 0.25f, 0.25f, 0.0f },
-  };
 #ifdef _OPENMP
   #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(plane, refavg, weights) \
+  dt_omp_firstprivate(plane, refavg) \
   dt_omp_sharedconst(pwidth, pheight) \
-  schedule(static) collapse(2)
+  schedule(static)
 #endif
-  for(size_t row = 0; row < pheight; row++)
+  for(size_t i = 0; i < pwidth * pheight; i++)
   {
-    for(size_t col = 0; col < pwidth; col++)
-    {
-      const size_t i = row * pwidth + col;
-      for(int p = 0; p < HL_REF_PLANES; p++)
-      {
-        refavg[p][i] =
-          weights[p][0] * plane[0][i] +
-          weights[p][1] * plane[1][i] +
-          weights[p][2] * plane[2][i] +
-          weights[p][3] * plane[3][i];
-      }
-    }
+    refavg[0][i] = 0.5f * (plane[1][i] + plane[2][i]);
+    refavg[1][i] = 0.5f * (plane[0][i] + plane[2][i]);
+    refavg[2][i] = 0.5f * (plane[0][i] + plane[1][i]);
   }
 
 #ifdef _OPENMP
@@ -133,12 +220,12 @@ static void _process_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const iv
   {
     for(size_t col = 0, o = row * width; col < width; col++, o++)
     {
-      const int p = _pos2plane(row, col, filters);
+      const int c = FC(row, col, filters);
       const float ival = fmaxf(0.0f, in[o]);
-      if(ival > clips[p])
+      if(ival > clips[c])
       {
         const size_t i = (row/2)*pwidth + (col/2) + p_off;
-        const float oval = fmaxf(coeffs[p], refavg[p][i]);
+        const float oval = fmaxf(coeffs[c], refavg[c][i]);
         out[o] = powf(oval, 3.0f);
       }
     }
@@ -146,8 +233,8 @@ static void _process_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const iv
 
   finish:
   dt_get_times(&time1);
-  dt_print(DT_DEBUG_PERF, "[inpaint opposed] %.1fMpix. Tim3: %.3fs.%s\n",
-       (float) (width * height) / 1.0e6f, time1.clock - time0.clock, (!has_clipped) ? " no clipped data" : "");
+  dt_print(DT_DEBUG_PERF, "[inpaint opposed report] %.1fMpix in %.3fs%s\n",
+       (float) (width * height) / 1.0e6f, time1.clock - time0.clock, (!has_clipped) ? ", no clipped data." : ".");
 
   dt_free_align(fbuffer);
 }


### PR DESCRIPTION
I am still not pleased with the highlights reconstruction algorithms. We currently have the
1. "clip" algorithm as default and on for raws. It often introduces a color cast in blown out areas and looses all details there.
2. "Reconstruct in LCh" is often better
3. "reconstruct color" likes maze pattern artefacts that can't be controlled
4. "guided laplacians" is often good for detail, doesn't handle color casts well and is very slow if you need to handle larger areas. Not for xtrans
5.  "segmentation based" requires user action for best results except you disable the segmentation. Not for xtrans too.

While working on the segmentation based stuff we became aware of how good the opposed inpainting works in many cases so i implemented a stripped down version of it only doing the inpainting (no finding of best candidates). This code
1. works for both bayer and xtrans
7. is pretty fast
8. could be efficiently done in OpenCL also

So i would like
1. More people to test, evaluate the quality and give feedback
2. Especially from the fuji world as i don't have a great number of images 
 