### PR TITLE
UI text: mistakes are corrected, not solved

### DIFF
--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2806,8 +2806,8 @@ static void _dt_dev_image_changed_callback(gpointer instance, dt_lib_module_t *s
     gtk_label_set_markup
       (GTK_LABEL(d->deprecated),
        _("the following modules are deprecated because they have internal design mistakes"
-         " which can't be solved and alternative modules which solve them.\n"
-         " they will be removed for new edits in the next release."));
+         " that can't be corrected and alternative modules that correct them.\n"
+         "they will be removed for new edits in the next release."));
   }
 
 }
@@ -2874,8 +2874,8 @@ void gui_init(dt_lib_module_t *self)
   // deprecated message
   d->deprecated
       = gtk_label_new(_("the following modules are deprecated because they have internal design mistakes"
-                        " which can't be solved and alternative modules which solve them.\nthey will be removed for"
-                        " new edits in the next release."));
+                        " that can't be corrected and alternative modules that correct them.\n"
+                        "they will be removed for new edits in the next release."));
   dt_gui_add_class(d->deprecated, "dt_warning");
   gtk_label_set_line_wrap(GTK_LABEL(d->deprecated), TRUE);
   gtk_box_pack_start(GTK_BOX(self->widget), d->deprecated, TRUE, TRUE, 0);


### PR DESCRIPTION
An extra leading space in the second line of one of the messages was also removed (the messages should have been identical, but because of this space they were not).
