### PR TITLE
Introduce balanced OpenCL vs CPU tiling

### DIFF
--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -194,8 +194,11 @@ typedef struct dt_opencl_device_t
   int disabled;
 
   // Some devices are known to be unused by other apps so there is no need to test for available memory at all.
-  // Also some devices might behave badly with the checking code, in this case we could enforce a headroom here.
   int forced_headroom;
+
+  // As the benchmarks are not good enough to calculate tiled-gpu vs untiled-cpu we have a parameter exposed
+  // in the cldevice conf key to balance this
+  float advantage;  
 } dt_opencl_device_t;
 
 struct dt_bilateral_cl_global_t;

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -2173,16 +2173,13 @@ void default_tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpi
   return;
 }
 
-int dt_tiling_piece_fits_host_memory(const size_t width, const size_t height, const unsigned bpp,
+gboolean dt_tiling_piece_fits_host_memory(const size_t width, const size_t height, const unsigned bpp,
                                      const float factor, const size_t overhead)
 {
   const size_t available = dt_get_available_mem();
   const size_t total = factor * width * height * bpp + overhead;
 
-  if(total <= available)
-    return TRUE;
-  else
-    return FALSE;
+  return (total <= available) ? TRUE : FALSE;
 }
 
 // clang-format off

--- a/src/develop/tiling.h
+++ b/src/develop/tiling.h
@@ -71,7 +71,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
                      const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
                      struct dt_develop_tiling_t *tiling);
 
-int dt_tiling_piece_fits_host_memory(const size_t width, const size_t height, const unsigned bpp,
+gboolean dt_tiling_piece_fits_host_memory(const size_t width, const size_t height, const unsigned bpp,
                                      const float factor, const size_t overhead);
 
 float dt_tiling_estimate_cpumem(struct dt_develop_tiling_t *tiling, struct dt_dev_pixelpipe_iop_t *piece,

--- a/src/develop/tiling.h
+++ b/src/develop/tiling.h
@@ -74,6 +74,15 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
 int dt_tiling_piece_fits_host_memory(const size_t width, const size_t height, const unsigned bpp,
                                      const float factor, const size_t overhead);
 
+float dt_tiling_estimate_cpumem(struct dt_develop_tiling_t *tiling, struct dt_dev_pixelpipe_iop_t *piece,
+                                        const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
+                                        const int max_bpp);
+
+#ifdef HAVE_OPENCL
+float dt_tiling_estimate_clmem(struct dt_develop_tiling_t *tiling, struct dt_dev_pixelpipe_iop_t *piece,
+                                          const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
+                                          const int max_bpp);
+#endif
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent


### PR DESCRIPTION
**Rationale**: On many machines we find pretty fast multicore cpus and a lot of system ram but a significantly gpu memory with somewhat resrticted number crunching power. There is no problem using OpenCL code in modules as long as that doesn't lead to excessive tiling with large overlapping areas. Such a situation was rare, now we have as examples D&S or laplacian highlights which might behave bad and it would have been better to use cpu code instead. One related issue is #11955 

Suggested "solutions" like per-module settings (whatever the complexity in the UI might be) are not good at all as runtime defined parameters are not taken into account.

**proposed solution**: follows two assumptions:
1. we have a proper benchmarking result measuring raw processing powers cpu vs cl device. (The results we already have in opencl.c are by far not good enough as they don't reflect real-world performance.)
2. the "overall processed memory" weighed by the tested performance in 1) is a good estimation of the resulting workload.

This pr introduces a decision in the opencl pixelpipe code
1. If the module can't be processed without tiling
2. and we have a user defined device specific advantage over cpu 
3. we estimate memory consumption cpu vs gpu
4. and thus decide if cpu code has an advantage over gpu

The per cl device **advantage** is found as the last entry in the cldevice specific conf key, the conf key is extended automatically and the advantage is set to zero disabling the check for now.

**How to** set up the advantage hint?

Measure performance (-d perf) in laplacian highlights after setting "diameter of reconstruction" to something high. While doing so make sure (by -d tiling) that the cl code doesn't tile. Check for execution times with opencl on and off. The advantage option can now be set to approx (cpu-time / gpu-time)

The code presented a) adds some complexity to tiling code b) does not lead to performance drops as long as the new parameter is untouched or properly set c) leads to performance gains in some modules especially if your graphics card is not a "power horse" and you have a fast cpu and lots of ram.

Edit: third set of opencl related changes for 4.2 
1. i checked the existing benchmark code, pre-heating cpu & gpu gives somewhat better results but not of real significance. Enlarging size of data in the benchmark is not always possible for small cards.