### PR TITLE
BUGFIX: highlights reconstruction visualize indicator

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -286,7 +286,8 @@ highlights_1f_clip (read_only image2d_t in, write_only image2d_t out, const int 
 
 kernel void
 highlights_false_color (read_only image2d_t in, write_only image2d_t out, const int width, const int height,
-                    const int rx, const int ry, const int filters, global const float *clips)
+                    const int rx, const int ry, const int filters, global const unsigned char (*const xtrans)[6],
+                    global const float *clips)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -294,7 +295,7 @@ highlights_false_color (read_only image2d_t in, write_only image2d_t out, const 
   if(x >= width || y >= height) return;
 
   const float ival = read_imagef(in, sampleri, (int2)(x, y)).x;
-  const int c = FC(y + ry, x + rx, filters);
+  const int c = (filters == 9u) ? FCxtrans(y + ry, x + rx, xtrans) : FC(y + ry, x + rx, filters);
   float oval = (ival < clips[c]) ? 0.2f * ival : 1.0f;
 
   write_imagef (out, (int2)(x, y), oval);

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -1935,7 +1935,7 @@ static void process_visualize(dt_dev_pixelpipe_iop_t *piece, const void *const i
     {
       const int c = is_xtrans ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
       const float ival = in[i];
-      out[i] = (ival < clips[c]) ? 0.01f * ival : 1.0f;
+      out[i] = (ival < clips[c]) ? 0.2f * ival : 1.0f;
     }
   }
 }


### PR DESCRIPTION
The false color indicator for clipped color planes was plain wrong for xtrans sensors.
Fixed for cpu and opencl code.