### PR TITLE
Manipulate masks without scrolling for tablet users

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2552,10 +2552,13 @@ static void _slider_add_step(GtkWidget *widget, float delta, guint state, gboole
 
   if(force || dt_modifier_is(state, GDK_SHIFT_MASK | GDK_CONTROL_MASK))
   {
-    if(d->factor > 0 ? d->pos < 0.0001 : d->pos > 0.9999) d->min = d->soft_min;
-    if(d->factor < 0 ? d->pos < 0.0001 : d->pos > 0.9999) d->max = d->soft_max;
+    if(d->factor > 0 ? d->pos < 0.0001 : d->pos > 0.9999) d->min = d->min > d->soft_min ? d->max : d->soft_min;
+    if(d->factor < 0 ? d->pos < 0.0001 : d->pos > 0.9999) d->max = d->max < d->soft_max ? d->min : d->soft_max;
     dt_bauhaus_slider_set(widget, value + delta);
   }
+  else if(!strcmp(d->format,"°") && (d->max - d->min) * d->factor == 360.0f
+          && fabsf(value + delta)/(d->max - d->min) < 2)
+    dt_bauhaus_slider_set(widget, fmodf(value + delta + d->max - 2*d->min, d->max - d->min) + d->min);
   else
     dt_bauhaus_slider_set(widget, CLAMP(value + delta, d->min, d->max));
 }

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2911,11 +2911,7 @@ static void _bauhaus_slider_value_change(dt_bauhaus_widget_t *w)
   }
 
   if(d->is_changed && d->is_dragging && !d->timeout_handle)
-  {
-    const int delay = CLAMP(darktable.develop->average_delay * 3 / 2, DT_BAUHAUS_SLIDER_VALUE_CHANGED_DELAY_MIN,
-                            DT_BAUHAUS_SLIDER_VALUE_CHANGED_DELAY_MAX);
-    d->timeout_handle = g_timeout_add(delay, _bauhaus_slider_value_change_dragging, w);
-  }
+    d->timeout_handle = g_idle_add(_bauhaus_slider_value_change_dragging, w);
 }
 
 static gboolean _bauhaus_slider_value_change_dragging(gpointer data)

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1358,7 +1358,6 @@ static gboolean _blendop_masks_add_shape(GtkWidget *widget, GdkEventButton *even
   // we create the new form
   dt_masks_form_t *form = dt_masks_create(bd->masks_type[this]);
   dt_masks_change_form_gui(form);
-  darktable.develop->form_gui->creation = TRUE;
   darktable.develop->form_gui->creation_module = self;
 
   if(continuous)

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1056,8 +1056,6 @@ void dt_dev_add_masks_history_item_ext(dt_develop_t *dev, dt_iop_module_t *_modu
 
 void dt_dev_add_masks_history_item(dt_develop_t *dev, dt_iop_module_t *module, gboolean enable)
 {
-  if(!darktable.gui || darktable.gui->reset) return;
-
   dt_dev_undo_start_record(dev);
 
   dt_pthread_mutex_lock(&dev->history_mutex);
@@ -2388,10 +2386,10 @@ void dt_dev_masks_list_remove(dt_develop_t *dev, int formid, int parentid)
     dev->proxy.masks.list_remove(dev->proxy.masks.module, formid, parentid);
 }
 void dt_dev_masks_selection_change(dt_develop_t *dev, struct dt_iop_module_t *module,
-                                   const int selectid, const int throw_event)
+                                   const int selectid)
 {
   if(dev->proxy.masks.module && dev->proxy.masks.selection_change)
-    dev->proxy.masks.selection_change(dev->proxy.masks.module, module, selectid, throw_event);
+    dev->proxy.masks.selection_change(dev->proxy.masks.module, module, selectid);
 }
 
 void dt_dev_snapshot_request(dt_develop_t *dev, const char *filename)

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -268,7 +268,7 @@ typedef struct dt_develop_t
       void (*list_remove)(struct dt_lib_module_t *self, int formid, int parentid);
       void (*list_update)(struct dt_lib_module_t *self);
       /* selected forms change */
-      void (*selection_change)(struct dt_lib_module_t *self, struct dt_iop_module_t *module, const int selectid, const int throw_event);
+      void (*selection_change)(struct dt_lib_module_t *self, struct dt_iop_module_t *module, const int selectid);
     } masks;
 
     // what is the ID of the module currently doing pipeline chromatic adaptation ?
@@ -444,7 +444,7 @@ void dt_dev_average_delay_update(const dt_times_t *start, uint32_t *average_dela
 void dt_dev_masks_list_change(dt_develop_t *dev);
 void dt_dev_masks_list_update(dt_develop_t *dev);
 void dt_dev_masks_list_remove(dt_develop_t *dev, int formid, int parentid);
-void dt_dev_masks_selection_change(dt_develop_t *dev, struct dt_iop_module_t *module, const int selectid, const int throw_event);
+void dt_dev_masks_selection_change(dt_develop_t *dev, struct dt_iop_module_t *module, const int selectid);
 
 /*
  * multi instances

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -636,6 +636,8 @@ int dt_masks_roundup(int num, int mult)
 #define DT_MASKS_CONF(type, shape, param) \
   (type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? "plugins/darkroom/spots/" #shape "_" #param : "plugins/darkroom/masks/" #shape "/" #param)
 
+void dt_masks_draw_anchor(cairo_t *cr, gboolean selected, const float zoom_scale, const float x, const float y);
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -633,6 +633,8 @@ int dt_masks_roundup(int num, int mult)
   return (rem == 0) ? num : num + mult - rem;
 }
 
+#define DT_MASKS_CONF(type, shape, param) \
+  (type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? "plugins/darkroom/spots/" #shape "_" #param : "plugins/darkroom/masks/" #shape "/" #param)
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -55,6 +55,18 @@ typedef enum dt_masks_state_t
   DT_MASKS_STATE_EXCLUSION = 1 << 6
 } dt_masks_state_t;
 
+typedef enum dt_masks_property_t
+{
+  DT_MASKS_PROPERTY_OPACITY,
+  DT_MASKS_PROPERTY_SIZE,
+  DT_MASKS_PROPERTY_HARDNESS,
+  DT_MASKS_PROPERTY_FEATHER,
+  DT_MASKS_PROPERTY_ROTATION,
+  DT_MASKS_PROPERTY_CURVATURE,
+  DT_MASKS_PROPERTY_COMPRESSION,
+  DT_MASKS_PROPERTY_LAST
+} dt_masks_property_t;
+
 typedef enum dt_masks_points_states_t
 {
   DT_MASKS_POINT_STATE_NORMAL = 1,
@@ -167,6 +179,7 @@ typedef struct dt_masks_functions_t
   void (*set_form_name)(struct dt_masks_form_t *const form, const size_t nb);
   void (*set_hint_message)(const struct dt_masks_form_gui_t *const gui, const struct dt_masks_form_t *const form,
                            const int opacity, char *const __restrict__ msgbuf, const size_t msgbuf_len);
+  void (*modify_property)(struct dt_masks_form_t *const form, dt_masks_property_t prop, float old_val, float new_val, float *sum, int *count, float *min, float *max);
   void (*duplicate_points)(struct dt_develop_t *const dev, struct dt_masks_form_t *base, struct dt_masks_form_t *dest);
   void (*initial_source_pos)(const float iwd, const float iht, float *x, float *y);
   void (*get_distance)(float x, float y, float as, struct dt_masks_form_gui_t *gui, int index, int num_points,
@@ -275,6 +288,7 @@ typedef struct dt_masks_form_gui_t
   int group_edited;
   int group_selected;
 
+  guint show_all_feathers;
 
   gboolean creation;
   gboolean creation_continuous;
@@ -404,7 +418,7 @@ int dt_masks_group_get_hash_buffer_length(dt_masks_form_t *form);
 char *dt_masks_group_get_hash_buffer(dt_masks_form_t *form, char *str);
 
 void dt_masks_form_remove(struct dt_iop_module_t *module, dt_masks_form_t *grp, dt_masks_form_t *form);
-void dt_masks_form_change_opacity(dt_masks_form_t *form, int parentid, int up);
+float dt_masks_form_change_opacity(dt_masks_form_t *form, int parentid, float amount);
 void dt_masks_form_move(dt_masks_form_t *grp, int formid, int up);
 int dt_masks_form_duplicate(dt_develop_t *dev, int formid);
 /* returns a duplicate tof form, including the formid */

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2907,6 +2907,18 @@ static void _brush_modify_property(dt_masks_form_t *const form, dt_masks_propert
   switch(prop)
   {
     case DT_MASKS_PROPERTY_SIZE:
+      if(gui->creation)
+      {
+        float masks_border = dt_conf_get_float(DT_MASKS_CONF(form->type, brush, border));
+        masks_border = MAX(BORDER_MIN, MIN(masks_border * ratio, BORDER_MAX));
+        dt_conf_set_float(DT_MASKS_CONF(form->type, brush, border), masks_border);
+
+        *sum += 2.0f * masks_border;
+        *max = fminf(*max, BORDER_MAX / masks_border);
+        *min = fmaxf(*min, BORDER_MIN / masks_border);
+        ++*count;
+      }
+      else
       for(GList *l = form->points; l; l = g_list_next(l))
       {
         if(gui->point_selected == -1 || gui->point_selected == pts_number)
@@ -2923,6 +2935,18 @@ static void _brush_modify_property(dt_masks_form_t *const form, dt_masks_propert
       }
       break;
     case DT_MASKS_PROPERTY_HARDNESS:
+      if(gui->creation)
+      {
+        float masks_hardness = dt_conf_get_float(DT_MASKS_CONF(form->type, brush, hardness));
+        masks_hardness = MAX(BORDER_MIN, MIN(masks_hardness * ratio, BORDER_MAX));
+        dt_conf_set_float(DT_MASKS_CONF(form->type, brush, hardness), masks_hardness);
+
+        *sum += masks_hardness;
+        *max = fminf(*max, HARDNESS_MAX / masks_hardness);
+        *min = fmaxf(*min, HARDNESS_MIN / masks_hardness);
+        ++*count;
+      }
+      else
       for(GList *l = form->points; l; l = g_list_next(l))
       {
         if(gui->point_selected == -1 || gui->point_selected == pts_number)

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2380,7 +2380,7 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
   }
 
   // draw corners
-  if((gui->show_all_feathers || gui->group_selected == index) && gpt->points_count > nb * 3 + 2)
+  if(gui->group_selected == index && gpt->points_count > nb * 3 + 2)
   {
     for(int k = 0; k < nb; k++)
       dt_masks_draw_anchor(cr, k == gui->point_dragging || k == gui->point_selected, zoom_scale,
@@ -2423,7 +2423,7 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
   }
 
   // draw border and corners
-  if((gui->group_selected == index) && gpt->border_count > nb * 3 + 2)
+  if((gui->show_all_feathers || gui->group_selected == index) && gpt->border_count > nb * 3 + 2)
   {
     cairo_move_to(cr, gpt->border[nb * 6], gpt->border[nb * 6 + 1]);
 

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1634,12 +1634,12 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
         else if(!gui->creation_continuous)
           dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
         dt_masks_iop_update(crea_module);
-        dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid, TRUE);
+        dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid);
         gui->creation_module = NULL;
       }
       else
       {
-        dt_dev_masks_selection_change(darktable.develop, NULL, form->formid, TRUE);
+        dt_dev_masks_selection_change(darktable.develop, NULL, form->formid);
       }
 
       if(gui->creation_continuous)

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2925,7 +2925,7 @@ static void _brush_modify_property(dt_masks_form_t *const form, dt_masks_propert
       if(gui->creation)
       {
         float masks_hardness = dt_conf_get_float(DT_MASKS_CONF(form->type, brush, hardness));
-        masks_hardness = MAX(BORDER_MIN, MIN(masks_hardness * ratio, BORDER_MAX));
+        masks_hardness = MAX(HARDNESS_MIN, MIN(masks_hardness * ratio, HARDNESS_MAX));
         dt_conf_set_float(DT_MASKS_CONF(form->type, brush, hardness), masks_hardness);
 
         *sum += masks_hardness;

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1196,7 +1196,6 @@ static int _brush_events_mouse_scrolled(struct dt_iop_module_t *module, float pz
       dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
       // we recreate the form points
-      dt_masks_gui_form_remove(form, gui, index);
       dt_masks_gui_form_create(form, gui, index, module);
 
       // we save the move
@@ -1317,7 +1316,6 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
         dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
         // we recreate the form points
-        dt_masks_gui_form_remove(form, gui, index);
         dt_masks_gui_form_create(form, gui, index, module);
         // we save the move
         dt_masks_update_image(darktable.develop);
@@ -1380,7 +1378,6 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
 
         form->points = g_list_insert(form->points, bzpt, gui->seg_selected + 1);
         _brush_init_ctrl_points(form);
-        dt_masks_gui_form_remove(form, gui, index);
         dt_masks_gui_form_create(form, gui, index, module);
         gui->point_edited = gui->point_dragging = gui->point_selected = gui->seg_selected + 1;
         gui->seg_selected = -1;
@@ -1460,7 +1457,6 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
     // we save the move
     dt_masks_update_image(darktable.develop);
@@ -1479,7 +1475,6 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
       dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
       // we recreate the form points
-      dt_masks_gui_form_remove(form, gui, index);
       dt_masks_gui_form_create(form, gui, index, module);
       // we save the move
       dt_masks_update_image(darktable.develop);
@@ -1744,7 +1739,6 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the move
@@ -1767,7 +1761,6 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the move
@@ -1812,7 +1805,6 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
     // we save the move
     dt_masks_update_image(darktable.develop);
@@ -1846,7 +1838,6 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
     // we save the move
     dt_masks_update_image(darktable.develop);
@@ -1914,7 +1905,6 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx, 
     bzpt->corner[1] = pzy;
     _brush_init_ctrl_points(form);
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;
@@ -1952,7 +1942,6 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx, 
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
 
     dt_control_queue_redraw_center();
@@ -1980,7 +1969,6 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx, 
 
     _brush_init_ctrl_points(form);
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;
@@ -2012,7 +2000,6 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx, 
     point->border[0] = point->border[1] = bdr;
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;
@@ -2048,7 +2035,6 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx, 
     }
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1660,7 +1660,6 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
           gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), FALSE);
           dt_masks_form_t *newform = dt_masks_create(form->type);
           dt_masks_change_form_gui(newform);
-          darktable.develop->form_gui->creation = TRUE;
           darktable.develop->form_gui->creation_module = crea_module;
           darktable.develop->form_gui->creation_continuous = TRUE;
           darktable.develop->form_gui->creation_continuous_module = crea_module;
@@ -1669,8 +1668,6 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
         {
           dt_masks_form_t *form_new = dt_masks_create(form->type);
           dt_masks_change_form_gui(form_new);
-
-          darktable.develop->form_gui->creation = TRUE;
           darktable.develop->form_gui->creation_module = gui->creation_continuous_module;
         }
       }

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2933,11 +2933,9 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module, const dt_dev
 static GSList *_brush_setup_mouse_actions(const struct dt_masks_form_t *const form)
 {
   GSList *lm = NULL;
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, 0, _("[BRUSH creation] change size"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_SHIFT_MASK,
-                                     _("[BRUSH creation] change hardness"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, 0, _("[BRUSH] change size"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_SHIFT_MASK, _("[BRUSH] change hardness"));
   lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_CONTROL_MASK, _("[BRUSH] change opacity"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, 0, _("[BRUSH] change hardness"));
   return lm;
 }
 

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2906,19 +2906,21 @@ static void _brush_modify_property(dt_masks_form_t *const form, dt_masks_propert
         ++*count;
       }
       else
-      for(GList *l = form->points; l; l = g_list_next(l))
       {
-        if(gui->point_selected == -1 || gui->point_selected == pts_number)
+        for(GList *l = form->points; l; l = g_list_next(l))
         {
-          dt_masks_point_brush_t *point = (dt_masks_point_brush_t *)l->data;
-          point->border[0] = CLAMP(point->border[0] * ratio, BORDER_MIN, BORDER_MAX);
-          point->border[1] = CLAMP(point->border[1] * ratio, BORDER_MIN, BORDER_MAX);
-          *sum += point->border[0] + point->border[1];
-          *max = fminf(*max, fminf(BORDER_MAX / point->border[0], BORDER_MAX / point->border[1]));
-          *min = fmaxf(*min, fmaxf(BORDER_MIN / point->border[0], BORDER_MIN / point->border[1]));
-          ++*count;
+          if(gui->point_selected == -1 || gui->point_selected == pts_number)
+          {
+            dt_masks_point_brush_t *point = (dt_masks_point_brush_t *)l->data;
+            point->border[0] = CLAMP(point->border[0] * ratio, BORDER_MIN, BORDER_MAX);
+            point->border[1] = CLAMP(point->border[1] * ratio, BORDER_MIN, BORDER_MAX);
+            *sum += point->border[0] + point->border[1];
+            *max = fminf(*max, fminf(BORDER_MAX / point->border[0], BORDER_MAX / point->border[1]));
+            *min = fmaxf(*min, fmaxf(BORDER_MIN / point->border[0], BORDER_MIN / point->border[1]));
+            ++*count;
+          }
+          pts_number++;
         }
-        pts_number++;
       }
       break;
     case DT_MASKS_PROPERTY_HARDNESS:
@@ -2934,18 +2936,20 @@ static void _brush_modify_property(dt_masks_form_t *const form, dt_masks_propert
         ++*count;
       }
       else
-      for(GList *l = form->points; l; l = g_list_next(l))
       {
-        if(gui->point_selected == -1 || gui->point_selected == pts_number)
+        for(GList *l = form->points; l; l = g_list_next(l))
         {
-          dt_masks_point_brush_t *point = (dt_masks_point_brush_t *)l->data;
-          point->hardness = CLAMP(point->hardness * ratio, HARDNESS_MIN, HARDNESS_MAX);
-          *sum += point->hardness;
-          *max = fminf(*max, HARDNESS_MAX / point->hardness);
-          *min = fmaxf(*min, HARDNESS_MIN / point->hardness);
-          ++*count;
+          if(gui->point_selected == -1 || gui->point_selected == pts_number)
+          {
+            dt_masks_point_brush_t *point = (dt_masks_point_brush_t *)l->data;
+            point->hardness = CLAMP(point->hardness * ratio, HARDNESS_MIN, HARDNESS_MAX);
+            *sum += point->hardness;
+            *max = fminf(*max, HARDNESS_MAX / point->hardness);
+            *min = fmaxf(*min, HARDNESS_MIN / point->hardness);
+            ++*count;
+          }
+          pts_number++;
         }
-        pts_number++;
       }
       break;
     default:;

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2383,31 +2383,8 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
   if(gui->group_selected == index && gpt->points_count > nb * 3 + 2)
   {
     for(int k = 0; k < nb; k++)
-    {
-      float anchor_size = 0.0f;
-      if(k == gui->point_dragging || k == gui->point_selected)
-      {
-        anchor_size = 7.0f / zoom_scale;
-      }
-      else
-      {
-        anchor_size = 5.0f / zoom_scale;
-      }
-      dt_draw_set_color_overlay(cr, TRUE, 0.8);
-      cairo_rectangle(cr, gpt->points[k * 6 + 2] - (anchor_size * 0.5),
-                      gpt->points[k * 6 + 3] - (anchor_size * 0.5), anchor_size, anchor_size);
-      cairo_fill_preserve(cr);
-
-      if((gui->group_selected == index) && (k == gui->point_dragging || k == gui->point_selected))
-        cairo_set_line_width(cr, 2.0 / zoom_scale);
-      else if((gui->group_selected == index)
-              && ((k == 0 || k == nb) && gui->creation && gui->creation_closing_form))
-        cairo_set_line_width(cr, 2.0 / zoom_scale);
-      else
-        cairo_set_line_width(cr, 1.0 / zoom_scale);
-      dt_draw_set_color_overlay(cr, FALSE, 0.8);
-      cairo_stroke(cr);
-    }
+      dt_masks_draw_anchor(cr, k == gui->point_dragging || k == gui->point_selected, zoom_scale,
+                           gpt->points[k * 6 + 2], gpt->points[k * 6 + 3]);
   }
 
   // draw feathers

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1095,20 +1095,9 @@ static int _brush_events_mouse_scrolled(struct dt_iop_module_t *module, float pz
     if(dt_modifier_is(state, GDK_SHIFT_MASK))
     {
       const float amount = up ? 1.03f : 0.97f;
-      float masks_hardness;
-
-      if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
-      {
-        masks_hardness = dt_conf_get_float("plugins/darkroom/spots/brush_hardness");
-        masks_hardness = MAX(HARDNESS_MIN, MIN(masks_hardness * amount, HARDNESS_MAX));
-        dt_conf_set_float("plugins/darkroom/spots/brush_hardness", masks_hardness);
-      }
-      else
-      {
-        masks_hardness = dt_conf_get_float("plugins/darkroom/masks/brush/hardness");
-        masks_hardness = MAX(HARDNESS_MIN, MIN(masks_hardness * amount, HARDNESS_MAX));
-        dt_conf_set_float("plugins/darkroom/masks/brush/hardness", masks_hardness);
-      }
+      float masks_hardness = dt_conf_get_float(DT_MASKS_CONF(form->type, brush, hardness));
+      masks_hardness = MAX(HARDNESS_MIN, MIN(masks_hardness * amount, HARDNESS_MAX));
+      dt_conf_set_float(DT_MASKS_CONF(form->type, brush, hardness), masks_hardness);
 
       if(gui->guipoints_count > 0)
       {
@@ -1119,20 +1108,10 @@ static int _brush_events_mouse_scrolled(struct dt_iop_module_t *module, float pz
     else if(dt_modifier_is(state, 0))
     {
       const float amount = up ? 1.03f : 0.97f;
-      float masks_border;
 
-      if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
-      {
-        masks_border = dt_conf_get_float("plugins/darkroom/spots/brush_border");
-        masks_border = MAX(BORDER_MIN, MIN(masks_border * amount, BORDER_MAX));
-        dt_conf_set_float("plugins/darkroom/spots/brush_border", masks_border);
-      }
-      else
-      {
-        masks_border = dt_conf_get_float("plugins/darkroom/masks/brush/border");
-        masks_border = MAX(BORDER_MIN, MIN(masks_border * amount, BORDER_MAX));
-        dt_conf_set_float("plugins/darkroom/masks/brush/border", masks_border);
-      }
+      float masks_border = dt_conf_get_float(DT_MASKS_CONF(form->type, brush, border));
+      masks_border = MAX(BORDER_MIN, MIN(masks_border * amount, BORDER_MAX));
+      dt_conf_set_float(DT_MASKS_CONF(form->type, brush, border), masks_border);
 
       if(gui->guipoints_count > 0)
       {
@@ -1175,18 +1154,9 @@ static int _brush_events_mouse_scrolled(struct dt_iop_module_t *module, float pz
           }
           pts_number++;
         }
-        if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
-        {
-          float masks_hardness = dt_conf_get_float("plugins/darkroom/spots/brush_hardness");
-          masks_hardness = MAX(HARDNESS_MIN, MIN(masks_hardness * amount, HARDNESS_MAX));
-          dt_conf_set_float("plugins/darkroom/spots/brush_hardness", masks_hardness);
-        }
-        else
-        {
-          float masks_hardness = dt_conf_get_float("plugins/darkroom/masks/brush/hardness");
-          masks_hardness = MAX(HARDNESS_MIN, MIN(masks_hardness * amount, HARDNESS_MAX));
-          dt_conf_set_float("plugins/darkroom/masks/brush/hardness", masks_hardness);
-        }
+        float masks_hardness = dt_conf_get_float(DT_MASKS_CONF(form->type, brush, hardness));
+        masks_hardness = MAX(HARDNESS_MIN, MIN(masks_hardness * amount, HARDNESS_MAX));
+        dt_conf_set_float(DT_MASKS_CONF(form->type, brush, hardness), masks_hardness);
       }
       else
       {
@@ -1214,20 +1184,10 @@ static int _brush_events_mouse_scrolled(struct dt_iop_module_t *module, float pz
           }
           pts_number++;
         }
-        if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
-        {
-          float masks_border = dt_conf_get_float("plugins/darkroom/spots/brush_border");
-          masks_border = MAX(BORDER_MIN, MIN(masks_border * amount, BORDER_MAX));
-          dt_conf_set_float("plugins/darkroom/spots/brush_border", masks_border);
-          dt_toast_log(_("size: %3.2f%%"), masks_border*2.f*100.f);
-        }
-        else
-        {
-          float masks_border = dt_conf_get_float("plugins/darkroom/masks/brush/border");
-          masks_border = MAX(BORDER_MIN, MIN(masks_border * amount, BORDER_MAX));
-          dt_conf_set_float("plugins/darkroom/masks/brush/border", masks_border);
-          dt_toast_log(_("size: %3.2f%%"), masks_border*2.f*100.f);
-        }
+        float masks_border = dt_conf_get_float(DT_MASKS_CONF(form->type, brush, border));
+        masks_border = MAX(BORDER_MIN, MIN(masks_border * amount, BORDER_MAX));
+        dt_conf_set_float(DT_MASKS_CONF(form->type, brush, border), masks_border);
+        dt_toast_log(_("size: %3.2f%%"), masks_border*2.f*100.f);
       }
 
       dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
@@ -1253,17 +1213,9 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
   dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return 0;
 
-  float masks_border = 0.0f;
-  if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
-    masks_border = MIN(dt_conf_get_float("plugins/darkroom/spots/brush_border"), BORDER_MAX);
-  else
-    masks_border = MIN(dt_conf_get_float("plugins/darkroom/masks/brush/border"), BORDER_MAX);
+  float masks_border = MIN(dt_conf_get_float(DT_MASKS_CONF(form->type, brush, border)), BORDER_MAX);
 
-  float masks_hardness = 0.0f;
-  if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
-    masks_hardness = MIN(dt_conf_get_float("plugins/darkroom/spots/brush_hardness"), HARDNESS_MAX);
-  else
-    masks_hardness = MIN(dt_conf_get_float("plugins/darkroom/masks/brush/hardness"), HARDNESS_MAX);
+  float masks_hardness = MIN(dt_conf_get_float(DT_MASKS_CONF(form->type, brush, hardness)), HARDNESS_MAX);
 
   // always start with a mask density of 100%, it will be adjusted with pen pressure if used.
   const float masks_density = 1.0f;
@@ -1572,11 +1524,7 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
   dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return 0;
 
-  float masks_border = 0.0f;
-  if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
-    masks_border = MIN(dt_conf_get_float("plugins/darkroom/spots/brush_border"), BORDER_MAX);
-  else
-    masks_border = MIN(dt_conf_get_float("plugins/darkroom/masks/brush/border"), BORDER_MAX);
+  float masks_border = MIN(dt_conf_get_float(DT_MASKS_CONF(form->type, brush, border)), BORDER_MAX);
 
   if(gui->creation && which == 1 &&
      (dt_modifier_is(state, GDK_SHIFT_MASK) || dt_modifier_is(state, GDK_CONTROL_MASK | GDK_SHIFT_MASK)))
@@ -2225,17 +2173,9 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
       dt_masks_form_t *form = darktable.develop->form_visible;
       if(!form) return;
 
-      float masks_border = 0.0f;
-      if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
-        masks_border = MIN(dt_conf_get_float("plugins/darkroom/spots/brush_border"), BORDER_MAX);
-      else
-        masks_border = MIN(dt_conf_get_float("plugins/darkroom/masks/brush/border"), BORDER_MAX);
+      float masks_border = MIN(dt_conf_get_float(DT_MASKS_CONF(form->type, brush, border)), BORDER_MAX);
 
-      float masks_hardness = 0.0f;
-      if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
-        masks_hardness = MIN(dt_conf_get_float("plugins/darkroom/spots/brush_hardness"), HARDNESS_MAX);
-      else
-        masks_hardness = MIN(dt_conf_get_float("plugins/darkroom/masks/brush/hardness"), HARDNESS_MAX);
+      float masks_hardness = MIN(dt_conf_get_float(DT_MASKS_CONF(form->type, brush, hardness)), HARDNESS_MAX);
 
       const float opacity = dt_conf_get_float("plugins/darkroom/masks/opacity");
 

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1119,6 +1119,7 @@ static int _brush_events_mouse_scrolled(struct dt_iop_module_t *module, float pz
       }
       dt_toast_log(_("size: %3.2f%%"), masks_border*2.f*100.f);
     }
+    dt_dev_masks_list_change(darktable.develop);
     dt_control_queue_redraw_center();
     return 1;
   }

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -278,13 +278,13 @@ static int _circle_events_button_pressed(struct dt_iop_module_t *module, float p
       else if(!gui->creation_continuous)
         dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
       dt_masks_iop_update(crea_module);
-      dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid, TRUE);
+      dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid);
       gui->creation_module = NULL;
     }
     else
     {
       // we select the new form
-      dt_dev_masks_selection_change(darktable.develop, NULL, form->formid, TRUE);
+      dt_dev_masks_selection_change(darktable.develop, NULL, form->formid);
     }
 
     // if we draw a clone circle, we start now the source dragging

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -148,7 +148,6 @@ static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module, float p
         else
           return 1;
         dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
-        dt_masks_gui_form_remove(form, gui, index);
         dt_masks_gui_form_create(form, gui, index, module);
         dt_conf_set_float(DT_MASKS_CONF(form->type, circle, border), circle->border);
         dt_toast_log(_("feather size: %3.2f%%"), (circle->border/circle->radius)*100.0f);
@@ -162,7 +161,6 @@ static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module, float p
         else
           return 1;
         dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
-        dt_masks_gui_form_remove(form, gui, index);
         dt_masks_gui_form_create(form, gui, index, module);
         dt_conf_set_float(DT_MASKS_CONF(form->type, circle, size), circle->radius);
         dt_toast_log(_("size: %3.2f%%"), circle->radius*100.0f);
@@ -393,7 +391,6 @@ static int _circle_events_button_released(struct dt_iop_module_t *module, float 
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the move
@@ -430,7 +427,6 @@ static int _circle_events_button_released(struct dt_iop_module_t *module, float 
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the move
@@ -487,7 +483,6 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
     }
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;
@@ -512,7 +507,6 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
     circle->radius = CLAMP(circle->radius * (1.0f + deltax / rx), 0.0005f, max_mask_size);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;
@@ -537,7 +531,6 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
 
     circle->border = CLAMP((circle->radius + circle->border) * (1.0f + deltax / rx) - circle->radius, 0.001f, max_mask_border);
 
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -119,6 +119,7 @@ static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module, float p
       dt_conf_set_float(DT_MASKS_CONF(form->type, circle, size), masks_size);
       dt_toast_log(_("size: %3.2f%%"), masks_size*100.0f);
     }
+    dt_dev_masks_list_change(darktable.develop);
     return 1;
   }
 

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -1329,8 +1329,8 @@ static GSList *_circle_setup_mouse_actions(const struct dt_masks_form_t *const f
 {
   GSList *lm = NULL;
   lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, 0, _("[CIRCLE] change size"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_CONTROL_MASK, _("[CIRCLE] change opacity"));
   lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_SHIFT_MASK, _("[CIRCLE] change feather size"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_CONTROL_MASK, _("[CIRCLE] change opacity"));
   return lm;
 }
 

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -61,6 +61,20 @@ static void _circle_get_distance(float x, float y, float as, dt_masks_form_gui_t
   const float cy = y - gpt->points[1];
   *dist = sqf(cx) + sqf(cy);
 
+  // compute distances from resize point
+
+  const float dx = x - gpt->points[2];
+  const float dy = y - gpt->points[3];
+  const float dd = sqf(dx) + sqf(dy);
+  *dist = fminf(*dist, dd);
+
+  // compute distances from feather point
+
+  const float bx = x - gpt->border[2];
+  const float by = y - gpt->border[3];
+  const float bd = sqf(bx) + sqf(by);
+  *dist = fminf(*dist, bd);
+
   // we check if it's inside borders
   if(!dt_masks_point_in_form_exact(x, y, gpt->border, 1, gpt->border_count)) return;
 

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -320,7 +320,6 @@ static int _circle_events_button_pressed(struct dt_iop_module_t *module, float p
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), FALSE);
       dt_masks_form_t *newform = dt_masks_create(form->type);
       dt_masks_change_form_gui(newform);
-      darktable.develop->form_gui->creation = TRUE;
       darktable.develop->form_gui->creation_module = crea_module;
       darktable.develop->form_gui->creation_continuous = TRUE;
       darktable.develop->form_gui->creation_continuous_module = crea_module;
@@ -390,8 +389,6 @@ static int _circle_events_button_released(struct dt_iop_module_t *module, float 
     {
       dt_masks_form_t *form_new = dt_masks_create(form->type);
       dt_masks_change_form_gui(form_new);
-
-      darktable.develop->form_gui->creation = TRUE;
       darktable.develop->form_gui->creation_module = gui->creation_continuous_module;
     }
     return 1;
@@ -429,8 +426,6 @@ static int _circle_events_button_released(struct dt_iop_module_t *module, float 
     {
       dt_masks_form_t *form_new = dt_masks_create(form->type);
       dt_masks_change_form_gui(form_new);
-
-      darktable.develop->form_gui->creation = TRUE;
       darktable.develop->form_gui->creation_module = gui->creation_continuous_module;
     }
 

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -107,7 +107,7 @@ static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module, float p
         masks_border *= 0.97f;
 
       dt_conf_set_float(DT_MASKS_CONF(form->type, circle, border), masks_border);
-      dt_toast_log(_("feather size: %3.2f%%"), (masks_border / masks_size)*100.0f);
+      dt_toast_log(_("feather size: %3.2f%%"), masks_border*100.0f);
     }
     else if(dt_modifier_is(state, 0))
     {
@@ -151,7 +151,7 @@ static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module, float p
         dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
         dt_masks_gui_form_create(form, gui, index, module);
         dt_conf_set_float(DT_MASKS_CONF(form->type, circle, border), circle->border);
-        dt_toast_log(_("feather size: %3.2f%%"), (circle->border/circle->radius)*100.0f);
+        dt_toast_log(_("feather size: %3.2f%%"), circle->border*100.0f);
       }
       else if(gui->edit_mode == DT_MASKS_EDIT_FULL)
       {
@@ -1430,7 +1430,7 @@ static void _circle_modify_property(dt_masks_form_t *const form, dt_masks_proper
       if(circle) circle->border = masks_border;
       dt_conf_set_float(DT_MASKS_CONF(form->type, circle, border), masks_border);
 
-      *sum += masks_border / masks_size;
+      *sum += masks_border;
       *max = fminf(*max, max_mask_border / masks_border);
       *min = fmaxf(*min, 0.0005f / masks_border);
       ++*count;

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -174,6 +174,10 @@ static void _ellipse_get_distance(float x, float y, float as, dt_masks_form_gui_
     const float cy = y - gpt->points[k * 2 + 1];
     const float dd = sqf(cx) + sqf(cy);
     *dist = fminf(*dist, dd);
+    const float by = y - gpt->border[k * 2 + 1];
+    const float bx = x - gpt->border[k * 2];
+    const float bd = sqf(bx) + sqf(by);
+    *dist = fminf(*dist, bd);
   }
 
   *inside_source = 0;

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -671,13 +671,13 @@ static int _ellipse_events_button_pressed(struct dt_iop_module_t *module, float 
       else if(!gui->creation_continuous)
         dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
       dt_masks_iop_update(crea_module);
-      dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid, TRUE);
+      dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid);
       gui->creation_module = NULL;
     }
     else
     {
       // we select the new form
-      dt_dev_masks_selection_change(darktable.develop, NULL, form->formid, TRUE);
+      dt_dev_masks_selection_change(darktable.develop, NULL, form->formid);
     }
 
     // if we draw a clone ellipse, we start now the source dragging

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -427,7 +427,7 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
         rotation += 10.f;
       else
         rotation -= 10.f;
-      rotation = fmodf(rotation, 360.0f);
+      rotation = fmodf(rotation + 360.0f, 360.0f);
 
       dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, rotation), rotation);
 
@@ -498,7 +498,7 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
           ellipse->rotation += 10.f;
         else
           ellipse->rotation -= 10.f;
-        ellipse->rotation = fmodf(ellipse->rotation, 360.0f);
+        ellipse->rotation = fmodf(ellipse->rotation + 360.0f, 360.0f);
 
         dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
         dt_masks_gui_form_create(form, gui, index, module);
@@ -2153,7 +2153,7 @@ static void _ellipse_modify_property(dt_masks_form_t *const form, dt_masks_prope
       break;
     case DT_MASKS_PROPERTY_ROTATION:;
       float rotation = ellipse ? ellipse->rotation : dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, rotation));
-      rotation = fmodf(rotation + new_val - old_val, 360.0f);
+      rotation = fmodf(rotation + new_val - old_val + 360.0f, 360.0f);
 
       if(ellipse) ellipse->rotation = rotation;
       dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, rotation), rotation);

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -501,7 +501,6 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
         ellipse->rotation = fmodf(ellipse->rotation, 360.0f);
 
         dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
-        dt_masks_gui_form_remove(form, gui, index);
         dt_masks_gui_form_create(form, gui, index, module);
         dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, rotation), ellipse->rotation);
         dt_toast_log(_("rotation: %3.f°"), ellipse->rotation);
@@ -517,7 +516,6 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
         else return 1;
         ellipse->border = CLAMP(ellipse->border, 0.001f * reference, radius_limit *reference);
         dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
-        dt_masks_gui_form_remove(form, gui, index);
         dt_masks_gui_form_create(form, gui, index, module);
         dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, border), ellipse->border);
         dt_toast_log(_("feather size: %3.2f%%"), ellipse->border*100.0f);
@@ -538,7 +536,6 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
         ellipse->radius[1] *= factor;
 
         dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
-        dt_masks_gui_form_remove(form, gui, index);
         dt_masks_gui_form_create(form, gui, index, module);
         dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, radius_a), ellipse->radius[0]);
         dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, radius_b), ellipse->radius[1]);
@@ -787,7 +784,6 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the move
@@ -833,7 +829,6 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the new parameters
@@ -882,7 +877,6 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the rotation
@@ -930,7 +924,6 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
 
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the updated shape
@@ -975,7 +968,6 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
 
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the updated shape
@@ -1006,7 +998,6 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the move
@@ -1053,7 +1044,6 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, float pzx
     }
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;
@@ -1125,7 +1115,6 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, float pzx
     }
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;
@@ -1165,7 +1154,6 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, float pzx
                             0.001f * reference, radius_limit *reference);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;
@@ -1205,7 +1193,6 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, float pzx
     dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, rotation), ellipse->rotation);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
 
     // we remap dx, dy to the right values, as it will be used in next movements

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -471,6 +471,7 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
       dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, radius_b), radius_b);
       dt_toast_log(_("size: %3.2f%%"), fmaxf(radius_a, radius_b)*100);
     }
+    dt_dev_masks_list_change(darktable.develop);
     return 1;
   }
 

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -726,7 +726,6 @@ static int _ellipse_events_button_pressed(struct dt_iop_module_t *module, float 
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), FALSE);
       dt_masks_form_t *newform = dt_masks_create(form->type);
       dt_masks_change_form_gui(newform);
-      darktable.develop->form_gui->creation = TRUE;
       darktable.develop->form_gui->creation_module = crea_module;
       darktable.develop->form_gui->creation_continuous = TRUE;
       darktable.develop->form_gui->creation_continuous_module = crea_module;
@@ -796,8 +795,6 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
     {
       dt_masks_form_t *form_new = dt_masks_create(form->type);
       dt_masks_change_form_gui(form_new);
-
-      darktable.develop->form_gui->creation = TRUE;
       darktable.develop->form_gui->creation_module = gui->creation_continuous_module;
     }
     return 1;
@@ -1017,8 +1014,6 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
     {
       dt_masks_form_t *form_new = dt_masks_create(form->type);
       dt_masks_change_form_gui(form_new);
-
-      darktable.develop->form_gui->creation = TRUE;
       darktable.develop->form_gui->creation_module = gui->creation_continuous_module;
     }
 

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -454,28 +454,12 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
   // add a preview when creating an ellipse
   if(gui->creation)
   {
-    float radius_a = 0.0f;
-    float radius_b = 0.0f;
-
-    if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
-    {
-      radius_a = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_a");
-      radius_b = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_b");
-    }
-    else
-    {
-      radius_a = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_a");
-      radius_b = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_b");
-    }
+    float radius_a = dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, radius_a));
+    float radius_b = dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, radius_b));
 
     if(dt_modifier_is(state, GDK_SHIFT_MASK | GDK_CONTROL_MASK))
     {
-      float rotation = 0.0f;
-
-      if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
-        rotation = dt_conf_get_float("plugins/darkroom/spots/ellipse_rotation");
-      else
-        rotation = dt_conf_get_float("plugins/darkroom/masks/ellipse/rotation");
+      float rotation = dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, rotation));
 
       if(up)
         rotation += 10.f;
@@ -483,32 +467,16 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
         rotation -= 10.f;
       rotation = fmodf(rotation, 360.0f);
 
-      if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
-        dt_conf_set_float("plugins/darkroom/spots/ellipse_rotation", rotation);
-      else
-        dt_conf_set_float("plugins/darkroom/masks/ellipse/rotation", rotation);
+      dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, rotation), rotation);
 
       dt_toast_log(_("rotation: %3.f°"), rotation);
     }
     else if(dt_modifier_is(state, GDK_SHIFT_MASK))
     {
-      float masks_border = 0.0f;
-      int flags = 0;
-
-      if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
-      {
-        masks_border = dt_conf_get_float("plugins/darkroom/spots/ellipse_border");
-        flags = dt_conf_get_int("plugins/darkroom/spots/ellipse_flags");
-        radius_a = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_a");
-        radius_b = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_b");
-      }
-      else
-      {
-        masks_border = dt_conf_get_float("plugins/darkroom/masks/ellipse/border");
-        flags = dt_conf_get_int("plugins/darkroom/masks/ellipse/flags");
-        radius_a = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_a");
-        radius_b = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_b");
-      }
+      float masks_border = dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, border));
+      int flags = dt_conf_get_int(DT_MASKS_CONF(form->type, ellipse, flags));
+      radius_a = dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, radius_a));
+      radius_b = dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, radius_b));
 
       const float reference = (flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? 1.0f / fmin(radius_a, radius_b) : 1.0f);
       if(!up && masks_border > 0.001f * reference)
@@ -519,10 +487,7 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
         return 1;
       masks_border = CLAMP(masks_border, 0.001f * reference, reference);
 
-      if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
-        dt_conf_set_float("plugins/darkroom/spots/ellipse_border", masks_border);
-      else
-        dt_conf_set_float("plugins/darkroom/masks/ellipse/border", masks_border);
+      dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, border), masks_border);
 
       dt_toast_log(_("feather size: %3.2f%%"), (masks_border/fmaxf(radius_a, radius_b))*100.0f);
     }
@@ -542,16 +507,8 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
       const float factor = radius_a / oldradius;
       radius_b *= factor;
 
-      if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
-      {
-        dt_conf_set_float("plugins/darkroom/spots/ellipse_radius_a", radius_a);
-        dt_conf_set_float("plugins/darkroom/spots/ellipse_radius_b", radius_b);
-      }
-      else
-      {
-        dt_conf_set_float("plugins/darkroom/masks/ellipse/radius_a", radius_a);
-        dt_conf_set_float("plugins/darkroom/masks/ellipse/radius_b", radius_b);
-      }
+      dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, radius_a), radius_a);
+      dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, radius_b), radius_b);
       dt_toast_log(_("size: %3.2f%%"), fmaxf(radius_a, radius_b)*100);
     }
     return 1;
@@ -586,10 +543,7 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
         dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
         dt_masks_gui_form_remove(form, gui, index);
         dt_masks_gui_form_create(form, gui, index, module);
-        if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
-          dt_conf_set_float("plugins/darkroom/spots/ellipse_rotation", ellipse->rotation);
-        else
-          dt_conf_set_float("plugins/darkroom/masks/ellipse/rotation", ellipse->rotation);
+        dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, rotation), ellipse->rotation);
         dt_toast_log(_("rotation: %3.f°"), ellipse->rotation);
       }
       // resize don't care where the mouse is inside a shape
@@ -605,10 +559,7 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
         dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
         dt_masks_gui_form_remove(form, gui, index);
         dt_masks_gui_form_create(form, gui, index, module);
-        if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
-          dt_conf_set_float("plugins/darkroom/spots/ellipse_border", ellipse->border);
-        else
-          dt_conf_set_float("plugins/darkroom/masks/ellipse/border", ellipse->border);
+        dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, border), ellipse->border);
         dt_toast_log(_("feather size: %3.2f%%"), ellipse->border*100.0f);
       }
       else if(gui->edit_mode == DT_MASKS_EDIT_FULL && dt_modifier_is(state, 0))
@@ -629,16 +580,8 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
         dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
         dt_masks_gui_form_remove(form, gui, index);
         dt_masks_gui_form_create(form, gui, index, module);
-        if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
-        {
-          dt_conf_set_float("plugins/darkroom/spots/ellipse_radius_a", ellipse->radius[0]);
-          dt_conf_set_float("plugins/darkroom/spots/ellipse_radius_b", ellipse->radius[1]);
-        }
-        else
-        {
-          dt_conf_set_float("plugins/darkroom/masks/ellipse/radius_a", ellipse->radius[0]);
-          dt_conf_set_float("plugins/darkroom/masks/ellipse/radius_b", ellipse->radius[1]);
-        }
+        dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, radius_a), ellipse->radius[0]);
+        dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, radius_b), ellipse->radius[1]);
         dt_toast_log(_("size: %3.2f%%"), fmaxf(ellipse->radius[0], ellipse->radius[1])*100);
       }
       else if(!dt_modifier_is(state, 0))
@@ -739,33 +682,20 @@ static int _ellipse_events_button_pressed(struct dt_iop_module_t *module, float 
     ellipse->center[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
     ellipse->center[1] = pts[1] / darktable.develop->preview_pipe->iheight;
 
-    if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
+    if(form->type & DT_MASKS_CLONE)
     {
-      ellipse->radius[0] = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_a");
-      ellipse->radius[1] = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_b");
-      ellipse->border = dt_conf_get_float("plugins/darkroom/spots/ellipse_border");
-      ellipse->rotation = dt_conf_get_float("plugins/darkroom/spots/ellipse_rotation");
-      ellipse->flags = dt_conf_get_int("plugins/darkroom/spots/ellipse_flags");
-      if(form->type & DT_MASKS_CLONE)
-      {
-        dt_masks_set_source_pos_initial_value(gui, DT_MASKS_ELLIPSE, form, pzx, pzy);
-      }
-      else
-      {
-        // not used for regular masks
-        form->source[0] = form->source[1] = 0.0f;
-      }
+      dt_masks_set_source_pos_initial_value(gui, DT_MASKS_ELLIPSE, form, pzx, pzy);
     }
     else
     {
-      ellipse->radius[0] = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_a");
-      ellipse->radius[1] = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_b");
-      ellipse->border = dt_conf_get_float("plugins/darkroom/masks/ellipse/border");
-      ellipse->rotation = dt_conf_get_float("plugins/darkroom/masks/ellipse/rotation");
-      ellipse->flags = dt_conf_get_int("plugins/darkroom/masks/ellipse/flags");
-      // not used for masks
+      // not used for regular masks
       form->source[0] = form->source[1] = 0.0f;
     }
+    ellipse->radius[0] = dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, radius_a));
+    ellipse->radius[1] = dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, radius_b));
+    ellipse->border = dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, border));
+    ellipse->rotation = dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, rotation));
+    ellipse->flags = dt_conf_get_int(DT_MASKS_CONF(form->type, ellipse, flags));
     form->points = g_list_append(form->points, ellipse);
     dt_masks_gui_form_save_creation(darktable.develop, crea_module, form, gui);
 
@@ -936,16 +866,8 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
       ellipse->flags |= DT_MASKS_ELLIPSE_PROPORTIONAL;
     }
 
-    if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
-    {
-      dt_conf_set_int("plugins/darkroom/spots/ellipse_flags", ellipse->flags);
-      dt_conf_set_float("plugins/darkroom/spots/ellipse_border", ellipse->border);
-    }
-    else
-    {
-      dt_conf_set_int("plugins/darkroom/masks/ellipse/flags", ellipse->flags);
-      dt_conf_set_float("plugins/darkroom/masks/ellipse/border", ellipse->border);
-    }
+    dt_conf_set_int(DT_MASKS_CONF(form->type, ellipse, flags), ellipse->flags);
+    dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, border), ellipse->border);
 
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
@@ -994,10 +916,7 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
     else
       ellipse->rotation += dv / M_PI * 180.0f;
 
-    if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
-      dt_conf_set_float("plugins/darkroom/spots/ellipse_rotation", ellipse->rotation);
-    else
-      dt_conf_set_float("plugins/darkroom/masks/ellipse/rotation", ellipse->rotation);
+    dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, rotation), ellipse->rotation);
 
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
@@ -1040,18 +959,12 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
        || ((k == 3 || k == 4) && ellipse->radius[0] <= ellipse->radius[1]))
     {
       ellipse->radius[0] = MAX(0.002f, ellipse->radius[0] * s);
-      if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
-        dt_conf_set_float("plugins/darkroom/spots/ellipse_radius_a", ellipse->radius[0]);
-      else
-        dt_conf_set_float("plugins/darkroom/masks/ellipse/radius_a", ellipse->radius[0]);
+      dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, radius_a), ellipse->radius[0]);
     }
     else
     {
       ellipse->radius[1] = MAX(0.002f, ellipse->radius[1] * s);
-      if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
-        dt_conf_set_float("plugins/darkroom/spots/ellipse_radius_b", ellipse->radius[1]);
-      else
-        dt_conf_set_float("plugins/darkroom/masks/ellipse/radius_b", ellipse->radius[1]);
+      dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, radius_b), ellipse->radius[1]);
     }
 
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
@@ -1171,18 +1084,12 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, float pzx
        || ((k == 3 || k == 4) && ellipse->radius[0] <= ellipse->radius[1]))
     {
       ellipse->radius[0] = MAX(0.002f, ellipse->radius[0] * s);
-      if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
-        dt_conf_set_float("plugins/darkroom/spots/ellipse_radius_a", ellipse->radius[0]);
-      else
-        dt_conf_set_float("plugins/darkroom/masks/ellipse/radius_a", ellipse->radius[0]);
+      dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, radius_a), ellipse->radius[0]);
     }
     else
     {
       ellipse->radius[1] = MAX(0.002f, ellipse->radius[1] * s);
-      if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
-        dt_conf_set_float("plugins/darkroom/spots/ellipse_radius_b", ellipse->radius[1]);
-      else
-        dt_conf_set_float("plugins/darkroom/masks/ellipse/radius_b", ellipse->radius[1]);
+      dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, radius_b), ellipse->radius[1]);
     }
 
     // as point 1 an 2 always correspond to the longer axis, point number may change when recreating the form
@@ -1251,10 +1158,7 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, float pzx
     else
       ellipse->rotation += dv / M_PI * 180.0f;
 
-    if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
-      dt_conf_set_float("plugins/darkroom/spots/ellipse_rotation", ellipse->rotation);
-    else
-      dt_conf_set_float("plugins/darkroom/masks/ellipse/rotation", ellipse->rotation);
+    dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, rotation), ellipse->rotation);
 
     // we recreate the form points
     dt_masks_gui_form_remove(form, gui, index);
@@ -1360,28 +1264,12 @@ static void _ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       if(!form) return;
 
       float x = 0.0f, y = 0.0f;
-      float masks_border = 0.0f;
-      int flags = 0;
-      float radius_a = 0.0f;
-      float radius_b = 0.0f;
-      float rotation = 0.0f;
 
-      if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
-      {
-        masks_border = dt_conf_get_float("plugins/darkroom/spots/ellipse_border");
-        flags = dt_conf_get_int("plugins/darkroom/spots/ellipse_flags");
-        radius_a = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_a");
-        radius_b = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_b");
-        rotation = dt_conf_get_float("plugins/darkroom/spots/ellipse_rotation");
-      }
-      else
-      {
-        masks_border = dt_conf_get_float("plugins/darkroom/masks/ellipse/border");
-        flags = dt_conf_get_int("plugins/darkroom/masks/ellipse/flags");
-        radius_a = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_a");
-        radius_b = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_b");
-        rotation = dt_conf_get_float("plugins/darkroom/masks/ellipse/rotation");
-      }
+      float masks_border = dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, border));
+      int flags = dt_conf_get_int(DT_MASKS_CONF(form->type, ellipse, flags));
+      float radius_a = dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, radius_a));
+      float radius_b = dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, radius_b));
+      float rotation = dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, rotation));
 
       float pzx = gui->posx;
       float pzy = gui->posy;
@@ -2197,26 +2085,11 @@ static void _ellipse_set_hint_message(const dt_masks_form_gui_t *const gui, cons
 
 static void _ellipse_sanitize_config(dt_masks_type_t type)
 {
-  int flags = -1;
-  float radius_a = 0.0f;
-  float radius_b = 0.0f;
-  float border = 0.0f;
-  if(type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
-  {
-    dt_conf_get_and_sanitize_float("plugins/darkroom/spots/ellipse_rotation", 0.0f, 360.f);
-    flags = dt_conf_get_and_sanitize_int("plugins/darkroom/spots/ellipse_flags", DT_MASKS_ELLIPSE_EQUIDISTANT, DT_MASKS_ELLIPSE_PROPORTIONAL);
-    radius_a = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_a");
-    radius_b = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_b");
-    border = dt_conf_get_float("plugins/darkroom/spots/ellipse_border");
-  }
-  else
-  {
-    dt_conf_get_and_sanitize_float("plugins/darkroom/masks/ellipse_rotation", 0.0f, 360.f);
-    flags = dt_conf_get_and_sanitize_int("plugins/darkroom/masks/ellipse/flags", DT_MASKS_ELLIPSE_EQUIDISTANT, DT_MASKS_ELLIPSE_PROPORTIONAL);
-    radius_a = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_a");
-    radius_b = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_b");
-    border = dt_conf_get_float("plugins/darkroom/masks/ellipse/border");
-  }
+  dt_conf_get_and_sanitize_float(DT_MASKS_CONF(type, ellipse, rotation), 0.0f, 360.f);
+  int flags = dt_conf_get_and_sanitize_int(DT_MASKS_CONF(type, ellipse, flags), DT_MASKS_ELLIPSE_EQUIDISTANT, DT_MASKS_ELLIPSE_PROPORTIONAL);
+  float radius_a = dt_conf_get_float(DT_MASKS_CONF(type, ellipse, radius_a));
+  float radius_b = dt_conf_get_float(DT_MASKS_CONF(type, ellipse, radius_b));
+  float border = dt_conf_get_float(DT_MASKS_CONF(type, ellipse, border));
 
   const float ratio = radius_a / radius_b;
 
@@ -2234,18 +2107,9 @@ static void _ellipse_sanitize_config(dt_masks_type_t type)
   const float reference = (flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? 1.0f / fmin(radius_a, radius_b) : 1.0f);
   border = CLAMPS(border, 0.001f * reference, reference);
 
-  if(type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
-  {
-    DT_CONF_SET_SANITIZED_FLOAT("plugins/darkroom/spots/ellipse_radius_a", radius_a, 0.001f, 0.5f)
-      DT_CONF_SET_SANITIZED_FLOAT("plugins/darkroom/spots/ellipse_radius_b", radius_b, 0.001f, 0.5f);
-    DT_CONF_SET_SANITIZED_FLOAT("plugins/darkroom/spots/ellipse_border", border, 0.001f, reference);
-  }
-  else
-  {
-    DT_CONF_SET_SANITIZED_FLOAT("plugins/darkroom/masks/ellipse/radius_a", radius_a, 0.001f, 0.5f);
-    DT_CONF_SET_SANITIZED_FLOAT("plugins/darkroom/masks/ellipse/radius_b", radius_b, 0.001f, 0.5f);
-    DT_CONF_SET_SANITIZED_FLOAT("plugins/darkroom/masks/ellipse/border", border, 0.001f, reference);
-  }
+  DT_CONF_SET_SANITIZED_FLOAT(DT_MASKS_CONF(type, ellipse, radius_a), radius_a, 0.001f, 0.5f);
+  DT_CONF_SET_SANITIZED_FLOAT(DT_MASKS_CONF(type, ellipse, radius_b), radius_b, 0.001f, 0.5f);
+  DT_CONF_SET_SANITIZED_FLOAT(DT_MASKS_CONF(type, ellipse, border), border, 0.001f, reference);
 }
 
 // The function table for ellipses.  This must be public, i.e. no "static" keyword.

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -2146,6 +2146,8 @@ static GSList *_ellipse_setup_mouse_actions(const struct dt_masks_form_t *const 
 {
   GSList *lm = NULL;
   lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, 0, _("[ELLIPSE] change size"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_SHIFT_MASK, _("[ELLIPSE] change feather size"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_SHIFT_MASK|GDK_CONTROL_MASK, _("[ELLIPSE] rotate shape"));
   lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_CONTROL_MASK, _("[ELLIPSE] change opacity"));
   lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_LEFT, GDK_SHIFT_MASK, _("[ELLIPSE] switch feathering mode"));
   lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_LEFT_DRAG, GDK_CONTROL_MASK, _("[ELLIPSE] rotate shape"));

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1374,9 +1374,6 @@ static void _ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
 
   if(!gpt) return;
 
-  const float r = atan2f(gpt->points[3] - gpt->points[1], gpt->points[2] - gpt->points[0]);
-  const float sinr = sinf(r);
-  const float cosr = cosf(r);
 
   xref = gpt->points[0];
   yref = gpt->points[1];
@@ -1397,6 +1394,10 @@ static void _ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
     _ellipse_draw_shape(TRUE, FALSE, cr, dashed, len, gui->border_selected, zoom_scale, xref, yref, gpt->border, gpt->border_count);
 
     // draw anchor points
+    const float r = atan2f(gpt->points[3] - gpt->points[1], gpt->points[2] - gpt->points[0]);
+    const float sinr = sinf(r);
+    const float cosr = cosf(r);
+
     for(int i = 1; i < 5; i++)
     {
       float x, y;

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -878,21 +878,7 @@ static void _gradient_draw_arrow(cairo_t *cr, double *dashed, const float len, c
   const float pivot_start_y = pts[5];
 
   // draw anchor point
-  {
-    cairo_set_dash(cr, dashed, 0, 0);
-    const float anchor_size = (selected) ? 7.0f / zoom_scale : 5.0f / zoom_scale;
-    dt_draw_set_color_overlay(cr, TRUE, 0.8);
-    cairo_rectangle(cr, anchor_x - (anchor_size * 0.5), anchor_y - (anchor_size * 0.5), anchor_size, anchor_size);
-    cairo_fill_preserve(cr);
-
-    if(selected)
-      cairo_set_line_width(cr, 2.0 / zoom_scale);
-    else
-      cairo_set_line_width(cr, 1.0 / zoom_scale);
-    dt_draw_set_color_overlay(cr, FALSE, 0.8);
-    cairo_stroke(cr);
-  }
-
+  dt_masks_draw_anchor(cr, selected, zoom_scale, anchor_x, anchor_y);
 
   // draw pivot points
   {

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -92,22 +92,22 @@ static int _gradient_events_mouse_scrolled(struct dt_iop_module_t *module, float
   {
     if(dt_modifier_is(state, GDK_SHIFT_MASK))
     {
-      float compression = MIN(1.0f, dt_conf_get_float("plugins/darkroom/masks/gradient/compression"));
+      float compression = MIN(1.0f, dt_conf_get_float(DT_MASKS_CONF(form->type, gradient, compression)));
       if(up)
         compression = fminf(fmaxf(compression, 0.001f) * 1.0f / 0.8f, 1.0f);
       else
         compression = fmaxf(compression, 0.001f) * 0.8f;
-      dt_conf_set_float("plugins/darkroom/masks/gradient/compression", compression);
+      dt_conf_set_float(DT_MASKS_CONF(form->type, gradient, compression), compression);
       dt_toast_log(_("compression: %3.2f%%"), compression*100.0f);
     }
     else if(dt_modifier_is(state, 0)) // simple scroll to adjust curvature, calling func adjusts opacity with Ctrl
     {
-      float curvature = dt_conf_get_float("plugins/darkroom/masks/gradient/curvature");
+      float curvature = dt_conf_get_float(DT_MASKS_CONF(form->type, gradient, curvature));
       if(up)
         curvature = fminf(curvature + 0.01f, 2.0f);
       else
         curvature = fmaxf(curvature - 0.01f, -2.0f);
-      dt_conf_set_float("plugins/darkroom/masks/gradient/curvature", curvature);
+      dt_conf_set_float(DT_MASKS_CONF(form->type, gradient, curvature), curvature);
       dt_toast_log(_("curvature: %3.2f%%"), curvature * 50.0f);
     }
     return 1;
@@ -136,7 +136,7 @@ static int _gradient_events_mouse_scrolled(struct dt_iop_module_t *module, float
       dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
       dt_masks_gui_form_remove(form, gui, index);
       dt_masks_gui_form_create(form, gui, index, module);
-      dt_conf_set_float("plugins/darkroom/masks/gradient/compression", gradient->compression);
+      dt_conf_set_float(DT_MASKS_CONF(form->type, gradient, compression), gradient->compression);
       dt_toast_log(_("compression: %3.2f%%"), gradient->compression*100.0f);
       dt_masks_update_image(darktable.develop);
     }
@@ -265,11 +265,11 @@ static void _gradient_init_values(float zoom_scale, dt_masks_form_gui_t *gui, fl
   check_angle = atan2f(sinf(check_angle), cosf(check_angle));
   if(check_angle < 0.0f) rot -= M_PI;
 
-  const float compr = MIN(1.0f, dt_conf_get_float("plugins/darkroom/masks/gradient/compression"));
+  const float compr = MIN(1.0f, dt_conf_get_float(DT_MASKS_CONF(0, gradient, compression)));
 
   *rotation = -rot / M_PI * 180.0f;
   *compression = MAX(0.0f, compr);
-  *curvature = MAX(-2.0f, MIN(2.0f, dt_conf_get_float("plugins/darkroom/masks/gradient/curvature")));
+  *curvature = MAX(-2.0f, MIN(2.0f, dt_conf_get_float(DT_MASKS_CONF(0, gradient, curvature))));
 }
 
 static int _gradient_events_button_released(struct dt_iop_module_t *module, float pzx, float pzy, int which,
@@ -1447,7 +1447,7 @@ static GSList *_gradient_setup_mouse_actions(const struct dt_masks_form_t *const
 static void _gradient_sanitize_config(dt_masks_type_t type)
 {
   // we always want to start with no curvature
-  dt_conf_set_float("plugins/darkroom/masks/gradient/curvature", 0.0f);
+  dt_conf_set_float(DT_MASKS_CONF(type, gradient, curvature), 0.0f);
 }
 
 static void _gradient_set_form_name(struct dt_masks_form_t *const form, const size_t nb)

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -431,13 +431,13 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
       // and we switch in edit mode to show all the forms
       dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
       dt_masks_iop_update(crea_module);
-      dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid, TRUE);
+      dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid);
       gui->creation_module = NULL;
     }
     else
     {
       // we select the new form
-      dt_dev_masks_selection_change(darktable.develop, NULL, form->formid, TRUE);
+      dt_dev_masks_selection_change(darktable.develop, NULL, form->formid);
     }
 
     if(crea_module && gui->creation_continuous)

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -110,6 +110,7 @@ static int _gradient_events_mouse_scrolled(struct dt_iop_module_t *module, float
       dt_conf_set_float(DT_MASKS_CONF(form->type, gradient, curvature), curvature);
       dt_toast_log(_("curvature: %3.2f%%"), curvature * 50.0f);
     }
+    dt_dev_masks_list_change(darktable.develop);
     return 1;
   }
 

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -1492,12 +1492,12 @@ static void _gradient_modify_property(dt_masks_form_t *const form, dt_masks_prop
       break;
     case DT_MASKS_PROPERTY_ROTATION:;
       float rotation = gradient ? gradient->rotation : dt_conf_get_float(DT_MASKS_CONF(form->type, gradient, rotation));
-      rotation = fmodf(rotation + new_val - old_val, 360.0f);
+      rotation = fmodf(rotation - new_val + old_val + 360.0f, 360.0f);
 
       if(gradient) gradient->rotation = rotation;
       dt_conf_set_float(DT_MASKS_CONF(form->type, gradient, rotation), rotation);
 
-      *sum += rotation;
+      *sum += 360.0f - rotation;
       ++*count;
       break;
     default:;

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -134,7 +134,6 @@ static int _gradient_events_mouse_scrolled(struct dt_iop_module_t *module, float
       else
         gradient->compression = fmaxf(gradient->compression, 0.001f) * 0.8f;
       dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
-      dt_masks_gui_form_remove(form, gui, index);
       dt_masks_gui_form_create(form, gui, index, module);
       dt_conf_set_float(DT_MASKS_CONF(form->type, gradient, compression), gradient->compression);
       dt_toast_log(_("compression: %3.2f%%"), gradient->compression*100.0f);
@@ -149,7 +148,6 @@ static int _gradient_events_mouse_scrolled(struct dt_iop_module_t *module, float
         gradient->curvature = fmaxf(gradient->curvature - 0.01f, -2.0f);
       dt_toast_log(_("curvature: %3.2f%%"), gradient->curvature*50.0f);
       dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
-      dt_masks_gui_form_remove(form, gui, index);
       dt_masks_gui_form_create(form, gui, index, module);
       dt_masks_update_image(darktable.develop);
     }
@@ -172,7 +170,6 @@ static int _gradient_events_button_pressed(struct dt_iop_module_t *module, float
     gradient->curvature = 0.0f;
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
 
     dt_masks_update_image(darktable.develop);
@@ -324,7 +321,6 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the move
@@ -370,7 +366,6 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the rotation
@@ -395,7 +390,6 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the new parameters
@@ -490,7 +484,6 @@ static int _gradient_events_mouse_moved(struct dt_iop_module_t *module, float pz
     gradient->anchor[1] = pts[1] / darktable.develop->preview_pipe->iheight;
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;
@@ -530,7 +523,6 @@ static int _gradient_events_mouse_moved(struct dt_iop_module_t *module, float pz
       gradient->rotation -= dv / M_PI * 180.0f;
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -456,7 +456,6 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), FALSE);
       dt_masks_form_t *newform = dt_masks_create(form->type);
       dt_masks_change_form_gui(newform);
-      darktable.develop->form_gui->creation = TRUE;
       darktable.develop->form_gui->creation_module = crea_module;
       darktable.develop->form_gui->creation_continuous = TRUE;
       darktable.develop->form_gui->creation_continuous_module = crea_module;

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1069,7 +1069,7 @@ int dt_masks_events_button_released(struct dt_iop_module_t *module, double x, do
 
   if(darktable.develop->mask_form_selected_id)
     dt_dev_masks_selection_change(darktable.develop, module,
-                                  darktable.develop->mask_form_selected_id, FALSE);
+                                  darktable.develop->mask_form_selected_id);
 
   if(form->functions)
     return form->functions->button_released(module, pzx, pzy, which, state, form, 0, gui, 0);
@@ -1249,7 +1249,7 @@ void dt_masks_change_form_gui(dt_masks_form_t *newform)
   if(newform && newform->type != DT_MASKS_GROUP)
     darktable.develop->form_gui->creation = TRUE;
 
-  dt_dev_masks_selection_change(darktable.develop, NULL, 0, FALSE);
+  dt_dev_masks_selection_change(darktable.develop, NULL, 0);
 }
 
 void dt_masks_reset_form_gui(void)
@@ -1315,10 +1315,7 @@ void dt_masks_set_edit_mode(struct dt_iop_module_t *module, dt_masks_edit_mode_t
 
   dt_masks_change_form_gui(grp);
   darktable.develop->form_gui->edit_mode = value;
-  if(value && form)
-    dt_dev_masks_selection_change(darktable.develop, NULL, form->formid, FALSE);
-  else
-    dt_dev_masks_selection_change(darktable.develop, NULL, 0, FALSE);
+  dt_dev_masks_selection_change(darktable.develop, NULL, value && form ? form->formid : 0);
 
   if(bd->masks_support)
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit),
@@ -1352,10 +1349,7 @@ void dt_masks_set_edit_mode_single_form(struct dt_iop_module_t *module, const in
   dt_masks_change_form_gui(grp2);
   darktable.develop->form_gui->edit_mode = value;
 
-  if(value && form)
-    dt_dev_masks_selection_change(darktable.develop, NULL, formid, FALSE);
-  else
-    dt_dev_masks_selection_change(darktable.develop, NULL, 0, FALSE);
+  dt_dev_masks_selection_change(darktable.develop, NULL, value && form ? formid : 0);
 
   dt_control_queue_redraw_center();
 }

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1760,11 +1760,14 @@ float dt_masks_form_change_opacity(dt_masks_form_t *form, int parentid, float am
     if(fpt->formid == id)
     {
       const float opacity = CLAMP(fpt->opacity + amount, 0.05f, 1.0f);
-      fpt->opacity = opacity;
-      const int opacitypercent = opacity * 100;
-      dt_toast_log(_("opacity: %d%%"), opacitypercent);
-      dt_dev_add_masks_history_item(darktable.develop, NULL, TRUE);
-      dt_masks_update_image(darktable.develop);
+      if(opacity != fpt->opacity)
+      {
+        fpt->opacity = opacity;
+        const int opacitypercent = opacity * 100;
+        dt_toast_log(_("opacity: %d%%"), opacitypercent);
+        dt_dev_add_masks_history_item(darktable.develop, NULL, TRUE);
+        dt_masks_update_image(darktable.develop);
+      }
       return opacity;
     }
   }

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1245,6 +1245,11 @@ void dt_masks_change_form_gui(dt_masks_form_t *newform)
   /* update sticky accels window */
   if(newform != old && darktable.view_manager->accels_window.window && darktable.view_manager->accels_window.sticky)
     dt_view_accels_refresh(darktable.view_manager);
+
+  if(newform && newform->type != DT_MASKS_GROUP)
+    darktable.develop->form_gui->creation = TRUE;
+
+  dt_dev_masks_selection_change(darktable.develop, NULL, 0, FALSE);
 }
 
 void dt_masks_reset_form_gui(void)
@@ -1391,7 +1396,6 @@ static void _menu_add_shape(struct dt_iop_module_t *module, dt_masks_type_t type
   // we create the new form
   dt_masks_form_t *form = dt_masks_create(type);
   dt_masks_change_form_gui(form);
-  darktable.develop->form_gui->creation = TRUE;
   darktable.develop->form_gui->creation_module = module;
   dt_control_queue_redraw_center();
 }

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2391,6 +2391,19 @@ void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mas
   *py = y;
 }
 
+void dt_masks_draw_anchor(cairo_t *cr, gboolean selected, const float zoom_scale, const float x, const float y)
+{
+  float anchor_size = (selected ? 8.0f : 5.0f) / zoom_scale;
+
+  cairo_set_dash(cr, NULL, 0, 0);
+  dt_draw_set_color_overlay(cr, TRUE, 0.8);
+  cairo_rectangle(cr, x - (anchor_size * 0.5), y - (anchor_size * 0.5), anchor_size, anchor_size);
+  cairo_fill_preserve(cr);
+  cairo_set_line_width(cr, (selected ? 2.0 : 1.0) / zoom_scale);
+  dt_draw_set_color_overlay(cr, FALSE, 0.8);
+  cairo_stroke(cr);
+}
+
 #include "detail.c"
 
 // clang-format off

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1739,16 +1739,15 @@ void dt_masks_form_remove(struct dt_iop_module_t *module, dt_masks_form_t *grp, 
   if(form_removed) dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 }
 
-void dt_masks_form_change_opacity(dt_masks_form_t *form, int parentid, int up)
+float dt_masks_form_change_opacity(dt_masks_form_t *form, int parentid, float amount)
 {
-  if(!form) return;
+  if(!form) return 0;
   dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, parentid);
-  if(!grp || !(grp->type & DT_MASKS_GROUP)) return;
+  if(!grp || !(grp->type & DT_MASKS_GROUP)) return 0;
 
   // we first need to test if the opacity can be set to the form
-  if(form->type & DT_MASKS_GROUP) return;
+  if(form->type & DT_MASKS_GROUP) return 0;
   const int id = form->formid;
-  const float amount = up ? 0.05f : -0.05f;
 
   // so we change the value inside the group
   for(GList *fpts = grp->points; fpts; fpts = g_list_next(fpts))
@@ -1762,9 +1761,10 @@ void dt_masks_form_change_opacity(dt_masks_form_t *form, int parentid, int up)
       dt_toast_log(_("opacity: %d%%"), opacitypercent);
       dt_dev_add_masks_history_item(darktable.develop, NULL, TRUE);
       dt_masks_update_image(darktable.develop);
-      break;
+      return opacity;
     }
   }
+  return 0;
 }
 
 void dt_masks_form_move(dt_masks_form_t *grp, int formid, int up)

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -180,15 +180,11 @@ void dt_masks_gui_form_create(dt_masks_form_t *form, dt_masks_form_gui_t *gui, i
 {
   const int npoints = g_list_length(gui->points);
   if(npoints == index)
-  {
-    dt_masks_form_gui_points_t *gpt2
-        = (dt_masks_form_gui_points_t *)calloc(1, sizeof(dt_masks_form_gui_points_t));
-    gui->points = g_list_append(gui->points, gpt2);
-  }
-  else if(npoints < index)
+    gui->points = g_list_append(gui->points, calloc(1, sizeof(dt_masks_form_gui_points_t)));
+  else if(npoints > index)
+    dt_masks_gui_form_remove(form, gui, index);
+  else
     return;
-
-  dt_masks_gui_form_remove(form, gui, index);
 
   dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(dt_masks_get_points_border(darktable.develop, form, &gpt->points, &gpt->points_count, &gpt->border,

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1104,7 +1104,6 @@ static int _path_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx
       dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
       // we recreate the form points
-      dt_masks_gui_form_remove(form, gui, index);
       dt_masks_gui_form_create(form, gui, index, module);
 
       // we save the move
@@ -1292,7 +1291,6 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
       _path_init_ctrl_points(form);
 
       // we recreate the form points
-      dt_masks_gui_form_remove(form, gui, index);
       dt_masks_gui_form_create(form, gui, index, module);
 
       dt_control_queue_redraw_center();
@@ -1342,7 +1340,6 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
         dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
         // we recreate the form points
-        dt_masks_gui_form_remove(form, gui, index);
         dt_masks_gui_form_create(form, gui, index, module);
         gpt->clockwise = _path_is_clockwise(form);
         // we save the move
@@ -1401,7 +1398,6 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
 
         form->points = g_list_insert(form->points, bzpt, gui->seg_selected + 1);
         _path_init_ctrl_points(form);
-        dt_masks_gui_form_remove(form, gui, index);
         dt_masks_gui_form_create(form, gui, index, module);
         gui->point_edited = gui->point_dragging = gui->point_selected = gui->seg_selected + 1;
         gui->seg_selected = -1;
@@ -1470,7 +1466,6 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
     gpt->clockwise = _path_is_clockwise(form);
     // we save the move
@@ -1490,7 +1485,6 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
       dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
       // we recreate the form points
-      dt_masks_gui_form_remove(form, gui, index);
       dt_masks_gui_form_create(form, gui, index, module);
       gpt->clockwise = _path_is_clockwise(form);
       // we save the move
@@ -1568,7 +1562,6 @@ static int _path_events_button_released(struct dt_iop_module_t *module, float pz
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the move
@@ -1591,7 +1584,6 @@ static int _path_events_button_released(struct dt_iop_module_t *module, float pz
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
 
     // we save the move
@@ -1637,7 +1629,6 @@ static int _path_events_button_released(struct dt_iop_module_t *module, float pz
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
     gpt->clockwise = _path_is_clockwise(form);
     // we save the move
@@ -1672,7 +1663,6 @@ static int _path_events_button_released(struct dt_iop_module_t *module, float pz
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
     gpt->clockwise = _path_is_clockwise(form);
     // we save the move
@@ -1750,7 +1740,6 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, f
     _path_init_ctrl_points(form);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;
@@ -1797,7 +1786,6 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, f
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
 
     dt_control_queue_redraw_center();
@@ -1823,7 +1811,6 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, f
 
     _path_init_ctrl_points(form);
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;
@@ -1850,7 +1837,6 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, f
     point->border[0] = point->border[1] = bdr;
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;
@@ -1884,7 +1870,6 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, f
     }
 
     // we recreate the form points
-    dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
     return 1;

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1206,8 +1206,6 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
         {
           dt_masks_form_t *form_new = dt_masks_create(form->type);
           dt_masks_change_form_gui(form_new);
-
-          darktable.develop->form_gui->creation = TRUE;
           darktable.develop->form_gui->creation_module = gui->creation_continuous_module;
         }
       }

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -3132,15 +3132,15 @@ static GSList *_path_setup_mouse_actions(const struct dt_masks_form_t *const for
   lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_LEFT, GDK_CONTROL_MASK,
                                      _("[PATH creation] add a sharp node"));
   lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_RIGHT, 0, _("[PATH creation] terminate path creation"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_CONTROL_MASK,
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_LEFT, GDK_CONTROL_MASK,
                                      _("[PATH on node] switch between smooth/sharp node"));
   lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_RIGHT, 0, _("[PATH on node] remove the node"));
   lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_RIGHT, 0, _("[PATH on feather] reset curvature"));
   lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_LEFT, GDK_CONTROL_MASK,
                                      _("[PATH on segment] add node"));
   lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, 0, _("[PATH] change size"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_CONTROL_MASK, _("[PATH] change opacity"));
   lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_SHIFT_MASK, _("[PATH] change feather size"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_CONTROL_MASK, _("[PATH] change opacity"));
   return lm;
 }
 

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1036,20 +1036,10 @@ static int _path_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx
           point->border[0] *= amount;
           point->border[1] *= amount;
         }
-        if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
-        {
-          float masks_border = dt_conf_get_float("plugins/darkroom/spots/path_border");
-          masks_border = MAX(0.0005f, MIN(masks_border * amount, 0.5f));
-          dt_conf_set_float("plugins/darkroom/spots/path_border", masks_border);
-          dt_toast_log(_("feather size: %3.2f%%"), (feather_size - masks_size) / masks_size *100.0f);
-        }
-        else
-        {
-          float masks_border = dt_conf_get_float("plugins/darkroom/masks/path/border");
-          masks_border = MAX(0.0005f, MIN(masks_border * amount, 0.5f));
-          dt_conf_set_float("plugins/darkroom/masks/path/border", masks_border);
-          dt_toast_log(_("feather size: %3.2f%%"), (feather_size - masks_size) / masks_size * 100.0f);
-        }
+        float masks_border = dt_conf_get_float(DT_MASKS_CONF(form->type, path, border));
+        masks_border = MAX(0.0005f, MIN(masks_border * amount, 0.5f));
+        dt_conf_set_float(DT_MASKS_CONF(form->type, path, border), masks_border);
+        dt_toast_log(_("feather size: %3.2f%%"), (feather_size - masks_size) / masks_size * 100.0f);
       }
       else if(gui->edit_mode == DT_MASKS_EDIT_FULL)
       {
@@ -1134,11 +1124,7 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
   dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return 0;
 
-  float masks_border;
-  if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
-    masks_border = MIN(dt_conf_get_float("plugins/darkroom/spots/path_border"), 0.5f);
-  else
-    masks_border = MIN(dt_conf_get_float("plugins/darkroom/masks/path/border"), 0.5f);
+  float masks_border = MIN(dt_conf_get_float(DT_MASKS_CONF(form->type, path, border)), 0.5f);
 
   if(gui->creation && which == 1 && form->points == NULL
      && (dt_modifier_is(state, GDK_CONTROL_MASK | GDK_SHIFT_MASK)

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1175,12 +1175,12 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
         else if(!gui->creation_continuous)
           dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
         dt_masks_iop_update(crea_module);
-        dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid, TRUE);
+        dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid);
         gui->creation_module = NULL;
       }
       else
       {
-        dt_dev_masks_selection_change(darktable.develop, NULL, form->formid, TRUE);
+        dt_dev_masks_selection_change(darktable.develop, NULL, form->formid);
       }
 
       if(gui->creation_continuous)

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -2029,33 +2029,11 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
   }
 
   // draw corners
-  float anchor_size = 0.0f;
   if(gui->group_selected == index && gpt->points_count > nb * 3 + 6)
   {
     for(int k = 0; k < nb; k++)
-    {
-      if(k == gui->point_dragging || k == gui->point_selected)
-      {
-        anchor_size = 7.0f / zoom_scale;
-      }
-      else
-      {
-        anchor_size = 5.0f / zoom_scale;
-      }
-      dt_draw_set_color_overlay(cr, TRUE, 0.8);
-      cairo_rectangle(cr, gpt->points[k * 6 + 2] - (anchor_size * 0.5),
-                      gpt->points[k * 6 + 3] - (anchor_size * 0.5), anchor_size, anchor_size);
-      cairo_fill_preserve(cr);
-
-      if(k == gui->point_dragging || k == gui->point_selected)
-        cairo_set_line_width(cr, 2.0 / zoom_scale);
-      else if((k == 0 || k == nb) && gui->creation && gui->creation_closing_form)
-        cairo_set_line_width(cr, 2.0 / zoom_scale);
-      else
-        cairo_set_line_width(cr, 1.0 / zoom_scale);
-      dt_draw_set_color_overlay(cr, FALSE, 0.8);
-      cairo_stroke(cr);
-    }
+      dt_masks_draw_anchor(cr, k == gui->point_dragging || k == gui->point_selected, zoom_scale,
+                           gpt->points[k * 6 + 2], gpt->points[k * 6 + 3]);
   }
 
   // draw feathers
@@ -2131,29 +2109,7 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
 
     // we draw the path segment by segment
     for(int k = 0; k < nb; k++)
-    {
-      // draw the point
-      if(gui->point_border_selected == k)
-      {
-        anchor_size = 7.0f / zoom_scale;
-      }
-      else
-      {
-        anchor_size = 5.0f / zoom_scale;
-      }
-      dt_draw_set_color_overlay(cr, TRUE, 0.8);
-      cairo_rectangle(cr, gpt->border[k * 6] - (anchor_size * 0.5), gpt->border[k * 6 + 1] - (anchor_size * 0.5),
-                      anchor_size, anchor_size);
-      cairo_fill_preserve(cr);
-
-      if(gui->point_border_selected == k)
-        cairo_set_line_width(cr, 2.0 / zoom_scale);
-      else
-        cairo_set_line_width(cr, 1.0 / zoom_scale);
-      dt_draw_set_color_overlay(cr, FALSE, 0.8);
-      cairo_set_dash(cr, dashed, 0, 0);
-      cairo_stroke(cr);
-    }
+      dt_masks_draw_anchor(cr, gui->point_border_selected == k, zoom_scale, gpt->border[k * 6], gpt->border[k * 6 + 1]);
   }
 
   // draw a cross where the source will be created

--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -570,15 +570,6 @@ static void _popup_date_update(GtkDarktableRangeSelect *range, GtkWidget *w)
   pop->internal_change--;
 }
 
-
-static void _current_resized(GtkWidget *widget, GtkAllocation *allocation, GtkDarktableRangeSelect *range)
-{
-  // we want to be sure that we have enough space to show it on top
-  gint wx, wy;
-  gtk_widget_translate_coordinates(range->band, gtk_widget_get_toplevel(range->band), 0, 0, &wx, &wy);
-  gtk_popover_set_position(GTK_POPOVER(range->cur_window), (wy < allocation->height) ? GTK_POS_RIGHT : GTK_POS_TOP);
-}
-
 static void _current_hide_popup(GtkDarktableRangeSelect *range)
 {
   if(!range->cur_window) return;
@@ -591,14 +582,7 @@ static void _current_show_popup(GtkDarktableRangeSelect *range)
   if(range->cur_window) return;
   range->cur_window = gtk_popover_new(range->band);
   gtk_widget_set_name(range->cur_window, "range-current");
-  // we try to guess what is the best position before we show the popup.
-  // Anyway this is rechecked on popup resizing
-  gint wx, wy;
-  gtk_widget_translate_coordinates(range->band, gtk_widget_get_toplevel(range->band), 0, 0, &wx, &wy);
-  gtk_popover_set_position(GTK_POPOVER(range->cur_window),
-                           (wy < 2 * gtk_widget_get_allocated_height(range->band)) ? GTK_POS_RIGHT : GTK_POS_TOP);
   gtk_popover_set_modal(GTK_POPOVER(range->cur_window), FALSE);
-  g_signal_connect(G_OBJECT(range->cur_window), "size-allocate", G_CALLBACK(_current_resized), range);
   range->cur_label = gtk_label_new(" ");
   dt_gui_add_class(range->cur_label, "dt_transparent_background");
   gtk_container_add(GTK_CONTAINER(range->cur_window), range->cur_label);
@@ -1494,16 +1478,17 @@ static gboolean _event_band_motion(GtkWidget *widget, GdkEventMotion *event, gpo
     return TRUE;
   }
   _current_show_popup(range);
-  // point the popup to the current position
-  if(gtk_popover_get_position(GTK_POPOVER(range->cur_window)) == GTK_POS_TOP)
+  // point the popup to the current position or to the right if no space
+  gint wx, wy;
+  gtk_widget_translate_coordinates(range->band, gtk_widget_get_toplevel(range->band), 0, 0, &wx, &wy);
+  if(wy > gtk_widget_get_allocated_height(range->band))
   {
-    GdkRectangle rect;
-    rect.x = event->x;
-    rect.width = 1;
-    rect.y = 0;
-    rect.height = gtk_widget_get_allocated_height(range->band);
+    gtk_popover_set_position(GTK_POPOVER(range->cur_window), GTK_POS_TOP);
+    GdkRectangle rect = {event->x, 0, 1, 1};
     gtk_popover_set_pointing_to(GTK_POPOVER(range->cur_window), &rect);
   }
+  else
+    gtk_popover_set_position(GTK_POPOVER(range->cur_window), GTK_POS_RIGHT);
 
   const double smin_r = (range->bounds & DT_RANGE_BOUND_MIN) ? range->min_r : range->select_min_r;
   const double smax_r = (range->bounds & DT_RANGE_BOUND_MAX) ? range->max_r : range->select_max_r;

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -3746,7 +3746,7 @@ gboolean dt_shortcut_dispatcher(GtkWidget *w, GdkEvent *event, gpointer user_dat
         if(gtk_widget_event(focused_widget, event))
           return TRUE;
 
-        if(GTK_IS_ENTRY(focused_widget) &&
+        if((GTK_IS_ENTRY(focused_widget) || GTK_IS_TREE_VIEW(focused_widget)) &&
            (event->key.keyval == GDK_KEY_Tab ||
             event->key.keyval == GDK_KEY_KP_Tab ||
             event->key.keyval == GDK_KEY_ISO_Left_Tab))

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2279,7 +2279,7 @@ static void _ui_init_panel_center_top(dt_ui_t *ui, GtkWidget *container)
 
   /* add container for center top center */
   ui->containers[DT_UI_CONTAINER_PANEL_CENTER_TOP_CENTER] = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_box_pack_start(GTK_BOX(widget), ui->containers[DT_UI_CONTAINER_PANEL_CENTER_TOP_CENTER], TRUE, TRUE,
+  gtk_box_pack_start(GTK_BOX(widget), ui->containers[DT_UI_CONTAINER_PANEL_CENTER_TOP_CENTER], TRUE, FALSE,
                      DT_UI_PANEL_MODULE_SPACING);
 
   /* add container for center top right */

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -970,7 +970,6 @@ static gboolean rt_add_shape(GtkWidget *widget, const int creation_continuous, d
       spot = dt_masks_create(type | DT_MASKS_NON_CLONE);
 
     dt_masks_change_form_gui(spot);
-    darktable.develop->form_gui->creation = TRUE;
     darktable.develop->form_gui->creation_module = self;
 
     if(creation_continuous)
@@ -1811,8 +1810,6 @@ static gboolean rt_select_algorithm_callback(GtkToggleButton *togglebutton, GdkE
     else
       spot = dt_masks_create(type | DT_MASKS_NON_CLONE);
     dt_masks_change_form_gui(spot);
-
-    darktable.develop->form_gui->creation = TRUE;
     darktable.develop->form_gui->creation_module = self;
     dt_control_queue_redraw_center();
   }

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -291,7 +291,6 @@ static gboolean _add_shape(GtkWidget *widget, const int creation_continuous, dt_
 
   dt_masks_form_t *form = dt_masks_create(type | DT_MASKS_CLONE);
   dt_masks_change_form_gui(form);
-  darktable.develop->form_gui->creation = TRUE;
   darktable.develop->form_gui->creation_module = self;
 
   if(creation_continuous)

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -1645,7 +1645,6 @@ static gboolean _sort_init(_widgets_sort_t *sort, const dt_collection_sort_t sor
   {
     sort->lib = d;
     sort->box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    gtk_widget_set_hexpand(sort->box, TRUE);
     // we only allow shortcut for the first sort order, always visible
     if(num == 0)
       sort->sort = dt_bauhaus_combobox_new_action(DT_ACTION(self));

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1710,6 +1710,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_tree_view_column_set_attributes(col, renderer, "pixbuf", TREE_IC_INVERSE, NULL);
   gtk_tree_view_column_add_attribute(col, renderer, "visible", TREE_IC_INVERSE_VISIBLE);
   renderer = gtk_cell_renderer_text_new();
+  g_object_set(renderer, "ellipsize", PANGO_ELLIPSIZE_MIDDLE, NULL);
   gtk_tree_view_column_pack_start(col, renderer, TRUE);
   gtk_tree_view_column_add_attribute(col, renderer, "text", TREE_TEXT);
   gtk_tree_view_column_add_attribute(col, renderer, "editable", TREE_EDITABLE);

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -172,7 +172,6 @@ static void _property_changed(GtkWidget *widget, dt_masks_property_t prop)
       if(value != d->last_value[prop] && count != saved_count && value != d->last_value[prop])
       {
         // we recreate the form points
-        dt_masks_gui_form_remove(sel, gui, pos);
         dt_masks_gui_form_create(sel, gui, pos, dev->gui_module);
       }
     }

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1743,6 +1743,7 @@ void gui_init(dt_lib_module_t *self)
                                                   _masks_properties[i].max, 0, 0.0, 2);
     dt_bauhaus_widget_set_label(d->property[i], N_("properties"), _masks_properties[i].name);
     dt_bauhaus_slider_set_format(d->property[i], _masks_properties[i].format);
+    dt_bauhaus_slider_set_digits(d->property[i], 2);
     d->last_value[i] = dt_bauhaus_slider_get(d->property[i]);
     gtk_box_pack_start(GTK_BOX(d->cs.container), d->property[i], FALSE, FALSE, 0);
     g_signal_connect(G_OBJECT(d->property[i]), "value-changed", G_CALLBACK(_property_changed), GINT_TO_POINTER(i));

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -272,7 +272,6 @@ static void _tree_add_circle(GtkButton *button, dt_iop_module_t *module)
   // we create the new form
   dt_masks_form_t *spot = dt_masks_create(DT_MASKS_CIRCLE);
   dt_masks_change_form_gui(spot);
-  darktable.develop->form_gui->creation = TRUE;
   darktable.develop->form_gui->creation_module = module;
   darktable.develop->form_gui->group_selected = 0;
   dt_control_queue_redraw_center();
@@ -296,7 +295,6 @@ static void _tree_add_ellipse(GtkButton *button, dt_iop_module_t *module)
   // we create the new form
   dt_masks_form_t *spot = dt_masks_create(DT_MASKS_ELLIPSE);
   dt_masks_change_form_gui(spot);
-  darktable.develop->form_gui->creation = TRUE;
   darktable.develop->form_gui->creation_module = module;
   darktable.develop->form_gui->group_selected = 0;
   dt_control_queue_redraw_center();
@@ -344,7 +342,6 @@ static void _tree_add_gradient(GtkButton *button, dt_iop_module_t *module)
   // we create the new form
   dt_masks_form_t *spot = dt_masks_create(DT_MASKS_GRADIENT);
   dt_masks_change_form_gui(spot);
-  darktable.develop->form_gui->creation = TRUE;
   darktable.develop->form_gui->creation_module = module;
   darktable.develop->form_gui->group_selected = 0;
   dt_control_queue_redraw_center();
@@ -367,7 +364,6 @@ static void _tree_add_brush(GtkButton *button, dt_iop_module_t *module)
   // we create the new form
   dt_masks_form_t *spot = dt_masks_create(DT_MASKS_BRUSH);
   dt_masks_change_form_gui(spot);
-  darktable.develop->form_gui->creation = TRUE;
   darktable.develop->form_gui->creation_module = module;
   darktable.develop->form_gui->group_selected = 0;
   dt_control_queue_redraw_center();

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -181,13 +181,11 @@ static void _property_changed(GtkWidget *widget, dt_masks_property_t prop)
 
   if(count)
   {
-    if(value != d->last_value[prop] && sum / count != d->last_value[prop])
+    if(value != d->last_value[prop] && sum / count != d->last_value[prop] && prop != DT_MASKS_PROPERTY_OPACITY)
     {
-      if(prop != DT_MASKS_PROPERTY_OPACITY)
-      {
-        if(gui->show_all_feathers) g_source_remove(gui->show_all_feathers);
-        gui->show_all_feathers = g_timeout_add_seconds(2, _timeout_show_all_feathers, gui);
-      }
+      if(gui->show_all_feathers) g_source_remove(gui->show_all_feathers);
+      gui->show_all_feathers = g_timeout_add_seconds(2, _timeout_show_all_feathers, gui);
+
       // we save the new parameters
       dt_dev_add_masks_history_item(darktable.develop, dev->gui_module, TRUE);
       dt_masks_update_image(darktable.develop);

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -120,15 +120,16 @@ static void _property_changed(GtkWidget *widget, dt_masks_property_t prop)
 {
   dt_lib_module_t *self = darktable.develop->proxy.masks.module;
   dt_lib_masks_t *d = self->data;
-
-  gtk_widget_hide(widget);
-  float value = dt_bauhaus_slider_get(widget);
-
   dt_develop_t *dev = darktable.develop;
   dt_masks_form_t *form = dev->form_visible;
   dt_masks_form_gui_t *gui = dev->form_gui;
-  if(!gui) return;
-  if(!form) return;
+  if(!form || !gui)
+  {
+    gtk_widget_hide(widget);
+    return;
+  }
+
+  float value = dt_bauhaus_slider_get(widget);
 
   ++darktable.gui->reset;
   int count = 0, pos = 0;
@@ -178,6 +179,7 @@ static void _property_changed(GtkWidget *widget, dt_masks_property_t prop)
     }
   }
 
+  gtk_widget_set_visible(widget, count != 0);
   if(count)
   {
     if(value != d->last_value[prop] && sum / count != d->last_value[prop]
@@ -206,10 +208,10 @@ static void _property_changed(GtkWidget *widget, dt_masks_property_t prop)
     dt_bauhaus_slider_set(widget, sum / count);
     d->last_value[prop] = dt_bauhaus_slider_get(widget);
 
-    gtk_widget_show(widget);
     gtk_widget_hide(d->none_label);
     dt_control_queue_redraw_center();
   }
+
   --darktable.gui->reset;
 }
 

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1458,6 +1458,8 @@ static void _lib_masks_recreate_list(dt_lib_module_t *self)
 
   g_object_unref(treestore);
 
+  _update_all_properties(lm);
+
   lm->gui_reset = gui_reset;
 }
 

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -147,34 +147,35 @@ static void _property_changed(GtkWidget *widget, dt_masks_property_t prop)
   if(gui->creation && form->functions && form->functions->modify_property)
     form->functions->modify_property(form, prop, d->last_value[prop], value, &sum, &count, &min, &max);
   else
-  for(GList *fpts = form->points; fpts; fpts = g_list_next(fpts))
   {
-    dt_masks_point_group_t *fpt = (dt_masks_point_group_t *)fpts->data;
-    dt_masks_form_t *sel = dt_masks_get_from_id(darktable.develop, fpt->formid);
-    if(!sel || (dev->mask_form_selected_id && dev->mask_form_selected_id != sel->formid)) continue;;
-
-    if(prop == DT_MASKS_PROPERTY_OPACITY && fpt->parentid)
+    for(GList *fpts = form->points; fpts; fpts = g_list_next(fpts), pos++)
     {
-      float new_opacity = dt_masks_form_change_opacity(sel, fpt->parentid, value - d->last_value[prop]);
-      sum += new_opacity;
-      max = fminf(max, 1.0f - new_opacity);
-      min = fmaxf(min, .05f - new_opacity);
-      ++count;
-    }
-    else
-    {
-      int saved_count = count;
+      dt_masks_point_group_t *fpt = (dt_masks_point_group_t *)fpts->data;
+      dt_masks_form_t *sel = dt_masks_get_from_id(darktable.develop, fpt->formid);
+      if(!sel || (dev->mask_form_selected_id && dev->mask_form_selected_id != sel->formid)) continue;;
 
-      if(sel->functions && sel->functions->modify_property)
-        sel->functions->modify_property(sel, prop, d->last_value[prop], value, &sum, &count, &min, &max);
-
-      if(value != d->last_value[prop] && count != saved_count && value != d->last_value[prop])
+      if(prop == DT_MASKS_PROPERTY_OPACITY && fpt->parentid)
       {
-        // we recreate the form points
-        dt_masks_gui_form_create(sel, gui, pos, dev->gui_module);
+        float new_opacity = dt_masks_form_change_opacity(sel, fpt->parentid, value - d->last_value[prop]);
+        sum += new_opacity;
+        max = fminf(max, 1.0f - new_opacity);
+        min = fmaxf(min, .05f - new_opacity);
+        ++count;
+      }
+      else
+      {
+        int saved_count = count;
+
+        if(sel->functions && sel->functions->modify_property)
+          sel->functions->modify_property(sel, prop, d->last_value[prop], value, &sum, &count, &min, &max);
+
+        if(value != d->last_value[prop] && count != saved_count && value != d->last_value[prop])
+        {
+          // we recreate the form points
+          dt_masks_gui_form_create(sel, gui, pos, dev->gui_module);
+        }
       }
     }
-    pos++;
   }
 
   if(count)

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -55,7 +55,7 @@ const char **views(dt_lib_module_t *self)
 
 uint32_t container(dt_lib_module_t *self)
 {
-  return DT_UI_CONTAINER_PANEL_CENTER_TOP_CENTER;
+  return DT_UI_CONTAINER_PANEL_CENTER_TOP_LEFT;
 }
 
 int expandable(dt_lib_module_t *self)


### PR DESCRIPTION
A frequent complaint has been that to manipulate mask shapes, one often has to use the scroll wheel (to change size, feathering or opacity) which can be inconvenient for pen users. This PR tries to address this somewhat. It consists of 2 main changes and a bit of code cleanup (of which _much_ more would be useful).

1. Add more handles/anchors to circles and ellipses that can be picked up to change size or feather (consistent with paths).
![image](https://user-images.githubusercontent.com/1549490/192785621-af50f08f-bbab-4a75-929b-701ed6a0a90c.png)
![image](https://user-images.githubusercontent.com/1549490/192786514-bf938708-e995-427d-afd2-58d308c575f6.png)

2. Add a collapsible section to the mask managers with sliders to change the proporties of currently selected (or created) shapes.

![image](https://user-images.githubusercontent.com/1549490/192788949-b0141686-9bdc-4e2e-a7de-ff8bd877b92c.png)

If a group of shapes has been selected, the soft limits of the sliders are attempting to prevent irreversible distortions (where some of the shapes are clamped at their extreme values whereas others are still adjusted, so that reversing the move doesn't lead to the original situation). But like any soft limits these can be forced.

@TurboGit I would say the main challenge in this PR was the incredible amount of code duplication in the masks area, which makes it very hard to see what's going on. I've cleaned up some, but it is tedious, careful, work that easily breaks stuff if copied code was slightly amended in one location but not in another either accidentally or for good reasons. Once duplicated code blocks exist, they tend to multiply since they are a sign of overdue refactoring. This PR definitely adds somewhat to the problem in that there is a large overlap between what the `modify_property` methods do and what happens in `mouse_scrolled`. This should be solved by having the latter call the former, but I did not want to do this in the initial release because it might break existing functionality while the new has not been properly tested yet. So I hope it doesn't sound to disingenuous to argue that we should be much more reticent to allow duplicated code, especially when large chunks are copied for just a tiny extra functionality. The expectation that "someone" will clean it up hardly ever comes true. Rather, once the duplicates have been duplicated a few times themselves, it massively discourages anyone to touch such toxic code again. I would suggest that if you are presented with a PR that is mostly duplicated code and where the submitter doesn't have the skill to properly refactor, you try to enlist the help of someone knowledgeable in the area. I can point at what happened with #11905 as an example. Yes, it will slow down merging, but PRs like that are hardly ever urgent and it really saves a lot of time, pain and discouragement later on.

Back to masks; apart from just more refactoring, some redesign of the code would be useful too. If, for example, a more complete object would be set up when creating a new shape, we would be able to read properties from the objects themselves, the same as when dealing with existing shapes, rather than in one case using the object and in another having to get values using `dt_conf_get_float`. This would simplify the logic and the code. Again, I haven't made such deep changes yet because I don't want to break the existing workflow while expecting people to test the new functionality. But also because I'm not sure about the lifetime of newly created shapes anyway (especially when the creation process is cancelled by right-clicking; it seem to me the skeletal shape does not get deleted, i.e. that there is a small memory leak).

This PR was obviously inspired by #9015. I tried the path of adding sliders to the top toolbar but felt it led to too many layouting issues and the mask manager was a more appropriate and convenient place. Before that decision I did fix a few small issues plaguing sliders in the middle top location.

This (partially) fixes #10228 (which, tbh, I was not aware of/did not remember).

@elstoc https://darktable-org.github.io/dtdocs/en/darkroom/masking-and-blending/masks/drawn/#available-shapes says that scrolling over a circle's border changes the feathering (even when not holding shift) but this hasn't been the case since #1719 (whether that was a good change or not is for everyone to decide for themselves).

Partially fixes #11964; you can now leave a treeview, for example the masks list, by pressing Tab, so that shortcuts work again. What's going on with the Ctrl-P combination specifically in treeviews is still a mystery to me.

Make 360 degree sliders wrap around while scrolling or using shortcuts.
