### PR TITLE
po/introspection types

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -232,6 +232,9 @@ void dt_iop_default_init(dt_iop_module_t *module)
   {
     switch(i->header.type)
     {
+    case DT_INTROSPECTION_TYPE_FLOATCOMPLEX:
+      *(float complex*)((uint8_t *)module->default_params + i->header.offset) = i->FloatComplex.Default;
+      break;
     case DT_INTROSPECTION_TYPE_FLOAT:
       *(float*)((uint8_t *)module->default_params + i->header.offset) = i->Float.Default;
       break;
@@ -243,6 +246,9 @@ void dt_iop_default_init(dt_iop_module_t *module)
       break;
     case DT_INTROSPECTION_TYPE_USHORT:
       *(unsigned short*)((uint8_t *)module->default_params + i->header.offset) = i->UShort.Default;
+      break;
+    case DT_INTROSPECTION_TYPE_INT8:
+      *(short*)((uint8_t *)module->default_params + i->header.offset) = i->Int8.Default;
       break;
     case DT_INTROSPECTION_TYPE_ENUM:
       *(int*)((uint8_t *)module->default_params + i->header.offset) = i->Enum.Default;

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1661,21 +1661,6 @@ void cleanup_global(dt_iop_module_so_t *module)
   module->data = NULL;
 }
 
-void init(dt_iop_module_t *module)
-{
-  // We don't use dt_iop_default_init(module); as some type int8, floatcomplex are not
-  // supported by introspection.
-
-  // module is disabled by default
-  module->default_enabled = 0;
-  module->params_size = sizeof(dt_iop_liquify_params_t);
-  module->gui_data = NULL;
-
-  // all allocated to 0, which is the default
-  module->params = calloc(1, module->params_size);
-  module->default_params = calloc(1, module->params_size);
-}
-
 // calculate the dot product of 2 vectors.
 
 static float cdot(const float complex p0, const float complex p1)


### PR DESCRIPTION
Add support for INT8 & FLOATCOMPLEX in introspection to be able to use `dt_iop_default_init` in liquify.