### PR TITLE
Version 2 of segmentation highlights reconstruction supports xtrans

### DIFF
--- a/src/common/distance_transform.h
+++ b/src/common/distance_transform.h
@@ -89,7 +89,7 @@ static void _image_distance_transform(const float *f, float *z, float *d, int *v
   }
 }
 
-float dt_image_distance_transform(float *const restrict src, float *const restrict out, const size_t width, const size_t height, const float clip, const dt_distance_transform_t mode)
+float dt_image_distance_transform(float *const src, float *const out, const size_t width, const size_t height, const float clip, const dt_distance_transform_t mode)
 {
   switch(mode)
   {
@@ -97,10 +97,10 @@ float dt_image_distance_transform(float *const restrict src, float *const restri
       break;
     case DT_DISTANCE_TRANSFORM_MASK:
 #ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
+  #pragma omp parallel for default(none) \
   dt_omp_firstprivate(src, out) \
   dt_omp_sharedconst(clip, width, height) \
-  schedule(static) aligned(src, out : 64)
+  schedule(static)
 #endif
       for(size_t i = 0; i < width * height; i++)
         out[i] = (src[i] < clip) ? 0.0f : DT_DISTANCE_TRANSFORM_MAX;
@@ -127,7 +127,7 @@ float dt_image_distance_transform(float *const restrict src, float *const restri
 
     // transform along columns
 #ifdef _OPENMP
-  #pragma omp for schedule(simd:static)
+  #pragma omp for schedule (static)
 #endif
     for(size_t x = 0; x < width; x++)
     {
@@ -140,7 +140,7 @@ float dt_image_distance_transform(float *const restrict src, float *const restri
     // implicit barrier :-)
     // transform along rows
 #ifdef _OPENMP
-  #pragma omp for schedule(simd:static) nowait
+  #pragma omp for schedule (static) nowait
 #endif
     for(size_t y = 0; y < height; y++)
     {

--- a/src/develop/masks/detail.c
+++ b/src/develop/masks/detail.c
@@ -90,14 +90,14 @@ static inline float _sqrf(float a)
   return a * a;
 }
 
-void dt_masks_extend_border(float *const restrict mask, const int width, const int height, const int border)
+void dt_masks_extend_border(float *const mask, const int width, const int height, const int border)
 {
   if(border <= 0) return;
 #ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
+  #pragma omp parallel for default(none) \
   dt_omp_firstprivate(mask) \
   dt_omp_sharedconst(width, height, border) \
-  schedule(simd:static) aligned(mask : 64)
+  schedule(static)
  #endif
   for(size_t row = border; row < height - border; row++)
   {
@@ -109,10 +109,10 @@ void dt_masks_extend_border(float *const restrict mask, const int width, const i
     }
   }
 #ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
+  #pragma omp parallel for default(none) \
   dt_omp_firstprivate(mask) \
   dt_omp_sharedconst(width, height, border) \
-  schedule(simd:static) aligned(mask : 64)
+  schedule(static)
  #endif
   for(size_t col = 0; col < width; col++)
   {

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -2410,7 +2410,6 @@ void gui_init(struct dt_iop_module_t *self)
                                                 "the mask button shows selected segments."));
   dt_bauhaus_slider_set_format(g->candidating, "%");
   dt_bauhaus_slider_set_digits(g->candidating, 0);
-  dt_bauhaus_slider_set_step(g->candidating, 0.05f);
   dt_bauhaus_widget_set_quad_paint(g->candidating, dtgtk_cairo_paint_showmask, 0, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->candidating, TRUE);
   dt_bauhaus_widget_set_quad_active(g->candidating, FALSE);

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -491,12 +491,20 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   if(d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS)
   {
     // even if the algorithm can't tile we want to calculate memory for pixelpipe checks and a possible warning
-    const int segments = roi_out->width * roi_out->height / 2000; // segments per mpix
-    tiling->xalign = 2;
-    tiling->yalign = 2;
+    const int segments = roi_out->width * roi_out->height / 4000; // segments per mpix
+    if(filters != 9u)
+    {
+      tiling->xalign = 2;
+      tiling->yalign = 2;
+    }
+    else
+    {
+      tiling->xalign = 3;
+      tiling->yalign = 3;
+    }
     tiling->overlap = 0;
     tiling->overhead = segments * 5 * 5 * sizeof(int); // segmentation stuff
-    tiling->factor = 2.0f + 3.3f; // in & out plus planes plus segmentation
+    tiling->factor = 3.0f;
     tiling->maxbuf = 1.0f;
     return;
   }
@@ -1970,7 +1978,7 @@ static void process_visualize(dt_dev_pixelpipe_iop_t *piece, const void *const i
   }
 }
 
-#include "iop/hlrecovery.c"
+#include "iop/hlrecovery_v2.c"
 #include "iop/opposed.c"
 
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
@@ -2077,10 +2085,12 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
     case DT_IOP_HIGHLIGHTS_SEGMENTS:
     {
-      dt_segments_mask_t vmode = DT_SEGMENTS_MASK_OFF;
-      if(g != NULL) vmode = g->segmentation_mask_mode;
+      const dt_segments_mask_t vmode = ((g != NULL) && fullpipe) ? g->segmentation_mask_mode : DT_SEGMENTS_MASK_OFF;
+      const gboolean anyclip = _process_opposed(piece, ivoid, ovoid, roi_in, roi_out, data);
+      const gboolean complete = fullpipe || (piece->pipe->type & DT_DEV_PIXELPIPE_EXPORT);
+      if(complete && (anyclip || (vmode != DT_SEGMENTS_MASK_OFF)))
+        _process_segmentation(piece, ivoid, ovoid, roi_in, roi_out, data, vmode);
 
-      _process_segmentation(piece, ivoid, ovoid, roi_in, roi_out, filters, data, vmode);
       if(vmode != DT_SEGMENTS_MASK_OFF)
       {
         piece->pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
@@ -2207,7 +2217,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   dt_bauhaus_widget_set_quad_visibility(g->clip, israw);
 
   const gboolean use_laplacian = bayer && mode == DT_IOP_HIGHLIGHTS_LAPLACIAN;
-  const gboolean use_segmentation = bayer && (mode == DT_IOP_HIGHLIGHTS_SEGMENTS);
+  const gboolean use_segmentation = (mode == DT_IOP_HIGHLIGHTS_SEGMENTS);
   const gboolean use_recovery = use_segmentation && (p->recovery != DT_RECOVERY_MODE_OFF);
 
   gtk_widget_set_visible(g->noise_level, use_laplacian || use_recovery);
@@ -2228,12 +2238,12 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     g->segmentation_mask_mode = DT_SEGMENTS_MASK_OFF;
   }
   // If guided laplacian or segmentation mode was copied as part of the history of another pic, sanitize it
-  // guided laplacian and segmentation are not available for XTrans
-  if(!bayer && ((mode == DT_IOP_HIGHLIGHTS_LAPLACIAN) || (mode == DT_IOP_HIGHLIGHTS_SEGMENTS)) )
+  // guided laplacian is not available for XTrans
+  if(!bayer && (mode == DT_IOP_HIGHLIGHTS_LAPLACIAN))
   {
     p->mode = DT_IOP_HIGHLIGHTS_CLIP;
     dt_bauhaus_combobox_set_from_value(g->mode, p->mode);
-    dt_control_log(_("highlights: guided laplacian and segmentation modes are not available for X-Trans sensors. falling back to clip."));
+    dt_control_log(_("highlights: guided laplacian is not available for X-Trans sensors. falling back to clip."));
   }
 }
 
@@ -2289,6 +2299,8 @@ void reload_defaults(dt_iop_module_t *module)
       dt_bauhaus_combobox_remove_at(g->mode, DT_IOP_HIGHLIGHTS_OPPOSED);
       dt_bauhaus_combobox_remove_at(g->mode, DT_IOP_HIGHLIGHTS_SEGMENTS);
       dt_bauhaus_combobox_remove_at(g->mode, DT_IOP_HIGHLIGHTS_LAPLACIAN);
+      dt_bauhaus_combobox_add_full(g->mode, _("segmentation based"), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,
+                                      GINT_TO_POINTER(DT_IOP_HIGHLIGHTS_SEGMENTS), NULL, TRUE);
       dt_bauhaus_combobox_add_full(g->mode, _("inpaint opposed"), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,
                                       GINT_TO_POINTER(DT_IOP_HIGHLIGHTS_OPPOSED), NULL, TRUE);
     }
@@ -2385,17 +2397,19 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->combine = dt_bauhaus_slider_from_params(self, "combine");
   dt_bauhaus_slider_set_digits(g->combine, 0);
-  gtk_widget_set_tooltip_text(g->combine, _("combine closely related clipped segments by morphological operations."));
+  gtk_widget_set_tooltip_text(g->combine, _("combine closely related clipped segments by morphological operations\n."
+                                            "the mask button shows resulting segment borders."));
   dt_bauhaus_widget_set_quad_paint(g->combine, dtgtk_cairo_paint_showmask, 0, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->combine, TRUE);
   dt_bauhaus_widget_set_quad_active(g->combine, FALSE);
   g_signal_connect(G_OBJECT(g->combine), "quad-pressed", G_CALLBACK(_combine_callback), self);
 
   g->candidating = dt_bauhaus_slider_from_params(self, "candidating");
-  gtk_widget_set_tooltip_text(g->candidating, _("dealing with isolated clipped segments in dark regions.\n"
-                                                   "increase to favour candidates found in segmentation analysis,\n"
-                                                   "decrease for simple inpainting."));
+  gtk_widget_set_tooltip_text(g->candidating, _("select inpainting after segmentation analysis.\n"
+                                                "increase to favour candidates found in segmentation analysis, decrease for opposed means inpainting.\n"
+                                                "the mask button shows selected segments."));
   dt_bauhaus_slider_set_format(g->candidating, "%");
+  dt_bauhaus_slider_set_digits(g->candidating, 0);
   dt_bauhaus_slider_set_step(g->candidating, 0.05f);
   dt_bauhaus_widget_set_quad_paint(g->candidating, dtgtk_cairo_paint_showmask, 0, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->candidating, TRUE);

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -2425,7 +2425,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->strength = dt_bauhaus_slider_from_params(self, "strength");
   gtk_widget_set_tooltip_text(g->strength, _("set strength of reconstruction in regions with all photosites clipped"));
   dt_bauhaus_slider_set_format(g->strength, "%");
-  dt_bauhaus_slider_set_step(g->strength, 0.1f);
+  dt_bauhaus_slider_set_digits(g->strength, 0);
   dt_bauhaus_widget_set_quad_paint(g->strength, dtgtk_cairo_paint_showmask, 0, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->strength, TRUE);
   dt_bauhaus_widget_set_quad_active(g->strength, FALSE);

--- a/src/iop/hlrecovery_v2.c
+++ b/src/iop/hlrecovery_v2.c
@@ -85,7 +85,7 @@ The chosen segmentation algorithm works like this:
 
 #define HL_RGB_PLANES 3
 #define HL_SEGMENT_PLANES 4
-#define HL_FLOAT_PLANES 8
+#define HL_FLOAT_PLANES 9
 #define HL_BORDER 8
 
 #include "iop/segmentation.h"
@@ -121,7 +121,7 @@ static float _calc_weight(const float *s, const size_t loc, const int w, const f
   return sval * smoothness;
 }
 
-static void _calc_plane_candidates(const float * restrict plane, const float * restrict refavg, dt_iop_segmentation_t *seg, const float clipval, const float badlevel)
+static void _calc_plane_candidates(const float *plane, const float *refavg, dt_iop_segmentation_t *seg, const float clipval, const float badlevel)
 {
 #ifdef _OPENMP
   #pragma omp parallel for default(none) \
@@ -209,6 +209,212 @@ static inline float _calc_refavg(const float *in, const uint8_t(*const xtrans)[6
   return (linear) ? powf(croot_refavg[color], 3.0f) : croot_refavg[color];
 }
 
+static void _initial_gradients(const size_t w, const size_t height, float *luminance, float *distance, float *gradient)
+{
+#ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+  dt_omp_firstprivate(luminance, gradient, distance) \
+  dt_omp_sharedconst(w, height) \
+  schedule(static) collapse(2)
+#endif
+  for(size_t row = HL_BORDER; row < height - HL_BORDER; row++)
+  {
+    for(size_t col = HL_BORDER; col < w - HL_BORDER; col++)
+    {
+      const size_t v = row * w + col;
+      float g = 0.0f;
+      if((distance[v] > 0.0f) && (distance[v] < 2.0f))
+      {
+        // scharr operator
+        const float gx = 47.0f * (luminance[v-w-1] - luminance[v-w+1])
+                      + 162.0f * (luminance[v-1]   - luminance[v+1])
+                       + 47.0f * (luminance[v+w-1] - luminance[v+w+1]);
+        const float gy = 47.0f * (luminance[v-w-1] - luminance[v+w-1])
+                      + 162.0f * (luminance[v-w]   - luminance[v+w])
+                       + 47.0f * (luminance[v-w+1] - luminance[v+w+1]);
+        g = 4.0f * sqrtf(sqf(gx / 256.0f) + sqf(gy / 256.0f));
+      }
+      gradient[v] = g;
+    }
+  }
+}
+
+static float _segment_maxdistance(const int width, const int height, float *distance, dt_iop_segmentation_t *seg, const int id)
+{
+  const int xmin = MAX(seg->xmin[id]-2, HL_BORDER);
+  const int xmax = MIN(seg->xmax[id]+3, width - HL_BORDER);
+  const int ymin = MAX(seg->ymin[id]-2, HL_BORDER);
+  const int ymax = MIN(seg->ymax[id]+3, height - HL_BORDER);
+  float max_distance = 0.0f;
+
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  reduction(max : max_distance) \
+  dt_omp_firstprivate(distance, seg) \
+  dt_omp_sharedconst(width, xmin, xmax, ymin, ymax, id) \
+  schedule(static) collapse(2)
+#endif
+  for(size_t row = ymin; row < ymax; row++)
+  {
+    for(size_t col = xmin; col < xmax; col++)
+    {
+      const size_t v = row * width + col;
+      if(id == seg->data[v])
+        max_distance = fmaxf(max_distance, distance[v]);
+    }
+  }
+  return max_distance;
+}
+
+static float _segment_attenuation(dt_iop_segmentation_t *seg, const int id, const int mode)
+{
+  const float attenuate[NUM_RECOVERY_MODES] = { 0.0f, 1.7f, 1.0f, 1.7f, 1.0f, 1.0f, 1.0f};
+  if(mode < DT_RECOVERY_MODE_ADAPT)
+    return attenuate[mode];
+  else
+  {
+    const float maxdist = fmaxf(1.0f, seg->val1[id]);
+    return fminf(1.7f,  0.9f + (3.0f / maxdist));
+  }
+}
+
+static float _segment_correction(dt_iop_segmentation_t *seg, const int id, const int mode, const int seg_border)
+{
+  const float correction = _segment_attenuation(seg, id, mode);
+  return correction - 0.1f * (float)seg_border;
+}
+
+static void _calc_distance_ring(const int width, const int xmin, const int xmax, const int ymin, const int ymax, float *gradient, float *distance, const float attenuate, const float dist, dt_iop_segmentation_t *seg, const int id)
+{
+#ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+  dt_omp_firstprivate(distance, gradient, seg) \
+  dt_omp_sharedconst(width, xmin, xmax, ymin, ymax, dist, id, attenuate) \
+  schedule(static) collapse(2)
+#endif
+  for(size_t row = ymin; row < ymax; row++)
+  {
+    for(size_t col = xmin; col < xmax; col++)
+    {
+      const size_t v = row * width + col;
+      const float dv = distance[v];
+      if((dv >= dist) && (dv < dist + 1.5f) && (id == seg->data[v]))
+      {
+        float grd = 0.0f;
+        float cnt = 0.0f;
+        for(int y = -2; y < 3; y++)
+        {
+          for(int x = -2; x < 3; x++)
+          {
+            size_t p = v + x + (width * y);
+            const float dd = distance[p];
+            if((dd >= dist - 1.5f) && (dd < dist))
+            {
+              cnt += 1.0f;
+              grd += gradient[p];
+            }
+          }
+        }
+        if(cnt > 0.0f)
+          gradient[v] = fminf(1.5f, (grd / cnt) * (1.0f + 1.0f / powf(distance[v], attenuate)));
+      }
+    }
+  }
+}
+
+static void _segment_gradients(const int width, const int height, float *distance, float *gradient, float *tmp, const int mode, dt_iop_segmentation_t *seg, const int id, const int seg_border)
+{
+  const int xmin = MAX(seg->xmin[id]-1, HL_BORDER);
+  const int xmax = MIN(seg->xmax[id]+2, width - HL_BORDER);
+  const int ymin = MAX(seg->ymin[id]-1, HL_BORDER);
+  const int ymax = MIN(seg->ymax[id]+2, height - HL_BORDER);
+  const float attenuate = _segment_attenuation(seg, id, mode);
+  const float strength = _segment_correction(seg, id, mode, seg_border);
+
+  float maxdist = 1.5f;
+  while(maxdist < seg->val1[id])
+  {
+    _calc_distance_ring(width, xmin, xmax, ymin, ymax, gradient, distance, attenuate, maxdist, seg, id);
+    maxdist += 1.5f;
+  }
+
+  if(maxdist > 4.0f)
+  {
+#ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+  dt_omp_firstprivate(gradient, tmp) \
+  dt_omp_sharedconst(width, xmin, xmax, ymin, ymax) \
+  schedule(static)
+#endif
+    for(size_t row = ymin; row < ymax; row++)
+    {
+      for(size_t col = xmin, s = row*width + col, d = (row-ymin)*(xmax-xmin); col < xmax; col++, s++, d++)
+        tmp[d] = gradient[s];
+    }
+
+    dt_box_mean(tmp, ymax-ymin, xmax-xmin, 1, MIN((int)maxdist, 15), 2);
+#ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+  dt_omp_firstprivate(gradient, tmp, distance, seg) \
+  dt_omp_sharedconst(width, xmin, xmax, ymin, ymax, id) \
+  schedule(static)
+#endif
+    for(size_t row = ymin; row < ymax; row++)
+    {
+      for(size_t col = xmin, v = row * width + col, s = (row-ymin)*(xmax-xmin); col < xmax; col++, v++, s++)
+      {
+        if(id == seg->data[v])
+          gradient[v] = tmp[s];
+      }
+    }
+  }
+#ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+  dt_omp_firstprivate(gradient, tmp, distance, seg) \
+  dt_omp_sharedconst(width, xmin, xmax, ymin, ymax, id, strength) \
+  schedule(static) collapse(2)
+#endif
+  for(size_t row = ymin; row < ymax; row++)
+  {
+    for(size_t col = xmin; col < xmax; col++)
+    {
+      const size_t v = row * width + col;
+      if(id == seg->data[v])
+        gradient[v] *= strength;
+    }
+  }
+}
+
+static void _add_poisson_noise(const int width, const int height, float *lum, dt_iop_segmentation_t *seg, const int id, const float noise_level)
+{
+  const int xmin = MAX(seg->xmin[id], HL_BORDER);
+  const int xmax = MIN(seg->xmax[id]+1, width - HL_BORDER);
+  const int ymin = MAX(seg->ymin[id], HL_BORDER);
+  const int ymax = MIN(seg->ymax[id]+1, height - HL_BORDER);
+  uint32_t DT_ALIGNED_ARRAY state[4] = { splitmix32(ymin), splitmix32(xmin), splitmix32(1337), splitmix32(666) };
+  xoshiro128plus(state);
+  xoshiro128plus(state);
+  xoshiro128plus(state);
+  xoshiro128plus(state);
+  for(size_t row = ymin; row < ymax; row++)
+  {
+    for(size_t col = xmin; col < xmax; col++)
+    {
+      const size_t v = row * width + col;
+      if(seg->data[v] == id)
+      {
+        const float pnoise = poisson_noise(lum[v] * noise_level, noise_level, col & 1, state);
+        lum[v] += pnoise;
+      }
+    }
+  }
+}
+
+static inline size_t _raw_to_plane(const int width, const int row, const int col)
+{
+  return (HL_BORDER + (row / 3)) * width + (col / 3) + HL_BORDER;
+}
+
 static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
                          const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
                          dt_iop_highlights_data_t *data, const int vmode)
@@ -224,12 +430,17 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
   const dt_aligned_pixel_t cube_coeffs = { powf(clips[0], 1.0f / 3.0f), powf(clips[1], 1.0f / 3.0f), powf(clips[2], 1.0f / 3.0f)};
 
   const int combining = (int) data->combine;
+  const int recovery_mode = data->recovery;
+  const float strength = data->strength;
+
+  const int recovery_closing[NUM_RECOVERY_MODES] = { 0, 0, 0, 2, 2, 0, 2};
+  const int seg_border = recovery_closing[recovery_mode];
+  const int segmentation_limit = roi_out->width * roi_out->height / 4000; // segments per mpix
 
   const int pwidth  = dt_round_size(roi_in->width / 3, 2) + 2 * HL_BORDER;
   const int pheight = dt_round_size(roi_in->height / 3, 2) + 2 * HL_BORDER;
   const size_t p_size = dt_round_size((size_t) (pwidth + 4) * (pheight + 4), 16);
-  const size_t p_off  = (HL_BORDER * pwidth) + HL_BORDER;
-
+ 
   float *fbuffer = dt_alloc_align_float((HL_FLOAT_PLANES) * p_size);
   if(!fbuffer) return;
 
@@ -242,16 +453,15 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
     refavg[i] = plane[HL_SEGMENT_PLANES + i];
 
   dt_iop_segmentation_t isegments[HL_SEGMENT_PLANES];
-
-  const int segmentation_limit = roi_out->width * roi_out->height / 4000; // segments per mpix
-
   for(int i = 0; i < HL_SEGMENT_PLANES; i++)
     dt_segmentation_init_struct(&isegments[i], pwidth, pheight, HL_BORDER, segmentation_limit);
 
+  gboolean has_allclipped = FALSE;
 #ifdef _OPENMP
   #pragma omp parallel for simd default(none) \
+  reduction( | : has_allclipped) \
   dt_omp_firstprivate(ivoid, ovoid, roi_in, roi_out, plane, isegments, cube_coeffs, refavg, xtrans) \
-  dt_omp_sharedconst(p_off, pwidth, filters) \
+  dt_omp_sharedconst(pwidth, filters) \
   schedule(static)
 #endif
   for(size_t row = 1; row < roi_out->height-1; row++)
@@ -279,7 +489,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
         for(int c = 0; c < 3; c++) mean[c] = powf(mean[c] / cnt[c], 1.0f / 3.0f);
         const dt_aligned_pixel_t cube_refavg = { 0.5f * (mean[1] + mean[2]), 0.5f * (mean[0] + mean[2]), 0.5f * (mean[0] + mean[1])};
 
-        const size_t o = p_off + (row/3) * pwidth + (col/3);
+        const size_t o = _raw_to_plane(pwidth, row, col);
         int allclipped = 0;
         for(int c = 0; c < 3; c++)
         {
@@ -292,11 +502,15 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
           }
         }
         isegments[3].data[o] = (allclipped == 3) ? 1 : 0;
+        has_allclipped |= (allclipped == 3) ? TRUE : FALSE;
       }
       out++;
       in++;
     }
   }
+
+  if(!has_allclipped && vmode == DT_SEGMENTS_MASK_OFF)
+    goto finish; 
 
   for(int i = 0; i < HL_RGB_PLANES; i++)
     dt_masks_extend_border(plane[i], pwidth, pheight, HL_BORDER);
@@ -331,8 +545,8 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(clips, ivoid, ovoid, roi_in, roi_out, xtrans, isegments) \
-  dt_omp_sharedconst(filters, p_off, pwidth) \
+  dt_omp_firstprivate(clips, ivoid, ovoid, roi_in, roi_out, xtrans, isegments, plane) \
+  dt_omp_sharedconst(filters, pwidth) \
   schedule(static)
 #endif
   for(int row = 1; row < roi_out->height-1; row++)
@@ -345,7 +559,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
       const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
       if(inval > clips[color])
       {
-        const size_t o = p_off + (row/3) * pwidth + (col/3);
+        const size_t o = _raw_to_plane(pwidth, row, col);
         const int pid = _get_segment_id(&isegments[color], o);
         const float candidate = isegments[color].val1[pid];
         if((pid > 1) && (pid < isegments[color].nr+2) && (candidate != 0.0f))
@@ -353,7 +567,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
           const float cand_reference = isegments[color].val2[pid];
           const float refavg_here = _calc_refavg(&in[0], xtrans, filters, row, col, roi_in, FALSE);
           const float oval = powf(refavg_here + candidate - cand_reference, 3.0f);
-          out[0] = fmaxf(inval, oval);
+          out[0] = plane[color][o] = fmaxf(inval, oval);
         }
       }
       out++;
@@ -361,12 +575,102 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
     }
   }
 
+  float *restrict distance  = plane[HL_SEGMENT_PLANES];
+  float *restrict gradient  = plane[HL_SEGMENT_PLANES + 1];
+  float *restrict luminance = plane[HL_SEGMENT_PLANES + 2];
+  float *restrict recout    = plane[HL_SEGMENT_PLANES + 3];
+  float *restrict tmp       = plane[HL_SEGMENT_PLANES + 4];
+
+  const gboolean do_recovery = (recovery_mode != DT_RECOVERY_MODE_OFF) && has_allclipped && (strength > 0.0f);
+  if(do_recovery || (vmode != DT_SEGMENTS_MASK_OFF))
+  {
+    dt_segments_transform_closing(&isegments[3], seg_border);
+    dt_iop_image_fill(gradient, 0.0f, pwidth, pheight, 1);
+    dt_iop_image_fill(distance, 0.0f, pwidth, pheight, 1);
+#ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+  dt_omp_firstprivate(tmp, plane, distance, isegments, icoeffs) \
+  dt_omp_sharedconst(pheight, pwidth) \
+  schedule(static)
+#endif
+    for(size_t row = HL_BORDER + 1; row < pheight - HL_BORDER - 1; row++)
+    {
+      for(size_t col = HL_BORDER + 1; col < pwidth - HL_BORDER - 1; col++)
+      {
+        const size_t i = row * pwidth + col;
+        // prepare the temporary luminance for later blurring and also prefill the distance plane
+        tmp[i] = (plane[0][i] * icoeffs[0] + plane[1][i] * icoeffs[1] + plane[2][i] * icoeffs[2]) / 3.0f;
+        distance[i] = (isegments[3].data[i] == 1) ? DT_DISTANCE_TRANSFORM_MAX : 0.0f;
+      }
+    }
+    dt_masks_extend_border(tmp, pwidth, pheight, HL_BORDER);
+    dt_masks_blur_fast(tmp, luminance, pwidth, pheight, 1.2f, 1.0f, 20.0f);
+    dt_masks_extend_border(luminance, pwidth, pheight, HL_BORDER);
+  }
+
+  if(do_recovery)
+  {
+    const float max_distance = dt_image_distance_transform(NULL, distance, pwidth, pheight, 1.0f, DT_DISTANCE_TRANSFORM_NONE);
+    if(max_distance > 3.0f)
+    {
+      dt_segmentize_plane(&isegments[3]);
+      _initial_gradients(pwidth, pheight, luminance, distance, recout);
+      dt_masks_extend_border(recout, pwidth, pheight, HL_BORDER);
+
+      // now we check for significant all-clipped-segments and reconstruct data
+      for(int id = 2; id < isegments[3].nr+2; id++)
+      {
+        const float seg_dist = _segment_maxdistance(pwidth, pheight, distance, &isegments[3], id);
+        isegments[3].val1[id] = seg_dist;
+
+        if(isegments[3].val1[id] > 2.0f)
+          _segment_gradients(pwidth, pheight, distance, recout, tmp, recovery_mode, &isegments[3], id, seg_border);
+      }
+
+      dt_masks_blur_fast(recout, gradient, pwidth, pheight, 1.2f, 1.0f, 20.0f);
+      // possibly add some noise
+      const float noise_level = data->noise_level / fmaxf(piece->iscale / roi_in->scale, 1.0f);
+      if(noise_level > 0.0f)
+      {
+        for(int id = 2; id < isegments[3].nr+2; id++)
+        {
+          if(isegments[3].val1[id] > 3.0f)
+            _add_poisson_noise(pwidth, pheight, gradient, &isegments[3], id, noise_level);
+        }
+      }
+      const float dshift = 2.0f + (float)recovery_closing[recovery_mode];
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(clips, ivoid, ovoid, roi_in, roi_out, xtrans, gradient, distance) \
+  dt_omp_sharedconst(filters, pwidth, dshift, strength) \
+  schedule(static)
+#endif
+      for(int row = 1; row < roi_out->height-1; row++)
+      {
+        float *out = (float *)ovoid + (size_t)roi_out->width * row + 1;
+        float *in = (float *)ivoid + (size_t)roi_in->width * row + 1;
+        for(int col = 1; col < roi_out->width-1; col++)
+        {
+          const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
+          if(fmaxf(0.0f, in[0]) > clips[color])
+          {
+            const size_t o = _raw_to_plane(pwidth, row, col);
+            const float effect = strength / (1.0f + expf(-(distance[o] - dshift)));
+            out[0] += fmaxf(0.0f, gradient[o] * effect);
+          }
+          out++;
+          in++;
+        }
+      }
+    }
+  }
+
   if((vmode != DT_SEGMENTS_MASK_OFF) && fullpipe)
   {
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(clips, ivoid, ovoid, roi_in, roi_out, xtrans, isegments) \
-  dt_omp_sharedconst(filters, p_off, pwidth, vmode) \
+  dt_omp_firstprivate(clips, ivoid, ovoid, roi_in, roi_out, xtrans, isegments, gradient) \
+  dt_omp_sharedconst(filters, pwidth, vmode, strength) \
   schedule(static)
 #endif
     for(int row = 1; row < roi_out->height-1; row++)
@@ -376,7 +680,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
       for(int col = 1; col < roi_out->width-1; col++)
       {
         const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
-        const size_t ppos = p_off + (row/3) * pwidth + (col/3);
+        const size_t ppos = _raw_to_plane(pwidth, row, col);
 
         const int pid = _get_segment_id(&isegments[color], ppos);
         const gboolean iclipped = (in[0] >= clips[color]);
@@ -386,15 +690,17 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
         out[0] = 0.1f * in[0];
         if((vmode == DT_SEGMENTS_MASK_COMBINE) && isegment && !iclipped)        out[0] = 1.0f;
         else if((vmode == DT_SEGMENTS_MASK_CANDIDATING) && isegment && !badseg) out[0] = 1.0f;
-//        else if(vmode == DT_SEGMENTS_MASK_STRENGTH)                            out[o] += gradient[i];
+        else if(vmode == DT_SEGMENTS_MASK_STRENGTH)                             out[0] += gradient[ppos] * strength;
         out++;
         in++;
       }
     }
   }
 
-//  fprintf(stderr, "[segmentation report]%6.1fMpix, segments: %4i red, %4i green, %4i blue, %4i all.\n",
-//       (float) (roi_in->width * roi_in->height) / 1.0e6f, isegments[0].nr, isegments[1].nr, isegments[2].nr, isegments[3].nr);
+//  fprintf(stderr, "[segmentation report]%5.1fMpix, segments: %3i red, %3i green, %3i blue, %3i all.\n",
+//     (float) (roi_in->width * roi_in->height) / 1.0e6f, isegments[0].nr, isegments[1].nr, isegments[2].nr, isegments[3].nr);
+
+  finish:
 
   for(int i = 0; i < HL_SEGMENT_PLANES; i++)
     dt_segmentation_free_struct(&isegments[i]);

--- a/src/iop/hlrecovery_v2.c
+++ b/src/iop/hlrecovery_v2.c
@@ -1,0 +1,403 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2022 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+Segmentation based highlight reconstruction Version 2
+
+** Overview **
+
+V2 of the segmentation based highlight reconstruction algorithm works for bayer and xtrans sensors.
+It has been developed in collaboration by Iain and garagecoder from the gmic team and Hanno Schwalm from dt.
+
+The original idea was presented by Iain in pixls.us in: https://discuss.pixls.us/t/highlight-recovery-teaser/17670
+and has been extensively discussed over the last year, a number of different approaches have been evaluated.
+
+No other external modules (like gmic …) are used, the current code has been tuned for performance using omp,
+no OpenCL codepath yet.
+
+** Main ideas **
+
+The algorithm follows these basic ideas:
+1. We approximate each of the red, green and blue color channels from sensor data in a 3x3 photosite region.
+2. We analyse all data on the channels independently.
+3. We want to keep details as much as possible
+4. In all 3 color planes we look for isolated areas being clipped (segments).
+   These segments also include the unclipped photosites at the borders, we also use these locations for estimating the global chrominance.
+   Inside these segments we look for a candidate to represent the value we take for restoration.
+   Choosing the candidate is done at all non-clipped locations of a segment, the best candidate is selected via a weighing
+   function - the weight is derived from
+   - the local standard deviation in a 5x5 area and
+   - the median value of unclipped positions also in a 5x5 area.
+   The best candidate points to the location in the color plane holding the reference value.
+   If there is no good candidate we use an averaging approximation over the whole segment with correction of chrominance.
+5. A core principle is to inpaint pseudo-chromacity, calculated by subtracting opponent channel means rather than luminance.
+6. Cube root is used instead of logarithm for better stability, which suffices for an estimate.
+
+The chosen segmentation algorithm works like this:
+1. Doing the segmentation in every color plane.
+2. To combine small segments for a shared candidate we use a morphological closing operation, the radius of that UI op
+   can be chosen interactively between 0 and 8.
+3. The segmentation algorithm uses a modified floodfill, it also takes care of the surrounding rectangle of every segment
+   and marks the segment borders.
+4. After segmentation we check every segment for
+   - the segment's best candidate via the weighing function
+   - the candidates location
+*/
+
+/* Recovery algorithm
+  In areas with all planes clipped we try to reconstruct (hopefully a good guess) data based on the border gradients and the
+  segment's size - here we use a distance transformation.
+  What do we need to do so?
+  1. We need a "luminance" plane, we use Y0 for this.
+  2. We have an additional cmask holding information about all-channels-clipped
+  3. Based on the Y0 data and all-clipped info we prepare a gradient plane.
+  4. We also do a segmentation for the all-clipped data.
+
+  After this preparation steps we reconstruct data for every segment.
+  1. Calculate average gradients in an iterative loop for every distance value.
+     The new gradients calculation uses the distance and averaged gradients of the last iterative step.
+     By doing so we avoid direction problems.
+  2. Do a box-blur to suppress ridges, the radius depends on segment size.
+  3. Possibly add some noise.
+  4. Do a sigmoid correction supressing artefacts at the borders.
+     and write back data from this segment to the gradients plane
+
+  The UI offers
+  1. A drop down menu defining the recovery mode
+  2. strength slider - this also has a mask button
+  3. noise slider
+*/
+
+#define HL_RGB_PLANES 3
+#define HL_SEGMENT_PLANES 4
+#define HL_FLOAT_PLANES 8
+#define HL_BORDER 8
+
+#include "iop/segmentation.h"
+#include "common/distance_transform.h"
+
+static inline float _local_std_deviation(const float *p, const int w)
+{
+  const int w2 = 2*w;
+  const float av = 0.04f *
+      (p[-w2-2] + p[-w2-1] + p[-w2] + p[-w2+1] + p[-w2+2] +
+       p[-w-2]  + p[-w-1]  + p[-w]  + p[-w+1]  + p[-w+2] +
+       p[-2]    + p[-1]    + p[0]   + p[1]     + p[2] +
+       p[w-2]   + p[w-1]   + p[w]   + p[w+1]   + p[w+2] +
+       p[w2-2]  + p[w2-1]  + p[w2]  + p[w2+1]  + p[w2+2]);
+  return sqrtf(0.04f *
+      (sqf(p[-w2-2]-av) + sqf(p[-w2-1]-av) + sqf(p[-w2]-av) + sqf(p[-w2+1]-av) + sqf(p[-w2+2]-av) +
+       sqf(p[-w-2]-av)  + sqf(p[-w-1]-av)  + sqf(p[-w]-av)  + sqf(p[-w+1]-av)  + sqf(p[-w+2]-av) +
+       sqf(p[-2]-av)    + sqf(p[-1]-av)    + sqf(p[0]-av)   + sqf(p[1]-av)     + sqf(p[2]-av) +
+       sqf(p[w-2]-av)   + sqf(p[w-1]-av)   + sqf(p[w]-av)   + sqf(p[w+1]-av)   + sqf(p[w+2]-av) +
+       sqf(p[w2-2]-av)  + sqf(p[w2-1]-av)  + sqf(p[w2]-av)  + sqf(p[w2+1]-av)  + sqf(p[w2+2]-av)));
+}
+
+static float _calc_weight(const float *s, const size_t loc, const int w, const float clipval)
+{
+  const float smoothness = fmaxf(0.0f, 1.0f - 10.0f * powf(_local_std_deviation(&s[loc], w), 0.5f));
+  float val = 0.0f;
+  for(int y = -1; y < 2; y++)
+  {
+    for(int x = -1; x < 2; x++)
+      val += s[loc + y*w + x] * 0.11111f;
+  }
+  const float sval = fmaxf(1.0f, powf(fminf(clipval, val) / clipval, 2.0f));
+  return sval * smoothness;
+}
+
+static void _calc_plane_candidates(const float * restrict plane, const float * restrict refavg, dt_iop_segmentation_t *seg, const float clipval, const float badlevel)
+{
+#ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+  dt_omp_firstprivate(plane, refavg, seg) \
+  dt_omp_sharedconst(clipval, badlevel) \
+  schedule(dynamic)
+#endif
+  for(int id = 2; id < seg->nr + 2; id++)
+  {
+    seg->val1[id] = 0.0f;
+    seg->val2[id] = 0.0f;
+    seg->ref[id] = 0;
+    // avoid very small segments
+    if((seg->ymax[id] - seg->ymin[id] > 2) && (seg->xmax[id] - seg->xmin[id] > 2))
+    {
+      size_t testref = 0;
+      float testweight = 0.0f;
+      for(int row = seg->ymin[id] -2 ; row < seg->ymax[id] + 3; row++)
+      {
+        for(int col = seg->xmin[id] -2; col < seg->xmax[id] + 3; col++)
+        {
+          const size_t pos = row * seg->width + col;
+          const int sid = _get_segment_id(seg, pos);
+          if((sid == id) && (plane[pos] < clipval))
+          {
+            const float wht = _calc_weight(plane, pos, seg->width, clipval);
+            if(wht > testweight)
+            {
+              testweight = wht;
+              testref = pos;
+            }
+          }
+        }
+      }
+      if(testref && (testweight > 1.0f - badlevel)) // We have found a reference location
+      {
+        float sum  = 0.0f;
+        float pix = 0.0f;
+        const float weights[5][5] = {
+          { 1.0f,  4.0f,  6.0f,  4.0f, 1.0f },
+          { 4.0f, 16.0f, 24.0f, 16.0f, 4.0f },
+          { 6.0f, 24.0f, 36.0f, 24.0f, 6.0f },
+          { 4.0f, 16.0f, 24.0f, 16.0f, 4.0f },
+          { 1.0f,  4.0f,  6.0f,  4.0f, 1.0f }};
+        for(int y = -2; y < 3; y++)
+        {
+          for(int x = -2; x < 3; x++)
+          {
+            const size_t pos = testref + y*seg->width + x;
+            const gboolean unclipped = plane[pos] < clipval;
+            sum += (unclipped) ? plane[pos] * weights[y+2][x+2] : 0.0f;
+            pix += (unclipped) ? weights[y+2][x+2] : 0.0f;
+          }
+        }
+        const float av = sum / fmaxf(1.0f, pix);
+        if(av > 0.25f * clipval)
+        {
+          seg->val1[id] = fminf(clipval, sum / fmaxf(1.0f, pix));
+          seg->val2[id] = refavg[testref];
+          seg->ref[id] = testref;
+        }
+      }
+    }
+  }
+}
+
+static inline float _calc_refavg(const float *in, const uint8_t(*const xtrans)[6], const uint32_t filters, const int row, const int col, const dt_iop_roi_t *const roi, const gboolean linear)
+{
+  const int color = (filters == 9u) ? FCxtrans(row, col, roi, xtrans) : FC(row, col, filters);
+  dt_aligned_pixel_t mean = { 0.0f, 0.0f, 0.0f };
+  dt_aligned_pixel_t cnt = { 0.0f, 0.0f, 0.0f };
+  for(int dy = -1; dy < 2; dy++)
+  {
+    for(int dx = -1; dx < 2; dx++)
+    {
+      const float val = in[(ssize_t)dy * roi->width + dx];
+      const int c = (filters == 9u) ? FCxtrans(row + dy, col + dx, roi, xtrans) : FC(row + dy, col + dx, filters);
+      mean[c] += val;
+      cnt[c] += 1.0f;
+    }
+  }
+  for(int c = 0; c < 3; c++) mean[c] = powf(mean[c] / cnt[c], 1.0f / 3.0f);
+
+  const dt_aligned_pixel_t croot_refavg = { 0.5f * (mean[1] + mean[2]), 0.5f * (mean[0] + mean[2]), 0.5f * (mean[0] + mean[1])};
+  return (linear) ? powf(croot_refavg[color], 3.0f) : croot_refavg[color];
+}
+
+static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+                         const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
+                         dt_iop_highlights_data_t *data, const int vmode)
+{
+  const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
+  const uint32_t filters = piece->pipe->dsc.filters;
+
+  const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
+
+  const float clipval = fmaxf(0.1f, 0.987f * data->clip);
+  const dt_aligned_pixel_t icoeffs = { piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1], piece->pipe->dsc.temperature.coeffs[2]};
+  const dt_aligned_pixel_t clips = { clipval * icoeffs[0], clipval * icoeffs[1], clipval * icoeffs[2]}; 
+  const dt_aligned_pixel_t cube_coeffs = { powf(clips[0], 1.0f / 3.0f), powf(clips[1], 1.0f / 3.0f), powf(clips[2], 1.0f / 3.0f)};
+
+  const int combining = (int) data->combine;
+
+  const int pwidth  = dt_round_size(roi_in->width / 3, 2) + 2 * HL_BORDER;
+  const int pheight = dt_round_size(roi_in->height / 3, 2) + 2 * HL_BORDER;
+  const size_t p_size = dt_round_size((size_t) (pwidth + 4) * (pheight + 4), 16);
+  const size_t p_off  = (HL_BORDER * pwidth) + HL_BORDER;
+
+  float *fbuffer = dt_alloc_align_float((HL_FLOAT_PLANES) * p_size);
+  if(!fbuffer) return;
+
+  float *plane[HL_FLOAT_PLANES];
+  for(int i = 0; i < HL_FLOAT_PLANES; i++)
+    plane[i] = fbuffer + i * p_size;
+
+  float *refavg[HL_RGB_PLANES];
+  for(int i = 0; i < HL_RGB_PLANES; i++)
+    refavg[i] = plane[HL_SEGMENT_PLANES + i];
+
+  dt_iop_segmentation_t isegments[HL_SEGMENT_PLANES];
+
+  const int segmentation_limit = roi_out->width * roi_out->height / 4000; // segments per mpix
+
+  for(int i = 0; i < HL_SEGMENT_PLANES; i++)
+    dt_segmentation_init_struct(&isegments[i], pwidth, pheight, HL_BORDER, segmentation_limit);
+
+#ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(ivoid, ovoid, roi_in, roi_out, plane, isegments, cube_coeffs, refavg, xtrans) \
+  dt_omp_sharedconst(p_off, pwidth, filters) \
+  schedule(static)
+#endif
+  for(size_t row = 1; row < roi_out->height-1; row++)
+  {
+    float *out = (float *)ovoid + (size_t)roi_out->width * row + 1;
+    float *in = (float *)ivoid + (size_t)roi_in->width * row + 1;
+    for(size_t col = 1; col < roi_out->width-1; col++)
+    {
+      // calc all color planes for the centre of a 3x3 area
+      if((col % 3 == 1) && (row % 3 == 1))
+      {
+        dt_aligned_pixel_t mean = { 0.0f, 0.0f, 0.0f };
+        dt_aligned_pixel_t cnt = { 0.0f, 0.0f, 0.0f };
+        for(int dy = -1; dy < 2; dy++)
+        {
+          for(int dx = -1; dx < 2; dx++)
+          {
+            const float val = in[(ssize_t)dy * roi_in->width + dx];
+            const int c = (filters == 9u) ? FCxtrans(row + dy, col + dx, roi_in, xtrans) : FC(row + dy, col + dx, filters);
+            mean[c] += val;
+            cnt[c] += 1.0f;
+          }
+        }
+
+        for(int c = 0; c < 3; c++) mean[c] = powf(mean[c] / cnt[c], 1.0f / 3.0f);
+        const dt_aligned_pixel_t cube_refavg = { 0.5f * (mean[1] + mean[2]), 0.5f * (mean[0] + mean[2]), 0.5f * (mean[0] + mean[1])};
+
+        const size_t o = p_off + (row/3) * pwidth + (col/3);
+        int allclipped = 0;
+        for(int c = 0; c < 3; c++)
+        {
+          plane[c][o] = mean[c];
+          refavg[c][o] = cube_refavg[c];
+          if(mean[c] > cube_coeffs[c])
+          { 
+            allclipped += 1;
+            isegments[c].data[o] = 1;
+          }
+        }
+        isegments[3].data[o] = (allclipped == 3) ? 1 : 0;
+      }
+      out++;
+      in++;
+    }
+  }
+
+  for(int i = 0; i < HL_RGB_PLANES; i++)
+    dt_masks_extend_border(plane[i], pwidth, pheight, HL_BORDER);
+
+  for(int p = 0; p < HL_RGB_PLANES; p++)
+  {
+    // We prefer to have slightly wider segment borders for a possibly better chosen candidate
+    if(combining > 0)
+    {
+      dt_segments_transform_dilate(&isegments[p], combining);
+      if(combining > 1)
+        dt_segments_transform_erode(&isegments[p], combining-1);
+    }
+  }
+  if(dt_get_num_threads() >= HL_RGB_PLANES)
+  {
+#ifdef _OPENMP
+  #pragma omp parallel num_threads(HL_RGB_PLANES)
+#endif
+    {
+      dt_segmentize_plane(&isegments[dt_get_thread_num()]);
+    }
+  }
+  else
+  {
+    for(int p = 0; p < HL_RGB_PLANES; p++)
+      dt_segmentize_plane(&isegments[p]);
+  }
+
+  for(int p = 0; p < HL_RGB_PLANES; p++)
+    _calc_plane_candidates(plane[p], refavg[p], &isegments[p], cube_coeffs[p], data->candidating);
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(clips, ivoid, ovoid, roi_in, roi_out, xtrans, isegments) \
+  dt_omp_sharedconst(filters, p_off, pwidth) \
+  schedule(static)
+#endif
+  for(int row = 1; row < roi_out->height-1; row++)
+  {
+    float *out = (float *)ovoid + (size_t)roi_out->width * row + 1;
+    float *in = (float *)ivoid + (size_t)roi_in->width * row + 1;
+    for(int col = 1; col < roi_out->width-1; col++)
+    {
+      const float inval = fmaxf(0.0f, in[0]);
+      const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
+      if(inval > clips[color])
+      {
+        const size_t o = p_off + (row/3) * pwidth + (col/3);
+        const int pid = _get_segment_id(&isegments[color], o);
+        const float candidate = isegments[color].val1[pid];
+        if((pid > 1) && (pid < isegments[color].nr+2) && (candidate != 0.0f))
+        {
+          const float cand_reference = isegments[color].val2[pid];
+          const float refavg_here = _calc_refavg(&in[0], xtrans, filters, row, col, roi_in, FALSE);
+          const float oval = powf(refavg_here + candidate - cand_reference, 3.0f);
+          out[0] = fmaxf(inval, oval);
+        }
+      }
+      out++;
+      in++;
+    }
+  }
+
+  if((vmode != DT_SEGMENTS_MASK_OFF) && fullpipe)
+  {
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(clips, ivoid, ovoid, roi_in, roi_out, xtrans, isegments) \
+  dt_omp_sharedconst(filters, p_off, pwidth, vmode) \
+  schedule(static)
+#endif
+    for(int row = 1; row < roi_out->height-1; row++)
+    {
+      float *out = (float *)ovoid + (size_t)roi_out->width * row + 1;
+      float *in = (float *)ivoid + (size_t)roi_in->width * row + 1;
+      for(int col = 1; col < roi_out->width-1; col++)
+      {
+        const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
+        const size_t ppos = p_off + (row/3) * pwidth + (col/3);
+
+        const int pid = _get_segment_id(&isegments[color], ppos);
+        const gboolean iclipped = (in[0] >= clips[color]);
+        const gboolean isegment = ((pid > 1) && (pid <= isegments[color].nr));
+        const gboolean badseg = isegment && (isegments[color].ref[pid] == 0);
+
+        out[0] = 0.1f * in[0];
+        if((vmode == DT_SEGMENTS_MASK_COMBINE) && isegment && !iclipped)        out[0] = 1.0f;
+        else if((vmode == DT_SEGMENTS_MASK_CANDIDATING) && isegment && !badseg) out[0] = 1.0f;
+//        else if(vmode == DT_SEGMENTS_MASK_STRENGTH)                            out[o] += gradient[i];
+        out++;
+        in++;
+      }
+    }
+  }
+
+//  fprintf(stderr, "[segmentation report]%6.1fMpix, segments: %4i red, %4i green, %4i blue, %4i all.\n",
+//       (float) (roi_in->width * roi_in->height) / 1.0e6f, isegments[0].nr, isegments[1].nr, isegments[2].nr, isegments[3].nr);
+
+  for(int i = 0; i < HL_SEGMENT_PLANES; i++)
+    dt_segmentation_free_struct(&isegments[i]);
+  dt_free_align(fbuffer);
+}
+

--- a/src/iop/hlrecovery_v2.c
+++ b/src/iop/hlrecovery_v2.c
@@ -177,7 +177,7 @@ static void _calc_plane_candidates(const float *plane, const float *refavg, dt_i
           }
         }
         const float av = sum / fmaxf(1.0f, pix);
-        if(av > 0.25f * clipval)
+        if(av > 0.125f * clipval)
         {
           seg->val1[id] = fminf(clipval, sum / fmaxf(1.0f, pix));
           seg->val2[id] = refavg[testref];
@@ -197,7 +197,7 @@ static inline float _calc_refavg(const float *in, const uint8_t(*const xtrans)[6
   {
     for(int dx = -1; dx < 2; dx++)
     {
-      const float val = in[(ssize_t)dy * roi->width + dx];
+      const float val = fmaxf(0.0f, in[(ssize_t)dy * roi->width + dx]);
       const int c = (filters == 9u) ? FCxtrans(row + dy, col + dx, roi, xtrans) : FC(row + dy, col + dx, filters);
       mean[c] += val;
       cnt[c] += 1.0f;
@@ -688,10 +688,10 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
           const int pid = _get_segment_id(&isegments[color], ppos);
           const gboolean iclipped = (in[0] >= clips[color]);
           const gboolean isegment = ((pid > 1) && (pid <= isegments[color].nr));
-          const gboolean badseg = isegment && (isegments[color].val1[pid] != 0.0f);
+          const gboolean goodseg = isegment && (isegments[color].val1[pid] != 0.0f);
 
           if((vmode == DT_SEGMENTS_MASK_COMBINE) && isegment && !iclipped)        out[0] = 1.0f;
-          else if((vmode == DT_SEGMENTS_MASK_CANDIDATING) && isegment && !badseg) out[0] = 1.0f;
+          else if((vmode == DT_SEGMENTS_MASK_CANDIDATING) && isegment && goodseg) out[0] = 1.0f;
           else if(vmode == DT_SEGMENTS_MASK_STRENGTH)                             out[0] += gradient[ppos] * strength;
         }
         out++;

--- a/src/iop/hlrecovery_v2.c
+++ b/src/iop/hlrecovery_v2.c
@@ -248,7 +248,7 @@ static float _segment_maxdistance(const int width, const int height, float *dist
   float max_distance = 0.0f;
 
 #ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
+  #pragma omp parallel for default(none) \
   reduction(max : max_distance) \
   dt_omp_firstprivate(distance, seg) \
   dt_omp_sharedconst(width, xmin, xmax, ymin, ymax, id) \
@@ -458,7 +458,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
 
   gboolean has_allclipped = FALSE;
 #ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
+  #pragma omp parallel for default(none) \
   reduction( | : has_allclipped) \
   dt_omp_firstprivate(ivoid, ovoid, roi_in, roi_out, plane, isegments, cube_coeffs, refavg, xtrans) \
   dt_omp_sharedconst(pwidth, filters) \
@@ -603,9 +603,9 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
         distance[i] = (isegments[3].data[i] == 1) ? DT_DISTANCE_TRANSFORM_MAX : 0.0f;
       }
     }
-    dt_masks_extend_border(tmp, pwidth, pheight, HL_BORDER);
+    dt_masks_extend_border(tmp, pwidth, pheight, HL_BORDER+1);
     dt_masks_blur_fast(tmp, luminance, pwidth, pheight, 1.2f, 1.0f, 20.0f);
-    dt_masks_extend_border(luminance, pwidth, pheight, HL_BORDER);
+    dt_masks_extend_border(luminance, pwidth, pheight, HL_BORDER+1);
   }
 
   if(do_recovery)
@@ -615,7 +615,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
     {
       dt_segmentize_plane(&isegments[3]);
       _initial_gradients(pwidth, pheight, luminance, distance, recout);
-      dt_masks_extend_border(recout, pwidth, pheight, HL_BORDER);
+      dt_masks_extend_border(recout, pwidth, pheight, HL_BORDER+1);
 
       // now we check for significant all-clipped-segments and reconstruct data
       for(int id = 2; id < isegments[3].nr+2; id++)

--- a/src/iop/segmentation.h
+++ b/src/iop/segmentation.h
@@ -191,10 +191,10 @@ static inline int _test_dilate(const int *img, const size_t i, const size_t w1, 
 static inline void _dilating(const int *img, int *o, const int w1, const int height, const int border, const int radius)
 {
 #ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
+  #pragma omp parallel for default(none) \
   dt_omp_firstprivate(img, o) \
   dt_omp_sharedconst(height, w1, border, radius) \
-  schedule(static) aligned(o, img : 64)
+  schedule(static)
 #endif
   for(size_t row = border; row < height - border; row++)
   {
@@ -315,10 +315,10 @@ static inline int _test_erode(const int *img, const size_t i, const size_t w1, c
 static inline void _eroding(const int *img, int *o, const int w1, const int height, const int border, const int radius)
 {
 #ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
+  #pragma omp parallel for default(none) \
   dt_omp_firstprivate(img, o) \
   dt_omp_sharedconst(height, w1, border, radius) \
-  schedule(static) aligned(o, img : 64)
+  schedule(static)
 #endif
   for(size_t row = border; row < height - border; row++)
   {


### PR DESCRIPTION
The second version of the segmentation based highlights reconstruction supports xtrans sensors.

A few design changes made this possible although the main algorithms works exactly the same.

1. The segments inpainting works as a post-processing step after opposed means, only segments selected via candidating and combine are inpainted now. This leads to a reduction of code complexity.
2. We don't use corresponding photosites of the sensor any more but use red, green and blue planes instead. The data are calculated as in opposed means via 3x3 areas. This results in fewer and smaller planes to be analysed leading to a twofold performance gain without any loss of quality.
3. The new way of calculating the planes also results in a vastly increased stability when selecting the clip threshold allowing further reduction of code complexity.
4. Some code cleanup & refactoring

Please note: First commit yet misses the fancy stuff like recovery in all-clipped-areas and noise but segmentation code is ready.