### PR TITLE
show image count in filter toolbox instead of hinter

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -2415,15 +2415,16 @@ void dt_collection_update_query(const dt_collection_t *collection, dt_collection
 
 gboolean dt_collection_hint_message_internal(void *message)
 {
-  dt_control_hinter_message(darktable.control,
-    dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_CENTER_TOP) ? "" : message);
-
   GtkWidget *count = dt_view_filter_get_count(darktable.view_manager);
   if(count)
   {
-    gtk_label_set_text(GTK_LABEL(count), message);
-    gtk_widget_set_tooltip_text(count, message);
+    gtk_label_set_markup(GTK_LABEL(count), message);
+    gtk_widget_set_tooltip_markup(count, message);
   }
+
+  message = dt_util_dstrcat(message, _(" in current collection"));
+  dt_control_hinter_message(darktable.control,
+    dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_CENTER_TOP) ? "" : message);
 
   g_free(message);
   return FALSE;
@@ -2450,14 +2451,14 @@ void dt_collection_hint_message(const dt_collection_t *collection)
       selected++;
     }
     g_list_free(selected_imgids);
-    message = g_strdup_printf(_("%d image of %d (#%d) in current collection is selected"), cs, c, selected);
+    message = g_strdup_printf(_("<b>%d</b> image (#<b>%d</b>) selected of <b>%d</b>"), cs, selected, c);
   }
   else
   {
     message = g_strdup_printf(
       ngettext(
-        "%d image of %d in current collection is selected",
-        "%d images of %d in current collection are selected",
+        "<b>%d</b> image selected of <b>%d</b>",
+        "<b>%d</b> images selected of <b>%d</b>",
         cs),
       cs, c);
   }

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -2415,7 +2415,16 @@ void dt_collection_update_query(const dt_collection_t *collection, dt_collection
 
 gboolean dt_collection_hint_message_internal(void *message)
 {
-  dt_control_hinter_message(darktable.control, message);
+  dt_control_hinter_message(darktable.control,
+    dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_CENTER_TOP) ? "" : message);
+
+  GtkWidget *count = dt_view_filter_get_count(darktable.view_manager);
+  if(count)
+  {
+    gtk_label_set_text(GTK_LABEL(count), message);
+    gtk_widget_set_tooltip_text(count, message);
+  }
+
   g_free(message);
   return FALSE;
 }

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1594,6 +1594,7 @@ void dt_ui_container_add_widget(dt_ui_t *ui, const dt_ui_container_t c, GtkWidge
 
     /* if box is center we want it to fill as much as it can */
     case DT_UI_CONTAINER_PANEL_TOP_CENTER:
+    case DT_UI_CONTAINER_PANEL_CENTER_TOP_LEFT:
     case DT_UI_CONTAINER_PANEL_CENTER_TOP_CENTER:
     case DT_UI_CONTAINER_PANEL_CENTER_BOTTOM_CENTER:
     case DT_UI_CONTAINER_PANEL_BOTTOM:
@@ -2274,7 +2275,7 @@ static void _ui_init_panel_center_top(dt_ui_t *ui, GtkWidget *container)
 
   /* add container for center top left */
   ui->containers[DT_UI_CONTAINER_PANEL_CENTER_TOP_LEFT] = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_box_pack_start(GTK_BOX(widget), ui->containers[DT_UI_CONTAINER_PANEL_CENTER_TOP_LEFT], FALSE, FALSE,
+  gtk_box_pack_start(GTK_BOX(widget), ui->containers[DT_UI_CONTAINER_PANEL_CENTER_TOP_LEFT], TRUE, TRUE,
                      DT_UI_PANEL_MODULE_SPACING);
 
   /* add container for center top center */

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -34,6 +34,7 @@ typedef struct dt_lib_tool_filter_t
 {
   GtkWidget *filter_box;
   GtkWidget *sort_box;
+  GtkWidget *count;
 } dt_lib_tool_filter_t;
 
 const char *name(dt_lib_module_t *self)
@@ -79,6 +80,12 @@ static GtkWidget *_lib_filter_get_sort_box(dt_lib_module_t *self)
   return d->sort_box;
 }
 
+static GtkWidget *_lib_filter_get_count(dt_lib_module_t *self)
+{
+  dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
+  return d->count;
+}
+
 void gui_init(dt_lib_module_t *self)
 {
   /* initialize ui widgets */
@@ -86,24 +93,29 @@ void gui_init(dt_lib_module_t *self)
   self->data = (void *)d;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_widget_set_halign(self->widget, GTK_ALIGN_START);
   gtk_widget_set_valign(self->widget, GTK_ALIGN_CENTER);
 
   d->filter_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_widget_set_name(d->filter_box, "header-rule-box");
-  gtk_box_pack_start(GTK_BOX(self->widget), d->filter_box, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), d->filter_box, FALSE, FALSE, 0);
 
   /* sort combobox */
   d->sort_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_widget_set_name(d->sort_box, "header-sort-box");
-  gtk_box_pack_start(GTK_BOX(self->widget), d->sort_box, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), d->sort_box, FALSE, FALSE, 0);
   GtkWidget *label = gtk_label_new(_("sort by"));
   gtk_box_pack_start(GTK_BOX(d->sort_box), label, TRUE, TRUE, 0);
+
+  /* label to display selected count */
+  d->count = gtk_label_new(_("count selected"));
+  gtk_label_set_ellipsize(GTK_LABEL(d->count), PANGO_ELLIPSIZE_END);
+  gtk_box_pack_start(GTK_BOX(self->widget), d->count, TRUE, FALSE, 0);
 
   /* initialize proxy */
   darktable.view_manager->proxy.filter.module = self;
   darktable.view_manager->proxy.filter.get_filter_box = _lib_filter_get_filter_box;
   darktable.view_manager->proxy.filter.get_sort_box = _lib_filter_get_sort_box;
+  darktable.view_manager->proxy.filter.get_count = _lib_filter_get_count;
 
   // test if the filtering module is already load and update its gui in this case
   // otherwise filtering module will do it in its gui_init()

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -107,8 +107,8 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(d->sort_box), label, TRUE, TRUE, 0);
 
   /* label to display selected count */
-  d->count = gtk_label_new(_("count selected"));
-  gtk_label_set_ellipsize(GTK_LABEL(d->count), PANGO_ELLIPSIZE_END);
+  d->count = gtk_label_new("");
+  gtk_label_set_ellipsize(GTK_LABEL(d->count), PANGO_ELLIPSIZE_MIDDLE);
   gtk_box_pack_start(GTK_BOX(self->widget), d->count, TRUE, FALSE, 0);
 
   /* initialize proxy */

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -951,6 +951,13 @@ GtkWidget *dt_view_filter_get_sort_box(const dt_view_manager_t *vm)
   return NULL;
 }
 
+GtkWidget *dt_view_filter_get_count(const dt_view_manager_t *vm)
+{
+  if(vm->proxy.filter.module && vm->proxy.filter.get_count)
+    return vm->proxy.filter.get_count(vm->proxy.filter.module);
+  return NULL;
+}
+
 void dt_view_active_images_reset(gboolean raise)
 {
   if(!darktable.view_manager->active_images) return;

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -257,6 +257,7 @@ typedef struct dt_view_manager_t
       struct dt_lib_module_t *module;
       GtkWidget *(*get_filter_box)(struct dt_lib_module_t *);
       GtkWidget *(*get_sort_box)(struct dt_lib_module_t *);
+      GtkWidget *(*get_count)(struct dt_lib_module_t *);
     } filter;
 
     /* module collection proxy object */
@@ -425,6 +426,7 @@ void dt_view_collection_update_history_state(const dt_view_manager_t *vm);
 void dt_view_filtering_reset(const dt_view_manager_t *vm, gboolean smart_filter);
 GtkWidget *dt_view_filter_get_filters_box(const dt_view_manager_t *vm);
 GtkWidget *dt_view_filter_get_sort_box(const dt_view_manager_t *vm);
+GtkWidget *dt_view_filter_get_count(const dt_view_manager_t *vm);
 
 // active images functions
 void dt_view_active_images_reset(gboolean raise);


### PR DESCRIPTION
fixes #10518

![image](https://user-images.githubusercontent.com/1549490/195136376-3a424496-1d05-4dfd-ae64-e7ab261876a4.png)
![image](https://user-images.githubusercontent.com/1549490/195136679-24c33789-b6ac-4500-a081-008cc017336e.png)

This allows the "hinter" to be hidden once one is comfortable enough with the mask/module controls to not need the reminder (which can also quickly be pulled up with "h").

Aside: the label widget in the filter toolbox that is used to display the selection is exposed using the same kind of proxy getter functions as the filter and sort box for consistency. I am not convinced there is much value in jumping through various levels of indirection to in the end expose very specific widgets in very specific modules, thereby completely breaking encapsulation anyway. As far as I'm concerned, just exposing the widget pointers directly, or even the module->data struct pointer and definition if that only contains 3 pointers, does not reduce any maintainability and in fact makes things more transparent. If any of the proxy interfaces are, at a later stage, more generically applicable (i.e. more than one module could use them) it could be refactored at that point. The complexity of the interface would then provide some indication of how widely used it might be, which at the moment is does not at all.