### PR TITLE
Further work on highlights reconstruction 

### DIFF
--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -2270,7 +2270,10 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
   // Sanitize mode if wrongfully copied as part of the history of another pic
   if((!bayer && (mode == DT_IOP_HIGHLIGHTS_LAPLACIAN))
-    || (linear_raw && (mode == DT_IOP_HIGHLIGHTS_LCH || mode == DT_IOP_HIGHLIGHTS_INPAINT)))
+    || (linear_raw && (mode == DT_IOP_HIGHLIGHTS_LCH
+        || mode == DT_IOP_HIGHLIGHTS_INPAINT
+        || mode == DT_IOP_HIGHLIGHTS_LAPLACIAN
+        || mode == DT_IOP_HIGHLIGHTS_SEGMENTS)))
   {
     p->mode = DT_IOP_HIGHLIGHTS_OPPOSED;
     dt_bauhaus_combobox_set_from_value(g->mode, p->mode);

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -2272,7 +2272,6 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   if((!bayer && (mode == DT_IOP_HIGHLIGHTS_LAPLACIAN))
     || (linear_raw && (mode == DT_IOP_HIGHLIGHTS_LCH
         || mode == DT_IOP_HIGHLIGHTS_INPAINT
-        || mode == DT_IOP_HIGHLIGHTS_LAPLACIAN
         || mode == DT_IOP_HIGHLIGHTS_SEGMENTS)))
   {
     p->mode = DT_IOP_HIGHLIGHTS_OPPOSED;

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -71,12 +71,12 @@ static float highlights_clip_magics[6] = { 1.0f, 1.0f, 0.987f, 0.995f, 0.987f, 0
 
 typedef enum dt_iop_highlights_mode_t
 {
-  DT_IOP_HIGHLIGHTS_OPPOSED = 5,  // $DESCRIPTION: "inpaint opposed"
   DT_IOP_HIGHLIGHTS_CLIP = 0,    // $DESCRIPTION: "clip highlights"
   DT_IOP_HIGHLIGHTS_LCH = 1,     // $DESCRIPTION: "reconstruct in LCh"
   DT_IOP_HIGHLIGHTS_INPAINT = 2, // $DESCRIPTION: "reconstruct color"
   DT_IOP_HIGHLIGHTS_LAPLACIAN = 3, //$DESCRIPTION: "guided laplacians"
   DT_IOP_HIGHLIGHTS_SEGMENTS = 4, // $DESCRIPTION: "segmentation based"
+  DT_IOP_HIGHLIGHTS_OPPOSED = 5,  // $DESCRIPTION: "inpaint opposed"
 } dt_iop_highlights_mode_t;
 
 typedef enum dt_atrous_wavelets_scales_t
@@ -2323,8 +2323,11 @@ void reload_defaults(dt_iop_module_t *module)
     // rebuild the complete menu depending on sensor type and possibly active but obsolete mode
     const uint32_t filters = module->dev->image_storage.buf_dsc.filters;
     const int menu_size = dt_bauhaus_combobox_length(g->mode);
-    for(int i = 0; i < menu_size - 1; i++)
-      dt_bauhaus_combobox_remove_at(g->mode, 1);
+    for(int i = 0; i < menu_size; i++)
+      dt_bauhaus_combobox_remove_at(g->mode, 0);
+
+    dt_bauhaus_combobox_add_full(g->mode, _("inpaint opposed"), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,
+                                      GINT_TO_POINTER(DT_IOP_HIGHLIGHTS_OPPOSED), NULL, TRUE);
 
     if(filters == 0)
       dt_bauhaus_combobox_add_full(g->mode, _("clip highlights"), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -2023,7 +2023,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       = data->clip * fminf(piece->pipe->dsc.processed_maximum[0],
                            fminf(piece->pipe->dsc.processed_maximum[1], piece->pipe->dsc.processed_maximum[2]));
 
-  if(!filters)
+  if((filters == 0) && (data->mode == DT_IOP_HIGHLIGHTS_CLIP))
   {
     process_clip(piece, ivoid, ovoid, roi_in, roi_out, clip);
     for(int k=0;k<3;k++)
@@ -2121,7 +2121,10 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
     case DT_IOP_HIGHLIGHTS_OPPOSED:
     {
-      _process_opposed(piece, ivoid, ovoid, roi_in, roi_out, data);
+      if(filters == 0)
+        _process_linear_opposed(piece, ivoid, ovoid, roi_in, roi_out, data);
+      else
+        _process_opposed(piece, ivoid, ovoid, roi_in, roi_out, data);
       break;
     }
 

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -16,24 +16,158 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/* The refavg value are calculated in raw-RGB-cube3 space
-   We calculate all color channels in the 3x3 photosite area, the "asking" location is in the centre.
-   As this should work for bayer and xtrans sensors we don't have a fixed ratio but calculate the average
+/* The refavg values are calculated in raw-RGB-cube3 space
+   We calculate all color channels in the 3x3 photosite area, this can be understaood as a "superpixel",
+   the "asking" location is in the centre.
+   As this works for bayer and xtrans sensors we don't have a fixed ratio but calculate the average
    for every color channel first.
-   refavg is defined as means of opposing color channels.
+   refavg for one of red, green or blue is defined as means of both other color channels (opposing).
    
    The basic idea / observation for the _process_opposed algorithm is, the refavg is a good estimate
    for any clipped color channel in the vast majority of images, working mostly fine both for small specular
    highlighted spots and large areas.
    
    The correction via some sort of global chrominance further helps to correct color casts.
-   Remaining casts are in most cases related to
+   The chrominace data are taken from the areas morphologically very close to clipped data.
+   Failures of the algorithm (color casts) are in most cases related to
     a) very large differences between optimal white balance coefficients vs what we have as D65 in the darktable pipeline
     b) complicated lightings so the gradients are not well related
     c) a wrong whitepoint setting in the rawprepare module. 
-   
-   Again the algorithms has been developed in collaboration by @garagecoder and @Iain from gmic team an @jenshannoschwalm from dt.
+    d) the maths might not be best
+
+   Again the algorithms has been developed in collaboration by @garagecoder and @Iain from gmic team and @jenshannoschwalm from dt.
 */
+
+static inline float _calc_linear_refavg(const float *in, const int row, const int col, const dt_iop_roi_t *const roi, const int color)
+{
+  dt_aligned_pixel_t mean = { 0.0f, 0.0f, 0.0f };
+  for(int dy = -1; dy < 2; dy++)
+  {
+    for(int dx = -1; dx < 2; dx++)
+    {
+      for(int c = 0; c < 3; c++)
+        mean[c] += fmaxf(0.0f, in[roi->width * 4 * dy + 4 * dx + c]);
+    }
+  }
+  for(int c = 0; c < 3; c++)
+    mean[c] = powf(mean[c] / 9.0f, 1.0f / 3.0f);
+
+  const dt_aligned_pixel_t croot_refavg = { 0.5f * (mean[1] + mean[2]), 0.5f * (mean[0] + mean[2]), 0.5f * (mean[0] + mean[1])};
+  return powf(croot_refavg[color], 3.0f);
+}
+
+// A slighly modified version for sraws
+static void _process_linear_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+                         const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
+                         dt_iop_highlights_data_t *data)
+{
+  const float clipval = 0.987f * data->clip;
+  const dt_aligned_pixel_t icoeffs = { piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1], piece->pipe->dsc.temperature.coeffs[2]};
+  const dt_aligned_pixel_t clips = { clipval * icoeffs[0], clipval * icoeffs[1], clipval * icoeffs[2]}; 
+  const dt_aligned_pixel_t clipdark = { 0.03f * clips[0], 0.125f * clips[1], 0.03f * clips[2] };   
+
+  const int pwidth  = dt_round_size(roi_in->width / 3, 2) + 2 * HL_BORDER;
+  const int pheight = dt_round_size(roi_in->height / 3, 2) + 2 * HL_BORDER;
+  const size_t p_size = (size_t) dt_round_size(pwidth * pheight, 16);
+
+  int *mask_buffer = dt_calloc_align(64, 4 * p_size * sizeof(int));
+
+  gboolean anyclipped = FALSE;
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  reduction( | : anyclipped) \
+  dt_omp_firstprivate(clips, ivoid, ovoid, roi_in, roi_out, mask_buffer) \
+  dt_omp_sharedconst(p_size, pwidth, pheight) \
+  schedule(static)
+#endif
+  for(int row = 0; row < roi_out->height; row++)
+  {
+    float *out = (float *)ovoid + (size_t)roi_out->width * row * 4;
+    float *in = (float *)ivoid + (size_t)roi_in->width * row * 4;
+    for(int col = 0; col < roi_out->width; col++)
+    {
+      for(int c = 0; c < 4; c++) out[c] = fmaxf(0.0f, in[c]);
+      if((col > 0) && (col < roi_out->width - 1) && (row > 0) && (row < roi_out->height - 1))
+      {
+        for(int c = 0; c < 3; c++)
+        {
+          if(out[c] >= clips[c])
+          {
+            out[c] = _calc_linear_refavg(&in[0], row, col, roi_in, c);
+            mask_buffer[c * p_size + _raw_to_plane(pwidth, row, col)] |= 1;
+            anyclipped |= TRUE;
+          }
+        }
+      }
+      out += 4;
+      in += 4;
+    }
+  }
+
+  if(!anyclipped) goto finish;
+
+  for(size_t i = 0; i < 3; i++)
+  {
+    int *mask = mask_buffer + i * p_size;
+    int *tmp = mask_buffer + 3 * p_size;
+    _intimage_borderfill(mask, pwidth, pheight, 0, HL_BORDER);
+    _dilating(mask, tmp, pwidth, pheight, HL_BORDER, 3);
+    memcpy(mask, tmp, p_size * sizeof(int));
+  }
+
+  double cr_sum[3] = {0.0f, 0.0f, 0.0f};
+  double cr_cnt[3] = {0.0f, 0.0f, 0.0f};
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(ivoid, roi_in, clips, clipdark, mask_buffer) \
+  reduction(+ : cr_sum, cr_cnt) \
+  dt_omp_sharedconst(p_size, pwidth) \
+  schedule(static)
+#endif
+  for(int row = 1; row < roi_in->height-1; row++)
+  {
+    float *in  = (float *)ivoid + (size_t)roi_in->width * row * 4 + 4;
+    for(int col = 1; col < roi_in->width-1; col++)
+    {
+      for(int c = 0; c < 3; c++)
+      {
+        const float inval = fmaxf(0.0f, in[c]); 
+        if((mask_buffer[c * p_size + _raw_to_plane(pwidth, row, col)]) && (inval > clipdark[c]) && (inval < clips[c]))
+        {
+          cr_sum[c] += (double) (inval - _calc_linear_refavg(&in[0], row, col, roi_in, c));
+          cr_cnt[c] += 1.0;
+        }
+      }
+      in += 4;
+    }
+  }
+  const dt_aligned_pixel_t chrominance = {cr_sum[0] / fmax(1.0, cr_cnt[0]), cr_sum[1] / fmax(1.0, cr_cnt[1]), cr_sum[2] / fmax(1.0, cr_cnt[2])};
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(clips, ivoid, ovoid, roi_in, roi_out, chrominance) \
+  schedule(static)
+#endif
+  for(int row = 1; row < roi_out->height-1; row++)
+  {
+    float *out = (float *)ovoid + (size_t)roi_out->width * row * 4 + 4;
+    float *in = (float *)ivoid + (size_t)roi_in->width * row * 4 + 4;
+    for(int col = 1; col < roi_out->width-1; col++)
+    {
+      for(int c = 0; c < 3; c++)
+      {
+        const float inval = fmaxf(0.0f, in[c]); 
+        if(inval > clips[c])
+          out[c] = fmaxf(inval, out[c] + chrominance[c]);
+      }
+      out += 4;
+      in += 4;
+    }
+  }
+
+  finish:
+  dt_free_align(mask_buffer);
+}
 
 static gboolean _process_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
                          const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,


### PR DESCRIPTION
As discussed in #12606 the "inpaint opposed" mode has been made the default here. Also the proposed order has changed.

As this module also supports sraw files the menu presenting the available modes for all supported types of files - sraw, bayer and xtrans - has been fixed.

As we have a new default sraw files had to get this mode too.
Also the highlights visualizing mask got support for sraws.

Missing yet: hide the "reconstruct color" mode if not selected by a developed image.

The sraw mode has been tested here with all files i got, i don't see any difference in quality - also the algo required very few technical mods - so i would propose to merge this to make it available for more people to test.