### PR TITLE
Improve XMP spelling consistency in darktable UI

### DIFF
--- a/data/darktableconfig.dtd
+++ b/data/darktableconfig.dtd
@@ -3,7 +3,7 @@
 <!ATTLIST dtconfig
 	prefs (import|lighttable|darkroom|otherviews|processing|security|cpugpu|storage|misc) #IMPLIED
         section
-        (import|session|interface|other|tags|geoloc|slideshow|cpugpu|database|xmp|accel|general|modules|thumbs) #IMPLIED
+        (import|session|interface|other|tags|geoloc|slideshow|cpugpu|database|XMP|accel|general|modules|thumbs) #IMPLIED
         dialog (collect|recentcollect|import|tagging) #IMPLIED
         ui (yes|no) #IMPLIED
         restart (true|false) #IMPLIED

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -259,7 +259,7 @@
     <shortdescription>timeout period of pixelpipe synchronization</shortdescription>
     <longdescription>time period (in units of 5ms) after which synchronization of preview and full pixelpipe is assumed to have failed. set to zero to omit pixelpipe synchronization. defaults to 200.</longdescription>
   </dtconfig>
-  <dtconfig prefs="storage" section="xmp">
+  <dtconfig prefs="storage" section="XMP">
     <name>write_sidecar_files</name>
     <type>
       <enum>
@@ -272,7 +272,7 @@
     <shortdescription>write sidecar file for each image</shortdescription>
     <longdescription>the sidecar files hold information about all your development steps to allow flawless re-importing of image files.\n\ndepending on the selected mode sidecar files will be written:\n - never\n - on import: immediately after importing the image\n - after edit: after any user change on the image</longdescription>
   </dtconfig>
-  <dtconfig prefs="storage" section="xmp">
+  <dtconfig prefs="storage" section="XMP">
     <name>compress_xmp_tags</name>
     <type>
       <enum>
@@ -282,8 +282,8 @@
       </enum>
     </type>
     <default>only large entries</default>
-    <shortdescription>store xmp tags in compressed format</shortdescription>
-    <longdescription>entries in xmp tags can get rather large and may exceed the available space to store the history stack in output files. this option allows xmp tags to be compressed and save space.</longdescription>
+    <shortdescription>store XMP tags in compressed format</shortdescription>
+    <longdescription>entries in XMP tags can get rather large and may exceed the available space to store the history stack in output files. this option allows XMP tags to be compressed and save space.</longdescription>
   </dtconfig>
   <dtconfig prefs="misc" section="tags">
     <name>omit_tag_hierarchy</name>
@@ -992,7 +992,7 @@
     <name>ui_last/import_last_tags_imported</name>
     <type>bool</type>
     <default>true</default>
-    <shortdescription>import tags from xmp</shortdescription>
+    <shortdescription>import tags from XMP</shortdescription>
     <longdescription/>
   </dtconfig>
   <dtconfig>
@@ -3212,12 +3212,12 @@
     <shortdescription>DPI value for exported files</shortdescription>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="storage" section="xmp">
+  <dtconfig prefs="storage" section="XMP">
     <name>run_crawler_on_start</name>
     <type>bool</type>
     <default>false</default>
-    <shortdescription>look for updated xmp files on startup</shortdescription>
-    <longdescription>check file modification times of all xmp files on startup to check if any got updated in the meantime</longdescription>
+    <shortdescription>look for updated XMP files on startup</shortdescription>
+    <longdescription>check file modification times of all XMP files on startup to check if any got updated in the meantime</longdescription>
   </dtconfig>
   <dtconfig prefs="security" section="other">
     <name>plugins/lighttable/audio_player</name>

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -61,7 +61,7 @@
 
 static void usage(const char *progname)
 {
-  fprintf(stderr, "usage: %s [<input file or dir>] [<xmp file>] <output destination> [options] [--core <darktable options>]\n", progname);
+  fprintf(stderr, "usage: %s [<input file or dir>] [<XMP file>] <output destination> [options] [--core <darktable options>]\n", progname);
   fprintf(stderr, "\n");
   fprintf(stderr, "options:\n");
   fprintf(stderr, "   --width <max width> default: 0 = full resolution\n");
@@ -580,7 +580,7 @@ int main(int argc, char *arg[])
       dt_image_t *image = dt_image_cache_get(darktable.image_cache, id, 'w');
       if(dt_exif_xmp_read(image, xmp_filename, 1) != 0)
       {
-        fprintf(stderr, _("error: can't open xmp file %s"), xmp_filename);
+        fprintf(stderr, _("error: can't open XMP file %s"), xmp_filename);
         fprintf(stderr, "\n");
         free(m_arg);
         g_free(output_filename);

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -2878,7 +2878,7 @@ static void add_mask_entries_to_db(int imgid, GHashTable *mask_entries, int mask
     dt_masks_point_group_t *group = (dt_masks_point_group_t *)entry->mask_points;
     if((int)(entry->mask_nb * sizeof(dt_masks_point_group_t)) != entry->mask_points_len)
     {
-      fprintf(stderr, "[masks] error loading masks from xmp file, bad binary blob size.\n");
+      fprintf(stderr, "[masks] error loading masks from XMP file, bad binary blob size.\n");
       return;
     }
     for(int i = 0; i < entry->mask_nb; i++)
@@ -4354,8 +4354,8 @@ int dt_exif_xmp_write(const int imgid, const char *filename)
       }
       else
       {
-        fprintf(stderr, "cannot read xmp file '%s': '%s'\n", filename, strerror(errno));
-        dt_control_log(_("cannot read xmp file '%s': '%s'"), filename, strerror(errno));
+        fprintf(stderr, "cannot read XMP file '%s': '%s'\n", filename, strerror(errno));
+        dt_control_log(_("cannot read XMP file '%s': '%s'"), filename, strerror(errno));
       }
 
       Exiv2::DataBuf buf = Exiv2::readFile(WIDEN(filename));
@@ -4406,8 +4406,8 @@ int dt_exif_xmp_write(const int imgid, const char *filename)
       }
       else
       {
-        fprintf(stderr, "cannot write xmp file '%s': '%s'\n", filename, strerror(errno));
-        dt_control_log(_("cannot write xmp file '%s': '%s'"), filename, strerror(errno));
+        fprintf(stderr, "cannot write XMP file '%s': '%s'\n", filename, strerror(errno));
+        dt_control_log(_("cannot write XMP file '%s': '%s'"), filename, strerror(errno));
         return -1;
       }
     }

--- a/src/control/crawler.c
+++ b/src/control/crawler.c
@@ -139,7 +139,7 @@ GList *dt_control_crawler_run()
         item->xmp_path = g_strdup(xmp_path);
 
         result = g_list_prepend(result, item);
-        dt_print(DT_DEBUG_CONTROL, "[crawler] `%s' (id: %d) is a newer xmp file.\n", xmp_path, id);
+        dt_print(DT_DEBUG_CONTROL, "[crawler] `%s' (id: %d) is a newer XMP file.\n", xmp_path, id);
       }
       // older timestamps are the case for all images after the db upgrade. better not report these
       //       else if(timestamp > statbuf.st_mtime)
@@ -605,7 +605,7 @@ void dt_control_crawler_show_image_list(GList *images)
                        DT_CONTROL_CRAWLER_COL_TS_DB, timestamp_db,
                        DT_CONTROL_CRAWLER_COL_TS_XMP_INT, item->timestamp_xmp,
                        DT_CONTROL_CRAWLER_COL_TS_DB_INT, item->timestamp_db,
-                       DT_CONTROL_CRAWLER_COL_REPORT, (item->timestamp_xmp > item->timestamp_db) ? _("xmp")
+                       DT_CONTROL_CRAWLER_COL_REPORT, (item->timestamp_xmp > item->timestamp_db) ? _("XMP")
                                                                                                  : _("database"),
                        DT_CONTROL_CRAWLER_COL_TIME_DELTA, timestamp_delta,
                        -1);
@@ -630,7 +630,7 @@ void dt_control_crawler_show_image_list(GList *images)
   gtk_tree_view_column_set_min_width(column, DT_PIXEL_APPLY_DPI(200));
   g_object_set(renderer_text, "ellipsize", PANGO_ELLIPSIZE_MIDDLE, NULL);
 
-  column = gtk_tree_view_column_new_with_attributes(_("xmp timestamp"), gtk_cell_renderer_text_new(), "text",
+  column = gtk_tree_view_column_new_with_attributes(_("XMP timestamp"), gtk_cell_renderer_text_new(), "text",
                                                     DT_CONTROL_CRAWLER_COL_TS_XMP, NULL);
   gtk_tree_view_append_column(GTK_TREE_VIEW(tree), column);
 
@@ -653,7 +653,7 @@ void dt_control_crawler_show_image_list(GList *images)
 
   // build a dialog window that contains the list of images
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  GtkWidget *dialog = gtk_dialog_new_with_buttons(_("updated xmp sidecar files found"), GTK_WINDOW(win),
+  GtkWidget *dialog = gtk_dialog_new_with_buttons(_("updated XMP sidecar files found"), GTK_WINDOW(win),
                                                   GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL, _("_close"),
                                                   GTK_RESPONSE_CLOSE, NULL);
 #ifdef GDK_WINDOWING_QUARTZ
@@ -683,7 +683,7 @@ void dt_control_crawler_show_image_list(GList *images)
   box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_pack_start(GTK_BOX(content_box), box, FALSE, FALSE, 1);
   GtkWidget *label = gtk_label_new_with_mnemonic(_("on the selection:"));
-  GtkWidget *reload_button = gtk_button_new_with_label(_("keep the xmp edit"));
+  GtkWidget *reload_button = gtk_button_new_with_label(_("keep the XMP edit"));
   GtkWidget *overwrite_button = gtk_button_new_with_label(_("keep the database edit"));
   GtkWidget *newest_button = gtk_button_new_with_label(_("keep the newest edit"));
   GtkWidget *oldest_button = gtk_button_new_with_label(_("keep the oldest edit"));

--- a/src/gui/import_metadata.c
+++ b/src/gui/import_metadata.c
@@ -427,12 +427,12 @@ void dt_import_metadata_init(dt_import_metadata_t *metadata)
   GtkWidget *presets = _set_up_combobox(metadata->m_model, DT_META_META_HEADER, metadata);
   g_signal_connect(presets, "changed", G_CALLBACK(_import_metadata_presets_changed), metadata);
 
-  label = gtk_label_new(_("from xmp"));
+  label = gtk_label_new(_("from XMP"));
   gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
   gtk_widget_set_tooltip_text(GTK_WIDGET(label),
                               _("selected metadata are imported from image and override the default value"
-                                "\n this drives also the \'look for updated xmp files\' and \'load sidecar file\' actions"
-                                "\n CAUTION: not selected metadata are cleaned up when xmp file is updated"
+                                "\n this drives also the \'look for updated XMP files\' and \'load sidecar file\' actions"
+                                "\n CAUTION: not selected metadata are cleaned up when XMP file is updated"
                               ));
   gtk_grid_attach(GTK_GRID(grid), label, 2, DT_META_META_HEADER, 1, 1);
 

--- a/src/libs/export_metadata.c
+++ b/src/libs/export_metadata.c
@@ -308,7 +308,7 @@ char *dt_lib_export_metadata_configuration_dialog(char *metadata_presets, const 
   gtk_widget_set_tooltip_text(exiftag, _("export EXIF metadata"));
   gtk_box_pack_start(GTK_BOX(vbox2), exiftag, FALSE, TRUE, 0);
   GtkWidget *dtmetadata = gtk_check_button_new_with_label(_("metadata"));
-  gtk_widget_set_tooltip_text(dtmetadata, _("export dt xmp metadata (from metadata editor module)"));
+  gtk_widget_set_tooltip_text(dtmetadata, _("export dt XMP metadata (from metadata editor module)"));
   gtk_box_pack_start(GTK_BOX(vbox2), dtmetadata, FALSE, TRUE, 0);
 
   GtkWidget *calculated;
@@ -320,8 +320,8 @@ char *dt_lib_export_metadata_configuration_dialog(char *metadata_presets, const 
     gtk_box_pack_start(GTK_BOX(box), vbox3, FALSE, TRUE, 10);
     calculated = gtk_check_button_new_with_label(_("only embedded"));
     gtk_widget_set_tooltip_text(calculated, _("per default the interface sends some (limited) metadata beside the image to remote storage.\n"
-        "to avoid this and let only image embedded dt xmp metadata, check this flag.\n"
-        "if remote storage doesn't understand dt xmp metadata, you can use calculated metadata instead"));
+        "to avoid this and let only image embedded dt XMP metadata, check this flag.\n"
+        "if remote storage doesn't understand dt XMP metadata, you can use calculated metadata instead"));
     gtk_box_pack_start(GTK_BOX(vbox3), calculated, FALSE, TRUE, 0);
   }
 
@@ -351,7 +351,7 @@ char *dt_lib_export_metadata_configuration_dialog(char *metadata_presets, const 
   gtk_widget_set_tooltip_text(hierarchical, _("export hierarchical tags (to Xmp.lr.Hierarchical Subject)"));
   gtk_box_pack_start(GTK_BOX(vbox2), hierarchical, FALSE, TRUE, 0);
   GtkWidget *dthistory = gtk_check_button_new_with_label(_("develop history"));
-  gtk_widget_set_tooltip_text(dthistory, _("export dt development data (recovery purpose in case of loss of database or xmp file)"));
+  gtk_widget_set_tooltip_text(dthistory, _("export dt development data (recovery purpose in case of loss of database or XMP file)"));
   gtk_box_pack_start(GTK_BOX(vbox2), dthistory, FALSE, TRUE, 0);
 
   // specific rules


### PR DESCRIPTION
In darktable UI in many cases XMP is written in upper case, but in some places there is also spelling in lower case. XMP is an acronym (to be more precise, initialism) and should therefore be in upper case.