### PR TITLE
build: enable ccache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ cmake_policy(SET CMP0048 NEW)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules/")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/")
 
+find_program(CCACHE_FOUND ccache)
+if(CCACHE_FOUND)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+endif(CCACHE_FOUND)
+
 ### Add defaults for cmake
 # These defaults need to be included before the project() call.
 include(DefineCMakeDefaults)


### PR DESCRIPTION
Hi darktable developers,

Long time I didn't contributed, so let's restart small, even tiny :-)

I've had this patch in my github fork for quite some time now, it's been rebased on top of master multiple times.

It enables ccache at CMake level if installed on the system.  Developers should enjoy faster builds when fetching/rebasing/pulling/validating a PR and then going though a full rebuild.

Typical build times on my laptop ( AMD Ryzen 7 PRO 5850U):
- non cached master build: 1m55,527s
- rather large revision gap build time: the cache is populated with a 4.0.1 build, then the build time for master is measured. 1m43,495s
- typical darktable dev PR compile check: the cache is populated with a master build, then a PR#12623 merged build time: 0m27,156s

I included the time required to reconfigure the tree with cmake which is not negligible but part of the cycle.