### PR TITLE
Lua processing events

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -632,6 +632,12 @@ restart:
   dt_control_toast_busy_leave();
   dt_pthread_mutex_unlock(&dev->pipe_mutex);
 
+  dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
+      0, NULL, NULL,
+      LUA_ASYNC_TYPENAME, "const char*", "pixelpipe-processing-complete",
+      LUA_ASYNC_TYPENAME, "dt_lua_image_t", GINT_TO_POINTER(dev->image_storage.id),
+      LUA_ASYNC_DONE);
+
   if(dev->gui_attached && !dev->gui_leaving)
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED);
 }

--- a/src/lua/events.c
+++ b/src/lua/events.c
@@ -656,6 +656,11 @@ int dt_lua_init_events(lua_State *L)
   lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
   dt_lua_event_add(L, "darkroom-image-history-changed");
 
+  lua_pushcfunction(L, dt_lua_event_multiinstance_register);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
+  dt_lua_event_add(L, "pixelpipe-processing-complete");
+
   return 0;
 }
 // clang-format off


### PR DESCRIPTION
In order to fully utilize the `darktable.gui.action() ` process to control the darktable UI, we need darktable to tell when it's finished performing an action so that a script knows that it can proceed to the next step.

This PR adds a new lua event, `pixelpipe-processing-complete`, that signals when a pixelpipe run is finished.

The existing lua event, `darkroom-image-loaded`, has been more carefully placed to better reflect what is happening.  A status has been added to the event to let the caller know if the image was loaded cleanly (pixelpipe locks were acquired) or not (the previous image still has the pixelpipe locked).  The caller can check the status and ask for a reload if the load wasn't clean, preventing the unintentional modifying of the previous image.

A test script is attached.  It adds a `display in darkroom` button to the selected images module.  Select a group of images, then press the button.  Each image is opened sequentially and 0.5ev of exposure is added.  After the last image is processed, the view returns to lighttable.  Run the script with the `-d lua` to see the debug messages to see what the script is doing and how the events are being used.

[display_in_darkroom.zip](https://github.com/darktable-org/darktable/files/9782737/display_in_darkroom.zip)
