### PR TITLE
Keep modules in place or fully visible when opening or expanding

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2162,6 +2162,13 @@
     <shortdescription>always show panels' scrollbars</shortdescription>
     <longdescription>defines whether the panel scrollbars should be always visible or activated only depending on the content.  (need a restart)</longdescription>
   </dtconfig>
+  <dtconfig prefs="misc" section="interface">
+    <name>darkroom/ui/transition_duration</name>
+    <type min="0" max="1000">int</type>
+    <default>250</default>
+    <shortdescription>duration of the ui transitions in ms</shortdescription>
+    <longdescription>how long the transitions take (in ms) for expanding or collapsing modules and other ui elements</longdescription>
+  </dtconfig>
   <dtconfig>
     <name>ui_last/expander_metadata</name>
     <type>int</type>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1065,7 +1065,6 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   {
     darktable.gui = (dt_gui_gtk_t *)calloc(1, sizeof(dt_gui_gtk_t));
     darktable.gui->grouping = dt_conf_get_bool("ui_last/grouping");
-    memset(darktable.gui->scroll_to, 0, sizeof(darktable.gui->scroll_to));
     dt_film_set_folder_status();
   }
 

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -456,7 +456,6 @@ void dt_develop_blendif_rgb_jzczhz_blend(struct dt_dev_pixelpipe_iop_t *piece, c
 
 
 /** gui related stuff */
-void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module);
 void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module);
 void dt_iop_gui_update_blending(dt_iop_module_t *module);
 void dt_iop_gui_update_blendif(dt_iop_module_t *module);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -493,18 +493,29 @@ static gboolean _blendif_clean_output_channels(dt_iop_module_t *module)
   return changed;
 }
 
+static void _add_wrapped_box(GtkWidget *container, GtkBox *box, gchar *help_url)
+{
+  GtkWidget *event_box = gtk_event_box_new();
+  GtkWidget *revealer = gtk_revealer_new();
+  gtk_container_add(GTK_CONTAINER(revealer), GTK_WIDGET(box));
+  gtk_container_add(GTK_CONTAINER(event_box), revealer);
+  gtk_container_add(GTK_CONTAINER(container), event_box);
+  // event box is needed so that one can click into the area to get help
+  dt_gui_add_help_link(event_box, dt_get_help_url(help_url));
+}
+
+static void _box_set_visible(GtkBox *box, gboolean visible)
+{
+  GtkRevealer *revealer = GTK_REVEALER(gtk_widget_get_parent(GTK_WIDGET(box)));
+  gtk_revealer_set_transition_duration(revealer, dt_conf_get_int("darkroom/ui/transition_duration"));
+  gtk_revealer_set_reveal_child(revealer, visible);
+}
+
 static void _blendop_masks_mode_callback(const unsigned int mask_mode, dt_iop_gui_blend_data_t *data)
 {
   data->module->blend_params->mask_mode = mask_mode;
 
-  if(mask_mode & DEVELOP_MASK_ENABLED)
-  {
-    gtk_widget_show(GTK_WIDGET(data->top_box));
-  }
-  else
-  {
-    gtk_widget_hide(GTK_WIDGET(data->top_box));
-  }
+  _box_set_visible(data->top_box, mask_mode & DEVELOP_MASK_ENABLED);
 
   dt_iop_set_mask_mode(data->module, mask_mode);
 
@@ -557,16 +568,16 @@ static void _blendop_masks_mode_callback(const unsigned int mask_mode, dt_iop_gu
       gtk_widget_show(GTK_WIDGET(data->showmask));
     }
 
-    gtk_widget_show(GTK_WIDGET(data->bottom_box));
+    _box_set_visible(data->bottom_box, TRUE);
   }
   else
   {
-    gtk_widget_hide(GTK_WIDGET(data->bottom_box));
+    _box_set_visible(data->bottom_box, FALSE);
   }
 
   if(data->masks_inited && (mask_mode & DEVELOP_MASK_MASK))
   {
-    gtk_widget_show(GTK_WIDGET(data->masks_box));
+    _box_set_visible(data->masks_box, TRUE);
   }
   else if(data->masks_inited)
   {
@@ -574,42 +585,31 @@ static void _blendop_masks_mode_callback(const unsigned int mask_mode, dt_iop_gu
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->masks_shapes[n]), FALSE);
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->masks_edit), FALSE);
     dt_masks_set_edit_mode(data->module, DT_MASKS_EDIT_OFF);
-    gtk_widget_hide(GTK_WIDGET(data->masks_box));
+    _box_set_visible(data->masks_box, FALSE);
   }
   else if(data->masks_support)
   {
     for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->masks_shapes[n]), FALSE);
-    gtk_widget_hide(GTK_WIDGET(data->masks_box));
+    _box_set_visible(data->masks_box, FALSE);
   }
 
-  if(data->raster_inited && (mask_mode & DEVELOP_MASK_RASTER))
-  {
-    gtk_widget_show(GTK_WIDGET(data->raster_box));
-  }
-  else if(data->raster_inited)
-  {
-    gtk_widget_hide(GTK_WIDGET(data->raster_box));
-  }
-  else
-  {
-    gtk_widget_hide(GTK_WIDGET(data->raster_box));
-  }
+  _box_set_visible(data->raster_box, data->raster_inited && (mask_mode & DEVELOP_MASK_RASTER));
 
   if(data->blendif_inited && (mask_mode & DEVELOP_MASK_CONDITIONAL))
   {
-    gtk_widget_show(GTK_WIDGET(data->blendif_box));
+    _box_set_visible(data->blendif_box, TRUE);
   }
   else if(data->blendif_inited)
   {
     /* switch off color picker */
     dt_iop_color_picker_reset(data->module, FALSE);
 
-    gtk_widget_hide(GTK_WIDGET(data->blendif_box));
+    _box_set_visible(data->blendif_box, FALSE);
   }
   else
   {
-    gtk_widget_hide(GTK_WIDGET(data->blendif_box));
+    _box_set_visible(data->blendif_box, FALSE);
   }
 
   dt_dev_add_history_item(darktable.develop, data->module, TRUE);
@@ -2040,6 +2040,7 @@ const char *slider_tooltip[] = { N_("adjustment based on input received by this 
                                     "markers: blend fully\n* range defined by lower markers: do not blend at all\n* range "
                                     "between adjacent upper/lower markers: blend gradually") };
 
+
 void dt_iop_gui_update_blendif(dt_iop_module_t *module)
 {
   dt_iop_gui_blend_data_t *bd = module->blend_data;
@@ -2109,16 +2110,13 @@ void dt_iop_gui_update_blendif(dt_iop_module_t *module)
 }
 
 
-void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
+void dt_iop_gui_init_blendif(GtkWidget *blendw, dt_iop_module_t *module)
 {
   dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
 
   bd->blendif_box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
   // add event box so that one can click into the area to get help for parametric masks
-  GtkWidget* event_box = gtk_event_box_new();
-  dt_gui_add_help_link(GTK_WIDGET(event_box), dt_get_help_url("masks_parametric"));
-  gtk_container_add(GTK_CONTAINER(blendw), event_box);
-  gtk_container_add(GTK_CONTAINER(event_box), GTK_WIDGET(bd->blendif_box));
+  _add_wrapped_box(blendw, bd->blendif_box, "masks_parametric");
 
   /* create and add blendif support if module supports it */
   if(bd->blendif_support)
@@ -2297,15 +2295,12 @@ void dt_iop_gui_update_masks(dt_iop_module_t *module)
   --darktable.gui->reset;
 }
 
-void dt_iop_gui_init_masks(GtkBox *blendw, dt_iop_module_t *module)
+void dt_iop_gui_init_masks(GtkWidget *blendw, dt_iop_module_t *module)
 {
   dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
 
   bd->masks_box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
-  // add event box so that one can click into the area to get help for drawn masks
-  GtkWidget* event_box = gtk_event_box_new();
-  dt_gui_add_help_link(GTK_WIDGET(event_box), dt_get_help_url("masks_drawn"));
-  gtk_container_add(GTK_CONTAINER(blendw), event_box);
+  _add_wrapped_box(blendw, bd->masks_box, "masks_drawn");
 
   /* create and add masks support if module supports it */
   if(bd->masks_support)
@@ -2367,7 +2362,6 @@ void dt_iop_gui_init_masks(GtkBox *blendw, dt_iop_module_t *module)
 
     bd->masks_inited = 1;
   }
-  gtk_container_add(GTK_CONTAINER(event_box), GTK_WIDGET(bd->masks_box));
 }
 
 typedef struct raster_combo_entry_t
@@ -2481,15 +2475,12 @@ static void _raster_polarity_callback(GtkToggleButton *togglebutton, dt_iop_modu
   dt_control_queue_redraw_widget(GTK_WIDGET(togglebutton));
 }
 
-void dt_iop_gui_init_raster(GtkBox *blendw, dt_iop_module_t *module)
+void dt_iop_gui_init_raster(GtkWidget *blendw, dt_iop_module_t *module)
 {
   dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
 
   bd->raster_box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
-  // add event box so that one can click into the area to get help for drawn masks
-  GtkWidget* event_box = gtk_event_box_new();
-  dt_gui_add_help_link(GTK_WIDGET(event_box), dt_get_help_url("masks_raster"));
-  gtk_container_add(GTK_CONTAINER(blendw), event_box);
+  _add_wrapped_box(blendw, bd->raster_box, "masks_raster");
 
   /* create and add raster support if module supports it (it's coupled to masks at the moment) */
   if(bd->masks_support)
@@ -2515,7 +2506,6 @@ void dt_iop_gui_init_raster(GtkBox *blendw, dt_iop_module_t *module)
 
     bd->raster_inited = 1;
   }
-  gtk_container_add(GTK_CONTAINER(event_box), GTK_WIDGET(bd->raster_box));
 }
 
 void dt_iop_gui_cleanup_blending(dt_iop_module_t *module)
@@ -2763,14 +2753,7 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
   /* now show hide controls as required */
   const unsigned int mask_mode = module->blend_params->mask_mode;
 
-  if(mask_mode & DEVELOP_MASK_ENABLED)
-  {
-    gtk_widget_show(GTK_WIDGET(bd->top_box));
-  }
-  else
-  {
-    gtk_widget_hide(GTK_WIDGET(bd->top_box));
-  }
+  _box_set_visible(bd->top_box, mask_mode & DEVELOP_MASK_ENABLED);
 
   const dt_image_t img = module->dev->image_storage;
   gtk_widget_set_visible(bd->details_slider, dt_image_is_rawprepare_supported(&img));
@@ -2811,7 +2794,7 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
       gtk_widget_show(GTK_WIDGET(bd->showmask));
     }
 
-    gtk_widget_show(GTK_WIDGET(bd->bottom_box));
+    _box_set_visible(bd->bottom_box, TRUE);
   }
   else
   {
@@ -2823,53 +2806,40 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
     module->suppress_mask = 0;
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->suppress), FALSE);
 
-    gtk_widget_hide(GTK_WIDGET(bd->bottom_box));
+    _box_set_visible(bd->bottom_box, FALSE);
   }
 
   if(bd->masks_inited && (mask_mode & DEVELOP_MASK_MASK))
   {
-    gtk_widget_show(GTK_WIDGET(bd->masks_box));
+    _box_set_visible(bd->masks_box, TRUE);
   }
   else if(bd->masks_inited)
   {
     dt_masks_set_edit_mode(module, DT_MASKS_EDIT_OFF);
 
-    gtk_widget_hide(GTK_WIDGET(bd->masks_box));
+    _box_set_visible(bd->masks_box, FALSE);
   }
   else
   {
-    gtk_widget_hide(GTK_WIDGET(bd->masks_box));
+    _box_set_visible(bd->masks_box, FALSE);
   }
 
-  if(bd->raster_inited && (mask_mode & DEVELOP_MASK_RASTER))
-  {
-    gtk_widget_show(GTK_WIDGET(bd->raster_box));
-  }
-  else if(bd->raster_inited)
-  {
-//     dt_masks_set_edit_mode(module, DT_MASKS_EDIT_OFF);
-
-    gtk_widget_hide(GTK_WIDGET(bd->raster_box));
-  }
-  else
-  {
-    gtk_widget_hide(GTK_WIDGET(bd->raster_box));
-  }
+  _box_set_visible(bd->raster_box, bd->raster_inited && (mask_mode & DEVELOP_MASK_RASTER));
 
   if(bd->blendif_inited && (mask_mode & DEVELOP_MASK_CONDITIONAL))
   {
-    gtk_widget_show(GTK_WIDGET(bd->blendif_box));
+    _box_set_visible(bd->blendif_box, TRUE);
   }
   else if(bd->blendif_inited)
   {
     /* switch off color picker */
     dt_iop_color_picker_reset(module, FALSE);
 
-    gtk_widget_hide(GTK_WIDGET(bd->blendif_box));
+    _box_set_visible(bd->blendif_box, FALSE);
   }
   else
   {
-    gtk_widget_hide(GTK_WIDGET(bd->blendif_box));
+    _box_set_visible(bd->blendif_box, FALSE);
   }
 
   if(module->hide_enable_button)
@@ -3151,11 +3121,11 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     gtk_box_pack_start(GTK_BOX(bd->top_box), blend_modes_hbox, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->top_box), bd->blend_mode_parameter_slider, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->top_box), bd->opacity_slider, TRUE, TRUE, 0);
-    gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(bd->top_box), TRUE, TRUE, 0);
+    _add_wrapped_box(box, bd->top_box, NULL);
 
-    dt_iop_gui_init_masks(GTK_BOX(iopw), module);
-    dt_iop_gui_init_raster(GTK_BOX(iopw), module);
-    dt_iop_gui_init_blendif(GTK_BOX(iopw), module);
+    dt_iop_gui_init_masks(iopw, module);
+    dt_iop_gui_init_raster(iopw, module);
+    dt_iop_gui_init_blendif(iopw, module);
 
     bd->bottom_box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
     gtk_box_pack_start(GTK_BOX(bd->bottom_box), GTK_WIDGET(bd->masks_combine_combo), TRUE, TRUE, 0);
@@ -3167,10 +3137,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     gtk_box_pack_start(GTK_BOX(bd->bottom_box), bd->blur_radius_slider, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->bottom_box), bd->brightness_slider, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->bottom_box), bd->contrast_slider, TRUE, TRUE, 0);
-    GtkWidget* event_box = gtk_event_box_new();
-    dt_gui_add_help_link(event_box, dt_get_help_url("masks_refinement"));
-    gtk_container_add(GTK_CONTAINER(event_box), GTK_WIDGET(bd->bottom_box));
-    gtk_box_pack_start(GTK_BOX(iopw), GTK_WIDGET(event_box), TRUE, TRUE, 0);
+    _add_wrapped_box(iopw, bd->bottom_box, "masks_refinement");
 
     gtk_widget_set_name(GTK_WIDGET(bd->top_box), "blending-box");
     gtk_widget_set_name(GTK_WIDGET(bd->masks_box), "blending-box");

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -737,9 +737,6 @@ dt_iop_module_t *dt_iop_gui_duplicate(dt_iop_module_t *base, gboolean copy_param
                           module->expander, g_value_get_int(&gv) + pos_base - pos_module + 1);
     dt_iop_gui_set_expanded(module, TRUE, FALSE);
 
-    if(dt_conf_get_bool("darkroom/ui/scroll_to_module"))
-        darktable.gui->scroll_to[1] = module->expander;
-
     dt_iop_reload_defaults(module); // some modules like profiled denoise update the gui in reload_defaults
 
     if(copy_params)
@@ -997,9 +994,6 @@ static void _gui_off_callback(GtkToggleButton *togglebutton, gpointer user_data)
     if(gtk_toggle_button_get_active(togglebutton))
     {
       module->enabled = 1;
-
-      if(dt_conf_get_bool("darkroom/ui/scroll_to_module"))
-        darktable.gui->scroll_to[1] = module->expander;
 
       if(!basics && dt_conf_get_bool("darkroom/ui/activate_expand") && !module->expanded)
         dt_iop_gui_set_expanded(module, TRUE, dt_conf_get_bool("darkroom/ui/single_module"));
@@ -2055,10 +2049,6 @@ static gboolean _iop_plugin_header_button_press(GtkWidget *w, GdkEventButton *e,
     }
     else
     {
-      // make gtk scroll to the module once it updated its allocation size
-      if(dt_conf_get_bool("darkroom/ui/scroll_to_module"))
-        darktable.gui->scroll_to[1] = module->expander;
-
       const gboolean collapse_others = !dt_conf_get_bool("darkroom/ui/single_module") != (!dt_modifier_is(e->state, GDK_SHIFT_MASK));
       dt_iop_gui_set_expanded(module, !module->expanded, collapse_others);
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1954,31 +1954,6 @@ static gboolean _ui_init_panel_container_center_scroll_event(GtkWidget *widget, 
   return (((event->state & gtk_accelerator_get_default_mod_mask()) != darktable.gui->sidebar_scroll_mask) != dt_conf_get_bool("darkroom/ui/sidebar_scroll_default"));
 }
 
-// this should work as long as everything happens in the gui thread
-static void _ui_panel_size_changed(GtkAdjustment *adjustment, GParamSpec *pspec, gpointer user_data)
-{
-  GtkAllocation allocation;
-  static float last_height[2] = { 0 };
-
-  const int side = GPOINTER_TO_INT(user_data);
-
-  // don't do anything when the size didn't actually change.
-  const float height = gtk_adjustment_get_upper(adjustment) - gtk_adjustment_get_lower(adjustment);
-
-  if(height == last_height[side]) return;
-  last_height[side] = height;
-
-  if(!darktable.gui->scroll_to[side]) return;
-
-  if(GTK_IS_WIDGET(darktable.gui->scroll_to[side]))
-  {
-    gtk_widget_get_allocation(darktable.gui->scroll_to[side], &allocation);
-    gtk_adjustment_set_value(adjustment, allocation.y);
-  }
-
-  darktable.gui->scroll_to[side] = NULL;
-}
-
 static GtkWidget *_ui_init_panel_container_center(GtkWidget *container, gboolean left)
 {
   GtkWidget *widget;
@@ -1998,8 +1973,6 @@ static GtkWidget *_ui_init_panel_container_center(GtkWidget *container, gboolean
   gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(widget), GTK_POLICY_AUTOMATIC,
                                  dt_conf_get_bool("panel_scrollbars_always_visible")?GTK_POLICY_ALWAYS:GTK_POLICY_AUTOMATIC);
 
-  g_signal_connect(G_OBJECT(gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(widget))), "notify::lower",
-                   G_CALLBACK(_ui_panel_size_changed), GINT_TO_POINTER(left ? 1 : 0));
   // we want the left/right window border to scroll the module lists
   g_signal_connect(G_OBJECT(left ? darktable.gui->widgets.right_border : darktable.gui->widgets.left_border),
                    "scroll-event", G_CALLBACK(_borders_scrolled), widget);

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -139,8 +139,6 @@ typedef struct dt_gui_gtk_t
   // store which gtkrc we loaded:
   char gtkrc[PATH_MAX];
 
-  GtkWidget *scroll_to[2]; // one for left, one for right
-
   gint scroll_mask;
   guint sidebar_scroll_mask;
 

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -842,9 +842,6 @@ void dt_lib_gui_set_expanded(dt_lib_module_t *module, gboolean expanded)
   {
     /* register to receive draw events */
     darktable.lib->gui_module = module;
-
-    if(dt_conf_get_bool("darkroom/ui/scroll_to_module"))
-      darktable.gui->scroll_to[1] = module->expander;
   }
   else
   {
@@ -888,16 +885,6 @@ static gboolean _lib_plugin_header_button_press(GtkWidget *w, GdkEventButton *e,
     /* bail out if module is static */
     if(!module->expandable(module)) return FALSE;
 
-    // make gtk scroll to the module once it updated its allocation size
-    uint32_t container = module->container(module);
-    if(dt_conf_get_bool("lighttable/ui/scroll_to_module"))
-    {
-      if(container == DT_UI_CONTAINER_PANEL_LEFT_CENTER)
-        darktable.gui->scroll_to[0] = module->expander;
-      else if(container == DT_UI_CONTAINER_PANEL_RIGHT_CENTER)
-        darktable.gui->scroll_to[1] = module->expander;
-    }
-
     /* handle shiftclick on expander, hide all except this */
     if(!dt_conf_get_bool("lighttable/ui/single_module") != !dt_modifier_is(e->state, GDK_SHIFT_MASK))
     {
@@ -907,7 +894,7 @@ static gboolean _lib_plugin_header_button_press(GtkWidget *w, GdkEventButton *e,
       {
         dt_lib_module_t *m = (dt_lib_module_t *)it->data;
 
-        if(m != module && container == m->container(m) && m->expandable(m) && dt_lib_is_visible_in_view(m, v))
+        if(m != module && module->container(module) == m->container(m) && m->expandable(m) && dt_lib_is_visible_in_view(m, v))
         {
           all_other_closed = all_other_closed && !dtgtk_expander_get_expanded(DTGTK_EXPANDER(m->expander));
           dt_lib_gui_set_expanded(m, FALSE);
@@ -944,16 +931,6 @@ static void show_module_callback(dt_lib_module_t *module)
   /* bail out if module is static */
   if(!module->expandable(module)) return;
 
-  // make gtk scroll to the module once it updated its allocation size
-  uint32_t container = module->container(module);
-  if(dt_conf_get_bool("lighttable/ui/scroll_to_module"))
-  {
-    if(container == DT_UI_CONTAINER_PANEL_LEFT_CENTER)
-      darktable.gui->scroll_to[0] = module->expander;
-    else if(container == DT_UI_CONTAINER_PANEL_RIGHT_CENTER)
-      darktable.gui->scroll_to[1] = module->expander;
-  }
-
   if(dt_conf_get_bool("lighttable/ui/single_module"))
   {
     const dt_view_t *v = dt_view_manager_get_current_view(darktable.view_manager);
@@ -962,7 +939,7 @@ static void show_module_callback(dt_lib_module_t *module)
     {
       dt_lib_module_t *m = (dt_lib_module_t *)it->data;
 
-      if(m != module && container == m->container(m) && m->expandable(m) && dt_lib_is_visible_in_view(m, v))
+      if(m != module && module->container(module) == m->container(m) && m->expandable(m) && dt_lib_is_visible_in_view(m, v))
       {
         all_other_closed = all_other_closed && !dtgtk_expander_get_expanded(DTGTK_EXPANDER(m->expander));
         dt_lib_gui_set_expanded(m, FALSE);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -541,7 +541,7 @@ void expose(
     if(dev->iso_12646.enabled)
     {
       // draw the white frame around picture
-      const double tbw = (float)(tb >> closeup) * 2.0 / 3.0;  
+      const double tbw = (float)(tb >> closeup) * 2.0 / 3.0;
       cairo_rectangle(cr, -tbw, -tbw, wd + 2.0 * tbw, ht + 2.0 * tbw);
       cairo_set_source_rgb(cr, 1., 1., 1.);
       cairo_fill(cr);
@@ -852,8 +852,6 @@ static void _dev_change_image(dt_develop_t *dev, const int32_t imgid)
   dev->proxy.wb_is_D65 = TRUE;
   dev->proxy.wb_coeffs[0] = 0.f;
 
-  memset(darktable.gui->scroll_to, 0, sizeof(darktable.gui->scroll_to));
-
   // change active image
   g_slist_free(darktable.view_manager->active_images);
   darktable.view_manager->active_images = g_slist_prepend(NULL, GINT_TO_POINTER(imgid));
@@ -914,12 +912,12 @@ static void _dev_change_image(dt_develop_t *dev, const int32_t imgid)
   // which in turn try to acquire the gdk lock.
   //
   // worst case, it'll drop some change image events. sorry.
-  if(dt_pthread_mutex_BAD_trylock(&dev->preview_pipe_mutex)) 
+  if(dt_pthread_mutex_BAD_trylock(&dev->preview_pipe_mutex))
   {
 
   #ifdef USE_LUA
 
-  _fire_darkroom_image_loaded_event(FALSE, imgid);  
+  _fire_darkroom_image_loaded_event(FALSE, imgid);
 
 #endif
 
@@ -931,7 +929,7 @@ static void _dev_change_image(dt_develop_t *dev, const int32_t imgid)
 
  #ifdef USE_LUA
 
-  _fire_darkroom_image_loaded_event(FALSE, imgid);  
+  _fire_darkroom_image_loaded_event(FALSE, imgid);
 
 #endif
 
@@ -944,7 +942,7 @@ static void _dev_change_image(dt_develop_t *dev, const int32_t imgid)
 
  #ifdef USE_LUA
 
-  _fire_darkroom_image_loaded_event(FALSE, imgid);  
+  _fire_darkroom_image_loaded_event(FALSE, imgid);
 
 #endif
 
@@ -1170,7 +1168,7 @@ static void _dev_change_image(dt_develop_t *dev, const int32_t imgid)
 
 #ifdef USE_LUA
 
-  _fire_darkroom_image_loaded_event(TRUE, imgid);  
+  _fire_darkroom_image_loaded_event(TRUE, imgid);
 
 #endif
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -241,9 +241,6 @@ int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
   // reset the cursor to the default one
   dt_control_change_cursor(GDK_LEFT_PTR);
 
-  // also ignore what scrolling there was previously happening
-  memset(darktable.gui->scroll_to, 0, sizeof(darktable.gui->scroll_to));
-
   // destroy old module list
 
   /*  clear the undo list, for now we do this unconditionally. At some point we will probably want to clear


### PR DESCRIPTION
When you open a module by clicking on its header, or when you expand it, by opening a collapsible section or adding a mask type, it can end up being partly obscured; at the bottom when it is too large or at the top if simultaneously another module above it was closed (because of "expand a single processing module at a time" or because shift was held). The latter also often unnecessarily causes the module to jump.

This PR solves both issues. It keeps the header at the same location, when possible, unless the module needs more space, in which case it moves it upward.

The move can be made smoothly, as well as the opening (and closing) itself, also of collapsible sections, using the same technique as #11408 (thanks @Sacules for the idea). The speed of the smooth transitions and scrolls can be configured in preferences/misc/duration of ui transitions, all the way down to 0/instantaneous/normal/as before. With smooth moves it easier to see where the module ended up, but there can be bit of flickering when simultaneously closing another module.

This also "fixes" a bug in master where "scroll processing modules to the top when expanded" would not work if the total height of all modules did not change when switching between two of them, i.e. if they had the same height, like, for example, multiple instances of the same module.

But tbh I wonder if "scroll to top" is as useful as it was before, since this already "guarantees" you'll be able to see the whole module (unless of course you are trying to draw a parametric mask for colorbalance rgb).

Feedback welcome!

Fixes #12087