### PR TITLE
New module: Sigmoid display transform

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -264,6 +264,7 @@ src/iop/rotatepixels.c
 src/iop/scalepixels.c
 src/iop/shadhi.c
 src/iop/sharpen.c
+src/iop/sigmoid.c
 src/iop/soften.c
 src/iop/splittoning.c
 src/iop/spots.c

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -818,6 +818,7 @@ GList *dt_ioppr_get_iop_order_list(int32_t imgid, gboolean sorted)
           _insert_before(iop_order_list, "graduatednd", "crop");
           _insert_before(iop_order_list, "colorbalance", "diffuse");
           _insert_before(iop_order_list, "nlmeans", "blurs");
+          _insert_before(iop_order_list, "filmic", "sigmoid");
         }
       }
       else if(version == DT_IOP_ORDER_LEGACY)

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -132,6 +132,7 @@ const dt_iop_order_entry_t legacy_order[] = {
   { {43.0f }, "colorzones", 0},
   { {44.0f }, "lowlight", 0},
   { {45.0f }, "monochrome", 0},
+  { {45.3f }, "sigmoid", 0},
   { {46.0f }, "filmic", 0},
   { {46.5f }, "filmicrgb", 0},
   { {47.0f }, "colisa", 0},
@@ -232,6 +233,7 @@ const dt_iop_order_entry_t v30_order[] = {
   { {44.0f }, "basecurve", 0},       // conversion from scene-referred to display referred, reverse-engineered
                                   //    on camera JPEG default look
   { {45.0f }, "filmic", 0},          // same, but different (parametric) approach
+  { {45.3f }, "sigmoid", 0},
   { {46.0f }, "filmicrgb", 0},       // same, upgraded
   { {36.0f }, "lut3d", 0},           // apply a creative style or film emulation, possibly non-linear
   { {47.0f }, "colisa", 0},          // edit contrast while damaging colour

--- a/src/iop/CMakeLists.txt
+++ b/src/iop/CMakeLists.txt
@@ -149,7 +149,7 @@ add_iop(colorbalancergb "colorbalancergb.c")
 add_iop(cacorrectrgb "cacorrectrgb.c")
 add_iop(diffuse "diffuse.c")
 add_iop(blurs "blurs.c")
-
+add_iop(sigmoid "sigmoid.c")
 
 if(Rsvg2_FOUND)
   add_iop(watermark "watermark.c")

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -680,6 +680,7 @@ void gui_update(dt_iop_module_t *self)
 
   dt_bauhaus_slider_set(g->contrast_slider, p->middle_grey_contrast);
   dt_bauhaus_slider_set(g->skewness_slider, p->contrast_skewness);
+  dt_bauhaus_slider_set(g->hue_preservation_slider, p->hue_preservation);
   dt_bauhaus_slider_set(g->display_black_slider, p->display_black_target);
   dt_bauhaus_slider_set(g->display_white_slider, p->display_white_target);
 

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -18,9 +18,8 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-// our includes go first:
+
 #include "bauhaus/bauhaus.h"
-#include "common/rgb_norms.h"
 #include "develop/imageop.h"
 #include "develop/imageop_gui.h"
 #include "develop/openmp_maths.h"

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -66,9 +66,6 @@ typedef struct dt_iop_sigmoid_data_t
   float hue_preservation;
 } dt_iop_sigmoid_data_t;
 
-typedef struct dt_iop_sigmoid_global_data_t
-{} dt_iop_sigmoid_global_data_t;
-
 typedef struct dt_iop_sigmoid_gui_data_t
 {
   GtkWidget *contrast_slider, *skewness_slider, *color_processing_list, *hue_preservation_slider,
@@ -515,17 +512,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   piece->data = calloc(1, sizeof(dt_iop_sigmoid_data_t));
-}
-
-void init_global(dt_iop_module_so_t *module)
-{
-  module->data = malloc(sizeof(dt_iop_sigmoid_global_data_t));
-}
-
-void cleanup_global(dt_iop_module_so_t *module)
-{
-  free(module->data);
-  module->data = NULL;
 }
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -112,12 +112,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return IOP_CS_RGB;
 }
 
-int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
-                  void *new_params, const int new_version)
-{
-  return 1;
-}
-
 void init_presets(dt_iop_module_so_t *self)
 {
   dt_iop_sigmoid_params_t p;
@@ -523,26 +517,9 @@ void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe
   piece->data = calloc(1, sizeof(dt_iop_sigmoid_data_t));
 }
 
-void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
-{
-  free(piece->data);
-  piece->data = NULL;
-}
-
 void init_global(dt_iop_module_so_t *module)
 {
   module->data = malloc(sizeof(dt_iop_sigmoid_global_data_t));
-}
-
-void cleanup(dt_iop_module_t *module)
-{
-  // Releases any memory allocated in init(module)
-  // Implement this function explicitly if the module allocates additional memory besides (default_)params.
-  // this is rare.
-  free(module->params);
-  module->params = NULL;
-  free(module->default_params);
-  module->default_params = NULL;
 }
 
 void cleanup_global(dt_iop_module_so_t *module)

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -80,6 +80,22 @@ const char *name()
   return _("sigmoid");
 }
 
+const char *aliases()
+{
+  return _("tone mapping|view transform|display transform");
+}
+
+const char **description(struct dt_iop_module_t *self)
+{
+  return dt_iop_set_description(self, _("apply a view transform to make a image displayable\n"
+                                        "on a screen or print. Uses a robust and smooth tone\n"
+                                        "tone curve with optional color preservation methods."),
+                                      _("corrective and creative"),
+                                      _("linear RGB, scene-referred"),
+                                      _("non-linear RGB"),
+                                      _("linear RGB, display-referred"));
+}
+
 int flags()
 {
   return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING;
@@ -544,12 +560,20 @@ void gui_init(dt_iop_module_t *self)
   g->contrast_slider = dt_bauhaus_slider_from_params(self, "middle_grey_contrast");
   dt_bauhaus_slider_set_soft_range(g->contrast_slider, 0.7f, 3.0f);
   dt_bauhaus_slider_set_digits(g->contrast_slider, 3);
+  gtk_widget_set_tooltip_text(g->contrast_slider, _("Compression of the applied curve\n"
+                                                    "implicitly defines the supported input dynamic range."));
   g->skewness_slider = dt_bauhaus_slider_from_params(self, "contrast_skewness");
+  gtk_widget_set_tooltip_text(g->skewness_slider, _("Shift the compression towards shadows or highlights.\n"
+                                                    "Negative values increase contrast in shadows.\n"
+                                                    "Positive values increase contrast in highlights.\n"
+                                                    "The opposite end will see a reduction in contrast."));
 
   // Color handling
   g->color_processing_list = dt_bauhaus_combobox_from_params(self, "color_processing");
   g->hue_preservation_slider = dt_bauhaus_slider_from_params(self, "hue_preservation");
   dt_bauhaus_slider_set_format(g->hue_preservation_slider, "%");
+  gtk_widget_set_tooltip_text(g->hue_preservation_slider, _("Optional correction of the hue twist introduced by\n"
+                                                            "the per-channel processing method."));
 
   // Target display
   GtkWidget *label = dt_ui_section_label_new(_("display luminance"));
@@ -561,9 +585,13 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_soft_range(g->display_black_slider, 0.0f, 1.0f);
   dt_bauhaus_slider_set_digits(g->display_black_slider, 4);
   dt_bauhaus_slider_set_format(g->display_black_slider, "%");
+  gtk_widget_set_tooltip_text(g->display_black_slider, _("The black luminance of the target display or print.\n"
+                                                         "Can be used creatively for a faded look."));
   g->display_white_slider = dt_bauhaus_slider_from_params(self, "display_white_target");
   dt_bauhaus_slider_set_soft_range(g->display_white_slider, 50.0f, 100.0f);
   dt_bauhaus_slider_set_format(g->display_white_slider, "%");
+  gtk_widget_set_tooltip_text(g->display_white_slider, _("The white luminance of the target display or print.\n"
+                                                         "Can be used creatively for a faded look or blowing out whites earlier."));
 }
 
 void gui_cleanup(dt_iop_module_t *self)

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -618,11 +618,6 @@ void gui_init(dt_iop_module_t *self)
                                                          "can be used creatively for a faded look or blowing out whites earlier."));
 }
 
-void gui_cleanup(dt_iop_module_t *self)
-{
-  IOP_GUI_FREE;
-}
-
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -240,7 +240,7 @@ void process_loglogistic_crosstalk(struct dt_iop_module_t *self, dt_dev_pixelpip
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(npixels, work_profile, magnitude, paper_exp, film_fog, contrast_power, skew_power) \
+  dt_omp_firstprivate(npixels, work_profile, saturation_factor, magnitude, paper_exp, film_fog, contrast_power, skew_power) \
   dt_omp_sharedconst(in, out) \
   schedule(static)
 #endif

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -24,6 +24,7 @@
 #include "develop/imageop_gui.h"
 #include "develop/openmp_maths.h"
 #include "gui/gtk.h"
+#include "gui/presets.h"
 #include "iop/iop_api.h"
 
 #include <gtk/gtk.h>
@@ -45,7 +46,7 @@ typedef enum dt_iop_sigmoid_methods_type_t
 
 typedef struct dt_iop_sigmoid_params_t
 {
-  float middle_grey_contrast;  // $MIN: 0.1  $MAX: 10.0 $DEFAULT: 1.6 $DESCRIPTION: "contrast"
+  float middle_grey_contrast;  // $MIN: 0.1  $MAX: 10.0 $DEFAULT: 1.5 $DESCRIPTION: "contrast"
   float contrast_skewness;     // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "skew"
   float display_white_target;  // $MIN: 20.0  $MAX: 1600.0 $DEFAULT: 100.0 $DESCRIPTION: "target white"
   float display_black_target;  // $MIN: 0.0  $MAX: 15.0 $DEFAULT: 0.0152 $DESCRIPTION: "target black"
@@ -115,6 +116,29 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
                   void *new_params, const int new_version)
 {
   return 1;
+}
+
+void init_presets(dt_iop_module_so_t *self)
+{
+  dt_iop_sigmoid_params_t p;
+  p.display_white_target = 100.0f;
+  p.display_black_target = 0.0152f;
+  p.color_processing = DT_SIGMOID_METHOD_PER_CHANNEL;
+
+  p.middle_grey_contrast = 1.22f;
+  p.contrast_skewness = 0.65f;
+  p.hue_preservation = 100.0f;
+  dt_gui_presets_add_generic(_("neutral grey"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
+
+  p.middle_grey_contrast = 1.6f;
+  p.contrast_skewness = -0.2f;
+  p.hue_preservation = 0.0f;
+  dt_gui_presets_add_generic(_("aces 100-nits like"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
+
+  p.middle_grey_contrast = 1.0f;
+  p.contrast_skewness = 0.0f;
+  p.color_processing = DT_SIGMOID_METHOD_RGB_RATIO;
+  dt_gui_presets_add_generic(_("reinhard"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 }
 
 // Declared here as it is used in the commit params function

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -398,7 +398,8 @@ void process_loglogistic_rgb_ratio(dt_dev_pixelpipe_iop_t *piece, const void *co
 static inline void preserve_hue_and_energy(const dt_aligned_pixel_t pix_in, const dt_aligned_pixel_t per_channel, dt_aligned_pixel_t pix_out,
     const dt_iop_sigmoid_value_order_t order, const float hue_preservation)
 {
-  if (per_channel[order.max] - per_channel[order.min] < 1e-9)
+  if (per_channel[order.max] - per_channel[order.min] < 1e-9 ||
+      per_channel[order.mid] - per_channel[order.min] < 1e-9 )
   {
     pix_out[order.min] = per_channel[order.min];
     pix_out[order.mid] = per_channel[order.mid];

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -89,7 +89,7 @@ const char *aliases()
 const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("apply a view transform to make a image displayable\n"
-                                        "on a screen or print. Uses a robust and smooth tone\n"
+                                        "on a screen or print. Uses a robust and smooth\n"
                                         "tone curve with optional color preservation methods."),
                                       _("corrective and creative"),
                                       _("linear RGB, scene-referred"),
@@ -246,7 +246,8 @@ static void pixel_channel_order(const float pix_in[4], dt_iop_sigmoid_value_orde
       pixel_value_order->max = 0;
       pixel_value_order->mid = 2;
       pixel_value_order->min = 1;
-    } else
+    }
+    else
     {  // Case 4: r == g == b
       // No change of the middle value, just assign something.
       pixel_value_order->max = 0;
@@ -384,10 +385,9 @@ void process_loglogistic_rgb_ratio(dt_dev_pixelpipe_iop_t *piece, const void *co
 
     // Hyperbolic gamut compression
     // Small chroma values, i.e., colors close to the acromatic axis are preserved while large chroma values are compressed.
-    float hyperbolic_chroma = 2.0f * chroma_vs_mapping_border / (1.0f - chroma_vs_mapping_border * chroma_vs_mapping_border + epsilon);
 
     const float pixel_chroma_adjustment = 1.0f / (chroma_vs_mapping_border * display_border_vs_chroma + epsilon);
-    hyperbolic_chroma *= pixel_chroma_adjustment;
+    const float hyperbolic_chroma = 2.0f * chroma_vs_mapping_border / (1.0f - chroma_vs_mapping_border * chroma_vs_mapping_border + epsilon) * pixel_chroma_adjustment;
 
     const float hyperbolic_z = sqrtf(hyperbolic_chroma * hyperbolic_chroma + 1.0f);
     const float chroma_factor = hyperbolic_chroma / (1.0f + hyperbolic_z) * display_border_vs_chroma;
@@ -584,19 +584,19 @@ void gui_init(dt_iop_module_t *self)
   g->contrast_slider = dt_bauhaus_slider_from_params(self, "middle_grey_contrast");
   dt_bauhaus_slider_set_soft_range(g->contrast_slider, 0.7f, 3.0f);
   dt_bauhaus_slider_set_digits(g->contrast_slider, 3);
-  gtk_widget_set_tooltip_text(g->contrast_slider, _("Compression of the applied curve\n"
+  gtk_widget_set_tooltip_text(g->contrast_slider, _("compression of the applied curve\n"
                                                     "implicitly defines the supported input dynamic range."));
   g->skewness_slider = dt_bauhaus_slider_from_params(self, "contrast_skewness");
-  gtk_widget_set_tooltip_text(g->skewness_slider, _("Shift the compression towards shadows or highlights.\n"
-                                                    "Negative values increase contrast in shadows.\n"
-                                                    "Positive values increase contrast in highlights.\n"
-                                                    "The opposite end will see a reduction in contrast."));
+  gtk_widget_set_tooltip_text(g->skewness_slider, _("shift the compression towards shadows or highlights.\n"
+                                                    "negative values increase contrast in shadows.\n"
+                                                    "positive values increase contrast in highlights.\n"
+                                                    "the opposite end will see a reduction in contrast."));
 
   // Color handling
   g->color_processing_list = dt_bauhaus_combobox_from_params(self, "color_processing");
   g->hue_preservation_slider = dt_bauhaus_slider_from_params(self, "hue_preservation");
   dt_bauhaus_slider_set_format(g->hue_preservation_slider, "%");
-  gtk_widget_set_tooltip_text(g->hue_preservation_slider, _("Optional correction of the hue twist introduced by\n"
+  gtk_widget_set_tooltip_text(g->hue_preservation_slider, _("optional correction of the hue twist introduced by\n"
                                                             "the per-channel processing method."));
 
   // Target display
@@ -609,13 +609,13 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_soft_range(g->display_black_slider, 0.0f, 1.0f);
   dt_bauhaus_slider_set_digits(g->display_black_slider, 4);
   dt_bauhaus_slider_set_format(g->display_black_slider, "%");
-  gtk_widget_set_tooltip_text(g->display_black_slider, _("The black luminance of the target display or print.\n"
-                                                         "Can be used creatively for a faded look."));
+  gtk_widget_set_tooltip_text(g->display_black_slider, _("the black luminance of the target display or print.\n"
+                                                         "can be used creatively for a faded look."));
   g->display_white_slider = dt_bauhaus_slider_from_params(self, "display_white_target");
   dt_bauhaus_slider_set_soft_range(g->display_white_slider, 50.0f, 100.0f);
   dt_bauhaus_slider_set_format(g->display_white_slider, "%");
   gtk_widget_set_tooltip_text(g->display_white_slider, _("The white luminance of the target display or print.\n"
-                                                         "Can be used creatively for a faded look or blowing out whites earlier."));
+                                                         "can be used creatively for a faded look or blowing out whites earlier."));
 }
 
 void gui_cleanup(dt_iop_module_t *self)

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -52,7 +52,8 @@ typedef enum dt_iop_sigmoid_methods_type_t
   DT_SIGMOID_METHOD_CROSSTALK = 0,     // $DESCRIPTION: "crosstalk"
   DT_SIGMOID_METHOD_HUE = 1,           // $DESCRIPTION: "preserve hue"
   DT_SIGMOID_METHOD_RGB_RATIO = 2,     // $DESCRIPTION: "rgb ratio"
-  DT_SIGMOID_METHOD_INTERPOLATE = 3    // $DESCRIPTION: "interpolate"
+  DT_SIGMOID_METHOD_INTERPOLATE = 3,   // $DESCRIPTION: "interpolate"
+  DT_SIGMOID_METHOD_EXPERIMENTAL = 4   // $DESCRIPTION: "experimental"
 } dt_iop_sigmoid_methods_type_t;
 
 typedef enum dt_iop_sigmoid_negative_values_type_t
@@ -97,7 +98,7 @@ typedef struct dt_iop_sigmoid_params_t
   float display_black_target;  // $MIN: 0.0  $MAX: 10.0 $DEFAULT: 0.0152 $DESCRIPTION: "target black"
   dt_iop_sigmoid_methods_type_t color_processing;  // $DEFAULT: DT_SIGMOID_METHOD_HUE $DESCRIPTION: "color processing"
   float hue_preservation;                          // $MIN: 0.0 $MAX: 100.0 $DEFAULT: 100.0 $DESCRIPTION: "preserve hue"
-  float chroma_preservation;                       // $MIN: 0.0 $MAX: 100.0 $DEFAULT: 0.0 $DESCRIPTION: "preserve chroma"
+  float chroma_preservation;                       // $MIN: -200.0 $MAX: 300.0 $DEFAULT: 0.0 $DESCRIPTION: "preserve chroma"
   float crosstalk_amount;                          // $MIN: 0.0 $MAX: 100.0 $DEFAULT: 4.0 $DESCRIPTION: "crosstalk amount"
   dt_iop_sigmoid_norm_type_t rgb_norm_method;      // $DEFAULT: DT_SIGMOID_METHOD_AVERAGE $DESCRIPTION: "luminance norm"
   dt_iop_sigmoid_negative_values_type_t negative_values_method; // $DEFAULT: DT_SIGMOID_NEGATIVE_DESATURATE $DESCRIPTION: "negative values"
@@ -111,6 +112,8 @@ typedef struct dt_iop_sigmoid_data_t
   float film_fog;
   float film_power;
   float paper_power;
+  float preshaper_exposure;
+  float preshaper_power;
   dt_iop_sigmoid_methods_type_t color_processing;
   float hue_preservation;
   float chroma_preservation;
@@ -205,9 +208,23 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
    * Slope at scene_grey independet of skewness i.e. only changed by the contrast parameter.
    */
 
+  float ref_film_power;
+  if (params->color_processing == DT_SIGMOID_METHOD_EXPERIMENTAL)
+  {
+    const float neutral_contrast = 1.2f;
+    module_data->preshaper_power = powf(params->middle_grey_contrast / neutral_contrast, params->chroma_preservation / 100.0f);
+    module_data->preshaper_exposure = powf(MIDDLE_GREY, 1.0f - module_data->preshaper_power);
+    ref_film_power = params->middle_grey_contrast / module_data->preshaper_power;
+  }
+  else
+  {
+    module_data->preshaper_power = 1.0f;
+    module_data->preshaper_exposure = 1.0f;
+    ref_film_power = params->middle_grey_contrast;
+  }
+
   // Calculate a reference slope for no skew and a normalized display
   const float ref_paper_power = 1.0f;
-  const float ref_film_power = params->middle_grey_contrast;
   const float ref_magnitude = 1.0;
   const float ref_film_fog = 0.0f;
   const float ref_paper_exposure = powf(ref_film_fog + MIDDLE_GREY, ref_film_power) * ((ref_magnitude / MIDDLE_GREY) - 1.0f);
@@ -355,6 +372,16 @@ typedef struct dt_iop_sigmoid_value_order_t
   size_t mid;
   size_t max;
 } dt_iop_sigmoid_value_order_t;
+
+// Linear interpolation for both hue and chroma preservation
+// Assumes hue_preservation and chroma_presevation strictly in range [0, 1]
+static inline void preserve_hue_interpolated(const float pix_in[4], float pix_out[4], const dt_iop_sigmoid_value_order_t order, const float hue_preservation)
+{
+  // Hue correction of the middle channel
+  const float full_hue_correction = pix_out[order.min] + ((pix_out[order.max] - pix_out[order.min]) * (pix_in[order.mid] - pix_in[order.min]) / (pix_in[order.max] - pix_in[order.min]));
+  const float no_hue_correction = pix_out[order.mid];
+  pix_out[order.mid] = (1.0 - hue_preservation) * no_hue_correction + hue_preservation * full_hue_correction;
+}
 
 // Linear interpolation for both hue and chroma preservation
 // Assumes hue_preservation and chroma_presevation strictly in range [0, 1]
@@ -660,6 +687,109 @@ void process_loglogistic_interpolated(dt_dev_pixelpipe_iop_t *piece, const void 
   }
 }
 
+void process_loglogistic_experimental(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+                                      const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+  const dt_iop_sigmoid_data_t *module_data = (dt_iop_sigmoid_data_t *)piece->data;
+
+  const float *const in = (const float *)ivoid;
+  float *const out = (float *)ovoid;
+  const size_t npixels = (size_t)roi_in->width * roi_in->height;
+
+  const float white_target = module_data->white_target;
+  const float paper_exp = module_data->paper_exposure;
+  const float film_fog = module_data->film_fog;
+
+  const float contrast_power = module_data->film_power;
+  const float skew_power = module_data->paper_power;
+  const float preshaper_exposure = module_data->preshaper_exposure;
+  const float preshaper_power = module_data->preshaper_power;
+  const float saturation_factor = module_data->crosstalk_amount;
+  const float hue_preservation = module_data->hue_preservation;
+  
+  const dt_iop_sigmoid_negative_values_type_t negative_values_method = module_data->negative_values_method;
+  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
+  const dt_iop_sigmoid_norm_type_t rgb_norm_method = module_data->rgb_norm_method;
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(npixels, saturation_factor, negative_values_method, white_target, paper_exp, film_fog, preshaper_exposure, preshaper_power, contrast_power, skew_power, hue_preservation, work_profile, rgb_norm_method) \
+  dt_omp_sharedconst(in, out) \
+  schedule(static)
+#endif
+  for(size_t k = 0; k < 4 * npixels; k += 4)
+  {
+    const float *const restrict pix_in = in + k;
+    float *const restrict pix_out = out + k;
+    float DT_ALIGNED_ARRAY pix_in_strict_positive[4];
+    float DT_ALIGNED_ARRAY rgb_ratio[4];
+
+    // Force negative values to zero
+    negative_values(pix_in, pix_in_strict_positive, negative_values_method);
+
+    // Preserve color ratios by applying the tone curve on a luma estimate and then scale the RGB tripplet uniformly
+    const float scene_luma = get_pixel_norm(pix_in, rgb_norm_method, work_profile);
+    const float mapped_luma = preshaper_exposure * powf(scene_luma, preshaper_power);
+
+    const float scaling_factor = mapped_luma / scene_luma;
+    for(size_t c = 0; c < 3; c++)
+    {
+      rgb_ratio[c] = scaling_factor * pix_in[c];
+    }
+
+    // Desature a bit to get proper roll off to white in highlights
+    const float pixel_average = (rgb_ratio[0] + rgb_ratio[1] + rgb_ratio[2]) / 3.0f;
+    for(size_t c = 0; c < 3; c++)
+    {
+      const float desaturated_value = pixel_average + saturation_factor * (rgb_ratio[c] - pixel_average);
+      pix_out[c] = generalized_loglogistic_sigmoid(desaturated_value, white_target, paper_exp, film_fog, contrast_power, skew_power);
+    }
+
+        // Hue correction by scaling the middle value relative to the max and min values.
+    dt_iop_sigmoid_value_order_t pixel_value_order;
+
+    if (pix_in[0] >= pix_in[1])
+    {
+      if (pix_in[1] > pix_in[2])
+      {  // Case 1: r >= g >  b
+        pixel_value_order = (dt_iop_sigmoid_value_order_t) {.max = 0, .mid = 1, .min = 2};
+      }
+      else if (pix_in[2] > pix_in[0])
+      {  // Case 2: b >  r >= g
+        pixel_value_order = (dt_iop_sigmoid_value_order_t) {.max = 2, .mid = 0, .min = 1};
+      }
+      else if (pix_in[2] > pix_in[1])
+      {  // Case 3: r >= b >  g
+        pixel_value_order = (dt_iop_sigmoid_value_order_t) {.max = 0, .mid = 2, .min = 1};
+      } else
+      {  // Case 4: r == g == b
+        // No change of the middle value, just assign something.
+        pixel_value_order = (dt_iop_sigmoid_value_order_t) {.max = 0, .mid = 1, .min = 2};
+      }
+    }
+    else
+    {
+      if (pix_in[0] >= pix_in[2])
+      {  // Case 5: g >  r >= b
+        pixel_value_order = (dt_iop_sigmoid_value_order_t) {.max = 1, .mid = 0, .min = 2};
+      }
+      else if (pix_in[2] > pix_in[1])
+      {  // Case 6: b >  g >  r
+        pixel_value_order = (dt_iop_sigmoid_value_order_t) {.max = 2, .mid = 1, .min = 0};
+      }
+      else
+      {  // Case 7: g >= b >  r
+        pixel_value_order = (dt_iop_sigmoid_value_order_t) {.max = 1, .mid = 2, .min = 0};
+      }
+    }
+
+    preserve_hue_interpolated(pix_in, pix_out, pixel_value_order, hue_preservation);
+
+    // Copy over the alpha channel
+    pix_out[3] = pix_in[3];
+  }
+}
+
 /** process, all real work is done here. */
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
@@ -679,9 +809,13 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   {
     process_loglogistic_ratio(piece, ivoid, ovoid, roi_in, roi_out);
   }
-  else
+  else if (module_data->color_processing == DT_SIGMOID_METHOD_INTERPOLATE)
   {
     process_loglogistic_interpolated(piece, ivoid, ovoid, roi_in, roi_out);
+  }
+  else
+  {
+    process_loglogistic_experimental(piece, ivoid, ovoid, roi_in, roi_out);
   }
 }
 
@@ -725,9 +859,11 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
   gtk_widget_set_visible(g->crosstalk_slider, p->color_processing != DT_SIGMOID_METHOD_RGB_RATIO);
   gtk_widget_set_visible(g->negative_values_list, p->color_processing != DT_SIGMOID_METHOD_RGB_RATIO);
-  gtk_widget_set_visible(g->hue_preservation_slider, p->color_processing == DT_SIGMOID_METHOD_INTERPOLATE);
-  gtk_widget_set_visible(g->chroma_preservation_slider, p->color_processing == DT_SIGMOID_METHOD_INTERPOLATE);
-  gtk_widget_set_visible(g->rgb_norm_method_list, p->color_processing == DT_SIGMOID_METHOD_RGB_RATIO || p->color_processing == DT_SIGMOID_METHOD_INTERPOLATE);
+  gtk_widget_set_visible(g->hue_preservation_slider, p->color_processing == DT_SIGMOID_METHOD_INTERPOLATE || p->color_processing == DT_SIGMOID_METHOD_EXPERIMENTAL);
+  gtk_widget_set_visible(g->chroma_preservation_slider, p->color_processing == DT_SIGMOID_METHOD_INTERPOLATE || p->color_processing == DT_SIGMOID_METHOD_EXPERIMENTAL);
+  gtk_widget_set_visible(g->rgb_norm_method_list, p->color_processing == DT_SIGMOID_METHOD_RGB_RATIO
+                         || p->color_processing == DT_SIGMOID_METHOD_INTERPOLATE
+                         || p->color_processing == DT_SIGMOID_METHOD_EXPERIMENTAL);
 }
 
 void gui_update(dt_iop_module_t *self)
@@ -790,6 +926,7 @@ void gui_init(dt_iop_module_t *self)
   g->color_processing_list = dt_bauhaus_combobox_from_params(self, "color_processing");
   g->hue_preservation_slider = dt_bauhaus_slider_from_params(self, "hue_preservation");
   g->chroma_preservation_slider = dt_bauhaus_slider_from_params(self, "chroma_preservation");
+  dt_bauhaus_slider_set_soft_range(g->chroma_preservation_slider, 0.0f, 100.0f);
   // Cross talk option
   g->crosstalk_slider = dt_bauhaus_slider_from_params(self, "crosstalk_amount");
   dt_bauhaus_slider_set_soft_range(g->crosstalk_slider, 0.0f, 10.0f);

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -1,0 +1,329 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2010-2020 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+// our includes go first:
+#include "bauhaus/bauhaus.h"
+#include "common/rgb_norms.h"
+#include "develop/imageop.h"
+#include "develop/imageop_gui.h"
+#include "gui/color_picker_proxy.h"
+#include "gui/gtk.h"
+#include "iop/iop_api.h"
+
+#include <gtk/gtk.h>
+#include <stdlib.h>
+
+// To have your module compile and appear in darkroom, add it to CMakeLists.txt, with
+//  add_iop(sigmoid "sigmoid.c")
+// and to iop_order.c, in the initialisation of legacy_order & v30_order with:
+//  { {XX.0f }, "sigmoid", 0},
+
+// Module version number
+DT_MODULE_INTROSPECTION(1, dt_iop_sigmoid_params_t)
+
+
+// Enums used in params_t can have $DESCRIPTIONs that will be used to
+// automatically populate a combobox with dt_bauhaus_combobox_from_params.
+// They are also used in the history changes tooltip.
+// Combobox options will be presented in the same order as defined here.
+// These numbers must not be changed when a new version is introduced.
+typedef enum dt_iop_sigmoid_type_t
+{
+  DT_SIGMOID_LOGLOGISTIC = 0,  // $DESCRIPTION: "Log-Logisitic"
+  DT_SIGMOID_WEIBULL = 1,      // $DESCRIPTION: "Weibull"
+} dt_iop_sigmoid_type_t;
+
+#define MIDDLE_GREY 0.18f
+
+typedef struct dt_iop_sigmoid_params_t
+{
+  // The parameters defined here fully record the state of the module and are stored
+  // (as a serialized binary blob) into the db.
+  // Make sure everything is in here does not depend on temporary memory (pointers etc).
+  // This struct defines the layout of self->params and self->default_params.
+  // You should keep changes to this struct to a minimum.
+  // If you have to change this struct, it will break
+  // user data bases, and you have to increment the version
+  // of DT_MODULE_INTROSPECTION(VERSION) above and provide a legacy_params upgrade path!
+  //
+  // Tags in the comments get picked up by the introspection framework and are
+  // used in gui_init to set range and labels (for widgets and history)
+  // and value checks before commit_params.
+  // If no explicit init() is specified, the default implementation uses $DEFAULT tags
+  // to initialise self->default_params, which is then used in gui_init to set widget defaults.
+
+  float middle_grey_contrast;  // $MIN: 0.1 $MAX: 10.0 $DEFAULT: 1.4 $DESCRIPTION: "Contrast"
+  dt_iop_sigmoid_type_t cumulative_distribution;  // $DEFAULT: DT_SIGMOID_LOGLOGISTIC $DESCRIPTION: "Curve type"
+} dt_iop_sigmoid_params_t;
+
+typedef struct dt_iop_sigmoid_global_data_t
+{} dt_iop_sigmoid_global_data_t;
+
+typedef struct dt_iop_sigmoid_gui_data_t
+{
+  // Whatever you need to make your gui happy and provide access to widgets between gui_init, gui_update etc.
+  // Stored in self->gui_data while in darkroom.
+  // To permanently store per-user gui configuration settings, you could use dt_conf_set/_get.
+  GtkWidget *contrast_slider, *distribution_list;
+} dt_iop_sigmoid_gui_data_t;
+
+
+// this returns a translatable name
+const char *name()
+{
+  // make sure you put all your translatable strings into _() !
+  return _("sigmoid");
+}
+
+int flags()
+{
+  return IOP_FLAGS_SUPPORTS_BLENDING;
+}
+
+// where does it appear in the gui?
+int default_group()
+{
+  return IOP_GROUP_TONE | IOP_GROUP_TECHNICAL;
+}
+
+int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+{
+  return iop_cs_rgb;
+}
+
+// Whenever new fields are added to (or removed from) dt_iop_..._params_t or when their meaning
+// changes, a translation from the old to the new version must be added here.
+// A verbatim copy of the old struct definition should be copied into the routine with a _v?_t ending.
+// Since this will get very little future testing (because few developers still have very
+// old versions lying around) existing code should be changed as little as possible, if at all.
+//
+// Upgrading from an older version than the previous one should always go through all in between versions
+// (unless there was a bug) so that the end result will always be the same.
+//
+// Be careful with changes to structs that are included in _params_t
+//
+// Individually copy each existing field that is still in the new version. This is robust even if reordered.
+// If only new fields were added at the end, one call can be used:
+//   memcpy(n, o, sizeof *o);
+//
+// Hardcode the default values for new fields that were added, rather than referring to default_params;
+// in future, the field may not exist anymore or the default may change. The best default for a new version
+// to replicate a previous version might not be the optimal default for a fresh image.
+//
+// FIXME: the calling logic needs to be improved to call upgrades from consecutive version in sequence.
+int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
+                  void *new_params, const int new_version)
+{
+  return 1;
+}
+
+void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+{
+  memcpy(piece->data, p1, self->params_size);
+}
+
+
+static inline float rgb_luma(const float pixel[4], const dt_iop_order_iccprofile_info_t *const work_profile)
+{
+  return (work_profile)
+            ? dt_workprofile_rgb_luminance(pixel, work_profile->matrix_in)
+            : dt_camera_rgb_luminance(pixel);
+}
+
+void process_loglogistic(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+                         void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+  const dt_iop_sigmoid_params_t *d = (dt_iop_sigmoid_params_t *)piece->data;
+  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
+
+  const float *const in = (const float *)ivoid;
+  float *const out = (float *)ovoid;
+  const size_t npixels = (size_t)roi_in->width * roi_in->height;
+
+  const float power = d->middle_grey_contrast;
+  const float pivot = (1.0f - MIDDLE_GREY) / MIDDLE_GREY;
+  const float grey = MIDDLE_GREY;
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(npixels, work_profile, pivot, grey, power) \
+  dt_omp_sharedconst(in, out) \
+  schedule(static)
+#endif
+  for(size_t k = 0; k < 4*npixels; k += 4)
+  {
+    // Desature a bit to get proper roll off to white in highlights
+    // This is taken from the ACES RRT implementation
+    const float luma = rgb_luma(in + k, work_profile);
+    for(size_t c = 0; c < 3; c++)
+    {
+      const float desat = fmaxf(luma + 0.96f * (in[k + c] - luma), 0.0f);
+      out[k + c] = 1.0f - pivot / (pivot + powf(desat / grey, power));
+    }
+    // Copy over the alpha channel
+    out[k + 3] = in[k + 3];
+  }
+}
+
+void process_weibull(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+                         void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+  const dt_iop_sigmoid_params_t *d = (dt_iop_sigmoid_params_t *)piece->data;
+  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
+
+  const float *const in = (const float *)ivoid;
+  float *const out = (float *)ovoid;
+  const size_t npixels = (size_t)roi_in->width * roi_in->height;
+
+  const float power = 0.91f * d->middle_grey_contrast;
+  const float scale = MIDDLE_GREY / powf(-logf(1.0f - MIDDLE_GREY), 1.0f / power);
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(npixels, work_profile, scale, power) \
+  dt_omp_sharedconst(in, out) \
+  schedule(static)
+#endif
+  for(size_t k = 0; k < 4*npixels; k += 4)
+  {
+    // Desature a bit to get proper roll off to white in highlights
+    // This is taken from the ACES RRT implementation
+    const float luma = rgb_luma(in + k, work_profile);
+    for(size_t c = 0; c < 3; c++)
+    {
+      const float desat = fmaxf(luma + 0.96f * (in[k + c] - luma), 0.0f);
+      out[k + c] = 1.0f - expf(-powf(desat / scale, power));
+    }
+    // Copy over the alpha channel
+    out[k + 3] = in[k + 3];
+  }
+}
+
+/** process, all real work is done here. */
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+  // this is called for preview and full pipe separately, each with its own pixelpipe piece.
+  // get our data struct:
+  dt_iop_sigmoid_params_t *d = (dt_iop_sigmoid_params_t *)piece->data;
+  const dt_iop_sigmoid_type_t cdf_type = d->cumulative_distribution;
+
+  if (cdf_type == DT_SIGMOID_LOGLOGISTIC)
+  {
+    process_loglogistic(self, piece, ivoid, ovoid, roi_in, roi_out);
+  }
+  else
+  {
+    process_weibull(self, piece, ivoid, ovoid, roi_in, roi_out);
+  }
+}
+
+void init_global(dt_iop_module_so_t *module)
+{
+  module->data = malloc(sizeof(dt_iop_sigmoid_global_data_t));
+}
+
+void cleanup(dt_iop_module_t *module)
+{
+  // Releases any memory allocated in init(module)
+  // Implement this function explicitly if the module allocates additional memory besides (default_)params.
+  // this is rare.
+  free(module->params);
+  module->params = NULL;
+  free(module->default_params);
+  module->default_params = NULL;
+}
+
+void cleanup_global(dt_iop_module_so_t *module)
+{
+  free(module->data);
+  module->data = NULL;
+}
+
+void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
+{}
+
+void gui_update(dt_iop_module_t *self)
+{
+  dt_iop_sigmoid_gui_data_t *g = (dt_iop_sigmoid_gui_data_t *)self->gui_data;
+  dt_iop_sigmoid_params_t *p = (dt_iop_sigmoid_params_t *)self->params;
+
+  dt_bauhaus_slider_set(g->contrast_slider, p->middle_grey_contrast);
+  dt_bauhaus_combobox_set_from_value(g->distribution_list, p->cumulative_distribution);
+  gui_changed(self, NULL, NULL);
+}
+
+void gui_init(dt_iop_module_t *self)
+{
+  // Allocates memory for the module's user interface in the darkroom and
+  // sets up the widgets in it.
+  //
+  // self->widget needs to be set to the top level widget.
+  // This can be a (vertical) box, a grid or even a notebook. Modules that are
+  // disabled for certain types of images (for example non-raw) may use a stack
+  // where one of the pages contains just a label explaining why it is disabled.
+  //
+  // Widgets that are directly linked to a field in params_t may be set up using the
+  // dt_bauhaus_..._from_params family. They take a string with the field
+  // name in the params_t struct definition. The $MIN, $MAX and $DEFAULT tags will be
+  // used to set up the widget (slider) ranges and default values and the $DESCRIPTION
+  // is used as the widget label.
+  //
+  // The _from_params calls also set up an automatic callback that updates the field in params
+  // whenever the widget is changed. In addition, gui_changed is called, if it exists,
+  // so that any other required changes, to dependent fields or to gui widgets, can be made.
+  //
+  // Whenever self->params changes (switching images or history) the widget values have to
+  // be updated in gui_update.
+  //
+  // Do not set the value of widgets or configure them depending on field values here;
+  // this should be done in gui_update (or gui_changed or individual widget callbacks)
+  //
+  // If any default values for (slider) widgets or options (in comboboxes) depend on the
+  // type of image, then the widgets have to be updated in reload_params.
+  dt_iop_sigmoid_gui_data_t *g = IOP_GUI_ALLOC(sigmoid);
+  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+
+  g->contrast_slider = dt_bauhaus_slider_from_params(self, "middle_grey_contrast");
+  g->distribution_list = dt_bauhaus_combobox_from_params(self, "cumulative_distribution");
+}
+
+void gui_cleanup(dt_iop_module_t *self)
+{
+  // This only needs to be provided if gui_init allocates any memory or resources besides
+  // self->widget and gui_data_t. The default function (if an explicit one isn't provided here)
+  // takes care of gui_data_t (and gtk destroys the widget anyway). If you override the default,
+  // you have to do whatever you have to do, and also call IOP_GUI_FREE to clean up gui_data_t.
+
+  IOP_GUI_FREE;
+}
+
+/** additional, optional callbacks to capture darkroom center events. */
+// void gui_post_expose(dt_iop_module_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t pointerx,
+// int32_t pointery);
+// int mouse_moved(dt_iop_module_t *self, double x, double y, double pressure, int which);
+// int button_pressed(dt_iop_module_t *self, double x, double y, double pressure, int which, int type,
+// uint32_t state);
+// int button_released(struct dt_iop_module_t *self, double x, double y, int which, uint32_t state);
+// int scrolled(dt_iop_module_t *self, double x, double y, int up, uint32_t state);
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -377,7 +377,7 @@ void process_loglogistic_rgb_ratio(dt_dev_pixelpipe_iop_t *piece, const void *co
     const float display_border_vs_chroma_white = (white_target - mapped_luma) / (pixel_max - mapped_luma + epsilon); // "Distance" to max channel = white_target
     const float display_border_vs_chroma_black = (black_target - mapped_luma) / (pixel_min - mapped_luma - epsilon); // "Distance" to min_channel = black_target
     const float display_border_vs_chroma = fminf(display_border_vs_chroma_white, display_border_vs_chroma_black); 
-    const float chroma_vs_mapping_border = (mapped_luma - pixel_min) / mapped_luma; // "Distance" to min channel = 0.0
+    const float chroma_vs_mapping_border = (mapped_luma - pixel_min) / (mapped_luma + epsilon); // "Distance" to min channel = 0.0
 
     // Hyperbolic gamut compression
     // Small chroma values, i.e., colors close to the acromatic axis are preserved while large chroma values are compressed.

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -56,9 +56,10 @@ typedef enum dt_iop_sigmoid_methods_type_t
 typedef enum dt_iop_sigmoid_norm_type_t
 {
   DT_SIGMOID_METHOD_LUMINANCE = 0,      // $DESCRIPTION: "luminance Y"
-  DT_SIGMOID_METHOD_EUCLIDEAN_NORM = 1, // $DESCRIPTION: "RGB euclidean norm"
-  DT_SIGMOID_METHOD_POWER_NORM = 2,     // $DESCRIPTION: "RGB power norm"
-  DT_SIGMOID_METHOD_MAX_RGB = 3,        // $DESCRIPTION: "max RGB"
+  DT_SIGMOID_METHOD_AVERAGE = 1,        // $DESCRIPTION: "average"
+  DT_SIGMOID_METHOD_EUCLIDEAN_NORM = 2, // $DESCRIPTION: "RGB euclidean norm"
+  DT_SIGMOID_METHOD_POWER_NORM = 3,     // $DESCRIPTION: "RGB power norm"
+  DT_SIGMOID_METHOD_MAX_RGB = 4,        // $DESCRIPTION: "max RGB"
 } dt_iop_sigmoid_norm_type_t;
 
 #define MIDDLE_GREY 0.1845f
@@ -202,6 +203,9 @@ static inline float get_pixel_norm(const float pixel[4], const dt_iop_sigmoid_no
 
     case(DT_SIGMOID_METHOD_EUCLIDEAN_NORM):
       return sqrtf(sqf(pixel[0]) + sqf(pixel[1]) + sqf(pixel[2])) * INVERSE_SQRT_3;
+
+    case(DT_SIGMOID_METHOD_AVERAGE):
+      return (pixel[0] + pixel[1] + pixel[2]) / 3.0f;
 
     case(DT_SIGMOID_METHOD_LUMINANCE):
     default:

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -75,7 +75,7 @@ typedef struct dt_iop_sigmoid_params_t
   float contrast_skewness;     // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "skew"
   float display_white_target;  // $MIN: 20.0  $MAX: 1600.0 $DEFAULT: 100.0 $DESCRIPTION: "target white"
   float display_grey_target;   // $MIN: 0.1  $MAX: 0.2 $DEFAULT: 0.1845 $DESCRIPTION: "target grey"
-  float display_black_target;  // $MIN: 0.0  $MAX: 10.0 $DEFAULT: 0.0152 $DESCRIPTION: "target black"
+  float display_black_target;  // $MIN: 0.0  $MAX: 15.0 $DEFAULT: 0.0152 $DESCRIPTION: "target black"
   dt_iop_sigmoid_methods_type_t color_processing;  // $DEFAULT: DT_SIGMOID_METHOD_PER_CHANNEL $DESCRIPTION: "color processing"
   float hue_preservation;                          // $MIN: 0.0 $MAX: 100.0 $DEFAULT: 100.0 $DESCRIPTION: "preserve hue"
 } dt_iop_sigmoid_params_t;
@@ -729,7 +729,7 @@ void gui_init(dt_iop_module_t *self)
   // Color handling
   g->color_processing_list = dt_bauhaus_combobox_from_params(self, "color_processing");
   g->hue_preservation_slider = dt_bauhaus_slider_from_params(self, "hue_preservation");
-  dt_bauhaus_slider_set_format(g->hue_preservation_slider, "%.1f %%");
+  dt_bauhaus_slider_set_format(g->hue_preservation_slider, "%");
 
   // Target display
   GtkWidget *label = dt_ui_section_label_new(_("display luminance"));
@@ -739,12 +739,11 @@ void gui_init(dt_iop_module_t *self)
 
   g->display_black_slider = dt_bauhaus_slider_from_params(self, "display_black_target");
   dt_bauhaus_slider_set_soft_range(g->display_black_slider, 0.0f, 1.0f);
-  dt_bauhaus_slider_set_step(g->display_black_slider, .001);
   dt_bauhaus_slider_set_digits(g->display_black_slider, 4);
-  dt_bauhaus_slider_set_format(g->display_black_slider, "%.3f %%");
+  dt_bauhaus_slider_set_format(g->display_black_slider, "%");
   g->display_white_slider = dt_bauhaus_slider_from_params(self, "display_white_target");
   dt_bauhaus_slider_set_soft_range(g->display_white_slider, 50.0f, 100.0f);
-  dt_bauhaus_slider_set_format(g->display_white_slider, "%.1f %%");
+  dt_bauhaus_slider_set_format(g->display_white_slider, "%");
 }
 
 void gui_cleanup(dt_iop_module_t *self)

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -125,7 +125,7 @@ int default_group()
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  return iop_cs_rgb;
+  return IOP_CS_RGB;
 }
 
 // Whenever new fields are added to (or removed from) dt_iop_..._params_t or when their meaning

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -151,8 +151,8 @@ static inline float generalized_loglogistic_sigmoid(const float value, const flo
   // The following equation can be derived as a model for film + paper but it has a pole at 0
   // magnitude * powf(1.0 + paper_exp * powf(film_fog + value, -film_power), -paper_power);
   // Rewritten on a stable form including a check for negative values:
-  const float film_response = film_fog + value > 0.0f ? pow(film_fog + value, film_power) : 0.0f;
-  return magnitude * pow(film_response / (paper_exp + film_response), paper_power);
+  const float film_response = film_fog + value > 0.0f ? powf(film_fog + value, film_power) : 0.0f;
+  return magnitude * powf(film_response / (paper_exp + film_response), paper_power);
 }
 
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1577,6 +1577,7 @@ void init_presets(dt_lib_module_t *self)
   AM("levels");
   AM("rgbcurve");
   AM("rgblevels");
+  AM("sigmoid");
   AM("tonecurve");
 
   SMG(C_("modulegroup", "color"), "color");
@@ -1724,6 +1725,7 @@ void init_presets(dt_lib_module_t *self)
 
   SMG(C_("modulegroup", "base"), "basic");
   AM("filmicrgb");
+  AM("sigmoid");
   AM("toneequal");
   AM("crop");
   AM("ashift");


### PR DESCRIPTION
# What?
A new display transform module based on the Log-Logistic / Naka-Rushton curve with skew added for more control.
It is developed as a drop-in alternative to filmic with the same responsibility of compressing an infinite dynamic range to the finite dynamic range of a display or print.

Screenshot of the module interface:
<img width="184" alt="sigmoid_interface" src="https://user-images.githubusercontent.com/7957113/195997445-8d6c8989-43c2-4042-92fa-0404e57f3a24.png">

The process of developing and testing the module is documented in its pixls thread:
https://discuss.pixls.us/t/new-sigmoid-scene-to-display-mapping/22635

That thread is very long now. Here are some of the more important posts. I can especially recommend the three in **bold**.
* **Showing the effect of the skew parameter**: https://discuss.pixls.us/t/new-sigmoid-scene-to-display-mapping/22635/126
* Color processing with pictures: https://discuss.pixls.us/t/new-sigmoid-scene-to-display-mapping/22635/169
* Color processing with technical: https://discuss.pixls.us/t/new-sigmoid-scene-to-display-mapping/22635/181
* Desaturation at high intensities: https://discuss.pixls.us/t/new-sigmoid-scene-to-display-mapping/22635/279
* A post about editing chroma with the sigmoid contrast slider: https://discuss.pixls.us/t/new-sigmoid-scene-to-display-mapping/22635/359
* Preserve hue, problem statement: https://discuss.pixls.us/t/new-sigmoid-scene-to-display-mapping/22635/369
* Preserve hue, technical observation: https://discuss.pixls.us/t/new-sigmoid-scene-to-display-mapping/22635/378
* **Preserve hue, implemented solution**: https://discuss.pixls.us/t/new-sigmoid-scene-to-display-mapping/22635/386
* Method comparison, general: https://discuss.pixls.us/t/new-sigmoid-scene-to-display-mapping/22635/479
* **Method comparison, portraits**: https://discuss.pixls.us/t/new-sigmoid-scene-to-display-mapping/22635/503

The Naka-Rushton curve is the same curve but with the name used in human vision research. It is a model that describes the cone response for a light pulse compared to an adapted environment. This in itself is enough to get excited about the use of this sigmoid curve in image editing!

Please check out my curve testing "app" that I made for this project if you want to get to know the curve itself a bit more:
https://jandren-tone-curve-explorer-streamlit-app-xca32q.streamlitapp.com/

# How?
It uses a Generalized Log-Logistic curve applied either on work profile rgb channels or on the rgb average as an rgb ratio.
This essentially means that one applies another power function on the normal log-logistic curve, which will cause the distribution, or in our case, the contrast, to skew towards shadows or highlights. Some behind-the-scenes manipulation is performed to keep the effect of the UI parameters orthogonal to each other. (The slope at middle grey with skew = 0 is maintained for all skew values). See the above-linked posts for more in-depth analysis and explanations. 

# Why a new module?
And why not integrate the new curve in filmic:
1. filmic depends heavily on the definition of a scene black and white point. The sigmoid curve is defined from 0 to inf, so there is no such concept as a scene black and white, just relative exposure to middle grey. It would thus be hard to make it work inside of filmic without redoing/removing both some functionality and UI elements.
2. I have tried to keep the proposed sigmoid module conceptually different from filmic by keeping it simple and robust instead of super configurable. I would like to continue exploring that path for a display transform further, as I believe that makes a tool fast to work with.

Some strengths of the module are that it is:
* Robust, always properly defined for any rgb value [0, inf).
* Always monotonic. The curve used for the mapping is, by design always monotonic.
* Very smooth, the curve is parametric and converges towards the display boundaries.
* Only two parameters while maintaining full control of the curve shape.
* Contrast and skew are orthogonal, making it very easy to work with.
* Future proof, it can, for example, model the ACES 1000 nits curve pretty well as it is.

# Future work
### Needed
* The contributed code only offers a C implementation. Optimized code paths need to be implemented as well.
* Documentation!

To be contributed if the module is accepted.

### Wanted
* Explicit selection of processing primaries instead of just using the work profile. (Has the greatest effect on the end result when not using hue preservation).
* Adjustable sharpness of gamut clipping/compression. The module currently clips out of gamut chroma to the rgb scene boundary before applying the display transform. There is interesting work to be done here where we can reuse the concept of a sigmoid curve but in the gamut direction. See, for example, the AgX discussion over at the Blender forum: https://blenderartists.org/t/feedback-development-filmic-baby-step-to-a-v2/1361663/1203

Both of these are extensions of functionality and can be added later without any backward compatibility problems. I agree with the feedback that @TurboGit has given me that these are better to tackle in separate PRs.

# Example images
(Taken from the threads linked above)
![IMG_7102](https://user-images.githubusercontent.com/7957113/196002572-bc8db5bd-3ee1-41bc-b3df-c359ee8992e4.jpg)
![IMG_8248](https://user-images.githubusercontent.com/7957113/196002589-7d9e46de-4a3f-4a72-9022-a0ad809845aa.jpg)
![IMG_2884](https://user-images.githubusercontent.com/7957113/196002686-9b26b36f-d4cb-46ef-85c3-8afbf811e13a.jpg)
![IMG_9203](https://user-images.githubusercontent.com/7957113/196002712-67221859-863a-4f7e-8f11-3f322e212091.jpg)
![IMG_6872](https://user-images.githubusercontent.com/7957113/196002789-ad29f999-2e9f-47d9-be2b-14114c82b3eb.jpg)
![SunsetColors](https://user-images.githubusercontent.com/7957113/196002997-fec7b4aa-d870-4ba9-ba05-5008bd2e19e5.jpg)
