### PR TITLE
Make "inpaint opposed" and "segmentation" hl reconstruction ROI immune

### DIFF
--- a/src/iop/hlrecovery_v2.c
+++ b/src/iop/hlrecovery_v2.c
@@ -85,7 +85,7 @@ The chosen segmentation algorithm works like this:
 
 #define HL_RGB_PLANES 3
 #define HL_SEGMENT_PLANES 4
-#define HL_FLOAT_PLANES 9
+#define HL_FLOAT_PLANES 8
 #define HL_BORDER 8
 
 #include "iop/segmentation.h"
@@ -115,7 +115,7 @@ static float _calc_weight(const float *s, const size_t loc, const int w, const f
   for(int y = -1; y < 2; y++)
   {
     for(int x = -1; x < 2; x++)
-      val += s[loc + y*w + x] * 0.11111f;
+      val += s[loc + y*w + x] / 9.0f;
   }
   const float sval = fmaxf(1.0f, powf(fminf(clipval, val) / clipval, 2.0f));
   return sval * smoothness;
@@ -573,11 +573,11 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
     }
   }
 
-  float *restrict distance  = plane[HL_SEGMENT_PLANES];
-  float *restrict gradient  = plane[HL_SEGMENT_PLANES + 1];
-  float *restrict luminance = plane[HL_SEGMENT_PLANES + 2];
-  float *restrict recout    = plane[HL_SEGMENT_PLANES + 3];
-  float *restrict tmp       = plane[HL_SEGMENT_PLANES + 4];
+  float *restrict distance  = plane[HL_RGB_PLANES];
+  float *restrict gradient  = plane[HL_RGB_PLANES + 1];
+  float *restrict luminance = plane[HL_RGB_PLANES + 2];
+  float *restrict recout    = plane[HL_RGB_PLANES + 3];
+  float *restrict tmp       = plane[HL_RGB_PLANES + 4];
 
   const gboolean do_recovery = (recovery_mode != DT_RECOVERY_MODE_OFF) && has_allclipped && (strength > 0.0f);
   if(do_recovery || (vmode != DT_SEGMENTS_MASK_OFF))

--- a/src/iop/hlrecovery_v2.c
+++ b/src/iop/hlrecovery_v2.c
@@ -663,6 +663,19 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
     }
   }
 
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(ovoid, tmpout, roi_in, roi_out) \
+  schedule(static)
+#endif
+  for(int row = 0; row < roi_out->height; row++)
+  {
+    float *out = (float *)ovoid + (size_t)roi_out->width * row;
+    float *in = tmpout + (size_t)roi_in->width * (row + roi_out->y) + roi_out->x;
+    for(int col = 0; col < roi_out->width; col++)
+      out[col] = in[col];
+  }
+
   if((vmode != DT_SEGMENTS_MASK_OFF) && fullpipe)
   {
 #ifdef _OPENMP
@@ -695,21 +708,6 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
         out++;
         in++;
       }
-    }
-  }
-  else
-  {
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ovoid, tmpout, roi_in, roi_out) \
-  schedule(static)
-#endif
-    for(int row = 0; row < roi_out->height; row++)
-    {
-      float *out = (float *)ovoid + (size_t)roi_out->width * row;
-      float *in = tmpout + (size_t)roi_in->width * (row + roi_out->y) + roi_out->x;
-      for(int col = 0; col < roi_out->width; col++)
-        out[col] = in[col];
     }
   }
 

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -139,8 +139,8 @@ static float * _process_linear_opposed(dt_dev_pixelpipe_iop_t *piece, const void
     memcpy(mask, tmp, p_size * sizeof(int));
   }
 
-  double cr_sum[4] = {0.0, 0.0, 0.0, 0.0};
-  double cr_cnt[4] = {0.0, 0.0, 0.0, 0.0};
+  dt_aligned_pixel_t cr_sum = {0.0f, 0.0f, 0.0f, 0.0f};
+  dt_aligned_pixel_t cr_cnt = {0.0f, 0.0f, 0.0f, 0.0f};
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(ivoid, roi_in, clips, clipdark, mask_buffer) \
@@ -158,8 +158,8 @@ static float * _process_linear_opposed(dt_dev_pixelpipe_iop_t *piece, const void
         const float inval = fmaxf(0.0f, in[c]); 
         if((mask_buffer[c * p_size + _raw_to_plane(pwidth, row, col)]) && (inval > clipdark[c]) && (inval < clips[c]))
         {
-          cr_sum[c] += (double) (inval - _calc_linear_refavg(&in[0], row, col, roi_in, c));
-          cr_cnt[c] += 1.0;
+          cr_sum[c] += inval - _calc_linear_refavg(&in[0], row, col, roi_in, c);
+          cr_cnt[c] += 1.0f;
         }
       }
       in += 4;
@@ -299,8 +299,8 @@ static float *_process_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const 
   }
 
   /* After having the surrounding mask for each color channel we can calculate the chrominance corrections. */ 
-  double cr_sum[4] = {0.0, 0.0, 0.0, 0.0};
-  double cr_cnt[4] = {0.0, 0.0, 0.0, 0.0};
+  dt_aligned_pixel_t cr_sum = {0.0f, 0.0f, 0.0f, 0.0f};
+  dt_aligned_pixel_t cr_cnt = {0.0f, 0.0f, 0.0f, 0.0f};
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(ivoid, roi_in, xtrans, clips, clipdark, mask_buffer) \
@@ -319,8 +319,8 @@ static float *_process_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const 
          to calculate the chrominance offset */
       if((mask_buffer[color * p_size + _raw_to_plane(pwidth, row, col)]) && (inval > clipdark[color]) && (inval < clips[color]))
       {
-        cr_sum[color] += (double) (inval - _calc_refavg(&in[0], xtrans, filters, row, col, roi_in, TRUE));
-        cr_cnt[color] += 1.0;
+        cr_sum[color] += inval - _calc_refavg(&in[0], xtrans, filters, row, col, roi_in, TRUE);
+        cr_cnt[color] += 1.0f;
       }
       in++;
     }

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -71,7 +71,8 @@ static float * _process_linear_opposed(dt_dev_pixelpipe_iop_t *piece, const void
   const size_t p_size = (size_t) dt_round_size(pwidth * pheight, 16);
 
   int *mask_buffer = dt_calloc_align(64, 4 * p_size * sizeof(int));
-  float *tmpout = dt_alloc_align_float(roi_in->width * roi_in->height * 8);
+  const size_t bsize = (4 + MAX(roi_in->width + roi_in->x, roi_out->width + roi_out->x)) * (4 + MAX(roi_in->height + roi_in->y, roi_out->height + roi_out->y)); 
+  float *tmpout = dt_alloc_align_float(4 * bsize);
 
   // make sure date are fully copied in case of an early exit
 #ifdef _OPENMP
@@ -235,7 +236,8 @@ static float *_process_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const 
   const size_t p_size = (size_t) dt_round_size(pwidth * pheight, 16);
 
   int *mask_buffer = dt_calloc_align(64, 4 * p_size * sizeof(int));
-  float *tmpout = dt_alloc_align_float(roi_in->width * roi_in->height * 2);
+  const size_t bsize = (4 + MAX(roi_in->width + roi_in->x, roi_out->width + roi_out->x)) * (4 + MAX(roi_in->height + roi_in->y, roi_out->height + roi_out->y)); 
+  float *tmpout = dt_alloc_align_float(bsize);
 
   // make sure date are fully copied in case of an early exit
 #ifdef _OPENMP


### PR DESCRIPTION
Both algorithms require global data per design, this until now lead to a different output while zooming in leading to possibly not-so-easy control of effects.

This pr is a redesign with some required changes and refactoring, in effect it expands the ROI_IN to full image data and writes correct data at the end of the algos.

The visual output stability for inpaint opposed might not be so obvious for most images, for segmentation the new code is crucial.

The color and segmentation maths dis not change at all.
1. inpaint opposed is supported for bayer, xtrans and sraw
2. segmentation based only for true raws (bayer and xtrans)

This leads to a measurable performance penalty - mostly not to be recognized in darkroom as the data in demosaicer module is cached with importance in the pixelpipe cache.

I experimented with linear raws (sraw) for segmentation too - the whole code is prepared to do that - but i simply don't have enough test images to be sure it's perfect.