### PR TITLE
Support for regional date and time format in thumbnail tooltips.

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1281,7 +1281,7 @@
   <dtconfig prefs="lighttable" section="thumbs">
     <name>plugins/lighttable/thumbnail_tooltip_pattern</name>
     <type>longstring</type>
-    <default>&lt;b&gt;$(FILE_NAME).$(FILE_EXTENSION)&lt;/b&gt;$(NL)$(EXIF_DAY)/$(EXIF_MONTH)/$(EXIF_YEAR) $(EXIF_HOUR):$(EXIF_MINUTE):$(EXIF_SECOND)$(NL)$(EXIF_EXPOSURE) • f/$(EXIF_APERTURE) • $(EXIF_FOCAL_LENGTH) mm • $(EXIF_ISO) ISO</default>
+    <default>&lt;b&gt;$(FILE_NAME).$(FILE_EXTENSION)&lt;/b&gt;$(NL)$(EXIF.DATE.REGIONAL) $(EXIF.TIME.REGIONAL)$(NL)$(EXIF_EXPOSURE) • f/$(EXIF_APERTURE) • $(EXIF_FOCAL_LENGTH) mm • $(EXIF_ISO) ISO</default>
     <shortdescription>pattern for the thumbnail tooltip (empty to disable)</shortdescription>
     <longdescription>see manual to know all the tags you can use.</longdescription>
   </dtconfig>

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -296,6 +296,10 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
     result = g_strdup(exif_datetime);
   }
 
+  else if(_has_prefix(variable, "EXIF.DATE.REGIONAL"))
+    result = g_date_time_format(datetime, "%x");
+  else if(_has_prefix(variable, "EXIF.TIME.REGIONAL"))
+    result = g_date_time_format(datetime, "%X");
   else if(_has_prefix(variable, "EXIF.YEAR.SHORT") || _has_prefix(variable, "EXIF.DATE.SHORT_YEAR"))
     result = g_date_time_format(datetime, "%y");
   else if(_has_prefix(variable, "EXIF.YEAR") || _has_prefix(variable, "EXIF_YEAR") || _has_prefix(variable, "EXIF.DATE.LONG_YEAR"))


### PR DESCRIPTION
Resolves #10763.

I'm not sticking to my choice of variable name here and I won't claim that I chose the best option. This is a case where I will not insist on my version, but will gladly make corrections if they make more sense.

The word "localized" in the name seems quite suitable to me, the only thing is that this word itself has a double spelling. On the other hand, spelling with -ize is also acceptable in British English, except that it is used less often.
