### PR TITLE
fix natural width of labelless combo

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2322,9 +2322,12 @@ static gint _bauhaus_natural_width(GtkWidget *widget, gboolean popup)
   pango_layout_set_attributes(layout, attrlist);
   pango_attr_list_unref(attrlist);
 
-  pango_layout_set_text(layout, w->label, -1);
-  pango_layout_get_size(layout, &natural_size, NULL);
-  natural_size /= PANGO_SCALE;
+  if(w->show_label || w->detached_popup)
+  {
+    pango_layout_set_text(layout, w->label, -1);
+    pango_layout_get_size(layout, &natural_size, NULL);
+    natural_size /= PANGO_SCALE;
+  }
 
   if(w->type == DT_BAUHAUS_COMBOBOX)
   {
@@ -2354,11 +2357,14 @@ static gint _bauhaus_natural_width(GtkWidget *widget, gboolean popup)
   else
   {
     gint number_width = 0;
-    char *text = dt_bauhaus_slider_get_text(widget, dt_bauhaus_slider_get(widget));
+    char *max = dt_bauhaus_slider_get_text(widget, w->data.slider.max);
+    char *min = dt_bauhaus_slider_get_text(widget, w->data.slider.min);
+    char *text = strlen(max) >= strlen(min) ? max : min;
     pango_layout_set_text(layout, text, -1);
     pango_layout_get_size(layout, &number_width, NULL);
     natural_size += 2 * INNER_PADDING + number_width / PANGO_SCALE;
-    g_free(text);
+    g_free(max);
+    g_free(min);
   }
 
   _margins_retrieve(w);


### PR DESCRIPTION
fixes #12657

Don't take the width of the label into account, when calculating the minimum width needed for a combobox, when it is not shown anyway.

This attempts to include the width of the label when the combo popup is shown disconnected from its widget, because it was called via a shortcut, but the `detached_popup` variable does not get set in time. So the popup will be too narrow and the label, which is printed on a separate line, gets ellipsized.
![image](https://user-images.githubusercontent.com/1549490/196310789-c39630ae-78a7-4437-9978-dd93cde635ca.png)
This needs to be fixed in `dt_bauhaus_show_popup`, but I don't particularly enjoy looking at that piece of code again. Maybe @AlicVB wants to give it a go?

There's also a small change here for the natural width calculation of sliders, which makes it less likely that the slider label gets ellipsized when you reach the min or max if you play around with https://github.com/darktable-org/darktable/pull/9015#issuecomment-1280095211