### PR TITLE
Fix ROI calculations for hl opposed and segmentation

### DIFF
--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -2014,14 +2014,10 @@ void modify_roi_out(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, dt_iop
     return;
 
   *roi_out = *roi_in;
-  roi_out->width = roi_in->width;
-  roi_out->height = roi_in->height;
-  roi_out->x = roi_in->x;
-  roi_out->y = roi_in->y;
-
-  // sanity check.
-  if(roi_out->x < 0) roi_out->x = 0;
-  if(roi_out->y < 0) roi_out->y = 0;
+  roi_out->x = MAX(roi_in->x, 0);
+  roi_out->y = MAX(roi_in->y, 0);
+  roi_out->width = MIN(roi_in->width-6, piece->buf_in.width);
+  roi_out->height = MIN(roi_in->height-6, piece->buf_in.height);
 }
 
 // 2nd pass: which roi would this operation need as input to fill the given output region?

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -2000,7 +2000,7 @@ static void process_visualize(dt_dev_pixelpipe_iop_t *piece, const void *const i
 
 /* inpaint opposed and segmentation based algorithms want the whole image for proper calculation
    of chrominance correction and best candidates so we change both rois.
-   1st pass: how large would the output be, given this input roi?
+   we're not scaling here so just crop borders
 */
 void modify_roi_out(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t *roi_out,
                     const dt_iop_roi_t *const roi_in)
@@ -2014,10 +2014,12 @@ void modify_roi_out(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, dt_iop
     return;
 
   *roi_out = *roi_in;
-  roi_out->x = MAX(roi_in->x, 0);
-  roi_out->y = MAX(roi_in->y, 0);
-  roi_out->width = MIN(roi_in->width-6, piece->buf_in.width);
-  roi_out->height = MIN(roi_in->height-6, piece->buf_in.height);
+ 
+  roi_out->x = MAX(0, roi_in->x);
+  roi_out->y = MAX(0, roi_in->y);
+ // fprintf(stderr, "[%s] in %f out %f iscale %f \n", dt_dev_pixelpipe_type_to_str(piece->pipe->type), roi_in->scale, roi_out->scale, piece->iscale);
+  roi_out->width = roi_in->width;
+  roi_out->height = roi_in->height;
 }
 
 // 2nd pass: which roi would this operation need as input to fill the given output region?

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -71,8 +71,7 @@ static float * _process_linear_opposed(dt_dev_pixelpipe_iop_t *piece, const void
   const size_t p_size = (size_t) dt_round_size(pwidth * pheight, 16);
 
   int *mask_buffer = dt_calloc_align(64, 4 * p_size * sizeof(int));
-  const size_t bsize = (4 + MAX(roi_in->width + roi_in->x, roi_out->width + roi_out->x)) * (4 + MAX(roi_in->height + roi_in->y, roi_out->height + roi_out->y)); 
-  float *tmpout = dt_alloc_align_float(4 * bsize);
+  float *tmpout = dt_alloc_align_float(8 * roi_in->width * roi_in->height);
 
   // make sure date are fully copied in case of an early exit
 #ifdef _OPENMP
@@ -236,8 +235,8 @@ static float *_process_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const 
   const size_t p_size = (size_t) dt_round_size(pwidth * pheight, 16);
 
   int *mask_buffer = dt_calloc_align(64, 4 * p_size * sizeof(int));
-  const size_t bsize = (4 + MAX(roi_in->width + roi_in->x, roi_out->width + roi_out->x)) * (4 + MAX(roi_in->height + roi_in->y, roi_out->height + roi_out->y)); 
-  float *tmpout = dt_alloc_align_float(bsize);
+  float *tmpout = dt_alloc_align_float(2 * roi_in->width * roi_in->height);
+//  fprintf(stderr, "[opposed] IMG: ROI_X %i/%i ROI_Y %i/%i WIDTH %i/%i %i HEIGHT %i %i %i\n", roi_in->x, roi_out->x, roi_in->y, roi_out->y, roi_in->width, roi_out->width, piece->buf_in.width, roi_in->height, roi_out->height, piece->buf_in.height);
 
   // make sure date are fully copied in case of an early exit
 #ifdef _OPENMP
@@ -254,7 +253,6 @@ static float *_process_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const 
   }
 
   if(!tmpout || !mask_buffer) goto error;
-
   gboolean anyclipped = FALSE;
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \


### PR DESCRIPTION
As reported in #12667 there were crashed in opposed code due to incorrect ROI calculations.
Should be fixed now.

@TurboGit and maybe @AlicVB the correction of ROIs is something i never touched before.

The idea here is:
1. We need the full image are defined as roi_in
2. I am not sure about better way for roi_out. The code loops through roi_out->width and height of course.
3. I checked all xtrans images and i found more with issues, they were all related to this problem and sort-of-fixed now, The reason seems to be we don't align as in bayers thus some rounding taking place?