### PR TITLE
po/fix style shortcut

### DIFF
--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -97,8 +97,19 @@ void dt_style_item_free(gpointer data)
 
 static void _apply_style_shortcut_callback(dt_action_t *action)
 {
+  const dt_view_t *v = dt_view_manager_get_current_view(darktable.view_manager);
   GList *imgs = dt_act_on_get_images(TRUE, TRUE, FALSE);
-  dt_styles_apply_to_list(action->label, imgs, FALSE);
+
+  if(v->view(v) == DT_VIEW_DARKROOM)
+  {
+    const int32_t imgid = GPOINTER_TO_INT(imgs->data);
+    dt_styles_apply_to_dev(action->label, imgid);
+  }
+  else
+  {
+    dt_styles_apply_to_list(action->label, imgs, FALSE);
+  }
+
   g_list_free(imgs);
 }
 

--- a/src/common/styles.h
+++ b/src/common/styles.h
@@ -88,6 +88,10 @@ void dt_styles_apply_style_item(dt_develop_t *dev, dt_style_item_t *style_item, 
 /** applies the style to image by imgid, takes care of overwrite and duplicate modes */
 void dt_styles_apply_to_image(const char *name, const gboolean duplicate, const gboolean overwrite, const int32_t imgid);
 
+/** applies the style to the currently edited image in the darkroom.
+    does nothing if not called with a proper dev struct initialized */
+void dt_styles_apply_to_dev(const char *name, const int32_t imgid);
+
 /** delete a style by name */
 void dt_styles_delete_by_name_adv(const char *name, const gboolean raise);
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1345,23 +1345,11 @@ static void _darkroom_ui_favorite_presets_popupmenu(GtkWidget *w, gpointer user_
     dt_control_log(_("no userdefined presets for favorite modules were found"));
 }
 
-static void _darkroom_ui_apply_style_activate_callback(gchar *name)
+static void _darkroom_ui_apply_style_activate_callback(const gchar *name)
 {
   dt_control_log(_("applied style `%s' on current image"), name);
 
-  /* write current history changes so nothing gets lost */
-  dt_dev_write_history(darktable.develop);
-
-  dt_dev_undo_start_record(darktable.develop);
-
-  /* apply style on image and reload*/
-  dt_styles_apply_to_image(name, FALSE, FALSE, darktable.develop->image_storage.id);
-  dt_dev_reload_image(darktable.develop, darktable.develop->image_storage.id);
-
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
-
-  /* record current history state : after change (needed for undo) */
-  dt_dev_undo_end_record(darktable.develop);
+  dt_styles_apply_to_dev(name, darktable.develop->image_storage.id);
 
   // rebuild the accelerators (style might have changed order)
   dt_iop_connect_accels_all();


### PR DESCRIPTION
Fix styles applied via a shorcut in darkroom.

Fixes #10639.

I put a high priority as during my testing I have been able to have broken images and/or crash using the undo. 