### PR TITLE
Introduce ROI debugging helpers

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -131,7 +131,7 @@ static int usage(const char *argv0)
   printf("  --configdir <user config directory>\n");
   printf("  -d {all,act_on,cache,camctl,camsupport,control,demosaic,dev,imageio,\n");
   printf("      input,ioporder,lighttable,lua,masks,memory,nan,opencl,params,\n");
-  printf("      perf,print,pwstorage,signal,sql,tiling,undo,verbose}\n");
+  printf("      perf,print,pwstorage,signal,sql,tiling,undo,verbose,roi}\n");
   printf("  --d-signal <signal> \n");
   printf("  --d-signal-act <all,raise,connect,disconnect");
   // clang-format on
@@ -695,6 +695,8 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
           darktable.unmuted |= DT_DEBUG_TILING;
         else if(!strcmp(argv[k + 1], "verbose"))
           darktable.unmuted |= DT_DEBUG_VERBOSE;
+        else if(!strcmp(argv[k + 1], "roi"))
+          darktable.unmuted |= DT_DEBUG_ROI;
         else
           return usage(argv[0]);
         k++;

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -272,7 +272,8 @@ typedef enum dt_debug_thread_t
   DT_DEBUG_DEMOSAIC       = 1 << 22,
   DT_DEBUG_ACT_ON         = 1 << 23,
   DT_DEBUG_TILING         = 1 << 24,
-  DT_DEBUG_VERBOSE        = 1 << 25
+  DT_DEBUG_VERBOSE        = 1 << 25,
+  DT_DEBUG_ROI            = 1 << 26
 } dt_debug_thread_t;
 
 typedef struct dt_codepath_t

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -981,6 +981,9 @@ static int pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev,
   /* process module on cpu. use tiling if needed and possible. */
   if(!fitting && piece->process_tiling_ready)
   {
+    dt_print(DT_DEBUG_ROI, "[process TILE]%17s %16s. IN (%4i/%4i) %4ix%4i scale=%.2f. OUT (%4i/%4i) %4ix%4i scale=%.2f\n", 
+        dt_dev_pixelpipe_type_to_str(piece->pipe->type), module->so->op, roi_in->x, roi_in->y, roi_in->width, roi_in->height, roi_in->scale,
+        roi_out->x, roi_out->y, roi_out->width, roi_out->height, roi_out->scale);
     module->process_tiling(module, piece, input, *output, roi_in, roi_out, in_bpp);
     *pixelpipe_flow |= (PIXELPIPE_FLOW_PROCESSED_ON_CPU | PIXELPIPE_FLOW_PROCESSED_WITH_TILING);
     *pixelpipe_flow &= ~(PIXELPIPE_FLOW_PROCESSED_ON_GPU);
@@ -990,6 +993,10 @@ static int pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev,
     if(!fitting)
       fprintf(stderr, "[pixelpipe_process_on_CPU] [%s] Warning: processes `%s' without tiling even if memory requirements are not met\n",
         dt_dev_pixelpipe_type_to_str(pipe->type), module->op); 
+
+    dt_print(DT_DEBUG_ROI, "[process CPU]%15s %16s. IN (%4i/%4i) %4ix%4i scale=%.2f. OUT (%4i/%4i) %4ix%4i scale=%.2f\n", 
+        dt_dev_pixelpipe_type_to_str(piece->pipe->type), module->so->op, roi_in->x, roi_in->y, roi_in->width, roi_in->height, roi_in->scale,
+        roi_out->x, roi_out->y, roi_out->width, roi_out->height, roi_out->scale);
 
     module->process(module, piece, input, *output, roi_in, roi_out);
     *pixelpipe_flow |= (PIXELPIPE_FLOW_PROCESSED_ON_CPU);
@@ -1225,8 +1232,13 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
   {
     return 1;
   }
+  dt_print(DT_DEBUG_ROI, "[modify roi IN] %12s %16s.    (%4i/%4i) %4ix%4i scale=%.2f",
+    dt_dev_pixelpipe_type_to_str(piece->pipe->type), module->so->op, roi_in.x, roi_in.y, roi_in.width, roi_in.height, roi_in.scale);
+
   module->modify_roi_in(module, piece, roi_out, &roi_in);
 
+  dt_print_nts(DT_DEBUG_ROI, "  --> (%4i/%4i) %4ix%4i scale=%.2f\n",
+    roi_in.x, roi_in.y, roi_in.width, roi_in.height, roi_in.scale);
   // recurse to get actual data of input buffer
 
   dt_iop_buffer_dsc_t _input_format = { 0 };
@@ -1515,8 +1527,11 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
         /* now call process_cl of module; module should emit meaningful messages in case of error */
         if(success_opencl)
         {
-          success_opencl
-              = module->process_cl(module, piece, cl_mem_input, *cl_mem_output, &roi_in, roi_out);
+          dt_print(DT_DEBUG_ROI, "[process CL]%16s %16s. IN (%4i/%4i) %4ix%4i scale=%.2f. OUT (%4i/%4i) %4ix%4i scale=%.2f\n", 
+              dt_dev_pixelpipe_type_to_str(piece->pipe->type), module->so->op, roi_in.x, roi_in.y, roi_in.width, roi_in.height, roi_in.scale,
+              roi_out->x, roi_out->y, roi_out->width, roi_out->height, roi_out->scale);
+
+          success_opencl = module->process_cl(module, piece, cl_mem_input, *cl_mem_output, &roi_in, roi_out);
           pixelpipe_flow |= (PIXELPIPE_FLOW_PROCESSED_ON_GPU);
           pixelpipe_flow &= ~(PIXELPIPE_FLOW_PROCESSED_ON_CPU | PIXELPIPE_FLOW_PROCESSED_WITH_TILING);
 
@@ -2310,7 +2325,11 @@ void dt_dev_pixelpipe_get_dimensions(dt_dev_pixelpipe_t *pipe, struct dt_develop
        && !(dev->gui_module && dev->gui_module != module
             && dev->gui_module->operation_tags_filter() & module->operation_tags()))
     {
+      dt_print(DT_DEBUG_ROI, "[modify roi OUT]%12s %16s.    (%4i/%4i) %4ix%4i scale=%.2f",
+        dt_dev_pixelpipe_type_to_str(piece->pipe->type), module->so->op, roi_in.x, roi_in.y, roi_in.width, roi_in.height, roi_in.scale);
       module->modify_roi_out(module, piece, &roi_out, &roi_in);
+      dt_print_nts(DT_DEBUG_ROI, "  --> (%4i/%4i) %4i*%4i scale=%.2f\n",
+        roi_in.x, roi_in.y, roi_in.width, roi_in.height, roi_in.scale);
     }
     else
     {

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -981,7 +981,7 @@ static int pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev,
   /* process module on cpu. use tiling if needed and possible. */
   if(!fitting && piece->process_tiling_ready)
   {
-    dt_print(DT_DEBUG_ROI, "[process TILE]%17s %16s. IN (%4i/%4i) %4ix%4i scale=%.2f. OUT (%4i/%4i) %4ix%4i scale=%.2f\n", 
+    dt_print(DT_DEBUG_ROI, "[process TILE] %17s %16s. IN (%4i/%4i) %4ix%4i scale=%.2f. OUT (%4i/%4i) %4ix%4i scale=%.2f\n", 
         dt_dev_pixelpipe_type_to_str(piece->pipe->type), module->so->op, roi_in->x, roi_in->y, roi_in->width, roi_in->height, roi_in->scale,
         roi_out->x, roi_out->y, roi_out->width, roi_out->height, roi_out->scale);
     module->process_tiling(module, piece, input, *output, roi_in, roi_out, in_bpp);
@@ -994,7 +994,7 @@ static int pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev,
       fprintf(stderr, "[pixelpipe_process_on_CPU] [%s] Warning: processes `%s' without tiling even if memory requirements are not met\n",
         dt_dev_pixelpipe_type_to_str(pipe->type), module->op); 
 
-    dt_print(DT_DEBUG_ROI, "[process CPU]%15s %16s. IN (%4i/%4i) %4ix%4i scale=%.2f. OUT (%4i/%4i) %4ix%4i scale=%.2f\n", 
+    dt_print(DT_DEBUG_ROI, "[process CPU] %15s %16s. IN (%4i/%4i) %4ix%4i scale=%.2f. OUT (%4i/%4i) %4ix%4i scale=%.2f\n", 
         dt_dev_pixelpipe_type_to_str(piece->pipe->type), module->so->op, roi_in->x, roi_in->y, roi_in->width, roi_in->height, roi_in->scale,
         roi_out->x, roi_out->y, roi_out->width, roi_out->height, roi_out->scale);
 
@@ -1232,7 +1232,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
   {
     return 1;
   }
-  dt_print(DT_DEBUG_ROI, "[modify roi IN] %12s %16s.    (%4i/%4i) %4ix%4i scale=%.2f",
+  dt_print(DT_DEBUG_ROI, "[modify roi IN] %13s %16s.    (%4i/%4i) %4ix%4i scale=%.2f",
     dt_dev_pixelpipe_type_to_str(piece->pipe->type), module->so->op, roi_in.x, roi_in.y, roi_in.width, roi_in.height, roi_in.scale);
 
   module->modify_roi_in(module, piece, roi_out, &roi_in);
@@ -1527,7 +1527,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
         /* now call process_cl of module; module should emit meaningful messages in case of error */
         if(success_opencl)
         {
-          dt_print(DT_DEBUG_ROI, "[process CL]%16s %16s. IN (%4i/%4i) %4ix%4i scale=%.2f. OUT (%4i/%4i) %4ix%4i scale=%.2f\n", 
+          dt_print(DT_DEBUG_ROI, "[process CL] %16s %16s. IN (%4i/%4i) %4ix%4i scale=%.2f. OUT (%4i/%4i) %4ix%4i scale=%.2f\n", 
               dt_dev_pixelpipe_type_to_str(piece->pipe->type), module->so->op, roi_in.x, roi_in.y, roi_in.width, roi_in.height, roi_in.scale,
               roi_out->x, roi_out->y, roi_out->width, roi_out->height, roi_out->scale);
 
@@ -2325,7 +2325,7 @@ void dt_dev_pixelpipe_get_dimensions(dt_dev_pixelpipe_t *pipe, struct dt_develop
        && !(dev->gui_module && dev->gui_module != module
             && dev->gui_module->operation_tags_filter() & module->operation_tags()))
     {
-      dt_print(DT_DEBUG_ROI, "[modify roi OUT]%12s %16s.    (%4i/%4i) %4ix%4i scale=%.2f",
+      dt_print(DT_DEBUG_ROI, "[modify roi OUT] %12s %16s.    (%4i/%4i) %4ix%4i scale=%.2f",
         dt_dev_pixelpipe_type_to_str(piece->pipe->type), module->so->op, roi_in.x, roi_in.y, roi_in.width, roi_in.height, roi_in.scale);
       module->modify_roi_out(module, piece, &roi_out, &roi_in);
       dt_print_nts(DT_DEBUG_ROI, "  --> (%4i/%4i) %4i*%4i scale=%.2f\n",

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -101,7 +101,7 @@ static inline int _maximum_number_tiles()
 
 static inline void _print_roi(const dt_iop_roi_t *roi, const char *label)
 {
-  if((darktable.unmuted & DT_DEBUG_VERBOSE) && (darktable.unmuted & DT_DEBUG_TILING))
+  if((darktable.unmuted & DT_DEBUG_VERBOSE) && (darktable.unmuted & (DT_DEBUG_TILING | DT_DEBUG_ROI)))
     fprintf(stderr,"     {%5d %5d ->%5d %5d (%5dx%5d)  %.6f } %s\n",
          roi->x, roi->y, roi->x + roi->width, roi->y + roi->height, roi->width, roi->height, roi->scale, label);
 }


### PR DESCRIPTION
To track down ROI issues a -d roi debugging option has been introduces to be used as usual via `dt_print()` and friends.

In `pixelpipe_hb.c` we tell about chenges via the roi modify callbacks plus roi informations when calling a module function.