### PR TITLE
Allow adding filmic auto-tune to quick access panel

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -578,6 +578,7 @@ dialog .sidebar row:selected:hover label,
 /* Set modules name header */
 #module-header
 {
+  border-bottom: 1px solid @plugin_bg_color;
   padding: 0.5em;
 }
 

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -3417,7 +3417,7 @@ static float _action_process_combo(gpointer target, dt_action_element_t element,
 
   if(!isnan(move_size))
   {
-    if(element == DT_ACTION_ELEMENT_BUTTON)
+    if(element == DT_ACTION_ELEMENT_BUTTON || !w->data.combobox.entries->len)
     {
       _action_process_button(widget, effect);
       return dt_bauhaus_widget_get_quad_active(widget);
@@ -3453,7 +3453,7 @@ static float _action_process_combo(gpointer target, dt_action_element_t element,
     dt_action_widget_toast(w->module, widget, "\n%s", dt_bauhaus_combobox_get_text(widget));
   }
 
-  if(element == DT_ACTION_ELEMENT_BUTTON)
+  if(element == DT_ACTION_ELEMENT_BUTTON || !w->data.combobox.entries->len)
     return dt_bauhaus_widget_get_quad_active(widget);
 
   for(int i = value; i >= 0; i--)

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -4250,7 +4250,6 @@ void gui_init(dt_iop_module_t *self)
   // Auto tune slider
   g->auto_button = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_combobox_new(self));
   dt_bauhaus_widget_set_label(g->auto_button, NULL, N_("auto tune levels"));
-  dt_action_define_iop(self, NULL, N_("auto tune levels"), GTK_WIDGET(g->auto_button), &dt_action_def_toggle);
   dt_gui_add_class(g->auto_button, "dt_bauhaus_alignment");
   gtk_widget_set_tooltip_text(g->auto_button, _("try to optimize the settings with some statistical assumptions.\n"
                                                 "this will fit the luminance range inside the histogram bounds.\n"

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -4248,10 +4248,8 @@ void gui_init(dt_iop_module_t *self)
                                                     "useful to give a safety margin to extreme luminances."));
 
   // Auto tune slider
-  GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_box_pack_start(GTK_BOX(hbox), dt_ui_label_new(_("auto tune levels")), TRUE, TRUE, 0);
-  g->auto_button = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, NULL);
-  gtk_box_pack_start(GTK_BOX(hbox), g->auto_button, FALSE, FALSE, 0);
+  g->auto_button = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_combobox_new(self));
+  dt_bauhaus_widget_set_label(g->auto_button, NULL, N_("auto tune levels"));
   dt_action_define_iop(self, NULL, N_("auto tune levels"), GTK_WIDGET(g->auto_button), &dt_action_def_toggle);
   dt_gui_add_class(g->auto_button, "dt_bauhaus_alignment");
   gtk_widget_set_tooltip_text(g->auto_button, _("try to optimize the settings with some statistical assumptions.\n"
@@ -4260,7 +4258,7 @@ void gui_init(dt_iop_module_t *self)
                                                 "but fails for high-keys, low-keys and high-ISO pictures.\n"
                                                 "this is not an artificial intelligence, but a simple guess.\n"
                                                 "ensure you understand its assumptions before using it."));
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), g->auto_button, FALSE, FALSE, 0);
 
   // Page RECONSTRUCT
   self->widget = dt_ui_notebook_page(g->notebook, N_("reconstruct"), NULL);
@@ -4286,7 +4284,7 @@ void gui_init(dt_iop_module_t *self)
                                 "increase to make the transition softer and blurrier."));
 
   // Highlight Reconstruction Mask
-  hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_pack_start(GTK_BOX(hbox), dt_ui_label_new(_("display highlight reconstruction mask")), TRUE, TRUE, 0);
   g->show_highlight_mask = dt_iop_togglebutton_new(self, NULL, N_("display highlight reconstruction mask"), NULL, G_CALLBACK(show_mask_callback),
                                            FALSE, 0, 0, dtgtk_cairo_paint_showmask, hbox);


### PR DESCRIPTION
Fix #12665. For that, this need to revert a work I've done on #11372 but it's more important to let users had filmic auto-tune line on quick access panel than having hover effect on the picker (we don't have it on sliders ones). So revert back.

But, @dterrahe I need your help. I don't understand how to let shortcut work now. I can set it with that PR but not use it. Could you post in a comment the correct code. My coding skills remains really limited.

This PR also improve line between module (CSS code). This follows a pixls.us comment: https://discuss.pixls.us/t/discussion-around-new-filters-widgets/32490/26?u=nilvus