### PR TITLE
Proper fix for highlights reconstruction ROI problems

### DIFF
--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -2000,7 +2000,6 @@ static void process_visualize(dt_dev_pixelpipe_iop_t *piece, const void *const i
 
 /* inpaint opposed and segmentation based algorithms want the whole image for proper calculation
    of chrominance correction and best candidates so we change both rois.
-   1st pass: how large would the output be, given this input roi?
 */
 void modify_roi_out(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t *roi_out,
                     const dt_iop_roi_t *const roi_in)
@@ -2014,17 +2013,12 @@ void modify_roi_out(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, dt_iop
     return;
 
   *roi_out = *roi_in;
-  roi_out->width = roi_in->width;
-  roi_out->height = roi_in->height;
-  roi_out->x = roi_in->x;
-  roi_out->y = roi_in->y;
-
-  // sanity check.
-  if(roi_out->x < 0) roi_out->x = 0;
-  if(roi_out->y < 0) roi_out->y = 0;
+  roi_out->x = MAX(0, roi_in->x);
+  roi_out->y = MAX(0, roi_in->y);
+  // we can't do a proper sanity check here for width & height; that has to be done in the
+  // opposed and segmentation code!
 }
 
-// 2nd pass: which roi would this operation need as input to fill the given output region?
 void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const dt_iop_roi_t *const roi_out,
                    dt_iop_roi_t *roi_in)
 {
@@ -2036,6 +2030,7 @@ void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const d
   if(visualizing || (d->mode != DT_IOP_HIGHLIGHTS_OPPOSED && d->mode != DT_IOP_HIGHLIGHTS_SEGMENTS))
     return;
 
+  // we always take the full date provided by rawspeed
   *roi_in = *roi_out;
   roi_in->x = 0;
   roi_in->y = 0;
@@ -2228,7 +2223,9 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
       piece->process_cl_ready = FALSE;
   }
   // check for heavy computing here to give an iop cache hint
-  const gboolean heavy = ((d->mode == DT_IOP_HIGHLIGHTS_LAPLACIAN) && ((d->iterations * 1<<(2+d->scales)) >= 256));
+  const gboolean heavy = (((d->mode == DT_IOP_HIGHLIGHTS_LAPLACIAN) && ((d->iterations * 1<<(2+d->scales)) >= 256))
+                          || (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS)
+                          || (d->mode == DT_IOP_HIGHLIGHTS_OPPOSED));
   self->cache_next_important = heavy;
 }
 

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -1970,7 +1970,7 @@ static void process_visualize(dt_dev_pixelpipe_iop_t *piece, const void *const i
 #endif
     for(size_t k = 0; k < 4*npixels; k += 4)
     {
-      for(int c = 0; c < 3; c++)
+      for_each_channel(c)
         out[k+c] = (in[k+c] < clips[c]) ? 0.2f * in[k+c] : 1.0f;
       out[k+3] = 0.0f;
     }
@@ -2032,7 +2032,7 @@ void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const d
   if(visualizing || (d->mode != DT_IOP_HIGHLIGHTS_OPPOSED && d->mode != DT_IOP_HIGHLIGHTS_SEGMENTS))
     return;
 
-  // we always take the full date provided by rawspeed
+  // we always take the full data provided by rawspeed
   roi_in->x = 0;
   roi_in->y = 0;
   roi_in->width = piece->buf_in.width;

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -2004,6 +2004,7 @@ static void process_visualize(dt_dev_pixelpipe_iop_t *piece, const void *const i
 void modify_roi_out(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t *roi_out,
                     const dt_iop_roi_t *const roi_in)
 {
+  *roi_out = *roi_in;
   dt_iop_highlights_data_t *d = (dt_iop_highlights_data_t *)piece->data;
   dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
   const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
@@ -2012,7 +2013,6 @@ void modify_roi_out(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, dt_iop
   if(visualizing || (d->mode != DT_IOP_HIGHLIGHTS_OPPOSED && d->mode != DT_IOP_HIGHLIGHTS_SEGMENTS))
     return;
 
-  *roi_out = *roi_in;
   roi_out->x = MAX(0, roi_in->x);
   roi_out->y = MAX(0, roi_in->y);
   // we can't do a proper sanity check here for width & height; that has to be done in the
@@ -2022,6 +2022,8 @@ void modify_roi_out(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, dt_iop
 void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const dt_iop_roi_t *const roi_out,
                    dt_iop_roi_t *roi_in)
 {
+  *roi_in = *roi_out;
+
   dt_iop_highlights_data_t *d = (dt_iop_highlights_data_t *)piece->data;
   dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
   const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
@@ -2031,7 +2033,6 @@ void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const d
     return;
 
   // we always take the full date provided by rawspeed
-  *roi_in = *roi_out;
   roi_in->x = 0;
   roi_in->y = 0;
   roi_in->width = piece->buf_in.width;

--- a/src/iop/hlrecovery_v2.c
+++ b/src/iop/hlrecovery_v2.c
@@ -88,6 +88,8 @@ The chosen segmentation algorithm works like this:
 #define HL_FLOAT_PLANES 8
 #define HL_BORDER 8
 
+#define HL_POWERF 3.0f
+
 #include "iop/segmentation.h"
 #include "common/distance_transform.h"
 
@@ -203,10 +205,10 @@ static inline float _calc_refavg(const float *in, const uint8_t(*const xtrans)[6
       cnt[c] += 1.0f;
     }
   }
-  for(int c = 0; c < 3; c++) mean[c] = powf(mean[c] / cnt[c], 1.0f / 3.0f);
+  for(int c = 0; c < 3; c++) mean[c] = powf(mean[c] / cnt[c], 1.0f / HL_POWERF);
 
   const dt_aligned_pixel_t croot_refavg = { 0.5f * (mean[1] + mean[2]), 0.5f * (mean[0] + mean[2]), 0.5f * (mean[0] + mean[1])};
-  return (linear) ? powf(croot_refavg[color], 3.0f) : croot_refavg[color];
+  return (linear) ? powf(croot_refavg[color], HL_POWERF) : croot_refavg[color];
 }
 
 static void _initial_gradients(const size_t w, const size_t height, float *luminance, float *distance, float *gradient)
@@ -427,7 +429,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
   const float clipval = fmaxf(0.1f, 0.987f * data->clip);
   const dt_aligned_pixel_t icoeffs = { piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1], piece->pipe->dsc.temperature.coeffs[2]};
   const dt_aligned_pixel_t clips = { clipval * icoeffs[0], clipval * icoeffs[1], clipval * icoeffs[2]}; 
-  const dt_aligned_pixel_t cube_coeffs = { powf(clips[0], 1.0f / 3.0f), powf(clips[1], 1.0f / 3.0f), powf(clips[2], 1.0f / 3.0f)};
+  const dt_aligned_pixel_t cube_coeffs = { powf(clips[0], 1.0f / HL_POWERF), powf(clips[1], 1.0f / HL_POWERF), powf(clips[2], 1.0f / HL_POWERF)};
 
   const int combining = (int) data->combine;
   const int recovery_mode = data->recovery;
@@ -440,6 +442,11 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
   const int pwidth  = dt_round_size(roi_in->width / 3, 2) + 2 * HL_BORDER;
   const int pheight = dt_round_size(roi_in->height / 3, 2) + 2 * HL_BORDER;
   const size_t p_size = dt_round_size((size_t) (pwidth + 4) * (pheight + 4), 16);
+
+  const int o_row_max = MIN(roi_out->height, roi_in->height - roi_out->y);
+  const int o_col_max = MIN(roi_out->width, roi_in->width - roi_out->y);
+  const int o_width = roi_out->width;
+  const int i_width = roi_in->width;
  
   float *fbuffer = dt_alloc_align_float((HL_FLOAT_PLANES) * p_size);
   if(!fbuffer) return;
@@ -461,13 +468,13 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
   #pragma omp parallel for default(none) \
   reduction( | : has_allclipped) \
   dt_omp_firstprivate(tmpout, roi_in, plane, isegments, cube_coeffs, refavg, xtrans) \
-  dt_omp_sharedconst(pwidth, filters) \
+  dt_omp_sharedconst(pwidth, filters, i_width) \
   schedule(static)
 #endif
   for(size_t row = 1; row < roi_in->height-1; row++)
   {
-    float *in = tmpout + (size_t)roi_in->width * row + 1;
-    for(size_t col = 1; col < roi_in->width-1; col++)
+    float *in = tmpout + (size_t)i_width * row + 1;
+    for(size_t col = 1; col < i_width - 1; col++)
     {
       // calc all color planes for the centre of a 3x3 area
       if((col % 3 == 1) && (row % 3 == 1))
@@ -478,14 +485,14 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
         {
           for(int dx = -1; dx < 2; dx++)
           {
-            const float val = in[(ssize_t)dy * roi_in->width + dx];
+            const float val = in[(ssize_t)dy * i_width + dx];
             const int c = (filters == 9u) ? FCxtrans(row + dy, col + dx, roi_in, xtrans) : FC(row + dy, col + dx, filters);
             mean[c] += val;
             cnt[c] += 1.0f;
           }
         }
 
-        for(int c = 0; c < 3; c++) mean[c] = powf(mean[c] / cnt[c], 1.0f / 3.0f);
+        for(int c = 0; c < 3; c++) mean[c] = powf(mean[c] / cnt[c], 1.0f / HL_POWERF);
         const dt_aligned_pixel_t cube_refavg = { 0.5f * (mean[1] + mean[2]), 0.5f * (mean[0] + mean[2]), 0.5f * (mean[0] + mean[1])};
 
         const size_t o = _raw_to_plane(pwidth, row, col);
@@ -544,13 +551,13 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(clips, ivoid, tmpout, roi_in, roi_out, xtrans, isegments, plane) \
-  dt_omp_sharedconst(filters, pwidth) \
+  dt_omp_sharedconst(filters, pwidth, i_width) \
   schedule(static)
 #endif
   for(int row = 1; row < roi_in->height-1; row++)
   {
-    float *out = tmpout + (size_t)roi_in->width * row + 1;
-    float *in = (float *)ivoid + (size_t)roi_in->width * row + 1;
+    float *out = tmpout + (size_t)i_width * row + 1;
+    float *in = (float *)ivoid + (size_t)i_width * row + 1;
     for(int col = 1; col < roi_in->width-1; col++)
     {
       const float inval = fmaxf(0.0f, in[0]);
@@ -564,7 +571,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
         {
           const float cand_reference = isegments[color].val2[pid];
           const float refavg_here = _calc_refavg(&in[0], xtrans, filters, row, col, roi_in, FALSE);
-          const float oval = powf(refavg_here + candidate - cand_reference, 3.0f);
+          const float oval = powf(refavg_here + candidate - cand_reference, HL_POWERF);
           out[0] = plane[color][o] = fmaxf(inval, oval);
         }
       }
@@ -640,13 +647,13 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(clips, ivoid, tmpout, roi_in, roi_out, xtrans, gradient, distance) \
-  dt_omp_sharedconst(filters, pwidth, dshift, strength) \
+  dt_omp_sharedconst(filters, pwidth, dshift, strength, i_width) \
   schedule(static)
 #endif
       for(int row = 1; row < roi_in->height-1; row++)
       {
-        float *out = tmpout + (size_t)roi_in->width * row + 1;
-        float *in = (float *)ivoid + (size_t)roi_in->width * row + 1;
+        float *out = tmpout + (size_t)i_width * row + 1;
+        float *in = (float *)ivoid + (size_t)i_width * row + 1;
         for(int col = 1; col < roi_out->width-1; col++)
         {
           const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
@@ -666,13 +673,14 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(ovoid, tmpout, roi_in, roi_out) \
+  dt_omp_sharedconst(o_row_max, o_col_max, o_width, i_width) \
   schedule(static)
 #endif
-  for(int row = 0; row < roi_out->height; row++)
+  for(int row = 0; row < o_row_max; row++)
   {
-    float *out = (float *)ovoid + (size_t)roi_out->width * row;
-    float *in = tmpout + (size_t)roi_in->width * (row + roi_out->y) + roi_out->x;
-    for(int col = 0; col < roi_out->width; col++)
+    float *out = (float *)ovoid + (size_t)o_width * row;
+    float *in = tmpout + (size_t)i_width * (row + roi_out->y) + roi_out->x;
+    for(int col = 0; col < o_col_max; col++)
       out[col] = in[col];
   }
 
@@ -681,17 +689,17 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(clips, ivoid, ovoid, roi_in, roi_out, xtrans, isegments, gradient) \
-  dt_omp_sharedconst(filters, pwidth, vmode, strength) \
+  dt_omp_sharedconst(filters, pwidth, vmode, strength, o_row_max, o_col_max, o_width, i_width) \
   schedule(static)
 #endif
-    for(int row = 0; row < roi_out->height; row++)
+    for(int row = 0; row < o_row_max; row++)
     {
-      float *out = (float *)ovoid + (size_t)roi_out->width * row;
-      float *in = (float *)ivoid + (size_t)roi_in->width * (row + roi_out->y) + roi_out->x;
-      for(int col = 0; col < roi_out->width; col++)
+      float *out = (float *)ovoid + (size_t)o_width * row;
+      float *in = (float *)ivoid + (size_t)i_width * (row + roi_out->y) + roi_out->x;
+      for(int col = 0; col < o_col_max; col++)
       {
         out[0] = 0.1f * in[0];
-        if((row > 0) && (col > 0) && (row < roi_out->height -1) && (col < roi_in->width -1))
+        if((row > 0) && (col > 0) && (row < roi_out->height -1) && (col < i_width -1))
         {
           const int color = (filters == 9u) ? FCxtrans(row+roi_out->y, col+roi_out->x, roi_in, xtrans) : FC(row+roi_out->y, col+roi_out->x, filters);
           const size_t ppos = _raw_to_plane(pwidth, row+roi_out->y, col+roi_out->x);

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -45,7 +45,7 @@ static inline float _calc_linear_refavg(const float *in, const int row, const in
   {
     for(int dx = -1; dx < 2; dx++)
     {
-      for(int c = 0; c < 3; c++)
+      for_each_channel(c)
         mean[c] += fmaxf(0.0f, in[roi->width * 4 * dy + 4 * dx + c]);
     }
   }

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -50,10 +50,10 @@ static inline float _calc_linear_refavg(const float *in, const int row, const in
     }
   }
   for(int c = 0; c < 3; c++)
-    mean[c] = powf(mean[c] / 9.0f, 1.0f / 3.0f);
+    mean[c] = powf(mean[c] / 9.0f, 1.0f / HL_POWERF);
 
   const dt_aligned_pixel_t croot_refavg = { 0.5f * (mean[1] + mean[2]), 0.5f * (mean[0] + mean[2]), 0.5f * (mean[0] + mean[1])};
-  return powf(croot_refavg[color], 3.0f);
+  return powf(croot_refavg[color], HL_POWERF);
 }
 
 // A slighly modified version for sraws
@@ -70,21 +70,26 @@ static float * _process_linear_opposed(dt_dev_pixelpipe_iop_t *piece, const void
   const int pheight = dt_round_size(roi_in->height / 3, 2) + 2 * HL_BORDER;
   const size_t p_size = (size_t) dt_round_size(pwidth * pheight, 16);
 
+  const int o_row_max = MIN(roi_out->height, roi_in->height - roi_out->y);
+  const int o_col_max = MIN(roi_out->width, roi_in->width - roi_out->y);
+  const int o_width = roi_out->width;
+  const int i_width = roi_in->width;
+
   int *mask_buffer = dt_calloc_align(64, 4 * p_size * sizeof(int));
-  const size_t bsize = (4 + MAX(roi_in->width + roi_in->x, roi_out->width + roi_out->x)) * (4 + MAX(roi_in->height + roi_in->y, roi_out->height + roi_out->y)); 
-  float *tmpout = dt_alloc_align_float(4 * bsize);
+  float *tmpout = dt_alloc_align_float(4 * roi_in->width * roi_in->height);
 
   // make sure date are fully copied in case of an early exit
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(ovoid, ivoid, roi_in, roi_out) \
+  dt_omp_sharedconst(o_row_max, o_col_max, o_width, i_width) \
   schedule(static)
 #endif
-  for(int row = 0; row < roi_out->height; row++)
+  for(int row = 0; row < o_row_max; row++)
   {
-    float *out = (float *)ovoid + (size_t)roi_out->width * row * 4;
-    float *in = (float *)ivoid + (size_t)roi_in->width * (row + roi_out->y) * 4 + roi_out->x * 4;
-    for(int col = 0; col < roi_out->width; col++)
+    float *out = (float *)ovoid + (size_t)o_width * row * 4;
+    float *in = (float *)ivoid + (size_t)i_width * (row + roi_out->y) * 4 + roi_out->x * 4;
+    for(int col = 0; col < o_col_max; col++)
     {
       for(int c = 0; c < 3; c++)
         out[c] = fmaxf(0.0f, in[c]);
@@ -100,19 +105,19 @@ static float * _process_linear_opposed(dt_dev_pixelpipe_iop_t *piece, const void
 #pragma omp parallel for default(none) \
   reduction( | : anyclipped) \
   dt_omp_firstprivate(clips, ivoid, tmpout, roi_in, roi_out, mask_buffer) \
-  dt_omp_sharedconst(p_size, pwidth, pheight) \
+  dt_omp_sharedconst(p_size, pwidth, pheight, i_width) \
   schedule(static)
 #endif
   for(int row = 0; row < roi_in->height; row++)
   {
-    float *tmp = tmpout + (size_t)roi_in->width * row * 4;
-    float *in = (float *)ivoid + (size_t)roi_in->width * row * 4;
-    for(int col = 0; col < roi_in->width; col++)
+    float *tmp = tmpout + (size_t)i_width * row * 4;
+    float *in = (float *)ivoid + (size_t)i_width * row * 4;
+    for(int col = 0; col < i_width; col++)
     {
       for(int c = 0; c < 3; c++)
         tmp[c] = fmaxf(0.0f, in[c]);
 
-      if((col > 0) && (col < roi_in->width - 1) && (row > 0) && (row < roi_in->height - 1))
+      if((col > 0) && (col < i_width - 1) && (row > 0) && (row < roi_in->height - 1))
       {
         for(int c = 0; c < 3; c++)
         {
@@ -146,13 +151,13 @@ static float * _process_linear_opposed(dt_dev_pixelpipe_iop_t *piece, const void
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(ivoid, roi_in, clips, clipdark, mask_buffer) \
   reduction(+ : cr_sum, cr_cnt) \
-  dt_omp_sharedconst(p_size, pwidth) \
+  dt_omp_sharedconst(p_size, pwidth, i_width) \
   schedule(static)
 #endif
   for(int row = 1; row < roi_in->height-1; row++)
   {
-    float *in  = (float *)ivoid + (size_t)roi_in->width * row * 4 + 4;
-    for(int col = 1; col < roi_in->width-1; col++)
+    float *in  = (float *)ivoid + (size_t)i_width * row * 4 + 4;
+    for(int col = 1; col < i_width-1; col++)
     {
       for(int c = 0; c < 3; c++)
       {
@@ -174,13 +179,14 @@ static float * _process_linear_opposed(dt_dev_pixelpipe_iop_t *piece, const void
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(clips, ivoid, tmpout, roi_in, roi_out, chrominance) \
+  dt_omp_sharedconst(o_row_max, o_col_max, i_width) \
   schedule(static)
 #endif
   for(int row = 0; row < roi_in->height; row++)
   {
-    float *in = (float *)ivoid + (size_t)roi_in->width * row * 4;
-    float *tmp = tmpout + (size_t)roi_in->width * row * 4;
-    for(int col = 0; col < roi_in->width; col++)
+    float *in = (float *)ivoid + (size_t)i_width * row * 4;
+    float *tmp = tmpout + (size_t)i_width * row * 4;
+    for(int col = 0; col < i_width; col++)
     {
       for(int c = 0; c < 3; c++)
       {
@@ -196,13 +202,14 @@ static float * _process_linear_opposed(dt_dev_pixelpipe_iop_t *piece, const void
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(ovoid, tmpout, roi_in, roi_out) \
+  dt_omp_sharedconst(o_row_max, o_col_max, o_width, i_width) \
   schedule(static)
 #endif
-  for(int row = 0; row < roi_out->height; row++)
+  for(int row = 0; row < o_row_max; row++)
   {
-    float *out = (float *)ovoid + (size_t)roi_out->width * row * 4;
-    float *tmp = tmpout + (size_t)(roi_in->width * (row + roi_out->y) * 4 + roi_out->x * 4);
-    for(int col = 0; col < roi_out->width; col++)
+    float *out = (float *)ovoid + (size_t)o_width * row * 4;
+    float *tmp = tmpout + (size_t)(i_width * (row + roi_out->y) * 4 + roi_out->x * 4);
+    for(int col = 0; col < o_col_max; col++)
     {
       for(int c = 0; c < 3; c++)
         out[c] = tmp[c];
@@ -236,20 +243,25 @@ static float *_process_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const 
   const size_t p_size = (size_t) dt_round_size(pwidth * pheight, 16);
 
   int *mask_buffer = dt_calloc_align(64, 4 * p_size * sizeof(int));
-  const size_t bsize = (4 + MAX(roi_in->width + roi_in->x, roi_out->width + roi_out->x)) * (4 + MAX(roi_in->height + roi_in->y, roi_out->height + roi_out->y)); 
-  float *tmpout = dt_alloc_align_float(bsize);
+  float *tmpout = dt_alloc_align_float(roi_in->width * roi_in->height);
+
+  const int o_row_max = MIN(roi_out->height, roi_in->height - roi_out->y);
+  const int o_col_max = MIN(roi_out->width, roi_in->width - roi_out->y);
+  const int o_width = roi_out->width;
+  const int i_width = roi_in->width;
 
   // make sure date are fully copied in case of an early exit
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ovoid, ivoid, roi_in, roi_out) \
+  dt_omp_firstprivate(ovoid, ivoid, roi_out) \
+  dt_omp_sharedconst(o_row_max, o_col_max, o_width, i_width) \
   schedule(static)
 #endif
-  for(int row = 0; row < roi_out->height; row++)
+  for(int row = 0; row < o_row_max; row++)
   {
-    float *out = (float *)ovoid + (size_t)roi_out->width * row;
-    float *in = (float *)ivoid + (size_t)roi_in->width * (row + roi_out->y) + roi_out->x;
-    for(int col = 0; col < roi_out->width; col++)
+    float *out = (float *)ovoid + o_width * row;
+    float *in = (float *)ivoid + i_width * (row + roi_out->y) + roi_out->x;
+    for(size_t col = 0; col < o_col_max; col++)
       out[col] = fmaxf(0.0f, in[col]);
   }
 
@@ -260,19 +272,19 @@ static float *_process_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const 
 #pragma omp parallel for default(none) \
   reduction( | : anyclipped) \
   dt_omp_firstprivate(clips, ivoid, tmpout, roi_in, roi_out, xtrans, mask_buffer) \
-  dt_omp_sharedconst(filters, p_size, pwidth, pheight) \
+  dt_omp_sharedconst(filters, p_size, pwidth, pheight, i_width, o_width) \
   schedule(static)
 #endif
   for(int row = 0; row < roi_in->height; row++)
   {
-    float *tmp = tmpout + (size_t)roi_in->width * row;
-    float *in = (float *)ivoid + (size_t)roi_in->width * row;
-    for(int col = 0; col < roi_in->width; col++)
+    float *tmp = tmpout + i_width * row;
+    float *in = (float *)ivoid + i_width * row;
+    for(int col = 0; col < i_width; col++)
     {
       const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
       tmp[0] = fmaxf(0.0f, in[0]);
       
-      if((tmp[0] >= clips[color]) && (col > 0) && (col < roi_in->width - 1) && (row > 0) && (row < roi_in->height - 1))
+      if((tmp[0] >= clips[color]) && (col > 0) && (col < i_width - 1) && (row > 0) && (row < roi_in->height - 1))
       {
         /* for the clipped photosites we later do the correction when the chrominance is available, we keep refavg in raw-RGB */
         tmp[0] = _calc_refavg(&in[0], xtrans, filters, row, col, roi_in, TRUE);
@@ -307,13 +319,13 @@ static float *_process_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const 
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(ivoid, roi_in, xtrans, clips, clipdark, mask_buffer) \
   reduction(+ : cr_sum, cr_cnt) \
-  dt_omp_sharedconst(filters, p_size, pwidth) \
+  dt_omp_sharedconst(filters, p_size, pwidth, i_width) \
   schedule(static)
 #endif
-  for(int row = 1; row < roi_in->height-1; row++)
+  for(int row = 1; row < roi_in->height - 1; row++)
   {
-    float *in  = (float *)ivoid + (size_t)roi_in->width * row + 1;
-    for(int col = 1; col < roi_in->width-1; col++)
+    float *in  = (float *)ivoid + (size_t)i_width * row + 1;
+    for(int col = 1; col < i_width - 1; col++)
     {
       const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
       const float inval = fmaxf(0.0f, in[0]); 
@@ -335,14 +347,14 @@ static float *_process_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(clips, ivoid, tmpout, roi_in, xtrans, chrominance) \
-  dt_omp_sharedconst(filters) \
+  dt_omp_sharedconst(filters, o_row_max, o_col_max, i_width) \
   schedule(static)
 #endif
   for(int row = 0; row < roi_in->height; row++)
   {
-    float *in = (float *)ivoid + (size_t)roi_in->width * row;
-    float *tmp = tmpout + (size_t)roi_in->width * row;
-    for(int col = 0; col < roi_in->width; col++)
+    float *in = (float *)ivoid + (size_t) i_width * row;
+    float *tmp = tmpout + (size_t)i_width * row;
+    for(int col = 0; col < i_width; col++)
     {
       const float inval = fmaxf(0.0f, in[0]);
       const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
@@ -356,13 +368,14 @@ static float *_process_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(ovoid, tmpout, roi_in, roi_out) \
+  dt_omp_sharedconst(o_row_max, o_col_max, i_width, o_width) \
   schedule(static)
 #endif
-  for(int row = 0; row < roi_out->height; row++)
+  for(int row = 0; row < o_row_max; row++)
   {
-    float *out = (float *)ovoid + (size_t)(roi_out->width * row);
-    float *tmp = tmpout + (size_t)(roi_in->width * (row + roi_out->y) + roi_out->x);
-    for(int col = 0; col < roi_out->width; col++)
+    float *out = (float *)ovoid + (size_t)o_width * row;
+    float *tmp = tmpout + (size_t)(i_width * (row + roi_out->y) + roi_out->x);
+    for(int col = 0; col < o_col_max; col++)
       out[col] = tmp[col];
   }
 


### PR DESCRIPTION
As reported in #12667 there were crashes in opposed or segmentation based code.

There has been a previous pr #12670, that one has become a mess but is a valuable resource to understand the problems.

In short; the mentioned algorithms require all image data for a stable calculation of chromacity correction (opposed) and the segmentation analysis and recovery code.

Thus we have to change the roi_in to "take it all". But - and that has been the problem of current code - the roi_out can be extended (for example by demosaic rounding for xtrans sensors). This results in a situation where the roi_out area is not fully inside roi_in.

This can't be properly fixed in the modify code, we have to check for the proper output range in the algorithms.

Fixes #12667

Replaces #12670