### PR TITLE
curl_tools: set proper useragent

### DIFF
--- a/src/common/curl_tools.c
+++ b/src/common/curl_tools.c
@@ -28,6 +28,10 @@ void dt_curl_init(CURL *curl, gboolean verbose)
 {
   curl_easy_reset(curl);
 
+  char useragent[64];
+  snprintf(useragent, sizeof(useragent), "darktable/%s", darktable_package_version);
+  curl_easy_setopt(curl, CURLOPT_USERAGENT, useragent);
+
   char datadir[PATH_MAX] = { 0 };
   dt_loc_get_datadir(datadir, sizeof(datadir));
   gchar *crtfilename = g_build_filename(datadir, "..", "curl", "curl-ca-bundle.crt", NULL);


### PR DESCRIPTION
Currently all outgoing HTTP requests from darktable carry no user-agent in the header. Although user-agent self-identification is not strictly required, some firewall implementation tends to block incoming requests with no UA.

This patch calls `curl_easy_setopt` to set UA to `darktable/$VERSION` during curl context setup.

Not sure whether 32B will be enough - the string may be truncated if the version string becomes too long (namely something like `4.1.0+620~g6e5bd4d3e-dirty` when built locally with changes)