### PR TITLE
RFC WIP add masks property bar and popup menu

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1310,11 +1310,24 @@
     <longdescription>defines how color channels are displayed when activated in the parametric masks feature.</longdescription>
   </dtconfig>
   <dtconfig prefs="darkroom" section="general">
-    <name>plugins/darkroom/image_infos_pattern</name>
-    <type>longstring</type>
-    <default>$(EXIF_EXPOSURE) • f/$(EXIF_APERTURE) • $(EXIF_FOCAL_LENGTH) mm • $(EXIF_ISO) ISO</default>
-    <shortdescription>pattern for the image information line</shortdescription>
-    <longdescription>see manual for a list of the tags you can use.</longdescription>
+    <name>masks_right_click_menu</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>right-click calls up mask menu</shortdescription>
+    <longdescription>right-clicking while in mask mode calls up a popup menu rather than deleting or ending creation of a shape</longdescription>
+  </dtconfig>
+  <dtconfig prefs="darkroom" section="general">
+    <name>plugins/darkroom/mask_bar_position</name>
+    <type>
+      <enum>
+        <option>hidden</option>
+        <option>top</option>
+        <option>bottom</option>
+      </enum>
+    </type>
+    <default>hidden</default>
+    <shortdescription>position of the mask slider bar</shortdescription>
+    <longdescription/>
   </dtconfig>
   <dtconfig prefs="darkroom" section="general">
     <name>plugins/darkroom/image_infos_position</name>
@@ -1330,6 +1343,13 @@
     <default>bottom</default>
     <shortdescription>position of the image information line</shortdescription>
     <longdescription/>
+  </dtconfig>
+  <dtconfig prefs="darkroom" section="general">
+    <name>plugins/darkroom/image_infos_pattern</name>
+    <type>longstring</type>
+    <default>$(EXIF_EXPOSURE) • f/$(EXIF_APERTURE) • $(EXIF_FOCAL_LENGTH) mm • $(EXIF_ISO) ISO</default>
+    <shortdescription>pattern for the image information line</shortdescription>
+    <longdescription>see manual for a list of the tags you can use.</longdescription>
   </dtconfig>
   <dtconfig>
     <name>database_cache_quality</name>

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -261,6 +261,7 @@ typedef struct dt_develop_t
       void (*list_update)(struct dt_lib_module_t *self);
       /* selected forms change */
       void (*selection_change)(struct dt_lib_module_t *self, struct dt_iop_module_t *module, const int selectid);
+      void (*popup)(dt_action_t *action);
     } masks;
 
     // what is the ID of the module currently doing pipeline chromatic adaptation ?

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -67,6 +67,15 @@ typedef enum dt_masks_property_t
   DT_MASKS_PROPERTY_LAST
 } dt_masks_property_t;
 
+typedef enum dt_masks_box_t
+{
+  DT_MASKS_BOX_MANAGER,
+  DT_MASKS_BOX_BAR,
+  DT_MASKS_BOX_POPUP,
+  DT_MASKS_BOX_LAST
+} dt_masks_box_t;
+
+
 typedef enum dt_masks_points_states_t
 {
   DT_MASKS_POINT_STATE_NORMAL = 1,

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1079,6 +1079,12 @@ int dt_masks_events_button_pressed(struct dt_iop_module_t *module, double x, dou
   pzx += 0.5f;
   pzy += 0.5f;
 
+  if(which == 3 && dt_conf_get_bool("masks_right_click_menu") && darktable.develop->proxy.masks.popup)
+  {
+    darktable.develop->proxy.masks.popup(DT_ACTION(darktable.develop->proxy.masks.module));
+    return 1;
+  }
+
   // allow to select a shape inside an iop
   if(gui && which == 1)
   {

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -957,7 +957,7 @@ static gboolean _button_pressed(GtkWidget *w, GdkEventButton *event, gpointer us
     gdk_event_get_axis ((GdkEvent *)event, GDK_AXIS_PRESSURE, &pressure);
   }
   dt_control_button_pressed(event->x, event->y, pressure, event->button, event->type, event->state & 0xf);
-  gtk_widget_grab_focus(w);
+  // gtk_widget_grab_focus(w);
   gtk_widget_queue_draw(w);
   return FALSE;
 }
@@ -2246,7 +2246,7 @@ static void _ui_init_panel_center_bottom(dt_ui_t *ui, GtkWidget *container)
                      DT_UI_PANEL_MODULE_SPACING);
 
   /* adding the center box */
-  ui->containers[DT_UI_CONTAINER_PANEL_CENTER_BOTTOM_CENTER] = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  ui->containers[DT_UI_CONTAINER_PANEL_CENTER_BOTTOM_CENTER] = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_pack_start(GTK_BOX(widget), ui->containers[DT_UI_CONTAINER_PANEL_CENTER_BOTTOM_CENTER], FALSE, TRUE,
                      DT_UI_PANEL_MODULE_SPACING);
 


### PR DESCRIPTION
This adds duplicates of the mask property sliders, that were recently added to a collapsible section of the mask manager, to a horizontal bar, that can be positioned at the top or bottom center of the screen, as well as to a pop-up menu.

![image](https://user-images.githubusercontent.com/1549490/197652951-11cec8c8-fd3b-49b8-b0d5-76b8e9774a63.png)
![image](https://user-images.githubusercontent.com/1549490/197653492-5b598eb7-8789-4027-b1c0-6066bb208212.png)
The popup menu can be called up using a shortcut or, if the preference is enabled, using right-click. The slider bar needs to be activated in the preferences as well. When changing from top to bottom or vice versa, reenter the darkroom to activate the new option (similar to the information line).

There are obvious problems. On a low resolution screen, there is not that much space in the top bar when all 7 sliders are shown (i.e. when a collection of shapes is selected). Especially if one has a lot of filters and the information line in the same bar. When the sliders get squashed, it is not pretty.

Worse; using right-click to call up the menu, though standard everywhere else, clashes fundamentally with assumptions in the dt ui. So things break. You can't, for example, even create a path, because you need to right-click to close it.

EDIT: I currently have no intention of "finishing" this, but would like to leave it open (in Draft) as inspiration/example/base/warning. It _is_ working/stable so anybody who wants to compile it into their personal copy is welcome to. That's what I'm doing, so I might (but don't guarantee to) resolve future merge conflicts.