### PR TITLE
clarify meaning of ctrl+scroll widget "resizing"

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3011,7 +3011,7 @@ static gboolean _scroll_wrap_scroll(GtkScrolledWindow *sw, GdkEventScroll *event
   {
     const gint new_size = dt_conf_get_int(config_str) + increment*delta_y;
 
-    dt_toast_log("%d", 1 + new_size / increment);
+    dt_toast_log(_("never show more than %d lines"), 1 + new_size / increment);
 
     dt_conf_set_int(config_str, new_size);
 


### PR DESCRIPTION
Clarify what ctrl+scroll over a list of variable size actually does. People are still justifiably confused even after it has been like this unchanged and intentionally for quite a while, because just showing a number does not impart a lot of information. The manual does help [module resizing](https://darktable-org.github.io/dtdocs/en/module-reference/overview/#module-resizing) but one would actually have to read it.

To explain again:
- some lists have varying sizes, so that they don't take up a lot of space when there's little information in them, but can expand when there is more.
- some have a _minimum_ size, especially when they often start out empty or with only one item, to make it obvious to the user that they aren't just labels but can contain multiple lines. And also to avoid excessive "jumping" when flying over a list of images with for example varying numbers of tags. When the list is filled with more than the minimum/start size allows, it will grow, as above.
- but allowing these lists to grow without limit can mean you'd need to scroll a lot to get to other modules. So that's why there is a (configurable) maximum size.
- this maximum size can also reduce the above mentioned "minimum" size (but that's not its main purpose.)

So unless the list is already currently using more than the maximum size you are setting, adjusting it won't do anything _now_.


The _minimum_ size is currently not configurable (setting a _minimum_ and a _maximum_ obviously would _fix_ the size, which is currently not possible except at the hardcoded minimum level for some lists). This functionality _could_ be added, at the cost of extra complexity, not code-wise but ui wise. Generally when it is explained that the current code is not considered "buggy", people don't go on to argue that it is "lacking", but if it _is_ and if a _minimum_ or _fixed_ size should be added, then suggestions what mouse/scroll actions they should be tied to are very welcome. "Fixing" the current functionality, so that instead of a size _cap_ it becomes a _fixed_ size, would be a _serious_ regression for me (I specifically built and like the way it currently works). So a suggestion to make a change like that should, out of politeness, at least be supported by proof of a wider consensus.