### PR TITLE
fix for build issue (#12720) with macOS sdk13

### DIFF
--- a/src/osx/osx.mm
+++ b/src/osx/osx.mm
@@ -15,6 +15,11 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+/* workaround to fix issue #12720 */
+#if defined(__APPLE__) && !defined(_DARWIN_C_SOURCE)
+#define _DARWIN_C_SOURCE
+#endif
+
 #include <Carbon/Carbon.h>
 #include <ApplicationServices/ApplicationServices.h>
 #include <CoreServices/CoreServices.h>

--- a/src/osx/osx.mm
+++ b/src/osx/osx.mm
@@ -16,9 +16,7 @@
 */
 
 /* workaround to fix issue #12720 */
-#if defined(__APPLE__) && !defined(_DARWIN_C_SOURCE)
 #define _DARWIN_C_SOURCE
-#endif
 
 #include <Carbon/Carbon.h>
 #include <ApplicationServices/ApplicationServices.h>


### PR DESCRIPTION
error message: `/Library/Developer/CommandLineTools/SDKs/MacOSX13.0.sdk/usr/include/netinet/ip.h:86:2: fatal error: unknown type name 'u_int' `
solution hint found in https://github.com/axel-download-accelerator/axel/pull/196

fixes #12720