### PR TITLE
imageio_rawspeed: remove explicit color matrix denominator

### DIFF
--- a/src/common/imageio.h
+++ b/src/common/imageio.h
@@ -36,9 +36,6 @@
 // FIXME: kill this pls.
 #define FILTERS_ARE_4BAYER(filters) (FILTERS_ARE_CYGM(filters) || FILTERS_ARE_RGBE(filters))
 
-// for Adobe coefficients from LibRaw & RawSpeed
-#define ADOBE_COEFF_FACTOR 10000
-
 typedef enum dt_imageio_levels_t
 {
   IMAGEIO_INT8 = 0x0,

--- a/src/common/imageio_dng.h
+++ b/src/common/imageio_dng.h
@@ -174,10 +174,10 @@ static inline void dt_imageio_dng_write_tiff_header(
   // ColorMatrix1 try to get camera matrix else m[k] like before
   if(!isnan(adobe_XYZ_to_CAM[0][0]))
   {
+    den = 10000;
     for(int k= 0; k < 3; k++)
       for(int i= 0; i < 3; i++)
-        m[k*3+i] = roundf(adobe_XYZ_to_CAM[k][i] * ADOBE_COEFF_FACTOR);
-    den = ADOBE_COEFF_FACTOR;
+        m[k*3+i] = roundf(adobe_XYZ_to_CAM[k][i] * den);
   }
 
   for(int k = 0; k < 9; k++)
@@ -234,4 +234,3 @@ static inline void dt_imageio_write_dng(
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/common/imageio_rawspeed.cc
+++ b/src/common/imageio_rawspeed.cc
@@ -257,20 +257,17 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
     for(int i = 0; i < 4; i++)
       img->wb_coeffs[i] = r->metadata.wbCoeffs[i];
 
+    // Grab the Adobe coeffs
     const int msize = r->metadata.colorMatrix.size();
-    // Grab the adobe coeff
     for(int k = 0; k < 4; k++)
       for(int i = 0; i < 3; i++)
       {
         const int idx = k*3 + i;
         if(idx < msize)
-          img->adobe_XYZ_to_CAM[k][i] =
-            (float)r->metadata.colorMatrix[idx] / (float)ADOBE_COEFF_FACTOR;
+          img->adobe_XYZ_to_CAM[k][i] = float(r->metadata.colorMatrix[idx]);
         else
           img->adobe_XYZ_to_CAM[k][i] = 0.0f;
       }
-
-    // FIXME: grab r->metadata.colorMatrix.
 
     // Get additional exif tags that are not cached in the database
     if(img->flags & DT_IMAGE_HAS_ADDITIONAL_DNG_TAGS)
@@ -572,4 +569,3 @@ dt_imageio_retval_t dt_imageio_open_rawspeed_sraw(dt_image_t *img, RawImage r, d
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-


### PR DESCRIPTION
@TurboGit This matches [rawspeed changes on develop](https://github.com/darktable-org/rawspeed/commit/70b01450c355f425fa04e6f1cd602b11c4248798), to be merged only when the module is bumped.