### PR TITLE
theme: set right color for .dt_bauhaus_popup:disabled

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1705,7 +1705,7 @@ treeview#delete-dialog:selected
 /* Bauhaus states */
 .dt_bauhaus_popup:disabled /* set categories titles in bauhaus combobox popup ; for example in collections module */
 {
-  color: white;
+  color: @bauhaus_fg_insensitive;
 }
 
 .dt_bauhaus_popup:hover


### PR DESCRIPTION
The color was set to white instead of @bauhaus_fg_insensitive