### PR TITLE
Double clicking on notebook tab resets all bauhaus widgets within to default

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2264,3 +2264,8 @@ Details :
 {
   margin: 0.07em 0.28em;
 }
+
+.changed
+{
+  background-color: @field_active_bg;
+}

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2818,17 +2818,21 @@ int dt_bauhaus_slider_get_feedback(GtkWidget *widget)
   return d->fill_feedback;
 }
 
-void dt_bauhaus_slider_reset(GtkWidget *widget)
+void dt_bauhaus_widget_reset(GtkWidget *widget)
 {
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(widget);
 
-  if(w->type != DT_BAUHAUS_SLIDER) return;
-  dt_bauhaus_slider_data_t *d = &w->data.slider;
+  if(w->type == DT_BAUHAUS_SLIDER)
+  {
+    dt_bauhaus_slider_data_t *d = &w->data.slider;
 
-  d->min = d->soft_min;
-  d->max = d->soft_max;
+    d->min = d->soft_min;
+    d->max = d->soft_max;
 
-  dt_bauhaus_slider_set(widget, d->defpos);
+    dt_bauhaus_slider_set(widget, d->defpos);
+  }
+  else
+    dt_bauhaus_combobox_set(widget, w->data.combobox.defpos);
 
   return;
 }
@@ -3098,7 +3102,7 @@ static gboolean dt_bauhaus_slider_button_press(GtkWidget *widget, GdkEventButton
     if(event->type == GDK_2BUTTON_PRESS)
     {
       d->is_dragging = 0;
-      dt_bauhaus_slider_reset(widget);
+      dt_bauhaus_widget_reset(widget);
     }
     else
     {
@@ -3329,7 +3333,7 @@ static float _action_process_slider(gpointer target, dt_action_element_t element
         --d->is_dragging;
         break;
       case DT_ACTION_EFFECT_RESET:
-        dt_bauhaus_slider_reset(widget);
+        dt_bauhaus_widget_reset(widget);
         break;
       case DT_ACTION_EFFECT_TOP:
         dt_bauhaus_slider_set(widget, element == DT_ACTION_ELEMENT_FORCE ? d->hard_max: d->max);

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1024,6 +1024,7 @@ static void _highlight_changed_notebook_tab(GtkWidget *w, gpointer user_data)
     if(!is_changed && DT_IS_BAUHAUS_WIDGET(c->data) && gtk_widget_get_visible(c->data))
     {
       dt_bauhaus_widget_t *b = DT_BAUHAUS_WIDGET(c->data);
+      if(!b->field) continue;
       if(b->type == DT_BAUHAUS_SLIDER)
       {
         dt_bauhaus_slider_data_t *d = &b->data.slider;
@@ -1044,7 +1045,7 @@ static void _highlight_changed_notebook_tab(GtkWidget *w, gpointer user_data)
 
 void dt_bauhaus_update_module(dt_iop_module_t *self)
 {
-  GtkWidget *notebook = NULL;
+  GtkWidget *n = NULL;
   for(GSList *w = self->widget_list_bh; w; w = w->next)
   {
     dt_action_target_t *at = w->data;
@@ -1093,10 +1094,10 @@ void dt_bauhaus_update_module(dt_iop_module_t *self)
         fprintf(stderr, "[dt_bauhaus_update_module] invalid bauhaus widget type encountered\n");
     }
 
-    if(!notebook) notebook = gtk_widget_get_ancestor(widget, GTK_TYPE_NOTEBOOK);
+    if(!n && (n = gtk_widget_get_parent(widget)) && (n = gtk_widget_get_parent(n)) && !GTK_IS_NOTEBOOK(n)) n = NULL;
   }
 
-  if(notebook) gtk_container_foreach(GTK_CONTAINER(notebook), _highlight_changed_notebook_tab, NULL);
+  if(n) gtk_container_foreach(GTK_CONTAINER(n), _highlight_changed_notebook_tab, NULL);
 }
 
 // make this quad a toggle button:

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1007,8 +1007,44 @@ void dt_bauhaus_widget_set_field(GtkWidget *widget, gpointer field, dt_introspec
   w->field_type = field_type;
 }
 
+static void _highlight_changed_notebook_tab(GtkWidget *w, gpointer user_data)
+{
+  GtkWidget *notebook = gtk_widget_get_parent(w);
+  if(!GTK_IS_NOTEBOOK(notebook))
+  {
+    w = notebook;
+    if(!notebook || !(GTK_IS_NOTEBOOK(notebook = gtk_widget_get_parent(notebook))))
+      return;
+  }
+
+  gboolean is_changed = GPOINTER_TO_INT(user_data);
+
+  for(GList *c = gtk_container_get_children(GTK_CONTAINER(w)); c; c = g_list_delete_link(c, c))
+  {
+    if(!is_changed && DT_IS_BAUHAUS_WIDGET(c->data) && gtk_widget_get_visible(c->data))
+    {
+      dt_bauhaus_widget_t *b = DT_BAUHAUS_WIDGET(c->data);
+      if(b->type == DT_BAUHAUS_SLIDER)
+      {
+        dt_bauhaus_slider_data_t *d = &b->data.slider;
+        is_changed = fabsf(d->pos - d->curve((d->defpos - d->min) / (d->max - d->min), DT_BAUHAUS_SET)) > 0.001f;
+      }
+      else
+        is_changed = b->data.combobox.entries->len && b->data.combobox.active != b->data.combobox.defpos;
+    }
+  }
+
+  GtkWidget *label = gtk_notebook_get_tab_label(GTK_NOTEBOOK(notebook), w);
+
+  if(is_changed)
+    dt_gui_add_class(label, "changed");
+  else
+    dt_gui_remove_class(label, "changed");
+}
+
 void dt_bauhaus_update_module(dt_iop_module_t *self)
 {
+  GtkWidget *notebook = NULL;
   for(GSList *w = self->widget_list_bh; w; w = w->next)
   {
     dt_action_target_t *at = w->data;
@@ -1056,7 +1092,11 @@ void dt_bauhaus_update_module(dt_iop_module_t *self)
       default:
         fprintf(stderr, "[dt_bauhaus_update_module] invalid bauhaus widget type encountered\n");
     }
+
+    if(!notebook) notebook = gtk_widget_get_ancestor(widget, GTK_TYPE_NOTEBOOK);
   }
+
+  if(notebook) gtk_container_foreach(GTK_CONTAINER(notebook), _highlight_changed_notebook_tab, NULL);
 }
 
 // make this quad a toggle button:
@@ -1486,6 +1526,7 @@ static void _bauhaus_combobox_set(dt_bauhaus_widget_t *w, const int pos, const g
           fprintf(stderr, "[_bauhaus_combobox_set] unsupported combo data type\n");
       }
     }
+    _highlight_changed_notebook_tab(GTK_WIDGET(w), GINT_TO_POINTER(d->active != d->defpos));
     g_signal_emit_by_name(G_OBJECT(w), "value-changed");
   }
 }
@@ -2912,6 +2953,7 @@ static void _bauhaus_slider_value_change(dt_bauhaus_widget_t *w)
       }
     }
 
+    _highlight_changed_notebook_tab(GTK_WIDGET(w), NULL);
     g_signal_emit_by_name(G_OBJECT(w), "value-changed");
     d->is_changed = 0;
   }

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -274,6 +274,8 @@ int dt_bauhaus_widget_get_quad_active(GtkWidget *w);
 void dt_bauhaus_widget_set_quad_visibility(GtkWidget *w, const gboolean visible);
 // set pointer to iop params field:
 void dt_bauhaus_widget_set_field(GtkWidget *w, gpointer field, dt_introspection_type_t field_type);
+// reset widget to default value
+void dt_bauhaus_widget_reset(GtkWidget *widget);
 
 // update all bauhaus widgets in an iop module from their params fields
 void dt_bauhaus_update_module(dt_iop_module_t *self);
@@ -319,7 +321,6 @@ float dt_bauhaus_slider_get_step(GtkWidget *w);
 void dt_bauhaus_slider_set_feedback(GtkWidget *w, int feedback);
 int dt_bauhaus_slider_get_feedback(GtkWidget *w);
 
-void dt_bauhaus_slider_reset(GtkWidget *widget);
 void dt_bauhaus_slider_set_format(GtkWidget *w, const char *format);
 void dt_bauhaus_slider_set_factor(GtkWidget *w, float factor);
 void dt_bauhaus_slider_set_offset(GtkWidget *w, float offset);

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -188,6 +188,7 @@ GtkWidget *dt_bauhaus_combobox_from_params(dt_iop_module_t *self, const char *pa
   gchar *section = _section_from_package(&self);
 
   dt_iop_params_t *p = (dt_iop_params_t *)self->params;
+  dt_iop_params_t *d = (dt_iop_params_t *)self->default_params;
   dt_introspection_field_t *f = self->so->get_f(param);
 
   GtkWidget *combobox = dt_bauhaus_combobox_new(self);
@@ -210,6 +211,7 @@ GtkWidget *dt_bauhaus_combobox_from_params(dt_iop_module_t *self, const char *pa
     {
       dt_bauhaus_combobox_add(combobox, _("no"));
       dt_bauhaus_combobox_add(combobox, _("yes"));
+      dt_bauhaus_combobox_set_default(combobox, *(gboolean*)((uint8_t *)d + f->header.offset));
     }
     else if(f->header.type == DT_INTROSPECTION_TYPE_ENUM)
     {
@@ -220,6 +222,7 @@ GtkWidget *dt_bauhaus_combobox_from_params(dt_iop_module_t *self, const char *pa
         if(*iter->description)
           dt_bauhaus_combobox_add_full(combobox, gettext(iter->description), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, GINT_TO_POINTER(iter->value), NULL, TRUE);
       }
+      dt_bauhaus_combobox_set_default(combobox, *(int*)((uint8_t *)d + f->header.offset));
 
       if(action && f->Enum.values)
         g_hash_table_insert(darktable.control->combo_introspection, action, f->Enum.values);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2872,6 +2872,8 @@ static gboolean _notebook_button_press_callback(GtkNotebook *notebook, GdkEventB
     ++darktable.gui->reset;
     _reset_all_bauhaus(box, &module);
     --darktable.gui->reset;
+    dt_gui_remove_class(gtk_notebook_get_tab_label(GTK_NOTEBOOK(notebook), box), "changed");
+
     if(module && module->type == DT_ACTION_TYPE_IOP_INSTANCE)
       dt_dev_add_history_item(darktable.develop, (dt_iop_module_t *)module, TRUE);
   }

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -978,7 +978,6 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_hard_min(g->exposure, -1.0);
   dt_bauhaus_slider_set_soft_min(g->exposure, -1.0);
   dt_bauhaus_slider_set_hard_max(g->exposure, 1.0);
-  dt_bauhaus_slider_set_default(g->exposure, 0.0);
   dt_bauhaus_slider_set_format(g->exposure, _(" EV"));
   gtk_widget_set_tooltip_text(g->exposure, _("correct the printing exposure after inversion to adjust\n"
                                              "the global contrast and avoid clipping highlights."));
@@ -1039,6 +1038,7 @@ void gui_update(dt_iop_module_t *const self)
 
 
   dt_bauhaus_slider_set(g->exposure, log2f(p->exposure));     // warning: GUI is in EV
+  dt_bauhaus_slider_set_default(g->exposure, log2f(p->exposure)); // otherwise always showes as "changed"
 
   // Update custom stuff
   gui_changed(self, NULL, NULL);


### PR DESCRIPTION
Some modules have tabs with many widgets in them and it would be useful to be able to reset all of them at the same time (and then undo that reset in one go). This PR allows doing that by double clicking on the tab (similar to how double clicking on a bauhaus resets it to default). This enables quickly checking, for example, what the impact of the "4 ways" tab in colorbalancergb is.

It can only reset bauhaus widgets, since for example toggle button widgets don't have default values embedded in them.

Hopefully this sufficiently fixes #7480 and fixes #9727, but if this gets merged, feel free to reopen with more specific left over requirements.

Separately, tabs that have changes in them (i.e. where some bauhaus widgets are not at their default value) are now subtly highlighted. So you can easily see that "B" and "brightness" have been adjusted in the below example.
![image](https://user-images.githubusercontent.com/1549490/198660231-6a8a4428-5463-473b-b30c-68cd8633c854.png)
@Nilvus obviously this is just an initial placeholder effect; I'll leave it up to you to tailor it (and place the css code where it belongs). If you want I can rename the "changed" class as well. Thanks!

Also fixes that the default value for a combobox as specified in the introspection comments did not get set by `dt_bauhaus_combobox_from_params`.