### PR TITLE
Manifest more optional features in the output of darktable --version

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -571,6 +571,12 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
                "  gPhoto2 support disabled\n"
 #endif
 
+#ifdef HAVE_LENSFUN
+               "  Lensfun support enabled\n"
+#else
+               "  Lensfun support disabled\n"
+#endif
+
 #ifdef HAVE_GRAPHICSMAGICK
                "  GraphicsMagick support enabled\n"
 #else
@@ -581,6 +587,24 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
                "  ImageMagick support enabled\n"
 #else
                "  ImageMagick support disabled\n"
+#endif
+
+#ifdef HAVE_LIBAVIF
+               "  libavif support enabled\n"
+#else
+               "  libavif support disabled\n"
+#endif
+
+#ifdef HAVE_LIBHEIF
+               "  libheif support enabled\n"
+#else
+               "  libheif support disabled\n"
+#endif
+
+#ifdef HAVE_OPENJPEG
+               "  OpenJPEG support enabled\n"
+#else
+               "  OpenJPEG support disabled\n"
 #endif
 
 #ifdef HAVE_OPENEXR


### PR DESCRIPTION
I didn't include each and every feature (do you really want to know if ISO Codes support is enabled?), but the most important ones are included.
