### PR TITLE
Suggesting a better place for bug reports in darktable --version output

### DIFF
--- a/src/config.cmake.h
+++ b/src/config.cmake.h
@@ -7,7 +7,7 @@
 // it butchers @@ and ${} :(
 
 #define PACKAGE_NAME "@CMAKE_PROJECT_NAME@"
-#define PACKAGE_BUGREPORT "darktable-dev@lists.darktable.org"
+#define PACKAGE_BUGREPORT "https://github.com/darktable-org/darktable/issues/new/choose"
 
 // these will be defined in build/bin/version_gen.c
 extern const char darktable_package_version[];


### PR DESCRIPTION
Let's direct users to GitHub as the preferred location for bug reports instead of a mailing list.
darktable-dev@lists.darktable.org is getting less and less traffic BTW, maybe because nowadays users don't like to subscribe to mailing lists just to leave a question or a request for help and then receive emails they don't need.
