### PR TITLE
add style preview in lighttable & darkroom

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2177,6 +2177,12 @@
     <longdescription>how long the transitions take (in ms) for expanding or collapsing modules and other ui elements</longdescription>
   </dtconfig>
   <dtconfig>
+    <name>ui/style/preview_size</name>
+    <type min="100" max="500">int</type>
+    <default>250</default>
+    <shortdescription>max style preview size</shortdescription>
+  </dtconfig>
+  <dtconfig>
     <name>ui_last/expander_metadata</name>
     <type>int</type>
     <default>0</default>

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -853,6 +853,13 @@ tooltip label,
   color: @tooltip_fg_color;
 }
 
+tooltip separator
+{
+  margin: 0.6em 2em;
+  padding-bottom: 0.07em;
+  background-color: @selected_bg_color;
+}
+
 combobox label
 {
   margin: 0 0.35em 0 0;

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -791,7 +791,7 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
   //  If a style is to be applied during export, add the iop params into the history
   if(use_style)
   {
-    GList *style_items = dt_styles_get_item_list(format_params->style, TRUE, -1);
+    GList *style_items = dt_styles_get_item_list(format_params->style, TRUE, -1, TRUE);
     if(!style_items)
     {
       dt_control_log(_("cannot find the style '%s' to apply during export."), format_params->style);

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -785,6 +785,7 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
     goto error;
   }
 
+  const int final_history_end = history_end == -1 ? dev.history_end : history_end;
   const gboolean use_style = !thumbnail_export && format_params->style[0] != '\0';
   const gboolean appending = format_params->style_append != FALSE;
   //  If a style is to be applied during export, add the iop params into the history
@@ -800,6 +801,7 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
     GList *modules_used = NULL;
 
     if(!appending) dt_dev_pop_history_items_ext(&dev, 0);
+
     dt_ioppr_update_for_style_items(&dev, style_items, appending);
 
     for(GList *st_items = style_items; st_items; st_items = g_list_next(st_items))
@@ -811,6 +813,8 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
     g_list_free(modules_used);
     g_list_free_full(style_items, dt_style_item_free);
   }
+  else if(history_end != -1)
+    dt_dev_pop_history_items_ext(&dev, final_history_end);
 
   dt_ioppr_resync_modules_order(&dev);
 

--- a/src/common/imageio.h
+++ b/src/common/imageio.h
@@ -25,6 +25,7 @@
 #include <glib.h>
 #include <stdio.h>
 
+#include <cairo.h>
 #include <inttypes.h>
 
 #define FILTERS_ARE_CYGM(filters)                                                                                 \
@@ -116,6 +117,12 @@ gboolean dt_imageio_lookup_makermodel(const char *maker, const char *model,
 
 // get the type of image from its extension
 dt_image_flags_t dt_imageio_get_type_from_extension(const char *extension);
+
+cairo_surface_t *dt_imageio_preview(const int32_t imgid,
+                                    const size_t width,
+                                    const size_t height,
+                                    const int history_end,
+                                    const char *style_name);
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -1032,7 +1032,7 @@ void dt_styles_delete_by_name(const char *name)
   dt_styles_delete_by_name_adv(name, TRUE);
 }
 
-GList *dt_styles_get_item_list(const char *name, gboolean params, int imgid)
+GList *dt_styles_get_item_list(const char *name, gboolean params, int imgid, gboolean with_multi_name)
 {
   GList *result = NULL;
   sqlite3_stmt *stmt;
@@ -1113,7 +1113,7 @@ GList *dt_styles_get_item_list(const char *name, gboolean params, int imgid)
         // when we get the parameters we do not want to get the operation localized as this
         // is used to compare against the internal module name.
 
-        if(has_multi_name)
+        if(has_multi_name && with_multi_name)
           g_snprintf(iname, sizeof(iname), "%s %s", sqlite3_column_text(stmt, 3), multi_name);
         else
           g_snprintf(iname, sizeof(iname), "%s", sqlite3_column_text(stmt, 3));
@@ -1137,7 +1137,7 @@ GList *dt_styles_get_item_list(const char *name, gboolean params, int imgid)
       {
         const gchar *itname = dt_iop_get_localized_name((char *)sqlite3_column_text(stmt, 3));
 
-        if(has_multi_name)
+        if(has_multi_name && with_multi_name)
           g_snprintf(iname, sizeof(iname), "%s %s", itname, multi_name);
         else
           g_snprintf(iname, sizeof(iname), "%s", itname);
@@ -1163,7 +1163,7 @@ GList *dt_styles_get_item_list(const char *name, gboolean params, int imgid)
 
 char *dt_styles_get_item_list_as_string(const char *name)
 {
-  GList *items = dt_styles_get_item_list(name, FALSE, -1);
+  GList *items = dt_styles_get_item_list(name, FALSE, -1, TRUE);
   if(items == NULL) return NULL;
 
   GList *names = NULL;

--- a/src/common/styles.h
+++ b/src/common/styles.h
@@ -111,10 +111,11 @@ gboolean dt_styles_has_module_order(const char *name);
 GList *dt_styles_get_list(const char *filter);
 
 /** get a list of items for a named style
-    if imgid != -1, then styles from the corresponding image are also reported if they are not already part of
-   the style
+    if imgid != -1, then styles from the corresponding image are also reported if they are
+    not already part of the style. If with_multi_name is TRUE the name field will contains
+    the multi_name.
 */
-GList *dt_styles_get_item_list(const char *name, gboolean params, int imgid);
+GList *dt_styles_get_item_list(const char *name, gboolean params, int imgid, gboolean with_multi_name);
 
 /** get list of items for a named style as a nice string */
 char *dt_styles_get_item_list_as_string(const char *name);
@@ -136,4 +137,3 @@ void dt_init_styles_actions();
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/gui/styles.h
+++ b/src/gui/styles.h
@@ -18,15 +18,20 @@
 
 #pragma once
 
+#include <cairo.h>
+
 /** shows a dialog for creating a new style */
 void dt_gui_styles_dialog_new(int imgid);
 
 /** shows a dialog for editing existing style */
 void dt_gui_styles_dialog_edit(const char *name);
 
+cairo_surface_t *dt_gui_get_style_preview(const uint32_t imgid, const char *name);
+
+GtkWidget *dt_gui_style_content_dialog(char *name, const int imgid);
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -734,12 +734,27 @@ GtkWidget *dt_gui_style_content_dialog(char *name, const int imgid)
 
   gtk_box_pack_start(GTK_BOX(ht), gtk_separator_new(GTK_ORIENTATION_HORIZONTAL), TRUE, TRUE, 2);
 
-  GList *items = dt_styles_get_item_list(name, FALSE, -1);
+  GList *items = dt_styles_get_item_list(name, FALSE, -1, FALSE);
   GList *l = items;
   while(l)
   {
+    char mn[64];
     dt_style_item_t *i = (dt_style_item_t *)l->data;
-    snprintf(buf, sizeof(buf), "  %s %s", i->enabled?"●":"○", i->name);
+
+    if(i->multi_name && strlen(i->multi_name) > 0)
+    {
+      snprintf(mn, sizeof(mn), "(%s)", i->multi_name);
+    }
+    else
+    {
+      snprintf(mn, sizeof(mn), "(%d)", i->multi_priority);
+    }
+
+    snprintf(buf, sizeof(buf), "  %s %s %s",
+             i->enabled ? "●" : "○",
+             gettext(i->name),
+             mn);
+
     label = gtk_label_new(buf);
     gtk_widget_set_halign(label, GTK_ALIGN_START);
     gtk_box_pack_start(GTK_BOX(ht), label, FALSE, FALSE, 0);

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -567,7 +567,7 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
                        DT_STYLE_ITEMS_COL_NUM,      -1,
                        -1);
     /* get history items for named style and populate the items list */
-    GList *items = dt_styles_get_item_list(name, FALSE, imgid);
+    GList *items = dt_styles_get_item_list(name, FALSE, imgid, TRUE);
     if(items)
     {
       for(const GList *items_iter = items; items_iter; items_iter = g_list_next(items_iter))

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -760,6 +760,8 @@ GtkWidget *dt_gui_style_content_dialog(char *name, const int imgid)
     l = g_list_next(l);
   }
 
+  g_list_free_full(items, dt_style_item_free);
+
   if(imgid >= 0)
   {
     gtk_box_pack_start(GTK_BOX(ht), gtk_separator_new(GTK_ORIENTATION_HORIZONTAL), TRUE, TRUE, 0);

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -696,7 +696,10 @@ static gboolean _preview_draw(GtkWidget *widget, cairo_t *cr, gpointer user_data
   if(data->imgid != -1)
   {
     cairo_surface_t *surface = dt_gui_get_style_preview(data->imgid, data->style_name);
-    cairo_set_source_surface(cr, surface, 0, 0);
+    const int psize = dt_conf_get_int("ui/style/preview_size");
+    const int swidth = cairo_image_surface_get_width(surface);
+    const int sheight = cairo_image_surface_get_height(surface);
+    cairo_set_source_surface(cr, surface, .5f * (psize - swidth), .5f * (psize - sheight));
     cairo_paint(cr);
     cairo_surface_destroy(surface);
 

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -764,8 +764,9 @@ GtkWidget *dt_gui_style_content_dialog(char *name, const int imgid)
   gtk_box_pack_start(GTK_BOX(ht), gtk_separator_new(GTK_ORIENTATION_HORIZONTAL), TRUE, TRUE, 2);
 
   // style preview
+  const int psize = dt_conf_get_int("ui/style/preview_size");
   GtkWidget *da = gtk_drawing_area_new();
-  gtk_widget_set_size_request(da, 200, 200);
+  gtk_widget_set_size_request(da, psize, psize);
   gtk_widget_set_halign(da, GTK_ALIGN_CENTER);
   gtk_widget_set_app_paintable(da, TRUE);
   gtk_box_pack_start(GTK_BOX(ht), da, TRUE, TRUE, 0);
@@ -779,7 +780,8 @@ GtkWidget *dt_gui_style_content_dialog(char *name, const int imgid)
 
 cairo_surface_t *dt_gui_get_style_preview(const uint32_t imgid, const char *name)
 {
-  cairo_surface_t *surface = dt_imageio_preview(imgid, 200, 200, -1, name);
+  const int psize = dt_conf_get_int("ui/style/preview_size");
+  cairo_surface_t *surface = dt_imageio_preview(imgid, psize, psize, -1, name);
   return surface;
 }
 

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -731,7 +731,7 @@ GtkWidget *dt_gui_style_content_dialog(char *name, const int imgid)
     gtk_box_pack_start(GTK_BOX(ht), label, FALSE, FALSE, 0);
   }
 
-  gtk_box_pack_start(GTK_BOX(ht), gtk_separator_new(GTK_ORIENTATION_HORIZONTAL), TRUE, TRUE, 2);
+  gtk_box_pack_start(GTK_BOX(ht), gtk_separator_new(GTK_ORIENTATION_HORIZONTAL), TRUE, TRUE, 0);
 
   GList *items = dt_styles_get_item_list(name, FALSE, -1, FALSE);
   GList *l = items;
@@ -760,19 +760,22 @@ GtkWidget *dt_gui_style_content_dialog(char *name, const int imgid)
     l = g_list_next(l);
   }
 
-  gtk_box_pack_start(GTK_BOX(ht), gtk_separator_new(GTK_ORIENTATION_HORIZONTAL), TRUE, TRUE, 2);
+  if(imgid >= 0)
+  {
+    gtk_box_pack_start(GTK_BOX(ht), gtk_separator_new(GTK_ORIENTATION_HORIZONTAL), TRUE, TRUE, 0);
 
-  // style preview
-  const int psize = dt_conf_get_int("ui/style/preview_size");
-  GtkWidget *da = gtk_drawing_area_new();
-  gtk_widget_set_size_request(da, psize, psize);
-  gtk_widget_set_halign(da, GTK_ALIGN_CENTER);
-  gtk_widget_set_app_paintable(da, TRUE);
-  gtk_box_pack_start(GTK_BOX(ht), da, TRUE, TRUE, 0);
-  _preview_data_t *data = g_malloc(sizeof(_preview_data_t));
-  g_strlcpy(data->style_name, name, sizeof(data->style_name));
-  data->imgid = imgid;
-  g_signal_connect(G_OBJECT(da), "draw", G_CALLBACK(_preview_draw), data);
+    // style preview
+    const int psize = dt_conf_get_int("ui/style/preview_size");
+    GtkWidget *da = gtk_drawing_area_new();
+    gtk_widget_set_size_request(da, psize, psize);
+    gtk_widget_set_halign(da, GTK_ALIGN_CENTER);
+    gtk_widget_set_app_paintable(da, TRUE);
+    gtk_box_pack_start(GTK_BOX(ht), da, TRUE, TRUE, 0);
+    _preview_data_t *data = g_malloc(sizeof(_preview_data_t));
+    g_strlcpy(data->style_name, name, sizeof(data->style_name));
+    data->imgid = imgid;
+    g_signal_connect(G_OBJECT(da), "draw", G_CALLBACK(_preview_draw), data);
+  }
 
   return ht;
 }

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -712,7 +712,6 @@ GtkWidget *dt_gui_style_content_dialog(char *name, const int imgid)
   char buf[1024];
   GtkWidget *ht = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
-  // GList *dt_styles_get_item_list(const char *name, gboolean params, int imgid);
   GtkWidget *label = NULL;
 
   // name

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -1104,7 +1104,8 @@ static gboolean checker_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data
 
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
-  int width = allocation.width, height = allocation.height;
+  const int width = allocation.width;
+  const int height = allocation.height;
   cairo_surface_t *cst = dt_cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
   // clear bg

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -71,7 +71,6 @@ int position(const dt_lib_module_t *self)
 typedef enum _styles_columns_t
 {
   DT_STYLES_COL_NAME = 0,
-  DT_STYLES_COL_TOOLTIP,
   DT_STYLES_COL_FULLNAME,
   DT_STYLES_NUM_COLS
 } _styles_columns_t;
@@ -120,6 +119,37 @@ static gboolean _get_node_for_name(GtkTreeModel *model, gboolean root, GtkTreeIt
   return FALSE;
 }
 
+gboolean _styles_tooltip_callback(GtkWidget* self, gint x, gint y, gboolean keyboard_mode,
+                                  GtkTooltip* tooltip, gpointer user_data)
+{
+  GtkTreeModel* model;
+  GtkTreePath* path;
+  GtkTreeIter iter;
+  int imgid = -1;
+
+  if(gtk_tree_view_get_tooltip_context(GTK_TREE_VIEW(self), &x, &y, FALSE, &model, &path, &iter))
+  {
+    gchar *name = NULL;
+    gtk_tree_model_get(model, &iter, DT_STYLES_COL_NAME, &name, -1);
+
+    GList *selected_image = dt_collection_get_selected(darktable.collection, 1);
+
+    if(selected_image)
+    {
+      imgid = GPOINTER_TO_INT(selected_image->data);
+      g_list_free(selected_image);
+    }
+
+    GtkWidget *ht = dt_gui_style_content_dialog(name, imgid);
+    gtk_widget_show_all(ht);
+
+    gtk_tooltip_set_custom(tooltip, ht);
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
 static void _gui_styles_update_view(dt_lib_styles_t *d)
 {
   /* clear current list */
@@ -135,19 +165,6 @@ static void _gui_styles_update_view(dt_lib_styles_t *d)
     for(const GList *res_iter = result; res_iter; res_iter = g_list_next(res_iter))
     {
       dt_style_t *style = (dt_style_t *)res_iter->data;
-
-      gchar *items_string = (gchar *)dt_styles_get_item_list_as_string(style->name);
-      gchar *tooltip = NULL;
-
-      if(style->description && *style->description)
-      {
-        tooltip
-            = g_strconcat("<b>", g_markup_escape_text(style->description, -1), "</b>\n", items_string, NULL);
-      }
-      else
-      {
-        tooltip = g_strdup(items_string);
-      }
 
       gchar **split = g_strsplit(style->name, "|", 0);
       int k = 0;
@@ -167,21 +184,19 @@ static void _gui_styles_update_view(dt_lib_styles_t *d)
           {
             // a leaf
             gtk_tree_store_set(GTK_TREE_STORE(model), &iter,
-                               DT_STYLES_COL_NAME, s, DT_STYLES_COL_TOOLTIP,
-                               tooltip, DT_STYLES_COL_FULLNAME, style->name, -1);
+                               DT_STYLES_COL_NAME, s,
+                               DT_STYLES_COL_FULLNAME, style->name, -1);
           }
         }
         k++;
       }
       g_strfreev(split);
-
-      g_free(items_string);
-      g_free(tooltip);
     }
     g_list_free_full(result, dt_style_free);
   }
 
-  gtk_tree_view_set_tooltip_column(GTK_TREE_VIEW(d->tree), DT_STYLES_COL_TOOLTIP);
+  g_signal_connect(GTK_TREE_VIEW(d->tree), "query-tooltip",
+                   G_CALLBACK(_styles_tooltip_callback), d);
   gtk_tree_view_set_model(GTK_TREE_VIEW(d->tree), model);
   g_object_unref(model);
 }

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -167,7 +167,8 @@ static void _gui_styles_update_view(dt_lib_styles_t *d)
           {
             // a leaf
             gtk_tree_store_set(GTK_TREE_STORE(model), &iter,
-                               DT_STYLES_COL_NAME, s, DT_STYLES_COL_TOOLTIP, tooltip, DT_STYLES_COL_FULLNAME, style->name, -1);
+                               DT_STYLES_COL_NAME, s, DT_STYLES_COL_TOOLTIP,
+                               tooltip, DT_STYLES_COL_FULLNAME, style->name, -1);
           }
         }
         k++;

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -130,7 +130,10 @@ gboolean _styles_tooltip_callback(GtkWidget* self, gint x, gint y, gboolean keyb
   if(gtk_tree_view_get_tooltip_context(GTK_TREE_VIEW(self), &x, &y, FALSE, &model, &path, &iter))
   {
     gchar *name = NULL;
-    gtk_tree_model_get(model, &iter, DT_STYLES_COL_NAME, &name, -1);
+    gtk_tree_model_get(model, &iter, DT_STYLES_COL_FULLNAME, &name, -1);
+
+    // only on leaf node
+    if(!name) return FALSE;
 
     GList *selected_image = dt_collection_get_selected(darktable.collection, 1);
 

--- a/src/lua/styles.c
+++ b/src/lua/styles.c
@@ -78,7 +78,7 @@ static int style_getnumber(lua_State *L)
   }
   dt_style_t style;
   luaA_to(L, dt_style_t, &style, -2);
-  GList *items = dt_styles_get_item_list(style.name, TRUE, -1);
+  GList *items = dt_styles_get_item_list(style.name, TRUE, -1, TRUE);
   dt_style_item_t *item = g_list_nth_data(items, index - 1);
   if(!item)
   {
@@ -97,7 +97,7 @@ static int style_length(lua_State *L)
 
   dt_style_t style;
   luaA_to(L, dt_style_t, &style, -1);
-  GList *items = dt_styles_get_item_list(style.name, TRUE, -1);
+  GList *items = dt_styles_get_item_list(style.name, TRUE, -1, TRUE);
   lua_pushinteger(L, g_list_length(items));
   g_list_free_full(items, dt_style_item_free);
   return 1;

--- a/src/lua/styles.c
+++ b/src/lua/styles.c
@@ -71,7 +71,7 @@ static int style_duplicate(lua_State *L)
 
 static int style_getnumber(lua_State *L)
 {
-  int index = luaL_checknumber(L, -1);
+  const int index = luaL_checknumber(L, -1);
   if(index <= 0)
   {
     return luaL_error(L, "incorrect index for style");
@@ -163,7 +163,7 @@ static int style_item_gc(lua_State *L)
   return 0;
 }
 
-static GList *style_item_table_to_id_list(lua_State *L, int index)
+static GList *style_item_table_to_id_list(lua_State *L, const int index)
 {
   if(lua_isnoneornil(L, index)) return NULL;
   luaL_checktype(L, index, LUA_TTABLE);
@@ -185,7 +185,7 @@ static GList *style_item_table_to_id_list(lua_State *L, int index)
 /////////////////////////
 static int style_table_index(lua_State *L)
 {
-  int index = luaL_checkinteger(L, -1);
+  const int index = luaL_checkinteger(L, -1);
   if(index < 1)
   {
     return luaL_error(L, "incorrect index in database");
@@ -363,4 +363,3 @@ int dt_lua_init_styles(lua_State *L)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-


### PR DESCRIPTION
This is a rework of the tooltip on the styles lib in the lighttable and menu items in darkroom to display a preview of the style applied to the first selected picture.
