### PR TITLE
select created mask shape and improve hinter visibility

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -2422,11 +2422,8 @@ gboolean dt_collection_hint_message_internal(void *message)
     gtk_widget_set_tooltip_markup(count, message);
   }
 
-  message = dt_util_dstrcat(message, " %s", _("in current collection"));
-  dt_control_hinter_message(darktable.control,
-    dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_CENTER_TOP) ? "" : message);
+  dt_control_hinter_message(darktable.control, "");
 
-  g_free(message);
   return FALSE;
 }
 

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1002,6 +1002,7 @@ int dt_masks_events_mouse_leave(struct dt_iop_module_t *module)
   {
     dt_masks_form_gui_t *gui = darktable.develop->form_gui;
     gui->mouse_leaved_center = TRUE;
+    dt_control_hinter_message(darktable.control, "");
   }
   return 0;
 }
@@ -1068,7 +1069,11 @@ int dt_masks_events_button_released(struct dt_iop_module_t *module, double x, do
                                   darktable.develop->mask_form_selected_id);
 
   if(form->functions)
-    return form->functions->button_released(module, pzx, pzy, which, state, form, 0, gui, 0);
+  {
+    int ret = form->functions->button_released(module, pzx, pzy, which, state, form, 0, gui, 0);
+    form->functions->mouse_moved(module, pzx, pzy, 0, which, form, 0, gui, 0);
+    return ret;
+  }
 
   return 0;
 }

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -314,6 +314,7 @@ static void _panel_toggle(dt_ui_border_t border, dt_ui_t *ui)
         dt_ui_panel_show(ui, DT_UI_PANEL_CENTER_TOP, TRUE, TRUE);
       else
         dt_ui_panel_show(ui, DT_UI_PANEL_TOP, TRUE, TRUE);
+      dt_control_hinter_message(darktable.control, "");
     }
     break;
 

--- a/src/libs/tools/hinter.c
+++ b/src/libs/tools/hinter.c
@@ -90,7 +90,20 @@ void gui_cleanup(dt_lib_module_t *self)
 void _lib_hinter_set_message(dt_lib_module_t *self, const char *message)
 {
   dt_lib_hinter_t *d = (dt_lib_hinter_t *)self->data;
-  gtk_label_set_markup(GTK_LABEL(d->label), message);
+
+  if(message && !*message && !dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_CENTER_TOP))
+  {
+    GtkWidget *count = dt_view_filter_get_count(darktable.view_manager);
+    if(count)
+    {
+      gchar *count_message = g_strdup_printf(_("%s in current collection"),
+                                            gtk_label_get_text(GTK_LABEL(count)));
+      gtk_label_set_markup(GTK_LABEL(d->label), count_message);
+      g_free(count_message);
+    }
+  }
+  else
+    gtk_label_set_markup(GTK_LABEL(d->label), message);
 }
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py


### PR DESCRIPTION
fixes #10927

The issue was not limited to continuous shape creation; after ending creation mode, any shape (often the just created one) could only be manipulated (moved, resized etc) after the mouse had moved.

There is still a similar but harder to fix bug in liquify (that I don't currently intend to spend more time on). When the mouse is not moved after a shape was just created or if it is moved to a different node on a newly created or changed shape that is still being recalculated, it does not get shown as "selectable" but can still be manipulated:
1. create a new point
2. click on it
3. move mouse to arrow on inner circle; hinter says "drag to adjust hardness (_center_)"; both line and arrow light up.
4. drag the arrow (still, like 3, correct hinter and highlighting
5. let go of mouse button and quickly move to arrow on next circle, while still recalculating. You may need to find a slow pc.
6. if you got there in time, the previous circle+arrow stay highlighted and the hinter doesn't change either, not even when you slightly move the mouse.
7. drag the arrow; adjusting the feathering works, but still no correct highlighting etc.
Expected behaviour: "drag to adjust hardness (_feather_)" is shown and correct circle highlighted.

This PR also improves (imho that is hopefully shared) the visibility of hinter messages. They would suggest that scrolling would resize a new shape, even if the mouse was still over the panel and the more likely effect was that the slider under the mouse would be moved. Now, the hints are only shown when the mouse is over the central area. This required most changes in the liquify module, but there hints are improved in that they continue to show as long as a mode is active (previously the "click to edit nodes" message would disappear after the first node was manipulated).

Lastly, this further improves #12620 in that the currently selected image count is shown in the hinter whenever the top toolbar is hidden, as long as no other message is shown. So after finishing working with a mask tool, the message "n images selected of m in current collection" is restored.



