### PR TITLE
[RFC] correctly handle "ignore exif rating" option

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1291,18 +1291,21 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
       dt_metadata_set_import(img->id, "Xmp.dc.rights", str.c_str());
     }
 
-    if(FIND_EXIF_TAG("Exif.Image.Rating"))
+    if(!dt_conf_get_bool("ui_last/ignore_exif_rating"))
     {
-      const int stars = pos->toLong();
-      dt_image_set_xmp_rating(img, stars);
+      if(FIND_EXIF_TAG("Exif.Image.Rating"))
+      {
+        const int stars = pos->toLong();
+        dt_image_set_xmp_rating(img, stars);
+      }
+      else if(FIND_EXIF_TAG("Exif.Image.RatingPercent"))
+      {
+        const int stars = pos->toLong() * 5. / 100;
+        dt_image_set_xmp_rating(img, stars);
+      }
+      else
+        dt_image_set_xmp_rating(img, -2);
     }
-    else if(FIND_EXIF_TAG("Exif.Image.RatingPercent"))
-    {
-      const int stars = pos->toLong() * 5. / 100;
-      dt_image_set_xmp_rating(img, stars);
-    }
-    else
-      dt_image_set_xmp_rating(img, -2);
 
     // read embedded color matrix as used in DNGs
     {

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1669,8 +1669,6 @@ static uint32_t _image_import_internal(const int32_t film_id, const char *filena
 
   // read dttags and exif for database queries!
   if(dt_exif_read(img, normalized_filename)) img->exif_inited = 0;
-  if(dt_conf_get_bool("ui_last/ignore_exif_rating"))
-    img->flags = flags;
   char dtfilename[PATH_MAX] = { 0 };
   g_strlcpy(dtfilename, normalized_filename, sizeof(dtfilename));
   // dt_image_path_append_version(id, dtfilename, sizeof(dtfilename));

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1298,10 +1298,7 @@ static int32_t dt_control_refresh_exif_run(dt_job_t *job)
       dt_image_t *img = dt_image_cache_get(darktable.image_cache, imgid, 'w');
       if(img)
       {
-        const uint32_t flags = img->flags;
         dt_exif_read(img, sourcefile);
-        if(dt_conf_get_bool("ui_last/ignore_exif_rating"))
-          img->flags = flags;
         dt_image_cache_write_release(darktable.image_cache, img, DT_IMAGE_CACHE_SAFE);
       }
       else


### PR DESCRIPTION
The dt_image_t flags currently doesn't contain only ratings but also many other flags.
But `_image_import_internal` and `dt_control_refresh_exif_run` where restoring all the flags after a call to dt_exif_read if that option was set.

This patch removes this flags restore and instead update flags rating only if the option is not set.

**NOTES**

* I'm marking it as RFC because I'm not sure if I'm covering the original use case and it's difficult to test for regressions. With this change when importing an image or refreshing the exif data and the option is enabled, the flags related to ratings won't be updated with the exif ratings but left as is.

* I tried to dig in the commit history to find why this was introduced and looks like in commit dd8c6126859fae8a5671b3112d00ccd3d844b423. 

* This was discovered while testing #12714 