### PR TITLE
fix resizing circle mask when rotated and resize anchor for hidpi

### DIFF
--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -429,6 +429,7 @@ GList *dt_masks_dup_forms_deep(GList *forms, dt_masks_form_t *form);
 /** utils functions */
 int dt_masks_point_in_form_exact(float x, float y, float *points, int points_start, int points_count);
 int dt_masks_point_in_form_near(float x, float y, float *points, int points_start, int points_count, float distance, int *near);
+float dt_masks_drag_factor(dt_masks_form_gui_t *gui, int index, int k, gboolean border);
 
 /** allow to select a shape inside an iop */
 void dt_masks_select_form(struct dt_iop_module_t *module, dt_masks_form_t *sel);

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -494,18 +494,9 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
 
     dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)((form->points)->data);
 
-    // we need the reference points
-    dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
-    if(!gpt) return 0;
+    const float s = dt_masks_drag_factor(gui, index, gui->point_dragging, FALSE);
 
-    const int k = gui->point_dragging;
-    const float xref = gpt->points[0];
-    const float rx = gpt->points[k * 2] - xref;
-    const float deltax = gui->posx + gui->dx - xref;
-
-    gui->dx = xref - gui->posx;
-
-    circle->radius = CLAMP(circle->radius * (1.0f + deltax / rx), 0.0005f, max_mask_size);
+    circle->radius = CLAMP(circle->radius * s, 0.0005f, max_mask_size);
 
     // we recreate the form points
     dt_masks_gui_form_create(form, gui, index, module);
@@ -518,19 +509,9 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
 
     dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)((form->points)->data);
 
+    const float s = dt_masks_drag_factor(gui, index, gui->point_border_dragging, TRUE);
 
-    // we need the reference points
-    dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
-    if(!gpt) return 0;
-
-    const int k = gui->point_border_dragging;
-    const float xref = gpt->points[0];
-    const float rx = gpt->border[k * 2] - xref;
-    const float deltax = gui->posx + gui->dx - xref;
-
-    gui->dx = xref - gui->posx;
-
-    circle->border = CLAMP((circle->radius + circle->border) * (1.0f + deltax / rx) - circle->radius, 0.001f, max_mask_border);
+    circle->border = CLAMP((circle->radius + circle->border) * s - circle->radius, 0.001f, max_mask_border);
 
     dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();


### PR DESCRIPTION
The recently introduced resizing and feathering anchors for mask circles did not work if the image was rotated. Fixed this and refactored a bit, including unnecessary duplication in ellipse (the last mouse move does not need to be processed in button_release, since gtk sends a move event first and the release event will just get identical coordinates).

Also increase the size of "anchors" a little on high dpi screens. This "should" probably be done for all line sizes as well, but that is all over the place.

What I find tedious with feathering anchors is that you have to be _within_ the shape to be able to grab them, otherwise the whole feather line disappears. So effectively the grab target is half the size of the resizing anchor. I was looking at the _near_ or _distance_ parameters of __circle_get_distance_ etc to see if that could be used to signal we are "within reach" of an anchor. __ellipse_get_distance_  seems to try to do this (with __ellipse_point_close_to_path_) but also, it doesn't seem to work. Any ideas/pointers welcome.