### PR TITLE
Fix typos

### DIFF
--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -337,7 +337,7 @@ static inline float4 Ych_to_pipe_RGB(float4 in, constant const float *const matr
 
 static inline float4 filmic_desaturate_v4(const float4 Ych_original, float4 Ych_final, const float saturation)
 {
-  // Note : Ych is normalized trough the LMS conversion,
+  // Note : Ych is normalized through the LMS conversion,
   // meaning c is actually a saturation (saturation ~= chroma / brightness).
   // So copy-pasting c and h from a different Y is equivalent to
   // tonemapping with a norm, which is equivalent to doing exposure compensation :

--- a/packaging/macosx/3_make_hb_darktable_package.sh
+++ b/packaging/macosx/3_make_hb_darktable_package.sh
@@ -28,7 +28,7 @@ homebrewHome=$(brew --prefix)
 function install_dependencies {
     local hbDependencies
 
-    # Get depedencies of current executable
+    # Get dependencies of current executable
     oToolLDependencies=$(otool -L "$1" 2>/dev/null | grep compatibility | cut -d\( -f1 | sed 's/^[[:blank:]]*//;s/[[:blank:]]*$//' | uniq)
 
     # Filter for homebrew dependencies

--- a/packaging/macosx/BUILD_hb.txt
+++ b/packaging/macosx/BUILD_hb.txt
@@ -8,7 +8,7 @@ How to make disk image with darktable application bundle from source (using Home
 2). Build and install darktable using either option A or B:
      - Option A: Build using the default build.sh, which should work for most use cases 
      $ 2_build_hb_darktable_default.sh
-     - Option B: Build using custom cmake options, edit according to your specific needs/enviroment
+     - Option B: Build using custom cmake options, edit according to your specific needs/environment
      $ 2_build_hb_darktable_custom.sh
 
 3). Create application bundle from build files. To properly sign the app bundle you can optionally provide your developer certificate email/id by defining CODECERT:
@@ -20,7 +20,7 @@ How to make disk image with darktable application bundle from source (using Home
 
 The final result is a DMG file: darktable-<current version>+<latest commit>-{arm64|i386}.dmg
 
-Y). Forcefully remove any remainder of previous attemps
+Y). Forcefully remove any remainder of previous attempts
      $ Y_cleanup_hb_darktable.sh
 
 LIMITATIONS:
@@ -35,7 +35,7 @@ MACOS SECURITY:
 
 NOTES:
 - It will be automatically build for the architecture you are currently on, either Apple Silicon (arm64) or Intel (i386).
-- If you want to build for i386 on arm64 see https://stackoverflow.com/questions/64951024/how-can-i-run-two-isolated-installations-of-homebrew/68443301#68443301 about how to handle both enviroments in parallel.
+- If you want to build for i386 on arm64 see https://stackoverflow.com/questions/64951024/how-can-i-run-two-isolated-installations-of-homebrew/68443301#68443301 about how to handle both environments in parallel.
 - After creating the darktable application bundle (step 3) you can directly run the result by executing:
      $ package/darktable.app/Contents/MacOS/darktable --configdir .config/darktable/ --cachedir .cache/darktable/
 

--- a/packaging/macosx/Y_cleanup_hb_darktable.sh
+++ b/packaging/macosx/Y_cleanup_hb_darktable.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Script to forcefully remove any remainder of previous attemps
+# Script to forcefully remove any remainder of previous attempts
 #
 
 removableDirs="../../build bin lib libexec share package .config .cache"

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -126,7 +126,7 @@ Feel free to adjust the number of parallel jobs according to your needs: Ninja w
 
 If you are in a hurry you can now run darktable by executing the `darktable.exe` found in the `build/bin` folder, install in `/opt/darktable` as described earlier, or create an install image.
 
-If you like experimenting you could also install `mingw-w64-ucrt-x86_64-{clang,openmp}` and use that compiler instead of gcc/g++ by setting the `CC=clang` and `CXX=clang++` variables. Alternatively, you can use the CLANG64 environment instead of UCRT64 and try building darktable with its defaut toolchain (note that the prefix for installation of all the packages above then becomes `mingw-w64-clang-x86_64-`).
+If you like experimenting you could also install `mingw-w64-ucrt-x86_64-{clang,openmp}` and use that compiler instead of gcc/g++ by setting the `CC=clang` and `CXX=clang++` variables. Alternatively, you can use the CLANG64 environment instead of UCRT64 and try building darktable with its default toolchain (note that the prefix for installation of all the packages above then becomes `mingw-w64-clang-x86_64-`).
 
 
 Cross-platform compile on Linux

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -263,7 +263,7 @@ gboolean dt_dev_pixelpipe_cache_get(struct dt_dev_pixelpipe_t *pipe, const uint6
       dt_vprint(DT_DEBUG_DEV, "[pixelpipe_cache_get] %12s %s HIT %16s, line%3i, age %4i, at %p, hash%22" PRIu64 ", basic%22" PRIu64 "\n",
         dt_dev_pixelpipe_type_to_str(pipe->type), (cache->used[k] < 0) ? "important" : "         ", name, k, cache->used[k], cache->data[k],
         cache->hash[k], cache->basichash[k]); 
-      // in case of a hit its always good to keep the cachline as important
+      // in case of a hit its always good to keep the cacheline as important
       cache->used[k] = -cache->entries;
       return FALSE;
     }

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1327,7 +1327,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
   /*
     As the iop cache holds modules input data we check for an important hint in the current module and
-    keep that infor for the next processed module
+    keep that info for the next processed module
   */
   gboolean input_important = pipe->next_important_module;
   if(module)

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -197,7 +197,7 @@ gboolean dt_dev_pixelpipe_init_thumbnail(dt_dev_pixelpipe_t *pipe, int32_t width
 // inits all but the pixel caches, so you can't actually process an image (just get dimensions and
 // distortions)
 gboolean dt_dev_pixelpipe_init_dummy(dt_dev_pixelpipe_t *pipe, int32_t width, int32_t height);
-// inits the pixelpipe with given cacheline size and number of entries. returns TRUE in case of sucess
+// inits the pixelpipe with given cacheline size and number of entries. returns TRUE in case of success
 gboolean dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe, size_t size, int32_t entries, size_t memlimit);
 // constructs a new input buffer from given RGB float array.
 void dt_dev_pixelpipe_set_input(dt_dev_pixelpipe_t *pipe, struct dt_develop_t *dev, float *input, int width,

--- a/src/imageio/format/exr.cc
+++ b/src/imageio/format/exr.cc
@@ -153,7 +153,7 @@ int write_image(dt_imageio_module_data_t *tmp, const char *filename, const void 
   // try to add the chromaticities
   cmsToneCurve *red_curve = NULL, *green_curve = NULL, *blue_curve = NULL;
   cmsCIEXYZ *red_color = NULL, *green_color = NULL, *blue_color = NULL;
-  Imf::Chromaticities chromaticities; // initialzed w/ Rec709 primaries and D65 white
+  Imf::Chromaticities chromaticities; // initialized w/ Rec709 primaries and D65 white
 
   // determine the actual (export vs colorout) color profile used
   const dt_colorspaces_color_profile_t *cp = dt_colorspaces_get_output_profile(imgid, over_type, over_filename);

--- a/src/imageio/format/jxl.c
+++ b/src/imageio/format/jxl.c
@@ -613,7 +613,7 @@ void gui_init(dt_imageio_module_format_t *self)
       dt_confgen_get_int("plugins/imageio/format/jxl/tier", DT_DEFAULT), 0);
   dt_bauhaus_slider_set(gui->tier, dt_conf_get_int("plugins/imageio/format/jxl/tier"));
   dt_bauhaus_widget_set_label(gui->tier, NULL, N_("decoding speed"));
-  gtk_widget_set_tooltip_text(gui->tier, _("the preffered decoding speed with some sacrifice of quality"));
+  gtk_widget_set_tooltip_text(gui->tier, _("the preferred decoding speed with some sacrifice of quality"));
   g_signal_connect(G_OBJECT(gui->tier), "value-changed", G_CALLBACK(tier_changed), NULL);
   gtk_box_pack_start(GTK_BOX(box), gui->tier, TRUE, TRUE, 0);
 }

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1066,7 +1066,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   const size_t width = roi_out->width;
   const size_t height = roi_out->height;
 
-  // allow fast mode, just copy input to ouput
+  // allow fast mode, just copy input to output
   if(fastmode)
   {
     const size_t ch = piece->colors;
@@ -1319,7 +1319,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const int width = roi_in->width;
   const int height = roi_in->height;
 
-  // allow fast mode, just copy input to ouput
+  // allow fast mode, just copy input to output
   if(fastmode)
   {
     size_t origin[] = { 0, 0, 0 };

--- a/src/iop/hlrecovery_v2.c
+++ b/src/iop/hlrecovery_v2.c
@@ -74,7 +74,7 @@ The chosen segmentation algorithm works like this:
      By doing so we avoid direction problems.
   2. Do a box-blur to suppress ridges, the radius depends on segment size.
   3. Possibly add some noise.
-  4. Do a sigmoid correction supressing artefacts at the borders.
+  4. Do a sigmoid correction suppressing artefacts at the borders.
      and write back data from this segment to the gradients plane
 
   The UI offers

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1440,7 +1440,7 @@ static void _commit_params_lf(struct dt_iop_module_t *self, dt_iop_params_t *p1,
 
 /* embedded metadata processing start */
 
-/* This code is based on the alghoritm developed by Freddie Witherden <freddie@witherden.org>
+/* This code is based on the algorithm developed by Freddie Witherden <freddie@witherden.org>
  * in pull request
  * https://github.com/darktable-org/darktable/pull/7092 */
 

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -2866,7 +2866,7 @@ int mouse_moved(struct dt_iop_module_t *module,
 
     if(g->last_hit.elem)
     {
-      // an item is selected, so this mouvement is handled and must
+      // an item is selected, so this movement is handled and must
       // not trigger any panning.
       handled = TRUE;
     }

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -56,7 +56,7 @@ static inline float _calc_linear_refavg(const float *in, const int row, const in
   return powf(croot_refavg[color], HL_POWERF);
 }
 
-// A slighly modified version for sraws
+// A slightly modified version for sraws
 static void _process_linear_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
                          const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
                          dt_iop_highlights_data_t *data)

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -116,7 +116,7 @@ typedef struct dt_iop_retouch_params_t
   dt_iop_retouch_fill_modes_t fill_mode; // $DEFAULT: DT_IOP_RETOUCH_FILL_ERASE $DESCRIPTION: "fill mode" mode for fill algorithm, erase or fill with color
   float fill_color[3];   // $DEFAULT: 0.0 color for fill algorithm
   float fill_brightness; // $MIN: -1.0 $MAX: 1.0 $DESCRIPTION: "brightness" value to be added to the color
-  int max_heal_iter;     // $DEFAULT: 2000 $DESCRIPTION: "max_iter" numbe of iteration for heal algorithm
+  int max_heal_iter;     // $DEFAULT: 2000 $DESCRIPTION: "max_iter" number of iterations for heal algorithm
 } dt_iop_retouch_params_t;
 
 typedef struct dt_iop_retouch_gui_data_t

--- a/src/lua/call.c
+++ b/src/lua/call.c
@@ -381,7 +381,7 @@ static void alien_job_init()
 
 /*
    STRING JOB
-   This is a source that deals with lua jobs that are gien as lua strings
+   This is a source that deals with lua jobs that are given as lua strings
    */
 
 typedef struct {


### PR DESCRIPTION
Found via `codespell -q 3 -S ./.git,*.patch,*.po,*.pot,./src/external,./src/common,./data/pswp,./tools/lua_doc/old_api -L ba,bloc,blocs,bu,childrens,childs,detailled,dinamic,eacg,hist,initiales,ist,inout,liquify,nd,nin,mye,residental,ro,uint,ue,webp,wirth`