### PR TITLE
better alignement of duplicates & fix navigation lib when snapshot active

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -102,6 +102,8 @@ void dt_dev_init(dt_develop_t *dev, gboolean gui_attached)
     // FIXME: these are uint32_t, setting to -1 is confusing
     dev->histogram_pre_tonecurve_max = -1;
     dev->histogram_pre_levels_max = -1;
+    dev->darkroom_mouse_in_center_area = FALSE;
+    dev->darkroom_skip_mouse_events = FALSE;
   }
 
   dev->iop_instance = 0;

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -330,6 +330,7 @@ typedef struct dt_develop_t
 
   int mask_form_selected_id; // select a mask inside an iop
   gboolean darkroom_skip_mouse_events; // skip mouse events for masks
+  gboolean darkroom_mouse_in_center_area; // TRUE if the mouse cursor is in center area
 } dt_develop_t;
 
 void dt_dev_init(dt_develop_t *dev, gboolean gui_attached);

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -526,6 +526,21 @@ void dt_second_window_check_zoom_bounds(dt_develop_t *dev, float *zoom_x, float 
 void dt_dev_undo_start_record(dt_develop_t *dev);
 void dt_dev_undo_end_record(dt_develop_t *dev);
 
+/*
+ * develop an image and returns the buf and processed width / height.
+ * this is done as in the context of the darkroom, meaning that the
+ * final processed sizes will align perfectly on the darkroom view.
+ *
+ */
+void dt_dev_image(
+  uint32_t imgid,
+  size_t width,
+  size_t height,
+  int history_end,
+  uint8_t **buf,
+  size_t *processed_width,
+  size_t *processed_height);
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -197,44 +197,7 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
 
   dt_dev_image(d->imgid, width, height, -1, &buf, &processed_width, &processed_height);
 
-  const int32_t stride =
-    cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, processed_width);
-  cairo_surface_t *surface = dt_cairo_image_surface_create_for_data
-    (buf, CAIRO_FORMAT_RGB24, processed_width, processed_height, stride);
-
-  dt_develop_t *dev = darktable.develop;
-
-  const int bs = dev->border_size;
-  const dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
-  const int closeup = dt_control_get_dev_closeup();
-  const float zoom_scale = dt_dev_get_zoom_scale(dev, zoom, 1<<closeup, 1);
-
-  const float sw = (float)processed_width;
-  const float sh = (float)processed_height;
-
-  cairo_translate(cri, ceilf(.5f * (width - sw)), ceilf(.5f * (height - sh)));
-  if(closeup)
-  {
-    const double scale = 1<<closeup;
-    cairo_scale(cri, scale, scale);
-    cairo_translate(cri, -(.5 - 0.5/scale) * sw, -(.5 - 0.5/scale) * sh);
-  }
-
-  if(dev->iso_12646.enabled)
-  {
-    // draw the white frame around picture
-    const double tbw = (float)(bs >> closeup) * 2.0 / 3.0;
-    cairo_rectangle(cri, -tbw, -tbw, sw + 2.0 * tbw, sh + 2.0 * tbw);
-    cairo_set_source_rgb(cri, 1., 1., 1.);
-    cairo_fill(cri);
-    dt_gui_gtk_set_source_rgb(cri, DT_GUI_COLOR_DARKROOM_BG);
-  }
-
-  cairo_set_source_surface (cri, surface, 0, 0);
-  cairo_pattern_set_filter
-    (cairo_get_source(cri),
-     zoom_scale >= 0.9999f ? CAIRO_FILTER_FAST : darktable.gui->dr_filter_image);
-  cairo_paint(cri);
+  dt_view_paint_buffer(cri, width, height, buf, processed_width, processed_height);
 }
 
 static void _thumb_remove(gpointer user_data)

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -150,24 +150,7 @@ static void _lib_duplicate_thumb_press_callback(GtkWidget *widget, GdkEventButto
   {
     if(event->type == GDK_BUTTON_PRESS)
     {
-      dt_develop_t *dev = darktable.develop;
-      if(!dev) return;
-
-      dt_dev_invalidate(dev);
-      dt_control_queue_redraw_center();
-
-      dt_dev_invalidate(darktable.develop);
-
       d->imgid = imgid;
-      int fw, fh;
-      fw = fh = 0;
-      dt_image_get_final_size(imgid, &fw, &fh);
-      if(d->cur_final_width <= 0)
-        dt_image_get_final_size(dev->image_storage.id, &d->cur_final_width, &d->cur_final_height);
-      d->allow_zoom
-          = (d->cur_final_width - fw < DUPLICATE_COMPARE_SIZE && d->cur_final_width - fw > -DUPLICATE_COMPARE_SIZE
-             && d->cur_final_height - fh < DUPLICATE_COMPARE_SIZE
-             && d->cur_final_height - fh > -DUPLICATE_COMPARE_SIZE);
       dt_control_queue_redraw_center();
     }
     else if(event->type == GDK_2BUTTON_PRESS)
@@ -205,166 +188,53 @@ void view_leave(struct dt_lib_module_t *self, struct dt_view_t *old_view, struct
 void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t height, int32_t pointerx, int32_t pointery)
 {
   dt_lib_duplicate_t *d = (dt_lib_duplicate_t *)self->data;
+
   if(d->imgid == 0) return;
+
+  uint8_t *buf = NULL;
+  size_t processed_width;
+  size_t processed_height;
+
+  dt_dev_image(d->imgid, width, height, -1, &buf, &processed_width, &processed_height);
+
+  const int32_t stride =
+    cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, processed_width);
+  cairo_surface_t *surface = dt_cairo_image_surface_create_for_data
+    (buf, CAIRO_FORMAT_RGB24, processed_width, processed_height, stride);
+
   dt_develop_t *dev = darktable.develop;
-  if(!dev->preview_pipe->backbuf || dev->preview_status != DT_DEV_PIXELPIPE_VALID) return;
 
-  // use the same resolution as main previem image to avoid blur
-  float img_wd, img_ht;
-  if(d->allow_zoom)
-  {
-    img_wd = dev->preview_pipe->backbuf_width;
-    img_ht = dev->preview_pipe->backbuf_height;
-  }
-  else
-  {
-    int w2, h2;
-    dt_image_get_final_size(d->imgid, &w2, &h2);
-    img_wd = w2;
-    img_ht = h2;
-  }
+  const int bs = dev->border_size;
+  const dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
+  const int closeup = dt_control_get_dev_closeup();
+  const float zoom_scale = dt_dev_get_zoom_scale(dev, zoom, 1<<closeup, 1);
 
-  const int32_t tb = darktable.develop->border_size;
+  const float sw = (float)processed_width;
+  const float sh = (float)processed_height;
 
-  // we rescale the sizes to the screen size
-  if(img_ht * (width - 2 * tb) > img_wd * (height - 2 * tb))
+  cairo_translate(cri, ceilf(.5f * (width - sw)), ceilf(.5f * (height - sh)));
+  if(closeup)
   {
-    img_wd = img_wd*(height - 2 * tb)/img_ht;
-    img_ht = (height - 2 * tb);
-  }
-  else
-  {
-    img_ht = img_ht*(width - 2 * tb)/img_wd;
-    img_wd = (width - 2 * tb);
+    const double scale = 1<<closeup;
+    cairo_scale(cri, scale, scale);
+    cairo_translate(cri, -(.5 - 0.5/scale) * sw, -(.5 - 0.5/scale) * sh);
   }
 
-  // Get the resizing from borders - only to check validity of mipmap cache size
-  float zoom_ratio = 1.f;
   if(dev->iso_12646.enabled)
   {
-    if(img_wd - 2 * tb < img_ht - 2 * tb)
-      zoom_ratio = (img_ht - 2 * tb) / img_ht;
-    else
-      zoom_ratio = (img_wd - 2 * tb) / img_wd;
+    // draw the white frame around picture
+    const double tbw = (float)(bs >> closeup) * 2.0 / 3.0;
+    cairo_rectangle(cri, -tbw, -tbw, sw + 2.0 * tbw, sh + 2.0 * tbw);
+    cairo_set_source_rgb(cri, 1., 1., 1.);
+    cairo_fill(cri);
+    dt_gui_gtk_set_source_rgb(cri, DT_GUI_COLOR_DARKROOM_BG);
   }
 
-  // if image have too different sizes, we show the full preview not zoomed
-  float nz = 1.0f;
-  if(d->allow_zoom)
-  {
-    const int closeup = dt_control_get_dev_closeup();
-    const dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
-    const float min_scale = dt_dev_get_zoom_scale(dev, DT_ZOOM_FIT, 1 << closeup, 0);
-    const float cur_scale = dt_dev_get_zoom_scale(dev, zoom, 1 << closeup, 0);
-    // if cur_scale is >=2.0f (200%) we disable preview as it can hit cairo size limits without warnings
-    if(cur_scale >= 2.0f)
-    {
-      /* xgettext:no-c-format */
-      dt_control_log(_("preview is only possible for zoom lower than 200%%"));
-      return;
-    }
-    nz = cur_scale / min_scale;
-  }
-
-  // if not cached, load or reload a mipmap
-  dt_view_surface_value_t res = DT_VIEW_SURFACE_OK;
-  if(d->preview_id != d->imgid || d->preview_zoom != nz * zoom_ratio || !d->preview_surf
-     || d->preview_width != width || d->preview_height != height)
-  {
-    d->preview_width = width;
-    d->preview_height = height;
-
-    res = dt_view_image_get_surface(d->imgid, img_wd * nz, img_ht * nz, &d->preview_surf, TRUE);
-
-    if(res == DT_VIEW_SURFACE_OK)
-    {
-      d->preview_id = d->imgid;
-      d->preview_zoom = nz * zoom_ratio; //  only to check validity of mipmap cache size
-    }
-  }
-
-  // if ready, we draw the surface
-  if(d->preview_surf)
-  {
-    cairo_save(cri);
-    // force middle grey in background
-    if(dev->iso_12646.enabled)
-      cairo_set_source_rgb(cri, 0.4663, 0.4663, 0.4663);
-    else
-      dt_gui_gtk_set_source_rgb(cri, DT_GUI_COLOR_DARKROOM_BG);
-
-    // draw background
-    cairo_paint(cri);
-
-    // move coordinates according to margin
-    float wd, ht;
-    if(d->allow_zoom)
-    {
-      wd = dev->pipe->output_backbuf_width / darktable.gui->ppd;
-      ht = dev->pipe->output_backbuf_height / darktable.gui->ppd;
-    }
-    else
-    {
-      wd = img_wd / darktable.gui->ppd;
-      ht = img_ht / darktable.gui->ppd;
-    }
-    const float margin_left = ceilf(.5f * (width - wd));
-    const float margin_top = ceilf(.5f * (height - ht));
-    cairo_translate(cri, margin_left, margin_top);
-
-    if(dev->iso_12646.enabled)
-    {
-      // draw the white frame around picture
-      cairo_rectangle(cri, -tb / 3., -tb / 3., wd + 2. * tb / 3., ht + 2. * tb / 3.);
-      cairo_set_source_rgb(cri, 1., 1., 1.);
-      cairo_fill(cri);
-    }
-
-    // finally, draw the image
-    cairo_rectangle(cri, 0, 0, wd, ht);
-    cairo_clip_preserve(cri);
-
-    const float scaler = 1.0f / darktable.gui->ppd_thb;
-    cairo_scale(cri, scaler, scaler);
-
-
-    if(d->allow_zoom)
-    {
-      // compute the surface pixel shift to match reference image FIXME!
-      const float zoom_y = dt_control_get_dev_zoom_y();
-      const float zoom_x = dt_control_get_dev_zoom_x();
-      const float dx = -floorf(zoom_x * (img_wd)*nz + img_wd * nz / 2. - width / 2.) - margin_left;
-      const float dy = -floorf(zoom_y * (img_ht)*nz + img_ht * nz / 2. - height / 2.) - margin_top;
-      cairo_set_source_surface(cri, d->preview_surf, dx / scaler, dy / scaler);
-    }
-    else
-      cairo_set_source_surface(cri, d->preview_surf, 0, 0);
-
-    cairo_pattern_set_filter(cairo_get_source(cri), (darktable.gui->filter_image == CAIRO_FILTER_FAST)
-      ? CAIRO_FILTER_GOOD : darktable.gui->filter_image) ;
-    cairo_paint(cri);
-
-    cairo_restore(cri);
-  }
-
-  if(res != DT_VIEW_SURFACE_OK)
-  {
-    if(!d->busy)
-    {
-      dt_control_log_busy_enter();
-      dt_control_toast_busy_enter();
-    }
-    d->busy = TRUE;
-  }
-  else
-  {
-    if(d->busy)
-    {
-      dt_control_log_busy_leave();
-      dt_control_toast_busy_leave();
-    }
-    d->busy = FALSE;
-  }
+  cairo_set_source_surface (cri, surface, 0, 0);
+  cairo_pattern_set_filter
+    (cairo_get_source(cri),
+     zoom_scale >= 0.9999f ? CAIRO_FILTER_FAST : darktable.gui->dr_filter_image);
+  cairo_paint(cri);
 }
 
 static void _thumb_remove(gpointer user_data)

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -129,22 +129,6 @@ static void _draw_sym(cairo_t *cr, float x, float y, gboolean vertical, gboolean
   g_object_unref(layout);
 }
 
-// export image for the snapshot d->snapshot[d->selected]
-static int _take_image_snapshot(
-  dt_lib_module_t *self,
-  uint32_t imgid,
-  size_t width,
-  size_t height,
-  int history_end)
-{
-  dt_lib_snapshots_t *d = (dt_lib_snapshots_t *)self->data;
-
-  dt_dev_image(imgid, width, height, history_end,
-               &d->params.buf, &d->params.width, &d->params.height);
-
-  return 0;
-}
-
 static gboolean _snap_expose_again(gpointer user_data)
 {
   dt_lib_snapshots_t *d = (dt_lib_snapshots_t *)user_data;
@@ -170,8 +154,9 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
     // if a new snapshot is needed, do this now
     if(d->snap_requested)
     {
-      // export image with proper size, remove the darkroom borders
-      _take_image_snapshot(self, snap->imgid, width, height, snap->history_end);
+      // export image with proper size
+      dt_dev_image(snap->imgid, width, height, snap->history_end,
+                   &d->params.buf, &d->params.width, &d->params.height);
 
       if(snap->surface) cairo_surface_destroy(snap->surface);
       snap->surface = dt_view_create_surface(d->params.buf, d->params.width, d->params.height);

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -190,9 +190,10 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
     if(snap->ctx != ctx
        || !snap->surface)
     {
-      // request a new snapshot now only if not panning, otherwise it will be
-      // requested by the cb timer below.
-      if(!d->panning) d->snap_requested = TRUE;
+      // request a new snapshot in the following conditions:
+      //    1. we are not panning
+      //    2. the mouse is not over the center area, probably panning with the navigation module
+      if(!d->panning && dev->darkroom_mouse_in_center_area) d->snap_requested = TRUE;
       if(d->expose_again_timeout_id != -1) g_source_remove(d->expose_again_timeout_id);
       d->expose_again_timeout_id = g_timeout_add(150, _snap_expose_again, d);
       return;

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -161,8 +161,6 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
       if(snap->surface) cairo_surface_destroy(snap->surface);
       snap->surface = dt_view_create_surface(d->params.buf, d->params.width, d->params.height);
 
-      snap->ctx = ctx;
-
       snap->width  = d->params.width;
       snap->height = d->params.height;
       d->snap_requested = FALSE;
@@ -199,11 +197,6 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
     const double ly = height * d->vp_ypointer;
 
     const double size = DT_PIXEL_APPLY_DPI(d->inverted ? -15 : 15);
-
-    // if we have not yet a proper surface, return
-    // we let the main darkroom picture displayed and wait for the
-    // proper aligned snapshot to be ready.
-    if(!snap->surface) return;
 
     // clear background
     dt_gui_gtk_set_source_rgb(cri, DT_GUI_COLOR_DARKROOM_BG);

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -56,7 +56,7 @@ typedef struct dt_lib_snapshot_t
 typedef struct dt_lib_snapshot_params_t
 {
   uint8_t *buf;
-  uint32_t width, height;
+  size_t width, height;
 } dt_lib_snapshot_params_t;
 
 typedef struct dt_lib_snapshots_t
@@ -145,45 +145,8 @@ static int _take_image_snapshot(
 {
   dt_lib_snapshots_t *d = (dt_lib_snapshots_t *)self->data;
 
-  // create a dev
-
-  dt_develop_t dev;
-  dt_dev_init(&dev, TRUE);
-  dev.border_size = darktable.develop->border_size;
-  dev.iso_12646.enabled = darktable.develop->iso_12646.enabled;
-
-  // create the full pipe
-
-  dt_dev_pixelpipe_init(dev.pipe);
-
-  // load image and set history_end
-
-  dt_dev_load_image(&dev, imgid);
-
-  if(history_end != -1)
-    dt_dev_pop_history_items_ext(&dev, history_end);
-
-  // configure the actual dev width & height
-
-  dt_dev_configure(&dev, width, height);
-
-  // process the pipe
-
-  dev.gui_attached = FALSE;
-  dt_dev_process_image_job(&dev);
-
-  // record resulting image and dimentions
-
-  const uint32_t bufsize =
-    sizeof(uint32_t) * dev.pipe->backbuf_width * dev.pipe->backbuf_height;
-  d->params.buf = dt_alloc_align(64, bufsize);
-  memcpy(d->params.buf, dev.pipe->backbuf, bufsize);
-  d->params.width  = dev.pipe->backbuf_width;
-  d->params.height = dev.pipe->backbuf_height;
-
-  // we take the backbuf, avoid it to be released
-
-  dt_dev_cleanup(&dev);
+  dt_dev_image(imgid, width, height, history_end,
+               &d->params.buf, &d->params.width, &d->params.height);
 
   return 0;
 }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3286,6 +3286,7 @@ void mouse_leave(dt_view_t *self)
   dt_develop_t *dev = (dt_develop_t *)self->data;
   dt_control_set_mouse_over_id(dev->image_storage.id);
 
+  dev->darkroom_mouse_in_center_area = FALSE;
   // masks
   int handled = dt_masks_events_mouse_leave(dev->gui_module);
   if(handled) return;
@@ -3319,6 +3320,7 @@ void mouse_enter(dt_view_t *self)
 {
   dt_develop_t *dev = (dt_develop_t *)self->data;
   // masks
+  dev->darkroom_mouse_in_center_area = TRUE;
   dt_masks_events_mouse_enter(dev->gui_module);
 }
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1459,9 +1459,74 @@ void dt_view_audio_stop(dt_view_manager_t *vm)
   g_spawn_close_pid(vm->audio.audio_player_pid);
   vm->audio.audio_player_id = -1;
 }
+
+void dt_view_paint_surface(
+  cairo_t *cr,
+  const size_t width,
+  const size_t height,
+  cairo_surface_t *surface,
+  const size_t processed_width,
+  const size_t processed_height)
+{
+  dt_develop_t *dev = darktable.develop;
+
+  const int bs = dev->border_size;
+  const dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
+  const int closeup = dt_control_get_dev_closeup();
+  const float zoom_scale = dt_dev_get_zoom_scale(dev, zoom, 1<<closeup, 1);
+
+  const float sw = (float)processed_width;
+  const float sh = (float)processed_height;
+
+  cairo_translate(cr, ceilf(.5f * (width - sw)), ceilf(.5f * (height - sh)));
+  if(closeup)
+  {
+    const double scale = 1<<closeup;
+    cairo_scale(cr, scale, scale);
+    cairo_translate(cr, -(.5 - 0.5/scale) * sw, -(.5 - 0.5/scale) * sh);
+  }
+
+  if(dev->iso_12646.enabled)
+  {
+    // draw the white frame around picture
+    const double tbw = (float)(bs >> closeup) * 2.0 / 3.0;
+    cairo_rectangle(cr, -tbw, -tbw, sw + 2.0 * tbw, sh + 2.0 * tbw);
+    cairo_set_source_rgb(cr, 1., 1., 1.);
+    cairo_fill(cr);
+  }
+
+  cairo_set_source_surface (cr, surface, 0, 0);
+  cairo_pattern_set_filter
+    (cairo_get_source(cr),
+     zoom_scale >= 0.9999f ? CAIRO_FILTER_FAST : darktable.gui->dr_filter_image);
+  cairo_paint(cr);
+}
+
+cairo_surface_t *dt_view_create_surface(
+  uint8_t *buffer,
+  const size_t processed_width,
+  const size_t processed_height)
+{
+  const int32_t stride =
+    cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, processed_width);
+  return dt_cairo_image_surface_create_for_data
+    (buffer, CAIRO_FORMAT_RGB24, processed_width, processed_height, stride);
+}
+
+void dt_view_paint_buffer(
+  cairo_t *cr,
+  const size_t width,
+  const size_t height,
+  uint8_t *buffer,
+  const size_t processed_width,
+  const size_t processed_height)
+{
+  cairo_surface_t *surface = dt_view_create_surface(buffer, processed_width, processed_height);
+  dt_view_paint_surface(cr, width, height, surface, processed_width, processed_height);
+}
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1525,6 +1525,43 @@ void dt_view_paint_buffer(
   dt_view_paint_surface(cr, width, height, surface, processed_width, processed_height);
 }
 
+#define ADD_TO_CONTEXT(v) ctx = ((ctx << 5) + ctx) ^ (dt_view_context_t)(v);
+
+dt_view_context_t dt_view_get_view_context(void)
+{
+  dt_develop_t *dev = darktable.develop;
+  const dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
+  const int closeup = dt_control_get_dev_closeup();
+  const float zoom_scale = dt_dev_get_zoom_scale(dev, zoom, 1<<closeup, 1);
+  const float zoom_y = dt_control_get_dev_zoom_y();
+  const float zoom_x = dt_control_get_dev_zoom_x();
+  const gboolean iso_12646 = dev->iso_12646.enabled;
+  const float flt_prec = 1.e6;
+
+  dt_view_context_t ctx = 0;
+  ADD_TO_CONTEXT(closeup);
+  ADD_TO_CONTEXT(zoom_scale * flt_prec);
+  ADD_TO_CONTEXT(zoom_x * flt_prec);
+  ADD_TO_CONTEXT(zoom_y * flt_prec);
+  ADD_TO_CONTEXT(iso_12646);
+
+  return ctx;
+}
+
+gboolean dt_view_check_view_context(dt_view_context_t *ctx)
+{
+  const dt_view_context_t curctx = dt_view_get_view_context();
+  if(curctx == *ctx)
+  {
+    return TRUE;
+  }
+  else
+  {
+    *ctx = curctx;
+    return FALSE;
+  }
+}
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -511,6 +511,12 @@ void dt_view_paint_surface(
   const size_t processed_width,
   const size_t processed_height);
 
+typedef uint64_t dt_view_context_t;
+
+dt_view_context_t dt_view_get_view_context(void);
+
+gboolean dt_view_check_view_context(dt_view_context_t *ctx);
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -485,9 +485,34 @@ void dt_view_map_drag_set_icon(const dt_view_manager_t *vm, GdkDragContext *cont
 void dt_view_print_settings(const dt_view_manager_t *vm, dt_print_info_t *pinfo, dt_images_box *imgs);
 #endif
 
+/*
+ * Paint buffer (size processed_width x processed_height) in cairo (as a surface)
+ * on the viewport (size width x height).
+ */
+
+void dt_view_paint_buffer(
+  cairo_t *cr,
+  const size_t width,
+  const size_t height,
+  uint8_t *buffer,
+  const size_t processed_width,
+  const size_t processed_height);
+
+cairo_surface_t *dt_view_create_surface(
+  uint8_t *buffer,
+  const size_t processed_width,
+  const size_t processed_height);
+
+void dt_view_paint_surface(
+  cairo_t *cr,
+  const size_t width,
+  const size_t height,
+  cairo_surface_t *surface,
+  const size_t processed_width,
+  const size_t processed_height);
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-


### PR DESCRIPTION
Rework duplicate display with newly added darkroom like dev pipe. This ensure proper alignment.

It has also been able to do a large clean-up.

@AlicVB : Can you have a look? TIA.

This latest version, after some code refactoring, also share code with the snapshots lib.