### PR TITLE
ioporder: use right name on reset

### DIFF
--- a/src/libs/ioporder.c
+++ b/src/libs/ioporder.c
@@ -120,23 +120,13 @@ void update(dt_lib_module_t *self)
     if(!found)
     {
       d->current_mode = DT_IOP_ORDER_CUSTOM;
-      gtk_label_set_text(GTK_LABEL(d->widget), _(dt_iop_order_string(DT_IOP_ORDER_CUSTOM)));
+      gtk_label_set_text(GTK_LABEL(d->widget), _(dt_iop_order_string(d->current_mode)));
     }
   }
-  else if(kind == DT_IOP_ORDER_LEGACY)
+  else
   {
     d->current_mode = kind;
-    gtk_label_set_text(GTK_LABEL(d->widget), _(dt_iop_order_string(DT_IOP_ORDER_LEGACY)));
-  }
-  else if(kind == DT_IOP_ORDER_V30)
-  {
-    d->current_mode = kind;
-    gtk_label_set_text(GTK_LABEL(d->widget), _(dt_iop_order_string(DT_IOP_ORDER_V30)));
-  }
-  else if(kind == DT_IOP_ORDER_V30_JPG)
-  {
-    d->current_mode = kind;
-    gtk_label_set_text(GTK_LABEL(d->widget), _(dt_iop_order_string(DT_IOP_ORDER_V30_JPG)));
+    gtk_label_set_text(GTK_LABEL(d->widget), _(dt_iop_order_string(d->current_mode)));
   }
 }
 
@@ -191,7 +181,7 @@ void gui_reset (dt_lib_module_t *self)
     dt_dev_pixelpipe_rebuild(darktable.develop);
 
     d->current_mode = DT_IOP_ORDER_V30;
-    if(d->widget) gtk_label_set_text(GTK_LABEL(d->widget), _(dt_iop_order_string(DT_IOP_ORDER_V30)));
+    if(d->widget) gtk_label_set_text(GTK_LABEL(d->widget), _(dt_iop_order_string(d->current_mode)));
 
     g_list_free_full(iop_order_list, free);
   }

--- a/src/libs/ioporder.c
+++ b/src/libs/ioporder.c
@@ -191,8 +191,8 @@ void gui_reset (dt_lib_module_t *self)
     dt_dev_pixelpipe_rebuild(darktable.develop);
 
     d->current_mode = DT_IOP_ORDER_V30;
-    if(d->widget)
-      gtk_label_set_text(GTK_LABEL(d->widget), _("v3.0"));
+    if(d->widget) gtk_label_set_text(GTK_LABEL(d->widget), _(dt_iop_order_string(DT_IOP_ORDER_V30)));
+
     g_list_free_full(iop_order_list, free);
   }
 }


### PR DESCRIPTION
On reset a fixed string was used instead of the utility function `dt_iop_order_string`.

Without the patch:

Click Reset:
![image](https://user-images.githubusercontent.com/1690273/199722528-16dc6a45-4032-4445-be89-768d4b65cf21.png)

After reset:
![image](https://user-images.githubusercontent.com/1690273/199722426-e8a5fc40-d56f-4c5e-8479-222741997367.png)

With this patch, after clicking reset the right name (`v3.0 RAW`) is used.
