### PR TITLE
Olympus embedded metadata lens correction

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -954,59 +954,9 @@ static gboolean _check_lens_correction_data(Exiv2::ExifData &exifData, dt_image_
   }
 
   /*
-   * Olympus distortion correction for a Four Thirds SLR lens on a FT or MFT body
+   * Olympus distortion correction
    */
   if(Exiv2::versionNumber() >= EXIV2_MAKE_VERSION(0, 27, 4)
-    && _exif_read_exif_tag(exifData, &pos, "Exif.OlympusIp.0x0800"))
-  {
-    if(pos->count() == 9)
-    {
-      for(int i = 0; i < 9; i++)
-      {
-        float kd = pos->toFloat(i);
-        if (kd != 0)
-        {
-          img->exif_correction_type = CORRECTION_TYPE_OLYMPUS;
-          img->exif_correction_data.olympus.has_ft_dist = TRUE;
-        }
-
-        img->exif_correction_data.olympus.ft_dist[i] = kd;
-      }
-    }
-  }
-
-  /*
-   * Olympus distortion correction for a Micro Four Thirds lens
-   *
-   * There are two tags that may contain distortion polynomials: 0x150a and
-   * 0x1510. Older cameras use 0x150a, some newer cameras use only 0x1510, and
-   * some cameras use both. For the case where both are defined, the only
-   * difference is that the coefficients in 0x1510 are scaled so that the
-   * undistorted image is slightly more cropped.
-   */
-  if(Exiv2::versionNumber() >= EXIV2_MAKE_VERSION(0, 27, 4)
-    && _exif_read_exif_tag(exifData, &pos, "Exif.OlympusIp.0x1510"))
-  {
-    if(pos->count() == 4)
-    {
-      for(int i = 0; i < 4; i++)
-      {
-        float kd = pos->toFloat(i);
-        img->exif_correction_data.olympus.mft_dist[i] = kd;
-        if (kd != 0 && i < 3)
-        {
-          // Assume it's valid if any of the first three elements are nonzero. Ignore the
-          // fourth element since the null value for no correction is '0 0 0 1'
-          img->exif_correction_type = CORRECTION_TYPE_OLYMPUS;
-          img->exif_correction_data.olympus.has_mft_dist = TRUE;
-        }
-      }
-    }
-  }
-
-  // If we didn't find a non-null 0x1510, then check for 0x150a
-  if(!(img->exif_correction_type == CORRECTION_TYPE_OLYMPUS && img->exif_correction_data.olympus.has_mft_dist)
-     && Exiv2::versionNumber() >= EXIV2_MAKE_VERSION(0, 27, 4)
      && _exif_read_exif_tag(exifData, &pos, "Exif.OlympusIp.0x150a"))
   {
     if(pos->count() == 4)
@@ -1014,20 +964,20 @@ static gboolean _check_lens_correction_data(Exiv2::ExifData &exifData, dt_image_
       for(int i = 0; i < 4; i++)
       {
         float kd = pos->toFloat(i);
-        img->exif_correction_data.olympus.mft_dist[i] = kd;
+        img->exif_correction_data.olympus.dist[i] = kd;
         if (kd != 0 && i < 3)
         {
           // Assume it's valid if any of the first three elements are nonzero. Ignore the
           // fourth element since the null value for no correction is '0 0 0 1'
           img->exif_correction_type = CORRECTION_TYPE_OLYMPUS;
-          img->exif_correction_data.olympus.has_mft_dist = TRUE;
+          img->exif_correction_data.olympus.has_dist = TRUE;
         }
       }
     }
   }
 
   /*
-   * Olympus CA correction for a Micro Four Thirds lens
+   * Olympus CA correction
    */
   if(Exiv2::versionNumber() >= EXIV2_MAKE_VERSION(0, 27, 4)
     && _exif_read_exif_tag(exifData, &pos, "Exif.OlympusIp.0x150c"))
@@ -1037,32 +987,11 @@ static gboolean _check_lens_correction_data(Exiv2::ExifData &exifData, dt_image_
       for(int i = 0; i < 6; i++)
       {
         float kc = pos->toFloat(i);
-        img->exif_correction_data.olympus.mft_ca[i] = kc;
+        img->exif_correction_data.olympus.ca[i] = kc;
         if (kc != 0)
         {
           img->exif_correction_type = CORRECTION_TYPE_OLYMPUS;
-          img->exif_correction_data.olympus.has_mft_ca = TRUE;
-        }
-      }
-    }
-  }
-
-  /*
-   * Olympus vignetting correction
-   */
-  if(Exiv2::versionNumber() >= EXIV2_MAKE_VERSION(0, 27, 4)
-    && _exif_read_exif_tag(exifData, &pos, "Exif.OlympusIp.0x0801"))
-  {
-    if(pos->count() == 16)
-    {
-      for(int i = 0; i < 16; i++)
-      {
-        float kv = pos->toFloat(i);
-        img->exif_correction_data.olympus.vignetting[i] = kv;
-        if (kv != 0)
-        {
-          img->exif_correction_type = CORRECTION_TYPE_OLYMPUS;
-          img->exif_correction_data.olympus.has_vignetting = TRUE;
+          img->exif_correction_data.olympus.has_ca = TRUE;
         }
       }
     }

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -963,7 +963,7 @@ static gboolean _check_lens_correction_data(Exiv2::ExifData &exifData, dt_image_
     {
       for(int i = 0; i < 4; i++)
       {
-        float kd = pos->toFloat(i);
+        const float kd = pos->toFloat(i);
         img->exif_correction_data.olympus.dist[i] = kd;
         if (kd != 0 && i < 3)
         {
@@ -986,7 +986,7 @@ static gboolean _check_lens_correction_data(Exiv2::ExifData &exifData, dt_image_
     {
       for(int i = 0; i < 6; i++)
       {
-        float kc = pos->toFloat(i);
+        const float kc = pos->toFloat(i);
         img->exif_correction_data.olympus.ca[i] = kc;
         if (kc != 0)
         {

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -2075,6 +2075,7 @@ void dt_image_init(dt_image_t *img)
   img->usercrop[2] = img->usercrop[3] = 1;
   img->dng_gain_maps = NULL;
   img->exif_correction_type = CORRECTION_TYPE_NONE;
+  memset(&img->exif_correction_data, 0, sizeof(img->exif_correction_data));
   img->cache_entry = 0;
 
   for(int k=0; k<4; k++)

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -153,7 +153,8 @@ typedef enum dt_image_correction_type_t
   CORRECTION_TYPE_NONE,
   CORRECTION_TYPE_SONY,
   CORRECTION_TYPE_FUJI,
-  CORRECTION_TYPE_DNG
+  CORRECTION_TYPE_DNG,
+  CORRECTION_TYPE_OLYMPUS
 } dt_image_correction_type_t;
 
 typedef union dt_image_correction_data_t
@@ -176,6 +177,16 @@ typedef union dt_image_correction_data_t
     gboolean has_warp;
     gboolean has_vignette;
   } dng;
+  struct {
+    gboolean has_ft_dist;
+    float ft_dist[9];
+    gboolean has_mft_dist;
+    float mft_dist[4];
+    gboolean has_mft_ca;
+    float mft_ca[6];
+    gboolean has_vignetting;
+    short vignetting[16];
+  } olympus;
 } dt_image_correction_data_t;
 
 typedef enum dt_image_loader_t

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -178,14 +178,10 @@ typedef union dt_image_correction_data_t
     gboolean has_vignette;
   } dng;
   struct {
-    gboolean has_ft_dist;
-    float ft_dist[9];
-    gboolean has_mft_dist;
-    float mft_dist[4];
-    gboolean has_mft_ca;
-    float mft_ca[6];
-    gboolean has_vignetting;
-    short vignetting[16];
+    gboolean has_dist;
+    float dist[4];
+    gboolean has_ca;
+    float ca[6];
   } olympus;
 } dt_image_correction_data_t;
 

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2431,7 +2431,16 @@ static int _init_coeffs_md_v2(const dt_image_t *img,
       if(cor_rgb && p->modify_flags & DT_IOP_LENS_MODIFY_FLAG_DISTORTION)
       {
         // Convert the polynomial to a spline by evaluating it at each knot
-        const float r_cor = dk0 + dk2 * powf(r, 2) + dk4 * powf(r, 4) + dk6 * powf(r, 6);
+        //
+        // The distortion polynomial maps a radius Rout in the output
+        // (undistorted) image, where the corner is defined as Rout=dk0, to a
+        // radius in the input (distorted) image, where the corner is defined as
+        // Rin=1.
+        // Rin = Rout * (1 + dk2 * Rout^2 + dk4 * Rout^4 + dk6 * Rout^6)
+        // Here we scale Rout by dk0 so that we can evaluate the spline with the
+        // corner of the output image defined as Rout=1 instead of Rout=dk0.
+        const float rs = r * dk0;
+        const float r_cor = dk0 * (1 + dk2 * powf(rs, 2) + dk4 * powf(rs, 4) + dk6 * powf(rs, 6));
         cor_rgb[0][i] = cor_rgb[1][i] = cor_rgb[2][i] = (p->cor_dist_ft * (r_cor - 1) + 1);
       }
       else if(cor_rgb)

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2401,10 +2401,10 @@ static int _init_coeffs_md_v2(const dt_image_t *img,
   else if(img->exif_correction_type == CORRECTION_TYPE_OLYMPUS)
   {
     // Get the coefficients for the distortion polynomial
-    float dk0 = 1, dk2 = 0, dk4 = 0, dk6 = 0;
+    float drs = 1, dk2 = 0, dk4 = 0, dk6 = 0;
     if(cd->olympus.has_dist)
     {
-      dk0 = cd->olympus.dist[3];
+      drs = cd->olympus.dist[3]; // Defines radius of corner of output image
       dk2 = cd->olympus.dist[0];
       dk4 = cd->olympus.dist[1];
       dk6 = cd->olympus.dist[2];
@@ -2433,14 +2433,14 @@ static int _init_coeffs_md_v2(const dt_image_t *img,
         // Convert the polynomial to a spline by evaluating it at each knot
         //
         // The distortion polynomial maps a radius Rout in the output
-        // (undistorted) image, where the corner is defined as Rout=dk0, to a
+        // (undistorted) image, where the corner is defined as Rout=drs, to a
         // radius in the input (distorted) image, where the corner is defined as
         // Rin=1.
         // Rin = Rout * (1 + dk2 * Rout^2 + dk4 * Rout^4 + dk6 * Rout^6)
-        // Here we scale Rout by dk0 so that we can evaluate the spline with the
-        // corner of the output image defined as Rout=1 instead of Rout=dk0.
-        const float rs = r * dk0;
-        const float r_cor = dk0 * (1 + dk2 * powf(rs, 2) + dk4 * powf(rs, 4) + dk6 * powf(rs, 6));
+        // Here we scale Rout by drs so that we can evaluate the spline with the
+        // corner of the output image defined as Rout=1 instead of Rout=drs.
+        const float rs = r * drs;
+        const float r_cor = drs * (1 + dk2 * powf(rs, 2) + dk4 * powf(rs, 4) + dk6 * powf(rs, 6));
         cor_rgb[0][i] = cor_rgb[1][i] = cor_rgb[2][i] = (p->cor_dist_ft * (r_cor - 1) + 1);
       }
       else if(cor_rgb)

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2428,21 +2428,20 @@ static int _init_coeffs_md_v2(const dt_image_t *img,
       const float r = (float) i / (float) (nc - 1);
       knots_dist[i] = knots_vig[i] = r;
 
-      // Convert the polynomial to a spline by evaluating it at each knot
-      //
-      // The distortion polynomial maps a radius Rout in the output
-      // (undistorted) image, where the corner is defined as Rout=1, to a
-      // radius in the input (distorted) image, where the corner is defined as
-      // Rin=1.
-      // Rin = Rout*dk0 * (1 + dk2 * (Rout*dk0)^2 + dk4 * (Rout*dk0)^4 + dk6 * (Rout*dk0)^6)
-      //
-      // r_cor is Rin / Rout. Calculate it even if distortion correction is
-      // off, because it is also used for CA correction.
-      const float rs2 = powf(r * drs, 2);
-      const float r_cor = drs * (1 + rs2 * (dk2 + rs2 * (dk4 + rs2 * dk6)));
-
       if(cor_rgb && p->modify_flags & DT_IOP_LENS_MODIFY_FLAG_DISTORTION)
       {
+        // Convert the polynomial to a spline by evaluating it at each knot
+        //
+        // The distortion polynomial maps a radius Rout in the output
+        // (undistorted) image, where the corner is defined as Rout=1, to a
+        // radius in the input (distorted) image, where the corner is defined
+        // as Rin=1.
+        // Rin = Rout*dk0 * (1 + dk2 * (Rout*dk0)^2 + dk4 * (Rout*dk0)^4 + dk6 * (Rout*dk0)^6)
+        //
+        // r_cor is Rin / Rout.
+        const float rs2 = powf(r * drs, 2);
+        const float r_cor = drs * (1 + rs2 * (dk2 + rs2 * (dk4 + rs2 * dk6)));
+
         cor_rgb[0][i] = cor_rgb[1][i] = cor_rgb[2][i] = (p->cor_dist_ft * (r_cor - 1) + 1);
       }
       else if(cor_rgb)
@@ -2450,8 +2449,8 @@ static int _init_coeffs_md_v2(const dt_image_t *img,
 
       if(cor_rgb && p->modify_flags & DT_IOP_LENS_MODIFY_FLAG_TCA)
       {
-        // Radius in the undistorted image of the current knot
-        const float rd = r_cor * r;
+        // Radius in the input (distorted) image of the current knot
+        const float rd = cor_rgb[1][i] * r;
         const float rd2 = powf(rd, 2);
         // CA correction is applied as:
         // Rin_with_CA = Rin * ((1 + car0) + car2 * Rin^2 + car4 * Rin^4)

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2402,34 +2402,23 @@ static int _init_coeffs_md_v2(const dt_image_t *img,
   {
     // Get the coefficients for the distortion polynomial
     float dk0 = 1, dk2 = 0, dk4 = 0, dk6 = 0;
-    if(cd->olympus.has_ft_dist)
+    if(cd->olympus.has_dist)
     {
-      // For Four Thirds lenses, the 9 element distortion tag contains 3 roughly
-      // similar sets of coefficients. The first always applies more correction,
-      // the second always applies less, and the third is always somewhere in
-      // between the other two. Here we use the third set.
-      dk0 = 1;
-      dk2 = cd->olympus.ft_dist[6];
-      dk4 = cd->olympus.ft_dist[7];
-      dk6 = cd->olympus.ft_dist[8];
-    }
-    else if (cd->olympus.has_mft_dist)
-    {
-      dk0 = cd->olympus.mft_dist[3];
-      dk2 = cd->olympus.mft_dist[0];
-      dk4 = cd->olympus.mft_dist[1];
-      dk6 = cd->olympus.mft_dist[2];
+      dk0 = cd->olympus.dist[3];
+      dk2 = cd->olympus.dist[0];
+      dk4 = cd->olympus.dist[1];
+      dk6 = cd->olympus.dist[2];
     }
     // Get the coefficients for the CA polynomial
     float car0 = 0, car2 = 0, car4 = 0, cab0 = 0, cab2 = 0, cab4 = 0;
-    if (cd->olympus.has_mft_ca)
+    if (cd->olympus.has_ca)
     {
-      car0 = cd->olympus.mft_ca[0];
-      car2 = cd->olympus.mft_ca[1];
-      car4 = cd->olympus.mft_ca[2];
-      cab0 = cd->olympus.mft_ca[3];
-      cab2 = cd->olympus.mft_ca[4];
-      cab4 = cd->olympus.mft_ca[5];
+      car0 = cd->olympus.ca[0];
+      car2 = cd->olympus.ca[1];
+      car4 = cd->olympus.ca[2];
+      cab0 = cd->olympus.ca[3];
+      cab2 = cd->olympus.ca[4];
+      cab4 = cd->olympus.ca[5];
     }
 
     nc = MAXKNOTS;

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2440,8 +2440,8 @@ static int _init_coeffs_md_v2(const dt_image_t *img,
       if(cor_rgb && p->modify_flags & DT_IOP_LENS_MODIFY_FLAG_TCA)
       {
         const float rd = cor_rgb[1][i];
-        cor_rgb[0][i] += car0 + car2 * powf(rd, 2) + car4 * powf(rd, 4);
-        cor_rgb[2][i] += cab0 + cab2 * powf(rd, 2) + cab4 * powf(rd, 4);
+        cor_rgb[0][i] += p->cor_ca_r_ft * (car0 + car2 * powf(rd, 2) + car4 * powf(rd, 4));
+        cor_rgb[2][i] += p->cor_ca_b_ft * (cab0 + cab2 * powf(rd, 2) + cab4 * powf(rd, 4));
       }
 
       if(vig)

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2087,10 +2087,6 @@ static int _init_coeffs_md_v1(const dt_image_t *img,
 
   if(img->exif_correction_type == CORRECTION_TYPE_SONY)
   {
-    if (modify_flags_image_md)
-      *modify_flags_image_md
-          = DT_IOP_LENS_MODIFY_FLAG_DISTORTION | DT_IOP_LENS_MODIFY_FLAG_TCA | DT_IOP_LENS_MODIFY_FLAG_VIGNETTING;
-
     int nc = cd->sony.nc;
     for(int i = 0; i < nc; i++)
     {
@@ -2162,76 +2158,6 @@ static int _init_coeffs_md_v1(const dt_image_t *img,
 
     return nc;
   }
-  else if(img->exif_correction_type == CORRECTION_TYPE_OLYMPUS)
-  {
-    if (modify_flags_image_md)
-      *modify_flags_image_md = 0;
-    // Get the coefficients for the distortion polynomial
-    float dk0 = 1, dk2 = 0, dk4 = 0, dk6 = 0;
-    if(cd->olympus.has_ft_dist)
-    {
-      if (modify_flags_image_md)
-        *modify_flags_image_md |= DT_IOP_LENS_MODIFY_FLAG_DISTORTION;
-      // For Four Thirds lenses, the 9 element distortion tag contains 3 roughly
-      // similar sets of coefficients. The first always applies more correction,
-      // the second always applies less, and the third is always somewhere in
-      // between the other two. Here we use the third set.
-      dk0 = 1;
-      dk2 = cd->olympus.ft_dist[6];
-      dk4 = cd->olympus.ft_dist[7];
-      dk6 = cd->olympus.ft_dist[8];
-    }
-    else if (cd->olympus.has_mft_dist)
-    {
-      if (modify_flags_image_md)
-        *modify_flags_image_md |= DT_IOP_LENS_MODIFY_FLAG_DISTORTION;
-      dk0 = cd->olympus.mft_dist[3];
-      dk2 = cd->olympus.mft_dist[0];
-      dk4 = cd->olympus.mft_dist[1];
-      dk6 = cd->olympus.mft_dist[2];
-    }
-    // Get the coefficients for the CA polynomial
-    float car0 = 0, car2 = 0, car4 = 0, cab0 = 0, cab2 = 0, cab4 = 0;
-    if (cd->olympus.has_mft_ca)
-    {
-      if (modify_flags_image_md)
-        *modify_flags_image_md |= DT_IOP_LENS_MODIFY_FLAG_TCA;
-      car0 = cd->olympus.mft_ca[0];
-      car2 = cd->olympus.mft_ca[1];
-      car4 = cd->olympus.mft_ca[2];
-      cab0 = cd->olympus.mft_ca[3];
-      cab2 = cd->olympus.mft_ca[4];
-      cab4 = cd->olympus.mft_ca[5];
-    }
-
-    for(int i = 0; i < MAXKNOTS; i++)
-    {
-      float r = (float) i / (MAXKNOTS - 1);
-      knots[i] = r;
-
-      if(cor_rgb && p->modify_flags & DT_IOP_LENS_MODIFY_FLAG_DISTORTION)
-      {
-        // Convert the polynomial to a spline by evaluating it at each knot
-        const float r_cor = dk0 + dk2 * powf(r, 2) + dk4 * powf(r, 4) + dk6 * powf(r, 6);
-        cor_rgb[0][i] = cor_rgb[1][i] = cor_rgb[2][i] = (p->cor_dist_ft * (r_cor - 1) + 1) * scale;
-      }
-      else if(cor_rgb)
-        cor_rgb[0][i] = cor_rgb[1][i] = cor_rgb[2][i] = scale;
-
-      if(cor_rgb && p->modify_flags & DT_IOP_LENS_MODIFY_FLAG_TCA)
-      {
-        const float rd = cor_rgb[1][i];
-        cor_rgb[0][i] += car0 + car2 * powf(rd, 2) + car4 * powf(rd, 4);
-        cor_rgb[2][i] += cab0 + cab2 * powf(rd, 2) + cab4 * powf(rd, 4);
-      }
-
-      if(vig)
-        vig[i] = 1;
-    }
-
-    return MAXKNOTS;
-  }
-
   else if(img->exif_correction_type == CORRECTION_TYPE_DNG)
   {
     const int nc = MAXKNOTS;
@@ -2472,6 +2398,68 @@ static int _init_coeffs_md_v2(const dt_image_t *img,
       }
     }
   }
+  else if(img->exif_correction_type == CORRECTION_TYPE_OLYMPUS)
+  {
+    // Get the coefficients for the distortion polynomial
+    float dk0 = 1, dk2 = 0, dk4 = 0, dk6 = 0;
+    if(cd->olympus.has_ft_dist)
+    {
+      // For Four Thirds lenses, the 9 element distortion tag contains 3 roughly
+      // similar sets of coefficients. The first always applies more correction,
+      // the second always applies less, and the third is always somewhere in
+      // between the other two. Here we use the third set.
+      dk0 = 1;
+      dk2 = cd->olympus.ft_dist[6];
+      dk4 = cd->olympus.ft_dist[7];
+      dk6 = cd->olympus.ft_dist[8];
+    }
+    else if (cd->olympus.has_mft_dist)
+    {
+      dk0 = cd->olympus.mft_dist[3];
+      dk2 = cd->olympus.mft_dist[0];
+      dk4 = cd->olympus.mft_dist[1];
+      dk6 = cd->olympus.mft_dist[2];
+    }
+    // Get the coefficients for the CA polynomial
+    float car0 = 0, car2 = 0, car4 = 0, cab0 = 0, cab2 = 0, cab4 = 0;
+    if (cd->olympus.has_mft_ca)
+    {
+      car0 = cd->olympus.mft_ca[0];
+      car2 = cd->olympus.mft_ca[1];
+      car4 = cd->olympus.mft_ca[2];
+      cab0 = cd->olympus.mft_ca[3];
+      cab2 = cd->olympus.mft_ca[4];
+      cab4 = cd->olympus.mft_ca[5];
+    }
+
+    nc = MAXKNOTS;
+
+    for(int i = 0; i < nc; i++)
+    {
+      const float r = (float) i / (float) (nc - 1);
+      knots_dist[i] = knots_vig[i] = r;
+
+      if(cor_rgb && p->modify_flags & DT_IOP_LENS_MODIFY_FLAG_DISTORTION)
+      {
+        // Convert the polynomial to a spline by evaluating it at each knot
+        const float r_cor = dk0 + dk2 * powf(r, 2) + dk4 * powf(r, 4) + dk6 * powf(r, 6);
+        cor_rgb[0][i] = cor_rgb[1][i] = cor_rgb[2][i] = (p->cor_dist_ft * (r_cor - 1) + 1);
+      }
+      else if(cor_rgb)
+        cor_rgb[0][i] = cor_rgb[1][i] = cor_rgb[2][i] = 1;
+
+      if(cor_rgb && p->modify_flags & DT_IOP_LENS_MODIFY_FLAG_TCA)
+      {
+        const float rd = cor_rgb[1][i];
+        cor_rgb[0][i] += car0 + car2 * powf(rd, 2) + car4 * powf(rd, 4);
+        cor_rgb[2][i] += cab0 + cab2 * powf(rd, 2) + cab4 * powf(rd, 4);
+      }
+
+      if(vig)
+        vig[i] = 1;
+    }
+  }
+
 
   // calculate the optimal scaling value to show the maximum
   // visible image box after distortion correction


### PR DESCRIPTION
Attempting to add support for Olympus lens correction for #12714. The exif tags are all undocumented and nobody else has published any code for interpreting them, so nothing here should be considered authoritative - just my attempt to figure them out.

Distortion and CA is supported for Micro Four Thirds lenses. I'm pretty sure this is correct, these tags were identified by comparing the tag values to their conversion to WarpRectilinear opcodes by Adobe DNG Converter.
There are two different tags that can contain the distortion - older bodies use one (Exif.OlympusIp.0x150a), newer bodies use the other (Exif.OlympusIp.0x1510), and some bodies use both. The only difference when they are both present is that 0x1510 crops slightly more (exactly like increasing 'scale' in lensfun mode). I use 0x1510 if both are present.
In general, the crop resulting from this distortion correction usually won't match the crop of the in camera jpeg or DNG with opcodes, but this should not affect the correctness of the distortion correction.

Unfortunately some older bodies (for example E-P5) which do not support CA correction for the in camera jpegs also do not put the CA correction tags (Exif.OlympusIp.0x150c) in the raw file. Unless there is some other tag that contains them encoded differently?

Distortion correction is also supported for Four Thirds SLR lenses, on newer FT bodies and when used with an adapter on MFT bodies. This one is a different tag (Exif.OlympusIp.0x0800). Not sure if I'm interpreting it exactly right - it contains three sets of coefficients which are very close together. The first one always applies less correction, the second one always applies more, and the third one is somewhere in between. They vary with focal length and focus distance. I don't know why there are three separate sets, but I just picked the third one and it seems to work well; the difference between them is barely noticeable in the undistorted image.

Vignetting is not supported at all yet. I suspect that Exif.OlympusIp.0x0801 might contain it but have not been able to work out the relationship to the amount of correction applied by the camera to the raw file contents when 'Shading Compensation' is turned on in camera settings.