### PR TITLE
paint surface refactoring - code sharing - color assesment on second window

### DIFF
--- a/src/common/focus_peaking.h
+++ b/src/common/focus_peaking.h
@@ -82,9 +82,8 @@ static inline void get_indices(const size_t i, const size_t j, const size_t widt
   index[7] = lower_line + right_row;      // south east
 }
 
-static inline void dt_focuspeaking(cairo_t *cr, int width, int height,
-                                   uint8_t *const restrict image,
-                                   const int buf_width, const int buf_height)
+static inline void dt_focuspeaking(cairo_t *cr, const int buf_width, const int buf_height,
+                                   uint8_t *const restrict image)
 {
   float *const restrict luma = dt_alloc_align_float((size_t)buf_width * buf_height);
   uint8_t *const restrict focus_peaking = dt_alloc_align(64, sizeof(uint8_t) * buf_width * buf_height * 4);

--- a/src/common/focus_peaking.h
+++ b/src/common/focus_peaking.h
@@ -246,4 +246,3 @@ schedule(static) collapse(2) aligned(focus_peaking, luma_ds:64) reduction(+:sigm
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -3170,6 +3170,7 @@ void dt_dev_image(
 
   // create the full pipe
 
+  dev.gui_attached = FALSE;
   dt_dev_pixelpipe_init(dev.pipe);
 
   // load image and set history_end
@@ -3185,7 +3186,6 @@ void dt_dev_image(
 
   // process the pipe
 
-  dev.gui_attached = FALSE;
   dt_dev_process_image_job(&dev);
 
   // record resulting image and dimentions

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -756,6 +756,28 @@ void dt_dev_configure(dt_develop_t *dev, int wd, int ht)
   }
 }
 
+void dt_dev_second_window_configure(dt_develop_t *dev, int wd, int ht)
+{
+  // fixed border on every side
+  const int32_t tb =
+    dev->iso_12646.enabled
+    ? MIN(1.75 * dev->second_window.dpi, 0.3 * MIN(wd, ht))
+    : 0;
+
+  wd -= 2*tb;
+  ht -= 2*tb;
+
+  if(dev->second_window.width != wd || dev->second_window.height != ht)
+  {
+    dev->second_window.width = wd;
+    dev->second_window.height = ht;
+    dev->second_window.border_size = tb;
+    dev->preview2_pipe->changed |= DT_DEV_PIPE_ZOOMED;
+    dt_dev_invalidate(dev);
+    dt_dev_reprocess_center(dev);
+  }
+}
+
 // helper used to synch a single history item with db
 int dt_dev_write_history_item(const int imgid, dt_dev_history_item_t *h, int32_t num)
 {

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -383,6 +383,7 @@ void dt_dev_get_pointer_zoom_pos(dt_develop_t *dev, const float px, const float 
                                  float *zoom_y);
 
 void dt_dev_configure(dt_develop_t *dev, int wd, int ht);
+void dt_dev_second_window_configure(dt_develop_t *dev, int wd, int ht);
 void dt_dev_invalidate_from_gui(dt_develop_t *dev);
 
 /*

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -314,7 +314,9 @@ typedef struct dt_develop_t
   {
     GtkWidget *second_wnd;
     GtkWidget *widget;
+    int32_t orig_width, orig_height;
     int width, height;
+    int32_t border_size;
     double dpi, dpi_factor, ppd, ppd_thb;
 
     GtkWidget *button;

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -591,9 +591,7 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
         {
           cairo_save(cr2);
           cairo_scale(cr2, 1.0f/scale, 1.0f/scale);
-          dt_focuspeaking(cr2, img_width, img_height, cairo_image_surface_get_data(thumb->img_surf),
-                          cairo_image_surface_get_width(thumb->img_surf),
-                          cairo_image_surface_get_height(thumb->img_surf));
+          dt_focuspeaking(cr2, img_width, img_height, cairo_image_surface_get_data(thumb->img_surf));
           cairo_restore(cr2);
         }
 

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -2061,4 +2061,3 @@ void dt_thumbnail_reload_infos(dt_thumbnail_t *thumb)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -221,6 +221,9 @@ static void _focuspeaking_switch_button_callback(GtkWidget *button, gpointer use
 
   gtk_widget_queue_draw(button);
 
+  // make sure the second window if active is updated
+  dt_dev_reprocess_center(darktable.develop);
+
   // we inform that all thumbnails need to be redraw
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, -1);
 }

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -108,7 +108,6 @@ typedef enum dt_gui_color_t
 
 typedef struct dt_gui_gtk_t
 {
-
   struct dt_ui_t *ui;
 
   dt_gui_widgets_t widgets;
@@ -466,4 +465,3 @@ void dt_gui_hide_collapsible_section(dt_gui_collapsible_section_t *cs);
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -201,7 +201,7 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
   }
 
   dt_view_paint_surface(cri, width, height, d->preview_surf,
-                        d->processed_width, d->processed_height);
+                        d->processed_width, d->processed_height, DT_WINDOW_MAIN);
 }
 
 static void _thumb_remove(gpointer user_data)

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -222,7 +222,8 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
       // display snapshot image surface
       cairo_save(cri);
 
-      dt_view_paint_surface(cri, width, height, snap->surface, snap->width, snap->height);
+      dt_view_paint_surface(cri, width, height,
+                            snap->surface, snap->width, snap->height, DT_WINDOW_MAIN);
 
       cairo_restore(cri);
     }

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -220,12 +220,8 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
     if(!d->snap_requested)
     {
       // display snapshot image surface
-      cairo_save(cri);
-
       dt_view_paint_surface(cri, width, height,
                             snap->surface, snap->width, snap->height, DT_WINDOW_MAIN);
-
-      cairo_restore(cri);
     }
 
     cairo_reset_clip(cri);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -503,13 +503,10 @@ void expose(
     // draw image
     mutex = &dev->pipe->backbuf_mutex;
     dt_pthread_mutex_lock(mutex);
-    float wd = dev->pipe->output_backbuf_width;
-    float ht = dev->pipe->output_backbuf_height;
+    const float wd = dev->pipe->output_backbuf_width;
+    const float ht = dev->pipe->output_backbuf_height;
 
     surface = dt_view_create_surface(dev->pipe->output_backbuf, wd, ht);
-
-    wd /= darktable.gui->ppd;
-    ht /= darktable.gui->ppd;
 
     if(dev->iso_12646.enabled)
     {
@@ -526,16 +523,6 @@ void expose(
     cairo_paint(cr);
 
     dt_view_paint_surface(cr, width, height, surface, wd, ht);
-
-    if(darktable.gui->show_focus_peaking)
-    {
-      cairo_save(cr);
-      cairo_scale(cr, 1./ darktable.gui->ppd, 1. / darktable.gui->ppd);
-      dt_focuspeaking(cr, wd, ht, cairo_image_surface_get_data(surface),
-                                  cairo_image_surface_get_width(surface),
-                                  cairo_image_surface_get_height(surface));
-      cairo_restore(cr);
-    }
 
     cairo_surface_destroy(surface);
     dt_pthread_mutex_unlock(mutex);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1482,16 +1482,16 @@ static int _iso_12646_get_border(dt_develop_t *d)
 
 static void _iso_12646_quickbutton_clicked(GtkWidget *w, gpointer user_data)
 {
-  dt_develop_t *d = (dt_develop_t *)user_data;
-  if(!d->gui_attached) return;
+  dt_develop_t *dev = (dt_develop_t *)user_data;
+  if(!dev->gui_attached) return;
 
-  d->iso_12646.enabled = !d->iso_12646.enabled;
-  d->width = d->orig_width;
-  d->height = d->orig_height;
-  d->border_size = _iso_12646_get_border(d);
-  dt_dev_configure(d, d->width, d->height);
+  dev->iso_12646.enabled = !dev->iso_12646.enabled;
+  dev->width = dev->orig_width;
+  dev->height = dev->orig_height;
+  dev->border_size = _iso_12646_get_border(dev);
+  dt_dev_configure(dev, dev->width, dev->height);
 
-  dt_dev_reprocess_center(d);
+  dt_dev_reprocess_center(dev);
 }
 
 /* overlay color */

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3888,7 +3888,8 @@ static void second_window_expose(GtkWidget *widget, dt_develop_t *dev, cairo_t *
   pointerx -= tb;
   pointery -= tb;
 
-  if(dev->preview2_status == DT_DEV_PIXELPIPE_DIRTY || dev->preview2_status == DT_DEV_PIXELPIPE_INVALID
+  if(dev->preview2_status == DT_DEV_PIXELPIPE_DIRTY
+     || dev->preview2_status == DT_DEV_PIXELPIPE_INVALID
      || dev->pipe->input_timestamp > dev->preview2_pipe->input_timestamp)
     dt_dev_process_preview2(dev);
 
@@ -3916,9 +3917,10 @@ static void second_window_expose(GtkWidget *widget, dt_develop_t *dev, cairo_t *
   cairo_surface_t *surface;
   cairo_t *cr = cairo_create(image_surface);
 
-  if(dev->preview2_pipe->output_backbuf && // do we have an image?
-    dev->preview2_pipe->backbuf_scale == backbuf_scale && // is this the zoom scale we want to display?
-    dev->preview2_pipe->backbuf_zoom_x == zoom_x && dev->preview2_pipe->backbuf_zoom_y == zoom_y)
+  if(dev->preview2_pipe->output_backbuf  // do we have an image?
+     && dev->preview2_pipe->backbuf_scale == backbuf_scale // is this the zoom scale we want to display?
+     && dev->preview2_pipe->backbuf_zoom_x == zoom_x
+     && dev->preview2_pipe->backbuf_zoom_y == zoom_y)
   {
     // draw image
     mutex = &dev->preview2_pipe->backbuf_mutex;

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -522,7 +522,7 @@ void expose(
     }
     cairo_paint(cr);
 
-    dt_view_paint_surface(cr, width, height, surface, wd, ht);
+    dt_view_paint_surface(cr, width, height, surface, wd, ht, DT_WINDOW_MAIN);
 
     cairo_surface_destroy(surface);
     dt_pthread_mutex_unlock(mutex);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3934,8 +3934,6 @@ static void second_window_expose(GtkWidget *widget, dt_develop_t *dev, cairo_t *
 
     surface = dt_view_create_surface(dev->preview2_pipe->output_backbuf, wd, ht);
 
-    cairo_surface_set_device_scale(surface, dev->second_window.ppd, dev->second_window.ppd);
-
     dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_DARKROOM_BG);
     cairo_paint(cr);
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1500,6 +1500,16 @@ void dt_view_paint_surface(
     (cairo_get_source(cr),
      zoom_scale >= 0.9999f ? CAIRO_FILTER_FAST : darktable.gui->dr_filter_image);
   cairo_paint(cr);
+
+  if(darktable.gui->show_focus_peaking)
+  {
+    cairo_save(cr);
+    cairo_scale(cr, 1./ darktable.gui->ppd, 1. / darktable.gui->ppd);
+    dt_focuspeaking(cr, sw, sh, cairo_image_surface_get_data(surface),
+                    cairo_image_surface_get_width(surface),
+                    cairo_image_surface_get_height(surface));
+    cairo_restore(cr);
+  }
 }
 
 cairo_surface_t *dt_view_create_surface(

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -770,7 +770,7 @@ dt_view_surface_value_t dt_view_image_get_surface(int imgid, int width, int heig
        So we pass the raw data to be processed, this is more data but correct.
     */
     if(darktable.gui->show_focus_peaking && mip == buf.size)
-      dt_focuspeaking(cr, img_width, img_height, rgbbuf, buf_wd, buf_ht);
+      dt_focuspeaking(cr, buf_wd, buf_ht, rgbbuf);
 
     cairo_surface_destroy(tmp_surface);
     cairo_destroy(cr);
@@ -1519,9 +1519,7 @@ void dt_view_paint_surface(
   {
     cairo_save(cr);
     cairo_scale(cr, 1. / ppd, 1. / ppd);
-    dt_focuspeaking(cr, sw, sh, cairo_image_surface_get_data(surface),
-                    cairo_image_surface_get_width(surface),
-                    cairo_image_surface_get_height(surface));
+    dt_focuspeaking(cr, sw, sh, cairo_image_surface_get_data(surface));
     cairo_restore(cr);
   }
 }

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1546,6 +1546,7 @@ dt_view_context_t dt_view_get_view_context(void)
   const float zoom_y = dt_control_get_dev_zoom_y();
   const float zoom_x = dt_control_get_dev_zoom_x();
   const gboolean iso_12646 = dev->iso_12646.enabled;
+  const gboolean focus_peaking = darktable.gui->show_focus_peaking;
   const float flt_prec = 1.e6;
 
   dt_view_context_t ctx = 0;
@@ -1554,6 +1555,7 @@ dt_view_context_t dt_view_get_view_context(void)
   ADD_TO_CONTEXT(zoom_x * flt_prec);
   ADD_TO_CONTEXT(zoom_y * flt_prec);
   ADD_TO_CONTEXT(iso_12646);
+  ADD_TO_CONTEXT(focus_peaking);
 
   return ctx;
 }

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1500,7 +1500,7 @@ void dt_view_paint_surface(
     cairo_translate(cr, -(.5 - 0.5/scale) * sw, -(.5 - 0.5/scale) * sh);
   }
 
-  if(window == DT_WINDOW_MAIN && dev->iso_12646.enabled)
+  if(dev->iso_12646.enabled)
   {
     // draw the white frame around picture
     const double tbw = (float)(bs >> closeup) * 2.0 / 3.0;

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1489,8 +1489,10 @@ void dt_view_paint_surface(
     ? darktable.gui->ppd
     : dev->second_window.ppd;
 
-  const float sw = (float)processed_width;
-  const float sh = (float)processed_height;
+  const float sw = (float)processed_width / ppd;
+  const float sh = (float)processed_height / ppd;
+
+  cairo_save(cr);
 
   cairo_translate(cr, ceilf(.5f * (width - sw)), ceilf(.5f * (height - sh)));
   if(closeup)
@@ -1509,6 +1511,8 @@ void dt_view_paint_surface(
     cairo_fill(cr);
   }
 
+  cairo_surface_set_device_scale(surface, ppd, ppd);
+
   cairo_set_source_surface (cr, surface, 0, 0);
   cairo_pattern_set_filter
     (cairo_get_source(cr),
@@ -1517,11 +1521,11 @@ void dt_view_paint_surface(
 
   if(darktable.gui->show_focus_peaking)
   {
-    cairo_save(cr);
     cairo_scale(cr, 1. / ppd, 1. / ppd);
-    dt_focuspeaking(cr, sw, sh, cairo_image_surface_get_data(surface));
-    cairo_restore(cr);
+    dt_focuspeaking(cr, processed_width, processed_height, cairo_image_surface_get_data(surface));
   }
+
+  cairo_restore(cr);
 }
 
 cairo_surface_t *dt_view_create_surface(
@@ -1531,7 +1535,7 @@ cairo_surface_t *dt_view_create_surface(
 {
   const int32_t stride =
     cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, processed_width);
-  return dt_cairo_image_surface_create_for_data
+  return cairo_image_surface_create_for_data
     (buffer, CAIRO_FORMAT_RGB24, processed_width, processed_height, stride);
 }
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1546,6 +1546,7 @@ void dt_view_paint_buffer(
 {
   cairo_surface_t *surface = dt_view_create_surface(buffer, processed_width, processed_height);
   dt_view_paint_surface(cr, width, height, surface, processed_width, processed_height, window);
+  cairo_surface_destroy(surface);
 }
 
 #define ADD_TO_CONTEXT(v) ctx = ((ctx << 5) + ctx) ^ (dt_view_context_t)(v);

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -490,13 +490,20 @@ void dt_view_print_settings(const dt_view_manager_t *vm, dt_print_info_t *pinfo,
  * on the viewport (size width x height).
  */
 
+typedef enum _window_t
+{
+  DT_WINDOW_MAIN,
+  DT_WINDOW_SECOND
+} dt_window_t;
+
 void dt_view_paint_buffer(
   cairo_t *cr,
   const size_t width,
   const size_t height,
   uint8_t *buffer,
   const size_t processed_width,
-  const size_t processed_height);
+  const size_t processed_height,
+  const dt_window_t window);
 
 cairo_surface_t *dt_view_create_surface(
   uint8_t *buffer,
@@ -509,7 +516,8 @@ void dt_view_paint_surface(
   const size_t height,
   cairo_surface_t *surface,
   const size_t processed_width,
-  const size_t processed_height);
+  const size_t processed_height,
+  const dt_window_t window);
 
 typedef uint64_t dt_view_context_t;
 


### PR DESCRIPTION
This is a code simplification of the darkroom using the new view's routines to draw dr surface.

- A fix for focus-peaking not updating in second window.
- Add support for color assessment mode in second window where is is after all quite important. 
- Fix snapshots in HiDPI screen

Again, more code sharing and so avoiding duplication.