### PR TITLE
Fix sigmoid iop order issues.

### DIFF
--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -819,7 +819,7 @@ GList *dt_ioppr_get_iop_order_list(int32_t imgid, gboolean sorted)
           _insert_before(iop_order_list, "graduatednd", "crop");
           _insert_before(iop_order_list, "colorbalance", "diffuse");
           _insert_before(iop_order_list, "nlmeans", "blurs");
-          _insert_before(iop_order_list, "filmic", "sigmoid");
+          _insert_before(iop_order_list, "filmicrgb", "sigmoid");
         }
       }
       else if(version == DT_IOP_ORDER_LEGACY)

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -345,6 +345,7 @@ const dt_iop_order_entry_t v30_jpg_order[] = {
   { { 44.0f }, "basecurve", 0 },     // conversion from scene-referred to display referred, reverse-engineered
                                      //    on camera JPEG default look
   { { 45.0f }, "filmic", 0 },        // same, but different (parametric) approach
+  { { 45.3f }, "sigmoid", 0},
   { { 46.0f }, "filmicrgb", 0 },     // same, upgraded
   { { 36.0f }, "lut3d", 0 },         // apply a creative style or film emulation, possibly non-linear
   { { 47.0f }, "colisa", 0 },        // edit contrast while damaging colour


### PR DESCRIPTION
* add sigmoid to v30_jpg_order
* insert sigmoid before filmicrgb and not filmic in image iop orders

Fixes #12763