### PR TITLE
modulegroups: add diffuse&sharpen in scene-referred group.

### DIFF
--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1760,6 +1760,7 @@ void init_presets(dt_lib_module_t *self)
   AM("watermark");
   AM("censorize");
   AM("blurs");
+  AM("diffuse");
 
   dt_lib_presets_add(_("workflow: scene-referred"), self->plugin_name, self->version(), tx, strlen(tx), TRUE);
 


### PR DESCRIPTION
Looks like an oversight to me, this mode can be used in scene-referred mode.