### PR TITLE
export: update module bit depth labels

### DIFF
--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -676,7 +676,7 @@ const char *extension(dt_imageio_module_data_t *data)
 
 const char *name()
 {
-  return _("AVIF (8/10/12-bit)");
+  return _("AVIF");
 }
 
 int flags(struct dt_imageio_module_data_t *data)
@@ -891,4 +891,3 @@ void gui_reset(dt_imageio_module_format_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/imageio/format/exr.cc
+++ b/src/imageio/format/exr.cc
@@ -442,7 +442,7 @@ const char *extension(dt_imageio_module_data_t *data)
 
 const char *name()
 {
-  return _("OpenEXR (16/32-bit float)");
+  return _("OpenEXR");
 }
 
 static void bpp_combobox_changed(GtkWidget *widget, gpointer user_data)
@@ -469,7 +469,7 @@ void gui_init(dt_imageio_module_format_t *self)
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL(gui->bpp,self, NULL, N_("bit depth"), NULL,
                                (bpp_last >> 4) - EXR_PT_HALF, bpp_combobox_changed, self,
-                               N_("16 bit"), N_("32 bit"));
+                               N_("16 bit (float)"), N_("32 bit (float)"));
   gtk_box_pack_start(GTK_BOX(self->widget), gui->bpp, TRUE, TRUE, 0);
 
   // Compression combo box

--- a/src/imageio/format/j2k.c
+++ b/src/imageio/format/j2k.c
@@ -564,7 +564,7 @@ void *legacy_params(dt_imageio_module_format_t *self, const void *const old_para
 void *get_params(dt_imageio_module_format_t *self)
 {
   dt_imageio_j2k_t *d = (dt_imageio_j2k_t *)calloc(1, sizeof(dt_imageio_j2k_t));
-  d->bpp = 16; // can be 8, 12 or 16
+  d->bpp = 12; // can be 8, 12 or 16
   d->format = dt_conf_get_int("plugins/imageio/format/j2k/format");
   d->preset = dt_conf_get_int("plugins/imageio/format/j2k/preset");
   d->quality = dt_conf_get_int("plugins/imageio/format/j2k/quality");
@@ -649,7 +649,7 @@ void gui_init(dt_imageio_module_format_t *self)
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL(gui->format, self, NULL, N_("format"), NULL,
                                format_last, format_changed, self,
-                               N_("J2K"), N_("jp2"));
+                               N_("j2k"), N_("jp2"));
   gtk_box_pack_start(GTK_BOX(self->widget), gui->format, TRUE, TRUE, 0);
 
   gui->quality = dt_bauhaus_slider_new_with_range((dt_iop_module_t*)self,
@@ -702,4 +702,3 @@ int flags(dt_imageio_module_data_t *data)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/imageio/format/pfm.c
+++ b/src/imageio/format/pfm.c
@@ -115,7 +115,7 @@ const char *extension(dt_imageio_module_data_t *data)
 
 const char *name()
 {
-  return _("PFM (float)");
+  return _("PFM");
 }
 
 void init(dt_imageio_module_format_t *self)
@@ -139,4 +139,3 @@ void gui_reset(dt_imageio_module_format_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/imageio/format/png.c
+++ b/src/imageio/format/png.c
@@ -500,7 +500,7 @@ const char *extension(dt_imageio_module_data_t *data)
 
 const char *name()
 {
-  return _("PNG (8/16-bit)");
+  return _("PNG");
 }
 
 static void bit_depth_changed(GtkWidget *widget, gpointer user_data)

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -788,7 +788,7 @@ const char *extension(dt_imageio_module_data_t *data)
 
 const char *name()
 {
-  return _("TIFF (8/16/32-bit)");
+  return _("TIFF");
 }
 
 static void bpp_combobox_changed(GtkWidget *widget, dt_imageio_tiff_gui_t *gui)

--- a/src/imageio/format/webp.c
+++ b/src/imageio/format/webp.c
@@ -346,7 +346,7 @@ const char *extension(dt_imageio_module_data_t *data)
 
 const char *name()
 {
-  return _("WebP (8-bit)");
+  return _("WebP");
 }
 
 static void compression_changed(GtkWidget *widget, dt_imageio_webp_gui_data_t *gui)

--- a/src/imageio/format/xcf.c
+++ b/src/imageio/format/xcf.c
@@ -292,7 +292,7 @@ const char *extension(dt_imageio_module_data_t *data)
 
 const char *name()
 {
-  return _("xcf");
+  return _("XCF");
 }
 
 void init(dt_imageio_module_format_t *self)
@@ -355,4 +355,3 @@ void gui_reset(dt_imageio_module_format_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-


### PR DESCRIPTION
The idea is to reduce UI clutter by removing all the export bit depth options from the module format label - they're visible in the dropdown anyway when the module is active. To avoid any ambiguities, I've kept:

"JPEG (8-bit)" because a 12-bit version of the codec/library exists (although we don't use it)

"JPEG 2000 (12-bit)" as it the only option we currently support, but the codec is capable of more

"PPM (16-bit)" as it the only option we currently support, but the format is capable of more