### PR TITLE
Fixing opposed & segmentaiion HLR issues

### DIFF
--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -2081,10 +2081,10 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     case DT_IOP_HIGHLIGHTS_SEGMENTS:
     {
       const dt_segments_mask_t vmode = ((g != NULL) && fullpipe) ? g->segmentation_mask_mode : DT_SEGMENTS_MASK_OFF;
-      const gboolean thumb = (piece->pipe->type & (DT_DEV_PIXELPIPE_PREVIEW | DT_DEV_PIXELPIPE_PREVIEW2 | DT_DEV_PIXELPIPE_THUMBNAIL)) != 0;
+      const gboolean complete = (piece->pipe->type & (DT_DEV_PIXELPIPE_PREVIEW | DT_DEV_PIXELPIPE_PREVIEW2)) == 0;
 
-      float *tmp = _process_opposed(self, piece, ivoid, ovoid, roi_in, roi_out, data);
-      if(tmp && !thumb)
+      float *tmp = _process_opposed(self, piece, ivoid, ovoid, roi_in, roi_out, data, complete);
+      if(tmp && complete)
         _process_segmentation(piece, ivoid, ovoid, roi_in, roi_out, data, vmode, tmp);
       dt_free_align(tmp);
 
@@ -2114,7 +2114,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     default:
     case DT_IOP_HIGHLIGHTS_OPPOSED:
     {
-      float *tmp = _process_opposed(self, piece, ivoid, ovoid, roi_in, roi_out, data);
+      float *tmp = _process_opposed(self, piece, ivoid, ovoid, roi_in, roi_out, data, FALSE);
       dt_free_align(tmp);
       break;
     }

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -60,7 +60,6 @@ static void dump_PFM(const char *filename, const float* out, const uint32_t w, c
 }
 #endif
 
-
 DT_MODULE_INTROSPECTION(4, dt_iop_highlights_params_t)
 
 /* As some of the internal algorithms use a smaller value for clipping than given by the UI
@@ -147,6 +146,8 @@ typedef struct dt_iop_highlights_gui_data_t
   GtkWidget *strength;
   gboolean show_visualize;
   dt_segments_mask_t segmentation_mask_mode;
+  dt_aligned_pixel_t chroma_correction;
+  gboolean valid_chroma_correction;
 } dt_iop_highlights_gui_data_t;
 
 typedef dt_iop_highlights_params_t dt_iop_highlights_data_t;
@@ -1934,18 +1935,18 @@ void modify_roi_out(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, dt_iop
                     const dt_iop_roi_t *const roi_in)
 {
   *roi_out = *roi_in;
+
   dt_iop_highlights_data_t *d = (dt_iop_highlights_data_t *)piece->data;
   dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
   const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
   const gboolean visualizing = (g != NULL) ? g->show_visualize && fullpipe : FALSE;
+  const gboolean use_opposing = (d->mode == DT_IOP_HIGHLIGHTS_OPPOSED) || (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS);
 
-  if(visualizing || (d->mode != DT_IOP_HIGHLIGHTS_OPPOSED && d->mode != DT_IOP_HIGHLIGHTS_SEGMENTS))
+  if(visualizing || !use_opposing)
     return;
 
   roi_out->x = MAX(0, roi_in->x);
   roi_out->y = MAX(0, roi_in->y);
-  // we can't do a proper sanity check here for width & height; that has to be done in the
-  // opposed and segmentation code!
 }
 
 void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const dt_iop_roi_t *const roi_out,
@@ -1957,11 +1958,11 @@ void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const d
   dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
   const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
   const gboolean visualizing = (g != NULL) ? g->show_visualize && fullpipe : FALSE;
-
-  if(visualizing || (d->mode != DT_IOP_HIGHLIGHTS_OPPOSED && d->mode != DT_IOP_HIGHLIGHTS_SEGMENTS))
+  const gboolean use_opposing = (d->mode == DT_IOP_HIGHLIGHTS_OPPOSED) || (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS);
+  
+  if(visualizing || !use_opposing)
     return;
 
-  // we always take the full data provided by rawspeed
   roi_in->x = 0;
   roi_in->y = 0;
   roi_in->width = piece->buf_in.width;
@@ -2002,7 +2003,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     }
     else
     {
-      _process_linear_opposed(piece, ivoid, ovoid, roi_in, roi_out, data);
+      _process_linear_opposed(self, piece, ivoid, ovoid, roi_in, roi_out, data);
     }
     return;
   }
@@ -2080,9 +2081,10 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     case DT_IOP_HIGHLIGHTS_SEGMENTS:
     {
       const dt_segments_mask_t vmode = ((g != NULL) && fullpipe) ? g->segmentation_mask_mode : DT_SEGMENTS_MASK_OFF;
+      const gboolean thumb = (piece->pipe->type & (DT_DEV_PIXELPIPE_PREVIEW | DT_DEV_PIXELPIPE_PREVIEW2 | DT_DEV_PIXELPIPE_THUMBNAIL)) != 0;
 
-      float *tmp = _process_opposed(piece, ivoid, ovoid, roi_in, roi_out, data);
-      if(tmp)
+      float *tmp = _process_opposed(self, piece, ivoid, ovoid, roi_in, roi_out, data);
+      if(tmp && !thumb)
         _process_segmentation(piece, ivoid, ovoid, roi_in, roi_out, data, vmode, tmp);
       dt_free_align(tmp);
 
@@ -2112,7 +2114,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     default:
     case DT_IOP_HIGHLIGHTS_OPPOSED:
     {
-      float *tmp = _process_opposed(piece, ivoid, ovoid, roi_in, roi_out, data);
+      float *tmp = _process_opposed(self, piece, ivoid, ovoid, roi_in, roi_out, data);
       dt_free_align(tmp);
       break;
     }
@@ -2253,6 +2255,9 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     dt_bauhaus_widget_set_quad_active(g->strength, FALSE);
     g->segmentation_mask_mode = DT_SEGMENTS_MASK_OFF;
   }
+
+  if(w == g->clip)
+    g->valid_chroma_correction = FALSE;
 }
 
 void gui_update(struct dt_iop_module_t *self)
@@ -2279,6 +2284,8 @@ void gui_update(struct dt_iop_module_t *self)
   if(p->mode == DT_IOP_HIGHLIGHTS_INPAINT && basic)
      dt_bauhaus_combobox_add_full(g->mode, _("reconstruct color"), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,
                                       GINT_TO_POINTER(DT_IOP_HIGHLIGHTS_INPAINT), NULL, TRUE);
+  g->valid_chroma_correction = FALSE;
+
   gui_changed(self, NULL, NULL);
 }
 
@@ -2341,6 +2348,7 @@ void reload_defaults(dt_iop_module_t *self)
         dt_bauhaus_combobox_add_full(g->mode, _("reconstruct color"), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,
                                       GINT_TO_POINTER(DT_IOP_HIGHLIGHTS_INPAINT), NULL, TRUE);
     }
+    g->valid_chroma_correction = FALSE;
   }
 }
 

--- a/src/iop/hlrecovery_v2.c
+++ b/src/iop/hlrecovery_v2.c
@@ -444,8 +444,11 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
   const size_t pheight = dt_round_size(roi_in->height / 3, 2) + 2 * HL_BORDER;
   const size_t p_size = dt_round_size((size_t) (pwidth + 4) * (pheight + 4), 16);
 
-  const size_t o_row_max = MIN(roi_out->height, roi_in->height - roi_out->y);
-  const size_t o_col_max = MIN(roi_out->width, roi_in->width - roi_out->y);
+  const size_t shift_x = roi_out->x;
+  const size_t shift_y = roi_out->y;
+
+  const size_t o_row_max = MIN(roi_out->height, roi_in->height - shift_y);
+  const size_t o_col_max = MIN(roi_out->width, roi_in->width - shift_x);
   const size_t o_width = roi_out->width;
   const size_t i_width = roi_in->width;
  
@@ -674,14 +677,14 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ovoid, tmpout, roi_in, roi_out) \
-  dt_omp_sharedconst(o_row_max, o_col_max, o_width, i_width) \
+  dt_omp_firstprivate(ovoid, tmpout) \
+  dt_omp_sharedconst(o_row_max, o_col_max, o_width, i_width, shift_x, shift_y) \
   schedule(static)
 #endif
   for(size_t row = 0; row < o_row_max; row++)
   {
     float *out = (float *)ovoid + o_width * row;
-    float *in = tmpout + i_width * (row + roi_out->y) + roi_out->x;
+    float *in = tmpout + i_width * (row + shift_y) + shift_x;
     for(size_t col = 0; col < o_col_max; col++)
       out[col] = in[col];
   }
@@ -691,20 +694,20 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(clips, ivoid, ovoid, roi_in, roi_out, xtrans, isegments, gradient) \
-  dt_omp_sharedconst(filters, pwidth, vmode, strength, o_row_max, o_col_max, o_width, i_width) \
+  dt_omp_sharedconst(filters, pwidth, vmode, strength, o_row_max, o_col_max, o_width, i_width, shift_x, shift_y) \
   schedule(static)
 #endif
     for(size_t row = 0; row < o_row_max; row++)
     {
       float *out = (float *)ovoid + o_width * row;
-      float *in = (float *)ivoid + i_width * (row + roi_out->y) + roi_out->x;
+      float *in = (float *)ivoid + i_width * (row + shift_y) + shift_x;
       for(size_t col = 0; col < o_col_max; col++)
       {
         out[0] = 0.1f * in[0];
         if((row > 0) && (col > 0) && (row < roi_out->height -1) && (col < i_width -1))
         {
-          const int color = (filters == 9u) ? FCxtrans(row+roi_out->y, col+roi_out->x, roi_in, xtrans) : FC(row+roi_out->y, col+roi_out->x, filters);
-          const size_t ppos = _raw_to_plane(pwidth, row+roi_out->y, col+roi_out->x);
+          const int color = (filters == 9u) ? FCxtrans(row + shift_y, col + shift_x, roi_in, xtrans) : FC(row + shift_y, col + shift_x, filters);
+          const size_t ppos = _raw_to_plane(pwidth, row + shift_y, col + shift_x);
 
           const int pid = _get_segment_id(&isegments[color], ppos);
           const gboolean iclipped = (in[0] >= clips[color]);

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -57,7 +57,7 @@ static inline float _calc_linear_refavg(const float *in, const int row, const in
 }
 
 // A slightly modified version for sraws
-static void _process_linear_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
                          const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
                          dt_iop_highlights_data_t *data)
 {
@@ -70,10 +70,23 @@ static void _process_linear_opposed(dt_dev_pixelpipe_iop_t *piece, const void *c
   const size_t pheight = dt_round_size(roi_in->height / 3, 2) + 2 * HL_BORDER;
   const size_t p_size = (size_t) dt_round_size(pwidth * pheight, 16);
 
-  const size_t o_row_max = MIN(roi_out->height, roi_in->height - roi_out->y);
-  const size_t o_col_max = MIN(roi_out->width, roi_in->width - roi_out->x);
+  const size_t shift_x = roi_out->x;
+  const size_t shift_y = roi_out->y;
+
+  const size_t o_row_max = MIN(roi_out->height, roi_in->height - shift_y);
+  const size_t o_col_max = MIN(roi_out->width, roi_in->width - shift_x);
   const size_t o_width = roi_out->width;
   const size_t i_width = roi_in->width;
+
+  dt_aligned_pixel_t chrominance = {0.0f, 0.0f, 0.0f, 0.0f};
+  gboolean valid_chrominance = FALSE;
+  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
+  if(g && g->valid_chroma_correction)
+  {
+    valid_chrominance = TRUE;
+    for_each_channel(c)
+      chrominance[c] = g->chroma_correction[c];          
+  }
 
   int *mask_buffer = dt_calloc_align(64, 4 * p_size * sizeof(int));
   float *tmpout = dt_alloc_align_float(4 * roi_in->width * roi_in->height);
@@ -81,14 +94,14 @@ static void _process_linear_opposed(dt_dev_pixelpipe_iop_t *piece, const void *c
   // make sure date are fully copied in case of an early exit
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ovoid, ivoid, roi_in, roi_out) \
-  dt_omp_sharedconst(o_row_max, o_col_max, o_width, i_width) \
+  dt_omp_firstprivate(ovoid, ivoid) \
+  dt_omp_sharedconst(o_row_max, o_col_max, o_width, i_width, shift_x, shift_y) \
   schedule(static)
 #endif
   for(size_t row = 0; row < o_row_max; row++)
   {
     float *out = (float *)ovoid + o_width * row * 4;
-    float *in = (float *)ivoid + 4 * (i_width * (row + roi_out->y) + roi_out->x);
+    float *in = (float *)ivoid + 4 * (i_width * (row + shift_y) + shift_x);
     for(size_t col = 0; col < o_col_max; col++)
     {
       for_each_channel(c)
@@ -136,17 +149,19 @@ static void _process_linear_opposed(dt_dev_pixelpipe_iop_t *piece, const void *c
 
   if(!anyclipped) goto finish;
 
-  for(size_t i = 0; i < 3; i++)
+  if(!valid_chrominance)
   {
-    int *mask = mask_buffer + i * p_size;
-    int *tmp = mask_buffer + 3 * p_size;
-    _intimage_borderfill(mask, pwidth, pheight, 0, HL_BORDER);
-    _dilating(mask, tmp, pwidth, pheight, HL_BORDER, 3);
-    memcpy(mask, tmp, p_size * sizeof(int));
-  }
+    for(size_t i = 0; i < 3; i++)
+    {
+      int *mask = mask_buffer + i * p_size;
+      int *tmp = mask_buffer + 3 * p_size;
+      _intimage_borderfill(mask, pwidth, pheight, 0, HL_BORDER);
+      _dilating(mask, tmp, pwidth, pheight, HL_BORDER, 3);
+      memcpy(mask, tmp, p_size * sizeof(int));
+    }
 
-  dt_aligned_pixel_t cr_sum = {0.0f, 0.0f, 0.0f, 0.0f};
-  dt_aligned_pixel_t cr_cnt = {0.0f, 0.0f, 0.0f, 0.0f};
+    dt_aligned_pixel_t cr_sum = {0.0f, 0.0f, 0.0f, 0.0f};
+    dt_aligned_pixel_t cr_cnt = {0.0f, 0.0f, 0.0f, 0.0f};
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(ivoid, roi_in, clips, clipdark, mask_buffer) \
@@ -154,44 +169,54 @@ static void _process_linear_opposed(dt_dev_pixelpipe_iop_t *piece, const void *c
   dt_omp_sharedconst(p_size, pwidth, i_width) \
   schedule(static)
 #endif
-  for(size_t row = 1; row < roi_in->height-1; row++)
-  {
-    float *in  = (float *)ivoid + i_width * row * 4 + 4;
-    for(size_t col = 1; col < i_width - 1; col++)
+    for(size_t row = 1; row < roi_in->height-1; row++)
+    {
+      float *in  = (float *)ivoid + i_width * row * 4 + 4;
+      for(size_t col = 1; col < i_width - 1; col++)
+      {
+        for_each_channel(c)
+        {
+          const float inval = fmaxf(0.0f, in[c]); 
+          if((mask_buffer[c * p_size + _raw_to_plane(pwidth, row, col)]) && (inval > clipdark[c]) && (inval < clips[c]))
+          {
+            cr_sum[c] += inval - _calc_linear_refavg(&in[0], row, col, roi_in, c);
+            cr_cnt[c] += 1.0f;
+          }
+        }
+        in += 4;
+      }
+    }
+    for_each_channel(c)
+      chrominance[c] = cr_sum[c] / fmax(1.0, cr_cnt[c]);    
+
+    if(g && piece->pipe->type & DT_DEV_PIXELPIPE_FULL)
     {
       for_each_channel(c)
-      {
-        const float inval = fmaxf(0.0f, in[c]); 
-        if((mask_buffer[c * p_size + _raw_to_plane(pwidth, row, col)]) && (inval > clipdark[c]) && (inval < clips[c]))
-        {
-          cr_sum[c] += inval - _calc_linear_refavg(&in[0], row, col, roi_in, c);
-          cr_cnt[c] += 1.0f;
-        }
-      }
-      in += 4;
+        g->chroma_correction[c] = chrominance[c];
+      g->valid_chroma_correction = TRUE;
+      // fprintf(stderr, "[opposed linear chroma corrections] %f, %f, %f\n", chrominance[0], chrominance[1], chrominance[2]);          
     }
   }
-  const dt_aligned_pixel_t chrominance = {cr_sum[0] / fmax(1.0, cr_cnt[0]), cr_sum[1] / fmax(1.0, cr_cnt[1]), cr_sum[2] / fmax(1.0, cr_cnt[2]), 0.0f};
 
 /* We kept the refavg data in tmpout[] in the first loop, just overwrite output data with
    chrominance corrections now.
 */
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ovoid, ivoid, tmpout, roi_in, roi_out, chrominance, clips) \
-  dt_omp_sharedconst(o_row_max, o_col_max, o_width, i_width) \
+  dt_omp_firstprivate(ovoid, ivoid, tmpout, chrominance, clips) \
+  dt_omp_sharedconst(o_row_max, o_col_max, o_width, i_width, shift_x, shift_y) \
   schedule(static)
 #endif
   for(size_t row = 0; row < o_row_max; row++)
   {
     float *out = (float *)ovoid + o_width * row * 4;
-    float *tmp = tmpout + 4 * (i_width * (row + roi_out->y) + roi_out->x);
-    float *in = (float *)ivoid + 4 * (i_width * (row + roi_out->y) + roi_out->x);
+    float *tmp = tmpout + 4 * (i_width * (row + shift_y) + shift_x);
+    float *in = (float *)ivoid + 4 * (i_width * (row + shift_y) + shift_x);
     for(size_t col = 0; col < o_col_max; col++)
     {
       for_each_channel(c)
       {
-        const float inval = fmaxf(0.0f, in[c]); 
+        const float inval = fmaxf(0.0f, in[c]);
         if(inval >= clips[c])
           out[c] = fmaxf(inval, tmp[c] + chrominance[c]);
       }
@@ -206,7 +231,7 @@ static void _process_linear_opposed(dt_dev_pixelpipe_iop_t *piece, const void *c
   dt_free_align(mask_buffer);
 }
 
-static float *_process_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+static float *_process_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
                          const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
                          dt_iop_highlights_data_t *data)
 {
@@ -224,22 +249,34 @@ static float *_process_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const 
   int *mask_buffer = dt_calloc_align(64, 4 * p_size * sizeof(int));
   float *tmpout = dt_alloc_align_float(roi_in->width * roi_in->height);
 
-  const size_t o_row_max = MIN(roi_out->height, roi_in->height - roi_out->y);
-  const size_t o_col_max = MIN(roi_out->width, roi_in->width - roi_out->x);
+  const size_t shift_x = roi_out->x;
+  const size_t shift_y = roi_out->y;
+
+  const size_t o_row_max = MIN(roi_out->height, roi_in->height - shift_y);
+  const size_t o_col_max = MIN(roi_out->width, roi_in->width - shift_x);
   const size_t o_width = roi_out->width;
   const size_t i_width = roi_in->width;
 
+  dt_aligned_pixel_t chrominance = {0.0f, 0.0f, 0.0f, 0.0f};
+  gboolean valid_chrominance = FALSE;
+  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
+  if(g && g->valid_chroma_correction)
+  {
+    valid_chrominance = TRUE;
+    for_each_channel(c)
+      chrominance[c] = g->chroma_correction[c];          
+  }
   // make sure date are fully copied in case of an early exit
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ovoid, ivoid, roi_out) \
-  dt_omp_sharedconst(o_row_max, o_col_max, o_width, i_width) \
+  dt_omp_firstprivate(ovoid, ivoid) \
+  dt_omp_sharedconst(o_row_max, o_col_max, o_width, i_width, shift_x, shift_y) \
   schedule(static)
 #endif
   for(size_t row = 0; row < o_row_max; row++)
   {
     float *out = (float *)ovoid + o_width * row;
-    float *in = (float *)ivoid + i_width * (row + roi_out->y) + roi_out->x;
+    float *in = (float *)ivoid + i_width * (row + shift_y) + shift_x;
     for(size_t col = 0; col < o_col_max; col++)
       out[col] = fmaxf(0.0f, in[col]);
   }
@@ -277,23 +314,25 @@ static float *_process_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const 
 
   if(!anyclipped) goto finish;
 
+  if(!valid_chrominance)
+  {
   /* We want to use the photosites closely around clipped data to be taken into account.
      The mask buffers holds data for each color channel, we dilate the mask buffer slightly
      to get those locations.
      As the mask buffers are scaled down by 3 the dilate is very fast. 
   */      
-  for(size_t i = 0; i < 3; i++)
-  {
-    int *mask = mask_buffer + i * p_size;
-    int *tmp = mask_buffer + 3 * p_size;
-    _intimage_borderfill(mask, pwidth, pheight, 0, HL_BORDER);
-    _dilating(mask, tmp, pwidth, pheight, HL_BORDER, 3);
-    memcpy(mask, tmp, p_size * sizeof(int));
-  }
+    for(size_t i = 0; i < 3; i++)
+    {
+      int *mask = mask_buffer + i * p_size;
+      int *tmp = mask_buffer + 3 * p_size;
+      _intimage_borderfill(mask, pwidth, pheight, 0, HL_BORDER);
+      _dilating(mask, tmp, pwidth, pheight, HL_BORDER, 3);
+      memcpy(mask, tmp, p_size * sizeof(int));
+    }
 
   /* After having the surrounding mask for each color channel we can calculate the chrominance corrections. */ 
-  dt_aligned_pixel_t cr_sum = {0.0f, 0.0f, 0.0f, 0.0f};
-  dt_aligned_pixel_t cr_cnt = {0.0f, 0.0f, 0.0f, 0.0f};
+    dt_aligned_pixel_t cr_sum = {0.0f, 0.0f, 0.0f, 0.0f};
+    dt_aligned_pixel_t cr_cnt = {0.0f, 0.0f, 0.0f, 0.0f};
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(ivoid, roi_in, xtrans, clips, clipdark, mask_buffer) \
@@ -301,24 +340,34 @@ static float *_process_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const 
   dt_omp_sharedconst(filters, p_size, pwidth, i_width) \
   schedule(static)
 #endif
-  for(size_t row = 1; row < roi_in->height - 1; row++)
-  {
-    float *in  = (float *)ivoid + i_width * row + 1;
-    for(size_t col = 1; col < i_width - 1; col++)
+    for(size_t row = 1; row < roi_in->height - 1; row++)
     {
-      const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
-      const float inval = fmaxf(0.0f, in[0]); 
-      /* we only use the unclipped photosites very close the true clipped data
-         to calculate the chrominance offset */
-      if((mask_buffer[color * p_size + _raw_to_plane(pwidth, row, col)]) && (inval > clipdark[color]) && (inval < clips[color]))
+      float *in  = (float *)ivoid + i_width * row + 1;
+      for(size_t col = 1; col < i_width - 1; col++)
       {
-        cr_sum[color] += inval - _calc_refavg(&in[0], xtrans, filters, row, col, roi_in, TRUE);
-        cr_cnt[color] += 1.0f;
+        const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
+        const float inval = fmaxf(0.0f, in[0]); 
+        /* we only use the unclipped photosites very close the true clipped data
+           to calculate the chrominance offset */
+        if((mask_buffer[color * p_size + _raw_to_plane(pwidth, row, col)]) && (inval > clipdark[color]) && (inval < clips[color]))
+        {
+          cr_sum[color] += inval - _calc_refavg(&in[0], xtrans, filters, row, col, roi_in, TRUE);
+          cr_cnt[color] += 1.0f;
+        }
+        in++;
       }
-      in++;
+    }
+    for_each_channel(c)
+      chrominance[c] = cr_sum[c] / fmax(1.0, cr_cnt[c]);    
+
+    if(g && piece->pipe->type & DT_DEV_PIXELPIPE_FULL)
+    {
+      for_each_channel(c)
+        g->chroma_correction[c] = chrominance[c];
+      g->valid_chroma_correction = TRUE;
+      // fprintf(stderr, "[opposed chroma corrections] %f, %f, %f\n", chrominance[0], chrominance[1], chrominance[2]);          
     }
   }
-  const dt_aligned_pixel_t chrominance = {cr_sum[0] / fmax(1.0, cr_cnt[0]), cr_sum[1] / fmax(1.0, cr_cnt[1]), cr_sum[2] / fmax(1.0, cr_cnt[2]), 0.0f};
 
 /* We kept the refavg data in tmpout[] in the first loop, just overwrite output data with
    chrominance corrections now. Also leave in tmpout for further postprocessing.
@@ -346,14 +395,14 @@ static float *_process_opposed(dt_dev_pixelpipe_iop_t *piece, const void *const 
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ovoid, tmpout, roi_in, roi_out) \
-  dt_omp_sharedconst(o_row_max, o_col_max, i_width, o_width) \
+  dt_omp_firstprivate(ovoid, tmpout) \
+  dt_omp_sharedconst(o_row_max, o_col_max, i_width, o_width, shift_x, shift_y) \
   schedule(static)
 #endif
   for(size_t row = 0; row < o_row_max; row++)
   {
     float *out = (float *)ovoid + o_width * row;
-    float *tmp = tmpout + i_width * (row + roi_out->y) + roi_out->x;
+    float *tmp = tmpout + i_width * (row + shift_y) + shift_x;
     for(size_t col = 0; col < o_col_max; col++)
       out[col] = tmp[col];
   }


### PR DESCRIPTION
- keeps calculated chroma_correction data for later processing in gui_data. Improves performance for full and previews pixelpipes as the morphological operations and looking for valid data can be avoided.

  I also tested saving calculated data in parameters but that lead to issues while doing presets or copy&paste of history.

- leaves thumbnail creation having to do the full calculation of chroma correction data.

- no mask displaced problems.

Replacing #12702

Some additional comments: I currently don't see a good way to improve thumbnail generation performance. While investigating this i was somewhat surprised that even for small thumbs we take the whole data to be processed until the demosaic stage. That might be something interesting for further investigation. 
