### PR TITLE
fix bauhaus popup size&position and remove detached label

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -60,7 +60,7 @@ static gboolean _widget_draw(GtkWidget *widget, cairo_t *crf);
 static gboolean _widget_scroll(GtkWidget *widget, GdkEventScroll *event);
 static gboolean _widget_key_press(GtkWidget *widget, GdkEventKey *event);
 static void _get_preferred_width(GtkWidget *widget, gint *minimum_size, gint *natural_size);
-static void _style_updated(GtkWidget *widget);
+static void _get_preferred_height(GtkWidget *widget, gint *minimum_height, gint *natural_height);
 static void dt_bauhaus_widget_accept(dt_bauhaus_widget_t *w);
 static void dt_bauhaus_widget_reject(dt_bauhaus_widget_t *w);
 static void _bauhaus_combobox_set(dt_bauhaus_widget_t *w, const int pos, const gboolean mute);
@@ -131,12 +131,10 @@ static GdkRGBA * default_color_assign()
 
 static void _margins_retrieve(dt_bauhaus_widget_t *w)
 {
-  if(!w->margin) w->margin = gtk_border_new();
-  if(!w->padding) w->padding = gtk_border_new();
   GtkStyleContext *context = gtk_widget_get_style_context(GTK_WIDGET(w));
   const GtkStateFlags state = gtk_widget_get_state_flags(GTK_WIDGET(w));
-  gtk_style_context_get_margin(context, state, w->margin);
-  gtk_style_context_get_padding(context, state, w->padding);
+  gtk_style_context_get_margin(context, state, &w->margin);
+  gtk_style_context_get_padding(context, state, &w->padding);
 }
 
 void dt_bauhaus_widget_set_section(GtkWidget *widget, const gboolean is_section)
@@ -557,11 +555,6 @@ static gboolean dt_bauhaus_popup_button_press(GtkWidget *widget, GdkEventButton 
 
 static void dt_bauhaus_window_show(GtkWidget *w, gpointer user_data)
 {
-  // Could grab the popup_area rather than popup_window, but if so
-  // then popup_area would get all motion events including those
-  // outside of the popup. This way the popup_area gets motion events
-  // related to updating the popup, and popup_window gets all others
-  // which would be the ones telling it to close the popup.
   gtk_grab_add(GTK_WIDGET(user_data));
 }
 
@@ -600,8 +593,6 @@ static void _widget_finalize(GObject *widget)
     free(d->text);
   }
   g_free(w->section);
-  gtk_border_free(w->margin);
-  gtk_border_free(w->padding);
 
   G_OBJECT_CLASS(dt_bh_parent_class)->finalize(widget);
 }
@@ -620,9 +611,9 @@ static void dt_bh_class_init(DtBauhausWidgetClass *class)
   widget_class->scroll_event = _widget_scroll;
   widget_class->key_press_event = _widget_key_press;
   widget_class->get_preferred_width = _get_preferred_width;
+  widget_class->get_preferred_height = _get_preferred_height;
   widget_class->enter_notify_event = _enter_leave;
   widget_class->leave_notify_event = _enter_leave;
-  widget_class->style_updated = _style_updated;
   G_OBJECT_CLASS(class)->finalize = _widget_finalize;
 }
 
@@ -1149,26 +1140,6 @@ GtkWidget *dt_bauhaus_slider_new_with_range_and_feedback(dt_iop_module_t *self, 
   return dt_bauhaus_slider_from_widget(w,self, min, max, step, defval, digits, feedback);
 }
 
-static void _style_updated(GtkWidget *widget)
-{
-  dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)widget;
-  _margins_retrieve(w);
-
-  if(w->type == DT_BAUHAUS_COMBOBOX)
-  {
-    gtk_widget_set_size_request(widget, -1,
-                                w->margin->top + w->padding->top + w->margin->bottom + w->padding->bottom
-                                    + darktable.bauhaus->line_height);
-  }
-  else if(w->type == DT_BAUHAUS_SLIDER)
-  {
-    // the lower thing to draw is indicator. See dt_bauhaus_draw_baseline for compute details
-    gtk_widget_set_size_request(widget, -1,
-                                w->margin->top + w->padding->top + w->margin->bottom + w->padding->bottom
-                                    + INNER_PADDING + darktable.bauhaus->baseline_size
-                                    + darktable.bauhaus->line_height + 1.5f * darktable.bauhaus->border_width);
-  }
-}
 
 GtkWidget *dt_bauhaus_slider_from_widget(dt_bauhaus_widget_t* w,dt_iop_module_t *self, float min, float max,
                                                          float step, float defval, int digits, int feedback)
@@ -1817,9 +1788,8 @@ static void dt_bauhaus_widget_accept(dt_bauhaus_widget_t *w)
     {
       // only set to what's in the filtered list.
       dt_bauhaus_combobox_data_t *d = &w->data.combobox;
-      const int top_gap = (w->detached_popup) ? w->top_gap + darktable.bauhaus->line_height : w->top_gap;
       const int active = darktable.bauhaus->end_mouse_y >= 0
-                             ? ((darktable.bauhaus->end_mouse_y - top_gap) / darktable.bauhaus->line_height)
+                             ? ((darktable.bauhaus->end_mouse_y - w->top_gap) / darktable.bauhaus->line_height)
                              : d->active;
       int k = 0, i = 0, kk = 0, match = 1;
 
@@ -2009,11 +1979,7 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       gboolean show_box_label = TRUE;
       int k = 0, i = 0;
       ht = darktable.bauhaus->line_height;
-      // case where the popup is detcahed (label on its specific line)
-      const int top_gap = (w->detached_popup) ? w->top_gap + ht : w->top_gap;
-      if(w->detached_popup || !w->show_label) first_label = FALSE;
-      if(!w->detached_popup && !w->show_label) show_box_label = FALSE;
-      const int hovered = (darktable.bauhaus->mouse_y - top_gap) / darktable.bauhaus->line_height;
+      const int hovered = (darktable.bauhaus->mouse_y - w->top_gap) / darktable.bauhaus->line_height;
       gchar *keys = g_utf8_casefold(darktable.bauhaus->keys, -1);
       const PangoEllipsizeMode ellipsis = d->entries_ellipsis;
 
@@ -2038,7 +2004,7 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
           {
             gchar *esc_label = g_markup_escape_text(entry->label, -1);
             gchar *label = g_strdup_printf("<b>%s</b>", esc_label);
-            label_width = show_pango_text(w, context, cr, label, 0, ht * k + top_gap, max_width, FALSE, FALSE,
+            label_width = show_pango_text(w, context, cr, label, 0, ht * k + w->top_gap, max_width, FALSE, FALSE,
                                           ellipsis, TRUE, FALSE, NULL, NULL);
             g_free(label);
             g_free(esc_label);
@@ -2046,18 +2012,18 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
           else if(entry->alignment == DT_BAUHAUS_COMBOBOX_ALIGN_MIDDLE)
           {
             // first pass, we just get the text width
-            label_width = show_pango_text(w, context, cr, entry->label, 0, ht * k + top_gap, max_width, FALSE,
+            label_width = show_pango_text(w, context, cr, entry->label, 0, ht * k + w->top_gap, max_width, FALSE,
                                           TRUE, ellipsis, TRUE, FALSE, NULL, NULL);
             // second pass, we draw it in the middle
             const int posx = MAX(0, (max_width - label_width) / 2);
-            label_width = show_pango_text(w, context, cr, entry->label, posx, ht * k + top_gap, max_width, FALSE,
+            label_width = show_pango_text(w, context, cr, entry->label, posx, ht * k + w->top_gap, max_width, FALSE,
                                           FALSE, ellipsis, TRUE, FALSE, NULL, NULL);
           }
           else
           {
             if(first_label) max_width *= 0.8; // give the label at least some room
             label_width
-                = show_pango_text(w, context, cr, entry->label, w2 - _widget_get_quad_width(w), ht * k + top_gap,
+                = show_pango_text(w, context, cr, entry->label, w2 - _widget_get_quad_width(w), ht * k + w->top_gap,
                                   max_width, TRUE, FALSE, ellipsis, FALSE, FALSE, NULL, NULL);
           }
 
@@ -2161,15 +2127,14 @@ static gboolean _widget_draw(GtkWidget *widget, cairo_t *crf)
 
   gtk_style_context_get_color(context, state, fg_color);
   gtk_style_context_get(context, state, "background-color", &bg_color, NULL);
-  _margins_retrieve(w);
 
   // translate to account for the widget spacing
-  const int h2 = height - w->margin->top - w->margin->bottom;
-  const int w2 = width - w->margin->left - w->margin->right;
-  const int h3 = h2 - w->padding->top - w->padding->bottom;
-  const int w3 = w2 - w->padding->left - w->padding->right;
-  gtk_render_background(context, cr, w->margin->left, w->margin->top, w2, h2);
-  cairo_translate(cr, w->margin->left + w->padding->left, w->margin->top + w->padding->top);
+  const int h2 = height - w->margin.top - w->margin.bottom;
+  const int w2 = width - w->margin.left - w->margin.right;
+  const int h3 = h2 - w->padding.top - w->padding.bottom;
+  const int w3 = w2 - w->padding.left - w->padding.right;
+  gtk_render_background(context, cr, w->margin.left, w->margin.top, w2, h2);
+  cairo_translate(cr, w->margin.left + w->padding.left, w->margin.top + w->padding.top);
 
   // draw type specific content:
   cairo_save(cr);
@@ -2297,7 +2262,7 @@ static gboolean _widget_draw(GtkWidget *widget, cairo_t *crf)
   cairo_surface_destroy(cst);
 
   // render eventual css borders
-  gtk_render_frame(context, crf, w->margin->left, w->margin->top, w2, h2);
+  gtk_render_frame(context, crf, w->margin.left, w->margin.top, w2, h2);
 
   gdk_rgba_free(text_color);
   gdk_rgba_free(fg_color);
@@ -2322,9 +2287,12 @@ static gint _bauhaus_natural_width(GtkWidget *widget, gboolean popup)
   pango_layout_set_attributes(layout, attrlist);
   pango_attr_list_unref(attrlist);
 
-  pango_layout_set_text(layout, w->label, -1);
-  pango_layout_get_size(layout, &natural_size, NULL);
-  natural_size /= PANGO_SCALE;
+  if(w->show_label || popup)
+  {
+    pango_layout_set_text(layout, w->label, -1);
+    pango_layout_get_size(layout, &natural_size, NULL);
+    natural_size /= PANGO_SCALE;
+  }
 
   if(w->type == DT_BAUHAUS_COMBOBOX)
   {
@@ -2332,11 +2300,8 @@ static gint _bauhaus_natural_width(GtkWidget *widget, gboolean popup)
 
     gint label_width = 0, entry_width = 0;
 
-    if(d->text_align == DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT && w->show_label)
-    {
-      if(!w->detached_popup) label_width = natural_size;
-      if(label_width) label_width += 2 * INNER_PADDING;
-    }
+    if(natural_size && d->text_align == DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT && (popup || w->show_label))
+      label_width = natural_size + 2 * INNER_PADDING;
 
     for(int i = 0; i < d->entries->len; i++)
     {
@@ -2354,32 +2319,50 @@ static gint _bauhaus_natural_width(GtkWidget *widget, gboolean popup)
   else
   {
     gint number_width = 0;
-    char *text = dt_bauhaus_slider_get_text(widget, dt_bauhaus_slider_get(widget));
-    pango_layout_set_text(layout, text, -1);
+    char *max = dt_bauhaus_slider_get_text(widget, w->data.slider.max);
+    char *min = dt_bauhaus_slider_get_text(widget, w->data.slider.min);
+    char *text = strlen(max) >= strlen(min) ? max : min;pango_layout_set_text(layout, text, -1);
     pango_layout_get_size(layout, &number_width, NULL);
     natural_size += 2 * INNER_PADDING + number_width / PANGO_SCALE;
-    g_free(text);
+    g_free(max);
+    g_free(min);
   }
 
-  _margins_retrieve(w);
-  natural_size += _widget_get_quad_width(w) + w->margin->left + w->margin->right
-                  + w->padding->left + w->padding->right;
-
+  natural_size += (w->show_quad ? _widget_get_quad_width(w) : 0);
   g_object_unref(layout);
 
   return natural_size;
 }
 
-static void _get_preferred_width(GtkWidget *widget, gint *minimum_size, gint *natural_size)
+static void _get_preferred_width(GtkWidget *widget, gint *minimum_width, gint *natural_width)
 {
-  *natural_size = _bauhaus_natural_width(widget, FALSE);
+  dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)widget;
+  _margins_retrieve(w);
+
+  *natural_width = _bauhaus_natural_width(widget, FALSE)
+                   + w->margin.left + w->margin.right + w->padding.left + w->padding.right;
+}
+
+static void _get_preferred_height(GtkWidget *widget, gint *minimum_height, gint *natural_height)
+{
+  dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)widget;
+  _margins_retrieve(w);
+
+  *minimum_height = w->margin.top + w->margin.bottom + w->padding.top + w->padding.bottom
+                    + darktable.bauhaus->line_height;
+  if(w->type == DT_BAUHAUS_SLIDER)
+  {
+    // the lower thing to draw is indicator. See dt_bauhaus_draw_baseline for compute details
+    *minimum_height += INNER_PADDING + darktable.bauhaus->baseline_size + 1.5f * darktable.bauhaus->border_width;
+  }
+
+  *natural_height = *minimum_height;
 }
 
 void dt_bauhaus_hide_popup()
 {
   if(darktable.bauhaus->current)
   {
-    darktable.bauhaus->current->detached_popup = FALSE;
     gtk_grab_remove(darktable.bauhaus->popup_area);
     gtk_widget_hide(darktable.bauhaus->popup_window);
     gtk_window_set_attached_to(GTK_WINDOW(darktable.bauhaus->popup_window), NULL);
@@ -2411,12 +2394,25 @@ void dt_bauhaus_show_popup(GtkWidget *widget)
   if(widget_window)
     gdk_window_get_origin(widget_window, &wx, &wy);
 
+  // we update the popup padding defined in css
+  if(!darktable.bauhaus->popup_padding) darktable.bauhaus->popup_padding = gtk_border_new();
+  GtkStyleContext *context = gtk_widget_get_style_context(darktable.bauhaus->popup_area);
+  gtk_style_context_add_class(context, "dt_bauhaus_popup");
+  // let's update the css class depending on the source widget type
+  // this allow to set different padding for example
+  if(w->show_quad)
+    gtk_style_context_remove_class(context, "dt_bauhaus_popup_right");
+  else
+    gtk_style_context_add_class(context, "dt_bauhaus_popup_right");
+
+  const GtkStateFlags state = gtk_widget_get_state_flags(darktable.bauhaus->popup_area);
+  gtk_style_context_get_padding(context, state, darktable.bauhaus->popup_padding);
+
   GtkAllocation tmp;
   gtk_widget_get_allocation(widget, &tmp);
-  gint natural_w = _bauhaus_natural_width(widget, TRUE);
-  if(tmp.width < natural_w)
-    tmp.width = natural_w;
-  else if(tmp.width == 1 || !w->margin)
+  const int ht = tmp.height;
+  const int right_of_w = wx + tmp.width - w->margin.right - w->padding.right;
+  if(tmp.width == 1)
   {
     if(dt_ui_panel_ancestor(darktable.gui->ui, DT_UI_PANEL_RIGHT, widget))
       tmp.width = dt_ui_panel_get_size(darktable.gui->ui, DT_UI_PANEL_RIGHT);
@@ -2429,23 +2425,29 @@ void dt_bauhaus_show_popup(GtkWidget *widget)
   else
   {
   // by default, we want the popup to be exactly the size of the widget content
-    tmp.width = MAX(1, tmp.width - (w->margin->left + w->margin->right + w->padding->left + w->padding->right));
+    tmp.width = MAX(1, tmp.width - (w->margin.left + w->margin.right + w->padding.left + w->padding.right));
   }
+
+  const gint natural_w = _bauhaus_natural_width(widget, TRUE);
+  if(tmp.width < natural_w)
+    tmp.width = natural_w;
 
   gint px, py;
   GdkDevice *pointer = gdk_seat_get_pointer(gdk_display_get_default_seat(gdk_display_get_default()));
   gdk_device_get_position(pointer, NULL, &px, &py);
 
-  w->detached_popup = FALSE;
-  if(px < wx || px > wx + tmp.width)
+  if(px < right_of_w - tmp.width  || px > right_of_w)
   {
-    w->detached_popup = TRUE;
     wx = px - (tmp.width - _widget_get_quad_width(w)) / 2;
     wy = py - darktable.bauhaus->line_height / 2;
   }
-  else if(py < wy || py > wy + tmp.height)
+  else
   {
-    wy = py - darktable.bauhaus->line_height / 2;
+    wx = right_of_w - tmp.width ;
+    if(py < wy || py > wy + tmp.height)
+    {
+      wy = py - darktable.bauhaus->line_height / 2;
+    }
   }
 
   switch(darktable.bauhaus->current->type)
@@ -2467,23 +2469,13 @@ void dt_bauhaus_show_popup(GtkWidget *widget)
       // comboboxes change immediately
       darktable.bauhaus->change_active = 1;
       if(!d->entries->len) return;
-      tmp.height = darktable.bauhaus->line_height * d->entries->len;
-      // if the popup is detached, we show the label in any cases, in a special line
-      if(w->detached_popup)
-      {
-        tmp.height += darktable.bauhaus->line_height;
-        wy -= darktable.bauhaus->line_height;
-        darktable.bauhaus->mouse_y = darktable.bauhaus->line_height;
-      }
+      tmp.height = darktable.bauhaus->line_height * d->entries->len
+                   + w->margin.top + w->margin.bottom + w->top_gap;
 
-      if(w->margin) tmp.height += w->margin->top + w->margin->bottom + w->top_gap;
-
-      GtkAllocation allocation_w;
-      gtk_widget_get_allocation(widget, &allocation_w);
-      const int ht = allocation_w.height;
       wy -= d->active * darktable.bauhaus->line_height;
+
       darktable.bauhaus->mouse_x = 0;
-      darktable.bauhaus->mouse_y += d->active * darktable.bauhaus->line_height + ht / 2;
+      darktable.bauhaus->mouse_y = d->active * darktable.bauhaus->line_height + ht / 2;
       break;
     }
     default:
@@ -2491,37 +2483,18 @@ void dt_bauhaus_show_popup(GtkWidget *widget)
   }
 
   // by default, we want the popup to be exactly at the position of the widget content
-  if(w->margin)
-  {
-    wx += w->margin->left + w->padding->left;
-    wy += w->margin->top + w->padding->top;
-  }
+  wx += w->margin.left + w->padding.left;
+  wy += w->margin.top + w->padding.top;
 
-  // we update the popup padding defined in css
-  if(!darktable.bauhaus->popup_padding) darktable.bauhaus->popup_padding = gtk_border_new();
-  GtkStyleContext *context = gtk_widget_get_style_context(darktable.bauhaus->popup_area);
-  gtk_style_context_add_class(context, "dt_bauhaus_popup");
-  // let's update the css class depending on the source widget type
-  // this allow to set different padding for example
-  if(w->show_quad)
-    gtk_style_context_remove_class(context, "dt_bauhaus_popup_right");
-  else
-    gtk_style_context_add_class(context, "dt_bauhaus_popup_right");
-
-  const GtkStateFlags state = gtk_widget_get_state_flags(darktable.bauhaus->popup_area);
-  gtk_style_context_get_padding(context, state, darktable.bauhaus->popup_padding);
   // and now we extent the popup to take account of its own padding
   wx -= darktable.bauhaus->popup_padding->left;
   wy -= darktable.bauhaus->popup_padding->top;
   tmp.width += darktable.bauhaus->popup_padding->left + darktable.bauhaus->popup_padding->right;
   tmp.height += darktable.bauhaus->popup_padding->top + darktable.bauhaus->popup_padding->bottom;
 
-  if(widget_window)
-  {
-    GdkRectangle workarea;
-    gdk_monitor_get_workarea(gdk_display_get_monitor_at_window(gdk_window_get_display(widget_window), widget_window), &workarea);
-    wx = MAX(workarea.x, MIN(wx, workarea.x + workarea.width - tmp.width));
-  }
+  GdkRectangle workarea;
+  gdk_monitor_get_workarea(gdk_display_get_monitor_at_point(gdk_display_get_default(), wx, wy), &workarea);
+  wx = MAX(workarea.x, MIN(wx, workarea.x + workarea.width - tmp.width));
 
   // gtk_widget_get_window will return null if not shown yet.
   // it is needed for gdk_window_move, and gtk_window move will
@@ -3073,10 +3046,10 @@ static gboolean dt_bauhaus_slider_button_press(GtkWidget *widget, GdkEventButton
 
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
-  const int w3 = allocation.width - w->margin->left - w->padding->left - w->margin->right - w->padding->right;
-  const double ex = event->x - w->margin->left - w->padding->left;
-  const double ey = event->y - w->margin->top - w->padding->top;
-  if(event->x > allocation.width - _widget_get_quad_width(w) - w->margin->right - w->padding->right)
+  const int w3 = allocation.width - w->margin.left - w->padding.left - w->margin.right - w->padding.right;
+  const double ex = event->x - w->margin.left - w->padding.left;
+  const double ey = event->y - w->margin.top - w->padding.top;
+  if(event->x > allocation.width - _widget_get_quad_width(w) - w->margin.right - w->padding.right)
   {
     dt_bauhaus_widget_press_quad(widget);
     return TRUE;
@@ -3143,8 +3116,8 @@ static gboolean dt_bauhaus_slider_motion_notify(GtkWidget *widget, GdkEventMotio
 
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
-  const int w3 = allocation.width - w->margin->left - w->padding->left - w->margin->right - w->padding->right;
-  const double ex = event->x - w->margin->left - w->padding->left;
+  const int w3 = allocation.width - w->margin.left - w->padding.left - w->margin.right - w->padding.right;
+  const double ex = event->x - w->margin.left - w->padding.left;
   if(d->is_dragging && event->state & GDK_BUTTON1_MASK)
   {
     const float r = slider_right_pos((float)w3, w);

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -169,12 +169,9 @@ typedef struct dt_bauhaus_widget_t
   gboolean is_section;
 
   // margin and padding structure, defined in css, retrieve on each draw
-  GtkBorder *margin, *padding;
+  GtkBorder margin, padding;
   // gap to add to the top padding due to the vertical centering
   int top_gap;
-
-  // is the popup not attached to the main widget (shortcuts)
-  gboolean detached_popup;
 
   // goes last, might extend past the end:
   dt_bauhaus_data_t data;

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1850,17 +1850,6 @@ static gboolean dt_iop_basecurve_button_press(GtkWidget *widget, GdkEventButton 
   return FALSE;
 }
 
-static gboolean area_resized(GtkWidget *widget, GdkEvent *event, gpointer user_data)
-{
-  GtkAllocation allocation;
-  gtk_widget_get_allocation(widget, &allocation);
-  GtkRequisition r;
-  r.width = allocation.width;
-  r.height = allocation.width;
-  gtk_widget_get_preferred_size(widget, &r, NULL);
-  return TRUE;
-}
-
 static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, float dx, float dy, guint state)
 {
   dt_iop_basecurve_params_t *p = (dt_iop_basecurve_params_t *)self->params;
@@ -2031,7 +2020,6 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(c->area), "motion-notify-event", G_CALLBACK(dt_iop_basecurve_motion_notify), self);
   g_signal_connect(G_OBJECT(c->area), "leave-notify-event", G_CALLBACK(dt_iop_basecurve_leave_notify), self);
   g_signal_connect(G_OBJECT(c->area), "enter-notify-event", G_CALLBACK(dt_iop_basecurve_enter_notify), self);
-  g_signal_connect(G_OBJECT(c->area), "configure-event", G_CALLBACK(area_resized), self);
   g_signal_connect(G_OBJECT(c->area), "scroll-event", G_CALLBACK(_scrolled), self);
   g_signal_connect(G_OBJECT(c->area), "key-press-event", G_CALLBACK(dt_iop_basecurve_key_press), self);
 }

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2070,17 +2070,6 @@ static gboolean _area_leave_notify_callback(GtkWidget *widget, GdkEventCrossing 
   return TRUE;
 }
 
-static gboolean _area_resized_callback(GtkWidget *widget, GdkEvent *event, gpointer user_data)
-{
-  GtkRequisition r;
-  GtkAllocation allocation;
-  gtk_widget_get_allocation(widget, &allocation);
-  r.width = allocation.width;
-  r.height = allocation.width;
-  gtk_widget_get_preferred_size(widget, &r, NULL);
-  return TRUE;
-}
-
 static gboolean _area_key_press_callback(GtkWidget *widget, GdkEventKey *event, dt_iop_module_t *self)
 {
   dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
@@ -2515,7 +2504,6 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(c->area), "leave-notify-event", G_CALLBACK(_area_leave_notify_callback), self);
   g_signal_connect(G_OBJECT(c->area), "enter-notify-event", G_CALLBACK(_area_enter_notify_callback), self);
   g_signal_connect(G_OBJECT(c->area), "scroll-event", G_CALLBACK(_area_scrolled_callback), self);
-  g_signal_connect(G_OBJECT(c->area), "configure-event", G_CALLBACK(_area_resized_callback), self);
   g_signal_connect(G_OBJECT(c->area), "key-press-event", G_CALLBACK(_area_key_press_callback), self);
 
   gtk_widget_add_events(GTK_WIDGET(c->bottom_area), GDK_BUTTON_PRESS_MASK);

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -421,17 +421,6 @@ static void tab_switch_callback(GtkNotebook *notebook, GtkWidget *page, guint pa
   gtk_widget_queue_draw(self->widget);
 }
 
-static gboolean _area_resized_callback(GtkWidget *widget, GdkEvent *event, gpointer user_data)
-{
-  GtkRequisition r;
-  GtkAllocation allocation;
-  gtk_widget_get_allocation(widget, &allocation);
-  r.width = allocation.width;
-  r.height = allocation.width;
-  gtk_widget_get_preferred_size(widget, &r, NULL);
-  return TRUE;
-}
-
 static inline int _add_node(dt_iop_rgbcurve_node_t *curve_nodes, int *nodes, float x, float y)
 {
   int selected = -1;
@@ -1408,7 +1397,6 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->area), "motion-notify-event", G_CALLBACK(_area_motion_notify_callback), self);
   g_signal_connect(G_OBJECT(g->area), "leave-notify-event", G_CALLBACK(_area_leave_notify_callback), self);
   g_signal_connect(G_OBJECT(g->area), "enter-notify-event", G_CALLBACK(_area_enter_notify_callback), self);
-  g_signal_connect(G_OBJECT(g->area), "configure-event", G_CALLBACK(_area_resized_callback), self);
   g_signal_connect(G_OBJECT(g->area), "scroll-event", G_CALLBACK(_area_scrolled_callback), self);
   g_signal_connect(G_OBJECT(g->area), "key-press-event", G_CALLBACK(_area_key_press_callback), self);
 

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -906,17 +906,6 @@ static void tab_switch(GtkNotebook *notebook, GtkWidget *page, guint page_num, g
   gtk_widget_queue_draw(self->widget);
 }
 
-static gboolean area_resized(GtkWidget *widget, GdkEvent *event, gpointer user_data)
-{
-  GtkRequisition r;
-  GtkAllocation allocation;
-  gtk_widget_get_allocation(widget, &allocation);
-  r.width = allocation.width;
-  r.height = allocation.width;
-  gtk_widget_get_preferred_size(widget, &r, NULL);
-  return TRUE;
-}
-
 static float to_log(const float x, const float base, const int ch, const int semilog, const int is_ordinate)
 {
   // don't log-encode the a and b channels
@@ -1171,7 +1160,6 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(c->area), "motion-notify-event", G_CALLBACK(dt_iop_tonecurve_motion_notify), self);
   g_signal_connect(G_OBJECT(c->area), "leave-notify-event", G_CALLBACK(dt_iop_tonecurve_leave_notify), self);
   g_signal_connect(G_OBJECT(c->area), "enter-notify-event", G_CALLBACK(dt_iop_tonecurve_enter_notify), self);
-  g_signal_connect(G_OBJECT(c->area), "configure-event", G_CALLBACK(area_resized), self);
   g_signal_connect(G_OBJECT(c->area), "scroll-event", G_CALLBACK(_scrolled), self);
   g_signal_connect(G_OBJECT(c->area), "key-press-event", G_CALLBACK(dt_iop_tonecurve_key_press), self);
 

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -1187,7 +1187,7 @@ static gboolean _widget_init(dt_lib_filtering_rule_t *rule, const dt_collection_
     g_object_set_data(G_OBJECT(rule->w_prop), "rule", rule);
     dt_bauhaus_combobox_set_from_value(rule->w_prop, prop);
     g_signal_connect(G_OBJECT(rule->w_prop), "value-changed", G_CALLBACK(_event_rule_change_type), self);
-    gtk_box_pack_start(GTK_BOX(hbox), rule->w_prop, TRUE, TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(hbox), rule->w_prop, TRUE, FALSE, 0);
   }
   else if(newprop)
   {


### PR DESCRIPTION
fixes https://github.com/darktable-org/darktable/issues/12657

Removes "detached" labels for bauhaus combo popups called via shortcuts since they caused issues and inconsistencies.

Labels are once again on the first line of the combo popup list. The popup will increase size to fit both label and items without ellipsizing. It will right align with the combo widget to avoid a jump in the selected item. Combos that are left aligned or have section headers do not show a label (blending, collections).

Also fixes a bug that highlighted the wrong or two combo items in the popup (fixes #12666)

Unrelatedly removed several _area_resized_ callbacks in four modules that were non-functional (they _get_ rather than _set_ a size). They were broken at some point, may historically have had a purpose, but I can't figure out what it would have been and resizing seems to work fine without them (_has_ been working fine without them doing anything).