### PR TITLE
po/rework overlay display

### DIFF
--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -727,26 +727,28 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
 
 static void _thumb_update_icons(dt_thumbnail_t *thumb)
 {
-  gtk_widget_set_visible(thumb->w_local_copy, thumb->has_localcopy);
-  gtk_widget_set_visible(thumb->w_altered, thumb->is_altered);
-  gtk_widget_set_visible(thumb->w_group, thumb->is_grouped);
-  gtk_widget_set_visible(thumb->w_audio, thumb->has_audio);
-  gtk_widget_set_visible(thumb->w_color, thumb->colorlabels != 0);
-  gtk_widget_set_visible(thumb->w_zoom_eb, (thumb->zoomable && thumb->over == DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK));
-  gtk_widget_show(thumb->w_bottom_eb);
-  gtk_widget_show(thumb->w_reject);
-  gtk_widget_show(thumb->w_ext);
-  gtk_widget_show(thumb->w_cursor);
-  for(int i = 0; i < MAX_STARS; i++) gtk_widget_show(thumb->w_stars[i]);
+  if(thumb->display_overlay)
+  {
+    gtk_widget_set_visible(thumb->w_local_copy, thumb->has_localcopy);
+    gtk_widget_set_visible(thumb->w_altered, thumb->is_altered);
+    gtk_widget_set_visible(thumb->w_group, thumb->is_grouped);
+    gtk_widget_set_visible(thumb->w_audio, thumb->has_audio);
+    gtk_widget_set_visible(thumb->w_color, thumb->colorlabels != 0);
+    gtk_widget_set_visible(thumb->w_zoom_eb, (thumb->zoomable && thumb->over == DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK));
+    gtk_widget_show(thumb->w_bottom_eb);
+    gtk_widget_show(thumb->w_reject);
+    gtk_widget_show(thumb->w_ext);
+    gtk_widget_show(thumb->w_cursor);
+    for(int i = 0; i < MAX_STARS; i++) gtk_widget_show(thumb->w_stars[i]);
+
+    _set_flag(thumb->w_reject, GTK_STATE_FLAG_ACTIVE, (thumb->rating == DT_VIEW_REJECT));
+    for(int i = 0; i < MAX_STARS; i++)
+      _set_flag(thumb->w_stars[i], GTK_STATE_FLAG_ACTIVE, (thumb->rating > i && thumb->rating < DT_VIEW_REJECT));
+    _set_flag(thumb->w_group, GTK_STATE_FLAG_ACTIVE, (thumb->imgid == thumb->groupid));
+  }
 
   _set_flag(thumb->w_main, GTK_STATE_FLAG_PRELIGHT, thumb->mouse_over);
   _set_flag(thumb->w_main, GTK_STATE_FLAG_ACTIVE, thumb->active);
-
-  _set_flag(thumb->w_reject, GTK_STATE_FLAG_ACTIVE, (thumb->rating == DT_VIEW_REJECT));
-  for(int i = 0; i < MAX_STARS; i++)
-    _set_flag(thumb->w_stars[i], GTK_STATE_FLAG_ACTIVE, (thumb->rating > i && thumb->rating < DT_VIEW_REJECT));
-  _set_flag(thumb->w_group, GTK_STATE_FLAG_ACTIVE, (thumb->imgid == thumb->groupid));
-
   _set_flag(thumb->w_main, GTK_STATE_FLAG_SELECTED, thumb->selected);
 
   // and the tooltip
@@ -783,8 +785,11 @@ static void _thumb_update_icons(dt_thumbnail_t *thumb)
   g_free(pattern);
 
   // we recompte the history tooltip if needed
-  thumb->is_altered = dt_image_altered(thumb->imgid);
-  gtk_widget_set_visible(thumb->w_altered, thumb->is_altered);
+  if(thumb->display_overlay)
+  {
+    thumb->is_altered = dt_image_altered(thumb->imgid);
+    gtk_widget_set_visible(thumb->w_altered, thumb->is_altered);
+  }
   if(thumb->is_altered)
   {
     char *tooltip = dt_history_get_items_as_string(thumb->imgid);
@@ -831,16 +836,30 @@ static gboolean _event_main_motion(GtkWidget *widget, GdkEventMotion *event, gpo
   // first, we hide the block overlays after a delay if the mouse hasn't move
   if(thumb->over == DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK)
   {
+    // check current mouse position, if lower-half never display the overlay
+    GtkAllocation allocation;
+    gtk_widget_get_allocation(widget, &allocation);
+    thumb->display_overlay = (event->y < allocation.height / 2.f);
+
     if(thumb->overlay_timeout_id > 0)
     {
       g_source_remove(thumb->overlay_timeout_id);
       thumb->overlay_timeout_id = 0;
     }
-    _thumbs_show_overlays(thumb);
-    if(thumb->overlay_timeout_duration >= 0)
+
+    if(thumb->display_overlay)
     {
-      thumb->overlay_timeout_id
-          = g_timeout_add_seconds(thumb->overlay_timeout_duration, _thumbs_hide_overlays, thumb);
+      _thumbs_show_overlays(thumb);
+      if(thumb->overlay_timeout_duration >= 0)
+      {
+        thumb->overlay_timeout_id
+          = g_timeout_add_seconds(thumb->overlay_timeout_duration,
+                                  _thumbs_hide_overlays, thumb);
+      }
+    }
+    else
+    {
+      _thumbs_hide_overlays(thumb);
     }
   }
 
@@ -1457,6 +1476,10 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb, float zoom_ratio)
   }
   gtk_widget_show(thumb->w_main);
   g_object_ref(G_OBJECT(thumb->w_main));
+
+  if(thumb->over == DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK)
+    _thumbs_hide_overlays(thumb);
+
   return thumb->w_main;
 }
 
@@ -1476,6 +1499,7 @@ dt_thumbnail_t *dt_thumbnail_new(int width, int height, float zoom_ratio, int im
   thumb->overlay_timeout_duration = dt_conf_get_int("plugins/lighttable/overlay_timeout");
   thumb->tooltip = tooltip;
   thumb->expose_again_timeout_id = 0;
+  thumb->display_overlay = (thumb->over != DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK);
 
   // we read and cache all the infos from dt_image_t that we need
   const dt_image_t *img = dt_image_cache_get(darktable.image_cache, thumb->imgid, 'r');

--- a/src/dtgtk/thumbnail.h
+++ b/src/dtgtk/thumbnail.h
@@ -124,6 +124,7 @@ typedef struct
   dt_thumbnail_overlay_t over;  // type of overlays
   int overlay_timeout_duration; // for hover_block overlay, we hide the it after a delay
   int overlay_timeout_id;       // id of the g_source timeout fct
+  gboolean display_overlay;     // FALSE if not displayed (based on mouse position)
   gboolean tooltip;             // should we show the tooltip ?
 
   int expose_again_timeout_id;  // source id of the expose_again timeout
@@ -184,4 +185,3 @@ float dt_thumbnail_get_zoom_ratio(dt_thumbnail_t *thumb);
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-


### PR DESCRIPTION
thumbnails: do not display overlay bloc by default.
    
The block gets displayed on when the mouse is move and in upper half
of thumb.

This feature was lost somehow, this PR recover it.