### PR TITLE
remove side panel min/max px limits

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -156,20 +156,6 @@
     <longdescription>after successfully creating snapshot, how many older snapshots to keep (excluding mandatory version update ones). enter -1 to keep all snapshots\nkeep in mind that snapshots do take some space and you only need the most recent one for successful restore</longdescription>
   </dtconfig>
   <dtconfig>
-    <name>min_panel_width</name>
-    <type>int</type>
-    <default>150</default>
-    <shortdescription>minimum width of the side panels in pixels</shortdescription>
-    <longdescription>(needs a restart)</longdescription>
-  </dtconfig>
-  <dtconfig>
-    <name>max_panel_width</name>
-    <type>int</type>
-    <default>500</default>
-    <shortdescription>maximum width of the side panels in pixels</shortdescription>
-    <longdescription>(needs a restart)</longdescription>
-  </dtconfig>
-  <dtconfig>
     <name>min_panel_height</name>
     <type>int</type>
     <default>64</default>

--- a/src/dtgtk/sidepanel.c
+++ b/src/dtgtk/sidepanel.c
@@ -30,9 +30,9 @@ static GtkSizeRequestMode dtgtk_side_panel_get_request_mode(GtkWidget *widget)
 
 static void dtgtk_side_panel_get_preferred_width(GtkWidget *widget, gint *minimum_size, gint *natural_size)
 {
-  GtkDarktableSidePanelClass *class = DTGTK_SIDE_PANEL_GET_CLASS(widget);
+  GTK_WIDGET_CLASS(dtgtk_side_panel_parent_class)->get_preferred_width(widget, minimum_size, NULL);
 
-  *minimum_size = *natural_size = class->width;
+  *natural_size = *minimum_size;
 }
 
 static void dtgtk_side_panel_class_init(GtkDarktableSidePanelClass *class)
@@ -41,9 +41,6 @@ static void dtgtk_side_panel_class_init(GtkDarktableSidePanelClass *class)
 
   widget_class->get_request_mode = dtgtk_side_panel_get_request_mode;
   widget_class->get_preferred_width = dtgtk_side_panel_get_preferred_width;
-
-  class->width
-      = dt_conf_get_int("min_panel_width"); // this is the miminum width, real size has to be applied after
 }
 
 static void dtgtk_side_panel_init(GtkDarktableSidePanel *panel)

--- a/src/dtgtk/sidepanel.h
+++ b/src/dtgtk/sidepanel.h
@@ -35,15 +35,12 @@ G_BEGIN_DECLS
 
 typedef struct _GtkDarktableSidePanel
 {
-  GtkPaned panel;
+  GtkBox panel;
 } GtkDarktableSidePanel;
 
 typedef struct _GtkDarktableSidePanelClass
 {
-  GtkPanedClass parent_class;
-
-  /*< private >*/
-  gint width;
+  GtkBoxClass parent_class;
 } GtkDarktableSidePanelClass;
 
 GType dtgtk_side_panel_get_type(void);

--- a/src/libs/filters/search.c
+++ b/src/libs/filters/search.c
@@ -172,9 +172,8 @@ static void _search_widget_init(dt_lib_filtering_rule_t *rule, const dt_collecti
   g_signal_connect(G_OBJECT(search->text), "search-changed", G_CALLBACK(_search_changed), search);
   g_signal_connect(G_OBJECT(search->text), "stop-search", G_CALLBACK(_search_reset_text_entry), rule);
   if(top)
-    gtk_entry_set_width_chars(GTK_ENTRY(search->text), 14);
-  else
-    gtk_entry_set_width_chars(GTK_ENTRY(search->text), 0);
+    gtk_entry_set_max_width_chars(GTK_ENTRY(search->text), 20);
+  gtk_entry_set_width_chars(GTK_ENTRY(search->text), 0);
   gtk_widget_set_tooltip_text(search->text,
                               /* xgettext:no-c-format */
                               _("filter by text from images metadata, tags, file path and name"


### PR DESCRIPTION
The side panel width was limited to an arbitrary 150-500 pixels, which does not make sense for hidpi or large fonts. Even with the lower boundary, the panel could be made too narrow for its contents forcing a horizontal scrollbar to appear and making some of the content invisible/not readily accessible, sometimes leading to confusion.

This PR removes those limits, instead preventing the user from making the panel wider than the window size and the (minimum) size of the top/bottom bars and other side panel allows. 

The minimum width of the panels will be automatically adjusted to the needs of their content. Now that most widgets have been correctly ellipsized, this means uncompressible buttons. So for example the iop modules panel will be at least wide enough for 7 blending icons. A horizontal scrollbar will never appear.

fixes #12787