### PR TITLE
range popup position

### DIFF
--- a/src/dtgtk/range.h
+++ b/src/dtgtk/range.h
@@ -116,6 +116,8 @@ struct _GtkDarktableRangeSelect
   // window used to show the value under the cursor
   GtkWidget *cur_window;
   GtkWidget *cur_label;
+  int y_root; // y position in the main window
+  GtkPositionType cur_pos;
 
   struct _range_date_popup *date_popup;
 };


### PR DESCRIPTION
this fixes a bug introduced by commit 2d34ed2fcad9683dfa33869270ffada5eda8a084
to avoid flickering (the issue the commit wanted to solve) we store the Y root position of the widget as well as the last popup position. That way the only case the popup position may be changed on the fly is when the mouse hover the widget for the first time...
@dterrahe : thanks for your input and advice. I let you review and comment. Thanks !