### PR TITLE
Introduce final_width&height for pixelpipes

### DIFF
--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -130,6 +130,7 @@ typedef struct dt_dev_pixelpipe_t
   // output buffer (for display)
   uint8_t *output_backbuf;
   int output_backbuf_width, output_backbuf_height;
+  int final_width, final_height;
 
   // the data for the luminance mask are kept in a buffer written by demosaic or rawprepare
   // as we have to scale the mask later ke keep roi at that stage


### PR DESCRIPTION
Currently there is no way to find out the final dimensions of a pixelpipe while processing it. This introduces final_width& height in the pipe struct taht can be read by modules while processing helping to possibly find optimal processing code.

While being here also fixed static functions styles.