### PR TITLE
history: merging a disabled module with try to replace an existing one.

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -291,7 +291,8 @@ int dt_history_merge_module_into_history(dt_develop_t *dev_dest, dt_develop_t *d
   dt_iop_module_t *mod_replace = NULL;
 
   // one-instance modules always replace the existing one
-  if(mod_src->flags() & IOP_FLAGS_ONE_INSTANCE)
+  if(mod_src->flags() & IOP_FLAGS_ONE_INSTANCE
+    || !mod_src->enabled)
   {
     mod_replace = dt_iop_get_module_by_op_priority(dev_dest->iop, mod_src->op, -1);
     if(mod_replace == NULL)


### PR DESCRIPTION
When a style contains a disbaled module the goal is for it to disable a possibly present module in the current history stack.

This fixes issue when using a style with a disabled module in the export module. It also fix the style preview which now properly display the preview without the module being applied.

Fixes #12789.