### PR TITLE
filtering enhancements

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -443,7 +443,7 @@
   <dtconfig>
     <name>plugins/lighttable/filtering/sort0</name>
     <type>int</type>
-    <default>0</default>
+    <default>1</default>
     <shortdescription>first sort orders</shortdescription>
     <longdescription></longdescription>
   </dtconfig>
@@ -457,7 +457,7 @@
   <dtconfig>
     <name>plugins/lighttable/filtering/item0</name>
     <type>int</type>
-    <default>32</default>
+    <default>9</default>
     <shortdescription>first filter</shortdescription>
     <longdescription></longdescription>
   </dtconfig>
@@ -476,23 +476,16 @@
     <longdescription></longdescription>
   </dtconfig>
   <dtconfig>
-    <name>plugins/lighttable/filtering/top0</name>
-    <type>int</type>
-    <default>1</default>
-    <shortdescription>first filter</shortdescription>
-    <longdescription></longdescription>
-  </dtconfig>
-  <dtconfig>
     <name>plugins/lighttable/filtering/string0</name>
     <type>string</type>
-    <default>%</default>
+    <default></default>
     <shortdescription>first filter</shortdescription>
     <longdescription></longdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/filtering/item1</name>
     <type>int</type>
-    <default>18</default>
+    <default>2</default>
     <shortdescription>second filter</shortdescription>
     <longdescription></longdescription>
   </dtconfig>
@@ -511,13 +504,6 @@
     <longdescription></longdescription>
   </dtconfig>
   <dtconfig>
-    <name>plugins/lighttable/filtering/top1</name>
-    <type>int</type>
-    <default>1</default>
-    <shortdescription>second filter</shortdescription>
-    <longdescription></longdescription>
-  </dtconfig>
-  <dtconfig>
     <name>plugins/lighttable/filtering/string1</name>
     <type>string</type>
     <default></default>
@@ -527,7 +513,7 @@
   <dtconfig>
     <name>plugins/lighttable/filtering/item2</name>
     <type>int</type>
-    <default>33</default>
+    <default>8</default>
     <shortdescription>third filter</shortdescription>
     <longdescription></longdescription>
   </dtconfig>
@@ -546,16 +532,9 @@
     <longdescription></longdescription>
   </dtconfig>
   <dtconfig>
-    <name>plugins/lighttable/filtering/top2</name>
-    <type>int</type>
-    <default>1</default>
-    <shortdescription>third filter</shortdescription>
-    <longdescription></longdescription>
-  </dtconfig>
-  <dtconfig>
     <name>plugins/lighttable/filtering/string2</name>
     <type>string</type>
-    <default>%%</default>
+    <default></default>
     <shortdescription>third filter</shortdescription>
     <longdescription></longdescription>
   </dtconfig>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -630,6 +630,55 @@
     <longdescription/>
   </dtconfig>
   <dtconfig>
+    <name>plugins/lighttable/topbar/num_rules</name>
+    <type>int</type>
+    <default>3</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/topbar/item0</name>
+    <type>int</type>
+    <default>32</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/topbar/string0</name>
+    <type>string</type>
+    <default></default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/topbar/item1</name>
+    <type>int</type>
+    <default>18</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/topbar/string1</name>
+    <type>string</type>
+    <default></default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/topbar/item2</name>
+    <type>int</type>
+    <default>33</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/topbar/string2</name>
+    <type>string</type>
+    <default></default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/session/jobcode</name>
     <type>string</type>
     <default>capture job</default>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -151,8 +151,9 @@ FILE(GLOB SOURCE_FILES
   "gui/import_metadata.c"
   "libs/lib.c"
   "views/view.c"
+  "libs/filters/filters.c"
   )
-FILE(GLOB HEADER_FILES "*.h" "common/*.h" "external/OpenCL/CL/*.h" "control/*.h" "iop/*.h" "libs/*.h" "views/*.h")
+FILE(GLOB HEADER_FILES "*.h" "common/*.h" "external/OpenCL/CL/*.h" "control/*.h" "iop/*.h" "libs/*.h" "libs/filters/*.h" "views/*.h")
 
 if(APPLE)
   list(APPEND SOURCE_FILES "osx/osx.mm")

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -1739,7 +1739,10 @@ void gui_cleanup(dt_lib_module_t *self)
 void view_enter(struct dt_lib_module_t *self, struct dt_view_t *old_view, struct dt_view_t *new_view)
 {
   dt_lib_filtering_t *d = (dt_lib_filtering_t *)self->data;
-  d->leaving = FALSE;
+  for(int i = 0; i < DT_COLLECTION_MAX_RULES; i++)
+  {
+    if(d->rule[i].filter) d->rule[i].filter->leaving = FALSE;
+  }
 
   // we change the tooltip of the reset button here, as we are sure the header is defined now
   gtk_widget_set_tooltip_text(self->reset_button, _("reset\nctrl-click to remove pinned rules too"));
@@ -1751,7 +1754,10 @@ void view_leave(struct dt_lib_module_t *self, struct dt_view_t *old_view, struct
   {
     // we are leaving dt, so we want to avoid pb with focus and such
     dt_lib_filtering_t *d = (dt_lib_filtering_t *)self->data;
-    d->leaving = TRUE;
+    for(int i = 0; i < DT_COLLECTION_MAX_RULES; i++)
+    {
+      if(d->rule[i].filter) d->rule[i].filter->leaving = TRUE;
+    }
   }
 }
 // clang-format off

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -1053,7 +1053,7 @@ static void _dt_collection_updated(gpointer instance, dt_collection_change_t que
   {
     g_free(d->last_where_ext);
     d->last_where_ext = g_strdup(where_ext);
-    for(int i = 0; i <= d->nb_rules; i++)
+    for(int i = 0; i < d->nb_rules; i++)
     {
       _widget_update(&d->rule[i]);
     }

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -986,8 +986,6 @@ static void _filters_gui_update(dt_lib_module_t *self)
     else if(!dt_filters_exists(prop, FALSE))
     {
       // that means that for some reason we have a filter with no implementation
-      d->nb_rules--;
-      i--;
       continue;
     }
     gtk_widget_show_all(d->rule[i].w_main);

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -1647,18 +1647,16 @@ void gui_init(dt_lib_module_t *self)
   d->nb_rules = 0;
   d->params = (dt_lib_filtering_params_t *)g_malloc0(sizeof(dt_lib_filtering_params_t));
 
+  // we initialize all the shortcuts provided by the different filters
   darktable.control->accel_initialising = TRUE;
   const int nb = dt_filters_get_count();
   for(int i = 0; i < nb; i++)
   {
-    /* TODO initialize all widgets for shortcut registering
-    dt_lib_filtering_rule_t temp_rule;
-    temp_rule.filter->w_special_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-
-    filters[i].widget_init(&temp_rule, filters[i].prop, "", self, FALSE);
-
-    gtk_widget_destroy(temp_rule.filter->w_special_box);
-    g_free(temp_rule.w_specific);*/
+    // initialize all widgets for shortcut registering
+    dt_lib_filters_rule_t *temp_rule = (dt_lib_filters_rule_t *)g_malloc0(sizeof(dt_lib_filters_rule_t));
+    temp_rule->w_special_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+    dt_filters_init(temp_rule, dt_filters_get_prop_by_pos(i), "", self, FALSE);
+    dt_filters_free(temp_rule);
   }
   darktable.control->accel_initialising = FALSE;
 

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -1728,6 +1728,7 @@ void gui_cleanup(dt_lib_module_t *self)
 
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_dt_collection_updated), self);
   darktable.view_manager->proxy.module_filtering.module = NULL;
+  if(d->last_where_ext) g_free(d->last_where_ext);
   free(d->params);
 
   /* TODO: Make sure we are cleaning up all allocations */

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -555,7 +555,7 @@ static gboolean _widget_init_special(dt_lib_filtering_rule_t *rule, const gchar 
   rule->filter->w_special_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_pack_start(GTK_BOX(rule->w_widget_box), rule->filter->w_special_box, TRUE, TRUE, 0);
 
-  if(dt_filters_exists(rule->prop))
+  if(dt_filters_exists(rule->prop, FALSE))
     dt_filters_init(rule->filter, rule->prop, text, self, FALSE);
   else
     return FALSE;
@@ -627,7 +627,7 @@ static void _popup_add_item(GtkMenuShell *pop, const gchar *name, const int id, 
                             GCallback callback, gpointer data, dt_lib_module_t *self, const float xalign)
 {
   // we first verify that the filter is defined
-  if(callback != G_CALLBACK(_sort_append_sort) && !title && !dt_filters_exists(id)) return;
+  if(callback != G_CALLBACK(_sort_append_sort) && !title && !dt_filters_exists(id, FALSE)) return;
 
   GtkWidget *smt = gtk_menu_item_new_with_label(name);
   if(title)
@@ -715,7 +715,7 @@ static gboolean _rule_show_popup(GtkWidget *widget, dt_lib_filtering_rule_t *rul
 
 static void _rule_populate_prop_combo_add(GtkWidget *w, const dt_collection_properties_t prop)
 {
-  if(!dt_filters_exists(prop)) return;
+  if(!dt_filters_exists(prop, FALSE)) return;
   dt_bauhaus_combobox_add_full(w, dt_collection_name(prop), DT_BAUHAUS_COMBOBOX_ALIGN_MIDDLE,
                                GUINT_TO_POINTER(prop), NULL, TRUE);
 }
@@ -859,7 +859,7 @@ static gboolean _widget_init(dt_lib_filtering_rule_t *rule, const dt_collection_
                              const gchar *text, const dt_lib_collect_mode_t mode, gboolean off, const int pos,
                              dt_lib_module_t *self)
 {
-  if(!dt_filters_exists(prop)) return FALSE;
+  if(!dt_filters_exists(prop, FALSE)) return FALSE;
   rule->filter = (dt_lib_filters_rule_t *)g_malloc0(sizeof(dt_lib_filters_rule_t));
   rule->filter->rule_changed = _event_rule_change_raw_text;
   rule->filter->parent = rule;
@@ -983,7 +983,7 @@ static void _filters_gui_update(dt_lib_module_t *self)
     // recreate main widget
     if(_widget_init(&d->rule[i], prop, txt, rmode, off, i, self))
       gtk_box_pack_start(GTK_BOX(d->rules_box), d->rule[i].w_main, FALSE, TRUE, 0);
-    else if(!dt_filters_exists(prop))
+    else if(!dt_filters_exists(prop, FALSE))
     {
       // that means that for some reason we have a filter with no implementation
       d->nb_rules--;

--- a/src/libs/filters/aperture.c
+++ b/src/libs/filters/aperture.c
@@ -21,15 +21,12 @@
 */
 
 
-static gboolean _aperture_update(dt_lib_filtering_rule_t *rule)
+static gboolean _aperture_update(dt_lib_filters_rule_t *rule, gchar *last_where_ext)
 {
   if(!rule->w_specific) return FALSE;
 
-  dt_lib_filtering_t *d = rule->lib;
   _widgets_range_t *special = (_widgets_range_t *)rule->w_specific;
-  _widgets_range_t *specialtop = (_widgets_range_t *)rule->w_specific_top;
   GtkDarktableRangeSelect *range = DTGTK_RANGE_SELECT(special->range_select);
-  GtkDarktableRangeSelect *rangetop = (specialtop) ? DTGTK_RANGE_SELECT(specialtop->range_select) : NULL;
 
   rule->manual_widget_set++;
   // first, we update the graph
@@ -40,28 +37,24 @@ static gboolean _aperture_update(dt_lib_filtering_rule_t *rule)
              " FROM main.images AS mi"
              " WHERE %s"
              " GROUP BY ROUND(aperture,1)",
-             d->last_where_ext);
+             last_where_ext);
   // clang-format on
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
   dtgtk_range_select_reset_blocks(range);
-  if(rangetop) dtgtk_range_select_reset_blocks(rangetop);
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
     const double val = sqlite3_column_double(stmt, 0);
     const int count = sqlite3_column_int(stmt, 1);
     dtgtk_range_select_add_block(range, val, count);
-    if(rangetop) dtgtk_range_select_add_block(rangetop, val, count);
   }
   sqlite3_finalize(stmt);
 
   // and setup the selection
   dtgtk_range_select_set_selection_from_raw_text(range, rule->raw_text, FALSE);
-  if(rangetop) dtgtk_range_select_set_selection_from_raw_text(rangetop, rule->raw_text, FALSE);
   rule->manual_widget_set--;
 
   dtgtk_range_select_redraw(range);
-  if(rangetop) dtgtk_range_select_redraw(rangetop);
   return TRUE;
 }
 
@@ -76,7 +69,7 @@ static gchar *_aperture_print_func(const double value, const gboolean detailled)
   return txt;
 }
 
-static void _aperture_widget_init(dt_lib_filtering_rule_t *rule, const dt_collection_properties_t prop,
+static void _aperture_widget_init(dt_lib_filters_rule_t *rule, const dt_collection_properties_t prop,
                                   const gchar *text, dt_lib_module_t *self, const gboolean top)
 {
   _widgets_range_t *special = (_widgets_range_t *)g_malloc0(sizeof(_widgets_range_t));

--- a/src/libs/filters/colors.c
+++ b/src/libs/filters/colors.c
@@ -110,7 +110,7 @@ static void _colors_operator_clicked(GtkWidget *w, _widgets_colors_t *colors)
   _colors_update(rule);
 }
 
-static gchar *_colors_pretty_print(const gchar *raw_txt)
+gchar *dt_filters_colors_pretty_print(const gchar *raw_txt)
 {
   gchar *txt = NULL;
   const int val = _get_mask(raw_txt);

--- a/src/libs/filters/date.c
+++ b/src/libs/filters/date.c
@@ -20,7 +20,7 @@
   This file contains the necessary routines to implement a filter for the filtering module
 */
 
-static gchar *_date_get_db_colname(dt_lib_filtering_rule_t *rule)
+static gchar *_date_get_db_colname(dt_lib_filters_rule_t *rule)
 {
   switch(rule->prop)
   {
@@ -37,15 +37,12 @@ static gchar *_date_get_db_colname(dt_lib_filtering_rule_t *rule)
   }
 }
 
-static gboolean _date_update(dt_lib_filtering_rule_t *rule)
+static gboolean _date_update(dt_lib_filters_rule_t *rule, gchar *last_where_ext)
 {
   if(!rule->w_specific) return FALSE;
 
-  dt_lib_filtering_t *d = rule->lib;
   _widgets_range_t *special = (_widgets_range_t *)rule->w_specific;
-  _widgets_range_t *specialtop = (_widgets_range_t *)rule->w_specific_top;
   GtkDarktableRangeSelect *range = DTGTK_RANGE_SELECT(special->range_select);
-  GtkDarktableRangeSelect *rangetop = (specialtop) ? DTGTK_RANGE_SELECT(specialtop->range_select) : NULL;
 
   rule->manual_widget_set++;
   // first, we update the graph
@@ -57,33 +54,29 @@ static gboolean _date_update(dt_lib_filtering_rule_t *rule)
              " FROM main.images AS mi"
              " WHERE %s IS NOT NULL AND %s"
              " GROUP BY date",
-             colname, colname, d->last_where_ext);
+             colname, colname, last_where_ext);
   // clang-format on
   g_free(colname);
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
   dtgtk_range_select_reset_blocks(range);
-  if(rangetop) dtgtk_range_select_reset_blocks(rangetop);
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
     const int count = sqlite3_column_int(stmt, 1);
     const long dt = sqlite3_column_int64(stmt, 0);
     dtgtk_range_select_add_block(range, dt, count);
-    if(rangetop) dtgtk_range_select_add_block(rangetop, dt, count);
   }
   sqlite3_finalize(stmt);
 
   // and setup the selection
   dtgtk_range_select_set_selection_from_raw_text(range, rule->raw_text, FALSE);
-  if(rangetop) dtgtk_range_select_set_selection_from_raw_text(rangetop, rule->raw_text, FALSE);
   rule->manual_widget_set--;
 
   dtgtk_range_select_redraw(range);
-  if(rangetop) dtgtk_range_select_redraw(rangetop);
   return TRUE;
 }
 
-static void _date_widget_init(dt_lib_filtering_rule_t *rule, const dt_collection_properties_t prop,
+static void _date_widget_init(dt_lib_filters_rule_t *rule, const dt_collection_properties_t prop,
                               const gchar *text, dt_lib_module_t *self, const gboolean top)
 {
   _widgets_range_t *special = (_widgets_range_t *)g_malloc0(sizeof(_widgets_range_t));

--- a/src/libs/filters/exposure.c
+++ b/src/libs/filters/exposure.c
@@ -21,15 +21,12 @@
 */
 
 
-static gboolean _exposure_update(dt_lib_filtering_rule_t *rule)
+static gboolean _exposure_update(dt_lib_filters_rule_t *rule, gchar *last_where_ext)
 {
   if(!rule->w_specific) return FALSE;
 
-  dt_lib_filtering_t *d = rule->lib;
   _widgets_range_t *special = (_widgets_range_t *)rule->w_specific;
-  _widgets_range_t *specialtop = (_widgets_range_t *)rule->w_specific_top;
   GtkDarktableRangeSelect *range = DTGTK_RANGE_SELECT(special->range_select);
-  GtkDarktableRangeSelect *rangetop = (specialtop) ? DTGTK_RANGE_SELECT(specialtop->range_select) : NULL;
 
   rule->manual_widget_set++;
   // first, we update the graph
@@ -40,29 +37,25 @@ static gboolean _exposure_update(dt_lib_filtering_rule_t *rule)
              " FROM main.images AS mi"
              " WHERE %s"
              " GROUP BY exposure",
-             d->last_where_ext);
+             last_where_ext);
   // clang-format on
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
   dtgtk_range_select_reset_blocks(range);
-  if(rangetop) dtgtk_range_select_reset_blocks(rangetop);
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
     const double val = sqlite3_column_double(stmt, 0);
     const int count = sqlite3_column_int(stmt, 1);
 
     dtgtk_range_select_add_block(range, val, count);
-    if(rangetop) dtgtk_range_select_add_block(rangetop, val, count);
   }
   sqlite3_finalize(stmt);
 
   // and setup the selection
   dtgtk_range_select_set_selection_from_raw_text(range, rule->raw_text, FALSE);
-  if(rangetop) dtgtk_range_select_set_selection_from_raw_text(rangetop, rule->raw_text, FALSE);
   rule->manual_widget_set--;
 
   dtgtk_range_select_redraw(range);
-  if(rangetop) dtgtk_range_select_redraw(rangetop);
   return TRUE;
 }
 
@@ -93,7 +86,7 @@ static gchar *_exposure_print_func(const double value, const gboolean detailled)
   }
 }
 
-static void _exposure_widget_init(dt_lib_filtering_rule_t *rule, const dt_collection_properties_t prop,
+static void _exposure_widget_init(dt_lib_filters_rule_t *rule, const dt_collection_properties_t prop,
                                   const gchar *text, dt_lib_module_t *self, const gboolean top)
 {
   _widgets_range_t *special = (_widgets_range_t *)g_malloc0(sizeof(_widgets_range_t));

--- a/src/libs/filters/filters.c
+++ b/src/libs/filters/filters.c
@@ -33,6 +33,7 @@ typedef struct _filter_t
   dt_collection_properties_t prop;
   _widget_init_func widget_init;
   _widget_update_func update;
+  gboolean allow_topbar;
 } _filter_t;
 
 typedef struct _widgets_range_t
@@ -72,25 +73,25 @@ static void _range_widget_add_to_rule(dt_lib_filters_rule_t *rule, _widgets_rang
 #include "libs/filters/search.c"
 
 static _filter_t filters[]
-    = { { DT_COLLECTION_PROP_COLORLABEL, _colors_widget_init, _colors_update },
-        { DT_COLLECTION_PROP_FILENAME, _filename_widget_init, _filename_update },
-        { DT_COLLECTION_PROP_TEXTSEARCH, _search_widget_init, _search_update },
-        { DT_COLLECTION_PROP_DAY, _date_widget_init, _date_update },
-        { DT_COLLECTION_PROP_CHANGE_TIMESTAMP, _date_widget_init, _date_update },
-        { DT_COLLECTION_PROP_EXPORT_TIMESTAMP, _date_widget_init, _date_update },
-        { DT_COLLECTION_PROP_IMPORT_TIMESTAMP, _date_widget_init, _date_update },
-        { DT_COLLECTION_PROP_PRINT_TIMESTAMP, _date_widget_init, _date_update },
-        { DT_COLLECTION_PROP_ASPECT_RATIO, _ratio_widget_init, _ratio_update },
-        { DT_COLLECTION_PROP_RATING_RANGE, _rating_range_widget_init, _rating_range_update },
-        { DT_COLLECTION_PROP_APERTURE, _aperture_widget_init, _aperture_update },
-        { DT_COLLECTION_PROP_FOCAL_LENGTH, _focal_widget_init, _focal_update },
-        { DT_COLLECTION_PROP_ISO, _iso_widget_init, _iso_update },
-        { DT_COLLECTION_PROP_EXPOSURE, _exposure_widget_init, _exposure_update },
-        { DT_COLLECTION_PROP_GROUPING, _grouping_widget_init, _grouping_update },
-        { DT_COLLECTION_PROP_LOCAL_COPY, _local_copy_widget_init, _local_copy_update },
-        { DT_COLLECTION_PROP_HISTORY, _history_widget_init, _history_update },
-        { DT_COLLECTION_PROP_ORDER, _module_order_widget_init, _module_order_update },
-        { DT_COLLECTION_PROP_RATING, _rating_widget_init, _rating_update } };
+    = { { DT_COLLECTION_PROP_COLORLABEL, _colors_widget_init, _colors_update, TRUE },
+        { DT_COLLECTION_PROP_FILENAME, _filename_widget_init, _filename_update, TRUE },
+        { DT_COLLECTION_PROP_TEXTSEARCH, _search_widget_init, _search_update, TRUE },
+        { DT_COLLECTION_PROP_DAY, _date_widget_init, _date_update, FALSE },
+        { DT_COLLECTION_PROP_CHANGE_TIMESTAMP, _date_widget_init, _date_update, FALSE },
+        { DT_COLLECTION_PROP_EXPORT_TIMESTAMP, _date_widget_init, _date_update, FALSE },
+        { DT_COLLECTION_PROP_IMPORT_TIMESTAMP, _date_widget_init, _date_update, FALSE },
+        { DT_COLLECTION_PROP_PRINT_TIMESTAMP, _date_widget_init, _date_update, FALSE },
+        { DT_COLLECTION_PROP_ASPECT_RATIO, _ratio_widget_init, _ratio_update, TRUE },
+        { DT_COLLECTION_PROP_RATING_RANGE, _rating_range_widget_init, _rating_range_update, TRUE },
+        { DT_COLLECTION_PROP_APERTURE, _aperture_widget_init, _aperture_update, TRUE },
+        { DT_COLLECTION_PROP_FOCAL_LENGTH, _focal_widget_init, _focal_update, TRUE },
+        { DT_COLLECTION_PROP_ISO, _iso_widget_init, _iso_update, TRUE },
+        { DT_COLLECTION_PROP_EXPOSURE, _exposure_widget_init, _exposure_update, TRUE },
+        { DT_COLLECTION_PROP_GROUPING, _grouping_widget_init, _grouping_update, TRUE },
+        { DT_COLLECTION_PROP_LOCAL_COPY, _local_copy_widget_init, _local_copy_update, TRUE },
+        { DT_COLLECTION_PROP_HISTORY, _history_widget_init, _history_update, TRUE },
+        { DT_COLLECTION_PROP_ORDER, _module_order_widget_init, _module_order_update, TRUE },
+        { DT_COLLECTION_PROP_RATING, _rating_widget_init, _rating_update, TRUE } };
 
 static _filter_t *_filters_get(const dt_collection_properties_t prop)
 {
@@ -153,9 +154,10 @@ static void _range_widget_add_to_rule(dt_lib_filters_rule_t *rule, _widgets_rang
   rule->w_specific = special;
 }
 
-gboolean dt_filters_exists(const dt_collection_properties_t prop)
+gboolean dt_filters_exists(const dt_collection_properties_t prop, const gboolean top)
 {
-  return (_filters_get(prop) != NULL);
+  _filter_t *f = _filters_get(prop);
+  return (f != NULL && (!top || f->allow_topbar));
 }
 
 gboolean dt_filters_update(dt_lib_filters_rule_t *rule, gchar *last_where_ext)
@@ -171,7 +173,7 @@ void dt_filters_init(dt_lib_filters_rule_t *rule, const dt_collection_properties
                      dt_lib_module_t *self, gboolean top)
 {
   _filter_t *f = _filters_get(prop);
-  if(f)
+  if(f && (!top || f->allow_topbar))
   {
     rule->prop = prop;
     f->widget_init(rule, prop, text, self, top);

--- a/src/libs/filters/filters.c
+++ b/src/libs/filters/filters.c
@@ -127,7 +127,7 @@ static void _range_changed(GtkWidget *widget, gpointer user_data)
 {
   _widgets_range_t *special = (_widgets_range_t *)user_data;
   if(special->rule->manual_widget_set) return;
-  // TODO if(special->rule->lib->leaving) return;
+  if(special->rule->leaving) return;
 
   // we recreate the right raw text and put it in the raw entry
   gchar *txt = dtgtk_range_select_get_raw_text(DTGTK_RANGE_SELECT(special->range_select));

--- a/src/libs/filters/filters.c
+++ b/src/libs/filters/filters.c
@@ -20,7 +20,9 @@
 #include "bauhaus/bauhaus.h"
 #include "common/debug.h"
 #include "common/image.h"
+#include "dtgtk/button.h"
 #include "dtgtk/range.h"
+#include "gui/accelerators.h"
 
 typedef void (*_widget_init_func)(dt_lib_filters_rule_t *rule, const dt_collection_properties_t prop,
                                   const gchar *text, dt_lib_module_t *self, gboolean top);
@@ -53,23 +55,23 @@ static void _rule_set_raw_text(dt_lib_filters_rule_t *rule, const gchar *text, c
 static void _range_widget_add_to_rule(dt_lib_filters_rule_t *rule, _widgets_range_t *special, const gboolean top);
 
 // filters definitions
-/*#include "libs/filters/aperture.c"
+#include "libs/filters/aperture.c"
 #include "libs/filters/colors.c"
 #include "libs/filters/date.c"
-#include "libs/filters/exposure.c"*/
+#include "libs/filters/exposure.c"
 #include "libs/filters/filename.c"
 #include "libs/filters/focal.c"
-/*#include "libs/filters/grouping.c"
+#include "libs/filters/grouping.c"
 #include "libs/filters/history.c"
-#include "libs/filters/iso.c"*/
+#include "libs/filters/iso.c"
 #include "libs/filters/local_copy.c"
-/*#include "libs/filters/module_order.c"
+#include "libs/filters/module_order.c"
 #include "libs/filters/rating.c"
 #include "libs/filters/rating_range.c"
 #include "libs/filters/ratio.c"
-#include "libs/filters/search.c"*/
+#include "libs/filters/search.c"
 
-/*static _filter_t filters[]
+static _filter_t filters[]
     = { { DT_COLLECTION_PROP_COLORLABEL, _colors_widget_init, _colors_update },
         { DT_COLLECTION_PROP_FILENAME, _filename_widget_init, _filename_update },
         { DT_COLLECTION_PROP_TEXTSEARCH, _search_widget_init, _search_update },
@@ -88,10 +90,7 @@ static void _range_widget_add_to_rule(dt_lib_filters_rule_t *rule, _widgets_rang
         { DT_COLLECTION_PROP_LOCAL_COPY, _local_copy_widget_init, _local_copy_update },
         { DT_COLLECTION_PROP_HISTORY, _history_widget_init, _history_update },
         { DT_COLLECTION_PROP_ORDER, _module_order_widget_init, _module_order_update },
-        { DT_COLLECTION_PROP_RATING, _rating_widget_init, _rating_update } };*/
-static _filter_t filters[] = { { DT_COLLECTION_PROP_FILENAME, _filename_widget_init, _filename_update },
-                               { DT_COLLECTION_PROP_FOCAL_LENGTH, _focal_widget_init, _focal_update },
-                               { DT_COLLECTION_PROP_LOCAL_COPY, _local_copy_widget_init, _local_copy_update } };
+        { DT_COLLECTION_PROP_RATING, _rating_widget_init, _rating_update } };
 
 static _filter_t *_filters_get(const dt_collection_properties_t prop)
 {
@@ -186,7 +185,7 @@ void dt_filters_reset(dt_lib_filters_rule_t *rule, const gboolean signal)
 
 void dt_filters_free(dt_lib_filters_rule_t *rule)
 {
-  gtk_widget_destroy(rule->w_special_box);
+  if(rule->w_special_box) gtk_widget_destroy(rule->w_special_box);
   rule->w_special_box = NULL;
   g_free(rule->w_specific);
   rule->w_specific = NULL;

--- a/src/libs/filters/filters.c
+++ b/src/libs/filters/filters.c
@@ -1,0 +1,204 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2010-2022 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "filters.h"
+#include "bauhaus/bauhaus.h"
+#include "common/debug.h"
+#include "common/image.h"
+#include "dtgtk/range.h"
+
+typedef void (*_widget_init_func)(dt_lib_filters_rule_t *rule, const dt_collection_properties_t prop,
+                                  const gchar *text, dt_lib_module_t *self, gboolean top);
+
+typedef gboolean (*_widget_update_func)(dt_lib_filters_rule_t *rule, gchar *last_where_ext);
+typedef struct _filter_t
+{
+  dt_collection_properties_t prop;
+  _widget_init_func widget_init;
+  _widget_update_func update;
+} _filter_t;
+
+typedef struct _widgets_range_t
+{
+  dt_lib_filters_rule_t *rule;
+
+  GtkWidget *range_select;
+} _widgets_range_t;
+
+typedef enum _tree_cols_t
+{
+  TREE_COL_TEXT = 0,
+  TREE_COL_TOOLTIP,
+  TREE_COL_PATH,
+  TREE_COL_COUNT,
+  TREE_NUM_COLS
+} _tree_cols_t;
+
+static void _rule_set_raw_text(dt_lib_filters_rule_t *rule, const gchar *text, const gboolean signal);
+static void _range_widget_add_to_rule(dt_lib_filters_rule_t *rule, _widgets_range_t *special, const gboolean top);
+
+// filters definitions
+/*#include "libs/filters/aperture.c"
+#include "libs/filters/colors.c"
+#include "libs/filters/date.c"
+#include "libs/filters/exposure.c"*/
+#include "libs/filters/filename.c"
+#include "libs/filters/focal.c"
+/*#include "libs/filters/grouping.c"
+#include "libs/filters/history.c"
+#include "libs/filters/iso.c"*/
+#include "libs/filters/local_copy.c"
+/*#include "libs/filters/module_order.c"
+#include "libs/filters/rating.c"
+#include "libs/filters/rating_range.c"
+#include "libs/filters/ratio.c"
+#include "libs/filters/search.c"*/
+
+/*static _filter_t filters[]
+    = { { DT_COLLECTION_PROP_COLORLABEL, _colors_widget_init, _colors_update },
+        { DT_COLLECTION_PROP_FILENAME, _filename_widget_init, _filename_update },
+        { DT_COLLECTION_PROP_TEXTSEARCH, _search_widget_init, _search_update },
+        { DT_COLLECTION_PROP_DAY, _date_widget_init, _date_update },
+        { DT_COLLECTION_PROP_CHANGE_TIMESTAMP, _date_widget_init, _date_update },
+        { DT_COLLECTION_PROP_EXPORT_TIMESTAMP, _date_widget_init, _date_update },
+        { DT_COLLECTION_PROP_IMPORT_TIMESTAMP, _date_widget_init, _date_update },
+        { DT_COLLECTION_PROP_PRINT_TIMESTAMP, _date_widget_init, _date_update },
+        { DT_COLLECTION_PROP_ASPECT_RATIO, _ratio_widget_init, _ratio_update },
+        { DT_COLLECTION_PROP_RATING_RANGE, _rating_range_widget_init, _rating_range_update },
+        { DT_COLLECTION_PROP_APERTURE, _aperture_widget_init, _aperture_update },
+        { DT_COLLECTION_PROP_FOCAL_LENGTH, _focal_widget_init, _focal_update },
+        { DT_COLLECTION_PROP_ISO, _iso_widget_init, _iso_update },
+        { DT_COLLECTION_PROP_EXPOSURE, _exposure_widget_init, _exposure_update },
+        { DT_COLLECTION_PROP_GROUPING, _grouping_widget_init, _grouping_update },
+        { DT_COLLECTION_PROP_LOCAL_COPY, _local_copy_widget_init, _local_copy_update },
+        { DT_COLLECTION_PROP_HISTORY, _history_widget_init, _history_update },
+        { DT_COLLECTION_PROP_ORDER, _module_order_widget_init, _module_order_update },
+        { DT_COLLECTION_PROP_RATING, _rating_widget_init, _rating_update } };*/
+static _filter_t filters[] = { { DT_COLLECTION_PROP_FILENAME, _filename_widget_init, _filename_update },
+                               { DT_COLLECTION_PROP_FOCAL_LENGTH, _focal_widget_init, _focal_update },
+                               { DT_COLLECTION_PROP_LOCAL_COPY, _local_copy_widget_init, _local_copy_update } };
+
+static _filter_t *_filters_get(const dt_collection_properties_t prop)
+{
+  const int nb = sizeof(filters) / sizeof(_filter_t);
+  for(int i = 0; i < nb; i++)
+  {
+    if(filters[i].prop == prop) return &filters[i];
+  }
+  return NULL;
+}
+
+static void _rule_set_raw_text(dt_lib_filters_rule_t *rule, const gchar *text, const gboolean signal)
+{
+  snprintf(rule->raw_text, sizeof(rule->raw_text), "%s", (text == NULL) ? "" : text);
+  if(signal && !rule->manual_widget_set) rule->rule_changed(rule);
+}
+
+static void _range_set_tooltip(_widgets_range_t *special)
+{
+  // we recreate the tooltip
+  gchar *val = dtgtk_range_select_get_bounds_pretty(DTGTK_RANGE_SELECT(special->range_select));
+  gchar *txt = g_strdup_printf("<b>%s</b>\n%s\n%s", dt_collection_name(special->rule->prop),
+                               _("click or click&#38;drag to select one or multiple values"),
+                               _("right-click opens a menu to select the available values"));
+
+  if(special->rule->prop != DT_COLLECTION_PROP_RATING_RANGE)
+    txt = g_strdup_printf("%s\n<b><i>%s:</i></b> %s", txt, _("actual selection"), val);
+  gtk_widget_set_tooltip_markup(special->range_select, txt);
+  g_free(txt);
+  g_free(val);
+}
+
+static void _range_changed(GtkWidget *widget, gpointer user_data)
+{
+  _widgets_range_t *special = (_widgets_range_t *)user_data;
+  if(special->rule->manual_widget_set) return;
+  // TODO if(special->rule->lib->leaving) return;
+
+  // we recreate the right raw text and put it in the raw entry
+  gchar *txt = dtgtk_range_select_get_raw_text(DTGTK_RANGE_SELECT(special->range_select));
+  _rule_set_raw_text(special->rule, txt, TRUE);
+  g_free(txt);
+
+  _range_set_tooltip(special);
+}
+
+static void _range_widget_add_to_rule(dt_lib_filters_rule_t *rule, _widgets_range_t *special, const gboolean top)
+{
+  special->rule = rule;
+
+  _range_set_tooltip(special);
+
+  gtk_box_pack_start(GTK_BOX(rule->w_special_box), special->range_select, TRUE, TRUE, 0);
+  g_signal_connect(G_OBJECT(special->range_select), "value-changed", G_CALLBACK(_range_changed), special);
+  if(top)
+  {
+    dt_gui_add_class(gtk_bin_get_child(GTK_BIN(special->range_select)), "dt_quick_filter");
+  }
+
+  rule->w_specific = special;
+}
+
+gboolean dt_filters_exists(const dt_collection_properties_t prop)
+{
+  return (_filters_get(prop) != NULL);
+}
+
+gboolean dt_filters_update(dt_lib_filters_rule_t *rule, gchar *last_where_ext)
+{
+  _filter_t *f = _filters_get(rule->prop);
+  if(f)
+    return f->update(rule, last_where_ext);
+  else
+    return FALSE;
+}
+
+void dt_filters_init(dt_lib_filters_rule_t *rule, const dt_collection_properties_t prop, const gchar *text,
+                     dt_lib_module_t *self, gboolean top)
+{
+  _filter_t *f = _filters_get(prop);
+  if(f)
+  {
+    rule->prop = prop;
+    f->widget_init(rule, prop, text, self, top);
+  }
+}
+
+void dt_filters_reset(dt_lib_filters_rule_t *rule, const gboolean signal)
+{
+  _rule_set_raw_text(rule, "", signal);
+}
+
+void dt_filters_free(dt_lib_filters_rule_t *rule)
+{
+  gtk_widget_destroy(rule->w_special_box);
+  rule->w_special_box = NULL;
+  g_free(rule->w_specific);
+  rule->w_specific = NULL;
+  g_free(rule);
+}
+
+int dt_filters_get_count()
+{
+  return sizeof(filters) / sizeof(_filter_t);
+}
+
+dt_collection_properties_t dt_filters_get_prop_by_pos(const int pos)
+{
+  return filters[pos].prop;
+}

--- a/src/libs/filters/filters.h
+++ b/src/libs/filters/filters.h
@@ -34,6 +34,7 @@ typedef struct dt_lib_filters_rule_t
 
   int manual_widget_set; // when we update manually the widget, we don't want events to be handled
   gboolean cleaning;     // if we have started a gui_cleanup (we don't want certain event to occurs)
+  gboolean leaving;      // if the lib that owned the filter lost focus because the view is changing
 
   gboolean topbar;
 

--- a/src/libs/filters/filters.h
+++ b/src/libs/filters/filters.h
@@ -1,0 +1,54 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2010-2022 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "common/collection.h"
+#include "libs/lib.h"
+
+#define PARAM_STRING_SIZE 256 // FIXME: is this enough !?
+
+typedef struct dt_lib_filters_rule_t
+{
+  dt_collection_properties_t prop;
+
+  GtkWidget *w_widget_box;
+  char raw_text[PARAM_STRING_SIZE];
+  GtkWidget *w_special_box;
+  void *w_specific; // structure which contains all the widgets specific to the rule type
+
+  int manual_widget_set; // when we update manually the widget, we don't want events to be handled
+  gboolean cleaning;     // if we have started a gui_cleanup (we don't want certain event to occurs)
+
+  gboolean topbar;
+
+  void *parent; // parent structure. This may esp. be used for the following function
+  void (*rule_changed)(void *rule);
+} dt_lib_filters_rule_t;
+
+gboolean dt_filters_exists(const dt_collection_properties_t prop);
+gboolean dt_filters_update(dt_lib_filters_rule_t *rule, gchar *last_where_ext);
+void dt_filters_init(dt_lib_filters_rule_t *rule, const dt_collection_properties_t prop, const gchar *text,
+                     dt_lib_module_t *self, gboolean top);
+void dt_filters_reset(dt_lib_filters_rule_t *rule, const gboolean signal);
+void dt_filters_free(dt_lib_filters_rule_t *rule);
+
+gchar *dt_filters_colors_pretty_print(const gchar *raw_txt);
+
+int dt_filters_get_count();
+dt_collection_properties_t dt_filters_get_prop_by_pos(const int pos);

--- a/src/libs/filters/filters.h
+++ b/src/libs/filters/filters.h
@@ -42,7 +42,7 @@ typedef struct dt_lib_filters_rule_t
   void (*rule_changed)(void *rule);
 } dt_lib_filters_rule_t;
 
-gboolean dt_filters_exists(const dt_collection_properties_t prop);
+gboolean dt_filters_exists(const dt_collection_properties_t prop, const gboolean top);
 gboolean dt_filters_update(dt_lib_filters_rule_t *rule, gchar *last_where_ext);
 void dt_filters_init(dt_lib_filters_rule_t *rule, const dt_collection_properties_t prop, const gchar *text,
                      dt_lib_module_t *self, gboolean top);

--- a/src/libs/filters/focal.c
+++ b/src/libs/filters/focal.c
@@ -21,15 +21,12 @@
 */
 
 
-static gboolean _focal_update(dt_lib_filtering_rule_t *rule)
+static gboolean _focal_update(dt_lib_filters_rule_t *rule, gchar *last_where_ext)
 {
   if(!rule->w_specific) return FALSE;
 
-  dt_lib_filtering_t *d = rule->lib;
   _widgets_range_t *special = (_widgets_range_t *)rule->w_specific;
-  _widgets_range_t *specialtop = (_widgets_range_t *)rule->w_specific_top;
   GtkDarktableRangeSelect *range = DTGTK_RANGE_SELECT(special->range_select);
-  GtkDarktableRangeSelect *rangetop = (specialtop) ? DTGTK_RANGE_SELECT(specialtop->range_select) : NULL;
 
   rule->manual_widget_set++;
   // first, we update the graph
@@ -40,28 +37,24 @@ static gboolean _focal_update(dt_lib_filtering_rule_t *rule)
              " FROM main.images AS mi"
              " WHERE %s"
              " GROUP BY ROUND(focal_length,0)",
-             d->last_where_ext);
+             last_where_ext);
   // clang-format on
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
   dtgtk_range_select_reset_blocks(range);
-  if(rangetop) dtgtk_range_select_reset_blocks(rangetop);
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
     const double val = sqlite3_column_double(stmt, 0);
     const int count = sqlite3_column_int(stmt, 1);
     dtgtk_range_select_add_block(range, val, count);
-    if(rangetop) dtgtk_range_select_add_block(rangetop, val, count);
   }
   sqlite3_finalize(stmt);
 
   // and setup the selection
   dtgtk_range_select_set_selection_from_raw_text(range, rule->raw_text, FALSE);
-  if(rangetop) dtgtk_range_select_set_selection_from_raw_text(rangetop, rule->raw_text, FALSE);
   rule->manual_widget_set--;
 
   dtgtk_range_select_redraw(range);
-  if(rangetop) dtgtk_range_select_redraw(rangetop);
   return TRUE;
 }
 
@@ -76,7 +69,7 @@ static gchar *_focal_print_func(const double value, const gboolean detailled)
   return txt;
 }
 
-static void _focal_widget_init(dt_lib_filtering_rule_t *rule, const dt_collection_properties_t prop,
+static void _focal_widget_init(dt_lib_filters_rule_t *rule, const dt_collection_properties_t prop,
                                const gchar *text, dt_lib_module_t *self, const gboolean top)
 {
   _widgets_range_t *special = (_widgets_range_t *)g_malloc0(sizeof(_widgets_range_t));

--- a/src/libs/filters/iso.c
+++ b/src/libs/filters/iso.c
@@ -21,15 +21,12 @@
 */
 
 
-static gboolean _iso_update(dt_lib_filtering_rule_t *rule)
+static gboolean _iso_update(dt_lib_filters_rule_t *rule, gchar *last_where_ext)
 {
   if(!rule->w_specific) return FALSE;
 
-  dt_lib_filtering_t *d = rule->lib;
   _widgets_range_t *special = (_widgets_range_t *)rule->w_specific;
-  _widgets_range_t *specialtop = (_widgets_range_t *)rule->w_specific_top;
   GtkDarktableRangeSelect *range = DTGTK_RANGE_SELECT(special->range_select);
-  GtkDarktableRangeSelect *rangetop = (specialtop) ? DTGTK_RANGE_SELECT(specialtop->range_select) : NULL;
 
   rule->manual_widget_set++;
   // first, we update the graph
@@ -40,29 +37,25 @@ static gboolean _iso_update(dt_lib_filtering_rule_t *rule)
              " FROM main.images AS mi"
              " WHERE %s"
              " GROUP BY ROUND(iso, 0)",
-             d->last_where_ext);
+             last_where_ext);
   // clang-format on
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
   dtgtk_range_select_reset_blocks(range);
-  if(rangetop) dtgtk_range_select_reset_blocks(rangetop);
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
     const double val = sqlite3_column_double(stmt, 0);
     const int count = sqlite3_column_int(stmt, 1);
 
     dtgtk_range_select_add_block(range, val, count);
-    if(rangetop) dtgtk_range_select_add_block(rangetop, val, count);
   }
   sqlite3_finalize(stmt);
 
   // and setup the selection
   dtgtk_range_select_set_selection_from_raw_text(range, rule->raw_text, FALSE);
-  if(rangetop) dtgtk_range_select_set_selection_from_raw_text(rangetop, rule->raw_text, FALSE);
   rule->manual_widget_set--;
 
   dtgtk_range_select_redraw(range);
-  if(rangetop) dtgtk_range_select_redraw(rangetop);
   return TRUE;
 }
 
@@ -100,8 +93,8 @@ static gchar *_iso_print_func(const double value, const gboolean detailled)
   }
 }
 
-static void _iso_widget_init(dt_lib_filtering_rule_t *rule, const dt_collection_properties_t prop,
-                             const gchar *text, dt_lib_module_t *self, const gboolean top)
+static void _iso_widget_init(dt_lib_filters_rule_t *rule, const dt_collection_properties_t prop, const gchar *text,
+                             dt_lib_module_t *self, const gboolean top)
 {
   _widgets_range_t *special = (_widgets_range_t *)g_malloc0(sizeof(_widgets_range_t));
 

--- a/src/libs/filters/rating.c
+++ b/src/libs/filters/rating.c
@@ -22,32 +22,12 @@
 
 typedef struct _widgets_rating_legacy_t
 {
-  dt_lib_filtering_rule_t *rule;
+  dt_lib_filters_rule_t *rule;
 
   GtkWidget *overlay;
   GtkWidget *comparator;
   GtkWidget *stars;
 } _widgets_rating_legacy_t;
-
-static void _rating_legacy_synchronise(_widgets_rating_legacy_t *source)
-{
-  _widgets_rating_legacy_t *dest = NULL;
-  if(source == source->rule->w_specific_top)
-    dest = source->rule->w_specific;
-  else
-    dest = source->rule->w_specific_top;
-
-  if(dest)
-  {
-    source->rule->manual_widget_set++;
-    const int comp = dt_bauhaus_combobox_get(source->comparator);
-    dt_bauhaus_combobox_set(dest->comparator, comp);
-    const int stars = dt_bauhaus_combobox_get(source->stars);
-    dt_bauhaus_combobox_set(dest->stars, stars);
-    gtk_widget_set_visible(dest->comparator, stars > 1 && stars < 7);
-    source->rule->manual_widget_set--;
-  }
-}
 
 static void _rating_legacy_decode(const gchar *txt, int *comp, int *stars)
 {
@@ -167,10 +147,9 @@ static void _rating_legacy_changed(GtkWidget *widget, gpointer user_data)
   }
 
   gtk_widget_set_visible(rating_legacy->comparator, stars > 1 && stars < 7);
-  _rating_legacy_synchronise(rating_legacy);
 }
 
-static gboolean _rating_update(dt_lib_filtering_rule_t *rule)
+static gboolean _rating_update(dt_lib_filters_rule_t *rule, gchar *last_where_ext)
 {
   if(!rule->w_specific) return FALSE;
   int comp = 3, stars = 0;
@@ -181,14 +160,13 @@ static gboolean _rating_update(dt_lib_filtering_rule_t *rule)
   dt_bauhaus_combobox_set(rating_legacy->comparator, comp);
   dt_bauhaus_combobox_set(rating_legacy->stars, stars);
   gtk_widget_set_visible(rating_legacy->comparator, stars > 1 && stars < 7);
-  _rating_legacy_synchronise(rating_legacy);
   rule->manual_widget_set--;
 
   return TRUE;
 }
 
-static void _rating_widget_init(dt_lib_filtering_rule_t *rule, const dt_collection_properties_t prop,
-                                       const gchar *text, dt_lib_module_t *self, const gboolean top)
+static void _rating_widget_init(dt_lib_filters_rule_t *rule, const dt_collection_properties_t prop,
+                                const gchar *text, dt_lib_module_t *self, const gboolean top)
 {
   _widgets_rating_legacy_t *rating_legacy
       = (_widgets_rating_legacy_t *)g_malloc0(sizeof(_widgets_rating_legacy_t));
@@ -216,13 +194,8 @@ static void _rating_widget_init(dt_lib_filtering_rule_t *rule, const dt_collecti
   dt_bauhaus_combobox_set_entry_label(rating_legacy->stars, 6, "           ★ ★ ★ ★ ★");
   gtk_container_add(GTK_CONTAINER(rating_legacy->overlay), rating_legacy->stars);
 
-  if(top)
-    gtk_box_pack_start(GTK_BOX(rule->w_special_box_top), rating_legacy->overlay, TRUE, TRUE, 0);
-  else
-  {
-    gtk_box_pack_start(GTK_BOX(rule->w_special_box), rating_legacy->overlay, TRUE, TRUE, 0);
-    gtk_widget_set_halign(rating_legacy->overlay, GTK_ALIGN_CENTER);
-  }
+  gtk_box_pack_start(GTK_BOX(rule->w_special_box), rating_legacy->overlay, TRUE, TRUE, 0);
+  gtk_widget_set_halign(rating_legacy->overlay, GTK_ALIGN_CENTER);
 
 
   if(top)
@@ -230,10 +203,7 @@ static void _rating_widget_init(dt_lib_filtering_rule_t *rule, const dt_collecti
     dt_gui_add_class(rating_legacy->overlay, "dt_quick_filter");
   }
 
-  if(top)
-    rule->w_specific_top = rating_legacy;
-  else
-    rule->w_specific = rating_legacy;
+  rule->w_specific = rating_legacy;
 }
 
 // clang-format off

--- a/src/libs/filters/ratio.c
+++ b/src/libs/filters/ratio.c
@@ -20,15 +20,12 @@
   This file contains the necessary routines to implement a filter for the filtering module
 */
 
-static gboolean _ratio_update(dt_lib_filtering_rule_t *rule)
+static gboolean _ratio_update(dt_lib_filters_rule_t *rule, gchar *last_where_ext)
 {
   if(!rule->w_specific) return FALSE;
 
-  dt_lib_filtering_t *d = rule->lib;
   _widgets_range_t *special = (_widgets_range_t *)rule->w_specific;
-  _widgets_range_t *specialtop = (_widgets_range_t *)rule->w_specific_top;
   GtkDarktableRangeSelect *range = DTGTK_RANGE_SELECT(special->range_select);
-  GtkDarktableRangeSelect *rangetop = (specialtop) ? DTGTK_RANGE_SELECT(specialtop->range_select) : NULL;
 
   rule->manual_widget_set++;
   // first, we update the graph
@@ -39,7 +36,7 @@ static gboolean _ratio_update(dt_lib_filtering_rule_t *rule)
              " FROM main.images AS mi"
              " WHERE %s"
              " GROUP BY ROUND(aspect_ratio,3)",
-             d->last_where_ext);
+             last_where_ext);
   // clang-format on
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
@@ -47,7 +44,6 @@ static gboolean _ratio_update(dt_lib_filtering_rule_t *rule)
   int nb_square = 0;
   int nb_landscape = 0;
   dtgtk_range_select_reset_blocks(range);
-  if(rangetop) dtgtk_range_select_reset_blocks(rangetop);
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
     const double val = sqlite3_column_double(stmt, 0);
@@ -60,7 +56,6 @@ static gboolean _ratio_update(dt_lib_filtering_rule_t *rule)
       nb_square += count;
 
     dtgtk_range_select_add_block(range, val, count);
-    if(rangetop) dtgtk_range_select_add_block(rangetop, val, count);
   }
   sqlite3_finalize(stmt);
 
@@ -74,23 +69,9 @@ static gboolean _ratio_update(dt_lib_filtering_rule_t *rule)
   // and setup the selection
   dtgtk_range_select_set_selection_from_raw_text(range, rule->raw_text, FALSE);
 
-  if(rangetop)
-  {
-    // predefined selections
-    dtgtk_range_select_add_range_block(rangetop, 1.0, 1.0, DT_RANGE_BOUND_MIN | DT_RANGE_BOUND_MAX,
-                                       _("all images"), nb_portrait + nb_square + nb_landscape);
-    dtgtk_range_select_add_range_block(rangetop, 0.5, 0.99, DT_RANGE_BOUND_MIN, _("portrait images"), nb_portrait);
-    dtgtk_range_select_add_range_block(rangetop, 1.0, 1.0, DT_RANGE_BOUND_FIXED, _("square images"), nb_square);
-    dtgtk_range_select_add_range_block(rangetop, 1.01, 2.0, DT_RANGE_BOUND_MAX, _("landscape images"),
-                                       nb_landscape);
-
-    // and setup the selection
-    dtgtk_range_select_set_selection_from_raw_text(rangetop, rule->raw_text, FALSE);
-  }
   rule->manual_widget_set--;
 
   dtgtk_range_select_redraw(range);
-  if(rangetop) dtgtk_range_select_redraw(rangetop);
   return TRUE;
 }
 
@@ -128,7 +109,7 @@ static gchar *_ratio_print_func(const double value, const gboolean detailled)
   return txt;
 }
 
-static void _ratio_widget_init(dt_lib_filtering_rule_t *rule, const dt_collection_properties_t prop,
+static void _ratio_widget_init(dt_lib_filters_rule_t *rule, const dt_collection_properties_t prop,
                                const gchar *text, dt_lib_module_t *self, const gboolean top)
 {
   _widgets_range_t *special = (_widgets_range_t *)g_malloc0(sizeof(_widgets_range_t));

--- a/src/libs/filters/search.c
+++ b/src/libs/filters/search.c
@@ -144,7 +144,10 @@ static void _search_widget_init(dt_lib_filters_rule_t *rule, const dt_collection
   search->text = gtk_search_entry_new();
   g_signal_connect(G_OBJECT(search->text), "search-changed", G_CALLBACK(_search_changed), search);
   g_signal_connect(G_OBJECT(search->text), "stop-search", G_CALLBACK(_search_reset_text_entry), rule);
-  gtk_entry_set_width_chars(GTK_ENTRY(search->text), 0);
+  if(top)
+    gtk_entry_set_width_chars(GTK_ENTRY(search->text), 14);
+  else
+    gtk_entry_set_width_chars(GTK_ENTRY(search->text), 0);
   gtk_widget_set_tooltip_text(search->text,
                               /* xgettext:no-c-format */
                               _("filter by text from images metadata, tags, file path and name"

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -383,6 +383,19 @@ void gui_init(dt_lib_module_t *self)
   dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)g_malloc0(sizeof(dt_lib_tool_filter_t));
   self->data = (void *)d;
 
+  // we initialize all the shortcuts provided by the different filters
+  darktable.control->accel_initialising = TRUE;
+  const int nb = dt_filters_get_count();
+  for(int i = 0; i < nb; i++)
+  {
+    // initialize all widgets for shortcut registering
+    dt_lib_filters_rule_t *temp_rule = (dt_lib_filters_rule_t *)g_malloc0(sizeof(dt_lib_filters_rule_t));
+    temp_rule->w_special_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+    dt_filters_init(temp_rule, dt_filters_get_prop_by_pos(i), "", self, FALSE);
+    dt_filters_free(temp_rule);
+  }
+  darktable.control->accel_initialising = FALSE;
+
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_widget_set_valign(self->widget, GTK_ALIGN_CENTER);
 

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -16,25 +16,40 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "bauhaus/bauhaus.h"
 #include "common/collection.h"
 #include "common/darktable.h"
 #include "control/conf.h"
 #include "control/control.h"
 #include "develop/develop.h"
+#include "dtgtk/button.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
-#include "dtgtk/button.h"
+#include "libs/filters/filters.h"
 #include "libs/lib.h"
 #include "libs/lib_api.h"
-#include "bauhaus/bauhaus.h"
 
 DT_MODULE(1)
+
+typedef struct dt_lib_tool_filter_filter_t
+{
+  dt_collection_properties_t prop;
+  gchar *raw_text;
+
+  dt_lib_filters_rule_t *rule;
+} dt_lib_tool_filter_filter_t;
 
 typedef struct dt_lib_tool_filter_t
 {
   GtkWidget *filter_box;
   GtkWidget *sort_box;
+<<<<<<< HEAD
   GtkWidget *count;
+=======
+
+  GList *filters;
+  GList *sorts;
+>>>>>>> 07f7975e37 (filters : reactivate topbar)
 } dt_lib_tool_filter_t;
 
 const char *name(dt_lib_module_t *self)
@@ -86,6 +101,108 @@ static GtkWidget *_lib_filter_get_count(dt_lib_module_t *self)
   return d->count;
 }
 
+static void _dt_collection_updated(gpointer instance, dt_collection_change_t query_change,
+                                   dt_collection_properties_t changed_property, gpointer imgs, int next,
+                                   gpointer self)
+{
+  /* TODO
+  dt_lib_module_t *dm = (dt_lib_module_t *)self;
+  dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)dm->data;
+
+  gchar *where_ext = dt_collection_get_extended_where(darktable.collection, 99999);
+  if(g_strcmp0(where_ext, d->last_where_ext))
+  {
+    g_free(d->last_where_ext);
+    d->last_where_ext = g_strdup(where_ext);
+    for(int i = 0; i <= d->nb_rules; i++)
+    {
+      _widget_update(&d->rule[i]);
+    }
+  }*/
+}
+
+static void _filters_changed(void *data)
+{
+  dt_lib_module_t *self = (dt_lib_module_t *)data;
+  dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
+
+  // save the values
+  char confname[200] = { 0 };
+  int i = 0;
+  int last = -1;
+  for(GList *iter = d->filters; iter; iter = g_list_next(iter))
+  {
+    dt_lib_tool_filter_filter_t *f = (dt_lib_tool_filter_filter_t *)iter->data;
+    snprintf(confname, sizeof(confname), "plugins/lighttable/topbar/item%1d", i);
+    dt_conf_set_int(confname, f->prop);
+    snprintf(confname, sizeof(confname), "plugins/lighttable/topbar/string%1d", i);
+    dt_conf_set_string(confname, f->raw_text);
+    last = f->prop;
+    i++;
+  }
+  dt_conf_set_int("plugins/lighttable/topbar/num_rules", i);
+
+  if(i == 0) return;
+
+  // update the query without throwing signal everywhere
+  dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(_dt_collection_updated),
+                                  darktable.view_manager->proxy.module_collect.module);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, last, NULL);
+  dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(_dt_collection_updated),
+                                    darktable.view_manager->proxy.module_collect.module);
+}
+
+static void _filter_free(gpointer data)
+{
+  dt_lib_tool_filter_filter_t *filter = (dt_lib_tool_filter_filter_t *)data;
+  if(filter->raw_text) g_free(filter->raw_text);
+  dt_filters_free(filter->rule);
+}
+
+static void _filters_init(dt_lib_module_t *self)
+{
+  dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
+
+  // first, let's reset all remaining filters
+  g_list_free_full(d->filters, _filter_free);
+  d->filters = NULL;
+
+  // then we read the number of existing filters
+  ++darktable.gui->reset;
+  const int nb = MAX(dt_conf_get_int("plugins/lighttable/topbar/num_rules"), 0);
+  char confname[200] = { 0 };
+
+  // create or update defined rules
+  for(int i = 0; i < nb; i++)
+  {
+    snprintf(confname, sizeof(confname), "plugins/lighttable/topbar/item%1d", i);
+    const int prop = dt_conf_get_int(confname);
+    if(!dt_filters_exists(prop)) continue;
+
+    // create a new filter structure
+    dt_lib_tool_filter_filter_t *f = (dt_lib_tool_filter_filter_t *)g_malloc0(sizeof(dt_lib_tool_filter_filter_t));
+
+    f->prop = prop;
+    snprintf(confname, sizeof(confname), "plugins/lighttable/topbar/string%1d", i);
+    f->raw_text = dt_conf_get_string(confname);
+
+    f->rule = (dt_lib_filters_rule_t *)g_malloc0(sizeof(dt_lib_filters_rule_t));
+    f->rule->parent = self;
+    f->rule->rule_changed = _filters_changed;
+    if(f->rule->w_special_box) gtk_widget_destroy(f->rule->w_special_box);
+    f->rule->w_special_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+
+    dt_filters_init(f->rule, f->prop, f->raw_text, self, TRUE);
+
+    gtk_box_pack_start(GTK_BOX(d->filter_box), f->rule->w_special_box, FALSE, TRUE, 0);
+    d->filters = g_list_append(d->filters, f);
+  }
+
+  gtk_widget_show_all(d->filter_box);
+
+  --darktable.gui->reset;
+}
+
 void gui_init(dt_lib_module_t *self)
 {
   /* initialize ui widgets */
@@ -99,7 +216,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_name(d->filter_box, "header-rule-box");
   gtk_box_pack_start(GTK_BOX(self->widget), d->filter_box, FALSE, FALSE, 0);
 
-  /* sort combobox */
   d->sort_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_widget_set_name(d->sort_box, "header-sort-box");
   gtk_box_pack_start(GTK_BOX(self->widget), d->sort_box, FALSE, FALSE, 0);
@@ -115,13 +231,26 @@ void gui_init(dt_lib_module_t *self)
   darktable.view_manager->proxy.filter.module = self;
   darktable.view_manager->proxy.filter.get_filter_box = _lib_filter_get_filter_box;
   darktable.view_manager->proxy.filter.get_sort_box = _lib_filter_get_sort_box;
+<<<<<<< HEAD
   darktable.view_manager->proxy.filter.get_count = _lib_filter_get_count;
+=======
+
+  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
+                                  G_CALLBACK(_dt_collection_updated), self);
+
+  // initialize the filters
+  _filters_init(self);
+>>>>>>> 07f7975e37 (filters : reactivate topbar)
 }
 
 void gui_cleanup(dt_lib_module_t *self)
 {
+  dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
+  g_list_free_full(d->filters, _filter_free);
   g_free(self->data);
   self->data = NULL;
+
+  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_dt_collection_updated), self);
 }
 
 // clang-format off

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -45,6 +45,7 @@ typedef struct dt_lib_tool_filter_t
   GtkWidget *filter_box;
   GtkWidget *sort_box;
   GtkWidget *count;
+  GtkWidget *menu_btn;
 
   GList *filters;
   GList *sorts;
@@ -148,6 +149,35 @@ static void _filter_free(gpointer data)
   dt_filters_free(filter->rule);
 }
 
+static dt_lib_tool_filter_filter_t *_filter_create_new(const dt_collection_properties_t prop,
+                                                       const gchar *raw_text, dt_lib_module_t *self)
+{
+  dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
+  if(!dt_filters_exists(prop)) return NULL;
+
+  // create a new filter structure
+  dt_lib_tool_filter_filter_t *f = (dt_lib_tool_filter_filter_t *)g_malloc0(sizeof(dt_lib_tool_filter_filter_t));
+
+  f->prop = prop;
+  f->num = g_list_length(d->filters);
+  f->raw_text = g_strdup(raw_text);
+
+  f->rule = (dt_lib_filters_rule_t *)g_malloc0(sizeof(dt_lib_filters_rule_t));
+  f->rule->parent = f;
+  f->rule->rule_changed = _filters_changed;
+  if(f->rule->w_special_box) gtk_widget_destroy(f->rule->w_special_box);
+  f->rule->w_special_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+
+  dt_filters_init(f->rule, f->prop, f->raw_text, self, TRUE);
+
+  gtk_box_pack_start(GTK_BOX(d->filter_box), f->rule->w_special_box, FALSE, TRUE, 0);
+  gtk_widget_show_all(f->rule->w_special_box);
+
+  d->filters = g_list_append(d->filters, f);
+
+  return f;
+}
+
 static void _filters_init(dt_lib_module_t *self)
 {
   dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
@@ -166,31 +196,208 @@ static void _filters_init(dt_lib_module_t *self)
   {
     snprintf(confname, sizeof(confname), "plugins/lighttable/topbar/item%1d", i);
     const int prop = dt_conf_get_int(confname);
-    if(!dt_filters_exists(prop)) continue;
-
-    // create a new filter structure
-    dt_lib_tool_filter_filter_t *f = (dt_lib_tool_filter_filter_t *)g_malloc0(sizeof(dt_lib_tool_filter_filter_t));
-
-    f->prop = prop;
-    f->num = i;
     snprintf(confname, sizeof(confname), "plugins/lighttable/topbar/string%1d", i);
-    f->raw_text = dt_conf_get_string(confname);
-
-    f->rule = (dt_lib_filters_rule_t *)g_malloc0(sizeof(dt_lib_filters_rule_t));
-    f->rule->parent = f;
-    f->rule->rule_changed = _filters_changed;
-    if(f->rule->w_special_box) gtk_widget_destroy(f->rule->w_special_box);
-    f->rule->w_special_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-
-    dt_filters_init(f->rule, f->prop, f->raw_text, self, TRUE);
-
-    gtk_box_pack_start(GTK_BOX(d->filter_box), f->rule->w_special_box, FALSE, TRUE, 0);
-    d->filters = g_list_append(d->filters, f);
+    _filter_create_new(prop, dt_conf_get_string_const(confname), self);
   }
 
   gtk_widget_show_all(d->filter_box);
 
   --darktable.gui->reset;
+}
+
+static gboolean _event_filter_remove(GtkWidget *widget, GdkEventButton *event, dt_lib_module_t *self)
+{
+  dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
+  dt_lib_tool_filter_filter_t *filter
+      = (dt_lib_tool_filter_filter_t *)g_object_get_data(G_OBJECT(widget), "filter");
+
+  // remove the filter from the GList and destroy it
+  for(GList *iter = d->filters; iter; iter = g_list_next(iter))
+  {
+    if(iter->data == filter)
+    {
+      d->filters = g_list_remove(d->filters, iter->data);
+      _filter_free(filter);
+      break;
+    }
+  }
+
+  // remove the filter from the saved properties
+  const int nb = MAX(dt_conf_get_int("plugins/lighttable/topbar/num_rules"), 0);
+  char confname[200] = { 0 };
+
+  // create or update defined rules
+  for(int i = filter->num + 1; i < nb; i++)
+  {
+    snprintf(confname, sizeof(confname), "plugins/lighttable/topbar/item%1d", i);
+    const int prop = dt_conf_get_int(confname);
+    snprintf(confname, sizeof(confname), "plugins/lighttable/topbar/string%1d", i);
+    gchar *txt = dt_conf_get_string(confname);
+
+    snprintf(confname, sizeof(confname), "plugins/lighttable/topbar/item%1d", i - 1);
+    dt_conf_set_int(confname, prop);
+    snprintf(confname, sizeof(confname), "plugins/lighttable/topbar/string%1d", i - 1);
+    dt_conf_set_string(confname, txt);
+
+    g_free(txt);
+  }
+  dt_conf_set_int("plugins/lighttable/topbar/num_rules", nb - 1);
+
+  // remove the entry in the popup
+  gtk_container_remove(GTK_CONTAINER(gtk_widget_get_parent(gtk_widget_get_parent(widget))),
+                       gtk_widget_get_parent(widget));
+
+  return TRUE;
+}
+
+static GtkWidget *_popup_get_new_filter_line(dt_lib_tool_filter_filter_t *filter, dt_lib_module_t *self)
+{
+  GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  GtkWidget *eb = gtk_event_box_new();
+  gtk_container_add(GTK_CONTAINER(eb), gtk_label_new(dt_collection_name(filter->prop)));
+  gtk_box_pack_start(GTK_BOX(hbox), eb, TRUE, TRUE, 0);
+  GtkWidget *btn = dtgtk_button_new(dtgtk_cairo_paint_remove, 0, NULL);
+  g_object_set_data(G_OBJECT(btn), "filter", filter);
+  gtk_widget_set_tooltip_text(btn, _("remove the filter"));
+  g_signal_connect(G_OBJECT(btn), "button-press-event", G_CALLBACK(_event_filter_remove), self);
+  gtk_box_pack_start(GTK_BOX(hbox), btn, FALSE, TRUE, 0);
+  gtk_widget_show_all(hbox);
+  return hbox;
+}
+
+static void _event_add_filter(GtkWidget *widget, dt_lib_module_t *self)
+{
+  dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
+
+  // create the filter and add it to the GList
+  const int prop = GPOINTER_TO_INT(dt_bauhaus_combobox_get_data(widget));
+  dt_lib_tool_filter_filter_t *filter = _filter_create_new(prop, "", self);
+  if(!filter) return;
+
+  // save the properties
+  const int nb = g_list_length(d->filters);
+  dt_conf_set_int("plugins/lighttable/topbar/num_rules", nb);
+  char confname[200] = { 0 };
+  snprintf(confname, sizeof(confname), "plugins/lighttable/topbar/item%1d", nb - 1);
+  dt_conf_set_int(confname, prop);
+  snprintf(confname, sizeof(confname), "plugins/lighttable/topbar/string%1d", nb - 1);
+  dt_conf_set_string(confname, "");
+
+  // add the line in the popup
+  GtkWidget *hbox = _popup_get_new_filter_line(filter, self);
+  gtk_box_pack_start(GTK_BOX(gtk_widget_get_parent(widget)), hbox, FALSE, TRUE, 0);
+
+  // reset the combobox
+  dt_bauhaus_combobox_set(widget, 0);
+}
+
+static void _rule_populate_prop_combo_add(GtkWidget *w, const dt_collection_properties_t prop)
+{
+  if(!dt_filters_exists(prop)) return;
+  dt_bauhaus_combobox_add_full(w, dt_collection_name(prop), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,
+                               GUINT_TO_POINTER(prop), NULL, TRUE);
+}
+
+static gboolean _event_menu_show(GtkWidget *widget, GdkEventButton *event, dt_lib_module_t *self)
+{
+  dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
+
+  GtkWidget *pop = gtk_popover_new(widget);
+
+  GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  gtk_container_add(GTK_CONTAINER(pop), vbox);
+
+  // we show already added filters
+  for(GList *iter = d->filters; iter; iter = g_list_next(iter))
+  {
+    dt_lib_tool_filter_filter_t *filter = (dt_lib_tool_filter_filter_t *)iter->data;
+    GtkWidget *hbox = _popup_get_new_filter_line(filter, self);
+    gtk_box_pack_start(GTK_BOX(vbox), hbox, FALSE, TRUE, 0);
+  }
+
+  // the combobox to add a new filter
+  GtkWidget *w = dt_bauhaus_combobox_new(NULL);
+  dt_bauhaus_widget_set_label(w, NULL, _("add new filter"));
+
+#define ADD_COLLECT_ENTRY(value) _rule_populate_prop_combo_add(w, value);
+
+  // otherwise we add all implemented rules
+  gtk_widget_set_tooltip_text(w, _("choose new filter property"));
+  dt_bauhaus_combobox_add_section(w, "");
+
+  dt_bauhaus_combobox_add_section(w, _("files"));
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_FILMROLL);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_FOLDERS);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_FILENAME);
+
+  dt_bauhaus_combobox_add_section(w, _("metadata"));
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_TAG);
+  for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
+  {
+    const uint32_t keyid = dt_metadata_get_keyid_by_display_order(i);
+    const gchar *name = dt_metadata_get_name(keyid);
+    gchar *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", name);
+    const gboolean hidden = dt_conf_get_int(setting) & DT_METADATA_FLAG_HIDDEN;
+    g_free(setting);
+    const int meta_type = dt_metadata_get_type(keyid);
+    if(meta_type != DT_METADATA_TYPE_INTERNAL && !hidden)
+    {
+      ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_METADATA + i);
+    }
+  }
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_RATING_RANGE);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_RATING);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_COLORLABEL);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_TEXTSEARCH);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_GEOTAGGING);
+
+  dt_bauhaus_combobox_add_section(w, _("times"));
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_DAY);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_TIME);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_IMPORT_TIMESTAMP);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_CHANGE_TIMESTAMP);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_EXPORT_TIMESTAMP);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_PRINT_TIMESTAMP);
+
+  dt_bauhaus_combobox_add_section(w, _("capture details"));
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_CAMERA);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_LENS);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_APERTURE);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_EXPOSURE);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_FOCAL_LENGTH);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_ISO);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_ASPECT_RATIO);
+
+  dt_bauhaus_combobox_add_section(w, _("darktable"));
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_GROUPING);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_LOCAL_COPY);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_HISTORY);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_MODULE);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_ORDER);
+
+#undef ADD_COLLECT_ENTRY
+  g_signal_connect(G_OBJECT(w), "value-changed", G_CALLBACK(_event_add_filter), self);
+  gtk_box_pack_end(GTK_BOX(vbox), w, FALSE, TRUE, 0);
+
+  // let's show the popup
+  GdkDevice *pointer = gdk_seat_get_pointer(gdk_display_get_default_seat(gdk_display_get_default()));
+
+  int x, y;
+  GdkWindow *pointer_window = gdk_device_get_window_at_position(pointer, &x, &y);
+  gpointer pointer_widget = NULL;
+  if(pointer_window) gdk_window_get_user_data(pointer_window, &pointer_widget);
+
+  GdkRectangle rect
+      = { gtk_widget_get_allocated_width(widget) / 2, gtk_widget_get_allocated_height(widget), 1, 1 };
+
+  if(pointer_widget && widget != pointer_widget)
+    gtk_widget_translate_coordinates(pointer_widget, widget, x, y, &rect.x, &rect.y);
+
+  gtk_popover_set_pointing_to(GTK_POPOVER(pop), &rect);
+
+  gtk_widget_show_all(pop);
+
+  return TRUE;
 }
 
 void gui_init(dt_lib_module_t *self)
@@ -202,10 +409,17 @@ void gui_init(dt_lib_module_t *self)
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_widget_set_valign(self->widget, GTK_ALIGN_CENTER);
 
+  // the hamburger button
+  d->menu_btn = dtgtk_button_new(dtgtk_cairo_paint_presets, 0, NULL);
+  g_signal_connect(G_OBJECT(d->menu_btn), "button-press-event", G_CALLBACK(_event_menu_show), self);
+  gtk_box_pack_start(GTK_BOX(self->widget), d->menu_btn, TRUE, TRUE, 0);
+
+  // the filter box
   d->filter_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_widget_set_name(d->filter_box, "header-rule-box");
   gtk_box_pack_start(GTK_BOX(self->widget), d->filter_box, FALSE, FALSE, 0);
 
+  // the sort box
   d->sort_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_widget_set_name(d->sort_box, "header-sort-box");
   gtk_box_pack_start(GTK_BOX(self->widget), d->sort_box, FALSE, FALSE, 0);

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -76,11 +76,6 @@ int position(const dt_lib_module_t *self)
   return 2001;
 }
 
-static GtkWidget *_lib_filter_get_filter_box(dt_lib_module_t *self)
-{
-  dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
-  return d->filter_box;
-}
 static GtkWidget *_lib_filter_get_sort_box(dt_lib_module_t *self)
 {
   dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
@@ -434,11 +429,8 @@ void gui_init(dt_lib_module_t *self)
 
   /* initialize proxy */
   darktable.view_manager->proxy.filter.module = self;
-  darktable.view_manager->proxy.filter.get_filter_box = _lib_filter_get_filter_box;
   darktable.view_manager->proxy.filter.get_sort_box = _lib_filter_get_sort_box;
-<<<<<<< HEAD
   darktable.view_manager->proxy.filter.get_count = _lib_filter_get_count;
-=======
 
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
                                   G_CALLBACK(_dt_collection_updated), self);
@@ -446,7 +438,13 @@ void gui_init(dt_lib_module_t *self)
   // initialize the filters
   _update_where_ext(self, FALSE);
   _filters_init(self);
->>>>>>> 07f7975e37 (filters : reactivate topbar)
+
+  // test if the filtering module is already load and update its gui in this case
+  // otherwise filtering module will do it in its gui_init()
+  if(darktable.view_manager->proxy.module_filtering.module)
+  {
+    darktable.view_manager->proxy.module_filtering.update(darktable.view_manager->proxy.module_filtering.module);
+  }
 }
 
 void gui_cleanup(dt_lib_module_t *self)

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -408,7 +408,7 @@ void gui_init(dt_lib_module_t *self)
   // the hamburger button
   d->menu_btn = dtgtk_button_new(dtgtk_cairo_paint_presets, 0, NULL);
   g_signal_connect(G_OBJECT(d->menu_btn), "button-press-event", G_CALLBACK(_event_menu_show), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), d->menu_btn, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), d->menu_btn, FALSE, TRUE, 0);
 
   // the filter box
   d->filter_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -116,13 +116,6 @@ void gui_init(dt_lib_module_t *self)
   darktable.view_manager->proxy.filter.get_filter_box = _lib_filter_get_filter_box;
   darktable.view_manager->proxy.filter.get_sort_box = _lib_filter_get_sort_box;
   darktable.view_manager->proxy.filter.get_count = _lib_filter_get_count;
-
-  // test if the filtering module is already load and update its gui in this case
-  // otherwise filtering module will do it in its gui_init()
-  if(darktable.view_manager->proxy.module_filtering.module)
-  {
-    darktable.view_manager->proxy.module_filtering.update(darktable.view_manager->proxy.module_filtering.module);
-  }
 }
 
 void gui_cleanup(dt_lib_module_t *self)

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -153,7 +153,7 @@ static dt_lib_filters_rule_t *_filter_create_new(const dt_collection_properties_
                                                  dt_lib_module_t *self)
 {
   dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
-  if(!dt_filters_exists(prop)) return NULL;
+  if(!dt_filters_exists(prop, TRUE)) return NULL;
 
   // create a new filter structure
   dt_lib_filters_rule_t *rule = (dt_lib_filters_rule_t *)g_malloc0(sizeof(dt_lib_filters_rule_t));
@@ -280,7 +280,7 @@ static void _event_add_filter(GtkWidget *widget, dt_lib_module_t *self)
 
 static void _rule_populate_prop_combo_add(GtkWidget *w, const dt_collection_properties_t prop)
 {
-  if(!dt_filters_exists(prop)) return;
+  if(!dt_filters_exists(prop, TRUE)) return;
   dt_bauhaus_combobox_add_full(w, dt_collection_name(prop), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,
                                GUINT_TO_POINTER(prop), NULL, TRUE);
 }
@@ -338,13 +338,14 @@ static gboolean _event_menu_show(GtkWidget *widget, GdkEventButton *event, dt_li
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_TEXTSEARCH);
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_GEOTAGGING);
 
+  /* this section is disabled because related filters are not designed for the topbar
   dt_bauhaus_combobox_add_section(w, _("times"));
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_DAY);
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_TIME);
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_IMPORT_TIMESTAMP);
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_CHANGE_TIMESTAMP);
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_EXPORT_TIMESTAMP);
-  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_PRINT_TIMESTAMP);
+  ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_PRINT_TIMESTAMP);*/
 
   dt_bauhaus_combobox_add_section(w, _("capture details"));
   ADD_COLLECT_ENTRY(DT_COLLECTION_PROP_CAMERA);
@@ -401,7 +402,7 @@ void gui_init(dt_lib_module_t *self)
     // initialize all widgets for shortcut registering
     dt_lib_filters_rule_t *temp_rule = (dt_lib_filters_rule_t *)g_malloc0(sizeof(dt_lib_filters_rule_t));
     temp_rule->w_special_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    dt_filters_init(temp_rule, dt_filters_get_prop_by_pos(i), "", self, FALSE);
+    dt_filters_init(temp_rule, dt_filters_get_prop_by_pos(i), "", self, TRUE);
     dt_filters_free(temp_rule);
   }
   darktable.control->accel_initialising = FALSE;

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -935,12 +935,6 @@ void dt_view_filtering_reset(const dt_view_manager_t *vm, gboolean smart_filter)
     vm->proxy.module_filtering.reset_filter(vm->proxy.module_filtering.module, smart_filter);
 }
 
-GtkWidget *dt_view_filter_get_filters_box(const dt_view_manager_t *vm)
-{
-  if(vm->proxy.filter.module && vm->proxy.filter.get_filter_box)
-    return vm->proxy.filter.get_filter_box(vm->proxy.filter.module);
-  return NULL;
-}
 GtkWidget *dt_view_filter_get_sort_box(const dt_view_manager_t *vm)
 {
   if(vm->proxy.filter.module && vm->proxy.filter.get_sort_box)

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -255,7 +255,6 @@ typedef struct dt_view_manager_t
     struct
     {
       struct dt_lib_module_t *module;
-      GtkWidget *(*get_filter_box)(struct dt_lib_module_t *);
       GtkWidget *(*get_sort_box)(struct dt_lib_module_t *);
       GtkWidget *(*get_count)(struct dt_lib_module_t *);
     } filter;
@@ -424,7 +423,6 @@ void dt_view_collection_update_history_state(const dt_view_manager_t *vm);
  * Filter dropdown proxy
  */
 void dt_view_filtering_reset(const dt_view_manager_t *vm, gboolean smart_filter);
-GtkWidget *dt_view_filter_get_filters_box(const dt_view_manager_t *vm);
 GtkWidget *dt_view_filter_get_sort_box(const dt_view_manager_t *vm);
 GtkWidget *dt_view_filter_get_count(const dt_view_manager_t *vm);
 


### PR DESCRIPTION
As promised, here is a implementation of what as been discussed in pixl.us about the evolution of the filtering system. (thanks to all contributor for the respectful and constructive discussion !)
For reference, here are the threads : 
https://discuss.pixls.us/t/discussion-around-collection-filters-improvements/32489
https://discuss.pixls.us/t/discussion-around-new-filters-widgets/32490
https://discuss.pixls.us/t/collection-filters-proposals/32995

Following the last one, this PR implement following changes : 
- remove the synchronization between lateral filtering module and topbar. This means we don't have the "pin" icon anymore in the lateral module. Filters in each modules (lateral and topbar) are now fully independent.
- add an "hamburger menu in the topbar, to add-remove filters
- remove the date-time filters from the topbar : they are way to small to be useful
- no change for sorting

This changes (corresponding to points 1-2-3-4 from pixl.us thread) are the first "pack" of planned filtering system enhancement.
Next "easy" steps will be : 
- enhancement of the range-rating filter (colors and icons) -> 4.2
- refactoring of some internal code in collection -> 4.2 ??
- allow to reorder filters (lateral module and topbar) -> 4.4
- allow presets for the topbar -> 4.4

Thanks all for your tests, reviews...