### PR TITLE
Performance tuning for thumbs in HLR opposed and segmentation

### DIFF
--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -1987,6 +1987,19 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     return;
   }
 
+  /* Some of the HLR algorithms can be pretty slow, while rendering thumnbnails we looks for an acceptable
+     lower quality like we do in demosaic and can tune the reconstruction code. So far only used by
+     opposed and segmentations algos as they make use of the full image data instead of ROI 
+  */
+  gboolean quality_thumb = TRUE;
+  if(piece->pipe->type & DT_DEV_PIXELPIPE_THUMBNAIL)
+  {
+    const int level = dt_mipmap_cache_get_matching_size(darktable.mipmap_cache, piece->pipe->final_width, piece->pipe->final_height);
+    const char *min = dt_conf_get_string_const("plugins/lighttable/thumbnail_hq_min_level");
+    const dt_mipmap_size_t min_s = dt_mipmap_cache_get_min_mip_from_pref(min);
+    quality_thumb = (level >= min_s);
+  }
+
   const float clip
       = data->clip * fminf(piece->pipe->dsc.processed_maximum[0],
                            fminf(piece->pipe->dsc.processed_maximum[1], piece->pipe->dsc.processed_maximum[2]));
@@ -2003,7 +2016,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     }
     else
     {
-      _process_linear_opposed(self, piece, ivoid, ovoid, roi_in, roi_out, data);
+      _process_linear_opposed(self, piece, ivoid, ovoid, roi_in, roi_out, data, quality_thumb);
     }
     return;
   }
@@ -2083,8 +2096,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       const dt_segments_mask_t vmode = ((g != NULL) && fullpipe) ? g->segmentation_mask_mode : DT_SEGMENTS_MASK_OFF;
       const gboolean complete = (piece->pipe->type & (DT_DEV_PIXELPIPE_PREVIEW | DT_DEV_PIXELPIPE_PREVIEW2)) == 0;
 
-      float *tmp = _process_opposed(self, piece, ivoid, ovoid, roi_in, roi_out, data, complete);
-      if(tmp && complete)
+      float *tmp = _process_opposed(self, piece, ivoid, ovoid, roi_in, roi_out, data, complete, quality_thumb);
+      if(tmp && complete && quality_thumb)
         _process_segmentation(piece, ivoid, ovoid, roi_in, roi_out, data, vmode, tmp);
       dt_free_align(tmp);
 
@@ -2114,7 +2127,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     default:
     case DT_IOP_HIGHLIGHTS_OPPOSED:
     {
-      float *tmp = _process_opposed(self, piece, ivoid, ovoid, roi_in, roi_out, data, FALSE);
+      float *tmp = _process_opposed(self, piece, ivoid, ovoid, roi_in, roi_out, data, FALSE, quality_thumb);
       dt_free_align(tmp);
       break;
     }

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -59,7 +59,7 @@ static inline float _calc_linear_refavg(const float *in, const int row, const in
 // A slightly modified version for sraws
 static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
                          const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
-                         dt_iop_highlights_data_t *data)
+                         dt_iop_highlights_data_t *data, const gboolean quality)
 {
   const float clipval = 0.987f * data->clip;
   const dt_aligned_pixel_t icoeffs = { piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1], piece->pipe->dsc.temperature.coeffs[2]};
@@ -114,10 +114,10 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
     goto finish;
   }
 
-  gboolean anyclipped = FALSE;
+  size_t anyclipped = 0;
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  reduction( | : anyclipped) \
+  reduction( + : anyclipped) \
   dt_omp_firstprivate(clips, ivoid, tmpout, roi_in, mask_buffer) \
   dt_omp_sharedconst(p_size, pwidth, pheight, i_width) \
   schedule(static)
@@ -139,7 +139,7 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
           {
             tmp[c] = _calc_linear_refavg(&in[0], row, col, roi_in, c);
             mask_buffer[c * p_size + _raw_to_plane(pwidth, row, col)] |= 1;
-            anyclipped |= TRUE;
+            anyclipped += 1;
           }
         }
       }
@@ -148,7 +148,7 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
     }
   }
 
-  if(!valid_chrominance && anyclipped)
+  if(!valid_chrominance && (anyclipped > 5) && quality)
   {
     for(size_t i = 0; i < 3; i++)
     {
@@ -193,7 +193,6 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
       for_each_channel(c)
         g->chroma_correction[c] = chrominance[c];
       g->valid_chroma_correction = TRUE;
-      // fprintf(stderr, "[opposed linear chroma corrections] %f, %f, %f\n", chrominance[0], chrominance[1], chrominance[2]);          
     }
   }
 
@@ -231,7 +230,7 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
 
 static float *_process_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
                          const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
-                         dt_iop_highlights_data_t *data, const gboolean keep)
+                         dt_iop_highlights_data_t *data, const gboolean keep, const gboolean quality)
 {
   const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
   const uint32_t filters = piece->pipe->dsc.filters;
@@ -285,10 +284,10 @@ static float *_process_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
     return NULL;
   }
 
-  gboolean anyclipped = FALSE;
+  size_t anyclipped = 0;
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  reduction( | : anyclipped) \
+  reduction( + : anyclipped) \
   dt_omp_firstprivate(clips, ivoid, tmpout, roi_in, xtrans, mask_buffer) \
   dt_omp_sharedconst(filters, p_size, pwidth, pheight, i_width, o_width) \
   schedule(static)
@@ -307,14 +306,14 @@ static float *_process_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
         /* for the clipped photosites we later do the correction when the chrominance is available, we keep refavg in raw-RGB */
         tmp[0] = _calc_refavg(&in[0], xtrans, filters, row, col, roi_in, TRUE);
         mask_buffer[color * p_size + _raw_to_plane(pwidth, row, col)] |= 1;
-        anyclipped |= TRUE;
+        anyclipped += 1;
       }
       tmp++;
       in++;
     }
   }
 
-  if(!valid_chrominance && anyclipped)
+  if(!valid_chrominance && (anyclipped > 5) && quality)
   {
   /* We want to use the photosites closely around clipped data to be taken into account.
      The mask buffers holds data for each color channel, we dilate the mask buffer slightly
@@ -358,14 +357,15 @@ static float *_process_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
       }
     }
     for_each_channel(c)
-      chrominance[c] = cr_sum[c] / fmax(1.0, cr_cnt[c]);    
+      chrominance[c] = cr_sum[c] / fmax(1.0, cr_cnt[c]);
+
+    // fprintf(stderr, "[opposed chroma corrections] %f, %f, %f\n", chrominance[0], chrominance[1], chrominance[2]);          
 
     if(g && piece->pipe->type & DT_DEV_PIXELPIPE_FULL)
     {
       for_each_channel(c)
         g->chroma_correction[c] = chrominance[c];
       g->valid_chroma_correction = TRUE;
-      // fprintf(stderr, "[opposed chroma corrections] %f, %f, %f\n", chrominance[0], chrominance[1], chrominance[2]);          
     }
   }
 

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -186,7 +186,7 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
       }
     }
     for_each_channel(c)
-      chrominance[c] = cr_sum[c] / fmax(1.0, cr_cnt[c]);    
+      chrominance[c] = cr_sum[c] / fmaxf(1.0f, cr_cnt[c]);    
 
     if(g && piece->pipe->type & DT_DEV_PIXELPIPE_FULL)
     {
@@ -357,7 +357,7 @@ static float *_process_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
       }
     }
     for_each_channel(c)
-      chrominance[c] = cr_sum[c] / fmax(1.0, cr_cnt[c]);
+      chrominance[c] = cr_sum[c] / fmaxf(1.0f, cr_cnt[c]);
 
     // fprintf(stderr, "[opposed chroma corrections] %f, %f, %f\n", chrominance[0], chrominance[1], chrominance[2]);          
 


### PR DESCRIPTION
Due to recently merged `pipe->final_width&height` we can do a runtime check for required high quality while rendering thumbnails.

Avoiding the costly chroma_correction calculation leads to a slight drop in thumb quality but almost doubles performance for standard lightroom.