### PR TITLE
fix module tab reset history

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2729,28 +2729,13 @@ GdkModifierType dt_key_modifier_state()
 
 static void _reset_all_bauhaus(GtkNotebook *notebook, GtkWidget *box)
 {
-  dt_action_t *module = NULL;
-
-  ++darktable.gui->reset;
-
   for(GList *c = gtk_container_get_children(GTK_CONTAINER(box)); c; c = g_list_delete_link(c, c))
   {
     if(DT_IS_BAUHAUS_WIDGET(c->data))
-    {
-      dt_bauhaus_widget_t *b = DT_BAUHAUS_WIDGET(c->data);
-      if(!b->field) continue;
-      module = b->module;
-
-      dt_bauhaus_widget_reset(GTK_WIDGET(b));
-    }
+      dt_bauhaus_widget_reset(GTK_WIDGET(c->data));
   }
 
-  --darktable.gui->reset;
-
   dt_gui_remove_class(gtk_notebook_get_tab_label(GTK_NOTEBOOK(notebook), box), "changed");
-
-  if(module && module->type == DT_ACTION_TYPE_IOP_INSTANCE)
-    dt_dev_add_history_item(darktable.develop, (dt_iop_module_t *)module, TRUE);
 }
 
 static void _notebook_size_callback(GtkNotebook *notebook, GdkRectangle *allocation, gpointer *data)


### PR DESCRIPTION
fixes #12786

Removes a mistaken attempt to use `gui->reset` to group all changes within a module tab into one undo entry when resetting it by double-click. This actually prevented the changes from taking effect at all.

The reason I added this at the last minute was that I sometimes saw a single undo only restoring some of the reset sliders, but I don't seem to be able to reproduce now. I'm not sure how undo decides what to include in one "step". If there is a need to address this, `dt_dev_undo_start_record`/`dt_dev_undo_end_record` might need to support multiple nested calls.

So further field testing of this change would be appreciated. Thanks @Nilvus for reporting the issue.