### PR TITLE
make colorpicking edges of image easier

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3285,7 +3285,7 @@ void mouse_leave(dt_view_t *self)
 /* This helper function tests for a position to be within the displayed area
    of an image. To avoid "border cases" we accept values to be slightly out of area too.
 */
-static int mouse_in_imagearea(dt_view_t *self, double x, double y)
+static int mouse_in_imagearea(dt_view_t *self, double *x, double *y)
 {
   dt_develop_t *dev = (dt_develop_t *)self->data;
 
@@ -3293,10 +3293,8 @@ static int mouse_in_imagearea(dt_view_t *self, double x, double y)
   const int pwidth = (dev->pipe->output_backbuf_width<<closeup) / darktable.gui->ppd;
   const int pheight = (dev->pipe->output_backbuf_height<<closeup) / darktable.gui->ppd;
 
-  x -= (self->width - pwidth) / 2;
-  y -= (self->height - pheight) / 2;
-
-  if((x < -3) || (x > (pwidth + 6)) || (y < -3) || (y > (pheight + 6))) return FALSE;
+  *x = CLAMP(*x, (self->width - pwidth) / 2, (self->width + pwidth) / 2);
+  *y = CLAMP(*y, (self->height - pheight) / 2, (self->height + pheight) / 2);
   return TRUE;
 }
 
@@ -3334,7 +3332,7 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
   if(dt_iop_color_picker_is_visible(dev) && ctl->button_down && ctl->button_down_which == 1)
   {
     // module requested a color box
-    if(mouse_in_imagearea(self, x, y))
+    if(mouse_in_imagearea(self, &x, &y))
     {
       dt_colorpicker_sample_t *const sample = darktable.lib->proxy.colorpicker.primary_sample;
       // Make sure a minimal width/height
@@ -3464,7 +3462,7 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
 
     if(which == 1)
     {
-      if(mouse_in_imagearea(self, x, y))
+      if(mouse_in_imagearea(self, &x, &y))
       {
         // The default box will be a square with 1% of the image width
         const float delta_x = 0.01f;
@@ -3527,7 +3525,7 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
       // apply a live sample's area to the active picker?
       // FIXME: this is a naive implementation, nicer would be to cycle through overlapping samples then reset
       dt_iop_color_picker_t *picker = darktable.lib->proxy.colorpicker.picker_proxy;
-      if(darktable.lib->proxy.colorpicker.display_samples && mouse_in_imagearea(self, x, y))
+      if(darktable.lib->proxy.colorpicker.display_samples && mouse_in_imagearea(self, &x, &y))
         for(GSList *samples = darktable.lib->proxy.colorpicker.live_samples; samples; samples = g_slist_next(samples))
         {
           dt_colorpicker_sample_t *live_sample = samples->data;


### PR DESCRIPTION
fixes #8579

As per comment of @johnny-bit in that issue, this now clips selections outside the image area instead of ignoring them.

It seems to me that in the existing code, if I started selecting a range outside of the image, it would be ignored, but if I then kept holding the mouse and moved to within the image range, it suddenly realised it was dragging a corner. Not sure if that had _intended_ side effects (as always, when touching this kind of code). So please report any new issues you notice with this change so I can fix those as well. I don't think that should stop this change which does indeed make selecting border areas with the picker much more pleasant (imho).