### PR TITLE
Bugfix: Harden pixelpipe cache

### DIFF
--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -183,11 +183,12 @@ uint64_t dt_dev_pixelpipe_cache_hash(int imgid, const dt_iop_roi_t *roi, dt_dev_
   return hash;
 }
 
-gboolean dt_dev_pixelpipe_cache_available(dt_dev_pixelpipe_cache_t *cache, const uint64_t hash)
+gboolean dt_dev_pixelpipe_cache_available(dt_dev_pixelpipe_cache_t *cache, const uint64_t hash, const size_t size)
 {
   // search for hash in cache
-  for(int32_t k = 0; k < cache->entries; k++)
-    if(cache->hash[k] == hash) return TRUE;
+  for(int k = 0; k < cache->entries; k++)
+    if((cache->hash[k] == hash) && (cache->size[k] >= size))
+      return TRUE;
   return FALSE;
 }
 
@@ -277,8 +278,8 @@ gboolean dt_dev_pixelpipe_cache_get(struct dt_dev_pixelpipe_t *pipe, const uint6
            In this case we can't simply realloc or alike as there might be data in the pipeline just making use
            of that buffer so we disable it and make the cleanup will free it.
         */ 
-        dt_print(DT_DEBUG_DEV, "[pixelpipe_cache_get] %12s HIT SIZE ERROR in %16s, line%3i, age %4i, at %p, cache size %lu, requested %lu\n",
-          dt_dev_pixelpipe_type_to_str(pipe->type), name, k, cache->used[k], cache->data[k], cache->size[k], size);
+        dt_print(DT_DEBUG_DEV, "[pixelpipe_cache_get] [%s] HIT SIZE ERROR in `%s', line%3i, age %4i, at %p, cache size %ikB, requested %ikB\n",
+          dt_dev_pixelpipe_type_to_str(pipe->type), name, k, cache->used[k], cache->data[k], (int)cache->size[k] / 1024, (int)size / 1024);
         cache->hash[k] = cache->basichash[k] = -1;
         cache->used[k] = VERY_OLD_CACHE_WEIGHT;
       }

--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -75,7 +75,7 @@ gboolean dt_dev_pixelpipe_cache_get(struct dt_dev_pixelpipe_t *pipe, const uint6
                                const size_t size, void **data, struct dt_iop_buffer_dsc_t **dsc, char *modname, const gboolean important);
 
 /** test availability of a cache line without destroying another, if it is not found. */
-gboolean dt_dev_pixelpipe_cache_available(dt_dev_pixelpipe_cache_t *cache, const uint64_t hash);
+gboolean dt_dev_pixelpipe_cache_available(dt_dev_pixelpipe_cache_t *cache, const uint64_t hash, const size_t size);
 
 /** invalidates all cachelines. */
 void dt_dev_pixelpipe_cache_flush(dt_dev_pixelpipe_cache_t *cache);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1182,7 +1182,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
      || strcmp(module->op, "gamma") != 0)
   {
     dt_dev_pixelpipe_cache_fullhash(pipe->image.id, roi_out, pipe, pos, &basichash, &hash);
-    cache_available = dt_dev_pixelpipe_cache_available(&(pipe->cache), hash);
+    cache_available = dt_dev_pixelpipe_cache_available(&(pipe->cache), hash, bufsize);
   }
   if(cache_available)
   {


### PR DESCRIPTION
The central function geting a cacheline buffer in the pixelpipe is `dt_dev_pixelpipe_cache_get()`.

A valid cacheline is defined by equality of hash, this seems to be not correct in all cases, we might have a remaining buffer with less size than requested but identical hash.

This pr does some hardening
- fully resetting pointers in `dt_dev_pixelpipe_cache_cleanup()` - probably not necessary but not hurting
- make an additional check for requested buffer size in `dt_dev_pixelpipe_cache_get()` and possibly write a debug message to console.

Likely this only happens if there is some problem calculating the hash in some module - at least we might be able to track this via the debugging message.

Fixes #12798

Might also be the root cause of #12120 as the cache-line-hit check worked the same way in pre-4.2 versions.