### PR TITLE
CI: cancel new jobs on PRs only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 # Keep in sync with manualrun.yml!


### PR DESCRIPTION
As per https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value