### PR TITLE
iop/lens: fix params resetting when modified is 0

### DIFF
--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1965,9 +1965,12 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   {
     /*
      * user did not modify anything in gui after autodetection - let's
-     * use current default_params as params - for presets and mass-export
+     * use current default_params as params with the exception of the method that must be kept
+     * For presets and mass-export
      */
+    const dt_iop_lens_method_t method = p->method;
     p = (dt_iop_lens_params_t *)self->default_params;
+    p->method = method;
   }
 
   d->method = p->method;
@@ -3250,9 +3253,12 @@ void gui_update(struct dt_iop_module_t *self)
   {
     /*
      * user did not modify anything in gui after autodetection - let's
-     * use current default_params as params - for presets and mass-export
+     * use current default_params as params with the exception of the method that must be kept
+     * For presets and mass-export
      */
+    const dt_iop_lens_method_t method = p->method;
     memcpy(self->params, self->default_params, sizeof(dt_iop_lens_params_t));
+    p->method = method;
   }
 
   int modflag = p->modify_flags;


### PR DESCRIPTION
Before adding the "embedded metadata" method the unique method was "lensfun". The module parameters contain a "modified" param that is set when the user changes something in the gui.

So there can be images saved or presets created with "modified" unset.

"modified" is used primarily for presets: you can enable lensfun without changing anything and then create a preset. This preset, having "modified" unset will auto configure its params based on the detected camera/lens.

After adding the "embedded metadata" method, the logic handling this "modified" parameter hasn't been changed but this could cause some issues:

* When developing an image having lens module enabled but with "modified" unset and method "lensfun" (set by parameter migration from v5 to v6), the logic will reset to default params, but now default params could have method of type "embedded metadata" by default if the image provides the related metadata and so the generated image will be different than the image generated with a previous darktable version (it's processed by a different lens correction method).

* if you have a preset saved with "modified" unset and method "lensfun" (set by parameter migration from v5 to v6) when applying it to an image, for the same reason of above, won't be correctly applied but the method will remain "embedded metadata".

This patch fixes this issues by restoring the current parameters method after resetting all the other parameters to default.