### PR TITLE
Fix segmentation HLR for previews and thumbs

### DIFF
--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -1982,13 +1982,13 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
      lower quality like we do in demosaic and can tune the reconstruction code. So far only used by
      opposed and segmentations algos as they make use of the full image data instead of ROI 
   */
-  gboolean quality_thumb = TRUE;
+  gboolean high_quality = TRUE;
   if(piece->pipe->type & DT_DEV_PIXELPIPE_THUMBNAIL)
   {
     const int level = dt_mipmap_cache_get_matching_size(darktable.mipmap_cache, piece->pipe->final_width, piece->pipe->final_height);
     const char *min = dt_conf_get_string_const("plugins/lighttable/thumbnail_hq_min_level");
     const dt_mipmap_size_t min_s = dt_mipmap_cache_get_min_mip_from_pref(min);
-    quality_thumb = (level >= min_s);
+    high_quality = (level >= min_s);
   }
 
   const float clip
@@ -2007,7 +2007,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     }
     else
     {
-      _process_linear_opposed(self, piece, ivoid, ovoid, roi_in, roi_out, data, quality_thumb);
+      _process_linear_opposed(self, piece, ivoid, ovoid, roi_in, roi_out, data, high_quality);
     }
     return;
   }
@@ -2085,10 +2085,9 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     case DT_IOP_HIGHLIGHTS_SEGMENTS:
     {
       const dt_segments_mask_t vmode = ((g != NULL) && fullpipe) ? g->segmentation_mask_mode : DT_SEGMENTS_MASK_OFF;
-      const gboolean complete = (piece->pipe->type & (DT_DEV_PIXELPIPE_PREVIEW | DT_DEV_PIXELPIPE_PREVIEW2)) == 0;
 
-      float *tmp = _process_opposed(self, piece, ivoid, ovoid, roi_in, roi_out, data, complete, quality_thumb);
-      if(tmp && complete && quality_thumb)
+      float *tmp = _process_opposed(self, piece, ivoid, ovoid, roi_in, roi_out, data, TRUE, TRUE);
+      if(tmp)
         _process_segmentation(piece, ivoid, ovoid, roi_in, roi_out, data, vmode, tmp);
       dt_free_align(tmp);
 
@@ -2118,7 +2117,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     default:
     case DT_IOP_HIGHLIGHTS_OPPOSED:
     {
-      float *tmp = _process_opposed(self, piece, ivoid, ovoid, roi_in, roi_out, data, FALSE, quality_thumb);
+      float *tmp = _process_opposed(self, piece, ivoid, ovoid, roi_in, roi_out, data, FALSE, high_quality);
       dt_free_align(tmp);
       break;
     }

--- a/src/iop/hlrecovery_v2.c
+++ b/src/iop/hlrecovery_v2.c
@@ -220,9 +220,9 @@ static void _initial_gradients(const size_t w, const size_t height, float *lumin
   dt_omp_sharedconst(w, height) \
   schedule(static) collapse(2)
 #endif
-  for(size_t row = HL_BORDER; row < height - HL_BORDER; row++)
+  for(size_t row = HL_BORDER + 2; row < height - HL_BORDER - 2; row++)
   {
-    for(size_t col = HL_BORDER; col < w - HL_BORDER; col++)
+    for(size_t col = HL_BORDER + 2; col < w - HL_BORDER - 2; col++)
     {
       const size_t v = row * w + col;
       float g = 0.0f;
@@ -595,7 +595,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
   if(do_recovery || (vmode != DT_SEGMENTS_MASK_OFF))
   {
     dt_segments_transform_closing(&isegments[3], seg_border);
-    dt_iop_image_fill(gradient, 0.0f, pwidth, pheight, 1);
+    dt_iop_image_fill(gradient, fminf(1.0f, 5.0f * strength), pwidth, pheight, 1);
     dt_iop_image_fill(distance, 0.0f, pwidth, pheight, 1);
 #ifdef _OPENMP
   #pragma omp parallel for default(none) \

--- a/src/iop/hlrecovery_v2.c
+++ b/src/iop/hlrecovery_v2.c
@@ -59,7 +59,7 @@ The chosen segmentation algorithm works like this:
    - the candidates location
 */
 
-/* Recovery algorithm
+/* Rebuild algorithm
   In areas with all planes clipped we try to reconstruct (hopefully a good guess) data based on the border gradients and the
   segment's size - here we use a distance transformation.
   What do we need to do so?

--- a/src/iop/hlrecovery_v2.c
+++ b/src/iop/hlrecovery_v2.c
@@ -659,7 +659,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
       {
         float *out = tmpout + i_width * row + 1;
         float *in = (float *)ivoid + i_width * row + 1;
-        for(size_t col = 1; col < o_width - 1; col++)
+        for(size_t col = 1; col < i_width - 1; col++)
         {
           const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
           if(fmaxf(0.0f, in[0]) > clips[color])


### PR DESCRIPTION
The 'fast mode' leads to more confusion because the preview and thumbnail output was so different from what was seen in darkroom so we also do the full segmentation stuff in these situations.

This means we have sort-of-correct histogram and a more correct-looking preview output in most cases.

Thumbs are much slower though while in segmentation mode.

There is another subtle issue in the rebuild step reported by @Iain which is still under investigation "how to solve". As that is deeper in segmenation code internals, thats another pr 