### PR TITLE
iop/lens: don't set modified when switching method in gui

### DIFF
--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2981,9 +2981,9 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     gtk_widget_set_sensitive(GTK_WIDGET(g->message), TRUE);
   }
 
-  if(w)
+  // set modified if user did modify something with some widget (excluding the method selector)
+  if(w && w != g->methods_selector)
   {
-    // user did modify something with some widget
     p->modified = 1;
   }
 


### PR DESCRIPTION
Don't set modified to 1 when switching the method in the method selector gui combobox

## Example issue fixed with this change:

* User enable the "lens" module in an image. The gui, depending on the image the user is working on, will choose "embedded metadata" (default if available on the image) or "lensfun" methods.
* Suppose both methods are available and the user switches from metadata to lensfun without changing anything else and saves a preset.

### Before this patch behavior:

It'll be saved with "modified" == 1 since changing the method sets modified.

If the preset is applied to an image the module will use the "lensfun" method BUT won't auto update the camera/lenses based on the current image but keep the ones saved in the preset since "modified" is 1, causing WRONG corrections.

### After this patch behavior:

It'll be saved with "modified" == 0 since changing the method doesn't set modified.

If the preset is applied to an image the module will use the "lensfun" method AND auto update the camera/lenses based on the current image since "modified" is 0.