### PR TITLE
imageio/rawspeed: always read additional exif tags

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1012,7 +1012,7 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
 
     if(_check_usercrop(exifData, img))
       {
-        img->flags |= DT_IMAGE_HAS_ADDITIONAL_DNG_TAGS;
+        img->flags |= DT_IMAGE_HAS_ADDITIONAL_EXIF_TAGS;
         guint tagid = 0;
         char tagname[64];
         snprintf(tagname, sizeof(tagname), "darktable|mode|exif-crop");
@@ -1022,12 +1022,12 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
 
     if(_check_dng_opcodes(exifData, img))
     {
-      img->flags |= DT_IMAGE_HAS_ADDITIONAL_DNG_TAGS;
+      img->flags |= DT_IMAGE_HAS_ADDITIONAL_EXIF_TAGS;
     }
 
     if(_check_lens_correction_data(exifData, img))
     {
-      img->flags |= DT_IMAGE_HAS_ADDITIONAL_DNG_TAGS;
+      img->flags |= DT_IMAGE_HAS_ADDITIONAL_EXIF_TAGS;
     }
 
     /*

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -86,7 +86,7 @@ typedef enum
   DT_IMAGE_MONOCHROME = 32768,
   // DNG image has exif tags which are not cached in the database but must be read and stored in dt_image_t
   // when the image is loaded.
-  DT_IMAGE_HAS_ADDITIONAL_DNG_TAGS = 65536,
+  DT_IMAGE_HAS_ADDITIONAL_EXIF_TAGS = 65536,
   // image is an sraw
   DT_IMAGE_S_RAW = 1 << 17,
   // image has a monochrome preview tested

--- a/src/common/imageio_rawspeed.cc
+++ b/src/common/imageio_rawspeed.cc
@@ -270,8 +270,7 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
       }
 
     // Get additional exif tags that are not cached in the database
-    if(img->flags & DT_IMAGE_HAS_ADDITIONAL_EXIF_TAGS)
-      dt_exif_img_check_additional_tags(img, filename);
+    dt_exif_img_check_additional_tags(img, filename);
 
     if(r->getDataType() == TYPE_FLOAT32)
     {

--- a/src/common/imageio_rawspeed.cc
+++ b/src/common/imageio_rawspeed.cc
@@ -270,7 +270,7 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
       }
 
     // Get additional exif tags that are not cached in the database
-    if(img->flags & DT_IMAGE_HAS_ADDITIONAL_DNG_TAGS)
+    if(img->flags & DT_IMAGE_HAS_ADDITIONAL_EXIF_TAGS)
       dt_exif_img_check_additional_tags(img, filename);
 
     if(r->getDataType() == TYPE_FLOAT32)


### PR DESCRIPTION
* Rename `DT_IMAGE_HAS_ADDITIONAL_DNG_TAGS` to `DT_IMAGE_HAS_ADDITIONAL_EXIF_TAGS` (cosmetic change)

* Always read additional exif tags instead of relying on the img flag `DT_IMAGE_HAS_ADDITIONAL_EXIF_TAGS`.

@TurboGit With this change there's no other code that has logic based on `DT_IMAGE_HAS_ADDITIONAL_EXIF_TAGS`.
I kept the flag anyway since removing will require many changes if we want to reuse this bit for other purposes.

Fixes #12804 

On my system (that is quite fast) I don't see any visible performance penalty also with images stored on my NAS on my local network.

I tried to collect some timing data on the call to method `dt_exif_img_check_additional_tags` and `dt_imageio_open_rawspeed ` (that also contains the time used by `dt_exif_img_check_additional_tags`), cleaning the os caches before opening them:

### local SSD

```
dt_exif_img_check_additional_tags took 0.015 secs (0.001 CPU)
dt_imageio_open_rawspeed took 0.066 secs (0.021 CPU)
```

```
dt_exif_img_check_additional_tags took 0.014 secs (0.000 CPU)
dt_imageio_open_rawspeed took 0.084 secs (0.044 CPU)
```

### NAS

```
dt_exif_img_check_additional_tags took 0.011 secs (0.000 CPU)
dt_imageio_open_rawspeed took 0.203 secs (1.039 CPU)
```

```
dt_exif_img_check_additional_tags took 0.012 secs (0.005 CPU)
dt_imageio_open_rawspeed took 0.184 secs (0.927 CPU)
```

looks like `dt_exif_img_check_additional_tags` isn't i/o bound (probably due to the fact that the exif part is already being read by rawspeed and so is in os buffer cache).

`dt_exif_img_check_additional_tags` has a fixed contribution to the total time used by `dt_imageio_open_rawspeed`




