### PR TITLE
add menu to filters topbar

### DIFF
--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -974,8 +974,7 @@ static void _rule_populate_prop_combo(dt_lib_filtering_rule_t *rule)
   if(rule->topbar)
   {
     _rule_populate_prop_combo_add(w, rule->prop);
-    gtk_widget_set_tooltip_text(w,
-                                _("rule property\nthis can't be changed as the rule is pinned into the toolbar"));
+    gtk_widget_set_tooltip_text(w, _("rule property\nthis can't be changed as the rule is pinned to the toolbar"));
     rule->manual_widget_set++;
     dt_bauhaus_combobox_set_from_value(rule->w_prop, rule->prop);
     rule->manual_widget_set--;
@@ -1049,13 +1048,13 @@ static void _widget_header_update(dt_lib_filtering_rule_t *rule)
 
   if(rule->topbar)
   {
-    gtk_widget_set_tooltip_text(rule->w_pin, _("this rule is pinned into the top toolbar\nclick to un-pin"));
-    gtk_widget_set_tooltip_text(rule->w_off, _("you can't disable the rule as it is pinned into the toolbar"));
-    gtk_widget_set_tooltip_text(rule->w_close, _("you can't remove the rule as it is pinned into the toolbar"));
+    gtk_widget_set_tooltip_text(rule->w_pin, _("this rule is pinned to the top toolbar\nclick to un-pin"));
+    gtk_widget_set_tooltip_text(rule->w_off, _("you can't disable the rule as it is pinned to the toolbar"));
+    gtk_widget_set_tooltip_text(rule->w_close, _("you can't remove the rule as it is pinned to the toolbar"));
   }
   else
   {
-    gtk_widget_set_tooltip_text(rule->w_pin, _("click to pin this rule into the top toolbar"));
+    gtk_widget_set_tooltip_text(rule->w_pin, _("click to pin this rule to the top toolbar"));
     gtk_widget_set_tooltip_text(rule->w_close, _("remove this collect rule"));
     if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(rule->w_off)))
       gtk_widget_set_tooltip_text(rule->w_off, _("this rule is enabled"));
@@ -1658,7 +1657,7 @@ static void _topbar_show_pref_menu(dt_lib_module_t *self, GtkWidget *bt)
   gtk_container_add(GTK_CONTAINER(pop), vbox);
 
   // fill the popover with all pinned rules
-  GtkWidget *lb = gtk_label_new(_("Shown filters"));
+  GtkWidget *lb = gtk_label_new(_("shown filters"));
   dt_gui_add_class(lb, "dt_section_label");
   gtk_box_pack_start(GTK_BOX(vbox), lb, TRUE, TRUE, 0);
 
@@ -1958,7 +1957,7 @@ static void _sort_gui_update(dt_lib_module_t *self)
     if(_sort_init(&d->sort[i], sort, sortorder, i, self))
       gtk_grid_attach(GTK_GRID(d->sort_box), d->sort[i].box, 1, i, 1, 1);
 
-    // we also put the first sort item into the topbar
+    // we also put the first sort item to the topbar
     if(i == 0)
     {
       d->sorttop.top = TRUE;

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -86,6 +86,12 @@ static GtkWidget *_lib_filter_get_count(dt_lib_module_t *self)
   return d->count;
 }
 
+static gboolean _pref_show(GtkWidget *widget, GdkEventButton *event, dt_lib_module_t *self)
+{
+  dt_view_filtering_show_pref_menu(darktable.view_manager, widget);
+  return TRUE;
+}
+
 void gui_init(dt_lib_module_t *self)
 {
   /* initialize ui widgets */
@@ -94,6 +100,11 @@ void gui_init(dt_lib_module_t *self)
 
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_widget_set_valign(self->widget, GTK_ALIGN_CENTER);
+
+  GtkWidget *bt = dtgtk_button_new(dtgtk_cairo_paint_presets, 0, NULL);
+  gtk_widget_set_tooltip_text(bt, _("filters preferences"));
+  g_signal_connect(G_OBJECT(bt), "button-press-event", G_CALLBACK(_pref_show), self);
+  gtk_box_pack_start(GTK_BOX(self->widget), bt, FALSE, TRUE, 0);
 
   d->filter_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_widget_set_name(d->filter_box, "header-rule-box");

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -935,6 +935,12 @@ void dt_view_filtering_reset(const dt_view_manager_t *vm, gboolean smart_filter)
     vm->proxy.module_filtering.reset_filter(vm->proxy.module_filtering.module, smart_filter);
 }
 
+void dt_view_filtering_show_pref_menu(const dt_view_manager_t *vm, GtkWidget *bt)
+{
+  if(vm->proxy.module_filtering.module && vm->proxy.module_filtering.show_pref_menu)
+    vm->proxy.module_filtering.show_pref_menu(vm->proxy.module_filtering.module, bt);
+}
+
 GtkWidget *dt_view_filter_get_filters_box(const dt_view_manager_t *vm)
 {
   if(vm->proxy.filter.module && vm->proxy.filter.get_filter_box)

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -282,6 +282,7 @@ typedef struct dt_view_manager_t
       void (*update)(struct dt_lib_module_t *);
       void (*set_sort)(struct dt_lib_module_t *, int sort, gboolean asc);
       void (*reset_filter)(struct dt_lib_module_t *, gboolean smart_filter);
+      void (*show_pref_menu)(struct dt_lib_module_t *, GtkWidget *bt);
     } module_filtering;
 
     /* filmstrip proxy object */
@@ -424,6 +425,7 @@ void dt_view_collection_update_history_state(const dt_view_manager_t *vm);
  * Filter dropdown proxy
  */
 void dt_view_filtering_reset(const dt_view_manager_t *vm, gboolean smart_filter);
+void dt_view_filtering_show_pref_menu(const dt_view_manager_t *vm, GtkWidget *bt);
 GtkWidget *dt_view_filter_get_filters_box(const dt_view_manager_t *vm);
 GtkWidget *dt_view_filter_get_sort_box(const dt_view_manager_t *vm);
 GtkWidget *dt_view_filter_get_count(const dt_view_manager_t *vm);


### PR DESCRIPTION
[Second try with "only" the menu for reference, first try is here : #12799]
As promised, here is a implementation of what as been discussed in pixl.us about the evolution of the filtering system. (thanks to all contributor for the respectful and constructive discussion !)
For reference, here are the threads :
https://discuss.pixls.us/t/discussion-around-collection-filters-improvements/32489
https://discuss.pixls.us/t/discussion-around-new-filters-widgets/32490
https://discuss.pixls.us/t/collection-filters-proposals/32995

Following the last one, this PR implement following changes :

- add an "hamburger menu in the topbar, to add-remove filters
- remove the date-time filters from the topbar : they are way to small to be useful

This changes (corresponding to points 2-3 from pixl.us thread) are the first "pack" of planned filtering system enhancement.

Thanks all for your tests, reviews...