### PR TITLE
request natural instead of fixed side panel width

### DIFF
--- a/src/dtgtk/sidepanel.c
+++ b/src/dtgtk/sidepanel.c
@@ -18,6 +18,7 @@
 
 #include "dtgtk/sidepanel.h"
 #include "develop/imageop.h"
+#include "gui/gtk.h"
 
 #include <gtk/gtk.h>
 
@@ -30,9 +31,13 @@ static GtkSizeRequestMode dtgtk_side_panel_get_request_mode(GtkWidget *widget)
 
 static void dtgtk_side_panel_get_preferred_width(GtkWidget *widget, gint *minimum_size, gint *natural_size)
 {
-  GTK_WIDGET_CLASS(dtgtk_side_panel_parent_class)->get_preferred_width(widget, minimum_size, NULL);
+  GTK_WIDGET_CLASS(dtgtk_side_panel_parent_class)->get_preferred_width(widget, minimum_size, natural_size);
 
-  *natural_size = *minimum_size;
+  const int width = dt_ui_panel_get_size(darktable.gui->ui, strcmp(gtk_widget_get_name(widget), "right")
+                                                          ? DT_UI_PANEL_LEFT : DT_UI_PANEL_RIGHT);
+
+  if(width > 10)
+    *natural_size = MAX(*minimum_size, width);
 }
 
 static void dtgtk_side_panel_class_init(GtkDarktableSidePanelClass *class)


### PR DESCRIPTION
fixes #12855, alternative to #12856

The side panels now request a customizable _natural_ size, rather than using `gtk_widget_set_size_request` to request a _fixed_ size. This means that if there is not enough space in the window, the panels will get scaled down to fit. This _should_ resolve any issues from opening on a lower res screen than where the panel widths were set or opening a side panel that was hidden when the opposite panels width was set to the maximum. In both those cases the size of the window would previously have been forced to increase, potentially pushing its borders off the screen.

If there is _no_ width set yet, this defaults to the _natural_ width of the panels contents, meaning no widgets would get ellipsized, even when changing font size for example, unless the window itself isn't large enough. This _does_ mean that if the contents of the panel changes (for example by switching module groups) it could resize itself. This behavior can be switched off by dragging the panel handle to "set" (advice, really) a specific size (which is still limited by the _minimum_ width of the panel contents).

If a specific size has been set but the user wants the automatic/default scaling back, they can simply drag the handle all the way "down" (make width "0") at which point it snaps back to natural size.

@TurboGit I haven't encountered any problems with this, but can't test the tethering view.