### PR TITLE
Fix HLR tiling unavailable for inpaint opposed too

### DIFF
--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -2146,7 +2146,9 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 
   // no OpenCL for DT_IOP_HIGHLIGHTS_INPAINT or DT_IOP_HIGHLIGHTS_SEGMENTS and DT_IOP_HIGHLIGHTS_OPPOSED
   piece->process_cl_ready = ((d->mode == DT_IOP_HIGHLIGHTS_INPAINT) || (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS) || (d->mode == DT_IOP_HIGHLIGHTS_OPPOSED)) ? 0 : 1;
-  if(d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS) piece->process_tiling_ready = 0;
+
+  if((d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS) || (d->mode == DT_IOP_HIGHLIGHTS_OPPOSED))
+    piece->process_tiling_ready = 0;
 
   dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
   if(g)
@@ -2158,8 +2160,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   }
   // check for heavy computing here to give an iop cache hint
   const gboolean heavy = (((d->mode == DT_IOP_HIGHLIGHTS_LAPLACIAN) && ((d->iterations * 1<<(2+d->scales)) >= 256))
-                          || (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS)
-                          || (d->mode == DT_IOP_HIGHLIGHTS_OPPOSED));
+                        || (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS));
   self->cache_next_important = heavy;
 }
 

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -241,7 +241,7 @@ static float *_process_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
 
   const size_t pwidth  = dt_round_size(roi_in->width / 3, 2) + 2 * HL_BORDER;
   const size_t pheight = dt_round_size(roi_in->height / 3, 2) + 2 * HL_BORDER;
-  const size_t p_size = (size_t) dt_round_size(pwidth * pheight, 16);
+  const size_t p_size = (size_t) dt_round_size((size_t) (pwidth + 4) * (pheight + 4), 16);
 
   int *mask_buffer = dt_calloc_align(64, 4 * p_size * sizeof(int));
   float *tmpout = dt_alloc_align_float(roi_in->width * roi_in->height);


### PR DESCRIPTION
1. We can't tile in inpaint opposed as in segmentation mode
2. For inpaint opposed it's not worth to do an important cache hint so less polling of the cache
3. make sure the tmp buffer has same size in opposed and segmentation

I got those while testing and re-reading the full sources because of the reported issue #12864

I don't think these are related
1. tiling requirements are very low so can't imagine this to be a problem
2. I can't think of 3 to be a problem but no real hurt to do so

but nevertheless corrections.