### PR TITLE
PNM loader fixes

### DIFF
--- a/src/common/imageio_pnm.c
+++ b/src/common/imageio_pnm.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2018-2021 darktable developers.
+    Copyright (C) 2018-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -196,7 +196,8 @@ dt_imageio_retval_t dt_imageio_open_pnm(dt_image_t *img, const char *filename, d
 {
   const char *ext = filename + strlen(filename);
   while(*ext != '.' && ext > filename) ext--;
-  if(strcasecmp(ext, ".pbm") && strcasecmp(ext, ".pgm") && strcasecmp(ext, ".ppm")) return DT_IMAGEIO_FILE_CORRUPTED;
+  if(strcasecmp(ext, ".pbm") && strcasecmp(ext, ".pgm") && strcasecmp(ext, ".pnm") && strcasecmp(ext, ".ppm"))
+    return DT_IMAGEIO_FILE_CORRUPTED;
   FILE *f = g_fopen(filename, "rb");
   if(!f) return DT_IMAGEIO_FILE_CORRUPTED;
   int ret = 0;

--- a/src/common/imageio_pnm.c
+++ b/src/common/imageio_pnm.c
@@ -73,8 +73,13 @@ static dt_imageio_retval_t _read_pgm(dt_image_t *img, FILE*f, float *buf)
   dt_imageio_retval_t result = DT_IMAGEIO_OK;
 
   unsigned int max;
-  int ret = fscanf(f, "%u", &max);
-  if(ret != 1 || max > 65535) return DT_IMAGEIO_FILE_CORRUPTED;
+  // We expect at most a 5-digit number (65535) + a newline + '\0', so 7 characters.
+  char maxvalue_string[7];
+  if(fgets(maxvalue_string,7,f))
+    max = atoi(maxvalue_string);
+  else
+    return DT_IMAGEIO_FILE_CORRUPTED;
+  if(max == 0 || max > 65535) return DT_IMAGEIO_FILE_CORRUPTED;
 
   if(max <= 255)
   {

--- a/src/common/imageio_pnm.c
+++ b/src/common/imageio_pnm.c
@@ -133,8 +133,13 @@ static dt_imageio_retval_t _read_ppm(dt_image_t *img, FILE*f, float *buf)
   dt_imageio_retval_t result = DT_IMAGEIO_OK;
 
   unsigned int max;
-  int ret = fscanf(f, "%u", &max);
-  if(ret != 1 || max > 65535) return DT_IMAGEIO_FILE_CORRUPTED;
+  // We expect at most a 5-digit number (65535) + a newline + '\0', so 7 characters.
+  char maxvalue_string[7];
+  if(fgets(maxvalue_string,7,f))
+    max = atoi(maxvalue_string);
+  else
+    return DT_IMAGEIO_FILE_CORRUPTED;
+  if(max == 0 || max > 65535) return DT_IMAGEIO_FILE_CORRUPTED;
 
   if(max <= 255)
   {


### PR DESCRIPTION
I started testing the image loaders in dt on various samples of different image formats in order to find bugs. Regarding PNM, it turned out that the loader of this format mistakenly read the newline character as the value of the image data, which caused the RGB channels to shift when reading.

To reproduce the bug:

- Create solid color images in PNM format, for example like this:
```
magick convert -size 8x8 -depth 8 xc:red red.ppm
magick convert -size 8x8 -depth 8 xc:green green.ppm
magick convert -size 8x8 -depth 8 xc:blue blue.ppm
```
- Import them and observe that the colors of the imported images do not correspond to the real ones.

Also, in this PR, the `.pnm` file extension has been added to the list of extensions handled by the loader. Before this, this file extension was processed by the IM/GM fallback loader.