### PR TITLE
Fixing $(FOLDER.PICTURES) incorrect name

### DIFF
--- a/src/gui/gtkentry.c
+++ b/src/gui/gtkentry.c
@@ -233,7 +233,7 @@ const dt_gtkentry_completion_spec *dt_gtkentry_get_default_path_compl_list()
           { "PUBLISHER", N_("$(PUBLISHER) - publisher from metadata") },
           { "RIGHTS", N_("$(RIGHTS) - rights from metadata") },
           { "USERNAME", N_("$(USERNAME) - login name") },
-          { "FOLDER.PICTURE", N_("$(FOLDER.PICTURES) - pictures folder") },
+          { "FOLDER.PICTURES", N_("$(FOLDER.PICTURES) - pictures folder") },
           { "FOLDER.HOME", N_("$(FOLDER.HOME) - home folder") },
           { "FOLDER.DESKTOP", N_("$(FOLDER.DESKTOP) - desktop folder") },
           { "OPENCL.ACTIVATED", N_("$(OPENCL.ACTIVATED) - whether OpenCL is activated") },


### PR DESCRIPTION
The path FOLDER.PICTURES was expanding incorrectly as FOLDER.PICTURE, which was causing the exported photos that used this to get exported incorrectly.