### PR TITLE
stop panel width jumping when search selects deprecated modules

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2536,6 +2536,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   {
     GtkWidget *lb = gtk_label_new(module->deprecated_msg());
     gtk_label_set_line_wrap(GTK_LABEL(lb), TRUE);
+    gtk_label_set_max_width_chars(GTK_LABEL(lb), 0); // don't propagate natural width
     gtk_label_set_xalign(GTK_LABEL(lb), 0.0);
     dt_gui_add_class(lb, "dt_warning");
     gtk_box_pack_start(GTK_BOX(iopw), lb, TRUE, TRUE, 0);


### PR DESCRIPTION
Don't consider the natural width of the long "deprecated" messages when calculating default panel width.

This reduces jumping of the panel while typing in the search box when no specific width has been set.

Fixes #12877 (or at least significantly reduces it).