### PR TITLE
Embedded dng lens corrections

### DIFF
--- a/src/common/dng_opcode.c
+++ b/src/common/dng_opcode.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2021 darktable developers.
+    Copyright (C) 2011-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -23,8 +23,10 @@
 #include "dng_opcode.h"
 
 #define OPCODE_ID_GAINMAP (9)
+#define OPCODE_ID_WARP_RECTILINEAR (1)
+#define OPCODE_ID_VIGNETTE_RADIAL (3)
 
-static double get_double(uint8_t *ptr)
+static double _get_double(uint8_t *ptr)
 {
   guint64 in;
   union {
@@ -36,7 +38,7 @@ static double get_double(uint8_t *ptr)
   return u.v;
 }
 
-static float get_float(uint8_t *ptr)
+static float _get_float(uint8_t *ptr)
 {
   guint32 in;
   union {
@@ -48,7 +50,7 @@ static float get_float(uint8_t *ptr)
   return u.v;
 }
 
-static uint32_t get_long(uint8_t *ptr)
+static uint32_t _get_long(uint8_t *ptr)
 {
   uint32_t in;
   memcpy(&in, ptr, sizeof(in));
@@ -60,13 +62,13 @@ void dt_dng_opcode_process_opcode_list_2(uint8_t *buf, uint32_t buf_size, dt_ima
   g_list_free_full(img->dng_gain_maps, g_free);
   img->dng_gain_maps = NULL;
 
-  uint32_t count = get_long(&buf[0]);
+  uint32_t count = _get_long(&buf[0]);
   uint32_t offset = 4;
   while(count > 0)
   {
-    uint32_t opcode_id = get_long(&buf[offset]);
-    uint32_t flags = get_long(&buf[offset + 8]);
-    uint32_t param_size = get_long(&buf[offset + 12]);
+    uint32_t opcode_id = _get_long(&buf[offset]);
+    uint32_t flags = _get_long(&buf[offset + 8]);
+    uint32_t param_size = _get_long(&buf[offset + 12]);
     uint8_t *param = &buf[offset + 16];
 
     if(offset + 16 + param_size > buf_size)
@@ -79,29 +81,95 @@ void dt_dng_opcode_process_opcode_list_2(uint8_t *buf, uint32_t buf_size, dt_ima
     {
       uint32_t gain_count = (param_size - 76) / 4;
       dt_dng_gain_map_t *gm = g_malloc(sizeof(dt_dng_gain_map_t) + gain_count * sizeof(float));
-      gm->top = get_long(&param[0]);
-      gm->left = get_long(&param[4]);
-      gm->bottom = get_long(&param[8]);
-      gm->right = get_long(&param[12]);
-      gm->plane = get_long(&param[16]);
-      gm->planes = get_long(&param[20]);
-      gm->row_pitch = get_long(&param[24]);
-      gm->col_pitch = get_long(&param[28]);
-      gm->map_points_v = get_long(&param[32]);
-      gm->map_points_h = get_long(&param[36]);
-      gm->map_spacing_v = get_double(&param[40]);
-      gm->map_spacing_h = get_double(&param[48]);
-      gm->map_origin_v = get_double(&param[56]);
-      gm->map_origin_h = get_double(&param[64]);
-      gm->map_planes = get_long(&param[72]);
+      gm->top = _get_long(&param[0]);
+      gm->left = _get_long(&param[4]);
+      gm->bottom = _get_long(&param[8]);
+      gm->right = _get_long(&param[12]);
+      gm->plane = _get_long(&param[16]);
+      gm->planes = _get_long(&param[20]);
+      gm->row_pitch = _get_long(&param[24]);
+      gm->col_pitch = _get_long(&param[28]);
+      gm->map_points_v = _get_long(&param[32]);
+      gm->map_points_h = _get_long(&param[36]);
+      gm->map_spacing_v = _get_double(&param[40]);
+      gm->map_spacing_h = _get_double(&param[48]);
+      gm->map_origin_v = _get_double(&param[56]);
+      gm->map_origin_h = _get_double(&param[64]);
+      gm->map_planes = _get_long(&param[72]);
       for(int i = 0; i < gain_count; i++)
-        gm->map_gain[i] = get_float(&param[76 + 4*i]);
+        gm->map_gain[i] = _get_float(&param[76 + 4*i]);
 
       img->dng_gain_maps = g_list_append(img->dng_gain_maps, gm);
     }
     else
     {
       dt_print(DT_DEBUG_IMAGEIO, "[dng_opcode] OpcodeList2 has unsupported %s opcode %d\n",
+        flags & 1 ? "optional" : "mandatory", opcode_id);
+    }
+
+    offset += 16 + param_size;
+    count--;
+  }
+}
+
+void dt_dng_opcode_process_opcode_list_3(uint8_t *buf, uint32_t buf_size, dt_image_t *img)
+{
+  dt_image_correction_data_t *cd = &img->exif_correction_data;
+  cd->dng.has_warp = FALSE;
+  cd->dng.has_vignette = FALSE;
+
+  uint32_t count = _get_long(&buf[0]);
+  uint32_t offset = 4;
+  while(count > 0)
+  {
+    uint32_t opcode_id = _get_long(&buf[offset]);
+    uint32_t flags = _get_long(&buf[offset + 8]);
+    uint32_t param_size = _get_long(&buf[offset + 12]);
+    uint8_t *param = &buf[offset + 16];
+
+    if(offset + 16 + param_size > buf_size)
+    {
+      dt_print(DT_DEBUG_IMAGEIO, "[dng_opcode] Invalid opcode size in OpcodeList3\n");
+      return;
+    }
+
+    if(opcode_id == OPCODE_ID_WARP_RECTILINEAR)
+    {
+      const int planes = _get_long(&param[0]);
+      if((planes != 1) && (planes != 3))
+      {
+        dt_print(DT_DEBUG_IMAGEIO, "[OPCODE_ID_WARP_RECTILINEAR] Invalid number of planes %i\n", planes);
+        return;
+      }
+
+      cd->dng.planes = planes;
+      for(int p = 0; p < planes; p++)
+      {
+        for(int i = 0; i < 6; i++)
+          cd->dng.cwarp[p][i] = _get_double(&param[4 + 8 * (i + p*6)]);
+      }
+
+      for(int i = 0; i < 2; i++)
+        cd->dng.centre_warp[i] = _get_double(&param[4 + 8 * (i + planes * 6)]);
+
+      img->exif_correction_type = CORRECTION_TYPE_DNG;
+      cd->dng.has_warp = TRUE;
+    }
+
+    else if(opcode_id == OPCODE_ID_VIGNETTE_RADIAL)
+    {
+      for(int i = 0; i < 5; i++)
+        cd->dng.cvig[i] = _get_double(&param[8 * i]);
+      for(int i = 0; i < 2; i++)
+        cd->dng.centre_vig[i] = _get_double(&param[8 * (5 + i)]);
+
+      cd->dng.has_vignette = TRUE;
+      img->exif_correction_type = CORRECTION_TYPE_DNG;
+    }
+
+    else
+    {
+      dt_print(DT_DEBUG_IMAGEIO, "[dng_opcode] OpcodeList3 has unsupported %s opcode %d\n",
         flags & 1 ? "optional" : "mandatory", opcode_id);
     }
 

--- a/src/common/dng_opcode.h
+++ b/src/common/dng_opcode.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2021 darktable developers.
+    Copyright (C) 2011-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -42,3 +42,4 @@ typedef struct dt_dng_gain_map_t
 } dt_dng_gain_map_t;
 
 void dt_dng_opcode_process_opcode_list_2(uint8_t *buf, uint32_t size, dt_image_t *img);
+void dt_dng_opcode_process_opcode_list_3(uint8_t *buf, uint32_t size, dt_image_t *img);

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -204,7 +204,7 @@ static void _image_set_monochrome_flag(const int32_t imgid, gboolean monochrome,
     }
   }
   else
-    fprintf(stderr,"[image] could not dt_image_cache_get imgid %i\n", imgid);
+    dt_print(DT_DEBUG_ALWAYS,"[image_set_monochrome_flag] could not get imgid=%i from cache\n", imgid);
 }
 
 void dt_image_set_monochrome_flag(const int32_t imgid, gboolean monochrome)
@@ -1567,7 +1567,8 @@ static uint32_t _image_import_internal(const int32_t film_id, const char *filena
   DT_DEBUG_SQLITE3_BIND_INT64(stmt, 4, dt_datetime_now_to_gtimespan());
 
   rc = sqlite3_step(stmt);
-  if(rc != SQLITE_DONE) fprintf(stderr, "sqlite3 error %d\n", rc);
+  if(rc != SQLITE_DONE)
+    dt_print(DT_DEBUG_ALWAYS, "[image_import_internal] sqlite3 error %d in `%s`\n", rc, filename);
   sqlite3_finalize(stmt);
 
   id = dt_image_get_id(film_id, imgfname);
@@ -2011,7 +2012,7 @@ int32_t dt_image_rename(const int32_t imgid, const int32_t filmid, const gchar *
         moveStatus = g_file_move(cold, cnew, 0, NULL, NULL, NULL, &moveError);
         if(!moveStatus)
         {
-          fprintf(stderr, "[dt_image_rename] error moving local copy `%s' -> `%s'\n", copysrcpath, copydestpath);
+          dt_print(DT_DEBUG_ALWAYS, "[dt_image_rename] error moving local copy `%s' -> `%s'\n", copysrcpath, copydestpath);
 
           if(g_error_matches(moveError, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
           {
@@ -2344,7 +2345,7 @@ int32_t dt_image_copy_rename(const int32_t imgid, const int32_t filmid, const gc
     }
     else
     {
-      fprintf(stderr, "Failed to copy image %s: %s\n", srcpath, gerror->message);
+      dt_print(DT_DEBUG_ALWAYS, "[dt_image_copy_rename] Failed to copy image %s: %s\n", srcpath, gerror->message);
     }
     g_object_unref(dest);
     g_object_unref(src);

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -144,7 +144,8 @@ typedef enum dt_image_correction_type_t
 {
   CORRECTION_TYPE_NONE,
   CORRECTION_TYPE_SONY,
-  CORRECTION_TYPE_FUJI
+  CORRECTION_TYPE_FUJI,
+  CORRECTION_TYPE_DNG
 } dt_image_correction_type_t;
 
 typedef union dt_image_correction_data_t
@@ -158,6 +159,15 @@ typedef union dt_image_correction_data_t
     float cropf;
     float knots[9], distortion[9], ca_r[9], ca_b[9], vignetting[9];
   } fuji;
+  struct {
+    int planes;
+    float cwarp[3][6]; // for up to 3 planes warp rectilinear
+    float centre_warp[2];
+    float cvig[5];     // for vignetting
+    float centre_vig[2];
+    gboolean has_warp;
+    gboolean has_vignette;
+  } dng;
 } dt_image_correction_data_t;
 
 typedef enum dt_image_loader_t

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1,6 +1,6 @@
 ﻿/*
     This file is part of darktable,
-    Copyright (C) 2019-2022 darktable developers.
+    Copyright (C) 2019-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -108,7 +108,7 @@ typedef struct dt_iop_lens_params_t
   int modify_flags; // $DEFAULT: DT_IOP_LENS_MODFLAG_ALL $DESCRIPTION: "corrections"
 
   // NOTE: the options for lensfun and metadata correction methods should be
-  // kept separate since also if similar their value have different effects
+  // kept separate since also if similar their value have different effects.
   // additionally this could permit to switch between the methods.
   // the unique parameter in common is modify_flags
 
@@ -153,13 +153,12 @@ typedef struct dt_iop_lens_gui_data_t
   GtkWidget *modflags, *target_geom, *reverse, *tca_override, *tca_r, *tca_b, *scale;
   GtkWidget *find_lens_button;
   GtkWidget *find_camera_button;
-  GtkWidget *cor_dist_ft, *cor_vig_ft;
+  GtkWidget *cor_dist_ft, *cor_vig_ft, *cor_scale;
   GList *modifiers;
   GtkLabel *message;
   int corrections_done;
   gboolean lensfun_trouble;
   const lfCamera *camera;
-
 } dt_iop_lens_gui_data_t;
 
 
@@ -197,7 +196,6 @@ typedef struct dt_iop_lens_data_t
   float scale_md;
   int nc;
   float knots[MAXKNOTS], cor_rgb[3][MAXKNOTS], vig[MAXKNOTS];
-
 } dt_iop_lens_data_t;
 
 
@@ -319,10 +317,12 @@ static int _lenstype_from_lensfun_lenstype(lfLensType lt)
   }
 }
 
-int legacy_params(dt_iop_module_t *self,
-                  const void *const old_params, const int old_version,
-                  void *new_params,
-                  const int new_version)
+int legacy_params(
+        dt_iop_module_t *self,
+        const void *const old_params,
+        const int old_version,
+        void *new_params,
+        const int new_version)
 {
   if(old_version == 2 && new_version == 7)
   {
@@ -525,6 +525,7 @@ int legacy_params(dt_iop_module_t *self,
 
     return o->modified == 0 ? -1 : 0;
   }
+
   if(old_version == 6 && new_version == 7)
   {
     typedef struct
@@ -561,7 +562,12 @@ int legacy_params(dt_iop_module_t *self,
 }
 
 /* lensfun processing start */
-static lfModifier * _get_modifier(int *mods_done, int w, int h, const dt_iop_lens_data_t *d, int mods_filter, gboolean force_inverse)
+static lfModifier * _get_modifier(
+        int *mods_done,
+        int w,
+        int h,
+        const dt_iop_lens_data_t *d,
+        int mods_filter, gboolean force_inverse)
 {
   lfModifier *mod;
 
@@ -594,7 +600,10 @@ static lfModifier * _get_modifier(int *mods_done, int w, int h, const dt_iop_len
   return mod;
 }
 
-static float _get_autoscale_lf(dt_iop_module_t *self, dt_iop_lens_params_t *p, const lfCamera *camera)
+static float _get_autoscale_lf(
+        dt_iop_module_t *self,
+        dt_iop_lens_params_t *p,
+        const lfCamera *camera)
 {
   dt_iop_lens_global_data_t *gd = (dt_iop_lens_global_data_t *)self->global_data;
   lfDatabase *dt_iop_lensfun_db = (lfDatabase *)gd->db;
@@ -667,8 +676,13 @@ static float _get_autoscale_lf(dt_iop_module_t *self, dt_iop_lens_params_t *p, c
    As green / Y channel is the most centric i took that as the canonical value instead of taking the mean.
 */
 
-static void _process_lf(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
-             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+static void _process_lf(
+        dt_iop_module_t *self,
+        dt_dev_pixelpipe_iop_t *piece,
+        const void *const ivoid,
+        void *const ovoid,
+        const dt_iop_roi_t *const roi_in,
+        const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_lens_data_t *const d = (dt_iop_lens_data_t *)piece->data;
 
@@ -876,8 +890,12 @@ static void _process_lf(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, co
 }
 
 #ifdef HAVE_OPENCL
-static int _process_cl_lf(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+static int _process_cl_lf(
+        struct dt_iop_module_t *self,
+        dt_dev_pixelpipe_iop_t *piece,
+        cl_mem dev_in, cl_mem dev_out,
+        const dt_iop_roi_t *const roi_in,
+        const dt_iop_roi_t *const roi_out)
 {
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
   dt_iop_lens_global_data_t *gd = (dt_iop_lens_global_data_t *)self->global_data;
@@ -1115,9 +1133,12 @@ error:
 }
 #endif
 
-static void _tiling_callback_lf(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                     const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
-                     struct dt_develop_tiling_t *tiling)
+static void _tiling_callback_lf(
+        struct dt_iop_module_t *self,
+        struct dt_dev_pixelpipe_iop_t *piece,
+        const dt_iop_roi_t *roi_in,
+        const dt_iop_roi_t *roi_out,
+        struct dt_develop_tiling_t *tiling)
 {
   tiling->factor = 4.5f; // in + out + tmp + tmpbuf
   tiling->maxbuf = 1.5f;
@@ -1128,7 +1149,11 @@ static void _tiling_callback_lf(struct dt_iop_module_t *self, struct dt_dev_pixe
   return;
 }
 
-static int _distort_transform_lf(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *const __restrict points, size_t points_count)
+static int _distort_transform_lf(
+        dt_iop_module_t *self,
+        dt_dev_pixelpipe_iop_t *piece,
+        float *const __restrict points,
+        size_t points_count)
 {
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
   if(!d->lens || !d->lens->Maker || d->crop <= 0.0f) return 0;
@@ -1160,8 +1185,11 @@ static int _distort_transform_lf(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
   return 1;
 }
 
-static int _distort_backtransform_lf(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *const __restrict points,
-                          size_t points_count)
+static int _distort_backtransform_lf(
+        dt_iop_module_t *self,
+        dt_dev_pixelpipe_iop_t *piece,
+        float *const __restrict points,
+        size_t points_count)
 {
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
 
@@ -1195,8 +1223,13 @@ static int _distort_backtransform_lf(dt_iop_module_t *self, dt_dev_pixelpipe_iop
 }
 
 // TODO: Shall we keep LF_MODIFY_TCA in the modifiers?
-static void _distort_mask_lf(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const float *const in,
-                  float *const out, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+static void _distort_mask_lf(
+        struct dt_iop_module_t *self,
+        struct dt_dev_pixelpipe_iop_t *piece,
+        const float *const in,
+        float *const out,
+        const dt_iop_roi_t *const roi_in,
+        const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_lens_data_t *const d = (dt_iop_lens_data_t *)piece->data;
 
@@ -1260,8 +1293,11 @@ static void _distort_mask_lf(struct dt_iop_module_t *self, struct dt_dev_pixelpi
   delete modifier;
 }
 
-static void _modify_roi_in_lf(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                   const dt_iop_roi_t *const roi_out, dt_iop_roi_t *roi_in)
+static void _modify_roi_in_lf(
+        struct dt_iop_module_t *self,
+        struct dt_dev_pixelpipe_iop_t *piece,
+        const dt_iop_roi_t *const roi_out,
+        dt_iop_roi_t *roi_in)
 {
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
   *roi_in = *roi_out;
@@ -1365,8 +1401,11 @@ static void _modify_roi_in_lf(struct dt_iop_module_t *self, struct dt_dev_pixelp
   delete modifier;
 }
 
-static void _commit_params_lf(struct dt_iop_module_t *self, dt_iop_lens_params_t *p, dt_dev_pixelpipe_t *pipe,
-                   dt_dev_pixelpipe_iop_t *piece)
+static void _commit_params_lf(
+        struct dt_iop_module_t *self,
+        dt_iop_lens_params_t *p,
+        dt_dev_pixelpipe_t *pipe,
+        dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
   dt_iop_lens_gui_data_t *g = (dt_iop_lens_gui_data_t *)self->gui_data;
@@ -1504,8 +1543,13 @@ static float _interpolate_linear_spline(const float *xi, const float *yi, int ni
   return yi[ni - 1];
 }
 
-static int _init_coeffs_md(const dt_image_t *img, const dt_iop_lens_params_t *p, float scale,
-                       float knots[MAXKNOTS], float cor_rgb[3][MAXKNOTS], float vig[MAXKNOTS])
+static int _init_coeffs_md(
+        const dt_image_t *img,
+        const dt_iop_lens_params_t *p,
+        const float scale,
+        float knots[MAXKNOTS],
+        float cor_rgb[3][MAXKNOTS],
+        float vig[MAXKNOTS])
 {
   const dt_image_correction_data_t *cd = &img->exif_correction_data;
 
@@ -1562,27 +1606,84 @@ static int _init_coeffs_md(const dt_image_t *img, const dt_iop_lens_params_t *p,
     return nc;
   }
 
+  else if(img->exif_correction_type == CORRECTION_TYPE_DNG)
+  {
+    const int nc = MAXKNOTS;
+    for(int i = 0; i < nc; i++)
+    {
+      const float r = (float) i / (float) (nc-1);
+      knots[i] = r;
+      if(cor_rgb) cor_rgb[0][i] = cor_rgb[1][i] = cor_rgb[2][i] = 1.0f;
+      if(vig)     vig[i] = 1.0f;
+
+      const float pw2 = powf(r, 2.0f), pw4 = powf(r, 4.0f), pw6 = powf(r, 6.0f);
+      if(cor_rgb && cd->dng.has_warp && p->modify_flags & (DT_IOP_LENS_MODIFY_FLAG_DISTORTION | DT_IOP_LENS_MODIFY_FLAG_TCA))
+      {
+        // Convert the polynomial to a spline by evaluating it at each knot
+        for(int c = 0; c < cd->dng.planes; c++)
+        {
+          const float r_cor = cd->dng.cwarp[c][0] + cd->dng.cwarp[c][1]*pw2 + cd->dng.cwarp[c][2]*pw4 + cd->dng.cwarp[c][3]*pw6;
+          cor_rgb[c][i] = (p->cor_dist_ft * (r_cor - 1.0f) + 1.0f) * scale;
+        }
+
+        if(cd->dng.planes == 1)
+          cor_rgb[2][i] = cor_rgb[1][i] = cor_rgb[0][i];
+      }
+
+      if(vig && cd->dng.has_vignette && (p->modify_flags & DT_IOP_LENS_MODIFY_FLAG_VIGNETTING))
+      {
+        const float dvig = cd->dng.cvig[0]*pw2 + cd->dng.cvig[1]*pw4 + cd->dng.cvig[2]*pw6
+                         + cd->dng.cvig[3]*powf(r, 8.0f) + cd->dng.cvig[4]*powf(r, 10.0f);
+        // Pixel value is to be divided by (1 + dvig) to correct vignetting
+        // Scale dvig according to fine-tune: 0 for no correction, 1 for
+        // correction specified by metadata, and 2 to double the correction.
+        // Store the square root since _process_md will square the value
+        vig[i] = sqrtf(1.0f / (1.0f + p->cor_vig_ft * dvig)); 
+      }
+    }
+    return nc;
+  }
+
   return 0;
 }
 
 static float _get_autoscale_md(dt_iop_module_t *self, dt_iop_lens_params_t *p)
 {
   const dt_image_t *img = &(self->dev->image_storage);
+  if(img->exif_correction_type == CORRECTION_TYPE_DNG)
+    return 1.0f;
+
+  const float tested = 200.0f;
 
   float knots[MAXKNOTS], cor_rgb[3][MAXKNOTS];
   // Default the scale to one for the benefit of init_coeffs
-  int nc = _init_coeffs_md(img, p, 1, knots, cor_rgb, NULL);
 
+  const int nc = _init_coeffs_md(img, p, 1.0f, knots, cor_rgb, NULL);
   // Compute the new scale
-  float scale = 0;
-  for(int i = 0; i < 200; i++)
+  float scale = 0.0f;
+  for(float i = 0.0f; i < tested; i++)
+  {
     for(int j = 0; j < 3; j++)
-      scale = MAX(scale, _interpolate_linear_spline(knots, cor_rgb[j], nc, 0.5 + 0.5*i/(200 - 1)));
-
-  return 1 / scale;
+      scale = fmaxf(scale, _interpolate_linear_spline(knots, cor_rgb[j], nc, 0.5f + 0.5f * i / (tested - 1.0f)));
+  }
+  return scale;
 }
 
-static void _commit_params_md(dt_iop_module_t *self, dt_iop_lens_params_t *p, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+static void _autoscale_pressed_md(GtkWidget *button, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  dt_iop_lens_gui_data_t *g = (dt_iop_lens_gui_data_t *)self->gui_data;
+  dt_iop_lens_params_t *p = (dt_iop_lens_params_t *)self->params;
+
+  const float scale = _get_autoscale_md(self, p);
+  dt_bauhaus_slider_set(g->cor_scale, scale);
+}
+
+static void _commit_params_md(
+        dt_iop_module_t *self,
+        dt_iop_lens_params_t *p,
+        dt_dev_pixelpipe_t *pipe,
+        dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
   dt_iop_lens_gui_data_t *g = (dt_iop_lens_gui_data_t *)self->gui_data;
@@ -1599,11 +1700,10 @@ static void _commit_params_md(dt_iop_module_t *self, dt_iop_lens_params_t *p, dt
   d->cor_dist_ft = p->cor_dist_ft;
   d->cor_vig_ft = p->cor_vig_ft;
 
-  // calculate auto scale
-  d->scale_md = _get_autoscale_md(self, p);
-
-  int nc = _init_coeffs_md(img, p, d->scale_md, d->knots, d->cor_rgb, d->vig);
-  d->nc = nc;
+  d->scale_md = p->cor_scale;
+  if((d->scale_md < 0.9f) || (d->scale_md > 1.1f)) // enforce an autoscale if unproper data
+    d->scale_md = _get_autoscale_md(self, p);
+  d->nc = _init_coeffs_md(img, p, 1.0f / d->scale_md, d->knots, d->cor_rgb, d->vig);
 
   if(self->dev->gui_attached && g && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
   {
@@ -1613,9 +1713,12 @@ static void _commit_params_md(dt_iop_module_t *self, dt_iop_lens_params_t *p, dt
   }
 }
 
-static void _tiling_callback_md(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                     const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
-                     struct dt_develop_tiling_t *tiling)
+static void _tiling_callback_md(
+        struct dt_iop_module_t *self,
+        struct dt_dev_pixelpipe_iop_t *piece,
+        const dt_iop_roi_t *roi_in,
+        const dt_iop_roi_t *roi_out,
+        struct dt_develop_tiling_t *tiling)
 {
   tiling->factor = 4.5f; // in + out + tmp + tmpbuf
   tiling->maxbuf = 1.5f;
@@ -1625,7 +1728,11 @@ static void _tiling_callback_md(struct dt_iop_module_t *self, struct dt_dev_pixe
   tiling->yalign = 1;
 }
 
-static int _distort_transform_md(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *points, size_t points_count)
+static int _distort_transform_md(
+        dt_iop_module_t *self,
+        dt_dev_pixelpipe_iop_t *piece,
+        float *points,
+        size_t points_count)
 {
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
 
@@ -1660,7 +1767,11 @@ static int _distort_transform_md(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
   return 1;
 }
 
-static int _distort_backtransform_md(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *points, size_t points_count)
+static int _distort_backtransform_md(
+        dt_iop_module_t *self,
+        dt_dev_pixelpipe_iop_t *piece,
+        float *points,
+        size_t points_count)
 {
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
 
@@ -1682,8 +1793,13 @@ static int _distort_backtransform_md(dt_iop_module_t *self, dt_dev_pixelpipe_iop
   return 1;
 }
 
-static void _distort_mask_md(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const float *const in,
-                  float *const out, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+static void _distort_mask_md(
+        struct dt_iop_module_t *self,
+        struct dt_dev_pixelpipe_iop_t *piece,
+        const float *const in,
+        float *const out,
+        const dt_iop_roi_t *const roi_in,
+        const dt_iop_roi_t *const roi_out)
 {
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
 
@@ -1716,8 +1832,13 @@ static void _distort_mask_md(struct dt_iop_module_t *self, struct dt_dev_pixelpi
   }
 }
 
-static void _process_md(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
-             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+static void _process_md(
+        struct dt_iop_module_t *self,
+        dt_dev_pixelpipe_iop_t *piece,
+        const void *const ivoid,
+        void *const ovoid,
+        const dt_iop_roi_t *const roi_in,
+        const dt_iop_roi_t *const roi_out)
 {
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
 
@@ -1730,7 +1851,7 @@ static void _process_md(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
   const int ch_width = ch * roi_in->width;
   const float w2 = 0.5f * roi_in->scale * piece->buf_in.width;
   const float h2 = 0.5f * roi_in->scale * piece->buf_in.height;
-  const float r = 1 / sqrtf(w2*w2 + h2*h2);
+  const float r = 1.0f / sqrtf(w2*w2 + h2*h2);
 
   const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
 
@@ -1782,8 +1903,11 @@ static void _process_md(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
   dt_free_align(buf);
 }
 
-static void _modify_roi_in_md(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                   const dt_iop_roi_t *const roi_out, dt_iop_roi_t *roi_in)
+static void _modify_roi_in_md(
+        struct dt_iop_module_t *self,
+        struct dt_dev_pixelpipe_iop_t *piece,
+        const dt_iop_roi_t *const roi_out,
+        dt_iop_roi_t *roi_in)
 {
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
 
@@ -1795,8 +1919,9 @@ static void _modify_roi_in_md(struct dt_iop_module_t *self, struct dt_dev_pixelp
 
   const float orig_w = roi_in->scale * piece->buf_in.width;
   const float orig_h = roi_in->scale * piece->buf_in.height;
-  const float w2 = 0.5f * orig_w, h2 = 0.5f * orig_h;
-  const float r = 1 / sqrtf(w2*w2 + h2*h2);
+  const float w2 = 0.5f * orig_w;
+  const float h2 = 0.5f * orig_h;
+  const float r = 1.0f / sqrtf(w2*w2 + h2*h2);
 
   const int xoff = roi_in->x, yoff = roi_in->y;
   const int width = roi_in->width, height = roi_in->height;
@@ -1841,8 +1966,13 @@ static void _modify_roi_in_md(struct dt_iop_module_t *self, struct dt_dev_pixelp
 }
 /* embedded metadata processing end */
 
-void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
-             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+void process(
+        dt_iop_module_t *self,
+        dt_dev_pixelpipe_iop_t *piece,
+        const void *const ivoid,
+        void *const ovoid,
+        const dt_iop_roi_t *const roi_in,
+        const dt_iop_roi_t *const roi_out)
 {
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
 
@@ -1858,17 +1988,25 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
 
 #ifdef HAVE_OPENCL
-int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+int process_cl(
+        struct dt_iop_module_t *self,
+        dt_dev_pixelpipe_iop_t *piece,
+        cl_mem dev_in,
+        cl_mem dev_out,
+        const dt_iop_roi_t *const roi_in,
+        const dt_iop_roi_t *const roi_out)
 {
   // process_cl is called only for lensfun method
   return _process_cl_lf(self, piece, dev_in, dev_out, roi_in, roi_out);
 }
 #endif
 
-void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                     const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
-                     struct dt_develop_tiling_t *tiling)
+void tiling_callback(
+        struct dt_iop_module_t *self,
+        struct dt_dev_pixelpipe_iop_t *piece,
+        const dt_iop_roi_t *roi_in,
+        const dt_iop_roi_t *roi_out,
+        struct dt_develop_tiling_t *tiling)
 {
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
 
@@ -1882,7 +2020,11 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   }
 }
 
-int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *const __restrict points, size_t points_count)
+int distort_transform(
+        dt_iop_module_t *self,
+        dt_dev_pixelpipe_iop_t *piece,
+        float *const __restrict points,
+        size_t points_count)
 {
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
 
@@ -1896,8 +2038,11 @@ int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, floa
   }
 }
 
-int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *const __restrict points,
-                          size_t points_count)
+int distort_backtransform(
+        dt_iop_module_t *self,
+        dt_dev_pixelpipe_iop_t *piece,
+        float *const __restrict points,
+        size_t points_count)
 {
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
 
@@ -1911,8 +2056,13 @@ int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, 
   }
 }
 
-void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const float *const in,
-                  float *const out, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+void distort_mask(
+        struct dt_iop_module_t *self,
+        struct dt_dev_pixelpipe_iop_t *piece,
+        const float *const in,
+        float *const out,
+        const dt_iop_roi_t *const roi_in,
+        const dt_iop_roi_t *const roi_out)
 {
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
 
@@ -1926,8 +2076,11 @@ void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *p
   }
 }
 
-void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                   const dt_iop_roi_t *const roi_out, dt_iop_roi_t *roi_in)
+void modify_roi_in(
+        struct dt_iop_module_t *self,
+        struct dt_dev_pixelpipe_iop_t *piece,
+        const dt_iop_roi_t *const roi_out,
+        dt_iop_roi_t *roi_in)
 {
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
 
@@ -1942,7 +2095,9 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
 }
 
 // _get_method returns the method to use based on the provided preferred method and available methods.
-const dt_iop_lens_method_t _get_method(struct dt_iop_module_t *self, dt_iop_lens_method_t method)
+const dt_iop_lens_method_t _get_method(
+        struct dt_iop_module_t *self,
+        dt_iop_lens_method_t method)
 {
   // currently we have only two methods. If new methods will be added a default
   // order of fallback methods should be defined to keeps reproducibilty
@@ -1957,11 +2112,15 @@ const dt_iop_lens_method_t _get_method(struct dt_iop_module_t *self, dt_iop_lens
   return method;
 }
 
-void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
-                   dt_dev_pixelpipe_iop_t *piece)
+void commit_params(
+        struct dt_iop_module_t *self,
+        dt_iop_params_t *p1,
+        dt_dev_pixelpipe_t *pipe,
+        dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_lens_params_t *p = (dt_iop_lens_params_t *)p1;
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
+  // check ?  p->method = _get_method(self, method);
 
   d->method = p->method;
   d->modify_flags = p->modify_flags;
@@ -1980,12 +2139,18 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   }
 }
 
-void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+void init_pipe(
+        struct dt_iop_module_t *self,
+        dt_dev_pixelpipe_t *pipe,
+        dt_dev_pixelpipe_iop_t *piece)
 {
   piece->data = calloc(1, sizeof(dt_iop_lens_data_t));
 }
 
-void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+void cleanup_pipe(
+        struct dt_iop_module_t *self,
+        dt_dev_pixelpipe_t *pipe,
+        dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
 
@@ -2035,7 +2200,7 @@ void init_global(dt_iop_module_so_t *module)
     const long sysdbts = dt_iop_lensfun_db->ReadTimestamp(sysdbpath);
     const char *dbpath = userdbts > sysdbts ? dt_iop_lensfun_db->UserUpdatesLocation : sysdbpath;
     if(dt_iop_lensfun_db->Load(dbpath) != LF_NO_ERROR)
-      fprintf(stderr, "[iop_lens]: could not load lensfun database in `%s'!\n", dbpath);
+      dt_print(DT_DEBUG_ALWAYS, "[iop_lens]: could not load lensfun database in `%s'!\n", dbpath);
     else
       dt_iop_lensfun_db->Load(dt_iop_lensfun_db->UserLocation);
 #else
@@ -2045,12 +2210,12 @@ void init_global(dt_iop_module_so_t *module)
     dt_iop_lensfun_db->HomeDataDir = g_strdup(sysdbpath);
     if(dt_iop_lensfun_db->Load() != LF_NO_ERROR)
     {
-      fprintf(stderr, "[iop_lens]: could not load lensfun database in `%s'!\n", sysdbpath);
+      dt_print(DT_DEBUG_ALWAYS, "[iop_lens]: could not load lensfun database in `%s'!\n", sysdbpath);
 #endif
       g_free(dt_iop_lensfun_db->HomeDataDir);
       dt_iop_lensfun_db->HomeDataDir = g_build_filename(path, "lensfun", (char *)NULL);
       if(dt_iop_lensfun_db->Load() != LF_NO_ERROR)
-        fprintf(stderr, "[iop_lens]: could not load lensfun database in `%s'!\n", dt_iop_lensfun_db->HomeDataDir);
+        dt_print(DT_DEBUG_ALWAYS, "[iop_lens]: could not load lensfun database in `%s'!\n", dt_iop_lensfun_db->HomeDataDir);
 #ifdef LF_MAX_DATABASE_VERSION
     }
 #endif
@@ -2205,6 +2370,7 @@ void reload_defaults(dt_iop_module_t *module)
   {
     // prefer embedded metadata if available
     d->method = DT_IOP_LENS_METHOD_EMBEDDED_METADATA;
+    d->cor_scale = _get_autoscale_md(module, d);
   }
 
   dt_iop_lens_gui_data_t *g = (dt_iop_lens_gui_data_t *)module->gui_data;
@@ -2253,7 +2419,7 @@ void cleanup_global(dt_iop_module_so_t *module)
 /* simple function to compute the floating-point precision
    which is enough for "normal use". The criteria is to have
    about 3 leading digits after the initial zeros.  */
-static int precision(double x, double adj)
+static int _precision(double x, double adj)
 {
   x *= adj;
 
@@ -2277,7 +2443,10 @@ static int precision(double x, double adj)
 
 /* -- ufraw ptr array functions -- */
 
-static int ptr_array_insert_sorted(GPtrArray *array, const void *item, GCompareFunc compare)
+static int _ptr_array_insert_sorted(
+        GPtrArray *array,
+        const void *item,
+        GCompareFunc compare)
 {
   int length = array->len;
   g_ptr_array_set_size(array, length + 1);
@@ -2311,7 +2480,10 @@ done:
   return m;
 }
 
-static int ptr_array_find_sorted(const GPtrArray *array, const void *item, GCompareFunc compare)
+static int _ptr_array_find_sorted(
+        const GPtrArray *array,
+        const void *item,
+        GCompareFunc compare)
 {
   int length = array->len;
   void **root = array->pdata;
@@ -2340,7 +2512,10 @@ static int ptr_array_find_sorted(const GPtrArray *array, const void *item, GComp
   return -1;
 }
 
-static void ptr_array_insert_index(GPtrArray *array, const void *item, int index)
+static void _ptr_array_insert_index(
+        GPtrArray *array,
+        const void *item,
+        int index)
 {
   const void **root;
   int length = array->len;
@@ -2354,7 +2529,7 @@ static void ptr_array_insert_index(GPtrArray *array, const void *item, int index
 
 /* -- camera -- */
 
-static void camera_set(dt_iop_module_t *self, const lfCamera *cam)
+static void _camera_set(dt_iop_module_t *self, const lfCamera *cam)
 {
   dt_iop_lens_gui_data_t *g = (dt_iop_lens_gui_data_t *)self->gui_data;
   dt_iop_lens_params_t *p = (dt_iop_lens_params_t *)self->params;
@@ -2401,10 +2576,10 @@ static void camera_set(dt_iop_module_t *self, const lfCamera *cam)
   g_free(fm);
 }
 
-static void camera_menu_select(GtkMenuItem *menuitem, gpointer user_data)
+static void _camera_menu_select(GtkMenuItem *menuitem, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  camera_set(self, (lfCamera *)g_object_get_data(G_OBJECT(menuitem), "lfCamera"));
+  _camera_set(self, (lfCamera *)g_object_get_data(G_OBJECT(menuitem), "lfCamera"));
   if(darktable.gui->reset) return;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -2428,14 +2603,14 @@ static void camera_menu_fill(dt_iop_module_t *self, const lfCamera *const *camli
   {
     GtkWidget *submenu, *item;
     const char *m = lf_mlstr_get(camlist[i]->Maker);
-    int idx = ptr_array_find_sorted(makers, m, (GCompareFunc)g_utf8_collate);
+    int idx = _ptr_array_find_sorted(makers, m, (GCompareFunc)g_utf8_collate);
     if(idx < 0)
     {
       /* No such maker yet, insert it into the array */
-      idx = ptr_array_insert_sorted(makers, m, (GCompareFunc)g_utf8_collate);
+      idx = _ptr_array_insert_sorted(makers, m, (GCompareFunc)g_utf8_collate);
       /* Create a submenu for cameras by this maker */
       submenu = gtk_menu_new();
-      ptr_array_insert_index(submenus, submenu, idx);
+      _ptr_array_insert_index(submenus, submenu, idx);
     }
 
     submenu = (GtkWidget *)g_ptr_array_index(submenus, idx);
@@ -2451,7 +2626,7 @@ static void camera_menu_fill(dt_iop_module_t *self, const lfCamera *const *camli
     }
     gtk_widget_show(item);
     g_object_set_data(G_OBJECT(item), "lfCamera", (void *)camlist[i]);
-    g_signal_connect(G_OBJECT(item), "activate", G_CALLBACK(camera_menu_select), self);
+    g_signal_connect(G_OBJECT(item), "activate", G_CALLBACK(_camera_menu_select), self);
     gtk_menu_shell_append(GTK_MENU_SHELL(submenu), item);
   }
 
@@ -2468,7 +2643,7 @@ static void camera_menu_fill(dt_iop_module_t *self, const lfCamera *const *camli
   g_ptr_array_free(makers, TRUE);
 }
 
-static void parse_model(const char *txt, char *model, size_t sz_model)
+static void _parse_model(const char *txt, char *model, size_t sz_model)
 {
   while(txt[0] && isspace(txt[0])) txt++;
   size_t len = strlen(txt);
@@ -2477,7 +2652,7 @@ static void parse_model(const char *txt, char *model, size_t sz_model)
   model[len] = 0;
 }
 
-static void camera_menusearch_clicked(GtkWidget *button, gpointer user_data)
+static void _camera_menusearch_clicked(GtkWidget *button, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_lens_global_data_t *gd = (dt_iop_lens_global_data_t *)self->global_data;
@@ -2496,7 +2671,7 @@ static void camera_menusearch_clicked(GtkWidget *button, gpointer user_data)
   dt_gui_menu_popup(GTK_MENU(g->camera_menu), button, GDK_GRAVITY_SOUTH, GDK_GRAVITY_NORTH);
 }
 
-static void camera_autosearch_clicked(GtkWidget *button, gpointer user_data)
+static void _camera_autosearch_clicked(GtkWidget *button, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_lens_global_data_t *gd = (dt_iop_lens_global_data_t *)self->global_data;
@@ -2518,7 +2693,7 @@ static void camera_autosearch_clicked(GtkWidget *button, gpointer user_data)
   }
   else
   {
-    parse_model(txt, model, sizeof(model));
+    _parse_model(txt, model, sizeof(model));
     dt_pthread_mutex_lock(&darktable.plugin_threadsafe);
     const lfCamera **camlist = dt_iop_lensfun_db->FindCamerasExt(make, model, 0);
     dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
@@ -2532,7 +2707,7 @@ static void camera_autosearch_clicked(GtkWidget *button, gpointer user_data)
 
 /* -- end camera -- */
 
-static void lens_comboentry_focal_update(GtkWidget *widget, dt_iop_module_t *self)
+static void _lens_comboentry_focal_update(GtkWidget *widget, dt_iop_module_t *self)
 {
   dt_iop_lens_params_t *p = (dt_iop_lens_params_t *)self->params;
   const char *text = dt_bauhaus_combobox_get_text(widget);
@@ -2540,7 +2715,7 @@ static void lens_comboentry_focal_update(GtkWidget *widget, dt_iop_module_t *sel
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void lens_comboentry_aperture_update(GtkWidget *widget, dt_iop_module_t *self)
+static void _lens_comboentry_aperture_update(GtkWidget *widget, dt_iop_module_t *self)
 {
   dt_iop_lens_params_t *p = (dt_iop_lens_params_t *)self->params;
   const char *text = dt_bauhaus_combobox_get_text(widget);
@@ -2548,7 +2723,7 @@ static void lens_comboentry_aperture_update(GtkWidget *widget, dt_iop_module_t *
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void lens_comboentry_distance_update(GtkWidget *widget, dt_iop_module_t *self)
+static void _lens_comboentry_distance_update(GtkWidget *widget, dt_iop_module_t *self)
 {
   dt_iop_lens_params_t *p = (dt_iop_lens_params_t *)self->params;
   const char *text = dt_bauhaus_combobox_get_text(widget);
@@ -2556,13 +2731,13 @@ static void lens_comboentry_distance_update(GtkWidget *widget, dt_iop_module_t *
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void delete_children(GtkWidget *widget, gpointer data)
+static void _delete_children(GtkWidget *widget, gpointer data)
 {
   (void)data;
   gtk_widget_destroy(widget);
 }
 
-static void lens_set(dt_iop_module_t *self, const lfLens *lens)
+static void _lens_set(dt_iop_module_t *self, const lfLens *lens)
 {
   dt_iop_lens_gui_data_t *g = (dt_iop_lens_gui_data_t *)self->gui_data;
   dt_iop_lens_params_t *p = (dt_iop_lens_params_t *)self->params;
@@ -2652,7 +2827,7 @@ static void lens_set(dt_iop_module_t *self, const lfLens *lens)
   g_free(fm);
 
   /* Create the focal/aperture/distance combo boxes */
-  gtk_container_foreach(GTK_CONTAINER(g->lens_param_box), delete_children, NULL);
+  gtk_container_foreach(GTK_CONTAINER(g->lens_param_box), _delete_children, NULL);
 
   int ffi = 1, fli = -1;
   for(i = 1; i < sizeof(focal_values) / sizeof(gdouble) - 1; i++)
@@ -2680,14 +2855,14 @@ static void lens_set(dt_iop_module_t *self, const lfLens *lens)
   w = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(w, NULL, N_("mm"));
   gtk_widget_set_tooltip_text(w, _("focal length (mm)"));
-  snprintf(txt, sizeof(txt), "%.*f", precision(p->focal, 10.0), p->focal);
+  snprintf(txt, sizeof(txt), "%.*f", _precision(p->focal, 10.0), p->focal);
   dt_bauhaus_combobox_add(w, txt);
   for(int k = 0; k < fli - ffi; k++)
   {
-    snprintf(txt, sizeof(txt), "%.*f", precision(focal_values[ffi + k], 10.0), focal_values[ffi + k]);
+    snprintf(txt, sizeof(txt), "%.*f", _precision(focal_values[ffi + k], 10.0), focal_values[ffi + k]);
     dt_bauhaus_combobox_add(w, txt);
   }
-  g_signal_connect(G_OBJECT(w), "value-changed", G_CALLBACK(lens_comboentry_focal_update), self);
+  g_signal_connect(G_OBJECT(w), "value-changed", G_CALLBACK(_lens_comboentry_focal_update), self);
   gtk_box_pack_start(GTK_BOX(g->lens_param_box), w, TRUE, TRUE, 0);
   dt_bauhaus_combobox_set_editable(w, 1);
   g->cbe[0] = w;
@@ -2705,14 +2880,14 @@ static void lens_set(dt_iop_module_t *self, const lfLens *lens)
   w = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(w, NULL, N_("f/"));
   gtk_widget_set_tooltip_text(w, _("f-number (aperture)"));
-  snprintf(txt, sizeof(txt), "%.*f", precision(p->aperture, 10.0), p->aperture);
+  snprintf(txt, sizeof(txt), "%.*f", _precision(p->aperture, 10.0), p->aperture);
   dt_bauhaus_combobox_add(w, txt);
   for(int k = 0; k < fli - ffi; k++)
   {
-    snprintf(txt, sizeof(txt), "%.*f", precision(aperture_values[ffi + k], 10.0), aperture_values[ffi + k]);
+    snprintf(txt, sizeof(txt), "%.*f", _precision(aperture_values[ffi + k], 10.0), aperture_values[ffi + k]);
     dt_bauhaus_combobox_add(w, txt);
   }
-  g_signal_connect(G_OBJECT(w), "value-changed", G_CALLBACK(lens_comboentry_aperture_update), self);
+  g_signal_connect(G_OBJECT(w), "value-changed", G_CALLBACK(_lens_comboentry_aperture_update), self);
   gtk_box_pack_start(GTK_BOX(g->lens_param_box), w, TRUE, TRUE, 0);
   dt_bauhaus_combobox_set_editable(w, 1);
   g->cbe[1] = w;
@@ -2720,18 +2895,18 @@ static void lens_set(dt_iop_module_t *self, const lfLens *lens)
   w = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(w, NULL, N_("d"));
   gtk_widget_set_tooltip_text(w, _("distance to subject"));
-  snprintf(txt, sizeof(txt), "%.*f", precision(p->distance, 10.0), p->distance);
+  snprintf(txt, sizeof(txt), "%.*f", _precision(p->distance, 10.0), p->distance);
   dt_bauhaus_combobox_add(w, txt);
   float val = 0.25f;
   for(int k = 0; k < 25; k++)
   {
     if(val > 1000.0f) val = 1000.0f;
-    snprintf(txt, sizeof(txt), "%.*f", precision(val, 10.0), val);
+    snprintf(txt, sizeof(txt), "%.*f", _precision(val, 10.0), val);
     dt_bauhaus_combobox_add(w, txt);
     if(val >= 1000.0f) break;
     val *= sqrtf(2.0f);
   }
-  g_signal_connect(G_OBJECT(w), "value-changed", G_CALLBACK(lens_comboentry_distance_update), self);
+  g_signal_connect(G_OBJECT(w), "value-changed", G_CALLBACK(_lens_comboentry_distance_update), self);
   gtk_box_pack_start(GTK_BOX(g->lens_param_box), w, TRUE, TRUE, 0);
   dt_bauhaus_combobox_set_editable(w, 1);
   g->cbe[2] = w;
@@ -2739,12 +2914,12 @@ static void lens_set(dt_iop_module_t *self, const lfLens *lens)
   gtk_widget_show_all(g->lens_param_box);
 }
 
-static void lens_menu_select(GtkMenuItem *menuitem, gpointer user_data)
+static void _lens_menu_select(GtkMenuItem *menuitem, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_lens_gui_data_t *g = (dt_iop_lens_gui_data_t *)self->gui_data;
   dt_iop_lens_params_t *p = (dt_iop_lens_params_t *)self->params;
-  lens_set(self, (lfLens *)g_object_get_data(G_OBJECT(menuitem), "lfLens"));
+  _lens_set(self, (lfLens *)g_object_get_data(G_OBJECT(menuitem), "lfLens"));
   if(darktable.gui->reset) return;
 
   const float scale = _get_autoscale_lf(self, p, g->camera);
@@ -2752,7 +2927,7 @@ static void lens_menu_select(GtkMenuItem *menuitem, gpointer user_data)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void lens_menu_fill(dt_iop_module_t *self, const lfLens *const *lenslist)
+static void _lens_menu_fill(dt_iop_module_t *self, const lfLens *const *lenslist)
 {
   dt_iop_lens_gui_data_t *g = (dt_iop_lens_gui_data_t *)self->gui_data;
   unsigned i;
@@ -2771,14 +2946,14 @@ static void lens_menu_fill(dt_iop_module_t *self, const lfLens *const *lenslist)
   {
     GtkWidget *submenu, *item;
     const char *m = lf_mlstr_get(lenslist[i]->Maker);
-    int idx = ptr_array_find_sorted(makers, m, (GCompareFunc)g_utf8_collate);
+    int idx = _ptr_array_find_sorted(makers, m, (GCompareFunc)g_utf8_collate);
     if(idx < 0)
     {
       /* No such maker yet, insert it into the array */
-      idx = ptr_array_insert_sorted(makers, m, (GCompareFunc)g_utf8_collate);
+      idx = _ptr_array_insert_sorted(makers, m, (GCompareFunc)g_utf8_collate);
       /* Create a submenu for lenses by this maker */
       submenu = gtk_menu_new();
-      ptr_array_insert_index(submenus, submenu, idx);
+      _ptr_array_insert_index(submenus, submenu, idx);
     }
 
     submenu = (GtkWidget *)g_ptr_array_index(submenus, idx);
@@ -2786,7 +2961,7 @@ static void lens_menu_fill(dt_iop_module_t *self, const lfLens *const *lenslist)
     item = gtk_menu_item_new_with_label(lf_mlstr_get(lenslist[i]->Model));
     gtk_widget_show(item);
     g_object_set_data(G_OBJECT(item), "lfLens", (void *)lenslist[i]);
-    g_signal_connect(G_OBJECT(item), "activate", G_CALLBACK(lens_menu_select), self);
+    g_signal_connect(G_OBJECT(item), "activate", G_CALLBACK(_lens_menu_select), self);
     gtk_menu_shell_append(GTK_MENU_SHELL(submenu), item);
   }
 
@@ -2803,7 +2978,7 @@ static void lens_menu_fill(dt_iop_module_t *self, const lfLens *const *lenslist)
   g_ptr_array_free(makers, TRUE);
 }
 
-static void lens_menusearch_clicked(GtkWidget *button, gpointer user_data)
+static void _lens_menusearch_clicked(GtkWidget *button, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_lens_global_data_t *gd = (dt_iop_lens_global_data_t *)self->global_data;
@@ -2818,13 +2993,13 @@ static void lens_menusearch_clicked(GtkWidget *button, gpointer user_data)
   dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
 
   if(!lenslist) return;
-  lens_menu_fill(self, lenslist);
+  _lens_menu_fill(self, lenslist);
   lf_free(lenslist);
 
   dt_gui_menu_popup(GTK_MENU(g->lens_menu), button, GDK_GRAVITY_SOUTH, GDK_GRAVITY_NORTH);
 }
 
-static void lens_autosearch_clicked(GtkWidget *button, gpointer user_data)
+static void _lens_autosearch_clicked(GtkWidget *button, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_lens_global_data_t *gd = (dt_iop_lens_global_data_t *)self->global_data;
@@ -2836,13 +3011,13 @@ static void lens_autosearch_clicked(GtkWidget *button, gpointer user_data)
 
   (void)button;
 
-  parse_model(txt, model, sizeof(model));
+  _parse_model(txt, model, sizeof(model));
   dt_pthread_mutex_lock(&darktable.plugin_threadsafe);
   lenslist = dt_iop_lensfun_db->FindLenses(g->camera, NULL,
                                            model[0] ? model : NULL, LF_SEARCH_SORT_AND_UNIQUIFY);
   dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
   if(!lenslist) return;
-  lens_menu_fill(self, lenslist);
+  _lens_menu_fill(self, lenslist);
   lf_free(lenslist);
 
   dt_gui_menu_popup(GTK_MENU(g->lens_menu), button, GDK_GRAVITY_SOUTH_EAST, GDK_GRAVITY_NORTH_EAST);
@@ -2850,7 +3025,7 @@ static void lens_autosearch_clicked(GtkWidget *button, gpointer user_data)
 
 /* -- end lens -- */
 
-static void autoscale_pressed_lf(GtkWidget *button, gpointer user_data)
+static void _autoscale_pressed_lf(GtkWidget *button, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_lens_gui_data_t *g = (dt_iop_lens_gui_data_t *)self->gui_data;
@@ -2860,7 +3035,7 @@ static void autoscale_pressed_lf(GtkWidget *button, gpointer user_data)
   dt_bauhaus_slider_set(g->scale, scale);
 }
 
-static void target_geometry_changed(GtkWidget *widget, gpointer user_data)
+static void _target_geometry_changed(GtkWidget *widget, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_lens_params_t *p = (dt_iop_lens_params_t *)self->params;
@@ -2892,7 +3067,7 @@ static void _display_errors(struct dt_iop_module_t *self)
   gtk_widget_queue_draw(self->widget);
 }
 
-static void modflags_changed(GtkWidget *widget, gpointer user_data)
+static void _modflags_changed(GtkWidget *widget, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(darktable.gui->reset) return;
@@ -2921,7 +3096,8 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   // enable methods selector combobox only if more than 1 methods are available
   gtk_widget_set_sensitive(g->methods_selector, _have_embedded_metadata(self) > 0);
 
-  if (p->method == DT_IOP_LENS_METHOD_LENSFUN){
+  if(p->method == DT_IOP_LENS_METHOD_LENSFUN)
+  {
     gtk_stack_set_visible_child_name(GTK_STACK(g->methods), "lensfun");
 
     gtk_widget_set_sensitive(GTK_WIDGET(g->modflags), !g->lensfun_trouble);
@@ -2944,6 +3120,16 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   {
     gtk_stack_set_visible_child_name(GTK_STACK(g->methods), "metadata");
 
+    const dt_image_t *img = &self->dev->image_storage;
+    const dt_image_correction_data_t *cd = &img->exif_correction_data;
+
+    const gboolean has_warp = (img->exif_correction_type == CORRECTION_TYPE_DNG) ? cd->dng.has_warp : TRUE;
+    const gboolean has_vign = (img->exif_correction_type == CORRECTION_TYPE_DNG) ? cd->dng.has_vignette : TRUE;
+
+    gtk_widget_set_visible(g->cor_dist_ft, has_warp);
+    gtk_widget_set_visible(g->cor_vig_ft, has_vign);
+    gtk_widget_set_visible(g->cor_scale, has_warp);
+
     gtk_widget_set_sensitive(GTK_WIDGET(g->modflags), TRUE);
     gtk_widget_set_sensitive(GTK_WIDGET(g->message), TRUE);
   }
@@ -2951,7 +3137,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   _display_errors(self);
 }
 
-static void corrections_done(gpointer instance, gpointer user_data)
+static void _have_corrections_done(gpointer instance, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_lens_gui_data_t *g = (dt_iop_lens_gui_data_t *)self->gui_data;
@@ -3059,11 +3245,11 @@ void gui_init(struct dt_iop_module_t *self)
   // camera selector
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   g->camera_model = dt_iop_button_new(self, N_("camera model"),
-                                      G_CALLBACK(camera_menusearch_clicked),
+                                      G_CALLBACK(_camera_menusearch_clicked),
                                       FALSE, 0, (GdkModifierType)0,
                                       NULL, 0, hbox);
   g->find_camera_button = dt_iop_button_new(self, N_("find camera"),
-                                            G_CALLBACK(camera_autosearch_clicked),
+                                            G_CALLBACK(_camera_autosearch_clicked),
                                             FALSE, 0, (GdkModifierType)0,
                                             dtgtk_cairo_paint_solid_arrow, CPF_DIRECTION_DOWN, NULL);
   dt_gui_add_class(g->find_camera_button, "dt_big_btn_canvas");
@@ -3073,11 +3259,11 @@ void gui_init(struct dt_iop_module_t *self)
   // lens selector
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   g->lens_model = dt_iop_button_new(self, N_("lens model"),
-                                    G_CALLBACK(lens_menusearch_clicked),
+                                    G_CALLBACK(_lens_menusearch_clicked),
                                     FALSE, 0, (GdkModifierType)0,
                                     NULL, 0, hbox);
   g->find_lens_button = dt_iop_button_new(self, N_("find lens"),
-                                          G_CALLBACK(lens_autosearch_clicked),
+                                          G_CALLBACK(_lens_autosearch_clicked),
                                           FALSE, 0, (GdkModifierType)0,
                                           dtgtk_cairo_paint_solid_arrow, CPF_DIRECTION_DOWN, NULL);
   dt_gui_add_class(g->find_lens_button, "dt_big_btn_canvas");
@@ -3120,14 +3306,14 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->target_geom, _("equisolid angle"));
   dt_bauhaus_combobox_add(g->target_geom, _("thoby fish-eye"));
 #endif
-  g_signal_connect(G_OBJECT(g->target_geom), "value-changed", G_CALLBACK(target_geometry_changed),
+  g_signal_connect(G_OBJECT(g->target_geom), "value-changed", G_CALLBACK(_target_geometry_changed),
                    (gpointer)self);
 
   // scale
   g->scale = dt_bauhaus_slider_from_params(self, N_("scale"));
   dt_bauhaus_slider_set_digits(g->scale, 3);
   dt_bauhaus_widget_set_quad_paint(g->scale, dtgtk_cairo_paint_refresh, 0, NULL);
-  g_signal_connect(G_OBJECT(g->scale), "quad-pressed", G_CALLBACK(autoscale_pressed_lf), self);
+  g_signal_connect(G_OBJECT(g->scale), "quad-pressed", G_CALLBACK(_autoscale_pressed_lf), self);
   gtk_widget_set_tooltip_text(g->scale, _("auto scale"));
 
   // reverse direction
@@ -3151,7 +3337,18 @@ void gui_init(struct dt_iop_module_t *self)
   GtkWidget *box_md = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
   g->cor_dist_ft = dt_bauhaus_slider_from_params(self, "cor_dist_ft");
+  dt_bauhaus_slider_set_digits(g->cor_dist_ft, 3);
+  gtk_widget_set_tooltip_text(g->cor_dist_ft, _("tune the warp and chromatic aberration correction"));
+
   g->cor_vig_ft = dt_bauhaus_slider_from_params(self, "cor_vig_ft");
+  dt_bauhaus_slider_set_digits(g->cor_vig_ft, 3);
+  gtk_widget_set_tooltip_text(g->cor_vig_ft, _("tune the vignette correction"));
+
+  g->cor_scale = dt_bauhaus_slider_from_params(self, "cor_scale");
+  dt_bauhaus_slider_set_digits(g->cor_scale, 4);
+  dt_bauhaus_widget_set_quad_paint(g->cor_scale, dtgtk_cairo_paint_refresh, 0, NULL);
+  g_signal_connect(G_OBJECT(g->cor_scale), "quad-pressed", G_CALLBACK(_autoscale_pressed_md), self);
+  gtk_widget_set_tooltip_text(g->cor_scale, _("override automatic scale"));
 
   // main widget
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
@@ -3175,7 +3372,7 @@ void gui_init(struct dt_iop_module_t *self)
   }
   dt_bauhaus_combobox_set(g->modflags, 0);
   g_signal_connect(G_OBJECT(g->modflags), "value-changed",
-                   G_CALLBACK(modflags_changed), (gpointer)self);
+                   G_CALLBACK(_modflags_changed), (gpointer)self);
 
   g->methods = gtk_stack_new();
   gtk_stack_set_homogeneous(GTK_STACK(g->methods), FALSE);
@@ -3199,7 +3396,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   /* add signal handler for preview pipe finish to update message on corrections done */
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
-                            G_CALLBACK(corrections_done), self);
+                            G_CALLBACK(_have_corrections_done), self);
 }
 
 void gui_focus(struct dt_iop_module_t *self, gboolean in)
@@ -3246,29 +3443,29 @@ void gui_update(struct dt_iop_module_t *self)
     cam = dt_iop_lensfun_db->FindCamerasExt(NULL, p->camera, 0);
     dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
     if(cam)
-      camera_set(self, cam[0]);
+      _camera_set(self, cam[0]);
     else
-      camera_set(self, NULL);
+      _camera_set(self, NULL);
   }
 
   if(g->camera && p->lens[0])
   {
     char model[200];
-    parse_model(p->lens, model, sizeof(model));
+    _parse_model(p->lens, model, sizeof(model));
     dt_pthread_mutex_lock(&darktable.plugin_threadsafe);
     const lfLens **lenslist = dt_iop_lensfun_db->FindLenses(g->camera, NULL,
                                                             model[0] ? model : NULL, 0);
     if(lenslist)
-      lens_set(self, lenslist[0]);
+      _lens_set(self, lenslist[0]);
     else
-      lens_set(self, NULL);
+      _lens_set(self, NULL);
     lf_free(lenslist);
     dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
   }
   else
   {
     dt_pthread_mutex_lock(&darktable.plugin_threadsafe);
-    lens_set(self, NULL);
+    _lens_set(self, NULL);
     dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
   }
 
@@ -3280,7 +3477,7 @@ void gui_cleanup(struct dt_iop_module_t *self)
 {
   dt_iop_lens_gui_data_t *g = (dt_iop_lens_gui_data_t *)self->gui_data;
 
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(corrections_done), self);
+  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_have_corrections_done), self);
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
                                      G_CALLBACK(_develop_ui_pipe_finished_callback), self);
 


### PR DESCRIPTION
Take this as WIP.

Reading dng metadata from exif using the opcode3 list for rectilinear and vignette_radial corrections and inserting in image struct is fully implemented and working. Data extraction can be seen via `-d imageio -d verbose` for checks.

As i don't feel safe with inserting those parameters into `_init_coeffs_md()` (lens.cc) i did only preliminary code doing the warp correction (for monochromes too) and would appreciate it very much if someone else would help out here or maybe even take over the code, maybe we can still get it into 4.2. (Otherwise i would keep track on this and do it myself ...)

@sgotti @paolodepetrillo @FreddieWitherden anything for you?

EDIT: See late comment about current implementation.

EDIT 2: version bump of the lens module to v7 including a scale correction for embedded lenses. We make sure that for existing edits of sony/fujis this defaults to the autoscale value, for dng it seems to be correct to scale to 1.0