### PR TITLE
A more accurate name of the image load status enum DT_IMAGEIO_FILE_CORRUPTED

### DIFF
--- a/src/common/image.h
+++ b/src/common/image.h
@@ -33,8 +33,8 @@ typedef enum dt_imageio_retval_t
 {
   DT_IMAGEIO_OK = 0,         // all good :)
   DT_IMAGEIO_FILE_NOT_FOUND, // file has been lost
-  DT_IMAGEIO_FILE_CORRUPTED, // file contains garbage
-  DT_IMAGEIO_CACHE_FULL      // dt's caches are full :(
+  DT_IMAGEIO_LOAD_FAILED,    // file either corrupted or in a format not supported by the current loader
+  DT_IMAGEIO_CACHE_FULL      // buffer allocation for image data failed
 } dt_imageio_retval_t;
 
 typedef enum dt_imageio_write_xmp_t

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2021 darktable developers.
+    Copyright (C) 2009-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -674,7 +674,7 @@ dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img, const char *filename, d
     return ret;
   }
 
-  return DT_IMAGEIO_FILE_CORRUPTED;
+  return DT_IMAGEIO_LOAD_FAILED;
 }
 
 void dt_imageio_to_fractional(float in, uint32_t *num, uint32_t *den)
@@ -1217,7 +1217,7 @@ dt_imageio_retval_t dt_imageio_open_exotic(dt_image_t *img, const char *filename
   }
 #endif
 
-  return DT_IMAGEIO_FILE_CORRUPTED;
+  return DT_IMAGEIO_LOAD_FAILED;
 }
 
 void dt_imageio_update_monochrome_workflow_tag(int32_t id, int mask)
@@ -1260,7 +1260,7 @@ dt_imageio_retval_t dt_imageio_open(dt_image_t *img,               // non-const 
   const int32_t was_hdr = (img->flags & DT_IMAGE_HDR);
   const int32_t was_bw = dt_image_monochrome_flags(img);
 
-  dt_imageio_retval_t ret = DT_IMAGEIO_FILE_CORRUPTED;
+  dt_imageio_retval_t ret = DT_IMAGEIO_LOAD_FAILED;
   img->loader = LOADER_UNKNOWN;
 
   /* check if file is ldr using magic's */

--- a/src/common/imageio_avif.c
+++ b/src/common/imageio_avif.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of darktable,
- * Copyright (C) 2019-2021 darktable developers.
+ * Copyright (C) 2019-2022 darktable developers.
  *
  *  darktable is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -50,7 +50,7 @@ dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
   if(decoder == NULL)
   {
     dt_print(DT_DEBUG_IMAGEIO, "[avif_open] failed to create decoder for `%s'\n", filename);
-    ret = DT_IMAGEIO_FILE_CORRUPTED;
+    ret = DT_IMAGEIO_LOAD_FAILED;
     goto out;
   }
 
@@ -62,7 +62,7 @@ dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
       /* print debug info only if genuine AVIF */
       dt_print(DT_DEBUG_IMAGEIO, "[avif_open] failed to parse `%s': %s\n", filename, avifResultToString(result));
     }
-    ret = DT_IMAGEIO_FILE_CORRUPTED;
+    ret = DT_IMAGEIO_LOAD_FAILED;
     goto out;
   }
 
@@ -78,7 +78,7 @@ dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
   {
     dt_print(DT_DEBUG_IMAGEIO, "[avif_open] failed to convert `%s' from YUV to RGB: %s\n", filename,
              avifResultToString(result));
-    ret = DT_IMAGEIO_FILE_CORRUPTED;
+    ret = DT_IMAGEIO_LOAD_FAILED;
     goto out;
   }
 

--- a/src/common/imageio_exr.cc
+++ b/src/common/imageio_exr.cc
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2020 darktable developers.
+    Copyright (C) 2010-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -62,7 +62,7 @@ dt_imageio_retval_t dt_imageio_open_exr(dt_image_t *img, const char *filename, d
 
 
   /* verify openexr image */
-  if(!Imf::isOpenExrFile((const char *)filename, isTiled)) return DT_IMAGEIO_FILE_CORRUPTED;
+  if(!Imf::isOpenExrFile((const char *)filename, isTiled)) return DT_IMAGEIO_LOAD_FAILED;
 
   /* open exr file */
   try
@@ -80,7 +80,7 @@ dt_imageio_retval_t dt_imageio_open_exr(dt_image_t *img, const char *filename, d
   }
   catch(const std::exception &e)
   {
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   }
 
   const Imf::Header &header = isTiled ? fileTiled->header() : file->header();
@@ -97,7 +97,7 @@ dt_imageio_retval_t dt_imageio_open_exr(dt_image_t *img, const char *filename, d
   if(!(hasR && hasG && hasB))
   {
     fprintf(stderr, "[exr_read] Warning, only files with RGB(A) channels are supported.\n");
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   }
 
   if(!img->exif_inited)

--- a/src/common/imageio_gm.c
+++ b/src/common/imageio_gm.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2020 darktable developers.
+    Copyright (C) 2012-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -56,13 +56,13 @@ static gboolean _supported_image(const gchar *filename)
 
 dt_imageio_retval_t dt_imageio_open_gm(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *mbuf)
 {
-  int err = DT_IMAGEIO_FILE_CORRUPTED;
+  int err = DT_IMAGEIO_LOAD_FAILED;
   ExceptionInfo exception;
   Image *image = NULL;
   ImageInfo *image_info = NULL;
   uint32_t width, height;
 
-  if(!_supported_image(filename)) return DT_IMAGEIO_FILE_CORRUPTED;
+  if(!_supported_image(filename)) return DT_IMAGEIO_LOAD_FAILED;
 
   if(!img->exif_inited) (void)dt_exif_read(img, filename);
 
@@ -85,7 +85,7 @@ dt_imageio_retval_t dt_imageio_open_gm(dt_image_t *img, const char *filename, dt
   if(IsCMYKColorspace(image->colorspace))
   {
     fprintf(stderr, "[GraphicsMagick_open] error: CMYK images are not supported.\n");
-    err =  DT_IMAGEIO_FILE_CORRUPTED;
+    err =  DT_IMAGEIO_LOAD_FAILED;
     goto error;
   }
 
@@ -114,7 +114,7 @@ dt_imageio_retval_t dt_imageio_open_gm(dt_image_t *img, const char *filename, dt
     if(ret != MagickPass)
     {
       fprintf(stderr, "[GraphicsMagick_open] error reading image `%s'\n", img->filename);
-      err = DT_IMAGEIO_FILE_CORRUPTED;
+      err = DT_IMAGEIO_LOAD_FAILED;
       goto error;
     }
   }

--- a/src/common/imageio_heif.c
+++ b/src/common/imageio_heif.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of darktable,
- * Copyright (C) 2021 darktable developers.
+ * Copyright (C) 2021-2022 darktable developers.
  *
  *  darktable is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -69,7 +69,7 @@ dt_imageio_retval_t dt_imageio_open_heif(dt_image_t *img,
       /* print debug info only if genuine HEIF */
       dt_print(DT_DEBUG_IMAGEIO, "Failed to read HEIF file [%s]: %s\n", filename, err.message);
     }
-    ret = DT_IMAGEIO_FILE_CORRUPTED;
+    ret = DT_IMAGEIO_LOAD_FAILED;
     goto out;
   }
 
@@ -80,7 +80,7 @@ dt_imageio_retval_t dt_imageio_open_heif(dt_image_t *img,
     dt_print(DT_DEBUG_IMAGEIO,
              "No images found in HEIF file [%s]\n",
              filename);
-    ret = DT_IMAGEIO_FILE_CORRUPTED;
+    ret = DT_IMAGEIO_LOAD_FAILED;
     goto out;
   }
 
@@ -91,7 +91,7 @@ dt_imageio_retval_t dt_imageio_open_heif(dt_image_t *img,
     dt_print(DT_DEBUG_IMAGEIO,
              "Failed to read primary image from HEIF file [%s]\n",
              filename);
-    ret = DT_IMAGEIO_FILE_CORRUPTED;
+    ret = DT_IMAGEIO_LOAD_FAILED;
     goto out;
   }
 
@@ -102,7 +102,7 @@ dt_imageio_retval_t dt_imageio_open_heif(dt_image_t *img,
     dt_print(DT_DEBUG_IMAGEIO,
              "Failed to decode HEIF file [%s]\n",
              filename);
-    ret = DT_IMAGEIO_FILE_CORRUPTED;
+    ret = DT_IMAGEIO_LOAD_FAILED;
     goto out;
   }
 

--- a/src/common/imageio_im.c
+++ b/src/common/imageio_im.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2020 darktable developers.
+    Copyright (C) 2020-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -61,11 +61,11 @@ static gboolean _supported_image(const gchar *filename)
 
 dt_imageio_retval_t dt_imageio_open_im(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *mbuf)
 {
-  int err = DT_IMAGEIO_FILE_CORRUPTED;
+  int err = DT_IMAGEIO_LOAD_FAILED;
   MagickWand *image = NULL;
   MagickBooleanType ret;
 
-  if(!_supported_image(filename)) return DT_IMAGEIO_FILE_CORRUPTED;
+  if(!_supported_image(filename)) return DT_IMAGEIO_LOAD_FAILED;
 
   if(!img->exif_inited) (void)dt_exif_read(img, filename);
 
@@ -88,7 +88,7 @@ dt_imageio_retval_t dt_imageio_open_im(dt_image_t *img, const char *filename, dt
   if((colorspace == CMYColorspace) || (colorspace == CMYKColorspace))
   {
     fprintf(stderr, "[ImageMagick_open] error: CMY(K) images are not supported.\n");
-    err =  DT_IMAGEIO_FILE_CORRUPTED;
+    err =  DT_IMAGEIO_LOAD_FAILED;
     goto error;
   }
 

--- a/src/common/imageio_jpeg.c
+++ b/src/common/imageio_jpeg.c
@@ -730,12 +730,12 @@ dt_imageio_retval_t dt_imageio_open_jpeg(dt_image_t *img, const char *filename, 
   // format (instead of the more common Exif metadata format)
   // See https://en.wikipedia.org/wiki/JPEG_File_Interchange_Format
   if(g_ascii_strcasecmp(ext, ".jpg") && g_ascii_strcasecmp(ext, ".jpeg") && g_ascii_strcasecmp(ext, ".jfif"))
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
 
   if(!img->exif_inited) (void)dt_exif_read(img, filename);
 
   dt_imageio_jpeg_t jpg;
-  if(dt_imageio_jpeg_read_header(filename, &jpg)) return DT_IMAGEIO_FILE_CORRUPTED;
+  if(dt_imageio_jpeg_read_header(filename, &jpg)) return DT_IMAGEIO_LOAD_FAILED;
   img->width = jpg.width;
   img->height = jpg.height;
 
@@ -743,7 +743,7 @@ dt_imageio_retval_t dt_imageio_open_jpeg(dt_image_t *img, const char *filename, 
   if(dt_imageio_jpeg_read(&jpg, tmp))
   {
     dt_free_align(tmp);
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   }
 
   img->buf_dsc.channels = 4;

--- a/src/common/imageio_jpegxl.c
+++ b/src/common/imageio_jpegxl.c
@@ -37,7 +37,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img, const char *filename
   if(!inputfile)
   {
     fprintf(stderr, "[jpegxl_open] Cannot open file for read: %s\n", filename);
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   }
 
   fseek(inputfile, 0, SEEK_END);
@@ -51,7 +51,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img, const char *filename
     fprintf(stderr, "[jpegxl_open] Failed to read %zu bytes: %s\n", inputFileSize, filename);
     free(read_buffer);
     fclose(inputfile);
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   }
   fclose(inputfile);
 
@@ -61,7 +61,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img, const char *filename
   {
     // It's normal if this function is called for a non-jxl file, so we should fail silently.
     free(read_buffer);
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   }
 
   const JxlPixelFormat pixel_format =
@@ -78,7 +78,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img, const char *filename
   {
     fprintf(stderr, "[jpegxl_open] ERROR: JxlDecoderCreate failed\n");
     free(read_buffer);
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   }
 
   JxlParallelRunner *runner = JxlResizableParallelRunnerCreate(NULL);
@@ -87,7 +87,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img, const char *filename
     fprintf(stderr, "[jpegxl_open] ERROR: JxlResizableParallelRunnerCreate failed\n");
     JxlDecoderDestroy(decoder);
     free(read_buffer);
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   }
 
   if(JxlDecoderSetInput(decoder, read_buffer, inputFileSize) != JXL_DEC_SUCCESS)
@@ -96,7 +96,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img, const char *filename
     JxlResizableParallelRunnerDestroy(runner);
     JxlDecoderDestroy(decoder);
     free(read_buffer);
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   }
 
   if(JxlDecoderSubscribeEvents(decoder, JXL_DEC_BASIC_INFO | JXL_DEC_COLOR_ENCODING | JXL_DEC_FULL_IMAGE) != JXL_DEC_SUCCESS)
@@ -105,7 +105,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img, const char *filename
     JxlResizableParallelRunnerDestroy(runner);
     JxlDecoderDestroy(decoder);
     free(read_buffer);
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   }
 
   if(JxlDecoderSetParallelRunner(decoder, JxlResizableParallelRunner, runner) != JXL_DEC_SUCCESS)
@@ -114,7 +114,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img, const char *filename
     JxlResizableParallelRunnerDestroy(runner);
     JxlDecoderDestroy(decoder);
     free(read_buffer);
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   }
 
 
@@ -129,7 +129,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img, const char *filename
       JxlResizableParallelRunnerDestroy(runner);
       JxlDecoderDestroy(decoder);
       free(read_buffer);
-      return DT_IMAGEIO_FILE_CORRUPTED;
+      return DT_IMAGEIO_LOAD_FAILED;
     }
 
     if(status == JXL_DEC_NEED_MORE_INPUT)
@@ -138,7 +138,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img, const char *filename
       JxlResizableParallelRunnerDestroy(runner);
       JxlDecoderDestroy(decoder);
       free(read_buffer);
-      return DT_IMAGEIO_FILE_CORRUPTED;
+      return DT_IMAGEIO_LOAD_FAILED;
     }
 
     if(status == JXL_DEC_BASIC_INFO)
@@ -149,7 +149,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img, const char *filename
         JxlResizableParallelRunnerDestroy(runner);
         JxlDecoderDestroy(decoder);
         free(read_buffer);
-        return DT_IMAGEIO_FILE_CORRUPTED;
+        return DT_IMAGEIO_LOAD_FAILED;
       }
 
       // Unlikely to happen, but let there be a sanity check
@@ -159,7 +159,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img, const char *filename
         JxlResizableParallelRunnerDestroy(runner);
         JxlDecoderDestroy(decoder);
         free(read_buffer);
-        return DT_IMAGEIO_FILE_CORRUPTED;
+        return DT_IMAGEIO_LOAD_FAILED;
       }
 
 
@@ -188,7 +188,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img, const char *filename
         JxlResizableParallelRunnerDestroy(runner);
         JxlDecoderDestroy(decoder);
         free(read_buffer);
-        return DT_IMAGEIO_FILE_CORRUPTED;
+        return DT_IMAGEIO_LOAD_FAILED;
       }
     continue;    // go to next iteration to process rest of the input
     }

--- a/src/common/imageio_libraw.c
+++ b/src/common/imageio_libraw.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2021 darktable developers.
+    Copyright (C) 2021-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -241,13 +241,13 @@ gboolean dt_libraw_lookup_makermodel(const char *maker, const char *model,
 
 dt_imageio_retval_t dt_imageio_open_libraw(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *mbuf)
 {
-  int err = DT_IMAGEIO_FILE_CORRUPTED;
+  int err = DT_IMAGEIO_LOAD_FAILED;
   int libraw_err = LIBRAW_SUCCESS;
-  if(!_supported_image(filename)) return DT_IMAGEIO_FILE_CORRUPTED;
+  if(!_supported_image(filename)) return DT_IMAGEIO_LOAD_FAILED;
   if(!img->exif_inited) (void)dt_exif_read(img, filename);
 
   libraw_data_t *raw = libraw_init(0);
-  if(!raw) return DT_IMAGEIO_FILE_CORRUPTED;
+  if(!raw) return DT_IMAGEIO_LOAD_FAILED;
 
 #if defined(_WIN32) && (defined(UNICODE) || defined(_UNICODE))
   wchar_t *wfilename = g_utf8_to_utf16(filename, -1, NULL, NULL, NULL);

--- a/src/common/imageio_pfm.c
+++ b/src/common/imageio_pfm.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2020 darktable developers.
+    Copyright (C) 2009-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -36,9 +36,9 @@ dt_imageio_retval_t dt_imageio_open_pfm(dt_image_t *img, const char *filename, d
 {
   const char *ext = filename + strlen(filename);
   while(*ext != '.' && ext > filename) ext--;
-  if(strcasecmp(ext, ".pfm")) return DT_IMAGEIO_FILE_CORRUPTED;
+  if(strcasecmp(ext, ".pfm")) return DT_IMAGEIO_LOAD_FAILED;
   FILE *f = g_fopen(filename, "rb");
-  if(!f) return DT_IMAGEIO_FILE_CORRUPTED;
+  if(!f) return DT_IMAGEIO_LOAD_FAILED;
   int ret = 0;
   int cols = 3;
   float scale_factor;
@@ -109,7 +109,7 @@ dt_imageio_retval_t dt_imageio_open_pfm(dt_image_t *img, const char *filename, d
 
 error_corrupt:
   fclose(f);
-  return DT_IMAGEIO_FILE_CORRUPTED;
+  return DT_IMAGEIO_LOAD_FAILED;
 error_cache_full:
   fclose(f);
   return DT_IMAGEIO_CACHE_FULL;

--- a/src/common/imageio_png.c
+++ b/src/common/imageio_png.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2020 darktable developers.
+    Copyright (C) 2009-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -155,7 +155,7 @@ dt_imageio_retval_t dt_imageio_open_png(dt_image_t *img, const char *filename, d
 {
   const char *ext = filename + strlen(filename);
   while(*ext != '.' && ext > filename) ext--;
-  if(strncmp(ext, ".png", 4) && strncmp(ext, ".PNG", 4)) return DT_IMAGEIO_FILE_CORRUPTED;
+  if(strncmp(ext, ".png", 4) && strncmp(ext, ".PNG", 4)) return DT_IMAGEIO_LOAD_FAILED;
   if(!img->exif_inited) (void)dt_exif_read(img, filename);
 
   dt_imageio_png_t image;
@@ -164,7 +164,7 @@ dt_imageio_retval_t dt_imageio_open_png(dt_image_t *img, const char *filename, d
   uint16_t bpp;
 
 
-  if(read_header(filename, &image) != 0) return DT_IMAGEIO_FILE_CORRUPTED;
+  if(read_header(filename, &image) != 0) return DT_IMAGEIO_LOAD_FAILED;
 
   width = img->width = image.width;
   height = img->height = image.height;
@@ -196,7 +196,7 @@ dt_imageio_retval_t dt_imageio_open_png(dt_image_t *img, const char *filename, d
   {
     dt_free_align(buf);
     fprintf(stderr, "[png_open] could not read image `%s'\n", img->filename);
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   }
 
   for(size_t j = 0; j < height; j++)
@@ -237,7 +237,7 @@ int dt_imageio_png_read_profile(const char *filename, uint8_t **out, dt_colorspa
 
   if(!(filename && *filename && out)) return 0;
 
-  if(read_header(filename, &image) != 0) return DT_IMAGEIO_FILE_CORRUPTED;
+  if(read_header(filename, &image) != 0) return DT_IMAGEIO_LOAD_FAILED;
 
   /* TODO: also add check for known cICP chunk read support once added to libpng */
 #ifdef PNG_STORE_UNKNOWN_CHUNKS_SUPPORTED

--- a/src/common/imageio_pnm.c
+++ b/src/common/imageio_pnm.c
@@ -45,7 +45,7 @@ static dt_imageio_retval_t _read_pbm(dt_image_t *img, FILE*f, float *buf)
   {
     if(fread(line, sizeof(uint8_t), (size_t)bytes_needed, f) != bytes_needed)
     {
-      result = DT_IMAGEIO_FILE_CORRUPTED;
+      result = DT_IMAGEIO_LOAD_FAILED;
       break;
     }
     for(size_t x = 0; x < bytes_needed; x++)
@@ -78,8 +78,8 @@ static dt_imageio_retval_t _read_pgm(dt_image_t *img, FILE*f, float *buf)
   if(fgets(maxvalue_string,7,f))
     max = atoi(maxvalue_string);
   else
-    return DT_IMAGEIO_FILE_CORRUPTED;
-  if(max == 0 || max > 65535) return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
+  if(max == 0 || max > 65535) return DT_IMAGEIO_LOAD_FAILED;
 
   if(max <= 255)
   {
@@ -90,7 +90,7 @@ static dt_imageio_retval_t _read_pgm(dt_image_t *img, FILE*f, float *buf)
     {
       if(fread(line, sizeof(uint8_t), (size_t)img->width, f) != img->width)
       {
-        result = DT_IMAGEIO_FILE_CORRUPTED;
+        result = DT_IMAGEIO_LOAD_FAILED;
         break;
       }
       for(size_t x = 0; x < img->width; x++)
@@ -112,7 +112,7 @@ static dt_imageio_retval_t _read_pgm(dt_image_t *img, FILE*f, float *buf)
     {
       if(fread(line, sizeof(uint16_t), (size_t)img->width, f) != img->width)
       {
-        result = DT_IMAGEIO_FILE_CORRUPTED;
+        result = DT_IMAGEIO_LOAD_FAILED;
         break;
       }
       for(size_t x = 0; x < img->width; x++)
@@ -143,8 +143,8 @@ static dt_imageio_retval_t _read_ppm(dt_image_t *img, FILE*f, float *buf)
   if(fgets(maxvalue_string,7,f))
     max = atoi(maxvalue_string);
   else
-    return DT_IMAGEIO_FILE_CORRUPTED;
-  if(max == 0 || max > 65535) return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
+  if(max == 0 || max > 65535) return DT_IMAGEIO_LOAD_FAILED;
 
   if(max <= 255)
   {
@@ -155,7 +155,7 @@ static dt_imageio_retval_t _read_ppm(dt_image_t *img, FILE*f, float *buf)
     {
       if(fread(line, 3 * sizeof(uint8_t), (size_t)img->width, f) != img->width)
       {
-        result = DT_IMAGEIO_FILE_CORRUPTED;
+        result = DT_IMAGEIO_LOAD_FAILED;
         break;
       }
       for(size_t x = 0; x < img->width; x++)
@@ -179,7 +179,7 @@ static dt_imageio_retval_t _read_ppm(dt_image_t *img, FILE*f, float *buf)
     {
       if(fread(line, 3 * sizeof(uint16_t), (size_t)img->width, f) != img->width)
       {
-        result = DT_IMAGEIO_FILE_CORRUPTED;
+        result = DT_IMAGEIO_LOAD_FAILED;
         break;
       }
       for(size_t x = 0; x < img->width; x++)
@@ -207,11 +207,11 @@ dt_imageio_retval_t dt_imageio_open_pnm(dt_image_t *img, const char *filename, d
   const char *ext = filename + strlen(filename);
   while(*ext != '.' && ext > filename) ext--;
   if(strcasecmp(ext, ".pbm") && strcasecmp(ext, ".pgm") && strcasecmp(ext, ".pnm") && strcasecmp(ext, ".ppm"))
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   FILE *f = g_fopen(filename, "rb");
-  if(!f) return DT_IMAGEIO_FILE_CORRUPTED;
+  if(!f) return DT_IMAGEIO_LOAD_FAILED;
   int ret = 0;
-  dt_imageio_retval_t result = DT_IMAGEIO_FILE_CORRUPTED;
+  dt_imageio_retval_t result = DT_IMAGEIO_LOAD_FAILED;
 
   char head[2] = { 'X', 'X' };
   ret = fscanf(f, "%c%c ", head, head + 1);

--- a/src/common/imageio_rawspeed.cc
+++ b/src/common/imageio_rawspeed.cc
@@ -135,7 +135,7 @@ static gboolean _ignore_image(const gchar *filename)
 dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filename,
                                              dt_mipmap_buffer_t *mbuf)
 {
-  if(_ignore_image(filename)) return DT_IMAGEIO_FILE_CORRUPTED;
+  if(_ignore_image(filename)) return DT_IMAGEIO_LOAD_FAILED;
 
   if(!img->exif_inited) (void)dt_exif_read(img, filename);
 
@@ -157,7 +157,7 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
     RawParser t(*m.get());
     d = t.getDecoder(meta);
 
-    if(!d.get()) return DT_IMAGEIO_FILE_CORRUPTED;
+    if(!d.get()) return DT_IMAGEIO_LOAD_FAILED;
 
     d->failOnUnknown = true;
     d->checkSupport(meta);
@@ -289,19 +289,19 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
     }
 
     if((r->getDataType() != TYPE_USHORT16) && (r->getDataType() != TYPE_FLOAT32))
-      return DT_IMAGEIO_FILE_CORRUPTED;
+      return DT_IMAGEIO_LOAD_FAILED;
 
     if((r->getBpp() != sizeof(uint16_t)) && (r->getBpp() != sizeof(float)))
-      return DT_IMAGEIO_FILE_CORRUPTED;
+      return DT_IMAGEIO_LOAD_FAILED;
 
     if((r->getDataType() == TYPE_USHORT16) && (r->getBpp() != sizeof(uint16_t)))
-      return DT_IMAGEIO_FILE_CORRUPTED;
+      return DT_IMAGEIO_LOAD_FAILED;
 
     if((r->getDataType() == TYPE_FLOAT32) && (r->getBpp() != sizeof(float)))
-      return DT_IMAGEIO_FILE_CORRUPTED;
+      return DT_IMAGEIO_LOAD_FAILED;
 
     const float cpp = r->getCpp();
-    if(cpp != 1) return DT_IMAGEIO_FILE_CORRUPTED;
+    if(cpp != 1) return DT_IMAGEIO_LOAD_FAILED;
 
     img->buf_dsc.channels = 1;
 
@@ -314,7 +314,7 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
         img->buf_dsc.datatype = TYPE_FLOAT;
         break;
       default:
-        return DT_IMAGEIO_FILE_CORRUPTED;
+        return DT_IMAGEIO_LOAD_FAILED;
     }
 
     // dimensions of uncropped image
@@ -411,12 +411,12 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
 
     /* if an exception is raised lets not retry or handle the
      specific ones, consider the file as corrupted */
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   }
   catch(...)
   {
     fprintf(stderr, "[rawspeed] unhandled exception in imageio_rawspeed\n");
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   }
 
   img->buf_dsc.cst = IOP_CS_RAW;
@@ -439,10 +439,10 @@ dt_imageio_retval_t dt_imageio_open_rawspeed_sraw(dt_image_t *img, RawImage r, d
   img->buf_dsc.datatype = TYPE_FLOAT;
 
   if(r->getDataType() != TYPE_USHORT16 && r->getDataType() != TYPE_FLOAT32)
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
 
   const uint32_t cpp = r->getCpp();
-  if(cpp != 1 && cpp != 3 && cpp != 4) return DT_IMAGEIO_FILE_CORRUPTED;
+  if(cpp != 1 && cpp != 3 && cpp != 4) return DT_IMAGEIO_LOAD_FAILED;
 
   // if buf is NULL, we quit the fct here
   if(!mbuf)

--- a/src/common/imageio_rgbe.c
+++ b/src/common/imageio_rgbe.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2020 darktable developers.
+    Copyright (C) 2009-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -593,9 +593,9 @@ dt_imageio_retval_t dt_imageio_open_rgbe(dt_image_t *img, const char *filename, 
   const char *ext = filename + strlen(filename);
   while(*ext != '.' && ext > filename) ext--;
   if(strncmp(ext, ".hdr", 4) && strncmp(ext, ".HDR", 4) && strncmp(ext, ".Hdr", 4))
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   FILE *f = g_fopen(filename, "rb");
-  if(!f) return DT_IMAGEIO_FILE_CORRUPTED;
+  if(!f) return DT_IMAGEIO_LOAD_FAILED;
 
   rgbe_header_info info;
   if(RGBE_ReadHeader(f, &img->width, &img->height, &info)) goto error_corrupt;
@@ -630,7 +630,7 @@ dt_imageio_retval_t dt_imageio_open_rgbe(dt_image_t *img, const char *filename, 
 
 error_corrupt:
   fclose(f);
-  return DT_IMAGEIO_FILE_CORRUPTED;
+  return DT_IMAGEIO_LOAD_FAILED;
 error_cache_full:
   fclose(f);
   return DT_IMAGEIO_CACHE_FULL;

--- a/src/common/imageio_tiff.c
+++ b/src/common/imageio_tiff.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2020 darktable developers.
+    Copyright (C) 2010-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -358,7 +358,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
   while(*ext != '.' && ext > filename) ext--;
   if(strncmp(ext, ".tif", 4) && strncmp(ext, ".TIF", 4) && strncmp(ext, ".tiff", 5)
      && strncmp(ext, ".TIFF", 5))
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   if(!img->exif_inited) (void)dt_exif_read(img, filename);
 
   tiff_t t;
@@ -376,7 +376,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
   t.tiff = TIFFOpen(filename, "rb");
 #endif
 
-  if(t.tiff == NULL) return DT_IMAGEIO_FILE_CORRUPTED;
+  if(t.tiff == NULL) return DT_IMAGEIO_LOAD_FAILED;
 
   TIFFGetField(t.tiff, TIFFTAG_IMAGEWIDTH, &t.width);
   TIFFGetField(t.tiff, TIFFTAG_IMAGELENGTH, &t.height);
@@ -391,13 +391,13 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
   {
     fprintf(stderr, "[tiff_open] error: CMYK (or multiink) TIFFs are not supported.\n");
     TIFFClose(t.tiff);
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   }
 
   if(TIFFRasterScanlineSize(t.tiff) != TIFFScanlineSize(t.tiff))
   {
     TIFFClose(t.tiff);
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   }
 
   t.scanlinesize = TIFFScanlineSize(t.tiff);
@@ -408,14 +408,14 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
   if(t.bpp != 8 && t.bpp != 16 && t.bpp != 32)
   {
     TIFFClose(t.tiff);
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   }
 
   /* we only support 1, 3 or 4 samples per pixel */
   if(t.spp != 1 && t.spp != 3 && t.spp != 4)
   {
     TIFFClose(t.tiff);
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   }
 
   /* don't depend on planar config if spp == 1 */
@@ -423,7 +423,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
   {
     fprintf(stderr, "[tiff_open] error: PlanarConfiguration other than chunky is not supported.\n");
     TIFFClose(t.tiff);
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   }
 
   /* initialize cached image buffer */
@@ -491,7 +491,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
     return DT_IMAGEIO_OK;
   }
   else
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
 }
 
 int dt_imageio_tiff_read_profile(const char *filename, uint8_t **out)

--- a/src/common/imageio_webp.c
+++ b/src/common/imageio_webp.c
@@ -35,7 +35,7 @@ dt_imageio_retval_t dt_imageio_open_webp(dt_image_t *img, const char *filename, 
   if(!f)
   {
     fprintf(stderr,"[webp_open] cannot open file for read: %s\n", filename);
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   }
 
   fseek(f, 0, SEEK_END);
@@ -49,7 +49,7 @@ dt_imageio_retval_t dt_imageio_open_webp(dt_image_t *img, const char *filename, 
     fclose(f);
     g_free(read_buffer);
     fprintf(stderr,"[webp_open] failed to read %zu bytes from %s\n", filesize, filename);
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   }
   fclose(f);
 
@@ -60,7 +60,7 @@ dt_imageio_retval_t dt_imageio_open_webp(dt_image_t *img, const char *filename, 
     // a different format (darktable just trying different loaders until it finds the right one).
     // We just have to return without complaining.
     g_free(read_buffer);
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   }
   img->width = w;
   img->height = h;
@@ -80,7 +80,7 @@ dt_imageio_retval_t dt_imageio_open_webp(dt_image_t *img, const char *filename, 
   {
     g_free(read_buffer);
     fprintf(stderr,"[webp_open] failed to decode file: %s\n", filename);
-    return DT_IMAGEIO_FILE_CORRUPTED;
+    return DT_IMAGEIO_LOAD_FAILED;
   }
 
   uint8_t intval;


### PR DESCRIPTION
No new functionality or bug fixes, it's just an improvement in source code comprehensibility. The old name (DT_IMAGEIO_FILE_CORRUPTED) was started to hurt my brain, because the corresponding status in practice almost always signals something else: that the image format is not supported by the current loader trying to read it.
It would be more accurate to say that this status means that the loading of the image has failed for whatever reason, and this is reflected in the new name, DT_IMAGEIO_LOAD_FAILED.
