### PR TITLE
range : fix and rework tooltips

### DIFF
--- a/src/dtgtk/range.h
+++ b/src/dtgtk/range.h
@@ -45,7 +45,7 @@ typedef double (*DTGTKTranslateValueFunc)(const double value);
 typedef gchar *(*DTGTKPrintValueFunc)(const double value, const gboolean detailled);
 typedef gboolean (*DTGTKDecodeValueFunc)(const gchar *text, double *value);
 typedef struct _GtkDarktableRangeSelect GtkDarktableRangeSelect;
-typedef gchar *(*DTGTKCurrentTextFunc)(GtkDarktableRangeSelect *range, const double current);
+typedef gchar *(*DTGTKCurrentTextFunc)(GtkDarktableRangeSelect *range);
 
 typedef enum dt_range_bounds_t
 {
@@ -102,7 +102,7 @@ struct _GtkDarktableRangeSelect
   // print function has detailled mode for extended infos
   DTGTKPrintValueFunc print;
   DTGTKDecodeValueFunc decode;
-  DTGTKCurrentTextFunc current_text;
+  DTGTKCurrentTextFunc current_bounds;
   GList *blocks;
   GList *icons;
   GList *markers;
@@ -116,6 +116,7 @@ struct _GtkDarktableRangeSelect
   // window used to show the value under the cursor
   GtkWidget *cur_window;
   GtkWidget *cur_label;
+  gchar *cur_help;
 
   struct _range_date_popup *date_popup;
 };

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -644,22 +644,6 @@ static void _rule_set_raw_text(dt_lib_filtering_rule_t *rule, const gchar *text,
   if(signal) _event_rule_changed(NULL, rule);
 }
 
-static void _range_set_tooltip(_widgets_range_t *special)
-{
-  // we recreate the tooltip
-  gchar *val = dtgtk_range_select_get_bounds_pretty(DTGTK_RANGE_SELECT(special->range_select));
-  gchar *txt = g_strdup_printf("<b>%s</b>\n%s\n%s",
-                               dt_collection_name(special->rule->prop),
-                               _("click or click&#38;drag to select one or multiple values"),
-                               _("right-click opens a menu to select the available values"));
-
-  if(special->rule->prop != DT_COLLECTION_PROP_RATING_RANGE)
-    txt = g_strdup_printf("%s\n<b><i>%s:</i></b> %s", txt, _("actual selection"), val);
-  gtk_widget_set_tooltip_markup(special->range_select, txt);
-  g_free(txt);
-  g_free(val);
-}
-
 static void _range_changed(GtkWidget *widget, gpointer user_data)
 {
   _widgets_range_t *special = (_widgets_range_t *)user_data;
@@ -670,8 +654,6 @@ static void _range_changed(GtkWidget *widget, gpointer user_data)
   gchar *txt = dtgtk_range_select_get_raw_text(DTGTK_RANGE_SELECT(special->range_select));
   _rule_set_raw_text(special->rule, txt, TRUE);
   g_free(txt);
-
-  _range_set_tooltip(special);
 
   // synchronize the other widget if any
   _widgets_range_t *dest = NULL;
@@ -693,7 +675,13 @@ static void _range_widget_add_to_rule(dt_lib_filtering_rule_t *rule, _widgets_ra
 {
   special->rule = rule;
 
-  _range_set_tooltip(special);
+  // we create the static part of the tooltip
+  gchar *txt = g_strdup_printf("\n<b>%s</b>\n%s\n%s", dt_collection_name(special->rule->prop),
+                               _("click or click&#38;drag to select one or multiple values"),
+                               _("right-click opens a menu to select the available values"));
+  if(DTGTK_RANGE_SELECT(special->range_select)->cur_help)
+    g_free(DTGTK_RANGE_SELECT(special->range_select)->cur_help);
+  DTGTK_RANGE_SELECT(special->range_select)->cur_help = txt;
 
   gtk_box_pack_start(GTK_BOX((top) ? rule->w_special_box_top : rule->w_special_box), special->range_select, TRUE,
                      TRUE, 0);

--- a/src/libs/filters/rating_range.c
+++ b/src/libs/filters/rating_range.c
@@ -108,11 +108,9 @@ static gchar *_rating_get_bounds_pretty(GtkDarktableRangeSelect *range)
 {
   if((range->bounds & DT_RANGE_BOUND_MIN) && (range->bounds & DT_RANGE_BOUND_MAX)) return g_strdup(_("all images"));
 
-  if((range->bounds & DT_RANGE_BOUND_MIN)) 
-    range->select_min_r = range->min_r;
-  if((range->bounds & DT_RANGE_BOUND_MAX)) 
-    range->select_max_r = range->max_r;
-    
+  if((range->bounds & DT_RANGE_BOUND_MIN)) range->select_min_r = range->min_r;
+  if((range->bounds & DT_RANGE_BOUND_MAX)) range->select_max_r = range->max_r;
+
   if(range->select_min_r == range->select_max_r)
   {
     gchar *printed_min = range->print(range->select_min_r, TRUE);
@@ -155,23 +153,6 @@ static gchar *_rating_get_bounds_pretty(GtkDarktableRangeSelect *range)
   }
 
   return dtgtk_range_select_get_bounds_pretty(range);
-}
-
-static gchar *_rating_current_text_func(GtkDarktableRangeSelect *range, const double current)
-{
-  gchar *hovered = range->print(current, TRUE);
-  gchar *hovered_escaped = g_markup_escape_text(hovered, -1);
-  gchar *selected = _rating_get_bounds_pretty(range);
-  gchar *selected_escaped = g_markup_escape_text(selected, -1);
-
-  gchar *rating_text = g_strdup_printf("  <b>%s</b> | %s: %s  ", 
-        hovered_escaped, _("selected"), selected_escaped);
-  
-  g_free(hovered);
-  g_free(hovered_escaped);
-  g_free(selected);
-  g_free(selected_escaped);
-  return rating_text;
 }
 
 static void _rating_paint_icon(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
@@ -327,7 +308,7 @@ static void _rating_range_widget_init(dt_lib_filtering_rule_t *rule, const dt_co
   dtgtk_range_select_add_icon(range, 78, 4, _rating_paint_icon, 0, NULL);
   dtgtk_range_select_add_icon(range, 93, 5, _rating_paint_icon, 0, NULL);
   range->print = _rating_print_func;
-  range->current_text = _rating_current_text_func;
+  range->current_bounds = _rating_get_bounds_pretty;
 
   dtgtk_range_select_set_selection_from_raw_text(range, text, FALSE);
 
@@ -338,6 +319,9 @@ static void _rating_range_widget_init(dt_lib_filtering_rule_t *rule, const dt_co
 
   dt_action_define(DT_ACTION(self), N_("rules"), dt_collection_name_untranslated(prop),
                    special->range_select, &dt_action_def_ratings_rule);
+
+  // avoid the action tooltips to interfere with the current value popup
+  gtk_widget_set_has_tooltip(special->range_select, FALSE);
 }
 
 // clang-format off


### PR DESCRIPTION
Following multiple issues (positionning and gtk_critical) see #12788 for ex.
Here is a rework that would simplify the code and remove the issues.

For instance, we have the following help "tooltips" for range widgets : 
- a "classic" tooltip under the widget, with "static" help infos + the current select, except for range rating
- a "popup" windows above the widget, which follow the mouse position and show the current value under the mouse + the current selection for range rating

But both have issues, inherent to gtk implementation (so we can't really change them) : 
- tooltips have an hardcoded delay before they are shown, and don't really follow the mouse pointer
- if we don't have enough space above the widget (topbar) we need to relocate the popup on the right, which cause flickering on start, because we can't know the popup height before it is shown
- another problem when relocating is that the resizing of the popup cause some GTK_CRITICAL (this looks like a gtk bug)

So what I propose here is to : 
- remove the "classic" tooltip
- move all information inside the "popup" that follow mouse position
- relocate the popup under the widget by default. And in the (rare) case where there's not enought space, it will automatically appears above, but that doesn't cause any GTK_CRITICAL, because the popup itself doesn't change it's size internally...
- One consequence is that we can easily have the same display (current value | current selection on top. which is good for consistency ;)

here's a screenshot : 
![Capture d’écran_2022-11-13_15-26-53](https://user-images.githubusercontent.com/1818223/201532475-e835098a-4841-408d-a31b-742fc825292c.png)

Basically, it's in fact just a merge of both tooltips window