### PR TITLE
Be permissive in the AVIF decoder so we can load even slightly-offspec files

### DIFF
--- a/src/common/imageio_avif.c
+++ b/src/common/imageio_avif.c
@@ -54,6 +54,9 @@ dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
     goto out;
   }
 
+  /* Be permissive so we can load even slightly-offspec files */
+  decoder->strictFlags = AVIF_STRICT_DISABLED;
+
   result = avifDecoderReadFile(decoder, &avif_image, filename);
   if(result != AVIF_RESULT_OK)
   {


### PR DESCRIPTION
How to test:

- Download some files from http://download.opencontent.netflix.com/?prefix=AV1/Chimera/AVIF/
- Import them
- See that HEIF is listed as a loader in the image info module

When running under the debugger, you can see that the AVIF loader tries to decode the file, but it fails because avifDecoderReadFile returns AVIF_RESULT_BMFF_PARSE_FAILED. So (if the dt is compiled with libheif) the HEIF loader works as a fallback (and succeeds because it's not as strict as libavif).
