### PR TITLE
fix crash when opening QAP add widget menu

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -667,6 +667,7 @@ void dt_control_toast_redraw()
 static int _widget_queue_draw(void *widget)
 {
   gtk_widget_queue_draw((GtkWidget*)widget);
+  g_object_unref(widget);
   return FALSE;
 }
 
@@ -674,6 +675,7 @@ void dt_control_queue_redraw_widget(GtkWidget *widget)
 {
   if(dt_control_running())
   {
+    g_object_ref(widget);
     g_idle_add(_widget_queue_draw, (void*)widget);
   }
 }

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2470,6 +2470,13 @@ static GtkWidget *_build_menu_from_actions(dt_action_t *actions, dt_lib_module_t
   GtkWidget *new_base = NULL;
   while(actions)
   {
+    if(actions == &darktable.control->actions_focus ||
+       actions == &darktable.control->actions_blend)
+    {
+        actions = actions->next;
+        continue;
+    }
+
     if(actions->type == DT_ACTION_TYPE_IOP)
     {
       dt_iop_module_so_t *so = (dt_iop_module_so_t *)actions;


### PR DESCRIPTION
fixes #12898

Also fix a possible use of a widget in an idle routine when it may already have been destroyed (for example by switching views).

I would expect it to be safe to call `gtk_widget_queue_draw` directly, from any thread, rather than having to use `dt_control_queue_redraw_widget`, since the drawing itself would get queued to happen in the main loop anyway and the idle source waiting for it would automatically get cancelled when the widget gets destroyed. Most of the uses are in the main loop as well, so would definitely not be a problem, but the few that are called from the pipe etc would need more extensive testing than I would want to inflict on anybody at this phase in the cycle and I can't find anything definite about thread safety of `gtk_widget_queue_draw` on google.