### PR TITLE
fix lib revealer issues when switching views

### DIFF
--- a/src/dtgtk/expander.c
+++ b/src/dtgtk/expander.c
@@ -187,7 +187,7 @@ GtkWidget *dtgtk_expander_new(GtkWidget *header, GtkWidget *body)
 
   expander
       = g_object_new(dtgtk_expander_get_type(), "orientation", GTK_ORIENTATION_VERTICAL, "spacing", 0, NULL);
-  expander->expanded = -1;
+  expander->expanded = TRUE;
   expander->header = header;
   expander->body = body;
 
@@ -198,6 +198,8 @@ GtkWidget *dtgtk_expander_new(GtkWidget *header, GtkWidget *body)
   GtkWidget *frame = gtk_frame_new(NULL);
   gtk_container_add(GTK_CONTAINER(frame), expander->body_evb);
   expander->frame = gtk_revealer_new();
+  gtk_revealer_set_transition_duration(GTK_REVEALER(expander->frame), 0);
+  gtk_revealer_set_reveal_child(GTK_REVEALER(expander->frame), TRUE);
   gtk_container_add(GTK_CONTAINER(expander->frame), frame);
 
   gtk_box_pack_start(GTK_BOX(expander), expander->header_evb, TRUE, FALSE, 0);

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -837,21 +837,7 @@ void dt_lib_gui_set_expanded(dt_lib_module_t *module, gboolean expanded)
   gint flags = (expanded ? CPF_DIRECTION_DOWN : CPF_DIRECTION_RIGHT);
   dtgtk_button_set_paint(DTGTK_BUTTON(module->arrow), dtgtk_cairo_paint_solid_arrow, flags, NULL);
 
-  /* show / hide plugin widget */
-  if(expanded)
-  {
-    /* register to receive draw events */
-    darktable.lib->gui_module = module;
-  }
-  else
-  {
-    if(darktable.lib->gui_module == module)
-    {
-      darktable.lib->gui_module = NULL;
-
-      dt_control_queue_redraw();
-    }
-  }
+  darktable.lib->gui_module = expanded ? module : NULL;
 
   /* store expanded state of module */
   char var[1024];

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -351,18 +351,6 @@ int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
           dt_gui_add_help_link(w, dt_get_help_url("darkroom_bottom_panel"));
       }
 
-
-      /* add module to its container */
-      dt_ui_container_add_widget(darktable.gui->ui, plugin->container(plugin), w);
-    }
-  }
-
-  /* hide/show modules as last config */
-  for(GList *iter = darktable.lib->plugins; iter; iter = g_list_next(iter))
-  {
-    dt_lib_module_t *plugin = (dt_lib_module_t *)(iter->data);
-    if(dt_lib_is_visible_in_view(plugin, new_view))
-    {
       /* set expanded if last mode was that */
       char var[1024];
       gboolean expanded = FALSE;
@@ -384,8 +372,13 @@ int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
           gtk_widget_hide(plugin->widget);
       }
       if(plugin->view_enter) plugin->view_enter(plugin, old_view, new_view);
+
+      /* add module to its container */
+      dt_ui_container_add_widget(darktable.gui->ui, plugin->container(plugin), w);
     }
   }
+
+  darktable.lib->gui_module = NULL;
 
   /* enter view. crucially, do this before initing the plugins below,
       as e.g. modulegroups requires the dr stuff to be inited. */


### PR DESCRIPTION
fixes #12713
fixes #12885

@pehar1 and @Nilvus please test if this fixes/improves your symptoms.

It seems that a box being added to a GtkRevealer gets treated slightly differently depending on whether the status is currently _revealed_ or not. So now instead of starting "collapsed" and then expanding depending on saved state, it starts "expanded" and collapses as needed. With this change I don't see anything strange happening anymore, but I couldn't perfectly reproduce the problems anyway, so please let me know how it goes for you.

EDIT: now revealing modules before adding them to view, which avoids flashing when switching between views. This removes a separate loop, which doesn't _seem_ to have any bad consequences...