### PR TITLE
Lua 4.2 changes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -255,7 +255,15 @@ accompanying blog post.
 
 ## Lua
 
-N/A
+- API version changed to 9.0.0 
+
+- darktable.gui.libs.filter.sort|sort order|rating|rating comparator functions removed
+
+- filename removed from dt_lua_snapshot_t data type
+
+- darktable.gui.libs.snapshot now updates the screen after changing direction or rotation
+
+- lua snapshot datatype correctly retrieves snapshot name
 
 ## Notes
 

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -760,6 +760,7 @@ static int direction_member(lua_State *L)
       d->vertical = TRUE;
       d->inverted = TRUE;
     }
+    dt_control_queue_redraw_center();
     return 0;
   }
 }
@@ -810,6 +811,7 @@ static int ratio_member(lua_State *L)
     {
       d->vp_xpointer = 1.0 - ratio;
     }
+    dt_control_queue_redraw_center();
     return 0;
   }
 }
@@ -888,7 +890,7 @@ static int name_member(lua_State *L)
   {
     return luaL_error(L, "Accessing a non-existent snapshot");
   }
-  lua_pushstring(L, gtk_button_get_label(GTK_BUTTON(d->snapshot[index].button)));
+  lua_pushstring(L, gtk_label_get_text(GTK_LABEL(gtk_bin_get_child(GTK_BIN(d->snapshot[index].button)))));
   return 1;
 }
 

--- a/src/lua/configuration.h
+++ b/src/lua/configuration.h
@@ -36,8 +36,9 @@
 // 3.2.0 was 6.0.0 (removed facebook, flickr, and picasa from types.dt_imageio_storage_module_t)
 // 3.6.0 was 7.0.0 (added naming to events, selections, and actions)
 // 3.8.0 was 8.0.0 (moved to lua 5.4 and added some events)
+// 4.2.0 was 9.0.0 (view toolbox functions and snapshot filename removed)
 /* incompatible API change */
-#define LUA_API_VERSION_MAJOR 8
+#define LUA_API_VERSION_MAJOR 9
 /* backward compatible API change */
 #define LUA_API_VERSION_MINOR 0
 /* bugfixes that should not change anything to the API */


### PR DESCRIPTION
Increment API to 9.0.0 because of breaking changes (darktable.gui.libs.filter functions removal and dt_lua_snapshot_t filename removal).

Fix lua snapshot bugs found while testing dynamic snapshots.

Fill in Lua section of Release Notes.