### PR TITLE
Minor bugfixes for `DT_DEV_PIXELPIPE_PREVIEW2`

### DIFF
--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -455,7 +455,7 @@ int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, floa
   // as dt_iop_roi_t contain int values and not floats, we can have some rounding errors
   // as a workaround, we use a factor for preview pipes
   float factor = 1.0f;
-  if(piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW) factor = 100.0f;
+  if(piece->pipe->type & (DT_DEV_PIXELPIPE_PREVIEW | DT_DEV_PIXELPIPE_PREVIEW2)) factor = 100.0f;
   // we first need to be sure that all data values are computed
   // this is done in modify_roi_out fct, so we create tmp roi
   dt_iop_roi_t roi_out, roi_in;
@@ -525,7 +525,7 @@ int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, 
   // as dt_iop_roi_t contain int values and not floats, we can have some rounding errors
   // as a workaround, we use a factor for preview pipes
   float factor = 1.0f;
-  if(piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW) factor = 100.0f;
+  if(piece->pipe->type & (DT_DEV_PIXELPIPE_PREVIEW | DT_DEV_PIXELPIPE_PREVIEW2)) factor = 100.0f;
   // we first need to be sure that all data values are computed
   // this is done in modify_roi_out fct, so we create tmp roi
   dt_iop_roi_t roi_out, roi_in;

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -327,7 +327,7 @@ static int get_dither_parameters(const dt_iop_dither_data_t *const data, const d
           break;
       }
       // no automatic dithering for preview and thumbnail
-      if(piece->pipe->type & (DT_DEV_PIXELPIPE_PREVIEW | DT_DEV_PIXELPIPE_THUMBNAIL))
+      if(piece->pipe->type & (DT_DEV_PIXELPIPE_PREVIEW | DT_DEV_PIXELPIPE_PREVIEW2 | DT_DEV_PIXELPIPE_THUMBNAIL))
       {
         graymode = -1;
       }

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -387,7 +387,7 @@ static void process_cpu(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
   const dt_aligned_pixel_t norm2 = { nL * nL, nC * nC, nC * nC, 1.0f };
 
   // faster but less accurate processing by skipping half the patches on previews and thumbnails
-  int decimate = (piece->pipe->type & (DT_DEV_PIXELPIPE_PREVIEW | DT_DEV_PIXELPIPE_THUMBNAIL));
+  int decimate = (piece->pipe->type & (DT_DEV_PIXELPIPE_PREVIEW | DT_DEV_PIXELPIPE_PREVIE2 | DT_DEV_PIXELPIPE_THUMBNAIL));
 
   const dt_nlmeans_param_t params = { .scattering = 0,
                                       .scale = scale,


### PR DESCRIPTION
In a few modules we do some special treatment for preview pixelpipes for performance. In a few places there we no checks for preview2

- clipping.c
- dither.c
- nlmeans.c