### PR TITLE
Fixing tests for coeff equality in temperature module

### DIFF
--- a/src/common/math.h
+++ b/src/common/math.h
@@ -71,6 +71,12 @@ static inline float clamp_range_f(const float x, const float low, const float hi
   return x > high ? high : (x < low ? low : x);
 }
 
+// test floats difference smaller than eps 
+static inline gboolean feqf(const float v1, const float v2, const float eps)
+{
+  return (fabsf(v1 - v2) < eps);
+}
+
 // Kahan summation algorithm
 #ifdef _OPENMP
 #pragma omp declare simd aligned(c)

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -646,7 +646,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     // advertise on the pipe if coeffs are D65 for validity check
     gboolean is_D65 = TRUE;
     for(int c = 0; c < 3; c++)
-      if(fabsf(d->coeffs[c] - (float)g->daylight_wb[c]) > DT_COEFF_EPS) is_D65 = FALSE;
+      if(!feqf(d->coeffs[c], (float)g->daylight_wb[c], DT_COEFF_EPS)) is_D65 = FALSE;
 
     self->dev->proxy.wb_is_D65 = is_D65;
   }
@@ -1099,7 +1099,7 @@ void gui_update(struct dt_iop_module_t *self)
   gboolean found = FALSE;
 
   // is this a "as shot" white balance?
-  if((fabsf(p->red - g->as_shot_wb[0]) < DT_COEFF_EPS) && (fabsf(p->green - g->as_shot_wb[1]) < DT_COEFF_EPS) && (fabsf(p->blue - g->as_shot_wb[2]) < DT_COEFF_EPS))
+  if(feqf(p->red, g->as_shot_wb[0], DT_COEFF_EPS) && feqf(p->green, g->as_shot_wb[1], DT_COEFF_EPS) && feqf(p->blue, g->as_shot_wb[2], DT_COEFF_EPS))
   {
     dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_AS_SHOT);
     found = TRUE;
@@ -1107,9 +1107,9 @@ void gui_update(struct dt_iop_module_t *self)
   else
   {
     // is this a "D65 white balance"?
-    if((fabsf(p->red - (float)g->daylight_wb[0]) < DT_COEFF_EPS) &&
-       (fabsf(p->green - (float)g->daylight_wb[1]) < DT_COEFF_EPS) &&
-       (fabsf(p->blue - (float)g->daylight_wb[2]) < DT_COEFF_EPS))
+    if(feqf(p->red, (float)g->daylight_wb[0], DT_COEFF_EPS)
+      && feqf(p->green, (float)g->daylight_wb[1], DT_COEFF_EPS)
+      && feqf(p->blue, (float)g->daylight_wb[2], DT_COEFF_EPS))
     {
       dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_D65);
       found = TRUE;

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -55,6 +55,8 @@ DT_MODULE_INTROSPECTION(3, dt_iop_temperature_params_t)
 #define DT_IOP_LOWEST_TINT 0.135
 #define DT_IOP_HIGHEST_TINT 2.326
 
+#define DT_COEFF_EPS 0.00001f
+
 #define DT_IOP_NUM_OF_STD_TEMP_PRESETS 4
 
 // If you reorder presets combo, change this consts
@@ -644,7 +646,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     // advertise on the pipe if coeffs are D65 for validity check
     gboolean is_D65 = TRUE;
     for(int c = 0; c < 3; c++)
-      if(d->coeffs[c] != (float)g->daylight_wb[c]) is_D65 = FALSE;
+      if(fabsf(d->coeffs[c] - (float)g->daylight_wb[c]) > DT_COEFF_EPS) is_D65 = FALSE;
 
     self->dev->proxy.wb_is_D65 = is_D65;
   }
@@ -1097,7 +1099,7 @@ void gui_update(struct dt_iop_module_t *self)
   gboolean found = FALSE;
 
   // is this a "as shot" white balance?
-  if(p->red == g->as_shot_wb[0] && p->green == g->as_shot_wb[1] && p->blue == g->as_shot_wb[2])
+  if((fabsf(p->red - g->as_shot_wb[0]) < DT_COEFF_EPS) && (fabsf(p->green - g->as_shot_wb[1]) < DT_COEFF_EPS) && (fabsf(p->blue - g->as_shot_wb[2]) < DT_COEFF_EPS))
   {
     dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_AS_SHOT);
     found = TRUE;
@@ -1105,9 +1107,9 @@ void gui_update(struct dt_iop_module_t *self)
   else
   {
     // is this a "D65 white balance"?
-    if((p->red == (float)g->daylight_wb[0]) &&
-       (p->green == (float)g->daylight_wb[1]) &&
-       (p->blue == (float)g->daylight_wb[2]))
+    if((fabsf(p->red - (float)g->daylight_wb[0]) < DT_COEFF_EPS) &&
+       (fabsf(p->green - (float)g->daylight_wb[1]) < DT_COEFF_EPS) &&
+       (fabsf(p->blue - (float)g->daylight_wb[2]) < DT_COEFF_EPS))
     {
       dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_D65);
       found = TRUE;


### PR DESCRIPTION
There have been many reports about the popup of warning messages in the temterature and calor calibration module.

Also the check for `camera refence` D65 setting was sometime faulty.

Basically the reason for this is due to improper float tests for being equal or not-equal.

This pr replaces equality tests by tests accepting a small eps.