### PR TITLE
further stabilize panel width during search

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -121,7 +121,7 @@ typedef struct dt_iop_demosaic_params_t
   dt_iop_demosaic_greeneq_t green_eq; // $DEFAULT: DT_IOP_GREEN_EQ_NO $DESCRIPTION: "match greens"
   float median_thrs; // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "edge threshold"
   dt_iop_demosaic_smooth_t color_smoothing; // $DEFAULT: DT_DEMOSAIC_SMOOTH_OFF $DESCRIPTION: "color smoothing"
-  dt_iop_demosaic_method_t demosaicing_method; // $DEFAULT: DT_IOP_DEMOSAIC_RCD $DESCRIPTION: "demosaicing method"
+  dt_iop_demosaic_method_t demosaicing_method; // $DEFAULT: DT_IOP_DEMOSAIC_RCD $DESCRIPTION: "method"
   dt_iop_demosaic_lmmse_t lmmse_refine; // $DEFAULT: DT_LMMSE_REFINE_1 $DESCRIPTION: "LMMSE refine"
   float dual_thrs; // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.20 $DESCRIPTION: "dual threshold"
 } dt_iop_demosaic_params_t;

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2876,6 +2876,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_container_add(GTK_CONTAINER(visibility_wrapper), d->text_entry);
   gtk_box_pack_start(GTK_BOX(d->hbox_search_box), visibility_wrapper, TRUE, TRUE, 0);
   gtk_entry_set_width_chars(GTK_ENTRY(d->text_entry), 0);
+  gtk_entry_set_max_width_chars(GTK_ENTRY(d->text_entry), 50);
   gtk_entry_set_icon_tooltip_text(GTK_ENTRY(d->text_entry), GTK_ENTRY_ICON_SECONDARY, _("clear text"));
 
   gtk_box_pack_start(GTK_BOX(self->widget), d->hbox_buttons, TRUE, TRUE, 0);


### PR DESCRIPTION
The newly introduced side panel resizing based on natural width can lead to jumps when searching in modules, especially when _no_ modules are found; the panel then suddenly becomes very narrow. Also, the "demosaicing method" dropdown has a long natural width, causing its inclusion or not in a search to lead to (smaller) jumps. This shortens the label to "method" and gives the search box itself a natural width so, at least when it is visible, the panel will not shrink too much. When it is _not_visible, switching between groups (especially empty ones) can still cause jumps, but I think that is much more acceptable.

The best size for the search box depends on language (and possibly font). For English and French, 50 is (more than) enough, but German is long. Maybe this encourages at least as short as possible translations. And otherwise this can probably be customized in css as well.

This is relevant only for the "corner case" of people who have never changed the panel size, but I believe that now that the _default_ is usually "good enough" or maybe even "optimal", that group, under new users, may become the dominant one, so it is useful to avoid annoying behavior. It is also nice for people who use multiple displays with differing resolutions to be able to leave the width on default and have it auto adjust.

@MStraeten another thing I noticed in the German translation, and maybe this can't be helped, is the changed word order in the text "1 Bild (#1) von 1 ausgewahlt". In English (and French) the numbers are at start and end, so even when almost the whole text gets ellipsized in the middle, because of narrow screen/large font/wide panels/many filter widgets, the important info can still be read. This is a very, _very_, minor point and as said, there may not be a way around because I'm aware German grammar is very strict and "1 Bild (#1) ausgewahlt von 1" may just be _Wrong_, but in general it may be useful to keep this aspect in mind just a little bit, at least for functionally important sentences like this. `</ocd>`

The "method" shortening in demosaic will break shortcuts, if anybody has them set up for this widget, and lua scripts accessing it via `dt.gui.action`, which would have been crash prone in 4.0 but may become more common from 4.2 with all the work @wpferguson is putting in. It would also have to be readded to QAP.
