### PR TITLE
Improve message dialog buttons

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1558,9 +1558,6 @@ gboolean dt_control_remove_images()
                                                        NULL, PROGRESS_SIMPLE, FALSE);
   if(dt_conf_get_bool("ask_before_remove"))
   {
-    GtkWidget *dialog;
-    GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-
     const dt_control_image_enumerator_t *e = (dt_control_image_enumerator_t *)dt_control_job_get_params(job);
     const int number = g_list_length(e->index);
     if(number == 0)
@@ -1569,19 +1566,11 @@ gboolean dt_control_remove_images()
       return TRUE;
     }
 
-    dialog = gtk_message_dialog_new(
-        GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-        ngettext("do you really want to remove %d image from darktable\n(without deleting file on disk)?",
-                 "do you really want to remove %d images from darktable\n(without deleting files on disk)?", number),
-        number);
-#ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_disallow_fullscreen(dialog);
-#endif
-
-    gtk_window_set_title(GTK_WINDOW(dialog), ngettext(_("remove image?"), _("remove images?"), number));
-    gint res = gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
-    if(res != GTK_RESPONSE_YES)
+    if(!dt_gui_show_yes_no_dialog(
+          ngettext(_("remove image?"), _("remove images?"), number),
+          ngettext("do you really want to remove %d image from darktable\n(without deleting file on disk)?",
+                   "do you really want to remove %d images from darktable\n(without deleting files on disk)?", number),
+          number))
     {
       dt_control_job_dispose(job);
       return FALSE;
@@ -1599,9 +1588,6 @@ void dt_control_delete_images()
   int send_to_trash = dt_conf_get_bool("send_to_trash");
   if(dt_conf_get_bool("ask_before_delete"))
   {
-    GtkWidget *dialog;
-    GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-
     const dt_control_image_enumerator_t *e = (dt_control_image_enumerator_t *)dt_control_job_get_params(job);
     const int number = g_list_length(e->index);
 
@@ -1612,21 +1598,13 @@ void dt_control_delete_images()
       return;
     }
 
-    dialog = gtk_message_dialog_new(
-        GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-        send_to_trash ? ngettext("do you really want to physically delete %d image\n(using trash if possible)?",
-                                 "do you really want to physically delete %d images\n(using trash if possible)?", number)
-                      : ngettext("do you really want to physically delete %d image from disk?",
-                                 "do you really want to physically delete %d images from disk?", number),
-        number);
-#ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_disallow_fullscreen(dialog);
-#endif
-
-    gtk_window_set_title(GTK_WINDOW(dialog), ngettext(_("delete image?"), _("delete images?"), number));
-    gint res = gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
-    if(res != GTK_RESPONSE_YES)
+    if(!dt_gui_show_yes_no_dialog(
+          ngettext(_("delete image?"), _("delete images?"), number),
+          send_to_trash ? ngettext("do you really want to physically delete %d image\n(using trash if possible)?",
+                                   "do you really want to physically delete %d images\n(using trash if possible)?", number)
+                        : ngettext("do you really want to physically delete %d image from disk?",
+                                   "do you really want to physically delete %d images from disk?", number),
+          number))
     {
       dt_control_job_dispose(job);
       return;
@@ -1643,9 +1621,6 @@ void dt_control_delete_image(int imgid)
   int send_to_trash = dt_conf_get_bool("send_to_trash");
   if(dt_conf_get_bool("ask_before_delete"))
   {
-    GtkWidget *dialog;
-    GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-
     // Do not show the dialog if no valid image
     if(imgid < 1)
     {
@@ -1653,18 +1628,10 @@ void dt_control_delete_image(int imgid)
       return;
     }
 
-    dialog = gtk_message_dialog_new(
-        GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-        send_to_trash ? _("do you really want to physically delete selected image (using trash if possible)?")
-                      : _("do you really want to physically delete selected image from disk?"));
-#ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_disallow_fullscreen(dialog);
-#endif
-
-    gtk_window_set_title(GTK_WINDOW(dialog), _("delete image?"));
-    gint res = gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
-    if(res != GTK_RESPONSE_YES)
+    if(!dt_gui_show_yes_no_dialog(
+          _("delete image?"),
+          send_to_trash ? _("do you really want to physically delete selected image (using trash if possible)?")
+                        : _("do you really want to physically delete selected image from disk?")))
     {
       dt_control_job_dispose(job);
       return;
@@ -1709,23 +1676,15 @@ void dt_control_move_images()
 
   if(dt_conf_get_bool("ask_before_move"))
   {
-    GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT,
-                                               GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-                                               ngettext("do you really want to physically move %d image to %s?\n"
-                                                        "(all duplicates will be moved along)",
-                                                        "do you really want to physically move %d images to %s?\n"
-                                                        "(all duplicates will be moved along)",
-                                                        number),
-                                               number, dir);
-#ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_disallow_fullscreen(dialog);
-#endif
-    gtk_window_set_title(GTK_WINDOW(dialog), ngettext("move image?", "move images?", number));
-
-    gint res = gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
-
-    if(res != GTK_RESPONSE_YES) goto abort;
+    if(!dt_gui_show_yes_no_dialog(
+          ngettext("move image?", "move images?", number),
+          ngettext("do you really want to physically move %d image to %s?\n"
+                   "(all duplicates will be moved along)",
+                   "do you really want to physically move %d images to %s?\n"
+                   "(all duplicates will be moved along)",
+                   number),
+          number, dir))
+      goto abort;
   }
 
   dt_control_add_job(darktable.control, DT_JOB_QUEUE_USER_FG, job);
@@ -1771,20 +1730,12 @@ void dt_control_copy_images()
 
   if(dt_conf_get_bool("ask_before_copy"))
   {
-    GtkWidget *dialog = gtk_message_dialog_new(
-        GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-        ngettext("do you really want to physically copy %d image to %s?",
-                 "do you really want to physically copy %d images to %s?", number),
-        number, dir);
-#ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_disallow_fullscreen(dialog);
-#endif
-    gtk_window_set_title(GTK_WINDOW(dialog), ngettext("copy image?", "copy images?", number));
-
-    gint res = gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
-
-    if(res != GTK_RESPONSE_YES) goto abort;
+    if(!dt_gui_show_yes_no_dialog(
+          ngettext("copy image?", "copy images?", number),
+          ngettext("do you really want to physically copy %d image to %s?",
+                   "do you really want to physically copy %d images to %s?", number),
+          number, dir))
+      goto abort;
   }
 
   dt_control_add_job(darktable.control, DT_JOB_QUEUE_USER_FG, job);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1247,9 +1247,6 @@ static void _thumbs_ask_for_discard(dt_thumbtable_t *table)
 
   if(min_level < max_level)
   {
-    GtkWidget *dialog;
-    GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-
     gchar *txt = g_strdup(_("you have changed the settings related to how thumbnails are generated.\n"));
     if(max_level >= DT_MIPMAP_8 && min_level == DT_MIPMAP_0)
       txt = dt_util_dstrcat(txt, _("all cached thumbnails need to be invalidated.\n\n"));
@@ -1264,17 +1261,8 @@ static void _thumbs_ask_for_discard(dt_thumbtable_t *table)
 
     txt = dt_util_dstrcat(txt, _("do you want to do that now?"));
 
-    dialog = gtk_message_dialog_new(GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION,
-                                    GTK_BUTTONS_YES_NO, "%s", txt);
-#ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_disallow_fullscreen(dialog);
-#endif
-
-    gtk_window_set_title(GTK_WINDOW(dialog), _("cached thumbnails invalidation"));
-    const gint res = gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
-    g_free(txt);
-    if(res == GTK_RESPONSE_YES)
+    if(dt_gui_show_yes_no_dialog(_("cached thumbnails invalidation"),
+                                 "%s", txt))
     {
       sqlite3_stmt *stmt = NULL;
       DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT id FROM main.images", -1, &stmt, NULL);
@@ -1288,6 +1276,7 @@ static void _thumbs_ask_for_discard(dt_thumbtable_t *table)
       }
       sqlite3_finalize(stmt);
     }
+    g_free(txt);
   }
   // in any case, we update thumbtable prefs values to new ones
   table->pref_hq = hql;

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1160,13 +1160,10 @@ static gboolean _insert_shortcut(dt_shortcut_t *shortcut, gboolean confirm)
 
     if(existing_labels)
     {
-      gchar *question = g_strdup_printf("%s\n%s",
-                                        _("remove these existing shortcuts?"),
-                                        existing_labels);
-      remove_existing = dt_gui_show_yes_no_dialog(_("clashing shortcuts exist"), question);
-
+      remove_existing = dt_gui_show_yes_no_dialog(_("clashing shortcuts exist"), "%s\n%s",
+                                                  _("remove these existing shortcuts?"),
+                                                  existing_labels);
       g_free(existing_labels);
-      g_free(question);
 
       if(!remove_existing)
       {

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1039,27 +1039,6 @@ static void _shortcut_row_inserted(GtkTreeModel *tree_model, GtkTreePath *path, 
   gtk_tree_path_free(filter_path);
 }
 
-static gboolean _yes_no_dialog(gchar *title, gchar *question)
-{
-  GtkWindow *win = NULL;
-  for(GList *wins = gtk_window_list_toplevels(); wins; wins = g_list_delete_link(wins, wins))
-    if(gtk_window_is_active(wins->data)) win = wins->data;
-
-  GtkWidget *dialog = gtk_message_dialog_new(win, GTK_DIALOG_DESTROY_WITH_PARENT,
-                                             GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO, "%s", question);
-  gtk_window_set_title(GTK_WINDOW(dialog), title);
-
-#ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_disallow_fullscreen(dialog);
-#endif
-
-  const int resp = gtk_dialog_run(GTK_DIALOG(dialog));
-
-  gtk_widget_destroy(dialog);
-
-  return resp == GTK_RESPONSE_YES;
-}
-
 static gboolean _insert_shortcut(dt_shortcut_t *shortcut, gboolean confirm)
 {
   if(!shortcut->speed && shortcut->effect != DT_ACTION_EFFECT_SET)
@@ -1103,8 +1082,8 @@ static gboolean _insert_shortcut(dt_shortcut_t *shortcut, gboolean confirm)
             if(_shortcut_is_move(e) && e->effect != DT_ACTION_EFFECT_DEFAULT_MOVE)
             {
               if(!confirm ||
-                 _yes_no_dialog(_("shortcut for move exists with single effect"),
-                                _("create separate shortcuts for up and down move?")))
+                 dt_gui_show_yes_no_dialog(_("shortcut for move exists with single effect"),
+                                           _("create separate shortcuts for up and down move?")))
               {
                 e->direction = (DT_SHORTCUT_UP | DT_SHORTCUT_DOWN) ^ s->direction;
                 if(s->effect == DT_ACTION_EFFECT_DEFAULT_MOVE)
@@ -1136,8 +1115,8 @@ static gboolean _insert_shortcut(dt_shortcut_t *shortcut, gboolean confirm)
                     e->instance != s->instance )
             {
               if(!confirm ||
-                 _yes_no_dialog(_("shortcut exists with different settings"),
-                                _("reset the settings of the shortcut?")))
+                 dt_gui_show_yes_no_dialog(_("shortcut exists with different settings"),
+                                           _("reset the settings of the shortcut?")))
               {
                 _remove_shortcut(existing);
                 _add_shortcut(s, view);
@@ -1148,8 +1127,8 @@ static gboolean _insert_shortcut(dt_shortcut_t *shortcut, gboolean confirm)
             {
               // there should be no other clashes because same mapping already existed
               if(confirm &&
-                 _yes_no_dialog(_("shortcut already exists"),
-                                _("remove the shortcut?")))
+                 dt_gui_show_yes_no_dialog(_("shortcut already exists"),
+                                           _("remove the shortcut?")))
               {
                 _remove_shortcut(existing);
               }
@@ -1184,7 +1163,7 @@ static gboolean _insert_shortcut(dt_shortcut_t *shortcut, gboolean confirm)
       gchar *question = g_strdup_printf("%s\n%s",
                                         _("remove these existing shortcuts?"),
                                         existing_labels);
-      remove_existing = _yes_no_dialog(_("clashing shortcuts exist"), question);
+      remove_existing = dt_gui_show_yes_no_dialog(_("clashing shortcuts exist"), question);
 
       g_free(existing_labels);
       g_free(question);
@@ -1567,8 +1546,8 @@ static gboolean _shortcut_key_pressed(GtkWidget *widget, GdkEventKey *event, gpo
       // GDK_KEY_BackSpace moves to parent in tree
       if(event->keyval == GDK_KEY_Delete || event->keyval == GDK_KEY_KP_Delete)
       {
-        if(_yes_no_dialog(_("removing shortcut"),
-                          _("remove the selected shortcut?")))
+        if(dt_gui_show_yes_no_dialog(_("removing shortcut"),
+                                     _("remove the selected shortcut?")))
         {
           _remove_shortcut(shortcut_iter);
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2503,6 +2503,40 @@ char *dt_gui_show_standalone_string_dialog(const char *title, const char *markup
   return NULL;
 }
 
+gboolean dt_gui_show_yes_no_dialog(const char *title, const char *format, ...)
+{
+  va_list ap;
+  va_start(ap, format);
+  gchar *question = g_strdup_vprintf(format, ap);
+  va_end(ap);
+
+  GtkWindow *win = NULL;
+  for(GList *wins = gtk_window_list_toplevels(); wins; wins = g_list_delete_link(wins, wins))
+    if(gtk_window_is_active(wins->data)) win = wins->data;
+
+  GtkWidget *dialog = gtk_message_dialog_new(win,
+                                             GTK_DIALOG_DESTROY_WITH_PARENT,
+                                             GTK_MESSAGE_QUESTION,
+                                             GTK_BUTTONS_NONE,
+                                             "%s", question);
+  gtk_dialog_add_buttons(GTK_DIALOG(dialog),
+                         _("yes"), GTK_RESPONSE_YES,
+                         _("no"), GTK_RESPONSE_NO,
+                         NULL);
+  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_NO);
+  gtk_window_set_title(GTK_WINDOW(dialog), title);
+
+#ifdef GDK_WINDOWING_QUARTZ
+    dt_osx_disallow_fullscreen(dialog);
+#endif
+
+  const int resp = gtk_dialog_run(GTK_DIALOG(dialog));
+  gtk_widget_destroy(dialog);
+  g_free(question);
+
+  return resp == GTK_RESPONSE_YES;
+}
+
 // TODO: should that go to another place than gtk.c?
 void dt_gui_add_help_link(GtkWidget *widget, const char *link)
 {

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -405,6 +405,8 @@ gboolean dt_gui_show_standalone_yes_no_dialog(const char *title, const char *mar
 char *dt_gui_show_standalone_string_dialog(const char *title, const char *markup, const char *placeholder,
                                            const char *no_text, const char *yes_text);
 
+gboolean dt_gui_show_yes_no_dialog(const char *title, const char *format, ...);
+
 void dt_gui_add_help_link(GtkWidget *widget, const char *link);
 
 // load a CSS theme

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -405,6 +405,7 @@ gboolean dt_gui_show_standalone_yes_no_dialog(const char *title, const char *mar
 char *dt_gui_show_standalone_string_dialog(const char *title, const char *markup, const char *placeholder,
                                            const char *no_text, const char *yes_text);
 
+// returns TRUE if YES was answered, FALSE otherwise
 gboolean dt_gui_show_yes_no_dialog(const char *title, const char *format, ...);
 
 void dt_gui_add_help_link(GtkWidget *widget, const char *link);

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -996,7 +996,7 @@ static gboolean tree_key_press_presets(GtkWidget *widget, GdkEventKey *event, gp
                        P_MODULE_COLUMN, &operation, P_EDITABLE_COLUMN, &editable, -1);
     if(editable == NULL)
     {
-      if(dt_gui_presets_confirm_and_delete(_preferences_dialog, name, operation, rowid))
+      if(dt_gui_presets_confirm_and_delete(name, operation, rowid))
         _delete_line_and_empty_parent(model, &iter);
     }
     else

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -167,23 +167,9 @@ static void _menuitem_delete_preset(GtkMenuItem *menuitem, dt_iop_module_t *modu
     return;
   }
 
-  gint res = GTK_RESPONSE_YES;
-
-  if(dt_conf_get_bool("plugins/lighttable/preset/ask_before_delete_preset"))
-  {
-    GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
-    GtkWidget *dialog
-      = gtk_message_dialog_new(GTK_WINDOW(window), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION,
-                               GTK_BUTTONS_YES_NO, _("do you really want to delete the preset `%s'?"), name);
-#ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_disallow_fullscreen(dialog);
-#endif
-    gtk_window_set_title(GTK_WINDOW(dialog), _("delete preset?"));
-    res = gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
-  }
-
-  if(res == GTK_RESPONSE_YES)
+  if(!dt_conf_get_bool("plugins/lighttable/preset/ask_before_delete_preset")
+     || dt_gui_show_yes_no_dialog(_("delete preset?"),
+                                  _("do you really want to delete the preset `%s'?"), name))
   {
     dt_action_rename_preset(&module->so->actions, name, NULL);
 
@@ -254,21 +240,9 @@ static void _edit_preset_response(GtkDialog *dialog, gint response_id, dt_gui_pr
       {
         sqlite3_finalize(stmt);
 
-        // show overwrite question dialog
-        GtkWidget *dlg_overwrite = gtk_message_dialog_new(
-            GTK_WINDOW(dialog), GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL, GTK_MESSAGE_WARNING,
-            GTK_BUTTONS_YES_NO, _("preset `%s' already exists.\ndo you want to overwrite?"), name);
-#ifdef GDK_WINDOWING_QUARTZ
-        dt_osx_disallow_fullscreen(dlg_overwrite);
-#endif
-
-        gtk_window_set_title(GTK_WINDOW(dlg_overwrite), _("overwrite preset?"));
-
-        const gint dlg_ret = gtk_dialog_run(GTK_DIALOG(dlg_overwrite));
-        gtk_widget_destroy(dlg_overwrite);
-
         // if result is BUTTON_NO or ESCAPE keypress exit without destroying dialog, to permit other name
-        if(dlg_ret == GTK_RESPONSE_YES)
+        if(dt_gui_show_yes_no_dialog(_("overwrite preset?"),
+                                     _("preset `%s' already exists.\ndo you want to overwrite?"), name))
         {
           // we remove the preset that will be overwrite
           dt_lib_presets_remove(name, g->operation, g->op_version);
@@ -402,7 +376,7 @@ static void _edit_preset_response(GtkDialog *dialog, gint response_id, dt_gui_pr
   }
   else if(response_id == GTK_RESPONSE_REJECT && g->old_id)
   {
-    if(dt_gui_presets_confirm_and_delete(GTK_WIDGET(dialog), g->original_name, g->operation, g->old_id)
+    if(dt_gui_presets_confirm_and_delete(g->original_name, g->operation, g->old_id)
        && g->callback)
     {
       g->old_id = 0;
@@ -417,21 +391,12 @@ static void _edit_preset_response(GtkDialog *dialog, gint response_id, dt_gui_pr
   free(g);
 }
 
-gboolean dt_gui_presets_confirm_and_delete(GtkWidget *parent_dialog, const char *name, const char *module_name, int rowid)
+gboolean dt_gui_presets_confirm_and_delete(const char *name, const char *module_name, int rowid)
 {
   if(!module_name) return FALSE;
 
-  // This means with want to remove the preset
-  GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(parent_dialog), GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL,
-                                             GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-                                             _("do you really want to delete the preset `%s'?"), name);
-#ifdef GDK_WINDOWING_QUARTZ
-  dt_osx_disallow_fullscreen(dialog);
-#endif
-
-  gtk_window_set_title(GTK_WINDOW(dialog), _("delete preset?"));
-  gboolean do_delete = gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_YES;
-  if(do_delete)
+  if(dt_gui_show_yes_no_dialog(_("delete preset?"),
+                               _("do you really want to delete the preset `%s'?"), name))
   {
     // deregistering accel...
     for(GList *modules = darktable.iop; modules; modules = modules->next)
@@ -462,10 +427,11 @@ gboolean dt_gui_presets_confirm_and_delete(GtkWidget *parent_dialog, const char 
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, rowid);
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
-  }
-  gtk_widget_destroy(dialog);
 
-  return do_delete;
+    return TRUE;
+  }
+
+  return FALSE;
 }
 
 static void _check_buttons_activated(GtkCheckButton *button, dt_gui_presets_edit_dialog_t *g)
@@ -827,23 +793,8 @@ static void _menuitem_update_preset(GtkMenuItem *menuitem, dt_iop_module_t *modu
 {
   gchar *name = g_object_get_data(G_OBJECT(menuitem), "dt-preset-name");
 
-  gint res = GTK_RESPONSE_YES;
-
-  if(dt_conf_get_bool("plugins/lighttable/preset/ask_before_delete_preset"))
-  {
-    GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
-    GtkWidget *dialog
-      = gtk_message_dialog_new(GTK_WINDOW(window), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION,
-                               GTK_BUTTONS_YES_NO, _("do you really want to update the preset `%s'?"), name);
-#ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_disallow_fullscreen(dialog);
-#endif
-    gtk_window_set_title(GTK_WINDOW(dialog), _("update preset?"));
-    res = gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
-  }
-
-  if(res == GTK_RESPONSE_YES)
+  if(!dt_conf_get_bool("plugins/lighttable/preset/ask_before_delete_preset")
+     || dt_gui_show_yes_no_dialog(_("update preset?"), _("do you really want to update the preset `%s'?"), name))
   {
     // commit all the module fields
     sqlite3_stmt *stmt;

--- a/src/gui/presets.h
+++ b/src/gui/presets.h
@@ -134,7 +134,7 @@ void dt_gui_presets_show_edit_dialog(const char *name_in, const char *module_nam
                                      GCallback final_callback, gpointer data, gboolean allow_name_change,
                                      gboolean allow_desc_change, gboolean allow_remove, GtkWindow *parent);
 
-gboolean dt_gui_presets_confirm_and_delete(GtkWidget *parent_dialog, const char *name, const char *module_name, int rowid);
+gboolean dt_gui_presets_confirm_and_delete(const char *name, const char *module_name, int rowid);
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -202,21 +202,9 @@ static void _gui_styles_new_style_response(GtkDialog *dialog, gint response_id, 
       /* show prompt dialog when style already exists */
       if(name && (dt_styles_exists(name)) != 0)
       {
-        GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
-        GtkWidget *dlg_overwrite = gtk_message_dialog_new(
-            GTK_WINDOW(window), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_WARNING, GTK_BUTTONS_YES_NO,
-            _("style `%s' already exists.\ndo you want to overwrite?"), name);
-#ifdef GDK_WINDOWING_QUARTZ
-        dt_osx_disallow_fullscreen(dlg_overwrite);
-#endif
-
-        gtk_window_set_title(GTK_WINDOW(dlg_overwrite), _("overwrite style?"));
-
-        const gint dlg_ret = gtk_dialog_run(GTK_DIALOG(dlg_overwrite));
-        gtk_widget_destroy(dlg_overwrite);
-
         /* on button yes delete style name for overwriting */
-        if(dlg_ret == GTK_RESPONSE_YES)
+        if(dt_gui_show_yes_no_dialog(_("overwrite style?"),
+                                     _("style `%s' already exists.\ndo you want to overwrite?"), name))
         {
           dt_styles_delete_by_name(name);
         }

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -219,31 +219,15 @@ static void copy_parts_button_clicked(GtkWidget *widget, gpointer user_data)
 
 static void discard_button_clicked(GtkWidget *widget, gpointer user_data)
 {
-  gint res = GTK_RESPONSE_YES;
-
   GList *imgs = dt_act_on_get_images(TRUE, TRUE, FALSE);
   if(!imgs) return;
 
-  if(dt_conf_get_bool("ask_before_discard"))
-  {
-    const GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
+  const int number = g_list_length((GList *)imgs);
 
-    const int number = g_list_length((GList *)imgs);
-
-    GtkWidget *dialog = gtk_message_dialog_new(
-        GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-        ngettext("do you really want to clear history of %d selected image?",
-                 "do you really want to clear history of %d selected images?", number), number);
-#ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_disallow_fullscreen(dialog);
-#endif
-
-    gtk_window_set_title(GTK_WINDOW(dialog), _("delete images' history?"));
-    res = gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
-  }
-
-  if(res == GTK_RESPONSE_YES)
+  if(!dt_conf_get_bool("ask_before_discard")
+     || dt_gui_show_yes_no_dialog(_("delete images' history?"),
+          ngettext("do you really want to clear history of %d selected image?",
+                   "do you really want to clear history of %d selected images?", number), number))
   {
     dt_history_delete_on_list(imgs, TRUE);
     dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -307,21 +307,12 @@ static void _export_button_clicked(GtkWidget *widget, dt_lib_export_t *d)
     confirm_message = mstorage->ask_user_confirmation(mstorage);
   if(confirm_message)
   {
-    const GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-    GtkWidget *dialog = gtk_message_dialog_new(
-        GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-        "%s", confirm_message);
-#ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_disallow_fullscreen(dialog);
-#endif
 
-    gtk_window_set_title(GTK_WINDOW(dialog), _("export to disk"));
-    const gint res = gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
+    gboolean res = dt_gui_show_yes_no_dialog(_("export to disk"),  "%s", confirm_message);
     g_free(confirm_message);
     confirm_message = NULL;
 
-    if(res != GTK_RESPONSE_YES)
+    if(!res)
     {
       return;
     }

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -1211,25 +1211,9 @@ void gui_reset(dt_lib_module_t *self)
   const int32_t imgid = darktable.develop->image_storage.id;
   if(!imgid) return;
 
-  gint res = GTK_RESPONSE_YES;
-
-  if(dt_conf_get_bool("ask_before_discard"))
-  {
-    const GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-
-    GtkWidget *dialog = gtk_message_dialog_new(
-        GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-        _("do you really want to clear history of current image?"));
-#ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_disallow_fullscreen(dialog);
-#endif
-
-    gtk_window_set_title(GTK_WINDOW(dialog), _("delete image's history?"));
-    res = gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
-  }
-
-  if(res == GTK_RESPONSE_YES)
+  if(!dt_conf_get_bool("ask_before_discard")
+     || dt_gui_show_yes_no_dialog(_("delete image's history?"),
+                                  _("do you really want to clear history of current image?")))
   {
     dt_dev_undo_start_record(darktable.develop);
 

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -151,23 +151,9 @@ static void menuitem_update_preset(GtkMenuItem *menuitem, dt_lib_module_info_t *
 {
   char *name = g_object_get_data(G_OBJECT(menuitem), "dt-preset-name");
 
-  gint res = GTK_RESPONSE_YES;
-
-  if(dt_conf_get_bool("plugins/lighttable/preset/ask_before_delete_preset"))
-  {
-    GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
-    GtkWidget *dialog
-      = gtk_message_dialog_new(GTK_WINDOW(window), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION,
-                               GTK_BUTTONS_YES_NO, _("do you really want to update the preset `%s'?"), name);
-#ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_disallow_fullscreen(dialog);
-#endif
-    gtk_window_set_title(GTK_WINDOW(dialog), _("update preset?"));
-    res = gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
-  }
-
-  if(res == GTK_RESPONSE_YES)
+  if(!dt_conf_get_bool("plugins/lighttable/preset/ask_before_delete_preset")
+     || dt_gui_show_yes_no_dialog(_("update preset?"),
+                                  _("do you really want to update the preset `%s'?"), name))
   {
     // commit all the module fields
     sqlite3_stmt *stmt;
@@ -238,23 +224,9 @@ static void menuitem_delete_preset(GtkMenuItem *menuitem, dt_lib_module_info_t *
   gchar *name = get_active_preset_name(minfo);
   if(name == NULL) return;
 
-  gint res = GTK_RESPONSE_YES;
-
-  if(dt_conf_get_bool("plugins/lighttable/preset/ask_before_delete_preset"))
-  {
-    GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
-    GtkWidget *dialog
-      = gtk_message_dialog_new(GTK_WINDOW(window), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION,
-                               GTK_BUTTONS_YES_NO, _("do you really want to delete the preset `%s'?"), name);
-#ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_disallow_fullscreen(dialog);
-#endif
-    gtk_window_set_title(GTK_WINDOW(dialog), _("delete preset?"));
-    res = gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
-  }
-
-  if(res == GTK_RESPONSE_YES)
+  if(!dt_conf_get_bool("plugins/lighttable/preset/ask_before_delete_preset")
+     || dt_gui_show_yes_no_dialog(_("delete preset?"),
+                                  _("do you really want to delete the preset `%s'?"), name))
   {
     dt_action_rename_preset(&minfo->module->actions, name, NULL);
 

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -3766,22 +3766,10 @@ static void _manage_preset_change(GtkWidget *widget, dt_lib_module_t *self)
 static void _manage_preset_delete(GtkWidget *widget, dt_lib_module_t *self)
 {
   dt_lib_modulegroups_t *d = (dt_lib_modulegroups_t *)self->data;
-  gint res = GTK_RESPONSE_YES;
 
-  if(dt_conf_get_bool("plugins/lighttable/preset/ask_before_delete_preset"))
-  {
-    GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(d->dialog), GTK_DIALOG_DESTROY_WITH_PARENT,
-                                               GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-                                               _("do you really want to delete the preset `%s'?"), d->edit_preset);
-#ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_disallow_fullscreen(dialog);
-#endif
-    gtk_window_set_title(GTK_WINDOW(dialog), _("delete preset?"));
-    res = gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
-  }
-
-  if(res == GTK_RESPONSE_YES)
+  if(!dt_conf_get_bool("plugins/lighttable/preset/ask_before_delete_preset")
+     || dt_gui_show_yes_no_dialog(_("delete preset?"),
+                                  _("do you really want to delete the preset `%s'?"), d->edit_preset))
   {
     dt_lib_presets_remove(d->edit_preset, self->plugin_name, self->version());
 

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -311,25 +311,11 @@ static void edit_clicked(GtkWidget *w, gpointer user_data)
 
 gboolean _ask_before_delete_style(const gint style_cnt)
 {
-  gint res = GTK_RESPONSE_YES;
-
-  if(dt_conf_get_bool("plugins/lighttable/style/ask_before_delete_style"))
-  {
-    const GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-    GtkWidget *dialog = gtk_message_dialog_new
-      (GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-       ngettext("do you really want to remove %d style?", "do you really want to remove %d styles?", style_cnt),
-       style_cnt);
-#ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_disallow_fullscreen(dialog);
-#endif
-
-    gtk_window_set_title(GTK_WINDOW(dialog), ngettext("remove style?", "remove styles?", style_cnt));
-    res = gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
-  }
-
-  return res == GTK_RESPONSE_YES;
+return !dt_conf_get_bool("plugins/lighttable/style/ask_before_delete_style")
+       || dt_gui_show_yes_no_dialog(
+            ngettext("remove style?", "remove styles?", style_cnt),
+            ngettext("do you really want to remove %d style?", "do you really want to remove %d styles?", style_cnt),
+            style_cnt);
 }
 
 static void delete_clicked(GtkWidget *w, gpointer user_data)

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -640,18 +640,8 @@ static void _main_do_event_help(GdkEvent *event, gpointer data)
             last_base_url = base_url;
 
             // ask the user if darktable.org may be accessed
-            GtkWidget *dialog = gtk_message_dialog_new
-              (GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT,
-               GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-               _("do you want to access `%s'?"), last_base_url);
-#ifdef GDK_WINDOWING_QUARTZ
-            dt_osx_disallow_fullscreen(dialog);
-#endif
-
-            gtk_window_set_title(GTK_WINDOW(dialog), _("access the online usermanual?"));
-            const gint res = gtk_dialog_run(GTK_DIALOG(dialog));
-            gtk_widget_destroy(dialog);
-            if(res == GTK_RESPONSE_YES)
+            if(dt_gui_show_yes_no_dialog(_("access the online usermanual?"),
+                                         _("do you want to access `%s'?"), last_base_url))
             {
               dt_conf_set_string("context_help/last_url", last_base_url);
             }


### PR DESCRIPTION
This is what I had in mind here https://github.com/darktable-org/darktable/pull/12303#issuecomment-1221311267

Also, taking into consideration https://euroquis.nl//kde/2022/11/14/refactor.html, I went over all uses of `GTK_BUTTONS_YES_NO` and only left one, that actually expands the dialog further before showing it so doesn't fit in this use case.

closes #12027

This is a bit chunky for a last-minute patch, even though it is all basically reformatting and no new functionality. It reuses the basis of a similar routine in `accelerators.c`, which makes sure it is on top of whatever window it was called from. This _should_ not cause any issues elsewhere. It fixes a bug, but we've had that for a long while...

