### PR TITLE
[bugfix] Fix crash on images with crop transformation in libheif loader

### DIFF
--- a/src/common/imageio_heif.c
+++ b/src/common/imageio_heif.c
@@ -95,8 +95,11 @@ dt_imageio_retval_t dt_imageio_open_heif(dt_image_t *img,
     goto out;
   }
 
+  struct heif_decoding_options *decode_options = heif_decoding_options_alloc();
+  decode_options->ignore_transformations = TRUE;
   // Darktable only supports LITTLE_ENDIAN systems, so RRGGBB_LE should be fine
-  err = heif_decode_image(handle, &heif_img, heif_colorspace_RGB, heif_chroma_interleaved_RRGGBB_LE, NULL);
+  err = heif_decode_image(handle, &heif_img, heif_colorspace_RGB, heif_chroma_interleaved_RRGGBB_LE, decode_options);
+  heif_decoding_options_free(decode_options);
   if(err.code != heif_error_Ok)
   {
     dt_print(DT_DEBUG_IMAGEIO,


### PR DESCRIPTION
The crash can be reproduced by trying to import an image from https://github.com/link-u/avif-sample-images/blob/master/kimono.crop.avif

Before #12889 this could be done on a standard dt build, because although the test file is AVIF, it was rejected by libavif loader due to strict mode warning and the libheif loader used as fallback. But now the libavif loader successfully imports this image. So, in order to reproduce the crash _on this particular image_ at the moment, you need to build dt without libavif, or, say, temporarily for the test, rearrange the loaders in dt_imageio_open so that dt_imageio_open_heif stands before dt_imageio_open_avif.

The problem, obviously, is that the decoder outputted only the cropped part of the image, hence a smaller number of bytes. But the following code, not knowing about it, tries to read the image buffer based on the number of bytes of the full image. And as a result, it segfaults.
