### PR TITLE
HLR segmentation refinements and stabilisation

### DIFF
--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -38,7 +38,7 @@
    Again the algorithm has been developed in collaboration by @garagecoder and @Iain from gmic team and @jenshannoschwalm from dt.
 */
 
-static inline float _calc_linear_refavg(const float *in, const int row, const int col, const dt_iop_roi_t *const roi, const int color)
+static inline float _calc_linear_refavg(const float *in, const dt_iop_roi_t *const roi, const int color)
 {
   dt_aligned_pixel_t mean = { 0.0f, 0.0f, 0.0f };
   for(int dy = -1; dy < 2; dy++)
@@ -137,7 +137,7 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
         {
           if(in[c] >= clips[c])
           {
-            tmp[c] = _calc_linear_refavg(&in[0], row, col, roi_in, c);
+            tmp[c] = _calc_linear_refavg(&in[0], roi_in, c);
             mask_buffer[c * p_size + _raw_to_plane(pwidth, row, col)] |= 1;
             anyclipped += 1;
           }
@@ -178,7 +178,7 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
           const float inval = fmaxf(0.0f, in[c]); 
           if((mask_buffer[c * p_size + _raw_to_plane(pwidth, row, col)]) && (inval > clipdark[c]) && (inval < clips[c]))
           {
-            cr_sum[c] += inval - _calc_linear_refavg(&in[0], row, col, roi_in, c);
+            cr_sum[c] += inval - _calc_linear_refavg(&in[0], roi_in, c);
             cr_cnt[c] += 1.0f;
           }
         }

--- a/src/iop/segmentation.h
+++ b/src/iop/segmentation.h
@@ -627,15 +627,20 @@ void dt_segments_transform_erode(dt_iop_segmentation_t *seg, const int radius)
   _intimage_borderfill(img, width, height, 1, border);
   _eroding(img, seg->tmp, width, height, border, radius);
   memcpy(img, seg->tmp, width*height * sizeof(int));
+ _intimage_borderfill(img, width, height, 0, border);
 }
   
 void dt_segments_transform_closing(dt_iop_segmentation_t *seg, const int radius)
 {
-  if(radius < 1) return;
   int *img = seg->data;
   const int width = seg->width;
   const int height = seg->height;
   const int border = seg->border;
+  if(radius < 1)
+  {
+    _intimage_borderfill(img, width, height, 0, border);
+    return;
+  }
   if(!seg->tmp) seg->tmp = dt_alloc_align(64, width * height * sizeof(int));
   if(!seg->tmp) return;
 


### PR DESCRIPTION
1. @MStraeten gave me an image from EOS 7D leading to investigation of possibly oversegmentations in current code. I tested / rechecked many images i already have and from pixls, indeed some cameras generate "sort of chroma noise" around the clipping value leading to extremely large numbers of segments. To keep control of that we now have at least a minimal dilating of 1, this is safe also for all other images.
2. As pointed out by @dhoulder we don't need col/row in `_calc_linear_refavg`
3. For stability we ensure valid border data for output in all morphological operations.
4. Improved security while calculating candidates.
5. Improved debugging output

@TurboGit this is for 4.2; at least 1,3 and 4 are fixes.