### PR TITLE
Updated sq translation

### DIFF
--- a/po/sq.po
+++ b/po/sq.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: darktable\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-17 21:52+0100\n"
-"PO-Revision-Date: 2022-11-18 09:00+0100\n"
+"POT-Creation-Date: 2022-11-21 22:59+0100\n"
+"PO-Revision-Date: 2022-11-22 09:45+0100\n"
 "Last-Translator: Besmir Godole <bgodole@gmail.com>\n"
 "Language-Team: Albanian\n"
 "Language: sq_AL\n"
@@ -229,7 +229,7 @@ msgstr ""
 
 #: ../build/bin/conf_gen.h:916
 msgid "apply metadata"
-msgstr "aplikoj metadatat"
+msgstr "aplikimi i metadatave"
 
 #: ../build/bin/conf_gen.h:917
 msgid "apply some metadata to all newly imported images."
@@ -470,7 +470,7 @@ msgid ""
 "influence the calculation time"
 msgstr ""
 "rritni ose zvogëloni përmasën hapësinore që zë grupi i imazheve në hartë. "
-"ndikon te vonesat në llogaritje"
+"mund të vonojë llogaritjen"
 
 #: ../build/bin/conf_gen.h:1796
 msgid "min images per group"
@@ -481,8 +481,7 @@ msgid ""
 "the minimum number of images to set up an images group. can influence the "
 "calculation time."
 msgstr ""
-"numri minimal i imazheve që përbëjnë një grup. ndikon te vonesat në "
-"llogaritje."
+"numri minimal i imazheve që përbëjnë një grup. mund të vonojë llogaritjen."
 
 #: ../build/bin/conf_gen.h:1802
 msgctxt "preferences"
@@ -503,7 +502,7 @@ msgid ""
 "three options are available: images thumbnails, only the count of images of "
 "the group or nothing"
 msgstr ""
-"ka tre mundësi: miniaturat e imazheve, vetëm numrin e imazheve në grup ose "
+"keni tre mundësi: miniaturat e imazheve, vetëm numrin e imazheve në grup ose "
 "asnjë"
 
 #: ../build/bin/conf_gen.h:1818
@@ -1007,7 +1006,7 @@ msgstr "miniaturat"
 
 #: ../build/bin/preferences_gen.h:4178
 msgid "use raw file instead of embedded JPEG from size"
-msgstr "përdor skedarin bruto, jo JPEG-në e bashkëngjitur"
+msgstr "përdorimi i skedarit bruto në vend të JPEG-së së bashkëngjitur"
 
 #: ../build/bin/preferences_gen.h:4251
 msgid ""
@@ -1025,7 +1024,7 @@ msgstr ""
 
 #: ../build/bin/preferences_gen.h:4273
 msgid "high quality processing from size"
-msgstr "procesoj me cilësi të lartë"
+msgstr "procesimi me cilësi të lartë"
 
 #: ../build/bin/preferences_gen.h:4346
 msgid ""
@@ -1166,7 +1165,7 @@ msgstr ""
 
 #: ../build/bin/preferences_gen.h:4967
 msgid "reduce resolution of preview image"
-msgstr "zvogëloj rezolucionin e imazhit të parashikuar"
+msgstr "zvogëlimi i rezolucionit për imazhin e parashikuar"
 
 #: ../build/bin/preferences_gen.h:5015
 msgid "decrease to speed up preview rendering, may hinder accurate masking"
@@ -1228,7 +1227,7 @@ msgstr "ky opsion lidhet me funksionin e klikimit me shift në dhomën e errët"
 
 #: ../build/bin/preferences_gen.h:5249
 msgid "only collapse modules in current group"
-msgstr "vetëm palos modulet në grupin aktual"
+msgstr "palos vetëm modulet në grupin aktual"
 
 #: ../build/bin/preferences_gen.h:5263
 msgid ""
@@ -1256,7 +1255,7 @@ msgstr "modulet e shpalosura të procesimit të hapen nga kreu"
 
 #: ../build/bin/preferences_gen.h:5357
 msgid "show right-side buttons in processing module headers"
-msgstr "shfaq djathtas butonët në modulet e procesimit"
+msgstr "paraqitja e butonëve djathtas në titujt e moduleve të procesimit"
 
 #: ../build/bin/preferences_gen.h:5425
 msgid ""
@@ -1284,7 +1283,7 @@ msgstr ""
 
 #: ../build/bin/preferences_gen.h:5447
 msgid "show mask indicator in module headers"
-msgstr "shfaq treguesin e maskës në titullin e modulit"
+msgstr "shfaq treguesin e maskës në titujt e moduleve"
 
 #: ../build/bin/preferences_gen.h:5461
 msgid ""
@@ -1347,7 +1346,7 @@ msgstr ""
 
 #: ../build/bin/preferences_gen.h:5719
 msgid "3D lut root folder"
-msgstr "dosja bazë për 3D lut"
+msgstr "dosja bazë për lut 3D"
 
 #: ../build/bin/preferences_gen.h:5724 ../src/control/jobs/control_jobs.c:1660
 #: ../src/control/jobs/control_jobs.c:1714 ../src/gui/preferences.c:1070
@@ -1370,7 +1369,7 @@ msgstr ""
 
 #: ../build/bin/preferences_gen.h:5762
 msgid "auto-apply pixel workflow defaults"
-msgstr "vetaplikoj procesin standard të punës"
+msgstr "procesi standard i punës"
 
 #: ../build/bin/preferences_gen.h:5805
 msgid ""
@@ -1386,7 +1385,7 @@ msgstr ""
 
 #: ../build/bin/preferences_gen.h:5827
 msgid "auto-apply chromatic adaptation defaults"
-msgstr "vetaplikoj adaptimin kromatik standard"
+msgstr "adaptimi kromatik standard"
 
 #: ../build/bin/preferences_gen.h:5865
 msgid ""
@@ -1696,7 +1695,7 @@ msgstr "të tjera"
 
 #: ../build/bin/preferences_gen.h:6802
 msgid "password storage backend to use"
-msgstr "përdor depon vartëse të fjalëkalimeve"
+msgstr "përdorimi i depos vartëse të fjalëkalimeve"
 
 #: ../build/bin/preferences_gen.h:6852
 msgid ""
@@ -1726,7 +1725,7 @@ msgstr "databaza"
 
 #: ../build/bin/preferences_gen.h:6943
 msgid "create database snapshot"
-msgstr "krijoj një pozë të databazës"
+msgstr "krijimi i pozës së databazës"
 
 #: ../build/bin/preferences_gen.h:6996
 msgid ""
@@ -1770,7 +1769,7 @@ msgstr "XMP"
 
 #: ../build/bin/preferences_gen.h:7071
 msgid "write sidecar file for each image"
-msgstr "shkruaj skedarin shoqërues për çdo imazh"
+msgstr "shkrimi i skedarit shoqërues për çdo imazh"
 
 #: ../build/bin/preferences_gen.h:7114
 msgid ""
@@ -1792,7 +1791,7 @@ msgstr ""
 
 #: ../build/bin/preferences_gen.h:7136
 msgid "store XMP tags in compressed format"
-msgstr "ruaj etiketat XMP në format të kompresuar"
+msgstr "ruajtja me kompresim e etiketave XMP"
 
 #: ../build/bin/preferences_gen.h:7179
 msgid ""
@@ -1902,7 +1901,7 @@ msgstr "indikatorët pozicionohen lart-majtas ose poshtë-djathtas ekranit"
 
 #: ../build/bin/preferences_gen.h:7552
 msgid "method to use for getting the display profile"
-msgstr "metoda që përdor për marrjen e profilit të ekranit"
+msgstr "metoda e përdorur për marrjen e profilit të ekranit"
 
 #: ../build/bin/preferences_gen.h:7595
 msgid ""
@@ -1914,7 +1913,7 @@ msgstr ""
 
 #: ../build/bin/preferences_gen.h:7617
 msgid "order or exclude midi devices"
-msgstr "radhit ose përjashtoj aparatet midi"
+msgstr "radhitja ose përjashtimi i aparateve midi"
 
 #: ../build/bin/preferences_gen.h:7635
 msgid ""
@@ -2062,7 +2061,7 @@ msgstr "koha e pritjes për fotot e diafilmit"
 #: ../build/bin/preferences_gen.h:8058 ../src/control/jobs/control_jobs.c:2319
 #: ../src/libs/import.c:172
 msgid "import"
-msgstr "importoj"
+msgstr "importimi"
 
 #: ../build/bin/preferences_gen.h:8061
 msgid "session options"
@@ -2070,7 +2069,7 @@ msgstr "opsionet e sesionit"
 
 #: ../build/bin/preferences_gen.h:8081
 msgid "base directory naming pattern"
-msgstr "modeli e emërtimit të direktorisë bazë"
+msgstr "modeli i emërtimit të direktorisë bazë"
 
 #: ../build/bin/preferences_gen.h:8099 ../build/bin/preferences_gen.h:8139
 msgid "part of full import path for an import session"
@@ -2078,7 +2077,7 @@ msgstr "adresa e plotë e importit për sesionin e importit"
 
 #: ../build/bin/preferences_gen.h:8121
 msgid "sub directory naming pattern"
-msgstr "modeli e emërtimit të nëndirektorive"
+msgstr "modeli i emërtimit të nëndirektorive"
 
 #: ../build/bin/preferences_gen.h:8161
 msgid "keep original filename"
@@ -2123,11 +2122,11 @@ msgstr ""
 
 #: ../build/bin/preferences_gen.h:8348 ../build/bin/preferences_gen.h:8588
 msgid "number of collections to be stored"
-msgstr "numri i koleksioneve që do të ruhen"
+msgstr "numri i koleksioneve që duhen ruajtur"
 
 #: ../build/bin/preferences_gen.h:8372 ../build/bin/preferences_gen.h:8612
 msgid "the number of recent collections to store and show in this list"
-msgstr "numri i koleksioneve të fundit që do të ruhen dhe shfaqen në listë"
+msgstr "numri i koleksioneve të fundit që ruhen dhe shfaqen në listë"
 
 #: ../build/bin/preferences_gen.h:8394
 msgid "hide the history button and show a specific module instead"
@@ -3265,7 +3264,7 @@ msgstr "prag statik (shpejt)"
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:90
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:163
 msgid "match greens"
-msgstr "përputh të gjelbrat"
+msgstr "përputhja e të gjelbrave"
 
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:96
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:167
@@ -3277,7 +3276,7 @@ msgstr "pragu këndor"
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:102
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:171
 msgid "color smoothing"
-msgstr "rrafshoj ngjyrat"
+msgstr "rrafshimi i ngjyrave"
 
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:108
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:175
@@ -3456,7 +3455,7 @@ msgstr "përmirësoni transformimin e profilizuar"
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:388
 #: ../src/imageio/format/avif.c:782 ../src/libs/colorpicker.c:577
 msgid "color mode"
-msgstr "metoda e ngjyrave"
+msgstr "mënyra e ngjyrimit"
 
 #: ../build/lib/darktable/plugins/introspection_denoiseprofile.c:410
 #: ../src/libs/colorpicker.c:51 ../src/libs/colorpicker.c:260
@@ -3784,15 +3783,15 @@ msgstr "poissonian"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:572
 msgid "hard"
-msgstr "e fortë"
+msgstr "i fortë"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:573
 msgid "soft"
-msgstr "e butë"
+msgstr "i butë"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:574
 msgid "safe"
-msgstr "e sigurt"
+msgstr "i sigurt"
 
 #: ../build/lib/darktable/plugins/introspection_filmicrgb.c:578
 msgid "v1 (2019)"
@@ -3851,7 +3850,7 @@ msgstr "tonet e mesme"
 
 #: ../build/lib/darktable/plugins/introspection_highlights.c:141
 #: ../build/lib/darktable/plugins/introspection_highlights.c:242
-#: ../src/views/darkroom.c:2309
+#: ../src/views/darkroom.c:2311
 msgid "clipping threshold"
 msgstr "pragu i shkurtimit"
 
@@ -3878,35 +3877,35 @@ msgstr "rindërtimi"
 #: ../build/lib/darktable/plugins/introspection_highlights.c:183
 #: ../build/lib/darktable/plugins/introspection_highlights.c:270
 msgid "inpaint a flat color"
-msgstr "pikturoj me ngjyrë të sheshtë"
+msgstr "pikturimi me ngjyrë të sheshtë"
 
 #: ../build/lib/darktable/plugins/introspection_highlights.c:284
-#: ../src/iop/highlights.c:2338 ../src/iop/highlights.c:2344
+#: ../src/iop/highlights.c:2368 ../src/iop/highlights.c:2374
 msgid "clip highlights"
 msgstr "shkurtoj reflekset"
 
 #: ../build/lib/darktable/plugins/introspection_highlights.c:285
-#: ../src/iop/highlights.c:2342
+#: ../src/iop/highlights.c:2372
 msgid "reconstruct in LCh"
 msgstr "rindërtoj në LCh"
 
 #: ../build/lib/darktable/plugins/introspection_highlights.c:286
-#: ../src/iop/highlights.c:2291 ../src/iop/highlights.c:2354
+#: ../src/iop/highlights.c:2321 ../src/iop/highlights.c:2384
 msgid "reconstruct color"
 msgstr "rindërtoj ngjyrat"
 
 #: ../build/lib/darktable/plugins/introspection_highlights.c:287
-#: ../src/iop/highlights.c:2349
+#: ../src/iop/highlights.c:2379
 msgid "guided laplacians"
 msgstr "laplacianët drejtues"
 
 #: ../build/lib/darktable/plugins/introspection_highlights.c:288
-#: ../src/iop/highlights.c:2346
+#: ../src/iop/highlights.c:2376
 msgid "segmentation based"
 msgstr "segmentoj"
 
 #: ../build/lib/darktable/plugins/introspection_highlights.c:289
-#: ../src/iop/highlights.c:2334
+#: ../src/iop/highlights.c:2364
 msgid "inpaint opposed"
 msgstr "kundërpikturoj"
 
@@ -3973,7 +3972,7 @@ msgstr "segmentet e mëdha të sheshta"
 #: ../build/lib/darktable/plugins/introspection_highpass.c:44
 #: ../build/lib/darktable/plugins/introspection_highpass.c:91
 msgid "contrast boost"
-msgstr "amplifikoj kontrastin"
+msgstr "amplifikimi i kontrastit"
 
 #: ../build/lib/darktable/plugins/introspection_hotpixels.c:59
 #: ../build/lib/darktable/plugins/introspection_hotpixels.c:116
@@ -3983,7 +3982,7 @@ msgstr "shënoj pikselët e ndrequr"
 #: ../build/lib/darktable/plugins/introspection_hotpixels.c:65
 #: ../build/lib/darktable/plugins/introspection_hotpixels.c:120
 msgid "detect by 3 neighbors"
-msgstr "diktoj me 3 të afërt"
+msgstr "diktoj me 3 të afërtit"
 
 #: ../build/lib/darktable/plugins/introspection_lens.cc:121
 #: ../build/lib/darktable/plugins/introspection_lens.cc:272
@@ -4010,7 +4009,7 @@ msgstr "korrigjimet"
 #: ../src/iop/levels.c:672 ../src/iop/profile_gamma.c:667
 #: ../src/libs/copy_history.c:358 ../src/libs/export.c:1280
 #: ../src/libs/image.c:599 ../src/libs/print_settings.c:2696
-#: ../src/libs/styles.c:830 ../src/views/darkroom.c:2290
+#: ../src/libs/styles.c:830 ../src/views/darkroom.c:2292
 msgid "mode"
 msgstr "mënyra"
 
@@ -4060,8 +4059,8 @@ msgstr "e flakur"
 
 #. move left/right/up/down
 #: ../build/lib/darktable/plugins/introspection_liquify.c:429
-#: ../src/views/darkroom.c:2189 ../src/views/darkroom.c:2584
-#: ../src/views/darkroom.c:2587 ../src/views/lighttable.c:761
+#: ../src/views/darkroom.c:2191 ../src/views/darkroom.c:2586
+#: ../src/views/darkroom.c:2589 ../src/views/lighttable.c:761
 #: ../src/views/lighttable.c:770 ../src/views/lighttable.c:1246
 #: ../src/views/lighttable.c:1250 ../src/views/lighttable.c:1254
 #: ../src/views/lighttable.c:1258 ../src/views/lighttable.c:1262
@@ -4088,7 +4087,7 @@ msgstr "zhvendosja e blusë"
 #: ../build/lib/darktable/plugins/introspection_shadhi.c:160
 #: ../build/lib/darktable/plugins/introspection_shadhi.c:247
 msgid "soften with"
-msgstr "zbutje me"
+msgstr "zbutja me"
 
 #: ../build/lib/darktable/plugins/introspection_lowpass.c:183
 #: ../build/lib/darktable/plugins/introspection_shadhi.c:261
@@ -4164,7 +4163,7 @@ msgstr "letër me lustër (reflekse pasqyrore)"
 #: ../build/lib/darktable/plugins/introspection_negadoctor.c:156
 #: ../build/lib/darktable/plugins/introspection_negadoctor.c:247
 msgid "print exposure adjustment"
-msgstr "printoj me ekspozim të rregulluar"
+msgstr "printimi me ekspozim të rregulluar"
 
 #: ../build/lib/darktable/plugins/introspection_negadoctor.c:261
 #: ../src/iop/negadoctor.c:377
@@ -4377,7 +4376,7 @@ msgstr "për kanal"
 
 #: ../build/lib/darktable/plugins/introspection_sigmoid.c:172
 msgid "rgb ratio"
-msgstr "raporti rgb"
+msgstr "në raport rgb"
 
 #: ../build/lib/darktable/plugins/introspection_temperature.c:66
 #: ../build/lib/darktable/plugins/introspection_temperature.c:121
@@ -4450,12 +4449,12 @@ msgstr "kuantizimi i maskës"
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:222
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:341
 msgid "mask contrast compensation"
-msgstr "kompensoj kontrastin e maskës"
+msgstr "kompensimi i kontrastit të maskës"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:228
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:345
 msgid "mask exposure compensation"
-msgstr "kompensoj maskën e ekspozimit"
+msgstr "kompensimi i ekspozimit të maskës"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:240
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:353
@@ -4465,7 +4464,7 @@ msgstr "vlerësuesi i luminancës"
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:246
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:357
 msgid "filter diffusion"
-msgstr "difuzioni i filtrit"
+msgstr "difuzimi i filtrit"
 
 #: ../build/lib/darktable/plugins/introspection_toneequal.c:372
 msgid "averaged guided filter"
@@ -4577,11 +4576,11 @@ msgstr "imazh"
 
 #: ../build/lib/darktable/plugins/introspection_watermark.c:286
 msgid "larger border"
-msgstr "bordurë e gjerë"
+msgstr "bordurë të gjerë"
 
 #: ../build/lib/darktable/plugins/introspection_watermark.c:287
 msgid "smaller border"
-msgstr "bordurë më e vogël"
+msgstr "bordurë më të vogël"
 
 #: ../build/lib/darktable/plugins/lighttable/tools/darktable_authors.h:6
 msgid "developers"
@@ -4699,32 +4698,32 @@ msgstr "nuk ka shumë butonë"
 
 #: ../src/bauhaus/bauhaus.c:3556 ../src/gui/accelerators.c:317
 msgid "value"
-msgstr "vlera"
+msgstr "vlerë"
 
 #: ../src/bauhaus/bauhaus.c:3557 ../src/bauhaus/bauhaus.c:3563
 #: ../src/bauhaus/bauhaus.c:3602 ../src/gui/accelerators.c:295
 msgid "button"
-msgstr "butoni"
+msgstr "buton"
 
 #: ../src/bauhaus/bauhaus.c:3558
 msgid "force"
-msgstr "forca"
+msgstr "forcë"
 
 #: ../src/bauhaus/bauhaus.c:3559
 msgid "zoom"
-msgstr "zmadhimi"
+msgstr "zmadhim"
 
 #: ../src/bauhaus/bauhaus.c:3562
 msgid "selection"
-msgstr "përzgjedhja"
+msgstr "përzgjedhje"
 
 #: ../src/bauhaus/bauhaus.c:3581 ../src/bauhaus/bauhaus.c:3592
 msgid "slider"
-msgstr "shkarësi"
+msgstr "shkarës"
 
 #: ../src/bauhaus/bauhaus.c:3586 ../src/bauhaus/bauhaus.c:3597
 msgid "dropdown"
-msgstr "menuja zbritëse"
+msgstr "menu zbritëse"
 
 #: ../src/chart/main.c:504 ../src/control/jobs/control_jobs.c:1661
 #: ../src/control/jobs/control_jobs.c:1715 ../src/gui/accelerators.c:1950
@@ -5056,7 +5055,7 @@ msgstr "gjeoetiketimi"
 
 #: ../src/common/collection.c:700 ../src/libs/tools/global_toolbox.c:396
 msgid "grouping"
-msgstr "grupimi"
+msgstr "grupim"
 
 #: ../src/common/collection.c:702 ../src/dtgtk/thumbnail.c:1425
 #: ../src/libs/metadata_view.c:129 ../src/libs/metadata_view.c:338
@@ -5148,14 +5147,14 @@ msgstr "e papërcaktuar"
 #: ../src/common/collection.c:2451
 #, c-format
 msgid "<b>%d</b> image (#<b>%d</b>) selected of <b>%d</b>"
-msgstr "<b>%d</b> imazh (#<b>%d</b>) i përzgjedhur nga <b>%d</b>"
+msgstr "keni përzgjedhur <b>%d</b> imazh (#<b>%d</b>) nga <b>%d</b>"
 
 #: ../src/common/collection.c:2457
 #, c-format
 msgid "<b>%d</b> image selected of <b>%d</b>"
 msgid_plural "<b>%d</b> images selected of <b>%d</b>"
-msgstr[0] "<b>%d</b> imazh i përzgjedhur nga <b>%d</b>"
-msgstr[1] "<b>%d</b> imazhe të përzgjedhura nga <b>%d</b>"
+msgstr[0] "keni përzgjedhur <b>%d</b> imazh nga <b>%d</b>"
+msgstr[1] "keni përzgjedhur <b>%d</b> imazhe nga <b>%d</b>"
 
 #: ../src/common/color_vocabulary.c:38 ../src/develop/blend_gui.c:1985
 #: ../src/develop/blend_gui.c:2012 ../src/gui/guides.c:729
@@ -5477,7 +5476,7 @@ msgid "export profile"
 msgstr "eksportimi i profilit"
 
 #: ../src/common/colorspaces.c:1407 ../src/common/colorspaces.c:1687
-#: ../src/views/darkroom.c:2449
+#: ../src/views/darkroom.c:2451
 msgid "softproof profile"
 msgstr "profili i bocës së ngjyrave"
 
@@ -5749,7 +5748,7 @@ msgstr ""
 "  Si zgjidhet ky problem?\n"
 "\n"
 "  1 - Nëse keni hapur një instancë tjetër të darktable, \n"
-"      anulojeni me klikim dhe përdorni atë instancë ose mbylleni para se ta "
+"      klikoni për ta anuluar dhe përdorni instancën ose mbylleni para se të "
 "rihapni darktable \n"
 "      (ID procesi <i><b>%d</b></i> shkaktoi bllokimin e databazës)\n"
 "\n"
@@ -5760,7 +5759,7 @@ msgstr ""
 "\n"
 "  3 - Nëse e keni provuar ose jeni të sigurt se nuk keni instanca të tjera "
 "aktive të darktable, \n"
-"      kjo nënkupton se instanca e fundit përfundoi në mënyrë jonormale. \n"
+"      kjo nënkupton se instanca e fundit nuk përfundoi si normalisht. \n"
 "      Klikimi i butonit \"fshij skedarët e bllokuar të databazës\" do i heqë "
 "skedarët <i>data.db.lock</i> dhe <i>library.db.lock</i>.  \n"
 "\n"
@@ -5886,7 +5885,7 @@ msgstr ""
 "\n"
 "kjo merr mjaft kohë nëse keni databazë të madhe\n"
 "\n"
-"do vijoni apo do e mbyllni tani programin për t'i bërë një kopje\n"
+"do vijoni apo do e mbyllni tani programin për të bërë kopjen\n"
 
 #: ../src/common/database.c:2953
 msgid "darktable - schema migration"
@@ -5932,10 +5931,10 @@ msgid ""
 "from the most recent snapshot or delete the corrupted database\n"
 "and start with a new one?"
 msgstr ""
-"do e mbyllni tani darktable që të riktheni manualisht një kopje\n"
+"do e mbyllni tani darktable që të riktheni manualisht kopjen\n"
 "funksionale të databazës, të tentoni rikthimin automatik duke\n"
 "u nisur nga poza e fundit apo do e fshini databazën e dëmtuar\n"
-"dhe do të filloni me një të re?"
+"që të filloni me një të re?"
 
 #: ../src/common/database.c:3291 ../src/common/database.c:3471
 msgid ""
@@ -5943,9 +5942,9 @@ msgid ""
 "the database from a backup or delete the corrupted database\n"
 "and start with a new one?"
 msgstr ""
-"do e mbyllni tani darktable që të riktheni manualisht një kopje\n"
+"do e mbyllni tani darktable që të riktheni manualisht kopjen\n"
 "funksionale të databazës apo do e fshini databazën e dëmtuar\n"
-"dhe do të filloni me një të re?"
+"që të filloni me një të re?"
 
 #: ../src/common/database.c:3298 ../src/common/database.c:3476
 #, c-format
@@ -6393,21 +6392,21 @@ msgstr "nuk keni përzgjedhur imazhet për vlerësim"
 
 #: ../src/common/ratings.c:274 ../src/libs/metadata_view.c:353
 msgid "image rejected"
-msgstr "refuzoi imazhin"
+msgstr "imazhi u refuzua"
 
 #: ../src/common/ratings.c:276
 msgid "image rated to 0 star"
-msgstr "imazhi vlerësohet me 0 yje"
+msgstr "imazhi u vlerësua me 0 yje"
 
 #: ../src/common/ratings.c:278
 #, c-format
 msgid "image rated to %s"
-msgstr "vlerësoi imazhin me %s"
+msgstr "imazhi u vlerësua me %s"
 
 #: ../src/common/ratings.c:305 ../src/libs/select.c:39
 #: ../src/views/lighttable.c:762
 msgid "select"
-msgstr "përzgjedh"
+msgstr "përzgjedhja"
 
 #: ../src/common/ratings.c:306
 msgid "upgrade"
@@ -6461,7 +6460,7 @@ msgid "style named '%s' successfully created"
 msgstr "krijoi me sukses stilin '%s'"
 
 #: ../src/common/styles.c:631 ../src/common/styles.c:659
-#: ../src/common/styles.c:698
+#: ../src/common/styles.c:698 ../src/dtgtk/culling.c:992
 msgid "no image selected!"
 msgstr "nuk keni përzgjedhur imazhin!"
 
@@ -6523,7 +6522,7 @@ msgid "m"
 msgstr "m"
 
 #: ../src/control/control.c:66 ../src/gui/accelerators.c:128
-#: ../src/views/darkroom.c:2075
+#: ../src/views/darkroom.c:2077
 msgid "hold"
 msgstr "mbaj"
 
@@ -6586,7 +6585,7 @@ msgstr "alternativat"
 #: ../src/control/control.c:121
 msgctxt "accel"
 msgid "<focused>"
-msgstr "<fokusi>"
+msgstr "<në fokus>"
 
 #: ../src/control/control.c:138
 msgid "show accels window"
@@ -6709,7 +6708,7 @@ msgstr "diferenca kohore"
 
 #: ../src/control/crawler.c:656
 msgid "updated XMP sidecar files found"
-msgstr "gjeti sk. shoqërues XMP të azhurnuar"
+msgstr "gjeti skedarët shoqërues XMP të azhurnuar"
 
 #: ../src/control/crawler.c:657
 msgid "_close"
@@ -6717,17 +6716,17 @@ msgstr "_mbyll"
 
 #. setup selection accelerators
 #. action-box
-#: ../src/control/crawler.c:671 ../src/dtgtk/thumbtable.c:2341
+#: ../src/control/crawler.c:671 ../src/dtgtk/thumbtable.c:2342
 #: ../src/libs/import.c:1712 ../src/libs/select.c:133
 msgid "select all"
 msgstr "përzgjedh të gjitha"
 
-#: ../src/control/crawler.c:672 ../src/dtgtk/thumbtable.c:2342
+#: ../src/control/crawler.c:672 ../src/dtgtk/thumbtable.c:2343
 #: ../src/libs/import.c:1716 ../src/libs/select.c:137
 msgid "select none"
 msgstr "asnjë përzgjedhje"
 
-#: ../src/control/crawler.c:673 ../src/dtgtk/thumbtable.c:2343
+#: ../src/control/crawler.c:673 ../src/dtgtk/thumbtable.c:2344
 #: ../src/libs/select.c:141
 msgid "invert selection"
 msgstr "përmbys"
@@ -6972,7 +6971,7 @@ msgstr "nuk ka imazh për eksport"
 msgid "exporting %d / %d to %s"
 msgstr "eksporton %d / %d në %s"
 
-#: ../src/control/jobs/control_jobs.c:1431 ../src/views/darkroom.c:766
+#: ../src/control/jobs/control_jobs.c:1431 ../src/views/darkroom.c:768
 #: ../src/views/print.c:337
 #, c-format
 msgid "image `%s' is currently unavailable"
@@ -7184,7 +7183,7 @@ msgstr "ofseti i orës"
 
 #: ../src/control/jobs/control_jobs.c:2014 ../src/libs/copy_history.c:370
 msgid "write sidecar files"
-msgstr "shkruaj sk. shoqërues"
+msgstr "shkruaj skedarët shoqërues"
 
 #: ../src/control/jobs/control_jobs.c:2228 ../src/control/jobs/film_jobs.c:297
 #, c-format
@@ -7274,7 +7273,7 @@ msgstr "mesatarizoj"
 #: ../src/develop/blend_gui.c:52
 msgctxt "blendmode"
 msgid "addition"
-msgstr "shtoj"
+msgstr "plus"
 
 #: ../src/develop/blend_gui.c:53
 msgctxt "blendmode"
@@ -7384,12 +7383,12 @@ msgstr "HSV ngjyra"
 #: ../src/develop/blend_gui.c:74
 msgctxt "blendmode"
 msgid "RGB red channel"
-msgstr "kanali i kuq RGB"
+msgstr "kanali kuqe RGB"
 
 #: ../src/develop/blend_gui.c:75
 msgctxt "blendmode"
 msgid "RGB green channel"
-msgstr "kanali i gjelbër RGB"
+msgstr "kanali gjelbër RGB"
 
 #: ../src/develop/blend_gui.c:76
 msgctxt "blendmode"
@@ -7399,7 +7398,7 @@ msgstr "kanali blu RGB"
 #: ../src/develop/blend_gui.c:77
 msgctxt "blendmode"
 msgid "divide"
-msgstr "ndaj"
+msgstr "pjesëtoj"
 
 #: ../src/develop/blend_gui.c:78
 msgctxt "blendmode"
@@ -7515,7 +7514,7 @@ msgstr "inputi pas sfumimit"
 #: ../src/gui/accelerators.c:206 ../src/imageio/format/avif.c:800
 #: ../src/libs/live_view.c:362
 msgid "on"
-msgstr "ndez"
+msgstr "ndezur"
 
 #: ../src/develop/blend_gui.c:856 ../src/develop/blend_gui.c:2187
 #: ../src/develop/imageop.c:2376 ../src/iop/channelmixerrgb.c:4105
@@ -7538,11 +7537,11 @@ msgstr " (ditari)"
 
 #: ../src/develop/blend_gui.c:1703
 msgid "reset to default blend colorspace"
-msgstr "kthej hapësirën e ngjyrave të bashkuara standarde"
+msgstr "ktheni hapësirën e ngjyrave të bashkuara standarde"
 
 #: ../src/develop/blend_gui.c:1750
 msgid "reset and hide output channels"
-msgstr "ktheni dhe fshihini kanalet output"
+msgstr "ktheni dhe fshihni kanalet output"
 
 #: ../src/develop/blend_gui.c:1756
 msgid "show output channels"
@@ -7770,7 +7769,7 @@ msgstr ""
 #: ../src/iop/toneequal.c:3132 ../src/iop/toneequal.c:3135
 #: ../src/iop/toneequal.c:3138 ../src/iop/toneequal.c:3141
 #: ../src/iop/toneequal.c:3235 ../src/iop/toneequal.c:3242
-#: ../src/iop/toneequal.c:3252 ../src/views/darkroom.c:2356
+#: ../src/iop/toneequal.c:3252 ../src/views/darkroom.c:2358
 msgid " EV"
 msgstr " EV"
 
@@ -7781,7 +7780,7 @@ msgstr " EV"
 #: ../src/develop/blend_gui.c:3064 ../src/develop/blend_gui.c:3070
 #: ../src/develop/blend_gui.c:3076 ../src/develop/blend_gui.c:3084
 msgid "blend"
-msgstr "shkrij"
+msgstr "bashkoj"
 
 #: ../src/develop/blend_gui.c:2226
 msgid "boost factor"
@@ -7897,7 +7896,7 @@ msgstr "metodat normale & aritmetike"
 
 #: ../src/develop/blend_gui.c:2698
 msgid "chromaticity & lightness modes"
-msgstr "mënyrat e kromaticitetit dhe ndriçimit"
+msgstr "metodat e kromaticitetit dhe ndriçimit"
 
 #. add deprecated blend mode
 #: ../src/develop/blend_gui.c:2709
@@ -7910,11 +7909,11 @@ msgstr "opsionet e bashkimit"
 
 #: ../src/develop/blend_gui.c:3007 ../src/libs/history.c:870
 msgid "blend mode"
-msgstr "mënyra"
+msgstr "metoda e bashkimit"
 
 #: ../src/develop/blend_gui.c:3008
 msgid "choose blending mode"
-msgstr "zgjidhni mënyrën e shkrirjes"
+msgstr "zgjidhni metodën e bashkimit"
 
 #: ../src/develop/blend_gui.c:3015
 msgid "toggle blend order"
@@ -8053,12 +8052,12 @@ msgstr ""
 
 #: ../src/develop/blend_gui.c:3100
 msgid "temporarily switch off blend mask"
-msgstr "fikeni përkohësisht maskën bashkuese"
+msgstr "fikni përkohësisht maskën bashkuese"
 
 #: ../src/develop/blend_gui.c:3102
 msgid "temporarily switch off blend mask. only for module in focus"
 msgstr ""
-"fikeni përkohësisht maskën bashkuese. vetëm për modulin që është në fokus"
+"fikni përkohësisht maskën bashkuese. vetëm për modulin që është në fokus"
 
 #: ../src/develop/develop.c:1538 ../src/gui/presets.c:970
 msgid "display-referred default"
@@ -8253,8 +8252,8 @@ msgstr "nuk gjen lightroom XMP!"
 #: ../src/develop/lightroom.c:1115 ../src/develop/lightroom.c:1137
 #: ../src/develop/lightroom.c:1157
 #, c-format
-msgid "`%s' not a lightroom XMP!"
-msgstr "`%s' nuk është XMP e lightroom!"
+msgid "`%s' is not a Lightroom XMP!"
+msgstr "`%s' nuk është XMP e Lightroom!"
 
 #: ../src/develop/lightroom.c:1556
 #, c-format
@@ -8631,10 +8630,6 @@ msgstr "keni arritur fundin e koleksionit"
 msgid "zooming is limited to %d images"
 msgstr "zmadhimi është kufizuar në %d imazhe"
 
-#: ../src/dtgtk/culling.c:992
-msgid "no image selected !"
-msgstr "nuk keni përzgjedhur imazhin!"
-
 #: ../src/dtgtk/range.c:214 ../src/dtgtk/range.c:219
 msgid "invalid"
 msgstr "e pasaktë"
@@ -8819,7 +8814,7 @@ msgstr "me dopioklik kthehet si më parë"
 
 #: ../src/dtgtk/thumbnail.c:92 ../src/dtgtk/thumbnail.c:122
 msgid "current"
-msgstr "aktuale"
+msgstr "aktual"
 
 #: ../src/dtgtk/thumbnail.c:92 ../src/dtgtk/thumbnail.c:98
 msgid "leader"
@@ -8831,13 +8826,13 @@ msgid ""
 "click here to set this image as group leader\n"
 msgstr ""
 "\n"
-"klikoni këtu që ta vendosni këtë imazh si udhëheqësin e grupit\n"
+"klikoni këtu për ta bërë imazhin udhëheqës të grupit\n"
 
 #. and the number of grouped images
 #: ../src/dtgtk/thumbnail.c:133 ../src/libs/filters/grouping.c:144
 #: ../src/libs/filters/grouping.c:169
 msgid "grouped images"
-msgstr "imazhet e grupuara"
+msgstr "imazhe të grupuara"
 
 #: ../src/dtgtk/thumbnail.c:712 ../src/dtgtk/thumbnail.c:1474
 #: ../src/iop/ashift.c:5757 ../src/iop/ashift.c:5824 ../src/iop/ashift.c:5825
@@ -8845,7 +8840,7 @@ msgstr "imazhet e grupuara"
 msgid "fit"
 msgstr "përshtat"
 
-#: ../src/dtgtk/thumbtable.c:984 ../src/views/slideshow.c:378
+#: ../src/dtgtk/thumbtable.c:984 ../src/views/slideshow.c:412
 msgid "there are no images in this collection"
 msgstr "nuk keni imazhe në koleksion"
 
@@ -8859,11 +8854,11 @@ msgstr "nëpërmjet modulit të importit"
 
 #: ../src/dtgtk/thumbtable.c:1003
 msgid "try to relax the filter settings in the top panel"
-msgstr "filtroni imazhet me panelin e sipërm"
+msgstr "imazhet filtrohen me panelin e sipërm"
 
 #: ../src/dtgtk/thumbtable.c:1012
 msgid "or add images in the collections module in the left panel"
-msgstr "ose shtojini te moduli 'koleksionet' në panelin majtas"
+msgstr "dhe shtohen te moduli 'koleksionet' në panelin majtas"
 
 #: ../src/dtgtk/thumbtable.c:1250
 msgid ""
@@ -8914,39 +8909,39 @@ msgid "cached thumbnails invalidation"
 msgstr "flakja e miniaturave në kash"
 
 #. setup history key accelerators
-#: ../src/dtgtk/thumbtable.c:2331
+#: ../src/dtgtk/thumbtable.c:2332
 msgid "copy history"
 msgstr "kopjoj historikun"
 
-#: ../src/dtgtk/thumbtable.c:2332
+#: ../src/dtgtk/thumbtable.c:2333
 msgid "copy history parts"
 msgstr "kopjoj pjesët e historikut"
 
-#: ../src/dtgtk/thumbtable.c:2333
+#: ../src/dtgtk/thumbtable.c:2334
 msgid "paste history"
 msgstr "ngjit historikun"
 
-#: ../src/dtgtk/thumbtable.c:2334
+#: ../src/dtgtk/thumbtable.c:2335
 msgid "paste history parts"
 msgstr "ngjit pjesët e historikut"
 
-#: ../src/dtgtk/thumbtable.c:2335 ../src/libs/copy_history.c:354
+#: ../src/dtgtk/thumbtable.c:2336 ../src/libs/copy_history.c:354
 msgid "discard history"
 msgstr "flak historikun"
 
-#: ../src/dtgtk/thumbtable.c:2337
+#: ../src/dtgtk/thumbtable.c:2338
 msgid "duplicate image"
 msgstr "dublikoj imazhin"
 
-#: ../src/dtgtk/thumbtable.c:2338
+#: ../src/dtgtk/thumbtable.c:2339
 msgid "duplicate image virgin"
 msgstr "dublikoj imazhin e virgjër"
 
-#: ../src/dtgtk/thumbtable.c:2344 ../src/libs/select.c:145
+#: ../src/dtgtk/thumbtable.c:2345 ../src/libs/select.c:145
 msgid "select film roll"
 msgstr "përzgjedh filmin"
 
-#: ../src/dtgtk/thumbtable.c:2345 ../src/libs/select.c:149
+#: ../src/dtgtk/thumbtable.c:2346 ../src/libs/select.c:149
 msgid "select untouched"
 msgstr "përzgjedh të paprekurat"
 
@@ -9028,7 +9023,7 @@ msgstr "pan"
 #: ../src/iop/ashift.c:5413 ../src/iop/ashift.c:5515 ../src/iop/ashift.c:5516
 #: ../src/iop/ashift.c:5825 ../src/iop/clipping.c:1905
 #: ../src/iop/clipping.c:2097 ../src/iop/clipping.c:2113
-#: ../src/views/darkroom.c:2584 ../src/views/lighttable.c:1250
+#: ../src/views/darkroom.c:2586 ../src/views/lighttable.c:1250
 msgid "horizontal"
 msgstr "horizontalisht"
 
@@ -9036,7 +9031,7 @@ msgstr "horizontalisht"
 #: ../src/iop/ashift.c:5413 ../src/iop/ashift.c:5515 ../src/iop/ashift.c:5516
 #: ../src/iop/ashift.c:5824 ../src/iop/clipping.c:1904
 #: ../src/iop/clipping.c:2098 ../src/iop/clipping.c:2112
-#: ../src/views/darkroom.c:2587 ../src/views/lighttable.c:1254
+#: ../src/views/darkroom.c:2589 ../src/views/lighttable.c:1254
 msgid "vertical"
 msgstr "vertikalisht"
 
@@ -9118,8 +9113,8 @@ msgstr "e para"
 #: ../src/gui/accelerators.c:119 ../src/gui/accelerators.c:131
 #: ../src/gui/accelerators.c:283 ../src/libs/filtering.c:1913
 #: ../src/libs/filters/rating_range.c:266 ../src/libs/tagging.c:3117
-#: ../src/views/darkroom.c:2272 ../src/views/darkroom.c:2322
-#: ../src/views/darkroom.c:2556
+#: ../src/views/darkroom.c:2274 ../src/views/darkroom.c:2324
+#: ../src/views/darkroom.c:2558
 msgid "toggle"
 msgstr "përdor"
 
@@ -9235,7 +9230,7 @@ msgstr "gjatë"
 #: ../src/gui/accelerators.c:620
 msgctxt "accel"
 msgid "double-click"
-msgstr "klikim dysh"
+msgstr "dopioklik"
 
 #: ../src/gui/accelerators.c:621
 msgctxt "accel"
@@ -9244,7 +9239,7 @@ msgstr "klikim tresh"
 
 #: ../src/gui/accelerators.c:622
 msgid "click"
-msgstr "klikoj"
+msgstr "klikim"
 
 #: ../src/gui/accelerators.c:650
 msgid "first instance"
@@ -9435,13 +9430,15 @@ msgstr "_edits"
 
 #: ../src/gui/accelerators.c:1958
 msgid ""
-"restore default shortcuts\n"
-"  or as at startup\n"
-"  or when the configuration dialog was opened\n"
+"restore shortcuts from one of these states:\n"
+"  - default\n"
+"  - as at startup\n"
+"  - as when opening this dialog\n"
 msgstr ""
-"ktheni shkurtoret fillestare\n"
-" ose gjatë nisjes së programit\n"
-" ose kur hapni tabelën e konfigurimit\n"
+"ktheni shkurtoret në një nga këto gjendjet:\n"
+" - standarde\n"
+" - si në nisje\n"
+" - si para hapjes së kësaj tabelës\n"
 
 #: ../src/gui/accelerators.c:1961
 msgid ""
@@ -9578,8 +9575,8 @@ msgid ""
 "enables default meanings for additional buttons, modifiers or moves\n"
 "when used in combination with a base shortcut"
 msgstr ""
-"aktivizon kuptimet standarde për butonët shtesë, modifikuesit ose lëvizjet\n"
-"kur përdoret së bashku me një shkurtore bazë"
+"aktivizoni kuptimet standarde për butonët shtesë, modifikuesit ose lëvizjet\n"
+"për t'i përdorur së bashku me një shkurtore bazë"
 
 #: ../src/gui/accelerators.c:2394
 msgid "restore..."
@@ -9627,7 +9624,7 @@ msgstr "%s nuk është caktuar"
 msgid "%s assigned to %s"
 msgstr "%s është caktuar për %s"
 
-#: ../src/gui/gtk.c:170 ../src/views/darkroom.c:4469
+#: ../src/gui/gtk.c:170 ../src/views/darkroom.c:4473
 msgid "darktable - darkroom preview"
 msgstr "darktable - parashikimi i dhomës së errët"
 
@@ -9672,7 +9669,7 @@ msgstr "telefotografimi"
 msgid "map"
 msgstr "harta"
 
-#: ../src/gui/gtk.c:1182 ../src/views/slideshow.c:346
+#: ../src/gui/gtk.c:1182 ../src/views/slideshow.c:380
 msgid "slideshow"
 msgstr "diafilmi"
 
@@ -9684,7 +9681,7 @@ msgstr "printoj"
 #. register ctrl-q to quit:
 #: ../src/gui/gtk.c:1189
 msgid "quit"
-msgstr "dal"
+msgstr "dalje"
 
 #. Full-screen accelerator (no ESC handler here to enable quit-slideshow using ESC)
 #: ../src/gui/gtk.c:1192
@@ -9726,7 +9723,7 @@ msgstr "përdorni sugjerimet"
 
 #: ../src/gui/gtk.c:1206
 msgid "reinitialise input devices"
-msgstr "rinisen aparatet input"
+msgstr "rinis aparatet input"
 
 #: ../src/gui/gtk.c:1244
 msgid "toggle focus-peaking mode"
@@ -10131,7 +10128,7 @@ msgid "global guide overlay settings"
 msgstr "parametrat globalë për shtrimin e udhëzuesve"
 
 #: ../src/gui/guides.c:710 ../src/gui/guides.c:719 ../src/gui/guides.c:727
-#: ../src/gui/guides.c:740 ../src/views/darkroom.c:2556
+#: ../src/gui/guides.c:740 ../src/views/darkroom.c:2558
 msgid "guide lines"
 msgstr "vijat udhëzuese"
 
@@ -10203,11 +10200,11 @@ msgstr "përzgjidhni pjesët për ngjitje"
 
 #: ../src/gui/hist_dialog.c:196 ../src/gui/styles_dialog.c:409
 msgid "select _all"
-msgstr "përzgjidhni_të gjitha"
+msgstr "përzgjedh_ të gjitha"
 
 #: ../src/gui/hist_dialog.c:197 ../src/gui/styles_dialog.c:410
 msgid "select _none"
-msgstr "asnjë_përzgjedhje"
+msgstr "asnjë_ përzgjedhje"
 
 #: ../src/gui/hist_dialog.c:225 ../src/gui/styles_dialog.c:476
 #: ../src/gui/styles_dialog.c:485
@@ -10742,15 +10739,15 @@ msgstr "thellësia e bitëve"
 #: ../src/imageio/format/avif.c:775
 msgid "color information stored in an image, higher is better"
 msgstr ""
-"informacioni për ngjyrat e depozituara në imazh. sa më lart, aq më mirë"
+"informacioni për ngjyrat e depozituara në imazh. sa më i lartë, aq më mirë"
 
 #: ../src/imageio/format/avif.c:783
 msgid "saving as grayscale will reduce the size for black & white images"
-msgstr "regjistrimi me tone gri e redukton madhësinë e imazheve bardhë e zi"
+msgstr "regjistrimi me ngjyrë gri e redukton madhësinë e imazheve bardhë e zi"
 
 #: ../src/imageio/format/avif.c:785
 msgid "rgb colors"
-msgstr "ngjyrat rgb"
+msgstr "me ngjyra"
 
 #: ../src/imageio/format/avif.c:785
 msgid "grayscale"
@@ -10770,9 +10767,9 @@ msgid ""
 "makes encoding faster. the impact on quality reduction is negligible, but "
 "increases the file size."
 msgstr ""
-"ndajeni imazhin në segmente.\n"
+"imazhi do të ndahet në segmente.\n"
 "\n"
-"kodimi do të jetë më i shpejtë. ndikon më pak në uljen e cilësisë, por rrit "
+"për kodim më të shpejtë. nuk ndikon shumë në uljen e cilësisë, por rrit "
 "madhësinë e skedarit."
 
 #: ../src/imageio/format/avif.c:813 ../src/imageio/format/webp.c:382
@@ -10806,9 +10803,9 @@ msgid ""
 "    81% -  90% -> YUV422\n"
 "     5% -  80% -> YUV420\n"
 msgstr ""
-"cilësia e një imazhi, cilësia e ulët nënkupton detaje më të pakëta.\n"
+"cilësia e imazhit, cilësia e ulët nënkupton detaje më të pakëta.\n"
 "\n"
-"këto më poshtë aplikohen vetëm për parametrat me humbje\n"
+"kjo aplikohet vetëm për parametrat me humbje\n"
 "\n"
 "lidhja mes formatit të pikselëve dhe cilësisë:\n"
 "\n"
@@ -10826,8 +10823,8 @@ msgid ""
 "do a 1:1 copy of the selected files.\n"
 "the global options below do not apply!"
 msgstr ""
-"bëni kopje 1:1 të imazheve të përzgjedhura,\n"
-"nuk përfshihen opsionet globale më poshtë!"
+"imazhet e përzgjedhura do të kopjohen në mënyrë identike,\n"
+"nuk merren parasysh opsionet globale më poshtë!"
 
 #: ../src/imageio/format/exr.cc:213
 msgid "the selected output profile doesn't work well with exr"
@@ -10857,7 +10854,7 @@ msgstr "kompresimi"
 #: ../src/imageio/format/exr.cc:480 ../src/imageio/format/pdf.c:682
 #: ../src/imageio/format/tiff.c:884
 msgid "uncompressed"
-msgstr "e pakompresuar"
+msgstr "pakompresuar"
 
 #: ../src/imageio/format/exr.cc:481
 msgid "RLE"
@@ -10964,7 +10961,7 @@ msgid ""
 "example: 210 mm x 2.97 cm"
 msgstr ""
 "madhësia e letrës në pdf\n"
-"ose një nga lista ose \"<gjerësia> [njësia] x <gjatësia> <njësia>\n"
+"vendoseni nga lista ose \"<gjerësia> [njësia] x <gjatësia> <njësia>\n"
 "shembull: 210 mm x 2.97 cm"
 
 #. orientation
@@ -10974,7 +10971,7 @@ msgstr "orientimi i faqes"
 
 #: ../src/imageio/format/pdf.c:601
 msgid "paper orientation of the pdf"
-msgstr "orientimi i faqes së pdf-së"
+msgstr "orientimi i faqes në pdf"
 
 #: ../src/imageio/format/pdf.c:604 ../src/iop/borders.c:1030
 #: ../src/libs/filtering.c:286 ../src/libs/filters/ratio.c:122
@@ -11001,7 +10998,7 @@ msgid ""
 msgstr ""
 "hapësira boshe rreth pdf-së\n"
 "formati: përmasa + njësia\n"
-"shembull: 10 mm, 1 inç"
+"shembull: 10 mm, 1 inch"
 
 #. dpi
 #: ../src/imageio/format/pdf.c:621 ../src/libs/export.c:1132
@@ -11016,7 +11013,7 @@ msgstr "dpi e imazheve brenda pdf-së"
 #. rotate images yes|no
 #: ../src/imageio/format/pdf.c:631
 msgid "rotate images"
-msgstr "rrotulloj imazhet"
+msgstr "rrotullimi i imazhit"
 
 #: ../src/imageio/format/pdf.c:632
 msgid ""
@@ -11047,7 +11044,7 @@ msgstr "fleta e kontaktit"
 #. embedded icc profile yes|no
 #: ../src/imageio/format/pdf.c:651
 msgid "embed icc profiles"
-msgstr "integroj profilet ICC"
+msgstr "profili i integruar ICC"
 
 #: ../src/imageio/format/pdf.c:652
 msgid "images can be tagged with their icc profile"
@@ -11064,8 +11061,8 @@ msgid ""
 "deflate -- smaller files but slower"
 msgstr ""
 "metoda që përdoret për kompresimin e imazhit\n"
-"e pakompresuar -- e shpejtë, por skedarët e mëdhenj\n"
-"shfryj -- e ngadaltë, por skedarët më të vegjël"
+"pakompresuar -- e shpejtë, por skedarët dalin të mëdhenj\n"
+"shfryj -- e ngadaltë, por skedarët dalin më të vegjël"
 
 #: ../src/imageio/format/pdf.c:682 ../src/imageio/format/tiff.c:884
 msgid "deflate"
@@ -11080,11 +11077,11 @@ msgstr "metoda e imazhit"
 msgid ""
 "normal -- just put the images into the pdf\n"
 "draft -- images are replaced with boxes\n"
-"debug -- only show the outlines and bounding boxen"
+"debug -- only show the outlines and bounding boxes"
 msgstr ""
-"normal -- imazhet do të vendosen në pdf\n"
+"normal -- imazhet vendosen në pdf\n"
 "draft -- imazhet zëvendësohen me kuti\n"
-"debug -- tregohen vetëm vijat dhe kutitë"
+"debug -- tregohen vetëm skicat dhe kufijtë grafikë"
 
 #: ../src/imageio/format/pdf.c:693
 msgid "normal"
@@ -11112,7 +11109,7 @@ msgstr "PPM (16-bit)"
 
 #: ../src/imageio/format/tiff.c:226
 msgid "will export as a grayscale image"
-msgstr "do të eksportohet si imazh me tone gri"
+msgstr "do të eksportohet si imazh me ngjyrë gri"
 
 #: ../src/imageio/format/tiff.c:791
 msgid "TIFF"
@@ -11133,7 +11130,7 @@ msgstr "vlerë pike notuese"
 
 #: ../src/imageio/format/tiff.c:885
 msgid "deflate with predictor"
-msgstr "shfryj me parashikues"
+msgstr "shfryj me parashikim"
 
 #: ../src/imageio/format/tiff.c:895
 msgid "compression level"
@@ -11142,15 +11139,15 @@ msgstr "niveli i kompresimit"
 #. shortfile option combo box
 #: ../src/imageio/format/tiff.c:904
 msgid "b&w image"
-msgstr "imazh bardhezi"
+msgstr "imazhi bardhezi"
 
 #: ../src/imageio/format/tiff.c:905
 msgid "write rgb colors"
-msgstr "shkruaj ngjyrat rgb"
+msgstr "shkruaj me ngjyra"
 
 #: ../src/imageio/format/tiff.c:905
 msgid "write grayscale"
-msgstr "shkruaj me tone gri"
+msgstr "shkruaj me ngjyrë gri"
 
 #: ../src/imageio/format/webp.c:349
 msgid "WebP"
@@ -11178,7 +11175,7 @@ msgstr ""
 
 #: ../src/imageio/format/webp.c:407
 msgid "image hint"
-msgstr "këshillë për imazhin"
+msgstr "natyra e imazhit"
 
 #: ../src/imageio/format/webp.c:408
 msgid ""
@@ -11188,9 +11185,9 @@ msgid ""
 "graphic : discrete tone image (graph, map-tile etc)"
 msgstr ""
 "karakteristikat e imazhit për koduesin bazë.\n"
-"figurë : figurë digjitale, si portret, shkrepje në studio\n"
+"figurë : foto digjitale, si portret, shkrepje në studio\n"
 "foto : fotografi në natyrë, në dritë natyrore\n"
-"grafik : imazh i shkëputur (diagramë, map-tile etj.)"
+"grafik : imazh diskret (diagramë, pjesë harte etj.)"
 
 #: ../src/imageio/format/webp.c:413
 msgid "picture"
@@ -11225,7 +11222,7 @@ msgstr ""
 
 #: ../src/imageio/storage/disk.c:182 ../src/imageio/storage/piwigo.c:1013
 msgid "on conflict"
-msgstr "në rast përplasjeje"
+msgstr "në rast konflikti"
 
 #: ../src/imageio/storage/disk.c:185
 msgid "create unique filename"
@@ -11629,18 +11626,17 @@ msgstr ""
 
 #: ../src/iop/ashift.c:5797
 msgid ""
-"automatically correct for vertical and horizontal perspective distortions; "
-"fitting rotation,lens shift in both directions, and shear\n"
+"automatically correct for vertical and horizontal perspective distortions, "
+"fitting rotation, lens shift in both directions, and shear\n"
 "ctrl+click to only fit rotation\n"
 "shift+click to only fit lens shift\n"
 "ctrl+shift+click to only fit rotation and lens shift"
 msgstr ""
 "korrigjoni automatikisht deformimet horizontale dhe vertikale të "
-"perspektivës, rrotullimin, zhvendosjen e objektivit në të dyja drejtimet dhe "
-"gërshërimin\n"
-"ctrl+klikim vetëm për rrotullimin\n"
-"shift+klikim vetëm për zhvendosjen e objektivit\n"
-"ctrl+shift+klikim vetëm për rrotullimin dhe zhvendosjen e objektivit"
+"perspektivës, rrotullimin, zhvendosjet e objektivit dhe gërshërimin\n"
+"ctrl+klikim vetëm rrotullimin\n"
+"shift+klikim vetëm zhvendosjet e objektivit\n"
+"ctrl+shift+klikim vetëm rrotullimin dhe zhvendosjet e objektivit"
 
 #: ../src/iop/ashift.c:5803
 msgid ""
@@ -11754,7 +11750,7 @@ msgstr "rrezatimi"
 
 #: ../src/iop/atrous.c:833 ../src/iop/bilat.c:163
 msgid "clarity"
-msgstr "pastërti"
+msgstr "kthjelloj"
 
 #: ../src/iop/atrous.c:853
 msgid "deblur: large blur, strength 3"
@@ -11983,7 +11979,7 @@ msgstr ""
 #: ../src/iop/cacorrectrgb.c:170 ../src/iop/colorreconstruction.c:135
 #: ../src/iop/defringe.c:81 ../src/iop/denoiseprofile.c:720
 #: ../src/iop/dither.c:103 ../src/iop/flip.c:105 ../src/iop/hazeremoval.c:112
-#: ../src/iop/highlights.c:182 ../src/iop/hotpixels.c:73
+#: ../src/iop/highlights.c:183 ../src/iop/hotpixels.c:73
 #: ../src/iop/invert.c:122 ../src/iop/lens.cc:217 ../src/iop/nlmeans.c:99
 #: ../src/iop/profile_gamma.c:101 ../src/iop/rawdenoise.c:130
 #: ../src/iop/retouch.c:209 ../src/iop/sharpen.c:94 ../src/iop/spots.c:67
@@ -12188,7 +12184,7 @@ msgstr "jolineare, Lab"
 
 #: ../src/iop/bilat.c:172
 msgid "HDR local tone-mapping"
-msgstr "rilevimi lokal i toneve HDR"
+msgstr "rilevoj tonet lokalisht si HDR"
 
 #: ../src/iop/bilat.c:428
 msgid ""
@@ -12235,7 +12231,7 @@ msgstr ""
 
 #: ../src/iop/bilateral.cc:73 ../src/iop/diffuse.c:324
 msgid "surface blur"
-msgstr "sfumimi i sipërfaqes"
+msgstr "sfumoj sipërfaqen"
 
 #: ../src/iop/bilateral.cc:78
 msgid "denoise (bilateral filter)"
@@ -12292,7 +12288,7 @@ msgstr "forca e rrezatimit"
 
 #: ../src/iop/blurs.c:81
 msgid "blurs"
-msgstr "sfumoj"
+msgstr "sfumimi"
 
 #: ../src/iop/blurs.c:86
 msgid "blur|lens|motion"
@@ -12451,7 +12447,7 @@ msgstr "përmasat e vijës së kornizës në raport me gjerësinë min. të bord
 
 #: ../src/iop/borders.c:1064
 msgid "offset of the frame line beginning on picture side"
-msgstr "ofseti i vijës së kornizës prej anës së figurës"
+msgstr "ofseti i vijës së kornizës prej anës së fotos"
 
 #: ../src/iop/borders.c:1071
 msgid "border color"
@@ -12488,8 +12484,8 @@ msgstr "korrigjoni aberracionet kromatike për sensorët Bayer"
 
 #: ../src/iop/cacorrect.c:89 ../src/iop/cacorrect.c:91
 #: ../src/iop/cacorrectrgb.c:171 ../src/iop/cacorrectrgb.c:173
-#: ../src/iop/demosaic.c:228 ../src/iop/highlights.c:183
-#: ../src/iop/highlights.c:185 ../src/iop/hotpixels.c:74
+#: ../src/iop/demosaic.c:228 ../src/iop/highlights.c:184
+#: ../src/iop/highlights.c:186 ../src/iop/hotpixels.c:74
 #: ../src/iop/hotpixels.c:76 ../src/iop/rawdenoise.c:131
 #: ../src/iop/rawdenoise.c:133 ../src/iop/rawprepare.c:154
 #: ../src/iop/rawprepare.c:156 ../src/iop/temperature.c:199
@@ -12643,7 +12639,7 @@ msgstr ""
 
 #: ../src/iop/censorize.c:77
 msgid "censorize"
-msgstr "censuroj"
+msgstr "censurimi"
 
 #: ../src/iop/censorize.c:82
 msgid "censorize license plates and body parts for privacy"
@@ -12838,7 +12834,7 @@ msgstr "B/Z: Fuji Acros 100"
 
 #: ../src/iop/channelmixerrgb.c:451
 msgid "basic channel mixer"
-msgstr "mikseri i kanaleve kryesore"
+msgstr "miksoj thjesht kanalet"
 
 #: ../src/iop/channelmixerrgb.c:477
 msgid "swap G and R"
@@ -13299,7 +13295,7 @@ msgstr "Datacolor SpyderCheckr 48 pas vitit 2018"
 
 #: ../src/iop/channelmixerrgb.c:4224
 msgid "optimize for"
-msgstr "optimizoj për"
+msgstr "optimizimi për"
 
 #: ../src/iop/channelmixerrgb.c:4225
 msgid ""
@@ -13308,9 +13304,9 @@ msgid ""
 "saturated colors gives the lowest maximum delta E but a high average delta "
 "E\n"
 "none is a trade-off between both\n"
-"the others are special behaviours to protect some hues"
+"the others are special behaviors to protect some hues"
 msgstr ""
-"zgjidhni ngjyrat për të cilat duhet treguar më shumë kujdes.\n"
+"zgjidhni cilat ngjyra duhen trajtuar me më shumë kujdes.\n"
 "ngjyrat neutrale kanë delta E mesatare më të ulët, por delta E maksimale të "
 "lartë\n"
 "ngjyrat e ngopura kanë delta E maksimale më të ulët, por delta E mesatare të "
@@ -13897,7 +13893,7 @@ msgstr "balancimi i ngjyrave funksionon vetëm me inputet RGB"
 #: ../src/iop/colorbalancergb.c:1474 ../src/iop/colorzones.c:2185
 #: ../src/iop/retouch.c:1848 ../src/iop/toneequal.c:1871
 msgid "cannot display masks when the blending mask is displayed"
-msgstr "nuk shihen maskat kur shfaqni një maskë bashkuese"
+msgstr "maskat nuk shihen kur aktivizoni maskën bashkuese"
 
 #: ../src/iop/colorbalancergb.c:1866
 msgid "global grading"
@@ -14495,26 +14491,26 @@ msgstr "synimi i zhvillimit"
 
 #: ../src/iop/colorout.c:858 ../src/libs/export.c:1264
 #: ../src/libs/print_settings.c:2325 ../src/libs/print_settings.c:2646
-#: ../src/views/darkroom.c:2425 ../src/views/lighttable.c:1173
+#: ../src/views/darkroom.c:2427 ../src/views/lighttable.c:1173
 msgid "perceptual"
 msgstr "perceptiv"
 
 #: ../src/iop/colorout.c:859 ../src/libs/export.c:1265
 #: ../src/libs/print_settings.c:2326 ../src/libs/print_settings.c:2647
-#: ../src/views/darkroom.c:2426 ../src/views/lighttable.c:1174
+#: ../src/views/darkroom.c:2428 ../src/views/lighttable.c:1174
 msgid "relative colorimetric"
 msgstr "kolorimetria relative"
 
 #: ../src/iop/colorout.c:860 ../src/libs/export.c:1266
 #: ../src/libs/print_settings.c:2327 ../src/libs/print_settings.c:2648
-#: ../src/views/darkroom.c:2427 ../src/views/lighttable.c:1175
+#: ../src/views/darkroom.c:2429 ../src/views/lighttable.c:1175
 msgctxt "rendering intent"
 msgid "saturation"
 msgstr "saturimi"
 
 #: ../src/iop/colorout.c:861 ../src/libs/export.c:1267
 #: ../src/libs/print_settings.c:2328 ../src/libs/print_settings.c:2649
-#: ../src/views/darkroom.c:2428 ../src/views/lighttable.c:1176
+#: ../src/views/darkroom.c:2430 ../src/views/lighttable.c:1176
 msgid "absolute colorimetric"
 msgstr "kolorimetria absolute"
 
@@ -14573,11 +14569,11 @@ msgstr ""
 "toni i nuancës që duhet të ketë përparësi mbi tonet e nuancave të tjera"
 
 #: ../src/iop/colorreconstruction.c:1265 ../src/iop/demosaic.c:5472
-#: ../src/iop/highlights.c:2502
+#: ../src/iop/highlights.c:2527
 msgid "not applicable"
 msgstr "nuk aplikohet"
 
-#: ../src/iop/colorreconstruction.c:1266 ../src/iop/highlights.c:2503
+#: ../src/iop/colorreconstruction.c:1266 ../src/iop/highlights.c:2528
 msgid "no highlights reconstruction for monochrome images"
 msgstr "nuk rindërtohen reflekset e imazheve monokromatike"
 
@@ -14638,7 +14634,7 @@ msgstr ""
 
 #: ../src/iop/colorzones.c:606
 msgid "red black white"
-msgstr "kuqe bardhë e zi"
+msgstr "kuqe dhe bardhë e zi"
 
 #: ../src/iop/colorzones.c:629
 msgid "black white and skin tones"
@@ -14749,7 +14745,7 @@ msgstr "kryej"
 
 #: ../src/iop/crop.c:1163
 msgid "commit changes"
-msgstr "kryeni ndryshimet"
+msgstr "bëni ndryshimet"
 
 #: ../src/iop/crop.c:1522
 msgid "<b>resize</b>: drag, <b>keep aspect ratio</b>: shift+drag"
@@ -14974,7 +14970,7 @@ msgstr "jolokale"
 
 #: ../src/iop/denoiseprofile.c:3529
 msgid "non-local means auto"
-msgstr "mjetet jokolake automatike"
+msgstr "mjete jolokake automatike"
 
 #: ../src/iop/denoiseprofile.c:3530
 msgid "wavelets"
@@ -15063,22 +15059,22 @@ msgstr ""
 
 #: ../src/iop/denoiseprofile.c:3581
 msgid ""
-"emergency use only: radius of the neighbourhood to search patches in. "
+"emergency use only: radius of the neighborhood to search patches in. "
 "increase for better denoising performance, but watch the long runtimes! "
 "large radii can be very slow. you have been warned"
 msgstr ""
 "vetëm për përdorim urgjent: rrezja e kërkimit për arnat në fqinjësi. rriteni "
-"që të përmirësoni performancën e imtësimit, por ju presin orë të gjata! "
-"rrezet e mëdha mund të jenë shumë të ngadalta. merreni si paralajmërim"
+"për të përmirësuar performancën e imtësimit, por kini parasysh vonesat! "
+"rrezet e mëdha mund të jenë shumë të ngadalta, sa për dijeni."
 
 #: ../src/iop/denoiseprofile.c:3584
 msgid ""
-"scattering of the neighbourhood to search patches in.\n"
+"scattering of the neighborhood to search patches in.\n"
 "increase for better coarse-grain noise reduction.\n"
 "does not affect execution time."
 msgstr ""
-"hapësira ku do të kryhet kërkimi për arnat.\n"
-"rriteni për të ulur kokrrizat e ashpër.\n"
+"shtrirja hapësinore e arnave që kërkohen.\n"
+"rriteni për të ulur kokrrizat e ashpra.\n"
 "nuk ndikon te koha e ekzekutimit."
 
 #: ../src/iop/denoiseprofile.c:3587
@@ -15147,30 +15143,30 @@ msgstr "difuzimi ose qartësimi"
 
 #: ../src/iop/diffuse.c:137
 msgid "diffusion|deconvolution|blur|sharpening"
-msgstr "difuzioni|dekonvolucioni|sfumoj|qartësimi"
+msgstr "difuzimi|dekonvolucioni|sfumimi|qartësimi"
 
 #: ../src/iop/diffuse.c:143
 msgid ""
 "simulate directional diffusion of light with heat transfer model\n"
 "to apply an iterative edge-oriented blur,\n"
-"inpaint damaged parts of the image,or to remove blur with blind "
+"inpaint damaged parts of the image, or to remove blur with blind "
 "deconvolution."
 msgstr ""
-"simuloni difuzionin e drejtuar të dritës siç transferohet nxehtësia\n"
-"për të aplikuar një efekt sfumues më të orientuar drejt cepave,\n"
-"pikturoni pjesët e dëmtuara të imazhit ose ulni sfumimin me dekonvolucion."
+"simuloni difuzionin e dritës sipas modelit të transferimit të nxehtësisë\n"
+"për një efekt sfumues më të orientuar drejt cepave, për të pikturuar\n"
+"pjesët e dëmtuara të imazhit ose për të ulur sfumimin me dekonvolucion."
 
 #: ../src/iop/diffuse.c:236
 msgid "lens deblur: soft"
-msgstr "desfumimi i objektivit: i butë"
+msgstr "desfumoj objektivin: butë"
 
 #: ../src/iop/diffuse.c:241
 msgid "lens deblur: medium"
-msgstr "desfumimi i objektivit: i mesëm"
+msgstr "desfumoj objektivin: mesëm"
 
 #: ../src/iop/diffuse.c:246
 msgid "lens deblur: hard"
-msgstr "desfumimi i objektivit: i fortë"
+msgstr "desfumoj objektivin: fort"
 
 #: ../src/iop/diffuse.c:265
 msgid "dehaze"
@@ -15178,15 +15174,15 @@ msgstr "çbrymëzoj"
 
 #: ../src/iop/diffuse.c:286
 msgid "denoise: fine"
-msgstr "zbutja e zhurmës: fine"
+msgstr "zbut zhurmën: fine"
 
 #: ../src/iop/diffuse.c:295
 msgid "denoise: medium"
-msgstr "zbutja e zhurmës: mesatare"
+msgstr "zbut zhurmën: mesatare"
 
 #: ../src/iop/diffuse.c:304
 msgid "denoise: coarse"
-msgstr "zbutja e zhurmës: e ashpër"
+msgstr "zbut zhurmën: ashpër"
 
 #: ../src/iop/diffuse.c:360
 msgid "sharpen demosaicing (no AA filter)"
@@ -15202,7 +15198,7 @@ msgstr "simuloj akuarelin"
 
 #: ../src/iop/diffuse.c:401
 msgid "simulate line drawing"
-msgstr "simuloj vizatimin e vijës"
+msgstr "simuloj vizatimin me laps"
 
 #: ../src/iop/diffuse.c:422
 msgid "add local contrast"
@@ -15214,7 +15210,7 @@ msgstr "pikturoj reflekset"
 
 #: ../src/iop/diffuse.c:463
 msgid "fast sharpness"
-msgstr "qartësi e shpejtë"
+msgstr "qartësoj shpejt"
 
 #: ../src/iop/diffuse.c:485
 msgid "fast local contrast"
@@ -15231,7 +15227,7 @@ msgstr ""
 #: ../src/iop/diffuse.c:1475 ../src/iop/splittoning.c:514
 #: ../src/libs/camera.c:487 ../src/libs/masks.c:1734 ../src/libs/masks.c:1742
 msgid "properties"
-msgstr "veti"
+msgstr "vetitë"
 
 #: ../src/iop/diffuse.c:1480
 msgid ""
@@ -15435,7 +15431,7 @@ msgstr ""
 
 #: ../src/iop/diffuse.c:1602
 msgid "diffusion spatiality"
-msgstr "hapësira e difuzionit"
+msgstr "hapësira e difuzimit"
 
 #: ../src/iop/diffuse.c:1607
 msgid ""
@@ -15643,7 +15639,7 @@ msgstr "ky modul është i vjetër. përdorni më mirë modulin filmik rgb."
 
 #: ../src/iop/filmic.c:306
 msgid "09 EV (low-key)"
-msgstr "09 EV (diskret)"
+msgstr "09 EV (diskrete)"
 
 #: ../src/iop/filmic.c:314
 msgid "10 EV (indoors)"
@@ -15651,7 +15647,7 @@ msgstr "10 EV (brenda)"
 
 #: ../src/iop/filmic.c:322
 msgid "11 EV (dim outdoors)"
-msgstr "11 EV (brenda pa shkëlqim)"
+msgstr "11 EV (jashtë pa shkëlqim)"
 
 #: ../src/iop/filmic.c:330
 msgid "12 EV (outdoors)"
@@ -15808,7 +15804,7 @@ msgstr ""
 #. Add export intent combo
 #: ../src/iop/filmic.c:1689 ../src/libs/export.c:1240
 #: ../src/libs/print_settings.c:2323 ../src/libs/print_settings.c:2642
-#: ../src/views/darkroom.c:2431 ../src/views/lighttable.c:1179
+#: ../src/views/darkroom.c:2433 ../src/views/lighttable.c:1179
 msgid "intent"
 msgstr "synimi"
 
@@ -16050,7 +16046,7 @@ msgstr ""
 #. Page RECONSTRUCT
 #: ../src/iop/filmicrgb.c:4257
 msgid "reconstruct"
-msgstr "rindërtoj"
+msgstr "rindërtimi"
 
 #: ../src/iop/filmicrgb.c:4259
 msgid "highlights clipping"
@@ -16253,13 +16249,13 @@ msgstr ""
 #: ../src/iop/filmicrgb.c:4432
 msgid ""
 "run extra passes of chromaticity reconstruction.\n"
-"more iterations means more color propagation from neighbourhood.\n"
+"more iterations means more color propagation from neighborhood.\n"
 "this will be slower but will yield more neutral highlights.\n"
 "it also helps with difficult cases of magenta highlights."
 msgstr ""
-"kaloni disa faza për rindërtimin e kromaticitetit\n"
+"kaloni disa faza për rindërtimin e kromaticitetit.\n"
 "përsëritjet sjellin përhapje më të mirë të ngjyrave me ato fqinje.\n"
-"procesi do të jetë i ngadaltë, por do të përfitoni reflekse më neutrale.\n"
+"procesi do të jetë i ngadaltë, por reflekset do të dalin më neutrale.\n"
 "ndihmon edhe në rastet e vështira të reflekseve të kuqërreme."
 
 #: ../src/iop/filmicrgb.c:4439
@@ -16315,7 +16311,7 @@ msgstr "vetëdiktoj"
 
 #: ../src/iop/flip.c:420
 msgid "no rotation"
-msgstr "mos e rrotulloni"
+msgstr "nuk rrotulloj"
 
 #: ../src/iop/flip.c:424 ../src/iop/flip.c:554
 msgid "flip horizontally"
@@ -16327,15 +16323,15 @@ msgstr "rrokulliseni vertikalisht"
 
 #: ../src/iop/flip.c:432
 msgid "rotate by -90 degrees"
-msgstr "rrotulloni -90 gradë"
+msgstr "rrotulloj -90 gradë"
 
 #: ../src/iop/flip.c:436
 msgid "rotate by  90 degrees"
-msgstr "rrotulloni 90 gradë"
+msgstr "rrotulloj 90 gradë"
 
 #: ../src/iop/flip.c:440
 msgid "rotate by 180 degrees"
-msgstr "rrotulloni 180 gradë"
+msgstr "rrotulloj 180 gradë"
 
 #: ../src/iop/flip.c:543
 msgid "transform"
@@ -16537,20 +16533,20 @@ msgstr "distanca"
 msgid "limit haze removal up to a specific spatial depth"
 msgstr "kufizoni heqjen e brymës në një hapësirë specifike"
 
-#: ../src/iop/highlights.c:176
+#: ../src/iop/highlights.c:177
 msgid "highlight reconstruction"
 msgstr "rindërtimi i reflekseve"
 
-#: ../src/iop/highlights.c:181
+#: ../src/iop/highlights.c:182
 msgid "avoid magenta highlights and try to recover highlights colors"
 msgstr ""
 "shmangni reflekset e kuqërreme dhe provoni të rikuperoni ngjyrat e tyre"
 
-#: ../src/iop/highlights.c:184 ../src/iop/hotpixels.c:75
+#: ../src/iop/highlights.c:185 ../src/iop/hotpixels.c:75
 msgid "reconstruction, raw"
 msgstr "rindërtimi, bruto"
 
-#: ../src/iop/highlights.c:2240
+#: ../src/iop/highlights.c:2261
 msgid ""
 "highlights: mode not available for this type of image. falling back to "
 "inpaint opposed."
@@ -16558,11 +16554,11 @@ msgstr ""
 "reflekset: kjo metodë nuk vlen për këtë lloj imazhi. do të përdoret "
 "kundërpikturimi."
 
-#: ../src/iop/highlights.c:2435
+#: ../src/iop/highlights.c:2460
 msgid "highlight reconstruction method"
 msgstr "metoda e rindërtimit të reflekseve"
 
-#: ../src/iop/highlights.c:2440
+#: ../src/iop/highlights.c:2465
 msgid ""
 "manually adjust the clipping threshold mostly used against magenta "
 "highlights\n"
@@ -16578,28 +16574,28 @@ msgstr ""
 "'segmentim',\n"
 "sidomos kur pika e bardhë e kamerës nuk është përcaktuar saktë."
 
-#: ../src/iop/highlights.c:2451
+#: ../src/iop/highlights.c:2476
 msgid ""
 "combine closely related clipped segments by morphological operations.\n"
 "the mask button shows the exact positions of resulting segment borders."
 msgstr ""
 "ndërthurni segmentet e afërta që janë shkurtuar nëpërmjet operacioneve "
 "morfologjike.\n"
-"butoni i maskës tregon pozicionet e sakta të kufijve finalë të segmentit."
+"butoni i maskës tregon pozicionet ekzakte të kufijve finalë të segmentit."
 
-#: ../src/iop/highlights.c:2459
+#: ../src/iop/highlights.c:2484
 msgid ""
 "select inpainting after segmentation analysis.\n"
 "increase to favour candidates found in segmentation analysis, decrease for "
 "opposed means inpainting.\n"
 "the mask button shows segments that are considered to have a good candidate."
 msgstr ""
-"pikturimi duhet përzgjedhur pas analizës segmentore.\n"
-"rriteni që të favorizoni kandidatët e zbuluar nga analiza segmentore, uleni "
-"për kundërpikturim.\n"
-"butoni i maskës tregon segmentet me kandidatët e konsideruar si të mirë."
+"përzgjidhni pikturimin pas analizës segmentore.\n"
+"rritja favorizon kandidatët e zbuluar nga analiza segmentore, ulja kryen "
+"kundërpikturimin.\n"
+"butoni i maskës tregon segmentet me kandidatët që konsiderohen të mirë."
 
-#: ../src/iop/highlights.c:2470
+#: ../src/iop/highlights.c:2495
 msgid ""
 "approximate lost data in regions with all photosites clipped, the effect "
 "depends on segment size and border gradients.\n"
@@ -16620,7 +16616,7 @@ msgstr ""
 "mënyrat e sheshta nuk i marrin parasysh strukturat e pashkurtuara (si linjat "
 "e elektrotransmetimit) për të evituar shfaqjen e gradientëve."
 
-#: ../src/iop/highlights.c:2476
+#: ../src/iop/highlights.c:2501
 msgid ""
 "set strength of rebuilding in regions with all photosites clipped.\n"
 "the mask buttons shows the effect that is added to already reconstructed "
@@ -16630,7 +16626,7 @@ msgstr ""
 "plotësisht.\n"
 "butoni i maskës tregon efektin në të dhënat e rindërtuara paraprakisht."
 
-#: ../src/iop/highlights.c:2486
+#: ../src/iop/highlights.c:2511
 msgid ""
 "add noise to visually blend the reconstructed areas\n"
 "into the rest of the noisy image. useful at high ISO."
@@ -16638,7 +16634,7 @@ msgstr ""
 "shtoni zhurmë për të bashkuar vizualisht zonat e rindërtuara\n"
 "me pjesën tjetër të imazhit të zhurmshëm. me dobi për ISO të larta."
 
-#: ../src/iop/highlights.c:2490
+#: ../src/iop/highlights.c:2515
 msgid ""
 "increase if magenta highlights don't get fully corrected\n"
 "each new iteration brings a performance penalty."
@@ -16646,7 +16642,7 @@ msgstr ""
 "rriteni nëse reflekset e kuqërreme nuk korrigjohen plotësisht\n"
 "çdo përsëritje e veprimit kryhet në dëm të performancës."
 
-#: ../src/iop/highlights.c:2495
+#: ../src/iop/highlights.c:2520
 msgid ""
 "increase if magenta highlights don't get fully corrected.\n"
 "this may produce non-smooth boundaries between valid and clipped regions."
@@ -16654,7 +16650,7 @@ msgstr ""
 "rriteni nëse reflekset e kuqërreme nuk korrigjohen plotësisht.\n"
 "mund të shfaqen caqe jo të rrafshëta në zonat e duhura dhe të shkurtuara."
 
-#: ../src/iop/highlights.c:2499
+#: ../src/iop/highlights.c:2524
 msgid ""
 "increase to correct larger clipped areas.\n"
 "large values bring huge performance penalties"
@@ -16695,9 +16691,8 @@ msgid "hot pixels"
 msgstr "pikselët e nxehtë"
 
 #: ../src/iop/hotpixels.c:72
-msgid "remove abnormally bright pixels by dampening them with neighbours"
-msgstr ""
-"hiqni pikselët që shndrijnë jonormalisht duke i shuar me pikselët fqinj"
+msgid "remove abnormally bright pixels by dampening them with neighbors"
+msgstr "hiqni pikselët që nuk shndrijnë normalisht duke i shuar me fqinjët"
 
 #: ../src/iop/hotpixels.c:363
 #, c-format
@@ -16850,15 +16845,15 @@ msgstr ""
 
 #: ../src/iop/lens.cc:3000
 msgid "distortion & TCA"
-msgstr "deformimi dhe TCA"
+msgstr "deformimin dhe TCA"
 
 #: ../src/iop/lens.cc:3006
 msgid "distortion & vignetting"
-msgstr "deformimi dhe vineta"
+msgstr "deformimin dhe vinetën"
 
 #: ../src/iop/lens.cc:3012
 msgid "TCA & vignetting"
-msgstr "TCA & vineta"
+msgstr "TCA & vinetën"
 
 #: ../src/iop/lens.cc:3018
 msgid "only distortion"
@@ -16870,7 +16865,7 @@ msgstr "vetëm TCA"
 
 #: ../src/iop/lens.cc:3030
 msgid "only vignetting"
-msgstr "vetëm vineta"
+msgstr "vetëm vinetën"
 
 #: ../src/iop/lens.cc:3041
 msgid "camera model"
@@ -16898,11 +16893,11 @@ msgstr "sy peshku"
 
 #: ../src/iop/lens.cc:3091
 msgid "panoramic"
-msgstr "panoramike"
+msgstr "panoramik"
 
 #: ../src/iop/lens.cc:3092
 msgid "equirectangular"
-msgstr "barabrinjëse"
+msgstr "barabrinjës"
 
 #: ../src/iop/lens.cc:3094
 msgid "orthographic"
@@ -17170,7 +17165,7 @@ msgstr "dritë ditore"
 
 #: ../src/iop/lowlight.c:336
 msgid "indoor bright"
-msgstr "e brendshme e shkëlqyer"
+msgstr "e brendshme me shkëlqim"
 
 #: ../src/iop/lowlight.c:354
 msgid "indoor dim"
@@ -17186,15 +17181,15 @@ msgstr "muzg"
 
 #: ../src/iop/lowlight.c:408
 msgid "night street lit"
-msgstr "rrugë nate e ndriçuar"
+msgstr "rrugë e ndriçuar natën"
 
 #: ../src/iop/lowlight.c:426
 msgid "night street"
-msgstr "rrugë nate"
+msgstr "rrugë natën"
 
 #: ../src/iop/lowlight.c:444
 msgid "night street dark"
-msgstr "rrugë nate e errët"
+msgstr "rrugë e errët natën"
 
 #: ../src/iop/lowlight.c:463
 msgid "night"
@@ -17230,7 +17225,7 @@ msgstr "izoloni frekuencat e ulëta të imazhit"
 
 #: ../src/iop/lowpass.c:542
 msgid "local contrast mask"
-msgstr "maska e kontrastit lokal"
+msgstr "maskë e kontrastit lokal"
 
 #: ../src/iop/lowpass.c:567
 msgid "radius of gaussian/bilateral blur"
@@ -17655,10 +17650,10 @@ msgstr ""
 msgid ""
 "gradually compress specular highlights past this value\n"
 "to avoid clipping while pushing the exposure for mid-tones.\n"
-"this somewhat reproduces the behaviour of matte paper."
+"this somewhat reproduces the behavior of matte paper."
 msgstr ""
 "kompresoni gradualisht reflekset pasqyrore përtej kësaj vlere\n"
-"për të evituar shkurtimin e tyre prej mbiekspozimin të toneve të mesme.\n"
+"për të evituar shkurtimin e tyre prej mbiekspozimit të toneve të mesme.\n"
 "me këtë mënyrë imitoni vetitë e letrës mat."
 
 #: ../src/iop/negadoctor.c:962
@@ -17706,9 +17701,9 @@ msgstr "rrafshoni ngjyrat"
 #. * let's fill the encapsulating widgets
 #. preview mode
 #. color scheme
-#: ../src/iop/overexposed.c:73 ../src/views/darkroom.c:2322
-#: ../src/views/darkroom.c:2340 ../src/views/darkroom.c:2347
-#: ../src/views/darkroom.c:2357 ../src/views/darkroom.c:2374
+#: ../src/iop/overexposed.c:73 ../src/views/darkroom.c:2324
+#: ../src/views/darkroom.c:2342 ../src/views/darkroom.c:2349
+#: ../src/views/darkroom.c:2359 ../src/views/darkroom.c:2376
 msgid "overexposed"
 msgstr "mbiekspozimi"
 
@@ -17731,23 +17726,23 @@ msgstr ""
 
 #: ../src/iop/profile_gamma.c:135
 msgid "16 EV dynamic range (generic)"
-msgstr "16 EV diapazon dinamik (gjenerik)"
+msgstr "diapazon dinamik 16 EV (gjenerik)"
 
 #: ../src/iop/profile_gamma.c:141
 msgid "14 EV dynamic range (generic)"
-msgstr "14 EV diapazon dinamik (gjenerik)"
+msgstr "diapazon dinamik 14 EV (gjenerik)"
 
 #: ../src/iop/profile_gamma.c:147
 msgid "12 EV dynamic range (generic)"
-msgstr "12 EV diapazon dinamik (gjenerik)"
+msgstr "diapazon dinamik 12 EV (gjenerik)"
 
 #: ../src/iop/profile_gamma.c:153
 msgid "10 EV dynamic range (generic)"
-msgstr "10 EV diapazon dinamik (gjenerik)"
+msgstr "diapazon dinamik 10 EV (gjenerik)"
 
 #: ../src/iop/profile_gamma.c:159
 msgid "08 EV dynamic range (generic)"
-msgstr "08 EV diapazon dinamik (gjenerik)"
+msgstr "diapazon dinamik 08 EV (gjenerik)"
 
 #: ../src/iop/profile_gamma.c:622
 msgid "linear part"
@@ -17815,9 +17810,9 @@ msgstr ""
 
 #. * let's fill the encapsulating widgets
 #. mode of operation
-#: ../src/iop/rawoverexposed.c:69 ../src/views/darkroom.c:2272
-#: ../src/views/darkroom.c:2290 ../src/views/darkroom.c:2296
-#: ../src/views/darkroom.c:2309
+#: ../src/iop/rawoverexposed.c:69 ../src/views/darkroom.c:2274
+#: ../src/views/darkroom.c:2292 ../src/views/darkroom.c:2298
+#: ../src/views/darkroom.c:2311
 msgid "raw overexposed"
 msgstr "mbiekspozimi i brutos"
 
@@ -17950,7 +17945,7 @@ msgstr "gjeometrik dhe frekuencial, RGB"
 
 #: ../src/iop/retouch.c:1512
 msgid "cannot display scales when the blending mask is displayed"
-msgstr "shkallët nuk shihen kur shfaqni maskën bashkuese"
+msgstr "shkallët nuk shihen kur aktivizoni maskën bashkuese"
 
 #: ../src/iop/retouch.c:1827 ../src/iop/retouch.c:1829
 #: ../src/iop/retouch.c:1831 ../src/iop/retouch.c:1833
@@ -18031,11 +18026,11 @@ msgstr "aktivizoni penelin korrektues"
 #. overwrite tooltip ourself to handle shift+click
 #: ../src/iop/retouch.c:2238
 msgid "ctrl+click to change tool for current form"
-msgstr "ctrl+klikim ndryshon instrumentin për formën aktuale"
+msgstr "me ctrl+klikim ndryshoni instrumentin për formën aktuale"
 
 #: ../src/iop/retouch.c:2239
 msgid "shift+click to set the tool as default"
-msgstr "shift+klikim cakton instrumentin standard"
+msgstr "me shift+klikim caktoni instrumentin standard"
 
 #: ../src/iop/retouch.c:2258
 msgid "scales:"
@@ -18243,11 +18238,11 @@ msgstr "rrotullimi i pikselëve"
 msgid ""
 "internal module to setup technical specificities of raw sensor.\n"
 "\n"
-"you should not touch values here !"
+"you should not touch values here!"
 msgstr ""
 "moduli i brendshëm për të sistemuar specifikat teknike të sensorit bruto.\n"
 "\n"
-"vlerat këtu nuk duhen prekur !"
+"vlerat këtu nuk duhen prekur!"
 
 #: ../src/iop/rotatepixels.c:366
 msgid "automatic pixel rotation"
@@ -18259,7 +18254,7 @@ msgid ""
 "only works for the sensors that need it."
 msgstr ""
 "vetërrotullimi i pikselëve\n"
-"vetëm për sensorët që e kanë të nevojshme."
+"vetëm për sensorët që e kanë të nevojshëm."
 
 #: ../src/iop/scalepixels.c:54
 msgctxt "modulename"
@@ -18381,7 +18376,7 @@ msgstr ""
 
 #: ../src/iop/sigmoid.c:122
 msgid "neutral gray"
-msgstr "grija neutrale"
+msgstr "gri neutrale"
 
 #: ../src/iop/sigmoid.c:127
 msgid "ACES 100-nit like"
@@ -18403,8 +18398,8 @@ msgid ""
 "the opposite end will see a reduction in contrast."
 msgstr ""
 "kompresimi do të zhvendoset drejt hijeve ose reflekseve.\n"
-"vlerat negative e rritin kontrastin në hije.\n"
-"vlerat pozitive e rritin kontrastin në reflekse.\n"
+"vlerat negative rritin kontrastin te hijet.\n"
+"vlerat pozitive rritin kontrastin te reflekset.\n"
 "të kundërtat shkaktojnë rënien e kontrastit."
 
 #: ../src/iop/sigmoid.c:567
@@ -18412,7 +18407,7 @@ msgid ""
 "optional correction of the hue twist introduced by\n"
 "the per-channel processing method."
 msgstr ""
-"korrigjim i mundshëm për nuancat e spostuara\n"
+"korrigjimi i mundshëm i nuancave të spostuara\n"
 "si pasojë e metodës së procesimit për kanal."
 
 #. Target display
@@ -18487,7 +18482,7 @@ msgstr "platinotip i vërtetë"
 
 #: ../src/iop/splittoning.c:145
 msgid "chocolate brown"
-msgstr "çokollatë kafe"
+msgstr "kafe çokollatë"
 
 #: ../src/iop/splittoning.c:475
 msgid "select the saturation tone"
@@ -18527,7 +18522,7 @@ msgid "geometric, raw"
 msgstr "gjeometrik, bruto"
 
 #: ../src/iop/spots.c:220
-msgid "spot module is limited to 64 shapes. please add a new instance !"
+msgid "spot module is limited to 64 shapes. please add a new instance!"
 msgstr ""
 "moduli i shenjave ka një limit prej 64 formash. lutemi të shtoni një "
 "instancë të re!"
@@ -18778,11 +18773,11 @@ msgstr "kurba e thjeshtë e toneve"
 
 #: ../src/iop/toneequal.c:438
 msgid "mask blending: all purposes"
-msgstr "shkrirja e maskës: e përgjithshme"
+msgstr "maska bashkuese: e përgjithshme"
 
 #: ../src/iop/toneequal.c:444
 msgid "mask blending: people with backlight"
-msgstr "shkrirja e maskës: njerëz me ndriçimin prapa"
+msgstr "maska bashkuese: njerëz me ndriçimin prapa"
 
 #: ../src/iop/toneequal.c:460
 msgid "compress shadows/highlights (eigf): strong"
@@ -18960,7 +18955,7 @@ msgstr ""
 #. Masking options
 #: ../src/iop/toneequal.c:3188
 msgid "masking"
-msgstr "maskoj"
+msgstr "maskimi"
 
 #: ../src/iop/toneequal.c:3192
 msgid ""
@@ -19295,7 +19290,7 @@ msgstr "përmasat në raport me"
 
 #: ../src/iop/watermark.c:1146 ../src/libs/print_settings.c:2508
 msgid "alignment"
-msgstr "rreshtimi"
+msgstr "radhitja"
 
 #. Let's add some tooltips and hook up some signals...
 #: ../src/iop/watermark.c:1167
@@ -19523,8 +19518,8 @@ msgid ""
 msgstr ""
 "përdorni `%' si metagermë\n"
 "me klikim përfshini hierarkinë aktuale + nënhierarkitë (prapashtesa `*')\n"
-"shift+klikim përfshini vetëm hierarkinë aktuale (pa prapashtesë)\n"
-"ctrl+klikim përfshini vetëm nënhierarkitë (prapashtesa `|%')"
+"me shift+klikim përfshini vetëm hierarkinë aktuale (pa prapashtesë)\n"
+"me ctrl+klikim përfshini vetëm nënhierarkitë (prapashtesa `|%')"
 
 #: ../src/libs/collect.c:2172
 #, no-c-format
@@ -19537,8 +19532,8 @@ msgstr ""
 "përdorni `%' si metagermë\n"
 "me klikim përfshini vendndodhjen aktuale + nënvendndodhjet (prapashtesa "
 "`*')\n"
-"shift+klikim përfshini vetëm vendndodhjen aktuale (pa prapashtesë)\n"
-"ctrl+klikim përfshini vetëm nënvendndodhjet (prapashtesa `|%')"
+"me shift+klikim përfshini vetëm vendndodhjen aktuale (pa prapashtesë)\n"
+"me ctrl+klikim përfshini vetëm nënvendndodhjet (prapashtesa `|%')"
 
 #: ../src/libs/collect.c:2184
 #, no-c-format
@@ -19550,8 +19545,8 @@ msgid ""
 msgstr ""
 "përdorni `%' si metagermë\n"
 "me klikim përfshini dosjen aktuale + nëndosjet (prapashtesa `*')\n"
-"shift+klikim përfshini vetëm dosjen aktuale (pa prapashtesë)\n"
-"ctrl+klikim përfshini vetëm nëndosjet (prapashtesa `|%')"
+"me shift+klikim përfshini vetëm dosjen aktuale (pa prapashtesë)\n"
+"me ctrl+klikim përfshini vetëm nëndosjet (prapashtesa `|%')"
 
 #: ../src/libs/collect.c:2195
 #, no-c-format
@@ -19692,7 +19687,7 @@ msgstr ""
 
 #: ../src/libs/colorpicker.c:554 ../src/libs/colorpicker.c:605
 msgid "click to (un)hide large color patch"
-msgstr "klikoni për të (mos) fshehur arnën e madhe me ngjyrë"
+msgstr "klikoni për të (mos) fshehur arnën e madhe me ngjyra"
 
 #: ../src/libs/colorpicker.c:568
 msgid "statistic"
@@ -19862,7 +19857,7 @@ msgstr "origjinali"
 
 #: ../src/libs/duplicate.c:359
 msgid "create a 'virgin' duplicate of the image without any development"
-msgstr "krijoni një dublikatë 'të virgjër' të imazhit pa e zhvilluar"
+msgstr "krijoni një dublikatë 'të virgjër' të imazhit pa u zhvilluar"
 
 #: ../src/libs/duplicate.c:362
 msgid "create a duplicate of the image with same history stack"
@@ -19871,7 +19866,7 @@ msgstr "krijoni një dublikatë të imazhit me të njëjtin historik zhvillimi"
 #. Export button
 #: ../src/libs/export.c:154 ../src/libs/export.c:1299
 msgid "export"
-msgstr "eksportoj"
+msgstr "eksportimi"
 
 #: ../src/libs/export.c:311
 msgid "export to disk"
@@ -19992,7 +19987,7 @@ msgstr "rishëmbëllej me cilësi të lartë"
 
 #: ../src/libs/export.c:1197
 msgid "do high quality resampling during export"
-msgstr "eksportojeni duke e rishëmbëllyer me cilësi të lartë"
+msgstr "eksportoni duke e rishëmbëllyer me cilësi të lartë"
 
 #: ../src/libs/export.c:1203
 msgid "store masks"
@@ -20238,32 +20233,31 @@ msgstr "filtrat e koleksionit"
 
 #: ../src/libs/filtering.c:273
 msgid "initial setting"
-msgstr "parametri fillestar"
+msgstr "parametër fillestar"
 
 #: ../src/libs/filtering.c:292
 msgid "imported: last 24h"
-msgstr "importi: 24 orët e fundit"
+msgstr "importuar: 24 orët e fundit"
 
 #: ../src/libs/filtering.c:297
 msgid "imported: last 30 days"
-msgstr "importi: 30 ditët e fundit"
+msgstr "importuar: 30 ditët e fundit"
 
 #: ../src/libs/filtering.c:303
 msgid "taken: last 24h"
-msgstr "fotografimi: 24 orët e fundit"
+msgstr "fotografuar: 24 orët e fundit"
 
 #: ../src/libs/filtering.c:307
 msgid "taken: last 30 days"
-msgstr "fotografimi: 30 ditët e fundit"
+msgstr "fotografuar: 30 ditët e fundit"
 
 #: ../src/libs/filtering.c:680
 msgid "click or click&#38;drag to select one or multiple values"
-msgstr ""
-"klikoni ose klikoni&#38;tërhiqni mausin për të përzgjedhur një a disa vlera"
+msgstr "me klikim ose klikim&#38;tërheqje mausi përzgjidhni një a disa vlera"
 
 #: ../src/libs/filtering.c:681
 msgid "right-click opens a menu to select the available values"
-msgstr "menuja për përzgjedhjen e vlerave të mundshme hapet me klikim djathtas"
+msgstr "me klikim djathtas hapni menunë për përzgjedhjen e vlerave të mundshme"
 
 #: ../src/libs/filtering.c:778
 #, c-format
@@ -20306,7 +20300,7 @@ msgstr "rregulla nuk hiqet, sepse është fiksuar në brezin e instrumenteve"
 
 #: ../src/libs/filtering.c:1046
 msgid "click to pin this rule to the top toolbar"
-msgstr "klikoni për të fiksuar rregullën në brezin e sipërm të instrumenteve"
+msgstr "fiksoni rregullën në brezin e sipërm të instrumenteve"
 
 #: ../src/libs/filtering.c:1047
 msgid "remove this collect rule"
@@ -20380,7 +20374,7 @@ msgstr "NGJIT"
 
 #: ../src/libs/filtering.c:2184
 msgid "new rule"
-msgstr "rregullë të rë"
+msgstr "rregullë të re"
 
 #: ../src/libs/filtering.c:2185
 msgid "append new rule to collect images"
@@ -20408,8 +20402,8 @@ msgid ""
 "reset\n"
 "ctrl-click to remove pinned rules too"
 msgstr ""
-"kthejeni në gjendjen fillestare\n"
-"ctrl-klikim për të hequr edhe rregullat e fiksuara"
+"ktheni gjendjen fillestare\n"
+"me ctrl-klikim hiqni edhe rregullat e fiksuara"
 
 #: ../src/libs/filters/colors.c:140
 msgid "Y"
@@ -20431,8 +20425,8 @@ msgid ""
 "the gray button affects all color labels"
 msgstr ""
 "filtroni imazhet sipas etiketës me ngjyrë\n"
-"përzgjidhni etiketën me ngjyrë me klikim\n"
-"ctrl+klikim e përjashton etiketën me ngjyrë\n"
+"me klikim përzgjidhni etiketën me ngjyrë\n"
+"me ctrl+klikim përjashtoni etiketën me ngjyrë\n"
 "butoni gri ndikon te të gjitha etiketat me ngjyrë"
 
 #: ../src/libs/filters/colors.c:301 ../src/libs/filters/colors.c:312
@@ -20630,8 +20624,7 @@ msgstr ""
 "të imazhit\n"
 "`%' është një metagermë\n"
 "metagermat e fillimit dhe të fundit vetaplikohen në mënyrën standarde\n"
-"metagermat përkatëse çaktivizohen kur i filloni dhe mbaroni me thonjëza "
-"dyshe\n"
+"metagermat çaktivizohen kur i filloni dhe mbaroni me thonjëza dyshe\n"
 "veprimi do të anashkalohet gjatë kërkimit"
 
 #: ../src/libs/geotagging.c:369
@@ -20680,7 +20673,7 @@ msgid "open GPX file"
 msgstr "hap skedarin GPX"
 
 #. Preview key
-#: ../src/libs/geotagging.c:928 ../src/views/darkroom.c:2142
+#: ../src/libs/geotagging.c:928 ../src/views/darkroom.c:2144
 #: ../src/views/lighttable.c:650 ../src/views/lighttable.c:1266
 msgid "preview"
 msgstr "parashikoj"
@@ -20773,9 +20766,8 @@ msgstr ""
 "lista e segmenteve në skedarin GPX, për secilin segment:\n"
 "- data/ora e fillimit sipas lokacionit (LT)\n"
 "- numri i pikave të gjurmuara\n"
-"- numri i imazheve të ngjashme mbi bazën e datës/orës, ofsetit dhe zonës "
-"kohore\n"
-"- informacion më i detajuar mbi kohën po të çohet mausi sipër rreshtit"
+"- numri i imazheve të ngjashme sipas datës/orës, ofsetit dhe zonës kohore\n"
+"- çoni mausin sipër rreshtit për informacion më të detajuar mbi kohën"
 
 #: ../src/libs/geotagging.c:1890
 msgid "preview images"
@@ -20905,7 +20897,7 @@ msgstr "histogrami"
 
 #: ../src/libs/histogram.c:1950 ../src/libs/histogram.c:1987
 msgid "cycle histogram modes"
-msgstr "ndërroni llojet e histogramit"
+msgstr "ndryshoni mënyrat e histogramit"
 
 #: ../src/libs/histogram.c:1955 ../src/libs/histogram.c:1988
 msgid "hide histogram"
@@ -20928,8 +20920,8 @@ msgid ""
 "create a minimal history stack which produces the same image\n"
 "ctrl+click to truncate history to the selected item"
 msgstr ""
-"krijimi i historikut minimal të zhvillimit prodhon të njëjtin imazh\n"
-"historiku hiqet nga elementi i përzgjedhur me ctrl+klikim"
+"prodhoni të njëjtin imazh me një historik minimal të zhvillimit\n"
+"me ctrl+klikim e shkurtoni historikun deri te elementi i përzgjedhur"
 
 #: ../src/libs/history.c:133
 msgid "create a style from the current history stack"
@@ -21269,7 +21261,7 @@ msgstr "fotot"
 
 #: ../src/libs/import.c:1539
 msgid "mark already imported pictures"
-msgstr "shenjoj skedat e importuara paraprakisht"
+msgstr "shenjoj fotot e importuara paraprakisht"
 
 #: ../src/libs/import.c:1553
 msgid "modified"
@@ -21581,7 +21573,7 @@ msgid ""
 "location' module)"
 msgstr ""
 "përzgjidhni formën e vendndodhjes kufitare në hartë, rreth apo drejtkëndësh\n"
-"apo edhe poligon (përzgjidhni fillimisht poligonin në modulin 'gjej "
+"madje edhe poligon (përzgjidhni fillimisht poligonin në modulin 'gjej "
 "vendndodhjen')"
 
 #: ../src/libs/map_locations.c:992
@@ -22333,35 +22325,35 @@ msgstr "lundrimi"
 msgid "hide navigation thumbnail"
 msgstr "fsheh miniaturën e lundrimit"
 
-#: ../src/libs/navigation.c:509
+#: ../src/libs/navigation.c:510
 msgid "small"
 msgstr "e vogël"
 
-#: ../src/libs/navigation.c:513
+#: ../src/libs/navigation.c:514
 msgid "fit to screen"
 msgstr "sipas ekranit"
 
-#: ../src/libs/navigation.c:517
+#: ../src/libs/navigation.c:518
 msgid "50%"
 msgstr "50%"
 
-#: ../src/libs/navigation.c:521
+#: ../src/libs/navigation.c:522
 msgid "100%"
 msgstr "100%"
 
-#: ../src/libs/navigation.c:525
+#: ../src/libs/navigation.c:526
 msgid "200%"
 msgstr "200%"
 
-#: ../src/libs/navigation.c:529
+#: ../src/libs/navigation.c:530
 msgid "400%"
 msgstr "400%"
 
-#: ../src/libs/navigation.c:533
+#: ../src/libs/navigation.c:534
 msgid "800%"
 msgstr "800%"
 
-#: ../src/libs/navigation.c:537
+#: ../src/libs/navigation.c:538
 msgid "1600%"
 msgstr "1600%"
 
@@ -22425,7 +22417,7 @@ msgstr "%3.2f (dpi:%d)"
 #: ../src/libs/print_settings.c:2252 ../src/libs/print_settings.c:2264
 #: ../src/libs/print_settings.c:2272 ../src/libs/print_settings.c:2323
 msgid "printer"
-msgstr "printer"
+msgstr "printeri"
 
 #: ../src/libs/print_settings.c:2264
 msgid "media"
@@ -22489,7 +22481,7 @@ msgstr "anësorja majtas"
 
 #: ../src/libs/print_settings.c:2414
 msgid "lock"
-msgstr "bllokoj"
+msgstr "fiksoj"
 
 #: ../src/libs/print_settings.c:2415
 msgid "change all margins uniformly"
@@ -22515,7 +22507,7 @@ msgstr "ngec në rrjetë"
 
 #: ../src/libs/print_settings.c:2476
 msgid "borderless mode required"
-msgstr "duhet mënyra pa bordura"
+msgstr "paraqit pa bordurë"
 
 #: ../src/libs/print_settings.c:2479
 msgid ""
@@ -22548,19 +22540,19 @@ msgstr ""
 
 #: ../src/libs/print_settings.c:2529
 msgid "delete image area"
-msgstr "do e fshini zonën e imazhit"
+msgstr "fshij zonën e imazhit"
 
 #: ../src/libs/print_settings.c:2530
 msgid "delete the currently selected image area"
-msgstr "fshij zonën e përzgjedhur të imazhit aktual"
+msgstr "fshini zonën e përzgjedhur të imazhit aktual"
 
 #: ../src/libs/print_settings.c:2533
 msgid "clear layout"
-msgstr "pastroj strukturën grafike"
+msgstr "pastroj strukturën"
 
 #: ../src/libs/print_settings.c:2534
 msgid "remove all image areas from the page"
-msgstr "heq të gjitha zonat e imazhit nga faqja"
+msgstr "hiqni të gjitha zonat e imazhit nga faqja"
 
 #. d->b_x = gtk_spin_button_new_with_range(0, 1000, 1);
 #: ../src/libs/print_settings.c:2549
@@ -23047,7 +23039,7 @@ msgstr ""
 
 #: ../src/libs/tagging.c:3158 ../src/libs/tagging.c:3164
 msgid "clear entry"
-msgstr "pastroj elementin"
+msgstr "pastroni elementin"
 
 #: ../src/libs/tagging.c:3211
 msgid ""
@@ -23063,7 +23055,7 @@ msgstr ""
 "shtypni Enter ose dopioklik për t'ua bashkëngjitur etiketën imazheve të "
 "përzgjedhura,\n"
 "po kështu me shift+Enter, plus që e vini në fokus elementin,\n"
-"shift+klikim e shpalosni plotësisht etiketën e përzgjedhur,\n"
+"me shift+klikim e shpalosni plotësisht etiketën e përzgjedhur,\n"
 "me klikimin djathtas shihni veprimet e tjera për etiketën e përzgjedhur,\n"
 "shtypni shift+Tab për të vënë fokusin te elementi,\n"
 "ripërmasoni dritaren me ctrl-rrëshqitje mausi"
@@ -23080,7 +23072,7 @@ msgstr "importoni etiketat nga skedari me fjalë kyç për Lightroom"
 
 #: ../src/libs/tagging.c:3253
 msgid "export all tags to a Lightroom keyword file"
-msgstr "eksportoj të gjitha etiketat si skedar me fjalë kyç për Lightroom"
+msgstr "eksportoni të gjitha etiketat në skedar me fjalë kyç për Lightroom"
 
 #: ../src/libs/tagging.c:3257
 msgid "toggle list / tree view"
@@ -23156,7 +23148,7 @@ msgid "filter"
 msgstr "filtroj"
 
 #: ../src/libs/tools/filter.c:105
-msgid "filters preferences"
+msgid "filter preferences"
 msgstr "preferencat për filtrat"
 
 #: ../src/libs/tools/gamepad.c:37
@@ -23332,12 +23324,12 @@ msgstr "nuk mundësohen mbishtresat..."
 #: ../src/libs/tools/global_toolbox.c:399
 #: ../src/libs/tools/global_toolbox.c:535
 msgid "expand grouped images"
-msgstr "zbërtheni imazhet e grupuara"
+msgstr "shpalosni imazhet e grupuara"
 
 #: ../src/libs/tools/global_toolbox.c:401
 #: ../src/libs/tools/global_toolbox.c:537
 msgid "collapse grouped images"
-msgstr "mblidhni imazhet e grupuara"
+msgstr "palosni imazhet e grupuara"
 
 #: ../src/libs/tools/global_toolbox.c:408
 msgid "thumbnail overlays options"
@@ -23354,39 +23346,39 @@ msgstr "mbishtresa për madhësinë"
 
 #: ../src/libs/tools/global_toolbox.c:436
 msgid "thumbnail overlays"
-msgstr "shtresat mbi miniatura"
+msgstr "mbishtresat mbi miniatura"
 
 #: ../src/libs/tools/global_toolbox.c:438
 #: ../src/libs/tools/global_toolbox.c:467
 msgid "no overlays"
-msgstr "pa shtresa"
+msgstr "pa mbishtresa"
 
 #: ../src/libs/tools/global_toolbox.c:439
 msgid "overlays on mouse hover"
-msgstr "shtresoj me mausin sipër"
+msgstr "mbishtresat me mausin sipër"
 
 #: ../src/libs/tools/global_toolbox.c:440
 msgid "extended overlays on mouse hover"
-msgstr "shtresoj gjerësisht me mausin sipër"
+msgstr "mbishtresat e zgjeruara me mausin sipër"
 
 #: ../src/libs/tools/global_toolbox.c:441
 #: ../src/libs/tools/global_toolbox.c:468
 msgid "permanent overlays"
-msgstr "shtresa të përhershme"
+msgstr "mbishtresat e përhershme"
 
 #: ../src/libs/tools/global_toolbox.c:442
 #: ../src/libs/tools/global_toolbox.c:469
 msgid "permanent extended overlays"
-msgstr "mbishtresat e përhershme"
+msgstr "mbishtresat e zgjeruara të përhershme"
 
 #: ../src/libs/tools/global_toolbox.c:443
 msgid "permanent overlays extended on mouse hover"
-msgstr "mbishtresat e përhershme shfaqen me kalimin sipër të mausit"
+msgstr "mbishtresat e zgjeruara të përhershme me mausin sipër"
 
 #: ../src/libs/tools/global_toolbox.c:445
 #: ../src/libs/tools/global_toolbox.c:471
 msgid "overlays block on mouse hover"
-msgstr "blloku i mbishtresave kur kalon mausi sipër"
+msgstr "blloku i mbishtresave me mausin sipër"
 
 #: ../src/libs/tools/global_toolbox.c:446
 #: ../src/libs/tools/global_toolbox.c:472
@@ -23420,7 +23412,7 @@ msgid ""
 "configuration"
 msgstr ""
 "përcaktoni shkurtoret\n"
-"çaktivizoni mbishkrimin e konfirmimeve me ctrl+klikim\n"
+"me ctrl+klikim çaktivizoni mbishkrimin e konfirmimeve\n"
 "\n"
 "kaloni mausin mbi vegël, shtypni tastet me klikim, rrëshqitni mausin ose "
 "lëvizni kombinimet\n"
@@ -23430,7 +23422,7 @@ msgstr ""
 
 #: ../src/libs/tools/global_toolbox.c:514
 msgid "show global preferences"
-msgstr "tregoni preferencat globale"
+msgstr "shihni preferencat globale"
 
 #. ask the user if darktable.org may be accessed
 #: ../src/libs/tools/global_toolbox.c:643
@@ -23469,23 +23461,23 @@ msgstr "infot për imazhin"
 
 #: ../src/libs/tools/lighttable.c:117
 msgid "click to exit from full preview layout."
-msgstr "klikoni për të mbyllur strukturën e parashikimit të plotë."
+msgstr "mbyllni strukturën e parashikimit të plotë."
 
 #: ../src/libs/tools/lighttable.c:119
 msgid "click to enter full preview layout."
-msgstr "klikoni për të hapur strukturën e parashikimit të plotë."
+msgstr "hapni strukturën e parashikimit të plotë."
 
 #: ../src/libs/tools/lighttable.c:122
 msgid "click to enter culling layout in fixed mode."
-msgstr "klikoni për të hapur strukturën fikse të seleksionimit."
+msgstr "hapni strukturën fikse të seleksionimit."
 
 #: ../src/libs/tools/lighttable.c:124 ../src/libs/tools/lighttable.c:129
 msgid "click to exit culling layout."
-msgstr "klikoni për të mbyllur strukturën e seleksionimit."
+msgstr "mbyllni strukturën e seleksionimit."
 
 #: ../src/libs/tools/lighttable.c:127
 msgid "click to enter culling layout in dynamic mode."
-msgstr "klikoni për të hapur strukturën dinamike të seleksionimit."
+msgstr "hapni strukturën dinamike të seleksionimit."
 
 #: ../src/libs/tools/lighttable.c:352
 msgid "toggle filemanager layout"
@@ -23493,7 +23485,7 @@ msgstr "përdorni strukturën e administruesit të skedarëve"
 
 #: ../src/libs/tools/lighttable.c:355
 msgid "click to enter filemanager layout."
-msgstr "klikoni për të hapur strukturën e administruesit të skedarëve."
+msgstr "hapni strukturën e administruesit të skedarëve."
 
 #: ../src/libs/tools/lighttable.c:361
 msgid "toggle zoomable lighttable layout"
@@ -23501,7 +23493,7 @@ msgstr "përdorni strukturën zmadhuese të fototekës"
 
 #: ../src/libs/tools/lighttable.c:364
 msgid "click to enter zoomable lighttable layout."
-msgstr "klikoni për të hapur strukturën zmadhuese të fototekës."
+msgstr "hapni strukturën zmadhuese të fototekës."
 
 #: ../src/libs/tools/lighttable.c:370
 msgid "toggle culling mode"
@@ -23513,7 +23505,7 @@ msgstr "përdorni këndin dinamik të seleksionimit"
 
 #: ../src/libs/tools/lighttable.c:386
 msgid "toggle sticky preview mode"
-msgstr "përdor mënyrën e parashikimit me ngulm"
+msgstr "përdorni mënyrën e parashikimit me fiksim"
 
 #: ../src/libs/tools/lighttable.c:427
 msgid "toggle culling zoom mode"
@@ -23521,7 +23513,7 @@ msgstr "përdorni këndin me zmadhim të seleksionimit"
 
 #: ../src/libs/tools/lighttable.c:429
 msgid "toggle sticky preview mode with focus detection"
-msgstr "përdor mënyrën e parashikimit me dallim fokusi"
+msgstr "përdorni mënyrën e parashikimit me dallim fokusi"
 
 #: ../src/libs/tools/lighttable.c:431
 msgid "exit current layout"
@@ -23598,7 +23590,7 @@ msgstr "me dopioklik kthehet në `%f'"
 msgid "lua options"
 msgstr "opsionet lua"
 
-#: ../src/views/darkroom.c:589
+#: ../src/views/darkroom.c:591
 #, c-format
 msgid ""
 "darktable could not load `%s', switching to lighttable now.\n"
@@ -23621,63 +23613,63 @@ msgstr ""
 "raportoni si problem\n"
 "në https://github.com/darktable-org/darktable"
 
-#: ../src/views/darkroom.c:606
+#: ../src/views/darkroom.c:608
 #, c-format
 msgctxt "darkroom"
 msgid "loading `%s' ..."
 msgstr "hap `%s' ..."
 
-#: ../src/views/darkroom.c:715 ../src/views/darkroom.c:2399
+#: ../src/views/darkroom.c:717 ../src/views/darkroom.c:2401
 msgid "gamut check"
 msgstr "kontrolli i spektrit të ngjyrave"
 
-#: ../src/views/darkroom.c:715
+#: ../src/views/darkroom.c:717
 msgid "soft proof"
 msgstr "gradimi i ngjyrave"
 
 #. fail :(
-#: ../src/views/darkroom.c:753 ../src/views/print.c:324
-msgid "no image to open !"
-msgstr "nuk ka imazh për të hapur !"
+#: ../src/views/darkroom.c:755 ../src/views/print.c:324
+msgid "no image to open!"
+msgstr "nuk ka imazh për të hapur!"
 
-#: ../src/views/darkroom.c:1292
+#: ../src/views/darkroom.c:1294
 msgid "no userdefined presets for favorite modules were found"
 msgstr "nuk gjen vlerat e paracaktuara për modulet e pëlqyera"
 
-#: ../src/views/darkroom.c:1297
+#: ../src/views/darkroom.c:1299
 #, c-format
 msgid "applied style `%s' on current image"
 msgstr "aplikoi stilin `%s' në imazhin aktual"
 
-#: ../src/views/darkroom.c:1420
+#: ../src/views/darkroom.c:1422
 msgid "no styles have been created yet"
 msgstr "akoma nuk keni krijuar stile"
 
-#: ../src/views/darkroom.c:2236
+#: ../src/views/darkroom.c:2238
 msgid "quick access to presets"
 msgstr "hapni shpejt vlerat e paracaktuara"
 
-#: ../src/views/darkroom.c:2245
+#: ../src/views/darkroom.c:2247
 msgid "quick access for applying any of your styles"
 msgstr "aplikoni shpejt stilet tuaja"
 
-#: ../src/views/darkroom.c:2251
+#: ../src/views/darkroom.c:2253
 msgid "second window"
 msgstr "dritarja e dytë"
 
-#: ../src/views/darkroom.c:2254
+#: ../src/views/darkroom.c:2256
 msgid "display a second darkroom image window"
 msgstr "shfaqni dhomën e errët në dritare tjetër"
 
-#: ../src/views/darkroom.c:2259
+#: ../src/views/darkroom.c:2261
 msgid "color assessment"
 msgstr "vlerësimi i ngjyrave"
 
-#: ../src/views/darkroom.c:2262
+#: ../src/views/darkroom.c:2264
 msgid "toggle ISO 12646 color assessment conditions"
 msgstr "vlerësoni ngjyrat në kushtet e ISO 12646"
 
-#: ../src/views/darkroom.c:2275
+#: ../src/views/darkroom.c:2277
 msgid ""
 "toggle raw over exposed indication\n"
 "right click for options"
@@ -23685,27 +23677,27 @@ msgstr ""
 "treguesi i mbiekspozimit bruto\n"
 "klikoni me të djathtën për opsionet"
 
-#: ../src/views/darkroom.c:2291
+#: ../src/views/darkroom.c:2293
 msgid "select how to mark the clipped pixels"
 msgstr "përzgjidhni si do të shenjohen pikselët e shkurtuar"
 
-#: ../src/views/darkroom.c:2293
+#: ../src/views/darkroom.c:2295
 msgid "mark with CFA color"
 msgstr "shenjoj me ngjyrë CFA"
 
-#: ../src/views/darkroom.c:2293
+#: ../src/views/darkroom.c:2295
 msgid "mark with solid color"
 msgstr "shenjoj me ngjyrë uniforme"
 
-#: ../src/views/darkroom.c:2293
+#: ../src/views/darkroom.c:2295
 msgid "false color"
 msgstr "ngjyrë false"
 
-#: ../src/views/darkroom.c:2296 ../src/views/darkroom.c:2347
+#: ../src/views/darkroom.c:2298 ../src/views/darkroom.c:2349
 msgid "color scheme"
 msgstr "skema e ngjyrave"
 
-#: ../src/views/darkroom.c:2297
+#: ../src/views/darkroom.c:2299
 msgid ""
 "select the solid color to indicate over exposure.\n"
 "will only be used if mode = mark with solid color"
@@ -23713,27 +23705,27 @@ msgstr ""
 "përzgjidhni ngjyrën që tregon mbiekspozimin.\n"
 "përdoret vetëm kur zgjidhni shenjimin me ngjyrë uniforme"
 
-#: ../src/views/darkroom.c:2300
+#: ../src/views/darkroom.c:2302
 msgctxt "solidcolor"
 msgid "red"
 msgstr "kuqe"
 
-#: ../src/views/darkroom.c:2301
+#: ../src/views/darkroom.c:2303
 msgctxt "solidcolor"
 msgid "green"
 msgstr "gjelbër"
 
-#: ../src/views/darkroom.c:2302
+#: ../src/views/darkroom.c:2304
 msgctxt "solidcolor"
 msgid "blue"
 msgstr "blu"
 
-#: ../src/views/darkroom.c:2303
+#: ../src/views/darkroom.c:2305
 msgctxt "solidcolor"
 msgid "black"
 msgstr "zezë"
 
-#: ../src/views/darkroom.c:2311
+#: ../src/views/darkroom.c:2313
 msgid ""
 "threshold of what shall be considered overexposed\n"
 "1.0 - white level\n"
@@ -23743,7 +23735,7 @@ msgstr ""
 "1.0 - niveli të bardhës\n"
 "0.0 - niveli i të zezës"
 
-#: ../src/views/darkroom.c:2325
+#: ../src/views/darkroom.c:2327
 msgid ""
 "toggle clipping indication\n"
 "right click for options"
@@ -23751,11 +23743,11 @@ msgstr ""
 "treguesi i parametrave të shkurtuar\n"
 "klikoni me të djathtën për opsionet"
 
-#: ../src/views/darkroom.c:2340
+#: ../src/views/darkroom.c:2342
 msgid "clipping preview mode"
 msgstr "parashikimi i parametrave të shkurtuar"
 
-#: ../src/views/darkroom.c:2341
+#: ../src/views/darkroom.c:2343
 msgid ""
 "select the metric you want to preview\n"
 "full gamut is the combination of all other modes"
@@ -23763,43 +23755,43 @@ msgstr ""
 "zgjidhni standardin për parashikimin\n"
 "spektri i plotë i ngjyrave ndërthur të gjitha mënyrat"
 
-#: ../src/views/darkroom.c:2343
+#: ../src/views/darkroom.c:2345
 msgid "full gamut"
 msgstr "spektri i plotë i ngjyrave"
 
-#: ../src/views/darkroom.c:2343
+#: ../src/views/darkroom.c:2345
 msgid "any RGB channel"
 msgstr "çdo kanal RGB"
 
-#: ../src/views/darkroom.c:2343
+#: ../src/views/darkroom.c:2345
 msgid "luminance only"
 msgstr "vetëm luminancën"
 
-#: ../src/views/darkroom.c:2343
+#: ../src/views/darkroom.c:2345
 msgid "saturation only"
 msgstr "vetëm saturimin"
 
-#: ../src/views/darkroom.c:2348
+#: ../src/views/darkroom.c:2350
 msgid "select colors to indicate clipping"
 msgstr "përzgjidhni ngjyrat që tregojnë parametrat e shkurtuar"
 
-#: ../src/views/darkroom.c:2350
+#: ../src/views/darkroom.c:2352
 msgid "black & white"
 msgstr "bardhë e zi"
 
-#: ../src/views/darkroom.c:2350
+#: ../src/views/darkroom.c:2352
 msgid "red & blue"
 msgstr "kuqe e blu"
 
-#: ../src/views/darkroom.c:2350
+#: ../src/views/darkroom.c:2352
 msgid "purple & green"
 msgstr "vjollcë e gjelbër"
 
-#: ../src/views/darkroom.c:2357
+#: ../src/views/darkroom.c:2359
 msgid "lower threshold"
 msgstr "pragu i poshtëm"
 
-#: ../src/views/darkroom.c:2358
+#: ../src/views/darkroom.c:2360
 msgid ""
 "clipping threshold for the black point,\n"
 "in EV, relatively to white (0 EV).\n"
@@ -23819,11 +23811,11 @@ msgstr ""
 "printimet me lustër me ngjyra tipike prodhojnë të zezën në -8.00 EV,\n"
 "printime me lustër B/Z tipike prodhojnë të zezën në -9.00 EV."
 
-#: ../src/views/darkroom.c:2374
+#: ../src/views/darkroom.c:2376
 msgid "upper threshold"
 msgstr "pragu i sipërm"
 
-#: ../src/views/darkroom.c:2376
+#: ../src/views/darkroom.c:2378
 #, no-c-format
 msgid ""
 "clipping threshold for the white point.\n"
@@ -23832,11 +23824,11 @@ msgstr ""
 "pragu i shkurtimit për pikën e bardhë.\n"
 "100% është piku i luminancës së mesme."
 
-#: ../src/views/darkroom.c:2388
+#: ../src/views/darkroom.c:2390
 msgid "softproof"
 msgstr "gradoj ngjyrat"
 
-#: ../src/views/darkroom.c:2391
+#: ../src/views/darkroom.c:2393
 msgid ""
 "toggle softproofing\n"
 "right click for profile options"
@@ -23844,7 +23836,7 @@ msgstr ""
 "përdorni bocën e ngjyrave\n"
 "klikoni me të djathtën për opsionet"
 
-#: ../src/views/darkroom.c:2402
+#: ../src/views/darkroom.c:2404
 msgid ""
 "toggle gamut checking\n"
 "right click for profile options"
@@ -23852,50 +23844,50 @@ msgstr ""
 "kontrolloni spektrin e ngjyrave\n"
 "klikoni me të djathtën për opsionet e profilit"
 
-#: ../src/views/darkroom.c:2431 ../src/views/darkroom.c:2433
-#: ../src/views/darkroom.c:2447 ../src/views/darkroom.c:2448
+#: ../src/views/darkroom.c:2433 ../src/views/darkroom.c:2435
 #: ../src/views/darkroom.c:2449 ../src/views/darkroom.c:2450
+#: ../src/views/darkroom.c:2451 ../src/views/darkroom.c:2452
 #: ../src/views/lighttable.c:1179 ../src/views/lighttable.c:1181
 msgid "profiles"
 msgstr "profilet"
 
-#: ../src/views/darkroom.c:2433 ../src/views/lighttable.c:1181
+#: ../src/views/darkroom.c:2435 ../src/views/lighttable.c:1181
 msgid "preview intent"
 msgstr "parashikimi i synuar"
 
-#: ../src/views/darkroom.c:2447 ../src/views/lighttable.c:1185
+#: ../src/views/darkroom.c:2449 ../src/views/lighttable.c:1185
 msgid "display profile"
 msgstr "profili i ekranit"
 
-#: ../src/views/darkroom.c:2448 ../src/views/lighttable.c:1188
+#: ../src/views/darkroom.c:2450 ../src/views/lighttable.c:1188
 msgid "preview display profile"
 msgstr "profili i ekranit për parashikim"
 
-#: ../src/views/darkroom.c:2450
+#: ../src/views/darkroom.c:2452
 msgid "histogram profile"
 msgstr "profili i histogramit"
 
-#: ../src/views/darkroom.c:2514 ../src/views/lighttable.c:1224
+#: ../src/views/darkroom.c:2516 ../src/views/lighttable.c:1224
 #, c-format
 msgid "display ICC profiles in %s or %s"
 msgstr "profilet ICC të ekranit në %s ose %s"
 
-#: ../src/views/darkroom.c:2517 ../src/views/lighttable.c:1227
+#: ../src/views/darkroom.c:2519 ../src/views/lighttable.c:1227
 #, c-format
 msgid "preview display ICC profiles in %s or %s"
 msgstr "profilet ICC të ekranit për parashikim në %s ose %s"
 
-#: ../src/views/darkroom.c:2520
+#: ../src/views/darkroom.c:2522
 #, c-format
 msgid "softproof ICC profiles in %s or %s"
 msgstr "profilet ICC për bocën e ngjyrave në %s ose %s"
 
-#: ../src/views/darkroom.c:2523
+#: ../src/views/darkroom.c:2525
 #, c-format
 msgid "histogram and color picker ICC profiles in %s or %s"
 msgstr "profilet ICC të histogramit dhe mbledhësit të ngjyrave në %s ose %s"
 
-#: ../src/views/darkroom.c:2559
+#: ../src/views/darkroom.c:2561
 msgid ""
 "toggle guide lines\n"
 "right click for guides options"
@@ -23904,145 +23896,145 @@ msgstr ""
 "klikoni me të djathtën për opsionet e vijave udhëzuese"
 
 #. Fullscreen preview key
-#: ../src/views/darkroom.c:2576
+#: ../src/views/darkroom.c:2578
 msgid "full preview"
 msgstr "parashikoj plotësisht"
 
 #. add an option to allow skip mouse events while other overlays are consuming mouse actions
-#: ../src/views/darkroom.c:2580
+#: ../src/views/darkroom.c:2582
 msgid "force pan & zoom with mouse"
 msgstr "detyroj panoramimin dhe zmadhimin me maus"
 
 #. Zoom shortcuts
-#: ../src/views/darkroom.c:2592
+#: ../src/views/darkroom.c:2594
 msgid "zoom close-up"
 msgstr "afroj"
 
-#: ../src/views/darkroom.c:2593
+#: ../src/views/darkroom.c:2595
 msgid "zoom fill"
 msgstr "mbush"
 
-#: ../src/views/darkroom.c:2594
+#: ../src/views/darkroom.c:2596
 msgid "zoom fit"
 msgstr "përshtat"
 
 #. zoom in/out
 #. zoom in/out/min/max
-#: ../src/views/darkroom.c:2597 ../src/views/lighttable.c:1284
+#: ../src/views/darkroom.c:2599 ../src/views/lighttable.c:1284
 msgid "zoom in"
 msgstr "zmadhoj"
 
-#: ../src/views/darkroom.c:2598 ../src/views/lighttable.c:1286
+#: ../src/views/darkroom.c:2600 ../src/views/lighttable.c:1286
 msgid "zoom out"
 msgstr "zvogëloj"
 
 #. Shortcut to skip images
-#: ../src/views/darkroom.c:2601
+#: ../src/views/darkroom.c:2603
 msgid "image forward"
 msgstr "imazhi para"
 
-#: ../src/views/darkroom.c:2602
+#: ../src/views/darkroom.c:2604
 msgid "image back"
 msgstr "imazhi prapa"
 
 #. cycle overlay colors
-#: ../src/views/darkroom.c:2605
+#: ../src/views/darkroom.c:2607
 msgid "cycle overlay colors"
 msgstr "ndërroni ngjyrat për mbishtresat"
 
 #. toggle visibility of drawn masks for current gui module
-#: ../src/views/darkroom.c:2608
+#: ../src/views/darkroom.c:2610
 msgid "show drawn masks"
 msgstr "tregoj maskat e vizatuara"
 
 #. brush size +/-
-#: ../src/views/darkroom.c:2611
+#: ../src/views/darkroom.c:2613
 msgid "increase brush size"
 msgstr "rrit përmasat e penelit"
 
-#: ../src/views/darkroom.c:2612
+#: ../src/views/darkroom.c:2614
 msgid "decrease brush size"
 msgstr "ul përmasat e penelit"
 
 #. brush hardness +/-
-#: ../src/views/darkroom.c:2615
+#: ../src/views/darkroom.c:2617
 msgid "increase brush hardness"
 msgstr "rrit fortësinë e penelit"
 
-#: ../src/views/darkroom.c:2616
+#: ../src/views/darkroom.c:2618
 msgid "decrease brush hardness"
 msgstr "ul fortësinë e penelit"
 
 #. brush opacity +/-
-#: ../src/views/darkroom.c:2619
+#: ../src/views/darkroom.c:2621
 msgid "increase brush opacity"
 msgstr "rrit tejdukshmërinë e penelit"
 
-#: ../src/views/darkroom.c:2620
+#: ../src/views/darkroom.c:2622
 msgid "decrease brush opacity"
 msgstr "ul tejdukshmërinë e penelit"
 
 #. undo/redo
-#: ../src/views/darkroom.c:2623 ../src/views/lighttable.c:1276
+#: ../src/views/darkroom.c:2625 ../src/views/lighttable.c:1276
 #: ../src/views/map.c:2115
 msgid "undo"
 msgstr "kthej"
 
-#: ../src/views/darkroom.c:2624 ../src/views/lighttable.c:1277
+#: ../src/views/darkroom.c:2626 ../src/views/lighttable.c:1277
 #: ../src/views/map.c:2116
 msgid "redo"
 msgstr "ribëj"
 
 #. change the precision for adjusting sliders with keyboard shortcuts
-#: ../src/views/darkroom.c:2627
+#: ../src/views/darkroom.c:2629
 msgid "change keyboard shortcut slider precision"
 msgstr "ndryshoni precizionin e shkarësit me shkurtoren e tastierës"
 
-#: ../src/views/darkroom.c:3808
+#: ../src/views/darkroom.c:3810
 msgid "keyboard shortcut slider precision: fine"
 msgstr "precizioni i shkarësit me shkurtoren e tastierës: fin"
 
-#: ../src/views/darkroom.c:3810
+#: ../src/views/darkroom.c:3812
 msgid "keyboard shortcut slider precision: normal"
 msgstr "precizioni i shkarësit me shkurtoren e tastierës: normal"
 
-#: ../src/views/darkroom.c:3812
+#: ../src/views/darkroom.c:3814
 msgid "keyboard shortcut slider precision: coarse"
 msgstr "precizioni i shkarësit me shkurtoren e tastierës: i trashë"
 
-#: ../src/views/darkroom.c:3828
+#: ../src/views/darkroom.c:3830
 msgid "switch to lighttable"
 msgstr "kaloj te fototeka"
 
-#: ../src/views/darkroom.c:3829 ../src/views/lighttable.c:878
+#: ../src/views/darkroom.c:3831 ../src/views/lighttable.c:878
 msgid "zoom in the image"
 msgstr "zmadhoj imazhin"
 
-#: ../src/views/darkroom.c:3830
+#: ../src/views/darkroom.c:3832
 msgid "unbounded zoom in the image"
 msgstr "zmadhim i palimituar i imazhit"
 
-#: ../src/views/darkroom.c:3831
+#: ../src/views/darkroom.c:3833
 msgid "zoom to 100% 200% and back"
 msgstr "zmadhoj në 100% 200% dhe kthehem"
 
-#: ../src/views/darkroom.c:3832 ../src/views/lighttable.c:881
+#: ../src/views/darkroom.c:3834 ../src/views/lighttable.c:881
 msgid "pan a zoomed image"
 msgstr "panoramoj imazhin e zmadhuar"
 
-#: ../src/views/darkroom.c:3834 ../src/views/lighttable.c:923
+#: ../src/views/darkroom.c:3836 ../src/views/lighttable.c:923
 msgid "[modules] expand module without closing others"
 msgstr "[modulet] shpalos modulin pa i mbyllur të tjerët"
 
-#: ../src/views/darkroom.c:3835 ../src/views/lighttable.c:924
+#: ../src/views/darkroom.c:3837 ../src/views/lighttable.c:924
 msgid "[modules] expand module and close others"
 msgstr "[modulet] shpalos modulin dhe mbyll të tjerët"
 
-#: ../src/views/darkroom.c:3837
+#: ../src/views/darkroom.c:3839
 msgid "[modules] rename module"
 msgstr "[modulet] riemërtoj modulin"
 
-#: ../src/views/darkroom.c:3839
+#: ../src/views/darkroom.c:3841
 msgid "[modules] change module position in pipe"
 msgstr "[modulet] ndryshoj pozicionin e modulit për zhvillim"
 
@@ -24182,59 +24174,59 @@ msgctxt "view"
 msgid "print"
 msgstr "printimi"
 
-#: ../src/views/slideshow.c:316
+#: ../src/views/slideshow.c:344
 msgid "end of images"
-msgstr "fundi i imazheve"
+msgstr "imazhet mbaruan"
 
-#: ../src/views/slideshow.c:332
+#: ../src/views/slideshow.c:365
 msgid "end of images. press any key to return to lighttable mode"
-msgstr "fundi i imazheve. shtypni çdo tast për t'u kthyer në fototekë"
+msgstr "imazhet mbaruan. shtypni një tast për t'u kthyer në fototekë"
 
-#: ../src/views/slideshow.c:454
+#: ../src/views/slideshow.c:495
 msgid "waiting to start slideshow"
 msgstr "pret nisjen e diafilmit"
 
-#: ../src/views/slideshow.c:569 ../src/views/slideshow.c:590
-#: ../src/views/slideshow.c:598
+#: ../src/views/slideshow.c:631 ../src/views/slideshow.c:652
+#: ../src/views/slideshow.c:660
 msgid "slideshow paused"
 msgstr "diafilmi në pauzë"
 
-#: ../src/views/slideshow.c:577 ../src/views/slideshow.c:584
+#: ../src/views/slideshow.c:639 ../src/views/slideshow.c:646
 #, c-format
 msgid "slideshow delay set to %d second"
 msgid_plural "slideshow delay set to %d seconds"
-msgstr[0] "vonesa për diafilmin është vendosur %d sekondë"
-msgstr[1] "vonesa për diafilmin është vendosur %d sekonda"
+msgstr[0] "vonesa për diafilmin u vendos %d sekondë"
+msgstr[1] "vonesa për diafilmin u vendos %d sekonda"
 
-#: ../src/views/slideshow.c:613
+#: ../src/views/slideshow.c:675
 msgid "start and stop"
 msgstr "filloj e ndaloj"
 
-#: ../src/views/slideshow.c:614
+#: ../src/views/slideshow.c:676
 msgid "exit slideshow"
 msgstr "mbyll diafilmin"
 
-#: ../src/views/slideshow.c:617
+#: ../src/views/slideshow.c:679
 msgid "slow down"
 msgstr "ngadalësoj"
 
-#: ../src/views/slideshow.c:620
+#: ../src/views/slideshow.c:682
 msgid "speed up"
 msgstr "shpejtoj"
 
-#: ../src/views/slideshow.c:624
+#: ../src/views/slideshow.c:686
 msgid "step forward"
 msgstr "bëj përpara"
 
-#: ../src/views/slideshow.c:625
+#: ../src/views/slideshow.c:687
 msgid "step back"
 msgstr "bëj prapa"
 
-#: ../src/views/slideshow.c:631
+#: ../src/views/slideshow.c:693
 msgid "go to next image"
 msgstr "shkoj te imazhi tjetër"
 
-#: ../src/views/slideshow.c:632
+#: ../src/views/slideshow.c:694
 msgid "go to previous image"
 msgstr "shkoj te imazhi pararendës"
 
@@ -24291,22 +24283,3 @@ msgstr "kaloni te dritarja klasike, e cila qëndron hapur kur e lëshoni tastin"
 #: ../src/views/view.c:1344
 msgid "mouse actions"
 msgstr "veprimet me maus"
-
-#~ msgid "demosaicing method"
-#~ msgstr "metoda e dematricimit"
-
-#~ msgid "no embedded metadata and lensfun disabled"
-#~ msgstr "nuk ka metadata të integruara dhe lensfun është çaktivizuar"
-
-#~ msgid ""
-#~ "embedded lens correction metadata is not available\n"
-#~ "and darktable is compiled without lensfun"
-#~ msgstr ""
-#~ "nuk mundësohen metadatat e integruara për korrigjimin e objektivit,\n"
-#~ "ndërsa darktable është kompiluar pa lensfun"
-
-#~ msgid "actual selection"
-#~ msgstr "përzgjedhjen aktuale"
-
-#~ msgid "allow to pan & zoom while editing masks"
-#~ msgstr "autorizoj panoramimin dhe zmadhimin gjatë përpunimit të maskave"


### PR DESCRIPTION
I noticed in darktable's dropdown language selector Albanian is maybe the only language that is not displayed in its localized form (Shqip), like Français, Deutsch. This is on a Windows system, on Ubuntu it is just in code "sq". Can it be something with regard to the actual language code "sq" instead of "sq_al" as it is now ?!

There is also some inconsistency with the other languages: some have their first letter capitalized while others are all lowercase.

Finally, there is at least one string which I underlined in red in the picture below, which cannot be translated although it is done in the darktable.pot file.

![2022-11-22_100010](https://user-images.githubusercontent.com/15838230/203274994-7f5faa34-b71d-4579-bb41-889ef81188ea.png)
