### PR TITLE
[GUI] Do not use the abbreviation for darktable

### DIFF
--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2021 darktable developers.
+    Copyright (C) 2010-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -752,7 +752,7 @@ void dt_styles_apply_style_item(dt_develop_t *dev, dt_style_item_t *style_item, 
            || module->legacy_params(module, style_item->params, labs(style_item->module_version),
                                           module->params, labs(module->version())))
         {
-          fprintf(stderr, "[dt_styles_apply_style_item] module `%s' version mismatch: history is %d, dt %d.\n",
+          fprintf(stderr, "[dt_styles_apply_style_item] module `%s' version mismatch: history is %d, darktable is %d.\n",
                   module->op, style_item->module_version, module->version());
           dt_control_log(_("module `%s' version mismatch: %d != %d"), module->op,
                          module->version(), style_item->module_version);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2021 darktable developers.
+    Copyright (C) 2009-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -2009,7 +2009,7 @@ void dt_dev_read_history_ext(dt_develop_t *dev, const int imgid, gboolean no_ima
          || hist->module->legacy_params(hist->module, module_params, labs(modversion),
                                         hist->params, labs(hist->module->version())))
       {
-        fprintf(stderr, "[dev_read_history] module `%s' version mismatch: history is %d, dt %d.\n",
+        fprintf(stderr, "[dev_read_history] module `%s' version mismatch: history is %d, darktable is %d.\n",
                 hist->module->op, modversion, hist->module->version());
 
         const char *fname = dev->image_storage.filename + strlen(dev->image_storage.filename);

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2013-2021 darktable developers.
+    Copyright (C) 2013-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -909,7 +909,7 @@ void dt_masks_read_masks_history(dt_develop_t *dev, const int imgid)
         if(fname > dev->image_storage.filename) fname++;
 
         fprintf(stderr,
-                "[_dev_read_masks_history] %s (imgid `%i'): mask version mismatch: history is %d, dt %d.\n",
+                "[_dev_read_masks_history] %s (imgid `%i'): mask version mismatch: history is %d, darktable is %d.\n",
                 fname, imgid, form->version, dt_masks_version());
         dt_control_log(_("%s: mask version mismatch: %d != %d"), fname, dt_masks_version(), form->version);
 

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1338,7 +1338,7 @@ static void _display_ca_error(struct dt_iop_module_t *self)
   else if(g->error == CACORRECT_ERROR_MATH)
      dt_iop_set_module_trouble_message(self, _("bypassed while zooming in"),
                                       _("while calculating the correction parameters the internal maths failed so module is bypassed.\n"
-                                        "you can get more info by running dt via the console."), NULL);
+                                        "you can get more info by running darktable via the console."), NULL);
   else if(g->error == CACORRECT_ERROR_LIN)
      dt_iop_set_module_trouble_message(self, _("quality"),
                                       _("internals maths found too few data points so restricted the order of the fit to linear.\n"

--- a/src/libs/export_metadata.c
+++ b/src/libs/export_metadata.c
@@ -308,7 +308,7 @@ char *dt_lib_export_metadata_configuration_dialog(char *metadata_presets, const 
   gtk_widget_set_tooltip_text(exiftag, _("export EXIF metadata"));
   gtk_box_pack_start(GTK_BOX(vbox2), exiftag, FALSE, TRUE, 0);
   GtkWidget *dtmetadata = gtk_check_button_new_with_label(_("metadata"));
-  gtk_widget_set_tooltip_text(dtmetadata, _("export dt XMP metadata (from metadata editor module)"));
+  gtk_widget_set_tooltip_text(dtmetadata, _("export darktable XMP metadata (from metadata editor module)"));
   gtk_box_pack_start(GTK_BOX(vbox2), dtmetadata, FALSE, TRUE, 0);
 
   GtkWidget *calculated;
@@ -320,8 +320,8 @@ char *dt_lib_export_metadata_configuration_dialog(char *metadata_presets, const 
     gtk_box_pack_start(GTK_BOX(box), vbox3, FALSE, TRUE, 10);
     calculated = gtk_check_button_new_with_label(_("only embedded"));
     gtk_widget_set_tooltip_text(calculated, _("per default the interface sends some (limited) metadata beside the image to remote storage.\n"
-        "to avoid this and let only image embedded dt XMP metadata, check this flag.\n"
-        "if remote storage doesn't understand dt XMP metadata, you can use calculated metadata instead"));
+        "to avoid this and let only image embedded darktable XMP metadata, check this flag.\n"
+        "if remote storage doesn't understand darktable XMP metadata, you can use calculated metadata instead"));
     gtk_box_pack_start(GTK_BOX(vbox3), calculated, FALSE, TRUE, 0);
   }
 
@@ -351,7 +351,7 @@ char *dt_lib_export_metadata_configuration_dialog(char *metadata_presets, const 
   gtk_widget_set_tooltip_text(hierarchical, _("export hierarchical tags (to Xmp.lr.Hierarchical Subject)"));
   gtk_box_pack_start(GTK_BOX(vbox2), hierarchical, FALSE, TRUE, 0);
   GtkWidget *dthistory = gtk_check_button_new_with_label(_("develop history"));
-  gtk_widget_set_tooltip_text(dthistory, _("export dt development data (recovery purpose in case of loss of database or XMP file)"));
+  gtk_widget_set_tooltip_text(dthistory, _("export darktable development data (recovery purpose in case of loss of database or XMP file)"));
   gtk_box_pack_start(GTK_BOX(vbox2), dthistory, FALSE, TRUE, 0);
 
   // specific rules

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -575,7 +575,7 @@ void gui_init(dt_lib_module_t *self)
 
   flag = gtk_check_button_new_with_label(_("metadata"));
   d->metadata_flag = flag;
-  gtk_widget_set_tooltip_text(flag, _("select dt metadata (from metadata editor module)"));
+  gtk_widget_set_tooltip_text(flag, _("select darktable metadata (from metadata editor module)"));
   ellipsize_button(flag);
   gtk_grid_attach(grid, flag, 0, line++, 3, 1);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(flag), dt_conf_get_bool("plugins/lighttable/copy_metadata/metadata"));


### PR DESCRIPTION
Although `dt` is a common abbreviation among developers and in various communications of advanced users (to save on typing), it is not an official name and should not be used in the interface to avoid confusing newbies.