### PR TITLE
Dark blue label is hardly visible on a dark background

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -226,7 +226,7 @@ Why that? Just because it's a developer choice and most classes use underscore i
 
 @define-color colorlabel_red rgb(230,0,0);
 @define-color colorlabel_green rgb(0,230,0);
-@define-color colorlabel_blue rgb(0,0,230);
+@define-color colorlabel_blue rgb(47, 133, 255);
 @define-color colorlabel_yellow rgb(255,180,0);
 @define-color colorlabel_purple rgb(230,0,230);
 


### PR DESCRIPTION
Currently the dark blue label is hardly visible:

![labels](https://user-images.githubusercontent.com/138573/203792648-0591f489-e51b-4c8c-a0ec-2d9513b04f1a.png)

I've tried to make the blue slightly brighter. After the change:
![labels_new](https://user-images.githubusercontent.com/138573/203792822-59680c93-b54a-4203-8766-ebfd0c7b5a6d.png)
