### PR TITLE
More segmentation and hlr masking fixes

### DIFF
--- a/src/iop/hlrecovery_v2.c
+++ b/src/iop/hlrecovery_v2.c
@@ -421,13 +421,13 @@ static inline size_t _raw_to_plane(const int width, const int row, const int col
 
 static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
                          const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
-                         dt_iop_highlights_data_t *data, const int vmode, float *tmpout)
+                         dt_iop_highlights_data_t *data, float *tmpout)
 {
   const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
   const uint32_t filters = piece->pipe->dsc.filters;
 
   const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
-
+  const int vmode = (fullpipe && (data->masking != DT_HIGHLIGHTS_MASK_OFF)) ? data->masking : DT_HIGHLIGHTS_MASK_OFF;
   const float clipval = fmaxf(0.1f, 0.987f * data->clip);
   const dt_aligned_pixel_t icoeffs = { piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1], piece->pipe->dsc.temperature.coeffs[2]};
   const dt_aligned_pixel_t clips = { clipval * icoeffs[0], clipval * icoeffs[1], clipval * icoeffs[2]}; 
@@ -729,7 +729,6 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
         in++;
       }
     }
-    dt_dev_pixelpipe_flush_caches(piece->pipe);
   }
 
   dt_vprint(DT_DEBUG_PERF, "[segmentation report %12s] %5.1fMpix, segments: %3i red, %3i green, %3i blue, %3i all, %4i allowed.\n",

--- a/src/iop/segmentation.h
+++ b/src/iop/segmentation.h
@@ -563,8 +563,27 @@ static gboolean _floodfill_segmentize(int yin, int xin, dt_iop_segmentation_t *s
   seg->xmax[id] = max_x;
   seg->ymin[id] = min_y;
   seg->ymax[id] = max_y;
-  if(cnt) seg->nr += 1;
-  return (cnt > 0);
+  if(cnt < 4)
+  {
+    // To avoid oversegmentizing we only use segments with a minimum size
+    // In any case we want to revert border markings too
+    for(int row = min_y-1; row <= max_y+1; row++)
+    {
+      for(int col = min_x-1; col <= max_x+1; col++)
+      {
+        size_t loc = w*row + col;
+        if(d[loc] == id)
+          d[loc] = 1;
+        else if(d[loc] == (id + DT_SEG_ID_MASK))
+          d[loc] = 0;
+      }
+    }  
+    return FALSE;
+  }
+  {
+    seg->nr += 1;
+    return TRUE;
+  }
 }
 
 // User interface


### PR DESCRIPTION
There are some things that still can be fixed/improved in the segmentation based highlights reconstruction code
for dt v4.2. I am awfully sorry to do another pr so late ...  

1. For bayer sensors segmentation we can improve the resistance to some chroma noise while averaging
   the photosite data in the 3x3 box by ensuring a 5:2:2 ratio for green:red:blue
   
2. To avoid oversegmentation in the preview pipes - that would mean missing some segment's reconstruction and
   keeping data generated by opposed means - we calculate the allowed number of segments from input/scale
   instead of roi size.
 
3. While calculating the best candidate for each segment we make sure the weight is not calculated
   from border data.

4. While doing the segmentize internals we avoid having mini-segments and also make sure the maskplane state
   changes for the tested segment are reverted (improved border check for so far untested segments)

5. Improve visual output mask of combining

6. The masking mode state is now kept in the parameter struct and is updated via commit_parameters
   from the UI mask buttons only here.
   This ensures a valid hash for the pixelpipe cache so we don't need the dirty workaround of
   clearing the cache any more.

@MStraeten please test this again :-) 