### PR TITLE
Improve OpenCL spelling consistency

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -177,7 +177,7 @@
     </type>
     <default>default</default>
     <shortdescription>darktable resources</shortdescription>
-    <longdescription>defines how much darktable may take from your system resources.\n - default: darktable takes ~50% of your systems resources and gives darktable enough to be still performant.\n - small: should be used if you are simultaneously running applications taking large parts of your systems memory or opencl/gl applications like games or hugin.\n - large: is the best option if you are mainly using darktable and want it to take most of your systems resources for performance.\n - unrestricted: should only be used for developing extremely large images as darktable will take all of your systems resources and thus might lead to swapping and unexpected performance drops. use with caution and not recommended for general use!</longdescription>
+    <longdescription>defines how much darktable may take from your system resources.\n - default: darktable takes ~50% of your systems resources and gives darktable enough to be still performant.\n - small: should be used if you are simultaneously running applications taking large parts of your systems memory or OpenCL/GL applications like games or Hugin.\n - large: is the best option if you are mainly using darktable and want it to take most of your systems resources for performance.\n - unrestricted: should only be used for developing extremely large images as darktable will take all of your systems resources and thus might lead to swapping and unexpected performance drops. use with caution and not recommended for general use!</longdescription>
   </dtconfig>
   <dtconfig prefs="processing" section="cpugpu">
     <name>ui/performance</name>

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -1116,14 +1116,14 @@ finally:
         cl->enabled = FALSE;
         dt_conf_set_bool("opencl", FALSE);
         dt_print_nts(DT_DEBUG_OPENCL, "[opencl_init] due to a slow GPU the opencl flag has been set to OFF.\n");
-        dt_control_log(_("due to a slow GPU hardware acceleration via opencl has been de-activated"));
+        dt_control_log(_("due to a slow GPU hardware acceleration using OpenCL has been deactivated"));
       }
       else if((cl->num_devs >= 2) && ((tgpumax / tgpumin) < 1.1f))
       {
         // set scheduling profile to "multiple GPUs" if more than one device has been found and they are equally fast
         dt_conf_set_string("opencl_scheduling_profile", "multiple GPUs");
         dt_print_nts(DT_DEBUG_OPENCL, "[opencl_init] set scheduling profile for multiple GPUs.\n");
-        dt_control_log(_("multiple GPUs detected - opencl scheduling profile has been set accordingly"));
+        dt_control_log(_("multiple GPUs detected - OpenCL scheduling profile has been set accordingly"));
       }
       else if((tcpu >= 2.0f * tgpumin) && (cl->num_devs == 1))
       {
@@ -1131,14 +1131,14 @@ finally:
         // We might want a better benchmark but even with the current result (underestimates real world performance) this is safe.
         dt_conf_set_string("opencl_scheduling_profile", "very fast GPU");
         dt_print_nts(DT_DEBUG_OPENCL, "[opencl_init] set scheduling profile for very fast GPU.\n");
-        dt_control_log(_("very fast GPU detected - opencl scheduling profile has been set accordingly"));
+        dt_control_log(_("very fast GPU detected - OpenCL scheduling profile has been set accordingly"));
       }
       else
       {
         // set scheduling profile to "default"
         dt_conf_set_string("opencl_scheduling_profile", "default");
         dt_print_nts(DT_DEBUG_OPENCL, "[opencl_init] set scheduling profile to default.\n");
-        dt_control_log(_("opencl scheduling profile set to default"));
+        dt_control_log(_("OpenCL scheduling profile set to default"));
       }
     }
     // apply config settings for scheduling profile: sets device priorities and pixelpipe synchronization timeout


### PR DESCRIPTION
In darktable UI in many places OpenCL is written in its proper case (the way this term was originally defined), but in some places there is also spelling in lower case. In the same PR, a couple more inaccuracies have also been corrected.