### PR TITLE
Bugfix 12993: highlights reconstruction for already demosaiced images

### DIFF
--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -280,7 +280,7 @@ gboolean dt_dev_pixelpipe_cache_get(struct dt_dev_pixelpipe_t *pipe, const uint6
            In this case we can't simply realloc or alike as there might be data in the pipeline just making use
            of that buffer so we disable it and make the cleanup will free it.
         */ 
-        dt_print(DT_DEBUG_DEV, "[pixelpipe_cache_get] [%s] HIT SIZE ERROR in `%s', line%3i, age %4i, at %p, cache size %ikB, requested %ikB\n",
+        dt_print(DT_DEBUG_DEV | DT_DEBUG_ROI, "[pixelpipe_cache_get] [%s] HIT SIZE ERROR in `%s', line%3i, age %4i, at %p, cache size %ikB, requested %ikB\n",
           dt_dev_pixelpipe_type_to_str(pipe->type), name, k, cache->used[k], cache->data[k], (int)cache->size[k] / 1024, (int)size / 1024);
         cache->hash[k] = cache->basichash[k] = -1;
         cache->used[k] = VERY_OLD_CACHE_WEIGHT;
@@ -292,7 +292,7 @@ gboolean dt_dev_pixelpipe_cache_get(struct dt_dev_pixelpipe_t *pipe, const uint6
         *dsc = &cache->dsc[k];
         ASAN_POISON_MEMORY_REGION(*data, cache->size[k]);
         ASAN_UNPOISON_MEMORY_REGION(*data, size);
-        dt_vprint(DT_DEBUG_DEV, "[pixelpipe_cache_get] %12s %s HIT %16s, line%3i, age %4i, at %p, hash%22" PRIu64 ", basic%22" PRIu64 "\n",
+        dt_print(DT_DEBUG_DEV | DT_DEBUG_ROI, "[pixelpipe_cache_get] %12s %s HIT %16s, line%3i, age %4i, at %p, hash%22" PRIu64 ", basic%22" PRIu64 "\n",
           dt_dev_pixelpipe_type_to_str(pipe->type), (cache->used[k] < 0) ? "important" : "         ", name, k, cache->used[k], cache->data[k],
           cache->hash[k], cache->basichash[k]); 
         // in case of a hit its always good to keep the cacheline as important
@@ -317,7 +317,7 @@ gboolean dt_dev_pixelpipe_cache_get(struct dt_dev_pixelpipe_t *pipe, const uint6
     {
       dt_free_align(cache->data[cline]);
       cache->allmem -= cache->size[cline];
-      dt_print(DT_DEBUG_DEV, "[pixelpipe_cache_get] %12s %s CHG %16s, line%3i, age %4i, was %s, %lu->%luMB\n",
+      dt_print(DT_DEBUG_DEV | DT_DEBUG_ROI, "[pixelpipe_cache_get] %12s %s CHG %16s, line%3i, age %4i, was %s, %lu->%luMB\n",
         dt_dev_pixelpipe_type_to_str(pipe->type), important ? "important" : "         ", name, cline, cache->used[cline], cache->modname[cline],
         cache->size[cline] / 1024lu / 1024lu, size / 1024lu / 1024lu); 
     }
@@ -335,7 +335,7 @@ gboolean dt_dev_pixelpipe_cache_get(struct dt_dev_pixelpipe_t *pipe, const uint6
   cache->dsc[cline] = **dsc;
   *dsc = &cache->dsc[cline];
 
-  dt_vprint(DT_DEBUG_DEV, "[pixelpipe_cache_get] %12s %s %s %16s, line%3i, age %4i, at %p, hash%22" PRIu64 ", basic%22" PRIu64 "\n",
+  dt_print(DT_DEBUG_DEV | DT_DEBUG_ROI, "[pixelpipe_cache_get] %12s %s %s %16s, line%3i, age %4i, at %p, hash%22" PRIu64 ", basic%22" PRIu64 "\n",
     dt_dev_pixelpipe_type_to_str(pipe->type), important ? "important" : "         ", new_cline ? "NEW" : "   ", name, cline, cache->used[cline], cache->data[cline],
     cache->hash[cline], cache->basichash[cline]); 
   cache->basichash[cline] = basichash;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1260,10 +1260,11 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
         else
         {
           dt_print(DT_DEBUG_ROI | DT_DEBUG_PERF,
-            "[Clip&Zoom roi] %13s. (none) (%4i/%4i) %4ix%4i scale=%.5f --> (%4i/%4i) %4ix%4i scale=%.5f\n",
+            "[Clip&Zoom roi] %13s (none) ROI_IN (%i/%i) %ix%i scale=%.5f, ROI_OUT (%i/%i) %ix%i scale=%.5f, PIPE %ix%i\n",
             dt_dev_pixelpipe_type_to_str(pipe->type),
             roi_in.x, roi_in.y, roi_in.width, roi_in.height, roi_in.scale,
-            roi_out->x, roi_out->y, roi_out->width, roi_out->height, roi_out->scale);
+            roi_out->x, roi_out->y, roi_out->width, roi_out->height, roi_out->scale,
+            pipe->iwidth, pipe->iheight);
           roi_in.x /= roi_out->scale;
           roi_in.y /= roi_out->scale;
           roi_in.width = pipe->iwidth;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1224,6 +1224,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
          && pipe->iheight == roi_out->height)
       {
         *output = pipe->input;
+        dt_print(DT_DEBUG_ROI | DT_DEBUG_PERF, "[full buff roi] %13s found as input data\n", dt_dev_pixelpipe_type_to_str(pipe->type));
       }
       else if(dt_dev_pixelpipe_cache_get(pipe, basichash, hash, bufsize, output, out_format, NULL, FALSE))
       {
@@ -1237,6 +1238,10 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
           const int in_y = MAX(roi_in.y, 0);
           const int cp_width = MAX(0, MIN(roi_out->width, pipe->iwidth - in_x));
           const int cp_height = MIN(roi_out->height, pipe->iheight - in_y);
+          dt_print(DT_DEBUG_ROI | DT_DEBUG_PERF,
+            "[Copy 1:1  roi] %13s input data %s\n",
+            dt_dev_pixelpipe_type_to_str(pipe->type),
+            (cp_width > 0) ? "copied" : "already available");
 
           if(cp_width > 0)
           {
@@ -1254,11 +1259,17 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
         }
         else
         {
+          dt_print(DT_DEBUG_ROI | DT_DEBUG_PERF,
+            "[Clip&Zoom roi] %13s. (none) (%4i/%4i) %4ix%4i scale=%.5f --> (%4i/%4i) %4ix%4i scale=%.5f\n",
+            dt_dev_pixelpipe_type_to_str(pipe->type),
+            roi_in.x, roi_in.y, roi_in.width, roi_in.height, roi_in.scale,
+            roi_out->x, roi_out->y, roi_out->width, roi_out->height, roi_out->scale);
           roi_in.x /= roi_out->scale;
           roi_in.y /= roi_out->scale;
           roi_in.width = pipe->iwidth;
           roi_in.height = pipe->iheight;
           roi_in.scale = 1.0f;
+ 
           dt_iop_clip_and_zoom(*output, pipe->input, roi_out, &roi_in, roi_out->width, pipe->iwidth);
 
           if(darktable.unmuted & (DT_DEBUG_PERF | DT_DEBUG_ROI)) // only check the clock in these cases for performance
@@ -1266,8 +1277,8 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
             dt_times_t zoomed;
             dt_get_times(&zoomed);
             dt_print(DT_DEBUG_ROI | DT_DEBUG_PERF,
-              "[Clip&Zoom roi] %13s. scale %.5f took %.4f secs (%.4f CPU)\n",
-              dt_dev_pixelpipe_type_to_str(pipe->type), roi_out->scale,
+              "[Zooming roi]   %13s (none) took %.4f secs (%.4f CPU)\n",
+              dt_dev_pixelpipe_type_to_str(pipe->type),
               zoomed.clock - start.clock, zoomed.user - start.user);
           }
         }

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1218,7 +1218,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
     dt_get_times(&start);
     // we're looking for the full buffer
     {
-      if(roi_out->scale == 1.0
+      if(roi_out->scale == 1.0f
          && roi_out->x == 0 && roi_out->y == 0
          && pipe->iwidth == roi_out->width
          && pipe->iheight == roi_out->height)
@@ -1260,6 +1260,16 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
           roi_in.height = pipe->iheight;
           roi_in.scale = 1.0f;
           dt_iop_clip_and_zoom(*output, pipe->input, roi_out, &roi_in, roi_out->width, pipe->iwidth);
+
+          if(darktable.unmuted & (DT_DEBUG_PERF | DT_DEBUG_ROI)) // only check the clock in these cases for performance
+          {
+            dt_times_t zoomed;
+            dt_get_times(&zoomed);
+            dt_print(DT_DEBUG_ROI | DT_DEBUG_PERF,
+              "[Clip&Zoom roi] %13s. scale %.5f took %.4f secs (%.4f CPU)\n",
+              dt_dev_pixelpipe_type_to_str(pipe->type), roi_out->scale,
+              zoomed.clock - start.clock, zoomed.user - start.user);
+          }
         }
       }
       // else found in cache.

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -1962,12 +1962,27 @@ void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const d
   *roi_in = *roi_out;
 
   dt_iop_highlights_data_t *d = (dt_iop_highlights_data_t *)piece->data;
+  const gboolean use_opposing = (d->mode == DT_IOP_HIGHLIGHTS_OPPOSED) || (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS);
+  /* When do we need the full input data so we have to expand the roi to maximum?
+     1. Certainly not if any other than opposed or segmentation based algo is used.
+  */
+  if(!use_opposing)
+    return;
+
   dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
   const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
-  const gboolean fullclipped = (g != NULL) ? (g->hlr_mask_mode == DT_HIGHLIGHTS_MASK_CLIPPED) && fullpipe : FALSE;
-  const gboolean use_opposing = (d->mode == DT_IOP_HIGHLIGHTS_OPPOSED) || (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS);
-  
-  if(fullclipped || !use_opposing)
+  const gboolean clipmask = (g != NULL) ? (g->hlr_mask_mode == DT_HIGHLIGHTS_MASK_CLIPPED) : FALSE;
+  /* 2. If we show the clipped mask that is also safe with current roi
+  */
+  if(fullpipe && clipmask)
+    return;
+
+  /* For non-demosaiced images
+       a) there is no downscaling done later after the demosaicer
+       b) we never do a segmentation postprocessing
+     So we accept the given size of roi instead of expanding to full image data.
+  */
+  if(!fullpipe && (piece->pipe->dsc.filters == 0))
     return;
 
   roi_in->x = 0;

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -2188,17 +2188,18 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   if((d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS) || (d->mode == DT_IOP_HIGHLIGHTS_OPPOSED))
     piece->process_tiling_ready = 0;
 
+  const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
   dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
   if(g)
   {
     const gboolean linear = piece->pipe->dsc.filters == 0;
-    const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
     if((g->hlr_mask_mode == DT_HIGHLIGHTS_MASK_CLIPPED) && linear && fullpipe)
       piece->process_cl_ready = FALSE;
   }
   // check for heavy computing here to give an iop cache hint
   const gboolean heavy = (((d->mode == DT_IOP_HIGHLIGHTS_LAPLACIAN) && ((d->iterations * 1<<(2+d->scales)) >= 256))
-                        || (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS));
+                        || (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS)
+                        || ((d->mode == DT_IOP_HIGHLIGHTS_OPPOSED) && fullpipe && (piece->pipe->dsc.filters == 0)));
   self->cache_next_important = heavy;
 }
 

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -60,7 +60,7 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
 
   const size_t pwidth  = dt_round_size(roi_in->width / 3, 2) + 2 * HL_BORDER;
   const size_t pheight = dt_round_size(roi_in->height / 3, 2) + 2 * HL_BORDER;
-  const size_t p_size = (size_t) dt_round_size(pwidth * pheight, 16);
+  const size_t p_size = (size_t) dt_round_size(pwidth * pheight, 64);
 
   const size_t shift_x = roi_out->x;
   const size_t shift_y = roi_out->y;
@@ -168,7 +168,7 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
         for_each_channel(c)
         {
           const float inval = fmaxf(0.0f, in[c]); 
-          if((mask_buffer[c * p_size + _raw_to_plane(pwidth, row, col)]) && (inval > clipdark[c]) && (inval < clips[c]))
+          if((inval > clipdark[c]) && (inval < clips[c]) && (mask_buffer[c * p_size + _raw_to_plane(pwidth, row, col)]))
           {
             cr_sum[c] += inval - _calc_linear_refavg(&in[0], c);
             cr_cnt[c] += 1.0f;
@@ -233,7 +233,7 @@ static float *_process_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
 
   const size_t pwidth  = dt_round_size(roi_in->width / 3, 2) + 2 * HL_BORDER;
   const size_t pheight = dt_round_size(roi_in->height / 3, 2) + 2 * HL_BORDER;
-  const size_t p_size = (size_t) dt_round_size((size_t) (pwidth + 4) * (pheight + 4), 16);
+  const size_t p_size = (size_t) dt_round_size((size_t) (pwidth + 4) * (pheight + 4), 64);
 
   int *mask_buffer = dt_calloc_align(64, 4 * p_size * sizeof(int));
   float *tmpout = dt_alloc_align_float(roi_in->width * roi_in->height);


### PR DESCRIPTION
Fixes #12993 

The reported issue is simple to explain, we expanded roi to full image data also for images that don't do a downscaling via the demosaicer later in the pipeline. This lead to all pipelines using full available image data thus to enourmous processing overhead (as while exporting).
This lead to "hanging of the system" and spikes in used memory while processing the thumbs.

Another code optimizing has been done, as we already have valid rgb channel data for every location we don't have to average surrounding locations while calculating the opposed means.   