### PR TITLE
Correct 'double-click' spelling

### DIFF
--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2021 darktable developers.
+    Copyright (C) 2011-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -62,7 +62,7 @@ typedef enum dt_signal_t
    */
   DT_SIGNAL_VIEWMANAGER_VIEW_CANNOT_CHANGE,
 
-  /** \bief This signal is raised when a thumb is doubleclicked in
+  /** \brief This signal is raised when a thumb is double-clicked in
     thumbtable (filemananger, filmstrip)
     1 : int the imageid of the thumbnail
     no returned value

--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -960,7 +960,7 @@ static void _popup_date_init(GtkDarktableRangeSelect *range)
   pop->calendar = gtk_calendar_new();
   gtk_widget_set_no_show_all(pop->calendar, TRUE);
   gtk_widget_set_tooltip_text(pop->calendar, _("simple click to select date\n"
-                                               "double click to use the date directly"));
+                                               "double-click to use the date directly"));
   g_signal_connect(G_OBJECT(pop->calendar), "day_selected", G_CALLBACK(_popup_date_changed), range);
   g_signal_connect(G_OBJECT(pop->calendar), "day_selected-double-click",
                    G_CALLBACK(_popup_date_day_selected_2click), range);
@@ -1026,7 +1026,7 @@ static void _popup_date_init(GtkDarktableRangeSelect *range)
                                                           G_TYPE_STRING, G_TYPE_STRING, G_TYPE_UINT, G_TYPE_UINT));
   pop->treeview = gtk_tree_view_new_with_model(model);
   gtk_widget_set_tooltip_text(pop->calendar, _("simple click to select date\n"
-                                               "double click to use the date directly"));
+                                               "double-click to use the date directly"));
   gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(pop->treeview), FALSE);
   g_signal_connect(G_OBJECT(pop->treeview), "row-activated", G_CALLBACK(_popup_date_tree_row_activated), range);
   g_signal_connect(G_OBJECT(gtk_tree_view_get_selection(GTK_TREE_VIEW(pop->treeview))), "changed",

--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -959,7 +959,7 @@ static void _popup_date_init(GtkDarktableRangeSelect *range)
   // the calendar
   pop->calendar = gtk_calendar_new();
   gtk_widget_set_no_show_all(pop->calendar, TRUE);
-  gtk_widget_set_tooltip_text(pop->calendar, _("simple click to select date\n"
+  gtk_widget_set_tooltip_text(pop->calendar, _("click to select date\n"
                                                "double-click to use the date directly"));
   g_signal_connect(G_OBJECT(pop->calendar), "day_selected", G_CALLBACK(_popup_date_changed), range);
   g_signal_connect(G_OBJECT(pop->calendar), "day_selected-double-click",
@@ -1025,7 +1025,7 @@ static void _popup_date_init(GtkDarktableRangeSelect *range)
   GtkTreeModel *model = GTK_TREE_MODEL(gtk_tree_store_new(DATETIME_NUM_COLS, G_TYPE_STRING, G_TYPE_UINT,
                                                           G_TYPE_STRING, G_TYPE_STRING, G_TYPE_UINT, G_TYPE_UINT));
   pop->treeview = gtk_tree_view_new_with_model(model);
-  gtk_widget_set_tooltip_text(pop->calendar, _("simple click to select date\n"
+  gtk_widget_set_tooltip_text(pop->calendar, _("click to select date\n"
                                                "double-click to use the date directly"));
   gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(pop->treeview), FALSE);
   g_signal_connect(G_OBJECT(pop->treeview), "row-activated", G_CALLBACK(_popup_date_tree_row_activated), range);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1311,12 +1311,12 @@ static gboolean _drawable_motion_notify_callback(GtkWidget *widget, GdkEventMoti
               (posx < 2.0f/9.0f && d->scope_orient == DT_LIB_HISTOGRAM_ORIENT_VERT))))
     {
       d->highlight = DT_LIB_HISTOGRAM_HIGHLIGHT_BLACK_POINT;
-      gtk_widget_set_tooltip_text(widget, _("drag to change black point,\ndoubleclick resets\nctrl+scroll to change display height"));
+      gtk_widget_set_tooltip_text(widget, _("drag to change black point,\ndouble-click resets\nctrl+scroll to change display height"));
     }
     else
     {
       d->highlight = DT_LIB_HISTOGRAM_HIGHLIGHT_EXPOSURE;
-      gtk_widget_set_tooltip_text(widget, _("drag to change exposure,\ndoubleclick resets\nctrl+scroll to change display height"));
+      gtk_widget_set_tooltip_text(widget, _("drag to change exposure,\ndouble-click resets\nctrl+scroll to change display height"));
     }
     if(prior_highlight != d->highlight)
     {

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2021 darktable developers.
+    Copyright (C) 2010-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -800,7 +800,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_tree_view_set_model(GTK_TREE_VIEW(d->tree), GTK_TREE_MODEL(treestore));
   g_object_unref(treestore);
 
-  gtk_widget_set_tooltip_text(GTK_WIDGET(d->tree), _("available styles,\ndoubleclick to apply"));
+  gtk_widget_set_tooltip_text(GTK_WIDGET(d->tree), _("available styles,\ndouble-click to apply"));
   g_signal_connect(d->tree, "row-activated", G_CALLBACK(_styles_row_activated_callback), d);
   g_signal_connect(gtk_tree_view_get_selection(GTK_TREE_VIEW(d->tree)), "changed", G_CALLBACK(_tree_selection_changed), self);
 

--- a/src/lua/preferences.c
+++ b/src/lua/preferences.c
@@ -1,6 +1,6 @@
 /*
    This file is part of darktable,
-   Copyright (C) 2013-2021 darktable developers.
+   Copyright (C) 2013-2022 darktable developers.
 
    darktable is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -679,7 +679,7 @@ static int register_pref_sub(lua_State *L)
 
       built_elt->widget = gtk_file_chooser_button_new(_("select file"), GTK_FILE_CHOOSER_ACTION_OPEN);
       gtk_file_chooser_button_set_width_chars(GTK_FILE_CHOOSER_BUTTON(built_elt->widget), 20);
-      built_elt->tooltip_reset= g_strdup_printf( _("double click to reset to `%s'"), built_elt->type_data.file_data.default_value);
+      built_elt->tooltip_reset= g_strdup_printf( _("double-click to reset to `%s'"), built_elt->type_data.file_data.default_value);
       g_object_ref_sink(G_OBJECT(built_elt->widget));
       built_elt->update_widget = update_widget_file;
       break;
@@ -707,7 +707,7 @@ static int register_pref_sub(lua_State *L)
       built_elt->widget = gtk_check_button_new();
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(built_elt->widget), dt_conf_get_bool(pref_name));
       g_object_ref_sink(G_OBJECT(built_elt->widget));
-      built_elt->tooltip_reset = g_strdup_printf(  _("double click to reset to `%s'"),
+      built_elt->tooltip_reset = g_strdup_printf(  _("double-click to reset to `%s'"),
           built_elt->type_data.bool_data.default_value ? "true" : "false");
       built_elt->update_widget = update_widget_bool;
       break;
@@ -757,7 +757,7 @@ static int register_pref_sub(lua_State *L)
           dt_conf_set_float(pref_name, built_elt->type_data.float_data.default_value);
 
         built_elt->widget = gtk_spin_button_new_with_range(min, max, step);
-        built_elt->tooltip_reset = g_strdup_printf( _("double click to reset to `%f'"),
+        built_elt->tooltip_reset = g_strdup_printf( _("double-click to reset to `%f'"),
             built_elt->type_data.float_data.default_value);
         g_object_ref_sink(G_OBJECT(built_elt->widget));
         built_elt->update_widget = update_widget_float;


### PR DESCRIPTION
In addition, a "simple click" is just a click. He is definitely not "simple", perhaps single, but this word is redundant.