### PR TITLE
small refactorings around styles and shortcuts

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -4160,6 +4160,8 @@ void dt_action_define_preset(dt_action_t *action, const gchar *name)
 
 void dt_action_rename(dt_action_t *action, const gchar *new_name)
 {
+  if(!action) return;
+
   g_free((char*)action->id);
   g_free((char*)action->label);
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1296,12 +1296,7 @@ static void _darkroom_ui_favorite_presets_popupmenu(GtkWidget *w, gpointer user_
 
 static void _darkroom_ui_apply_style_activate_callback(const gchar *name)
 {
-  dt_control_log(_("applied style `%s' on current image"), name);
-
   dt_styles_apply_to_dev(name, darktable.develop->image_storage.id);
-
-  // rebuild the accelerators (style might have changed order)
-  dt_iop_connect_accels_all();
 }
 
 gboolean _styles_tooltip_callback(GtkWidget* self, gint x, gint y, gboolean keyboard_mode,


### PR DESCRIPTION
Makes sure an action gets set up when a style is created from a file/imported as well as from an image. This stops a crash when then later renaming the style. Fixes #13004

Also perform identical action when applying a style in the darkroom via shortcut or menu (so the toast is shown and multi-instance shortcuts pick the correct instance).