### PR TITLE
[GUI] We shouldn't do vertical alignment in the tooltip text

### DIFF
--- a/src/imageio/format/webp.c
+++ b/src/imageio/format/webp.c
@@ -406,9 +406,9 @@ void gui_init(dt_imageio_module_format_t *self)
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL(gui->hint, self, NULL, N_("image hint"),
                                _("image characteristics hint for the underlying encoder.\n"
-                                 "picture : digital picture, like portrait, inner shot\n"
-                                 "photo   : outdoor photograph, with natural lighting\n"
-                                 "graphic : discrete tone image (graph, map-tile etc)"),
+                                 "picture: digital picture, like portrait, inner shot\n"
+                                 "photo: outdoor photograph, with natural lighting\n"
+                                 "graphic: discrete tone image (graph, map-tile etc)"),
                                hint, hint_combobox_changed, self,
                                N_("default"), N_("picture"), N_("photo"), N_("graphic"));
   gtk_box_pack_start(GTK_BOX(self->widget), gui->hint, TRUE, TRUE, 0);


### PR DESCRIPTION
We shouldn't do vertical alignment in the tooltip text, as this only works with monospaced fonts. It looks out of place with other fonts.