### PR TITLE
topbar: avoid scrolling issue in the add new filter menu

### DIFF
--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -1677,6 +1677,7 @@ static void _topbar_show_pref_menu(dt_lib_module_t *self, GtkWidget *bt)
 
   // the "add new rule" part
   GtkWidget *nr = dt_bauhaus_combobox_new(NULL);
+  dt_bauhaus_combobox_mute_scrolling(nr);
   dt_bauhaus_widget_set_label(nr, NULL, _("new filter"));
   _topbar_populate_rules_combo(nr, d);
   g_signal_connect(G_OBJECT(nr), "value-changed", G_CALLBACK(_topbar_rule_add), self);

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -1635,6 +1635,14 @@ static void _topbar_rule_add(GtkWidget *widget, dt_lib_module_t *self)
   const int prop = GPOINTER_TO_INT(dt_bauhaus_combobox_get_data(widget));
   if(prop < 0) return;
 
+  // verify the number of rules
+  if(d->nb_rules >= DT_COLLECTION_MAX_RULES)
+  {
+    dt_control_log(_("you can't add more rules."));
+    dt_bauhaus_combobox_set(widget, 0);
+    return;
+  }
+
   // add the new rule
   g_object_set_data(G_OBJECT(widget), "collect_id", GINT_TO_POINTER(prop));
   g_object_set_data(G_OBJECT(widget), "topbar", GINT_TO_POINTER(1));


### PR DESCRIPTION
this fixes #12956

This is a way more simple fix than previous PR #13010 . In fact bauhaus combobox already has everything required to "mute" scrolling feature :)