### PR TITLE
[GUI] Fix ctrl+scroll spelling

### DIFF
--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2021 darktable developers.
+    Copyright (C) 2010-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -3214,7 +3214,7 @@ void gui_init(dt_lib_module_t *self)
                                                   "\nshift+click to fully expand the selected tag,"
                                                   "\nright-click for other actions on selected tag,"
                                                   "\npress shift+Tab to give the focus to entry,"
-                                                  "\nctrl-scroll to resize the window"));
+                                                  "\nctrl+scroll to resize the window"));
 
   g_signal_connect(G_OBJECT(view), "button-press-event", G_CALLBACK(_click_on_view_dictionary), (gpointer)self);
   g_signal_connect(G_OBJECT(view), "key-press-event", G_CALLBACK(_dictionary_key_pressed), (gpointer)self);


### PR DESCRIPTION
In all other places we spell ctrl+scroll with a plus sign.