### PR TITLE
Bugfix: non-raw highlights reconstruction (#12993)

### DIFF
--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -1962,19 +1962,36 @@ void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const d
   *roi_in = *roi_out;
 
   dt_iop_highlights_data_t *d = (dt_iop_highlights_data_t *)piece->data;
-  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
-  const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
-  const gboolean fullclipped = (g != NULL) ? (g->hlr_mask_mode == DT_HIGHLIGHTS_MASK_CLIPPED) && fullpipe : FALSE;
   const gboolean use_opposing = (d->mode == DT_IOP_HIGHLIGHTS_OPPOSED) || (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS);
-  
-  if(fullclipped || !use_opposing)
+  const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
+  /* When do we need to expand the roi to maximum of the full input data?
+     1. Certainly not if
+       a) any other than opposed or segmentation based algo is used.
+       b) we have another pipe than fullpipe as they all have roi correctly set
+  */
+  if(!use_opposing || !fullpipe)
+    return;
+
+  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
+  const gboolean clipmask = (g != NULL) ? (g->hlr_mask_mode == DT_HIGHLIGHTS_MASK_CLIPPED) : FALSE;
+  /*
+       c) Certainly not if we show the clipped mask as that is also safe with current roi
+       d) linear raws all miss the automatic downscaler provided by the demosaicer stage, so
+          the expanding to full image data does not work as we do a downscaling very early in
+          the pixelpipe. So - no quality achieved but really bad performance.
+          FIXME For dt 4.4 we might want to implement a downscaling step for this modules in these cases.
+            For now we don't expand and keep the linear opposed simple.
+          See #12998 and #12993 for lengthy discussions
+  */
+  if((fullpipe && clipmask) || piece->pipe->dsc.filters == 0)
     return;
 
   roi_in->x = 0;
   roi_in->y = 0;
   roi_in->width = piece->buf_in.width;
   roi_in->height = piece->buf_in.height;
-}
+  roi_in->scale = 1.0f;
+ }
 
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
@@ -2036,7 +2053,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     }
     else
     {
-      _process_linear_opposed(self, piece, ivoid, ovoid, roi_in, roi_out, data, high_quality);
+      _process_linear_opposed(self, piece, ivoid, ovoid, roi_in, roi_out, data);
     }
     return;
   }
@@ -2173,17 +2190,18 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   if((d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS) || (d->mode == DT_IOP_HIGHLIGHTS_OPPOSED))
     piece->process_tiling_ready = 0;
 
+  const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
   dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
   if(g)
   {
     const gboolean linear = piece->pipe->dsc.filters == 0;
-    const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
     if((g->hlr_mask_mode == DT_HIGHLIGHTS_MASK_CLIPPED) && linear && fullpipe)
       piece->process_cl_ready = FALSE;
   }
   // check for heavy computing here to give an iop cache hint
   const gboolean heavy = (((d->mode == DT_IOP_HIGHLIGHTS_LAPLACIAN) && ((d->iterations * 1<<(2+d->scales)) >= 256))
-                        || (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS));
+                        || (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS)
+                        || ((d->mode == DT_IOP_HIGHLIGHTS_OPPOSED) && fullpipe && (piece->pipe->dsc.filters == 0)));
   self->cache_next_important = heavy;
 }
 

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -1965,27 +1965,28 @@ void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const d
   const gboolean use_opposing = (d->mode == DT_IOP_HIGHLIGHTS_OPPOSED) || (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS);
   const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
   /* When do we need to expand the roi to maximum of the full input data?
-     1. Certainly not if
-       a) any other than opposed or segmentation based algo is used.
-       b) we have another pipe than fullpipe as they all have roi correctly set
-  */
-  if(!use_opposing || !fullpipe)
+     1. Certainly not if any other than opposed or segmentation based algos is used.
+   */
+  if(!use_opposing)
     return;
 
   dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
   const gboolean clipmask = (g != NULL) ? (g->hlr_mask_mode == DT_HIGHLIGHTS_MASK_CLIPPED) : FALSE;
   /*
-       c) Certainly not if we show the clipped mask as that is also safe with current roi
-       d) linear raws all miss the automatic downscaler provided by the demosaicer stage, so
-          the expanding to full image data does not work as we do a downscaling very early in
-          the pixelpipe. So - no quality achieved but really bad performance.
-          FIXME For dt 4.4 we might want to implement a downscaling step for this modules in these cases.
-            For now we don't expand and keep the linear opposed simple.
+     2. Certainly not if we show the clipped mask as that is also safe with current roi
+     3. Certainly not as linear raws all miss the automatic downscaler provided by the demosaicer stage, so
+        the expanding to full image data does not work as we do a downscaling very early in
+        the pixelpipe. So - no quality achieved but really bad performance.
+        FIXME For dt 4.4 we might want to implement a downscaling step for this modules in these cases.
+          For now we don't expand and keep the linear opposed simple.
           See #12998 and #12993 for lengthy discussions
   */
-  if((fullpipe && clipmask) || piece->pipe->dsc.filters == 0)
+  if((fullpipe && clipmask) || (piece->pipe->dsc.filters == 0))
     return;
 
+  /* We require the correct expansion with a defined scale for all pixelpipes for proper
+     aligning and scaling in the demosiacer
+  */ 
   roi_in->x = 0;
   roi_in->y = 0;
   roi_in->width = piece->buf_in.width;

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -38,28 +38,20 @@
    Again the algorithm has been developed in collaboration by @garagecoder and @Iain from gmic team and @jenshannoschwalm from dt.
 */
 
-static inline float _calc_linear_refavg(const float *in, const dt_iop_roi_t *const roi, const int color)
+static inline float _calc_linear_refavg(const float *in, const int color)
 {
-  dt_aligned_pixel_t mean = { 0.0f, 0.0f, 0.0f };
-  for(int dy = -1; dy < 2; dy++)
-  {
-    for(int dx = -1; dx < 2; dx++)
-    {
-      for_each_channel(c)
-        mean[c] += fmaxf(0.0f, in[roi->width * 4 * dy + 4 * dx + c]);
-    }
-  }
-  for_each_channel(c)
-    mean[c] = powf(mean[c] / 9.0f, 1.0f / HL_POWERF);
+  const dt_aligned_pixel_t ins = { powf(fmaxf(0.0f, in[0]), 1.0f / HL_POWERF),
+                                   powf(fmaxf(0.0f, in[1]), 1.0f / HL_POWERF),
+                                   powf(fmaxf(0.0f, in[2]), 1.0f / HL_POWERF), 0.0f };
+  const dt_aligned_pixel_t opp = { 0.5f*(ins[1]+ins[2]), 0.5f*(ins[0]+ins[2]), 0.5f*(ins[0]+ins[1]), 0.0f};
 
-  const dt_aligned_pixel_t croot_refavg = { 0.5f * (mean[1] + mean[2]), 0.5f * (mean[0] + mean[2]), 0.5f * (mean[0] + mean[1])};
-  return powf(croot_refavg[color], HL_POWERF);
+  return powf(opp[color], HL_POWERF);
 }
 
 // A slightly modified version for sraws
 static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
                          const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
-                         dt_iop_highlights_data_t *data, const gboolean quality)
+                         dt_iop_highlights_data_t *data)
 {
   const float clipval = 0.987f * data->clip;
   const dt_aligned_pixel_t icoeffs = { piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1], piece->pipe->dsc.temperature.coeffs[2]};
@@ -68,15 +60,10 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
 
   const size_t pwidth  = dt_round_size(roi_in->width / 3, 2) + 2 * HL_BORDER;
   const size_t pheight = dt_round_size(roi_in->height / 3, 2) + 2 * HL_BORDER;
-  const size_t p_size = (size_t) dt_round_size(pwidth * pheight, 16);
+  const size_t p_size = (size_t) dt_round_size(pwidth * pheight, 64);
 
-  const size_t shift_x = roi_out->x;
-  const size_t shift_y = roi_out->y;
-
-  const size_t o_row_max = MIN(roi_out->height, roi_in->height - shift_y);
-  const size_t o_col_max = MIN(roi_out->width, roi_in->width - shift_x);
-  const size_t o_width = roi_out->width;
   const size_t i_width = roi_in->width;
+  const size_t i_height = roi_in->height;
 
   dt_aligned_pixel_t chrominance = {0.0f, 0.0f, 0.0f, 0.0f};
   gboolean valid_chrominance = FALSE;
@@ -96,14 +83,14 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(ovoid, ivoid) \
-  dt_omp_sharedconst(o_row_max, o_col_max, o_width, i_width, shift_x, shift_y) \
+  dt_omp_sharedconst(i_width, i_height) \
   schedule(static)
 #endif
-    for(size_t row = 0; row < o_row_max; row++)
+    for(size_t row = 0; row < i_height; row++)
     {
-      float *out = (float *)ovoid + o_width * row * 4;
-      float *in = (float *)ivoid + 4 * (i_width * (row + shift_y) + shift_x);
-      for(size_t col = 0; col < o_col_max; col++)
+      float *out = (float *)ovoid + i_width * row * 4;
+      float *in = (float *)ivoid + 4 * i_width * row;
+      for(size_t col = 0; col < i_width; col++)
       {
         for_each_channel(c)
           out[c] = fmaxf(0.0f, in[c]);
@@ -119,10 +106,10 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
 #pragma omp parallel for default(none) \
   reduction( + : anyclipped) \
   dt_omp_firstprivate(clips, ivoid, tmpout, roi_in, mask_buffer) \
-  dt_omp_sharedconst(p_size, pwidth, pheight, i_width) \
+  dt_omp_sharedconst(p_size, pwidth, pheight, i_width, i_height) \
   schedule(static)
 #endif
-  for(size_t row = 0; row < roi_in->height; row++)
+  for(size_t row = 0; row < i_height; row++)
   {
     float *tmp = tmpout + i_width * row * 4;
     float *in = (float *)ivoid + i_width * row * 4;
@@ -131,13 +118,13 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
       for_each_channel(c)
         tmp[c] = fmaxf(0.0f, in[c]);
 
-      if((col > 0) && (col < i_width - 1) && (row > 0) && (row < roi_in->height - 1))
+      if((col > 0) && (col < i_width - 1) && (row > 0) && (row < i_height - 1))
       {
         for_each_channel(c)
         {
           if(in[c] >= clips[c])
           {
-            tmp[c] = _calc_linear_refavg(&in[0], roi_in, c);
+            tmp[c] = _calc_linear_refavg(&in[0], c);
             mask_buffer[c * p_size + _raw_to_plane(pwidth, row, col)] |= 1;
             anyclipped += 1;
           }
@@ -148,7 +135,7 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
     }
   }
 
-  if(!valid_chrominance && (anyclipped > 5) && quality)
+  if(!valid_chrominance && (anyclipped > 5))
   {
     for(size_t i = 0; i < 3; i++)
     {
@@ -165,10 +152,10 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(ivoid, roi_in, clips, clipdark, mask_buffer) \
   reduction(+ : cr_sum, cr_cnt) \
-  dt_omp_sharedconst(p_size, pwidth, i_width) \
+  dt_omp_sharedconst(p_size, pwidth, i_width, i_height) \
   schedule(static)
 #endif
-    for(size_t row = 1; row < roi_in->height-1; row++)
+    for(size_t row = 1; row < i_height-1; row++)
     {
       float *in  = (float *)ivoid + i_width * row * 4 + 4;
       for(size_t col = 1; col < i_width - 1; col++)
@@ -176,9 +163,9 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
         for_each_channel(c)
         {
           const float inval = fmaxf(0.0f, in[c]); 
-          if((mask_buffer[c * p_size + _raw_to_plane(pwidth, row, col)]) && (inval > clipdark[c]) && (inval < clips[c]))
+          if((inval > clipdark[c]) && (inval < clips[c]) && (mask_buffer[c * p_size + _raw_to_plane(pwidth, row, col)]))
           {
-            cr_sum[c] += inval - _calc_linear_refavg(&in[0], roi_in, c);
+            cr_sum[c] += inval - _calc_linear_refavg(&in[0], c);
             cr_cnt[c] += 1.0f;
           }
         }
@@ -202,15 +189,15 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(ovoid, ivoid, tmpout, chrominance, clips) \
-  dt_omp_sharedconst(o_row_max, o_col_max, o_width, i_width, shift_x, shift_y) \
+  dt_omp_sharedconst(i_width, i_height) \
   schedule(static)
 #endif
-  for(size_t row = 0; row < o_row_max; row++)
+  for(size_t row = 0; row < i_height; row++)
   {
-    float *out = (float *)ovoid + o_width * row * 4;
-    float *tmp = tmpout + 4 * (i_width * (row + shift_y) + shift_x);
-    float *in = (float *)ivoid + 4 * (i_width * (row + shift_y) + shift_x);
-    for(size_t col = 0; col < o_col_max; col++)
+    float *out = (float *)ovoid + i_width * row * 4;
+    float *tmp = tmpout + 4 * i_width * row;
+    float *in = (float *)ivoid + 4 * i_width * row;
+    for(size_t col = 0; col < i_width; col++)
     {
       for_each_channel(c)
       {
@@ -241,7 +228,7 @@ static float *_process_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
 
   const size_t pwidth  = dt_round_size(roi_in->width / 3, 2) + 2 * HL_BORDER;
   const size_t pheight = dt_round_size(roi_in->height / 3, 2) + 2 * HL_BORDER;
-  const size_t p_size = (size_t) dt_round_size((size_t) (pwidth + 4) * (pheight + 4), 16);
+  const size_t p_size = (size_t) dt_round_size((size_t) (pwidth + 4) * (pheight + 4), 64);
 
   int *mask_buffer = dt_calloc_align(64, 4 * p_size * sizeof(int));
   float *tmpout = dt_alloc_align_float(roi_in->width * roi_in->height);

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -175,7 +175,8 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
     for_each_channel(c)
       chrominance[c] = cr_sum[c] / fmaxf(1.0f, cr_cnt[c]);    
 
-    if(g && piece->pipe->type & DT_DEV_PIXELPIPE_FULL)
+    if(g && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL)
+         && ((int)(roi_out->width / roi_out->scale) == piece->buf_in.width))
     {
       for_each_channel(c)
         g->chroma_correction[c] = chrominance[c];


### PR DESCRIPTION
Fixes #12993

See the lengthy discussion in #12998 what was wrong and what needed to be fixed.

A summary of what was wrong: (non-raws are all images with no demosaicer following)

1. non-raws of course don't have the scaling applied by the demosaicer module so we can't set roi_in scale to 1.0 here
2. so if i expand roi_in to full image data in hlr reconstruction for those images we don't take image data from the pixelpipe input data for processing but take image data and crop & scale to what we seem to need.
3. That step (2) is a) bad for quality b) is done at a part of the pipeline without OpenCL - so very slow - c) takes an extra cacheline without good reason so using more memory
4. we want a scale of 1.0f here to avoid issues with buffer sizes later in the pipeline
5. The opposed algorithm for non-raws is very simple now, will do the full roi aware code for 4.4 likely also including a scaling step in this module.

Replaces #12998 as that pr was not readable any more :-)

@TurboGit and @jorismak this one is better after understanding the issue. This one if for 4.2