### PR TITLE
[GUI] Improve the consistency of mentions of the ctrl+scroll action

### DIFF
--- a/src/libs/map_locations.c
+++ b/src/libs/map_locations.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2021 darktable developers.
+    Copyright (C) 2012-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -969,7 +969,7 @@ void gui_init(dt_lib_module_t *self)
                                 "\n - to remove a group of locations clear its name"
                                 "\n - press enter to validate the new name, escape to cancel the edit"
                                 "\nright-click for other actions: delete location and go to collection,"
-                                "\nctrl-wheel scroll to resize the window"));
+                                "\nctrl+scroll to resize the window"));
 
   // buttons
   GtkBox *hbox = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2021 darktable developers.
+    Copyright (C) 2010-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -778,7 +778,7 @@ void gui_init(dt_lib_module_t *self)
     gtk_container_add(GTK_CONTAINER(labelev), d->label[i]);
     gtk_grid_attach(grid, labelev, 0, i, 1, 1);
     gtk_widget_set_tooltip_text(GTK_WIDGET(d->label[i]),
-              _("metadata text. ctrl-wheel scroll to resize the text box"
+              _("metadata text. ctrl+scroll to resize the text box"
               "\n ctrl-enter inserts a new line (caution, may not be compatible with standard metadata)."
               "\nif <leave unchanged> selected images have different metadata."
               "\nin that case, right-click gives the possibility to choose one of them."

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -3098,7 +3098,7 @@ void gui_init(dt_lib_module_t *self)
                                                   "\npress Delete or double-click to detach"
                                                   "\nright-click for other actions on attached tag,"
                                                   "\npress Tab to give the focus to entry,"
-                                                  "\nctrl-wheel scroll to resize the window"));
+                                                  "\nctrl+scroll to resize the window"));
   g_signal_connect(G_OBJECT(view), "button-press-event", G_CALLBACK(_click_on_view_attached), (gpointer)self);
   g_signal_connect(G_OBJECT(view), "key-press-event", G_CALLBACK(_attached_key_pressed), (gpointer)self);
   g_signal_connect(gtk_tree_view_get_selection(view), "changed", G_CALLBACK(_tree_selection_changed), self);


### PR DESCRIPTION
In three places it is mentioned "wheel scroll" instead of just "scroll", while in most places it is not.