### PR TITLE
[GUI] Fix incorrect naming of the slider in the vignetting module

### DIFF
--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2021 darktable developers.
+    Copyright (C) 2010-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -100,8 +101,8 @@ typedef struct dt_iop_vignette_params3_t
 
 typedef struct dt_iop_vignette_params_t
 {
-  float scale;               // $MIN: 0.0 $MAX: 200.0 $DEFAULT: 80.0 Inner radius, percent of largest image dimension
-  float falloff_scale;       // $MIN: 0.0 $MAX: 200.0 $DEFAULT: 50.0 $DESCRIPTION: "fall-off strength" 0 - 100 Radius for falloff -- outer radius = inner radius + falloff_scale
+  float scale;               // $MIN: 0.0 $MAX: 200.0 $DEFAULT: 80.0 $DESCRIPTION: "fall-off start" Inner radius, percent of largest image dimension
+  float falloff_scale;       // $MIN: 0.0 $MAX: 200.0 $DEFAULT: 50.0 $DESCRIPTION: "fall-off radius" 0 - 100 Radius for falloff -- outer radius = inner radius + falloff_scale
   float brightness;          // $MIN: -1.0 $MAX: 1.0 $DEFAULT: -0.5 -1 - 1 Strength of brightness reduction
   float saturation;          // $MIN: -1.0 $MAX: 1.0 $DEFAULT: -0.5 -1 - 1 Strength of saturation reduction
   dt_iop_vector_2d_t center; // Center of vignette


### PR DESCRIPTION
What is the problem? The problem is that the label for the slider `fall-off strength` describes something that is ___the exact opposite of what the code actually does___.

When we say that the slider controls the strength of something, the minimum value of the slider (zero) is obviously the weakest strength, and the maximum value of the slider is the strongest strength.

What do we really have? The maximum value of `fall-off strength` is actually the _weakest_ fall-off. The minimum strength (zero) is actually the _strongest_, it is a sharp drop.

Essentially, these sliders control where the start and end of fall-off will be. So it seems logical to rename "fall-off strength" to `fall-off end`. This will immediately show the user that this slider controls the end of the fall-off area (what should "strength" mean? strength of what action?). Also more clear will be the name `fall-off start` instead of abstract (and unclear without a tooltip) "scale" (well, scale of WHAT?). Additionally, these two names will become uniform and it will be easier for the user to instantly perceive them as controlling the same feature.

