### PR TITLE
Avoid simd specific sqf() function in highlights reconstruction

### DIFF
--- a/src/common/distance_transform.h
+++ b/src/common/distance_transform.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2021 darktable developers.
+    Copyright (C) 2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -67,11 +67,11 @@ static void _image_distance_transform(const float *f, float *z, float *d, int *v
   z[1] = DT_DISTANCE_TRANSFORM_MAX;
   for(int q = 1; q <= n-1; q++)
   {
-    float s = (f[q] + sqf((float)q)) - (f[v[k]] + sqf((float)v[k]));
+    float s = (f[q] + sqrf((float)q)) - (f[v[k]] + sqrf((float)v[k]));
     while(s <= z[k] * (float)(2*q - 2*v[k]))
     {
       k--;
-      s = (f[q] + sqf((float)q)) - (f[v[k]] + sqf((float)v[k]));
+      s = (f[q] + sqrf((float)q)) - (f[v[k]] + sqrf((float)v[k]));
     }
     s /= (float)(2*q - 2*v[k]);
     k++;
@@ -85,7 +85,7 @@ static void _image_distance_transform(const float *f, float *z, float *d, int *v
   {
     while(z[k+1] < (float)q)
       k++;
-    d[q] = sqf((float)(q-v[k])) + f[v[k]];
+    d[q] = sqrf((float)(q-v[k])) + f[v[k]];
   }
 }
 

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -77,6 +77,12 @@ static inline gboolean feqf(const float v1, const float v2, const float eps)
   return (fabsf(v1 - v2) < eps);
 }
 
+// We don't want to use the SIMD version sqf() in cases we might access unaligned memory
+static inline float sqrf(float a)
+{
+  return a * a;
+}
+
 // Kahan summation algorithm
 #ifdef _OPENMP
 #pragma omp declare simd aligned(c)

--- a/src/common/printing.c
+++ b/src/common/printing.c
@@ -53,11 +53,6 @@ void dt_printing_clear_boxes(dt_images_box *imgs)
   imgs->imgid_to_load = -1;
 }
 
-static inline float sqrf(float a)
-{
-  return a * a;
-}
-
 int32_t dt_printing_get_image_box(const dt_images_box *imgs, const int x, const int y)
 {
   int box = -1;

--- a/src/common/printing.h
+++ b/src/common/printing.h
@@ -23,7 +23,7 @@
 #include "common/pdf.h"
 #include "common/cups_print.h"
 #include "common/image.h"
-
+#include "common/math.h"
 
 #define MAX_IMAGE_PER_PAGE 20
 

--- a/src/develop/masks/detail.c
+++ b/src/develop/masks/detail.c
@@ -84,12 +84,6 @@
   hanno@schwalm-bremen.de 21/04/29
 */
 
-// We don't want to use the SIMD version as we might access unaligned memory
-static inline float _sqrf(float a)
-{
-  return a * a;
-}
-
 void dt_masks_extend_border(float *const mask, const int width, const int height, const int border)
 {
   if(border <= 0) return;
@@ -129,16 +123,16 @@ void dt_masks_extend_border(float *const mask, const int width, const int height
 void _masks_blur_5x5_coeff(float *c, const float sigma)
 {
   float kernel[5][5];
-  const float temp = -2.0f * _sqrf(sigma);
-  const float range = _sqrf(3.0f * 0.84f);
+  const float temp = -2.0f * sqrf(sigma);
+  const float range = sqrf(3.0f * 0.84f);
   float sum = 0.0f;
   for(int k = -2; k <= 2; k++)
   {
     for(int j = -2; j <= 2; j++)
     {
-      if((_sqrf(k) + _sqrf(j)) <= range)
+      if((sqrf(k) + sqrf(j)) <= range)
       {
-        kernel[k + 2][j + 2] = expf((_sqrf(k) + _sqrf(j)) / temp);
+        kernel[k + 2][j + 2] = expf((sqrf(k) + sqrf(j)) / temp);
         sum += kernel[k + 2][j + 2];
       }
       else
@@ -169,16 +163,16 @@ void _masks_blur_5x5_coeff(float *c, const float sigma)
 void dt_masks_blur_9x9_coeff(float *c, const float sigma)
 {
   float kernel[9][9];
-  const float temp = -2.0f * _sqrf(sigma);
-  const float range = _sqrf(3.0f * 1.5f);
+  const float temp = -2.0f * sqrf(sigma);
+  const float range = sqrf(3.0f * 1.5f);
   float sum = 0.0f;
   for(int k = -4; k <= 4; k++)
   {
     for(int j = -4; j <= 4; j++)
     {
-      if((_sqrf(k) + _sqrf(j)) <= range)
+      if((sqrf(k) + sqrf(j)) <= range)
       {
-        kernel[k + 4][j + 4] = expf((_sqrf(k) + _sqrf(j)) / temp);
+        kernel[k + 4][j + 4] = expf((sqrf(k) + sqrf(j)) / temp);
         sum += kernel[k + 4][j + 4];
       }
       else
@@ -252,16 +246,16 @@ void dt_masks_blur_9x9(float *const restrict src, float *const restrict out, con
 void _masks_blur_13x13_coeff(float *c, const float sigma)
 {
   float kernel[13][13];
-  const float temp = -2.0f * _sqrf(sigma);
-  const float range = _sqrf(3.0f * 2.0f);
+  const float temp = -2.0f * sqrf(sigma);
+  const float range = sqrf(3.0f * 2.0f);
   float sum = 0.0f;
   for(int k = -6; k <= 6; k++)
   {
     for(int j = -6; j <= 6; j++)
     {
-      if((_sqrf(k) + _sqrf(j)) <= range)
+      if((sqrf(k) + sqrf(j)) <= range)
       {
-        kernel[k + 6][j + 6] = expf((_sqrf(k) + _sqrf(j)) / temp);
+        kernel[k + 6][j + 6] = expf((sqrf(k) + sqrf(j)) / temp);
         sum += kernel[k + 6][j + 6];
       }
       else
@@ -431,7 +425,7 @@ void dt_masks_calc_rawdetail_mask(float *const restrict src, float *const restri
       const float gy = 47.0f * (tmp[idx-width-1] - tmp[idx+width-1])
                     + 162.0f * (tmp[idx-width]   - tmp[idx+width])
                      + 47.0f * (tmp[idx-width+1] - tmp[idx+width+1]);
-      const float gradient_magnitude = sqrtf(_sqrf(gx / 256.0f) + _sqrf(gy / 256.0f));
+      const float gradient_magnitude = sqrtf(sqrf(gx / 256.0f) + sqrf(gy / 256.0f));
       mask[idx] = scale * gradient_magnitude;
     }
   }

--- a/src/iop/hlrecovery_v2.c
+++ b/src/iop/hlrecovery_v2.c
@@ -93,12 +93,6 @@ The chosen segmentation algorithm works like this:
 #include "iop/segmentation.h"
 #include "common/distance_transform.h"
 
-// We don't want to use the SIMD version as we might access unaligned memory
-static inline float sqrf(float a)
-{
-  return a * a;
-}
-
 static inline float _local_std_deviation(const float *p, const int w)
 {
   const int w2 = 2*w;

--- a/src/iop/hlrecovery_v2.c
+++ b/src/iop/hlrecovery_v2.c
@@ -93,6 +93,12 @@ The chosen segmentation algorithm works like this:
 #include "iop/segmentation.h"
 #include "common/distance_transform.h"
 
+// We don't want to use the SIMD version as we might access unaligned memory
+static inline float sqrf(float a)
+{
+  return a * a;
+}
+
 static inline float _local_std_deviation(const float *p, const int w)
 {
   const int w2 = 2*w;
@@ -103,11 +109,11 @@ static inline float _local_std_deviation(const float *p, const int w)
        p[w-2]   + p[w-1]   + p[w]   + p[w+1]   + p[w+2] +
        p[w2-2]  + p[w2-1]  + p[w2]  + p[w2+1]  + p[w2+2]);
   return sqrtf(0.04f *
-      (sqf(p[-w2-2]-av) + sqf(p[-w2-1]-av) + sqf(p[-w2]-av) + sqf(p[-w2+1]-av) + sqf(p[-w2+2]-av) +
-       sqf(p[-w-2]-av)  + sqf(p[-w-1]-av)  + sqf(p[-w]-av)  + sqf(p[-w+1]-av)  + sqf(p[-w+2]-av) +
-       sqf(p[-2]-av)    + sqf(p[-1]-av)    + sqf(p[0]-av)   + sqf(p[1]-av)     + sqf(p[2]-av) +
-       sqf(p[w-2]-av)   + sqf(p[w-1]-av)   + sqf(p[w]-av)   + sqf(p[w+1]-av)   + sqf(p[w+2]-av) +
-       sqf(p[w2-2]-av)  + sqf(p[w2-1]-av)  + sqf(p[w2]-av)  + sqf(p[w2+1]-av)  + sqf(p[w2+2]-av)));
+      (sqrf(p[-w2-2]-av) + sqrf(p[-w2-1]-av) + sqrf(p[-w2]-av) + sqrf(p[-w2+1]-av) + sqrf(p[-w2+2]-av) +
+       sqrf(p[-w-2]-av)  + sqrf(p[-w-1]-av)  + sqrf(p[-w]-av)  + sqrf(p[-w+1]-av)  + sqrf(p[-w+2]-av) +
+       sqrf(p[-2]-av)    + sqrf(p[-1]-av)    + sqrf(p[0]-av)   + sqrf(p[1]-av)     + sqrf(p[2]-av) +
+       sqrf(p[w-2]-av)   + sqrf(p[w-1]-av)   + sqrf(p[w]-av)   + sqrf(p[w+1]-av)   + sqrf(p[w+2]-av) +
+       sqrf(p[w2-2]-av)  + sqrf(p[w2-1]-av)  + sqrf(p[w2]-av)  + sqrf(p[w2+1]-av)  + sqrf(p[w2+2]-av)));
 }
 
 static float _calc_weight(const float *s, const size_t loc, const int w, const float clipval)
@@ -236,7 +242,7 @@ static void _initial_gradients(const size_t w, const size_t height, float *lumin
         const float gy = 47.0f * (luminance[v-w-1] - luminance[v+w-1])
                       + 162.0f * (luminance[v-w]   - luminance[v+w])
                        + 47.0f * (luminance[v-w+1] - luminance[v+w+1]);
-        g = 4.0f * sqrtf(sqf(gx / 256.0f) + sqf(gy / 256.0f));
+        g = 4.0f * sqrtf(sqrf(gx / 256.0f) + sqrf(gy / 256.0f));
       }
       gradient[v] = g;
     }
@@ -439,7 +445,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
 
   const int recovery_closing[NUM_RECOVERY_MODES] = { 0, 0, 0, 2, 2, 0, 2};
   const int seg_border = recovery_closing[recovery_mode];
-  const int segmentation_limit = (piece->pipe->iwidth * piece->pipe->iheight) * sqf(piece->pipe->iscale) / 4000; // 250 segments per mpix
+  const int segmentation_limit = (piece->pipe->iwidth * piece->pipe->iheight) * sqrf(piece->pipe->iscale) / 4000; // 250 segments per mpix
 
   const size_t pwidth  = dt_round_size(roi_in->width / 3, 2) + 2 * HL_BORDER;
   const size_t pheight = dt_round_size(roi_in->height / 3, 2) + 2 * HL_BORDER;

--- a/src/iop/rcd_demosaic.c
+++ b/src/iop/rcd_demosaic.c
@@ -101,12 +101,6 @@ static INLINE float safe_in(float a, float scale)
   return fmaxf(0.0f, a) * scale;
 }
 
-// We don't want to use the SIMD version as we might access unaligned memory
-static INLINE float sqrf(float a)
-{
-  return a * a;
-}
-
 /** This is basically ppg adopted to only write data to RCD_MARGIN */
 static void rcd_ppg_border(float *const out, const float *const in, const int width, const int height, const uint32_t filters, const int margin)
 {


### PR DESCRIPTION
The sqf() function used here is only valid for simd code with known alignment. Can't do that here in all cases so could give wrong results or access to undefined locations.

A safe fix for 4.2 

We use this elsewhere or alike macros, should really be done in maths.h ?
 