### PR TITLE
fix crash in qap moving from multi to single module

### DIFF
--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -335,7 +335,7 @@ static void _basics_free_item(dt_lib_modulegroups_basic_item_t *item)
 
 static void _basics_remove_widget(dt_lib_modulegroups_basic_item_t *item)
 {
-  if(item->widget && item->widget_type != WIDGET_TYPE_ACTIVATE_BTN)
+  if(item->widget && item->widget_type != WIDGET_TYPE_ACTIVATE_BTN && item->temp_widget)
   {
     g_signal_handlers_disconnect_by_data(item->widget, item);
     g_signal_handlers_disconnect_by_data(item->old_parent, item);
@@ -603,6 +603,7 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
     gtk_widget_add_events(item->temp_widget, GDK_VISIBILITY_NOTIFY_MASK);
     g_signal_connect(item->temp_widget, "show", G_CALLBACK(_sync_visibility), item);
     g_signal_connect(item->temp_widget, "hide", G_CALLBACK(_sync_visibility), item);
+    g_signal_connect(G_OBJECT(item->temp_widget), "destroy", G_CALLBACK(gtk_widget_destroyed), &item->temp_widget);
 
     _sync_visibility(item->widget, item);
   }


### PR DESCRIPTION
fixes #13046

Quite a bit has changed here after 4.0.1 (#12404) which also removed the ineffective attempt (as per #13046 and also because multi-instances can be added using shortcuts) to disable qap for a module when it has multiple instances. This fixes a crash when the module instance that was shadowed in the qap gets deleted when switching to an image that has fewer instances of a module. It is still possible to cause crashes when removing instances using shortcuts (i.e. without leaving qap), but presumably they are less common and can be addressed in 4.4.

@TurboGit I think this is a low risk and correct partial fix; it skips trying to put back a shadowed widget into its original place when its temporary placeholder there has already been destroyed (meaning the whole module probably doesn't exist anymore). It then instead gets destroyed together with the qap module it was a part of, so I don't think this would leak memory. It fixes an easy way to trigger a crash for me by switching images, but I can't guarantee that it fixes _all_ "obvious" crashes (there are quite a few preferences that could influence which instance would be shown in the qap and who knows what kind of unexpected interactions they could have). However it definitely doesn't prevent _all_ possible crashes that could be triggered by using shortcuts to manipulate instances in the background while the qap remains open.

I would suggest including this in 4.2 and opening a more specific version of #13046 for shortcut triggered crashes.