### PR TITLE
catch some more qap crashes with multi-instance

### DIFF
--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -376,11 +376,11 @@ static void _basics_remove_widget(dt_lib_modulegroups_basic_item_t *item)
     }
   }
   // cleanup item
-  if(item->box) gtk_widget_destroy(item->box);
-  if(item->temp_widget) gtk_widget_destroy(item->temp_widget);
-  item->box = NULL;
-  item->temp_widget = NULL;
   item->widget = NULL;
+  if(item->box) gtk_widget_destroy(item->box);
+  item->box = NULL;
+  if(item->temp_widget) gtk_widget_destroy(item->temp_widget);
+  item->temp_widget = NULL;
   item->old_parent = NULL;
   item->module = NULL;
   if(item->tooltip)
@@ -604,6 +604,7 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
     g_signal_connect(item->temp_widget, "show", G_CALLBACK(_sync_visibility), item);
     g_signal_connect(item->temp_widget, "hide", G_CALLBACK(_sync_visibility), item);
     g_signal_connect(G_OBJECT(item->temp_widget), "destroy", G_CALLBACK(gtk_widget_destroyed), &item->temp_widget);
+    g_signal_connect_swapped(G_OBJECT(item->temp_widget), "destroy", G_CALLBACK(_basics_remove_widget), item);
 
     _sync_visibility(item->widget, item);
   }


### PR DESCRIPTION
This may catch remaining crashes when deleting, via shortcuts or lua, multi-instances of a module that has widgets in the qap, _while_ the qap is being shown. It has a larger potential for side-effects/regressions than the previous patch so I'd likely prefer to keep this out of 4.2

This does _not_ switch the qap version of widgets to a different instance when the original gets removed; it simply deletes any now-invalid widgets. In theory, the "correct" way of dealing with multi-instance in qap is to follow the "preferred" instance as determined for shortcuts and following the preferences set in _miscellaneous_. But this would mean updating/recreating qap every time a module status changes (focused/expanded/enabled/masked). This now only (implicitly) happens when switching _to_ the qap tab. Unless there's an outcry of people who really care about this behavior, I'd consider it wasted time to further refine this.