### PR TITLE
Update to add White Balance presets for the Fujifilm X-T5

### DIFF
--- a/data/wb_presets.json
+++ b/data/wb_presets.json
@@ -29610,6 +29610,221 @@
           ]
         },
         {
+          "model": "X-T5",
+	  "presets": [
+	    {
+              "name": "Daylight",
+              "tuning": -9,
+              "channels": [
+                1.884106,
+                1,
+                1.039735,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": 0,
+              "channels": [
+                1.884106,
+                1,
+                1.811258,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": 9,
+              "channels": [
+                1.884106,
+                1,
+                2.711921,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": -9,
+              "channels": [
+                2.0625,
+                1,
+                0.898809,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": 0,
+              "channels": [
+                2.059603,
+                1,
+                1.566225,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": 9,
+              "channels": [
+                2.059603,
+                1,
+                2.347682,
+                0
+              ]
+            },
+            {
+              "name": "Incandescent",
+              "tuning": -9,
+              "channels": [
+                1.274834,
+                1,
+                1.569536,
+                0
+              ]
+            },
+            {
+              "name": "Incandescent",
+              "tuning": 0,
+              "channels": [
+                1.274834,
+                1,
+                2.738411,
+                0
+              ]
+            },
+            {
+              "name": "Incandescent",
+              "tuning": 9,
+              "channels": [
+                1.274834,
+                1,
+                4.102649,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": -9,
+              "channels": [
+                2.036424,
+                1,
+                1.112582,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": 0,
+              "channels": [
+                2.036424,
+                1,
+                1.943709,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": 9,
+              "channels": [
+                2.036424,
+                1,
+                2.910596,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": -9,
+              "channels": [
+                2.392857,
+                1,
+                0.898809,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": 0,
+              "channels": [
+                2.390728,
+                1,
+                1.562914,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": 9,
+              "channels": [
+                2.390728,
+                1,
+                2.341059,
+                0
+              ]
+            },
+            {
+              "name": "White Fluorescent",
+              "tuning": -9,
+              "channels": [
+                1.933775,
+                1,
+                1.390728,
+                0
+              ]
+            },
+            {
+              "name": "White Fluorescent",
+              "tuning": 0,
+              "channels": [
+                1.933775,
+                1,
+                2.423841,
+                0
+              ]
+            },
+            {
+              "name": "White Fluorescent",
+              "tuning": 9,
+              "channels": [
+                1.933775,
+                1,
+                3.632450,
+                0
+              ]
+            },
+            {
+              "name": "Underwater",
+              "tuning": -9,
+              "channels": [
+                1.884106,
+                1,
+                1.039735,
+                0
+              ]
+            },
+            {
+              "name": "Underwater",
+              "tuning": 0,
+              "channels": [
+                1.884106,
+                1,
+                1.811258,
+                0
+              ]
+            },
+            {
+              "name": "Underwater",
+              "tuning": 9,
+              "channels": [
+                1.884106,
+                1,
+                2.711921,
+                0
+              ]
+            }
+          ]
+        },
+        {
           "model": "X-T10",
           "presets": [
             {


### PR DESCRIPTION
This PR is for adding the White Balance presets for the Fujifilm X-T5 camera.  I used the export_wb.py script to generate the values and then manually updated the wb_presets.json file.  This is my first time with the new white balance json, so I hope it's correct.