### PR TITLE
Fix HLR masking & cache issues

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -963,7 +963,7 @@ static void _collect_histogram_on_CPU(dt_dev_pixelpipe_t *pipe, dt_develop_t *de
     *pixelpipe_flow |= (PIXELPIPE_FLOW_HISTOGRAM_ON_CPU);
     *pixelpipe_flow &= ~(PIXELPIPE_FLOW_HISTOGRAM_NONE | PIXELPIPE_FLOW_HISTOGRAM_ON_GPU);
 
-    if(piece->histogram && (module->request_histogram & DT_REQUEST_ON) && (pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
+    if(piece->histogram && (module->request_histogram & DT_REQUEST_ON) && (pipe->type == DT_DEV_PIXELPIPE_PREVIEW))
     {
       const size_t buf_size = 4 * piece->histogram_stats.bins_count * sizeof(uint32_t);
       module->histogram = realloc(module->histogram, buf_size);
@@ -1559,8 +1559,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
           pixelpipe_flow |= (PIXELPIPE_FLOW_HISTOGRAM_ON_GPU);
           pixelpipe_flow &= ~(PIXELPIPE_FLOW_HISTOGRAM_NONE | PIXELPIPE_FLOW_HISTOGRAM_ON_CPU);
 
-          if(piece->histogram && (module->request_histogram & DT_REQUEST_ON)
-             && (pipe->type & DT_DEV_PIXELPIPE_PREVIEW) == DT_DEV_PIXELPIPE_PREVIEW)
+          if(piece->histogram && (module->request_histogram & DT_REQUEST_ON) && (pipe->type == DT_DEV_PIXELPIPE_PREVIEW))
           {
             const size_t buf_size = sizeof(uint32_t) * 4 * piece->histogram_stats.bins_count;
             module->histogram = realloc(module->histogram, buf_size);

--- a/src/iop/hlrecovery_v2.c
+++ b/src/iop/hlrecovery_v2.c
@@ -443,7 +443,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
 
   const size_t pwidth  = dt_round_size(roi_in->width / 3, 2) + 2 * HL_BORDER;
   const size_t pheight = dt_round_size(roi_in->height / 3, 2) + 2 * HL_BORDER;
-  const size_t p_size = dt_round_size((size_t) (pwidth + 4) * (pheight + 4), 16);
+  const size_t p_size =  dt_round_size((size_t) pwidth * pheight, 64);
 
   const size_t shift_x = roi_out->x;
   const size_t shift_y = roi_out->y;
@@ -729,10 +729,9 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
         in++;
       }
     }
-    dt_dev_pixelpipe_flush_caches(piece->pipe);
   }
 
-  dt_vprint(DT_DEBUG_PERF, "[segmentation report %12s] %5.1fMpix, segments: %3i red, %3i green, %3i blue, %3i all, %4i allowed.\n",
+  dt_print(DT_DEBUG_PERF, "[segmentation report %12s] %5.1fMpix, segments: %3i red, %3i green, %3i blue, %3i all, %4i allowed.\n",
       dt_dev_pixelpipe_type_to_str(piece->pipe->type),     
       (float) (roi_in->width * roi_in->height) / 1.0e6f, isegments[0].nr -2, isegments[1].nr-2, isegments[2].nr-2, isegments[3].nr-2,
       segmentation_limit-2);

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -60,7 +60,7 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
 
   const size_t pwidth  = dt_round_size(roi_in->width / 3, 2) + 2 * HL_BORDER;
   const size_t pheight = dt_round_size(roi_in->height / 3, 2) + 2 * HL_BORDER;
-  const size_t p_size = (size_t) dt_round_size(pwidth * pheight, 64);
+  const size_t p_size =  dt_round_size(pwidth * pheight, 64);
 
   const size_t i_width = roi_in->width;
   const size_t i_height = roi_in->height;
@@ -75,7 +75,7 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
       chrominance[c] = g->chroma_correction[c];          
   }
 
-  int *mask_buffer = dt_calloc_align(64, 4 * p_size * sizeof(int));
+  int *mask_buffer = dt_alloc_align(64, 4 * p_size * sizeof(int));
   float *tmpout = dt_alloc_align_float(4 * roi_in->width * roi_in->height);
 
   if(!tmpout || !mask_buffer)
@@ -141,7 +141,7 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
     {
       int *mask = mask_buffer + i * p_size;
       int *tmp = mask_buffer + 3 * p_size;
-      _intimage_borderfill(mask, pwidth, pheight, 0, HL_BORDER);
+      _intimage_borderfill(mask, pwidth, pheight, 0, HL_BORDER+1);
       _dilating(mask, tmp, pwidth, pheight, HL_BORDER, 3);
       memcpy(mask, tmp, p_size * sizeof(int));
     }
@@ -229,9 +229,9 @@ static float *_process_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
 
   const size_t pwidth  = dt_round_size(roi_in->width / 3, 2) + 2 * HL_BORDER;
   const size_t pheight = dt_round_size(roi_in->height / 3, 2) + 2 * HL_BORDER;
-  const size_t p_size = (size_t) dt_round_size((size_t) (pwidth + 4) * (pheight + 4), 64);
+  const size_t p_size =  dt_round_size((size_t) pwidth * pheight, 64);
 
-  int *mask_buffer = dt_calloc_align(64, 4 * p_size * sizeof(int));
+  int *mask_buffer = dt_alloc_align(64, 4 * p_size * sizeof(int));
   float *tmpout = dt_alloc_align_float(roi_in->width * roi_in->height);
 
   const size_t shift_x = roi_out->x;
@@ -312,7 +312,7 @@ static float *_process_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
     {
       int *mask = mask_buffer + i * p_size;
       int *tmp = mask_buffer + 3 * p_size;
-      _intimage_borderfill(mask, pwidth, pheight, 0, HL_BORDER);
+      _intimage_borderfill(mask, pwidth, pheight, 0, HL_BORDER+1);
       _dilating(mask, tmp, pwidth, pheight, HL_BORDER, 3);
       memcpy(mask, tmp, p_size * sizeof(int));
     }
@@ -418,7 +418,6 @@ static float *_process_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
       }
     }
   }
-
   dt_free_align(mask_buffer);
   return tmpout;
 }

--- a/src/iop/segmentation.h
+++ b/src/iop/segmentation.h
@@ -592,10 +592,13 @@ void dt_segmentize_plane(dt_iop_segmentation_t *seg)
   dt_ff_stack_t stack;  
   const size_t width = seg->width;
   const size_t height = seg->height;
-  stack.size = width * height / 16;
-  stack.el = dt_alloc_align(16, stack.size * sizeof(dt_pos_t));
-  if(!stack.el) return;
-
+  stack.size = width * height / 32;
+  stack.el = dt_alloc_align(64, stack.size * sizeof(dt_pos_t));
+  if(!stack.el)
+  {
+    fprintf(stderr, "[segmentize_plane] can't allocate segmentation stack\n");
+    return;
+  }
   const size_t border = seg->border;
   int id = 2;
   for(size_t row = border; row < height - border; row++)
@@ -612,8 +615,9 @@ void dt_segmentize_plane(dt_iop_segmentation_t *seg)
 
   finish:
 
-  if((id >= (seg->slots - 2)) && (darktable.unmuted & DT_DEBUG_VERBOSE))
-    fprintf(stderr, "[segmentize_plane] number of segments exceed maximum=%i\n", seg->slots);
+  if(id >= (seg->slots - 2))
+    fprintf(stderr, "[segmentize_plane] %lux%lu number of segments exceeds maximum=%i\n",
+      width, height, seg->slots);
 
   dt_free_align(stack.el);
 }


### PR DESCRIPTION
As tested and confirmed in #13047 we had some "strange" colorspace transform errors while switching between the masking modes and changed parameters. 

The reason for this is basically: we don't yet keep track of pixelpipe passthru modes and might use a cacheline as valid input data but don't update the passthru flag.

Done here:
1. make sure the histogram is updated **only** if not in fast mode
2. while switching between the different masking modes in this module we make sure the `DT_DEV_PIXELPIPE_FAST` and `DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU` flags are only set in fullpipe mode to avoid caching conflicts
3. As doing 1&2 we don't have to do the cache invalidate workarounds.


@MStraeten could you test this again :-)

@TurboGit concidering this still for 4.2 

Related to #12913 
Replaces #12984 