### PR TITLE
allow 1600% zoom to be written entirely

### DIFF
--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -250,7 +250,7 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, g
       cairo_set_source_rgba(cr, 1., 1., 1., 0.5);
       cairo_set_line_join(cr, CAIRO_LINE_JOIN_ROUND);
 
-      char zoomline[5];
+      char zoomline[6];
       snprintf(zoomline, sizeof(zoomline), "%.0f%%", cur_scale * 100 * darktable.gui->ppd);
 
       pango_layout_set_text(layout, zoomline, -1);


### PR DESCRIPTION
A super small fix in the navigation thumbnail.
A 1600% zoom requires a string of 6 chars (5 + null termination), or it will be clipped.

Before
![image](https://user-images.githubusercontent.com/43290988/205581639-609e9fd9-82ec-4167-92bc-fd9b4cfe37cd.png)

After
![image](https://user-images.githubusercontent.com/43290988/205581866-ba985c73-04af-49e7-b6e6-cd8236278098.png)
