### PR TITLE
fix jumping panels when searching modules for wide languages

### DIFF
--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2877,7 +2877,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_container_add(GTK_CONTAINER(visibility_wrapper), d->text_entry);
   gtk_box_pack_start(GTK_BOX(d->hbox_search_box), visibility_wrapper, TRUE, TRUE, 0);
   gtk_entry_set_width_chars(GTK_ENTRY(d->text_entry), 0);
-  gtk_entry_set_max_width_chars(GTK_ENTRY(d->text_entry), 50);
+  gtk_entry_set_max_width_chars(GTK_ENTRY(d->text_entry), 35);
   gtk_entry_set_icon_tooltip_text(GTK_ENTRY(d->text_entry), GTK_ENTRY_ICON_SECONDARY, _("clear text"));
 
   gtk_box_pack_start(GTK_BOX(self->widget), d->hbox_buttons, TRUE, TRUE, 0);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2999,6 +2999,10 @@ void enter(dt_view_t *self)
   /*
    * add IOP modules to plugin list
    */
+  GtkWidget *box = GTK_WIDGET(dt_ui_get_container(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER));
+  GtkScrolledWindow *sw = GTK_SCROLLED_WINDOW(gtk_widget_get_ancestor(box, GTK_TYPE_SCROLLED_WINDOW));
+  if(sw) gtk_scrolled_window_set_propagate_natural_width(sw, FALSE);
+
   char option[1024];
   for(const GList *modules = g_list_last(dev->iop); modules; modules = g_list_previous(modules))
   {
@@ -3224,6 +3228,10 @@ void leave(dt_view_t *self)
     free(dev->alliop->data);
     dev->alliop = g_list_delete_link(dev->alliop, dev->alliop);
   }
+
+  GtkWidget *box = GTK_WIDGET(dt_ui_get_container(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER));
+  GtkScrolledWindow *sw = GTK_SCROLLED_WINDOW(gtk_widget_get_ancestor(box, GTK_TYPE_SCROLLED_WINDOW));
+  if(sw) gtk_scrolled_window_set_propagate_natural_width(sw, TRUE);
 
   dt_pthread_mutex_unlock(&dev->history_mutex);
 


### PR DESCRIPTION
https://github.com/darktable-org/darktable/pull/12879#issuecomment-1337441933

@victoryforce please revert if this would sufficiently placate you and your friends to allow us to go ahead with the release? If xmas _does_ need to be cancelled, a heads-up as soon as possible would be appreciated; no need to wait to the very last minute again.

@TurboGit I believe this to be low risk. Basically for iops this makes it ignore natural width (which changes when modules are (un-)hidden) in deriving the default width of the right panel. In effect the width is now determined by the module group icons or the search box (which is reduced to 35 wide; best for English while other languages might see some ellipsizing. This "reverts" the 50 chars which were chosen in a futile attempt to reduce jumping for most languages).

For other (libs) panels, the default width is still set to fit the longest text.