### PR TITLE
Implemented writing an xmp sidecar file on export

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -242,11 +242,12 @@
         <option>never</option>
         <option>after edit</option>
         <option>on import</option>
+        <option>on export</option>
       </enum>
     </type>
     <default>on import</default>
     <shortdescription>write sidecar file for each image</shortdescription>
-    <longdescription>the sidecar files hold information about all your development steps to allow flawless re-importing of image files.\n\ndepending on the selected mode sidecar files will be written:\n - never\n - on import: immediately after importing the image\n - after edit: after any user change on the image</longdescription>
+    <longdescription>the sidecar files hold information about all your development steps to allow flawless re-importing of image files.\n\ndepending on the selected mode sidecar files will be written:\n - never\n - after edit: after any user change on the image\n - on import: immediately after importing the image\n - on export: immediately after exporting the image</longdescription>
   </dtconfig>
   <dtconfig prefs="storage" section="XMP">
     <name>compress_xmp_tags</name>

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -302,6 +302,8 @@ void dt_image_film_roll(const dt_image_t *img, char *pathname, size_t pathname_l
 dt_imageio_write_xmp_t dt_image_get_xmp_mode()
 {
   dt_imageio_write_xmp_t res = DT_WRITE_XMP_NEVER;
+  dt_conf_set_bool( "write_sidecar_on_export", FALSE );
+
   const char *config = dt_conf_get_string_const("write_sidecar_files");
   if(config)
   {
@@ -309,6 +311,11 @@ dt_imageio_write_xmp_t dt_image_get_xmp_mode()
       res = DT_WRITE_XMP_LAZY;
     else if(!strcmp(config, "on import"))
       res = DT_WRITE_XMP_ALWAYS;
+    else if(!strcmp(config, "on export"))
+    {
+      dt_conf_set_bool( "write_sidecar_on_export", TRUE );
+      res = DT_WRITE_XMP_NEVER; /* for clarity of intention */
+    }
     else if(!strcmp(config, "TRUE"))
     {
       // migration path from boolean settings in <= 3.6, lazy mode was introduced in 3.8

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -362,6 +362,12 @@ static void _export_button_clicked(GtkWidget *widget, dt_lib_export_t *d)
 
   _scale_optim();
   gtk_entry_set_text(GTK_ENTRY(d->scale), dt_conf_get_string_const(CONFIG_PREFIX "resizing_factor"));
+
+  // Optionally write the sidecar file.
+  if (dt_conf_get_bool( "write_sidecar_on_export" ) )
+  {
+    dt_control_write_sidecar_files();
+  }
 }
 
 static void _scale_changed(GtkEntry *spin, dt_lib_export_t *d)


### PR DESCRIPTION
This contribution adds in the preferences/storage/xmp section the option to write an xmp sidecar file "on export". The option is almost identical to the case where an xmp file is never written, except when an export of an image is explicitly requested. With this option, one can always be assured that the xmp is consistent with the exported image. It fits a workflow where the work on a (raw) image is considered done only when an export (say of a jpg file) has been done. And there is no accidental generation of xmp-files for images that have not been edited yet. 

The impact on the code is in three places:

-   in data/darktableconfig.xml.in the option "on export" is added to the appropriate combo (including tooltip text)
-   In common/image.c the (string)value of the new option is handled, in the routine dt_image_get_xmp_mode(). . Note that it is not required to introduce another enum value. The new option corresponds to the existing value DT_WRITE_XMP_NEVER. In addition, a (new) boolean configuration variable "write_sidecar_on_export" is being used: its value defaults to FALSE, but set to TRUE when the user has selected the "on export" option.
-   In libs/export.c, routine _export_button_clicked(), an if-statement is added to write the xmp files when the mentioned boolean variable has been set to TRUE.

