### PR TITLE
imageio: workaround for disabling metadata export

### DIFF
--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -1108,7 +1108,7 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
   format_params->width = processed_width;
   format_params->height = processed_height;
 
-  if(!ignore_exif)
+  if(!ignore_exif && metadata->flags != DT_META_NONE)
   {
     uint8_t *exif_profile = NULL; // Exif data should be 65536 bytes max, but if original size is close to that,
                                   // adding new tags could make it go over that... so let it be and see what

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -1108,7 +1108,20 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
   format_params->width = processed_width;
   format_params->height = processed_height;
 
-  if(!ignore_exif && metadata->flags != DT_META_NONE)
+  // Check if all the metadata export flags are set for AVIF/EXR/JPEG XL (opt-in)
+  // TODO: this is a workround as these formats do not support fine grained metadata control through
+  // dt_exif_xmp_attach_export() below due to lack of exiv2 write support
+  gboolean md_flags_set = TRUE;
+  if(!strcmp(format->mime(NULL), "image/avif") || !strcmp(format->mime(NULL), "image/x-exr")
+     || !strcmp(format->mime(NULL), "image/jxl"))
+  {
+    const int32_t meta_all = DT_META_EXIF | DT_META_METADATA | DT_META_GEOTAG | DT_META_TAG
+                             | DT_META_HIERARCHICAL_TAG | DT_META_DT_HISTORY | DT_META_PRIVATE_TAG
+                             | DT_META_SYNONYMS_TAG | DT_META_OMIT_HIERARCHY;
+    md_flags_set = metadata ? (metadata->flags & meta_all) == meta_all : FALSE;
+  }
+
+  if(!ignore_exif && md_flags_set)
   {
     uint8_t *exif_profile = NULL; // Exif data should be 65536 bytes max, but if original size is close to that,
                                   // adding new tags could make it go over that... so let it be and see what

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -440,12 +440,16 @@ int write_image(struct dt_imageio_module_data_t *data,
     avifImageSetMetadataExif(image, exif, exif_len);
 
   /* TODO: workaround; remove when exiv2 implements AVIF write support and update flags() */
-  char *xmp_string = dt_exif_xmp_read_string(imgid);
-  size_t xmp_len;
-  if(xmp_string && (xmp_len = strlen(xmp_string)) > 0)
+  /* TODO: workaround; uses valid exif as a way to indicate ALL metadata was requested */
+  if(exif && exif_len > 0)
   {
-    avifImageSetMetadataXMP(image, (const uint8_t *)xmp_string, xmp_len);
-    g_free(xmp_string);
+    char *xmp_string = dt_exif_xmp_read_string(imgid);
+    size_t xmp_len;
+    if(xmp_string && (xmp_len = strlen(xmp_string)) > 0)
+    {
+      avifImageSetMetadataXMP(image, (const uint8_t *)xmp_string, xmp_len);
+      g_free(xmp_string);
+    }
   }
 
   encoder = avifEncoderCreate();

--- a/src/imageio/format/exr.cc
+++ b/src/imageio/format/exr.cc
@@ -137,17 +137,23 @@ int write_image(dt_imageio_module_data_t *tmp, const char *filename, const void 
 
   header.insert("comment", Imf::StringAttribute(comment));
 
+  // TODO: workaround; remove when exiv2 implements EXR write support and use dt_exif_write_blob() at the end
   if(exif && exif_len > 0)
   {
     Imf::Blob exif_blob(exif_len, (uint8_t *)exif);
     header.insert("exif", Imf::BlobAttribute(exif_blob));
   }
 
-  char *xmp_string = dt_exif_xmp_read_string(imgid);
-  if(xmp_string && strlen(xmp_string) > 0)
+  // TODO: workaround; remove when exiv2 implements EXR write support and update flags()
+  // TODO: workaround; uses valid exif as a way to indicate ALL metadata was requested
+  if(exif && exif_len > 0)
   {
-    header.insert("xmp", Imf::StringAttribute(xmp_string));
-    g_free(xmp_string);
+    char *xmp_string = dt_exif_xmp_read_string(imgid);
+    if(xmp_string && strlen(xmp_string) > 0)
+    {
+      header.insert("xmp", Imf::StringAttribute(xmp_string));
+      g_free(xmp_string);
+    }
   }
 
   // try to add the chromaticities

--- a/src/imageio/format/jpeg.c
+++ b/src/imageio/format/jpeg.c
@@ -374,7 +374,7 @@ int write_image(dt_imageio_module_data_t *jpg_tmp, const char *filename, const v
   jpeg_destroy_compress(&(jpg->cinfo));
   fclose(f);
 
-  dt_exif_write_blob(exif, exif_len, filename, 1);
+  if(exif) dt_exif_write_blob(exif, exif_len, filename, 1);
 
   return 0;
 }

--- a/src/imageio/format/webp.c
+++ b/src/imageio/format/webp.c
@@ -246,7 +246,7 @@ error:
   WebPDataClear(&assembled_data);
   WebPMuxDelete(mux);
   fclose(out);
-  if(!res) dt_exif_write_blob(exif, exif_len, filename, 1);
+  if(!res && exif) dt_exif_write_blob(exif, exif_len, filename, 1);
   return res;
 }
 


### PR DESCRIPTION
Proposed workaround for #13077 