### PR TITLE
[debugging feature] Allow raw loader selection by file extension

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -235,6 +235,13 @@
     <shortdescription>timeout period of pixelpipe synchronization</shortdescription>
     <longdescription>time period (in units of 5ms) after which synchronization of preview and full pixelpipe is assumed to have failed. set to zero to omit pixelpipe synchronization. defaults to 200.</longdescription>
   </dtconfig>
+  <dtconfig>
+    <name>libraw_extensions</name>
+    <type>string</type>
+    <default></default>
+    <shortdescription>raw file extensions to be processed by libraw</shortdescription>
+    <longdescription>space-delimited list of raw file extensions (without a leading dot, in lowercase) to be processed by libraw instead of rawspeed.</longdescription>
+  </dtconfig>
   <dtconfig prefs="storage" section="XMP">
     <name>write_sidecar_files</name>
     <type>

--- a/src/imageio/imageio_libraw.c
+++ b/src/imageio/imageio_libraw.c
@@ -208,15 +208,31 @@ const model_map_t modelMap[] = {
 
 static gboolean _supported_image(const gchar *filename)
 {
-  const char *extensions_whitelist[] = { "cr3", NULL };
-  char *ext = g_strrstr(filename, ".");
+  // At the moment of writing this code CR3 files are not supported by RawSpeed,
+  // so they are always processed by LibRaw.
+  gchar *extensions_whitelist;
+  const gchar *always_by_libraw = "cr3";
+
+  gchar *ext = g_strrstr(filename, ".");
   if(!ext) return FALSE;
   ext++;
-  for(const char **i = extensions_whitelist; *i != NULL; i++)
-    if(!g_ascii_strncasecmp(ext, *i, strlen(*i)))
-    {
-      return TRUE;
-    }
+
+  if(dt_conf_key_not_empty("libraw_extensions"))
+    extensions_whitelist = g_strjoin(" ", always_by_libraw, dt_conf_get_string_const("libraw_extensions"), NULL);
+  else
+    extensions_whitelist = g_strdup(always_by_libraw);
+
+  fprintf(stderr, "[libraw_open] extensions whitelist: `%s'\n", extensions_whitelist);
+
+  gchar *ext_lowercased = g_ascii_strdown(ext,-1);
+  if(g_strstr_len(extensions_whitelist,-1,ext_lowercased))
+  {
+    g_free(ext_lowercased);
+    g_free(extensions_whitelist);
+    return TRUE;
+  }
+  g_free(ext_lowercased);
+  g_free(extensions_whitelist);
   return FALSE;
 }
 


### PR DESCRIPTION
Sometimes it would be nice to be able to temporarily select a different raw loader (libraw, that is) for debugging (to check the correctness of the white point, whether problem in loading the file are the result of corrupted file or a bug in rawspeed, etc.).

I believe that this PR is completely safe because of the simplicity of the code, the simplicity of the idea behind it, and the fact that when the user doesn't try to change the loader, everything works _exactly the same as before_. This code simply adds a feature that advanced users (and even dt devs) _could use_ if needed.

As an afterword: when testing this PR, I alternately loaded a considerable number of formats with both raw loaders, in some cases the higher speed of the rawspeed loader was visually noticeable!

And finally, I would like to emphasize once again that this PR should not be considered as an attempt to add the ability to choose a loader for all users during normal use of dt. __This is only a debugging aid__. That is why the interface for managing this feature was __intentionally__ not added to the dt settings.
