### PR TITLE
Bugfix: HLR roi_out data safety

### DIFF
--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -241,6 +241,8 @@ static float *_process_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
   const size_t o_col_max = MIN(roi_out->width, roi_in->width - shift_x);
   const size_t o_width = roi_out->width;
   const size_t i_width = roi_in->width;
+  if((o_row_max != roi_out->height) || (o_col_max != roi_out->width))
+    dt_iop_image_fill((float *)ovoid, 0.0f, roi_out->width, roi_out->height, 1);
 
   dt_aligned_pixel_t chrominance = {0.0f, 0.0f, 0.0f, 0.0f};
   gboolean valid_chrominance = FALSE;


### PR DESCRIPTION
As we take the full available image data area as roi_in the roi_out area can be larger than available input due to some scaling situations.

In current code we make sure to avoid out-of-bounds access by defining `o_row_max`.

Using this can unfortunately lead to parts of the roi_out data being not written by this module thus being random (including NaNs) depending on what was in the buffer that was allocated by the iop cache handler. These NaN might backfire proplems later in the pipeline.

In this pr:
1. we check for such a scaling condition and if found initialize the buffer to float zero before writing valid data in available area.