### PR TITLE
[WIP] Update fonts CSS code to respect CSS standard specs

### DIFF
--- a/data/themes/darktable-elegant-darker.css
+++ b/data/themes/darktable-elegant-darker.css
@@ -23,6 +23,16 @@
 /* hide selection frame in culling */
 @define-color culling_selected_border_color transparent;
 
+*
+{
+  font-family: "Roboto",                  	/* best case scenario */
+               "Segoe UI",              	/* Windows 10 default */
+               "SF Pro Display",  			/* Mac OS X default */
+               "Ubuntu", "IPAPGothic",  	/* Ubuntu default */
+               "Cantarell",                 /* Gnome default */
+                sans-serif;                 /* default default */
+}
+
 .dt_plugin_ui,
 .dt_bauhaus,
 .dt_bauhaus_popup,
@@ -67,35 +77,13 @@ eventbox *,
 box,
 box *
 {
-  font-family: "Roboto Light", "Roboto",                  /* best case scenario */
-               "Segoe UI Light", "Segoe UI",              /* Windows 10 default */
-               "SF Pro Display Light", "SF Pro Display",  /* Mac OS X default */
-               "Ubuntu Light", "Ubuntu", "IPAPGothic",    /* Ubuntu default */
-               "Cantarell",                               /* Gnome default */
-                sans-serif;                                /* default default */
-}
-
-.dt_section_label:not(#blending-box),
-#blending-box .dt_section_label label,
-#blending-box .dt_section_label .dt_bauhaus
-{
-  font-family: "Roboto Medium", "Roboto",
-               "Segoe UI Semibold", "Segoe UI",
-               "SF Pro Display Medium", "SF Pro Display",
-               "Ubuntu Medium", "Ubuntu", "IPAPGothic",
-               "Cantarell",
-                sans-serif;
+  font-weight: 300;
 }
 
 #iop-panel-label,
 #lib-panel-label
 {
-  font-family: "Roboto Condensed", "Roboto",
-               "Segoe UI Condensed", "Segoe UI",
-               "SF Pro Display", "SF Pro Display",
-               "Ubuntu Condensed", "Ubuntu", "IPAPGothic",
-               "Cantarell",
-               sans-serif;
+  font-stretch: condensed;
 }
 
 .active_menu_item *, /* needed for some Pango issues not rendering synthetic bold for all OS */
@@ -110,4 +98,5 @@ tooltip label,
                "Ubuntu", "IPAPGothic",
                "Cantarell",
                 sans-serif;
+  font-weight: normal;
 }

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -353,7 +353,6 @@ textview,
   border: 1px solid @button_border; /* this too */
   border-radius: 0.21em;
   background-color: @button_bg;
-  font-family: sans-serif;
 }
 
 /* then set specific settings for all text zones and combo */
@@ -591,7 +590,6 @@ dialog .sidebar row:selected:hover label,
   color: @plugin_label_color;
   padding: 0 0.14em 0.14em 0.45em;
   font-weight: normal;
-  font-family: sans-serif;
   font-size: 1.1em;
 }
 
@@ -607,7 +605,6 @@ dialog .sidebar row:selected:hover label,
 {
   padding: 0.14em 0;
   color: @section_label;
-  font-family: sans-serif;
   font-weight: 500;
 }
 
@@ -883,14 +880,6 @@ combobox separator
 /*----------------------
   - GTK Notebooks tabs -
   ----------------------*/
-notebook tabs,
-#blending-tabs,
-#guides-line,
-#modules-tabs
-{
-  font-family: sans-serif;
-}
-
 #blending-tabs,
 #guides-line,
 #modules-tabs


### PR DESCRIPTION
Closes #13084

This change all CSS code for elegant fonts. This needed to also remove some lines on main darktable theme. Lines removed were redundant and unuseful as they all inherit from line 240 with same setting.

I tested changes (on Japan language due to IPAPGothic font set and on Ukrainian one as well as non-Cyrillic language like French) on many parts and didn't see any changes except one:
- all modules titles are less condensed (but remains condensed). I think that new way is better as they were way too condensed and it's more natural regarding fonts.

Now, code use correct way to handle font with CSS, starting from real family, then set light or bold or medium or condensed with font-weight and font-stretch settings.

@victoryforce, @Mark-64 and @dterrahe: your reviews are more than welcomed, especially to test if it's ok on Windows as I can test that part. Be sure to check #13084 issue of course and as far as possible with both Pango release pointed (the one who have the issue and the one who have not). I hope that new code will work with both versions.

@Mark-64: another thing, good if you can check if that PR do not break your fix related to last one on that PR: #7671