### PR TITLE
po/multiple auto presets & iop module label 

### DIFF
--- a/src/common/database.c
+++ b/src/common/database.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2021 darktable developers.
+    Copyright (C) 2011-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -2597,8 +2597,8 @@ static void _create_memory_schema(dt_database_t *db)
   sqlite3_exec(
       db->handle,
       "CREATE TABLE memory.history (imgid INTEGER, num INTEGER, module INTEGER, "
-      "operation VARCHAR(256) UNIQUE ON CONFLICT REPLACE, op_params BLOB, enabled INTEGER, "
-      "blendop_params BLOB, blendop_version INTEGER, multi_priority INTEGER, multi_name VARCHAR(256))",
+      "operation VARCHAR(256), op_params BLOB, enabled INTEGER, "
+      "blendop_params BLOB, blendop_version INTEGER, multi_priority INTEGER, multi_name VARCHAR(256), CONSTRAINT opprio UNIQUE (operation, multi_priority))",
       NULL, NULL, NULL);
   sqlite3_exec(
       db->handle,

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -49,7 +49,7 @@
 
 // whenever _create_*_schema() gets changed you HAVE to bump this version and add an update path to
 // _upgrade_*_schema_step()!
-#define CURRENT_DATABASE_VERSION_LIBRARY 37
+#define CURRENT_DATABASE_VERSION_LIBRARY 38
 #define CURRENT_DATABASE_VERSION_DATA     9
 
 // #define USE_NESTED_TRANSACTIONS
@@ -2158,6 +2158,14 @@ static int _upgrade_library_schema_step(dt_database_t *db, int version)
              "[init] can't create metadata_index_value\n");
     new_version = 37;
   }
+  else if(version == 37)
+  {
+    TRY_EXEC("ALTER TABLE main.history ADD COLUMN multi_name_hand_edited INTEGER default 0",
+             "[init] can't add multi_name_hand_edited column\n");
+    TRY_EXEC("UPDATE main.history SET multi_name_hand_edited = 1 WHERE multi_name != ''",
+             "[init] can't set multi_name_hand_edited column\n");
+    new_version = 38;
+  }
   else
     new_version = version; // should be the fallback so that calling code sees that we are in an infinite loop
 
@@ -2476,7 +2484,7 @@ static void _create_library_schema(dt_database_t *db)
       db->handle,
       "CREATE TABLE main.history (imgid INTEGER, num INTEGER, module INTEGER, "
       "operation VARCHAR(256), op_params BLOB, enabled INTEGER, "
-      "blendop_params BLOB, blendop_version INTEGER, multi_priority INTEGER, multi_name VARCHAR(256), "
+      "blendop_params BLOB, blendop_version INTEGER, multi_priority INTEGER, multi_name VARCHAR(256), multi_name_hand_edited INTEGER, "
       "FOREIGN KEY(imgid) REFERENCES images(id) ON UPDATE CASCADE ON DELETE CASCADE)",
       NULL, NULL, NULL);
   sqlite3_exec(db->handle, "CREATE INDEX main.history_imgid_op_index ON history (imgid, operation)", NULL, NULL, NULL);
@@ -2598,19 +2606,19 @@ static void _create_memory_schema(dt_database_t *db)
       db->handle,
       "CREATE TABLE memory.history (imgid INTEGER, num INTEGER, module INTEGER, "
       "operation VARCHAR(256), op_params BLOB, enabled INTEGER, "
-      "blendop_params BLOB, blendop_version INTEGER, multi_priority INTEGER, multi_name VARCHAR(256), CONSTRAINT opprio UNIQUE (operation, multi_priority))",
+      "blendop_params BLOB, blendop_version INTEGER, multi_priority INTEGER, multi_name VARCHAR(256), multi_name_hand_edited INTEGER, CONSTRAINT opprio UNIQUE (operation, multi_priority))",
       NULL, NULL, NULL);
   sqlite3_exec(
       db->handle,
       "CREATE TABLE memory.history_snapshot (id INTEGER, num INTEGER, module INTEGER, "
       "operation VARCHAR(256), op_params BLOB, enabled INTEGER, "
-      "blendop_params BLOB, blendop_version INTEGER, multi_priority INTEGER, multi_name VARCHAR(256))",
+      "blendop_params BLOB, blendop_version INTEGER, multi_priority INTEGER, multi_name VARCHAR(256), multi_name_hand_edited INTEGER)",
       NULL, NULL, NULL);
   sqlite3_exec(
       db->handle,
       "CREATE TABLE memory.undo_history (id INTEGER, imgid INTEGER, num INTEGER, module INTEGER, "
       "operation VARCHAR(256), op_params BLOB, enabled INTEGER, "
-      "blendop_params BLOB, blendop_version INTEGER, multi_priority INTEGER, multi_name VARCHAR(256))",
+      "blendop_params BLOB, blendop_version INTEGER, multi_priority INTEGER, multi_name VARCHAR(256), multi_name_hand_edited INTEGER)",
       NULL, NULL, NULL);
   sqlite3_exec(
       db->handle,

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -3198,7 +3198,8 @@ int dt_exif_xmp_read(dt_image_t *img, const char *filename, const int history_on
 
     dt_database_start_transaction(darktable.db);
 
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "DELETE FROM main.history WHERE imgid = ?1", -1,
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                                "DELETE FROM main.history WHERE imgid = ?1", -1,
                                 &stmt, NULL);
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, img->id);
     if(sqlite3_step(stmt) != SQLITE_DONE)

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -366,6 +366,7 @@ int dt_history_merge_module_into_history(dt_develop_t *dev_dest, dt_develop_t *d
       {
         module->instance = mod_src->instance;
         module->multi_priority = mod_src->multi_priority;
+        module->multi_name_hand_edited = mod_src->multi_name_hand_edited;
         module->iop_order = dt_ioppr_get_iop_order(dev_dest->iop_order_list, module->op, module->multi_priority);
       }
     }

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -649,9 +649,9 @@ static int _history_copy_and_paste_on_image_overwrite(const int32_t imgid, const
     gchar *query = g_strdup_printf
       ("INSERT INTO main.history "
        "            (imgid,num,module,operation,op_params,enabled,blendop_params, "
-       "             blendop_version,multi_priority,multi_name)"
+       "             blendop_version,multi_priority,multi_name,multi_name_hand_edited)"
        " SELECT ?1,num,module,operation,op_params,enabled,blendop_params, "
-       "        blendop_version,multi_priority,multi_name "
+       "        blendop_version,multi_priority,multi_name,multi_name_hand_edited "
        " FROM main.history"
        " WHERE imgid=?2"
        "       AND operation NOT IN (%s)"

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -986,7 +986,9 @@ void dt_history_compress_on_image(const int32_t imgid)
   // get history_end for image
   int my_history_end = 0;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-    "SELECT history_end FROM main.images WHERE id=?1", -1, &stmt, NULL);
+    "SELECT history_end"
+    " FROM main.images"
+    " WHERE id=?1", -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
 
   if(sqlite3_step(stmt) == SQLITE_ROW)
@@ -1010,7 +1012,9 @@ void dt_history_compress_on_image(const int32_t imgid)
   // because only if this is **not** true history nums and history_end must be increased
   // clang-format off
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-    "SELECT COUNT(*) FROM main.history WHERE imgid = ?1 AND operation = ?2 AND num = 0", -1, &stmt, NULL);
+    "SELECT COUNT(*)"
+    " FROM main.history"
+    " WHERE imgid = ?1 AND operation = ?2 AND num = 0", -1, &stmt, NULL);
   // clang-format on
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
   DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 2, op_mask_manager, -1, SQLITE_TRANSIENT);

--- a/src/common/history_snapshot.c
+++ b/src/common/history_snapshot.c
@@ -64,7 +64,7 @@ void dt_history_snapshot_undo_create(const int32_t imgid, int *snap_id, int *his
     // clang-format off
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                                 "INSERT INTO memory.undo_history"
-                                "  VALUES (?1, ?2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)"
+                                "  VALUES (?1, ?2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0)"
                                 , -1, &stmt, NULL);
     // clang-format on
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, *snap_id);
@@ -79,8 +79,9 @@ void dt_history_snapshot_undo_create(const int32_t imgid, int *snap_id, int *his
   // clang-format off
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                               "INSERT INTO memory.undo_history"
-                              "  SELECT ?1, imgid, num, module, operation, op_params, enabled, "
-                              "         blendop_params, blendop_version, multi_priority, multi_name "
+                              "  SELECT ?1, imgid, num, module, operation, op_params,"
+                              "         enabled, blendop_params, blendop_version,"
+                              "         multi_priority, multi_name, multi_name_hand_edited "
                               "  FROM main.history"
                               "  WHERE imgid=?2", -1, &stmt, NULL);
   // clang-format on
@@ -157,7 +158,8 @@ static void _history_snapshot_undo_restore(const int32_t imgid, const int snap_i
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                               "INSERT INTO main.history"
                               "  SELECT imgid, num, module, operation, op_params, enabled, "
-                              "         blendop_params, blendop_version, multi_priority, multi_name "
+                              "         blendop_params, blendop_version, multi_priority,"
+                              "         multi_name, multi_name_hand_edited "
                               "  FROM memory.undo_history"
                               "  WHERE imgid=?2 AND id=?1", -1, &stmt, NULL);
   // clang-format on

--- a/src/common/history_snapshot.c
+++ b/src/common/history_snapshot.c
@@ -281,4 +281,3 @@ void dt_history_snapshot_undo_pop(gpointer user_data, dt_undo_type_t type, dt_un
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/common/iop_order.h
+++ b/src/common/iop_order.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2018-2020 darktable developers.
+    Copyright (C) 2018-2022 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by
@@ -178,6 +178,8 @@ dt_iop_order_entry_t *dt_ioppr_get_iop_order_entry(GList *iop_order_list, const 
 GList *dt_ioppr_get_iop_order_link(GList *iop_order_list, const char *op_name, const int multi_priority);
 /** For a non custom order, returns TRUE if iop_order_list has multiple instances grouped together */
 gboolean dt_ioppr_has_multiple_instances(GList *iop_order_list);
+/** returns a list of dt_iop_order_entry_t and updates *_version */
+GList *dt_ioppr_get_multiple_instances_iop_order_list(int32_t imgid, gboolean memory);
 
 /** returns the iop_order from iop_order_list list with operation = op_name */
 int dt_ioppr_get_iop_order(GList *iop_order_list, const char *op_name, const int multi_priority);
@@ -253,4 +255,3 @@ void dt_ioppr_print_iop_order(GList *iop_order_list, const char *msg);
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/common/presets.c
+++ b/src/common/presets.c
@@ -320,7 +320,9 @@ gboolean dt_presets_module_can_autoapply(const gchar *operation)
 
 char *dt_presets_get_name(const char *module_name,
                           const void *params,
-                          const uint32_t param_size)
+                          const uint32_t param_size,
+                          const void *blend_params,
+                          const uint32_t blend_params_size)
 {
   sqlite3_stmt *stmt;
 
@@ -328,11 +330,14 @@ char *dt_presets_get_name(const char *module_name,
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                               "SELECT name"
                               " FROM data.presets"
-                              " WHERE operation = ?1 AND op_params = ?2",
+                              " WHERE operation = ?1"
+                              "   AND op_params = ?2"
+                              "   AND blendop_params = ?3",
                               -1, &stmt, NULL);
   // clang-format on
   DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, module_name, strlen(module_name), SQLITE_TRANSIENT);
   DT_DEBUG_SQLITE3_BIND_BLOB(stmt, 2, params, param_size, SQLITE_TRANSIENT);
+  DT_DEBUG_SQLITE3_BIND_BLOB(stmt, 3, blend_params, blend_params_size, SQLITE_TRANSIENT);
 
   char *result = NULL;
 

--- a/src/common/presets.c
+++ b/src/common/presets.c
@@ -317,9 +317,35 @@ gboolean dt_presets_module_can_autoapply(const gchar *operation)
   }
   return TRUE;
 }
+
+char *dt_presets_get_name(const char *module_name,
+                          const void *params,
+                          const uint32_t param_size)
+{
+  sqlite3_stmt *stmt;
+
+  // clang-format off
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "SELECT name"
+                              " FROM data.presets"
+                              " WHERE operation = ?1 AND op_params = ?2",
+                              -1, &stmt, NULL);
+  // clang-format on
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, module_name, strlen(module_name), SQLITE_TRANSIENT);
+  DT_DEBUG_SQLITE3_BIND_BLOB(stmt, 2, params, param_size, SQLITE_TRANSIENT);
+
+  char *result = NULL;
+
+  if(sqlite3_step(stmt) == SQLITE_ROW)
+    result = g_strdup((gchar *)sqlite3_column_text(stmt, 0));
+
+  sqlite3_finalize(stmt);
+
+  return result;
+}
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/common/presets.h
+++ b/src/common/presets.h
@@ -26,11 +26,16 @@ void dt_presets_save_to_file(const int rowid, const char *preset_name, const cha
 /** load preset from file */
 int dt_presets_import_from_file(const char *preset_path);
 
-// does the module support autoapplying presets ?
+/** does the module support autoapplying presets ? */
 gboolean dt_presets_module_can_autoapply(const gchar *operation);
+
+/** get preset name for given module params */
+char *dt_presets_get_name(const char *module_name,
+                          const void *params,
+                          const uint32_t param_size);
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/common/presets.h
+++ b/src/common/presets.h
@@ -32,7 +32,9 @@ gboolean dt_presets_module_can_autoapply(const gchar *operation);
 /** get preset name for given module params */
 char *dt_presets_get_name(const char *module_name,
                           const void *params,
-                          const uint32_t param_size);
+                          const uint32_t param_size,
+                          const void *blend_params,
+                          const uint32_t blend_params_size);
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -808,12 +808,14 @@ int dt_dev_write_history_item(const int imgid, dt_dev_history_item_t *h, int32_t
   // *(float *)h->params, *(((float *)h->params)+1));
   sqlite3_finalize(stmt);
   // clang-format off
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "UPDATE main.history"
-                              " SET operation = ?1, op_params = ?2, module = ?3, enabled = ?4, "
-                              "     blendop_params = ?7, blendop_version = ?8, multi_priority = ?9, multi_name = ?10, multi_name_hand_edited = ?11"
-                              " WHERE imgid = ?5 AND num = ?6",
-                              -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_PREPARE_V2
+    (dt_database_get(darktable.db),
+     "UPDATE main.history"
+     " SET operation = ?1, op_params = ?2, module = ?3, enabled = ?4, "
+     "     blendop_params = ?7, blendop_version = ?8, multi_priority = ?9,"
+     "     multi_name = ?10, multi_name_hand_edited = ?11"
+     " WHERE imgid = ?5 AND num = ?6",
+     -1, &stmt, NULL);
   // clang-format on
   DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, h->module->op, -1, SQLITE_TRANSIENT);
   DT_DEBUG_SQLITE3_BIND_BLOB(stmt, 2, h->params, h->module->params_size, SQLITE_TRANSIENT);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1425,8 +1425,8 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
   const gboolean is_raw = dt_image_is_raw(image);
   const gboolean is_modern_chroma = dt_is_scene_referred();
 
-  // flag was already set? only apply presets once in the lifetime of a history stack.
-  // (the flag will be cleared when removing it).
+  // flag was already set? only apply presets once in the lifetime of
+  // a history stack.  (the flag will be cleared when removing it).
   if(!run || image->id <= 0)
   {
     // Next section is to recover old edits where all modules with
@@ -1464,14 +1464,15 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
           // raw file we need to add one now with the default legacy
           // parameters. And we want to do this only for old edits.
           //
-          // For new edits the temperature will be added back depending on the chromatic
-          // adaptation the standard way.
+          // For new edits the temperature will be added back
+          // depending on the chromatic adaptation the standard way.
 
           if(!strcmp(module->op, "temperature")
              && (image->change_timestamp == -1))
           {
-            // it is important to recover temperature in this case (modern chroma and
-            // not module present as we need to have the pre 3.0 default parameters used.
+            // it is important to recover temperature in this case
+            // (modern chroma and not module present as we need to
+            // have the pre 3.0 default parameters used.
 
             dt_conf_set_string("plugins/darkroom/workflow", "display-referred (legacy)");
             dt_iop_reload_defaults(module);
@@ -1526,8 +1527,9 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
     }
   }
 
-  // select all presets from one of the following table and add them into memory.history. Note that
-  // this is appended to possibly already present default modules.
+  // select all presets from one of the following table and add them
+  // into memory.history. Note that this is appended to possibly
+  // already present default modules.
   const char *preset_table[2] = { "data.presets", "main.legacy_presets" };
   const int legacy = (image->flags & DT_IMAGE_NO_LEGACY_PRESETS) ? 0 : 1;
   char query[1024];

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -41,6 +41,7 @@ typedef struct dt_dev_history_item_t
   int iop_order;
   int multi_priority;
   char multi_name[128];
+  gboolean multi_name_hand_edited;
   GList *forms; // snapshot of dt_develop_t->forms
   int num; // num of history on database
   int32_t focus_hash;             // used to determine whether or not to start a new item or to merge down

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -3159,6 +3159,22 @@ void dt_iop_gui_changed(dt_action_t *action, GtkWidget *widget, gpointer data)
   dt_iop_color_picker_reset(module, TRUE);
 
   dt_dev_add_history_item(darktable.develop, module, TRUE);
+
+  // module is enabled, module label has not been hand edited and the name is set.
+  // reset to multi-prioriry or empty is main instance.
+
+  if(module->enabled
+     && !module->multi_name_hand_edited)
+  {
+    char nl[5] = { 0 };
+    snprintf(nl, sizeof(nl), "%d", module->multi_priority);
+
+    g_strlcpy(module->multi_name,
+              module->multi_priority == 0 ? "" : nl,
+              sizeof(module->multi_name));
+
+    dt_iop_gui_update_header(module);
+  }
 }
 
 enum

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -833,11 +833,16 @@ static gboolean _rename_module_key_press(GtkWidget *entry, GdkEventKey *event, d
         g_strlcpy(module->multi_name, name, sizeof(module->multi_name));
         dt_dev_add_history_item(module->dev, module, TRUE);
       }
+
+      // this has been hand edited, the name should not be changed when
+      // applying a preset or a style.
+      module->multi_name_hand_edited = TRUE;
     }
     else
     {
       // clear out multi-name (set 1st char to 0)
       module->multi_name[0] = 0;
+      module->multi_name_hand_edited = FALSE;
       dt_dev_add_history_item(module->dev, module, TRUE);
     }
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -812,7 +812,9 @@ static gboolean _rename_module_key_press(GtkWidget *entry, GdkEventKey *event, d
 {
   int ended = 0;
 
-  if(event->type == GDK_FOCUS_CHANGE || event->keyval == GDK_KEY_Return || event->keyval == GDK_KEY_KP_Enter)
+  if(event->type == GDK_FOCUS_CHANGE
+     || event->keyval == GDK_KEY_Return
+     || event->keyval == GDK_KEY_KP_Enter)
   {
     if(gtk_entry_get_text_length(GTK_ENTRY(entry)) > 0)
     {
@@ -820,7 +822,9 @@ static gboolean _rename_module_key_press(GtkWidget *entry, GdkEventKey *event, d
 
        const gchar *name = gtk_entry_get_text(GTK_ENTRY(entry));
 
-      // restore saved 1st character of instance name (without it the same name wouls still produce unnecessary copy + add history item)
+      // restore saved 1st character of instance name (without it the
+      // same name wouls still produce unnecessary copy + add history
+      // item)
       module->multi_name[0] = module->multi_name[sizeof(module->multi_name) - 1];
       module->multi_name[sizeof(module->multi_name) - 1] = 0;
 
@@ -1196,7 +1200,9 @@ static void _init_presets(dt_iop_module_so_t *module_so)
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(
       dt_database_get(darktable.db),
-      "SELECT name, op_version, op_params, blendop_version, blendop_params FROM data.presets WHERE operation = ?1",
+      "SELECT name, op_version, op_params, blendop_version, blendop_params"
+      " FROM data.presets"
+      " WHERE operation = ?1",
       -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, module_so->op, -1, SQLITE_TRANSIENT);
 
@@ -1217,9 +1223,12 @@ static void _init_presets(dt_iop_module_so_t *module_so)
       // the module version from that.
 
       sqlite3_stmt *stmt2;
-      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                  "SELECT module FROM main.history WHERE operation = ?1 AND op_params = ?2", -1,
-                                  &stmt2, NULL);
+      DT_DEBUG_SQLITE3_PREPARE_V2
+        (dt_database_get(darktable.db),
+         "SELECT module"
+         " FROM main.history"
+         " WHERE operation = ?1 AND op_params = ?2", -1,
+         &stmt2, NULL);
       DT_DEBUG_SQLITE3_BIND_TEXT(stmt2, 1, module_so->op, -1, SQLITE_TRANSIENT);
       DT_DEBUG_SQLITE3_BIND_BLOB(stmt2, 2, old_params, old_params_size, SQLITE_TRANSIENT);
 
@@ -1244,8 +1253,11 @@ static void _init_presets(dt_iop_module_so_t *module_so)
       fprintf(stderr, "[imageop_init_presets] Found version %d for '%s' preset '%s'\n", old_params_version,
               module_so->op, name);
 
-      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                  "UPDATE data.presets SET op_version=?1 WHERE operation=?2 AND name=?3", -1,
+      DT_DEBUG_SQLITE3_PREPARE_V2
+        (dt_database_get(darktable.db),
+         "UPDATE data.presets"
+         " SET op_version=?1"
+         " WHERE operation=?2 AND name=?3", -1,
                                   &stmt2, NULL);
       DT_DEBUG_SQLITE3_BIND_INT(stmt2, 1, old_params_version);
       DT_DEBUG_SQLITE3_BIND_TEXT(stmt2, 2, module_so->op, -1, SQLITE_TRANSIENT);
@@ -1255,7 +1267,8 @@ static void _init_presets(dt_iop_module_so_t *module_so)
       sqlite3_finalize(stmt2);
     }
 
-    if(module_version > old_params_version && module_so->legacy_params != NULL)
+    if(module_version > old_params_version
+       && module_so->legacy_params != NULL)
     {
       // we need a dt_iop_module_t for legacy_params()
       dt_iop_module_t *module;
@@ -1265,17 +1278,6 @@ static void _init_presets(dt_iop_module_so_t *module_so)
         free(module);
         continue;
       }
-/*
-      module->init(module);
-      if(module->params_size == 0)
-      {
-        dt_iop_cleanup_module(module);
-        free(module);
-        continue;
-      }
-      // we call reload_defaults() in case the module defines it
-      if(module->reload_defaults) module->reload_defaults(module); // why not call dt_iop_reload_defaults? (if needed at all)
-*/
 
       const int32_t new_params_size = module->params_size;
       void *new_params = calloc(1, new_params_size);
@@ -1296,9 +1298,10 @@ static void _init_presets(dt_iop_module_so_t *module_so)
       // and write the new params back to the database
       sqlite3_stmt *stmt2;
       // clang-format off
-      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "UPDATE data.presets "
-                                                                 "SET op_version=?1, op_params=?2 "
-                                                                 "WHERE operation=?3 AND name=?4",
+      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                                  "UPDATE data.presets"
+                                  " SET op_version=?1, op_params=?2"
+                                  " WHERE operation=?3 AND name=?4",
                                   -1, &stmt2, NULL);
       // clang-format on
       DT_DEBUG_SQLITE3_BIND_INT(stmt2, 1, module->version());
@@ -1360,9 +1363,10 @@ static void _init_presets(dt_iop_module_so_t *module_so)
       // and write the new blend params back to the database
       sqlite3_stmt *stmt2;
       // clang-format off
-      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "UPDATE data.presets "
-                                                                 "SET blendop_version=?1, blendop_params=?2 "
-                                                                 "WHERE operation=?3 AND name=?4",
+      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                                  "UPDATE data.presets"
+                                  " SET blendop_version=?1, blendop_params=?2"
+                                  " WHERE operation=?3 AND name=?4",
                                   -1, &stmt2, NULL);
       // clang-format on
       DT_DEBUG_SQLITE3_BIND_INT(stmt2, 1, dt_develop_blend_version());
@@ -1387,7 +1391,10 @@ static void _init_presets_actions(dt_iop_module_so_t *module)
   /** load shortcuts for presets **/
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "SELECT name FROM data.presets WHERE operation=?1 ORDER BY writeprotect DESC, rowid",
+                              "SELECT name"
+                              " FROM data.presets"
+                              " WHERE operation=?1"
+                              " ORDER BY writeprotect DESC, rowid",
                               -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, module->op, -1, SQLITE_TRANSIENT);
   while(sqlite3_step(stmt) == SQLITE_ROW)
@@ -1415,7 +1422,8 @@ static void _init_module_so(void *m)
     // create a gui and have the widgets register their accelerators
     dt_iop_module_t *module_instance = (dt_iop_module_t *)calloc(1, sizeof(dt_iop_module_t));
 
-    if(module->gui_init && !dt_iop_load_module_by_so(module_instance, module, NULL))
+    if(module->gui_init
+       && !dt_iop_load_module_by_so(module_instance, module, NULL))
     {
       darktable.control->accel_initialising = TRUE;
       dt_iop_gui_init(module_instance);
@@ -1813,9 +1821,11 @@ static void _gui_reset_callback(GtkButton *button, GdkEventButton *event, dt_iop
   const gboolean disabled = !module->default_enabled && module->hide_enable_button;
   if(disabled) return;
 
-  //Ctrl is used to apply any auto-presets to the current module
-  //If Ctrl was not pressed, or no auto-presets were applied, reset the module parameters
-  if(!(event && dt_modifier_is(event->state, GDK_CONTROL_MASK)) || !dt_gui_presets_autoapply_for_module(module))
+  // Ctrl is used to apply any auto-presets to the current module
+  // If Ctrl was not pressed, or no auto-presets were applied, reset the module parameters
+  if(!(event
+       && dt_modifier_is(event->state, GDK_CONTROL_MASK))
+     || !dt_gui_presets_autoapply_for_module(module))
   {
     // if a drawn mask is set, remove it from the list
     if(module->blend_params->mask_id > 0)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -846,6 +846,11 @@ static gboolean _rename_module_key_press(GtkWidget *entry, GdkEventKey *event, d
       dt_dev_add_history_item(module->dev, module, TRUE);
     }
 
+    // make sure we write history & xmp to ensure that the new module name
+    // gets recorded into the XMP and won't be lost in case of crash.
+    dt_dev_write_history(darktable.develop);
+    dt_image_synch_xmp(darktable.develop->image_storage.id);
+
     ended = 1;
   }
   else if(event->keyval == GDK_KEY_Escape)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1721,18 +1721,22 @@ static gboolean _iop_update_label(gpointer data)
 {
   dt_iop_module_t *module = (dt_iop_module_t *)data;
 
-  char nl[256] = { 0 };
   char *preset_name =
-    dt_presets_get_name(module->op, module->params, module->params_size);
+    dt_presets_get_name(module->op,
+                        module->params, module->params_size,
+                        module->blend_params, sizeof(dt_develop_blend_params_t));
+
+  // if we have a preset-name, use it. otherwise set the label to the multi-priority
+  // except for 0 where the multi-name is cleared.
 
   if(preset_name)
-    snprintf(nl, sizeof(nl), "%s", preset_name);
+    snprintf(module->multi_name, sizeof(module->multi_name), "%s", preset_name);
   else if(module->multi_priority != 0)
-    snprintf(nl, sizeof(nl), "%d", module->multi_priority);
+    snprintf(module->multi_name, sizeof(module->multi_name), "%d", module->multi_priority);
+  else
+    g_strlcpy(module->multi_name, "", sizeof(module->multi_name));
 
   g_free(preset_name);
-
-  g_strlcpy(module->multi_name, nl, sizeof(module->multi_name));
 
   dt_iop_gui_update_header(module);
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1524,6 +1524,10 @@ GList *dt_iop_load_modules(dt_develop_t *dev)
 
 void dt_iop_cleanup_module(dt_iop_module_t *module)
 {
+  if(module->label_recompute_handle)
+    g_source_remove(module->label_recompute_handle);
+  module->label_recompute_handle = 0;
+
   module->cleanup(module);
 
   free(module->blend_params);

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -110,7 +110,7 @@ typedef enum dt_iop_flags_t
   IOP_FLAGS_GUIDES_SPECIAL_DRAW = 1 << 14, // handle the grid drawing directly
   IOP_FLAGS_GUIDES_WIDGET = 1 << 15,       // require the guides widget
   IOP_FLAGS_CACHE_IMPORTANT_NOW = 1 << 16, // hints for higher priority in iop cache
-  IOP_FLAGS_CACHE_IMPORTANT_NEXT = 1 << 17  
+  IOP_FLAGS_CACHE_IMPORTANT_NEXT = 1 << 17
 } dt_iop_flags_t;
 
 /** status of a module*/
@@ -517,4 +517,3 @@ void dt_iop_gui_changed(dt_action_t *action, GtkWidget *widget, gpointer data);
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -297,6 +297,7 @@ typedef struct dt_iop_module_t
 
   /** delayed-event handling */
   guint timeout_handle;
+  guint label_recompute_handle;
 
   void (*process_plain)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                         const void *const i, void *const o, const struct dt_iop_roi_t *const roi_in,

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -288,6 +288,7 @@ typedef struct dt_iop_module_t
   /** multi-instances things */
   int multi_priority; // user may change this
   char multi_name[128]; // user may change this name
+  gboolean multi_name_hand_edited;
   gboolean multi_show_close;
   gboolean multi_show_up;
   gboolean multi_show_down;

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -202,7 +202,9 @@ static void _edit_preset_response(GtkDialog *dialog, gint response_id, dt_gui_pr
 
     // we verify eventual name collisions
     const gchar *name = gtk_entry_get_text(g->name);
-    if(((g->old_id >= 0) && (strcmp(g->original_name, name) != 0)) || (g->old_id < 0))
+    if(((g->old_id >= 0)
+        && (strcmp(g->original_name, name) != 0))
+       || (g->old_id < 0))
     {
       if(name == NULL || *name == '\0' || strcmp(_("new preset"), name) == 0)
       {
@@ -221,8 +223,8 @@ static void _edit_preset_response(GtkDialog *dialog, gint response_id, dt_gui_pr
         return;
       }
 
-      // editing existing preset with different name or store new preset -> check for a preset with the same
-      // name:
+      // editing existing preset with different name or store new
+      // preset -> check for a preset with the same name:
       // clang-format off
       DT_DEBUG_SQLITE3_PREPARE_V2(
           dt_database_get(darktable.db),

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -858,6 +858,9 @@ void dt_gui_presets_apply_preset(const gchar* name, dt_iop_module_t *module)
     {
       memcpy(module->params, op_params, op_length);
       module->enabled = enabled;
+      // if module name has not been hand edited, use preset name as module label
+      if(!module->multi_name_hand_edited)
+        g_strlcpy(module->multi_name, name, sizeof(module->multi_name));
     }
     if(blendop_params && (blendop_version == dt_develop_blend_version())
        && (bl_length == sizeof(dt_develop_blend_params_t)))

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -627,7 +627,8 @@ static void _lib_snapshots_add_button_clicked_callback(GtkWidget *widget, gpoint
     (dt_database_get(darktable.db),
      "INSERT INTO memory.history_snapshot"
      " SELECT ?1, num, module, operation, op_params,"
-     "        enabled, blendop_params, blendop_version, multi_priority, multi_name"
+     "        enabled, blendop_params, blendop_version, multi_priority,"
+     "        multi_name, multi_name_hand_edited"
      " FROM main.history"
      " WHERE imgid = ?2 AND num < ?3",
      -1, &stmt, NULL);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -812,15 +812,18 @@ static void _dev_change_image(dt_develop_t *dev, const int32_t imgid)
   {
     sqlite3_stmt *stmt;
     // clang-format off
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                "SELECT m.imgid FROM memory.collected_images as m, main.selected_images as s "
-                                "WHERE m.imgid=s.imgid",
-                                -1, &stmt, NULL);
+    DT_DEBUG_SQLITE3_PREPARE_V2
+      (dt_database_get(darktable.db),
+       "SELECT m.imgid"
+       " FROM memory.collected_images as m, main.selected_images as s"
+       " WHERE m.imgid=s.imgid",
+       -1, &stmt, NULL);
     // clang-format on
     gboolean follow = FALSE;
     if(sqlite3_step(stmt) == SQLITE_ROW)
     {
-      if(sqlite3_column_int(stmt, 0) == dev->image_storage.id && sqlite3_step(stmt) != SQLITE_ROW)
+      if(sqlite3_column_int(stmt, 0) == dev->image_storage.id
+         && sqlite3_step(stmt) != SQLITE_ROW)
       {
         follow = TRUE;
       }
@@ -837,9 +840,11 @@ static void _dev_change_image(dt_develop_t *dev, const int32_t imgid)
     dt_iop_color_picker_reset(darktable.lib->proxy.colorpicker.picker_proxy->module, FALSE);
 
   // update aspect ratio
-  if(dev->preview_pipe->backbuf && dev->preview_status == DT_DEV_PIXELPIPE_VALID)
+  if(dev->preview_pipe->backbuf
+     && dev->preview_status == DT_DEV_PIXELPIPE_VALID)
   {
-    const double aspect_ratio = (double)dev->preview_pipe->backbuf_width / (double)dev->preview_pipe->backbuf_height;
+    const double aspect_ratio =
+      (double)dev->preview_pipe->backbuf_width / (double)dev->preview_pipe->backbuf_height;
     dt_image_set_aspect_ratio_to(dev->preview_pipe->image.id, aspect_ratio, TRUE);
   }
   else

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -795,6 +795,14 @@ static void _dev_change_image(dt_develop_t *dev, const int32_t imgid)
   // stop crazy users from sleeping on key-repeat spacebar:
   if(dev->image_loading) return;
 
+  // deactivate module label timer if set
+  if(darktable.develop->gui_module
+     && darktable.develop->gui_module->label_recompute_handle)
+  {
+    g_source_remove(darktable.develop->gui_module->label_recompute_handle);
+    darktable.develop->gui_module->label_recompute_handle = 0;
+  }
+
   // Pipe reset needed when changing image
   // FIXME: synch with dev_init() and dev_cleanup() instead of redoing it
   dev->proxy.chroma_adaptation = NULL;


### PR DESCRIPTION
Add support for multiple auto-presets of same operation..

To test create some presets for the same iop and auto apply all of them. Reset history stack of some images and see that all the presets have been applied as duplicate instances.

**WARNING: backup `library.db` before testing as this PR does change the schema.**

In this PR there is also:
- add preset name into the iop label
- reset iop label if some controls are changed
- in all cases, keep iop label if hand edited

Fixes #12853.
