### PR TITLE
Fixing pixelpipe cache issues related to mask visuals

### DIFF
--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -115,7 +115,6 @@ typedef enum dt_dev_pixelpipe_display_mask_t
   DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Cz = 14 << 3,
   DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_hz = 15 << 3,
   DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU = 16 << 3, // show module's output without processing by later iops
-  DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU_MONO = 17 << 3, // same as above but specific for pre-demosaic to stay monochrome
   DT_DEV_PIXELPIPE_DISPLAY_ANY = 0xff << 2,
   DT_DEV_PIXELPIPE_DISPLAY_STICKY = 1 << 16
 } dt_dev_pixelpipe_display_mask_t;

--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -84,7 +84,7 @@ void dt_dev_pixelpipe_cache_flush(dt_dev_pixelpipe_cache_t *cache);
 void dt_dev_pixelpipe_cache_flush_all_but(dt_dev_pixelpipe_cache_t *cache, uint64_t basichash);
 
 /** makes this buffer very important after it has been pulled from the cache. */
-void dt_dev_pixelpipe_cache_reweight(dt_dev_pixelpipe_cache_t *cache, void *data);
+void dt_dev_pixelpipe_cache_reweight(struct dt_dev_pixelpipe_t *pipe, void *data, const size_t size);
 
 /** mark the given cache line pointer as invalid. */
 void dt_dev_pixelpipe_cache_invalidate(dt_dev_pixelpipe_cache_t *cache, void *data);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2010,7 +2010,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
   {
     // give the input buffer to the currently focused plugin more weight.
     // the user is likely to change that one soon, so keep it in cache.
-    dt_dev_pixelpipe_cache_reweight(&(pipe->cache), input);
+    dt_dev_pixelpipe_cache_reweight(pipe, input, roi_in.width * roi_in.height * in_bpp);
   }
 
   // we check for an important hint after processing the module as we want to track a runtime hint too.

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -2968,8 +2968,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     // take care of passthru modes
     if(piece->pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU)
       demosaicing_method = (piece->pipe->dsc.filters != 9u) ? DT_IOP_DEMOSAIC_RCD : DT_IOP_DEMOSAIC_MARKESTEIJN;
-    else if(piece->pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU_MONO)
-      demosaicing_method = DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME;
   }
 
   if((qual_flags & DT_DEMOSAIC_MEDIUM_QUAL)
@@ -4799,8 +4797,6 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     // take care of passthru modes
     if(piece->pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU)
       demosaicing_method = (piece->pipe->dsc.filters != 9u) ? DT_IOP_DEMOSAIC_RCD : DT_IOP_DEMOSAIC_MARKESTEIJN;
-    else if(piece->pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU_MONO)
-      demosaicing_method = DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME;
   }
 
   const int qual_flags = demosaic_qual_flags(piece, &self->dev->image_storage, roi_out);


### PR DESCRIPTION
Rationale:
1. The pixelpipe makes sure it has valid=correct input data for a module via checking for size plus the hash. Unfortunately we might change "visual output" via one of the masking visuals or by the passthrough mode at runtime while processing the module so the hash is not valid.
2. If we watch in visualizing mode we simply don't want to cache data following later in the pipeline as that would a) pollute the cache with undesired data and b) we want to avoid invalid data.
3. By avoiding high priority cachelines we also improve the chance of a cacheline hit.

This pr does:
1. The `DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU_MONO` is not used anymore in the code and in fact would need some extra care to be supported properly so it's gone.
2. In `dt_dev_pixelpipe_cache_basichash` the hash is properly (djb2) calculated respecting fast mode and all mask visualizers.
3. `dt_dev_pixelpipe_cache_get()` checks if the cacheline is requested while in mask visualizing mode. if so, the weight is minimized so data is not cached and memory will be reused/deallocated at next pixelpipe run to keep memory available for relevant cachelines.
4. `dt_dev_pixelpipe_cache_reweight(struct dt_dev_pixelpipe_t *pipe, void *data, const size_t size)` is redefined checking also for size and masking modes.
5. debugging output improved