### PR TITLE
RELEASE_NOTES for 4.2: Gtk 3.24.15 min needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Compatible compilers:
 
 Required dependencies (minimum version):
 * CMake 3.10
-* GTK 3.22
+* GTK 3.24.15
 * GLib 2.40
 * SQLite 3.15 *(but 3.24 or newer strongly recommended)*
 * Exiv2 0.24 *(but at least 0.27.4 built with ISO BMFF support needed for Canon CR3 raw import)*

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -337,7 +337,7 @@ The following is a summary of the main features added to darktable
 
 ## Changed Dependencies
 
-N/A
+Bump Gtk minimum release from 3.22 to 3.24.15
 
 ## RawSpeed changes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -332,6 +332,8 @@ The following is a summary of the main features added to darktable
   formats JXL, AVIF and EXR, darktable will not include the metadata
   fields unless the user selects all of the checkboxes in the export
   preference options.
+  
+- With adding of font-feature-settings: tnum; line that allow correct display of numbers, minimal Gtk release needed (that add support of that new line) is 3.24.15. If you have older one, just remove line 241 of darktable.css file on your system. See: https://github.com/darktable-org/darktable/issues/13166
 
 ## Changed Dependencies
 


### PR DESCRIPTION
Closes #13166.

Thanks to @jade-nl issue, found that new font-feature-setting: "tnum"; added is only supported since march of 2020, with Gtk+3 3.24.15. I think it remains good but actually darktable specs require only 3.22. That seems to remains good except for that new line. As 3.24.15 is now quite old, I think we could keep it as it but that means that darktable will not work correctly by default on older release.

What do we do for that? For 4.2 release, I propose to update release notes as suggested by that PR. But that's probably not enough. Or we report that line and remove it by now (it's useful but we could deal without), or we propose as a minimum 3.24.15 instead of 3.22.

@dterrahe: as that line proposal is from you, your feedback is welcomed.