### PR TITLE
Add "uk" to LINGUAS file

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -28,5 +28,6 @@ sr@latin
 sv
 th
 tr
+uk
 zh_CN
 zh_TW


### PR DESCRIPTION
It somehow happened that the "uk" language was not added to the LINGUAS file yet. This did not interfere with the processing and installation of the translation, since it was based on the presence of the corresponding file in the po/ folder. But the absence of a language in the LINGUAS file prevents the translation from being included in the appdata.xml file.