### PR TITLE
[CI] Avoid macOS CI build failures (this time it's a long term fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -481,16 +481,7 @@ jobs:
       - name: Install Base Dependencies
         run: |
           brew update > /dev/null || true
-          brew unlink python@3.8
-          sudo rm '/usr/local/bin/2to3'
-          # We need to remove following symlinks to avoid possible conflicts between python versions, resulting in CI run failing.
-          # This workaround introduced 22.12.2022 and can be removed when python 3.10 package install/upgrade will not be triggered by our bundle.
-          sudo rm '/usr/local/bin/idle3'
-          sudo rm '/usr/local/bin/pydoc3'
-          sudo rm '/usr/local/bin/python3'
-          sudo rm '/usr/local/bin/python3-config'
-          brew link --overwrite python@3.10 # workaround due to dependency on python 3.10
-          # brew upgrade --ignore-pinned # workaround introduced 18.07.2021, replace asap
+          brew upgrade || true
           brew tap Homebrew/bundle
           cd src/.ci
           brew bundle --verbose


### PR DESCRIPTION
The problem was that Homebrew can't upgrade the base package list "cleanly" without warnings about not being able to rewrite symlinks when installing a python package. Such a situation is formally treated as an error, causes an error code to be returned, and thus causes the CI build to fail.

Previously, the upgrade was triggered when installing a bundle of packages required for building dt. We now move the upgrade to an explicit previous step and instead of fiddling with python symlinks to prevent a situation where brew returns an error, we now simply assume that the upgrade of the base set of packages cannot actually fail and so we protect it against being treated as failed with `|| true` (if this step _really_ fails to produce sane environment, it's a serious problem with github itself, not ours).