### PR TITLE
avoid zoom-in wraparound when CTRL+scroll-up

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3745,19 +3745,21 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
       scale = 8.0f / ppd;
   }
 
-  if(fitscale <= 1.0f) // for large image size, stop at 1:1 and FIT levels, minimum at 0.5 * FIT
-  {
-    if((scale - 1.0) * (oldscale - 1.0) < 0) scale = 1.0f / ppd;
-    if((scale - fitscale) * (oldscale - fitscale) < 0) scale = fitscale;
-    scale = fmaxf(scale, 0.5 * fitscale);
+  if(constrained) {
+    if(fitscale <= 1.0f) // for large image size, stop at 1:1 and FIT levels, minimum at 0.5 * FIT
+    {
+      if((scale - 1.0) * (oldscale - 1.0) < 0) scale = 1.0f / ppd;
+      if((scale - fitscale) * (oldscale - fitscale) < 0) scale = fitscale;
+      scale = fmaxf(scale, 0.5 * fitscale);
+    }
+    else if(fitscale > 1.0f && fitscale <= 2.0f) // for medium image size, stop at 2:1 and FIT levels, minimum at 0.5 * FIT
+    {
+      if((scale - 2.0) * (oldscale - 2.0) < 0) scale = 2.0f / ppd;
+      if((scale - fitscale) * (oldscale - fitscale) < 0) scale = fitscale;
+      scale = fmaxf(scale, 0.5 * fitscale);
+    }
+    else scale = fmaxf(scale, 1.0f / ppd); // for small image size, minimum at 1:1
   }
-  else if(fitscale > 1.0f && fitscale <= 2.0f) // for medium image size, stop at 2:1 and FIT levels, minimum at 0.5 * FIT
-  {
-    if((scale - 2.0) * (oldscale - 2.0) < 0) scale = 2.0f / ppd;
-    if((scale - fitscale) * (oldscale - fitscale) < 0) scale = fitscale;
-    scale = fmaxf(scale, 0.5 * fitscale);
-  }
-  else scale = fmaxf(scale, 1.0f / ppd); // for small image size, minimum at 1:1
   scale = fminf(scale, 16.0f / ppd);
 
   // pixel doubling instead of interpolation at >= 200% lodpi, >= 400% hidpi


### PR DESCRIPTION
Currently zooming-in unconstrained by CTRL+scroll-up has a corner case issue:
in some cases the zoom reaches 190-something% and then, instead of going to 200%+, it goes back to 100%.
It depends really on the image size and/or screen size, but I can reproduce reliably by:
- middle click to zoom 100%
- CTRL-scroll-up until 200% and more

The issue is due to the code not checking for the `constrained` flag in the new zoom level calculation resulting from CTRL+scroll-up