### PR TITLE
Culling fixes

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2081,9 +2081,9 @@ Details :
 .dt_overlays_mixed #thumb-main:hover .dt_thumb_btn,
 .dt_overlays_mixed #thumb-main:selected .dt_thumb_btn,
 .dt_overlays_mixed #thumb-main:hover #thumb-bottom-label,
-.dt_overlays_hover_block #thumb-main:hover .dt_thumb_btn,
-.dt_overlays_hover_block #thumb-main:hover .dt_thumb_btn:active,
-.dt_overlays_hover_block #thumb-main:hover #thumb-bottom-label
+.dt_overlays_hover_block #thumb-image:hover .dt_thumb_btn,
+.dt_overlays_hover_block #thumb-image:hover .dt_thumb_btn:active,
+.dt_overlays_hover_block #thumb-image:hover #thumb-bottom-label
 {
   color: @thumbnail_font_color;
 }
@@ -2132,7 +2132,7 @@ Details :
 .dt_overlays_always #thumb-main:hover #thumb-star:hover,
 .dt_overlays_always_extended #thumb-main:hover #thumb-star:hover,
 .dt_overlays_mixed #thumb-main:hover #thumb-star:hover,
-.dt_overlays_hover_block #thumb-main:hover #thumb-star:hover
+.dt_overlays_hover_block #thumb-image:hover #thumb-star:hover
 {
   color: @thumbnail_star_hover_color;
   background-color: @thumbnail_star_bg_color;
@@ -2144,7 +2144,7 @@ Details :
 .dt_overlays_always #thumb-main:hover #thumb-group-audio:hover,
 .dt_overlays_always_extended #thumb-main:hover #thumb-group-audio:hover,
 .dt_overlays_mixed #thumb-main:hover #thumb-group-audio:hover,
-.dt_overlays_hover_block #thumb-main:hover #thumb-group-audio:hover
+.dt_overlays_hover_block #thumb-image:hover #thumb-group-audio:hover
 {
   color: @thumbnail_fg_color;
 }

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1639,7 +1639,7 @@ void dt_culling_full_redraw(dt_culling_t *table, gboolean force)
   // we prefetch next/previous images
   _thumbs_prefetch(table);
 
-  // ensure one of the shown image as the focus (to avoid to keep focus to hidden image)
+  // ensure that no hidden image as the focus
   const int selid = dt_control_get_mouse_over_id();
   if(selid >= 0)
   {
@@ -1653,10 +1653,9 @@ void dt_culling_full_redraw(dt_culling_t *table, gboolean force)
         break;
       }
     }
-    if(!in_list && table->list)
+    if(!in_list)
     {
-      dt_thumbnail_t *thumb = (dt_thumbnail_t *)table->list->data;
-      dt_control_set_mouse_over_id(thumb->imgid);
+      dt_control_set_mouse_over_id(-1);
     }
   }
 

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1769,7 +1769,7 @@ void dt_culling_set_overlays_mode(dt_culling_t *table, dt_thumbnail_overlay_t ov
 }
 
 // force the overlays to be shown
-void dt_culling_force_overlay(dt_culling_t *table, gboolean force)
+void dt_culling_force_overlay(dt_culling_t *table, const gboolean force)
 {
   if(!table) return;
 

--- a/src/dtgtk/culling.h
+++ b/src/dtgtk/culling.h
@@ -95,6 +95,7 @@ void dt_culling_zoom_fit(dt_culling_t *table);
 
 // set the overlays type
 void dt_culling_set_overlays_mode(dt_culling_t *table, dt_thumbnail_overlay_t over);
+void dt_culling_force_overlay(dt_culling_t *table, gboolean force);
 
 // update active images list
 void dt_culling_update_active_images_list(dt_culling_t *table);

--- a/src/dtgtk/culling.h
+++ b/src/dtgtk/culling.h
@@ -95,7 +95,7 @@ void dt_culling_zoom_fit(dt_culling_t *table);
 
 // set the overlays type
 void dt_culling_set_overlays_mode(dt_culling_t *table, dt_thumbnail_overlay_t over);
-void dt_culling_force_overlay(dt_culling_t *table, gboolean force);
+void dt_culling_force_overlay(dt_culling_t *table, const gboolean force);
 
 // update active images list
 void dt_culling_update_active_images_list(dt_culling_t *table);

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -841,7 +841,6 @@ static gboolean _event_main_motion(GtkWidget *widget, GdkEventMotion *event, gpo
 {
   if(!user_data) return TRUE;
   dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
-
   // first, we hide the block overlays after a delay if the mouse hasn't move
   _thumbs_show_overlays(thumb);
 
@@ -1898,10 +1897,11 @@ void dt_thumbnail_set_mouseover(dt_thumbnail_t *thumb, gboolean over)
   thumb->mouse_over = over;
   _thumbs_show_overlays(thumb);
 
-  if(!thumb->mouse_over)
-  {
-    _set_flag(thumb->w_bottom_eb, GTK_STATE_FLAG_PRELIGHT, FALSE);
-  }
+  if(!thumb->mouse_over) _set_flag(thumb->w_bottom_eb, GTK_STATE_FLAG_PRELIGHT, FALSE);
+
+  _set_flag(thumb->w_main, GTK_STATE_FLAG_PRELIGHT, thumb->mouse_over);
+  _set_flag(thumb->w_image_box, GTK_STATE_FLAG_PRELIGHT, thumb->mouse_over);
+
   gtk_widget_queue_draw(thumb->w_main);
 }
 

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -833,6 +833,8 @@ static void _thumbs_show_overlays(dt_thumbnail_t *thumb)
           = g_timeout_add_seconds(thumb->overlay_timeout_duration, _thumbs_hide_overlays, thumb);
     }
   }
+  else
+    _thumb_update_icons(thumb);
 }
 
 static gboolean _event_main_motion(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
@@ -1894,7 +1896,7 @@ void dt_thumbnail_set_mouseover(dt_thumbnail_t *thumb, gboolean over)
 {
   if(thumb->mouse_over == over) return;
   thumb->mouse_over = over;
-  _thumb_update_icons(thumb);
+  _thumbs_show_overlays(thumb);
 
   if(!thumb->mouse_over)
   {

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -1947,7 +1947,7 @@ static void _widget_change_parent_overlay(GtkWidget *w, GtkOverlay *new_parent)
   gtk_widget_show(w);
   g_object_unref(w);
 }
-void dt_thumbnail_set_overlay(dt_thumbnail_t *thumb, dt_thumbnail_overlay_t over, int timeout)
+void dt_thumbnail_set_overlay(dt_thumbnail_t *thumb, dt_thumbnail_overlay_t over, const int timeout)
 {
   // if no change...
   if(thumb->over == over)

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -1129,6 +1129,11 @@ static gboolean _event_box_enter_leave(GtkWidget *widget, GdkEventCrossing *even
 static gboolean _event_image_enter_leave(GtkWidget *widget, GdkEventCrossing *event, gpointer user_data)
 {
   dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
+
+  // we ensure that the image has mouse over
+  if(!thumb->mouse_over && event->type == GDK_ENTER_NOTIFY && !thumb->disable_mouseover)
+    dt_control_set_mouse_over_id(thumb->imgid);
+
   _set_flag(thumb->w_image_box, GTK_STATE_FLAG_PRELIGHT, (event->type == GDK_ENTER_NOTIFY));
   return FALSE;
 }

--- a/src/dtgtk/thumbnail.h
+++ b/src/dtgtk/thumbnail.h
@@ -184,4 +184,3 @@ float dt_thumbnail_get_zoom_ratio(dt_thumbnail_t *thumb);
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/dtgtk/thumbnail.h
+++ b/src/dtgtk/thumbnail.h
@@ -124,7 +124,6 @@ typedef struct
   dt_thumbnail_overlay_t over;  // type of overlays
   int overlay_timeout_duration; // for hover_block overlay, we hide the it after a delay
   int overlay_timeout_id;       // id of the g_source timeout fct
-  gboolean display_overlay;     // FALSE if not displayed (based on mouse position)
   gboolean tooltip;             // should we show the tooltip ?
 
   int expose_again_timeout_id;  // source id of the expose_again timeout
@@ -185,3 +184,4 @@ float dt_thumbnail_get_zoom_ratio(dt_thumbnail_t *thumb);
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
+

--- a/src/libs/tools/timeline.c
+++ b/src/libs/tools/timeline.c
@@ -1424,6 +1424,7 @@ void gui_init(dt_lib_module_t *self)
   // we update the selection with actual collect rules
   _lib_timeline_collection_changed(NULL, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL, -1, self);
 
+  gtk_widget_show_all(self->widget);
   /* initialize view manager proxy */
   darktable.view_manager->proxy.timeline.module = self;
 

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -607,7 +607,7 @@ void scrollbar_changed(dt_view_t *self, double x, double y)
     dt_thumbtable_scrollbar_changed(dt_ui_thumbtable(darktable.gui->ui), x, y);
 }
 
-static void _overlays_force(dt_view_t *self, gboolean show)
+static void _overlays_force(dt_view_t *self, const gboolean show)
 {
   dt_library_t *lib = (dt_library_t *)self->data;
 
@@ -675,8 +675,8 @@ const dt_action_def_t dt_action_def_preview
       _action_elements_preview,
       NULL, TRUE };
 
-static float _action_process_infos(gpointer target, dt_action_element_t element, dt_action_effect_t effect,
-                                   float move_size)
+static float _action_process_infos(gpointer target, const dt_action_element_t element,
+                                   const dt_action_effect_t effect, const float move_size)
 {
   dt_view_t *self = darktable.view_manager->proxy.lighttable.view;
   dt_library_t *lib = (dt_library_t *)self->data;

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -607,6 +607,29 @@ void scrollbar_changed(dt_view_t *self, double x, double y)
     dt_thumbtable_scrollbar_changed(dt_ui_thumbtable(darktable.gui->ui), x, y);
 }
 
+static void _overlays_force(dt_view_t *self, gboolean show)
+{
+  dt_library_t *lib = (dt_library_t *)self->data;
+
+  // full_preview change
+  if(lib->preview_state
+     && (!show || lib->preview->overlays == DT_THUMBNAIL_OVERLAYS_NONE
+         || lib->preview->overlays == DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK))
+  {
+    dt_culling_force_overlay(lib->preview, show);
+  }
+
+  // culling change (note that full_preview can be combined with culling)
+  if((lib->current_layout == DT_LIGHTTABLE_LAYOUT_CULLING
+      || lib->current_layout == DT_LIGHTTABLE_LAYOUT_CULLING_DYNAMIC)
+     && (!show || lib->preview->overlays == DT_THUMBNAIL_OVERLAYS_NONE
+         || lib->preview->overlays == DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK))
+  {
+    dt_culling_force_overlay(lib->culling, show);
+  }
+}
+
+
 enum
 {
   DT_ACTION_ELEMENT_FOCUS_DETECT = 1,
@@ -651,6 +674,33 @@ const dt_action_def_t dt_action_def_preview
       _action_process_preview,
       _action_elements_preview,
       NULL, TRUE };
+
+static float _action_process_infos(gpointer target, dt_action_element_t element, dt_action_effect_t effect,
+                                   float move_size)
+{
+  dt_view_t *self = darktable.view_manager->proxy.lighttable.view;
+  dt_library_t *lib = (dt_library_t *)self->data;
+
+  if(!isnan(move_size))
+  {
+    if(effect != DT_ACTION_EFFECT_ON)
+    {
+      _overlays_force(self, FALSE);
+    }
+    else if(effect != DT_ACTION_EFFECT_OFF)
+    {
+      _overlays_force(self, TRUE);
+    }
+  }
+
+  return lib->preview_state;
+}
+
+const dt_action_element_def_t _action_elements_infos[] = { { "normal", dt_action_effect_hold }, { NULL } };
+
+const dt_action_def_t dt_action_def_infos
+    = { N_("show infos"), _action_process_infos, _action_elements_infos, NULL, TRUE };
+
 
 enum
 {
@@ -1266,6 +1316,10 @@ void gui_init(dt_view_t *self)
   ac = dt_action_define(sa, NULL, N_("preview"), NULL, &dt_action_def_preview);
   dt_shortcut_register(ac, DT_ACTION_ELEMENT_DEFAULT, DT_ACTION_EFFECT_HOLD, GDK_KEY_w, 0);
   dt_shortcut_register(ac, DT_ACTION_ELEMENT_FOCUS_DETECT, DT_ACTION_EFFECT_HOLD, GDK_KEY_w, GDK_CONTROL_MASK);
+
+  // Show infos key
+  ac = dt_action_define(sa, NULL, N_("show infos"), NULL, &dt_action_def_infos);
+  dt_shortcut_register(ac, DT_ACTION_ELEMENT_DEFAULT, DT_ACTION_EFFECT_HOLD, GDK_KEY_i, 0);
 
   dt_action_register(DT_ACTION(self), N_("align images to grid"), _accel_align_to_grid, 0, 0);
   dt_action_register(DT_ACTION(self), N_("reset first image offset"), _accel_reset_first_offset, 0, 0);


### PR DESCRIPTION
Some changes to fix multiple, recently reported, issues on culling and preview : 
- remove the "move mouse to bottom to hide overlay" feature in favor of a new shortcut ('i' by default) to show the overlay on demand if "no overlays" mode is set. This fixes #13036
- fix show of the overlay on image load (show right overlay and start timeout directly if needed)
- avoid "ghost" block overlays when using scroll or keyboard to move. This fixes #13173
- ensure the image under the cursor always has the focus, especially at culling startup
- fix the timeline visibility when starting in culling then going to filemanager. This fixes #13182