### PR TITLE
colorpicker cleanups/improvements

### DIFF
--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -296,7 +296,6 @@ static void _color_picker_work_1ch(const float *const pixel,
     weights.v[c] ? (stats.acc[c] / (float)weights.v[c]) : 0.0f;
 }
 
-// picked_color, picked_color_min and picked_color_max should be aligned
 void dt_color_picker_helper(const dt_iop_buffer_dsc_t *dsc, const float *const pixel,
                             const dt_iop_roi_t *roi, const int *const box,
                             const gboolean denoise,

--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -32,6 +32,7 @@ static inline size_t _box_size(const int *const box)
 
 // define custom reduction operations to handle pixel stats/weights
 // we can't return an array from a function, so wrap the array type in a struct
+// FIXME: use lib_colorpicker_sample_statistics instead?
 typedef struct _stats_pixel {
   dt_aligned_pixel_t acc, min, max;
 } _stats_pixel;
@@ -102,16 +103,13 @@ static inline void _color_picker_rgb_or_lab(dt_aligned_pixel_t avg, dt_aligned_p
                                             const float *const pixels, const size_t width)
 {
   for(size_t i = 0; i < width; i += 4)
-  {
-    dt_aligned_pixel_t pick;
-    copy_pixel(pick, pixels + i);
     for_each_channel(k)
     {
-      avg[k] += pick[k];
-      min[k] = fminf(min[k], pick[k]);
-      max[k] = fmaxf(max[k], pick[k]);
+      const float v = pixels[i + k];
+      avg[k] += v;
+      min[k] = fminf(min[k], v);
+      max[k] = fmaxf(max[k], v);
     }
-  }
 }
 
 #ifdef _OPENMP
@@ -175,8 +173,7 @@ static inline void _color_picker_jzczhz(dt_aligned_pixel_t avg, dt_aligned_pixel
   }
 }
 
-static void color_picker_helper_4ch(const dt_iop_buffer_dsc_t *const dsc, const float *const pixel,
-                                    const dt_iop_roi_t *const roi, const int *const box,
+static void color_picker_helper_4ch(const float *const pixel, const dt_iop_roi_t *const roi, const int *const box,
                                     dt_aligned_pixel_t picked_color, dt_aligned_pixel_t picked_color_min,
                                     dt_aligned_pixel_t picked_color_max,
                                     const dt_iop_colorspace_type_t cst_from,
@@ -362,9 +359,10 @@ void dt_color_picker_helper(const dt_iop_buffer_dsc_t *dsc, const float *const p
     float *const DT_ALIGNED_ARRAY tempbuf = dt_alloc_perthread_float(4 * roi->width, &padded_size); //TODO: alloc in caller
 
     // blur without clipping negatives because Lab a and b channels can be legitimately negative
+    // FIXME: this blurs whole image even when just a bit is sampled
     blur_2D_Bspline(pixel, denoised, tempbuf, roi->width, roi->height, 1, FALSE);
 
-    color_picker_helper_4ch(dsc, denoised, roi, box,
+    color_picker_helper_4ch(denoised, roi, box,
                             picked_color, picked_color_min, picked_color_max,
                             image_cst, picker_cst, profile);
 

--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -37,9 +37,14 @@ typedef struct _stats_pixel {
 } _stats_pixel;
 typedef struct _count_pixel { DT_ALIGNED_PIXEL uint32_t v[4]; } _count_pixel;
 
-#define OPENMP_CUSTOM_REDUCTIONS !(defined(__apple_build_version__) && __apple_build_version__ < 11030000) //makes Xcode 11.3.1 compiler crash
+// custom reductions make Xcode 11.3.1 compiler crash?
+#if defined(__apple_build_version__) && __apple_build_version__ < 11030000
+#define _CUSTOM_REDUCTIONS 0
+#else
+#define _CUSTOM_REDUCTIONS 1
+#endif
 
-#if defined(_OPENMP) && OPENMP_CUSTOM_REDUCTIONS
+#if defined(_OPENMP) && _CUSTOM_REDUCTIONS
 
 static inline _stats_pixel _reduce_stats_pixel(_stats_pixel stats, _stats_pixel newval)
 {
@@ -189,14 +194,14 @@ static void color_picker_helper_4ch(const dt_iop_buffer_dsc_t *const dsc, const 
                          .min = { FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX },
                          .max = { -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX } };
 
-#if defined(_OPENMP) && OPENMP_CUSTOM_REDUCTIONS
+#if defined(_OPENMP) && _CUSTOM_REDUCTIONS
 #pragma omp parallel default(none) if (size > 100)                       \
   dt_omp_firstprivate(cst_from, cst_to, profile, pixel, width, stride,   \
                       off_mul, off_add, box)                             \
   reduction(vstats : stats)
 #endif
   if(cst_from == IOP_CS_LAB && cst_to == IOP_CS_LCH)
-#if defined(_OPENMP) && OPENMP_CUSTOM_REDUCTIONS
+#if defined(_OPENMP) && _CUSTOM_REDUCTIONS
 #pragma omp for schedule(static)
 #endif
     for(size_t j = box[1]; j < box[3]; j++)
@@ -205,7 +210,7 @@ static void color_picker_helper_4ch(const dt_iop_buffer_dsc_t *const dsc, const 
       _color_picker_lch(stats.acc, stats.min, stats.max, pixel + offset, stride);
     }
   else if(cst_from == IOP_CS_RGB && cst_to == IOP_CS_HSL)
-#if defined(_OPENMP) && OPENMP_CUSTOM_REDUCTIONS
+#if defined(_OPENMP) && _CUSTOM_REDUCTIONS
 #pragma omp for schedule(static)
 #endif
     for(size_t j = box[1]; j < box[3]; j++)
@@ -214,7 +219,7 @@ static void color_picker_helper_4ch(const dt_iop_buffer_dsc_t *const dsc, const 
       _color_picker_hsl(stats.acc, stats.min, stats.max, pixel + offset, stride);
     }
   else if(cst_from == IOP_CS_RGB && cst_to == IOP_CS_JZCZHZ)
-#if defined(_OPENMP) && OPENMP_CUSTOM_REDUCTIONS
+#if defined(_OPENMP) && _CUSTOM_REDUCTIONS
 #pragma omp for schedule(static)
 #endif
     for(size_t j = box[1]; j < box[3]; j++)
@@ -228,7 +233,7 @@ static void color_picker_helper_4ch(const dt_iop_buffer_dsc_t *const dsc, const 
     if(cst_from != cst_to && cst_to != IOP_CS_NONE)
       dt_print(DT_DEBUG_DEV, "[color_picker_helper_4ch_parallel] unknown colorspace conversion from %d to %d\n", cst_from, cst_to);
 
-#if defined(_OPENMP) && OPENMP_CUSTOM_REDUCTIONS
+#if defined(_OPENMP) && _CUSTOM_REDUCTIONS
 #pragma omp for schedule(static)
 #endif
     for(size_t j = box[1]; j < box[3]; j++)
@@ -259,7 +264,7 @@ static void color_picker_helper_bayer(const dt_iop_buffer_dsc_t *const dsc, cons
                          .min = { FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX },
                          .max = { -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX } };
 
-#if defined(_OPENMP) && OPENMP_CUSTOM_REDUCTIONS
+#if defined(_OPENMP) && _CUSTOM_REDUCTIONS
 #pragma omp parallel for default(none) if (_box_size(box) > 100)        \
   dt_omp_firstprivate(pixel, width, roi, filters, box)                  \
   reduction(vstats : stats) reduction(vsum : weights)                   \
@@ -299,7 +304,7 @@ static void color_picker_helper_xtrans(const dt_iop_buffer_dsc_t *const dsc, con
                          .min = { FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX },
                          .max = { -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX } };
 
-#if defined(_OPENMP) && OPENMP_CUSTOM_REDUCTIONS
+#if defined(_OPENMP) && _CUSTOM_REDUCTIONS
 #pragma omp parallel for default(none) if (_box_size(box) > 100)        \
   dt_omp_firstprivate(pixel, width, roi, xtrans, box)                   \
   reduction(vstats : stats) reduction(vsum : weights)                   \

--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -32,7 +32,7 @@ static inline size_t _box_size(const int *const box)
 
 // define custom reduction operations to handle pixel stats/weights
 // we can't return an array from a function, so wrap the array type in a struct
-// FIXME: use lib_colorpicker_sample_statistics instead?
+// FIXME: use lib_colorpicker_sample_statistics instead? or do we need a locally allocated version of the data for the sake of speed?
 typedef struct _stats_pixel {
   dt_aligned_pixel_t acc, min, max;
 } _stats_pixel;
@@ -47,22 +47,23 @@ typedef struct _count_pixel { DT_ALIGNED_PIXEL uint32_t v[4]; } _count_pixel;
 
 #if defined(_OPENMP) && _CUSTOM_REDUCTIONS
 
-static inline _stats_pixel _reduce_stats_pixel(_stats_pixel stats, _stats_pixel newval)
+static inline _stats_pixel _reduce_stats(_stats_pixel stats, _stats_pixel newval)
 {
   for_four_channels(c)
   {
     stats.acc[c] += newval.acc[c];
-    stats.min[c] = fminf(stats.min[c], newval.min[c]);
-    stats.max[c] = fmaxf(stats.max[c], newval.max[c]);
+    stats.min[c] = MIN(stats.min[c], newval.min[c]);
+    stats.max[c] = MAX(stats.max[c], newval.max[c]);
   }
   return stats;
 }
-#pragma omp declare reduction(vstats:_stats_pixel:omp_out=_reduce_stats_pixel(omp_out,omp_in)) \
+#pragma omp declare reduction(vstats:_stats_pixel:omp_out=_reduce_stats(omp_out,omp_in)) \
   initializer(omp_priv = omp_orig)
 
 static inline _count_pixel _add_counts(_count_pixel acc, _count_pixel newval)
 {
-  for_each_channel(c) acc.v[c] += newval.v[c];
+  for_each_channel(c)
+    acc.v[c] += newval.v[c];
   return acc;
 }
 #pragma omp declare reduction(vsum:_count_pixel:omp_out=_add_counts(omp_out,omp_in)) \
@@ -96,26 +97,21 @@ static inline void rgb_to_JzCzhz(const dt_aligned_pixel_t rgb, dt_aligned_pixel_
   dt_JzAzBz_2_JzCzhz(JzAzBz, JzCzhz);
 }
 
-#ifdef _OPENMP
-#pragma omp declare simd aligned(avg, min, max, pixels: 16) uniform(width)
-#endif
-static inline void _color_picker_rgb_or_lab(dt_aligned_pixel_t avg, dt_aligned_pixel_t min, dt_aligned_pixel_t max,
+// FIXME: set these up as helpers as in common histogram code?
+static inline void _color_picker_rgb_or_lab(_stats_pixel *const stats,
                                             const float *const pixels, const size_t width)
 {
   for(size_t i = 0; i < width; i += 4)
-    for_each_channel(k)
+    for_each_channel(k, aligned(pixels:16))
     {
       const float v = pixels[i + k];
-      avg[k] += v;
-      min[k] = fminf(min[k], v);
-      max[k] = fmaxf(max[k], v);
+      stats->acc[k] += v;
+      stats->min[k] = MIN(stats->min[k], v);
+      stats->max[k] = MAX(stats->max[k], v);
     }
 }
 
-#ifdef _OPENMP
-#pragma omp declare simd aligned(avg, min, max, pixels: 16) uniform(width)
-#endif
-static inline void _color_picker_lch(dt_aligned_pixel_t avg, dt_aligned_pixel_t min, dt_aligned_pixel_t max,
+static inline void _color_picker_lch(_stats_pixel *const stats,
                                      const float *const pixels, const size_t width)
 {
   for(size_t i = 0; i < width; i += 4)
@@ -123,19 +119,16 @@ static inline void _color_picker_lch(dt_aligned_pixel_t avg, dt_aligned_pixel_t 
     dt_aligned_pixel_t pick;
     dt_Lab_2_LCH(pixels + i, pick);
     pick[3] = pick[2] < 0.5f ? pick[2] + 0.5f : pick[2] - 0.5f;
-    for_four_channels(k)
+    for_four_channels(k, aligned(pixels:16))
     {
-      avg[k] += pick[k];
-      min[k] = fminf(min[k], pick[k]);
-      max[k] = fmaxf(max[k], pick[k]);
+      stats->acc[k] += pick[k];
+      stats->min[k] = MIN(stats->min[k], pick[k]);
+      stats->max[k] = MAX(stats->max[k], pick[k]);
     }
   }
 }
 
-#ifdef _OPENMP
-#pragma omp declare simd aligned(avg, min, max, pixels: 16) uniform(width)
-#endif
-static inline void _color_picker_hsl(dt_aligned_pixel_t avg, dt_aligned_pixel_t min, dt_aligned_pixel_t max,
+static inline void _color_picker_hsl(_stats_pixel *const stats,
                                      const float *const pixels, const size_t width)
 {
   for(size_t i = 0; i < width; i += 4)
@@ -143,19 +136,16 @@ static inline void _color_picker_hsl(dt_aligned_pixel_t avg, dt_aligned_pixel_t 
     dt_aligned_pixel_t pick;
     dt_RGB_2_HSL(pixels + i, pick);
     pick[3] = pick[0] < 0.5f ? pick[0] + 0.5f : pick[0] - 0.5f;
-    for_four_channels(k)
+    for_four_channels(k, aligned(pixels:16))
     {
-      avg[k] += pick[k];
-      min[k] = fminf(min[k], pick[k]);
-      max[k] = fmaxf(max[k], pick[k]);
+      stats->acc[k] += pick[k];
+      stats->min[k] = MIN(stats->min[k], pick[k]);
+      stats->max[k] = MAX(stats->max[k], pick[k]);
     }
   }
 }
 
-#ifdef _OPENMP
-#pragma omp declare simd aligned(avg, min, max, pixels: 16) uniform(width, profile)
-#endif
-static inline void _color_picker_jzczhz(dt_aligned_pixel_t avg, dt_aligned_pixel_t min, dt_aligned_pixel_t max,
+static inline void _color_picker_jzczhz(_stats_pixel *const stats,
                                         const float *const pixels, const size_t width,
                                         const dt_iop_order_iccprofile_info_t *const profile)
 {
@@ -164,18 +154,17 @@ static inline void _color_picker_jzczhz(dt_aligned_pixel_t avg, dt_aligned_pixel
     dt_aligned_pixel_t pick;
     rgb_to_JzCzhz(pixels + i, pick, profile);
     pick[3] = pick[2] < 0.5f ? pick[2] + 0.5f : pick[2] - 0.5f;
-    for_four_channels(k)
+    for_four_channels(k, aligned(pixels:16))
     {
-      avg[k] += pick[k];
-      min[k] = fminf(min[k], pick[k]);
-      max[k] = fmaxf(max[k], pick[k]);
+      stats->acc[k] += pick[k];
+      stats->min[k] = MIN(stats->min[k], pick[k]);
+      stats->max[k] = MAX(stats->max[k], pick[k]);
     }
   }
 }
 
 static void color_picker_helper_4ch(const float *const pixel, const dt_iop_roi_t *const roi, const int *const box,
-                                    dt_aligned_pixel_t picked_color, dt_aligned_pixel_t picked_color_min,
-                                    dt_aligned_pixel_t picked_color_max,
+                                    lib_colorpicker_stats pick,
                                     const dt_iop_colorspace_type_t cst_from,
                                     const dt_iop_colorspace_type_t cst_to,
                                     const dt_iop_order_iccprofile_info_t *const profile)
@@ -193,6 +182,7 @@ static void color_picker_helper_4ch(const float *const pixel, const dt_iop_roi_t
 
   // cutoffs for using threads depends on # of samples and complexity
   // of the colorspace conversion
+  // FIXME: will this run faster if we use collapse(2)? will this take rejiggering of function calls?
   if(cst_from == IOP_CS_LAB && cst_to == IOP_CS_LCH)
   {
 #if defined(_OPENMP) && _CUSTOM_REDUCTIONS
@@ -203,7 +193,7 @@ static void color_picker_helper_4ch(const float *const pixel, const dt_iop_roi_t
     for(size_t j = box[1]; j < box[3]; j++)
     {
       const size_t offset = j * off_mul + off_add;
-      _color_picker_lch(stats.acc, stats.min, stats.max, pixel + offset, stride);
+      _color_picker_lch(&stats, pixel + offset, stride);
     }
   }
   else if(cst_from == IOP_CS_RGB && cst_to == IOP_CS_HSL)
@@ -216,7 +206,7 @@ static void color_picker_helper_4ch(const float *const pixel, const dt_iop_roi_t
     for(size_t j = box[1]; j < box[3]; j++)
     {
       const size_t offset = j * off_mul + off_add;
-      _color_picker_hsl(stats.acc, stats.min, stats.max, pixel + offset, stride);
+      _color_picker_hsl(&stats, pixel + offset, stride);
     }
   }
   else if(cst_from == IOP_CS_RGB && cst_to == IOP_CS_JZCZHZ)
@@ -229,7 +219,7 @@ static void color_picker_helper_4ch(const float *const pixel, const dt_iop_roi_t
     for(size_t j = box[1]; j < box[3]; j++)
     {
       const size_t offset = j * off_mul + off_add;
-      _color_picker_jzczhz(stats.acc, stats.min, stats.max, pixel + offset, stride, profile);
+      _color_picker_jzczhz(&stats, pixel + offset, stride, profile);
     }
   }
   else
@@ -246,22 +236,23 @@ static void color_picker_helper_4ch(const float *const pixel, const dt_iop_roi_t
     for(size_t j = box[1]; j < box[3]; j++)
     {
       const size_t offset = j * off_mul + off_add;
-      _color_picker_rgb_or_lab(stats.acc, stats.min, stats.max, pixel + offset, stride);
+      _color_picker_rgb_or_lab(&stats, pixel + offset, stride);
     }
   }
 
+  // copy all four channels, as four some colorspaces there may be
+  // meaningful data in the fourth pixel
   for_four_channels(c)
   {
-    picked_color[c] = stats.acc[c] / (float)size;
-    picked_color_min[c] = stats.min[c];
-    picked_color_max[c] = stats.max[c];
+    pick[DT_PICK_MEAN][c] = stats.acc[c] / (float)size;
+    pick[DT_PICK_MIN][c] = stats.min[c];
+    pick[DT_PICK_MAX][c] = stats.max[c];
   }
 }
 
 static void color_picker_helper_bayer(const dt_iop_buffer_dsc_t *const dsc, const float *const pixel,
                                       const dt_iop_roi_t *const roi, const int *const box,
-                                      dt_aligned_pixel_t picked_color, dt_aligned_pixel_t picked_color_min,
-                                      dt_aligned_pixel_t picked_color_max)
+                                      lib_colorpicker_stats pick)
 {
   const int width = roi->width;
   const uint32_t filters = dsc->filters;
@@ -282,27 +273,28 @@ static void color_picker_helper_bayer(const dt_iop_buffer_dsc_t *const dsc, cons
     for(size_t i = box[0]; i < box[2]; i++)
     {
       const int c = FC(j + roi->y, i + roi->x, filters);
+      // FIXME: fold into line below
       const size_t k = width * j + i;
 
       const float px = pixel[k];
 
       stats.acc[c] += px;
-      stats.min[c] = fminf(stats.min[c], px);
-      stats.max[c] = fmaxf(stats.max[c], px);
+      stats.min[c] = MIN(stats.min[c], px);
+      stats.max[c] = MAX(stats.max[c], px);
       weights.v[c]++;
     }
 
-  copy_pixel(picked_color_min, stats.min);
-  copy_pixel(picked_color_max, stats.max);
+  copy_pixel(pick[DT_PICK_MIN], stats.min);
+  copy_pixel(pick[DT_PICK_MAX], stats.max);
   // and finally normalize data. For bayer, there is twice as much green.
   for_each_channel(c)
-    picked_color[c] = weights.v[c] ? (stats.acc[c] / (float)weights.v[c]) : 0.0f;
+    pick[DT_PICK_MEAN][c] =
+      weights.v[c] ? (stats.acc[c] / (float)weights.v[c]) : 0.0f;
 }
 
 static void color_picker_helper_xtrans(const dt_iop_buffer_dsc_t *const dsc, const float *const pixel,
                                        const dt_iop_roi_t *const roi, const int *const box,
-                                       dt_aligned_pixel_t picked_color, dt_aligned_pixel_t picked_color_min,
-                                       dt_aligned_pixel_t picked_color_max)
+                                       lib_colorpicker_stats pick)
 {
   const int width = roi->width;
   const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])dsc->xtrans;
@@ -323,28 +315,31 @@ static void color_picker_helper_xtrans(const dt_iop_buffer_dsc_t *const dsc, con
     for(size_t i = box[0]; i < box[2]; i++)
     {
       const int c = FCxtrans(j, i, roi, xtrans);
+      // FIXME: fold into line below
       const size_t k = width * j + i;
 
       const float px = pixel[k];
 
       stats.acc[c] += px;
-      stats.min[c] = fminf(stats.min[c], px);
-      stats.max[c] = fmaxf(stats.max[c], px);
+      stats.min[c] = MIN(stats.min[c], px);
+      stats.max[c] = MAX(stats.max[c], px);
       weights.v[c]++;
     }
 
-  copy_pixel(picked_color_min, stats.min);
-  copy_pixel(picked_color_max, stats.max);
+  copy_pixel(pick[DT_PICK_MIN], stats.min);
+  copy_pixel(pick[DT_PICK_MAX], stats.max);
   // and finally normalize data.
   // X-Trans RGB weighting averages to 2:5:2 for each 3x3 cell
   for_each_channel(c)
-    picked_color[c] = weights.v[c] ? (stats.acc[c] / (float)weights.v[c]) : 0.0f;
+    pick[DT_PICK_MEAN][c] =
+      weights.v[c] ? (stats.acc[c] / (float)weights.v[c]) : 0.0f;
 }
 
 // picked_color, picked_color_min and picked_color_max should be aligned
-void dt_color_picker_helper(const dt_iop_buffer_dsc_t *dsc, const float *const pixel, const dt_iop_roi_t *roi,
-                            const int *const box, dt_aligned_pixel_t picked_color, dt_aligned_pixel_t picked_color_min,
-                            dt_aligned_pixel_t picked_color_max, const dt_iop_colorspace_type_t image_cst,
+void dt_color_picker_helper(const dt_iop_buffer_dsc_t *dsc, const float *const pixel,
+                            const dt_iop_roi_t *roi, const int *const box,
+                            lib_colorpicker_stats pick,
+                            const dt_iop_colorspace_type_t image_cst,
                             const dt_iop_colorspace_type_t picker_cst,
                             const dt_iop_order_iccprofile_info_t *const profile)
 {
@@ -360,24 +355,22 @@ void dt_color_picker_helper(const dt_iop_buffer_dsc_t *dsc, const float *const p
 
     // blur without clipping negatives because Lab a and b channels can be legitimately negative
     // FIXME: this blurs whole image even when just a bit is sampled
+    // FIXME: if multiple samples are made, the blur is called each time -- instead if this is to even happen outside of per-module, do this once
+    // FIXME: if this is done in pixelpipe, we should have a spare buffer (output) to write this into, hence can skip the alloc above, and all do this on the input to filmic
     blur_2D_Bspline(pixel, denoised, tempbuf, roi->width, roi->height, 1, FALSE);
 
-    color_picker_helper_4ch(denoised, roi, box,
-                            picked_color, picked_color_min, picked_color_max,
-                            image_cst, picker_cst, profile);
+    color_picker_helper_4ch(denoised, roi, box, pick, image_cst, picker_cst, profile);
 
     dt_free_align(denoised);
     dt_free_align(tempbuf);
   }
   else if(dsc->channels == 1u && dsc->filters != 0u && dsc->filters != 9u)
   {
-    color_picker_helper_bayer(dsc, pixel, roi, box, picked_color,
-                              picked_color_min, picked_color_max);
+    color_picker_helper_bayer(dsc, pixel, roi, box, pick);
   }
   else if(dsc->channels == 1u && dsc->filters == 9u)
   {
-    color_picker_helper_xtrans(dsc, pixel, roi, box, picked_color,
-                               picked_color_min, picked_color_max);
+    color_picker_helper_xtrans(dsc, pixel, roi, box, pick);
   }
   else
     dt_unreachable_codepath();

--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -187,9 +187,9 @@ static void color_picker_helper_4ch(const dt_iop_buffer_dsc_t *const dsc, const 
   const size_t off_mul = 4 * width;
   const size_t off_add = 4 * box[0];
 
-  _aligned_pixel macc = { { *picked_color } };
-  _aligned_pixel mmin = { { *picked_color_min } };
-  _aligned_pixel mmax = { { *picked_color_max } };
+  _aligned_pixel macc = { { 0.0f, 0.0f, 0.0f, 0.0f } };
+  _aligned_pixel mmin = { { FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX } };
+  _aligned_pixel mmax = { { -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX } };
 
 #ifdef OPENMP_CUSTOM_REDUCTIONS
 #pragma omp parallel default(none) if (size > 100)                       \
@@ -258,9 +258,9 @@ static void color_picker_helper_bayer(const dt_iop_buffer_dsc_t *const dsc, cons
   const uint32_t filters = dsc->filters;
 
   _aligned_vec_uint weights = { { 0u, 0u, 0u, 0u } };
-  _aligned_pixel macc = { { *picked_color } };
-  _aligned_pixel mmin = { { *picked_color_min } };
-  _aligned_pixel mmax = { { *picked_color_max } };
+  _aligned_pixel macc = { { 0.0f, 0.0f, 0.0f, 0.0f } };
+  _aligned_pixel mmin = { { FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX } };
+  _aligned_pixel mmax = { { -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX } };
 
 #ifdef OPENMP_CUSTOM_REDUCTIONS
 #pragma omp parallel for default(none) if (size > 100)                   \
@@ -304,9 +304,9 @@ static void color_picker_helper_xtrans(const dt_iop_buffer_dsc_t *const dsc, con
   const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])dsc->xtrans;
 
   _aligned_vec_uint weights = { { 0u, 0u, 0u, 0u } };
-  _aligned_pixel macc = { { *picked_color } };
-  _aligned_pixel mmin = { { *picked_color_min } };
-  _aligned_pixel mmax = { { *picked_color_max } };
+  _aligned_pixel macc = { { 0.0f, 0.0f, 0.0f, 0.0f } };
+  _aligned_pixel mmin = { { FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX } };
+  _aligned_pixel mmax = { { -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX } };
 
 #ifdef OPENMP_CUSTOM_REDUCTIONS
 #pragma omp parallel for default(none) if (size > 100)                   \

--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -252,7 +252,6 @@ static void color_picker_helper_bayer(const dt_iop_buffer_dsc_t *const dsc, cons
                                       dt_aligned_pixel_t picked_color_max)
 {
   const int width = roi->width;
-  const size_t size = _box_size(box);
   const uint32_t filters = dsc->filters;
 
   _count_pixel weights = { { 0u, 0u, 0u, 0u } };
@@ -261,9 +260,9 @@ static void color_picker_helper_bayer(const dt_iop_buffer_dsc_t *const dsc, cons
                          .max = { -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX } };
 
 #if defined(_OPENMP) && OPENMP_CUSTOM_REDUCTIONS
-#pragma omp parallel for default(none) if (size > 100)                   \
-  dt_omp_firstprivate(pixel, width, roi, filters, box)                   \
-  reduction(vstats : stats) reduction(vsum : weights)                    \
+#pragma omp parallel for default(none) if (_box_size(box) > 100)        \
+  dt_omp_firstprivate(pixel, width, roi, filters, box)                  \
+  reduction(vstats : stats) reduction(vsum : weights)                   \
   schedule(static)
 #endif
   for(size_t j = box[1]; j < box[3]; j++)
@@ -293,7 +292,6 @@ static void color_picker_helper_xtrans(const dt_iop_buffer_dsc_t *const dsc, con
                                        dt_aligned_pixel_t picked_color_max)
 {
   const int width = roi->width;
-  const size_t size = _box_size(box);
   const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])dsc->xtrans;
 
   _count_pixel weights = { { 0u, 0u, 0u, 0u } };
@@ -302,9 +300,9 @@ static void color_picker_helper_xtrans(const dt_iop_buffer_dsc_t *const dsc, con
                          .max = { -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX } };
 
 #if defined(_OPENMP) && OPENMP_CUSTOM_REDUCTIONS
-#pragma omp parallel for default(none) if (size > 100)                   \
-  dt_omp_firstprivate(pixel, width, roi, xtrans, box)                    \
-  reduction(vstats : stats) reduction(vsum : weights)                    \
+#pragma omp parallel for default(none) if (_box_size(box) > 100)        \
+  dt_omp_firstprivate(pixel, width, roi, xtrans, box)                   \
+  reduction(vstats : stats) reduction(vsum : weights)                   \
   schedule(static)
 #endif
   for(size_t j = box[1]; j < box[3]; j++)

--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -273,11 +273,7 @@ static void color_picker_helper_bayer(const dt_iop_buffer_dsc_t *const dsc, cons
     for(size_t i = box[0]; i < box[2]; i++)
     {
       const int c = FC(j + roi->y, i + roi->x, filters);
-      // FIXME: fold into line below
-      const size_t k = width * j + i;
-
-      const float px = pixel[k];
-
+      const float px = pixel[width * j + i];
       stats.acc[c] += px;
       stats.min[c] = MIN(stats.min[c], px);
       stats.max[c] = MAX(stats.max[c], px);
@@ -315,11 +311,7 @@ static void color_picker_helper_xtrans(const dt_iop_buffer_dsc_t *const dsc, con
     for(size_t i = box[0]; i < box[2]; i++)
     {
       const int c = FCxtrans(j, i, roi, xtrans);
-      // FIXME: fold into line below
-      const size_t k = width * j + i;
-
-      const float px = pixel[k];
-
+      const float px = pixel[width * j + i];
       stats.acc[c] += px;
       stats.min[c] = MIN(stats.min[c], px);
       stats.max[c] = MAX(stats.max[c], px);

--- a/src/common/color_picker.h
+++ b/src/common/color_picker.h
@@ -19,14 +19,15 @@
 #pragma once
 
 #include "common/iop_profile.h"
+#include "libs/colorpicker.h"
 
 struct dt_iop_buffer_dsc_t;
 struct dt_iop_roi_t;
 enum dt_iop_colorspace_type_t;
 
 void dt_color_picker_helper(const struct dt_iop_buffer_dsc_t *dsc, const float *const pixel,
-                            const struct dt_iop_roi_t *roi, const int *const box, dt_aligned_pixel_t picked_color,
-                            dt_aligned_pixel_t picked_color_min, dt_aligned_pixel_t picked_color_max,
+                            const struct dt_iop_roi_t *roi, const int *const box,
+                            lib_colorpicker_stats pick,
                             const enum dt_iop_colorspace_type_t image_cst,
                             const enum dt_iop_colorspace_type_t picker_cst,
                             const dt_iop_order_iccprofile_info_t *const profile);

--- a/src/common/color_picker.h
+++ b/src/common/color_picker.h
@@ -27,6 +27,7 @@ enum dt_iop_colorspace_type_t;
 
 void dt_color_picker_helper(const struct dt_iop_buffer_dsc_t *dsc, const float *const pixel,
                             const struct dt_iop_roi_t *roi, const int *const box,
+                            const gboolean denoise,
                             lib_colorpicker_stats pick,
                             const enum dt_iop_colorspace_type_t image_cst,
                             const enum dt_iop_colorspace_type_t picker_cst,

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2146,11 +2146,11 @@ void dt_iop_gui_init_blendif(GtkWidget *blendw, dt_iop_module_t *module)
     gtk_box_pack_start(GTK_BOX(header), gtk_label_new(""),
                        FALSE, FALSE, DT_PIXEL_APPLY_DPI(10));
 
-    bd->colorpicker = dt_color_picker_new(module, DT_COLOR_PICKER_POINT_AREA, header);
+    bd->colorpicker = dt_color_picker_new(module, DT_COLOR_PICKER_POINT_AREA | DT_COLOR_PICKER_IO, header);
     gtk_widget_set_tooltip_text(bd->colorpicker, _("pick GUI color from image\nctrl+click or right-click to select an area"));
     gtk_widget_set_name(bd->colorpicker, "keep-active");
 
-    bd->colorpicker_set_values = dt_color_picker_new(module, DT_COLOR_PICKER_AREA, header);
+    bd->colorpicker_set_values = dt_color_picker_new(module, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_IO, header);
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(bd->colorpicker_set_values),
                                  dtgtk_cairo_paint_colorpicker_set_values, 0, NULL);
     dt_gui_add_class(bd->colorpicker_set_values, "dt_transparent_background");

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -619,6 +619,7 @@ static int _pixelpipe_picker_box(dt_iop_module_t *module, const dt_iop_roi_t *ro
 {
   if(picker_source == PIXELPIPE_PICKER_OUTPUT && !sample->pick_output)
     return 1;
+
   const float wd = darktable.develop->preview_pipe->backbuf_width;
   const float ht = darktable.develop->preview_pipe->backbuf_height;
   const int width = roi->width;
@@ -831,12 +832,9 @@ static void _pixelpipe_pick_samples(dt_develop_t *dev, dt_iop_module_t *module,
        !_pixelpipe_picker_box(module, roi_in, sample, PIXELPIPE_PICKER_INPUT, box))
     {
       // pixel input is in display profile, hence the sample output will be as well
-      // FIXME: previously we used special purpose code here, but the generic color picker code blurs the image -- do we want to keep this behavior? and similarly if we *do* want to blur the image, should we do this once rather than once for each sample?
       dt_color_picker_helper(dsc, input, roi_in, box, sample->denoise,
                              sample->display,
-                             IOP_CS_RGB, IOP_CS_RGB,
-                             // FIXME: this is ignored, just use NULL?
-                             histogram_profile);
+                             IOP_CS_RGB, IOP_CS_RGB, display_profile);
 
       // NOTE: conversions assume that dt_aligned_pixel_t[x] has no
       // padding, e.g. is equivalent to float[x*4], and that on failure

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -700,7 +700,9 @@ static void _pixelpipe_picker(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *p
   {
     const dt_iop_order_iccprofile_info_t *const profile =
       dt_ioppr_get_pipe_current_profile_info(module, piece->pipe);
-    dt_color_picker_helper(dsc, pixel, roi, box, pick, image_cst,
+    dt_color_picker_helper(dsc, pixel, roi, box,
+                           darktable.lib->proxy.colorpicker.primary_sample->denoise,
+                           pick, image_cst,
                            dt_iop_color_picker_get_active_cst(module), profile);
   }
 
@@ -779,7 +781,9 @@ static void _pixelpipe_picker_cl(int devid, dt_iop_module_t *module, dt_dev_pixe
       { -INFINITY, -INFINITY, -INFINITY, -INFINITY } };
 
   const dt_iop_order_iccprofile_info_t *const profile = dt_ioppr_get_pipe_current_profile_info(module, piece->pipe);
-  dt_color_picker_helper(dsc, pixel, &roi_copy, box, pick, image_cst,
+  dt_color_picker_helper(dsc, pixel, &roi_copy, box,
+                         darktable.lib->proxy.colorpicker.primary_sample->denoise,
+                         pick, image_cst,
                          dt_iop_color_picker_get_active_cst(module), profile);
 
   for_four_channels(k)
@@ -826,7 +830,7 @@ static void _pixelpipe_pick_samples(dt_develop_t *dev, dt_iop_module_t *module,
     {
       // pixel input is in display profile, hence the sample output will be as well
       // FIXME: previously we used special purpose code here, but the generic color picker code blurs the image -- do we want to keep this behavior? and similarly if we *do* want to blur the image, should we do this once rather than once for each sample?
-      dt_color_picker_helper(dsc, input, roi_in, box,
+      dt_color_picker_helper(dsc, input, roi_in, box, sample->denoise,
                              sample->display,
                              IOP_CS_RGB, IOP_CS_RGB,
                              // FIXME: this is ignored, just use NULL?

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -617,6 +617,8 @@ static int _pixelpipe_picker_box(dt_iop_module_t *module, const dt_iop_roi_t *ro
                                  const dt_colorpicker_sample_t *const sample,
                                  dt_pixelpipe_picker_source_t picker_source, int *box)
 {
+  if(picker_source == PIXELPIPE_PICKER_OUTPUT && !sample->pick_output)
+    return 1;
   const float wd = darktable.develop->preview_pipe->backbuf_width;
   const float ht = darktable.develop->preview_pipe->backbuf_height;
   const int width = roi->width;
@@ -826,7 +828,7 @@ static void _pixelpipe_pick_samples(dt_develop_t *dev, dt_iop_module_t *module,
     int box[4];
     dt_colorpicker_sample_t *sample = samples->data;
     if(!sample->locked &&
-       !_pixelpipe_picker_box(module, roi_in, sample, PIXELPIPE_PICKER_OUTPUT, box))
+       !_pixelpipe_picker_box(module, roi_in, sample, PIXELPIPE_PICKER_INPUT, box))
     {
       // pixel input is in display profile, hence the sample output will be as well
       // FIXME: previously we used special purpose code here, but the generic color picker code blurs the image -- do we want to keep this behavior? and similarly if we *do* want to blur the image, should we do this once rather than once for each sample?

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -133,7 +133,7 @@ void dt_iop_color_picker_reset(dt_iop_module_t *module, gboolean keep)
 }
 
 static void _init_picker(dt_iop_color_picker_t *picker, dt_iop_module_t *module,
-                         dt_iop_color_picker_kind_t kind, GtkWidget *button)
+                         dt_iop_color_picker_flags_t kind, GtkWidget *button)
 {
   // module is NULL if primary colorpicker
   picker->module     = module;
@@ -172,9 +172,10 @@ static gboolean _color_picker_callback_button_press(GtkWidget *button, GdkEventB
 
   const GdkModifierType state = e != NULL ? e->state : dt_key_modifier_state();
   const gboolean ctrl_key_pressed = dt_modifier_is(state, GDK_CONTROL_MASK) || (e != NULL && e->button == 3);
-  dt_iop_color_picker_kind_t kind = self->kind;
+  dt_iop_color_picker_flags_t kind = self->kind;
 
-  if(prior_picker != self || (kind == DT_COLOR_PICKER_POINT_AREA &&
+  if(prior_picker != self ||
+     (((kind & DT_COLOR_PICKER_POINT) && (kind & DT_COLOR_PICKER_AREA)) &&
       (ctrl_key_pressed ^ (darktable.lib->proxy.colorpicker.primary_sample->size == DT_LIB_COLORPICKER_SIZE_BOX))))
   {
     darktable.lib->proxy.colorpicker.picker_proxy = self;
@@ -182,7 +183,7 @@ static gboolean _color_picker_callback_button_press(GtkWidget *button, GdkEventB
     if(module)
       module->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
 
-    if(kind == DT_COLOR_PICKER_POINT_AREA)
+    if((kind & DT_COLOR_PICKER_POINT) && (kind & DT_COLOR_PICKER_AREA))
     {
       kind = ctrl_key_pressed ? DT_COLOR_PICKER_AREA : DT_COLOR_PICKER_POINT;
     }
@@ -329,7 +330,7 @@ void dt_iop_color_picker_cleanup(void)
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_color_picker_proxy_preview_pipe_callback), NULL);
 }
 
-static GtkWidget *_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_kind_t kind, GtkWidget *w,
+static GtkWidget *_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_flags_t kind, GtkWidget *w,
                                     const gboolean init_cst, const dt_iop_colorspace_type_t cst)
 {
   dt_iop_color_picker_t *color_picker = (dt_iop_color_picker_t *)g_malloc(sizeof(dt_iop_color_picker_t));
@@ -361,12 +362,12 @@ static GtkWidget *_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker
   }
 }
 
-GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_kind_t kind, GtkWidget *w)
+GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_flags_t kind, GtkWidget *w)
 {
   return _color_picker_new(module, kind, w, FALSE, IOP_CS_NONE);
 }
 
-GtkWidget *dt_color_picker_new_with_cst(dt_iop_module_t *module, dt_iop_color_picker_kind_t kind, GtkWidget *w,
+GtkWidget *dt_color_picker_new_with_cst(dt_iop_module_t *module, dt_iop_color_picker_flags_t kind, GtkWidget *w,
                                         const dt_iop_colorspace_type_t cst)
 {
   return _color_picker_new(module, kind, w, TRUE, cst);

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -188,12 +188,13 @@ static gboolean _color_picker_callback_button_press(GtkWidget *button, GdkEventB
       kind = ctrl_key_pressed ? DT_COLOR_PICKER_AREA : DT_COLOR_PICKER_POINT;
     }
     // pull picker's last recorded positions
-    if(kind == DT_COLOR_PICKER_AREA)
+    if(kind & DT_COLOR_PICKER_AREA)
       dt_lib_colorpicker_set_box_area(darktable.lib, self->pick_box);
-    else if(kind == DT_COLOR_PICKER_POINT)
+    else if(kind & DT_COLOR_PICKER_POINT)
       dt_lib_colorpicker_set_point(darktable.lib, self->pick_pos);
     else
       dt_unreachable_codepath();
+    dt_lib_colorpicker_set_denoise(darktable.lib, kind & DT_COLOR_PICKER_DENOISE);
 
     // important to have set up state before toggling button and
     // triggering more callbacks

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -133,11 +133,11 @@ void dt_iop_color_picker_reset(dt_iop_module_t *module, gboolean keep)
 }
 
 static void _init_picker(dt_iop_color_picker_t *picker, dt_iop_module_t *module,
-                         dt_iop_color_picker_flags_t kind, GtkWidget *button)
+                         dt_iop_color_picker_flags_t flags, GtkWidget *button)
 {
   // module is NULL if primary colorpicker
   picker->module     = module;
-  picker->kind       = kind;
+  picker->flags      = flags;
   picker->picker_cst = module ? module->default_colorspace(module, NULL, NULL) : IOP_CS_NONE;
   picker->colorpick  = button;
   picker->changed    = FALSE;
@@ -171,22 +171,26 @@ static gboolean _color_picker_callback_button_press(GtkWidget *button, GdkEventB
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), TRUE);
 
   const GdkModifierType state = e != NULL ? e->state : dt_key_modifier_state();
-  const gboolean ctrl_key_pressed = dt_modifier_is(state, GDK_CONTROL_MASK) || (e != NULL && e->button == 3);
-  dt_iop_color_picker_flags_t kind = self->kind;
+  const gboolean to_area_mode =
+    dt_modifier_is(state, GDK_CONTROL_MASK) || (e != NULL && e->button == 3);
+  dt_iop_color_picker_flags_t flags = self->flags;
 
-  if(prior_picker != self ||
-     (((kind & DT_COLOR_PICKER_POINT) && (kind & DT_COLOR_PICKER_AREA)) &&
-      (ctrl_key_pressed ^ (darktable.lib->proxy.colorpicker.primary_sample->size == DT_LIB_COLORPICKER_SIZE_BOX))))
+  // setup if a new picker or switching between point/area mode
+  if(prior_picker != self
+     || (((flags & DT_COLOR_PICKER_POINT_AREA) == DT_COLOR_PICKER_POINT_AREA)
+         && (to_area_mode !=
+             (darktable.lib->proxy.colorpicker.primary_sample->size ==
+              DT_LIB_COLORPICKER_SIZE_BOX))))
   {
     darktable.lib->proxy.colorpicker.picker_proxy = self;
 
     if(module)
       module->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
 
-    if((kind & DT_COLOR_PICKER_POINT) && (kind & DT_COLOR_PICKER_AREA))
-    {
-      kind = ctrl_key_pressed ? DT_COLOR_PICKER_AREA : DT_COLOR_PICKER_POINT;
-    }
+    // set point or area mode without stomping on any other flags
+    dt_iop_color_picker_flags_t kind = self->flags & DT_COLOR_PICKER_POINT_AREA;
+    if(kind == DT_COLOR_PICKER_POINT_AREA)
+      kind = to_area_mode ? DT_COLOR_PICKER_AREA : DT_COLOR_PICKER_POINT;
     // pull picker's last recorded positions
     if(kind & DT_COLOR_PICKER_AREA)
       dt_lib_colorpicker_set_box_area(darktable.lib, self->pick_box);
@@ -194,7 +198,8 @@ static gboolean _color_picker_callback_button_press(GtkWidget *button, GdkEventB
       dt_lib_colorpicker_set_point(darktable.lib, self->pick_pos);
     else
       dt_unreachable_codepath();
-    dt_lib_colorpicker_set_denoise(darktable.lib, kind & DT_COLOR_PICKER_DENOISE);
+
+    dt_lib_colorpicker_set_denoise(darktable.lib, flags & DT_COLOR_PICKER_DENOISE);
 
     // important to have set up state before toggling button and
     // triggering more callbacks
@@ -331,7 +336,7 @@ void dt_iop_color_picker_cleanup(void)
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_color_picker_proxy_preview_pipe_callback), NULL);
 }
 
-static GtkWidget *_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_flags_t kind, GtkWidget *w,
+static GtkWidget *_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_flags_t flags, GtkWidget *w,
                                     const gboolean init_cst, const dt_iop_colorspace_type_t cst)
 {
   dt_iop_color_picker_t *color_picker = (dt_iop_color_picker_t *)g_malloc(sizeof(dt_iop_color_picker_t));
@@ -340,7 +345,7 @@ static GtkWidget *_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker
   {
     GtkWidget *button = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, 0, NULL);
     dt_gui_add_class(button, "dt_transparent_background");
-    _init_picker(color_picker, module, kind, button);
+    _init_picker(color_picker, module, flags, button);
     if(init_cst)
       color_picker->picker_cst = cst;
     g_signal_connect_data(G_OBJECT(button), "button-press-event",
@@ -353,7 +358,7 @@ static GtkWidget *_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker
   {
     dt_bauhaus_widget_set_quad_paint(w, dtgtk_cairo_paint_colorpicker, 0, NULL);
     dt_bauhaus_widget_set_quad_toggle(w, TRUE);
-    _init_picker(color_picker, module, kind, w);
+    _init_picker(color_picker, module, flags, w);
     if(init_cst)
       color_picker->picker_cst = cst;
     g_signal_connect_data(G_OBJECT(w), "quad-pressed",
@@ -363,15 +368,15 @@ static GtkWidget *_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker
   }
 }
 
-GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_flags_t kind, GtkWidget *w)
+GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_flags_t flags, GtkWidget *w)
 {
-  return _color_picker_new(module, kind, w, FALSE, IOP_CS_NONE);
+  return _color_picker_new(module, flags, w, FALSE, IOP_CS_NONE);
 }
 
-GtkWidget *dt_color_picker_new_with_cst(dt_iop_module_t *module, dt_iop_color_picker_flags_t kind, GtkWidget *w,
+GtkWidget *dt_color_picker_new_with_cst(dt_iop_module_t *module, dt_iop_color_picker_flags_t flags, GtkWidget *w,
                                         const dt_iop_colorspace_type_t cst)
 {
-  return _color_picker_new(module, kind, w, TRUE, cst);
+  return _color_picker_new(module, flags, w, TRUE, cst);
 }
 
 // clang-format off

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -199,7 +199,9 @@ static gboolean _color_picker_callback_button_press(GtkWidget *button, GdkEventB
     else
       dt_unreachable_codepath();
 
-    dt_lib_colorpicker_set_denoise(darktable.lib, flags & DT_COLOR_PICKER_DENOISE);
+    dt_lib_colorpicker_setup(darktable.lib,
+                             flags & DT_COLOR_PICKER_DENOISE,
+                             flags & DT_COLOR_PICKER_IO);
 
     // important to have set up state before toggling button and
     // triggering more callbacks

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -37,7 +37,9 @@ typedef enum _iop_color_picker_flags_t
   DT_COLOR_PICKER_AREA = 1 << 1,
   DT_COLOR_PICKER_POINT_AREA = DT_COLOR_PICKER_POINT | DT_COLOR_PICKER_AREA,
   // only works with 4-channel images
-  DT_COLOR_PICKER_DENOISE = 1 << 2
+  DT_COLOR_PICKER_DENOISE = 1 << 2,
+  // all pickers sample input, only ones with this flag set sample output
+  DT_COLOR_PICKER_IO = 1 << 3
 } dt_iop_color_picker_flags_t;
 
 typedef struct dt_iop_color_picker_t

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -44,7 +44,7 @@ typedef struct dt_iop_color_picker_t
 {
   // iop which contains this picker, or NULL if primary colorpicker
   dt_iop_module_t *module;
-  dt_iop_color_picker_flags_t kind;
+  dt_iop_color_picker_flags_t flags;
   /** requested colorspace for the color picker, valid options are:
    * IOP_CS_NONE: module colorspace
    * IOP_CS_LCH: for Lab modules
@@ -80,10 +80,10 @@ void dt_iop_color_picker_init();
 void dt_iop_color_picker_cleanup();
 
 /* link color picker to widget */
-GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_flags_t kind, GtkWidget *w);
+GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_flags_t flags, GtkWidget *w);
 
 /* link color picker to widget and initialize color picker color space with given value */
-GtkWidget *dt_color_picker_new_with_cst(dt_iop_module_t *module, dt_iop_color_picker_flags_t kind, GtkWidget *w,
+GtkWidget *dt_color_picker_new_with_cst(dt_iop_module_t *module, dt_iop_color_picker_flags_t flags, GtkWidget *w,
                                         const dt_iop_colorspace_type_t cst);
 
 // clang-format off

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -30,19 +30,19 @@
 #include <gtk/gtk.h>
 #include "develop/imageop.h"
 
-typedef enum _iop_color_picker_kind_t
+typedef enum _iop_color_picker_flags_t
 {
-  DT_COLOR_PICKER_POINT = 0,
-  // FIXME: s/AREA/BOX/
-  DT_COLOR_PICKER_AREA,
-  DT_COLOR_PICKER_POINT_AREA // allow the user to select between point and area
-} dt_iop_color_picker_kind_t;
+  // at least one of point or area must be used
+  DT_COLOR_PICKER_POINT = 1 << 0,
+  DT_COLOR_PICKER_AREA = 1 << 1,
+  DT_COLOR_PICKER_POINT_AREA = DT_COLOR_PICKER_POINT | DT_COLOR_PICKER_AREA
+} dt_iop_color_picker_flags_t;
 
 typedef struct dt_iop_color_picker_t
 {
   // iop which contains this picker, or NULL if primary colorpicker
   dt_iop_module_t *module;
-  dt_iop_color_picker_kind_t kind;
+  dt_iop_color_picker_flags_t kind;
   /** requested colorspace for the color picker, valid options are:
    * IOP_CS_NONE: module colorspace
    * IOP_CS_LCH: for Lab modules
@@ -78,10 +78,10 @@ void dt_iop_color_picker_init();
 void dt_iop_color_picker_cleanup();
 
 /* link color picker to widget */
-GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_kind_t kind, GtkWidget *w);
+GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_flags_t kind, GtkWidget *w);
 
 /* link color picker to widget and initialize color picker color space with given value */
-GtkWidget *dt_color_picker_new_with_cst(dt_iop_module_t *module, dt_iop_color_picker_kind_t kind, GtkWidget *w,
+GtkWidget *dt_color_picker_new_with_cst(dt_iop_module_t *module, dt_iop_color_picker_flags_t kind, GtkWidget *w,
                                         const dt_iop_colorspace_type_t cst);
 
 // clang-format off

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -35,7 +35,9 @@ typedef enum _iop_color_picker_flags_t
   // at least one of point or area must be used
   DT_COLOR_PICKER_POINT = 1 << 0,
   DT_COLOR_PICKER_AREA = 1 << 1,
-  DT_COLOR_PICKER_POINT_AREA = DT_COLOR_PICKER_POINT | DT_COLOR_PICKER_AREA
+  DT_COLOR_PICKER_POINT_AREA = DT_COLOR_PICKER_POINT | DT_COLOR_PICKER_AREA,
+  // only works with 4-channel images
+  DT_COLOR_PICKER_DENOISE = 1 << 2
 } dt_iop_color_picker_flags_t;
 
 typedef struct dt_iop_color_picker_t

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -836,9 +836,9 @@ static void _draw_color_picker(dt_iop_module_t *self, cairo_t *cr, dt_iop_colorz
           // this functions need a 4c image
           for(int k = 0; k < 3; k++)
           {
-            pick_mean[k] = sample->scope[DT_LIB_COLORPICKER_STATISTIC_MEAN][k];
-            pick_min[k] = sample->scope[DT_LIB_COLORPICKER_STATISTIC_MIN][k];
-            pick_max[k] = sample->scope[DT_LIB_COLORPICKER_STATISTIC_MAX][k];
+            pick_mean[k] = sample->scope[DT_PICK_MEAN][k];
+            pick_min[k] = sample->scope[DT_PICK_MIN][k];
+            pick_max[k] = sample->scope[DT_PICK_MAX][k];
           }
           pick_mean[3] = pick_min[3] = pick_max[3] = 1.f;
 

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1585,7 +1585,8 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->grey_point_source, _("adjust to match the average luminance of the subject.\n"
                                                       "except in back-lighting situations, this should be around 18%."));
   g_signal_connect(G_OBJECT(g->grey_point_source), "value-changed", G_CALLBACK(grey_point_source_callback), self);
-  dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->grey_point_source);
+  dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE,
+                      g->grey_point_source);
 
   // White slider
   g->white_point_source = dt_bauhaus_slider_new_with_range(self, 0.0, 16.0, 0, p->white_point_source, 2);
@@ -1597,7 +1598,8 @@ void gui_init(dt_iop_module_t *self)
                                                        "this is a reading a lightmeter would give you on the scene.\n"
                                                        "adjust so highlights clipping is avoided"));
   g_signal_connect(G_OBJECT(g->white_point_source), "value-changed", G_CALLBACK(white_point_source_callback), self);
-  dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->white_point_source);
+  dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE,
+                      g->white_point_source);
 
   // Black slider
   g->black_point_source = dt_bauhaus_slider_new_with_range(self, -16.0, -0.1, 0, p->black_point_source, 2);
@@ -1609,7 +1611,8 @@ void gui_init(dt_iop_module_t *self)
                                                        "this is a reading a lightmeter would give you on the scene.\n"
                                                        "increase to get more contrast.\ndecrease to recover more details in low-lights."));
   g_signal_connect(G_OBJECT(g->black_point_source), "value-changed", G_CALLBACK(black_point_source_callback), self);
-  dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->black_point_source);
+  dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE,
+                      g->black_point_source);
 
   // Security factor
   g->security_factor = dt_bauhaus_slider_new_with_range(self, -50., 50., 0, p->security_factor, 2);
@@ -1623,7 +1626,8 @@ void gui_init(dt_iop_module_t *self)
   // Auto tune slider
   g->auto_button = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->auto_button, NULL, N_("auto tune levels"));
-  dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->auto_button);
+  dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE,
+                      g->auto_button);
   gtk_widget_set_tooltip_text(g->auto_button, _("try to optimize the settings with some guessing.\n"
                                                 "this will fit the luminance range inside the histogram bounds.\n"
                                                 "works better for landscapes and evenly-lit pictures\nbut fails for high-keys and low-keys." ));

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -4206,7 +4206,8 @@ void gui_init(dt_iop_module_t *self)
   self->widget = dt_ui_notebook_page(g->notebook, N_("scene"), NULL);
 
   g->grey_point_source
-      = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "grey_point_source"));
+      = dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE,
+                            dt_bauhaus_slider_from_params(self, "grey_point_source"));
   dt_bauhaus_slider_set_soft_range(g->grey_point_source, .1, 36.0);
   dt_bauhaus_slider_set_format(g->grey_point_source, "%");
   gtk_widget_set_tooltip_text(g->grey_point_source,
@@ -4217,7 +4218,8 @@ void gui_init(dt_iop_module_t *self)
 
   // White slider
   g->white_point_source
-      = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "white_point_source"));
+      = dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE,
+                            dt_bauhaus_slider_from_params(self, "white_point_source"));
   dt_bauhaus_slider_set_soft_range(g->white_point_source, 2.0, 8.0);
   dt_bauhaus_slider_set_format(g->white_point_source, _(" EV"));
   gtk_widget_set_tooltip_text(g->white_point_source,
@@ -4227,7 +4229,8 @@ void gui_init(dt_iop_module_t *self)
 
   // Black slider
   g->black_point_source
-      = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "black_point_source"));
+      = dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE,
+                            dt_bauhaus_slider_from_params(self, "black_point_source"));
   dt_bauhaus_slider_set_soft_range(g->black_point_source, -14.0, -3);
   dt_bauhaus_slider_set_format(g->black_point_source, _(" EV"));
   gtk_widget_set_tooltip_text(
@@ -4243,7 +4246,8 @@ void gui_init(dt_iop_module_t *self)
                                                     "useful to give a safety margin to extreme luminances."));
 
   // Auto tune slider
-  g->auto_button = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_combobox_new(self));
+  g->auto_button = dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_DENOISE,
+                                       dt_bauhaus_combobox_new(self));
   dt_bauhaus_widget_set_label(g->auto_button, NULL, N_("auto tune levels"));
   gtk_widget_set_tooltip_text(g->auto_button, _("try to optimize the settings with some statistical assumptions.\n"
                                                 "this will fit the luminance range inside the histogram bounds.\n"

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2388,7 +2388,7 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->colorpick), "color-set", G_CALLBACK(rt_colorpick_color_set_callback), self);
   gtk_box_pack_start(GTK_BOX(g->hbox_color_pick), GTK_WIDGET(g->colorpick), TRUE, TRUE, 0);
 
-  g->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, g->hbox_color_pick);
+  g->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT | DT_COLOR_PICKER_IO, g->hbox_color_pick);
   gtk_widget_set_tooltip_text(g->colorpicker, _("pick fill color from image"));
 
   gtk_box_pack_start(GTK_BOX(g->vbox_fill), g->hbox_color_pick, TRUE, TRUE, 0);

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1363,10 +1363,10 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(hbox), gtk_grid_new(), TRUE, TRUE, 0);
 
   // color pickers
-  g->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT_AREA, hbox);
+  g->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT_AREA | DT_COLOR_PICKER_IO, hbox);
   gtk_widget_set_tooltip_text(g->colorpicker, _("pick GUI color from image\nctrl+click or right-click to select an area"));
   gtk_widget_set_name(g->colorpicker, "keep-active");
-  g->colorpicker_set_values = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, hbox);
+  g->colorpicker_set_values = dt_color_picker_new(self, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_IO, hbox);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->colorpicker_set_values),
                                dtgtk_cairo_paint_colorpicker_set_values, 0, NULL);
   dt_gui_add_class(g->colorpicker_set_values, "dt_transparent_background");

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -864,9 +864,9 @@ static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_modu
             // this functions need a 4c image
             for(int k = 0; k < 3; k++)
             {
-              picker_mean[k] = sample->scope[DT_LIB_COLORPICKER_STATISTIC_MEAN][k];
-              picker_min[k] = sample->scope[DT_LIB_COLORPICKER_STATISTIC_MIN][k];
-              picker_max[k] = sample->scope[DT_LIB_COLORPICKER_STATISTIC_MAX][k];
+              picker_mean[k] = sample->scope[DT_PICK_MEAN][k];
+              picker_min[k] = sample->scope[DT_PICK_MIN][k];
+              picker_max[k] = sample->scope[DT_PICK_MAX][k];
             }
             picker_mean[3] = picker_min[3] = picker_max[3] = 1.f;
 

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -1138,7 +1138,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(c->channel_tabs), TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hbox), gtk_grid_new(), TRUE, TRUE, 0);
 
-  c->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT_AREA, hbox);
+  c->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT_AREA | DT_COLOR_PICKER_IO, hbox);
   gtk_widget_set_tooltip_text(c->colorpicker, _("pick GUI color from image\nctrl+click or right-click to select an area"));
 
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 0);

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -1400,9 +1400,9 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       {
         dt_colorpicker_sample_t *sample = samples->data;
 
-        picker_scale(sample->lab[DT_LIB_COLORPICKER_STATISTIC_MEAN], picker_mean);
-        picker_scale(sample->lab[DT_LIB_COLORPICKER_STATISTIC_MIN], picker_min);
-        picker_scale(sample->lab[DT_LIB_COLORPICKER_STATISTIC_MAX], picker_max);
+        picker_scale(sample->lab[DT_PICK_MEAN], picker_mean);
+        picker_scale(sample->lab[DT_PICK_MIN], picker_min);
+        picker_scale(sample->lab[DT_PICK_MAX], picker_max);
 
         // Convert abcissa to log coordinates if needed
         picker_min[ch] = to_log(picker_min[ch], c->loglogscale, ch, c->semilog, 0);

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -260,7 +260,7 @@ static gboolean _sample_tooltip_callback(GtkWidget *widget, gint x, gint y, gboo
                                     CLAMP(sample->label_rgb[2], 0, 255), _("RGB"));
   sample_parts[7] = g_strdup_printf("\n<big><b>%14s</b></big>", _("Lab"));
 
-  for(int i = 0; i < DT_LIB_COLORPICKER_STATISTIC_N; i++)
+  for(int i = 0; i < DT_PICK_N; i++)
   {
     sample_parts[i] = g_strdup_printf("<span background='#%02X%02X%02X'>%32s</span>",
                                       (int)roundf(CLAMP(sample->display[i][0], 0.f, 1.f) * 255.f),
@@ -281,7 +281,7 @@ static gboolean _sample_tooltip_callback(GtkWidget *widget, gint x, gint y, gboo
   }
 
   dt_aligned_pixel_t color;
-  dt_Lab_2_LCH(sample->lab[DT_LIB_COLORPICKER_STATISTIC_MEAN], color);
+  dt_Lab_2_LCH(sample->lab[DT_PICK_MEAN], color);
   sample_parts[11] = g_strdup_printf("\n<big><b>%14s</b></big>", _("color"));
   sample_parts[12] = g_strdup_printf("%6s", Lch_to_color_name(color));
 
@@ -690,7 +690,7 @@ void gui_reset(dt_lib_module_t *self)
   // Resetting the picked colors
   for(int i = 0; i < 3; i++)
   {
-    for(int s = 0; s < DT_LIB_COLORPICKER_STATISTIC_N; s++)
+    for(int s = 0; s < DT_PICK_N; s++)
     {
       data->primary_sample.display[s][i] = 0.f;
       data->primary_sample.scope[s][i] = 0.f;

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -250,10 +250,11 @@ static void _set_sample_point(dt_lib_module_t *self, const float pos[2])
   _update_size(self, DT_LIB_COLORPICKER_SIZE_POINT);
 }
 
-static void _set_sample_denoise(dt_lib_module_t *self, const gboolean denoise)
+static void _setup_sample(dt_lib_module_t *self, const gboolean denoise, const gboolean pick_output)
 {
   dt_lib_colorpicker_t *data = self->data;
   data->primary_sample.denoise = denoise;
+  data->primary_sample.pick_output = pick_output;
 }
 
 static gboolean _sample_tooltip_callback(GtkWidget *widget, gint x, gint y, gboolean keyboard_mode,
@@ -535,7 +536,7 @@ void gui_init(dt_lib_module_t *self)
   darktable.lib->proxy.colorpicker.update_samples = _update_samples_output;
   darktable.lib->proxy.colorpicker.set_sample_box_area = _set_sample_box_area;
   darktable.lib->proxy.colorpicker.set_sample_point = _set_sample_point;
-  darktable.lib->proxy.colorpicker.set_sample_denoise = _set_sample_denoise;
+  darktable.lib->proxy.colorpicker.setup_sample = _setup_sample;
 
   const char *str = dt_conf_get_string_const("ui_last/colorpicker_model"), **names;
   names = dt_lib_colorpicker_model_names;
@@ -673,6 +674,7 @@ void gui_cleanup(dt_lib_module_t *self)
   darktable.lib->proxy.colorpicker.update_samples = NULL;
   darktable.lib->proxy.colorpicker.set_sample_box_area = NULL;
   darktable.lib->proxy.colorpicker.set_sample_point = NULL;
+  darktable.lib->proxy.colorpicker.setup_sample = NULL;
 
   darktable.lib->proxy.colorpicker.primary_sample = NULL;
   while(darktable.lib->proxy.colorpicker.live_samples)

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -250,6 +250,12 @@ static void _set_sample_point(dt_lib_module_t *self, const float pos[2])
   _update_size(self, DT_LIB_COLORPICKER_SIZE_POINT);
 }
 
+static void _set_sample_denoise(dt_lib_module_t *self, const gboolean denoise)
+{
+  dt_lib_colorpicker_t *data = self->data;
+  data->primary_sample.denoise = denoise;
+}
+
 static gboolean _sample_tooltip_callback(GtkWidget *widget, gint x, gint y, gboolean keyboard_mode,
                                          GtkTooltip *tooltip, const dt_colorpicker_sample_t *sample)
 {
@@ -529,6 +535,7 @@ void gui_init(dt_lib_module_t *self)
   darktable.lib->proxy.colorpicker.update_samples = _update_samples_output;
   darktable.lib->proxy.colorpicker.set_sample_box_area = _set_sample_box_area;
   darktable.lib->proxy.colorpicker.set_sample_point = _set_sample_point;
+  darktable.lib->proxy.colorpicker.set_sample_denoise = _set_sample_denoise;
 
   const char *str = dt_conf_get_string_const("ui_last/colorpicker_model"), **names;
   names = dt_lib_colorpicker_model_names;

--- a/src/libs/colorpicker.h
+++ b/src/libs/colorpicker.h
@@ -29,13 +29,13 @@ typedef enum dt_lib_colorpicker_size_t
 
 typedef enum dt_lib_colorpicker_statistic_t
 {
-  DT_LIB_COLORPICKER_STATISTIC_MEAN = 0,
-  DT_LIB_COLORPICKER_STATISTIC_MIN,
-  DT_LIB_COLORPICKER_STATISTIC_MAX,
-  DT_LIB_COLORPICKER_STATISTIC_N // needs to be the last one
+  DT_PICK_MEAN = 0,
+  DT_PICK_MIN,
+  DT_PICK_MAX,
+  DT_PICK_N // needs to be the last one
 } dt_lib_colorpicker_statistic_t;
 
-typedef dt_aligned_pixel_t lib_colorpicker_sample_statistics[DT_LIB_COLORPICKER_STATISTIC_N];
+typedef dt_aligned_pixel_t lib_colorpicker_stats[DT_LIB_COLORPICKER_STATISTIC_N];
 
 /** The struct for primary and live color picker samples */
 typedef struct dt_colorpicker_sample_t
@@ -52,11 +52,11 @@ typedef struct dt_colorpicker_sample_t
 
   /** The actual picked colors */
   // picked color in display profile, as picked from preview pixelpipe
-  lib_colorpicker_sample_statistics display;
+  lib_colorpicker_stats display;
   // picked color converted display profile -> histogram profile
-  lib_colorpicker_sample_statistics scope;
+  lib_colorpicker_stats scope;
   // picked color converted display profile -> Lab
-  lib_colorpicker_sample_statistics lab;
+  lib_colorpicker_stats lab;
   // in scope profile with current statistic
   int label_rgb[4];
   // in display profile with current statistic

--- a/src/libs/colorpicker.h
+++ b/src/libs/colorpicker.h
@@ -35,7 +35,7 @@ typedef enum dt_lib_colorpicker_statistic_t
   DT_PICK_N // needs to be the last one
 } dt_lib_colorpicker_statistic_t;
 
-typedef dt_aligned_pixel_t lib_colorpicker_stats[DT_LIB_COLORPICKER_STATISTIC_N];
+typedef dt_aligned_pixel_t lib_colorpicker_stats[DT_PICK_N];
 
 /** The struct for primary and live color picker samples */
 typedef struct dt_colorpicker_sample_t

--- a/src/libs/colorpicker.h
+++ b/src/libs/colorpicker.h
@@ -47,6 +47,7 @@ typedef struct dt_colorpicker_sample_t
   float point[2];
   dt_boundingbox_t box;
   dt_lib_colorpicker_size_t size;
+  gboolean denoise;
   // NOTE: only applies to live samples
   gboolean locked;
 

--- a/src/libs/colorpicker.h
+++ b/src/libs/colorpicker.h
@@ -48,6 +48,7 @@ typedef struct dt_colorpicker_sample_t
   dt_boundingbox_t box;
   dt_lib_colorpicker_size_t size;
   gboolean denoise;
+  gboolean pick_output;
   // NOTE: only applies to live samples
   gboolean locked;
 

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -1143,10 +1143,11 @@ void dt_lib_colorpicker_set_point(dt_lib_t *lib, const float pos[2])
   gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));
 }
 
-void dt_lib_colorpicker_set_denoise(dt_lib_t *lib, const gboolean denoise)
+void dt_lib_colorpicker_setup(dt_lib_t *lib, const gboolean denoise, const gboolean pick_output)
+
 {
-  if(!lib->proxy.colorpicker.module || !lib->proxy.colorpicker.set_sample_denoise) return;
-  lib->proxy.colorpicker.set_sample_denoise(lib->proxy.colorpicker.module, denoise);
+  if(!lib->proxy.colorpicker.module || !lib->proxy.colorpicker.setup_sample) return;
+  lib->proxy.colorpicker.setup_sample(lib->proxy.colorpicker.module, denoise, pick_output);
 }
 
 dt_lib_module_t *dt_lib_get_module(const char *name)

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -1143,6 +1143,12 @@ void dt_lib_colorpicker_set_point(dt_lib_t *lib, const float pos[2])
   gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));
 }
 
+void dt_lib_colorpicker_set_denoise(dt_lib_t *lib, const gboolean denoise)
+{
+  if(!lib->proxy.colorpicker.module || !lib->proxy.colorpicker.set_sample_denoise) return;
+  lib->proxy.colorpicker.set_sample_denoise(lib->proxy.colorpicker.module, denoise);
+}
+
 dt_lib_module_t *dt_lib_get_module(const char *name)
 {
   /* hide/show modules as last config */

--- a/src/libs/lib.h
+++ b/src/libs/lib.h
@@ -60,7 +60,8 @@ typedef struct dt_lib_t
       void (*update_samples)(struct dt_lib_module_t *self);
       void (*set_sample_box_area)(struct dt_lib_module_t *self, const dt_boundingbox_t size);
       void (*set_sample_point)(struct dt_lib_module_t *self, const float pos[2]);
-      void (*set_sample_denoise)(struct dt_lib_module_t *self, const gboolean denoise);
+      void (*setup_sample)(struct dt_lib_module_t *self, const gboolean denoise,
+                           const gboolean pick_output);
     } colorpicker;
 
     /** Histogram processing hooks */
@@ -167,8 +168,8 @@ void dt_lib_colorpicker_set_box_area(dt_lib_t *lib, const dt_boundingbox_t box);
 /** set the colorpicker point selection tool and position */
 void dt_lib_colorpicker_set_point(dt_lib_t *lib, const float pos[2]);
 
-/** turn on/off denoising for the colorpicker */
-void dt_lib_colorpicker_set_denoise(dt_lib_t *lib, const gboolean denoise);
+/** setup colorpicker options */
+void dt_lib_colorpicker_setup(dt_lib_t *lib, const gboolean denoise, const gboolean pick_output);
 
 /** sorter callback to add a lib in the list of libs after init */
 gint dt_lib_sort_plugins(gconstpointer a, gconstpointer b);

--- a/src/libs/lib.h
+++ b/src/libs/lib.h
@@ -60,6 +60,7 @@ typedef struct dt_lib_t
       void (*update_samples)(struct dt_lib_module_t *self);
       void (*set_sample_box_area)(struct dt_lib_module_t *self, const dt_boundingbox_t size);
       void (*set_sample_point)(struct dt_lib_module_t *self, const float pos[2]);
+      void (*set_sample_denoise)(struct dt_lib_module_t *self, const gboolean denoise);
     } colorpicker;
 
     /** Histogram processing hooks */
@@ -165,6 +166,9 @@ void dt_lib_colorpicker_set_box_area(dt_lib_t *lib, const dt_boundingbox_t box);
 
 /** set the colorpicker point selection tool and position */
 void dt_lib_colorpicker_set_point(dt_lib_t *lib, const float pos[2]);
+
+/** turn on/off denoising for the colorpicker */
+void dt_lib_colorpicker_set_denoise(dt_lib_t *lib, const gboolean denoise);
 
 /** sorter callback to add a lib in the list of libs after init */
 gint dt_lib_sort_plugins(gconstpointer a, gconstpointer b);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3534,14 +3534,16 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
         for(GSList *samples = darktable.lib->proxy.colorpicker.live_samples; samples; samples = g_slist_next(samples))
         {
           dt_colorpicker_sample_t *live_sample = samples->data;
-          if(live_sample->size == DT_LIB_COLORPICKER_SIZE_BOX && picker->kind != DT_COLOR_PICKER_POINT)
+          if(live_sample->size == DT_LIB_COLORPICKER_SIZE_BOX
+             && (picker->flags & DT_COLOR_PICKER_AREA))
           {
             if(zoom_x < live_sample->box[0] || zoom_x > live_sample->box[2]
                || zoom_y < live_sample->box[1] || zoom_y > live_sample->box[3])
               continue;
             dt_lib_colorpicker_set_box_area(darktable.lib, live_sample->box);
           }
-          else if(live_sample->size == DT_LIB_COLORPICKER_SIZE_POINT && picker->kind != DT_COLOR_PICKER_AREA)
+          else if(live_sample->size == DT_LIB_COLORPICKER_SIZE_POINT
+                  && (picker->flags & DT_COLOR_PICKER_POINT))
           {
             // magic values derived from _darkroom_pickers_draw
             float slop_px = MAX(26.0f, roundf(3.0f * zoom_scale));


### PR DESCRIPTION
Cleanups to colorpicking code. Removes > 300 LOC. There should be no user-visible differences in most cases (excepting being a bit faster).

Big changes:

- Unify the iop, global, and live sample colorpicking code. Much of this code did the same thing, but previously it had multiple executions paths.
- Add a flag to allow denoising to be turned on per picker. Denoising is helpful for filmic auto-tuning, but in other cases we actually _want_ to see the real minimum/maximum pixel values, noise and all. Denoising also is slow (5x slowdown, plus more memory usage), albeit for what is generally a very fast operation. And the current denoising implementation will denoise the entire image on the CPU path, even if the sample is only a point sample. In this PR, denoising is only enabled for filmic.
- Add a flag which iop's must set to turn on sampling of their output. In the case of many iops, we only need to sample the input. In these cases, turning off output sampling is a 2x speedup.
- Unify the sequential and parallel paths for colorpicker sampling. As before, parallelization is only used for sufficiently large sample sizes. But now this is done via an OpenMP if() clause, which eliminates a lot of very similar code.
- Explicitly handle sampling of monochrome images without generation a warning.
- Remove colorspace conversions before colorpicking in per-iop pickers. These were nop's. And as the colorpicker code is colorspace-aware, it should be the one to handle this if necessary, anyhow.

Some more fine grained changes:

- Use "worker" style functions (as in histogram) to allow for more succinct code.
- Use custom OpenMP reductions (thanks to OpenMP > 4.0) in the parallel code, rather than handcoding effectively the same work.
- When accumulating pixel values, only do the division to calculate their mean at the end.
- Initialize the min/max/mean color picker values before sampling in all cases. (Previously, these were only initialized in the parallel case.) Use initial min/max values of `FLT_MAX` and `-FLT_MAX` rather than `INFINITY` and `-INFINITY`, as the former seem more in the spirit of IEEE floating point.
- Use MIN() and MAX() macros instead of fminf() and fmaxf(). This should produce the same results, and allows the min/max code to use assembly opcodes vs. a call to libc.
- Avoid possible division by zero for very small 1-channel X-Trans samples.
- Print  diagnostic if the requested colorspace conversion isn't supported by the code.
- Use the `for_four_channels` and `for_each_channel` macros when possible. These give SIMD speedups and allow for removing uses of `omp declare simd`.

Here's some timing data using this PR to sample from a full preview (approx. 1,150,000 pixels). All times are in
seconds. For OpenMP, times are elapsed/CPU, for non-OpenMP time is CPU.

```
               non-OpenMP    OpenMP
RGB -> RGB     0.003         0.001/0.007
Lab -> Lab     0.003         0.001/0.007
Lab -> LCh     0.027         0.006/0.053
RGB -> HSL     0.013         0.004/0.025
RGB -> JzCzhz  0.127         0.025/0.245
X-Trans        0.002         0.001/0.005
Bayer          0.002         0.001/0.004
```

For single pixel samples, in all cases the results are 0.000 sec. elapsed/CPU, whether using OpenMP or not. Tests on a i7-10750H.

For sampling with OpenMP, turning on denoising takes 0.005 secs. vs. 0.001 sec. without denoising.

For comparison, here is timings with OpenMP before the current set of changes (using commit 105e72b89ec6264d5b0be27a3346347f11f6d7fe):

```
               box picker       point picker
RGB -> RGB     0.007/0.051      0.005/0.013
Lab -> Lab     0.008/0.050      0.005/0.007
Lab -> LCh     0.015/0.109      0.005/0.009
RGB -> HSL     0.011/0.070      0.005/0.010
RGB -> JzCzhz  0.031/0.277      0.007/0.040
X-Trans        0.015/0.170
Bayer          0.015/0.140
```

This isn't a totally fair comparison, as the timings of the current code are made without denoising. The 0.005 sec. overhead of denoising results in most of the speedup. On the other hand, the new code is no slower than the old code. And the old code would often unnecessarily run the picker on the output, hence doubling the sampling time.
