### PR TITLE
po/rework workflow & module groups

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3276,26 +3276,15 @@
     <name>plugins/darkroom/workflow</name>
     <type>
       <enum>
-        <option>scene-referred</option>
-        <option>display-referred</option>
+        <option>scene-referred (filmic)</option>
+        <option>scene-referred (sigmoid)</option>
+        <option>display-referred (legacy)</option>
         <option>none</option>
       </enum>
     </type>
-    <default>scene-referred</default>
+    <default>scene-referred (filmic)</default>
     <shortdescription>auto-apply pixel workflow defaults</shortdescription>
-    <longdescription>scene-referred workflow is based on linear modules and will auto-apply filmic and exposure,\ndisplay-referred workflow is based on Lab modules and will auto-apply base curve and the legacy module pipe order.</longdescription>
-  </dtconfig>
-  <dtconfig prefs="processing" section="general">
-    <name>plugins/darkroom/chromatic-adaptation</name>
-    <type>
-      <enum>
-        <option>modern</option>
-        <option>legacy</option>
-      </enum>
-    </type>
-    <default>legacy</default>
-    <shortdescription>auto-apply chromatic adaptation defaults</shortdescription>
-    <longdescription>legacy performs a basic chromatic adaptation using only the white balance module\nmodern uses a combination of white balance module and color calibration module, with improved color science for chromatic adaptation</longdescription>
+    <longdescription>scene-referred workflow is based on linear modules and will auto-apply filmic or sigmoid, color calibrary and exposure,\ndisplay-referred workflow is based on Lab modules and will auto-apply base curve, white balance and the legacy module pipe order.</longdescription>
   </dtconfig>
   <dtconfig prefs="processing" section="general" restart="true">
     <name>plugins/darkroom/basecurve/auto_apply_percamera_presets</name>

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -1461,7 +1461,7 @@ static int _upgrade_library_schema_step(dt_database_t *db, int version)
     // insert an history_hash entry for all images which have an history
     // note that images without history don't get hash and are considered as basic
     sqlite3_stmt *h_stmt;
-    const gboolean basecurve_auto_apply = dt_conf_is_equal("plugins/darkroom/workflow", "display-referred");
+    const gboolean basecurve_auto_apply = dt_is_display_referred();
     // clang-format off
     char *query = g_strdup_printf(
                             "SELECT id, CASE WHEN imgid IS NULL THEN 0 ELSE 1 END as altered "

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -2986,8 +2986,7 @@ static gboolean _image_altered_deprecated(const uint32_t imgid)
 {
   sqlite3_stmt *stmt;
 
-  const gboolean basecurve_auto_apply =
-    dt_conf_is_equal("plugins/darkroom/workflow", "display-referred");
+  const gboolean basecurve_auto_apply = dt_is_display_referred();
 
   char query[1024] = { 0 };
 

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -434,8 +434,7 @@ static GList *_insert_before(GList *iop_order_list, const char *module, const ch
 
 dt_iop_order_t dt_ioppr_get_iop_order_version(const int32_t imgid)
 {
-  const gboolean is_display_referred =
-    dt_conf_is_equal("plugins/darkroom/workflow", "display-referred");
+  const gboolean is_display_referred = dt_is_display_referred();
   dt_iop_order_t iop_order_version =
     is_display_referred ? DT_IOP_ORDER_LEGACY : DT_IOP_ORDER_V30;
 
@@ -850,8 +849,10 @@ GList *dt_ioppr_get_iop_order_list(int32_t imgid, gboolean sorted)
   // and new image not yet loaded or whose history has been reset.
   if(!iop_order_list)
   {
-    const char *workflow = dt_conf_get_string_const("plugins/darkroom/workflow");
-    dt_iop_order_t iop_order_version = strcmp(workflow, "display-referred") == 0 ? DT_IOP_ORDER_LEGACY : DT_IOP_ORDER_V30;
+    dt_iop_order_t iop_order_version =
+      dt_is_display_referred()
+      ? DT_IOP_ORDER_LEGACY
+      : DT_IOP_ORDER_V30;
 
     if(iop_order_version == DT_IOP_ORDER_LEGACY)
       iop_order_list = _table_to_list(legacy_order);

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -22,6 +22,7 @@
 #include "common/file_location.h"
 #include "common/grealpath.h"
 #include "common/utility.h"
+#include "control/conf.h"
 #include "gui/gtk.h"
 
 /* getpwnam_r availability check */
@@ -994,9 +995,19 @@ gchar *dt_str_replace(const char *string, const char *search, const char *replac
   return res;
 }
 
+gboolean dt_is_scene_referred(void)
+{
+  return dt_conf_is_equal("plugins/darkroom/workflow", "scene-referred (filmic)")
+    || dt_conf_is_equal("plugins/darkroom/workflow", "scene-referred (sigmoid)");
+}
+
+gboolean dt_is_display_referred(void)
+{
+  return dt_conf_is_equal("plugins/darkroom/workflow", "display-referred (legacy)");
+}
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -113,9 +113,14 @@ char *dt_copy_filename_extension(const char *filename1, const char *filename2);
 // replaces all occurences of a substring in a string
 gchar *dt_str_replace(const char *string, const char *search, const char *replace);
 
+// returns true if current settings is scene-referred
+gboolean dt_is_scene_referred(void);
+
+// returns true if current settings is display-referred
+gboolean dt_is_display_referred(void);
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -88,7 +88,7 @@ static inline dt_develop_blend_colorspace_t _blend_default_module_blend_colorspa
 
 dt_develop_blend_colorspace_t dt_develop_blend_default_module_blend_colorspace(dt_iop_module_t *module)
 {
-  const gboolean is_scene_referred = dt_conf_is_equal("plugins/darkroom/workflow", "scene-referred");
+  const gboolean is_scene_referred = dt_is_scene_referred();
   return _blend_default_module_blend_colorspace(module, is_scene_referred);
 }
 
@@ -1907,4 +1907,3 @@ int dt_develop_blend_legacy_params_from_so(dt_iop_module_so_t *module_so, const 
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1414,21 +1414,23 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
   if(!(image->flags & DT_IMAGE_AUTO_PRESETS_APPLIED)) run = TRUE;
 
   const gboolean is_raw = dt_image_is_raw(image);
-  const gboolean is_modern_chroma =
-    dt_conf_is_equal("plugins/darkroom/chromatic-adaptation", "modern");
+  const gboolean is_modern_chroma = dt_is_scene_referred();
 
   // flag was already set? only apply presets once in the lifetime of a history stack.
   // (the flag will be cleared when removing it).
   if(!run || image->id <= 0)
   {
-    // Next section is to recover old edits where all modules with default parameters were not
-    // recorded in the db nor in the .XMP.
+    // Next section is to recover old edits where all modules with
+    // default parameters were not recorded in the db nor in the .XMP.
     //
-    // One crucial point is the white-balance which has automatic default based on the camera
-    // and depends on the chroma-adaptation. In modern mode the default won't be the same used
-    // in legacy mode and if the white-balance is not found on the history one will be added by
-    // default using current defaults. But if we are in modern chromatic adaptation the default
-    // will not be equivalent to the one used to develop this old edit.
+    // One crucial point is the white-balance which has automatic
+    // default based on the camera and depends on the
+    // chroma-adaptation. In modern mode the default won't be the same
+    // used in legacy mode and if the white-balance is not found on
+    // the history one will be added by default using current
+    // defaults. But if we are in modern chromatic adaptation the
+    // default will not be equivalent to the one used to develop this
+    // old edit.
 
     // So if the current mode is the modern chromatic-adaptation, do check the history.
 
@@ -1449,9 +1451,9 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
                   "[_dev_auto_apply_presets] missing mandatory module %s for image %d\n",
                   module->op, imgid);
 
-          // If the module is white-balance and we are dealing with a raw file we need to add
-          // one now with the default legacy parameters. And we want to do this only for
-          // old edits.
+          // If the module is white-balance and we are dealing with a
+          // raw file we need to add one now with the default legacy
+          // parameters. And we want to do this only for old edits.
           //
           // For new edits the temperature will be added back depending on the chromatic
           // adaptation the standard way.
@@ -1462,10 +1464,10 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
             // it is important to recover temperature in this case (modern chroma and
             // not module present as we need to have the pre 3.0 default parameters used.
 
-            dt_conf_set_string("plugins/darkroom/chromatic-adaptation", "legacy");
+            dt_conf_set_string("plugins/darkroom/workflow", "display-referred (legacy)");
             dt_iop_reload_defaults(module);
             _dev_insert_module(dev, module, imgid);
-            dt_conf_set_string("plugins/darkroom/chromatic-adaptation", "modern");
+            dt_conf_set_string("plugins/darkroom/workflow", "scene-referred (filmic)");
             dt_iop_reload_defaults(module);
           }
         }
@@ -1476,10 +1478,9 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
     return FALSE;
   }
 
-  const char *workflow = dt_conf_get_string_const("plugins/darkroom/workflow");
-  const gboolean is_scene_referred = strcmp(workflow, "scene-referred") == 0;
-  const gboolean is_display_referred = strcmp(workflow, "display-referred") == 0;
-  const gboolean is_workflow_none = strcmp(workflow, "none") == 0;
+  const gboolean is_scene_referred = dt_is_scene_referred();
+  const gboolean is_display_referred = dt_is_display_referred();
+  const gboolean is_workflow_none = !is_scene_referred && !is_display_referred;
 
   //  Add scene-referred workflow
   //  Note that we cannot use a preset for FilmicRGB as the default values are
@@ -1488,7 +1489,15 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
 
   const gboolean has_matrix = dt_image_is_matrix_correction_supported(image);
 
-  const gboolean auto_apply_filmic = is_raw && is_scene_referred;
+  const char *workflow = dt_conf_get_string_const("plugins/darkroom/workflow");
+
+  const gboolean auto_apply_filmic =
+    is_raw
+    && strcmp(workflow, "scene-referred (filmic)") == 0;
+  const gboolean auto_apply_sigmoid =
+    is_raw
+    && strcmp(workflow, "scene-referred (sigmoid)") == 0;
+
   const gboolean auto_apply_cat = has_matrix && is_modern_chroma;
 
   if(auto_apply_filmic || auto_apply_cat)
@@ -1497,8 +1506,9 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
     {
       dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
 
-      if(((auto_apply_filmic && strcmp(module->op, "filmicrgb") == 0) ||
-          (auto_apply_cat && strcmp(module->op, "channelmixerrgb") == 0))
+      if(((auto_apply_filmic && strcmp(module->op, "filmicrgb") == 0)
+          || (auto_apply_sigmoid && strcmp(module->op, "sigmoid") == 0)
+          || (auto_apply_cat && strcmp(module->op, "channelmixerrgb") == 0))
          && !dt_history_check_module_exists(imgid, module->op, FALSE)
          && !(module->flags() & IOP_FLAGS_NO_HISTORY_STACK))
       {

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -941,9 +941,8 @@ gboolean dt_gui_presets_autoapply_for_module(dt_iop_module_t *module)
 {
   dt_image_t *image = &module->dev->image_storage;
 
-  const char *workflow = dt_conf_get_string_const("plugins/darkroom/workflow");
-  const gboolean is_display_referred = strcmp(workflow, "display-referred") == 0;
-  const gboolean is_scene_referred = strcmp(workflow, "scene-referred") == 0;
+  const gboolean is_display_referred = dt_is_display_referred();
+  const gboolean is_scene_referred = dt_is_scene_referred();
   const gboolean has_matrix = dt_image_is_matrix_correction_supported(image);
 
   char query[2024];
@@ -1697,4 +1696,3 @@ void dt_gui_presets_update_filter(const char *name, dt_dev_operation_t op, const
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -3495,8 +3495,7 @@ void reload_defaults(dt_iop_module_t *module)
   d->illuminant = module->get_f("illuminant")->Enum.Default;
   d->adaptation = module->get_f("adaptation")->Enum.Default;
 
-  const gboolean is_modern =
-    dt_conf_is_equal("plugins/darkroom/chromatic-adaptation", "modern");
+  const gboolean is_modern = dt_is_scene_referred();
 
   // note that if there is already an instance of this module with an
   // adaptation set we default to RGB (none) in this instance.
@@ -4302,4 +4301,3 @@ void gui_cleanup(struct dt_iop_module_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2981,9 +2981,10 @@ void reload_defaults(dt_iop_module_t *module)
 
   module->default_enabled = FALSE;
 
-  const gboolean is_scene_referred = dt_conf_is_equal("plugins/darkroom/workflow", "scene-referred");
+  const gboolean is_scene_referred = dt_is_scene_referred();
 
-  if(dt_image_is_matrix_correction_supported(&module->dev->image_storage) && is_scene_referred)
+  if(dt_image_is_matrix_correction_supported(&module->dev->image_storage)
+     && is_scene_referred)
   {
     // For scene-referred workflow, auto-enable and adjust based on exposure
     // TODO: fetch actual exposure in module, don't assume 1.

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1392,8 +1392,7 @@ void reload_defaults(dt_iop_module_t *module)
 
   const gboolean is_raw = dt_image_is_matrix_correction_supported(&module->dev->image_storage);
   const gboolean true_monochrome = dt_image_monochrome_flags(&module->dev->image_storage) & DT_IMAGE_MONOCHROME;
-  const gboolean is_modern =
-    dt_conf_is_equal("plugins/darkroom/chromatic-adaptation", "modern");
+  const gboolean is_modern = dt_is_scene_referred();
 
   module->default_enabled = 0;
   module->hide_enable_button = true_monochrome;

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -38,8 +38,8 @@
 DT_MODULE(1)
 
 // the T_ macros are for the translation engine to take them into account
-#define FALLBACK_PRESET_NAME     "modules: default"
-#define T_FALLBACK_PRESET_NAME _("modules: default")
+#define FALLBACK_PRESET_NAME     "workflow: scene-referred"
+#define T_FALLBACK_PRESET_NAME _("workflow: scene-referred")
 
 #define DEPRECATED_PRESET_NAME     "modules: deprecated"
 #define T_DEPRECATED_PRESET_NAME _("modules: deprecated")
@@ -1541,6 +1541,12 @@ void init_presets(dt_lib_module_t *self)
   */
 
   const gboolean is_scene_referred = dt_is_scene_referred();
+  const gboolean wf_filmic =
+    dt_conf_is_equal("plugins/darkroom/workflow", "scene-referred (filmic)");
+  const gboolean wf_sigmoid =
+    dt_conf_is_equal("plugins/darkroom/workflow", "scene-referred (sigmoid)");
+  const gboolean wf_none =
+    dt_conf_is_equal("plugins/darkroom/workflow", "none");
 
   // all modules
   gchar *tx = NULL;
@@ -1636,7 +1642,7 @@ void init_presets(dt_lib_module_t *self)
   AM("ashift");
 
   if(is_scene_referred)
-    AM("filmicrgb");
+    AM("sigmoid");
   else
     AM("basecurve");
 
@@ -1719,8 +1725,10 @@ void init_presets(dt_lib_module_t *self)
   SQA(TRUE);
 
   SMG(C_("modulegroup", "base"), "basic");
-  AM("filmicrgb");
-  AM("sigmoid");
+  if(wf_filmic || wf_none)
+    AM("filmicrgb");
+  if(wf_sigmoid || wf_none)
+    AM("sigmoid");
   AM("toneequal");
   AM("crop");
   AM("ashift");
@@ -1758,84 +1766,6 @@ void init_presets(dt_lib_module_t *self)
   AM("diffuse");
 
   dt_lib_presets_add(_("workflow: scene-referred"), self->plugin_name, self->version(), tx, strlen(tx), TRUE);
-
-  // default / 3 tabs based on Aurélien's proposal
-
-  SQA(is_scene_referred);
-
-  SMG(C_("modulegroup", "technical"), "technical");
-  AM("basecurve");
-  AM("bilateral");
-  AM("cacorrect");
-  AM("crop");
-  AM("ashift");
-  AM("colorchecker");
-  AM("colorin");
-  AM("colorout");
-
-  AM("colorreconstruct");
-  AM("cacorrectrgb");
-  AM("demosaic");
-  AM("denoiseprofile");
-  AM("dither");
-  AM("exposure");
-  AM("filmicrgb");
-  AM("finalscale");
-  AM("flip");
-  AM("hazeremoval");
-  AM("highlights");
-  AM("hotpixels");
-  AM("lens");
-  AM("lut3d");
-  AM("negadoctor");
-  AM("nlmeans");
-  AM("overexposed");
-  AM("rawdenoise");
-  AM("rawoverexposed");
-  AM("rotatepixels");
-  AM("temperature");
-  AM("scalepixels");
-
-  SMG(C_("modulegroup", "grading"), "grading");
-  AM("channelmixerrgb");
-  AM("colisa");
-  AM("colorbalancergb");
-  AM("colorcontrast");
-  AM("colorcorrection");
-  AM("colorize");
-  AM("colorzones");
-  AM("graduatednd");
-  AM("levels");
-  AM("rgbcurve");
-  AM("rgblevels");
-  AM("shadhi");
-  AM("splittoning");
-  AM("tonecurve");
-  AM("toneequal");
-  AM("velvia");
-
-  SMG(C_("modulegroup", "effects"), "effect");
-  AM("atrous");
-  AM("bilat");
-  AM("bloom");
-  AM("borders");
-  AM("colormapping");
-  AM("grain");
-  AM("highpass");
-  AM("liquify");
-  AM("lowlight");
-  AM("lowpass");
-  AM("monochrome");
-  AM("retouch");
-  AM("sharpen");
-  AM("soften");
-  AM("vignette");
-  AM("watermark");
-  AM("censorize");
-  AM("blurs");
-  AM("diffuse");
-
-  dt_lib_presets_add(_(FALLBACK_PRESET_NAME), self->plugin_name, self->version(), tx, strlen(tx), TRUE);
 
   // search only (only active modules visible)
   SNQA();

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1493,7 +1493,7 @@ static void _preset_from_string(dt_lib_module_t *self, gchar *txt, gboolean edit
   }
 
 // start quick access
-#define SQA(is_modern, is_scene_referred)                                                                         \
+#define SQA(is_scene_referred)                                                                         \
   {                                                                                                               \
     g_free(tx);                                                                                                   \
     tx = g_strdup_printf("1|0ꬹ1||");                                                                            \
@@ -1502,9 +1502,6 @@ static void _preset_from_string(dt_lib_module_t *self, gchar *txt, gboolean edit
       AM("filmicrgb/white relative exposure");                                                                    \
       AM("filmicrgb/black relative exposure");                                                                    \
       AM("filmicrgb/contrast");                                                                                   \
-    }                                                                                                             \
-    if(is_modern)                                                                                                 \
-    {                                                                                                             \
       AM("channelmixerrgb/temperature");                                                                          \
       AM("channelmixerrgb/chroma");                                                                               \
       AM("channelmixerrgb/hue");                                                                                  \
@@ -1543,15 +1540,12 @@ void init_presets(dt_lib_module_t *self)
             echo "AM(\"${BN:0:16}\");" ; done
   */
 
-  const gboolean is_modern =
-    dt_conf_is_equal("plugins/darkroom/chromatic-adaptation", "modern");
-  const gboolean is_scene_referred =
-    dt_conf_is_equal("plugins/darkroom/workflow", "scene-referred");
+  const gboolean is_scene_referred = dt_is_scene_referred();
 
   // all modules
   gchar *tx = NULL;
 
-  SQA(is_modern, is_scene_referred);
+  SQA(is_scene_referred);
 
   SMG(C_("modulegroup", "base"), "basic");
   AM("basecurve");
@@ -1636,7 +1630,7 @@ void init_presets(dt_lib_module_t *self)
 
   // minimal / 3 tabs
 
-  SQA(is_modern, is_scene_referred);
+  SQA(is_scene_referred);
 
   SMG(C_("modulegroup", "base"), "basic");
   AM("ashift");
@@ -1672,7 +1666,7 @@ void init_presets(dt_lib_module_t *self)
   dt_lib_presets_add(_("workflow: beginner"), self->plugin_name, self->version(), tx, strlen(tx), TRUE);
 
   // display referred
-  SQA(is_modern, FALSE);
+  SQA(FALSE);
 
   SMG(C_("modulegroup", "base"), "basic");
   AM("basecurve");
@@ -1722,7 +1716,7 @@ void init_presets(dt_lib_module_t *self)
 
   // scene referred
 
-  SQA(is_modern, TRUE);
+  SQA(TRUE);
 
   SMG(C_("modulegroup", "base"), "basic");
   AM("filmicrgb");
@@ -1767,7 +1761,7 @@ void init_presets(dt_lib_module_t *self)
 
   // default / 3 tabs based on Aurélien's proposal
 
-  SQA(is_modern, is_scene_referred);
+  SQA(is_scene_referred);
 
   SMG(C_("modulegroup", "technical"), "technical");
   AM("basecurve");
@@ -1881,13 +1875,12 @@ void init_presets(dt_lib_module_t *self)
 
 static gchar *_presets_get_minimal(dt_lib_module_t *self)
 {
-  const gboolean is_modern = dt_conf_is_equal("plugins/darkroom/chromatic-adaptation", "modern");
-  const gboolean is_scene_referred = dt_conf_is_equal("plugins/darkroom/workflow", "scene-referred");
+  const gboolean is_scene_referred = dt_is_scene_referred();
 
   // all modules
   gchar *tx = NULL;
 
-  SQA(is_modern, is_scene_referred);
+  SQA(is_scene_referred);
   AM("exposure/exposure");
   AM("colorbalancergb/contrast");
 


### PR DESCRIPTION
1. Rework the workflow preference to be simpler.
    
    The new values are now:
        
     - scene-refrerred (filmic)
     - scene-referred (sigmoid)
     - display-referred (legacy)
     - none
    
    The chromatic-adaptation is implied by the workflow setting (removing
    one preference). And is "modern" for all scene-referred workflow.

2. Rework the module groups to be simpler.
    
    - Remove the "default" group.
    - Add either Sigmoid or FilmicRGB module based on current workflow
    - Use Sigmoid instead of FilmicRGB for the beginner workflow.

Fixes #12917.