### PR TITLE
de: Fix module layout duplication string

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -22588,7 +22588,7 @@ msgstr "neuer Name des Modullayouts:"
 
 #: ../src/libs/modulegroups.c:3542
 msgid "a preset with this name already exists!"
-msgstr "Modullayout mit dem Namen „%s” existiert bereits!"
+msgstr "Ein Modullayout mit diesem Namen existiert bereits!"
 
 #: ../src/libs/modulegroups.c:3875
 msgid "preset: "


### PR DESCRIPTION
There is no parameter for this string, which results in showing the `%s` on the interface.