### PR TITLE
Reorder the configuration loading (Fix value sanitization).

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -992,13 +992,18 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 
   // initialize the config backend. this needs to be done first...
   darktable.conf = (dt_conf_t *)calloc(1, sizeof(dt_conf_t));
+
+  // initialize the configuration default/min/max
+  dt_confgen_init();
+
+  // read actual configuration, needs confgen above for sanitizing values
   dt_conf_init(darktable.conf, darktablerc, config_override);
+
   g_slist_free_full(config_override, g_free);
 
   // set the interface language and prepare selection for prefs
   darktable.l10n = dt_l10n_init(init_gui);
 
-  dt_confgen_init();
   const int last_configure_version = dt_conf_get_int("performance_configuration_version_completed");
 
   // we need this REALLY early so that error messages can be shown, however after gtk_disable_setlocale

--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -39,18 +39,6 @@ typedef struct dt_conf_dreggn_t
   const char *match;
 } dt_conf_dreggn_t;
 
-static void _free_confgen_value(void *value)
-{
-  dt_confgen_value_t *s = (dt_confgen_value_t *)value;
-  g_free(s->def);
-  g_free(s->min);
-  g_free(s->max);
-  g_free(s->enum_values);
-  g_free(s->shortdesc);
-  g_free(s->longdesc);
-  g_free(s);
-}
-
 /** return slot for this variable or newly allocated slot. */
 static inline char *dt_conf_get_var(const char *name)
 {
@@ -410,6 +398,7 @@ static char *_sanitize_confgen(const char *name, const char *value)
         result = g_strdup(dt_confgen_get(name, DT_DEFAULT));
       else
         result = g_strdup(value);
+
       g_free(v);
     }
     break;
@@ -423,8 +412,6 @@ static char *_sanitize_confgen(const char *name, const char *value)
 
 void dt_conf_init(dt_conf_t *cf, const char *filename, GSList *override_entries)
 {
-  cf->x_confgen = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, _free_confgen_value);
-
   cf->table = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
   cf->override_entries = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
   dt_pthread_mutex_init(&darktable.conf->mutex, NULL);
@@ -842,4 +829,3 @@ void dt_conf_cleanup(dt_conf_t *cf)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/tools/generate_darktablerc_conf.xsl
+++ b/tools/generate_darktablerc_conf.xsl
@@ -133,8 +133,22 @@ static void _insert_longdescription(const char *name, const char *value)
   item->longdesc = g_strdup(value);
 }
 
+static void _free_confgen_value(void *value)
+{
+  dt_confgen_value_t *s = (dt_confgen_value_t *)value;
+  g_free(s->def);
+  g_free(s->min);
+  g_free(s->max);
+  g_free(s->enum_values);
+  g_free(s->shortdesc);
+  g_free(s->longdesc);
+  g_free(s);
+}
+
 void dt_confgen_init()
 {
+   darktable.conf->x_confgen = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, _free_confgen_value);
+
 ]]></xsl:text>
 
   <xsl:for-each select="./dtconfiglist/dtconfig">


### PR DESCRIPTION
We must first load the confgen to ensure that we can sanitize the current values based on enum, min, max as described in the XML.

This is important for 4.2.1. I found out this because the work on workflow. I have renamed them but then the new default was not applied. I got an empty value for the workflow value.

This fix a long standing bug that I had already encountered but did not investigate until now.