### PR TITLE
README.md fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ This builds the software for your architecture only, with:
 If you want to have dartkable displayed along your other applications, you only need to add a symbolic link:
 
 ```bash
-ln -s /opt/darktable/share/applications/darktable.desktop /usr/share/applications/darktable.desktop
+ln -s /opt/darktable/share/applications/org.darktable.darktable.desktop /usr/share/applications/org.darktable.darktable.desktop
 ```
 
 Now, your custom-built darktable is ready to be used just like any pre-packaged software.
@@ -358,7 +358,7 @@ the test/unstable one will save in `~/.config/darktable-test`, and the two versi
 Simply launch it from your desktop application menu or, from a terminal, run `darktable` or `/opt/darktable/bin/darktable`. If the installation did not create a launcher in your applications menu, run:
 
 ```bash
-sudo ln -s /opt/darktable/share/applications/darktable.desktop /usr/share/applications/darktable.desktop
+sudo ln -s /opt/darktable/share/applications/org.darktable.darktable.desktop /usr/share/applications/org.darktable.darktable.desktop
 ```
 
 You may find darktable configuration files in `~/.config/darktable`.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Requirements
 
 * Linux (64-bit)
 * FreeBSD (64-bit)
-* Windows (64-bit), 8.1 w/ [UCRT](https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c), or later
+* Windows (64-bit), 8.1 w/ [UCRT](https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c) and later
 * macOS
 
 *Big-endian platforms are not supported.*


### PR DESCRIPTION
This PR reflects the recent renaming of the .desktop file in the README (the need for this was forgotten in that PR).

Another small change is related to the list of supported platforms. When we talk about requirements, when we list the versions of a certain dependency (for example, versions of libraries), we say that ANY of the specified versions will satisfy us. So we list those versions with "or". When we talk about supported platforms, let's say Windows versions, we mean that ALL listed versions are supported. So there should be an "and".

Sorry for being so scrupulous. 😉

Oh, and one more thing: you shouldn't put a comma before and/or in this case. The rule is: "When used in a list, _and_ and _or_ never take a comma when the list has two items"
