### PR TITLE
HLR updates for 4.4 (incl OpenCL)

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -301,6 +301,206 @@ highlights_false_color (read_only image2d_t in, write_only image2d_t out, const 
   write_imagef (out, (int2)(x, y), oval);
 }
 
+static inline float _calc_refavg(read_only image2d_t in, global const unsigned char (*const xtrans)[6], const unsigned int filters, int row, int col, int width)
+{
+  const int color = (filters == 9u) ? FCxtrans(row, col, xtrans) : FC(row, col, filters);
+  float mean[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+  float cnt[4]  = { 0.0f, 0.0f, 0.0f, 0.0f };
+  for(int dy = -1; dy < 2; dy++)
+  {
+    for(int dx = -1; dx < 2; dx++)
+    {
+      const float val = max(0.0f, read_imagef(in, sampleri, (int2)(col+dx, row+dy)).x);
+      const int c = (filters == 9u) ? FCxtrans(row + dy, col + dx, xtrans) : FC(row + dy, col + dx, filters);
+      mean[c] += val;
+      cnt[c] += 1.0f;
+    }
+  }
+  for(int c = 0; c < 3; c++)
+    mean[c] = pow(mean[c] / cnt[c], 1.0f / 3.0f);
+
+  float croot_refavg[4]  = { 0.5f * (mean[1] + mean[2]), 0.5f * (mean[0] + mean[2]), 0.5f * (mean[0] + mean[1]), 0.0f};
+  return pow(croot_refavg[color], 3.0f);
+}
+
+kernel void
+highlights_initmask (read_only image2d_t in, global char *inmask, 
+                    const int width, const int height, const int psize, const int pwidth,
+                    const unsigned int filters, global const unsigned char (*const xtrans)[6],
+                    global const float *clips)
+{
+  const int col = get_global_id(0);
+  const int row = get_global_id(1);
+  if((col >= width) || (row >= height)) return;
+
+  float val = fmax(0.0f, read_imagef(in, sampleri, (int2)(col, row)).x);
+  const int color = (filters == 9u) ? FCxtrans(row, col, xtrans) : FC(row, col, filters);
+
+  const int idx = mad24(row/3, pwidth, col/3);
+  const char masked = (val >= clips[color]) ? 1 : 0;
+  inmask[idx + color*psize] = masked;
+}
+
+kernel void
+highlights_dilatemask (global char *in, global char *out, 
+                    const int w1, const int height, const int psize)
+{
+  const int col = get_global_id(0);
+  const int row = get_global_id(1);
+  if((col >= w1) || (row >= height)) return;
+
+  const int w2 = 2 * w1;
+  const int w3 = 3 * w1;
+
+  int i = mad24(row, w1, col);
+  char mask = 0;
+  if((col > 2) && (row > 2) && (col < w1 - 3) && (row < height - 3))
+  {
+    mask = in[i-w1-1] | in[i-w1] | in[i-w1+1] |
+           in[i-1]    | in[i]    | in[i+1] |
+           in[i+w1-1] | in[i+w1] | in[i+w1+1] |
+           in[i-w2-1] | in[i-w2] | in[i-w2+1] |
+           in[i-w1-2] | in[i-w1+2] | in[i-2]    | in[i+2] | in[i+w1-2] | in[i+w1+2] |
+           in[i+w2-1] | in[i+w2]   | in[i+w2+1] |
+           in[i-w3-2] | in[i-w3-1] | in[i-w3] | in[i-w3+1] | in[i-w3+2] |
+           in[i-w2-3] | in[i-w2-2] | in[i-w2+2] | in[i-w2+3] |
+           in[i-w1-3] | in[i-w1+3] | in[i-3] | in[i+3] | in[i+w1-3] | in[i+w1+3] |
+           in[i+w2-3] | in[i+w2-2] | in[i+w2+2] | in[i+w2+3] |
+           in[i+w3-2] | in[i+w3-1] | in[i+w3] | in[i+w3+1] | in[i+w3+2];
+  }
+  out[i] = mask;
+
+  i = psize + mad24(row, w1, col);
+  mask = 0;
+  if((col > 2) && (row > 2) && (col < w1 - 3) && (row < height - 3))
+  {
+    mask = in[i-w1-1] | in[i-w1] | in[i-w1+1] |
+           in[i-1]    | in[i]    | in[i+1] |
+           in[i+w1-1] | in[i+w1] | in[i+w1+1] |
+           in[i-w2-1] | in[i-w2] | in[i-w2+1] |
+           in[i-w1-2] | in[i-w1+2] | in[i-2]    | in[i+2] | in[i+w1-2] | in[i+w1+2] |
+           in[i+w2-1] | in[i+w2]   | in[i+w2+1] |
+           in[i-w3-2] | in[i-w3-1] | in[i-w3] | in[i-w3+1] | in[i-w3+2] |
+           in[i-w2-3] | in[i-w2-2] | in[i-w2+2] | in[i-w2+3] |
+           in[i-w1-3] | in[i-w1+3] | in[i-3] | in[i+3] | in[i+w1-3] | in[i+w1+3] |
+           in[i+w2-3] | in[i+w2-2] | in[i+w2+2] | in[i+w2+3] |
+           in[i+w3-2] | in[i+w3-1] | in[i+w3] | in[i+w3+1] | in[i+w3+2];
+  }
+  out[i] = mask;
+
+  i = 2*psize + mad24(row, w1, col);
+  mask = 0;
+  if((col > 2) && (row > 2) && (col < w1 - 3) && (row < height - 3))
+  {
+    mask = in[i-w1-1] | in[i-w1] | in[i-w1+1] |
+           in[i-1]    | in[i]    | in[i+1] |
+           in[i+w1-1] | in[i+w1] | in[i+w1+1] |
+           in[i-w2-1] | in[i-w2] | in[i-w2+1] |
+           in[i-w1-2] | in[i-w1+2] | in[i-2]    | in[i+2] | in[i+w1-2] | in[i+w1+2] |
+           in[i+w2-1] | in[i+w2]   | in[i+w2+1] |
+           in[i-w3-2] | in[i-w3-1] | in[i-w3] | in[i-w3+1] | in[i-w3+2] |
+           in[i-w2-3] | in[i-w2-2] | in[i-w2+2] | in[i-w2+3] |
+           in[i-w1-3] | in[i-w1+3] | in[i-3] | in[i+3] | in[i+w1-3] | in[i+w1+3] |
+           in[i+w2-3] | in[i+w2-2] | in[i+w2+2] | in[i+w2+3] |
+           in[i+w3-2] | in[i+w3-1] | in[i+w3] | in[i+w3+1] | in[i+w3+2];
+  }
+  out[i] = mask;
+}
+
+void atomic_add_f(
+    global float *val,
+    const  float delta)
+{
+#ifdef NVIDIA_SM_20
+  // buys me another 3x--10x over the `algorithmic' improvements in the splat kernel below,
+  // depending on configuration (sigma_s and sigma_r)
+  float res = 0;
+  asm volatile ("atom.global.add.f32 %0, [%1], %2;" : "=f"(res) : "l"(val), "f"(delta));
+
+#else
+  union
+  {
+    float f;
+    unsigned int i;
+  }
+  old_val;
+  union
+  {
+    float f;
+    unsigned int i;
+  }
+  new_val;
+
+  global volatile unsigned int *ival = (global volatile unsigned int *)val;
+
+  do
+  {
+    // the following is equivalent to old_val.f = *val. however, as according to the opencl standard
+    // we can not rely on global buffer val to be consistently cached (relaxed memory consistency) we 
+    // access it via a slower but consistent atomic operation.
+    old_val.i = atomic_add(ival, 0);
+    new_val.f = old_val.f + delta;
+  }
+  while (atomic_cmpxchg (ival, old_val.i, new_val.i) != old_val.i);
+#endif
+}
+
+kernel void
+highlights_chroma (read_only image2d_t in, global char *mask, global float *accu,
+                   const int width, const int height,
+                   const int pwidth, const int pheight, const int psize, 
+                   const int filters, global const unsigned char (*const xtrans)[6],
+                   global const float *clips, global const float *dark)
+{
+  const int col = get_global_id(0);
+  const int row = get_global_id(1);
+  if((col < 1) || (row < 1) || (col > width - 2) || (row > height - 2))
+    return;
+
+  const int idx = mad24(row, width, col);
+  const int color = (filters == 9u) ? FCxtrans(row, col, xtrans) : FC(row, col, filters);
+  const float inval = fmax(0.0f, read_imagef(in, sampleri, (int2)(col, row)).x);
+  const int px = mad24(row/3, pwidth, col/3);
+  if(mask[color * psize + px] && (inval > dark[color]) && (inval < clips[color]))
+  {
+    const float ref = _calc_refavg(in, xtrans, filters, row, col, width);
+    atomic_add_f(accu + color , inval - ref);
+    atomic_add_f(accu + color+4, 1.0f);
+  }
+}
+
+kernel void
+highlights_opposed (read_only image2d_t in, write_only image2d_t out,
+                    const int owidth, const int oheight, const int iwidth, const int iheight,
+                    const int dx, const int dy,
+                    const int filters, global const unsigned char (*const xtrans)[6],
+                    global const float *clips, global const float *chroma)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  if(x >= owidth || y >= oheight) return;
+
+  const int irow = y + dy;
+  const int icol = x + dx;
+  float val = 0.0f;
+
+  if((icol >= 0) && (icol < iwidth) && (irow >= 0) && (irow < iheight))
+  {
+    val = fmax(0.0f, read_imagef(in, sampleri, (int2)(icol, irow)).x);
+ 
+    if((icol > 0) && (icol < iwidth-1) && (irow > 0) && (irow < iheight-1))
+    {
+      const int color = (filters == 9u) ? FCxtrans(irow, icol, xtrans) : FC(irow, icol, filters);
+      if(val >= clips[color])
+      {
+        const float ref = _calc_refavg(in, xtrans, filters, irow, icol, iwidth);
+        val = fmax(val, ref + chroma[color]);
+      }
+    }
+  }
+  write_imagef (out, (int2)(x, y), val);
+}
+
 #define SQRT3 1.7320508075688772935274463415058723669f
 #define SQRT12 3.4641016151377545870548926830117447339f // 2*SQRT3
 kernel void

--- a/src/iop/hlrecovery_v2.c
+++ b/src/iop/hlrecovery_v2.c
@@ -419,15 +419,13 @@ static inline size_t _raw_to_plane(const int width, const int row, const int col
   return (HL_BORDER + (row / 3)) * width + (col / 3) + HL_BORDER;
 }
 
-static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const float *const input, float *const output,
                          const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
                          dt_iop_highlights_data_t *data, const int vmode, float *tmpout)
 {
   const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
   const uint32_t filters = piece->pipe->dsc.filters;
-
   const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
-
   const float clipval = fmaxf(0.1f, 0.987f * data->clip);
   const dt_aligned_pixel_t icoeffs = { piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1], piece->pipe->dsc.temperature.coeffs[2]};
   const dt_aligned_pixel_t clips = { clipval * icoeffs[0], clipval * icoeffs[1], clipval * icoeffs[2]}; 
@@ -443,16 +441,8 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
 
   const size_t pwidth  = dt_round_size(roi_in->width / 3, 2) + 2 * HL_BORDER;
   const size_t pheight = dt_round_size(roi_in->height / 3, 2) + 2 * HL_BORDER;
-  const size_t p_size = dt_round_size((size_t) (pwidth + 4) * (pheight + 4), 16);
+  const size_t p_size =  dt_round_size((size_t) pwidth * pheight, 64);
 
-  const size_t shift_x = roi_out->x;
-  const size_t shift_y = roi_out->y;
-
-  const size_t o_row_max = MIN(roi_out->height, roi_in->height - shift_y);
-  const size_t o_col_max = MIN(roi_out->width, roi_in->width - shift_x);
-  const size_t o_width = roi_out->width;
-  const size_t i_width = roi_in->width;
- 
   float *fbuffer = dt_alloc_align_float((HL_FLOAT_PLANES) * p_size);
   if(!fbuffer) return;
 
@@ -477,13 +467,12 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
   reduction( | : has_allclipped) \
   reduction( + : anyclipped) \
   dt_omp_firstprivate(tmpout, roi_in, plane, isegments, cube_coeffs, refavg, xtrans) \
-  dt_omp_sharedconst(pwidth, filters, i_width, xshifter) \
-  schedule(static)
+  dt_omp_sharedconst(pwidth, filters, xshifter) \
+  schedule(static) collapse(2)
 #endif
   for(size_t row = 1; row < roi_in->height-1; row++)
   {
-    float *in = tmpout + (size_t)i_width * row + 1;
-    for(size_t col = 1; col < i_width - 1; col++)
+    for(size_t col = 1; col < roi_in->width - 1; col++)
     {
       // calc all color planes in a 3x3 area. For chroma noise stability in bayer sensors we make sure
       // to align the box with a green photosite in centre so we always have a 5:2:2 ratio
@@ -495,7 +484,8 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
         {
           for(int dx = -1; dx < 2; dx++)
           {
-            const float val = in[(ssize_t)dy * i_width + dx];
+            const size_t idx = (row + dy) * roi_in->width + col + dx;
+            const float val = tmpout[idx];
             const int c = (filters == 9u) ? FCxtrans(row + dy, col + dx, roi_in, xtrans) : FC(row + dy, col + dx, filters);
             mean[c] += val;
             cnt[c] += 1.0f;
@@ -522,7 +512,6 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
         has_allclipped |= (allclipped == 3) ? TRUE : FALSE;
         anyclipped += allclipped;
       }
-      in++;
     }
   }
 
@@ -559,17 +548,16 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(clips, ivoid, tmpout, roi_in, xtrans, isegments, plane) \
-  dt_omp_sharedconst(filters, pwidth, i_width) \
-  schedule(static)
+  dt_omp_firstprivate(clips, input, tmpout, roi_in, xtrans, isegments, plane) \
+  dt_omp_sharedconst(filters, pwidth) \
+  schedule(static) collapse(2)
 #endif
   for(size_t row = 1; row < roi_in->height-1; row++)
   {
-    float *out = tmpout + i_width * row + 1;
-    float *in = (float *)ivoid + i_width * row + 1;
     for(size_t col = 1; col < roi_in->width - 1; col++)
     {
-      const float inval = fmaxf(0.0f, in[0]);
+      const size_t idx = row * roi_in->width + col;
+      const float inval = fmaxf(0.0f, input[idx]);
       const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
       if(inval > clips[color])
       {
@@ -581,14 +569,12 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
           if(candidate != 0.0f)
           {
             const float cand_reference = isegments[color].val2[pid];
-            const float refavg_here = _calc_refavg(&in[0], xtrans, filters, row, col, roi_in, FALSE);
+            const float refavg_here = _calc_refavg(&input[idx], xtrans, filters, row, col, roi_in, FALSE);
             const float oval = powf(refavg_here + candidate - cand_reference, HL_POWERF);
-            out[0] = plane[color][o] = fmaxf(inval, oval);
+            tmpout[idx] = plane[color][o] = fmaxf(inval, oval);
           }
         }
       }
-      out++;
-      in++;
     }
   }
 
@@ -656,27 +642,25 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
         }
       }
       const float dshift = 2.0f + (float)recovery_closing[recovery_mode];
+
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(clips, ivoid, tmpout, roi_in, xtrans, gradient, distance) \
-  dt_omp_sharedconst(filters, pwidth, dshift, strength, i_width, o_width) \
-  schedule(static)
+  dt_omp_firstprivate(clips, input, tmpout, roi_in, xtrans, gradient, distance) \
+  dt_omp_sharedconst(filters, pwidth, dshift, strength) \
+  schedule(static) collapse(2)
 #endif
       for(size_t row = 1; row < roi_in->height-1; row++)
       {
-        float *out = tmpout + i_width * row + 1;
-        float *in = (float *)ivoid + i_width * row + 1;
-        for(size_t col = 1; col < i_width - 1; col++)
+        for(size_t col = 1; col < roi_in->width - 1; col++)
         {
+          const size_t idx = row * roi_in->width + col;
           const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
-          if(fmaxf(0.0f, in[0]) > clips[color])
+          if(fmaxf(0.0f, input[idx]) > clips[color])
           {
             const size_t o = _raw_to_plane(pwidth, row, col);
             const float effect = strength / (1.0f + expf(-(distance[o] - dshift)));
-            out[0]+= fmaxf(0.0f, gradient[o] * effect);
+            tmpout[idx]+= fmaxf(0.0f, gradient[o] * effect);
           }
-          out++;
-          in++;
         }
       }
     }
@@ -684,55 +668,44 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const void *con
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ovoid, tmpout) \
-  dt_omp_sharedconst(o_row_max, o_col_max, o_width, i_width, shift_x, shift_y) \
-  schedule(static)
+  dt_omp_firstprivate(clips, output, tmpout, roi_in, roi_out, xtrans, isegments, gradient) \
+  dt_omp_sharedconst(filters, pwidth, vmode, strength, fullpipe) \
+  schedule(static) collapse(2)
 #endif
-  for(size_t row = 0; row < o_row_max; row++)
+  for(size_t row = 0; row < roi_out->height; row++)
   {
-    float *out = (float *)ovoid + o_width * row;
-    float *in = tmpout + i_width * (row + shift_y) + shift_x;
-    for(size_t col = 0; col < o_col_max; col++)
-      out[col] = in[col];
-  }
-
-  if((vmode != DT_HIGHLIGHTS_MASK_OFF) && fullpipe)
-  {
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(clips, ivoid, ovoid, roi_in, roi_out, xtrans, isegments, gradient) \
-  dt_omp_sharedconst(filters, pwidth, vmode, strength, o_row_max, o_col_max, o_width, i_width, shift_x, shift_y) \
-  schedule(static)
-#endif
-    for(size_t row = 0; row < o_row_max; row++)
+    for(size_t col = 0; col < roi_out->width; col++)
     {
-      float *out = (float *)ovoid + o_width * row;
-      float *in = (float *)ivoid + i_width * (row + shift_y) + shift_x;
-      for(size_t col = 0; col < o_col_max; col++)
+      const size_t odx = row * roi_out->width + col;
+      const size_t inrow = row + roi_out->y;
+      const size_t incol = col + roi_out->x;
+      const size_t idx = inrow * roi_in->width + incol;
+      if((inrow < roi_in->height) && (incol < roi_in->width))
       {
-        out[0] = 0.1f * fmaxf(0.0f, in[0]);
-        if((row > 0) && (col > 0) && (row < o_row_max - 1) && (col < o_col_max - 1))
+        output[odx] = tmpout[idx];
+        if((vmode != DT_HIGHLIGHTS_MASK_OFF) && fullpipe)
         {
-          const int color = (filters == 9u) ? FCxtrans(row + shift_y, col + shift_x, roi_in, xtrans) : FC(row + shift_y, col + shift_x, filters);
-          const size_t ppos = _raw_to_plane(pwidth, row + shift_y, col + shift_x);
-
-          const int pid = _get_segment_id(&isegments[color], ppos);
-          const gboolean isegment = ((pid > 1) && (pid < isegments[color].nr));
-          const gboolean goodseg = isegment && (isegments[color].val1[pid] != 0.0f);
-          const int allid = _get_segment_id(&isegments[3], ppos);
-          const gboolean allseg = ((allid > 1) && (allid < isegments[3].nr));
-          if((vmode == DT_HIGHLIGHTS_MASK_COMBINE) && isegment)         out[0] = (isegments[color].data[ppos] & DT_SEG_ID_MASK) ? 1.0f : 0.5f;
-          else if((vmode == DT_HIGHLIGHTS_MASK_CANDIDATING) && goodseg) out[0] = (ppos == isegments[color].ref[pid]) ? 1.0f : 0.5f;
-          else if((vmode == DT_HIGHLIGHTS_MASK_STRENGTH) && allseg)     out[0] += strength * gradient[ppos];
+          output[odx] *= 0.1f;
+          const gboolean inrefs = (inrow > 0) && (incol > 0) && (inrow < roi_in->height-1) && (incol < roi_in->width-1);
+          if(inrefs)
+          {
+            const int color = (filters == 9u) ? FCxtrans(inrow, incol, roi_in, xtrans) : FC(inrow, incol, filters);
+            const size_t ppos = _raw_to_plane(pwidth, inrow, incol);
+            const int pid = _get_segment_id(&isegments[color], ppos);
+            const gboolean isegment = ((pid > 1) && (pid < isegments[color].nr));
+            const gboolean goodseg = isegment && (isegments[color].val1[pid] != 0.0f);
+            const int allid = _get_segment_id(&isegments[3], ppos);
+            const gboolean allseg = ((allid > 1) && (allid < isegments[3].nr));
+            if((vmode == DT_HIGHLIGHTS_MASK_COMBINE) && isegment)         output[odx] = (isegments[color].data[ppos] & DT_SEG_ID_MASK) ? 1.0f : 0.6f;
+            else if((vmode == DT_HIGHLIGHTS_MASK_CANDIDATING) && goodseg) output[odx] = (ppos == isegments[color].ref[pid]) ? 1.0f : 0.6f;
+            else if((vmode == DT_HIGHLIGHTS_MASK_STRENGTH) && allseg)     output[odx] += strength * gradient[ppos];
+          }
         }
-        out++;
-        in++;
       }
     }
-    dt_dev_pixelpipe_flush_caches(piece->pipe);
   }
 
-  dt_vprint(DT_DEBUG_PERF, "[segmentation report %12s] %5.1fMpix, segments: %3i red, %3i green, %3i blue, %3i all, %4i allowed.\n",
+  dt_print(DT_DEBUG_PERF, "[segmentation report %12s] %5.1fMpix, segments: %3i red, %3i green, %3i blue, %3i all, %4i allowed.\n",
       dt_dev_pixelpipe_type_to_str(piece->pipe->type),     
       (float) (roi_in->width * roi_in->height) / 1.0e6f, isegments[0].nr -2, isegments[1].nr-2, isegments[2].nr-2, isegments[3].nr-2,
       segmentation_limit-2);

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2022 darktable developers.
+    Copyright (C) 2022-23 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -37,6 +37,7 @@
 
    Again the algorithm has been developed in collaboration by @garagecoder and @Iain from gmic team and @jenshannoschwalm from dt.
 */
+// #define DT_OPPCHROMA_HISTORY
 
 static inline float _calc_linear_refavg(const float *in, const int color)
 {
@@ -48,380 +49,482 @@ static inline float _calc_linear_refavg(const float *in, const int color)
   return powf(opp[color], HL_POWERF);
 }
 
-// A slightly modified version for sraws
-static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
-                         const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
-                         dt_iop_highlights_data_t *data)
+static inline size_t _raw_to_cmap(const size_t width, const size_t row, const size_t col)
 {
-  const float clipval = 0.987f * data->clip;
-  const dt_aligned_pixel_t icoeffs = { piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1], piece->pipe->dsc.temperature.coeffs[2]};
+  return (row / 3) * width + (col / 3);
+}
+
+static inline char _mask_dilated(const char *in, const size_t w1)
+{
+  if(in[0])
+    return 1;
+
+  if(in[-w1-1] | in[-w1] | in[-w1+1] | in[-1] | in[1] | in[w1-1] | in[w1] | in[w1+1])
+    return 1;
+
+  const size_t w2 = 2*w1;
+  const size_t w3 = 3*w1;
+  return  in[-w3-2] | in[-w3-1] | in[-w3] | in[-w3+1] | in[-w3+2] |
+          in[-w2-3] | in[-w2-2] | in[-w2-1] | in[-w2] | in[-w2+1] | in[-w2+2] | in[-w2+3] |
+          in[-w1-3] | in[-w1-2] | in[-w1+2] | in[-w1+3] |
+          in[-3]    | in[-2]    | in[2]     | in[3] |
+          in[w1-3]  | in[w1-2]  | in[w1+2]  | in[w1+3] |
+          in[w2-3]  | in[w2-2]  | in[w2-1]  | in[w2]  | in[w2+1]  | in[w2+2]  | in[w2+3] |
+          in[w3-2]  | in[w3-1]  | in[w3]  | in[w3+1]  | in[w3+2];
+}
+
+
+// A slightly modified version for sraws
+static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const float *const input, float *const output,
+                         const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out, const gboolean quality)
+{
+  dt_iop_highlights_data_t *d = (dt_iop_highlights_data_t *)piece->data;
+  const float clipval = 0.987f * d->clip;
+  const dt_iop_buffer_dsc_t *dsc = &piece->pipe->dsc;
+  const gboolean wbon = dsc->temperature.enabled;
+  const dt_aligned_pixel_t icoeffs = { wbon ? dsc->temperature.coeffs[0] : 1.0f,
+                                       wbon ? dsc->temperature.coeffs[1] : 1.0f,
+                                       wbon ? dsc->temperature.coeffs[2] : 1.0f};
   const dt_aligned_pixel_t clips = { clipval * icoeffs[0], clipval * icoeffs[1], clipval * icoeffs[2]}; 
   const dt_aligned_pixel_t clipdark = { 0.03f * clips[0], 0.125f * clips[1], 0.03f * clips[2] };   
 
-  const size_t pwidth  = dt_round_size(roi_in->width / 3, 2) + 2 * HL_BORDER;
-  const size_t pheight = dt_round_size(roi_in->height / 3, 2) + 2 * HL_BORDER;
-  const size_t p_size = (size_t) dt_round_size(pwidth * pheight, 64);
+  const size_t mwidth  = roi_in->width / 3;
+  const size_t mheight = roi_in->height / 3;
+  const size_t msize = dt_round_size((size_t) (mwidth+1) * (mheight+1), 64);
 
-  const size_t i_width = roi_in->width;
-  const size_t i_height = roi_in->height;
+  dt_aligned_pixel_t chrominance = {d->chroma_correction[0], d->chroma_correction[1], d->chroma_correction[2], 0.0f};
 
-  dt_aligned_pixel_t chrominance = {0.0f, 0.0f, 0.0f, 0.0f};
-  gboolean valid_chrominance = FALSE;
-  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
-  if(g && g->valid_chroma_correction)
+  if(!feqf(_color_magic(piece), d->chroma_correction[3], 1e-6f))
   {
-    valid_chrominance = TRUE;
-    for_each_channel(c)
-      chrominance[c] = g->chroma_correction[c];          
-  }
-
-  int *mask_buffer = dt_calloc_align(64, 4 * p_size * sizeof(int));
-  float *tmpout = dt_alloc_align_float(4 * roi_in->width * roi_in->height);
-
-  if(!tmpout || !mask_buffer)
-  {
+    char *mask = (quality) ? dt_calloc_align(64, 6 * msize * sizeof(char)) : NULL;
+    if(mask)
+    {
+      gboolean anyclipped = FALSE;
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ovoid, ivoid) \
-  dt_omp_sharedconst(i_width, i_height) \
+  reduction( | : anyclipped) \
+  dt_omp_firstprivate(clips, input, roi_in, mask) \
+  dt_omp_sharedconst(msize, mwidth) \
   schedule(static)
 #endif
-    for(size_t row = 0; row < i_height; row++)
-    {
-      float *out = (float *)ovoid + i_width * row * 4;
-      float *in = (float *)ivoid + 4 * i_width * row;
-      for(size_t col = 0; col < i_width; col++)
+      for(size_t row = 1; row < roi_in->height -1; row++)
       {
-        for_each_channel(c)
-          out[c] = fmaxf(0.0f, in[c]);
-        out += 4;
-        in += 4;
-      }
-    }
-    goto finish;
-  }
-
-  size_t anyclipped = 0;
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  reduction( + : anyclipped) \
-  dt_omp_firstprivate(clips, ivoid, tmpout, roi_in, mask_buffer) \
-  dt_omp_sharedconst(p_size, pwidth, pheight, i_width, i_height) \
-  schedule(static)
-#endif
-  for(size_t row = 0; row < i_height; row++)
-  {
-    float *tmp = tmpout + i_width * row * 4;
-    float *in = (float *)ivoid + i_width * row * 4;
-    for(size_t col = 0; col < i_width; col++)
-    {
-      for_each_channel(c)
-        tmp[c] = fmaxf(0.0f, in[c]);
-
-      if((col > 0) && (col < i_width - 1) && (row > 0) && (row < i_height - 1))
-      {
-        for_each_channel(c)
+        for(size_t col = 1; col < roi_in->width -1; col++)
         {
-          if(in[c] >= clips[c])
+          const size_t idx = (row * roi_in->width + col) * 4;
+          for_each_channel(c)
           {
-            tmp[c] = _calc_linear_refavg(&in[0], c);
-            mask_buffer[c * p_size + _raw_to_plane(pwidth, row, col)] |= 1;
-            anyclipped += 1;
+            if(input[idx+c] >= clips[c])
+            {
+              mask[c * msize + _raw_to_cmap(mwidth, row, col)] |= 1;
+              anyclipped |= TRUE;
+            }
           }
         }
       }
-      in += 4;
-      tmp += 4;
-    }
-  }
-
-  if(!valid_chrominance && (anyclipped > 5))
-  {
-    for(size_t i = 0; i < 3; i++)
-    {
-      int *mask = mask_buffer + i * p_size;
-      int *tmp = mask_buffer + 3 * p_size;
-      _intimage_borderfill(mask, pwidth, pheight, 0, HL_BORDER);
-      _dilating(mask, tmp, pwidth, pheight, HL_BORDER, 3);
-      memcpy(mask, tmp, p_size * sizeof(int));
-    }
-
-    dt_aligned_pixel_t cr_sum = {0.0f, 0.0f, 0.0f, 0.0f};
-    dt_aligned_pixel_t cr_cnt = {0.0f, 0.0f, 0.0f, 0.0f};
+      /* We want to use the photosites closely around clipped data to be taken into account.
+         The mask buffers holds data for each color channel, we dilate the mask buffer slightly
+         to get those locations.
+      */
+      if(anyclipped)
+      {
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ivoid, roi_in, clips, clipdark, mask_buffer) \
+  dt_omp_firstprivate(mask) \
+  dt_omp_sharedconst(mwidth, mheight, msize) \
+  schedule(static) collapse(2)
+#endif
+        for(size_t row = 3; row < mheight - 3; row++)
+        {
+          for(size_t col = 3; col < mwidth - 3; col++)
+          {
+            const size_t mx = row * mwidth + col;
+            mask[3*msize + mx] = _mask_dilated(mask + mx, mwidth);
+            mask[4*msize + mx] = _mask_dilated(mask + msize + mx, mwidth);
+            mask[5*msize + mx] = _mask_dilated(mask + 2*msize + mx, mwidth);
+          }
+        }
+
+        dt_aligned_pixel_t cr_sum = {0.0f, 0.0f, 0.0f, 0.0f};
+        dt_aligned_pixel_t cr_cnt = {0.0f, 0.0f, 0.0f, 0.0f};
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(input, roi_in, clips, clipdark, mask) \
   reduction(+ : cr_sum, cr_cnt) \
-  dt_omp_sharedconst(p_size, pwidth, i_width, i_height) \
+  dt_omp_sharedconst(msize, mwidth) \
   schedule(static)
 #endif
-    for(size_t row = 1; row < i_height-1; row++)
-    {
-      float *in  = (float *)ivoid + i_width * row * 4 + 4;
-      for(size_t col = 1; col < i_width - 1; col++)
-      {
-        for_each_channel(c)
+        for(size_t row = 1; row < roi_in->height-1; row++)
         {
-          const float inval = fmaxf(0.0f, in[c]); 
-          if((inval > clipdark[c]) && (inval < clips[c]) && (mask_buffer[c * p_size + _raw_to_plane(pwidth, row, col)]))
+          for(size_t col = 1; col < roi_in->width - 1; col++)
           {
-            cr_sum[c] += inval - _calc_linear_refavg(&in[0], c);
-            cr_cnt[c] += 1.0f;
+            const size_t idx = (row * roi_in->width + col) * 4;
+            for_each_channel(c)
+            {
+              const float inval = fmaxf(0.0f, input[idx+c]); 
+              if((inval > clipdark[c]) && (inval < clips[c]) && (mask[(c+3) * msize + _raw_to_cmap(mwidth, row, col)]))
+              {
+                cr_sum[c] += inval - _calc_linear_refavg(&input[idx], c);
+                cr_cnt[c] += 1.0f;
+              }
+            }
           }
         }
-        in += 4;
+        for_each_channel(c)
+          chrominance[c] = cr_sum[c] / fmaxf(1.0f, cr_cnt[c]);
+      }
+
+      // also checking for an altered image to avoid xmp writing if not desired
+      if((piece->pipe->type == DT_DEV_PIXELPIPE_FULL)
+         && (abs((int)(roi_out->width / roi_out->scale) - piece->buf_in.width) < 10)
+         && (abs((int)(roi_out->height / roi_out->scale) - piece->buf_in.height) < 10)
+         && dt_image_altered(piece->pipe->image.id))
+      {
+        dt_iop_highlights_params_t *p = (dt_iop_highlights_params_t *)self->params;
+        for(int c = 0; c < 3; c++)
+          d->chroma_correction[c] = p->chroma_correction[c] = chrominance[c];
+        d->chroma_correction[3] = p->chroma_correction[3] = _color_magic(piece);
+        dt_dev_add_history_item(darktable.develop, self, TRUE);
+#ifdef DT_OPPCHROMA_HISTORY
+        fprintf(stderr, "[new linear chroma history] %f %f %f\n", chrominance[0], chrominance[1], chrominance[2]);
+#endif
       }
     }
-    for_each_channel(c)
-      chrominance[c] = cr_sum[c] / fmaxf(1.0f, cr_cnt[c]);    
-
-    if(g && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL)
-         && ((int)(roi_out->width / roi_out->scale) == piece->buf_in.width))
-    {
-      for_each_channel(c)
-        g->chroma_correction[c] = chrominance[c];
-      g->valid_chroma_correction = TRUE;
-    }
+    dt_free_align(mask);
   }
-
-/* We kept the refavg data in tmpout[] in the first loop, just overwrite output data with
-   chrominance corrections now.
-*/
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ovoid, ivoid, tmpout, chrominance, clips) \
-  dt_omp_sharedconst(i_width, i_height) \
-  schedule(static)
+  dt_omp_firstprivate(output, input, roi_in, roi_out, chrominance, clips) \
+  schedule(static) collapse(2)
 #endif
-  for(size_t row = 0; row < i_height; row++)
+  for(ssize_t row = 0; row < roi_out->height; row++)
   {
-    float *out = (float *)ovoid + i_width * row * 4;
-    float *tmp = tmpout + 4 * i_width * row;
-    float *in = (float *)ivoid + 4 * i_width * row;
-    for(size_t col = 0; col < i_width; col++)
+    for(ssize_t col = 0; col < roi_out->width; col++)
     {
+      const ssize_t odx = (row * roi_out->width + col) * 4;
+      const ssize_t inrow = MIN(row, roi_in->height-1);
+      const ssize_t incol = MIN(col, roi_in->width-1);
+      const ssize_t idx = (inrow * roi_in->width + incol) * 4;
       for_each_channel(c)
       {
-        const float inval = fmaxf(0.0f, in[c]);
-        out[c] = (inval >= clips[c]) ? fmaxf(inval, tmp[c] + chrominance[c]) : inval;
+        const float ref = _calc_linear_refavg(&input[idx], c);
+        const float inval = fmaxf(0.0f, input[idx+c]);
+        output[odx+c] = (inval >= clips[c]) ? fmaxf(inval, ref + chrominance[c]) : inval;
       }
-      out += 4;
-      tmp += 4;
-      in += 4;
     }
   }
-
-  finish:
-  dt_free_align(tmpout);
-  dt_free_align(mask_buffer);
 }
 
-static float *_process_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+static float *_process_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const float *const input, float *const output,
                          const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
-                         dt_iop_highlights_data_t *data, const gboolean keep, const gboolean quality)
+                         const gboolean keep, const gboolean quality)
 {
+  dt_iop_highlights_data_t *d = (dt_iop_highlights_data_t *)piece->data;
   const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
   const uint32_t filters = piece->pipe->dsc.filters;
-  const float clipval = 0.987f * data->clip;
-  const dt_aligned_pixel_t icoeffs = { piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1], piece->pipe->dsc.temperature.coeffs[2]};
+  const float clipval = 0.987f * d->clip;
+  const dt_iop_buffer_dsc_t *dsc = &piece->pipe->dsc;
+  const gboolean wbon = dsc->temperature.enabled;
+  const dt_aligned_pixel_t icoeffs = { wbon ? dsc->temperature.coeffs[0] : 1.0f,
+                                       wbon ? dsc->temperature.coeffs[1] : 1.0f,
+                                       wbon ? dsc->temperature.coeffs[2] : 1.0f};
   const dt_aligned_pixel_t clips = { clipval * icoeffs[0], clipval * icoeffs[1], clipval * icoeffs[2]};
   const dt_aligned_pixel_t clipdark = { 0.03f * clips[0], 0.125f * clips[1], 0.03f * clips[2] };
 
-  const size_t pwidth  = dt_round_size(roi_in->width / 3, 2) + 2 * HL_BORDER;
-  const size_t pheight = dt_round_size(roi_in->height / 3, 2) + 2 * HL_BORDER;
-  const size_t p_size = (size_t) dt_round_size((size_t) (pwidth + 4) * (pheight + 4), 64);
+  const size_t mwidth  = roi_in->width / 3;
+  const size_t mheight = roi_in->height / 3;
+  const size_t msize = dt_round_size((size_t) (mwidth+1) * (mheight+1), 64);
 
-  int *mask_buffer = dt_calloc_align(64, 4 * p_size * sizeof(int));
-  float *tmpout = dt_alloc_align_float(roi_in->width * roi_in->height);
+  dt_aligned_pixel_t chrominance = {d->chroma_correction[0], d->chroma_correction[1], d->chroma_correction[2], 0.0f};
 
-  const size_t shift_x = roi_out->x;
-  const size_t shift_y = roi_out->y;
-
-  const size_t o_row_max = MIN(roi_out->height, roi_in->height - shift_y);
-  const size_t o_col_max = MIN(roi_out->width, roi_in->width - shift_x);
-  const size_t o_width = roi_out->width;
-  const size_t i_width = roi_in->width;
-  if((o_row_max != roi_out->height) || (o_col_max != roi_out->width))
-    dt_iop_image_fill((float *)ovoid, 0.0f, roi_out->width, roi_out->height, 1);
-
-  dt_aligned_pixel_t chrominance = {0.0f, 0.0f, 0.0f, 0.0f};
-  gboolean valid_chrominance = FALSE;
-  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
-  if(g && g->valid_chroma_correction)
+  if(!feqf(_color_magic(piece), d->chroma_correction[3], 1e-6f))
   {
-    valid_chrominance = TRUE;
-    for_each_channel(c)
-      chrominance[c] = g->chroma_correction[c];          
-  }
-
-  if(!tmpout || !mask_buffer)
-  {
+    char *mask = (quality) ? dt_calloc_align(64, 6 * msize * sizeof(char)) : NULL;
+    if(mask)
+    {
+      gboolean anyclipped = FALSE;
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ovoid, ivoid) \
-  dt_omp_sharedconst(o_row_max, o_col_max, o_width, i_width, shift_x, shift_y) \
-  schedule(static)
+  reduction( | : anyclipped) \
+  dt_omp_firstprivate(clips, input, roi_in, xtrans, mask) \
+  dt_omp_sharedconst(filters, msize, mwidth) \
+  schedule(static) collapse(2)
 #endif
-    for(size_t row = 0; row < o_row_max; row++)
-    {
-      float *out = (float *)ovoid + o_width * row;
-      float *in = (float *)ivoid + i_width * (row + shift_y) + shift_x;
-      for(size_t col = 0; col < o_col_max; col++)
-        out[col] = fmaxf(0.0f, in[col]);
-    }
-    dt_free_align(tmpout);
-    dt_free_align(mask_buffer);
-    return NULL;
-  }
-
-  size_t anyclipped = 0;
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  reduction( + : anyclipped) \
-  dt_omp_firstprivate(clips, ivoid, tmpout, roi_in, xtrans, mask_buffer) \
-  dt_omp_sharedconst(filters, p_size, pwidth, pheight, i_width, o_width) \
-  schedule(static)
-#endif
-  for(size_t row = 0; row < roi_in->height; row++)
-  {
-    float *tmp = tmpout + i_width * row;
-    float *in = (float *)ivoid + i_width * row;
-    for(size_t col = 0; col < i_width; col++)
-    {
-      const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
-      tmp[0] = fmaxf(0.0f, in[0]);
-      
-      if((tmp[0] >= clips[color]) && (col > 0) && (col < i_width - 1) && (row > 0) && (row < roi_in->height - 1))
+      for(size_t row = 1; row < roi_in->height -1; row++)
       {
-        /* for the clipped photosites we later do the correction when the chrominance is available, we keep refavg in raw-RGB */
-        tmp[0] = _calc_refavg(&in[0], xtrans, filters, row, col, roi_in, TRUE);
-        mask_buffer[color * p_size + _raw_to_plane(pwidth, row, col)] |= 1;
-        anyclipped += 1;
-      }
-      tmp++;
-      in++;
-    }
-  }
-
-  if(!valid_chrominance && (anyclipped > 5) && quality)
-  {
-  /* We want to use the photosites closely around clipped data to be taken into account.
-     The mask buffers holds data for each color channel, we dilate the mask buffer slightly
-     to get those locations.
-     As the mask buffers are scaled down by 3 the dilate is very fast. 
-  */      
-    for(size_t i = 0; i < 3; i++)
-    {
-      int *mask = mask_buffer + i * p_size;
-      int *tmp = mask_buffer + 3 * p_size;
-      _intimage_borderfill(mask, pwidth, pheight, 0, HL_BORDER);
-      _dilating(mask, tmp, pwidth, pheight, HL_BORDER, 3);
-      memcpy(mask, tmp, p_size * sizeof(int));
-    }
-
-  /* After having the surrounding mask for each color channel we can calculate the chrominance corrections. */ 
-    dt_aligned_pixel_t cr_sum = {0.0f, 0.0f, 0.0f, 0.0f};
-    dt_aligned_pixel_t cr_cnt = {0.0f, 0.0f, 0.0f, 0.0f};
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ivoid, roi_in, xtrans, clips, clipdark, mask_buffer) \
-  reduction(+ : cr_sum, cr_cnt) \
-  dt_omp_sharedconst(filters, p_size, pwidth, i_width) \
-  schedule(static)
-#endif
-    for(size_t row = 1; row < roi_in->height - 1; row++)
-    {
-      float *in  = (float *)ivoid + i_width * row + 1;
-      for(size_t col = 1; col < i_width - 1; col++)
-      {
-        const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
-        const float inval = fmaxf(0.0f, in[0]); 
-        /* we only use the unclipped photosites very close the true clipped data
-           to calculate the chrominance offset */
-        if((mask_buffer[color * p_size + _raw_to_plane(pwidth, row, col)]) && (inval > clipdark[color]) && (inval < clips[color]))
+        for(size_t col = 1; col < roi_in->width -1; col++)
         {
-          cr_sum[color] += inval - _calc_refavg(&in[0], xtrans, filters, row, col, roi_in, TRUE);
-          cr_cnt[color] += 1.0f;
+          const size_t idx = row * roi_in->width + col;
+          const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
+          if(fmaxf(0.0f, input[idx]) >= clips[color])
+          {
+            mask[color * msize + _raw_to_cmap(mwidth, row, col)] |= 1;
+            anyclipped |= TRUE;
+          }
         }
-        in++;
       }
-    }
-    for_each_channel(c)
-      chrominance[c] = cr_sum[c] / fmaxf(1.0f, cr_cnt[c]);
-
-    // fprintf(stderr, "[opposed chroma corrections] %f, %f, %f\n", chrominance[0], chrominance[1], chrominance[2]);          
-
-    if(g && piece->pipe->type & DT_DEV_PIXELPIPE_FULL)
-    {
-      for_each_channel(c)
-        g->chroma_correction[c] = chrominance[c];
-      g->valid_chroma_correction = TRUE;
-    }
-  }
-
-  if(keep && anyclipped)
-  {
-/* We kept the refavg data in tmpout[] in the first loop, just overwrite output data with
-   chrominance corrections now. Also leave in tmpout for further postprocessing.
-*/
+      /* We want to use the photosites closely around clipped data to be taken into account.
+         The mask buffers holds data for each color channel, we dilate the mask buffer slightly
+         to get those locations.
+         If there are no clipped locations we keep the chrominance correction at 0 but make it valid 
+      */
+      if(anyclipped)
+      {
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(clips, ivoid, tmpout, roi_in, xtrans, chrominance) \
-  dt_omp_sharedconst(filters, o_row_max, o_col_max, i_width) \
-  schedule(static)
+  dt_omp_firstprivate(mask) \
+  dt_omp_sharedconst(mwidth, mheight, msize) \
+  schedule(static) collapse(2)
+#endif
+        for(size_t row = 3; row < mheight - 3; row++)
+        {
+          for(size_t col = 3; col < mwidth - 3; col++)
+          {
+            const size_t mx = row * mwidth + col;
+            mask[3*msize + mx] = _mask_dilated(mask + mx, mwidth);
+            mask[4*msize + mx] = _mask_dilated(mask + msize + mx, mwidth);
+            mask[5*msize + mx] = _mask_dilated(mask + 2*msize + mx, mwidth);
+          }
+        }
+
+        /* After having the surrounding mask for each color channel we can calculate the chrominance corrections. */ 
+        dt_aligned_pixel_t cr_sum = {0.0f, 0.0f, 0.0f, 0.0f};
+        dt_aligned_pixel_t cr_cnt = {0.0f, 0.0f, 0.0f, 0.0f};
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(input, roi_in, xtrans, clips, clipdark, mask) \
+  reduction(+ : cr_sum, cr_cnt) \
+  dt_omp_sharedconst(filters, msize, mwidth) \
+  schedule(static) collapse(2)
+#endif
+        for(size_t row = 1; row < roi_in->height - 1; row++)
+        {
+          for(size_t col = 1; col < roi_in->width - 1; col++)
+          {
+            const size_t idx = row * roi_in->width + col;
+            const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
+            const float inval = fmaxf(0.0f, input[idx]); 
+            /* we only use the unclipped photosites very close the true clipped data to calculate the chrominance offset */
+            if((inval < clips[color]) && (inval > clipdark[color]) && (mask[(color+3) * msize + _raw_to_cmap(mwidth, row, col)]))
+            {
+              cr_sum[color] += inval - _calc_refavg(&input[idx], xtrans, filters, row, col, roi_in, TRUE);
+              cr_cnt[color] += 1.0f;
+            }
+          }
+        }
+        for_each_channel(c)
+          chrominance[c] = cr_sum[c] / fmaxf(1.0f, cr_cnt[c]);
+      }
+
+      // also checking for an altered image to avoid xmp writing if not desired
+      if((piece->pipe->type == DT_DEV_PIXELPIPE_FULL) && dt_image_altered(piece->pipe->image.id))
+      {
+        dt_iop_highlights_params_t *p = (dt_iop_highlights_params_t *)self->params;
+        for(int c = 0; c < 3; c++)
+          d->chroma_correction[c] = p->chroma_correction[c] = chrominance[c];
+        d->chroma_correction[3] = p->chroma_correction[3] = _color_magic(piece);
+        dt_dev_add_history_item(darktable.develop, self, TRUE);
+#ifdef DT_OPPCHROMA_HISTORY
+        fprintf(stderr, "[new chroma history] %f %f %f\n", chrominance[0], chrominance[1], chrominance[2]);
+#endif
+      }
+    }
+    dt_free_align(mask);
+  }
+ 
+  float *tmpout = (keep) ? dt_alloc_align_float(roi_in->width * roi_in->height) : NULL;
+  if(tmpout)
+  {
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(clips, input, tmpout, roi_in, xtrans, chrominance) \
+  dt_omp_sharedconst(filters) \
+  schedule(static) collapse(2)
 #endif
     for(size_t row = 0; row < roi_in->height; row++)
     {
-      float *in = (float *)ivoid + i_width * row;
-      float *tmp = tmpout + i_width * row;
-      for(size_t col = 0; col < i_width; col++)
+      for(size_t col = 0; col < roi_in->width; col++)
       {
-        const float inval = fmaxf(0.0f, in[0]);
+        const size_t idx = row * roi_in->width + col;
         const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
-        if(inval > clips[color])
-          tmp[0] = fmaxf(inval, tmp[0] + chrominance[color]);
-        in++;
-        tmp++;
+        const float inval = fmaxf(0.0f, input[idx]);
+        if((inval >= clips[color]) && (col > 0) && (col < roi_in->width - 1) && (row > 0) && (row < roi_in->height - 1))
+        {
+          const float ref = _calc_refavg(&input[idx], xtrans, filters, row, col, roi_in, TRUE);
+          tmpout[idx] = fmaxf(inval, ref + chrominance[color]);
+        }
+        else
+          tmpout[idx] = inval;
       }
     }
-
+  }
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ovoid, tmpout) \
-  dt_omp_sharedconst(o_row_max, o_col_max, i_width, o_width, shift_x, shift_y) \
-  schedule(static)
+  dt_omp_firstprivate(output, input, tmpout, chrominance, clips, xtrans, roi_in, roi_out) \
+  dt_omp_sharedconst(filters) \
+  schedule(static) collapse(2)
 #endif
-    for(size_t row = 0; row < o_row_max; row++)
-    {
-      float *out = (float *)ovoid + o_width * row;
-      float *tmp = tmpout + i_width * (row + shift_y) + shift_x;
-      for(size_t col = 0; col < o_col_max; col++)
-        out[col] = tmp[col];
-    }
-  }
-  else
+  for(size_t row = 0; row < roi_out->height; row++)
   {
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ovoid, ivoid, tmpout, chrominance, clips, xtrans, roi_in) \
-  dt_omp_sharedconst(filters, o_row_max, o_col_max, o_width, i_width, shift_x, shift_y) \
-  schedule(static)
-#endif
-    for(size_t row = 0; row < o_row_max; row++)
+    for(size_t col = 0; col < roi_out->width; col++) 
     {
-      float *out = (float *)ovoid + o_width * row;
-      float *tmp = tmpout + i_width * (row + shift_y) + shift_x;
-      float *in = (float *)ivoid + i_width * (row + shift_y) + shift_x;
-      for(size_t col = 0; col < o_col_max; col++)
+      const size_t odx = row * roi_out->width + col;
+      const size_t irow = row + roi_out->y;
+      const size_t icol = col + roi_out->x;
+      const size_t ix = irow * roi_in->width + icol;
+      float oval = 0.0f;
+      if((irow < roi_in->height) && (icol < roi_in->width))
       {
-        const float inval = fmaxf(0.0f, in[col]);
-        const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
-        out[col] = (inval >= clips[color]) ? fmaxf(inval, tmp[col] + chrominance[color]) : inval;
+        if(tmpout)
+          oval = tmpout[ix];
+        else
+        { 
+          const int color = (filters == 9u) ? FCxtrans(irow, icol, roi_in, xtrans) : FC(irow, icol, filters);
+          const gboolean inrefs = (irow > 0) && (icol > 0) && (irow < roi_in->height-1) && (icol < roi_in->width-1);
+          oval = fmaxf(0.0f, input[ix]);
+          if(inrefs && (oval >= clips[color]))
+          {
+            const float ref = _calc_refavg(&input[ix], xtrans, filters, irow, icol, roi_in, TRUE);
+            oval = fmaxf(oval, ref + chrominance[color]);
+          }
+        }
       }
+      output[odx] = oval;
     }
   }
-
-  dt_free_align(mask_buffer);
   return tmpout;
 }
+
+#ifdef HAVE_OPENCL
+static cl_int process_opposed_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
+                                         cl_mem dev_in, cl_mem dev_out,
+                                         const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+  dt_iop_highlights_data_t *d = (dt_iop_highlights_data_t *)piece->data;
+  const dt_iop_highlights_global_data_t *gd = (dt_iop_highlights_global_data_t *)self->global_data;
+
+  const int devid = piece->pipe->devid;
+  const uint32_t filters = piece->pipe->dsc.filters;
+  const float clipval = 0.987f * d->clip;
+  const dt_iop_buffer_dsc_t *dsc = &piece->pipe->dsc;
+  const gboolean wbon = dsc->temperature.enabled;
+  const dt_aligned_pixel_t icoeffs = { wbon ? dsc->temperature.coeffs[0] : 1.0f,
+                                       wbon ? dsc->temperature.coeffs[1] : 1.0f,
+                                       wbon ? dsc->temperature.coeffs[2] : 1.0f};
+
+  dt_aligned_pixel_t clips = { clipval * icoeffs[0], clipval * icoeffs[1], clipval * icoeffs[2], 1.0f};
+  dt_aligned_pixel_t chrominance = { d->chroma_correction[0], d->chroma_correction[1], d->chroma_correction[2], 0.0f};
+  dt_aligned_pixel_t clipdark = { 0.03f * clips[0], 0.125f * clips[1], 0.03f * clips[2], 0.0f };
+
+  cl_int err = DT_OPENCL_DEFAULT_ERROR;
+  cl_mem dev_chrominance = NULL;
+  cl_mem dev_dark = NULL;
+  cl_mem dev_xtrans = NULL;
+  cl_mem dev_clips = NULL;
+  cl_mem dev_inmask = NULL;
+  cl_mem dev_outmask = NULL;
+  cl_mem dev_accu = NULL;
+
+  const size_t iwidth = ROUNDUPDWD(roi_in->width, devid);
+  const size_t iheight = ROUNDUPDHT(roi_in->height, devid);
+
+  const int mwidth  = roi_in->width / 3;
+  const int mheight = roi_in->height / 3;
+  const int msize = dt_round_size((size_t) (mwidth+1) * (mheight+1), 64);
+
+  dev_xtrans = dt_opencl_copy_host_to_device_constant(devid, sizeof(piece->pipe->dsc.xtrans), piece->pipe->dsc.xtrans);
+  if(dev_xtrans == NULL) goto error;
+
+  dev_clips = dt_opencl_copy_host_to_device_constant(devid, 4 * sizeof(float), clips);
+  if(dev_clips == NULL) goto error;
+
+  if(!feqf(_color_magic(piece), d->chroma_correction[3], 1e-6f))
+  {
+    // We don't have valid chrominance correction so go the hard way
+    dev_dark = dt_opencl_copy_host_to_device_constant(devid, 4 * sizeof(float), clipdark);
+    if(dev_dark == NULL) goto error;
+
+    dev_inmask = dt_opencl_alloc_device_buffer(devid, sizeof(char) * 3 * msize);
+    if(dev_inmask == NULL) goto error;
+
+    dev_outmask =  dt_opencl_alloc_device_buffer(devid, sizeof(char) * 3 * msize);
+    if(dev_outmask == NULL) goto error;
+
+    dev_accu = dt_opencl_alloc_device_buffer(devid, sizeof(float) * 8);
+    if(dev_accu == NULL) goto error;
+
+    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_highlights_initmask, iwidth, iheight,
+            CLARG(dev_in), CLARG(dev_inmask), CLARG(roi_in->width), CLARG(roi_in->height), CLARG(msize), CLARG(mwidth),
+            CLARG(filters), CLARG(dev_xtrans), CLARG(dev_clips));
+    if(err != CL_SUCCESS) goto error;
+
+    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_highlights_dilatemask, mwidth, mheight,
+            CLARG(dev_inmask), CLARG(dev_outmask), CLARG(mwidth), CLARG(mheight), CLARG(msize));
+    if(err != CL_SUCCESS) goto error;
+
+    float accu[8] = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
+    err = dt_opencl_write_buffer_to_device(devid, accu, dev_accu, 0, 8 * sizeof(float), TRUE);
+    if(err != CL_SUCCESS) goto error;
+
+    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_highlights_chroma, iwidth, iheight,
+            CLARG(dev_in), CLARG(dev_outmask), CLARG(dev_accu),
+            CLARG(roi_in->width), CLARG(roi_in->height),
+            CLARG(mwidth), CLARG(mheight), CLARG(msize),
+            CLARG(filters), CLARG(dev_xtrans),
+            CLARG(dev_clips), CLARG(dev_dark)); 
+    if(err != CL_SUCCESS) goto error;
+
+    err = dt_opencl_read_buffer_from_device(devid, accu, dev_accu, 0, 8 * sizeof(float), TRUE);
+    if(err != CL_SUCCESS) goto error;
+
+    for(int c = 0; c < 3; c++)
+      chrominance[c] = accu[c] / fmaxf(1.0f, accu[c+4]);
+
+    // also checking for an altered image to avoid xmp writing if not desired
+    if((piece->pipe->type == DT_DEV_PIXELPIPE_FULL) && dt_image_altered(piece->pipe->image.id))
+    {
+      dt_iop_highlights_params_t *p = (dt_iop_highlights_params_t *)self->params;
+      for(int c = 0; c < 3; c++)
+        d->chroma_correction[c] = p->chroma_correction[c] = chrominance[c];
+      d->chroma_correction[3] = p->chroma_correction[3] = _color_magic(piece);
+      dt_dev_add_history_item(darktable.develop, self, TRUE);
+#ifdef DT_OPPCHROMA_HISTORY
+      fprintf(stderr, "[new OpenCL chroma history] %f %f %f\n", chrominance[0], chrominance[1], chrominance[2]);
+#endif
+    }
+  }
+
+  dev_chrominance = dt_opencl_copy_host_to_device_constant(devid, 4 * sizeof(float), chrominance);
+  if(dev_chrominance == NULL) goto error;
+
+  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_highlights_opposed, iwidth, iheight,
+          CLARG(dev_in), CLARG(dev_out),
+          CLARG(roi_out->width), CLARG(roi_out->height), CLARG(roi_in->width), CLARG(roi_in->height),
+          CLARG(roi_out->x), CLARG(roi_out->y), CLARG(filters), CLARG(dev_xtrans),
+          CLARG(dev_clips), CLARG(dev_chrominance));
+  if(err != CL_SUCCESS) goto error;
+
+  dt_opencl_release_mem_object(dev_clips);
+  dt_opencl_release_mem_object(dev_xtrans);
+  dt_opencl_release_mem_object(dev_chrominance);
+  dt_opencl_release_mem_object(dev_dark);
+  dt_opencl_release_mem_object(dev_inmask);
+  dt_opencl_release_mem_object(dev_outmask);
+  dt_opencl_release_mem_object(dev_accu);
+  return CL_SUCCESS;
+
+  error:
+  // just in case the last error was generated via a copy function
+  if(err == CL_SUCCESS) err = DT_OPENCL_DEFAULT_ERROR;
+
+  dt_opencl_release_mem_object(dev_clips);
+  dt_opencl_release_mem_object(dev_xtrans);
+  dt_opencl_release_mem_object(dev_chrominance);
+  dt_opencl_release_mem_object(dev_dark);
+  dt_opencl_release_mem_object(dev_inmask);
+  dt_opencl_release_mem_object(dev_outmask);
+  dt_opencl_release_mem_object(dev_accu);
+  return err;
+}
+#endif
 

--- a/src/iop/segmentation.h
+++ b/src/iop/segmentation.h
@@ -592,10 +592,13 @@ void dt_segmentize_plane(dt_iop_segmentation_t *seg)
   dt_ff_stack_t stack;  
   const size_t width = seg->width;
   const size_t height = seg->height;
-  stack.size = width * height / 16;
-  stack.el = dt_alloc_align(16, stack.size * sizeof(dt_pos_t));
-  if(!stack.el) return;
-
+  stack.size = width * height / 32;
+  stack.el = dt_alloc_align(64, stack.size * sizeof(dt_pos_t));
+  if(!stack.el)
+  {
+    fprintf(stderr, "[segmentize_plane] can't allocate segmentation stack\n");
+    return;
+  }
   const size_t border = seg->border;
   int id = 2;
   for(size_t row = border; row < height - border; row++)
@@ -612,8 +615,9 @@ void dt_segmentize_plane(dt_iop_segmentation_t *seg)
 
   finish:
 
-  if((id >= (seg->slots - 2)) && (darktable.unmuted & DT_DEBUG_VERBOSE))
-    fprintf(stderr, "[segmentize_plane] number of segments exceed maximum=%i\n", seg->slots);
+  if(id >= (seg->slots - 2))
+    fprintf(stderr, "[segmentize_plane] %ix%i number of segments exceeds maximum=%i\n",
+      (int)width, (int)height, seg->slots);
 
   dt_free_align(stack.el);
 }


### PR DESCRIPTION
Performance and stability updates for highlights reconstruction.

1. No change of color reconstruction maths, segmentation or module parameters/version
2. A major refactoring in opposed possibly making use of validated chroma correction doubles the opposed algorithm performance and halfes the memory footprint.
3. Full OpenCL support for raw files inpaint opposed.
4. We keep track of the mask visualizers in a single gui data element `dt_highlights_mask_t hlr_mask_mode`
5. No "dirty tricks" invalidating the iop cache any more for performance.
6. Always write to full roi_out space by cropping input instead of limiting the output size. Fixes uninitialized roi_out data.
7. Proper 64 aligning of p_size
8. a subtle border fix while calculation the chroma correction
9. Some work on segmentation stack, proper aligning, some error messages in case of errors and reduced size
10. Use smaller&faster char mask with lower mem footprint for opposed chroma correction

EDIT: this reflects current PR status