### PR TITLE
lighttable : fix act_on list with shortcut + mouse move

### DIFF
--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -572,8 +572,10 @@ static gboolean _event_leave_notify(GtkWidget *widget, GdkEventCrossing *event, 
   }
 
   // if we leave thumbtable in favour of an inferior (a thumbnail) it's not a real leave !
-  // same if this is not a mouse move action (shortcut that activate a buuton for example)
-  if(event->detail == GDK_NOTIFY_INFERIOR || event->mode == GDK_CROSSING_GTK_GRAB) return FALSE;
+  // same if this is not a mouse move action (shortcut that activate a button for example)
+  if(event->detail == GDK_NOTIFY_INFERIOR || event->mode == GDK_CROSSING_GTK_GRAB
+     || event->mode == GDK_CROSSING_GRAB)
+    return FALSE;
 
   table->mouse_inside = FALSE;
   dt_control_set_mouse_over_id(-1);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1060,8 +1060,10 @@ static gboolean _event_leave_notify(GtkWidget *widget, GdkEventCrossing *event, 
   }
 
   // if we leave thumbtable in favour of an inferior (a thumbnail) it's not a real leave !
-  // same if this is not a mouse move action (shortcut that activate a buuton for example)
-  if(event->detail == GDK_NOTIFY_INFERIOR || event->mode == GDK_CROSSING_GTK_GRAB) return FALSE;
+  // same if this is not a mouse move action (shortcut that activate a button for example)
+  if(event->detail == GDK_NOTIFY_INFERIOR || event->mode == GDK_CROSSING_GTK_GRAB
+     || event->mode == GDK_CROSSING_GRAB)
+    return FALSE;
 
   table->mouse_inside = FALSE;
   dt_control_set_mouse_over_id(-1);


### PR DESCRIPTION
this fix #13170 

this avoid the deselection of the hovered image if one move the cursor during a shortcut press.
To reproduce the bug with master : 
- in lighttable show lot of images (ex : 5 per row)
- select images 2 and 3 of row 1
- move the mouse continuously over a very different image (ex : 4 of row 3)
- press`r`
- see that the selected images are rejected, instead of the hovered one

Same issue exists in culling. See #13170 discussion

Thanks @dterrahe for the help !