### PR TITLE
Add launchable tag to appdata.xml metainfo

### DIFF
--- a/data/org.darktable.darktable.appdata.xml.in
+++ b/data/org.darktable.darktable.appdata.xml.in
@@ -4,6 +4,7 @@
 <component type="desktop">
   <id>org.darktable.darktable</id>
   <name>darktable</name>
+  <launchable type="desktop-id">org.darktable.darktable.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0+</project_license>
   <_summary>Organize and develop images from digital cameras</_summary>


### PR DESCRIPTION
Quoting the AppStream description on the freedesktop.org page:

"The tag makes it possible for software centers to offer launching an application immediately after installation. It also connects the metainfo file with a .desktop file, so AppStream metadata generators and the distribution can absorb its metadata into the final AppStream output."
