### PR TITLE
darktableconfig.xml.in: Add RYB option for vectorscope.

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2998,6 +2998,7 @@
       <enum>
         <option>u*v*</option>
         <option>AzBz</option>
+        <option>RYB</option>
       </enum>
     </type>
     <default>u*v*</default>


### PR DESCRIPTION
Fixes #13263.