### PR TITLE
config: use fgets instead of fscanf to avoid broken fscanf implementation on Windows

### DIFF
--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -434,9 +434,10 @@ void dt_conf_init(dt_conf_t *cf, const char *filename, GSList *override_entries)
   {
     while(!feof(f))
     {
-      const int read = fscanf(f, "%" STR(LINE_SIZE) "[^\r\n]\r\n", line);
-      if(read > 0)
+      const char* ret = fgets(line, LINE_SIZE, f);
+      if(ret != NULL)
       {
+        g_strchomp(line);
         char *c = line;
         char *end = line + strlen(line);
         // check for '=' which is separator between the conf name and value


### PR DESCRIPTION
This fixes an odd issue on Windows which prevents darktable to start on my workstation. The problem started to happen on 4.2, previous darktable versions were working fine.

On my workstation, loading the configuration file never completes, the last call to `fscanf` never returns, it's stuck in an infinite loop and at that point, darktable process consumes a full CPU core. Removing the configuration file makes it possible to start darktable, as `fscanf` is not called during startup when there's no configuration file. There was no code change in `dt_conf_init` in DT 4.2, so I suspect the issue is caused by a change in the compiler libs. I checked the changes in the MinGW repo but couldn't figure out what could trigger that odd behavior. I noticed there was recent changes to `vfscanf` though. I try to compile with an older compiler version but I couldn't install an old MinGW version, I ran into too many dependency issues.

Below is the stack of the thread with `fscanf` stuck:

```
Thread 1 (Thread 11048.0x2b58):
#0  0x00007ffb51858de4 in ucrtbase!_configure_wide_argv () from /c/Windows/System32/ucrtbase.dll
#1  0x00007ffb5184cf70 in ucrtbase!___mb_cur_max_func () from /c/Windows/System32/ucrtbase.dll
#2  0x00007ffb518a78e2 in ucrtbase!_isspace_l () from /c/Windows/System32/ucrtbase.dll
#3  0x00007ffafbce476c in __mingw_sformat (s=<optimized out>, s@entry=0xf0127fdd80, format=<optimized out>, format@entry=0x7ffafbdd1f20 <libdarktable!Daylight+64> "%1023[^\r\n]\r\n", argp=<optimized out>, argp@entry=0xf0127fee00 "0\356\177", <incomplete sequence \360>) at C:/M/mingw-w64-crt-git/src/mingw-w64/mingw-w64-crt/stdio/mingw_vfscanf.c:1607
#4  0x00007ffafbce8230 in __mingw_vfscanf (s=s@entry=0x2c7722066e0, format=format@entry=0x7ffafbdd1f20 <libdarktable!Daylight+64> "%1023[^\r\n]\r\n", argp=argp@entry=0xf0127fee00 "0\356\177", <incomplete sequence \360>) at C:/M/mingw-w64-crt-git/src/mingw-w64/mingw-w64-crt/stdio/mingw_vfscanf.c:1620
#5  0x00007ffafb9fd2d4 in fscanf (__stream=__stream@entry=0x2c7722066e0, __format=0x7ffafbdd1f20 <libdarktable!Daylight+64> "%1023[^\r\n]\r\n", __format=0x7ffafbdd1f20 <libdarktable!Daylight+64> "%1023[^\r\n]\r\n") at C:/msys64/ucrt64/include/stdio.h:316
#6  0x00007ffafb9ffc26 in dt_conf_init (cf=<optimized out>, filename=filename@entry=0xf0127ff770 "C:\\Users\\admin\\AppData\\Local\\darktable/darktablerc", override_entries=override_entries@entry=0x0) at C:/msys64/home/bill/src/darktable-4.2.0/src/control/conf.c:450
#7  0x00007ffafb934e99 in dt_init (argc=<optimized out>, argc@entry=1, argv=<optimized out>, argv@entry=0x2c770715690, init_gui=init_gui@entry=1, load_data=load_data@entry=1, L=L@entry=0x0) at C:/msys64/home/bill/src/darktable-4.2.0/src/common/darktable.c:995
#8  0x00007ff79f772dc4 in main (argc=1, argv=0x2c770715690) at C:/msys64/home/bill/src/darktable-4.2.0/src/main.c:93
```

It smells like an incompatibility between ucrtbase and mingw, but I've no idea what it could be. I don't have much experience in C programming.

The PR is pretty straightforward, it replaces `fscanf` with `fgets`. I tested it both on Windows and Linux.

I assume nobody is impacted by this issue expect me but would appreciate if you could consider this fix.

Thanks for this awesome software!