### PR TITLE
don't recalculate on crop change when focused

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -722,10 +722,15 @@ void dt_image_update_final_size(const int32_t imgid)
                                     darktable.develop->pipe->iheight, &ww, &hh);
   }
   dt_image_t *imgtmp = dt_image_cache_get(darktable.image_cache, imgid, 'w');
-  imgtmp->final_width = ww;
-  imgtmp->final_height = hh;
-  dt_image_cache_write_release(darktable.image_cache, imgtmp, DT_IMAGE_CACHE_RELAXED);
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_METADATA_UPDATE);
+  if(ww == imgtmp->final_width && hh == imgtmp->final_height)
+    dt_cache_release(&darktable.image_cache->cache, imgtmp->cache_entry);
+  else
+  {
+    imgtmp->final_width = ww;
+    imgtmp->final_height = hh;
+    dt_image_cache_write_release(darktable.image_cache, imgtmp, DT_IMAGE_CACHE_RELAXED);
+    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_METADATA_UPDATE);
+  }
 }
 
 gboolean dt_image_get_final_size(const int32_t imgid, int *width, int *height)

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -66,6 +66,7 @@ void dt_dev_init(dt_develop_t *dev, gboolean gui_attached)
   dt_pthread_mutex_init(&dev->history_mutex, NULL);
   dev->history_end = 0;
   dev->history = NULL; // empty list
+  dev->history_postpone_invalidate = FALSE;
 
   dev->gui_attached = gui_attached;
   dev->width = -1;
@@ -1023,7 +1024,7 @@ void _dev_add_history_item(dt_develop_t *dev, dt_iop_module_t *module, gboolean 
   dt_image_cache_set_change_timestamp(darktable.image_cache, imgid);
 
   // invalidate buffers and force redraw of darkroom
-  dt_dev_invalidate_all(dev);
+  if(!dev->history_postpone_invalidate || module != dev->gui_module) dt_dev_invalidate_all(dev);
   dt_pthread_mutex_unlock(&dev->history_mutex);
 
   if(dev->gui_attached)

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -349,6 +349,9 @@ restart:
 
   dev->preview_status = DT_DEV_PIXELPIPE_VALID;
 
+  if(!dev->history_postpone_invalidate)
+    dt_image_update_final_size(dev->preview_pipe->output_imgid);
+
   dt_show_times(&start, "[dev_process_preview] pixel pipeline processing");
   dt_dev_average_delay_update(&start, &dev->preview_average_delay);
 

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -185,6 +185,7 @@ typedef struct dt_develop_t
   dt_pthread_mutex_t history_mutex;
   int32_t history_end;
   GList *history;
+  gboolean history_postpone_invalidate;
 
   // operations pipeline
   int32_t iop_instance;

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1890,9 +1890,6 @@ void dt_iop_request_focus(dt_iop_module_t *module)
     // we also remove the focus css class
     GtkWidget *iop_w = gtk_widget_get_parent(dt_iop_gui_get_pluginui(out_focus_module));
     dt_gui_remove_class(iop_w, "dt_module_focus");
-
-    // if the module change the image size, we update the final sizes
-    if(out_focus_module->modify_roi_out) dt_image_update_final_size(darktable.develop->preview_pipe->output_imgid);
   }
 
   /* set the focus on module */

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3230,6 +3230,7 @@ static void do_fit(dt_iop_module_t *module, dt_iop_ashift_params_t *p, dt_iop_as
 
   // finally apply cropping
   do_crop(module, p);
+  dt_dev_invalidate_all(darktable.develop);
 
   ++darktable.gui->reset;
   dt_bauhaus_slider_set(g->rotation, p->rotation);
@@ -5024,6 +5025,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   {
     do_crop(self, p);
     _commit_crop_box(p, g);
+    if(w != g->cropmode) dt_dev_invalidate_all(self->dev);
   }
   else
   {
@@ -5287,6 +5289,7 @@ static void _event_process_after_preview_callback(gpointer instance, gpointer us
       _swap_shadow_crop_box(p, g); // temporarily update real crop box
       dt_dev_add_history_item(darktable.develop, self, TRUE);
       _swap_shadow_crop_box(p, g);
+      dt_dev_invalidate_all(darktable.develop);
       break;
 
     case ASHIFT_JOBCODE_GET_STRUCTURE_QUAD:
@@ -5534,6 +5537,8 @@ static void _event_preview_updated_callback(gpointer instance, dt_iop_module_t *
 
 void gui_focus(struct dt_iop_module_t *self, gboolean in)
 {
+  darktable.develop->history_postpone_invalidate = in && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS;
+
   if(self->enabled)
   {
     dt_iop_ashift_params_t *p = (dt_iop_ashift_params_t *)self->params;

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5526,15 +5526,6 @@ static gboolean _event_draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *sel
   return FALSE;
 }
 
-static void _event_preview_updated_callback(gpointer instance, dt_iop_module_t *self)
-{
-  if(self->dev->gui_module != self)
-  {
-    dt_image_update_final_size(self->dev->preview_pipe->output_imgid);
-  }
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_event_preview_updated_callback), self);
-}
-
 void gui_focus(struct dt_iop_module_t *self, gboolean in)
 {
   darktable.develop->history_postpone_invalidate = in && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS;
@@ -5550,9 +5541,6 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
     }
     else
     {
-      // once the pipe is recomputed, we want to update final sizes
-      DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
-                                      G_CALLBACK(_event_preview_updated_callback), self);
       _commit_crop_box(p, g);
     }
   }

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1322,10 +1322,6 @@ static void _event_preview_updated_callback(gpointer instance, dt_iop_module_t *
 {
   dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
   g->preview_ready = TRUE;
-  if(self->dev->gui_module != self)
-  {
-    dt_image_update_final_size(self->dev->preview_pipe->output_imgid);
-  }
 
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_event_preview_updated_callback), self);
   // force max size to be recomputed

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -1623,6 +1623,7 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
     g->clip_w = 1.0f;
     g->clip_h = 1.0f;
     _aspect_apply(self, GRAB_BOTTOM_RIGHT);
+    gui_changed(self, NULL, NULL);
     return 1;
   }
   else

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -399,6 +399,8 @@ static void _event_preview_updated_callback(gpointer instance, dt_iop_module_t *
 
 void gui_focus(struct dt_iop_module_t *self, gboolean in)
 {
+  darktable.develop->history_postpone_invalidate = in && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS;
+
   dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)self->gui_data;
   dt_iop_crop_params_t *p = (dt_iop_crop_params_t *)self->params;
   if(self->enabled)

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -1574,7 +1574,7 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
     dt_dev_get_pointer_zoom_pos(self->dev, x, y, &pzx, &pzy);
 
     // switch module on already, other code depends in this:
-    dt_dev_add_history_item(darktable.develop, self, TRUE);
+    if(!self->enabled) dt_dev_add_history_item(darktable.develop, self, TRUE);
 
     g->button_down_x = x;
     g->button_down_y = y;

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -389,10 +389,7 @@ static void _event_preview_updated_callback(gpointer instance, dt_iop_module_t *
   if(!g) return; // seems that sometimes, g can be undefined for some reason...
   g->preview_ready = TRUE;
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_event_preview_updated_callback), self);
-  if(self->dev->gui_module != self)
-  {
-    dt_image_update_final_size(self->dev->preview_pipe->output_imgid);
-  }
+
   // force max size to be recomputed
   g->clip_max_pipe_hash = 0;
 }

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1231,17 +1231,6 @@ static void _build_global_distortion_map(struct dt_iop_module_t *module,
   g_list_free_full(interpolated, free);
 }
 
-// 1st pass: how large would the output be, given this input roi?
-// this is always called with the full buffer before processing.
-void modify_roi_out(struct dt_iop_module_t *module,
-                     struct dt_dev_pixelpipe_iop_t *piece,
-                     dt_iop_roi_t *roi_out,
-                     const dt_iop_roi_t *roi_in)
-{
-  // output is same size as input
-  *roi_out = *roi_in;
-}
-
 // 2nd pass: which roi would this operation need as input to fill the given output region?
 void modify_roi_in(struct dt_iop_module_t *module,
                     struct dt_dev_pixelpipe_iop_t *piece,

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2482,12 +2482,6 @@ void gui_cleanup(dt_iop_module_t *self)
   IOP_GUI_FREE;
 }
 
-void modify_roi_out(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t *roi_out,
-                    const dt_iop_roi_t *roi_in)
-{
-  *roi_out = *roi_in;
-}
-
 static void rt_compute_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                               dt_iop_roi_t *roi_in, int *_roir, int *_roib, int *_roix, int *_roiy)
 {

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -398,12 +398,6 @@ static gboolean masks_form_is_in_roi(dt_iop_module_t *self, dt_dev_pixelpipe_iop
   return TRUE;
 }
 
-void modify_roi_out(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t *roi_out,
-                    const dt_iop_roi_t *roi_in)
-{
-  *roi_out = *roi_in;
-}
-
 // needed if mask dest is in roi and mask src is not
 void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                    const dt_iop_roi_t *roi_out, dt_iop_roi_t *roi_in)

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1012,6 +1012,8 @@ static void _lib_modulegroups_toggle(GtkWidget *button, gpointer user_data)
   if(button == d->basic_btn) gid = DT_MODULEGROUP_BASICS;
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->basic_btn), FALSE);
 
+  if(d->current == DT_MODULEGROUP_BASICS) dt_iop_request_focus(NULL);
+
   /* only deselect button if not currently searching else re-enable module */
   if(d->current == gid && !(text_entered && text_entered[0] != '\0'))
     d->current = DT_MODULEGROUP_NONE;


### PR DESCRIPTION
Simpler implementation of #13258

Fixes #12700

@AlicVB I _think_ this does the same thing your PR does, but with the added benefit that sliders in the crop/margins section also do not trigger a recalc. I haven't tested much, but am wondering if an explicit invalidation has to be triggered when ashift loses focus (only if a crop has changed). Maybe this already happens anyway (maybe even when no crop has changed?) As said, I haven't tested much but let me know any problems you find.

Many refactoring/deduplication options in ashift, but I'm not going to bother with those.

EDIT: Now also changes when dimension metadata in the ui is updated. This was previously triggered when a module loses focus (crop and perspective at that point switch back to cropped dimensions) however there were several issues with
https://github.com/darktable-org/darktable/blob/0c00b9875639e51e6687f65cecef8b95f8db4c91/src/develop/imageop.c#L1895
For one thing, this gets called for _all_ modules since `modify_roi_out` gets assigned a pointer to the default implementation whenever a module doesn't specify a specific one. For another, this can cause large delays when a module loses focus while the pipe recalc hasn't completed yet ("always" when closing crop); it will have to wait (and locks the ui) for that to be done, which isn't nice on slow computers. For a third, this doesn't respond when crops are changed from qap or shortcuts or when modules change roi "instantaneously", like the framing module.

The new approach updates the final dimensions every time the preview pipe is finished (and sends a signal to update metadata on screen if there has been an actual change). It might be possible to do it somewhere else where the calculated size is already available (so it doesn't have to be determined again) but I'm not sure where would be best. Also, it could be done when _starting_ the pipe calculation, so the metadata gets updated earlier, possibly multiple times if it changes during a pipe recalc, but this would cause more (database) overhead and I'm not sure if it is worth it.

While crop or perspective have focus, the dimensions _don't_ get updated. Otherwise they would just reflect the full image size as that is what the preview will show at that moment.