### PR TITLE
color harmony guide lines in RYB vectorscope

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3046,6 +3046,53 @@
     <longdescription/>
   </dtconfig>
   <dtconfig>
+    <name>plugins/darkroom/histogram/vectorscope/show_color_harmony</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/darkroom/histogram/vectorscope/harmony_type</name>
+    <type>
+      <enum>
+		<option>monochromatic</option>
+		<option>analogous</option>
+		<option>analogous complementary</option>
+		<option>complementary</option>
+		<option>split complementary</option>
+		<option>dyad</option>
+		<option>triad</option>
+		<option>tetrad</option>
+		<option>square</option>
+      </enum>
+    </type>
+    <default>complementary</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/darkroom/histogram/vectorscope/harmony_rotation</name>
+    <type>int</type>
+    <default>0</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/darkroom/histogram/vectorscope/harmony_width</name>
+    <type>
+      <enum>
+		<option>normal</option>
+		<option>large</option>
+		<option>narrow</option>
+		<option>line</option>
+      </enum>
+    </type>
+    <default>normal</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/darkroom/masks/opacity</name>
     <type>float</type>
     <default>1.0</default>

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -659,15 +659,9 @@ dialog .sidebar row:selected:hover label,
   min-width: 1em;
 }
 
-/* be sure all color icons have (nearly) same size ; needed has red color is in stack widget and this change how the size is rendered */
-#main-histogram #green-channel-button,
-#main-histogram #blue-channel-button
-{
-  min-width: 1.1em;
-}
-
 /* set background color and color of scope/histogram buttons */
-#main-histogram .dt_module_btn:not(.toggle)
+#main-histogram .dt_module_btn:not(.toggle),
+#main-histogram #color-harmony-button
 {
   color: alpha(@field_selected_fg, 0.56);
   background-color: alpha(darker(@button_bg),0.8);
@@ -720,6 +714,25 @@ dialog .sidebar row:selected:hover label,
 #blue-channel-button:hover
 {
   background-color: alpha(@graph_blue, 0.5);
+}
+
+/* color harmony button states */
+#main-histogram #color-harmony-button:checked
+{
+  background-color: @field_selected_bg;
+  color: @field_selected_fg;
+}
+
+#main-histogram #color-harmony-button:hover
+{
+  background-color: alpha(@button_hover_bg, 0.5);
+  border-color: transparent;
+  color: shade(@fg_color, 1.15);
+}
+
+#main-histogram #color-harmony-button:hover:checked
+{
+  background-color: alpha(@button_hover_bg, 0.8);
 }
 
 /*------------------

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -659,9 +659,15 @@ dialog .sidebar row:selected:hover label,
   min-width: 1em;
 }
 
+/* be sure all color icons have (nearly) same size ; needed has red color is in stack widget and this change how the size is rendered */
+#main-histogram #green-channel-button,
+#main-histogram #blue-channel-button
+{
+  min-width: 1.1em;
+}
+
 /* set background color and color of scope/histogram buttons */
-#main-histogram .dt_module_btn:not(.toggle),
-#main-histogram #color-harmony-button
+#main-histogram .dt_module_btn:not(.toggle)
 {
   color: alpha(@field_selected_fg, 0.56);
   background-color: alpha(darker(@button_bg),0.8);
@@ -714,25 +720,6 @@ dialog .sidebar row:selected:hover label,
 #blue-channel-button:hover
 {
   background-color: alpha(@graph_blue, 0.5);
-}
-
-/* color harmony button states */
-#main-histogram #color-harmony-button:checked
-{
-  background-color: @field_selected_bg;
-  color: @field_selected_fg;
-}
-
-#main-histogram #color-harmony-button:hover
-{
-  background-color: alpha(@button_hover_bg, 0.5);
-  border-color: transparent;
-  color: shade(@fg_color, 1.15);
-}
-
-#main-histogram #color-harmony-button:hover:checked
-{
-  background-color: alpha(@button_hover_bg, 0.8);
 }
 
 /*------------------

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1340,6 +1340,44 @@ void dtgtk_cairo_paint_ryb(cairo_t *cr, gint x, gint y, gint w, gint h, gint fla
   FINISH
 }
 
+void dtgtk_cairo_paint_color_swatch(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 1, 0, 0)
+
+  const double degrees = M_PI / 180.0;
+
+    cairo_translate(cr, .8, .8);
+    cairo_arc(cr, 0.0, 0.0, 0.2, 0.0 * degrees, 180.0 * degrees);
+    cairo_rel_line_to(cr, 0.0, -0.8);
+    cairo_rel_line_to(cr, 0.4, 0.0);
+    cairo_close_path(cr);
+    cairo_stroke(cr);
+
+    cairo_arc(cr, 0.0, 0.0, 0.05, 0.05 * degrees, 360.0 * degrees);
+    cairo_stroke(cr);
+
+    cairo_rectangle(cr, -0.1, -0.7, 0.2, 0.2);
+    cairo_fill(cr);
+    cairo_rectangle(cr, -0.1, -0.4, 0.2, 0.2);
+    cairo_fill(cr);
+
+    cairo_rotate(cr, -45.0 * degrees);
+    cairo_move_to(cr, -0.2, -0.1);
+    cairo_rel_line_to(cr, 0.0, -0.7);
+    cairo_rel_line_to(cr, 0.4, 0.0);
+    cairo_rel_line_to(cr, 0.0, 0.25);
+    cairo_stroke(cr);
+
+    cairo_rotate(cr, -45.0 * degrees);
+    cairo_move_to(cr, -0.2, -0.1);
+    cairo_rel_line_to(cr, 0.0, -0.7);
+    cairo_rel_line_to(cr, 0.4, 0.0);
+    cairo_rel_line_to(cr, 0.0, 0.25);
+    cairo_stroke(cr);
+
+  FINISH
+}
+
 void dtgtk_cairo_paint_filmstrip(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   gdouble sw = 0.6;

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -223,6 +223,8 @@ void dtgtk_cairo_paint_luv(cairo_t *cr, gint x, gint y, gint w, gint h, gint fla
 void dtgtk_cairo_paint_jzazbz(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint RYB icon */
 void dtgtk_cairo_paint_ryb(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** paint color swatch icon */
+void dtgtk_cairo_paint_color_swatch(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 
 /** paint active modulegroup icon */
 void dtgtk_cairo_paint_modulegroup_active(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -2225,7 +2225,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(d->button_box), d->colorspace_button, FALSE, FALSE, 0);
 
   d->color_harmony_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_color_swatch, CPF_NONE, NULL);
-  gtk_widget_set_name(d->color_harmony_button, "color-harmony-button");
   gtk_widget_set_tooltip_text(d->color_harmony_button, d->show_color_harmony ?
                                   _("hide color harmony guide lines") :
                                   _("show color harmony guide lines"));

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -2222,7 +2222,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(d->button_box_rgb), d->blue_channel_button, FALSE, FALSE, 0);
 
   d->colorspace_button = dtgtk_button_new(dtgtk_cairo_paint_empty, CPF_NONE, NULL);
-  gtk_widget_set_name(d->color_harmony_button, "colorspace-button");
   gtk_box_pack_start(GTK_BOX(d->button_box), d->colorspace_button, FALSE, FALSE, 0);
 
   d->color_harmony_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_color_swatch, CPF_NONE, NULL);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1524,8 +1524,8 @@ static void _color_harmony_toggle(GtkWidget *button, dt_lib_histogram_t *d)
 {
   d->show_color_harmony = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
   gtk_widget_set_tooltip_text(button, d->show_color_harmony ?
-                                  _("click to hide color harmony guide lines") :
-                                  _("click to show color harmony guide lines"));
+                                  _("hide color harmony guide lines") :
+                                  _("show color harmony guide lines"));
   dt_conf_set_bool("plugins/darkroom/histogram/vectorscope/show_color_harmony", d->show_color_harmony);
   dt_control_queue_redraw_widget(d->scope_draw);
 }
@@ -1827,7 +1827,7 @@ static void _colorspace_clicked(GtkWidget *button, dt_lib_histogram_t *d)
 static void _red_channel_toggle(GtkWidget *button, dt_lib_histogram_t *d)
 {
   d->red = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
-  gtk_widget_set_tooltip_text(button, d->red ? _("click to hide red channel") : _("click to show red channel"));
+  gtk_widget_set_tooltip_text(button, d->red ? _("hide red channel") : _("show red channel"));
   dt_conf_set_bool("plugins/darkroom/histogram/show_red", d->red);
   dt_control_queue_redraw_widget(d->scope_draw);
 }
@@ -1835,7 +1835,7 @@ static void _red_channel_toggle(GtkWidget *button, dt_lib_histogram_t *d)
 static void _green_channel_toggle(GtkWidget *button, dt_lib_histogram_t *d)
 {
   d->green = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
-  gtk_widget_set_tooltip_text(button, d->green ? _("click to hide green channel") : _("click to show green channel"));
+  gtk_widget_set_tooltip_text(button, d->green ? _("hide green channel") : _("show green channel"));
   dt_conf_set_bool("plugins/darkroom/histogram/show_green", d->green);
   dt_control_queue_redraw_widget(d->scope_draw);
 }
@@ -1843,7 +1843,7 @@ static void _green_channel_toggle(GtkWidget *button, dt_lib_histogram_t *d)
 static void _blue_channel_toggle(GtkWidget *button, dt_lib_histogram_t *d)
 {
   d->blue = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
-  gtk_widget_set_tooltip_text(button, d->blue ? _("click to hide blue channel") : _("click to show blue channel"));
+  gtk_widget_set_tooltip_text(button, d->blue ? _("hide blue channel") : _("show blue channel"));
   dt_conf_set_bool("plugins/darkroom/histogram/show_blue", d->blue);
   dt_control_queue_redraw_widget(d->scope_draw);
 }
@@ -1861,9 +1861,9 @@ static gboolean _eventbox_motion_notify_callback(GtkWidget *widget, GdkEventCros
 {
   //This is required in order to correctly display the button tooltips
   dt_lib_histogram_t *d = (dt_lib_histogram_t *)user_data;
-  gtk_widget_set_tooltip_text(d->green_channel_button, d->green ? _("click to hide green channel") : _("click to show green channel"));
-  gtk_widget_set_tooltip_text(d->blue_channel_button, d->blue ? _("click to hide blue channel") : _("click to show blue channel"));
-  gtk_widget_set_tooltip_text(d->red_channel_button, d->red ? _("click to hide red channel") : _("click to show red channel"));
+  gtk_widget_set_tooltip_text(d->green_channel_button, d->green ? _("hide green channel") : _("show green channel"));
+  gtk_widget_set_tooltip_text(d->blue_channel_button, d->blue ? _("hide blue channel") : _("show blue channel"));
+  gtk_widget_set_tooltip_text(d->red_channel_button, d->red ? _("hide red channel") : _("show red channel"));
   _scope_type_update(d);
   return TRUE;
 }
@@ -2205,19 +2205,19 @@ void gui_init(dt_lib_module_t *self)
   // these are toggle boxes with a meaningful active state, unlike the type/view buttons
   d->red_channel_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_color, CPF_NONE, NULL);
   gtk_widget_set_name(d->red_channel_button, "red-channel-button");
-  gtk_widget_set_tooltip_text(d->red_channel_button, d->red ? _("click to hide red channel") : _("click to show red channel"));
+  gtk_widget_set_tooltip_text(d->red_channel_button, d->red ? _("hide red channel") : _("show red channel"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->red_channel_button), d->red);
   gtk_box_pack_start(GTK_BOX(d->button_box_rgb), d->red_channel_button, FALSE, FALSE, 0);
 
   d->green_channel_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_color, CPF_NONE, NULL);
   gtk_widget_set_name(d->green_channel_button, "green-channel-button");
-  gtk_widget_set_tooltip_text(d->green_channel_button, d->green ? _("click to hide green channel") : _("click to show green channel"));
+  gtk_widget_set_tooltip_text(d->green_channel_button, d->green ? _("hide green channel") : _("show green channel"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->green_channel_button), d->green);
   gtk_box_pack_start(GTK_BOX(d->button_box_rgb), d->green_channel_button, FALSE, FALSE, 0);
 
   d->blue_channel_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_color, CPF_NONE, NULL);
   gtk_widget_set_name(d->blue_channel_button, "blue-channel-button");
-  gtk_widget_set_tooltip_text(d->blue_channel_button, d->blue ? _("click to hide blue channel") : _("click to show blue channel"));
+  gtk_widget_set_tooltip_text(d->blue_channel_button, d->blue ? _("hide blue channel") : _("show blue channel"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->blue_channel_button), d->blue);
   gtk_box_pack_start(GTK_BOX(d->button_box_rgb), d->blue_channel_button, FALSE, FALSE, 0);
 
@@ -2228,8 +2228,8 @@ void gui_init(dt_lib_module_t *self)
   d->color_harmony_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_color_swatch, CPF_NONE, NULL);
   gtk_widget_set_name(d->color_harmony_button, "color-harmony-button");
   gtk_widget_set_tooltip_text(d->color_harmony_button, d->show_color_harmony ?
-                                  _("click to hide color harmony guide lines") :
-                                  _("click to show color harmony guide lines"));
+                                  _("hide color harmony guide lines") :
+                                  _("show color harmony guide lines"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->color_harmony_button), d->show_color_harmony);
   gtk_box_pack_start(GTK_BOX(d->button_box), d->color_harmony_button, FALSE, FALSE, 0);
 

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -2225,7 +2225,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_name(d->color_harmony_button, "colorspace-button");
   gtk_box_pack_start(GTK_BOX(d->button_box), d->colorspace_button, FALSE, FALSE, 0);
 
-  d->color_harmony_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_eye, CPF_NONE, NULL);
+  d->color_harmony_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_color_swatch, CPF_NONE, NULL);
   gtk_widget_set_name(d->color_harmony_button, "color-harmony-button");
   gtk_widget_set_tooltip_text(d->color_harmony_button, d->show_color_harmony ?
                                   _("click to hide color harmony guide lines") :


### PR DESCRIPTION
Fixes #13247 

This PR introduces in RYB vectorscope the visualization of guide lines corresponding to various "color harmonies". See the linked issue for some background.
It is still a draft, for testing and evaluation purposes.

**Use case**
This workflow is inspired by Johanna Kustra's videos on YT about color harmonies.

1) With the global color picker, take live samples of the key color areas of the image. The choice of those is purely artistic, depending on the feeling you want to convey. Display them on the RYB vectorscope.

2) With the new color harmony selection button (the one that replaces the green button, icon is a random one, still to be done), select (by clicking multiple times) the color harmony you want to implement (in the range of doable), or the closest to the distribution of the live samples. Scroll to rotate. Some sectors are longer that others, those are the primary colors.

3) If  some of the samples fall outside the guide lines, bring them inside. You can use any DT color manipulation tool you like. Personally, I like to use color balance RGB + masks (waiting for the future color equalizer module). Use hue shift / croma / saturation to move the targeted live sample in the vectorscope. Remember that vectorscope only shows hue and saturation, not luminance. Keep an eye that the result looks credible, don't try to force fitting the color harmony at any cost, approximate is ok.
Also consider the overall balance of the colors; primary color should be more prominent, meaning more saturated and/or take more space.

As for every tool in photography, the above will not turn a bad picture in a masterpiece, and surely you could judge the color harmony by eyeballs. All in all those are just guidelines, like the ones we have for composition (rule of thirds or similar). Here we try to help the composition of colors. Also, rules are made to be broken sometimes...

Examples (pics are taken from [Joanna Kustra website](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwiHkd-LmK78AhXogP0HHaBSDksQFnoECA4QAQ&url=https%3A%2F%2Fjoannakustra.com%2F&usg=AOvVaw0qcLZzGFicAKEj8VK9IkFD))

**1. Monochromatic**

![mono1](https://user-images.githubusercontent.com/43290988/210584971-c008cc72-84fe-401e-b6a5-51b09e7a1b11.png)

![mono12](https://user-images.githubusercontent.com/43290988/210585034-e58f3791-ebd4-46b4-b7f9-d2405417fe3a.png)

**2. Analogous**
![analog2](https://user-images.githubusercontent.com/43290988/210585869-ca9596d3-45fc-4b4d-9602-65a5691aeed8.png)

![analog22](https://user-images.githubusercontent.com/43290988/210585893-199d202c-f2d5-4df7-979f-e7bb5656e4bf.png)

**3. Complementary**
![compl3](https://user-images.githubusercontent.com/43290988/210585588-6815b1f3-03c0-441f-9022-699376f9a78b.png)

![compl32](https://user-images.githubusercontent.com/43290988/210585630-7b1c5243-562a-4159-a7fa-11f864f80a24.png)

**4. Dyad**
![dyad1](https://user-images.githubusercontent.com/43290988/210586090-8061f727-a90e-4900-abc7-b8c5c9602bad.png)

![dyad12](https://user-images.githubusercontent.com/43290988/210586106-b4571abe-7c17-4ee5-9266-0469a2147c17.png)

**5. Split Complementary**
![splitc1](https://user-images.githubusercontent.com/43290988/210586231-59f11183-5908-4937-a59b-0c026699d781.png)

![splitc12](https://user-images.githubusercontent.com/43290988/210586243-ba9f55d3-d343-4010-b6a0-74124744bc46.png)

**6. Triad**
![triad1](https://user-images.githubusercontent.com/43290988/210586425-d2d78e90-a0bd-4ac8-b47e-530aa200dca6.png)

![triad12](https://user-images.githubusercontent.com/43290988/210586473-4836fa51-7373-48b3-9c96-3a8459dafed3.png)

**7. Tetrad**
![tetrad4](https://user-images.githubusercontent.com/43290988/210586586-5cb250f7-5705-46b8-83d6-b88dec71ee65.png)

![tetrad42](https://user-images.githubusercontent.com/43290988/210587599-856c23aa-b656-4f19-ac53-9ba21a8d3c69.png)

Any feedback is welcome

