### PR TITLE
Fixing Y0-mask calculations (#13271)

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2517,9 +2517,11 @@ gboolean dt_dev_write_rawdetail_mask(dt_dev_pixelpipe_iop_t *piece, float *const
   p->rawdetail_mask_data = mask;
   memcpy(&p->rawdetail_mask_roi, roi_in, sizeof(dt_iop_roi_t));
 
-  const dt_aligned_pixel_t wb = {fmaxf(1.0f, piece->pipe->dsc.temperature.coeffs[0]),
-                                 fmaxf(1.0f, piece->pipe->dsc.temperature.coeffs[1]),
-                                 fmaxf(1.0f, piece->pipe->dsc.temperature.coeffs[2])};
+  const gboolean nocoeff =(p->want_detail_mask & ~DT_DEV_DETAIL_MASK_REQUIRED) == DT_DEV_DETAIL_MASK_RAWPREPARE;
+  const gboolean wboff = !piece->pipe->dsc.temperature.enabled || nocoeff;
+  const dt_aligned_pixel_t wb = { wboff ? 1.0f : piece->pipe->dsc.temperature.coeffs[0],
+                                  wboff ? 1.0f : piece->pipe->dsc.temperature.coeffs[1],
+                                  wboff ? 1.0f : piece->pipe->dsc.temperature.coeffs[2]};
   dt_masks_calc_rawdetail_mask(rgb, mask, tmp, width, height, wb);
   dt_free_align(tmp);
   dt_print(DT_DEBUG_MASKS,
@@ -2566,13 +2568,11 @@ gboolean dt_dev_write_rawdetail_mask_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in
 
   {
     const int kernel = darktable.opencl->blendop->kernel_calc_Y0_mask;
-    dt_aligned_pixel_t wb = { piece->pipe->dsc.temperature.coeffs[0],
-                              piece->pipe->dsc.temperature.coeffs[1],
-                              piece->pipe->dsc.temperature.coeffs[2] };
-    if((p->want_detail_mask & ~DT_DEV_DETAIL_MASK_REQUIRED) == DT_DEV_DETAIL_MASK_RAWPREPARE)
-    {
-      wb[0] = wb[1] = wb[2] = 1.0f;
-    }
+    const gboolean nocoeff =(p->want_detail_mask & ~DT_DEV_DETAIL_MASK_REQUIRED) == DT_DEV_DETAIL_MASK_RAWPREPARE;
+    const gboolean wboff = !piece->pipe->dsc.temperature.enabled || nocoeff;
+    const dt_aligned_pixel_t wb = { wboff ? 1.0f : piece->pipe->dsc.temperature.coeffs[0],
+                                  wboff ? 1.0f : piece->pipe->dsc.temperature.coeffs[1],
+                                  wboff ? 1.0f : piece->pipe->dsc.temperature.coeffs[2]};
     err = dt_opencl_enqueue_kernel_2d_args(devid, kernel, width, height,
       CLARG(tmp), CLARG(in), CLARG(width), CLARG(height), CLARG(wb[0]), CLARG(wb[1]), CLARG(wb[2]));
     if(err != CL_SUCCESS) goto error;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2517,13 +2517,9 @@ gboolean dt_dev_write_rawdetail_mask(dt_dev_pixelpipe_iop_t *piece, float *const
   p->rawdetail_mask_data = mask;
   memcpy(&p->rawdetail_mask_roi, roi_in, sizeof(dt_iop_roi_t));
 
-  dt_aligned_pixel_t wb = { piece->pipe->dsc.temperature.coeffs[0],
-                            piece->pipe->dsc.temperature.coeffs[1],
-                            piece->pipe->dsc.temperature.coeffs[2] };
-  if((p->want_detail_mask & ~DT_DEV_DETAIL_MASK_REQUIRED) == DT_DEV_DETAIL_MASK_RAWPREPARE)
-  {
-    wb[0] = wb[1] = wb[2] = 1.0f;
-  }
+  const dt_aligned_pixel_t wb = {fmaxf(1.0f, piece->pipe->dsc.temperature.coeffs[0]),
+                                 fmaxf(1.0f, piece->pipe->dsc.temperature.coeffs[1]),
+                                 fmaxf(1.0f, piece->pipe->dsc.temperature.coeffs[2])};
   dt_masks_calc_rawdetail_mask(rgb, mask, tmp, width, height, wb);
   dt_free_align(tmp);
   dt_print(DT_DEBUG_MASKS,

--- a/src/iop/dual_demosaic.c
+++ b/src/iop/dual_demosaic.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2021 darktable developers.
+    Copyright (C) 2010-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -59,8 +59,10 @@ static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict r
   if(info) dt_get_times(&start_blend);
 
   const float contrastf = slider2contrast(dual_threshold);
-
-  dt_masks_calc_rawdetail_mask(rgb_data, blend, tmp, width, height, piece->pipe->dsc.temperature.coeffs);
+  const dt_aligned_pixel_t wb = {fmaxf(1.0f, piece->pipe->dsc.temperature.coeffs[0]),
+                                 fmaxf(1.0f, piece->pipe->dsc.temperature.coeffs[1]),
+                                 fmaxf(1.0f, piece->pipe->dsc.temperature.coeffs[2])};
+  dt_masks_calc_rawdetail_mask(rgb_data, blend, tmp, width, height, wb);
   dt_masks_calc_detail_mask(blend, blend, tmp, width, height, contrastf, TRUE);
 
   if(dual_mask)
@@ -113,8 +115,9 @@ gboolean dual_demosaic_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
     piece->pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
 
   {
-    const dt_aligned_pixel_t wb = { piece->pipe->dsc.temperature.coeffs[0], piece->pipe->dsc.temperature.coeffs[1],
-                                    piece->pipe->dsc.temperature.coeffs[2] };
+    const dt_aligned_pixel_t wb = {fmaxf(1.0f, piece->pipe->dsc.temperature.coeffs[0]),
+                                   fmaxf(1.0f, piece->pipe->dsc.temperature.coeffs[1]),
+                                   fmaxf(1.0f, piece->pipe->dsc.temperature.coeffs[2])};
     const int kernel = darktable.opencl->blendop->kernel_calc_Y0_mask;
     const int err = dt_opencl_enqueue_kernel_2d_args(devid, kernel, width, height,
       CLARG(detail), CLARG(high_image), CLARG(width), CLARG(height), CLARG(wb[0]), CLARG(wb[1]), CLARG(wb[2]));

--- a/src/iop/dual_demosaic.c
+++ b/src/iop/dual_demosaic.c
@@ -59,9 +59,11 @@ static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict r
   if(info) dt_get_times(&start_blend);
 
   const float contrastf = slider2contrast(dual_threshold);
-  const dt_aligned_pixel_t wb = {fmaxf(1.0f, piece->pipe->dsc.temperature.coeffs[0]),
-                                 fmaxf(1.0f, piece->pipe->dsc.temperature.coeffs[1]),
-                                 fmaxf(1.0f, piece->pipe->dsc.temperature.coeffs[2])};
+  const gboolean wbon = piece->pipe->dsc.temperature.enabled;
+  const dt_aligned_pixel_t wb = { wbon ? piece->pipe->dsc.temperature.coeffs[0] : 1.0f,
+                                  wbon ? piece->pipe->dsc.temperature.coeffs[1] : 1.0f,
+                                  wbon ? piece->pipe->dsc.temperature.coeffs[2] : 1.0f};
+
   dt_masks_calc_rawdetail_mask(rgb_data, blend, tmp, width, height, wb);
   dt_masks_calc_detail_mask(blend, blend, tmp, width, height, contrastf, TRUE);
 
@@ -115,9 +117,10 @@ gboolean dual_demosaic_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
     piece->pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
 
   {
-    const dt_aligned_pixel_t wb = {fmaxf(1.0f, piece->pipe->dsc.temperature.coeffs[0]),
-                                   fmaxf(1.0f, piece->pipe->dsc.temperature.coeffs[1]),
-                                   fmaxf(1.0f, piece->pipe->dsc.temperature.coeffs[2])};
+    const gboolean wbon = piece->pipe->dsc.temperature.enabled;
+    const dt_aligned_pixel_t wb = { wbon ? piece->pipe->dsc.temperature.coeffs[0] : 1.0f,
+                                    wbon ? piece->pipe->dsc.temperature.coeffs[1] : 1.0f,
+                                    wbon ? piece->pipe->dsc.temperature.coeffs[2] : 1.0f};
     const int kernel = darktable.opencl->blendop->kernel_calc_Y0_mask;
     const int err = dt_opencl_enqueue_kernel_2d_args(devid, kernel, width, height,
       CLARG(detail), CLARG(high_image), CLARG(width), CLARG(height), CLARG(wb[0]), CLARG(wb[1]), CLARG(wb[2]));


### PR DESCRIPTION
The reported issue was about instability while dual-demosaicing if white-balance module was switched off.

This is due to undefined wb coeffs (zero) possibly calculating NaNs while calculating the Y0 mask which is used for the scharr operator.

This pr makes sure the the taken coeffs are at least 1.0 for each channel, this affects dual demosaicers and the details mask (there was a workaround for that).

Fixes #13271

Safe bugfix for 4.2.1