### PR TITLE
[GUI] MIDI is an acronym and should be spelled all caps

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3618,7 +3618,7 @@
     <name>plugins/midi/devices</name>
     <type>string</type>
     <default></default>
-    <shortdescription>order or exclude midi devices</shortdescription>
-    <longdescription>comma-separated list of device name fragments that if matched load midi device at id given by location in list or if preceded by - prevent matching devices from loading. add encoding and number of knobs like 'BeatStep:63:16'</longdescription>
+    <shortdescription>order or exclude MIDI devices</shortdescription>
+    <longdescription>comma-separated list of device name fragments that if matched load MIDI device at id given by location in list or if preceded by - prevent matching devices from loading. add encoding and number of knobs like 'BeatStep:63:16'</longdescription>
   </dtconfig>
 </dtconfiglist>


### PR DESCRIPTION
MIDI is an acronym for "Musical Instrument Digital Interface".
