### PR TITLE
Fix segfaults (double free & color conversion) in darktable-chart

### DIFF
--- a/src/chart/colorchart.c
+++ b/src/chart/colorchart.c
@@ -326,7 +326,6 @@ chart_t *parse_cht(const char *filename)
               }
 
               if(!first_label) first_label = label;
-              g_free(last_label);
               last_label = label;
 
               // store it
@@ -367,7 +366,6 @@ chart_t *parse_cht(const char *filename)
           if(kl == 'X' || kl == 'Y')
             g_hash_table_insert(result->patch_sets, g_strdup_printf("%s .. %s", first_label, last_label), labels);
 
-          g_free(last_label);
           free(y_label);
           free(x_label);
         }

--- a/src/chart/main.c
+++ b/src/chart/main.c
@@ -1658,12 +1658,15 @@ static void image_lab_to_xyz(float *image, const int width, const int height)
   for(int y = 0; y < height; y++)
     for(int x = 0; x < width; x++)
     {
-      dt_aligned_pixel_t pixel_lab = { image[(x + y * width) * 3 + 0], image[(x + y * width) * 3 + 1], image[(x + y * width) * 3 + 2]};
-      dt_aligned_pixel_t pixel_xyz; /*  = { 0.0 }; */
+      const int i0 = (x + y * width) * 3 + 0;
+      const int i1 = (x + y * width) * 3 + 1;
+      const int i2 = (x + y * width) * 3 + 2;
+      dt_aligned_pixel_t pixel_lab = { image[i0], image[i1], image[i2] };
+      dt_aligned_pixel_t pixel_xyz = { 0.0 };
       dt_Lab_to_XYZ(pixel_lab, pixel_xyz);
-      image[(x + y * width) * 3 + 0] = pixel_xyz[0];
-      image[(x + y * width) * 3 + 1] = pixel_xyz[1];
-      image[(x + y * width) * 3 + 2] = pixel_xyz[2];
+      image[i0] = pixel_xyz[0];
+      image[i1] = pixel_xyz[1];
+      image[i2] = pixel_xyz[2];
     }
 }
 

--- a/src/chart/main.c
+++ b/src/chart/main.c
@@ -1658,8 +1658,12 @@ static void image_lab_to_xyz(float *image, const int width, const int height)
   for(int y = 0; y < height; y++)
     for(int x = 0; x < width; x++)
     {
-      float *pixel = &image[(x + y * width) * 3];
-      dt_Lab_to_XYZ(pixel, pixel);
+      dt_aligned_pixel_t pixel_lab = { image[(x + y * width) * 3 + 0], image[(x + y * width) * 3 + 1], image[(x + y * width) * 3 + 2]};
+      dt_aligned_pixel_t pixel_xyz; /*  = { 0.0 }; */
+      dt_Lab_to_XYZ(pixel_lab, pixel_xyz);
+      image[(x + y * width) * 3 + 0] = pixel_xyz[0];
+      image[(x + y * width) * 3 + 1] = pixel_xyz[1];
+      image[(x + y * width) * 3 + 2] = pixel_xyz[2];
     }
 }
 


### PR DESCRIPTION
As reported, darktable-chart crashes with a segmentation fault (issues #10550) and displays wrong colors (issue #10974).

The _g_hash_table_ `box_table` gets corrupted, which seems due to [78858df](https://github.com/darktable-org/darktable/commit/78858df91d5950bbcff8a32a70bafd3827724041), so the first change (`f19efbb`) is a partial revert of that change (only for the darktable-chart related file `src/chart/colorchart.c`).

Furthermore the `dt_Lab_to_XYZ` function now uses `dt_aligned_pixel_t` as arguments, so the second change (`4ad1b93`) addresses this change also for darktable-chart.

With these patches applied I can successfully use darktable-chart again. I verified against darktable-chart 3.6 (this seems the last working version) and got very similar results (numerical values differ slightly, but probably only because of small differences the manual alignment process for the color checker). Maybe someone with more experience using darktable-chart can double check.

Result with darktable-chart 3.6:
![dt-chart_3 6](https://user-images.githubusercontent.com/3230061/210811450-88e4f694-1bce-4b41-9dda-94d6040b7090.png)

Result with darktable-chart buildwith this pull request:
![dt-chart_using_this_pr](https://user-images.githubusercontent.com/3230061/210811486-f648ecfc-ff5a-4624-b09a-519f6e6c5da7.png)
