### PR TITLE
Bump required CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.0)
+cmake_minimum_required(VERSION 3.18)
 
 cmake_policy(SET CMP0011 NEW)
 cmake_policy(SET CMP0025 NEW)

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Compatible compilers:
 * MinGW-w64: 6 and later
 
 Required dependencies (minimum version):
-* CMake 3.10
+* CMake 3.18
 * GTK 3.24.15
 * GLib 2.40
 * SQLite 3.15 *(but 3.24 or newer strongly recommended)*


### PR DESCRIPTION
We currently declare CMake version 3.10 to be sufficient for building darktable. But the minimum required version of CMake for the rawspeed build is now 3.18:

https://github.com/darktable-org/rawspeed/blob/5ceb9e64a64fa28c134b255861ba06f8594d5ee8/CMakeLists.txt#L1

Since rawspeed is always compiled when building darktable, 3.18 is actually the minimum required version for the entire program.