### PR TITLE
make quick access styles and presets buttons shortcutable

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1356,7 +1356,7 @@ static void _darkroom_ui_apply_style_popupmenu(GtkWidget *w, gpointer user_data)
 
       GtkWidget *mi = gtk_menu_item_new_with_label(mi_name);
       // need a tooltip for the signal below to be raised
-      gtk_widget_set_tooltip_markup(mi, "x");
+      gtk_widget_set_has_tooltip(mi, TRUE);
       g_signal_connect(mi, "query-tooltip",
                        G_CALLBACK(_styles_tooltip_callback), g_strdup(style->name));
 
@@ -2230,6 +2230,7 @@ void gui_init(dt_view_t *self)
 
   /* create favorite plugin preset popup tool */
   GtkWidget *favorite_presets = dtgtk_button_new(dtgtk_cairo_paint_presets, 0, NULL);
+  dt_action_define(sa, NULL, N_("quick access presets"), favorite_presets, &dt_action_def_button);
   gtk_widget_set_tooltip_text(favorite_presets, _("quick access to presets"));
   g_signal_connect(G_OBJECT(favorite_presets), "clicked", G_CALLBACK(_darkroom_ui_favorite_presets_popupmenu),
                    NULL);
@@ -2238,6 +2239,7 @@ void gui_init(dt_view_t *self)
 
   /* create quick styles popup menu tool */
   GtkWidget *styles = dtgtk_button_new(dtgtk_cairo_paint_styles, 0, NULL);
+  dt_action_define(sa, NULL, N_("quick access styles"), styles, &dt_action_def_button);
   g_signal_connect(G_OBJECT(styles), "clicked", G_CALLBACK(_darkroom_ui_apply_style_popupmenu), NULL);
   gtk_widget_set_tooltip_text(styles, _("quick access for applying any of your styles"));
   dt_gui_add_help_link(styles, dt_get_help_url("bottom_panel_styles"));

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1357,8 +1357,8 @@ static void _darkroom_ui_apply_style_popupmenu(GtkWidget *w, gpointer user_data)
       GtkWidget *mi = gtk_menu_item_new_with_label(mi_name);
       // need a tooltip for the signal below to be raised
       gtk_widget_set_has_tooltip(mi, TRUE);
-      g_signal_connect(mi, "query-tooltip",
-                       G_CALLBACK(_styles_tooltip_callback), g_strdup(style->name));
+      g_signal_connect_data(mi, "query-tooltip",
+                            G_CALLBACK(_styles_tooltip_callback), g_strdup(style->name), (GClosureNotify)g_free, 0);
 
       g_free(mi_name);
 
@@ -1398,9 +1398,9 @@ static void _darkroom_ui_apply_style_popupmenu(GtkWidget *w, gpointer user_data)
         gtk_widget_show(GTK_WIDGET(smi));
       }
 
-      g_signal_connect_swapped(G_OBJECT(mi), "activate",
-                               G_CALLBACK(_darkroom_ui_apply_style_activate_callback),
-                               (gpointer)g_strdup(style->name));
+      g_signal_connect_data(G_OBJECT(mi), "activate",
+                            G_CALLBACK(_darkroom_ui_apply_style_activate_callback),
+                            g_strdup(style->name), (GClosureNotify)g_free, G_CONNECT_SWAPPED);
       gtk_widget_show(mi);
 
       g_strfreev(split);


### PR DESCRIPTION
Fixes #13233

Looked into addressing #13232 as well, by implementing a popover on keyboard moves, rather than a tooltip which as @TurboGit points out only shows up at the mouse location. But this is somewhat complicated by `dt_gui_style_content_dialog` (or rather `_preview_draw`) being synchronous. On slow machines, this would mean that after each arrow move, you'd have to wait until the preview is calculated before being able to move to the next style. Of course this could be "solved" by implementing a delay (which is why it somewhat works for tooltips which only lock up after some inaction), but that would make it slow to react again. Ideally, the dialog with the textual description of enabled modules would appear immediately and the preview would be filled in once the pipe is complete (triggered by a signal). But I don't know enough about pipes to know if the export pipe has the flexibility to be used asynchronously. This would also mean that `_styles_tooltip_callback` should not rebuild `dt_gui_style_content_dialog` each time the tooltip is updated, which is with each mouse move, but only when it has been destroyed (see `_changes_tooltip_callback` in history.c).