### PR TITLE
Fixing two exporting bugs

### DIFF
--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -908,7 +908,7 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
     height = pipe.processed_height;
   }
 
-  const double max_scale = (upscale && (width > 0 || height > 0)) ? 100.0 : 1.0;
+  const double max_scale = (upscale && ((width > 0 || height > 0) || is_scaling)) ? 100.0 : 1.0;
 
   const double scalex = width > 0 ? fmin((double)width / (double)pipe.processed_width, max_scale) : max_scale;
   const double scaley = height > 0 ? fmin((double)height / (double)pipe.processed_height, max_scale) : max_scale;
@@ -970,9 +970,9 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
       }
     }
 
-    dt_print(DT_DEBUG_IMAGEIO,"[dt_imageio_export] imgid %d, pipe %ix%i, range %ix%i --> exact %i, upscale %i, hq %i, corrected %i, scale %.7f, corr %.6f, size %ix%i\n",
+    dt_print(DT_DEBUG_IMAGEIO,"[dt_imageio_export] imgid %d, pipe %ix%i, range %ix%i --> exact=%s, upscale=%s, hq=%s, corrected=%s, scale %.7f, corr %.6f, size %ix%i\n",
              imgid, pipe.processed_width, pipe.processed_height, format_params->max_width, format_params->max_height,
-             exact_size, upscale, high_quality_processing, corrected, scale, corrscale, processed_width, processed_height);
+             exact_size ? "yes" : "no", upscale ? "yes" : "no", high_quality_processing ? "yes" : "no", corrected ? "yes" : "no", scale, corrscale, processed_width, processed_height);
   }
   else
   {

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1799,7 +1799,7 @@ static void dt_control_export_cleanup(void *p)
 }
 
 void dt_control_export(GList *imgid_list, int max_width, int max_height, int format_index, int storage_index,
-                       gboolean high_quality, gboolean upscale, gboolean export_masks, char *style, gboolean style_append,
+                       gboolean high_quality, gboolean upscale, gboolean scaling, gboolean export_masks, char *style, gboolean style_append,
                        dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
                        dt_iop_color_intent_t icc_intent, const gchar *metadata_export)
 {
@@ -1834,7 +1834,7 @@ void dt_control_export(GList *imgid_list, int max_width, int max_height, int for
   data->sdata = sdata;
   data->high_quality = high_quality;
   data->export_masks = export_masks;
-  data->upscale = (max_width == 0 && max_height == 0) ? FALSE : upscale;
+  data->upscale = ((max_width == 0 && max_height == 0) && !scaling) ? FALSE : upscale;
   g_strlcpy(data->style, style, sizeof(data->style));
   data->style_append = style_append;
   data->icc_type = icc_type;

--- a/src/control/jobs/control_jobs.h
+++ b/src/control/jobs/control_jobs.h
@@ -42,7 +42,7 @@ void dt_control_copy_images();
 void dt_control_set_local_copy_images();
 void dt_control_reset_local_copy_images();
 void dt_control_export(GList *imgid_list, int max_width, int max_height, int format_index, int storage_index,
-                       gboolean high_quality, gboolean upscale, gboolean export_masks,
+                       gboolean high_quality, gboolean upscale, gboolean scaling, gboolean export_masks,
                        char *style, gboolean style_append,
                        dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
                        dt_iop_color_intent_t icc_intent, const gchar *metadata_export);

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -326,6 +326,7 @@ static void _export_button_clicked(GtkWidget *widget, dt_lib_export_t *d)
   const gboolean high_quality = dt_conf_get_bool(CONFIG_PREFIX "high_quality_processing");
   const gboolean export_masks = dt_conf_get_bool(CONFIG_PREFIX "export_masks");
   const gboolean style_append = dt_conf_get_bool(CONFIG_PREFIX "style_append");
+  const gboolean scaling = dt_conf_get_int(CONFIG_PREFIX "dimensions_type") == DT_DIMENSIONS_SCALE;
   const char *tmp = dt_conf_get_string_const(CONFIG_PREFIX "style");
   if(tmp)
   {
@@ -355,7 +356,7 @@ static void _export_button_clicked(GtkWidget *widget, dt_lib_export_t *d)
   const dt_iop_color_intent_t icc_intent = dt_conf_get_int(CONFIG_PREFIX "iccintent");
 
   GList *list = dt_act_on_get_images(TRUE, TRUE, TRUE);
-  dt_control_export(list, max_width, max_height, format_index, storage_index, high_quality, upscale, export_masks,
+  dt_control_export(list, max_width, max_height, format_index, storage_index, high_quality, upscale, scaling, export_masks,
                     style, style_append, icc_type, icc_filename, icc_intent, d->metadata_export);
 
   g_free(icc_filename);


### PR DESCRIPTION
1. As reported in #12386 we might access data as "on the very right border" but while reading data from input we are taking from "the very left" due to an out-of-bounds access. The reason for me seems to be the roi_in correction in the finalscale module, we now ensure a correct size.
2. #12194 fixed the discussed issue but unfortunately the added test for allowed upscaling left out the possibility of ` dimensions_type == DT_DIMENSIONS_SCALE` Fixed via adding a parameter to `dt_control_export()`

Fixes #12386
Fixes #12194 regression


