### PR TITLE
[CI] Remove azure mirror in a desperate attempt to fix CI build failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
     steps:
       - name: Install compiler ${{ matrix.compiler.compiler }}
         run: |
+          # Remove azure mirror because it is unreliable and sometimes unpredictably leads to failed CI
+          sudo sed -i 's/azure\.//' /etc/apt/sources.list
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
           sudo add-apt-repository -y universe
           sudo add-apt-repository -y multiverse
@@ -235,6 +237,8 @@ jobs:
     steps:
       - name: Install compiler ${{ matrix.compiler.compiler }}
         run: |
+          # Remove azure mirror because it is unreliable and sometimes unpredictably leads to failed CI
+          sudo sed -i 's/azure\.//' /etc/apt/sources.list
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo add-apt-repository -y universe
           sudo add-apt-repository -y multiverse


### PR DESCRIPTION
For the past few days, this mirror has been returning HTTP error 503 when we try to get certain packages, without any pattern, apparently at times of server overload. This leads to failures that are not the fault of the code being built, making the CI process meaningless.

This PR excludes an unreliable mirror in the hope that other mirrors are more reliable and will not refuse to deliver packages.
