### PR TITLE
Redesign of export & thumbs

### DIFF
--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -863,14 +863,10 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
   // get only once at the beginning, in case the user changes it on the way:
   const gboolean high_quality_processing = high_quality;
 
-  const gboolean iscropped =
-    (   (pipe.processed_width < (wd - img->crop_x - img->crop_width))
-     || (pipe.processed_height < (ht - img->crop_y - img->crop_height)));
-
   int width = MAX(format_params->max_width, 0);
   int height = MAX(format_params->max_height, 0);
 
-  if(iscropped && !thumbnail_export && width == 0 && height == 0)
+  if(!thumbnail_export && width == 0 && height == 0)
   {
     width = pipe.processed_width;
     height = pipe.processed_height;

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1799,7 +1799,7 @@ static void dt_control_export_cleanup(void *p)
 }
 
 void dt_control_export(GList *imgid_list, int max_width, int max_height, int format_index, int storage_index,
-                       gboolean high_quality, gboolean upscale, gboolean export_masks, char *style, gboolean style_append,
+                       gboolean high_quality, gboolean upscale, gboolean dimensions_scale, gboolean export_masks, char *style, gboolean style_append,
                        dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
                        dt_iop_color_intent_t icc_intent, const gchar *metadata_export)
 {
@@ -1834,7 +1834,7 @@ void dt_control_export(GList *imgid_list, int max_width, int max_height, int for
   data->sdata = sdata;
   data->high_quality = high_quality;
   data->export_masks = export_masks;
-  data->upscale = (max_width == 0 && max_height == 0) ? FALSE : upscale;
+  data->upscale = ((max_width == 0 && max_height == 0) && !dimensions_scale) ? FALSE : upscale;
   g_strlcpy(data->style, style, sizeof(data->style));
   data->style_append = style_append;
   data->icc_type = icc_type;

--- a/src/control/jobs/control_jobs.h
+++ b/src/control/jobs/control_jobs.h
@@ -42,7 +42,7 @@ void dt_control_copy_images();
 void dt_control_set_local_copy_images();
 void dt_control_reset_local_copy_images();
 void dt_control_export(GList *imgid_list, int max_width, int max_height, int format_index, int storage_index,
-                       gboolean high_quality, gboolean upscale, gboolean export_masks,
+                       gboolean high_quality, gboolean upscale, gboolean dimensions_scale, gboolean export_masks,
                        char *style, gboolean style_append,
                        dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
                        dt_iop_color_intent_t icc_intent, const gchar *metadata_export);

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -61,9 +61,17 @@ void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const d
 
   roi_in->x /= roi_out->scale;
   roi_in->y /= roi_out->scale;
+/*
+  Keep <= v4.2 code here as reference
+  That lead to rounded-down width&height so if in case of a scale of 1 both would be one less than roi_out
+  dimensions. This is bad because we have to fight the missing data by adopting either scale or size in
+  dt_imageio_export_with_flags() leading to either reduced size or some slight upscale of the output image.
   // out = in * scale + .5f to more precisely round to user input in export module:
   roi_in->width  = (roi_out->width  - .5f)/roi_out->scale;
   roi_in->height = (roi_out->height - .5f)/roi_out->scale;
+*/
+  roi_in->width  = ceilf(roi_out->width / roi_out->scale);
+  roi_in->height = ceilf(roi_out->height / roi_out->scale);
   roi_in->scale = 1.0f;
 }
 
@@ -79,28 +87,32 @@ void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *p
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
                const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
-  if(roi_out->scale >= 1.00001f)
+  if(roi_out->scale > 1.0f) // trust cl code for 1:1 copy here or downscale
   {
-    dt_print(DT_DEBUG_OPENCL,
-             "[opencl_finalscale] finalscale with upscaling not yet supported by opencl code\n");
+    dt_print(DT_DEBUG_OPENCL, "[opencl_finalscale] upscaling not yet supported by opencl code\n");
     return FALSE;
   }
 
   const int devid = piece->pipe->devid;
+  dt_print(DT_DEBUG_IMAGEIO, "[finalscale OpenCL %i] %ix%i (scale %f) -> %ix%i (scale %f)\n",
+    devid, roi_in->width, roi_in->height, roi_in->scale, roi_out->width, roi_out->height, roi_out->scale);
+
   cl_int err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_in, roi_out, roi_in);
-  if(err != CL_SUCCESS) goto error;
+  if(err != CL_SUCCESS)
+  {
+    dt_print(DT_DEBUG_OPENCL, "[opencl_finalscale] couldn't `dt_iop_clip_and_zoom_roi_cl`: %s\n", cl_errstr(err));
+    return FALSE;
+  }
 
   return TRUE;
-
-error:
-  dt_print(DT_DEBUG_OPENCL, "[opencl_finalscale] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
 }
 #endif
 
 void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
+  dt_print(DT_DEBUG_IMAGEIO, "[finalscale CPU] %ix%i (scale %f) -> %ix%i (scale %f)\n",
+    roi_in->width, roi_in->height, roi_in->scale, roi_out->width, roi_out->height, roi_out->scale);
   dt_iop_clip_and_zoom_roi(ovoid, ivoid, roi_out, roi_in, roi_out->width, roi_in->width);
 }
 

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -323,6 +323,7 @@ static void _export_button_clicked(GtkWidget *widget, dt_lib_export_t *d)
   uint32_t max_height = dt_conf_get_int(CONFIG_PREFIX "height");
 
   const gboolean upscale = dt_conf_get_bool(CONFIG_PREFIX "upscale");
+  const gboolean scaledimension = dt_conf_get_int(CONFIG_PREFIX "dimensions_type") == DT_DIMENSIONS_SCALE;
   const gboolean high_quality = dt_conf_get_bool(CONFIG_PREFIX "high_quality_processing");
   const gboolean export_masks = dt_conf_get_bool(CONFIG_PREFIX "export_masks");
   const gboolean style_append = dt_conf_get_bool(CONFIG_PREFIX "style_append");
@@ -355,7 +356,7 @@ static void _export_button_clicked(GtkWidget *widget, dt_lib_export_t *d)
   const dt_iop_color_intent_t icc_intent = dt_conf_get_int(CONFIG_PREFIX "iccintent");
 
   GList *list = dt_act_on_get_images(TRUE, TRUE, TRUE);
-  dt_control_export(list, max_width, max_height, format_index, storage_index, high_quality, upscale, export_masks,
+  dt_control_export(list, max_width, max_height, format_index, storage_index, high_quality, upscale, scaledimension, export_masks,
                     style, style_append, icc_type, icc_filename, icc_intent, d->metadata_export);
 
   g_free(icc_filename);


### PR DESCRIPTION
For some dt versions there have been a number of issues and fixes related to exact exported size
or crashes/errors related to out of memory access while processing exports.

After some work on the pixelpipe and roi handling i think the underlying culprit is current handling
of roi_in size in finalscale since dt 2.0
```
  // out = in * scale + .5f to more precisely round to user input in export module:
  roi_in->width  = (roi_out->width  - .5f)/roi_out->scale;
  roi_in->height = (roi_out->height - .5f)/roi_out->scale;
```

The code leads to a reduction of the roi_in size which is possibly/likely too small to provide complete data
for the processed roi_out. Let's look at the simple example of an 1.0 scaled output of a 1000x1000 image,
the export pixelpipe will be processed with an input of 999x999 -> 1000x1000 with a scale of 1.0.

In `dt_imageio_export_with_flags()` we had to handle this conflict and introduced some fixes/workarounds
that basically either reduced output size by 1 or did a cpu bound costly & slightly blurring upscaling to
the requested size. Both are bad.

The new code
1. in finalscale rounds **up** the roi_in size thus providing requested input data in all cases for roi_out
2. avoids needs to either size reduction or upscaling thus improving quality and performance
3. removed workarounds so less code complexity

Also the upscaling while using "set size by scale" did not work, for `dt_control_export()` a parameter flag
`dimensions_scale` had to be added to support this.

Any downsides?
All exports and thumbnails will be slightly different as they are either of correct/different size or with
same size but not upscaled/blurred.

Incomplete list of related issues and pr's

#12386 #12194 #12165 #11716 #10837 #9738 #8952 #7465 #5232 #5228

Certainly requires profound testing and updates in darktable-tests

