### PR TITLE
Histogram calculation updates

### DIFF
--- a/src/common/histogram.c
+++ b/src/common/histogram.c
@@ -69,52 +69,6 @@ inline void dt_histogram_helper_cs_RAW_uint16(const dt_dev_histogram_collection_
 
 //------------------------------------------------------------------------------
 
-inline static void __attribute__((__unused__)) histogram_helper_cs_rgb_helper_process_pixel_float_compensated(
-    const dt_dev_histogram_collection_params_t *const histogram_params, const float *pixel, uint32_t *histogram,
-    const dt_iop_order_iccprofile_info_t *const profile_info)
-{
-  const dt_aligned_pixel_t rgb = { dt_ioppr_compensate_middle_grey(pixel[0], profile_info),
-                                   dt_ioppr_compensate_middle_grey(pixel[1], profile_info),
-                                   dt_ioppr_compensate_middle_grey(pixel[2], profile_info) };
-  const uint32_t R = bin(rgb[0], histogram_params);
-  const uint32_t G = bin(rgb[1], histogram_params);
-  const uint32_t B = bin(rgb[2], histogram_params);
-  histogram[4 * R]++;
-  histogram[4 * G + 1]++;
-  histogram[4 * B + 2]++;
-}
-
-
-#if defined(__SSE2__)
-inline static void histogram_helper_cs_rgb_helper_process_pixel_m128_compensated(
-    const dt_dev_histogram_collection_params_t *const histogram_params, const float *pixel, uint32_t *histogram,
-    const dt_iop_order_iccprofile_info_t *const profile_info)
-{
-  const __m128 rgb = { dt_ioppr_compensate_middle_grey(pixel[0], profile_info),
-      dt_ioppr_compensate_middle_grey(pixel[1], profile_info),
-      dt_ioppr_compensate_middle_grey(pixel[2], profile_info), 1.f };
-  const __m128 scale = _mm_set1_ps(histogram_params->mul);
-  const __m128 val_min = _mm_setzero_ps();
-  const __m128 val_max = _mm_set1_ps(histogram_params->bins_count - 1);
-
-  assert(dt_is_aligned(pixel, 16));
-  const __m128 input = rgb;
-  const __m128 scaled = _mm_mul_ps(input, scale);
-  const __m128 clamped = _mm_max_ps(_mm_min_ps(scaled, val_max), val_min);
-
-  const __m128i indexes = _mm_cvtps_epi32(clamped);
-
-  __m128i values __attribute__((aligned(16)));
-  _mm_store_si128(&values, indexes);
-
-  const uint32_t *valuesi = (uint32_t *)(&values);
-
-  histogram[4 * valuesi[0]]++;
-  histogram[4 * valuesi[1] + 1]++;
-  histogram[4 * valuesi[2] + 2]++;
-}
-#endif
-
 inline static void histogram_helper_cs_rgb(const dt_dev_histogram_collection_params_t *const histogram_params,
                                            const void *pixel, uint32_t *histogram, int j,
                                            const dt_iop_order_iccprofile_info_t *const profile_info)
@@ -141,18 +95,20 @@ inline static void histogram_helper_cs_rgb_compensated(const dt_dev_histogram_co
 {
   const dt_histogram_roi_t *roi = histogram_params->roi;
   float *in = (float *)pixel + 4 * (roi->width * j + roi->crop_x);
+  const float max_bin = histogram_params->bins_count - 1;
+  const float scale = histogram_params->mul;
 
-  // process aligned pixels with SSE
-  for(int i = 0; i < roi->width - roi->crop_width - roi->crop_x; i++, in += 4)
+  for(int i = 0; i < roi->width - roi->crop_width - roi->crop_x; i++)
   {
-    if(darktable.codepath.OPENMP_SIMD)
-      histogram_helper_cs_rgb_helper_process_pixel_float_compensated(histogram_params, in, histogram, profile_info);
-#if defined(__SSE2__)
-    else if(darktable.codepath.SSE2)
-      histogram_helper_cs_rgb_helper_process_pixel_m128_compensated(histogram_params, in, histogram, profile_info);
-#endif
-    else
-      dt_unreachable_codepath();
+    dt_aligned_pixel_t b;
+    for_each_channel(k,aligned(in,b:16))
+    {
+      const float c = dt_ioppr_compensate_middle_grey(in[i*4+k], profile_info);
+      b[k] = CLAMP(scale * c, 0.0f, max_bin);
+    }
+    histogram[4 * (uint32_t)b[0]]++;
+    histogram[4 * (uint32_t)b[1] + 1]++;
+    histogram[4 * (uint32_t)b[2] + 2]++;
   }
 }
 

--- a/src/common/histogram.c
+++ b/src/common/histogram.c
@@ -255,47 +255,20 @@ void dt_histogram_max_helper(const dt_dev_histogram_stats_t *const histogram_sta
   {
     case IOP_CS_RAW:
       for(int k = 0; k < 4 * histogram_stats->bins_count; k += 4)
-        histogram_max[0] = histogram_max[0] > hist[k] ? histogram_max[0] : hist[k];
+        histogram_max[0] = MAX(histogram_max[0], hist[k]);
       break;
 
-    case IOP_CS_RGB:
-      // don't count <= 0 pixels
-      for(int k = 4; k < 4 * histogram_stats->bins_count; k += 4)
-        histogram_max[0] = histogram_max[0] > hist[k] ? histogram_max[0] : hist[k];
-      for(int k = 5; k < 4 * histogram_stats->bins_count; k += 4)
-        histogram_max[1] = histogram_max[1] > hist[k] ? histogram_max[1] : hist[k];
-      for(int k = 6; k < 4 * histogram_stats->bins_count; k += 4)
-        histogram_max[2] = histogram_max[2] > hist[k] ? histogram_max[2] : hist[k];
-      for(int k = 7; k < 4 * histogram_stats->bins_count; k += 4)
-        histogram_max[3] = histogram_max[3] > hist[k] ? histogram_max[3] : hist[k];
-      break;
-
-    case IOP_CS_LAB:
+    // RGB, Lab, and LCh
     default:
-      if(cst_to == IOP_CS_LCH)
+      // don't count <= 0 pixels except for ab or Ch
+      if(cst == IOP_CS_LAB)
       {
-        // don't count <= 0 pixels
-        for(int k = 4; k < 4 * histogram_stats->bins_count; k += 4)
-          histogram_max[0] = histogram_max[0] > hist[k] ? histogram_max[0] : hist[k];
-        for(int k = 5; k < 4 * histogram_stats->bins_count; k += 4)
-          histogram_max[1] = histogram_max[1] > hist[k] ? histogram_max[1] : hist[k];
-        for(int k = 6; k < 4 * histogram_stats->bins_count; k += 4)
-          histogram_max[2] = histogram_max[2] > hist[k] ? histogram_max[2] : hist[k];
-        for(int k = 7; k < 4 * histogram_stats->bins_count; k += 4)
-          histogram_max[3] = histogram_max[3] > hist[k] ? histogram_max[3] : hist[k];
+        histogram_max[1] = hist[1];
+        histogram_max[2] = hist[2];
       }
-      else
-      {
-        // don't count <= 0 pixels in L
-        for(int k = 4; k < 4 * histogram_stats->bins_count; k += 4)
-          histogram_max[0] = histogram_max[0] > hist[k] ? histogram_max[0] : hist[k];
-
-        // don't count <= -128 and >= +128 pixels in a and b
-        for(int k = 5; k < 4 * (histogram_stats->bins_count - 1); k += 4)
-          histogram_max[1] = histogram_max[1] > hist[k] ? histogram_max[1] : hist[k];
-        for(int k = 6; k < 4 * (histogram_stats->bins_count - 1); k += 4)
-          histogram_max[2] = histogram_max[2] > hist[k] ? histogram_max[2] : hist[k];
-      }
+      for(int k = 4; k < 4 * histogram_stats->bins_count; k += 4)
+        for_each_channel(ch,aligned(hist:16))
+          histogram_max[ch] = MAX(histogram_max[ch], hist[k+ch]);
       break;
   }
 

--- a/src/common/histogram.c
+++ b/src/common/histogram.c
@@ -185,7 +185,7 @@ void dt_histogram_worker(dt_dev_histogram_collection_params_t *const histogram_p
 void dt_histogram_helper(dt_dev_histogram_collection_params_t *histogram_params,
     dt_dev_histogram_stats_t *histogram_stats, const dt_iop_colorspace_type_t cst,
     const dt_iop_colorspace_type_t cst_to, const void *pixel, uint32_t **histogram,
-    const int compensate_middle_grey, const dt_iop_order_iccprofile_info_t *const profile_info)
+    const gboolean compensate_middle_grey, const dt_iop_order_iccprofile_info_t *const profile_info)
 {
   dt_times_t start_time = { 0 }, end_time = { 0 };
   if(darktable.unmuted & DT_DEBUG_PERF) dt_get_times(&start_time);
@@ -203,10 +203,10 @@ void dt_histogram_helper(dt_dev_histogram_collection_params_t *histogram_params,
 
     case IOP_CS_RGB:
       if(compensate_middle_grey && profile_info)
-        // for rgbcurve (sometimes)
+        // for rgbcurve (compensated)
         dt_histogram_worker(histogram_params, histogram_stats, pixel, histogram, histogram_helper_cs_rgb_compensated, profile_info);
       else
-        // used by levels, rgbcurve (sometimes), rgblevels
+        // used by levels, rgbcurve (uncompensated), rgblevels
         dt_histogram_worker(histogram_params, histogram_stats, pixel, histogram, histogram_helper_cs_rgb, profile_info);
       histogram_stats->ch = 3u;
       break;

--- a/src/common/histogram.c
+++ b/src/common/histogram.c
@@ -367,6 +367,9 @@ void dt_histogram_helper(dt_dev_histogram_collection_params_t *histogram_params,
     const dt_iop_colorspace_type_t cst_to, const void *pixel, uint32_t **histogram,
     const int compensate_middle_grey, const dt_iop_order_iccprofile_info_t *const profile_info)
 {
+  dt_times_t start_time = { 0 }, end_time = { 0 };
+  if(darktable.unmuted & DT_DEBUG_PERF) dt_get_times(&start_time);
+
   switch(cst)
   {
     case IOP_CS_RAW:
@@ -391,6 +394,14 @@ void dt_histogram_helper(dt_dev_histogram_collection_params_t *histogram_params,
       histogram_stats->ch = 3u;
       break;
   }
+
+  if(darktable.unmuted & DT_DEBUG_PERF)
+  {
+    dt_get_times(&end_time);
+    fprintf(stderr, "histogram calculation %d bins %d -> %d %d channels %d pixels took %.3f secs (%.3f CPU)\n",
+            histogram_params->bins_count, cst, cst_to, histogram_stats->ch, histogram_stats->pixels,
+            end_time.clock - start_time.clock, end_time.user - start_time.user);
+  }
 }
 
 void dt_histogram_max_helper(const dt_dev_histogram_stats_t *const histogram_stats,
@@ -398,6 +409,10 @@ void dt_histogram_max_helper(const dt_dev_histogram_stats_t *const histogram_sta
                              uint32_t **histogram, uint32_t *histogram_max)
 {
   if(*histogram == NULL) return;
+
+  dt_times_t start_time = { 0 }, end_time = { 0 };
+  if(darktable.unmuted & DT_DEBUG_PERF) dt_get_times(&start_time);
+
   histogram_max[0] = histogram_max[1] = histogram_max[2] = histogram_max[3] = 0;
   uint32_t *hist = *histogram;
   switch(cst)
@@ -446,6 +461,13 @@ void dt_histogram_max_helper(const dt_dev_histogram_stats_t *const histogram_sta
           histogram_max[2] = histogram_max[2] > hist[k] ? histogram_max[2] : hist[k];
       }
       break;
+  }
+
+  if(darktable.unmuted & DT_DEBUG_PERF)
+  {
+    dt_get_times(&end_time);
+    fprintf(stderr, "histogram max calc took %.3f secs (%.3f CPU)\n",
+        end_time.clock - start_time.clock, end_time.user - start_time.user);
   }
 }
 

--- a/src/common/histogram.h
+++ b/src/common/histogram.h
@@ -39,7 +39,7 @@ typedef struct dt_histogram_roi_t
 void dt_histogram_helper(dt_dev_histogram_collection_params_t *histogram_params,
                          dt_dev_histogram_stats_t *histogram_stats, const dt_iop_colorspace_type_t cst,
                          const dt_iop_colorspace_type_t cst_to, const void *pixel, uint32_t **histogram,
-                         const int compensate_middle_grey, const dt_iop_order_iccprofile_info_t *const profile_info);
+                         const gboolean compensate_middle_grey, const dt_iop_order_iccprofile_info_t *const profile_info);
 
 void dt_histogram_max_helper(const dt_dev_histogram_stats_t *const histogram_stats,
                              const dt_iop_colorspace_type_t cst, const dt_iop_colorspace_type_t cst_to,

--- a/src/common/histogram.h
+++ b/src/common/histogram.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2014-2020 darktable developers.
+    Copyright (C) 2014-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/common/histogram.h
+++ b/src/common/histogram.h
@@ -36,6 +36,9 @@ typedef struct dt_histogram_roi_t
   int width, height, crop_x, crop_y, crop_width, crop_height;
 } dt_histogram_roi_t;
 
+// allocates an aligned histogram buffer if needed, callers
+// (pixelpipe, exposure, global histogram) must garbage collect this
+// buffer via dt_free_align()
 void dt_histogram_helper(dt_dev_histogram_collection_params_t *histogram_params,
                          dt_dev_histogram_stats_t *histogram_stats, const dt_iop_colorspace_type_t cst,
                          const dt_iop_colorspace_type_t cst_to, const void *pixel, uint32_t **histogram,

--- a/src/common/histogram.h
+++ b/src/common/histogram.h
@@ -40,13 +40,13 @@ typedef struct dt_histogram_roi_t
 // (pixelpipe, exposure, global histogram) must garbage collect this
 // buffer via dt_free_align()
 void dt_histogram_helper(dt_dev_histogram_collection_params_t *histogram_params,
-                         dt_dev_histogram_stats_t *histogram_stats, const dt_iop_colorspace_type_t cst,
-                         const dt_iop_colorspace_type_t cst_to, const void *pixel, uint32_t **histogram,
-                         const gboolean compensate_middle_grey, const dt_iop_order_iccprofile_info_t *const profile_info);
-
-void dt_histogram_max_helper(const dt_dev_histogram_stats_t *const histogram_stats,
-                             const dt_iop_colorspace_type_t cst, const dt_iop_colorspace_type_t cst_to,
-                             uint32_t **histogram, uint32_t *histogram_max);
+                         dt_dev_histogram_stats_t *histogram_stats,
+                         const dt_iop_colorspace_type_t cst,
+                         const dt_iop_colorspace_type_t cst_to,
+                         const void *pixel,
+                         uint32_t **histogram, uint32_t *histogram_max,
+                         const gboolean compensate_middle_grey,
+                         const dt_iop_order_iccprofile_info_t *const profile_info);
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/histogram.h
+++ b/src/common/histogram.h
@@ -36,19 +36,6 @@ typedef struct dt_histogram_roi_t
   int width, height, crop_x, crop_y, crop_width, crop_height;
 } dt_histogram_roi_t;
 
-void dt_histogram_helper_cs_RAW_uint16(const dt_dev_histogram_collection_params_t *histogram_params,
-                                       const void *pixel, uint32_t *histogram, int j,
-                                       const dt_iop_order_iccprofile_info_t *const profile_info);
-
-typedef void((*dt_worker)(const dt_dev_histogram_collection_params_t *const histogram_params,
-                          const void *pixel, uint32_t *histogram, int j,
-                          const dt_iop_order_iccprofile_info_t *const profile_info));
-
-void dt_histogram_worker(dt_dev_histogram_collection_params_t *const histogram_params,
-                         dt_dev_histogram_stats_t *histogram_stats, const void *const pixel,
-                         uint32_t **histogram, const dt_worker Worker,
-                         const dt_iop_order_iccprofile_info_t *const profile_info);
-
 void dt_histogram_helper(dt_dev_histogram_collection_params_t *histogram_params,
                          dt_dev_histogram_stats_t *histogram_stats, const dt_iop_colorspace_type_t cst,
                          const dt_iop_colorspace_type_t cst_to, const void *pixel, uint32_t **histogram,

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -221,7 +221,7 @@ typedef struct dt_iop_module_t
    */
   dt_iop_colorspace_type_t histogram_cst;
   /** scale the histogram so the middle grey is at .5 */
-  int histogram_middle_grey;
+  gboolean histogram_middle_grey;
   /** the module is used in this develop module. */
   struct dt_develop_t *dev;
   /** non zero if this node should be processed. */

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2021 darktable developers.
+    Copyright (C) 2009-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/develop/pixelpipe.h
+++ b/src/develop/pixelpipe.h
@@ -53,8 +53,6 @@ typedef struct dt_dev_histogram_collection_params_t
   const struct dt_histogram_roi_t *roi;
   /** count of histogram bins. */
   uint32_t bins_count;
-  /** in most cases, bins_count-1. */
-  float mul;
 } dt_dev_histogram_collection_params_t;
 
 // params used to collect histogram during last histogram capture

--- a/src/develop/pixelpipe.h
+++ b/src/develop/pixelpipe.h
@@ -60,6 +60,8 @@ typedef struct dt_dev_histogram_stats_t
 {
   /** count of histogram bins. */
   uint32_t bins_count;
+  /** size of currently allocated buffer, or 0 if none */
+  size_t buf_size;
   /** count of pixels sampled during histogram capture. */
   uint32_t pixels;
   /** count of channels: 1 for RAW, 3 for rgb/Lab. */

--- a/src/develop/pixelpipe.h
+++ b/src/develop/pixelpipe.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2020 darktable developers.
+    Copyright (C) 2009-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2022 darktable developers.
+    Copyright (C) 2009-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -549,11 +549,10 @@ static void _histogram_collect(dt_dev_pixelpipe_iop_t *piece, const void *pixel,
   const dt_iop_colorspace_type_t cst = piece->module->input_colorspace(piece->module, piece->pipe, piece);
 
   dt_histogram_helper(&histogram_params, &piece->histogram_stats, cst,
-                      piece->module->histogram_cst, pixel, histogram,
+                      piece->module->histogram_cst,
+                      pixel, histogram, histogram_max,
                       piece->module->histogram_middle_grey,
                       dt_ioppr_get_pipe_work_profile_info(piece->pipe));
-  dt_histogram_max_helper(&piece->histogram_stats, cst,
-                          piece->module->histogram_cst, histogram, histogram_max);
 }
 
 #ifdef HAVE_OPENCL
@@ -601,11 +600,10 @@ static void _histogram_collect_cl(int devid, dt_dev_pixelpipe_iop_t *piece, cl_m
   const dt_iop_colorspace_type_t cst = piece->module->input_colorspace(piece->module, piece->pipe, piece);
 
   dt_histogram_helper(&histogram_params, &piece->histogram_stats,
-                      cst, piece->module->histogram_cst, pixel, histogram,
+                      cst, piece->module->histogram_cst,
+                      pixel, histogram, histogram_max,
                       piece->module->histogram_middle_grey,
                       dt_ioppr_get_pipe_work_profile_info(piece->pipe));
-  dt_histogram_max_helper(&piece->histogram_stats, cst,
-                          piece->module->histogram_cst, histogram, histogram_max);
 
   if(tmpbuf) dt_free_align(tmpbuf);
 }

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -279,7 +279,7 @@ void dt_dev_pixelpipe_cleanup_nodes(dt_dev_pixelpipe_t *pipe)
     piece->module->cleanup_pipe(piece->module, pipe, piece);
     free(piece->blendop_data);
     piece->blendop_data = NULL;
-    free(piece->histogram);
+    dt_free_align(piece->histogram);
     piece->histogram = NULL;
     g_hash_table_destroy(piece->raster_masks);
     piece->raster_masks = NULL;

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -322,7 +322,7 @@ static void _deflicker_prepare_histogram(dt_iop_module_t *self, uint32_t **histo
   histogram_params.bins_count = DEFLICKER_BINS_COUNT;
 
   dt_histogram_helper(&histogram_params, histogram_stats, IOP_CS_RAW, IOP_CS_NONE,
-                      buf.buf, histogram, 0, NULL);
+                      buf.buf, histogram, FALSE, NULL);
 
   dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
 }

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -400,7 +400,7 @@ static void _process_common_setup(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t 
       dt_dev_histogram_stats_t histogram_stats;
       _deflicker_prepare_histogram(self, &histogram, &histogram_stats);
       _compute_correction(self, &d->params, piece->pipe, histogram, &histogram_stats, &exposure);
-      free(histogram);
+      dt_free_align(histogram);
     }
 
     // second, show computed correction in UI.
@@ -572,7 +572,7 @@ void gui_update(struct dt_iop_module_t *self)
 
   dt_iop_gui_leave_critical_section(self);
 
-  free(g->deflicker_histogram);
+  dt_free_align(g->deflicker_histogram);
   g->deflicker_histogram = NULL;
 
   gtk_label_set_text(g->deflicker_used_EC, "");
@@ -805,7 +805,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
   if(w == g->mode)
   {
-    free(g->deflicker_histogram);
+    dt_free_align(g->deflicker_histogram);
     g->deflicker_histogram = NULL;
 
     switch(p->mode)
@@ -1150,7 +1150,7 @@ void gui_cleanup(struct dt_iop_module_t *self)
   if(darktable.develop->proxy.exposure.module == self)
     darktable.develop->proxy.exposure.module = NULL;
 
-  free(g->deflicker_histogram);
+  dt_free_align(g->deflicker_histogram);
   g->deflicker_histogram = NULL;
 
   IOP_GUI_FREE;

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2021 darktable developers.
+    Copyright (C) 2009-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -352,18 +352,16 @@ static void _compute_correction(dt_iop_module_t *self, dt_iop_params_t *p1, dt_d
 
   if(histogram == NULL) return;
 
-  const size_t total = (size_t)histogram_stats->ch * histogram_stats->pixels;
-
   const double thr
-      = CLAMP(((double)total * (double)p->deflicker_percentile / (double)100.0), 0.0, (double)total);
+      = CLAMP(((double)histogram_stats->pixels * (double)p->deflicker_percentile
+               / (double)100.0), 0.0, (double)histogram_stats->pixels);
 
   size_t n = 0;
   uint32_t raw = 0;
 
-  for(uint32_t i = 0; i < histogram_stats->bins_count; i++)
+  for(size_t i = 0; i < histogram_stats->bins_count; i++)
   {
-    for(uint32_t k = 0; k < histogram_stats->ch; k++)
-      n += histogram[4 * i + k];
+    n += histogram[i];
 
     if((double)n >= thr)
     {

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -322,7 +322,7 @@ static void _deflicker_prepare_histogram(dt_iop_module_t *self, uint32_t **histo
   histogram_params.bins_count = DEFLICKER_BINS_COUNT;
 
   dt_histogram_helper(&histogram_params, histogram_stats, IOP_CS_RAW, IOP_CS_NONE,
-                      buf.buf, histogram, FALSE, NULL);
+                      buf.buf, histogram, NULL, FALSE, NULL);
 
   dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
 }

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -321,9 +321,8 @@ static void _deflicker_prepare_histogram(dt_iop_module_t *self, uint32_t **histo
   histogram_params.roi = &histogram_roi;
   histogram_params.bins_count = DEFLICKER_BINS_COUNT;
 
-  dt_histogram_worker(&histogram_params, histogram_stats, buf.buf, histogram,
-                      dt_histogram_helper_cs_RAW_uint16, NULL);
-  histogram_stats->ch = 1u;
+  dt_histogram_helper(&histogram_params, histogram_stats, IOP_CS_RAW, IOP_CS_NONE,
+                      buf.buf, histogram, 0, NULL);
 
   dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
 }

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -156,7 +156,7 @@ void init_presets(dt_iop_module_so_t *self)
   p.curve_type[DT_IOP_RGBCURVE_G] = CUBIC_SPLINE;
   p.curve_type[DT_IOP_RGBCURVE_B] = CUBIC_SPLINE;
   p.curve_autoscale = DT_S_SCALE_AUTOMATIC_RGB;
-  p.compensate_middle_grey = 1;
+  p.compensate_middle_grey = TRUE;
   p.preserve_colors = 1;
 
   float linear_ab[7] = { 0.0, 0.08, 0.3, 0.5, 0.7, 0.92, 1.0 };

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2019-2021 darktable developers.
+    Copyright (C) 2019-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -189,8 +189,8 @@ static void _lib_histogram_process_histogram(dt_lib_histogram_t *const d, const 
 
   // FIXME: for point sample, calculate whole graph and the point sample values, draw these on top of the graph
   // FIXME: set up "custom" histogram worker which can do colorspace conversion on fly -- in cases that we need to do that -- may need to add from colorspace to dt_dev_histogram_collection_params_t
-  dt_histogram_helper(&histogram_params, &histogram_stats, cst, IOP_CS_NONE, input, &d->histogram, FALSE, NULL);
-  dt_histogram_max_helper(&histogram_stats, cst, IOP_CS_NONE, &d->histogram, histogram_max);
+  dt_histogram_helper(&histogram_params, &histogram_stats, cst, IOP_CS_NONE,
+                      input, &d->histogram, histogram_max, FALSE, NULL);
   d->histogram_max = MAX(MAX(histogram_max[0], histogram_max[1]), histogram_max[2]);
 }
 

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2022 darktable developers.
+    Copyright (C) 2011-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -178,7 +178,7 @@ static void _lib_histogram_process_histogram(dt_lib_histogram_t *const d, const 
 {
   dt_dev_histogram_collection_params_t histogram_params = { 0 };
   const dt_iop_colorspace_type_t cst = IOP_CS_RGB;
-  dt_dev_histogram_stats_t histogram_stats = { .bins_count = HISTOGRAM_BINS, .ch = 4, .pixels = 0 };
+  dt_dev_histogram_stats_t histogram_stats = { .bins_count = HISTOGRAM_BINS, .ch = 4, .pixels = 0, .buf_size = sizeof(uint32_t) * 4 * HISTOGRAM_BINS };
   uint32_t histogram_max[4] = { 0 };
 
   d->histogram_max = 0;
@@ -1880,7 +1880,7 @@ void gui_init(dt_lib_module_t *self)
   int a = dt_conf_get_int("plugins/darkroom/histogram/vectorscope/angle");
   d->vectorscope_angle = a * M_PI / 180.0;
 
-  d->histogram = (uint32_t *)dt_alloc_align(16, 4 * HISTOGRAM_BINS * sizeof(uint32_t));
+  d->histogram = (uint32_t *)dt_alloc_align(64, 4 * HISTOGRAM_BINS * sizeof(uint32_t));
   memset(d->histogram, 0, 4 * HISTOGRAM_BINS * sizeof(uint32_t));
   d->histogram_max = 0;
 

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1881,7 +1881,8 @@ void gui_init(dt_lib_module_t *self)
   int a = dt_conf_get_int("plugins/darkroom/histogram/vectorscope/angle");
   d->vectorscope_angle = a * M_PI / 180.0;
 
-  d->histogram = (uint32_t *)calloc(4 * HISTOGRAM_BINS, sizeof(uint32_t));
+  d->histogram = (uint32_t *)dt_alloc_align(16, 4 * HISTOGRAM_BINS * sizeof(uint32_t));
+  memset(d->histogram, 0, 4 * HISTOGRAM_BINS * sizeof(uint32_t));
   d->histogram_max = 0;
 
   // Waveform buffer doesn't need to be coupled with the histogram
@@ -2102,7 +2103,7 @@ void gui_cleanup(dt_lib_module_t *self)
 {
   dt_lib_histogram_t *d = (dt_lib_histogram_t *)self->data;
 
-  free(d->histogram);
+  dt_free_align(d->histogram);
   for(int ch=0; ch<3; ch++)
     dt_free_align(d->waveform_img[ch]);
   dt_free_align(d->vectorscope_graph);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -186,7 +186,6 @@ static void _lib_histogram_process_histogram(dt_lib_histogram_t *const d, const 
 
   histogram_params.roi = roi;
   histogram_params.bins_count = HISTOGRAM_BINS;
-  histogram_params.mul = histogram_params.bins_count - 1;
 
   // FIXME: for point sample, calculate whole graph and the point sample values, draw these on top of the graph
   // FIXME: set up "custom" histogram worker which can do colorspace conversion on fly -- in cases that we need to do that -- may need to add from colorspace to dt_dev_histogram_collection_params_t


### PR DESCRIPTION
This modernizes the histogram calculation code (the code in common/histogram.c, not to be confused with the UI scope code in libs/histogram.c. It removes the hand-written SSE code, but the generated code should be equivalent in speed. It removes approx. 189 LOC.

Changes:

- Remove the code to generate a histogram of a floating point raw images. This appears to be unused anywhere in the current darktable codebase.
- The exposure deflicker code previously bypassed the standard histogram call `dt_histogram_helper()`. It now uses that call to generate a histogram of the raw image data (which will be 16 bit unsigned int).
- The histogram data buffer is now 64-bit aligned. As before the caller to `dt_histogram_helper()` must free any returned buffer, but now it must use `dt_free_align()`
- As mentioned, all the SSE code is gone. But I used it as a model for the revised code (which relies heavily on the `for_each_channel()`), hence the generated assembly should look eerily similar in many cases.
- ~~Clamping of bin numbers is now always done by converting them to integers first. Previously they were sometimes clamped as floats. This shouldn't make any difference in the results, but is more "correct".~~ Wrong! Clamping negative floats as unsigned integers is not advisable.
- The `mul` parameter was removed from `dt_dev_histogram_collection_params_t`. It appears to have been intended for scaling the binning to something other than the maximum # of bins, but no current code used this feature.
- A `buf_size` parameter was added to `dt_dev_histogram_stats_t`. This allows the histogram code to calculate if the # of bins has changed, and if so allocate a larger buffer if necessary. (Changing of the buffer size is only used by the levels iop. It might be a bit more slick to put this tracking/reallocating responsibility on the levels iop.)
- `dt_histogram_max_helper()` as a separate call was eliminated. Pass the `histogram_max` array in to the main `dt_histogram_helper()` function instead, or `NULL` if no maximum calculation is needed (which is the case for exposure deflicker).
- The prior code ignored the first bin when calculating max values for each channel. This makes sense for the `R`, `G`, `B`, `L`, and `C` channels to avoid scaling to underexposed values. But not so much for the `a`, `b` and `h` values, so bin 0 for these is counted.
- Rather than using hand-rolled per-thread buffers and explicitly written reduction code when using OpenMP threads, the code relies on OpenMP array reductions. This simplifies the code, and there appears to be no speed difference.
- `compensate_middle_grey` is now a boolean (it was an int)

Rationale for this work:
- Compilers are increasingly capable, and it doesn't make sense in many cases to handcode SIMD instructions.
- OpenMP 4.5 allows for array reductions, which further reduces code size.
- The prior histogram calculation code, when perused, looks like something magic. Though this PR's code is much less magic, it is more succinct, and hence should be easier to reason about.
- There was some idea that the crashes on Windows are caused by unaligned access to histogram data. Though I don't see any huge signs of problems here, this code does align the histogram data, which might help.
- There has been so much revision in the use of histogram code over the years that it makes sense to perform an overhaul. This allows for discovering unused code, etc. As the actual uses of histograms in darktable has become clear, it makes sense to code the histogram calculation around how the histograms are actually used, rather than coding something slightly more generalized.
- Prior code often had OpenMP and SSE execution paths for the same operation. This PR only has one execution path for each operation.