### PR TITLE
Reflect rename of .desktop file in POTFILES.in

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -87,7 +87,7 @@ build/lib/darktable/plugins/introspection_vignette.c
 build/lib/darktable/plugins/introspection_watermark.c
 build/lib/darktable/plugins/introspection_zonesystem.c
 build/lib/darktable/plugins/lighttable/tools/darktable_authors.h
-build/share/darktable/darktable.desktop.in
+build/share/darktable/org.darktable.darktable.desktop.in
 data/org.darktable.darktable.appdata.xml.in
 data/org.darktable.darktable.desktop.in
 src/bauhaus/bauhaus.c


### PR DESCRIPTION
Commit 17508f1608 changed the desktop file from
`darktable.desktop.in` to `org.darktable.darktable.desktop.in`, but this change has not made into the pot file, so `intltool-update` is confused:

```
$ intltool-update -pot
can't open ./../build/share/darktable/darktable.desktop.in: No such file or directory at /usr/bin/intltool-extract line 212. xgettext: error while opening "../build/bin/conf_gen.h" for reading: No such file or directory ERROR: xgettext failed to generate PO template file. Please consult
       error message above if there is any.

$ intltool-update pt_BR
can't open ./../build/share/darktable/darktable.desktop.in: No such file or directory at /usr/bin/intltool-extract line 212. xgettext: error while opening "../build/share/darktable/darktable.desktop.in.h" for reading: No such file or directory ERROR: xgettext failed to generate PO template file. Please consult
       error message above if there is any.
```

This patch changes the desktop file name in `POTFILES.in` (and `darktable.pot`), so `intltool-update` runs as expected.
