### PR TITLE
Fix homebrew build failure on Ventura

### DIFF
--- a/packaging/macosx/3_make_hb_darktable_package.sh
+++ b/packaging/macosx/3_make_hb_darktable_package.sh
@@ -74,8 +74,12 @@ function reset_exec_path {
 
     # Handle libdarktable.dylib
     if [[ "$oToolLDependencies" == *"@rpath/libdarktable.dylib"* && "$1" != *"libdarktable.dylib"* ]]; then
-        echo "Resetting loader path for libdarktable.dylib of <$1>"
-        install_name_tool -rpath @loader_path/../lib/darktable @loader_path/../Resources/lib/darktable "$1"
+        # Only need to reset binaries that live outside of lib/darktable
+        oToolLoader=$(otool -l "$1" 2>/dev/null | grep '@loader_path' | cut -d\( -f1 | sed 's/^[[:blank:]]*path[[:blank:]]*//;s/[[:blank:]]*$//' )
+        if [[ "$oToolLoader" == "@loader_path/../lib/darktable" ]]; then
+            echo "Resetting loader path for libdarktable.dylib of <$1>"
+            install_name_tool -rpath @loader_path/../lib/darktable @loader_path/../Resources/lib/darktable "$1"
+        fi
     fi
 
     # Filter for any homebrew specific paths


### PR DESCRIPTION
This is my first PR for darktrace.  My apologies if I am missing any required information.

When building darktable 4.2.0 on macos Ventura under homebrew I ran into a failure in the packaging script:

`error: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool: no LC_RPATH load command with path: @loader_path/../lib/darktable found in: package/darktable.app/Contents/Resources/lib/darktable/plugins/libcolorbalance.so (for architecture x86_64), required for specified option "-rpath @loader_path/../lib/darktable @loader_path/../Resources/lib/darktable"
`

When searching for similar issues I found a comment with the identical error: https://github.com/darktable-org/darktable/pull/11579#issuecomment-1368538246

The error results because the package script is attempting to update the @loader_path on all binaries that reference libdarktrace.dylib and failing on binaries that have a different @loader_path than the one specified in the script.  As it turns out all the plugin binaries in ../lib/darktrace have the correct path and only the binaries outside of ../lib/darktrace require updating.  This PR restricts the update process to binaries with the incorrect @loader_path.  

After applying this patch darktrace builds and runs successfully for both release-4.2.0 and HEAD.