### PR TITLE
Homebrew dependency installer improvements

### DIFF
--- a/packaging/macosx/1_install_hb_dependencies.sh
+++ b/packaging/macosx/1_install_hb_dependencies.sh
@@ -98,3 +98,6 @@ if [ "${notfound}" ]; then
 
     brew install ${notfound}
 fi
+
+# fix for keg-only libomp
+brew link --force libomp

--- a/packaging/macosx/1_install_hb_dependencies.sh
+++ b/packaging/macosx/1_install_hb_dependencies.sh
@@ -61,7 +61,40 @@ hbDependencies="adwaita-icon-theme \
     sdl2 \
     webp"
 
-# Install homebrew dependencies
+# Categorize dependency list
+standalone=
+deps=
+notfound=
+hbInstalled=$( brew list --formula --quiet )
+hbLeaves=$( brew leaves --installed-on-request )
 for hbDependency in $hbDependencies; do
-    brew install "$hbDependency"
+    if [[ " ${hbInstalled[*]} " == *"${hbDependency}"* ]];
+    then
+      if [[ " ${hbLeaves[*]} " == *"${hbDependency}"* ]]; then
+        standalone="${hbDependency} ${standalone}"
+      else
+        deps="${hbDependency} ${deps}"
+      fi
+    else
+      notfound="${hbDependency} ${notfound}"
+    fi
 done
+
+# Show installed dependencies
+if [ "${standalone}" -o "${deps}" ]; then
+    echo
+    echo "Installed Dependencies:"
+    (
+        brew list --formula --quiet --versions ${standalone}
+        brew list --formula --quiet --versions ${deps} | sed -e 's/$/ (autoinstalled)/'
+    ) | sort
+fi
+
+# Install missing dependencies
+if [ "${notfound}" ]; then
+    echo
+    echo "Missing Dependencies:"
+    echo "${notfound}"
+
+    brew install ${notfound}
+fi


### PR DESCRIPTION
When building darktable on macos Ventura with homebrew the dependency installation script worked but was extremely slow as it attempts to install each dependency in turn with lots of failure messages for packages that are already present.

This PR is a minor enhancement that updates the script to quickly identify and display installed dependencies, identify which packages are standalone packages, and quickly install any dependencies that are missing.

With this PR behavior now looks like this:
```
~/src/darktable/packaging/macosx*
❯ brew remove sdl2
Uninstalling /usr/local/Cellar/sdl2/2.26.2... (93 files, 6.4MB)

~/src/darktable/packaging/macosx*
❯ ./1_install_hb_dependencies.sh 
Found homebrew running in i386-based environment.
Updated 1 tap (homebrew/core).

Installed Dependencies:
adwaita-icon-theme 43
cmake 3.25.1
cmocka 1.1.5
curl 7.87.0
desktop-file-utils 0.26
exiv2 0.27.5_1
gettext 0.21.1 (autoinstalled)
git 2.39.0
glib 2.74.4
gmic 3.1.6
gphoto2 2.5.28_1
graphicsmagick 1.3.40
gtk+3 3.24.36 (autoinstalled)
gtk-mac-integration 3.0.1
icu4c 71.1 (autoinstalled)
intltool 0.51.0_1
iso-codes 4.12.0
jpeg 9e (autoinstalled)
jpeg-xl 0.7.0_1 (autoinstalled)
json-glib 1.6.6
lensfun 0.3.3_1
libavif 0.11.1 (autoinstalled)
libheif 1.14.2 (autoinstalled)
libomp 15.0.7 (autoinstalled)
librsvg 2.55.1 (autoinstalled)
libsecret 0.20.5
libsoup@2 2.74.2_1 (autoinstalled)
little-cms2 2.14 (autoinstalled)
llvm 15.0.7
lua 5.4.4_1
ninja 1.11.1
openexr 3.1.5 (autoinstalled)
openjpeg 2.5.0 (autoinstalled)
osm-gps-map 1.2.0_1
perl 5.36.0 (autoinstalled)
po4a 0.69
portmidi 2.0.4
pugixml 1.13
webp 1.3.0 (autoinstalled)

Missing Dependencies:
sdl2 
==> Fetching sdl2
==> Downloading https://ghcr.io/v2/homebrew/core/sdl2/manifests/2.26.2
Already downloaded: /Users/shonjir/Library/Caches/Homebrew/downloads/9723651848b421374c85476c2b97a00e7e68342c20045a6c2fc2fa802d8e25c9--sdl2-2.26.2.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/sdl2/blobs/sha256:be08030ea0bc6bcac11b442b32d9e4ee181108e69c06037a1d4dc50ba69f62f2
Already downloaded: /Users/shonjir/Library/Caches/Homebrew/downloads/08b3423963a918ad91769b3b5e7e3a8fb789bc2a72a01babc94ffe5ee7dadb59--sdl2--2.26.2.ventura.bottle.tar.gz
==> Pouring sdl2--2.26.2.ventura.bottle.tar.gz
🍺  /usr/local/Cellar/sdl2/2.26.2: 93 files, 6.4MB
==> Running `brew cleanup sdl2`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).

~/src/darktable/packaging/macosx* 16s
>
```