### PR TITLE
rgbcurve bugfix: draw histogram properly when compensate middle grey is set

### DIFF
--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1593,9 +1593,14 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   dt_iop_rgbcurve_params_t *p = (dt_iop_rgbcurve_params_t *)p1;
 
   if(pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
+  {
     piece->request_histogram |= (DT_REQUEST_ON);
+    self->histogram_middle_grey = p->compensate_middle_grey;
+  }
   else
+  {
     piece->request_histogram &= ~(DT_REQUEST_ON);
+  }
 
   for(int ch = 0; ch < DT_IOP_RGBCURVE_MAX_CHANNELS; ch++)
     d->curve_changed[ch]


### PR DESCRIPTION
Fixes bug where, when opening an image with an rgbcurve iop with "compensate middle gray" turned on, the background histogram would not be compensated.

To replicate the bug with code prior to this pr:

1. Open an image in darkroom view
2. Enable the RGB curve iop
3. Click "compensate middle grey", note that the module's background histogram has updated (moved to right).
4. Switch back to lighttable view
5. Switch back to darkroom view
6. Note that the module's background histogram is no longer compensated (it has moved back to left), even though the "compensate middle gray" button is checked
7. Uncheck "compensate middle gray" button, and note that the background histogram doesn't change
8. Check the "compensate middle gray" button, and note that the background histogram has changed (moved to the right)

Expected behavior:

6. The background histogram will be compensated (move to right)
7. The background histogram will change (move to left)

Note that there is no problem with the processing behavior of the module. Points on the curve would still respect the "compensate middle gray" checkbox, and the results of the iop were still as expected. But it may be confusing to the user to draw points on the curve when the background histogram doesn't accurately reflect the image.