### PR TITLE
Rotate with right-drag in qap and if focused module not using it

### DIFF
--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -229,6 +229,9 @@ typedef struct dt_develop_t
     // each element is dt_dev_proxy_exposure_t
     dt_dev_proxy_exposure_t exposure;
 
+    // this module receives right-drag events if not already claimed
+    struct dt_iop_module_t *rotate;
+
     // modulegroups plugin hooks
     struct
     {

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1100,8 +1100,8 @@ int dt_masks_events_button_pressed(struct dt_iop_module_t *module, double x, dou
   }
 
   if(form->functions)
-    return form->functions->button_pressed(module, pzx, pzy, pressure, which, type, state, form, 0, gui, 0);
-
+    return form->functions->button_pressed(module, pzx, pzy, pressure, which, type, state, form, 0, gui, 0)
+        || which == 3; // swallow right-clicks even when not handled so right-drag rotate is disabled when forms visible
   return 0;
 }
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3849,7 +3849,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
 
   // we draw the cropping area; we need x_off/y_off/width/height which is only available
   // after g->buf has been processed
-  if(g->buf && self->enabled)
+  if(g->buf && self->enabled && gui_has_focus(self))
   {
     // roi data of the preview pipe input buffer
 
@@ -5829,10 +5829,15 @@ void gui_init(struct dt_iop_module_t *self)
   /* add signal handler for preview pipe finish to redraw the overlay */
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
                                   G_CALLBACK(_event_process_after_preview_callback), self);
+
+  darktable.develop->proxy.rotate = self;
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
+  if(darktable.develop->proxy.rotate == self)
+    darktable.develop->proxy.rotate = NULL;
+
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_event_process_after_preview_callback), self);
 
   dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -3163,6 +3163,13 @@ int button_pressed(struct dt_iop_module_t *module,
     goto done;
   }
 
+  // right-click is handled on release
+  if(which == 3)
+  {
+    handled = 1;
+    goto done;
+  }
+
 done:
   dt_iop_gui_leave_critical_section(module);
   return handled;


### PR DESCRIPTION
fixes #12222
fixes #10757

This always let's the rotate & perspective module process right-click & drags, unless something else already claims it. So it works in QAP and when most other modules are focused, but _not_ when crop is active (because then right-click resets the crop), or when color-picking or when editing masks (even when not above a mask, for safety).

Also require that a right-drag needs to be over a certain distance before an angle will be calculated (and shown) and rotation applied when released. So a simple right click (without mouse move) will be ignored.

Adds a toast with the amount of the adjustment and the new angle (for when rotation widget or panel are hidden).