### PR TITLE
Pixelpipe debugging mods

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1539,42 +1539,41 @@ void dt_cleanup()
   dt_exif_cleanup();
 }
 
+/* The dt_print variations can be used with a combination of DT_DEBUG_ flags.
+   A special case: if you combine with DT_DEBUG_VERBOSE output will only be done
+   if dt has been started with -d verbose
+*/
 void dt_print(dt_debug_thread_t thread, const char *msg, ...)
 {
-  if(darktable.unmuted & thread)
-  {
-    printf("%f ", dt_get_wtime() - darktable.start_wtime);
-    va_list ap;
-    va_start(ap, msg);
-    vprintf(msg, ap);
-    va_end(ap);
-    fflush(stdout);
-  }
+  if(((thread & DT_DEBUG_VERBOSE) && ((darktable.unmuted & DT_DEBUG_VERBOSE) == 0))
+    || !(darktable.unmuted & thread))
+    return;
+
+  char buf[128];
+  char vbuf[2048];
+  snprintf(buf, sizeof(buf), "%f", dt_get_wtime() - darktable.start_wtime);
+
+  va_list ap;
+  va_start(ap, msg);
+  vsnprintf(vbuf, sizeof(vbuf), msg, ap);
+  va_end(ap);
+
+  printf("%11s %s", buf, vbuf);
+  fflush(stdout);
 }
 
 void dt_print_nts(dt_debug_thread_t thread, const char *msg, ...)
 {
-  if(darktable.unmuted & thread)
-  {
-    va_list ap;
-    va_start(ap, msg);
-    vprintf(msg, ap);
-    va_end(ap);
-    fflush(stdout);
-  }
-}
+  if(((thread & DT_DEBUG_VERBOSE) && ((darktable.unmuted & DT_DEBUG_VERBOSE) == 0))
+    || !(darktable.unmuted & thread))
+    return;
 
-void dt_vprint(dt_debug_thread_t thread, const char *msg, ...)
-{
-  if((darktable.unmuted & DT_DEBUG_VERBOSE) && (darktable.unmuted & thread))
-  {
-    printf("%f ", dt_get_wtime() - darktable.start_wtime);
-    va_list ap;
-    va_start(ap, msg);
-    vprintf(msg, ap);
-    va_end(ap);
-    fflush(stdout);
-  }
+  char vbuf[2048];
+  va_list ap;
+  va_start(ap, msg);
+  vsnprintf(vbuf, sizeof(vbuf), msg, ap);
+  va_end(ap);
+  printf("%s", vbuf);
 }
 
 void *dt_alloc_align(size_t alignment, size_t size)

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -131,7 +131,7 @@ static int usage(const char *argv0)
   printf("  --configdir <user config directory>\n");
   printf("  -d {all,act_on,cache,camctl,camsupport,control,demosaic,dev,imageio,\n");
   printf("      input,ioporder,lighttable,lua,masks,memory,nan,opencl,params,\n");
-  printf("      perf,print,pwstorage,signal,sql,tiling,undo,verbose,roi}\n");
+  printf("      perf,print,pwstorage,signal,sql,tiling,undo,verbose,pipe}\n");
   printf("  --d-signal <signal> \n");
   printf("  --d-signal-act <all,raise,connect,disconnect");
   // clang-format on
@@ -725,8 +725,8 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
           darktable.unmuted |= DT_DEBUG_TILING;
         else if(!strcmp(argv[k + 1], "verbose"))
           darktable.unmuted |= DT_DEBUG_VERBOSE;
-        else if(!strcmp(argv[k + 1], "roi"))
-          darktable.unmuted |= DT_DEBUG_ROI;
+        else if(!strcmp(argv[k + 1], "pipe"))
+          darktable.unmuted |= DT_DEBUG_PIPE;
         else
           return usage(argv[0]);
         k++;
@@ -1551,7 +1551,7 @@ void dt_print(dt_debug_thread_t thread, const char *msg, ...)
 
   char buf[128];
   char vbuf[2048];
-  snprintf(buf, sizeof(buf), "%f", dt_get_wtime() - darktable.start_wtime);
+  snprintf(buf, sizeof(buf), "%.4f", dt_get_wtime() - darktable.start_wtime);
 
   va_list ap;
   va_start(ap, msg);

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -366,8 +366,6 @@ void dt_cleanup();
 void dt_print(dt_debug_thread_t thread, const char *msg, ...) __attribute__((format(printf, 2, 3)));
 /* same as above but without time stamp : nts = no time stamp */
 void dt_print_nts(dt_debug_thread_t thread, const char *msg, ...) __attribute__((format(printf, 2, 3)));
-/* same as above but requires additional DT_DEBUG_VERBOSE flag to be true */
-void dt_vprint(dt_debug_thread_t thread, const char *msg, ...) __attribute__((format(printf, 2, 3)));
 int dt_worker_threads();
 size_t dt_get_available_mem();
 size_t dt_get_singlebuffer_mem();

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -273,7 +273,7 @@ typedef enum dt_debug_thread_t
   DT_DEBUG_ACT_ON         = 1 << 23,
   DT_DEBUG_TILING         = 1 << 24,
   DT_DEBUG_VERBOSE        = 1 << 25,
-  DT_DEBUG_ROI            = 1 << 26
+  DT_DEBUG_PIPE           = 1 << 26
 } dt_debug_thread_t;
 
 typedef struct dt_codepath_t

--- a/src/common/dlopencl.c
+++ b/src/common/dlopencl.c
@@ -64,9 +64,9 @@ dt_dlopencl_t *dt_dlopencl_init(const char *name)
     library = name;
     module = dt_gmodule_open(library);
     if(module == NULL)
-      dt_vprint(DT_DEBUG_OPENCL, "[dt_dlopencl_init] could not find opencl runtime library '%s'\n", library);
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[dt_dlopencl_init] could not find opencl runtime library '%s'\n", library);
     else
-      dt_vprint(DT_DEBUG_OPENCL, "[dt_dlopencl_init] found opencl runtime library '%s'\n", library);
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[dt_dlopencl_init] found opencl runtime library '%s'\n", library);
   }
   else
   {
@@ -76,9 +76,9 @@ dt_dlopencl_t *dt_dlopencl_init(const char *name)
       library = *iter;
       module = dt_gmodule_open(library);
       if(module == NULL)
-        dt_vprint(DT_DEBUG_OPENCL, "[dt_dlopencl_init] could not find opencl runtime library '%s'\n", library);
+        dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[dt_dlopencl_init] could not find opencl runtime library '%s'\n", library);
       else
-        dt_vprint(DT_DEBUG_OPENCL, "[dt_dlopencl_init] found opencl runtime library '%s'\n", library);
+        dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[dt_dlopencl_init] found opencl runtime library '%s'\n", library);
       iter++;
     }
   }

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -748,10 +748,7 @@ static gboolean _check_dng_opcodes(Exiv2::ExifData &exifData, dt_image_t *img)
     g_free(data);
     has_opcodes = TRUE;
   }
-  else
-  {
-    dt_vprint(DT_DEBUG_IMAGEIO, "DNG OpcodeList2 tag not found\n");
-  }
+
   return has_opcodes;
 }
 

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1112,6 +1112,7 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
   else
   {
     // downsample
+    dt_print_pipe(DT_DEBUG_PIPE, "mipmap clip and zoom", NULL, "", &roi_in, &roi_out, "\n");
     dt_iop_clip_and_zoom(out, (const float *)buf.buf, &roi_out, &roi_in, roi_out.width, roi_in.width);
   }
 

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -237,14 +237,14 @@ void dt_opencl_write_device_config(const int devid)
     cl->dev[devid].disabled & 1,
     cl->dev[devid].benchmark,
     cl->dev[devid].advantage);
-  dt_vprint(DT_DEBUG_OPENCL, "[dt_opencl_write_device_config] writing data '%s' for '%s'\n", dat, key);
+  dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[dt_opencl_write_device_config] writing data '%s' for '%s'\n", dat, key);
   dt_conf_set_string(key, dat);
 
   // Also take care of extended device data, these are not only device specific but also depend on the devid
   // to support systems with two similar cards.
   g_snprintf(key, 254, "%s%s_id%i", DT_CLDEVICE_HEAD, cl->dev[devid].cname, devid);
   g_snprintf(dat, 510, "%i", cl->dev[devid].forced_headroom);
-  dt_vprint(DT_DEBUG_OPENCL, "[dt_opencl_write_device_config] writing data '%s' for '%s'\n", dat, key);
+  dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[dt_opencl_write_device_config] writing data '%s' for '%s'\n", dat, key);
   dt_conf_set_string(key, dat);
 }
 
@@ -791,7 +791,7 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
 
       snprintf(filename, PATH_MAX * sizeof(char), "%s" G_DIR_SEPARATOR_S "%s", kerneldir, programname);
       snprintf(binname, PATH_MAX * sizeof(char), "%s" G_DIR_SEPARATOR_S "%s.bin", cachedir, programname);
-      dt_vprint(DT_DEBUG_OPENCL, "[dt_opencl_device_init] testing program `%s' ..\n", programname);
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[dt_opencl_device_init] testing program `%s' ..\n", programname);
       int loaded_cached;
       char md5sum[33];
       if(dt_opencl_load_program(dev, prog, filename, binname, cachedir, md5sum, includemd5, &loaded_cached)
@@ -2047,10 +2047,10 @@ int dt_opencl_load_program(const int dev, const int prog, const char *filename, 
   else
   {
     free(file);
-    dt_vprint(DT_DEBUG_OPENCL, "[opencl_load_program] loaded cached binary program from file '%s' MD5: '%s' \n", binname, md5sum);
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[opencl_load_program] loaded cached binary program from file '%s' MD5: '%s' \n", binname, md5sum);
   }
 
-  dt_vprint(DT_DEBUG_OPENCL, "[opencl_load_program] successfully loaded program from '%s' MD5: '%s'\n", filename, md5sum);
+  dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[opencl_load_program] successfully loaded program from '%s' MD5: '%s'\n", filename, md5sum);
 
   return 1;
 }
@@ -2066,12 +2066,12 @@ int dt_opencl_build_program(const int dev, const int prog, const char *binname, 
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL, "[opencl_build_program] could not build program: %s\n", cl_errstr(err));
   else
-    dt_vprint(DT_DEBUG_OPENCL, "[opencl_build_program] successfully built program\n");
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[opencl_build_program] successfully built program\n");
 
   cl_build_status build_status;
   (cl->dlocl->symbols->dt_clGetProgramBuildInfo)(program, cl->dev[dev].devid, CL_PROGRAM_BUILD_STATUS,
                                                  sizeof(cl_build_status), &build_status, NULL);
-  dt_vprint(DT_DEBUG_OPENCL, "[opencl_build_program] BUILD STATUS: %d\n", build_status);
+  dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[opencl_build_program] BUILD STATUS: %d\n", build_status);
 
   char *build_log;
   size_t ret_val_size;
@@ -2087,8 +2087,8 @@ int dt_opencl_build_program(const int dev, const int prog, const char *binname, 
 
       build_log[ret_val_size] = '\0';
 
-      dt_vprint(DT_DEBUG_OPENCL, "BUILD LOG:\n");
-      dt_vprint(DT_DEBUG_OPENCL, "%s\n", build_log);
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "BUILD LOG:\n");
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "%s\n", build_log);
 
       free(build_log);
     }
@@ -2100,7 +2100,7 @@ int dt_opencl_build_program(const int dev, const int prog, const char *binname, 
   {
     if(!loaded_cached)
     {
-      dt_vprint(DT_DEBUG_OPENCL, "[opencl_build_program] saving binary\n");
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[opencl_build_program] saving binary\n");
 
       cl_uint numdev = 0;
       err = (cl->dlocl->symbols->dt_clGetProgramInfo)(program, CL_PROGRAM_NUM_DEVICES, sizeof(cl_uint),
@@ -2210,7 +2210,7 @@ int dt_opencl_create_kernel(const int prog, const char *name)
       }
     if(k < DT_OPENCL_MAX_KERNELS)
     {
-      dt_vprint(DT_DEBUG_OPENCL, "[opencl_create_kernel] successfully loaded kernel `%s' (%d) for device %d\n",
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[opencl_create_kernel] successfully loaded kernel `%s' (%d) for device %d\n",
                name, k, dev);
     }
     else
@@ -2977,7 +2977,7 @@ void dt_opencl_update_settings(void)
   dt_opencl_scheduling_profile_t profile = dt_opencl_get_scheduling_profile();
   dt_opencl_apply_scheduling_profile(profile);
   const char *pstr = dt_conf_get_string_const("opencl_scheduling_profile");
-  dt_vprint(DT_DEBUG_OPENCL, "[opencl_update_settings] scheduling profile set to %s\n", pstr);
+  dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[opencl_update_settings] scheduling profile set to %s\n", pstr);
 }
 
 /** read scheduling profile for config variables */
@@ -3209,7 +3209,7 @@ void dt_opencl_events_wait_for(const int devid)
   cl_int err = (cl->dlocl->symbols->dt_clWaitForEvents)(*numevents - *eventsconsolidated,
                                            (*eventlist) + *eventsconsolidated);
   if((err != CL_SUCCESS) && (err != CL_INVALID_VALUE))
-    dt_vprint(DT_DEBUG_OPENCL, "[dt_opencl_events_wait_for] reported %s for device %i\n",
+    dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[dt_opencl_events_wait_for] reported %s for device %i\n",
        cl_errstr(err), devid);
 }
 

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -407,7 +407,7 @@ void dt_dev_pixelpipe_cache_invalidate(dt_dev_pixelpipe_cache_t *cache, void *da
 static size_t _free_cacheline(dt_dev_pixelpipe_cache_t *cache, const int k, const int pipetype)
 {
   const size_t removed = cache->size[k];
-  dt_vprint(DT_DEBUG_DEV, "  [free cacheline] %s %16s, age %4i, line%3i, size=%luMB at %p\n",
+  dt_print(DT_DEBUG_DEV | DT_DEBUG_VERBOSE , "  [free cacheline] %s %16s, age %4i, line%3i, size=%luMB at %p\n",
     dt_dev_pixelpipe_type_to_str(pipetype), cache->modname[k], cache->used[k], k, removed / 1024lu / 1024lu, cache->data[k]);
 
   dt_free_align(cache->data[k]);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1919,7 +1919,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
   // we check for an important hint after processing the module as we want to track a runtime hint too.
   pipe->next_important_module = _check_module_next_important(pipe, module);
   if(pipe->next_important_module)
-    dt_vprint(DT_DEBUG_DEV, "[dev_pixelpipe] [%s] module `%s' passing important hint to next module\n", dt_dev_pixelpipe_type_to_str(pipe->type), module ? module->so->op : NULL);
+    dt_print(DT_DEBUG_DEV | DT_DEBUG_VERBOSE, "[dev_pixelpipe] [%s] module `%s' passing important hint to next module\n", dt_dev_pixelpipe_type_to_str(pipe->type), module ? module->so->op : NULL);
 
   // warn on NaN or infinity
 #ifndef _DEBUG
@@ -2536,7 +2536,7 @@ float *dt_dev_distort_detail_mask(const dt_dev_pixelpipe_t *pipe, float *src, co
   }
 
   if(!valid) return NULL;
-  dt_vprint(DT_DEBUG_MASKS, "[dt_dev_distort_detail_mask] (%ix%i) for module %s\n", pipe->rawdetail_mask_roi.width, pipe->rawdetail_mask_roi.height, target_module->op);
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_VERBOSE, "[dt_dev_distort_detail_mask] (%ix%i) for module %s\n", pipe->rawdetail_mask_roi.width, pipe->rawdetail_mask_roi.height, target_module->op);
 
   float *resmask = src;
   float *inmask  = src;
@@ -2555,7 +2555,7 @@ float *dt_dev_distort_detail_mask(const dt_dev_pixelpipe_t *pipe, float *src, co
                     && module->processed_roi_in.height == 0))
         {
           float *tmp = dt_alloc_align_float((size_t)module->processed_roi_out.width * module->processed_roi_out.height);
-          dt_vprint(DT_DEBUG_MASKS, "   %s %ix%i -> %ix%i\n", module->module->op, module->processed_roi_in.width, module->processed_roi_in.height, module->processed_roi_out.width, module->processed_roi_out.height);
+          dt_print(DT_DEBUG_MASKS | DT_DEBUG_VERBOSE, "   %s %ix%i -> %ix%i\n", module->module->op, module->processed_roi_in.width, module->processed_roi_in.height, module->processed_roi_out.width, module->processed_roi_out.height);
           module->module->distort_mask(module->module, module, inmask, tmp, &module->processed_roi_in, &module->processed_roi_out);
           resmask = tmp;
           if(inmask != src) dt_free_align(inmask);

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -260,6 +260,10 @@ gboolean dt_dev_write_rawdetail_mask(dt_dev_pixelpipe_iop_t *piece, float *const
 gboolean dt_dev_write_rawdetail_mask_cl(dt_dev_pixelpipe_iop_t *piece, cl_mem in, const dt_iop_roi_t *const roi_in, const int mode);
 #endif
 
+/* specialized version of dt_print for pixelpipe debugging */
+void dt_print_pipe(dt_debug_thread_t thread, const char *title, dt_dev_pixelpipe_t *pipe, const char *mod,
+      const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out, const char *msg, ...);
+
 // helper function writing the pipe-processed ctmask data to dest
 float *dt_dev_distort_detail_mask(const dt_dev_pixelpipe_t *pipe, float *src, const struct dt_iop_module_t *target_module);
 

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -101,7 +101,7 @@ static inline int _maximum_number_tiles()
 
 static inline void _print_roi(const dt_iop_roi_t *roi, const char *label)
 {
-  if((darktable.unmuted & DT_DEBUG_VERBOSE) && (darktable.unmuted & (DT_DEBUG_TILING | DT_DEBUG_ROI)))
+  if((darktable.unmuted & DT_DEBUG_VERBOSE) && (darktable.unmuted & DT_DEBUG_TILING))
     fprintf(stderr,"     {%5d %5d ->%5d %5d (%5dx%5d)  %.6f } %s\n",
          roi->x, roi->y, roi->x + roi->width, roi->y + roi->height, roi->width, roi->height, roi->scale, label);
 }

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -529,7 +529,7 @@ static int _nm_fit_output_to_input_roi(struct dt_iop_module_t *self, struct dt_d
 
   int iter = _simplex(_nm_fitness, start, 4, epsilon, 1.0, maxiter, NULL, rest);
 
-  dt_vprint(DT_DEBUG_TILING, "[_nm_fit_output_to_input_roi] _simplex: %d, delta: %d, epsilon: %f\n", iter, delta, epsilon);
+  dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE, "[_nm_fit_output_to_input_roi] _simplex: %d, delta: %d, epsilon: %f\n", iter, delta, epsilon);
 
   oroi->x = start[0] * piece->iwidth;
   oroi->y = start[1] * piece->iheight;
@@ -654,7 +654,7 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self, struct dt_
       width = floorf(width * sqrtf(scale));
       height = floorf(height * sqrtf(scale));
     }
-    dt_vprint(DT_DEBUG_TILING, "[default_process_tiling_ptp] buffer exceeds singlebuffer, corrected to %dx%d\n",
+    dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE, "[default_process_tiling_ptp] buffer exceeds singlebuffer, corrected to %dx%d\n",
             width, height);
   }
 
@@ -662,7 +662,7 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self, struct dt_
   if(3 * tiling.overlap > width || 3 * tiling.overlap > height)
   {
     width = height = floorf(sqrtf((float)width * height));
-    dt_vprint(DT_DEBUG_TILING, "[default_process_tiling_roi] use squares because of overlap, corrected to %dx%d\n",
+    dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE, "[default_process_tiling_roi] use squares because of overlap, corrected to %dx%d\n",
             width, height);
   }
 
@@ -926,7 +926,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
       width = _align_down((int)floorf(width * sqrtf(scale)), xyalign);
       height = _align_down((int)floorf(height * sqrtf(scale)), xyalign);
     }
-    dt_vprint(DT_DEBUG_TILING, "[default_process_tiling_roi] [%s] buffer exceeds singlebuffer, corrected to %dx%d\n",
+    dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE, "[default_process_tiling_roi] [%s] buffer exceeds singlebuffer, corrected to %dx%d\n",
             dt_dev_pixelpipe_type_to_str(piece->pipe->type), width, height);
   }
 
@@ -934,7 +934,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
   if(3 * tiling.overlap > width || 3 * tiling.overlap > height)
   {
     width = height = _align_down((int)floorf(sqrtf((float)width * height)), xyalign);
-    dt_vprint(DT_DEBUG_TILING, "[default_process_tiling_roi] [%s] use squares because of overlap, corrected to %dx%d\n",
+    dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE, "[default_process_tiling_roi] [%s] use squares because of overlap, corrected to %dx%d\n",
             dt_dev_pixelpipe_type_to_str(piece->pipe->type), width, height);
   }
 
@@ -1362,7 +1362,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
       width = floorf(width * sqrtf(scale));
       height = floorf(height * sqrtf(scale));
     }
-    dt_vprint(DT_DEBUG_TILING, "[default_process_tiling_cl_ptp] [%s] buffer exceeds singlebuffer, corrected to %dx%d\n",
+    dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE, "[default_process_tiling_cl_ptp] [%s] buffer exceeds singlebuffer, corrected to %dx%d\n",
             dt_dev_pixelpipe_type_to_str(piece->pipe->type), width, height);
   }
 
@@ -1370,7 +1370,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
   if(3 * tiling.overlap > width || 3 * tiling.overlap > height)
   {
     width = height = floorf(sqrtf((float)width * height));
-    dt_vprint(DT_DEBUG_TILING, "[default_process_tiling_cl_ptp] [%s] use squares because of overlap, corrected to %dx%d\n",
+    dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE, "[default_process_tiling_cl_ptp] [%s] use squares because of overlap, corrected to %dx%d\n",
             dt_dev_pixelpipe_type_to_str(piece->pipe->type), width, height);
   }
 
@@ -1739,7 +1739,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
       width = _align_down((int)floorf(width * sqrtf(scale)), xyalign);
       height = _align_down((int)floorf(height * sqrtf(scale)), xyalign);
     }
-    dt_vprint(DT_DEBUG_TILING, "[default_process_tiling_cl_roi] [%s] buffer exceeds singlebuffer, corrected to %dx%d\n",
+    dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE, "[default_process_tiling_cl_roi] [%s] buffer exceeds singlebuffer, corrected to %dx%d\n",
             dt_dev_pixelpipe_type_to_str(piece->pipe->type), width, height);
   }
 
@@ -1747,7 +1747,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
   if(3 * tiling.overlap > width || 3 * tiling.overlap > height)
   {
     width = height = _align_down((int)floorf(sqrtf((float)width * height)), xyalign);
-    dt_vprint(DT_DEBUG_TILING, "[default_process_tiling_cl_roi] [%s] use squares because of overlap, corrected to %dx%d\n",
+    dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE, "[default_process_tiling_cl_roi] [%s] use squares because of overlap, corrected to %dx%d\n",
             dt_dev_pixelpipe_type_to_str(piece->pipe->type), width, height);
   }
 
@@ -1964,7 +1964,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
 
       dt_print(DT_DEBUG_TILING,  "[default_process_tiling_cl_roi] [%s] process tile (%zu,%zu) size %dx%d at origin [%d,%d]\n",
                dt_dev_pixelpipe_type_to_str(piece->pipe->type), tx, ty, iroi_full.width, iroi_full.height, iroi_full.x, iroi_full.y);
-      dt_vprint(DT_DEBUG_TILING, "[default_process_tiling_cl_roi]    dest [%lu,%lu] at [%lu,%lu], offsets [%i,%i] -> [%i,%i], delta=%i\n\n",
+      dt_print(DT_DEBUG_TILING | DT_DEBUG_VERBOSE, "[default_process_tiling_cl_roi]    dest [%lu,%lu] at [%lu,%lu], offsets [%i,%i] -> [%i,%i], delta=%i\n\n",
                oregion[0], oregion[1], oorigin[0], oorigin[1], in_dx, in_dy, out_dx, out_dy, delta);
 
       /* get opencl input and output buffers */

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -3188,7 +3188,7 @@ static float _process_shortcut(float move_size)
 {
   float return_value = NAN;
 
-  dt_vprint(DT_DEBUG_INPUT,
+  dt_print(DT_DEBUG_INPUT | DT_DEBUG_VERBOSE,
             "  [_process_shortcut] processing shortcut: %s\n",
             _shortcut_description(&_sc));
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -3106,6 +3106,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     if(scaled)
     {
       roi = *roi_out;
+      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi", piece->pipe, self->so->op, roi_in, roi_out, "\n");
       dt_iop_clip_and_zoom_roi((float *)o, tmp, &roi, &roo, roi.width, roo.width);
       dt_free_align(tmp);
     }
@@ -3553,6 +3554,7 @@ static int process_rcd_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
 
     if(scaled)
     {
+      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self->so->op, roi_in, roi_out, "\n");
       // scale aux buffer to output buffer
       err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
       if(err != CL_SUCCESS) goto error;
@@ -3743,6 +3745,7 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
 
     if(scaled)
     {
+      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self->so->op, roi_in, roi_out, "\n");
       // scale aux buffer to output buffer
       err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
       if(err != CL_SUCCESS) goto error;
@@ -4095,6 +4098,7 @@ static int process_vng_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
 
     if(scaled)
     {
+      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self->so->op, roi_in, roi_out, "\n");
       // scale temp buffer to output buffer
       err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
       if(err != CL_SUCCESS) goto error;
@@ -4719,6 +4723,7 @@ static int process_markesteijn_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe
 
     if(scaled)
     {
+      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self->so->op, roi_in, roi_out, "\n");
       // scale temp buffer to output buffer
       err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_tmp, roi_out, roi_in);
       if(err != CL_SUCCESS) goto error;
@@ -4915,6 +4920,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   if(scaled)
   {
+    dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self->so->op, roi_in, roi_out, "\n");
     // scale aux buffer to output buffer
     const int err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
     if(err != CL_SUCCESS)

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -94,9 +94,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   }
 
   const int devid = piece->pipe->devid;
-  dt_print(DT_DEBUG_IMAGEIO, "[finalscale OpenCL %i] %ix%i (scale %f) -> %ix%i (scale %f)\n",
-    devid, roi_in->width, roi_in->height, roi_in->scale, roi_out->width, roi_out->height, roi_out->scale);
-
+  dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_IMAGEIO, "clip_and_zoom_roi CL", piece->pipe, self->so->op, roi_in, roi_out, "device=%i\n", devid);
   cl_int err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_in, roi_out, roi_in);
   if(err != CL_SUCCESS)
   {
@@ -111,8 +109,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
-  dt_print(DT_DEBUG_IMAGEIO, "[finalscale CPU] %ix%i (scale %f) -> %ix%i (scale %f)\n",
-    roi_in->width, roi_in->height, roi_in->scale, roi_out->width, roi_out->height, roi_out->scale);
+  dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_IMAGEIO, "clip_and_zoom_roi", piece->pipe, self->so->op, roi_in, roi_out, "\n");
   dt_iop_clip_and_zoom_roi(ovoid, ivoid, roi_out, roi_in, roi_out->width, roi_in->width);
 }
 


### PR DESCRIPTION
While doing a lot of debugging on the pixelpipes i sometimes ran into garbled output (several pipes writing to log...) plus lot's of copy&paste. So

1. `dt_print()` and `dt_print_nts()` habe been modified;
   a) both write internally to a buffer first and write the whole bunch to stdout at the end
   b) both also test for a thread parameter combined with `DT_DEBUG_VERBOSE`, if so output is only done if darktable
       had been started with `-d verbose`
2. because of (1) `dt_vprint()` could go
3. a new function `dt_print_pipe()` has been implemented in `pixelpipe_hb.c`, it's specialized for pixelpipe and roi stuff debugging so more dense code while using it
4. all pixelpipe roi, scaling and cache `dt_prints` have been replaced with the new function
5. made sure that scaling operations are visualized for pending issues
6. many modified files but nothing tricky