### PR TITLE
CI: update path for SSL certs on Windows

### DIFF
--- a/cmake/windows-macros.cmake
+++ b/cmake/windows-macros.cmake
@@ -304,7 +304,7 @@ if (WIN32 AND NOT BUILD_MSYS2_INSTALL)
 
   # Add ca-cert for curl
   install(FILES
-      "${MINGW_PATH}/../ssl/certs/ca-bundle.crt"
+      "${MINGW_PATH}/../etc/ssl/certs/ca-bundle.crt"
       DESTINATION share/curl/
       RENAME curl-ca-bundle.crt
       COMPONENT DTApplication)


### PR DESCRIPTION
See https://github.com/msys2/MINGW-packages/commit/68419ae39386e5c9256452b9220486fb80f07854

This fixes the Windows CI, but the macOS one is still broken...

@TurboGit Merge for 4.2.x branch as well SVP, but I guess only if @wpferguson intends to build 4,2.1 with an updated mys2 environment.