### PR TITLE
fix ignore Exif rating on import

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -518,10 +518,15 @@ static bool _exif_decode_xmp_data(dt_image_t *img, Exiv2::XmpData &xmpData, int 
       }
     }
 
-    if(FIND_XMP_TAG("Xmp.xmp.Rating"))
+    if(!dt_conf_get_bool("ui_last/ignore_exif_rating"))
     {
-      const int stars = pos->toLong();
-      dt_image_set_xmp_rating(img, stars);
+      if(FIND_XMP_TAG("Xmp.xmp.Rating"))
+      {
+        const int stars = pos->toLong();
+        dt_image_set_xmp_rating(img, stars);
+      }
+      else
+        dt_image_set_xmp_rating(img, -2);
     }
     else
       dt_image_set_xmp_rating(img, -2);

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -518,7 +518,8 @@ static bool _exif_decode_xmp_data(dt_image_t *img, Exiv2::XmpData &xmpData, int 
       }
     }
 
-    if(!dt_conf_get_bool("ui_last/ignore_exif_rating"))
+    // If xmp file(s) are found, read the rating from here.
+    if(FIND_XMP_TAG("Xmp.darktable.xmp_version") || !dt_conf_get_bool("ui_last/ignore_exif_rating"))
     {
       if(FIND_XMP_TAG("Xmp.xmp.Rating"))
       {
@@ -528,8 +529,6 @@ static bool _exif_decode_xmp_data(dt_image_t *img, Exiv2::XmpData &xmpData, int 
       else
         dt_image_set_xmp_rating(img, -2);
     }
-    else
-      dt_image_set_xmp_rating(img, -2);
 
     if(!exif_read) dt_colorlabels_remove_labels(img->id);
     if(FIND_XMP_TAG("Xmp.xmp.Label"))


### PR DESCRIPTION
This PR fixes #13286

<img width="308" alt="Bildschirm­foto 2023-01-18 um 19 01 57" src="https://user-images.githubusercontent.com/4083281/213259196-4b8bcc54-3a38-4a00-8abd-39c617ddabfc.png">


The _ignore EXIF rating_ checkbox is handled for `XMP.xmp.Rating` too and with this change it works as I would expect it to work:

If _ignore EXIF rating_ is checked, the rating gets overridden by the import settings (even if there is an xmp file with a rating besides the image file).

So maybe the checkbox should be renamed as well: "ignore Exif/XMP rating" ?

What do you think?
