### PR TITLE
dont leak refs when cleaning up iop

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1763,8 +1763,6 @@ void dt_iop_commit_params(dt_iop_module_t *module, dt_iop_params_t *params,
 
 void dt_iop_gui_cleanup_module(dt_iop_module_t *module)
 {
-  while(g_idle_remove_by_data(module->widget))
-    ; // remove multiple delayed gtk_widget_queue_draw triggers
   g_slist_free_full(module->widget_list, g_free);
   module->widget_list = NULL;
   module->gui_cleanup(module);


### PR DESCRIPTION
This code in `dt_iop_gui_cleanup_module` was originally intended to prevent problems like #12898 where a delayed call to `gtk_widget_queue_draw` for the module widget was posted in `dt_control_queue_redraw_widget` but the module and its widget was subsequently destroyed (for example by changing views) _before_ the idle routine queued the redraw on the now non-existent widget.

#12900 solves this better and more generically, by holding a ref to the widget while waiting for idle time, but now deleting the idle routine would prevent that ref from ever being released, leading to a memory leak.