### PR TITLE
Ignore build folders for build with homebrew

### DIFF
--- a/packaging/macosx/.gitignore
+++ b/packaging/macosx/.gitignore
@@ -1,1 +1,5 @@
 darktable-*.dmg
+bin/
+lib/
+share/
+package/


### PR DESCRIPTION
When building with homebrew using the scripts

`packaging/macosx/2_build_hb_darktable_custom.sh`
`packaging/macosx/2_build_hb_darktable_default.sh`
`packaging/macosx/3_make_hb_darktable_package.sh`

the folders `bin`, `lib`, `share` and `package` are created within `packaging/macosx`

Added these folders to the macosx `.gitignore` file.
