### PR TITLE
Bugfix: Opposed chroma correction OpenCL update

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2329,26 +2329,32 @@ int dt_opencl_enqueue_kernel_2d(const int dev, const int kernel, const size_t *s
   return dt_opencl_enqueue_kernel_2d_with_local(dev, kernel, sizes, NULL);
 }
 
-
-int dt_opencl_enqueue_kernel_2d_with_local(const int dev, const int kernel, const size_t *sizes,
-                                           const size_t *local)
+/** launch kernel with specified dimension and defined local size! */
+int dt_opencl_enqueue_kernel_ndim_with_local(const int dev, const int kernel, const size_t *sizes,
+                                           const size_t *local, const int dimensions)
 {
   dt_opencl_t *cl = darktable.opencl;
   if(!cl->inited || dev < 0) return -1;
   if(kernel < 0 || kernel >= DT_OPENCL_MAX_KERNELS) return CL_INVALID_KERNEL;
 
-  char buf[256];
-  buf[0] = '\0';
+  char buf[256] = { 0 };
   if(darktable.unmuted & DT_DEBUG_OPENCL)
     (cl->dlocl->symbols->dt_clGetKernelInfo)(cl->dev[dev].kernel[kernel], CL_KERNEL_FUNCTION_NAME, 256, buf, NULL);
   cl_event *eventp = dt_opencl_events_get_slot(dev, buf);
   cl_int err = (cl->dlocl->symbols->dt_clEnqueueNDRangeKernel)(cl->dev[dev].cmd_queue, cl->dev[dev].kernel[kernel],
-                                                        2, NULL, sizes, local, 0, NULL, eventp);
+                                                        dimensions, NULL, sizes, local, 0, NULL, eventp);
 
   if(err != CL_SUCCESS)
-    dt_print(DT_DEBUG_OPENCL, "[dt_opencl_enqueue_kernel_2d%s] kernel %i on device %d: %s\n", local ? "_with_local" : "", kernel, dev, cl_errstr(err));
+    dt_print(DT_DEBUG_OPENCL, "[dt_opencl_enqueue_kernel_%id%s] kernel %i on device %d: %s\n",
+      dimensions, local ? "_with_local" : "", kernel, dev, cl_errstr(err));
   _check_clmem_err(dev, err); 
   return err;
+}
+
+int dt_opencl_enqueue_kernel_2d_with_local(const int dev, const int kernel, const size_t *sizes,
+                                           const size_t *local)
+{
+  return dt_opencl_enqueue_kernel_ndim_with_local(dev, kernel, sizes, local, 2);
 }
 
 int dt_opencl_enqueue_kernel_2d_args_internal(const int dev, const int kernel, const size_t w, const size_t h, ...)

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -371,6 +371,9 @@ int dt_opencl_enqueue_kernel_2d_with_local(const int dev, const int kernel, cons
 int dt_opencl_enqueue_kernel_2d_args_internal(const int dev, const int kernel,
                                               const size_t w, const size_t h, ...);
 
+/** launch kernel with specified dimension and defined local size! */
+int dt_opencl_enqueue_kernel_ndim_with_local(const int dev, const int kernel, const size_t *sizes,
+                                           const size_t *local, const int dimensions);
 /** check if opencl is inited */
 int dt_opencl_is_inited(void);
 

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -512,7 +512,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
       tiling->xalign = 2;
       tiling->yalign = 2;
     }
-    tiling->factor = 2.0f; // in & out plus plane buffers including some border safety
+    tiling->factor = 2.5f; // enough for in&output buffers plus masks
     tiling->overlap = 0;
     tiling->maxbuf = 1.0f;
     tiling->overhead = 0;

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -306,7 +306,7 @@ static float *_process_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
         }
         for_each_channel(c)
           chrominance[c] = cr_sum[c] / fmaxf(1.0f, cr_cnt[c]);
-//        fprintf(stderr, " R: %f %f %f  G: %f %f %f  B: %f %f %f\n", cr_sum[0], cr_cnt[0], chrominance[0], cr_sum[1], cr_cnt[1], chrominance[1], cr_sum[2], cr_cnt[2], chrominance[2]);  
+        // fprintf(stderr, " R: %.1f %.1f %f  G: %.1f %.1f %f  B: %.1f %.1f %f\n", cr_sum[0], cr_cnt[0], chrominance[0], cr_sum[1], cr_cnt[1], chrominance[1], cr_sum[2], cr_cnt[2], chrominance[2]);  
 
       }
     }
@@ -405,7 +405,8 @@ static cl_int process_opposed_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_
   cl_mem dev_inmask = NULL;
   cl_mem dev_outmask = NULL;
   cl_mem dev_accu = NULL;
-
+  float *claccu = NULL;
+ 
   const size_t iwidth = ROUNDUPDWD(roi_in->width, devid);
   const size_t iheight = ROUNDUPDHT(roi_in->height, devid);
   const size_t owidth = ROUNDUPDWD(roi_out->width, devid);
@@ -433,9 +434,6 @@ static cl_int process_opposed_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_
     dev_outmask =  dt_opencl_alloc_device_buffer(devid, sizeof(char) * 3 * msize);
     if(dev_outmask == NULL) goto error;
 
-    dev_accu = dt_opencl_alloc_device_buffer(devid, sizeof(float) * 8);
-    if(dev_accu == NULL) goto error;
-
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_highlights_initmask, iwidth, iheight,
             CLARG(dev_in), CLARG(dev_inmask), CLARG(roi_in->width), CLARG(roi_in->height), CLARG(msize), CLARG(mwidth),
             CLARG(filters), CLARG(dev_xtrans), CLARG(dev_clips));
@@ -445,24 +443,39 @@ static cl_int process_opposed_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_
             CLARG(dev_inmask), CLARG(dev_outmask), CLARG(mwidth), CLARG(mheight), CLARG(msize));
     if(err != CL_SUCCESS) goto error;
 
-    float accu[8] = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
-    err = dt_opencl_write_buffer_to_device(devid, accu, dev_accu, 0, 8 * sizeof(float), TRUE);
-    if(err != CL_SUCCESS) goto error;
+    dev_accu = dt_opencl_alloc_device_buffer(devid, sizeof(float) * 6 * iheight);
+    if(dev_accu == NULL) goto error;
+    claccu = dt_calloc_align_float(6 * iheight);
+    if(claccu == NULL) goto error;
 
-    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_highlights_chroma, iwidth, iheight,
+    size_t sizes[] = { iheight, 1};
+
+    dt_opencl_set_kernel_args(devid, gd->kernel_highlights_chroma, 0,
             CLARG(dev_in), CLARG(dev_outmask), CLARG(dev_accu),
-            CLARG(roi_in->width), CLARG(roi_in->height),
-            CLARG(mwidth), CLARG(mheight), CLARG(msize),
-            CLARG(filters), CLARG(dev_xtrans),
-            CLARG(dev_clips), CLARG(dev_dark)); 
+            CLARG(roi_in->width), CLARG(roi_in->height), CLARG(mwidth), CLARG(msize),
+            CLARG(filters), CLARG(dev_xtrans), CLARG(dev_clips), CLARG(dev_dark)); 
+
+    err = dt_opencl_enqueue_kernel_ndim_with_local(devid, gd->kernel_highlights_chroma, sizes, NULL, 1);
     if(err != CL_SUCCESS) goto error;
 
-    err = dt_opencl_read_buffer_from_device(devid, accu, dev_accu, 0, 8 * sizeof(float), TRUE);
+    err = dt_opencl_read_buffer_from_device(devid, claccu, dev_accu, 0, 6 * iheight * sizeof(float), TRUE);
     if(err != CL_SUCCESS) goto error;
+
+    // collect row data and accumulate
+    dt_aligned_pixel_t sums = { 0.0f, 0.0f, 0.0f};
+    dt_aligned_pixel_t cnts = { 0.0f, 0.0f, 0.0f};
+    for(int grp = 3; grp < roi_in->height-3; grp++)
+    {
+      for(int c = 0; c < 3; c++)
+      {
+        sums[c] += claccu[grp*6 + c];
+        cnts[c] += claccu[grp*6 + 3 + c];
+      }
+    }
 
     for(int c = 0; c < 3; c++)
-      chrominance[c] = accu[c] / fmaxf(1.0f, accu[c+4]);
-//    fprintf(stderr, " R: %f %f %f  G: %f %f %f  B: %f %f %f\n", accu[0], accu[4], chrominance[0], accu[1], accu[5], chrominance[1], accu[2], accu[6], chrominance[2]);  
+      chrominance[c] = sums[c] / fmaxf(1.0f, cnts[c]);
+    // fprintf(stderr, " R: %.1f %.1f %f  G: %.1f %.1f %f  B: %.1f %.1f %f\n", sums[0], cnts[0], chrominance[0], sums[1], cnts[1], chrominance[1], sums[2], cnts[2], chrominance[2]);  
   }
 
   dev_chrominance = dt_opencl_copy_host_to_device_constant(devid, 4 * sizeof(float), chrominance);
@@ -482,6 +495,7 @@ static cl_int process_opposed_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_
   dt_opencl_release_mem_object(dev_inmask);
   dt_opencl_release_mem_object(dev_outmask);
   dt_opencl_release_mem_object(dev_accu);
+  dt_free_align(claccu);
   return CL_SUCCESS;
 
   error:
@@ -495,6 +509,7 @@ static cl_int process_opposed_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_
   dt_opencl_release_mem_object(dev_inmask);
   dt_opencl_release_mem_object(dev_outmask);
   dt_opencl_release_mem_object(dev_accu);
+  dt_free_align(claccu);
   return err;
 }
 #endif

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -448,7 +448,7 @@ static cl_int process_opposed_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_
     claccu = dt_calloc_align_float(6 * iheight);
     if(claccu == NULL) goto error;
 
-    size_t sizes[] = { iheight, 1};
+    size_t sizes[] = { iheight, 1, 1};
 
     dt_opencl_set_kernel_args(devid, gd->kernel_highlights_chroma, 0,
             CLARG(dev_in), CLARG(dev_outmask), CLARG(dev_accu),


### PR DESCRIPTION
As reported the current OpenCL code for chroma correction is **very** slow at least on AMD cards, in fact it only works fine on nvidia cards as they support an atomic float add (the other cards use a simulated instruction involving a poll).

The new code doen't use any atomic instructions at all, as the algorithm doesn't allow a simple reduction based on 2d data a bunch of new functions for 1d kernels was introduced.

On my machine the new code has no penalty (in fact seems to be a bit faster) and should also work fine on non-nvidia devices.  

Fixes #13362
Replaces #13372 