### PR TITLE
Fix potential macro expansion error

### DIFF
--- a/src/common/film.c
+++ b/src/common/film.c
@@ -91,13 +91,15 @@ int32_t dt_film_get_id(const char *folder)
 {
   int32_t filmroll_id = -1;
   sqlite3_stmt *stmt;
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
 #ifdef _WIN32
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                               "SELECT id FROM main.film_rolls WHERE folder LIKE ?1",
-#else
-                              "SELECT id FROM main.film_rolls WHERE folder = ?1",
-#endif
                               -1, &stmt, NULL);
+#else
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "SELECT id FROM main.film_rolls WHERE folder = ?1",
+                              -1, &stmt, NULL);
+#endif
   DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, folder, -1, SQLITE_STATIC);
   if(sqlite3_step(stmt) == SQLITE_ROW) filmroll_id = sqlite3_column_int(stmt, 0);
   sqlite3_finalize(stmt);


### PR DESCRIPTION
From cppcheck 2.9 (the only such error ID in the recent scan):
```
Id: preprocessorErrorDirective
failed to expand 'DT_DEBUG_SQLITE3_PREPARE_V2', it is invalid to use a preprocessor directive as macro parameter
```