### PR TITLE
A very minor fix in the Windows build instructions

### DIFF
--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -59,8 +59,8 @@ How to make a darktable Windows installer (x64 only; Windows 8.1 will need to ha
         ```
         * If you have to set them manually you can do so by setting the variables in your `~/.bash_profile`. For example (check your version numbers first):
             ```
-            export CAMLIBS="/$MINGW_PREFIX/lib/libgphoto2/2.5.30/"
-            export IOLIBS="/$MINGW_PREFIX/lib/libgphoto2_port/0.12.1/"
+            export CAMLIBS="$MINGW_PREFIX/lib/libgphoto2/2.5.30/"
+            export IOLIBS="$MINGW_PREFIX/lib/libgphoto2_port/0.12.1/"
             ```
         * If you do so, execute the following command to activate those profile changes:
             ```bash


### PR DESCRIPTION
`$MINGW_PREFIX` always starts with `/`, so we got a double slash at the beginning. This was not noticeable and did not lead to an error, because a double slash is equivalent to a single one, but it would still be nice to fix.