### PR TITLE
Fix dt_print() verbose checks

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1572,6 +1572,7 @@ void dt_print_nts(dt_debug_thread_t thread, const char *msg, ...)
   vsnprintf(vbuf, sizeof(vbuf), msg, ap);
   va_end(ap);
   printf("%s", vbuf);
+  fflush(stdout);
 }
 
 void *dt_alloc_align(size_t alignment, size_t size)

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1545,9 +1545,8 @@ void dt_cleanup()
 */
 void dt_print(dt_debug_thread_t thread, const char *msg, ...)
 {
-  if(((thread & DT_DEBUG_VERBOSE) && ((darktable.unmuted & DT_DEBUG_VERBOSE) == 0))
-    || !(darktable.unmuted & thread))
-    return;
+  if(((darktable.unmuted & thread) & ~DT_DEBUG_VERBOSE) == 0) return;
+  if((thread & DT_DEBUG_VERBOSE) && !(darktable.unmuted & DT_DEBUG_VERBOSE)) return;
 
   char buf[128];
   char vbuf[2048];
@@ -1564,9 +1563,8 @@ void dt_print(dt_debug_thread_t thread, const char *msg, ...)
 
 void dt_print_nts(dt_debug_thread_t thread, const char *msg, ...)
 {
-  if(((thread & DT_DEBUG_VERBOSE) && ((darktable.unmuted & DT_DEBUG_VERBOSE) == 0))
-    || !(darktable.unmuted & thread))
-    return;
+  if(((darktable.unmuted & thread) & ~DT_DEBUG_VERBOSE) == 0) return;
+  if((thread & DT_DEBUG_VERBOSE) && !(darktable.unmuted & DT_DEBUG_VERBOSE)) return;
 
   char vbuf[2048];
   va_list ap;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -109,14 +109,13 @@ void dt_print_pipe(dt_debug_thread_t thread, const char *title, dt_dev_pixelpipe
       const dt_iop_roi_t *roi_out,
       const char *msg, ...)
 {
-  if(((thread & DT_DEBUG_VERBOSE) && ((darktable.unmuted & DT_DEBUG_VERBOSE) == 0))
-    || !(darktable.unmuted & thread))
-    return;
+  if(((darktable.unmuted & thread) & ~DT_DEBUG_VERBOSE) == 0) return;
+  if((thread & DT_DEBUG_VERBOSE) && !(darktable.unmuted & DT_DEBUG_VERBOSE)) return;
 
   char buf[3][128];
-  char vbuf[2048] = "";
-  char rois[1024] = "";
-  char name[128] = "";
+  char vbuf[2048] = { 0 };
+  char rois[1024] = { 0 };
+  char name[128] = { 0 };
 
   snprintf(buf[0], sizeof(buf[0]), "%.4f", dt_get_wtime() - darktable.start_wtime);
   snprintf(buf[1], sizeof(buf[1]), "[%s]", title);


### PR DESCRIPTION
There was a bug leading to console printing if there was -d verbose as the only option.