### PR TITLE
Respect "force pan & zoom on mouse" in more places

### DIFF
--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1036,12 +1036,6 @@ int dt_masks_events_mouse_moved(struct dt_iop_module_t *module, double x, double
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
   }
 
-  // do not process if no forms visible
-  if(!form) return 0;
-
-  // add an option to allow skip mouse events while editing masks
-  if(darktable.develop->darkroom_skip_mouse_events) return 0;
-
   int rep = 0;
   if(form->functions)
     rep = form->functions->mouse_moved(module, pzx, pzy, pressure, which, form, 0, gui, 0);
@@ -1054,9 +1048,6 @@ int dt_masks_events_mouse_moved(struct dt_iop_module_t *module, double x, double
 int dt_masks_events_button_released(struct dt_iop_module_t *module, double x, double y, int which,
                                     uint32_t state)
 {
-  // add an option to allow skip mouse events while editing masks
-  if(darktable.develop->darkroom_skip_mouse_events) return 0;
-
   dt_masks_form_t *form = darktable.develop->form_visible;
   dt_masks_form_gui_t *gui = darktable.develop->form_gui;
   float pzx = 0.0f, pzy = 0.0f;
@@ -1081,9 +1072,6 @@ int dt_masks_events_button_released(struct dt_iop_module_t *module, double x, do
 int dt_masks_events_button_pressed(struct dt_iop_module_t *module, double x, double y, double pressure,
                                    int which, int type, uint32_t state)
 {
-  // add an option to allow skip mouse events while editing masks
-  if(darktable.develop->darkroom_skip_mouse_events) return 0;
-
   dt_masks_form_t *form = darktable.develop->form_visible;
   dt_masks_form_gui_t *gui = darktable.develop->form_gui;
   float pzx = 0.0f, pzy = 0.0f;
@@ -1119,9 +1107,6 @@ int dt_masks_events_button_pressed(struct dt_iop_module_t *module, double x, dou
 
 int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module, double x, double y, int up, uint32_t state)
 {
-  // add an option to allow skip mouse events while editing masks
-  if(darktable.develop->darkroom_skip_mouse_events) return 0;
-
   dt_masks_form_t *form = darktable.develop->form_visible;
   dt_masks_form_gui_t *gui = darktable.develop->form_gui;
   float pzx = 0.0f, pzy = 0.0f;

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -3019,8 +3019,6 @@ int scrolled(struct dt_iop_module_t *module, double x, double y, int up, uint32_
 {
   const dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *)module->gui_data;
 
-  // add an option to allow skip mouse events while editing masks
-  if(darktable.develop->darkroom_skip_mouse_events) return 0;
   const gboolean incr = dt_mask_scroll_increases(up);
 
   if(g->temp)

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -2110,8 +2110,7 @@ int scrolled(struct dt_iop_module_t *self, double x, double y, int up, uint32_t 
   if(!self->enabled)
     if(self->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
 
-  // add an option to allow skip mouse events while editing masks
-  if(darktable.develop->darkroom_skip_mouse_events || in_mask_editing(self)) return 0;
+  if(in_mask_editing(self)) return 0;
 
   // if GUI buffers not ready, exit but still handle the cursor
   dt_iop_gui_enter_critical_section(self);

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -333,7 +333,7 @@ int button_pressed(struct dt_lib_module_t *self, double x, double y, double pres
     return 0;
   }
 
-  if(d->selected >= 0)
+  if(d->selected >= 0 && which == 1)
   {
     if(d->on_going) return 1;
 
@@ -342,13 +342,12 @@ int button_pressed(struct dt_lib_module_t *self, double x, double y, double pres
 
     /* do the split rotating */
     const double hhs = HANDLE_SIZE * 0.5;
-    if(which == 1
-       && (((d->vertical && xp > d->vp_xpointer - hhs && xp < d->vp_xpointer + hhs)
-            && yp > 0.5 - hhs && yp < 0.5 + hhs)
-           || ((!d->vertical && yp > d->vp_ypointer - hhs && yp < d->vp_ypointer + hhs)
-               && xp > 0.5 - hhs && xp < 0.5 + hhs)
-           || (d->vp_xrotate > xp - hhs && d->vp_xrotate <= xp + hhs && d->vp_yrotate > yp - hhs
-               && d->vp_yrotate <= yp + hhs )))
+    if(((d->vertical && xp > d->vp_xpointer - hhs && xp < d->vp_xpointer + hhs)
+        && yp > 0.5 - hhs && yp < 0.5 + hhs)
+        || ((!d->vertical && yp > d->vp_ypointer - hhs && yp < d->vp_ypointer + hhs)
+            && xp > 0.5 - hhs && xp < 0.5 + hhs)
+        || (d->vp_xrotate > xp - hhs && d->vp_xrotate <= xp + hhs && d->vp_yrotate > yp - hhs
+            && d->vp_yrotate <= yp + hhs))
     {
       /* let's rotate */
       _lib_snapshot_rotation_cnt++;
@@ -364,7 +363,7 @@ int button_pressed(struct dt_lib_module_t *self, double x, double y, double pres
       dt_control_queue_redraw_center();
     }
     /* do the dragging !? */
-    else if(which == 1)
+    else
     {
       d->dragging = TRUE;
       d->vp_ypointer = yp;

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -182,7 +182,6 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
       if(snap->surface) cairo_surface_destroy(snap->surface);
       snap->surface = NULL;
       d->expose_again_timeout_id = g_timeout_add(150, _snap_expose_again, d);
-      return;
     }
 
     float pzx, pzy;
@@ -217,7 +216,7 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
     cairo_clip(cri);
     cairo_fill(cri);
 
-    if(!d->snap_requested)
+    if(snap->surface && !d->snap_requested)
     {
       // display snapshot image surface
       dt_view_paint_surface(cri, width, height,

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3349,7 +3349,9 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
   if(height_i > capht) offy = (capht - height_i) * .5f;
   int handled = 0;
 
-  if(dt_iop_color_picker_is_visible(dev) && ctl->button_down && ctl->button_down_which == 1)
+  if(!darktable.develop->darkroom_skip_mouse_events
+     && dt_iop_color_picker_is_visible(dev)
+     && ctl->button_down && ctl->button_down_which == 1)
   {
     // module requested a color box
     if(mouse_in_imagearea(self, &x, &y))
@@ -3382,15 +3384,18 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
   x += offx;
   y += offy;
   // masks
-  handled = dt_masks_events_mouse_moved(dev->gui_module, x, y, pressure, which);
+  if(dev->form_visible
+     && !darktable.develop->darkroom_skip_mouse_events)
+    handled = dt_masks_events_mouse_moved(dev->gui_module, x, y, pressure, which);
   if(handled) return;
   // module
   if(dev->gui_module && dev->gui_module->mouse_moved
+     && !darktable.develop->darkroom_skip_mouse_events
      && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS)
     handled = dev->gui_module->mouse_moved(dev->gui_module, x, y, pressure, which);
   if(handled) return;
 
-  if(darktable.control->button_down && darktable.control->button_down_which == 1)
+  if(ctl->button_down && ctl->button_down_which == 1)
   {
     // depending on dev_zoom, adjust dev_zoom_x/y.
     const dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
@@ -3426,6 +3431,12 @@ int button_released(dt_view_t *self, double x, double y, int which, uint32_t sta
   if(width_i > capwd) x += (capwd - width_i) * .5f;
   if(height_i > capht) y += (capht - height_i) * .5f;
 
+  if(darktable.develop->darkroom_skip_mouse_events && which == 1)
+  {
+    dt_control_change_cursor(GDK_LEFT_PTR);
+    return 1;
+  }
+
   int handled = 0;
   if(dt_iop_color_picker_is_visible(dev) && which == 1)
   {
@@ -3439,7 +3450,8 @@ int button_released(dt_view_t *self, double x, double y, int which, uint32_t sta
     return 1;
   }
   // masks
-  if(dev->form_visible) handled = dt_masks_events_button_released(dev->gui_module, x, y, which, state);
+  if(dev->form_visible)
+    handled = dt_masks_events_button_released(dev->gui_module, x, y, which, state);
   if(handled) return handled;
   // module
   if(dev->gui_module && dev->gui_module->button_released
@@ -3463,6 +3475,12 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
   float offx = 0.0f, offy = 0.0f;
   if(width_i > capwd) offx = (capwd - width_i) * .5f;
   if(height_i > capht) offy = (capht - height_i) * .5f;
+
+  if(darktable.develop->darkroom_skip_mouse_events && which == 1 && type == GDK_BUTTON_PRESS)
+  {
+    dt_control_change_cursor(GDK_HAND1);
+    return 1;
+  }
 
   int handled = 0;
   if(dt_iop_color_picker_is_visible(dev))
@@ -3690,10 +3708,13 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
 
   int handled = 0;
   // masks
-  if(dev->form_visible) handled = dt_masks_events_mouse_scrolled(dev->gui_module, x, y, up, state);
+  if(dev->form_visible
+     && !!darktable.develop->darkroom_skip_mouse_events)
+    handled = dt_masks_events_mouse_scrolled(dev->gui_module, x, y, up, state);
   if(handled) return;
   // module
   if(dev->gui_module && dev->gui_module->scrolled
+     && !darktable.develop->darkroom_skip_mouse_events
      && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS)
     handled = dev->gui_module->scrolled(dev->gui_module, x, y, up, state);
   if(handled) return;

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2076,6 +2076,10 @@ static float _action_process_skip_mouse(gpointer target, dt_action_element_t ele
     default:
       darktable.develop->darkroom_skip_mouse_events ^= TRUE;
     }
+
+    // don't turn on if drag underway; would not receive button_released
+    if(darktable.control->button_down)
+      darktable.develop->darkroom_skip_mouse_events = FALSE;
   }
 
   return darktable.develop->darkroom_skip_mouse_events;

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3713,7 +3713,7 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
   int handled = 0;
   // masks
   if(dev->form_visible
-     && !!darktable.develop->darkroom_skip_mouse_events)
+     && !darktable.develop->darkroom_skip_mouse_events)
     handled = dt_masks_events_mouse_scrolled(dev->gui_module, x, y, up, state);
   if(handled) return;
   // module


### PR DESCRIPTION
Some modules (crop, color calibration, graduated density) ignored the _force pan & zoom_ mode (activated via "a" by default), so you couldn't pan around while those modules were focused. Same for colorpicker mode. This PR checks centrally in the darkroom view whether the mode is active and if so, does not delegate (certain) mouse handling to the modules.

It was also possible to get into a "sticky" state when, for example, the "force pan" mode was switched on _while_ the user was already doing a drag (for example they grabbed a mask shape). If they subsequently released the mouse button, the mask would not receive this event (because we'd be panning instead at that moment) and then if first the mouse button and then the "force pan" mode was released, the mask would be dragged around again even though no mouse button was being pressed.

Also a few small changes in snapshot mode; middle-click now adjust zoom (100%/200%/full) like normal (fixes #12970) and the divider bar will be shown during panning (even though the snapshot side of it is not available untiil recalculated).

As usual, this can use some testing to see if it breaks any assumptions anywhere.