### PR TITLE
Fix a bug in date-time sanitization function

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -472,8 +472,8 @@ static void _sanitize_datetime(char *datetime)
   {
     *c = ' ';
   }
-  // replace '-' and '/' by ':'
-  while((c = strchr(datetime, '-')) != NULL || (c = strchr(datetime, '/')) != NULL)
+  // replace '-' and '/' with ':' but limit the length to avoid replacing '-' sign before the TZ specifier
+  while((c = strpbrk(datetime, "-/")) && (c - datetime < 18))
   {
     *c = ':';
   }


### PR DESCRIPTION
Fixes #13355.

A bug was introduced in the sanitization code in PR #9256. The problem was that the sanitization function, among other things, was intended to replace the `-` in the date record with a `:`. But at the same time, this code also replaced `-` before the time zone value, which made the date-time value incorrect and led to the "zero" date being entered in the database.
