### PR TITLE
po/auto init presets

### DIFF
--- a/src/common/presets.h
+++ b/src/common/presets.h
@@ -33,6 +33,7 @@ gboolean dt_presets_module_can_autoapply(const gchar *operation);
 char *dt_presets_get_name(const char *module_name,
                           const void *params,
                           const uint32_t param_size,
+                          const gboolean is_default_params,
                           const void *blend_params,
                           const uint32_t blend_params_size);
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2074,7 +2074,12 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
     }
 
     // Copy module params if valid, else try to convert legacy params
-    if(is_valid_module_version && is_valid_params_size && is_valid_module_name)
+    if(param_length == 0)
+    {
+      // special case of auto-init presets being loaded in history
+      memcpy(hist->params, hist->module->default_params, hist->module->params_size);
+    }
+    else if(is_valid_module_version && is_valid_params_size && is_valid_module_name)
     {
       memcpy(hist->params, module_params, hist->module->params_size);
     }

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1761,10 +1761,13 @@ static gboolean _iop_update_label(gpointer data)
 {
   dt_iop_module_t *module = (dt_iop_module_t *)data;
 
-  char *preset_name =
-    dt_presets_get_name(module->op,
-                        module->params, module->params_size,
-                        module->blend_params, sizeof(dt_develop_blend_params_t));
+  const gboolean is_default_params =
+    memcmp(module->params, module->default_params, module->params_size) == 0;
+
+  char *preset_name = dt_presets_get_name
+    (module->op,
+     module->params, module->params_size, is_default_params,
+     module->blend_params, sizeof(dt_develop_blend_params_t));
 
   // if we have a preset-name, use it. otherwise set the label to the multi-priority
   // except for 0 where the multi-name is cleared.

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -418,7 +418,9 @@ static void _edit_preset_response(GtkDialog *dialog,
   free(g);
 }
 
-gboolean dt_gui_presets_confirm_and_delete(const char *name, const char *module_name, int rowid)
+gboolean dt_gui_presets_confirm_and_delete(const char *name,
+                                           const char *module_name,
+                                           const int rowid)
 {
   if(!module_name) return FALSE;
 
@@ -461,7 +463,8 @@ gboolean dt_gui_presets_confirm_and_delete(const char *name, const char *module_
   return FALSE;
 }
 
-static void _check_buttons_activated(GtkCheckButton *button, dt_gui_presets_edit_dialog_t *g)
+static void _check_buttons_activated(GtkCheckButton *button,
+                                     dt_gui_presets_edit_dialog_t *g)
 {
   if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->autoapply))
      || gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->filter)))
@@ -475,8 +478,10 @@ static void _check_buttons_activated(GtkCheckButton *button, dt_gui_presets_edit
     gtk_widget_set_visible(GTK_WIDGET(g->details), FALSE);
 }
 
-static void _presets_show_edit_dialog(dt_gui_presets_edit_dialog_t *g, gboolean allow_name_change,
-                                      gboolean allow_desc_change, gboolean allow_remove)
+static void _presets_show_edit_dialog(dt_gui_presets_edit_dialog_t *g,
+                                      const gboolean allow_name_change,
+                                      const gboolean allow_desc_change,
+                                      const gboolean allow_remove)
 {
   /* Create the widgets */
   char title[1024];
@@ -714,9 +719,10 @@ static void _presets_show_edit_dialog(dt_gui_presets_edit_dialog_t *g, gboolean 
     dt_bauhaus_combobox_set(g->aperture_max, k);
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(g->focal_length_min), 0);
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(g->focal_length_max), 1000);
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->autoapply), 0);
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->filter), 0);
-    for(k = 0; k < 5; k++) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->format_btn[k]), TRUE);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->autoapply), FALSE);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->filter), FALSE);
+    for(k = 0; k < 5; k++)
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->format_btn[k]), TRUE);
   }
   sqlite3_finalize(stmt);
 
@@ -748,9 +754,9 @@ void dt_gui_presets_show_iop_edit_dialog(const char *name_in,
                                          dt_iop_module_t *module,
                                          GCallback final_callback,
                                          gpointer data,
-                                         gboolean allow_name_change,
-                                         gboolean allow_desc_change,
-                                         gboolean allow_remove,
+                                         const gboolean allow_name_change,
+                                         const gboolean allow_desc_change,
+                                         const gboolean allow_remove,
                                          GtkWindow *parent)
 {
   dt_gui_presets_edit_dialog_t *g
@@ -773,9 +779,9 @@ void dt_gui_presets_show_edit_dialog(const char *name_in,
                                      int rowid,
                                      GCallback final_callback,
                                      gpointer data,
-                                     gboolean allow_name_change,
-                                     gboolean allow_desc_change,
-                                     gboolean allow_remove,
+                                     const gboolean allow_name_change,
+                                     const gboolean allow_desc_change,
+                                     const gboolean allow_remove,
                                      GtkWindow *parent)
 {
   sqlite3_stmt *stmt;

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -183,6 +183,7 @@ static void _menuitem_delete_preset(GtkMenuItem *menuitem, dt_iop_module_t *modu
   }
   g_free(name);
 }
+
 static void _edit_preset_final_callback(dt_gui_presets_edit_dialog_t *g)
 {
   dt_gui_store_last_preset(gtk_entry_get_text(g->name));
@@ -883,6 +884,7 @@ void dt_gui_presets_apply_preset(const gchar* name, dt_iop_module_t *module)
     const int bl_length = sqlite3_column_bytes(stmt, 2);
     const int blendop_version = sqlite3_column_int(stmt, 3);
     const int writeprotect = sqlite3_column_int(stmt, 4);
+
     if(op_params && (op_length == module->params_size))
     {
       memcpy(module->params, op_params, op_length);
@@ -1322,9 +1324,9 @@ void dt_gui_favorite_presets_menu_show()
 
 
 static void _gui_presets_popup_menu_show_internal(dt_dev_operation_t op,
-                                                  int32_t version,
+                                                  const int32_t version,
                                                   dt_iop_params_t *params,
-                                                  int32_t params_size,
+                                                  const int32_t params_size,
                                                   dt_develop_blend_params_t *bl_params,
                                                   dt_iop_module_t *module,
                                                   const dt_image_t *image,
@@ -1515,7 +1517,8 @@ static void _gui_presets_popup_menu_show_internal(dt_dev_operation_t op,
 
       if(darktable.gui->last_preset && found)
       {
-        char *markup = g_markup_printf_escaped("%s <span weight='bold'>%s</span>", _("update preset"),
+        char *markup = g_markup_printf_escaped("%s <span weight='bold'>%s</span>",
+                                               _("update preset"),
                                                darktable.gui->last_preset);
         mi = gtk_menu_item_new_with_label("");
         gtk_label_set_markup(GTK_LABEL(gtk_bin_get_child(GTK_BIN(mi))), markup);

--- a/src/gui/presets.h
+++ b/src/gui/presets.h
@@ -51,7 +51,7 @@ typedef struct dt_gui_presets_edit_dialog_t
   int op_version;
 
   GtkEntry *name, *description;
-  GtkCheckButton *autoapply, *filter;
+  GtkCheckButton *autoinit, *autoapply, *filter;
   GtkWidget *details;
   GtkWidget *model, *maker, *lens;
   GtkWidget *iso_min, *iso_max;


### PR DESCRIPTION
    Add support for auto initialization of presets.
    
    A preset with this module can be used to self initialize it
    depending on the current picture. This is useful for modules
    like color calibration and lens correction for example.
    
    For #13429.
