### PR TITLE
Reduce the size of the white border during ISO 12646

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1499,7 +1499,7 @@ static int _iso_12646_get_border(dt_develop_t *d)
 {
   if(d->iso_12646.enabled)
   {
-    return MIN(1.75 * darktable.gui->dpi, 0.3 * MIN(d->width, d->height));
+    return MIN(0.9 * darktable.gui->dpi, 0.14 * MIN(d->width, d->height));
   }
   else
   {


### PR DESCRIPTION
This PR will reduce the size of the white border. I tested multiple sizes until I settled on this one. As described in this issue https://github.com/darktable-org/darktable/issues/13386, I could not find any guidance for the size of the white. 

Here is how it looks after this PR:
![image](https://user-images.githubusercontent.com/97920861/214466886-47fe8953-9094-4be7-87f3-b3537c03e574.png)

This is how is looks before the PR:
![image](https://user-images.githubusercontent.com/97920861/214467374-ae7e18ed-dedc-4955-8106-ef56e68cf3c3.png)
I think this is safe for 4.2.1