### PR TITLE
histogram gui: radio buttons on the left for mode switching

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -648,7 +648,7 @@ dialog .sidebar row:selected:hover label,
 /*-------------------
   - Scope/Histogram -
   -------------------*/
-#main-histogram buttonbox
+#main-histogram .button_box
 {
   margin: 0.21em;
 }
@@ -659,15 +659,8 @@ dialog .sidebar row:selected:hover label,
   min-width: 1em;
 }
 
-/* be sure all color icons have (nearly) same size ; needed has red color is in stack widget and this change how the size is rendered */
-#main-histogram #green-channel-button,
-#main-histogram #blue-channel-button
-{
-  min-width: 1.1em;
-}
-
 /* set background color and color of scope/histogram buttons */
-#main-histogram .dt_module_btn:not(.toggle)
+#main-histogram .dt_module_btn:not(.rgb_toggle)
 {
   color: alpha(@field_selected_fg, 0.56);
   background-color: alpha(darker(@button_bg),0.8);
@@ -1654,7 +1647,8 @@ menuitem:active,
 menuitem:selected,
 messagedialog .default,  /* this show that a button in confirmation action pop-up has the focus (no by default) */
 treeview *:selected:not(check),
-treeview *:checked:not(check)
+treeview *:checked:not(check),
+#main-histogram .dt_module_btn:checked:not(.rgb_toggle)
 {
   background-color: @field_selected_bg;
   color: @field_selected_fg;
@@ -1679,7 +1673,7 @@ radiobutton:hover label,
 treeview:not(#lutname) *:hover:not(check),
 #dt-range-date-popup .text-button:hover,
 #lens-module .text-button:hover,
-#main-histogram .dt_module_btn:hover:not(.toggle),
+#main-histogram .dt_module_btn:hover:not(.rgb_toggle),
 #non-flat:hover,
 #view-label:hover,
 #view-dropdown .combo:hover

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -145,6 +145,9 @@ const gchar *dt_lib_histogram_orient_names[DT_LIB_HISTOGRAM_ORIENT_N] = { "horiz
 const gchar *dt_lib_histogram_vectorscope_type_names[DT_LIB_HISTOGRAM_VECTORSCOPE_N] = { "u*v*", "AzBz", "RYB" };
 const gchar *dt_lib_histogram_color_harmony_width_names[DT_LIB_HISTOGRAM_HARMONY_WIDTH_N] = { "normal", "large", "narrow", "line" };
 
+const float dt_lib_histogram_color_harmony_width[DT_LIB_HISTOGRAM_HARMONY_WIDTH_N] =
+    { 0.5f/12.f, 0.75f/12.f, 0.25f/12.f, 0.0f };
+
 const void *dt_lib_histogram_scope_type_icons[DT_LIB_HISTOGRAM_SCOPE_N] =
              { dtgtk_cairo_paint_histogram_scope,
                dtgtk_cairo_paint_waveform_scope,
@@ -1135,24 +1138,7 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
   {
     cairo_save(cr);
 
-    float hw = 0.f;
-    switch(d->harmony_width)
-    {
-      case DT_LIB_HISTOGRAM_HARMONY_WIDTH_NORMAL:
-        hw = 0.5f / 12.f;
-        break;
-      case DT_LIB_HISTOGRAM_HARMONY_WIDTH_LARGE:
-        hw = 0.75f / 12.f;
-        break;
-      case DT_LIB_HISTOGRAM_HARMONY_WIDTH_NARROW:
-        hw = 0.25f / 12.f;
-        break;
-      case DT_LIB_HISTOGRAM_HARMONY_WIDTH_LINE:
-        break;
-      case DT_LIB_HISTOGRAM_HARMONY_WIDTH_N:
-        dt_unreachable_codepath();
-        break;
-    }
+    float hw = dt_lib_histogram_color_harmony_width[d->harmony_width];
     cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.));
     dt_lib_histogram_color_harmony_t hm = dt_color_harmonies[d->color_harmony];
     for(int i = 0; i < hm.sectors; i++)


### PR DESCRIPTION
Partially fixes #13338 
Improve usability of histogram gui, by

1) putting a fixed group of 4 radio buttons on the left side, to quickly switch between histogram, waveform, rbg parade and vectorscope. We get rid of the annoying button "next mode"
2) putting the remaining buttons on the right side. Those are options which are consequence of the chosen main mode and therefore it is a variable group: linear/log switch, orientation, vectorscope variant, color harmonies. They are only shown if relevant
3) introduced actions for most of the above, to be able to define shortcuts (@dterrahe please make a review)

![image](https://user-images.githubusercontent.com/43290988/214552565-241dac4c-6075-4a39-9271-cd1a8c11c8f8.png)

On a side note, I decided not to introduce a new dt radio button subclass, because the implications are significant and the advantage is small.

Next steps (with separate PRs)

1) a submenu for choosing the color harmony ?
2) a switch for graph brightness (normal / high) ?
3) better icons, following the suggestions received

@Nilvus I am afraid this requires a css adaptation, see the screenshot. I will propose it with a separate commit in this PR

