### PR TITLE
Introduce DT_PRINT_ALWAYS for dt_print() variants

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -674,7 +674,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
       else if(argv[k][1] == 'd' && argc > k + 1)
       {
         if(!strcmp(argv[k + 1], "all"))
-          darktable.unmuted = 0xffffffff & ~DT_DEBUG_VERBOSE; // enable all debug information except verbose
+          darktable.unmuted = DT_DEBUG_ALL; // enable all debug information except verbose
         else if(!strcmp(argv[k + 1], "cache"))
           darktable.unmuted |= DT_DEBUG_CACHE; // enable debugging for lib/film/cache module
         else if(!strcmp(argv[k + 1], "control"))
@@ -1540,14 +1540,18 @@ void dt_cleanup()
 }
 
 /* The dt_print variations can be used with a combination of DT_DEBUG_ flags.
-   A special case: if you combine with DT_DEBUG_VERBOSE output will only be done
-   if dt has been started with -d verbose
+   Two special cases are supported also:
+   a) if you combine with DT_DEBUG_VERBOSE, output will only be written if dt had
+      been started with -d verbose
+   b) 'thread' may be identical to DT_DEBUG_ALWAYS to write output 
 */
 void dt_print(dt_debug_thread_t thread, const char *msg, ...)
 {
-  if(((darktable.unmuted & thread) & ~DT_DEBUG_VERBOSE) == 0) return;
-  if((thread & DT_DEBUG_VERBOSE) && !(darktable.unmuted & DT_DEBUG_VERBOSE)) return;
-
+  if(thread != DT_DEBUG_ALWAYS)
+  {
+    if(((darktable.unmuted & thread) & ~DT_DEBUG_VERBOSE) == 0) return;
+    if((thread & DT_DEBUG_VERBOSE) && !(darktable.unmuted & DT_DEBUG_VERBOSE)) return;
+  }
   char buf[128];
   char vbuf[2048];
   snprintf(buf, sizeof(buf), "%.4f", dt_get_wtime() - darktable.start_wtime);
@@ -1563,9 +1567,11 @@ void dt_print(dt_debug_thread_t thread, const char *msg, ...)
 
 void dt_print_nts(dt_debug_thread_t thread, const char *msg, ...)
 {
-  if(((darktable.unmuted & thread) & ~DT_DEBUG_VERBOSE) == 0) return;
-  if((thread & DT_DEBUG_VERBOSE) && !(darktable.unmuted & DT_DEBUG_VERBOSE)) return;
-
+  if(thread != DT_DEBUG_ALWAYS)
+  {
+    if(((darktable.unmuted & thread) & ~DT_DEBUG_VERBOSE) == 0) return;
+    if((thread & DT_DEBUG_VERBOSE) && !(darktable.unmuted & DT_DEBUG_VERBOSE)) return;
+  }
   char vbuf[2048];
   va_list ap;
   va_start(ap, msg);

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -248,6 +248,7 @@ typedef float dt_boundingbox_t[4];  //(x,y) of upperleft, then (x,y) of lowerrig
 typedef enum dt_debug_thread_t
 {
   // powers of two, masking
+  DT_DEBUG_ALWAYS         = 0,       // special case tested by dt_print() variants
   DT_DEBUG_CACHE          = 1 <<  0,
   DT_DEBUG_CONTROL        = 1 <<  1,
   DT_DEBUG_DEV            = 1 <<  2,
@@ -273,7 +274,8 @@ typedef enum dt_debug_thread_t
   DT_DEBUG_ACT_ON         = 1 << 23,
   DT_DEBUG_TILING         = 1 << 24,
   DT_DEBUG_VERBOSE        = 1 << 25,
-  DT_DEBUG_PIPE           = 1 << 26
+  DT_DEBUG_PIPE           = 1 << 26,
+  DT_DEBUG_ALL            = 0xffffffff & ~DT_DEBUG_VERBOSE
 } dt_debug_thread_t;
 
 typedef struct dt_codepath_t

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1179,7 +1179,7 @@ void dt_iop_set_module_trouble_message(dt_iop_module_t *const module,
   if(stderr_message)
   {
     const char *name = module ? module->name() : "?";
-    fprintf(stderr, "[%s] %s\n", name, stderr_message ? stderr_message : trouble_msg);
+    dt_print(DT_DEBUG_ALWAYS, "Trouble: [%s] %s\n", name, stderr_message ? stderr_message : trouble_msg);
   }
 
   if(!dt_iop_is_hidden(module) && module->gui_data && dt_conf_get_bool("plugins/darkroom/show_warnings"))

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -109,9 +109,11 @@ void dt_print_pipe(dt_debug_thread_t thread, const char *title, dt_dev_pixelpipe
       const dt_iop_roi_t *roi_out,
       const char *msg, ...)
 {
-  if(((darktable.unmuted & thread) & ~DT_DEBUG_VERBOSE) == 0) return;
-  if((thread & DT_DEBUG_VERBOSE) && !(darktable.unmuted & DT_DEBUG_VERBOSE)) return;
-
+  if(thread != DT_DEBUG_ALWAYS)
+  {
+    if(((darktable.unmuted & thread) & ~DT_DEBUG_VERBOSE) == 0) return;
+    if((thread & DT_DEBUG_VERBOSE) && !(darktable.unmuted & DT_DEBUG_VERBOSE)) return;
+  }
   char buf[3][128];
   char vbuf[2048] = { 0 };
   char rois[1024] = { 0 };


### PR DESCRIPTION
Currently we write error messages like for example those generated by the trouble handler via fprintf to stderr.

This has some disadvantages:
1. stderr might not be writing to stdout depending on OS and user script settings
2. writing might be not synchronized to other threads writing
3. might be nicer to have a formatted output for readability

So we add DT_DEBUG_ALWAYS to the enum and make all dt_print() variants testing for that flag to write to stdout or the logfile derived from that.