### PR TITLE
print: fix very minor typo in typedef declaration

### DIFF
--- a/src/common/printing.h
+++ b/src/common/printing.h
@@ -27,7 +27,7 @@
 
 #define MAX_IMAGE_PER_PAGE 20
 
-typedef struct _imgage_pos
+typedef struct _image_pos
 {
   float x, y, width, height;
 } dt_image_pos;


### PR DESCRIPTION
s/imgage_pos/image_pos/

As it is an identifier for a typedef, this doesn't affect the rest of the code.