### PR TITLE
database: add missing column "multi_name_hand_edited" in create table

### DIFF
--- a/src/common/database.c
+++ b/src/common/database.c
@@ -2586,6 +2586,7 @@ static void _create_data_schema(dt_database_t *db)
                            "VARCHAR, op_version INTEGER, op_params BLOB, "
                            "enabled INTEGER, blendop_params BLOB, blendop_version INTEGER, "
                            "multi_priority INTEGER, multi_name VARCHAR(256), "
+                           "multi_name_hand_edited INTEGER, "
                            "model VARCHAR, maker VARCHAR, lens VARCHAR, iso_min REAL, iso_max REAL, "
                            "exposure_min REAL, exposure_max REAL, "
                            "aperture_min REAL, aperture_max REAL, focal_length_min REAL, "


### PR DESCRIPTION
This was added for schema upgrades in #13391 in commit
3e01aae8ec97c72cc8310321265166c4a0eb1436, but not on initial table creation.