### PR TITLE
brightness control button in histogram

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3001,6 +3001,13 @@
     <longdescription/>
   </dtconfig>
   <dtconfig>
+    <name>plugins/darkroom/histogram/bright</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/darkroom/histogram/waveform</name>
     <type>
       <enum>

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1378,6 +1378,37 @@ void dtgtk_cairo_paint_color_swatch(cairo_t *cr, gint x, gint y, gint w, gint h,
   FINISH
 }
 
+void dtgtk_cairo_paint_brightness(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 1, 0, 0)
+
+  const double degrees = M_PI / 180.0;
+  const gboolean high = *((gboolean *)data);
+
+    cairo_translate(cr, .5, .5);
+    if(high)
+    {
+      cairo_arc(cr, 0.0, 0.0, 0.35, 0.0 * degrees, 360.0 * degrees);
+      cairo_fill(cr);
+    }
+    else
+    {
+      cairo_scale(cr, 0.8, 0.8);
+      cairo_arc(cr, 0.0, 0.0, 0.35, 0.0 * degrees, 360.0 * degrees);
+      cairo_stroke(cr);
+    }
+
+    for(int i = 0; i < 8; i++)
+    {
+      cairo_rotate(cr, 45.0 * degrees);
+      cairo_move_to(cr, 0.5, 0.0);
+      cairo_rel_line_to(cr, 0.2, 0.0);
+      cairo_stroke(cr);
+    }
+
+  FINISH
+}
+
 void dtgtk_cairo_paint_filmstrip(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   gdouble sw = 0.6;

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -225,6 +225,8 @@ void dtgtk_cairo_paint_jzazbz(cairo_t *cr, gint x, gint y, gint w, gint h, gint 
 void dtgtk_cairo_paint_ryb(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint color swatch icon */
 void dtgtk_cairo_paint_color_swatch(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** paint brightness icon */
+void dtgtk_cairo_paint_brightness(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 
 /** paint active modulegroup icon */
 void dtgtk_cairo_paint_modulegroup_active(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1839,8 +1839,6 @@ static void _brightness_clicked(GtkWidget *button, dt_lib_histogram_t *d)
 {
   d->bright = !(d->bright);
   dt_conf_set_bool("plugins/darkroom/histogram/bright", d->bright);
-  dtgtk_button_set_paint(DTGTK_BUTTON(d->brightness_button),
-                         dtgtk_cairo_paint_brightness, CPF_NONE, &(d->bright));
   dt_control_queue_redraw_widget(d->scope_draw);
 }
 


### PR DESCRIPTION
This introduces graph brightness control button in histogram, switching between normal / high brightness.
Normal correspond to the current one.

Examples

Normal
![image](https://user-images.githubusercontent.com/43290988/215248119-f8e765bc-f1b5-405c-8cb3-19196af6c3fa.png)

High
![image](https://user-images.githubusercontent.com/43290988/215248148-0609774d-cbd5-485b-b6b7-85de99f6f563.png)

Normal
![image](https://user-images.githubusercontent.com/43290988/215248204-6ba69270-b381-445b-a865-4a672beef31c.png)

High
![image](https://user-images.githubusercontent.com/43290988/215248235-bdcfd83b-b4aa-4f06-add1-6df142f303e6.png)

I have the feeling this could be controversial:
- many (including myself) consider current histogram too dim (especially vectorscope), others find brighter colors disturbing
- too many buttons in gui? could this option be hidden somewhere else?

Just to be clear, I have no strong opinion on the above, and it's not terribly important either.
Let's see if we get consensus.