### PR TITLE
[GUI] Let's not surprise users with the word "bauhaus"

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -86,7 +86,7 @@
     <type>bool</type>
     <default>true</default>
     <shortdescription>scale slider step with min/max</shortdescription>
-    <longdescription>vary bauhaus slider step size with min/max range</longdescription>
+    <longdescription>vary slider step size with min/max range</longdescription>
   </dtconfig>
   <dtconfig>
     <name>database</name>


### PR DESCRIPTION
This PR removes the word `bauhaus` from the string `vary bauhaus slider step size with min/max range`.

Rationale: The fact that the developers named the widget style created for darktable with the word "bauhaus" is not communicated neither in the program nor in the documentation. This name is mentioned on darktable.org, but only [in a blog post from 2012](https://www.darktable.org/2012/03/bauhaus-widgets/) (!) when this widget style was created. Therefore, using the word bauhaus in the GUI does not make anything more understandable for the user. On the contrary, the program mentions some unknown "bauhaus" that the user does not know about, which provokes a feeling of insufficient understanding of what has been read.