### PR TITLE
rework color harmony GUI - guides selection

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2955,8 +2955,8 @@
     <type>
       <enum>
         <option>vectorscope</option>
-        <option>rgb parade</option>
         <option>waveform</option>
+        <option>rgb parade</option>
         <option>histogram</option>
       </enum>
     </type>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3066,16 +3066,10 @@
     <longdescription/>
   </dtconfig>
   <dtconfig>
-    <name>plugins/darkroom/histogram/vectorscope/show_color_harmony</name>
-    <type>bool</type>
-    <default>false</default>
-    <shortdescription/>
-    <longdescription/>
-  </dtconfig>
-  <dtconfig>
     <name>plugins/darkroom/histogram/vectorscope/harmony_type</name>
     <type>
       <enum>
+		<option>none</option>
 		<option>monochromatic</option>
 		<option>analogous</option>
 		<option>analogous complementary</option>
@@ -3087,7 +3081,7 @@
 		<option>square</option>
       </enum>
     </type>
-    <default>complementary</default>
+    <default>none</default>
     <shortdescription/>
     <longdescription/>
   </dtconfig>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2954,10 +2954,10 @@
     <name>plugins/darkroom/histogram/mode</name>
     <type>
       <enum>
-        <option>histogram</option>
-        <option>waveform</option>
-        <option>rgb parade</option>
         <option>vectorscope</option>
+        <option>rgb parade</option>
+        <option>waveform</option>
+        <option>histogram</option>
       </enum>
     </type>
     <default>histogram</default>

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1345,23 +1345,30 @@ void dtgtk_cairo_paint_color_harmony(cairo_t *cr, gint x, gint y, gint w, gint h
   PREAMBLE(1, 1, 0.5, 0.5)
 
   const double degrees = M_PI / 180.0;
+  typedef struct
+  {
+    const char *name;
+    const int sectors;
+    const float angle[4];
+    const float length[4];
+  } ch_t;
+  ch_t *ch = (ch_t *)data;
 
   cairo_arc(cr, 0.0, 0.0, 0.5, 0.0 * degrees, 360.0 * degrees);
   cairo_stroke(cr);
 
-#define SECTOR \
-  cairo_move_to(cr, 0.0, 0.0); \
-  cairo_line_to(cr, 0.0, -0.5); \
-  cairo_stroke(cr); \
-  cairo_arc(cr, 0.0, -0.5, 0.15, 0.0 * degrees, 360.0 * degrees); \
-  cairo_fill(cr); \
-
-  cairo_rotate(cr, -20.0 * degrees);
-  SECTOR;
-  cairo_rotate(cr, 130.0 * degrees);
-  SECTOR;
-  cairo_rotate(cr, 100.0 * degrees);
-  SECTOR;
+  for(int i = 0; i < ch->sectors; i++)
+  {
+    float angle = ch->angle[i] * 360.0 * degrees;
+    cairo_save(cr);
+    cairo_rotate(cr, angle);
+    cairo_move_to(cr, 0.0, 0.0);
+    cairo_line_to(cr, 0.0, -0.5);
+    cairo_stroke(cr);
+    cairo_arc(cr, 0.0, -0.5, 0.15, 0.0 * degrees, 360.0 * degrees);
+    cairo_fill(cr);
+    cairo_restore(cr);
+  }
 
   FINISH
 }

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1340,40 +1340,28 @@ void dtgtk_cairo_paint_ryb(cairo_t *cr, gint x, gint y, gint w, gint h, gint fla
   FINISH
 }
 
-void dtgtk_cairo_paint_color_swatch(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+void dtgtk_cairo_paint_color_harmony(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  PREAMBLE(1, 1, 0, 0)
+  PREAMBLE(1, 1, 0.5, 0.5)
 
   const double degrees = M_PI / 180.0;
 
-    cairo_translate(cr, .8, .8);
-    cairo_arc(cr, 0.0, 0.0, 0.2, 0.0 * degrees, 180.0 * degrees);
-    cairo_rel_line_to(cr, 0.0, -0.8);
-    cairo_rel_line_to(cr, 0.4, 0.0);
-    cairo_close_path(cr);
-    cairo_stroke(cr);
+  cairo_arc(cr, 0.0, 0.0, 0.5, 0.0 * degrees, 360.0 * degrees);
+  cairo_stroke(cr);
 
-    cairo_arc(cr, 0.0, 0.0, 0.05, 0.05 * degrees, 360.0 * degrees);
-    cairo_stroke(cr);
+#define SECTOR \
+  cairo_move_to(cr, 0.0, 0.0); \
+  cairo_line_to(cr, 0.0, -0.5); \
+  cairo_stroke(cr); \
+  cairo_arc(cr, 0.0, -0.5, 0.15, 0.0 * degrees, 360.0 * degrees); \
+  cairo_fill(cr); \
 
-    cairo_rectangle(cr, -0.1, -0.7, 0.2, 0.2);
-    cairo_fill(cr);
-    cairo_rectangle(cr, -0.1, -0.4, 0.2, 0.2);
-    cairo_fill(cr);
-
-    cairo_rotate(cr, -45.0 * degrees);
-    cairo_move_to(cr, -0.2, -0.1);
-    cairo_rel_line_to(cr, 0.0, -0.7);
-    cairo_rel_line_to(cr, 0.4, 0.0);
-    cairo_rel_line_to(cr, 0.0, 0.25);
-    cairo_stroke(cr);
-
-    cairo_rotate(cr, -45.0 * degrees);
-    cairo_move_to(cr, -0.2, -0.1);
-    cairo_rel_line_to(cr, 0.0, -0.7);
-    cairo_rel_line_to(cr, 0.4, 0.0);
-    cairo_rel_line_to(cr, 0.0, 0.25);
-    cairo_stroke(cr);
+  cairo_rotate(cr, -20.0 * degrees);
+  SECTOR;
+  cairo_rotate(cr, 130.0 * degrees);
+  SECTOR;
+  cairo_rotate(cr, 100.0 * degrees);
+  SECTOR;
 
   FINISH
 }

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -223,8 +223,8 @@ void dtgtk_cairo_paint_luv(cairo_t *cr, gint x, gint y, gint w, gint h, gint fla
 void dtgtk_cairo_paint_jzazbz(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint RYB icon */
 void dtgtk_cairo_paint_ryb(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
-/** paint color swatch icon */
-void dtgtk_cairo_paint_color_swatch(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** paint color harmony icon */
+void dtgtk_cairo_paint_color_harmony(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 
 /** paint active modulegroup icon */
 void dtgtk_cairo_paint_modulegroup_active(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -2010,6 +2010,16 @@ static void _lib_histogram_change_type_callback(dt_action_t *action)
   _scope_view_clicked(d->scope_view_button, d);
 }
 
+static void _lib_histogram_cycle_harmony_callback(dt_action_t *action)
+{
+  dt_lib_module_t *self = darktable.lib->proxy.histogram.module;
+  dt_lib_histogram_t *d = (dt_lib_histogram_t *)self->data;
+  d->color_harmony = (d->color_harmony + 1) % DT_LIB_HISTOGRAM_HARMONY_N;
+  gtk_toggle_button_set_active(g_slist_nth_data(d->color_armony_rb_group,
+                                                DT_LIB_HISTOGRAM_HARMONY_N - 1 - d->color_harmony), TRUE);
+  _color_harmony_changed(d);
+}
+
 // this is only called in darkroom view
 static void _lib_histogram_preview_updated_callback(gpointer instance, dt_lib_module_t *self)
 {
@@ -2254,6 +2264,10 @@ void gui_init(dt_lib_module_t *self)
                                d->color_harmony != DT_LIB_HISTOGRAM_HARMONY_NONE);
   gtk_box_pack_end(GTK_BOX(box_right), d->color_harmony_button, FALSE, FALSE, 0);
 
+  // !: quale widget ?
+  ac = dt_action_define(dark, N_("color harmonies"), N_("cycle color harmonies"), d->color_harmony_button, NULL);
+  dt_action_register(ac, NULL, _lib_histogram_cycle_harmony_callback, 0, 0);
+
   d->color_harmony_popup = gtk_popover_new(d->color_harmony_button);
   g_object_set(G_OBJECT(d->color_harmony_popup), "transitions-enabled", FALSE, NULL);
 
@@ -2265,7 +2279,7 @@ void gui_init(dt_lib_module_t *self)
   {
     rb = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(rb),
                                                      _(dt_color_harmonies[i].name));
-    dt_action_define(dark, "color harmonies", dt_color_harmonies[i].name,
+    dt_action_define(dark, N_("color harmonies"), dt_color_harmonies[i].name,
                      rb, &dt_action_def_button);
     g_signal_connect(G_OBJECT(rb), "toggled", G_CALLBACK(_color_harmony_radio_button_toggle), d);
     gtk_box_pack_start(GTK_BOX(vbox), rb, TRUE, TRUE, 0);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -208,6 +208,7 @@ typedef struct dt_lib_histogram_t
   dt_lib_histogram_color_harmony_type_t color_harmony;
   int harmony_rotation; // in degrees
   dt_lib_histogram_color_harmony_width_t harmony_width;
+  GSList *color_armony_rb_group;
 } dt_lib_histogram_t;
 
 const char *name(dt_lib_module_t *self)
@@ -1835,7 +1836,6 @@ static void _blue_channel_toggle(GtkWidget *button, dt_lib_histogram_t *d)
 
 static gboolean _color_harmony_clicked(GtkWidget *button, GdkEventButton *event, dt_lib_histogram_t *d)
 {
-  gtk_widget_show(d->color_harmony_button);
   gtk_widget_show_all(d->color_harmony_popup);
   return TRUE;
 }
@@ -1852,9 +1852,8 @@ static void _color_harmony_changed(dt_lib_histogram_t *d)
 static void _color_harmony_radio_button_toggle(GtkWidget *button, dt_lib_histogram_t *d)
 {
   if(!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button))) return;
-  GSList *group = gtk_radio_button_get_group(GTK_RADIO_BUTTON(button));
   // radio buttons are put in their list in reverse order
-  d->color_harmony = DT_LIB_HISTOGRAM_HARMONY_N - 1 - g_slist_index(group, button);
+  d->color_harmony = DT_LIB_HISTOGRAM_HARMONY_N - 1 - g_slist_index(d->color_armony_rb_group, button);
   gtk_widget_hide(d->color_harmony_popup);
   _color_harmony_changed(d);
 }
@@ -1867,6 +1866,8 @@ static gboolean _color_harmony_scroll_callback(GtkWidget *widget, GdkEventScroll
   {
     if(d->color_harmony == 0 && delta_y < 0) d->color_harmony = DT_LIB_HISTOGRAM_HARMONY_N - 1;
     else d->color_harmony = (d->color_harmony + delta_y) % DT_LIB_HISTOGRAM_HARMONY_N;
+    gtk_toggle_button_set_active(g_slist_nth_data(d->color_armony_rb_group,
+                                                  DT_LIB_HISTOGRAM_HARMONY_N - 1 - d->color_harmony), TRUE);
     _color_harmony_changed(d);
   }
   return TRUE;
@@ -2269,8 +2270,8 @@ void gui_init(dt_lib_module_t *self)
     g_signal_connect(G_OBJECT(rb), "toggled", G_CALLBACK(_color_harmony_radio_button_toggle), d);
     gtk_box_pack_start(GTK_BOX(vbox), rb, TRUE, TRUE, 0);
    }
-  GSList *group = gtk_radio_button_get_group(GTK_RADIO_BUTTON(rb));
-  gtk_toggle_button_set_active(g_slist_nth_data(group, DT_LIB_HISTOGRAM_HARMONY_N - 1 - d->color_harmony), TRUE);
+  d->color_armony_rb_group = gtk_radio_button_get_group(GTK_RADIO_BUTTON(rb));
+  gtk_toggle_button_set_active(g_slist_nth_data(d->color_armony_rb_group, DT_LIB_HISTOGRAM_HARMONY_N - 1 - d->color_harmony), TRUE);
 
   // will change visibility of buttons, hence must run after all buttons are declared
   _scope_type_update(d);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -66,8 +66,8 @@ typedef enum dt_lib_histogram_highlight_t
 typedef enum dt_lib_histogram_scope_type_t
 {
   DT_LIB_HISTOGRAM_SCOPE_VECTORSCOPE = 0,
-  DT_LIB_HISTOGRAM_SCOPE_PARADE,
   DT_LIB_HISTOGRAM_SCOPE_WAVEFORM,
+  DT_LIB_HISTOGRAM_SCOPE_PARADE,
   DT_LIB_HISTOGRAM_SCOPE_HISTOGRAM,
   DT_LIB_HISTOGRAM_SCOPE_N // needs to be the last one
 } dt_lib_histogram_scope_type_t;
@@ -141,7 +141,7 @@ dt_lib_histogram_color_harmony_t dt_color_harmonies[DT_LIB_HISTOGRAM_HARMONY_N] 
 };
 
 // FIXME: are these lists available from the enum/options in darktableconfig.xml?
-const gchar *dt_lib_histogram_scope_type_names[DT_LIB_HISTOGRAM_SCOPE_N] = { N_("vectorscope"), N_("rgb parade"), N_("waveform"), N_("histogram") };
+const gchar *dt_lib_histogram_scope_type_names[DT_LIB_HISTOGRAM_SCOPE_N] = { N_("vectorscope"), N_("waveform"), N_("rgb parade"), N_("histogram") };
 const gchar *dt_lib_histogram_scale_names[DT_LIB_HISTOGRAM_SCALE_N] = { "logarithmic", "linear" };
 const gchar *dt_lib_histogram_orient_names[DT_LIB_HISTOGRAM_ORIENT_N] = { "horizontal", "vertical" };
 const gchar *dt_lib_histogram_vectorscope_type_names[DT_LIB_HISTOGRAM_VECTORSCOPE_N] = { "u*v*", "AzBz", "RYB" };
@@ -152,8 +152,8 @@ const float dt_lib_histogram_color_harmony_width[DT_LIB_HISTOGRAM_HARMONY_WIDTH_
 
 const void *dt_lib_histogram_scope_type_icons[DT_LIB_HISTOGRAM_SCOPE_N] =
               { dtgtk_cairo_paint_vectorscope,
-                dtgtk_cairo_paint_rgb_parade,
                 dtgtk_cairo_paint_waveform_scope,
+                dtgtk_cairo_paint_rgb_parade,
                 dtgtk_cairo_paint_histogram_scope };
 
 typedef struct dt_lib_histogram_t


### PR DESCRIPTION
Fixes #13458 (or at least it tries to).

Introduce a pop over menu to select the color harmony in place of the ALT+SCROLL.
New icon for the button too.

![image](https://user-images.githubusercontent.com/43290988/215343716-762e1213-d3cc-442d-9c9f-9c839a16c32d.png)
