### PR TITLE
fix resize cursor when scrolled to bottom of listview

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3126,6 +3126,7 @@ static gboolean _resize_wrap_motion(GtkWidget *widget, GdkEventMotion *event, co
     return TRUE;
   }
   else if(!(event->state & GDK_BUTTON1_MASK)
+          && event->window == gtk_widget_get_window(widget)
           && event->y > gtk_widget_get_allocated_height(widget) - DT_RESIZE_HANDLE_SIZE)
   {
     dt_control_change_cursor(GDK_SB_V_DOUBLE_ARROW);


### PR DESCRIPTION
fixes #13468

@Nilvus could you please check if this solves your issue and doesn't cause new ones (not just for history, but for all other resizable widgets)?