### PR TITLE
[GUI] Fix display of infinity symbol in 'crop and rotate' module hinter

### DIFF
--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -3067,12 +3067,12 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
       }
       else if(g->k_selected_segment >= 0)
       {
-        dt_control_hinter_message(darktable.control, _("<b>move line</b>: drag, <b>toggle symmetry</b>: click <tt>ꝏ</tt>"));
+        dt_control_hinter_message(darktable.control, _("<b>move line</b>: drag, <b>toggle symmetry</b>: click ꝏ"));
         dt_control_change_cursor(GDK_CROSS);
       }
       else
       {
-        dt_control_hinter_message(darktable.control, _("<b>apply</b>: click <tt>ok</tt>, <b>toggle symmetry</b>: click <tt>ꝏ</tt>\n"
+        dt_control_hinter_message(darktable.control, _("<b>apply</b>: click <tt>ok</tt>, <b>toggle symmetry</b>: click ꝏ\n"
                                                        "<b>move line/control point</b>: drag"));
         dt_control_change_cursor(GDK_FLEUR);
       }


### PR DESCRIPTION
Well, I do know this module is deprecated, but still it is not hidden permanently so fixing bugs in its interface makes sense. The module was deprecated in 2021 and is currently present, albeit in a separate module group with warnings, but still available to work with (not just to maintain old edits).

The problem is observed in darktable on the Windows 10 platform (preinstalled on the laptop, without any fonts added or removed from the system). The issue is that in Windows 10, the infinity sign is not displayed in the hinter of this module.

The root of the problem is that in the current code we are trying to output the infinity symbol in a monospaced font. As we can see from the result, the font that dt uses for this on Windows does not contain this symbol.

This problem is not observed in Ubuntu 22.04. I have no information about macOS.

I didn't try to keep the old option with monospaced font for platforms where there is no problem, because in my opinion the infinity symbol without font switching looks even more noticeable and clear.
