### PR TITLE
Getting rid of -d demosaic

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -129,7 +129,7 @@ static int usage(const char *argv0)
   printf("  --cachedir <user cache directory>\n");
   printf("  --conf <key>=<value>\n");
   printf("  --configdir <user config directory>\n");
-  printf("  -d {all,act_on,cache,camctl,camsupport,control,demosaic,dev,imageio,\n");
+  printf("  -d {all,act_on,cache,camctl,camsupport,control,dev,imageio,\n");
   printf("      input,ioporder,lighttable,lua,masks,memory,nan,opencl,params,\n");
   printf("      perf,print,pwstorage,signal,sql,tiling,undo,verbose,pipe}\n");
   printf("  --d-signal <signal> \n");
@@ -717,8 +717,6 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
           darktable.unmuted |= DT_DEBUG_SIGNAL; // signal information on console
         else if(!strcmp(argv[k + 1], "params"))
           darktable.unmuted |= DT_DEBUG_PARAMS; // iop module params checks on console
-        else if(!strcmp(argv[k + 1], "demosaic"))
-          darktable.unmuted |= DT_DEBUG_DEMOSAIC;
         else if(!strcmp(argv[k + 1], "act_on"))
           darktable.unmuted |= DT_DEBUG_ACT_ON;
         else if(!strcmp(argv[k + 1], "tiling"))

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -270,11 +270,10 @@ typedef enum dt_debug_thread_t
   DT_DEBUG_UNDO           = 1 << 19,
   DT_DEBUG_SIGNAL         = 1 << 20,
   DT_DEBUG_PARAMS         = 1 << 21,
-  DT_DEBUG_DEMOSAIC       = 1 << 22,
-  DT_DEBUG_ACT_ON         = 1 << 23,
-  DT_DEBUG_TILING         = 1 << 24,
-  DT_DEBUG_VERBOSE        = 1 << 25,
-  DT_DEBUG_PIPE           = 1 << 26,
+  DT_DEBUG_ACT_ON         = 1 << 22,
+  DT_DEBUG_TILING         = 1 << 23,
+  DT_DEBUG_VERBOSE        = 1 << 24,
+  DT_DEBUG_PIPE           = 1 << 25,
   DT_DEBUG_ALL            = 0xffffffff & ~DT_DEBUG_VERBOSE
 } dt_debug_thread_t;
 

--- a/src/iop/dual_demosaic.c
+++ b/src/iop/dual_demosaic.c
@@ -50,13 +50,9 @@ static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict r
     dt_control_log(_("[dual demosaic] can't allocate internal buffers"));
     return;
   }
-  const gboolean info = ((darktable.unmuted & (DT_DEBUG_DEMOSAIC | DT_DEBUG_PERF)) && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL));
 
   vng_interpolate(vng_image, raw_data, roi_out, roi_in, filters, xtrans, FALSE);
   color_smoothing(vng_image, roi_out, 2);
-
-  dt_times_t start_blend = { 0 }, end_blend = { 0 };
-  if(info) dt_get_times(&start_blend);
 
   const float contrastf = slider2contrast(dual_threshold);
   const gboolean wbon = piece->pipe->dsc.temperature.enabled;
@@ -95,11 +91,7 @@ static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict r
         rgb_data[oidx + c] = intp(blend[idx], rgb_data[oidx + c], vng_image[oidx + c]);
     }
   }
-  if(info)
-  {
-    dt_get_times(&end_blend);
-    fprintf(stderr," [demosaic] CPU dual blending %.4f secs (%.4f CPU)\n", end_blend.clock - start_blend.clock, end_blend.user - start_blend.user);
-  }
+
   dt_free_align(tmp);
   dt_free_align(blend);
   dt_free_align(vng_image);


### PR DESCRIPTION
The -d demosaic switch was very specific while doing a lot of benchmarking internal algorithms of the demosaicer. Let's get rid of it as a residual. 