### PR TITLE
Demosaic debug workup

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -129,7 +129,7 @@ static int usage(const char *argv0)
   printf("  --cachedir <user cache directory>\n");
   printf("  --conf <key>=<value>\n");
   printf("  --configdir <user config directory>\n");
-  printf("  -d {all,act_on,cache,camctl,camsupport,control,demosaic,dev,imageio,\n");
+  printf("  -d {all,act_on,cache,camctl,camsupport,control,dev,imageio,\n");
   printf("      input,ioporder,lighttable,lua,masks,memory,nan,opencl,params,\n");
   printf("      perf,print,pwstorage,signal,sql,tiling,undo,verbose,pipe}\n");
   printf("  --d-signal <signal> \n");
@@ -717,8 +717,6 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
           darktable.unmuted |= DT_DEBUG_SIGNAL; // signal information on console
         else if(!strcmp(argv[k + 1], "params"))
           darktable.unmuted |= DT_DEBUG_PARAMS; // iop module params checks on console
-        else if(!strcmp(argv[k + 1], "demosaic"))
-          darktable.unmuted |= DT_DEBUG_DEMOSAIC;
         else if(!strcmp(argv[k + 1], "act_on"))
           darktable.unmuted |= DT_DEBUG_ACT_ON;
         else if(!strcmp(argv[k + 1], "tiling"))

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -270,11 +270,10 @@ typedef enum dt_debug_thread_t
   DT_DEBUG_UNDO           = 1 << 19,
   DT_DEBUG_SIGNAL         = 1 << 20,
   DT_DEBUG_PARAMS         = 1 << 21,
-  DT_DEBUG_DEMOSAIC       = 1 << 22,
-  DT_DEBUG_ACT_ON         = 1 << 23,
-  DT_DEBUG_TILING         = 1 << 24,
-  DT_DEBUG_VERBOSE        = 1 << 25,
-  DT_DEBUG_PIPE           = 1 << 26,
+  DT_DEBUG_ACT_ON         = 1 << 22,
+  DT_DEBUG_TILING         = 1 << 23,
+  DT_DEBUG_VERBOSE        = 1 << 24,
+  DT_DEBUG_PIPE           = 1 << 25,
   DT_DEBUG_ALL            = 0xffffffff & ~DT_DEBUG_VERBOSE
 } dt_debug_thread_t;
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1636,7 +1636,7 @@ static void xtrans_fdc_interpolate(struct dt_iop_module_t *self, float *out, con
   char *const all_buffers = (char *)dt_alloc_perthread(buffer_size, sizeof(char), &padded_buffer_size);
   if(!all_buffers)
   {
-    fprintf(stderr, "[demosaic] not able to allocate FDC base buffers\n");
+    dt_print(DT_DEBUG_ALWAYS, "[demosaic] not able to allocate FDC base buffers\n");
     return;
   }
 
@@ -2382,7 +2382,7 @@ static void vng_interpolate(float *out, const float *const in,
       = (char *)dt_alloc_align(64, sizeof(**brow) * width * 3 + sizeof(*ip) * prow * pcol * 320);
   if(!buffer)
   {
-    fprintf(stderr, "[demosaic] not able to allocate VNG buffer\n");
+    dt_print(DT_DEBUG_ALWAYS, "[demosaic] not able to allocate VNG buffer\n");
     return;
   }
   for(int row = 0; row < 3; row++) brow[row] = (float(*)[4])buffer + row * width;
@@ -2949,7 +2949,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   dt_iop_roi_t roo = *roi_out;
   roo.x = roo.y = 0;
   // roi_out->scale = global scale: (iscale == 1.0, always when demosaic is on)
-  const gboolean info = ((darktable.unmuted & DT_DEBUG_DEMOSAIC) && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL));
+  const gboolean info = ((darktable.unmuted & DT_DEBUG_PERF) && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL));
   const gboolean run_fast = piece->pipe->type & DT_DEV_PIXELPIPE_FAST;
 
   const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
@@ -3092,7 +3092,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       dt_get_times(&end_time);
       const float tclock = end_time.clock - start_time.clock;
       const float uclock = end_time.user - start_time.user;
-      fprintf(stderr," [demosaic] process CPU `%s' did %.2fmpix, %.4f secs (%.4f CPU), %.2f pix/us\n",
+      dt_print(DT_DEBUG_ALWAYS, "[demosaic] process CPU `%s' did %.2fmpix, %.4f secs (%.4f CPU), %.2f pix/us\n",
         _method2string(demosaicing_method & ~DT_DEMOSAIC_DUAL), mpixels, tclock, uclock, mpixels / tclock);
     }
 
@@ -4785,7 +4785,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
                const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_times_t start_time = { 0 }, end_time = { 0 };
-  const gboolean info = ((darktable.unmuted & DT_DEBUG_DEMOSAIC) && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL));
+  const gboolean info = ((darktable.unmuted & DT_DEBUG_PERF) && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL));
   const gboolean run_fast = piece->pipe->type & DT_DEV_PIXELPIPE_FAST;
 
   dt_dev_clear_rawdetail_mask(piece->pipe);
@@ -4870,7 +4870,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     dt_get_times(&end_time);
     const float tclock = end_time.clock - start_time.clock;
     const float uclock = end_time.user - start_time.user;
-    fprintf(stderr," [demosaic] process GPU `%s' did %.2fmpix, %.4f secs (%.4f CPU), %.2f pix/us\n",
+    dt_print(DT_DEBUG_ALWAYS, "[demosaic] process GPU `%s' did %.2fmpix, %.4f secs (%.4f CPU), %.2f pix/us\n",
       _method2string(demosaicing_method & ~DT_DEMOSAIC_DUAL), mpixels, tclock, uclock, mpixels / tclock);
   }
   if(!dual)
@@ -4915,7 +4915,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   if(info)
   {
     dt_get_times(&end_time);
-    fprintf(stderr," [demosaic] GPU dual blending %.4f secs (%.4f CPU)\n", end_time.clock - start_time.clock, end_time.user - start_time.user);
+    dt_print(DT_DEBUG_ALWAYS, "[demosaic] GPU dual blending %.4f secs (%.4f CPU)\n", end_time.clock - start_time.clock, end_time.user - start_time.user);
   }
 
   if(scaled)
@@ -5305,7 +5305,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
                                                self->dev->image_storage.d65_color_matrix, NULL))
     {
       const char *camera = self->dev->image_storage.camera_makermodel;
-      fprintf(stderr, "[colorspaces] `%s' color matrix not found for 4bayer image!\n", camera);
+      dt_print(DT_DEBUG_ALWAYS, "[colorspaces] `%s' color matrix not found for 4bayer image!\n", camera);
       dt_control_log(_("`%s' color matrix not found for 4bayer image!"), camera);
     }
   }

--- a/src/iop/dual_demosaic.c
+++ b/src/iop/dual_demosaic.c
@@ -50,7 +50,7 @@ static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict r
     dt_control_log(_("[dual demosaic] can't allocate internal buffers"));
     return;
   }
-  const gboolean info = ((darktable.unmuted & (DT_DEBUG_DEMOSAIC | DT_DEBUG_PERF)) && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL));
+  const gboolean info = ((darktable.unmuted & DT_DEBUG_PERF) && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL));
 
   vng_interpolate(vng_image, raw_data, roi_out, roi_in, filters, xtrans, FALSE);
   color_smoothing(vng_image, roi_out, 2);
@@ -98,7 +98,7 @@ static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict r
   if(info)
   {
     dt_get_times(&end_blend);
-    fprintf(stderr," [demosaic] CPU dual blending %.4f secs (%.4f CPU)\n", end_blend.clock - start_blend.clock, end_blend.user - start_blend.user);
+    dt_print(DT_DEBUG_ALWAYS, "[demosaic] CPU dual blending %.4f secs (%.4f CPU)\n", end_blend.clock - start_blend.clock, end_blend.user - start_blend.user);
   }
   dt_free_align(tmp);
   dt_free_align(blend);


### PR DESCRIPTION
- the special -d demosaic option seems to be superflucious now, had been used while checking internal demsaicing code extensively.
- use -d perf instead
- use dt_print() instead of fprintf()