### PR TITLE
po/auto init style

### DIFF
--- a/src/common/history.h
+++ b/src/common/history.h
@@ -62,29 +62,29 @@ typedef struct dt_history_copy_item_t
 void dt_history_item_free(gpointer data);
 
 /** adds to dev_dest module mod_src */
-int dt_history_merge_module_into_history(struct dt_develop_t *dev_dest,
-                                         struct dt_develop_t *dev_src,
-                                         struct dt_iop_module_t *mod_src,
-                                         GList **_modules_used,
-                                         const int append);
+gboolean dt_history_merge_module_into_history(struct dt_develop_t *dev_dest,
+                                              struct dt_develop_t *dev_src,
+                                              struct dt_iop_module_t *mod_src,
+                                              GList **_modules_used,
+                                              const int append);
 
 /** copy history from imgid and pasts on dest_imgid, merge or overwrite... */
-int dt_history_copy_and_paste_on_image(const int32_t imgid,
-                                       const int32_t dest_imgid,
-                                       const gboolean merge,
-                                       GList *ops,
-                                       const gboolean copy_iop_order,
-                                       const gboolean copy_full);
+gboolean dt_history_copy_and_paste_on_image(const int32_t imgid,
+                                            const int32_t dest_imgid,
+                                            const gboolean merge,
+                                            GList *ops,
+                                            const gboolean copy_iop_order,
+                                            const gboolean copy_full);
 
 /** delete all history for the given image */
-void dt_history_delete_on_image(int32_t imgid);
+void dt_history_delete_on_image(const int32_t imgid);
 
 /** as above but control whether to record undo/redo */
-void dt_history_delete_on_image_ext(int32_t imgid, gboolean undo);
+void dt_history_delete_on_image_ext(const int32_t imgid, const gboolean undo);
 
 /** copy history from imgid and pasts on selected images, merge or overwrite... */
-gboolean dt_history_copy(int imgid);
-gboolean dt_history_copy_parts(int imgid);
+gboolean dt_history_copy(const int imgid);
+gboolean dt_history_copy_parts(const int imgid);
 gboolean dt_history_paste_on_list(const GList *list, gboolean undo);
 gboolean dt_history_paste_parts_on_list(const GList *list, gboolean undo);
 
@@ -94,13 +94,15 @@ static inline gboolean dt_history_module_skip_copy(const int flags)
 }
 
 /** load a dt file and applies to selected images */
-int dt_history_load_and_apply_on_list(gchar *filename, const GList *list);
+gboolean dt_history_load_and_apply_on_list(gchar *filename, const GList *list);
 
 /** load a dt file and applies to specified image */
-int dt_history_load_and_apply(int imgid, gchar *filename, int history_only);
+gboolean dt_history_load_and_apply(const int imgid,
+                                   gchar *filename,
+                                   const gboolean history_only);
 
 /** delete historystack of selected images */
-gboolean dt_history_delete_on_list(const GList *list, gboolean undo);
+gboolean dt_history_delete_on_list(const GList *list, const gboolean undo);
 
 /** compress history stack */
 int dt_history_compress_on_list(const GList *imgs);

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -66,7 +66,8 @@ gboolean dt_history_merge_module_into_history(struct dt_develop_t *dev_dest,
                                               struct dt_develop_t *dev_src,
                                               struct dt_iop_module_t *mod_src,
                                               GList **_modules_used,
-                                              const int append);
+                                              const gboolean append,
+                                              const gboolean auto_init);
 
 /** copy history from imgid and pasts on dest_imgid, merge or overwrite... */
 gboolean dt_history_copy_and_paste_on_image(const int32_t imgid,

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -490,7 +490,9 @@ GList *dt_ioppr_get_iop_order_rules()
   return g_list_reverse(rules);  // list was built in reverse order, so un-reverse it
 }
 
-GList *dt_ioppr_get_iop_order_link(GList *iop_order_list, const char *op_name, const int multi_priority)
+GList *dt_ioppr_get_iop_order_link(GList *iop_order_list,
+                                   const char *op_name,
+                                   const int multi_priority)
 {
   GList *link = NULL;
 
@@ -522,7 +524,9 @@ dt_iop_order_entry_t *dt_ioppr_get_iop_order_entry(GList *iop_order_list,
 }
 
 // returns the iop_order associated with the iop order entry that matches operation == op_name
-int dt_ioppr_get_iop_order(GList *iop_order_list, const char *op_name, const int multi_priority)
+int dt_ioppr_get_iop_order(GList *iop_order_list,
+                           const char *op_name,
+                           const int multi_priority)
 {
   int iop_order = INT_MAX;
   const dt_iop_order_entry_t *const restrict order_entry =
@@ -667,7 +671,8 @@ gboolean dt_ioppr_has_multiple_instances(GList *iop_order_list)
   return FALSE;
 }
 
-GList *dt_ioppr_get_multiple_instances_iop_order_list(int32_t imgid, gboolean memory)
+GList *dt_ioppr_get_multiple_instances_iop_order_list(const int32_t imgid,
+                                                      const gboolean memory)
 {
   GList *res = NULL;
   sqlite3_stmt *stmt = NULL;
@@ -716,9 +721,10 @@ gboolean dt_ioppr_write_iop_order(const dt_iop_order_t kind,
 {
   sqlite3_stmt *stmt;
 
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "INSERT OR REPLACE INTO main.module_order VALUES (?1, 0, NULL)", -1,
-                              &stmt, NULL);
+  DT_DEBUG_SQLITE3_PREPARE_V2
+    (dt_database_get(darktable.db),
+     "INSERT OR REPLACE INTO main.module_order VALUES (?1, 0, NULL)", -1,
+     &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
   if(sqlite3_step(stmt) != SQLITE_DONE) return FALSE;
   sqlite3_finalize(stmt);
@@ -726,9 +732,12 @@ gboolean dt_ioppr_write_iop_order(const dt_iop_order_t kind,
   if(kind == DT_IOP_ORDER_CUSTOM || dt_ioppr_has_multiple_instances(iop_order_list))
   {
     gchar *iop_list_txt = dt_ioppr_serialize_text_iop_order_list(iop_order_list);
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                "UPDATE main.module_order SET version = ?2, iop_list = ?3 WHERE imgid = ?1", -1,
-                                &stmt, NULL);
+    DT_DEBUG_SQLITE3_PREPARE_V2
+      (dt_database_get(darktable.db),
+       "UPDATE main.module_order"
+       " SET version = ?2, iop_list = ?3"
+       " WHERE imgid = ?1", -1,
+       &stmt, NULL);
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, kind);
     DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 3, iop_list_txt, -1, SQLITE_TRANSIENT);
@@ -740,7 +749,9 @@ gboolean dt_ioppr_write_iop_order(const dt_iop_order_t kind,
   else
   {
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                "UPDATE main.module_order SET version = ?2, iop_list = NULL WHERE imgid = ?1", -1,
+                                "UPDATE main.module_order"
+                                " SET version = ?2, iop_list = NULL"
+                                " WHERE imgid = ?1", -1,
                                 &stmt, NULL);
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, kind);
@@ -995,7 +1006,9 @@ void dt_ioppr_migrate_iop_order(struct dt_develop_t *dev, const int32_t imgid)
   dt_dev_reload_history_items(dev);
 }
 
-void dt_ioppr_change_iop_order(struct dt_develop_t *dev, const int32_t imgid, GList *new_iop_list)
+void dt_ioppr_change_iop_order(struct dt_develop_t *dev,
+                               const int32_t imgid,
+                               GList *new_iop_list)
 {
   GList *iop_list = dt_ioppr_iop_order_copy_deep(new_iop_list);
   GList *mi = dt_ioppr_extract_multi_instances_list(darktable.develop->iop_order_list);
@@ -1128,8 +1141,8 @@ GList *dt_ioppr_merge_multi_instance_iop_order_list(GList *iop_order_list,
   return iop_order_list;
 }
 
-static void _count_iop_module(GList *iop, const
-                              char *operation,
+static void _count_iop_module(GList *iop,
+                              const char *operation,
                               int *max_multi_priority,
                               int *count,
                               int *max_multi_priority_enabled,
@@ -1204,7 +1217,9 @@ int _get_multi_priority(dt_develop_t *dev,
   return INT_MAX;
 }
 
-void dt_ioppr_update_for_entries(dt_develop_t *dev, GList *entry_list, const gboolean append)
+void dt_ioppr_update_for_entries(dt_develop_t *dev,
+                                 GList *entry_list,
+                                 const gboolean append)
 {
   // for each priority list to be checked
   for(GList *e_list = entry_list; e_list; e_list = g_list_next(e_list))
@@ -1299,7 +1314,9 @@ void dt_ioppr_update_for_entries(dt_develop_t *dev, GList *entry_list, const gbo
 //  dt_ioppr_print_iop_order(dev->iop_order_list, "upd sitem");
 }
 
-void dt_ioppr_update_for_style_items(dt_develop_t *dev, GList *st_items, const gboolean append)
+void dt_ioppr_update_for_style_items(dt_develop_t *dev,
+                                     GList *st_items,
+                                     const gboolean append)
 {
   GList *e_list = NULL;
 
@@ -1349,7 +1366,9 @@ void dt_ioppr_update_for_style_items(dt_develop_t *dev, GList *st_items, const g
   g_list_free(e_list);
 }
 
-void dt_ioppr_update_for_modules(dt_develop_t *dev, GList *modules, const gboolean append)
+void dt_ioppr_update_for_modules(dt_develop_t *dev,
+                                 GList *modules,
+                                 const gboolean append)
 {
   GList *e_list = NULL;
 
@@ -2003,7 +2022,9 @@ void dt_ioppr_insert_module_instance(struct dt_develop_t *dev, dt_iop_module_t *
   dev->iop_order_list = g_list_insert_before(dev->iop_order_list, place, entry);
 }
 
-int dt_ioppr_check_iop_order(dt_develop_t *dev, const int imgid, const char *msg)
+int dt_ioppr_check_iop_order(dt_develop_t *dev,
+                             const int imgid,
+                             const char *msg)
 {
   int iop_order_ok = 1;
 

--- a/src/common/iop_order.h
+++ b/src/common/iop_order.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2018-2022 darktable developers.
+    Copyright (C) 2018-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by
@@ -166,10 +166,11 @@ dt_iop_order_t dt_ioppr_get_iop_order_version(const int32_t imgid);
 dt_iop_order_t dt_ioppr_get_iop_order_list_kind(GList *iop_order_list);
 
 /** returns true if imgid has an iop-order set */
-gboolean dt_ioppr_has_iop_order_list(int32_t imgid);
+gboolean dt_ioppr_has_iop_order_list(const int32_t imgid);
 
 /** returns a list of dt_iop_order_entry_t and updates *_version */
-GList *dt_ioppr_get_iop_order_list(int32_t imgid, gboolean sorted);
+GList *dt_ioppr_get_iop_order_list(const int32_t imgid,
+                                   const gboolean sorted);
 /** return the iop-order list for the given version, this is used to get the built-in lists */
 GList *dt_ioppr_get_iop_order_list_version(dt_iop_order_t version);
 /** returns the dt_iop_order_entry_t of iop_order_list with operation = op_name */
@@ -186,12 +187,17 @@ gboolean dt_ioppr_has_multiple_instances(GList *iop_order_list);
 GList *dt_ioppr_get_multiple_instances_iop_order_list(int32_t imgid, gboolean memory);
 
 /** returns the iop_order from iop_order_list list with operation = op_name */
-int dt_ioppr_get_iop_order(GList *iop_order_list, const char *op_name, const int multi_priority);
+int dt_ioppr_get_iop_order(GList *iop_order_list,
+                           const char *op_name,
+                           const int multi_priority);
 /** returns TRUE if operation/multi-priority is before base_operation (first in pipe) on the iop-list */
-gboolean dt_ioppr_is_iop_before(GList *iop_order_list, const char *base_operation,
-                                const char *operation, const int multi_priority);
+gboolean dt_ioppr_is_iop_before(GList *iop_order_list,
+                                const char *base_operation,
+                                const char *operation,
+                                const int multi_priority);
 /* write iop-order list for the given image */
-gboolean dt_ioppr_write_iop_order_list(GList *iop_order_list, const int32_t imgid);
+gboolean dt_ioppr_write_iop_order_list(GList *iop_order_list,
+                                       const int32_t imgid);
 gboolean dt_ioppr_write_iop_order(const dt_iop_order_t kind,
                                   GList *iop_order_list,
                                   const int32_t imgid);
@@ -205,15 +211,22 @@ char *dt_ioppr_serialize_text_iop_order_list(GList *iop_order_list);
 GList *dt_ioppr_deserialize_text_iop_order_list(const char *buf);
 
 /** insert a match for module into the iop-order list */
-void dt_ioppr_insert_module_instance(struct dt_develop_t *dev, struct dt_iop_module_t *module);
+void dt_ioppr_insert_module_instance(struct dt_develop_t *dev,
+                                     struct dt_iop_module_t *module);
 void dt_ioppr_resync_modules_order(struct dt_develop_t *dev);
 void dt_ioppr_resync_iop_list(struct dt_develop_t *dev);
 
 /** update target_iop_order_list to ensure that modules in iop_order_list are in target_iop_order_list
     note that iop_order_list contains a set of dt_iop_order_entry_t where order is the multi-priority */
-void dt_ioppr_update_for_entries(struct dt_develop_t *dev, GList *entry_list, const gboolean append);
-void dt_ioppr_update_for_style_items(struct dt_develop_t *dev, GList *st_items, const gboolean append);
-void dt_ioppr_update_for_modules(struct dt_develop_t *dev, GList *modules, const gboolean append);
+void dt_ioppr_update_for_entries(struct dt_develop_t *dev,
+                                 GList *entry_list,
+                                 const gboolean append);
+void dt_ioppr_update_for_style_items(struct dt_develop_t *dev,
+                                     GList *st_items,
+                                     const gboolean append);
+void dt_ioppr_update_for_modules(struct dt_develop_t *dev,
+                                 GList *modules,
+                                 const gboolean append);
 
 /** check if there's duplicate iop_order entries in iop_list */
 void dt_ioppr_check_duplicate_iop_order(GList **_iop_list, GList *history_list);

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -754,7 +754,9 @@ void dt_styles_apply_style_item(dt_develop_t *dev,
     if(dt_iop_load_module(module, mod_src->so, dev))
     {
       module = NULL;
-      fprintf(stderr, "[dt_styles_apply_style_item] can't load module %s %s\n", style_item->operation,
+      fprintf(stderr,
+              "[dt_styles_apply_style_item] can't load module %s %s\n",
+              style_item->operation,
               style_item->multi_name);
     }
     else

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -290,27 +290,37 @@ static void _dt_style_update_from_image(const int id,
 
     do
     {
+      const int item_included = GPOINTER_TO_INT(list->data);
+      const int item_updated = GPOINTER_TO_INT(upd->data);
+      const gboolean autoinit = item_updated < 0;
+
       query[0] = '\0';
 
       // included and update set, we then need to update the corresponding style item
-      if(GPOINTER_TO_INT(upd->data) != -1 && GPOINTER_TO_INT(list->data) != -1)
+      if(item_updated != 0 && item_included != 0)
       {
         g_strlcpy(query, "UPDATE data.style_items SET ", sizeof(query));
 
         for(int k = 0; fields[k]; k++)
         {
-          if(k != 0) g_strlcat(query, ",", sizeof(query));
-          snprintf(tmp, sizeof(tmp),
-                   "%s=(SELECT %s FROM main.history WHERE imgid=%d AND num=%d)",
-                   fields[k], fields[k], imgid, GPOINTER_TO_INT(upd->data));
+          if(autoinit && k==0)
+            snprintf(tmp, sizeof(tmp), "%s=NULL", fields[k]);
+          else
+          {
+            if(k != 0) g_strlcat(query, ",", sizeof(query));
+            snprintf(tmp, sizeof(tmp),
+                     "%s=(SELECT %s FROM main.history WHERE imgid=%d AND num=%d)",
+                     fields[k], fields[k], imgid, abs(item_updated));
+          }
           g_strlcat(query, tmp, sizeof(query));
         }
         snprintf(tmp, sizeof(tmp), " WHERE styleid=%d AND data.style_items.num=%d", id,
-                 GPOINTER_TO_INT(list->data));
+                 item_included);
         g_strlcat(query, tmp, sizeof(query));
       }
       // update only, so we want to insert the new style item
-      else if(GPOINTER_TO_INT(upd->data) != -1)
+      else if(item_updated != 0)
+      {
         // clang-format off
         snprintf(query, sizeof(query),
                  "INSERT INTO data.style_items "
@@ -321,13 +331,14 @@ static void _dt_style_update_from_image(const int id,
                  "     FROM data.style_items"
                  "     WHERE styleid=%d"
                  "     ORDER BY num DESC LIMIT 1), "
-                 "   module, operation, op_params, enabled,"
+                 "   module, operation, %s, enabled,"
                  "   blendop_params, blendop_version,"
                  "   multi_priority, multi_name, multi_name_hand_edited"
                  " FROM main.history"
                  " WHERE imgid=%d AND num=%d",
-                 id, id, imgid, GPOINTER_TO_INT(upd->data));
+                 id, id, autoinit?"NULL":"op_params", imgid, abs(item_updated));
         // clang-format on
+      }
 
       if(*query) DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), query, NULL, NULL, NULL);
 
@@ -562,27 +573,33 @@ gboolean dt_styles_create_from_image(const char *name,
     {
       char tmp[64];
       char include[2048] = { 0 };
-      g_strlcat(include, "num IN (", sizeof(include));
+      char autoinit[2048] = { 0 };
       for(GList *list = filter; list; list = g_list_next(list))
       {
         if(list != filter) g_strlcat(include, ",", sizeof(include));
-        snprintf(tmp, sizeof(tmp), "%d", GPOINTER_TO_INT(list->data));
+        const int num = GPOINTER_TO_INT(list->data);
+        snprintf(tmp, sizeof(tmp), "%d", abs(num));
         g_strlcat(include, tmp, sizeof(include));
+        if(num < 0)
+        {
+          if(autoinit[0]) g_strlcat(autoinit, ",", sizeof(autoinit));
+          g_strlcat(autoinit, tmp, sizeof(autoinit));
+        }
       }
 
-      g_strlcat(include, ")", sizeof(include));
       char query[4096] = { 0 };
       // clang-format off
       snprintf(query, sizeof(query),
                "INSERT INTO data.style_items"
                " (styleid, num, module, operation, op_params, enabled, blendop_params,"
                "  blendop_version, multi_priority, multi_name, multi_name_hand_edited)"
-               " SELECT ?1, num, module, operation, op_params, enabled,"
-               "        blendop_params, blendop_version, multi_priority,"
+               " SELECT ?1, num, module, operation,"
+               "        CASE WHEN num in (%s) THEN NULL ELSE op_params END,"
+               "        enabled, blendop_params, blendop_version, multi_priority,"
                "        multi_name, multi_name_hand_edited"
                " FROM main.history"
-               " WHERE imgid=?2 AND %s",
-               include);
+               " WHERE imgid=?2 AND NUM in (%s)",
+               autoinit, include);
       // clang-format on
       DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
     }
@@ -789,13 +806,17 @@ void dt_styles_apply_style_item(dt_develop_t *dev,
         memcpy(module->blend_params, module->default_blendop_params, sizeof(dt_develop_blend_params_t));
       }
 
-      if(module->version() != style_item->module_version
-         || module->params_size != style_item->params_size
-         || strcmp(style_item->operation, module->op))
+      gboolean autoinit = FALSE;
+
+      if(style_item->params_size != 0
+         && (module->version() != style_item->module_version
+             || module->params_size != style_item->params_size
+             || strcmp(style_item->operation, module->op)))
       {
         if(!module->legacy_params
-           || module->legacy_params(module, style_item->params, labs(style_item->module_version),
-                                          module->params, labs(module->version())))
+           || module->legacy_params(module, style_item->params,
+                                    labs(style_item->module_version),
+                                    module->params, labs(module->version())))
         {
           fprintf(stderr, "[dt_styles_apply_style_item] module `%s' version mismatch: history is %d, darktable is %d.\n",
                   module->op, style_item->module_version, module->version());
@@ -832,12 +853,20 @@ void dt_styles_apply_style_item(dt_develop_t *dev,
       }
       else
       {
-        memcpy(module->params, style_item->params, module->params_size);
+        if(style_item->params_size == 0)
+        {
+          /* an auto-init module, we cannot handle this here as we
+             don't have the image's default parameters. This parameter
+             must be set when loading history in the darkroom. */
+          autoinit = TRUE;
+        }
+        else
+          memcpy(module->params, style_item->params, style_item->params_size);
       }
 
       if(do_merge)
         dt_history_merge_module_into_history
-          (dev, NULL, module, modules_used, append, FALSE);
+          (dev, NULL, module, modules_used, append, autoinit);
     }
 
     if(module)

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -836,7 +836,8 @@ void dt_styles_apply_style_item(dt_develop_t *dev,
       }
 
       if(do_merge)
-        dt_history_merge_module_into_history(dev, NULL, module, modules_used, append);
+        dt_history_merge_module_into_history
+          (dev, NULL, module, modules_used, append, FALSE);
     }
 
     if(module)

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1221,7 +1221,10 @@ void dt_dev_pop_history_items_ext(dt_develop_t *dev, int32_t cnt)
   for(int i = 0; i < cnt && history; i++)
   {
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
-    memcpy(hist->module->params, hist->params, hist->module->params_size);
+    if(hist->module->params_size == 0)
+      memcpy(hist->module->params, hist->module->default_params, hist->module->params_size);
+    else
+      memcpy(hist->module->params, hist->params, hist->module->params_size);
     dt_iop_commit_blend_params(hist->module, hist->blend_params);
 
     hist->module->iop_order = hist->iop_order;

--- a/src/gui/hist_dialog.c
+++ b/src/gui/hist_dialog.c
@@ -121,7 +121,9 @@ static void _gui_hist_copy_response(GtkDialog *dialog,
   }
 }
 
-static void _gui_hist_item_toggled(GtkCellRendererToggle *cell, gchar *path_str, gpointer data)
+static void _gui_hist_item_toggled(GtkCellRendererToggle *cell,
+                                   const gchar *path_str,
+                                   gpointer data)
 {
   dt_history_copy_item_t *d = (dt_history_copy_item_t *)data;
 
@@ -186,7 +188,9 @@ tree_on_row_activated(GtkTreeView        *treeview,
   }
 }
 
-int dt_gui_hist_dialog_new(dt_history_copy_item_t *d, const int imgid, const gboolean iscopy)
+int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
+                           const int imgid,
+                           const gboolean iscopy)
 {
   int res;
   GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
@@ -224,13 +228,15 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d, const int imgid, const gbo
   g_object_set_data(G_OBJECT(renderer), "column", (gint *)DT_HIST_ITEMS_COL_ENABLED);
   g_signal_connect(renderer, "toggled", G_CALLBACK(_gui_hist_item_toggled), d);
 
-  gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(d->items), -1, _("include"), renderer, "active",
-                                              DT_HIST_ITEMS_COL_ENABLED, NULL);
+  gtk_tree_view_insert_column_with_attributes
+    (GTK_TREE_VIEW(d->items), -1, _("include"), renderer, "active",
+     DT_HIST_ITEMS_COL_ENABLED, NULL);
 
   /* active */
   renderer = gtk_cell_renderer_pixbuf_new();
-  GtkTreeViewColumn *column = gtk_tree_view_column_new_with_attributes("", renderer, "pixbuf",
-                                                                       DT_HIST_ITEMS_COL_ISACTIVE, NULL);
+  GtkTreeViewColumn *column = gtk_tree_view_column_new_with_attributes
+    ("", renderer, "pixbuf",
+     DT_HIST_ITEMS_COL_ISACTIVE, NULL);
   gtk_tree_view_append_column(GTK_TREE_VIEW(d->items), column);
   gtk_tree_view_column_set_alignment(column, 0.5);
   gtk_tree_view_column_set_clickable(column, FALSE);
@@ -240,14 +246,18 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d, const int imgid, const gbo
   renderer = gtk_cell_renderer_text_new();
   g_object_set_data(G_OBJECT(renderer), "column", (gint *)DT_HIST_ITEMS_COL_NAME);
   g_object_set(renderer, "xalign", 0.0, (gchar *)0);
-  gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(d->items), -1, _("item"), renderer, "text",
-                                              DT_HIST_ITEMS_COL_NAME, NULL);
+  gtk_tree_view_insert_column_with_attributes
+    (GTK_TREE_VIEW(d->items), -1, _("item"), renderer, "text",
+     DT_HIST_ITEMS_COL_NAME, NULL);
 
-  gtk_tree_selection_set_mode(gtk_tree_view_get_selection(GTK_TREE_VIEW(d->items)), GTK_SELECTION_SINGLE);
+  gtk_tree_selection_set_mode(gtk_tree_view_get_selection(GTK_TREE_VIEW(d->items)),
+                              GTK_SELECTION_SINGLE);
   gtk_tree_view_set_model(GTK_TREE_VIEW(d->items), GTK_TREE_MODEL(liststore));
 
-  GdkPixbuf *is_active_pb = dt_draw_paint_to_pixbuf(GTK_WIDGET(dialog), 10, 0, dtgtk_cairo_paint_switch);
-  GdkPixbuf *is_inactive_pb = dt_draw_paint_to_pixbuf(GTK_WIDGET(dialog), 10, 0, dtgtk_cairo_paint_switch_inactive);
+  GdkPixbuf *is_active_pb =
+    dt_draw_paint_to_pixbuf(GTK_WIDGET(dialog), 10, 0, dtgtk_cairo_paint_switch);
+  GdkPixbuf *is_inactive_pb =
+    dt_draw_paint_to_pixbuf(GTK_WIDGET(dialog), 10, 0, dtgtk_cairo_paint_switch_inactive);
 
   /* fill list with history items */
   GList *items = dt_history_get_items(imgid, FALSE);
@@ -296,7 +306,8 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d, const int imgid, const gbo
     return GTK_RESPONSE_CANCEL;
   }
 
-  g_signal_connect(GTK_TREE_VIEW(d->items), "row-activated", (GCallback)tree_on_row_activated, GTK_WIDGET(dialog));
+  g_signal_connect(GTK_TREE_VIEW(d->items), "row-activated",
+                   (GCallback)tree_on_row_activated, GTK_WIDGET(dialog));
   g_object_unref(liststore);
 
   g_signal_connect(dialog, "response", G_CALLBACK(_gui_hist_copy_response), d);
@@ -306,7 +317,9 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d, const int imgid, const gbo
   while(1)
   {
     res = gtk_dialog_run(GTK_DIALOG(dialog));
-    if(res == GTK_RESPONSE_CANCEL || res == GTK_RESPONSE_DELETE_EVENT || res == GTK_RESPONSE_OK) break;
+    if(res == GTK_RESPONSE_CANCEL
+       || res == GTK_RESPONSE_DELETE_EVENT
+       || res == GTK_RESPONSE_OK) break;
   }
 
   gtk_widget_destroy(GTK_WIDGET(dialog));

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -116,26 +116,28 @@ void _gui_styles_get_active_items(dt_gui_styles_dialog_t *sd,
   GtkTreeIter iter;
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(sd->items));
   gint num = 0, update_num = 0;
-  gboolean active, uactive;
+  gboolean active, uactive, autoinit;
 
   if(gtk_tree_model_get_iter_first(model, &iter))
   {
     do
     {
-      gtk_tree_model_get(model, &iter, DT_STYLE_ITEMS_COL_ENABLED, &active,
+      gtk_tree_model_get(model, &iter,
+                         DT_STYLE_ITEMS_COL_ENABLED, &active,
                          DT_STYLE_ITEMS_COL_UPDATE, &uactive,
                          DT_STYLE_ITEMS_COL_NUM, &num,
                          DT_STYLE_ITEMS_COL_UPDATE_NUM, &update_num,
+                         DT_STYLE_ITEMS_COL_AUTOINIT, &autoinit,
                          -1);
       if((active || uactive) && num >= 0)
       {
-        *enabled = g_list_append(*enabled, GINT_TO_POINTER(num));
+        *enabled = g_list_append(*enabled, GINT_TO_POINTER(autoinit ? -num : num));
         if(update != NULL)
         {
           if(uactive)
             *update = g_list_append(*update, GINT_TO_POINTER(update_num));
           else
-            *update = g_list_append(*update, GINT_TO_POINTER(-1));
+            *update = g_list_append(*update, GINT_TO_POINTER(0));
         }
       }
     } while(gtk_tree_model_iter_next(model, &iter));
@@ -151,18 +153,19 @@ void _gui_styles_get_active_items(dt_gui_styles_dialog_t *sd,
                          DT_STYLE_ITEMS_COL_ENABLED, &active,
                          DT_STYLE_ITEMS_COL_NUM, &num,
                          DT_STYLE_ITEMS_COL_UPDATE_NUM, &update_num,
+                         DT_STYLE_ITEMS_COL_AUTOINIT, &autoinit,
                          -1);
       if(active)
       {
         if(update_num == -1) // item from style
         {
           *enabled = g_list_append(*enabled, GINT_TO_POINTER(num));
-          *update = g_list_append(*update, GINT_TO_POINTER(-1));
+          *update = g_list_append(*update, GINT_TO_POINTER(0));
         }
         else // item from image
         {
-          *update = g_list_append(*update, GINT_TO_POINTER(update_num));
-          *enabled = g_list_append(*enabled, GINT_TO_POINTER(-1));
+          *update = g_list_append(*update, GINT_TO_POINTER(autoinit ? -update_num : update_num));
+          *enabled = g_list_append(*enabled, GINT_TO_POINTER(0));
         }
       }
     } while(gtk_tree_model_iter_next(model, &iter));

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -581,7 +581,8 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
   gtk_cell_renderer_toggle_set_activatable(GTK_CELL_RENDERER_TOGGLE(renderer), TRUE);
   g_object_set_data(G_OBJECT(renderer), "column", (gint *)DT_STYLE_ITEMS_COL_ENABLED);
   g_signal_connect(renderer, "toggled", G_CALLBACK(_gui_styles_item_toggled), sd);
-  gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items), -1, _("include"),
+  gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items), -1,
+                                              edit ? _("keep") : _("include"),
                                               renderer, "active",
                                               DT_STYLE_ITEMS_COL_ENABLED, NULL);
 

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -50,6 +50,7 @@ typedef enum _style_items_columns_t
   DT_STYLE_ITEMS_COL_ENABLED = 0,
   DT_STYLE_ITEMS_COL_UPDATE,
   DT_STYLE_ITEMS_COL_ISACTIVE,
+  DT_STYLE_ITEMS_COL_AUTOINIT,
   DT_STYLE_ITEMS_COL_NAME,
   DT_STYLE_ITEMS_COL_NUM,
   DT_STYLE_ITEMS_COL_UPDATE_NUM,
@@ -359,6 +360,65 @@ static void _gui_styles_item_toggled(GtkCellRendererToggle *cell,
   gtk_tree_path_free(path);
 }
 
+static void _gui_styles_item_autoinit_toggled(GtkCellRendererToggle *cell,
+                                              gchar *path_str,
+                                              gpointer data)
+{
+  dt_gui_styles_dialog_t *sd = (dt_gui_styles_dialog_t *)data;
+
+  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(sd->items));
+  GtkTreePath *path = gtk_tree_path_new_from_string(path_str);
+  GtkTreeIter iter;
+  gboolean toggle_item;
+
+  gtk_tree_model_get_iter(model, &iter, path);
+  gtk_tree_model_get(model, &iter,
+                     DT_STYLE_ITEMS_COL_AUTOINIT,  &toggle_item,
+                     -1);
+
+  toggle_item = (toggle_item == TRUE) ? FALSE : TRUE;
+
+  gtk_list_store_set(GTK_LIST_STORE(model), &iter,
+                     DT_STYLE_ITEMS_COL_AUTOINIT, toggle_item, -1);
+
+  // auto-init (reset) is only meaningful if the module is also updated
+  if(toggle_item)
+    gtk_list_store_set(GTK_LIST_STORE(model), &iter,
+                       DT_STYLE_ITEMS_COL_ENABLED, !toggle_item,
+                       DT_STYLE_ITEMS_COL_UPDATE, toggle_item, -1);
+
+  gtk_tree_path_free(path);
+}
+
+static void _gui_styles_item_new_autoinit_toggled(GtkCellRendererToggle *cell,
+                                                  gchar *path_str,
+                                                  gpointer data)
+{
+  dt_gui_styles_dialog_t *sd = (dt_gui_styles_dialog_t *)data;
+
+  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(sd->items_new));
+  GtkTreePath *path = gtk_tree_path_new_from_string(path_str);
+  GtkTreeIter iter;
+  gboolean toggle_item;
+
+  gtk_tree_model_get_iter(model, &iter, path);
+  gtk_tree_model_get(model, &iter,
+                     DT_STYLE_ITEMS_COL_AUTOINIT,  &toggle_item,
+                     -1);
+
+  toggle_item = (toggle_item == TRUE) ? FALSE : TRUE;
+
+  gtk_list_store_set(GTK_LIST_STORE(model), &iter,
+                     DT_STYLE_ITEMS_COL_AUTOINIT, toggle_item, -1);
+
+  // auto-init (reset) is only meaningful if the module is also included
+  if(toggle_item)
+    gtk_list_store_set(GTK_LIST_STORE(model), &iter,
+                       DT_STYLE_ITEMS_COL_ENABLED, toggle_item, -1);
+
+  gtk_tree_path_free(path);
+}
+
 static void _gui_styles_item_new_toggled(GtkCellRendererToggle *cell,
                                          gchar *path_str,
                                          gpointer data)
@@ -377,6 +437,12 @@ static void _gui_styles_item_new_toggled(GtkCellRendererToggle *cell,
 
   gtk_list_store_set(GTK_LIST_STORE(model), &iter,
                      DT_STYLE_ITEMS_COL_ENABLED, toggle_item, -1);
+
+  // auto-init (reset) is only meaningful if the module is also included
+  if(!toggle_item)
+    gtk_list_store_set(GTK_LIST_STORE(model), &iter,
+                       DT_STYLE_ITEMS_COL_AUTOINIT, toggle_item, -1);
+
   gtk_tree_path_free(path);
 }
 
@@ -519,8 +585,19 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
                                               renderer, "active",
                                               DT_STYLE_ITEMS_COL_ENABLED, NULL);
 
+  /* auto-init */
+  renderer = gtk_cell_renderer_toggle_new();
+  gtk_cell_renderer_toggle_set_activatable(GTK_CELL_RENDERER_TOGGLE(renderer), TRUE);
+  g_object_set_data(G_OBJECT(renderer), "column", (gint *)DT_STYLE_ITEMS_COL_AUTOINIT);
+  g_signal_connect(renderer, "toggled",
+                   G_CALLBACK(_gui_styles_item_autoinit_toggled), sd);
+  gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items), -1, _("reset"),
+                                              renderer, "active",
+                                              DT_STYLE_ITEMS_COL_AUTOINIT, NULL);
+
   if(edit)
   {
+    /* include */
     renderer = gtk_cell_renderer_toggle_new();
     gtk_cell_renderer_toggle_set_activatable(GTK_CELL_RENDERER_TOGGLE(renderer), TRUE);
     g_object_set_data(G_OBJECT(renderer), "column", (gint *)DT_STYLE_ITEMS_COL_ENABLED);
@@ -528,6 +605,17 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
     gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items_new), -1,
                                                 _("include"), renderer,
                                                 "active", DT_STYLE_ITEMS_COL_ENABLED, NULL);
+
+    /* auto-init */
+    renderer = gtk_cell_renderer_toggle_new();
+    gtk_cell_renderer_toggle_set_activatable(GTK_CELL_RENDERER_TOGGLE(renderer), TRUE);
+    g_object_set_data(G_OBJECT(renderer), "column", (gint *)DT_STYLE_ITEMS_COL_AUTOINIT);
+    g_signal_connect(renderer, "toggled",
+                     G_CALLBACK(_gui_styles_item_new_autoinit_toggled), sd);
+    gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items_new), -1,
+                                                _("reset"),
+                                                renderer, "active",
+                                                DT_STYLE_ITEMS_COL_AUTOINIT, NULL);
   }
 
   /* update */
@@ -616,6 +704,7 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
           gtk_list_store_append(GTK_LIST_STORE(liststore), &iter);
           gtk_list_store_set(GTK_LIST_STORE(liststore), &iter,
                              DT_STYLE_ITEMS_COL_ENABLED,    TRUE,
+                             DT_STYLE_ITEMS_COL_AUTOINIT,   FALSE,
                              DT_STYLE_ITEMS_COL_UPDATE,     FALSE,
                              DT_STYLE_ITEMS_COL_ISACTIVE,   item->enabled ? is_active_pb : is_inactive_pb,
                              DT_STYLE_ITEMS_COL_NAME,       item->name,
@@ -630,6 +719,7 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
           gtk_list_store_append(GTK_LIST_STORE(liststore_new), &iter);
           gtk_list_store_set(GTK_LIST_STORE(liststore_new), &iter,
                              DT_STYLE_ITEMS_COL_ENABLED,    item->num != -1 ? TRUE : FALSE,
+                             DT_STYLE_ITEMS_COL_AUTOINIT,   FALSE,
                              DT_STYLE_ITEMS_COL_ISACTIVE,   item->enabled ? is_active_pb : is_inactive_pb,
                              DT_STYLE_ITEMS_COL_NAME,       item->name,
                              DT_STYLE_ITEMS_COL_NUM,        item->num,
@@ -677,12 +767,14 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
         }
 
         gtk_list_store_append(GTK_LIST_STORE(liststore), &iter);
-        gtk_list_store_set(GTK_LIST_STORE(liststore), &iter,
-                           DT_STYLE_ITEMS_COL_ENABLED,  enabled,
-                           DT_STYLE_ITEMS_COL_ISACTIVE, item->enabled ? is_active_pb : is_inactive_pb,
-                           DT_STYLE_ITEMS_COL_NAME,     item->name,
-                           DT_STYLE_ITEMS_COL_NUM,      item->num,
-                           -1);
+        gtk_list_store_set
+          (GTK_LIST_STORE(liststore), &iter,
+           DT_STYLE_ITEMS_COL_ENABLED,  enabled,
+           DT_STYLE_ITEMS_COL_AUTOINIT, FALSE,
+           DT_STYLE_ITEMS_COL_ISACTIVE, item->enabled ? is_active_pb : is_inactive_pb,
+           DT_STYLE_ITEMS_COL_NAME,     item->name,
+           DT_STYLE_ITEMS_COL_NUM,      item->num,
+           -1);
 
         has_item = TRUE;
       }

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -60,8 +60,9 @@ static int _single_selected_imgid()
 {
   int imgid = -1;
   sqlite3_stmt *stmt;
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT imgid FROM main.selected_images", -1, &stmt,
-                              NULL);
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "SELECT imgid FROM main.selected_images",
+                              -1, &stmt, NULL);
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
     if(imgid == -1)
@@ -85,7 +86,9 @@ static gboolean _gui_styles_is_copy_module_order_set(dt_gui_styles_dialog_t *d)
   gboolean active = FALSE;
   gint num = 0;
   if(gtk_tree_model_get_iter_first(model, &iter))
-    gtk_tree_model_get(model, &iter, DT_STYLE_ITEMS_COL_ENABLED, &active, DT_STYLE_ITEMS_COL_NUM, &num, -1);
+    gtk_tree_model_get(model, &iter,
+                       DT_STYLE_ITEMS_COL_ENABLED, &active,
+                       DT_STYLE_ITEMS_COL_NUM, &num, -1);
   return active && (num == -1);
 }
 
@@ -98,11 +101,15 @@ static gboolean _gui_styles_is_update_module_order_set(dt_gui_styles_dialog_t *d
   gboolean active = FALSE;
   gint num = 0;
   if(gtk_tree_model_get_iter_first(model, &iter))
-    gtk_tree_model_get(model, &iter, DT_STYLE_ITEMS_COL_UPDATE, &active, DT_STYLE_ITEMS_COL_NUM, &num, -1);
+    gtk_tree_model_get(model, &iter,
+                       DT_STYLE_ITEMS_COL_UPDATE, &active,
+                       DT_STYLE_ITEMS_COL_NUM, &num, -1);
   return active && (num == -1);
 }
 
-void _gui_styles_get_active_items(dt_gui_styles_dialog_t *sd, GList **enabled, GList **update)
+void _gui_styles_get_active_items(dt_gui_styles_dialog_t *sd,
+                                  GList **enabled,
+                                  GList **update)
 {
   /* run through all items and add active ones to result */
   GtkTreeIter iter;
@@ -161,7 +168,7 @@ void _gui_styles_get_active_items(dt_gui_styles_dialog_t *sd, GList **enabled, G
   }
 }
 
-static void _gui_styles_select_all_items(dt_gui_styles_dialog_t *d, gboolean active)
+static void _gui_styles_select_all_items(dt_gui_styles_dialog_t *d, const gboolean active)
 {
   /* run through all items and set active status */
   GtkTreeView *items = (d->duplicate) ? d->items_new : d->items;
@@ -176,7 +183,9 @@ static void _gui_styles_select_all_items(dt_gui_styles_dialog_t *d, gboolean act
   }
 }
 
-static void _gui_styles_new_style_response(GtkDialog *dialog, gint response_id, dt_gui_styles_dialog_t *g)
+static void _gui_styles_new_style_response(GtkDialog *dialog,
+                                           const gint response_id,
+                                           dt_gui_styles_dialog_t *g)
 {
   if(response_id == GTK_RESPONSE_YES)
   {
@@ -203,8 +212,9 @@ static void _gui_styles_new_style_response(GtkDialog *dialog, gint response_id, 
       if(name && (dt_styles_exists(name)) != 0)
       {
         /* on button yes delete style name for overwriting */
-        if(dt_gui_show_yes_no_dialog(_("overwrite style?"),
-                                     _("style `%s' already exists.\ndo you want to overwrite?"), name))
+        if(dt_gui_show_yes_no_dialog
+           (_("overwrite style?"),
+            _("style `%s' already exists.\ndo you want to overwrite?"), name))
         {
           dt_styles_delete_by_name(name);
         }
@@ -215,8 +225,11 @@ static void _gui_styles_new_style_response(GtkDialog *dialog, gint response_id, 
         }
       }
 
-      if(dt_styles_create_from_image(name, gtk_entry_get_text(GTK_ENTRY(g->description)),
-                                     g->imgid, result, _gui_styles_is_copy_module_order_set(g)))
+      if(dt_styles_create_from_image(name,
+                                     gtk_entry_get_text(GTK_ENTRY(g->description)),
+                                     g->imgid,
+                                     result,
+                                     _gui_styles_is_copy_module_order_set(g)))
       {
         dt_control_log(_("style named '%s' successfully created"), name);
       };
@@ -226,8 +239,11 @@ static void _gui_styles_new_style_response(GtkDialog *dialog, gint response_id, 
       /* show dialog if name is missing from entry */
       GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
       GtkWidget *dlg_changename
-                    = gtk_message_dialog_new(GTK_WINDOW(window), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_WARNING,
-                                             GTK_BUTTONS_OK, _("please give style a name"));
+                    = gtk_message_dialog_new(GTK_WINDOW(window),
+                                             GTK_DIALOG_DESTROY_WITH_PARENT,
+                                             GTK_MESSAGE_WARNING,
+                                             GTK_BUTTONS_OK,
+                                             _("please give style a name"));
 #ifdef GDK_WINDOWING_QUARTZ
       dt_osx_disallow_fullscreen(dlg_changename);
 #endif
@@ -242,7 +258,9 @@ static void _gui_styles_new_style_response(GtkDialog *dialog, gint response_id, 
   g_free(g);
 }
 
-static void _gui_styles_edit_style_response(GtkDialog *dialog, gint response_id, dt_gui_styles_dialog_t *g)
+static void _gui_styles_edit_style_response(GtkDialog *dialog,
+                                            const gint response_id,
+                                            dt_gui_styles_dialog_t *g)
 {
   if(response_id == GTK_RESPONSE_YES)
   {
@@ -266,15 +284,23 @@ static void _gui_styles_edit_style_response(GtkDialog *dialog, gint response_id,
     {
       if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->duplicate)))
       {
-        dt_styles_create_from_style(g->nameorig, name, gtk_entry_get_text(GTK_ENTRY(g->description)),
-                                    result, g->imgid, update,
+        dt_styles_create_from_style(g->nameorig,
+                                    name,
+                                    gtk_entry_get_text(GTK_ENTRY(g->description)),
+                                    result,
+                                    g->imgid,
+                                    update,
                                     _gui_styles_is_copy_module_order_set(g),
                                     _gui_styles_is_update_module_order_set(g));
       }
       else
       {
-        dt_styles_update(g->nameorig, name, gtk_entry_get_text(GTK_ENTRY(g->description)),
-                         result, g->imgid, update,
+        dt_styles_update(g->nameorig,
+                         name,
+                         gtk_entry_get_text(GTK_ENTRY(g->description)),
+                         result,
+                         g->imgid,
+                         update,
                          _gui_styles_is_copy_module_order_set(g),
                          _gui_styles_is_update_module_order_set(g));
       }
@@ -285,8 +311,11 @@ static void _gui_styles_edit_style_response(GtkDialog *dialog, gint response_id,
       /* show dialog if name is missing from entry */
       GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
       GtkWidget *dlg_changename
-                    = gtk_message_dialog_new(GTK_WINDOW(window), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_WARNING,
-                                             GTK_BUTTONS_OK, _("please give style a name"));
+                    = gtk_message_dialog_new(GTK_WINDOW(window),
+                                             GTK_DIALOG_DESTROY_WITH_PARENT,
+                                             GTK_MESSAGE_WARNING,
+                                             GTK_BUTTONS_OK,
+                                             _("please give style a name"));
 #ifdef GDK_WINDOWING_QUARTZ
       dt_osx_disallow_fullscreen(dlg_changename);
 #endif
@@ -301,7 +330,9 @@ static void _gui_styles_edit_style_response(GtkDialog *dialog, gint response_id,
   g_free(g);
 }
 
-static void _gui_styles_item_toggled(GtkCellRendererToggle *cell, gchar *path_str, gpointer data)
+static void _gui_styles_item_toggled(GtkCellRendererToggle *cell,
+                                     gchar *path_str,
+                                     gpointer data)
 {
   dt_gui_styles_dialog_t *sd = (dt_gui_styles_dialog_t *)data;
 
@@ -323,11 +354,14 @@ static void _gui_styles_item_toggled(GtkCellRendererToggle *cell, gchar *path_st
   if(update_num != -1 && toggle_item) // include so not updated
     gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_STYLE_ITEMS_COL_UPDATE, FALSE, -1);
 
-  gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_STYLE_ITEMS_COL_ENABLED, toggle_item, -1);
+  gtk_list_store_set(GTK_LIST_STORE(model), &iter,
+                     DT_STYLE_ITEMS_COL_ENABLED, toggle_item, -1);
   gtk_tree_path_free(path);
 }
 
-static void _gui_styles_item_new_toggled(GtkCellRendererToggle *cell, gchar *path_str, gpointer data)
+static void _gui_styles_item_new_toggled(GtkCellRendererToggle *cell,
+                                         gchar *path_str,
+                                         gpointer data)
 {
   dt_gui_styles_dialog_t *sd = (dt_gui_styles_dialog_t *)data;
 
@@ -341,11 +375,14 @@ static void _gui_styles_item_new_toggled(GtkCellRendererToggle *cell, gchar *pat
 
   toggle_item = (toggle_item == TRUE) ? FALSE : TRUE;
 
-  gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_STYLE_ITEMS_COL_ENABLED, toggle_item, -1);
+  gtk_list_store_set(GTK_LIST_STORE(model), &iter,
+                     DT_STYLE_ITEMS_COL_ENABLED, toggle_item, -1);
   gtk_tree_path_free(path);
 }
 
-static void _gui_styles_update_toggled(GtkCellRendererToggle *cell, gchar *path_str, gpointer data)
+static void _gui_styles_update_toggled(GtkCellRendererToggle *cell,
+                                       gchar *path_str,
+                                       gpointer data)
 {
   dt_gui_styles_dialog_t *sd = (dt_gui_styles_dialog_t *)data;
 
@@ -359,8 +396,10 @@ static void _gui_styles_update_toggled(GtkCellRendererToggle *cell, gchar *path_
 
   toggle_item = (toggle_item == TRUE) ? FALSE : TRUE;
 
-  gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_STYLE_ITEMS_COL_ENABLED, !toggle_item, -1);
-  gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_STYLE_ITEMS_COL_UPDATE, toggle_item, -1);
+  gtk_list_store_set(GTK_LIST_STORE(model), &iter,
+                     DT_STYLE_ITEMS_COL_ENABLED, !toggle_item, -1);
+  gtk_list_store_set(GTK_LIST_STORE(model), &iter,
+                     DT_STYLE_ITEMS_COL_UPDATE, toggle_item, -1);
   gtk_tree_path_free(path);
 }
 
@@ -419,8 +458,10 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
   GtkBox *box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
 
   GtkWidget *scroll = gtk_scrolled_window_new(NULL, NULL);
-  gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll), GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
-  gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(scroll), DT_PIXEL_APPLY_DPI(450));
+  gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll),
+                                 GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+  gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(scroll),
+                                             DT_PIXEL_APPLY_DPI(450));
 //  only available in 3.22, and not making the expected job anyway
 //  gtk_scrolled_window_set_max_content_height(GTK_SCROLLED_WINDOW(scroll), DT_PIXEL_APPLY_DPI(700));
 //  gtk_scrolled_window_set_propagate_natural_height(GTK_SCROLLED_WINDOW(scroll), TRUE);
@@ -460,20 +501,22 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
 
   /* create the list of items */
   sd->items = GTK_TREE_VIEW(gtk_tree_view_new());
-  GtkListStore *liststore = gtk_list_store_new(DT_STYLE_ITEMS_NUM_COLS, G_TYPE_BOOLEAN, G_TYPE_BOOLEAN,
-                                               GDK_TYPE_PIXBUF, G_TYPE_STRING, G_TYPE_INT, G_TYPE_INT);
+  GtkListStore *liststore = gtk_list_store_new(
+    DT_STYLE_ITEMS_NUM_COLS, G_TYPE_BOOLEAN, G_TYPE_BOOLEAN,
+    GDK_TYPE_PIXBUF, G_TYPE_BOOLEAN, G_TYPE_STRING, G_TYPE_INT, G_TYPE_INT);
 
   sd->items_new = GTK_TREE_VIEW(gtk_tree_view_new());
-  GtkListStore *liststore_new = gtk_list_store_new(DT_STYLE_ITEMS_NUM_COLS, G_TYPE_BOOLEAN, G_TYPE_STRING,
-                                                   GDK_TYPE_PIXBUF, G_TYPE_STRING, G_TYPE_INT, G_TYPE_INT);
+  GtkListStore *liststore_new = gtk_list_store_new
+    (DT_STYLE_ITEMS_NUM_COLS, G_TYPE_BOOLEAN, G_TYPE_STRING,
+      GDK_TYPE_PIXBUF, G_TYPE_BOOLEAN, G_TYPE_STRING, G_TYPE_INT, G_TYPE_INT);
 
   /* enabled */
   GtkCellRenderer *renderer = gtk_cell_renderer_toggle_new();
   gtk_cell_renderer_toggle_set_activatable(GTK_CELL_RENDERER_TOGGLE(renderer), TRUE);
   g_object_set_data(G_OBJECT(renderer), "column", (gint *)DT_STYLE_ITEMS_COL_ENABLED);
   g_signal_connect(renderer, "toggled", G_CALLBACK(_gui_styles_item_toggled), sd);
-
-  gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items), -1, _("include"), renderer, "active",
+  gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items), -1, _("include"),
+                                              renderer, "active",
                                               DT_STYLE_ITEMS_COL_ENABLED, NULL);
 
   if(edit)
@@ -482,7 +525,8 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
     gtk_cell_renderer_toggle_set_activatable(GTK_CELL_RENDERER_TOGGLE(renderer), TRUE);
     g_object_set_data(G_OBJECT(renderer), "column", (gint *)DT_STYLE_ITEMS_COL_ENABLED);
     g_signal_connect(renderer, "toggled", G_CALLBACK(_gui_styles_item_new_toggled), sd);
-    gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items_new), -1, _("include"), renderer,
+    gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items_new), -1,
+                                                _("include"), renderer,
                                                 "active", DT_STYLE_ITEMS_COL_ENABLED, NULL);
   }
 
@@ -494,14 +538,17 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
     g_object_set_data(G_OBJECT(renderer), "column", (gint *)DT_STYLE_ITEMS_COL_UPDATE);
     g_signal_connect(renderer, "toggled", G_CALLBACK(_gui_styles_update_toggled), sd);
 
-    gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items), -1, _("update"), renderer, "active",
+    gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items), -1,
+                                                _("update"), renderer, "active",
                                                 DT_STYLE_ITEMS_COL_UPDATE, NULL);
   }
 
   /* active */
   renderer = gtk_cell_renderer_pixbuf_new();
-  GtkTreeViewColumn *column = gtk_tree_view_column_new_with_attributes("", renderer, "pixbuf",
-                                                                       DT_STYLE_ITEMS_COL_ISACTIVE, NULL);
+  GtkTreeViewColumn *column = gtk_tree_view_column_new_with_attributes
+    ("", renderer,
+     "pixbuf",
+     DT_STYLE_ITEMS_COL_ISACTIVE, NULL);
   gtk_tree_view_append_column(GTK_TREE_VIEW(sd->items), column);
   gtk_tree_view_column_set_alignment(column, 0.5);
   gtk_tree_view_column_set_clickable(column, FALSE);
@@ -521,12 +568,14 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
   renderer = gtk_cell_renderer_text_new();
   g_object_set_data(G_OBJECT(renderer), "column", (gint *)DT_STYLE_ITEMS_COL_NAME);
   g_object_set(renderer, "xalign", 0.0, (gchar *)0);
-  gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items), -1, _("item"), renderer, "text",
+  gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items), -1,
+                                              _("item"), renderer, "text",
                                               DT_STYLE_ITEMS_COL_NAME, NULL);
 
   if(edit)
   {
-    gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items_new), -1, _("item"), renderer, "text",
+    gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items_new), -1,
+                                                _("item"), renderer, "text",
                                                 DT_STYLE_ITEMS_COL_NAME, NULL);
   }
 
@@ -619,7 +668,7 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
         if(modules)
         {
           GList *result = g_list_find_custom(
-              modules, item->op, _g_list_find_module_by_name); // (dt_iop_module_t *)(modules->data);
+              modules, item->op, _g_list_find_module_by_name);
           if(result)
           {
             module = (dt_iop_module_t *)(result->data);

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -129,7 +129,10 @@ dt_image_flags_t dt_imageio_get_type_from_extension(const char *extension)
 }
 
 // load a full-res thumbnail:
-int dt_imageio_large_thumbnail(const char *filename, uint8_t **buffer, int32_t *width, int32_t *height,
+int dt_imageio_large_thumbnail(const char *filename,
+                               uint8_t **buffer,
+                               int32_t *width,
+                               int32_t *height,
                                dt_colorspaces_color_profile_type_t *color_space)
 {
   int res = 1;
@@ -312,8 +315,14 @@ gboolean dt_imageio_has_mono_preview(const char *filename)
   return mono;
 }
 
-void dt_imageio_flip_buffers(char *out, const char *in, const size_t bpp, const int wd, const int ht,
-                             const int fwd, const int fht, const int stride,
+void dt_imageio_flip_buffers(char *out,
+                             const char *in,
+                             const size_t bpp,
+                             const int wd,
+                             const int ht,
+                             const int fwd,
+                             const int fht,
+                             const int stride,
                              const dt_image_orientation_t orientation)
 {
   if(!orientation)
@@ -363,9 +372,16 @@ void dt_imageio_flip_buffers(char *out, const char *in, const size_t bpp, const 
   }
 }
 
-void dt_imageio_flip_buffers_ui8_to_float(float *out, const uint8_t *in, const float black, const float white,
-                                          const int ch, const int wd, const int ht, const int fwd,
-                                          const int fht, const int stride,
+void dt_imageio_flip_buffers_ui8_to_float(float *out,
+                                          const uint8_t *in,
+                                          const float black,
+                                          const float white,
+                                          const int ch,
+                                          const int wd,
+                                          const int ht,
+                                          const int fwd,
+                                          const int fht,
+                                          const int stride,
                                           const dt_image_orientation_t orientation)
 {
   const float scale = 1.0f / (white - black);
@@ -419,8 +435,13 @@ void dt_imageio_flip_buffers_ui8_to_float(float *out, const uint8_t *in, const f
   }
 }
 
-size_t dt_imageio_write_pos(int i, int j, int wd, int ht, float fwd, float fht,
-                            dt_image_orientation_t orientation)
+size_t dt_imageio_write_pos(const int i,
+                            const int j,
+                            const int wd,
+                            const int ht,
+                            const float fwd,
+                            const float fht,
+                            const dt_image_orientation_t orientation)
 {
   int ii = i, jj = j, w = wd, fw = fwd, fh = fht;
   if(orientation & ORIENTATION_SWAP_XY)
@@ -436,7 +457,9 @@ size_t dt_imageio_write_pos(int i, int j, int wd, int ht, float fwd, float fht,
   return (size_t)jj * w + ii;
 }
 
-dt_imageio_retval_t dt_imageio_open_hdr(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf)
+dt_imageio_retval_t dt_imageio_open_hdr(dt_image_t *img,
+                                        const char *filename,
+                                        dt_mipmap_buffer_t *buf)
 {
   // if buf is NULL, don't proceed
   if(!buf) return DT_IMAGEIO_OK;
@@ -588,7 +611,9 @@ int dt_imageio_is_hdr(const char *filename)
 }
 
 // transparent read method to load ldr image to dt_raw_image_t with exif and so on.
-dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf)
+dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img,
+                                        const char *filename,
+                                        dt_mipmap_buffer_t *buf)
 {
   // if buf is NULL, don't proceed
   if(!buf) return DT_IMAGEIO_OK;
@@ -746,7 +771,7 @@ int dt_imageio_export_with_flags(const int32_t imgid,
                                  dt_imageio_module_storage_t *storage,
                                  dt_imageio_module_data_t *storage_params,
                                  int num,
-                                 int total,
+                                 const int total,
                                  dt_export_metadata_t *metadata,
                                  const int history_end)
 {
@@ -1311,9 +1336,14 @@ dt_imageio_retval_t dt_imageio_open(dt_image_t *img,        // non-const * means
   return ret;
 }
 
-gboolean dt_imageio_lookup_makermodel(const char *maker, const char *model,
-                                      char *mk, int mk_len, char *md, int md_len,
-                                      char *al, int al_len)
+gboolean dt_imageio_lookup_makermodel(const char *maker,
+                                      const char *model,
+                                      char *mk,
+                                      const int mk_len,
+                                      char *md,
+                                      const int md_len,
+                                      char *al,
+                                      const int al_len)
 {
   // At this stage, we can't tell which loader is used to open the image.
   gboolean found = dt_rawspeed_lookup_makermodel(maker, model,

--- a/src/imageio/imageio_common.h
+++ b/src/imageio/imageio_common.h
@@ -63,56 +63,109 @@ void dt_imageio_set_hdr_tag(dt_image_t *img);
 // Update the tag for b&w workflow
 void dt_imageio_update_monochrome_workflow_tag(int32_t id, int mask);
 // opens the file using pfm, hdr, exr.
-dt_imageio_retval_t dt_imageio_open_hdr(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf);
+dt_imageio_retval_t dt_imageio_open_hdr(dt_image_t *img,
+                                        const char *filename,
+                                        dt_mipmap_buffer_t *buf);
 // opens file using imagemagick
-dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf);
+dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img,
+                                        const char *filename,
+                                        dt_mipmap_buffer_t *buf);
 // try all the options in sequence
-dt_imageio_retval_t dt_imageio_open(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf);
+dt_imageio_retval_t dt_imageio_open(dt_image_t *img,
+                                    const char *filename,
+                                    dt_mipmap_buffer_t *buf);
 // tries to open the files not opened by the other routines using GraphicsMagick (if supported)
 dt_imageio_retval_t dt_imageio_open_exotic(dt_image_t *img, const char *filename,
                                            dt_mipmap_buffer_t *buf);
 
 struct dt_imageio_module_format_t;
 struct dt_imageio_module_data_t;
-int dt_imageio_export(const int32_t imgid, const char *filename, struct dt_imageio_module_format_t *format,
-                      struct dt_imageio_module_data_t *format_params, const gboolean high_quality,
-                      const gboolean upscale, const gboolean copy_metadata, const gboolean export_masks,
-                      dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
-                      dt_iop_color_intent_t icc_intent, dt_imageio_module_storage_t *storage,
-                      dt_imageio_module_data_t *storage_params, int num, int total, dt_export_metadata_t *metadata);
+int dt_imageio_export(const int32_t imgid,
+                      const char *filename,
+                      struct dt_imageio_module_format_t *format,
+                      struct dt_imageio_module_data_t *format_params,
+                      const gboolean high_quality,
+                      const gboolean upscale,
+                      const gboolean copy_metadata,
+                      const gboolean export_masks,
+                      dt_colorspaces_color_profile_type_t icc_type,
+                      const gchar *icc_filename,
+                      dt_iop_color_intent_t icc_intent,
+                      dt_imageio_module_storage_t *storage,
+                      dt_imageio_module_data_t *storage_params,
+                      int num,
+                      const int total,
+                      dt_export_metadata_t *metadata);
 
 int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
                                  struct dt_imageio_module_format_t *format,
-                                 struct dt_imageio_module_data_t *format_params, const gboolean ignore_exif,
-                                 const gboolean display_byteorder, const gboolean high_quality, const gboolean upscale, gboolean is_scaling,
-                                 const gboolean thumbnail_export, const char *filter, const gboolean copy_metadata,
-                                 const gboolean export_masks, dt_colorspaces_color_profile_type_t icc_type,
-                                 const gchar *icc_filename, dt_iop_color_intent_t icc_intent,
-                                 dt_imageio_module_storage_t *storage, dt_imageio_module_data_t *storage_params,
-                                 int num, int total, dt_export_metadata_t *metadata, const int history_end);
+                                 struct dt_imageio_module_data_t *format_params,
+                                 const gboolean ignore_exif,
+                                 const gboolean display_byteorder,
+                                 const gboolean high_quality,
+                                 const gboolean upscale,
+                                 const gboolean is_scaling,
+                                 const gboolean thumbnail_export,
+                                 const char *filter,
+                                 const gboolean copy_metadata,
+                                 const gboolean export_masks,
+                                 dt_colorspaces_color_profile_type_t icc_type,
+                                 const gchar *icc_filename,
+                                 dt_iop_color_intent_t icc_intent,
+                                 dt_imageio_module_storage_t *storage,
+                                 dt_imageio_module_data_t *storage_params,
+                                 int num,
+                                 const int total,
+                                 dt_export_metadata_t *metadata,
+                                 const int history_end);
 
-size_t dt_imageio_write_pos(int i, int j, int wd, int ht, float fwd, float fht,
-                            dt_image_orientation_t orientation);
+size_t dt_imageio_write_pos(const int i,
+                            const int j,
+                            const int wd,
+                            const int ht,
+                            const float fwd,
+                            const float fht,
+                            const dt_image_orientation_t orientation);
 
 // general, efficient buffer flipping function using memcopies
-void dt_imageio_flip_buffers(char *out, const char *in,
+void dt_imageio_flip_buffers(char *out,
+                             const char *in,
                              const size_t bpp, // bytes per pixel
-                             const int wd, const int ht, const int fwd, const int fht, const int stride,
+                             const int wd,
+                             const int ht,
+                             const int fwd,
+                             const int fht,
+                             const int stride,
                              const dt_image_orientation_t orientation);
 
-void dt_imageio_flip_buffers_ui8_to_float(float *out, const uint8_t *in, const float black, const float white,
-                                          const int ch, const int wd, const int ht, const int fwd,
-                                          const int fht, const int stride,
+void dt_imageio_flip_buffers_ui8_to_float(float *out,
+                                          const uint8_t *in,
+                                          const float black,
+                                          const float white,
+                                          const int ch,
+                                          const int wd,
+                                          const int ht,
+                                          const int fwd,
+                                          const int fht,
+                                          const int stride,
                                           const dt_image_orientation_t orientation);
 
 // allocate buffer and return 0 on success along with largest jpg thumbnail from raw.
-int dt_imageio_large_thumbnail(const char *filename, uint8_t **buffer, int32_t *width, int32_t *height,
+int dt_imageio_large_thumbnail(const char *filename,
+                               uint8_t **buffer,
+                               int32_t *width,
+                               int32_t *height,
                                dt_colorspaces_color_profile_type_t *color_space);
 
 // lookup maker and model, dispatch lookup to rawspeed or libraw
-gboolean dt_imageio_lookup_makermodel(const char *maker, const char *model,
-                                      char *mk, int mk_len, char *md, int md_len,
-                                      char *al, int al_len);
+gboolean dt_imageio_lookup_makermodel(const char *maker,
+                                      const char *model,
+                                      char *mk,
+                                      const int mk_len,
+                                      char *md,
+                                      const int md_len,
+                                      char *al,
+                                      const int al_len);
 
 // get the type of image from its extension
 dt_image_flags_t dt_imageio_get_type_from_extension(const char *extension);


### PR DESCRIPTION
Initial support of auto-init iop in style.
    
As for the copy/paste of auto-init iop we record the params as NULL
in the db and use the module's default params when the style item
is applied.

EDIT: This PR is build on top of the PR to support copy/paste with auto-init module, so it contains also the PR #13450.
