### PR TITLE
RFC: this PR deprecate levels & tonecurve as we have rgblevels & rgbcuvre

### DIFF
--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -104,6 +104,11 @@ typedef struct dt_iop_levels_global_data_t
 } dt_iop_levels_global_data_t;
 
 
+const char *deprecated_msg()
+{
+  return _("this module is deprecated. please use the RGB levels module instead.");
+}
+
 const char *name()
 {
   return _("levels");
@@ -116,7 +121,7 @@ int default_group()
 
 int flags()
 {
-  return IOP_FLAGS_SUPPORTS_BLENDING;
+  return IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_DEPRECATED;
 }
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
@@ -987,4 +992,3 @@ static void dt_iop_levels_autoadjust_callback(GtkRange *range, dt_iop_module_t *
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -185,6 +185,11 @@ typedef struct dt_iop_tonecurve_global_data_t
 } dt_iop_tonecurve_global_data_t;
 
 
+const char *deprecated_msg()
+{
+  return _("this module is deprecated. please use the RGB curve module instead.");
+}
+
 const char *name()
 {
   return _("tone curve");
@@ -197,7 +202,7 @@ int default_group()
 
 int flags()
 {
-  return IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING;
+  return IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_DEPRECATED;
 }
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
@@ -1797,4 +1802,3 @@ static gboolean dt_iop_tonecurve_button_press(GtkWidget *widget, GdkEventButton 
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1777,16 +1777,15 @@ void init_presets(dt_lib_module_t *self)
   SNQA();
   dt_lib_presets_add(_("search only"), self->plugin_name, self->version(), tx, strlen(tx), TRUE);
 
+  // DEACTIVATED : no more recently deprecated modules
+
   // this is a special preset for all newly deprecated modules
   // so users still have a chance to access them until next release (with warning messages)
   // this modules are deprecated in 3.4 and should be removed from this group in 3.8 (1 year later)
   SNQA();
   SMG(C_("modulegroup", "deprecated"), "basic");
-  // these modules are deprecated in 3.6 and should be removed in 4.0 (1 year later)
-  AM("spots");
-  AM("defringe");
-  // these modules are deprecated in 3.8 and should be removed in 4.1 (1 year later)
-  AM("clipping");
+  AM("levels");
+  AM("tonecurve");
 
   dt_lib_presets_add(_(DEPRECATED_PRESET_NAME), self->plugin_name, self->version(), tx, strlen(tx), TRUE);
 


### PR DESCRIPTION
We don't have recently deprecated modules. The last ones were deprecated on darktable 3.8.