### PR TITLE
RFC show ctrl+scroll tooltip for all resizable lists

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -759,6 +759,8 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget, gint x, gint y, gboolea
   }
   else
   {
+    if(g_object_get_data(G_OBJECT(widget), "scroll-resize-tooltip"))
+      original_markup = dt_util_dstrcat(original_markup, "%s%s", original_markup ? "\n" : "", _("ctrl+scroll to change height"));
     action = g_hash_table_lookup(darktable.control->widgets, widget);
     if(!action)
     {
@@ -781,8 +783,6 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget, gint x, gint y, gboolea
                                             _("scroll to change default speed"),
                                             _("right click to exit mapping mode"));
     }
-    else if(g_object_get_data(G_OBJECT(widget), "scroll-resize-tooltip"))
-      original_markup = dt_util_dstrcat(original_markup, "%s%s", original_markup ? "\n" : "", _("ctrl+scroll to change height"));
   }
 
   const dt_action_def_t *def = _action_find_definition(action);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3171,6 +3171,8 @@ static gboolean _resize_wrap_leave(GtkWidget *widget, GdkEventCrossing *event, c
 GtkWidget *dt_ui_resize_wrap(GtkWidget *w, gint min_size, char *config_str)
 {
   if(!w) w = dtgtk_drawing_area_new_with_aspect_ratio(1.0);
+  gtk_widget_set_has_tooltip(w, TRUE);
+  g_object_set_data(G_OBJECT(w), "scroll-resize-tooltip", GINT_TO_POINTER(TRUE));
   if(DTGTK_IS_DRAWING_AREA(w))
   {
     const float aspect = dt_conf_get_int(config_str);
@@ -3197,7 +3199,6 @@ GtkWidget *dt_ui_resize_wrap(GtkWidget *w, gint min_size, char *config_str)
   g_signal_connect(G_OBJECT(w), "button-press-event", G_CALLBACK(_resize_wrap_button), config_str);
   g_signal_connect(G_OBJECT(w), "button-release-event", G_CALLBACK(_resize_wrap_button), config_str);
   g_signal_connect(G_OBJECT(w), "leave-notify-event", G_CALLBACK(_resize_wrap_leave), config_str);
-  g_object_set_data(G_OBJECT(w), "scroll-resize-tooltip", GINT_TO_POINTER(TRUE));
 
   return w;
 }


### PR DESCRIPTION
Improves #13418 tooltip so that it shows whenever a list doesn't provide a custom per-item tooltip.

This adds "ctrl+scroll to change height" tooltips to styles, tags, metadata entries, history, duplicate etc lists.

Currently the tooltip doesn't mention dragging the bottom edge to resize. This might not be needed as it is somewhat intuitive and gives a visual hint when the mouse cursor passes over it. As opposed to ctrl+scroll which would otherwise be completely undiscoverable (but maybe now isn't needed anymore anyway). So two points for discussion:
- should the tooltip mention dragging and if so, how. Options:
   - ctrl+scroll or drag to change height
   - ctrl+scroll or drag bottom edge to change height
   - drag bottom edge to change height
   - remove line in tooltip completely
- Now that ctrl+scroll might not be used by many, could we change it to alt+shift+scroll, so that ctrl+scroll is freed up to consistently decrease the speed of adjustment (for example #13129 and https://github.com/darktable-org/darktable/pull/13469#issuecomment-1407753922)