### PR TITLE
deprecates levels & contrast brightness saturation

### DIFF
--- a/src/iop/colisa.c
+++ b/src/iop/colisa.c
@@ -74,6 +74,11 @@ typedef struct dt_iop_colisa_global_data_t
 } dt_iop_colisa_global_data_t;
 
 
+const char *deprecated_msg()
+{
+  return _("this module is deprecated. please use colorbalance RGB module instead.");
+}
+
 const char *name()
 {
   return _("contrast brightness saturation");
@@ -90,7 +95,8 @@ const char **description(struct dt_iop_module_t *self)
 
 int flags()
 {
-  return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING;
+  return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING
+    | IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_DEPRECATED;
 }
 
 int default_group()
@@ -309,4 +315,3 @@ void gui_init(struct dt_iop_module_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -104,6 +104,11 @@ typedef struct dt_iop_levels_global_data_t
 } dt_iop_levels_global_data_t;
 
 
+const char *deprecated_msg()
+{
+  return _("this module is deprecated. please use the RGB levels module instead.");
+}
+
 const char *name()
 {
   return _("levels");
@@ -116,7 +121,7 @@ int default_group()
 
 int flags()
 {
-  return IOP_FLAGS_SUPPORTS_BLENDING;
+  return IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_DEPRECATED;
 }
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
@@ -987,4 +992,3 @@ static void dt_iop_levels_autoadjust_callback(GtkRange *range, dt_iop_module_t *
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1782,11 +1782,9 @@ void init_presets(dt_lib_module_t *self)
   // this modules are deprecated in 3.4 and should be removed from this group in 3.8 (1 year later)
   SNQA();
   SMG(C_("modulegroup", "deprecated"), "basic");
-  // these modules are deprecated in 3.6 and should be removed in 4.0 (1 year later)
-  AM("spots");
-  AM("defringe");
-  // these modules are deprecated in 3.8 and should be removed in 4.1 (1 year later)
-  AM("clipping");
+  // these modules are deprecated in 4.4 and should be removed in 4.8 (1 year later)
+  AM("levels");
+  AM("colisa");
 
   dt_lib_presets_add(_(DEPRECATED_PRESET_NAME), self->plugin_name, self->version(), tx, strlen(tx), TRUE);
 


### PR DESCRIPTION
- levels use rgblevels instead
- ~~tonecurve use rgbcuvre instead~~
- contrast brightness saturation use colorbalance rgb instead 