### PR TITLE
po/lens clean up - use generic auto-init

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -145,13 +145,15 @@ void dt_history_delete_on_image_ext(const int32_t imgid, const gboolean undo)
   }
 }
 
-void dt_history_delete_on_image(int32_t imgid)
+void dt_history_delete_on_image(const int32_t imgid)
 {
   dt_history_delete_on_image_ext(imgid, TRUE);
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
 }
 
-int dt_history_load_and_apply(const int imgid, gchar *filename, int history_only)
+gboolean dt_history_load_and_apply(const int imgid,
+                                   gchar *filename,
+                                   const gboolean history_only)
 {
   dt_lock_image(imgid);
   dt_image_t *img = dt_image_cache_get(darktable.image_cache, imgid, 'w');
@@ -167,7 +169,7 @@ int dt_history_load_and_apply(const int imgid, gchar *filename, int history_only
                                    // ugly but if not history_only => called from crawler - do not write the xmp
                                    history_only ? DT_IMAGE_CACHE_SAFE : DT_IMAGE_CACHE_RELAXED);
       dt_unlock_image(imgid);
-      return 1;
+      return TRUE;
     }
     dt_history_snapshot_undo_create(hist->imgid, &hist->after, &hist->after_history_end);
     dt_undo_start_group(darktable.undo, DT_UNDO_LT_HISTORY);
@@ -187,24 +189,25 @@ int dt_history_load_and_apply(const int imgid, gchar *filename, int history_only
   dt_unlock_image(imgid);
   // signal that the mipmap need to be updated
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, imgid);
-  return 0;
+  return FALSE;
 }
 
-int dt_history_load_and_apply_on_list(gchar *filename, const GList *list)
+gboolean dt_history_load_and_apply_on_list(gchar *filename, const GList *list)
 {
-  int res = 0;
+  gboolean res = FALSE;
   dt_undo_start_group(darktable.undo, DT_UNDO_LT_HISTORY);
   for(GList *l = (GList *)list; l; l = g_list_next(l))
   {
     const int imgid = GPOINTER_TO_INT(l->data);
-    if(dt_history_load_and_apply(imgid, filename, 1)) res = 1;
+    if(dt_history_load_and_apply(imgid, filename, 1)) res = TRUE;
   }
   dt_undo_end_group(darktable.undo);
   return res;
 }
 
 // returns the first history item with hist->module == module
-static dt_dev_history_item_t *_search_history_by_module(dt_develop_t *dev, dt_iop_module_t *module)
+static dt_dev_history_item_t *_search_history_by_module(dt_develop_t *dev,
+                                                        const dt_iop_module_t *module)
 {
   dt_dev_history_item_t *hist_mod = NULL;
   for(GList *history = dev->history; history; history = g_list_next(history))
@@ -221,7 +224,8 @@ static dt_dev_history_item_t *_search_history_by_module(dt_develop_t *dev, dt_io
 }
 
 // returns the first history item with corresponding module->op
-static dt_dev_history_item_t *_search_history_by_op(dt_develop_t *dev, dt_iop_module_t *module)
+static dt_dev_history_item_t *_search_history_by_op(dt_develop_t *dev,
+                                                    const dt_iop_module_t *module)
 {
   dt_dev_history_item_t *hist_mod = NULL;
   for(GList *history = dev->history; history; history = g_list_next(history))
@@ -239,7 +243,8 @@ static dt_dev_history_item_t *_search_history_by_op(dt_develop_t *dev, dt_iop_mo
 
 // returns the module on modules_list that is equal to module
 // used to check if module exists on the list
-static dt_iop_module_t *_search_list_iop_by_module(GList *modules_list, dt_iop_module_t *module)
+static dt_iop_module_t *_search_list_iop_by_module(GList *modules_list,
+                                                   const dt_iop_module_t *module)
 {
   dt_iop_module_t *mod_ret = NULL;
   for(GList *modules = modules_list; modules; modules = g_list_next(modules))
@@ -256,7 +261,7 @@ static dt_iop_module_t *_search_list_iop_by_module(GList *modules_list, dt_iop_m
 }
 
 // fills used with formid, if it is a group it recurs and fill all sub-forms
-static void _fill_used_forms(GList *forms_list, int formid, int *used, int nb)
+static void _fill_used_forms(GList *forms_list, const int formid, int *used, const int nb)
 {
   // first, we search for the formid in used table
   for(int i = 0; i < nb; i++)
@@ -283,13 +288,14 @@ static void _fill_used_forms(GList *forms_list, int formid, int *used, int nb)
 }
 
 // dev_src is used only to copy masks, if no mask will be copied it can be null
-int dt_history_merge_module_into_history(dt_develop_t *dev_dest,
-                                         dt_develop_t *dev_src,
-                                         dt_iop_module_t *mod_src,
-                                         GList **_modules_used,
-                                         const int append)
+gboolean dt_history_merge_module_into_history(dt_develop_t *dev_dest,
+                                              dt_develop_t *dev_src,
+                                              dt_iop_module_t *mod_src,
+                                              GList **_modules_used,
+                                              const gboolean append,
+                                              const gboolean auto_init)
 {
-  int module_added = 1;
+  gboolean module_added = TRUE;
   GList *modules_used = *_modules_used;
   dt_iop_module_t *module = NULL;
   dt_iop_module_t *mod_replace = NULL;
@@ -309,7 +315,7 @@ int dt_history_merge_module_into_history(dt_develop_t *dev_dest,
     {
       fprintf(stderr, "[dt_history_merge_module_into_history] can't find single instance module %s\n",
               mod_src->op);
-      module_added = 0;
+      module_added = FALSE;
     }
   }
 
@@ -356,7 +362,7 @@ int dt_history_merge_module_into_history(dt_develop_t *dev_dest,
       if(mod_replace == NULL)
       {
         fprintf(stderr, "[dt_history_merge_module_into_history] can't find base instance module %s\n", mod_src->op);
-        module_added = 0;
+        module_added = FALSE;
       }
     }
   }
@@ -371,7 +377,7 @@ int dt_history_merge_module_into_history(dt_develop_t *dev_dest,
       if(dt_iop_load_module(module, base->so, dev_dest))
       {
         fprintf(stderr, "[dt_history_merge_module_into_history] can't load module %s\n", mod_src->op);
-        module_added = 0;
+        module_added = FALSE;
       }
       else
       {
@@ -389,7 +395,14 @@ int dt_history_merge_module_into_history(dt_develop_t *dev_dest,
     module->enabled = mod_src->enabled;
     g_strlcpy(module->multi_name, modsrc_multi_name, sizeof(module->multi_name));
 
-    memcpy(module->params, mod_src->params, module->params_size);
+    if(auto_init)
+    {
+      module->params = NULL;
+      module->params_size = 0;
+    }
+    else
+      memcpy(module->params, mod_src->params, module->params_size);
+
     if(module->flags() & IOP_FLAGS_SUPPORTS_BLENDING)
     {
       memcpy(module->blend_params, mod_src->blend_params, sizeof(dt_develop_blend_params_t));
@@ -535,6 +548,7 @@ static int _history_copy_and_paste_on_image_merge(const int32_t imgid,
   dt_ioppr_check_iop_order(dev_dest, dest_imgid, "_history_copy_and_paste_on_image_merge 1");
 
   GList *mod_list = NULL;
+  GList *autoinit_list = NULL;
 
   if(ops)
   {
@@ -542,18 +556,21 @@ static int _history_copy_and_paste_on_image_merge(const int32_t imgid,
     // copy only selected history entries
     for(const GList *l = g_list_last(ops); l; l = g_list_previous(l))
     {
-      const unsigned int num = GPOINTER_TO_UINT(l->data);
+      const int num = GPOINTER_TO_INT(l->data);
+      const gboolean autoinit = (num < 0);
 
-      const dt_dev_history_item_t *hist = g_list_nth_data(dev_src->history, num);
+      const dt_dev_history_item_t *hist = g_list_nth_data(dev_src->history, abs(num));
 
       if(hist)
       {
         if(!dt_iop_is_hidden(hist->module))
         {
           if(DT_IOP_ORDER_INFO)
-            fprintf(stderr,"\n  module %20s, multiprio %i",  hist->module->op, hist->module->multi_priority);
+            fprintf(stderr,"\n  module %20s, multiprio %i",
+                    hist->module->op, hist->module->multi_priority);
 
           mod_list = g_list_prepend(mod_list, hist->module);
+          autoinit_list = g_list_prepend(autoinit_list, GINT_TO_POINTER(autoinit));
         }
       }
     }
@@ -562,7 +579,9 @@ static int _history_copy_and_paste_on_image_merge(const int32_t imgid,
   {
     if(DT_IOP_ORDER_INFO) fprintf(stderr," all modules");
     // we will copy all modules
-    for(GList *modules_src = dev_src->iop; modules_src; modules_src = g_list_next(modules_src))
+    for(GList *modules_src = dev_src->iop;
+        modules_src;
+        modules_src = g_list_next(modules_src))
     {
       dt_iop_module_t *mod_src = (dt_iop_module_t *)(modules_src->data);
 
@@ -580,15 +599,21 @@ static int _history_copy_and_paste_on_image_merge(const int32_t imgid,
   }
   if(DT_IOP_ORDER_INFO) fprintf(stderr,"\nvvvvv\n");
 
-  mod_list = g_list_reverse(mod_list);   // list was built in reverse order, so un-reverse it
+  // list were built in reverse order, so un-reverse it
+  mod_list = g_list_reverse(mod_list);
+  autoinit_list = g_list_reverse(autoinit_list);
 
   // update iop-order list to have entries for the new modules
   dt_ioppr_update_for_modules(dev_dest, mod_list, FALSE);
 
+  GList *ai = autoinit_list;
+
   for(GList *l = mod_list; l; l = g_list_next(l))
   {
     dt_iop_module_t *mod = (dt_iop_module_t *)l->data;
-    dt_history_merge_module_into_history(dev_dest, dev_src, mod, &modules_used, FALSE);
+    const gboolean autoinit = GPOINTER_TO_INT(ai->data);
+    dt_history_merge_module_into_history
+      (dev_dest, dev_src, mod, &modules_used, FALSE, autoinit);
   }
 
   // update iop-order list to have entries for the new modules
@@ -602,7 +627,9 @@ static int _history_copy_and_paste_on_image_merge(const int32_t imgid,
   dt_dev_cleanup(dev_src);
   dt_dev_cleanup(dev_dest);
 
+  g_list_free(mod_list);
   g_list_free(modules_used);
+  g_list_free(autoinit_list);
 
   return 0;
 }

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -62,29 +62,30 @@ typedef struct dt_history_copy_item_t
 void dt_history_item_free(gpointer data);
 
 /** adds to dev_dest module mod_src */
-int dt_history_merge_module_into_history(struct dt_develop_t *dev_dest,
-                                         struct dt_develop_t *dev_src,
-                                         struct dt_iop_module_t *mod_src,
-                                         GList **_modules_used,
-                                         const int append);
+gboolean dt_history_merge_module_into_history(struct dt_develop_t *dev_dest,
+                                              struct dt_develop_t *dev_src,
+                                              struct dt_iop_module_t *mod_src,
+                                              GList **_modules_used,
+                                              const gboolean append,
+                                              const gboolean auto_init);
 
 /** copy history from imgid and pasts on dest_imgid, merge or overwrite... */
-int dt_history_copy_and_paste_on_image(const int32_t imgid,
-                                       const int32_t dest_imgid,
-                                       const gboolean merge,
-                                       GList *ops,
-                                       const gboolean copy_iop_order,
-                                       const gboolean copy_full);
+gboolean dt_history_copy_and_paste_on_image(const int32_t imgid,
+                                            const int32_t dest_imgid,
+                                            const gboolean merge,
+                                            GList *ops,
+                                            const gboolean copy_iop_order,
+                                            const gboolean copy_full);
 
 /** delete all history for the given image */
-void dt_history_delete_on_image(int32_t imgid);
+void dt_history_delete_on_image(const int32_t imgid);
 
 /** as above but control whether to record undo/redo */
-void dt_history_delete_on_image_ext(int32_t imgid, gboolean undo);
+void dt_history_delete_on_image_ext(const int32_t imgid, const gboolean undo);
 
 /** copy history from imgid and pasts on selected images, merge or overwrite... */
-gboolean dt_history_copy(int imgid);
-gboolean dt_history_copy_parts(int imgid);
+gboolean dt_history_copy(const int imgid);
+gboolean dt_history_copy_parts(const int imgid);
 gboolean dt_history_paste_on_list(const GList *list, gboolean undo);
 gboolean dt_history_paste_parts_on_list(const GList *list, gboolean undo);
 
@@ -94,13 +95,15 @@ static inline gboolean dt_history_module_skip_copy(const int flags)
 }
 
 /** load a dt file and applies to selected images */
-int dt_history_load_and_apply_on_list(gchar *filename, const GList *list);
+gboolean dt_history_load_and_apply_on_list(gchar *filename, const GList *list);
 
 /** load a dt file and applies to specified image */
-int dt_history_load_and_apply(int imgid, gchar *filename, int history_only);
+gboolean dt_history_load_and_apply(const int imgid,
+                                   gchar *filename,
+                                   const gboolean history_only);
 
 /** delete historystack of selected images */
-gboolean dt_history_delete_on_list(const GList *list, gboolean undo);
+gboolean dt_history_delete_on_list(const GList *list, const gboolean undo);
 
 /** compress history stack */
 int dt_history_compress_on_list(const GList *imgs);

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2018-2022 darktable developers.
+    Copyright (C) 2018-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -490,7 +490,9 @@ GList *dt_ioppr_get_iop_order_rules()
   return g_list_reverse(rules);  // list was built in reverse order, so un-reverse it
 }
 
-GList *dt_ioppr_get_iop_order_link(GList *iop_order_list, const char *op_name, const int multi_priority)
+GList *dt_ioppr_get_iop_order_link(GList *iop_order_list,
+                                   const char *op_name,
+                                   const int multi_priority)
 {
   GList *link = NULL;
 
@@ -522,7 +524,9 @@ dt_iop_order_entry_t *dt_ioppr_get_iop_order_entry(GList *iop_order_list,
 }
 
 // returns the iop_order associated with the iop order entry that matches operation == op_name
-int dt_ioppr_get_iop_order(GList *iop_order_list, const char *op_name, const int multi_priority)
+int dt_ioppr_get_iop_order(GList *iop_order_list,
+                           const char *op_name,
+                           const int multi_priority)
 {
   int iop_order = INT_MAX;
   const dt_iop_order_entry_t *const restrict order_entry =
@@ -667,7 +671,8 @@ gboolean dt_ioppr_has_multiple_instances(GList *iop_order_list)
   return FALSE;
 }
 
-GList *dt_ioppr_get_multiple_instances_iop_order_list(int32_t imgid, gboolean memory)
+GList *dt_ioppr_get_multiple_instances_iop_order_list(const int32_t imgid,
+                                                      const gboolean memory)
 {
   GList *res = NULL;
   sqlite3_stmt *stmt = NULL;
@@ -716,9 +721,10 @@ gboolean dt_ioppr_write_iop_order(const dt_iop_order_t kind,
 {
   sqlite3_stmt *stmt;
 
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "INSERT OR REPLACE INTO main.module_order VALUES (?1, 0, NULL)", -1,
-                              &stmt, NULL);
+  DT_DEBUG_SQLITE3_PREPARE_V2
+    (dt_database_get(darktable.db),
+     "INSERT OR REPLACE INTO main.module_order VALUES (?1, 0, NULL)", -1,
+     &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
   if(sqlite3_step(stmt) != SQLITE_DONE) return FALSE;
   sqlite3_finalize(stmt);
@@ -726,9 +732,12 @@ gboolean dt_ioppr_write_iop_order(const dt_iop_order_t kind,
   if(kind == DT_IOP_ORDER_CUSTOM || dt_ioppr_has_multiple_instances(iop_order_list))
   {
     gchar *iop_list_txt = dt_ioppr_serialize_text_iop_order_list(iop_order_list);
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                "UPDATE main.module_order SET version = ?2, iop_list = ?3 WHERE imgid = ?1", -1,
-                                &stmt, NULL);
+    DT_DEBUG_SQLITE3_PREPARE_V2
+      (dt_database_get(darktable.db),
+       "UPDATE main.module_order"
+       " SET version = ?2, iop_list = ?3"
+       " WHERE imgid = ?1", -1,
+       &stmt, NULL);
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, kind);
     DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 3, iop_list_txt, -1, SQLITE_TRANSIENT);
@@ -740,7 +749,9 @@ gboolean dt_ioppr_write_iop_order(const dt_iop_order_t kind,
   else
   {
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                "UPDATE main.module_order SET version = ?2, iop_list = NULL WHERE imgid = ?1", -1,
+                                "UPDATE main.module_order"
+                                " SET version = ?2, iop_list = NULL"
+                                " WHERE imgid = ?1", -1,
                                 &stmt, NULL);
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, kind);
@@ -995,7 +1006,9 @@ void dt_ioppr_migrate_iop_order(struct dt_develop_t *dev, const int32_t imgid)
   dt_dev_reload_history_items(dev);
 }
 
-void dt_ioppr_change_iop_order(struct dt_develop_t *dev, const int32_t imgid, GList *new_iop_list)
+void dt_ioppr_change_iop_order(struct dt_develop_t *dev,
+                               const int32_t imgid,
+                               GList *new_iop_list)
 {
   GList *iop_list = dt_ioppr_iop_order_copy_deep(new_iop_list);
   GList *mi = dt_ioppr_extract_multi_instances_list(darktable.develop->iop_order_list);
@@ -1128,8 +1141,8 @@ GList *dt_ioppr_merge_multi_instance_iop_order_list(GList *iop_order_list,
   return iop_order_list;
 }
 
-static void _count_iop_module(GList *iop, const
-                              char *operation,
+static void _count_iop_module(GList *iop,
+                              const char *operation,
                               int *max_multi_priority,
                               int *count,
                               int *max_multi_priority_enabled,
@@ -1204,7 +1217,9 @@ int _get_multi_priority(dt_develop_t *dev,
   return INT_MAX;
 }
 
-void dt_ioppr_update_for_entries(dt_develop_t *dev, GList *entry_list, const gboolean append)
+void dt_ioppr_update_for_entries(dt_develop_t *dev,
+                                 GList *entry_list,
+                                 const gboolean append)
 {
   // for each priority list to be checked
   for(GList *e_list = entry_list; e_list; e_list = g_list_next(e_list))
@@ -1299,7 +1314,9 @@ void dt_ioppr_update_for_entries(dt_develop_t *dev, GList *entry_list, const gbo
 //  dt_ioppr_print_iop_order(dev->iop_order_list, "upd sitem");
 }
 
-void dt_ioppr_update_for_style_items(dt_develop_t *dev, GList *st_items, const gboolean append)
+void dt_ioppr_update_for_style_items(dt_develop_t *dev,
+                                     GList *st_items,
+                                     const gboolean append)
 {
   GList *e_list = NULL;
 
@@ -1308,13 +1325,23 @@ void dt_ioppr_update_for_style_items(dt_develop_t *dev, GList *st_items, const g
   {
     const dt_style_item_t *const restrict si = (dt_style_item_t *)si_list->data;
 
-    dt_iop_order_entry_t *n = (dt_iop_order_entry_t *)malloc(sizeof(dt_iop_order_entry_t));
-    memcpy(n->operation, si->operation, sizeof(n->operation));
-    n->instance = si->multi_priority;
-    g_strlcpy(n->name, si->multi_name, sizeof(n->name));
-    n->o.iop_order = 0;
-    e_list = g_list_prepend(e_list, n);
+    /* check for an auto-init module, such module is meant to reset (so replace)
+       and existing instance. We do not want to add a new iop-order in the list
+       for such module. */
+    if(si->params_size > 0)
+    {
+      dt_iop_order_entry_t *n = (dt_iop_order_entry_t *)malloc(sizeof(dt_iop_order_entry_t));
+      memcpy(n->operation, si->operation, sizeof(n->operation));
+      n->instance = si->multi_priority;
+      g_strlcpy(n->name, si->multi_name, sizeof(n->name));
+      n->o.iop_order = 0;
+      e_list = g_list_prepend(e_list, n);
+    }
   }
+
+  // only auto-init modules, nothing else to do
+  if(!e_list) return;
+
   e_list = g_list_reverse(e_list);  // list was built in reverse order, so un-reverse it
 
   dt_ioppr_update_for_entries(dev, e_list, append);
@@ -1325,17 +1352,23 @@ void dt_ioppr_update_for_style_items(dt_develop_t *dev, GList *st_items, const g
   for(const GList *si_list = st_items; si_list; si_list = g_list_next(si_list))
   {
     dt_style_item_t *si = (dt_style_item_t *)si_list->data;
-    const dt_iop_order_entry_t *const restrict e = (dt_iop_order_entry_t *)el->data;
 
-    si->multi_priority = e->instance;
-    si->iop_order = dt_ioppr_get_iop_order(dev->iop_order_list, si->operation, si->multi_priority);
-    el = g_list_next(el);
+    if(si->params_size > 0)
+    {
+      const dt_iop_order_entry_t *const restrict e = (dt_iop_order_entry_t *)el->data;
+
+      si->multi_priority = e->instance;
+      si->iop_order = dt_ioppr_get_iop_order(dev->iop_order_list, si->operation, si->multi_priority);
+      el = g_list_next(el);
+    }
   }
 
   g_list_free(e_list);
 }
 
-void dt_ioppr_update_for_modules(dt_develop_t *dev, GList *modules, const gboolean append)
+void dt_ioppr_update_for_modules(dt_develop_t *dev,
+                                 GList *modules,
+                                 const gboolean append)
 {
   GList *e_list = NULL;
 
@@ -1989,7 +2022,9 @@ void dt_ioppr_insert_module_instance(struct dt_develop_t *dev, dt_iop_module_t *
   dev->iop_order_list = g_list_insert_before(dev->iop_order_list, place, entry);
 }
 
-int dt_ioppr_check_iop_order(dt_develop_t *dev, const int imgid, const char *msg)
+int dt_ioppr_check_iop_order(dt_develop_t *dev,
+                             const int imgid,
+                             const char *msg)
 {
   int iop_order_ok = 1;
 

--- a/src/common/iop_order.h
+++ b/src/common/iop_order.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2018-2022 darktable developers.
+    Copyright (C) 2018-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by
@@ -166,10 +166,11 @@ dt_iop_order_t dt_ioppr_get_iop_order_version(const int32_t imgid);
 dt_iop_order_t dt_ioppr_get_iop_order_list_kind(GList *iop_order_list);
 
 /** returns true if imgid has an iop-order set */
-gboolean dt_ioppr_has_iop_order_list(int32_t imgid);
+gboolean dt_ioppr_has_iop_order_list(const int32_t imgid);
 
 /** returns a list of dt_iop_order_entry_t and updates *_version */
-GList *dt_ioppr_get_iop_order_list(int32_t imgid, gboolean sorted);
+GList *dt_ioppr_get_iop_order_list(const int32_t imgid,
+                                   const gboolean sorted);
 /** return the iop-order list for the given version, this is used to get the built-in lists */
 GList *dt_ioppr_get_iop_order_list_version(dt_iop_order_t version);
 /** returns the dt_iop_order_entry_t of iop_order_list with operation = op_name */
@@ -186,12 +187,17 @@ gboolean dt_ioppr_has_multiple_instances(GList *iop_order_list);
 GList *dt_ioppr_get_multiple_instances_iop_order_list(int32_t imgid, gboolean memory);
 
 /** returns the iop_order from iop_order_list list with operation = op_name */
-int dt_ioppr_get_iop_order(GList *iop_order_list, const char *op_name, const int multi_priority);
+int dt_ioppr_get_iop_order(GList *iop_order_list,
+                           const char *op_name,
+                           const int multi_priority);
 /** returns TRUE if operation/multi-priority is before base_operation (first in pipe) on the iop-list */
-gboolean dt_ioppr_is_iop_before(GList *iop_order_list, const char *base_operation,
-                                const char *operation, const int multi_priority);
+gboolean dt_ioppr_is_iop_before(GList *iop_order_list,
+                                const char *base_operation,
+                                const char *operation,
+                                const int multi_priority);
 /* write iop-order list for the given image */
-gboolean dt_ioppr_write_iop_order_list(GList *iop_order_list, const int32_t imgid);
+gboolean dt_ioppr_write_iop_order_list(GList *iop_order_list,
+                                       const int32_t imgid);
 gboolean dt_ioppr_write_iop_order(const dt_iop_order_t kind,
                                   GList *iop_order_list,
                                   const int32_t imgid);
@@ -205,15 +211,22 @@ char *dt_ioppr_serialize_text_iop_order_list(GList *iop_order_list);
 GList *dt_ioppr_deserialize_text_iop_order_list(const char *buf);
 
 /** insert a match for module into the iop-order list */
-void dt_ioppr_insert_module_instance(struct dt_develop_t *dev, struct dt_iop_module_t *module);
+void dt_ioppr_insert_module_instance(struct dt_develop_t *dev,
+                                     struct dt_iop_module_t *module);
 void dt_ioppr_resync_modules_order(struct dt_develop_t *dev);
 void dt_ioppr_resync_iop_list(struct dt_develop_t *dev);
 
 /** update target_iop_order_list to ensure that modules in iop_order_list are in target_iop_order_list
     note that iop_order_list contains a set of dt_iop_order_entry_t where order is the multi-priority */
-void dt_ioppr_update_for_entries(struct dt_develop_t *dev, GList *entry_list, const gboolean append);
-void dt_ioppr_update_for_style_items(struct dt_develop_t *dev, GList *st_items, const gboolean append);
-void dt_ioppr_update_for_modules(struct dt_develop_t *dev, GList *modules, const gboolean append);
+void dt_ioppr_update_for_entries(struct dt_develop_t *dev,
+                                 GList *entry_list,
+                                 const gboolean append);
+void dt_ioppr_update_for_style_items(struct dt_develop_t *dev,
+                                     GList *st_items,
+                                     const gboolean append);
+void dt_ioppr_update_for_modules(struct dt_develop_t *dev,
+                                 GList *modules,
+                                 const gboolean append);
 
 /** check if there's duplicate iop_order entries in iop_list */
 void dt_ioppr_check_duplicate_iop_order(GList **_iop_list, GList *history_list);

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -754,7 +754,9 @@ void dt_styles_apply_style_item(dt_develop_t *dev,
     if(dt_iop_load_module(module, mod_src->so, dev))
     {
       module = NULL;
-      fprintf(stderr, "[dt_styles_apply_style_item] can't load module %s %s\n", style_item->operation,
+      fprintf(stderr,
+              "[dt_styles_apply_style_item] can't load module %s %s\n",
+              style_item->operation,
               style_item->multi_name);
     }
     else
@@ -834,7 +836,8 @@ void dt_styles_apply_style_item(dt_develop_t *dev,
       }
 
       if(do_merge)
-        dt_history_merge_module_into_history(dev, NULL, module, modules_used, append);
+        dt_history_merge_module_into_history
+          (dev, NULL, module, modules_used, append, FALSE);
     }
 
     if(module)

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -290,27 +290,37 @@ static void _dt_style_update_from_image(const int id,
 
     do
     {
+      const int item_included = GPOINTER_TO_INT(list->data);
+      const int item_updated = GPOINTER_TO_INT(upd->data);
+      const gboolean autoinit = item_updated < 0;
+
       query[0] = '\0';
 
       // included and update set, we then need to update the corresponding style item
-      if(GPOINTER_TO_INT(upd->data) != -1 && GPOINTER_TO_INT(list->data) != -1)
+      if(item_updated != 0 && item_included != 0)
       {
         g_strlcpy(query, "UPDATE data.style_items SET ", sizeof(query));
 
         for(int k = 0; fields[k]; k++)
         {
-          if(k != 0) g_strlcat(query, ",", sizeof(query));
-          snprintf(tmp, sizeof(tmp),
-                   "%s=(SELECT %s FROM main.history WHERE imgid=%d AND num=%d)",
-                   fields[k], fields[k], imgid, GPOINTER_TO_INT(upd->data));
+          if(autoinit && k==0)
+            snprintf(tmp, sizeof(tmp), "%s=NULL", fields[k]);
+          else
+          {
+            if(k != 0) g_strlcat(query, ",", sizeof(query));
+            snprintf(tmp, sizeof(tmp),
+                     "%s=(SELECT %s FROM main.history WHERE imgid=%d AND num=%d)",
+                     fields[k], fields[k], imgid, abs(item_updated));
+          }
           g_strlcat(query, tmp, sizeof(query));
         }
         snprintf(tmp, sizeof(tmp), " WHERE styleid=%d AND data.style_items.num=%d", id,
-                 GPOINTER_TO_INT(list->data));
+                 item_included);
         g_strlcat(query, tmp, sizeof(query));
       }
       // update only, so we want to insert the new style item
-      else if(GPOINTER_TO_INT(upd->data) != -1)
+      else if(item_updated != 0)
+      {
         // clang-format off
         snprintf(query, sizeof(query),
                  "INSERT INTO data.style_items "
@@ -321,13 +331,14 @@ static void _dt_style_update_from_image(const int id,
                  "     FROM data.style_items"
                  "     WHERE styleid=%d"
                  "     ORDER BY num DESC LIMIT 1), "
-                 "   module, operation, op_params, enabled,"
+                 "   module, operation, %s, enabled,"
                  "   blendop_params, blendop_version,"
                  "   multi_priority, multi_name, multi_name_hand_edited"
                  " FROM main.history"
                  " WHERE imgid=%d AND num=%d",
-                 id, id, imgid, GPOINTER_TO_INT(upd->data));
+                 id, id, autoinit?"NULL":"op_params", imgid, abs(item_updated));
         // clang-format on
+      }
 
       if(*query) DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), query, NULL, NULL, NULL);
 
@@ -562,27 +573,33 @@ gboolean dt_styles_create_from_image(const char *name,
     {
       char tmp[64];
       char include[2048] = { 0 };
-      g_strlcat(include, "num IN (", sizeof(include));
+      char autoinit[2048] = { 0 };
       for(GList *list = filter; list; list = g_list_next(list))
       {
         if(list != filter) g_strlcat(include, ",", sizeof(include));
-        snprintf(tmp, sizeof(tmp), "%d", GPOINTER_TO_INT(list->data));
+        const int num = GPOINTER_TO_INT(list->data);
+        snprintf(tmp, sizeof(tmp), "%d", abs(num));
         g_strlcat(include, tmp, sizeof(include));
+        if(num < 0)
+        {
+          if(autoinit[0]) g_strlcat(autoinit, ",", sizeof(autoinit));
+          g_strlcat(autoinit, tmp, sizeof(autoinit));
+        }
       }
 
-      g_strlcat(include, ")", sizeof(include));
       char query[4096] = { 0 };
       // clang-format off
       snprintf(query, sizeof(query),
                "INSERT INTO data.style_items"
                " (styleid, num, module, operation, op_params, enabled, blendop_params,"
                "  blendop_version, multi_priority, multi_name, multi_name_hand_edited)"
-               " SELECT ?1, num, module, operation, op_params, enabled,"
-               "        blendop_params, blendop_version, multi_priority,"
+               " SELECT ?1, num, module, operation,"
+               "        CASE WHEN num in (%s) THEN NULL ELSE op_params END,"
+               "        enabled, blendop_params, blendop_version, multi_priority,"
                "        multi_name, multi_name_hand_edited"
                " FROM main.history"
-               " WHERE imgid=?2 AND %s",
-               include);
+               " WHERE imgid=?2 AND NUM in (%s)",
+               autoinit, include);
       // clang-format on
       DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
     }
@@ -789,13 +806,17 @@ void dt_styles_apply_style_item(dt_develop_t *dev,
         memcpy(module->blend_params, module->default_blendop_params, sizeof(dt_develop_blend_params_t));
       }
 
-      if(module->version() != style_item->module_version
-         || module->params_size != style_item->params_size
-         || strcmp(style_item->operation, module->op))
+      gboolean autoinit = FALSE;
+
+      if(style_item->params_size != 0
+         && (module->version() != style_item->module_version
+             || module->params_size != style_item->params_size
+             || strcmp(style_item->operation, module->op)))
       {
         if(!module->legacy_params
-           || module->legacy_params(module, style_item->params, labs(style_item->module_version),
-                                          module->params, labs(module->version())))
+           || module->legacy_params(module, style_item->params,
+                                    labs(style_item->module_version),
+                                    module->params, labs(module->version())))
         {
           fprintf(stderr, "[dt_styles_apply_style_item] module `%s' version mismatch: history is %d, darktable is %d.\n",
                   module->op, style_item->module_version, module->version());
@@ -832,12 +853,20 @@ void dt_styles_apply_style_item(dt_develop_t *dev,
       }
       else
       {
-        memcpy(module->params, style_item->params, module->params_size);
+        if(style_item->params_size == 0)
+        {
+          /* an auto-init module, we cannot handle this here as we
+             don't have the image's default parameters. This parameter
+             must be set when loading history in the darkroom. */
+          autoinit = TRUE;
+        }
+        else
+          memcpy(module->params, style_item->params, style_item->params_size);
       }
 
       if(do_merge)
         dt_history_merge_module_into_history
-          (dev, NULL, module, modules_used, append, FALSE);
+          (dev, NULL, module, modules_used, append, autoinit);
     }
 
     if(module)

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1221,7 +1221,10 @@ void dt_dev_pop_history_items_ext(dt_develop_t *dev, int32_t cnt)
   for(int i = 0; i < cnt && history; i++)
   {
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
-    memcpy(hist->module->params, hist->params, hist->module->params_size);
+    if(hist->module->params_size == 0)
+      memcpy(hist->module->params, hist->module->default_params, hist->module->params_size);
+    else
+      memcpy(hist->module->params, hist->params, hist->module->params_size);
     dt_iop_commit_blend_params(hist->module, hist->blend_params);
 
     hist->module->iop_order = hist->iop_order;

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1959,9 +1959,11 @@ static void _presets_popup_callback(GtkButton *button, dt_iop_module_t *module)
 
   dt_gui_presets_popup_menu_show_for_module(module);
 
-  g_signal_connect(G_OBJECT(darktable.gui->presets_popup_menu), "deactivate", G_CALLBACK(_header_menu_deactivate_callback), module);
+  g_signal_connect(G_OBJECT(darktable.gui->presets_popup_menu), "deactivate",
+                   G_CALLBACK(_header_menu_deactivate_callback), module);
 
-  dt_gui_menu_popup(darktable.gui->presets_popup_menu, GTK_WIDGET(button), GDK_GRAVITY_SOUTH_EAST, GDK_GRAVITY_NORTH_EAST);
+  dt_gui_menu_popup(darktable.gui->presets_popup_menu,
+                    GTK_WIDGET(button), GDK_GRAVITY_SOUTH_EAST, GDK_GRAVITY_NORTH_EAST);
 }
 
 void dt_iop_request_focus(dt_iop_module_t *module)
@@ -2558,16 +2560,22 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   module->header = header;
 
   /* setup the header box */
-  g_signal_connect(G_OBJECT(header_evb), "button-press-event", G_CALLBACK(_iop_plugin_header_button_press), module);
+  g_signal_connect(G_OBJECT(header_evb), "button-press-event",
+                   G_CALLBACK(_iop_plugin_header_button_press), module);
   gtk_widget_add_events(header_evb, GDK_POINTER_MOTION_MASK);
-  g_signal_connect(G_OBJECT(header_evb), "enter-notify-event", G_CALLBACK(_header_motion_notify_show_callback), module);
-  g_signal_connect(G_OBJECT(header_evb), "leave-notify-event", G_CALLBACK(_header_motion_notify_hide_callback), module);
+  g_signal_connect(G_OBJECT(header_evb), "enter-notify-event",
+                   G_CALLBACK(_header_motion_notify_show_callback), module);
+  g_signal_connect(G_OBJECT(header_evb), "leave-notify-event",
+                   G_CALLBACK(_header_motion_notify_hide_callback), module);
 
   /* connect mouse button callbacks for focus and presets */
-  g_signal_connect(G_OBJECT(body_evb), "button-press-event", G_CALLBACK(_iop_plugin_body_button_press), module);
+  g_signal_connect(G_OBJECT(body_evb), "button-press-event",
+                   G_CALLBACK(_iop_plugin_body_button_press), module);
   gtk_widget_add_events(body_evb, GDK_POINTER_MOTION_MASK);
-  g_signal_connect(G_OBJECT(body_evb), "enter-notify-event", G_CALLBACK(_header_motion_notify_show_callback), module);
-  g_signal_connect(G_OBJECT(body_evb), "leave-notify-event", G_CALLBACK(_header_motion_notify_hide_callback), module);
+  g_signal_connect(G_OBJECT(body_evb), "enter-notify-event",
+                   G_CALLBACK(_header_motion_notify_show_callback), module);
+  g_signal_connect(G_OBJECT(body_evb), "leave-notify-event",
+                   G_CALLBACK(_header_motion_notify_hide_callback), module);
 
   /*
    * initialize the header widgets
@@ -2593,7 +2601,8 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
     gtk_widget_set_name(lab, "iop_description");
     g_signal_connect(lab, "query-tooltip", G_CALLBACK(_iop_tooltip_callback), module);
   }
-  g_signal_connect(G_OBJECT(hw[IOP_MODULE_LABEL]), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
+  g_signal_connect(G_OBJECT(hw[IOP_MODULE_LABEL]), "enter-notify-event",
+                   G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_SHOW));
 
   /* add multi instances menu button */
@@ -2602,9 +2611,11 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   if(!(module->flags() & IOP_FLAGS_ONE_INSTANCE))
     gtk_widget_set_tooltip_text(GTK_WIDGET(hw[IOP_MODULE_INSTANCE]),
                                 _("multiple instance actions\nright-click creates new instance"));
-  g_signal_connect(G_OBJECT(hw[IOP_MODULE_INSTANCE]), "button-press-event", G_CALLBACK(_gui_multiinstance_callback),
+  g_signal_connect(G_OBJECT(hw[IOP_MODULE_INSTANCE]), "button-press-event",
+                   G_CALLBACK(_gui_multiinstance_callback),
                    module);
-  g_signal_connect(G_OBJECT(hw[IOP_MODULE_INSTANCE]), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
+  g_signal_connect(G_OBJECT(hw[IOP_MODULE_INSTANCE]), "enter-notify-event",
+                   G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_INSTANCE));
 
   dt_gui_add_help_link(expander, dt_get_help_url(module->op));
@@ -2613,8 +2624,10 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   hw[IOP_MODULE_RESET] = dtgtk_button_new(dtgtk_cairo_paint_reset, 0, NULL);
   module->reset_button = GTK_WIDGET(hw[IOP_MODULE_RESET]);
   gtk_widget_set_tooltip_text(GTK_WIDGET(hw[IOP_MODULE_RESET]), _("reset parameters\nctrl+click to reapply any automatic presets"));
-  g_signal_connect(G_OBJECT(hw[IOP_MODULE_RESET]), "button-press-event", G_CALLBACK(_gui_reset_callback), module);
-  g_signal_connect(G_OBJECT(hw[IOP_MODULE_RESET]), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
+  g_signal_connect(G_OBJECT(hw[IOP_MODULE_RESET]), "button-press-event",
+                   G_CALLBACK(_gui_reset_callback), module);
+  g_signal_connect(G_OBJECT(hw[IOP_MODULE_RESET]), "enter-notify-event",
+                   G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_RESET));
 
   /* add preset button if module has implementation */
@@ -2622,8 +2635,10 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   module->presets_button = GTK_WIDGET(hw[IOP_MODULE_PRESETS]);
   if(!(module->flags() & IOP_FLAGS_ONE_INSTANCE))
     gtk_widget_set_tooltip_text(GTK_WIDGET(hw[IOP_MODULE_PRESETS]), _("presets\nright-click to apply on new instance"));
-  g_signal_connect(G_OBJECT(hw[IOP_MODULE_PRESETS]), "clicked", G_CALLBACK(_presets_popup_callback), module);
-  g_signal_connect(G_OBJECT(hw[IOP_MODULE_PRESETS]), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback),
+  g_signal_connect(G_OBJECT(hw[IOP_MODULE_PRESETS]), "clicked",
+                   G_CALLBACK(_presets_popup_callback), module);
+  g_signal_connect(G_OBJECT(hw[IOP_MODULE_PRESETS]), "enter-notify-event",
+                   G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_PRESETS));
 
   /* add enabled button */
@@ -2637,9 +2652,12 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   g_free(module_label);
   gtk_widget_set_tooltip_text(GTK_WIDGET(hw[IOP_MODULE_SWITCH]), tooltip);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(hw[IOP_MODULE_SWITCH]), module->enabled);
-  g_signal_connect(G_OBJECT(hw[IOP_MODULE_SWITCH]), "toggled", G_CALLBACK(_gui_off_callback), module);
-  g_signal_connect(G_OBJECT(hw[IOP_MODULE_SWITCH]), "button-press-event", G_CALLBACK(_gui_off_button_press), module);
-  g_signal_connect(G_OBJECT(hw[IOP_MODULE_SWITCH]), "enter-notify-event", G_CALLBACK(_header_enter_notify_callback), GINT_TO_POINTER(DT_ACTION_ELEMENT_ENABLE));
+  g_signal_connect(G_OBJECT(hw[IOP_MODULE_SWITCH]), "toggled",
+                   G_CALLBACK(_gui_off_callback), module);
+  g_signal_connect(G_OBJECT(hw[IOP_MODULE_SWITCH]), "button-press-event",
+                   G_CALLBACK(_gui_off_button_press), module);
+  g_signal_connect(G_OBJECT(hw[IOP_MODULE_SWITCH]), "enter-notify-event",
+                   G_CALLBACK(_header_enter_notify_callback), GINT_TO_POINTER(DT_ACTION_ELEMENT_ENABLE));
 
   module->off = DTGTK_TOGGLEBUTTON(hw[IOP_MODULE_SWITCH]);
   gtk_widget_set_sensitive(GTK_WIDGET(hw[IOP_MODULE_SWITCH]), !module->hide_enable_button);
@@ -2999,12 +3017,26 @@ dt_iop_module_t *dt_iop_get_module_by_op_priority(GList *modules,
 dt_iop_module_t *dt_iop_get_module_preferred_instance(dt_iop_module_so_t *module)
 {
   /*
-   decide which module instance keyboard shortcuts will be applied to based on user preferences, as follows
-    - Use the focused module, if it is an instance of this module type and the appropriate preference is checked. Otherwise
-    - prefer expanded instances (when selected and instances of the module are expanded on the RHS of the screen, collapsed instances will be ignored)
-    - prefer enabled instances (when selected, after applying the above rule, if instances of the module are active, inactive instances will be ignored)
-    - prefer unmasked instances (when selected, after applying the above rules, if instances of the module are unmasked, masked instances will be ignored)
-    - selection order (after applying the above rules, apply the shortcut to the first or last instance remaining)
+   decide which module instance keyboard shortcuts will be applied to
+   based on user preferences, as follows
+
+    - Use the focused module, if it is an instance of this module type
+      and the appropriate preference is checked. Otherwise
+
+    - prefer expanded instances (when selected and instances of the
+      module are expanded on the RHS of the screen, collapsed
+      instances will be ignored)
+
+    - prefer enabled instances (when selected, after applying the
+      above rule, if instances of the module are active, inactive
+      instances will be ignored)
+
+    - prefer unmasked instances (when selected, after applying the
+      above rules, if instances of the module are unmasked, masked
+      instances will be ignored)
+
+    - selection order (after applying the above rules, apply the
+      shortcut to the first or last instance remaining)
   */
   const gboolean prefer_focused = dt_conf_get_bool("accel/prefer_focused");
   const int prefer_expanded = dt_conf_get_bool("accel/prefer_expanded") ? 8 : 0;
@@ -3016,7 +3048,8 @@ dt_iop_module_t *dt_iop_get_module_preferred_instance(dt_iop_module_so_t *module
 
   // if any instance has focus, use that one
   if(prefer_focused && darktable.develop->gui_module
-     && (darktable.develop->gui_module->so == module || DT_ACTION(module) == &darktable.control->actions_focus))
+     && (darktable.develop->gui_module->so == module
+         || DT_ACTION(module) == &darktable.control->actions_focus))
     accel_mod = darktable.develop->gui_module;
   else
   {
@@ -3067,7 +3100,9 @@ void dt_iop_connect_accels_multi(dt_iop_module_so_t *module)
 
 void dt_iop_connect_accels_all()
 {
-  for(const GList *iop_mods = g_list_last(darktable.develop->iop); iop_mods; iop_mods = g_list_previous(iop_mods))
+  for(const GList *iop_mods = g_list_last(darktable.develop->iop);
+      iop_mods;
+      iop_mods = g_list_previous(iop_mods))
   {
     dt_iop_module_t *mod = (dt_iop_module_t *)iop_mods->data;
     dt_iop_connect_accels_multi(mod->so);
@@ -3099,7 +3134,9 @@ int dt_iop_count_instances(dt_iop_module_so_t *module)
 {
   int inst_count = 0;
 
-  for(const GList *iop_mods = g_list_last(darktable.develop->iop); iop_mods; iop_mods = g_list_previous(iop_mods))
+  for(const GList *iop_mods = g_list_last(darktable.develop->iop);
+      iop_mods;
+      iop_mods = g_list_previous(iop_mods))
   {
     dt_iop_module_t *mod = (dt_iop_module_t *)iop_mods->data;
     if(mod->so == module && mod->iop_order != INT_MAX)
@@ -3142,7 +3179,8 @@ void dt_iop_refresh_center(dt_iop_module_t *module)
   if(dev && dev->gui_attached)
   {
     // invalidate the pixelpipe cache except for the output of the prior module
-    const uint64_t hash = dt_dev_pixelpipe_cache_basichash_prior(dev->pipe->image.id, dev->pipe, module);
+    const uint64_t hash =
+      dt_dev_pixelpipe_cache_basichash_prior(dev->pipe->image.id, dev->pipe, module);
     dt_dev_pixelpipe_cache_flush_all_but(&dev->pipe->cache, hash);
     dev->pipe->changed |= DT_DEV_PIPE_SYNCH; //ensure that commit_params gets called to pick up any GUI changes
     dt_dev_invalidate(dev);
@@ -3157,7 +3195,8 @@ void dt_iop_refresh_preview(dt_iop_module_t *module)
   if(dev && dev->gui_attached)
   {
     // invalidate the pixelpipe cache except for the output of the prior module
-    const uint64_t hash = dt_dev_pixelpipe_cache_basichash_prior(dev->pipe->image.id, dev->preview_pipe, module);
+    const uint64_t hash =
+      dt_dev_pixelpipe_cache_basichash_prior(dev->pipe->image.id, dev->preview_pipe, module);
     dt_dev_pixelpipe_cache_flush_all_but(&dev->preview_pipe->cache, hash);
     dev->pipe->changed |= DT_DEV_PIPE_SYNCH; //ensure that commit_params gets called to pick up any GUI changes
     dt_dev_invalidate_all(dev);
@@ -3172,7 +3211,8 @@ void dt_iop_refresh_preview2(dt_iop_module_t *module)
   if(dev && dev->gui_attached)
   {
     // invalidate the pixelpipe cache except for the output of the prior module
-    const uint64_t hash = dt_dev_pixelpipe_cache_basichash_prior(dev->pipe->image.id, dev->preview2_pipe, module);
+    const uint64_t hash =
+      dt_dev_pixelpipe_cache_basichash_prior(dev->pipe->image.id, dev->preview2_pipe, module);
     dt_dev_pixelpipe_cache_flush_all_but(&dev->preview2_pipe->cache, hash);
     dev->pipe->changed |= DT_DEV_PIPE_SYNCH; //ensure that commit_params gets called to pick up any GUI changes
     dt_dev_invalidate_all(dev);
@@ -3195,21 +3235,24 @@ static gboolean _postponed_history_update(gpointer data)
   return FALSE; //cancel the timer
 }
 
-/** queue a delayed call of the add_history function after user interaction, to capture parameter updates (but not */
-/** too often). */
+/** queue a delayed call of the add_history function after user
+    interaction, to capture parameter updates (but not too often). */
 void dt_iop_queue_history_update(dt_iop_module_t *module, gboolean extend_prior)
 {
   if(module->timeout_handle && extend_prior)
   {
-    // we already queued an update, but we don't want to have the update happen until the timeout expires
-    // without any activity, so cancel the queued callback
+    // we already queued an update, but we don't want to have the
+    // update happen until the timeout expires without any activity,
+    // so cancel the queued callback
     g_source_remove(module->timeout_handle);
   }
   if(!module->timeout_handle || extend_prior)
   {
-    // adaptively set the timeout to 150% of the average time the past several pixelpipe runs took, clamped
-    //   to keep updates from appearing to be too sluggish (though early iops such as rawdenoise may have
-    //   multiple very slow iops following them, leading to >1000ms processing times)
+    // adaptively set the timeout to 150% of the average time the past
+    // several pixelpipe runs took, clamped to keep updates from
+    // appearing to be too sluggish (though early iops such as
+    // rawdenoise may have multiple very slow iops following them,
+    // leading to >1000ms processing times)
     const int delay = CLAMP(darktable.develop->average_delay * 3 / 2, 10, 1200);
     module->timeout_handle = g_timeout_add(delay, _postponed_history_update, module);
   }
@@ -3398,11 +3441,19 @@ static const dt_action_element_def_t _action_elements[]
       { NULL } };
 
 static const dt_shortcut_fallback_t _action_fallbacks[]
-  = { { .element = DT_ACTION_ELEMENT_ENABLE, .button = DT_SHORTCUT_LEFT },
-      { .element = DT_ACTION_ELEMENT_FOCUS, .button = DT_SHORTCUT_LEFT, .click = DT_SHORTCUT_LONG },
-      { .element = DT_ACTION_ELEMENT_INSTANCE, .button = DT_SHORTCUT_RIGHT, .click = DT_SHORTCUT_DOUBLE },
-      { .element = DT_ACTION_ELEMENT_RESET, .button = DT_SHORTCUT_LEFT, .click = DT_SHORTCUT_DOUBLE },
-      { .element = DT_ACTION_ELEMENT_PRESETS, .button = DT_SHORTCUT_RIGHT },
+  = { { .element = DT_ACTION_ELEMENT_ENABLE,
+        .button = DT_SHORTCUT_LEFT },
+      { .element = DT_ACTION_ELEMENT_FOCUS,
+        .button = DT_SHORTCUT_LEFT,
+        .click = DT_SHORTCUT_LONG },
+      { .element = DT_ACTION_ELEMENT_INSTANCE,
+        .button = DT_SHORTCUT_RIGHT,
+        .click = DT_SHORTCUT_DOUBLE },
+      { .element = DT_ACTION_ELEMENT_RESET,
+        .button = DT_SHORTCUT_LEFT,
+        .click = DT_SHORTCUT_DOUBLE },
+      { .element = DT_ACTION_ELEMENT_PRESETS,
+        .button = DT_SHORTCUT_RIGHT },
       { } };
 
 const dt_action_def_t dt_action_def_iop

--- a/src/gui/hist_dialog.c
+++ b/src/gui/hist_dialog.c
@@ -35,6 +35,7 @@ typedef enum _style_items_columns_t
 {
   DT_HIST_ITEMS_COL_ENABLED = 0,
   DT_HIST_ITEMS_COL_ISACTIVE,
+  DT_HIST_ITEMS_COL_AUTOINIT,
   DT_HIST_ITEMS_COL_NAME,
   DT_HIST_ITEMS_COL_NUM,
   DT_HIST_ITEMS_NUM_COLS
@@ -73,10 +74,16 @@ static GList *_gui_hist_get_active_items(dt_history_copy_item_t *d)
     do
     {
       gboolean active = FALSE;
+      gboolean autoinit = FALSE;
       gint num = 0;
-      gtk_tree_model_get(model, &iter, DT_HIST_ITEMS_COL_ENABLED, &active, DT_HIST_ITEMS_COL_NUM, &num, -1);
+      gtk_tree_model_get(model, &iter,
+                         DT_HIST_ITEMS_COL_ENABLED, &active,
+                         DT_HIST_ITEMS_COL_AUTOINIT, &autoinit,
+                         DT_HIST_ITEMS_COL_NUM, &num,
+                         -1);
+
       if(active && num >= 0)
-        result = g_list_prepend(result, GINT_TO_POINTER(num));
+        result = g_list_prepend(result, GINT_TO_POINTER(autoinit ? -num : num));
 
     } while(gtk_tree_model_iter_next(model, &iter));
   }
@@ -121,9 +128,14 @@ static void _gui_hist_copy_response(GtkDialog *dialog,
   }
 }
 
-static void _gui_hist_item_toggled(GtkCellRendererToggle *cell, gchar *path_str, gpointer data)
+static void _gui_hist_item_toggled(GtkCellRendererToggle *cell,
+                                   const gchar *path_str,
+                                   gpointer data)
 {
   dt_history_copy_item_t *d = (dt_history_copy_item_t *)data;
+
+  const _styles_columns_t col =
+    GPOINTER_TO_INT(g_object_get_data(G_OBJECT(cell), "column"));
 
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(d->items));
   GtkTreePath *path = gtk_tree_path_new_from_string(path_str);
@@ -131,11 +143,11 @@ static void _gui_hist_item_toggled(GtkCellRendererToggle *cell, gchar *path_str,
   gboolean toggle_item;
 
   gtk_tree_model_get_iter(model, &iter, path);
-  gtk_tree_model_get(model, &iter, DT_HIST_ITEMS_COL_ENABLED, &toggle_item, -1);
+  gtk_tree_model_get(model, &iter, col, &toggle_item, -1);
 
   toggle_item = (toggle_item == TRUE) ? FALSE : TRUE;
 
-  gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_HIST_ITEMS_COL_ENABLED, toggle_item, -1);
+  gtk_list_store_set(GTK_LIST_STORE(model), &iter, col, toggle_item, -1);
   gtk_tree_path_free(path);
 }
 
@@ -171,7 +183,8 @@ tree_on_row_activated(GtkTreeView        *treeview,
   {
     do
     {
-      gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_HIST_ITEMS_COL_ENABLED, FALSE, -1);
+      gtk_list_store_set(GTK_LIST_STORE(model), &iter,
+                         DT_HIST_ITEMS_COL_ENABLED, FALSE, -1);
 
     } while(gtk_tree_model_iter_next(model, &iter));
   }
@@ -186,7 +199,9 @@ tree_on_row_activated(GtkTreeView        *treeview,
   }
 }
 
-int dt_gui_hist_dialog_new(dt_history_copy_item_t *d, const int imgid, const gboolean iscopy)
+int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
+                           const int imgid,
+                           const gboolean iscopy)
 {
   int res;
   GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
@@ -216,7 +231,8 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d, const int imgid, const gbo
 
   GtkListStore *liststore
     = gtk_list_store_new(DT_HIST_ITEMS_NUM_COLS,
-                         G_TYPE_BOOLEAN, GDK_TYPE_PIXBUF, G_TYPE_STRING, G_TYPE_UINT);
+                         G_TYPE_BOOLEAN, GDK_TYPE_PIXBUF, G_TYPE_BOOLEAN,
+                         G_TYPE_STRING, G_TYPE_UINT);
 
   /* enabled */
   GtkCellRenderer *renderer = gtk_cell_renderer_toggle_new();
@@ -224,13 +240,25 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d, const int imgid, const gbo
   g_object_set_data(G_OBJECT(renderer), "column", (gint *)DT_HIST_ITEMS_COL_ENABLED);
   g_signal_connect(renderer, "toggled", G_CALLBACK(_gui_hist_item_toggled), d);
 
-  gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(d->items), -1, _("include"), renderer, "active",
-                                              DT_HIST_ITEMS_COL_ENABLED, NULL);
+  gtk_tree_view_insert_column_with_attributes
+    (GTK_TREE_VIEW(d->items), -1, _("include"), renderer, "active",
+     DT_HIST_ITEMS_COL_ENABLED, NULL);
+
+  /* auto-init */
+  renderer = gtk_cell_renderer_toggle_new();
+  gtk_cell_renderer_toggle_set_activatable(GTK_CELL_RENDERER_TOGGLE(renderer), TRUE);
+  g_object_set_data(G_OBJECT(renderer), "column", (gint *)DT_HIST_ITEMS_COL_AUTOINIT);
+  g_signal_connect(renderer, "toggled", G_CALLBACK(_gui_hist_item_toggled), d);
+
+  gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(d->items), -1, _("reset"),
+                                              renderer, "active",
+                                              DT_HIST_ITEMS_COL_AUTOINIT, NULL);
 
   /* active */
   renderer = gtk_cell_renderer_pixbuf_new();
-  GtkTreeViewColumn *column = gtk_tree_view_column_new_with_attributes("", renderer, "pixbuf",
-                                                                       DT_HIST_ITEMS_COL_ISACTIVE, NULL);
+  GtkTreeViewColumn *column = gtk_tree_view_column_new_with_attributes
+    ("", renderer, "pixbuf",
+     DT_HIST_ITEMS_COL_ISACTIVE, NULL);
   gtk_tree_view_append_column(GTK_TREE_VIEW(d->items), column);
   gtk_tree_view_column_set_alignment(column, 0.5);
   gtk_tree_view_column_set_clickable(column, FALSE);
@@ -240,14 +268,18 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d, const int imgid, const gbo
   renderer = gtk_cell_renderer_text_new();
   g_object_set_data(G_OBJECT(renderer), "column", (gint *)DT_HIST_ITEMS_COL_NAME);
   g_object_set(renderer, "xalign", 0.0, (gchar *)0);
-  gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(d->items), -1, _("item"), renderer, "text",
-                                              DT_HIST_ITEMS_COL_NAME, NULL);
+  gtk_tree_view_insert_column_with_attributes
+    (GTK_TREE_VIEW(d->items), -1, _("item"), renderer, "text",
+     DT_HIST_ITEMS_COL_NAME, NULL);
 
-  gtk_tree_selection_set_mode(gtk_tree_view_get_selection(GTK_TREE_VIEW(d->items)), GTK_SELECTION_SINGLE);
+  gtk_tree_selection_set_mode(gtk_tree_view_get_selection(GTK_TREE_VIEW(d->items)),
+                              GTK_SELECTION_SINGLE);
   gtk_tree_view_set_model(GTK_TREE_VIEW(d->items), GTK_TREE_MODEL(liststore));
 
-  GdkPixbuf *is_active_pb = dt_draw_paint_to_pixbuf(GTK_WIDGET(dialog), 10, 0, dtgtk_cairo_paint_switch);
-  GdkPixbuf *is_inactive_pb = dt_draw_paint_to_pixbuf(GTK_WIDGET(dialog), 10, 0, dtgtk_cairo_paint_switch_inactive);
+  GdkPixbuf *is_active_pb =
+    dt_draw_paint_to_pixbuf(GTK_WIDGET(dialog), 10, 0, dtgtk_cairo_paint_switch);
+  GdkPixbuf *is_inactive_pb =
+    dt_draw_paint_to_pixbuf(GTK_WIDGET(dialog), 10, 0, dtgtk_cairo_paint_switch_inactive);
 
   /* fill list with history items */
   GList *items = dt_history_get_items(imgid, FALSE);
@@ -265,12 +297,14 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d, const int imgid, const gbo
         const gboolean is_safe = !dt_history_module_skip_copy(flags);
 
         gtk_list_store_append(GTK_LIST_STORE(liststore), &iter);
-        gtk_list_store_set(GTK_LIST_STORE(liststore), &iter,
-                           DT_HIST_ITEMS_COL_ENABLED, iscopy ? is_safe : _gui_is_set(d->selops, item->num),
-                           DT_HIST_ITEMS_COL_ISACTIVE, (gboolean)item->enabled ? is_active_pb : is_inactive_pb,
-                           DT_HIST_ITEMS_COL_NAME, item->name,
-                           DT_HIST_ITEMS_COL_NUM, (gint)item->num,
-                           -1);
+        gtk_list_store_set
+          (GTK_LIST_STORE(liststore), &iter,
+           DT_HIST_ITEMS_COL_ENABLED, iscopy ? is_safe : _gui_is_set(d->selops, item->num),
+           DT_HIST_ITEMS_COL_AUTOINIT, FALSE,
+           DT_HIST_ITEMS_COL_ISACTIVE, (gboolean)item->enabled ? is_active_pb : is_inactive_pb,
+           DT_HIST_ITEMS_COL_NAME, item->name,
+           DT_HIST_ITEMS_COL_NUM, (gint)item->num,
+           -1);
       }
     }
     g_list_free_full(items, dt_history_item_free);
@@ -296,7 +330,8 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d, const int imgid, const gbo
     return GTK_RESPONSE_CANCEL;
   }
 
-  g_signal_connect(GTK_TREE_VIEW(d->items), "row-activated", (GCallback)tree_on_row_activated, GTK_WIDGET(dialog));
+  g_signal_connect(GTK_TREE_VIEW(d->items), "row-activated",
+                   (GCallback)tree_on_row_activated, GTK_WIDGET(dialog));
   g_object_unref(liststore);
 
   g_signal_connect(dialog, "response", G_CALLBACK(_gui_hist_copy_response), d);
@@ -306,7 +341,9 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d, const int imgid, const gbo
   while(1)
   {
     res = gtk_dialog_run(GTK_DIALOG(dialog));
-    if(res == GTK_RESPONSE_CANCEL || res == GTK_RESPONSE_DELETE_EVENT || res == GTK_RESPONSE_OK) break;
+    if(res == GTK_RESPONSE_CANCEL
+       || res == GTK_RESPONSE_DELETE_EVENT
+       || res == GTK_RESPONSE_OK) break;
   }
 
   gtk_widget_destroy(GTK_WIDGET(dialog));

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -202,7 +202,9 @@ static void _edit_preset_response(GtkDialog *dialog,
     // find the module action list this preset belongs to
     dt_action_t *module_actions = g->iop ? &g->iop->so->actions : NULL;
 
-    for(GList *libs = darktable.lib->plugins; !module_actions && libs; libs = g_list_next(libs))
+    for(GList *libs = darktable.lib->plugins;
+        !module_actions && libs;
+        libs = g_list_next(libs))
     {
       dt_lib_module_t *lib = libs->data;
 
@@ -222,9 +224,9 @@ static void _edit_preset_response(GtkDialog *dialog,
       if(name == NULL || *name == '\0' || strcmp(_("new preset"), name) == 0)
       {
         // show error dialog
-        GtkWidget *dlg_changename
-            = gtk_message_dialog_new(GTK_WINDOW(dialog), GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL,
-                                     GTK_MESSAGE_WARNING, GTK_BUTTONS_OK, _("please give preset a name"));
+        GtkWidget *dlg_changename =
+          gtk_message_dialog_new(GTK_WINDOW(dialog), GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL,
+                                 GTK_MESSAGE_WARNING, GTK_BUTTONS_OK, _("please give preset a name"));
 #ifdef GDK_WINDOWING_QUARTZ
         dt_osx_disallow_fullscreen(dlg_changename);
 #endif
@@ -255,7 +257,8 @@ static void _edit_preset_response(GtkDialog *dialog,
       {
         sqlite3_finalize(stmt);
 
-        // if result is BUTTON_NO or ESCAPE keypress exit without destroying dialog, to permit other name
+        // if result is BUTTON_NO or ESCAPE keypress exit without
+        // destroying dialog, to permit other name
         if(dt_gui_show_yes_no_dialog(_("overwrite preset?"),
                                      _("preset `%s' already exists.\ndo you want to overwrite?"), name))
         {
@@ -301,7 +304,7 @@ static void _edit_preset_response(GtkDialog *dialog,
          "  aperture_max, focal_length_min, focal_length_max, autoapply,"
          "  filter, format, def, writeprotect, operation, op_version, op_params, enabled,"
          "  blendop_params, blendop_version,"
-         "   multi_priority, multi_name, multi_name_hand_edited) "
+         "  multi_priority, multi_name, multi_name_hand_edited) "
          "VALUES"
          " (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16,"
          "   0, 0, ?17, ?18, ?19, ?20, ?21, ?22, 0, ?23, ?24)");
@@ -847,7 +850,9 @@ void dt_gui_presets_show_edit_dialog(const char *name_in,
 {
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "SELECT operation, op_version FROM data.presets WHERE rowid = ?1", -1, &stmt, NULL);
+                              "SELECT operation, op_version"
+                              " FROM data.presets"
+                              " WHERE rowid = ?1", -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, rowid);
   if(sqlite3_step(stmt) == SQLITE_ROW)
   {

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -60,8 +60,9 @@ static int _single_selected_imgid()
 {
   int imgid = -1;
   sqlite3_stmt *stmt;
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT imgid FROM main.selected_images", -1, &stmt,
-                              NULL);
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "SELECT imgid FROM main.selected_images",
+                              -1, &stmt, NULL);
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
     if(imgid == -1)
@@ -85,7 +86,9 @@ static gboolean _gui_styles_is_copy_module_order_set(dt_gui_styles_dialog_t *d)
   gboolean active = FALSE;
   gint num = 0;
   if(gtk_tree_model_get_iter_first(model, &iter))
-    gtk_tree_model_get(model, &iter, DT_STYLE_ITEMS_COL_ENABLED, &active, DT_STYLE_ITEMS_COL_NUM, &num, -1);
+    gtk_tree_model_get(model, &iter,
+                       DT_STYLE_ITEMS_COL_ENABLED, &active,
+                       DT_STYLE_ITEMS_COL_NUM, &num, -1);
   return active && (num == -1);
 }
 
@@ -98,11 +101,15 @@ static gboolean _gui_styles_is_update_module_order_set(dt_gui_styles_dialog_t *d
   gboolean active = FALSE;
   gint num = 0;
   if(gtk_tree_model_get_iter_first(model, &iter))
-    gtk_tree_model_get(model, &iter, DT_STYLE_ITEMS_COL_UPDATE, &active, DT_STYLE_ITEMS_COL_NUM, &num, -1);
+    gtk_tree_model_get(model, &iter,
+                       DT_STYLE_ITEMS_COL_UPDATE, &active,
+                       DT_STYLE_ITEMS_COL_NUM, &num, -1);
   return active && (num == -1);
 }
 
-void _gui_styles_get_active_items(dt_gui_styles_dialog_t *sd, GList **enabled, GList **update)
+void _gui_styles_get_active_items(dt_gui_styles_dialog_t *sd,
+                                  GList **enabled,
+                                  GList **update)
 {
   /* run through all items and add active ones to result */
   GtkTreeIter iter;
@@ -161,7 +168,7 @@ void _gui_styles_get_active_items(dt_gui_styles_dialog_t *sd, GList **enabled, G
   }
 }
 
-static void _gui_styles_select_all_items(dt_gui_styles_dialog_t *d, gboolean active)
+static void _gui_styles_select_all_items(dt_gui_styles_dialog_t *d, const gboolean active)
 {
   /* run through all items and set active status */
   GtkTreeView *items = (d->duplicate) ? d->items_new : d->items;
@@ -176,7 +183,9 @@ static void _gui_styles_select_all_items(dt_gui_styles_dialog_t *d, gboolean act
   }
 }
 
-static void _gui_styles_new_style_response(GtkDialog *dialog, gint response_id, dt_gui_styles_dialog_t *g)
+static void _gui_styles_new_style_response(GtkDialog *dialog,
+                                           const gint response_id,
+                                           dt_gui_styles_dialog_t *g)
 {
   if(response_id == GTK_RESPONSE_YES)
   {
@@ -203,8 +212,9 @@ static void _gui_styles_new_style_response(GtkDialog *dialog, gint response_id, 
       if(name && (dt_styles_exists(name)) != 0)
       {
         /* on button yes delete style name for overwriting */
-        if(dt_gui_show_yes_no_dialog(_("overwrite style?"),
-                                     _("style `%s' already exists.\ndo you want to overwrite?"), name))
+        if(dt_gui_show_yes_no_dialog
+           (_("overwrite style?"),
+            _("style `%s' already exists.\ndo you want to overwrite?"), name))
         {
           dt_styles_delete_by_name(name);
         }
@@ -215,8 +225,11 @@ static void _gui_styles_new_style_response(GtkDialog *dialog, gint response_id, 
         }
       }
 
-      if(dt_styles_create_from_image(name, gtk_entry_get_text(GTK_ENTRY(g->description)),
-                                     g->imgid, result, _gui_styles_is_copy_module_order_set(g)))
+      if(dt_styles_create_from_image(name,
+                                     gtk_entry_get_text(GTK_ENTRY(g->description)),
+                                     g->imgid,
+                                     result,
+                                     _gui_styles_is_copy_module_order_set(g)))
       {
         dt_control_log(_("style named '%s' successfully created"), name);
       };
@@ -226,8 +239,11 @@ static void _gui_styles_new_style_response(GtkDialog *dialog, gint response_id, 
       /* show dialog if name is missing from entry */
       GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
       GtkWidget *dlg_changename
-                    = gtk_message_dialog_new(GTK_WINDOW(window), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_WARNING,
-                                             GTK_BUTTONS_OK, _("please give style a name"));
+                    = gtk_message_dialog_new(GTK_WINDOW(window),
+                                             GTK_DIALOG_DESTROY_WITH_PARENT,
+                                             GTK_MESSAGE_WARNING,
+                                             GTK_BUTTONS_OK,
+                                             _("please give style a name"));
 #ifdef GDK_WINDOWING_QUARTZ
       dt_osx_disallow_fullscreen(dlg_changename);
 #endif
@@ -242,7 +258,9 @@ static void _gui_styles_new_style_response(GtkDialog *dialog, gint response_id, 
   g_free(g);
 }
 
-static void _gui_styles_edit_style_response(GtkDialog *dialog, gint response_id, dt_gui_styles_dialog_t *g)
+static void _gui_styles_edit_style_response(GtkDialog *dialog,
+                                            const gint response_id,
+                                            dt_gui_styles_dialog_t *g)
 {
   if(response_id == GTK_RESPONSE_YES)
   {
@@ -266,15 +284,23 @@ static void _gui_styles_edit_style_response(GtkDialog *dialog, gint response_id,
     {
       if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->duplicate)))
       {
-        dt_styles_create_from_style(g->nameorig, name, gtk_entry_get_text(GTK_ENTRY(g->description)),
-                                    result, g->imgid, update,
+        dt_styles_create_from_style(g->nameorig,
+                                    name,
+                                    gtk_entry_get_text(GTK_ENTRY(g->description)),
+                                    result,
+                                    g->imgid,
+                                    update,
                                     _gui_styles_is_copy_module_order_set(g),
                                     _gui_styles_is_update_module_order_set(g));
       }
       else
       {
-        dt_styles_update(g->nameorig, name, gtk_entry_get_text(GTK_ENTRY(g->description)),
-                         result, g->imgid, update,
+        dt_styles_update(g->nameorig,
+                         name,
+                         gtk_entry_get_text(GTK_ENTRY(g->description)),
+                         result,
+                         g->imgid,
+                         update,
                          _gui_styles_is_copy_module_order_set(g),
                          _gui_styles_is_update_module_order_set(g));
       }
@@ -285,8 +311,11 @@ static void _gui_styles_edit_style_response(GtkDialog *dialog, gint response_id,
       /* show dialog if name is missing from entry */
       GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
       GtkWidget *dlg_changename
-                    = gtk_message_dialog_new(GTK_WINDOW(window), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_WARNING,
-                                             GTK_BUTTONS_OK, _("please give style a name"));
+                    = gtk_message_dialog_new(GTK_WINDOW(window),
+                                             GTK_DIALOG_DESTROY_WITH_PARENT,
+                                             GTK_MESSAGE_WARNING,
+                                             GTK_BUTTONS_OK,
+                                             _("please give style a name"));
 #ifdef GDK_WINDOWING_QUARTZ
       dt_osx_disallow_fullscreen(dlg_changename);
 #endif
@@ -301,7 +330,9 @@ static void _gui_styles_edit_style_response(GtkDialog *dialog, gint response_id,
   g_free(g);
 }
 
-static void _gui_styles_item_toggled(GtkCellRendererToggle *cell, gchar *path_str, gpointer data)
+static void _gui_styles_item_toggled(GtkCellRendererToggle *cell,
+                                     gchar *path_str,
+                                     gpointer data)
 {
   dt_gui_styles_dialog_t *sd = (dt_gui_styles_dialog_t *)data;
 
@@ -323,11 +354,14 @@ static void _gui_styles_item_toggled(GtkCellRendererToggle *cell, gchar *path_st
   if(update_num != -1 && toggle_item) // include so not updated
     gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_STYLE_ITEMS_COL_UPDATE, FALSE, -1);
 
-  gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_STYLE_ITEMS_COL_ENABLED, toggle_item, -1);
+  gtk_list_store_set(GTK_LIST_STORE(model), &iter,
+                     DT_STYLE_ITEMS_COL_ENABLED, toggle_item, -1);
   gtk_tree_path_free(path);
 }
 
-static void _gui_styles_item_new_toggled(GtkCellRendererToggle *cell, gchar *path_str, gpointer data)
+static void _gui_styles_item_new_toggled(GtkCellRendererToggle *cell,
+                                         gchar *path_str,
+                                         gpointer data)
 {
   dt_gui_styles_dialog_t *sd = (dt_gui_styles_dialog_t *)data;
 
@@ -341,11 +375,14 @@ static void _gui_styles_item_new_toggled(GtkCellRendererToggle *cell, gchar *pat
 
   toggle_item = (toggle_item == TRUE) ? FALSE : TRUE;
 
-  gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_STYLE_ITEMS_COL_ENABLED, toggle_item, -1);
+  gtk_list_store_set(GTK_LIST_STORE(model), &iter,
+                     DT_STYLE_ITEMS_COL_ENABLED, toggle_item, -1);
   gtk_tree_path_free(path);
 }
 
-static void _gui_styles_update_toggled(GtkCellRendererToggle *cell, gchar *path_str, gpointer data)
+static void _gui_styles_update_toggled(GtkCellRendererToggle *cell,
+                                       gchar *path_str,
+                                       gpointer data)
 {
   dt_gui_styles_dialog_t *sd = (dt_gui_styles_dialog_t *)data;
 
@@ -359,8 +396,10 @@ static void _gui_styles_update_toggled(GtkCellRendererToggle *cell, gchar *path_
 
   toggle_item = (toggle_item == TRUE) ? FALSE : TRUE;
 
-  gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_STYLE_ITEMS_COL_ENABLED, !toggle_item, -1);
-  gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_STYLE_ITEMS_COL_UPDATE, toggle_item, -1);
+  gtk_list_store_set(GTK_LIST_STORE(model), &iter,
+                     DT_STYLE_ITEMS_COL_ENABLED, !toggle_item, -1);
+  gtk_list_store_set(GTK_LIST_STORE(model), &iter,
+                     DT_STYLE_ITEMS_COL_UPDATE, toggle_item, -1);
   gtk_tree_path_free(path);
 }
 
@@ -419,8 +458,10 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
   GtkBox *box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
 
   GtkWidget *scroll = gtk_scrolled_window_new(NULL, NULL);
-  gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll), GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
-  gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(scroll), DT_PIXEL_APPLY_DPI(450));
+  gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll),
+                                 GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+  gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(scroll),
+                                             DT_PIXEL_APPLY_DPI(450));
 //  only available in 3.22, and not making the expected job anyway
 //  gtk_scrolled_window_set_max_content_height(GTK_SCROLLED_WINDOW(scroll), DT_PIXEL_APPLY_DPI(700));
 //  gtk_scrolled_window_set_propagate_natural_height(GTK_SCROLLED_WINDOW(scroll), TRUE);
@@ -460,20 +501,22 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
 
   /* create the list of items */
   sd->items = GTK_TREE_VIEW(gtk_tree_view_new());
-  GtkListStore *liststore = gtk_list_store_new(DT_STYLE_ITEMS_NUM_COLS, G_TYPE_BOOLEAN, G_TYPE_BOOLEAN,
-                                               GDK_TYPE_PIXBUF, G_TYPE_STRING, G_TYPE_INT, G_TYPE_INT);
+  GtkListStore *liststore = gtk_list_store_new(
+    DT_STYLE_ITEMS_NUM_COLS, G_TYPE_BOOLEAN, G_TYPE_BOOLEAN,
+    GDK_TYPE_PIXBUF, G_TYPE_BOOLEAN, G_TYPE_STRING, G_TYPE_INT, G_TYPE_INT);
 
   sd->items_new = GTK_TREE_VIEW(gtk_tree_view_new());
-  GtkListStore *liststore_new = gtk_list_store_new(DT_STYLE_ITEMS_NUM_COLS, G_TYPE_BOOLEAN, G_TYPE_STRING,
-                                                   GDK_TYPE_PIXBUF, G_TYPE_STRING, G_TYPE_INT, G_TYPE_INT);
+  GtkListStore *liststore_new = gtk_list_store_new
+    (DT_STYLE_ITEMS_NUM_COLS, G_TYPE_BOOLEAN, G_TYPE_STRING,
+      GDK_TYPE_PIXBUF, G_TYPE_BOOLEAN, G_TYPE_STRING, G_TYPE_INT, G_TYPE_INT);
 
   /* enabled */
   GtkCellRenderer *renderer = gtk_cell_renderer_toggle_new();
   gtk_cell_renderer_toggle_set_activatable(GTK_CELL_RENDERER_TOGGLE(renderer), TRUE);
   g_object_set_data(G_OBJECT(renderer), "column", (gint *)DT_STYLE_ITEMS_COL_ENABLED);
   g_signal_connect(renderer, "toggled", G_CALLBACK(_gui_styles_item_toggled), sd);
-
-  gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items), -1, _("include"), renderer, "active",
+  gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items), -1, _("include"),
+                                              renderer, "active",
                                               DT_STYLE_ITEMS_COL_ENABLED, NULL);
 
   if(edit)
@@ -482,7 +525,8 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
     gtk_cell_renderer_toggle_set_activatable(GTK_CELL_RENDERER_TOGGLE(renderer), TRUE);
     g_object_set_data(G_OBJECT(renderer), "column", (gint *)DT_STYLE_ITEMS_COL_ENABLED);
     g_signal_connect(renderer, "toggled", G_CALLBACK(_gui_styles_item_new_toggled), sd);
-    gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items_new), -1, _("include"), renderer,
+    gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items_new), -1,
+                                                _("include"), renderer,
                                                 "active", DT_STYLE_ITEMS_COL_ENABLED, NULL);
   }
 
@@ -494,14 +538,17 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
     g_object_set_data(G_OBJECT(renderer), "column", (gint *)DT_STYLE_ITEMS_COL_UPDATE);
     g_signal_connect(renderer, "toggled", G_CALLBACK(_gui_styles_update_toggled), sd);
 
-    gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items), -1, _("update"), renderer, "active",
+    gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items), -1,
+                                                _("update"), renderer, "active",
                                                 DT_STYLE_ITEMS_COL_UPDATE, NULL);
   }
 
   /* active */
   renderer = gtk_cell_renderer_pixbuf_new();
-  GtkTreeViewColumn *column = gtk_tree_view_column_new_with_attributes("", renderer, "pixbuf",
-                                                                       DT_STYLE_ITEMS_COL_ISACTIVE, NULL);
+  GtkTreeViewColumn *column = gtk_tree_view_column_new_with_attributes
+    ("", renderer,
+     "pixbuf",
+     DT_STYLE_ITEMS_COL_ISACTIVE, NULL);
   gtk_tree_view_append_column(GTK_TREE_VIEW(sd->items), column);
   gtk_tree_view_column_set_alignment(column, 0.5);
   gtk_tree_view_column_set_clickable(column, FALSE);
@@ -521,12 +568,14 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
   renderer = gtk_cell_renderer_text_new();
   g_object_set_data(G_OBJECT(renderer), "column", (gint *)DT_STYLE_ITEMS_COL_NAME);
   g_object_set(renderer, "xalign", 0.0, (gchar *)0);
-  gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items), -1, _("item"), renderer, "text",
+  gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items), -1,
+                                              _("item"), renderer, "text",
                                               DT_STYLE_ITEMS_COL_NAME, NULL);
 
   if(edit)
   {
-    gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items_new), -1, _("item"), renderer, "text",
+    gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items_new), -1,
+                                                _("item"), renderer, "text",
                                                 DT_STYLE_ITEMS_COL_NAME, NULL);
   }
 
@@ -619,7 +668,7 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
         if(modules)
         {
           GList *result = g_list_find_custom(
-              modules, item->op, _g_list_find_module_by_name); // (dt_iop_module_t *)(modules->data);
+              modules, item->op, _g_list_find_module_by_name);
           if(result)
           {
             module = (dt_iop_module_t *)(result->data);

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -129,7 +129,10 @@ dt_image_flags_t dt_imageio_get_type_from_extension(const char *extension)
 }
 
 // load a full-res thumbnail:
-int dt_imageio_large_thumbnail(const char *filename, uint8_t **buffer, int32_t *width, int32_t *height,
+int dt_imageio_large_thumbnail(const char *filename,
+                               uint8_t **buffer,
+                               int32_t *width,
+                               int32_t *height,
                                dt_colorspaces_color_profile_type_t *color_space)
 {
   int res = 1;
@@ -312,8 +315,14 @@ gboolean dt_imageio_has_mono_preview(const char *filename)
   return mono;
 }
 
-void dt_imageio_flip_buffers(char *out, const char *in, const size_t bpp, const int wd, const int ht,
-                             const int fwd, const int fht, const int stride,
+void dt_imageio_flip_buffers(char *out,
+                             const char *in,
+                             const size_t bpp,
+                             const int wd,
+                             const int ht,
+                             const int fwd,
+                             const int fht,
+                             const int stride,
                              const dt_image_orientation_t orientation)
 {
   if(!orientation)
@@ -363,9 +372,16 @@ void dt_imageio_flip_buffers(char *out, const char *in, const size_t bpp, const 
   }
 }
 
-void dt_imageio_flip_buffers_ui8_to_float(float *out, const uint8_t *in, const float black, const float white,
-                                          const int ch, const int wd, const int ht, const int fwd,
-                                          const int fht, const int stride,
+void dt_imageio_flip_buffers_ui8_to_float(float *out,
+                                          const uint8_t *in,
+                                          const float black,
+                                          const float white,
+                                          const int ch,
+                                          const int wd,
+                                          const int ht,
+                                          const int fwd,
+                                          const int fht,
+                                          const int stride,
                                           const dt_image_orientation_t orientation)
 {
   const float scale = 1.0f / (white - black);
@@ -419,8 +435,13 @@ void dt_imageio_flip_buffers_ui8_to_float(float *out, const uint8_t *in, const f
   }
 }
 
-size_t dt_imageio_write_pos(int i, int j, int wd, int ht, float fwd, float fht,
-                            dt_image_orientation_t orientation)
+size_t dt_imageio_write_pos(const int i,
+                            const int j,
+                            const int wd,
+                            const int ht,
+                            const float fwd,
+                            const float fht,
+                            const dt_image_orientation_t orientation)
 {
   int ii = i, jj = j, w = wd, fw = fwd, fh = fht;
   if(orientation & ORIENTATION_SWAP_XY)
@@ -436,7 +457,9 @@ size_t dt_imageio_write_pos(int i, int j, int wd, int ht, float fwd, float fht,
   return (size_t)jj * w + ii;
 }
 
-dt_imageio_retval_t dt_imageio_open_hdr(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf)
+dt_imageio_retval_t dt_imageio_open_hdr(dt_image_t *img,
+                                        const char *filename,
+                                        dt_mipmap_buffer_t *buf)
 {
   // if buf is NULL, don't proceed
   if(!buf) return DT_IMAGEIO_OK;
@@ -588,7 +611,9 @@ int dt_imageio_is_hdr(const char *filename)
 }
 
 // transparent read method to load ldr image to dt_raw_image_t with exif and so on.
-dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf)
+dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img,
+                                        const char *filename,
+                                        dt_mipmap_buffer_t *buf)
 {
   // if buf is NULL, don't proceed
   if(!buf) return DT_IMAGEIO_OK;
@@ -746,7 +771,7 @@ int dt_imageio_export_with_flags(const int32_t imgid,
                                  dt_imageio_module_storage_t *storage,
                                  dt_imageio_module_data_t *storage_params,
                                  int num,
-                                 int total,
+                                 const int total,
                                  dt_export_metadata_t *metadata,
                                  const int history_end)
 {
@@ -811,7 +836,35 @@ int dt_imageio_export_with_flags(const int32_t imgid,
     for(GList *st_items = style_items; st_items; st_items = g_list_next(st_items))
     {
       dt_style_item_t *st_item = (dt_style_item_t *)st_items->data;
-      dt_styles_apply_style_item(&dev, st_item, &modules_used, appending);
+      gboolean ok = TRUE;
+      gboolean autoinit = FALSE;
+
+      /* check for auto-init module */
+      if(st_item->params_size == 0)
+      {
+        // get iop for this operation as we need the corresponding default parameters
+        const dt_iop_module_t *module =
+          dt_iop_get_module_from_list(dev.iop, st_item->operation);
+        if(module)
+        {
+          st_item->params_size = module->params_size;
+          st_item->params = (dt_iop_params_t *)malloc(st_item->params_size);
+          memcpy(st_item->params, module->default_params, module->params_size);
+          autoinit = TRUE;
+        }
+        else
+        {
+          fprintf(stderr,
+                  "[dt_imageio_export_with_flags] cannot find module %s for style\n",
+                  st_item->operation);
+          ok = FALSE;
+        }
+      }
+
+      if(ok)
+      {
+        dt_styles_apply_style_item(&dev, st_item, &modules_used, !autoinit && appending);
+      }
     }
 
     g_list_free(modules_used);
@@ -1283,9 +1336,14 @@ dt_imageio_retval_t dt_imageio_open(dt_image_t *img,        // non-const * means
   return ret;
 }
 
-gboolean dt_imageio_lookup_makermodel(const char *maker, const char *model,
-                                      char *mk, int mk_len, char *md, int md_len,
-                                      char *al, int al_len)
+gboolean dt_imageio_lookup_makermodel(const char *maker,
+                                      const char *model,
+                                      char *mk,
+                                      const int mk_len,
+                                      char *md,
+                                      const int md_len,
+                                      char *al,
+                                      const int al_len)
 {
   // At this stage, we can't tell which loader is used to open the image.
   gboolean found = dt_rawspeed_lookup_makermodel(maker, model,

--- a/src/imageio/imageio_common.h
+++ b/src/imageio/imageio_common.h
@@ -63,56 +63,109 @@ void dt_imageio_set_hdr_tag(dt_image_t *img);
 // Update the tag for b&w workflow
 void dt_imageio_update_monochrome_workflow_tag(int32_t id, int mask);
 // opens the file using pfm, hdr, exr.
-dt_imageio_retval_t dt_imageio_open_hdr(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf);
+dt_imageio_retval_t dt_imageio_open_hdr(dt_image_t *img,
+                                        const char *filename,
+                                        dt_mipmap_buffer_t *buf);
 // opens file using imagemagick
-dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf);
+dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img,
+                                        const char *filename,
+                                        dt_mipmap_buffer_t *buf);
 // try all the options in sequence
-dt_imageio_retval_t dt_imageio_open(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf);
+dt_imageio_retval_t dt_imageio_open(dt_image_t *img,
+                                    const char *filename,
+                                    dt_mipmap_buffer_t *buf);
 // tries to open the files not opened by the other routines using GraphicsMagick (if supported)
 dt_imageio_retval_t dt_imageio_open_exotic(dt_image_t *img, const char *filename,
                                            dt_mipmap_buffer_t *buf);
 
 struct dt_imageio_module_format_t;
 struct dt_imageio_module_data_t;
-int dt_imageio_export(const int32_t imgid, const char *filename, struct dt_imageio_module_format_t *format,
-                      struct dt_imageio_module_data_t *format_params, const gboolean high_quality,
-                      const gboolean upscale, const gboolean copy_metadata, const gboolean export_masks,
-                      dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
-                      dt_iop_color_intent_t icc_intent, dt_imageio_module_storage_t *storage,
-                      dt_imageio_module_data_t *storage_params, int num, int total, dt_export_metadata_t *metadata);
+int dt_imageio_export(const int32_t imgid,
+                      const char *filename,
+                      struct dt_imageio_module_format_t *format,
+                      struct dt_imageio_module_data_t *format_params,
+                      const gboolean high_quality,
+                      const gboolean upscale,
+                      const gboolean copy_metadata,
+                      const gboolean export_masks,
+                      dt_colorspaces_color_profile_type_t icc_type,
+                      const gchar *icc_filename,
+                      dt_iop_color_intent_t icc_intent,
+                      dt_imageio_module_storage_t *storage,
+                      dt_imageio_module_data_t *storage_params,
+                      int num,
+                      const int total,
+                      dt_export_metadata_t *metadata);
 
 int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
                                  struct dt_imageio_module_format_t *format,
-                                 struct dt_imageio_module_data_t *format_params, const gboolean ignore_exif,
-                                 const gboolean display_byteorder, const gboolean high_quality, const gboolean upscale, gboolean is_scaling,
-                                 const gboolean thumbnail_export, const char *filter, const gboolean copy_metadata,
-                                 const gboolean export_masks, dt_colorspaces_color_profile_type_t icc_type,
-                                 const gchar *icc_filename, dt_iop_color_intent_t icc_intent,
-                                 dt_imageio_module_storage_t *storage, dt_imageio_module_data_t *storage_params,
-                                 int num, int total, dt_export_metadata_t *metadata, const int history_end);
+                                 struct dt_imageio_module_data_t *format_params,
+                                 const gboolean ignore_exif,
+                                 const gboolean display_byteorder,
+                                 const gboolean high_quality,
+                                 const gboolean upscale,
+                                 const gboolean is_scaling,
+                                 const gboolean thumbnail_export,
+                                 const char *filter,
+                                 const gboolean copy_metadata,
+                                 const gboolean export_masks,
+                                 dt_colorspaces_color_profile_type_t icc_type,
+                                 const gchar *icc_filename,
+                                 dt_iop_color_intent_t icc_intent,
+                                 dt_imageio_module_storage_t *storage,
+                                 dt_imageio_module_data_t *storage_params,
+                                 int num,
+                                 const int total,
+                                 dt_export_metadata_t *metadata,
+                                 const int history_end);
 
-size_t dt_imageio_write_pos(int i, int j, int wd, int ht, float fwd, float fht,
-                            dt_image_orientation_t orientation);
+size_t dt_imageio_write_pos(const int i,
+                            const int j,
+                            const int wd,
+                            const int ht,
+                            const float fwd,
+                            const float fht,
+                            const dt_image_orientation_t orientation);
 
 // general, efficient buffer flipping function using memcopies
-void dt_imageio_flip_buffers(char *out, const char *in,
+void dt_imageio_flip_buffers(char *out,
+                             const char *in,
                              const size_t bpp, // bytes per pixel
-                             const int wd, const int ht, const int fwd, const int fht, const int stride,
+                             const int wd,
+                             const int ht,
+                             const int fwd,
+                             const int fht,
+                             const int stride,
                              const dt_image_orientation_t orientation);
 
-void dt_imageio_flip_buffers_ui8_to_float(float *out, const uint8_t *in, const float black, const float white,
-                                          const int ch, const int wd, const int ht, const int fwd,
-                                          const int fht, const int stride,
+void dt_imageio_flip_buffers_ui8_to_float(float *out,
+                                          const uint8_t *in,
+                                          const float black,
+                                          const float white,
+                                          const int ch,
+                                          const int wd,
+                                          const int ht,
+                                          const int fwd,
+                                          const int fht,
+                                          const int stride,
                                           const dt_image_orientation_t orientation);
 
 // allocate buffer and return 0 on success along with largest jpg thumbnail from raw.
-int dt_imageio_large_thumbnail(const char *filename, uint8_t **buffer, int32_t *width, int32_t *height,
+int dt_imageio_large_thumbnail(const char *filename,
+                               uint8_t **buffer,
+                               int32_t *width,
+                               int32_t *height,
                                dt_colorspaces_color_profile_type_t *color_space);
 
 // lookup maker and model, dispatch lookup to rawspeed or libraw
-gboolean dt_imageio_lookup_makermodel(const char *maker, const char *model,
-                                      char *mk, int mk_len, char *md, int md_len,
-                                      char *al, int al_len);
+gboolean dt_imageio_lookup_makermodel(const char *maker,
+                                      const char *model,
+                                      char *mk,
+                                      const int mk_len,
+                                      char *md,
+                                      const int md_len,
+                                      char *al,
+                                      const int al_len);
 
 // get the type of image from its extension
 dt_image_flags_t dt_imageio_get_type_from_extension(const char *extension);

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -233,7 +233,8 @@ int operation_tags()
 
 int flags()
 {
-  return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_TILING_FULL_ROI | IOP_FLAGS_UNSAFE_COPY | IOP_FLAGS_GUIDES_WIDGET;
+  return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_TILING_FULL_ROI
+    | IOP_FLAGS_UNSAFE_COPY | IOP_FLAGS_GUIDES_WIDGET;
 }
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
@@ -2841,7 +2842,7 @@ static void target_geometry_changed(GtkWidget *widget, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_lens_params_t *p = (dt_iop_lens_params_t *)self->params;
 
-  int pos = dt_bauhaus_combobox_get(widget);
+  const int pos = dt_bauhaus_combobox_get(widget);
   p->target_geom = (pos + DT_IOP_LENS_LENSTYPE_UNKNOWN + 1);
   p->modified = 1;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -2873,9 +2874,11 @@ static void modflags_changed(GtkWidget *widget, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(darktable.gui->reset) return;
+
   dt_iop_lens_params_t *p = (dt_iop_lens_params_t *)self->params;
   dt_iop_lens_gui_data_t *g = (dt_iop_lens_gui_data_t *)self->gui_data;
-  int pos = dt_bauhaus_combobox_get(widget);
+
+  const int pos = dt_bauhaus_combobox_get(widget);
   for(GList *modifiers = g->modifiers;  modifiers; modifiers = g_list_next(modifiers))
   {
     dt_iop_lens_gui_modifier_t *mm = (dt_iop_lens_gui_modifier_t *)modifiers->data;
@@ -2915,7 +2918,9 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     gtk_widget_set_visible(g->tca_r, p->tca_override && !raw_monochrome);
     gtk_widget_set_visible(g->tca_b, p->tca_override && !raw_monochrome);
 
-  } else {
+  }
+  else
+  {
     gtk_stack_set_visible_child_name(GTK_STACK(g->methods), "metadata");
 
     gtk_widget_set_sensitive(GTK_WIDGET(g->modflags), TRUE);
@@ -3039,10 +3044,12 @@ void gui_init(struct dt_iop_module_t *self)
   // camera selector
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   g->camera_model = dt_iop_button_new(self, N_("camera model"),
-                                      G_CALLBACK(camera_menusearch_clicked), FALSE, 0, (GdkModifierType)0,
+                                      G_CALLBACK(camera_menusearch_clicked),
+                                      FALSE, 0, (GdkModifierType)0,
                                       NULL, 0, hbox);
   g->find_camera_button = dt_iop_button_new(self, N_("find camera"),
-                                            G_CALLBACK(camera_autosearch_clicked), FALSE, 0, (GdkModifierType)0,
+                                            G_CALLBACK(camera_autosearch_clicked),
+                                            FALSE, 0, (GdkModifierType)0,
                                             dtgtk_cairo_paint_solid_arrow, CPF_DIRECTION_DOWN, NULL);
   dt_gui_add_class(g->find_camera_button, "dt_big_btn_canvas");
   gtk_box_pack_start(GTK_BOX(hbox), g->find_camera_button, FALSE, FALSE, 0);
@@ -3051,10 +3058,12 @@ void gui_init(struct dt_iop_module_t *self)
   // lens selector
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   g->lens_model = dt_iop_button_new(self, N_("lens model"),
-                                    G_CALLBACK(lens_menusearch_clicked), FALSE, 0, (GdkModifierType)0,
+                                    G_CALLBACK(lens_menusearch_clicked),
+                                    FALSE, 0, (GdkModifierType)0,
                                     NULL, 0, hbox);
   g->find_lens_button = dt_iop_button_new(self, N_("find lens"),
-                                          G_CALLBACK(lens_autosearch_clicked), FALSE, 0, (GdkModifierType)0,
+                                          G_CALLBACK(lens_autosearch_clicked),
+                                          FALSE, 0, (GdkModifierType)0,
                                           dtgtk_cairo_paint_solid_arrow, CPF_DIRECTION_DOWN, NULL);
   dt_gui_add_class(g->find_lens_button, "dt_big_btn_canvas");
   gtk_box_pack_start(GTK_BOX(hbox), g->find_lens_button, FALSE, FALSE, 0);
@@ -3141,6 +3150,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->modflags, NULL, N_("corrections"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->modflags, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->modflags, _("which corrections to apply"));
+
   GList *l = g->modifiers;
   while(l)
   {
@@ -3149,7 +3159,8 @@ void gui_init(struct dt_iop_module_t *self)
     l = g_list_next(l);
   }
   dt_bauhaus_combobox_set(g->modflags, 0);
-  g_signal_connect(G_OBJECT(g->modflags), "value-changed", G_CALLBACK(modflags_changed), (gpointer)self);
+  g_signal_connect(G_OBJECT(g->modflags), "value-changed",
+                   G_CALLBACK(modflags_changed), (gpointer)self);
 
   g->methods = gtk_stack_new();
   gtk_stack_set_homogeneous(GTK_STACK(g->methods), FALSE);
@@ -3158,8 +3169,9 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_stack_add_named(GTK_STACK(g->methods), box_lf, "lensfun");
   gtk_stack_add_named(GTK_STACK(g->methods), box_md, "metadata");
 
-  // message box to inform user what corrections have been done. this is useful as depending on lensfuns
-  // profile only some of the lens flaws can be corrected
+  // message box to inform user what corrections have been done. this
+  // is useful as depending on lensfuns profile only some of the lens
+  // flaws can be corrected
   GtkBox *hbox1 = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
   GtkWidget *label = gtk_label_new(_("corrections done: "));
   gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_MIDDLE);
@@ -3198,7 +3210,7 @@ void gui_update(struct dt_iop_module_t *self)
     p->method = _get_method(self, method);
   }
 
-  int modflag = p->modify_flags;
+  const int modflag = p->modify_flags;
   for(GList *modifiers = g->modifiers; modifiers; modifiers = g_list_next(modifiers))
   {
     dt_iop_lens_gui_modifier_t *mm = (dt_iop_lens_gui_modifier_t *)modifiers->data;
@@ -3211,8 +3223,9 @@ void gui_update(struct dt_iop_module_t *self)
 
   dt_iop_lens_global_data_t *gd = (dt_iop_lens_global_data_t *)self->global_data;
   lfDatabase *dt_iop_lensfun_db = (lfDatabase *)gd->db;
-  // these are the wrong (untranslated) strings in general but that's ok, they will be overwritten further
-  // down
+
+  // these are the wrong (untranslated) strings in general but that's
+  // ok, they will be overwritten further down
   gtk_label_set_text(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->camera_model))), p->camera);
   gtk_label_set_text(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->lens_model))), p->lens);
   gtk_widget_set_tooltip_text(g->camera_model, "");
@@ -3221,6 +3234,7 @@ void gui_update(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_set(g->target_geom, p->target_geom - LF_UNKNOWN - 1);
   dt_bauhaus_combobox_set(g->reverse, p->inverse);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->tca_override), p->tca_override);
+
   const lfCamera **cam = NULL;
   g->camera = NULL;
   if(p->camera[0])
@@ -3233,6 +3247,7 @@ void gui_update(struct dt_iop_module_t *self)
     else
       camera_set(self, NULL);
   }
+
   if(g->camera && p->lens[0])
   {
     char model[200];


### PR DESCRIPTION
lens: Remove old code to be able to copy/paste lens correction.
    
This was a hack in this specific module to be able to copy/paste the
module and yet let it auto-initialized based on the picture camera
and lens. It is preferable to now use the generic auto-init support
which is available for all modules.

+ support for modifying more presets fields