### PR TITLE
Introduce dt_dump_pfm() as a developers helper

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -143,6 +143,7 @@ static int usage(const char *argv0)
 #ifdef HAVE_OPENCL
   printf("  --disable-opencl\n");
 #endif
+  printf("  --dump-pfm <module>\n");
   printf("  -h, --help");
 #ifdef _WIN32
   printf(", /?");
@@ -334,13 +335,13 @@ static void dt_codepaths_init()
 #endif
   {
     darktable.codepath.OPENMP_SIMD = 1;
-    fprintf(stderr, "[dt_codepaths_init] will be using experimental plain OpenMP SIMD codepath.\n");
+    dt_print(DT_DEBUG_ALWAYS, "[dt_codepaths_init] will be using experimental plain OpenMP SIMD codepath.\n");
   }
 
 #if defined(__SSE__)
   if(darktable.codepath._no_intrinsics)
   {
-    fprintf(stderr, "[dt_codepaths_init] SSE2-optimized codepath is disabled or unavailable.\n");
+    dt_print(DT_DEBUG_ALWAYS, "[dt_codepaths_init] SSE2-optimized codepath is disabled or unavailable.\n");
   }
 #endif
 }
@@ -386,7 +387,7 @@ static inline size_t _get_total_memory()
   return memInfo.ullTotalPhys / (uint64_t)1024;
 #else
   // assume 2GB until we have a better solution.
-  fprintf(stderr, "Unknown memory size. Assuming 2GB\n");
+  dt_print(DT_DEBUG_ALWAYS, "[get_total_memory] Unknown memory size. Assuming 2GB\n");
   return 2097152;
 #endif
 }
@@ -417,13 +418,53 @@ void check_resourcelevel(const char *key, int *fractions, const int level)
   }
 }
 
+void dt_dump_pfm(
+        const char *filename,
+        const float* data,
+        const int width,
+        const int height,
+        const int channels,
+        const char *modname)
+{
+  if(!darktable.dump_pfm_module) return;
+  if(!modname) return;
+  if(strcmp(modname, darktable.dump_pfm_module)) return; 
+
+  if(!((channels == 1) || (channels == 3)))
+  {
+    dt_print(DT_DEBUG_ALWAYS, "[dt_dump_pfm] only supports 1 or 3 channels\n"); 
+    return;
+  }
+
+  char fname[512];
+  snprintf(fname, sizeof (fname), "/tmp/darktable/%s/%s.pfm", modname, filename);
+
+  FILE *f = g_fopen(fname, "wb");
+  if(f == NULL)
+  {
+    dt_print(DT_DEBUG_ALWAYS, "[dt_dump_pfm] can't write file '%s' in wb mode\n", filename); 
+    return;
+  }
+
+  fprintf(f, "P%s\n%d %d\n-1.0\n", (channels == 1) ? "f" : "F", width, height);
+  for(int row = height - 1; row >= 0; row--)
+  {
+    for(int col = 0; col < width; col++)
+    {
+      const size_t blk = (row * width + col) * ((channels == 1) ? 1 : 4);
+      fwrite(data + blk, channels, sizeof(float), f);
+    }
+  }
+  fclose(f);
+}
+
 int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load_data, lua_State *L)
 {
   double start_wtime = dt_get_wtime();
 
 #ifndef _WIN32
   if(getuid() == 0 || geteuid() == 0)
-    printf(
+    dt_print(DT_DEBUG_ALWAYS,
         "WARNING: either your user id or the effective user id are 0. are you running darktable as root?\n");
 #endif
 
@@ -434,8 +475,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 
   dt_set_signal_handlers();
 
-  int sse2_supported = 0;
-
+  gboolean sse2_supported = FALSE;
 #ifdef HAVE_BUILTIN_CPU_SUPPORTS
   // NOTE: _may_i_use_cpu_feature() looks better, but only available in ICC
   __builtin_cpu_init();
@@ -443,11 +483,6 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 #else
   sse2_supported = dt_detect_cpu_features() & CPU_FLAG_SSE2;
 #endif
-  if(!sse2_supported)
-  {
-    fprintf(stderr, "[dt_init] SSE2 instruction set is unavailable.\n");
-    fprintf(stderr, "[dt_init] expect a LOT of functionality to be broken. you have been warned.\n");
-  }
 
 #ifdef M_MMAP_THRESHOLD
   mallopt(M_MMAP_THRESHOLD, 128 * 1024); /* use mmap() for large allocations */
@@ -460,6 +495,9 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   memset(&darktable, 0, sizeof(darktable_t));
 
   darktable.start_wtime = start_wtime;
+  if(!sse2_supported)
+    dt_print(DT_DEBUG_ALWAYS, "[dt_init] SSE2 instruction set is unavailable.\n"
+                              "[dt_init] expect a LOT of functionality to be broken. you have been warned.\n");
 
   darktable.progname = argv[0];
 
@@ -488,6 +526,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   char *configdir_from_command = NULL;
   char *cachedir_from_command = NULL;
 
+  darktable.dump_pfm_module = NULL;
 #ifdef HAVE_OPENCL
   gboolean exclude_opencl = FALSE;
   gboolean print_statistics = (strstr(argv[0], "darktable-cltest") == NULL);
@@ -629,6 +668,12 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
                );
         return 1;
       }
+      else if(!strcmp(argv[k], "--dump-pfm") && argc > k + 1)
+      {
+        darktable.dump_pfm_module = argv[++k];
+        argv[k-1] = NULL;
+        argv[k] = NULL;
+      }
       else if(!strcmp(argv[k], "--library") && argc > k + 1)
       {
         dbfilename_from_command = argv[++k];
@@ -746,7 +791,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 #ifdef DT_HAVE_SIGNAL_TRACE
           darktable.unmuted_signal_dbg_acts |= DT_DEBUG_SIGNAL_ACT_PRINT_TRACE; // enable printing of signal tracing
 #else
-          fprintf(stderr, "[signal] print-trace not available, skipping\n");
+          dt_print(DT_DEBUG_ALWAYS, "[signal] print-trace not available, skipping\n");
 #endif
         }
         else
@@ -805,7 +850,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
         CHKSIGDBG(DT_SIGNAL_METADATA_UPDATE);
         else
         {
-          fprintf(stderr, "unknown signal name: '%s'. use 'ALL' to enable debug for all or use full signal name\n", str);
+          dt_print(DT_DEBUG_SIGNAL, "[dt_init] unknown signal name: '%s'. use 'ALL' to enable debug for all or use full signal name\n", str);
           return usage(argv[0]);
         }
         g_free(str);
@@ -817,7 +862,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
       else if(argv[k][1] == 't' && argc > k + 1)
       {
         darktable.num_openmp_threads = CLAMP(atol(argv[k + 1]), 1, 100);
-        printf("[dt_init] using %d threads for openmp parallel sections\n", darktable.num_openmp_threads);
+        dt_print(DT_DEBUG_ALWAYS, "[dt_init] using %d threads for openmp parallel sections\n", darktable.num_openmp_threads);
         k++;
         argv[k-1] = NULL;
         argv[k] = NULL;
@@ -904,7 +949,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 
   if(darktable.unmuted & DT_DEBUG_MEMORY)
   {
-    fprintf(stderr, "[memory] at startup\n");
+    dt_print(DT_DEBUG_ALWAYS, "[memory] at startup\n");
     dt_print_mem_usage();
   }
 
@@ -1025,7 +1070,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   darktable.db = dt_database_init(dbfilename_from_command, load_data, init_gui);
   if(darktable.db == NULL)
   {
-    printf("ERROR : cannot open database\n");
+    dt_print(DT_DEBUG_ALWAYS, "ERROR : cannot open database\n");
     return 1;
   }
   else if(!dt_database_get_lock_acquired(darktable.db))
@@ -1035,7 +1080,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
       gboolean image_loaded_elsewhere = FALSE;
 #ifndef MAC_INTEGRATION
       // send the images to the other instance via dbus
-      fprintf(stderr, "trying to open the images in the running instance\n");
+      dt_print(DT_DEBUG_ALWAYS, "[dt_init] trying to open the images in the running instance\n");
 
       GDBusConnection *connection = NULL;
       for(int i = 1; i < argc; i++)
@@ -1057,7 +1102,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 
       if(!image_loaded_elsewhere) dt_database_show_error(darktable.db);
     }
-    fprintf(stderr, "ERROR: can't acquire database lock, aborting.\n");
+    dt_print(DT_DEBUG_ALWAYS, "ERROR: can't acquire database lock, aborting.\n");
     return 1;
   }
 
@@ -1199,7 +1244,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   {
     if(dt_gui_gtk_init(darktable.gui))
     {
-      fprintf(stderr, "ERROR: can't init gui, aborting.\n");
+      dt_print(DT_DEBUG_ALWAYS, "[dt_init] ERROR: can't init gui, aborting.\n");
       return 1;
     }
     dt_bauhaus_init();
@@ -1213,7 +1258,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   // check whether we were able to load darkroom view. if we failed, we'll crash everywhere later on.
   if(!darktable.develop)
   {
-    fprintf(stderr, "ERROR: can't init develop system, aborting.\n");
+    dt_print(DT_DEBUG_ALWAYS, "[dt_init] ERROR: can't init develop system, aborting.\n");
     return 1;
   }
 
@@ -1229,7 +1274,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   // check if all modules have a iop order assigned
   if(dt_ioppr_check_so_iop_order(darktable.iop, darktable.iop_order_list))
   {
-    fprintf(stderr, "ERROR: iop order looks bad, aborting.\n");
+    dt_print(DT_DEBUG_ALWAYS, "[dt_init] ERROR: iop order looks bad, aborting.\n");
     return 1;
   }
 
@@ -1241,6 +1286,10 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 
   // init metadata flags
   dt_metadata_init();
+
+  if(darktable.dump_pfm_module)
+    dt_print(DT_DEBUG_ALWAYS, "[dt_init] writing intermediate pfm files for module '%s'\n",
+      darktable.dump_pfm_module);
 
   if(init_gui)
   {
@@ -1273,7 +1322,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 
   if(darktable.unmuted & DT_DEBUG_MEMORY)
   {
-    fprintf(stderr, "[memory] after successful startup\n");
+    dt_print(DT_DEBUG_ALWAYS, "[memory] after successful startup\n");
     dt_print_mem_usage();
   }
 
@@ -1344,7 +1393,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     dt_control_crawler_show_image_list(changed_xmp_files);
   }
 
-  dt_print(DT_DEBUG_CONTROL, "[init] startup took %f seconds\n", dt_get_wtime() - start_wtime);
+  dt_print(DT_DEBUG_CONTROL, "[dt_init] startup took %f seconds\n", dt_get_wtime() - start_wtime);
 
   return 0;
 }
@@ -1384,14 +1433,14 @@ void dt_get_sysresource_level()
   {
     const int oldgrp = res->group;
     res->group = 4 * level;
-    fprintf(stderr,"[dt_get_sysresource_level] switched to %i as `%s'\n", level, config);
-    fprintf(stderr,"  total mem:       %luMB\n", res->total_memory / 1024lu / 1024lu);
-    fprintf(stderr,"  mipmap cache:    %luMB\n", _get_mipmap_size() / 1024lu / 1024lu);
-    fprintf(stderr,"  available mem:   %luMB\n", dt_get_available_mem() / 1024lu / 1024lu);
-    fprintf(stderr,"  singlebuff:      %luMB\n", dt_get_singlebuffer_mem() / 1024lu / 1024lu);
+    dt_print(DT_DEBUG_ALWAYS, "[dt_get_sysresource_level] switched to %i as `%s'\n", level, config);
+    dt_print(DT_DEBUG_ALWAYS, "  total mem:       %luMB\n", res->total_memory / 1024lu / 1024lu);
+    dt_print(DT_DEBUG_ALWAYS, "  mipmap cache:    %luMB\n", _get_mipmap_size() / 1024lu / 1024lu);
+    dt_print(DT_DEBUG_ALWAYS, "  available mem:   %luMB\n", dt_get_available_mem() / 1024lu / 1024lu);
+    dt_print(DT_DEBUG_ALWAYS, "  singlebuff:      %luMB\n", dt_get_singlebuffer_mem() / 1024lu / 1024lu);
 #ifdef HAVE_OPENCL
-    fprintf(stderr,"  OpenCL tune mem: %s\n", ((tunecl & DT_OPENCL_TUNE_MEMSIZE) && (level >= 0)) ? "WANTED" : "OFF");
-    fprintf(stderr,"  OpenCL pinned:   %s\n", ((tunecl & DT_OPENCL_TUNE_PINNED) && (level >= 0)) ? "WANTED" : "OFF");
+    dt_print(DT_DEBUG_ALWAYS, "  OpenCL tune mem: %s\n", ((tunecl & DT_OPENCL_TUNE_MEMSIZE) && (level >= 0)) ? "WANTED" : "OFF");
+    dt_print(DT_DEBUG_ALWAYS, "  OpenCL pinned:   %s\n", ((tunecl & DT_OPENCL_TUNE_PINNED) && (level >= 0)) ? "WANTED" : "OFF");
 #endif
     res->group = oldgrp;
   }
@@ -1879,7 +1928,8 @@ void dt_print_mem_usage()
   free(line);
   fclose(f);
 
-  fprintf(stderr, "[memory] max address space (vmpeak): %15s"
+  dt_print(DT_DEBUG_ALWAYS,
+                  "[memory] max address space (vmpeak): %15s"
                   "[memory] cur address space (vmsize): %15s"
                   "[memory] max used memory   (vmhwm ): %15s"
                   "[memory] cur used memory   (vmrss ): %15s",
@@ -1891,12 +1941,13 @@ void dt_print_mem_usage()
 
   if(KERN_SUCCESS != task_info(mach_task_self(), TASK_BASIC_INFO, (task_info_t)&t_info, &t_info_count))
   {
-    fprintf(stderr, "[memory] task memory info unknown.\n");
+    dt_print(DT_DEBUG_ALWAYS, "[memory] task memory info unknown.\n");
     return;
   }
 
   // Report in kB, to match output of /proc on Linux.
-  fprintf(stderr, "[memory] max address space (vmpeak): %15s\n"
+  dt_print(DT_DEBUG_ALWAYS,
+                  "[memory] max address space (vmpeak): %15s\n"
                   "[memory] cur address space (vmsize): %12llu kB\n"
                   "[memory] max used memory   (vmhwm ): %15s\n"
                   "[memory] cur used memory   (vmrss ): %12llu kB\n",
@@ -1921,7 +1972,8 @@ void dt_print_mem_usage()
   size_t physMemUsedByMe = pmc.WorkingSetSize;
 
 
-  fprintf(stderr, "[memory] max address space (vmpeak): %12llu kB\n"
+  dt_print(DT_DEBUG_ALWAYS,
+                  "[memory] max address space (vmpeak): %12llu kB\n"
                   "[memory] cur address space (vmsize): %12llu kB\n"
                   "[memory] max used memory   (vmhwm ): %12llu kB\n"
                   "[memory] cur used memory   (vmrss ): %12llu Kb\n",
@@ -1929,7 +1981,7 @@ void dt_print_mem_usage()
           physMemUsedByMe / 1024);
 
 #else
-  fprintf(stderr, "dt_print_mem_usage() currently unsupported on this platform\n");
+  dt_print(DT_DEBUG_ALWAYS, "dt_print_mem_usage() currently unsupported on this platform\n");
 #endif
 }
 

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -342,6 +342,7 @@ typedef struct darktable_t
   char *tmpdir;
   char *configdir;
   char *cachedir;
+  char *dump_pfm_module;
   dt_lua_state_t lua_state;
   GList *guides;
   double start_wtime;
@@ -370,6 +371,7 @@ void dt_print_nts(dt_debug_thread_t thread, const char *msg, ...) __attribute__(
 int dt_worker_threads();
 size_t dt_get_available_mem();
 size_t dt_get_singlebuffer_mem();
+void dt_dump_pfm(const char *filename, const float* data, const int width, const int height, const int channels, const char *modname);
 
 void *dt_alloc_align(size_t alignment, size_t size);
 static inline void* dt_calloc_align(size_t alignment, size_t size)

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -277,6 +277,14 @@ typedef enum dt_debug_thread_t
   DT_DEBUG_ALL            = 0xffffffff & ~DT_DEBUG_VERBOSE
 } dt_debug_thread_t;
 
+typedef enum dt_dump_pfm_t
+{
+  DT_DUMP_PFM_MASK        = 0,
+  DT_DUMP_PFM_RGB         = 1,
+  DT_DUMP_PFM_LAST        = 1,
+} dt_dump_pfm_t;
+
+
 typedef struct dt_codepath_t
 {
   unsigned int SSE2 : 1;
@@ -371,7 +379,7 @@ void dt_print_nts(dt_debug_thread_t thread, const char *msg, ...) __attribute__(
 int dt_worker_threads();
 size_t dt_get_available_mem();
 size_t dt_get_singlebuffer_mem();
-void dt_dump_pfm(const char *filename, const float* data, const int width, const int height, const int channels, const char *modname);
+void dt_dump_pfm(const char *filename, const void* data, const int width, const int height, dt_dump_pfm_t mode, const char *modname);
 
 void *dt_alloc_align(size_t alignment, size_t size);
 static inline void* dt_calloc_align(size_t alignment, size_t size)

--- a/src/common/locallaplacian.c
+++ b/src/common/locallaplacian.c
@@ -357,7 +357,7 @@ static inline float *ll_pad_input(
   }
   if((b && b->mode == 2) && (darktable.dump_pfm_module))
   {
-    dt_dump_pfm("padded", out, *wd2, *ht2, 3, "locallaplacian");
+    dt_dump_pfm("padded", out, *wd2, *ht2, DT_DUMP_PFM_RGB, "locallaplacian");
   }
   return out;
 }
@@ -640,8 +640,8 @@ void local_laplacian_internal(
     const int pw = dl(w,last_level), ph = dl(h,last_level);
     const int pw0 = dl(b->pwd, pl0), ph0 = dl(b->pht, pl0);
     const int pw1 = dl(b->pwd, pl1), ph1 = dl(b->pht, pl1);
-    dt_dump_pfm("coarse", b->output[pl0], pw0, ph0, 3, "locallaplacian");
-    dt_dump_pfm("oldcoarse", output[last_level], pw, ph, 3, "locallaplacian");
+    dt_dump_pfm("coarse", b->output[pl0], pw0, ph0, DT_DUMP_PFM_RGB, "locallaplacian");
+    dt_dump_pfm("oldcoarse", output[last_level], pw, ph, DT_DUMP_PFM_RGB, "locallaplacian");
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static) collapse(2) default(shared)
 #endif
@@ -679,7 +679,7 @@ void local_laplacian_internal(
 #endif
       output[last_level][j*pw+i] = weight * c1 + (1.0f-weight) * c0;
     }
-    dt_dump_pfm("newcoarse", output[last_level], pw, ph, 3, "locallaplacian");
+    dt_dump_pfm("newcoarse", output[last_level], pw, ph, DT_DUMP_PFM_RGB, "locallaplacian");
   }
 
   // assemble output pyramid coarse to fine

--- a/src/common/locallaplacian.c
+++ b/src/common/locallaplacian.c
@@ -34,8 +34,6 @@
 // the number of segments for the piecewise linear interpolation
 #define num_gamma 6
 
-//#define DEBUG_DUMP
-
 // downsample width/height to given level
 static inline int dl(int size, const int level)
 {
@@ -43,22 +41,6 @@ static inline int dl(int size, const int level)
     size = (size-1)/2+1;
   return size;
 }
-
-#ifdef DEBUG_DUMP
-static void dump_PFM(const char *filename, const float* out, const uint32_t w, const uint32_t h)
-{
-  FILE *f = g_fopen(filename, "wb");
-  fprintf(f, "PF\n%u %u\n-1.0\n", w, h);
-  for(int j=0;j<h;j++)
-    for(int i=0;i<w;i++)
-      for(int c=0;c<3;c++)
-        fwrite(out + w*j+i, 1, sizeof(float), f);
-  fclose(f);
-}
-#define debug_dump_PFM dump_PFM
-#else
-#define debug_dump_PFM(f,b,w,h)
-#endif
 
 // needs a boundary of 1 or 2px around i,j or else it will crash.
 // (translates to a 1px boundary around the corresponding pixel in the coarse buffer)
@@ -373,12 +355,10 @@ static inline float *ll_pad_input(
     }
     pad_by_replication(out, *wd2, *ht2, max_supp);
   }
-#ifdef DEBUG_DUMP
-  if(b && b->mode == 2)
+  if((b && b->mode == 2) && (darktable.dump_pfm_module))
   {
-    dump_PFM("/tmp/padded.pfm",out,*wd2,*ht2);
+    dt_dump_pfm("padded", out, *wd2, *ht2, 3, "locallaplacian");
   }
-#endif
   return out;
 }
 
@@ -660,8 +640,8 @@ void local_laplacian_internal(
     const int pw = dl(w,last_level), ph = dl(h,last_level);
     const int pw0 = dl(b->pwd, pl0), ph0 = dl(b->pht, pl0);
     const int pw1 = dl(b->pwd, pl1), ph1 = dl(b->pht, pl1);
-    debug_dump_PFM("/tmp/coarse.pfm", b->output[pl0], pw0, ph0);
-    debug_dump_PFM("/tmp/oldcoarse.pfm", output[last_level], pw, ph);
+    dt_dump_pfm("coarse", b->output[pl0], pw0, ph0, 3, "locallaplacian");
+    dt_dump_pfm("oldcoarse", output[last_level], pw, ph, 3, "locallaplacian");
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static) collapse(2) default(shared)
 #endif
@@ -699,7 +679,7 @@ void local_laplacian_internal(
 #endif
       output[last_level][j*pw+i] = weight * c1 + (1.0f-weight) * c0;
     }
-    debug_dump_PFM("/tmp/newcoarse.pfm", output[last_level], pw, ph);
+    dt_dump_pfm("newcoarse", output[last_level], pw, ph, 3, "locallaplacian");
   }
 
   // assemble output pyramid coarse to fine

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -350,7 +350,7 @@ static void debug_dump_PFM(const dt_dev_pixelpipe_iop_t *const piece, const char
 
   char name[256];
   snprintf(name, sizeof(name), namespec, scale);
-  dt_dump_pfm(name, buf, width, height, 3, "denoiseprofile");
+  dt_dump_pfm(name, buf, width, height, DT_DUMP_PFM_RGB, "denoiseprofile");
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -926,10 +926,10 @@ static inline gint wavelets_process(const float *const restrict in, float *const
     {
       char name[64];
       sprintf(name, "scale-input-%i", s);
-      dt_dump_pfm(name, buffer_in, width, height, 3, "diffuse");
+      dt_dump_pfm(name, buffer_in, width, height, DT_DUMP_PFM_RGB, "diffuse");
  
       sprintf(name, "scale-blur-%i", s);
-      dt_dump_pfm(name, buffer_out, width, height, 3, "diffuse");
+      dt_dump_pfm(name, buffer_out, width, height, DT_DUMP_PFM_RGB, "diffuse");
     }
   }
   dt_free_align(tempbuf);
@@ -984,7 +984,7 @@ static inline gint wavelets_process(const float *const restrict in, float *const
     {
       char name[64];
       sprintf(name, "scale-up-unblur-%i", s);
-      dt_dump_pfm(name, buffer_out, width, height, 3, "diffuse");
+      dt_dump_pfm(name, buffer_out, width, height, DT_DUMP_PFM_RGB, "diffuse");
     }
     count++;
   }

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -1587,10 +1587,10 @@ static inline gint wavelets_process(const float *const restrict in, float
     {
       char name[64];
       sprintf(name, "scale-input-%i", s);
-      dt_dump_pfm(name, buffer_in, width, height, 3, "highlights");
+      dt_dump_pfm(name, buffer_in, width, height, DT_DUMP_PFM_RGB, "highlights");
 
       sprintf(name, "scale-blur-%i", s);
-      dt_dump_pfm(name, buffer_out, width, height, 3, "highlights");
+      dt_dump_pfm(name, buffer_out, width, height, DT_DUMP_PFM_RGB, "highlights");
     }
   }
   dt_free_align(tempbuf);
@@ -1667,8 +1667,8 @@ static void process_laplacian_bayer(struct dt_iop_module_t *self, dt_dev_pixelpi
 
   if(darktable.dump_pfm_module)
   {
-    dt_dump_pfm("interpolated", interpolated, width, height, 3, "highlights");
-    dt_dump_pfm("clipping_mask", clipping_mask, width, height, 3, "highlights");
+    dt_dump_pfm("interpolated", interpolated, width, height, DT_DUMP_PFM_RGB, "highlights");
+    dt_dump_pfm("clipping_mask", clipping_mask, width, height, DT_DUMP_PFM_RGB, "highlights");
   }
 
   dt_free_align(interpolated);


### PR DESCRIPTION
At various places in darktable we use some pfm file writing for intermediate results of processing modules.
These writes are switched on/off at compile time, it might be worth to investigate such intermediate data without recompile cycles.

Also deduplicates code.

This pr

1. introduces a darktable runtime switch `--dump-pfm <modname>`
2. implements 
``` 
void dt_dump_pfm(
      const char *filename,
      const float *data,
      const int width,
      const int height,
      const int channels,
      const char *modname);
```
   that can write masks or rgb data.
   The file written will always be at: `/tmp/darktable/<modname>/<filename>.pfm`

3. some minor code cleanup
