### PR TITLE
use shift+alt+scroll for widget resize instead of ctrl+scroll

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2393,7 +2393,7 @@ void dt_dev_exposure_reset_defaults(dt_develop_t *dev)
 
   dt_iop_module_t *exposure = instance->module;
   memcpy(exposure->params, exposure->default_params, exposure->params_size);
-  exposure->gui_update(exposure);
+  dt_iop_gui_update(exposure);
   dt_dev_add_history_item(exposure->dev, exposure, TRUE);
 }
 

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -760,7 +760,7 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget, gint x, gint y, gboolea
   else
   {
     if(g_object_get_data(G_OBJECT(widget), "scroll-resize-tooltip"))
-      original_markup = dt_util_dstrcat(original_markup, "%s%s", original_markup ? "\n" : "", _("ctrl+scroll to change height"));
+      original_markup = dt_util_dstrcat(original_markup, "%s%s", original_markup ? "\n" : "", _("shift+alt+scroll to change height"));
     action = g_hash_table_lookup(darktable.control->widgets, widget);
     if(!action)
     {

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3063,7 +3063,7 @@ static gboolean _resize_wrap_scroll(GtkScrolledWindow *sw, GdkEventScroll *event
 
   dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y);
 
-  if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
+  if(dt_modifier_is(event->state, GDK_SHIFT_MASK | GDK_MOD1_MASK))
   {
     const gint new_size = dt_conf_get_int(config_str) + increment*delta_y;
 
@@ -3090,7 +3090,7 @@ static gboolean _resize_wrap_scroll(GtkScrolledWindow *sw, GdkEventScroll *event
 
 static gboolean _scroll_wrap_aspect(GtkWidget *w, GdkEventScroll *event, const char *config_str)
 {
-  if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
+  if(dt_modifier_is(event->state, GDK_SHIFT_MASK | GDK_MOD1_MASK))
   {
     int delta_y;
     if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3099,9 +3099,8 @@ static gboolean _scroll_wrap_aspect(GtkWidget *w, GdkEventScroll *event, const c
       const int aspect = dt_conf_get_int(config_str);
       dt_conf_set_int(config_str, aspect + delta_y);
       dtgtk_drawing_area_set_aspect_ratio(w, aspect / 100.0);
-
-      return TRUE;
     }
+    return TRUE;
   }
 
   return FALSE;

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -958,7 +958,7 @@ static gboolean dt_iop_levels_scroll(GtkWidget *widget, GdkEventScroll *event, g
 
   if(darktable.develop->gui_module != self) dt_iop_request_focus(self);
 
-  const float interval = 0.002; // Distance moved for each scroll event
+  const float interval = 0.002 * dt_accel_get_speed_multiplier(widget, event->state); // Distance moved for each scroll event
   int delta_y;
   if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
   {

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -653,7 +653,7 @@ static gboolean _area_scroll_callback(GtkWidget *widget, GdkEventScroll *event, 
 
   if(darktable.develop->gui_module != self) dt_iop_request_focus(self);
 
-  const float interval = 0.002; // Distance moved for each scroll event
+  const float interval = 0.002 * dt_accel_get_speed_multiplier(widget, event->state); // Distance moved for each scroll event
   int delta_y;
   if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
   {

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1194,18 +1194,16 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
       pango_layout_set_alignment(layout, PANGO_ALIGN_RIGHT);
 
       // scale conservatively to 100% of width:
-      gchar *text = g_strdup_printf("analogous complementary\nrotation: 360°");
-      pango_layout_set_text(layout, text, -1);
-      pango_layout_get_pixel_extents(layout, &ink, NULL);
+      pango_layout_set_text(layout, _("analogous complementary"), -1);
+      pango_layout_get_pixel_extents(layout, NULL, &ink);
       pango_font_description_set_absolute_size(desc, width * 0.9 / ink.width * PANGO_SCALE);
       pango_layout_set_font_description(layout, desc);
-      g_free(text);
 
-      text = g_strdup_printf("%d°\n%s", d->harmony_rotation, _(hm.name));
+      gchar *text = g_strdup_printf("%d°\n%s", d->harmony_rotation, _(hm.name));
 
       set_color(cr, darktable.bauhaus->graph_fg);
       pango_layout_set_text(layout, text, -1);
-      pango_layout_get_pixel_extents(layout, &ink, NULL);
+      pango_layout_get_pixel_extents(layout, NULL, &ink);
       cairo_scale(cr, 1., -1.);
       cairo_rotate(cr, -d->vectorscope_angle);
       cairo_move_to(cr, 0.48f * width - ink.width - ink.x, 0.48 * height - ink.height - ink.y);
@@ -1425,12 +1423,12 @@ static gboolean _drawable_motion_notify_callback(GtkWidget *widget, GdkEventMoti
     // FIXME: see dt_bauhaus_slider_postponed_value_change(): delay processing until the pixelpipe can update based on dev->preview_average_delay for smoother interaction
     if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_EXPOSURE)
     {
-      const float exposure = d->button_down_value + diff * 4.0f / (float)range;
+      const float exposure = d->button_down_value + diff * 4.0f / (float)range * dt_accel_get_speed_multiplier(widget, event->state);
       dt_dev_exposure_set_exposure(dev, exposure);
     }
     else if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_BLACK_POINT)
     {
-      const float black = d->button_down_value - diff * .1f / (float)range;
+      const float black = d->button_down_value - diff * .1f / (float)range * dt_accel_get_speed_multiplier(widget, event->state);
       dt_dev_exposure_set_black(dev, black);
     }
   }
@@ -1445,17 +1443,22 @@ static gboolean _drawable_motion_notify_callback(GtkWidget *widget, GdkEventMoti
     const gboolean hooks_available = (cv->view(cv) == DT_VIEW_DARKROOM) && dt_dev_exposure_hooks_available(dev);
 
     // FIXME: make just one tooltip for the widget depending on whether it is draggable or not, and set it when enter the view
-    if(!hooks_available || d->scope_type == DT_LIB_HISTOGRAM_SCOPE_VECTORSCOPE)
+    if(d->scope_type == DT_LIB_HISTOGRAM_SCOPE_VECTORSCOPE)
     {
       d->highlight = DT_LIB_HISTOGRAM_HIGHLIGHT_NONE;
       if(d->scope_type == DT_LIB_HISTOGRAM_SCOPE_VECTORSCOPE &&
               d->vectorscope_type == DT_LIB_HISTOGRAM_VECTORSCOPE_RYB &&
               d->color_harmony != DT_LIB_HISTOGRAM_HARMONY_NONE)
-      gtk_widget_set_tooltip_text(widget, "histogram");
+        gtk_widget_set_tooltip_text(widget, _("vectorscope\nscroll to coarse-rotate\nctrl+scroll to fine rotate"
+                                              "\nshift+scroll to change width\nalt+scroll to cycle"));
+      else
+        gtk_widget_set_tooltip_text(widget, _("vectorscope"));
     }
+    else if(!hooks_available)
+      gtk_widget_set_tooltip_text(widget, _("histogram"));
     // FIXME: could a GtkRange be used to do this work?
     else if((posx < 0.2f && d->scope_type == DT_LIB_HISTOGRAM_SCOPE_HISTOGRAM) ||
-            (d->scope_type == DT_LIB_HISTOGRAM_SCOPE_WAVEFORM &&
+            ((d->scope_type == DT_LIB_HISTOGRAM_SCOPE_WAVEFORM || d->scope_type == DT_LIB_HISTOGRAM_SCOPE_PARADE) &&
              ((posy > 7.0f/9.0f && d->scope_orient == DT_LIB_HISTOGRAM_ORIENT_HORI) ||
               (posx < 2.0f/9.0f && d->scope_orient == DT_LIB_HISTOGRAM_ORIENT_VERT))))
     {
@@ -1513,19 +1516,31 @@ static gboolean _drawable_button_press_callback(GtkWidget *widget, GdkEventButto
   return TRUE;
 }
 
-static gboolean _drawable_scroll_callback(GtkWidget *widget, GdkEventScroll *event, gpointer user_data)
+static void _color_harmony_button_on_off(dt_lib_histogram_color_harmony_type_t on,
+                                         dt_lib_histogram_color_harmony_type_t off,
+                                         dt_lib_histogram_t *d)
 {
-  if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
-  {
-    // bubble to adjusting the overall widget size
-    return FALSE;
-  }
+  if(off != DT_LIB_HISTOGRAM_HARMONY_NONE)
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->color_harmony_button[off - 1]), FALSE);
+  if(on != DT_LIB_HISTOGRAM_HARMONY_NONE)
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->color_harmony_button[on - 1]), TRUE);
+}
+
+static void _color_harmony_changed(dt_lib_histogram_t *d);
+
+static gboolean _eventbox_scroll_callback(GtkWidget *widget, GdkEventScroll *event, gpointer user_data)
+{
   dt_lib_histogram_t *d = (dt_lib_histogram_t *)user_data;
   int delta_y = 0;
+  if(dt_modifier_is(event->state, GDK_SHIFT_MASK | GDK_MOD1_MASK))
+  {
+    // bubble to adjusting the overall widget size
+    gtk_widget_event(d->scope_draw, (GdkEvent*)event);
+  }
   // note are using unit rather than smooth scroll events, as
   // exposure changes can get laggy if handling a multitude of smooth
   // scroll events
-  if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y) && delta_y != 0)
+  else if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y) && delta_y != 0)
   {
     if(d->highlight != DT_LIB_HISTOGRAM_HIGHLIGHT_NONE)
     {
@@ -1534,13 +1549,44 @@ static gboolean _drawable_scroll_callback(GtkWidget *widget, GdkEventScroll *eve
       if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_EXPOSURE)
       {
         const float ce = dt_dev_exposure_get_exposure(dev);
-        dt_dev_exposure_set_exposure(dev, ce - 0.15f * delta_y);
+        dt_dev_exposure_set_exposure(dev, ce - 0.15f * delta_y * dt_accel_get_speed_multiplier(widget, event->state));
       }
       else if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_BLACK_POINT)
       {
         const float cb = dt_dev_exposure_get_black(dev);
-        dt_dev_exposure_set_black(dev, cb + 0.001f * delta_y);
+        dt_dev_exposure_set_black(dev, cb + 0.001f * delta_y * dt_accel_get_speed_multiplier(widget, event->state));
       }
+    }
+    else if(d->scope_type == DT_LIB_HISTOGRAM_SCOPE_VECTORSCOPE)
+    {
+      if(dt_modifier_is(event->state, GDK_SHIFT_MASK)) // SHIFT+SCROLL
+      {
+        if(d->harmony_width == 0 && delta_y < 0) d->harmony_width = DT_LIB_HISTOGRAM_HARMONY_WIDTH_N - 1;
+        else d->harmony_width = (d->harmony_width +delta_y) % DT_LIB_HISTOGRAM_HARMONY_WIDTH_N;
+      }
+      else if(dt_modifier_is(event->state, GDK_MOD1_MASK)) // ALT+SCROLL
+      {
+        if(d->color_harmony_old == DT_LIB_HISTOGRAM_HARMONY_NONE && delta_y < 0)
+          d->color_harmony = DT_LIB_HISTOGRAM_HARMONY_N - 1;
+        else d->color_harmony = (d->color_harmony_old + delta_y) % DT_LIB_HISTOGRAM_HARMONY_N;
+        _color_harmony_button_on_off(d->color_harmony, d->color_harmony_old, d);
+        d->color_harmony_old = d->color_harmony;
+      }
+      else
+      {
+        int a;
+        if(dt_modifier_is(event->state, GDK_CONTROL_MASK)) // CTRL+SCROLL
+          a = d->harmony_rotation + delta_y;
+        else // SCROLL
+        {
+          d->harmony_rotation = (int)(d->harmony_rotation / 15.) * 15;
+          a = d->harmony_rotation + 15 * delta_y;
+        }
+        a %= 360;
+        if(a < 0) a += 360;
+        d->harmony_rotation = a;
+      }
+      _color_harmony_changed(d);
     }
   }
   return TRUE;
@@ -1814,17 +1860,6 @@ static void _color_harmony_changed(dt_lib_histogram_t *d)
   dt_control_queue_redraw_widget(d->scope_draw);
 }
 
-static void _color_harmony_button_on_off(dt_lib_histogram_color_harmony_type_t on,
-                                         dt_lib_histogram_color_harmony_type_t off,
-                                         dt_lib_histogram_t *d)
-{
-  if(off != DT_LIB_HISTOGRAM_HARMONY_NONE)
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->color_harmony_button[off - 1]), FALSE);
-  if(on != DT_LIB_HISTOGRAM_HARMONY_NONE)
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->color_harmony_button[on - 1]), TRUE);
-}
-
-
 static gboolean _color_harmony_clicked(GtkWidget *button, GdkEventButton *event, dt_lib_histogram_t *d)
 {
   if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button)))
@@ -1847,44 +1882,6 @@ static gboolean _color_harmony_clicked(GtkWidget *button, GdkEventButton *event,
     d->color_harmony = d->color_harmony_old = pos + 1;
   }
   _color_harmony_changed(d);
-  return TRUE;
-}
-
-static gboolean _color_harmony_scroll_callback(GtkWidget *widget, GdkEventScroll *event, gpointer user_data)
-{
-  dt_lib_histogram_t *d = (dt_lib_histogram_t *)user_data;
-  int delta_y = 0;
-  if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y) && delta_y != 0)
-  {
-    if(dt_modifier_is(event->state, GDK_SHIFT_MASK)) // SHIFT+SCROLL
-    {
-      if(d->harmony_width == 0 && delta_y < 0) d->harmony_width = DT_LIB_HISTOGRAM_HARMONY_WIDTH_N - 1;
-      else d->harmony_width = (d->harmony_width +delta_y) % DT_LIB_HISTOGRAM_HARMONY_WIDTH_N;
-    }
-    else if(dt_modifier_is(event->state, GDK_MOD1_MASK)) // ALT+SCROLL
-    {
-      if(d->color_harmony_old == DT_LIB_HISTOGRAM_HARMONY_NONE && delta_y < 0)
-        d->color_harmony = DT_LIB_HISTOGRAM_HARMONY_N - 1;
-      else d->color_harmony = (d->color_harmony_old + delta_y) % DT_LIB_HISTOGRAM_HARMONY_N;
-      _color_harmony_button_on_off(d->color_harmony, d->color_harmony_old, d);
-      d->color_harmony_old = d->color_harmony;
-    }
-    else
-    {
-      int a;
-      if(dt_modifier_is(event->state, GDK_CONTROL_MASK)) // CTRL+SCROLL
-        a = d->harmony_rotation + delta_y;
-      else // SCROLL
-        {
-          d->harmony_rotation = (int)(d->harmony_rotation / 15.) * 15;
-          a = d->harmony_rotation + 15 * delta_y;
-        }
-      a %= 360;
-      if(a < 0) a += 360;
-      d->harmony_rotation = a;
-    }
-    _color_harmony_changed(d);
-  }
   return TRUE;
 }
 
@@ -2252,22 +2249,7 @@ void gui_init(dt_lib_module_t *self)
   for(int i=0; i<DT_LIB_HISTOGRAM_SCOPE_N; i++)
   {
     d->scope_type_button[i] = dtgtk_togglebutton_new(dt_lib_histogram_scope_type_icons[i], CPF_NONE, NULL);
-    if(i == DT_LIB_HISTOGRAM_SCOPE_VECTORSCOPE)
-    {
-      gchar *text = g_strdup_printf("%s\n\n%s\n%s\n%s\n%s",
-                                    _(dt_lib_histogram_scope_type_names[i]),
-                                    _("scroll to coarse-rotate"),
-                                    _("ctrl+scroll to fine rotate"),
-                                    _("shift+scroll to change width"),
-                                    _("alt+scroll to cycle"));
-      gtk_widget_set_tooltip_text(d->scope_type_button[i], text);
-      g_free(text);
-    }
-    else
-    {
-      gtk_widget_set_tooltip_text(d->scope_type_button[i],
-                                  _(dt_lib_histogram_scope_type_names[i]));
-    }
+    gtk_widget_set_tooltip_text(d->scope_type_button[i], _(dt_lib_histogram_scope_type_names[i]));
     dt_action_define(dark, N_("modes"), dt_lib_histogram_scope_type_names[i],
                      d->scope_type_button[i], &dt_action_def_toggle);
     gtk_box_pack_start(GTK_BOX(box_left), d->scope_type_button[i], FALSE, FALSE, 0);
@@ -2323,9 +2305,6 @@ void gui_init(dt_lib_module_t *self)
                                            &(dt_color_harmonies[i]));
     dt_action_define(dark, N_("color harmonies"), dt_color_harmonies[i].name, rb, &dt_action_def_toggle);
     g_signal_connect(G_OBJECT(rb), "button-press-event", G_CALLBACK(_color_harmony_clicked), d);
-    gtk_widget_add_events(rb, darktable.gui->scroll_mask);
-    g_signal_connect(G_OBJECT(rb), "scroll-event",
-                     G_CALLBACK(_color_harmony_scroll_callback), d);
     g_signal_connect(G_OBJECT(rb), "enter-notify-event",
                      G_CALLBACK(_color_harmony_enter_notify_callback), d);
     g_signal_connect(G_OBJECT(rb), "leave-notify-event",
@@ -2382,8 +2361,8 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(d->green_channel_button), "toggled", G_CALLBACK(_green_channel_toggle), d);
   g_signal_connect(G_OBJECT(d->blue_channel_button), "toggled", G_CALLBACK(_blue_channel_toggle), d);
 
-  gtk_widget_add_events(d->scope_draw, GDK_LEAVE_NOTIFY_MASK | GDK_POINTER_MOTION_MASK | GDK_BUTTON_PRESS_MASK |
-                                       GDK_BUTTON_RELEASE_MASK | darktable.gui->scroll_mask);
+  gtk_widget_add_events(d->scope_draw, GDK_LEAVE_NOTIFY_MASK | GDK_POINTER_MOTION_MASK
+                                     | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK);
   // FIXME: why does cursor motion over buttons trigger multiple draw callbacks?
   g_signal_connect(G_OBJECT(d->scope_draw), "draw", G_CALLBACK(_drawable_draw_callback), d);
   g_signal_connect(G_OBJECT(d->scope_draw), "leave-notify-event",
@@ -2394,10 +2373,10 @@ void gui_init(dt_lib_module_t *self)
                    G_CALLBACK(_drawable_button_release_callback), d);
   g_signal_connect(G_OBJECT(d->scope_draw), "motion-notify-event",
                    G_CALLBACK(_drawable_motion_notify_callback), d);
-  g_signal_connect(G_OBJECT(d->scope_draw), "scroll-event",
-                   G_CALLBACK(_drawable_scroll_callback), d);
 
-  gtk_widget_add_events(eventbox, GDK_LEAVE_NOTIFY_MASK | GDK_ENTER_NOTIFY_MASK | GDK_POINTER_MOTION_MASK);
+  gtk_widget_add_events(eventbox, GDK_LEAVE_NOTIFY_MASK | GDK_ENTER_NOTIFY_MASK | GDK_POINTER_MOTION_MASK | darktable.gui->scroll_mask);
+  g_signal_connect(G_OBJECT(eventbox), "scroll-event",
+                   G_CALLBACK(_eventbox_scroll_callback), d);
   g_signal_connect(G_OBJECT(eventbox), "enter-notify-event",
                    G_CALLBACK(_eventbox_enter_notify_callback), d);
   g_signal_connect(G_OBJECT(eventbox), "leave-notify-event",

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -89,7 +89,7 @@ int position(const dt_lib_module_t *self)
 static void _lib_navigation_control_redraw_callback(gpointer instance, gpointer user_data)
 {
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
-  dt_control_queue_redraw_widget(self->widget);
+  dt_control_queue_redraw_widget(gtk_bin_get_child(GTK_BIN(self->widget)));
 }
 
 
@@ -311,7 +311,7 @@ void _lib_navigation_set_position(dt_lib_module_t *self, double x, double y, int
     dt_control_set_dev_zoom_y(zoom_y);
 
     /* redraw myself */
-    gtk_widget_queue_draw(self->widget);
+    _lib_navigation_control_redraw_callback(NULL, self);
 
     /* redraw pipe */
     dt_dev_invalidate(darktable.develop);

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -442,7 +442,7 @@ static gboolean _lib_navigation_button_press_callback(GtkWidget *widget, GdkEven
   dt_lib_navigation_t *d = (dt_lib_navigation_t *)self->data;
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
-  if(event->type == GDK_BUTTON_PRESS && event->button.button == 1)
+  if(event->type == GDK_BUTTON_PRESS && event->button.button != 2)
   {
     d->dragging = 1;
     _lib_navigation_set_position(self, event->button.x, event->button.y, allocation.width, allocation.height);


### PR DESCRIPTION
REQUEST FOR COMMENTS.

Please vote by adding an emoji to this first post:
❤️ HEART this is great; please merge
👍 THUMBS UP fine by me; I won't complain if merged
👎 THUMBS DOWN please no, this breaks my muscle memory

Now that it is possible to resize many widgets and graphs by dragging the lower border up or down, the old way of doing this by scrolling with the mouse wheel while holding ctrl may not be as necessary anymore and could be replaced by a slightly more awkward shift+alt+scroll for those rare occasions when we can't seem to hit the stretch spot.

![image](https://user-images.githubusercontent.com/1549490/216730779-e9763414-722a-43a5-8dc9-44b0d05c0522.png)


The advantage of this is that it frees up ctrl so it can be used in the ordinary way, namely to finetune the effect of a scroll (dividing the magnitude by 10, by default).

The modules that benefit are:
- levels (rgb): moving the levels by scroll can now by sped up and down by holding shift and ctrl respectively
- histogram: while adjusting the exposure or black level correction (by either scrolling or dragging over the histogram) the accuracy of the adjustment can be increased by holding ctrl.
- vectorscope: the speed of rotation can be reduced by holding ctrl (shift is for varying the width) and scrolling works over the whole area rather than just the buttons (which was the approach used to avoid conflict with resizing)
- navigation: holding ctrl while scrolling adjusts the zoom level without boundaries (as it does over the center image)

This PR adds a couple of additional fixes to histogram;
- resetting the exposure by double-clicking correctly updates the sliders in the module
- the tooltip is updated for the different modes
- exposure adjustments works in "rgb parade" as well.
- the small jumps when switching between harmonies after recent change to angle\nharmony resolved
- correct mode name in tooltips (fixes #13484)

Also fixes some bugs introduced in https://github.com/darktable-org/darktable/pull/13507