### PR TITLE
Improve debugging output for parameter/style/presets related stuff

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -34,8 +34,6 @@
 #include "gui/hist_dialog.h"
 #include "imageio/imageio_common.h"
 
-#define DT_IOP_ORDER_INFO (darktable.unmuted & DT_DEBUG_IOPORDER)
-
 void dt_history_item_free(gpointer data)
 {
   dt_history_item_t *item = (dt_history_item_t *)data;
@@ -552,7 +550,7 @@ static int _history_copy_and_paste_on_image_merge(const int32_t imgid,
 
   if(ops)
   {
-    if(DT_IOP_ORDER_INFO) fprintf(stderr," selected ops");
+    dt_print(DT_DEBUG_IOPORDER, "[history_copy_and_paste_on_image_merge] selected modules\n");
     // copy only selected history entries
     for(const GList *l = g_list_last(ops); l; l = g_list_previous(l))
     {
@@ -565,8 +563,7 @@ static int _history_copy_and_paste_on_image_merge(const int32_t imgid,
       {
         if(!dt_iop_is_hidden(hist->module))
         {
-          if(DT_IOP_ORDER_INFO)
-            fprintf(stderr,"\n  module %20s, multiprio %i",
+          dt_print(DT_DEBUG_IOPORDER, "  module %20s, multiprio %i\n",
                     hist->module->op, hist->module->multi_priority);
 
           mod_list = g_list_prepend(mod_list, hist->module);
@@ -577,7 +574,7 @@ static int _history_copy_and_paste_on_image_merge(const int32_t imgid,
   }
   else
   {
-    if(DT_IOP_ORDER_INFO) fprintf(stderr," all modules");
+    dt_print(DT_DEBUG_IOPORDER, "[history_copy_and_paste_on_image_merge] all modules\n");
     // we will copy all modules
     for(GList *modules_src = dev_src->iop;
         modules_src;
@@ -597,7 +594,6 @@ static int _history_copy_and_paste_on_image_merge(const int32_t imgid,
       }
     }
   }
-  if(DT_IOP_ORDER_INFO) fprintf(stderr,"\nvvvvv\n");
 
   // list were built in reverse order, so un-reverse it
   mod_list = g_list_reverse(mod_list);
@@ -1372,7 +1368,7 @@ GList *dt_history_duplicate(GList *hist)
       else
       {
         // nothing else to do
-        fprintf(stderr, "[_duplicate_history] can't find base module for %s\n", old->op_name);
+        dt_print(DT_DEBUG_ALWAYS, "[_duplicate_history] can't find base module for %s\n", old->op_name);
       }
     }
 
@@ -1882,7 +1878,6 @@ gboolean dt_history_delete_on_list(const GList *list, const gboolean undo)
   return TRUE;
 }
 
-#undef DT_IOP_ORDER_INFO
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -39,8 +39,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#define DT_IOP_ORDER_INFO (darktable.unmuted & DT_DEBUG_IOPORDER)
-
 typedef struct
 {
   GString *name;
@@ -954,8 +952,8 @@ void _styles_apply_to_image_ext(const char *name,
 
     dt_ioppr_check_iop_order(dev_dest, newimgid, "dt_styles_apply_to_image 1");
 
-    if(DT_IOP_ORDER_INFO)
-      fprintf(stderr,"\n^^^^^ Apply style on image %i, history size %i",imgid,dev_dest->history_end);
+    dt_print(DT_DEBUG_IOPORDER, "[styles_apply_to_image_ext] Apply style on image `%s' id %i, history size %i",
+      dev_dest->image_storage.filename, newimgid, dev_dest->history_end);
 
     // go through all entries in style
     // clang-format off
@@ -1010,8 +1008,6 @@ void _styles_apply_to_image_ext(const char *name,
     }
 
     g_list_free_full(si_list, dt_style_item_free);
-
-    if(DT_IOP_ORDER_INFO) fprintf(stderr,"\nvvvvv --> look for written history below\n");
 
     dt_ioppr_check_iop_order(dev_dest, newimgid, "dt_styles_apply_to_image 2");
 
@@ -1786,7 +1782,6 @@ dt_style_t *dt_styles_get_by_name(const char *name)
   }
 }
 
-#undef DT_IOP_ORDER_INFO
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -55,7 +55,6 @@ DT_MODULE(1)
 // if a preset cannot be loaded or the current preset deleted, this is the fallback preset
 
 #define PADDING 2
-#define DT_IOP_ORDER_INFO (darktable.unmuted & DT_DEBUG_IOPORDER)
 
 #include "modulegroups.h"
 
@@ -829,8 +828,7 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
                                   ? gtk_entry_get_text(GTK_ENTRY(d->text_entry))
                                   : NULL;
 
-  if(DT_IOP_ORDER_INFO)
-    fprintf(stderr,"\n^^^^^ modulegroups");
+  dt_print(DT_DEBUG_IOPORDER, "[lib_modulegroups_update_iop_visibility] modulegroups\n");
 
   // update basic button selection too
   g_signal_handlers_block_matched(d->basic_btn, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, _lib_modulegroups_toggle, NULL);
@@ -867,11 +865,9 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
     dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
     GtkWidget *w = module->expander;
 
-    if((DT_IOP_ORDER_INFO) && (module->enabled))
-    {
-      fprintf(stderr, "\n%20s %d", module->op, module->iop_order);
-      if(dt_iop_is_hidden(module)) fprintf(stderr, ", hidden");
-    }
+    if(module->enabled)
+    dt_print(DT_DEBUG_IOPORDER, "%20s %d%s",
+      module->op, module->iop_order, (dt_iop_is_hidden(module)) ? ", hidden" : "");
 
       /* skip modules without an gui */
       if(dt_iop_is_hidden(module)) continue;
@@ -981,7 +977,7 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
       }
 
   }
-  if(DT_IOP_ORDER_INFO) fprintf(stderr,"\nvvvvv\n");
+
   // now that visibility has been updated set multi-show
   dt_dev_modules_update_multishow(darktable.develop);
 


### PR DESCRIPTION
- use dt_print() all over for readability
- leave some hint about the filename while processing the pipe
- getting rid of some macros