### PR TITLE
Bugfix OpenCL: avoid bad pinned transfer

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -1107,7 +1107,7 @@ finally:
           tgpumax = fmaxf(cl->dev[n].benchmark, tgpumax);
         }
       }
-      
+
       if(tcpu < tgpumin / 3.0f)
       {
         // de-activate opencl for darktable in case the cpu is three times faster than the fastest GPU.
@@ -2841,13 +2841,16 @@ void dt_opencl_check_tuning(const int devid)
   static int oldtuned = -999;
 
   const int tunemode = res->tunemode;
-  const int pinmode = cl->dev[devid].pinned_memory;
-  
   cl->dev[devid].tuneactive = tunemode & DT_OPENCL_TUNE_MEMSIZE;
 
-  if(((pinmode & DT_OPENCL_PINNING_DISABLED) == 0) &&
-     ((cl->dev[devid].runtime_error & DT_OPENCL_TUNE_PINNED) == 0) &&
-     ((pinmode & DT_OPENCL_PINNING_ON) || (tunemode & DT_OPENCL_TUNE_PINNED)))
+  const int pinmode = cl->dev[devid].pinned_memory;
+  const gboolean safe_clmemsize = cl->dev[devid].max_global_mem < (size_t) (darktable.dtresources.total_memory / 16lu / cl->num_devs); 
+  const gboolean want_pinned = (pinmode & DT_OPENCL_PINNING_ON) || (tunemode & DT_OPENCL_TUNE_PINNED);
+
+  if(((pinmode & DT_OPENCL_PINNING_DISABLED) == 0)
+       && ((cl->dev[devid].runtime_error & DT_OPENCL_TUNE_PINNED) == 0)
+       && want_pinned
+       && safe_clmemsize)
     cl->dev[devid].tuneactive |= DT_OPENCL_TUNE_PINNED;
 
   int level = res->level;

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -159,7 +159,7 @@ typedef struct dt_opencl_device_t
   // this can often be avoided by using indirect transfers via pinned memory,
   // other devices have more efficient direct memory transfer implementations.
   // We can't predict on solid grounds if a device belongs to the first or second group,
-  // also pinned mem transfer requires slightly more ram. 
+  // also pinned mem transfer requires slightly more video ram plus system memory. 
   // this holds a bitmask defined by dt_opencl_pinmode_t
   // the device specific conf key might hold
   // 0 -> disabled by default; might be switched on by tune for performance


### PR DESCRIPTION
As a reminder, we might want to use pinned memory transfer in dt.

As implemented and used this mode is for tiling; we might have a massive amout of repeated memory transfer there and in such a case the pinned mode might have performance gains.

But: it comes with a cost
- slightly more graphics mem used (is this still necessary with correct drivers)
- while pinning we map system memory which is als used otherwise, we must make sure those demands are safe otherwise the system might get in deep trouble.

There is no safe bet on this but we have to do a safety belt.

We accept a total of 1/8th of system memory to be used for pinned mapping, if we can't garantee that we prefer a possibly minor performance drop over stability issues.

It might be a rare issue (people must switch on pinned transfer and have a lot of graphics ram and not so much system mem) but still an issue. Probably also for 4.2.1 