### PR TITLE
Remove SSE2 code from nlmeans

### DIFF
--- a/src/common/nlmeans_core.c
+++ b/src/common/nlmeans_core.c
@@ -52,9 +52,6 @@
 // architectures with slower multiplication.
 //#define CACHE_PIXDIFFS
 
-// re-checked SSE2 codepath performance on 8-core Intel (tested with nthreads 4, 8, 16) there was no gain
-// of significance. So dropping code for less maintenance burden and possibly bugs. 
-
 // number of intermediate buffers used by OpenCL code path.  If you change this, you must also change
 //   the definition in src/iop/nlmeans.c and src/iop/denoiseprofile.c
 #define NUM_BUCKETS 4

--- a/src/common/nlmeans_core.h
+++ b/src/common/nlmeans_core.h
@@ -1,7 +1,7 @@
 #pragma once
 /*
     This file is part of darktable,
-    Copyright (C) 2020 darktable developers.
+    Copyright (C) 2020-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -43,10 +43,6 @@ typedef struct dt_nlmeans_param_t dt_nlmeans_param_t;
 void nlmeans_denoise(const float *const inbuf, float *const outbuf,
                      const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
                      const dt_nlmeans_param_t *const params);
-
-void nlmeans_denoise_sse2(const float *const inbuf, float *const outbuf,
-                          const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
-                          const dt_nlmeans_param_t *const params);
 
 #ifdef HAVE_OPENCL
 int nlmeans_denoise_cl(const dt_nlmeans_param_t *const params, const int devid,

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2020 darktable developers.
+    Copyright (C) 2011-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -31,10 +31,6 @@
 #include "iop/iop_api.h"
 #include <gtk/gtk.h>
 #include <stdlib.h>
-
-#if defined(__SSE__)
-#include <xmmintrin.h>
-#endif
 
 // which version of the non-local means code should be used?  0=old (this file), 1=new (src/common/nlmeans_core.c)
 #define USE_NEW_IMPL_CL 0
@@ -361,12 +357,13 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   return;
 }
 
-static void process_cpu(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
-                        void *const ovoid, const dt_iop_roi_t *const roi_in,
-                        const dt_iop_roi_t *const roi_out,
-                        void (*denoiser)(const float *const inbuf, float *const outbuf,
-                                         const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
-                                         const dt_nlmeans_param_t *const params))
+void process(
+        struct dt_iop_module_t *self,
+        dt_dev_pixelpipe_iop_t *piece,
+        const void *const ivoid,
+        void *const ovoid,
+        const dt_iop_roi_t *const roi_in,
+        const dt_iop_roi_t *const roi_out)
 {
   // this is called for preview and full pipe separately, each with its own pixelpipe piece.
   // get our data struct:
@@ -399,27 +396,11 @@ static void process_cpu(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
                                       .search_radius = K,
                                       .decimate = decimate,
                                       .norm = norm2 };
-  denoiser(ivoid,ovoid,roi_in,roi_out,&params);
+
+  nlmeans_denoise(ivoid, ovoid, roi_in, roi_out, &params);
   if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
     dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
-
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
-             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
-{
-  process_cpu(piece,ivoid,ovoid,roi_in,roi_out,nlmeans_denoise);
-  return;
-}
-
-#if defined(__SSE__)
-/** process, all real work is done here. */
-void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
-                  void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
-{
-  process_cpu(piece,ivoid,ovoid,roi_in,roi_out,nlmeans_denoise_sse2);
-  return;
-}
-#endif
 
 void init_global(dt_iop_module_so_t *module)
 {


### PR DESCRIPTION
Issue #12662 lead to investigating the code, the underlying reason seems not to be fully understood yet but performance tests did not show any significant performance gain (using -O3) for the SSE2 codepath so that has been dropped. (astrophoto denoise and nlmeans part of profiled denoise)

There is another optional codeath 'CACHE_PIXDIFFS' that might give an advantage, on my tested system there is at least not a penalty so that code has been kept.

Additional info: 
1. Reported is a possible dependency on the image (sample in #13371)
2. Crash might be hard to trigger, didn't have a single one on OpenCL or this pr

@ralfbrown could you review please?