### PR TITLE
Debug memory checks & pixelpipe buffer check

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -952,11 +952,8 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   // get valid directories
   dt_loc_init(datadir_from_command, moduledir_from_command, localedir_from_command, configdir_from_command, cachedir_from_command, tmpdir_from_command);
 
-  if(darktable.unmuted & DT_DEBUG_MEMORY)
-  {
-    dt_print(DT_DEBUG_ALWAYS, "[memory] at startup\n");
-    dt_print_mem_usage();
-  }
+  dt_print(DT_DEBUG_MEMORY, "[memory] at startup\n");
+  dt_print_mem_usage();
 
   char sharedir[PATH_MAX] = { 0 };
   dt_loc_get_sharedir(sharedir, sizeof(sharedir));
@@ -1325,11 +1322,8 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     darktable.undo = dt_undo_init();
   }
 
-  if(darktable.unmuted & DT_DEBUG_MEMORY)
-  {
-    dt_print(DT_DEBUG_ALWAYS, "[memory] after successful startup\n");
-    dt_print_mem_usage();
-  }
+  dt_print(DT_DEBUG_MEMORY, "[memory] after successful startup\n");
+  dt_print_mem_usage();
 
   dt_image_local_copy_synch();
 
@@ -1903,6 +1897,8 @@ void dt_capabilities_cleanup()
 
 void dt_print_mem_usage()
 {
+  if(!(darktable.unmuted & DT_DEBUG_MEMORY))
+    return;
 #if defined(__linux__)
   char *line = NULL;
   size_t len = 128;

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -632,6 +632,7 @@ static inline const GList *g_list_prev_wraparound(const GList *list)
   return g_list_previous(list) ? g_list_previous(list) : g_list_last((GList*)list);
 }
 
+// checks internally for DT_DEBUG_MEMORY
 void dt_print_mem_usage();
 
 void dt_configure_runtime_performance(const int version, char *config_info);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1031,6 +1031,10 @@ static int pixelpipe_process_on_CPU(
   if(dt_atomic_get_int(&pipe->shutdown))
     return 1;
 
+  // the data buffers must always have a 64 alignment
+  if((((uintptr_t)input) & 63) || (((uintptr_t)*output) & 63))
+    dt_print(DT_DEBUG_ALWAYS, "[pixelpipe_process_on_CPU] buffer aligment problem: IN=%p OUT=%p\n", input, *output);
+
   // Fetch RGB working profile
   // if input is RAW, we can't color convert because RAW is not in a color space
   // so we send NULL to by-pass
@@ -2263,11 +2267,8 @@ int dt_dev_pixelpipe_process(
 
   dt_dev_pixelpipe_cache_checkmem(pipe);
 
-  if(darktable.unmuted & DT_DEBUG_MEMORY)
-  {
-    dt_print(DT_DEBUG_ALWAYS, "[memory] before pixelpipe process\n");
-    dt_print_mem_usage();
-  }
+  dt_print(DT_DEBUG_MEMORY, "[memory] before pixelpipe process\n");
+  dt_print_mem_usage();
 
   if(pipe->devid >= 0) dt_opencl_events_reset(pipe->devid);
 


### PR DESCRIPTION
1. refactored dt_print_mem_usage() testing for DT_DEBUG_MEMORY and make dt using it
2. Introduce a in/out data buffer pointer validition for 64 alignment while processing the pixelpipe