### PR TITLE
[imageio] Move setting image flags to loaders

### DIFF
--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -620,17 +620,7 @@ dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img,
   dt_imageio_retval_t ret;
 
   ret = dt_imageio_open_jpeg(img, filename, buf);
-  if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL)
-  {
-    img->buf_dsc.cst = IOP_CS_RGB; // jpeg is always RGB
-    img->buf_dsc.filters = 0u;
-    img->flags &= ~DT_IMAGE_RAW;
-    img->flags &= ~DT_IMAGE_S_RAW;
-    img->flags &= ~DT_IMAGE_HDR;
-    img->flags |= DT_IMAGE_LDR;
-    img->loader = LOADER_JPEG;
-    return ret;
-  }
+  if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL) return ret;
 
   ret = dt_imageio_open_tiff(img, filename, buf);
   if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL)

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -646,17 +646,7 @@ dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img,
 
 #ifdef HAVE_WEBP
   ret = dt_imageio_open_webp(img, filename, buf);
-  if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL)
-  {
-    img->buf_dsc.cst = IOP_CS_RGB;
-    img->buf_dsc.filters = 0u;
-    img->flags &= ~DT_IMAGE_RAW;
-    img->flags &= ~DT_IMAGE_S_RAW;
-    img->flags &= ~DT_IMAGE_HDR;
-    img->flags |= DT_IMAGE_LDR;
-    img->loader = LOADER_WEBP;
-    return ret;
-  }
+  if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL) return ret;
 #endif
 
   ret = dt_imageio_open_png(img, filename, buf);

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -650,17 +650,7 @@ dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img,
 #endif
 
   ret = dt_imageio_open_png(img, filename, buf);
-  if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL)
-  {
-    img->buf_dsc.cst = IOP_CS_RGB; // png is always RGB
-    img->buf_dsc.filters = 0u;
-    img->flags &= ~DT_IMAGE_RAW;
-    img->flags &= ~DT_IMAGE_S_RAW;
-    img->flags &= ~DT_IMAGE_HDR;
-    img->flags |= DT_IMAGE_LDR;
-    img->loader = LOADER_PNG;
-    return ret;
-  }
+  if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL) return ret;
 
 #ifdef HAVE_OPENJPEG
   ret = dt_imageio_open_j2k(img, filename, buf);

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -654,17 +654,7 @@ dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img,
 
 #ifdef HAVE_OPENJPEG
   ret = dt_imageio_open_j2k(img, filename, buf);
-  if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL)
-  {
-    img->buf_dsc.cst = IOP_CS_RGB; // j2k is always RGB
-    img->buf_dsc.filters = 0u;
-    img->flags &= ~DT_IMAGE_RAW;
-    img->flags &= ~DT_IMAGE_HDR;
-    img->flags &= ~DT_IMAGE_S_RAW;
-    img->flags |= DT_IMAGE_LDR;
-    img->loader = LOADER_J2K;
-    return ret;
-  }
+  if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL) return ret;
 #endif
 
   ret = dt_imageio_open_pnm(img, filename, buf);

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -623,16 +623,7 @@ dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img,
   if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL) return ret;
 
   ret = dt_imageio_open_tiff(img, filename, buf);
-  if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL)
-  {
-    // cst is set by dt_imageio_open_tiff()
-    img->buf_dsc.filters = 0u;
-    // TIFF can be HDR or LDR. corresponding flags are set in dt_imageio_open_tiff()
-    img->flags &= ~DT_IMAGE_RAW;
-    img->flags &= ~DT_IMAGE_S_RAW;
-    img->loader = LOADER_TIFF;
-    return ret;
-  }
+  if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL) return ret;
 
 #ifdef HAVE_WEBP
   ret = dt_imageio_open_webp(img, filename, buf);

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -639,17 +639,7 @@ dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img,
 #endif
 
   ret = dt_imageio_open_pnm(img, filename, buf);
-  if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL)
-  {
-    img->buf_dsc.cst = IOP_CS_RGB; // pnm is always RGB
-    img->buf_dsc.filters = 0u;
-    img->flags &= ~DT_IMAGE_RAW;
-    img->flags &= ~DT_IMAGE_S_RAW;
-    img->flags &= ~DT_IMAGE_HDR;
-    img->flags |= DT_IMAGE_LDR;
-    img->loader = LOADER_PNM;
-    return ret;
-  }
+  if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL) return ret;
 
   return DT_IMAGEIO_LOAD_FAILED;
 }

--- a/src/imageio/imageio_j2k.c
+++ b/src/imageio/imageio_j2k.c
@@ -306,7 +306,14 @@ dt_imageio_retval_t dt_imageio_open_j2k(dt_image_t *img, const char *filename, d
         buf[i * 4 + k] = (float)(image->comps[k].data[i] + signed_offsets[k]) / float_divs[k];
   }
 
+  img->buf_dsc.cst = IOP_CS_RGB; // j2k is always RGB
+  img->buf_dsc.filters = 0u;
+  img->flags &= ~DT_IMAGE_RAW;
+  img->flags &= ~DT_IMAGE_HDR;
+  img->flags &= ~DT_IMAGE_S_RAW;
+  img->flags |= DT_IMAGE_LDR;
   img->loader = LOADER_J2K;
+
   ret = DT_IMAGEIO_OK;
 
 end_of_the_world:

--- a/src/imageio/imageio_jpeg.c
+++ b/src/imageio/imageio_jpeg.c
@@ -799,7 +799,14 @@ dt_imageio_retval_t dt_imageio_open_jpeg(dt_image_t *img,
 
   dt_free_align(tmp);
 
+  img->buf_dsc.cst = IOP_CS_RGB; // jpeg is always RGB
+  img->buf_dsc.filters = 0u;
+  img->flags &= ~DT_IMAGE_RAW;
+  img->flags &= ~DT_IMAGE_S_RAW;
+  img->flags &= ~DT_IMAGE_HDR;
+  img->flags |= DT_IMAGE_LDR;
   img->loader = LOADER_JPEG;
+
   return DT_IMAGEIO_OK;
 }
 

--- a/src/imageio/imageio_png.c
+++ b/src/imageio/imageio_png.c
@@ -213,7 +213,15 @@ dt_imageio_retval_t dt_imageio_open_png(dt_image_t *img, const char *filename, d
   }
 
   dt_free_align(buf);
+
+  img->buf_dsc.cst = IOP_CS_RGB; // png is always RGB
+  img->buf_dsc.filters = 0u;
+  img->flags &= ~DT_IMAGE_RAW;
+  img->flags &= ~DT_IMAGE_S_RAW;
+  img->flags &= ~DT_IMAGE_HDR;
+  img->flags |= DT_IMAGE_LDR;
   img->loader = LOADER_PNG;
+
   return DT_IMAGEIO_OK;
 }
 

--- a/src/imageio/imageio_pnm.c
+++ b/src/imageio/imageio_pnm.c
@@ -15,10 +15,12 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
 #include "common/darktable.h"
+#include "develop/imageop.h"         // for IOP_CS_RGB
 #include "imageio/imageio_pfm.h"
 
 #include <assert.h>
@@ -247,6 +249,18 @@ dt_imageio_retval_t dt_imageio_open_pnm(dt_image_t *img, const char *filename, d
 
 end:
   fclose(f);
+
+  if(result == DT_IMAGEIO_OK)
+  {
+    img->buf_dsc.cst = IOP_CS_RGB; // pnm is always RGB
+    img->buf_dsc.filters = 0u;
+    img->flags &= ~DT_IMAGE_RAW;
+    img->flags &= ~DT_IMAGE_S_RAW;
+    img->flags &= ~DT_IMAGE_HDR;
+    img->flags |= DT_IMAGE_LDR;
+    img->loader = LOADER_PNM;
+  }
+
   return result;
 }
 
@@ -255,4 +269,3 @@ end:
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/imageio/imageio_tiff.c
+++ b/src/imageio/imageio_tiff.c
@@ -433,6 +433,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
   t.image->buf_dsc.channels = 4;
   t.image->buf_dsc.datatype = TYPE_FLOAT;
   t.image->buf_dsc.cst = IOP_CS_RGB;
+  t.image->buf_dsc.filters = 0u;
 
   t.mipbuf = (float *)dt_mipmap_cache_alloc(mbuf, t.image);
   if(!t.mipbuf)
@@ -487,6 +488,8 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
 
   if(ok == 1)
   {
+    img->flags &= ~DT_IMAGE_RAW;
+    img->flags &= ~DT_IMAGE_S_RAW;
     img->loader = LOADER_TIFF;
     return DT_IMAGEIO_OK;
   }

--- a/src/imageio/imageio_webp.c
+++ b/src/imageio/imageio_webp.c
@@ -22,6 +22,7 @@
 #include <webp/mux.h>
 
 #include "common/image.h"
+#include "develop/imageop.h"         // for IOP_CS_RGB
 #include "imageio/imageio_common.h"
 
 dt_imageio_retval_t dt_imageio_open_webp(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *mbuf)
@@ -116,6 +117,13 @@ dt_imageio_retval_t dt_imageio_open_webp(dt_image_t *img, const char *filename, 
 
   g_free(read_buffer);
 
+  img->buf_dsc.cst = IOP_CS_RGB;
+  img->buf_dsc.filters = 0u;
+  img->flags &= ~DT_IMAGE_RAW;
+  img->flags &= ~DT_IMAGE_S_RAW;
+  img->flags &= ~DT_IMAGE_HDR;
+  img->flags |= DT_IMAGE_LDR;
+  img->loader = LOADER_WEBP;
   return DT_IMAGEIO_OK;
 }
 


### PR DESCRIPTION
All setting of the necessary flags and values related to the loaded image must happen locally in the function that handles the loading of the image. Relying on this being done somewhere else, at the point of the function call is bad code writing practice.