### PR TITLE
RFC: Improve correctness of highlights and temperature module descriptions

### DIFF
--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -174,7 +174,7 @@ const char *name()
 
 const char **description(struct dt_iop_module_t *self)
 {
-  return dt_iop_set_description(self, _("avoid magenta highlights and try to recover highlights colors"),
+  return dt_iop_set_description(self, _("try to recover highlights colors"),
                                       _("corrective"),
                                       _("linear, raw, scene-referred"),
                                       _("reconstruction, raw"),

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -194,7 +194,7 @@ const char *name()
 
 const char **description(struct dt_iop_module_t *self)
 {
-  return dt_iop_set_description(self, _("scale raw RGB channels to balance white and help demosaicing"),
+  return dt_iop_set_description(self, _("scale raw RGB channels to balance white and help demosaicing and highlights reconstruction"),
                                       _("corrective"),
                                       _("linear, raw, scene-referred"),
                                       _("linear, raw"),


### PR DESCRIPTION
The title info for
 - highlights reconstruction
 - temperature

are
1. somewhat misleading for highlights reconstruction (it's not basically about magenta)
2. miss the relevance for highlights reconstruction for the temperature module.