### PR TITLE
imageio: export masks for EXRs as extra channels

### DIFF
--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -29,12 +29,20 @@
 #include "common/action.h"
 #include "control/settings.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 /** region of interest, needed by pixelpipe.h */
 typedef struct dt_iop_roi_t
 {
   int x, y, width, height;
   float scale;
 } dt_iop_roi_t;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 #include "develop/pixelpipe.h"
 #include "dtgtk/togglebutton.h"

--- a/src/develop/pixelpipe.h
+++ b/src/develop/pixelpipe.h
@@ -24,6 +24,10 @@
 #include "config.h"
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 /* The pixelpipe types here are all defined as a bit mask to ensure easy testing via & operator */
 typedef enum dt_dev_pixelpipe_type_t
 {
@@ -75,6 +79,10 @@ typedef void dt_iop_params_t;
 
 const char *dt_pixelpipe_name(dt_dev_pixelpipe_type_t pipe);
 
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
+
 #include "develop/pixelpipe_hb.h"
 
 // clang-format off
@@ -82,4 +90,3 @@ const char *dt_pixelpipe_name(dt_dev_pixelpipe_type_t pipe);
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -27,6 +27,10 @@
 #include "develop/pixelpipe_cache.h"
 #include "imageio/imageio_common.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 /**
  * struct used by iop modules to connect to pixelpipe.
  * data can be used to store whatever private data and
@@ -267,9 +271,12 @@ void dt_print_pipe(dt_debug_thread_t thread, const char *title, dt_dev_pixelpipe
 // helper function writing the pipe-processed ctmask data to dest
 float *dt_dev_distort_detail_mask(const dt_dev_pixelpipe_t *pipe, float *src, const struct dt_iop_module_t *target_module);
 
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/imageio/imageio_exr.h
+++ b/src/imageio/imageio_exr.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2020 darktable developers.
+    Copyright (C) 2010-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -13,7 +13,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+    along with darktable.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #pragma once
@@ -36,4 +36,3 @@ dt_imageio_retval_t dt_imageio_open_exr(dt_image_t *img, const char *filename, d
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/imageio/imageio_exr.hh
+++ b/src/imageio/imageio_exr.hh
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2020 darktable developers.
+    Copyright (C) 2012-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -13,21 +13,14 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+    along with darktable.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #pragma once
 
-#include "common/image.h"
-#include "common/mipmap_cache.h"
-
+#include <cinttypes>
 #include <ciso646>
-
-#if defined(_LIBCPP_VERSION)
 #include <memory>
-#else
-#include <tr1/memory>
-#endif
 
 #include <OpenEXR/ImfChannelList.h>
 #include <OpenEXR/ImfFrameBuffer.h>
@@ -69,11 +62,7 @@ public:
   }
 
   uint32_t size;
-#if defined(_LIBCPP_VERSION)
   std::shared_ptr<uint8_t> data;
-#else
-  std::tr1::shared_ptr<uint8_t> data;
-#endif
 };
 
 
@@ -96,6 +85,8 @@ template <> void BlobAttribute::readValueFrom(IStream &is, int size, int version
 }
 }
 
-// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
-// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-space on;
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on


### PR DESCRIPTION
Addresses #13546 @sventetzlaff 

This uses the channel naming scheme for the layers, making it compatible with older apps.

If one is to target apps supporting OpenEXR 2.0, an alternative "multi-part" scheme could be considered (making it possible to use different pixel type and/or compression for the masks).

Edit: [GIMP doesn't seem to support multi-part files yet.](https://gitlab.gnome.org/GNOME/gimp/-/issues/4379)