### PR TITLE
RFC: Add a simple way to benchmark a module

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -146,6 +146,11 @@ static int usage(const char *argv0)
 #endif
   printf("  --dump-pfm <module>\n");
   printf("  --dump-pipe <module>\n");
+  printf("  --bench-module <module>\n");
+#ifdef _WIN32
+  printf(", /?");
+#endif
+  printf("\n");
   printf("  --library <library file>\n");
   printf("  --localedir <locale directory>\n");
 #ifdef USE_LUA
@@ -593,6 +598,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   darktable.dump_pfm_module = NULL;
   darktable.dump_pfm_pipe = NULL;
   darktable.tmp_directory = NULL;
+  darktable.bench_module = NULL;
 
 #ifdef HAVE_OPENCL
   gboolean exclude_opencl = FALSE;
@@ -738,6 +744,12 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
       else if(!strcmp(argv[k], "--dump-pfm") && argc > k + 1)
       {
         darktable.dump_pfm_module = argv[++k];
+        argv[k-1] = NULL;
+        argv[k] = NULL;
+      }
+      else if(!strcmp(argv[k], "--bench-module") && argc > k + 1)
+      {
+        darktable.bench_module = argv[++k];
         argv[k-1] = NULL;
         argv[k] = NULL;
       }

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -147,10 +147,6 @@ static int usage(const char *argv0)
   printf("  --dump-pfm <module>\n");
   printf("  --dump-pipe <module>\n");
   printf("  --bench-module <module>\n");
-#ifdef _WIN32
-  printf(", /?");
-#endif
-  printf("\n");
   printf("  --library <library file>\n");
   printf("  --localedir <locale directory>\n");
 #ifdef USE_LUA

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -354,6 +354,7 @@ typedef struct darktable_t
   char *dump_pfm_module;
   char *dump_pfm_pipe;
   char *tmp_directory;
+  char *bench_module;
   dt_lua_state_t lua_state;
   GList *guides;
   double start_wtime;


### PR DESCRIPTION
Rationale:
We might want a simple way to benchmark a module on a working dt system either to
 - test and compare the compiler
 - compare SSE2 vs non-SSE2 performance
 - compare CPU vs GPU performance
 - test performance while working on a module

Would also allow user feedback and decisions about used code taken from more results.

This code does **not** do any statistics, just plain repeating of module processing, calculating average of spent time plus info about pixels accepting advantage of cpu caching.
Please note that dt_print() logs while bench processing are switched off.
For GPU code the timing does not include buffer handling.
For simplicity we don't expect tiled code. 

As we want to keep the system running in a usable way we
1. only bench a single module
2. only do benching while in full or export pipe

The switch to turn it on is
 --bench-module <module>

Comment: i am using this stuff for "testing" since a while, it certainly blows up the pixelpipe code but might be useful for all of us  