### PR TITLE
images: Do not set the crop_width/crop_height in dt_image_update_final_size.

### DIFF
--- a/src/common/histogram.c
+++ b/src/common/histogram.c
@@ -60,7 +60,7 @@ static inline void _bin_raw(const dt_dev_histogram_collection_params_t *const pa
   uint16_t *in = (uint16_t *)pixel + roi->width * j + roi->crop_x;
   const size_t max_bin = params->bins_count - 1;
 
-  for(int i = 0; i < roi->width - roi->crop_width - roi->crop_x; i++)
+  for(int i = 0; i < roi->width - roi->crop_right - roi->crop_x; i++)
   {
     // WARNING: you must ensure that bins_count is big enough
     // e.g. 2^16 if you expect 16 bit raw files
@@ -79,7 +79,7 @@ static inline void _bin_rgb(const dt_dev_histogram_collection_params_t *const pa
   float *in = (float *)pixel + 4 * (roi->width * j + roi->crop_x);
   const float max_bin = params->bins_count - 1;
 
-  for(int i = 0; i < roi->width - roi->crop_width - roi->crop_x; i++)
+  for(int i = 0; i < roi->width - roi->crop_right - roi->crop_x; i++)
   {
     dt_aligned_pixel_t b;
     for_each_channel(k,aligned(in,b:16))
@@ -97,7 +97,7 @@ static inline void _bin_rgb_compensated(const dt_dev_histogram_collection_params
   float *in = (float *)pixel + 4 * (roi->width * j + roi->crop_x);
   const float max_bin = params->bins_count - 1;
 
-  for(int i = 0; i < roi->width - roi->crop_width - roi->crop_x; i++)
+  for(int i = 0; i < roi->width - roi->crop_right - roi->crop_x; i++)
   {
     dt_aligned_pixel_t b;
     for_each_channel(k,aligned(in,b:16))
@@ -121,7 +121,7 @@ static inline void _bin_Lab(const dt_dev_histogram_collection_params_t *const pa
                                      max_bin / 256.0f, 0.0f };
   const dt_aligned_pixel_t shift = { 0.0f, 128.0f, 128.0f, 0.0f };
 
-  for(int i = 0; i < roi->width - roi->crop_width - roi->crop_x; i++)
+  for(int i = 0; i < roi->width - roi->crop_right - roi->crop_x; i++)
   {
     dt_aligned_pixel_t b;
     for_each_channel(k,aligned(in,b,scale,shift:16))
@@ -142,7 +142,7 @@ static inline void _bin_Lab_LCh(const dt_dev_histogram_collection_params_t *cons
                                      max_bin / (128.0f * sqrtf(2.0f)),
                                      max_bin, 0.0f };
 
-  for(int i = 0; i < roi->width - roi->crop_width - roi->crop_x; i++)
+  for(int i = 0; i < roi->width - roi->crop_right - roi->crop_x; i++)
   {
     dt_aligned_pixel_t LCh, b;
     dt_Lab_2_LCH(in + i*4, LCh);
@@ -185,14 +185,14 @@ void _hist_worker(dt_dev_histogram_collection_params_t *const histogram_params,
   reduction(+:working_hist[:bins_total])                                \
   schedule(static)
 #endif
-  for(int j = roi->crop_y; j < roi->height - roi->crop_height; j++)
+  for(int j = roi->crop_y; j < roi->height - roi->crop_bottom; j++)
   {
     Worker(histogram_params, pixel, working_hist, j, profile_info);
   }
 
   histogram_stats->bins_count = histogram_params->bins_count;
-  histogram_stats->pixels = (roi->width - roi->crop_width - roi->crop_x)
-                            * (roi->height - roi->crop_height - roi->crop_y);
+  histogram_stats->pixels = (roi->width - roi->crop_right - roi->crop_x)
+                            * (roi->height - roi->crop_bottom - roi->crop_y);
 }
 
 //------------------------------------------------------------------------------

--- a/src/common/histogram.h
+++ b/src/common/histogram.h
@@ -33,7 +33,7 @@
  */
 typedef struct dt_histogram_roi_t
 {
-  int width, height, crop_x, crop_y, crop_width, crop_height;
+  int width, height, crop_x, crop_y, crop_right, crop_bottom;
 } dt_histogram_roi_t;
 
 // allocates an aligned histogram buffer if needed, callers
@@ -53,4 +53,3 @@ void dt_histogram_helper(dt_dev_histogram_collection_params_t *histogram_params,
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -802,8 +802,8 @@ void dt_image_update_final_size(const int32_t imgid)
   }
   else
   {
-    imgtmp->final_width = imgtmp->crop_width = ww;
-    imgtmp->final_height = imgtmp->crop_height = hh;
+    imgtmp->final_width = ww;
+    imgtmp->final_height = hh;
     dt_image_cache_write_release(darktable.image_cache, imgtmp, DT_IMAGE_CACHE_RELAXED);
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_METADATA_UPDATE);
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_IMAGE_CHANGED);

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1917,7 +1917,7 @@ void dt_image_init(dt_image_t *img)
   img->width = img->height = 0;
   img->final_width = img->final_height = img->p_width = img->p_height = 0;
   img->aspect_ratio = 0.f;
-  img->crop_x = img->crop_y = img->crop_width = img->crop_height = 0;
+  img->crop_x = img->crop_y = img->crop_right = img->crop_bottom = 0;
   img->orientation = ORIENTATION_NULL;
 
   img->import_timestamp = img->change_timestamp = img->export_timestamp = img->print_timestamp = 0;

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -261,7 +261,8 @@ typedef struct dt_image_t
 
   // to understand this, look at comment for dt_histogram_roi_t
   int32_t width, height, final_width, final_height, p_width, p_height;
-  int32_t crop_x, crop_y, crop_width, crop_height;
+  int32_t crop_x, crop_y;
+  int32_t crop_right, crop_bottom;
   float aspect_ratio;
 
   // used by library

--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -57,7 +57,7 @@ void dt_image_cache_allocate(void *data, dt_cache_entry_t *entry)
     img->film_id = sqlite3_column_int(stmt, 2);
     img->width = sqlite3_column_int(stmt, 3);
     img->height = sqlite3_column_int(stmt, 4);
-    img->crop_x = img->crop_y = img->crop_width = img->crop_height = 0;
+    img->crop_x = img->crop_y = img->crop_right = img->crop_bottom = 0;
     img->filename[0] = img->exif_maker[0] = img->exif_model[0] = img->exif_lens[0] = '\0';
     dt_datetime_exif_to_img(img, "");
     char *str;

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -555,8 +555,8 @@ static void dt_masks_legacy_params_v2_to_v3_transform(const dt_image_t *img, flo
 
   const float cx = (float)img->crop_x, cy = (float)img->crop_y;
 
-  const float cw = (float)(img->width - img->crop_x - img->crop_width),
-              ch = (float)(img->height - img->crop_y - img->crop_height);
+  const float cw = (float)(img->width - img->crop_x - img->crop_right);
+  const float ch = (float)(img->height - img->crop_y - img->crop_bottom);
 
   /*
    * masks coordinates are normalized, so we need to:
@@ -573,8 +573,8 @@ static void dt_masks_legacy_params_v2_to_v3_transform_only_rescale(const dt_imag
 {
   const float w = (float)img->width, h = (float)img->height;
 
-  const float cw = (float)(img->width - img->crop_x - img->crop_width),
-              ch = (float)(img->height - img->crop_y - img->crop_height);
+  const float cw = (float)(img->width - img->crop_x - img->crop_right);
+  const float ch = (float)(img->height - img->crop_y - img->crop_bottom);
 
   /*
    * masks coordinates are normalized, so we need to:
@@ -595,7 +595,10 @@ static int dt_masks_legacy_params_v2_to_v3(dt_develop_t *dev, void *params)
 
   const dt_image_t *img = &(dev->image_storage);
 
-  if(img->crop_x == 0 && img->crop_y == 0 && img->crop_width == 0 && img->crop_height == 0)
+  if(img->crop_x == 0
+     && img->crop_y == 0
+     && img->crop_right == 0
+     && img->crop_bottom == 0)
   {
     // image has no "raw cropping", we're fine!
     m->version = 3;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -611,7 +611,12 @@ static void _histogram_collect(
   if(histogram_params.roi == NULL)
   {
     histogram_roi = (dt_histogram_roi_t){
-      .width = roi->width, .height = roi->height, .crop_x = 0, .crop_y = 0, .crop_width = 0, .crop_height = 0
+      .width = roi->width,
+      .height = roi->height,
+      .crop_x = 0,
+      .crop_y = 0,
+      .crop_right = 0,
+      .crop_bottom = 0
     };
 
     histogram_params.roi = &histogram_roi;
@@ -667,8 +672,12 @@ static void _histogram_collect_cl(
   if(histogram_params.roi == NULL)
   {
     histogram_roi = (dt_histogram_roi_t){
-      .width = roi->width, .height = roi->height,
-      .crop_x = 0, .crop_y = 0, .crop_width = 0, .crop_height = 0
+      .width = roi->width,
+      .height = roi->height,
+      .crop_x = 0,
+      .crop_y = 0,
+      .crop_right = 0,
+      .crop_bottom = 0
     };
 
     histogram_params.roi = &histogram_roi;

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1271,8 +1271,8 @@ dt_imageio_retval_t dt_imageio_open(dt_image_t *img,        // non-const * means
   if((ret == DT_IMAGEIO_OK) && (was_bw != dt_image_monochrome_flags(img)))
     dt_imageio_update_monochrome_workflow_tag(img->id, dt_image_monochrome_flags(img));
 
-  img->p_width = img->width - img->crop_x - img->crop_width;
-  img->p_height = img->height - img->crop_y - img->crop_height;
+  img->p_width = img->width - img->crop_x - img->crop_right;
+  img->p_height = img->height - img->crop_y - img->crop_bottom;
 
   return ret;
 }

--- a/src/imageio/imageio_libraw.c
+++ b/src/imageio/imageio_libraw.c
@@ -326,8 +326,8 @@ dt_imageio_retval_t dt_imageio_open_libraw(dt_image_t *img, const char *filename
   libraw_raw_inset_crop_t *ric = &raw->rawdata.sizes.raw_inset_crops[0];
   img->crop_x = ric->cleft;
   img->crop_y = ric->ctop;
-  img->crop_width = raw->rawdata.sizes.raw_width - ric->cwidth - ric->cleft;
-  img->crop_height = raw->rawdata.sizes.raw_height - ric->cheight - ric->ctop;
+  img->crop_right = raw->rawdata.sizes.raw_width - ric->cwidth - ric->cleft;
+  img->crop_bottom = raw->rawdata.sizes.raw_height - ric->cheight - ric->ctop;
 
   // We can reuse the libraw filters property, it's already well-handled in dt.
   // It contains (for CR3) the Bayer pattern, but we have to undo some LibRaw logic.

--- a/src/imageio/imageio_rawspeed.cc
+++ b/src/imageio/imageio_rawspeed.cc
@@ -347,8 +347,8 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
 
     // crop - Bottom,Right corner
     iPoint2D cropBR = dimUncropped - dimCropped - cropTL;
-    img->crop_width = cropBR.x;
-    img->crop_height = cropBR.y;
+    img->crop_right = cropBR.x;
+    img->crop_bottom = cropBR.y;
 
     img->fuji_rotation_pos = r->metadata.fujiRotationPos;
     img->pixel_aspect_ratio = (float)r->metadata.pixelAspectRatio;

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -315,8 +315,8 @@ static void _deflicker_prepare_histogram(dt_iop_module_t *self, uint32_t **histo
                                       // FIXME: get those from rawprepare IOP somehow !!!
                                       .crop_x = image.crop_x,
                                       .crop_y = image.crop_y,
-                                      .crop_width = image.crop_width,
-                                      .crop_height = image.crop_height };
+                                      .crop_right = image.crop_right,
+                                      .crop_bottom = image.crop_bottom };
 
   histogram_params.roi = &histogram_roi;
   histogram_params.bins_count = DEFLICKER_BINS_COUNT;

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -639,8 +639,8 @@ static float _get_autoscale_lf(
       const dt_image_t *img = &(self->dev->image_storage);
 
       // FIXME: get those from rawprepare IOP somehow !!!
-      const int iwd = img->width - img->crop_x - img->crop_width,
-                iht = img->height - img->crop_y - img->crop_height;
+      const int iwd = img->width - img->crop_x - img->crop_right,
+                iht = img->height - img->crop_y - img->crop_bottom;
 
       // create dummy modifier
 #if defined(__GNUC__) && (__GNUC__ > 7)

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -813,8 +813,8 @@ void reload_defaults(dt_iop_module_t *self)
 
   *d = (dt_iop_rawprepare_params_t){.left = image->crop_x,
                                     .top = image->crop_y,
-                                    .right = image->crop_width,
-                                    .bottom = image->crop_height,
+                                    .right = image->crop_right,
+                                    .bottom = image->crop_bottom,
                                     .raw_black_level_separate[0] = image->raw_black_level_separate[0],
                                     .raw_black_level_separate[1] = image->raw_black_level_separate[1],
                                     .raw_black_level_separate[2] = image->raw_black_level_separate[2],

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -295,8 +295,8 @@ static void _lib_histogram_process_waveform(dt_lib_histogram_t *const d,
 {
   // FIXME: for point sample, calculate whole graph and the point
   // sample values, draw these on top of a dimmer graph
-  const int sample_width = MAX(1, roi->width - roi->crop_width - roi->crop_x);
-  const int sample_height = MAX(1, roi->height - roi->crop_height - roi->crop_y);
+  const int sample_width = MAX(1, roi->width - roi->crop_right - roi->crop_x);
+  const int sample_height = MAX(1, roi->height - roi->crop_bottom - roi->crop_y);
 
   // Use integral sized bins for columns, as otherwise they will be
   // unequal and have banding. Rely on draw to smoothly do horizontal
@@ -740,8 +740,8 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
   const float max_radius = d->vectorscope_radius;
   const float max_diam = max_radius * 2.f;
 
-  int sample_width = MAX(1, roi->width - roi->crop_width - roi->crop_x);
-  int sample_height = MAX(1, roi->height - roi->crop_height - roi->crop_y);
+  int sample_width = MAX(1, roi->width - roi->crop_right - roi->crop_x);
+  int sample_height = MAX(1, roi->height - roi->crop_bottom - roi->crop_y);
   if(sample_width == 1 && sample_height == 1)
   {
     // point sample still calculates graph based on whole image
@@ -908,8 +908,12 @@ static void dt_lib_histogram_process(struct dt_lib_module_t *self, const float *
 
   // FIXME: scope goes black when click histogram lib colorpicker on -- is this meant to happen?
   // FIXME: scope doesn't redraw when click histogram lib colorpicker off -- is this meant to happen?
-  dt_histogram_roi_t roi = { .width = width, .height = height,
-                             .crop_x = 0, .crop_y = 0, .crop_width = 0, .crop_height = 0 };
+  dt_histogram_roi_t roi = { .width = width,
+                             .height = height,
+                             .crop_x = 0,
+                             .crop_y = 0,
+                             .crop_right = 0,
+                             .crop_bottom = 0 };
 
   // Constraining the area if the colorpicker is active in area mode
   // FIXME: only need to do colorspace conversion below on roi
@@ -928,15 +932,15 @@ static void dt_lib_histogram_process(struct dt_lib_module_t *self, const float *
       {
         roi.crop_x = MIN(width, MAX(0, sample->box[0] * width));
         roi.crop_y = MIN(height, MAX(0, sample->box[1] * height));
-        roi.crop_width = width - MIN(width, MAX(0, sample->box[2] * width));
-        roi.crop_height = height - MIN(height, MAX(0, sample->box[3] * height));
+        roi.crop_right = width - MIN(width, MAX(0, sample->box[2] * width));
+        roi.crop_bottom = height - MIN(height, MAX(0, sample->box[3] * height));
       }
       else if(sample->size == DT_LIB_COLORPICKER_SIZE_POINT)
       {
         roi.crop_x = MIN(width, MAX(0, sample->point[0] * width));
         roi.crop_y = MIN(height, MAX(0, sample->point[1] * height));
-        roi.crop_width = width - MIN(width, MAX(0, sample->point[0] * width));
-        roi.crop_height = height - MIN(height, MAX(0, sample->point[1] * height));
+        roi.crop_right = width - MIN(width, MAX(0, sample->point[0] * width));
+        roi.crop_bottom = height - MIN(height, MAX(0, sample->point[1] * height));
       }
     }
   }


### PR DESCRIPTION
This reverts part of f83e9efaf2 and seems to still fixes #10979.

Second commit renames crop_width & crop_height to crop_right and crop_bottom as this wrong naming has proved to be very bad for code reader!