### PR TITLE
interpolation: fix mirror and wrap border modes

### DIFF
--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -107,11 +107,16 @@ static inline int clip(int i, int min, int max, enum border_mode mode)
     case BORDER_MIRROR:
       if(i < min)
       {
-        i = 2 * min - i;
+        // i == min - 1  -->  min + 1
+        // i == min - 2  -->  min + 2, etc.
+        // but as min == 0 in all current cases, this really optimizes to i = -i
+        i = min + (min - i);
       }
       else if(i > max)
       {
-        i = 2 * max - i;
+        // i == max + 1  -->  max - 1
+        // i == max + 2  -->  max - 2, etc.
+        i = max - (i - max);
       }
       break;
     case BORDER_WRAP:

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -1,6 +1,6 @@
 /* --------------------------------------------------------------------------
     This file is part of darktable,
-    Copyright (C) 2012-2021 darktable developers.
+    Copyright (C) 2012-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -107,7 +107,7 @@ static inline int clip(int i, int min, int max, enum border_mode mode)
     case BORDER_MIRROR:
       if(i < min)
       {
-        i = min - i;
+        i = 2 * min - i;
       }
       else if(i > max)
       {
@@ -117,11 +117,11 @@ static inline int clip(int i, int min, int max, enum border_mode mode)
     case BORDER_WRAP:
       if(i < min)
       {
-        i = max - (min - i);
+        i = 1 + max - (min - i);
       }
       else if(i > max)
       {
-        i = min + (i - max);
+        i = min + (i - max) - 1;
       }
       break;
     case BORDER_CLAMP:
@@ -528,7 +528,8 @@ static inline void compute_upsampling_kernel_sse(const struct dt_interpolation *
 static inline void compute_upsampling_kernel(const struct dt_interpolation *itor, float *kernel, float *norm,
                                              int *first, float t)
 {
-  if(darktable.codepath.OPENMP_SIMD) return compute_upsampling_kernel_plain(itor, kernel, norm, first, t);
+  if(darktable.codepath.OPENMP_SIMD)
+    return compute_upsampling_kernel_plain(itor, kernel, norm, first, t);
 #if defined(__SSE2__)
   else if(darktable.codepath.SSE2)
     return compute_upsampling_kernel_sse(itor, kernel, norm, first, t);

--- a/src/common/interpolation.h
+++ b/src/common/interpolation.h
@@ -1,6 +1,6 @@
 /* --------------------------------------------------------------------------
     This file is part of darktable,
-    Copyright (C) 2012-2021 darktable developers.
+    Copyright (C) 2012-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -126,9 +126,9 @@ const struct dt_interpolation *dt_interpolation_new(enum dt_interpolation_type t
  * <li>The resampling is isotropic (same for both x and y directions),
  * represented by roi_out->scale</li>
  * <li>It generates roi_out->width samples horizontally whose positions span
- * from roi_out->x to roi_out->x + roi_out->width</li>
+ * from roi_out->x to roi_out->x + roi_out->width - 1</li>
  * <li>It generates roi_out->height samples vertically whose positions span
- * from roi_out->y to roi_out->y + roi_out->height</li>
+ * from roi_out->y to roi_out->y + roi_out->height - 1</li>
  * </ul>
  *
  * @param itor [in] Interpolator to use
@@ -168,9 +168,9 @@ void dt_interpolation_free_cl_global(dt_interpolation_cl_global_t *g);
  * <li>The resampling is isotropic (same for both x and y directions),
  * represented by roi_out->scale</li>
  * <li>It generates roi_out->width samples horizontally whose positions span
- * from roi_out->x to roi_out->x + roi_out->width</li>
+ * from roi_out->x to roi_out->x + roi_out->width - 1</li>
  * <li>It generates roi_out->height samples vertically whose positions span
- * from roi_out->y to roi_out->y + roi_out->height</li>
+ * from roi_out->y to roi_out->y + roi_out->height - 1</li>
  * </ul>
  *
  * @param itor [in] Interpolator to use


### PR DESCRIPTION
Mirror math was off such that could reference memory below the minimum of the clip range. Mirror mode is used when computing single samples, which is used by various iops (e.g. lens, liquify, ashift, scalepixels, rotatepixels), and hence could cause an unexpected memory reference, perhaps including one before the start of the image.

Wrap math was off such that when wrapping from min to max, it would actually wrap to max-1 (missing max). And conversely when wrapping from max to min, it would wrap to min + 1 (missing min). Wrap code is unused, so this should have had no effect.

Also, some minor fixups:

- Clarify comments describing dt_interpolation_resample*() functions: output runs to roi width/height less 1
- Tidy indentation
- Update copyright lines

I'm still going through the code to figure out the offset problems between preview/full pixelpipes. This PR came from looking carefully through relevant code, but is orthogonal to that work, hence is a separate PR.