### PR TITLE
Disable pthread informational stderr printing

### DIFF
--- a/src/common/dtpthread.c
+++ b/src/common/dtpthread.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2016-2020 darktable developers.
+    Copyright (C) 2016-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -56,10 +56,6 @@ int dt_pthread_create(pthread_t *thread, void *(*start_routine)(void *), void *a
   if(ret != 0 || stacksize < WANTED_THREADS_STACK_SIZE /*|| 1*/)
   {
     // looks like we need to bump/set it...
-
-    fprintf(stderr, "[dt_pthread_create] info: bumping pthread's stacksize from %zu to %"PRIuMAX"\n", stacksize,
-            (uintmax_t)WANTED_THREADS_STACK_SIZE);
-
     ret = pthread_attr_setstacksize(&attr, WANTED_THREADS_STACK_SIZE);
     if(ret != 0)
     {

--- a/src/common/dtpthread.c
+++ b/src/common/dtpthread.c
@@ -53,7 +53,7 @@ int dt_pthread_create(pthread_t *thread, void *(*start_routine)(void *), void *a
     fprintf(stderr, "[dt_pthread_create] error: pthread_attr_getstacksize() returned %i\n", ret);
   }
 
-  if(ret != 0 || stacksize < WANTED_THREADS_STACK_SIZE /*|| 1*/)
+  if(ret != 0 || stacksize < WANTED_THREADS_STACK_SIZE)
   {
     // looks like we need to bump/set it...
     ret = pthread_attr_setstacksize(&attr, WANTED_THREADS_STACK_SIZE);


### PR DESCRIPTION
This does not appear under Linux, but every time dt is launched under Windows, about a dozen messages of the following type are recorded in the log:
```
[dt_pthread_create] info: bumping pthread's stacksize from 0 to 2097152
[dt_pthread_create] info: bumping pthread's stacksize from 0 to 2097152
[dt_pthread_create] info: bumping pthread's stacksize from 0 to 2097152
[dt_pthread_create] info: bumping pthread's stacksize from 0 to 2097152
[dt_pthread_create] info: bumping pthread's stacksize from 0 to 2097152
[dt_pthread_create] info: bumping pthread's stacksize from 0 to 2097152
[dt_pthread_create] info: bumping pthread's stacksize from 0 to 2097152
[dt_pthread_create] info: bumping pthread's stacksize from 0 to 2097152
[dt_pthread_create] info: bumping pthread's stacksize from 0 to 2097152
```

These are purely informational messages that do not report any abnormal situations or errors, so there is no need to log them. They only confuse users and distract them from possible real error messages.
