### PR TITLE
define widget type mimicking actions with flexible lua scripts

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -466,11 +466,8 @@ static gboolean dt_bauhaus_popup_leave_notify(GtkWidget *widget, GdkEventCrossin
 
 static gboolean dt_bauhaus_popup_button_release(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
-  int delay = 0;
-  g_object_get(gtk_settings_get_default(), "gtk-double-click-time", &delay, NULL);
-
   if(darktable.bauhaus->current && (darktable.bauhaus->current->type == DT_BAUHAUS_COMBOBOX)
-     && (event->button == 1) && (event->time >= darktable.bauhaus->opentime + delay) && !darktable.bauhaus->hiding)
+     && (event->button == 1) && dt_gui_long_click(event->time, darktable.bauhaus->opentime) && !darktable.bauhaus->hiding)
   {
     gtk_widget_set_state_flags(widget, GTK_STATE_FLAG_ACTIVE, TRUE);
 
@@ -503,12 +500,10 @@ static gboolean dt_bauhaus_popup_button_press(GtkWidget *widget, GdkEventButton 
     return TRUE;
   }
 
-  int delay = 0;
-  g_object_get(gtk_settings_get_default(), "gtk-double-click-time", &delay, NULL);
   if(event->button == 1)
   {
     if(darktable.bauhaus->current->type == DT_BAUHAUS_COMBOBOX
-       && event->time < darktable.bauhaus->opentime + delay)
+       && !dt_gui_long_click(event->time, darktable.bauhaus->opentime))
     {
       // counts as double click, reset:
       const dt_bauhaus_combobox_data_t *d = &darktable.bauhaus->current->data.combobox;

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1278,6 +1278,28 @@ void dt_bauhaus_combobox_add_list(GtkWidget *widget, dt_action_t *action, const 
     dt_bauhaus_combobox_add_full(widget, Q_(*(texts++)), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, GINT_TO_POINTER(item++), NULL, TRUE);
 }
 
+gboolean dt_bauhaus_combobox_add_introspection(GtkWidget *widget,
+                                               dt_action_t *action,
+                                               const dt_introspection_type_enum_tuple_t *list,
+                                               const int start,
+                                               const int end)
+{
+  dt_introspection_type_enum_tuple_t *item = (dt_introspection_type_enum_tuple_t *)list;
+
+  if(action)
+    g_hash_table_insert(darktable.control->combo_introspection, action, (gpointer)list);
+
+  while(item->name && item->value != start) item++;
+  for(; item->name; item++)
+  {
+    dt_bauhaus_combobox_add_full(widget, Q_(item->description ? item->description : item->name),
+                                 DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, GUINT_TO_POINTER(item->value), NULL, TRUE);
+    if(item->value == end) return TRUE;
+  }
+  return FALSE;
+}
+
+
 void dt_bauhaus_combobox_add(GtkWidget *widget, const char *text)
 {
   dt_bauhaus_combobox_add_full(widget, text, DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, NULL, NULL, TRUE);

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1278,8 +1278,9 @@ void dt_bauhaus_combobox_add_list(GtkWidget *widget, dt_action_t *action, const 
   if(action)
     g_hash_table_insert(darktable.control->combo_list, action, texts);
 
+  int item = 0;
   while(texts && *texts)
-    dt_bauhaus_combobox_add_full(widget, Q_(*(texts++)), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, NULL, NULL, TRUE);
+    dt_bauhaus_combobox_add_full(widget, Q_(*(texts++)), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, GINT_TO_POINTER(item++), NULL, TRUE);
 }
 
 void dt_bauhaus_combobox_add(GtkWidget *widget, const char *text)
@@ -3460,7 +3461,12 @@ static float _action_process_combo(gpointer target, dt_action_element_t element,
       break;
     default:
       value = effect - DT_ACTION_EFFECT_COMBO_SEPARATOR - 1;
-      dt_bauhaus_combobox_set(widget, value);
+      dt_introspection_type_enum_tuple_t *values
+        = g_hash_table_lookup(darktable.control->combo_introspection, dt_action_widget(target));
+      if(values)
+        value = values[value].value;
+
+      dt_bauhaus_combobox_set_from_value(widget, value);
       break;
     }
 

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -3579,17 +3579,17 @@ static const dt_action_def_t _action_def_combo
       _action_fallbacks_combo };
 
 static const dt_action_def_t _action_def_focus_slider
-  = { N_("slider"),
+  = { N_("sliders"),
       _action_process_focus_slider,
       DT_ACTION_ELEMENTS_NUM(value),
       NULL, TRUE };
 static const dt_action_def_t _action_def_focus_combo
-  = { N_("dropdown"),
+  = { N_("dropdowns"),
       _action_process_focus_combo,
       DT_ACTION_ELEMENTS_NUM(selection),
       NULL, TRUE };
 static const dt_action_def_t _action_def_focus_button
-  = { N_("button"),
+  = { N_("buttons"),
       _action_process_focus_button,
       DT_ACTION_ELEMENTS_NUM(toggle),
       NULL, TRUE };

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -372,6 +372,11 @@ void dt_bauhaus_combobox_set_default(GtkWidget *widget, int def);
 int dt_bauhaus_combobox_get_default(GtkWidget *widget);
 void dt_bauhaus_combobox_add_populate_fct(GtkWidget *widget, void (*fct)(GtkWidget *w, struct dt_iop_module_t **module));
 void dt_bauhaus_combobox_add_list(GtkWidget *widget, dt_action_t *action, const char **texts);
+gboolean dt_bauhaus_combobox_add_introspection(GtkWidget *widget,
+                                               dt_action_t *action,
+                                               const dt_introspection_type_enum_tuple_t *list,
+                                               const int start,
+                                               const int end);
 void dt_bauhaus_combobox_entry_set_sensitive(GtkWidget *widget, int pos, gboolean sensitive);
 void dt_bauhaus_combobox_set_entries_ellipsis(GtkWidget *widget, PangoEllipsizeMode ellipis);
 PangoEllipsizeMode dt_bauhaus_combobox_get_entries_ellipsis(GtkWidget *widget);

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -631,52 +631,6 @@ static void _collection_update_aspect_ratio(const dt_collection_t *collection)
   }
 }
 
-const char *dt_collection_sort_name_untranslated(dt_collection_sort_t sort)
-{
-  switch(sort)
-  {
-    case DT_COLLECTION_SORT_FILENAME:
-      return N_("filename");
-    case DT_COLLECTION_SORT_DATETIME:
-      return N_("capture time");
-    case DT_COLLECTION_SORT_IMPORT_TIMESTAMP:
-      return N_("import time");
-    case DT_COLLECTION_SORT_CHANGE_TIMESTAMP:
-      return N_("modification time");
-    case DT_COLLECTION_SORT_EXPORT_TIMESTAMP:
-      return N_("export time");
-    case DT_COLLECTION_SORT_PRINT_TIMESTAMP:
-      return N_("print time");
-    case DT_COLLECTION_SORT_RATING:
-      return N_("rating");
-    case DT_COLLECTION_SORT_ID:
-      return N_("id");
-    case DT_COLLECTION_SORT_COLOR:
-      return N_("color label");
-    case DT_COLLECTION_SORT_GROUP:
-      return N_("group");
-    case DT_COLLECTION_SORT_PATH:
-      return N_("full path");
-    case DT_COLLECTION_SORT_CUSTOM_ORDER:
-      return N_("custom sort");
-    case DT_COLLECTION_SORT_TITLE:
-      return N_("title");
-    case DT_COLLECTION_SORT_DESCRIPTION:
-      return N_("description");
-    case DT_COLLECTION_SORT_ASPECT_RATIO:
-      return N_("aspect ratio");
-    case DT_COLLECTION_SORT_SHUFFLE:
-      return N_("shuffle");
-    default:
-      return "";
-  }
-};
-
-const char *dt_collection_sort_name(dt_collection_sort_t sort)
-{
-  return _(dt_collection_sort_name_untranslated(sort));
-};
-
 const char *dt_collection_name_untranslated(dt_collection_properties_t prop)
 {
   char *col_name = NULL;

--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -152,9 +152,6 @@ typedef struct dt_collection_t
 /* returns the name for the given collection property */
 const char *dt_collection_name(dt_collection_properties_t prop);
 const char *dt_collection_name_untranslated(dt_collection_properties_t prop);
-/* returns the name for the given collection sort property */
-const char *dt_collection_sort_name(dt_collection_sort_t sort);
-const char *dt_collection_sort_name_untranslated(dt_collection_sort_t sort);
 
 /** instantiates a collection context, if clone equals NULL default query is constructed. */
 const dt_collection_t *dt_collection_new(const dt_collection_t *clone);

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -450,7 +450,7 @@ void dt_styles_update(const char *name,
   if(g_strcmp0(name, newname))
   {
     dt_action_t *old = dt_action_locate(&darktable.control->actions_global,
-                                        (gchar **)(const gchar *[]){"styles", name, NULL}, FALSE);
+                                        (gchar *[]){"styles", (gchar *)name, NULL}, FALSE);
     dt_action_rename(old, newname);
   }
 
@@ -1126,7 +1126,7 @@ void dt_styles_delete_by_name_adv(const char *name, const gboolean raise)
     sqlite3_finalize(stmt);
 
     dt_action_t *old = dt_action_locate(&darktable.control->actions_global,
-                                        (gchar **)(const gchar *[]){"styles", name, NULL}, FALSE);
+                                        (gchar *[]){"styles", (gchar *)name, NULL}, FALSE);
     dt_action_rename(old, NULL);
 
     if(raise)

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -274,19 +274,13 @@ typedef struct dt_iop_gui_blendif_filter_t
   GtkBox *box;
 } dt_iop_gui_blendif_filter_t;
 
-typedef struct dt_iop_blend_name_value_t
-{
-  char name[40];
-  int value;
-} dt_develop_name_value_t;
-
-extern const dt_develop_name_value_t dt_develop_blend_colorspace_names[];
-extern const dt_develop_name_value_t dt_develop_blend_mode_names[];
-extern const dt_develop_name_value_t dt_develop_blend_mode_flag_names[];
-extern const dt_develop_name_value_t dt_develop_mask_mode_names[];
-extern const dt_develop_name_value_t dt_develop_combine_masks_names[];
-extern const dt_develop_name_value_t dt_develop_feathering_guide_names[];
-extern const dt_develop_name_value_t dt_develop_invert_mask_names[];
+extern const dt_introspection_type_enum_tuple_t dt_develop_blend_colorspace_names[];
+extern const dt_introspection_type_enum_tuple_t dt_develop_blend_mode_names[];
+extern const dt_introspection_type_enum_tuple_t dt_develop_blend_mode_flag_names[];
+extern const dt_introspection_type_enum_tuple_t dt_develop_mask_mode_names[];
+extern const dt_introspection_type_enum_tuple_t dt_develop_combine_masks_names[];
+extern const dt_introspection_type_enum_tuple_t dt_develop_feathering_guide_names[];
+extern const dt_introspection_type_enum_tuple_t dt_develop_invert_mask_names[];
 
 #define DEVELOP_MASKS_NB_SHAPES 5
 

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2552,11 +2552,8 @@ static GtkWidget *_combobox_new_from_list(dt_iop_module_t *module, const gchar *
   if(field)
     dt_bauhaus_widget_set_field(combo, field, DT_INTROSPECTION_TYPE_ENUM);
   dt_action_t *ac = dt_bauhaus_widget_set_label(combo, N_("blend"), label);
-  if(ac) g_hash_table_insert(darktable.control->combo_introspection, ac, (gpointer)list);
   gtk_widget_set_tooltip_text(combo, tooltip);
-  for(; list->name; list++)
-    dt_bauhaus_combobox_add_full(combo, _(list->name), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,
-                                 GUINT_TO_POINTER(list->value), NULL, TRUE);
+  dt_bauhaus_combobox_add_introspection(combo, ac, list, list[0].value, -1);
 
   return combo;
 }
@@ -3007,7 +3004,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
 
     bd->blend_modes_combo = dt_bauhaus_combobox_new(module);
     dt_action_t * ac = dt_bauhaus_widget_set_label(bd->blend_modes_combo, N_("blend"), N_("blend mode"));
-    if(ac) g_hash_table_insert(darktable.control->combo_introspection, ac, (gpointer)&dt_develop_blend_mode_names);
+    dt_bauhaus_combobox_add_introspection(bd->blend_modes_combo, ac, dt_develop_blend_mode_names, -1, -1);
     gtk_widget_set_tooltip_text(bd->blend_modes_combo, _("choose blending mode"));
 
     g_signal_connect(G_OBJECT(bd->blend_modes_combo), "value-changed",
@@ -3038,13 +3035,13 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     module->fusion_slider = bd->opacity_slider;
     gtk_widget_set_tooltip_text(bd->opacity_slider, _("set the opacity of the blending"));
 
-    bd->masks_combine_combo = _combobox_new_from_list(module, _("combine masks"), dt_develop_combine_masks_names, NULL,
+    bd->masks_combine_combo = _combobox_new_from_list(module, N_("combine masks"), dt_develop_combine_masks_names, NULL,
                                                       _("how to combine individual drawn mask and different channels of parametric mask"));
     g_signal_connect(G_OBJECT(bd->masks_combine_combo), "value-changed",
                      G_CALLBACK(_blendop_masks_combine_callback), bd);
     dt_gui_add_help_link(GTK_WIDGET(bd->masks_combine_combo), dt_get_help_url("masks_combined"));
 
-    bd->masks_invert_combo = _combobox_new_from_list(module, _("invert mask"), dt_develop_invert_mask_names, NULL,
+    bd->masks_invert_combo = _combobox_new_from_list(module, N_("invert mask"), dt_develop_invert_mask_names, NULL,
                                                      _("apply mask in normal or inverted mode"));
     g_signal_connect(G_OBJECT(bd->masks_invert_combo), "value-changed",
                      G_CALLBACK(_blendop_masks_invert_callback), bd);
@@ -3057,7 +3054,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
                                                       "\nnegative values select flat areas"));
     g_signal_connect(G_OBJECT(bd->details_slider), "value-changed", G_CALLBACK(_blendop_blendif_details_callback), bd);
 
-    bd->masks_feathering_guide_combo = _combobox_new_from_list(module, _("feathering guide"), dt_develop_feathering_guide_names,
+    bd->masks_feathering_guide_combo = _combobox_new_from_list(module, N_("feathering guide"), dt_develop_feathering_guide_names,
                                                                &module->blend_params->feathering_guide,
                                                                _("choose to guide mask by input or output image and"
                                                                  "\nchoose to apply feathering before or after mask blur"));

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -44,44 +44,51 @@
 
 const dt_introspection_type_enum_tuple_t dt_develop_blend_mode_names[]
     = { { NC_("blendmode", "normal"), DEVELOP_BLEND_NORMAL2 },
+        { NC_("blendmode", "average"), DEVELOP_BLEND_AVERAGE },
+        { NC_("blendmode", "difference"), DEVELOP_BLEND_DIFFERENCE2 },
+
         { NC_("blendmode", "normal bounded"), DEVELOP_BLEND_BOUNDED },
         { NC_("blendmode", "lighten"), DEVELOP_BLEND_LIGHTEN },
         { NC_("blendmode", "darken"), DEVELOP_BLEND_DARKEN },
+        { NC_("blendmode", "screen"), DEVELOP_BLEND_SCREEN },
+
         { NC_("blendmode", "multiply"), DEVELOP_BLEND_MULTIPLY },
-        { NC_("blendmode", "average"), DEVELOP_BLEND_AVERAGE },
+        { NC_("blendmode", "divide"), DEVELOP_BLEND_DIVIDE },
         { NC_("blendmode", "addition"), DEVELOP_BLEND_ADD },
         { NC_("blendmode", "subtract"), DEVELOP_BLEND_SUBTRACT },
-        { NC_("blendmode", "difference"), DEVELOP_BLEND_DIFFERENCE2 },
-        { NC_("blendmode", "screen"), DEVELOP_BLEND_SCREEN },
+        { NC_("blendmode", "geometric mean"), DEVELOP_BLEND_GEOMETRIC_MEAN },
+        { NC_("blendmode", "harmonic mean"), DEVELOP_BLEND_HARMONIC_MEAN },
+
         { NC_("blendmode", "overlay"), DEVELOP_BLEND_OVERLAY },
         { NC_("blendmode", "softlight"), DEVELOP_BLEND_SOFTLIGHT },
         { NC_("blendmode", "hardlight"), DEVELOP_BLEND_HARDLIGHT },
         { NC_("blendmode", "vividlight"), DEVELOP_BLEND_VIVIDLIGHT },
         { NC_("blendmode", "linearlight"), DEVELOP_BLEND_LINEARLIGHT },
         { NC_("blendmode", "pinlight"), DEVELOP_BLEND_PINLIGHT },
+
         { NC_("blendmode", "lightness"), DEVELOP_BLEND_LIGHTNESS },
         { NC_("blendmode", "chromaticity"), DEVELOP_BLEND_CHROMATICITY },
-        { NC_("blendmode", "hue"), DEVELOP_BLEND_HUE },
-        { NC_("blendmode", "color"), DEVELOP_BLEND_COLOR },
-        { NC_("blendmode", "coloradjustment"), DEVELOP_BLEND_COLORADJUST },
+
         { NC_("blendmode", "Lab lightness"), DEVELOP_BLEND_LAB_LIGHTNESS },
-        { NC_("blendmode", "Lab color"), DEVELOP_BLEND_LAB_COLOR },
-        { NC_("blendmode", "Lab L-channel"), DEVELOP_BLEND_LAB_L },
         { NC_("blendmode", "Lab a-channel"), DEVELOP_BLEND_LAB_A },
         { NC_("blendmode", "Lab b-channel"), DEVELOP_BLEND_LAB_B },
-        { NC_("blendmode", "HSV value"), DEVELOP_BLEND_HSV_VALUE },
-        { NC_("blendmode", "HSV color"), DEVELOP_BLEND_HSV_COLOR },
+        { NC_("blendmode", "Lab color"), DEVELOP_BLEND_LAB_COLOR },
+
         { NC_("blendmode", "RGB red channel"), DEVELOP_BLEND_RGB_R },
         { NC_("blendmode", "RGB green channel"), DEVELOP_BLEND_RGB_G },
         { NC_("blendmode", "RGB blue channel"), DEVELOP_BLEND_RGB_B },
-        { NC_("blendmode", "divide"), DEVELOP_BLEND_DIVIDE },
-        { NC_("blendmode", "geometric mean"), DEVELOP_BLEND_GEOMETRIC_MEAN },
-        { NC_("blendmode", "harmonic mean"), DEVELOP_BLEND_HARMONIC_MEAN },
+        { NC_("blendmode", "HSV value"), DEVELOP_BLEND_HSV_VALUE },
+        { NC_("blendmode", "HSV color"), DEVELOP_BLEND_HSV_COLOR },
+
+        { NC_("blendmode", "hue"), DEVELOP_BLEND_HUE },
+        { NC_("blendmode", "color"), DEVELOP_BLEND_COLOR },
+        { NC_("blendmode", "coloradjustment"), DEVELOP_BLEND_COLORADJUST },
 
         /** deprecated blend modes: make them available as legacy history stacks might want them */
         { NC_("blendmode", "difference (deprecated)"), DEVELOP_BLEND_DIFFERENCE },
         { NC_("blendmode", "subtract inverse (deprecated)"), DEVELOP_BLEND_SUBTRACT_INVERSE },
         { NC_("blendmode", "divide inverse (deprecated)"), DEVELOP_BLEND_DIVIDE_INVERSE },
+        { NC_("blendmode", "Lab L-channel (deprecated)"), DEVELOP_BLEND_LAB_L },
         { } };
 
 const dt_introspection_type_enum_tuple_t dt_develop_blend_mode_flag_names[]
@@ -2528,19 +2535,15 @@ void dt_iop_gui_cleanup_blending(dt_iop_module_t *module)
 }
 
 
-static gboolean _add_blendmode_combo(GtkWidget *combobox, dt_develop_blend_mode_t mode)
+static gboolean _add_blendmode_combo(GtkWidget *combobox,
+                                     dt_develop_blend_mode_t start,
+                                     dt_develop_blend_mode_t end)
 {
-  for(const dt_introspection_type_enum_tuple_t *bm = dt_develop_blend_mode_names; *bm->name; bm++)
-  {
-    if(bm->value == mode)
-    {
-      dt_bauhaus_combobox_add_full(combobox, Q_(bm->name), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, GUINT_TO_POINTER(bm->value), NULL, TRUE);
-
-      return TRUE;
-    }
-  }
-
-  return FALSE;
+  return dt_bauhaus_combobox_add_introspection(combobox,
+                                               NULL,
+                                               dt_develop_blend_mode_names,
+                                               start,
+                                               end);
 }
 
 static GtkWidget *_combobox_new_from_list(dt_iop_module_t *module, const gchar *label,
@@ -2629,74 +2632,42 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
        || bd->csp == DEVELOP_BLEND_CS_RGB_DISPLAY
        || bd->csp == DEVELOP_BLEND_CS_RAW )
     {
-      dt_bauhaus_combobox_add_section(bd->blend_modes_combo, _("normal & difference modes"));
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_NORMAL2);
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_BOUNDED);
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_AVERAGE);
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_DIFFERENCE2);
-      dt_bauhaus_combobox_add_section(bd->blend_modes_combo, _("lighten modes"));
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_LIGHTEN);
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_ADD);
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_SCREEN);
-      dt_bauhaus_combobox_add_section(bd->blend_modes_combo, _("darken modes"));
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_DARKEN);
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_SUBTRACT);
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_MULTIPLY);
-      dt_bauhaus_combobox_add_section(bd->blend_modes_combo, _("contrast enhancing modes"));
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_OVERLAY);
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_SOFTLIGHT);
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_HARDLIGHT);
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_VIVIDLIGHT);
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_LINEARLIGHT);
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_PINLIGHT);
+      dt_bauhaus_combobox_add_section(bd->blend_modes_combo, _("normal & difference"));
+      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_NORMAL2, DEVELOP_BLEND_DIFFERENCE2);
+      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_BOUNDED, DEVELOP_BLEND_BOUNDED);
+      dt_bauhaus_combobox_add_section(bd->blend_modes_combo, _("lighten"));
+      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_LIGHTEN, DEVELOP_BLEND_LIGHTEN);
+      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_ADD, DEVELOP_BLEND_ADD);
+      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_SCREEN, DEVELOP_BLEND_SCREEN);
+      dt_bauhaus_combobox_add_section(bd->blend_modes_combo, _("darken"));
+      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_DARKEN, DEVELOP_BLEND_DARKEN);
+      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_SUBTRACT, DEVELOP_BLEND_SUBTRACT);
+      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_MULTIPLY, DEVELOP_BLEND_MULTIPLY);
+      dt_bauhaus_combobox_add_section(bd->blend_modes_combo, _("contrast enhancing"));
+      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_OVERLAY, DEVELOP_BLEND_PINLIGHT);
 
-      if(bd->csp == DEVELOP_BLEND_CS_LAB)
+      if(bd->csp == DEVELOP_BLEND_CS_LAB || bd->csp == DEVELOP_BLEND_CS_RGB_DISPLAY)
       {
-        dt_bauhaus_combobox_add_section(bd->blend_modes_combo, _("color channel modes"));
-        _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_LAB_LIGHTNESS);
-        _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_LAB_A);
-        _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_LAB_B);
-        _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_LAB_COLOR);
-        _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_LIGHTNESS);
-        _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_CHROMATICITY);
-        _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_HUE);
-        _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_COLOR);
-        _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_COLORADJUST);
-      }
-      else if(bd->csp == DEVELOP_BLEND_CS_RGB_DISPLAY)
-      {
-        dt_bauhaus_combobox_add_section(bd->blend_modes_combo, _("color channel modes"));
-        _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_RGB_R);
-        _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_RGB_G);
-        _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_RGB_B);
-        _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_LIGHTNESS);
-        _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_HSV_VALUE);
-        _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_CHROMATICITY);
-        _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_HSV_COLOR);
-        _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_HUE);
-        _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_COLOR);
-        _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_COLORADJUST);
+        dt_bauhaus_combobox_add_section(bd->blend_modes_combo, _("color channel"));
+        if(bd->csp == DEVELOP_BLEND_CS_LAB)
+          _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_LAB_LIGHTNESS, DEVELOP_BLEND_LAB_COLOR);
+        else
+          _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_RGB_R, DEVELOP_BLEND_HSV_COLOR);
+        _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_HUE, DEVELOP_BLEND_COLORADJUST);
+
+        dt_bauhaus_combobox_add_section(bd->blend_modes_combo, _("chromaticity & lightness"));
+        _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_LIGHTNESS, DEVELOP_BLEND_CHROMATICITY);
       }
     }
     else if(bd->csp == DEVELOP_BLEND_CS_RGB_SCENE)
     {
-      dt_bauhaus_combobox_add_section(bd->blend_modes_combo, _("normal & arithmetic modes"));
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_NORMAL2);
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_MULTIPLY);
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_DIVIDE);
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_ADD);
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_SUBTRACT);
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_DIFFERENCE2);
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_AVERAGE);
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_GEOMETRIC_MEAN);
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_HARMONIC_MEAN);
-      dt_bauhaus_combobox_add_section(bd->blend_modes_combo, _("color channel modes"));
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_RGB_R);
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_RGB_G);
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_RGB_B);
-      dt_bauhaus_combobox_add_section(bd->blend_modes_combo, _("chromaticity & lightness modes"));
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_LIGHTNESS);
-      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_CHROMATICITY);
+      dt_bauhaus_combobox_add_section(bd->blend_modes_combo, _("normal & arithmetic"));
+      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_NORMAL2, DEVELOP_BLEND_DIFFERENCE2);
+      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_MULTIPLY, DEVELOP_BLEND_HARMONIC_MEAN);
+      dt_bauhaus_combobox_add_section(bd->blend_modes_combo, _("color channel"));
+      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_RGB_R, DEVELOP_BLEND_RGB_B);
+      dt_bauhaus_combobox_add_section(bd->blend_modes_combo, _("chromaticity & lightness"));
+      _add_blendmode_combo(bd->blend_modes_combo, DEVELOP_BLEND_LIGHTNESS, DEVELOP_BLEND_CHROMATICITY);
     }
     bd->blend_modes_csp = bd->csp;
   }
@@ -2705,8 +2676,8 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
   if(!dt_bauhaus_combobox_set_from_value(bd->blend_modes_combo, blend_mode))
   {
     // add deprecated blend mode
-    dt_bauhaus_combobox_add_section(bd->blend_modes_combo, _("deprecated modes"));
-    if(!_add_blendmode_combo(bd->blend_modes_combo, blend_mode))
+    dt_bauhaus_combobox_add_section(bd->blend_modes_combo, _("deprecated"));
+    if(!_add_blendmode_combo(bd->blend_modes_combo, blend_mode, blend_mode))
     {
       // should never happen: unknown blend mode
       dt_control_log("unknown blend mode '%d' in module '%s'", blend_mode, module->op);

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -212,17 +212,12 @@ GtkWidget *dt_bauhaus_combobox_from_params(dt_iop_module_t *self, const char *pa
     }
     else if(f->header.type == DT_INTROSPECTION_TYPE_ENUM)
     {
-      for(dt_introspection_type_enum_tuple_t *iter = f->Enum.values; iter && iter->name; iter++)
-      {
-        // we do not want to support a context as it break all translations see #5498
-        // dt_bauhaus_combobox_add_full(combobox, g_dpgettext2(NULL, "introspection description", iter->description), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, GINT_TO_POINTER(iter->value), NULL, TRUE);
-        if(*iter->description)
-          dt_bauhaus_combobox_add_full(combobox, gettext(iter->description), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, GINT_TO_POINTER(iter->value), NULL, TRUE);
-      }
+      dt_bauhaus_combobox_add_introspection(combobox,
+                                            action,
+                                            f->Enum.values,
+                                            f->Enum.values[0].value,
+                                            f->Enum.values[f->Enum.entries - 1].value);
       dt_bauhaus_combobox_set_default(combobox, *(int*)((uint8_t *)d + f->header.offset));
-
-      if(action && f->Enum.values)
-        g_hash_table_insert(darktable.control->combo_introspection, action, f->Enum.values);
     }
   }
   else

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -63,6 +63,7 @@ const gchar *shortcut_category_label[]
       N_("fallbacks"),
       N_("speed") };
 #define NUM_CATEGORIES G_N_ELEMENTS(shortcut_category_label)
+
 typedef struct dt_device_key_t
 {
   dt_input_device_t key_device;
@@ -961,12 +962,12 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget, gint x, gint y, gboolea
   const gchar *element_name = NULL;
   if(def)
   {
-    for(int i = 0; i <= darktable.control->element; i++)
+    for(int i = 0; i <= lua_shortcut.element; i++)
     {
       element_name = def->elements[i].name;
       if(!element_name) break;
     }
-    if(element_name && (darktable.control->element || !has_fallbacks) && show_element == 0)
+    if(element_name && (lua_shortcut.element || !has_fallbacks) && show_element == 0)
       description = g_markup_escape_text(_(element_name), -1);
   }
 

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -26,6 +26,7 @@
 #include "develop/blend.h"
 #include "gui/presets.h"
 #include "dtgtk/expander.h"
+#include "bauhaus/bauhaus.h"
 
 #include <assert.h>
 #include <gtk/gtk.h>
@@ -777,6 +778,30 @@ static gchar *_shortcut_lua_command(GtkWidget *widget, dt_shortcut_t *s, gchar *
     return NULL;
 
   for(int c = 0; c < s->element; c++) if(!elements[c].name) s->element = c - 1;
+
+  if(DT_IS_BAUHAUS_WIDGET(widget) && s->element == DT_ACTION_ELEMENT_DEFAULT)
+  {
+    if(DT_BAUHAUS_WIDGET(widget)->type == DT_BAUHAUS_COMBOBOX)
+    {
+      int value = GPOINTER_TO_INT(dt_bauhaus_combobox_get_data(widget));
+      dt_introspection_type_enum_tuple_t *values
+        = g_hash_table_lookup(darktable.control->combo_introspection, s->action);
+      for(int i = 0; values && values->name; values++, i++)
+      {
+        if(values->value == value)
+        {
+          value = i;
+          break;
+        }
+      }
+      s->effect = DT_ACTION_EFFECT_COMBO_SEPARATOR + 1 + value;
+    }
+    else
+    {
+      s->effect = DT_ACTION_EFFECT_SET;
+      s->speed = dt_bauhaus_slider_get(widget);
+    }
+  }
 
   const gchar *cef = elements ? _action_find_effect_combo(s->action, &elements[s->element], s->effect) : NULL;
   const gchar *el = elements ? elements[s->element].name : NULL;

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1043,8 +1043,7 @@ static dt_view_type_flags_t _find_views(dt_action_t *action)
   dt_view_type_flags_t vws = 0;
 
   dt_action_t *owner = action;
-  while(owner && owner->type >= DT_ACTION_TYPE_SECTION)
-    owner = owner->owner;
+  while(owner && owner->type >= DT_ACTION_TYPE_SECTION) owner = owner->owner;
 
   if(owner)
 
@@ -1385,6 +1384,10 @@ static void _fill_shortcut_fields(GtkTreeViewColumn *column, GtkCellRenderer *ce
   {
     const dt_action_element_def_t *elements = NULL;
     dt_shortcut_t *s = g_sequence_get(data_ptr);
+
+    dt_action_t *owner = s->action;
+    while(owner && owner->type >= DT_ACTION_TYPE_SECTION) owner = owner->owner;
+
     switch(field)
     {
     case SHORTCUT_VIEW_DESCRIPTION:
@@ -1395,7 +1398,7 @@ static void _fill_shortcut_fields(GtkTreeViewColumn *column, GtkCellRenderer *ce
         field_text = _action_full_label(s->action);
       break;
     case SHORTCUT_VIEW_ELEMENT:
-      if(s->action->owner == &darktable.control->actions_lua || _shortcut_is_speed(s)) break;
+      if(owner == &darktable.control->actions_lua || _shortcut_is_speed(s)) break;
       elements = _action_find_elements(s->action);
       if(elements && elements->name)
       {
@@ -1406,7 +1409,7 @@ static void _fill_shortcut_fields(GtkTreeViewColumn *column, GtkCellRenderer *ce
       }
       break;
     case SHORTCUT_VIEW_EFFECT:
-      if(s->action->owner == &darktable.control->actions_lua || _shortcut_is_speed(s)) break;
+      if(owner == &darktable.control->actions_lua || _shortcut_is_speed(s)) break;
       elements = _action_find_elements(s->action);
       if(elements)
       {
@@ -1435,7 +1438,7 @@ static void _fill_shortcut_fields(GtkTreeViewColumn *column, GtkCellRenderer *ce
       break;
     case SHORTCUT_VIEW_INSTANCE:
       if(_shortcut_is_speed(s)) break;
-      for(dt_action_t *owner = s->action; owner; owner = owner->owner)
+      for(; owner; owner = owner->owner)
       {
         if(owner->type == DT_ACTION_TYPE_IOP)
         {

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1568,13 +1568,12 @@ static void _effect_editing_started(GtkCellRenderer *renderer, GtkCellEditable *
       // insert empty/separator row
       gtk_list_store_insert_with_values(store, NULL, -1, DT_ACTION_EFFECT_COLUMN_SEPARATOR, TRUE, -1);
 
-      while(values->name)
+      for(; values->name; values++)
       {
         gtk_list_store_insert_with_values(store, NULL, -1,
-                                          DT_ACTION_EFFECT_COLUMN_NAME, values->description ? Q_(values->description) : Q_(values->name),
+                                          DT_ACTION_EFFECT_COLUMN_NAME, Q_(values->description ? values->description : values->name),
                                           DT_ACTION_EFFECT_COLUMN_WEIGHT, PANGO_WEIGHT_NORMAL,
                                           -1);
-        values++;
       }
     }
     else

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -214,6 +214,9 @@ GtkWidget *dt_action_button_new(dt_lib_module_t *self, const gchar *label, gpoin
 // create a shortcutable entry field
 GtkWidget *dt_action_entry_new(dt_action_t *ac, const gchar *label, gpointer callback, gpointer data, const gchar *tooltip, const gchar *text);
 
+// find the action a widget is linked to
+dt_action_t *dt_action_widget(GtkWidget *widget);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif /* __cplusplus */

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -41,7 +41,8 @@ void dt_shortcuts_select_view(dt_view_type_flags_t view);
 
 gboolean dt_shortcut_dispatcher(GtkWidget *w, GdkEvent *event, gpointer user_data);
 gboolean dt_shortcut_tooltip_callback(GtkWidget *widget, gint x, gint y, gboolean keyboard_mode,
-                                      GtkTooltip *tooltip, gpointer user_data);
+                                      GtkTooltip *tooltip, GtkWidget *vbox);
+void dt_shortcut_copy_lua(dt_action_t *action, gchar *preset_name);
 
 float dt_action_process(const gchar *action, int instance, const gchar *element, const gchar *effect, float size);
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3404,7 +3404,7 @@ void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
                    G_CALLBACK(_collapse_expander_click), cs);
 }
 
-gboolean dt_gui_long_click(int second, int first)
+gboolean dt_gui_long_click(const int second, const int first)
 {
   int delay = 0;
   g_object_get(gtk_settings_get_default(), "gtk-double-click-time", &delay, NULL);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3404,6 +3404,13 @@ void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
                    G_CALLBACK(_collapse_expander_click), cs);
 }
 
+gboolean dt_gui_long_click(int second, int first)
+{
+  int delay = 0;
+  g_object_get(gtk_settings_get_default(), "gtk-double-click-time", &delay, NULL);
+  return second - first > delay;
+}
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -465,7 +465,7 @@ void dt_gui_update_collapsible_section(dt_gui_collapsible_section_t *cs);
 void dt_gui_hide_collapsible_section(dt_gui_collapsible_section_t *cs);
 
 // is delay between first and second click/press longer than double-click time?
-gboolean dt_gui_long_click(int second, int first);
+gboolean dt_gui_long_click(const int second, const int first);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -464,6 +464,9 @@ void dt_gui_update_collapsible_section(dt_gui_collapsible_section_t *cs);
 // routine to hide the collapsible section
 void dt_gui_hide_collapsible_section(dt_gui_collapsible_section_t *cs);
 
+// is delay between first and second click/press longer than double-click time?
+gboolean dt_gui_long_click(int second, int first);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif /* __cplusplus */

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -1092,7 +1092,8 @@ gboolean dt_gui_presets_autoapply_for_module(dt_iop_module_t *module)
   return applied;
 }
 
-static gboolean _menuitem_button_preset(GtkMenuItem *menuitem, GdkEventButton *event,
+static gboolean _menuitem_button_preset(GtkMenuItem *menuitem,
+                                        GdkEventButton *event,
                                         dt_iop_module_t *module)
 {
   static guint click_time = 0;

--- a/src/iop/blurs.c
+++ b/src/iop/blurs.c
@@ -211,7 +211,7 @@ static inline void create_motion_kernel(float *const restrict buffer,
   const float A = curvature / 2.f;
   const float B = 1.f;
   const float C = -A * offset * offset + B * offset;
-  // Note : C ensures the polynomial arc always goes through the central pixel
+  // Note : C ensures the polynomial arc always goes through the central pixel
   // so we don't shift pixels. This is meant to allow seamless connection
   // with unmasked areas when using masked blur.
 

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -47,16 +47,27 @@
 DT_MODULE_INTROSPECTION(3, dt_iop_borders_params_t)
 
 // Module constants
-#define DT_IOP_BORDERS_ASPECT_COUNT 12
-#define DT_IOP_BORDERS_ASPECT_IMAGE_IDX 0
-#define DT_IOP_BORDERS_ASPECT_CONSTANT_IDX 11
 #define DT_IOP_BORDERS_ASPECT_IMAGE_VALUE 0.0f
 #define DT_IOP_BORDERS_ASPECT_CONSTANT_VALUE -1.0f
-#define DT_IOP_BORDERS_ASPECT_ORIENTATION_AUTO 0
-#define DT_IOP_BORDERS_ASPECT_ORIENTATION_PORTRAIT 1
-#define DT_IOP_BORDERS_ASPECT_ORIENTATION_LANDSCAPE 2
-#define DT_IOP_BORDERS_POSITION_H_COUNT 5
-#define DT_IOP_BORDERS_POSITION_V_COUNT 5
+typedef enum dt_iop_orientation_t
+{
+  DT_IOP_BORDERS_ASPECT_ORIENTATION_AUTO = 0,      // $DESCRIPTION: "auto"
+  DT_IOP_BORDERS_ASPECT_ORIENTATION_PORTRAIT = 1,  // $DESCRIPTION: "portrait"
+  DT_IOP_BORDERS_ASPECT_ORIENTATION_LANDSCAPE = 2, // $DESCRIPTION: "landscape"
+} dt_iop_orientation_t;
+
+static const float _aspect_ratios[]
+  = { DT_IOP_BORDERS_ASPECT_IMAGE_VALUE,
+      3.0f, 95.0f / 33.0f, 2.0f, 16.0f / 9.0f, PHI, 3.0f / 2.0f, 297.0f / 210.0f, M_SQRT2, 4.0f / 3.0f, 1.0f,
+      DT_IOP_BORDERS_ASPECT_CONSTANT_VALUE };
+static const float _pos_h_ratios[] = { 0.5f, 1.0f / 3.0f, 3.0f / 8.0f, 5.0f / 8.0f, 2.0f / 3.0f };
+static const float _pos_v_ratios[] = { 0.5f, 1.0f / 3.0f, 3.0f / 8.0f, 5.0f / 8.0f, 2.0f / 3.0f };
+
+#define DT_IOP_BORDERS_ASPECT_COUNT G_N_ELEMENTS(_aspect_ratios)
+#define DT_IOP_BORDERS_ASPECT_IMAGE_IDX 0
+#define DT_IOP_BORDERS_ASPECT_CONSTANT_IDX (DT_IOP_BORDERS_ASPECT_COUNT - 1)
+#define DT_IOP_BORDERS_POSITION_H_COUNT G_N_ELEMENTS(_pos_h_ratios)
+#define DT_IOP_BORDERS_POSITION_V_COUNT G_N_ELEMENTS(_pos_v_ratios)
 
 typedef struct dt_iop_borders_params_t
 {
@@ -65,7 +76,7 @@ typedef struct dt_iop_borders_params_t
                                $MIN: 1.0 $MAX: 3.0 $DEFAULT: DT_IOP_BORDERS_ASPECT_CONSTANT_VALUE $DESCRIPTION: "aspect ratio" */
   char aspect_text[20];     /* aspect ratio of the outer frame w/h (user string version)
                                DEFAULT: "constant border" */
-  int aspect_orient;        /* aspect ratio orientation
+  dt_iop_orientation_t aspect_orient;        /* aspect ratio orientation
                                $DEFAULT: 0 $DESCRIPTION: "orientation" */
   float size;               /* border width relative to overall frame width
                                $MIN: 0.0 $MAX: 0.5 $DEFAULT: 0.1 $DESCRIPTION: "border size" */
@@ -98,9 +109,6 @@ typedef struct dt_iop_borders_gui_data_t
   GtkWidget *pos_v_slider;
   GtkWidget *colorpick;
   GtkWidget *border_picker; // the 1st button
-  float aspect_ratios[DT_IOP_BORDERS_ASPECT_COUNT];
-  float pos_h_ratios[DT_IOP_BORDERS_POSITION_H_COUNT];
-  float pos_v_ratios[DT_IOP_BORDERS_POSITION_V_COUNT];
   GtkWidget *frame_size;
   GtkWidget *frame_offset;
   GtkWidget *frame_colorpick;
@@ -775,7 +783,7 @@ static void aspect_changed(GtkWidget *combo, dt_iop_module_t *self)
   else if(which < DT_IOP_BORDERS_ASPECT_COUNT)
   {
     g_strlcpy(p->aspect_text, text, sizeof(p->aspect_text));
-    p->aspect = g->aspect_ratios[which];
+    p->aspect = _aspect_ratios[which];
     ++darktable.gui->reset;
     dt_bauhaus_slider_set(g->aspect_slider,p->aspect);
     --darktable.gui->reset;
@@ -797,7 +805,7 @@ static void position_h_changed(GtkWidget *combo, dt_iop_module_t *self)
   else if(which < DT_IOP_BORDERS_POSITION_H_COUNT)
   {
     g_strlcpy(p->pos_h_text, text, sizeof(p->pos_h_text));
-    p->pos_h = g->pos_h_ratios[which];
+    p->pos_h = _pos_h_ratios[which];
     ++darktable.gui->reset;
     dt_bauhaus_slider_set(g->pos_h_slider,p->pos_h);
     --darktable.gui->reset;
@@ -819,7 +827,7 @@ static void position_v_changed(GtkWidget *combo, dt_iop_module_t *self)
   else if(which < DT_IOP_BORDERS_POSITION_V_COUNT)
   {
     g_strlcpy(p->pos_v_text, text, sizeof(p->pos_v_text));
-    p->pos_v = g->pos_v_ratios[which];
+    p->pos_v = _pos_v_ratios[which];
     ++darktable.gui->reset;
     dt_bauhaus_slider_set(g->pos_v_slider,p->pos_v);
     --darktable.gui->reset;
@@ -831,18 +839,35 @@ static void position_v_changed(GtkWidget *combo, dt_iop_module_t *self)
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
+  dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
 
-  if(w == g->aspect_slider)
+  int k;
+  if(!w || w == g->aspect_slider)
   {
-    dt_bauhaus_combobox_set(g->aspect, DT_IOP_BORDERS_ASPECT_COUNT);
+    for(k = 0; k < DT_IOP_BORDERS_ASPECT_COUNT; k++)
+    {
+      if(fabsf(p->aspect - _aspect_ratios[k]) < 0.01f)
+        break;
+    }
+    dt_bauhaus_combobox_set(g->aspect, k);
   }
-  else if(w == g->pos_h_slider)
+  else if(!w || w == g->pos_h_slider)
   {
-    dt_bauhaus_combobox_set(g->pos_h, DT_IOP_BORDERS_POSITION_H_COUNT);
+    for(k = 0; k < DT_IOP_BORDERS_POSITION_H_COUNT; k++)
+    {
+      if(fabsf(p->pos_h - _pos_h_ratios[k]) < 0.01f)
+        break;
+    }
+    dt_bauhaus_combobox_set(g->pos_h, k);
   }
-  else if(w == g->pos_v_slider)
+  else if(!w || w == g->pos_v_slider)
   {
-    dt_bauhaus_combobox_set(g->pos_v, DT_IOP_BORDERS_POSITION_V_COUNT);
+    for(k = 0; k < DT_IOP_BORDERS_POSITION_V_COUNT; k++)
+    {
+      if(fabsf(p->pos_v - _pos_v_ratios[k]) < 0.01f)
+        break;
+    }
+    dt_bauhaus_combobox_set(g->pos_v, k);
   }
 }
 
@@ -886,49 +911,7 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
 
-// FIXME by hand
-  // ----- Aspect
-  int k = 0;
-  for(; k < DT_IOP_BORDERS_ASPECT_COUNT; k++)
-  {
-    if(fabsf(p->aspect - g->aspect_ratios[k]) < 0.01f)
-    {
-      dt_bauhaus_combobox_set(g->aspect, k);
-      break;
-    }
-  }
-  if(k == DT_IOP_BORDERS_ASPECT_COUNT)
-  {
-      dt_bauhaus_combobox_set(g->aspect, k);
-  }
-
-  // ----- Position H
-  for(k = 0; k < DT_IOP_BORDERS_POSITION_H_COUNT; k++)
-  {
-    if(fabsf(p->pos_h - g->pos_h_ratios[k]) < 0.01f)
-    {
-      dt_bauhaus_combobox_set(g->pos_h, k);
-      break;
-    }
-  }
-  if(k == DT_IOP_BORDERS_POSITION_H_COUNT)
-  {
-    dt_bauhaus_combobox_set(g->pos_h, k);
-  }
-
-  // ----- Position V
-  for(k = 0; k < DT_IOP_BORDERS_POSITION_V_COUNT; k++)
-  {
-    if(fabsf(p->pos_v - g->pos_v_ratios[k]) < 0.01f)
-    {
-      dt_bauhaus_combobox_set(g->pos_v, k);
-      break;
-    }
-  }
-  if(k == DT_IOP_BORDERS_POSITION_V_COUNT)
-  {
-    dt_bauhaus_combobox_set(g->pos_v, k);
-  }
+  gui_changed(self, NULL, NULL);
 
   // ----- Border Color
   GdkRGBA c = (GdkRGBA){.red = p->color[0], .green = p->color[1], .blue = p->color[2], .alpha = 1.0 };
@@ -941,70 +924,6 @@ void gui_update(struct dt_iop_module_t *self)
   gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(g->frame_colorpick), &fc);
 }
 
-static void gui_init_aspect(struct dt_iop_module_t *self)
-{
-  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
-
-  dt_bauhaus_combobox_add(g->aspect, _("image"));
-  dt_bauhaus_combobox_add(g->aspect, _("3:1"));
-  dt_bauhaus_combobox_add(g->aspect, _("95:33"));
-  dt_bauhaus_combobox_add(g->aspect, _("2:1"));
-  dt_bauhaus_combobox_add(g->aspect, _("16:9"));
-  dt_bauhaus_combobox_add(g->aspect, _("golden cut"));
-  dt_bauhaus_combobox_add(g->aspect, _("3:2"));
-  dt_bauhaus_combobox_add(g->aspect, _("A4"));
-  dt_bauhaus_combobox_add(g->aspect, _("DIN"));
-  dt_bauhaus_combobox_add(g->aspect, _("4:3"));
-  dt_bauhaus_combobox_add(g->aspect, _("square"));
-  dt_bauhaus_combobox_add(g->aspect, _("constant border"));
-  dt_bauhaus_combobox_add(g->aspect, _("custom..."));
-
-  g->aspect_ratios[DT_IOP_BORDERS_ASPECT_IMAGE_IDX] = DT_IOP_BORDERS_ASPECT_IMAGE_VALUE;
-  g->aspect_ratios[DT_IOP_BORDERS_ASPECT_CONSTANT_IDX] = DT_IOP_BORDERS_ASPECT_CONSTANT_VALUE;
-  int i = 1;
-  g->aspect_ratios[i++] = 3.0f;
-  g->aspect_ratios[i++] = 95.0f / 33.0f;
-  g->aspect_ratios[i++] = 2.0f;
-  g->aspect_ratios[i++] = 16.0f / 9.0f;
-  g->aspect_ratios[i++] = PHI;
-  g->aspect_ratios[i++] = 3.0f / 2.0f;
-  g->aspect_ratios[i++] = 297.0f / 210.0f;
-  g->aspect_ratios[i++] = sqrtf(2.0f);
-  g->aspect_ratios[i++] = 4.0f / 3.0f;
-  g->aspect_ratios[i++] = 1.0f;
-}
-
-static void gui_init_positions(struct dt_iop_module_t *self)
-{
-  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
-
-  dt_bauhaus_combobox_add(g->pos_h, _("center"));
-  dt_bauhaus_combobox_add(g->pos_h, _("1/3"));
-  dt_bauhaus_combobox_add(g->pos_h, _("3/8"));
-  dt_bauhaus_combobox_add(g->pos_h, _("5/8"));
-  dt_bauhaus_combobox_add(g->pos_h, _("2/3"));
-  dt_bauhaus_combobox_add(g->pos_h, _("custom..."));
-  dt_bauhaus_combobox_add(g->pos_v, _("center"));
-  dt_bauhaus_combobox_add(g->pos_v, _("1/3"));
-  dt_bauhaus_combobox_add(g->pos_v, _("3/8"));
-  dt_bauhaus_combobox_add(g->pos_v, _("5/8"));
-  dt_bauhaus_combobox_add(g->pos_v, _("2/3"));
-  dt_bauhaus_combobox_add(g->pos_v, _("custom..."));
-
-  int i = 0;
-  g->pos_h_ratios[i++] = 0.5f;
-  g->pos_h_ratios[i++] = 1.0f / 3.0f;
-  g->pos_h_ratios[i++] = 3.0f / 8.0f;
-  g->pos_h_ratios[i++] = 5.0f / 8.0f;
-  g->pos_h_ratios[i++] = 2.0f / 3.0f;
-  i = 0;
-  g->pos_v_ratios[i++] = 0.5f;
-  g->pos_v_ratios[i++] = 1.0f / 3.0f;
-  g->pos_v_ratios[i++] = 3.0f / 8.0f;
-  g->pos_v_ratios[i++] = 5.0f / 8.0f;
-  g->pos_v_ratios[i++] = 2.0f / 3.0f;
-}
-
 void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_borders_gui_data_t *g = IOP_GUI_ALLOC(borders);
@@ -1015,43 +934,52 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->size, "%");
   gtk_widget_set_tooltip_text(g->size, _("size of the border in percent of the full image"));
 
-  g->aspect = dt_bauhaus_combobox_new(self);
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(g->aspect, self, NULL, N_("aspect"),
+                               _("select the aspect ratio or right click and type your own (w:h)"),
+                               0, aspect_changed, self,
+                               N_("image"),
+                               N_("3:1"),
+                               N_("95:33"),
+                               N_("2:1"),
+                               N_("16:9"),
+                               N_("golden cut"),
+                               N_("3:2"),
+                               N_("A4"),
+                               N_("DIN"),
+                               N_("4:3"),
+                               N_("square"),
+                               N_("constant border"),
+                               N_("custom..."));
   dt_bauhaus_combobox_set_editable(g->aspect, 1);
-  dt_bauhaus_widget_set_label(g->aspect, NULL, N_("aspect"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->aspect, TRUE, TRUE, 0);
-  gui_init_aspect(self);
-  g_signal_connect(G_OBJECT(g->aspect), "value-changed", G_CALLBACK(aspect_changed), self);
-  gtk_widget_set_tooltip_text(g->aspect, _("select the aspect ratio or right click and type your own (w:h)"));
+
   g->aspect_slider = dt_bauhaus_slider_from_params(self, "aspect");
   gtk_widget_set_tooltip_text(g->aspect_slider, _("set the custom aspect ratio"));
 
   g->aspect_orient = dt_bauhaus_combobox_from_params(self, "aspect_orient");
-  dt_bauhaus_combobox_add(g->aspect_orient, _("auto"));
-  dt_bauhaus_combobox_add(g->aspect_orient, _("portrait"));
-  dt_bauhaus_combobox_add(g->aspect_orient, _("landscape"));
   gtk_widget_set_tooltip_text(g->aspect_orient, _("aspect ratio orientation of the image with border"));
 
-  g->pos_h = dt_bauhaus_combobox_new(self);
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(g->pos_h, self, NULL, N_("horizontal position"),
+                               _("select the horizontal position ratio relative to top "
+                                 "or right click and type your own (y:h)"),
+                               0, position_h_changed, self,
+                               N_("center"), N_("1/3"), N_("3/8"), N_("5/8"), N_("2/3"), N_("custom..."));
   dt_bauhaus_combobox_set_editable(g->pos_h, 1);
-  dt_bauhaus_widget_set_label(g->pos_h, NULL, N_("horizontal position"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->pos_h, TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(g->pos_h), "value-changed", G_CALLBACK(position_h_changed), self);
-  gtk_widget_set_tooltip_text(g->pos_h, _("select the horizontal position ratio relative to top "
-                                          "or right click and type your own (y:h)"));
+
   g->pos_h_slider = dt_bauhaus_slider_from_params(self, "pos_h");
   gtk_widget_set_tooltip_text(g->pos_h_slider, _("custom horizontal position"));
 
-  g->pos_v = dt_bauhaus_combobox_new(self);
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(g->pos_v, self, NULL, N_("vertical position"),
+                               _("select the vertical position ratio relative to left "
+                                 "or right click and type your own (x:w)"),
+                               0, position_v_changed, self,
+                               N_("center"), N_("1/3"), N_("3/8"), N_("5/8"), N_("2/3"), N_("custom..."));
   dt_bauhaus_combobox_set_editable(g->pos_v, 1);
-  dt_bauhaus_widget_set_label(g->pos_v, NULL, N_("vertical position"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->pos_v, TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(g->pos_v), "value-changed", G_CALLBACK(position_v_changed), self);
-  gtk_widget_set_tooltip_text(g->pos_v, _("select the vertical position ratio relative to left "
-                                          "or right click and type your own (x:w)"));
+
   g->pos_v_slider = dt_bauhaus_slider_from_params(self, "pos_v");
   gtk_widget_set_tooltip_text(g->pos_v_slider, _("custom vertical position"));
-
-  gui_init_positions(self);
 
   g->frame_size = dt_bauhaus_slider_from_params(self, "frame_size");
   dt_bauhaus_slider_set_digits(g->frame_size, 4);

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -702,7 +702,7 @@ static inline void _loop_switch(const float *const restrict in,
     for(size_t c = 0; c < DT_PIXEL_SIMD_CHANNELS; c++)
       temp_two[c] = (clip) ? fmaxf(in[k + c], 0.0f) : in[k + c];
 
-    /* WE START IN PIPELINE RGB */
+    /* WE START IN PIPELINE RGB */
 
     switch(kind)
     {
@@ -802,7 +802,7 @@ static inline void _loop_switch(const float *const restrict in,
       }
     }
 
-    /* FROM HERE WE ARE MANDATORILY IN XYZ - DATA IS IN temp_one */
+    /* FROM HERE WE ARE MANDATORILY IN XYZ - DATA IS IN temp_one */
 
     // Gamut mapping happens in XYZ space no matter what
     _gamut_mapping(temp_one, gamut, clip, temp_two);
@@ -828,7 +828,7 @@ static inline void _loop_switch(const float *const restrict in,
       }
     }
 
-    /* FROM HERE WE ARE IN LMS, XYZ OR PIPELINE RGB depending on user
+    /* FROM HERE WE ARE IN LMS, XYZ OR PIPELINE RGB depending on user
        param - DATA IS IN temp_one */
 
     // Clip in LMS
@@ -876,7 +876,7 @@ static inline void _loop_switch(const float *const restrict in,
         }
       }
 
-      /* FROM HERE WE ARE MANDATORILY IN XYZ - DATA IS IN temp_one */
+      /* FROM HERE WE ARE MANDATORILY IN XYZ - DATA IS IN temp_one */
 
       // Clip in XYZ
       if(clip) for(size_t c = 0; c < DT_PIXEL_SIMD_CHANNELS; c++) temp_one[c] = fmaxf(temp_one[c], 0.0f);
@@ -1144,7 +1144,7 @@ static void _check_if_close_to_daylight(const float x,
    * If so, we enable the daylight GUI for better ergonomics
    * Otherwise, we default to direct x, y control for better accuracy
    *
-   * Note : The use of CCT is discouraged if dE > 5 % in CIE 1960 Yuv space
+   * Note : The use of CCT is discouraged if dE > 5 % in CIE 1960 Yuv space
    *        reference : https://onlinelibrary.wiley.com/doi/abs/10.1002/9780470175637.ch3
    */
 
@@ -1231,7 +1231,7 @@ static inline void compute_patches_delta_E(const float *const restrict patches,
 
     // Compute delta E 2000 to make your computer heat
     // ref: https://en.wikipedia.org/wiki/Color_difference#CIEDE2000
-    // note : it will only be luck if I didn't mess-up the computation somewhere
+    // note : it will only be luck if I didn't mess-up the computation somewhere
     const float DL = Lab_ref[0] - Lab_test[0];
     const float L_avg = (Lab_ref[0] + Lab_test[0]) / 2.f;
     const float C_ref = dt_fast_hypotf(Lab_ref[1], Lab_ref[2]);
@@ -1255,7 +1255,7 @@ static inline void compute_patches_delta_E(const float *const restrict patches,
     if(C_ref_prime == 0.f) h_ref_prime = 0.f;
     if(C_test_prime == 0.f) h_test_prime = 0.f;
 
-    // Get the hue angles from [-pi ; pi] back to [0 ; 2 pi],
+    // Get the hue angles from [-pi ; pi] back to [0 ; 2 pi],
     // again, to comply with specifications
     if(h_ref_prime < 0.f) h_ref_prime = 2.f * M_PI - h_ref_prime;
     if(h_test_prime < 0.f) h_test_prime = 2.f * M_PI - h_test_prime;
@@ -1410,7 +1410,7 @@ static const extraction_result_t _extract_patches(const float *const restrict in
           {
             patches[k * 4 + c] += in[(j * width + i) * 4 + c];
 
-            // Debug : inpaint a black square in the preview to ensure the coordanites of
+            // Debug : inpaint a black square in the preview to ensure the coordanites of
             // overlay drawings and actual pixel processing match
             // out[(j * width + i) * 4 + c] = 0.f;
           }
@@ -1702,19 +1702,19 @@ void extract_color_checker(const float *const restrict in,
       w = sqrtf(1.f - hypotf(reference[1] / 128.f, reference[2] / 128.f));
     else if(g->optimization == DT_SOLVE_OPTIMIZE_SKIN)
     {
-      // average skin hue angle is 1.0 rad, hue range is [0.75 ; 1.25]
+      // average skin hue angle is 1.0 rad, hue range is [0.75 ; 1.25]
       const float ref_hue = 1.f;
       GET_WEIGHT;
     }
     else if(g->optimization == DT_SOLVE_OPTIMIZE_FOLIAGE)
     {
-      // average foliage hue angle is 2.23 rad, hue range is [1.94 ; 2.44]
+      // average foliage hue angle is 2.23 rad, hue range is [1.94 ; 2.44]
       const float ref_hue = 2.23f;
       GET_WEIGHT;
     }
     else if(g->optimization == DT_SOLVE_OPTIMIZE_SKY)
     {
-      // average sky/water hue angle is -1.93 rad, hue range is [-1.64 ; -2.41]
+      // average sky/water hue angle is -1.93 rad, hue range is [-1.64 ; -2.41]
       const float ref_hue = -1.93f;
       GET_WEIGHT;
     }
@@ -2548,7 +2548,7 @@ void gui_post_expose(struct dt_iop_module_t *self,
   cairo_line_to(cr, right.x, right.y);
   cairo_stroke(cr);
 
-  /* For debug : display center of the image and center of the ideal target
+  /* For debug : display center of the image and center of the ideal target
   point_t new_target_center = apply_homography(target_center, g->homography);
   cairo_set_source_rgba(cr, 1., 1., 1., 1.);
   cairo_arc(cr, new_target_center.x, new_target_center.y, 7., 0, 2. * M_PI);
@@ -3084,7 +3084,7 @@ static void _update_illuminants(dt_iop_module_t *self)
  * However, it's not a great GUI since x and y are not perceptually
  * scaled. So the `g->illum_x` and `g->illum_y` actually display
  * respectively hue and chroma, in LCh color space, which is designed
- * for illuminants and preceptually spaced. This gives UI controls
+ * for illuminants and preceptually spaced. This gives UI controls
  * which effect feels more even to the user.
  *
  * But that makes things a bit tricky, API-wise, since a set of (x, y)
@@ -3726,7 +3726,7 @@ static void _spot_settings_changed_callback(GtkWidget *slider, dt_iop_module_t *
   const dt_spot_mode_t mode = dt_bauhaus_combobox_get(g->spot_mode);
   if(mode == DT_SPOT_MODE_CORRECT)
     _auto_set_illuminant(self, darktable.develop->pipe);
-  // else : just record new values and do nothing
+  // else : just record new values and do nothing
 }
 
 
@@ -3895,14 +3895,14 @@ void _auto_set_illuminant(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe)
   dot_product(RGB, work_profile->matrix_in, XYZ);
   dt_XYZ_to_sRGB(XYZ, g->spot_RGB);
 
-  // Convert to Lch for GUI feedback (input)
+  // Convert to Lch for GUI feedback (input)
   dt_aligned_pixel_t Lab;
   dt_aligned_pixel_t Lch;
   dt_XYZ_to_Lab(XYZ, Lab);
   dt_Lab_2_LCH(Lab, Lch);
 
   // Write report in GUI
-  gchar *str = g_strdup_printf(_("L: \t%.1f %%\nh: \t%.1f °\nc: \t%.1f"),
+  gchar *str = g_strdup_printf(_("L: \t%.1f %%\nh: \t%.1f °\nc: \t%.1f"),
                                Lch[0], Lch[2] * 360.f, Lch[1]);
   ++darktable.gui->reset;
   gtk_label_set_text(GTK_LABEL(g->Lch_origin), str);
@@ -4037,7 +4037,7 @@ void _auto_set_illuminant(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe)
       float MIX_INV_3x3[9];
       matrice_pseudoinverse((float (*)[3])MIX_3x3, (float (*)[3])MIX_INV_3x3, 3);
 
-      // Transpose and repack the inverse to SSE matrix because the inversion transposes too
+      // Transpose and repack the inverse to SSE matrix because the inversion transposes too
       dt_colormatrix_t MIX_INV;
       transpose_3x3_to_3xSSE(MIX_INV_3x3, MIX_INV);
 
@@ -4283,7 +4283,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->Lch_origin = gtk_label_new(_("L: \tN/A\nh: \tN/A\nc: \tN/A"));
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->Lch_origin),
-                              _("these LCh coordinates are computed from CIE Lab 1976 coordinates"));
+                              _("these LCh coordinates are computed from CIE Lab 1976 coordinates"));
   gtk_box_pack_start(GTK_BOX(vvbox), GTK_WIDGET(g->Lch_origin), FALSE, FALSE, 0);
 
   gtk_box_pack_start(GTK_BOX(hhbox), GTK_WIDGET(vvbox), FALSE, FALSE, DT_BAUHAUS_SPACE);

--- a/src/iop/choleski.h
+++ b/src/iop/choleski.h
@@ -374,7 +374,7 @@ static inline int pseudo_solve(float *const restrict A,
   if(m < n)
   {
     valid = 0;
-    fprintf(stdout, "Pseudo solve: cannot cast %zu × %zu matrice\n", m, n);
+    fprintf(stdout, "Pseudo solve: cannot cast %zu × %zu matrice\n", m, n);
     return valid;
   }
 

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -42,11 +42,11 @@
 
 //#include <gtk/gtk.h>
 #include <stdlib.h>
-#define LUT_ELEM 360     // gamut LUT number of elements: resolution of 1°
+#define LUT_ELEM 360     // gamut LUT number of elements: resolution of 1°
 #define STEPS 92         // so we test 92×92×92 combinations of RGB in [0; 1] to build the gamut LUT
 
 // Filmlight Yrg puts red at 330°, while usual HSL wheels put it at 360/0°
-// so shift in GUI only it to not confuse people. User params are always degrees,
+// so shift in GUI only it to not confuse people. User params are always degrees,
 // pixel params are always radians.
 #define ANGLE_SHIFT -30.f
 #define DEG_TO_RAD(x) ((x + ANGLE_SHIFT) * M_PI / 180.f)
@@ -676,7 +676,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     Ych[2] = hue_rotation_matrix[0][0] * cos_h + hue_rotation_matrix[0][1] * sin_h;
     Ych[3] = hue_rotation_matrix[1][0] * cos_h + hue_rotation_matrix[1][1] * sin_h;
 
-    // Linear chroma : distance to achromatic at constant luminance in scene-referred
+    // Linear chroma : distance to achromatic at constant luminance in scene-referred
     const float chroma_boost = d->chroma_global + scalar_product(opacities, chroma);
     const float vibrance = d->vibrance * (1.0f - powf(Ych[1], fabsf(d->vibrance)));
     const float chroma_factor = fmaxf(1.f + chroma_boost + vibrance, 0.f);
@@ -730,10 +730,10 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
       // Convert to JCh
       float JC[2] = { Jab[0], dt_fast_hypotf(Jab[1], Jab[2]) };   // brightness/chroma vector
-      const float h = atan2f(Jab[2], Jab[1]);  // hue : (a, b) angle
+      const float h = atan2f(Jab[2], Jab[1]);  // hue : (a, b) angle
 
       // Project JC onto S, the saturation eigenvector, with orthogonal vector O.
-      // Note : O should be = (C * cosf(T) - J * sinf(T)) = 0 since S is the eigenvector,
+      // Note : O should be = (C * cosf(T) - J * sinf(T)) = 0 since S is the eigenvector,
       // so we add the chroma projected along the orthogonal axis to get some control value
       const float T = atan2f(JC[1], JC[0]); // angle of the eigenvector over the hue plane
       const float sin_T = sinf(T);
@@ -838,7 +838,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       dt_UCS_HCB_to_JCH(HCB, JCH);
 
       // Gamut mapping
-      const float max_colorfulness = lookup_gamut(gamut_LUT, JCH[2]); // WARNING : this is M²
+      const float max_colorfulness = lookup_gamut(gamut_LUT, JCH[2]); // WARNING : this is M²
       const float max_chroma = 15.932993652962535f * powf(JCH[0] * L_white, 0.6523997524738018f) * powf(max_colorfulness, 0.6007557017508491f) / L_white;
       const dt_aligned_pixel_t JCH_gamut_boundary = { JCH[0], max_chroma, JCH[2], 0.f };
       dt_aligned_pixel_t HSB_gamut_boundary;
@@ -1284,7 +1284,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
           int index = (int)(H_round + 180);
           index += (index < 0) ? 360 : 0;
           index -= (index > 359) ? 360 : 0;
-          // Warning: we store M², the square of the colorfulness
+          // Warning: we store M², the square of the colorfulness
           dt_UCS_LUT[index] = UV_star_prime[0] * UV_star_prime[0] + UV_star_prime[1] * UV_star_prime[1];
         }
       }

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -927,7 +927,7 @@ static inline gint wavelets_process(const float *const restrict in, float *const
       char name[64];
       sprintf(name, "scale-input-%i", s);
       dt_dump_pfm(name, buffer_in, width, height, DT_DUMP_PFM_RGB, "diffuse");
- 
+
       sprintf(name, "scale-blur-%i", s);
       dt_dump_pfm(name, buffer_out, width, height, DT_DUMP_PFM_RGB, "diffuse");
     }
@@ -950,7 +950,7 @@ static inline gint wavelets_process(const float *const restrict in, float *const
     const float strength = data->sharpness * norm + 1.f;
 
     /* debug
-    fprintf(stdout, "PDE solve : scale %i : mult = %i ; current rad = %.0f ; real rad = %.0f ; norm = %f ; strength = %f\n", s,
+    fprintf(stdout, "PDE solve : scale %i : mult = %i ; current rad = %.0f ; real rad = %.0f ; norm = %f ; strength = %f\n", s,
             1 << s, current_radius, real_radius, norm, strength);
     */
 

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -1036,7 +1036,7 @@ static void _spot_settings_changed_callback(GtkWidget *slider, dt_iop_module_t *
   const dt_spot_mode_t mode = dt_bauhaus_combobox_get(g->spot_mode);
   if(mode == DT_SPOT_MODE_CORRECT)
     _auto_set_exposure(self, darktable.develop->pipe);
-  // else : just record new values and do nothing
+  // else : just record new values and do nothing
 }
 
 void gui_reset(struct dt_iop_module_t *self)
@@ -1142,7 +1142,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->Lch_origin = gtk_label_new(_("L : \tN/A"));
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->Lch_origin),
-                              _("these LCh coordinates are computed from CIE Lab 1976 coordinates"));
+                              _("these LCh coordinates are computed from CIE Lab 1976 coordinates"));
   gtk_box_pack_start(GTK_BOX(vvbox), GTK_WIDGET(g->Lch_origin), FALSE, FALSE, 0);
 
   gtk_box_pack_start(GTK_BOX(hhbox), GTK_WIDGET(vvbox), FALSE, FALSE, DT_BAUHAUS_SPACE);

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1116,7 +1116,7 @@ inline static void wavelets_reconstruct_RGB(const float *const restrict HF, cons
     const float *const restrict TT_c = __builtin_assume_aligned(texture + k, 16);
 
     // synthesize the max of all RGB channels texture as a flat texture term for the whole pixel
-    // this is useful if only 1 or 2 channels are clipped, so we transfer the valid/sharpest texture on the other
+    // this is useful if only 1 or 2 channels are clipped, so we transfer the valid/sharpest texture on the other
     // channels
     const float grey_texture = fmaxabsf(fmaxabsf(TT_c[0], TT_c[1]), TT_c[2]);
 
@@ -1166,7 +1166,7 @@ inline static void wavelets_reconstruct_ratios(const float *const restrict HF, c
  * The ratios represent the chromaticity in image and contain low frequencies in the absence of noise or
  * aberrations, so, here, we favor them instead.
  *
- * Consequences : 
+ * Consequences :
  *  1. use min of interpolated channels details instead of max, to get smoother details
  *  4. use the max of low frequency channels instead of min, to favor achromatic solution.
  *
@@ -1189,7 +1189,7 @@ inline static void wavelets_reconstruct_ratios(const float *const restrict HF, c
     const float *const restrict TT_c = __builtin_assume_aligned(texture + k, 16);
 
     // synthesize the max of all RGB channels texture as a flat texture term for the whole pixel
-    // this is useful if only 1 or 2 channels are clipped, so we transfer the valid/sharpest texture on the other
+    // this is useful if only 1 or 2 channels are clipped, so we transfer the valid/sharpest texture on the other
     // channels
     const float grey_texture = fmaxabsf(fmaxabsf(TT_c[0], TT_c[1]), TT_c[2]);
 
@@ -1223,7 +1223,7 @@ static inline void init_reconstruct(const float *const restrict in, const float 
                                     float *const restrict reconstructed, const size_t width, const size_t height)
 {
 // init the reconstructed buffer with non-clipped and partially clipped pixels
-// Note : it's a simple multiplied alpha blending where mask = alpha weight
+// Note : it's a simple multiplied alpha blending where mask = alpha weight
 #ifdef _OPENMP
 #pragma omp parallel for default(none) dt_omp_firstprivate(in, mask, reconstructed, width, height) \
   schedule(static)
@@ -1322,7 +1322,7 @@ static inline gint reconstruct_highlights(const float *const restrict in, const 
     float *restrict LF;                 // output buffer for the current scale
     float *restrict HF_RGB_temp;        // temp buffer for HF_RBG terms before blurring
 
-    // swap buffers so we only need 2 LF buffers : the LF at scale (s-1) and the one at current scale (s)
+    // swap buffers so we only need 2 LF buffers : the LF at scale (s-1) and the one at current scale (s)
     if(s == 0)
     {
       detail = in;
@@ -1589,7 +1589,7 @@ static inline void filmic_chroma_v2_v3(const float *const restrict in, float *co
 
 static inline void filmic_desaturate_v4(const dt_aligned_pixel_t Ych_original, dt_aligned_pixel_t Ych_final, const float saturation)
 {
-  // Note : Ych is normalized trough the LMS conversion,
+  // Note : Ych is normalized trough the LMS conversion,
   // meaning c is actually a saturation (saturation ~= chroma / brightness).
   // So copy-pasting c and h from a different Y is equivalent to
   // tonemapping with a norm, which is equivalent to doing exposure compensation :
@@ -2101,7 +2101,7 @@ static inline cl_int reconstruct_highlights_cl(cl_mem in, cl_mem mask, cl_mem re
     cl_mem detail;
     cl_mem LF;
 
-    // swap buffers so we only need 2 LF buffers : the LF at scale (s-1) and the one at current scale (s)
+    // swap buffers so we only need 2 LF buffers : the LF at scale (s-1) and the one at current scale (s)
     if(s == 0)
     {
       detail = in;
@@ -3221,7 +3221,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
 
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
 
-  // write the graph legend at GUI default size
+  // write the graph legend at GUI default size
   pango_font_description_set_size(desc, font_size);
   pango_layout_set_font_description(layout, desc);
   if(g->gui_mode == DT_FILMIC_GUI_LOOK)
@@ -3648,7 +3648,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
     // draw the dynamic range of display
     // if white = 100%, assume -11.69 EV because of uint8 output + sRGB OETF.
     // for uint10 output, white should be set to 400%, so anything above 100% increases DR
-    // FIXME : if darktable becomes HDR-10bits compatible (for output), this needs to be updated
+    // FIXME : if darktable becomes HDR-10bits compatible (for output), this needs to be updated
     const float display_DR = 12.f + log2f(p->white_point_target / 100.f);
 
     const float y_display = g->allocation.height / 3.f + g->line_height;
@@ -3727,7 +3727,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
     const float max_DR = ceilf(fmaxf(display_HL_EV, scene_HL_EV)) + ceilf(fmaxf(display_LL_EV, scene_LL_EV));
     const float EV = (column_right) / max_DR;
 
-    // all greys are aligned vertically in GUI since they are the fulcrum of the transform
+    // all greys are aligned vertically in GUI since they are the fulcrum of the transform
     // so, get their coordinates
     const float grey_EV = fmaxf(ceilf(display_HL_EV), ceilf(scene_HL_EV));
     const float grey_x = g->allocation.width - (grey_EV)*EV - darktable.bauhaus->quad_width;

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -1218,9 +1218,9 @@ typedef enum diffuse_reconstruct_variant_t
 
 enum wavelets_scale_t
 {
-  ANY_SCALE   = 1 << 0, // any wavelets scale   : reconstruct += HF
-  FIRST_SCALE = 1 << 1, // first wavelets scale : reconstruct = 0
-  LAST_SCALE  = 1 << 2, // last wavelets scale  : reconstruct += residual
+  ANY_SCALE   = 1 << 0, // any wavelets scale   : reconstruct += HF
+  FIRST_SCALE = 1 << 1, // first wavelets scale : reconstruct = 0
+  LAST_SCALE  = 1 << 2, // last wavelets scale  : reconstruct += residual
 };
 
 
@@ -1369,7 +1369,7 @@ static inline void guide_laplacians(const float *const restrict high_freq, const
           out[index + c] = fmaxf(out[index + c] + LF[index + c], 0.f);
       }
 
-      // Last step of RGB reconstruct : add noise
+      // Last step of RGB reconstruct : add noise
       if((scale & LAST_SCALE) && salt && alpha > 0.f)
       {
         // Init random number generator
@@ -1522,7 +1522,7 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq, con
             out[index + c] /= (c != ALPHA && norm > 1e-4f) ? norm : 1.f;
         }
 
-        // Last scale : reconstruct RGB from ratios and norm - norm stays in the 4th channel
+        // Last scale : reconstruct RGB from ratios and norm - norm stays in the 4th channel
         // we need it to evaluate the gradient
         for_four_channels(c, aligned(out))
           out[index + c] = (c == ALPHA) ? out[index + ALPHA] : out[index + c] * out[index + ALPHA];
@@ -1864,7 +1864,7 @@ static cl_int process_laplacian_bayer_cl(struct dt_iop_module_t *self, dt_dev_pi
 
   // Upsample
   dt_opencl_set_kernel_args(devid, gd->kernel_interpolate_bilinear, 0,
-    CLARG(ds_interpolated), CLARG(ds_width), CLARG(ds_height), CLARG(interpolated), CLARG(width), CLARG(height)); 
+    CLARG(ds_interpolated), CLARG(ds_width), CLARG(ds_height), CLARG(interpolated), CLARG(width), CLARG(height));
   err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_interpolate_bilinear, sizes);
   if(err != CL_SUCCESS) goto error;
 
@@ -2033,7 +2033,7 @@ void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const d
 
   /* We require the correct (full-image-data) expansion with a defined scale for all pixelpipes for proper
      aligning and scaling in the demosiacer
-  */ 
+  */
   roi_in->x = 0;
   roi_in->y = 0;
   roi_in->width = piece->buf_in.width;
@@ -2238,7 +2238,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     piece->process_tiling_ready = 0;
 
   const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
- 
+
   // check for heavy computing here to possibly give an iop cache hint
   gboolean heavy = (((d->mode == DT_IOP_HIGHLIGHTS_LAPLACIAN) && ((d->iterations * 1<<(2+d->scales)) >= 256))
                   || (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS));
@@ -2250,7 +2250,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     if((g->hlr_mask_mode == DT_HIGHLIGHTS_MASK_CLIPPED) && linear && fullpipe)
       piece->process_cl_ready = FALSE;
     // only give a heavy hint if we are not in masking mode
-    if(g->hlr_mask_mode != DT_HIGHLIGHTS_MASK_OFF) 
+    if(g->hlr_mask_mode != DT_HIGHLIGHTS_MASK_OFF)
       heavy = FALSE;
   }
   self->cache_next_important = heavy;
@@ -2391,7 +2391,7 @@ void gui_update(struct dt_iop_module_t *self)
   dt_bauhaus_widget_set_quad_active(g->combine, FALSE);
   dt_bauhaus_widget_set_quad_active(g->strength, FALSE);
   g->hlr_mask_mode = DT_HIGHLIGHTS_MASK_OFF;
- 
+
   const int menu_size = dt_bauhaus_combobox_length(g->mode);
   const uint32_t filters = self->dev->image_storage.buf_dsc.filters;
   const gboolean bayer = (filters != 0) && (filters != 9u);

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -295,7 +295,7 @@ void process(struct dt_iop_module_t *const self, dt_dev_pixelpipe_iop_t *const p
 
       // Print density on paper : ((1 - 10^corrected_de + black) * exposure)^gamma rewritten for FMA
       const float print_linear = -(d->exposure * fast_exp10f(corrected_de) + d->black);
-      const float print_gamma = powf(fmaxf(print_linear, 0.0f), d->gamma); // note : this is always > 0
+      const float print_gamma = powf(fmaxf(print_linear, 0.0f), d->gamma); // note : this is always > 0
 
       // Compress highlights. from https://lists.gnu.org/archive/html/openexr-devel/2005-03/msg00009.html
       pix_out[c] =  (print_gamma > d->soft_clip) ? d->soft_clip + (1.0f - fast_expf(-(print_gamma - d->soft_clip) / d->soft_clip_comp)) * d->soft_clip_comp
@@ -408,7 +408,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 }
 
 
-/* Global GUI stuff */
+/* Global GUI stuff */
 
 static void setup_color_variables(dt_iop_negadoctor_gui_data_t *const g, const gint state)
 {
@@ -664,7 +664,7 @@ static void apply_auto_WB_low(dt_iop_module_t *self)
   for(int c = 0; c < 3; c++)
     RGB_min[c] = log10f(p->Dmin[c] / fmaxf(self->picked_color[c], THRESHOLD)) / p->D_max;
 
-  const float RGB_v_min = v_minf(RGB_min); // warning: can be negative
+  const float RGB_v_min = v_minf(RGB_min); // warning: can be negative
   for(int c = 0; c < 3; c++) p->wb_low[c] =  RGB_v_min / RGB_min[c];
 
   ++darktable.gui->reset;
@@ -1024,7 +1024,7 @@ void gui_update(dt_iop_module_t *const self)
   dt_iop_color_picker_reset(self, TRUE);
 
 
-  dt_bauhaus_slider_set(g->exposure, log2f(p->exposure));     // warning: GUI is in EV
+  dt_bauhaus_slider_set(g->exposure, log2f(p->exposure));     // warning: GUI is in EV
   dt_bauhaus_slider_set_default(g->exposure, log2f(p->exposure)); // otherwise always showes as "changed"
 
   // Update custom stuff

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -120,8 +120,8 @@ DT_MODULE_INTROSPECTION(2, dt_iop_toneequalizer_params_t)
 #define MIN_FLOAT exp2f(-16.0f)
 
 /**
- * Build the exposures octaves : 
- * band-pass filters with gaussian windows spaced by 1 EV
+ * Build the exposures octaves :
+ * band-pass filters with gaussian windows spaced by 1 EV
 **/
 
 #define CHANNELS 9
@@ -136,7 +136,7 @@ static const float centers_ops[PIXEL_CHAN] DT_ALIGNED_ARRAY = {-56.0f / 7.0f, //
                                                                -24.0f / 7.0f,
                                                                -16.0f / 7.0f,
                                                                 -8.0f / 7.0f,
-                                                                 0.0f / 7.0f}; // split 8 EV into 7 evenly-spaced channels
+                                                                 0.0f / 7.0f}; // split 8 EV into 7 evenly-spaced channels
 
 static const float centers_params[CHANNELS] DT_ALIGNED_ARRAY = { -8.0f, -7.0f, -6.0f, -5.0f,
                                                                  -4.0f, -3.0f, -2.0f, -1.0f, 0.0f};
@@ -282,7 +282,7 @@ typedef struct dt_iop_toneequalizer_gui_data_t
   int luminance_valid;      // TRUE if the luminance cache is ready
   int histogram_valid;      // TRUE if the histogram cache and stats are ready
   int lut_valid;            // TRUE if the gui_lut is ready
-  int graph_valid;          // TRUE if the UI graph view is ready
+  int graph_valid;          // TRUE if the UI graph view is ready
   int user_param_valid;     // TRUE if users params set in interactive view are in bounds
   int factors_valid;        // TRUE if radial-basis coeffs are ready
 
@@ -457,11 +457,11 @@ void init_presets(dt_iop_module_so_t *self)
   p.details = DT_TONEEQ_EIGF;
   p.feathering = 20.0f;
   compress_shadows_highlight_preset_set_exposure_params(&p, 0.65f);
-  dt_gui_presets_add_generic(_("compress shadows/highlights (eigf): strong"), self->op,
+  dt_gui_presets_add_generic(_("compress shadows/highlights (eigf): strong"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
   p.details = DT_TONEEQ_GUIDED;
   p.feathering = 500.0f;
-  dt_gui_presets_add_generic(_("compress shadows/highlights (gf): strong"), self->op,
+  dt_gui_presets_add_generic(_("compress shadows/highlights (gf): strong"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 
   p.details = DT_TONEEQ_EIGF;
@@ -481,7 +481,7 @@ void init_presets(dt_iop_module_so_t *self)
   p.feathering = 1.0f;
   p.iterations = 1;
   compress_shadows_highlight_preset_set_exposure_params(&p, 0.25f);
-  dt_gui_presets_add_generic(_("compress shadows/highlights (eigf): soft"), self->op,
+  dt_gui_presets_add_generic(_("compress shadows/highlights (eigf): soft"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
   p.details = DT_TONEEQ_GUIDED;
   p.feathering = 500.0f;
@@ -1009,7 +1009,7 @@ void toneeq_process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
   }
   else
   {
-    // no interactive editing/caching : just allocate a local temp buffer
+    // no interactive editing/caching : just allocate a local temp buffer
     luminance = dt_alloc_sse_ps(num_elem);
   }
 
@@ -1023,7 +1023,7 @@ void toneeq_process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
   // Compute the luminance mask
   if(cached)
   {
-    // caching path : store the luminance mask for GUI access
+    // caching path : store the luminance mask for GUI access
 
     if(piece->pipe->type & DT_DEV_PIXELPIPE_FULL)
     {
@@ -1286,7 +1286,7 @@ static void gui_cache_init(struct dt_iop_module_t *self)
   g->luminance_valid = FALSE;      // TRUE if the luminance cache is ready
   g->histogram_valid = FALSE;      // TRUE if the histogram cache and stats are ready
   g->lut_valid = FALSE;            // TRUE if the gui_lut is ready
-  g->graph_valid = FALSE;          // TRUE if the UI graph view is ready
+  g->graph_valid = FALSE;          // TRUE if the UI graph view is ready
   g->user_param_valid = FALSE;     // TRUE if users params set in interactive view are in bounds
   g->factors_valid = TRUE;         // TRUE if radial-basis coeffs are ready
 
@@ -1540,7 +1540,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   // but the actual regularization params applied in guided filter behaves the other way
   d->feathering = 1.f / (p->feathering);
 
-  // UI params are in log2 offsets (EV) : convert to linear factors
+  // UI params are in log2 offsets (EV) : convert to linear factors
   d->contrast_boost = exp2f(p->contrast_boost);
   d->exposure_boost = exp2f(p->exposure_boost);
 
@@ -1965,8 +1965,8 @@ static void switch_cursors(struct dt_iop_module_t *self)
 
 int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressure, int which)
 {
-  // Whenever the mouse moves over the picture preview, store its coordinates in the GUI struct
-  // for later use. This works only if dev->preview_pipe perfectly overlaps with the UI preview
+  // Whenever the mouse moves over the picture preview, store its coordinates in the GUI struct
+  // for later use. This works only if dev->preview_pipe perfectly overlaps with the UI preview
   // meaning all distortions, cropping, rotations etc. are applied before this module in the pipe.
 
   dt_develop_t *dev = self->dev;
@@ -2085,7 +2085,7 @@ static inline int set_new_params_interactive(const float control_exposure, const
   }
   else
   {
-    // Reset the GUI copy of user params
+    // Reset the GUI copy of user params
     get_channels_factors(factors, p);
     dt_simd_memcpy(factors, g->temp_user_params, CHANNELS);
     g->user_param_valid = 1;
@@ -2112,7 +2112,7 @@ int scrolled(struct dt_iop_module_t *self, double x, double y, int up, uint32_t 
 
   if(in_mask_editing(self)) return 0;
 
-  // if GUI buffers not ready, exit but still handle the cursor
+  // if GUI buffers not ready, exit but still handle the cursor
   dt_iop_gui_enter_critical_section(self);
   const int fail = (!g->cursor_valid || !g->luminance_valid || !g->interpolation_valid || !g->user_param_valid || dev->pipe->processing || !g->has_focus);
   dt_iop_gui_leave_critical_section(self);
@@ -2190,7 +2190,7 @@ void cairo_draw_hatches(cairo_t *cr, double center[2], double span[2], int insta
 
 static void get_shade_from_luminance(cairo_t *cr, const float luminance, const float alpha)
 {
-  // TODO: fetch screen gamma from ICC display profile
+  // TODO: fetch screen gamma from ICC display profile
   const float gamma = 1.0f / 2.2f;
   const float shade = powf(luminance, gamma);
   cairo_set_source_rgba(cr, shade, shade, shade, alpha);

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -52,6 +52,29 @@ DT_MODULE(1)
 
 #define PARAM_STRING_SIZE 256 // FIXME: is this enough !?
 
+
+static const dt_introspection_type_enum_tuple_t _collection_sort_names[]
+  = { { N_("filename"), DT_COLLECTION_SORT_FILENAME },
+      { N_("full path"), DT_COLLECTION_SORT_PATH },
+      { N_("aspect ratio"), DT_COLLECTION_SORT_ASPECT_RATIO },
+
+      { N_("capture time"), DT_COLLECTION_SORT_DATETIME },
+      { N_("import time"), DT_COLLECTION_SORT_IMPORT_TIMESTAMP },
+      { N_("modification time"), DT_COLLECTION_SORT_CHANGE_TIMESTAMP },
+      { N_("export time"), DT_COLLECTION_SORT_EXPORT_TIMESTAMP },
+      { N_("print time"), DT_COLLECTION_SORT_PRINT_TIMESTAMP },
+
+      { N_("rating"), DT_COLLECTION_SORT_RATING },
+      { N_("color label"), DT_COLLECTION_SORT_COLOR },
+      { N_("title"), DT_COLLECTION_SORT_TITLE },
+      { N_("description"), DT_COLLECTION_SORT_DESCRIPTION },
+
+      { N_("group"), DT_COLLECTION_SORT_GROUP },
+      { N_("id"), DT_COLLECTION_SORT_ID },
+      { N_("custom sort"), DT_COLLECTION_SORT_CUSTOM_ORDER },
+      { N_("shuffle"), DT_COLLECTION_SORT_SHUFFLE },
+      { } };
+
 typedef enum _preset_save_type_t
 {
   _PRESET_NONE = 0,
@@ -1838,8 +1861,6 @@ static gboolean _sort_close(GtkWidget *widget, GdkEventButton *event, dt_lib_mod
   return TRUE;
 }
 
-static char **_sort_names = NULL;
-
 static gboolean _sort_init(_widgets_sort_t *sort, const dt_collection_sort_t sortid, const int sortorder,
                            const int num, dt_lib_module_t *self)
 {
@@ -1861,55 +1882,20 @@ static gboolean _sort_init(_widgets_sort_t *sort, const dt_collection_sort_t sor
       sort->sort = dt_bauhaus_combobox_new_action(DT_ACTION(self));
     else
       sort->sort = dt_bauhaus_combobox_new(NULL);
-    dt_bauhaus_widget_set_label(sort->sort, NULL, _("sort order"));
+    dt_action_t *ac = dt_bauhaus_widget_set_label(sort->sort, NULL, _("sort order"));
     DT_BAUHAUS_WIDGET(sort->sort)->show_label = FALSE;
     gtk_widget_set_tooltip_text(sort->sort, _("determine the sort order of shown images"));
     g_signal_connect(G_OBJECT(sort->sort), "value-changed", G_CALLBACK(_sort_combobox_changed), sort);
-
-#define ADD_SORT_ENTRY(value)                                                                                     \
-  dt_bauhaus_combobox_add_full(sort->sort, dt_collection_sort_name(value), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,       \
-                               GUINT_TO_POINTER(value), NULL, TRUE)
-
-    // as the setting rely on ids, the orders of items can be changed if needed
-    ADD_SORT_ENTRY(DT_COLLECTION_SORT_FILENAME);
-    ADD_SORT_ENTRY(DT_COLLECTION_SORT_DATETIME);
-    ADD_SORT_ENTRY(DT_COLLECTION_SORT_IMPORT_TIMESTAMP);
-    ADD_SORT_ENTRY(DT_COLLECTION_SORT_CHANGE_TIMESTAMP);
-    ADD_SORT_ENTRY(DT_COLLECTION_SORT_EXPORT_TIMESTAMP);
-    ADD_SORT_ENTRY(DT_COLLECTION_SORT_PRINT_TIMESTAMP);
-    ADD_SORT_ENTRY(DT_COLLECTION_SORT_RATING);
-    ADD_SORT_ENTRY(DT_COLLECTION_SORT_ID);
-    ADD_SORT_ENTRY(DT_COLLECTION_SORT_COLOR);
-    ADD_SORT_ENTRY(DT_COLLECTION_SORT_GROUP);
-    ADD_SORT_ENTRY(DT_COLLECTION_SORT_PATH);
-    ADD_SORT_ENTRY(DT_COLLECTION_SORT_CUSTOM_ORDER);
-    ADD_SORT_ENTRY(DT_COLLECTION_SORT_TITLE);
-    ADD_SORT_ENTRY(DT_COLLECTION_SORT_DESCRIPTION);
-    ADD_SORT_ENTRY(DT_COLLECTION_SORT_ASPECT_RATIO);
-    ADD_SORT_ENTRY(DT_COLLECTION_SORT_SHUFFLE);
-
-#undef ADD_SORT_ENTRY
-
-    if(num == 0)
-    {
-      if(!_sort_names)
-      {
-        // we insert untranslated sort name in the array + NULL at the end
-        _sort_names = g_malloc0_n(dt_bauhaus_combobox_length(sort->sort) + 1, sizeof(char *));
-        for(int i = 0; i < dt_bauhaus_combobox_length(sort->sort); i++)
-        {
-          // we recover the sort enum value from the bauhaus combobox.
-          // this is needed because combobox can have a items order different than the enum one
-          const dt_bauhaus_combobox_data_t *cbd = &DT_BAUHAUS_WIDGET(sort->sort)->data.combobox;
-          if(!cbd) continue;
-          const dt_bauhaus_combobox_entry_t *entry = g_ptr_array_index(cbd->entries, i);
-          _sort_names[i] = g_strdup(dt_collection_sort_name_untranslated(GPOINTER_TO_INT(entry->data)));
-        }
-      }
-      g_hash_table_insert(darktable.control->combo_list, (dt_action_t *)(DT_BAUHAUS_WIDGET(sort->sort)->module),
-                          _sort_names);
-    }
     gtk_box_pack_start(GTK_BOX(sort->box), sort->sort, TRUE, TRUE, 0);
+
+    dt_bauhaus_combobox_add_section(sort->sort, _("files"));
+    dt_bauhaus_combobox_add_introspection(sort->sort, ac, _collection_sort_names, DT_COLLECTION_SORT_FILENAME, DT_COLLECTION_SORT_ASPECT_RATIO);
+    dt_bauhaus_combobox_add_section(sort->sort, _("times"));
+    dt_bauhaus_combobox_add_introspection(sort->sort, ac, _collection_sort_names, DT_COLLECTION_SORT_DATETIME, DT_COLLECTION_SORT_PRINT_TIMESTAMP);
+    dt_bauhaus_combobox_add_section(sort->sort, _("metadata"));
+    dt_bauhaus_combobox_add_introspection(sort->sort, ac, _collection_sort_names, DT_COLLECTION_SORT_RATING, DT_COLLECTION_SORT_DESCRIPTION);
+    dt_bauhaus_combobox_add_section(sort->sort, _("darktable"));
+    dt_bauhaus_combobox_add_introspection(sort->sort, ac, _collection_sort_names, DT_COLLECTION_SORT_GROUP, DT_COLLECTION_SORT_SHUFFLE);
 
     /* reverse order checkbutton */
     sort->direction = dtgtk_togglebutton_new(dtgtk_cairo_paint_sortby, CPF_DIRECTION_UP, NULL);
@@ -1918,10 +1904,7 @@ static gboolean _sort_init(_widgets_sort_t *sort, const dt_collection_sort_t sor
     g_signal_connect(G_OBJECT(sort->direction), "toggled", G_CALLBACK(_sort_reverse_changed), sort);
     dt_gui_add_class(sort->direction, "dt_ignore_fg_state");
     if(num == 0)
-    {
-      dt_action_t *toggle = dt_action_section(DT_ACTION(self), N_("toggle"));
-      dt_action_define(toggle, NULL, _("sort direction"), sort->direction, &dt_action_def_toggle);
-    }
+      dt_action_define(DT_ACTION(self), NULL, _("sort direction"), sort->direction, &dt_action_def_toggle);
 
     sort->close = dtgtk_button_new(dtgtk_cairo_paint_remove, 0, NULL);
     gtk_widget_set_no_show_all(sort->close, TRUE);
@@ -2033,26 +2016,8 @@ static void _sort_show_add_popup(GtkWidget *widget, gpointer user_data)
   GtkMenuShell *spop = GTK_MENU_SHELL(gtk_menu_new());
   gtk_widget_set_size_request(GTK_WIDGET(spop), 200, -1);
 
-#define ADD_SORT_ENTRY(value)                                                                                     \
-  _popup_add_item(spop, dt_collection_sort_name(value), value, FALSE, G_CALLBACK(_sort_append_sort), NULL, self,  \
-                  0.0);
-
-  ADD_SORT_ENTRY(DT_COLLECTION_SORT_FILENAME);
-  ADD_SORT_ENTRY(DT_COLLECTION_SORT_DATETIME);
-  ADD_SORT_ENTRY(DT_COLLECTION_SORT_IMPORT_TIMESTAMP);
-  ADD_SORT_ENTRY(DT_COLLECTION_SORT_CHANGE_TIMESTAMP);
-  ADD_SORT_ENTRY(DT_COLLECTION_SORT_EXPORT_TIMESTAMP);
-  ADD_SORT_ENTRY(DT_COLLECTION_SORT_PRINT_TIMESTAMP);
-  ADD_SORT_ENTRY(DT_COLLECTION_SORT_RATING);
-  ADD_SORT_ENTRY(DT_COLLECTION_SORT_ID);
-  ADD_SORT_ENTRY(DT_COLLECTION_SORT_COLOR);
-  ADD_SORT_ENTRY(DT_COLLECTION_SORT_GROUP);
-  ADD_SORT_ENTRY(DT_COLLECTION_SORT_PATH);
-  ADD_SORT_ENTRY(DT_COLLECTION_SORT_CUSTOM_ORDER);
-  ADD_SORT_ENTRY(DT_COLLECTION_SORT_TITLE);
-  ADD_SORT_ENTRY(DT_COLLECTION_SORT_DESCRIPTION);
-  ADD_SORT_ENTRY(DT_COLLECTION_SORT_ASPECT_RATIO);
-  ADD_SORT_ENTRY(DT_COLLECTION_SORT_SHUFFLE);
+  for(const dt_introspection_type_enum_tuple_t *list = _collection_sort_names; list->name; list++)
+    _popup_add_item(spop, Q_(list->name), list->value, FALSE, G_CALLBACK(_sort_append_sort), NULL, self, 0.0);
 
   dt_gui_menu_popup(GTK_MENU(spop), widget, GDK_GRAVITY_SOUTH, GDK_GRAVITY_NORTH);
 #undef ADD_SORT_ENTRY
@@ -2078,7 +2043,10 @@ static void _sort_history_pretty_print(const char *buf, char *out, size_t outsiz
 
     if(n == 2)
     {
-      c = snprintf(out, outsize, "%s%s (%s)", (k > 0) ? " - " : "", dt_collection_sort_name(sortid),
+      const dt_introspection_type_enum_tuple_t *list = _collection_sort_names;
+      while(list->name && list->value != sortid) list++;
+
+      c = snprintf(out, outsize, "%s%s (%s)", (k > 0) ? " - " : "", list->name,
                    (sortorder) ? _("DESC") : _("ASC"));
       out += c;
       outsize -= c;

--- a/src/libs/filters/grouping.c
+++ b/src/libs/filters/grouping.c
@@ -164,7 +164,7 @@ static void _grouping_widget_init(dt_lib_filtering_rule_t *rule, const dt_collec
   _widgets_grouping_t *grouping = (_widgets_grouping_t *)g_malloc0(sizeof(_widgets_grouping_t));
   grouping->rule = rule;
 
-  DT_BAUHAUS_COMBOBOX_NEW_FULL(grouping->combo, self, NULL, N_("grouping filter"),
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(grouping->combo, self, N_("rules"), N_("grouping"),
                                _("select the type of grouped image to filter"), 0, _grouping_changed,
                                grouping, N_("all images"), N_("ungrouped images"), N_("grouped images"),
                                N_("group leaders"), N_("group followers"));

--- a/src/libs/filters/history.c
+++ b/src/libs/filters/history.c
@@ -150,7 +150,7 @@ static void _history_widget_init(dt_lib_filtering_rule_t *rule, const dt_collect
   history->rule = rule;
 
   history->combo
-      = dt_bauhaus_combobox_new_full(DT_ACTION(self), NULL, N_("history filter"), _("filter on history state"), 0,
+      = dt_bauhaus_combobox_new_full(DT_ACTION(self), N_("rules"), N_("history"), _("filter on history state"), 0,
                                      (GtkCallback)_history_changed, history, _history_names);
   DT_BAUHAUS_WIDGET(history->combo)->show_label = FALSE;
 

--- a/src/libs/filters/local_copy.c
+++ b/src/libs/filters/local_copy.c
@@ -139,7 +139,7 @@ static void _local_copy_widget_init(dt_lib_filtering_rule_t *rule, const dt_coll
   local_copy->rule = rule;
 
   local_copy->combo = dt_bauhaus_combobox_new_full(
-      DT_ACTION(self), NULL, N_("local_copy filter"), _("local copied state filter"), 0,
+      DT_ACTION(self), N_("rules"), N_("local copy"), _("local copied state filter"), 0,
       (GtkCallback)_local_copy_changed, local_copy, _local_copy_names);
   DT_BAUHAUS_WIDGET(local_copy->combo)->show_label = FALSE;
 

--- a/src/libs/filters/module_order.c
+++ b/src/libs/filters/module_order.c
@@ -158,7 +158,7 @@ static void _module_order_widget_init(dt_lib_filtering_rule_t *rule, const dt_co
     _module_order_names[DT_IOP_ORDER_LAST + 1] = g_strdup(N_("none"));
   }
   module_order->combo = dt_bauhaus_combobox_new_full(
-      DT_ACTION(self), NULL, N_("module order filter"), _("filter images based on their module order"), 0,
+      DT_ACTION(self), N_("rules"), N_("module order"), _("filter images based on their module order"), 0,
       (GtkCallback)_module_order_changed, module_order, (const char **)_module_order_names);
   DT_BAUHAUS_WIDGET(module_order->combo)->show_label = FALSE;
 

--- a/src/libs/filters/rating.c
+++ b/src/libs/filters/rating.c
@@ -196,7 +196,7 @@ static void _rating_widget_init(dt_lib_filtering_rule_t *rule, const dt_collecti
 
   rating_legacy->overlay = gtk_overlay_new();
 
-  DT_BAUHAUS_COMBOBOX_NEW_FULL(rating_legacy->comparator, self, NULL, N_("comparator"),
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(rating_legacy->comparator, self, N_("rules"), N_("comparator"),
                                _("filter by images rating"), 3, _rating_legacy_changed, rating_legacy, "<", "≤",
                                "=", "≥", ">", "≠");
   DT_BAUHAUS_WIDGET(rating_legacy->comparator)->show_label = FALSE;
@@ -207,7 +207,7 @@ static void _rating_widget_init(dt_lib_filtering_rule_t *rule, const dt_collecti
   gtk_overlay_set_overlay_pass_through(GTK_OVERLAY(rating_legacy->overlay), rating_legacy->comparator, TRUE);
 
   /* create the filter combobox */
-  DT_BAUHAUS_COMBOBOX_NEW_FULL(rating_legacy->stars, self, NULL, N_("ratings"), _("filter by images rating"), 0,
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(rating_legacy->stars, self, N_("rules"), N_("ratings"), _("filter by images rating"), 0,
                                _rating_legacy_changed, rating_legacy, N_("all"), N_("unstarred only"), "★", "★ ★",
                                "★ ★ ★", "★ ★ ★ ★", "★ ★ ★ ★ ★", N_("rejected only"), N_("all except rejected"));
   DT_BAUHAUS_WIDGET(rating_legacy->stars)->show_label = FALSE;

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -851,7 +851,7 @@ static gboolean _changes_tooltip_callback(GtkWidget *widget, gint x, gint y, gbo
       if((hitem->blend_params->field) != (old_blend->field))                                     \
       {                                                                                          \
         const char *old_str = NULL, *new_str = NULL;                                             \
-        for(const dt_develop_name_value_t *i = list; *i->name; i++)                              \
+        for(const dt_introspection_type_enum_tuple_t *i = list; i->name; i++)                    \
         {                                                                                        \
           if(i->value == (old_blend->field)) old_str = i->name;                                  \
           if(i->value == (hitem->blend_params->field)) new_str = i->name;                        \

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2220,7 +2220,7 @@ static int _lib_modulegroups_basics_module_toggle(dt_lib_module_t *self, GtkWidg
 {
   if(GTK_IS_BUTTON(widget)) return 0;
 
-  dt_action_t *action = g_hash_table_lookup(darktable.control->widgets, widget);
+  dt_action_t *action = dt_action_widget(widget);
 
   dt_action_t *owner = action;
   while(owner && owner->type >= DT_ACTION_TYPE_SECTION) owner = owner->owner;

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -788,7 +788,7 @@ static void _set_mapping_mode_cursor(GtkWidget *widget)
 
   if(widget && !strcmp(gtk_widget_get_name(widget), "module-header"))
     cursor = GDK_BASED_ARROW_DOWN;
-  else if(g_hash_table_lookup(darktable.control->widgets, darktable.control->mapping_widget)
+  else if(dt_action_widget(darktable.control->mapping_widget)
           && darktable.develop)
   {
     switch(dt_dev_modulegroups_basics_module_toggle(darktable.develop, widget, FALSE))

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -830,7 +830,9 @@ static void _show_shortcuts_prefs(GtkWidget *w)
 
 static void _main_do_event_keymap(GdkEvent *event, gpointer data)
 {
+  dt_lib_tool_preferences_t *d = data;
   GtkWidget *event_widget = gtk_get_event_widget(event);
+  static guint click_time = 0;
 
   switch(event->type)
   {
@@ -855,7 +857,6 @@ static void _main_do_event_keymap(GdkEvent *event, gpointer data)
     if(!gtk_window_is_active(GTK_WINDOW(main_window)))
       break;
 
-    dt_lib_tool_preferences_t *d = (dt_lib_tool_preferences_t *)data;
     if(event_widget == d->keymap_button)
       break;
 
@@ -863,7 +864,7 @@ static void _main_do_event_keymap(GdkEvent *event, gpointer data)
       break;
 
     if(event->button.button == GDK_BUTTON_SECONDARY)
-      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->keymap_button), FALSE);
+      click_time = event->button.time;
     else if(event->button.button == GDK_BUTTON_MIDDLE)
       dt_shortcut_dispatcher(event_widget, event, data);
     else if(event->button.button > 7)
@@ -886,6 +887,16 @@ static void _main_do_event_keymap(GdkEvent *event, gpointer data)
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->keymap_button), FALSE);
       _show_shortcuts_prefs(event_widget);
     }
+
+    return;
+  case GDK_BUTTON_RELEASE:
+    if(event->button.button != GDK_BUTTON_SECONDARY)
+      break;
+
+    if(dt_gui_long_click(event->button.time, click_time))
+      dt_shortcut_copy_lua(NULL, NULL);
+    else
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->keymap_button), FALSE);
 
     return;
   default:

--- a/src/lua/events.c
+++ b/src/lua/events.c
@@ -547,6 +547,8 @@ int dt_lua_init_early_events(lua_State *L)
 {
   lua_newtable(L);
   lua_setfield(L, LUA_REGISTRYINDEX, "dt_lua_event_list");
+  lua_newtable(L);
+  lua_setfield(L, LUA_REGISTRYINDEX, "dt_lua_mimic_list");
   dt_lua_push_darktable_lib(L);
   lua_pushstring(L, "register_event");
   lua_pushcfunction(L, &lua_register_event);

--- a/src/lua/gui.c
+++ b/src/lua/gui.c
@@ -160,7 +160,8 @@ static int _mimic_cb(lua_State *L)
     if(!strcmp(def->name, ac_type)) break;
   }
 
-  dt_action_define(&darktable.control->actions_lua, NULL, ac_name, NULL, def);
+  lua_getglobal(L, "script_manager_running_script");
+  dt_action_define(&darktable.control->actions_lua, lua_tolstring(L,-1,NULL), ac_name, NULL, def);
 
 mimic_end:
   lua_pop(L, 1);

--- a/src/lua/lua.c
+++ b/src/lua/lua.c
@@ -132,13 +132,13 @@ void dt_lua_init_lock()
 
 void dt_lua_lock_internal(const char *function, const char *file, int line, gboolean silent)
 {
+#ifdef _DEBUG
   if(!silent && !darktable.lua_state.ending && pthread_equal(darktable.control->gui_thread, pthread_self()) != 0)
   {
     dt_print(DT_DEBUG_LUA, "LUA WARNING locking from the gui thread should be avoided\n");
     //g_assert(false);
   }
 
-#ifdef _DEBUG
   dt_print(DT_DEBUG_LUA,"LUA DEBUG : thread %p waiting from %s:%d\n", g_thread_self(), function, line);
 #endif
   dt_pthread_mutex_lock(&darktable.lua_state.mutex);

--- a/src/lua/widget/combobox.c
+++ b/src/lua/widget/combobox.c
@@ -83,7 +83,9 @@ static int label_member(lua_State *L)
   if(lua_gettop(L) > 2) {
     char tmp[256];
     luaA_to(L,char_256,&tmp,3);
-    dt_bauhaus_widget_set_label(combobox->widget,NULL,tmp);
+    lua_getglobal(L, "script_manager_running_script");
+    DT_BAUHAUS_WIDGET(combobox->widget)->module = &darktable.control->actions_lua;
+    dt_bauhaus_widget_set_label(combobox->widget,lua_tolstring(L,-1,NULL),tmp);
     return 0;
   }
   lua_pushstring(L,dt_bauhaus_widget_get_label(combobox->widget));

--- a/src/lua/widget/slider.c
+++ b/src/lua/widget/slider.c
@@ -48,7 +48,9 @@ static int label_member(lua_State *L)
   if(lua_gettop(L) > 2) {
     char tmp[256];
     luaA_to(L,char_256,&tmp,3);
-    dt_bauhaus_widget_set_label(slider->widget,NULL,tmp);
+    lua_getglobal(L, "script_manager_running_script");
+    DT_BAUHAUS_WIDGET(slider->widget)->module = &darktable.control->actions_lua;
+    dt_bauhaus_widget_set_label(slider->widget,lua_tolstring(L,-1,NULL),tmp);
     return 0;
   }
   lua_pushstring(L,dt_bauhaus_widget_get_label(slider->widget));

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1301,7 +1301,7 @@ static void _darkroom_ui_favorite_presets_popupmenu(GtkWidget *w, gpointer user_
   /* create favorites menu and popup */
   dt_gui_favorite_presets_menu_show();
 
-  /* if we got any styles, lets popup menu for selection */
+  /* if we got any favorite presets, lets popup menu for selection */
   if(darktable.gui->presets_popup_menu)
   {
     dt_gui_menu_popup(darktable.gui->presets_popup_menu, w, GDK_GRAVITY_SOUTH_WEST, GDK_GRAVITY_NORTH_WEST);
@@ -1310,9 +1310,21 @@ static void _darkroom_ui_favorite_presets_popupmenu(GtkWidget *w, gpointer user_
     dt_control_log(_("no userdefined presets for favorite modules were found"));
 }
 
-static void _darkroom_ui_apply_style_activate_callback(const gchar *name)
+static void _darkroom_ui_apply_style_activate_callback(GtkMenuItem *menuitem, gchar *name)
 {
-  dt_styles_apply_to_dev(name, darktable.develop->image_storage.id);
+  if(gtk_get_current_event()->type == GDK_KEY_PRESS)
+    dt_styles_apply_to_dev(name, darktable.develop->image_storage.id);
+}
+
+static gboolean _darkroom_ui_apply_style_button_callback(GtkMenuItem *menuitem, GdkEventButton *event,
+                                                         gchar *name)
+{
+  if(event->button == 1)
+    dt_styles_apply_to_dev(name, darktable.develop->image_storage.id);
+  else
+    dt_shortcut_copy_lua(NULL, name);
+
+  return FALSE;
 }
 
 gboolean _styles_tooltip_callback(GtkWidget* self,
@@ -1332,11 +1344,10 @@ gboolean _styles_tooltip_callback(GtkWidget* self,
   dt_dev_write_history(dev);
 
   GtkWidget *ht = dt_gui_style_content_dialog(name, imgid);
-  gtk_widget_show_all(ht);
 
-  gtk_tooltip_set_custom(tooltip, ht);
+  g_object_set_data_full(G_OBJECT(self), "dt-preset-name", g_strdup(name), g_free);
 
-  return TRUE;
+  return dt_shortcut_tooltip_callback(self, x, y, keyboard_mode, tooltip, ht);
 }
 
 static void _darkroom_ui_apply_style_popupmenu(GtkWidget *w, gpointer user_data)
@@ -1420,7 +1431,12 @@ static void _darkroom_ui_apply_style_popupmenu(GtkWidget *w, gpointer user_data)
 
       g_signal_connect_data(G_OBJECT(mi), "activate",
                             G_CALLBACK(_darkroom_ui_apply_style_activate_callback),
-                            g_strdup(style->name), (GClosureNotify)g_free, G_CONNECT_SWAPPED);
+                            g_strdup(style->name), (GClosureNotify)g_free, 0);
+
+      g_signal_connect_data(G_OBJECT(mi), "button-press-event",
+                            G_CALLBACK(_darkroom_ui_apply_style_button_callback),
+                            g_strdup(style->name), (GClosureNotify)g_free, 0);
+
       gtk_widget_show(mi);
 
       g_strfreev(split);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1316,7 +1316,8 @@ static void _darkroom_ui_apply_style_activate_callback(GtkMenuItem *menuitem, gc
     dt_styles_apply_to_dev(name, darktable.develop->image_storage.id);
 }
 
-static gboolean _darkroom_ui_apply_style_button_callback(GtkMenuItem *menuitem, GdkEventButton *event,
+static gboolean _darkroom_ui_apply_style_button_callback(GtkMenuItem *menuitem,
+                                                         GdkEventButton *event,
                                                          gchar *name)
 {
   if(event->button == 1)


### PR DESCRIPTION
This PR has picked up a bunch of separate functionalities with interdependencies (so splitting into separate PRs would involve extra work, waiting and rebasing). It might be best just to list some release notes entries:

- the lua call to `dt.gui.action` has become more flexible, with most parameters optional, so you can read the focused status of a module doing just `dt.gui.action("iop/filmicrgb", "focus")`
- tooltips show these compacter lua commands in mapping mode (only adding the last parameter, _instance_, if the module supports multi-instance) and have been added to presets and styles menus as well
- lua commands can be copied to the clipboard, using ctrl+v in the shortcuts dialog, both from a selected action or shortcut, or long right click when in mapping mode (over a widget) or in the presets/styles menus
- the shown/copied lua command for a slider or combobox will set the value it currently has
- a bug with shortcuts (and `dt.gui.action`) to set the active item in a combobox with varying content has been fixed and now it is also possible to directly set the values of the combos for the focused module's blending mode etc. (by setting the shortcuts _effect_)
- added section headers to the _sort by_ drop-down (_files_, _times_, etc)
- shortcuts assigned to presets or styles will be shown when hovering over them in their menu
- _long_ left clicking a preset will keep the menu open so you can quickly switch between several to see the effect without having to repeatedly click the preset button to reopen the menu. You can also scroll over the preset button to switch to previous/next presets (like you already could via shortcuts)
- a shortcut can now be directed to a lua script that mimics a standard slider, dropdown or button, but dynamically selects the real widget(s) that receive(s) it, based on for example which module is focused or enabled. The advantage is that all fallbacks work as normal, so you can assign a midi knob to it and turning it (holding shift/ctrl to speed up/down) or pressing it to reset work regardless of which widget receives it. Basically this is a much more flexible alternative to the fake widgets under `processing modules/<focused>`. This allows owners of for example an x-touch mini to use their scarce rotors in different, fully configurable, ways while working in different modules (which can also be focused using midi buttons which will then light up). Such configurations could be shared using https://github.com/darktable-org/lua-scripts
- support shortcuts to sliders/combos created in lua, either via visual mapping mode or in the shortcuts dialog under the _lua_ category. _Elements_ and _effects_ are not supported.

ORIGINAL POST:
Introduce a new lua call `dt.gui.mimic` that creates an action for a "fake" widget (in the shortcuts action list under "lua scripts"). The widget _looks_ like a normal _slider_ or _dropdown_, so when a shortcut is mapped to it, it accepts the same elements and effects and uses the same fallbacks. But instead of sending these directly to a _real_ widget, it calls a lua routine, which can then decide (based on for example which module has the focus, but this could be anything) to which _real_ widget the shortcut should be forwarded. It does this by calling `dt.gui.action` with the arguments it received.

@jenshannoschwalm You could do what you mentioned in https://github.com/darktable-org/darktable/pull/11361#issuecomment-1152726578 but instead of having different modifiers direct where the _contrast_ knob goes, it could depend on whether filmic is currently focused. And shift and ctrl would still work to speed it up or slow it down.

```
local dt = require "darktable"

dt.gui.mimic("slider", "multi-contrast",
  function(action, element, effect, size)
      if dt.gui.action("iop/filmicrgb", "focus") == 1 then
        which = "iop/filmicrgb/contrast"
      else
        which = "iop/colorbalancergb/contrast"
      end
      return dt.gui.action(which, element, effect, size)
    end
)
```

You could also have one shortcut be sent to two widgets at the same time
```
dt.gui.mimic("dropdown", "double combo",
  function(action, element, effect, size)
    dt.gui.action("iop/filmicrgb/contrast in shadows", element, effect, size)
    return dt.gui.action("iop/filmicrgb/contrast in highlights", element, effect, size)
  end
)
```
In this case, if mapped to a knob on the x-touch mini, the rotator lights would indicate the status of the second widget.

This could be expanded, for the x-touch or similar, to define 8 fake sliders and assign all of the rotator knobs to those. They could then be redirected to the different point on the curve in color zones, if that module is active, or to the different parameters of shapes, if a mask is currently being edited (test `dt.gui.action("iop/blend/tools/show and edit mask elements", 0, "", "")`), and to some other frequently used sliders when neither of these are the case.
Old style calls are still supported so existing scripts shouldn't break.

EDIT: makes calls to dt.gui.action more flexible and moves _instance_ parameter to the end (since it is only relevant for a subset of actions (multi-instance iop modules) and even then usually defaults to 0. Most parameters are now optional, so you can read the focus state of a module with `dt.action.gui("iop/modulename", "focus")` or set it with `dt.action.gui("iop/modulename", "focus", 1)`

EDIT2: fixes a bug with combobox shortcuts/dt.gui.action calls that specify a specific "item:" in cases where the list in the live combo options was manipulated at runtime. The nth item in the combo would not correspond to the nth item in the actions list anymore. Now more robust. Could be used to provide a static list of options in, say, the blend mode dropdown as well to allow them to be selected by shortcut.