### PR TITLE
fix midi note name bug

### DIFF
--- a/src/libs/tools/midi.c
+++ b/src/libs/tools/midi.c
@@ -85,7 +85,7 @@ const char *note_names[] = { "C","C#","D","D#","E","F","F#","G","G#","A","A#","B
 
 gchar *key_to_string(const guint key, const gboolean display)
 {
-  return g_strdup_printf("%s%u", note_names[key % 12], key / 12 - 1);
+  return g_strdup_printf("%s%d", note_names[key % 12], (int)key / 12 - 1);
 }
 
 gboolean string_to_key(const gchar *string, guint *key)


### PR DESCRIPTION
Saving and restoring the shortcuts configuration for the first few buttons on the top left of the X-touch mini was broken by #13508 because they have names like G#-1