### PR TITLE
wb_presets: match Leica M9 to rawspeed

### DIFF
--- a/data/wb_presets.json
+++ b/data/wb_presets.json
@@ -30621,7 +30621,7 @@
           ]
         },
         {
-          "model": "M9 Digital Camera",
+          "model": "M9",
           "presets": [
             {
               "name": "Tungsten",


### PR DESCRIPTION
Use the rawspeed sanitized model name that was included after 4.2.0 so @TurboGit this needs to go into 4.2.1 as well.