### PR TITLE
Better handling of update preset entry in preset menu.

### DIFF
--- a/src/common/presets.h
+++ b/src/common/presets.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2019-2020 darktable developers.
+    Copyright (C) 2019-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "common/darktable.h"
+#include "develop/imageop.h"
 
 /** save preset to file */
 void dt_presets_save_to_file(const int rowid, const char *preset_name, const char *filedir);
@@ -36,6 +37,9 @@ char *dt_presets_get_name(const char *module_name,
                           const gboolean is_default_params,
                           const void *blend_params,
                           const uint32_t blend_params_size);
+
+/** get currently active preset name for the module */
+gchar *dt_get_active_preset_name(dt_iop_module_t *module, gboolean *writeprotect);
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2049,6 +2049,12 @@ void dt_iop_request_focus(dt_iop_module_t *module)
     // we also add the focus css class
     GtkWidget *iop_w = gtk_widget_get_parent(dt_iop_gui_get_pluginui(darktable.develop->gui_module));
     dt_gui_add_class(iop_w, "dt_module_focus");
+
+    // update last preset name to get the update preset entry
+    gboolean writeprotect = FALSE;
+    gchar *name = dt_get_active_preset_name(module, &writeprotect);
+    if(!writeprotect && name) dt_gui_store_last_preset(name);
+    g_free(name);
   }
 
   /* update sticky accels window */


### PR DESCRIPTION
This was only possible after selecting a preset on the module. At this point the last selected preset was recorded and a modification of the parameters was triggering the entry "update preset". This is true for each single module, that is editing another module it was possible to get the "update preset" entry only after having selected a preset.

In this implementation we check for the current preset when the focus is given to the module. So the last preset is known when first entering the darkroom and for each module worked on during the development.

Fixes #13581.