### PR TITLE
[CI] Optimize Linux-minimal CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,13 @@ jobs:
           - { compiler: GNU10,  CC: gcc-10,   CXX: g++-10,     packages: gcc-10 g++-10 }
           - { compiler: LLVM14, CC: clang-14, CXX: clang++-14, packages: clang-14 libomp-14-dev libclang-common-14-dev llvm-14-dev clang++-14 libc++-14-dev libc++1-14 libc++abi1-14 lld-14}
         btype:
-          - RelWithDebInfo
+          - Debug
+          #- RelWithDebInfo
           #- Release
         target:
-          #- build
-          - nofeatures
-          - nofeatures_nosse
+          - skiptest
+          #- nofeatures
+          #- nofeatures_nosse
         generator:
           #- Unix Makefiles
           - Ninja

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,10 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - { label: ubuntu-20.04, code: focal }
+          - { label: ubuntu-latest, code: latest }
         compiler:
           - { compiler: GNU10,  CC: gcc-10,   CXX: g++-10,     packages: gcc-10 g++-10 }
-          - { compiler: LLVM12, CC: clang-12, CXX: clang++-12, packages: clang-12 libomp-12-dev libclang-common-12-dev llvm-12-dev clang++-12 libc++-12-dev libc++1-12 libc++abi1-12 lld-12}
+          - { compiler: LLVM14, CC: clang-14, CXX: clang++-14, packages: clang-14 libomp-14-dev libclang-common-14-dev llvm-14-dev clang++-14 libc++-14-dev libc++1-14 libc++abi1-14 lld-14}
         btype:
           - RelWithDebInfo
           #- Release


### PR DESCRIPTION
The rationale for these changes is as follows:

Linux-minimal is for a quick check before the main Linux matrix. If there are errors in the code (warnings are also treated as errors), we would definitely like to catch them at this stage to report the problem as early as possible.

Before this PR, we built darktable here without full coverage, without an optional code. This does not really serve the purpose, because although it is faster, errors in optional code simply will not be caught.

Now we are building full-featured code here. Increasing the amount of compiled code increases build time, but this is compensated by a faster compilation without optimizations.

Also, we'd like to check here both that the code is compiled with the base compiler that will probaly be used to compile the program in the official distribution packages (this is typically the default GCC of the oldest supported Ubuntu release), and that it is compiled with the most advanced currently available compiler that most often raises the bar for code correctness (this is typically the latest version of LLVM).
