### PR TITLE
Demosaicer maintenance code

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -297,66 +297,6 @@ int output_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe,
   return IOP_CS_RGB;
 }
 
-static const char* _method2string(dt_iop_demosaic_method_t method)
-{
-  const char *string;
-
-  switch(method)
-  {
-    case DT_IOP_DEMOSAIC_PPG:
-      string = "PPG";
-      break;
-    case DT_IOP_DEMOSAIC_AMAZE:
-      string = "AMaZE";
-      break;
-    case DT_IOP_DEMOSAIC_VNG4:
-      string = "VNG4";
-      break;
-    case DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME:
-      string = "passthrough monochrome";
-      break;
-    case DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR:
-      string = "photosites";
-      break;
-    case DT_IOP_DEMOSAIC_RCD:
-      string = "RCD";
-      break;
-    case DT_IOP_DEMOSAIC_LMMSE:
-      string = "LMMSE";
-      break;
-    case DT_IOP_DEMOSAIC_RCD_VNG:
-      string = "RCD + VNG4";
-      break;
-    case DT_IOP_DEMOSAIC_AMAZE_VNG:
-      string = "AMaZE + VNG4";
-      break;
-    case DT_IOP_DEMOSAIC_VNG:
-      string = "VNG (xtrans)";
-      break;
-    case DT_IOP_DEMOSAIC_MARKESTEIJN:
-      string = "Markesteijn-1 (xtrans)";
-      break;
-    case DT_IOP_DEMOSAIC_MARKESTEIJN_3:
-      string = "Markesteijn-3 (xtrans)";
-      break;
-    case DT_IOP_DEMOSAIC_MARKEST3_VNG:
-      string = "Markesteijn 3-pass + VNG";
-      break;
-    case DT_IOP_DEMOSAIC_FDC:
-      string = "Frequency Domain Chroma (xtrans)";
-      break;
-    case DT_IOP_DEMOSAIC_PASSTHR_MONOX:
-      string = "passthrough monochrome (xtrans)";
-      break;
-    case DT_IOP_DEMOSAIC_PASSTHR_COLORX:
-      string = "photosites (xtrans)";
-      break;
-    default:
-      string = "(unknown method)";
-  }
-  return string;
-}
-
 #define SWAP(a, b)                                                                                           \
   {                                                                                                          \
     const float tmp = (b);                                                                                   \
@@ -4955,7 +4895,7 @@ int process_cl(
   }
   else
   {
-    dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] demosaicing method '%s' not yet supported by opencl code\n", _method2string(demosaicing_method));
+    dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] demosaicing method %d not yet supported by opencl code\n", demosaicing_method);
     return FALSE;
   }
 

--- a/src/iop/dual_demosaic.c
+++ b/src/iop/dual_demosaic.c
@@ -28,9 +28,16 @@ static float slider2contrast(float slider)
 {
   return 0.005f * powf(slider, 1.1f);
 }
-static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict rgb_data, const float *const restrict raw_data,
-                          dt_iop_roi_t *const roi_out, const dt_iop_roi_t *const roi_in, const uint32_t filters, const uint8_t (*const xtrans)[6],
-                          const gboolean dual_mask, float dual_threshold)
+static void dual_demosaic(
+        dt_dev_pixelpipe_iop_t *piece,
+        float *const restrict rgb_data,
+        const float *const restrict raw_data,
+        dt_iop_roi_t *const roi_out,
+        const dt_iop_roi_t *const roi_in,
+        const uint32_t filters,
+        const uint8_t (*const xtrans)[6],
+        const gboolean dual_mask,
+        const float dual_threshold)
 {
   const int width = roi_in->width;
   const int height = roi_in->height;
@@ -50,13 +57,9 @@ static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict r
     dt_control_log(_("[dual demosaic] can't allocate internal buffers"));
     return;
   }
-  const gboolean info = ((darktable.unmuted & DT_DEBUG_PERF) && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL));
 
   vng_interpolate(vng_image, raw_data, roi_out, roi_in, filters, xtrans, FALSE);
   color_smoothing(vng_image, roi_out, 2);
-
-  dt_times_t start_blend = { 0 }, end_blend = { 0 };
-  if(info) dt_get_times(&start_blend);
 
   const float contrastf = slider2contrast(dual_threshold);
   const gboolean wbon = piece->pipe->dsc.temperature.enabled;
@@ -92,21 +95,27 @@ static void dual_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict r
     {
       const int oidx = 4 * idx;
       for(int c = 0; c < 4; c++)
-        rgb_data[oidx + c] = intp(blend[idx], rgb_data[oidx + c], vng_image[oidx + c]);
+        rgb_data[oidx + c] = _intp(blend[idx], rgb_data[oidx + c], vng_image[oidx + c]);
     }
   }
-  if(info)
-  {
-    dt_get_times(&end_blend);
-    dt_print(DT_DEBUG_ALWAYS, "[demosaic] CPU dual blending %.4f secs (%.4f CPU)\n", end_blend.clock - start_blend.clock, end_blend.user - start_blend.user);
-  }
+
   dt_free_align(tmp);
   dt_free_align(blend);
   dt_free_align(vng_image);
 }
 
 #ifdef HAVE_OPENCL
-gboolean dual_demosaic_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem detail, cl_mem blend, cl_mem high_image, cl_mem low_image, cl_mem out, const int width, const int height, const int showmask)
+gboolean dual_demosaic_cl(
+        struct dt_iop_module_t *self,
+        dt_dev_pixelpipe_iop_t *piece,
+        cl_mem detail,
+        cl_mem blend,
+        cl_mem high_image,
+        cl_mem low_image,
+        cl_mem out,
+        const int width,
+        const int height,
+        const int showmask)
 {
   const int devid = piece->pipe->devid;
   dt_iop_demosaic_data_t *data = (dt_iop_demosaic_data_t *)piece->data;

--- a/src/iop/rcd_demosaic.c
+++ b/src/iop/rcd_demosaic.c
@@ -69,12 +69,6 @@
   #pragma GCC optimize ("fast-math", "fp-contract=fast", "finite-math-only", "no-math-errno")
 #endif
 
-#ifdef __GNUC__
-  #define INLINE __inline
-#else
-  #define INLINE inline
-#endif
-
 #define RCD_BORDER 9          // avoid tile-overlap errors
 #define RCD_MARGIN 6          // for the outermost tiles we can have a smaller outer border
 #define RCD_TILEVALID (RCD_TILESIZE - 2 * RCD_BORDER)
@@ -86,7 +80,7 @@
 #define eps 1e-5f              // Tolerance to avoid dividing by zero
 #define epssq 1e-10f
 
-static INLINE float intp(float a, float b, float c)
+static inline float _intp(float a, float b, float c)
 {   // taken from rt code
     // calculate a * b + (1 - a) * c
     // following is valid:
@@ -96,13 +90,19 @@ static INLINE float intp(float a, float b, float c)
 }
 
 // We might have negative data in input and also want to normalise
-static INLINE float safe_in(float a, float scale)
+static inline float _safe_in(float a, float scale)
 {
   return fmaxf(0.0f, a) * scale;
 }
 
 /** This is basically ppg adopted to only write data to RCD_MARGIN */
-static void rcd_ppg_border(float *const out, const float *const in, const int width, const int height, const uint32_t filters, const int margin)
+static void rcd_ppg_border(
+        float *const out,
+        const float *const in,
+        const int width,
+        const int height,
+        const uint32_t filters,
+        const int margin)
 {
   const int border = margin + 3;
   // write approximatad 3-pixel border region to out
@@ -293,8 +293,13 @@ static void rcd_ppg_border(float *const out, const float *const in, const int wi
 #ifdef _OPENMP
   #pragma omp declare simd aligned(in, out)
 #endif
-static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict out, const float *const restrict in, dt_iop_roi_t *const roi_out,
-                                   const dt_iop_roi_t *const roi_in, const uint32_t filters)
+static void rcd_demosaic(
+        dt_dev_pixelpipe_iop_t *piece,
+        float *const restrict out,
+        const float *const restrict in,
+        dt_iop_roi_t *const roi_out,
+        const dt_iop_roi_t *const roi_in,
+        const uint32_t filters)
 {
   const int width = roi_in->width;
   const int height = roi_in->height;
@@ -364,7 +369,7 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
           const int c1 = FC(row, colStart + 1, filters);
           for(int col = colStart, indx = (row - rowStart) * RCD_TILESIZE, in_indx = row * width + colStart; col < colEnd; col++, indx++, in_indx++)
           {
-            cfa[indx] = rgb[c0][indx] = rgb[c1][indx] = safe_in(in[in_indx], revscaler);
+            cfa[indx] = rgb[c0][indx] = rgb[c1][indx] = _safe_in(in[in_indx], revscaler);
           }
         }
 
@@ -450,7 +455,7 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
             const float VH_Neighbourhood_Value = 0.25f * (VH_Dir[indx - w1 - 1] + VH_Dir[indx - w1 + 1] + VH_Dir[indx + w1 - 1] + VH_Dir[indx + w1 + 1]);
             const float VH_Disc = (fabs(0.5f - VH_Central_Value) < fabs(0.5f - VH_Neighbourhood_Value)) ? VH_Neighbourhood_Value : VH_Central_Value;
 
-            rgb[1][indx] = intp(VH_Disc, H_Est, V_Est);
+            rgb[1][indx] = _intp(VH_Disc, H_Est, V_Est);
           }
         }
 
@@ -504,7 +509,7 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
             const float Q_Est = (NE_Grad * SW_Est + SW_Grad * NE_Est) / (NE_Grad + SW_Grad);
 
             // R@B and B@R interpolation
-            rgb[c][indx] = rgb[1][indx] + intp(PQ_Disc, Q_Est, P_Est);
+            rgb[c][indx] = rgb[1][indx] + _intp(PQ_Disc, Q_Est, P_Est);
           }
         }
 
@@ -550,7 +555,7 @@ static void rcd_demosaic(dt_dev_pixelpipe_iop_t *piece, float *const restrict ou
               const float H_Est = (E_Grad * W_Est + W_Grad * E_Est) / (E_Grad + W_Grad);
 
               // R@G and B@G interpolation
-              rgb[c][indx] = rgb1 + intp(VH_Disc, H_Est, V_Est);
+              rgb[c][indx] = rgb1 + _intp(VH_Disc, H_Est, V_Est);
             }
           }
         }


### PR DESCRIPTION
Main thing, removed the demosaicer specific benching stuff as we now have general benching support via command-line.

- common indentation
- leading underscores for inline static
- some int -> gboolean conversions
- removed some compiler specific inline stuff