### PR TITLE
add build folders to .gitignore

### DIFF
--- a/packaging/macosx/.gitignore
+++ b/packaging/macosx/.gitignore
@@ -3,3 +3,6 @@ bin/
 lib/
 share/
 package/
+libexec/
+.config/
+.cache/


### PR DESCRIPTION
Some more folders to ignore when building using the homebrew build scripts in `packaging/macosx`