### PR TITLE
Support multiple modules for debugging helpers

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -144,9 +144,9 @@ static int usage(const char *argv0)
 #ifdef HAVE_OPENCL
   printf("  --disable-opencl\n");
 #endif
-  printf("  --dump-pfm <module>\n");
-  printf("  --dump-pipe <module>\n");
-  printf("  --bench-module <module>\n");
+  printf("  --dump-pfm <module,moduleb>\n");
+  printf("  --dump-pipe <module,moduleb>\n");
+  printf("  --bench-module <module,moduleb>\n");
   printf("  --library <library file>\n");
   printf("  --localedir <locale directory>\n");
 #ifdef USE_LUA
@@ -501,7 +501,7 @@ void dt_dump_pfm(
 {
   if(!darktable.dump_pfm_module) return;
   if(!modname) return;
-  if(strcmp(modname, darktable.dump_pfm_module)) return; 
+  if(!dt_str_commasubstring(darktable.dump_pfm_module, modname)) return; 
 
   _dump_pfm_file(filename, in, width, height, mode, modname, FALSE, FALSE);
 }
@@ -517,7 +517,7 @@ void dt_dump_pipe_pfm(
 {
   if(!darktable.dump_pfm_pipe) return;
   if(!mod) return;
-  if(strcmp(mod, darktable.dump_pfm_pipe)) return; 
+  if(!dt_str_commasubstring(darktable.dump_pfm_pipe, mod)) return; 
 
   _dump_pfm_file(pipe, data, width, height, (bpp == 4) ? DT_DUMP_PFM_RGB : DT_DUMP_PFM_MASK, mod, input, !input);
 }

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -144,9 +144,9 @@ static int usage(const char *argv0)
 #ifdef HAVE_OPENCL
   printf("  --disable-opencl\n");
 #endif
-  printf("  --dump-pfm <module,moduleb>\n");
-  printf("  --dump-pipe <module,moduleb>\n");
-  printf("  --bench-module <module,moduleb>\n");
+  printf("  --dump-pfm <modulea,moduleb>\n");
+  printf("  --dump-pipe <modulea,moduleb>\n");
+  printf("  --bench-module <modulea,moduleb>\n");
   printf("  --library <library file>\n");
   printf("  --localedir <locale directory>\n");
 #ifdef USE_LUA

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -995,6 +995,29 @@ gchar *dt_str_replace(const char *string, const char *search, const char *replac
   return res;
 }
 
+gboolean dt_str_commasubstring(const char *list, const char *search)
+{
+  if(search == NULL)
+    return FALSE;
+
+  gchar *nlist = g_strdup(list);
+  char delimiter[] = ",";
+
+  char *ptr =strtok(nlist, delimiter);
+  while(ptr != NULL)
+  {
+    if(g_strcmp0(search, ptr) == 0)
+    {
+      g_free(nlist);
+      return TRUE;
+    }
+	  ptr = strtok(NULL, delimiter);
+  }
+
+  g_free(nlist);
+  return FALSE;
+}
+
 gboolean dt_is_scene_referred(void)
 {
   return dt_conf_is_equal("plugins/darkroom/workflow", "scene-referred (filmic)")

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -1011,7 +1011,7 @@ gboolean dt_str_commasubstring(const char *list, const char *search)
       g_free(nlist);
       return TRUE;
     }
-	  ptr = strtok(NULL, delimiter);
+    ptr = strtok(NULL, delimiter);
   }
 
   g_free(nlist);

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -50,6 +50,8 @@ gchar *dt_util_foo_to_utf8(const char *string);
 guint dt_util_string_count_char(const char *text, const char needle);
 /* helper function to convert en float numbers to local based numbers for scanf */
 void dt_util_str_to_loc_numbers_format(char *data);
+/* helper function to search for a string in a comma seperated string */
+gboolean dt_str_commasubstring(const char *list, const char *search);
 
 typedef enum dt_logo_season_t
 {

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1107,35 +1107,36 @@ static int pixelpipe_process_on_CPU(
     // this code section is for simplistic benchmarking via --bench-module
     if((piece->pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_EXPORT)) && darktable.bench_module)
     {
-      if(!strcmp(module->so->op, darktable.bench_module))
+      if(dt_str_commasubstring(darktable.bench_module, module->so->op))
       {
         dt_times_t start;
         dt_times_t end;
         const int old_muted = darktable.unmuted;
-        darktable.unmuted = 0;;
+        darktable.unmuted = 0;
         const gboolean full = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
+        const int counter = (piece->pipe->type & DT_DEV_PIXELPIPE_FULL) ? 100 : 50;
         const float mpix = (roi_out->width * roi_out->height) / 1.0e6;
 
 #if defined(__SSE__)
         if(module->process_sse2)
         {
           dt_get_times(&start);
-          for(int i = 0; i < 50; i++)
+          for(int i = 0; i < counter; i++)
             module->process_sse2(module, piece, input, *output, roi_in, roi_out);
           dt_get_times(&end);
-          const float clock = (end.clock - start.clock) / 50.0f;
-          dt_print(DT_DEBUG_ALWAYS, "[bench module SSE2]  [%s] `%s' takes %.5fs, %.2fmpix, %.3fpix/us\n",
+          const float clock = (end.clock - start.clock) / (float) counter;
+          dt_print(DT_DEBUG_ALWAYS, "[bench module SSE2]  [%s] `%15s' takes %8.5fs,%7.2fmpix,%9.3fpix/us\n",
                 full ? "full" : "export", module->so->op, clock, mpix, mpix/clock);
         }
 #endif
         if(module->process_plain)
         {
           dt_get_times(&start);
-          for(int i = 0; i < 50; i++)
+          for(int i = 0; i < counter; i++)
             module->process_plain(module, piece, input, *output, roi_in, roi_out);
           dt_get_times(&end);
-          const float clock = (end.clock - start.clock) / 50.0f;
-          dt_print(DT_DEBUG_ALWAYS, "[bench module plain] [%s] `%s' takes %.5fs, %.2fmpix, %.3fpix/us\n",
+          const float clock = (end.clock - start.clock) / (float) counter;
+          dt_print(DT_DEBUG_ALWAYS, "[bench module plain] [%s] `%15s' takes %8.5fs,%7.2fmpix,%9.3fpix/us\n",
                 full ? "full" : "export", module->so->op, clock, mpix, mpix/clock);
         }
         darktable.unmuted = old_muted;
@@ -1689,7 +1690,7 @@ static int dt_dev_pixelpipe_process_rec(
           // this code section is for simplistic benchmarking via --bench-module
           if((piece->pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_EXPORT)) && darktable.bench_module)
           {
-            if(!strcmp(module->so->op, darktable.bench_module))
+            if(dt_str_commasubstring(darktable.bench_module, module->so->op))
             {
               dt_times_t bench;
               dt_times_t end;
@@ -1707,7 +1708,7 @@ static int dt_dev_pixelpipe_process_rec(
               {
                 dt_get_times(&end);
                 const float clock = (end.clock - bench.clock) / 100.0f;
-                dt_print(DT_DEBUG_ALWAYS, "[bench module GPU] [%s] `%s' takes %.5fs, %.2fmpix, %.3fpix/us\n",
+                dt_print(DT_DEBUG_ALWAYS, "[bench module GPU]   [%s] `%15s' takes %8.5fs,%7.2fmpix,%9.3fpix/us\n",
                     full ? "full" : "export", module->so->op, clock, mpix, mpix/clock);
               }
               else


### PR DESCRIPTION
The command line options `--dump-pfm`, `--dump-pipe` and `--bench-modules` all now take not only one module but a comma-seperated-list of modules like

`--bench-module colorin,colorout,demosaic`

Some mods in the bench output for
- better readability of the logs
- somewhat improved accuracy as for full pipe we might have too low processing time.