### PR TITLE
[CI] Optimize Linux CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,6 @@ jobs:
           - Release
         target:
           - build
-          - nofeatures
           - nofeatures_nosse
         generator:
           #- Unix Makefiles

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,10 +170,9 @@ jobs:
         os:
           - { label: ubuntu-latest, code: latest }
         compiler:
-          - { compiler: GNU9,   CC: gcc-9,    CXX: g++-9,      packages: gcc-9 g++-9 }
-          - { compiler: GNU10,  CC: gcc-10,   CXX: g++-10,     packages: gcc-10 g++-10 }
           - { compiler: GNU11,  CC: gcc-11,   CXX: g++-11,     packages: gcc-11 g++-11 }
-          - { compiler: LLVM12, CC: clang-12, CXX: clang++-12, packages: clang-12 libomp-12-dev libclang-common-12-dev llvm-12-dev clang++-12 libc++-12-dev libc++1-12 libc++abi1-12 lld-12}
+          - { compiler: GNU12,  CC: gcc-12,   CXX: g++-12,     packages: gcc-12 g++-12 }
+          - { compiler: LLVM14, CC: clang-14, CXX: clang++-14, packages: clang-14 libomp-14-dev libclang-common-14-dev llvm-14-dev clang++-14 libc++-14-dev libc++1-14 libc++abi1-14 lld-14}
         btype:
           - Release
         target:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - { label: ubuntu-20.04, code: focal }
+          - { label: ubuntu-latest, code: latest }
         compiler:
           - { compiler: GNU9,   CC: gcc-9,    CXX: g++-9,      packages: gcc-9 g++-9 }
           - { compiler: GNU10,  CC: gcc-10,   CXX: g++-10,     packages: gcc-10 g++-10 }
@@ -196,22 +196,22 @@ jobs:
             target: skiptest
             generator: Ninja
         exclude:
-          - os: { label: ubuntu-20.04, code: focal }
+          - os: { label: ubuntu-latest, code: latest }
             btype: RelWithDebInfo
             compiler: { compiler: GNU9,   CC: gcc-9,    CXX: g++-9,      packages: gcc-9 g++-9 }
             target: nofeatures
             generator: Ninja
-          - os: { label: ubuntu-20.04, code: focal }
+          - os: { label: ubuntu-latest, code: latest }
             btype: RelWithDebInfo
             compiler: { compiler: GNU9,   CC: gcc-9,    CXX: g++-9,      packages: gcc-9 g++-9 }
             target: nofeatures_nosse
             generator: Ninja
-          - os: { label: ubuntu-20.04, code: focal }
+          - os: { label: ubuntu-latest, code: latest }
             btype: RelWithDebInfo
             compiler: { compiler: LLVM12, CC: clang-12, CXX: clang++-12, packages: clang-12 libomp-12-dev libclang-common-12-dev llvm-12-dev clang++-12 libc++-12-dev libc++1-12 libc++abi1-12 lld-12}
             target: nofeatures
             generator: Ninja
-          - os: { label: ubuntu-20.04, code: focal }
+          - os: { label: ubuntu-latest, code: latest }
             btype: RelWithDebInfo
             compiler: { compiler: LLVM12, CC: clang-12, CXX: clang++-12, packages: clang-12 libomp-12-dev libclang-common-12-dev llvm-12-dev clang++-12 libc++-12-dev libc++1-12 libc++abi1-12 lld-12}
             target: nofeatures_nosse

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,13 +170,9 @@ jobs:
         os:
           - { label: ubuntu-20.04, code: focal }
         compiler:
-          #- { compiler: GNU8,   CC: gcc-8,    CXX: g++-8,      packages: gcc-8 g++-8 }
           - { compiler: GNU9,   CC: gcc-9,    CXX: g++-9,      packages: gcc-9 g++-9 }
           - { compiler: GNU10,  CC: gcc-10,   CXX: g++-10,     packages: gcc-10 g++-10 }
           - { compiler: GNU11,  CC: gcc-11,   CXX: g++-11,     packages: gcc-11 g++-11 }
-          #- { compiler: LLVM9,  CC: clang-9,  CXX: clang++-9,  packages: clang-9 libomp-9-dev libclang-common-9-dev llvm-9-dev clang++-9 libc++-9-dev lld-9}
-          #- { compiler: LLVM10, CC: clang-10, CXX: clang++-10, packages: clang-10 libomp-10-dev libclang-common-10-dev llvm-10-dev clang++-10 libc++-10-dev lld-10}
-          # - { compiler: LLVM11, CC: clang-11, CXX: clang++-11, packages: clang-11 libomp-11-dev libclang-common-11-dev llvm-11-dev clang++-11 libc++-11-dev lld-11}
           - { compiler: LLVM12, CC: clang-12, CXX: clang++-12, packages: clang-12 libomp-12-dev libclang-common-12-dev llvm-12-dev clang++-12 libc++-12-dev libc++1-12 libc++abi1-12 lld-12}
         btype:
           - RelWithDebInfo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,6 @@ jobs:
           - { compiler: GNU11,  CC: gcc-11,   CXX: g++-11,     packages: gcc-11 g++-11 }
           - { compiler: LLVM12, CC: clang-12, CXX: clang++-12, packages: clang-12 libomp-12-dev libclang-common-12-dev llvm-12-dev clang++-12 libc++-12-dev libc++1-12 libc++abi1-12 lld-12}
         btype:
-          - RelWithDebInfo
           - Release
         target:
           - build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,27 +181,6 @@ jobs:
         generator:
           #- Unix Makefiles
           - Ninja
-        exclude:
-          - os: { label: ubuntu-latest, code: latest }
-            btype: RelWithDebInfo
-            compiler: { compiler: GNU9,   CC: gcc-9,    CXX: g++-9,      packages: gcc-9 g++-9 }
-            target: nofeatures
-            generator: Ninja
-          - os: { label: ubuntu-latest, code: latest }
-            btype: RelWithDebInfo
-            compiler: { compiler: GNU9,   CC: gcc-9,    CXX: g++-9,      packages: gcc-9 g++-9 }
-            target: nofeatures_nosse
-            generator: Ninja
-          - os: { label: ubuntu-latest, code: latest }
-            btype: RelWithDebInfo
-            compiler: { compiler: LLVM12, CC: clang-12, CXX: clang++-12, packages: clang-12 libomp-12-dev libclang-common-12-dev llvm-12-dev clang++-12 libc++-12-dev libc++1-12 libc++abi1-12 lld-12}
-            target: nofeatures
-            generator: Ninja
-          - os: { label: ubuntu-latest, code: latest }
-            btype: RelWithDebInfo
-            compiler: { compiler: LLVM12, CC: clang-12, CXX: clang++-12, packages: clang-12 libomp-12-dev libclang-common-12-dev llvm-12-dev clang++-12 libc++-12-dev libc++1-12 libc++abi1-12 lld-12}
-            target: nofeatures_nosse
-            generator: Ninja
     env:
       CC: ${{ matrix.compiler.CC }}
       CXX: ${{ matrix.compiler.CXX }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,17 +181,6 @@ jobs:
         generator:
           #- Unix Makefiles
           - Ninja
-        include:
-          - os: { label: ubuntu-latest, code: latest }
-            btype: Debug
-            compiler: { compiler: GNU9,   CC: gcc-9,    CXX: g++-9,      packages: gcc-9 g++-9 }
-            target: skiptest
-            generator: Ninja
-          - os: { label: ubuntu-latest, code: latest }
-            btype: Debug
-            compiler: { compiler: LLVM12, CC: clang-12, CXX: clang++-12, packages: clang-12 libomp-12-dev libclang-common-12-dev llvm-12-dev clang++-12 libc++-12-dev libc++1-12 libc++abi1-12 lld-12}
-            target: skiptest
-            generator: Ninja
         exclude:
           - os: { label: ubuntu-latest, code: latest }
             btype: RelWithDebInfo


### PR DESCRIPTION
My changes and their rationale:

- Keep only one btype. RelWithDebinfo in CI in addition to Release does not make any sense.
- There is no need in nofeatures build. I'm keeping nofeatures_nosse for now to verify the correctness of the build with SSE2 disabled. But more and more SSE2-specific code is being removed, because on modern compilers it no longer gives an advantage over compiler-optimized code. So in the future nofeatures_nosse can also be deleted.
- Remove older compilers from matrix. Instead of GCC 10 used by Linux-minimal, the Linux matrix uses GCC 11 as the base compiler for Ubuntu LTS 22.04 and GCC 12 as the latest stable version.
- The include section is unnecessary after the latest changes in Linux-minimal, the exclude section is unnecessary, because now the Linux and Linux-minimal matrices do not intersect.