### PR TITLE
POC Title case all labels and bauhaus everywhere

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -180,6 +180,8 @@ static int show_pango_text(dt_bauhaus_widget_t *w, GtkStyleContext *context, cai
   PangoAttrList *attrlist = pango_attr_list_new();
   PangoAttribute *attr = pango_attr_font_features_new("tnum");
   pango_attr_list_insert(attrlist, attr);
+  attr = pango_attr_text_transform_new(PANGO_TEXT_TRANSFORM_CAPITALIZE);
+  pango_attr_list_insert(attrlist, attr);
   pango_layout_set_attributes(layout, attrlist);
   pango_attr_list_unref(attrlist);
 
@@ -2316,6 +2318,8 @@ static gint _bauhaus_natural_width(GtkWidget *widget, gboolean popup)
   pango_layout_set_font_description(layout, font_desc);
   PangoAttrList *attrlist = pango_attr_list_new();
   PangoAttribute *attr = pango_attr_font_features_new("tnum");
+  pango_attr_list_insert(attrlist, attr);
+  attr = pango_attr_text_transform_new(PANGO_TEXT_TRANSFORM_CAPITALIZE);
   pango_attr_list_insert(attrlist, attr);
   pango_layout_set_attributes(layout, attrlist);
   pango_attr_list_unref(attrlist);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1025,6 +1025,15 @@ static const char* _get_axis_name(int pos)
   return AXIS_NAMES[pos];
 }
 
+static void _label_map_callback(GtkWidget *widget)
+{
+  PangoAttrList *attrlist = pango_attr_list_new();
+  PangoAttribute *attr = pango_attr_text_transform_new(PANGO_TEXT_TRANSFORM_CAPITALIZE);
+  pango_attr_list_insert(attrlist, attr);
+  gtk_label_set_attributes(GTK_LABEL(widget), attrlist);
+  g_signal_chain_from_overridden_handler(widget);
+}
+
 int dt_gui_gtk_init(dt_gui_gtk_t *gui)
 {
   /* lets zero mem */
@@ -1176,6 +1185,7 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   g_signal_connect(G_OBJECT(widget), "configure-event", G_CALLBACK(_window_configure), NULL);
   g_signal_connect(G_OBJECT(widget), "event", G_CALLBACK(dt_shortcut_dispatcher), NULL);
   g_signal_override_class_handler("query-tooltip", gtk_widget_get_type(), G_CALLBACK(dt_shortcut_tooltip_callback));
+  g_signal_override_class_handler("map", gtk_label_get_type(), G_CALLBACK(_label_map_callback));
 
   //an action that does nothing - used for overriding/removing default shortcuts
   dt_action_register(&darktable.control->actions_global, N_("no-op"), _gui_noop_action_callback, 0, 0);


### PR DESCRIPTION
This is just a demo of a possible different way to approach #13609

This uses a pango attribute to achieve Title Case Capitalization for most of the widgets in the UI (there are some, very few exceptions). This would allow switching with a simple setting (probably requiring a reboot).

Main problem in its current form is that it also affects tooltips, but I suspect if there's interest in this that could be fixed. Tooltips we'd want to convert anyway, probably using a script and further manual adjustments, but to Sentence case, not Title Case.

Also, I'm not sure if "map" is the correct signal to override; it may be applying the adjustment repeatedly unnecessarily but I'll do more investigation later, if desired.

![image](https://user-images.githubusercontent.com/1549490/218284344-2b88d685-30d9-4986-919d-252232792e13.png)
