### PR TITLE
Don't show tooltips for window behind dialog

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -720,6 +720,7 @@ GHashTable *dt_shortcut_category_lists(dt_view_type_flags_t v)
 gboolean dt_shortcut_tooltip_callback(GtkWidget *widget, gint x, gint y, gboolean keyboard_mode,
                                       GtkTooltip *tooltip, gpointer user_data)
 {
+  if(!gtk_window_is_active(GTK_WINDOW(gtk_widget_get_toplevel(widget)))) return FALSE;
   if(dt_key_modifier_state() & (GDK_BUTTON1_MASK|GDK_BUTTON2_MASK|GDK_BUTTON3_MASK)) return FALSE;
 
   gchar *markup_text = NULL;


### PR DESCRIPTION
@nilvus I remember there being an issue filed about this but can't find it now.

Used to be that if for example the preference dialog was open, if you move the mouse over the main window behind it, tooltips would still pop up, sometimes for hidden widgets (like star ratings). This blocks that.

Fixes #13171