### PR TITLE
RFC: separate colorbalancergb module descriptions

### DIFF
--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -155,7 +155,7 @@ const char *aliases()
 
 const char **description(struct dt_iop_module_t *self)
 {
-  return dt_iop_set_description(self, _("affect color, brightness and contrast"),
+  return dt_iop_set_description(self, _("shift colors selectively by luminance range"),
                                       _("corrective or creative"),
                                       _("linear, Lab, scene-referred"),
                                       _("non-linear, RGB"),

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -180,7 +180,8 @@ const char *aliases()
 
 const char **description(struct dt_iop_module_t *self)
 {
-  return dt_iop_set_description(self, _("affect color, brightness and contrast"),
+  return dt_iop_set_description(self, _("a color-grading tools improved from ASC CDL"
+                                        "using masks to split shadows and highlights properly"),
                                       _("corrective or creative"),
                                       _("linear, RGB, scene-referred"),
                                       _("non-linear, RGB"),

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -180,7 +180,7 @@ const char *aliases()
 
 const char **description(struct dt_iop_module_t *self)
 {
-  return dt_iop_set_description(self, _("a color grading tool improved from ASC CDL"
+  return dt_iop_set_description(self, _("a color grading tool improved from ASC CDL\n"
                                         "using masks to split shadows and highlights properly"),
                                       _("corrective or creative"),
                                       _("linear, RGB, scene-referred"),

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -180,8 +180,8 @@ const char *aliases()
 
 const char **description(struct dt_iop_module_t *self)
 {
-  return dt_iop_set_description(self, _("a color grading tool improved from ASC CDL\n"
-                                        "using masks to split shadows and highlights properly"),
+  return dt_iop_set_description(self, _("color grading tools using alpha masks to separate\n"
+                                        "shadows, mid-tones and highlights"),
                                       _("corrective or creative"),
                                       _("linear, RGB, scene-referred"),
                                       _("non-linear, RGB"),

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -180,7 +180,7 @@ const char *aliases()
 
 const char **description(struct dt_iop_module_t *self)
 {
-  return dt_iop_set_description(self, _("a color-grading tools improved from ASC CDL"
+  return dt_iop_set_description(self, _("a color grading tool improved from ASC CDL"
                                         "using masks to split shadows and highlights properly"),
                                       _("corrective or creative"),
                                       _("linear, RGB, scene-referred"),


### PR DESCRIPTION
To separate descriptions of two colorbalance modules. Texts were excerpted from user manual.

**Purpose:**

1. clearer module descriptions
2. translators could use different texts for two modules

**Replenish:**

I use a description style in zh_TW translation that could help users to realize each module's English name. And I add introductions for every module to help beginers. By separated it, colorbalance and colorbalancergb could have their own detailed descriptions. It won't break anything.

```
"Chinese module name | English module name\n"
"module introductions (excerpted from manual)"
```