### PR TITLE
Maintenance of some inline functions

### DIFF
--- a/src/common/math.h
+++ b/src/common/math.h
@@ -83,6 +83,12 @@ static inline float sqrf(const float a)
   return a * a;
 }
 
+// taken from rt code: calculate a * b + (1 - a) * c
+static inline float interpolatef(float a, float b, float c)
+{
+  return a * (b - c) + c;
+}
+
 // Kahan summation algorithm
 #ifdef _OPENMP
 #pragma omp declare simd aligned(c)

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -78,7 +78,7 @@ static inline gboolean feqf(const float v1, const float v2, const float eps)
 }
 
 // We don't want to use the SIMD version sqf() in cases we might access unaligned memory
-static inline float sqrf(float a)
+static inline float sqrf(const float a)
 {
   return a * a;
 }

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -94,8 +94,6 @@
 // define to get debugging output
 #undef ASHIFT_DEBUG
 
-#define SQR(a) ((a) * (a))
-
 // maximum number of drawn lines that can be saved in parameters
 // any change in this value needs to upgrade parameters version !
 #define MAX_SAVED_LINES 50
@@ -2495,7 +2493,7 @@ static double crop_fitness(double *params, void *data)
       I[1] /= I[2];
 
       // calculate distance from I to P
-      const float d2 = SQR(P[0] - I[0]) + SQR(P[1] - I[1]);
+      const float d2 = sqrf(P[0] - I[0]) + sqrf(P[1] - I[1]);
 
       // the minimum distance over all intersection points
       d2min = MIN(d2min, d2);
@@ -2768,7 +2766,7 @@ static void crop_adjust(dt_iop_module_t *module, const dt_iop_ashift_params_t *c
       I[1] /= I[2];
 
       // calculate distance from I to P
-      const float d2 = SQR(P[0] - I[0]) + SQR(P[1] - I[1]);
+      const float d2 = sqrf(P[0] - I[0]) + sqrf(P[1] - I[1]);
 
       // the minimum distance over all intersection points
       d2min = MIN(d2min, d2);

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2022 darktable developers.
+    Copyright (C) 2010-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -113,11 +113,6 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
 /*==================================================================================
  * begin raw therapee code, hg checkout of march 09, 2016 branch master.
  *==================================================================================*/
-
-static inline float _inlimits(const float a, const float b, const float c)
-{
-  return MAX(b, MIN(a, c));
-}
 
 ////////////////////////////////////////////////////////////////
 //
@@ -1036,10 +1031,10 @@ void process(
               powVblock *= vblock;
             }
             const float bslim = 3.99; // max allowed CA shift
-            lblockshifts[0][0] = _inlimits(lblockshifts[0][0], -bslim, bslim);
-            lblockshifts[0][1] = _inlimits(lblockshifts[0][1], -bslim, bslim);
-            lblockshifts[1][0] = _inlimits(lblockshifts[1][0], -bslim, bslim);
-            lblockshifts[1][1] = _inlimits(lblockshifts[1][1], -bslim, bslim);
+            lblockshifts[0][0] = CLAMPF(lblockshifts[0][0], -bslim, bslim);
+            lblockshifts[0][1] = CLAMPF(lblockshifts[0][1], -bslim, bslim);
+            lblockshifts[1][0] = CLAMPF(lblockshifts[1][0], -bslim, bslim);
+            lblockshifts[1][1] = CLAMPF(lblockshifts[1][1], -bslim, bslim);
           } // end of setting CA shift parameters
 
 
@@ -1209,7 +1204,7 @@ void process(
       for(int col = firstCol; col < width; col += 2)
       {
         nongreen[(row / 2) * h_width + col / 2] = (in[row * width + col] <= 1.0f || oldraw[row * h_width + col / 2] <= 1.0f)
-          ? 1.0f : _inlimits(oldraw[row * h_width + col / 2] / in[row * width + col], 0.5f, 2.0f);
+          ? 1.0f : CLAMPF(oldraw[row * h_width + col / 2] / in[row * width + col], 0.5f, 2.0f);
       }
     }
 

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -118,14 +118,6 @@ static inline float _inlimits(const float a, const float b, const float c)
 {
   return MAX(b, MIN(a, c));
 }
-static inline float _intp(const float a, const float b, const float c)
-{
-  // calculate a * b + (1 - a) * c
-  // following is valid:
-  // _intp(a, b+x, c+x) = _intp(a, b, c) + x
-  // _intp(a, b*x, c*x) = _intp(a, b, c) * x
-  return a * (b - c) + c;
-}
 
 ////////////////////////////////////////////////////////////////
 //
@@ -1086,12 +1078,12 @@ void process(
             for(int cc = 4 + (FC(rr, 2, filters) & 1), c = FC(rr, cc, filters); cc < cc1 - 4; cc += 2)
             {
               // perform CA correction using colour ratios or colour differences
-              const float Ginthfloor = _intp(shifthfrac[c], rgb[1][(rr + shiftvfloor[c]) * ts + cc + shifthceil[c]],
+              const float Ginthfloor = interpolatef(shifthfrac[c], rgb[1][(rr + shiftvfloor[c]) * ts + cc + shifthceil[c]],
                                       rgb[1][(rr + shiftvfloor[c]) * ts + cc + shifthfloor[c]]);
-              const float Ginthceil = _intp(shifthfrac[c], rgb[1][(rr + shiftvceil[c]) * ts + cc + shifthceil[c]],
+              const float Ginthceil = interpolatef(shifthfrac[c], rgb[1][(rr + shiftvceil[c]) * ts + cc + shifthceil[c]],
                                      rgb[1][(rr + shiftvceil[c]) * ts + cc + shifthfloor[c]]);
               // Gint is bilinear interpolation of G at CA shift point
-              const float Gint = _intp(shiftvfrac[c], Ginthceil, Ginthfloor);
+              const float Gint = interpolatef(shiftvfrac[c], Ginthceil, Ginthfloor);
 
               // determine R/B at grid points using colour differences at shift point plus interpolated G
               // value at grid point
@@ -1116,14 +1108,14 @@ void process(
               const float grbdiffold = rgb[1][indx] - rgb[c][indx];
 
               // interpolate colour difference from optical R/B locations to grid locations
-              const float grbdiffinthfloor = _intp(shifthfrac[c],
+              const float grbdiffinthfloor = interpolatef(shifthfrac[c],
                            grbdiff[(indx - GRBdir[1][c]) >> 1],
                            grbdiff[indx >> 1]);
-              const float grbdiffinthceil  = _intp(shifthfrac[c],
+              const float grbdiffinthceil  = interpolatef(shifthfrac[c],
                            grbdiff[((rr - GRBdir[0][c]) * ts + cc - GRBdir[1][c]) >> 1],
                            grbdiff[((rr - GRBdir[0][c]) * ts + cc) >> 1]);
               // grbdiffint is bilinear interpolation of G-R/G-B at grid point
-              float grbdiffint = _intp(shiftvfrac[c], grbdiffinthceil, grbdiffinthfloor);
+              float grbdiffint = interpolatef(shiftvfrac[c], grbdiffinthceil, grbdiffinthfloor);
 
               // now determine R/B at grid points using interpolated colour differences and interpolated G
               // value at grid point

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -114,10 +114,6 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
  * begin raw therapee code, hg checkout of march 09, 2016 branch master.
  *==================================================================================*/
 
-static inline float _sqrf(float x)
-{
-  return (x * x);
-}
 static inline float _inlimits(const float a, const float b, const float c)
 {
   return MAX(b, MIN(a, c));
@@ -540,16 +536,16 @@ void process(
             for(int cc = 3 + (FC(rr, 3, filters) & 1), indx = rr * ts + cc, c = FC(rr, cc, filters); cc < cc1 - 3; cc += 2, indx += 2)
             {
               // compute directional weights using image gradients
-              const float wtu = 1.f / _sqrf(eps + fabsf(rgb[1][indx + v1] - rgb[1][indx - v1])
+              const float wtu = 1.f / sqrf(eps + fabsf(rgb[1][indx + v1] - rgb[1][indx - v1])
                                     + fabsf(rgb[c][indx] - rgb[c][indx - v2])
                                     + fabsf(rgb[1][indx - v1] - rgb[1][indx - v3]));
-              const float wtd = 1.f / _sqrf(eps + fabsf(rgb[1][indx - v1] - rgb[1][indx + v1])
+              const float wtd = 1.f / sqrf(eps + fabsf(rgb[1][indx - v1] - rgb[1][indx + v1])
                                     + fabsf(rgb[c][indx] - rgb[c][indx + v2])
                                     + fabsf(rgb[1][indx + v1] - rgb[1][indx + v3]));
-              const float wtl = 1.f / _sqrf(eps + fabsf(rgb[1][indx + 1] - rgb[1][indx - 1])
+              const float wtl = 1.f / sqrf(eps + fabsf(rgb[1][indx + 1] - rgb[1][indx - 1])
                                     + fabsf(rgb[c][indx] - rgb[c][indx - 2])
                                     + fabsf(rgb[1][indx - 1] - rgb[1][indx - 3]));
-              const float wtr = 1.f / _sqrf(eps + fabsf(rgb[1][indx - 1] - rgb[1][indx + 1])
+              const float wtr = 1.f / sqrf(eps + fabsf(rgb[1][indx - 1] - rgb[1][indx + 1])
                                     + fabsf(rgb[c][indx] - rgb[c][indx + 2])
                                     + fabsf(rgb[1][indx + 1] - rgb[1][indx + 3]));
 
@@ -680,7 +676,7 @@ void process(
               if(fabsf(CAshift[dir][c]) < 2.0f)
               {
                 blockavethr[dir][c] += CAshift[dir][c];
-                blocksqavethr[dir][c] += _sqrf(CAshift[dir][c]);
+                blocksqavethr[dir][c] += sqrf(CAshift[dir][c]);
                 blockdenomthr[dir][c] += 1;
               }
               // evaluate the shifts to the location that minimizes CA within the tile
@@ -718,7 +714,7 @@ void process(
             if(blockdenom[dir][c])
             {
               blockvar[dir][c]
-                  = blocksqave[dir][c] / blockdenom[dir][c] - _sqrf(blockave[dir][c] / blockdenom[dir][c]);
+                  = blocksqave[dir][c] / blockdenom[dir][c] - sqrf(blockave[dir][c] / blockdenom[dir][c]);
             }
             else
             {
@@ -820,8 +816,8 @@ void process(
 
                 // now prepare coefficient matrix; use only data points within caautostrength/2 std devs of
                 // zero
-                if(_sqrf(bstemp[0]) > caautostrength * blockvar[0][c]
-                   || _sqrf(bstemp[1]) > caautostrength * blockvar[1][c])
+                if(sqrf(bstemp[0]) > caautostrength * blockvar[0][c]
+                   || sqrf(bstemp[1]) > caautostrength * blockvar[1][c])
                 {
                   continue;
                 }

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -556,7 +556,6 @@ static void green_equilibration_favg(
 
 // xtrans_interpolate adapted from dcraw 9.20
 
-#define SQR(x) ((x) * (x))
 // tile size, optimized to keep data in L2 cache
 #define TS 122
 
@@ -879,8 +878,8 @@ static void xtrans_markesteijn_interpolate(
                 // For 2nd and 3rd hori+vert passes, create a sum of
                 // steepness for both cardinal directions.
                 if(d > 1)
-                  diff[d] += SQR(rfx[i << c][1] - rfx[-(i << c)][1] - rfx[i << c][h] + rfx[-(i << c)][h])
-                             + SQR(g);
+                  diff[d] += sqrf(rfx[i << c][1] - rfx[-(i << c)][1] - rfx[i << c][h] + rfx[-(i << c)][h])
+                             + sqrf(g);
               }
               if((d < 2) || (d & 1))
               { // output for passes 0, 1, 3, 5
@@ -981,9 +980,9 @@ static void xtrans_markesteijn_interpolate(
           for(int col = pad_drv; col < mcol - pad_drv; col++)
           {
             const float(*yfx)[TS][TS] = (float(*)[TS][TS]) & yuv[0][row][col];
-            drv[d][row][col] = SQR(2 * yfx[0][0][0] - yfx[0][0][f] - yfx[0][0][-f])
-                               + SQR(2 * yfx[1][0][0] - yfx[1][0][f] - yfx[1][0][-f])
-                               + SQR(2 * yfx[2][0][0] - yfx[2][0][f] - yfx[2][0][-f]);
+            drv[d][row][col] = sqrf(2 * yfx[0][0][0] - yfx[0][0][f] - yfx[0][0][-f])
+                               + sqrf(2 * yfx[1][0][0] - yfx[1][0][f] - yfx[1][0][-f])
+                               + sqrf(2 * yfx[2][0][0] - yfx[2][0][f] - yfx[2][0][-f]);
           }
       }
 
@@ -1876,7 +1875,7 @@ static void xtrans_fdc_interpolate(
               float g = 2 * rfx[0][1] - rfx[i << c][1] - rfx[-(i << c)][1];
               color[h][d] = g + rfx[i << c][h] + rfx[-(i << c)][h];
               if(d > 1)
-                diff[d] += SQR(rfx[i << c][1] - rfx[-(i << c)][1] - rfx[i << c][h] + rfx[-(i << c)][h]) + SQR(g);
+                diff[d] += sqrf(rfx[i << c][1] - rfx[-(i << c)][1] - rfx[i << c][h] + rfx[-(i << c)][h]) + sqrf(g);
             }
             if(d > 1 && (d & 1))
               if(diff[d - 1] < diff[d])
@@ -1984,9 +1983,9 @@ static void xtrans_fdc_interpolate(
           for(int col = pad_drv; col < mcol - pad_drv; col++)
           {
             float(*yfx)[TS][TS] = (float(*)[TS][TS]) & yuv[0][row][col];
-            drv[d][row][col] = SQR(2 * yfx[0][0][0] - yfx[0][0][f] - yfx[0][0][-f])
-                               + SQR(2 * yfx[1][0][0] - yfx[1][0][f] - yfx[1][0][-f])
-                               + SQR(2 * yfx[2][0][0] - yfx[2][0][f] - yfx[2][0][-f]);
+            drv[d][row][col] = sqrf(2 * yfx[0][0][0] - yfx[0][0][f] - yfx[0][0][-f])
+                               + sqrf(2 * yfx[1][0][0] - yfx[1][0][f] - yfx[1][0][-f])
+                               + sqrf(2 * yfx[2][0][0] - yfx[2][0][f] - yfx[2][0][-f]);
           }
       }
 

--- a/src/iop/dual_demosaic.c
+++ b/src/iop/dual_demosaic.c
@@ -95,7 +95,7 @@ static void dual_demosaic(
     {
       const int oidx = 4 * idx;
       for(int c = 0; c < 4; c++)
-        rgb_data[oidx + c] = _intp(blend[idx], rgb_data[oidx + c], vng_image[oidx + c]);
+        rgb_data[oidx + c] = interpolatef(blend[idx], rgb_data[oidx + c], vng_image[oidx + c]);
     }
   }
 

--- a/src/iop/lmmse_demosaic.c
+++ b/src/iop/lmmse_demosaic.c
@@ -62,11 +62,6 @@
 #define w3 (LMMSE_GRP * 3)
 #define w4 (LMMSE_GRP * 4)
 
-static inline float _limf(float x, float min, float max)
-{
-  return fmaxf(min, fminf(x, max));
-}
-
 static inline float _median3f(float x0, float x1, float x2)
 {
   return fmaxf(fminf(x0,x1), fminf(x2, fmaxf(x0,x1)));
@@ -230,14 +225,14 @@ static void lmmse_demosaic(
             float *hdiff = qix[0] + rr * LMMSE_GRP + cc;
             hdiff[0] = -0.25f * (cfa[ -2] + cfa[ 2]) + 0.5f * (cfa[ -1] + cfa[0] + cfa[ 1]);
             const float Y0 = v0 + 0.5f * hdiff[0];
-            hdiff[0] = (cfa[0] > 1.75f * Y0) ? _median3f(hdiff[0], cfa[ -1], cfa[ 1]) : _limf(hdiff[0], 0.0f, 1.0f);
+            hdiff[0] = (cfa[0] > 1.75f * Y0) ? _median3f(hdiff[0], cfa[ -1], cfa[ 1]) : CLAMPF(hdiff[0], 0.0f, 1.0f);
             hdiff[0] -= cfa[0];
 
             // vertical
             float *vdiff = qix[1] + rr * LMMSE_GRP + cc;
             vdiff[0] = -0.25f * (cfa[-w2] + cfa[w2]) + 0.5f * (cfa[-w1] + cfa[0] + cfa[w1]);
             const float Y1 = v0 + 0.5f * vdiff[0];
-            vdiff[0] = (cfa[0] > 1.75f * Y1) ? _median3f(vdiff[0], cfa[-w1], cfa[w1]) : _limf(vdiff[0], 0.0f, 1.0f);
+            vdiff[0] = (cfa[0] > 1.75f * Y1) ? _median3f(vdiff[0], cfa[-w1], cfa[w1]) : CLAMPF(vdiff[0], 0.0f, 1.0f);
             vdiff[0] -= cfa[0];
           }
 
@@ -249,8 +244,8 @@ static void lmmse_demosaic(
             float *vdiff = qix[1] + rr * LMMSE_GRP + ccc;
             hdiff[0] = 0.25f * (cfa[ -2] + cfa[ 2]) - 0.5f * (cfa[ -1] + cfa[0] + cfa[ 1]);
             vdiff[0] = 0.25f * (cfa[-w2] + cfa[w2]) - 0.5f * (cfa[-w1] + cfa[0] + cfa[w1]);
-            hdiff[0] = _limf(hdiff[0], -1.0f, 0.0f) + cfa[0];
-            vdiff[0] = _limf(vdiff[0], -1.0f, 0.0f) + cfa[0];
+            hdiff[0] = CLAMPF(hdiff[0], -1.0f, 0.0f) + cfa[0];
+            vdiff[0] = CLAMPF(vdiff[0], -1.0f, 0.0f) + cfa[0];
           }
         }
 

--- a/src/iop/rcd_demosaic.c
+++ b/src/iop/rcd_demosaic.c
@@ -80,15 +80,6 @@
 #define eps 1e-5f              // Tolerance to avoid dividing by zero
 #define epssq 1e-10f
 
-static inline float _intp(float a, float b, float c)
-{   // taken from rt code
-    // calculate a * b + (1 - a) * c
-    // following is valid:
-    // intp(a, b+x, c+x) = intp(a, b, c) + x
-    // intp(a, b*x, c*x) = intp(a, b, c) * x
-    return a * (b - c) + c;
-}
-
 // We might have negative data in input and also want to normalise
 static inline float _safe_in(float a, float scale)
 {
@@ -455,7 +446,7 @@ static void rcd_demosaic(
             const float VH_Neighbourhood_Value = 0.25f * (VH_Dir[indx - w1 - 1] + VH_Dir[indx - w1 + 1] + VH_Dir[indx + w1 - 1] + VH_Dir[indx + w1 + 1]);
             const float VH_Disc = (fabs(0.5f - VH_Central_Value) < fabs(0.5f - VH_Neighbourhood_Value)) ? VH_Neighbourhood_Value : VH_Central_Value;
 
-            rgb[1][indx] = _intp(VH_Disc, H_Est, V_Est);
+            rgb[1][indx] = interpolatef(VH_Disc, H_Est, V_Est);
           }
         }
 
@@ -509,7 +500,7 @@ static void rcd_demosaic(
             const float Q_Est = (NE_Grad * SW_Est + SW_Grad * NE_Est) / (NE_Grad + SW_Grad);
 
             // R@B and B@R interpolation
-            rgb[c][indx] = rgb[1][indx] + _intp(PQ_Disc, Q_Est, P_Est);
+            rgb[c][indx] = rgb[1][indx] + interpolatef(PQ_Disc, Q_Est, P_Est);
           }
         }
 
@@ -555,7 +546,7 @@ static void rcd_demosaic(
               const float H_Est = (E_Grad * W_Est + W_Grad * E_Est) / (E_Grad + W_Grad);
 
               // R@G and B@G interpolation
-              rgb[c][indx] = rgb1 + _intp(VH_Disc, H_Est, V_Est);
+              rgb[c][indx] = rgb1 + interpolatef(VH_Disc, H_Est, V_Est);
             }
           }
         }


### PR DESCRIPTION
- introduce static inline float interpolatef(float a, float b, float c)
  calculates a * b + (1 - a) * c
- make use of sqrf() where possible instead of redefinitions
- make use of CLAMPF()

Something for the compiler experts: @ralfbrown maybe you

In math.h we have two definitions doing practically the same

```
#define CLAMPF(a, mn, mx) ((a) >= (mn) ? ((a) <= (mx) ? (a) : (mx)) : (mn))
```

and 
```
static inline float clamp_range_f(const float x, const float low, const float high)
{
  return x > high ? high : (x < low ? low : x);
}
```

Any reason for having two? Is one "better" or "correct"? Any difference for vectorizing?

