### PR TITLE
Fix CIELUV Hue Ring for histogram profile = linear prophoto RGB.

### DIFF
--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -475,7 +475,7 @@ static void _lib_histogram_vectorscope_bkgd
 
   const float vertex_rgb[6][4] DT_ALIGNED_PIXEL = {{1.f, 0.f, 0.f}, {1.f, 1.f, 0.f},
                                                    {0.f, 1.f, 0.f}, {0.f, 1.f, 1.f},
-                                                   {0.f, 0.f, 1.f}, {1.f, 0.f, 1.f} };
+                                                   {0.05f, 0.05f, 0.95f}, {1.f, 0.f, 1.f} };
 
   float max_radius = 0.f;
   const dt_lib_histogram_vectorscope_type_t vs_type = d->vectorscope_type;
@@ -483,6 +483,7 @@ static void _lib_histogram_vectorscope_bkgd
   // chromaticities for drawing both hue ring and graph
   // NOTE: As ProPhoto's blue primary is very dark (and imaginary), it
   // maps to a very small radius in CIELuv.
+  // Changing RGB cube point to {0.05f, 0.05f, 0.95f}, will fix this.
   cairo_pattern_t *p = cairo_pattern_create_mesh();
   // initialize to make gcc-7 happy
   dt_aligned_pixel_t rgb_display = { 0.f };


### PR DESCRIPTION
Changing RGB Cube point from `{0.f, 0.f, 1.f}` to `{0.05f, 0.05f, 0.95f}` in `/libs/histogram.c`
```
  const float vertex_rgb[6][4] DT_ALIGNED_PIXEL = {{1.f, 0.f, 0.f}, {1.f, 1.f, 0.f},
                                                   {0.f, 1.f, 0.f}, {0.f, 1.f, 1.f},
                                                   {0.05f, 0.05f, 0.95f}, {1.f, 0.f, 1.f} };
```
Will fix https://github.com/darktable-org/darktable/issues/13532#issue-1571295119.

Discussion is here: https://discuss.pixls.us/t/edit-still-a-problem-dt-4-3-master-vectorscope-cieluv-missing-point-in-hue-ring/35153.