### PR TITLE
imageio: add OpenMP to XCF export

### DIFF
--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -503,7 +503,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
             for(int x = 0; x < w; x++, out += layers)
             {
               for(int c = 0; c < layers; c++)
-                out[c] = CLIP(in[x]) * 65535.0f + 0.5f;
+                out[c] = (uint16_t)roundf(CLIP(in[x]) * 65535.0f);
             }
 
             if(TIFFWriteScanline(tif, rowdata, y, 0) == -1)
@@ -523,7 +523,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
             for(int x = 0; x < w; x++, out += layers)
             {
               for(int c = 0; c < layers; c++)
-                out[c] = CLIP(in[x]) * 255.0f + 0.5f;
+                out[c] = (uint8_t)roundf(CLIP(in[x]) * 255.0f);
             }
 
             if(TIFFWriteScanline(tif, rowdata, y, 0) == -1)

--- a/src/imageio/format/xcf.c
+++ b/src/imageio/format/xcf.c
@@ -196,15 +196,25 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
         {
           channel_data = malloc(sizeof(uint8_t) * d->global.width * d->global.height);
           uint8_t *ch = (uint8_t *)channel_data;
-          for(size_t i = 0; i < (size_t)d->global.width * d->global.height; i++)
-            ch[i] = CLAMP((int)(raster_mask[i] * 255.0), 0, 255);
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(ch, d, raster_mask) \
+  schedule(simd:static)
+#endif
+          for(size_t i = 0; i < (size_t)d->global.width * d->global.height; ++i)
+            ch[i] = (uint8_t)roundf(CLIP(raster_mask[i]) * 255.0f);
         }
         else if(d->bpp == 16)
         {
           channel_data = malloc(sizeof(uint16_t) * d->global.width * d->global.height);
           uint16_t *ch = (uint16_t *)channel_data;
-          for(size_t i = 0; i < (size_t)d->global.width * d->global.height; i++)
-            ch[i] = CLAMP((int)(raster_mask[i] * 65535.0), 0, 65535);
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(ch, d, raster_mask) \
+  schedule(simd:static)
+#endif
+          for(size_t i = 0; i < (size_t)d->global.width * d->global.height; ++i)
+            ch[i] = (uint16_t)roundf(CLIP(raster_mask[i]) * 65535.0f);
         }
         else if(d->bpp == 32)
         {


### PR DESCRIPTION
Also made the TIFF mask export calculation identical to the XCF one.