### PR TITLE
Bugfix: make sure correct HLR chroma corrections

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -335,7 +335,7 @@ highlights_initmask (read_only image2d_t in, global char *inmask,
 
   float val = fmax(0.0f, read_imagef(in, sampleri, (int2)(col, row)).x);
   const int color = (filters == 9u) ? FCxtrans(row, col, xtrans) : FC(row, col, filters);
-  const int idx = color*psize + mad24(row/3, pwidth, col/3);
+  const size_t idx = color*psize + mad24(row/3, pwidth, col/3);
 
   if((val >= clips[color]) && (inmask[idx] == 0))
   {
@@ -399,7 +399,7 @@ highlights_chroma (read_only image2d_t in, global char *mask, global float *accu
                    const int width, const int height,
                    const int pwidth, const int psize, 
                    const int filters, global const unsigned char (*const xtrans)[6],
-                   global const float *clips, global const float *dark)
+                   global const float *clips)
 {
   const int row = get_global_id(0);
 
@@ -410,11 +410,11 @@ highlights_chroma (read_only image2d_t in, global char *mask, global float *accu
 
   for(int col = 3; col < width-3; col++)
   {
-    const int idx = mad24(row, width, col);
+    const size_t idx = mad24(row, width, col);
     const int color = (filters == 9u) ? FCxtrans(row, col, xtrans) : FC(row, col, filters);
     const float inval = fmax(0.0f, read_imagef(in, sampleri, (int2)(col, row)).x);
-    const int px = color * psize + mad24(row/3, pwidth, col/3);
-    if(mask[px] && (inval > dark[color]) && (inval < clips[color]))
+    const size_t px = color * psize + mad24(row/3, pwidth, col/3);
+    if(mask[px] && (inval > 0.2f*clips[color]) && (inval < clips[color]))
     {
       const float ref = _calc_refavg(in, xtrans, filters, row, col, width);
       sum[color] += inval - ref;
@@ -423,8 +423,8 @@ highlights_chroma (read_only image2d_t in, global char *mask, global float *accu
   }
   for(int c = 0; c < 3; c++)
   {
-    accu[row*6 + c] = sum[c];
-    accu[row*6 + 3 + c] = cnt[c];
+    accu[row*8 + c] = sum[c];
+    accu[row*8 + 3 + c] = cnt[c];
   }
 }
 

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -90,13 +90,13 @@ static inline char _mask_dilated(const char *in, const size_t w1)
 
   const size_t w2 = 2*w1;
   const size_t w3 = 3*w1;
-  return  in[-w3-2] | in[-w3-1] | in[-w3]   | in[-w3+1] | in[-w3+2] |
+  return (in[-w3-2] | in[-w3-1] | in[-w3]   | in[-w3+1] | in[-w3+2] |
           in[-w2-3] | in[-w2-2] | in[-w2-1] | in[-w2]   | in[-w2+1] | in[-w2+2] | in[-w2+3] |
           in[-w1-3] | in[-w1-2] | in[-w1+2] | in[-w1+3] |
           in[-3]    | in[-2]    | in[2]     | in[3]     |
           in[w1-3]  | in[w1-2]  | in[w1+2]  | in[w1+3]  |
           in[w2-3]  | in[w2-2]  | in[w2-1]  | in[w2]    | in[w2+1]  | in[w2+2]  | in[w2+3] |
-          in[w3-2]  | in[w3-1]  | in[w3]    | in[w3+1]  | in[w3+2];
+          in[w3-2]  | in[w3-1]  | in[w3]    | in[w3+1]  | in[w3+2]) ? 1 : 0;
 }
 
 
@@ -292,12 +292,12 @@ static float *_process_opposed(
         {
           char mbuff[4] = { 0, 0, 0, 0 };
           const size_t grp = 3 * (mrow * roi_in->width + mcol);
-          for(int y = -1; y < 1; y++)
+          for(int y = -1; y < 2; y++)
           {
-            for(int x = -1; x < 1; x++)
+            for(int x = -1; x < 2; x++)
             {
               const size_t idx = grp + y * roi_in->width + x;
-              const int color = (filters == 9u) ? FCxtrans(mrow+y, mcol+y, roi_in, xtrans) : FC(mrow+y, mcol+x, filters);
+              const int color = (filters == 9u) ? FCxtrans(mrow+y, mcol+x, roi_in, xtrans) : FC(mrow+y, mcol+x, filters);
               mbuff[color] += (fmaxf(0.0f, input[idx]) >= clips[color]) ? 1 : 0;
             }
           }

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -38,7 +38,7 @@
    Again the algorithm has been developed in collaboration by @garagecoder and @Iain from gmic team and @jenshannoschwalm from dt.
 */
 
-static uint64_t _opposed_hash(dt_dev_pixelpipe_iop_t *piece)
+static uint64_t _opposed_parhash(dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_buffer_dsc_t *dsc = &piece->pipe->dsc;
   dt_iop_highlights_data_t *d = (dt_iop_highlights_data_t *)piece->data;
@@ -58,7 +58,14 @@ static uint64_t _opposed_hash(dt_dev_pixelpipe_iop_t *piece)
   for(size_t ip = 0; ip < sizeof(d->clip); ip++)
     hash = ((hash << 5) + hash) ^ pstr[ip];
 
-  pstr = (char *) &piece->pipe->image.id;
+  return hash;
+}
+
+static uint64_t _opposed_hash(dt_dev_pixelpipe_iop_t *piece)
+{
+  uint64_t hash = _opposed_parhash(piece);
+
+  char *pstr = (char *) &piece->pipe->image.id;
   for(size_t ip = 0; ip < sizeof(piece->pipe->image.id); ip++)
     hash = ((hash << 5) + hash) ^ pstr[ip];
 
@@ -213,8 +220,8 @@ static void _process_linear_opposed(
         for(int c=0; c<3; c++)
           img_oppchroma[c] = chrominance[c];
         img_opphash = opphash;
-        dt_print(DT_DEBUG_PIPE, "[opposed chroma cache CPU] red: %8.6f (%.0f), green: %8.6f (%.0f), blue: %8.6f (%.0f) for opphash%22" PRIu64 "\n",
-          chrominance[0], cnts[0], chrominance[1], cnts[1], chrominance[2], cnts[2], opphash);
+        dt_print(DT_DEBUG_PIPE, "[opposed chroma cache CPU] red: %8.6f (%.0f), green: %8.6f (%.0f), blue: %8.6f (%.0f) for hash%22" PRIu64 "\n",
+          chrominance[0], cnts[0], chrominance[1], cnts[1], chrominance[2], cnts[2], _opposed_parhash(piece));
       }
     }
     dt_free_align(mask);
@@ -361,8 +368,8 @@ static float *_process_opposed(
         for(int c=0; c<3; c++)
           img_oppchroma[c] = chrominance[c];
         img_opphash = opphash;
-        dt_print(DT_DEBUG_PIPE, "[opposed chroma cache CPU] red: %8.6f (%.0f), green: %8.6f (%.0f), blue: %8.6f (%.0f) for opphash%22" PRIu64 "\n",
-          chrominance[0], cnts[0], chrominance[1], cnts[1], chrominance[2], cnts[2], opphash);
+        dt_print(DT_DEBUG_PIPE, "[opposed chroma cache CPU] red: %8.6f (%.0f), green: %8.6f (%.0f), blue: %8.6f (%.0f) for hash%22" PRIu64 "\n",
+          chrominance[0], cnts[0], chrominance[1], cnts[1], chrominance[2], cnts[2], _opposed_parhash(piece));
       }
     }
     dt_free_align(mask);
@@ -547,8 +554,8 @@ static cl_int process_opposed_cl(
       for(int c=0; c<3; c++)
         img_oppchroma[c] = chrominance[c];
       img_opphash = opphash;
-      dt_print(DT_DEBUG_PIPE, "[opposed chroma cache GPU] red: %8.6f (%.0f), green: %8.6f (%.0f), blue: %8.6f (%.0f) for opphash%22" PRIu64 "\n",
-        chrominance[0], claccu[1], chrominance[1], claccu[3], chrominance[2], claccu[5], opphash);
+      dt_print(DT_DEBUG_PIPE, "[opposed chroma cache GPU] red: %8.6f (%.0f), green: %8.6f (%.0f), blue: %8.6f (%.0f) for hash%22" PRIu64 "\n",
+        chrominance[0], claccu[1], chrominance[1], claccu[3], chrominance[2], claccu[5], _opposed_parhash(piece));
     }
   }
 


### PR DESCRIPTION
See #13632 and #13646

In some situations the calculated chroma corrections are vastly wrong. The first idea was about precision errors because of using floats for summing up data and the counters, that could be ruled out.

The reported errors could be related (this is my current understanding) to:
1. improper data sampling because of the relaxed global memory policy, this could still be the case although unlikely because the errors keep happening after correcting data to be always in a gpu cacheline. (It might be we have to intruce a `lock-per-line`)
2. Other issues on AMD often pinpointed to a) float data not being initialized or b) math errors like div by zero. (Nvidia never had problems on this) The code has been reviewed for strictly avoiding this.
3. The for_each_channel usage was wrong in many parts of the code as we don't calc 4-channel pixels but we do a loop over a "color-range" of 0-2. This could have resulted to a div-by-zero.
4. The dark-level was a code left-over, it's safe to use 0.2 of clip in all cases. (This is the only maths change in this pr. The dark clips lead to problems in very few images if there were a lot of black-to-white transitions)
5. It is very good to avoid chroma corrections derived from a very small number of border pixels, we make sure now to have at least a "sensible" number.

Thanks to many people having tested #13646, could i ask you to check again @groutr @MStraeten @kofa73 @gi-man @sarunasb ?

To test this:
1. Use the "duck-at-the-pond" image from #13632 
2. Start dt either with `--disable-opencl` or not
3. use `-d pipe` and watch out for reports like `[opposed chroma cache GPU/CPU]`
4. Compare the values reported, they must be **"almost identical"** for CPU vs GPU, any difference must be concidered to be a bug.
5. If you made sure: rawprepare, temperature and clip in hlr are all set to default, and using opposed method your results should be
```
   13.2351 [opposed chroma cache GPU] red: 1.056767 (18406), green: -0.025674 (123257), blue: -0.394672 (16525) for opphash  11498776663581970802
    3.7372 [opposed chroma cache CPU] red: 1.056766 (18406), green: -0.025674 (123257), blue: -0.394673 (16525) for opphash  11498776663581970802
```

A sidenote, the algo has also changed slightly, the results might be slightly different from master but tested on this pr the reports must be identical for GPU and CPU
 