### PR TITLE
[CI] macOS: Explictly install pkg-config

### DIFF
--- a/.ci/Brewfile
+++ b/.ci/Brewfile
@@ -1,5 +1,5 @@
 #    This file is part of darktable.
-#    copyright (c) 2016 Roman Lebedev.
+#    Copyright (C) 2016-2023 darktable developers.
 #
 #    darktable is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
 #    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 
 brew 'cmake'
+brew 'pkg-config'
 brew 'desktop-file-utils'
 brew 'exiv2'
 brew 'gettext'


### PR DESCRIPTION
Looks like pkg-config is no longer provided implicitly (not installed in macOS image or as a dependency of other packages?)