### PR TITLE
[imageio][performance] Add OpenMP to the PNG loader

### DIFF
--- a/src/imageio/imageio_png.c
+++ b/src/imageio/imageio_png.c
@@ -199,22 +199,44 @@ dt_imageio_retval_t dt_imageio_open_png(dt_image_t *img, const char *filename, d
     return DT_IMAGEIO_LOAD_FAILED;
   }
 
-  for(size_t j = 0; j < height; j++)
+  const size_t npixels = (size_t)width * height;
+
+  if(bpp < 16)
   {
-    if(bpp < 16)
-      for(size_t i = 0; i < width; i++)
-        for(int k = 0; k < 3; k++)
-          mipbuf[4 * (j * width + i) + k] = buf[3 * (j * width + i) + k] * (1.0f / 255.0f);
-    else
-      for(size_t i = 0; i < width; i++)
-        for(int k = 0; k < 3; k++)
-          mipbuf[4 * (j * width + i) + k] = (256.0f * buf[2 * (3 * (j * width + i) + k)]
-                                             + buf[2 * (3 * (j * width + i) + k) + 1]) * (1.0f / 65535.0f);
+    const float normalizer = 1.0f / 255.0f;
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(npixels, normalizer, buf) \
+  shared(mipbuf)
+#endif
+    for(size_t index = 0; index < npixels; index++)
+    {
+      mipbuf[4 * index]     = buf[3 * index]     * normalizer;
+      mipbuf[4 * index + 1] = buf[3 * index + 1] * normalizer;
+      mipbuf[4 * index + 2] = buf[3 * index + 2] * normalizer;
+    }
+  }
+  else
+  {
+    const float normalizer = 1.0f / 65535.0f;
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(npixels, normalizer, buf) \
+  shared(mipbuf)
+#endif
+    for(size_t index = 0; index < npixels; index++)
+    {
+      mipbuf[4 * index]     = (buf[2 * (3 * index)]     * 256.0f + buf[2 * (3 * index)     + 1]) * normalizer;
+      mipbuf[4 * index + 1] = (buf[2 * (3 * index + 1)] * 256.0f + buf[2 * (3 * index + 1) + 1]) * normalizer;
+      mipbuf[4 * index + 2] = (buf[2 * (3 * index + 2)] * 256.0f + buf[2 * (3 * index + 1) + 1]) * normalizer;
+    }
   }
 
   dt_free_align(buf);
 
-  img->buf_dsc.cst = IOP_CS_RGB; // png is always RGB
+  img->buf_dsc.cst = IOP_CS_RGB; // PNG is always RGB
   img->buf_dsc.filters = 0u;
   img->flags &= ~DT_IMAGE_RAW;
   img->flags &= ~DT_IMAGE_S_RAW;


### PR DESCRIPTION
This PR significantly speeds up the conversion of decoded image data into the format required by darktable (4 x float32[0..1]).

For example, on my processor (a rather old Intel i7-6700HQ) on a test PNG image with a resolution of 24 MP, the following acceleration is observed:

- 8-bit data was converted in about 0.1 seconds without OpenMP and in 0.06 seconds with it
- 16-bit data - 0.26-0.27 sec without OpenMP and less than 0.05 sec with it

I don't really understand why the 8-bit data conversion speedup is less than expected, but at least it's still there.

On top of that, the code has been reformatted and the variables have been renamed to make the code more understandable.