### PR TITLE
Reduce verbosity for committing parameters

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1897,7 +1897,7 @@ void dt_iop_commit_params(dt_iop_module_t *module,
 
     free(str);
 
-    dt_print(DT_DEBUG_PARAMS | DT_DEBUG_PIPE, "[dt_iop_commit_params] [%s] committed for %s with hash %lu\n",
+    dt_print(DT_DEBUG_PARAMS, "[dt_iop_commit_params] [%s] committed for %s with hash %lu\n",
       dt_dev_pixelpipe_type_to_str(pipe->type), module->op, (long unsigned int)piece->hash);
   }
   // printf("commit params hash += module %s: %lu, enabled = %d\n", piece->module->op, piece->hash,


### PR DESCRIPTION
The info for commited params should only be shown if we want to check for params, just for DT_DEBUG_PIPE it's too much noise.