### PR TITLE
colorcontrast: optimize code and remove SSE

### DIFF
--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -34,10 +34,6 @@
 #include <gtk/gtk.h>
 #include <stdlib.h>
 
-#if defined(__SSE__)
-#include <xmmintrin.h>
-#endif
-
 DT_MODULE_INTROSPECTION(2, dt_iop_colorcontrast_params_t)
 
 typedef struct dt_iop_colorcontrast_params1_t
@@ -206,59 +202,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     }
   }
 }
-
-#if defined(__SSE__)
-void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const restrict ivoid,
-                  void *const restrict ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
-{
-  // this is called for preview and full pipe separately, each with its own pixelpipe piece.
-
-  // get our data struct:
-  const dt_iop_colorcontrast_params_t *const d = (dt_iop_colorcontrast_params_t *)piece->data;
-
-  // how many colors in our buffer?
-  if(!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece->colors,
-                                         ivoid, ovoid, roi_in, roi_out))
-    return; // image has been copied through to output and module's trouble flag has been updated
-
-  const __m128 scale = _mm_set_ps(1.0f, d->b_steepness, d->a_steepness, 1.0f);
-  const __m128 offset = _mm_set_ps(0.0f, d->b_offset, d->a_offset, 0.0f);
-  const __m128 min = _mm_set_ps(-INFINITY, -128.0f, -128.0f, -INFINITY);
-  const __m128 max = _mm_set_ps(INFINITY, 128.0f, 128.0f, INFINITY);
-
-  const float *const restrict in = (float*)ivoid;
-  float *const restrict out = (float*)ovoid;
-
-  // iterate over all output pixels (same coordinates as input)
-  const int npixels = roi_out->height * roi_out->width;
-  if(d->unbound)
-  {
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(in, out, offset, npixels, scale) \
-  schedule(static)
-#endif
-    for(int j = 0; j < 4 * npixels; j += 4)
-    {
-      _mm_stream_ps(out + j, offset + scale * _mm_load_ps(in + j));
-    }
-  }
-  else
-  {
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(in, out, max, min, offset, npixels, scale) \
-  schedule(static)
-#endif
-    for(int j = 0; j < 4 * npixels; j += 4)
-    {
-      _mm_stream_ps(out + j, _mm_min_ps(max, _mm_max_ps(min, offset + scale * _mm_load_ps(in + j))));
-    }
-  }
-  _mm_sfence();
-}
-#endif
-
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,


### PR DESCRIPTION
Eliminating the cacheline fills for the output buffer cuts the runtime
enough to make the plain code slightly faster than the SSE codepath.
```
Thr     SSE     new-plain
1     10.57ms   9.95ms
2      6.19ms   5.99ms
4      4.82ms   4.72ms
6      4.30ms   4.29ms
8      3.92ms   3.88ms
16     4.30ms   4.17ms
32     4.53ms   4.47ms
```
Verified pixel-identical output for integration test 0038.