### PR TITLE
maintenance: move copy_pixel_nontemporal to imageop.h

### DIFF
--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -612,7 +612,7 @@ static inline void dt_sfence()
 // parallelization, we should play it safe and emit a memory fence.
 // This function should be used right after a parallelized for loop,
 // where it will produce a barrier only if needed.
-#ifdef _OPENMPx
+#ifdef _OPENMP
 #define dt_omploop_sfence()
 #else
 #define dt_omploop_sfence() dt_sfence()

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -900,6 +900,8 @@ void process(struct dt_iop_module_t *self,
         length += length_inc;
       }
     }
+    // ensure that the nontemporal writes have finished before continuing
+    dt_omploop_sfence();
   }
   else
   {
@@ -954,6 +956,8 @@ void process(struct dt_iop_module_t *self,
         length += length_inc;
       }
     }
+    // ensure that the nontemporal writes have finished before continuing
+    dt_omploop_sfence();
   }
 
   if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)


### PR DESCRIPTION
Move the definition from darktable.h to imageop.h to reduce the number of files which need to compile the SSE header.  Add a wrapper around _mm_sfence that falls back to a standard C11 function when compiling without SSE, and add calls to it to graduatednd.c.
