### PR TITLE
optimization: use dt_iop_image_fill instead of memset

### DIFF
--- a/src/common/locallaplacian.c
+++ b/src/common/locallaplacian.c
@@ -231,7 +231,6 @@ static inline void gauss_reduce(
 
   // this is the scalar (non-simd) code:
   const float w[5] = { 1.f/16.f, 4.f/16.f, 6.f/16.f, 4.f/16.f, 1.f/16.f };
-  memset(coarse, 0, sizeof(float)*cw*ch);
   // direct 5x5 stencil only on required pixels:
 #ifdef _OPENMP
   // DON'T parallelize the very smallest levels of the pyramid, as the threading overhead
@@ -244,9 +243,11 @@ static inline void gauss_reduce(
   for(int j=1;j<ch-1;j++)
     for(int i=1;i<cw-1;i++)
     {
+      float sum = 0.0f;
       for(int jj=-2;jj<=2;jj++)
         for(int ii=-2;ii<=2;ii++)
-          coarse[j*cw+i] += input[(2*j+jj)*wd+2*i+ii] * w[ii+2] * w[jj+2];
+          sum += input[(2*j+jj)*wd+2*i+ii] * w[ii+2] * w[jj+2];
+      coarse[j*cw+i] = sum;
     }
   ll_fill_boundary1(coarse, cw, ch);
 }

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -296,7 +296,7 @@ static void process_wavelets(struct dt_iop_module_t *self, struct dt_dev_pixelpi
   float *buf2 = tmp;
 
   // clear the output buffer, which will be accumulating all of the detail scales
-  memset(out, 0, sizeof(float) * 4 * width * height);
+  dt_iop_image_fill(out, 0.0f, width, height, 4);
 
   // now do the wavelet decomposition, immediately synthesizing the detail scale into the final output so
   // that we don't need to store it past the current scale's iteration

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1357,7 +1357,7 @@ static void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
   float *restrict buf2 = tmp;
 
   // clear the output buffer, which will be accumulating all of the detail scales
-  memset(out, 0, sizeof(float) * 4 * npixels);
+  dt_iop_image_fill(out, 0.0f, width, height, 4);
 
   for(int scale = 0; scale < max_scale; scale++)
   {

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -900,6 +900,8 @@ void process(struct dt_iop_module_t *self,
         length += length_inc;
       }
     }
+    // ensure that the nontemporal writes have finished before continuing
+    dt_omploop_sfence();
   }
   else
   {
@@ -954,6 +956,8 @@ void process(struct dt_iop_module_t *self,
         length += length_inc;
       }
     }
+    // ensure that the nontemporal writes have finished before continuing
+    dt_omploop_sfence();
   }
 
   if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)


### PR DESCRIPTION
This PR uses dt_iop_image_fill to initialize image buffers, allowing parallelization and the use of nontemporal stores.  This reduces the pixpipe time in darktable-bench on the v3.8 sidecar from 5.595 seconds to 5.493 seconds or about 1.8%.

(Oops, just saw that this PR includes the commits from my previous PR.  They aren't actually needed for this PR and could be dropped if it is decided not to use the prior PR.)
