### PR TITLE
fix redraw loop of navigation widget

### DIFF
--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -361,7 +361,7 @@ void dt_control_signal_raise(const dt_control_signal_t *ctlsig, dt_signal_t sign
 
   if(!signal_description->synchronous)
   {
-    g_main_context_invoke(NULL, _signal_raise, params);
+    g_main_context_invoke_full(NULL, G_PRIORITY_HIGH_IDLE, _signal_raise, params, NULL);
   }
   else
   {
@@ -376,7 +376,7 @@ void dt_control_signal_raise(const dt_control_signal_t *ctlsig, dt_signal_t sign
       g_cond_init(&communication.end_cond);
       g_mutex_lock(&communication.end_mutex);
       communication.user_data = params;
-      g_main_context_invoke(NULL,_async_com_callback,&communication);
+      g_main_context_invoke_full(NULL,G_PRIORITY_HIGH_IDLE, _async_com_callback,&communication, NULL);
       g_cond_wait(&communication.end_cond,&communication.end_mutex);
       g_mutex_unlock(&communication.end_mutex);
       g_mutex_clear(&communication.end_mutex);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1572,7 +1572,7 @@ static gboolean _drawable_motion_notify_callback(GtkWidget *widget, GdkEventMoti
 
     if(prior_highlight != d->highlight)
     {
-      dt_control_queue_redraw_widget(widget);
+      gtk_widget_queue_draw(widget);
       if(d->highlight != DT_LIB_HISTOGRAM_HIGHLIGHT_NONE)
       {
         // FIXME: should really use named cursors, and differentiate between "grab" and "grabbing"
@@ -1714,7 +1714,7 @@ static gboolean _drawable_leave_notify_callback(GtkWidget *widget, GdkEventCross
   {
     d->highlight = DT_LIB_HISTOGRAM_HIGHLIGHT_NONE;
     dt_control_change_cursor(GDK_LEFT_PTR);
-    dt_control_queue_redraw_widget(widget);
+    gtk_widget_queue_draw(widget);
   }
   // event should bubble up to the eventbox
   return FALSE;
@@ -1841,7 +1841,7 @@ static void _scope_type_changed(dt_lib_histogram_t *d)
   if(d->waveform_bins)
   {
     // waveform and RGB parade both work on the same underlying data
-    dt_control_queue_redraw_widget(d->scope_draw);
+    gtk_widget_queue_draw(d->scope_draw);
   }
   else
   {
@@ -1885,7 +1885,7 @@ static void _scope_view_clicked(GtkWidget *button, dt_lib_histogram_t *d)
                          dt_lib_histogram_scale_names[d->histogram_scale]);
       _histogram_scale_update(d);
       // no need to reprocess data
-      dt_control_queue_redraw_widget(d->scope_draw);
+      gtk_widget_queue_draw(d->scope_draw);
       return;
     case DT_LIB_HISTOGRAM_SCOPE_WAVEFORM:
     case DT_LIB_HISTOGRAM_SCOPE_PARADE:
@@ -1932,21 +1932,21 @@ static void _red_channel_toggle(GtkWidget *button, dt_lib_histogram_t *d)
 {
   d->red = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
   dt_conf_set_bool("plugins/darkroom/histogram/show_red", d->red);
-  dt_control_queue_redraw_widget(d->scope_draw);
+  gtk_widget_queue_draw(d->scope_draw);
 }
 
 static void _green_channel_toggle(GtkWidget *button, dt_lib_histogram_t *d)
 {
   d->green = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
   dt_conf_set_bool("plugins/darkroom/histogram/show_green", d->green);
-  dt_control_queue_redraw_widget(d->scope_draw);
+  gtk_widget_queue_draw(d->scope_draw);
 }
 
 static void _blue_channel_toggle(GtkWidget *button, dt_lib_histogram_t *d)
 {
   d->blue = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
   dt_conf_set_bool("plugins/darkroom/histogram/show_blue", d->blue);
-  dt_control_queue_redraw_widget(d->scope_draw);
+  gtk_widget_queue_draw(d->scope_draw);
 }
 
 static void _color_harmony_changed(dt_lib_histogram_t *d)
@@ -1957,7 +1957,7 @@ static void _color_harmony_changed(dt_lib_histogram_t *d)
                   d->harmony_width);
   dt_conf_set_int("plugins/darkroom/histogram/vectorscope/harmony_rotation",
                   d->harmony_rotation);
-  dt_control_queue_redraw_widget(d->scope_draw);
+  gtk_widget_queue_draw(d->scope_draw);
 }
 
 static gboolean _color_harmony_clicked(GtkWidget *button, GdkEventButton *event, dt_lib_histogram_t *d)
@@ -1999,7 +1999,7 @@ static gboolean _color_harmony_enter_notify_callback(GtkWidget *widget, GdkEvent
     }
   d->color_harmony_old = d->color_harmony;
   d->color_harmony = pos + 1;
-  dt_control_queue_redraw_widget(d->scope_draw);
+  gtk_widget_queue_draw(d->scope_draw);
   return TRUE;
 }
 
@@ -2008,7 +2008,7 @@ static gboolean _color_harmony_leave_notify_callback(GtkWidget *widget, GdkEvent
 {
   dt_lib_histogram_t *d = (dt_lib_histogram_t *)user_data;
   d->color_harmony = d->color_harmony_old;
-  dt_control_queue_redraw_widget(d->scope_draw);
+  gtk_widget_queue_draw(d->scope_draw);
   return TRUE;
 }
 

--- a/src/lua/call.c
+++ b/src/lua/call.c
@@ -666,7 +666,7 @@ static int gtk_wrap(lua_State*L)
     g_cond_init(&communication.end_cond);
     communication.L = L;
     g_mutex_lock(&communication.end_mutex);
-    g_main_context_invoke(NULL,dt_lua_gtk_wrap_callback,&communication);
+    g_main_context_invoke_full(NULL,G_PRIORITY_HIGH_IDLE, dt_lua_gtk_wrap_callback,&communication, NULL);
     g_cond_wait(&communication.end_cond,&communication.end_mutex);
     g_mutex_unlock(&communication.end_mutex);
     g_mutex_clear(&communication.end_mutex);


### PR DESCRIPTION
fixes #13664

This updates the shown zoom % when a redraw of the navigation widget is requested, rather than when it is actually redrawn (which might have been triggered because the zoom combo on top of it is being drawn which needs its background to be drawn first, triggering a loop).

I've also changed that on zoom change not the _whole_ UI is redrawn, but just the center and the navigator. This somehow fixed the small issue that when you directly type a zoom level into the zoom combobox (say "23") it would not get updated to "23_%_" until some other navigation event (a pan) occurred. I haven't noticed any averse affects, but maybe I'm overlooking other results (histogram??) that might need redrawing. So please check carefully if you can make anything go stale by zoom changes (scroll, middle button click, shortcuts) or panning.