### PR TITLE
Bugfixes for HLR opposed

### DIFF
--- a/src/common/dttypes.h
+++ b/src/common/dttypes.h
@@ -66,12 +66,18 @@ typedef float DT_ALIGNED_ARRAY dt_colormatrix_t[4][4];
 #define for_four_channels(_var, ...) \
   _DT_Pragma(omp simd __VA_ARGS__) \
   for (size_t _var = 0; _var < 4; _var++)
+#define for_three_channels(_var, ...) \
+  _DT_Pragma(omp simd __VA_ARGS__) \
+  for (size_t _var = 0; _var < 3; _var++)
 #else
 #define for_each_channel(_var, ...) \
   for (size_t _var = 0; _var < DT_PIXEL_SIMD_CHANNELS; _var++)
 #define for_four_channels(_var, ...) \
   for (size_t _var = 0; _var < 4; _var++)
+#define for_three_channels(_var, ...) \
+  for (size_t _var = 0; _var < 3; _var++)
 #endif
+
 
 // transpose a padded 3x3 matrix
 static inline void transpose_3xSSE(const dt_colormatrix_t input, dt_colormatrix_t output)

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -38,7 +38,7 @@
    Again the algorithm has been developed in collaboration by @garagecoder and @Iain from gmic team and @jenshannoschwalm from dt.
 */
 
-static uint64_t _opposed_hash(dt_dev_pixelpipe_iop_t *piece)
+static uint64_t _opposed_parhash(dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_buffer_dsc_t *dsc = &piece->pipe->dsc;
   dt_iop_highlights_data_t *d = (dt_iop_highlights_data_t *)piece->data;
@@ -58,7 +58,14 @@ static uint64_t _opposed_hash(dt_dev_pixelpipe_iop_t *piece)
   for(size_t ip = 0; ip < sizeof(d->clip); ip++)
     hash = ((hash << 5) + hash) ^ pstr[ip];
 
-  pstr = (char *) &piece->pipe->image.id;
+  return hash;
+}
+
+static uint64_t _opposed_hash(dt_dev_pixelpipe_iop_t *piece)
+{
+  uint64_t hash = _opposed_parhash(piece);
+
+  char *pstr = (char *) &piece->pipe->image.id;
   for(size_t ip = 0; ip < sizeof(piece->pipe->image.id); ip++)
     hash = ((hash << 5) + hash) ^ pstr[ip];
 
@@ -90,19 +97,24 @@ static inline char _mask_dilated(const char *in, const size_t w1)
 
   const size_t w2 = 2*w1;
   const size_t w3 = 3*w1;
-  return  in[-w3-2] | in[-w3-1] | in[-w3]   | in[-w3+1] | in[-w3+2] |
+  return (in[-w3-2] | in[-w3-1] | in[-w3]   | in[-w3+1] | in[-w3+2] |
           in[-w2-3] | in[-w2-2] | in[-w2-1] | in[-w2]   | in[-w2+1] | in[-w2+2] | in[-w2+3] |
           in[-w1-3] | in[-w1-2] | in[-w1+2] | in[-w1+3] |
           in[-3]    | in[-2]    | in[2]     | in[3]     |
           in[w1-3]  | in[w1-2]  | in[w1+2]  | in[w1+3]  |
           in[w2-3]  | in[w2-2]  | in[w2-1]  | in[w2]    | in[w2+1]  | in[w2+2]  | in[w2+3] |
-          in[w3-2]  | in[w3-1]  | in[w3]    | in[w3+1]  | in[w3+2];
+          in[w3-2]  | in[w3-1]  | in[w3]    | in[w3+1]  | in[w3+2]) ? 1 : 0;
 }
 
 
 // A slightly modified version for sraws
-static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const float *const input, float *const output,
-                         const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out, const gboolean quality)
+static void _process_linear_opposed(
+        struct dt_iop_module_t *self,
+        dt_dev_pixelpipe_iop_t *piece,
+        const float *const input, float *const output,
+        const dt_iop_roi_t *const roi_in,
+        const dt_iop_roi_t *const roi_out,
+        const gboolean quality)
 {
   dt_iop_highlights_data_t *d = (dt_iop_highlights_data_t *)piece->data;
   const float clipval = 0.987f * d->clip;
@@ -112,25 +124,21 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
                                        wbon ? dsc->temperature.coeffs[1] : 1.0f,
                                        wbon ? dsc->temperature.coeffs[2] : 1.0f};
   const dt_aligned_pixel_t clips = { clipval * icoeffs[0], clipval * icoeffs[1], clipval * icoeffs[2]}; 
-  const dt_aligned_pixel_t clipdark = { 0.03f * clips[0], 0.125f * clips[1], 0.03f * clips[2] };   
 
   const size_t mwidth  = roi_in->width / 3;
   const size_t mheight = roi_in->height / 3;
-  const size_t msize = dt_round_size((size_t) (mwidth+1) * (mheight+1), 64);
+  const size_t msize = dt_round_size((size_t) (mwidth+1) * (mheight+1), 16);
 
-  const uint64_t opphash = _opposed_hash(piece);
+  /* As we don't have linear raws available with full image as roi_in we can't use any
+     precalculated chroma correction coeffs
+  */
+
   dt_aligned_pixel_t chrominance = {0.0f, 0.0f, 0.0f, 0.0f};
 
-  if(opphash == img_opphash)
+  char *mask = (quality) ? dt_calloc_align(64, 6 * msize * sizeof(char)) : NULL;
+  if(mask)
   {
-    for_each_channel(c) chrominance[c] = img_oppchroma[c];
-  }
-  else
-  {
-    char *mask = (quality) ? dt_calloc_align(64, 6 * msize * sizeof(char)) : NULL;
-    if(mask)
-    {
-      gboolean anyclipped = FALSE;
+    gboolean anyclipped = FALSE;
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   reduction( | : anyclipped) \
@@ -138,81 +146,74 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
   dt_omp_sharedconst(msize, mwidth) \
   schedule(static)
 #endif
-      for(size_t row = 1; row < roi_in->height -1; row++)
+    for(size_t row = 1; row < roi_in->height -1; row++)
+    {
+      for(size_t col = 1; col < roi_in->width -1; col++)
       {
-        for(size_t col = 1; col < roi_in->width -1; col++)
+        const size_t idx = (row * roi_in->width + col) * 4;
+        const size_t mdx = _raw_to_cmap(mwidth, row, col); 
+        for_three_channels(c)
         {
-          const size_t idx = (row * roi_in->width + col) * 4;
-          for_each_channel(c)
+          if((input[idx] >= clips[c]) && (mask[c*msize + mdx] == 0))
           {
-            if(input[idx+c] >= clips[c])
-            {
-              mask[c * msize + _raw_to_cmap(mwidth, row, col)] |= 1;
-              anyclipped |= TRUE;
-            }
+            mask[c * msize + mdx] |= 1;
+            anyclipped |= TRUE;
           }
         }
       }
-      /* We want to use the photosites closely around clipped data to be taken into account.
-         The mask buffers holds data for each color channel, we dilate the mask buffer slightly
-         to get those locations.
-      */
-      if(anyclipped)
-      {
+    }
+    /* We want to use the photosites closely around clipped data to be taken into account.
+       The mask buffers holds data for each color channel, we dilate the mask buffer slightly
+       to get those locations.
+    */
+
+    dt_aligned_pixel_t sums = {0.0f, 0.0f, 0.0f, 0.0f};
+    dt_aligned_pixel_t cnts = {0.0f, 0.0f, 0.0f, 0.0f};
+
+    if(anyclipped)
+    {
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(mask) \
   dt_omp_sharedconst(mwidth, mheight, msize) \
   schedule(static) collapse(2)
 #endif
-        for(size_t row = 3; row < mheight - 3; row++)
+      for(size_t row = 3; row < mheight - 3; row++)
+      {
+        for(size_t col = 3; col < mwidth - 3; col++)
         {
-          for(size_t col = 3; col < mwidth - 3; col++)
-          {
-            const size_t mx = row * mwidth + col;
-            mask[3*msize + mx] = _mask_dilated(mask + mx, mwidth);
-            mask[4*msize + mx] = _mask_dilated(mask + msize + mx, mwidth);
-            mask[5*msize + mx] = _mask_dilated(mask + 2*msize + mx, mwidth);
-          }
+          const size_t mx = row * mwidth + col;
+          mask[3*msize + mx] = _mask_dilated(mask + mx, mwidth);
+          mask[4*msize + mx] = _mask_dilated(mask + msize + mx, mwidth);
+          mask[5*msize + mx] = _mask_dilated(mask + 2*msize + mx, mwidth);
         }
+      }
 
-        dt_aligned_pixel_t cr_sum = {0.0f, 0.0f, 0.0f, 0.0f};
-        dt_aligned_pixel_t cr_cnt = {0.0f, 0.0f, 0.0f, 0.0f};
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(input, roi_in, clips, clipdark, mask) \
-  reduction(+ : cr_sum, cr_cnt) \
+  dt_omp_firstprivate(input, roi_in, clips, mask) \
+  reduction(+ : sums, cnts) \
   dt_omp_sharedconst(msize, mwidth) \
   schedule(static)
 #endif
-        for(size_t row = 3; row < roi_in->height - 3; row++)
+      for(size_t row = 3; row < roi_in->height - 3; row++)
+      {
+        for(size_t col = 3; col < roi_in->width - 3; col++)
         {
-          for(size_t col = 3; col < roi_in->width - 3; col++)
+          const size_t idx = (row * roi_in->width + col) * 4;
+          for_three_channels(c)
           {
-            const size_t idx = (row * roi_in->width + col) * 4;
-            for_each_channel(c)
+            const float inval = input[idx+c]; 
+            if((inval > 0.2f * clips[c]) && (inval < clips[c]) && (mask[(c+3) * msize + _raw_to_cmap(mwidth, row, col)]))
             {
-              const float inval = fmaxf(0.0f, input[idx+c]); 
-              if((inval > clipdark[c]) && (inval < clips[c]) && (mask[(c+3) * msize + _raw_to_cmap(mwidth, row, col)]))
-              {
-                cr_sum[c] += inval - _calc_linear_refavg(&input[idx], c);
-                cr_cnt[c] += 1.0f;
-              }
+              sums[c] += inval - _calc_linear_refavg(&input[idx], c);
+              cnts[c] += 1.0f;
             }
           }
         }
-        for_each_channel(c) chrominance[c] = cr_sum[c] / fmaxf(1.0f, cr_cnt[c]);
       }
-
-      // we only have valid precalculated data if in fullpipe and complete (allow some rounding) image
-      if((piece->pipe->type == DT_DEV_PIXELPIPE_FULL)
-         && (abs((int)(roi_out->width / roi_out->scale) - piece->buf_in.width) < 8)
-         && (abs((int)(roi_out->height / roi_out->scale) - piece->buf_in.height) < 8))
-      {
-        for_each_channel(c) img_oppchroma[c] = chrominance[c];
-        img_opphash = opphash;
-        dt_print(DT_DEBUG_PIPE, "[opposed chroma cache] %f %f %f for opphash%22" PRIu64 "\n", chrominance[0], chrominance[1], chrominance[2], opphash);
-       }
+      for_three_channels(c)
+        chrominance[c] = (cnts[c] > 30.0f) ? sums[c] / cnts[c] : 0.0f;
     }
     dt_free_align(mask);
   }
@@ -229,7 +230,7 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
       const ssize_t inrow = MIN(row, roi_in->height-1);
       const ssize_t incol = MIN(col, roi_in->width-1);
       const ssize_t idx = (inrow * roi_in->width + incol) * 4;
-      for_each_channel(c)
+      for_three_channels(c)
       {
         const float ref = _calc_linear_refavg(&input[idx], c);
         const float inval = fmaxf(0.0f, input[idx+c]);
@@ -239,9 +240,15 @@ static void _process_linear_opposed(struct dt_iop_module_t *self, dt_dev_pixelpi
   }
 }
 
-static float *_process_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const float *const input, float *const output,
-                         const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
-                         const gboolean keep, const gboolean quality)
+static float *_process_opposed(
+        struct dt_iop_module_t *self,
+        dt_dev_pixelpipe_iop_t *piece,
+        const float *const input,
+        float *const output,
+        const dt_iop_roi_t *const roi_in,
+        const dt_iop_roi_t *const roi_out,
+        const gboolean keep,
+        const gboolean quality)
 {
   dt_iop_highlights_data_t *d = (dt_iop_highlights_data_t *)piece->data;
   const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
@@ -253,18 +260,18 @@ static float *_process_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
                                        wbon ? dsc->temperature.coeffs[1] : 1.0f,
                                        wbon ? dsc->temperature.coeffs[2] : 1.0f};
   const dt_aligned_pixel_t clips = { clipval * icoeffs[0], clipval * icoeffs[1], clipval * icoeffs[2]};
-  const dt_aligned_pixel_t clipdark = { 0.03f * clips[0], 0.125f * clips[1], 0.03f * clips[2] };
 
   const size_t mwidth  = roi_in->width / 3;
   const size_t mheight = roi_in->height / 3;
-  const size_t msize = dt_round_size((size_t) (mwidth+1) * (mheight+1), 64);
+  const size_t msize = dt_round_size((size_t) (mwidth+1) * (mheight+1), 16);
 
   const uint64_t opphash = _opposed_hash(piece);
   dt_aligned_pixel_t chrominance = {0.0f, 0.0f, 0.0f, 0.0f};
 
   if(opphash == img_opphash)
   {
-    for_each_channel(c) chrominance[c] = img_oppchroma[c];
+    for_three_channels(c)
+      chrominance[c] = img_oppchroma[c];
   }
   else
   {
@@ -276,29 +283,41 @@ static float *_process_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
 #pragma omp parallel for default(none) \
   reduction( | : anyclipped) \
   dt_omp_firstprivate(clips, input, roi_in, xtrans, mask) \
-  dt_omp_sharedconst(filters, msize, mwidth) \
+  dt_omp_sharedconst(filters, msize, mwidth, mheight) \
   schedule(static) collapse(2)
 #endif
-      for(size_t row = 1; row < roi_in->height -1; row++)
+      for(int mrow = 1; mrow < mheight-1; mrow++)
       {
-        for(size_t col = 1; col < roi_in->width -1; col++)
+        for(int mcol = 1; mcol < mwidth-1; mcol++)
         {
-          const size_t idx = row * roi_in->width + col;
-          const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
-          if(fmaxf(0.0f, input[idx]) >= clips[color])
+          char mbuff[3] = { 0, 0, 0 };
+          const size_t grp = 3 * (mrow * roi_in->width + mcol);
+          for(int y = -1; y < 2; y++)
           {
-            mask[color * msize + _raw_to_cmap(mwidth, row, col)] |= 1;
-            anyclipped |= TRUE;
+            for(int x = -1; x < 2; x++)
+            {
+              const size_t idx = grp + y * roi_in->width + x;
+              const int color = (filters == 9u) ? FCxtrans(mrow+y, mcol+x, roi_in, xtrans) : FC(mrow+y, mcol+x, filters);
+              const gboolean clipped = fmaxf(0.0f, input[idx]) >= clips[color];
+              mbuff[color] += (clipped) ? 1 : 0;
+              anyclipped |= clipped;
+            }
           }
+          for_three_channels(c)
+            mask[c * msize + mrow * mwidth + mcol] = (mbuff[c]) ? 1 : 0;
         }
       }
-      /* We want to use the photosites closely around clipped data to be taken into account.
+
+      dt_aligned_pixel_t sums = {0.0f, 0.0f, 0.0f, 0.0f};
+      dt_aligned_pixel_t cnts = {0.0f, 0.0f, 0.0f, 0.0f};
+
+      if(anyclipped)
+      {
+        /* We want to use the photosites closely around clipped data to be taken into account.
          The mask buffers holds data for each color channel, we dilate the mask buffer slightly
          to get those locations.
          If there are no clipped locations we keep the chrominance correction at 0 but make it valid 
-      */
-      if(anyclipped)
-      {
+        */
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(mask) \
@@ -316,13 +335,11 @@ static float *_process_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
           }
         }
 
-        /* After having the surrounding mask for each color channel we can calculate the chrominance corrections. */ 
-        dt_aligned_pixel_t cr_sum = {0.0f, 0.0f, 0.0f, 0.0f};
-        dt_aligned_pixel_t cr_cnt = {0.0f, 0.0f, 0.0f, 0.0f};
+       /* After having the surrounding mask for each color channel we can calculate the chrominance corrections. */ 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(input, roi_in, xtrans, clips, clipdark, mask) \
-  reduction(+ : cr_sum, cr_cnt) \
+  dt_omp_firstprivate(input, roi_in, xtrans, clips, mask) \
+  reduction(+ : sums, cnts) \
   dt_omp_sharedconst(filters, msize, mwidth) \
   schedule(static) collapse(2)
 #endif
@@ -333,21 +350,26 @@ static float *_process_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
             const size_t idx = row * roi_in->width + col;
             const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
             const float inval = fmaxf(0.0f, input[idx]); 
+
             /* we only use the unclipped photosites very close the true clipped data to calculate the chrominance offset */
-            if((inval < clips[color]) && (inval > clipdark[color]) && (mask[(color+3) * msize + _raw_to_cmap(mwidth, row, col)]))
+            if((inval < clips[color]) && (inval > (0.2f * clips[color])) && (mask[(color+3) * msize + _raw_to_cmap(mwidth, row, col)]))
             {
-              cr_sum[color] += inval - _calc_refavg(&input[idx], xtrans, filters, row, col, roi_in, TRUE);
-              cr_cnt[color] += 1.0f;
+              sums[color] += inval - _calc_refavg(&input[idx], xtrans, filters, row, col, roi_in, TRUE);
+              cnts[color] += 1.0f;
             }
           }
         }
-        for_each_channel(c) chrominance[c] = cr_sum[c] / fmaxf(1.0f, cr_cnt[c]);
+        for_three_channels(c)
+          chrominance[c] = (cnts[c] > 100.0f) ? sums[c] / cnts[c] : 0.0f;
       }
+
       if(piece->pipe->type == DT_DEV_PIXELPIPE_FULL)
       {
-        for_each_channel(c) img_oppchroma[c] = chrominance[c];
+        for_three_channels(c)
+          img_oppchroma[c] = chrominance[c];
         img_opphash = opphash;
-        dt_print(DT_DEBUG_PIPE, "[opposed chroma cache] %f %f %f for opphash%22" PRIu64 "\n", chrominance[0], chrominance[1], chrominance[2], opphash);
+        dt_print(DT_DEBUG_PIPE, "[opposed chroma cache CPU] red: %8.6f (%.0f), green: %8.6f (%.0f), blue: %8.6f (%.0f) for hash%22" PRIu64 "\n",
+          chrominance[0], cnts[0], chrominance[1], cnts[1], chrominance[2], cnts[2], _opposed_parhash(piece));
       }
     }
     dt_free_align(mask);
@@ -379,6 +401,7 @@ static float *_process_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
       }
     }
   }
+
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(output, input, tmpout, chrominance, clips, xtrans, roi_in, roi_out) \
@@ -417,9 +440,13 @@ static float *_process_opposed(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
 }
 
 #ifdef HAVE_OPENCL
-static cl_int process_opposed_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
-                                         cl_mem dev_in, cl_mem dev_out,
-                                         const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+static cl_int process_opposed_cl(
+        struct dt_iop_module_t *self,
+        dt_dev_pixelpipe_iop_t *piece,
+        cl_mem dev_in,
+        cl_mem dev_out,
+        const dt_iop_roi_t *const roi_in,
+        const dt_iop_roi_t *const roi_out)
 {
   dt_iop_highlights_data_t *d = (dt_iop_highlights_data_t *)piece->data;
   const dt_iop_highlights_global_data_t *gd = (dt_iop_highlights_global_data_t *)self->global_data;
@@ -434,26 +461,23 @@ static cl_int process_opposed_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_
                                        wbon ? dsc->temperature.coeffs[2] : 1.0f};
 
   dt_aligned_pixel_t clips = { clipval * icoeffs[0], clipval * icoeffs[1], clipval * icoeffs[2], 1.0f};
-  dt_aligned_pixel_t clipdark = { 0.03f * clips[0], 0.125f * clips[1], 0.03f * clips[2], 0.0f };
 
   cl_int err = DT_OPENCL_DEFAULT_ERROR;
   cl_mem dev_chrominance = NULL;
-  cl_mem dev_dark = NULL;
   cl_mem dev_xtrans = NULL;
   cl_mem dev_clips = NULL;
   cl_mem dev_inmask = NULL;
   cl_mem dev_outmask = NULL;
   cl_mem dev_accu = NULL;
   float *claccu = NULL;
- 
-  const size_t iwidth = ROUNDUPDWD(roi_in->width, devid);
+
   const size_t iheight = ROUNDUPDHT(roi_in->height, devid);
   const size_t owidth = ROUNDUPDWD(roi_out->width, devid);
   const size_t oheight = ROUNDUPDHT(roi_out->height, devid);
 
   const int mwidth  = roi_in->width / 3;
   const int mheight = roi_in->height / 3;
-  const int msize = dt_round_size((size_t) (mwidth+1) * (mheight+1), 64);
+  const int msize = dt_round_size((size_t) (mwidth+1) * (mheight+1), 16);
 
   dev_xtrans = dt_opencl_copy_host_to_device_constant(devid, sizeof(piece->pipe->dsc.xtrans), piece->pipe->dsc.xtrans);
   if(dev_xtrans == NULL) goto error;
@@ -466,13 +490,12 @@ static cl_int process_opposed_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_
 
   if(opphash == img_opphash)
   {
-    for_each_channel(c) chrominance[c] = img_oppchroma[c];
+    for_three_channels(c)
+      chrominance[c] = img_oppchroma[c];
   }
   else
   {
     // We don't have valid chrominance correction so go the hard way
-    dev_dark = dt_opencl_copy_host_to_device_constant(devid, 4 * sizeof(float), clipdark);
-    if(dev_dark == NULL) goto error;
 
     dev_inmask = dt_opencl_alloc_device_buffer(devid, sizeof(char) * 3 * msize);
     if(dev_inmask == NULL) goto error;
@@ -480,51 +503,63 @@ static cl_int process_opposed_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_
     dev_outmask =  dt_opencl_alloc_device_buffer(devid, sizeof(char) * 3 * msize);
     if(dev_outmask == NULL) goto error;
 
-    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_highlights_initmask, iwidth, iheight,
-            CLARG(dev_in), CLARG(dev_inmask), CLARG(roi_in->width), CLARG(roi_in->height), CLARG(msize), CLARG(mwidth),
-            CLARG(filters), CLARG(dev_xtrans), CLARG(dev_clips));
+    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_highlights_initmask, mwidth, mheight,
+            CLARG(dev_in), CLARG(dev_inmask),
+            CLARG(msize), CLARG(mwidth), CLARG(mheight),
+            CLARG(filters), CLARG(dev_xtrans),
+            CLARG(dev_clips));
     if(err != CL_SUCCESS) goto error;
 
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_highlights_dilatemask, mwidth, mheight,
-            CLARG(dev_inmask), CLARG(dev_outmask), CLARG(mwidth), CLARG(mheight), CLARG(msize));
+            CLARG(dev_inmask), CLARG(dev_outmask),
+            CLARG(msize), CLARG(mwidth), CLARG(mheight));
     if(err != CL_SUCCESS) goto error;
 
-    dev_accu = dt_opencl_alloc_device_buffer(devid, sizeof(float) * 6 * iheight);
+    const size_t accusize = sizeof(float) * 6 * iheight;
+    dev_accu = dt_opencl_alloc_device_buffer(devid, accusize);
     if(dev_accu == NULL) goto error;
+
     claccu = dt_calloc_align_float(6 * iheight);
     if(claccu == NULL) goto error;
 
-    size_t sizes[] = { iheight, 1, 1};
+    err = dt_opencl_write_buffer_to_device(devid, claccu, dev_accu, 0, accusize, TRUE);
+    if(err != CL_SUCCESS) goto error;
+
+    size_t sizes[] = { iheight, 1, 1 };
 
     dt_opencl_set_kernel_args(devid, gd->kernel_highlights_chroma, 0,
             CLARG(dev_in), CLARG(dev_outmask), CLARG(dev_accu),
-            CLARG(roi_in->width), CLARG(roi_in->height), CLARG(mwidth), CLARG(msize),
-            CLARG(filters), CLARG(dev_xtrans), CLARG(dev_clips), CLARG(dev_dark)); 
+            CLARG(roi_in->width), CLARG(roi_in->height),
+            CLARG(msize), CLARG(mwidth),
+            CLARG(filters), CLARG(dev_xtrans), CLARG(dev_clips)); 
 
     err = dt_opencl_enqueue_kernel_ndim_with_local(devid, gd->kernel_highlights_chroma, sizes, NULL, 1);
     if(err != CL_SUCCESS) goto error;
 
-    err = dt_opencl_read_buffer_from_device(devid, claccu, dev_accu, 0, 6 * iheight * sizeof(float), TRUE);
+    err = dt_opencl_read_buffer_from_device(devid, claccu, dev_accu, 0, accusize, TRUE);
     if(err != CL_SUCCESS) goto error;
 
     // collect row data and accumulate
     dt_aligned_pixel_t sums = { 0.0f, 0.0f, 0.0f};
     dt_aligned_pixel_t cnts = { 0.0f, 0.0f, 0.0f};
-    for(int grp = 3; grp < roi_in->height-3; grp++)
+    for(int row = 3; row < roi_in->height - 3; row++)
     {
-      for(int c = 0; c < 3; c++)
+      for_three_channels(c)
       {
-        sums[c] += claccu[grp*6 + c];
-        cnts[c] += claccu[grp*6 + 3 + c];
+        sums[c] += claccu[6*row + 2*c];
+        cnts[c] += claccu[6*row + 2*c +1];
       }
     }
-    for_each_channel(c) chrominance[c] = sums[c] / fmaxf(1.0f, cnts[c]);
+    for_three_channels(c)
+      chrominance[c] = (cnts[c] > 100.0f) ? sums[c] / cnts[c] : 0.0f;
 
     if(piece->pipe->type == DT_DEV_PIXELPIPE_FULL)
     {
-      for_each_channel(c) img_oppchroma[c] = chrominance[c];
+      for_three_channels(c)
+        img_oppchroma[c] = chrominance[c];
       img_opphash = opphash;
-      dt_print(DT_DEBUG_PIPE, "[opposed chroma cache] %f %f %f for opphash%22" PRIu64 "\n", chrominance[0], chrominance[1], chrominance[2], opphash);
+      dt_print(DT_DEBUG_PIPE, "[opposed chroma cache GPU] red: %8.6f (%.0f), green: %8.6f (%.0f), blue: %8.6f (%.0f) for hash%22" PRIu64 "\n",
+        chrominance[0], cnts[0], chrominance[1], cnts[1], chrominance[2], cnts[2], _opposed_parhash(piece));
     }
   }
 
@@ -533,15 +568,17 @@ static cl_int process_opposed_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_
 
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_highlights_opposed, owidth, oheight,
           CLARG(dev_in), CLARG(dev_out),
-          CLARG(roi_out->width), CLARG(roi_out->height), CLARG(roi_in->width), CLARG(roi_in->height),
-          CLARG(roi_out->x), CLARG(roi_out->y), CLARG(filters), CLARG(dev_xtrans),
-          CLARG(dev_clips), CLARG(dev_chrominance));
+          CLARG(roi_out->width), CLARG(roi_out->height),
+          CLARG(roi_in->width), CLARG(roi_in->height),
+          CLARG(roi_out->x), CLARG(roi_out->y),
+          CLARG(filters), CLARG(dev_xtrans),
+          CLARG(dev_clips),
+          CLARG(dev_chrominance));
   if(err != CL_SUCCESS) goto error;
 
   dt_opencl_release_mem_object(dev_clips);
   dt_opencl_release_mem_object(dev_xtrans);
   dt_opencl_release_mem_object(dev_chrominance);
-  dt_opencl_release_mem_object(dev_dark);
   dt_opencl_release_mem_object(dev_inmask);
   dt_opencl_release_mem_object(dev_outmask);
   dt_opencl_release_mem_object(dev_accu);
@@ -555,7 +592,6 @@ static cl_int process_opposed_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_
   dt_opencl_release_mem_object(dev_clips);
   dt_opencl_release_mem_object(dev_xtrans);
   dt_opencl_release_mem_object(dev_chrominance);
-  dt_opencl_release_mem_object(dev_dark);
   dt_opencl_release_mem_object(dev_inmask);
   dt_opencl_release_mem_object(dev_outmask);
   dt_opencl_release_mem_object(dev_accu);


### PR DESCRIPTION
1. Make sure the masks for calculating the chroma corrections are properly initialized Corrrectly dilating the mask (only OpenCL kernel)

2. It is not correct to use the 'for_each_channel' macro as we don't calculate on channels but on rgb colors. Thus a new macro 'for_three_channels()' has been introduced an is used for those cases.

3. In OpenCL code we make sure valid numbers strictly avoiding any div-by-zero case

4. Some refactoring allows to see the 'parameter hash' instead of opphash, this allows to evaluate correct data depending on tested parameters.

5. For the linear_raw code it doesn't make any sense to use precalculated chroma coeffs as we don't use full data as roi_in

6. As we check manually for being inside the image we can use samplerA for slightly better performance.

7. Corrected initializing of the OpenCL chroma accu data and improved sorting of data for data safety.

8. Avoid using any chroma correction for a channel if number of found locations is too small

9. Don't use the per channel dark levels any more. We always use 0.2*clip as 'dark'. Improves coeffs for images with a lot of sharp 'black-to-white' transitions.

Some comments:
These are fixes for bugs in master found while investigating #13632 and the wip #13654

The problems on some intel & amd machines are not fully solved yet, anyway these are genuine bugs here so i would suggest to get this merged rather soon. Just one commit for ease of maintenance. 