### PR TITLE
css navigation zoom tweak

### DIFF
--- a/data/themes/darktable-elegant-dark.css
+++ b/data/themes/darktable-elegant-dark.css
@@ -85,7 +85,6 @@
 @define-color graph_bg @grey_25;
 @define-color graph_border @grey_20;
 @define-color graph_fg @grey_90;
-@define-color graph_fg_active @grey_95;
 @define-color graph_grid @grey_20;
 @define-color inset_histogram alpha(@grey_80, 0.50);
 

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -88,7 +88,6 @@
 @define-color graph_bg @grey_40;
 @define-color graph_border @grey_15;
 @define-color graph_fg @grey_100;
-@define-color graph_fg_active @grey_95;
 @define-color graph_grid @grey_30;
 @define-color inset_histogram alpha(@grey_95, 0.50);
 

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1467,6 +1467,19 @@ border-bottom: 0.07em solid alpha(@selected_bg_color, 0.75);
   background-color: @graph_bg;
 }
 
+#nav-zoom
+{
+  background-color: alpha(@darkroom_bg_color, 0.25);
+  color: @graph_fg_active;
+  border-top-left-radius: 0.21em;
+  margin: 0;
+}
+
+#nav-zoom:hover
+{
+  background-color: alpha(@darkroom_bg_color, 0.5);
+}
+
 /* search boxes (background color is set on collect module part above ; to be the same as other filters in quick filter bar) */
 #right .search  /* set only search box margin in modules panel */
 {

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -163,6 +163,7 @@ void gui_init(dt_lib_module_t *self)
   DT_BAUHAUS_WIDGET(d->zoom)->show_label = FALSE;
   gtk_widget_set_halign(d->zoom, GTK_ALIGN_END);
   gtk_widget_set_valign(d->zoom, GTK_ALIGN_END);
+  gtk_widget_set_name(d->zoom, "nav-zoom");
 
   self->widget = gtk_overlay_new();
   gtk_container_add(GTK_CONTAINER(self->widget), thumbnail);


### PR DESCRIPTION
Following #13507 PR from @dterrahe.

I test those settings about 2 weeks on multiple images (and on dark and darker themes), they seems to be the best to keep @dterrahe PR spirit while allowing making menu visible when bottom background of the image is bright (images with snow for example).

graph_fg_active lines removed are just duplicate ones (already set on main css file), so just a little cleanup.