### PR TITLE
Ci macos nightly

### DIFF
--- a/.ci/Brewfile
+++ b/.ci/Brewfile
@@ -16,6 +16,7 @@
 
 brew 'cmake'
 brew 'pkg-config'
+brew 'adwaita-icon-theme'
 brew 'desktop-file-utils'
 brew 'exiv2'
 brew 'gettext'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -124,3 +124,84 @@ jobs:
           name: darktable.${{ github.sha }}.win64.zip
           path: ${{ env.BUILD_DIR }}/darktable-*.exe
           retention-days: 2
+
+  macOS:
+    if: github.repository == 'darktable-org/darktable' || github.event_name == 'workflow_dispatch'
+    name: Nightly darktable.${{ github.sha }}.macosx
+    runs-on: ${{ matrix.build.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        build:
+          - { os: macos-11, xcode: 12.5.1, deployment: 11.3 }
+        compiler:
+          - { compiler: XCode,   CC: cc, CXX: c++ }
+        btype: [ Release ]
+        eco: [-DBINARY_PACKAGE_BUILD=ON -DBUILD_CURVE_TOOLS=ON -DBUILD_NOISE_TOOLS=ON]
+        target:
+          - skiptest
+        generator:
+          - Ninja
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.build.xcode }}.app/Contents/Developer
+      CC: ${{ matrix.compiler.CC }}
+      CXX: ${{ matrix.compiler.CXX }}
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.build.deployment }}
+      SRC_DIR: ${{ github.workspace }}/src
+      BUILD_DIR: ${{ github.workspace }}/src/build
+      INSTALL_PREFIX: ${{ github.workspace }}/src/build/macosx
+      CMAKE_BUILD_TYPE: ${{ matrix.btype }}
+      GENERATOR: ${{ matrix.generator }}
+      TARGET: ${{ matrix.target }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: true
+          path: src
+      - name: Install Base Dependencies
+        run: |
+          brew update > /dev/null || true
+          # brew upgrade || true        # no need for a very time-consuming upgrade of ALL packages
+          brew tap Homebrew/bundle
+          cd src/.ci
+          export HOMEBREW_NO_INSTALL_UPGRADE=1
+          brew bundle --verbose || true
+          brew link --force libomp # fix for keg-only libomp
+      - name: Build and Install
+          # todo: use linker which supports --wrap, ld.bfd and ld.gold support it
+        run: |
+          cmake -E make_directory "${BUILD_DIR}";
+          cmake -E make_directory "${INSTALL_PREFIX}";
+          ./src/.ci/ci-script.sh;
+      - name: Check if it runs
+        run: |
+          ${INSTALL_PREFIX}/bin/darktable --version || true
+          ${INSTALL_PREFIX}/bin/darktable-cli \
+                 --width 2048 --height 2048 \
+                 --hq true --apply-custom-presets false \
+                 "${SRC_DIR}/src/tests/integration/images/mire1.cr2" \
+                 "${SRC_DIR}/src/tests/integration/0000-nop/nop.xmp" \
+                 output.png \
+                 --core --disable-opencl --conf host_memory_limit=8192 \
+                 --conf worker_threads=4 -t 4 \
+                 --conf plugins/lighttable/export/force_lcms2=FALSE \
+                 --conf plugins/lighttable/export/iccintent=0 || true # OpenMP builds crash for most configs
+      - name: Build macosx package
+        run: |
+          ./src/packaging/macosx/3_make_hb_darktable_package.sh
+      - name: Create DMG file
+        run: |
+          ./src/packaging/macosx/4_make_hb_darktable_dmg.sh
+      - name: Get version info
+        run: |      
+          cd ${{ env.SRC_DIR }}
+          echo "DMG=$(git describe --tags | sed 's/^release-//;s/-/+/;s/-/~/;s/rc/~rc/')-$(arch)" >> $GITHUB_ENV
+      - name: Package upload
+        if: ${{ success() && matrix.btype == 'Release' && matrix.target == 'skiptest' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: darktable-${{ env.DMG }}.dmg
+          path: ${{ env.INSTALL_PREFIX }}/darktable-${{ env.DMG }}.dmg
+          retention-days: 2
+

--- a/packaging/macosx/3_make_hb_darktable_package.sh
+++ b/packaging/macosx/3_make_hb_darktable_package.sh
@@ -274,10 +274,10 @@ cp open.desktop "$dtResourcesDir"/share/applications/
 # Sign app bundle
 if [ -n "$CODECERT" ]; then
     # Use certificate if one has been provided
-    find ${dtPackageDir}/darktable.app/Contents/Resources/lib -type f -exec codesign --verbose --force --options runtime -i "org.darktable" -s "${CODECERT}" \{} \;
-    codesign --deep --verbose --force --options runtime -i "org.darktable" -s "${CODECERT}" ${dtPackageDir}/darktable.app
+    find ${dtWorkingDir}/Contents/Resources/lib -type f -exec codesign --verbose --force --options runtime -i "org.darktable" -s "${CODECERT}" \{} \;
+    codesign --deep --verbose --force --options runtime -i "org.darktable" -s "${CODECERT}" ${dtWorkingDir}
 else
     # Use ad-hoc signing and preserve metadata
-    find ${dtPackageDir}/darktable.app/Contents/Resources/lib -type f -exec codesign --verbose --force --preserve-metadata=entitlements,requirements,flags,runtime -i "org.darktable" -s - \{} \;
-    codesign --deep --verbose --force --preserve-metadata=entitlements,requirements,flags,runtime -i "org.darktable" -s - ${dtPackageDir}/darktable.app
+    find ${dtWorkingDir}/Contents/Resources/lib -type f -exec codesign --verbose --force --preserve-metadata=entitlements,requirements,flags,runtime -i "org.darktable" -s - \{} \;
+    codesign --deep --verbose --force --preserve-metadata=entitlements,requirements,flags,runtime -i "org.darktable" -s - ${dtWorkingDir}
 fi


### PR DESCRIPTION
Since there is no further progress in PR [#10360](https://github.com/darktable-org/darktable/pull/10360) I made another approach by only using the already existing build scripts.

With github hosted runners for MacOS we have the following limitations:

- Oldest supported MacOS version is macos-11 (Big Sur)
- i386 platform only

This PR creates nightly dmg files for i386 Macs running Big Sur or above.
