### PR TITLE
Feature lua image orientation

### DIFF
--- a/src/lua/image.c
+++ b/src/lua/image.c
@@ -509,6 +509,7 @@ int dt_lua_init_image(lua_State *L)
   luaA_struct_member(L, dt_image_t, filename, const char_filename_length);
   luaA_struct_member(L, dt_image_t, width, const int32_t);
   luaA_struct_member(L, dt_image_t, height, const int32_t);
+  luaA_struct_member(L, dt_image_t, orientation, const int32_t);
   luaA_struct_member_name(L, dt_image_t, geoloc.longitude, protected_double, longitude); // set to NAN if value is not set
   luaA_struct_member_name(L, dt_image_t, geoloc.latitude, protected_double, latitude); // set to NAN if value is not set
   luaA_struct_member_name(L, dt_image_t, geoloc.elevation, protected_double, elevation); // set to NAN if value is not set

--- a/src/lua/image.c
+++ b/src/lua/image.c
@@ -510,6 +510,8 @@ int dt_lua_init_image(lua_State *L)
   luaA_struct_member(L, dt_image_t, width, const int32_t);
   luaA_struct_member(L, dt_image_t, height, const int32_t);
   luaA_struct_member(L, dt_image_t, orientation, const int32_t);
+  luaA_struct_member(L, dt_image_t, aspect_ratio, float);
+
   luaA_struct_member_name(L, dt_image_t, geoloc.longitude, protected_double, longitude); // set to NAN if value is not set
   luaA_struct_member_name(L, dt_image_t, geoloc.latitude, protected_double, latitude); // set to NAN if value is not set
   luaA_struct_member_name(L, dt_image_t, geoloc.elevation, protected_double, elevation); // set to NAN if value is not set

--- a/src/lua/image.c
+++ b/src/lua/image.c
@@ -509,8 +509,7 @@ int dt_lua_init_image(lua_State *L)
   luaA_struct_member(L, dt_image_t, filename, const char_filename_length);
   luaA_struct_member(L, dt_image_t, width, const int32_t);
   luaA_struct_member(L, dt_image_t, height, const int32_t);
-  luaA_struct_member(L, dt_image_t, orientation, const int32_t);
-  luaA_struct_member(L, dt_image_t, aspect_ratio, float);
+  luaA_struct_member(L, dt_image_t, aspect_ratio, const float);
 
   luaA_struct_member_name(L, dt_image_t, geoloc.longitude, protected_double, longitude); // set to NAN if value is not set
   luaA_struct_member_name(L, dt_image_t, geoloc.latitude, protected_double, latitude); // set to NAN if value is not set


### PR DESCRIPTION
This PR is trying to provide a solution for #13686.

You can use this lua script to test it : https://gist.github.com/rds13/15675bd692133017d88cb18479abe40d

You need to 

1. Start darktable in lua debug mode with "-d lua" option
2. load the script from luarc, a Dummy exporter will be available
3. select some images in darktable
4. choose 'Dummy' as exporter
5. Export
6. You should see some trace with the path of images and the aspect_ratio found