### PR TITLE
maintenance: fix 'extern "C"' mess

### DIFF
--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -34,6 +34,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 #define DT_BAUHAUS_WIDGET_TYPE dt_bh_get_type()
 #define DT_BAUHAUS_WIDGET(obj) G_TYPE_CHECK_INSTANCE_CAST((obj), DT_BAUHAUS_WIDGET_TYPE, DtBauhausWidget)
 #define DT_BAUHAUS_WIDGET_CLASS(obj) G_TYPE_CHECK_CLASS_CAST((obj), DT_BAUHAUS_WIDGET, DtBauhausWidgetClass)
@@ -383,6 +387,10 @@ static inline void set_color(cairo_t *cr, GdkRGBA color)
 {
   cairo_set_source_rgba(cr, color.red, color.green, color.blue, color.alpha);
 }
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/atomic.h
+++ b/src/common/atomic.h
@@ -26,10 +26,7 @@
 //   4. otherwise: fall back to using Posix mutex to serialize access
 
 #if defined(__cplusplus) && __cplusplus > 201100
-// G++ throws an error on trying to use C++ atomics with C linkage
-// all of the C++ files which (indirectly) include this header do so inside an extern "C" {}, so we need to
-//   exit out of the extern statement, make our definitions, and then restart another extern block.
-} // end of extern "C" block
+
 #include <atomic>
 
 typedef std::atomic<int> dt_atomic_int;
@@ -40,8 +37,6 @@ inline int dt_atomic_sub_int(dt_atomic_int *var, int decr) { return std::atomic_
 inline int dt_atomic_exch_int(dt_atomic_int *var, int value) { return std::atomic_exchange(var,value); }
 inline int dt_atomic_CAS_int(dt_atomic_int *var, int *expected, int value)
 { return std::atomic_compare_exchange_strong(var,expected,value); }
-
-extern "C" { // restart C linkage block
 
 #elif !defined(__STDC_NO_ATOMICS__)
 

--- a/src/common/colorlabels.h
+++ b/src/common/colorlabels.h
@@ -2,6 +2,11 @@
 
 #include "common/darktable.h"
 #include <gtk/gtk.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 /** array of names and constant to ease label manipulation */
 typedef enum dt_colorlables_enum
 {
@@ -34,6 +39,10 @@ const char *dt_colorlabels_to_string(int label);
 int dt_colorlabels_check_label(const int imgid, const int color);
 
 extern const struct dt_action_def_t dt_action_def_color_label;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -124,6 +124,19 @@ typedef unsigned int u_int;
 
 #endif /* _OPENMP */
 
+#ifndef _RELEASE
+#include "common/poison.h"
+#endif
+
+#include "common/usermanual_url.h"
+
+// for signal debugging symbols
+#include "control/signal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 /* Create cloned functions for various CPU SSE generations */
 /* See for instructions https://hannes.hauswedell.net/post/2017/12/09/fmv/ */
 /* TL;DR : use only on SIMD functions containing low-level paralellized/vectorized loops */
@@ -142,15 +155,6 @@ typedef unsigned int u_int;
 
 /* Helper to force stack vectors to be aligned on 64 bits blocks to enable AVX2 */
 #define DT_IS_ALIGNED(x) __builtin_assume_aligned(x, 64)
-
-#ifndef _RELEASE
-#include "common/poison.h"
-#endif
-
-#include "common/usermanual_url.h"
-
-// for signal debugging symbols
-#include "control/signal.h"
 
 #define DT_MODULE_VERSION 23 // version of dt's module interface
 
@@ -696,6 +700,10 @@ static inline const gchar *NQ_(const gchar *String)
   const gchar *context_end = strchr(String, '|');
   return context_end ? context_end + 1 : String;
 }
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/database.h
+++ b/src/common/database.h
@@ -20,6 +20,10 @@
 
 #include <glib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 struct dt_database_t;
 
 /** allocates and initializes database */
@@ -56,6 +60,10 @@ gchar *dt_database_get_most_recent_snap(const char* db_filename);
 void dt_database_start_transaction(const struct dt_database_t *db);
 void dt_database_release_transaction(const struct dt_database_t *db);
 void dt_database_rollback_transaction(const struct dt_database_t *db);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/datetime.h
+++ b/src/common/datetime.h
@@ -20,6 +20,10 @@
 #include <glib.h>
 #include "common/image.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 #define DT_DATETIME_EXIF_LENGTH 20  // exif format string length
 
 // The GTimeSpan saved in db is an offset to datetime_origin (0001:01:01 00:00:00)
@@ -113,6 +117,10 @@ GTimeSpan dt_datetime_gtimespan_add_numbers(const GTimeSpan dt, const dt_datetim
 // add values (represented by dt_datetime_t) to exif datetime
 gboolean dt_datetime_exif_add_numbers(const gchar *exif, const dt_datetime_t numbers, const gboolean add,
                                       gchar **result);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/dng_opcode.h
+++ b/src/common/dng_opcode.h
@@ -21,6 +21,10 @@
 #include <stdint.h>
 #include "image.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 typedef struct dt_dng_gain_map_t
 {
   uint32_t top;
@@ -43,3 +47,13 @@ typedef struct dt_dng_gain_map_t
 
 void dt_dng_opcode_process_opcode_list_2(uint8_t *buf, uint32_t size, dt_image_t *img);
 void dt_dng_opcode_process_opcode_list_3(uint8_t *buf, uint32_t size, dt_image_t *img);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -18,7 +18,6 @@
 
 #define __STDC_FORMAT_MACROS
 
-extern "C" {
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -33,7 +32,6 @@ extern "C" {
 #include <zlib.h>
 
 #include "control/control.h"
-}
 
 #include <array>
 #include <cassert>
@@ -56,7 +54,6 @@ extern "C" {
 
 using namespace std;
 
-extern "C" {
 #include "common/colorlabels.h"
 #include "common/darktable.h"
 #include "common/debug.h"
@@ -77,7 +74,6 @@ extern "C" {
 #include "develop/masks.h"
 #include "imageio/imageio_common.h"
 #include "imageio/imageio_jpeg.h"
-}
 
 #define DT_XMP_EXIF_VERSION 5
 

--- a/src/common/file_location.h
+++ b/src/common/file_location.h
@@ -21,6 +21,10 @@
 #include <gtk/gtk.h>
 #include <string.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 /** returns the users home directory */
 gchar *dt_loc_get_home_dir(const gchar *user);
 
@@ -54,6 +58,10 @@ void dt_loc_get_localedir(char *localedir, size_t bufsize);
 void dt_loc_get_tmp_dir(char *tmpdir, size_t bufsize);
 void dt_loc_get_user_config_dir(char *configdir, size_t bufsize);
 void dt_loc_get_user_cache_dir(char *cachedir, size_t bufsize);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -23,6 +23,10 @@
 #include <sqlite3.h>
 #include "develop/imageop.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 struct dt_develop_t;
 struct dt_iop_module_t;
 
@@ -157,6 +161,10 @@ void dt_history_hash_write(const int32_t imgid, dt_history_hash_values_t *hash);
 
 /** read hash values from db */
 void dt_history_hash_read(const int32_t imgid, dt_history_hash_values_t *hash);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -28,6 +28,10 @@
 #include <glib.h>
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 /** return value of image io functions. */
 typedef enum dt_imageio_retval_t
 {
@@ -537,6 +541,10 @@ float dt_image_get_exposure_bias(const struct dt_image_t *image_storage);
 char *dt_image_camera_missing_sample_message(const struct dt_image_t *img,
                                              const gboolean logmsg);
 void dt_image_check_camera_missing_sample(const struct dt_image_t *img);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/image_cache.h
+++ b/src/common/image_cache.h
@@ -21,6 +21,10 @@
 #include "common/cache.h"
 #include "common/image.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 typedef struct dt_image_cache_t
 {
   dt_cache_t cache;
@@ -72,6 +76,10 @@ void dt_image_cache_set_change_timestamp_from_image(dt_image_cache_t *cache, con
 void dt_image_cache_unset_change_timestamp(dt_image_cache_t *cache, const int32_t imgid);
 void dt_image_cache_set_export_timestamp(dt_image_cache_t *cache, const int32_t imgid);
 void dt_image_cache_set_print_timestamp(dt_image_cache_t *cache, const int32_t imgid);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/imagebuf.h
+++ b/src/common/imagebuf.h
@@ -23,6 +23,10 @@
 
 #include "develop/imageop.h" // for dt_iop_roi_t
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 // Allocate a 64-byte aligned buffer for an image of the given dimensions and channels.
 // The return value must be freed with dt_free_align().
 static inline float *__restrict__ dt_iop_image_alloc(const size_t width, const size_t height, const size_t ch)
@@ -136,6 +140,10 @@ void dt_iop_image_copy_benchmark();
 
 // load configurable settings from darktablerc
 void dt_iop_image_copy_configure();
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/interpolation.h
+++ b/src/common/interpolation.h
@@ -25,6 +25,10 @@
 #include <xmmintrin.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 /** Available interpolations */
 enum dt_interpolation_type
 {
@@ -201,6 +205,10 @@ void dt_interpolation_resample_roi_1c(const struct dt_interpolation *itor, float
                                       const dt_iop_roi_t *const roi_out, const int32_t out_stride,
                                       const float *const in, const dt_iop_roi_t *const roi_in,
                                       const int32_t in_stride);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/iop_order.h
+++ b/src/common/iop_order.h
@@ -117,12 +117,15 @@
          This is done by using the dt_ioppr_get_iop_order.
  */
 
-#ifndef DT_IOP_ORDER_H
-#define DT_IOP_ORDER_H
+#pragma once
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 struct dt_iop_module_t;
 struct dt_develop_t;
@@ -277,7 +280,10 @@ void dt_ioppr_print_module_iop_order(GList *iop_list, const char *msg);
 void dt_ioppr_print_history_iop_order(GList *history_list, const char *msg);
 void dt_ioppr_print_iop_order(GList *iop_order_list, const char *msg);
 
-#endif
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/metadata.h
+++ b/src/common/metadata.h
@@ -21,6 +21,10 @@
 #include "common/darktable.h"
 #include "gui/gtk.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 typedef enum dt_metadata_t
 {
   // do change the order. Must match with dt_metadata_def[] in metadata.c.
@@ -126,6 +130,10 @@ void dt_metadata_clear(const GList *imgs, const gboolean undo_on); // libs/metad
 
 /** check if the "Xmp.darktable.image_id" already exists */
 gboolean dt_metadata_already_imported(const char *filename, const char *datetime);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/mipmap_cache.h
+++ b/src/common/mipmap_cache.h
@@ -22,6 +22,10 @@
 #include "common/colorspaces.h"
 #include "common/image.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 // sizes stored in the mipmap cache, set to fixed values in mipmap_cache.c
 typedef enum dt_mipmap_size_t {
   DT_MIPMAP_0 = 0,
@@ -167,6 +171,11 @@ void dt_mipmap_cache_copy_thumbnails(const dt_mipmap_cache_t *cache, const uint3
 
 // return the mipmap corresponding to text value saved in prefs
 dt_mipmap_size_t dt_mipmap_cache_get_min_mip_from_pref(const char *value);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -52,6 +52,10 @@
 #include <CL/cl.h>
 // #pragma GCC diagnostic
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 #define ROUNDUP(a, n) ((a) % (n) == 0 ? (a) : ((a) / (n)+1) * (n))
 
 // use per device roundups here
@@ -525,9 +529,18 @@ int dt_opencl_avoid_atomics(const int devid);
 int dt_opencl_micro_nap(const int devid);
 gboolean dt_opencl_use_pinned_memory(const int devid);
 
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
+
 #else
 #include "control/conf.h"
 #include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 typedef struct dt_opencl_t
 {
   int inited;
@@ -669,6 +682,11 @@ static inline int dt_opencl_events_flush(const int devid, const int reset)
 static inline void dt_opencl_events_profiling(const int devid, const int aggregated)
 {
 }
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
+
 #endif
 
 // clang-format off

--- a/src/common/ratings.h
+++ b/src/common/ratings.h
@@ -21,6 +21,10 @@
 #include "common/darktable.h"
 #include <gtk/gtk.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 #define DT_VIEW_RATINGS_MASK 0x7
 // first three bits of dt_view_image_over_t
 
@@ -35,6 +39,10 @@ void dt_ratings_apply_on_image(const int imgid, const int rating, const gboolean
 void dt_ratings_apply_on_list(const GList *list, const int rating, const gboolean undo_on);
 
 extern const struct dt_action_def_t dt_action_def_rating;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -22,6 +22,10 @@
 #include <sqlite3.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 typedef struct dt_tag_t
 {
   guint id;
@@ -208,6 +212,10 @@ uint32_t dt_tag_get_tag_id_by_name(const char * const name);
 
 /** init the darktable tags table */
 void dt_set_darktable_tags();
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -22,6 +22,10 @@
 #include <string.h>
 #include <librsvg/rsvg.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 /** dynamically allocate and concatenate string */
 gchar *dt_util_dstrcat(gchar *str, const gchar *format, ...) __attribute__((format(printf, 2, 3)));
 
@@ -120,6 +124,10 @@ gboolean dt_is_scene_referred(void);
 
 // returns true if current settings is display-referred
 gboolean dt_is_display_referred(void);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/variables.h
+++ b/src/common/variables.h
@@ -22,6 +22,10 @@
 #include <stdint.h>
 #include "common/image.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 typedef struct dt_variables_params_t
 {
   /** used for expanding variables that uses filename $(FILE_FOLDER) $(FILE_NAME) and $(FILE_EXTENSION). */
@@ -74,6 +78,10 @@ char *dt_variables_expand(dt_variables_params_t *params,
                           const gboolean iterate);
 /** reset sequence number */
 void dt_variables_reset_sequence(dt_variables_params_t *params);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/control/conf.h
+++ b/src/control/conf.h
@@ -28,6 +28,10 @@
 #include <gtk/gtk.h>
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 typedef enum dt_confgen_type_t
 {
   DT_INT,
@@ -126,6 +130,10 @@ const char *dt_confgen_get_tooltip(const char *name);
 
 gboolean dt_conf_is_default(const char *name);
 gchar* dt_conf_expand_default_dir(const char *dir);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -38,6 +38,10 @@
 #include <shobjidl.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 struct dt_lib_backgroundjob_element_t;
 
 typedef GdkCursorType dt_cursor_t;
@@ -280,6 +284,10 @@ static inline int32_t dt_ctl_get_num_procs()
 #endif
 #endif
 }
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/control/jobs/control_jobs.h
+++ b/src/control/jobs/control_jobs.h
@@ -26,6 +26,10 @@
 #include "common/cups_print.h"
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 void dt_control_gpx_apply(const gchar *filename, int32_t filmid, const gchar *tz, GList *imgs);
 
 void dt_control_datetime(const GTimeSpan offset, const char *datetime, GList *imgs);
@@ -51,6 +55,10 @@ void dt_control_import(GList *imgs, const char *datetime_override, const gboolea
 void dt_control_seed_denoise();
 void dt_control_denoise();
 void dt_control_refresh_exif();
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -20,6 +20,10 @@
 
 #include <glib-object.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 /** \brief enum of signals to listen for in darktable.
     \note To add a new signal, first off add a enum and
     document what it's used for, then add a matching signal string
@@ -322,6 +326,10 @@ void dt_control_signal_unblock_by_func(const struct dt_control_signal_t *ctlsig,
     }                                                                                                                            \
     dt_control_signal_disconnect(ctlsig, cb, user_data);                                                                         \
   } while (0)
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -27,6 +27,10 @@
 
 #define DEVELOP_BLEND_VERSION (11)
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 typedef enum dt_develop_blend_colorspace_t
 {
   DEVELOP_BLEND_CS_NONE = 0,
@@ -476,6 +480,10 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
                                 cl_mem dev_in, cl_mem dev_out, const struct dt_iop_roi_t *roi_in,
                                 const struct dt_iop_roi_t *roi_out);
 #endif
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -29,6 +29,10 @@
 #include "control/settings.h"
 #include "develop/imageop.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 struct dt_iop_module_t;
 
 typedef struct dt_dev_history_item_t
@@ -556,6 +560,10 @@ void dt_dev_image_ext(
   int border_size,
   gboolean iso_12646,
   int32_t snapshot_id);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/develop/imageop_gui.h
+++ b/src/develop/imageop_gui.h
@@ -20,6 +20,10 @@
 
 #include "develop/imageop.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *param);
 
 GtkWidget *dt_bauhaus_combobox_from_params(dt_iop_module_t *self, const char *param);
@@ -50,6 +54,10 @@ GtkWidget *dt_iop_button_new(dt_iop_module_t *self, const gchar *label,
 
 /* returns up or !up depending on the masks_updown preference */
 gboolean dt_mask_scroll_increases(int up);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -28,6 +28,10 @@
 
 #define DEVELOP_MASKS_VERSION (6)
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 /**forms types */
 typedef enum dt_masks_type_t
 {
@@ -652,6 +656,10 @@ int dt_masks_roundup(int num, int mult)
   (type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? "plugins/darkroom/spots/" #shape "_" #param : "plugins/darkroom/masks/" #shape "/" #param)
 
 void dt_masks_draw_anchor(cairo_t *cr, gboolean selected, const float zoom_scale, const float x, const float y);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -21,6 +21,10 @@
 #include <cairo.h>
 #include <gtk/gtk.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 #define CPF_USER_DATA 0x1000
 
 typedef enum dtgtk_cairo_paint_flags_t
@@ -338,6 +342,10 @@ void dtgtk_cairo_paint_shortcut(cairo_t *cr, gint x, gint y, gint w, gint h, gin
 void dtgtk_cairo_paint_pin(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a menu icon for filtering in topbar */
 void dtgtk_cairo_paint_filtering_menu(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -24,6 +24,10 @@
 #include "libs/lib.h"
 #include "views/view.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 GtkWidget *dt_shortcuts_prefs(GtkWidget *widget);
 GHashTable *dt_shortcut_category_lists(dt_view_type_flags_t v);
 
@@ -209,6 +213,10 @@ GtkWidget *dt_action_button_new(dt_lib_module_t *self, const gchar *label, gpoin
 
 // create a shortcutable entry field
 GtkWidget *dt_action_entry_new(dt_action_t *ac, const gchar *label, gpointer callback, gpointer data, const gchar *tooltip, const gchar *text);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -24,6 +24,10 @@
 #include <gtk/gtk.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 #define DT_GUI_IOP_MODULE_CONTROL_SPACING 0
 
 #define DT_GUI_THUMBSIZE_REDUCE 0.7f
@@ -459,6 +463,10 @@ void dt_gui_update_collapsible_section(dt_gui_collapsible_section_t *cs);
 
 // routine to hide the collapsible section
 void dt_gui_hide_collapsible_section(dt_gui_collapsible_section_t *cs);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/imageio/format/exr.cc
+++ b/src/imageio/format/exr.cc
@@ -29,7 +29,6 @@
 #include <OpenEXR/ImfThreading.h>
 #include <OpenEXR/ImfOutputFile.h>
 
-extern "C" {
 #include "bauhaus/bauhaus.h"
 #include "common/colorspaces.h"
 #include "common/darktable.h"
@@ -39,7 +38,6 @@ extern "C" {
 #include "imageio/imageio_exr.h"
 #include "imageio/imageio_module.h"
 #include "imageio/format/imageio_format_api.h"
-}
 #include "imageio/imageio_exr.hh"
 
 #ifdef __cplusplus

--- a/src/imageio/imageio_common.h
+++ b/src/imageio/imageio_common.h
@@ -38,6 +38,10 @@
 // FIXME: kill this pls.
 #define FILTERS_ARE_4BAYER(filters) (FILTERS_ARE_CYGM(filters) || FILTERS_ARE_RGBE(filters))
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 typedef enum dt_imageio_levels_t
 {
   IMAGEIO_INT8 = 0x0,
@@ -175,6 +179,10 @@ cairo_surface_t *dt_imageio_preview(const int32_t imgid,
                                     const size_t height,
                                     const int history_end,
                                     const char *style_name);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/imageio/imageio_exr.cc
+++ b/src/imageio/imageio_exr.cc
@@ -34,7 +34,6 @@
 #include <OpenEXR/ImfThreading.h>
 #include <OpenEXR/ImfTiledInputFile.h>
 
-extern "C" {
 #include "common/colorspaces.h"
 #include "common/darktable.h"
 #include "common/exif.h"
@@ -44,7 +43,6 @@ extern "C" {
 #include "develop/develop.h"
 #include "imageio/imageio_common.h"
 #include "imageio/imageio_exr.h"
-}
 #include "imageio/imageio_exr.hh"
 
 dt_imageio_retval_t dt_imageio_open_exr(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *mbuf)

--- a/src/imageio/imageio_jpeg.h
+++ b/src/imageio/imageio_jpeg.h
@@ -32,6 +32,10 @@
 #include "common/image.h"
 #include "common/mipmap_cache.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 typedef struct dt_imageio_jpeg_t
 {
   int width, height;
@@ -69,6 +73,10 @@ dt_colorspaces_color_profile_type_t dt_imageio_jpeg_read_color_space(dt_imageio_
 
 /** utility function to read and open jpeg from imagio.c */
 dt_imageio_retval_t dt_imageio_open_jpeg(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/imageio/imageio_module.h
+++ b/src/imageio/imageio_module.h
@@ -34,6 +34,10 @@
 #include "lua/types.h"
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 
 /** Flag for the format modules */
 typedef enum dt_imageio_format_flags_t
@@ -151,6 +155,10 @@ void dt_imageio_remove_storage(dt_imageio_module_storage_t *storage);
 // and improve the readability of the displayed string itself in the "scale" field
 // of the settings export.
 gchar *dt_imageio_resizing_factor_get_and_parsing(double *num, double *denum);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/imageio/imageio_rawspeed.cc
+++ b/src/imageio/imageio_rawspeed.cc
@@ -29,7 +29,6 @@
 
 #define __STDC_LIMIT_MACROS
 
-extern "C" {
 #include "common/colorspaces.h"
 #include "common/darktable.h"
 #include "common/exif.h"
@@ -39,7 +38,6 @@ extern "C" {
 #include "imageio/imageio_common.h"
 #include "imageio/imageio_rawspeed.h"
 #include <stdint.h>
-}
 
 // define this function, it is only declared in rawspeed:
 int rawspeed_get_number_of_processor_cores()

--- a/src/iop/amaze_demosaic_RT.cc
+++ b/src/iop/amaze_demosaic_RT.cc
@@ -22,10 +22,16 @@
 #include <xmmintrin.h>
 #endif
 
-extern "C" {
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
 
+extern "C" {
 // otherwise the name will be mangled and the linker won't be able to see the function ...
 void amaze_demosaic_RT(
     dt_dev_pixelpipe_iop_t *piece,
@@ -35,12 +41,6 @@ void amaze_demosaic_RT(
     const dt_iop_roi_t *const roi_out,
     const int filters);
 }
-
-#include <algorithm>
-#include <cmath>
-#include <cstdint>
-#include <cstdlib>
-#include <cstring>
 
 static __inline float clampnan(const float x, const float m, const float M)
 {

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -18,7 +18,6 @@
 
 #define __STDC_FORMAT_MACROS
 
-extern "C" {
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -37,11 +36,11 @@ extern "C" {
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
-}
 #include "iop/Permutohedral.h"
-extern "C" {
 #include <gtk/gtk.h>
 #include <inttypes.h>
+
+extern "C" {
 
 /**
  * implementation of the 5d-color bilateral filter using andrew adams et al.'s

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -20,10 +20,6 @@
 
 #ifdef FULL_API_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "common/introspection.h"
 
 #include <cairo/cairo.h>
@@ -37,6 +33,10 @@ extern "C" {
 
 #ifdef HAVE_OPENCL
 #include <CL/cl.h>
+#endif
+
+#if defined(__cplusplus) && !defined(INCLUDE_API_FROM_MODULE_H)
+extern "C" {
 #endif
 
 struct dt_iop_module_so_t;
@@ -228,8 +228,8 @@ OPTIONAL(void, set_preferences, void *menu, struct dt_iop_module_t *self);
 
 #pragma GCC visibility pop
 
-#ifdef __cplusplus
-}
+#if defined(__cplusplus) && !defined(INCLUDE_API_FROM_MODULE_H)
+} // extern "C"
 #endif
 
 #endif // FULL_API_H

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -16,8 +16,6 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-extern "C" {
-
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -45,8 +43,6 @@ extern "C" {
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
-}
-
 #include <lensfun.h>
 
 #define MAXKNOTS 16

--- a/src/iop/tonemap.cc
+++ b/src/iop/tonemap.cc
@@ -26,8 +26,6 @@
 
 #define __STDC_FORMAT_MACROS
 
-extern "C" {
-
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -46,7 +44,6 @@ extern "C" {
 #include "iop/iop_api.h"
 #include <gtk/gtk.h>
 #include <inttypes.h>
-}
 
 #include "iop/Permutohedral.h"
 


### PR DESCRIPTION
A comment on #13673 pointed out the very dodgy practice in dt's codebase of wrapping #include inside an extern "C" { } from C++ files.  This PR fixes up all instances I could find, so that there should no longer be any headers (dt's or system) being included inside of an extern-C block.

Hopefully fixes the compile error for Apple arm64 found in that report.
