### PR TITLE
Bugfix: highlights opposed & segmentation

### DIFF
--- a/src/iop/hlrecovery_v2.c
+++ b/src/iop/hlrecovery_v2.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2022 darktable developers.
+    Copyright (C) 2022-23 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -219,7 +219,11 @@ static inline float _calc_refavg(const float *in,
   return (linear) ? powf(croot_refavg[color], HL_POWERF) : croot_refavg[color];
 }
 
-static void _initial_gradients(const size_t w, const size_t height, float *luminance, float *distance, float *gradient)
+static void _initial_gradients(const size_t w,
+                               const size_t height,
+                               float *luminance,
+                               float *distance,
+                               float *gradient)
 {
 #ifdef _OPENMP
   #pragma omp parallel for default(none) \
@@ -249,7 +253,11 @@ static void _initial_gradients(const size_t w, const size_t height, float *lumin
   }
 }
 
-static float _segment_maxdistance(const int width, const int height, float *distance, dt_iop_segmentation_t *seg, const int id)
+static float _segment_maxdistance(const int width,
+                                  const int height,
+                                  float *distance,
+                                  dt_iop_segmentation_t *seg,
+                                  const int id)
 {
   const int xmin = MAX(seg->xmin[id]-2, HL_BORDER);
   const int xmax = MIN(seg->xmax[id]+3, width - HL_BORDER);
@@ -288,13 +296,26 @@ static float _segment_attenuation(dt_iop_segmentation_t *seg, const int id, cons
   }
 }
 
-static float _segment_correction(dt_iop_segmentation_t *seg, const int id, const int mode, const int seg_border)
+static float _segment_correction(dt_iop_segmentation_t *seg,
+                                 const int id,
+                                 const int mode,
+                                 const int seg_border)
 {
   const float correction = _segment_attenuation(seg, id, mode);
   return correction - 0.1f * (float)seg_border;
 }
 
-static void _calc_distance_ring(const int width, const int xmin, const int xmax, const int ymin, const int ymax, float *gradient, float *distance, const float attenuate, const float dist, dt_iop_segmentation_t *seg, const int id)
+static void _calc_distance_ring(const int width,
+                                const int xmin,
+                                const int xmax,
+                                const int ymin,
+                                const int ymax,
+                                float *gradient,
+                                float *distance,
+                                const float attenuate,
+                                const float dist,
+                                dt_iop_segmentation_t *seg,
+                                const int id)
 {
 #ifdef _OPENMP
   #pragma omp parallel for default(none) \
@@ -332,7 +353,15 @@ static void _calc_distance_ring(const int width, const int xmin, const int xmax,
   }
 }
 
-static void _segment_gradients(const int width, const int height, float *distance, float *gradient, float *tmp, const int mode, dt_iop_segmentation_t *seg, const int id, const int seg_border)
+static void _segment_gradients(const int width,
+                               const int height,
+                               float *distance,
+                               float *gradient,
+                               float *tmp,
+                               const int mode,
+                               dt_iop_segmentation_t *seg,
+                               const int id,
+                               const int seg_border)
 {
   const int xmin = MAX(seg->xmin[id]-1, HL_BORDER);
   const int xmax = MIN(seg->xmax[id]+2, width - HL_BORDER);
@@ -395,7 +424,12 @@ static void _segment_gradients(const int width, const int height, float *distanc
   }
 }
 
-static void _add_poisson_noise(const int width, const int height, float *lum, dt_iop_segmentation_t *seg, const int id, const float noise_level)
+static void _add_poisson_noise(const int width,
+                               const int height,
+                               float *lum,
+                               dt_iop_segmentation_t *seg,
+                               const int id,
+                               const float noise_level)
 {
   const int xmin = MAX(seg->xmin[id], HL_BORDER);
   const int xmax = MIN(seg->xmax[id]+1, width - HL_BORDER);
@@ -425,9 +459,14 @@ static inline size_t _raw_to_plane(const int width, const int row, const int col
   return (HL_BORDER + (row / 3)) * width + (col / 3) + HL_BORDER;
 }
 
-static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece, const float *const input, float *const output,
-                         const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
-                         dt_iop_highlights_data_t *data, const int vmode, float *tmpout)
+static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece,
+                                  const float *const input,
+                                  float *const output,
+                                  const dt_iop_roi_t *const roi_in,
+                                  const dt_iop_roi_t *const roi_out,
+                                  dt_iop_highlights_data_t *data,
+                                  const int vmode,
+                                  float *tmpout)
 {
   const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
   const uint32_t filters = piece->pipe->dsc.filters;

--- a/src/iop/segmentation.h
+++ b/src/iop/segmentation.h
@@ -39,7 +39,7 @@ typedef struct dt_pos_t
 typedef struct dt_iop_segmentation_t
 {
   int *data;      // holding segment id's for every location
-  int *size;      // size of each segment      
+  int *size;      // size of each segment
   int *xmin;      // bounding rectangle for each segment
   int *xmax;
   int *ymin;
@@ -202,7 +202,12 @@ static inline int _test_dilate(const int *img, const size_t i, const size_t w1, 
   return retval;
 }
 
-static inline void _dilating(const int *img, int *o, const int w1, const int height, const int border, const int radius)
+static inline void _dilating(const int *img,
+                             int *o,
+                             const int w1,
+                             const int height,
+                             const int border,
+                             const int radius)
 {
 #ifdef _OPENMP
   #pragma omp parallel for default(none) \
@@ -326,7 +331,12 @@ static inline int _test_erode(const int *img, const size_t i, const size_t w1, c
   return retval;
 }
 
-static inline void _eroding(const int *img, int *o, const int w1, const int height, const int border, const int radius)
+static inline void _eroding(const int *img,
+                            int *o,
+                            const int w1,
+                            const int height,
+                            const int border,
+                            const int radius)
 {
 #ifdef _OPENMP
   #pragma omp parallel for default(none) \
@@ -341,9 +351,13 @@ static inline void _eroding(const int *img, int *o, const int w1, const int heig
   }
 }
 
-static inline void _intimage_borderfill(int *d, const int width, const int height, const int val, const int border)
+static inline void _intimage_borderfill(int *d,
+                                        const int width,
+                                        const int height,
+                                        const int val,
+                                        const int border)
 {
-  for(size_t i = 0; i < border * width; i++)                            
+  for(size_t i = 0; i < border * width; i++)
     d[i] = val;
   for(size_t i = (height - border - 1) * width; i < width*height; i++)
     d[i] = val;
@@ -356,7 +370,13 @@ static inline void _intimage_borderfill(int *d, const int width, const int heigh
   }
 }
 
-static gboolean _floodfill_segmentize(int yin, int xin, dt_iop_segmentation_t *seg, const int w, const int h, const int id, dt_ff_stack_t *stack)
+static gboolean _floodfill_segmentize(int yin,
+                                      int xin,
+                                      dt_iop_segmentation_t *seg,
+                                      const int w,
+                                      const int h,
+                                      const int id,
+                                      dt_ff_stack_t *stack)
 {
   if(id >= seg->slots - 2) return FALSE;
 
@@ -413,7 +433,7 @@ static gboolean _floodfill_segmentize(int yin, int xin, dt_iop_segmentation_t *s
           d[rp] = DT_SEG_ID_MASK + id;
         }
       }
-      
+
       if(yDown < h-border && d[yDown*w+x] == 1)
       {
         _push_stack(x, yDown, stack); firstXDown = lastXDown = TRUE;
@@ -432,7 +452,7 @@ static gboolean _floodfill_segmentize(int yin, int xin, dt_iop_segmentation_t *s
           d[rp] = DT_SEG_ID_MASK + id;
         }
       }
-      
+
       int xr = x + 1;
       while(xr < w-border && d[y*w+xr] == 1)
       {
@@ -674,7 +694,11 @@ void dt_segments_transform_closing(dt_iop_segmentation_t *seg, const int radius)
   _eroding(seg->tmp, img, width, height, border, radius);
 }
 
-void dt_segmentation_init_struct(dt_iop_segmentation_t *seg, const int width, const int height, const int border, const int wanted_slots)
+void dt_segmentation_init_struct(dt_iop_segmentation_t *seg,
+                                 const int width,
+                                 const int height,
+                                 const int border,
+                                 const int wanted_slots)
 {
   const int slots = MIN(wanted_slots, DT_SEG_ID_MASK - 2);
   if(slots != wanted_slots)


### PR DESCRIPTION
Strictly avoid chance for div-by-zero on the ununsed 4-th color channel, relevant for opposed and segmentation algos in cpu code path (possibly depending on compiler and compiler options).

@MStraeten could you recheck #12913 ? (Just in case ...)
