### PR TITLE
po/history label name

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2451,15 +2451,6 @@ void dt_dev_get_pointer_zoom_pos(dt_develop_t *dev,
   *zoom_y = zoom2_y;
 }
 
-void dt_dev_get_history_item_label(dt_dev_history_item_t *hist,
-                                   char *label,
-                                   const int cnt)
-{
-  gchar *module_label = dt_history_item_get_name(hist->module);
-  g_snprintf(label, cnt, "%s (%s)", module_label, hist->enabled ? _("on") : _("off"));
-  g_free(module_label);
-}
-
 int dt_dev_is_current_image(dt_develop_t *dev, uint32_t imgid)
 {
   return (dev->image_storage.id == imgid) ? 1 : 0;

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -32,6 +32,7 @@
 #include "common/mipmap_cache.h"
 #include "common/opencl.h"
 #include "common/tags.h"
+#include "common/presets.h"
 #include "control/conf.h"
 #include "control/control.h"
 #include "control/jobs.h"
@@ -1462,16 +1463,28 @@ void _dev_insert_module(dt_develop_t *dev, dt_iop_module_t *module, const int im
 {
   sqlite3_stmt *stmt;
 
+  // we make sure that the multi-name is updated if possible with the
+  // actual preset name if any is defined for the default parameters.
+
+  char *preset_name = dt_presets_get_name
+    (module->op,
+     module->default_params, module->params_size, TRUE,
+     module->blend_params, sizeof(dt_develop_blend_params_t));
+
   DT_DEBUG_SQLITE3_PREPARE_V2(
     dt_database_get(darktable.db),
-    "INSERT INTO memory.history VALUES (?1, 0, ?2, ?3, ?4, 1, NULL, 0, 0, '', 0)",
+    "INSERT INTO memory.history VALUES (?1, 0, ?2, ?3, ?4, 1, NULL, 0, 0, ?5, 0)",
     -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, module->version());
   DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 3, module->op, -1, SQLITE_TRANSIENT);
-  DT_DEBUG_SQLITE3_BIND_BLOB(stmt, 4, module->default_params, module->params_size, SQLITE_TRANSIENT);
+  DT_DEBUG_SQLITE3_BIND_BLOB(stmt, 4, module->default_params, module->params_size,
+                             SQLITE_TRANSIENT);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 5, preset_name ? preset_name : "", -1, SQLITE_TRANSIENT);
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);
+
+  g_free(preset_name);
 
   dt_print(DT_DEBUG_PARAMS, "[dev_insert_module] `%s' inserted to history\n", module->op);
 }
@@ -2826,7 +2839,7 @@ gchar *dt_history_item_get_name(const struct dt_iop_module_t *module)
   if(!module->multi_name[0] || strcmp(module->multi_name, "0") == 0)
     label = g_strdup(module->name());
   else
-    label = g_strdup_printf("%s %s", module->name(), module->multi_name);
+    label = g_strdup_printf("%s • %s", module->name(), module->multi_name);
   return label;
 }
 

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -407,7 +407,6 @@ void dt_dev_invalidate(dt_develop_t *dev);
 void dt_dev_invalidate_all(dt_develop_t *dev);
 void dt_dev_set_histogram(dt_develop_t *dev);
 void dt_dev_set_histogram_pre(dt_develop_t *dev);
-void dt_dev_get_history_item_label(dt_dev_history_item_t *hist, char *label, const int cnt);
 void dt_dev_reprocess_all(dt_develop_t *dev);
 void dt_dev_reprocess_center(dt_develop_t *dev);
 void dt_dev_reprocess_preview(dt_develop_t *dev);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -893,7 +893,9 @@ static gboolean _rename_module_key_press(GtkWidget *entry,
   {
     gtk_widget_show(module->instance_name);
 
-    g_signal_handlers_disconnect_by_func(entry, G_CALLBACK(_rename_module_key_press), module);
+    g_signal_handlers_disconnect_by_func(entry,
+                                         G_CALLBACK(_rename_module_key_press),
+                                         module);
     gtk_widget_destroy(entry);
     dt_iop_show_hide_header_buttons(module, NULL, TRUE, FALSE); // after removing entry
     dt_iop_gui_update_header(module);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -860,12 +860,6 @@ static gboolean _rename_module_key_press(GtkWidget *entry,
 
        const gchar *name = gtk_entry_get_text(GTK_ENTRY(entry));
 
-      // restore saved 1st character of instance name (without it the
-      // same name wouls still produce unnecessary copy + add history
-      // item)
-      module->multi_name[0] = module->multi_name[sizeof(module->multi_name) - 1];
-      module->multi_name[sizeof(module->multi_name) - 1] = 0;
-
       if(g_strcmp0(module->multi_name, name) != 0)
       {
         g_strlcpy(module->multi_name, name, sizeof(module->multi_name));
@@ -892,15 +886,13 @@ static gboolean _rename_module_key_press(GtkWidget *entry,
   }
   else if(event->keyval == GDK_KEY_Escape)
   {
-    // restore saved 1st character of instance name
-    module->multi_name[0] = module->multi_name[sizeof(module->multi_name) - 1];
-    module->multi_name[sizeof(module->multi_name) - 1] = 0;
-
     ended = 1;
   }
 
   if(ended)
   {
+    gtk_widget_show(module->instance_name);
+
     g_signal_handlers_disconnect_by_func(entry, G_CALLBACK(_rename_module_key_press), module);
     gtk_widget_destroy(entry);
     dt_iop_show_hide_header_buttons(module, NULL, TRUE, FALSE); // after removing entry
@@ -940,10 +932,8 @@ void dt_iop_gui_rename_module(dt_iop_module_t *module)
   gtk_entry_set_max_length(GTK_ENTRY(entry), sizeof(module->multi_name) - 1);
   gtk_entry_set_text(GTK_ENTRY(entry), module->multi_name);
 
-  // remove instance name but save 1st character in case of escape
-  module->multi_name[sizeof(module->multi_name) - 1] = module->multi_name[0];
-  module->multi_name[0] = 0;
-  dt_iop_gui_update_header(module);
+  //  hide module instance name as we need the space for the entry
+  gtk_widget_hide(module->instance_name);
 
   gtk_widget_add_events(entry, GDK_FOCUS_CHANGE_MASK);
   g_signal_connect(entry, "key-press-event", G_CALLBACK(_rename_module_key_press), module);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1121,6 +1121,10 @@ static void _iop_panel_name(dt_iop_module_t *module)
 {
   // IOP instance name if any
 
+  // do not mess with panel name if we are not on the top of the history
+  if(darktable.develop->history_end < g_list_length(darktable.develop->history))
+    return;
+
   GtkLabel *iname = GTK_LABEL(module->instance_name);
   gchar *new_label = NULL;
   gchar *multi_name = NULL;

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -179,6 +179,8 @@ void gui_cleanup(dt_lib_module_t *self)
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
                                      G_CALLBACK(_lib_history_change_callback), self);
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
+                                     G_CALLBACK(_lib_history_will_change_callback), self);
+  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
                                      G_CALLBACK(_lib_history_module_remove_callback), self);
   g_free(self->data);
   self->data = NULL;
@@ -1103,6 +1105,19 @@ static gboolean _changes_tooltip_callback(GtkWidget *widget,
   return show_tooltip;
 }
 
+static gchar *_lib_history_button_label(const dt_dev_history_item_t *item)
+{
+  gchar *label = NULL;
+  if(!item)
+    label = g_strdup("");
+  else if(!item->multi_name[0] || strcmp(item->multi_name, "0") == 0)
+    label = g_strdup(item->module->name());
+  else
+    label = g_strdup_printf("%s • %s", item->module->name(), item->multi_name);
+
+  return label;
+}
+
 static void _lib_history_change_callback(gpointer instance, gpointer user_data)
 {
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
@@ -1161,11 +1176,7 @@ static void _lib_history_change_callback(gpointer instance, gpointer user_data)
       history = g_list_next(history))
   {
     const dt_dev_history_item_t *hitem = (dt_dev_history_item_t *)(history->data);
-    gchar *label;
-    if(!hitem->multi_name[0] || strcmp(hitem->multi_name, "0") == 0)
-      label = g_strdup(hitem->module->name());
-    else
-      label = g_strdup_printf("%s %s", hitem->module->name(), hitem->multi_name);
+    gchar *label = _lib_history_button_label(hitem);
 
     const gboolean selected = (num == darktable.develop->history_end - 1);
     widget =


### PR DESCRIPTION
history: Update module label when it is changed.
    
Also the label now use the same format as used in module header.
    
Fixes #13702.
