### PR TITLE
maintenance: dedup colorspace conversions (to/from rec709 and srgb)

### DIFF
--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -1,6 +1,6 @@
 /*
  *    This file is part of darktable,
- *    Copyright (C) 2017-2021 darktable developers.
+ *    Copyright (C) 2017-2023 darktable developers.
  *
  *    darktable is free software: you can redistribute it and/or modify
  *    it under the terms of the GNU General Public License as published by
@@ -810,13 +810,6 @@ static inline float dt_camera_rgb_luminance(const dt_aligned_pixel_t rgb)
 static inline void dt_XYZ_D50_2_XYZ_D65(const dt_aligned_pixel_t XYZ_D50, dt_aligned_pixel_t XYZ_D65)
 {
   // Bradford adaptation matrix from http://www.brucelindbloom.com/index.html?Eqn_ChromAdapt.html
-#if 0
-  static const dt_colormatrix_t M = {
-      {  0.9555766f, -0.0230393f,  0.0631636f, 0.0f },
-      { -0.0282895f,  1.0099416f,  0.0210077f, 0.0f },
-      {  0.0122982f, -0.0204830f,  1.3299098f, 0.0f },
-  };
-#endif
   static const dt_colormatrix_t M_transposed = {
       {  0.9555766f, -0.0282895f,  0.0122982f, 0.0f },
       { -0.0230393f,  1.0099416f, -0.0204830f, 0.0f },
@@ -833,13 +826,6 @@ static inline void dt_XYZ_D50_2_XYZ_D65(const dt_aligned_pixel_t XYZ_D50, dt_ali
 static inline void dt_XYZ_D65_2_XYZ_D50(const dt_aligned_pixel_t XYZ_D65, dt_aligned_pixel_t XYZ_D50)
 {
   // Bradford adaptation matrix from http://www.brucelindbloom.com/index.html?Eqn_ChromAdapt.html
-#if 0
-  static const dt_colormatrix_t M = {
-      {  1.0478112f,  0.0228866f, -0.0501270f, 0.0f },
-      {  0.0295424f,  0.9904844f, -0.0170491f, 0.0f },
-      { -0.0092345f,  0.0150436f,  0.7521316f, 0.0f },
-  };
-#endif
   static const dt_colormatrix_t M_transposed = {
       {  1.0478112f,  0.0295424f, -0.0092345f, 0.0f },
       {  0.0228866f,  0.9904844f,  0.0150436f, 0.0f },
@@ -877,13 +863,6 @@ static inline void dt_XYZ_2_JzAzBz(const dt_aligned_pixel_t XYZ_D65, dt_aligned_
       { -0.2015100f, 1.120649f, 0.0531008f, 0.0f },
       { -0.0166008f, 0.264800f, 0.6684799f, 0.0f },
   };
-#if 0
-  static const dt_colormatrix_t A = {
-      { 0.5f,       0.5f,       0.0f,      0.0f },
-      { 3.524000f, -4.066708f,  0.542708f, 0.0f },
-      { 0.199076f,  1.096799f, -1.295875f, 0.0f },
-  };
-#endif
   static const dt_colormatrix_t A_transposed = {
       { 0.5f,       3.524000f,  0.199076f, 0.0f },
       { 0.5f,      -4.066708f,  1.096799f, 0.0f },

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -1341,14 +1341,6 @@ error:
   return FALSE;
 }
 
-// XYZ -> sRGB matrix
-static void XYZ_to_sRGB(const dt_aligned_pixel_t XYZ, dt_aligned_pixel_t sRGB)
-{
-  sRGB[0] =  3.1338561f * XYZ[0] - 1.6168667f * XYZ[1] - 0.4906146f * XYZ[2];
-  sRGB[1] = -0.9787684f * XYZ[0] + 1.9161415f * XYZ[1] + 0.0334540f * XYZ[2];
-  sRGB[2] =  0.0719453f * XYZ[0] - 0.2289914f * XYZ[1] + 1.4052427f * XYZ[2];
-}
-
 // detail enhancement via bilateral grid (function arguments in and out may represent identical buffers)
 static int detail_enhance(const float *const in, float *const out, const int width, const int height)
 {
@@ -1399,7 +1391,7 @@ static int detail_enhance(const float *const in, float *const out, const int wid
   {
     dt_aligned_pixel_t XYZ;
     dt_Lab_to_XYZ(out + index, XYZ);
-    XYZ_to_sRGB(XYZ, out + index);
+    dt_XYZ_to_linearRGB(XYZ, out + index);
   }
 
   return success;

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -1,6 +1,6 @@
 /*
   This file is part of darktable,
-  Copyright (C) 2016-2022 darktable developers.
+  Copyright (C) 2016-2023 darktable developers.
 
   darktable is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -1349,14 +1349,6 @@ static void XYZ_to_sRGB(const dt_aligned_pixel_t XYZ, dt_aligned_pixel_t sRGB)
   sRGB[2] =  0.0719453f * XYZ[0] - 0.2289914f * XYZ[1] + 1.4052427f * XYZ[2];
 }
 
-// sRGB -> XYZ matrix
-static void sRGB_to_XYZ(const dt_aligned_pixel_t sRGB, dt_aligned_pixel_t XYZ)
-{
-  XYZ[0] = 0.4360747f * sRGB[0] + 0.3850649f * sRGB[1] + 0.1430804f * sRGB[2];
-  XYZ[1] = 0.2225045f * sRGB[0] + 0.7168786f * sRGB[1] + 0.0606169f * sRGB[2];
-  XYZ[2] = 0.0139322f * sRGB[0] + 0.0971045f * sRGB[1] + 0.7141733f * sRGB[2];
-}
-
 // detail enhancement via bilateral grid (function arguments in and out may represent identical buffers)
 static int detail_enhance(const float *const in, float *const out, const int width, const int height)
 {
@@ -1379,7 +1371,7 @@ static int detail_enhance(const float *const in, float *const out, const int wid
   for(size_t index = 0; index < 4*npixels; index += 4)
   {
     dt_aligned_pixel_t XYZ;
-    sRGB_to_XYZ(in + index, XYZ);
+    dt_Rec709_to_XYZ_D50(in + index, XYZ);  // convert linear sRBG to XYZ
     dt_XYZ_to_Lab(XYZ, out + index);
   }
 

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2021 darktable developers.
+    Copyright (C) 2011-2023x darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -284,11 +284,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   }
   else
   {
-    // this fits better. conversion matrix from sRGB to XYZ@D50 - which is what dt_XYZ_to_Lab() expects as
-    // input
-    XYZ[0] = (rgb[0] * 0.4360747f) + (rgb[1] * 0.3850649f) + (rgb[2] * 0.1430804f);
-    XYZ[1] = (rgb[0] * 0.2225045f) + (rgb[1] * 0.7168786f) + (rgb[2] * 0.0606169f);
-    XYZ[2] = (rgb[0] * 0.0139322f) + (rgb[1] * 0.0971045f) + (rgb[2] * 0.7141733f);
+    dt_Rec709_to_XYZ_D50(rgb, XYZ);
   }
 
   dt_XYZ_to_Lab(XYZ, Lab);

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2023x darktable developers.
+    Copyright (C) 2011-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -1,6 +1,6 @@
 /*
   This file is part of darktable,
-  Copyright (C) 2015-2021 darktable developers.
+  Copyright (C) 2015-2023 darktable developers.
 
   darktable is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -200,11 +200,7 @@ static inline float hue_conversion(const float HSL_Hue)
   dt_aligned_pixel_t Lab = { 0 };
 
   hsl2rgb(rgb, HSL_Hue, 1.0f, 0.5f);
-
-  XYZ[0] = (rgb[0] * 0.4360747f) + (rgb[1] * 0.3850649f) + (rgb[2] * 0.1430804f);
-  XYZ[1] = (rgb[0] * 0.2225045f) + (rgb[1] * 0.7168786f) + (rgb[2] * 0.0606169f);
-  XYZ[2] = (rgb[0] * 0.0139322f) + (rgb[1] * 0.0971045f) + (rgb[2] * 0.7141733f);
-
+  dt_Rec709_to_XYZ_D50(rgb, XYZ);
   dt_XYZ_to_Lab(XYZ, Lab);
 
   // Hue from LCH color space in [-pi, +pi] interval


### PR DESCRIPTION
Remove multiple copies of color matrices and associated duplicate code.  Note that some of the "insertions" are moved code so that globals could be accessed or related functions appear together.

I've run the entire integration test suite, and while this PR fails six tests, so does master as of an hour ago.
```
Errors     6
   - 0018-perspective-corr
   - 0032-watermark
   - 0035-multiple-modules
   - 0077-croprotate-keystone
   - 0096-lensfun
   - 0097-sigmoid
```
