### PR TITLE
colorize: optimize pixel loop

### DIFF
--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -126,40 +126,39 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
   return 1;
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
-             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+void process(struct dt_iop_module_t *self,
+             dt_dev_pixelpipe_iop_t *piece,
+             const void *const ivoid,
+             void *const ovoid,
+             const dt_iop_roi_t *const roi_in,
+             const dt_iop_roi_t *const roi_out)
 {
-  float *in, *out;
+  if(!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece->colors,
+                                         ivoid, ovoid, roi_in, roi_out))
+    return;
+
+  const float *const in = (float*)ivoid;
+  float *const out = (float*)ovoid;
   dt_iop_colorize_data_t *d = (dt_iop_colorize_data_t *)piece->data;
-  const int ch = piece->colors;
 
   const float L = d->L;
   const float a = d->a;
   const float b = d->b;
   const float mix = d->mix;
   const float Lmlmix = L - (mix * 100.0f) / 2.0f;
+  const size_t npixels = (size_t)roi_out->height * roi_out->width;
+  const dt_aligned_pixel_t color = { 0.0f, a, b, 0.0f };
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(a, b, ch, ivoid, Lmlmix, mix, ovoid, roi_out) \
-  private(in, out) \
+  dt_omp_firstprivate(a, b, in, out, Lmlmix, mix, npixels, color)  \
   schedule(static)
 #endif
-  for(int k = 0; k < roi_out->height; k++)
+  for(size_t k = 0; k < npixels; k++)
   {
-
-    const int stride = ch * roi_out->width;
-
-    in = (float *)ivoid + (size_t)k * stride;
-    out = (float *)ovoid + (size_t)k * stride;
-
-    for(int l = 0; l < stride; l += ch)
-    {
-      out[l + 0] = Lmlmix + in[l + 0] * mix;
-      out[l + 1] = a;
-      out[l + 2] = b;
-      out[l + 3] = in[l + 3];
-    }
+    const float mixed_L = Lmlmix + in[4*k + 0] * mix;
+    copy_pixel(out + 4*k, color);
+    out[4*k] = mixed_L;
   }
 }
 


### PR DESCRIPTION
```
Thr    Master    PR
1      18.53    14.71
2      10.83     9.15
4       7.69     7.57
8       7.04     6.89
16      7.39     7.45
32      7.78     7.75
```
I tried using copy_pixel_nontemporal, but the compiler added enough additional memory accesses to build up the dt_aligned_pixel_t that it was substantially slower when the memory bus is not saturated (+300% at two threads, -30% at 32 threads due to decreased main-memory bandwidth -- the intermediate memory accesses all stay in L1).

Verified pixel-identical on integration test 0057.
