### PR TITLE
Fix slideshow not working on HiDPI displays

### DIFF
--- a/src/views/slideshow.c
+++ b/src/views/slideshow.c
@@ -202,7 +202,16 @@ static int _process_image(dt_slideshow_t *d, dt_slideshow_slot_t slot)
   dt_pthread_mutex_unlock(&d->lock);
 
   dt_dev_image_ext
-    (imgid, d->width, d->height, -1, &buf, &width, &height, 0, FALSE, -1);
+    (imgid, 
+     d->width / darktable.gui->ppd,
+     d->height / darktable.gui->ppd,
+     -1,
+     &buf,
+     &width,
+     &height,
+     0,
+     FALSE,
+     -1);
 
   dt_pthread_mutex_lock(&d->lock);
 


### PR DESCRIPTION
fixes #13678

Not the most important module but this bug has bothered me as well.

The problem is that the pixel density of HiDPI displays is used twice. The generated image for the slideshow is doubled in width and height, leading to an endless loop in the slideshow module.

Not sure if I changed that on the correct position, so please review.
