### PR TITLE
Fix color harmony font size

### DIFF
--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1279,16 +1279,10 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
       PangoRectangle ink;
       PangoFontDescription *desc = pango_font_description_copy_static(darktable.bauhaus->pango_font_desc);
       pango_font_description_set_weight(desc, PANGO_WEIGHT_NORMAL);
-      pango_font_description_set_absolute_size(desc, PANGO_SCALE);
+      pango_font_description_set_absolute_size(desc, DT_PIXEL_APPLY_DPI(16) * PANGO_SCALE);
       layout = pango_cairo_create_layout(cr);
       pango_layout_set_font_description(layout, desc);
       pango_layout_set_alignment(layout, PANGO_ALIGN_RIGHT);
-
-      // scale conservatively to 100% of width:
-      pango_layout_set_text(layout, _("analogous complementary"), -1);
-      pango_layout_get_pixel_extents(layout, NULL, &ink);
-      pango_font_description_set_absolute_size(desc, DT_PIXEL_APPLY_DPI(16) * PANGO_SCALE);
-      pango_layout_set_font_description(layout, desc);
 
       gchar *text = g_strdup_printf("%d°\n%s", d->harmony_rotation, _(hm.name));
 

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1287,7 +1287,7 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
       // scale conservatively to 100% of width:
       pango_layout_set_text(layout, _("analogous complementary"), -1);
       pango_layout_get_pixel_extents(layout, NULL, &ink);
-      pango_font_description_set_absolute_size(desc, width * 0.9 / ink.width * PANGO_SCALE);
+      pango_font_description_set_absolute_size(desc, DT_PIXEL_APPLY_DPI(16) * PANGO_SCALE);
       pango_layout_set_font_description(layout, desc);
 
       gchar *text = g_strdup_printf("%d°\n%s", d->harmony_rotation, _(hm.name));


### PR DESCRIPTION
Fixes #13703 
Setting font size for color harmony name in proportion of the vectorscope graph size does not work with est asian fonts, as they use less "characters" and font size becomes too large.
With this PR we use a fixed font size for all languages

![image](https://user-images.githubusercontent.com/43290988/221004736-61d106d1-392b-441b-9e61-33db264773c3.png)
