### PR TITLE
bilat: add checks for memory allocation failure

### DIFF
--- a/src/common/bilateral.c
+++ b/src/common/bilateral.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2016-2021 darktable developers.
+    Copyright (C) 2016-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -53,8 +53,10 @@ void dt_bilateral_grid_size(dt_bilateral_t *b, const int width, const int height
   b->size_y = (int)ceilf(height / b->sigma_s) + 1;
   b->size_z = (int)ceilf(L_range / b->sigma_r) + 1;
 #if 0
-  if(b->sigma_s != sigma_s) fprintf(stderr, "[bilateral] clamped sigma_s (%g -> %g)!\n",sigma_s,b->sigma_s);
-  if(b->sigma_r != sigma_r) fprintf(stderr, "[bilateral] clamped sigma_r (%g -> %g)!\n",sigma_r,b->sigma_r);
+  if(b->sigma_s != sigma_s)
+    dt_print(DT_DEBUG_ALWAYS, "[bilateral] clamped sigma_s (%g -> %g)!\n",sigma_s,b->sigma_s);
+  if(b->sigma_r != sigma_r)
+    dt_print(DT_DEBUG_ALWAYS, "[bilateral] clamped sigma_r (%g -> %g)!\n",sigma_r,b->sigma_r);
 #endif
 }
 
@@ -151,7 +153,8 @@ dt_bilateral_t *dt_bilateral_init(const int width,     // width of input image
   b->buf = dt_calloc_align_float(b->size_x * b->size_z * b->numslices * b->slicerows);
   if(!b->buf)
   {
-    fprintf(stderr,"[bilateral] unable to allocate buffer for %zux%zux%zu grid\n",b->size_x,b->size_y,b->size_z);
+    dt_print(DT_DEBUG_ALWAYS,
+             "[bilateral] unable to allocate buffer for %zux%zux%zu grid\n",b->size_x,b->size_y,b->size_z);
     free(b);
     return NULL;
   }

--- a/src/common/locallaplacian.c
+++ b/src/common/locallaplacian.c
@@ -569,7 +569,7 @@ void local_laplacian_internal(
     padded[0] = ll_pad_input(input, wd, ht, max_supp, &w, &h, 0);
 
   // allocate pyramid pointers for padded input
-  gboolean success = TRUE;
+  gboolean success = padded[0] != NULL;
   for(int l=1;l<=last_level;l++)
   {
     padded[l] = dt_alloc_align_float((size_t)dl(w,l) * dl(h,l));
@@ -602,6 +602,10 @@ void local_laplacian_internal(
       dt_free_align(padded[l]);
       dt_free_align(output[l]);
     }
+    // copy the input buffer to the output so that we at least get a
+    // valid result
+    for(size_t k = 0; k < (size_t)4 * wd * ht; k++)
+      out[k] = input[k];
     return;
   }
 
@@ -633,7 +637,13 @@ void local_laplacian_internal(
     {
       buf[k][l] = dt_alloc_align_float((size_t)dl(w,l)*dl(h,l));
       if(!buf[k][l])
+      {
+        // copy the input buffer to the output so that we at least get a
+        // valid result
+        for(size_t p = 0; p < (size_t)4 * wd * ht; p++)
+          out[p] = input[p];
         goto cleanup;
+      }
     }
   
   // the paper says remapping only level 3 not 0 does the trick, too

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2020 darktable developers.
+    Copyright (C) 2012-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -22,6 +22,7 @@
 #include "bauhaus/bauhaus.h"
 #include "common/bilateral.h"
 #include "common/bilateralcl.h"
+#include "common/imagebuf.h"
 #include "common/locallaplacian.h"
 #include "common/locallaplaciancl.h"
 #include "develop/imageop.h"
@@ -315,10 +316,18 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
   if(d->mode == s_mode_bilateral)
   {
     dt_bilateral_t *b = dt_bilateral_init(roi_in->width, roi_in->height, sigma_s, sigma_r);
-    dt_bilateral_splat(b, (float *)i);
-    dt_bilateral_blur(b);
-    dt_bilateral_slice(b, (float *)i, (float *)o, d->detail);
-    dt_bilateral_free(b);
+    if (b)
+    {
+      dt_bilateral_splat(b, (float *)i);
+      dt_bilateral_blur(b);
+      dt_bilateral_slice(b, (float *)i, (float *)o, d->detail);
+      dt_bilateral_free(b);
+    }
+    else
+    {
+      // dt_bilateral_init will have spit out an error message.  Now just copy the input to output
+      dt_iop_image_copy_by_size(o, i, roi_out->width, roi_out->height, piece->colors);
+    }
   }
   else // s_mode_local_laplacian
   {
@@ -345,10 +354,18 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   if(d->mode == s_mode_bilateral)
   {
     dt_bilateral_t *b = dt_bilateral_init(roi_in->width, roi_in->height, sigma_s, sigma_r);
-    dt_bilateral_splat(b, (float *)i);
-    dt_bilateral_blur(b);
-    dt_bilateral_slice(b, (float *)i, (float *)o, d->detail);
-    dt_bilateral_free(b);
+    if (b)
+    {
+      dt_bilateral_splat(b, (float *)i);
+      dt_bilateral_blur(b);
+      dt_bilateral_slice(b, (float *)i, (float *)o, d->detail);
+      dt_bilateral_free(b);
+    }
+    else
+    {
+      // dt_bilateral_init will have spit out an error message.  Now just copy the input to output
+      dt_iop_image_copy_by_size(o, i, roi_out->width, roi_out->height, piece->colors);
+    }
   }
   else // s_mode_local_laplacian
   {


### PR DESCRIPTION
Hopefully fixes #13717 by preventing local contrast from crashing if there is insufficient memory to allocate working buffers.