### PR TITLE
maintenance: memory allocation checks

### DIFF
--- a/src/common/box_filters.c
+++ b/src/common/box_filters.c
@@ -44,8 +44,7 @@
 #define PREFETCH_NTA(addr)
 #endif
 
-static void _blur_horizontal_1ch(
-    float *const restrict buf,
+static void _blur_horizontal_1ch(float *const restrict buf,
     const int height,
     const int width,
     const int radius,
@@ -109,8 +108,7 @@ static void _blur_horizontal_1ch(
   return;
 }
 
-static void _blur_horizontal_2ch(
-    float *const restrict buf,
+static void _blur_horizontal_2ch(float *const restrict buf,
     const int height,
     const int width,
     const int radius,
@@ -187,8 +185,8 @@ static void _blur_horizontal_2ch(
 // With optimization enabled, this gets inlined and interleaved with other instructions as though it had been
 // written in place, so we get a net win from better vectorization.
 static void _load_add_4wide(float *const restrict out,
-                           dt_aligned_pixel_t accum,
-                           const float *const restrict values)
+                            dt_aligned_pixel_t accum,
+                            const float *const restrict values)
 {
   for_four_channels(c,aligned(accum, out))
   {
@@ -199,7 +197,7 @@ static void _load_add_4wide(float *const restrict out,
 }
 
 static void _sub_4wide(float *const restrict accum,
-                      const dt_aligned_pixel_t values)
+                       const dt_aligned_pixel_t values)
 {
   for_four_channels(c,aligned(accum))
     accum[c] -= values[c];
@@ -208,8 +206,7 @@ static void _sub_4wide(float *const restrict accum,
 // Put the to-be-vectorized loop into a function by itself to nudge the compiler into actually vectorizing...
 // With optimization enabled, this gets inlined and interleaved with other instructions as though it had been
 // written in place, so we get a net win from better vectorization.
-static void _load_add_4wide_Kahan(
-    float *const restrict out,
+static void _load_add_4wide_Kahan(float *const restrict out,
     dt_aligned_pixel_t accum,
     const float *const restrict values,
     float *const restrict comp)
@@ -226,8 +223,7 @@ static void _load_add_4wide_Kahan(
   }
 }
 
-static void _sub_4wide_Kahan(
-    float *const restrict accum,
+static void _sub_4wide_Kahan(float *const restrict accum,
     const dt_aligned_pixel_t values,
     float *const restrict comp)
 {
@@ -241,17 +237,16 @@ static void _sub_4wide_Kahan(
   }
 }
 
-static void store_scaled_4wide(
-    float *const restrict out,
-    const dt_aligned_pixel_t in,
-    const float scale)
+static void store_scaled_4wide(float *const restrict out,
+                               const dt_aligned_pixel_t in,
+                               const float scale)
 {
   for_four_channels(c,aligned(in))
     out[c] = in[c] / scale;
 }
 
 static void _sub_16wide(float *const restrict accum,
-                       const float *const restrict values)
+                        const float *const restrict values)
 {
 #ifdef _OPENMP
 #pragma omp simd aligned(accum : 64) aligned(values : 16)
@@ -261,8 +256,7 @@ static void _sub_16wide(float *const restrict accum,
 }
 
 // copy 16 floats from a possibly-unaligned buffer into aligned temporary space, and also add to accumulator
-static void _load_add_16wide(
-    float *const restrict out,
+static void _load_add_16wide(float *const restrict out,
     float *const restrict accum,
     const float *const restrict in)
 {
@@ -277,8 +271,7 @@ static void _load_add_16wide(
   }
 }
 
-static void _sub_16wide_Kahan(
-    float *const restrict accum,
+static void _sub_16wide_Kahan(float *const restrict accum,
     const float *const restrict values,
     float *const restrict comp)
 {
@@ -297,8 +290,7 @@ static void _sub_16wide_Kahan(
 }
 
 // copy 16 floats from a possibly-unaligned buffer into aligned temporary space, and also add to accumulator
-static void _load_add_16wide_Kahan(
-    float *const restrict out,
+static void _load_add_16wide_Kahan(float *const restrict out,
     float *const restrict accum,
     const float *const restrict in,
     float *const restrict comp)
@@ -319,7 +311,7 @@ static void _load_add_16wide_Kahan(
 }
 
 // copy 16 floats from aligned temporary space back to the possibly-unaligned user buffer
-static void store_16wide(float *const restrict out,
+static void _store_16wide(float *const restrict out,
                          const float *const restrict in)
 {
 #ifdef _OPENMP
@@ -329,8 +321,7 @@ static void store_16wide(float *const restrict out,
     out[c] = in[c];
 }
 
-static void store_scaled_16wide(
-    float *const restrict out,
+static void store_scaled_16wide(float *const restrict out,
     const float *const restrict in,
     const float scale)
 {
@@ -341,8 +332,7 @@ static void store_scaled_16wide(
     out[c] = in[c] / scale;
 }
 
-static void _sub_Nwide_Kahan(
-    const size_t N,
+static void _sub_Nwide_Kahan(const size_t N,
     float *const restrict accum,
     const float *const restrict values,
     float *const restrict comp)
@@ -362,8 +352,7 @@ static void _sub_Nwide_Kahan(
 }
 
 // copy N (<=16) floats from a possibly-unaligned buffer into aligned temporary space, and also add to accumulator
-static void _load_add_Nwide_Kahan(
-    const size_t N,
+static void _load_add_Nwide_Kahan(const size_t N,
     float *const restrict out,
     float *const restrict accum,
     const float *const restrict in,
@@ -384,8 +373,7 @@ static void _load_add_Nwide_Kahan(
   }
 }
 
-static void store_scaled_Nwide(
-    const size_t N,
+static void store_scaled_Nwide(const size_t N,
     float *const restrict out,
     const float *const restrict in,
     const float scale)
@@ -398,8 +386,7 @@ static void store_scaled_Nwide(
 }
 
 
-static void _blur_horizontal_4ch(
-    float *const restrict buf,
+static void _blur_horizontal_4ch(float *const restrict buf,
     const size_t height,
     const size_t width,
     const size_t radius,
@@ -464,8 +451,7 @@ static void _blur_horizontal_4ch(
 }
 
 // invoked inside an OpenMP parallel for, so no need to parallelize
-static void _blur_horizontal_4ch_Kahan(
-    float *const restrict buf,
+static void _blur_horizontal_4ch_Kahan(float *const restrict buf,
     const size_t width,
     const size_t radius,
     float *const restrict scratch)
@@ -515,8 +501,7 @@ static void _blur_horizontal_4ch_Kahan(
 }
 
 // invoked inside an OpenMP parallel for, so no need to parallelize
-static void _blur_horizontal_Nch_Kahan(
-    const size_t N,
+static void _blur_horizontal_Nch_Kahan(const size_t N,
     float *const restrict buf,
     const size_t width,
     const size_t radius,
@@ -570,8 +555,7 @@ static void _blur_horizontal_Nch_Kahan(
 }
 
 #ifdef __SSE2__
-static void _blur_vertical_1ch_sse(
-    float *const restrict buf,
+static void _blur_vertical_1ch_sse(float *const restrict buf,
     const int height,
     const int width,
     const int radius,
@@ -638,8 +622,7 @@ static void _blur_vertical_1ch_sse(
 #endif /* __SSE2__ */
 
 #ifdef __SSE2__
-static void _blur_vertical_4ch_sse(
-    float *const restrict buf,
+static void _blur_vertical_4ch_sse(float *const restrict buf,
     const size_t height,
     const size_t width,
     const size_t radius,
@@ -718,8 +701,7 @@ static void _blur_vertical_4ch_sse(
 #endif /* __SSE2__ */
 
 // invoked inside an OpenMP parallel for, so no need to parallelize
-static void _blur_vertical_1wide(
-    float *const restrict buf,
+static void _blur_vertical_1wide(float *const restrict buf,
     const size_t height,
     const size_t width,
     const size_t radius,
@@ -789,8 +771,7 @@ static void _blur_vertical_1wide(
 }
 
 // invoked inside an OpenMP parallel for, so no need to parallelize
-static void _blur_vertical_1wide_Kahan(
-    float *const restrict buf,
+static void _blur_vertical_1wide_Kahan(float *const restrict buf,
     const size_t height,
     const size_t width,
     const size_t radius,
@@ -861,8 +842,7 @@ static void _blur_vertical_1wide_Kahan(
 }
 
 // invoked inside an OpenMP parallel for, so no need to parallelize
-static void _blur_vertical_4wide(
-    float *const restrict buf,
+static void _blur_vertical_4wide(float *const restrict buf,
     const size_t height,
     const size_t width,
     const size_t radius,
@@ -932,8 +912,7 @@ static void _blur_vertical_4wide(
 }
 
 // invoked inside an OpenMP parallel for, so no need to parallelize
-static void _blur_vertical_4wide_Kahan(
-    float *const restrict buf,
+static void _blur_vertical_4wide_Kahan(float *const restrict buf,
     const size_t height,
     const size_t width,
     const size_t radius,
@@ -996,8 +975,7 @@ static void _blur_vertical_4wide_Kahan(
 }
 
 // invoked inside an OpenMP parallel for, so no need to parallelize
-static void _blur_vertical_16wide(
-    float *const restrict buf,
+static void _blur_vertical_16wide(float *const restrict buf,
     const size_t height,
     const size_t width,
     const size_t radius,
@@ -1069,8 +1047,7 @@ static void _blur_vertical_16wide(
 }
 
 // invoked inside an OpenMP parallel for, so no need to parallelize
-static void _blur_vertical_16wide_Kahan(
-    float *const restrict buf,
+static void _blur_vertical_16wide_Kahan(float *const restrict buf,
     const size_t height,
     const size_t width,
     const size_t radius,
@@ -1225,8 +1202,7 @@ static void dt_box_mean_4ch(float *const buf,
   dt_free_align(scanlines);
 }
 
-static void box_mean_vert_1ch_Kahan(
-    float *const buf,
+static void box_mean_vert_1ch_Kahan(float *const buf,
     const int height,
     const size_t width,
     const size_t radius)
@@ -1262,8 +1238,7 @@ static void box_mean_vert_1ch_Kahan(
   dt_free_align(scratch_buf);
 }
 
-static void dt_box_mean_4ch_Kahan(
-    float *const buf,
+static void dt_box_mean_4ch_Kahan(float *const buf,
     const size_t height,
     const size_t width,
     const int radius,
@@ -1293,8 +1268,7 @@ static void dt_box_mean_4ch_Kahan(
 
 }
 
-static inline void box_mean_2ch(
-    float *const restrict in,
+static inline void box_mean_2ch(float *const restrict in,
     const size_t height,
     const size_t width,
     const int radius,
@@ -1345,8 +1319,7 @@ void dt_box_mean(float *const buf,
     dt_unreachable_codepath();
 }
 
-void dt_box_mean_horizontal(
-    float *const restrict buf,
+void dt_box_mean_horizontal(float *const restrict buf,
     const size_t width,
     const int ch,
     const int radius,
@@ -1380,8 +1353,7 @@ void dt_box_mean_horizontal(
     dt_unreachable_codepath();
 }
 
-void dt_box_mean_vertical(
-    float *const buf,
+void dt_box_mean_vertical(float *const buf,
     const size_t height,
     const size_t width,
     const int ch,
@@ -1409,12 +1381,11 @@ static inline float window_max(const float *x, int n)
 
 // calculate the one-dimensional moving maximum over a window of size 2*w+1
 // input array x has stride 1, output array y has stride stride_y
-static inline void box_max_1d(
-    int N,
-    const float *const restrict x,
-    float *const restrict y,
-    size_t stride_y,
-    int w)
+static inline void box_max_1d(const int N,
+                              const float *const restrict x,
+                              float *const restrict y,
+                              const size_t stride_y,
+                              const int w)
 {
   float m = window_max(x, MIN(w + 1, N));
   for(int i = 0; i < N; i++)
@@ -1443,8 +1414,7 @@ static void set_16wide(float *const restrict out, const float value)
     out[c] = value;
 }
 
-static inline void update_max_16wide(
-    float m[16],
+static inline void update_max_16wide(float m[16],
     const float *const restrict base)
 {
 #ifdef _OPENMP
@@ -1456,8 +1426,7 @@ static inline void update_max_16wide(
   }
 }
 
-static inline void _load_update_max_16wide(
-    float *const restrict out,
+static inline void _load_update_max_16wide(float *const restrict out,
     float m[16],
     const float *const restrict base)
 {
@@ -1475,8 +1444,7 @@ static inline void _load_update_max_16wide(
 // calculate the one-dimensional moving maximum on four adjacent columns over a window of size 2*w+1
 // input/output array 'buf' has stride 'stride' and we will write 16 consecutive elements every stride elements
 // (thus processing a cache line at a time)
-static inline void box_max_vert_16wide(
-    const int N,
+static inline void box_max_vert_16wide(const int N,
     float *const restrict scratch,
     float *const restrict buf,
     const int stride,
@@ -1496,7 +1464,7 @@ static inline void box_max_vert_16wide(
   {
     PREFETCH_NTA(buf + stride*(i+24));
     // store maximum of current window at center position
-    store_16wide(buf + stride * i, m);
+    _store_16wide(buf + stride * i, m);
     // If the earliest member of the current window is the max, we need to
     // rescan the window to determine the new maximum
     if(i >= w)
@@ -1617,8 +1585,7 @@ static inline void update_min_16wide(float m[16], const float *const restrict ba
   }
 }
 
-static inline void _load_update_min_16wide(
-    float *const restrict out,
+static inline void _load_update_min_16wide(float *const restrict out,
     float m[16],
     const float *const restrict base)
 {
@@ -1636,8 +1603,7 @@ static inline void _load_update_min_16wide(
 // calculate the one-dimensional moving minimum on four adjacent columns over a window of size 2*w+1
 // input/output array 'buf' has stride 'stride' and we will write 16 consecutive elements every stride elements
 // (thus processing a cache line at a time)
-static inline void box_min_vert_16wide(
-    const int N,
+static inline void box_min_vert_16wide(const int N,
     float *const restrict scratch,
     float *const restrict buf,
     const int stride,
@@ -1657,7 +1623,7 @@ static inline void box_min_vert_16wide(
   {
     PREFETCH_NTA(buf + stride*(i+24));
     // store minimum of current window at center position
-    store_16wide(buf + i * stride, m);
+    _store_16wide(buf + i * stride, m);
     // If the earliest member of the current window is the min, we need to
     // rescan the window to determine the new minimum
     if(i >= w)

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2590,15 +2590,22 @@ float *dt_dev_get_raster_mask(
             {
               float *transformed_mask = dt_alloc_align_float((size_t)module->processed_roi_out.width
                                                               * module->processed_roi_out.height);
-              module->module->distort_mask(module->module,
-                                          module,
-                                          raster_mask,
-                                          transformed_mask,
-                                          &module->processed_roi_in,
-                                          &module->processed_roi_out);
-              if(*free_mask) dt_free_align(raster_mask);
-              *free_mask = TRUE;
-              raster_mask = transformed_mask;
+              if(transformed_mask)
+              {
+                module->module->distort_mask(module->module,
+                                             module,
+                                             raster_mask,
+                                             transformed_mask,
+                                             &module->processed_roi_in,
+                                             &module->processed_roi_out);
+                if(*free_mask) dt_free_align(raster_mask);
+                *free_mask = TRUE;
+                raster_mask = transformed_mask;
+              }
+              else
+              {
+                dt_print(DT_DEBUG_ALWAYS,"skipped transforming mask due to lack of memory\n");
+              }
             }
             else if(!module->module->distort_mask &&
                     (module->processed_roi_in.width != module->processed_roi_out.width ||

--- a/src/iop/blurs.c
+++ b/src/iop/blurs.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2021 darktable developers.
+    Copyright (C) 2021-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -296,7 +296,11 @@ static inline void build_gui_kernel(unsigned char *const buffer, const size_t wi
 {
   float *const restrict kernel_1 = dt_alloc_align_float(width * height);
   float *const restrict kernel_2 = dt_alloc_align_float(width * height);
-
+  if(!kernel_1 || !kernel_2)
+  {
+    dt_print(DT_DEBUG_ALWAYS,"[blurs] out of memory, skipping build_gui_kernel\n");
+    goto cleanup;
+  }
 
   if(p->type == DT_BLUR_LENS)
   {
@@ -327,7 +331,7 @@ static inline void build_gui_kernel(unsigned char *const buffer, const size_t wi
   {
     buffer[k * 4] = buffer[k * 4 + 1] = buffer[k * 4 + 2] = buffer[k * 4 + 3] = roundf(255.f * kernel_2[k]);
   }
-
+cleanup:
   dt_free_align(kernel_1);
   dt_free_align(kernel_2);
 }
@@ -367,6 +371,11 @@ static inline void build_pixel_kernel(float *const buffer, const size_t width, c
                                       dt_iop_blurs_params_t *p)
 {
   float *const restrict kernel_1 = dt_alloc_align_float(width * height);
+  if(!kernel_1)
+  {
+    dt_print(DT_DEBUG_ALWAYS,"[blurs] out of memory, skippping build_pixel_kernel\n");
+    return;
+  }
 
   if(p->type == DT_BLUR_LENS)
   {
@@ -423,6 +432,11 @@ static void process_fft(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
 
   float *const restrict padded_in = dt_alloc_align_float(padded_width * padded_height * 4);
   float *const restrict padded_out = dt_alloc_align_float(padded_width * padded_height * 4);
+  if(!padded_in || !padded_out)
+  {
+    dt_print(DT_DEBUG_ALWAYS,"[blurs] out of memory, skipping process_fft\n");
+    goto cleanup;
+  }
 
   // Write the image in the padded buffer
 #ifdef _OPENMP
@@ -539,6 +553,7 @@ static void process_fft(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
 
   dt_free_align(kernel);
   dt_free_align(padded_kernel);
+cleanup:
   dt_free_align(padded_in);
   dt_free_align(padded_out);
 }

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -266,6 +266,12 @@ void process(
   float *Gtmp = NULL;
 
   float *out = dt_alloc_align_float(roi_in->width * roi_in->height);
+  if(!out)
+  {
+    dt_iop_copy_image_roi(ovoid, ivoid, piece->colors, roi_in, roi_out, 0);
+    dt_print(DT_DEBUG_ALWAYS,"[cacorrect] out of memory, skipping\n");
+    return;
+  }
   dt_iop_image_copy(out, input, roi_in->width * roi_in->height);
 
   if(run_fast) goto writeout;
@@ -297,7 +303,11 @@ void process(
     redfactor = dt_calloc_align_float(buffsize);
     bluefactor = dt_calloc_align_float(buffsize);
     oldraw = dt_calloc_align_float(buffsize * 2);
-
+    if(!redfactor || !bluefactor || !oldraw)
+    {
+      dt_print(DT_DEBUG_ALWAYS,"[cacorrect] out of memory, skipping\n");
+      goto writeout;
+    }
     // copy raw values before ca correction
 #ifdef _OPENMP
         #pragma omp parallel for
@@ -319,6 +329,11 @@ void process(
   // temporary array to avoid race conflicts, only every second pixel needs to be saved here
   RawDataTmp = dt_alloc_align_float(height * width / 2 + 4);
 
+  if(!Gtmp || !RawDataTmp)
+  {
+    dt_print(DT_DEBUG_ALWAYS,"[cacorrect] out of memory, skipping\n");
+    goto writeout;
+  }
   const int border = 8;
   const int border2 = 16;
 

--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -1,6 +1,6 @@
 /*
   This file is part of darktable,
-  Copyright (C) 2020 darktable developers.
+  Copyright (C) 2020-2023 darktable developers.
 
   darktable is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -138,6 +138,14 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
                                          ivoid, ovoid, roi_in, roi_out))
     return; // image has been copied through to output and module's trouble flag has been updated
 
+  float *restrict temp;
+  if(!dt_iop_alloc_image_buffers(self,roi_in,roi_out,
+                                 4 | DT_IMGSZ_INPUT, &temp,
+                                 0, NULL))
+  {
+    dt_iop_copy_image_roi(ovoid, ivoid, piece->colors, roi_in, roi_out, 0);
+    return;
+  }
   dt_iop_censorize_data_t *data = (dt_iop_censorize_data_t *)piece->data;
   const float *const restrict in = DT_IS_ALIGNED((const float *const restrict)ivoid);
   float *const restrict out = DT_IS_ALIGNED((float *const restrict)ovoid);
@@ -145,8 +153,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const int width = roi_in->width;
   const int height = roi_in->height;
   const int ch = 4;
-
-  float *const restrict temp = dt_alloc_align_float((size_t)width * height * ch);
 
   const float sigma_1 = data->radius_1 * roi_in->scale / piece->iscale;
   const float sigma_2 = data->radius_2 * roi_in->scale / piece->iscale;

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1,6 +1,6 @@
 /*
    This file is part of darktable,
-   Copyright (C) 2019-2022 darktable developers.
+   Copyright (C) 2019-2023 darktable developers.
 
    darktable is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -1971,15 +1971,19 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   {
     // init the blown areas with noise to create particles
     float *const restrict inpainted =  dt_alloc_align_float((size_t)roi_out->width * roi_out->height * 4);
-    inpaint_noise(in, mask, inpainted, data->noise_level / scale, data->reconstruct_threshold, data->noise_distribution,
-                  roi_out->width, roi_out->height);
-
-    // diffuse particles with wavelets reconstruction
-    // PASS 1 on RGB channels
-    const gint success_1 = reconstruct_highlights(inpainted, mask, reconstructed, DT_FILMIC_RECONSTRUCT_RGB, ch, data, piece, roi_in, roi_out);
+    gint success_1 = FALSE;
     gint success_2 = TRUE;
+    if(inpainted)
+    {
+      inpaint_noise(in, mask, inpainted, data->noise_level / scale, data->reconstruct_threshold,
+                    data->noise_distribution, roi_out->width, roi_out->height);
 
-    dt_free_align(inpainted);
+      // diffuse particles with wavelets reconstruction
+      // PASS 1 on RGB channels
+      success_1 = reconstruct_highlights(inpainted, mask, reconstructed, DT_FILMIC_RECONSTRUCT_RGB,
+                                         ch, data, piece, roi_in, roi_out);
+      dt_free_align(inpainted);
+    }
 
     if(data->high_quality_reconstruction > 0 && success_1)
     {

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -1620,30 +1620,46 @@ static void process_laplacian_bayer(struct dt_iop_module_t *self, dt_dev_pixelpi
 
   const size_t height = roi_in->height;
   const size_t width = roi_in->width;
-  const size_t size = roi_in->width * roi_in->height;
-
   const size_t ds_height = height / DS_FACTOR;
   const size_t ds_width = width / DS_FACTOR;
-  const size_t ds_size = ds_height * ds_width;
 
-  float *const restrict interpolated = dt_alloc_align_float(size * 4);  // [R, G, B, norm] for each pixel
-  float *const restrict clipping_mask = dt_alloc_align_float(size * 4); // [R, G, B, norm] for each pixel
+  // [R, G, B, norm] for each pixel
+  float *restrict interpolated, *restrict clipping_mask;
+  // temp buffers for blurs. We will need to cycle between them for memory efficiency
+  float *restrict LF_odd, *restrict LF_even, *restrict temp;
+  // wavelets scales buffers
+  float *restrict HF, *restrict ds_interpolated, *restrict ds_clipping_mask;
 
-  // temp buffer for blurs. We will need to cycle between them for memory efficiency
-  float *const restrict LF_odd = dt_alloc_align_float(ds_size * 4);
-  float *const restrict LF_even = dt_alloc_align_float(ds_size * 4);
-  float *const restrict temp = dt_alloc_align_float(ds_size * 4);
+  if(!dt_iop_alloc_image_buffers(self, roi_in, roi_out,
+                                 4 | DT_IMGSZ_INPUT, &interpolated,
+                                 4 | DT_IMGSZ_INPUT, &clipping_mask,
+                                 0, NULL))
+  {
+    dt_iop_copy_image_roi(ovoid, ivoid, piece->colors, roi_in, roi_out, 0);
+    return;
+  }
+
+  const dt_iop_roi_t roi_ds = { .x = 0, .y = 0, .height = ds_height, .width = ds_width };
+  if(!dt_iop_alloc_image_buffers(self, &roi_ds, &roi_ds,
+                                 4 | DT_IMGSZ_INPUT, &LF_odd,
+                                 4 | DT_IMGSZ_INPUT, &LF_even,
+                                 4 | DT_IMGSZ_INPUT, &temp,
+                                 4 | DT_IMGSZ_INPUT, &HF,
+                                 4 | DT_IMGSZ_INPUT, &ds_interpolated,
+                                 4 | DT_IMGSZ_INPUT, &ds_clipping_mask,
+                                 0, NULL))
+  {
+    dt_free_align(interpolated);
+    dt_free_align(clipping_mask);
+    dt_iop_copy_image_roi(ovoid, ivoid, piece->colors, roi_in, roi_out, 0);
+    return;
+  }
 
   const float scale = fmaxf(DS_FACTOR * piece->iscale / (roi_in->scale), 1.f);
   const float final_radius = (float)((int)(1 << data->scales)) / scale;
   const int scales = CLAMP((int)ceilf(log2f(final_radius)), 1, MAX_NUM_SCALES);
 
   const float noise_level = data->noise_level / scale;
-
-  // wavelets scales buffers
-  float *restrict HF = dt_alloc_align_float(ds_size * 4);
-  float *restrict ds_interpolated = dt_alloc_align_float(ds_size * 4);
-  float *restrict ds_clipping_mask = dt_alloc_align_float(ds_size * 4);
 
   const float *const restrict input = (const float *const restrict)ivoid;
   float *const restrict output = (float *const restrict)ovoid;

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -403,7 +403,7 @@ static void node_gc(dt_iop_liquify_params_t *p)
       k++;
   }
   //  invalidate all nodes beyond the last moved one
-  for(int l=last+1; l<MAX_NODES; k++)
+  for(int l=last+1; l<MAX_NODES; l++)
     p->nodes[l].header.type = DT_LIQUIFY_PATH_INVALIDATED;
 }
 

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -403,8 +403,8 @@ static void node_gc(dt_iop_liquify_params_t *p)
       k++;
   }
   //  invalidate all nodes beyond the last moved one
-  for(k=last+1; k<MAX_NODES; k++)
-    p->nodes[k].header.type = DT_LIQUIFY_PATH_INVALIDATED;
+  for(int l=last+1; l<MAX_NODES; k++)
+    p->nodes[l].header.type = DT_LIQUIFY_PATH_INVALIDATED;
 }
 
 static void node_delete(dt_iop_liquify_params_t *p, dt_liquify_path_data_t *this)

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2014-2021 darktable developers.
+    Copyright (C) 2014-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -43,8 +43,6 @@
 
 // this is the version of the modules parameters, and includes version information about compile-time dt
 DT_MODULE_INTROSPECTION(1, dt_iop_liquify_params_t)
-
-#pragma GCC diagnostic ignored "-Wshadow"
 
 #define MAX_NODES 100 // max of nodes in one instance
 
@@ -405,7 +403,7 @@ static void node_gc(dt_iop_liquify_params_t *p)
       k++;
   }
   //  invalidate all nodes beyond the last moved one
-  for(int k=last+1; k<MAX_NODES; k++)
+  for(k=last+1; k<MAX_NODES; k++)
     p->nodes[k].header.type = DT_LIQUIFY_PATH_INVALIDATED;
 }
 
@@ -833,11 +831,16 @@ static float complex point_at_arc_length(const float complex points[], const int
 static float *build_lookup_table(const int distance, const float control1, const float control2)
 {
   float complex *clookup = dt_alloc_align(64, sizeof(float complex) * (distance + 2));
-
+  float *lookup = dt_alloc_align_float((size_t)(distance + 2));
+  if (!clookup || !lookup)
+  {
+    dt_free_align(clookup);
+    dt_free_align(lookup);
+    return NULL;
+  }
   interpolate_cubic_bezier(I, control1 + I, control2, 1.0, clookup, distance + 2);
 
   // reparameterize bezier by x and keep only y values
-  float *lookup = dt_alloc_align_float((size_t)(distance + 2));
   float *ptr = lookup;
   float complex *cptr = clookup + 1;
   const float complex *cptr_end = cptr + distance;
@@ -916,7 +919,13 @@ static void build_round_stamp(float complex **pstamp,
   // lookup table: map of distance from center point => warp
   const int table_size = iradius * LOOKUP_OVERSAMPLE;
   const float *const restrict lookup_table = build_lookup_table(table_size, warp->control1, warp->control2);
-
+  if(!stamp || !lookup_table)
+  {
+    *pstamp = stamp;
+    dt_free_align((void*)lookup_table);
+    dt_print(DT_DEBUG_ALWAYS,"[liquify] out of memory, round stamp skipped\n");
+    return;
+  }
   // points into buffer at the center of the circle
   float complex *const center = stamp + 2 * iradius * iradius + 2 * iradius;
 
@@ -2299,8 +2308,8 @@ void _hit_paths(dt_iop_module_t *module,
       }
       else if(layer == DT_LIQUIFY_LAYER_STRENGTHPOINT)
       {
-        const float complex p = warp->point - warp->strength;
-        CHECK_HIT_PT(warp->strength + (float)DT_PIXEL_APPLY_DPI(5) * (p / cabsf(p)));
+        const float complex wp = warp->point - warp->strength;
+        CHECK_HIT_PT(warp->strength + (float)DT_PIXEL_APPLY_DPI(5) * (wp / cabsf(wp)));
       }
 
       if(data->header.type == DT_LIQUIFY_PATH_CURVE_TO_V1)
@@ -2535,8 +2544,8 @@ static void smooth_paths_linsys(dt_iop_liquify_params_t *params)
     {
       const dt_liquify_path_data_t *d = (dt_liquify_path_data_t *) node;
       const dt_liquify_path_data_t *p = node_prev(params, node);
-      const dt_liquify_path_data_t *n = node_next(params, node);
-      const dt_liquify_path_data_t *nn = n ? node_next(params, n) : NULL;
+      const dt_liquify_path_data_t *nx = node_next(params, node);
+      const dt_liquify_path_data_t *nn = nx ? node_next(params, nx) : NULL;
 
       pt[idx] = node->warp.point;
       if(d->header.type == DT_LIQUIFY_PATH_CURVE_TO_V1)
@@ -2546,10 +2555,10 @@ static void smooth_paths_linsys(dt_iop_liquify_params_t *params)
       }
 
       const int autosmooth      = d->header.node_type == DT_LIQUIFY_NODE_TYPE_AUTOSMOOTH;
-      const int next_autosmooth = n   &&  n->header.node_type == DT_LIQUIFY_NODE_TYPE_AUTOSMOOTH;
+      const int next_autosmooth = nx  &&  nx->header.node_type == DT_LIQUIFY_NODE_TYPE_AUTOSMOOTH;
       const int firstseg        = !p  ||  d->header.type != DT_LIQUIFY_PATH_CURVE_TO_V1;
       const int lastseg         = !nn ||  nn->header.type != DT_LIQUIFY_PATH_CURVE_TO_V1;
-      const int lineseg         = n   &&  n->header.type == DT_LIQUIFY_PATH_LINE_TO_V1;
+      const int lineseg         = nx  &&  nx->header.type == DT_LIQUIFY_PATH_LINE_TO_V1;
 
       // Program the linear system with equations:
       //

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2017-2022 darktable developers.
+    Copyright (C) 2017-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -3039,7 +3039,7 @@ static void rt_build_scaled_mask(float *const mask, dt_iop_roi_t *const roi_mask
   mask_tmp = dt_alloc_align_float((size_t)roi_mask_scaled->width * roi_mask_scaled->height);
   if(mask_tmp == NULL)
   {
-    fprintf(stderr, "rt_build_scaled_mask: error allocating memory\n");
+    dt_print(DT_DEBUG_ALWAYS, "[retouch] rt_build_scaled_mask: error allocating memory\n");
     goto cleanup;
   }
   dt_iop_image_fill(mask_tmp, 0.0f, roi_mask_scaled->width, roi_mask_scaled->height, 1);
@@ -3168,7 +3168,7 @@ static void _retouch_clone(float *const in, dt_iop_roi_t *const roi_in, float *c
   float *img_src = dt_alloc_align_float((size_t)4 * roi_mask_scaled->width * roi_mask_scaled->height);
   if(img_src == NULL)
   {
-    fprintf(stderr, "retouch_clone: error allocating memory for cloning\n");
+    dt_print(DT_DEBUG_ALWAYS, "[retouch] error allocating memory for cloning\n");
     goto cleanup;
   }
 
@@ -3196,7 +3196,7 @@ static void _retouch_blur(dt_iop_module_t *self, float *const in, dt_iop_roi_t *
   img_dest = dt_alloc_align_float((size_t)4 * roi_mask_scaled->width * roi_mask_scaled->height);
   if(img_dest == NULL)
   {
-    fprintf(stderr, "retouch_blur: error allocating memory for blurring\n");
+    dt_print(DT_DEBUG_ALWAYS, "[retouch] error allocating memory for blurring\n");
     goto cleanup;
   }
 
@@ -3267,7 +3267,7 @@ static void _retouch_heal(float *const in, dt_iop_roi_t *const roi_in, float *co
   img_dest = dt_alloc_align_float((size_t)4 * roi_mask_scaled->width * roi_mask_scaled->height);
   if((img_src == NULL) || (img_dest == NULL))
   {
-    fprintf(stderr, "retouch_heal: error allocating memory for healing\n");
+    dt_print(DT_DEBUG_ALWAYS, "[retouch] error allocating memory for healing\n");
     goto cleanup;
   }
 
@@ -3323,21 +3323,21 @@ static void rt_process_forms(float *layer, dwt_params_t *const wt_p, const int s
         const dt_masks_point_group_t *grpt = (dt_masks_point_group_t *)forms->data;
         if(grpt == NULL)
         {
-          fprintf(stderr, "rt_process_forms: invalid form\n");
+          dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: invalid form\n");
           continue;
         }
         const int formid = grpt->formid;
         const float form_opacity = grpt->opacity;
         if(formid == 0)
         {
-          fprintf(stderr, "rt_process_forms: form is null\n");
+          dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: form is null\n");
           continue;
         }
         const int index = rt_get_index_from_formid(p, formid);
         if(index == -1)
         {
           // FIXME: we get this error when user go back in history, so forms are the same but the array has changed
-          fprintf(stderr, "rt_process_forms: missing form=%i from array\n", formid);
+          dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: missing form=%i from array\n", formid);
           continue;
         }
 
@@ -3351,7 +3351,7 @@ static void rt_process_forms(float *layer, dwt_params_t *const wt_p, const int s
         dt_masks_form_t *form = dt_masks_get_from_id_ext(piece->pipe->forms, formid);
         if(form == NULL)
         {
-          fprintf(stderr, "rt_process_forms: missing form=%i from masks\n", formid);
+          dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: missing form=%i from masks\n", formid);
           continue;
         }
 
@@ -3368,7 +3368,7 @@ static void rt_process_forms(float *layer, dwt_params_t *const wt_p, const int s
         dt_masks_get_mask(self, piece, form, &mask, &roi_mask.width, &roi_mask.height, &roi_mask.x, &roi_mask.y);
         if(mask == NULL)
         {
-          fprintf(stderr, "rt_process_forms: error retrieving mask\n");
+          dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: error retrieving mask\n");
           continue;
         }
 
@@ -3440,7 +3440,7 @@ static void rt_process_forms(float *layer, dwt_params_t *const wt_p, const int s
             _retouch_fill(layer, roi_layer, mask_scaled, &roi_mask_scaled, form_opacity, fill_color);
           }
           else
-            fprintf(stderr, "rt_process_forms: unknown algorithm %i\n", algo);
+            dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: unknown algorithm %i\n", algo);
 
           if(mask_display)
             rt_copy_mask_to_alpha(layer, roi_layer, wt_p->ch, mask_scaled, &roi_mask_scaled, form_opacity);
@@ -3478,8 +3478,11 @@ static void process_internal(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
   // we will do all the clone, heal, etc on the input image,
   // this way the source for one algorithm can be the destination from a previous one
   in_retouch = dt_alloc_align_float((size_t)4 * roi_rt->width * roi_rt->height);
-  if(in_retouch == NULL) goto cleanup;
-
+  if(in_retouch == NULL)
+  {
+    dt_print(DT_DEBUG_ALWAYS,"[retouch] out of memory\n");
+    goto cleanup;
+  }
   dt_iop_image_copy_by_size(in_retouch, ivoid, roi_rt->width, roi_rt->height, 4);
 
   // user data passed from the decompose routine to the one that process each scale
@@ -3606,7 +3609,7 @@ cl_int rt_process_stats_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t 
   src_buffer = dt_alloc_align_float((size_t)ch * width * height);
   if(src_buffer == NULL)
   {
-    fprintf(stderr, "dt_heal_cl: error allocating memory for healing\n");
+    dt_print(DT_DEBUG_ALWAYS, "[retouch] error allocating memory for healing (OpenCL)\n");
     err = DT_OPENCL_SYSMEM_ALLOCATION;
     goto cleanup;
   }
@@ -3645,7 +3648,7 @@ cl_int rt_adjust_levels_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t 
   src_buffer = dt_alloc_align_float((size_t)ch * width * height);
   if(src_buffer == NULL)
   {
-    fprintf(stderr, "dt_heal_cl: error allocating memory for healing\n");
+    dt_print(DT_DEBUG_ALWAYS, "[retouch] error allocating memory for healing (OpenCL)\n");
     err = DT_OPENCL_SYSMEM_ALLOCATION;
     goto cleanup;
   }
@@ -3689,7 +3692,7 @@ static cl_int rt_copy_in_to_out_cl(const int devid, cl_mem dev_in, const struct 
   dev_roi_out = dt_opencl_copy_host_to_device_constant(devid, sizeof(dt_iop_roi_t), (void *)roi_out);
   if(dev_roi_in == NULL || dev_roi_out == NULL)
   {
-    fprintf(stderr, "rt_copy_in_to_out_cl error 1\n");
+    dt_print(DT_DEBUG_ALWAYS, "rt_copy_in_to_out_cl error 1\n");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
@@ -3698,7 +3701,7 @@ static cl_int rt_copy_in_to_out_cl(const int devid, cl_mem dev_in, const struct 
     CLARG(dev_in), CLARG(dev_roi_in), CLARG(dev_out), CLARG(dev_roi_out), CLARG(xoffs), CLARG(yoffs));
   if(err != CL_SUCCESS)
   {
-    fprintf(stderr, "rt_copy_in_to_out_cl error 2\n");
+    dt_print(DT_DEBUG_ALWAYS, "rt_copy_in_to_out_cl error 2\n");
     goto cleanup;
   }
 
@@ -3726,7 +3729,7 @@ static cl_int rt_build_scaled_mask_cl(const int devid, float *const mask, dt_iop
       = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_mask_scaled->width * roi_mask_scaled->height);
   if(dev_mask_scaled == NULL)
   {
-    fprintf(stderr, "rt_build_scaled_mask_cl error 2\n");
+    dt_print(DT_DEBUG_ALWAYS, "rt_build_scaled_mask_cl error 2\n");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
@@ -3735,14 +3738,14 @@ static cl_int rt_build_scaled_mask_cl(const int devid, float *const mask, dt_iop
                                          sizeof(float) * roi_mask_scaled->width * roi_mask_scaled->height, CL_TRUE);
   if(err != CL_SUCCESS)
   {
-    fprintf(stderr, "rt_build_scaled_mask_cl error 4\n");
+    dt_print(DT_DEBUG_ALWAYS, "rt_build_scaled_mask_cl error 4\n");
     goto cleanup;
   }
 
   *p_dev_mask_scaled = dev_mask_scaled;
 
 cleanup:
-  if(err != CL_SUCCESS) fprintf(stderr, "rt_build_scaled_mask_cl error\n");
+  if(err != CL_SUCCESS) dt_print(DT_DEBUG_ALWAYS, "rt_build_scaled_mask_cl error\n");
 
   return err;
 }
@@ -3821,7 +3824,7 @@ static cl_int _retouch_clone_cl(const int devid, cl_mem dev_layer, dt_iop_roi_t 
                                           sizeof(float) * ch * roi_mask_scaled->width * roi_mask_scaled->height);
   if(dev_src == NULL)
   {
-    fprintf(stderr, "retouch_clone_cl error 2\n");
+    dt_print(DT_DEBUG_ALWAYS, "retouch_clone_cl error 2\n");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
@@ -3831,7 +3834,7 @@ static cl_int _retouch_clone_cl(const int devid, cl_mem dev_layer, dt_iop_roi_t 
                              gd->kernel_retouch_copy_buffer_to_buffer);
   if(err != CL_SUCCESS)
   {
-    fprintf(stderr, "retouch_clone_cl error 4\n");
+    dt_print(DT_DEBUG_ALWAYS, "retouch_clone_cl error 4\n");
     goto cleanup;
   }
 
@@ -3840,7 +3843,7 @@ static cl_int _retouch_clone_cl(const int devid, cl_mem dev_layer, dt_iop_roi_t 
                                 gd->kernel_retouch_copy_buffer_to_buffer_masked);
   if(err != CL_SUCCESS)
   {
-    fprintf(stderr, "retouch_clone_cl error 5\n");
+    dt_print(DT_DEBUG_ALWAYS, "retouch_clone_cl error 5\n");
     goto cleanup;
   }
 
@@ -3897,7 +3900,7 @@ static cl_int _retouch_blur_cl(const int devid, cl_mem dev_layer, dt_iop_roi_t *
     dt_opencl_alloc_device(devid, roi_mask_scaled->width, roi_mask_scaled->height, sizeof(float) * ch);
   if(dev_dest == NULL)
   {
-    fprintf(stderr, "retouch_blur_cl error 2\n");
+    dt_print(DT_DEBUG_ALWAYS, "retouch_blur_cl error 2\n");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
@@ -3914,7 +3917,7 @@ static cl_int _retouch_blur_cl(const int devid, cl_mem dev_layer, dt_iop_roi_t *
                              gd->kernel_retouch_copy_buffer_to_image);
   if(err != CL_SUCCESS)
   {
-    fprintf(stderr, "retouch_blur_cl error 4\n");
+    dt_print(DT_DEBUG_ALWAYS, "retouch_blur_cl error 4\n");
     goto cleanup;
   }
 
@@ -3955,7 +3958,7 @@ static cl_int _retouch_blur_cl(const int devid, cl_mem dev_layer, dt_iop_roi_t *
                                 gd->kernel_retouch_copy_image_to_buffer_masked);
   if(err != CL_SUCCESS)
   {
-    fprintf(stderr, "retouch_blur_cl error 5\n");
+    dt_print(DT_DEBUG_ALWAYS, "retouch_blur_cl error 5\n");
     goto cleanup;
   }
 
@@ -3986,7 +3989,7 @@ static cl_int _retouch_heal_cl(const int devid, cl_mem dev_layer, dt_iop_roi_t *
                                           sizeof(float) * ch * roi_mask_scaled->width * roi_mask_scaled->height);
   if(dev_src == NULL)
   {
-    fprintf(stderr, "retouch_heal_cl: error allocating memory for healing\n");
+    dt_print(DT_DEBUG_ALWAYS, "retouch_heal_cl: error allocating memory for healing\n");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
@@ -3995,7 +3998,7 @@ static cl_int _retouch_heal_cl(const int devid, cl_mem dev_layer, dt_iop_roi_t *
                                            sizeof(float) * ch * roi_mask_scaled->width * roi_mask_scaled->height);
   if(dev_dest == NULL)
   {
-    fprintf(stderr, "retouch_heal_cl: error allocating memory for healing\n");
+    dt_print(DT_DEBUG_ALWAYS, "retouch_heal_cl: error allocating memory for healing\n");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
@@ -4004,7 +4007,7 @@ static cl_int _retouch_heal_cl(const int devid, cl_mem dev_layer, dt_iop_roi_t *
                              gd->kernel_retouch_copy_buffer_to_buffer);
   if(err != CL_SUCCESS)
   {
-    fprintf(stderr, "retouch_heal_cl error 4\n");
+    dt_print(DT_DEBUG_ALWAYS, "retouch_heal_cl error 4\n");
     goto cleanup;
   }
 
@@ -4012,7 +4015,7 @@ static cl_int _retouch_heal_cl(const int devid, cl_mem dev_layer, dt_iop_roi_t *
                              gd->kernel_retouch_copy_buffer_to_buffer);
   if(err != CL_SUCCESS)
   {
-    fprintf(stderr, "retouch_heal_cl error 4\n");
+    dt_print(DT_DEBUG_ALWAYS, "retouch_heal_cl error 4\n");
     goto cleanup;
   }
 
@@ -4034,7 +4037,7 @@ static cl_int _retouch_heal_cl(const int devid, cl_mem dev_layer, dt_iop_roi_t *
                                 gd->kernel_retouch_copy_buffer_to_buffer_masked);
   if(err != CL_SUCCESS)
   {
-    fprintf(stderr, "retouch_heal_cl error 6\n");
+    dt_print(DT_DEBUG_ALWAYS, "retouch_heal_cl error 6\n");
     goto cleanup;
   }
 
@@ -4087,21 +4090,21 @@ static cl_int rt_process_forms_cl(cl_mem dev_layer, dwt_params_cl_t *const wt_p,
         dt_masks_point_group_t *grpt = (dt_masks_point_group_t *)forms->data;
         if(grpt == NULL)
         {
-          fprintf(stderr, "rt_process_forms: invalid form\n");
+          dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: invalid form\n");
           continue;
         }
         const int formid = grpt->formid;
         const float form_opacity = grpt->opacity;
         if(formid == 0)
         {
-          fprintf(stderr, "rt_process_forms: form is null\n");
+          dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: form is null\n");
           continue;
         }
         const int index = rt_get_index_from_formid(p, formid);
         if(index == -1)
         {
           // FIXME: we get this error when user go back in history, so forms are the same but the array has changed
-          fprintf(stderr, "rt_process_forms: missing form=%i from array\n", formid);
+          dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: missing form=%i from array\n", formid);
           continue;
         }
 
@@ -4115,7 +4118,7 @@ static cl_int rt_process_forms_cl(cl_mem dev_layer, dwt_params_cl_t *const wt_p,
         dt_masks_form_t *form = dt_masks_get_from_id_ext(piece->pipe->forms, formid);
         if(form == NULL)
         {
-          fprintf(stderr, "rt_process_forms: missing form=%i from masks\n", formid);
+          dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: missing form=%i from masks\n", formid);
           continue;
         }
 
@@ -4132,7 +4135,7 @@ static cl_int rt_process_forms_cl(cl_mem dev_layer, dwt_params_cl_t *const wt_p,
         dt_masks_get_mask(self, piece, form, &mask, &roi_mask.width, &roi_mask.height, &roi_mask.x, &roi_mask.y);
         if(mask == NULL)
         {
-          fprintf(stderr, "rt_process_forms: error retrieving mask\n");
+          dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: error retrieving mask\n");
           continue;
         }
 
@@ -4218,7 +4221,7 @@ static cl_int rt_process_forms_cl(cl_mem dev_layer, dwt_params_cl_t *const wt_p,
                                    fill_color, gd);
           }
           else
-            fprintf(stderr, "rt_process_forms: unknown algorithm %i\n", algo);
+            dt_print(DT_DEBUG_ALWAYS, "rt_process_forms: unknown algorithm %i\n", algo);
 
           if(mask_display)
             rt_copy_mask_to_alpha_cl(devid, dev_layer, roi_layer, dev_mask_scaled, &roi_mask_scaled, form_opacity,

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2019-2022 darktable developers.
+    Copyright (C) 2019-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -965,7 +965,7 @@ static float _action_process(gpointer target, dt_action_element_t element, dt_ac
       const float new_position = p->levels[c->channel][element] + interval * move_size;
       _rgblevels_move_handle(self, element, new_position, p->levels[c->channel], c->drag_start_percentage);
     default:
-      fprintf(stderr, "[_action_process_tabs] unknown shortcut effect (%d) for levels\n", effect);
+      dt_print(DT_DEBUG_ALWAYS, "[_action_process_tabs] unknown shortcut effect (%d) for levels\n", effect);
       break;
     }
 
@@ -1377,7 +1377,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
       src_buffer = dt_alloc_align_float((size_t)ch * width * height);
       if(src_buffer == NULL)
       {
-        fprintf(stderr, "[rgblevels process_cl] error allocating memory for temp table 1\n");
+        dt_print(DT_DEBUG_ALWAYS, "[rgblevels process_cl] error allocating memory for temp table 1\n");
         err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
         goto cleanup;
       }
@@ -1385,7 +1385,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
       err = dt_opencl_copy_device_to_host(devid, src_buffer, dev_in, width, height, ch * sizeof(float));
       if(err != CL_SUCCESS)
       {
-        fprintf(stderr, "[rgblevels process_cl] error allocating memory for temp table 2\n");
+        dt_print(DT_DEBUG_ALWAYS, "[rgblevels process_cl] error allocating memory for temp table 2\n");
         goto cleanup;
       }
 
@@ -1414,21 +1414,21 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   dev_lutr = dt_opencl_copy_host_to_device(devid, d->lut[0], 256, 256, sizeof(float));
   if(dev_lutr == NULL)
   {
-    fprintf(stderr, "[rgblevels process_cl] error allocating memory 1\n");
+    dt_print(DT_DEBUG_ALWAYS, "[rgblevels process_cl] error allocating memory 1\n");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
   dev_lutg = dt_opencl_copy_host_to_device(devid, d->lut[1], 256, 256, sizeof(float));
   if(dev_lutg == NULL)
   {
-    fprintf(stderr, "[rgblevels process_cl] error allocating memory 2\n");
+    dt_print(DT_DEBUG_ALWAYS, "[rgblevels process_cl] error allocating memory 2\n");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
   dev_lutb = dt_opencl_copy_host_to_device(devid, d->lut[2], 256, 256, sizeof(float));
   if(dev_lutb == NULL)
   {
-    fprintf(stderr, "[rgblevels process_cl] error allocating memory 3\n");
+    dt_print(DT_DEBUG_ALWAYS, "[rgblevels process_cl] error allocating memory 3\n");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
@@ -1436,7 +1436,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   dev_levels = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3 * 3, (float *)d->params.levels);
   if(dev_levels == NULL)
   {
-    fprintf(stderr, "[rgblevels process_cl] error allocating memory 4\n");
+    dt_print(DT_DEBUG_ALWAYS, "[rgblevels process_cl] error allocating memory 4\n");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
@@ -1444,7 +1444,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   dev_inv_gamma = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3, (float *)d->inv_gamma);
   if(dev_inv_gamma == NULL)
   {
-    fprintf(stderr, "[rgblevels process_cl] error allocating memory 5\n");
+    dt_print(DT_DEBUG_ALWAYS, "[rgblevels process_cl] error allocating memory 5\n");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
@@ -1459,7 +1459,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
     CLARG(dev_profile_lut), CLARG(use_work_profile));
   if(err != CL_SUCCESS)
   {
-    fprintf(stderr, "[rgblevels process_cl] error %i enqueue kernel\n", err);
+    dt_print(DT_DEBUG_ALWAYS, "[rgblevels process_cl] error %i enqueue kernel\n", err);
     goto cleanup;
   }
 

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -111,11 +111,15 @@ void init_presets(dt_iop_module_so_t *self)
 
 static float *const init_gaussian_kernel(const int rad, const size_t mat_size, const float sigma2)
 {
-  float weight = 0.0f;
-  float *const mat = dt_alloc_align_float(mat_size);
-  memset(mat, 0, sizeof(float) * mat_size);
-  for(int l = -rad; l <= rad; l++) weight += mat[l + rad] = expf(-l * l / (2.f * sigma2));
-  for(int l = -rad; l <= rad; l++) mat[l + rad] /= weight;
+  float *const mat = dt_calloc_align_float(mat_size);
+  if(mat)
+  {
+    float weight = 0.0f;
+    for(int l = -rad; l <= rad; l++)
+      weight += mat[l + rad] = expf(-l * l / (2.f * sigma2));
+    for(int l = -rad; l <= rad; l++)
+      mat[l + rad] /= weight;
+  }
   return mat;
 }
 
@@ -159,6 +163,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const float sigma2 = (1.0f / (2.5 * 2.5)) * (d->radius * roi_in->scale / piece->iscale)
                        * (d->radius * roi_in->scale / piece->iscale);
   mat = init_gaussian_kernel(rad, wd, sigma2);
+  if(!mat)
+    goto error;
 
   int hblocksize;
   dt_opencl_local_buffer_t hlocopt
@@ -294,7 +300,12 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const float sigma2 = (1.0f / (2.5 * 2.5)) * (data->radius * roi_in->scale / piece->iscale)
                        * (data->radius * roi_in->scale / piece->iscale);
   float *const mat = init_gaussian_kernel(rad, mat_size, sigma2);
-
+  if(!mat)
+  {
+    dt_print(DT_DEBUG_ALWAYS,"[sharpen] out of memory\n");
+    dt_iop_copy_image_roi(ovoid, ivoid, 4, roi_in, roi_out, TRUE);
+    return;
+  }
   const float *const restrict in = (float*)ivoid;
   const size_t width = roi_out->width;
 #ifdef _OPENMP


### PR DESCRIPTION
Added checks for failed memory allocations on a fairly systematic basis to avoid future crashes like in #13717.
I looked specifically at calls to `dt_alloc_align_float` that were allocating entire 2D images, but did also fix up handling of a few single-row buffers.

Verified unchanged (compared to master) on all integration tests.
