### PR TITLE
Bugfix: restrict --threads to possible values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-concurrency:
+concurrency: 
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
@@ -52,7 +52,7 @@ jobs:
           - { compiler: GNU10,  CC: gcc-10,   CXX: g++-10,     packages: gcc-10 g++-10 }
           - { compiler: GNU11,  CC: gcc-11,   CXX: g++-11,     packages: gcc-11 g++-11 }
           - { compiler: GNU12,  CC: gcc-12,   CXX: g++-12,     packages: gcc-12 g++-12 }
-          - { compiler: LLVM12, CC: clang-12, CXX: clang++-12, packages: clang-12 libomp-12-dev libclang-common-12-dev llvm-12-dev clang++-12 libc++-12-dev libc++1-12 libc++abi1-12 lld-12}
+          - { compiler: LLVM14, CC: clang-14, CXX: clang++-14, packages: clang-14 libomp-14-dev libclang-common-14-dev llvm-14-dev clang++-14 libc++-14-dev libc++1-14 libc++abi1-14 lld-14}
         btype:
           - Release
         target:

--- a/src/common/bilateral.c
+++ b/src/common/bilateral.c
@@ -72,7 +72,7 @@ size_t dt_bilateral_memory_use(const int width,     // width of input image
   // OpenCL path needs two buffers
   return 2 * grid_size * sizeof(float);
 #else
-  return (grid_size + 3 * darktable.num_openmp_threads * b.size_x * b.size_z) * sizeof(float);
+  return (grid_size + 3 * dt_get_num_threads() * b.size_x * b.size_z) * sizeof(float);
 #endif /* HAVE_OPENCL */
 }
 
@@ -96,7 +96,7 @@ size_t dt_bilateral_singlebuffer_size(const int width,     // width of input ima
   dt_bilateral_t b;
   dt_bilateral_grid_size(&b,width,height,100.0f,sigma_s,sigma_r);
   size_t grid_size = b.size_x * b.size_y * b.size_z;
-  return (grid_size + 3 * darktable.num_openmp_threads * b.size_x * b.size_z) * sizeof(float);
+  return (grid_size + 3 * dt_get_num_threads() * b.size_x * b.size_z) * sizeof(float);
 }
 
 #ifndef HAVE_OPENCL
@@ -147,7 +147,7 @@ dt_bilateral_t *dt_bilateral_init(const int width,     // width of input image
   dt_bilateral_grid_size(b,width,height,100.0f,sigma_s,sigma_r);
   b->width = width;
   b->height = height;
-  b->numslices = darktable.num_openmp_threads;
+  b->numslices = dt_get_num_threads();
   b->sliceheight = (height + b->numslices - 1) / b->numslices;
   b->slicerows = (b->size_y + b->numslices - 1) / b->numslices + 2;
   b->buf = dt_calloc_align_float(b->size_x * b->size_z * b->numslices * b->slicerows);
@@ -176,7 +176,7 @@ void dt_bilateral_splat(const dt_bilateral_t *b, const float *const in)
 
   if(!buf) return;
   // splat into downsampled grid
-  const int nthreads = darktable.num_openmp_threads;
+  const int nthreads = dt_get_num_threads();
   const size_t offsets[8] =
   {
     0,

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -605,10 +605,8 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   char *lua_command = NULL;
 #endif
 
-  darktable.num_openmp_threads = 1;
-#ifdef _OPENMP
-  darktable.num_openmp_threads = omp_get_num_procs();
-#endif
+  darktable.num_openmp_threads = dt_get_num_procs();
+
   darktable.unmuted = 0;
   GSList *config_override = NULL;
   for(int k = 1; k < argc; k++)
@@ -944,7 +942,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
       }
       else if((argv[k][1] == 't' && argc > k + 1) || (!strcmp(argv[k], "--threads") && argc > k + 1))
       {
-        const int possible = dt_get_num_threads(); // either 1 or current omp_get_num_procs()
+        const int possible = dt_get_num_procs();
         const int desired = atol(argv[k + 1]);
         darktable.num_openmp_threads = CLAMP(desired, 1, possible);
         if(desired > possible)

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1845,7 +1845,7 @@ size_t dt_get_singlebuffer_mem()
 
 void dt_configure_runtime_performance(const int old, char *info)
 {
-  const size_t threads = dt_get_num_threads();
+  const size_t threads = dt_get_num_procs();
   const size_t mem = darktable.dtresources.total_memory / 1024lu / 1024lu;
   const size_t bits = CHAR_BIT * sizeof(void *);
   const gboolean sufficient = mem >= 4096 && threads >= 2;

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -944,8 +944,14 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
       }
       else if((argv[k][1] == 't' && argc > k + 1) || (!strcmp(argv[k], "--threads") && argc > k + 1))
       {
-        darktable.num_openmp_threads = CLAMP(atol(argv[k + 1]), 1, 100);
-        dt_print(DT_DEBUG_ALWAYS, "[dt_init] using %d threads for openmp parallel sections\n", darktable.num_openmp_threads);
+        const int possible = dt_get_num_threads(); // either 1 or current omp_get_num_procs()
+        const int desired = atol(argv[k + 1]);
+        darktable.num_openmp_threads = CLAMP(desired, 1, possible);
+        if(desired > possible)
+          dt_print(DT_DEBUG_ALWAYS, "[dt_init --threads] requested %d ompthreads restricted to %d\n",
+            desired, possible);
+        dt_print(DT_DEBUG_ALWAYS, "[dt_init --threads] using %d threads for openmp parallel sections\n",
+          darktable.num_openmp_threads);
         k++;
         argv[k-1] = NULL;
         argv[k] = NULL;

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -521,7 +521,6 @@ gboolean dt_supported_image(const gchar *filename);
 static inline size_t dt_get_num_threads()
 {
 #ifdef _OPENMP
-  // we can safely assume omp_get_num_procs is > 0
   return (size_t)CLAMP(omp_get_num_procs(), 1, darktable.num_openmp_threads);
 #else
   return 1;

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -522,6 +522,16 @@ static inline size_t dt_get_num_threads()
 {
 #ifdef _OPENMP
   // we can safely assume omp_get_num_procs is > 0
+  return (size_t)CLAMP(omp_get_num_procs(), 1, darktable.num_openmp_threads);
+#else
+  return 1;
+#endif
+}
+
+static inline size_t dt_get_num_procs()
+{
+#ifdef _OPENMP
+  // we can safely assume omp_get_num_procs is > 0
   return (size_t)omp_get_num_procs();
 #else
   return 1;

--- a/src/common/imagebuf.c
+++ b/src/common/imagebuf.c
@@ -150,7 +150,7 @@ void dt_iop_image_copy(float *const __restrict__ out, const float *const __restr
     // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
     // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
     // memory won't be able to take advantage of more than four cores).
-    const int nthreads = MIN(darktable.num_openmp_threads,parallel_imgop_maxthreads);
+    const int nthreads = MIN(dt_get_num_threads(), parallel_imgop_maxthreads);
     // determine the number of 4-float vectors to be processed by each thread
     const size_t chunksize = (((nfloats + nthreads - 1) / nthreads) + 3) / 4;
 #pragma omp parallel for simd aligned(in, out : 16) default(none) \
@@ -227,7 +227,7 @@ void dt_iop_image_scaled_copy(float *const restrict buf, const float *const rest
     // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
     // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
     // memory won't be able to take advantage of more than four cores).
-    const int nthreads = MIN(darktable.num_openmp_threads,parallel_imgop_maxthreads);
+    const int nthreads = MIN(dt_get_num_threads(), parallel_imgop_maxthreads);
 #pragma omp parallel for simd aligned(buf, src : 16) default(none) \
   dt_omp_firstprivate(buf, src, scale, nfloats) schedule(simd:static) num_threads(nthreads)
     for(size_t k = 0; k < nfloats; k++)
@@ -250,7 +250,7 @@ void dt_iop_image_fill(float *const buf, const float fill_value, const size_t wi
 #ifdef _OPENMP
   if(nfloats > parallel_imgop_minimum)	// is the copy big enough to outweigh threading overhead?
   {
-    const size_t nthreads = MIN(16,darktable.num_openmp_threads);
+    const size_t nthreads = MIN(16, dt_get_num_threads());
     // determine the number of 4-float vectors to be processed by each thread
     const size_t chunksize = (((nfloats + nthreads - 1) / nthreads) + 3) / 4;
 #pragma omp parallel for default(none) \
@@ -296,7 +296,7 @@ void dt_iop_image_add_const(float *const buf, const float add_value, const size_
     // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
     // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
     // memory won't be able to take advantage of more than four cores).
-    const int nthreads = MIN(darktable.num_openmp_threads,parallel_imgop_maxthreads);
+    const int nthreads = MIN(dt_get_num_threads(), parallel_imgop_maxthreads);
 #pragma omp parallel for simd aligned(buf:16) default(none) \
   dt_omp_firstprivate(buf, add_value, nfloats) schedule(simd:static) num_threads(nthreads)
     for(size_t k = 0; k < nfloats; k++)
@@ -322,7 +322,7 @@ void dt_iop_image_add_image(float *const buf, const float* const other_image,
     // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
     // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
     // memory won't be able to take advantage of more than four cores).
-    const int nthreads = MIN(darktable.num_openmp_threads,parallel_imgop_maxthreads);
+    const int nthreads = MIN(dt_get_num_threads(), parallel_imgop_maxthreads);
 #pragma omp parallel for simd aligned(buf, other_image : 16) default(none) \
   dt_omp_firstprivate(buf, other_image, nfloats) schedule(simd:static) num_threads(nthreads)
     for(size_t k = 0; k < nfloats; k++)
@@ -348,7 +348,7 @@ void dt_iop_image_sub_image(float *const buf, const float* const other_image,
     // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
     // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
     // memory won't be able to take advantage of more than four cores).
-    const int nthreads = MIN(darktable.num_openmp_threads,parallel_imgop_maxthreads);
+    const int nthreads = MIN(dt_get_num_threads(), parallel_imgop_maxthreads);
 #pragma omp parallel for simd aligned(buf, other_image : 16) default(none) \
   dt_omp_firstprivate(buf, other_image, nfloats) schedule(simd:static) num_threads(nthreads)
     for(size_t k = 0; k < nfloats; k++)
@@ -374,7 +374,7 @@ void dt_iop_image_invert(float *const buf, const float max_value, const size_t w
     // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
     // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
     // memory won't be able to take advantage of more than four cores).
-    const int nthreads = MIN(darktable.num_openmp_threads,parallel_imgop_maxthreads);
+    const int nthreads = MIN(dt_get_num_threads(), parallel_imgop_maxthreads);
 #pragma omp parallel for simd aligned(buf:16) default(none) \
   dt_omp_firstprivate(buf, max_value, nfloats) schedule(simd:static) num_threads(nthreads)
     for(size_t k = 0; k < nfloats; k++)
@@ -400,7 +400,7 @@ void dt_iop_image_mul_const(float *const buf, const float mul_value, const size_
     // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
     // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
     // memory won't be able to take advantage of more than four cores).
-    const int nthreads = MIN(darktable.num_openmp_threads,parallel_imgop_maxthreads);
+    const int nthreads = MIN(dt_get_num_threads(), parallel_imgop_maxthreads);
 #pragma omp parallel for simd aligned(buf:16) default(none) \
   dt_omp_firstprivate(buf, mul_value, nfloats) schedule(simd:static) num_threads(nthreads)
     for(size_t k = 0; k < nfloats; k++)
@@ -454,7 +454,7 @@ void dt_iop_image_linear_blend(float *const restrict buf, const float lambda, co
     // we can gain a little by using a small number of threads in parallel, but not much since the memory bus
     // quickly saturates (basically, each core can saturate a memory channel, so a system with quad-channel
     // memory won't be able to take advantage of more than four cores).
-    const int nthreads = MIN(darktable.num_openmp_threads,parallel_imgop_maxthreads);
+    const int nthreads = MIN(dt_get_num_threads(), parallel_imgop_maxthreads);
 #pragma omp parallel for simd aligned(buf:16) default(none) \
   dt_omp_firstprivate(buf, lambda, lambda_1,  nfloats) \
   dt_omp_sharedconst(other) schedule(simd:static) num_threads(nthreads)

--- a/src/common/nlmeans_core.c
+++ b/src/common/nlmeans_core.c
@@ -363,7 +363,7 @@ void nlmeans_denoise(
   const int chk_height = compute_slice_height(roi_out->height);
   const int chk_width = compute_slice_width(roi_out->width);
 #ifdef _OPENMP
-#pragma omp parallel for default(none) num_threads(darktable.num_openmp_threads) \
+#pragma omp parallel for default(none) \
       dt_omp_firstprivate(patches, num_patches, scratch_buf, padded_scratch_size, chk_height, chk_width, radius) \
       dt_omp_sharedconst(params, roi_out, outbuf, inbuf, stride, center_norm, skip_blend, weight, invert) \
       schedule(static) \

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -272,19 +272,6 @@ void dt_control_set_dev_closeup(int value);
 dt_dev_zoom_t dt_control_get_dev_zoom();
 void dt_control_set_dev_zoom(dt_dev_zoom_t value);
 
-static inline int32_t dt_ctl_get_num_procs()
-{
-#ifdef _OPENMP
-  return omp_get_num_procs();
-#else
-#ifdef _SC_NPROCESSORS_ONLN
-  return sysconf(_SC_NPROCESSORS_ONLN);
-#else
-  return 1;
-#endif
-#endif
-}
-
 #ifdef __cplusplus
 } // extern "C"
 #endif /* __cplusplus */

--- a/src/control/jobs.c
+++ b/src/control/jobs.c
@@ -503,7 +503,7 @@ static int32_t dt_control_get_threadid_res()
 static void *dt_control_work_res(void *ptr)
 {
 #ifdef _OPENMP // need to do this in every thread
-  omp_set_num_threads(darktable.num_openmp_threads);
+  omp_set_num_threads(dt_get_num_threads());
 #endif
   worker_thread_parameters_t *params = (worker_thread_parameters_t *)ptr;
   dt_control_t *s = params->self;
@@ -548,7 +548,7 @@ static void *dt_control_worker_kicker(void *ptr)
 static void *dt_control_work(void *ptr)
 {
 #ifdef _OPENMP // need to do this in every thread
-  omp_set_num_threads(darktable.num_openmp_threads);
+  omp_set_num_threads(dt_get_num_threads());
 #endif
   worker_thread_parameters_t *params = (worker_thread_parameters_t *)ptr;
   dt_control_t *control = params->self;

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -1002,7 +1002,7 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module,
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(h, w) \
   dt_omp_sharedconst(points, pos_x, pos_y) \
-  schedule(static) if(h*w > 50000) num_threads(MIN(darktable.num_openmp_threads,(h*w)/20000))
+  schedule(static) if(h*w > 50000) num_threads(MIN(dt_get_num_threads(), (h*w)/20000))
 #endif
   for(int i = 0; i < h; i++)
   {
@@ -1059,7 +1059,7 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module,
 #pragma omp parallel for default(none)  \
   dt_omp_firstprivate(h, w) \
   dt_omp_sharedconst(border2, total2, centerx, centery, points, points_y, ptbuffer) \
-  schedule(simd:static) if(h*w > 50000) num_threads(MIN(darktable.num_openmp_threads,(h*w)/20000))
+  schedule(simd:static) if(h*w > 50000) num_threads(MIN(dt_get_num_threads(), (h*w)/20000))
 #endif
   for(int i = 0 ; i < h*w; i++)
   {
@@ -1274,7 +1274,7 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(bbh, bbw, centerx, centery, border2, total2) \
   dt_omp_sharedconst(points) \
-  schedule(static) collapse(2) if(bbh*bbw > 50000) num_threads(MIN(darktable.num_openmp_threads,(h*w)/20000))
+  schedule(static) collapse(2) if(bbh*bbw > 50000) num_threads(MIN(dt_get_num_threads(), (h*w)/20000))
 #else
 #pragma omp parallel for shared(points)
 #endif

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -2881,7 +2881,7 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_
 #if !defined(__SUNOS__) && !defined(__NetBSD__)
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(xxmin, xxmax, yymin, yymax, width) \
-  shared(buffer) schedule(static) num_threads(MIN(8,darktable.num_openmp_threads))
+  shared(buffer) schedule(static) num_threads(MIN(8, dt_get_num_threads()))
 #else
 #pragma omp parallel for shared(buffer)
 #endif

--- a/src/imageio/imageio_j2k.c
+++ b/src/imageio/imageio_j2k.c
@@ -164,7 +164,7 @@ dt_imageio_retval_t dt_imageio_open_j2k(dt_image_t *img, const char *filename, d
   // opj_set_info_handler(d_codec, error_callback, stderr);
 
   /* Decode JPEG-2000 with using multiple threads */
-  if(!opj_codec_set_threads(d_codec, darktable.num_openmp_threads))
+  if(!opj_codec_set_threads(d_codec, dt_get_num_threads()))
   {
     /* This may not seem like a critical error but failure to initialise the treads
      is a symptom of major resource exhaustion, bail out as quickly as possible */

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5037,7 +5037,7 @@ void tiling_callback(
     else
       tiling->factor += smooth;                        // + smooth
     tiling->maxbuf = 1.0f;
-    tiling->overhead = sizeof(float) * RCD_TILESIZE * RCD_TILESIZE * 8 * MAX(1, darktable.num_openmp_threads);
+    tiling->overhead = sizeof(float) * RCD_TILESIZE * RCD_TILESIZE * 8 * dt_get_num_threads();
     tiling->xalign = 2;
     tiling->yalign = 2;
     tiling->overlap = 10;
@@ -5053,7 +5053,7 @@ void tiling_callback(
     else
       tiling->factor += smooth;                        // + smooth
     tiling->maxbuf = 1.0f;
-    tiling->overhead = sizeof(float) * LMMSE_GRP * LMMSE_GRP * 6 * MAX(1, darktable.num_openmp_threads);
+    tiling->overhead = sizeof(float) * LMMSE_GRP * LMMSE_GRP * 6 * dt_get_num_threads();
     tiling->xalign = 2;
     tiling->yalign = 2;
     tiling->overlap = 10;

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -330,7 +330,7 @@ static void wavelet_denoise_xtrans(const float *const restrict in, float *const 
       fimg[col] = 0.5f;
       fimg[(size_t)(height-1)*width + col] = 0.5f;
     }
-    const size_t nthreads = darktable.num_openmp_threads; // go direct, dt_get_num_threads() always returns numprocs
+    const size_t nthreads = dt_get_num_threads();
     const size_t chunksize = (height + nthreads - 1) / nthreads;
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \


### PR DESCRIPTION
Setting the number of ompthreads via --threads or the -t variant must be limited to what the omp system reports.

Important because `darktable.num_openmp_threads` is used all over the codebase for faster reading the number of threads.

This is certainly not fixing all issues but at least restricts to something possible and gives some report.

See #13727