### PR TITLE
colorin: optimize simple colormatrix conversion, remove SSE

### DIFF
--- a/src/chart/main.c
+++ b/src/chart/main.c
@@ -757,7 +757,8 @@ static void add_patches_to_array(dt_lut_t *self, GList *patch_names, int *N, int
     get_Lab_from_box(source_patch, source_Lab);
     get_Lab_from_box(reference_patch, reference_Lab);
 
-    for(int j = 0; j < 3; j++) colorchecker_Lab[3 * (*i) + j] = source_Lab[j];
+    for_three_channels(j)
+      colorchecker_Lab[3 * (*i) + j] = source_Lab[j];
     target_L[*i] = reference_Lab[0];
     target_a[*i] = reference_Lab[1];
     target_b[*i] = reference_Lab[2];
@@ -1421,12 +1422,13 @@ static void get_Lab_from_box(box_t *box, float *Lab)
     case DT_COLORSPACE_XYZ:
     {
       dt_aligned_pixel_t XYZ;
-      for(int i = 0; i < 3; i++) XYZ[i] = box->color[i] * 0.01;
+      for_each_channel(i)
+        XYZ[i] = box->color[i] * 0.01;
       dt_XYZ_to_Lab(XYZ, Lab);
       break;
     }
     case DT_COLORSPACE_LAB:
-      for(int i = 0; i < 3; i++) Lab[i] = box->color[i];
+      for_each_channel(i) Lab[i] = box->color[i];
       break;
     default:
       break;
@@ -1661,7 +1663,7 @@ static void image_lab_to_xyz(float *image, const int width, const int height)
       const int i0 = (x + y * width) * 3 + 0;
       const int i1 = (x + y * width) * 3 + 1;
       const int i2 = (x + y * width) * 3 + 2;
-      dt_aligned_pixel_t pixel_lab = { image[i0], image[i1], image[i2] };
+      dt_aligned_pixel_t pixel_lab = { image[i0], image[i1], image[i2], 0.0f };
       dt_aligned_pixel_t pixel_xyz = { 0.0 };
       dt_Lab_to_XYZ(pixel_lab, pixel_xyz);
       image[i0] = pixel_xyz[0];

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -765,6 +765,28 @@ static void process_cmatrix_bm(struct dt_iop_module_t *self,
   }
 }
 
+#ifdef _OPENMP
+#pragma omp declare simd aligned(in, out: 64)
+#endif
+static void _cmatrix_fastpath_simple(float *out,
+                                     const float *in,
+                                     size_t npixels,
+                                     const dt_colormatrix_t cmatrix)
+{
+  dt_colormatrix_t transposed;
+  transpose_3xSSE(cmatrix, transposed);
+
+  // this function is called from inside a parallel for loop, so no need for further parallelization
+  for(size_t k = 0; k < npixels; k++)
+  {
+    dt_aligned_pixel_t xyz = { 0.0f, 0.0f, 0.0f, 0.0f };
+    dt_apply_transposed_color_matrix(in + 4*k, transposed, xyz);
+    dt_aligned_pixel_t res;
+    dt_XYZ_to_Lab(xyz, res);
+    copy_pixel_nontemporal(out + 4*k, res);
+  }
+}
+
 static void process_cmatrix_fastpath_simple(struct dt_iop_module_t *self,
                                             dt_dev_pixelpipe_iop_t *piece,
                                             const void *const ivoid,
@@ -775,26 +797,28 @@ static void process_cmatrix_fastpath_simple(struct dt_iop_module_t *self,
   const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
   assert(piece->colors == 4);
 
-  dt_colormatrix_t cmatrix;
-  transpose_3xSSE(d->cmatrix, cmatrix);
-
-// fprintf(stderr, "Using cmatrix codepath\n");
-// only color matrix. use our optimized fast path!
+  const size_t npixels = (size_t)roi_out->width * roi_out->height;
+  const float *const restrict in = (float*)ivoid;
+  float *const restrict  out = (float*)ovoid;
+  
 #ifdef _OPENMP
+  // figure out the number of pixels each thread needs to process
+  // round up to a multiple of 4 pixels so that each chunk starts aligned(64)
+  const size_t nthreads = dt_get_num_threads();
+  const size_t chunksize = 4 * (((npixels / nthreads) + 3) / 4);
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ivoid, ovoid, roi_out)    \
-  shared(cmatrix) \
+  dt_omp_firstprivate(in, out, npixels, chunksize, nthreads, d)  \
   schedule(static)
-#endif
-  for(int k = 0; k < (size_t)roi_out->width * roi_out->height; k++)
+  for(size_t chunk = 0; chunk < nthreads; chunk++)
   {
-    float *in = (float *)ivoid + (size_t)4 * k;
-    float *out = (float *)ovoid + (size_t)4 * k;
-
-    dt_aligned_pixel_t _xyz = { 0.0f, 0.0f, 0.0f, 0.0f };
-    dt_apply_transposed_color_matrix(in, cmatrix, _xyz);
-    dt_XYZ_to_Lab(_xyz, out);
+    size_t start = chunksize * dt_get_thread_num();
+    size_t end = MIN(start + chunksize, npixels);
+    _cmatrix_fastpath_simple(out + 4*start, in + 4*start, end-start, d->cmatrix);
   }
+  dt_omploop_sfence();
+#else
+  _cmatrix_fastpath_simple(out, in, npixels, d->cmatrix);
+#endif
 }
 
 static void process_cmatrix_fastpath_clipping(struct dt_iop_module_t *self,

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1213,41 +1213,6 @@ static void process_sse2_cmatrix_bm(struct dt_iop_module_t *self,
   _mm_sfence();
 }
 
-static void process_sse2_cmatrix_fastpath_simple(struct dt_iop_module_t *self,
-                                                 dt_dev_pixelpipe_iop_t *piece,
-                                                 const void *const ivoid,
-                                                 void *const ovoid,
-                                                 const dt_iop_roi_t *const roi_in,
-                                                 const dt_iop_roi_t *const roi_out)
-{
-  const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
-  const int ch = piece->colors;
-
-  // only color matrix. use our optimized fast path!
-  const __m128 cm0 = _mm_set_ps(0.0f, d->cmatrix[2][0], d->cmatrix[1][0], d->cmatrix[0][0]);
-  const __m128 cm1 = _mm_set_ps(0.0f, d->cmatrix[2][1], d->cmatrix[1][1], d->cmatrix[0][1]);
-  const __m128 cm2 = _mm_set_ps(0.0f, d->cmatrix[2][2], d->cmatrix[1][2], d->cmatrix[0][2]);
-
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ch, cm0, cm1, cm2, ivoid, ovoid, roi_out) \
-  schedule(static)
-#endif
-  for(int k = 0; k < (size_t)roi_out->width * roi_out->height; k++)
-  {
-    float *in = (float *)ivoid + (size_t)ch * k;
-    float *out = (float *)ovoid + (size_t)ch * k;
-
-    __m128 input = _mm_load_ps(in);
-
-    __m128 xyz = _mm_add_ps(_mm_add_ps(_mm_mul_ps(cm0, _mm_shuffle_ps(input, input, _MM_SHUFFLE(0, 0, 0, 0))),
-                                       _mm_mul_ps(cm1, _mm_shuffle_ps(input, input, _MM_SHUFFLE(1, 1, 1, 1)))),
-                            _mm_mul_ps(cm2, _mm_shuffle_ps(input, input, _MM_SHUFFLE(2, 2, 2, 2))));
-    _mm_stream_ps(out, dt_XYZ_to_Lab_sse2(xyz));
-  }
-  _mm_sfence();
-}
-
 static void process_sse2_cmatrix_fastpath_clipping(struct dt_iop_module_t *self,
                                                    dt_dev_pixelpipe_iop_t *piece,
                                                    const void *const ivoid,
@@ -1303,7 +1268,7 @@ static void process_sse2_cmatrix_fastpath(struct dt_iop_module_t *self,
 
   if(!clipping)
   {
-    process_sse2_cmatrix_fastpath_simple(self, piece, ivoid, ovoid, roi_in, roi_out);
+    process_cmatrix_fastpath_simple(self, piece, ivoid, ovoid, roi_in, roi_out);
   }
   else
   {

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -964,7 +964,7 @@ static void _draw_color_picker(dt_iop_module_t *self, cairo_t *cr, dt_iop_colorz
   const float clip2 = clip * clip * clip;                                                                         \
   Lab[1] *= Lab[0] / L0 * clip2;                                                                                  \
   Lab[2] *= Lab[0] / L0 * clip2;                                                                                  \
-                                                                                                                  \
+  Lab[3] = 0.0f;                                                                                                  \
   dt_aligned_pixel_t xyz;                                                                                         \
   dt_aligned_pixel_t rgb;                                                                                         \
   dt_Lab_to_XYZ(Lab, xyz);                                                                                        \

--- a/src/iop/gamma.c
+++ b/src/iop/gamma.c
@@ -159,7 +159,7 @@ static void _channel_display_false_color(const float *const restrict in,
         // colors with "a" exceeding the range [-56,56] range will
         // yield colors not representable in sRGB
         const float value = fminf(fmaxf(in[j + 1] * 256.0f - 128.0f, -56.0f), 56.0f);
-        const dt_aligned_pixel_t lab = { 79.0f - value * (11.0f / 56.0f), value, 0.0f };
+        const dt_aligned_pixel_t lab = { 79.0f - value * (11.0f / 56.0f), value, 0.0f, 0.0f };
         dt_Lab_to_XYZ(lab, xyz);
         _XYZ_to_REC_709_normalized(xyz, pixel, 0.75f);
         _write_pixel(pixel, out + j, mask_color, in[j + 3] * alpha);
@@ -177,7 +177,7 @@ static void _channel_display_false_color(const float *const restrict in,
         // colors with "b" exceeding the range [-65,65] range will
         // yield colors not representable in sRGB
         const float value = fminf(fmaxf(in[j + 1] * 256.0f - 128.0f, -65.0f), 65.0f);
-        const dt_aligned_pixel_t lab = { 60.0f + value * (2.0f / 65.0f), 0.0f, value };
+        const dt_aligned_pixel_t lab = { 60.0f + value * (2.0f / 65.0f), 0.0f, value, 0.0f };
         dt_Lab_to_XYZ(lab, xyz);
         _XYZ_to_REC_709_normalized(xyz, pixel, 0.75f);
         _write_pixel(pixel, out + j, mask_color, in[j + 3] * alpha);
@@ -244,6 +244,7 @@ static void _channel_display_false_color(const float *const restrict in,
         dt_aligned_pixel_t lch = { 65.0f, 37.0f, in[j + 1], 0.0f };
         dt_aligned_pixel_t lab, xyz, pixel;
         dt_LCH_2_Lab(lch, lab);
+        lab[3] = 0.0f;
         dt_Lab_to_XYZ(lab, xyz);
         _XYZ_to_REC_709_normalized(xyz, pixel, 0.75f);
         _write_pixel(pixel, out + j, mask_color, in[j + 3] * alpha);


### PR DESCRIPTION
Worked on the codepath used when the input colorspace is a linear color matrix (e.g. the standard camera matrix) and no gamut clipping is applied.

I got the plain C code to effective parity with the SSE codepath, so we can now remove it.
```
Thr    SSE      plain
1     70.75    71.83    +1.5%
2     35.41    36.00    +1.6%
4     17.77    18.02    +1.4%
8      8.95     9.06    +1.2%
16     4.78     4.78    0%
32     5.53     5.52    -0.2%
```
