### PR TITLE
Move lua event pixelpipe-processing-complete to color_picker_proxy

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -648,14 +648,6 @@ restart:
   dt_control_toast_busy_leave();
   dt_pthread_mutex_unlock(&dev->pipe_mutex);
 
-#ifdef USE_LUA
-  dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
-      0, NULL, NULL,
-      LUA_ASYNC_TYPENAME, "const char*", "pixelpipe-processing-complete",
-      LUA_ASYNC_TYPENAME, "dt_lua_image_t", GINT_TO_POINTER(dev->image_storage.id),
-      LUA_ASYNC_DONE);
-#endif
-
   if(dev->gui_attached && !dev->gui_leaving)
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED);
 }

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -320,6 +320,15 @@ static void _color_picker_proxy_preview_pipe_callback(gpointer instance, gpointe
     // called. Hence the UI will always update once the picker data
     // updates. But I'm not clear how this is guaranteed to be so.
   }
+
+  // we need to fire an event to let lua scripts know that 
+  // all pixelpipe processing is complete.
+#ifdef USE_LUA
+  dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
+      0, NULL, NULL,
+      LUA_ASYNC_TYPENAME, "const char*", "pixelpipe-processing-complete",
+       LUA_ASYNC_DONE);
+#endif
 }
 
 void dt_iop_color_picker_init(void)


### PR DESCRIPTION
It seems that _color_picker_proxy_preview_pipe_callback() is called after all pixelpipe processing is complete, so I moved the lua event trigger for `pixelpipe-processing-complete` there.  This allows scripts using darktable.gui.action() to run without having to resort to adding sleeps to allow the pixelpipe to complete before running the next action.

I've attached a script that adds a button to selected images named `display in darkroom`.   Select a set of images in lighttable view, then click the button.  Each image should be loaded and 0.5 ev of exposure added to it.
[display_in_darkroom.zip](https://github.com/darktable-org/darktable/files/10833032/display_in_darkroom.zip)

Fixes #13745 