### PR TITLE
OpenCL supports --dump-pipe

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -429,7 +429,8 @@ void dt_dump_pfm_file(
         const char *modname,
         const char *head,
         const gboolean input,
-        const gboolean output)
+        const gboolean output,
+        const gboolean cpu)
 {
   static int written = 0;
 
@@ -445,20 +446,18 @@ void dt_dump_pfm_file(
   }
 
   char fname[PATH_MAX]= { 0 };
-  snprintf(fname, sizeof (fname), "%s/%04d_%s_%s%s%s.%s",
+  snprintf(fname, sizeof (fname), "%s/%04d_%s_%s_%s%s%s.%s",
      path,
      written,
      modname,
-     (input) ? "in_" : "",
-     (output) ? "out_" : "",
+     cpu ? "cpu" : "GPU", 
+     input ? "in_" : "",
+     output ? "out_" : "",
      (bpp != 16) ? "M" : "C",
      (bpp==2) ? "ppm" : "pfm");
 
-  if(!((width>0) && (height>0) && (width<50000) && (height<50000) && data))
-  {
-    dt_print(DT_DEBUG_ALWAYS, "%20s '%s' invalid data at%p\n", head, fname, data); 
+  if((width<1) || (height<1) || !data)
     return;
-  }
 
   FILE *f = g_fopen(fname, "wb");
   if(f == NULL)
@@ -498,7 +497,7 @@ void dt_dump_pfm(
   if(!modname) return;
   if(!dt_str_commasubstring(darktable.dump_pfm_module, modname)) return; 
 
-  dt_dump_pfm_file(modname, data, width, height, bpp, filename, "[dt_dump_pfm]", FALSE, FALSE);
+  dt_dump_pfm_file(modname, data, width, height, bpp, filename, "[dt_dump_pfm]", FALSE, FALSE, TRUE);
 }
 
 void dt_dump_pipe_pfm(
@@ -514,7 +513,7 @@ void dt_dump_pipe_pfm(
   if(!mod) return;
   if(!dt_str_commasubstring(darktable.dump_pfm_pipe, mod)) return; 
 
-  dt_dump_pfm_file(pipe, data, width, height, bpp, mod, "[dt_dump_pipe_pfm]", input, !input);
+  dt_dump_pfm_file(pipe, data, width, height, bpp, mod, "[dt_dump_pipe_pfm]", input, !input, TRUE);
 }
 
 

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -420,95 +420,90 @@ void check_resourcelevel(const char *key, int *fractions, const int level)
   }
 }
 
-void _dump_pfm_file(
-        const char *name,
-        const void* in,
+void dt_dump_pfm_file(
+        const char *pipe,
+        const void* data,
         const int width,
         const int height,
-        const dt_dump_pfm_t mode,
+        const int bpp,
         const char *modname,
+        const char *head,
         const gboolean input,
         const gboolean output)
 {
   static int written = 0;
 
-  if(mode > DT_DUMP_PFM_LAST)
-  {
-    dt_print(DT_DEBUG_ALWAYS, "[dt_dump_pfm] undefined mode %i\n", mode);
-    return;
-  }
-
-  if((width < 1) || (height < 1) || (height > 20000) || (width > 20000))
-  {
-    dt_print(DT_DEBUG_ALWAYS, "[dt_dump_pfm] bad dimensions %dx%d\n", width, height);
-    return;
-  }
-
-  const size_t colors = (mode == DT_DUMP_PFM_MASK) ? 1 : 3;
-  const size_t p = (mode == DT_DUMP_PFM_MASK) ? 1 : 4;
-
-  char counts[32]= { 0 };
-  snprintf(counts, sizeof(counts), "%04d_", written);
-
   char path[PATH_MAX]= { 0 };
-  snprintf(path, sizeof(path), "%s/%s", darktable.tmp_directory, modname);
+  snprintf(path, sizeof(path), "%s/%s", darktable.tmp_directory, pipe);
   if(!dt_util_test_writable_dir(path))
   {
     if(g_mkdir(path, 0750))
     {
-      dt_print(DT_DEBUG_ALWAYS, "[dt_dump_pfm] can't create directory '%s'\n", path);
+      dt_print(DT_DEBUG_ALWAYS, "%20s can't create directory '%s'\n", head, path);
       return;
     }
   }
 
   char fname[PATH_MAX]= { 0 };
-  snprintf(fname, sizeof (fname), "%s/%s%s%s%s%s.pfm",
-     path, counts, (input) ? "in_" : "", (output) ? "out_" : "",
-     name, (p == 1) ? "_M" : "_C");
+  snprintf(fname, sizeof (fname), "%s/%04d_%s_%s%s%s.%s",
+     path,
+     written,
+     modname,
+     (input) ? "in_" : "",
+     (output) ? "out_" : "",
+     (bpp != 16) ? "M" : "C",
+     (bpp==2) ? "ppm" : "pfm");
+
+  if(!((width>0) && (height>0) && (width<50000) && (height<50000) && data))
+  {
+    dt_print(DT_DEBUG_ALWAYS, "%20s '%s' invalid data at%p\n", head, fname, data); 
+    return;
+  }
 
   FILE *f = g_fopen(fname, "wb");
   if(f == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[dt_dump_pfm] can't write file '%s' in wb mode\n", fname); 
+    dt_print(DT_DEBUG_ALWAYS, "%20s can't write file '%s' in wb mode\n", head, fname); 
     return;
   }
 
-  if((mode == DT_DUMP_PFM_MASK) || (mode == DT_DUMP_PFM_RGB))
+  if(bpp==2)
+    fprintf(f, "P5\n%d %d\n", width, height);
+  else
+    fprintf(f, "P%s\n%d %d\n-1.0\n", (bpp != 16) ? "f" : "F", width, height);
+
+  for(int row = height - 1; row >= 0; row--)
   {
-    fprintf(f, "P%s\n%d %d\n-1.0\n", (p == 1) ? "f" : "F", width, height);
-    const float *data = in;
-    for(int row = height - 1; row >= 0; row--)
+    for(int col = 0; col < width; col++)
     {
-      for(int col = 0; col < width; col++)
-      {
-        const size_t blk = (row * width + col) * p;
-        fwrite(data + blk, colors, sizeof(float), f);
-      }
+      const size_t blk = (row * width + col) * bpp;
+      fwrite(data + blk, (bpp==16) ? 12 : bpp, 1, f);
     }
   }
-  dt_print(DT_DEBUG_ALWAYS, "[dt_dump_pfm] '%s' size size %dx%d\n", fname, width, height);
+
+  dt_print(DT_DEBUG_ALWAYS, "%20s %s,  %dx%d, bpp=%d\n", head, fname, width, height, bpp);
   fclose(f);
   written += 1;
 }
 
 void dt_dump_pfm(
         const char *filename,
-        const void* in,
+        const void *data,
         const int width,
         const int height,
-        const dt_dump_pfm_t mode,
+        const int bpp,
         const char *modname)
 {
   if(!darktable.dump_pfm_module) return;
   if(!modname) return;
   if(!dt_str_commasubstring(darktable.dump_pfm_module, modname)) return; 
 
-  _dump_pfm_file(filename, in, width, height, mode, modname, FALSE, FALSE);
+  dt_dump_pfm_file(modname, data, width, height, bpp, filename, "[dt_dump_pfm]", FALSE, FALSE);
 }
 
 void dt_dump_pipe_pfm(
-        const char* mod,
-        const void* data,
+        const char *mod,
+        const void *data,
         const int width,
         const int height,
         const int bpp,
@@ -519,7 +514,7 @@ void dt_dump_pipe_pfm(
   if(!mod) return;
   if(!dt_str_commasubstring(darktable.dump_pfm_pipe, mod)) return; 
 
-  _dump_pfm_file(pipe, data, width, height, (bpp == 4) ? DT_DUMP_PFM_RGB : DT_DUMP_PFM_MASK, mod, input, !input);
+  dt_dump_pfm_file(pipe, data, width, height, bpp, mod, "[dt_dump_pipe_pfm]", input, !input);
 }
 
 

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -282,14 +282,6 @@ typedef enum dt_debug_thread_t
   DT_DEBUG_COMMON         = DT_DEBUG_OPENCL | DT_DEBUG_DEV | DT_DEBUG_MASKS | DT_DEBUG_PARAMS | DT_DEBUG_IMAGEIO | DT_DEBUG_PIPE,
 } dt_debug_thread_t;
 
-typedef enum dt_dump_pfm_t
-{
-  DT_DUMP_PFM_MASK        = 0,
-  DT_DUMP_PFM_RGB         = 1,
-  DT_DUMP_PFM_LAST        = 1,
-} dt_dump_pfm_t;
-
-
 typedef struct dt_codepath_t
 {
   unsigned int SSE2 : 1;
@@ -387,7 +379,9 @@ void dt_print_nts(dt_debug_thread_t thread, const char *msg, ...) __attribute__(
 int dt_worker_threads();
 size_t dt_get_available_mem();
 size_t dt_get_singlebuffer_mem();
-void dt_dump_pfm(const char *filename, const void* data, const int width, const int height, dt_dump_pfm_t mode, const char *modname);
+
+void dt_dump_pfm_file(const char *pipe, const void *data, const int width, const int height, const int bpp, const char *modname, const char *head, const gboolean input, const gboolean output);
+void dt_dump_pfm(const char *filename, const void* data, const int width, const int height, const int bpp, const char *modname);
 void dt_dump_pipe_pfm(const char *mod, const void* data, const int width, const int height, const int bpp, const gboolean input, const char *pipe);
 
 void *dt_alloc_align(size_t alignment, size_t size);

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -380,7 +380,7 @@ int dt_worker_threads();
 size_t dt_get_available_mem();
 size_t dt_get_singlebuffer_mem();
 
-void dt_dump_pfm_file(const char *pipe, const void *data, const int width, const int height, const int bpp, const char *modname, const char *head, const gboolean input, const gboolean output);
+void dt_dump_pfm_file(const char *pipe, const void *data, const int width, const int height, const int bpp, const char *modname, const char *head, const gboolean input, const gboolean output, const gboolean cpu);
 void dt_dump_pfm(const char *filename, const void* data, const int width, const int height, const int bpp, const char *modname);
 void dt_dump_pipe_pfm(const char *mod, const void* data, const int width, const int height, const int bpp, const gboolean input, const char *pipe);
 

--- a/src/common/locallaplacian.c
+++ b/src/common/locallaplacian.c
@@ -358,7 +358,7 @@ static inline float *ll_pad_input(
   }
   if((b && b->mode == 2) && (darktable.dump_pfm_module))
   {
-    dt_dump_pfm("padded", out, *wd2, *ht2, DT_DUMP_PFM_RGB, "locallaplacian");
+    dt_dump_pfm("padded", out, *wd2, *ht2, 4 * sizeof(float), "locallaplacian");
   }
   return out;
 }
@@ -684,8 +684,11 @@ void local_laplacian_internal(
     const int pw = dl(w,last_level), ph = dl(h,last_level);
     const int pw0 = dl(b->pwd, pl0), ph0 = dl(b->pht, pl0);
     const int pw1 = dl(b->pwd, pl1), ph1 = dl(b->pht, pl1);
-    dt_dump_pfm("coarse", b->output[pl0], pw0, ph0, DT_DUMP_PFM_RGB, "locallaplacian");
-    dt_dump_pfm("oldcoarse", output[last_level], pw, ph, DT_DUMP_PFM_RGB, "locallaplacian");
+    if(darktable.dump_pfm_module)
+    {
+      dt_dump_pfm("coarse", b->output[pl0], pw0, ph0,  4 * sizeof(float), "locallaplacian");
+      dt_dump_pfm("oldcoarse", output[last_level], pw, ph,  4 * sizeof(float), "locallaplacian");
+    }
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static) collapse(2) default(shared)
 #endif
@@ -723,7 +726,8 @@ void local_laplacian_internal(
 #endif
       output[last_level][j*pw+i] = weight * c1 + (1.0f-weight) * c0;
     }
-    dt_dump_pfm("newcoarse", output[last_level], pw, ph, DT_DUMP_PFM_RGB, "locallaplacian");
+    if(darktable.dump_pfm_module)
+      dt_dump_pfm("newcoarse", output[last_level], pw, ph,  4 * sizeof(float), "locallaplacian");
   }
 
   // assemble output pyramid coarse to fine

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -3019,7 +3019,7 @@ void dt_opencl_dump_pipe_pfm(const char* mod,
   {
     const cl_int err = dt_opencl_read_host_from_device(devid, data, img, width, height, element_size);
     if(err == CL_SUCCESS)
-      dt_dump_pfm_file(pipe, data, width, height, element_size, mod, "[dt_opencl_dump_pipe_pfm]", input, !input);
+      dt_dump_pfm_file(pipe, data, width, height, element_size, mod, "[dt_opencl_dump_pipe_pfm]", input, !input, FALSE);
 
     dt_free_align(data);
   }

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2576,7 +2576,7 @@ int dt_opencl_write_host_to_device_rowpitch_non_blocking(
   const size_t region[] = { width, height, 1 };
   // non-blocking.
 
-  cl_int err = dt_opencl_write_host_to_device_raw(devid, host, device, origin, region, rowpitch, CL_FALSE);
+  const cl_int err = dt_opencl_write_host_to_device_raw(devid, host, device, origin, region, rowpitch, CL_FALSE);
   _check_clmem_err(devid, err); 
   return err;
 }
@@ -2595,7 +2595,7 @@ int dt_opencl_write_host_to_device_raw(
 
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Write Image (from host to device)]");
 
-  cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueWriteImage)(darktable.opencl->dev[devid].cmd_queue,
+  const cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueWriteImage)(darktable.opencl->dev[devid].cmd_queue,
                                                                     device, blocking ? CL_TRUE : CL_FALSE, origin, region,
                                                                     rowpitch, 0, host, 0, NULL, eventp);
   _check_clmem_err(devid, err); 
@@ -2614,7 +2614,7 @@ int dt_opencl_enqueue_copy_image(
     return -1;
 
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Copy Image (on device)]");
-  cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyImage)(
+  const cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyImage)(
       darktable.opencl->dev[devid].cmd_queue, src, dst, orig_src, orig_dst, region, 0, NULL, eventp);
 
   if(err != CL_SUCCESS) dt_print(DT_DEBUG_OPENCL, "[opencl copy_image] could not copy image on device %d: %s\n", devid, cl_errstr(err));
@@ -2634,7 +2634,7 @@ int dt_opencl_enqueue_copy_image_to_buffer(
     return -1;
 
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Copy Image to Buffer (on device)]");
-  cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyImageToBuffer)(
+  const cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyImageToBuffer)(
       darktable.opencl->dev[devid].cmd_queue, src_image, dst_buffer, origin, region, offset, 0, NULL, eventp);
 
   if(err != CL_SUCCESS)
@@ -2655,7 +2655,7 @@ int dt_opencl_enqueue_copy_buffer_to_image(
     return -1;
 
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Copy Buffer to Image (on device)]");
-  cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyBufferToImage)(
+  const cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyBufferToImage)(
       darktable.opencl->dev[devid].cmd_queue, src_buffer, dst_image, offset, origin, region, 0, NULL, eventp);
 
   if(err != CL_SUCCESS)
@@ -2676,7 +2676,7 @@ int dt_opencl_enqueue_copy_buffer_to_buffer(
     return -1;
 
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Copy Buffer to Buffer (on device)]");
-  cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyBuffer)(darktable.opencl->dev[devid].cmd_queue,
+  const cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyBuffer)(darktable.opencl->dev[devid].cmd_queue,
                                                                    src_buffer, dst_buffer, srcoffset,
                                                                    dstoffset, size, 0, NULL, eventp);
   if(err != CL_SUCCESS)
@@ -2947,7 +2947,7 @@ size_t dt_opencl_get_mem_object_size(cl_mem mem)
   size_t size;
   if(mem == NULL) return 0;
 
-  cl_int err = (darktable.opencl->dlocl->symbols->dt_clGetMemObjectInfo)(mem, CL_MEM_SIZE, sizeof(size), &size, NULL);
+  const cl_int err = (darktable.opencl->dlocl->symbols->dt_clGetMemObjectInfo)(mem, CL_MEM_SIZE, sizeof(size), &size, NULL);
 
   return (err == CL_SUCCESS) ? size : 0;
 }
@@ -2957,7 +2957,7 @@ int dt_opencl_get_mem_context_id(cl_mem mem)
   cl_context context;
   if(mem == NULL) return -1;
 
-  cl_int err = (darktable.opencl->dlocl->symbols->dt_clGetMemObjectInfo)(mem, CL_MEM_CONTEXT, sizeof(context), &context, NULL);
+  const cl_int err = (darktable.opencl->dlocl->symbols->dt_clGetMemObjectInfo)(mem, CL_MEM_CONTEXT, sizeof(context), &context, NULL);
   if(err != CL_SUCCESS)
     return -1;
 
@@ -2975,7 +2975,7 @@ int dt_opencl_get_image_width(cl_mem mem)
   size_t size;
   if(mem == NULL) return 0;
 
-  cl_int err = (darktable.opencl->dlocl->symbols->dt_clGetImageInfo)(mem, CL_IMAGE_WIDTH, sizeof(size), &size, NULL);
+  const cl_int err = (darktable.opencl->dlocl->symbols->dt_clGetImageInfo)(mem, CL_IMAGE_WIDTH, sizeof(size), &size, NULL);
   if(size > INT_MAX) size = 0;
 
   return (err == CL_SUCCESS) ? (int)size : 0;
@@ -2986,7 +2986,7 @@ int dt_opencl_get_image_height(cl_mem mem)
   size_t size;
   if(mem == NULL) return 0;
 
-  cl_int err = (darktable.opencl->dlocl->symbols->dt_clGetImageInfo)(mem, CL_IMAGE_HEIGHT, sizeof(size), &size, NULL);
+  const cl_int err = (darktable.opencl->dlocl->symbols->dt_clGetImageInfo)(mem, CL_IMAGE_HEIGHT, sizeof(size), &size, NULL);
   if(size > INT_MAX) size = 0;
 
   return (err == CL_SUCCESS) ? (int)size : 0;
@@ -2997,11 +2997,32 @@ int dt_opencl_get_image_element_size(cl_mem mem)
   size_t size;
   if(mem == NULL) return 0;
 
-  cl_int err = (darktable.opencl->dlocl->symbols->dt_clGetImageInfo)(mem, CL_IMAGE_ELEMENT_SIZE, sizeof(size), &size,
+  const cl_int err = (darktable.opencl->dlocl->symbols->dt_clGetImageInfo)(mem, CL_IMAGE_ELEMENT_SIZE, sizeof(size), &size,
                                                               NULL);
   if(size > INT_MAX) size = 0;
 
   return (err == CL_SUCCESS) ? (int)size : 0;
+}
+
+void dt_opencl_dump_pipe_pfm(const char* mod,
+                             const int devid,
+                             cl_mem img,
+                             const gboolean input,
+                             const char *pipe)
+{
+  if(!darktable.opencl->inited || devid < 0) return;
+  const int width = dt_opencl_get_image_width(img);
+  const int height = dt_opencl_get_image_height(img);
+  const int element_size = dt_opencl_get_image_element_size(img);
+  float *data = dt_alloc_align(64, (size_t)width * height * element_size);
+  if(data)
+  {
+    const cl_int err = dt_opencl_read_host_from_device(devid, data, img, width, height, element_size);
+    if(err == CL_SUCCESS)
+      dt_dump_pfm_file(pipe, data, width, height, element_size, mod, "[dt_opencl_dump_pipe_pfm]", input, !input);
+
+    dt_free_align(data);
+  }
 }
 
 void dt_opencl_memory_statistics(int devid, cl_mem mem, dt_opencl_memory_t action)

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -487,6 +487,8 @@ int dt_opencl_get_image_height(cl_mem mem);
 
 int dt_opencl_get_image_element_size(cl_mem mem);
 
+void dt_opencl_dump_pipe_pfm(const char* mod, const int devid, cl_mem img, const gboolean input, const char *pipe);
+
 int dt_opencl_get_mem_context_id(cl_mem mem);
 
 void dt_opencl_memory_statistics(int devid, cl_mem mem, dt_opencl_memory_t action);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -349,7 +349,7 @@ static void debug_dump_PFM(const dt_dev_pixelpipe_iop_t *const piece, const char
 
   char name[256];
   snprintf(name, sizeof(name), namespec, scale);
-  dt_dump_pfm(name, buf, width, height, DT_DUMP_PFM_RGB, "denoiseprofile");
+  dt_dump_pfm(name, buf, width, height,  4 * sizeof(float), "denoiseprofile");
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -926,10 +926,10 @@ static inline gint wavelets_process(const float *const restrict in, float *const
     {
       char name[64];
       sprintf(name, "scale-input-%i", s);
-      dt_dump_pfm(name, buffer_in, width, height, DT_DUMP_PFM_RGB, "diffuse");
+      dt_dump_pfm(name, buffer_in, width, height,  4 * sizeof(float), "diffuse");
 
       sprintf(name, "scale-blur-%i", s);
-      dt_dump_pfm(name, buffer_out, width, height, DT_DUMP_PFM_RGB, "diffuse");
+      dt_dump_pfm(name, buffer_out, width, height,  4 * sizeof(float), "diffuse");
     }
   }
   dt_free_align(tempbuf);
@@ -984,7 +984,7 @@ static inline gint wavelets_process(const float *const restrict in, float *const
     {
       char name[64];
       sprintf(name, "scale-up-unblur-%i", s);
-      dt_dump_pfm(name, buffer_out, width, height, DT_DUMP_PFM_RGB, "diffuse");
+      dt_dump_pfm(name, buffer_out, width, height,  4 * sizeof(float), "diffuse");
     }
     count++;
   }

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -1590,10 +1590,10 @@ static inline gint wavelets_process(const float *const restrict in, float
     {
       char name[64];
       sprintf(name, "scale-input-%i", s);
-      dt_dump_pfm(name, buffer_in, width, height, DT_DUMP_PFM_RGB, "highlights");
+      dt_dump_pfm(name, buffer_in, width, height,  4 * sizeof(float), "highlights");
 
       sprintf(name, "scale-blur-%i", s);
-      dt_dump_pfm(name, buffer_out, width, height, DT_DUMP_PFM_RGB, "highlights");
+      dt_dump_pfm(name, buffer_out, width, height,  4 * sizeof(float), "highlights");
     }
   }
   dt_free_align(tempbuf);
@@ -1686,8 +1686,8 @@ static void process_laplacian_bayer(struct dt_iop_module_t *self, dt_dev_pixelpi
 
   if(darktable.dump_pfm_module)
   {
-    dt_dump_pfm("interpolated", interpolated, width, height, DT_DUMP_PFM_RGB, "highlights");
-    dt_dump_pfm("clipping_mask", clipping_mask, width, height, DT_DUMP_PFM_RGB, "highlights");
+    dt_dump_pfm("interpolated", interpolated, width, height,  4 * sizeof(float), "highlights");
+    dt_dump_pfm("clipping_mask", clipping_mask, width, height,  4 * sizeof(float), "highlights");
   }
 
   dt_free_align(interpolated);


### PR DESCRIPTION
As said, while processing the pipe also the cl_mem buffers of opencl devices for input & output of the specified modules are dumped.

Requisite for work on color-correct scaling

EDIT: some sort of redesign and refactoring, also supports rawprepare (has 16bit int data as input, this is writing ppm files instead.
