### PR TITLE
fix bauhaus non-toggle button toggled by shortcut

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1110,11 +1110,10 @@ void dt_bauhaus_widget_press_quad(GtkWidget *widget)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   if(w->quad_toggle)
-  {
     w->quad_paint_flags ^= CPF_ACTIVE;
-  }
   else
     w->quad_paint_flags |= CPF_ACTIVE;
+  gtk_widget_queue_draw(GTK_WIDGET(w));
 
   g_signal_emit_by_name(G_OBJECT(w), "quad-pressed");
 }
@@ -3328,9 +3327,14 @@ static void _action_process_button(GtkWidget *widget, dt_action_effect_t effect)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   if(effect != (w->quad_paint_flags & CPF_ACTIVE ? DT_ACTION_EFFECT_ON : DT_ACTION_EFFECT_OFF))
+  {
     dt_bauhaus_widget_press_quad(widget);
+    dt_bauhaus_widget_release_quad(widget);
+  }
 
-  gchar *text = w->quad_paint_flags & CPF_ACTIVE ? _("button on") : _("button off");
+  gchar *text = w->quad_toggle
+              ? w->quad_paint_flags & CPF_ACTIVE ? _("button on") : _("button off")
+              : _("button pressed")  ;
   dt_action_widget_toast(w->module, widget, text);
 
   gtk_widget_queue_draw(widget);

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -189,6 +189,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_container_add(GTK_CONTAINER(self->widget), thumbnail);
   gtk_overlay_add_overlay(GTK_OVERLAY(self->widget), d->zoom);
   dt_gui_add_class(self->widget, "dt_plugin_ui_main");
+  gtk_widget_show_all(self->widget);
 
   darktable.lib->proxy.navigation.module = self;
 }


### PR DESCRIPTION
Fixes https://github.com/darktable-org/darktable/issues/13745#issuecomment-1445213516

A non-toggle bauhaus button when pressed should stay untoggled (but briefly light up _while_ being pressed).
This PR fixes that for shortcuts (which incorrectly would toggle them on) and also makes the temporary switching on of the button during the button press slightly more responsive under load.

Also (completely unrelated but non-risky) fixes navigator unhiding (similar issue to #13303d, predictably introduced with #13507).