### PR TITLE
[CI] Win64: Link with the packaged libraw

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,7 @@ jobs:
         generator:
           #- MSYS Makefiles
           - Ninja
+        eco: [-DDONT_USE_INTERNAL_LIBRAW=ON]
     defaults:
       run:
         shell: msys2 {0}
@@ -228,6 +229,7 @@ jobs:
             libheif:p
             libjpeg-turbo:p
             libjxl:p
+            libraw:p
             libsecret:p
             libtiff:p
             libwebp:p


### PR DESCRIPTION
This PR kills two birds with one stone:
1. We check whether linking with the system libraw works as advertised. MSYS2, being essentially a rolling release environment, provides us with the fresh version of libraw we need for this.
2. We do this on the platform where the build takes the longest and therefore most likely to speed up CI completion by the time it would have taken to compile the in-tree libraw.