### PR TITLE
Fix build with LLVM 15

### DIFF
--- a/src/imageio/imageio_rawspeed.cc
+++ b/src/imageio/imageio_rawspeed.cc
@@ -127,7 +127,7 @@ static gboolean _ignore_image(const gchar *filename)
   ext++;
 
   if(dt_conf_key_not_empty("libraw_extensions"))
-    extensions_whitelist = g_strjoin(" ", always_by_libraw, dt_conf_get_string_const("libraw_extensions"), NULL);
+    extensions_whitelist = g_strjoin(" ", always_by_libraw, dt_conf_get_string_const("libraw_extensions"), (char *)NULL);
   else
     extensions_whitelist = g_strdup(always_by_libraw);
 


### PR DESCRIPTION
LLVM 15 fails to compile the code with `missing sentinel in function call` error.

Well, LLVM15 is correct here, imageio_rawspeed.cc is C++ source code, and in C++ (unlike C) NULL is defined as "just" 0, i.e. an integer, not a pointer (and sentinel should be a pointer).
