### PR TITLE
colorchecker/CLUT: allow adding color patch on 7x7 grid

### DIFF
--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -1232,7 +1232,7 @@ static gboolean checker_button_press(
     }
     if(new_color_valid)
     {
-      if(p->num_patches < 24 && (patch < 0 || patch >= p->num_patches))
+      if(p->num_patches < MAX_PATCHES && (patch < 0 || patch >= p->num_patches))
       {
         p->num_patches = MIN(MAX_PATCHES, p->num_patches + 1);
         patch = p->num_patches - 1;


### PR DESCRIPTION
Fixes #13765 (mostly).
It still isn't possible to add a patch when there are exactly 24 patches even if we got there by removing patches from a 7x7 grid because 24 or fewer are displayed on a 4x6 grid and there simply isn't an empty space in which to click for adding a patch.
