### PR TITLE
po/fix workflow none

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1555,11 +1555,13 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
             // it is important to recover temperature in this case
             // (modern chroma and not module present as we need to
             // have the pre 3.0 default parameters used.
+            const gchar *current_workflow =
+              dt_conf_get_string_const("plugins/darkroom/workflow");
 
             dt_conf_set_string("plugins/darkroom/workflow", "display-referred (legacy)");
             dt_iop_reload_defaults(module);
             _dev_insert_module(dev, module, imgid);
-            dt_conf_set_string("plugins/darkroom/workflow", "scene-referred (filmic)");
+            dt_conf_set_string("plugins/darkroom/workflow", current_workflow);
             dt_iop_reload_defaults(module);
           }
         }

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2234,7 +2234,8 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
     }
 
     // make sure that always-on modules are always on. duh.
-    if(hist->module->default_enabled == 1 && hist->module->hide_enable_button == 1)
+    if(hist->module->default_enabled == 1
+       && hist->module->hide_enable_button == 1)
       hist->enabled = 1;
 
     dev->history = g_list_append(dev->history, hist);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2025,6 +2025,13 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
 
   dev->history_end = 0;
 
+  // Specific handling for None workflow (interdependency)
+
+  const gboolean is_workflow_none = dt_conf_is_equal("plugins/darkroom/workflow", "none");
+
+  dt_iop_module_t *channelmixerrgb = NULL;
+  dt_iop_module_t *temperature = NULL;
+
   // Strip rows from DB lookup. One row == One module in history
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
@@ -2118,6 +2125,12 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
                module_name, imgid, dev->image_storage.filename);
       free(hist);
       continue;
+    }
+
+    if(is_workflow_none && hist->module->enabled)
+    {
+      if(!strcmp(hist->module->op, "temperature"))     temperature = hist->module;
+      if(!strcmp(hist->module->op, "channelmixerrgb")) channelmixerrgb = hist->module;
     }
 
     // module has no user params and won't bother us in GUI - exit early, we are done
@@ -2242,6 +2255,16 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
     dev->history_end++;
   }
   sqlite3_finalize(stmt);
+
+  // Both modules are actives and found on the history stack, let's
+  // again reload the defaults to ensure the whiteblance is properly
+  // set depending on the CAT handling.
+  if(temperature && channelmixerrgb)
+  {
+    dt_print(DT_DEBUG_PARAMS,
+             "[dt_dev_read_history_ext] reset defaults for workflow none\n");
+    temperature->reload_defaults(temperature);
+  }
 
   dt_ioppr_resync_modules_order(dev);
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2963,7 +2963,7 @@ static void _enable_module_callback(dt_iop_module_t *module)
   //cannot toggle module if there's no enable button
   if(module->hide_enable_button) return;
 
-  gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(module->off));
+  const gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(module->off));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), !active);
 }
 

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -3793,7 +3793,8 @@ void reload_defaults(dt_iop_module_t *module)
   d->illuminant = module->get_f("illuminant")->Enum.Default;
   d->adaptation = module->get_f("adaptation")->Enum.Default;
 
-  const gboolean is_modern = dt_is_scene_referred();
+  const gboolean is_workflow_none = dt_conf_is_equal("plugins/darkroom/workflow", "none");
+  const gboolean is_modern = dt_is_scene_referred() || is_workflow_none;
 
   // note that if there is already an instance of this module with an
   // adaptation set we default to RGB (none) in this instance.

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1215,16 +1215,13 @@ void gui_update(struct dt_iop_module_t *self)
     dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_AS_SHOT);
     found = TRUE;
   }
-  else
+  // is this a "D65 white balance"?
+  else if(feqf(p->red, (float)g->daylight_wb[0], DT_COEFF_EPS)
+          && feqf(p->green, (float)g->daylight_wb[1], DT_COEFF_EPS)
+          && feqf(p->blue, (float)g->daylight_wb[2], DT_COEFF_EPS))
   {
-    // is this a "D65 white balance"?
-    if(feqf(p->red, (float)g->daylight_wb[0], DT_COEFF_EPS)
-      && feqf(p->green, (float)g->daylight_wb[1], DT_COEFF_EPS)
-      && feqf(p->blue, (float)g->daylight_wb[2], DT_COEFF_EPS))
-    {
-      dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_D65);
-      found = TRUE;
-    }
+    dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_D65);
+    found = TRUE;
   }
 
   if(!found)

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1512,7 +1512,23 @@ void reload_defaults(dt_iop_module_t *module)
     dt_image_is_matrix_correction_supported(&module->dev->image_storage);
   const gboolean true_monochrome =
     dt_image_monochrome_flags(&module->dev->image_storage) & DT_IMAGE_MONOCHROME;
-  const gboolean is_modern = dt_is_scene_referred();
+
+  gboolean another_cat_defined = FALSE;
+  const gboolean is_workflow_none = dt_conf_is_equal("plugins/darkroom/workflow", "none");
+
+  // check if with workflow set to None we still have another CAT
+  // defined. That is an auto-applied preset for the Color Calibration
+  // module.
+  if(is_workflow_none)
+  {
+    another_cat_defined =
+      dt_history_check_module_exists(module->dev->image_storage.id,
+                                     "channelmixerrgb", TRUE);
+  }
+
+  const gboolean is_modern =
+    dt_is_scene_referred()
+    || (is_workflow_none && another_cat_defined);
 
   module->default_enabled = 0;
   module->hide_enable_button = true_monochrome;


### PR DESCRIPTION
temperature: Check for scene-referred mode when using None workflow.
    
When using a workflow None one can still auto-enable modules
white balance & color calibration using presets. In this situation
the white balance module defaults must be scene-referred.
    
Fixes #13746.
