### PR TITLE
imageop: Properly ellipsise the module instance name.

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2724,6 +2724,8 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   module->instance_name = gtk_label_new("");
   hw[IOP_MODULE_INSTANCE_NAME] = module->instance_name;
   gtk_widget_set_name(module->instance_name, "iop-module-name");
+  gtk_label_set_ellipsize(GTK_LABEL(module->instance_name), PANGO_ELLIPSIZE_MIDDLE);
+  g_object_set(G_OBJECT(module->instance_name), "xalign", 0.0, (gchar *)0);
 
   if((module->flags() & IOP_FLAGS_DEPRECATED) && module->deprecated_msg())
     gtk_widget_set_tooltip_text(lab, module->deprecated_msg());


### PR DESCRIPTION
Fixes #13762.