### PR TITLE
po/fix masks manager

### DIFF
--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -818,7 +818,7 @@ const dt_colorspaces_color_profile_t *dt_colorspaces_get_work_profile(const int 
     for(const GList *modules = darktable.iop; modules; modules = g_list_next(modules))
     {
       const dt_iop_module_so_t *module = (const dt_iop_module_so_t *)(modules->data);
-      if(!strcmp(module->op, "colorin"))
+      if(dt_iop_module_is(module, "colorin"))
       {
         colorin = module;
         break;
@@ -870,7 +870,7 @@ const dt_colorspaces_color_profile_t *dt_colorspaces_get_output_profile(const in
     for(const GList *modules = darktable.iop; modules; modules = g_list_next(modules))
     {
       const dt_iop_module_so_t *module = (const dt_iop_module_so_t *)(modules->data);
-      if(!strcmp(module->op, "colorout"))
+      if(dt_iop_module_is(module, "colorout"))
       {
         colorout = module;
         break;
@@ -2445,4 +2445,3 @@ void dt_colorspaces_rgb_to_cygm(float *out, int num, double RGB_to_CAM[4][3])
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -230,7 +230,7 @@ static dt_dev_history_item_t *_search_history_by_op(dt_develop_t *dev,
   {
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
 
-    if(strcmp(hist->module->op, module->op) == 0)
+    if(dt_iop_module_is(hist->module->so, module->op))
     {
       hist_mod = hist;
       break;

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -916,7 +916,7 @@ dt_image_orientation_t dt_image_get_orientation(const int32_t imgid)
     for(const GList *modules = darktable.iop; modules; modules = g_list_next(modules))
     {
       dt_iop_module_so_t *module = (dt_iop_module_so_t *)(modules->data);
-      if(!strcmp(module->op, "flip"))
+      if(dt_iop_module_is(module, "flip"))
       {
         flip = module;
         break;

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -1156,7 +1156,7 @@ static void _count_iop_module(GList *iop,
   for(const GList *modules = iop; modules; modules = g_list_next(modules))
   {
     const dt_iop_module_t *const restrict mod = (dt_iop_module_t *)modules->data;
-    if(!strcmp(mod->op, operation))
+    if(dt_iop_module_is(mod->so, operation))
     {
       (*count)++;
       if(*max_multi_priority < mod->multi_priority)
@@ -1207,7 +1207,7 @@ int _get_multi_priority(dt_develop_t *dev,
   for(const GList *l = dev->iop; l; l = g_list_next(l))
   {
     const dt_iop_module_t *const restrict mod = (dt_iop_module_t *)l->data;
-    if((!only_disabled || mod->enabled == FALSE) && !strcmp(mod->op, operation))
+    if((!only_disabled || mod->enabled == FALSE) && dt_iop_module_is(mod->so, operation))
     {
       count++;
       if(count == n) return mod->multi_priority;
@@ -1630,7 +1630,8 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list,
         {
           const dt_iop_order_rule_t *const restrict rule = (dt_iop_order_rule_t *)rules->data;
 
-          if(strcmp(module->op, rule->op_prev) == 0 && strcmp(mod->op, rule->op_next) == 0)
+          if(dt_iop_module_is(module->so, rule->op_prev)
+             && dt_iop_module_is(mod->so, rule->op_next))
           {
             rule_found = 1;
             break;
@@ -1707,7 +1708,8 @@ gboolean dt_ioppr_check_can_move_before_iop(GList *iop_list,
         {
           const dt_iop_order_rule_t *const restrict rule = (dt_iop_order_rule_t *)rules->data;
 
-          if(strcmp(mod->op, rule->op_prev) == 0 && strcmp(module->op, rule->op_next) == 0)
+          if(dt_iop_module_is(mod->so, rule->op_prev)
+             && dt_iop_module_is(module->so, rule->op_next))
           {
             rule_found = 1;
             break;
@@ -1955,7 +1957,7 @@ static void _ioppr_check_rules(GList *iop_list, const int imgid, const char *msg
       const dt_iop_order_rule_t *const restrict rule = (dt_iop_order_rule_t *)rules->data;
 
       // mod must be before rule->op_next
-      if(strcmp(mod->op, rule->op_prev) == 0)
+      if(dt_iop_module_is(mod->so, rule->op_prev))
       {
         // check if there's a rule->op_next module before mod
         for(const GList *modules_prev = g_list_previous(modules);
@@ -1973,7 +1975,7 @@ static void _ioppr_check_rules(GList *iop_list, const int imgid, const char *msg
         }
       }
       // mod must be after rule->op_prev
-      else if(strcmp(mod->op, rule->op_next) == 0)
+      else if(dt_iop_module_is(mod->so, rule->op_next))
       {
         // check if there's a rule->op_prev module after mod
         for(const GList *modules_next = g_list_next(modules); modules_next;  modules_next = g_list_next(modules_next))
@@ -2041,10 +2043,12 @@ int dt_ioppr_check_iop_order(dt_develop_t *dev,
     {
       const dt_iop_module_t *const restrict mod = (dt_iop_module_t *)modules->data;
 
-      if(strcmp(mod->op, "gamma") != 0)
+      if(!dt_iop_module_is(mod->so, "gamma"))
       {
         iop_order_ok = 0;
-        fprintf(stderr, "[dt_ioppr_check_iop_order] gamma is not the last iop, last is %s %s(%d) image %i (%s)\n",
+        fprintf(stderr,
+                "[dt_ioppr_check_iop_order] gamma is not the last iop,"
+                " last is %s %s(%d) image %i (%s)\n",
                 mod->op, mod->multi_name, mod->iop_order,imgid, msg);
       }
     }

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -814,17 +814,17 @@ dt_iop_order_iccprofile_info_t *dt_ioppr_get_iop_work_profile_info(struct dt_iop
     dt_iop_module_t *mod = (dt_iop_module_t *)(modules->data);
 
     // we reach the module, that's it
-    if(strcmp(mod->op, module->op) == 0) break;
+    if(dt_iop_module_is(mod->so, module->op)) break;
 
     // if we reach colorout means that the module is after it
-    if(strcmp(mod->op, "colorout") == 0)
+    if(dt_iop_module_is(mod->so, "colorout"))
     {
       in_between = FALSE;
       break;
     }
 
     // we reach colorin, so far we're good
-    if(strcmp(mod->op, "colorin") == 0)
+    if(dt_iop_module_is(mod->so, "colorin"))
     {
       in_between = TRUE;
       break;
@@ -980,7 +980,7 @@ void dt_ioppr_get_work_profile_type(struct dt_develop_t *dev,
   for(const GList *modules = darktable.iop; modules; modules = g_list_next(modules))
   {
     dt_iop_module_so_t *module_so = (dt_iop_module_so_t *)(modules->data);
-    if(!strcmp(module_so->op, "colorin"))
+    if(dt_iop_module_is(module_so, "colorin"))
     {
       colorin_so = module_so;
       break;
@@ -991,7 +991,7 @@ void dt_ioppr_get_work_profile_type(struct dt_develop_t *dev,
     for(const GList *modules = dev->iop; modules; modules = g_list_next(modules))
     {
       dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
-      if(!strcmp(module->op, "colorin"))
+      if(dt_iop_module_is(module->so, "colorin"))
       {
         colorin = module;
         break;
@@ -1027,7 +1027,7 @@ void dt_ioppr_get_export_profile_type(struct dt_develop_t *dev,
   for(const GList *modules = g_list_last(darktable.iop); modules; modules = g_list_previous(modules))
   {
     dt_iop_module_so_t *module_so = (dt_iop_module_so_t *)(modules->data);
-    if(!strcmp(module_so->op, "colorout"))
+    if(dt_iop_module_is(module_so, "colorout"))
     {
       colorout_so = module_so;
       break;
@@ -1038,7 +1038,7 @@ void dt_ioppr_get_export_profile_type(struct dt_develop_t *dev,
     for(const GList *modules = g_list_last(dev->iop); modules; modules = g_list_previous(modules))
     {
       dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
-      if(!strcmp(module->op, "colorout"))
+      if(dt_iop_module_is(module->so, "colorout"))
       {
         colorout = module;
         break;

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -837,7 +837,7 @@ void dt_styles_apply_style_item(dt_develop_t *dev,
         }
         else
         {
-          if(!strcmp(module->op, "spots") && style_item->module_version == 1)
+          if(dt_iop_module_is(module->so, "spots") && style_item->module_version == 1)
           {
             // FIXME: not sure how to handle this here...
             // quick and dirty hack to handle spot removal legacy_params
@@ -853,7 +853,7 @@ void dt_styles_apply_style_item(dt_develop_t *dev,
          * by default, so if it is disabled, enable it, and replace params with
          * default_params. if user want to, he can disable it.
          */
-        if(!strcmp(module->op, "flip")
+        if(dt_iop_module_is(module->so, "flip")
            && module->enabled == 0
            && labs(style_item->module_version) == 1)
         {

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1128,7 +1128,7 @@ void dt_dev_add_masks_history_item_ext(
     for(GList *modules = dev->iop; modules; modules = g_list_next(modules))
     {
       dt_iop_module_t *mod = (dt_iop_module_t *)(modules->data);
-      if(strcmp(mod->op, "mask_manager") == 0)
+      if(dt_iop_module_is(mod->so, "mask_manager"))
       {
         module = mod;
         break;
@@ -1549,7 +1549,7 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
           // For new edits the temperature will be added back
           // depending on the chromatic adaptation the standard way.
 
-          if(!strcmp(module->op, "temperature")
+          if(dt_iop_module_is(module->so, "temperature")
              && (image->change_timestamp == -1))
           {
             // it is important to recover temperature in this case
@@ -1602,11 +1602,11 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
     {
       dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
 
-      if(((auto_apply_exposure && strcmp(module->op, "exposure") == 0)
-          || (auto_apply_filmic && strcmp(module->op, "filmicrgb") == 0)
-          || (auto_apply_sigmoid && strcmp(module->op, "sigmoid") == 0)
-          || (auto_apply_basecurve && strcmp(module->op, "basecurve") == 0)
-          || (auto_apply_cat && strcmp(module->op, "channelmixerrgb") == 0))
+      if(((auto_apply_exposure && dt_iop_module_is(module->so, "exposure"))
+          || (auto_apply_filmic && dt_iop_module_is(module->so, "filmicrgb"))
+          || (auto_apply_sigmoid && dt_iop_module_is(module->so, "sigmoid"))
+          || (auto_apply_basecurve && dt_iop_module_is(module->so, "basecurve"))
+          || (auto_apply_cat && dt_iop_module_is(module->so, "channelmixerrgb")))
          && !dt_history_check_module_exists(imgid, module->op, FALSE)
          && !(module->flags() & IOP_FLAGS_NO_HISTORY_STACK))
       {
@@ -2078,7 +2078,7 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
     for(GList *modules = dev->iop; modules; modules = g_list_next(modules))
     {
       dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
-      if(!strcmp(module->op, module_name))
+      if(dt_iop_module_is(module->so, module_name))
       {
         if(module->multi_priority == multi_priority)
         {
@@ -2129,8 +2129,10 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
 
     if(is_workflow_none && hist->module->enabled)
     {
-      if(!strcmp(hist->module->op, "temperature"))     temperature = hist->module;
-      if(!strcmp(hist->module->op, "channelmixerrgb")) channelmixerrgb = hist->module;
+      if(dt_iop_module_is(hist->module->so, "temperature"))
+        temperature = hist->module;
+      if(dt_iop_module_is(hist->module->so, "channelmixerrgb"))
+        channelmixerrgb = hist->module;
     }
 
     // module has no user params and won't bother us in GUI - exit early, we are done
@@ -2224,7 +2226,8 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
       }
       else
       {
-        if(!strcmp(hist->module->op, "spots") && modversion == 1)
+        if(dt_iop_module_is(hist->module->so, "spots")
+           && modversion == 1)
         {
           // quick and dirty hack to handle spot removal legacy_params
           memcpy(hist->blend_params, hist->module->blend_params,
@@ -2239,7 +2242,9 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
        * by default, so if it is disabled, enable it, and replace params with
        * default_params. if user want to, he can disable it.
        */
-      if(!strcmp(hist->module->op, "flip") && hist->enabled == 0 && labs(modversion) == 1)
+      if(dt_iop_module_is(hist->module->so, "flip")
+         && hist->enabled == 0
+         && labs(modversion) == 1)
       {
         memcpy(hist->params, hist->module->default_params, hist->module->params_size);
         hist->enabled = 1;

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1716,7 +1716,7 @@ void dt_iop_commit_blend_params(dt_iop_module_t *module,
     for(GList *iter = module->dev->iop; iter; iter = g_list_next(iter))
     {
       dt_iop_module_t *m = (dt_iop_module_t *)iter->data;
-      if(!strcmp(m->op, blendop_params->raster_mask_source))
+      if(dt_iop_module_is(m->so, blendop_params->raster_mask_source))
       {
         if(m->multi_priority == blendop_params->raster_mask_instance)
         {
@@ -2899,7 +2899,7 @@ dt_iop_module_t *dt_iop_get_module_from_list(GList *iop_list, const char *op)
   for(GList *modules = iop_list; modules; modules = g_list_next(modules))
   {
     dt_iop_module_t *mod = (dt_iop_module_t *)modules->data;
-    if(strcmp(mod->op, op) == 0)
+    if(dt_iop_module_is(mod->so, op))
     {
       result = mod;
       break;
@@ -2920,7 +2920,8 @@ int dt_iop_get_module_flags(const char *op)
   while(modules)
   {
     dt_iop_module_so_t *module = (dt_iop_module_so_t *)modules->data;
-    if(!strcmp(module->op, op)) return module->flags();
+    if(dt_iop_module_is(module, op))
+      return module->flags();
     modules = g_list_next(modules);
   }
   return 0;
@@ -3154,7 +3155,7 @@ dt_iop_module_t *dt_iop_get_module_by_op_priority(GList *modules,
   {
     dt_iop_module_t *mod = (dt_iop_module_t *)m->data;
 
-    if(strcmp(mod->op, operation) == 0
+    if(dt_iop_module_is(mod->so, operation)
        && (mod->multi_priority == multi_priority || multi_priority == -1))
     {
       mod_ret = mod;
@@ -3271,7 +3272,7 @@ dt_iop_module_t *dt_iop_get_module_by_instance_name(GList *modules,
   {
     dt_iop_module_t *mod = (dt_iop_module_t *)m->data;
 
-    if((strcmp(mod->op, operation) == 0)
+    if((dt_iop_module_is(mod->so, operation))
        && ((multi_name == NULL) || (strcmp(mod->multi_name, multi_name) == 0)))
     {
       mod_ret = mod;
@@ -3306,7 +3307,7 @@ gboolean dt_iop_is_first_instance(GList *modules, dt_iop_module_t *module)
   while(iop)
   {
     dt_iop_module_t *m = (dt_iop_module_t *)iop->data;
-    if(!strcmp(m->op, module->op))
+    if(dt_iop_module_is(m->so, module->op))
     {
       is_first = (m == module);
       break;

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -461,6 +461,13 @@ dt_iop_module_t *dt_iop_get_module_by_op_priority(GList *modules,
 dt_iop_module_t *dt_iop_get_module_by_instance_name(GList *modules,
                                                     const char *operation,
                                                     const char *multi_name);
+/** check for module name */
+static inline gboolean dt_iop_module_is(const dt_iop_module_so_t *module,
+                                        const char*operation)
+{
+  return !g_strcmp0(module->op, operation);
+}
+
 /** count instances of a module **/
 int dt_iop_count_instances(dt_iop_module_so_t *module);
 /** return preferred module instance for shortcuts **/

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2013-2021 darktable developers.
+    Copyright (C) 2013-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -181,38 +181,123 @@ typedef struct dt_masks_functions_t
   void (*sanitize_config)(dt_masks_type_t type_flags);
   GSList *(*setup_mouse_actions)(const struct dt_masks_form_t *const form);
   void (*set_form_name)(struct dt_masks_form_t *const form, const size_t nb);
-  void (*set_hint_message)(const struct dt_masks_form_gui_t *const gui, const struct dt_masks_form_t *const form,
-                           const int opacity, char *const __restrict__ msgbuf, const size_t msgbuf_len);
-  void (*modify_property)(struct dt_masks_form_t *const form, dt_masks_property_t prop, float old_val, float new_val, float *sum, int *count, float *min, float *max);
-  void (*duplicate_points)(struct dt_develop_t *const dev, struct dt_masks_form_t *base, struct dt_masks_form_t *dest);
-  void (*initial_source_pos)(const float iwd, const float iht, float *x, float *y);
-  void (*get_distance)(float x, float y, float as, struct dt_masks_form_gui_t *gui, int index, int num_points,
-                       int *inside, int *inside_border, int *near, int *inside_source, float *dist);
-  int (*get_points)(dt_develop_t *dev, float x, float y, float radius_a, float radius_b, float rotation,
-                    float **points, int *points_count);
-  int (*get_points_border)(dt_develop_t *dev, struct dt_masks_form_t *form, float **points, int *points_count,
-                           float **border, int *border_count, int source, const dt_iop_module_t *const module);
-  int (*get_mask)(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
+  void (*set_hint_message)(const struct dt_masks_form_gui_t *const gui,
+                           const struct dt_masks_form_t *const form,
+                           const int opacity,
+                           char *const __restrict__ msgbuf,
+                           const size_t msgbuf_len);
+  void (*modify_property)(struct dt_masks_form_t *const form,
+                          dt_masks_property_t prop,
+                          const float old_val,
+                          const float new_val,
+                          float *sum,
+                          int *count,
+                          float *min,
+                          float *max);
+  void (*duplicate_points)(struct dt_develop_t *const dev,
+                           struct dt_masks_form_t *base,
+                           struct dt_masks_form_t *dest);
+  void (*initial_source_pos)(const float iwd,
+                             const float iht,
+                             float *x,
+                             float *y);
+  void (*get_distance)(const float x,
+                       const float y,
+                       const float as,
+                       struct dt_masks_form_gui_t *gui,
+                       const int index,
+                       const int num_points,
+                       int *inside,
+                       int *inside_border,
+                       int *near,
+                       int *inside_source,
+                       float *dist);
+  int (*get_points)(dt_develop_t *dev,
+                    const float x,
+                    const float y,
+                    const float radius_a,
+                    const float radius_b,
+                    const float rotation,
+                    float **points,
+                    int *points_count);
+  int (*get_points_border)(dt_develop_t *dev,
+                           struct dt_masks_form_t *form,
+                           float **points,
+                           int *points_count,
+                           float **border,
+                           int *border_count,
+                           const int source,
+                           const dt_iop_module_t *const module);
+  int (*get_mask)(const dt_iop_module_t *const module,
+                  const dt_dev_pixelpipe_iop_t *const piece,
                   struct dt_masks_form_t *const form,
-                  float **buffer, int *width, int *height, int *posx, int *posy);
-  int (*get_mask_roi)(const dt_iop_module_t *const fmodule, const dt_dev_pixelpipe_iop_t *const piece,
+                  float **buffer,
+                  int *width,
+                  int *height,
+                  int *posx,
+                  int *posy);
+  int (*get_mask_roi)(const dt_iop_module_t *const fmodule,
+                      const dt_dev_pixelpipe_iop_t *const piece,
                       struct dt_masks_form_t *const form,
-                      const dt_iop_roi_t *roi, float *buffer);
-  int (*get_area)(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
+                      const dt_iop_roi_t *roi,
+                      float *buffer);
+  int (*get_area)(const dt_iop_module_t *const module,
+                  const dt_dev_pixelpipe_iop_t *const piece,
                   struct dt_masks_form_t *const form,
-                  int *width, int *height, int *posx, int *posy);
-  int (*get_source_area)(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, struct dt_masks_form_t *form,
-                         int *width, int *height, int *posx, int *posy);
-  int (*mouse_moved)(struct dt_iop_module_t *module, float pzx, float pzy, double pressure, int which,
-                     struct dt_masks_form_t *form, int parentid, struct dt_masks_form_gui_t *gui, int index);
-  int (*mouse_scrolled)(struct dt_iop_module_t *module, float pzx, float pzy, int up, uint32_t state,
-                        struct dt_masks_form_t *form, int parentid, struct dt_masks_form_gui_t *gui, int index);
-  int (*button_pressed)(struct dt_iop_module_t *module, float pzx, float pzy,
-                        double pressure, int which, int type, uint32_t state,
-                        struct dt_masks_form_t *form, int parentid, struct dt_masks_form_gui_t *gui, int index);
-  int (*button_released)(struct dt_iop_module_t *module, float pzx, float pzy, int which, uint32_t state,
-                         struct dt_masks_form_t *form, int parentid, struct dt_masks_form_gui_t *gui, int index);
-  void (*post_expose)(cairo_t *cr, float zoom_scale, struct dt_masks_form_gui_t *gui, int index, int num_points);
+                  int *width,
+                  int *height,
+                  int *posx,
+                  int *posy);
+  int (*get_source_area)(dt_iop_module_t *module,
+                         dt_dev_pixelpipe_iop_t *piece,
+                         struct dt_masks_form_t *form,
+                         int *width,
+                         int *height,
+                         int *posx,
+                         int *posy);
+  int (*mouse_moved)(struct dt_iop_module_t *module,
+                     float pzx,
+                     float pzy,
+                     const double pressure,
+                     const int which,
+                     struct dt_masks_form_t *form,
+                     const int parentid,
+                     struct dt_masks_form_gui_t *gui,
+                     const int index);
+  int (*mouse_scrolled)(struct dt_iop_module_t *module,
+                        float pzx,
+                        float pzy,
+                        const int up,
+                        uint32_t state,
+                        struct dt_masks_form_t *form,
+                        const int parentid,
+                        struct dt_masks_form_gui_t *gui,
+                        const int index);
+  int (*button_pressed)(struct dt_iop_module_t *module,
+                        float pzx,
+                        float pzy,
+                        const double pressure,
+                        const int which,
+                        const int type,
+                        const uint32_t state,
+                        struct dt_masks_form_t *form,
+                        const int parentid,
+                        struct dt_masks_form_gui_t *gui,
+                        const int index);
+  int (*button_released)(struct dt_iop_module_t *module,
+                         float pzx,
+                         float pzy,
+                         const int which,
+                         const uint32_t state,
+                         struct dt_masks_form_t *form,
+                         const int parentid,
+                         struct dt_masks_form_gui_t *gui,
+                         const int index);
+  void (*post_expose)(cairo_t *cr,
+                      const float zoom_scale,
+                      struct dt_masks_form_gui_t *gui,
+                      const int index,
+                      const int num_points);
 } dt_masks_functions_t;
 
 /** structure used to define a form */
@@ -320,37 +405,75 @@ void dt_masks_init_form_gui(dt_masks_form_gui_t *gui);
 
 /** get points in real space with respect of distortion dx and dy are used to eventually move the center of
  * the circle */
-int dt_masks_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, float **points, int *points_count,
-                               float **border, int *border_count, int source, dt_iop_module_t *module);
+int dt_masks_get_points_border(dt_develop_t *dev,
+                               dt_masks_form_t *form,
+                               float **points,
+                               int *points_count,
+                               float **border,
+                               int *border_count,
+                               const int source,
+                               dt_iop_module_t *module);
 
 /** get the rectangle which include the form and his border */
-int dt_masks_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *form,
-                      int *width, int *height, int *posx, int *posy);
-int dt_masks_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *form,
-                             int *width, int *height, int *posx, int *posy);
+int dt_masks_get_area(dt_iop_module_t *module,
+                      dt_dev_pixelpipe_iop_t *piece,
+                      dt_masks_form_t *form,
+                      int *width,
+                      int *height,
+                      int *posx,
+                      int *posy);
+int dt_masks_get_source_area(dt_iop_module_t *module,
+                             dt_dev_pixelpipe_iop_t *piece,
+                             dt_masks_form_t *form,
+                             int *width,
+                             int *height,
+                             int *posx,
+                             int *posy);
 /** get the transparency mask of the form and his border */
-static inline int dt_masks_get_mask(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
-                      dt_masks_form_t *const form,
-                      float **buffer, int *width, int *height, int *posx, int *posy)
+static inline int dt_masks_get_mask(const dt_iop_module_t *const module,
+                                    const dt_dev_pixelpipe_iop_t *const piece,
+                                    dt_masks_form_t *const form,
+                                    float **buffer,
+                                    int *width,
+                                    int *height,
+                                    int *posx,
+                                    int *posy)
 {
-  return form->functions ? form->functions->get_mask(module, piece, form, buffer, width, height, posx, posy) : 0;
+  return form->functions
+    ? form->functions->get_mask(module, piece, form, buffer, width, height, posx, posy)
+    : 0;
 }
-static inline int dt_masks_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
-                          dt_masks_form_t *const form, const dt_iop_roi_t *roi, float *buffer)
+static inline int dt_masks_get_mask_roi(const dt_iop_module_t *const module,
+                                        const dt_dev_pixelpipe_iop_t *const piece,
+                                        dt_masks_form_t *const form,
+                                        const dt_iop_roi_t *roi,
+                                        float *buffer)
 {
-  return form->functions ? form->functions->get_mask_roi(module, piece, form, roi, buffer) : 0;
+  return form->functions
+    ? form->functions->get_mask_roi(module, piece, form, roi, buffer)
+    : 0;
 }
 
-int dt_masks_group_render(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *form,
-                          float **buffer, int *roi, float scale);
-int dt_masks_group_render_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *form,
-                              const dt_iop_roi_t *roi, float *buffer);
+int dt_masks_group_render(dt_iop_module_t *module,
+                          dt_dev_pixelpipe_iop_t *piece,
+                          dt_masks_form_t *form,
+                          float **buffer,
+                          int *roi,
+                          const float scale);
+int dt_masks_group_render_roi(dt_iop_module_t *module,
+                              dt_dev_pixelpipe_iop_t *piece,
+                              dt_masks_form_t *form,
+                              const dt_iop_roi_t *roi,
+                              float *buffer);
 
 // returns current masks version
 int dt_masks_version(void);
 
 // update masks from older versions
-int dt_masks_legacy_params(dt_develop_t *dev, void *params, const int old_version, const int new_version);
+int dt_masks_legacy_params(dt_develop_t *dev,
+                           void *params,
+                           const int old_version,
+                           const int new_version);
 /*
  * TODO:
  *
@@ -375,7 +498,9 @@ dt_masks_form_t *dt_masks_get_from_id(dt_develop_t *dev, int id);
 /** read the forms from the db */
 void dt_masks_read_masks_history(dt_develop_t *dev, const int imgid);
 /** write the forms into the db */
-void dt_masks_write_masks_history_item(const int imgid, const int num, dt_masks_form_t *form);
+void dt_masks_write_masks_history_item(const int imgid,
+                                       const int num,
+                                       dt_masks_form_t *form);
 void dt_masks_free_form(dt_masks_form_t *form);
 void dt_masks_update_image(dt_develop_t *dev);
 void dt_masks_cleanup_unused(dt_develop_t *dev);
@@ -386,101 +511,198 @@ void dt_masks_clear_form_gui(dt_develop_t *dev);
 void dt_masks_reset_form_gui(void);
 void dt_masks_reset_show_masks_icons(void);
 
-int dt_masks_events_mouse_moved(struct dt_iop_module_t *module, double x, double y, double pressure,
-                                int which);
-int dt_masks_events_button_released(struct dt_iop_module_t *module, double x, double y, int which,
-                                    uint32_t state);
-int dt_masks_events_button_pressed(struct dt_iop_module_t *module, double x, double y, double pressure,
-                                   int which, int type, uint32_t state);
-int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module, double x, double y, int up, uint32_t state);
-void dt_masks_events_post_expose(struct dt_iop_module_t *module, cairo_t *cr, int32_t width, int32_t height,
-                                 int32_t pointerx, int32_t pointery);
+int dt_masks_events_mouse_moved(struct dt_iop_module_t *module,
+                                const double x,
+                                const double y,
+                                const double pressure,
+                                const int which);
+int dt_masks_events_button_released(struct dt_iop_module_t *module,
+                                    const double x,
+                                    const double y,
+                                    const int which,
+                                    const uint32_t state);
+int dt_masks_events_button_pressed(struct dt_iop_module_t *module,
+                                   const double x,
+                                   const double y,
+                                   const double pressure,
+                                   const int which,
+                                   const int type,
+                                   const uint32_t state);
+int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module,
+                                   const double x,
+                                   const double y,
+                                   const int up,
+                                   const uint32_t state);
+void dt_masks_events_post_expose(struct dt_iop_module_t *module,
+                                 cairo_t *cr,
+                                 const int32_t width,
+                                 const int32_t height,
+                                 const int32_t pointerx,
+                                 const int32_t pointery);
 int dt_masks_events_mouse_leave(struct dt_iop_module_t *module);
 int dt_masks_events_mouse_enter(struct dt_iop_module_t *module);
 
 /** functions used to manipulate gui data */
-void dt_masks_gui_form_create(dt_masks_form_t *form, dt_masks_form_gui_t *gui, int index,
+void dt_masks_gui_form_create(dt_masks_form_t *form,
+                              dt_masks_form_gui_t *gui,
+                              const int index,
                               struct dt_iop_module_t *module);
-void dt_masks_gui_form_remove(dt_masks_form_t *form, dt_masks_form_gui_t *gui, int index);
-void dt_masks_gui_form_test_create(dt_masks_form_t *form, dt_masks_form_gui_t *gui, struct dt_iop_module_t *module);
-void dt_masks_gui_form_save_creation(dt_develop_t *dev, struct dt_iop_module_t *module, dt_masks_form_t *form,
+void dt_masks_gui_form_remove(dt_masks_form_t *form,
+                              dt_masks_form_gui_t *gui,
+                              const int index);
+void dt_masks_gui_form_test_create(dt_masks_form_t *form,
+                                   dt_masks_form_gui_t *gui,
+                                   struct dt_iop_module_t *module);
+void dt_masks_gui_form_save_creation(dt_develop_t *dev,
+                                     struct dt_iop_module_t *module,
+                                     dt_masks_form_t *form,
                                      dt_masks_form_gui_t *gui);
 void dt_masks_group_ungroup(dt_masks_form_t *dest_grp, dt_masks_form_t *grp);
 void dt_masks_group_update_name(dt_iop_module_t *module);
-dt_masks_point_group_t *dt_masks_group_add_form(dt_masks_form_t *grp, dt_masks_form_t *form);
+dt_masks_point_group_t *dt_masks_group_add_form(dt_masks_form_t *grp,
+                                                dt_masks_form_t *form);
 
-void dt_masks_iop_edit_toggle_callback(GtkToggleButton *togglebutton, struct dt_iop_module_t *module);
-void dt_masks_iop_value_changed_callback(GtkWidget *widget, struct dt_iop_module_t *module);
+void dt_masks_iop_edit_toggle_callback(GtkToggleButton *togglebutton,
+                                       struct dt_iop_module_t *module);
+void dt_masks_iop_value_changed_callback(GtkWidget *widget,
+                                         struct dt_iop_module_t *module);
 dt_masks_edit_mode_t dt_masks_get_edit_mode(struct dt_iop_module_t *module);
-void dt_masks_set_edit_mode(struct dt_iop_module_t *module, dt_masks_edit_mode_t value);
-void dt_masks_set_edit_mode_single_form(struct dt_iop_module_t *module, const int formid,
-                                        dt_masks_edit_mode_t value);
+void dt_masks_set_edit_mode(struct dt_iop_module_t *module,
+                            dt_masks_edit_mode_t value);
+void dt_masks_set_edit_mode_single_form(struct dt_iop_module_t *module,
+                                        const int formid,
+                                        const dt_masks_edit_mode_t value);
 void dt_masks_iop_update(struct dt_iop_module_t *module);
-void dt_masks_iop_combo_populate(GtkWidget *w, struct dt_iop_module_t **m);
-void dt_masks_iop_use_same_as(struct dt_iop_module_t *module, struct dt_iop_module_t *src);
+void dt_masks_iop_combo_populate(GtkWidget *w,
+                                 struct dt_iop_module_t **m);
+void dt_masks_iop_use_same_as(struct dt_iop_module_t *module,
+                              struct dt_iop_module_t *src);
 int dt_masks_group_get_hash_buffer_length(dt_masks_form_t *form);
-char *dt_masks_group_get_hash_buffer(dt_masks_form_t *form, char *str);
+char *dt_masks_group_get_hash_buffer(dt_masks_form_t *form,
+                                     char *str);
 
-void dt_masks_form_remove(struct dt_iop_module_t *module, dt_masks_form_t *grp, dt_masks_form_t *form);
-float dt_masks_form_change_opacity(dt_masks_form_t *form, int parentid, float amount);
-void dt_masks_form_move(dt_masks_form_t *grp, const int formid, const int up);
-int dt_masks_form_duplicate(dt_develop_t *dev, const int formid);
+void dt_masks_form_remove(struct dt_iop_module_t *module,
+                          dt_masks_form_t *grp,
+                          dt_masks_form_t *form);
+float dt_masks_form_change_opacity(dt_masks_form_t *form,
+                                   const int parentid,
+                                   const float amount);
+void dt_masks_form_move(dt_masks_form_t *grp,
+                        const int formid,
+                        const int up);
+int dt_masks_form_duplicate(dt_develop_t *dev,
+                            const int formid);
 /* returns a duplicate tof form, including the formid */
 dt_masks_form_t *dt_masks_dup_masks_form(const dt_masks_form_t *form);
 /* duplicate the list of forms, replace item in the list with form with the same formid */
 GList *dt_masks_dup_forms_deep(GList *forms, dt_masks_form_t *form);
 
 /** utils functions */
-int dt_masks_point_in_form_exact(float x, float y, float *points, int points_start, int points_count);
-int dt_masks_point_in_form_near(float x, float y, float *points, int points_start, int points_count, float distance, int *near);
-float dt_masks_drag_factor(dt_masks_form_gui_t *gui, int index, int k, gboolean border);
+int dt_masks_point_in_form_exact(const float x,
+                                 const float y,
+                                 float *points,
+                                 const int points_start,
+                                 const int points_count);
+int dt_masks_point_in_form_near(const float x,
+                                const float y,
+                                float *points,
+                                const int points_start,
+                                const int points_count,
+                                const float distance,
+                                int *near);
+float dt_masks_drag_factor(dt_masks_form_gui_t *gui,
+                           const int index,
+                           const int k,
+                           const gboolean border);
 
 /** allow to select a shape inside an iop */
-void dt_masks_select_form(struct dt_iop_module_t *module, dt_masks_form_t *sel);
+void dt_masks_select_form(struct dt_iop_module_t *module,
+                          dt_masks_form_t *sel);
 
 /** utils for selecting the source of a clone mask while creating it */
-void dt_masks_draw_clone_source_pos(cairo_t *cr, const float zoom_scale, const float x, const float y);
-void dt_masks_set_source_pos_initial_state(dt_masks_form_gui_t *gui, const uint32_t state, const float pzx,
+void dt_masks_draw_clone_source_pos(cairo_t *cr,
+                                    const float zoom_scale,
+                                    const float x,
+                                    const float y);
+void dt_masks_set_source_pos_initial_state(dt_masks_form_gui_t *gui,
+                                           const uint32_t state,
+                                           const float pzx,
                                            const float pzy);
-void dt_masks_set_source_pos_initial_value(dt_masks_form_gui_t *gui, const int mask_type, dt_masks_form_t *form,
-                                                   const float pzx, const float pzy);
-void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mask_type, const float initial_xpos,
-                                         const float initial_ypos, const float xpos, const float ypos, float *px,
-                                         float *py, const int adding);
+void dt_masks_set_source_pos_initial_value(dt_masks_form_gui_t *gui,
+                                           const int mask_type,
+                                           dt_masks_form_t *form,
+                                           const float pzx,
+                                           const float pzy);
+void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui,
+                                         const int mask_type,
+                                         const float initial_xpos,
+                                         const float initial_ypos,
+                                         const float xpos,
+                                         const float ypos,
+                                         float *px,
+                                         float *py,
+                                         const int adding);
 
 /** detail mask support */
-void dt_masks_extend_border(float *const mask, const int width, const int height, const int border);
+void dt_masks_extend_border(float *const mask,
+                            const int width,
+                            const int height,
+                            const int border);
 void dt_masks_blur_9x9_coeff(float *coeffs, const float sigma);
-void dt_masks_blur_9x9(float *const src, float *const out, const int width, const int height, const float sigma);
-void dt_masks_calc_rawdetail_mask(float *const src, float *const out, float *const tmp, const int width,
-                                  const int height, const dt_aligned_pixel_t wb);
-void dt_masks_calc_detail_mask(float *const src, float *const out, float *const tmp, const int width, const int height, const float threshold, const gboolean detail);
+void dt_masks_blur_9x9(float *const src,
+                       float *const out,
+                       const int width,
+                       const int height,
+                       const float sigma);
+void dt_masks_calc_rawdetail_mask(float *const src,
+                                  float *const out,
+                                  float *const tmp,
+                                  const int width,
+                                  const int height,
+                                  const dt_aligned_pixel_t wb);
+void dt_masks_calc_detail_mask(float *const src,
+                               float *const out,
+                               float *const tmp,
+                               const int width,
+                               const int height,
+                               const float threshold,
+                               const gboolean detail);
 
 /** the output data are blurred-val * gain and are clipped to be within 0 to clip
     The returned int might be used to expand the border as this depends on sigma */
-int dt_masks_blur_fast(float *const src, float *const out, const int width, const int height, const float sigma, const float gain, const float clip);
+int dt_masks_blur_fast(float *const src,
+                       float *const out,
+                       const int width,
+                       const int height,
+                       const float sigma,
+                       const float gain,
+                       const float clip);
 
 /** return the list of possible mouse actions */
 GSList *dt_masks_mouse_actions(dt_masks_form_t *form);
 
-void dt_group_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_form_t *form,
+void dt_group_events_post_expose(cairo_t *cr,
+                                 const float zoom_scale,
+                                 dt_masks_form_t *form,
                                  dt_masks_form_gui_t *gui);
 
 /** code for dynamic handling of intermediate buffers */
-static inline gboolean _dt_masks_dynbuf_growto(dt_masks_dynbuf_t *a, size_t size)
+static inline gboolean _dt_masks_dynbuf_growto(dt_masks_dynbuf_t *a, const size_t size)
 {
   const size_t newsize = dt_round_size_sse(sizeof(float) * size) / sizeof(float);
   float *newbuf = dt_alloc_align_float(newsize);
   if (!newbuf)
   {
     // not much we can do here except emit an error message
-    fprintf(stderr, "critical: out of memory for dynbuf '%s' with size request %zu!\n", a->tag, size);
+    fprintf(stderr, "critical: out of memory for dynbuf '%s' with size request %zu!\n",
+            a->tag, size);
     return FALSE;
   }
   if (a->buffer)
   {
     memcpy(newbuf, a->buffer, a->size * sizeof(float));
-    dt_print(DT_DEBUG_MASKS, "[masks dynbuf '%s'] grows to size %lu (is %p, was %p)\n", a->tag,
+    dt_print(DT_DEBUG_MASKS, "[masks dynbuf '%s'] grows to size %lu (is %p, was %p)\n",
+             a->tag,
              (unsigned long)a->size, newbuf, a->buffer);
     dt_free_align(a->buffer);
   }
@@ -500,7 +722,8 @@ dt_masks_dynbuf_t *dt_masks_dynbuf_init(size_t size, const char *tag)
     g_strlcpy(a->tag, tag, sizeof(a->tag)); //only for debugging purposes
     a->pos = 0;
     if(_dt_masks_dynbuf_growto(a, size))
-      dt_print(DT_DEBUG_MASKS, "[masks dynbuf '%s'] with initial size %lu (is %p)\n", a->tag,
+      dt_print(DT_DEBUG_MASKS, "[masks dynbuf '%s'] with initial size %lu (is %p)\n",
+               a->tag,
                (unsigned long)a->size, a->buffer);
     if(a->buffer == NULL)
     {
@@ -538,8 +761,9 @@ void dt_masks_dynbuf_add_2(dt_masks_dynbuf_t *a, float value1, float value2)
   a->buffer[a->pos++] = value2;
 }
 
-// Return a pointer to N floats past the current end of the dynbuf's contents, marking them as already in use.
-// The caller should then fill in the reserved elements using the returned pointer.
+// Return a pointer to N floats past the current end of the dynbuf's
+// contents, marking them as already in use.  The caller should then
+// fill in the reserved elements using the returned pointer.
 static inline
 float *dt_masks_dynbuf_reserve_n(dt_masks_dynbuf_t *a, const int n)
 {
@@ -555,7 +779,8 @@ float *dt_masks_dynbuf_reserve_n(dt_masks_dynbuf_t *a, const int n)
       return NULL;
     }
   }
-  // get the current end of the (possibly reallocated) buffer, then mark the next N items as in-use
+  // get the current end of the (possibly reallocated) buffer, then
+  // mark the next N items as in-use
   float *reserved = a->buffer + a->pos;
   a->pos += n;
   return reserved;
@@ -576,7 +801,8 @@ void dt_masks_dynbuf_add_zeros(dt_masks_dynbuf_t *a, const int n)
       return;
     }
   }
-  // now that we've ensured a sufficiently large buffer add N zeros to the end of the existing data
+  // now that we've ensured a sufficiently large buffer add N zeros to
+  // the end of the existing data
   memset(a->buffer + a->pos, 0, n * sizeof(float));
   a->pos += n;
 }
@@ -653,9 +879,15 @@ int dt_masks_roundup(int num, int mult)
 }
 
 #define DT_MASKS_CONF(type, shape, param) \
-  (type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? "plugins/darkroom/spots/" #shape "_" #param : "plugins/darkroom/masks/" #shape "/" #param)
+  (type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) \
+   ? "plugins/darkroom/spots/" #shape "_" #param \
+   : "plugins/darkroom/masks/" #shape "/" #param)
 
-void dt_masks_draw_anchor(cairo_t *cr, gboolean selected, const float zoom_scale, const float x, const float y);
+void dt_masks_draw_anchor(cairo_t *cr,
+                          const gboolean selected,
+                          const float zoom_scale,
+                          const float x,
+                          const float y);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1533,8 +1533,6 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
   }
   else if(gui->creation && which == 1)
   {
-    dt_iop_module_t *crea_module = gui->creation_module;
-
     if(gui->guipoints && gui->guipoints_count > 0)
     {
       // if the path consists only of one x/y pair we add a second one close so we don't need to deal with
@@ -1623,6 +1621,8 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
       gui->guipoints_count = 0;
 
       // we save the form and quit creation mode
+      dt_iop_module_t *crea_module = gui->creation_module;
+
       dt_masks_gui_form_save_creation(darktable.develop, crea_module, form, gui);
 
       if(crea_module)
@@ -1635,13 +1635,10 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
         else if(!gui->creation_continuous)
           dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
         dt_masks_iop_update(crea_module);
-        dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid);
-        gui->creation_module = NULL;
       }
-      else
-      {
-        dt_dev_masks_selection_change(darktable.develop, NULL, form->formid);
-      }
+
+      dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid);
+      gui->creation_module = NULL;
 
       if(gui->creation_continuous)
       {

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1671,8 +1671,8 @@ static int _brush_events_button_released(struct dt_iop_module_t *module,
         // and we switch in edit mode to show all the forms
         // spots and retouch have their own handling of creation_continuous
         if(gui->creation_continuous
-           && ( strcmp(crea_module->so->op, "spots") == 0
-                || strcmp(crea_module->so->op, "retouch") == 0))
+           && (dt_iop_module_is(crea_module->so, "spots")
+               || dt_iop_module_is(crea_module->so, "retouch")))
           dt_masks_set_edit_mode_single_form(crea_module, form->formid, DT_MASKS_EDIT_FULL);
         else if(!gui->creation_continuous)
           dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
@@ -1686,8 +1686,8 @@ static int _brush_events_button_released(struct dt_iop_module_t *module,
          && gui->creation_continuous)
       {
         //spot and retouch manage creation_continuous in their own way
-        if(strcmp(crea_module->so->op, "spots") != 0
-           && strcmp(crea_module->so->op, "retouch") != 0)
+        if(!dt_iop_module_is(crea_module->so, "spots")
+           && !dt_iop_module_is(crea_module->so, "retouch"))
         {
           dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)crea_module->blend_data;
           for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2013-2021 darktable developers.
+    Copyright (C) 2013-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "bauhaus/bauhaus.h"
 #include "common/debug.h"
 #include "common/imagebuf.h"
@@ -32,8 +33,12 @@
 #define BORDER_MIN 0.00005f
 #define BORDER_MAX 0.5f
 
-/** get squared distance of indexed point to line segment, taking weighted payload data into account */
-static float _brush_point_line_distance2(int index, int pointscount, const float *points, const float *payload)
+/** get squared distance of indexed point to line segment, taking
+ * weighted payload data into account */
+static float _brush_point_line_distance2(const int index,
+                                         const int pointscount,
+                                         const float *points,
+                                         const float *payload)
 {
   const float x = points[2 * index];
   const float y = points[2 * index + 1];
@@ -104,9 +109,12 @@ static float _brush_point_line_distance2(int index, int pointscount, const float
   return sqf(dx) + sqf(dy) + bweight * sqf(db) + hweight * dh * dh + dweight * sqf(dd);
 }
 
-/** remove unneeded points (Ramer-Douglas-Peucker algorithm) and return resulting path as linked list */
-static GList *_brush_ramer_douglas_peucker(const float *points, int points_count, const float *payload,
-                                           float epsilon2)
+/** remove unneeded points (Ramer-Douglas-Peucker algorithm) and
+ * return resulting path as linked list */
+static GList *_brush_ramer_douglas_peucker(const float *points,
+                                           const int points_count,
+                                           const float *payload,
+                                           const float epsilon2)
 {
   GList *ResultList = NULL;
 
@@ -115,7 +123,7 @@ static GList *_brush_ramer_douglas_peucker(const float *points, int points_count
 
   for(int i = 1; i < points_count - 1; i++)
   {
-    float d2 = _brush_point_line_distance2(i, points_count, points, payload);
+    const float d2 = _brush_point_line_distance2(i, points_count, points, payload);
     if(d2 > dmax2)
     {
       index = i;
@@ -125,9 +133,11 @@ static GList *_brush_ramer_douglas_peucker(const float *points, int points_count
 
   if(dmax2 >= epsilon2)
   {
-    GList *ResultList1 = _brush_ramer_douglas_peucker(points, index + 1, payload, epsilon2);
-    GList *ResultList2 = _brush_ramer_douglas_peucker(points + index * 2, points_count - index,
-                                                      payload + index * 4, epsilon2);
+    GList *ResultList1 =
+      _brush_ramer_douglas_peucker(points, index + 1, payload, epsilon2);
+    GList *ResultList2 =
+      _brush_ramer_douglas_peucker(points + index * 2, points_count - index,
+                                   payload + index * 4, epsilon2);
 
     // remove last element from ResultList1
     GList *end1 = g_list_last(ResultList1);
@@ -163,8 +173,17 @@ static GList *_brush_ramer_douglas_peucker(const float *points, int points_count
 }
 
 /** get the point of the brush at pos t [0,1]  */
-static void _brush_get_XY(float p0x, float p0y, float p1x, float p1y, float p2x, float p2y, float p3x,
-                          float p3y, float t, float *x, float *y)
+static void _brush_get_XY(const float p0x,
+                          const float p0y,
+                          const float p1x,
+                          const float p1y,
+                          const float p2x,
+                          const float p2y,
+                          const float p3x,
+                          const float p3y,
+                          const float t,
+                          float *x,
+                          float *y)
 {
   const float ti = 1.0f - t;
   const float a = ti * ti * ti;
@@ -175,9 +194,22 @@ static void _brush_get_XY(float p0x, float p0y, float p1x, float p1y, float p2x,
   *y = p0y * a + p1y * b + p2y * c + p3y * d;
 }
 
-/** get the point of the brush at pos t [0,1]  AND the corresponding border point */
-static void _brush_border_get_XY(float p0x, float p0y, float p1x, float p1y, float p2x, float p2y, float p3x,
-                                 float p3y, float t, float rad, float *xc, float *yc, float *xb, float *yb)
+/** get the point of the brush at pos t [0,1] AND the corresponding
+ * border point */
+static void _brush_border_get_XY(const float p0x,
+                                 const float p0y,
+                                 const float p1x,
+                                 const float p1y,
+                                 const float p2x,
+                                 const float p2y,
+                                 const float p3x,
+                                 const float p3y,
+                                 const float t,
+                                 const float rad,
+                                 float *xc,
+                                 float *yc,
+                                 float *xb,
+                                 float *yb)
 {
   // we get the point
   _brush_get_XY(p0x, p0y, p1x, p1y, p2x, p2y, p3x, p3y, t, xc, yc);
@@ -206,8 +238,13 @@ static void _brush_border_get_XY(float p0x, float p0y, float p1x, float p1y, flo
 
 /** get feather extremity from the control point n°2 */
 /** the values should be in orthonormal space */
-static void _brush_ctrl2_to_feather(float ptx, float pty, float ctrlx, float ctrly, float *fx, float *fy,
-                                    gboolean clockwise)
+static void _brush_ctrl2_to_feather(const float ptx,
+                                    const float pty,
+                                    const float ctrlx,
+                                    const float ctrly,
+                                    float *fx,
+                                    float *fy,
+                                    const gboolean clockwise)
 {
   if(clockwise)
   {
@@ -223,9 +260,15 @@ static void _brush_ctrl2_to_feather(float ptx, float pty, float ctrlx, float ctr
 
 /** get bezier control points from feather extremity */
 /** the values should be in orthonormal space */
-static void _brush_feather_to_ctrl(float ptx, float pty, float fx, float fy,
-                                   float *ctrl1x, float *ctrl1y,
-                                   float *ctrl2x, float *ctrl2y, gboolean clockwise)
+static void _brush_feather_to_ctrl(const float ptx,
+                                   const float pty,
+                                   const float fx,
+                                   const float fy,
+                                   float *ctrl1x,
+                                   float *ctrl1y,
+                                   float *ctrl2x,
+                                   float *ctrl2y,
+                                   const gboolean clockwise)
 {
   if(clockwise)
   {
@@ -244,8 +287,18 @@ static void _brush_feather_to_ctrl(float ptx, float pty, float fx, float fy,
 }
 
 /** Get the control points of a segment to match exactly a catmull-rom spline */
-static void _brush_catmull_to_bezier(float x1, float y1, float x2, float y2, float x3, float y3, float x4,
-                                     float y4, float *bx1, float *by1, float *bx2, float *by2)
+static void _brush_catmull_to_bezier(const float x1,
+                                     const float y1,
+                                     const float x2,
+                                     const float y2,
+                                     const float x3,
+                                     const float y3,
+                                     const float x4,
+                                     const float y4,
+                                     float *bx1,
+                                     float *by1,
+                                     float *bx2,
+                                     float *by2)
 {
   *bx1 = (-x1 + 6 * x2 + x3) / 6;
   *by1 = (-y1 + 6 * y2 + y3) / 6;
@@ -253,7 +306,8 @@ static void _brush_catmull_to_bezier(float x1, float y1, float x2, float y2, flo
   *by2 = (y2 + 6 * y3 - y4) / 6;
 }
 
-/** initialise all control points to eventually match a catmull-rom like spline */
+/** initialise all control points to eventually match a catmull-rom
+ * like spline */
 static void _brush_init_ctrl_points(dt_masks_form_t *form)
 {
   // if we have less than 2 points, what to do ??
@@ -262,7 +316,9 @@ static void _brush_init_ctrl_points(dt_masks_form_t *form)
   // we need extra points to deal with curve ends
   dt_masks_point_brush_t start_point[2], end_point[2];
 
-  for(GList *form_points = form->points; form_points; form_points = g_list_next(form_points))
+  for(GList *form_points = form->points;
+      form_points;
+      form_points = g_list_next(form_points))
   {
     dt_masks_point_brush_t *point3 = (dt_masks_point_brush_t *)form_points->data;
     // if the point has not been set manually, we redefine it
@@ -281,8 +337,10 @@ static void _brush_init_ctrl_points(dt_masks_form_t *form)
       // deal with end points: make both extending points mirror their neighborhood
       if(point1 == NULL && point2 == NULL)
       {
-        start_point[0].corner[0] = start_point[1].corner[0] = 2 * point3->corner[0] - point4->corner[0];
-        start_point[0].corner[1] = start_point[1].corner[1] = 2 * point3->corner[1] - point4->corner[1];
+        start_point[0].corner[0] =
+          start_point[1].corner[0] = 2 * point3->corner[0] - point4->corner[0];
+        start_point[0].corner[1] =
+          start_point[1].corner[1] = 2 * point3->corner[1] - point4->corner[1];
         point1 = &(start_point[0]);
         point2 = &(start_point[1]);
       }
@@ -295,8 +353,10 @@ static void _brush_init_ctrl_points(dt_masks_form_t *form)
 
       if(point4 == NULL && point5 == NULL)
       {
-        end_point[0].corner[0] = end_point[1].corner[0] = 2 * point3->corner[0] - point2->corner[0];
-        end_point[0].corner[1] = end_point[1].corner[1] = 2 * point3->corner[1] - point2->corner[1];
+        end_point[0].corner[0] =
+          end_point[1].corner[0] = 2 * point3->corner[0] - point2->corner[0];
+        end_point[0].corner[1] =
+          end_point[1].corner[1] = 2 * point3->corner[1] - point2->corner[1];
         point4 = &(end_point[0]);
         point5 = &(end_point[1]);
       }
@@ -309,15 +369,19 @@ static void _brush_init_ctrl_points(dt_masks_form_t *form)
 
 
       float bx1 = 0.0f, by1 = 0.0f, bx2 = 0.0f, by2 = 0.0f;
-      _brush_catmull_to_bezier(point1->corner[0], point1->corner[1], point2->corner[0], point2->corner[1],
-                               point3->corner[0], point3->corner[1], point4->corner[0], point4->corner[1],
+      _brush_catmull_to_bezier(point1->corner[0], point1->corner[1],
+                               point2->corner[0], point2->corner[1],
+                               point3->corner[0], point3->corner[1],
+                               point4->corner[0], point4->corner[1],
                                &bx1, &by1, &bx2, &by2);
       if(point2->ctrl2[0] == -1.0) point2->ctrl2[0] = bx1;
       if(point2->ctrl2[1] == -1.0) point2->ctrl2[1] = by1;
       point3->ctrl1[0] = bx2;
       point3->ctrl1[1] = by2;
-      _brush_catmull_to_bezier(point2->corner[0], point2->corner[1], point3->corner[0], point3->corner[1],
-                               point4->corner[0], point4->corner[1], point5->corner[0], point5->corner[1],
+      _brush_catmull_to_bezier(point2->corner[0], point2->corner[1],
+                               point3->corner[0], point3->corner[1],
+                               point4->corner[0], point4->corner[1],
+                               point5->corner[0], point5->corner[1],
                                &bx1, &by1, &bx2, &by2);
       if(point4->ctrl1[0] == -1.0) point4->ctrl1[0] = bx2;
       if(point4->ctrl1[1] == -1.0) point4->ctrl1[1] = by2;
@@ -329,10 +393,15 @@ static void _brush_init_ctrl_points(dt_masks_form_t *form)
 
 
 /** fill the gap between 2 points with an arc of circle */
-/** this function is here because we can have gap in border, esp. if the corner is very sharp */
-static void _brush_points_recurs_border_gaps(float *cmax, float *bmin, float *bmin2, float *bmax,
-                                             dt_masks_dynbuf_t *dpoints, dt_masks_dynbuf_t *dborder,
-                                             gboolean clockwise)
+/** this function is here because we can have gap in border, esp. if
+ * the corner is very sharp */
+static void _brush_points_recurs_border_gaps(float *cmax,
+                                             float *bmin,
+                                             float *bmin2,
+                                             float *bmax,
+                                             dt_masks_dynbuf_t *dpoints,
+                                             dt_masks_dynbuf_t *dborder,
+                                             const gboolean clockwise)
 {
   // we want to find the start and end angles
   float a1 = atan2f(bmin[1] - cmax[1], bmin[0] - cmax[0]);
@@ -351,8 +420,10 @@ static void _brush_points_recurs_border_gaps(float *cmax, float *bmin, float *bm
   }
 
   // we determine start and end radius too
-  float r1 = sqrtf((bmin[1] - cmax[1]) * (bmin[1] - cmax[1]) + (bmin[0] - cmax[0]) * (bmin[0] - cmax[0]));
-  float r2 = sqrtf((bmax[1] - cmax[1]) * (bmax[1] - cmax[1]) + (bmax[0] - cmax[0]) * (bmax[0] - cmax[0]));
+  float r1 = sqrtf((bmin[1] - cmax[1]) * (bmin[1] - cmax[1])
+                   + (bmin[0] - cmax[0]) * (bmin[0] - cmax[0]));
+  float r2 = sqrtf((bmax[1] - cmax[1]) * (bmax[1] - cmax[1])
+                   + (bmax[0] - cmax[0]) * (bmax[0] - cmax[0]));
 
   // and the max length of the circle arc
   int l;
@@ -363,15 +434,16 @@ static void _brush_points_recurs_border_gaps(float *cmax, float *bmin, float *bm
   if(l < 2) return;
 
   // and now we add the points
-  float incra = (a2 - a1) / l;
-  float incrr = (r2 - r1) / l;
+  const float incra = (a2 - a1) / l;
+  const float incrr = (r2 - r1) / l;
   float rr = r1 + incrr;
   float aa = a1 + incra;
   // allocate entries in the dynbufs
   float *dpoints_ptr = dt_masks_dynbuf_reserve_n(dpoints, 2*(l-1));
   float *dborder_ptr = dt_masks_dynbuf_reserve_n(dborder, 2*(l-1));
-  // and fill them in: the same center pos for each point in dpoints, and the corresponding border point at
-  //  successive angular positions for dborder
+  // and fill them in: the same center pos for each point in dpoints,
+  //  and the corresponding border point at successive angular
+  //  positions for dborder
   if(dpoints_ptr && dborder_ptr)
   {
     for(int i = 1; i < l; i++)
@@ -387,20 +459,29 @@ static void _brush_points_recurs_border_gaps(float *cmax, float *bmin, float *bm
 }
 
 /** fill small gap between 2 points with an arc of circle */
-/** in contrast to the previous function it will always run the shortest path (max. PI) and does not consider
- * clock or anti-clockwise action */
-static void _brush_points_recurs_border_small_gaps(float *cmax, float *bmin, float *bmin2, float *bmax,
-                                                   dt_masks_dynbuf_t *dpoints, dt_masks_dynbuf_t *dborder)
+/** in contrast to the previous function it will always run the
+ * shortest path (max. PI) and does not consider clock or
+ * anti-clockwise action */
+static void _brush_points_recurs_border_small_gaps(float *cmax,
+                                                   float *bmin,
+                                                   float *bmin2,
+                                                   float *bmax,
+                                                   dt_masks_dynbuf_t *dpoints,
+                                                   dt_masks_dynbuf_t *dborder)
 {
   // we want to find the start and end angles
-  const float a1 = fmodf(atan2f(bmin[1] - cmax[1], bmin[0] - cmax[0]) + 2.0f * M_PI, 2.0f * M_PI);
-  const float a2 = fmodf(atan2f(bmax[1] - cmax[1], bmax[0] - cmax[0]) + 2.0f * M_PI, 2.0f * M_PI);
+  const float a1 = fmodf(atan2f(bmin[1] - cmax[1], bmin[0] - cmax[0])
+                         + 2.0f * M_PI, 2.0f * M_PI);
+  const float a2 = fmodf(atan2f(bmax[1] - cmax[1], bmax[0] - cmax[0])
+                         + 2.0f * M_PI, 2.0f * M_PI);
 
   if(a1 == a2) return;
 
   // we determine start and end radius too
-  const float r1 = sqrtf((bmin[1] - cmax[1]) * (bmin[1] - cmax[1]) + (bmin[0] - cmax[0]) * (bmin[0] - cmax[0]));
-  const float r2 = sqrtf((bmax[1] - cmax[1]) * (bmax[1] - cmax[1]) + (bmax[0] - cmax[0]) * (bmax[0] - cmax[0]));
+  const float r1 = sqrtf((bmin[1] - cmax[1]) * (bmin[1] - cmax[1])
+                         + (bmin[0] - cmax[0]) * (bmin[0] - cmax[0]));
+  const float r2 = sqrtf((bmax[1] - cmax[1]) * (bmax[1] - cmax[1])
+                         + (bmax[0] - cmax[0]) * (bmax[0] - cmax[0]));
 
   // we close the gap in the shortest direction
   float delta = a2 - a1;
@@ -418,8 +499,9 @@ static void _brush_points_recurs_border_small_gaps(float *cmax, float *bmin, flo
   // allocate entries in the dynbufs
   float *dpoints_ptr = dt_masks_dynbuf_reserve_n(dpoints, 2*(l-1));
   float *dborder_ptr = dt_masks_dynbuf_reserve_n(dborder, 2*(l-1));
-  // and fill them in: the same center pos for each point in dpoints, and the corresponding border point at
-  //  successive angular positions for dborder
+  // and fill them in: the same center pos for each point in dpoints,
+  //  and the corresponding border point at successive angular
+  //  positions for dborder
   if(dpoints_ptr && dborder_ptr)
   {
     for(int i = 1; i < l; i++)
@@ -435,16 +517,20 @@ static void _brush_points_recurs_border_small_gaps(float *cmax, float *bmin, flo
 }
 
 
-/** draw a circle with given radius. can be used to terminate a stroke and to draw junctions where attributes
- * (opacity) change */
-static void _brush_points_stamp(float *cmax, float *bmin, dt_masks_dynbuf_t *dpoints,  dt_masks_dynbuf_t *dborder,
-                                gboolean clockwise)
+/** draw a circle with given radius. can be used to terminate a stroke
+ * and to draw junctions where attributes (opacity) change */
+static void _brush_points_stamp(float *cmax,
+                                float *bmin,
+                                dt_masks_dynbuf_t *dpoints,
+                                dt_masks_dynbuf_t *dborder,
+                                const gboolean clockwise)
 {
   // we want to find the start angle
   const float a1 = atan2f(bmin[1] - cmax[1], bmin[0] - cmax[0]);
 
   // we determine the radius too
-  const float rad = sqrtf((bmin[1] - cmax[1]) * (bmin[1] - cmax[1]) + (bmin[0] - cmax[0]) * (bmin[0] - cmax[0]));
+  const float rad = sqrtf((bmin[1] - cmax[1]) * (bmin[1] - cmax[1])
+                          + (bmin[0] - cmax[0]) * (bmin[0] - cmax[0]));
 
   // determine the max length of the circle arc
   const int l = 2.0f * M_PI * rad;
@@ -456,8 +542,9 @@ static void _brush_points_stamp(float *cmax, float *bmin, dt_masks_dynbuf_t *dpo
   // allocate entries in the dynbufs
   float *dpoints_ptr = dt_masks_dynbuf_reserve_n(dpoints, 2*(l-1));
   float *dborder_ptr = dt_masks_dynbuf_reserve_n(dborder, 2*(l-1));
-  // and fill them in: the same center pos for each point in dpoints, and the corresponding border point at
-  //  successive angular positions for dborder
+  // and fill them in: the same center pos for each point in dpoints,
+  //  and the corresponding border point at successive angular
+  //  positions for dborder
   if(dpoints_ptr && dborder_ptr)
   {
     for(int i = 0; i < l; i++)
@@ -471,11 +558,22 @@ static void _brush_points_stamp(float *cmax, float *bmin, dt_masks_dynbuf_t *dpo
   }
 }
 
-/** recursive function to get all points of the brush AND all point of the border */
-/** the function takes care to avoid big gaps between points */
-static void _brush_points_recurs(float *p1, float *p2, double tmin, double tmax, float *points_min,
-                                 float *points_max, float *border_min, float *border_max, float *rpoints,
-                                 float *rborder, float *rpayload, dt_masks_dynbuf_t *dpoints, dt_masks_dynbuf_t *dborder,
+/** recursive function to get all points of the brush AND all point of
+ * the border the function takes care to avoid big gaps between
+ * points */
+static void _brush_points_recurs(float *p1,
+                                 float *p2,
+                                 const double tmin,
+                                 const double tmax,
+                                 float *points_min,
+                                 float *points_max,
+                                 float *border_min,
+                                 float *border_max,
+                                 float *rpoints,
+                                 float *rborder,
+                                 float *rpayload,
+                                 dt_masks_dynbuf_t *dpoints,
+                                 dt_masks_dynbuf_t *dborder,
                                  dt_masks_dynbuf_t *dpayload)
 {
   const gboolean withborder = (dborder != NULL);
@@ -484,22 +582,29 @@ static void _brush_points_recurs(float *p1, float *p2, double tmin, double tmax,
   // we calculate points if needed
   if(isnan(points_min[0]))
   {
-    _brush_border_get_XY(p1[0], p1[1], p1[2], p1[3], p2[2], p2[3], p2[0], p2[1], tmin,
-                         p1[4] + (p2[4] - p1[4]) * tmin * tmin * (3.0 - 2.0 * tmin), points_min,
+    _brush_border_get_XY(p1[0], p1[1], p1[2], p1[3],
+                         p2[2], p2[3], p2[0], p2[1], tmin,
+                         p1[4] + (p2[4] - p1[4]) * tmin * tmin * (3.0 - 2.0 * tmin),
+                         points_min,
                          points_min + 1, border_min, border_min + 1);
   }
   if(isnan(points_max[0]))
   {
-    _brush_border_get_XY(p1[0], p1[1], p1[2], p1[3], p2[2], p2[3], p2[0], p2[1], tmax,
-                         p1[4] + (p2[4] - p1[4]) * tmax * tmax * (3.0 - 2.0 * tmax), points_max,
+    _brush_border_get_XY(p1[0], p1[1], p1[2], p1[3],
+                         p2[2], p2[3], p2[0], p2[1], tmax,
+                         p1[4] + (p2[4] - p1[4]) * tmax * tmax * (3.0 - 2.0 * tmax),
+                         points_max,
                          points_max + 1, border_max, border_max + 1);
   }
   // are the points near ?
   if((tmax - tmin < 0.0001f)
-     || ((int)points_min[0] - (int)points_max[0] < 1 && (int)points_min[0] - (int)points_max[0] > -1
-         && (int)points_min[1] - (int)points_max[1] < 1 && (int)points_min[1] - (int)points_max[1] > -1
+     || ((int)points_min[0] - (int)points_max[0] < 1
+         && (int)points_min[0] - (int)points_max[0] > -1
+         && (int)points_min[1] - (int)points_max[1] < 1
+         && (int)points_min[1] - (int)points_max[1] > -1
          && (!withborder
-             || ((int)border_min[0] - (int)border_max[0] < 1 && (int)border_min[0] - (int)border_max[0] > -1
+             || ((int)border_min[0] - (int)border_max[0] < 1
+                 && (int)border_min[0] - (int)border_max[0] > -1
                  && (int)border_min[1] - (int)border_max[1] < 1
                  && (int)border_min[1] - (int)border_max[1] > -1))))
   {
@@ -521,9 +626,11 @@ static void _brush_points_recurs(float *p1, float *p2, double tmin, double tmax,
       }
 
       // we check gaps in the border (sharp edges)
-      if(abs((int)border_max[0] - (int)border_min[0]) > 2 || abs((int)border_max[1] - (int)border_min[1]) > 2)
+      if(abs((int)border_max[0] - (int)border_min[0]) > 2
+         || abs((int)border_max[1] - (int)border_min[1]) > 2)
       {
-        _brush_points_recurs_border_small_gaps(points_max, border_min, NULL, border_max, dpoints, dborder);
+        _brush_points_recurs_border_small_gaps
+          (points_max, border_min, NULL, border_max, dpoints, dborder);
       }
 
       rborder[0] = border_max[0];
@@ -548,15 +655,17 @@ static void _brush_points_recurs(float *p1, float *p2, double tmin, double tmax,
   double tx = (tmin + tmax) / 2.0;
   float c[2] = { NAN, NAN }, b[2] = { NAN, NAN };
   float rc[2], rb[2], rp[2];
-  _brush_points_recurs(p1, p2, tmin, tx, points_min, c, border_min, b, rc, rb, rp, dpoints, dborder, dpayload);
-  _brush_points_recurs(p1, p2, tx, tmax, rc, points_max, rb, border_max, rpoints, rborder, rpayload, dpoints,
+  _brush_points_recurs(p1, p2, tmin, tx, points_min, c,
+                       border_min, b, rc, rb, rp, dpoints, dborder, dpayload);
+  _brush_points_recurs(p1, p2, tx, tmax, rc, points_max, rb,
+                       border_max, rpoints, rborder, rpayload, dpoints,
                        dborder, dpayload);
 }
 
 
-/** converts n into a cyclical sequence counting upwards from 0 to nb-1 and back down again, counting
- * endpoints twice */
-static inline int _brush_cyclic_cursor(int n, int nb)
+/** converts n into a cyclical sequence counting upwards from 0 to
+ * nb-1 and back down again, counting endpoints twice */
+static inline int _brush_cyclic_cursor(const int n, const int nb)
 {
   const int o = n % (2 * nb);
   const int p = o % nb;
@@ -567,10 +676,17 @@ static inline int _brush_cyclic_cursor(int n, int nb)
 
 /** get all points of the brush and the border */
 /** this takes care of gaps and iop distortions */
-static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const double iop_order, const int transf_direction,
-                                    dt_dev_pixelpipe_t *pipe, float **points, int *points_count,
-                                    float **border, int *border_count, float **payload, int *payload_count,
-                                    int source)
+static int _brush_get_pts_border(dt_develop_t *dev,
+                                 dt_masks_form_t *form,
+                                 const double iop_order,
+                                 const int transf_direction,
+                                 dt_dev_pixelpipe_t *pipe,
+                                 float **points, int *points_count,
+                                 float **border,
+                                 int *border_count,
+                                 float **payload,
+                                 int *payload_count,
+                                 const int source)
 {
   double start2 = 0.0;
   if(darktable.unmuted & DT_DEBUG_PERF) start2 = dt_get_wtime();
@@ -621,7 +737,9 @@ static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const
     dy = (pt->corner[1] - form->source[1]) * ht;
   }
 
-  for(GList *form_points = form->points; form_points; form_points = g_list_next(form_points))
+  for(GList *form_points = form->points;
+      form_points;
+      form_points = g_list_next(form_points))
   {
     const dt_masks_point_brush_t *const pt = (dt_masks_point_brush_t *)form_points->data;
     float *const buf = dt_masks_dynbuf_reserve_n(dpoints, 6);
@@ -668,22 +786,41 @@ static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const
     const int k1 = _brush_cyclic_cursor(n + 1, nb);
     const int k2 = _brush_cyclic_cursor(n + 2, nb);
 
-    dt_masks_point_brush_t *point1 = (dt_masks_point_brush_t *)g_list_nth_data(form->points, k);
-    dt_masks_point_brush_t *point2 = (dt_masks_point_brush_t *)g_list_nth_data(form->points, k1);
-    dt_masks_point_brush_t *point3 = (dt_masks_point_brush_t *)g_list_nth_data(form->points, k2);
+    dt_masks_point_brush_t *point1 =
+      (dt_masks_point_brush_t *)g_list_nth_data(form->points, k);
+    dt_masks_point_brush_t *point2 =
+      (dt_masks_point_brush_t *)g_list_nth_data(form->points, k1);
+    dt_masks_point_brush_t *point3 =
+      (dt_masks_point_brush_t *)g_list_nth_data(form->points, k2);
     if(cw > 0)
     {
-      const float pa[7] = { point1->corner[0] * wd - dx, point1->corner[1] * ht - dy, point1->ctrl2[0] * wd - dx,
-                            point1->ctrl2[1] * ht - dy, point1->border[1] * MIN(wd, ht), point1->hardness,
+      const float pa[7] = { point1->corner[0] * wd - dx,
+                            point1->corner[1] * ht - dy,
+                            point1->ctrl2[0] * wd - dx,
+                            point1->ctrl2[1] * ht - dy,
+                            point1->border[1] * MIN(wd, ht),
+                            point1->hardness,
                             point1->density };
-      const float pb[7] = { point2->corner[0] * wd - dx, point2->corner[1] * ht - dy, point2->ctrl1[0] * wd - dx,
-                            point2->ctrl1[1] * ht - dy, point2->border[0] * MIN(wd, ht), point2->hardness,
+      const float pb[7] = { point2->corner[0] * wd - dx,
+                            point2->corner[1] * ht - dy,
+                            point2->ctrl1[0] * wd - dx,
+                            point2->ctrl1[1] * ht - dy,
+                            point2->border[0] * MIN(wd, ht),
+                            point2->hardness,
                             point2->density };
-      const float pc[7] = { point2->corner[0] * wd - dx, point2->corner[1] * ht - dy, point2->ctrl2[0] * wd - dx,
-                            point2->ctrl2[1] * ht - dy, point2->border[1] * MIN(wd, ht), point2->hardness,
+      const float pc[7] = { point2->corner[0] * wd - dx,
+                            point2->corner[1] * ht - dy,
+                            point2->ctrl2[0] * wd - dx,
+                            point2->ctrl2[1] * ht - dy,
+                            point2->border[1] * MIN(wd, ht),
+                            point2->hardness,
                             point2->density };
-      const float pd[7] = { point3->corner[0] * wd - dx, point3->corner[1] * ht - dy, point3->ctrl1[0] * wd - dx,
-                            point3->ctrl1[1] * ht - dy, point3->border[0] * MIN(wd, ht), point3->hardness,
+      const float pd[7] = { point3->corner[0] * wd - dx,
+                            point3->corner[1] * ht - dy,
+                            point3->ctrl1[0] * wd - dx,
+                            point3->ctrl1[1] * ht - dy,
+                            point3->border[0] * MIN(wd, ht),
+                            point3->hardness,
                             point3->density };
       memcpy(p1, pa, sizeof(float) * 7);
       memcpy(p2, pb, sizeof(float) * 7);
@@ -692,17 +829,33 @@ static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const
     }
     else
     {
-      const float pa[7] = { point1->corner[0] * wd - dx, point1->corner[1] * ht - dy, point1->ctrl1[0] * wd - dx,
-                            point1->ctrl1[1] * ht - dy, point1->border[1] * MIN(wd, ht), point1->hardness,
+      const float pa[7] = { point1->corner[0] * wd - dx,
+                            point1->corner[1] * ht - dy,
+                            point1->ctrl1[0] * wd - dx,
+                            point1->ctrl1[1] * ht - dy,
+                            point1->border[1] * MIN(wd, ht),
+                            point1->hardness,
                             point1->density };
-      const float pb[7] = { point2->corner[0] * wd - dx, point2->corner[1] * ht - dy, point2->ctrl2[0] * wd - dx,
-                            point2->ctrl2[1] * ht - dy, point2->border[0] * MIN(wd, ht), point2->hardness,
+      const float pb[7] = { point2->corner[0] * wd - dx,
+                            point2->corner[1] * ht - dy,
+                            point2->ctrl2[0] * wd - dx,
+                            point2->ctrl2[1] * ht - dy,
+                            point2->border[0] * MIN(wd, ht),
+                            point2->hardness,
                             point2->density };
-      const float pc[7] = { point2->corner[0] * wd - dx, point2->corner[1] * ht - dy, point2->ctrl1[0] * wd - dx,
-                            point2->ctrl1[1] * ht - dy, point2->border[1] * MIN(wd, ht), point2->hardness,
+      const float pc[7] = { point2->corner[0] * wd - dx,
+                            point2->corner[1] * ht - dy,
+                            point2->ctrl1[0] * wd - dx,
+                            point2->ctrl1[1] * ht - dy,
+                            point2->border[1] * MIN(wd, ht),
+                            point2->hardness,
                             point2->density };
-      const float pd[7] = { point3->corner[0] * wd - dx, point3->corner[1] * ht - dy, point3->ctrl2[0] * wd - dx,
-                            point3->ctrl2[1] * ht - dy, point3->border[0] * MIN(wd, ht), point3->hardness,
+      const float pd[7] = { point3->corner[0] * wd - dx,
+                            point3->corner[1] * ht - dy,
+                            point3->ctrl2[0] * wd - dx,
+                            point3->ctrl2[1] * ht - dy,
+                            point3->border[0] * MIN(wd, ht),
+                            point3->hardness,
                             point3->density };
       memcpy(p1, pa, sizeof(float) * 7);
       memcpy(p2, pb, sizeof(float) * 7);
@@ -710,8 +863,11 @@ static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const
       memcpy(p4, pd, sizeof(float) * 7);
     }
 
-    // 1st. special case: render abrupt transitions between different opacity and/or hardness values
-    if((fabsf(p1[5] - p2[5]) > 0.05f || fabsf(p1[6] - p2[6]) > 0.05f) || (start_stamp && n == 2 * nb - 1))
+    // 1st. special case: render abrupt transitions between different
+    // opacity and/or hardness values
+    if((fabsf(p1[5] - p2[5]) > 0.05f
+        || fabsf(p1[6] - p2[6]) > 0.05f)
+       || (start_stamp && n == 2 * nb - 1))
     {
       if(n == 0)
       {
@@ -721,8 +877,10 @@ static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const
       {
         if(dborder)
         {
-          float bmin[2] = { dt_masks_dynbuf_get(dborder, -2), dt_masks_dynbuf_get(dborder, -1) };
-          float cmax[2] = { dt_masks_dynbuf_get(dpoints, -2), dt_masks_dynbuf_get(dpoints, -1) };
+          float bmin[2] = { dt_masks_dynbuf_get(dborder, -2),
+                            dt_masks_dynbuf_get(dborder, -1) };
+          float cmax[2] = { dt_masks_dynbuf_get(dpoints, -2),
+                            dt_masks_dynbuf_get(dpoints, -1) };
           _brush_points_stamp(cmax, bmin, dpoints, dborder, TRUE);
         }
 
@@ -741,8 +899,10 @@ static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const
     {
       if(dborder)
       {
-        float bmin[2] = { dt_masks_dynbuf_get(dborder, -2), dt_masks_dynbuf_get(dborder, -1) };
-        float cmax[2] = { dt_masks_dynbuf_get(dpoints, -2), dt_masks_dynbuf_get(dpoints, -1) };
+        float bmin[2] = { dt_masks_dynbuf_get(dborder, -2),
+                          dt_masks_dynbuf_get(dborder, -1) };
+        float cmax[2] = { dt_masks_dynbuf_get(dpoints, -2),
+                          dt_masks_dynbuf_get(dpoints, -1) };
         float bmax[2] = { 2 * cmax[0] - bmin[0], 2 * cmax[1] - bmin[1] };
         _brush_points_recurs_border_gaps(cmax, bmin, NULL, bmax, dpoints, dborder, TRUE);
       }
@@ -761,8 +921,10 @@ static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const
     {
       if(dborder)
       {
-        float bmin[2] = { dt_masks_dynbuf_get(dborder, -2), dt_masks_dynbuf_get(dborder, -1) };
-        float cmax[2] = { dt_masks_dynbuf_get(dpoints, -2), dt_masks_dynbuf_get(dpoints, -1) };
+        float bmin[2] = { dt_masks_dynbuf_get(dborder, -2),
+                          dt_masks_dynbuf_get(dborder, -1) };
+        float cmax[2] = { dt_masks_dynbuf_get(dpoints, -2),
+                          dt_masks_dynbuf_get(dpoints, -1) };
         float bmax[2] = { 2 * cmax[0] - bmin[0], 2 * cmax[1] - bmin[1] };
         _brush_points_recurs_border_gaps(cmax, bmin, NULL, bmax, dpoints, dborder, TRUE);
       }
@@ -779,14 +941,16 @@ static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const
       continue;
     }
 
-    // and we determine all points by recursion (to be sure the distance between 2 points is <=1)
+    // and we determine all points by recursion (to be sure the
+    // distance between 2 points is <=1)
     float rc[2], rb[2], rp[2];
     float bmin[2] = { NAN, NAN };
     float bmax[2] = { NAN, NAN };
     float cmin[2] = { NAN, NAN };
     float cmax[2] = { NAN, NAN };
 
-    _brush_points_recurs(p1, p2, 0.0, 1.0, cmin, cmax, bmin, bmax, rc, rb, rp, dpoints, dborder, dpayload);
+    _brush_points_recurs(p1, p2, 0.0, 1.0, cmin, cmax,
+                         bmin, bmax, rc, rb, rp, dpoints, dborder, dpayload);
 
     dt_masks_dynbuf_add_2(dpoints, rc[0], rc[1]);
 
@@ -814,14 +978,19 @@ static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const
     if(dborder && nb >= 3)
     {
       // we get the next point (start of the next segment)
-      _brush_border_get_XY(p3[0], p3[1], p3[2], p3[3], p4[2], p4[3], p4[0], p4[1], 0, p3[4], cmin, cmin + 1,
+      _brush_border_get_XY(p3[0], p3[1], p3[2], p3[3],
+                           p4[2], p4[3], p4[0], p4[1], 0, p3[4], cmin, cmin + 1,
                            bmax, bmax + 1);
       if(isnan(bmax[0]))
       {
-        _brush_border_get_XY(p3[0], p3[1], p3[2], p3[3], p4[2], p4[3], p4[0], p4[1], 0.0001, p3[4], cmin,
+        _brush_border_get_XY(p3[0], p3[1], p3[2], p3[3],
+                             p4[2], p4[3], p4[0], p4[1], 0.0001, p3[4], cmin,
                              cmin + 1, bmax, bmax + 1);
       }
-      if(bmax[0] - rb[0] > 1 || bmax[0] - rb[0] < -1 || bmax[1] - rb[1] > 1 || bmax[1] - rb[1] < -1)
+      if(bmax[0] - rb[0] > 1
+         || bmax[0] - rb[0] < -1
+         || bmax[1] - rb[1] > 1
+         || bmax[1] - rb[1] < -1)
       {
         // float bmin2[2] = {(*border)[posb-22],(*border)[posb-21]};
         _brush_points_recurs_border_gaps(rc, rb, NULL, bmax, dpoints, dborder, cw);
@@ -859,7 +1028,8 @@ static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] brush_points point recurs %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] brush_points point recurs %0.04f sec\n", form->name,
              dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
@@ -869,12 +1039,17 @@ static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const
   {
     // we transform with all distortion that happen *before* the module
     // so we have now the TARGET points in module input reference
-    if(dt_dev_distort_transform_plus(dev, pipe, iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL, *points, *points_count))
+    if(dt_dev_distort_transform_plus(dev, pipe, iop_order,
+                                     DT_DEV_TRANSFORM_DIR_BACK_EXCL,
+                                     *points, *points_count))
     {
       // now we move all the points by the shift
       // so we have now the SOURCE points in module input reference
       float pts[2] = { form->source[0] * wd, form->source[1] * ht };
-      if(!dt_dev_distort_transform_plus(dev, pipe, iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL, pts, 1)) goto fail;
+      if(!dt_dev_distort_transform_plus(dev, pipe, iop_order,
+                                        DT_DEV_TRANSFORM_DIR_BACK_EXCL,
+                                        pts, 1))
+        goto fail;
 
       dx = pts[0] - (*points)[0];
       dy = pts[1] - (*points)[1];
@@ -891,22 +1066,28 @@ static int _brush_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const
 
       // we apply the rest of the distortions (those after the module)
       // so we have now the SOURCE points in final image reference
-      if(!dt_dev_distort_transform_plus(dev, pipe, iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL, *points,
-                                        *points_count))
+      if(!dt_dev_distort_transform_plus(dev, pipe, iop_order,
+                                        DT_DEV_TRANSFORM_DIR_FORW_INCL,
+                                        *points, *points_count))
         goto fail;
     }
 
     if(darktable.unmuted & DT_DEBUG_PERF)
-      dt_print(DT_DEBUG_MASKS, "[masks %s] path_points end took %0.04f sec\n", form->name, dt_get_wtime() - start2);
+      dt_print(DT_DEBUG_MASKS,
+               "[masks %s] path_points end took %0.04f sec\n",
+               form->name, dt_get_wtime() - start2);
 
     return 1;
   }
-  if(dt_dev_distort_transform_plus(dev, pipe, iop_order, transf_direction, *points, *points_count))
+  if(dt_dev_distort_transform_plus(dev, pipe, iop_order,
+                                   transf_direction, *points, *points_count))
   {
-    if(!border || dt_dev_distort_transform_plus(dev, pipe, iop_order, transf_direction, *border, *border_count))
+    if(!border || dt_dev_distort_transform_plus(dev, pipe, iop_order,
+                                                transf_direction, *border, *border_count))
     {
       if(darktable.unmuted & DT_DEBUG_PERF)
-        dt_print(DT_DEBUG_MASKS, "[masks %s] brush_points transform took %0.04f sec\n", form->name,
+        dt_print(DT_DEBUG_MASKS,
+                 "[masks %s] brush_points transform took %0.04f sec\n", form->name,
                  dt_get_wtime() - start2);
       return 1;
     }
@@ -933,8 +1114,17 @@ fail:
 }
 
 /** get the distance between point (x,y) and the brush */
-static void _brush_get_distance(float x, float y, float as, dt_masks_form_gui_t *gui, int index,
-                                int corner_count, int *inside, int *inside_border, int *near, int *inside_source, float *dist)
+static void _brush_get_distance(const float x,
+                                const float y,
+                                const float as,
+                                dt_masks_form_gui_t *gui,
+                                const int index,
+                                const int corner_count,
+                                int *inside,
+                                int *inside_border,
+                                int *near,
+                                int *inside_source,
+                                float *dist)
 {
   // initialise returned values
   *inside_source = 0;
@@ -945,7 +1135,8 @@ static void _brush_get_distance(float x, float y, float as, dt_masks_form_gui_t 
 
   if(!gui) return;
 
-  dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+  dt_masks_form_gui_points_t *gpt =
+    (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return;
 
   const float as2 = as * as;
@@ -953,7 +1144,8 @@ static void _brush_get_distance(float x, float y, float as, dt_masks_form_gui_t 
   // we first check if we are inside the source form
 
   // add support for clone masks
-  if(gpt->points_count > 2 + corner_count * 3 && gpt->source_count > 2 + corner_count * 3)
+  if(gpt->points_count > 2 + corner_count * 3
+     && gpt->source_count > 2 + corner_count * 3)
   {
     const float dx = -gpt->points[2] + gpt->source[2];
     const float dy = -gpt->points[3] + gpt->source[3];
@@ -1041,19 +1233,30 @@ static void _brush_get_distance(float x, float y, float as, dt_masks_form_gui_t 
     *dist = 0.0f;
 }
 
-static int _brush_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, float **points, int *points_count,
-                                    float **border, int *border_count, int source, const dt_iop_module_t *module)
+static int _brush_get_points_border(dt_develop_t *dev,
+                                    dt_masks_form_t *form,
+                                    float **points,
+                                    int *points_count,
+                                    float **border,
+                                    int *border_count,
+                                    const int source,
+                                    const dt_iop_module_t *module)
 {
   if(source && !module) return 0;
   const double ioporder = (module) ? module->iop_order : 0.0f;
-  return _brush_get_pts_border(dev, form, ioporder, DT_DEV_TRANSFORM_DIR_ALL, dev->preview_pipe, points,
+  return _brush_get_pts_border(dev, form, ioporder,
+                               DT_DEV_TRANSFORM_DIR_ALL, dev->preview_pipe, points,
                                points_count, border, border_count, NULL, NULL, source);
 }
 
-/** find relative position within a brush segment that is closest to the point given by coordinates x and y;
-    we only need to find the minimum with a resolution of 1%, so we just do an exhaustive search without any
-   frills */
-static float _brush_get_position_in_segment(float x, float y, dt_masks_form_t *form, int segment)
+/** find relative position within a brush segment that is closest to
+    the point given by coordinates x and y; we only need to find the
+    minimum with a resolution of 1%, so we just do an exhaustive
+    search without any frills */
+static float _brush_get_position_in_segment(const float x,
+                                            const float y,
+                                            dt_masks_form_t *form,
+                                            const int segment)
 {
   GList *firstpt = g_list_nth(form->points, segment);
   dt_masks_point_brush_t *point0 = (dt_masks_point_brush_t *)firstpt->data;
@@ -1072,8 +1275,10 @@ static float _brush_get_position_in_segment(float x, float y, dt_masks_form_t *f
   {
     const float t = i / 100.0f;
     float sx, sy;
-    _brush_get_XY(point0->corner[0], point0->corner[1], point1->corner[0], point1->corner[1],
-                  point2->corner[0], point2->corner[1], point3->corner[0], point3->corner[1], t, &sx, &sy);
+    _brush_get_XY(point0->corner[0], point0->corner[1],
+                  point1->corner[0], point1->corner[1],
+                  point2->corner[0], point2->corner[1],
+                  point3->corner[0], point3->corner[1], t, &sx, &sy);
 
     const float d = (x - sx) * (x - sx) + (y - sy) * (y - sy);
     if(d < dmin)
@@ -1086,9 +1291,15 @@ static float _brush_get_position_in_segment(float x, float y, dt_masks_form_t *f
   return tmin;
 }
 
-static int _brush_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx, float pzy, int up,
-                                        uint32_t state, dt_masks_form_t *form, int parentid,
-                                        dt_masks_form_gui_t *gui, int index)
+static int _brush_events_mouse_scrolled(struct dt_iop_module_t *module,
+                                        const float pzx,
+                                        const float pzy,
+                                        const int up,
+                                        const uint32_t state,
+                                        dt_masks_form_t *form,
+                                        const int parentid,
+                                        dt_masks_form_gui_t *gui,
+                                        const int index)
 {
   if(gui->creation)
   {
@@ -1157,7 +1368,8 @@ static int _brush_events_mouse_scrolled(struct dt_iop_module_t *module, float pz
         }
 
         // FIXME scale default hardess even when adjusting one point?
-        float masks_hardness = dt_conf_get_float(DT_MASKS_CONF(form->type, brush, hardness));
+        float masks_hardness =
+          dt_conf_get_float(DT_MASKS_CONF(form->type, brush, hardness));
         masks_hardness = MAX(HARDNESS_MIN, MIN(masks_hardness * amount, HARDNESS_MAX));
         dt_conf_set_float(DT_MASKS_CONF(form->type, brush, hardness), masks_hardness);
       }
@@ -1187,7 +1399,8 @@ static int _brush_events_mouse_scrolled(struct dt_iop_module_t *module, float pz
           }
           pts_number++;
         }
-        // FIXME scale default border even when adjusting one point? Not showing toast for point itself?
+        // FIXME scale default border even when adjusting one point?
+        // Not showing toast for point itself?
         float masks_border = dt_conf_get_float(DT_MASKS_CONF(form->type, brush, border));
         masks_border = MAX(BORDER_MIN, MIN(masks_border * amount, BORDER_MAX));
         dt_conf_set_float(DT_MASKS_CONF(form->type, brush, border), masks_border);
@@ -1379,7 +1592,8 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module,
       if(dt_modifier_is(state, GDK_CONTROL_MASK) && gui->seg_selected < nb - 1)
       {
         // we add a new point to the brush
-        dt_masks_point_brush_t *bzpt = (dt_masks_point_brush_t *)(malloc(sizeof(dt_masks_point_brush_t)));
+        dt_masks_point_brush_t *bzpt =
+          (dt_masks_point_brush_t *)(malloc(sizeof(dt_masks_point_brush_t)));
 
         const float wd = darktable.develop->preview_pipe->backbuf_width;
         const float ht = darktable.develop->preview_pipe->backbuf_height;
@@ -1392,9 +1606,11 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module,
         bzpt->ctrl1[0] = bzpt->ctrl1[1] = bzpt->ctrl2[0] = bzpt->ctrl2[1] = -1.0;
         bzpt->state = DT_MASKS_POINT_STATE_NORMAL;
 
-        // set other attributes of the new point. we interpolate the starting and the end point of that
-        // segment
-        const float t = _brush_get_position_in_segment(bzpt->corner[0], bzpt->corner[1], form, gui->seg_selected);
+        // set other attributes of the new point. we interpolate the
+        // starting and the end point of that segment
+        const float t = _brush_get_position_in_segment(bzpt->corner[0],
+                                                       bzpt->corner[1],
+                                                       form, gui->seg_selected);
         // start and end point of the segment
         GList *pt = g_list_nth(form->points, gui->seg_selected);
         dt_masks_point_brush_t *point0 = (dt_masks_point_brush_t *)pt->data;
@@ -1407,7 +1623,8 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module,
         form->points = g_list_insert(form->points, bzpt, gui->seg_selected + 1);
         _brush_init_ctrl_points(form);
         dt_masks_gui_form_create(form, gui, index, module);
-        gui->point_edited = gui->point_dragging = gui->point_selected = gui->seg_selected + 1;
+        gui->point_edited = gui->point_dragging =
+          gui->point_selected = gui->seg_selected + 1;
         gui->seg_selected = -1;
         dt_control_queue_redraw_center();
       }
@@ -1455,7 +1672,9 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module,
       {
         const int emode = gui->edit_mode;
         dt_masks_clear_form_gui(darktable.develop);
-        for(GList *forms = darktable.develop->form_visible->points; forms; forms = g_list_next(forms))
+        for(GList *forms = darktable.develop->form_visible->points;
+            forms;
+            forms = g_list_next(forms))
         {
           dt_masks_point_group_t *guipt = (dt_masks_point_group_t *)forms->data;
           if(guipt->formid == form->formid)
@@ -1519,7 +1738,10 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module,
     else
     {
       dt_masks_clear_form_gui(darktable.develop);
-      for(GList *forms = darktable.develop->form_visible->points; forms; forms = g_list_next(forms))
+
+      for(GList *forms = darktable.develop->form_visible->points;
+          forms;
+          forms = g_list_next(forms))
       {
         dt_masks_point_group_t *guipt = (dt_masks_point_group_t *)forms->data;
         if(guipt->formid == form->formid)
@@ -1903,9 +2125,15 @@ static int _brush_events_button_released(struct dt_iop_module_t *module,
   return 0;
 }
 
-static int _brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx, float pzy, double pressure,
-                                     int which, dt_masks_form_t *form, int parentid,
-                                     dt_masks_form_gui_t *gui, int index)
+static int _brush_events_mouse_moved(struct dt_iop_module_t *module,
+                                     float pzx,
+                                     float pzy,
+                                     const double pressure,
+                                     const int which,
+                                     dt_masks_form_t *form,
+                                     const int parentid,
+                                     dt_masks_form_gui_t *gui,
+                                     const int index)
 {
   const dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
   const int closeup = dt_control_get_dev_closeup();
@@ -1913,14 +2141,16 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx, 
   const float as = DT_PIXEL_APPLY_DPI(5) / zoom_scale;
 
   if(!gui) return 0;
-  dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+  dt_masks_form_gui_points_t *gpt =
+    (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return 0;
 
   if(gui->creation)
   {
     if(gui->guipoints)
     {
-      dt_masks_dynbuf_add_2(gui->guipoints, pzx * darktable.develop->preview_pipe->backbuf_width,
+      dt_masks_dynbuf_add_2(gui->guipoints,
+                            pzx * darktable.develop->preview_pipe->backbuf_width,
                             pzy * darktable.develop->preview_pipe->backbuf_height);
       const float border = dt_masks_dynbuf_get(gui->guipoints_payload, -4);
       const float hardness = dt_masks_dynbuf_get(gui->guipoints_payload, -3);
@@ -2036,11 +2266,13 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx, 
 
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
-    dt_masks_point_brush_t *point = (dt_masks_point_brush_t *)g_list_nth_data(form->points, k);
+    dt_masks_point_brush_t *point =
+      (dt_masks_point_brush_t *)g_list_nth_data(form->points, k);
     const float nx = point->corner[0] * darktable.develop->preview_pipe->iwidth;
     const float ny = point->corner[1] * darktable.develop->preview_pipe->iheight;
     const float nr = sqrtf((pts[0] - nx) * (pts[0] - nx) + (pts[1] - ny) * (pts[1] - ny));
-    const float bdr = nr / fminf(darktable.develop->preview_pipe->iwidth, darktable.develop->preview_pipe->iheight);
+    const float bdr = nr / fminf(darktable.develop->preview_pipe->iwidth,
+                                 darktable.develop->preview_pipe->iheight);
 
     point->border[0] = point->border[1] = bdr;
 
@@ -2106,8 +2338,11 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx, 
        && gpt->points[k * 6 + 3] != gpt->points[k * 6 + 5])
     {
       float ffx, ffy;
-      _brush_ctrl2_to_feather(gpt->points[k * 6 + 2], gpt->points[k * 6 + 3], gpt->points[k * 6 + 4],
-                              gpt->points[k * 6 + 5], &ffx, &ffy, TRUE);
+      _brush_ctrl2_to_feather(gpt->points[k * 6 + 2],
+                              gpt->points[k * 6 + 3],
+                              gpt->points[k * 6 + 4],
+                              gpt->points[k * 6 + 5],
+                              &ffx, &ffy, TRUE);
       if(pzx - ffx > -as && pzx - ffx < as && pzy - ffy > -as && pzy - ffy < as)
       {
         gui->feather_selected = k;
@@ -2224,8 +2459,10 @@ static void _brush_events_post_expose(cairo_t *cr,
       if((gui->posx == -1.0f && gui->posy == -1.0f)
          || gui->mouse_leaved_center)
       {
-        xpos = (.5f + dt_control_get_dev_zoom_x()) * darktable.develop->preview_pipe->backbuf_width;
-        ypos = (.5f + dt_control_get_dev_zoom_y()) * darktable.develop->preview_pipe->backbuf_height;
+        xpos = (.5f + dt_control_get_dev_zoom_x())
+          * darktable.develop->preview_pipe->backbuf_width;
+        ypos = (.5f + dt_control_get_dev_zoom_y())
+          * darktable.develop->preview_pipe->backbuf_height;
       }
       else
       {
@@ -2257,7 +2494,8 @@ static void _brush_events_post_expose(cairo_t *cr,
     else
     {
       float masks_border = 0.0f, masks_hardness = 0.0f, masks_density = 0.0f;
-      float radius = 0.0f, oldradius = 0.0f, opacity = 0.0f, oldopacity = 0.0f, pressure = 0.0f;
+      float radius = 0.0f, oldradius = 0.0f, opacity = 0.0f;
+      float oldopacity = 0.0f, pressure = 0.0f;
       int stroked = 1;
 
       const float *guipoints = dt_masks_dynbuf_buffer(gui->guipoints);
@@ -2359,7 +2597,8 @@ static void _brush_events_post_expose(cairo_t *cr,
       cairo_stroke(cr);
       cairo_set_dash(cr, dashed, len, 0);
       cairo_arc(cr, guipoints[2 * (gui->guipoints_count - 1)],
-                guipoints[2 * (gui->guipoints_count - 1) + 1], masks_border * min_iwd_iht, 0,
+                guipoints[2 * (gui->guipoints_count - 1) + 1],
+                masks_border * min_iwd_iht, 0,
                 2.0 * M_PI);
       cairo_stroke(cr);
 
@@ -2368,7 +2607,8 @@ static void _brush_events_post_expose(cairo_t *cr,
       {
         const int i = gui->guipoints_count - 1;
         float x = 0.0f, y = 0.0f;
-        dt_masks_calculate_source_pos_value(gui, DT_MASKS_BRUSH, guipoints[0], guipoints[1], guipoints[i * 2],
+        dt_masks_calculate_source_pos_value(gui, DT_MASKS_BRUSH,
+                                            guipoints[0], guipoints[1], guipoints[i * 2],
                                             guipoints[i * 2 + 1], &x, &y, TRUE);
         dt_masks_draw_clone_source_pos(cr, zoom_scale, x, y);
       }
@@ -2421,8 +2661,11 @@ static void _brush_events_post_expose(cairo_t *cr,
   if(gui->group_selected == index && gpt->points_count > nb * 3 + 2)
   {
     for(int k = 0; k < nb; k++)
-      dt_masks_draw_anchor(cr, k == gui->point_dragging || k == gui->point_selected, zoom_scale,
-                           gpt->points[k * 6 + 2], gpt->points[k * 6 + 3]);
+      dt_masks_draw_anchor(cr,
+                           k == gui->point_dragging || k == gui->point_selected,
+                           zoom_scale,
+                           gpt->points[k * 6 + 2],
+                           gpt->points[k * 6 + 3]);
   }
 
   // draw feathers
@@ -2437,8 +2680,11 @@ static void _brush_events_post_expose(cairo_t *cr,
     cairo_line_to(cr, gui->points[k*6+4]+dx,gui->points[k*6+5]+dy);
     cairo_stroke(cr);*/
     float ffx, ffy;
-    _brush_ctrl2_to_feather(gpt->points[k * 6 + 2], gpt->points[k * 6 + 3], gpt->points[k * 6 + 4],
-                            gpt->points[k * 6 + 5], &ffx, &ffy, TRUE);
+    _brush_ctrl2_to_feather(gpt->points[k * 6 + 2],
+                            gpt->points[k * 6 + 3],
+                            gpt->points[k * 6 + 4],
+                            gpt->points[k * 6 + 5],
+                            &ffx, &ffy, TRUE);
     cairo_move_to(cr, gpt->points[k * 6 + 2], gpt->points[k * 6 + 3]);
     cairo_line_to(cr, ffx, ffy);
     cairo_set_line_width(cr, 1.5 / zoom_scale);
@@ -2448,7 +2694,9 @@ static void _brush_events_post_expose(cairo_t *cr,
     dt_draw_set_color_overlay(cr, TRUE, 0.8);
     cairo_stroke(cr);
 
-    if((gui->group_selected == index) && (k == gui->feather_dragging || k == gui->feather_selected))
+    if((gui->group_selected == index)
+       && (k == gui->feather_dragging
+           || k == gui->feather_selected))
       cairo_arc(cr, ffx, ffy, 3.0f / zoom_scale, 0, 2.0 * M_PI);
     else
       cairo_arc(cr, ffx, ffy, 1.5f / zoom_scale, 0, 2.0 * M_PI);
@@ -2544,7 +2792,8 @@ static void _brush_events_post_expose(cairo_t *cr,
       cairo_set_line_width(cr, 1.5 / zoom_scale);
     dt_draw_set_color_overlay(cr, FALSE, 0.8);
     cairo_move_to(cr, gpt->source[nb * 6], gpt->source[nb * 6 + 1]);
-    for(int i = nb * 3; i < gpt->source_count; i++) cairo_line_to(cr, gpt->source[i * 2], gpt->source[i * 2 + 1]);
+    for(int i = nb * 3; i < gpt->source_count; i++)
+      cairo_line_to(cr, gpt->source[i * 2], gpt->source[i * 2 + 1]);
     cairo_line_to(cr, gpt->source[nb * 6], gpt->source[nb * 6 + 1]);
     cairo_stroke_preserve(cr);
     if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
@@ -2556,8 +2805,14 @@ static void _brush_events_post_expose(cairo_t *cr,
   }
 }
 
-static void _brush_bounding_box_raw(const float *const points, const float *const border, const int nb_corner,
-                                    const int num_points, float *x_min, float *x_max, float *y_min, float *y_max)
+static void _brush_bounding_box_raw(const float *const points,
+                                    const float *const border,
+                                    const int nb_corner,
+                                    const int num_points,
+                                    float *x_min,
+                                    float *x_max,
+                                    float *y_min,
+                                    float *y_max)
 {
   // now we want to find the area, so we search min/max points
   float xmin = FLT_MAX, xmax = FLT_MIN, ymin = FLT_MAX, ymax = FLT_MIN;
@@ -2588,25 +2843,40 @@ static void _brush_bounding_box_raw(const float *const points, const float *cons
   *y_max = ymax;
 }
 
-static void _brush_bounding_box(const float *const points, const float *const border, const int nb_corner,
-                                const int num_points, int *width, int *height, int *posx, int *posy)
+static void _brush_bounding_box(const float *const points,
+                                const float *const border,
+                                const int nb_corner,
+                                const int num_points,
+                                int *width,
+                                int *height,
+                                int *posx,
+                                int *posy)
 {
   float xmin = FLT_MAX, xmax = FLT_MIN, ymin = FLT_MAX, ymax = FLT_MIN;
-  _brush_bounding_box_raw(points, border, nb_corner, num_points, &xmin, &xmax, &ymin, &ymax);
+  _brush_bounding_box_raw(points, border, nb_corner, num_points,
+                          &xmin, &xmax, &ymin, &ymax);
   *height = ymax - ymin + 4;
   *width = xmax - xmin + 4;
   *posx = xmin - 2;
   *posy = ymin - 2;
 }
 
-static int _get_area(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
-                     dt_masks_form_t *const form, int *width, int *height, int *posx, int *posy, int get_source)
+static int _get_area(const dt_iop_module_t *const module,
+                     const dt_dev_pixelpipe_iop_t *const piece,
+                     dt_masks_form_t *const form,
+                     int *width,
+                     int *height,
+                     int *posx,
+                     int *posy,
+                     const int get_source)
 {
   if(!module) return 0;
   // we get buffers for all points
   float *points = NULL, *border = NULL;
   int points_count, border_count;
-  if(!_brush_get_pts_border(module->dev, form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, piece->pipe, &points, &points_count,
+  if(!_brush_get_pts_border(module->dev, form, module->iop_order,
+                            DT_DEV_TRANSFORM_DIR_BACK_INCL,
+                            piece->pipe, &points, &points_count,
                             &border, &border_count, NULL, NULL, get_source))
   {
     dt_free_align(points);
@@ -2622,24 +2892,41 @@ static int _get_area(const dt_iop_module_t *const module, const dt_dev_pixelpipe
   return 1;
 }
 
-static int _brush_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece,
-                                  dt_masks_form_t *form, int *width, int *height, int *posx, int *posy)
+static int _brush_get_source_area(dt_iop_module_t *module,
+                                  dt_dev_pixelpipe_iop_t *piece,
+                                  dt_masks_form_t *form,
+                                  int *width,
+                                  int *height,
+                                  int *posx,
+                                  int *posy)
 {
   return _get_area(module, piece, form, width, height, posx, posy, 1);
 }
 
-static int _brush_get_area(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
-                           dt_masks_form_t *const form, int *width, int *height, int *posx, int *posy)
+static int _brush_get_area(const dt_iop_module_t *const module,
+                           const dt_dev_pixelpipe_iop_t *const piece,
+                           dt_masks_form_t *const form,
+                           int *width,
+                           int *height,
+                           int *posx,
+                           int *posy)
 {
   return _get_area(module, piece, form, width, height, posx, posy, 0);
 }
 
 /** we write a falloff segment */
-static void _brush_falloff(float *const restrict buffer, int p0[2], int p1[2], int posx, int posy, int bw,
-                           float hardness, float density)
+static void _brush_falloff(float *const restrict buffer,
+                           int p0[2],
+                           int p1[2],
+                           const int posx,
+                           const int posy,
+                           const int bw,
+                           const float hardness,
+                           const float density)
 {
   // segment length
-  const int l = sqrt((p1[0] - p0[0]) * (p1[0] - p0[0]) + (p1[1] - p0[1]) * (p1[1] - p0[1])) + 1;
+  const int l = sqrt((p1[0] - p0[0])
+                     * (p1[0] - p0[0]) + (p1[1] - p0[1]) * (p1[1] - p0[1])) + 1;
   const int solid = (int)l * hardness;
   const int soft = l - solid;
 
@@ -2651,20 +2938,32 @@ static void _brush_falloff(float *const restrict buffer, int p0[2], int p1[2], i
     // position
     const int x = (int)((float)i * lx / (float)l) + p0[0] - posx;
     const int y = (int)((float)i * ly / (float)l) + p0[1] - posy;
-    const float op = density * ((i <= solid) ? 1.0f : 1.0 - (float)(i - solid) / (float)soft);
+    const float op = density * ((i <= solid)
+                                ? 1.0f
+                                : 1.0 - (float)(i - solid) / (float)soft);
+
     buffer[y * bw + x] = MAX(buffer[y * bw + x], op);
     if(x > 0)
       buffer[y * bw + x - 1]
-          = MAX(buffer[y * bw + x - 1], op); // this one is to avoid gap due to int rounding
+          = MAX(buffer[y * bw + x - 1], op); // this one is to avoid
+                                             // gap due to int
+                                             // rounding
     if(y > 0)
       buffer[(y - 1) * bw + x]
-          = MAX(buffer[(y - 1) * bw + x], op); // this one is to avoid gap due to int rounding
+          = MAX(buffer[(y - 1) * bw + x], op); // this one is to avoid
+                                               // gap due to int
+                                               // rounding
   }
 }
 
-static int _brush_get_mask(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
+static int _brush_get_mask(const dt_iop_module_t *const module,
+                           const dt_dev_pixelpipe_iop_t *const piece,
                            dt_masks_form_t *const form,
-                           float **buffer, int *width, int *height, int *posx, int *posy)
+                           float **buffer,
+                           int *width,
+                           int *height,
+                           int *posx,
+                           int *posy)
 {
   if(!module) return 0;
   double start = 0.0;
@@ -2674,8 +2973,10 @@ static int _brush_get_mask(const dt_iop_module_t *const module, const dt_dev_pix
   // we get buffers for all points
   float *points = NULL, *border = NULL, *payload = NULL;
   int points_count, border_count, payload_count;
-  if(!_brush_get_pts_border(module->dev, form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, piece->pipe,&points, &points_count,
-                               &border, &border_count, &payload, &payload_count, 0))
+  if(!_brush_get_pts_border(module->dev, form, module->iop_order,
+                            DT_DEV_TRANSFORM_DIR_BACK_INCL,
+                            piece->pipe,&points, &points_count,
+                            &border, &border_count, &payload, &payload_count, 0))
   {
     dt_free_align(points);
     dt_free_align(border);
@@ -2685,7 +2986,9 @@ static int _brush_get_mask(const dt_iop_module_t *const module, const dt_dev_pix
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] brush points took %0.04f sec\n", form->name, dt_get_wtime() - start2);
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] brush points took %0.04f sec\n",
+             form->name, dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
 
@@ -2693,12 +2996,14 @@ static int _brush_get_mask(const dt_iop_module_t *const module, const dt_dev_pix
   _brush_bounding_box(points, border, nb_corner, points_count, width, height, posx, posy);
 
   if(darktable.unmuted & DT_DEBUG_PERF)
-    dt_print(DT_DEBUG_MASKS, "[masks %s] brush_fill min max took %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] brush_fill min max took %0.04f sec\n", form->name,
              dt_get_wtime() - start2);
 
   // we allocate the buffer
   const size_t bufsize = (size_t)(*width) * (*height);
-  // ensure that the buffer is zeroed, as the below code only fills in pixels in the falloff region
+  // ensure that the buffer is zeroed, as the below code only fills in
+  // pixels in the falloff region
   *buffer = dt_calloc_align_float(bufsize);
   if(*buffer == NULL)
   {
@@ -2718,7 +3023,8 @@ static int _brush_get_mask(const dt_iop_module_t *const module, const dt_dev_pix
     p1[0] = border[i * 2];
     p1[1] = border[i * 2 + 1];
 
-    _brush_falloff(*buffer, p0, p1, *posx, *posy, *width, payload[i * 2], payload[i * 2 + 1]);
+    _brush_falloff(*buffer, p0, p1, *posx, *posy, *width,
+                   payload[i * 2], payload[i * 2 + 1]);
   }
 
   dt_free_align(points);
@@ -2733,11 +3039,18 @@ static int _brush_get_mask(const dt_iop_module_t *const module, const dt_dev_pix
 }
 
 /** we write a falloff segment respecting limits of buffer */
-static inline void _brush_falloff_roi(float *buffer, const int *p0, const int *p1, int bw, int bh, float hardness,
-                                      float density)
+static inline void _brush_falloff_roi(float *buffer,
+                                      const int *p0,
+                                      const int *p1,
+                                      const int bw,
+                                      const int bh,
+                                      const float hardness,
+                                      const float density)
 {
-  // segment length (increase by 1 to avoid division-by-zero special case handling)
-  const int l = sqrt((p1[0] - p0[0]) * (p1[0] - p0[0]) + (p1[1] - p0[1]) * (p1[1] - p0[1])) + 1;
+  // segment length (increase by 1 to avoid division-by-zero special
+  // case handling)
+  const int l = sqrt((p1[0] - p0[0])
+                     * (p1[0] - p0[0]) + (p1[1] - p0[1]) * (p1[1] - p0[1])) + 1;
   const int solid = hardness * l;
 
   const float lx = (float)(p1[0] - p0[0]) / (float)l;
@@ -2839,11 +3152,13 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module,
 
 
   float xmin = 0.0f, xmax = 0.0f, ymin = 0.0f, ymax = 0.0f;
-  _brush_bounding_box_raw(points, border, nb_corner, points_count, &xmin, &xmax, &ymin, &ymax);
+  _brush_bounding_box_raw(points, border, nb_corner,
+                          points_count, &xmin, &xmax, &ymin, &ymax);
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] brush_fill min max took %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] brush_fill min max took %0.04f sec\n", form->name,
              dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
@@ -2897,9 +3212,12 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module,
 static GSList *_brush_setup_mouse_actions(const struct dt_masks_form_t *const form)
 {
   GSList *lm = NULL;
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, 0, _("[BRUSH] change size"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_SHIFT_MASK, _("[BRUSH] change hardness"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_CONTROL_MASK, _("[BRUSH] change opacity"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL,
+                                     0, _("[BRUSH] change size"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL,
+                                     GDK_SHIFT_MASK, _("[BRUSH] change hardness"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL,
+                                     GDK_CONTROL_MASK, _("[BRUSH] change opacity"));
   return lm;
 }
 
@@ -2908,15 +3226,20 @@ static void _brush_sanitize_config(dt_masks_type_t type)
   // nothing to do (yet?)
 }
 
-static void _brush_set_form_name(struct dt_masks_form_t *const form, const size_t nb)
+static void _brush_set_form_name(struct dt_masks_form_t *const form,
+                                 const size_t nb)
 {
   snprintf(form->name, sizeof(form->name), _("brush #%d"), (int)nb);
 }
 
-static void _brush_set_hint_message(const dt_masks_form_gui_t *const gui, const dt_masks_form_t *const form,
-                                     const int opacity, char *const restrict msgbuf, const size_t msgbuf_len)
+static void _brush_set_hint_message(const dt_masks_form_gui_t *const gui,
+                                    const dt_masks_form_t *const form,
+                                    const int opacity,
+                                    char *const restrict msgbuf,
+                                    const size_t msgbuf_len)
 {
-  // TODO: check if it would be good idea to have same controls on creation and for selected brush
+  // TODO: check if it would be good idea to have same controls on
+  // creation and for selected brush
   if(gui->creation || gui->form_selected)
     g_snprintf(msgbuf, msgbuf_len,
                _("<b>size</b>: scroll, <b>hardness</b>: shift+scroll\n"
@@ -2925,25 +3248,38 @@ static void _brush_set_hint_message(const dt_masks_form_gui_t *const gui, const 
     g_strlcat(msgbuf, _("<b>size</b>: scroll"), msgbuf_len);
 }
 
-static void _brush_duplicate_points(dt_develop_t *const dev, dt_masks_form_t *const base, dt_masks_form_t *const dest)
+static void _brush_duplicate_points(dt_develop_t *const dev,
+                                    dt_masks_form_t *const base,
+                                    dt_masks_form_t *const dest)
 {
   (void)dev; // unused arg, keep compiler from complaining
   for(GList *pts = base->points; pts; pts = g_list_next(pts))
   {
     dt_masks_point_brush_t *pt = (dt_masks_point_brush_t *)pts->data;
-    dt_masks_point_brush_t *npt = (dt_masks_point_brush_t *)malloc(sizeof(dt_masks_point_brush_t));
+    dt_masks_point_brush_t *npt =
+      (dt_masks_point_brush_t *)malloc(sizeof(dt_masks_point_brush_t));
     memcpy(npt, pt, sizeof(dt_masks_point_brush_t));
     dest->points = g_list_append(dest->points, npt);
   }
 }
 
-static void _brush_initial_source_pos(const float iwd, const float iht, float *x, float *y)
+static void _brush_initial_source_pos(const float iwd,
+                                      const float iht,
+                                      float *x,
+                                      float *y)
 {
   *x = 0.01f * iwd;
   *y = 0.01f * iht;
 }
 
-static void _brush_modify_property(dt_masks_form_t *const form, dt_masks_property_t prop, float old_val, float new_val, float *sum, int *count, float *min, float *max)
+static void _brush_modify_property(dt_masks_form_t *const form,
+                                   dt_masks_property_t prop,
+                                   const float old_val,
+                                   const float new_val,
+                                   float *sum,
+                                   int *count,
+                                   float *min,
+                                   float *max)
 {
   float ratio = (!old_val || !new_val) ? 1.0f : new_val / old_val;
 
@@ -2975,8 +3311,10 @@ static void _brush_modify_property(dt_masks_form_t *const form, dt_masks_propert
             point->border[0] = CLAMP(point->border[0] * ratio, BORDER_MIN, BORDER_MAX);
             point->border[1] = CLAMP(point->border[1] * ratio, BORDER_MIN, BORDER_MAX);
             *sum += point->border[0] + point->border[1];
-            *max = fminf(*max, fminf(BORDER_MAX / point->border[0], BORDER_MAX / point->border[1]));
-            *min = fmaxf(*min, fmaxf(BORDER_MIN / point->border[0], BORDER_MIN / point->border[1]));
+            *max = fminf(*max, fminf(BORDER_MAX / point->border[0],
+                                     BORDER_MAX / point->border[1]));
+            *min = fmaxf(*min, fmaxf(BORDER_MIN / point->border[0],
+                                     BORDER_MIN / point->border[1]));
             ++*count;
           }
           pts_number++;
@@ -2986,7 +3324,8 @@ static void _brush_modify_property(dt_masks_form_t *const form, dt_masks_propert
     case DT_MASKS_PROPERTY_HARDNESS:
       if(gui->creation)
       {
-        float masks_hardness = dt_conf_get_float(DT_MASKS_CONF(form->type, brush, hardness));
+        float masks_hardness =
+          dt_conf_get_float(DT_MASKS_CONF(form->type, brush, hardness));
         masks_hardness = MAX(HARDNESS_MIN, MIN(masks_hardness * ratio, HARDNESS_MAX));
         dt_conf_set_float(DT_MASKS_CONF(form->type, brush, hardness), masks_hardness);
 

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1682,7 +1682,8 @@ static int _brush_events_button_released(struct dt_iop_module_t *module,
       dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid);
       gui->creation_module = NULL;
 
-      if(gui->creation_continuous)
+      if(crea_module
+         && gui->creation_continuous)
       {
         //spot and retouch manage creation_continuous in their own way
         if(strcmp(crea_module->so->op, "spots") != 0

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1684,11 +1684,11 @@ static int _brush_events_button_released(struct dt_iop_module_t *module,
       dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid);
       gui->creation_module = NULL;
 
-      if(crea_module
-         && gui->creation_continuous)
+      if(gui->creation_continuous)
       {
         //spot and retouch manage creation_continuous in their own way
-        if(!dt_iop_module_is(crea_module->so, "spots")
+        if(crea_module
+           && !dt_iop_module_is(crea_module->so, "spots")
            && !dt_iop_module_is(crea_module->so, "retouch"))
         {
           dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)crea_module->blend_data;

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1207,27 +1207,44 @@ static int _brush_events_mouse_scrolled(struct dt_iop_module_t *module, float pz
   return 0;
 }
 
-static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pzx, float pzy,
-                                        double pressure, int which, int type, uint32_t state,
-                                        dt_masks_form_t *form, int parentid, dt_masks_form_gui_t *gui, int index)
+static int _brush_events_button_pressed(struct dt_iop_module_t *module,
+                                        const float pzx,
+                                        const float pzy,
+                                        const double pressure,
+                                        const int which,
+                                        const int type,
+                                        const uint32_t state,
+                                        dt_masks_form_t *form,
+                                        const int parentid,
+                                        dt_masks_form_gui_t *gui,
+                                        const int index)
 {
   if(type == GDK_2BUTTON_PRESS || type == GDK_3BUTTON_PRESS) return 1;
   if(!gui) return 0;
-  dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+  dt_masks_form_gui_points_t *gpt =
+    (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return 0;
 
-  float masks_border = MIN(dt_conf_get_float(DT_MASKS_CONF(form->type, brush, border)), BORDER_MAX);
+  const float masks_border =
+    MIN(dt_conf_get_float(DT_MASKS_CONF(form->type, brush, border)),
+        BORDER_MAX);
 
-  float masks_hardness = MIN(dt_conf_get_float(DT_MASKS_CONF(form->type, brush, hardness)), HARDNESS_MAX);
+  const float masks_hardness =
+    MIN(dt_conf_get_float(DT_MASKS_CONF(form->type, brush, hardness)),
+        HARDNESS_MAX);
 
-  // always start with a mask density of 100%, it will be adjusted with pen pressure if used.
+  // always start with a mask density of 100%, it will be adjusted
+  // with pen pressure if used.
   const float masks_density = 1.0f;
 
-  if(gui->creation && which == 1
-     && (dt_modifier_is(state, GDK_CONTROL_MASK | GDK_SHIFT_MASK) || dt_modifier_is(state, GDK_SHIFT_MASK)))
+  if(gui->creation
+     && which == 1
+     && (dt_modifier_is(state, GDK_CONTROL_MASK | GDK_SHIFT_MASK)
+         || dt_modifier_is(state, GDK_SHIFT_MASK)))
   {
     // set some absolute or relative position for the source of the clone mask
-    if(form->type & DT_MASKS_CLONE) dt_masks_set_source_pos_initial_state(gui, state, pzx, pzy);
+    if(form->type & DT_MASKS_CLONE)
+      dt_masks_set_source_pos_initial_state(gui, state, pzx, pzy);
 
     return 1;
   }
@@ -1238,10 +1255,14 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
       const float wd = darktable.develop->preview_pipe->backbuf_width;
       const float ht = darktable.develop->preview_pipe->backbuf_height;
 
-      if(!gui->guipoints) gui->guipoints = dt_masks_dynbuf_init(200000, "brush guipoints");
-      if(!gui->guipoints) return 1;
-      if(!gui->guipoints_payload) gui->guipoints_payload = dt_masks_dynbuf_init(400000, "brush guipoints_payload");
-      if(!gui->guipoints_payload) return 1;
+      if(!gui->guipoints)
+        gui->guipoints = dt_masks_dynbuf_init(200000, "brush guipoints");
+      if(!gui->guipoints)
+        return 1;
+      if(!gui->guipoints_payload)
+        gui->guipoints_payload = dt_masks_dynbuf_init(400000, "brush guipoints_payload");
+      if(!gui->guipoints_payload)
+        return 1;
       dt_masks_dynbuf_add_2(gui->guipoints, pzx * wd, pzy * ht);
       dt_masks_dynbuf_add_2(gui->guipoints_payload, masks_border, masks_hardness);
       dt_masks_dynbuf_add_2(gui->guipoints_payload, masks_density, pressure);
@@ -1278,9 +1299,11 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
       dt_control_queue_redraw_center();
       return 1;
     }
-    else if(gui->source_selected && gui->edit_mode == DT_MASKS_EDIT_FULL)
+    else if(gui->source_selected
+            && gui->edit_mode == DT_MASKS_EDIT_FULL)
     {
-      dt_masks_form_gui_points_t *guipt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+      dt_masks_form_gui_points_t *guipt =
+        (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
       if(!guipt) return 0;
       // we start the form dragging
       gui->source_dragging = TRUE;
@@ -1288,7 +1311,8 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
       gui->dy = guipt->source[1] - gui->posy;
       return 1;
     }
-    else if(gui->form_selected && gui->edit_mode == DT_MASKS_EDIT_FULL)
+    else if(gui->form_selected
+            && gui->edit_mode == DT_MASKS_EDIT_FULL)
     {
       gui->form_dragging = TRUE;
       gui->point_edited = -1;
@@ -1299,7 +1323,8 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
     else if(gui->point_selected >= 0)
     {
       // if ctrl is pressed, we change the type of point
-      if(gui->point_edited == gui->point_selected && dt_modifier_is(state, GDK_CONTROL_MASK))
+      if(gui->point_edited == gui->point_selected
+         && dt_modifier_is(state, GDK_CONTROL_MASK))
       {
         dt_masks_point_brush_t *point
             = (dt_masks_point_brush_t *)g_list_nth_data(form->points, gui->point_edited);
@@ -1323,7 +1348,9 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
         return 1;
       }
       // we register the current position to avoid accidental move
-      if(gui->point_edited < 0 && gui->scrollx == 0.0f && gui->scrolly == 0.0f)
+      if(gui->point_edited < 0
+         && gui->scrollx == 0.0f
+         && gui->scrolly == 0.0f)
       {
         gui->scrollx = pzx;
         gui->scrolly = pzy;
@@ -1514,19 +1541,30 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module, float pz
   return 0;
 }
 
-static int _brush_events_button_released(struct dt_iop_module_t *module, float pzx, float pzy, int which,
-                                         uint32_t state, dt_masks_form_t *form, int parentid,
-                                         dt_masks_form_gui_t *gui, int index)
+static int _brush_events_button_released(struct dt_iop_module_t *module,
+                                         const float pzx,
+                                         const float pzy,
+                                         const int which,
+                                         const uint32_t state,
+                                         dt_masks_form_t *form,
+                                         const int parentid,
+                                         dt_masks_form_gui_t *gui,
+                                         const int index)
 {
   if(!gui) return 0;
 
-  dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+  dt_masks_form_gui_points_t *gpt =
+    (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return 0;
 
-  float masks_border = MIN(dt_conf_get_float(DT_MASKS_CONF(form->type, brush, border)), BORDER_MAX);
+  const float masks_border =
+    MIN(dt_conf_get_float(DT_MASKS_CONF(form->type, brush, border)),
+        BORDER_MAX);
 
-  if(gui->creation && which == 1 &&
-     (dt_modifier_is(state, GDK_SHIFT_MASK) || dt_modifier_is(state, GDK_CONTROL_MASK | GDK_SHIFT_MASK)))
+  if(gui->creation
+     && which == 1
+     && (dt_modifier_is(state, GDK_SHIFT_MASK)
+         || dt_modifier_is(state, GDK_CONTROL_MASK | GDK_SHIFT_MASK)))
   {
     // user just set the source position, so just return
     return 1;
@@ -1535,8 +1573,8 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
   {
     if(gui->guipoints && gui->guipoints_count > 0)
     {
-      // if the path consists only of one x/y pair we add a second one close so we don't need to deal with
-      // this special case later
+      // if the path consists only of one x/y pair we add a second one
+      // close so we don't need to deal with this special case later
       if(gui->guipoints_count == 1)
       {
         // add a helper node very close to the single spot
@@ -1605,12 +1643,14 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
         factor = 0.04f;
 
       // accuracy level for node elimination, dependent on brush size
-      const float epsilon2 = factor * MAX(BORDER_MIN, masks_border) * MAX(BORDER_MIN, masks_border);
+      const float epsilon2 =
+        factor
+        * MAX(BORDER_MIN, masks_border)
+        * MAX(BORDER_MIN, masks_border);
 
       // we simplify the path and generate the nodes
-      form->points = _brush_ramer_douglas_peucker(guipoints, gui->guipoints_count, guipoints_payload, epsilon2);
-
-      // printf("guipoints_count %d, points %d\n", gui->guipoints_count, g_list_length(form->points));
+      form->points = _brush_ramer_douglas_peucker(guipoints, gui->guipoints_count,
+                                                  guipoints_payload, epsilon2);
 
       _brush_init_ctrl_points(form);
 
@@ -1630,7 +1670,9 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
         dt_dev_add_history_item(darktable.develop, crea_module, TRUE);
         // and we switch in edit mode to show all the forms
         // spots and retouch have their own handling of creation_continuous
-        if(gui->creation_continuous && ( strcmp(crea_module->so->op, "spots") == 0 || strcmp(crea_module->so->op, "retouch") == 0))
+        if(gui->creation_continuous
+           && ( strcmp(crea_module->so->op, "spots") == 0
+                || strcmp(crea_module->so->op, "retouch") == 0))
           dt_masks_set_edit_mode_single_form(crea_module, form->formid, DT_MASKS_EDIT_FULL);
         else if(!gui->creation_continuous)
           dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
@@ -1643,7 +1685,8 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
       if(gui->creation_continuous)
       {
         //spot and retouch manage creation_continuous in their own way
-        if(strcmp(crea_module->so->op, "spots") != 0 && strcmp(crea_module->so->op, "retouch") != 0)
+        if(strcmp(crea_module->so->op, "spots") != 0
+           && strcmp(crea_module->so->op, "retouch") != 0)
         {
           dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)crea_module->blend_data;
           for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)
@@ -1684,7 +1727,8 @@ static int _brush_events_button_released(struct dt_iop_module_t *module, float p
         if(!gui2) return 1;
         gui2->group_selected = pos2;
 
-        dt_masks_select_form(crea_module, dt_masks_get_from_id(darktable.develop, form->formid));
+        dt_masks_select_form(crea_module,
+                             dt_masks_get_from_id(darktable.develop, form->formid));
       }
     }
     else
@@ -2133,10 +2177,15 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx, 
   return 1;
 }
 
-static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_form_gui_t *gui, int index, int nb)
+static void _brush_events_post_expose(cairo_t *cr,
+                                      const float zoom_scale,
+                                      dt_masks_form_gui_t *gui,
+                                      const int index,
+                                      const int nb)
 {
   if(!gui) return;
-  dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+  dt_masks_form_gui_points_t *gpt =
+    (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return;
 
   double dashed[] = { 4.0, 4.0 };
@@ -2157,9 +2206,11 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
       dt_masks_form_t *form = darktable.develop->form_visible;
       if(!form) return;
 
-      float masks_border = MIN(dt_conf_get_float(DT_MASKS_CONF(form->type, brush, border)), BORDER_MAX);
+      const float masks_border =
+        MIN(dt_conf_get_float(DT_MASKS_CONF(form->type, brush, border)), BORDER_MAX);
 
-      float masks_hardness = MIN(dt_conf_get_float(DT_MASKS_CONF(form->type, brush, hardness)), HARDNESS_MAX);
+      const float masks_hardness =
+        MIN(dt_conf_get_float(DT_MASKS_CONF(form->type, brush, hardness)), HARDNESS_MAX);
 
       const float opacity = dt_conf_get_float("plugins/darkroom/masks/opacity");
 
@@ -2407,7 +2458,9 @@ static void _brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_fo
   }
 
   // draw border and corners
-  if((gui->show_all_feathers || gui->group_selected == index) && gpt->border_count > nb * 3 + 2)
+  if((gui->show_all_feathers
+      || gui->group_selected == index)
+     && gpt->border_count > nb * 3 + 2)
   {
     cairo_move_to(cr, gpt->border[nb * 6], gpt->border[nb * 6 + 1]);
 
@@ -2721,8 +2774,11 @@ static inline void _brush_falloff_roi(float *buffer, const int *p0, const int *p
 
 // build a stamp which can be combined with other shapes in the same group
 // prerequisite: 'buffer' is all zeros
-static int _brush_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
-                               dt_masks_form_t *const form, const dt_iop_roi_t *roi, float *buffer)
+static int _brush_get_mask_roi(const dt_iop_module_t *const module,
+                               const dt_dev_pixelpipe_iop_t *const piece,
+                               dt_masks_form_t *const form,
+                               const dt_iop_roi_t *roi,
+                               float *buffer)
 {
   if(!module) return 0;
   double start = 0.0;
@@ -2740,8 +2796,10 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module, const dt_dev
 
   int points_count, border_count, payload_count;
 
-  if(!_brush_get_pts_border(module->dev, form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, piece->pipe,&points, &points_count,
-                               &border, &border_count, &payload, &payload_count, 0))
+  if(!_brush_get_pts_border(module->dev, form, module->iop_order,
+                            DT_DEV_TRANSFORM_DIR_BACK_INCL,
+                            piece->pipe,&points, &points_count,
+                            &border, &border_count, &payload, &payload_count, 0))
   {
     dt_free_align(points);
     dt_free_align(border);
@@ -2751,7 +2809,9 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module, const dt_dev
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] brush points took %0.04f sec\n", form->name, dt_get_wtime() - start2);
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] brush points took %0.04f sec\n",
+             form->name, dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
 

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1660,6 +1660,8 @@ static int _brush_events_button_released(struct dt_iop_module_t *module,
       gui->guipoints_payload = NULL;
       gui->guipoints_count = 0;
 
+      dt_masks_gui_form_create(form, gui, index, module);
+
       // we save the form and quit creation mode
       dt_iop_module_t *crea_module = gui->creation_module;
 

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2013-2021 darktable developers.
+    Copyright (C) 2013-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "bauhaus/bauhaus.h"
 #include "common/debug.h"
 #include "common/undo.h"
@@ -25,8 +26,17 @@
 #include "develop/masks.h"
 #include "develop/openmp_maths.h"
 
-static void _circle_get_distance(float x, float y, float as, dt_masks_form_gui_t *gui, int index,
-                                 int num_points, int *inside, int *inside_border, int *near, int *inside_source, float *dist)
+static void _circle_get_distance(const float x,
+                                 const float y,
+                                 const float as,
+                                 dt_masks_form_gui_t *gui,
+                                 const int index,
+                                 const int num_points,
+                                 int *inside,
+                                 int *inside_border,
+                                 int *near,
+                                 int *inside_source,
+                                 float *dist)
 {
   (void)num_points; // unused arg, keep compiler from complaining
   // initialise returned values
@@ -83,15 +93,24 @@ static void _circle_get_distance(float x, float y, float as, dt_masks_form_gui_t
   *near = 0;
 
   // and we check if it's inside form
-  *inside_border = !(dt_masks_point_in_form_near(x, y, gpt->points, 1, gpt->points_count, as, near));
+  *inside_border = !(dt_masks_point_in_form_near(x, y, gpt->points, 1,
+                                                 gpt->points_count, as, near));
 }
 
-static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx, float pzy, int up,
-                                         uint32_t state, dt_masks_form_t *form, int parentid,
-                                         dt_masks_form_gui_t *gui, int index)
+static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module,
+                                         const float pzx,
+                                         const float pzy,
+                                         const int up,
+                                         const uint32_t state,
+                                         dt_masks_form_t *form,
+                                         const int parentid,
+                                         dt_masks_form_gui_t *gui,
+                                         const int index)
 {
-  const float max_mask_border = form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 1.0f;
-  const float max_mask_size = form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 1.0f;
+  const float max_mask_border =
+    form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 1.0f;
+  const float max_mask_size =
+    form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 1.0f;
 
   // add a preview when creating a circle
   if(gui->creation)
@@ -362,11 +381,19 @@ static int _circle_events_button_pressed(struct dt_iop_module_t *module,
   return 0;
 }
 
-static int _circle_events_button_released(struct dt_iop_module_t *module, float pzx, float pzy, int which,
-                                          uint32_t state, dt_masks_form_t *form, int parentid,
-                                          dt_masks_form_gui_t *gui, int index)
+static int _circle_events_button_released(struct dt_iop_module_t *module,
+                                          const float pzx,
+                                          const float pzy,
+                                          const int which,
+                                          const uint32_t state,
+                                          dt_masks_form_t *form,
+                                          const int parentid,
+                                          dt_masks_form_gui_t *gui,
+                                          const int index)
 {
-  if(which == 3 && parentid > 0 && gui->edit_mode == DT_MASKS_EDIT_FULL)
+  if(which == 3
+     && parentid > 0
+     && gui->edit_mode == DT_MASKS_EDIT_FULL)
   {
     // we hide the form
     if(!(darktable.develop->form_visible->type & DT_MASKS_GROUP))
@@ -376,7 +403,9 @@ static int _circle_events_button_released(struct dt_iop_module_t *module, float 
     else
     {
       dt_masks_clear_form_gui(darktable.develop);
-      for(GList *forms = darktable.develop->form_visible->points; forms; forms = g_list_next(forms))
+      for(GList *forms = darktable.develop->form_visible->points;
+          forms;
+          forms = g_list_next(forms))
       {
         dt_masks_point_group_t *gpt = (dt_masks_point_group_t *)forms->data;
         if(gpt->formid == form->formid)
@@ -429,9 +458,11 @@ static int _circle_events_button_released(struct dt_iop_module_t *module, float 
   {
     // we end the form dragging
     gui->source_dragging = FALSE;
+
     if(gui->scrollx != 0.0 || gui->scrolly != 0.0)
     {
-      // if there's no dragging the source is calculated in _circle_events_button_pressed()
+      // if there's no dragging the source is calculated in
+      // _circle_events_button_pressed()
     }
     else
     {
@@ -481,9 +512,15 @@ static int _circle_events_button_released(struct dt_iop_module_t *module, float 
   return 0;
 }
 
-static int _circle_events_mouse_moved(struct dt_iop_module_t *module, float pzx, float pzy, double pressure,
-                                      int which, dt_masks_form_t *form, int parentid,
-                                      dt_masks_form_gui_t *gui, int index)
+static int _circle_events_mouse_moved(struct dt_iop_module_t *module,
+                                      const float pzx,
+                                      const float pzy,
+                                      const double pressure,
+                                      const int which,
+                                      dt_masks_form_t *form,
+                                      const int parentid,
+                                      dt_masks_form_gui_t *gui,
+                                      const int index)
 {
   if(gui->form_dragging || gui->source_dragging)
   {
@@ -491,6 +528,7 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
     const float ht = darktable.develop->preview_pipe->backbuf_height;
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
+
     if(gui->form_dragging)
     {
       dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)((form->points)->data);
@@ -510,7 +548,8 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
   }
   else if(gui->point_dragging >= 1)
   {
-    const float max_mask_size = form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 1.0f;
+    const float max_mask_size =
+      form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 1.0f;
 
     dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)((form->points)->data);
 
@@ -525,13 +564,15 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
   }
   else if(gui->point_border_dragging >= 1)
   {
-    const float max_mask_border = form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 1.0f;
+    const float max_mask_border =
+      form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 1.0f;
 
     dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)((form->points)->data);
 
     const float s = dt_masks_drag_factor(gui, index, gui->point_border_dragging, TRUE);
 
-    circle->border = CLAMP((circle->radius + circle->border) * s - circle->radius, 0.001f, max_mask_border);
+    circle->border = CLAMP((circle->radius + circle->border) * s - circle->radius,
+                           0.001f, max_mask_border);
 
     dt_masks_gui_form_create(form, gui, index, module);
     dt_control_queue_redraw_center();
@@ -582,14 +623,17 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
       dt_masks_form_gui_points_t *gpt =
         (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
 
-      // prefer border point over shape itself in case of near overlap for ease of pickup
+      // prefer border point over shape itself in case of near overlap
+      // for ease of pickup
       if(x - gpt->border[2] > -as && x - gpt->border[2] < as &&
          y - gpt->border[3] > -as && y - gpt->border[3] < as)
       {
         gui->point_border_selected = 1;
       }
-      else if(x - gpt->points[2] > -as && x - gpt->points[2] < as &&
-              y - gpt->points[3] > -as && y - gpt->points[3] < as)
+      else if(x - gpt->points[2] > -as
+              && x - gpt->points[2] < as
+              && y - gpt->points[3] > -as
+              && y - gpt->points[3] < as)
       {
         gui->point_selected = 1;
       }
@@ -610,13 +654,18 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
   return 0;
 }
 
-static void _circle_draw_lines(gboolean borders, gboolean source, cairo_t *cr, double *dashed, const int len,
-                               const gboolean selected, const float zoom_scale, float *points,
+static void _circle_draw_lines(gboolean borders, gboolean source,
+                               cairo_t *cr, double *dashed,
+                               const int len,
+                               const gboolean selected,
+                               const float zoom_scale,
+                               float *points,
                                const int points_count)
 {
   if(points_count <= 6) return;
 
-  cairo_set_line_width(cr, ((borders ? 2.0 : 3.0) + selected ? 2.0 : 0.0) / (borders || source ? 2.0 : 1.0)/zoom_scale);
+  cairo_set_line_width(cr, ((borders ? 2.0 : 3.0) + selected ? 2.0 : 0.0)
+                       / (borders || source ? 2.0 : 1.0)/zoom_scale);
 
   dt_draw_set_color_overlay(cr, FALSE, 0.8);
   cairo_set_dash(cr, dashed, len, 0);
@@ -636,7 +685,12 @@ static void _circle_draw_lines(gboolean borders, gboolean source, cairo_t *cr, d
   cairo_stroke(cr);
 }
 
-static float *_points_to_transform(float x, float y, float radius, float wd, float ht, int *points_count)
+static float *_points_to_transform(const float x,
+                                   const float y,
+                                   const float radius,
+                                   const float wd,
+                                   const float ht,
+                                   int *points_count)
 {
   // how many points do we need?
   const float r = radius * MIN(wd, ht);
@@ -669,8 +723,16 @@ static float *_points_to_transform(float x, float y, float radius, float wd, flo
   return points;
 }
 
-static int _circle_get_points_source(dt_develop_t *dev, float x, float y, float xs, float ys, float radius,
-                                     float radius2, float rotation, float **points, int *points_count,
+static int _circle_get_points_source(dt_develop_t *dev,
+                                     const float x,
+                                     const float y,
+                                     const float xs,
+                                     const float ys,
+                                     const float radius,
+                                     const float radius2,
+                                     const float rotation,
+                                     float **points,
+                                     int *points_count,
                                      const dt_iop_module_t *module)
 {
   (void)radius2; // keep compiler from complaining about unused arg
@@ -685,13 +747,15 @@ static int _circle_get_points_source(dt_develop_t *dev, float x, float y, float 
 
   // we transform with all distortion that happen *before* the module
   // so we have now the TARGET points in module input reference
-  if(dt_dev_distort_transform_plus(dev, dev->preview_pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
+  if(dt_dev_distort_transform_plus(dev, dev->preview_pipe, module->iop_order,
+                                   DT_DEV_TRANSFORM_DIR_BACK_EXCL,
                                    *points, *points_count))
   {
     // now we move all the points by the shift
     // so we have now the SOURCE points in module input reference
     float pts[2] = { xs * wd, ys * ht };
-    if(dt_dev_distort_transform_plus(dev, dev->preview_pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
+    if(dt_dev_distort_transform_plus(dev, dev->preview_pipe, module->iop_order,
+                                     DT_DEV_TRANSFORM_DIR_BACK_EXCL,
                                      pts, 1))
     {
       const float dx = pts[0] - (*points)[0];
@@ -709,7 +773,8 @@ static int _circle_get_points_source(dt_develop_t *dev, float x, float y, float 
 
       // we apply the rest of the distortions (those after the module)
       // so we have now the SOURCE points in final image reference
-      if(dt_dev_distort_transform_plus(dev, dev->preview_pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
+      if(dt_dev_distort_transform_plus(dev, dev->preview_pipe, module->iop_order,
+                                       DT_DEV_TRANSFORM_DIR_FORW_INCL,
                                        *points, *points_count))
         return 1;
     }
@@ -722,8 +787,14 @@ static int _circle_get_points_source(dt_develop_t *dev, float x, float y, float 
   return 0;
 }
 
-static int _circle_get_points(dt_develop_t *dev, float x, float y, float radius, float radius2, float rotation,
-                              float **points, int *points_count)
+static int _circle_get_points(dt_develop_t *dev,
+                              const float x,
+                              const float y,
+                              const float radius,
+                              const float radius2,
+                              const float rotation,
+                              float **points,
+                              int *points_count)
 {
   (void)radius2; // keep compiler from complaining about unused arg
   (void)rotation;
@@ -792,18 +863,22 @@ static void _circle_events_post_expose(cairo_t *cr,
       int points_count = 0;
       float *border = NULL;
       int border_count = 0;
-      int draw = _circle_get_points(darktable.develop, x, y, radius_a, 0.0, 0.0, &points, &points_count);
+      int draw = _circle_get_points(darktable.develop, x, y,
+                                    radius_a, 0.0, 0.0, &points, &points_count);
       if(draw && radius_a != radius_b)
       {
-        draw = _circle_get_points(darktable.develop, x, y, radius_b, 0.0, 0.0, &border, &border_count);
+        draw = _circle_get_points(darktable.develop, x, y,
+                                  radius_b, 0.0, 0.0, &border, &border_count);
       }
 
       // we draw the form and it's border
       cairo_save(cr);
       // we draw the main shape
-      _circle_draw_lines(FALSE, FALSE, cr, dashed, len, FALSE, zoom_scale, points, points_count);
+      _circle_draw_lines(FALSE, FALSE, cr, dashed, len,
+                         FALSE, zoom_scale, points, points_count);
       // we draw the borders
-      _circle_draw_lines(TRUE, FALSE, cr, dashed, len, FALSE, zoom_scale, border, border_count);
+      _circle_draw_lines(TRUE, FALSE, cr, dashed, len,
+                         FALSE, zoom_scale, border, border_count);
       cairo_restore(cr);
 
       // draw a cross where the source will be created
@@ -811,7 +886,8 @@ static void _circle_events_post_expose(cairo_t *cr,
       {
         x = 0.0f;
         y = 0.0f;
-        dt_masks_calculate_source_pos_value(gui, DT_MASKS_CIRCLE, pzx, pzy, pzx, pzy, &x, &y, FALSE);
+        dt_masks_calculate_source_pos_value(gui, DT_MASKS_CIRCLE,
+                                            pzx, pzy, pzx, pzy, &x, &y, FALSE);
         dt_masks_draw_clone_source_pos(cr, zoom_scale, x, y);
       }
 
@@ -824,17 +900,23 @@ static void _circle_events_post_expose(cairo_t *cr,
 
   if(!gpt) return;
   // we draw the main shape
-  const gboolean selected = (gui->group_selected == index) && (gui->form_selected || gui->form_dragging);
-  _circle_draw_lines(FALSE, FALSE, cr, dashed, 0, selected, zoom_scale, gpt->points, gpt->points_count);
+  const gboolean selected = (gui->group_selected == index)
+    && (gui->form_selected || gui->form_dragging);
+
+  _circle_draw_lines(FALSE, FALSE, cr, dashed, 0,
+                     selected, zoom_scale, gpt->points, gpt->points_count);
   // we draw the borders
   if(gui->show_all_feathers || gui->group_selected == index)
   {
-    _circle_draw_lines(TRUE, FALSE, cr, dashed, len, gui->border_selected, zoom_scale, gpt->border,
+    _circle_draw_lines(TRUE, FALSE, cr, dashed, len,
+                       gui->border_selected, zoom_scale, gpt->border,
                        gpt->border_count);
-          // _ellipse_point_transform(xref, yref, gpt->points[i * 2], gpt->points[i * 2 + 1], sinr, cosr, &x, &y);
-    dt_masks_draw_anchor(cr, gui->point_dragging > 0 || gui->point_selected > 0, zoom_scale, gpt->points[2], gpt->points[3]);
-      // _ellipse_point_transform(xref, yref, gpt->border[i * 2], gpt->border[i * 2 + 1], sinr, cosr, &x, &y);
-    dt_masks_draw_anchor(cr, gui->point_border_dragging > 0 || gui->point_border_selected > 0, zoom_scale, gpt->border[2], gpt->border[3]);
+    dt_masks_draw_anchor(cr, gui->point_dragging > 0
+                         || gui->point_selected > 0,
+                         zoom_scale, gpt->points[2], gpt->points[3]);
+    dt_masks_draw_anchor(cr, gui->point_border_dragging > 0
+                         || gui->point_border_selected > 0,
+                         zoom_scale, gpt->border[2], gpt->border[3]);
   }
 
   // draw the source if any
@@ -843,7 +925,8 @@ static void _circle_events_post_expose(cairo_t *cr,
     const float pr_d = darktable.develop->preview_downsampling;
     const float radius = fabs(gpt->points[2] - gpt->points[0]);
 
-    // compute the dest inner circle intersection with the line from source center to dest center.
+    // compute the dest inner circle intersection with the line from
+    // source center to dest center.
     const float cdx = gpt->source[0] - gpt->points[0];
     const float cdy = gpt->source[1] - gpt->points[1];
 
@@ -858,8 +941,9 @@ static void _circle_events_post_expose(cairo_t *cr,
       else
         cangle = -(M_PI / 2) - cangle;
 
-      // (arrowx,arrowy) is the point of intersection, we move it (factor 1.11) a bit farther than the
-      // inner circle to avoid superposition.
+      // (arrowx,arrowy) is the point of intersection, we move it
+      // (factor 1.11) a bit farther than the inner circle to avoid
+      // superposition.
       const float arrowx = gpt->points[0] + 1.11 * radius * cosf(cangle);
       const float arrowy = gpt->points[1] + 1.11 * radius * sinf(cangle);
 
@@ -889,11 +973,17 @@ static void _circle_events_post_expose(cairo_t *cr,
     }
 
     // we only the main shape for the source, no borders
-    _circle_draw_lines(FALSE, TRUE, cr, dashed, 0, selected, zoom_scale, gpt->source, gpt->source_count);
+    _circle_draw_lines(FALSE, TRUE, cr, dashed, 0, selected,
+                       zoom_scale, gpt->source, gpt->source_count);
   }
 }
 
-static void _bounding_box(const float *const points, int num_points, int *width, int *height, int *posx, int *posy)
+static void _bounding_box(const float *const points,
+                          const int num_points,
+                          int *width,
+                          int *height,
+                          int *posx,
+                          int *posy)
 {
   // search for min/max X and Y coordinates
   float xmin = FLT_MAX, xmax = FLT_MIN, ymin = FLT_MAX, ymax = FLT_MIN;
@@ -911,8 +1001,13 @@ static void _bounding_box(const float *const points, int num_points, int *width,
   *height = (ymax - ymin);
 }
 
-static int _circle_get_points_border(dt_develop_t *dev, struct dt_masks_form_t *form, float **points,
-                                     int *points_count, float **border, int *border_count, int source,
+static int _circle_get_points_border(dt_develop_t *dev,
+                                     struct dt_masks_form_t *form,
+                                     float **points,
+                                     int *points_count,
+                                     float **border,
+                                     int *border_count,
+                                     const int source,
                                      const dt_iop_module_t *module)
 {
   dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)((form->points)->data);
@@ -921,17 +1016,23 @@ static int _circle_get_points_border(dt_develop_t *dev, struct dt_masks_form_t *
   if(source)
   {
     float xs = form->source[0], ys = form->source[1];
-    return _circle_get_points_source(dev, x, y, xs, ys, circle->radius, circle->radius, 0, points, points_count,
+    return _circle_get_points_source(dev, x, y, xs, ys,
+                                     circle->radius, circle->radius, 0,
+                                     points, points_count,
                                      module);
   }
   else
   {
-    if(form->functions->get_points(dev, x, y, circle->radius, circle->radius, 0, points, points_count))
+    if(form->functions->get_points(dev, x, y,
+                                   circle->radius, circle->radius, 0,
+                                   points, points_count))
     {
       if(border)
       {
         float outer_radius = circle->radius + circle->border;
-        return form->functions->get_points(dev, x, y, outer_radius, outer_radius, 0, border, border_count);
+        return form->functions->get_points(dev, x, y,
+                                           outer_radius, outer_radius, 0,
+                                           border, border_count);
       }
       else
         return 1;
@@ -940,8 +1041,13 @@ static int _circle_get_points_border(dt_develop_t *dev, struct dt_masks_form_t *
   return 0;
 }
 
-static int _circle_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece,
-                                   dt_masks_form_t *form, int *width, int *height, int *posx, int *posy)
+static int _circle_get_source_area(dt_iop_module_t *module,
+                                   dt_dev_pixelpipe_iop_t *piece,
+                                   dt_masks_form_t *form,
+                                   int *width,
+                                   int *height,
+                                   int *posx,
+                                   int *posy)
 {
   // we get the circle values
   dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)((form->points)->data);
@@ -951,12 +1057,15 @@ static int _circle_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop
   const float outer_radius = circle->radius + circle->border;
   int num_points;
   float *const restrict points =
-    _points_to_transform(form->source[0], form->source[1], outer_radius, wd, ht, &num_points);
+    _points_to_transform(form->source[0], form->source[1],
+                         outer_radius, wd, ht, &num_points);
   if(points == NULL)
     return 0;
 
   // and transform them with all distorted modules
-  if(!dt_dev_distort_transform_plus(darktable.develop, piece->pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points, num_points))
+  if(!dt_dev_distort_transform_plus(darktable.develop, piece->pipe,
+                                    module->iop_order,
+                                    DT_DEV_TRANSFORM_DIR_BACK_INCL, points, num_points))
   {
     dt_free_align(points);
     return 0;
@@ -970,7 +1079,10 @@ static int _circle_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop
 static int _circle_get_area(const dt_iop_module_t *const restrict module,
                             const dt_dev_pixelpipe_iop_t *const restrict piece,
                             dt_masks_form_t *const restrict form,
-                            int *width, int *height, int *posx, int *posy)
+                            int *width,
+                            int *height,
+                            int *posx,
+                            int *posy)
 {
   // we get the circle values
   dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)((form->points)->data);
@@ -980,12 +1092,14 @@ static int _circle_get_area(const dt_iop_module_t *const restrict module,
   const float outer_radius = circle->radius + circle->border;
   int num_points;
   float *const restrict points =
-    _points_to_transform(circle->center[0], circle->center[1], outer_radius, wd, ht, &num_points);
+    _points_to_transform(circle->center[0], circle->center[1],
+                         outer_radius, wd, ht, &num_points);
   if(points == NULL)
     return 0;
 
   // and transform them with all distorted modules
-  if(!dt_dev_distort_transform_plus(module->dev, piece->pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points, num_points))
+  if(!dt_dev_distort_transform_plus(module->dev, piece->pipe, module->iop_order,
+                                    DT_DEV_TRANSFORM_DIR_BACK_INCL, points, num_points))
   {
     dt_free_align(points);
     return 0;
@@ -999,7 +1113,11 @@ static int _circle_get_area(const dt_iop_module_t *const restrict module,
 static int _circle_get_mask(const dt_iop_module_t *const restrict module,
                             const dt_dev_pixelpipe_iop_t *const restrict piece,
                             dt_masks_form_t *const restrict form,
-                            float **buffer, int *width, int *height, int *posx, int *posy)
+                            float **buffer,
+                            int *width,
+                            int *height,
+                            int *posx,
+                            int *posy)
 {
   double start2 = 0.0;
   if(darktable.unmuted & DT_DEBUG_PERF) start2 = dt_get_wtime();
@@ -1009,12 +1127,15 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module,
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] circle area took %0.04f sec\n", form->name, dt_get_wtime() - start2);
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] circle area took %0.04f sec\n",
+             form->name, dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
 
   // we get the circle values
-  dt_masks_point_circle_t *const restrict circle = (dt_masks_point_circle_t *)((form->points)->data);
+  dt_masks_point_circle_t *const restrict circle =
+    (dt_masks_point_circle_t *)((form->points)->data);
 
   // we create a buffer of points with all points in the area
   const int w = *width, h = *height;
@@ -1045,12 +1166,15 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module,
   }
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] circle draw took %0.04f sec\n", form->name, dt_get_wtime() - start2);
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] circle draw took %0.04f sec\n", form->name, dt_get_wtime() - start2);
 
     start2 = dt_get_wtime();
   }
   // we back transform all this points
-  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points, (size_t)w * h))
+  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, module->iop_order,
+                                        DT_DEV_TRANSFORM_DIR_BACK_INCL,
+                                        points, (size_t)w * h))
   {
     dt_free_align(points);
     return 0;
@@ -1058,7 +1182,8 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module,
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] circle transform took %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] circle transform took %0.04f sec\n", form->name,
              dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
@@ -1078,7 +1203,8 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module,
   const float centerx = circle->center[0] * wi;
   const float centery = circle->center[1] * hi;
   const float radius2 = circle->radius * mindim * circle->radius * mindim;
-  const float total2 = (circle->radius + circle->border) * mindim * (circle->radius + circle->border) * mindim;
+  const float total2 = (circle->radius + circle->border) * mindim
+    * (circle->radius + circle->border) * mindim;
   const float border2 = total2 - radius2;
   const float *const points_y = points + 1;
 #ifdef _OPENMP
@@ -1091,7 +1217,8 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module,
   {
     // find the square of the distance from the center
     const float l2 = sqf(points[2 * i] - centerx) + sqf(points_y[2 * i] - centery);
-    // quadratic falloff between the circle's radius and the radius of the outside of the feathering
+    // quadratic falloff between the circle's radius and the radius of
+    // the outside of the feathering
     const float ratio = (total2 - l2) / border2;
     // enforce 1.0 inside the circle and 0.0 outside the feathering
     const float f = CLIP(ratio);
@@ -1101,7 +1228,9 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module,
   dt_free_align(points);
 
   if(darktable.unmuted & DT_DEBUG_PERF)
-    dt_print(DT_DEBUG_MASKS, "[masks %s] circle fill took %0.04f sec\n", form->name, dt_get_wtime() - start2);
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] circle fill took %0.04f sec\n",
+             form->name, dt_get_wtime() - start2);
 
   return 1;
 }
@@ -1109,7 +1238,8 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module,
 
 static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
                                 const dt_dev_pixelpipe_iop_t *const restrict piece,
-                                dt_masks_form_t *const form, const dt_iop_roi_t *const roi,
+                                dt_masks_form_t *const form,
+                                const dt_iop_roi_t *const roi,
                                 float *const restrict buffer)
 {
   double start1 = 0.0;
@@ -1128,14 +1258,16 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
   const float total2 = total * total;
   const float border2 = total2 - radius2;
 
-  // we create a buffer of grid points for later interpolation: higher speed and reduced memory footprint;
-  // we match size of buffer to bounding box around the shape
+  // we create a buffer of grid points for later interpolation: higher
+  // speed and reduced memory footprint; we match size of buffer to
+  // bounding box around the shape
   const int w = roi->width;
   const int h = roi->height;
   const int px = roi->x;
   const int py = roi->y;
   const float iscale = 1.0f / roi->scale;
-  const int grid = CLAMP((10.0f * roi->scale + 2.0f) / 3.0f, 1, 4); // scale dependent resolution
+  // scale dependent resolution
+  const int grid = CLAMP((10.0f * roi->scale + 2.0f) / 3.0f, 1, 4);
   const int gw = (w + grid - 1) / grid + 1;  // grid dimension of total roi
   const int gh = (h + grid - 1) / grid + 1;  // grid dimension of total roi
 
@@ -1144,12 +1276,15 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] circle init took %0.04f sec\n", form->name, dt_get_wtime() - start2);
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] circle init took %0.04f sec\n",
+             form->name, dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
 
-  // we look at the outer circle of the shape - no effects outside of this circle;
-  // we need many points as we do not know how the circle might get distorted in the pixelpipe
+  // we look at the outer circle of the shape - no effects outside of
+  // this circle; we need many points as we do not know how the circle
+  // might get distorted in the pixelpipe
   const size_t circpts = dt_masks_roundup(MIN(360, 2 * M_PI * total2), 8);
   float *const restrict circ = dt_alloc_align_float(circpts * 2);
   if(circ == NULL) return 0;
@@ -1192,8 +1327,9 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
   }
 
   // we transform the outer circle from input image coordinates to current point in pixelpipe
-  if(!dt_dev_distort_transform_plus(module->dev, piece->pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, circ,
-                                        circpts))
+  if(!dt_dev_distort_transform_plus(module->dev, piece->pipe, module->iop_order,
+                                    DT_DEV_TRANSFORM_DIR_BACK_INCL, circ,
+                                    circpts))
   {
     dt_free_align(circ);
     return 0;
@@ -1201,7 +1337,9 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] circle outline took %0.04f sec\n", form->name, dt_get_wtime() - start2);
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] circle outline took %0.04f sec\n",
+             form->name, dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
 
@@ -1241,12 +1379,15 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] circle bounding box took %0.04f sec\n", form->name, dt_get_wtime() - start2);
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] circle bounding box took %0.04f sec\n",
+             form->name, dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
 
-  // check if there is anything to do at all;
-  // only if width and height of bounding box is 2 or greater the shape lies inside of roi and requires action
+  // check if there is anything to do at all; only if width and height
+  // of bounding box is 2 or greater the shape lies inside of roi and
+  // requires action
   if(bbw <= 1 || bbh <= 1)
     return 1;
 
@@ -1274,12 +1415,14 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] circle grid took %0.04f sec\n", form->name, dt_get_wtime() - start2);
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] circle grid took %0.04f sec\n", form->name, dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
 
   // we back transform all these points to the input image coordinates
-  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points,
+  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, module->iop_order,
+                                        DT_DEV_TRANSFORM_DIR_BACK_INCL, points,
                                         (size_t)bbw * bbh))
   {
     dt_free_align(points);
@@ -1288,7 +1431,8 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] circle transform took %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] circle transform took %0.04f sec\n", form->name,
              dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
@@ -1310,8 +1454,10 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
     {
       const size_t index = (size_t)j * bbw + i;
       // find the square of the distance from the center
-      const float l2 = sqf(points[2 * index] - centerx) + sqf(points[2 * index + 1] - centery);
-      // quadratic falloff between the circle's radius and the radius of the outside of the feathering
+      const float l2 = sqf(points[2 * index] - centerx)
+        + sqf(points[2 * index + 1] - centery);
+      // quadratic falloff between the circle's radius and the radius
+      // of the outside of the feathering
       const float ratio = (total2 - l2) / border2;
       // enforce 1.0 inside the circle and 0.0 outside the feathering
       const float f = CLAMP(ratio, 0.0f, 1.0f);
@@ -1320,7 +1466,8 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] circle draw took %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] circle draw took %0.04f sec\n", form->name,
              dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
@@ -1348,8 +1495,10 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
       const int mi = i / grid - bbxm;
       const size_t mindex = (size_t)mj * bbw + mi;
       buffer[(size_t)j * w + i]
-          = (points[mindex * 2] * (grid - ii) * (grid - jj) + points[(mindex + 1) * 2] * ii * (grid - jj)
-             + points[(mindex + bbw) * 2] * (grid - ii) * jj + points[(mindex + bbw + 1) * 2] * ii * jj)
+          = (points[mindex * 2] * (grid - ii) * (grid - jj)
+             + points[(mindex + 1) * 2] * ii * (grid - jj)
+             + points[(mindex + bbw) * 2] * (grid - ii) * jj
+             + points[(mindex + bbw + 1) * 2] * ii * jj)
             / (grid * grid);
     }
   }
@@ -1358,8 +1507,11 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] circle fill took %0.04f sec\n", form->name, dt_get_wtime() - start2);
-    dt_print(DT_DEBUG_MASKS, "[masks %s] circle total render took %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] circle fill took %0.04f sec\n",
+             form->name, dt_get_wtime() - start2);
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] circle total render took %0.04f sec\n", form->name,
              dt_get_wtime() - start1);
   }
 
@@ -1369,9 +1521,12 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
 static GSList *_circle_setup_mouse_actions(const struct dt_masks_form_t *const form)
 {
   GSList *lm = NULL;
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, 0, _("[CIRCLE] change size"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_SHIFT_MASK, _("[CIRCLE] change feather size"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_CONTROL_MASK, _("[CIRCLE] change opacity"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL,
+                                     0, _("[CIRCLE] change size"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL,
+                                     GDK_SHIFT_MASK, _("[CIRCLE] change feather size"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL,
+                                     GDK_CONTROL_MASK, _("[CIRCLE] change opacity"));
   return lm;
 }
 
@@ -1381,13 +1536,17 @@ static void _circle_sanitize_config(dt_masks_type_t type)
   dt_conf_get_and_sanitize_float(DT_MASKS_CONF(type, circle, border), 0.0005f, 0.5f);
 }
 
-static void _circle_set_form_name(struct dt_masks_form_t *const form, const size_t nb)
+static void _circle_set_form_name(struct dt_masks_form_t *const form,
+                                  const size_t nb)
 {
   snprintf(form->name, sizeof(form->name), _("circle #%d"), (int)nb);
 }
 
-static void _circle_set_hint_message(const dt_masks_form_gui_t *const gui, const dt_masks_form_t *const form,
-                                     const int opacity, char *const restrict msgbuf, const size_t msgbuf_len)
+static void _circle_set_hint_message(const dt_masks_form_gui_t *const gui,
+                                     const dt_masks_form_t *const form,
+                                     const int opacity,
+                                     char *const restrict msgbuf,
+                                     const size_t msgbuf_len)
 {
   // circle has same controls on creation and on edit
   g_snprintf(msgbuf, msgbuf_len,
@@ -1395,30 +1554,43 @@ static void _circle_set_hint_message(const dt_masks_form_gui_t *const gui, const
                "<b>opacity</b>: ctrl+scroll (%d%%)"), opacity);
 }
 
-static void _circle_duplicate_points(dt_develop_t *dev, dt_masks_form_t *const base, dt_masks_form_t *const dest)
+static void _circle_duplicate_points(dt_develop_t *dev,
+                                     dt_masks_form_t *const base,
+                                     dt_masks_form_t *const dest)
 {
   (void)dev; // unused arg, keep compiler from complaining
   for(GList *pts = base->points; pts; pts = g_list_next(pts))
   {
     dt_masks_point_circle_t *pt = (dt_masks_point_circle_t *)pts->data;
-    dt_masks_point_circle_t *npt = (dt_masks_point_circle_t *)malloc(sizeof(dt_masks_point_circle_t));
+    dt_masks_point_circle_t *npt =
+      (dt_masks_point_circle_t *)malloc(sizeof(dt_masks_point_circle_t));
     memcpy(npt, pt, sizeof(dt_masks_point_circle_t));
     dest->points = g_list_append(dest->points, npt);
   }
 }
 
-static void _circle_modify_property(dt_masks_form_t *const form, dt_masks_property_t prop, float old_val, float new_val, float *sum, int *count, float *min, float *max)
+static void _circle_modify_property(dt_masks_form_t *const form,
+                                    const dt_masks_property_t prop,
+                                    const float old_val,
+                                    const float new_val,
+                                    float *sum,
+                                    int *count,
+                                    float *min,
+                                    float *max)
 {
   float ratio = (!old_val || !new_val) ? 1.0f : new_val / old_val;
 
   dt_masks_point_circle_t *circle = form->points ? form->points->data : NULL;
 
-  float masks_size = circle ? circle->radius : dt_conf_get_float(DT_MASKS_CONF(form->type, circle, size));
+  float masks_size = circle
+    ? circle->radius
+    : dt_conf_get_float(DT_MASKS_CONF(form->type, circle, size));
 
   switch(prop)
   {
     case DT_MASKS_PROPERTY_SIZE:;
-      const float max_mask_size = form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 1.0f;
+      const float max_mask_size =
+        form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 1.0f;
       masks_size = CLAMP(masks_size * ratio, 0.001f, max_mask_size);
 
       if(circle) circle->radius = masks_size;
@@ -1430,8 +1602,13 @@ static void _circle_modify_property(dt_masks_form_t *const form, dt_masks_proper
       ++*count;
       break;
     case DT_MASKS_PROPERTY_FEATHER:;
-      const float max_mask_border = form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 1.0f;
-      float masks_border = circle ? circle->border : dt_conf_get_float(DT_MASKS_CONF(form->type, circle, border));
+      const float max_mask_border =
+        form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 1.0f;
+      float masks_border =
+        circle
+        ? circle->border
+        : dt_conf_get_float(DT_MASKS_CONF(form->type, circle, border));
+
       masks_border = CLAMP(masks_border * ratio, 0.0005f, max_mask_border);
 
       if(circle) circle->border = masks_border;
@@ -1446,7 +1623,10 @@ static void _circle_modify_property(dt_masks_form_t *const form, dt_masks_proper
   }
 }
 
-static void _circle_initial_source_pos(const float iwd, const float iht, float *x, float *y)
+static void _circle_initial_source_pos(const float iwd,
+                                       const float iht,
+                                       float *x,
+                                       float *y)
 {
   const float radius = MIN(0.5f, dt_conf_get_float("plugins/darkroom/spots/circle_size"));
 
@@ -1477,7 +1657,6 @@ const dt_masks_functions_t dt_masks_functions_circle = {
   .button_released = _circle_events_button_released,
   .post_expose = _circle_events_post_expose
 };
-
 
 
 // clang-format off

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -283,8 +283,8 @@ static int _circle_events_button_pressed(struct dt_iop_module_t *module,
       // and we switch in edit mode to show all the forms
       // spots and retouch have their own handling of creation_continuous
       if(gui->creation_continuous
-         && (strcmp(crea_module->so->op, "spots") == 0
-             || strcmp(crea_module->so->op, "retouch") == 0))
+         && (dt_iop_module_is(crea_module->so, "spots")
+             || dt_iop_module_is(crea_module->so, "retouch")))
         dt_masks_set_edit_mode_single_form(crea_module, form->formid, DT_MASKS_EDIT_FULL);
       else if(!gui->creation_continuous)
         dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
@@ -331,8 +331,8 @@ static int _circle_events_button_pressed(struct dt_iop_module_t *module,
     //spot and retouch manage creation_continuous in their own way
     if(crea_module
        && gui->creation_continuous
-       && strcmp(crea_module->so->op, "spots") != 0
-       && strcmp(crea_module->so->op, "retouch") != 0)
+       && !dt_iop_module_is(crea_module->so, "spots")
+       && !dt_iop_module_is(crea_module->so, "retouch"))
     {
       dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)crea_module->blend_data;
       for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -239,7 +239,6 @@ static int _circle_events_button_pressed(struct dt_iop_module_t *module, float p
   }
   else
   {
-    dt_iop_module_t *crea_module = gui->creation_module;
     // we create the circle
     dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)(malloc(sizeof(dt_masks_point_circle_t)));
 
@@ -264,6 +263,8 @@ static int _circle_events_button_pressed(struct dt_iop_module_t *module, float p
     circle->radius = dt_conf_get_float(DT_MASKS_CONF(form->type, circle, size));
     circle->border = dt_conf_get_float(DT_MASKS_CONF(form->type, circle, border));
     form->points = g_list_append(form->points, circle);
+
+    dt_iop_module_t *crea_module = gui->creation_module;
     dt_masks_gui_form_save_creation(darktable.develop, crea_module, form, gui);
 
     if(crea_module)
@@ -279,14 +280,10 @@ static int _circle_events_button_pressed(struct dt_iop_module_t *module, float p
       else if(!gui->creation_continuous)
         dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
       dt_masks_iop_update(crea_module);
-      dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid);
-      gui->creation_module = NULL;
     }
-    else
-    {
-      // we select the new form
-      dt_dev_masks_selection_change(darktable.develop, NULL, form->formid);
-    }
+
+    dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid);
+    gui->creation_module = NULL;
 
     // if we draw a clone circle, we start now the source dragging
     if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -242,14 +242,16 @@ static int _circle_events_button_pressed(struct dt_iop_module_t *module,
               || dt_modifier_is(state, GDK_SHIFT_MASK)))
   {
     // set some absolute or relative position for the source of the clone mask
-    if(form->type & DT_MASKS_CLONE) dt_masks_set_source_pos_initial_state(gui, state, pzx, pzy);
+    if(form->type & DT_MASKS_CLONE)
+      dt_masks_set_source_pos_initial_state(gui, state, pzx, pzy);
 
     return 1;
   }
   else
   {
     // we create the circle
-    dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)(malloc(sizeof(dt_masks_point_circle_t)));
+    dt_masks_point_circle_t *circle =
+      (dt_masks_point_circle_t *)(malloc(sizeof(dt_masks_point_circle_t)));
 
     // we change the center value
     const float wd = darktable.develop->preview_pipe->backbuf_width;
@@ -329,23 +331,32 @@ static int _circle_events_button_pressed(struct dt_iop_module_t *module,
       dt_masks_select_form(module, dt_masks_get_from_id(darktable.develop, form->formid));
     }
     //spot and retouch manage creation_continuous in their own way
-    if(crea_module
-       && gui->creation_continuous
-       && !dt_iop_module_is(crea_module->so, "spots")
-       && !dt_iop_module_is(crea_module->so, "retouch"))
+    if(gui->creation_continuous)
     {
-      dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)crea_module->blend_data;
-      for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)
-        if(bd->masks_type[n] == form->type)
-          gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_shapes[n]), TRUE);
+      if(crea_module
+         && !dt_iop_module_is(crea_module->so, "spots")
+         && !dt_iop_module_is(crea_module->so, "retouch"))
+      {
+        dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)crea_module->blend_data;
+        for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)
+          if(bd->masks_type[n] == form->type)
+            gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_shapes[n]), TRUE);
 
-      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), FALSE);
-      dt_masks_form_t *newform = dt_masks_create(form->type);
-      dt_masks_change_form_gui(newform);
-      darktable.develop->form_gui->creation_module = crea_module;
-      darktable.develop->form_gui->creation_continuous = TRUE;
-      darktable.develop->form_gui->creation_continuous_module = crea_module;
+        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), FALSE);
+        dt_masks_form_t *newform = dt_masks_create(form->type);
+        dt_masks_change_form_gui(newform);
+        darktable.develop->form_gui->creation_module = crea_module;
+        darktable.develop->form_gui->creation_continuous = TRUE;
+        darktable.develop->form_gui->creation_continuous_module = crea_module;
+      }
+      else
+      {
+        dt_masks_form_t *form_new = dt_masks_create(form->type);
+        dt_masks_change_form_gui(form_new);
+        darktable.develop->form_gui->creation_module = gui->creation_continuous_module;
+      }
     }
+
     return 1;
   }
   return 0;

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -38,7 +38,8 @@ static void _circle_get_distance(float x, float y, float as, dt_masks_form_gui_t
 
   if(!gui) return;
 
-  dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+  dt_masks_form_gui_points_t *gpt =
+    (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return;
 
   // we first check if we are inside the source form
@@ -177,15 +178,23 @@ static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module, float p
   return 0;
 }
 
-static int _circle_events_button_pressed(struct dt_iop_module_t *module, float pzx, float pzy,
-                                         double pressure, int which, int type, uint32_t state,
-                                         dt_masks_form_t *form, int parentid, dt_masks_form_gui_t *gui, int index)
+static int _circle_events_button_pressed(struct dt_iop_module_t *module,
+                                         float pzx, float pzy,
+                                         const double pressure,
+                                         const int which,
+                                         const int type,
+                                         const uint32_t state,
+                                         dt_masks_form_t *form,
+                                         const int parentid,
+                                         dt_masks_form_gui_t *gui,
+                                         const int index)
 {
   if(!gui) return 0;
 
   if(!gui->creation)
   {
-    dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+    dt_masks_form_gui_points_t *gpt =
+      (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
     if(!gpt) return 0;
 
     if(gui->edit_mode == DT_MASKS_EDIT_FULL)
@@ -320,7 +329,10 @@ static int _circle_events_button_pressed(struct dt_iop_module_t *module, float p
       dt_masks_select_form(module, dt_masks_get_from_id(darktable.develop, form->formid));
     }
     //spot and retouch manage creation_continuous in their own way
-    if(crea_module && gui->creation_continuous && strcmp(crea_module->so->op, "spots") != 0 && strcmp(crea_module->so->op, "retouch") != 0)
+    if(crea_module
+       && gui->creation_continuous
+       && strcmp(crea_module->so->op, "spots") != 0
+       && strcmp(crea_module->so->op, "retouch") != 0)
     {
       dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)crea_module->blend_data;
       for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)
@@ -553,9 +565,11 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
     // see if we are close to the anchor points
     gui->point_selected = -1;
     gui->point_border_selected = -1;
+
     if(gui->form_selected)
     {
-      dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+      dt_masks_form_gui_points_t *gpt =
+        (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
 
       // prefer border point over shape itself in case of near overlap for ease of pickup
       if(x - gpt->border[2] > -as && x - gpt->border[2] < as &&
@@ -719,15 +733,19 @@ static int _circle_get_points(dt_develop_t *dev, float x, float y, float radius,
   return 0;
 }
 
-static void _circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_form_gui_t *gui, int index,
-                                       int num_points)
+static void _circle_events_post_expose(cairo_t *cr,
+                                       const float zoom_scale,
+                                       dt_masks_form_gui_t *gui,
+                                       const int index,
+                                       const int num_points)
 {
   (void)num_points; // unused arg, keep compiler from complaining
   double dashed[] = { 4.0, 4.0 };
   dashed[0] /= zoom_scale;
   dashed[1] /= zoom_scale;
   const int len = sizeof(dashed) / sizeof(dashed[0]);
-  dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+  dt_masks_form_gui_points_t *gpt =
+    (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
 
   // add a preview when creating a circle
   // in creation mode
@@ -1456,4 +1474,3 @@ const dt_masks_functions_t dt_masks_functions_circle = {
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -622,10 +622,12 @@ static int _ellipse_events_button_pressed(struct dt_iop_module_t *module, float 
     return 1;
   }
   else if(which == 1
-          && (dt_modifier_is(state, GDK_CONTROL_MASK | GDK_SHIFT_MASK) || dt_modifier_is(state, GDK_SHIFT_MASK)))
+          && (dt_modifier_is(state, GDK_CONTROL_MASK | GDK_SHIFT_MASK)
+              || dt_modifier_is(state, GDK_SHIFT_MASK)))
   {
     // set some absolute or relative position for the source of the clone mask
-    if(form->type & DT_MASKS_CLONE) dt_masks_set_source_pos_initial_state(gui, state, pzx, pzy);
+    if(form->type & DT_MASKS_CLONE)
+      dt_masks_set_source_pos_initial_state(gui, state, pzx, pzy);
 
     return 1;
   }
@@ -669,7 +671,9 @@ static int _ellipse_events_button_pressed(struct dt_iop_module_t *module, float 
       dt_dev_add_history_item(darktable.develop, crea_module, TRUE);
       // and we switch in edit mode to show all the forms
       // spots and retouch have their own handling of creation_continuous
-      if(gui->creation_continuous && ( strcmp(crea_module->so->op, "spots") == 0 || strcmp(crea_module->so->op, "retouch") == 0))
+      if(gui->creation_continuous
+         && (strcmp(crea_module->so->op, "spots") == 0
+             || strcmp(crea_module->so->op, "retouch") == 0))
         dt_masks_set_edit_mode_single_form(crea_module, form->formid, DT_MASKS_EDIT_FULL);
       else if(!gui->creation_continuous)
         dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
@@ -714,7 +718,10 @@ static int _ellipse_events_button_pressed(struct dt_iop_module_t *module, float 
       dt_masks_select_form(module, dt_masks_get_from_id(darktable.develop, form->formid));
     }
     //spot and retouch manage creation_continuous in their own way
-    if(crea_module && gui->creation_continuous && strcmp(crea_module->so->op, "spots") != 0 && strcmp(crea_module->so->op, "retouch") != 0)
+    if(crea_module
+       && gui->creation_continuous
+       && strcmp(crea_module->so->op, "spots") != 0
+       && strcmp(crea_module->so->op, "retouch") != 0)
     {
       dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)crea_module->blend_data;
       for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)
@@ -2089,4 +2096,3 @@ const dt_masks_functions_t dt_masks_functions_ellipse = {
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2013-2021 darktable developers.
+    Copyright (C) 2013-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "bauhaus/bauhaus.h"
 #include "common/debug.h"
 #include "common/undo.h"
@@ -25,18 +26,29 @@
 #include "develop/masks.h"
 #include "develop/openmp_maths.h"
 
-static inline void _ellipse_point_transform(const float xref, const float yref, const float x, const float y,
-                                            const float sinr, const float cosr, float *xnew, float *ynew)
+static inline void _ellipse_point_transform(const float xref,
+                                            const float yref,
+                                            const float x,
+                                            const float y,
+                                            const float sinr,
+                                            const float cosr,
+                                            float *xnew,
+                                            float *ynew)
 {
-  const float xtmp = (sinr * sinr + cosr * cosr) * (x - xref) + (cosr * sinr - cosr * sinr) * (y - yref);
-  const float ytmp = (cosr * sinr - cosr * sinr) * (x - xref) + (sinr * sinr + cosr * cosr) * (y - yref);
+  const float xtmp = (sinr * sinr + cosr * cosr) * (x - xref)
+    + (cosr * sinr - cosr * sinr) * (y - yref);
+  const float ytmp = (cosr * sinr - cosr * sinr) * (x - xref)
+    + (sinr * sinr + cosr * cosr) * (y - yref);
 
   *xnew = xref + xtmp;
   *ynew = yref + ytmp;
 }
 
 // Jordan's point in polygon test
-static int _ellipse_cross_test(float x, float y, float *point_1, float *point_2)
+static int _ellipse_cross_test(const float x,
+                               const float y,
+                               float *point_1,
+                               float *point_2)
 {
   const float x_a = x;
   const float y_a = y;
@@ -74,7 +86,10 @@ static int _ellipse_cross_test(float x, float y, float *point_1, float *point_2)
     return 0;
 }
 
-static int _ellipse_point_in_polygon(float x, float y, float *points, int points_count)
+static int _ellipse_point_in_polygon(const float x,
+                                     const float y,
+                                     float *points,
+                                     const int points_count)
 {
   int t = -1;
 
@@ -87,9 +102,13 @@ static int _ellipse_point_in_polygon(float x, float y, float *points, int points
 }
 
 // check if point is close to path - segment by segment
-static int _ellipse_point_close_to_path(float x, float y, float as, float *points, int points_count)
+static int _ellipse_point_close_to_path(const float x,
+                                        const float y,
+                                        const float as,
+                                        float *points,
+                                        const int points_count)
 {
-  float as2 = as * as;
+  const float as2 = as * as;
 
   const float lastx = points[2 * (points_count - 1)];
   const float lasty = points[2 * (points_count - 1) + 1];
@@ -129,13 +148,22 @@ static int _ellipse_point_close_to_path(float x, float y, float as, float *point
     const float dx = x - xx;
     const float dy = y - yy;
 
-    if(sqf(dx) + sqf(dy) < as2) return 1;
+    if(sqf(dx) + sqf(dy) < as2)
+      return 1;
   }
   return 0;
 }
 
-static void _ellipse_get_distance(float x, float y, float as, dt_masks_form_gui_t *gui, int index,
-                                  int num_points, int *inside, int *inside_border, int *near, int *inside_source, float *dist)
+static void _ellipse_get_distance(const float x,
+                                  const float y,
+                                  const float as,
+                                  dt_masks_form_gui_t *gui, int index,
+                                  const int num_points,
+                                  int *inside,
+                                  int *inside_border,
+                                  int *near,
+                                  int *inside_source,
+                                  float *dist)
 {
   (void)num_points; // unused arg, keep compiler from complaining
 
@@ -143,7 +171,8 @@ static void _ellipse_get_distance(float x, float y, float as, dt_masks_form_gui_
 
   if(!gui) return;
 
-  dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+  dt_masks_form_gui_points_t *gpt =
+    (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return;
 
   // we first check if we are inside the source form
@@ -195,13 +224,23 @@ static void _ellipse_get_distance(float x, float y, float as, dt_masks_form_gui_
   *near = 0;
   *inside_border = 1;
 
-  if(_ellipse_point_in_polygon(x, y, gpt->points + 10, gpt->points_count - 5) >= 0) *inside_border = 0;
-  if(_ellipse_point_close_to_path(x, y, as, gpt->points + 10, gpt->points_count - 5)) *near = 1;
+  if(_ellipse_point_in_polygon(x, y, gpt->points + 10, gpt->points_count - 5) >= 0)
+    *inside_border = 0;
+  if(_ellipse_point_close_to_path(x, y, as, gpt->points + 10, gpt->points_count - 5))
+    *near = 1;
 }
 
-static void _ellipse_draw_shape(gboolean borders, gboolean source, cairo_t *cr, double *dashed, const float len,
-                                const int selected, const float zoom_scale,
-                                const float xref, const float yref, float *points, const int points_count)
+static void _ellipse_draw_shape(const gboolean borders,
+                                const gboolean source,
+                                cairo_t *cr,
+                                double *dashed,
+                                const float len,
+                                const int selected,
+                                const float zoom_scale,
+                                const float xref,
+                                const float yref,
+                                float *points,
+                                const int points_count)
 {
   if(points_count <= 10) return;
 
@@ -212,7 +251,9 @@ static void _ellipse_draw_shape(gboolean borders, gboolean source, cairo_t *cr, 
   float x = 0.0f;
   float y = 0.0f;
 
-  cairo_set_line_width(cr, ((borders ? 2.0 : 3.0) + selected ? 2.0 : 0.0) / (borders || source ? 2.0 : 1.0)/zoom_scale);
+  cairo_set_line_width(cr, ((borders ? 2.0 : 3.0)
+                            + selected ? 2.0 : 0.0) / (borders || source ? 2.0 : 1.0)
+                       /zoom_scale);
 
   dt_draw_set_color_overlay(cr, FALSE, 0.8);
   cairo_set_dash(cr, dashed, len, 0);
@@ -221,7 +262,8 @@ static void _ellipse_draw_shape(gboolean borders, gboolean source, cairo_t *cr, 
   cairo_move_to(cr, x, y);
   for(int i = 6; i < points_count; i++)
   {
-    _ellipse_point_transform(xref, yref, points[i * 2], points[i * 2 + 1], sinr, cosr, &x, &y);
+    _ellipse_point_transform(xref, yref, points[i * 2], points[i * 2 + 1],
+                             sinr, cosr, &x, &y);
     cairo_line_to(cr, x, y);
   }
   _ellipse_point_transform(xref, yref, points[10], points[11], sinr, cosr, &x, &y);
@@ -235,8 +277,14 @@ static void _ellipse_draw_shape(gboolean borders, gboolean source, cairo_t *cr, 
   cairo_stroke(cr);
 }
 
-static float *_points_to_transform(float xx, float yy, float radius_a, float radius_b, float rotation, float wd,
-                                   float ht, int *points_count)
+static float *_points_to_transform(const float xx,
+                                   const float yy,
+                                   const float radius_a,
+                                   const float radius_b,
+                                   const float rotation,
+                                   const float wd,
+                                   const float ht,
+                                   int *points_count)
 {
   const float v1 = (rotation / 180.0f) * M_PI;
   const float v2 = (rotation - 90.0f) / 180.0f * M_PI;
@@ -258,13 +306,14 @@ static float *_points_to_transform(float xx, float yy, float radius_a, float rad
   const float sinv = sinf(v);
   const float cosv = cosf(v);
 
-  // how many points do we need? we only take every nth point and rely on interpolation (only affecting GUI
-  // anyhow)
+  // how many points do we need? we only take every nth point and rely
+  // on interpolation (only affecting GUI anyhow)
   const int n = 10;
   const float lambda = (a - b) / (a + b);
   const int l = MAX(
       100, (int)((M_PI * (a + b)
-                  * (1.0f + (3.0f * lambda * lambda) / (10.0f + sqrtf(4.0f - 3.0f * lambda * lambda)))) / n));
+                  * (1.0f + (3.0f * lambda * lambda)
+                     / (10.0f + sqrtf(4.0f - 3.0f * lambda * lambda)))) / n));
 
   // buffer allocations
   float *const restrict points = dt_alloc_align_float((size_t)2 * (l + 5));
@@ -305,8 +354,16 @@ static float *_points_to_transform(float xx, float yy, float radius_a, float rad
   return points;
 }
 
-static int _ellipse_get_points_source(dt_develop_t *dev, float xx, float yy, float xs, float ys, float radius_a,
-                                      float radius_b, float rotation, float **points, int *points_count,
+static int _ellipse_get_points_source(dt_develop_t *dev,
+                                      const float xx,
+                                      const float yy,
+                                      const float xs,
+                                      const float ys,
+                                      const float radius_a,
+                                      const float radius_b,
+                                      const float rotation,
+                                      float **points,
+                                      int *points_count,
                                       const dt_iop_module_t *module)
 {
   const float wd = dev->preview_pipe->iwidth;
@@ -314,18 +371,21 @@ static int _ellipse_get_points_source(dt_develop_t *dev, float xx, float yy, flo
 
   // compute the points of the target (center and circumference of circle)
   // we get the point in RAW image reference
-  *points = _points_to_transform(xx, yy, radius_a, radius_b, rotation, wd, ht, points_count);
+  *points = _points_to_transform(xx, yy, radius_a, radius_b,
+                                 rotation, wd, ht, points_count);
   if(!*points) return 0;
 
   // we transform with all distortion that happen *before* the module
   // so we have now the TARGET points in module input reference
-  if(dt_dev_distort_transform_plus(dev, dev->preview_pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
+  if(dt_dev_distort_transform_plus(dev, dev->preview_pipe,
+                                   module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
                                    *points, *points_count))
   {
     // now we move all the points by the shift
     // so we have now the SOURCE points in module input reference
     float pts[2] = { xs * wd, ys * ht };
-    if(dt_dev_distort_transform_plus(dev, dev->preview_pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
+    if(dt_dev_distort_transform_plus(dev, dev->preview_pipe,
+                                     module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL,
                                      pts, 1))
     {
       const float dx = pts[0] - (*points)[0];
@@ -345,7 +405,8 @@ static int _ellipse_get_points_source(dt_develop_t *dev, float xx, float yy, flo
 
       // we apply the rest of the distortions (those after the module)
       // so we have now the SOURCE points in final image reference
-      if(dt_dev_distort_transform_plus(dev, dev->preview_pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
+      if(dt_dev_distort_transform_plus(dev, dev->preview_pipe,
+                                       module->iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL,
                                        *points, *points_count))
         return 1;
     }
@@ -358,13 +419,20 @@ static int _ellipse_get_points_source(dt_develop_t *dev, float xx, float yy, flo
   return 0;
 }
 
-static int _ellipse_get_points(dt_develop_t *dev, float xx, float yy, float radius_a, float radius_b,
-                               float rotation, float **points, int *points_count)
+static int _ellipse_get_points(dt_develop_t *dev,
+                               const float xx,
+                               const float yy,
+                               const float radius_a,
+                               const float radius_b,
+                               const float rotation,
+                               float **points,
+                               int *points_count)
 {
   const float wd = dev->preview_pipe->iwidth;
   const float ht = dev->preview_pipe->iheight;
 
-  *points = _points_to_transform(xx, yy, radius_a, radius_b, rotation, wd, ht, points_count);
+  *points = _points_to_transform(xx, yy, radius_a, radius_b,
+                                 rotation, wd, ht, points_count);
   if(!*points) return 0;
 
   // and we transform them with all distorted modules
@@ -377,8 +445,13 @@ static int _ellipse_get_points(dt_develop_t *dev, float xx, float yy, float radi
   return 0;
 }
 
-static int _ellipse_get_points_border(dt_develop_t *dev, struct dt_masks_form_t *form, float **points,
-                                      int *points_count, float **border, int *border_count, int source,
+static int _ellipse_get_points_border(dt_develop_t *dev,
+                                      struct dt_masks_form_t *form,
+                                      float **points,
+                                      int *points_count,
+                                      float **border,
+                                      int *border_count,
+                                      const int source,
                                       const dt_iop_module_t *module)
 {
   dt_masks_point_ellipse_t *ellipse = (dt_masks_point_ellipse_t *)((form->points)->data);
@@ -388,7 +461,8 @@ static int _ellipse_get_points_border(dt_develop_t *dev, struct dt_masks_form_t 
   if(source)
   {
     float xs = form->source[0], ys = form->source[1];
-    return _ellipse_get_points_source(dev, x, y, xs, ys, a, b, ellipse->rotation, points, points_count, module);
+    return _ellipse_get_points_source(dev, x, y, xs, ys, a, b,
+                                      ellipse->rotation, points, points_count, module);
   }
   else
   {
@@ -397,8 +471,13 @@ static int _ellipse_get_points_border(dt_develop_t *dev, struct dt_masks_form_t 
       if(border)
       {
         const int prop = ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL;
-        return _ellipse_get_points(dev, x, y, (prop ? a * (1.0f + ellipse->border) : a + ellipse->border),
-                                   (prop ? b * (1.0f + ellipse->border) : b + ellipse->border), ellipse->rotation,
+        return _ellipse_get_points(dev, x, y,
+                                   (prop
+                                    ? a * (1.0f + ellipse->border)
+                                    : a + ellipse->border),
+                                   (prop
+                                    ? b * (1.0f + ellipse->border)
+                                    : b + ellipse->border), ellipse->rotation,
                                    border, border_count);
       }
       else
@@ -408,11 +487,18 @@ static int _ellipse_get_points_border(dt_develop_t *dev, struct dt_masks_form_t 
   return 0;
 }
 
-static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx, float pzy, int up,
-                                          uint32_t state, dt_masks_form_t *form, int parentid,
-                                          dt_masks_form_gui_t *gui, int index)
+static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module,
+                                          const float pzx,
+                                          const float pzy,
+                                          const int up,
+                                          const uint32_t state,
+                                          dt_masks_form_t *form,
+                                          const int parentid,
+                                          dt_masks_form_gui_t *gui,
+                                          const int index)
 {
-  const float radius_limit = form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 1.0f;
+  const float radius_limit =
+    form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 1.0f;
   // add a preview when creating an ellipse
   if(gui->creation)
   {
@@ -438,7 +524,8 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
       float masks_border = dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, border));
       int flags = dt_conf_get_int(DT_MASKS_CONF(form->type, ellipse, flags));
 
-      const float reference = (flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? 1.0f / fmin(radius_a, radius_b) : 1.0f);
+      const float reference =
+        (flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? 1.0f / fmin(radius_a, radius_b) : 1.0f);
       if(!up && masks_border > 0.001f * reference)
         masks_border *= 0.97f;
       else if(up && masks_border < radius_limit * reference)
@@ -449,7 +536,8 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
 
       dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, border), masks_border);
 
-      dt_toast_log(_("feather size: %3.2f%%"), (masks_border/fmaxf(radius_a, radius_b))*100.0f);
+      dt_toast_log(_("feather size: %3.2f%%"),
+                   (masks_border/fmaxf(radius_a, radius_b))*100.0f);
     }
     else if(dt_modifier_is(state, 0))
     {
@@ -490,7 +578,8 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
     }
     else
     {
-      dt_masks_point_ellipse_t *ellipse = (dt_masks_point_ellipse_t *)((form->points)->data);
+      dt_masks_point_ellipse_t *ellipse =
+        (dt_masks_point_ellipse_t *)((form->points)->data);
       if(dt_modifier_is(state, GDK_SHIFT_MASK | GDK_CONTROL_MASK)
          && gui->edit_mode == DT_MASKS_EDIT_FULL)
       {
@@ -509,13 +598,17 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
       // resize don't care where the mouse is inside a shape
       if(dt_modifier_is(state, GDK_SHIFT_MASK))
       {
-        const float reference = (ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? 1.0f/fmin(ellipse->radius[0], ellipse->radius[1]) : 1.0f);
+        const float reference =
+          (ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL
+           ? 1.0f/fmin(ellipse->radius[0], ellipse->radius[1])
+           : 1.0f);
         if(!up && ellipse->border > 0.001f * reference)
           ellipse->border *= 0.97f;
         else if(up && ellipse->border < radius_limit * reference)
           ellipse->border *= 1.0f/0.97f;
         else return 1;
-        ellipse->border = CLAMP(ellipse->border, 0.001f * reference, radius_limit *reference);
+        ellipse->border = CLAMP(ellipse->border, 0.001f * reference,
+                                radius_limit *reference);
         dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
         dt_masks_gui_form_create(form, gui, index, module);
         dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, border), ellipse->border);
@@ -544,8 +637,9 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
       }
       else if(!dt_modifier_is(state, 0))
       {
-        // user is holding down a modifier key, but we didn't handle that particular combination
-        // say we've processed the scroll event so that the image is not zoomed instead
+        // user is holding down a modifier key, but we didn't handle
+        // that particular combination say we've processed the scroll
+        // event so that the image is not zoomed instead
         return 1;
       }
       else
@@ -559,16 +653,24 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float 
   return 0;
 }
 
-static int _ellipse_events_button_pressed(struct dt_iop_module_t *module, float pzx, float pzy,
-                                          double pressure, int which, int type, uint32_t state,
-                                          dt_masks_form_t *form, int parentid, dt_masks_form_gui_t *gui,
-                                          int index)
+static int _ellipse_events_button_pressed(struct dt_iop_module_t *module,
+                                          const float pzx,
+                                          const float pzy,
+                                          const double pressure,
+                                          const int which,
+                                          const int type,
+                                          const uint32_t state,
+                                          dt_masks_form_t *form,
+                                          const int parentid,
+                                          dt_masks_form_gui_t *gui,
+                                          const int index)
 {
   if(!gui) return 0;
 
   if(!gui->creation)
   {
-    dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+    dt_masks_form_gui_points_t *gpt =
+      (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
     if(!gpt) return 0;
 
     if(gui->form_selected && dt_modifier_is(state, GDK_SHIFT_MASK))
@@ -748,11 +850,19 @@ static int _ellipse_events_button_pressed(struct dt_iop_module_t *module, float 
   return 0;
 }
 
-static int _ellipse_events_button_released(struct dt_iop_module_t *module, float pzx, float pzy, int which,
-                                           uint32_t state, dt_masks_form_t *form, int parentid,
-                                           dt_masks_form_gui_t *gui, int index)
+static int _ellipse_events_button_released(struct dt_iop_module_t *module,
+                                           const float pzx,
+                                           const float pzy,
+                                           const int which,
+                                           const uint32_t state,
+                                           dt_masks_form_t *form,
+                                           const int parentid,
+                                           dt_masks_form_gui_t *gui,
+                                           const int index)
 {
-  if(which == 3 && parentid > 0 && gui->edit_mode == DT_MASKS_EDIT_FULL)
+  if(which == 3
+     && parentid > 0
+     && gui->edit_mode == DT_MASKS_EDIT_FULL)
   {
     // we hide the form
     if(!(darktable.develop->form_visible->type & DT_MASKS_GROUP))
@@ -762,7 +872,9 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
     else
     {
       dt_masks_clear_form_gui(darktable.develop);
-      for(GList *forms = darktable.develop->form_visible->points; forms; forms = g_list_next(forms))
+      for(GList *forms = darktable.develop->form_visible->points;
+          forms;
+          forms = g_list_next(forms))
       {
         dt_masks_point_group_t *gpt = (dt_masks_point_group_t *)forms->data;
         if(gpt->formid == form->formid)
@@ -783,7 +895,8 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
   if(gui->form_dragging)
   {
     // we get the ellipse
-    dt_masks_point_ellipse_t *ellipse = (dt_masks_point_ellipse_t *)((form->points)->data);
+    dt_masks_point_ellipse_t *ellipse =
+      (dt_masks_point_ellipse_t *)((form->points)->data);
 
     // we end the form dragging
     gui->form_dragging = FALSE;
@@ -864,7 +977,8 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
     const float y = pzy * ht;
 
     // we need the reference point
-    dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+    dt_masks_form_gui_points_t *gpt =
+      (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
     if(!gpt) return 0;
 
     // ellipse center
@@ -873,12 +987,16 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
 
     const float pts[8] = { xref, yref, x , y, 0, 0, gui->dx, gui->dy };
 
-    const float dv = atan2f(pts[3] - pts[1], pts[2] - pts[0]) - atan2f(-(pts[7] - pts[5]), -(pts[6] - pts[4]));
+    const float dv = atan2f(pts[3] - pts[1],
+                            pts[2] - pts[0]) - atan2f(-(pts[7] - pts[5]),
+                                                      -(pts[6] - pts[4]));
 
     float pts2[8] = { xref, yref, x , y, xref+10.0f, yref, xref, yref+10.0f };
     dt_dev_distort_backtransform(darktable.develop, pts2, 4);
 
-    float check_angle = atan2f(pts2[7] - pts2[1], pts2[6] - pts2[0]) - atan2f(pts2[5] - pts2[1], pts2[4] - pts2[0]);
+    float check_angle = atan2f(pts2[7] - pts2[1],
+                               pts2[6] - pts2[0]) - atan2f(pts2[5] - pts2[1],
+                                                           pts2[4] - pts2[0]);
     // Normalize to the range -180 to 180 degrees
     check_angle = atan2f(sinf(check_angle), cosf(check_angle));
     if(check_angle < 0)
@@ -898,7 +1016,8 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
 
     return 1;
   }
-  else if(gui->point_dragging >= 1 && gui->edit_mode == DT_MASKS_EDIT_FULL)
+  else if(gui->point_dragging >= 1
+          && gui->edit_mode == DT_MASKS_EDIT_FULL)
   {
    // we end the point dragging
     gui->point_dragging = -1;
@@ -908,7 +1027,8 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
 
     return 1;
   }
-  else if(gui->point_border_dragging >= 1 && gui->edit_mode == DT_MASKS_EDIT_FULL)
+  else if(gui->point_border_dragging >= 1
+          && gui->edit_mode == DT_MASKS_EDIT_FULL)
   {
     // we end the point dragging
     gui->point_border_dragging = -1;
@@ -922,9 +1042,12 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
   {
     // we end the form dragging
     gui->source_dragging = FALSE;
-    if(gui->scrollx != 0.0 || gui->scrolly != 0.0)
+
+    if(gui->scrollx != 0.0
+       || gui->scrolly != 0.0)
     {
-      // if there's no dragging the source is calculated in _ellipse_events_button_pressed()
+      // if there's no dragging the source is calculated in
+      // _ellipse_events_button_pressed()
     }
     else
     {
@@ -964,9 +1087,15 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module, float
   return 0;
 }
 
-static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, float pzx, float pzy,
-                                       double pressure, int which, dt_masks_form_t *form, int parentid,
-                                       dt_masks_form_gui_t *gui, int index)
+static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module,
+                                       const float pzx,
+                                       const float pzy,
+                                       const double pressure,
+                                       const int which,
+                                       dt_masks_form_t *form,
+                                       const int parentid,
+                                       dt_masks_form_gui_t *gui,
+                                       const int index)
 {
   if(gui->form_dragging || gui->source_dragging)
   {
@@ -974,9 +1103,11 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, float pzx
     const float ht = darktable.develop->preview_pipe->backbuf_height;
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
+
     if(gui->form_dragging)
     {
-      dt_masks_point_ellipse_t *ellipse = (dt_masks_point_ellipse_t *)((form->points)->data);
+      dt_masks_point_ellipse_t *ellipse =
+        (dt_masks_point_ellipse_t *)((form->points)->data);
       ellipse->center[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
       ellipse->center[1] = pts[1] / darktable.develop->preview_pipe->iheight;
     }
@@ -998,7 +1129,8 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, float pzx
 
     const float s = dt_masks_drag_factor(gui, index, k, FALSE);
 
-    // make sure we adjust the right radius: anchor points and 1 and 2 correspond to the ellipse's longer axis
+    // make sure we adjust the right radius: anchor points and 1 and 2
+    // correspond to the ellipse's longer axis
     const gboolean dir = (ellipse->radius[0] > ellipse->radius[1]);
     if(((k == 1 || k == 2) && ellipse->radius[0] > ellipse->radius[1])
        || ((k == 3 || k == 4) && ellipse->radius[0] <= ellipse->radius[1]))
@@ -1012,8 +1144,9 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, float pzx
       dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, radius_b), ellipse->radius[1]);
     }
 
-    // as point 1 an 2 always correspond to the longer axis, point number may change when recreating the form
-    // this happen if radius values order change
+    // as point 1 an 2 always correspond to the longer axis, point
+    // number may change when recreating the form this happen if
+    // radius values order change
     if(dir != (ellipse->radius[0] > ellipse->radius[1]))
     {
       if(dir)
@@ -1052,15 +1185,18 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, float pzx
 
     const float s = dt_masks_drag_factor(gui, index, k, TRUE);
 
-    const float radius_limit = form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 1.0f;
+    const float radius_limit =
+      form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 1.0f;
     const int prop = ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL;
     const float reference = (prop ? 1.0f/fmin(ellipse->radius[0], ellipse->radius[1]) : 1.0f);
 
-    ellipse->border = CLAMP(prop ? (1.0f + ellipse->border) * s - 1.0f
-                                 : ((gui->point_border_dragging >= 3) ^ (ellipse->radius[0] > ellipse->radius[1]))
-                                 ? (ellipse->radius[0] + ellipse->border) * s - ellipse->radius[0]
-                                 : (ellipse->radius[1] + ellipse->border) * s - ellipse->radius[1],
-                            0.001f * reference, radius_limit *reference);
+    ellipse->border =
+      CLAMP(prop ? (1.0f + ellipse->border) * s - 1.0f
+            : ((gui->point_border_dragging >= 3)
+               ^ (ellipse->radius[0] > ellipse->radius[1]))
+            ? (ellipse->radius[0] + ellipse->border) * s - ellipse->radius[0]
+            : (ellipse->radius[1] + ellipse->border) * s - ellipse->radius[1],
+            0.001f * reference, radius_limit *reference);
 
     // we recreate the form points
     dt_masks_gui_form_create(form, gui, index, module);
@@ -1077,7 +1213,8 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, float pzx
     const float y = pzy * ht;
 
     // we need the reference point
-    dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+    dt_masks_form_gui_points_t *gpt =
+      (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
     if(!gpt) return 0;
 
     // ellipse center
@@ -1091,7 +1228,9 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, float pzx
     float pts2[8] = { xref, yref, x, y, xref + 10.0f, yref, xref, yref + 10.0f };
     dt_dev_distort_backtransform(darktable.develop, pts2, 4);
 
-    float check_angle = atan2f(pts2[7] - pts2[1], pts2[6] - pts2[0]) - atan2f(pts2[5] - pts2[1], pts2[4] - pts2[0]);
+    float check_angle = atan2f(pts2[7] - pts2[1],
+                               pts2[6] - pts2[0]) - atan2f(pts2[5] - pts2[1],
+                                                           pts2[4] - pts2[0]);
     // Normalize to the range -180 to 180 degrees
     check_angle = atan2f(sinf(check_angle), cosf(check_angle));
     if(check_angle < 0)
@@ -1116,11 +1255,12 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, float pzx
     const dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
     const int closeup = dt_control_get_dev_closeup();
     const float zoom_scale = dt_dev_get_zoom_scale(darktable.develop, zoom, 1<<closeup, 1);
-    const float as = DT_PIXEL_APPLY_DPI(5) / zoom_scale;  // transformed to backbuf dimensions
+    // transformed to backbuf dimensions
+    const float as = DT_PIXEL_APPLY_DPI(5) / zoom_scale;
     const float x = pzx * darktable.develop->preview_pipe->backbuf_width;
     const float y = pzy * darktable.develop->preview_pipe->backbuf_height;
 
-    int in = 0, inb = 0, near = 0, ins = 0; // FIXME gcc7 false-positive
+    int in = 0, inb = 0, near = 0, ins = 0;
     float dist = 0.0f;
     _ellipse_get_distance(x, y, as, gui, index, 0, &in, &inb, &near, &ins, &dist);
     if(ins)
@@ -1153,17 +1293,23 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, float pzx
     gui->point_border_selected = -1;
     if(gui->form_selected)
     {
-      dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+      dt_masks_form_gui_points_t *gpt =
+        (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
       for(int i = 1; i < 5; i++)
       {
-        // prefer border points over shape itself in case of near overlap for ease of pickup
-        if(x - gpt->border[i * 2] > -as && x - gpt->border[i * 2] < as && y - gpt->border[i * 2 + 1] > -as
+        // prefer border points over shape itself in case of near
+        // overlap for ease of pickup
+        if(x - gpt->border[i * 2] > -as
+           && x - gpt->border[i * 2] < as
+           && y - gpt->border[i * 2 + 1] > -as
            && y - gpt->border[i * 2 + 1] < as)
         {
           gui->point_border_selected = i;
           break;
         }
-        if(x - gpt->points[i * 2] > -as && x - gpt->points[i * 2] < as && y - gpt->points[i * 2 + 1] > -as
+        if(x - gpt->points[i * 2] > -as
+           && x - gpt->points[i * 2] < as
+           && y - gpt->points[i * 2 + 1] > -as
            && y - gpt->points[i * 2 + 1] < as)
         {
           gui->point_selected = i;
@@ -1187,15 +1333,19 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module, float pzx
   return 0;
 }
 
-static void _ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_form_gui_t *gui, int index,
-                                        int num_points)
+static void _ellipse_events_post_expose(cairo_t *cr,
+                                        const float zoom_scale,
+                                        dt_masks_form_gui_t *gui,
+                                        const int index,
+                                        const int num_points)
 {
   (void)num_points; //unused arg, keep compiler from complaining
   double dashed[] = { 4.0, 4.0 };
   dashed[0] /= zoom_scale;
   dashed[1] /= zoom_scale;
   const int len = sizeof(dashed) / sizeof(dashed[0]);
-  dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+  dt_masks_form_gui_points_t *gpt =
+    (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
 
   float xref = 0.0f, yref = 0.0f;
   float xrefs = 0.0f, yrefs = 0.0f;
@@ -1240,13 +1390,18 @@ static void _ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
 
       int draw = 0;
 
-      draw = _ellipse_get_points(darktable.develop, x, y, radius_a, radius_b, rotation, &points, &points_count);
+      draw = _ellipse_get_points(darktable.develop, x, y, radius_a, radius_b,
+                                 rotation, &points, &points_count);
       if(draw && masks_border > 0.f)
       {
         draw = _ellipse_get_points(
             darktable.develop, x, y,
-            (flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? radius_a * (1.0f + masks_border) : radius_a + masks_border),
-            (flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? radius_b * (1.0f + masks_border) : radius_b + masks_border),
+            (flags & DT_MASKS_ELLIPSE_PROPORTIONAL
+             ? radius_a * (1.0f + masks_border)
+             : radius_a + masks_border),
+            (flags & DT_MASKS_ELLIPSE_PROPORTIONAL
+             ? radius_b * (1.0f + masks_border)
+             : radius_b + masks_border),
             rotation, &border, &border_count);
       }
 
@@ -1255,14 +1410,16 @@ static void _ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
         xref = points[0];
         yref = points[1];
 
-        _ellipse_draw_shape(FALSE, FALSE, cr, dashed, len, FALSE, zoom_scale, xref, yref, points, points_count);
+        _ellipse_draw_shape(FALSE, FALSE, cr, dashed, len, FALSE,
+                            zoom_scale, xref, yref, points, points_count);
       }
       if(draw && border_count >= 2)
       {
         xref = border[0];
         yref = border[1];
 
-        _ellipse_draw_shape(TRUE, FALSE, cr, dashed, len, FALSE, zoom_scale, xref, yref, border, border_count);
+        _ellipse_draw_shape(TRUE, FALSE, cr, dashed, len, FALSE,
+                            zoom_scale, xref, yref, border, border_count);
       }
 
       // draw a cross where the source will be created
@@ -1270,7 +1427,8 @@ static void _ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       {
         x = 0.0f;
         y = 0.0f;
-        dt_masks_calculate_source_pos_value(gui, DT_MASKS_ELLIPSE, pzx, pzy, pzx, pzy, &x, &y, FALSE);
+        dt_masks_calculate_source_pos_value(gui, DT_MASKS_ELLIPSE,
+                                            pzx, pzy, pzx, pzy, &x, &y, FALSE);
         dt_masks_draw_clone_source_pos(cr, zoom_scale, x, y);
       }
 
@@ -1293,26 +1451,36 @@ static void _ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
   }
 
   // draw shape
-  const gboolean selected = (gui->group_selected == index) && (gui->form_selected || gui->form_dragging);
-  _ellipse_draw_shape(FALSE, FALSE, cr, dashed, 0, selected, zoom_scale, xref, yref, gpt->points, gpt->points_count);
+  const gboolean selected =
+    (gui->group_selected == index) && (gui->form_selected || gui->form_dragging);
+  _ellipse_draw_shape(FALSE, FALSE, cr, dashed, 0, selected,
+                      zoom_scale, xref, yref, gpt->points, gpt->points_count);
 
   // draw border
   if(gui->show_all_feathers || gui->group_selected == index)
   {
-    _ellipse_draw_shape(TRUE, FALSE, cr, dashed, len, gui->border_selected, zoom_scale, xref, yref, gpt->border, gpt->border_count);
+    _ellipse_draw_shape(TRUE, FALSE, cr, dashed, len,
+                        gui->border_selected, zoom_scale, xref, yref,
+                        gpt->border, gpt->border_count);
 
     // draw anchor points
-    const float r = atan2f(gpt->points[3] - gpt->points[1], gpt->points[2] - gpt->points[0]);
+    const float r = atan2f(gpt->points[3] - gpt->points[1],
+                           gpt->points[2] - gpt->points[0]);
     const float sinr = sinf(r);
     const float cosr = cosf(r);
 
     for(int i = 1; i < 5; i++)
     {
       float x, y;
-      _ellipse_point_transform(xref, yref, gpt->points[i * 2], gpt->points[i * 2 + 1], sinr, cosr, &x, &y);
-      dt_masks_draw_anchor(cr, i == gui->point_dragging || i == gui->point_selected, zoom_scale, x, y);
-      _ellipse_point_transform(xref, yref, gpt->border[i * 2], gpt->border[i * 2 + 1], sinr, cosr, &x, &y);
-      dt_masks_draw_anchor(cr, i == gui->point_border_dragging || i == gui->point_border_selected, zoom_scale, x, y);
+      _ellipse_point_transform(xref, yref, gpt->points[i * 2],
+                               gpt->points[i * 2 + 1], sinr, cosr, &x, &y);
+      dt_masks_draw_anchor(cr, i == gui->point_dragging || i == gui->point_selected,
+                           zoom_scale, x, y);
+      _ellipse_point_transform(xref, yref, gpt->border[i * 2],
+                               gpt->border[i * 2 + 1], sinr, cosr, &x, &y);
+      dt_masks_draw_anchor
+        (cr, i == gui->point_border_dragging || i == gui->point_border_selected,
+         zoom_scale, x, y);
     }
   }
 
@@ -1320,7 +1488,8 @@ static void _ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
   if(gpt->source_count > 10)
   {
     const float pr_d = darktable.develop->preview_downsampling;
-    // compute the dest inner ellipse intersection with the line from source center to dest center.
+    // compute the dest inner ellipse intersection with the line from
+    // source center to dest center.
     const float cdx = gpt->source[0] - gpt->points[0];
     const float cdy = gpt->source[1] - gpt->points[1];
 
@@ -1335,8 +1504,9 @@ static void _ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       else
         cangle = -(M_PI / 2) - cangle;
 
-      // compute raidus a & radius b. at this stage this must be computed from the list
-      // of transformed point for drawing the ellipse.
+      // compute raidus a & radius b. at this stage this must be
+      // computed from the list of transformed point for drawing the
+      // ellipse.
 
       const float bot_x = gpt->points[2];
       const float bot_y = gpt->points[3];
@@ -1353,13 +1523,15 @@ static void _ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       const float bdy = cnt_y - rgt_y;
       const float b = sqrtf(bdx * bdx + bdy * bdy);
 
-      // takes the biggest radius, should always been a as the points are arranged
+      // takes the biggest radius, should always been a as the points
+      // are arranged
       const float radius = MAX(a, b);
 
-      // the top/left/bottom/right controls of the ellipse are not always at the
-      // same place in g->points[], it depends on the rotation of the ellipse which
-      // is not recorded anywhere. Let's use a stupid search to find the closest
-      // point on the border where to attach the arrow.
+      // the top/left/bottom/right controls of the ellipse are not
+      // always at the same place in g->points[], it depends on the
+      // rotation of the ellipse which is not recorded anywhere. Let's
+      // use a stupid search to find the closest point on the border
+      // where to attach the arrow.
 
       const float cosc = cosf(cangle);
       const float sinc = sinf(cangle);
@@ -1418,11 +1590,17 @@ static void _ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
     }
 
     // we draw the source
-    _ellipse_draw_shape(FALSE, TRUE, cr, dashed, 0, selected, zoom_scale, xrefs, yrefs, gpt->source, gpt->source_count);
+    _ellipse_draw_shape(FALSE, TRUE, cr, dashed, 0, selected,
+                        zoom_scale, xrefs, yrefs, gpt->source, gpt->source_count);
    }
 }
 
-static void _bounding_box(const float *const points, int num_points, int *width, int *height, int *posx, int *posy)
+static void _bounding_box(const float *const points,
+                          const int num_points,
+                          int *width,
+                          int *height,
+                          int *posx,
+                          int *posy)
 {
   // search for min/max X and Y coordinates
   float xmin = FLT_MAX, xmax = FLT_MIN, ymin = FLT_MAX, ymax = FLT_MIN;
@@ -1440,9 +1618,16 @@ static void _bounding_box(const float *const points, int num_points, int *width,
   *height = (ymax - ymin);
 }
 
-static void _fill_mask(const size_t numpoints, float *const bufptr, const float *const points,
-                       const float *const center, const float a, const float b, const float ta, const float tb,
-                       const float alpha, const size_t out_scale)
+static void _fill_mask(const size_t numpoints,
+                       float *const bufptr,
+                       const float *const points,
+                       const float *const center,
+                       const float a,
+                       const float b,
+                       const float ta,
+                       const float tb,
+                       const float alpha,
+                       const size_t out_scale)
 {
   const float a2 = a * a;
   const float b2 = b * b;
@@ -1451,12 +1636,16 @@ static void _fill_mask(const size_t numpoints, float *const bufptr, const float 
   const float cos_alpha = cosf(alpha);
   const float sin_alpha = sinf(alpha);
 
-  // Determine the strength of the mask for each of the distorted points.  If inside the border of the ellipse,
-  // the strength is always 1.0; if outside the falloff region, it is 0.0, and in between it falls off quadratically.
-  // To compute this, we need to do the equivalent of projecting the vector from the center of the ellipse to the
-  // given point until it intersect the ellipse and the outer edge of the falloff, respectively.  The ellipse can
-  // be rotated, but we can compensate for that by applying a rotation matrix for the same rotation in the opposite
-  // direction before projecting the vector.
+  // Determine the strength of the mask for each of the distorted
+  // points.  If inside the border of the ellipse, the strength is
+  // always 1.0; if outside the falloff region, it is 0.0, and in
+  // between it falls off quadratically.  To compute this, we need to
+  // do the equivalent of projecting the vector from the center of the
+  // ellipse to the given point until it intersect the ellipse and the
+  // outer edge of the falloff, respectively.  The ellipse can be
+  // rotated, but we can compensate for that by applying a rotation
+  // matrix for the same rotation in the opposite direction before
+  // projecting the vector.
 #ifdef _OPENMP
 #if !defined(__SUNOS__) && !defined(__NetBSD__)
 #pragma omp parallel for default(none) \
@@ -1473,22 +1662,29 @@ static void _fill_mask(const size_t numpoints, float *const bufptr, const float 
       // find the square of the distance from the center
       const float l2 = x * x + y * y;
       const float l = sqrtf(l2);
-      // normalize the point's coordinate to form a unit vector, taking care not to divide by zero
+      // normalize the point's coordinate to form a unit vector,
+      // taking care not to divide by zero
       const float x_norm = l ? x / l : 0.0f;
-      const float y_norm = l ? y / l : 1.0f;  // ensure we don't get 0 for both sine and cosine below
+      const float y_norm = l ? y / l : 1.0f;  // ensure we don't get 0
+                                              // for both sine and
+                                              // cosine below
       // apply the rotation matrix
       const float x_rot = x_norm * cos_alpha + y_norm * sin_alpha;
       const float y_rot = -x_norm * sin_alpha + y_norm * cos_alpha;
-      // at this point, x_rot = cos(v) and y_rot = sin(v) since they are on the unit circle; we need the squared values
+      // at this point, x_rot = cos(v) and y_rot = sin(v) since they
+      // are on the unit circle; we need the squared values
       const float cosv2 = x_rot * x_rot;
       const float sinv2 = y_rot * y_rot;
 
-      // project the rotated unit vector out to the ellipse and the outer border
+      // project the rotated unit vector out to the ellipse and the
+      // outer border
       const float radius2 = a2 * b2 / (a2 * sinv2 + b2 * cosv2);
       const float total2 = ta2 * tb2 / (ta2 * sinv2 + tb2 * cosv2);
 
-      // quadratic falloff between the ellipses's radius and the radius of the outside of the feathering
-      // ratio = 0.0 at the outer border, >= 1.0 within the ellipse, negative outside the falloff
+      // quadratic falloff between the ellipses's radius and the
+      // radius of the outside of the feathering ratio = 0.0 at the
+      // outer border, >= 1.0 within the ellipse, negative outside the
+      // falloff
       const float ratio = (total2 - l2) / (total2 - radius2);
       // enforce 1.0 inside the ellipse and 0.0 outside the feathering
       const float f = CLIP(ratio);
@@ -1496,8 +1692,13 @@ static void _fill_mask(const size_t numpoints, float *const bufptr, const float 
     }
 }
 
-static float *const _ellipse_points_to_transform(const float center_x, const float center_y, const float dim1, const float dim2,
-                                                 const float rotation, const float wd, const float ht, size_t *point_count)
+static float *const _ellipse_points_to_transform(const float center_x,
+                                                 const float center_y,
+                                                 const float dim1, const float dim2,
+                                                 const float rotation,
+                                                 const float wd,
+                                                 const float ht,
+                                                 size_t *point_count)
 {
 
   const float v1 = ((rotation) / 180.0f) * M_PI;
@@ -1523,7 +1724,8 @@ static float *const _ellipse_points_to_transform(const float center_x, const flo
   // how many points do we need ?
   const float lambda = (a - b) / (a + b);
   const int l = (int)(M_PI * (a + b)
-                      * (1.0f + (3.0f * lambda * lambda) / (10.0f + sqrtf(4.0f - 3.0f * lambda * lambda))));
+                      * (1.0f + (3.0f * lambda * lambda)
+                         / (10.0f + sqrtf(4.0f - 3.0f * lambda * lambda))));
 
   // buffer allocation
   float *points = dt_alloc_align_float((size_t) 2 * (l + 5));
@@ -1553,25 +1755,38 @@ static float *const _ellipse_points_to_transform(const float center_x, const flo
   return points;
 }
 
-static int _ellipse_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece,
-                                    dt_masks_form_t *form, int *width, int *height, int *posx, int *posy)
+static int _ellipse_get_source_area(dt_iop_module_t *module,
+                                    dt_dev_pixelpipe_iop_t *piece,
+                                    dt_masks_form_t *form,
+                                    int *width,
+                                    int *height,
+                                    int *posx,
+                                    int *posy)
 {
   // we get the ellipse values
   dt_masks_point_ellipse_t *ellipse = (dt_masks_point_ellipse_t *)((form->points)->data);
   const float wd = piece->pipe->iwidth, ht = piece->pipe->iheight;
   const int prop = ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL;
-  const float total[2] = { (prop ? ellipse->radius[0] * (1.0f + ellipse->border) : ellipse->radius[0] + ellipse->border) * MIN(wd, ht),
-                           (prop ? ellipse->radius[1] * (1.0f + ellipse->border) : ellipse->radius[1] + ellipse->border) * MIN(wd, ht) };
+  const float total[2] = { (prop
+                            ? ellipse->radius[0] * (1.0f + ellipse->border)
+                            : ellipse->radius[0] + ellipse->border) * MIN(wd, ht),
+                           (prop
+                            ? ellipse->radius[1] * (1.0f + ellipse->border)
+                            : ellipse->radius[1] + ellipse->border) * MIN(wd, ht) };
 
   // next we compute the points to be transformed
   size_t point_count = 0;
   float *const restrict points
-    = _ellipse_points_to_transform(form->source[0], form->source[1], total[0], total[1], ellipse->rotation, wd, ht, &point_count);
+    = _ellipse_points_to_transform(form->source[0], form->source[1],
+                                   total[0], total[1],
+                                   ellipse->rotation, wd, ht, &point_count);
   if(!points)
     return 0;
 
   // and we transform them with all distorted modules
-  if(!dt_dev_distort_transform_plus(darktable.develop, piece->pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points, point_count))
+  if(!dt_dev_distort_transform_plus(darktable.develop, piece->pipe,
+                                    module->iop_order,
+                                    DT_DEV_TRANSFORM_DIR_BACK_INCL, points, point_count))
   {
     dt_free_align(points);
     return 0;
@@ -1583,26 +1798,37 @@ static int _ellipse_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_io
   return 1;
 }
 
-static int _ellipse_get_area(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
+static int _ellipse_get_area(const dt_iop_module_t *const module,
+                             const dt_dev_pixelpipe_iop_t *const piece,
                              dt_masks_form_t *const form,
-                             int *width, int *height, int *posx, int *posy)
+                             int *width,
+                             int *height,
+                             int *posx,
+                             int *posy)
 {
   // we get the ellipse values
   dt_masks_point_ellipse_t *ellipse = (dt_masks_point_ellipse_t *)((form->points)->data);
   const float wd = piece->pipe->iwidth, ht = piece->pipe->iheight;
   const int prop = ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL;
-  const float total[2] = { (prop ? ellipse->radius[0] * (1.0f + ellipse->border) : ellipse->radius[0] + ellipse->border) * MIN(wd, ht),
-                           (prop ? ellipse->radius[1] * (1.0f + ellipse->border) : ellipse->radius[1] + ellipse->border) * MIN(wd, ht) };
+  const float total[2] = { (prop
+                            ? ellipse->radius[0] * (1.0f + ellipse->border)
+                            : ellipse->radius[0] + ellipse->border) * MIN(wd, ht),
+                           (prop
+                            ? ellipse->radius[1] * (1.0f + ellipse->border)
+                            : ellipse->radius[1] + ellipse->border) * MIN(wd, ht) };
 
   // next we compute the points to be transformed
   size_t point_count = 0;
   float *const restrict points
-    = _ellipse_points_to_transform(ellipse->center[0], ellipse->center[1], total[0], total[1], ellipse->rotation, wd, ht, &point_count);
+    = _ellipse_points_to_transform(ellipse->center[0], ellipse->center[1],
+                                   total[0], total[1], ellipse->rotation,
+                                   wd, ht, &point_count);
   if(!points)
     return 0;
 
   // and we transform them with all distorted modules
-  if(!dt_dev_distort_transform_plus(module->dev, piece->pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points, point_count))
+  if(!dt_dev_distort_transform_plus(module->dev, piece->pipe, module->iop_order,
+                                    DT_DEV_TRANSFORM_DIR_BACK_INCL, points, point_count))
   {
     dt_free_align(points);
     return 0;
@@ -1614,9 +1840,14 @@ static int _ellipse_get_area(const dt_iop_module_t *const module, const dt_dev_p
   return 1;
 }
 
-static int _ellipse_get_mask(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
+static int _ellipse_get_mask(const dt_iop_module_t *const module,
+                             const dt_dev_pixelpipe_iop_t *const piece,
                              dt_masks_form_t *const form,
-                             float **buffer, int *width, int *height, int *posx, int *posy)
+                             float **buffer,
+                             int *width,
+                             int *height,
+                             int *posx,
+                             int *posy)
 {
   double start2 = 0.0;
   if(darktable.unmuted & DT_DEBUG_PERF) start2 = dt_get_wtime();
@@ -1626,7 +1857,9 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module, const dt_dev_p
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] ellipse area took %0.04f sec\n", form->name, dt_get_wtime() - start2);
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] ellipse area took %0.04f sec\n",
+             form->name, dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
 
@@ -1648,12 +1881,16 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module, const dt_dev_p
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] ellipse draw took %0.04f sec\n", form->name, dt_get_wtime() - start2);
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] ellipse draw took %0.04f sec\n",
+             form->name, dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
 
   // we back transform all this points
-  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points, (size_t)w * h))
+  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, module->iop_order,
+                                        DT_DEV_TRANSFORM_DIR_BACK_INCL,
+                                        points, (size_t)w * h))
   {
     dt_free_align(points);
     return 0;
@@ -1661,7 +1898,8 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module, const dt_dev_p
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] ellipse transform took %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] ellipse transform took %0.04f sec\n", form->name,
              dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
@@ -1676,10 +1914,16 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module, const dt_dev_p
 
   // we populate the buffer
   const int wi = piece->pipe->iwidth, hi = piece->pipe->iheight;
-  const float center[2] = { ellipse->center[0] * wi, ellipse->center[1] * hi };
-  const float radius[2] = { ellipse->radius[0] * MIN(wi, hi), ellipse->radius[1] * MIN(wi, hi) };
-  const float total[2] =  { (ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? ellipse->radius[0] * (1.0f + ellipse->border) : ellipse->radius[0] + ellipse->border) * MIN(wi, hi),
-                            (ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? ellipse->radius[1] * (1.0f + ellipse->border) : ellipse->radius[1] + ellipse->border) * MIN(wi, hi) };
+  const float center[2] = { ellipse->center[0] * wi,
+                            ellipse->center[1] * hi };
+  const float radius[2] = { ellipse->radius[0] * MIN(wi, hi),
+                            ellipse->radius[1] * MIN(wi, hi) };
+  const float total[2] =  { (ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL
+                             ? ellipse->radius[0] * (1.0f + ellipse->border)
+                             : ellipse->radius[0] + ellipse->border) * MIN(wi, hi),
+                            (ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL
+                             ? ellipse->radius[1] * (1.0f + ellipse->border)
+                             : ellipse->radius[1] + ellipse->border) * MIN(wi, hi) };
 
   float a = 0.0F, b = 0.0F, ta = 0.0F, tb = 0.0F, alpha = 0.0F;
 
@@ -1712,8 +1956,11 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module, const dt_dev_p
   return 1;
 }
 
-static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
-                                 dt_masks_form_t *const form, const dt_iop_roi_t *roi, float *buffer)
+static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
+                                 const dt_dev_pixelpipe_iop_t *const piece,
+                                 dt_masks_form_t *const form,
+                                 const dt_iop_roi_t *roi,
+                                 float *buffer)
 {
   double start1 = 0.0;
   double start2 = start1;
@@ -1722,10 +1969,16 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, const dt_d
   // we get the ellipse parameters
   dt_masks_point_ellipse_t *ellipse = (dt_masks_point_ellipse_t *)((form->points)->data);
   const int wi = piece->pipe->iwidth, hi = piece->pipe->iheight;
-  const float center[2] = { ellipse->center[0] * wi, ellipse->center[1] * hi };
-  const float radius[2] = { ellipse->radius[0] * MIN(wi, hi), ellipse->radius[1] * MIN(wi, hi) };
-  const float total[2] = { (ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? ellipse->radius[0] * (1.0f + ellipse->border) : ellipse->radius[0] + ellipse->border) * MIN(wi, hi),
-                           (ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? ellipse->radius[1] * (1.0f + ellipse->border) : ellipse->radius[1] + ellipse->border) * MIN(wi, hi) };
+  const float center[2] = { ellipse->center[0] * wi,
+                            ellipse->center[1] * hi };
+  const float radius[2] = { ellipse->radius[0] * MIN(wi, hi),
+                            ellipse->radius[1] * MIN(wi, hi) };
+  const float total[2] = { (ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL
+                            ? ellipse->radius[0] * (1.0f + ellipse->border)
+                            : ellipse->radius[0] + ellipse->border) * MIN(wi, hi),
+                           (ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL
+                            ? ellipse->radius[1] * (1.0f + ellipse->border)
+                            : ellipse->radius[1] + ellipse->border) * MIN(wi, hi) };
 
   const float a = radius[0];
   const float b = radius[1];
@@ -1735,27 +1988,33 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, const dt_d
   const float cosa = cosf(alpha);
   const float sina = sinf(alpha);
 
-  // we create a buffer of grid points for later interpolation: higher speed and reduced memory footprint;
-  // we match size of buffer to bounding box around the shape
+  // we create a buffer of grid points for later interpolation: higher
+  // speed and reduced memory footprint; we match size of buffer to
+  // bounding box around the shape
   const int w = roi->width;
   const int h = roi->height;
   const int px = roi->x;
   const int py = roi->y;
   const float iscale = 1.0f / roi->scale;
-  const int grid = CLAMP((10.0f * roi->scale + 2.0f) / 3.0f, 1, 4); // scale dependent resolution
+  const int grid = CLAMP((10.0f * roi->scale + 2.0f) / 3.0f, 1, 4);
   const int gw = (w + grid - 1) / grid + 1;  // grid dimension of total roi
   const int gh = (h + grid - 1) / grid + 1;  // grid dimension of total roi
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] ellipse init took %0.04f sec\n", form->name, dt_get_wtime() - start2);
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] ellipse init took %0.04f sec\n",
+             form->name, dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
 
-  // we look at the outer line of the shape - no effects outside of this ellipse;
-  // we need many points as we do not know how the ellipse might get distorted in the pixelpipe
+  // we look at the outer line of the shape - no effects outside of
+  // this ellipse; we need many points as we do not know how the
+  // ellipse might get distorted in the pixelpipe
   const float lambda = (ta - tb) / (ta + tb);
-  const int l = (int)(M_PI * (ta + tb) * (1.0f + (3.0f * lambda * lambda) / (10.0f + sqrtf(4.0f - 3.0f * lambda * lambda))));
+  const int l = (int)(M_PI * (ta + tb)
+                      * (1.0f + (3.0f * lambda * lambda)
+                         / (10.0f + sqrtf(4.0f - 3.0f * lambda * lambda))));
   const size_t ellpts = MIN(360, l);
   float *ell = dt_alloc_align_float(ellpts * 2);
   if(ell == NULL) return 0;
@@ -1780,13 +2039,16 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, const dt_d
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] ellipse outline took %0.04f sec\n", form->name, dt_get_wtime() - start2);
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] ellipse outline took %0.04f sec\n",
+             form->name, dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
 
   // we transform the outline from input image coordinates to current position in pixelpipe
-  if(!dt_dev_distort_transform_plus(module->dev, piece->pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, ell,
-                                        ellpts))
+  if(!dt_dev_distort_transform_plus(module->dev, piece->pipe, module->iop_order,
+                                    DT_DEV_TRANSFORM_DIR_BACK_INCL, ell,
+                                    ellpts))
   {
     dt_free_align(ell);
     return 0;
@@ -1794,7 +2056,9 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, const dt_d
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] ellipse outline transform took %0.04f sec\n", form->name, dt_get_wtime() - start2);
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] ellipse outline transform took %0.04f sec\n",
+             form->name, dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
 
@@ -1834,12 +2098,15 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, const dt_d
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] ellipse bounding box took %0.04f sec\n", form->name, dt_get_wtime() - start2);
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] ellipse bounding box took %0.04f sec\n",
+             form->name, dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
 
-  // check if there is anything to do at all;
-  // only if width and height of bounding box is 2 or greater the shape lies inside of roi and requires action
+  // check if there is anything to do at all; only if width and height
+  // of bounding box is 2 or greater the shape lies inside of roi and
+  // requires action
   if(bbw <= 1 || bbh <= 1)
     return 1;
 
@@ -1866,12 +2133,15 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, const dt_d
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] ellipse grid took %0.04f sec\n", form->name, dt_get_wtime() - start2);
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] ellipse grid took %0.04f sec\n",
+             form->name, dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
 
   // we back transform all these points to the input image coordinates
-  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points,
+  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, module->iop_order,
+                                        DT_DEV_TRANSFORM_DIR_BACK_INCL, points,
                                         (size_t)bbw * bbh))
   {
     dt_free_align(points);
@@ -1880,13 +2150,15 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, const dt_d
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] ellipse transform took %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] ellipse transform took %0.04f sec\n", form->name,
              dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
 
-  // we calculate the mask values at the transformed points;
-  // re-use the points array for results; this requires out_scale==1 to double the offsets at which they are stored
+  // we calculate the mask values at the transformed points; re-use
+  // the points array for results; this requires out_scale==1 to
+  // double the offsets at which they are stored
   _fill_mask((size_t)(bbh)*bbw, points, points, center, a, b, ta, tb, alpha, 1);
 
   if(darktable.unmuted & DT_DEBUG_PERF)
@@ -1919,8 +2191,10 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, const dt_d
       const int mi = i / grid - bbxm;
       const size_t mindex = (size_t)mj * bbw + mi;
       buffer[(size_t)j * w + i]
-          = (points[mindex * 2] * (grid - ii) * (grid - jj) + points[(mindex + 1) * 2] * ii * (grid - jj)
-             + points[(mindex + bbw) * 2] * (grid - ii) * jj + points[(mindex + bbw + 1) * 2] * ii * jj)
+          = (points[mindex * 2] * (grid - ii) * (grid - jj)
+             + points[(mindex + 1) * 2] * ii * (grid - jj)
+             + points[(mindex + bbw) * 2] * (grid - ii) * jj
+             + points[(mindex + bbw + 1) * 2] * ii * jj)
             / (grid * grid);
     }
   }
@@ -1929,8 +2203,11 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, const dt_d
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] ellipse fill took %0.04f sec\n", form->name, dt_get_wtime() - start2);
-    dt_print(DT_DEBUG_MASKS, "[masks %s] ellipse total render took %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] ellipse fill took %0.04f sec\n",
+             form->name, dt_get_wtime() - start2);
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] ellipse total render took %0.04f sec\n", form->name,
              dt_get_wtime() - start1);
   }
   return 1;
@@ -1939,33 +2216,52 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module, const dt_d
 static GSList *_ellipse_setup_mouse_actions(const struct dt_masks_form_t *const form)
 {
   GSList *lm = NULL;
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, 0, _("[ELLIPSE] change size"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_SHIFT_MASK, _("[ELLIPSE] change feather size"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_SHIFT_MASK|GDK_CONTROL_MASK, _("[ELLIPSE] rotate shape"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_CONTROL_MASK, _("[ELLIPSE] change opacity"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_LEFT, GDK_SHIFT_MASK, _("[ELLIPSE] switch feathering mode"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_LEFT_DRAG, GDK_CONTROL_MASK, _("[ELLIPSE] rotate shape"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL,
+                                     0,
+                                     _("[ELLIPSE] change size"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL,
+                                     GDK_SHIFT_MASK,
+                                     _("[ELLIPSE] change feather size"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL,
+                                     GDK_SHIFT_MASK|GDK_CONTROL_MASK,
+                                     _("[ELLIPSE] rotate shape"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL,
+                                     GDK_CONTROL_MASK,
+                                     _("[ELLIPSE] change opacity"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_LEFT,
+                                     GDK_SHIFT_MASK,
+                                     _("[ELLIPSE] switch feathering mode"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_LEFT_DRAG,
+                                     GDK_CONTROL_MASK,
+                                     _("[ELLIPSE] rotate shape"));
   return lm;
 }
 
-static void _ellipse_set_form_name(struct dt_masks_form_t *const form, const size_t nb)
+static void _ellipse_set_form_name(struct dt_masks_form_t *const form,
+                                   const size_t nb)
 {
   snprintf(form->name, sizeof(form->name), _("ellipse #%d"), (int)nb);
 }
 
-static void _ellipse_duplicate_points(dt_develop_t *const dev, dt_masks_form_t *const base, dt_masks_form_t *const dest)
+static void _ellipse_duplicate_points(dt_develop_t *const dev,
+                                      dt_masks_form_t *const base,
+                                      dt_masks_form_t *const dest)
 {
   (void)dev; // unused arg, keep compiler from complaining
   for(GList *pts = base->points; pts; pts = g_list_next(pts))
   {
     dt_masks_point_ellipse_t *pt = (dt_masks_point_ellipse_t *)pts->data;
-    dt_masks_point_ellipse_t *npt = (dt_masks_point_ellipse_t *)malloc(sizeof(dt_masks_point_ellipse_t));
+    dt_masks_point_ellipse_t *npt =
+      (dt_masks_point_ellipse_t *)malloc(sizeof(dt_masks_point_ellipse_t));
     memcpy(npt, pt, sizeof(dt_masks_point_ellipse_t));
     dest->points = g_list_append(dest->points, npt);
   }
 }
 
-static void _ellipse_initial_source_pos(const float iwd, const float iht, float *x, float *y)
+static void _ellipse_initial_source_pos(const float iwd,
+                                        const float iht,
+                                        float *x,
+                                        float *y)
 {
   const float radius_a = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_a");
   const float radius_b = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_b");
@@ -1974,25 +2270,32 @@ static void _ellipse_initial_source_pos(const float iwd, const float iht, float 
   *y = -(radius_b * iht);
 }
 
-static void _ellipse_set_hint_message(const dt_masks_form_gui_t *const gui, const dt_masks_form_t *const form,
-                                        const int opacity, char *const restrict msgbuf, const size_t msgbuf_len)
+static void _ellipse_set_hint_message(const dt_masks_form_gui_t *const gui,
+                                      const dt_masks_form_t *const form,
+                                      const int opacity,
+                                      char *const restrict msgbuf,
+                                      const size_t msgbuf_len)
 {
   if(gui->creation)
     g_snprintf(msgbuf, msgbuf_len,
                _("<b>size</b>: scroll, <b>feather size</b>: shift+scroll\n"
-                 "<b>rotation</b>: ctrl+shift+scroll, <b>opacity</b>: ctrl+scroll (%d%%)"), opacity);
+                 "<b>rotation</b>: ctrl+shift+scroll, "
+                 "<b>opacity</b>: ctrl+scroll (%d%%)"), opacity);
   else if(gui->point_selected >= 0)
     g_strlcat(msgbuf, _("<b>rotate</b>: ctrl+drag"), msgbuf_len);
   else if(gui->form_selected)
     g_snprintf(msgbuf, msgbuf_len,
                _("<b>feather mode</b>: shift+click, <b>rotate</b>: ctrl+drag\n"
-                 "<b>size</b>: scroll, <b>feather size</b>: shift+scroll, <b>opacity</b>: ctrl+scroll (%d%%)"), opacity);
+                 "<b>size</b>: scroll, <b>feather size</b>: shift+scroll,"
+                 " <b>opacity</b>: ctrl+scroll (%d%%)"), opacity);
 }
 
 static void _ellipse_sanitize_config(dt_masks_type_t type)
 {
   dt_conf_get_and_sanitize_float(DT_MASKS_CONF(type, ellipse, rotation), 0.0f, 360.f);
-  int flags = dt_conf_get_and_sanitize_int(DT_MASKS_CONF(type, ellipse, flags), DT_MASKS_ELLIPSE_EQUIDISTANT, DT_MASKS_ELLIPSE_PROPORTIONAL);
+  const int flags = dt_conf_get_and_sanitize_int
+    (DT_MASKS_CONF(type, ellipse, flags),
+     DT_MASKS_ELLIPSE_EQUIDISTANT, DT_MASKS_ELLIPSE_PROPORTIONAL);
   float radius_a = dt_conf_get_float(DT_MASKS_CONF(type, ellipse, radius_a));
   float radius_b = dt_conf_get_float(DT_MASKS_CONF(type, ellipse, radius_b));
   float border = dt_conf_get_float(DT_MASKS_CONF(type, ellipse, border));
@@ -2010,24 +2313,41 @@ static void _ellipse_sanitize_config(dt_masks_type_t type)
     radius_a = ratio * radius_b;
   }
 
-  const float reference = (flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? 1.0f / fmin(radius_a, radius_b) : 1.0f);
+  const float reference = (flags & DT_MASKS_ELLIPSE_PROPORTIONAL
+                           ? 1.0f / fmin(radius_a, radius_b)
+                           : 1.0f);
   border = CLAMPS(border, 0.001f * reference, reference);
 
-  DT_CONF_SET_SANITIZED_FLOAT(DT_MASKS_CONF(type, ellipse, radius_a), radius_a, 0.001f, 0.5f);
-  DT_CONF_SET_SANITIZED_FLOAT(DT_MASKS_CONF(type, ellipse, radius_b), radius_b, 0.001f, 0.5f);
-  DT_CONF_SET_SANITIZED_FLOAT(DT_MASKS_CONF(type, ellipse, border), border, 0.001f, reference);
+  DT_CONF_SET_SANITIZED_FLOAT(DT_MASKS_CONF(type, ellipse, radius_a),
+                              radius_a, 0.001f, 0.5f);
+  DT_CONF_SET_SANITIZED_FLOAT(DT_MASKS_CONF(type, ellipse, radius_b),
+                              radius_b, 0.001f, 0.5f);
+  DT_CONF_SET_SANITIZED_FLOAT(DT_MASKS_CONF(type, ellipse, border),
+                              border, 0.001f, reference);
 }
 
-static void _ellipse_modify_property(dt_masks_form_t *const form, dt_masks_property_t prop, float old_val, float new_val, float *sum, int *count, float *min, float *max)
+static void _ellipse_modify_property(dt_masks_form_t *const form,
+                                     const dt_masks_property_t prop,
+                                     const float old_val,
+                                     const float new_val,
+                                     float *sum,
+                                     int *count,
+                                     float *min,
+                                     float *max)
 {
   float ratio = (!old_val || !new_val) ? 1.0f : new_val / old_val;
 
   dt_masks_point_ellipse_t *ellipse = form->points ? form->points->data : NULL;
 
-  float radius_a = ellipse ? ellipse->radius[0] : dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, radius_a));
-  float radius_b = ellipse ? ellipse->radius[1] : dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, radius_b));
+  float radius_a = ellipse
+    ? ellipse->radius[0]
+    : dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, radius_a));
+  float radius_b = ellipse
+    ? ellipse->radius[1]
+    : dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, radius_b));
 
-  const float radius_limit = form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 1.0f;
+  const float radius_limit =
+    form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 1.0f;
 
   switch(prop)
   {
@@ -2048,10 +2368,17 @@ static void _ellipse_modify_property(dt_masks_form_t *const form, dt_masks_prope
       ++*count;
       break;
     case DT_MASKS_PROPERTY_FEATHER:;
-      dt_masks_ellipse_flags_t flags = ellipse ? ellipse->flags : dt_conf_get_int(DT_MASKS_CONF(form->type, ellipse, flags));
-      const float reference = flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? 1.0f/fmin(radius_a, radius_b) : 1.0f;
-      float masks_border = ellipse ? ellipse->border : dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, border));
-      masks_border = CLAMP(masks_border * ratio, 0.001f * reference, radius_limit * reference);
+      dt_masks_ellipse_flags_t flags = ellipse
+        ? ellipse->flags
+        : dt_conf_get_int(DT_MASKS_CONF(form->type, ellipse, flags));
+      const float reference = flags & DT_MASKS_ELLIPSE_PROPORTIONAL
+        ? 1.0f/fmin(radius_a, radius_b)
+        : 1.0f;
+      float masks_border = ellipse
+        ? ellipse->border
+        : dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, border));
+      masks_border = CLAMP(masks_border * ratio, 0.001f * reference,
+                           radius_limit * reference);
 
       if(ellipse) ellipse->border = masks_border;
       dt_conf_set_float(DT_MASKS_CONF(form->type, ellipse, border), masks_border);
@@ -2062,7 +2389,9 @@ static void _ellipse_modify_property(dt_masks_form_t *const form, dt_masks_prope
       ++*count;
       break;
     case DT_MASKS_PROPERTY_ROTATION:;
-      float rotation = ellipse ? ellipse->rotation : dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, rotation));
+      float rotation = ellipse
+        ? ellipse->rotation
+        : dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, rotation));
       rotation = fmodf(rotation + new_val - old_val + 360.0f, 360.0f);
 
       if(ellipse) ellipse->rotation = rotation;

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -631,7 +631,6 @@ static int _ellipse_events_button_pressed(struct dt_iop_module_t *module, float 
   }
   else
   {
-    dt_iop_module_t *crea_module = gui->creation_module;
     // we create the ellipse
     dt_masks_point_ellipse_t *ellipse
         = (dt_masks_point_ellipse_t *)(malloc(sizeof(dt_masks_point_ellipse_t)));
@@ -659,6 +658,9 @@ static int _ellipse_events_button_pressed(struct dt_iop_module_t *module, float 
     ellipse->rotation = dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, rotation));
     ellipse->flags = dt_conf_get_int(DT_MASKS_CONF(form->type, ellipse, flags));
     form->points = g_list_append(form->points, ellipse);
+
+    dt_iop_module_t *crea_module = gui->creation_module;
+
     dt_masks_gui_form_save_creation(darktable.develop, crea_module, form, gui);
 
     if(crea_module)
@@ -672,14 +674,10 @@ static int _ellipse_events_button_pressed(struct dt_iop_module_t *module, float 
       else if(!gui->creation_continuous)
         dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
       dt_masks_iop_update(crea_module);
-      dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid);
-      gui->creation_module = NULL;
     }
-    else
-    {
-      // we select the new form
-      dt_dev_masks_selection_change(darktable.develop, NULL, form->formid);
-    }
+
+    dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid);
+    gui->creation_module = NULL;
 
     // if we draw a clone ellipse, we start now the source dragging
     if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -672,8 +672,8 @@ static int _ellipse_events_button_pressed(struct dt_iop_module_t *module, float 
       // and we switch in edit mode to show all the forms
       // spots and retouch have their own handling of creation_continuous
       if(gui->creation_continuous
-         && (strcmp(crea_module->so->op, "spots") == 0
-             || strcmp(crea_module->so->op, "retouch") == 0))
+         && (dt_iop_module_is(crea_module->so, "spots")
+             || dt_iop_module_is(crea_module->so, "retouch")))
         dt_masks_set_edit_mode_single_form(crea_module, form->formid, DT_MASKS_EDIT_FULL);
       else if(!gui->creation_continuous)
         dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
@@ -720,8 +720,8 @@ static int _ellipse_events_button_pressed(struct dt_iop_module_t *module, float 
     //spot and retouch manage creation_continuous in their own way
     if(crea_module
        && gui->creation_continuous
-       && strcmp(crea_module->so->op, "spots") != 0
-       && strcmp(crea_module->so->op, "retouch") != 0)
+       && !dt_iop_module_is(crea_module->so, "spots")
+       && !dt_iop_module_is(crea_module->so, "retouch"))
     {
       dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)crea_module->blend_data;
       for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -718,22 +718,30 @@ static int _ellipse_events_button_pressed(struct dt_iop_module_t *module, float 
       dt_masks_select_form(module, dt_masks_get_from_id(darktable.develop, form->formid));
     }
     //spot and retouch manage creation_continuous in their own way
-    if(crea_module
-       && gui->creation_continuous
-       && !dt_iop_module_is(crea_module->so, "spots")
-       && !dt_iop_module_is(crea_module->so, "retouch"))
+    if(gui->creation_continuous)
     {
-      dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)crea_module->blend_data;
-      for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)
-        if(bd->masks_type[n] == form->type)
-          gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_shapes[n]), TRUE);
+      if(crea_module
+         && !dt_iop_module_is(crea_module->so, "spots")
+         && !dt_iop_module_is(crea_module->so, "retouch"))
+      {
+        dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)crea_module->blend_data;
+        for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)
+          if(bd->masks_type[n] == form->type)
+            gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_shapes[n]), TRUE);
 
-      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), FALSE);
-      dt_masks_form_t *newform = dt_masks_create(form->type);
-      dt_masks_change_form_gui(newform);
-      darktable.develop->form_gui->creation_module = crea_module;
-      darktable.develop->form_gui->creation_continuous = TRUE;
-      darktable.develop->form_gui->creation_continuous_module = crea_module;
+        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), FALSE);
+        dt_masks_form_t *newform = dt_masks_create(form->type);
+        dt_masks_change_form_gui(newform);
+        darktable.develop->form_gui->creation_module = crea_module;
+        darktable.develop->form_gui->creation_continuous = TRUE;
+        darktable.develop->form_gui->creation_continuous_module = crea_module;
+      }
+      else
+      {
+        dt_masks_form_t *form_new = dt_masks_create(form->type);
+        dt_masks_change_form_gui(form_new);
+        darktable.develop->form_gui->creation_module = gui->creation_continuous_module;
+      }
     }
     return 1;
   }

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -303,7 +303,9 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
     return 1;
   }
 
-  if(gui->form_dragging && gui->edit_mode == DT_MASKS_EDIT_FULL)
+  if(gui->form_dragging
+     && form->points
+     && gui->edit_mode == DT_MASKS_EDIT_FULL)
   {
     // we get the gradient
     dt_masks_point_gradient_t *gradient =
@@ -330,7 +332,9 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
 
     return 1;
   }
-  else if(gui->form_rotating && gui->edit_mode == DT_MASKS_EDIT_FULL)
+  else if(gui->form_rotating
+          && form->points
+          && gui->edit_mode == DT_MASKS_EDIT_FULL)
   {
     // we get the gradient
     dt_masks_point_gradient_t *gradient =

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -408,7 +408,6 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
     const int closeup = dt_control_get_dev_closeup();
     const float zoom_scale = dt_dev_get_zoom_scale(darktable.develop, zoom, 1 << closeup, 1);
 
-    dt_iop_module_t *crea_module = gui->creation_module;
     // we create the gradient
     dt_masks_point_gradient_t *gradient = (dt_masks_point_gradient_t *)(malloc(sizeof(dt_masks_point_gradient_t)));
 
@@ -423,6 +422,8 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
     form->source[0] = form->source[1] = 0.0f;
 
     form->points = g_list_append(form->points, gradient);
+
+    dt_iop_module_t *crea_module = gui->creation_module;
     dt_masks_gui_form_save_creation(darktable.develop, crea_module, form, gui);
 
     if(crea_module)
@@ -432,14 +433,10 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
       // and we switch in edit mode to show all the forms
       dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
       dt_masks_iop_update(crea_module);
-      dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid);
-      gui->creation_module = NULL;
     }
-    else
-    {
-      // we select the new form
-      dt_dev_masks_selection_change(darktable.develop, NULL, form->formid);
-    }
+
+    dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid);
+    gui->creation_module = NULL;
 
     if(crea_module && gui->creation_continuous)
     {

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -446,19 +446,28 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
     dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid);
     gui->creation_module = NULL;
 
-    if(crea_module && gui->creation_continuous)
+    if(gui->creation_continuous)
     {
-      dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)crea_module->blend_data;
-      for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)
-        if(bd->masks_type[n] == form->type)
-          gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_shapes[n]), TRUE);
+      if(crea_module)
+      {
+        dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)crea_module->blend_data;
+        for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)
+          if(bd->masks_type[n] == form->type)
+            gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_shapes[n]), TRUE);
 
-      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), FALSE);
-      dt_masks_form_t *newform = dt_masks_create(form->type);
-      dt_masks_change_form_gui(newform);
-      darktable.develop->form_gui->creation_module = crea_module;
-      darktable.develop->form_gui->creation_continuous = TRUE;
-      darktable.develop->form_gui->creation_continuous_module = crea_module;
+        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), FALSE);
+        dt_masks_form_t *newform = dt_masks_create(form->type);
+        dt_masks_change_form_gui(newform);
+        darktable.develop->form_gui->creation_module = crea_module;
+        darktable.develop->form_gui->creation_continuous = TRUE;
+        darktable.develop->form_gui->creation_continuous_module = crea_module;
+      }
+      else
+      {
+        dt_masks_form_t *form_new = dt_masks_create(form->type);
+        dt_masks_change_form_gui(form_new);
+        darktable.develop->form_gui->creation_module = gui->creation_continuous_module;
+      }
     }
     return 1;
   }

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2013-2021 darktable developers.
+    Copyright (C) 2013-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "bauhaus/bauhaus.h"
 #include "common/debug.h"
 #include "common/undo.h"
@@ -25,8 +26,17 @@
 #include "develop/masks.h"
 #include "develop/openmp_maths.h"
 
-static void _gradient_get_distance(float x, float y, float as, dt_masks_form_gui_t *gui, int index,
-                                   int num_points, int *inside, int *inside_border, int *near, int *inside_source, float *dist)
+static void _gradient_get_distance(const float x,
+                                   const float y,
+                                   const float as,
+                                   dt_masks_form_gui_t *gui,
+                                   const int index,
+                                   const int num_points,
+                                   int *inside,
+                                   int *inside_border,
+                                   int *near,
+                                   int *inside_source,
+                                   float *dist)
 {
   (void)num_points; // unused arg, keep compiler from complaining
   if(!gui) return;
@@ -35,7 +45,8 @@ static void _gradient_get_distance(float x, float y, float as, dt_masks_form_gui
   *near = -1;
   *dist = FLT_MAX;
 
-  const dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+  const dt_masks_form_gui_points_t *gpt =
+    (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return;
 
   const float as2 = as * as;
@@ -84,15 +95,22 @@ static void _gradient_get_distance(float x, float y, float as, dt_masks_form_gui
 }
 
 
-static int _gradient_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx, float pzy, int up,
-                                           uint32_t state, dt_masks_form_t *form, int parentid,
-                                           dt_masks_form_gui_t *gui, int index)
+static int _gradient_events_mouse_scrolled(struct dt_iop_module_t *module,
+                                           const float pzx,
+                                           const float pzy,
+                                           const int up,
+                                           const uint32_t state,
+                                           dt_masks_form_t *form,
+                                           const int parentid,
+                                           dt_masks_form_gui_t *gui,
+                                           const int index)
 {
   if(gui->creation)
   {
     if(dt_modifier_is(state, GDK_SHIFT_MASK))
     {
-      float compression = MIN(1.0f, dt_conf_get_float(DT_MASKS_CONF(form->type, gradient, compression)));
+      float compression =
+        MIN(1.0f, dt_conf_get_float(DT_MASKS_CONF(form->type, gradient, compression)));
       if(up)
         compression = fminf(fmaxf(compression, 0.001f) * 1.0f / 0.8f, 1.0f);
       else
@@ -100,7 +118,9 @@ static int _gradient_events_mouse_scrolled(struct dt_iop_module_t *module, float
       dt_conf_set_float(DT_MASKS_CONF(form->type, gradient, compression), compression);
       dt_toast_log(_("compression: %3.2f%%"), compression*100.0f);
     }
-    else if(dt_modifier_is(state, 0)) // simple scroll to adjust curvature, calling func adjusts opacity with Ctrl
+    else if(dt_modifier_is(state, 0)) // simple scroll to adjust
+                                      // curvature, calling func
+                                      // adjusts opacity with Ctrl
     {
       float curvature = dt_conf_get_float(DT_MASKS_CONF(form->type, gradient, curvature));
       if(up)
@@ -129,20 +149,24 @@ static int _gradient_events_mouse_scrolled(struct dt_iop_module_t *module, float
     }
     else if(dt_modifier_is(state, GDK_SHIFT_MASK))
     {
-      dt_masks_point_gradient_t *gradient = (dt_masks_point_gradient_t *)((form->points)->data);
+      dt_masks_point_gradient_t *gradient =
+        (dt_masks_point_gradient_t *)((form->points)->data);
       if(up)
-        gradient->compression = fminf(fmaxf(gradient->compression, 0.001f) * 1.0f / 0.8f, 1.0f);
+        gradient->compression =
+          fminf(fmaxf(gradient->compression, 0.001f) * 1.0f / 0.8f, 1.0f);
       else
         gradient->compression = fmaxf(gradient->compression, 0.001f) * 0.8f;
       dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
       dt_masks_gui_form_create(form, gui, index, module);
-      dt_conf_set_float(DT_MASKS_CONF(form->type, gradient, compression), gradient->compression);
+      dt_conf_set_float(DT_MASKS_CONF(form->type, gradient, compression),
+                        gradient->compression);
       dt_toast_log(_("compression: %3.2f%%"), gradient->compression*100.0f);
       dt_masks_update_image(darktable.develop);
     }
     else if(gui->edit_mode == DT_MASKS_EDIT_FULL)
     {
-      dt_masks_point_gradient_t *gradient = (dt_masks_point_gradient_t *)((form->points)->data);
+      dt_masks_point_gradient_t *gradient =
+        (dt_masks_point_gradient_t *)((form->points)->data);
       if(up)
         gradient->curvature = fminf(gradient->curvature + 0.01f, 2.0f);
       else
@@ -157,16 +181,26 @@ static int _gradient_events_mouse_scrolled(struct dt_iop_module_t *module, float
   return 0;
 }
 
-static int _gradient_events_button_pressed(struct dt_iop_module_t *module, float pzx, float pzy,
-                                           double pressure, int which, int type, uint32_t state,
-                                           dt_masks_form_t *form, int parentid, dt_masks_form_gui_t *gui, int index)
+static int _gradient_events_button_pressed(struct dt_iop_module_t *module,
+                                           const float pzx,
+                                           const float pzy,
+                                           const double pressure,
+                                           const int which,
+                                           const int type,
+                                           const uint32_t state,
+                                           dt_masks_form_t *form,
+                                           const int parentid,
+                                           dt_masks_form_gui_t *gui,
+                                           const int index)
 {
   if(!gui) return 0;
 
-  if(which == 1 && type == GDK_2BUTTON_PRESS)
+  if(which == 1
+     && type == GDK_2BUTTON_PRESS)
   {
     // double-click resets curvature
-    dt_masks_point_gradient_t *gradient = (dt_masks_point_gradient_t *)((form->points)->data);
+    dt_masks_point_gradient_t *gradient =
+      (dt_masks_point_gradient_t *)((form->points)->data);
 
     gradient->curvature = 0.0f;
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
@@ -177,18 +211,22 @@ static int _gradient_events_button_pressed(struct dt_iop_module_t *module, float
 
     return 1;
   }
-  else if(!gui->creation && dt_modifier_is(state, GDK_SHIFT_MASK))
+  else if(!gui->creation
+          && dt_modifier_is(state, GDK_SHIFT_MASK))
   {
-    dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+    dt_masks_form_gui_points_t *gpt =
+      (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
     if(!gpt) return 0;
 
     gui->gradient_toggling = TRUE;
 
     return 1;
   }
-  else if(!gui->creation && gui->edit_mode == DT_MASKS_EDIT_FULL)
+  else if(!gui->creation
+          && gui->edit_mode == DT_MASKS_EDIT_FULL)
   {
-    const dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+    const dt_masks_form_gui_points_t *gpt =
+      (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
     if(!gpt) return 0;
     // we start the form rotating or dragging
     if(gui->pivot_selected)
@@ -199,7 +237,8 @@ static int _gradient_events_button_pressed(struct dt_iop_module_t *module, float
     gui->dy = gpt->points[1] - gui->posy;
     return 1;
   }
-  else if(gui->creation && (which == 3))
+  else if(gui->creation
+          && (which == 3))
   {
     dt_masks_set_edit_mode(module, DT_MASKS_EDIT_FULL);
     dt_masks_iop_update(module);
@@ -215,8 +254,16 @@ static int _gradient_events_button_pressed(struct dt_iop_module_t *module, float
   return 0;
 }
 
-static void _gradient_init_values(float zoom_scale, dt_masks_form_gui_t *gui, float xpos, float ypos, float pzx,
-                                  float pzy, float *anchorx, float *anchory, float *rotation, float *compression,
+static void _gradient_init_values(const float zoom_scale,
+                                  dt_masks_form_gui_t *gui,
+                                  const float xpos,
+                                  const float ypos,
+                                  const float pzx,
+                                  const float pzy,
+                                  float *anchorx,
+                                  float *anchory,
+                                  float *rotation,
+                                  float *compression,
                                   float *curvature)
 {
   const float pr_d = darktable.develop->preview_downsampling;
@@ -225,7 +272,9 @@ static void _gradient_init_values(float zoom_scale, dt_masks_form_gui_t *gui, fl
   float dx = 0.0f, dy = 0.0f;
 
   if(!gui->form_dragging
-     || (gui->posx_source - xpos > -diff && gui->posx_source - xpos < diff && gui->posy_source - ypos > -diff
+     || (gui->posx_source - xpos > -diff
+         && gui->posx_source - xpos < diff
+         && gui->posy_source - ypos > -diff
          && gui->posy_source - ypos < diff))
   {
     x0 = pzx;
@@ -258,23 +307,35 @@ static void _gradient_init_values(float zoom_scale, dt_masks_form_gui_t *gui, fl
   // in the correct direction as dragged. We test for this by checking the
   // angle between two vectors that should be 90 degrees apart. If the angle
   // is -90 degrees, then the image is flipped.
-  float check_angle = atan2f(pts[7] - pts[1], pts[6] - pts[0]) - atan2f(pts[5] - pts[1], pts[4] - pts[0]);
+  float check_angle = atan2f(pts[7] - pts[1],
+                             pts[6] - pts[0]) - atan2f(pts[5] - pts[1],
+                                                       pts[4] - pts[0]);
   // Normalize to the range -180 to 180 degrees
   check_angle = atan2f(sinf(check_angle), cosf(check_angle));
   if(check_angle < 0.0f) rot -= M_PI;
 
-  const float compr = MIN(1.0f, dt_conf_get_float(DT_MASKS_CONF(0, gradient, compression)));
+  const float compr =
+    MIN(1.0f, dt_conf_get_float(DT_MASKS_CONF(0, gradient, compression)));
 
   *rotation = -rot / M_PI * 180.0f;
   *compression = MAX(0.0f, compr);
-  *curvature = MAX(-2.0f, MIN(2.0f, dt_conf_get_float(DT_MASKS_CONF(0, gradient, curvature))));
+  *curvature = MAX(-2.0f, MIN(2.0f,
+                              dt_conf_get_float(DT_MASKS_CONF(0, gradient, curvature))));
 }
 
-static int _gradient_events_button_released(struct dt_iop_module_t *module, float pzx, float pzy, int which,
-                                            uint32_t state, dt_masks_form_t *form, int parentid,
-                                            dt_masks_form_gui_t *gui, int index)
+static int _gradient_events_button_released(struct dt_iop_module_t *module,
+                                            const float pzx,
+                                            const float pzy,
+                                            const int which,
+                                            const uint32_t state,
+                                            dt_masks_form_t *form,
+                                            const int parentid,
+                                            dt_masks_form_gui_t *gui,
+                                            const int index)
 {
-  if(which == 3 && parentid > 0 && gui->edit_mode == DT_MASKS_EDIT_FULL)
+  if(which == 3
+     && parentid > 0
+     && gui->edit_mode == DT_MASKS_EDIT_FULL)
   {
     // we hide the form
     if(!(darktable.develop->form_visible->type & DT_MASKS_GROUP))
@@ -284,7 +345,9 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
     else
     {
       dt_masks_clear_form_gui(darktable.develop);
-      for(GList *forms = darktable.develop->form_visible->points; forms; forms = g_list_next(forms))
+      for(GList *forms = darktable.develop->form_visible->points;
+          forms;
+          forms = g_list_next(forms))
       {
         dt_masks_point_group_t *gpt = (dt_masks_point_group_t *)forms->data;
         if(gpt->formid == form->formid)
@@ -357,13 +420,17 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
 
     float pts[8] = { xref, yref, x , y, 0, 0, gui->dx, gui->dy };
 
-    const float dv = atan2f(pts[3] - pts[1], pts[2] - pts[0]) - atan2f(-(pts[7] - pts[5]), -(pts[6] - pts[4]));
+    const float dv = atan2f(pts[3] - pts[1],
+                            pts[2] - pts[0]) - atan2f(-(pts[7] - pts[5]),
+                                                      -(pts[6] - pts[4]));
 
     float pts2[8] = { xref, yref, x , y, xref+10.0f, yref, xref, yref+10.0f };
 
     dt_dev_distort_backtransform(darktable.develop, pts2, 4);
 
-    float check_angle = atan2f(pts2[7] - pts2[1], pts2[6] - pts2[0]) - atan2f(pts2[5] - pts2[1], pts2[4] - pts2[0]);
+    float check_angle = atan2f(pts2[7] - pts2[1],
+                               pts2[6] - pts2[0]) - atan2f(pts2[5] - pts2[1],
+                                                           pts2[4] - pts2[0]);
     // Normalize to the range -180 to 180 degrees
     check_angle = atan2f(sinf(check_angle), cosf(check_angle));
     if(check_angle < 0)
@@ -417,10 +484,13 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
     const float zoom_scale = dt_dev_get_zoom_scale(darktable.develop, zoom, 1 << closeup, 1);
 
     // we create the gradient
-    dt_masks_point_gradient_t *gradient = (dt_masks_point_gradient_t *)(malloc(sizeof(dt_masks_point_gradient_t)));
+    dt_masks_point_gradient_t *gradient =
+      (dt_masks_point_gradient_t *)(malloc(sizeof(dt_masks_point_gradient_t)));
 
-    _gradient_init_values(zoom_scale, gui, gui->posx, gui->posy, pzx * wd, pzy * ht, &gradient->anchor[0],
-                          &gradient->anchor[1], &gradient->rotation, &gradient->compression, &gradient->curvature);
+    _gradient_init_values(zoom_scale, gui, gui->posx, gui->posy, pzx * wd, pzy * ht,
+                          &gradient->anchor[0],
+                          &gradient->anchor[1], &gradient->rotation,
+                          &gradient->compression, &gradient->curvature);
 
     gui->form_dragging = FALSE;
 
@@ -475,9 +545,15 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
   return 0;
 }
 
-static int _gradient_events_mouse_moved(struct dt_iop_module_t *module, float pzx, float pzy,
-                                        double pressure, int which, dt_masks_form_t *form, int parentid,
-                                        dt_masks_form_gui_t *gui, int index)
+static int _gradient_events_mouse_moved(struct dt_iop_module_t *module,
+                                        const float pzx,
+                                        const float pzy,
+                                        const double pressure,
+                                        const int which,
+                                        dt_masks_form_t *form,
+                                        const int parentid,
+                                        dt_masks_form_gui_t *gui,
+                                        const int index)
 {
   if(gui->creation && gui->form_dragging)
   {
@@ -487,7 +563,8 @@ static int _gradient_events_mouse_moved(struct dt_iop_module_t *module, float pz
   else if(gui->form_dragging)
   {
     // we get the gradient
-    dt_masks_point_gradient_t *gradient = (dt_masks_point_gradient_t *)((form->points)->data);
+    dt_masks_point_gradient_t *gradient =
+      (dt_masks_point_gradient_t *)((form->points)->data);
 
     // we change the center value
     const float wd = darktable.develop->preview_pipe->backbuf_width;
@@ -505,7 +582,8 @@ static int _gradient_events_mouse_moved(struct dt_iop_module_t *module, float pz
   }
   if(gui->form_rotating)
   {
-    dt_masks_point_gradient_t *gradient = (dt_masks_point_gradient_t *)((form->points)->data);
+    dt_masks_point_gradient_t *gradient =
+      (dt_masks_point_gradient_t *)((form->points)->data);
 
     const float wd = darktable.develop->preview_pipe->backbuf_width;
     const float ht = darktable.develop->preview_pipe->backbuf_height;
@@ -513,7 +591,8 @@ static int _gradient_events_mouse_moved(struct dt_iop_module_t *module, float pz
     const float y = pzy * ht;
 
     // we need the reference point
-    dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+    dt_masks_form_gui_points_t *gpt =
+      (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
     if(!gpt) return 0;
     const float xref = gpt->points[0];
     const float yref = gpt->points[1];
@@ -524,12 +603,16 @@ static int _gradient_events_mouse_moved(struct dt_iop_module_t *module, float pz
     gui->dx = xref - gui->posx;
     gui->dy = yref - gui->posy;
 
-    const float dv = atan2f(pts[3] - pts[1], pts[2] - pts[0]) - atan2f(-(pts[7] - pts[5]), -(pts[6] - pts[4]));
+    const float dv = atan2f(pts[3] - pts[1],
+                            pts[2] - pts[0]) - atan2f(-(pts[7] - pts[5]),
+                                                      -(pts[6] - pts[4]));
 
     float pts2[8] = { xref, yref, x, y, xref + 10.0f, yref, xref, yref + 10.0f };
     dt_dev_distort_backtransform(darktable.develop, pts2, 4);
 
-    float check_angle = atan2f(pts2[7] - pts2[1], pts2[6] - pts2[0]) - atan2f(pts2[5] - pts2[1], pts2[4] - pts2[0]);
+    float check_angle = atan2f(pts2[7] - pts2[1],
+                               pts2[6] - pts2[0]) - atan2f(pts2[5] - pts2[1],
+                                                           pts2[4] - pts2[0]);
     // Normalize to the range -180 to 180 degrees
     check_angle = atan2f(sinf(check_angle), cosf(check_angle));
     if(check_angle < 0.0f)
@@ -548,24 +631,28 @@ static int _gradient_events_mouse_moved(struct dt_iop_module_t *module, float pz
     const int closeup = dt_control_get_dev_closeup();
     const float zoom_scale = dt_dev_get_zoom_scale(darktable.develop, zoom, 1<<closeup, 1);
     const float pr_d = darktable.develop->preview_downsampling;
-    const float as = DT_PIXEL_APPLY_DPI(20) / (pr_d * zoom_scale);  // transformed to backbuf dimensions
+    // transformed to backbuf dimensions
+    const float as = DT_PIXEL_APPLY_DPI(20) / (pr_d * zoom_scale);
     const float x = pzx * darktable.develop->preview_pipe->backbuf_width;
     const float y = pzy * darktable.develop->preview_pipe->backbuf_height;
     int in, inb, near, ins;
     float dist;
     _gradient_get_distance(x, y, as, gui, index, 0, &in, &inb, &near, &ins, &dist);
 
-    const dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+    const dt_masks_form_gui_points_t *gpt =
+      (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
 
     if(gpt
-       && (x - gpt->points[2]) * (x - gpt->points[2]) + (y - gpt->points[3]) * (y - gpt->points[3]) < as)
+       && (x - gpt->points[2]) * (x - gpt->points[2])
+       + (y - gpt->points[3]) * (y - gpt->points[3]) < as)
     {
       gui->pivot_selected = TRUE;
       gui->form_selected = TRUE;
       gui->border_selected = FALSE;
     }
     else if(gpt
-            && (x - gpt->points[4]) * (x - gpt->points[4]) + (y - gpt->points[5]) * (y - gpt->points[5])
+            && (x - gpt->points[4]) * (x - gpt->points[4])
+            + (y - gpt->points[5]) * (y - gpt->points[5])
                < as)
     {
       gui->pivot_selected = TRUE;
@@ -607,13 +694,26 @@ static int _gradient_events_mouse_moved(struct dt_iop_module_t *module, float pz
 }
 
 // check if(x,y) lies within reasonable limits relative to image frame
-static inline int _gradient_is_canonical(const float x, const float y, const float wd, const float ht)
+static inline gboolean _gradient_is_canonical(const float x,
+                                              const float y,
+                                              const float wd,
+                                              const float ht)
 {
-  return (isnormal(x) && isnormal(y) && x >= -wd && x <= 2 * wd && y >= -ht && y <= 2 * ht) ? TRUE : FALSE;
+  return (isnormal(x)
+          && isnormal(y)
+          && x >= -wd
+          && x <= 2 * wd
+          && y >= -ht
+          && y <= 2 * ht);
 }
 
-static int _gradient_get_points(dt_develop_t *dev, float x, float y, float rotation, float curvature,
-                                float **points, int *points_count)
+static int _gradient_get_points(dt_develop_t *dev,
+                                const float x,
+                                const float y,
+                                const float rotation,
+                                const float curvature,
+                                float **points,
+                                int *points_count)
 {
   *points = NULL;
   *points_count = 0;
@@ -671,8 +771,9 @@ static int _gradient_get_points(dt_develop_t *dev, float x, float y, float rotat
     const float xiii = xii + x * wd;
     const float yiii = yii + y * ht;
 
-    // don't generate guide points if they extend too far beyond the image frame;
-    // this is to avoid that modules like lens correction fail on out of range coordinates
+    // don't generate guide points if they extend too far beyond the
+    // image frame; this is to avoid that modules like lens correction
+    // fail on out of range coordinates
     if(!(xiii < -wd || xiii > 2 * wd || yiii < -ht || yiii > 2 * ht))
     {
       const int thread = dt_get_thread_num();
@@ -708,8 +809,14 @@ static int _gradient_get_points(dt_develop_t *dev, float x, float y, float rotat
   return 0;
 }
 
-static int _gradient_get_pts_border(dt_develop_t *dev, float x, float y, float rotation, float distance,
-                                    float curvature, float **points, int *points_count)
+static int _gradient_get_pts_border(dt_develop_t *dev,
+                                    const float x,
+                                    const float y,
+                                    const float rotation,
+                                    const float distance,
+                                    const float curvature,
+                                    float **points,
+                                    int *points_count)
 {
   *points = NULL;
   *points_count = 0;
@@ -726,21 +833,24 @@ static int _gradient_get_pts_border(dt_develop_t *dev, float x, float y, float r
   const float x1 = (x * wd + distance * scale * cosf(v1)) / wd;
   const float y1 = (y * ht + distance * scale * sinf(v1)) / ht;
 
-  const int r1 = _gradient_get_points(dev, x1, y1, rotation, curvature, &points1, &points_count1);
+  const int r1 = _gradient_get_points(dev, x1, y1, rotation, curvature,
+                                      &points1, &points_count1);
 
   const float v2 = (-(rotation + 90.0f) / 180.0f) * M_PI;
 
   const float x2 = (x * wd + distance * scale * cosf(v2)) / wd;
   const float y2 = (y * ht + distance * scale * sinf(v2)) / ht;
 
-  const int r2 = _gradient_get_points(dev, x2, y2, rotation, curvature, &points2, &points_count2);
+  const int r2 = _gradient_get_points(dev, x2, y2, rotation, curvature,
+                                      &points2, &points_count2);
 
   int res = 0;
 
   if(r1 && r2 && points_count1 > 4 && points_count2 > 4)
   {
     int k = 0;
-    *points = dt_alloc_align_float((size_t)2 * ((points_count1 - 3) + (points_count2 - 3) + 1));
+    *points = dt_alloc_align_float((size_t)2 * ((points_count1 - 3)
+                                                + (points_count2 - 3) + 1));
     if(*points == NULL) goto end;
     *points_count = (points_count1 - 3) + (points_count2 - 3) + 1;
     for(int i = 3; i < points_count1; i++)
@@ -799,9 +909,15 @@ end:
   return res;
 }
 
-static void _gradient_draw_lines(gboolean borders, cairo_t *cr, double *dashed, const float len,
-                                 const gboolean selected, const float zoom_scale, float *pts_line,
-                                 int pts_line_count, const float xref, const float yref)
+static void _gradient_draw_lines(gboolean borders, cairo_t *cr,
+                                 double *dashed,
+                                 const float len,
+                                 const gboolean selected,
+                                 const float zoom_scale,
+                                 float *pts_line,
+                                 const int pts_line_count,
+                                 const float xref,
+                                 const float yref)
 {
   // safeguard in case of malformed arrays of points
   if(borders && pts_line_count <= 3) return;
@@ -857,7 +973,8 @@ static void _gradient_draw_lines(gboolean borders, cairo_t *cr, double *dashed, 
     count++;
     for(; count < points_count && isnormal(points[count * 2]); count++)
     {
-      if(!_gradient_is_canonical(points[count * 2], points[count * 2 + 1], wd, ht)) break;
+      if(!_gradient_is_canonical(points[count * 2], points[count * 2 + 1], wd, ht))
+        break;
 
       cairo_line_to(cr, points[count * 2], points[count * 2 + 1]);
     }
@@ -871,8 +988,13 @@ static void _gradient_draw_lines(gboolean borders, cairo_t *cr, double *dashed, 
   }
 }
 
-static void _gradient_draw_arrow(cairo_t *cr, double *dashed, const float len, const gboolean selected,
-                                 const gboolean border_selected, const float zoom_scale, float *pts, int pts_count)
+static void _gradient_draw_arrow(cairo_t *cr, double *dashed,
+                                 const float len,
+                                 const gboolean selected,
+                                 const gboolean border_selected,
+                                 const float zoom_scale,
+                                 float *pts,
+                                 const int pts_count)
 {
   if(pts_count < 3) return;
 
@@ -939,7 +1061,11 @@ static void _gradient_draw_arrow(cairo_t *cr, double *dashed, const float len, c
   }
 }
 
-static void _gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_form_gui_t *gui, int index, int nb)
+static void _gradient_events_post_expose(cairo_t *cr,
+                                         const float zoom_scale,
+                                         dt_masks_form_gui_t *gui,
+                                         const int index,
+                                         const int nb)
 {
   (void)nb; // unused arg, keep compiler from complaining
   double dashed[] = { 4.0, 4.0 };
@@ -966,61 +1092,79 @@ static void _gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
     }
 
     float xx = 0.0f, yy = 0.0f, rotation = 0.0f, compression = 0.0f, curvature = 0.0f;
-    _gradient_init_values(zoom_scale, gui, xpos, ypos, xpos, ypos, &xx, &yy, &rotation, &compression, &curvature);
+    _gradient_init_values(zoom_scale, gui, xpos, ypos, xpos, ypos, &xx, &yy,
+                          &rotation, &compression, &curvature);
 
     float *points = NULL;
     int points_count = 0;
     float *border = NULL;
     int border_count = 0;
-    int draw = _gradient_get_points(darktable.develop, xx, yy, rotation, curvature, &points, &points_count);
+    int draw = _gradient_get_points(darktable.develop, xx, yy, rotation, curvature,
+                                    &points, &points_count);
     if(draw && compression > 0.0)
     {
-      draw = _gradient_get_pts_border(darktable.develop, xx, yy, rotation, compression, curvature, &border,
+      draw = _gradient_get_pts_border(darktable.develop, xx, yy, rotation,
+                                      compression, curvature, &border,
                                       &border_count);
     }
 
     cairo_save(cr);
     // draw main line
-    _gradient_draw_lines(FALSE, cr, dashed, len, FALSE, zoom_scale, points, points_count, points[0], points[1]);
+    _gradient_draw_lines(FALSE, cr, dashed, len, FALSE, zoom_scale,
+                         points, points_count, points[0], points[1]);
     // draw borders
-    _gradient_draw_lines(TRUE, cr, dashed, len, FALSE, zoom_scale, border, border_count, points[0], points[1]);
+    _gradient_draw_lines(TRUE, cr, dashed, len, FALSE, zoom_scale,
+                         border, border_count, points[0], points[1]);
     // draw arrow
-    _gradient_draw_arrow(cr, dashed, len, FALSE, FALSE, zoom_scale, points, points_count);
+    _gradient_draw_arrow(cr, dashed, len, FALSE, FALSE, zoom_scale,
+                         points, points_count);
     cairo_restore(cr);
 
     if(points) dt_free_align(points);
     if(border) dt_free_align(border);
     return;
   }
-  const dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+  const dt_masks_form_gui_points_t *gpt =
+    (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return;
   const float xref = gpt->points[0];
   const float yref = gpt->points[1];
 
-  const gboolean selected = (gui->group_selected == index) && (gui->form_selected || gui->form_dragging);
+  const gboolean selected = (gui->group_selected == index)
+    && (gui->form_selected || gui->form_dragging);
   // draw main line
-  _gradient_draw_lines(FALSE, cr, dashed, len, selected, zoom_scale, gpt->points, gpt->points_count, xref, yref);
+  _gradient_draw_lines(FALSE, cr, dashed, len, selected, zoom_scale,
+                       gpt->points, gpt->points_count, xref, yref);
   // draw borders
   if(gui->show_all_feathers || gui->group_selected == index)
-    _gradient_draw_lines(TRUE, cr, dashed, len, gui->border_selected, zoom_scale, gpt->border, gpt->border_count,
+    _gradient_draw_lines(TRUE, cr, dashed, len, gui->border_selected, zoom_scale,
+                         gpt->border, gpt->border_count,
                          xref, yref);
 
-  _gradient_draw_arrow(cr, dashed, len, selected, ((gui->group_selected == index) && (gui->border_selected)),
+  _gradient_draw_arrow(cr, dashed, len, selected,
+                       ((gui->group_selected == index) && (gui->border_selected)),
                        zoom_scale, gpt->points, gpt->points_count);
 }
 
-static int _gradient_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, float **points, int *points_count,
-                                       float **border, int *border_count, int source,
+static int _gradient_get_points_border(dt_develop_t *dev,
+                                       dt_masks_form_t *form,
+                                       float **points,
+                                       int *points_count,
+                                       float **border,
+                                       int *border_count,
+                                       const int source,
                                        const dt_iop_module_t *module)
 {
   (void)source;  // unused arg, keep compiler from complaining
   dt_masks_point_gradient_t *gradient = (dt_masks_point_gradient_t *)form->points->data;
-  if(_gradient_get_points(dev, gradient->anchor[0], gradient->anchor[1], gradient->rotation, gradient->curvature,
+  if(_gradient_get_points(dev, gradient->anchor[0], gradient->anchor[1],
+                          gradient->rotation, gradient->curvature,
                           points, points_count))
   {
     if(border)
       return _gradient_get_pts_border(dev, gradient->anchor[0], gradient->anchor[1],
-                                      gradient->rotation, gradient->compression, gradient->curvature,
+                                      gradient->rotation,
+                                      gradient->compression, gradient->curvature,
                                       border, border_count);
     else
       return 1;
@@ -1028,16 +1172,22 @@ static int _gradient_get_points_border(dt_develop_t *dev, dt_masks_form_t *form,
   return 0;
 }
 
-static int _gradient_get_area(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
+static int _gradient_get_area(const dt_iop_module_t *const module,
+                              const dt_dev_pixelpipe_iop_t *const piece,
                               dt_masks_form_t *const form,
-                              int *width, int *height, int *posx, int *posy)
+                              int *width,
+                              int *height,
+                              int *posx,
+                              int *posy)
 {
   const float wd = piece->pipe->iwidth, ht = piece->pipe->iheight;
 
   float points[8] = { 0.0f, 0.0f, wd, 0.0f, wd, ht, 0.0f, ht };
 
   // and we transform them with all distorted modules
-  if(!dt_dev_distort_transform_plus(module->dev, piece->pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points, 4)) return 0;
+  if(!dt_dev_distort_transform_plus(module->dev, piece->pipe, module->iop_order,
+                                    DT_DEV_TRANSFORM_DIR_BACK_INCL, points, 4))
+    return 0;
 
   // now we search min and max
   float xmin = 0.0f, xmax = 0.0f, ymin = 0.0f, ymax = 0.0f;
@@ -1068,9 +1218,14 @@ static inline float dt_gradient_lookup(const float *lut, const float i)
   return lut[bin1] * f + lut[bin0] * (1.0f - f);
 }
 
-static int _gradient_get_mask(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
+static int _gradient_get_mask(const dt_iop_module_t *const module,
+                              const dt_dev_pixelpipe_iop_t *const piece,
                               dt_masks_form_t *const form,
-                              float **buffer, int *width, int *height, int *posx, int *posy)
+                              float **buffer,
+                              int *width,
+                              int *height,
+                              int *posx,
+                              int *posy)
 {
   double start2 = 0.0;
   if(darktable.unmuted & DT_DEBUG_PERF) start2 = dt_get_wtime();
@@ -1079,15 +1234,18 @@ static int _gradient_get_mask(const dt_iop_module_t *const module, const dt_dev_
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] gradient area took %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] gradient area took %0.04f sec\n", form->name,
              dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
 
   // we get the gradient values
-  dt_masks_point_gradient_t *gradient = (dt_masks_point_gradient_t *)((form->points)->data);
+  dt_masks_point_gradient_t *gradient =
+    (dt_masks_point_gradient_t *)((form->points)->data);
 
-  // we create a buffer of grid points for later interpolation. mainly in order to reduce memory footprint
+  // we create a buffer of grid points for later interpolation. mainly
+  // in order to reduce memory footprint
   const int w = *width;
   const int h = *height;
   const int px = *posx;
@@ -1117,13 +1275,17 @@ static int _gradient_get_mask(const dt_iop_module_t *const module, const dt_dev_
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] gradient draw took %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] gradient draw took %0.04f sec\n", form->name,
              dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
 
   // we backtransform all these points
-  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points, (size_t)gw * gh))
+  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe,
+                                        module->iop_order,
+                                        DT_DEV_TRANSFORM_DIR_BACK_INCL,
+                                        points, (size_t)gw * gh))
   {
     dt_free_align(points);
     return 0;
@@ -1131,7 +1293,8 @@ static int _gradient_get_mask(const dt_iop_module_t *const module, const dt_dev_
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] gradient transform took %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] gradient transform took %0.04f sec\n", form->name,
              dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
@@ -1172,7 +1335,10 @@ static int _gradient_get_mask(const dt_iop_module_t *const module, const dt_dev_
   for(int n = 0; n < lutsize; n++)
   {
     const float distance = (n - lutmax) * hwscale;
-    const float value = 0.5f + 0.5f * ((state == DT_MASKS_GRADIENT_STATE_LINEAR) ? normf * distance: erff(distance / compression));
+    const float value = 0.5f
+      + 0.5f * ((state == DT_MASKS_GRADIENT_STATE_LINEAR)
+                ? normf * distance
+                : erff(distance / compression));
     lut[n] = (value < 0.0f) ? 0.0f : ((value > 1.0f) ? 1.0f : value);
   }
 
@@ -1202,7 +1368,9 @@ static int _gradient_get_mask(const dt_iop_module_t *const module, const dt_dev_
       const float distance = y0 - curvature * x0 * x0;
 
       points[(j * gw + i) * 2] = (distance <= -4.0f * compression) ? 0.0f :
-                                    ((distance >= 4.0f * compression) ? 1.0f : dt_gradient_lookup(clut, distance * ihwscale));
+                                    ((distance >= 4.0f * compression)
+                                     ? 1.0f
+                                     : dt_gradient_lookup(clut, distance * ihwscale));
     }
   }
 
@@ -1254,15 +1422,20 @@ static int _gradient_get_mask(const dt_iop_module_t *const module, const dt_dev_
 }
 
 
-static int _gradient_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
-                                  dt_masks_form_t *const form, const dt_iop_roi_t *roi, float *buffer)
+static int _gradient_get_mask_roi(const dt_iop_module_t *const module,
+                                  const dt_dev_pixelpipe_iop_t *const piece,
+                                  dt_masks_form_t *const form,
+                                  const dt_iop_roi_t *roi,
+                                  float *buffer)
 {
   double start2 = 0.0;
   if(darktable.unmuted & DT_DEBUG_PERF) start2 = dt_get_wtime();
   // we get the gradient values
-  const dt_masks_point_gradient_t *gradient = (dt_masks_point_gradient_t *)(form->points->data);
+  const dt_masks_point_gradient_t *gradient =
+    (dt_masks_point_gradient_t *)(form->points->data);
 
-  // we create a buffer of grid points for later interpolation. mainly in order to reduce memory footprint
+  // we create a buffer of grid points for later interpolation. mainly
+  // in order to reduce memory footprint
   const int w = roi->width;
   const int h = roi->height;
   const int px = roi->x;
@@ -1295,13 +1468,16 @@ static int _gradient_get_mask_roi(const dt_iop_module_t *const module, const dt_
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] gradient draw took %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] gradient draw took %0.04f sec\n", form->name,
              dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
 
   // we backtransform all these points
-  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points,
+  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe,
+                                        module->iop_order,
+                                        DT_DEV_TRANSFORM_DIR_BACK_INCL, points,
                                         (size_t)gw * gh))
   {
     dt_free_align(points);
@@ -1310,7 +1486,8 @@ static int _gradient_get_mask_roi(const dt_iop_module_t *const module, const dt_
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] gradient transform took %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] gradient transform took %0.04f sec\n", form->name,
              dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
@@ -1351,7 +1528,10 @@ static int _gradient_get_mask_roi(const dt_iop_module_t *const module, const dt_
   for(int n = 0; n < lutsize; n++)
   {
     const float distance = (n - lutmax) * hwscale;
-    const float value = 0.5f + 0.5f * ((state == DT_MASKS_GRADIENT_STATE_LINEAR) ? normf * distance: erff(distance / compression));
+    const float value = 0.5f
+      + 0.5f * ((state == DT_MASKS_GRADIENT_STATE_LINEAR)
+                ? normf * distance
+                : erff(distance / compression));
     lut[n] = (value < 0.0f) ? 0.0f : ((value > 1.0f) ? 1.0f : value);
   }
 
@@ -1380,7 +1560,11 @@ static int _gradient_get_mask_roi(const dt_iop_module_t *const module, const dt_
 
       const float distance = y0 - curvature * x0 * x0;
 
-      points[index * 2] = (distance <= -4.0f * compression) ? 0.0f : ((distance >= 4.0f * compression) ? 1.0f : dt_gradient_lookup(clut, distance * ihwscale));
+      points[index * 2] = (distance <= -4.0f * compression)
+        ? 0.0f
+        : ((distance >= 4.0f * compression)
+           ? 1.0f
+           : dt_gradient_lookup(clut, distance * ihwscale));
     }
   }
 
@@ -1428,11 +1612,16 @@ static int _gradient_get_mask_roi(const dt_iop_module_t *const module, const dt_
 static GSList *_gradient_setup_mouse_actions(const struct dt_masks_form_t *const form)
 {
   GSList *lm = NULL;
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_LEFT_DRAG, 0, _("[GRADIENT on pivot] rotate shape"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_LEFT_DRAG, 0, _("[GRADIENT creation] set rotation"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, 0, _("[GRADIENT] change curvature"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_SHIFT_MASK, _("[GRADIENT] change compression"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_CONTROL_MASK, _("[GRADIENT] change opacity"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_LEFT_DRAG,
+                                     0, _("[GRADIENT on pivot] rotate shape"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_LEFT_DRAG,
+                                     0, _("[GRADIENT creation] set rotation"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL,
+                                     0, _("[GRADIENT] change curvature"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL,
+                                     GDK_SHIFT_MASK, _("[GRADIENT] change compression"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL,
+                                     GDK_CONTROL_MASK, _("[GRADIENT] change opacity"));
   return lm;
 }
 
@@ -1442,13 +1631,17 @@ static void _gradient_sanitize_config(dt_masks_type_t type)
   dt_conf_set_float(DT_MASKS_CONF(type, gradient, curvature), 0.0f);
 }
 
-static void _gradient_set_form_name(struct dt_masks_form_t *const form, const size_t nb)
+static void _gradient_set_form_name(struct dt_masks_form_t *const form,
+                                    const size_t nb)
 {
   snprintf(form->name, sizeof(form->name), _("gradient #%d"), (int)nb);
 }
 
-static void _gradient_set_hint_message(const dt_masks_form_gui_t *const gui, const dt_masks_form_t *const form,
-                                     const int opacity, char *const restrict msgbuf, const size_t msgbuf_len)
+static void _gradient_set_hint_message(const dt_masks_form_gui_t *const gui,
+                                       const dt_masks_form_t *const form,
+                                       const int opacity,
+                                       char *const restrict msgbuf,
+                                       const size_t msgbuf_len)
 {
   if(gui->creation)
     g_snprintf(msgbuf, msgbuf_len,
@@ -1456,32 +1649,45 @@ static void _gradient_set_hint_message(const dt_masks_form_gui_t *const gui, con
                  "<b>rotation</b>: click+drag, <b>opacity</b>: ctrl+scroll (%d%%)"),
                opacity);
   else if(gui->form_selected)
-    g_snprintf(msgbuf, msgbuf_len, _("<b>curvature</b>: scroll, <b>compression</b>: shift+scroll\n"
-                                     "<b>opacity</b>: ctrl+scroll (%d%%)"), opacity);
+    g_snprintf(msgbuf, msgbuf_len,
+               _("<b>curvature</b>: scroll, <b>compression</b>: shift+scroll\n"
+                 "<b>opacity</b>: ctrl+scroll (%d%%)"), opacity);
   else if(gui->pivot_selected)
     g_strlcat(msgbuf, _("<b>rotate</b>: drag"), msgbuf_len);
 }
 
-static void _gradient_duplicate_points(dt_develop_t *dev, dt_masks_form_t *const base, dt_masks_form_t *const dest)
+static void _gradient_duplicate_points(dt_develop_t *dev,
+                                       dt_masks_form_t *const base,
+                                       dt_masks_form_t *const dest)
 {
   (void)dev; // unused arg, keep compiler from complaining
   for(GList *pts = base->points; pts; pts = g_list_next(pts))
   {
     dt_masks_point_gradient_t *pt = (dt_masks_point_gradient_t *)pts->data;
-    dt_masks_point_gradient_t *npt = (dt_masks_point_gradient_t *)malloc(sizeof(dt_masks_point_gradient_t));
+    dt_masks_point_gradient_t *npt =
+      (dt_masks_point_gradient_t *)malloc(sizeof(dt_masks_point_gradient_t));
     memcpy(npt, pt, sizeof(dt_masks_point_gradient_t));
     dest->points = g_list_append(dest->points, npt);
   }
 }
 
-static void _gradient_modify_property(dt_masks_form_t *const form, dt_masks_property_t prop, float old_val, float new_val, float *sum, int *count, float *min, float *max)
+static void _gradient_modify_property(dt_masks_form_t *const form,
+                                      const dt_masks_property_t prop,
+                                      const float old_val,
+                                      const float new_val,
+                                      float *sum,
+                                      int *count,
+                                      float *min,
+                                      float *max)
 {
   dt_masks_point_gradient_t *gradient = form->points ? form->points->data : NULL;
 
   switch(prop)
   {
     case DT_MASKS_PROPERTY_CURVATURE:;
-      float curvature = gradient ? gradient->curvature : dt_conf_get_float(DT_MASKS_CONF(form->type, gradient, curvature));
+      float curvature = gradient
+        ? gradient->curvature
+        : dt_conf_get_float(DT_MASKS_CONF(form->type, gradient, curvature));
       curvature = CLAMP(curvature + new_val - old_val, -2.0f, 2.0f);
 
       if(gradient) gradient->curvature = curvature;
@@ -1494,7 +1700,9 @@ static void _gradient_modify_property(dt_masks_form_t *const form, dt_masks_prop
       break;
     case DT_MASKS_PROPERTY_COMPRESSION:;
       float ratio = (!old_val || !new_val) ? 1.0f : new_val / old_val;
-      float compression = gradient ? gradient->compression : dt_conf_get_float(DT_MASKS_CONF(form->type, gradient, compression));
+      float compression = gradient
+        ? gradient->compression
+        : dt_conf_get_float(DT_MASKS_CONF(form->type, gradient, compression));
       compression = CLAMP(compression * ratio, 0.001f, 1.0f);
 
       if(gradient) gradient->compression = compression;
@@ -1506,7 +1714,9 @@ static void _gradient_modify_property(dt_masks_form_t *const form, dt_masks_prop
       ++*count;
       break;
     case DT_MASKS_PROPERTY_ROTATION:;
-      float rotation = gradient ? gradient->rotation : dt_conf_get_float(DT_MASKS_CONF(form->type, gradient, rotation));
+      float rotation = gradient
+        ? gradient->rotation
+        : dt_conf_get_float(DT_MASKS_CONF(form->type, gradient, rotation));
       rotation = fmodf(rotation - new_val + old_val + 360.0f, 360.0f);
 
       if(gradient) gradient->rotation = rotation;

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -306,7 +306,8 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
   if(gui->form_dragging && gui->edit_mode == DT_MASKS_EDIT_FULL)
   {
     // we get the gradient
-    dt_masks_point_gradient_t *gradient = (dt_masks_point_gradient_t *)((form->points)->data);
+    dt_masks_point_gradient_t *gradient =
+      (dt_masks_point_gradient_t *)((form->points)->data);
 
     // we end the form dragging
     gui->form_dragging = FALSE;
@@ -332,7 +333,8 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
   else if(gui->form_rotating && gui->edit_mode == DT_MASKS_EDIT_FULL)
   {
     // we get the gradient
-    dt_masks_point_gradient_t *gradient = (dt_masks_point_gradient_t *)((form->points)->data);
+    dt_masks_point_gradient_t *gradient =
+      (dt_masks_point_gradient_t *)((form->points)->data);
 
     // we end the form rotating
     gui->form_rotating = FALSE;
@@ -343,7 +345,8 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
     const float y = pzy * ht;
 
     // we need the reference point
-    dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+    dt_masks_form_gui_points_t *gpt =
+      (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
     if(!gpt) return 0;
     const float xref = gpt->points[0];
     const float yref = gpt->points[1];
@@ -377,7 +380,8 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module, floa
   else if(gui->gradient_toggling)
   {
     // we get the gradient
-    dt_masks_point_gradient_t *gradient = (dt_masks_point_gradient_t *)((form->points)->data);
+    dt_masks_point_gradient_t *gradient =
+      (dt_masks_point_gradient_t *)((form->points)->data);
 
     // we end the gradient toggling
     gui->gradient_toggling = FALSE;
@@ -1528,4 +1532,3 @@ const dt_masks_functions_t dt_masks_functions_gradient = {
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -70,7 +70,8 @@ static void *_dup_masks_form_cb(const void *formdata, gpointer user_data)
 }
 
 // duplicate the list of forms, replace item in the list with form with the same formid
-GList *dt_masks_dup_forms_deep(GList *forms, dt_masks_form_t *form)
+GList *dt_masks_dup_forms_deep(GList *forms,
+                               dt_masks_form_t *form)
 {
   return (GList *)g_list_copy_deep(forms, _dup_masks_form_cb, (gpointer)form);
 }
@@ -296,14 +297,17 @@ static void _check_id(dt_masks_form_t *form)
   }
 }
 
-static void _set_group_name_from_module(dt_iop_module_t *module, dt_masks_form_t *grp)
+static void _set_group_name_from_module(dt_iop_module_t *module,
+                                        dt_masks_form_t *grp)
 {
   gchar *module_label = dt_history_item_get_name(module);
   snprintf(grp->name, sizeof(grp->name), "grp %s", module_label);
   g_free(module_label);
 }
 
-static dt_masks_form_t *_group_create(dt_develop_t *dev, dt_iop_module_t *module, dt_masks_type_t type)
+static dt_masks_form_t *_group_create(dt_develop_t *dev,
+                                      dt_iop_module_t *module,
+                                      const dt_masks_type_t type)
 {
   dt_masks_form_t* grp = dt_masks_create(type);
   _set_group_name_from_module(module, grp);
@@ -313,7 +317,8 @@ static dt_masks_form_t *_group_create(dt_develop_t *dev, dt_iop_module_t *module
   return grp;
 }
 
-static dt_masks_form_t *_group_from_module(dt_develop_t *dev, dt_iop_module_t *module)
+static dt_masks_form_t *_group_from_module(dt_develop_t *dev,
+                                           dt_iop_module_t *module)
 {
   return dt_masks_get_from_id(dev, module->blend_params->mask_id);
 }
@@ -422,19 +427,31 @@ int dt_masks_form_duplicate(dt_develop_t *dev, const int formid)
   return fdest->formid;
 }
 
-int dt_masks_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, float **points, int *points_count,
-                               float **border, int *border_count, int source, dt_iop_module_t *module)
+int dt_masks_get_points_border(dt_develop_t *dev,
+                               dt_masks_form_t *form,
+                               float **points,
+                               int *points_count,
+                               float **border,
+                               int *border_count,
+                               const int source,
+                               dt_iop_module_t *module)
 {
   if(form->functions && form->functions->get_points_border)
   {
-    return form->functions->get_points_border(dev, form, points, points_count, border, border_count, source,
+    return form->functions->get_points_border(dev, form, points, points_count,
+                                              border, border_count, source,
                                               module);
   }
   return 0;
 }
 
-int dt_masks_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *form,
-                      int *width, int *height, int *posx, int *posy)
+int dt_masks_get_area(dt_iop_module_t *module,
+                      dt_dev_pixelpipe_iop_t *piece,
+                      dt_masks_form_t *form,
+                      int *width,
+                      int *height,
+                      int *posx,
+                      int *posy)
 {
   if(form->functions)
     return form->functions->get_area(module, piece, form, width, height, posx, posy);
@@ -442,8 +459,13 @@ int dt_masks_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, dt
   return 0;
 }
 
-int dt_masks_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *form,
-                             int *width, int *height, int *posx, int *posy)
+int dt_masks_get_source_area(dt_iop_module_t *module,
+                             dt_dev_pixelpipe_iop_t *piece,
+                             dt_masks_form_t *form,
+                             int *width,
+                             int *height,
+                             int *posx,
+                             int *posy)
 {
   *width = *height = *posx = *posy = 0;
 
@@ -451,7 +473,8 @@ int dt_masks_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *pi
   if(form->type & DT_MASKS_CLONE)
   {
     if(form->functions)
-      return form->functions->get_source_area(module, piece, form, width, height, posx, posy);
+      return form->functions->get_source_area(module, piece, form, width, height,
+                                              posx, posy);
   }
   return 0;
 }
@@ -572,7 +595,8 @@ static int dt_masks_legacy_params_v1_to_v2(dt_develop_t *dev, void *params)
   }
 }
 
-static void dt_masks_legacy_params_v2_to_v3_transform(const dt_image_t *img, float *points)
+static void dt_masks_legacy_params_v2_to_v3_transform(const dt_image_t *img,
+                                                      float *points)
 {
   const float w = (float)img->width, h = (float)img->height;
 
@@ -591,8 +615,10 @@ static void dt_masks_legacy_params_v2_to_v3_transform(const dt_image_t *img, flo
   points[1] = ((points[1] * ch) + cy) / h;
 }
 
-static void dt_masks_legacy_params_v2_to_v3_transform_only_rescale(const dt_image_t *img, float *points,
-                                                                   size_t points_count)
+static void dt_masks_legacy_params_v2_to_v3_transform_only_rescale
+  (const dt_image_t *img,
+   float *points,
+   const size_t points_count)
 {
   const float w = (float)img->width, h = (float)img->height;
 
@@ -604,7 +630,8 @@ static void dt_masks_legacy_params_v2_to_v3_transform_only_rescale(const dt_imag
    * 1. de-normalize them by minimal of image original cropped dimensions
    * 2. normalize them by the minimal of image fully uncropped dimensions
    */
-  for(size_t i = 0; i < points_count; i++) points[i] = ((points[i] * MIN(cw, ch))) / MIN(w, h);
+  for(size_t i = 0; i < points_count; i++)
+    points[i] = ((points[i] * MIN(cw, ch))) / MIN(w, h);
 }
 
 static int dt_masks_legacy_params_v2_to_v3(dt_develop_t *dev, void *params)
@@ -765,7 +792,10 @@ static int dt_masks_legacy_params_v5_to_v6(dt_develop_t *dev, void *params)
 }
 
 
-int dt_masks_legacy_params(dt_develop_t *dev, void *params, const int old_version, const int new_version)
+int dt_masks_legacy_params(dt_develop_t *dev,
+                           void *params,
+                           const int old_version,
+                           const int new_version)
 {
   int res = 1;
 #if 0 // we should not need this any longer
@@ -843,9 +873,10 @@ dt_masks_form_t *dt_masks_create_ext(dt_masks_type_t type)
 {
   dt_masks_form_t *form = dt_masks_create(type);
 
-  // all forms created here are registered in darktable.develop->allforms for later cleanup
+  // all forms created here are registered in
+  // darktable.develop->allforms for later cleanup
   if(form)
-  darktable.develop->allforms = g_list_append(darktable.develop->allforms, form);
+    darktable.develop->allforms = g_list_append(darktable.develop->allforms, form);
 
   return form;
 }
@@ -856,7 +887,8 @@ void dt_masks_replace_current_forms(dt_develop_t *dev, GList *forms)
 
   while(dev->forms)
   {
-    darktable.develop->allforms = g_list_append(darktable.develop->allforms, dev->forms->data);
+    darktable.develop->allforms =
+      g_list_append(darktable.develop->allforms, dev->forms->data);
     dev->forms = g_list_delete_link(dev->forms, dev->forms);
   }
 
@@ -873,7 +905,7 @@ dt_masks_form_t *dt_masks_get_from_id_ext(GList *forms, int id)
   return NULL;
 }
 
-dt_masks_form_t *dt_masks_get_from_id(dt_develop_t *dev, int id)
+dt_masks_form_t *dt_masks_get_from_id(dt_develop_t *dev, const int id)
 {
   return dt_masks_get_from_id_ext(dev->forms, id);
 }
@@ -896,8 +928,8 @@ void dt_masks_read_masks_history(dt_develop_t *dev, const int imgid)
 
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
-    // db record:
-    // 0-img, 1-formid, 2-form_type, 3-name, 4-version, 5-points, 6-points_count, 7-source, 8-num
+    // db record: 0-img, 1-formid, 2-form_type, 3-name, 4-version,
+    // 5-points, 6-points_count, 7-source, 8-num
 
     // we get the values
 
@@ -930,14 +962,17 @@ void dt_masks_read_masks_history(dt_develop_t *dev, const int imgid)
     {
       if(dt_masks_legacy_params(dev, form, form->version, dt_masks_version()))
       {
-        const char *fname = dev->image_storage.filename + strlen(dev->image_storage.filename);
+        const char *fname =
+          dev->image_storage.filename + strlen(dev->image_storage.filename);
         while(fname > dev->image_storage.filename && *fname != '/') fname--;
         if(fname > dev->image_storage.filename) fname++;
 
         fprintf(stderr,
-                "[_dev_read_masks_history] %s (imgid `%i'): mask version mismatch: history is %d, darktable is %d.\n",
+                "[_dev_read_masks_history] %s (imgid `%i'):"
+                " mask version mismatch: history is %d, darktable is %d.\n",
                 fname, imgid, form->version, dt_masks_version());
-        dt_control_log(_("%s: mask version mismatch: %d != %d"), fname, dt_masks_version(), form->version);
+        dt_control_log(_("%s: mask version mismatch: %d != %d"),
+                       fname, dt_masks_version(), form->version);
 
         continue;
       }
@@ -965,7 +1000,8 @@ void dt_masks_read_masks_history(dt_develop_t *dev, const int imgid)
     }
     else
       fprintf(stderr,
-              "[_dev_read_masks_history] can't find history entry %i while adding mask %s(%i)\n",
+              "[_dev_read_masks_history] can't find history entry %i"
+              " while adding mask %s(%i)\n",
               num, form->name, formid);
 
     if(num < dev->history_end) hist_item_last = hist_item;
@@ -976,17 +1012,20 @@ void dt_masks_read_masks_history(dt_develop_t *dev, const int imgid)
   dt_masks_replace_current_forms(dev, (hist_item_last)?hist_item_last->forms:NULL);
 }
 
-void dt_masks_write_masks_history_item(const int imgid, const int num, dt_masks_form_t *form)
+void dt_masks_write_masks_history_item(const int imgid,
+                                       const int num,
+                                       dt_masks_form_t *form)
 {
   sqlite3_stmt *stmt;
 
   // write the form into the database
   // clang-format off
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "INSERT INTO main.masks_history (imgid, num, formid, form, name, "
-                              "version, points, points_count,source) VALUES "
-                              "(?1, ?9, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-                              -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_PREPARE_V2
+    (dt_database_get(darktable.db),
+     "INSERT INTO main.masks_history (imgid, num, formid, form, name, "
+     "                                version, points, points_count,source)"
+     " VALUES (?1, ?9, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+     -1, &stmt, NULL);
   // clang-format on
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 9, num);
@@ -1043,7 +1082,11 @@ int dt_masks_events_mouse_enter(struct dt_iop_module_t *module)
   return 0;
 }
 
-int dt_masks_events_mouse_moved(struct dt_iop_module_t *module, double x, double y, double pressure, int which)
+int dt_masks_events_mouse_moved(struct dt_iop_module_t *module,
+                                const double x,
+                                const double y,
+                                const double pressure,
+                                const int which)
 {
   // record mouse position even if there are no masks visible
   dt_masks_form_gui_t *gui = darktable.develop->form_gui;
@@ -1056,7 +1099,8 @@ int dt_masks_events_mouse_moved(struct dt_iop_module_t *module, double x, double
 
   if(gui)
   {
-    // This assume that if this event is generated the mouse is over the center window
+    // This assume that if this event is generated the mouse is over
+    // the center window
     gui->mouse_leaved_center = FALSE;
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
@@ -1071,8 +1115,11 @@ int dt_masks_events_mouse_moved(struct dt_iop_module_t *module, double x, double
   return rep;
 }
 
-int dt_masks_events_button_released(struct dt_iop_module_t *module, double x, double y, int which,
-                                    uint32_t state)
+int dt_masks_events_button_released(struct dt_iop_module_t *module,
+                                    const double x,
+                                    const double y,
+                                    const int which,
+                                    const uint32_t state)
 {
   dt_develop_t *dev = darktable.develop;
   dt_masks_form_t *form = dev->form_visible;
@@ -1089,7 +1136,8 @@ int dt_masks_events_button_released(struct dt_iop_module_t *module, double x, do
 
   if(form->functions)
   {
-    const int ret = form->functions->button_released(module, pzx, pzy, which, state, form, 0, gui, 0);
+    const int ret =
+      form->functions->button_released(module, pzx, pzy, which, state, form, 0, gui, 0);
     form->functions->mouse_moved(module, pzx, pzy, 0, which, form, 0, gui, 0);
     return ret;
   }
@@ -1097,8 +1145,13 @@ int dt_masks_events_button_released(struct dt_iop_module_t *module, double x, do
   return 0;
 }
 
-int dt_masks_events_button_pressed(struct dt_iop_module_t *module, double x, double y, double pressure,
-                                   int which, int type, uint32_t state)
+int dt_masks_events_button_pressed(struct dt_iop_module_t *module,
+                                   const double x,
+                                   const double y,
+                                   const double pressure,
+                                   const int which,
+                                   const int type,
+                                   const uint32_t state)
 {
   dt_masks_form_t *form = darktable.develop->form_visible;
   dt_masks_form_gui_t *gui = darktable.develop->form_gui;
@@ -1112,12 +1165,16 @@ int dt_masks_events_button_pressed(struct dt_iop_module_t *module, double x, dou
   {
     dt_masks_form_t *sel = NULL;
 
-    if((gui->form_selected || gui->source_selected || gui->point_selected || gui->seg_selected
+    if((gui->form_selected
+        || gui->source_selected
+        || gui->point_selected
+        || gui->seg_selected
         || gui->feather_selected)
        && !gui->creation && gui->group_edited >= 0)
     {
       // we get the selected form
-      dt_masks_point_group_t *fpt = (dt_masks_point_group_t *)g_list_nth_data(form->points, gui->group_edited);
+      dt_masks_point_group_t *fpt =
+        (dt_masks_point_group_t *)g_list_nth_data(form->points, gui->group_edited);
       if(fpt)
       {
         sel = dt_masks_get_from_id(darktable.develop, fpt->formid);
@@ -1128,8 +1185,11 @@ int dt_masks_events_button_pressed(struct dt_iop_module_t *module, double x, dou
   }
 
   if(form->functions)
-    return form->functions->button_pressed(module, pzx, pzy, pressure, which, type, state, form, 0, gui, 0)
-        || which == 3; // swallow right-clicks even when not handled so right-drag rotate is disabled when forms visible
+    return form->functions->button_pressed(module, pzx, pzy, pressure,
+                                           which, type, state, form, 0, gui, 0)
+      || which == 3; // swallow right-clicks even when not handled so
+                     // right-drag rotate is disabled when forms
+                     // visible
   return 0;
 }
 
@@ -1175,6 +1235,7 @@ int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module,
 
   return ret;
 }
+
 void dt_masks_events_post_expose(struct dt_iop_module_t *module,
                                  cairo_t *cr,
                                  const int32_t width,
@@ -1310,7 +1371,9 @@ void dt_masks_reset_show_masks_icons(void)
        && !(m->flags() & IOP_FLAGS_NO_MASKS))
     {
       dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)m->blend_data;
-      if(!bd) break;  // TODO: this doesn't look right. Why do we break the while look as soon as one module has no blend_data?
+      if(!bd) break;  // TODO: this doesn't look right. Why do we
+                      // break the while look as soon as one module
+                      // has no blend_data?
       bd->masks_shown = DT_MASKS_EDIT_OFF;
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), FALSE);
       gtk_widget_queue_draw(bd->masks_edit);
@@ -1330,14 +1393,17 @@ dt_masks_edit_mode_t dt_masks_get_edit_mode(struct dt_iop_module_t *module)
     : DT_MASKS_EDIT_OFF;
 }
 
-void dt_masks_set_edit_mode(struct dt_iop_module_t *module, dt_masks_edit_mode_t value)
+void dt_masks_set_edit_mode(struct dt_iop_module_t *module,
+                            dt_masks_edit_mode_t value)
 {
   if(!module) return;
   dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
   if(!bd) return;
 
   dt_masks_form_t *grp = NULL;
-  dt_masks_form_t *form = dt_masks_get_from_id(module->dev, module->blend_params->mask_id);
+  dt_masks_form_t *form =
+    dt_masks_get_from_id(module->dev, module->blend_params->mask_id);
+
   if(value && form)
   {
     grp = dt_masks_create_ext(DT_MASKS_GROUP);
@@ -1361,8 +1427,9 @@ void dt_masks_set_edit_mode(struct dt_iop_module_t *module, dt_masks_edit_mode_t
   dt_control_queue_redraw_center();
 }
 
-void dt_masks_set_edit_mode_single_form(struct dt_iop_module_t *module, const int formid,
-                                        dt_masks_edit_mode_t value)
+void dt_masks_set_edit_mode_single_form(struct dt_iop_module_t *module,
+                                        const int formid,
+                                        const dt_masks_edit_mode_t value)
 {
   if(!module) return;
 
@@ -1372,7 +1439,8 @@ void dt_masks_set_edit_mode_single_form(struct dt_iop_module_t *module, const in
   dt_masks_form_t *form = dt_masks_get_from_id(darktable.develop, formid);
   if(form)
   {
-    dt_masks_point_group_t *fpt = (dt_masks_point_group_t *)malloc(sizeof(dt_masks_point_group_t));
+    dt_masks_point_group_t *fpt =
+      (dt_masks_point_group_t *)malloc(sizeof(dt_masks_point_group_t));
     fpt->formid = formid;
     fpt->parentid = grid;
     fpt->state = DT_MASKS_STATE_USE;
@@ -1393,7 +1461,8 @@ void dt_masks_set_edit_mode_single_form(struct dt_iop_module_t *module, const in
   dt_control_queue_redraw_center();
 }
 
-void dt_masks_iop_edit_toggle_callback(GtkToggleButton *togglebutton, dt_iop_module_t *module)
+void dt_masks_iop_edit_toggle_callback(GtkToggleButton *togglebutton,
+                                       dt_iop_module_t *module)
 {
   if(!module) return;
   dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
@@ -1405,7 +1474,9 @@ void dt_masks_iop_edit_toggle_callback(GtkToggleButton *togglebutton, dt_iop_mod
 
   // reset the gui
   dt_masks_set_edit_mode(module,
-                         (bd->masks_shown == DT_MASKS_EDIT_OFF ? DT_MASKS_EDIT_FULL : DT_MASKS_EDIT_OFF));
+                         (bd->masks_shown == DT_MASKS_EDIT_OFF
+                          ? DT_MASKS_EDIT_FULL
+                          : DT_MASKS_EDIT_OFF));
 }
 
 static void _menu_no_masks(struct dt_iop_module_t *module)
@@ -1413,6 +1484,7 @@ static void _menu_no_masks(struct dt_iop_module_t *module)
   // we drop all the forms in the iop
   dt_masks_form_t *grp = _group_from_module(darktable.develop, module);
   if(grp) dt_masks_form_remove(module, NULL, grp);
+
   module->blend_params->mask_id = 0;
 
   // and we update the iop
@@ -1422,7 +1494,8 @@ static void _menu_no_masks(struct dt_iop_module_t *module)
   dt_dev_add_history_item(darktable.develop, module, TRUE);
 }
 
-static void _menu_add_shape(struct dt_iop_module_t *module, dt_masks_type_t type)
+static void _menu_add_shape(struct dt_iop_module_t *module,
+                            const dt_masks_type_t type)
 {
   // we want to be sure that the iop has focus
   dt_iop_request_focus(module);
@@ -1433,7 +1506,8 @@ static void _menu_add_shape(struct dt_iop_module_t *module, dt_masks_type_t type
   dt_control_queue_redraw_center();
 }
 
-static void _menu_add_exist(dt_iop_module_t *module, int formid)
+static void _menu_add_exist(dt_iop_module_t *module,
+                            const int formid)
 {
   if(!module) return;
   dt_masks_form_t *form = dt_masks_get_from_id(darktable.develop, formid);
@@ -1465,7 +1539,8 @@ void dt_masks_group_update_name(dt_iop_module_t *module)
   dt_masks_iop_update(module);
 }
 
-void dt_masks_iop_use_same_as(dt_iop_module_t *module, dt_iop_module_t *src)
+void dt_masks_iop_use_same_as(dt_iop_module_t *module,
+                              dt_iop_module_t *src)
 {
   if(!module || !src) return;
 
@@ -1508,7 +1583,10 @@ void dt_masks_iop_combo_populate(GtkWidget *w, struct dt_iop_module_t **m)
   dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
 
   // we determine a higher approx of the entry number
-  const guint nbe = 5 + g_list_length(darktable.develop->forms) + g_list_length(darktable.develop->iop);
+  const guint nbe = 5
+    + g_list_length(darktable.develop->forms)
+    + g_list_length(darktable.develop->iop);
+
   free(bd->masks_combo_ids);
   bd->masks_combo_ids = malloc(sizeof(int) * nbe);
 
@@ -1527,7 +1605,9 @@ void dt_masks_iop_combo_populate(GtkWidget *w, struct dt_iop_module_t **m)
 
   // add existing shapes
   int nb = 0;
-  for(GList *forms = darktable.develop->forms; forms; forms = g_list_next(forms))
+  for(GList *forms = darktable.develop->forms;
+      forms;
+      forms = g_list_next(forms))
   {
     const dt_masks_form_t *form = (dt_masks_form_t *)forms->data;
     if((form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
@@ -1567,7 +1647,9 @@ void dt_masks_iop_combo_populate(GtkWidget *w, struct dt_iop_module_t **m)
   // masks from other iops
   nb = 0;
   int pos2 = 1;
-  for(GList *modules = darktable.develop->iop; modules; modules = g_list_next(modules))
+  for(GList *modules = darktable.develop->iop;
+      modules;
+      modules = g_list_next(modules))
   {
     dt_iop_module_t *other_mod = (dt_iop_module_t *)modules->data;
 
@@ -1594,7 +1676,8 @@ void dt_masks_iop_combo_populate(GtkWidget *w, struct dt_iop_module_t **m)
   }
 }
 
-void dt_masks_iop_value_changed_callback(GtkWidget *widget, struct dt_iop_module_t *module)
+void dt_masks_iop_value_changed_callback(GtkWidget *widget,
+                                         struct dt_iop_module_t *module)
 {
   // we get the corresponding value
   dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
@@ -1676,13 +1759,16 @@ void dt_masks_iop_update(struct dt_iop_module_t *module)
   dt_iop_gui_update_masks(module);
 }
 
-void dt_masks_form_remove(struct dt_iop_module_t *module, dt_masks_form_t *grp, dt_masks_form_t *form)
+void dt_masks_form_remove(struct dt_iop_module_t *module,
+                          dt_masks_form_t *grp,
+                          dt_masks_form_t *form)
 {
   if(!form) return;
   const int id = form->formid;
   if(grp && !(grp->type & DT_MASKS_GROUP)) return;
 
-  if(!(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE)) && grp)
+  if(!(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
+     && grp)
   {
     // we try to remove the form from the masks group
     gboolean ok = FALSE;
@@ -1709,14 +1795,17 @@ void dt_masks_form_remove(struct dt_iop_module_t *module, dt_masks_form_t *grp, 
 
   if(form->type & DT_MASKS_GROUP && form->type & DT_MASKS_CLONE)
   {
-    // when removing a cloning group the children have to be removed, too, as they won't be shown in the mask manager
-    // and are thus not accessible afterwards.
+    // when removing a cloning group the children have to be removed,
+    // too, as they won't be shown in the mask manager and are thus
+    // not accessible afterwards.
     while(form->points)
     {
       dt_masks_point_group_t *group_child = (dt_masks_point_group_t *)form->points->data;
-      dt_masks_form_t *child = dt_masks_get_from_id(darktable.develop, group_child->formid);
+      dt_masks_form_t *child =
+        dt_masks_get_from_id(darktable.develop, group_child->formid);
       dt_masks_form_remove(module, form, child);
-      // no need to do anything to form->points, the recursive call will have removed child from the list
+      // no need to do anything to form->points, the recursive call
+      // will have removed child from the list
     }
   }
 
@@ -1780,7 +1869,9 @@ void dt_masks_form_remove(struct dt_iop_module_t *module, dt_masks_form_t *grp, 
   if(form_removed) dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 }
 
-float dt_masks_form_change_opacity(dt_masks_form_t *form, int parentid, float amount)
+float dt_masks_form_change_opacity(dt_masks_form_t *form,
+                                   const int parentid,
+                                   const float amount)
 {
   if(!form) return 0;
   dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, parentid);
@@ -1811,7 +1902,9 @@ float dt_masks_form_change_opacity(dt_masks_form_t *form, int parentid, float am
   return 0;
 }
 
-void dt_masks_form_move(dt_masks_form_t *grp, const int formid, const int up)
+void dt_masks_form_move(dt_masks_form_t *grp,
+                        const int formid,
+                        const int up)
 {
   if(!grp || !(grp->type & DT_MASKS_GROUP)) return;
 
@@ -1844,10 +1937,12 @@ void dt_masks_form_move(dt_masks_form_t *grp, const int formid, const int up)
   }
 }
 
-static int _find_in_group(dt_masks_form_t *grp, const int formid)
+static int _find_in_group(dt_masks_form_t *grp,
+                          const int formid)
 {
   if(!(grp->type & DT_MASKS_GROUP)) return 0;
   if(grp->formid == formid) return 1;
+
   int nb = 0;
   for(GList *forms = grp->points; forms; forms = g_list_next(forms))
   {
@@ -1861,7 +1956,8 @@ static int _find_in_group(dt_masks_form_t *grp, const int formid)
   return nb;
 }
 
-dt_masks_point_group_t *dt_masks_group_add_form(dt_masks_form_t *grp, dt_masks_form_t *form)
+dt_masks_point_group_t *dt_masks_group_add_form(dt_masks_form_t *grp,
+                                                dt_masks_form_t *form)
 {
   // add a form to group and check for self inclusion
 
@@ -1884,10 +1980,13 @@ dt_masks_point_group_t *dt_masks_group_add_form(dt_masks_form_t *grp, dt_masks_f
   return NULL;
 }
 
-void dt_masks_group_ungroup(dt_masks_form_t *dest_grp, dt_masks_form_t *grp)
+void dt_masks_group_ungroup(dt_masks_form_t *dest_grp,
+                            dt_masks_form_t *grp)
 {
   if(!grp || !dest_grp) return;
-  if(!(grp->type & DT_MASKS_GROUP) || !(dest_grp->type & DT_MASKS_GROUP)) return;
+  if(!(grp->type & DT_MASKS_GROUP)
+     || !(dest_grp->type & DT_MASKS_GROUP))
+    return;
 
   for(GList *forms = grp->points; forms; forms = g_list_next(forms))
   {
@@ -1901,7 +2000,8 @@ void dt_masks_group_ungroup(dt_masks_form_t *dest_grp, dt_masks_form_t *grp)
       }
       else
       {
-        dt_masks_point_group_t *fpt = (dt_masks_point_group_t *)malloc(sizeof(dt_masks_point_group_t));
+        dt_masks_point_group_t *fpt =
+          (dt_masks_point_group_t *)malloc(sizeof(dt_masks_point_group_t));
         fpt->formid = grpt->formid;
         fpt->parentid = grpt->parentid;
         fpt->state = grpt->state;
@@ -1922,7 +2022,9 @@ int dt_masks_group_get_hash_buffer_length(dt_masks_form_t *form)
   pos += sizeof(int);
   pos += 2 * sizeof(float);
 
-  for(GList *forms = form->points; forms; forms = g_list_next(forms))
+  for(GList *forms = form->points;
+      forms;
+      forms = g_list_next(forms))
   {
     if(form->type & DT_MASKS_GROUP)
     {
@@ -1999,7 +2101,10 @@ void dt_masks_update_image(dt_develop_t *dev)
 
 // adds formid to used array
 // if formid is a group it adds all the forms that belongs to that group
-static void _cleanup_unused_recurs(GList *forms, int formid, int *used, int nb)
+static void _cleanup_unused_recurs(GList *forms,
+                                   const int formid,
+                                   int *used,
+                                   const int nb)
 {
   // first, we search for the formid in used table
   for(int i = 0; i < nb; i++)
@@ -2026,7 +2131,9 @@ static void _cleanup_unused_recurs(GList *forms, int formid, int *used, int nb)
 }
 
 // removes from _forms all forms that are not used in history_list up to history_end
-static int _masks_cleanup_unused(GList **_forms, GList *history_list, const int history_end)
+static int _masks_cleanup_unused(GList **_forms,
+                                 GList *history_list,
+                                 const int history_end)
 {
   int masks_removed = 0;
   GList *forms = *_forms;
@@ -2035,15 +2142,19 @@ static int _masks_cleanup_unused(GList **_forms, GList *history_list, const int 
   const guint nbf = g_list_length(forms);
   int *used = calloc(nbf, sizeof(int));
 
-  // check in history if the module has drawn masks and add it to used array
+  // check in history if the module has drawn masks and add it to used
+  // array
   int num = 0;
-  for(GList *history = history_list; history && num < history_end; history = g_list_next(history))
+  for(GList *history = history_list;
+      history && num < history_end;
+      history = g_list_next(history))
   {
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)history->data;
     dt_develop_blend_params_t *blend_params = hist->blend_params;
     if(blend_params)
     {
-      if(blend_params->mask_id > 0) _cleanup_unused_recurs(forms, blend_params->mask_id, used, nbf);
+      if(blend_params->mask_id > 0)
+        _cleanup_unused_recurs(forms, blend_params->mask_id, used, nbf);
     }
     num++;
   }
@@ -2064,7 +2175,9 @@ static int _masks_cleanup_unused(GList **_forms, GList *history_list, const int 
       if(used[i] == 0) break;
     }
 
-    shapes = g_list_next(shapes); // need to get 'next' now, because we may be removing the current node
+    shapes = g_list_next(shapes); // need to get 'next' now, because
+                                  // we may be removing the current
+                                  // node
 
     if(found == FALSE)
     {
@@ -2082,20 +2195,25 @@ static int _masks_cleanup_unused(GList **_forms, GList *history_list, const int 
   return masks_removed;
 }
 
-// removes all unused form from history
-// if there are multiple hist->forms entries in history it may leave some unused forms
-// we do it like this so the user can go back in history
-// for a more accurate cleanup the user should compress history
+// removes all unused form from history if there are multiple
+// hist->forms entries in history it may leave some unused forms we do
+// it like this so the user can go back in history for a more accurate
+// cleanup the user should compress history
 void dt_masks_cleanup_unused_from_list(GList *history_list)
 {
-  // a mask is used in a given hist->forms entry if it is used up to the next hist->forms
-  // so we are going to remove for each hist->forms from the top
+  // a mask is used in a given hist->forms entry if it is used up to
+  // the next hist->forms so we are going to remove for each
+  // hist->forms from the top
   int num = g_list_length(history_list);
   int history_end = num;
-  for(const GList *history = g_list_last(history_list); history; history = g_list_previous(history))
+
+  for(const GList *history = g_list_last(history_list);
+      history;
+      history = g_list_previous(history))
   {
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)history->data;
-    if(hist->forms && strcmp(hist->op_name, "mask_manager") == 0)
+    if(hist->forms
+       && strcmp(hist->op_name, "mask_manager") == 0)
     {
       _masks_cleanup_unused(&hist->forms, history_list, history_end);
       history_end = num - 1;
@@ -2122,7 +2240,9 @@ void dt_masks_cleanup_unused(dt_develop_t *dev)
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)history->data;
 
     if(hist->forms) forms = hist->forms;
-    if(hist->module && strcmp(hist->op_name, "mask_manager") != 0) module = hist->module;
+    if(hist->module
+       && strcmp(hist->op_name, "mask_manager") != 0)
+      module = hist->module;
 
     num++;
   }
@@ -2135,11 +2255,15 @@ void dt_masks_cleanup_unused(dt_develop_t *dev)
     dt_dev_add_masks_history_item(dev, NULL, TRUE);
 }
 
-int dt_masks_point_in_form_exact(float x, float y, float *points, int points_start, int points_count)
+int dt_masks_point_in_form_exact(const float x,
+                                 const float y,
+                                 float *points,
+                                 const int points_start,
+                                 const int points_count)
 {
-  // we use ray casting algorithm
-  // to avoid most problems with horizontal segments, y should be rounded as int
-  // so that there's very little chance than y==points...
+  // we use ray casting algorithm to avoid most problems with
+  // horizontal segments, y should be rounded as int so that there's
+  // very little chance than y==points...
 
   if(points_count > 2 + points_start)
   {
@@ -2150,11 +2274,13 @@ int dt_masks_point_in_form_exact(float x, float y, float *points, int points_sta
 
     const float yf = (float)y;
     int nb = 0;
+
     for(int i = start, next = start + 1; i < points_count;)
     {
       const float y1 = points[i * 2 + 1];
       const float y2 = points[next * 2 + 1];
-      //if we need to skip points (in case of deleted point, because of self-intersection)
+      //if we need to skip points (in case of deleted point, because
+      //of self-intersection)
       if(isnan(points[next * 2]))
       {
         next = isnan(y2) ? start : (int)y2;
@@ -2173,19 +2299,26 @@ int dt_masks_point_in_form_exact(float x, float y, float *points, int points_sta
   return 0;
 }
 
-int dt_masks_point_in_form_near(float x, float y, float *points, int points_start, int points_count, float distance, int *near)
+int dt_masks_point_in_form_near(const float x,
+                                const float y,
+                                float *points,
+                                const int points_start,
+                                const int points_count,
+                                const float distance,
+                                int *near)
 {
-  // we use ray casting algorithm
-  // to avoid most problems with horizontal segments, y should be rounded as int
-  // so that there's very little chance than y==points...
+  // we use ray casting algorithm to avoid most problems with
+  // horizontal segments, y should be rounded as int so that there's
+  // very little chance than y==points...
 
   // TODO : distance is only evaluated in x, not y...
 
   if(points_count > 2 + points_start)
   {
-    const int start = isnan(points[points_start * 2]) && !isnan(points[points_start * 2 + 1])
-                      ? points[points_start * 2 + 1]
-                      : points_start;
+    const int start =
+      isnan(points[points_start * 2]) && !isnan(points[points_start * 2 + 1])
+      ? points[points_start * 2 + 1]
+      : points_start;
 
     const float yf = (float)y;
     int nb = 0;
@@ -2193,7 +2326,8 @@ int dt_masks_point_in_form_near(float x, float y, float *points, int points_star
     {
       const float y1 = points[i * 2 + 1];
       const float y2 = points[next * 2 + 1];
-      //if we need to jump to skip points (in case of deleted point, because of self-intersection)
+      //if we need to jump to skip points (in case of deleted point,
+      //because of self-intersection)
       if(isnan(points[next * 2]))
       {
         next = isnan(y2) ? start : (int)y2;
@@ -2279,7 +2413,10 @@ void dt_masks_select_form(struct dt_iop_module_t *module,
 }
 
 // draw a cross where the source position of a clone mask will be created
-void dt_masks_draw_clone_source_pos(cairo_t *cr, const float zoom_scale, const float x, const float y)
+void dt_masks_draw_clone_source_pos(cairo_t *cr,
+                                    const float zoom_scale,
+                                    const float x,
+                                    const float y)
 {
   const float dx = 3.5f / zoom_scale;
   const float dy = 3.5f / zoom_scale;
@@ -2303,9 +2440,11 @@ void dt_masks_draw_clone_source_pos(cairo_t *cr, const float zoom_scale, const f
   cairo_stroke(cr);
 }
 
-// sets if the initial source position for a clone mask will be absolute or relative,
-// based on mouse position and key state
-void dt_masks_set_source_pos_initial_state(dt_masks_form_gui_t *gui, const uint32_t state, const float pzx,
+// sets if the initial source position for a clone mask will be
+// absolute or relative, based on mouse position and key state
+void dt_masks_set_source_pos_initial_state(dt_masks_form_gui_t *gui,
+                                           const uint32_t state,
+                                           const float pzx,
                                            const float pzy)
 {
   if(dt_modifier_is(state, GDK_SHIFT_MASK | GDK_CONTROL_MASK))
@@ -2315,16 +2454,19 @@ void dt_masks_set_source_pos_initial_state(dt_masks_form_gui_t *gui, const uint3
   else
     fprintf(stderr, "[dt_masks_set_source_pos_initial_state] unknown state for setting masks position type\n");
 
-  // both source types record an absolute position,
-  // for the relative type, the first time is used the position is recorded,
-  // the second time a relative position is calculated based on that one
+  // both source types record an absolute position, for the relative
+  // type, the first time is used the position is recorded, the second
+  // time a relative position is calculated based on that one
   gui->posx_source = pzx * darktable.develop->preview_pipe->backbuf_width;
   gui->posy_source = pzy * darktable.develop->preview_pipe->backbuf_height;
 }
 
 // set the initial source position value for a clone mask
-void dt_masks_set_source_pos_initial_value(dt_masks_form_gui_t *gui, const int mask_type, dt_masks_form_t *form,
-                                                   const float pzx, const float pzy)
+void dt_masks_set_source_pos_initial_value(dt_masks_form_gui_t *gui,
+                                           const int mask_type,
+                                           dt_masks_form_t *form,
+                                           const float pzx,
+                                           const float pzy)
 {
   const float wd = darktable.develop->preview_pipe->backbuf_width;
   const float ht = darktable.develop->preview_pipe->backbuf_height;
@@ -2342,7 +2484,8 @@ void dt_masks_set_source_pos_initial_value(dt_masks_form_gui_t *gui, const int m
         form->functions->initial_source_pos(iwd, iht, &gui->posx_source, &gui->posy_source);
       }
       else
-        fprintf(stderr, "[dt_masks_set_source_pos_initial_value] unsupported masks type when calculating source position initial value\n");
+        fprintf(stderr, "[dt_masks_set_source_pos_initial_value]"
+                " unsupported masks type when calculating source position initial value\n");
 
       float pts[2] = { pzx * wd + gui->posx_source, pzy * ht + gui->posy_source };
       dt_dev_distort_backtransform(darktable.develop, pts, 1);
@@ -2352,7 +2495,8 @@ void dt_masks_set_source_pos_initial_value(dt_masks_form_gui_t *gui, const int m
     }
     else
     {
-      // if a position was defined by the user, use the absolute value the first time
+      // if a position was defined by the user, use the absolute value
+      // the first time
       float pts[2] = { gui->posx_source, gui->posy_source };
       dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
@@ -2367,8 +2511,10 @@ void dt_masks_set_source_pos_initial_value(dt_masks_form_gui_t *gui, const int m
   }
   else if(gui->source_pos_type == DT_MASKS_SOURCE_POS_RELATIVE)
   {
-    // original pos was already defined and relative value calculated, just use it
-    float pts[2] = { pzx * wd + gui->posx_source, pzy * ht + gui->posy_source };
+    // original pos was already defined and relative value calculated,
+    // just use it
+    float pts[2] = { pzx * wd + gui->posx_source,
+                     pzy * ht + gui->posy_source };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
     form->source[0] = pts[0] / iwd;
@@ -2384,13 +2530,20 @@ void dt_masks_set_source_pos_initial_value(dt_masks_form_gui_t *gui, const int m
     form->source[1] = pts_src[1] / iht;
   }
   else
-    fprintf(stderr, "[dt_masks_set_source_pos_initial_value] unknown source position type\n");
+    fprintf(stderr, "[dt_masks_set_source_pos_initial_value]"
+            " unknown source position type\n");
 }
 
 // calculates the source position value for preview drawing, on cairo coordinates
-void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mask_type, const float initial_xpos,
-                                         const float initial_ypos, const float xpos, const float ypos, float *px,
-                                         float *py, const int adding)
+void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui,
+                                         const int mask_type,
+                                         const float initial_xpos,
+                                         const float initial_ypos,
+                                         const float xpos,
+                                         const float ypos,
+                                         float *px,
+                                         float *py,
+                                         const int adding)
 {
   float x = 0.0f, y = 0.0f;
   const float pr_d = darktable.develop->preview_downsampling;
@@ -2406,7 +2559,8 @@ void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mas
   {
     if(gui->posx_source == -1.0f && gui->posy_source == -1.0f)
     {
-#if 0 //TODO: replace individual cases with this generic one (will require passing 'form' through multiple layers...)
+#if 0 //TODO: replace individual cases with this generic one (will
+      //require passing 'form' through multiple layers...)
       if(form->functions && form->functions->initial_source_pos)
       {
         form->functions->initial_source_pos(iwd, iht, &x, &y);
@@ -2440,7 +2594,8 @@ void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mas
       }
 #endif
       else
-        fprintf(stderr, "[dt_masks_calculate_source_pos_value] unsupported masks type when calculating source position value\n");
+        fprintf(stderr, "[dt_masks_calculate_source_pos_value]"
+                " unsupported masks type when calculating source position value\n");
     }
     else
     {
@@ -2465,19 +2620,28 @@ void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mas
   }
   else
     fprintf(stderr,
-            "[dt_masks_calculate_source_pos_value] unknown source position type for setting source position value\n");
+            "[dt_masks_calculate_source_pos_value]"
+            " unknown source position type for setting source position value\n");
 
   *px = x;
   *py = y;
 }
 
-void dt_masks_draw_anchor(cairo_t *cr, gboolean selected, const float zoom_scale, const float x, const float y)
+void dt_masks_draw_anchor(cairo_t *cr,
+                          const gboolean selected,
+                          const float zoom_scale,
+                          const float x,
+                          const float y)
 {
   const float anchor_size = DT_PIXEL_APPLY_DPI(selected ? 8.0f : 5.0f) / zoom_scale;
 
   cairo_set_dash(cr, NULL, 0, 0);
   dt_draw_set_color_overlay(cr, TRUE, 0.8);
-  cairo_rectangle(cr, x - (anchor_size * 0.5), y - (anchor_size * 0.5), anchor_size, anchor_size);
+  cairo_rectangle(cr,
+                  x - (anchor_size * 0.5),
+                  y - (anchor_size * 0.5),
+                  anchor_size,
+                  anchor_size);
   cairo_fill_preserve(cr);
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(selected ? 2.0 : 1.0) / zoom_scale);
   dt_draw_set_color_overlay(cr, FALSE, 0.8);

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2013-2022 darktable developers.
+    Copyright (C) 2013-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "develop/masks.h"
 #include "bauhaus/bauhaus.h"
 #include "common/debug.h"
@@ -53,7 +54,8 @@ dt_masks_form_t *dt_masks_dup_masks_form(const dt_masks_form_t *form)
       }
     }
   }
-  new_form->points = g_list_reverse(newpoints);  // list was built in reverse order, so un-reverse it
+  // list was built in reverse order, so un-reverse it
+  new_form->points = g_list_reverse(newpoints);
 
   return new_form;
 }
@@ -73,11 +75,14 @@ GList *dt_masks_dup_forms_deep(GList *forms, dt_masks_form_t *form)
   return (GList *)g_list_copy_deep(forms, _dup_masks_form_cb, (gpointer)form);
 }
 
-static int _get_opacity(dt_masks_form_gui_t *gui, const dt_masks_form_t *form)
+static int _get_opacity(dt_masks_form_gui_t *gui,
+                        const dt_masks_form_t *form)
 {
-  const dt_masks_point_group_t *fpt = (dt_masks_point_group_t *)g_list_nth_data(form->points, gui->group_edited);
+  const dt_masks_point_group_t *fpt =
+    (dt_masks_point_group_t *)g_list_nth_data(form->points, gui->group_edited);
   const dt_masks_form_t *sel = dt_masks_get_from_id(darktable.develop, fpt->formid);
   if(!sel) return 0;
+
   const int formid = sel->formid;
 
   // look for apacity
@@ -129,13 +134,15 @@ GSList *dt_masks_mouse_actions(dt_masks_form_t *form)
   // add the common action(s) shared by all shapes
   if(formtype != 0)
   {
-    lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_RIGHT, 0,  _("[SHAPE] remove shape"));
+    lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_RIGHT, 0,
+                                       _("[SHAPE] remove shape"));
   }
 
   return lm;
 }
 
-static void _set_hinter_message(dt_masks_form_gui_t *gui, const dt_masks_form_t *form)
+static void _set_hinter_message(dt_masks_form_gui_t *gui,
+                                const dt_masks_form_t *form)
 {
   char msg[256] = "";
 
@@ -147,7 +154,8 @@ static void _set_hinter_message(dt_masks_form_gui_t *gui, const dt_masks_form_t 
   if((ftype & DT_MASKS_GROUP) && (gui->group_edited >= 0))
   {
     // we get the selected form
-    const dt_masks_point_group_t *fpt = (dt_masks_point_group_t *)g_list_nth_data(form->points, gui->group_edited);
+    const dt_masks_point_group_t *fpt =
+      (dt_masks_point_group_t *)g_list_nth_data(form->points, gui->group_edited);
     sel = dt_masks_get_from_id(darktable.develop, fpt->formid);
     if(!sel) return;
 
@@ -176,9 +184,13 @@ void dt_masks_init_form_gui(dt_masks_form_gui_t *gui)
   gui->source_pos_type = DT_MASKS_SOURCE_POS_RELATIVE_TEMP;
 }
 
-void dt_masks_gui_form_create(dt_masks_form_t *form, dt_masks_form_gui_t *gui, int index, dt_iop_module_t *module)
+void dt_masks_gui_form_create(dt_masks_form_t *form,
+                              dt_masks_form_gui_t *gui,
+                              const int index,
+                              dt_iop_module_t *module)
 {
   const int npoints = g_list_length(gui->points);
+
   if(npoints == index)
     gui->points = g_list_append(gui->points, calloc(1, sizeof(dt_masks_form_gui_points_t)));
   else if(npoints > index)
@@ -186,12 +198,16 @@ void dt_masks_gui_form_create(dt_masks_form_t *form, dt_masks_form_gui_t *gui, i
   else
     return;
 
-  dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
-  if(dt_masks_get_points_border(darktable.develop, form, &gpt->points, &gpt->points_count, &gpt->border,
-                                &gpt->border_count, 0, NULL))
+  dt_masks_form_gui_points_t *gpt =
+    (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+
+  if(dt_masks_get_points_border(darktable.develop, form,
+                                &gpt->points, &gpt->points_count,
+                                &gpt->border, &gpt->border_count, 0, NULL))
   {
     if(form->type & DT_MASKS_CLONE)
-      dt_masks_get_points_border(darktable.develop, form, &gpt->source, &gpt->source_count, NULL, NULL, 1, module);
+      dt_masks_get_points_border(darktable.develop, form,
+                                 &gpt->source, &gpt->source_count, NULL, NULL, 1, module);
     gui->pipe_hash = darktable.develop->preview_pipe->backbuf_hash;
     gui->formid = form->formid;
   }
@@ -209,9 +225,12 @@ void dt_masks_form_gui_points_free(gpointer data)
   free(gpt);
 }
 
-void dt_masks_gui_form_remove(dt_masks_form_t *form, dt_masks_form_gui_t *gui, int index)
+void dt_masks_gui_form_remove(dt_masks_form_t *form,
+                              dt_masks_form_gui_t *gui,
+                              const int index)
 {
-  dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+  dt_masks_form_gui_points_t *gpt =
+    (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   gui->pipe_hash = gui->formid = 0;
 
   if(gpt)
@@ -226,7 +245,9 @@ void dt_masks_gui_form_remove(dt_masks_form_t *form, dt_masks_form_gui_t *gui, i
   }
 }
 
-void dt_masks_gui_form_test_create(dt_masks_form_t *form, dt_masks_form_gui_t *gui, dt_iop_module_t *module)
+void dt_masks_gui_form_test_create(dt_masks_form_t *form,
+                                   dt_masks_form_gui_t *gui,
+                                   dt_iop_module_t *module)
 {
   // we test if the image has changed
   if(gui->pipe_hash > 0)
@@ -297,7 +318,9 @@ static dt_masks_form_t *_group_from_module(dt_develop_t *dev, dt_iop_module_t *m
   return dt_masks_get_from_id(dev, module->blend_params->mask_id);
 }
 
-void dt_masks_gui_form_save_creation(dt_develop_t *dev, dt_iop_module_t *module, dt_masks_form_t *form,
+void dt_masks_gui_form_save_creation(dt_develop_t *dev,
+                                     dt_iop_module_t *module,
+                                     dt_masks_form_t *form,
                                      dt_masks_form_gui_t *gui)
 {
   // we check if the id is already registered
@@ -1108,7 +1131,11 @@ int dt_masks_events_button_pressed(struct dt_iop_module_t *module, double x, dou
   return 0;
 }
 
-int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module, double x, double y, int up, uint32_t state)
+int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module,
+                                   const double x,
+                                   const double y,
+                                   const int up,
+                                   const uint32_t state)
 {
   dt_masks_form_t *form = darktable.develop->form_visible;
   dt_masks_form_gui_t *gui = darktable.develop->form_gui;
@@ -1127,7 +1154,8 @@ int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module, double x, dou
 
   if(gui)
   {
-    // for brush, the opacity is the density of the masks, do not update opacity here for the brush.
+    // for brush, the opacity is the density of the masks, do not
+    // update opacity here for the brush.
     if(gui->creation && dt_modifier_is(state, GDK_CONTROL_MASK))
     {
       float opacity = dt_conf_get_float("plugins/darkroom/masks/opacity");
@@ -1145,8 +1173,12 @@ int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module, double x, dou
 
   return ret;
 }
-void dt_masks_events_post_expose(struct dt_iop_module_t *module, cairo_t *cr, int32_t width, int32_t height,
-                                 int32_t pointerx, int32_t pointery)
+void dt_masks_events_post_expose(struct dt_iop_module_t *module,
+                                 cairo_t *cr,
+                                 const int32_t width,
+                                 const int32_t height,
+                                 const int32_t pointerx,
+                                 const int32_t pointery)
 {
   dt_develop_t *dev = darktable.develop;
   dt_masks_form_t *form = dev->form_visible;
@@ -1206,14 +1238,15 @@ void dt_masks_clear_form_gui(dt_develop_t *dev)
   dev->form_gui->pipe_hash = dev->form_gui->formid = 0;
   dev->form_gui->dx = dev->form_gui->dy = 0.0f;
   dev->form_gui->scrollx = dev->form_gui->scrolly = 0.0f;
-  dev->form_gui->form_selected = dev->form_gui->border_selected = dev->form_gui->form_dragging
-      = dev->form_gui->form_rotating = dev->form_gui->border_toggling = dev->form_gui->gradient_toggling = FALSE;
+  dev->form_gui->form_selected = dev->form_gui->border_selected =
+    dev->form_gui->form_dragging = dev->form_gui->form_rotating =
+    dev->form_gui->border_toggling = dev->form_gui->gradient_toggling = FALSE;
   dev->form_gui->source_selected = dev->form_gui->source_dragging = FALSE;
   dev->form_gui->pivot_selected = FALSE;
-  dev->form_gui->point_border_selected = dev->form_gui->seg_selected = dev->form_gui->point_selected
-      = dev->form_gui->feather_selected = -1;
-  dev->form_gui->point_border_dragging = dev->form_gui->seg_dragging = dev->form_gui->feather_dragging
-      = dev->form_gui->point_dragging = -1;
+  dev->form_gui->point_border_selected = dev->form_gui->seg_selected =
+    dev->form_gui->point_selected = dev->form_gui->feather_selected = -1;
+  dev->form_gui->point_border_dragging = dev->form_gui->seg_dragging =
+    dev->form_gui->feather_dragging = dev->form_gui->point_dragging = -1;
   dev->form_gui->creation_closing_form = dev->form_gui->creation = FALSE;
   dev->form_gui->pressure_sensitivity = DT_MASKS_PRESSURE_OFF;
   dev->form_gui->creation_module = NULL;
@@ -2173,10 +2206,14 @@ int dt_masks_point_in_form_near(float x, float y, float *points, int points_star
   return 0;
 }
 
-float dt_masks_drag_factor(dt_masks_form_gui_t *gui, int index, int k, gboolean border)
+float dt_masks_drag_factor(dt_masks_form_gui_t *gui,
+                           const int index,
+                           const int k,
+                           const gboolean border)
 {
   // we need the reference points
   dt_masks_form_gui_points_t *gpt = g_list_nth_data(gui->points, index);
+
   if(!gpt) return 0;
 
   float *boundary = border ? gpt->border : gpt->points;
@@ -2187,7 +2224,8 @@ float dt_masks_drag_factor(dt_masks_form_gui_t *gui, int index, int k, gboolean 
   const float deltax = gui->posx + gui->dx - xref;
   const float deltay = gui->posy + gui->dy - yref;
 
-  // we remap dx, dy to the right values, as it will be used in next movements
+  // we remap dx, dy to the right values, as it will be used in next
+  // movements
   gui->dx = xref - gui->posx;
   gui->dy = yref - gui->posy;
 
@@ -2199,7 +2237,8 @@ float dt_masks_drag_factor(dt_masks_form_gui_t *gui, int index, int k, gboolean 
 }
 
 // allow to select a shape inside an iop
-void dt_masks_select_form(struct dt_iop_module_t *module, dt_masks_form_t *sel)
+void dt_masks_select_form(struct dt_iop_module_t *module,
+                          dt_masks_form_t *sel)
 {
   gboolean selection_changed = FALSE;
 

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1100,7 +1100,6 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
     }
     else
     {
-      dt_iop_module_t *crea_module = gui->creation_module;
       // we delete last point (the one we are currently dragging)
       dt_masks_point_path_t *point = (dt_masks_point_path_t *)g_list_last(form->points)->data;
       form->points = g_list_remove(form->points, point);
@@ -1111,7 +1110,9 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
       _path_init_ctrl_points(form);
 
       // we save the form and quit creation mode
+      dt_iop_module_t *crea_module = gui->creation_module;
       dt_masks_gui_form_save_creation(darktable.develop, crea_module, form, gui);
+
       if(crea_module)
       {
         dt_dev_add_history_item(darktable.develop, crea_module, TRUE);
@@ -1124,13 +1125,10 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
         else if(!gui->creation_continuous)
           dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
         dt_masks_iop_update(crea_module);
-        dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid);
-        gui->creation_module = NULL;
       }
-      else
-      {
-        dt_dev_masks_selection_change(darktable.develop, NULL, form->formid);
-      }
+
+      dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid);
+      gui->creation_module = NULL;
 
       if(gui->creation_continuous)
       {

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1339,11 +1339,11 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module,
       dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid);
       gui->creation_module = NULL;
 
-      if(crea_module
-         && gui->creation_continuous)
+      if(gui->creation_continuous)
       {
         //spot and retouch manage creation_continuous in their own way
-        if(!dt_iop_module_is(crea_module->so, "spots")
+        if(crea_module
+           && !dt_iop_module_is(crea_module->so, "spots")
            && !dt_iop_module_is(crea_module->so, "retouch"))
         {
           dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)crea_module->blend_data;

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1318,6 +1318,8 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module,
 
       _path_init_ctrl_points(form);
 
+      dt_masks_gui_form_create(form, gui, index, module);
+
       // we save the form and quit creation mode
       dt_iop_module_t *crea_module = gui->creation_module;
       dt_masks_gui_form_save_creation(darktable.develop, crea_module, form, gui);

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2013-2021 darktable developers.
+    Copyright (C) 2013-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -27,12 +27,28 @@
 #include "develop/openmp_maths.h"
 #include <assert.h>
 
-static void _path_bounding_box_raw(const float *const points, const float *border, const int nb_corner, const int num_points, int num_borders,
-                                   float *x_min, float *x_max, float *y_min, float *y_max);
+static void _path_bounding_box_raw(const float *const points,
+                                   const float *border,
+                                   const int nb_corner,
+                                   const int num_points,
+                                   const int num_borders,
+                                   float *x_min,
+                                   float *x_max,
+                                   float *y_min,
+                                   float *y_max);
 
 /** get the point of the path at pos t [0,1]  */
-static void _path_get_XY(float p0x, float p0y, float p1x, float p1y, float p2x, float p2y, float p3x,
-                         float p3y, float t, float *x, float *y)
+static void _path_get_XY(const float p0x,
+                         const float p0y,
+                         const float p1x,
+                         const float p1y,
+                         const float p2x,
+                         const float p2y,
+                         const float p3x,
+                         const float p3y,
+                         const float t,
+                         float *x,
+                         float *y)
 {
   const float ti = 1.0f - t;
   const float a = ti * ti * ti;
@@ -44,11 +60,23 @@ static void _path_get_XY(float p0x, float p0y, float p1x, float p1y, float p2x, 
 }
 
 /** get the point of the path at pos t [0,1]  AND the corresponding border point */
-static void _path_border_get_XY(float p0x, float p0y, float p1x, float p1y, float p2x, float p2y, float p3x,
-                                float p3y, float t, float rad, float *xc, float *yc, float *xb, float *yb)
+static void _path_border_get_XY(const float p0x,
+                                const float p0y,
+                                const float p1x,
+                                const float p1y,
+                                const float p2x,
+                                const float p2y,
+                                const float p3x,
+                                const float p3y,
+                                const float t,
+                                const float rad,
+                                float *xc,
+                                float *yc,
+                                float *xb,
+                                float *yb)
 {
-  // we use double precision math here to avoid rounding issues in paths with sharp corners
-  // we get the point
+  // we use double precision math here to avoid rounding issues in
+  // paths with sharp corners we get the point
   _path_get_XY(p0x, p0y, p1x, p1y, p2x, p2y, p3x, p3y, t, xc, yc);
 
   // now we get derivative points
@@ -80,8 +108,13 @@ static void _path_border_get_XY(float p0x, float p0y, float p1x, float p1y, floa
 
 /** get feather extremity from the control point n°2 */
 /** the values should be in orthonormal space */
-static void _path_ctrl2_to_feather(float ptx, float pty, float ctrlx, float ctrly, float *fx, float *fy,
-                                   gboolean clockwise)
+static void _path_ctrl2_to_feather(const float ptx,
+                                   const float pty,
+                                   const float ctrlx,
+                                   const float ctrly,
+                                   float *fx,
+                                   float *fy,
+                                   const gboolean clockwise)
 {
   if(clockwise)
   {
@@ -97,9 +130,15 @@ static void _path_ctrl2_to_feather(float ptx, float pty, float ctrlx, float ctrl
 
 /** get bezier control points from feather extremity */
 /** the values should be in orthonormal space */
-static void _path_feather_to_ctrl(float ptx, float pty, float fx, float fy,
-                                  float *ctrl1x, float *ctrl1y, float *ctrl2x, float *ctrl2y,
-                                  gboolean clockwise)
+static void _path_feather_to_ctrl(const float ptx,
+                                  const float pty,
+                                  const float fx,
+                                  const float fy,
+                                  float *ctrl1x,
+                                  float *ctrl1y,
+                                  float *ctrl2x,
+                                  float *ctrl2y,
+                                  const gboolean clockwise)
 {
   if(clockwise)
   {
@@ -117,9 +156,20 @@ static void _path_feather_to_ctrl(float ptx, float pty, float fx, float fy,
   }
 }
 
-/** Get the control points of a segment to match exactly a catmull-rom spline */
-static void _path_catmull_to_bezier(float x1, float y1, float x2, float y2, float x3, float y3, float x4,
-                                    float y4, float *bx1, float *by1, float *bx2, float *by2)
+/** Get the control points of a segment to match exactly a catmull-rom
+ * spline */
+static void _path_catmull_to_bezier(const float x1,
+                                    const float y1,
+                                    const float x2,
+                                    const float y2,
+                                    const float x3,
+                                    const float y3,
+                                    const float x4,
+                                    const float y4,
+                                    float *bx1,
+                                    float *by1,
+                                    float *bx2,
+                                    float *by2)
 {
   *bx1 = (-x1 + 6 * x2 + x3) / 6;
   *by1 = (-y1 + 6 * y2 + y3) / 6;
@@ -127,7 +177,8 @@ static void _path_catmull_to_bezier(float x1, float y1, float x2, float y2, floa
   *by2 = (y2 + 6 * y3 - y4) / 6;
 }
 
-/** initialise all control points to eventually match a catmull-rom like spline */
+/** initialise all control points to eventually match a catmull-rom
+ * like spline */
 static void _path_init_ctrl_points(dt_masks_form_t *form)
 {
   // if we have less that 3 points, what to do ??
@@ -141,11 +192,14 @@ static void _path_init_ctrl_points(dt_masks_form_t *form)
     // if the point has not been set manually, we redefine it
     if(point3->state & DT_MASKS_POINT_STATE_NORMAL)
     {
-      // we want to get point-2 (into pt1), point-1 (into pt2), point+1 (into pt4), point+2 (into pt5), wrapping
-      // around to the other end of the list
-      const GList *pt2 = g_list_prev_wraparound(form_points); // prev, wrapping around if already on first element
+      // we want to get point-2 (into pt1), point-1 (into pt2),
+      // point+1 (into pt4), point+2 (into pt5), wrapping around to
+      // the other end of the list
+      // prev, wrapping around if already on first element
+      const GList *pt2 = g_list_prev_wraparound(form_points);
       const GList *pt1 = g_list_prev_wraparound(pt2);
-      const GList *pt4 = g_list_next_wraparound(form_points, form->points); // next, wrapping around if on last element
+       // next, wrapping around if on last element
+      const GList *pt4 = g_list_next_wraparound(form_points, form->points);
       const GList *pt5 = g_list_next_wraparound(pt4, form->points);
       dt_masks_point_path_t *point1 = (dt_masks_point_path_t *)pt1->data;
       dt_masks_point_path_t *point2 = (dt_masks_point_path_t *)pt2->data;
@@ -153,15 +207,19 @@ static void _path_init_ctrl_points(dt_masks_form_t *form)
       dt_masks_point_path_t *point5 = (dt_masks_point_path_t *)pt5->data;
 
       float bx1 = 0.0f, by1 = 0.0f, bx2 = 0.0f, by2 = 0.0f;
-      _path_catmull_to_bezier(point1->corner[0], point1->corner[1], point2->corner[0], point2->corner[1],
-                              point3->corner[0], point3->corner[1], point4->corner[0], point4->corner[1],
+      _path_catmull_to_bezier(point1->corner[0], point1->corner[1],
+                              point2->corner[0], point2->corner[1],
+                              point3->corner[0], point3->corner[1],
+                              point4->corner[0], point4->corner[1],
                               &bx1, &by1, &bx2, &by2);
       if(point2->ctrl2[0] == -1.0) point2->ctrl2[0] = bx1;
       if(point2->ctrl2[1] == -1.0) point2->ctrl2[1] = by1;
       point3->ctrl1[0] = bx2;
       point3->ctrl1[1] = by2;
-      _path_catmull_to_bezier(point2->corner[0], point2->corner[1], point3->corner[0], point3->corner[1],
-                              point4->corner[0], point4->corner[1], point5->corner[0], point5->corner[1],
+      _path_catmull_to_bezier(point2->corner[0], point2->corner[1],
+                              point3->corner[0], point3->corner[1],
+                              point4->corner[0], point4->corner[1],
+                              point5->corner[0], point5->corner[1],
                               &bx1, &by1, &bx2, &by2);
       if(point4->ctrl1[0] == -1.0) point4->ctrl1[0] = bx2;
       if(point4->ctrl1[1] == -1.0) point4->ctrl1[1] = by2;
@@ -178,13 +236,17 @@ static gboolean _path_is_clockwise(dt_masks_form_t *form)
   if(!g_list_shorter_than(form->points,3)) // if we have at least three points...
   {
     float sum = 0.0f;
-    for(const GList *form_points = form->points; form_points; form_points = g_list_next(form_points))
+    for(const GList *form_points = form->points;
+        form_points;
+        form_points = g_list_next(form_points))
     {
-      const GList *next = g_list_next_wraparound(form_points, form->points); // next, wrapping around if on last elt
-      dt_masks_point_path_t *point1 = (dt_masks_point_path_t *)form_points->data; // kth element of form->points
+      // next, wrapping around if on last elt
+      const GList *next = g_list_next_wraparound(form_points, form->points);
+      // kth element of form->points
+      dt_masks_point_path_t *point1 = (dt_masks_point_path_t *)form_points->data;
       dt_masks_point_path_t *point2 = (dt_masks_point_path_t *)next->data;
-      sum += (point2->corner[0] - point1->corner[0]) * (point2->corner[1] + point1->corner[1]);
-      ;
+      sum += (point2->corner[0] - point1->corner[0])
+        * (point2->corner[1] + point1->corner[1]);
     }
     return (sum < 0);
   }
@@ -193,7 +255,11 @@ static gboolean _path_is_clockwise(dt_masks_form_t *form)
 }
 
 /** fill eventual gaps between 2 points with a line */
-static int _path_fill_gaps(int lastx, int lasty, int x, int y, dt_masks_dynbuf_t *points)
+static int _path_fill_gaps(const int lastx,
+                           const int lasty,
+                           const int x,
+                           const int y,
+                           dt_masks_dynbuf_t *points)
 {
   dt_masks_dynbuf_reset(points);
   dt_masks_dynbuf_add_2(points, x, y);
@@ -249,9 +315,15 @@ static int _path_fill_gaps(int lastx, int lasty, int x, int y, dt_masks_dynbuf_t
 }
 
 /** fill the gap between 2 points with an arc of circle */
-/** this function is here because we can have gap in border, esp. if the corner is very sharp */
-static void _path_points_recurs_border_gaps(float *cmax, float *bmin, float *bmin2, float *bmax, dt_masks_dynbuf_t *dpoints,
-                                            dt_masks_dynbuf_t *dborder, gboolean clockwise)
+/** this function is here because we can have gap in border, esp. if
+ * the corner is very sharp */
+static void _path_points_recurs_border_gaps(float *cmax,
+                                            float *bmin,
+                                            float *bmin2,
+                                            float *bmax,
+                                            dt_masks_dynbuf_t *dpoints,
+                                            dt_masks_dynbuf_t *dborder,
+                                            const gboolean clockwise)
 {
   // we want to find the start and end angles
   double a1 = atan2f(bmin[1] - cmax[1], bmin[0] - cmax[0]);
@@ -269,8 +341,10 @@ static void _path_points_recurs_border_gaps(float *cmax, float *bmin, float *bmi
   }
 
   // we determine start and end radius too
-  const float r1 = sqrtf((bmin[1] - cmax[1]) * (bmin[1] - cmax[1]) + (bmin[0] - cmax[0]) * (bmin[0] - cmax[0]));
-  const float r2 = sqrtf((bmax[1] - cmax[1]) * (bmax[1] - cmax[1]) + (bmax[0] - cmax[0]) * (bmax[0] - cmax[0]));
+  const float r1 = sqrtf((bmin[1] - cmax[1]) * (bmin[1] - cmax[1])
+                         + (bmin[0] - cmax[0]) * (bmin[0] - cmax[0]));
+  const float r2 = sqrtf((bmax[1] - cmax[1]) * (bmax[1] - cmax[1])
+                         + (bmax[0] - cmax[0]) * (bmax[0] - cmax[0]));
 
   // and the max length of the circle arc
   int l = 0;
@@ -288,8 +362,9 @@ static void _path_points_recurs_border_gaps(float *cmax, float *bmin, float *bmi
   // allocate entries in the dynbufs
   float *dpoints_ptr = dt_masks_dynbuf_reserve_n(dpoints, 2*(l-1));
   float *dborder_ptr = dborder ? dt_masks_dynbuf_reserve_n(dborder, 2*(l-1)) : NULL;
-  // and fill them in: the same center pos for each point in dpoints, and the corresponding border point at
-  //  successive angular positions for dborder
+  // and fill them in: the same center pos for each point in dpoints,
+  //  and the corresponding border point at successive angular
+  //  positions for dborder
   if(dpoints_ptr)
   {
     for(int i = 1; i < l; i++)
@@ -309,30 +384,44 @@ static void _path_points_recurs_border_gaps(float *cmax, float *bmin, float *bmi
 
 /** recursive function to get all points of the path AND all point of the border */
 /** the function take care to avoid big gaps between points */
-static void _path_points_recurs(float *p1, float *p2, double tmin, double tmax, float *path_min,
-                                float *path_max, float *border_min, float *border_max, float *rpath,
-                                float *rborder, dt_masks_dynbuf_t *dpoints, dt_masks_dynbuf_t *dborder,
-                                int withborder)
+static void _path_points_recurs(float *p1,
+                                float *p2,
+                                const double tmin,
+                                const double tmax,
+                                float *path_min,
+                                float *path_max,
+                                float *border_min,
+                                float *border_max,
+                                float *rpath,
+                                float *rborder,
+                                dt_masks_dynbuf_t *dpoints,
+                                dt_masks_dynbuf_t *dborder,
+                                const int withborder)
 {
   // we calculate points if needed
   if(isnan(path_min[0]))
   {
     _path_border_get_XY(p1[0], p1[1], p1[2], p1[3], p2[2], p2[3], p2[0], p2[1], tmin,
-                        p1[4] + (p2[4] - p1[4]) * tmin * tmin * (3.0 - 2.0 * tmin), path_min, path_min + 1,
+                        p1[4] + (p2[4] - p1[4]) * tmin * tmin * (3.0 - 2.0 * tmin),
+                        path_min, path_min + 1,
                         border_min, border_min + 1);
   }
   if(isnan(path_max[0]))
   {
     _path_border_get_XY(p1[0], p1[1], p1[2], p1[3], p2[2], p2[3], p2[0], p2[1], tmax,
-                        p1[4] + (p2[4] - p1[4]) * tmax * tmax * (3.0 - 2.0 * tmax), path_max, path_max + 1,
+                        p1[4] + (p2[4] - p1[4]) * tmax * tmax * (3.0 - 2.0 * tmax),
+                        path_max, path_max + 1,
                         border_max, border_max + 1);
   }
   // are the points near ?
   if((tmax - tmin < 0.0001)
-     || ((int)path_min[0] - (int)path_max[0] < 1 && (int)path_min[0] - (int)path_max[0] > -1
-         && (int)path_min[1] - (int)path_max[1] < 1 && (int)path_min[1] - (int)path_max[1] > -1
+     || ((int)path_min[0] - (int)path_max[0] < 1
+         && (int)path_min[0] - (int)path_max[0] > -1
+         && (int)path_min[1] - (int)path_max[1] < 1
+         && (int)path_min[1] - (int)path_max[1] > -1
          && (!withborder
-             || ((int)border_min[0] - (int)border_max[0] < 1 && (int)border_min[0] - (int)border_max[0] > -1
+             || ((int)border_min[0] - (int)border_max[0] < 1
+                 && (int)border_min[0] - (int)border_max[0] > -1
                  && (int)border_min[1] - (int)border_max[1] < 1
                  && (int)border_min[1] - (int)border_max[1] > -1))))
   {
@@ -353,12 +442,17 @@ static void _path_points_recurs(float *p1, float *p2, double tmin, double tmax, 
   double tx = (tmin + tmax) / 2.0;
   float c[2] = { NAN, NAN }, b[2] = { NAN, NAN };
   float rc[2] = { 0 }, rb[2] = { 0 };
-  _path_points_recurs(p1, p2, tmin, tx, path_min, c, border_min, b, rc, rb, dpoints, dborder, withborder);
-  _path_points_recurs(p1, p2, tx, tmax, rc, path_max, rb, border_max, rpath, rborder, dpoints, dborder, withborder);
+  _path_points_recurs(p1, p2, tmin, tx, path_min, c, border_min, b, rc, rb,
+                      dpoints, dborder, withborder);
+  _path_points_recurs(p1, p2, tx, tmax, rc, path_max, rb,
+                      border_max, rpath, rborder, dpoints, dborder, withborder);
 }
 
 /** find all self intersections in a path */
-static int _path_find_self_intersection(dt_masks_dynbuf_t *inter, int nb_corners, float *border, int border_count)
+static int _path_find_self_intersection(dt_masks_dynbuf_t *inter,
+                                        const int nb_corners,
+                                        float *border,
+                                        const int border_count)
 {
   if(nb_corners == 0 || border_count == 0) return 0;
 
@@ -416,10 +510,10 @@ static int _path_find_self_intersection(dt_masks_dynbuf_t *inter, int nb_corners
     return 0;
   }
 
-  // we'll iterate through all border points, but we can't start at point[0]
-  // because it may be in a self-intersected section
-  // so we choose a point where we are sure there's no intersection:
-  // one from border shape extrema (here x_max)
+  // we'll iterate through all border points, but we can't start at
+  // point[0] because it may be in a self-intersected section so we
+  // choose a point where we are sure there's no intersection: one
+  // from border shape extrema (here x_max)
   int lastx = border[(posextr[1] - 1) * 2];
   int lasty = border[(posextr[1] - 1) * 2 + 1];
 
@@ -458,8 +552,9 @@ static int _path_find_self_intersection(dt_masks_dynbuf_t *inter, int nb_corners
       {
         if(v[k] > 0)
         {
-          // there's already a border point "registered" at this coordinate.
-          // so we've potentially found a self-intersection portion between v[k] and i
+          // there's already a border point "registered" at this
+          // coordinate.  so we've potentially found a
+          // self-intersection portion between v[k] and i
           if((xx == lastx && yy == lasty) || v[k] == i - 1)
           {
             // we haven't move from last point.
@@ -467,17 +562,26 @@ static int _path_find_self_intersection(dt_masks_dynbuf_t *inter, int nb_corners
             binter[idx] = i;
           }
           else if((i > v[k]
-                   && ((posextr[0] < v[k] || posextr[0] > i) && (posextr[1] < v[k] || posextr[1] > i)
-                       && (posextr[2] < v[k] || posextr[2] > i) && (posextr[3] < v[k] || posextr[3] > i)))
-                  || (i < v[k] && posextr[0] < v[k] && posextr[0] > i && posextr[1] < v[k] && posextr[1] > i
-                      && posextr[2] < v[k] && posextr[2] > i && posextr[3] < v[k] && posextr[3] > i))
+                   && ((posextr[0] < v[k] || posextr[0] > i)
+                       && (posextr[1] < v[k] || posextr[1] > i)
+                       && (posextr[2] < v[k] || posextr[2] > i)
+                       && (posextr[3] < v[k] || posextr[3] > i)))
+                  || (i < v[k]
+                      && posextr[0] < v[k] && posextr[0] > i
+                      && posextr[1] < v[k] && posextr[1] > i
+                      && posextr[2] < v[k] && posextr[2] > i
+                      && posextr[3] < v[k] && posextr[3] > i))
           {
-            // we have found a self-intersection portion, between v[k] and i
-            // and we are sure that this portion doesn't include one of the shape extrema
+            // we have found a self-intersection portion, between v[k]
+            // and i and we are sure that this portion doesn't include
+            // one of the shape extrema
             if(inter_count > 0)
             {
-              if((v[k] - i) * ((int)dt_masks_dynbuf_get(inter, -2) - (int)dt_masks_dynbuf_get(inter, -1)) > 0
-                 && (int)dt_masks_dynbuf_get(inter, -2) >= v[k] && (int)dt_masks_dynbuf_get(inter, -1) <= i)
+              if((v[k] - i)
+                 * ((int)dt_masks_dynbuf_get(inter, -2)
+                    - (int)dt_masks_dynbuf_get(inter, -1)) > 0
+                 && (int)dt_masks_dynbuf_get(inter, -2) >= v[k]
+                 && (int)dt_masks_dynbuf_get(inter, -1) <= i)
               {
                 // we find an self-intersection portion which include the last one
                 // we just update it
@@ -520,9 +624,16 @@ static int _path_find_self_intersection(dt_masks_dynbuf_t *inter, int nb_corners
 
 /** get all points of the path and the border */
 /** this take care of gaps and self-intersection and iop distortions */
-static int _path_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const double iop_order, const int transf_direction,
-                                   dt_dev_pixelpipe_t *pipe, float **points, int *points_count,
-                                   float **border, int *border_count, gboolean source)
+static int _path_get_pts_border(dt_develop_t *dev,
+                                dt_masks_form_t *form,
+                                const double iop_order,
+                                const int transf_direction,
+                                dt_dev_pixelpipe_t *pipe,
+                                float **points,
+                                int *points_count,
+                                float **border,
+                                int *border_count,
+                                const gboolean source)
 {
   double start2 = 0.0;
 
@@ -610,26 +721,41 @@ static int _path_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const 
     dt_masks_point_path_t *point1 = (dt_masks_point_path_t *)form_points->data; // kth element of form->points
     dt_masks_point_path_t *point2 = (dt_masks_point_path_t *)pt2->data;
     dt_masks_point_path_t *point3 = (dt_masks_point_path_t *)pt3->data;
-    float p1[5] = { point1->corner[0] * wd - dx, point1->corner[1] * ht - dy, point1->ctrl2[0] * wd - dx,
-                    point1->ctrl2[1] * ht - dy, cw * point1->border[1] * MIN(wd, ht) };
-    float p2[5] = { point2->corner[0] * wd - dx, point2->corner[1] * ht - dy, point2->ctrl1[0] * wd - dx,
-                    point2->ctrl1[1] * ht - dy, cw * point2->border[0] * MIN(wd, ht) };
-    float p3[5] = { point2->corner[0] * wd - dx, point2->corner[1] * ht - dy, point2->ctrl2[0] * wd - dx,
-                    point2->ctrl2[1] * ht - dy, cw * point2->border[1] * MIN(wd, ht) };
-    float p4[5] = { point3->corner[0] * wd - dx, point3->corner[1] * ht - dy, point3->ctrl1[0] * wd - dx,
-                    point3->ctrl1[1] * ht - dy, cw * point3->border[0] * MIN(wd, ht) };
+    float p1[5] = { point1->corner[0] * wd - dx,
+                    point1->corner[1] * ht - dy,
+                    point1->ctrl2[0] * wd - dx,
+                    point1->ctrl2[1] * ht - dy,
+                    cw * point1->border[1] * MIN(wd, ht) };
+    float p2[5] = { point2->corner[0] * wd - dx,
+                    point2->corner[1] * ht - dy,
+                    point2->ctrl1[0] * wd - dx,
+                    point2->ctrl1[1] * ht - dy,
+                    cw * point2->border[0] * MIN(wd, ht) };
+    float p3[5] = { point2->corner[0] * wd - dx,
+                    point2->corner[1] * ht - dy,
+                    point2->ctrl2[0] * wd - dx,
+                    point2->ctrl2[1] * ht - dy,
+                    cw * point2->border[1] * MIN(wd, ht) };
+    float p4[5] = { point3->corner[0] * wd - dx,
+                    point3->corner[1] * ht - dy,
+                    point3->ctrl1[0] * wd - dx,
+                    point3->ctrl1[1] * ht - dy,
+                    cw * point3->border[0] * MIN(wd, ht) };
 
-    // advance form_points for next iteration so that it tracks the kth element of form->points
+    // advance form_points for next iteration so that it tracks the
+    // kth element of form->points
     form_points = g_list_next(form_points);
 
-    // and we determine all points by recursion (to be sure the distance between 2 points is <=1)
+    // and we determine all points by recursion (to be sure the
+    // distance between 2 points is <=1)
     float rc[2] = { 0 }, rb[2] = { 0 };
     float bmin[2] = { NAN, NAN };
     float bmax[2] = { NAN, NAN };
     float cmin[2] = { NAN, NAN };
     float cmax[2] = { NAN, NAN };
 
-    _path_points_recurs(p1, p2, 0.0, 1.0, cmin, cmax, bmin, bmax, rc, rb, dpoints, dborder, border && (nb >= 3));
+    _path_points_recurs(p1, p2, 0.0, 1.0, cmin, cmax, bmin, bmax,
+                        rc, rb, dpoints, dborder, border && (nb >= 3));
 
     // we check gaps in the border (sharp edges)
     if(dborder && (fabs(dt_masks_dynbuf_get(dborder, -2) - rb[0]) > 1.0f
@@ -657,27 +783,36 @@ static int _path_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const 
       }
       dt_masks_dynbuf_add_2(dborder, rb[0], rb[1]);
 
-      (dt_masks_dynbuf_buffer(dborder))[k * 6] = border_init[k * 6] = (dt_masks_dynbuf_buffer(dborder))[pb];
-      (dt_masks_dynbuf_buffer(dborder))[k * 6 + 1] = border_init[k * 6 + 1] = (dt_masks_dynbuf_buffer(dborder))[pb + 1];
+      (dt_masks_dynbuf_buffer(dborder))[k * 6] =
+        border_init[k * 6] = (dt_masks_dynbuf_buffer(dborder))[pb];
+      (dt_masks_dynbuf_buffer(dborder))[k * 6 + 1] =
+        border_init[k * 6 + 1] = (dt_masks_dynbuf_buffer(dborder))[pb + 1];
     }
 
     // we first want to be sure that there are no gaps in border
     if(dborder && nb >= 3)
     {
-      // we get the next point (start of the next segment)
-      // t=0.00001f to workaround rounding effects with full optimization that result in bmax[0] NOT being set to
-      // NAN when t=0 and the two points in p3 are identical (as is the case on a control node set to sharp corner)
-      _path_border_get_XY(p3[0], p3[1], p3[2], p3[3], p4[2], p4[3], p4[0], p4[1], 0.00001f, p3[4], cmin, cmin + 1,
-                          bmax, bmax + 1);
+      // we get the next point (start of the next segment) t=0.00001f
+      // to workaround rounding effects with full optimization that
+      // result in bmax[0] NOT being set to NAN when t=0 and the two
+      // points in p3 are identical (as is the case on a control node
+      // set to sharp corner)
+      _path_border_get_XY(p3[0], p3[1], p3[2], p3[3], p4[2], p4[3], p4[0], p4[1],
+                          0.00001f, p3[4], cmin, cmin + 1, bmax, bmax + 1);
       if(isnan(bmax[0]))
       {
-        _path_border_get_XY(p3[0], p3[1], p3[2], p3[3], p4[2], p4[3], p4[0], p4[1], 0.00001f, p3[4], cmin,
-                            cmin + 1, bmax, bmax + 1);
+        _path_border_get_XY(p3[0], p3[1], p3[2], p3[3], p4[2], p4[3], p4[0], p4[1],
+                            0.00001f, p3[4], cmin, cmin + 1, bmax, bmax + 1);
       }
-      if(bmax[0] - rb[0] > 1 || bmax[0] - rb[0] < -1 || bmax[1] - rb[1] > 1 || bmax[1] - rb[1] < -1)
+      if(bmax[0] - rb[0] > 1
+         || bmax[0] - rb[0] < -1
+         || bmax[1] - rb[1] > 1
+         || bmax[1] - rb[1] < -1)
       {
-        float bmin2[2] = { dt_masks_dynbuf_get(dborder, -22), dt_masks_dynbuf_get(dborder, -21) };
-        _path_points_recurs_border_gaps(rc, rb, bmin2, bmax, dpoints, dborder, _path_is_clockwise(form));
+        float bmin2[2] = { dt_masks_dynbuf_get(dborder, -22),
+                           dt_masks_dynbuf_get(dborder, -21) };
+        _path_points_recurs_border_gaps(rc, rb, bmin2, bmax, dpoints, dborder,
+                                        _path_is_clockwise(form));
       }
     }
   }
@@ -695,7 +830,8 @@ static int _path_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const 
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] path_points point recurs %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS, "[masks %s] path_points point recurs %0.04f sec\n",
+             form->name,
              dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
@@ -708,7 +844,8 @@ static int _path_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const 
 
     if(darktable.unmuted & DT_DEBUG_PERF)
     {
-      dt_print(DT_DEBUG_MASKS, "[masks %s] path_points self-intersect took %0.04f sec\n", form->name,
+      dt_print(DT_DEBUG_MASKS,
+               "[masks %s] path_points self-intersect took %0.04f sec\n", form->name,
                dt_get_wtime() - start2);
       start2 = dt_get_wtime();
     }
@@ -719,12 +856,16 @@ static int _path_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const 
   {
     // we transform with all distortion that happen *before* the module
     // so we have now the TARGET points in module input reference
-    if(dt_dev_distort_transform_plus(dev, pipe, iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL, *points, *points_count))
+    if(dt_dev_distort_transform_plus(dev, pipe, iop_order,
+                                     DT_DEV_TRANSFORM_DIR_BACK_EXCL,
+                                     *points, *points_count))
     {
       // now we move all the points by the shift
       // so we have now the SOURCE points in module input reference
       float pts[2] = { form->source[0] * wd, form->source[1] * ht };
-      if(!dt_dev_distort_transform_plus(dev, pipe, iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL, pts, 1)) goto fail;
+      if(!dt_dev_distort_transform_plus(dev, pipe, iop_order,
+                                        DT_DEV_TRANSFORM_DIR_BACK_EXCL, pts, 1))
+        goto fail;
 
       dx = pts[0] - (*points)[2];
       dy = pts[1] - (*points)[3];
@@ -742,25 +883,31 @@ static int _path_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const 
 
       // we apply the rest of the distortions (those after the module)
       // so we have now the SOURCE points in final image reference
-      if(!dt_dev_distort_transform_plus(dev, pipe, iop_order, DT_DEV_TRANSFORM_DIR_FORW_INCL, *points,
+      if(!dt_dev_distort_transform_plus(dev, pipe, iop_order,
+                                        DT_DEV_TRANSFORM_DIR_FORW_INCL, *points,
                                         *points_count))
         goto fail;
     }
 
     if(darktable.unmuted & DT_DEBUG_PERF)
-      dt_print(DT_DEBUG_MASKS, "[masks %s] path_points end took %0.04f sec\n", form->name, dt_get_wtime() - start2);
+      dt_print(DT_DEBUG_MASKS, "[masks %s] path_points end took %0.04f sec\n",
+               form->name, dt_get_wtime() - start2);
 
     dt_masks_dynbuf_free(intersections);
     dt_free_align(border_init);
     return 1;
   }
-  else if(dt_dev_distort_transform_plus(dev, pipe, iop_order, transf_direction, *points, *points_count))
+  else if(dt_dev_distort_transform_plus(dev, pipe, iop_order, transf_direction,
+                                        *points, *points_count))
   {
-    if(!border || dt_dev_distort_transform_plus(dev, pipe, iop_order, transf_direction, *border, *border_count))
+    if(!border
+       || dt_dev_distort_transform_plus(dev, pipe, iop_order,
+                                        transf_direction, *border, *border_count))
     {
       if(darktable.unmuted & DT_DEBUG_PERF)
       {
-        dt_print(DT_DEBUG_MASKS, "[masks %s] path_points transform took %0.04f sec\n", form->name,
+        dt_print(DT_DEBUG_MASKS,
+                 "[masks %s] path_points transform took %0.04f sec\n", form->name,
                  dt_get_wtime() - start2);
         start2 = dt_get_wtime();
       }
@@ -800,7 +947,8 @@ static int _path_get_pts_border(dt_develop_t *dev, dt_masks_form_t *form, const 
       }
 
       if(darktable.unmuted & DT_DEBUG_PERF)
-        dt_print(DT_DEBUG_MASKS, "[masks %s] path_points end took %0.04f sec\n", form->name,
+        dt_print(DT_DEBUG_MASKS,
+                 "[masks %s] path_points end took %0.04f sec\n", form->name,
                  dt_get_wtime() - start2);
 
       dt_masks_dynbuf_free(intersections);
@@ -823,8 +971,17 @@ fail:
 }
 
 /** get the distance between point (x,y) and the path */
-static void _path_get_distance(float x, float y, float as, dt_masks_form_gui_t *gui, int index,
-                               int corner_count, int *inside, int *inside_border, int *near, int *inside_source, float *dist)
+static void _path_get_distance(const float x,
+                               const float y,
+                               const float as,
+                               dt_masks_form_gui_t *gui,
+                               const int index,
+                               const int corner_count,
+                               int *inside,
+                               int *inside_border,
+                               int *near,
+                               int *inside_source,
+                               float *dist)
 {
   // initialise returned values
   *inside_source = 0;
@@ -835,7 +992,8 @@ static void _path_get_distance(float x, float y, float as, dt_masks_form_gui_t *
 
   if(!gui) return;
 
-  dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+  dt_masks_form_gui_points_t *gpt =
+    (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return;
 
   // we first check if we are inside the source form
@@ -890,7 +1048,8 @@ static void _path_get_distance(float x, float y, float as, dt_masks_form_gui_t *
 
     for(int i = corner_count * 3; i < gpt->points_count; i++)
     {
-      //if we need to jump to skip points (in case of deleted point, because of self-intersection)
+      //if we need to jump to skip points (in case of deleted point,
+      //because of self-intersection)
       if(isnan(gpt->points[i * 2]))
       {
         if(isnan(gpt->points[i * 2 + 1])) break;
@@ -938,21 +1097,37 @@ static void _path_get_distance(float x, float y, float as, dt_masks_form_gui_t *
   else *inside_border = 1;
 }
 
-static int _path_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, float **points, int *points_count,
-                                   float **border, int *border_count, int source, const dt_iop_module_t *module)
+static int _path_get_points_border(dt_develop_t *dev,
+                                   dt_masks_form_t *form,
+                                   float **points,
+                                   int *points_count,
+                                   float **border,
+                                   int *border_count,
+                                   const int source,
+                                   const dt_iop_module_t *module)
 {
   if(source && !module) return 0;
   const double ioporder = (module) ? module->iop_order : 0.0f;
-  return _path_get_pts_border(dev, form, ioporder, DT_DEV_TRANSFORM_DIR_ALL, dev->preview_pipe, points,
+  return _path_get_pts_border(dev, form, ioporder,
+                              DT_DEV_TRANSFORM_DIR_ALL, dev->preview_pipe, points,
                               points_count, border, border_count, source);
 }
 
-static int _path_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx, float pzy, int up,
-                                       uint32_t state, dt_masks_form_t *form, int parentid,
-                                       dt_masks_form_gui_t *gui, int index)
+static int _path_events_mouse_scrolled(struct dt_iop_module_t *module,
+                                       const float pzx,
+                                       const float pzy,
+                                       const int up,
+                                       const uint32_t state,
+                                       dt_masks_form_t *form,
+                                       const int parentid,
+                                       dt_masks_form_gui_t *gui,
+                                       const int index)
 {
   // resize a shape even if on a node or segment
-  if(gui->form_selected || gui->point_selected >= 0 || gui->feather_selected >= 0 || gui->seg_selected >= 0
+  if(gui->form_selected
+     || gui->point_selected >= 0
+     || gui->feather_selected >= 0
+     || gui->seg_selected >= 0
      || gui->point_border_selected >= 0)
   {
     // we register the current position
@@ -978,7 +1153,10 @@ static int _path_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx
         for(const GList *l = form->points; l; l = g_list_next(l))
         {
           const dt_masks_point_path_t *point = (dt_masks_point_path_t *)l->data;
-          if(amount > 1.0f && (point->border[0] > 1.0f || point->border[1] > 1.0f)) return 1;
+          if(amount > 1.0f
+             && (point->border[0] > 1.0f
+                 || point->border[1] > 1.0f))
+            return 1;
         }
         for(const GList *l = form->points; l; l = g_list_next(l))
         {
@@ -990,7 +1168,8 @@ static int _path_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx
         float masks_border = dt_conf_get_float(DT_MASKS_CONF(form->type, path, border));
         masks_border = MAX(0.0005f, MIN(masks_border * amount, 0.5f));
         dt_conf_set_float(DT_MASKS_CONF(form->type, path, border), masks_border);
-        dt_toast_log(_("feather size: %3.2f%%"), feather_size * 50.0f / g_list_length(form->points));
+        dt_toast_log(_("feather size: %3.2f%%"),
+                     feather_size * 50.0f / g_list_length(form->points));
       }
       else if(gui->edit_mode == DT_MASKS_EDIT_FULL)
       {
@@ -999,17 +1178,26 @@ static int _path_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx
         float by = 0.0f;
         float surf = 0.0f;
 
-        for(const GList *form_points = form->points; form_points; form_points = g_list_next(form_points))
+        for(const GList *form_points = form->points;
+            form_points;
+            form_points = g_list_next(form_points))
         {
-          const GList *next = g_list_next_wraparound(form_points, form->points); // next w/ wrap
-          dt_masks_point_path_t *point1 = (dt_masks_point_path_t *)form_points->data; // kth element of form->points
-          dt_masks_point_path_t *point2 = (dt_masks_point_path_t *)next->data;
-          surf += point1->corner[0] * point2->corner[1] - point2->corner[0] * point1->corner[1];
+          const GList *next =
+            g_list_next_wraparound(form_points, form->points); // next w/ wrap
+          dt_masks_point_path_t *point1 =
+            (dt_masks_point_path_t *)form_points->data; // kth element of form->points
+          dt_masks_point_path_t *point2 =
+            (dt_masks_point_path_t *)next->data;
+
+          surf += point1->corner[0] * point2->corner[1]
+            - point2->corner[0] * point1->corner[1];
 
           bx += (point1->corner[0] + point2->corner[0])
-                * (point1->corner[0] * point2->corner[1] - point2->corner[0] * point1->corner[1]);
+                * (point1->corner[0] * point2->corner[1]
+                   - point2->corner[0] * point1->corner[1]);
           by += (point1->corner[1] + point2->corner[1])
-                * (point1->corner[0] * point2->corner[1] - point2->corner[0] * point1->corner[1]);
+                * (point1->corner[0] * point2->corner[1]
+                   - point2->corner[0] * point1->corner[1]);
         }
         bx /= 3.0f * surf;
         by /= 3.0f * surf;
@@ -1063,34 +1251,53 @@ static int _path_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx
   return 0;
 }
 
-static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx, float pzy,
-                                       double pressure, int which, int type, uint32_t state,
-                                       dt_masks_form_t *form, int parentid, dt_masks_form_gui_t *gui, int index)
+static int _path_events_button_pressed(struct dt_iop_module_t *module,
+                                       const float pzx,
+                                       const float pzy,
+                                       const double pressure,
+                                       const int which,
+                                       const int type,
+                                       const uint32_t state,
+                                       dt_masks_form_t *form,
+                                       const int parentid,
+                                       dt_masks_form_gui_t *gui,
+                                       const int index)
 {
-  if(type == GDK_2BUTTON_PRESS || type == GDK_3BUTTON_PRESS) return 1;
+  if(type == GDK_2BUTTON_PRESS
+     || type == GDK_3BUTTON_PRESS)
+    return 1;
+
   if(!gui) return 0;
-  dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+
+  dt_masks_form_gui_points_t *gpt =
+    (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return 0;
 
-  float masks_border = MIN(dt_conf_get_float(DT_MASKS_CONF(form->type, path, border)), 0.5f);
+  const float masks_border =
+    MIN(dt_conf_get_float(DT_MASKS_CONF(form->type, path, border)), 0.5f);
 
-  if(gui->creation && which == 1 && form->points == NULL
+  if(gui->creation
+     && which == 1
+     && form->points == NULL
      && (dt_modifier_is(state, GDK_CONTROL_MASK | GDK_SHIFT_MASK)
          || dt_modifier_is(state, GDK_SHIFT_MASK)))
   {
     // set some absolute or relative position for the source of the clone mask
-    if(form->type & DT_MASKS_CLONE) dt_masks_set_source_pos_initial_state(gui, state, pzx, pzy);
+    if(form->type & DT_MASKS_CLONE)
+      dt_masks_set_source_pos_initial_state(gui, state, pzx, pzy);
 
     return 1;
   }
-  else if(gui->creation && (which == 3 || gui->creation_closing_form))
+  else if(gui->creation
+          && (which == 3 || gui->creation_closing_form))
   {
     // we don't want a form with less than 3 points
     if(g_list_shorter_than(form->points, 4))
     {
-      // we don't really have a way to know if the user wants to cancel the continuous add here
-      // or just cancelling this mask, let's assume that this is not a mistake and cancel
-      // the continuous add
+      // we don't really have a way to know if the user wants to
+      // cancel the continuous add here or just cancelling this mask,
+      // let's assume that this is not a mistake and cancel the
+      // continuous add
       gui->creation_continuous = FALSE;
       gui->creation_continuous_module = NULL;
       dt_masks_set_edit_mode(module, DT_MASKS_EDIT_FULL);
@@ -1101,12 +1308,14 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
     else
     {
       // we delete last point (the one we are currently dragging)
-      dt_masks_point_path_t *point = (dt_masks_point_path_t *)g_list_last(form->points)->data;
+      dt_masks_point_path_t *point =
+        (dt_masks_point_path_t *)g_list_last(form->points)->data;
       form->points = g_list_remove(form->points, point);
       free(point);
       point = NULL;
 
       gui->point_dragging = -1;
+
       _path_init_ctrl_points(form);
 
       // we save the form and quit creation mode
@@ -1133,7 +1342,8 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
       if(gui->creation_continuous)
       {
         //spot and retouch manage creation_continuous in their own way
-        if(strcmp(crea_module->so->op, "spots") != 0 && strcmp(crea_module->so->op, "retouch") != 0)
+        if(strcmp(crea_module->so->op, "spots") != 0
+           && strcmp(crea_module->so->op, "retouch") != 0)
         {
           dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)crea_module->blend_data;
           for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)
@@ -1175,7 +1385,8 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
         if(!gui2) return 1;
         gui2->group_selected = pos2;
 
-        dt_masks_select_form(crea_module, dt_masks_get_from_id(darktable.develop, form->formid));
+        dt_masks_select_form(crea_module,
+                             dt_masks_get_from_id(darktable.develop, form->formid));
       }
 
       dt_control_queue_redraw_center();
@@ -1185,7 +1396,8 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
   {
     if(gui->creation)
     {
-      dt_masks_point_path_t *bzpt = (dt_masks_point_path_t *)(malloc(sizeof(dt_masks_point_path_t)));
+      dt_masks_point_path_t *bzpt =
+        (dt_masks_point_path_t *)(malloc(sizeof(dt_masks_point_path_t)));
       int nb = g_list_length(form->points);
       // change the values
       const float wd = darktable.develop->preview_pipe->backbuf_width;
@@ -1203,7 +1415,8 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
       // if that's the first point we should had another one as base point
       if(nb == 0)
       {
-        dt_masks_point_path_t *bzpt2 = (dt_masks_point_path_t *)(malloc(sizeof(dt_masks_point_path_t)));
+        dt_masks_point_path_t *bzpt2 =
+          (dt_masks_point_path_t *)(malloc(sizeof(dt_masks_point_path_t)));
         bzpt2->corner[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
         bzpt2->corner[1] = pts[1] / darktable.develop->preview_pipe->iheight;
         bzpt2->ctrl1[0] = bzpt2->ctrl1[1] = bzpt2->ctrl2[0] = bzpt2->ctrl2[1] = -1.0;
@@ -1264,7 +1477,8 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
     else if(gui->point_selected >= 0)
     {
       // if ctrl is pressed, we change the type of point
-      if(gui->point_edited == gui->point_selected && dt_modifier_is(state, GDK_CONTROL_MASK))
+      if(gui->point_edited == gui->point_selected
+         && dt_modifier_is(state, GDK_CONTROL_MASK))
       {
         dt_masks_point_path_t *point
             = (dt_masks_point_path_t *)g_list_nth_data(form->points, gui->point_edited);
@@ -1323,7 +1537,8 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
       if(dt_modifier_is(state, GDK_CONTROL_MASK))
       {
         // we add a new point to the path
-        dt_masks_point_path_t *bzpt = (dt_masks_point_path_t *)(malloc(sizeof(dt_masks_point_path_t)));
+        dt_masks_point_path_t *bzpt =
+          (dt_masks_point_path_t *)(malloc(sizeof(dt_masks_point_path_t)));
         // change the values
         const float wd = darktable.develop->preview_pipe->backbuf_width;
         const float ht = darktable.develop->preview_pipe->backbuf_height;
@@ -1337,7 +1552,8 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
 
         // interpolate the border width of the two neighbour points'
         const GList* first = g_list_nth(form->points, gui->seg_selected);
-        const GList* second = g_list_next_wraparound(first, form->points); // next, wrapping around if on last element
+        // next, wrapping around if on last element
+        const GList* second = g_list_next_wraparound(first, form->points);
         dt_masks_point_path_t *left = (dt_masks_point_path_t *)first->data;
         dt_masks_point_path_t *right = (dt_masks_point_path_t *)second->data;
         bzpt->border[0] = MAX(0.0005f, (left->border[0] + right->border[0]) * 0.5);
@@ -1346,7 +1562,8 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
         form->points = g_list_insert(form->points, bzpt, gui->seg_selected + 1);
         _path_init_ctrl_points(form);
         dt_masks_gui_form_create(form, gui, index, module);
-        gui->point_edited = gui->point_dragging = gui->point_selected = gui->seg_selected + 1;
+        gui->point_edited = gui->point_dragging =
+          gui->point_selected = gui->seg_selected + 1;
         gui->seg_selected = -1;
         dt_control_queue_redraw_center();
       }
@@ -1378,7 +1595,9 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
       {
         const int emode = gui->edit_mode;
         dt_masks_clear_form_gui(darktable.develop);
-        for(GList *forms = darktable.develop->form_visible->points; forms; forms = g_list_next(forms))
+        for(GList *forms = darktable.develop->form_visible->points;
+            forms;
+            forms = g_list_next(forms))
         {
           dt_masks_point_group_t *guipt = (dt_masks_point_group_t *)forms->data;
           if(guipt->formid == form->formid)
@@ -1406,7 +1625,6 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
     }
     form->points = g_list_remove(form->points, point);
     free(point);
-    // form->points = g_list_delete_link(form->points, g_list_nth(form->points, gui->point_selected));
     gui->point_selected = -1;
     _path_init_ctrl_points(form);
 
@@ -1424,7 +1642,8 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
   {
     dt_masks_point_path_t *point
         = (dt_masks_point_path_t *)g_list_nth_data(form->points, gui->feather_selected);
-    if(point != NULL && point->state != DT_MASKS_POINT_STATE_NORMAL)
+    if(point != NULL
+       && point->state != DT_MASKS_POINT_STATE_NORMAL)
     {
       point->state = DT_MASKS_POINT_STATE_NORMAL;
       _path_init_ctrl_points(form);
@@ -1439,7 +1658,9 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
     }
     return 1;
   }
-  else if(which == 3 && parentid > 0 && gui->edit_mode == DT_MASKS_EDIT_FULL)
+  else if(which == 3
+          && parentid > 0
+          && gui->edit_mode == DT_MASKS_EDIT_FULL)
   {
     // we hide the form
     if(!(darktable.develop->form_visible->type & DT_MASKS_GROUP))
@@ -1449,7 +1670,9 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
     else
     {
       dt_masks_clear_form_gui(darktable.develop);
-      for(GList *forms = darktable.develop->form_visible->points; forms; forms = g_list_next(forms))
+      for(GList *forms = darktable.develop->form_visible->points;
+          forms;
+          forms = g_list_next(forms))
       {
         dt_masks_point_group_t *guipt = (dt_masks_point_group_t *)forms->data;
         if(guipt->formid == form->formid)
@@ -1472,13 +1695,21 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module, float pzx
   return 0;
 }
 
-static int _path_events_button_released(struct dt_iop_module_t *module, float pzx, float pzy, int which,
-                                        uint32_t state, dt_masks_form_t *form, int parentid,
-                                        dt_masks_form_gui_t *gui, int index)
+static int _path_events_button_released(struct dt_iop_module_t *module,
+                                        const float pzx,
+                                        const float pzy,
+                                        const int which,
+                                        const uint32_t state,
+                                        dt_masks_form_t *form,
+                                        const int parentid,
+                                        dt_masks_form_gui_t *gui,
+                                        const int index)
 {
   if(!gui) return 0;
   if(gui->creation) return 1;
-  dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+
+  dt_masks_form_gui_points_t *gpt =
+    (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return 0;
   if(gui->form_dragging)
   {
@@ -1631,17 +1862,26 @@ static int _path_events_button_released(struct dt_iop_module_t *module, float pz
   return 0;
 }
 
-static int _path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, float pzy, double pressure,
-                                    int which, dt_masks_form_t *form, int parentid,
-                                    dt_masks_form_gui_t *gui, int index)
+static int _path_events_mouse_moved(struct dt_iop_module_t *module,
+                                    float pzx,
+                                    float pzy,
+                                    const double pressure,
+                                    const int which,
+                                    dt_masks_form_t *form,
+                                    const int parentid,
+                                    dt_masks_form_gui_t *gui,
+                                    const int index)
 {
   const dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
   const int closeup = dt_control_get_dev_closeup();
   const float zoom_scale = dt_dev_get_zoom_scale(darktable.develop, zoom, 1<<closeup, 1);
-  // centre view will have zoom_scale * backbuf_width pixels, we want the handle offset to scale with DPI:
-  const float as = DT_PIXEL_APPLY_DPI(5) / zoom_scale;  // transformed to backbuf dimensions
+  // centre view will have zoom_scale * backbuf_width pixels, we want
+  // the handle offset to scale with DPI:
+  // transformed to backbuf dimensions
+  const float as = DT_PIXEL_APPLY_DPI(5) / zoom_scale;
   if(!gui) return 0;
-  dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+  dt_masks_form_gui_points_t *gpt =
+    (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return 0;
 
   const float wd = darktable.develop->preview_pipe->backbuf_width;
@@ -1653,8 +1893,10 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, f
     if(gui->creation && !g_list_shorter_than(form->points, 4))
     {
       // if we are near the first point, we have to say that the form should be closed
-      if(pts[0] - gpt->points[2] < as && pts[0] - gpt->points[2] > -as
-         && pts[1] - gpt->points[3] < as && pts[1] - gpt->points[3] > -as)
+      if(pts[0] - gpt->points[2] < as
+         && pts[0] - gpt->points[2] > -as
+         && pts[1] - gpt->points[3] < as
+         && pts[1] - gpt->points[3] > -as)
       {
         gui->creation_closing_form = TRUE;
       }
@@ -1665,7 +1907,8 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, f
     }
 
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
-    dt_masks_point_path_t *bzpt = (dt_masks_point_path_t *)g_list_nth_data(form->points, gui->point_dragging);
+    dt_masks_point_path_t *bzpt =
+      (dt_masks_point_path_t *)g_list_nth_data(form->points, gui->point_dragging);
     pzx = pts[0] / darktable.develop->preview_pipe->iwidth;
     pzy = pts[1] / darktable.develop->preview_pipe->iheight;
 
@@ -1775,11 +2018,13 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, f
 
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
-    dt_masks_point_path_t *point = (dt_masks_point_path_t *)g_list_nth_data(form->points, k);
+    dt_masks_point_path_t *point =
+      (dt_masks_point_path_t *)g_list_nth_data(form->points, k);
     const float nx = point->corner[0] * darktable.develop->preview_pipe->iwidth;
     const float ny = point->corner[1] * darktable.develop->preview_pipe->iheight;
     const float nr = sqrtf((pts[0] - nx) * (pts[0] - nx) + (pts[1] - ny) * (pts[1] - ny));
-    const float bdr = nr / fminf(darktable.develop->preview_pipe->iwidth, darktable.develop->preview_pipe->iheight);
+    const float bdr = nr / fminf(darktable.develop->preview_pipe->iwidth,
+                                 darktable.develop->preview_pipe->iheight);
 
     point->border[0] = point->border[1] = bdr;
 
@@ -1843,9 +2088,15 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, f
        && gpt->points[k * 6 + 3] != gpt->points[k * 6 + 5])
     {
       float ffx, ffy;
-      _path_ctrl2_to_feather(gpt->points[k * 6 + 2], gpt->points[k * 6 + 3], gpt->points[k * 6 + 4],
-                             gpt->points[k * 6 + 5], &ffx, &ffy, gpt->clockwise);
-      if(pzx - ffx > -as && pzx - ffx < as && pzy - ffy > -as && pzy - ffy < as)
+      _path_ctrl2_to_feather(gpt->points[k * 6 + 2],
+                             gpt->points[k * 6 + 3],
+                             gpt->points[k * 6 + 4],
+                             gpt->points[k * 6 + 5],
+                             &ffx, &ffy, gpt->clockwise);
+      if(pzx - ffx > -as
+         && pzx - ffx < as
+         && pzy - ffy > -as
+         && pzy - ffy < as)
       {
         gui->feather_selected = k;
         dt_control_queue_redraw_center();
@@ -1853,8 +2104,10 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, f
       }
     }
     // corner ??
-    if(pzx - gpt->points[k * 6 + 2] > -as && pzx - gpt->points[k * 6 + 2] < as
-       && pzy - gpt->points[k * 6 + 3] > -as && pzy - gpt->points[k * 6 + 3] < as)
+    if(pzx - gpt->points[k * 6 + 2] > -as
+       && pzx - gpt->points[k * 6 + 2] < as
+       && pzy - gpt->points[k * 6 + 3] > -as
+       && pzy - gpt->points[k * 6 + 3] < as)
     {
       gui->point_selected = k;
       dt_control_queue_redraw_center();
@@ -1865,8 +2118,10 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, f
   for(int k = 0; k < nb; k++)
   {
     // corner ??
-    if(pzx - gpt->points[k * 6 + 2] > -as && pzx - gpt->points[k * 6 + 2] < as
-       && pzy - gpt->points[k * 6 + 3] > -as && pzy - gpt->points[k * 6 + 3] < as)
+    if(pzx - gpt->points[k * 6 + 2] > -as
+       && pzx - gpt->points[k * 6 + 2] < as
+       && pzy - gpt->points[k * 6 + 3] > -as
+       && pzy - gpt->points[k * 6 + 3] < as)
     {
       gui->point_selected = k;
       dt_control_queue_redraw_center();
@@ -1874,8 +2129,10 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, f
     }
 
     // border corner ??
-    if(pzx - gpt->border[k * 6] > -as && pzx - gpt->border[k * 6] < as
-       && pzy - gpt->border[k * 6 + 1] > -as && pzy - gpt->border[k * 6 + 1] < as)
+    if(pzx - gpt->border[k * 6] > -as
+       && pzx - gpt->border[k * 6] < as
+       && pzy - gpt->border[k * 6 + 1] > -as
+       && pzy - gpt->border[k * 6 + 1] < as)
     {
       gui->point_border_selected = k;
       dt_control_queue_redraw_center();
@@ -1906,19 +2163,26 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module, float pzx, f
     }
   }
   dt_control_queue_redraw_center();
-  if(!gui->form_selected && !gui->border_selected && gui->seg_selected < 0) return 0;
-  if(gui->edit_mode != DT_MASKS_EDIT_FULL) return 0;
+  if(!gui->form_selected && !gui->border_selected && gui->seg_selected < 0)
+    return 0;
+  if(gui->edit_mode != DT_MASKS_EDIT_FULL)
+    return 0;
   return 1;
 }
 
-static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_form_gui_t *gui, int index, int nb)
+static void _path_events_post_expose(cairo_t *cr,
+                                     const float zoom_scale,
+                                     dt_masks_form_gui_t *gui,
+                                     const int index,
+                                     const int nb)
 {
   double dashed[] = { 4.0, 4.0 };
   dashed[0] /= zoom_scale;
   dashed[1] /= zoom_scale;
   const int len = sizeof(dashed) / sizeof(dashed[0]);
   if(!gui) return;
-  dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+  dt_masks_form_gui_points_t *gpt =
+    (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return;
 
   // draw path
@@ -1962,8 +2226,11 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
   if(gui->group_selected == index && gpt->points_count > nb * 3 + 6)
   {
     for(int k = 0; k < nb; k++)
-      dt_masks_draw_anchor(cr, k == gui->point_dragging || k == gui->point_selected, zoom_scale,
-                           gpt->points[k * 6 + 2], gpt->points[k * 6 + 3]);
+      dt_masks_draw_anchor(cr,
+                           k == gui->point_dragging
+                           || k == gui->point_selected, zoom_scale,
+                           gpt->points[k * 6 + 2],
+                           gpt->points[k * 6 + 3]);
   }
 
   // draw feathers
@@ -1978,8 +2245,11 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
     cairo_line_to(cr, gui->points[k*6+4],gui->points[k*6+5]);
     cairo_stroke(cr);*/
     float ffx = 0.0f, ffy = 0.0f;
-    _path_ctrl2_to_feather(gpt->points[k * 6 + 2], gpt->points[k * 6 + 3], gpt->points[k * 6 + 4],
-                           gpt->points[k * 6 + 5], &ffx, &ffy, gpt->clockwise);
+    _path_ctrl2_to_feather(gpt->points[k * 6 + 2],
+                           gpt->points[k * 6 + 3],
+                           gpt->points[k * 6 + 4],
+                           gpt->points[k * 6 + 5],
+                           &ffx, &ffy, gpt->clockwise);
     cairo_move_to(cr, gpt->points[k * 6 + 2], gpt->points[k * 6 + 3]);
     cairo_line_to(cr, ffx, ffy);
     cairo_set_line_width(cr, 1.5 / zoom_scale);
@@ -2002,7 +2272,9 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
   }
 
   // draw border and corners
-  if((gui->show_all_feathers || gui->group_selected == index) && gpt->border_count > nb * 3 + 6)
+  if((gui->show_all_feathers
+      || gui->group_selected == index)
+     && gpt->border_count > nb * 3 + 6)
   {
     int dep = 1;
     for(int i = nb * 3; i < gpt->border_count; i++)
@@ -2039,7 +2311,11 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
 
     // we draw the path segment by segment
     for(int k = 0; k < nb; k++)
-      dt_masks_draw_anchor(cr, gui->point_border_selected == k, zoom_scale, gpt->border[k * 6], gpt->border[k * 6 + 1]);
+      dt_masks_draw_anchor(cr,
+                           gui->point_border_selected == k,
+                           zoom_scale,
+                           gpt->border[k * 6],
+                           gpt->border[k * 6 + 1]);
   }
 
   // draw a cross where the source will be created
@@ -2051,8 +2327,10 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
     if((k * 6 + 2) >= 0)
     {
       float x = 0.f, y = 0.f;
-      dt_masks_calculate_source_pos_value(gui, DT_MASKS_PATH, gpt->points[2], gpt->points[3],
-                                          gpt->points[k * 6 + 2], gpt->points[k * 6 + 3], &x, &y, TRUE);
+      dt_masks_calculate_source_pos_value(gui, DT_MASKS_PATH,
+                                          gpt->points[2], gpt->points[3],
+                                          gpt->points[k * 6 + 2], gpt->points[k * 6 + 3],
+                                          &x, &y, TRUE);
       dt_masks_draw_clone_source_pos(cr, zoom_scale, x, y);
     }
     else
@@ -2060,8 +2338,10 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
       float xpos, ypos;
       if((gui->posx == -1.f && gui->posy == -1.f) || gui->mouse_leaved_center)
       {
-        xpos = (.5f + dt_control_get_dev_zoom_x()) * darktable.develop->preview_pipe->backbuf_width;
-        ypos = (.5f + dt_control_get_dev_zoom_y()) * darktable.develop->preview_pipe->backbuf_height;
+        xpos = (.5f + dt_control_get_dev_zoom_x())
+          * darktable.develop->preview_pipe->backbuf_width;
+        ypos = (.5f + dt_control_get_dev_zoom_y())
+          * darktable.develop->preview_pipe->backbuf_height;
       }
       else
       {
@@ -2070,7 +2350,8 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
       }
 
       float x = 0.0f, y = 0.0f;
-      dt_masks_calculate_source_pos_value(gui, DT_MASKS_PATH, xpos, ypos, xpos, ypos, &x, &y, FALSE);
+      dt_masks_calculate_source_pos_value(gui, DT_MASKS_PATH, xpos, ypos, xpos, ypos,
+                                          &x, &y, FALSE);
       dt_masks_draw_clone_source_pos(cr, zoom_scale, x, y);
     }
   }
@@ -2082,32 +2363,43 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
     cairo_move_to(cr, gpt->source[2], gpt->source[3]);
     cairo_line_to(cr, gpt->points[2], gpt->points[3]);
     cairo_set_dash(cr, dashed, 0, 0);
-    if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
+    if((gui->group_selected == index)
+       && (gui->form_selected || gui->form_dragging))
       cairo_set_line_width(cr, 2.5 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.5 / zoom_scale);
+
     dt_draw_set_color_overlay(cr, FALSE, 0.8);
     cairo_stroke_preserve(cr);
-    if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
+
+    if((gui->group_selected == index)
+       && (gui->form_selected || gui->form_dragging))
       cairo_set_line_width(cr, 1.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 0.5 / zoom_scale);
+
     dt_draw_set_color_overlay(cr, TRUE, 0.8);
     cairo_stroke(cr);
 
     // we draw the source
     cairo_set_dash(cr, dashed, 0, 0);
-    if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
+    if((gui->group_selected == index)
+       && (gui->form_selected || gui->form_dragging))
       cairo_set_line_width(cr, 2.5 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.5 / zoom_scale);
+
     dt_draw_set_color_overlay(cr, FALSE, 0.8);
     cairo_move_to(cr, gpt->source[nb * 6], gpt->source[nb * 6 + 1]);
+
     for(int i = nb * 3; i < gpt->source_count; i++)
       cairo_line_to(cr, gpt->source[i * 2], gpt->source[i * 2 + 1]);
+
     cairo_line_to(cr, gpt->source[nb * 6], gpt->source[nb * 6 + 1]);
     cairo_stroke_preserve(cr);
-    if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
+
+    if((gui->group_selected == index)
+       && (gui->form_selected || gui->form_dragging))
       cairo_set_line_width(cr, 1.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 0.5 / zoom_scale);
@@ -2116,12 +2408,20 @@ static void _path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_for
   }
 }
 
-static void _path_bounding_box_raw(const float *const points, const float *border, const int nb_corner, const int num_points, int num_borders,
-                                   float *x_min, float *x_max, float *y_min, float *y_max)
+static void _path_bounding_box_raw(const float *const points,
+                                   const float *border,
+                                   const int nb_corner,
+                                   const int num_points,
+                                   const int num_borders,
+                                   float *x_min,
+                                   float *x_max,
+                                   float *y_min,
+                                   float *y_max)
 {
   float xmin, xmax, ymin, ymax;
   xmin = ymin = FLT_MAX;
   xmax = ymax = FLT_MIN;
+
   for(int i = nb_corner * 3; i < num_borders; i++)
   {
     // we look at the borders
@@ -2155,20 +2455,34 @@ static void _path_bounding_box_raw(const float *const points, const float *borde
   *y_max = ymax;
 }
 
-static void _path_bounding_box(const float *const points, const float *border, const int nb_corner, const int num_points, int num_borders,
-                               int *width, int *height, int *posx, int *posy)
+static void _path_bounding_box(const float *const points,
+                               const float *border,
+                               const int nb_corner,
+                               const int num_points,
+                               const int num_borders,
+                               int *width,
+                               int *height,
+                               int *posx,
+                               int *posy)
 {
   // now we want to find the area, so we search min/max points
   float xmin, xmax, ymin, ymax;
-  _path_bounding_box_raw(points, border, nb_corner, num_points, num_borders, &xmin, &xmax, &ymin, &ymax);
+  _path_bounding_box_raw(points, border, nb_corner, num_points,
+                         num_borders, &xmin, &xmax, &ymin, &ymax);
   *height = ymax - ymin + 4;
   *width = xmax - xmin + 4;
   *posx = xmin - 2;
   *posy = ymin - 2;
 }
 
-static int _get_area(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
-                     dt_masks_form_t *const form, int *width, int *height, int *posx, int *posy, gboolean get_source)
+static int _get_area(const dt_iop_module_t *const module,
+                     const dt_dev_pixelpipe_iop_t *const piece,
+                     dt_masks_form_t *const form,
+                     int *width,
+                     int *height,
+                     int *posx,
+                     int *posy,
+                     const gboolean get_source)
 {
   if(!module) return 0;
 
@@ -2176,7 +2490,9 @@ static int _get_area(const dt_iop_module_t *const module, const dt_dev_pixelpipe
   float *points = NULL, *border = NULL;
   int points_count = 0, border_count = 0;
 
-  if(!_path_get_pts_border(module->dev, form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, piece->pipe, &points, &points_count,
+  if(!_path_get_pts_border(module->dev, form, module->iop_order,
+                           DT_DEV_TRANSFORM_DIR_BACK_INCL, piece->pipe,
+                           &points, &points_count,
                            &border, &border_count, get_source))
   {
     dt_free_align(points);
@@ -2185,28 +2501,43 @@ static int _get_area(const dt_iop_module_t *const module, const dt_dev_pixelpipe
   }
 
   const guint nb_corner = g_list_length(form->points);
-  _path_bounding_box(points, border, nb_corner, points_count, border_count, width, height, posx, posy);
+  _path_bounding_box(points, border, nb_corner, points_count, border_count,
+                     width, height, posx, posy);
 
   dt_free_align(points);
   dt_free_align(border);
   return 1;
 }
 
-static int _path_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece,
-                                 dt_masks_form_t *form, int *width, int *height, int *posx, int *posy)
+static int _path_get_source_area(dt_iop_module_t *module,
+                                 dt_dev_pixelpipe_iop_t *piece,
+                                 dt_masks_form_t *form,
+                                 int *width,
+                                 int *height,
+                                 int *posx,
+                                 int *posy)
 {
   return _get_area(module, piece, form, width, height, posx, posy, TRUE);
 }
 
-static int _path_get_area(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
+static int _path_get_area(const dt_iop_module_t *const module,
+                          const dt_dev_pixelpipe_iop_t *const piece,
                           dt_masks_form_t *const form,
-                          int *width, int *height, int *posx, int *posy)
+                          int *width,
+                          int *height,
+                          int *posx,
+                          int *posy)
 {
   return _get_area(module, piece, form, width, height, posx, posy, FALSE);
 }
 
 /** we write a falloff segment */
-/*static*/ void _path_falloff(float *const restrict buffer, int *p0, int *p1, int posx, int posy, int bw)
+static void _path_falloff(float *const restrict buffer,
+                          int *p0,
+                          int *p1,
+                          const int posx,
+                          const int posy,
+                          const int bw)
 {
   // segment length
   int l = sqrtf(sqf(p1[0] - p0[0]) + sqf(p1[1] - p0[1])) + 1;
@@ -2222,16 +2553,23 @@ static int _path_get_area(const dt_iop_module_t *const module, const dt_dev_pixe
     const float op = 1.0 - (float)i / (float)l;
     size_t idx = y * bw + x;
     buffer[idx] = fmaxf(buffer[idx], op);
+    // this one is to avoid gap due to int rounding
     if(x > 0)
-      buffer[idx - 1] = fmaxf(buffer[idx - 1], op); // this one is to avoid gap due to int rounding
+      buffer[idx - 1] = fmaxf(buffer[idx - 1], op);
+    // this one is to avoid gap due to int rounding
     if(y > 0)
-      buffer[idx - bw] = fmaxf(buffer[idx - bw], op); // this one is to avoid gap due to int rounding
+      buffer[idx - bw] = fmaxf(buffer[idx - bw], op);
   }
 }
 
-static int _path_get_mask(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
+static int _path_get_mask(const dt_iop_module_t *const module,
+                          const dt_dev_pixelpipe_iop_t *const piece,
                           dt_masks_form_t *const form,
-                          float **buffer, int *width, int *height, int *posx, int *posy)
+                          float **buffer,
+                          int *width,
+                          int *height,
+                          int *posx,
+                          int *posy)
 {
   if(!module) return 0;
   double start = 0.0;
@@ -2243,7 +2581,8 @@ static int _path_get_mask(const dt_iop_module_t *const module, const dt_dev_pixe
   float *points = NULL, *border = NULL;
   int points_count, border_count;
   if(!_path_get_pts_border(module->dev, form, module->iop_order,
-                           DT_DEV_TRANSFORM_DIR_BACK_INCL, piece->pipe, &points, &points_count,
+                           DT_DEV_TRANSFORM_DIR_BACK_INCL, piece->pipe,
+                           &points, &points_count,
                            &border, &border_count, FALSE))
   {
     dt_free_align(points);
@@ -2253,27 +2592,32 @@ static int _path_get_mask(const dt_iop_module_t *const module, const dt_dev_pixe
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] path points took %0.04f sec\n", form->name, dt_get_wtime() - start);
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] path points took %0.04f sec\n",
+             form->name, dt_get_wtime() - start);
     start = start2 = dt_get_wtime();
   }
 
   // now we want to find the area, so we search min/max points
   const guint nb_corner = g_list_length(form->points);
-  _path_bounding_box(points, border, nb_corner, points_count, border_count, width, height, posx, posy);
+  _path_bounding_box(points, border, nb_corner, points_count, border_count,
+                     width, height, posx, posy);
 
   const int hb = *height;
   const int wb = *width;
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] path_fill min max took %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] path_fill min max took %0.04f sec\n", form->name,
              dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
 
   // we allocate the buffer
   const size_t bufsize = (size_t)(*width) * (*height);
-  // ensure that the buffer is zeroed, as the following code only actually sets the path+falloff pixels
+  // ensure that the buffer is zeroed, as the following code only
+  // actually sets the path+falloff pixels
   float *const restrict bufptr = *buffer = dt_calloc_align_float(bufsize);
   if(*buffer == NULL)
   {
@@ -2342,8 +2686,9 @@ static int _path_get_mask(const dt_iop_module_t *const module, const dt_dev_pixe
       // we add the point
       if(just_change_dir && ii == i)
       {
-        // if we have changed the direction, we have to be careful that point can be at the same place
-        // as the previous one, especially on sharp edges
+        // if we have changed the direction, we have to be careful
+        // that point can be at the same place as the previous one,
+        // especially on sharp edges
         const size_t idx = (size_t)(yy - (*posy)) * (*width) + xx - (*posx);
         assert(idx < bufsize);
         float v = bufptr[idx];
@@ -2385,7 +2730,8 @@ static int _path_get_mask(const dt_iop_module_t *const module, const dt_dev_pixe
   }
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] path_fill draw path took %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] path_fill draw path took %0.04f sec\n", form->name,
              dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
@@ -2408,7 +2754,8 @@ static int _path_get_mask(const dt_iop_module_t *const module, const dt_dev_pixe
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] path_fill fill plain took %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] path_fill fill plain took %0.04f sec\n", form->name,
              dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
@@ -2440,7 +2787,10 @@ static int _path_get_mask(const dt_iop_module_t *const module, const dt_dev_pixe
     }
 
     // and we draw the falloff
-    if(last0[0] != p0[0] || last0[1] != p0[1] || last1[0] != p1[0] || last1[1] != p1[1])
+    if(last0[0] != p0[0]
+       || last0[1] != p0[1]
+       || last1[0] != p1[0]
+       || last1[1] != p1[1])
     {
       _path_falloff(bufptr, p0, p1, *posx, *posy, *width);
       last0[0] = p0[0];
@@ -2451,24 +2801,30 @@ static int _path_get_mask(const dt_iop_module_t *const module, const dt_dev_pixe
   }
 
   if(darktable.unmuted & DT_DEBUG_PERF)
-    dt_print(DT_DEBUG_MASKS, "[masks %s] path_fill fill falloff took %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] path_fill fill falloff took %0.04f sec\n", form->name,
              dt_get_wtime() - start2);
 
   dt_free_align(points);
   dt_free_align(border);
 
   if(darktable.unmuted & DT_DEBUG_PERF)
-    dt_print(DT_DEBUG_MASKS, "[masks %s] path fill buffer took %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] path fill buffer took %0.04f sec\n", form->name,
              dt_get_wtime() - start);
 
   return 1;
 }
 
 
-/** crop path to roi given by xmin, xmax, ymin, ymax. path segments outside of roi are replaced by
-    nodes lying on roi borders. */
-static int _path_crop_to_roi(float *path, const int point_count, float xmin, float xmax, float ymin,
-                             float ymax)
+/** crop path to roi given by xmin, xmax, ymin, ymax. path segments
+    outside of roi are replaced by nodes lying on roi borders. */
+static int _path_crop_to_roi(float *path,
+                             const int point_count,
+                             const float xmin,
+                             const float xmax,
+                             const float ymin,
+                             const float ymax)
 {
   int point_start = -1;
   int l = -1, r = -1;
@@ -2477,23 +2833,24 @@ static int _path_crop_to_roi(float *path, const int point_count, float xmin, flo
   // first try to find a node clearly inside roi
   for(int k = 0; k < point_count; k++)
   {
-    float x = path[2 * k];
-    float y = path[2 * k + 1];
+    const float x = path[2 * k];
+    const float y = path[2 * k + 1];
 
-    if(x >= xmin + 1 && y >= ymin + 1
-       && x <= xmax - 1 && y <= ymax - 1)
+    if(x >= xmin + 1
+       && y >= ymin + 1
+       && x <= xmax - 1
+       && y <= ymax - 1)
     {
       point_start = k;
       break;
     }
   }
 
-  // printf("crop to xmin %f, xmax %f, ymin %f, ymax %f - start %d (%f, %f)\n", xmin, xmax, ymin, ymax,
-  // point_start, path[2*point_start], path[2*point_start+1]);
+  if(point_start < 0)
+    return 0; // no point means roi lies completely within path
 
-  if(point_start < 0) return 0; // no point means roi lies completely within path
-
-  // find the crossing points with xmin and replace segment by nodes on border
+  // find the crossing points with xmin and replace segment by nodes
+  // on border
   for(int k = 0; k < point_count; k++)
   {
     const int kk = (k + point_start) % point_count;
@@ -2507,7 +2864,10 @@ static int _path_crop_to_roi(float *path, const int point_count, float xmin, flo
       const int count = r - l + 1;
       const int ll = (l - 1 + point_start) % point_count;
       const int rr = (r + 1 + point_start) % point_count;
-      const float delta_y = (count == 1) ? 0 : (path[2 * rr + 1] - path[2 * ll + 1]) / (count - 1);
+      const float delta_y = (count == 1)
+        ? 0
+        : (path[2 * rr + 1] - path[2 * ll + 1]) / (count - 1);
+
       const float start_y = path[2 * ll + 1];
 
       for(int n = 0; n < count; n++)
@@ -2535,7 +2895,10 @@ static int _path_crop_to_roi(float *path, const int point_count, float xmin, flo
       const int count = r - l + 1;
       const int ll = (l - 1 + point_start) % point_count;
       const int rr = (r + 1 + point_start) % point_count;
-      const float delta_y = (count == 1) ? 0 : (path[2 * rr + 1] - path[2 * ll + 1]) / (count - 1);
+      const float delta_y = (count == 1)
+        ? 0
+        : (path[2 * rr + 1] - path[2 * ll + 1]) / (count - 1);
+
       const float start_y = path[2 * ll + 1];
 
       for(int n = 0; n < count; n++)
@@ -2563,7 +2926,10 @@ static int _path_crop_to_roi(float *path, const int point_count, float xmin, flo
       const int count = r - l + 1;
       const int ll = (l - 1 + point_start) % point_count;
       const int rr = (r + 1 + point_start) % point_count;
-      const float delta_x = (count == 1) ? 0 : (path[2 * rr] - path[2 * ll]) / (count - 1);
+      const float delta_x = (count == 1)
+        ? 0
+        : (path[2 * rr] - path[2 * ll]) / (count - 1);
+
       const float start_x = path[2 * ll];
 
       for(int n = 0; n < count; n++)
@@ -2591,7 +2957,10 @@ static int _path_crop_to_roi(float *path, const int point_count, float xmin, flo
       const int count = r - l + 1;
       const int ll = (l - 1 + point_start) % point_count;
       const int rr = (r + 1 + point_start) % point_count;
-      const float delta_x = (count == 1) ? 0 : (path[2 * rr] - path[2 * ll]) / (count - 1);
+      const float delta_x = (count == 1)
+        ? 0
+        : (path[2 * rr] - path[2 * ll]) / (count - 1);
+
       const float start_x = path[2 * ll];
 
       for(int n = 0; n < count; n++)
@@ -2608,10 +2977,15 @@ static int _path_crop_to_roi(float *path, const int point_count, float xmin, flo
 }
 
 /** we write a falloff segment respecting limits of buffer */
-static void _path_falloff_roi(float *buffer, int *p0, int *p1, int bw, int bh)
+static void _path_falloff_roi(float *buffer,
+                              int *p0,
+                              int *p1,
+                              const int bw,
+                              const int bh)
 {
   // segment length
-  const int l = sqrt((p1[0] - p0[0]) * (p1[0] - p0[0]) + (p1[1] - p0[1]) * (p1[1] - p0[1])) + 1;
+  const int l = sqrt((p1[0] - p0[0]) * (p1[0] - p0[0])
+                     + (p1[1] - p0[1]) * (p1[1] - p0[1])) + 1;
 
   const float lx = p1[0] - p0[0];
   const float ly = p1[1] - p0[1];
@@ -2627,6 +3001,7 @@ static void _path_falloff_roi(float *buffer, int *p0, int *p1, int bw, int bh)
     const int y = (int)((float)i * ly / (float)l) + p0[1];
     const float op = 1.0f - (float)i / (float)l;
     float *buf = buffer + (size_t)y * bw + x;
+
     if(x >= 0 && x < bw && y >= 0 && y < bh)
       buf[0] = MAX(buf[0], op);
     if(x + dx >= 0 && x + dx < bw && y >= 0 && y < bh)
@@ -2638,9 +3013,11 @@ static void _path_falloff_roi(float *buffer, int *p0, int *p1, int bw, int bh)
 
 // build a stamp which can be combined with other shapes in the same group
 // prerequisite: 'buffer' is all zeros
-static int _path_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_pixelpipe_iop_t *const piece,
+static int _path_get_mask_roi(const dt_iop_module_t *const module,
+                              const dt_dev_pixelpipe_iop_t *const piece,
                               dt_masks_form_t *const form,
-                              const dt_iop_roi_t *roi, float *buffer)
+                              const dt_iop_roi_t *roi,
+                              float *buffer)
 {
   if(!module) return 0;
   double start = 0.0;
@@ -2665,7 +3042,9 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_
   // we get buffers for all points
   float *points = NULL, *border = NULL;
   int points_count = 0, border_count = 0;
-  if(!_path_get_pts_border(module->dev, form, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, piece->pipe, &points, &points_count,
+  if(!_path_get_pts_border(module->dev, form, module->iop_order,
+                           DT_DEV_TRANSFORM_DIR_BACK_INCL, piece->pipe,
+                           &points, &points_count,
                            &border, &border_count, FALSE) || (points_count <= 2))
   {
     dt_free_align(points);
@@ -2675,7 +3054,9 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] path points took %0.04f sec\n", form->name, dt_get_wtime() - start);
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] path points took %0.04f sec\n",
+             form->name, dt_get_wtime() - start);
     start = start2 = dt_get_wtime();
   }
 
@@ -2716,7 +3097,8 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_
     }
   }
 
-  // if not this still might mean that path fully encircles roi -> we need to check that
+  // if not this still might mean that path fully encircles roi -> we
+  // need to check that
   if(!path_in_roi)
   {
     int nb = 0;
@@ -2733,7 +3115,8 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_
       }
       last = yy;
     }
-    // if there is an uneven number of intersection points roi lies within path
+    // if there is an uneven number of intersection points roi lies
+    // within path
     if(nb & 1)
     {
       path_in_roi = 1;
@@ -2759,7 +3142,8 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_
     }
   }
 
-  // if path and feather completely lie outside of roi -> we're done/mask remains empty
+  // if path and feather completely lie outside of roi -> we're
+  // done/mask remains empty
   if(!path_in_roi && !feather_in_roi)
   {
     dt_free_align(points);
@@ -2769,18 +3153,21 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_
 
   // now get min/max values
   float xmin, xmax, ymin, ymax;
-  _path_bounding_box_raw(points, border, nb_corner, points_count, border_count, &xmin, &xmax, &ymin, &ymax);
+  _path_bounding_box_raw(points, border, nb_corner, points_count, border_count,
+                         &xmin, &xmax, &ymin, &ymax);
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] path_fill min max took %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] path_fill min max took %0.04f sec\n", form->name,
              dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] path_fill clear mask took %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] path_fill clear mask took %0.04f sec\n", form->name,
              dt_get_wtime() - start2);
     start2 = dt_get_wtime();
   }
@@ -2798,17 +3185,23 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_
     }
     memcpy(cpoints, points, sizeof(float) * 2 * points_count);
 
-    // now we clip cpoints to roi -> catch special case when roi lies completely within path.
-    // dirty trick: we allow path to extend one pixel beyond height-1. this avoids need of special handling
-    // of the last roi line in the following edge-flag polygon fill algorithm.
+    // now we clip cpoints to roi -> catch special case when roi lies
+    // completely within path.  dirty trick: we allow path to extend
+    // one pixel beyond height-1. this avoids need of special handling
+    // of the last roi line in the following edge-flag polygon fill
+    // algorithm.
     const int crop_success = _path_crop_to_roi(cpoints + 2 * (nb_corner * 3),
-                                               points_count - nb_corner * 3, 0,
-                                               width - 1, 0, height);
+                                               points_count - nb_corner * 3,
+                                               0,
+                                               width - 1,
+                                               0,
+                                               height);
     path_encircles_roi = path_encircles_roi || !crop_success;
 
     if(darktable.unmuted & DT_DEBUG_PERF)
     {
-      dt_print(DT_DEBUG_MASKS, "[masks %s] path_fill crop to roi took %0.04f sec\n", form->name,
+      dt_print(DT_DEBUG_MASKS,
+               "[masks %s] path_fill crop to roi took %0.04f sec\n", form->name,
                dt_get_wtime() - start2);
       start2 = dt_get_wtime();
     }
@@ -2841,16 +3234,20 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_
           tmp = xstart, xstart = xend, xend = tmp;
         }
 
-        const float m = (xstart - xend) / (ystart - yend); // we don't need special handling of ystart==yend
-                                                           // as following loop will take care
+        // we don't need special handling of ystart==yend
+        // as following loop will take care
+        const float m = (xstart - xend) / (ystart - yend);
 
-        for(int yy = (int)ceilf(ystart); (float)yy < yend;
-            yy++) // this would normally never touch the last roi line => see comment further above
+        for(int yy = (int)ceilf(ystart);
+            (float)yy < yend;
+            yy++) // this would normally never touch the last roi line
+                  // => see comment further above
         {
           const float xcross = xstart + m * (yy - ystart);
 
           int xx = floorf(xcross);
-          if((float)xx + 0.5f <= xcross) xx++;
+          if((float)xx + 0.5f <= xcross)
+            xx++;
 
           if(xx < 0 || xx >= width || yy < 0 || yy >= height)
             continue; // sanity check just to be on the safe side
@@ -2863,7 +3260,8 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_
 
       if(darktable.unmuted & DT_DEBUG_PERF)
       {
-        dt_print(DT_DEBUG_MASKS, "[masks %s] path_fill draw path took %0.04f sec\n", form->name,
+        dt_print(DT_DEBUG_MASKS,
+                 "[masks %s] path_fill draw path took %0.04f sec\n", form->name,
                  dt_get_wtime() - start2);
         start2 = dt_get_wtime();
       }
@@ -2898,7 +3296,8 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_
 
       if(darktable.unmuted & DT_DEBUG_PERF)
       {
-        dt_print(DT_DEBUG_MASKS, "[masks %s] path_fill fill plain took %0.04f sec\n", form->name,
+        dt_print(DT_DEBUG_MASKS,
+                 "[masks %s] path_fill fill plain took %0.04f sec\n", form->name,
                  dt_get_wtime() - start2);
         start2 = dt_get_wtime();
       }
@@ -2951,7 +3350,10 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_
       }
 
       // and we draw the falloff
-      if(last0[0] != p0[0] || last0[1] != p0[1] || last1[0] != p1[0] || last1[1] != p1[1])
+      if(last0[0] != p0[0]
+         || last0[1] != p0[1]
+         || last1[0] != p1[0]
+         || last1[1] != p1[1])
       {
         dpoints[dindex] = p0[0];
         dpoints[dindex + 1] = p0[1];
@@ -2982,7 +3384,8 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_
 
     if(darktable.unmuted & DT_DEBUG_PERF)
     {
-      dt_print(DT_DEBUG_MASKS, "[masks %s] path_fill fill falloff took %0.04f sec\n", form->name,
+      dt_print(DT_DEBUG_MASKS,
+               "[masks %s] path_fill fill falloff took %0.04f sec\n", form->name,
                dt_get_wtime() - start2);
     }
   }
@@ -2991,7 +3394,8 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_
   dt_free_align(border);
 
   if(darktable.unmuted & DT_DEBUG_PERF)
-    dt_print(DT_DEBUG_MASKS, "[masks %s] path fill buffer took %0.04f sec\n", form->name,
+    dt_print(DT_DEBUG_MASKS,
+             "[masks %s] path fill buffer took %0.04f sec\n", form->name,
              dt_get_wtime() - start);
 
   return 1;
@@ -3000,19 +3404,26 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module, const dt_dev_
 static GSList *_path_setup_mouse_actions(const struct dt_masks_form_t *const form)
 {
   GSList *lm = NULL;
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_LEFT, 0, _("[PATH creation] add a smooth node"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_LEFT, 0,
+                                     _("[PATH creation] add a smooth node"));
   lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_LEFT, GDK_CONTROL_MASK,
                                      _("[PATH creation] add a sharp node"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_RIGHT, 0, _("[PATH creation] terminate path creation"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_RIGHT, 0,
+                                     _("[PATH creation] terminate path creation"));
   lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_LEFT, GDK_CONTROL_MASK,
                                      _("[PATH on node] switch between smooth/sharp node"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_RIGHT, 0, _("[PATH on node] remove the node"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_RIGHT, 0, _("[PATH on feather] reset curvature"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_RIGHT, 0,
+                                     _("[PATH on node] remove the node"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_RIGHT, 0,
+                                     _("[PATH on feather] reset curvature"));
   lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_LEFT, GDK_CONTROL_MASK,
                                      _("[PATH on segment] add node"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, 0, _("[PATH] change size"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_SHIFT_MASK, _("[PATH] change feather size"));
-  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, GDK_CONTROL_MASK, _("[PATH] change opacity"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL, 0,
+                                     _("[PATH] change size"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL,
+                                     GDK_SHIFT_MASK, _("[PATH] change feather size"));
+  lm = dt_mouse_action_create_simple(lm, DT_MOUSE_ACTION_SCROLL,
+                                     GDK_CONTROL_MASK, _("[PATH] change opacity"));
   return lm;
 }
 
@@ -3021,13 +3432,17 @@ static void _path_sanitize_config(dt_masks_type_t type)
   // nothing to do (yet?)
 }
 
-static void _path_set_form_name(struct dt_masks_form_t *const form, const size_t nb)
+static void _path_set_form_name(struct dt_masks_form_t *const form,
+                                const size_t nb)
 {
   snprintf(form->name, sizeof(form->name), _("path #%d"), (int)nb);
 }
 
-static void _path_set_hint_message(const dt_masks_form_gui_t *const gui, const dt_masks_form_t *const form,
-                                     const int opacity, char *const restrict msgbuf, const size_t msgbuf_len)
+static void _path_set_hint_message(const dt_masks_form_gui_t *const gui,
+                                   const dt_masks_form_t *const form,
+                                   const int opacity,
+                                   char *const restrict msgbuf,
+                                   const size_t msgbuf_len)
 {
   if(gui->creation && g_list_length(form->points) < 4)
     g_strlcat(msgbuf, _("<b>add node</b>: click, <b>add sharp node</b>:ctrl+click\n"
@@ -3039,33 +3454,50 @@ static void _path_set_hint_message(const dt_masks_form_gui_t *const gui, const d
     g_strlcat(msgbuf, _("<b>move node</b>: drag, <b>remove node</b>: right-click\n"
                         "<b>switch smooth/sharp mode</b>: ctrl+click"), msgbuf_len);
   else if(gui->feather_selected >= 0)
-    g_strlcat(msgbuf, _("<b>node curvature</b>: drag\n<b>reset curvature</b>: right-click"), msgbuf_len);
+    g_strlcat(msgbuf,
+              _("<b>node curvature</b>: drag\n<b>reset curvature</b>: right-click"),
+              msgbuf_len);
   else if(gui->seg_selected >= 0)
-    g_strlcat(msgbuf, _("<b>move segment</b>: drag\n<b>add node</b>: ctrl+click"), msgbuf_len);
+    g_strlcat(msgbuf,
+              _("<b>move segment</b>: drag\n<b>add node</b>: ctrl+click"), msgbuf_len);
   else if(gui->form_selected)
-    g_snprintf(msgbuf, msgbuf_len, _("<b>size</b>: scroll, <b>feather size</b>: shift+scroll\n"
-                                     "<b>opacity</b>: ctrl+scroll (%d%%)"), opacity);
+    g_snprintf(msgbuf, msgbuf_len,
+               _("<b>size</b>: scroll, <b>feather size</b>: shift+scroll\n"
+                 "<b>opacity</b>: ctrl+scroll (%d%%)"), opacity);
 }
 
-static void _path_duplicate_points(dt_develop_t *const dev, dt_masks_form_t *const base, dt_masks_form_t *const dest)
+static void _path_duplicate_points(dt_develop_t *const dev,
+                                   dt_masks_form_t *const base,
+                                   dt_masks_form_t *const dest)
 {
   (void)dev; // unused arg, keep compiler from complaining
   for(const GList *pts = base->points; pts; pts = g_list_next(pts))
   {
     dt_masks_point_path_t *pt = (dt_masks_point_path_t *)pts->data;
-    dt_masks_point_path_t *npt = (dt_masks_point_path_t *)malloc(sizeof(dt_masks_point_path_t));
+    dt_masks_point_path_t *npt =
+      (dt_masks_point_path_t *)malloc(sizeof(dt_masks_point_path_t));
     memcpy(npt, pt, sizeof(dt_masks_point_path_t));
     dest->points = g_list_append(dest->points, npt);
   }
 }
 
-static void _path_initial_source_pos(const float iwd, const float iht, float *x, float *y)
+static void _path_initial_source_pos(const float iwd,
+                                     const float iht,
+                                     float *x,
+                                     float *y)
 {
   *x = (0.02f * iwd);
   *y = (0.02f * iht);
 }
 
-static void _path_modify_property(dt_masks_form_t *const form, dt_masks_property_t prop, float old_val, float new_val, float *sum, int *count, float *min, float *max)
+static void _path_modify_property(dt_masks_form_t *const form,
+                                  dt_masks_property_t prop,
+                                  const float old_val,
+                                  const float new_val,
+                                  float *sum,
+                                  int *count,
+                                  float *min,
+                                  float *max)
 {
   float ratio = (!old_val || !new_val) ? 1.0f : new_val / old_val;
 
@@ -3077,7 +3509,9 @@ static void _path_modify_property(dt_masks_form_t *const form, dt_masks_property
       float by = 0.0f;
       float surf = 0.0f;
 
-      for(const GList *form_points = form->points; form_points; form_points = g_list_next(form_points))
+      for(const GList *form_points = form->points;
+          form_points;
+          form_points = g_list_next(form_points))
       {
         const GList *next = g_list_next_wraparound(form_points, form->points);
         float *point1 = ((dt_masks_point_path_t *)form_points->data)->corner;
@@ -3172,4 +3606,3 @@ const dt_masks_functions_t dt_masks_functions_path = {
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1339,7 +1339,8 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module,
       dt_dev_masks_selection_change(darktable.develop, crea_module, form->formid);
       gui->creation_module = NULL;
 
-      if(gui->creation_continuous)
+      if(crea_module
+         && gui->creation_continuous)
       {
         //spot and retouch manage creation_continuous in their own way
         if(strcmp(crea_module->so->op, "spots") != 0

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1328,8 +1328,8 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module,
         // and we switch in edit mode to show all the forms
         // spots and retouch have their own handling of creation_continuous
         if(gui->creation_continuous
-           && (strcmp(crea_module->so->op, "spots") == 0
-               || strcmp(crea_module->so->op, "retouch") == 0))
+           && (dt_iop_module_is(crea_module->so, "spots")
+               || dt_iop_module_is(crea_module->so, "retouch")))
           dt_masks_set_edit_mode_single_form(crea_module, form->formid, DT_MASKS_EDIT_FULL);
         else if(!gui->creation_continuous)
           dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
@@ -1343,8 +1343,8 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module,
          && gui->creation_continuous)
       {
         //spot and retouch manage creation_continuous in their own way
-        if(strcmp(crea_module->so->op, "spots") != 0
-           && strcmp(crea_module->so->op, "retouch") != 0)
+        if(!dt_iop_module_is(crea_module->so, "spots")
+           && !dt_iop_module_is(crea_module->so, "retouch"))
         {
           dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)crea_module->blend_data;
           for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "bauhaus/bauhaus.h"
 #include "common/debug.h"
 #include "common/imagebuf.h"
@@ -716,9 +717,11 @@ static int _path_get_pts_border(dt_develop_t *dev,
   {
     const int pb = dborder ? dt_masks_dynbuf_position(dborder) : 0;
     border_init[k * 6 + 2] = -pb;
-    const GList *pt2 = g_list_next_wraparound(form_points, form->points); // next, wrapping around if on last element
+    // next, wrapping around if on last element
+    const GList *pt2 = g_list_next_wraparound(form_points, form->points);
     const GList *pt3 = g_list_next_wraparound(pt2, form->points);
-    dt_masks_point_path_t *point1 = (dt_masks_point_path_t *)form_points->data; // kth element of form->points
+    // kth element of form->points
+    dt_masks_point_path_t *point1 = (dt_masks_point_path_t *)form_points->data;
     dt_masks_point_path_t *point2 = (dt_masks_point_path_t *)pt2->data;
     dt_masks_point_path_t *point3 = (dt_masks_point_path_t *)pt3->data;
     float p1[5] = { point1->corner[0] * wd - dx,

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -405,7 +405,7 @@ gboolean dt_gui_presets_confirm_and_delete(const char *name,
     {
       dt_iop_module_so_t *mod = modules->data;
 
-      if(!strcmp(mod->op, module_name))
+      if(dt_iop_module_is(mod, module_name))
       {
         dt_action_rename_preset(&mod->actions, name, NULL);
         break;

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -934,7 +934,7 @@ int dt_imageio_export_with_flags(const int32_t imgid,
       for(const GList *nodes = g_list_last(pipe.nodes); nodes; nodes = g_list_previous(nodes))
       {
         dt_dev_pixelpipe_iop_t *node = (dt_dev_pixelpipe_iop_t *)(nodes->data);
-        if(!strcmp(node->module->op, "finalscale"))
+        if(dt_iop_module_is(node->module->so, "finalscale"))
         {
           finalscale = node;
           break;

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -293,6 +293,7 @@ static void _bt_add_shape(GtkWidget *widget, GdkEventButton *event, gpointer sha
   if(event->button == 1)
   {
     _tree_add_shape(NULL, shape);
+
     if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
     {
       darktable.develop->form_gui->creation_continuous = TRUE;

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1447,7 +1447,7 @@ gboolean _find_mask_iter_by_values(GtkTreeModel *model,
     _lib_masks_get_values(model, iter, &mod, NULL, &fid);
     gboolean found = (fid == formid)
       && ((level == 1)
-          || (module == NULL || (mod && (!g_strcmp0(module->op, mod->op)))));
+          || (module == NULL || (mod && dt_iop_module_is(module->so, mod->op))));
     if(found) return found;
 
     GtkTreeIter child, parent = *iter;
@@ -1707,7 +1707,7 @@ static gboolean _lib_masks_selection_change_r(GtkTreeModel *model,
 
     if((id == selectid)
        && ((level == 1)
-           || (module == NULL || (mod && (!g_strcmp0(module->op, mod->op))))))
+           || (module == NULL || (mod && dt_iop_module_is(module->so, mod->op)))))
     {
       gtk_tree_selection_select_iter(selection, &i);
       found = TRUE;

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -283,6 +283,8 @@ static void _tree_add_shape(GtkButton *button, gpointer shape)
   dt_masks_change_form_gui(spot);
   darktable.develop->form_gui->creation_module = module;
   darktable.develop->form_gui->group_selected = 0;
+  // the new form must be editable
+  darktable.develop->form_gui->edit_mode = DT_MASKS_EDIT_FULL;
   dt_control_queue_redraw_center();
 }
 


### PR DESCRIPTION
Two fixes here (For #13755).
- make circle/ellipsis/gradient modifiable after being created in mask manager
- fix crash for gradien when created in mask manager

There is another issue I have found, the brush is not visible when after being created from mask manager. I have tracked this down to:

```
commit dbc3f4f15f498c8bdeb25a16c581822acb645a51
Author: Diederik ter Rahe <dterrahe@yahoo.com>
Date:   Sun Oct 9 16:44:57 2022 -0400

    switch dt_lib_masks_t.gui_reset to standard darktable.gui->reset

 src/develop/develop.c        |  6 ++--
 src/develop/develop.h        |  4 +--
 src/develop/masks/brush.c    |  4 +--
 src/develop/masks/circle.c   |  4 +--
 src/develop/masks/ellipse.c  |  4 +--
 src/develop/masks/gradient.c |  4 +--
 src/develop/masks/masks.c    | 14 +++------
 src/develop/masks/path.c     |  4 +--
 src/libs/masks.c             | 73 +++++++++++++++++++++-----------------------
 9 files changed, 52 insertions(+), 65 deletions(-)
```

@dterrahe : Can you help for this one? I have hard time to see what is wrong... TIA.