### PR TITLE
Fix distort_mask in finalscale

### DIFF
--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -87,7 +87,7 @@ void distort_mask(struct dt_iop_module_t *self,
                   const dt_iop_roi_t *const roi_out)
 {
   const struct dt_interpolation *itor =
-    dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
+    dt_interpolation_new(DT_INTERPOLATION_USERPREF);
   dt_interpolation_resample_roi_1c(itor,
                                    out, roi_out, roi_out->width * sizeof(float),
                                    in, roi_in, roi_in->width * sizeof(float));


### PR DESCRIPTION
The mask interpolator should be the same as the one used for dt_iop_clip_and_zoom_roi and the cl variant.