### PR TITLE
Fix PPG & VNG/VNG4 demosaicer CPU code

### DIFF
--- a/data/kernels/demosaic_vng.cl
+++ b/data/kernels/demosaic_vng.cl
@@ -110,7 +110,7 @@ vng_lin_interpolate(read_only image2d_t in, write_only image2d_t out, const int 
     const int yy = yul + bufidx / stride;
     buffer[bufidx] = read_imagef(in, sampleri, (int2)(xx, yy)).x;
   }
-  
+
   // center buffer around current x,y-Pixel
   buffer += mad24(ylid + 1, stride, xlid + 1);
 
@@ -141,10 +141,10 @@ vng_lin_interpolate(read_only image2d_t in, write_only image2d_t out, const int 
   // for each interpolated color, load it into the pixel
   for(int i = 0; i < colors - 1; i++, ip += 2)
   {
-    o[ip[0]] = sum[ip[0]] / ip[1];
+    o[ip[0]] = fmax(0.0f, sum[ip[0]] / ip[1]);
   }
 
-  o[ip[0]] = buffer[0];
+  o[ip[0]] = fmax(0.0f, buffer[0]);
 
   write_imagef(out, (int2)(x, y), (float4)(o[0], o[1], o[2], o[3]));
 }
@@ -187,7 +187,7 @@ vng_interpolate(read_only image2d_t in, write_only image2d_t out, const int widt
     float4 pixel = read_imagef(in, sampleri, (int2)(xx, yy));
     vstore4(pixel, bufidx, buffer);
   }
-  
+
   // center buffer around current x,y-Pixel
   buffer += 4 * mad24(ylid + 2, stride, xlid + 2);
 
@@ -242,7 +242,7 @@ vng_interpolate(read_only image2d_t in, write_only image2d_t out, const int widt
 
   if(gmax == 0.0f)
   {
-    write_imagef(out, (int2)(x, y), (float4)(buffer[0], buffer[1], buffer[2], buffer[3]));
+    write_imagef(out, (int2)(x, y), (float4)(fmax(0.0f, buffer[0]), fmax(0.0f, buffer[1]), fmax(0.0f, buffer[2]), fmax(0.0f, buffer[3])));
     return;
   }
 
@@ -260,12 +260,12 @@ vng_interpolate(read_only image2d_t in, write_only image2d_t out, const int widt
       const int x0 = (short)(offset0 & 0xffffu);
       const int y0 = (short)(offset0 >> 16);
       const int idx0 = 4 * mad24(y0, stride, x0);
-    
+
       const int offset1 = ip[1];
       const int x1 = (short)(offset1 & 0xffffu);
       const int y1 = (short)(offset1 >> 16);
       const int idx1 = 4 * mad24(y1, stride, x1);
-    
+
       const int c1 = ip[2];
 
       for(int c = 0; c < colors; c++)
@@ -289,9 +289,9 @@ vng_interpolate(read_only image2d_t in, write_only image2d_t out, const int widt
   {
     float tot = buffer[color];
     if(c != color) tot += (sum[c] - sum[color]) / num;
-    o[c] = tot;
+    o[c] = fmax(0.0f, tot);
   }
-  
+
   write_imagef(out, (int2)(x, y), (float4)(o[0], o[1], o[2], o[3]));
 }
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -2314,12 +2314,10 @@ static void lin_interpolate(
    I've extended the basic idea to work with non-Bayer filter arrays.
    Gradients are numbered clockwise from NW=0 to W=7.
 */
-static inline void _ensure_abovezero(void *to, void *from, int num)
+static inline void _ensure_abovezero(float *to, float *from, const int floats)
 {
-  float *in = from;
-  float *out = to;
-  for(int i=0; i < num; i++)
-    out[i] = fmaxf(0.0f, in[i]);
+  for(int i = 0; i < floats; i++)
+    to[i] = fmaxf(0.0f, from[i]);
 }
 
 static void vng_interpolate(
@@ -2483,13 +2481,14 @@ static void vng_interpolate(
       }
     }
     if(row > 3) /* Write buffer to image */
-      _ensure_abovezero(out + 4 * ((row - 2) * width + 2), brow[0] + 2, 4 * (width - 4));
+      _ensure_abovezero(out + 4 * ((row - 2) * width + 2), (float *)(brow[0] + 2), 4 * (width - 4));
+
     // rotate ring buffer
     for(int g = 0; g < 4; g++) brow[(g - 1) & 3] = brow[g];
   }
   // copy the final two rows to the image
-  _ensure_abovezero(out + (4 * ((height - 4) * width + 2)), brow[0] + 2, 4 * (width - 4));
-  _ensure_abovezero(out + (4 * ((height - 3) * width + 2)), brow[1] + 2, 4 * (width - 4));
+  _ensure_abovezero(out + (4 * ((height - 4) * width + 2)), (float *)(brow[0] + 2), 4 * (width - 4));
+  _ensure_abovezero(out + (4 * ((height - 3) * width + 2)), (float *)(brow[1] + 2), 4 * (width - 4));
   dt_free_align(buffer);
 
   if(filters != 9 && !FILTERS_ARE_4BAYER(filters)) // x-trans or CYGM/RGBE

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -490,7 +490,7 @@ static void green_equilibration_lavg(
                           + fabsf(o2_3 - o2_4) + fabsf(o2_2 - o2_4)) / 6.0f;
         if((in[j * width + i] < maximum * 0.95f) && (c1 < maximum * thr) && (c2 < maximum * thr))
         {
-          out[j * width + i] = in[j * width + i] * m1 / m2;
+          out[j * width + i] = fmaxf(0.0f, in[j * width + i] * m1 / m2);
         }
       }
     }
@@ -544,7 +544,7 @@ static void green_equilibration_favg(
   {
     for(int i = oi; i < (width - 1 - g2_offset); i += 2)
     {
-      out[(size_t)j * width + i] = in[(size_t)j * width + i] * gr_ratio;
+      out[(size_t)j * width + i] = fmaxf(0.0f, in[(size_t)j * width + i] * gr_ratio);
     }
   }
 }


### PR DESCRIPTION
Both - CPU & GPU - paths should produce almost identical results. The PPG demosaicer didn't work that way leading to significant differences.

We now make sure output is always at least zero for all channels as we do in OpenCL code