### PR TITLE
[GUI] Change mention of "ROI" to a clearer explanation

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2021 darktable developers.
+    Copyright (C) 2011-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "blend.h"
 #include "common/gaussian.h"
 #include "common/guided_filter.h"
@@ -456,7 +457,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
   if(oscale != iscale || xoffs < 0 || yoffs < 0
      || ((xoffs > 0 || yoffs > 0) && (owidth + xoffs > iwidth || oheight + yoffs > iheight)))
   {
-    dt_control_log(_("skipped blending in module '%s': roi's do not match"), self->op);
+    dt_control_log(_("skipped blending in module '%s': working area mismatch"), self->op);
     return;
   }
 
@@ -842,7 +843,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
   if(oscale != iscale || xoffs < 0 || yoffs < 0
      || ((xoffs > 0 || yoffs > 0) && (owidth + xoffs > iwidth || oheight + yoffs > iheight)))
   {
-    dt_control_log(_("skipped blending in module '%s': roi's do not match"), self->op);
+    dt_control_log(_("skipped blending in module '%s': working area mismatch"), self->op);
     return TRUE;
   }
 


### PR DESCRIPTION
<del>Initialisms should be spelled all caps. Also, when the term is written in upper case, there is no need to separate `s` from it with an apostrophe for clarity, creating the impression of "possessive s".</del> We shouldn't show users internal terms that aren't even defined in the documentation.