### PR TITLE
maintenance: remove unnecessary alpha-channel copying

### DIFF
--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2021 darktable developers.
+    Copyright (C) 2010-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -316,9 +316,6 @@ static void process_wavelets(struct dt_iop_module_t *self, struct dt_dev_pixelpi
 #endif
   for(size_t k = 0; k < (size_t)4 * width * height; k++)
     out[k] += buf1[k];
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
-    dt_iop_alpha_copy(i, o, width, height);
 
   dt_free_align(detail);
   dt_free_align(tmp);

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -358,9 +358,6 @@ void process_sse2(struct dt_iop_module_t *self,
     local_laplacian_sse2(i, o, roi_in->width, roi_in->height,
                          d->midtone, d->sigma_s, d->sigma_r, d->detail, 0);
   }
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
-    dt_iop_alpha_copy(i, o, roi_in->width, roi_in->height);
 }
 #endif
 
@@ -401,9 +398,6 @@ void process(struct dt_iop_module_t *self,
     local_laplacian(i, o, roi_in->width, roi_in->height,
                     d->midtone, d->sigma_s, d->sigma_r, d->detail, 0);
   }
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
-    dt_iop_alpha_copy(i, o, roi_in->width, roi_in->height);
 }
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2021 darktable developers.
+    Copyright (C) 2010-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -265,8 +265,6 @@ void process(struct dt_iop_module_t *self,
       }
     }
   }
-
-  if(piece->pipe->mask_display) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2021 darktable developers.
+    Copyright (C) 2010-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -164,9 +164,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     out[4*k+3] = in[4*k+3];
   }
   dt_free_align(blurlightness);
-
-//  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
-//    dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 #ifdef HAVE_OPENCL

--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -256,9 +256,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   if(noise != 0.f)
     make_noise(output, noise, width, height);
 
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
-    dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
-
   dt_free_align(temp);
 }
 

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -1,6 +1,6 @@
 /*
   This file is part of darktable,
-  Copyright (C) 2010-2021 darktable developers.
+  Copyright (C) 2010-2023 darktable developers.
 
   darktable is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -377,7 +377,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     default:
       break;
   }
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 #ifdef HAVE_OPENCL

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -4,7 +4,7 @@ http://www.youtube.com/watch?v=JVoUgR6bhBc
 
 /*
     This file is part of darktable,
-    Copyright (C) 2013-2022 darktable developers.
+    Copyright (C) 2013-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -511,7 +511,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       break;
     }
   }
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 #if defined(__SSE__)
@@ -742,7 +741,6 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
       break;
     }
   }
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 #endif
 

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -467,9 +467,6 @@ void process(struct dt_iop_module_t *self,
   dt_omploop_sfence();
   dt_free_align(patches);
   dt_free_align(sources);
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
-    dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1116,9 +1116,6 @@ void process(struct dt_iop_module_t *self,
   {
     process_lcms2(self, piece, ivoid, ovoid, roi_in, roi_out);
   }
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
-    dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 #if defined(__SSE2__)
@@ -1398,9 +1395,6 @@ void process_sse2(struct dt_iop_module_t *self,
   {
     process_lcms2(self, piece, ivoid, ovoid, roi_in, roi_out);
   }
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
-    dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 #endif
 

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2021 darktable developers.
+    Copyright (C) 2009-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -459,9 +459,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       }
     }
   }
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
-    dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 #if defined(__SSE__)
@@ -537,8 +534,6 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
     }
     _mm_sfence();
   }
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 #endif
 

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2013-2021 darktable developers.
+    Copyright (C) 2013-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -394,9 +394,6 @@ void process(struct dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, cons
       }
     }
   }
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
-    dt_iop_alpha_copy(i, o, roi_out->width, roi_out->height);
 
   goto FINISH_PROCESS;
 

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1403,9 +1403,6 @@ static void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
   dt_free_align(tmp);
   dt_free_align(precond);
 
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
-    dt_iop_alpha_copy(ivoid, ovoid, width, height);
-
 #undef MAX_MAX_SCALE
 }
 
@@ -1606,9 +1603,6 @@ static void process_nlmeans(
 
   dt_free_align(in);
   nlmeans_backtransform(d,ovoid,roi_in,scale,compensate_p,wb,aa,bb,p);
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
-    dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 static void sum_rec(const size_t npixels, const float *in, float *out)

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -359,9 +359,6 @@ static void process_floyd_steinberg(
       _clipnan_pixel(out + 4 * j, in + 4 * j);
       _nearest_color(out + 4 * j, err, graymode, f, rf);
     }
-
-    if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
-      dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
     return;
   }
 
@@ -497,10 +494,6 @@ static void process_floyd_steinberg(
     // lower right pixel
     _nearest_color(outrow + 4 * (width - 1), err, graymode, f, rf);  // quantize the last pixel, no neighbors left
   }
-
-  // copy alpha channel if needed
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
-    dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 static void process_random(
@@ -554,8 +547,6 @@ static void process_random(
     }
   }
   free_tea_states(tea_states);
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(ivoid, ovoid, width, height);
 }
 
 

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -503,11 +503,8 @@ void process(struct dt_iop_module_t *self,
   {
     out[k] = (in[k] - black) * scale;
   }
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
-    dt_iop_alpha_copy(i, o, roi_out->width, roi_out->height);
-
-  for(int k = 0; k < 3; k++) piece->pipe->dsc.processed_maximum[k] *= d->scale;
+  for(int k = 0; k < 3; k++)
+    piece->pipe->dsc.processed_maximum[k] *= d->scale;
 }
 
 

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1,6 +1,6 @@
 /*
    This file is part of darktable,
-   Copyright (C) 2018-2021 darktable developers.
+   Copyright (C) 2018-2023 darktable developers.
 
    darktable is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -490,9 +490,6 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     // sRGB -> XYZ
     dt_prophotorgb_to_Lab(rgb, out);
   }
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
-    dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 
@@ -616,8 +613,6 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
     // XYZ -> Lab
     _mm_stream_ps(out, dt_XYZ_to_Lab_sse2(XYZ));
   }
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 #endif
 

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2042,9 +2042,6 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   }
 
   if(reconstructed) dt_free_align(reconstructed);
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
-    dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 #ifdef HAVE_OPENCL

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2021 darktable developers.
+    Copyright (C) 2012-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -312,8 +312,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     dt_bilateral_slice_to_output(b, (float *)ivoid, (float *)ovoid, data->detail);
     dt_bilateral_free(b);
   }
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 #ifdef HAVE_OPENCL

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2017-2020 darktable developers.
+    Copyright (C) 2017-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -523,9 +523,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
   free_gray_image(&trans_map);
   free_gray_image(&trans_map_filtered);
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
-    dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 #ifdef HAVE_OPENCL

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -2227,8 +2227,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
                           piece->pipe->dsc.processed_maximum[2]);
     for(int k = 0; k < 3; k++) piece->pipe->dsc.processed_maximum[k] = m;
   }
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2022 darktable developers.
+    Copyright (C) 2011-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -289,8 +289,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         out[p] = d->color[c] - in[p];
       }
     }
-
-    if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
   }
 }
 
@@ -437,8 +435,6 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
       }
     }
     _mm_sfence();
-
-    if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
   }
 }
 #endif

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2021 darktable developers.
+    Copyright (C) 2011-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -404,9 +404,6 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     out[i+1] = in[i+1] * L_out / denom;
     out[i+2] = in[i+2] * L_out / denom;
   }
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
-    dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 #ifdef HAVE_OPENCL

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2020-2022 darktable developers.
+    Copyright (C) 2020-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -302,9 +302,6 @@ void process(struct dt_iop_module_t *const self, dt_dev_pixelpipe_iop_t *const p
                                                  : print_gamma;
     }
   }
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
-    dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -398,8 +398,6 @@ void process(
                                       .norm = norm2 };
 
   nlmeans_denoise(ivoid, ovoid, roi_in, roi_out, &params);
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
-    dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 void init_global(dt_iop_module_so_t *module)

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2020 darktable developers.
+    Copyright (C) 2009-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -387,9 +387,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
   dt_free_align(mat);
   dt_free_align(tmp);
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
-    dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -592,9 +592,6 @@ void process(struct dt_iop_module_t *self,
         out[k+c] = in[k+c] * d_coeffs[c];
       }
     }
-
-    if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
-      dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
   }
 
   piece->pipe->dsc.temperature.enabled = 1;

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2020 darktable developers.
+    Copyright (C) 2010-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -164,8 +164,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       out[2] = CLAMPS(in[2] + saturation * (in[2] - 0.5f * (in[0] + in[1])), 0.0f, 1.0f);
     }
   }
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 #ifdef HAVE_OPENCL


### PR DESCRIPTION
Ever since a change to the pixelpipe around two years ago to improve the responsiveness of mask displays, non-distorting iops are no longer called when a mask is being sent down the pixelpipe.  This means non-distorting iops never encounter a condition where they need to preserve the alpha channel in their output.

This PR removes the now-redundant check for whether a mask is being passed and the associated call to dt_iop_alpha_copy to preserve the alpha channel.
