### PR TITLE
RFC: Use camera, maker and lens fields in text search

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1933,10 +1933,10 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
              " UNION SELECT imgid AS id FROM main.tagged_images AS ti, data.tags AS t"
              "   WHERE t.id=ti.tagid AND (t.name LIKE '%s' OR t.synonyms LIKE '%s')"
              " UNION SELECT id FROM main.images"
-             "   WHERE (filename LIKE '%s' OR maker LIKE '%s' OR model LIKE '%s' OR lens LIKE '%s')"
+             "   WHERE (filename LIKE '%s' OR maker LIKE '%s' OR model LIKE '%s')"
              " UNION SELECT i.id FROM main.images AS i, main.film_rolls AS fr"
              "   WHERE fr.id=i.film_id AND fr.folder LIKE '%s'))",
-             escaped_text, escaped_text, escaped_text, escaped_text, escaped_text, escaped_text, escaped_text, escaped_text );
+             escaped_text, escaped_text, escaped_text, escaped_text, escaped_text, escaped_text, escaped_text );
         // clang-format on
       }
       break;

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1933,10 +1933,10 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
              " UNION SELECT imgid AS id FROM main.tagged_images AS ti, data.tags AS t"
              "   WHERE t.id=ti.tagid AND (t.name LIKE '%s' OR t.synonyms LIKE '%s')"
              " UNION SELECT id FROM main.images"
-             "   WHERE filename LIKE '%s'"
+             "   WHERE (filename LIKE '%s' OR maker LIKE '%s' OR model LIKE '%s' OR lens LIKE '%s')"
              " UNION SELECT i.id FROM main.images AS i, main.film_rolls AS fr"
              "   WHERE fr.id=i.film_id AND fr.folder LIKE '%s'))",
-             escaped_text, escaped_text, escaped_text, escaped_text, escaped_text);
+             escaped_text, escaped_text, escaped_text, escaped_text, escaped_text, escaped_text, escaped_text, escaped_text );
         // clang-format on
       }
       break;

--- a/src/libs/filters/search.c
+++ b/src/libs/filters/search.c
@@ -176,7 +176,7 @@ static void _search_widget_init(dt_lib_filtering_rule_t *rule, const dt_collecti
   gtk_entry_set_width_chars(GTK_ENTRY(search->text), 0);
   gtk_widget_set_tooltip_text(search->text,
                               /* xgettext:no-c-format */
-                              _("filter by text from images metadata, tags, file path and name"
+                              _("filter by text from images metadata, camera brand/model, tags, file path and name"
                                 /* xgettext:no-c-format */
                                 "\n`%' is the wildcard character"
                                 /* xgettext:no-c-format */


### PR DESCRIPTION
fixes #13747

Camera maker, model and lens are used in full text search as well.
