### PR TITLE
Suppress hidden files in import dialog

### DIFF
--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -683,6 +683,12 @@ static guint _import_set_file_list(const gchar *folder, const int folder_lgth,
       gchar *uifullname = g_build_filename(folder, uifilename, NULL);
       gchar *fullname = g_build_filename(folder, filename, NULL);
 
+      /* g_file_info_get_is_hidden() always returns 0 on macOS,
+        so we check if the filename starts with a '.' */
+      const gboolean is_hidden = g_file_info_get_is_hidden(info) || filename[0] ==  '.';
+      if (is_hidden)
+        continue;
+
       if(recursive && filetype == G_FILE_TYPE_DIRECTORY)
       {
         nb = _import_set_file_list(fullname, folder_lgth, nb, self);

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -676,18 +676,19 @@ static guint _import_set_file_list(const gchar *folder, const int folder_lgth,
       const char *filename = g_file_info_get_name(info);
       if(!filename)
         continue;
-      const time_t datetime = g_file_info_get_attribute_uint64(info, G_FILE_ATTRIBUTE_TIME_MODIFIED);
-      GDateTime *dt_datetime = g_date_time_new_from_unix_local(datetime);
-      gchar *dt_txt = g_date_time_format(dt_datetime, "%x %X");
-      const GFileType filetype = g_file_info_get_file_type(info);
-      gchar *uifullname = g_build_filename(folder, uifilename, NULL);
-      gchar *fullname = g_build_filename(folder, filename, NULL);
 
       /* g_file_info_get_is_hidden() always returns 0 on macOS,
         so we check if the filename starts with a '.' */
       const gboolean is_hidden = g_file_info_get_is_hidden(info) || filename[0] ==  '.';
       if (is_hidden)
         continue;
+
+      const time_t datetime = g_file_info_get_attribute_uint64(info, G_FILE_ATTRIBUTE_TIME_MODIFIED);
+      GDateTime *dt_datetime = g_date_time_new_from_unix_local(datetime);
+      gchar *dt_txt = g_date_time_format(dt_datetime, "%x %X");
+      const GFileType filetype = g_file_info_get_file_type(info);
+      gchar *uifullname = g_build_filename(folder, uifilename, NULL);
+      gchar *fullname = g_build_filename(folder, filename, NULL);
 
       if(recursive && filetype == G_FILE_TYPE_DIRECTORY)
       {


### PR DESCRIPTION
Trying to fix some old macOS issues...

fixes #11225

I think it doesn't make sense to display hidden files in the import dialog.

Found a strange bug: `g_file_info_get_is_hidden()` always returns 0, at least on macOS so I made an additional check if the filename starts with a `.`