### PR TITLE
Fix missing map module on macOS homebrew builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,8 +316,9 @@ jobs:
           cd src/.ci
           export HOMEBREW_NO_INSTALL_UPGRADE=1
           brew bundle --verbose || true
-          brew link --force libomp # fix for keg-only libomp
-          brew link libsoup@2
+          # handle keg-only libs
+          brew link --force libomp
+          brew link --force libsoup@2
       - name: Build and Install
           # todo: use linker which supports --wrap, ld.bfd and ld.gold support it
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,6 +317,7 @@ jobs:
           export HOMEBREW_NO_INSTALL_UPGRADE=1
           brew bundle --verbose || true
           brew link --force libomp # fix for keg-only libomp
+          brew link libsoup@2
       - name: Build and Install
           # todo: use linker which supports --wrap, ld.bfd and ld.gold support it
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -175,6 +175,7 @@ jobs:
           export HOMEBREW_NO_INSTALL_UPGRADE=1
           brew bundle --verbose || true
           brew link --force libomp # fix for keg-only libomp
+          brew link libsoup@2
       - name: Build and Install
           # todo: use linker which supports --wrap, ld.bfd and ld.gold support it
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -174,8 +174,9 @@ jobs:
           cd src/.ci
           export HOMEBREW_NO_INSTALL_UPGRADE=1
           brew bundle --verbose || true
-          brew link --force libomp # fix for keg-only libomp
-          brew link libsoup@2
+          # handle keg-only libs
+          brew link --force libomp
+          brew link --force libsoup@2
       - name: Build and Install
           # todo: use linker which supports --wrap, ld.bfd and ld.gold support it
         run: |

--- a/packaging/macosx/1_install_hb_dependencies.sh
+++ b/packaging/macosx/1_install_hb_dependencies.sh
@@ -62,7 +62,7 @@ hbDependencies="adwaita-icon-theme \
     webp"
 
 # Dependencies that must be linked
-hbMustLink="libomp"
+hbMustLink="libomp libsoup@2"
 
 # Categorize dependency list
 standalone=


### PR DESCRIPTION
A required library `libsoup@2` needs to be correctly linked for homebrew, otherwise cmake cannot find `osmgpsmap-1.0` and the Map module is missing.


