### PR TITLE
[GUI] A more accurate tooltip for highlights reconstruction module

### DIFF
--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -2400,7 +2400,7 @@ void gui_update(struct dt_iop_module_t *self)
   // enable this per default if raw or sraw if not real monochrome
   self->default_enabled = dt_image_is_rawprepare_supported(&self->dev->image_storage) && !monochrome;
   self->hide_enable_button = monochrome;
-  gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->default_enabled ? "default" : "monochrome");
+  gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->default_enabled ? "default" : "notapplicable");
   dt_bauhaus_widget_set_quad_active(g->clip, FALSE);
   dt_bauhaus_widget_set_quad_active(g->candidating, FALSE);
   dt_bauhaus_widget_set_quad_active(g->combine, FALSE);
@@ -2444,7 +2444,7 @@ void reload_defaults(dt_iop_module_t *self)
     d->mode = DT_IOP_HIGHLIGHTS_OPPOSED;
 
   if(self->widget)
-    gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->default_enabled ? "default" : "monochrome");
+    gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->default_enabled ? "default" : "notapplicable");
 
   dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
   if(g)
@@ -2622,13 +2622,13 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->scales, _("increase to correct larger clipped areas.\n"
                                            "large values bring huge performance penalties"));
 
-  GtkWidget *monochromes = dt_ui_label_new(_("not applicable"));
-  gtk_widget_set_tooltip_text(monochromes, _("this module only works with non-monochrome RAW and sRAW"));
+  GtkWidget *notapplicable = dt_ui_label_new(_("not applicable"));
+  gtk_widget_set_tooltip_text(notapplicable, _("this module only works with non-monochrome RAW and sRAW"));
 
   // start building top level widget
   self->widget = gtk_stack_new();
   gtk_stack_set_homogeneous(GTK_STACK(self->widget), FALSE);
-  gtk_stack_add_named(GTK_STACK(self->widget), monochromes, "monochrome");
+  gtk_stack_add_named(GTK_STACK(self->widget), notapplicable, "notapplicable");
   gtk_stack_add_named(GTK_STACK(self->widget), box_raw, "default");
 }
 

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -14,7 +14,8 @@
 
    You should have received a copy of the GNU General Public License
    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
- */
+*/
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -2622,7 +2623,7 @@ void gui_init(struct dt_iop_module_t *self)
                                            "large values bring huge performance penalties"));
 
   GtkWidget *monochromes = dt_ui_label_new(_("not applicable"));
-  gtk_widget_set_tooltip_text(monochromes, _("no highlights reconstruction for monochrome images"));
+  gtk_widget_set_tooltip_text(monochromes, _("this module only works with non-monochrome RAW and sRAW"));
 
   // start building top level widget
   self->widget = gtk_stack_new();


### PR DESCRIPTION
This module only works with RAW and sRAW images, which are not monochrome images. So it won't work with color JPEG images, for example. But at the same time, the tooltip to the text "not applicable" in the body of the module contained the explanation "no highlights reconstruction for monochrome images", which is incorrect in the case of color JPEG.

Additionally, the "not applicable" text is not a widget label, so it doesn't need to be left-aligned, it looks better centered.
