### PR TITLE
denoiseprofile: remove unused SSE wavelet codepath

### DIFF
--- a/src/common/eaw.c
+++ b/src/common/eaw.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2017-2021 darktable developers.
+    Copyright (C) 2017-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/common/eaw.h
+++ b/src/common/eaw.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2017-2020 darktable developers.
+    Copyright (C) 2017-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -48,9 +48,7 @@ typedef void((*eaw_dn_decompose_t)(float *const restrict out, const float *const
 void eaw_dn_decompose(float *const restrict out, const float *const restrict in, float *const restrict detail,
                       dt_aligned_pixel_t sum_squared, const int scale, const float inv_sigma2,
                       const int32_t width, const int32_t height);
-void eaw_dn_decompose_sse(float *const restrict out, const float *const restrict in, float *const restrict detail,
-                          dt_aligned_pixel_t sum_squared, const int scale, const float inv_sigma2,
-                          const int32_t width, const int32_t height);
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent


### PR DESCRIPTION
Remove the function eaw_dn_decompose_sse from eaw.c, as it is not currently used by denoiseprofile.c (unlike eaw_dn_decompose) and in a quick check proved to be nearly identical in speed to the autovectorized code.