### PR TITLE
RFC: Keep sort order on collection change

### DIFF
--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -1751,9 +1751,9 @@ uint32_t dt_tag_get_tag_id_by_name(const char * const name)
     dt_conf_is_equal("plugins/lighttable/tagging/case_sensitivity", "insensitive");
   // clang-format off
   const char *query = is_insensitive
-                      ? "SELECT T.id, T.flags FROM data.tags AS T "
+                      ? "SELECT T.id FROM data.tags AS T "
                         "WHERE T.name LIKE ?1"
-                      : "SELECT T.id, T.flags FROM data.tags AS T "
+                      : "SELECT T.id FROM data.tags AS T "
                         "WHERE T.name = ?1";
   // clang-format on
   sqlite3_stmt *stmt;

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -199,14 +199,6 @@ uint32_t dt_tag_images_count(gint tagid);
 /** retrieves the subtags of requested level for the requested category */
 char *dt_tag_get_subtags(const gint imgid, const char *category, const int level);
 
-/** return the images order associated to that tag */
-gboolean dt_tag_get_tag_order_by_id(const uint32_t tagid, uint32_t *sort,
-                                          gboolean *descending);
-
-/** save the images order on the tag */
-void dt_tag_set_tag_order_by_id(const uint32_t tagid, const uint32_t sort,
-                                const gboolean descending);
-
 /** return the tagid of that tag - follow tag sensitivity - return 0 if not found*/
 uint32_t dt_tag_get_tag_id_by_name(const char * const name);
 

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2503,27 +2503,12 @@ static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTr
       }
       else if(active == 0 && g_strcmp0(text, _("not tagged")))
       {
-        // first filter is tag and the row is a leave
-        uint32_t sort = DT_COLLECTION_SORT_NONE;
-        gboolean descending = FALSE;
+        // // first filter is tag and the row is a leave
         const uint32_t tagid = dt_tag_get_tag_id_by_name(text);
         if(tagid)
-        {
-          if(dt_tag_get_tag_order_by_id(tagid, &sort, &descending))
-          {
-            order = g_strdup_printf("1:%u:%d$", sort, descending);
-          }
-          else
-          {
-            // the tag order is not set yet - default order (filename)
-            const int orderid = DT_COLLECTION_SORT_FILENAME;
-            order = g_strdup_printf("1:%d:0$", orderid);
-            dt_tag_set_tag_order_by_id(tagid, orderid & ~DT_COLLECTION_ORDER_FLAG,
-                                       orderid & DT_COLLECTION_ORDER_FLAG);
-          }
           dt_collection_set_tag_id((dt_collection_t *)darktable.collection, tagid);
-        }
-        else dt_collection_set_tag_id((dt_collection_t *)darktable.collection, 0);
+        else
+          dt_collection_set_tag_id((dt_collection_t *)darktable.collection, 0);
       }
     }
   }


### PR DESCRIPTION
fixes #13731 

By studying the code I see that the basic idea is to store the used sort order in a tag attribute. But this is not fully implemented and results in the sort order always been reset to 'filename' when the (tag) collection is changed.

I have removed that part of the code so that the user chosen sort order is always kept.

I understand the basic idea here: To set and keep a sort order for each chosen tag collection but personally I would find that somewhat confusing. But this is my personal opinion, hence the RFC.

With this PR the functions `dt_tag_get_tag_order_by_id()` and `dt_tag_set_tag_order_by_id()` are dead code but I did not remove them for maybe future use.