### PR TITLE
darktable.css: Make treeview background not transparent.

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1690,6 +1690,11 @@ button.dt_transparent_background:checked:not(:disabled):not(.dt_ignore_fg_state)
   color: @field_active_fg;
 }
 
+treeview *
+{
+  background-color: @bg_color;
+}
+
 /* Hover states, some needed background only */
 .dt_history_items:hover,
 .dt_transparent_background:hover,


### PR DESCRIPTION
Do not use alpha() for the tree background to avoid seeing the layer below. Fix editing shapes name from masks manager.

Fixes #13839, Fixes #13767.