### PR TITLE
Simplify css code for treeview entries

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1038,13 +1038,6 @@ treeview header label
   padding: 0.14em;
 }
 
-/* be sure spinbutton is displayed without alpha background on treeview */
-treeview entry,
-treeview spinbutton
-{
-  background-color: @field_active_bg;
-}
-
 /* set margin around treeview (need to be applied on scrolledwindow which is a direct parent) */
 .dt_spacing_sw scrolledwindow
 {
@@ -1742,7 +1735,9 @@ button:checked cellview
 
 /* Treeviews, entries and filechoosers states */
 menuitem:not(.dt_transparent_background) check,  /* be sure transparent background is applied to preset and blend menus */
-treeview check /* set specific background color about check buttons like in copy/paste dialog window */
+treeview check, /* set specific background color about check buttons like in copy/paste dialog window */
+treeview entry, /* be sure entry is displayed without alpha background on treeview */
+treeview spinbutton /* and same thing for spinbutton */
 {
   background-color: @field_active_bg;
   border-color: @border_color;


### PR DESCRIPTION
@TurboGit: I even finally found a better way to deal with last CSS issue by using less lines (and have same place for all specific items on treeview. So this code just simplify CSS.