### PR TITLE
imageio: lookup camera make/model in any mode available

### DIFF
--- a/src/imageio/imageio_rawspeed.cc
+++ b/src/imageio/imageio_rawspeed.cc
@@ -79,10 +79,8 @@ gboolean dt_rawspeed_lookup_makermodel(const char *maker, const char *model,
   gboolean got_it_done = FALSE;
   try {
     dt_rawspeed_load_meta();
-    const Camera *cam = meta->getCamera(maker, model, "");
-    // Also look for dng cameras
-    if(!cam)
-      cam = meta->getCamera(maker, model, "dng");
+    // Look for camera in any mode available
+    const Camera *cam = meta->getCamera(maker, model);
     if(cam)
     {
       g_strlcpy(mk, cam->canonical_make.c_str(), mk_len);


### PR DESCRIPTION
Fixes https://github.com/darktable-org/darktable/issues/6644 and also partially addresses https://github.com/darktable-org/darktable/issues/13712