### PR TITLE
Add missing mutex init for darktable-cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,4 +339,4 @@ jobs:
                  --core --disable-opencl --conf host_memory_limit=8192 \
                  --conf worker_threads=4 -t 4 \
                  --conf plugins/lighttable/export/force_lcms2=FALSE \
-                 --conf plugins/lighttable/export/iccintent=0 || true # OpenMP builds crash for most configs
+                 --conf plugins/lighttable/export/iccintent=0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -195,7 +195,7 @@ jobs:
                  --core --disable-opencl --conf host_memory_limit=8192 \
                  --conf worker_threads=4 -t 4 \
                  --conf plugins/lighttable/export/force_lcms2=FALSE \
-                 --conf plugins/lighttable/export/iccintent=0 || true # OpenMP builds crash for most configs
+                 --conf plugins/lighttable/export/iccintent=0
       - name: Build macOS package
         run: |
           ./src/packaging/macosx/3_make_hb_darktable_package.sh

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1212,6 +1212,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
       dt_gui_presets_init(); // init preset db schema.
     darktable.control->running = 0;
     dt_pthread_mutex_init(&darktable.control->run_mutex, NULL);
+    dt_pthread_mutex_init(&darktable.control->log_mutex, NULL);
   }
 
   // we initialize grouping early because it's needed for collection init


### PR DESCRIPTION
The added mutex initialization should fix the issue with `assert()` being triggered by EINVAL error code returned by `pthread_mutex_lock()`.

Also removed the forced successful completion from the CI step, as there should be no job failure issues after this fix.
