### PR TITLE
gaussian.c: optimize and remove SSE

### DIFF
--- a/src/common/gaussian.c
+++ b/src/common/gaussian.c
@@ -19,9 +19,6 @@
 
 #include <assert.h>
 #include <math.h>
-#if defined(__SSE__)
-#include <xmmintrin.h>
-#endif
 #include "common/gaussian.h"
 #include "common/math.h"
 #include "common/opencl.h"
@@ -317,7 +314,7 @@ void dt_gaussian_blur(dt_gaussian_t *g, const float *const in, float *const out)
   }
 }
 
-void dt_gaussian_blur_4c_plain(dt_gaussian_t *g, const float *const in, float *const out)
+void dt_gaussian_blur_4c(dt_gaussian_t *g, const float *const in, float *const out)
 {
   assert(g->channels == 4);
   const size_t width = g->width;
@@ -474,182 +471,6 @@ void dt_gaussian_blur_4c_plain(dt_gaussian_t *g, const float *const in, float *c
       }
     }
   }
-}
-
-
-
-#if defined(__SSE__)
-static void dt_gaussian_blur_4c_sse(dt_gaussian_t *g, const float *const in, float *const out)
-{
-  const int width = g->width;
-  const int height = g->height;
-  const int ch = 4;
-
-  assert(g->channels == 4);
-
-  float a0, a1, a2, a3, b1, b2, coefp, coefn;
-
-  compute_gauss_params(g->sigma, g->order, &a0, &a1, &a2, &a3, &b1, &b2, &coefp, &coefn);
-
-  const __m128 Labmax = _mm_set_ps(g->max[3], g->max[2], g->max[1], g->max[0]);
-  const __m128 Labmin = _mm_set_ps(g->min[3], g->min[2], g->min[1], g->min[0]);
-
-  float *temp = g->buf;
-
-
-// vertical blur column by column
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(in, Labmin, Labmax, width, height, ch) \
-  shared(temp, a0, a1, a2, a3, b1, b2, coefp, coefn) \
-  schedule(static)
-#endif
-  for(int i = 0; i < width; i++)
-  {
-    __m128 xp = _mm_setzero_ps();
-    __m128 yb = _mm_setzero_ps();
-    __m128 yp = _mm_setzero_ps();
-    __m128 xc = _mm_setzero_ps();
-    __m128 yc = _mm_setzero_ps();
-    __m128 xn = _mm_setzero_ps();
-    __m128 xa = _mm_setzero_ps();
-    __m128 yn = _mm_setzero_ps();
-    __m128 ya = _mm_setzero_ps();
-
-    // forward filter
-    xp = MMCLAMPPS(_mm_load_ps(in + i * ch), Labmin, Labmax);
-    yb = _mm_mul_ps(_mm_set_ps1(coefp), xp);
-    yp = yb;
-
-
-    for(int j = 0; j < height; j++)
-    {
-      size_t offset = ((size_t)j * width + i) * ch;
-
-      xc = MMCLAMPPS(_mm_load_ps(in + offset), Labmin, Labmax);
-
-
-      yc = _mm_add_ps(
-          _mm_mul_ps(xc, _mm_set_ps1(a0)),
-          _mm_sub_ps(_mm_mul_ps(xp, _mm_set_ps1(a1)),
-                     _mm_add_ps(_mm_mul_ps(yp, _mm_set_ps1(b1)), _mm_mul_ps(yb, _mm_set_ps1(b2)))));
-
-      _mm_store_ps(temp + offset, yc);
-
-      xp = xc;
-      yb = yp;
-      yp = yc;
-    }
-
-    // backward filter
-    xn = MMCLAMPPS(_mm_load_ps(in + ((size_t)(height - 1) * width + i) * ch), Labmin, Labmax);
-    xa = xn;
-    yn = _mm_mul_ps(_mm_set_ps1(coefn), xn);
-    ya = yn;
-
-    for(int j = height - 1; j > -1; j--)
-    {
-      size_t offset = ((size_t)j * width + i) * ch;
-
-      xc = MMCLAMPPS(_mm_load_ps(in + offset), Labmin, Labmax);
-
-      yc = _mm_add_ps(
-          _mm_mul_ps(xn, _mm_set_ps1(a2)),
-          _mm_sub_ps(_mm_mul_ps(xa, _mm_set_ps1(a3)),
-                     _mm_add_ps(_mm_mul_ps(yn, _mm_set_ps1(b1)), _mm_mul_ps(ya, _mm_set_ps1(b2)))));
-
-
-      xa = xn;
-      xn = xc;
-      ya = yn;
-      yn = yc;
-
-      _mm_store_ps(temp + offset, _mm_add_ps(_mm_load_ps(temp + offset), yc));
-    }
-  }
-
-// horizontal blur line by line
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(out, Labmin, Labmax, width, height, ch) \
-  shared(temp, a0, a1, a2, a3, b1, b2, coefp, coefn) \
-  schedule(static)
-#endif
-  for(size_t j = 0; j < height; j++)
-  {
-    __m128 xp = _mm_setzero_ps();
-    __m128 yb = _mm_setzero_ps();
-    __m128 yp = _mm_setzero_ps();
-    __m128 xc = _mm_setzero_ps();
-    __m128 yc = _mm_setzero_ps();
-    __m128 xn = _mm_setzero_ps();
-    __m128 xa = _mm_setzero_ps();
-    __m128 yn = _mm_setzero_ps();
-    __m128 ya = _mm_setzero_ps();
-
-    // forward filter
-    xp = MMCLAMPPS(_mm_load_ps(temp + j * width * ch), Labmin, Labmax);
-    yb = _mm_mul_ps(_mm_set_ps1(coefp), xp);
-    yp = yb;
-
-
-    for(int i = 0; i < width; i++)
-    {
-      size_t offset = ((size_t)j * width + i) * ch;
-
-      xc = MMCLAMPPS(_mm_load_ps(temp + offset), Labmin, Labmax);
-
-      yc = _mm_add_ps(
-          _mm_mul_ps(xc, _mm_set_ps1(a0)),
-          _mm_sub_ps(_mm_mul_ps(xp, _mm_set_ps1(a1)),
-                     _mm_add_ps(_mm_mul_ps(yp, _mm_set_ps1(b1)), _mm_mul_ps(yb, _mm_set_ps1(b2)))));
-
-      _mm_store_ps(out + offset, yc);
-
-      xp = xc;
-      yb = yp;
-      yp = yc;
-    }
-
-    // backward filter
-    xn = MMCLAMPPS(_mm_load_ps(temp + ((size_t)(j + 1) * width - 1) * ch), Labmin, Labmax);
-    xa = xn;
-    yn = _mm_mul_ps(_mm_set_ps1(coefn), xn);
-    ya = yn;
-
-
-    for(int i = width - 1; i > -1; i--)
-    {
-      size_t offset = ((size_t)j * width + i) * ch;
-
-      xc = MMCLAMPPS(_mm_load_ps(temp + offset), Labmin, Labmax);
-
-      yc = _mm_add_ps(
-          _mm_mul_ps(xn, _mm_set_ps1(a2)),
-          _mm_sub_ps(_mm_mul_ps(xa, _mm_set_ps1(a3)),
-                     _mm_add_ps(_mm_mul_ps(yn, _mm_set_ps1(b1)), _mm_mul_ps(ya, _mm_set_ps1(b2)))));
-
-
-      xa = xn;
-      xn = xc;
-      ya = yn;
-      yn = yc;
-
-      _mm_store_ps(out + offset, _mm_add_ps(_mm_load_ps(out + offset), yc));
-    }
-  }
-}
-#endif
-
-void dt_gaussian_blur_4c(dt_gaussian_t *g, const float *const in, float *const out)
-{
-  if(darktable.codepath.OPENMP_SIMD) return dt_gaussian_blur_4c_plain(g, in, out);
-#if defined(__SSE__)
-  else if(darktable.codepath.SSE2)
-    return dt_gaussian_blur_4c_sse(g, in, out);
-#endif
-  else
-    dt_unreachable_codepath();
 }
 
 void dt_gaussian_free(dt_gaussian_t *g)


### PR DESCRIPTION
Optimize the 4-channel plain C codepath so that it matches or beats the SSE code path, and remove the SSE code path as redundant.

I tested with the Chromatic Aberrations module, which makes four calls to the gaussian blur code, with the following result (showing times for each of the four calls):
```
Thr	SSE				PR
1	26.884+23.773+23.656+364.482	24.553+21.714+21.526+345.068
2	14.876+12.439+12.277+191.275	13.770+11.624+11.392+182.631
4	8.211+6.421+6.426+100.660	7.815+6.096+6.004+96.630
8	6.460+3.376+3.468+55.070	6.418+3.256+3.434+54.744
16	8.287+2.170+2.138+34.748	8.253+2.120+2.131+34.170
32	14.379+2.153+2.141+39.940	14.857+2.236+2.112+39.038
```
I don't know why there's a big increase in runtime for the first call at the highest thread counts.

Timings for the lowpass module as a whole (without the optimizations from my previous PR):
```
Thr   Master-SSE    PR
1      307.39     315.79
8       51.80      52.22
32      52.27      51.58
```

I created the new integration test in PR darktable-org/darktable-tests#19 to test this update with minimal interference from additional processing after the blur.  max dE is 1.08, which I checked manually as the result of 707 pixels changing in their least significant bit (i.e. rounding).  It looks like this is due to *less* internal round-off error since the compiler is using FMA instructions instead of the separate multiply and add in the SSE code.  This PR does fail test 0058 with 70 pixels changed and a max dE of 2.7.

