### PR TITLE
exposure: Properly reset the spot mode to correct when changing image.

### DIFF
--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -661,6 +661,8 @@ void gui_update(struct dt_iop_module_t *self)
       break;
   }
 
+  dt_bauhaus_combobox_set(g->spot_mode, 0);
+
   dt_gui_update_collapsible_section(&g->cs);
 }
 


### PR DESCRIPTION
Fixes #13701.