### PR TITLE
filmic.c(legacy): optimize and remove SSE

### DIFF
--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -495,19 +495,27 @@ static inline void dt_XYZ_to_prophotorgb(const dt_aligned_pixel_t XYZ, dt_aligne
   dt_apply_transposed_color_matrix(XYZ,xyz_to_rgb_transpose,rgb);
 }
 
+// transpose and pad the conversion matrix to enable vectorization
+static const dt_colormatrix_t prophotorgb_to_xyz_transpose = {
+  // prophoto rgb
+  { 0.7976749f, 0.2880402f, 0.0000000f, 0.0f },
+  { 0.1351917f, 0.7118741f, 0.0000000f, 0.0f },
+  { 0.0313534f, 0.0000857f, 0.8252100f, 0.0f }
+};
+
 #ifdef _OPENMP
 #pragma omp declare simd aligned(rgb, XYZ)
 #endif
 static inline void dt_prophotorgb_to_XYZ(const dt_aligned_pixel_t rgb, dt_aligned_pixel_t XYZ)
 {
-  // transpose and pad the conversion matrix to enable vectorization
-  static const dt_colormatrix_t rgb_to_xyz_transpose = {
-    // prophoto rgb
-    { 0.7976749f, 0.2880402f, 0.0000000f, 0.0f },
-    { 0.1351917f, 0.7118741f, 0.0000000f, 0.0f },
-    { 0.0313534f, 0.0000857f, 0.8252100f, 0.0f }
-  };
-  dt_apply_transposed_color_matrix(rgb,rgb_to_xyz_transpose,XYZ);
+  dt_apply_transposed_color_matrix(rgb,prophotorgb_to_xyz_transpose,XYZ);
+}
+
+static inline float dt_prophotorgb_to_XYZ_luma(const dt_aligned_pixel_t rgb)
+{
+  return (prophotorgb_to_xyz_transpose[0][1] * rgb[0]
+          + prophotorgb_to_xyz_transpose[1][1] * rgb[1]
+          + prophotorgb_to_xyz_transpose[2][1] * rgb[2]);
 }
 
 // Conversion matrix from http://www.brucelindbloom.com/Eqn_RGB_XYZ_Matrix.html

--- a/src/common/sse.h
+++ b/src/common/sse.h
@@ -41,14 +41,15 @@ static inline __m128 _mm_exp2_ps(__m128 x)
   __m128i ipart;
   __m128 fpart, expipart, expfpart;
 
+  /* clamp the exponent to the suppported range */
   x = _mm_min_ps(x, _mm_set1_ps(129.00000f));
   x = _mm_max_ps(x, _mm_set1_ps(-126.99999f));
 
   /* ipart = int(x - 0.5) */
-  ipart = _mm_cvtps_epi32(_mm_sub_ps(x, _mm_set1_ps(0.5f)));
+  ipart = _mm_cvtps_epi32(x - _mm_set1_ps(0.5f));
 
   /* fpart = x - ipart */
-  fpart = _mm_sub_ps(x, _mm_cvtepi32_ps(ipart));
+  fpart = x - _mm_cvtepi32_ps(ipart);
 
   /* expipart = (float) (1 << ipart) */
   expipart = _mm_castsi128_ps(_mm_slli_epi32(_mm_add_epi32(ipart, _mm_set1_epi32(127)), 23));
@@ -110,9 +111,7 @@ static inline __m128 _mm_log2_ps(__m128 x)
 #endif
 
   /* This effectively increases the polynomial degree by one, but ensures that log2(1) == 0*/
-  logmant = _mm_mul_ps(logmant, _mm_sub_ps(mant, one));
-
-  return _mm_add_ps(logmant, exp);
+  return (logmant * (mant - one)) + exp;
 }
 
 static inline __m128 _mm_pow_ps(__m128 x, __m128 y)

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -46,10 +46,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef __SSE2__
-#include "common/sse.h"
-#endif
-
 #define DT_GUI_CURVE_EDITOR_INSET DT_PIXEL_APPLY_DPI(1)
 
 
@@ -172,7 +168,7 @@ int default_group()
 
 int flags()
 {
-  return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING /*| IOP_FLAGS_DEPRECATED*/;
+  return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_DEPRECATED;
 }
 
 const char *deprecated_msg()
@@ -531,131 +527,6 @@ void process(dt_iop_module_t *self,
   }
   dt_omploop_sfence();
 }
-
-
-#if defined(__SSE__)
-void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
-             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
-{
-  dt_iop_filmic_data_t *const data = (dt_iop_filmic_data_t *)piece->data;
-
-  const int ch = piece->colors;
-  const int preserve_color = data->preserve_color;
-
-  const float grey = data->grey_source;
-  const float black = data->black_source;
-  const float dynamic_range = data->dynamic_range;
-  const float saturation = (data->global_saturation / 100.0f);
-
-  const __m128 grey_sse = _mm_set1_ps(grey);
-  const __m128 black_sse = _mm_set1_ps(black);
-  const __m128 dynamic_range_sse = _mm_set1_ps(dynamic_range);
-  const __m128 power = _mm_set1_ps(data->output_power);
-  const __m128 saturation_sse = _mm_set1_ps(saturation);
-
-  // If saturation == 100, we have a no-op. Disable the op then.
-  const int desaturate = (data->global_saturation == 100.0f) ? FALSE : TRUE;
-
-  const float eps = powf(2.0f, -16);
-  const __m128 EPS = _mm_setr_ps(eps, eps, eps, 0.0f);
-  const __m128 zero = _mm_setzero_ps();
-  const __m128 one = _mm_set1_ps(1.0f);
-
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(black, black_sse, ch, data, desaturate, dynamic_range, \
-                      dynamic_range_sse, EPS, grey, grey_sse, ivoid, one, \
-                      ovoid, power, preserve_color, roi_out, saturation_sse, \
-                      zero, eps) \
-  schedule(static)
-#endif
-  for(size_t k = 0; k < (size_t)roi_out->height * roi_out->width * ch; k += ch)
-  {
-    float *in = ((float *)ivoid) + k;
-    float *out = ((float *)ovoid) + k;
-
-    __m128 XYZ = dt_Lab_to_XYZ_sse2(_mm_load_ps(in));
-    __m128 rgb = dt_XYZ_to_prophotoRGB_sse2(XYZ);
-
-    __m128 concavity;
-    __m128 luma;
-
-    // Global saturation adjustment
-    if(desaturate)
-    {
-      luma = _mm_set1_ps(XYZ[1]);
-      rgb = luma + saturation_sse * (rgb - luma);
-    }
-
-    if(preserve_color)
-    {
-      // Get the max of the RGB values
-      float max = MAX(MAX(rgb[0], rgb[1]), rgb[2]);
-      __m128 max_sse = _mm_set1_ps(max);
-
-      // Save the ratios
-      const __m128 ratios = rgb / max_sse;
-
-      // Log tone-mapping
-      max = max / grey;
-      max = (max > eps) ? (fastlog2(max) - black) / dynamic_range : eps;
-      max = CLAMP(max, 0.0f, 1.0f);
-
-      // Filmic S curve on the max RGB
-      const int index = CLAMP(max * 0x10000ul, 0, 0xffff);
-      max = data->table[index];
-      concavity = _mm_set1_ps(data->grad_2[index]);
-
-      // Re-apply ratios
-      max_sse = _mm_set1_ps(max);
-      rgb = ratios * max_sse;
-      luma = max_sse;
-    }
-    else
-    {
-      // Log tone-mapping
-      rgb = rgb / grey_sse;
-      rgb = _mm_max_ps(rgb, EPS);
-      rgb = _mm_log2_ps(rgb);
-      rgb -= black_sse;
-      rgb /=  dynamic_range_sse;
-      rgb = _mm_max_ps(rgb, zero);
-      rgb = _mm_min_ps(rgb, one);
-
-      // Store the derivative at the pixel luminance
-      XYZ = dt_prophotoRGB_to_XYZ_sse2(rgb);
-      concavity = _mm_set1_ps(data->grad_2[(int)CLAMP(XYZ[1] * 0x10000ul, 0, 0xffff)]);
-
-      // Unpack SSE vector to regular array
-      dt_aligned_pixel_t rgb_unpack;
-
-      // Filmic S curve
-      for(int c = 0; c < 4; ++c)
-      {
-        rgb_unpack[c] = data->table[(int)CLAMP(rgb[c] * 0x10000ul, 0, 0xffff)];
-      }
-
-      rgb = _mm_load_ps(rgb_unpack);
-      XYZ = dt_prophotoRGB_to_XYZ_sse2(rgb);
-      luma = _mm_set1_ps(XYZ[1]);
-    }
-
-    rgb = luma + concavity * (rgb - luma);
-    rgb = _mm_max_ps(rgb, zero);
-    rgb = _mm_min_ps(rgb, one);
-
-    // Apply the transfer function of the display
-    rgb = _mm_pow_ps(rgb, power);
-
-    // transform the result back to Lab
-    // sRGB -> XYZ
-    XYZ = dt_prophotoRGB_to_XYZ_sse2(rgb);
-    // XYZ -> Lab
-    _mm_stream_ps(out, dt_XYZ_to_Lab_sse2(XYZ));
-  }
-}
-#endif
-
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,


### PR DESCRIPTION
Plain C codepath is now on par with SSE code:
```
Thr	SSE	PR
1	659.55	672.29	+1.9%
2	328.14	336.21	+2.4%
4	165.80	169.73	+2.4%
8	 83.49	85.99	+2.9%
16	 41.87	42.93	+2.3%
32	 23.63	21.81	-7.7% (median of five runs)
64	 13.54	14.40	+6.3% (median of five runs)
```
The new test in PR https://github.com/darktable-org/darktable-tests/pull/20 passes with max dE 1.19 (differing round-offs).
