### PR TITLE
eaw.c: optimize function eaw_synthesize, drop SSE version

### DIFF
--- a/src/common/eaw.h
+++ b/src/common/eaw.h
@@ -37,9 +37,6 @@ void eaw_synthesize(float *const restrict out, const float *const restrict in, c
 
 void eaw_decompose_sse2(float *const restrict out, const float *const restrict in, float *const restrict detail,
                         const int scale, const float sharpen, const int32_t width, const int32_t height);
-void eaw_synthesize_sse2(float *const restrict out, const float *const restrict in, const float *const restrict detail,
-                         const float *const restrict thrsf, const float *const restrict boostf,
-                         const int32_t width, const int32_t height);
 
 typedef void((*eaw_dn_decompose_t)(float *const restrict out, const float *const restrict in, float *const restrict detail,
                                    dt_aligned_pixel_t sum_squared, const int scale, const float inv_sigma2,

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -330,7 +330,7 @@ void process(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
 void process_sse2(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
                   void *const o, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
-  process_wavelets(self, piece, i, o, roi_in, roi_out, eaw_decompose_sse2, eaw_synthesize_sse2);
+  process_wavelets(self, piece, i, o, roi_in, roi_out, eaw_decompose_sse2, eaw_synthesize);
 }
 #endif
 


### PR DESCRIPTION
The optimized plain C version is now on par speed-wise, so drop the SSE version.
Working on a PR for the paired eaw_decompose function, but that's been giving me trouble.
