### PR TITLE
Bugfix/issue 13856

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,11 +7,6 @@ cmake_policy(SET CMP0048 NEW)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules/")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/")
 
-find_program(CCACHE_FOUND ccache)
-if(CCACHE_FOUND)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-endif(CCACHE_FOUND)
-
 ### Add defaults for cmake
 # These defaults need to be included before the project() call.
 include(DefineCMakeDefaults)

--- a/build.sh
+++ b/build.sh
@@ -31,6 +31,7 @@ DO_CONFIG=1
 DO_BUILD=1
 DO_INSTALL=0
 SUDO=""
+CMAKE_OPTIONS_FROM_CMDLINE=""
 
 PRINT_HELP=0
 
@@ -120,6 +121,10 @@ parse_args()
 		-h|--help)
 			PRINT_HELP=1
 			;;
+		--)
+			shift
+			CMAKE_OPTIONS_FROM_CMDLINE="$@"
+			;;
 		*)
 			echo "warning: ignoring unknown option $option"
 			;;
@@ -135,7 +140,7 @@ parse_args()
 print_help()
 {
 	cat <<EOF
-$(basename $0) [OPTIONS]
+$(basename $0) [OPTIONS] [-- [additional cmake configuration options...]]
 
 Options:
 Installation:
@@ -169,6 +174,9 @@ Cleanup actions:
    --clean-all                Clean both build and install directories
 -f --force                    Force clean-build to perform removal
                               ignoring any errors
+
+Additional cmake configuration options:
+Options passed as is to the cmake configure command
 
 Features:
 By default cmake will enable the features it autodetects on the build machine.
@@ -362,7 +370,7 @@ if [ $ADDRESS_SANITIZER -ne 0 ] ; then
 fi
 
 
-cmd_config="${ASAN_FLAGS}cmake -G \"$BUILD_GENERATOR\" -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${CMAKE_MORE_OPTIONS} \"$DT_SRC_DIR\""
+cmd_config="${ASAN_FLAGS}cmake -G \"$BUILD_GENERATOR\" -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${CMAKE_MORE_OPTIONS} ${CMAKE_OPTIONS_FROM_CMDLINE} \"$DT_SRC_DIR\""
 cmd_build="cmake --build "$BUILD_DIR" -- -j$MAKE_TASKS"
 cmd_install="${SUDO}cmake --build \"$BUILD_DIR\" --target install -- -j$MAKE_TASKS"
 


### PR DESCRIPTION
The automatic ccache handling is removed.

The purpose of the changes made to build.sh is to give a way to users to specify the CMake 3.17 CMAKE_(C|CXX)_LAUNCHER_PROGRAM config variables if they wish to enable a caching program. 

This should address all  concerns form  #13856.