### PR TITLE
[GUI] Add a translation context to the word fill

### DIFF
--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -98,7 +98,7 @@ static void _lib_navigation_control_redraw_callback(gpointer instance, gpointer 
   const float cur_scale = dt_dev_get_zoom_scale(dev, zoom, 1<<closeup, 0);
 
   gchar *zoomline = zoom == DT_ZOOM_FIT ? g_strdup(_("fit"))
-                  : zoom == DT_ZOOM_FILL ? g_strdup(_("fill"))
+                  : zoom == DT_ZOOM_FILL ? g_strdup(C_("navigationbox", "fill"))
                   : 0.5 * dt_dev_get_zoom_scale(dev, DT_ZOOM_FIT, 1.0, 0)
                     == dt_dev_get_zoom_scale(dev, DT_ZOOM_FREE, 1.0, 0) ? g_strdup(_("small"))
                   : g_strdup_printf("%.0f%%", cur_scale * 100 * darktable.gui->ppd);
@@ -168,7 +168,7 @@ void gui_init(dt_lib_module_t *self)
                                -1, _zoom_changed, NULL,
                                N_("small"),
                                N_("fit"),
-                               N_("fill"),
+                               NC_("navigationbox", "fill"),
                                N_("50%"),
                                N_("100%"),
                                N_("200%"),


### PR DESCRIPTION
The word `fill` has two translations into Ukrainian. The first translation ("_заповнити_") is more general, it can mean the filling of something in all senses. It can be filling a space with something until it is full (the root of the translation word can be translated back into English as full). It can be filling a certain shape with color/paint as well.

Another translation ("_залити_") refers only to the act of filling a form with liquid, the root of the translation word can be translated back into English as pour or flood (obviously a figurative reference to filling a form with liquid paint). This word is used in the translation of 'fill' in the retouch module. I want to emphasize that the choice of translation in the retouch module was not random, the same term was chosen that was used in the official translation of Adobe Photoshop.

As a result, we now have a situation where the translation of the word fill in the navigation module is completely inappropriate, because we do not "pour" the image into the navigation box

Of course, it is possible to change the translation in the retouch module. But this is not very good because:
- Term consistency with official Adobe terminology is lost.
- The term I used is already to some extent a standard term in Ukrainian for form/shape filling operations in graphic editors, in retouching. It is found here much more often than the more universal version of the translation.