### PR TITLE
rgblevels: add nontemporal writes and optimize OpenMP loop

### DIFF
--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -1207,8 +1207,12 @@ static void _auto_levels(const float *const img, const int width, const int heig
   p->levels[channel][1] = (p->levels[channel][2] + p->levels[channel][0]) / 2.f;
 }
 
-void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
-             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+void process(dt_iop_module_t *self,
+             dt_dev_pixelpipe_iop_t *piece,
+             const void *const ivoid,
+             void *const ovoid,
+             const dt_iop_roi_t *const roi_in,
+             const dt_iop_roi_t *const roi_out)
 {
   if(!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece->colors,
                                          ivoid, ovoid, roi_in, roi_out))
@@ -1233,7 +1237,8 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
       int box[4] = { 0 };
       _get_selected_area(self, piece, g, roi_in, box);
-      _auto_levels((const float *const)ivoid, roi_in->width, roi_in->height, box, &(g->params), g->channel, work_profile);
+      _auto_levels((const float *const)ivoid, roi_in->width, roi_in->height, box,
+                   &(g->params), g->channel, work_profile);
 
       dt_iop_gui_enter_critical_section(self);
       g->call_auto_levels = 2;
@@ -1252,11 +1257,16 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   const size_t npixels = (size_t)roi_out->width * roi_out->height;
   const float *const restrict in = (const float*)ivoid;
   float *const restrict out = (float*)ovoid;
-  if(d->params.autoscale == DT_IOP_RGBLEVELS_INDEPENDENT_CHANNELS || d->params.preserve_colors == DT_RGB_NORM_NONE)
+  if(d->params.autoscale == DT_IOP_RGBLEVELS_INDEPENDENT_CHANNELS
+     || d->params.preserve_colors == DT_RGB_NORM_NONE)
   {
+    const dt_aligned_pixel_t min_levels
+      = { d->params.levels[0][0], d->params.levels[1][0], d->params.levels[2][0], 0.0f };
+    const dt_aligned_pixel_t max_levels
+      = { d->params.levels[0][2], d->params.levels[1][2], d->params.levels[2][2], 1.0f };
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(npixels, in, out, work_profile, d, mult) \
+  dt_omp_firstprivate(npixels, in, out, work_profile, d, mult, min_levels, max_levels) \
   schedule(static)
 #endif
     for(int k = 0; k < 4U*npixels; k += 4)
@@ -1265,20 +1275,21 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
       {
         const float L_in = in[k+c];
 
-        if(L_in <= d->params.levels[c][0])
+        if(L_in <= min_levels[c])
         {
           // Anything below the lower threshold just clips to zero
           out[k+c] = 0.0f;
         }
-        else if(L_in >= d->params.levels[c][2])
+        else if(L_in >= max_levels[c])
         {
-          const float percentage = (L_in - d->params.levels[c][0]) * mult[c];
+          // above the upper limit we extrapolate using the gamma value
+          const float percentage = (L_in - min_levels[c]) * mult[c];
           out[k+c] = powf(percentage, d->inv_gamma[c]);
         }
         else
         {
           // Within the expected input range we can use the lookup table
-          const float percentage = (L_in - d->params.levels[c][0]) * mult[c];
+          const float percentage = (L_in - min_levels[c]) * mult[c];
           out[k+c] = d->lut[c][CLAMP((int)(percentage * 0x10000ul), 0, 0xffff)];
         }
       }
@@ -1289,19 +1300,23 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     const int ch_levels = 0;
     const float mult_ch = mult[ch_levels];
     const float *const restrict levels = d->params.levels[ch_levels];
+    const float min_level = levels[0];
+    const float max_level = levels[2];
+    static const dt_aligned_pixel_t zero = { 0.0f, 0.0f, 0.0f, 0.0f };
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(npixels, in, out, work_profile, d, levels, mult_ch, ch_levels) \
+  dt_omp_firstprivate(npixels, in, out, work_profile, d, min_level, max_level, \
+                      mult_ch, ch_levels, zero)                         \
   schedule(static)
 #endif
     for(int k = 0; k < 4U*npixels; k += 4)
     {
       const float lum = dt_rgb_norm(in+k, d->params.preserve_colors, work_profile);
-      if(lum > levels[0])
+      if(lum > min_level)
       {
         float curve_lum;
-        const float percentage = (lum - levels[0]) * mult_ch;
-        if(lum >= levels[2])
+        const float percentage = (lum - min_level) * mult_ch;
+        if(lum >= max_level)
         {
           curve_lum = powf(percentage, d->inv_gamma[ch_levels]);
         }
@@ -1312,18 +1327,20 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
         }
 
         const float ratio = curve_lum / lum;
+        dt_aligned_pixel_t res;
 
         for_each_channel(c,aligned(in,out:16))
         {
-          out[k+c] = (ratio * in[k+c]);
+          res[c] = (ratio * in[k+c]);
         }
+        copy_pixel_nontemporal(out + k, res);
       }
       else
       {
-        for_each_channel(c,aligned(out:16))
-          out[k+c] = 0.f;
+        copy_pixel_nontemporal(out + k, zero);
       }
-   }
+    }
+    dt_omploop_sfence(); // ensure nontemporal writes are flushed before continuing
   }
 }
 

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -1282,7 +1282,6 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
           out[k+c] = d->lut[c][CLAMP((int)(percentage * 0x10000ul), 0, 0xffff)];
         }
       }
-      out[k+3] = in[k+3];
     }
   }
   else
@@ -1324,7 +1323,6 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
         for_each_channel(c,aligned(out:16))
           out[k+c] = 0.f;
       }
-      out[k+3] = in[k+3];
    }
   }
 }


### PR DESCRIPTION
Linked channels benefit quite a bit from nontemporal writes at higher thread counts due to the lower memory bandwidth from not loading cache lines.
```
Thr	Master	PR
1	42.92	41.15	 -4.1%
2	22.14	21.26	 -3.9%
4	11.35	10.67	 -6.0%
8	 6.51	 5.50	-15.5%
16	 6.47	 4.09	-36.7%
32	 6.64	 4.24	-36.1%
```
Independent channels are not using nontemporal writes, so come out within measurement error.  I tried nontemporal writes here as well, but they only benefited 16+ threads and were 50% slower at 2 threads due to an extra memory write (which never gets beyond L1 cache, so adds clock cycles but not RAM traffic which is the limiting factor at high thread counts).
```
Thr	Master	PR
1	46.69	46.10
2	23.89	23.98
4	12.53	12.42
8	 7.29	 7.58
16	 6.63	 6.56
32	 6.76	 6.78
```