### PR TITLE
RFC: remove OPENMP_SIMD codepath config

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -324,18 +324,6 @@ static void dt_codepaths_init()
   // last: do we have any intrinsics sets enabled?
   darktable.codepath._no_intrinsics = !(darktable.codepath.SSE2);
 
-// if there is no SSE, we must enable plain codepath by default,
-// else, enable it conditionally.
-#if defined(__SSE__)
-  // disabled by default, needs to be manually enabled if needed.
-  // disabling all optimized codepaths enables it automatically.
-  if(dt_conf_get_bool("codepaths/openmp_simd") || darktable.codepath._no_intrinsics)
-#endif
-  {
-    darktable.codepath.OPENMP_SIMD = 1;
-    dt_print(DT_DEBUG_ALWAYS, "[dt_codepaths_init] will be using experimental plain OpenMP SIMD codepath.\n");
-  }
-
 #if defined(__SSE__)
   if(darktable.codepath._no_intrinsics)
   {

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -286,7 +286,6 @@ typedef struct dt_codepath_t
 {
   unsigned int SSE2 : 1;
   unsigned int _no_intrinsics : 1;
-  unsigned int OPENMP_SIMD : 1; // always stays the last one
 } dt_codepath_t;
 
 typedef struct dt_sys_resources_t

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -533,14 +533,12 @@ static inline void compute_upsampling_kernel_sse(const struct dt_interpolation *
 static inline void compute_upsampling_kernel(const struct dt_interpolation *itor, float *kernel, float *norm,
                                              int *first, float t)
 {
-  if(darktable.codepath.OPENMP_SIMD)
-    return compute_upsampling_kernel_plain(itor, kernel, norm, first, t);
 #if defined(__SSE2__)
-  else if(darktable.codepath.SSE2)
+  if(darktable.codepath.SSE2)
     return compute_upsampling_kernel_sse(itor, kernel, norm, first, t);
 #endif
   else
-    dt_unreachable_codepath();
+    return compute_upsampling_kernel_plain(itor, kernel, norm, first, t);
 }
 
 /** Computes a downsampling filtering kernel
@@ -664,14 +662,12 @@ static inline void compute_downsampling_kernel_sse(const struct dt_interpolation
 static inline void compute_downsampling_kernel(const struct dt_interpolation *itor, int *taps, int *first,
                                                float *kernel, float *norm, float outoinratio, int xout)
 {
-  if(darktable.codepath.OPENMP_SIMD)
-    return compute_downsampling_kernel_plain(itor, taps, first, kernel, norm, outoinratio, xout);
 #if defined(__SSE2__)
-  else if(darktable.codepath.SSE2)
+  if(darktable.codepath.SSE2)
     return compute_downsampling_kernel_sse(itor, taps, first, kernel, norm, outoinratio, xout);
 #endif
   else
-    dt_unreachable_codepath();
+    return compute_downsampling_kernel_plain(itor, taps, first, kernel, norm, outoinratio, xout);
 }
 
 /* --------------------------------------------------------------------------
@@ -973,14 +969,12 @@ void dt_interpolation_compute_pixel4c(const struct dt_interpolation *itor, const
                                       const float x, const float y, const int width, const int height,
                                       const int linestride)
 {
-  if(darktable.codepath.OPENMP_SIMD)
-    return dt_interpolation_compute_pixel4c_plain(itor, in, out, x, y, width, height, linestride);
 #if defined(__SSE2__)
-  else if(darktable.codepath.SSE2)
+  if(darktable.codepath.SSE2)
     return dt_interpolation_compute_pixel4c_sse(itor, in, out, x, y, width, height, linestride);
 #endif
   else
-    dt_unreachable_codepath();
+    return dt_interpolation_compute_pixel4c_plain(itor, in, out, x, y, width, height, linestride);
 }
 
 static void dt_interpolation_compute_pixel1c_plain(const struct dt_interpolation *itor, const float *in,
@@ -1680,14 +1674,12 @@ void dt_interpolation_resample(const struct dt_interpolation *itor, float *out,
     return;
   }
 
-  if(darktable.codepath.OPENMP_SIMD)
-    return dt_interpolation_resample_plain(itor, out, roi_out, out_stride, in, roi_in, in_stride);
 #if defined(__SSE2__)
-  else if(darktable.codepath.SSE2)
+  if(darktable.codepath.SSE2)
     return dt_interpolation_resample_sse(itor, out, roi_out, out_stride, in, roi_in, in_stride);
 #endif
   else
-    dt_unreachable_codepath();
+    return dt_interpolation_resample_plain(itor, out, roi_out, out_stride, in, roi_in, in_stride);
 }
 
 /** Applies resampling (re-scaling) on a specific region-of-interest of an image. The input

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -201,13 +201,12 @@ static void default_process(struct dt_iop_module_t *self,
 {
   if(roi_in->width <= 1 || roi_in->height <= 1 || roi_out->width <= 1 || roi_out->height <= 1) return;
 
-  if(darktable.codepath.OPENMP_SIMD && self->process_plain)
-    self->process_plain(self, piece, i, o, roi_in, roi_out);
 #if defined(__SSE__)
-  else if(darktable.codepath.SSE2 && self->process_sse2)
+  if(darktable.codepath.SSE2 && self->process_sse2)
     self->process_sse2(self, piece, i, o, roi_in, roi_out);
+  else
 #endif
-  else if(self->process_plain)
+  if(self->process_plain)
     self->process_plain(self, piece, i, o, roi_in, roi_out);
   else
     dt_unreachable_codepath_with_desc(self->op);


### PR DESCRIPTION
As we near the end of the SSE removal, we can also remove the remnants of a special code path for OpenMP autovectorization (since there are in fact no cases where we have both autovectorized and unvectorized code paths).