### PR TITLE
dedup dt_alloc_sse_ps

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -471,11 +471,6 @@ static inline gboolean dt_is_aligned(const void *pointer, size_t byte_count)
     return (uintptr_t)pointer % byte_count == 0;
 }
 
-static inline void * dt_alloc_sse_ps(size_t pixels)
-{
-  return __builtin_assume_aligned(dt_alloc_align(64, pixels * sizeof(float)), 64);
-}
-
 static inline void * dt_check_sse_aligned(void * pointer)
 {
   if(dt_is_aligned(pointer, 64))

--- a/src/common/eigf.h
+++ b/src/common/eigf.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2019-2020 darktable developers.
+    Copyright (C) 2019-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -74,7 +74,7 @@ static inline void eigf_variance_analysis(const float *const restrict guide, // 
 {
   // We also use gaussian blurs instead of the square blurs of the guided filter
   const size_t Ndim = width * height;
-  float *const restrict in = dt_alloc_sse_ps(Ndim * 4);
+  float *const restrict in = dt_alloc_align_float(Ndim * 4);
 
   float ming = 10000000.0f;
   float maxg = 0.0f;
@@ -141,7 +141,7 @@ static inline void eigf_variance_analysis_no_mask(const float *const restrict gu
 {
   // We also use gaussian blurs instead of the square blurs of the guided filter
   const size_t Ndim = width * height;
-  float *const restrict in = dt_alloc_sse_ps(Ndim * 2);
+  float *const restrict in = dt_alloc_align_float(Ndim * 2);
 
   float ming = 10000000.0f;
   float maxg = 0.0f;
@@ -276,12 +276,12 @@ static inline void fast_eigf_surface_blur(float *const restrict image,
   const size_t num_elem_ds = ds_width * ds_height;
   const size_t num_elem = width * height;
 
-  float *const restrict mask = dt_alloc_sse_ps(dt_round_size_sse(num_elem));
-  float *const restrict ds_image = dt_alloc_sse_ps(dt_round_size_sse(num_elem_ds));
-  float *const restrict ds_mask = dt_alloc_sse_ps(dt_round_size_sse(num_elem_ds));
+  float *const restrict mask = dt_alloc_align_float(dt_round_size_sse(num_elem));
+  float *const restrict ds_image = dt_alloc_align_float(dt_round_size_sse(num_elem_ds));
+  float *const restrict ds_mask = dt_alloc_align_float(dt_round_size_sse(num_elem_ds));
   // average - variance arrays: store the guide and mask averages and variances
-  float *const restrict ds_av = dt_alloc_sse_ps(dt_round_size_sse(num_elem_ds * 4));
-  float *const restrict av = dt_alloc_sse_ps(dt_round_size_sse(num_elem * 4));
+  float *const restrict ds_av = dt_alloc_align_float(dt_round_size_sse(num_elem_ds * 4));
+  float *const restrict av = dt_alloc_align_float(dt_round_size_sse(num_elem * 4));
 
   if(!ds_image || !ds_mask || !ds_av || !av)
   {

--- a/src/common/fast_guided_filter.h
+++ b/src/common/fast_guided_filter.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2019-2021 darktable developers.
+    Copyright (C) 2019-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -306,10 +306,10 @@ static inline void fast_surface_blur(float *const restrict image,
   const size_t num_elem_ds = ds_width * ds_height;
   const size_t num_elem = width * height;
 
-  float *const restrict ds_image = dt_alloc_sse_ps(dt_round_size_sse(num_elem_ds));
-  float *const restrict ds_mask = dt_alloc_sse_ps(dt_round_size_sse(num_elem_ds));
-  float *const restrict ds_ab = dt_alloc_sse_ps(dt_round_size_sse(num_elem_ds * 2));
-  float *const restrict ab = dt_alloc_sse_ps(dt_round_size_sse(num_elem * 2));
+  float *const restrict ds_image = dt_alloc_align_float(dt_round_size_sse(num_elem_ds));
+  float *const restrict ds_mask = dt_alloc_align_float(dt_round_size_sse(num_elem_ds));
+  float *const restrict ds_ab = dt_alloc_align_float(dt_round_size_sse(num_elem_ds * 2));
+  float *const restrict ab = dt_alloc_align_float(dt_round_size_sse(num_elem * 2));
 
   if(!ds_image || !ds_mask || !ds_ab || !ab)
   {

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -948,7 +948,12 @@ static inline void _auto_detect_WB(const float *const restrict in,
    *
   */
 
-   float *const restrict temp = dt_alloc_sse_ps(width * height * ch);
+   float *const restrict temp = dt_alloc_align_float(width * height * ch);
+   if(!temp)
+   {
+     dt_print(DT_DEBUG_ALWAYS,"[auto detect WB] unable to allocate memory, skipping white balance\n");
+     return;
+   }
 
    // Convert RGB to xy
 #ifdef _OPENMP
@@ -1400,7 +1405,7 @@ static const extraction_result_t _extract_patches(const float *const restrict in
   const float radius_y = radius_x / g->checker->ratio;
 
   if(g->delta_E_in == NULL)
-    g->delta_E_in = dt_alloc_sse_ps(g->checker->patches);
+    g->delta_E_in = dt_alloc_align_float(g->checker->patches);
 
   /* Get the average color over each patch */
   for(size_t k = 0; k < g->checker->patches; k++)
@@ -1607,7 +1612,7 @@ void extract_color_checker(const float *const restrict in,
                            const dt_colormatrix_t XYZ_to_CAM,
                            const dt_adaptation_t kind)
 {
-  float *const restrict patches = dt_alloc_sse_ps(g->checker->patches * 4);
+  float *const restrict patches = dt_alloc_align_float(g->checker->patches * 4);
 
   dt_simd_memcpy(in, out, (size_t)roi_in->width * roi_in->height * 4);
 
@@ -1905,7 +1910,7 @@ void validate_color_checker(const float *const restrict in,
                             const dt_colormatrix_t XYZ_to_RGB,
                             const dt_colormatrix_t XYZ_to_CAM)
 {
-  float *const restrict patches = dt_alloc_sse_ps(4 * g->checker->patches);
+  float *const restrict patches = dt_alloc_align_float(4 * g->checker->patches);
   extraction_result_t extraction_result =
     _extract_patches(in, roi_in, g, RGB_to_XYZ, XYZ_to_CAM, patches, FALSE);
 

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1282,13 +1282,17 @@ static inline gint reconstruct_highlights(const float *const restrict in, const 
   const int scales = get_scales(roi_in, piece);
 
   // wavelets scales buffers
-  float *const restrict LF_even = dt_alloc_sse_ps(ch * roi_out->width * roi_out->height); // low-frequencies RGB
-  float *const restrict LF_odd = dt_alloc_sse_ps(ch * roi_out->width * roi_out->height);  // low-frequencies RGB
-  float *const restrict HF_RGB = dt_alloc_sse_ps(ch * roi_out->width * roi_out->height);  // high-frequencies RGB
-  float *const restrict HF_grey = dt_alloc_sse_ps(ch * roi_out->width * roi_out->height); // high-frequencies RGB backup
+  float *const restrict LF_even
+    = dt_alloc_align_float(ch * roi_out->width * roi_out->height);  // low-frequencies RGB
+  float *const restrict LF_odd
+    = dt_alloc_align_float(ch * roi_out->width * roi_out->height);  // low-frequencies RGB
+  float *const restrict HF_RGB
+    = dt_alloc_align_float(ch * roi_out->width * roi_out->height);  // high-frequencies RGB
+  float *const restrict HF_grey
+    = dt_alloc_align_float(ch * roi_out->width * roi_out->height);  // high-frequencies RGB backup
 
   // alloc a permanent reusable buffer for intermediate computations - avoid multiple alloc/free
-  float *const restrict temp = dt_alloc_sse_ps(dt_get_num_threads() * ch * roi_out->width);
+  float *const restrict temp = dt_alloc_align_float(dt_get_num_threads() * ch * roi_out->width);
 
   if(!LF_even || !LF_odd || !HF_RGB || !HF_grey || !temp)
   {
@@ -1941,7 +1945,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
   float *restrict in = (float *)ivoid;
   float *const restrict out = (float *)ovoid;
-  float *const restrict mask = dt_alloc_sse_ps((size_t)roi_out->width * roi_out->height);
+  float *const restrict mask = dt_alloc_align_float((size_t)roi_out->width * roi_out->height);
 
   // used to adjuste noise level depending on size. Don't amplify noise if magnified > 100%
   const float scale = fmaxf(piece->iscale / roi_in->scale, 1.f);

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1064,7 +1064,7 @@ void toneeq_process(struct dt_iop_module_t *self,
       if(g->full_preview_buf_width != width || g->full_preview_buf_height != height)
       {
         if(g->full_preview_buf) dt_free_align(g->full_preview_buf);
-        g->full_preview_buf = dt_alloc_sse_ps(num_elem);
+        g->full_preview_buf = dt_alloc_align_float(num_elem);
         g->full_preview_buf_width = width;
         g->full_preview_buf_height = height;
       }
@@ -1084,7 +1084,7 @@ void toneeq_process(struct dt_iop_module_t *self,
       if(g->thumb_preview_buf_width != width || g->thumb_preview_buf_height != height)
       {
         if(g->thumb_preview_buf) dt_free_align(g->thumb_preview_buf);
-        g->thumb_preview_buf = dt_alloc_sse_ps(num_elem);
+        g->thumb_preview_buf = dt_alloc_align_float(num_elem);
         g->thumb_preview_buf_width = width;
         g->thumb_preview_buf_height = height;
         g->luminance_valid = FALSE;
@@ -1097,14 +1097,14 @@ void toneeq_process(struct dt_iop_module_t *self,
     }
     else // just to please GCC
     {
-      luminance = dt_alloc_sse_ps(num_elem);
+      luminance = dt_alloc_align_float(num_elem);
     }
 
   }
   else
   {
     // no interactive editing/caching : just allocate a local temp buffer
-    luminance = dt_alloc_sse_ps(num_elem);
+    luminance = dt_alloc_align_float(num_elem);
   }
 
   // Check if the luminance buffer exists


### PR DESCRIPTION
dt_alloc_sse_ps() is identical to the more-frequently-used dt_alloc_align_float(), so convert calls to the former so that we have just one function instead of two.