### PR TITLE
atrous: remove process_sse2

### DIFF
--- a/src/common/eaw.c
+++ b/src/common/eaw.c
@@ -132,6 +132,14 @@ static inline __m128 weight_sse2(const __m128 *c1, const __m128 *c2, const float
 void eaw_decompose(float *const restrict out, const float *const restrict in, float *const restrict detail,
                    const int scale, const float sharpen, const int32_t width, const int32_t height)
 {
+#if defined(__SSE2__)
+  if(darktable.codepath.SSE2)
+  {
+    eaw_decompose_sse2(out, in, detail, scale, sharpen, width, height);
+    return;
+  }
+#endif
+
   const int mult = 1 << scale;
   static const float filter[5] = { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
   const int boundary = 2 * mult;

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -326,14 +326,6 @@ void process(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
   process_wavelets(self, piece, i, o, roi_in, roi_out, eaw_decompose, eaw_synthesize);
 }
 
-#if defined(__SSE2__)
-void process_sse2(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
-                  void *const o, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
-{
-  process_wavelets(self, piece, i, o, roi_in, roi_out, eaw_decompose_sse2, eaw_synthesize);
-}
-#endif
-
 #ifdef HAVE_OPENCL
 
 #ifdef USE_NEW_CL


### PR DESCRIPTION
Since the only difference between process_sse and process_sse2 is now the variant of eaw_decompose which is called, we can put that decision inside eaw_decompose and remove process_sse2.  I haven't yet been able to meaningfully narrow the 3x performance gap between plain and SSE code, so we'll need to keep both code paths for now.

This leaves just two IOPs with process_sse2 functions (old non-RGB Color Balance and colorin), for which I've also not yet achieved performance parity.
