### PR TITLE
colorbalance: refactor and optimize

### DIFF
--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -487,12 +487,12 @@ static inline void dt_sRGB_to_linear_sRGB(const dt_aligned_pixel_t sRGB, dt_alig
 static inline void dt_XYZ_to_prophotorgb(const dt_aligned_pixel_t XYZ, dt_aligned_pixel_t rgb)
 {
   // transpose and pad the conversion matrix to enable vectorization
-  static const dt_colormatrix_t xyz_to_rgb_transpose = {
+  static const dt_colormatrix_t xyz_to_prophotorgb_transpose = {
     {  1.3459433f, -0.5445989f, 0.0000000f, 0.0f },
     { -0.2556075f,  1.5081673f, 0.0000000f, 0.0f },
     { -0.0511118f,  0.0205351f, 1.2118128f, 0.0f }
   };
-  dt_apply_transposed_color_matrix(XYZ,xyz_to_rgb_transpose,rgb);
+  dt_apply_transposed_color_matrix(XYZ,xyz_to_prophotorgb_transpose,rgb);
 }
 
 // transpose and pad the conversion matrix to enable vectorization

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -630,11 +630,12 @@ static inline void dt_XYZ_to_sRGB_clipped(const dt_aligned_pixel_t XYZ, dt_align
 #ifdef _OPENMP
 #pragma omp declare simd aligned(Lab, rgb)
 #endif
-static inline void dt_Lab_to_prophotorgb(const dt_aligned_pixel_t Lab, dt_aligned_pixel_t rgb)
+static inline float dt_Lab_to_prophotorgb(const dt_aligned_pixel_t Lab, dt_aligned_pixel_t rgb)
 {
   dt_aligned_pixel_t XYZ = { 0.0f };
   dt_Lab_to_XYZ(Lab, XYZ);
   dt_XYZ_to_prophotorgb(XYZ, rgb);
+  return XYZ[1];
 }
 
 #ifdef _OPENMP

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -532,7 +532,7 @@ static inline void dt_vector_powf(const dt_aligned_pixel_t input,
     for_four_channels(c)
     {
       // Apply the transfer function of the display
-      output[c] = powf(input[c], output[c]);
+      output[c] = powf(input[c], power[c]);
     }
 #endif
 }

--- a/src/develop/openmp_maths.h
+++ b/src/develop/openmp_maths.h
@@ -1,6 +1,6 @@
 /*
    This file is part of darktable,
-   Copyright (C) 2020 - darktable developers.
+   Copyright (C) 2020-2023 - darktable developers.
 
    darktable is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -60,6 +60,12 @@ extern float logf(const float x);
 
 #endif
 
+#if defined(_OPENMP) && defined(__GNUC__) && __GNUC__ >= 10
+
+#pragma omp declare simd
+extern float powf(const float x, const float y);
+
+#endif
 
 /* Bring our own optimized maths functions because Clang makes dumb shit */
 


### PR DESCRIPTION
Not at parity yet performance-wise, but it might be worth dropping the SSE code for the old legacy mode (see discussion below).  The plain C code used to take about twice as long as the SSE code but is now much closer at 3.5-17% slower.  Passes tests 0033, 0034, and new 0105/0106.

legacy sRGB lift/gamma/gain
```
Thr	SSE	Plain
1	698.46	722.90	+3.4%
2	350.28	362.51	+3.4%
4	174.62	181.77	+4.0%
8	 87.47	 90.44	+3.3%
16	 44.98	 45.34	+0.8%
32	 24.95	 22.84	-8.4%
64	 13.47	 13.83	+2.6%
```
lift/gamma/gain mode
```
Thr	SSE	Plain		Plain-Neutral
1	775.54	871.28	+12.3%	532.41	-31.3%
2	387.48	436.42	+12.6%	266.41	-31.2%
4	193.76	219.19	+13.1%	132.98	-31.3%
8	 96.92	109.17	+12.6%	 66.52	-31.3%
16	 49.59	 54.68	+10.2%	 33.34	-32.7%
32	 26.02	 27.54	 +5.8%	 16.70	-35.8%
64	 14.97	 16.85	+12.5%	 10.64	-28.9%
```
slope/offset/power mode
```
Thr	SSE	Plain		Plain-Neutral
1	570.39	668.64	+17.2%	314.85	-44.8%
2	286.32	334.51	+16.8%	157.52	-44.9%
4	143.16	167.28	+16.8%	 79.26	-44.6%
8	 71.63	 83.69	+16.8%	 39.48	-44.8%
16	 37.35	 42.29	+13.2%	 19.75	-47.1%
32	 22.00	 21.72	 -1.2%	  9.96	-54.7%
64	 11.29	 12.89	+14.1%	  7.04	-37.6%
```
Plain-Neutral has the "Master" section set to neutral (constrast = 0, saturations = 100%) to allow skipping parts of the processing.  The pre-existing code does check for those values, but uses exact equality while the actual parameters differ by ~1e-7 after a double-click
reset.  So the code was performing the contrast and saturation computations regardless.

At only about 3% slower and unlikely to be used on many old edits, I would suggest that it's worth dropping the SSE code for the legacy mode.  At 13-17% slower, we should keep the SSE code for the other two modes.  I will be making another PR which also refactors the SSE code and makes the decision which path to use in this module instead of in the pixelpipe code, so that `process_sse2` can be removed.
