### PR TITLE
dt_mm_enable_flush_zero needs to produce value in non-SSE builds

### DIFF
--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -659,7 +659,7 @@ static inline void dt_mm_restore_flush_zero(const unsigned int mode)
 }
 #else
 #define dt_mm_enable_flush_zero() 0
-#define dt_mm_restore_flush_zero(mode)
+#define dt_mm_restore_flush_zero(mode) (void)mode;
 #endif /* __SSE2__ */
 
 #ifdef __cplusplus

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -658,7 +658,7 @@ static inline void dt_mm_restore_flush_zero(const unsigned int mode)
   _MM_SET_FLUSH_ZERO_MODE(mode);
 }
 #else
-#define dt_mm_enable_flush_zero()
+#define dt_mm_enable_flush_zero() 0
 #define dt_mm_restore_flush_zero(mode)
 #endif /* __SSE2__ */
 


### PR DESCRIPTION
Fixes #13877 
