### PR TITLE
remove OpenMP directive for powf

### DIFF
--- a/src/develop/openmp_maths.h
+++ b/src/develop/openmp_maths.h
@@ -60,13 +60,6 @@ extern float logf(const float x);
 
 #endif
 
-#if defined(_OPENMP) && defined(__GNUC__) && __GNUC__ >= 10
-
-#pragma omp declare simd
-extern float powf(const float x, const float y);
-
-#endif
-
 /* Bring our own optimized maths functions because Clang makes dumb shit */
 
 #ifdef _OPENMP


### PR DESCRIPTION
Fixes #13895.

The "simd" directive was added to try making the compiler produce a vectorized powf(), but that is now obsolete anyway with the introduction of dt_vector_powf.