### PR TITLE
colorin: optimize plain codepath, refactor

### DIFF
--- a/src/common/math.h
+++ b/src/common/math.h
@@ -537,6 +537,30 @@ static inline void dt_vector_powf(const dt_aligned_pixel_t input,
 #endif
 }
 
+static inline void dt_vector_min(dt_aligned_pixel_t min,
+                                 const dt_aligned_pixel_t v1,
+                                 const dt_aligned_pixel_t v2)
+{
+#ifdef __SSE__
+  *((__m128*)min) = _mm_max_ps(*((__m128*)v1), *((__m128*)v2));
+#else
+  for_each_channel(c)
+    min[c] = MIN(v1[c], v2[c]);
+#endif
+}
+
+static inline void dt_vector_max(dt_aligned_pixel_t max,
+                                 const dt_aligned_pixel_t v1,
+                                 const dt_aligned_pixel_t v2)
+{
+#ifdef __SSE__
+  *((__m128*)max) = _mm_max_ps(*((__m128*)v1), *((__m128*)v2));
+#else
+  for_each_channel(c)
+    max[c] = MAX(v1[c], v2[c]);
+#endif
+}
+
 static inline float dt_vector_channel_max(const dt_aligned_pixel_t pixel)
 {
   dt_aligned_pixel_t swapRG = { pixel[1], pixel[0], pixel[2], pixel[3] };
@@ -545,6 +569,18 @@ static inline float dt_vector_channel_max(const dt_aligned_pixel_t pixel)
   for_each_channel(c)
     maximum[c] = MAX(MAX(pixel[c], swapRG[c]), swapRB[c]);
   return maximum[0];
+}
+
+static inline void dt_vector_clip(dt_aligned_pixel_t values)
+{
+#ifdef __SSE__
+  static const __m128 zero = { 0.0f, 0.0f, 0.0f, 0.0f };
+  static const __m128 one = { 1.0f, 1.0f, 1.0f, 1.0f };
+  *((__m128*)values) = _mm_min_ps(_mm_max_ps(*((__m128*)values), zero), one);
+#else
+  for_each_channel(c)
+    values[c] = CLIP(values[c]);
+#endif
 }
 
 

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -678,6 +678,7 @@ static inline void apply_blue_mapping(const float *const in, float *const out)
   }
 }
 
+// legacy processing (IOP versions 1 and 2, 2014 and earlier)
 static void process_cmatrix_bm(struct dt_iop_module_t *self,
                                dt_dev_pixelpipe_iop_t *piece,
                                const void *const ivoid,
@@ -754,6 +755,7 @@ static void process_cmatrix_bm(struct dt_iop_module_t *self,
 }
 
 #if defined(__SSE2__)
+// legacy processing (IOP versions 1 and 2, 2014 and earlier)
 static void process_sse2_cmatrix_bm(struct dt_iop_module_t *self,
                                     dt_dev_pixelpipe_iop_t *piece,
                                     const void *const ivoid,
@@ -1221,6 +1223,7 @@ static void process_cmatrix(struct dt_iop_module_t *self,
   }
 }
 
+// legacy processing (IOP versions 1 and 2, 2014 and earlier)
 static void process_lcms2_bm(struct dt_iop_module_t *self,
                              dt_dev_pixelpipe_iop_t *piece,
                              const void *const ivoid,

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -771,39 +771,41 @@ static void _cmatrix_fastpath_simple(float *const restrict out,
   }
 }
 
-static void process_cmatrix_fastpath_simple(struct dt_iop_module_t *self,
-                                            dt_dev_pixelpipe_iop_t *piece,
-                                            const void *const ivoid,
-                                            void *const ovoid,
-                                            const dt_iop_roi_t *const roi_in,
-                                            const dt_iop_roi_t *const roi_out)
+#ifdef __SSE2__
+static inline void _cmatrix_fastpath_clipping_sse(float *const restrict out,
+                                                  const float *const restrict in,
+                                                  size_t npixels,
+                                                  const dt_colormatrix_t nmatrix,
+                                                  const dt_colormatrix_t lmatrix)
 {
-  const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
-  assert(piece->colors == 4);
+  // only color matrix. use our optimized fast path!
+  const __m128 nm0 = _mm_set_ps(0.0f, nmatrix[2][0], nmatrix[1][0], nmatrix[0][0]);
+  const __m128 nm1 = _mm_set_ps(0.0f, nmatrix[2][1], nmatrix[1][1], nmatrix[0][1]);
+  const __m128 nm2 = _mm_set_ps(0.0f, nmatrix[2][2], nmatrix[1][2], nmatrix[0][2]);
 
-  const size_t npixels = (size_t)roi_out->width * roi_out->height;
-  const float *const restrict in = (float*)ivoid;
-  float *const restrict  out = (float*)ovoid;
-  
-#ifdef _OPENMP
-  // figure out the number of pixels each thread needs to process
-  // round up to a multiple of 4 pixels so that each chunk starts aligned(64)
-  const size_t nthreads = dt_get_num_threads();
-  const size_t chunksize = 4 * (((npixels / nthreads) + 3) / 4);
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(in, out, npixels, chunksize, nthreads, d)  \
-  schedule(static)
-  for(size_t chunk = 0; chunk < nthreads; chunk++)
+  const __m128 lm0 = _mm_set_ps(0.0f, lmatrix[2][0], lmatrix[1][0], lmatrix[0][0]);
+  const __m128 lm1 = _mm_set_ps(0.0f, lmatrix[2][1], lmatrix[1][1], lmatrix[0][1]);
+  const __m128 lm2 = _mm_set_ps(0.0f, lmatrix[2][2], lmatrix[1][2], lmatrix[0][2]);
+
+  // this function is called from inside a parallel for loop, so no need for further parallelization
+  for(size_t k = 0; k < npixels; k++)
   {
-    size_t start = chunksize * dt_get_thread_num();
-    size_t end = MIN(start + chunksize, npixels);
-    _cmatrix_fastpath_simple(out + 4*start, in + 4*start, end-start, d->cmatrix);
+    __m128 input = _mm_load_ps(in + 4*k);
+    // convert to gamut space
+    __m128 nrgb = ((nm0 * _mm_shuffle_ps(input, input, _MM_SHUFFLE(0, 0, 0, 0))) +
+                   (nm1 * _mm_shuffle_ps(input, input, _MM_SHUFFLE(1, 1, 1, 1))) +
+                   (nm2 * _mm_shuffle_ps(input, input, _MM_SHUFFLE(2, 2, 2, 2))));
+    // clip to gamut
+    __m128 crgb = _mm_min_ps(_mm_max_ps(nrgb, _mm_set1_ps(0.0f)), _mm_set1_ps(1.0f));
+    // convert to output space
+    __m128 xyz = ((lm0 * _mm_shuffle_ps(crgb, crgb, _MM_SHUFFLE(0, 0, 0, 0))) +
+                  (lm1 * _mm_shuffle_ps(crgb, crgb, _MM_SHUFFLE(1, 1, 1, 1))) +
+                  (lm2 * _mm_shuffle_ps(crgb, crgb, _MM_SHUFFLE(2, 2, 2, 2))));
+    _mm_stream_ps(out + 4*k, dt_XYZ_to_Lab_sse2(xyz));
   }
-  dt_omploop_sfence();
-#else
-  _cmatrix_fastpath_simple(out, in, npixels, d->cmatrix);
-#endif
+  _mm_sfence();
 }
+#endif
 
 static inline void _cmatrix_fastpath_clipping(float *const restrict out,
                                               const float *const restrict in,
@@ -811,6 +813,13 @@ static inline void _cmatrix_fastpath_clipping(float *const restrict out,
                                               const dt_colormatrix_t nmatrix,
                                               const dt_colormatrix_t lmatrix)
 {
+#ifdef __SSE2__
+  if(darktable.codepath.SSE2)
+  {
+    _cmatrix_fastpath_clipping_sse(out, in, npixels, nmatrix, lmatrix);
+    return;
+  }
+#endif
   const dt_aligned_pixel_t nmatrix_row0 = { nmatrix[0][0], nmatrix[1][0], nmatrix[2][0], 0.0f };
   const dt_aligned_pixel_t nmatrix_row1 = { nmatrix[0][1], nmatrix[1][1], nmatrix[2][1], 0.0f };
   const dt_aligned_pixel_t nmatrix_row2 = { nmatrix[0][2], nmatrix[1][2], nmatrix[2][2], 0.0f };
@@ -837,15 +846,16 @@ static inline void _cmatrix_fastpath_clipping(float *const restrict out,
   }
 }
 
-static void process_cmatrix_fastpath_clipping(struct dt_iop_module_t *self,
-                                              dt_dev_pixelpipe_iop_t *piece,
-                                              const void *const ivoid,
-                                              void *const ovoid,
-                                              const dt_iop_roi_t *const roi_in,
-                                              const dt_iop_roi_t *const roi_out)
+static void process_cmatrix_fastpath(struct dt_iop_module_t *self,
+                                     dt_dev_pixelpipe_iop_t *piece,
+                                     const void *const ivoid,
+                                     void *const ovoid,
+                                     const dt_iop_roi_t *const roi_in,
+                                     const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
   assert(piece->colors == 4);
+  const int clipping = (d->nrgb != NULL);
 
   const size_t npixels = (size_t)roi_out->width * roi_out->height;
   const float *const restrict in = (float*)ivoid;
@@ -857,40 +867,61 @@ static void process_cmatrix_fastpath_clipping(struct dt_iop_module_t *self,
   const size_t nthreads = dt_get_num_threads();
   const size_t chunksize = 4 * (((npixels / nthreads) + 3) / 4);
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(in, out, npixels, chunksize, nthreads, d)  \
+  dt_omp_firstprivate(in, out, npixels, chunksize, nthreads, d, clipping)  \
   schedule(static)
   for(size_t chunk = 0; chunk < nthreads; chunk++)
   {
     size_t start = chunksize * dt_get_thread_num();
     size_t end = MIN(start + chunksize, npixels);
-    _cmatrix_fastpath_clipping(out + 4*start, in + 4*start, end-start, d->nmatrix, d->lmatrix);
+    if(clipping)
+      _cmatrix_fastpath_clipping(out + 4*start, in + 4*start, end-start, d->nmatrix, d->lmatrix);
+    else
+      _cmatrix_fastpath_simple(out + 4*start, in + 4*start, end-start, d->cmatrix);
   }
-#else
-  _cmatrix_fastpath_clipping(out, in, npixels, d->nmatrix, d->lmatrix);
+#else // no OpenMP
+  if(clipping)
+    _cmatrix_fastpath_clipping(out, in, npixels, d->nmatrix, d->lmatrix);
+  else
+    _cmatrix_fastpath_simple(out, in, npixels, d->cmatrix);
 #endif
   // ensure that all nontemporal writes have been flushed to RAM before we return
   dt_omploop_sfence();
 }
 
-static void process_cmatrix_fastpath(struct dt_iop_module_t *self,
-                                     dt_dev_pixelpipe_iop_t *piece,
-                                     const void *const ivoid,
-                                     void *const ovoid,
-                                     const dt_iop_roi_t *const roi_in,
-                                     const dt_iop_roi_t *const roi_out)
+#ifdef __SSE2__
+static void _cmatrix_proper_simple_sse(float *const restrict out,
+                                       const float *const restrict in,
+                                       size_t npixels,
+                                       const dt_iop_colorin_data_t *const d,
+                                       const dt_colormatrix_t cmatrix)
 {
-  const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
-  const int clipping = (d->nrgb != NULL);
+  const __m128 cm0 = _mm_set_ps(0.0f, d->cmatrix[2][0], d->cmatrix[1][0], d->cmatrix[0][0]);
+  const __m128 cm1 = _mm_set_ps(0.0f, d->cmatrix[2][1], d->cmatrix[1][1], d->cmatrix[0][1]);
+  const __m128 cm2 = _mm_set_ps(0.0f, d->cmatrix[2][2], d->cmatrix[1][2], d->cmatrix[0][2]);
 
-  if(!clipping)
+  // this function is called from inside a parallel for loop, so no need for further parallelization
+  for(size_t k = 0; k < npixels; k++)
   {
-    process_cmatrix_fastpath_simple(self, piece, ivoid, ovoid, roi_in, roi_out);
-  }
-  else
-  {
-    process_cmatrix_fastpath_clipping(self, piece, ivoid, ovoid, roi_in, roi_out);
+    dt_aligned_pixel_t cam;
+
+    // memcpy(cam, in, sizeof(float)*3);
+    // avoid calling this for linear profiles (marked with negative
+    // entries), assures unbounded color management without
+    // extrapolation.
+    for(int c = 0; c < 3; c++)
+      cam[c] = (d->lut[c][0] >= 0.0f)
+        ? ((in[4*k+c] < 1.0f)
+           ? lerp_lut(d->lut[c], in[4*k+c])
+           : dt_iop_eval_exp(d->unbounded_coeffs[c], in[4*k+c]))
+        : in[4*k+c];
+
+    __m128 xyz = ((cm0 * _mm_set1_ps(cam[0]))
+                  + (cm1 * _mm_set1_ps(cam[1]))
+                  + (cm2 * _mm_set1_ps(cam[2])));
+    _mm_stream_ps(out + 4*k, dt_XYZ_to_Lab_sse2(xyz));
   }
 }
+#endif
 
 static void _cmatrix_proper_simple(float *const restrict out,
                                    const float *const restrict in,
@@ -898,6 +929,13 @@ static void _cmatrix_proper_simple(float *const restrict out,
                                    const dt_iop_colorin_data_t *const d,
                                    const dt_colormatrix_t cmatrix)
 {
+#ifdef __SSE2__
+  if(darktable.codepath.SSE2)
+  {
+    _cmatrix_proper_simple_sse(out, in, npixels, d, cmatrix);
+    return;
+  }
+#endif
   const dt_aligned_pixel_t cmatrix_row0 = { cmatrix[0][0], cmatrix[1][0], cmatrix[2][0], 0.0f };
   const dt_aligned_pixel_t cmatrix_row1 = { cmatrix[0][1], cmatrix[1][1], cmatrix[2][1], 0.0f };
   const dt_aligned_pixel_t cmatrix_row2 = { cmatrix[0][2], cmatrix[1][2], cmatrix[2][2], 0.0f };
@@ -923,6 +961,52 @@ static void _cmatrix_proper_simple(float *const restrict out,
   }
 }
 
+#ifdef __SSE2__
+static inline void _cmatrix_proper_clipping_sse(float *const restrict out,
+                                                const float *const restrict in,
+                                                size_t npixels,
+                                                const dt_iop_colorin_data_t *const d,
+                                                const dt_colormatrix_t nmatrix,
+                                                const dt_colormatrix_t lmatrix)
+{
+  const __m128 nm0 = _mm_set_ps(0.0f, d->nmatrix[2][0], d->nmatrix[1][0], d->nmatrix[0][0]);
+  const __m128 nm1 = _mm_set_ps(0.0f, d->nmatrix[2][1], d->nmatrix[1][1], d->nmatrix[0][1]);
+  const __m128 nm2 = _mm_set_ps(0.0f, d->nmatrix[2][2], d->nmatrix[1][2], d->nmatrix[0][2]);
+  const __m128 lm0 = _mm_set_ps(0.0f, d->lmatrix[2][0], d->lmatrix[1][0], d->lmatrix[0][0]);
+  const __m128 lm1 = _mm_set_ps(0.0f, d->lmatrix[2][1], d->lmatrix[1][1], d->lmatrix[0][1]);
+  const __m128 lm2 = _mm_set_ps(0.0f, d->lmatrix[2][2], d->lmatrix[1][2], d->lmatrix[0][2]);
+
+  // this function is called from inside a parallel for loop, so no need for further parallelization
+  for(size_t k = 0; k < npixels; k++)
+  {
+    dt_aligned_pixel_t cam;
+
+    // memcpy(cam, in, sizeof(float)*3);
+    // avoid calling this for linear profiles (marked with negative
+    // entries), assures unbounded color management without
+    // extrapolation.
+    for(int c = 0; c < 3; c++)
+      cam[c] = (d->lut[c][0] >= 0.0f)
+        ? ((in[4*k+c] < 1.0f)
+           ? lerp_lut(d->lut[c], in[4*k+c])
+           : dt_iop_eval_exp(d->unbounded_coeffs[c], in[4*k+c]))
+        : in[4*k+c];
+
+    // convert to clipping colorspace
+    __m128 nrgb = ((nm0 * _mm_set1_ps(cam[0]))
+                   + (nm1 * _mm_set1_ps(cam[1]))
+                   + (nm2 * _mm_set1_ps(cam[2])));
+    // clip to gamut
+    __m128 crgb = _mm_min_ps(_mm_max_ps(nrgb, _mm_set1_ps(0.0f)), _mm_set1_ps(1.0f));
+    // convert to output colorspace
+    __m128 xyz = ((lm0 * _mm_shuffle_ps(crgb, crgb, _MM_SHUFFLE(0, 0, 0, 0)))
+                  + (lm1 * _mm_shuffle_ps(crgb, crgb, _MM_SHUFFLE(1, 1, 1, 1)))
+                  + (lm2 * _mm_shuffle_ps(crgb, crgb, _MM_SHUFFLE(2, 2, 2, 2))));
+    _mm_stream_ps(out + 4*k, dt_XYZ_to_Lab_sse2(xyz));
+  }
+}
+#endif
+
 static inline void _cmatrix_proper_clipping(float *const restrict out,
                                             const float *const restrict in,
                                             size_t npixels,
@@ -930,6 +1014,13 @@ static inline void _cmatrix_proper_clipping(float *const restrict out,
                                             const dt_colormatrix_t nmatrix,
                                             const dt_colormatrix_t lmatrix)
 {
+#ifdef __SSE2__
+  if(darktable.codepath.SSE2)
+  {
+    _cmatrix_proper_clipping_sse(out, in, npixels, d, nmatrix, lmatrix);
+    return;
+  }
+#endif
   const dt_aligned_pixel_t nmatrix_row0 = { nmatrix[0][0], nmatrix[1][0], nmatrix[2][0], 0.0f };
   const dt_aligned_pixel_t nmatrix_row1 = { nmatrix[0][1], nmatrix[1][1], nmatrix[2][1], 0.0f };
   const dt_aligned_pixel_t nmatrix_row2 = { nmatrix[0][2], nmatrix[1][2], nmatrix[2][2], 0.0f };
@@ -1018,7 +1109,7 @@ static void process_cmatrix(struct dt_iop_module_t *self,
                             const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
-  const int blue_mapping = 0 &&
+  const int blue_mapping =
     d->blue_mapping && dt_image_is_matrix_correction_supported(&piece->pipe->image);
 
   if(!blue_mapping && d->nonlinearlut == 0)
@@ -1266,144 +1357,6 @@ static void process_sse2_cmatrix_bm(struct dt_iop_module_t *self,
   _mm_sfence();
 }
 
-static void process_sse2_cmatrix_fastpath_clipping(struct dt_iop_module_t *self,
-                                                   dt_dev_pixelpipe_iop_t *piece,
-                                                   const void *const ivoid,
-                                                   void *const ovoid,
-                                                   const dt_iop_roi_t *const roi_in,
-                                                   const dt_iop_roi_t *const roi_out)
-{
-  const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
-  const int ch = piece->colors;
-
-  // only color matrix. use our optimized fast path!
-  const __m128 nm0 = _mm_set_ps(0.0f, d->nmatrix[2][0], d->nmatrix[1][0], d->nmatrix[0][0]);
-  const __m128 nm1 = _mm_set_ps(0.0f, d->nmatrix[2][1], d->nmatrix[1][1], d->nmatrix[0][1]);
-  const __m128 nm2 = _mm_set_ps(0.0f, d->nmatrix[2][2], d->nmatrix[1][2], d->nmatrix[0][2]);
-
-  const __m128 lm0 = _mm_set_ps(0.0f, d->lmatrix[2][0], d->lmatrix[1][0], d->lmatrix[0][0]);
-  const __m128 lm1 = _mm_set_ps(0.0f, d->lmatrix[2][1], d->lmatrix[1][1], d->lmatrix[0][1]);
-  const __m128 lm2 = _mm_set_ps(0.0f, d->lmatrix[2][2], d->lmatrix[1][2], d->lmatrix[0][2]);
-
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ch, ivoid, lm0, lm1, lm2, nm0, nm1, nm2, ovoid, roi_out) \
-  schedule(static)
-#endif
-  for(int k = 0; k < (size_t)roi_out->width * roi_out->height; k++)
-  {
-    float *in = (float *)ivoid + (size_t)ch * k;
-    float *out = (float *)ovoid + (size_t)ch * k;
-
-    __m128 input = _mm_load_ps(in);
-    __m128 nrgb = ((nm0 * _mm_shuffle_ps(input, input, _MM_SHUFFLE(0, 0, 0, 0))) +
-                   (nm1 * _mm_shuffle_ps(input, input, _MM_SHUFFLE(1, 1, 1, 1))) +
-                   (nm2 * _mm_shuffle_ps(input, input, _MM_SHUFFLE(2, 2, 2, 2))));
-    __m128 crgb = _mm_min_ps(_mm_max_ps(nrgb, _mm_set1_ps(0.0f)), _mm_set1_ps(1.0f));
-    __m128 xyz = ((lm0 * _mm_shuffle_ps(crgb, crgb, _MM_SHUFFLE(0, 0, 0, 0))) +
-                  (lm1 * _mm_shuffle_ps(crgb, crgb, _MM_SHUFFLE(1, 1, 1, 1))) +
-                  (lm2 * _mm_shuffle_ps(crgb, crgb, _MM_SHUFFLE(2, 2, 2, 2))));
-    _mm_stream_ps(out, dt_XYZ_to_Lab_sse2(xyz));
-  }
-  _mm_sfence();
-}
-
-static void process_sse2_cmatrix_fastpath(struct dt_iop_module_t *self,
-                                          dt_dev_pixelpipe_iop_t *piece,
-                                          const void *const ivoid,
-                                          void *const ovoid,
-                                          const dt_iop_roi_t *const roi_in,
-                                          const dt_iop_roi_t *const roi_out)
-{
-  const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
-  const int clipping = (d->nrgb != NULL);
-
-  if(!clipping)
-  {
-    process_cmatrix_fastpath_simple(self, piece, ivoid, ovoid, roi_in, roi_out);
-  }
-  else
-  {
-    process_sse2_cmatrix_fastpath_clipping(self, piece, ivoid, ovoid, roi_in, roi_out);
-  }
-}
-
-static void process_sse2_cmatrix_proper(struct dt_iop_module_t *self,
-                                        dt_dev_pixelpipe_iop_t *piece,
-                                        const void *const ivoid,
-                                        void *const ovoid,
-                                        const dt_iop_roi_t *const roi_in,
-                                        const dt_iop_roi_t *const roi_out)
-{
-  const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
-  const int ch = piece->colors;
-  const int clipping = (d->nrgb != NULL);
-
-  // only color matrix. use our optimized fast path!
-  float *in = (float *)ivoid;
-  float *out = (float *)ovoid;
-
-  const __m128 cm0 = _mm_set_ps(0.0f, d->cmatrix[2][0], d->cmatrix[1][0], d->cmatrix[0][0]);
-  const __m128 cm1 = _mm_set_ps(0.0f, d->cmatrix[2][1], d->cmatrix[1][1], d->cmatrix[0][1]);
-  const __m128 cm2 = _mm_set_ps(0.0f, d->cmatrix[2][2], d->cmatrix[1][2], d->cmatrix[0][2]);
-  const __m128 nm0 = _mm_set_ps(0.0f, d->nmatrix[2][0], d->nmatrix[1][0], d->nmatrix[0][0]);
-  const __m128 nm1 = _mm_set_ps(0.0f, d->nmatrix[2][1], d->nmatrix[1][1], d->nmatrix[0][1]);
-  const __m128 nm2 = _mm_set_ps(0.0f, d->nmatrix[2][2], d->nmatrix[1][2], d->nmatrix[0][2]);
-  const __m128 lm0 = _mm_set_ps(0.0f, d->lmatrix[2][0], d->lmatrix[1][0], d->lmatrix[0][0]);
-  const __m128 lm1 = _mm_set_ps(0.0f, d->lmatrix[2][1], d->lmatrix[1][1], d->lmatrix[0][1]);
-  const __m128 lm2 = _mm_set_ps(0.0f, d->lmatrix[2][2], d->lmatrix[1][2], d->lmatrix[0][2]);
-
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ch, clipping, d, roi_in, roi_out, cm0, cm1, cm2, nm0, nm1, nm2, lm0, lm1, lm2) \
-  shared(out, in) \
-  schedule(static)
-#endif
-  for(int j = 0; j < roi_out->height; j++)
-  {
-
-    float *buf_in = in + (size_t)ch * roi_in->width * j;
-    float *buf_out = out + (size_t)ch * roi_out->width * j;
-    dt_aligned_pixel_t cam;
-
-    for(int i = 0; i < roi_out->width; i++, buf_in += ch, buf_out += ch)
-    {
-
-      // memcpy(cam, buf_in, sizeof(float)*3);
-      // avoid calling this for linear profiles (marked with negative
-      // entries), assures unbounded color management without
-      // extrapolation.
-      for(int c = 0; c < 3; c++)
-        cam[c] = (d->lut[c][0] >= 0.0f)
-          ? ((buf_in[c] < 1.0f)
-             ? lerp_lut(d->lut[c], buf_in[c])
-             : dt_iop_eval_exp(d->unbounded_coeffs[c], buf_in[c]))
-          : buf_in[c];
-
-      if(!clipping)
-      {
-        __m128 xyz
-            = _mm_add_ps(_mm_add_ps(_mm_mul_ps(cm0, _mm_set1_ps(cam[0])),
-                                    _mm_mul_ps(cm1, _mm_set1_ps(cam[1]))),
-                         _mm_mul_ps(cm2, _mm_set1_ps(cam[2])));
-        _mm_stream_ps(buf_out, dt_XYZ_to_Lab_sse2(xyz));
-      }
-      else
-      {
-        __m128 nrgb
-            = _mm_add_ps(_mm_add_ps(_mm_mul_ps(nm0, _mm_set1_ps(cam[0])), _mm_mul_ps(nm1, _mm_set1_ps(cam[1]))),
-                         _mm_mul_ps(nm2, _mm_set1_ps(cam[2])));
-        __m128 crgb = _mm_min_ps(_mm_max_ps(nrgb, _mm_set1_ps(0.0f)), _mm_set1_ps(1.0f));
-        __m128 xyz = _mm_add_ps(_mm_add_ps(_mm_mul_ps(lm0, _mm_shuffle_ps(crgb, crgb, _MM_SHUFFLE(0, 0, 0, 0))),
-                                           _mm_mul_ps(lm1, _mm_shuffle_ps(crgb, crgb, _MM_SHUFFLE(1, 1, 1, 1)))),
-                                _mm_mul_ps(lm2, _mm_shuffle_ps(crgb, crgb, _MM_SHUFFLE(2, 2, 2, 2))));
-        _mm_stream_ps(buf_out, dt_XYZ_to_Lab_sse2(xyz));
-      }
-    }
-  }
-  _mm_sfence();
-}
-
 static void process_sse2_cmatrix(struct dt_iop_module_t *self,
                                  dt_dev_pixelpipe_iop_t *piece,
                                  const void *const ivoid,
@@ -1417,7 +1370,7 @@ static void process_sse2_cmatrix(struct dt_iop_module_t *self,
 
   if(!blue_mapping && d->nonlinearlut == 0)
   {
-    process_sse2_cmatrix_fastpath(self, piece, ivoid, ovoid, roi_in, roi_out);
+    process_cmatrix_fastpath(self, piece, ivoid, ovoid, roi_in, roi_out);
   }
   else if(blue_mapping)
   {
@@ -1425,7 +1378,7 @@ static void process_sse2_cmatrix(struct dt_iop_module_t *self,
   }
   else
   {
-    process_sse2_cmatrix_proper(self, piece, ivoid, ovoid, roi_in, roi_out);
+    process_cmatrix_proper(self, piece, ivoid, ovoid, roi_in, roi_out);
   }
 }
 

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1232,44 +1232,43 @@ static void process_lcms2_bm(struct dt_iop_module_t *self,
                              const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
-  const int ch = piece->colors;
+  const size_t height = roi_out->height;
+  const size_t width = roi_out->width;
 
 // use general lcms2 fallback
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ch, d, ivoid, ovoid, roi_out) \
+  dt_omp_firstprivate(d, ivoid, ovoid, height, width) \
   schedule(static)
 #endif
-  for(int k = 0; k < roi_out->height; k++)
+  for(int k = 0; k < height; k++)
   {
-    const float *in = (const float *)ivoid + (size_t)ch * k * roi_out->width;
-    float *out = (float *)ovoid + (size_t)ch * k * roi_out->width;
+    const float *in = (const float *)ivoid + (size_t)4 * k * width;
+    float *out = (float *)ovoid + (size_t)4 * k * width;
 
-    float *camptr = (float *)out;
-    for(int j = 0; j < roi_out->width; j++, in += 4, camptr += 4)
+    for(int j = 0; j < width; j++)
     {
-      apply_blue_mapping(in, camptr);
+      apply_blue_mapping(in + 4*j, out + 4*j);
     }
 
     // convert to (L,a/L,b/L) to be able to change L without changing saturation.
     if(!d->nrgb)
     {
-      cmsDoTransform(d->xform_cam_Lab, out, out, roi_out->width);
+      cmsDoTransform(d->xform_cam_Lab, out, out, width);
     }
     else
     {
-      cmsDoTransform(d->xform_cam_nrgb, out, out, roi_out->width);
+      cmsDoTransform(d->xform_cam_nrgb, out, out, width);
 
-      float *rgbptr = (float *)out;
-      for(int j = 0; j < roi_out->width; j++, rgbptr += 4)
+      for(int j = 0; j < width; j++)
       {
-        for(int c = 0; c < 3; c++)
+        for_each_channel(c)
         {
-          rgbptr[c] = CLAMP(rgbptr[c], 0.0f, 1.0f);
+          out[4*j+c] = CLAMP(out[4*j+c], 0.0f, 1.0f);
         }
       }
 
-      cmsDoTransform(d->xform_nrgb_Lab, out, out, roi_out->width);
+      cmsDoTransform(d->xform_nrgb_Lab, out, out, width);
     }
   }
 }
@@ -1282,61 +1281,38 @@ static void process_lcms2_proper(struct dt_iop_module_t *self,
                                  const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
-  const int ch = piece->colors;
+  const size_t height = roi_out->height;
+  const size_t width = roi_out->width;
 
-// use general lcms2 fallback
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ch, d, ivoid, ovoid, roi_out) \
+  dt_omp_firstprivate(d, ivoid, ovoid, height, width) \
   schedule(static)
 #endif
-  for(int k = 0; k < roi_out->height; k++)
+  for(size_t k = 0; k < height; k++)
   {
-    const float *in = (const float *)ivoid + (size_t)ch * k * roi_out->width;
-    float *out = (float *)ovoid + (size_t)ch * k * roi_out->width;
+    const float *in = (const float *)ivoid + (size_t)4 * k * width;
+    float *out = (float *)ovoid + (size_t)4 * k * width;
 
     // convert to (L,a/L,b/L) to be able to change L without changing saturation.
     if(!d->nrgb)
     {
-      cmsDoTransform(d->xform_cam_Lab, in, out, roi_out->width);
+      cmsDoTransform(d->xform_cam_Lab, in, out, width);
     }
     else
     {
-      cmsDoTransform(d->xform_cam_nrgb, in, out, roi_out->width);
+      cmsDoTransform(d->xform_cam_nrgb, in, out, width);
 
-      float *rgbptr = (float *)out;
-      for(int j = 0; j < roi_out->width; j++, rgbptr += 4)
+      for(int j = 0; j < width; j++)
       {
-        for(int c = 0; c < 3; c++)
+        for_each_channel(c)
         {
-          rgbptr[c] = CLAMP(rgbptr[c], 0.0f, 1.0f);
+          out[4*j+c] = CLAMP(out[4*j+c], 0.0f, 1.0f);
         }
       }
 
-      cmsDoTransform(d->xform_nrgb_Lab, out, out, roi_out->width);
+      cmsDoTransform(d->xform_nrgb_Lab, out, out, width);
     }
-  }
-}
-
-static void process_lcms2(struct dt_iop_module_t *self,
-                          dt_dev_pixelpipe_iop_t *piece,
-                          const void *const ivoid,
-                          void *const ovoid,
-                          const dt_iop_roi_t *const roi_in,
-                          const dt_iop_roi_t *const roi_out)
-{
-  const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
-  const int blue_mapping =
-    d->blue_mapping && dt_image_is_matrix_correction_supported(&piece->pipe->image);
-
-  // use general lcms2 fallback
-  if(blue_mapping)
-  {
-    process_lcms2_bm(self, piece, ivoid, ovoid, roi_in, roi_out);
-  }
-  else
-  {
-    process_lcms2_proper(self, piece, ivoid, ovoid, roi_in, roi_out);
   }
 }
 
@@ -1347,7 +1323,13 @@ void process(struct dt_iop_module_t *self,
              const dt_iop_roi_t *const roi_in,
              const dt_iop_roi_t *const roi_out)
 {
+  if(!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece->colors,
+                                         ivoid, ovoid, roi_in, roi_out))
+    return;
+
   const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
+  const int blue_mapping =
+    d->blue_mapping && dt_image_is_matrix_correction_supported(&piece->pipe->image);
 
   if(d->type == DT_COLORSPACE_LAB)
   {
@@ -1359,7 +1341,15 @@ void process(struct dt_iop_module_t *self,
   }
   else
   {
-    process_lcms2(self, piece, ivoid, ovoid, roi_in, roi_out);
+    // use general lcms2 fallback
+    if(blue_mapping)
+    {
+      process_lcms2_bm(self, piece, ivoid, ovoid, roi_in, roi_out);
+    }
+    else
+    {
+      process_lcms2_proper(self, piece, ivoid, ovoid, roi_in, roi_out);
+    }
   }
 }
 

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -753,6 +753,99 @@ static void process_cmatrix_bm(struct dt_iop_module_t *self,
   dt_omploop_sfence();
 }
 
+#if defined(__SSE2__)
+static void process_sse2_cmatrix_bm(struct dt_iop_module_t *self,
+                                    dt_dev_pixelpipe_iop_t *piece,
+                                    const void *const ivoid,
+                                    void *const ovoid,
+                                    const dt_iop_roi_t *const roi_in,
+                                    const dt_iop_roi_t *const roi_out)
+{
+  const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
+  const int ch = piece->colors;
+  const int clipping = (d->nrgb != NULL);
+
+  // only color matrix. use our optimized fast path!
+  float cmat[9], nmat[9], lmat[9];
+  pack_3xSSE_to_3x3(d->cmatrix, cmat);
+  pack_3xSSE_to_3x3(d->nmatrix, nmat);
+  pack_3xSSE_to_3x3(d->lmatrix, lmat);
+  float *in = (float *)ivoid;
+  float *out = (float *)ovoid;
+
+  const __m128 cm0 = _mm_set_ps(0.0f, cmat[6], cmat[3], cmat[0]);
+  const __m128 cm1 = _mm_set_ps(0.0f, cmat[7], cmat[4], cmat[1]);
+  const __m128 cm2 = _mm_set_ps(0.0f, cmat[8], cmat[5], cmat[2]);
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(ch, clipping, d, lmat, nmat, roi_in, roi_out, cm0, cm1, cm2) \
+  shared(out, in) \
+  schedule(static)
+#endif
+  for(int j = 0; j < roi_out->height; j++)
+  {
+
+    float *buf_in = in + (size_t)ch * roi_in->width * j;
+    float *buf_out = out + (size_t)ch * roi_out->width * j;
+    dt_aligned_pixel_t cam;
+
+    const __m128 nm0 = _mm_set_ps(0.0f, nmat[6], nmat[3], nmat[0]);
+    const __m128 nm1 = _mm_set_ps(0.0f, nmat[7], nmat[4], nmat[1]);
+    const __m128 nm2 = _mm_set_ps(0.0f, nmat[8], nmat[5], nmat[2]);
+
+    const __m128 lm0 = _mm_set_ps(0.0f, lmat[6], lmat[3], lmat[0]);
+    const __m128 lm1 = _mm_set_ps(0.0f, lmat[7], lmat[4], lmat[1]);
+    const __m128 lm2 = _mm_set_ps(0.0f, lmat[8], lmat[5], lmat[2]);
+
+    for(int i = 0; i < roi_out->width; i++, buf_in += ch, buf_out += ch)
+    {
+
+      // memcpy(cam, buf_in, sizeof(float)*3);
+      // avoid calling this for linear profiles (marked with negative
+      // entries), assures unbounded color management without
+      // extrapolation.
+      for(int c = 0; c < 3; c++)
+        cam[c] = (d->lut[c][0] >= 0.0f)
+          ? ((buf_in[c] < 1.0f)
+             ? lerp_lut(d->lut[c], buf_in[c])
+             : dt_iop_eval_exp(d->unbounded_coeffs[c], buf_in[c]))
+          : buf_in[c];
+
+      apply_blue_mapping(cam, cam);
+
+      if(!clipping)
+      {
+        __m128 xyz
+            = _mm_add_ps(_mm_add_ps(_mm_mul_ps(cm0, _mm_set1_ps(cam[0])),
+                                    _mm_mul_ps(cm1, _mm_set1_ps(cam[1]))),
+                         _mm_mul_ps(cm2, _mm_set1_ps(cam[2])));
+        _mm_stream_ps(buf_out, dt_XYZ_to_Lab_sse2(xyz));
+      }
+      else
+      {
+        __m128 nrgb
+            = _mm_add_ps(_mm_add_ps(_mm_mul_ps(nm0, _mm_set1_ps(cam[0])),
+                                    _mm_mul_ps(nm1, _mm_set1_ps(cam[1]))),
+                         _mm_mul_ps(nm2, _mm_set1_ps(cam[2])));
+        __m128 crgb = _mm_min_ps(_mm_max_ps(nrgb, _mm_set1_ps(0.0f)),
+                                 _mm_set1_ps(1.0f));
+        __m128 xyz = _mm_add_ps(_mm_add_ps
+                                (_mm_mul_ps(lm0,
+                                            _mm_shuffle_ps(crgb, crgb,
+                                                           _MM_SHUFFLE(0, 0, 0, 0))),
+                                 _mm_mul_ps(lm1,
+                                            _mm_shuffle_ps(crgb, crgb,
+                                                           _MM_SHUFFLE(1, 1, 1, 1)))),
+                                _mm_mul_ps(lm2, _mm_shuffle_ps(crgb, crgb,
+                                                               _MM_SHUFFLE(2, 2, 2, 2))));
+        _mm_stream_ps(buf_out, dt_XYZ_to_Lab_sse2(xyz));
+      }
+    }
+  }
+  _mm_sfence();
+}
+#endif
+
 static void _cmatrix_fastpath_simple(float *const restrict out,
                                      const float *const restrict in,
                                      size_t npixels,
@@ -1118,6 +1211,11 @@ static void process_cmatrix(struct dt_iop_module_t *self,
   }
   else if(blue_mapping)
   {
+#ifdef __SSE2__
+    if(darktable.codepath.SSE2)
+      process_sse2_cmatrix_bm(self, piece, ivoid, ovoid, roi_in, roi_out);
+    else
+#endif
     process_cmatrix_bm(self, piece, ivoid, ovoid, roi_in, roi_out);
   }
   else
@@ -1264,147 +1362,6 @@ void process(struct dt_iop_module_t *self,
     process_lcms2(self, piece, ivoid, ovoid, roi_in, roi_out);
   }
 }
-
-#if defined(__SSE2__)
-static void process_sse2_cmatrix_bm(struct dt_iop_module_t *self,
-                                    dt_dev_pixelpipe_iop_t *piece,
-                                    const void *const ivoid,
-                                    void *const ovoid,
-                                    const dt_iop_roi_t *const roi_in,
-                                    const dt_iop_roi_t *const roi_out)
-{
-  const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
-  const int ch = piece->colors;
-  const int clipping = (d->nrgb != NULL);
-
-  // only color matrix. use our optimized fast path!
-  float cmat[9], nmat[9], lmat[9];
-  pack_3xSSE_to_3x3(d->cmatrix, cmat);
-  pack_3xSSE_to_3x3(d->nmatrix, nmat);
-  pack_3xSSE_to_3x3(d->lmatrix, lmat);
-  float *in = (float *)ivoid;
-  float *out = (float *)ovoid;
-
-  const __m128 cm0 = _mm_set_ps(0.0f, cmat[6], cmat[3], cmat[0]);
-  const __m128 cm1 = _mm_set_ps(0.0f, cmat[7], cmat[4], cmat[1]);
-  const __m128 cm2 = _mm_set_ps(0.0f, cmat[8], cmat[5], cmat[2]);
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ch, clipping, d, lmat, nmat, roi_in, roi_out, cm0, cm1, cm2) \
-  shared(out, in) \
-  schedule(static)
-#endif
-  for(int j = 0; j < roi_out->height; j++)
-  {
-
-    float *buf_in = in + (size_t)ch * roi_in->width * j;
-    float *buf_out = out + (size_t)ch * roi_out->width * j;
-    dt_aligned_pixel_t cam;
-
-    const __m128 nm0 = _mm_set_ps(0.0f, nmat[6], nmat[3], nmat[0]);
-    const __m128 nm1 = _mm_set_ps(0.0f, nmat[7], nmat[4], nmat[1]);
-    const __m128 nm2 = _mm_set_ps(0.0f, nmat[8], nmat[5], nmat[2]);
-
-    const __m128 lm0 = _mm_set_ps(0.0f, lmat[6], lmat[3], lmat[0]);
-    const __m128 lm1 = _mm_set_ps(0.0f, lmat[7], lmat[4], lmat[1]);
-    const __m128 lm2 = _mm_set_ps(0.0f, lmat[8], lmat[5], lmat[2]);
-
-    for(int i = 0; i < roi_out->width; i++, buf_in += ch, buf_out += ch)
-    {
-
-      // memcpy(cam, buf_in, sizeof(float)*3);
-      // avoid calling this for linear profiles (marked with negative
-      // entries), assures unbounded color management without
-      // extrapolation.
-      for(int c = 0; c < 3; c++)
-        cam[c] = (d->lut[c][0] >= 0.0f)
-          ? ((buf_in[c] < 1.0f)
-             ? lerp_lut(d->lut[c], buf_in[c])
-             : dt_iop_eval_exp(d->unbounded_coeffs[c], buf_in[c]))
-          : buf_in[c];
-
-      apply_blue_mapping(cam, cam);
-
-      if(!clipping)
-      {
-        __m128 xyz
-            = _mm_add_ps(_mm_add_ps(_mm_mul_ps(cm0, _mm_set1_ps(cam[0])),
-                                    _mm_mul_ps(cm1, _mm_set1_ps(cam[1]))),
-                         _mm_mul_ps(cm2, _mm_set1_ps(cam[2])));
-        _mm_stream_ps(buf_out, dt_XYZ_to_Lab_sse2(xyz));
-      }
-      else
-      {
-        __m128 nrgb
-            = _mm_add_ps(_mm_add_ps(_mm_mul_ps(nm0, _mm_set1_ps(cam[0])),
-                                    _mm_mul_ps(nm1, _mm_set1_ps(cam[1]))),
-                         _mm_mul_ps(nm2, _mm_set1_ps(cam[2])));
-        __m128 crgb = _mm_min_ps(_mm_max_ps(nrgb, _mm_set1_ps(0.0f)),
-                                 _mm_set1_ps(1.0f));
-        __m128 xyz = _mm_add_ps(_mm_add_ps
-                                (_mm_mul_ps(lm0,
-                                            _mm_shuffle_ps(crgb, crgb,
-                                                           _MM_SHUFFLE(0, 0, 0, 0))),
-                                 _mm_mul_ps(lm1,
-                                            _mm_shuffle_ps(crgb, crgb,
-                                                           _MM_SHUFFLE(1, 1, 1, 1)))),
-                                _mm_mul_ps(lm2, _mm_shuffle_ps(crgb, crgb,
-                                                               _MM_SHUFFLE(2, 2, 2, 2))));
-        _mm_stream_ps(buf_out, dt_XYZ_to_Lab_sse2(xyz));
-      }
-    }
-  }
-  _mm_sfence();
-}
-
-static void process_sse2_cmatrix(struct dt_iop_module_t *self,
-                                 dt_dev_pixelpipe_iop_t *piece,
-                                 const void *const ivoid,
-                                 void *const ovoid,
-                                 const dt_iop_roi_t *const roi_in,
-                                 const dt_iop_roi_t *const roi_out)
-{
-  const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
-  const int blue_mapping =
-    d->blue_mapping && dt_image_is_matrix_correction_supported(&piece->pipe->image);
-
-  if(!blue_mapping && d->nonlinearlut == 0)
-  {
-    process_cmatrix_fastpath(self, piece, ivoid, ovoid, roi_in, roi_out);
-  }
-  else if(blue_mapping)
-  {
-    process_sse2_cmatrix_bm(self, piece, ivoid, ovoid, roi_in, roi_out);
-  }
-  else
-  {
-    process_cmatrix_proper(self, piece, ivoid, ovoid, roi_in, roi_out);
-  }
-}
-
-void process_sse2(struct dt_iop_module_t *self,
-                  dt_dev_pixelpipe_iop_t *piece,
-                  const void *const ivoid,
-                  void *const ovoid,
-                  const dt_iop_roi_t *const roi_in,
-                  const dt_iop_roi_t *const roi_out)
-{
-  const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
-
-  if(d->type == DT_COLORSPACE_LAB)
-  {
-    dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, piece->colors);
-  }
-  else if(!isnan(d->cmatrix[0][0]))
-  {
-    process_sse2_cmatrix(self, piece, ivoid, ovoid, roi_in, roi_out);
-  }
-  else
-  {
-    process_lcms2(self, piece, ivoid, ovoid, roi_in, roi_out);
-  }
-}
-#endif
 
 void commit_params(struct dt_iop_module_t *self,
                    dt_iop_params_t *p1,


### PR DESCRIPTION
Removed the `process_sse2` function, instead selecting which codepath to use internally.
Auto-vectorized is faster than before (particularly at 32 and 64 threads due to the non-temporal writes), but still somewhat slower than SSE (about 5 percent for gamut-clipped linear input space and 7% for a tonemapped color space without clipping; the combination should fall in that range but I didn't run the timings).  So it's still worth keeping the SSE code for now.

Nonlinear color space:
```
Thr	Mast-S	PR-S		Mast-AV	PR-AV
1	150.34	144.39		155.00	154.96
2	75.51	 73.41		77.58	 77.53
4	38.01	 36.67		39.52	 39.33
8	19.46	 18.51		19.67	 20.02
16	10.18	 10.52		10.16	 10.46
32	 7.94	  7.82		 8.82	  7.86
64	 4.56	  4.57		 7.12	  4.78
```
Linear color space, with gamut clipping:
```
Thr	Mast-S	PR-S		Mast-AV	PR-AV
1	83.10	83.61		96.93	87.91
2	41.69	41.91		48.48	44.11
4	20.89	21.07		24.26	22.10
8	10.47	10.55		12.16	11.07
16	 5.95	 6.06		 6.30	 6.02
32	 5.00	 5.03		 6.98	 5.01
64	 4.10	 4.08		 7.08	 4.04
```
Passes the three new tests for which I have a PR in the other repo.

This is the last iop to have a process_sse2 function, so if this is merged I will follow up with another PR to remove the final traces of process_sse2.
