### PR TITLE
splittoning: optimize

### DIFF
--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -1091,66 +1091,6 @@ error:
   g_free(utf8);
 }
 
-void rgb2hsl(const dt_aligned_pixel_t rgb, float *h, float *s, float *l)
-{
-  const float r = rgb[0], g = rgb[1], b = rgb[2];
-  const float pmax = fmaxf(r, fmax(g, b));
-  const float pmin = fminf(r, fmin(g, b));
-  const float delta = (pmax - pmin);
-
-  float hv = 0, sv = 0, lv = (pmin + pmax) / 2.0;
-
-  if(delta != 0.0f)
-  {
-    sv = lv < 0.5 ? delta / fmaxf(pmax + pmin, 1.52587890625e-05f)
-                  : delta / fmaxf(2.0 - pmax - pmin, 1.52587890625e-05f);
-
-    if(pmax == r)
-      hv = (g - b) / delta;
-    else if(pmax == g)
-      hv = 2.0 + (b - r) / delta;
-    else if(pmax == b)
-      hv = 4.0 + (r - g) / delta;
-    hv /= 6.0;
-    if(hv < 0.0)
-      hv += 1.0;
-    else if(hv > 1.0)
-      hv -= 1.0;
-  }
-  *h = hv;
-  *s = sv;
-  *l = lv;
-}
-
-// for efficiency, 'hue' must be pre-scaled to be in 0..6
-static inline float hue2rgb(float m1, float m2, float hue)
-{
-  // compute the value for one of the RGB channels from the hue angle.
-  // If 1 <= angle < 3, return m2; if 4 <= angle <= 6, return m1; otherwise, linearly interpolate between m1 and m2.
-  if(hue < 1.0f)
-    return (m1 + (m2 - m1) * hue);
-  else if(hue < 3.0f)
-    return m2;
-  else
-    return hue < 4.0f ? (m1 + (m2 - m1) * (4.0f - hue)) : m1;
-}
-
-void hsl2rgb(dt_aligned_pixel_t rgb, float h, float s, float l)
-{
-  float m1, m2;
-  if(s == 0)
-  {
-    rgb[0] = rgb[1] = rgb[2] = l;
-    return;
-  }
-  m2 = l < 0.5 ? l * (1.0 + s) : l + s - l * s;
-  m1 = (2.0 * l - m2);
-  h *= 6.0f;  // pre-scale hue angle
-  rgb[0] = hue2rgb(m1, m2, h < 4.0f ? h + 2.0f : h - 4.0f);
-  rgb[1] = hue2rgb(m1, m2, h);
-  rgb[2] = hue2rgb(m1, m2, h > 2.0f ? h - 2.0f : h + 4.0f);
-}
-
 static dt_colorspaces_color_profile_t *_create_profile(dt_colorspaces_color_profile_type_t type,
                                                        cmsHPROFILE profile, const char *name, int in_pos,
                                                        int out_pos, int display_pos, int category_pos,

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -252,8 +252,69 @@ void dt_colorspaces_get_profile_name(cmsHPROFILE p, const char *language, const 
 const char *dt_colorspaces_get_name(dt_colorspaces_color_profile_type_t type, const char *filename);
 
 /** common functions to change between colorspaces, used in iop modules */
-void rgb2hsl(const dt_aligned_pixel_t rgb, float *h, float *s, float *l);
-void hsl2rgb(dt_aligned_pixel_t rgb, float h, float s, float l);
+//void rgb2hsl(const dt_aligned_pixel_t rgb, float *h, float *s, float *l);
+//void hsl2rgb(dt_aligned_pixel_t rgb, float h, float s, float l);
+static inline void rgb2hsl(const dt_aligned_pixel_t rgb, float *h, float *s, float *l)
+{
+  const float r = rgb[0], g = rgb[1], b = rgb[2];
+  const float pmax = fmaxf(r, fmax(g, b));
+  const float pmin = fminf(r, fmin(g, b));
+  const float delta = (pmax - pmin);
+
+  float hv = 0, sv = 0, lv = (pmin + pmax) / 2.0;
+
+  if(delta != 0.0f)
+  {
+    sv = lv < 0.5 ? delta / fmaxf(pmax + pmin, 1.52587890625e-05f)
+                  : delta / fmaxf(2.0 - pmax - pmin, 1.52587890625e-05f);
+
+    if(pmax == r)
+      hv = (g - b) / delta;
+    else if(pmax == g)
+      hv = 2.0 + (b - r) / delta;
+    else if(pmax == b)
+      hv = 4.0 + (r - g) / delta;
+    hv /= 6.0;
+    if(hv < 0.0)
+      hv += 1.0;
+    else if(hv > 1.0)
+      hv -= 1.0;
+  }
+  *h = hv;
+  *s = sv;
+  *l = lv;
+}
+
+// for efficiency, 'hue' must be pre-scaled to be in 0..6
+static inline float hue2rgb(float m1, float m2, float hue)
+{
+  // compute the value for one of the RGB channels from the hue angle.
+  // If 1 <= angle < 3, return m2; if 4 <= angle <= 6, return m1; otherwise, linearly interpolate between m1 and m2.
+  if(hue < 1.0f)
+    return (m1 + (m2 - m1) * hue);
+  else if(hue < 3.0f)
+    return m2;
+  else
+    return hue < 4.0f ? (m1 + (m2 - m1) * (4.0f - hue)) : m1;
+}
+
+static inline void hsl2rgb(dt_aligned_pixel_t rgb, float h, float s, float l)
+{
+  float m1, m2;
+  if(s == 0)
+  {
+    rgb[0] = rgb[1] = rgb[2] = l;
+    return;
+  }
+  m2 = l < 0.5 ? l * (1.0 + s) : l + s - l * s;
+  m1 = (2.0 * l - m2);
+  h *= 6.0f;  // pre-scale hue angle
+  rgb[0] = hue2rgb(m1, m2, h < 4.0f ? h + 2.0f : h - 4.0f);
+  rgb[1] = hue2rgb(m1, m2, h);
+  rgb[2] = hue2rgb(m1, m2, h > 2.0f ? h - 2.0f : h + 4.0f);
+}
+
+
 
 /** trigger updating the display profile from the system settings (x atom, colord, ...) */
 void dt_colorspaces_set_display_profile(const dt_colorspaces_color_profile_type_t profile_type);

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -304,6 +304,7 @@ static inline void hsl2rgb(dt_aligned_pixel_t rgb, float h, float s, float l)
   if(s == 0)
   {
     rgb[0] = rgb[1] = rgb[2] = l;
+    rgb[3] = 0.0f;
     return;
   }
   m2 = l < 0.5 ? l * (1.0 + s) : l + s - l * s;
@@ -312,6 +313,7 @@ static inline void hsl2rgb(dt_aligned_pixel_t rgb, float h, float s, float l)
   rgb[0] = hue2rgb(m1, m2, h < 4.0f ? h + 2.0f : h - 4.0f);
   rgb[1] = hue2rgb(m1, m2, h);
   rgb[2] = hue2rgb(m1, m2, h > 2.0f ? h - 2.0f : h + 4.0f);
+  rgb[3] = 0.0f;
 }
 
 


### PR DESCRIPTION
Optimize OpenMP, use nontemporal writes, and inline the HSL conversion functions (also used by Soften module).

Converting into and out of HSL space consumes the bulk of the time for split toning, so inlining the conversion functions yields a big speedup (and using nontemporal writes extends the speedup to higher thread counts).  For Soften, most of the time is spent in the bilateral blur, so the
speedup is much smaller. 

Passes tests 0051 and 0062.

splittoning
```
Thr	Master	PR
1	240.44 143.12	-40.4%
2	122.51	71.83	-41.3%
4	 63.06	38.05	-39.6%
8	 32.32	18.89	-41.5%
16	 17.80	 9.98	-56.0%
32	 12.57	 8.42	-33.0%
64	  7.92	 4.42	-44.1%
```
soften
```
Thr	Master	PR
1	848.25	808.28	-4.7%
2	442.88	417.60	-5.7%
4	239.19	226.45	-5.3%
8	133.90	127.70	-4.6%
16	103.77	 96.42	-7.0%
32	 91.18	 88.61	-2.8%
64	 90.96	 88.34	-2.8%
```