### PR TITLE
maintenance: remove process_sse2 remnants

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -201,11 +201,6 @@ static void default_process(struct dt_iop_module_t *self,
 {
   if(roi_in->width <= 1 || roi_in->height <= 1 || roi_out->width <= 1 || roi_out->height <= 1) return;
 
-#if defined(__SSE__)
-  if(darktable.codepath.SSE2 && self->process_sse2)
-    self->process_sse2(self, piece, i, o, roi_in, roi_out);
-  else
-#endif
   if(self->process_plain)
     self->process_plain(self, piece, i, o, roi_in, roi_out);
   else

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1151,19 +1151,6 @@ static int pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
         const int counter = (piece->pipe->type & DT_DEV_PIXELPIPE_FULL) ? 100 : 50;
         const float mpix = (roi_out->width * roi_out->height) / 1.0e6;
 
-#if defined(__SSE__)
-        if(module->process_sse2)
-        {
-          dt_get_times(&start);
-          for(int i = 0; i < counter; i++)
-            module->process_sse2(module, piece, input, *output, roi_in, roi_out);
-          dt_get_times(&end);
-          const float clock = (end.clock - start.clock) / (float) counter;
-          dt_print(DT_DEBUG_ALWAYS,
-                   "[bench module SSE2]  [%s] `%15s' takes %8.5fs,%7.2fmpix,%9.3fpix/us\n",
-                   full ? "full" : "export", module->so->op, clock, mpix, mpix/clock);
-        }
-#endif
         if(module->process_plain)
         {
           dt_get_times(&start);

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -182,14 +182,6 @@ DEFAULT(void, process_tiling, struct dt_iop_module_t *self, struct dt_dev_pixelp
                                void *const o, const struct dt_iop_roi_t *const roi_in,
                                const struct dt_iop_roi_t *const roi_out, const int bpp);
 
-#if defined(__SSE__)
-/** a variant process(), that can contain SSE2 intrinsics. */
-/** can be provided by each IOP. */
-OPTIONAL(void, process_sse2, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
-                             void *const o, const struct dt_iop_roi_t *const roi_in,
-                             const struct dt_iop_roi_t *const roi_out);
-#endif
-
 #ifdef HAVE_OPENCL
 /** the opencl equivalent of process(). */
 OPTIONAL(int, process_cl, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in,


### PR DESCRIPTION
Now that none of the IOPs have a process_sse2() function anymore, we can clean up the calling side of the API as well.