### PR TITLE
po/fix iop label - some defensive code (& rework check for label update)

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1200,6 +1200,8 @@ void dt_dev_reload_history_items(dt_develop_t *dev)
   {
     GList *next = g_list_next(history);
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
+    hist->module->multi_name_hand_edited = FALSE;
+    g_strlcpy(hist->module->multi_name, "", sizeof(hist->module->multi_name));
     dt_dev_free_history_item(hist);
     dev->history = g_list_delete_link(dev->history, history);
     history = next;

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1113,7 +1113,8 @@ static void _iop_panel_name(dt_iop_module_t *module)
   // IOP instance name if any
 
   // do not mess with panel name if we are not on the top of the history
-  if(darktable.develop->history_end < g_list_length(darktable.develop->history))
+  if(darktable.develop->history_end < g_list_length(darktable.develop->history)
+    || !module->instance_name)
     return;
 
   GtkLabel *iname = GTK_LABEL(module->instance_name);
@@ -1920,8 +1921,8 @@ void dt_iop_commit_params(dt_iop_module_t *module,
      && module_is_enabled
      && module_params_changed
      && !module->multi_name_hand_edited
-     // do not set module-name if currently editing it (see _rename_module_key_press).
-     && module->multi_name[sizeof(module->multi_name) - 1] == '\0')
+     && module->instance_name
+     && gtk_widget_get_visible(module->instance_name))
   {
     if(module->label_recompute_handle)
       g_source_remove(module->label_recompute_handle);


### PR DESCRIPTION
Could help for #13893.

+ properly reset module's label for truncated history. 