### PR TITLE
darkroom: Avoid simultaneous image loading.

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1918,6 +1918,7 @@ void dt_iop_commit_params(dt_iop_module_t *module,
   // multi_name for this module.
 
   if(!dt_iop_is_hidden(module)
+     && module->gui_data
      && module_is_enabled
      && module_params_changed
      && !module->multi_name_hand_edited

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -812,7 +812,9 @@ static void _fire_darkroom_image_loaded_event(const bool clean, const int32_t im
 static void _dev_change_image(dt_develop_t *dev, const int32_t imgid)
 {
   // stop crazy users from sleeping on key-repeat spacebar:
-  if(dev->image_loading) return;
+  const gboolean is_loading =
+    dt_atomic_exch_int((dt_atomic_int *)&dev->image_loading, TRUE);
+  if(is_loading) return;
 
   // deactivate module label timer if set
   if(darktable.develop->gui_module


### PR DESCRIPTION
Properly ensure that next image loading is not starting before previous was ended.

Attempt to fix #13893.