### PR TITLE
more responsive style previews

### DIFF
--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -268,6 +268,8 @@ static gboolean dt_styles_create_style_header(const char *name,
   dt_action_t *stl = dt_action_section(&darktable.control->actions_global, N_("styles"));
   dt_action_register(stl, name, _apply_style_shortcut_callback, 0, 0);
 
+  dt_gui_style_content_dialog("", -1);
+
   g_free(iop_list_txt);
   return TRUE;
 }
@@ -453,6 +455,8 @@ void dt_styles_update(const char *name,
                                         (gchar *[]){"styles", (gchar *)name, NULL}, FALSE);
     dt_action_rename(old, newname);
   }
+
+  dt_gui_style_content_dialog("", -1);
 
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_STYLE_CHANGED);
 


### PR DESCRIPTION
On my slow laptop style tooltips have two problems:
- if an image preview is to be shown (in darkroom or in lighttable if an image is selected) this is calculated and shown in the same "draw" as the complete tooltip. This means _nothing_ is shown until the preview image is complete, locking up the gui thread without any indication that anything is going on in the background. If the user now moves the mouse away to see if anything else is responsive, by the time the preview is complete, it is already outdated and the tooltip may have been hidden anyway.
- If I _do_ keep the mouse still on one style until the preview is ready and shown and _then_ move it, the tooltip immediately gets updated, probably while still on the same style. So now the gui again is locked up and nothing changes until the old (useless) preview is ready and then immediately a new preview gets calculated with as only feedback that now the style under the mouse is highlighted in the menu or treeview.

This PR solves the first issue by skipping the first "draw" of the preview image, immediately requesting a redraw but giving the tooltip the chance to show itself (with the other style details). On the 2nd draw, the full preview is calculated, locking up the gui thread but at least we can now look at the tooltip and conclude that probably the empty space for the preview is going to be filled in.

The 2nd issue is "solved" by checking if we are still requesting a tooltip for the same image and style. If so, the old preview is used again.

Of course this leads to problems if in the mean time the style or the image itself have been changed. You can easily update the preview by moving to another style and back, but this is not obvious.

@TurboGit I don't know too much about history hashes but it may be trivial to find if they have changed for either image or style? A further improvement would be to calculate the preview in the background, without locking the gui, and update the drawingarea when it is complete, but we'd want to avoid firing off a volley of preview calculations by moving over the whole menu. This PR doesn't clean up the last calculated surface, which is probably not too much of an issue, but I guess it could be cleared when any history or style definition is changed.

Please feel free to solve the problems mentioned here in a better way and I'll close this PR.