### PR TITLE
[CI] update compiler matrix for macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,9 +282,8 @@ jobs:
       fail-fast: true
       matrix:
         build:
-          - { os: macos-11,    xcode: 12.5.1, deployment: 11.3 }
-          - { os: macos-11,    xcode: 13.2.1, deployment: 12.1 }
-          - { os: macos-12,    xcode: 13.4,   deployment: 12.3 }
+          - { os: macos-11, xcode: 13.2.1, deployment: 11.3 }
+          - { os: macos-12, xcode: 14.2,   deployment: 12.5 }
         compiler:
           - { compiler: XCode,   CC: cc, CXX: c++ }
         btype: [ Debug ]

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -139,7 +139,7 @@ jobs:
       fail-fast: true
       matrix:
         build:
-          - { os: macos-11, xcode: 12.5.1, deployment: 11.3 }
+          - { os: macos-11, xcode: 13.2.1, deployment: 11.3 }
         compiler:
           - { compiler: XCode,   CC: cc, CXX: c++ }
         btype: [ Release ]


### PR DESCRIPTION
According to the decisions made: https://github.com/darktable-org/rawspeed/pull/441/files

Support for the oldest supported macOS version 11 and newest available Xcode on that platform.