### PR TITLE
[CI] macOS: Speed up build by removing the limiting number of parallel jobs

### DIFF
--- a/.ci/ci-script.sh
+++ b/.ci/ci-script.sh
@@ -50,22 +50,18 @@ fi;
 
 target_build()
 {
-  # to get as much of the issues into the log as possible
-  cmake --build "$BUILD_DIR" -- $JOBS "$VERBOSE" "$KEEPGOING" || cmake --build "$BUILD_DIR" -- -j1 "$VERBOSE" "$KEEPGOING"
+  cmake --build "$BUILD_DIR" -- $JOBS "$VERBOSE" "$KEEPGOING"
 
   ctest --output-on-failure || ctest --rerun-failed -V -VV
 
-  # and now check that it installs where told and only there.
-  cmake --build "$BUILD_DIR" --target install -- $JOBS "$VERBOSE" "$KEEPGOING" || cmake --build "$BUILD_DIR" --target install -- -j1 "$VERBOSE" "$KEEPGOING"
+  cmake --build "$BUILD_DIR" --target install -- $JOBS "$VERBOSE" "$KEEPGOING"
 }
 
 target_notest()
 {
-  # to get as much of the issues into the log as possible
-  cmake --build "$BUILD_DIR" -- $JOBS "$VERBOSE" "$KEEPGOING" || cmake --build "$BUILD_DIR" -- -j1 "$VERBOSE" "$KEEPGOING"
+  cmake --build "$BUILD_DIR" -- $JOBS "$VERBOSE" "$KEEPGOING"
 
-  # and now check that it installs where told and only there.
-  cmake --build "$BUILD_DIR" --target install -- $JOBS "$VERBOSE" "$KEEPGOING" || cmake --build "$BUILD_DIR" --target install -- -j1 "$VERBOSE" "$KEEPGOING"
+  cmake --build "$BUILD_DIR" --target install -- $JOBS "$VERBOSE" "$KEEPGOING"
 }
 
 diskspace()

--- a/.ci/ci-script.sh
+++ b/.ci/ci-script.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #    This file is part of darktable.
-#    copyright (c) 2016 Roman Lebedev.
+#    Copyright (C) 2016-2023 darktable developers.
 #
 #    darktable is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -27,44 +27,45 @@
 
 set -ex
 
-VERBOSE="-v"
-KEEPGOING="-k0"
+if [ "$GENERATOR" = "Ninja" ];
+then
+  VERBOSE="-v"
+  KEEPGOING="-k0"
+  JOBS=""
+fi;
 
 if [ "$GENERATOR" = "Unix Makefiles" ];
 then
   VERBOSE="VERBOSE=1";
   KEEPGOING="-k"
+  JOBS="-j2"
 fi;
 
 if [ "$GENERATOR" = "MSYS Makefiles" ];
 then
   VERBOSE="VERBOSE=1";
   KEEPGOING="-k"
+  JOBS="-j2"
 fi;
-
-if [ -z "${MAKEFLAGS+x}" ];
-then
-  MAKEFLAGS="-j2 $VERBOSE"
-fi
 
 target_build()
 {
   # to get as much of the issues into the log as possible
-  cmake --build "$BUILD_DIR" -- $MAKEFLAGS || cmake --build "$BUILD_DIR" -- -j1 "$VERBOSE" "$KEEPGOING"
+  cmake --build "$BUILD_DIR" -- $JOBS "$VERBOSE" "$KEEPGOING" || cmake --build "$BUILD_DIR" -- -j1 "$VERBOSE" "$KEEPGOING"
 
   ctest --output-on-failure || ctest --rerun-failed -V -VV
 
   # and now check that it installs where told and only there.
-  cmake --build "$BUILD_DIR" --target install -- $MAKEFLAGS || cmake --build "$BUILD_DIR" --target install -- -j1 "$VERBOSE" "$KEEPGOING"
+  cmake --build "$BUILD_DIR" --target install -- $JOBS "$VERBOSE" "$KEEPGOING" || cmake --build "$BUILD_DIR" --target install -- -j1 "$VERBOSE" "$KEEPGOING"
 }
 
 target_notest()
 {
   # to get as much of the issues into the log as possible
-  cmake --build "$BUILD_DIR" -- $MAKEFLAGS || cmake --build "$BUILD_DIR" -- -j1 "$VERBOSE" "$KEEPGOING"
+  cmake --build "$BUILD_DIR" -- $JOBS "$VERBOSE" "$KEEPGOING" || cmake --build "$BUILD_DIR" -- -j1 "$VERBOSE" "$KEEPGOING"
 
   # and now check that it installs where told and only there.
-  cmake --build "$BUILD_DIR" --target install -- $MAKEFLAGS || cmake --build "$BUILD_DIR" --target install -- -j1 "$VERBOSE" "$KEEPGOING"
+  cmake --build "$BUILD_DIR" --target install -- $JOBS "$VERBOSE" "$KEEPGOING" || cmake --build "$BUILD_DIR" --target install -- -j1 "$VERBOSE" "$KEEPGOING"
 }
 
 target_usermanual()

--- a/.ci/ci-script.sh
+++ b/.ci/ci-script.sh
@@ -68,16 +68,6 @@ target_notest()
   cmake --build "$BUILD_DIR" --target install -- $JOBS "$VERBOSE" "$KEEPGOING" || cmake --build "$BUILD_DIR" --target install -- -j1 "$VERBOSE" "$KEEPGOING"
 }
 
-target_usermanual()
-{
-  cmake --build "$BUILD_DIR" -- -j1 -v -k0 validate_usermanual_xml
-
-  # # to get as much of the issues into the log as possible
-  # cmake --build "$BUILD_DIR" -- $PARALLEL -v darktable-usermanual || cmake --build "$BUILD_DIR" -- -j1 -v -k0 darktable-usermanual
-  # test -r doc/usermanual/darktable-usermanual.pdf
-  # ls -lah doc/usermanual/darktable-usermanual.pdf
-}
-
 diskspace()
 {
   df

--- a/.ci/ci-script.sh
+++ b/.ci/ci-script.sh
@@ -16,13 +16,13 @@
 #    You should have received a copy of the GNU General Public License
 #    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 
-# it is supposed to be run by travis-ci
-# expects a few env variables to be set:
-#   BUILD_DIR - the working directory, where to build
-#   INSTALL_DIR - the installation prefix.
-#   SRC_DIR - read-only directory with git checkout to compile
-#   CC, CXX, CFLAGS, CXXFLAGS are not required, should make sense too
-#   TARGET - either build, skiptest, nofeatures or usermanual
+# This script is supposed to be run by Travis CI or GitHub workflow.
+# It expects a few env variables to be set:
+#   BUILD_DIR - the working directory where the program will be built
+#   INSTALL_DIR - the installation prefix
+#   SRC_DIR - directory with the source code to be compiled
+#   CC, CXX, CFLAGS, CXXFLAGS are optional, but make sense for build
+#   TARGET - either build, skiptest, nofeatures or nofeatures_nosse
 #   ECO - some other flags for cmake
 
 set -ex


### PR DESCRIPTION
macOS virtual machines available for GitHub Actions have three processor cores (unlike Linux and Windows, for which only two cores are available). The current version of the script limited concurrency to two processes, thereby not using one of the cores on macOS.

Due to the large variance of compile time values across different runs in GitHub workflows, it is difficult to measure more or less precisely the time saved by this fix. However, averaging over several runs compared to pre-fix runs gives an approximate time savings of about 2 minutes.

Also added a commit that removes from the script an obsolete target usermanual that is no longer in use.
