### PR TITLE
More dt_print() variants used instead of fprintf()

### DIFF
--- a/src/common/cups_print.c
+++ b/src/common/cups_print.c
@@ -437,7 +437,7 @@ void dt_print_file(const int32_t imgid, const char *filename, const char *job_ti
     if(fd == -1)
     {
       dt_control_log(_("failed to create temporary file for printing options"));
-      fprintf(stderr, "failed to create temporary pdf for printing options\n");
+      dt_print(DT_DEBUG_ALWAYS, "failed to create temporary pdf for printing options\n");
       return;
     }
     close(fd);

--- a/src/common/dlopencl.c
+++ b/src/common/dlopencl.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2020 darktable developers.
+    Copyright (C) 2011-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -41,7 +41,7 @@ static const char *ocllib[] = { "libOpenCL", "libOpenCL.so", "libOpenCL.so.1", N
 void dt_dlopencl_noop(void)
 {
   /* we should normally never get here */
-  fprintf(stderr, "dt_dlopencl internal error: unsupported function call\n");
+  dt_print(DT_DEBUG_OPENCL, "dt_dlopencl internal error: unsupported function call\n");
   raise(SIGABRT);
 }
 

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1423,13 +1423,12 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
           }
         }
 
-      if((sel_illu > -1) && (darktable.unmuted & DT_DEBUG_IMAGEIO))
-      {
-        fprintf(stderr, "[exif] `%s` dng illuminant %i (%iK) selected from ", img->filename, illu[sel_illu], sel_temp);
-        for(int i = 0; i < 3; i++)
-          fprintf(stderr," -- [%i] %i (%iK)", i + 1, illu[i], _illu_to_temp(illu[i]));
-        fprintf(stderr, "\n");
-      }
+      if(sel_illu > -1)
+        dt_print(DT_DEBUG_IMAGEIO, "[exif] `%s` dng illuminant %i (%iK) selected from  [1] %i (%iK), [2] %i (%iK), [3] %i (%iK)\n",
+          img->filename, illu[sel_illu], sel_temp,
+          illu[0], _illu_to_temp(illu[0]),
+          illu[1], _illu_to_temp(illu[1]),
+          illu[2], _illu_to_temp(illu[2])); 
 
       // Take the found CalibrationIlluminant / ColorMatrix pair.
       // D65: just copy. Otherwise multiply by the specific correction matrix.

--- a/src/common/locallaplaciancl.c
+++ b/src/common/locallaplaciancl.c
@@ -116,7 +116,7 @@ dt_local_laplacian_cl_t *dt_local_laplacian_init_cl(
   return g;
 
 error:
-  fprintf(stderr, "[local laplacian cl] could not allocate temporary buffers\n");
+  dt_print(DT_DEBUG_OPENCL, "[local laplacian cl] could not allocate temporary buffers\n");
   dt_local_laplacian_free_cl(g);
   return NULL;
 }

--- a/src/common/module_api.h
+++ b/src/common/module_api.h
@@ -42,7 +42,7 @@
   if(!g_module_symbol(module->module, "dt_module_dt_version", (gpointer) & (version))) goto api_h_error;
   if(version() != dt_version())
   {
-    fprintf(stderr,
+    dt_print(DT_DEBUG_ALWAYS,
             "[" INCLUDE_API_FROM_MODULE_LOAD "] `%s' is compiled for another version of dt (module %d (%s) != dt %d (%s)) !\n",
             libname, abs(version()), version() < 0 ? "debug" : "opt", abs(dt_version()),
             dt_version() < 0 ? "debug" : "opt");
@@ -52,7 +52,7 @@
 
   goto skip_error;
 api_h_error:
-  fprintf(stderr, "[" INCLUDE_API_FROM_MODULE_LOAD "] failed to open `%s': %s\n", module_name, g_module_error());
+  dt_print(DT_DEBUG_ALWAYS, "[" INCLUDE_API_FROM_MODULE_LOAD "] failed to open `%s': %s\n", module_name, g_module_error());
   if(module->module) g_module_close(module->module);
   module->module = NULL;
   return 1;

--- a/src/common/noiseprofiles.c
+++ b/src/common/noiseprofiles.c
@@ -1,6 +1,6 @@
 /*
  *    This file is part of darktable,
- *    Copyright (C) 2015-2021 darktable developers.
+ *    Copyright (C) 2015-2023 darktable developers.
  *
  *    darktable is free software: you can redistribute it and/or modify
  *    it under the terms of the GNU General Public License as published by

--- a/src/common/noiseprofiles.c
+++ b/src/common/noiseprofiles.c
@@ -49,7 +49,7 @@ JsonParser *dt_noiseprofile_init(const char *alternative)
   JsonParser *parser = json_parser_new();
   if(!json_parser_load_from_file(parser, filename, &error))
   {
-    fprintf(stderr, "[noiseprofile] error: parsing json from `%s' failed\n%s\n", filename, error->message);
+    dt_print(DT_DEBUG_ALWAYS, "[noiseprofile] error: parsing json from `%s' failed\n%s\n", filename, error->message);
     g_error_free(error);
     g_object_unref(parser);
     return NULL;
@@ -59,7 +59,7 @@ JsonParser *dt_noiseprofile_init(const char *alternative)
   if(!dt_noiseprofile_verify(parser))
   {
     dt_control_log(_("noiseprofile file `%s' is not valid"), filename);
-    fprintf(stderr, "[noiseprofile] error: `%s' is not a valid noiseprofile file. run with -d control for details\n", filename);
+    dt_print(DT_DEBUG_ALWAYS, "[noiseprofile] error: `%s' is not a valid noiseprofile file. run with -d control for details\n", filename);
     g_object_unref(parser);
     return NULL;
   }

--- a/src/common/printprof.c
+++ b/src/common/printprof.c
@@ -61,7 +61,7 @@ int dt_apply_printer_profile(void **in, uint32_t width, uint32_t height, int bpp
 
   if(!hTransform)
   {
-    fprintf(stderr, "error printer profile may be corrupted\n");
+    dt_print(DT_DEBUG_ALWAYS, "error printer profile may be corrupted\n");
     return 1;
   }
 

--- a/src/common/profiling.c
+++ b/src/common/profiling.c
@@ -33,7 +33,7 @@ void dt_timer_stop_with_name(dt_timer_t *t)
   g_assert(t != NULL);
   g_timer_stop(t->timer);
   gulong ms = 0;
-  fprintf(stderr, "Timer %s in function %s took %.3f seconds to execute.\n", t->description, t->function,
+  dt_print(DT_DEBUG_PERF, "Timer %s in function %s took %.3f seconds to execute.\n", t->description, t->function,
           g_timer_elapsed(t->timer, &ms));
   g_timer_destroy(t->timer);
   g_free(t);

--- a/src/common/pwstorage/backend_libsecret.c
+++ b/src/common/pwstorage/backend_libsecret.c
@@ -2,7 +2,8 @@
 //
 // Copyright (c) 2014 Moritz Lipp <mlq@pwmt.org>.
 // Copyright (c) 2016 tobias ellinghaus <me@houz.org>.
-//
+// Copyright (C) 2023 darktable developers.
+
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
@@ -23,6 +24,7 @@
 
 #include "backend_libsecret.h"
 #include "control/conf.h"
+#include "common/darktable.h"
 
 #include <glib.h>
 #include <json-glib/json-glib.h>
@@ -64,7 +66,7 @@ const backend_libsecret_context_t *dt_pwstorage_libsecret_new()
   SecretService *secret_service = secret_service_get_sync(SECRET_SERVICE_LOAD_COLLECTIONS, NULL, &error);
   if(error)
   {
-    fprintf(stderr, "[pwstorage_libsecret] error connecting to Secret Service: %s\n", error->message);
+    dt_print(DT_DEBUG_ALWAYS, "[pwstorage_libsecret] error connecting to Secret Service: %s\n", error->message);
     g_error_free(error);
     if(secret_service) g_object_unref(secret_service);
     dt_pwstorage_libsecret_destroy(context);
@@ -116,7 +118,7 @@ gboolean dt_pwstorage_libsecret_set(const backend_libsecret_context_t *context, 
                                             NULL);
   if(!res)
   {
-    fprintf(stderr, "[pwstorage_libsecret] error storing password: %s\n", error->message);
+    dt_print(DT_DEBUG_ALWAYS, "[pwstorage_libsecret] error storing password: %s\n", error->message);
     g_error_free(error);
   }
 
@@ -145,7 +147,7 @@ GHashTable *dt_pwstorage_libsecret_get(const backend_libsecret_context_t *contex
                                              NULL);
   if(error)
   {
-    fprintf(stderr, "[pwstorage_libsecret] error retrieving password: %s\n", error->message);
+    dt_print(DT_DEBUG_ALWAYS, "[pwstorage_libsecret] error retrieving password: %s\n", error->message);
     g_error_free(error);
     goto error;
   }

--- a/src/common/pwstorage/pwstorage.c
+++ b/src/common/pwstorage/pwstorage.c
@@ -1,5 +1,6 @@
 // This file is part of darktable
 // Copyright (c) 2010-2016 Tobias Ellinghaus <me@houz.org>.
+// Copyright (C) 2023 darktable developers.
 
 // darktable is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -30,6 +31,7 @@
 
 #include "control/conf.h"
 #include "control/control.h"
+#include "common/darktable.h"
 
 #include <glib.h>
 #include <string.h>
@@ -79,7 +81,7 @@ const dt_pwstorage_t *dt_pwstorage_new()
 #endif
   else if(strcmp(_backend_str, "gnome keyring") == 0)
   {
-    fprintf(stderr, "[pwstorage_new] GNOME Keyring backend is no longer supported.\n");
+    dt_print(DT_DEBUG_ALWAYS, "[pwstorage_new] GNOME Keyring backend is no longer supported.\n");
     dt_control_log(_("GNOME Keyring backend is no longer supported. configure a different one"));
     _backend = PW_STORAGE_BACKEND_NONE;
   }


### PR DESCRIPTION
Make use of the better logging dt_print() variants instead of plain-old fprintf()
