### PR TITLE
Bugfix: Opposed HLR Inpaint border issues

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -522,14 +522,11 @@ kernel void highlights_opposed(
   {
     val = fmax(0.0f, read_imagef(in, samplerA, (int2)(icol, irow)).x);
 
-    if((icol > 0) && (icol < iwidth-1) && (irow > 0) && (irow < iheight-1))
+    const int color = (filters == 9u) ? FCxtrans(irow, icol, xtrans) : FC(irow, icol, filters);
+    if(val >= clips[color])
     {
-      const int color = (filters == 9u) ? FCxtrans(irow, icol, xtrans) : FC(irow, icol, filters);
-      if(val >= clips[color])
-      {
-        const float ref = _calc_refavg(in, xtrans, filters, irow, icol, iheight, iwidth);
-        val = fmax(val, ref + chroma[color]);
-      }
+      const float ref = _calc_refavg(in, xtrans, filters, irow, icol, iheight, iwidth);
+      val = fmax(val, ref + chroma[color]);
     }
   }
   write_imagef (out, (int2)(x, y), val);

--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -313,15 +313,22 @@ static float _calc_refavg(
         global const unsigned char (*const xtrans)[6],
         const unsigned int filters,
         int row,
-        int col)
+        int col,
+        int maxrow,
+        int maxcol)
 {
   float mean[3] = { 0.0f, 0.0f, 0.0f };
   float sum[3] =  { 0.0f, 0.0f, 0.0f };
   float cnt[3]  = { 0.0f, 0.0f, 0.0f };
 
-  for(int dy = -1; dy < 2; dy++)
+  const int dymin = (row > 0) ? -1 : 0;
+  const int dxmin = (col > 0) ? -1 : 0;
+  const int dymax = (row < maxrow -1) ? 2 : 1;
+  const int dxmax = (col < maxcol -1) ? 2 : 1;
+
+  for(int dy = dymin; dy < dymax; dy++)
   {
-    for(int dx = -1; dx < 2; dx++)
+    for(int dx = dxmin; dx < dxmax; dx++)
     {
       const float val = fmax(0.0f, read_imagef(in, samplerA, (int2)(col+dx, row+dy)).x);
       const int c = (filters == 9u) ? FCxtrans(row + dy, col + dx, xtrans) : FC(row + dy, col + dx, filters);
@@ -332,7 +339,7 @@ static float _calc_refavg(
 
   const float onethird = 1.0f / 3.0f;
   for(int c = 0; c < 3; c++)
-    mean[c] = pow(sum[c] / cnt[c], onethird);
+    mean[c] = (cnt[c] > 0.0f) ? pow(sum[c] / cnt[c], onethird) : 0.0f;
 
   const float croot_refavg[3] = { 0.5f * (mean[1] + mean[2]), 0.5f * (mean[0] + mean[2]), 0.5f * (mean[0] + mean[1])};
   const int color = (filters == 9u) ? FCxtrans(row, col, xtrans) : FC(row, col, filters);
@@ -473,7 +480,7 @@ kernel void highlights_chroma(
     const int px = color * msize + mad24(row/3, mwidth, col/3);
     if(mask[px] && (inval > 0.2f*clips[color]) && (inval < clips[color]))
     {
-      const float ref = _calc_refavg(in, xtrans, filters, row, col);
+      const float ref = _calc_refavg(in, xtrans, filters, row, col, height, width);
       sum[color] += inval - ref;
       cnt[color] += 1.0f;
     }
@@ -520,7 +527,7 @@ kernel void highlights_opposed(
       const int color = (filters == 9u) ? FCxtrans(irow, icol, xtrans) : FC(irow, icol, filters);
       if(val >= clips[color])
       {
-        const float ref = _calc_refavg(in, xtrans, filters, irow, icol);
+        const float ref = _calc_refavg(in, xtrans, filters, irow, icol, iheight, iwidth);
         val = fmax(val, ref + chroma[color]);
       }
     }

--- a/src/iop/hlrecovery_v2.c
+++ b/src/iop/hlrecovery_v2.c
@@ -202,9 +202,15 @@ static inline float _calc_refavg(const float *in,
   const int color = (filters == 9u) ? FCxtrans(row, col, roi, xtrans) : FC(row, col, filters);
   dt_aligned_pixel_t mean = { 0.0f, 0.0f, 0.0f, 0.0f };
   dt_aligned_pixel_t cnt = { 0.0f, 0.0f, 0.0f, 0.0f };
-  for(int dy = -1; dy < 2; dy++)
+
+  const int dymin = (row > 0) ? -1 : 0;
+  const int dxmin = (col > 0) ? -1 : 0;
+  const int dymax = (row < roi->height -1) ? 2 : 1;
+  const int dxmax = (col < roi->width -1) ? 2 : 1;
+
+  for(int dy = dymin; dy < dymax; dy++)
   {
-    for(int dx = -1; dx < 2; dx++)
+    for(int dx = dxmin; dx < dxmax; dx++)
     {
       const float val = fmaxf(0.0f, in[(ssize_t)dy * roi->width + dx]);
       const int c = (filters == 9u) ? FCxtrans(row + dy, col + dx, roi, xtrans) : FC(row + dy, col + dx, filters);

--- a/src/iop/opposed.c
+++ b/src/iop/opposed.c
@@ -391,7 +391,7 @@ static float *_process_opposed(
         const size_t idx = row * roi_in->width + col;
         const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
         const float inval = fmaxf(0.0f, input[idx]);
-        if((inval >= clips[color]) && (col > 0) && (col < roi_in->width - 1) && (row > 0) && (row < roi_in->height - 1))
+        if(inval >= clips[color])
         {
           const float ref = _calc_refavg(&input[idx], xtrans, filters, row, col, roi_in, TRUE);
           tmpout[idx] = fmaxf(inval, ref + chrominance[color]);
@@ -424,9 +424,8 @@ static float *_process_opposed(
         else
         { 
           const int color = (filters == 9u) ? FCxtrans(irow, icol, roi_in, xtrans) : FC(irow, icol, filters);
-          const gboolean inrefs = (irow > 0) && (icol > 0) && (irow < roi_in->height-1) && (icol < roi_in->width-1);
           oval = fmaxf(0.0f, input[ix]);
-          if(inrefs && (oval >= clips[color]))
+          if(oval >= clips[color])
           {
             const float ref = _calc_refavg(&input[ix], xtrans, filters, irow, icol, roi_in, TRUE);
             oval = fmaxf(oval, ref + chrominance[color]);


### PR DESCRIPTION
The outermost photosites were not HLR corrected so far leading to artefacts for the outermost single photosites.
The effect depended on the chosen demosaicer.

I came across this while investigating #13924