### PR TITLE
[GUI] sRGB profile name improvements

### DIFF
--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2022 darktable developers.
+    Copyright (C) 2010-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -1359,7 +1359,7 @@ dt_colorspaces_t *dt_colorspaces_init()
   // TODO: what about display?
   res->profiles
       = g_list_append(res->profiles, _create_profile(DT_COLORSPACE_SRGB, dt_colorspaces_create_srgb_profile_v4(),
-                                                     _("sRGB (e.g. JPG)"), ++in_pos, -1, -1, -1, -1, -1));
+                                                     _("sRGB"), ++in_pos, -1, -1, -1, -1, -1));
 
   res->profiles
       = g_list_append(res->profiles, _create_profile(DT_COLORSPACE_SRGB, dt_colorspaces_create_srgb_profile(),

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1281,7 +1281,7 @@ static GList* _get_profiles()
 
   dt_lib_export_profile_t *prof = (dt_lib_export_profile_t *)g_malloc0(sizeof(dt_lib_export_profile_t));
   prof->type = DT_COLORSPACE_SRGB;
-  dt_utf8_strlcpy(prof->name, _("sRGB (web-safe)"), sizeof(prof->name));
+  dt_utf8_strlcpy(prof->name, _("sRGB"), sizeof(prof->name));
   prof->pos = -2;
   prof->ppos = -2;
   list = g_list_prepend(list, prof);


### PR DESCRIPTION
1. Adding "e.g. JPG" to the sRGB profile name makes no sense. What is so special about sRGB that we don't just name it, but include some kind of explanation? What is special about the JPEG format that it is mentioned here? JPEG can only be in sRGB? No. Then why do we specify that the profile is "sRGB as in JPEG"? It looks strange and there is absolutely no logic in it.

2. We can leave "web-safe" as part of the profile name in the export module (just to remind the user that this is the best choice for images that will be posted on the web), but in print mode the mention of web-safe is out of place.
