### PR TITLE
Bugfix and refactor xmp writing tests

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1706,7 +1706,7 @@ void dt_history_hash_set_mipmap(const int32_t imgid)
 
 dt_history_hash_t dt_history_hash_get_status(const int32_t imgid)
 {
-  dt_history_hash_t status = 0;
+  dt_history_hash_t status = DT_HISTORY_HASH_NONE;
   if(imgid == -1) return status;
   sqlite3_stmt *stmt;
   // clang-format off

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2022 darktable developers.
+    Copyright (C) 2010-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -37,6 +37,7 @@ struct dt_iop_module_t;
 // note that if an image has no history (and no history hash) it is considered as basic
 typedef enum dt_history_hash_t
 {
+  DT_HISTORY_HASH_NONE = 0,          // no defined status for initializing
   DT_HISTORY_HASH_BASIC   = 1 << 0,  // only mandatory modules
   DT_HISTORY_HASH_AUTO    = 1 << 1,  // mandatory modules plus the auto applied ones
   DT_HISTORY_HASH_CURRENT = 1 << 2,  // current state, with or without change

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -513,8 +513,8 @@ gboolean dt_image_safe_remove(const int32_t imgid);
 /* try to sync .xmp for all local copies */
 void dt_image_local_copy_synch(void);
 // xmp functions:
-int dt_image_write_sidecar_file(const int32_t imgid);
-void dt_image_synch_xmp(const int selected);
+gboolean dt_image_write_sidecar_file(const int32_t imgid);
+void dt_image_synch_xmp(const int32_t selected);
 void dt_image_synch_xmps(const GList *img);
 void dt_image_synch_all_xmp(const gchar *pathname);
 /** get the mode xmp sidecars are written */

--- a/src/control/crawler.c
+++ b/src/control/crawler.c
@@ -418,8 +418,7 @@ static void sync_xmp_to_db(GtkTreeModel *model,
   _get_crawler_entry_from_model(model, iter, &entry);
   _db_update_timestamp(entry.id, entry.timestamp_xmp);
 
-  const int error =
-    dt_history_load_and_apply(entry.id, entry.xmp_path, 0);  // success = 0, fail = 1
+  const gboolean error = dt_history_load_and_apply(entry.id, entry.xmp_path, 0);
 
   if(error)
   {
@@ -448,7 +447,7 @@ static void sync_db_to_xmp(GtkTreeModel *model,
   _get_crawler_entry_from_model(model, iter, &entry);
 
   // write the XMP and make sure it get the last modified timestamp of the db
-  const int error = dt_image_write_sidecar_file(entry.id);  // success = 0, fail = 1
+  const gboolean error = dt_image_write_sidecar_file(entry.id);
   _set_modification_time(entry.xmp_path, entry.timestamp_db);
 
   if(error)
@@ -476,7 +475,7 @@ static void sync_newest_to_oldest(GtkTreeModel *model,
   dt_control_crawler_result_t entry = { 0 };
   _get_crawler_entry_from_model(model, iter, &entry);
 
-  int error = 0;
+  gboolean error = FALSE;
 
   if(entry.timestamp_xmp > entry.timestamp_db)
   {
@@ -527,7 +526,7 @@ static void sync_newest_to_oldest(GtkTreeModel *model,
   {
     // we should never reach that part of the code
     // if both timestamps are equal, they should not be in this list in the first place
-    error = 1;
+    error = TRUE;
     _log_synchronization(gui, _("EXCEPTION: %s has inconsistent timestamps"),
                          entry.image_path);
   }
@@ -546,7 +545,7 @@ static void sync_oldest_to_newest(GtkTreeModel *model,
   dt_control_crawler_gui_t *gui = (dt_control_crawler_gui_t *)user_data;
   dt_control_crawler_result_t entry = { 0 };
   _get_crawler_entry_from_model(model, iter, &entry);
-  int error = 0;
+  gboolean error = FALSE;
 
   if(entry.timestamp_xmp < entry.timestamp_db)
   {
@@ -594,7 +593,7 @@ static void sync_oldest_to_newest(GtkTreeModel *model,
   {
     // we should never reach that part of the code
     // if both timestamps are equal, they should not be in this list in the first place
-    error = 1;
+    error = TRUE;
     _log_synchronization(gui,
                          _("EXCEPTION: %s has inconsistent timestamps"),
                          entry.image_path);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -947,15 +947,15 @@ static void _dev_change_image(dt_develop_t *dev, const int32_t imgid)
   // commit image ops to db
   dt_dev_write_history(dev);
 
-  const int32_t devid = dev->image_storage.id;
+  const int32_t new_imgid = dev->image_storage.id;
 
   // be sure light table will update the thumbnail
-  if(!dt_history_hash_is_mipmap_synced(devid))
+  if(!dt_history_hash_is_mipmap_synced(new_imgid))
   {
-    dt_mipmap_cache_remove(darktable.mipmap_cache, devid);
-    dt_image_update_final_size(devid);
-    dt_image_synch_xmp(devid);
-    dt_history_hash_set_mipmap(devid);
+    dt_mipmap_cache_remove(darktable.mipmap_cache, new_imgid);
+    dt_image_update_final_size(new_imgid);
+    dt_image_synch_xmp(new_imgid);
+    dt_history_hash_set_mipmap(new_imgid);
 #ifdef USE_LUA
     dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
         0, NULL, NULL,
@@ -3236,7 +3236,7 @@ void leave(dt_view_t *self)
   // commit image ops to db
   dt_dev_write_history(dev);
 
-  const int32_t devid = dev->image_storage.id;
+  const int32_t imgid = dev->image_storage.id;
 
   // update aspect ratio
   if(dev->preview_pipe->backbuf && dev->preview_status == DT_DEV_PIXELPIPE_VALID)
@@ -3246,16 +3246,16 @@ void leave(dt_view_t *self)
   }
   else
   {
-    dt_image_set_aspect_ratio(devid, FALSE);
+    dt_image_set_aspect_ratio(imgid, FALSE);
   }
 
   // be sure light table will regenerate the thumbnail:
-  if(!dt_history_hash_is_mipmap_synced(devid))
+  if(!dt_history_hash_is_mipmap_synced(imgid))
   {
-    dt_mipmap_cache_remove(darktable.mipmap_cache, devid);
-    dt_image_update_final_size(devid);
-    dt_image_synch_xmp(devid);
-    dt_history_hash_set_mipmap(devid);
+    dt_mipmap_cache_remove(darktable.mipmap_cache, imgid);
+    dt_image_update_final_size(imgid);
+    dt_image_synch_xmp(imgid);
+    dt_history_hash_set_mipmap(imgid);
 #ifdef USE_LUA
     dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
         0, NULL, NULL,

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -947,18 +947,15 @@ static void _dev_change_image(dt_develop_t *dev, const int32_t imgid)
   // commit image ops to db
   dt_dev_write_history(dev);
 
-  // be sure light table will update the thumbnail
-  if(!dt_history_hash_is_mipmap_synced(dev->image_storage.id))
-  {
-    const dt_history_hash_t hash_status = dt_history_hash_get_status(dev->image_storage.id);
+  const int32_t devid = dev->image_storage.id;
 
-    dt_mipmap_cache_remove(darktable.mipmap_cache, dev->image_storage.id);
-    dt_image_update_final_size(dev->image_storage.id);
-    const gboolean fresh = (hash_status == DT_HISTORY_HASH_BASIC) || (hash_status == DT_HISTORY_HASH_AUTO);
-    const dt_imageio_write_xmp_t xmp_mode = dt_image_get_xmp_mode();
-    if((xmp_mode == DT_WRITE_XMP_ALWAYS) || ((xmp_mode == DT_WRITE_XMP_LAZY) && !fresh))
-      dt_image_synch_xmp(dev->image_storage.id);
-    dt_history_hash_set_mipmap(dev->image_storage.id);
+  // be sure light table will update the thumbnail
+  if(!dt_history_hash_is_mipmap_synced(devid))
+  {
+    dt_mipmap_cache_remove(darktable.mipmap_cache, devid);
+    dt_image_update_final_size(devid);
+    dt_image_synch_xmp(devid);
+    dt_history_hash_set_mipmap(devid);
 #ifdef USE_LUA
     dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
         0, NULL, NULL,
@@ -3239,6 +3236,8 @@ void leave(dt_view_t *self)
   // commit image ops to db
   dt_dev_write_history(dev);
 
+  const int32_t devid = dev->image_storage.id;
+
   // update aspect ratio
   if(dev->preview_pipe->backbuf && dev->preview_status == DT_DEV_PIXELPIPE_VALID)
   {
@@ -3247,22 +3246,16 @@ void leave(dt_view_t *self)
   }
   else
   {
-    dt_image_set_aspect_ratio(dev->image_storage.id, FALSE);
+    dt_image_set_aspect_ratio(devid, FALSE);
   }
 
   // be sure light table will regenerate the thumbnail:
-  if(!dt_history_hash_is_mipmap_synced(dev->image_storage.id))
+  if(!dt_history_hash_is_mipmap_synced(devid))
   {
-    dt_mipmap_cache_remove(darktable.mipmap_cache, dev->image_storage.id);
-    dt_image_update_final_size(dev->image_storage.id);
-    // possibly dump new xmp data
-    const dt_history_hash_t hash_status = dt_history_hash_get_status(dev->image_storage.id);
-
-    const gboolean fresh = (hash_status == DT_HISTORY_HASH_BASIC) || (hash_status == DT_HISTORY_HASH_AUTO);
-    const dt_imageio_write_xmp_t xmp_mode = dt_image_get_xmp_mode();
-    if((xmp_mode == DT_WRITE_XMP_ALWAYS) || ((xmp_mode == DT_WRITE_XMP_LAZY) && !fresh))
-      dt_image_synch_xmp(dev->image_storage.id);
-    dt_history_hash_set_mipmap(dev->image_storage.id);
+    dt_mipmap_cache_remove(darktable.mipmap_cache, devid);
+    dt_image_update_final_size(devid);
+    dt_image_synch_xmp(devid);
+    dt_history_hash_set_mipmap(devid);
 #ifdef USE_LUA
     dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
         0, NULL, NULL,


### PR DESCRIPTION
Fixes #13870

Investigated above issue, an easier way to reproduce (also a more common use case):

1. Select "after edit" in UI's "write sidecar for each image"
2. Import some raws and jpegs
3. close dt and check for possibly written sidecars (there should be none)
4. open dt and remove those images from the database
5. close dt and check for written sidecars again
6. You will find written sidecars for non-raws which is wrong.

Central fix is in `gboolean dt_image_write_sidecar_file(const int32_t imgid)`

- now returns a gboolean, TRUE if no sidecar was written
- it properly checks if xmp writing mode is DT_WRITE_XMP_NEVER OR writing mode is DT_WRITE_XMP_LAZY **and** image is un-altered
- in both cases xmp files are **not** written

Add DT_HISTORY_HASH_NONE to dt_history_hash_t
image ids should always be int32_t