### PR TITLE
fix for off-by-one error at top/left edges

### DIFF
--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -450,7 +450,12 @@ static inline void compute_upsampling_kernel_plain(const struct dt_interpolation
                                                    int *first,
                                                    float t)
 {
-  int f = (int)t - itor->width + 1;
+  // find first pixel contributing to the filter's kernel.  We need
+  // floorf() because a simple cast to int truncates toward zero,
+  // yielding an incorrect result for the slightly-negative positions
+  // that can occur at the top and left edges when doing perspective
+  // correction
+  int f = (int)floorf(t) - itor->width + 1;
   if(first)
   {
     *first = f;
@@ -495,7 +500,12 @@ static inline void compute_upsampling_kernel_sse(const struct dt_interpolation *
                                                  int *first,
                                                  float t)
 {
-  int f = (int)t - itor->width + 1;
+  // find first pixel contributing to the filter's kernel.  We need
+  // floorf() because a simple cast to int truncates toward zero,
+  // yielding an incorrect result for the slightly-negative positions
+  // that can occur at the top and left edges when doing perspective
+  // correction
+  int f = (int)floorf(t) - itor->width + 1;
   if(first)
   {
     *first = f;


### PR DESCRIPTION
@TurboGit: this is not intended to be merged, as the equivalent fix is incorporated into my upcoming big PR reworking the pixel interpolators.  The intent is to give you a way to distinguish the (large!) maxDE caused by the fix from any actual regressions in my new code.

This PR affects the results of new tests 0110 to 0112.  0113-0115 are unaffected because resizing doesn't cause resampling of negative coordinates.
