### PR TITLE
reposition module tooltips if off to right

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -859,6 +859,22 @@ void dt_shortcut_copy_lua(dt_action_t *action, gchar *preset_name)
   _shortcut_copy_lua(widget, &shortcut, preset_name);
 }
 
+static void _tooltip_reposition(GtkWidget *widget, GdkRectangle *allocation, gpointer user_data)
+{
+  GdkWindow *window = gtk_widget_get_window(gtk_widget_get_toplevel(widget));
+  if(!window) return;
+
+  gint wx, wy, width = gdk_window_get_width(window);
+  gdk_window_get_origin(window, &wx, &wy);
+
+  GdkRectangle workarea;
+  gdk_monitor_get_workarea(gdk_display_get_monitor_at_window(gdk_window_get_display(window), window), &workarea);
+
+  wx = CLAMP(wx, workarea.x, workarea.x + workarea.width - width);
+
+  gdk_window_move(window, wx, wy);
+}
+
 gboolean dt_shortcut_tooltip_callback(GtkWidget *widget, gint x, gint y, gboolean keyboard_mode,
                                       GtkTooltip *tooltip, GtkWidget *vbox)
 {
@@ -1045,6 +1061,7 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget, gint x, gint y, gboolea
 
   gtk_widget_show_all(vbox);
   gtk_tooltip_set_custom(tooltip, vbox);
+  g_signal_connect(G_OBJECT(vbox), "size-allocate", G_CALLBACK(_tooltip_reposition), widget);
 
   return TRUE;
 }


### PR DESCRIPTION
As kindly reported here https://github.com/aurelienpierreeng/ansel/commit/5cfd4d856a158b72953d884fa4b8edb6d93bd13a gtk does not always correctly position module tooltips so they have a tendency to fall off the right side of the screen. Possibly to do with vboxes in `gtk_tooltip_set_custom` or an incorrectly set anchor hint, but unfortunately not easily solved by ripping out `dt_shortcut_tooltip_callback`.

I've briefly tried, but failed, to use `gdk_window_move_to_rect` with `GDK_ANCHOR_FLIP | GDK_ANCHOR_SLIDE` to fix this. Maybe somebody else wants to give this a go. From google it seems that this is likely to be a not easily solved problem on wayland as well, although I have not even gone there.

But under X, with one monitor, this PR solves the issue for me.

Needs testing under multi-monitor as well (in case a tooltip that is just off to the left gets pushed completely to a screen on the left).

There still is a related issue where hovering over a module with a long tooltip and then over one with a short one causes the second one to appear much more to the left than necessary. Again, this may be solvable with `gdk_window_move_to_rect`, but I haven't managed to find the correct coordinates for `rect`.

@TurboGit now that module headers often contain (long) preset names as well and as a result get ellipsized more frequently, could we consider having the full name of the module (and preset) in the tooltip as well? With the obvious drawback of making it larger...