### PR TITLE
Make dt_lua_image_t millisecond aware

### DIFF
--- a/src/lua/image.c
+++ b/src/lua/image.c
@@ -326,10 +326,13 @@ static int exif_datetime_taken_member(lua_State *L)
   if(lua_gettop(L) != 3)
   {
     const dt_image_t *my_image = checkreadimage(L, 1);
-    char sdt[DT_DATETIME_EXIF_LENGTH] = {0};
-    dt_datetime_img_to_exif(sdt, sizeof(sdt), my_image);
+    int datetime_size = dt_conf_get_bool("lighttable/ui/milliseconds") ? DT_DATETIME_LENGTH 
+                                                                       : DT_DATETIME_EXIF_LENGTH;
+    char *sdt = calloc(datetime_size, sizeof(char));
+    dt_datetime_img_to_exif(sdt, datetime_size, my_image);
     lua_pushstring(L, sdt);
     releasereadimage(L, my_image);
+    free(sdt);
     return 1;
   }
   else


### PR DESCRIPTION
   Make the dt_lua_image_t datetime_taken field respect he `show image time with milliseconds` preference.

Partially fixes #12583 

To test: 
- add the print_image_time.lua script and enable it
- run darktable in a console
- assign a shortcut to the print_image_time script
- hover over an image and use the shortcut.  Image time will be printed in the console
- change the `lighttable/show time with milliseconds` setting then use the shortcut again to print image time.

[print_image_time.zip](https://github.com/darktable-org/darktable/files/11009241/print_image_time.zip)
