### PR TITLE
[CI] Speed up Linux and MSYS2 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
             SDL2:p
             sqlite3:p
             zlib:p
-          update: true
+          update: false
       - run: git config --global core.autocrlf input
         shell: bash
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,11 @@ jobs:
           sudo add-apt-repository -y universe
           sudo add-apt-repository -y multiverse
           sudo apt-get update
-          sudo apt-get -y install \
+          sudo eatmydata apt-get -y install \
             ${{ matrix.compiler.packages }}
       - name: Install Base Dependencies
         run: |
-          sudo apt-get -y install \
+          sudo eatmydata apt-get -y install \
             build-essential \
             appstream-util \
             desktop-file-utils \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -82,7 +82,7 @@ jobs:
             SDL2:p
             sqlite3:p
             zlib:p
-          update: true
+          update: false
       - run: git config --global core.autocrlf input
         shell: bash
       - uses: actions/checkout@v3


### PR DESCRIPTION
apt operations are speeded up thanks to [eatmyadata](https://github.com/stewartsmith/libeatmydata), an LD_PRELOAD tool that makes sync/fsync a no-op.

Fot MSYS2, the base installation will not be updated saving time that would be wasted on updates we don't really need.
