### PR TITLE
performance: RGB-scene blending

### DIFF
--- a/src/develop/blends/blendif_rgb_jzczhz.c
+++ b/src/develop/blends/blendif_rgb_jzczhz.c
@@ -36,8 +36,8 @@
 #define DT_BLENDIF_RGB_BCH 3
 
 
-typedef void(_blend_row_func)(const float *const restrict a, const float *const restrict b, const float p,
-                              float *const restrict out, const float *const restrict mask, const size_t stride);
+typedef void(_blend_row_func)(const float *const a, const float *const b, const float p,
+                              float *const out, const float *const restrict mask, const size_t stride);
 
 
 #ifdef _OPENMP
@@ -369,8 +369,12 @@ void dt_develop_blendif_rgb_jzczhz_make_mask(struct dt_dev_pixelpipe_iop_t *piec
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out:16) uniform(p, stride)
 #endif
-static void _blend_normal(const float *const restrict a, const float *const restrict b, const float p,
-                          float *const restrict out, const float *const restrict mask, const size_t stride)
+static void _blend_normal(const float *const a,
+                          const float *const b,
+                          const float p,
+                          float *const out,
+                          const float *const restrict mask,
+                          const size_t stride)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
   {
@@ -387,8 +391,12 @@ static void _blend_normal(const float *const restrict a, const float *const rest
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out:16) uniform(p, stride)
 #endif
-static void _blend_multiply(const float *const restrict a, const float *const restrict b, const float p,
-                            float *const restrict out, const float *const restrict mask, const size_t stride)
+static void _blend_multiply(const float *const a,
+                            const float *const b,
+                            const float p,
+                            float *const out,
+                            const float *const restrict mask,
+                            const size_t stride)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
   {
@@ -405,8 +413,12 @@ static void _blend_multiply(const float *const restrict a, const float *const re
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out:16) uniform(p, stride)
 #endif
-static void _blend_add(const float *const restrict a, const float *const restrict b, const float p,
-                       float *const restrict out, const float *const restrict mask, const size_t stride)
+static void _blend_add(const float *const a,
+                       const float *const b,
+                       const float p,
+                       float *const out,
+                       const float *const restrict mask,
+                       const size_t stride)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
   {
@@ -423,8 +435,12 @@ static void _blend_add(const float *const restrict a, const float *const restric
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out:16) uniform(p, stride)
 #endif
-static void _blend_subtract(const float *const restrict a, const float *const restrict b, const float p,
-                            float *const restrict out, const float *const restrict mask, const size_t stride)
+static void _blend_subtract(const float *const a,
+                            const float *const b,
+                            const float p,
+                            float *const out,
+                            const float *const restrict mask,
+                            const size_t stride)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
   {
@@ -441,8 +457,11 @@ static void _blend_subtract(const float *const restrict a, const float *const re
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out:16) uniform(p, stride)
 #endif
-static void _blend_subtract_inverse(const float *const restrict a, const float *const restrict b, const float p,
-                                    float *const restrict out, const float *const restrict mask,
+static void _blend_subtract_inverse(const float *const a,
+                                    const float *const b,
+                                    const float p,
+                                    float *const out,
+                                    const float *const restrict mask,
                                     const size_t stride)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
@@ -460,8 +479,12 @@ static void _blend_subtract_inverse(const float *const restrict a, const float *
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out:16) uniform(p, stride)
 #endif
-static void _blend_difference(const float *const restrict a, const float *const restrict b, const float p,
-                              float *const restrict out, const float *const restrict mask, const size_t stride)
+static void _blend_difference(const float *const a,
+                              const float *const b,
+                              const float p,
+                              float *const out,
+                              const float *const restrict mask,
+                              const size_t stride)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
   {
@@ -478,8 +501,12 @@ static void _blend_difference(const float *const restrict a, const float *const 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out:16) uniform(p, stride)
 #endif
-static void _blend_divide(const float *const restrict a, const float *const restrict b, const float p,
-                          float *const restrict out, const float *const restrict mask, const size_t stride)
+static void _blend_divide(const float *const a,
+                          const float *const b,
+                          const float p,
+                          float *const out,
+                          const float *const restrict mask,
+                          const size_t stride)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
   {
@@ -496,8 +523,12 @@ static void _blend_divide(const float *const restrict a, const float *const rest
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out:16) uniform(p, stride)
 #endif
-static void _blend_divide_inverse(const float *const restrict a, const float *const restrict b, const float p,
-                                  float *const restrict out, const float *const restrict mask, const size_t stride)
+static void _blend_divide_inverse(const float *const a,
+                                  const float *const b,
+                                  const float p,
+                                  float *const out,
+                                  const float *const restrict mask,
+                                  const size_t stride)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
   {
@@ -514,8 +545,12 @@ static void _blend_divide_inverse(const float *const restrict a, const float *co
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out:16) uniform(p, stride)
 #endif
-static void _blend_average(const float *const restrict a, const float *const restrict b, const float p,
-                           float *const restrict out, const float *const restrict mask, const size_t stride)
+static void _blend_average(const float *const a,
+                           const float *const b,
+                           const float p,
+                           float *const out,
+                           const float *const restrict mask,
+                           const size_t stride)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
   {
@@ -532,8 +567,12 @@ static void _blend_average(const float *const restrict a, const float *const res
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out:16) uniform(p, stride)
 #endif
-static void _blend_geometric_mean(const float *const restrict a, const float *const restrict b, const float p,
-                                  float *const restrict out, const float *const restrict mask, const size_t stride)
+static void _blend_geometric_mean(const float *const a,
+                                  const float *const b,
+                                  const float p,
+                                  float *const out,
+                                  const float *const restrict mask,
+                                  const size_t stride)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
   {
@@ -550,8 +589,12 @@ static void _blend_geometric_mean(const float *const restrict a, const float *co
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out:16) uniform(p, stride)
 #endif
-static void _blend_harmonic_mean(const float *const restrict a, const float *const restrict b, const float p,
-                                 float *const restrict out, const float *const restrict mask, const size_t stride)
+static void _blend_harmonic_mean(const float *const a,
+                                 const float *const b,
+                                 const float p,
+                                 float *const out,
+                                 const float *const restrict mask,
+                                 const size_t stride)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
   {
@@ -570,8 +613,12 @@ static void _blend_harmonic_mean(const float *const restrict a, const float *con
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out:16) uniform(p, stride)
 #endif
-static void _blend_chromaticity(const float *const restrict a, const float *const restrict b, const float p,
-                                float *const restrict out, const float *const restrict mask, const size_t stride)
+static void _blend_chromaticity(const float *const a,
+                                const float *const b,
+                                const float p,
+                                float *const out,
+                                const float *const restrict mask,
+                                const size_t stride)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
   {
@@ -590,8 +637,12 @@ static void _blend_chromaticity(const float *const restrict a, const float *cons
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out:16) uniform(p, stride)
 #endif
-static void _blend_luminance(const float *const restrict a, const float *const restrict b, const float p,
-                             float *const restrict out, const float *const restrict mask, const size_t stride)
+static void _blend_luminance(const float *const a,
+                             const float *const b,
+                             const float p,
+                             float *const out,
+                             const float *const restrict mask,
+                             const size_t stride)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
   {
@@ -610,8 +661,12 @@ static void _blend_luminance(const float *const restrict a, const float *const r
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out:16) uniform(p, stride)
 #endif
-static void _blend_RGB_R(const float *const restrict a, const float *const restrict b, const float p,
-                         float *const restrict out, const float *const restrict mask, const size_t stride)
+static void _blend_RGB_R(const float *const a,
+                         const float *const b,
+                         const float p,
+                         float *const out,
+                         const float *const restrict mask,
+                         const size_t stride)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
   {
@@ -627,8 +682,12 @@ static void _blend_RGB_R(const float *const restrict a, const float *const restr
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out:16) uniform(p, stride)
 #endif
-static void _blend_RGB_G(const float *const restrict a, const float *const restrict b, const float p,
-                         float *const restrict out, const float *const restrict mask, const size_t stride)
+static void _blend_RGB_G(const float *const a,
+                         const float *const b,
+                         const float p,
+                         float *const out,
+                         const float *const restrict mask,
+                         const size_t stride)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
   {
@@ -644,8 +703,12 @@ static void _blend_RGB_G(const float *const restrict a, const float *const restr
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out:16) uniform(p, stride)
 #endif
-static void _blend_RGB_B(const float *const restrict a, const float *const restrict b, const float p,
-                         float *const restrict out, const float *const restrict mask, const size_t stride)
+static void _blend_RGB_B(const float *const a,
+                         const float *const b,
+                         const float p,
+                         float *const out,
+                         const float *const restrict mask,
+                         const size_t stride)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_RGB_CH)
   {
@@ -1004,39 +1067,33 @@ void dt_develop_blendif_rgb_jzczhz_blend(struct dt_dev_pixelpipe_iop_t *piece, c
     const float p = exp2f(d->blend_parameter);
     _blend_row_func *const blend = _choose_blend_func(d->blend_mode);
 
-    float *tmp_buffer = dt_alloc_align_float((size_t)owidth * oheight * DT_BLENDIF_RGB_CH);
-    if(tmp_buffer != NULL)
+    if((d->blend_mode & DEVELOP_BLEND_REVERSE) == DEVELOP_BLEND_REVERSE)
     {
-      dt_iop_image_copy(tmp_buffer, b, (size_t)owidth * oheight * DT_BLENDIF_RGB_CH);
-      if((d->blend_mode & DEVELOP_BLEND_REVERSE) == DEVELOP_BLEND_REVERSE)
-      {
 #ifdef _OPENMP
-#pragma omp parallel for schedule(static) default(none) \
-  dt_omp_firstprivate(a, b, tmp_buffer, mask, blend, oheight, owidth, iwidth, xoffs, yoffs, p)
+#pragma omp parallel for schedule(static) default(none)                 \
+  dt_omp_firstprivate(a, b, mask, blend, oheight, owidth, iwidth, xoffs, yoffs, p)
 #endif
-        for(size_t y = 0; y < oheight; y++)
-        {
-          const size_t a_start = ((y + yoffs) * iwidth + xoffs) * DT_BLENDIF_RGB_CH;
-          const size_t b_start = y * owidth * DT_BLENDIF_RGB_CH;
-          const size_t m_start = y * owidth;
-          blend(tmp_buffer + b_start, a + a_start, p, b + b_start, mask + m_start, owidth);
-        }
-      }
-      else
+      for(size_t y = 0; y < oheight; y++)
       {
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static) default(none) \
-  dt_omp_firstprivate(a, b, tmp_buffer, mask, blend, oheight, owidth, iwidth, xoffs, yoffs, p)
-#endif
-        for(size_t y = 0; y < oheight; y++)
-        {
-          const size_t a_start = ((y + yoffs) * iwidth + xoffs) * DT_BLENDIF_RGB_CH;
-          const size_t b_start = y * owidth * DT_BLENDIF_RGB_CH;
-          const size_t m_start = y * owidth;
-          blend(a + a_start, tmp_buffer + b_start, p, b + b_start, mask + m_start, owidth);
-        }
+        const size_t a_start = ((y + yoffs) * iwidth + xoffs) * DT_BLENDIF_RGB_CH;
+        const size_t b_start = y * owidth * DT_BLENDIF_RGB_CH;
+        const size_t m_start = y * owidth;
+        blend(b + b_start, a + a_start, p, b + b_start, mask + m_start, owidth);
       }
-      dt_free_align(tmp_buffer);
+    }
+    else
+    {
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static) default(none)                 \
+  dt_omp_firstprivate(a, b, mask, blend, oheight, owidth, iwidth, xoffs, yoffs, p)
+#endif
+      for(size_t y = 0; y < oheight; y++)
+      {
+        const size_t a_start = ((y + yoffs) * iwidth + xoffs) * DT_BLENDIF_RGB_CH;
+        const size_t b_start = y * owidth * DT_BLENDIF_RGB_CH;
+        const size_t m_start = y * owidth;
+        blend(a + a_start, b + b_start, p, b + b_start, mask + m_start, owidth);
+      }
     }
   }
 


### PR DESCRIPTION
Eliminate the intermediate buffer as for RGB-display blending, saving about 30ms on a 10 MPixel image due to reduced memory bandwidth.  Generates same results as master on tests 0119, 0120, and 0121.

Peformance on integration test 0119:
```
exposure1 (normal mode)
Thr	Master	PR	(abs)	(rel)
1	0.197	0.107	-0.090	-45%
2	0.116	0.061	-0.055	-47%
4	0.072	0.038	-0.034	-47%
8	0.062	0.029	-0.033	-53%
16	0.060	0.027	-0.033	-55%
32	0.063	0.028	-0.035	-55%
64	0.073	0.034	-0.039	-53%

exposure2 (difference)
Thr	Master	PR	(abs)	(rel)
1	0.788	0.731	-0.055	 -7%
2	0.414	0.375	-0.039	 -9%
4	0.229	0.201	-0.028	-12%
8	0.149	0.120	-0.029	-19%
16	0.119	0.087	-0.032	-27%
32	0.124	0.090	-0.034	-27%
64	0.198	0.161	-0.037	-18%

exposure3 (geom.mean)
Thr	Master	PR	(abs)	(rel)
1	2.494	2.418	-0.076	 -3%
2	1.272	1.223	-0.049   -4%
4	0.656	0.624	-0.032	 -5%
8	0.357	0.325	-0.032	 -9%
16	0.206	0.174	-0.032	-15%
32	0.134	0.101	-0.033	-24%
64	0.117	0.078	-0.039	-33%

exposure4 (green)
Thr	Master	PR	(abs)	(rel)
1	0.140	0.060	-0.080	-57%
2	0.085	0.034	-0.051	-60%
4	0.054	0.022	-0.032	-59%
8	0.051	0.019	-0.032	-62%
16	0.051	0.019	-0.032	-62%
32	0.053	0.022	-0.031	-58%
64	0.059	0.026	-0.033	-56%
```
Un-masked instance for comparison:
```
Thr	Master	PR
1	0.044	0.044
2	0.030	0.030
4	0.018	0.017
8	0.012	0.012
16	0.009	0.009
32	0.008	0.008
64	0.008	0.008
```
