### PR TITLE
performance: Lab blending

### DIFF
--- a/src/develop/blends/blendif_lab.c
+++ b/src/develop/blends/blendif_lab.c
@@ -37,8 +37,8 @@
 #define DT_BLENDIF_LAB_BCH 3
 
 
-typedef void(_blend_row_func)(const float *const restrict a, const float *const restrict b,
-                              float *const restrict out, const float *const restrict mask, const size_t stride,
+typedef void(_blend_row_func)(const float *const a, const float *const b,
+                              float *const out, const float *const restrict mask, const size_t stride,
                               const dt_aligned_pixel_t min, const dt_aligned_pixel_t max);
 
 
@@ -366,9 +366,13 @@ static inline void _blend_Lab_rescale(const float *i, float *o)
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_normal_bounded(const float *const restrict a, const float *const restrict b,
-                                  float *const restrict out, const float *const restrict mask, const size_t stride,
-                                  const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_normal_bounded(const float *const a,
+                                  const float *const b,
+                                  float *const out,
+                                  const float *const restrict mask,
+                                  const size_t stride,
+                                  const dt_aligned_pixel_t min,
+                                  const dt_aligned_pixel_t max)
 {
   for(size_t i = 0; i < stride; i++)
   {
@@ -391,10 +395,13 @@ static void _blend_normal_bounded(const float *const restrict a, const float *co
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_normal_unbounded(const float *const restrict a, const float *const restrict b,
-                                    float *const restrict out,
-                                    const float *const restrict mask, const size_t stride,
-                                    const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_normal_unbounded(const float *const a,
+                                    const float *const b,
+                                    float *const out,
+                                    const float *const restrict mask,
+                                    const size_t stride,
+                                    const dt_aligned_pixel_t min,
+                                    const dt_aligned_pixel_t max)
 {
   for(size_t i = 0; i < stride; i++)
   {
@@ -417,9 +424,13 @@ static void _blend_normal_unbounded(const float *const restrict a, const float *
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_lighten(const float *const restrict a, const float *const restrict b,
-                           float *const restrict out, const float *const restrict mask, const size_t stride,
-                           const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_lighten(const float *const a,
+                           const float *const b,
+                           float *const out,
+                           const float *const restrict mask,
+                           const size_t stride,
+                           const dt_aligned_pixel_t min,
+                           const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -445,9 +456,13 @@ static void _blend_lighten(const float *const restrict a, const float *const res
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_darken(const float *const restrict a, const float *const restrict b,
-                          float *const restrict out, const float *const restrict mask, const size_t stride,
-                          const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_darken(const float *const a,
+                          const float *const b,
+                          float *const out,
+                          const float *const restrict mask,
+                          const size_t stride,
+                          const dt_aligned_pixel_t min,
+                          const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -473,9 +488,13 @@ static void _blend_darken(const float *const restrict a, const float *const rest
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_multiply(const float *const restrict a, const float *const restrict b,
-                            float *const restrict out, const float *const restrict mask, const size_t stride,
-                            const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_multiply(const float *const a,
+                            const float *const b,
+                            float *const out,
+                            const float *const restrict mask,
+                            const size_t stride,
+                            const dt_aligned_pixel_t min,
+                            const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -500,9 +519,13 @@ static void _blend_multiply(const float *const restrict a, const float *const re
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_average(const float *const restrict a, const float *const restrict b,
-                           float *const restrict out, const float *const restrict mask, const size_t stride,
-                           const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_average(const float *const a,
+                           const float *const b,
+                           float *const out,
+                           const float *const restrict mask,
+                           const size_t stride,
+                           const dt_aligned_pixel_t min,
+                           const dt_aligned_pixel_t max)
 {
   for(size_t i = 0; i < stride; i++)
   {
@@ -525,9 +548,13 @@ static void _blend_average(const float *const restrict a, const float *const res
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_add(const float *const restrict a, const float *const restrict b,
-                       float *const restrict out, const float *const restrict mask, const size_t stride,
-                       const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_add(const float *const a,
+                       const float *const b,
+                       float *const out,
+                       const float *const restrict mask,
+                       const size_t stride,
+                       const dt_aligned_pixel_t min,
+                       const dt_aligned_pixel_t max)
 {
   for(size_t i = 0; i < stride; i++)
   {
@@ -550,9 +577,13 @@ static void _blend_add(const float *const restrict a, const float *const restric
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_subtract(const float *const restrict a, const float *const restrict b,
-                            float *const restrict out, const float *const restrict mask, const size_t stride,
-                            const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_subtract(const float *const a,
+                            const float *const b,
+                            float *const out,
+                            const float *const restrict mask,
+                            const size_t stride,
+                            const dt_aligned_pixel_t min,
+                            const dt_aligned_pixel_t max)
 {
   for(size_t i = 0; i < stride; i++)
   {
@@ -576,9 +607,13 @@ static void _blend_subtract(const float *const restrict a, const float *const re
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_difference(const float *const restrict a, const float *const restrict b,
-                              float *const restrict out, const float *const restrict mask, const size_t stride,
-                              const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_difference(const float *const a,
+                              const float *const b,
+                              float *const out,
+                              const float *const restrict mask,
+                              const size_t stride,
+                              const dt_aligned_pixel_t min,
+                              const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -606,9 +641,13 @@ static void _blend_difference(const float *const restrict a, const float *const 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_difference2(const float *const restrict a, const float *const restrict b,
-                               float *const restrict out, const float *const restrict mask, const size_t stride,
-                               const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_difference2(const float *const a,
+                               const float *const b,
+                               float *const out,
+                               const float *const restrict mask,
+                               const size_t stride,
+                               const dt_aligned_pixel_t min,
+                               const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -635,9 +674,13 @@ static void _blend_difference2(const float *const restrict a, const float *const
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_screen(const float *const restrict a, const float *const restrict b,
-                          float *const restrict out, const float *const restrict mask, const size_t stride,
-                          const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_screen(const float *const a,
+                          const float *const b,
+                          float *const out,
+                          const float *const restrict mask,
+                          const size_t stride,
+                          const dt_aligned_pixel_t min,
+                          const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -670,9 +713,13 @@ static void _blend_screen(const float *const restrict a, const float *const rest
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_overlay(const float *const restrict a, const float *const restrict b,
-                           float *const restrict out, const float *const restrict mask, const size_t stride,
-                           const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_overlay(const float *const a,
+                           const float *const b,
+                           float *const out,
+                           const float *const restrict mask,
+                           const size_t stride,
+                           const dt_aligned_pixel_t min,
+                           const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -709,9 +756,13 @@ static void _blend_overlay(const float *const restrict a, const float *const res
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_softlight(const float *const restrict a, const float *const restrict b,
-                             float *const restrict out, const float *const restrict mask, const size_t stride,
-                             const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_softlight(const float *const a,
+                             const float *const b,
+                             float *const out,
+                             const float *const restrict mask,
+                             const size_t stride,
+                             const dt_aligned_pixel_t min,
+                             const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -747,9 +798,13 @@ static void _blend_softlight(const float *const restrict a, const float *const r
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_hardlight(const float *const restrict a, const float *const restrict b,
-                             float *const restrict out, const float *const restrict mask, const size_t stride,
-                             const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_hardlight(const float *const a,
+                             const float *const b,
+                             float *const out,
+                             const float *const restrict mask,
+                             const size_t stride,
+                             const dt_aligned_pixel_t min,
+                             const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -786,9 +841,13 @@ static void _blend_hardlight(const float *const restrict a, const float *const r
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_vividlight(const float *const restrict a, const float *const restrict b,
-                              float *const restrict out, const float *const restrict mask, const size_t stride,
-                              const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_vividlight(const float *const a,
+                              const float *const b,
+                              float *const out,
+                              const float *const restrict mask,
+                              const size_t stride,
+                              const dt_aligned_pixel_t min,
+                              const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -825,9 +884,13 @@ static void _blend_vividlight(const float *const restrict a, const float *const 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_linearlight(const float *const restrict a, const float *const restrict b,
-                               float *const restrict out, const float *const restrict mask, const size_t stride,
-                               const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_linearlight(const float *const a,
+                               const float *const b,
+                               float *const out,
+                               const float *const restrict mask,
+                               const size_t stride,
+                               const dt_aligned_pixel_t min,
+                               const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -860,9 +923,13 @@ static void _blend_linearlight(const float *const restrict a, const float *const
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_pinlight(const float *const restrict a, const float *const restrict b,
-                            float *const restrict out, const float *const restrict mask, const size_t stride,
-                            const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_pinlight(const float *const a,
+                            const float *const b,
+                            float *const out,
+                            const float *const restrict mask,
+                            const size_t stride,
+                            const dt_aligned_pixel_t min,
+                            const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -898,9 +965,13 @@ static void _blend_pinlight(const float *const restrict a, const float *const re
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_lightness(const float *const restrict a, const float *const restrict b,
-                             float *const restrict out, const float *const restrict mask, const size_t stride,
-                             const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_lightness(const float *const a,
+                             const float *const b,
+                             float *const out,
+                             const float *const restrict mask,
+                             const size_t stride,
+                             const dt_aligned_pixel_t min,
+                             const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -925,9 +996,13 @@ static void _blend_lightness(const float *const restrict a, const float *const r
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_chromaticity(const float *const restrict a, const float *const restrict b,
-                                float *const restrict out, const float *const restrict mask, const size_t stride,
-                                const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_chromaticity(const float *const a,
+                                const float *const b,
+                                float *const out,
+                                const float *const restrict mask,
+                                const size_t stride,
+                                const dt_aligned_pixel_t min,
+                                const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -958,9 +1033,13 @@ static void _blend_chromaticity(const float *const restrict a, const float *cons
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_hue(const float *const restrict a, const float *const restrict b,
-                       float *const restrict out, const float *const restrict mask, const size_t stride,
-                       const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_hue(const float *const a,
+                       const float *const b,
+                       float *const out,
+                       const float *const restrict mask,
+                       const size_t stride,
+                       const dt_aligned_pixel_t min,
+                       const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -994,9 +1073,13 @@ static void _blend_hue(const float *const restrict a, const float *const restric
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_color(const float *const restrict a, const float *const restrict b,
-                         float *const restrict out, const float *const restrict mask, const size_t stride,
-                         const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_color(const float *const a,
+                         const float *const b,
+                         float *const out,
+                         const float *const restrict mask,
+                         const size_t stride,
+                         const dt_aligned_pixel_t min,
+                         const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -1031,9 +1114,13 @@ static void _blend_color(const float *const restrict a, const float *const restr
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_coloradjust(const float *const restrict a, const float *const restrict b,
-                               float *const restrict out, const float *const restrict mask, const size_t stride,
-                               const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_coloradjust(const float *const a,
+                               const float *const b,
+                               float *const out,
+                               const float *const restrict mask,
+                               const size_t stride,
+                               const dt_aligned_pixel_t min,
+                               const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -1068,9 +1155,13 @@ static void _blend_coloradjust(const float *const restrict a, const float *const
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_Lab_lightness(const float *const restrict a, const float *const restrict b,
-                                 float *const restrict out, const float *const restrict mask, const size_t stride,
-                                 const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_Lab_lightness(const float *const a,
+                                 const float *const b,
+                                 float *const out,
+                                 const float *const restrict mask,
+                                 const size_t stride,
+                                 const dt_aligned_pixel_t min,
+                                 const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -1093,9 +1184,13 @@ static void _blend_Lab_lightness(const float *const restrict a, const float *con
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_Lab_a(const float *const restrict a, const float *const restrict b,
-                         float *const restrict out, const float *const restrict mask, const size_t stride,
-                         const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_Lab_a(const float *const a,
+                         const float *const b,
+                         float *const out,
+                         const float *const restrict mask,
+                         const size_t stride,
+                         const dt_aligned_pixel_t min,
+                         const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -1118,9 +1213,13 @@ static void _blend_Lab_a(const float *const restrict a, const float *const restr
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_Lab_b(const float *const restrict a, const float *const restrict b,
-                         float *const restrict out, const float *const restrict mask, const size_t stride,
-                         const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_Lab_b(const float *const a,
+                         const float *const b,
+                         float *const out,
+                         const float *const restrict mask,
+                         const size_t stride,
+                         const dt_aligned_pixel_t min,
+                         const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -1144,9 +1243,13 @@ static void _blend_Lab_b(const float *const restrict a, const float *const restr
 #ifdef _OPENMP
 #pragma omp declare simd aligned(a, b, out, min, max: 16) uniform(stride, min, max)
 #endif
-static void _blend_Lab_color(const float *const restrict a, const float *const restrict b,
-                             float *const restrict out, const float *const restrict mask, const size_t stride,
-                             const dt_aligned_pixel_t min, const dt_aligned_pixel_t max)
+static void _blend_Lab_color(const float *const a,
+                             const float *const b,
+                             float *const out,
+                             const float *const restrict mask,
+                             const size_t stride,
+                             const dt_aligned_pixel_t min,
+                             const dt_aligned_pixel_t max)
 {
   for(size_t i = 0, j = 0; i < stride; i++, j += DT_BLENDIF_LAB_CH)
   {
@@ -1487,42 +1590,36 @@ void dt_develop_blendif_lab_blend(struct dt_dev_pixelpipe_iop_t *piece,
   {
     _blend_row_func *const blend = _choose_blend_func(d->blend_mode);
     // minimum and maximum values after scaling !!!
-    const dt_aligned_pixel_t min = { 0.0f, -1.0f, -1.0f, 0.0f };
-    const dt_aligned_pixel_t max = { 1.0f, 1.0f, 1.0f, 1.0f };
+    static const dt_aligned_pixel_t min = { 0.0f, -1.0f, -1.0f, 0.0f };
+    static const dt_aligned_pixel_t max = { 1.0f, 1.0f, 1.0f, 1.0f };
 
-    float *tmp_buffer = dt_alloc_align_float((size_t)owidth * oheight * DT_BLENDIF_LAB_CH);
-    if(tmp_buffer != NULL)
+    if((d->blend_mode & DEVELOP_BLEND_REVERSE) == DEVELOP_BLEND_REVERSE)
     {
-      dt_iop_image_copy(tmp_buffer, b, (size_t)owidth * oheight * DT_BLENDIF_LAB_CH);
-      if((d->blend_mode & DEVELOP_BLEND_REVERSE) == DEVELOP_BLEND_REVERSE)
-      {
 #ifdef _OPENMP
-#pragma omp parallel for schedule(static) default(none) \
-  dt_omp_firstprivate(a, b, tmp_buffer, mask, blend, oheight, owidth, iwidth, xoffs, yoffs, min, max)
+#pragma omp parallel for schedule(static) default(none)                 \
+  dt_omp_firstprivate(a, b, mask, blend, oheight, owidth, iwidth, xoffs, yoffs, min, max)
 #endif
-        for(size_t y = 0; y < oheight; y++)
-        {
-          const size_t a_start = ((y + yoffs) * iwidth + xoffs) * DT_BLENDIF_LAB_CH;
-          const size_t b_start = y * owidth * DT_BLENDIF_LAB_CH;
-          const size_t m_start = y * owidth;
-          blend(tmp_buffer + b_start, a + a_start, b + b_start, mask + m_start, owidth, min, max);
-        }
-      }
-      else
+      for(size_t y = 0; y < oheight; y++)
       {
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static) default(none) \
-  dt_omp_firstprivate(a, b, tmp_buffer, mask, blend, oheight, owidth, iwidth, xoffs, yoffs, min, max)
-#endif
-        for(size_t y = 0; y < oheight; y++)
-        {
-          const size_t a_start = ((y + yoffs) * iwidth + xoffs) * DT_BLENDIF_LAB_CH;
-          const size_t b_start = y * owidth * DT_BLENDIF_LAB_CH;
-          const size_t m_start = y * owidth;
-          blend(a + a_start, tmp_buffer + b_start, b + b_start, mask + m_start, owidth, min, max);
-        }
+        const size_t a_start = ((y + yoffs) * iwidth + xoffs) * DT_BLENDIF_LAB_CH;
+        const size_t b_start = y * owidth * DT_BLENDIF_LAB_CH;
+        const size_t m_start = y * owidth;
+        blend(b + b_start, a + a_start, b + b_start, mask + m_start, owidth, min, max);
       }
-      dt_free_align(tmp_buffer);
+    }
+    else
+    {
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static) default(none)                 \
+  dt_omp_firstprivate(a, b, mask, blend, oheight, owidth, iwidth, xoffs, yoffs, min, max)
+#endif
+      for(size_t y = 0; y < oheight; y++)
+      {
+        const size_t a_start = ((y + yoffs) * iwidth + xoffs) * DT_BLENDIF_LAB_CH;
+        const size_t b_start = y * owidth * DT_BLENDIF_LAB_CH;
+        const size_t m_start = y * owidth;
+        blend(a + a_start, b + b_start, b + b_start, mask + m_start, owidth, min, max);
+      }
     }
   }
 


### PR DESCRIPTION
Remove the intermediate buffer for Lab blending.

Passes new integration tests 0122, 0123, and 0124.

Performance using the sidecar from 0122:
```
tone curve 1 (normal)
Thr	Master	PR	(abs)	(rel)
1	0.681	0.610	-0.071	-10%
2	0.367	0.318	-0.049	-13%
4	0.200	0.168	-0.032	-16%
8	0.126	0.094	-0.032	-25%
16	0.091	0.058	-0.033	-36%
32	0.075	0.041	-0.034	-45%
64	0.078	0.041	-0.037	-47%

tone curve 2 (darken)
Thr	Master	PR	(abs)	(rel)
1	0.347	0.282	-0.065	-18%
2	0.190	0.147	-0.043	-22%
4	0.111	0.078	-0.033	-29%
8	0.074	0.045	-0.029	-39%
16	0.061	0.029	-0.032	-52%
32	0.062	0.028	-0.034	-54%
64	0.071	0.032	-0.039	-55%

tone curve 3 (linearlight)
Thr	Master	PR	(abs)	(rel)
1	0.388	0.328	-0.060	-15%
2	0.210	0.171	-0.039	-18%
4	0.117	0.090	-0.027	-23%
8	0.079	0.051	-0.028	-35%
16	0.063	0.033	-0.030	-47%
32	0.063	0.030	-0.033	-52%
64	0.072	0.034	-0.038	-52%

tone curve 4 (chromaticity)
Thr	Master	PR	(abs)	(rel)
1	1.373	1.298	-0.075	 -5%
2	0.713	0.661	-0.048	 -7%
4	0.371	0.339	-0.032	 -8%
8	0.207	0.177	-0.030	-14%
16	0.126	0.095	-0.031	-24%
32	0.091	0.058	-0.033	-36%
64	0.091	0.052	-0.039	-42%
```
