### PR TITLE
Bugfix #13975

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -578,7 +578,7 @@ int main(int argc, char *arg[])
     {
       int id = GPOINTER_TO_INT(iter->data);
       dt_image_t *image = dt_image_cache_get(darktable.image_cache, id, 'w');
-      if(dt_exif_xmp_read(image, xmp_filename, 1) != 0)
+      if(dt_exif_xmp_read(image, xmp_filename, 1))
       {
         fprintf(stderr, _("error: can't open XMP file %s"), xmp_filename);
         fprintf(stderr, "\n");

--- a/src/common/exif.h
+++ b/src/common/exif.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2020 darktable developers.
+    Copyright (C) 2009-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -65,15 +65,16 @@ const GList* dt_exif_get_exiv2_taglist();
 void dt_exif_sanitize_datetime(char *datetime);
 
 /** read metadata from file with full path name, XMP data trumps IPTC data trumps EXIF data, store to image
- * struct. returns 0 on success. */
-int dt_exif_read(dt_image_t *img, const char *path);
+ * struct. returns TRUE if no success. */
+gboolean dt_exif_read(dt_image_t *img, const char *path);
 
-/** read exif data to image struct from given data blob, wherever you got it from. */
-int dt_exif_read_from_blob(dt_image_t *img, uint8_t *blob, const int size);
+/** read exif data to image struct from given data blob, wherever you got it from.
+    returns TRUE in case of an error */
+gboolean dt_exif_read_from_blob(dt_image_t *img, uint8_t *blob, const int size);
 
 /** write exif to blob, return length in bytes. blob will be allocated by the function. sRGB should be true
  * if sRGB colorspace is used as output. */
-int dt_exif_read_blob(uint8_t **blob, const char *path, const int imgid, const int sRGB, const int out_width,
+int dt_exif_read_blob(uint8_t **blob, const char *path, const int32_t imgid, const int sRGB, const int out_width,
                       const int out_height, const int dng_mode);
 
 /** Reads exif tags that are not cached in the database */
@@ -83,23 +84,23 @@ void dt_exif_img_check_additional_tags(dt_image_t *img, const char *filename);
 int dt_exif_write_blob(uint8_t *blob, uint32_t size, const char *path, const int compressed);
 
 /** write xmp sidecar file. */
-int dt_exif_xmp_write(const int imgid, const char *filename);
+gboolean dt_exif_xmp_write(const int32_t imgid, const char *filename);
 
 /** write xmp packet inside an image. */
-int dt_exif_xmp_attach_export(const int imgid, const char *filename, void *metadata,
+gboolean dt_exif_xmp_attach_export(const int32_t imgid, const char *filename, void *metadata,
     dt_develop_t *dev, dt_dev_pixelpipe_t *pipe);
 
 /** get the xmp blob for imgid. */
-char *dt_exif_xmp_read_string(const int imgid);
+char *dt_exif_xmp_read_string(const int32_t imgid);
 
-/** read xmp sidecar file. */
-int dt_exif_xmp_read(dt_image_t *img, const char *filename, const int history_only);
+/** read xmp sidecar file. Returns TRUE in case of any error*/
+gboolean dt_exif_xmp_read(dt_image_t *img, const char *filename, const int history_only);
 
 /** apply default import metadata */
 void dt_exif_apply_default_metadata(dt_image_t *img);
 
-/** fetch largest exif thumbnail jpg bytestream into buffer*/
-int dt_exif_get_thumbnail(const char *path, uint8_t **buffer, size_t *size, char **mime_type);
+/** fetch largest exif thumbnail jpg bytestream into buffer. Returns TRUE in case of any error */
+gboolean dt_exif_get_thumbnail(const char *path, uint8_t **buffer, size_t *size, char **mime_type);
 
 /** thread safe init and cleanup. */
 void dt_exif_init();


### PR DESCRIPTION
Fix gboolean dt_image_write_sidecar_file(const int32_t imgid)
- the sidecar is written only if required but the timestamp must be put into db
  - in case of no reported error while writing the sidecar
  - or if no sidecar writing was required

While checking the issue:
Exif functions return gbooleans where appropriate and use int32_t for imgid
- gboolean dt_exif_read()
- gboolean dt_exif_read_from_blob()
- gboolean dt_exif_xmp_write()
- boolean dt_exif_xmp_attach_export()
- char *dt_exif_xmp_read_string()
- gboolean dt_exif_xmp_read()
- gboolean dt_exif_get_thumbnail()