### PR TITLE
fix mouse moves over bauhaus causing histogram redraws

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -551,9 +551,11 @@ static void dt_bh_init(DtBauhausWidget *class)
 static gboolean _enter_leave(GtkWidget *widget, GdkEventCrossing *event)
 {
   if(event->type == GDK_ENTER_NOTIFY)
-    gtk_widget_set_state_flags(widget, GTK_STATE_FLAG_PRELIGHT, FALSE);
+    // gtk_widget_set_state_flags triggers resize&draw avalanche
+    // instead add GTK_STATE_FLAG_PRELIGHT in _widget_draw
+    darktable.bauhaus->hovered = widget;
   else
-    gtk_widget_unset_state_flags(widget, GTK_STATE_FLAG_PRELIGHT);
+    darktable.bauhaus->hovered = NULL;
 
   gtk_widget_queue_draw(widget);
 
@@ -2177,7 +2179,8 @@ static gboolean _widget_draw(GtkWidget *widget, cairo_t *crf)
   GdkRGBA *fg_color = default_color_assign();
   GdkRGBA *bg_color;
   GdkRGBA *text_color = default_color_assign();
-  const GtkStateFlags state = gtk_widget_get_state_flags(widget);
+  const GtkStateFlags hovering = widget == darktable.bauhaus->hovered ? GTK_STATE_FLAG_PRELIGHT : 0;
+  const GtkStateFlags state = gtk_widget_get_state_flags(widget) | hovering;
   gtk_style_context_get_color(context, state, text_color);
 
   gtk_style_context_get_color(context, state, fg_color);

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2379,7 +2379,8 @@ static gint _bauhaus_natural_width(GtkWidget *widget, gboolean popup)
     gint number_width = 0;
     char *max = dt_bauhaus_slider_get_text(widget, w->data.slider.max);
     char *min = dt_bauhaus_slider_get_text(widget, w->data.slider.min);
-    char *text = strlen(max) >= strlen(min) ? max : min;pango_layout_set_text(layout, text, -1);
+    char *text = strlen(max) >= strlen(min) ? max : min;
+    pango_layout_set_text(layout, text, -1);
     pango_layout_get_size(layout, &number_width, NULL);
     natural_size += 2 * INNER_PADDING + number_width / PANGO_SCALE;
     g_free(max);

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -199,6 +199,8 @@ enum
 typedef struct dt_bauhaus_t
 {
   struct dt_bauhaus_widget_t *current;
+  // the widget that has the mouse over it
+  GtkWidget *hovered;
   GtkWidget *popup_window;
   GtkWidget *popup_area;
   // are set by the motion notification, to be used during drawing.

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -2159,7 +2159,7 @@ static void _lib_histogram_preview_updated_callback(gpointer instance, dt_lib_mo
   // pre-gamma image. Now that preview pipe is complete, draw it
   // FIXME: it would be nice if process() just queued a redraw if not in live view, but then our draw code would have to have some other way to assure that the histogram image is current besides checking the pixelpipe to see if it has processed the current image
   dt_lib_histogram_t *d = (dt_lib_histogram_t *)self->data;
-  dt_control_queue_redraw_widget(d->scope_draw);
+  gtk_widget_queue_draw(d->scope_draw);
 }
 
 void view_enter(struct dt_lib_module_t *self, struct dt_view_t *old_view, struct dt_view_t *new_view)


### PR DESCRIPTION
As mentioned in a kindly submitted bug report (it was somewhat lengthy and I can't exactly remember where this came up) since hovering over a bauhaus widget now causes it to be highlighted (very subtly, when using the grey theme) gtk not unreasonably assumes that this could select a completely different, possibly larger, font and triggers a resizing and redrawing avalanche of the whole side panel, including the histogram. So the histogram gets redrawn multiple times using up a bunch of cpu.

This PR doesn't register the hovering state in the widget itself, but instead checks it in the drawing routine. Which seems to solve the problem for bauhaus. A similar issue within the standard gtk notebook widget (see for example filmic) can't be easily circumvented since we don't have control over that code.

@AxelG-DE mentioned an issue with flickering histograms which I assume this doesn't resolve, but it wouldn't hurt testing and then providing more details. Thanks!