### PR TITLE
Makes module & label display consistent in all cases.

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -916,7 +916,7 @@ GList *dt_history_get_items(const int32_t imgid,
 
   // clang-format off
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "SELECT num, operation, enabled, multi_name"
+                              "SELECT num, operation, enabled, multi_name, blendop_params"
                               " FROM main.history"
                               " WHERE imgid=?1"
                               "   AND num IN (SELECT MAX(num)"
@@ -938,8 +938,12 @@ GList *dt_history_get_items(const int32_t imgid,
     char name[512] = { 0 };
     dt_history_item_t *item = g_malloc(sizeof(dt_history_item_t));
     const char *op = (char *)sqlite3_column_text(stmt, 1);
+    // first uint32_t of blend_params is the mode
+    const uint32_t *blend_params = (uint32_t *)sqlite3_column_blob(stmt, 4);
+    const int blend_params_len = sqlite3_column_bytes(stmt, 4);
     item->num = sqlite3_column_int(stmt, 0);
     item->enabled = sqlite3_column_int(stmt, 2);
+    item->mask_mode = blend_params_len > 0 ? blend_params[0] : DEVELOP_MASK_DISABLED;
 
     const char *mname = (char *)sqlite3_column_text(stmt, 3);
 

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -131,7 +131,9 @@ typedef struct dt_history_item_t
 } dt_history_item_t;
 
 /** get list of history items for image */
-GList *dt_history_get_items(int32_t imgid, gboolean enabled);
+GList *dt_history_get_items(const int32_t imgid,
+                            const gboolean enabled,
+                            const gboolean markup);
 
 /** get list of history items for image as a nice string */
 char *dt_history_get_items_as_string(const int32_t imgid);

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -22,6 +22,7 @@
 #include <inttypes.h>
 #include <sqlite3.h>
 #include "develop/imageop.h"
+#include "develop/blend.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -128,6 +129,7 @@ typedef struct dt_history_item_t
   gchar *op;
   gchar *name;
   gboolean enabled;
+  dt_develop_mask_mode_t mask_mode;
 } dt_history_item_t;
 
 /** get list of history items for image */

--- a/src/common/styles.h
+++ b/src/common/styles.h
@@ -136,7 +136,7 @@ GList *dt_styles_get_list(const char *filter);
     the multi_name.
 */
 GList *dt_styles_get_item_list(const char *name,
-                               const gboolean params,
+                               const gboolean localized,
                                const int imgid,
                                const gboolean with_multi_name);
 

--- a/src/develop/lightroom.c
+++ b/src/develop/lightroom.c
@@ -214,7 +214,7 @@ typedef struct dt_iop_colorin_params_v1_t
 #define LRDT_BLEND_VERSION 4
 #define DEVELOP_BLENDIF_SIZE 16
 
-typedef struct dt_develop_blend_params_t
+typedef struct dt_lr_develop_blend_params_t
 {
   /** blending mode */
   uint32_t mode;
@@ -228,7 +228,7 @@ typedef struct dt_develop_blend_params_t
   float radius;
   /** blendif parameters */
   float blendif_parameters[4 * DEVELOP_BLENDIF_SIZE];
-} dt_develop_blend_params_t;
+} dt_lr_develop_blend_params_t;
 
 //
 // end of blend_params
@@ -330,7 +330,7 @@ static void dt_add_hist(int imgid, char *operation, dt_iop_params_t *params, int
                         size_t imported_len, int version, int *import_count)
 {
   int32_t num = 0;
-  dt_develop_blend_params_t blend_params = { 0 };
+  dt_lr_develop_blend_params_t blend_params = { 0 };
 
   //  get current num if any
   sqlite3_stmt *stmt;
@@ -357,7 +357,7 @@ static void dt_add_hist(int imgid, char *operation, dt_iop_params_t *params, int
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 3, version);
   DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 4, operation, -1, SQLITE_TRANSIENT);
   DT_DEBUG_SQLITE3_BIND_BLOB(stmt, 5, params, params_size, SQLITE_TRANSIENT);
-  DT_DEBUG_SQLITE3_BIND_BLOB(stmt, 6, &blend_params, sizeof(dt_develop_blend_params_t), SQLITE_TRANSIENT);
+  DT_DEBUG_SQLITE3_BIND_BLOB(stmt, 6, &blend_params, sizeof(dt_lr_develop_blend_params_t), SQLITE_TRANSIENT);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 7, LRDT_BLEND_VERSION);
 
   sqlite3_step(stmt);
@@ -1572,4 +1572,3 @@ gboolean dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/gui/hist_dialog.c
+++ b/src/gui/hist_dialog.c
@@ -269,7 +269,7 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
   g_object_set_data(G_OBJECT(renderer), "column", (gint *)DT_HIST_ITEMS_COL_NAME);
   g_object_set(renderer, "xalign", 0.0, (gchar *)0);
   gtk_tree_view_insert_column_with_attributes
-    (GTK_TREE_VIEW(d->items), -1, _("item"), renderer, "text",
+    (GTK_TREE_VIEW(d->items), -1, _("item"), renderer, "markup",
      DT_HIST_ITEMS_COL_NAME, NULL);
 
   gtk_tree_selection_set_mode(gtk_tree_view_get_selection(GTK_TREE_VIEW(d->items)),
@@ -282,7 +282,7 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
     dt_draw_paint_to_pixbuf(GTK_WIDGET(dialog), 10, 0, dtgtk_cairo_paint_switch_inactive);
 
   /* fill list with history items */
-  GList *items = dt_history_get_items(imgid, FALSE);
+  GList *items = dt_history_get_items(imgid, FALSE, TRUE);
   if(items)
   {
     GtkTreeIter iter;

--- a/src/gui/hist_dialog.c
+++ b/src/gui/hist_dialog.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2022 darktable developers.
+    Copyright (C) 2012-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -43,7 +44,8 @@ typedef enum _style_items_columns_t
 
 static gboolean _gui_hist_is_copy_module_order_set(dt_history_copy_item_t *d)
 {
-  /* iterate through TreeModel to find if module order was copied (num=-1 and active)  */
+  /* iterate through TreeModel to find if module order was copied
+   * (num=-1 and active) */
   GtkTreeIter iter;
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(d->items));
 
@@ -54,7 +56,10 @@ static gboolean _gui_hist_is_copy_module_order_set(dt_history_copy_item_t *d)
   gtk_tree_model_get_iter_first(model, &iter);
   do
   {
-      gtk_tree_model_get(model, &iter, DT_HIST_ITEMS_COL_ENABLED, &active, DT_HIST_ITEMS_COL_NUM, &num, -1);
+      gtk_tree_model_get(model, &iter,
+                         DT_HIST_ITEMS_COL_ENABLED, &active,
+                         DT_HIST_ITEMS_COL_NUM, &num,
+                         -1);
       if(active && (num == -1)) module_order_was_copied = TRUE;
   }
   while(gtk_tree_model_iter_next(model, &iter));
@@ -90,7 +95,8 @@ static GList *_gui_hist_get_active_items(dt_history_copy_item_t *d)
   return g_list_reverse(result);  // list was built in reverse order, so un-reverse it
 }
 
-static void _gui_hist_set_items(dt_history_copy_item_t *d, const gboolean active)
+static void _gui_hist_set_items(dt_history_copy_item_t *d,
+                                const gboolean active)
 {
   /* run through all items and set active status */
   GtkTreeIter iter;
@@ -99,7 +105,9 @@ static void _gui_hist_set_items(dt_history_copy_item_t *d, const gboolean active
   {
     do
     {
-      gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_HIST_ITEMS_COL_ENABLED, active, -1);
+      gtk_list_store_set(GTK_LIST_STORE(model), &iter,
+                         DT_HIST_ITEMS_COL_ENABLED, active,
+                         -1);
     } while(gtk_tree_model_iter_next(model, &iter));
   }
 }
@@ -151,7 +159,8 @@ static void _gui_hist_item_toggled(GtkCellRendererToggle *cell,
   gtk_tree_path_free(path);
 }
 
-static gboolean _gui_is_set(GList *selops, const unsigned int num)
+static gboolean _gui_is_set(GList *selops,
+                            const unsigned int num)
 {
   /* nothing to filter */
   if(!selops) return TRUE;
@@ -167,11 +176,10 @@ static gboolean _gui_is_set(GList *selops, const unsigned int num)
   return FALSE;
 }
 
-void
-tree_on_row_activated(GtkTreeView        *treeview,
-                      GtkTreePath        *path,
-                      GtkTreeViewColumn  *col,
-                      gpointer            userdata)
+void tree_on_row_activated(GtkTreeView       *treeview,
+                           GtkTreePath       *path,
+                           GtkTreeViewColumn *col,
+                           gpointer           userdata)
 {
   GtkDialog *dialog = GTK_DIALOG(userdata);
   GtkTreeModel *model = gtk_tree_view_get_model(treeview);
@@ -193,7 +201,9 @@ tree_on_row_activated(GtkTreeView        *treeview,
 
   if(gtk_tree_model_get_iter(model, &iter, path))
   {
-    gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_HIST_ITEMS_COL_ENABLED, TRUE, -1);
+    gtk_list_store_set(GTK_LIST_STORE(model), &iter,
+                       DT_HIST_ITEMS_COL_ENABLED, TRUE,
+                       -1);
     // and finally close the dialog
     g_signal_emit_by_name(dialog, "response", GTK_RESPONSE_OK, NULL);
   }
@@ -206,23 +216,27 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
   int res;
   GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
 
-  GtkDialog *dialog = GTK_DIALOG(gtk_dialog_new_with_buttons(
-                                   iscopy ? _("select parts to copy") : _("select parts to paste"),
-                                   GTK_WINDOW(window), GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
-                                   _("_cancel"),      GTK_RESPONSE_CANCEL,
-                                   _("select _all"),  GTK_RESPONSE_YES,
-                                   _("select _none"), GTK_RESPONSE_NONE,
-                                   _("_ok"),          GTK_RESPONSE_OK,
-                                   NULL));
+  GtkDialog *dialog = GTK_DIALOG
+    (gtk_dialog_new_with_buttons(
+      iscopy ? _("select parts to copy") : _("select parts to paste"),
+      GTK_WINDOW(window), GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
+      _("_cancel"),      GTK_RESPONSE_CANCEL,
+      _("select _all"),  GTK_RESPONSE_YES,
+      _("select _none"), GTK_RESPONSE_NONE,
+      _("_ok"),          GTK_RESPONSE_OK,
+      NULL));
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(GTK_WIDGET(dialog));
 #endif
 
-  GtkContainer *content_area = GTK_CONTAINER(gtk_dialog_get_content_area(GTK_DIALOG(dialog)));
+  GtkContainer *content_area =
+    GTK_CONTAINER(gtk_dialog_get_content_area(GTK_DIALOG(dialog)));
 
   GtkWidget *scroll = gtk_scrolled_window_new(NULL, NULL);
-  gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll), GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
-  gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(scroll), DT_PIXEL_APPLY_DPI(450));
+  gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll),
+                                 GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+  gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(scroll),
+                                             DT_PIXEL_APPLY_DPI(450));
 
   /* create the list of items */
   d->items = GTK_TREE_VIEW(gtk_tree_view_new());
@@ -301,7 +315,9 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
           (GTK_LIST_STORE(liststore), &iter,
            DT_HIST_ITEMS_COL_ENABLED, iscopy ? is_safe : _gui_is_set(d->selops, item->num),
            DT_HIST_ITEMS_COL_AUTOINIT, FALSE,
-           DT_HIST_ITEMS_COL_ISACTIVE, (gboolean)item->enabled ? is_active_pb : is_inactive_pb,
+           DT_HIST_ITEMS_COL_ISACTIVE, (gboolean)item->enabled
+                                        ? is_active_pb
+                                        : is_inactive_pb,
            DT_HIST_ITEMS_COL_NAME, item->name,
            DT_HIST_ITEMS_COL_NUM, (gint)item->num,
            -1);
@@ -313,7 +329,8 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
     if(iscopy || d->copy_iop_order)
     {
       const dt_iop_order_t order = dt_ioppr_get_iop_order_version(imgid);
-      char *label = g_strdup_printf("%s (%s)", _("module order"), dt_iop_order_string(order));
+      char *label = g_strdup_printf("%s (%s)", _("module order"),
+                                    dt_iop_order_string(order));
       gtk_list_store_append(GTK_LIST_STORE(liststore), &iter);
       gtk_list_store_set(GTK_LIST_STORE(liststore), &iter,
                          DT_HIST_ITEMS_COL_ENABLED, TRUE,

--- a/src/gui/hist_dialog.c
+++ b/src/gui/hist_dialog.c
@@ -38,6 +38,7 @@ typedef enum _style_items_columns_t
   DT_HIST_ITEMS_COL_ISACTIVE,
   DT_HIST_ITEMS_COL_AUTOINIT,
   DT_HIST_ITEMS_COL_NAME,
+  DT_HIST_ITEMS_COL_MASK,
   DT_HIST_ITEMS_COL_NUM,
   DT_HIST_ITEMS_NUM_COLS
 } _styles_columns_t;
@@ -192,8 +193,8 @@ void tree_on_row_activated(GtkTreeView       *treeview,
     do
     {
       gtk_list_store_set(GTK_LIST_STORE(model), &iter,
-                         DT_HIST_ITEMS_COL_ENABLED, FALSE, -1);
-
+                         DT_HIST_ITEMS_COL_ENABLED, FALSE,
+                         -1);
     } while(gtk_tree_model_iter_next(model, &iter));
   }
 
@@ -246,7 +247,7 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
   GtkListStore *liststore
     = gtk_list_store_new(DT_HIST_ITEMS_NUM_COLS,
                          G_TYPE_BOOLEAN, GDK_TYPE_PIXBUF, G_TYPE_BOOLEAN,
-                         G_TYPE_STRING, G_TYPE_UINT);
+                         G_TYPE_STRING, GDK_TYPE_PIXBUF, G_TYPE_UINT);
 
   /* enabled */
   GtkCellRenderer *renderer = gtk_cell_renderer_toggle_new();
@@ -286,6 +287,16 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
     (GTK_TREE_VIEW(d->items), -1, _("item"), renderer, "markup",
      DT_HIST_ITEMS_COL_NAME, NULL);
 
+  /* mask */
+  renderer = gtk_cell_renderer_pixbuf_new();
+  column = gtk_tree_view_column_new_with_attributes
+    (_("mask"), renderer, "pixbuf",
+     DT_HIST_ITEMS_COL_MASK, NULL);
+  gtk_tree_view_append_column(GTK_TREE_VIEW(d->items), column);
+  gtk_tree_view_column_set_alignment(column, 0.5);
+  gtk_tree_view_column_set_clickable(column, FALSE);
+  gtk_tree_view_column_set_min_width(column, DT_PIXEL_APPLY_DPI(30));
+
   gtk_tree_selection_set_mode(gtk_tree_view_get_selection(GTK_TREE_VIEW(d->items)),
                               GTK_SELECTION_SINGLE);
   gtk_tree_view_set_model(GTK_TREE_VIEW(d->items), GTK_TREE_MODEL(liststore));
@@ -294,6 +305,8 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
     dt_draw_paint_to_pixbuf(GTK_WIDGET(dialog), 10, 0, dtgtk_cairo_paint_switch);
   GdkPixbuf *is_inactive_pb =
     dt_draw_paint_to_pixbuf(GTK_WIDGET(dialog), 10, 0, dtgtk_cairo_paint_switch_inactive);
+  GdkPixbuf *mask =
+    dt_draw_paint_to_pixbuf(GTK_WIDGET(dialog), 10, 0, dtgtk_cairo_paint_showmask);
 
   /* fill list with history items */
   GList *items = dt_history_get_items(imgid, FALSE, TRUE);
@@ -315,10 +328,9 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
           (GTK_LIST_STORE(liststore), &iter,
            DT_HIST_ITEMS_COL_ENABLED, iscopy ? is_safe : _gui_is_set(d->selops, item->num),
            DT_HIST_ITEMS_COL_AUTOINIT, FALSE,
-           DT_HIST_ITEMS_COL_ISACTIVE, (gboolean)item->enabled
-                                        ? is_active_pb
-                                        : is_inactive_pb,
+           DT_HIST_ITEMS_COL_ISACTIVE, item->enabled ? is_active_pb : is_inactive_pb,
            DT_HIST_ITEMS_COL_NAME, item->name,
+           DT_HIST_ITEMS_COL_MASK, item->mask_mode > 0 ? mask : NULL,
            DT_HIST_ITEMS_COL_NUM, (gint)item->num,
            -1);
       }

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -661,13 +661,13 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
   g_object_set_data(G_OBJECT(renderer), "column", (gint *)DT_STYLE_ITEMS_COL_NAME);
   g_object_set(renderer, "xalign", 0.0, (gchar *)0);
   gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items), -1,
-                                              _("item"), renderer, "text",
+                                              _("item"), renderer, "markup",
                                               DT_STYLE_ITEMS_COL_NAME, NULL);
 
   if(edit)
   {
     gtk_tree_view_insert_column_with_attributes(GTK_TREE_VIEW(sd->items_new), -1,
-                                                _("item"), renderer, "text",
+                                                _("item"), renderer, "markup",
                                                 DT_STYLE_ITEMS_COL_NAME, NULL);
   }
 
@@ -748,7 +748,7 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
                        -1);
     g_free(label);
 
-    GList *items = dt_history_get_items(imgid, FALSE);
+    GList *items = dt_history_get_items(imgid, FALSE, TRUE);
     if(items)
     {
       for(const GList *items_iter = items; items_iter; items_iter = g_list_next(items_iter))

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -52,6 +52,7 @@ typedef enum _style_items_columns_t
   DT_STYLE_ITEMS_COL_ISACTIVE,
   DT_STYLE_ITEMS_COL_AUTOINIT,
   DT_STYLE_ITEMS_COL_NAME,
+  DT_STYLE_ITEMS_COL_MASK,
   DT_STYLE_ITEMS_COL_NUM,
   DT_STYLE_ITEMS_COL_UPDATE_NUM,
   DT_STYLE_ITEMS_NUM_COLS
@@ -572,12 +573,14 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
   sd->items = GTK_TREE_VIEW(gtk_tree_view_new());
   GtkListStore *liststore = gtk_list_store_new(
     DT_STYLE_ITEMS_NUM_COLS, G_TYPE_BOOLEAN, G_TYPE_BOOLEAN,
-    GDK_TYPE_PIXBUF, G_TYPE_BOOLEAN, G_TYPE_STRING, G_TYPE_INT, G_TYPE_INT);
+    GDK_TYPE_PIXBUF, G_TYPE_BOOLEAN, G_TYPE_STRING,
+    GDK_TYPE_PIXBUF, G_TYPE_INT, G_TYPE_INT);
 
   sd->items_new = GTK_TREE_VIEW(gtk_tree_view_new());
   GtkListStore *liststore_new = gtk_list_store_new
     (DT_STYLE_ITEMS_NUM_COLS, G_TYPE_BOOLEAN, G_TYPE_STRING,
-      GDK_TYPE_PIXBUF, G_TYPE_BOOLEAN, G_TYPE_STRING, G_TYPE_INT, G_TYPE_INT);
+     GDK_TYPE_PIXBUF, G_TYPE_BOOLEAN, G_TYPE_STRING,
+     GDK_TYPE_PIXBUF, G_TYPE_INT, G_TYPE_INT);
 
   /* enabled */
   GtkCellRenderer *renderer = gtk_cell_renderer_toggle_new();
@@ -671,6 +674,26 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
                                                 DT_STYLE_ITEMS_COL_NAME, NULL);
   }
 
+  /* mask */
+  renderer = gtk_cell_renderer_pixbuf_new();
+  column = gtk_tree_view_column_new_with_attributes
+    (_("mask"), renderer, "pixbuf",
+     DT_STYLE_ITEMS_COL_MASK, NULL);
+  gtk_tree_view_append_column(GTK_TREE_VIEW(sd->items), column);
+  gtk_tree_view_column_set_alignment(column, 0.5);
+  gtk_tree_view_column_set_clickable(column, FALSE);
+  gtk_tree_view_column_set_min_width(column, DT_PIXEL_APPLY_DPI(30));
+
+  if(edit)
+  {
+    column = gtk_tree_view_column_new_with_attributes(_("mask"), renderer, "pixbuf",
+                                                      DT_STYLE_ITEMS_COL_MASK, NULL);
+    gtk_tree_view_column_set_alignment(column, 0.5);
+    gtk_tree_view_column_set_clickable(column, FALSE);
+    gtk_tree_view_column_set_min_width(column, DT_PIXEL_APPLY_DPI(30));
+    gtk_tree_view_append_column(GTK_TREE_VIEW(sd->items_new), column);
+  }
+
   gtk_tree_selection_set_mode(gtk_tree_view_get_selection(GTK_TREE_VIEW(sd->items)), GTK_SELECTION_SINGLE);
   gtk_tree_view_set_model(GTK_TREE_VIEW(sd->items), GTK_TREE_MODEL(liststore));
 
@@ -683,6 +706,8 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
     dt_draw_paint_to_pixbuf(GTK_WIDGET(dialog), 10, 0, dtgtk_cairo_paint_switch);
   GdkPixbuf *is_inactive_pb =
     dt_draw_paint_to_pixbuf(GTK_WIDGET(dialog), 10, 0, dtgtk_cairo_paint_switch_inactive);
+  GdkPixbuf *mask =
+    dt_draw_paint_to_pixbuf(GTK_WIDGET(dialog), 10, 0, dtgtk_cairo_paint_showmask);
 
   /* fill list with history items */
   GtkTreeIter iter;
@@ -702,6 +727,7 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
       for(const GList *items_iter = items; items_iter; items_iter = g_list_next(items_iter))
       {
         dt_style_item_t *item = (dt_style_item_t *)items_iter->data;
+        const dt_develop_mask_mode_t mask_mode = item->blendop_params->mask_mode;
 
         if(item->num != -1 && item->selimg_num != -1) // defined in style and image
         {
@@ -712,6 +738,7 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
                              DT_STYLE_ITEMS_COL_UPDATE,     FALSE,
                              DT_STYLE_ITEMS_COL_ISACTIVE,   item->enabled ? is_active_pb : is_inactive_pb,
                              DT_STYLE_ITEMS_COL_NAME,       item->name,
+                             DT_STYLE_ITEMS_COL_MASK,       mask_mode > 0 ? mask : NULL,
                              DT_STYLE_ITEMS_COL_NUM,        item->num,
                              DT_STYLE_ITEMS_COL_UPDATE_NUM, item->selimg_num,
                              -1);
@@ -726,6 +753,7 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
                              DT_STYLE_ITEMS_COL_AUTOINIT,   FALSE,
                              DT_STYLE_ITEMS_COL_ISACTIVE,   item->enabled ? is_active_pb : is_inactive_pb,
                              DT_STYLE_ITEMS_COL_NAME,       item->name,
+                             DT_STYLE_ITEMS_COL_MASK,       mask_mode > 0 ? mask : NULL,
                              DT_STYLE_ITEMS_COL_NUM,        item->num,
                              DT_STYLE_ITEMS_COL_UPDATE_NUM, item->selimg_num,
                              -1);
@@ -777,6 +805,7 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
            DT_STYLE_ITEMS_COL_AUTOINIT, FALSE,
            DT_STYLE_ITEMS_COL_ISACTIVE, item->enabled ? is_active_pb : is_inactive_pb,
            DT_STYLE_ITEMS_COL_NAME,     item->name,
+           DT_STYLE_ITEMS_COL_MASK,     item->mask_mode > 0 ? mask : NULL,
            DT_STYLE_ITEMS_COL_NUM,      item->num,
            -1);
 

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -696,7 +696,7 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, int imgid)
                        DT_STYLE_ITEMS_COL_NUM,      -1,
                        -1);
     /* get history items for named style and populate the items list */
-    GList *items = dt_styles_get_item_list(name, FALSE, imgid, TRUE);
+    GList *items = dt_styles_get_item_list(name, TRUE, imgid, TRUE);
     if(items)
     {
       for(const GList *items_iter = items; items_iter; items_iter = g_list_next(items_iter))
@@ -903,7 +903,7 @@ GtkWidget *dt_gui_style_content_dialog(char *name, const int imgid)
 
   gtk_box_pack_start(GTK_BOX(ht), gtk_separator_new(GTK_ORIENTATION_HORIZONTAL), TRUE, TRUE, 0);
 
-  GList *items = dt_styles_get_item_list(name, FALSE, -1, FALSE);
+  GList *items = dt_styles_get_item_list(name, TRUE, -1, FALSE);
   GList *l = items;
   while(l)
   {

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -751,7 +751,7 @@ int dt_imageio_export_with_flags(const int32_t imgid,
   //  If a style is to be applied during export, add the iop params into the history
   if(use_style)
   {
-    GList *style_items = dt_styles_get_item_list(format_params->style, TRUE, -1, TRUE);
+    GList *style_items = dt_styles_get_item_list(format_params->style, FALSE, -1, TRUE);
     if(!style_items)
     {
       dt_control_log(_("cannot find the style '%s' to apply during export."), format_params->style);

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -208,12 +208,13 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self,
   GtkWidget *onoff = NULL;
 
   /* create toggle button */
-  GtkWidget *widget = gtk_toggle_button_new_with_label(label);
+  GtkWidget *widget = gtk_toggle_button_new_with_label("");
   dt_gui_add_class(widget, "dt_transparent_background");
   GtkWidget *lab = gtk_bin_get_child(GTK_BIN(widget));
   gtk_widget_set_halign(lab, GTK_ALIGN_START);
   gtk_label_set_xalign(GTK_LABEL(lab), 0);
   gtk_label_set_ellipsize(GTK_LABEL(lab), PANGO_ELLIPSIZE_END);
+  gtk_label_set_markup (GTK_LABEL (lab), label);
   if(always_on)
   {
     onoff = dtgtk_button_new(dtgtk_cairo_paint_switch_on, 0, NULL);
@@ -1111,7 +1112,7 @@ static gchar *_lib_history_button_label(const dt_dev_history_item_t *item)
   else if(!item->multi_name[0] || strcmp(item->multi_name, "0") == 0)
     label = g_strdup(item->module->name());
   else
-    label = g_strdup_printf("%s • %s", item->module->name(), item->multi_name);
+    label = g_strdup_printf("%s <small>• %s</small>", item->module->name(), item->multi_name);
 
   return label;
 }

--- a/src/lua/styles.c
+++ b/src/lua/styles.c
@@ -78,7 +78,7 @@ static int style_getnumber(lua_State *L)
   }
   dt_style_t style;
   luaA_to(L, dt_style_t, &style, -2);
-  GList *items = dt_styles_get_item_list(style.name, TRUE, -1, TRUE);
+  GList *items = dt_styles_get_item_list(style.name, FALSE, -1, TRUE);
   dt_style_item_t *item = g_list_nth_data(items, index - 1);
   if(!item)
   {
@@ -97,7 +97,7 @@ static int style_length(lua_State *L)
 
   dt_style_t style;
   luaA_to(L, dt_style_t, &style, -1);
-  GList *items = dt_styles_get_item_list(style.name, TRUE, -1, TRUE);
+  GList *items = dt_styles_get_item_list(style.name, FALSE, -1, TRUE);
   lua_pushinteger(L, g_list_length(items));
   g_list_free_full(items, dt_style_item_free);
   return 1;


### PR DESCRIPTION
The style & history copy dialog now use a small font for the module's label which is separated by a dot.

Part of #13970.