### PR TITLE
performance: vectorize negadoctor code

### DIFF
--- a/src/common/math.h
+++ b/src/common/math.h
@@ -522,6 +522,44 @@ static inline void dt_vector_log2(const dt_aligned_pixel_t x, dt_aligned_pixel_t
 #endif
 }
 
+static inline void dt_vector_exp(const dt_aligned_pixel_t x, dt_aligned_pixel_t result)
+{
+  // meant for the range [-100.0f, 0.0f]. largest error ~ -0.06 at 0.0f.
+  // will get _a_lot_ worse for x > 0.0f (9000 at 10.0f)..
+  const int i1 = 0x3f800000u;
+  // e^x, the comment would be 2^x
+  const int i2 = 0x402DF854u; // 0x40000000u;
+  // const int k = CLAMPS(i1 + x * (i2 - i1), 0x0u, 0x7fffffffu);
+  // without max clamping (doesn't work for large x, but is faster):
+  union float_int u[4];
+  for_four_channels(c, aligned(x, result))
+  {
+    const int k0 = i1 + (int)(x[c] * (i2 - i1));
+    u[c].k = k0 > 0 ? k0 : 0;
+    result[c] = u[c].f;
+  }
+}
+
+static inline void dt_vector_exp2(const dt_aligned_pixel_t x, dt_aligned_pixel_t res)
+{
+#ifdef __SSE2__
+  *((__m128*)res) = _mm_exp2_ps(*((__m128*)x));
+#else
+  //TODO: plain C implementation of _mm_exp2_ps from sse.h
+  for_four_channels(c,aligned(x,res))
+    res[c] = exp2f(x[c]);
+#endif
+}
+
+static inline void dt_vector_exp10(const dt_aligned_pixel_t x, dt_aligned_pixel_t res)
+{
+  // 10^x == 2^(3.3219280948873626 * x)
+  dt_aligned_pixel_t scaled;
+  for_four_channels(c,aligned(x,scaled))
+    scaled[c] = 3.3219280948873626f * x[c];
+  dt_vector_exp2(scaled, res);
+}
+
 static inline void dt_vector_powf(const dt_aligned_pixel_t input,
                                   const dt_aligned_pixel_t power,
                                   dt_aligned_pixel_t output)

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -292,14 +292,9 @@ static inline void _process_pixel(const dt_aligned_pixel_t pix_in,
     dt_aligned_pixel_t print_gamma;
     dt_vector_powf(print_linear, gamma, print_gamma); // note : this is always > 0
     dt_aligned_pixel_t e_to_gamma;
-#if 0
-    for_each_channel(c)
-      e_to_gamma[c] = fast_expf(-(print_gamma[c] - soft_clip[c]) / soft_clip_comp[c]);
-#else
     dt_aligned_pixel_t clipped_gamma;
     for_each_channel(c)
       clipped_gamma[c] = -(print_gamma[c] - soft_clip[c]) / soft_clip_comp[c];
-#endif
     dt_vector_exp(clipped_gamma, e_to_gamma);
     for_each_channel(c)
     {

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -41,17 +41,6 @@
 #include <math.h>
 #include <stdlib.h>
 
-#if defined(__GNUC__)
-#pragma GCC optimize ("unroll-loops", "tree-loop-if-convert", \
-                      "tree-loop-distribution", "no-strict-aliasing", \
-                      "loop-interchange", "loop-nest-optimize", "tree-loop-im", \
-                      "unswitch-loops", "tree-loop-ivcanon", "ira-loop-pressure", \
-                      "split-ivs-in-unroller", "variable-expansion-in-unroller", \
-                      "split-loops", "ivopts", "predictive-commoning",\
-                      "tree-loop-linear", "loop-block", "loop-strip-mine", \
-                      "finite-math-only", "fp-contract=fast", "fast-math")
-#endif
-
 /** DOCUMENTATION
  *
  * This module allows to invert scanned negatives and simulate their print on paper, based on Kodak Cineon
@@ -260,6 +249,66 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   d->gamma = p->gamma;
 }
 
+static inline void _process_pixel(const dt_aligned_pixel_t pix_in,
+                                  dt_aligned_pixel_t pix_out,
+                                  const dt_aligned_pixel_t Dmin,
+                                  const dt_aligned_pixel_t wb_high,
+                                  const dt_aligned_pixel_t offset,
+                                  const dt_aligned_pixel_t black,
+                                  const dt_aligned_pixel_t exposure,
+                                  const dt_aligned_pixel_t gamma,
+                                  const dt_aligned_pixel_t soft_clip,
+                                  const dt_aligned_pixel_t soft_clip_comp)
+{
+    dt_aligned_pixel_t density;
+    // Convert transmission to density using Dmin as a fulcrum
+    dt_aligned_pixel_t clamped;
+    for_each_channel(c)
+    {
+      clamped[c] = MAX(pix_in[c],THRESHOLD);  // threshold to -32 EV
+      density[c] = Dmin[c] / clamped[c];
+    }
+    dt_aligned_pixel_t log_density;
+    dt_vector_log2(density, log_density);
+    #define LOG2_to_LOG10 0.3010299956f
+    for_each_channel(c)
+      log_density[c] *= -LOG2_to_LOG10;
+    // now log_density = -log10f( Dmin / MAX(pix_in, THRESHOLD) )
+    dt_aligned_pixel_t corrected_de;
+    for_each_channel(c)
+    {
+      // Correct density in log space
+      corrected_de[c] = wb_high[c] * log_density[c] + offset[c];
+    }
+    dt_aligned_pixel_t ten_to_x;
+    dt_vector_exp10(corrected_de, ten_to_x);
+    dt_aligned_pixel_t print_linear;
+    for_each_channel(c)
+    {
+      // Print density on paper : ((1 - 10^corrected_de + black) * exposure)^gamma rewritten for FMA
+      print_linear[c] = -(exposure[c] * ten_to_x[c] + black[c]);
+      print_linear[c] = MAX(print_linear[c], 0.0f);
+    }
+    dt_aligned_pixel_t print_gamma;
+    dt_vector_powf(print_linear, gamma, print_gamma); // note : this is always > 0
+    dt_aligned_pixel_t e_to_gamma;
+#if 0
+    for_each_channel(c)
+      e_to_gamma[c] = fast_expf(-(print_gamma[c] - soft_clip[c]) / soft_clip_comp[c]);
+#else
+    dt_aligned_pixel_t clipped_gamma;
+    for_each_channel(c)
+      clipped_gamma[c] = -(print_gamma[c] - soft_clip[c]) / soft_clip_comp[c];
+#endif
+    dt_vector_exp(clipped_gamma, e_to_gamma);
+    for_each_channel(c)
+    {
+      // Compress highlights. from https://lists.gnu.org/archive/html/openexr-devel/2005-03/msg00009.html
+      pix_out[c] = (print_gamma[c] > soft_clip[c])
+        ? soft_clip[c] + (1.0f - e_to_gamma[c] * soft_clip_comp[c])
+        : print_gamma[c];
+    }
+}
 
 void process(struct dt_iop_module_t *const self, dt_dev_pixelpipe_iop_t *const piece,
              const void *const restrict ivoid, void *const restrict ovoid,
@@ -271,37 +320,35 @@ void process(struct dt_iop_module_t *const self, dt_dev_pixelpipe_iop_t *const p
   const float *const restrict in = (float *)ivoid;
   float *const restrict out = (float *)ovoid;
 
+  dt_aligned_pixel_t gamma;
+  dt_aligned_pixel_t black;
+  dt_aligned_pixel_t exposure;
+  dt_aligned_pixel_t soft_clip;
+  dt_aligned_pixel_t soft_clip_comp;
+  for_each_channel(c)
+  {
+    gamma[c] = d->gamma;
+    black[c] = d->black;
+    exposure[c] = d->exposure;
+    soft_clip[c] = d->soft_clip;
+    soft_clip_comp[c] = d->soft_clip_comp;
+  }
+  // Unpack vectors one by one with extra pragmas to be sure the compiler understands they can be vectorized
+  const float *const restrict Dmin = __builtin_assume_aligned(d->Dmin, 16);
+  const float *const restrict wb_high = __builtin_assume_aligned(d->wb_high, 16);
+  const float *const restrict offset = __builtin_assume_aligned(d->offset, 16);
 
 #ifdef _OPENMP
   #pragma omp parallel for simd default(none) \
-    dt_omp_firstprivate(d, in, out, roi_out) \
-    aligned(in, out:64) collapse(2)
+    dt_omp_firstprivate(d, in, out, roi_out, exposure, black, gamma, soft_clip, soft_clip_comp, \
+                        Dmin, wb_high, offset)                                              \
+    aligned(in, out:64)
 #endif
   for(size_t k = 0; k < (size_t)roi_out->height * roi_out->width * 4; k += 4)
   {
-    for(size_t c = 0; c < 4; c++)
-    {
-      // Unpack vectors one by one with extra pragmas to be sure the compiler understands they can be vectorized
-      const float *const restrict pix_in = in + k;
-      float *const restrict pix_out = out + k;
-      const float *const restrict Dmin = __builtin_assume_aligned(d->Dmin, 16);
-      const float *const restrict wb_high = __builtin_assume_aligned(d->wb_high, 16);
-      const float *const restrict offset = __builtin_assume_aligned(d->offset, 16);
-
-      // Convert transmission to density using Dmin as a fulcrum
-      const float density = - log10f(Dmin[c] / fmaxf(pix_in[c], THRESHOLD)); // threshold to -32 EV
-
-      // Correct density in log space
-      const float corrected_de = wb_high[c] * density + offset[c];
-
-      // Print density on paper : ((1 - 10^corrected_de + black) * exposure)^gamma rewritten for FMA
-      const float print_linear = -(d->exposure * fast_exp10f(corrected_de) + d->black);
-      const float print_gamma = powf(fmaxf(print_linear, 0.0f), d->gamma); // note : this is always > 0
-
-      // Compress highlights. from https://lists.gnu.org/archive/html/openexr-devel/2005-03/msg00009.html
-      pix_out[c] =  (print_gamma > d->soft_clip) ? d->soft_clip + (1.0f - fast_expf(-(print_gamma - d->soft_clip) / d->soft_clip_comp)) * d->soft_clip_comp
-                                                 : print_gamma;
-    }
+    const float *const restrict pix_in = in + k;
+    float *const restrict pix_out = out + k;
+    _process_pixel(pix_in, pix_out, Dmin, wb_high, offset, black, exposure, gamma, soft_clip, soft_clip_comp);
   }
 }
 


### PR DESCRIPTION
The existing code didn't vectorize at all.  Now it does, for a four-fold speed improvement. I removed the optimization pragma at the start of negadoctor.c because the code proved to be about 4% faster without it.

Passes new test 0135.
```
Thr	Master	PR
1	2.675	0.671	-75%
2	1.350	0.336	-75%
4	0.679	0.168	-75%
8	0.339	0.084	-75%
16	0.170	0.042	-75%
32	0.087	0.022	-74%
64	0.062	0.018	-70%
```
