### PR TITLE
Relax compiler version check to allow GCC 10.x.

### DIFF
--- a/cmake/compiler-versions.cmake
+++ b/cmake/compiler-versions.cmake
@@ -36,10 +36,10 @@
 # and that will allow us to require Xcode 14.2 (LLVM14-based),
 # and that will allow us to require LLVM14,
 
-if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 12)
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 10)
   message(SEND_ERROR "GNU C compiler version ${CMAKE_C_COMPILER_VERSION} is too old and is unsupported. Version 12+ is required.")
 endif()
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10)
   message(SEND_ERROR "GNU C++ compiler version ${CMAKE_CXX_COMPILER_VERSION} is too old and is unsupported. Version 12+ is required.")
 endif()
 


### PR DESCRIPTION
This is done at least until 4.4 is out and when all distributions will have GCC 12.x or later (especially Debian-12 in Jul or Aug).

Discussed in #13943