### PR TITLE
[maintenance] Enhance error messaging by using dt_print instead of printf

### DIFF
--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -374,7 +374,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
   fdata->max_width = save_max_width;
   fdata->max_height = save_max_height;
 
-  printf("[export_job] exported to `%s'\n", filename);
+  dt_print(DT_DEBUG_ALWAYS, "[export_job] exported to `%s'\n", filename);
   dt_control_log(ngettext("%d/%d exported to `%s'", "%d/%d exported to `%s'", num),
                  num, total, filename);
   return 0;

--- a/src/imageio/storage/latex.c
+++ b/src/imageio/storage/latex.c
@@ -336,7 +336,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
   dt_imageio_export(imgid, filename, format, fdata, high_quality, upscale, TRUE, export_masks, icc_type, icc_filename,
                     icc_intent, self, sdata, num, total, metadata);
 
-  printf("[export_job] exported to `%s'\n", filename);
+  dt_print(DT_DEBUG_ALWAYS, "[export_job] exported to `%s'\n", filename);
   dt_control_log(ngettext("%d/%d exported to `%s'", "%d/%d exported to `%s'", num),
                  num, total, filename);
   return 0;
@@ -438,4 +438,3 @@ int set_params(dt_imageio_module_storage_t *self, const void *params, const int 
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-


### PR DESCRIPTION
It seems that almost all the printing code worth replacing has already been replaced (unless I'll find a couple more places). (f)printf calls that should not or do not make sense to replace:
- (f)printf in command line utilities and in darktable itself, when implement printing in response to --help and --version
- in commented code fragments
- added __just in case__ to code fragments to which the execution flow should not reach, regardless of the level of corruption of the input data __IF__ it is necessary to add an extra include for this (it is simply not worth it)
