### PR TITLE
Use preset's multi_name as module label.

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3584,6 +3584,13 @@
     <shortdescription>prompt for name on addition of new instance</shortdescription>
     <longdescription>if enabled, a rename prompt will be present for each new module instance (either new instance or duplicate)</longdescription>
   </dtconfig>
+  <dtconfig prefs="darkroom" section="modules">
+    <name>darkroom/ui/auto_module_name_update</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>automatically update module name</shortdescription>
+    <longdescription>if enabled, the module name will be automatically update to match a preset name if present.</longdescription>
+  </dtconfig>
 
   @DARKTABLECONFIG_IOP_ENTRIES@
 

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -385,7 +385,6 @@ gboolean dt_history_merge_module_into_history(dt_develop_t *dev_dest,
       {
         module->instance = mod_src->instance;
         module->multi_priority = mod_src->multi_priority;
-        module->multi_name_hand_edited = mod_src->multi_name_hand_edited;
         module->iop_order = dt_ioppr_get_iop_order(dev_dest->iop_order_list,
                                                    module->op, module->multi_priority);
       }
@@ -397,6 +396,7 @@ gboolean dt_history_merge_module_into_history(dt_develop_t *dev_dest,
 
     module->enabled = mod_src->enabled;
     g_strlcpy(module->multi_name, modsrc_multi_name, sizeof(module->multi_name));
+    module->multi_name_hand_edited = mod_src->multi_name_hand_edited;
 
     if(auto_init)
     {

--- a/src/common/presets.c
+++ b/src/common/presets.c
@@ -371,17 +371,17 @@ gchar *dt_get_active_preset_name(dt_iop_module_t *module, gboolean *writeprotect
   return name;
 }
 
-char *dt_presets_get_name(const char *module_name,
-                          const void *params,
-                          const uint32_t param_size,
-                          const gboolean is_default_params,
-                          const void *blend_params,
-                          const uint32_t blend_params_size)
+char *dt_presets_get_multi_name(const char *module_name,
+                                const void *params,
+                                const uint32_t param_size,
+                                const gboolean is_default_params,
+                                const void *blend_params,
+                                const uint32_t blend_params_size)
 {
   sqlite3_stmt *stmt;
 
   // clang-format off
-  char *query = g_strdup_printf("SELECT name"
+  char *query = g_strdup_printf("SELECT name, multi_name"
                                 " FROM data.presets"
                                 " WHERE operation = ?1"
                                 "   AND (op_params = ?2"
@@ -398,9 +398,15 @@ char *dt_presets_get_name(const char *module_name,
 
   char *result = NULL;
 
+  // returns the preset's multi_name if defined otherwise the preset
+  // name is returned.
   if(sqlite3_step(stmt) == SQLITE_ROW)
-    result = g_strdup((gchar *)sqlite3_column_text(stmt, 0));
-
+  {
+    const char *name = (const char *)sqlite3_column_text(stmt, 0);
+    const char *multi_name = (const char *)sqlite3_column_text(stmt, 1);
+    if(strlen(multi_name) == 0 || multi_name[0] != ' ')
+      result = g_strdup(strlen(multi_name) > 0 ? multi_name : name);
+  }
   g_free(query);
   sqlite3_finalize(stmt);
 

--- a/src/common/presets.c
+++ b/src/common/presets.c
@@ -371,13 +371,18 @@ gchar *dt_get_active_preset_name(dt_iop_module_t *module, gboolean *writeprotect
   return name;
 }
 
-char *dt_presets_get_multi_name(const char *module_name,
-                                const void *params,
-                                const uint32_t param_size,
-                                const gboolean is_default_params,
-                                const void *blend_params,
-                                const uint32_t blend_params_size)
+char *dt_presets_get_module_label(const char *module_name,
+                                  const void *params,
+                                  const uint32_t param_size,
+                                  const gboolean is_default_params,
+                                  const void *blend_params,
+                                  const uint32_t blend_params_size)
 {
+  const gboolean auto_module = dt_conf_get_bool("darkroom/ui/auto_module_name_update");
+
+  if(!auto_module)
+    return NULL;
+
   sqlite3_stmt *stmt;
 
   // clang-format off
@@ -405,12 +410,24 @@ char *dt_presets_get_multi_name(const char *module_name,
     const char *name = (const char *)sqlite3_column_text(stmt, 0);
     const char *multi_name = (const char *)sqlite3_column_text(stmt, 1);
     if(strlen(multi_name) == 0 || multi_name[0] != ' ')
-      result = g_strdup(strlen(multi_name) > 0 ? multi_name : name);
+      result = g_strdup(dt_presets_get_multi_name(name, multi_name));
   }
   g_free(query);
   sqlite3_finalize(stmt);
 
   return result;
+}
+
+const char *dt_presets_get_multi_name(const char *name, const char *multi_name)
+{
+  const gboolean auto_module = dt_conf_get_bool("darkroom/ui/auto_module_name_update");
+
+  // in auto-update mode     : use either the multi_name if defined otherwise the name
+  // in non auto-update mode : use only the multi_name if defined
+  if(auto_module)
+    return strlen(multi_name) > 0 ? multi_name : name;
+  else
+    return strlen(multi_name) > 0 ? multi_name : "";
 }
 
 // clang-format off

--- a/src/common/presets.h
+++ b/src/common/presets.h
@@ -30,13 +30,13 @@ int dt_presets_import_from_file(const char *preset_path);
 /** does the module support autoapplying presets ? */
 gboolean dt_presets_module_can_autoapply(const gchar *operation);
 
-/** get preset name for given module params */
-char *dt_presets_get_name(const char *module_name,
-                          const void *params,
-                          const uint32_t param_size,
-                          const gboolean is_default_params,
-                          const void *blend_params,
-                          const uint32_t blend_params_size);
+/** get preset multi_name for given module params */
+char *dt_presets_get_multi_name(const char *module_name,
+                                const void *params,
+                                const uint32_t param_size,
+                                const gboolean is_default_params,
+                                const void *blend_params,
+                                const uint32_t blend_params_size);
 
 /** get currently active preset name for the module */
 gchar *dt_get_active_preset_name(dt_iop_module_t *module, gboolean *writeprotect);

--- a/src/common/presets.h
+++ b/src/common/presets.h
@@ -31,12 +31,18 @@ int dt_presets_import_from_file(const char *preset_path);
 gboolean dt_presets_module_can_autoapply(const gchar *operation);
 
 /** get preset multi_name for given module params */
-char *dt_presets_get_multi_name(const char *module_name,
-                                const void *params,
-                                const uint32_t param_size,
-                                const gboolean is_default_params,
-                                const void *blend_params,
-                                const uint32_t blend_params_size);
+char *dt_presets_get_module_label(const char *module_name,
+                                  const void *params,
+                                  const uint32_t param_size,
+                                  const gboolean is_default_params,
+                                  const void *blend_params,
+                                  const uint32_t blend_params_size);
+
+/* returns the module's multi-name to use given the name of the preset
+   and the recorded preset's multi_name. This depends on the preference
+   darkroom/ui/auto_module_name_update
+*/
+const char *dt_presets_get_multi_name(const char *name, const char *multi_name);
 
 /** get currently active preset name for the module */
 gchar *dt_get_active_preset_name(dt_iop_module_t *module, gboolean *writeprotect);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1470,7 +1470,7 @@ void _dev_insert_module(dt_develop_t *dev, dt_iop_module_t *module, const int im
   // we make sure that the multi-name is updated if possible with the
   // actual preset name if any is defined for the default parameters.
 
-  char *preset_name = dt_presets_get_name
+  char *preset_name = dt_presets_get_multi_name
     (module->op,
      module->default_params, module->params_size, TRUE,
      module->blend_params, sizeof(dt_develop_blend_params_t));

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1863,7 +1863,7 @@ static gboolean _iop_update_label(gpointer data)
   const gboolean is_default_params =
     memcmp(module->params, module->default_params, module->params_size) == 0;
 
-  char *preset_name = dt_presets_get_multi_name
+  char *preset_name = dt_presets_get_module_label
     (module->op,
      module->params, module->params_size, is_default_params,
      module->blend_params, sizeof(dt_develop_blend_params_t));
@@ -1924,7 +1924,8 @@ void dt_iop_commit_params(dt_iop_module_t *module,
      && module_params_changed
      && !module->multi_name_hand_edited
      && module->instance_name
-     && gtk_widget_get_visible(module->instance_name))
+     && gtk_widget_get_visible(module->instance_name)
+     && dt_conf_get_bool("darkroom/ui/auto_module_name_update"))
   {
     if(module->label_recompute_handle)
       g_source_remove(module->label_recompute_handle);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1863,7 +1863,7 @@ static gboolean _iop_update_label(gpointer data)
   const gboolean is_default_params =
     memcmp(module->params, module->default_params, module->params_size) == 0;
 
-  char *preset_name = dt_presets_get_name
+  char *preset_name = dt_presets_get_multi_name
     (module->op,
      module->params, module->params_size, is_default_params,
      module->blend_params, sizeof(dt_develop_blend_params_t));

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -951,11 +951,15 @@ void dt_gui_presets_apply_preset(const gchar* name, dt_iop_module_t *module)
 
     // if module name has not been hand edited, use preset multi_name
     // or name as module label.
-    if(!module->multi_name_hand_edited
+
+    const gboolean auto_module = dt_conf_get_bool("darkroom/ui/auto_module_name_update");
+
+    if(auto_module
+       && !module->multi_name_hand_edited
        && (strlen(multi_name) == 0 || multi_name[0] != ' '))
     {
       g_strlcpy(module->multi_name,
-                strlen(multi_name) > 0 ? multi_name : name,
+                dt_presets_get_multi_name(name, multi_name),
                 sizeof(module->multi_name));
       module->multi_name_hand_edited = multi_name_hand_edited;
     }

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -971,7 +971,8 @@ void dt_gui_presets_apply_preset(const gchar* name, dt_iop_module_t *module)
       dt_iop_commit_blend_params(module, blendop_params);
     }
     else if(blendop_params
-            && dt_develop_blend_legacy_params(module, blendop_params, blendop_version, module->blend_params,
+            && dt_develop_blend_legacy_params(module, blendop_params,
+                                              blendop_version, module->blend_params,
                                               dt_develop_blend_version(), bl_length) == 0)
     {
       // do nothing

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -603,7 +603,7 @@ void init_presets(dt_iop_module_so_t *self)
     p.curve_num_nodes[c] = DT_IOP_COLORZONES_BANDS - 1;
     p.curve_type[c] = CATMULL_ROM;
   }
-  dt_gui_presets_add_generic(_("red black white"), self->op,
+  dt_gui_presets_add_generic(_("B&W: with red"), self->op,
                              version, &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_DISPLAY);
 
   // black white and skin tones
@@ -626,7 +626,7 @@ void init_presets(dt_iop_module_so_t *self)
     p.curve_num_nodes[c] = DT_IOP_COLORZONES_BANDS - 1;
     p.curve_type[c] = CATMULL_ROM;
   }
-  dt_gui_presets_add_generic(_("black white and skin tones"), self->op,
+  dt_gui_presets_add_generic(_("B&W: with skin tones"), self->op,
                              version, &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_DISPLAY);
 
   // polarizing filter
@@ -701,7 +701,7 @@ void init_presets(dt_iop_module_so_t *self)
     p.curve_num_nodes[c] = DT_IOP_COLORZONES_BANDS - 1;
     p.curve_type[c] = CATMULL_ROM;
   }
-  dt_gui_presets_add_generic(_("black & white film"), self->op,
+  dt_gui_presets_add_generic(_("B&W: film"), self->op,
                              version, &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_DISPLAY);
 
   // neutral preset with just a set of nodes uniformly distributed along the hue axis

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -469,9 +469,9 @@ void init_presets(dt_iop_module_so_t *self)
   dt_database_start_transaction(darktable.db);
 
   p.orientation = ORIENTATION_NULL;
-  dt_gui_presets_add_generic(_("autodetect"), self->op,
+  dt_gui_presets_add_generic(_("auto"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_NONE);
-  dt_gui_presets_update_autoapply(_("autodetect"), self->op, self->version(), 1);
+  dt_gui_presets_update_autoapply(_("auto"), self->op, self->version(), 1);
 
   p.orientation = ORIENTATION_NONE;
   dt_gui_presets_add_generic(_("no rotation"), self->op,


### PR DESCRIPTION
In an attempt to give better control to the actual module label used (avoiding also long preset names possibly hard to read and ellipsize) the module label is now using the preset multi_name if set. If not set, the preset name is used as before.

For #13982.

This PR is a follow up to change in the way the module label is updated.

Until 4.2 the module label was updated only with numbers for multiple instance.

Starting with 4.4 the module's label is updated with the following action:

- Applying a preset, the multi-name of the preset recorded at creation time is used as label or if empty the preset name is used.
- Applying auto-presets when starting an edit or resetting the history stack does the same as above.
- Changing params in the module will check for a corresponding preset, if found the preset name is displayed otherwise the module label is cleared.
- If a module label is hand edited it will be record and won't change due action above. That is, the module label will always be the one hand edited.

A new preference has been added to disable the auto renaming of module label and so if disabled the behavior will be the one found in  4.2.