### PR TITLE
don't show undescribed enum in combo

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -694,6 +694,8 @@ void dt_bauhaus_init()
   dt_bauhaus_load_theme();
 
   darktable.bauhaus->skip_accel = 1;
+  darktable.bauhaus->combo_introspection = g_hash_table_new(NULL, NULL);
+  darktable.bauhaus->combo_list = g_hash_table_new(NULL, NULL);
 
   // this easily gets keyboard input:
   // darktable.bauhaus->popup_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
@@ -1273,7 +1275,7 @@ void dt_bauhaus_combobox_add_populate_fct(GtkWidget *widget, void (*fct)(GtkWidg
 void dt_bauhaus_combobox_add_list(GtkWidget *widget, dt_action_t *action, const char **texts)
 {
   if(action)
-    g_hash_table_insert(darktable.control->combo_list, action, texts);
+    g_hash_table_insert(darktable.bauhaus->combo_list, action, texts);
 
   int item = 0;
   while(texts && *texts)
@@ -1289,7 +1291,7 @@ gboolean dt_bauhaus_combobox_add_introspection(GtkWidget *widget,
   dt_introspection_type_enum_tuple_t *item = (dt_introspection_type_enum_tuple_t *)list;
 
   if(action)
-    g_hash_table_insert(darktable.control->combo_introspection, action, (gpointer)list);
+    g_hash_table_insert(darktable.bauhaus->combo_introspection, action, (gpointer)list);
 
   while(item->name && item->value != start) item++;
   for(; item->name; item++)
@@ -1558,7 +1560,7 @@ gboolean dt_bauhaus_combobox_set_from_value(GtkWidget *widget, int value)
 
   // this might be a legacy option that was hidden; try to re-add from introspection
   dt_introspection_type_enum_tuple_t *values
-    = g_hash_table_lookup(darktable.control->combo_introspection, dt_action_widget(widget));
+    = g_hash_table_lookup(darktable.bauhaus->combo_introspection, dt_action_widget(widget));
   if(values)
   {
     dt_bauhaus_combobox_add_introspection(widget, NULL, values, value, value);
@@ -3509,7 +3511,7 @@ static float _action_process_combo(gpointer target, dt_action_element_t element,
     default:
       value = effect - DT_ACTION_EFFECT_COMBO_SEPARATOR - 1;
       dt_introspection_type_enum_tuple_t *values
-        = g_hash_table_lookup(darktable.control->combo_introspection, dt_action_widget(target));
+        = g_hash_table_lookup(darktable.bauhaus->combo_introspection, dt_action_widget(target));
       if(values)
         value = values[value].value;
 

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1555,6 +1555,17 @@ gboolean dt_bauhaus_combobox_set_from_value(GtkWidget *widget, int value)
       return TRUE;
     }
   }
+
+  // this might be a legacy option that was hidden; try to re-add from introspection
+  dt_introspection_type_enum_tuple_t *values
+    = g_hash_table_lookup(darktable.control->combo_introspection, dt_action_widget(widget));
+  if(values)
+  {
+    dt_bauhaus_combobox_add_introspection(widget, NULL, values, value, value);
+    dt_bauhaus_combobox_set(widget, d->entries->len - 1);
+    return TRUE;
+  }
+
   return FALSE;
 }
 

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1294,8 +1294,11 @@ gboolean dt_bauhaus_combobox_add_introspection(GtkWidget *widget,
   while(item->name && item->value != start) item++;
   for(; item->name; item++)
   {
-    dt_bauhaus_combobox_add_full(widget, Q_(item->description ? item->description : item->name),
-                                 DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, GUINT_TO_POINTER(item->value), NULL, TRUE);
+    const char *text = item->description ? item->description : item->name;
+    if(*text)
+      dt_bauhaus_combobox_add_full(widget, Q_(text),
+                                   DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,
+                                   GUINT_TO_POINTER(item->value), NULL, TRUE);
     if(item->value == end) return TRUE;
   }
   return FALSE;

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1544,7 +1544,7 @@ gboolean dt_bauhaus_combobox_set_from_text(GtkWidget *widget, const char *text)
   return FALSE;
 }
 
-gboolean dt_bauhaus_combobox_set_from_value(GtkWidget *widget, int value)
+int dt_bauhaus_combobox_get_from_value(GtkWidget *widget, int value)
 {
   const dt_bauhaus_combobox_data_t *d = _combobox_data(widget);
 
@@ -1553,18 +1553,27 @@ gboolean dt_bauhaus_combobox_set_from_value(GtkWidget *widget, int value)
     const dt_bauhaus_combobox_entry_t *entry = g_ptr_array_index(d->entries, i);
     if(GPOINTER_TO_INT(entry->data) == value)
     {
-      dt_bauhaus_combobox_set(widget, i);
-      return TRUE;
+      return i;
     }
   }
+
+  return -1;
+}
+
+gboolean dt_bauhaus_combobox_set_from_value(GtkWidget *widget, int value)
+{
+  const int pos = dt_bauhaus_combobox_get_from_value(widget, value);
+  dt_bauhaus_combobox_set(widget, pos);
+
+  if(pos != -1) return TRUE;
 
   // this might be a legacy option that was hidden; try to re-add from introspection
   dt_introspection_type_enum_tuple_t *values
     = g_hash_table_lookup(darktable.bauhaus->combo_introspection, dt_action_widget(widget));
-  if(values)
+  if(values
+     && dt_bauhaus_combobox_add_introspection(widget, NULL, values, value, value))
   {
-    dt_bauhaus_combobox_add_introspection(widget, NULL, values, value, value);
-    dt_bauhaus_combobox_set(widget, d->entries->len - 1);
+    dt_bauhaus_combobox_set(widget, dt_bauhaus_combobox_length(widget) - 1);
     return TRUE;
   }
 

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -221,6 +221,7 @@ typedef struct dt_bauhaus_t
 
   // initialise or connect accelerators in set_label
   int skip_accel;
+  GHashTable *combo_introspection, *combo_list;
 
   // appearance relevant stuff:
   // sizes and fonts:

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -355,6 +355,7 @@ gboolean dt_bauhaus_combobox_set_entry_label(GtkWidget *widget, const int pos, c
 void dt_bauhaus_combobox_set(GtkWidget *w, int pos);
 gboolean dt_bauhaus_combobox_set_from_text(GtkWidget *w, const char *text);
 gboolean dt_bauhaus_combobox_set_from_value(GtkWidget *w, int value);
+int dt_bauhaus_combobox_get_from_value(GtkWidget *widget, int value);
 void dt_bauhaus_combobox_remove_at(GtkWidget *widget, int pos);
 void dt_bauhaus_combobox_insert(GtkWidget *widget, const char *text,int pos);
 void dt_bauhaus_combobox_insert_full(GtkWidget *widget, const char *text, dt_bauhaus_combobox_alignment_t align,

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -188,8 +188,6 @@ void dt_control_init(dt_control_t *s)
   dt_action_insert_sorted(&s->actions_iops, &s->actions_focus);
 
   s->widgets = g_hash_table_new(NULL, NULL);
-  s->combo_introspection = g_hash_table_new(NULL, NULL);
-  s->combo_list = g_hash_table_new(NULL, NULL);
   s->shortcuts = g_sequence_new(g_free);
   s->enable_fallbacks = dt_conf_get_bool("accel/enable_fallbacks");
   s->mapping_widget = NULL;

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -136,7 +136,7 @@ typedef struct dt_control_t
                actions_iops, actions_blend, actions_focus,
                actions_lua, actions_fallbacks, *actions_modifiers;
 
-  GHashTable *widgets, *combo_introspection, *combo_list;
+  GHashTable *widgets;
   GSequence *shortcuts;
   gboolean enable_fallbacks;
   GtkWidget *mapping_widget;

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -375,7 +375,7 @@ static const gchar *_action_find_effect_combo(dt_action_t *ac, const dt_action_e
   if(el->effects == dt_action_effect_selection && ef > DT_ACTION_EFFECT_COMBO_SEPARATOR)
   {
     dt_introspection_type_enum_tuple_t *values
-      = g_hash_table_lookup(darktable.control->combo_introspection, ac);
+      = g_hash_table_lookup(darktable.bauhaus->combo_introspection, ac);
     if(values)
     {
       values += ef - DT_ACTION_EFFECT_COMBO_SEPARATOR - 1;
@@ -387,7 +387,7 @@ static const gchar *_action_find_effect_combo(dt_action_t *ac, const dt_action_e
     else
     {
       gchar **strings
-        = g_hash_table_lookup(darktable.control->combo_list, ac);
+        = g_hash_table_lookup(darktable.bauhaus->combo_list, ac);
       if(strings)
         return strings[ef - DT_ACTION_EFFECT_COMBO_SEPARATOR - 1];
       else
@@ -794,7 +794,7 @@ static gchar *_shortcut_lua_command(GtkWidget *widget, dt_shortcut_t *s, gchar *
     {
       int value = GPOINTER_TO_INT(dt_bauhaus_combobox_get_data(widget));
       dt_introspection_type_enum_tuple_t *values
-        = g_hash_table_lookup(darktable.control->combo_introspection, s->action);
+        = g_hash_table_lookup(darktable.bauhaus->combo_introspection, s->action);
       for(int i = 0; values && values->name; values++, i++)
       {
         if(values->value == value)
@@ -1593,7 +1593,7 @@ static void _effect_editing_started(GtkCellRenderer *renderer, GtkCellEditable *
     gtk_combo_box_set_row_separator_func(combo_box, _effects_separator_func, NULL, NULL);
 
     dt_introspection_type_enum_tuple_t *values
-      = g_hash_table_lookup(darktable.control->combo_introspection, s->action);
+      = g_hash_table_lookup(darktable.bauhaus->combo_introspection, s->action);
     if(values)
     {
       // insert empty/separator row
@@ -1610,7 +1610,7 @@ static void _effect_editing_started(GtkCellRenderer *renderer, GtkCellEditable *
     else
     {
       gchar **strings
-        = g_hash_table_lookup(darktable.control->combo_list, s->action);
+        = g_hash_table_lookup(darktable.bauhaus->combo_list, s->action);
       if(strings)
       {
         // insert empty/separator row
@@ -2704,7 +2704,7 @@ static gboolean _find_combo_effect(const gchar **effects, const gchar *token, dt
     const char *entry = NULL;
 
     dt_introspection_type_enum_tuple_t *values
-      = g_hash_table_lookup(darktable.control->combo_introspection, ac);
+      = g_hash_table_lookup(darktable.bauhaus->combo_introspection, ac);
     if(values)
     {
       while((entry = (values[++effect].description ? values[effect].description : values[effect].name)))
@@ -2713,7 +2713,7 @@ static gboolean _find_combo_effect(const gchar **effects, const gchar *token, dt
     else
     {
       gchar **strings
-        = g_hash_table_lookup(darktable.control->combo_list, ac);
+        = g_hash_table_lookup(darktable.bauhaus->combo_list, ac);
       if(strings)
       {
         while((entry = strings[++effect]))

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -3855,12 +3855,8 @@ void reload_defaults(dt_iop_module_t *module)
     }
 
     if(dt_image_is_matrix_correction_supported(img) && !dt_image_is_monochrome(img))
-    {
-      if(dt_bauhaus_combobox_length(g->illuminant) < DT_ILLUMINANT_CAMERA + 1)
-        dt_bauhaus_combobox_add_full(g->illuminant, _("as shot in camera"),
-                                     DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,
-                                     GINT_TO_POINTER(DT_ILLUMINANT_CAMERA), NULL, TRUE);
-    }
+      // add back if needed
+      dt_bauhaus_combobox_set_from_value(g->illuminant, DT_ILLUMINANT_CAMERA);
     else
       dt_bauhaus_combobox_remove_at(g->illuminant, DT_ILLUMINANT_CAMERA);
 

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -3854,11 +3854,16 @@ void reload_defaults(dt_iop_module_t *module)
       g->delta_E_label_text = NULL;
     }
 
+    const int pos = dt_bauhaus_combobox_get_from_value(g->illuminant, DT_ILLUMINANT_CAMERA);
     if(dt_image_is_matrix_correction_supported(img) && !dt_image_is_monochrome(img))
-      // add back if needed
-      dt_bauhaus_combobox_set_from_value(g->illuminant, DT_ILLUMINANT_CAMERA);
+    {
+      if(pos == -1)
+        dt_bauhaus_combobox_add_introspection(g->illuminant, NULL,
+                                              module->so->get_f("illuminant")->Enum.values,
+                                              DT_ILLUMINANT_CAMERA, DT_ILLUMINANT_CAMERA);
+    }
     else
-      dt_bauhaus_combobox_remove_at(g->illuminant, DT_ILLUMINANT_CAMERA);
+      dt_bauhaus_combobox_remove_at(g->illuminant, pos);
 
     gui_changed(module, NULL, NULL);
   }

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2460,7 +2460,6 @@ void gui_init(struct dt_iop_module_t *self)
 
   // select by which dimension
   c->select_by = dt_bauhaus_combobox_from_params(self, "channel");
-  dt_bauhaus_combobox_remove_at(c->select_by, DT_IOP_COLORZONES_MAX_CHANNELS);
   gtk_widget_set_tooltip_text(c->select_by, _("choose selection criterion, will be the abscissa in the graph"));
 
   c->mode = dt_bauhaus_combobox_from_params(self, "mode");

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5468,11 +5468,13 @@ void gui_init(struct dt_iop_module_t *self)
   GtkWidget *box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
   g->demosaic_method_bayer = dt_bauhaus_combobox_from_params(self, "demosaicing_method");
-  for(int i=0;i<7;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_bayer, 9);
+
+  const int xtrans = dt_bauhaus_combobox_get_from_value(g->demosaic_method_bayer, DT_DEMOSAIC_XTRANS);
+  for(int i=0;i<7;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_bayer, xtrans);
   gtk_widget_set_tooltip_text(g->demosaic_method_bayer, _("Bayer sensor demosaicing method, PPG and RCD are fast, AMaZE and LMMSE are slow.\nLMMSE is suited best for high ISO images.\ndual demosaicers double processing time."));
 
   g->demosaic_method_xtrans = dt_bauhaus_combobox_from_params(self, "demosaicing_method");
-  for(int i=0;i<9;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_xtrans, 0);
+  for(int i=0;i<xtrans;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_xtrans, 0);
   gtk_widget_set_tooltip_text(g->demosaic_method_xtrans, _("X-Trans sensor demosaicing method, Markesteijn 3-pass and frequency domain chroma are slow.\ndual demosaicers double processing time."));
 
   g->median_thrs = dt_bauhaus_slider_from_params(self, "median_thrs");

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -66,11 +66,11 @@
 
 typedef enum dt_iop_denoiseprofile_mode_t
 {
-  MODE_NLMEANS = 0,
-  MODE_WAVELETS = 1,
-  MODE_VARIANCE = 2,
-  MODE_NLMEANS_AUTO = 3,
-  MODE_WAVELETS_AUTO = 4
+  MODE_NLMEANS = 0,       // $DESCRIPTION: "non-local means"
+  MODE_NLMEANS_AUTO = 3,  // $DESCRIPTION: "non-local means auto"
+  MODE_WAVELETS = 1,      // $DESCRIPTION: "wavelets"
+  MODE_WAVELETS_AUTO = 4, // $DESCRIPTION: "wavelets auto"
+  MODE_VARIANCE = 2,      // $DESCRIPTION: "compute variance"
 } dt_iop_denoiseprofile_mode_t;
 
 typedef enum dt_iop_denoiseprofile_wavelet_mode_t
@@ -3075,129 +3075,99 @@ static void profile_callback(GtkWidget *w, dt_iop_module_t *self)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void mode_callback(GtkWidget *w, dt_iop_module_t *self)
-{
-  dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;
-  dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
-  const unsigned mode = dt_bauhaus_combobox_get(w);
-  switch(mode)
-  {
-    case 0:
-      p->mode = MODE_NLMEANS;
-      gtk_widget_hide(g->box_wavelets);
-      gtk_widget_hide(g->box_variance);
-      gtk_widget_show_all(g->box_nlm);
-      break;
-    case 1:
-      p->mode = MODE_NLMEANS_AUTO;
-      gtk_widget_hide(g->box_wavelets);
-      gtk_widget_hide(g->box_variance);
-      gtk_widget_show_all(g->box_nlm);
-      gtk_widget_set_visible(g->radius, FALSE);
-      gtk_widget_set_visible(g->nbhood, FALSE);
-      gtk_widget_set_visible(g->scattering, FALSE);
-      break;
-    case 2:
-      p->mode = MODE_WAVELETS;
-      gtk_widget_hide(g->box_nlm);
-      gtk_widget_hide(g->box_variance);
-      gtk_widget_show_all(g->box_wavelets);
-      gtk_widget_set_visible(GTK_WIDGET(g->wavelet_color_mode), p->use_new_vst);
-      gtk_widget_set_visible(GTK_WIDGET(g->channel_tabs),
-                             p->use_new_vst && (p->wavelet_color_mode == MODE_RGB));
-      gtk_widget_set_visible(GTK_WIDGET(g->channel_tabs_Y0U0V0),
-                             p->use_new_vst && (p->wavelet_color_mode == MODE_Y0U0V0));
-      break;
-    case 3:
-      p->mode = MODE_WAVELETS_AUTO;
-      gtk_widget_hide(g->box_nlm);
-      gtk_widget_hide(g->box_variance);
-      gtk_widget_show_all(g->box_wavelets);
-      gtk_widget_set_visible(GTK_WIDGET(g->wavelet_color_mode), p->use_new_vst);
-      gtk_widget_set_visible(GTK_WIDGET(g->channel_tabs),
-                             p->use_new_vst && (p->wavelet_color_mode == MODE_RGB));
-      gtk_widget_set_visible(GTK_WIDGET(g->channel_tabs_Y0U0V0),
-                             p->use_new_vst && (p->wavelet_color_mode == MODE_Y0U0V0));
-      break;
-    case 4:
-      p->mode = MODE_VARIANCE;
-      gtk_widget_hide(g->box_wavelets);
-      gtk_widget_hide(g->box_nlm);
-      gtk_widget_show_all(g->box_variance);
-      break;
-  }
-  const gboolean auto_mode =
-    (p->mode == MODE_NLMEANS_AUTO) || (p->mode == MODE_WAVELETS_AUTO);
-  gtk_widget_set_visible(g->shadows, p->use_new_vst && !auto_mode);
-  gtk_widget_set_visible(g->bias, p->use_new_vst && !auto_mode);
-  gtk_widget_set_visible(g->overshooting, auto_mode);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;
   dt_iop_denoiseprofile_gui_data_t *g =
     (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
 
-  if(w == g->wavelet_color_mode)
+  if(!w || w == g->mode)
   {
-    gtk_widget_set_visible(GTK_WIDGET(g->channel_tabs),
-                           p->wavelet_color_mode == MODE_RGB);
-    gtk_widget_set_visible(GTK_WIDGET(g->channel_tabs_Y0U0V0),
-                           p->wavelet_color_mode == MODE_Y0U0V0);
+    switch(p->mode)
+    {
+      case MODE_NLMEANS:
+        gtk_widget_hide(g->box_wavelets);
+        gtk_widget_hide(g->box_variance);
+        gtk_widget_show_all(g->box_nlm);
+        break;
+      case MODE_NLMEANS_AUTO:
+        gtk_widget_hide(g->box_wavelets);
+        gtk_widget_hide(g->box_variance);
+        gtk_widget_show_all(g->box_nlm);
+        gtk_widget_set_visible(g->radius, FALSE);
+        gtk_widget_set_visible(g->nbhood, FALSE);
+        gtk_widget_set_visible(g->scattering, FALSE);
+        break;
+      case MODE_WAVELETS:
+        gtk_widget_hide(g->box_nlm);
+        gtk_widget_hide(g->box_variance);
+        gtk_widget_show_all(g->box_wavelets);
+        break;
+      case MODE_WAVELETS_AUTO:
+        gtk_widget_hide(g->box_nlm);
+        gtk_widget_hide(g->box_variance);
+        gtk_widget_show_all(g->box_wavelets);
+        break;
+      case MODE_VARIANCE:
+        gtk_widget_hide(g->box_wavelets);
+        gtk_widget_hide(g->box_nlm);
+        gtk_widget_show_all(g->box_variance);
+        break;
+    }
+  }
+
+  if(!w || w == g->wavelet_color_mode)
+  {
     if(p->wavelet_color_mode == MODE_RGB)
       g->channel = DT_DENOISE_PROFILE_ALL;
     else
       g->channel = DT_DENOISE_PROFILE_Y0;
   }
-  else if(w == g->overshooting)
-  {
-    const float gain = p->overshooting;
-    float a = p->a[1];
-    if(p->a[0] == -1.0)
-    {
-      dt_noiseprofile_t interpolated = dt_iop_denoiseprofile_get_auto_profile(self);
-      a = interpolated.a[1];
-    }
-    // set the sliders as visible while we are setting their values
-    // otherwise a log message appears
-    if(p->mode == MODE_NLMEANS_AUTO)
-    {
-      gtk_widget_set_visible(g->radius, TRUE);
-      gtk_widget_set_visible(g->scattering, TRUE);
-      dt_bauhaus_slider_set(g->radius, infer_radius_from_profile(a * gain));
-      dt_bauhaus_slider_set(g->scattering, infer_scattering_from_profile(a * gain));
-      gtk_widget_set_visible(g->radius, FALSE);
-      gtk_widget_set_visible(g->scattering, FALSE);
-    }
-    else
-    {
-      // we are in wavelets mode.
-      // we need to show the box_nlm, setting the sliders to visible is not enough
-      gtk_widget_show_all(g->box_nlm);
-      dt_bauhaus_slider_set(g->radius, infer_radius_from_profile(a * gain));
-      dt_bauhaus_slider_set(g->scattering, infer_scattering_from_profile(a * gain));
-      gtk_widget_hide(g->box_nlm);
-    }
-    gtk_widget_set_visible(g->shadows, TRUE);
-    gtk_widget_set_visible(g->bias, TRUE);
-    dt_bauhaus_slider_set(g->shadows, infer_shadows_from_profile(a * gain));
-    dt_bauhaus_slider_set(g->bias, infer_bias_from_profile(a * gain));
-    gtk_widget_set_visible(g->shadows, FALSE);
-    gtk_widget_set_visible(g->bias, FALSE);
-  }
-  else if(w == g->use_new_vst)
-  {
-    const gboolean auto_mode =
-      (p->mode == MODE_NLMEANS_AUTO) || (p->mode == MODE_WAVELETS_AUTO);
-    gtk_widget_set_visible(g->shadows, p->use_new_vst && !auto_mode);
-    gtk_widget_set_visible(g->bias, p->use_new_vst && !auto_mode);
-    gtk_widget_set_visible(g->wavelet_color_mode, p->use_new_vst);
 
+  if(!w || w == g->mode || w == g->wavelet_color_mode || w == g->use_new_vst)
+  {
     if(!p->use_new_vst
        && p->wavelet_color_mode == MODE_Y0U0V0)
       p->wavelet_color_mode = MODE_RGB;
+
+    gtk_widget_set_visible(GTK_WIDGET(g->channel_tabs),
+                            p->wavelet_color_mode == MODE_RGB);
+    gtk_widget_set_visible(GTK_WIDGET(g->channel_tabs_Y0U0V0),
+                            p->wavelet_color_mode == MODE_Y0U0V0);
+  }
+
+  if(!w || w == g->overshooting)
+  {
+    float a = p->a[1];
+    if(p->a[0] == -1.0)
+    {
+      dt_bauhaus_combobox_set(g->profile, 0);
+
+      dt_noiseprofile_t interpolated = dt_iop_denoiseprofile_get_auto_profile(self);
+      a = interpolated.a[1];
+    }
+
+    if((p->mode == MODE_NLMEANS_AUTO) || (p->mode == MODE_WAVELETS_AUTO))
+    {
+      const float gain = p->overshooting;
+      dt_bauhaus_slider_set(g->radius, infer_radius_from_profile(a * gain));
+      dt_bauhaus_slider_set(g->scattering, infer_scattering_from_profile(a * gain));
+      dt_bauhaus_slider_set(g->shadows, infer_shadows_from_profile(a * gain));
+      dt_bauhaus_slider_set(g->bias, infer_bias_from_profile(a * gain));
+    }
+  }
+
+  if(!w || w == g->mode || w == g->use_new_vst)
+  {
+
+    const gboolean auto_mode =
+      (p->mode == MODE_NLMEANS_AUTO) || (p->mode == MODE_WAVELETS_AUTO);
+    const gboolean wavelet_mode =
+      (p->mode == MODE_WAVELETS) || (p->mode == MODE_WAVELETS_AUTO);
+    gtk_widget_set_visible(g->overshooting, auto_mode);
+    gtk_widget_set_visible(g->wavelet_color_mode, p->use_new_vst && wavelet_mode);
+    gtk_widget_set_visible(g->shadows, p->use_new_vst && !auto_mode);
+    gtk_widget_set_visible(g->bias, p->use_new_vst && !auto_mode);
   }
 }
 
@@ -3207,80 +3177,18 @@ void gui_update(dt_iop_module_t *self)
   dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;
 
   dt_bauhaus_combobox_set(g->profile, -1);
-  unsigned combobox_index = 0;
-  switch(p->mode)
+  int i = 1;
+  for(GList *iter = g->profiles; iter; iter = g_list_next(iter), i++)
   {
-    case MODE_NLMEANS:
-      combobox_index = 0;
-      gtk_widget_hide(g->box_wavelets);
-      gtk_widget_hide(g->box_variance);
-      gtk_widget_show_all(g->box_nlm);
-      break;
-    case MODE_NLMEANS_AUTO:
-      combobox_index = 1;
-      gtk_widget_hide(g->box_wavelets);
-      gtk_widget_hide(g->box_variance);
-      gtk_widget_show_all(g->box_nlm);
-      gtk_widget_set_visible(g->radius, FALSE);
-      gtk_widget_set_visible(g->nbhood, FALSE);
-      gtk_widget_set_visible(g->scattering, FALSE);
-      break;
-    case MODE_WAVELETS:
-      combobox_index = 2;
-      gtk_widget_hide(g->box_nlm);
-      gtk_widget_hide(g->box_variance);
-      gtk_widget_show_all(g->box_wavelets);
-      break;
-    case MODE_WAVELETS_AUTO:
-      combobox_index = 3;
-      gtk_widget_hide(g->box_nlm);
-      gtk_widget_hide(g->box_variance);
-      gtk_widget_show_all(g->box_wavelets);
-      break;
-    case MODE_VARIANCE:
-      combobox_index = 4;
-      gtk_widget_hide(g->box_wavelets);
-      gtk_widget_hide(g->box_nlm);
-      gtk_widget_show_all(g->box_variance);
-      if(dt_bauhaus_combobox_length(g->mode) == 4)
-      {
-        dt_bauhaus_combobox_add(g->mode, _("compute variance"));
-      }
-      break;
-  }
-  float a = p->a[1];
-  if(p->a[0] == -1.0)
-  {
-    dt_noiseprofile_t interpolated = dt_iop_denoiseprofile_get_auto_profile(self);
-    a = interpolated.a[1];
-  }
-  if((p->mode == MODE_NLMEANS_AUTO) || (p->mode == MODE_WAVELETS_AUTO))
-  {
-    const float gain = p->overshooting;
-    dt_bauhaus_slider_set(g->radius, infer_radius_from_profile(a * gain));
-    dt_bauhaus_slider_set(g->scattering, infer_scattering_from_profile(a * gain));
-    dt_bauhaus_slider_set(g->shadows, infer_shadows_from_profile(a * gain));
-    dt_bauhaus_slider_set(g->bias, infer_bias_from_profile(a * gain));
-  }
-  dt_bauhaus_combobox_set(g->mode, combobox_index);
-  if(p->a[0] == -1.0)
-  {
-    dt_bauhaus_combobox_set(g->profile, 0);
-  }
-  else
-  {
-    int i = 1;
-    for(GList *iter = g->profiles; iter; iter = g_list_next(iter), i++)
+    dt_noiseprofile_t *profile = (dt_noiseprofile_t *)iter->data;
+    if(!memcmp(profile->a, p->a, sizeof(float) * 3)
+        && !memcmp(profile->b, p->b, sizeof(float) * 3))
     {
-      dt_noiseprofile_t *profile = (dt_noiseprofile_t *)iter->data;
-      if(!memcmp(profile->a, p->a, sizeof(float) * 3)
-         && !memcmp(profile->b, p->b, sizeof(float) * 3))
-      {
-        dt_bauhaus_combobox_set(g->profile, i);
-        break;
-      }
+      dt_bauhaus_combobox_set(g->profile, i);
+      break;
     }
   }
+
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->wb_adaptive_anscombe),
                                p->wb_adaptive_anscombe);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->fix_anscombe_and_nlmeans_norm),
@@ -3289,18 +3197,6 @@ void gui_update(dt_iop_module_t *self)
                          !p->fix_anscombe_and_nlmeans_norm);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->use_new_vst), p->use_new_vst);
   gtk_widget_set_visible(g->use_new_vst, !p->use_new_vst);
-  const gboolean auto_mode =
-    (p->mode == MODE_NLMEANS_AUTO) || (p->mode == MODE_WAVELETS_AUTO);
-  const gboolean wavelet_mode =
-    (p->mode == MODE_WAVELETS) || (p->mode == MODE_WAVELETS_AUTO);
-  gtk_widget_set_visible(g->overshooting, auto_mode);
-  gtk_widget_set_visible(g->wavelet_color_mode, p->use_new_vst && wavelet_mode);
-  gtk_widget_set_visible(g->shadows, p->use_new_vst && !auto_mode);
-  gtk_widget_set_visible(g->bias, p->use_new_vst && !auto_mode);
-  gtk_widget_set_visible(GTK_WIDGET(g->channel_tabs),
-                         p->wavelet_color_mode == MODE_RGB);
-  gtk_widget_set_visible(GTK_WIDGET(g->channel_tabs_Y0U0V0),
-                         p->wavelet_color_mode == MODE_Y0U0V0);
   if((p->wavelet_color_mode == MODE_Y0U0V0) && (g->channel < DT_DENOISE_PROFILE_Y0))
   {
     g->channel = DT_DENOISE_PROFILE_Y0;
@@ -3312,6 +3208,8 @@ void gui_update(dt_iop_module_t *self)
     g->channel = DT_DENOISE_PROFILE_ALL;
     gtk_notebook_set_current_page(GTK_NOTEBOOK(g->channel_tabs), g->channel);
   }
+
+  gui_changed(self, NULL, NULL);
 }
 
 void gui_reset(dt_iop_module_t *self)
@@ -3877,17 +3775,10 @@ void gui_init(dt_iop_module_t *self)
 
   g->wb_adaptive_anscombe = dt_bauhaus_toggle_from_params(self, "wb_adaptive_anscombe");
 
-  g->mode = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->mode, NULL, N_("mode"));
-  dt_bauhaus_combobox_add(g->mode, _("non-local means"));
-  dt_bauhaus_combobox_add(g->mode, _("non-local means auto"));
-  dt_bauhaus_combobox_add(g->mode, _("wavelets"));
-  dt_bauhaus_combobox_add(g->mode, _("wavelets auto"));
+  g->mode = dt_bauhaus_combobox_from_params(self, N_("mode"));
   const gboolean compute_variance =
     dt_conf_get_bool("plugins/darkroom/denoiseprofile/show_compute_variance_mode");
-  if(compute_variance) dt_bauhaus_combobox_add(g->mode, _("compute variance"));
-  g_signal_connect(G_OBJECT(g->mode), "value-changed", G_CALLBACK(mode_callback), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->mode, TRUE, TRUE, 0);
+  if(!compute_variance) dt_bauhaus_combobox_remove_at(g->mode, 4);
 
   gtk_box_pack_start(GTK_BOX(self->widget), g->box_nlm, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), g->box_wavelets, TRUE, TRUE, 0);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3778,7 +3778,9 @@ void gui_init(dt_iop_module_t *self)
   g->mode = dt_bauhaus_combobox_from_params(self, N_("mode"));
   const gboolean compute_variance =
     dt_conf_get_bool("plugins/darkroom/denoiseprofile/show_compute_variance_mode");
-  if(!compute_variance) dt_bauhaus_combobox_remove_at(g->mode, 4);
+  const int pos = dt_bauhaus_combobox_get_from_value(g->mode, MODE_VARIANCE);
+  if(!compute_variance && pos != -1)
+    dt_bauhaus_combobox_remove_at(g->mode, pos);
 
   gtk_box_pack_start(GTK_BOX(self->widget), g->box_nlm, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), g->box_wavelets, TRUE, TRUE, 0);

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -4352,7 +4352,9 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->preserve_color, _("ensure the original colors are preserved.\n"
                                                    "may reinforce chromatic aberrations and chroma noise,\n"
                                                    "so ensure they are properly corrected elsewhere."));
-  dt_bauhaus_combobox_remove_at(g->preserve_color, DT_FILMIC_METHOD_EUCLIDEAN_NORM_V1); // hide legacy Euclidean norm by default
+  // hide legacy Euclidean norm by default
+  const int pos = dt_bauhaus_combobox_get_from_value(g->preserve_color, DT_FILMIC_METHOD_EUCLIDEAN_NORM_V1);
+  dt_bauhaus_combobox_remove_at(g->preserve_color, pos);
 
   // Curve type
   g->highlights = dt_bauhaus_combobox_from_params(self, "highlights");

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -114,9 +114,8 @@ typedef enum dt_iop_filmicrgb_methods_type_t
   DT_FILMIC_METHOD_MAX_RGB = 1,           // $DESCRIPTION: "max RGB"
   DT_FILMIC_METHOD_LUMINANCE = 2,         // $DESCRIPTION: "luminance Y"
   DT_FILMIC_METHOD_POWER_NORM = 3,        // $DESCRIPTION: "RGB power norm"
-  DT_FILMIC_METHOD_EUCLIDEAN_NORM_V2 = 5, // $DESCRIPTION: "RGB euclidean norm"
   DT_FILMIC_METHOD_EUCLIDEAN_NORM_V1 = 4, // $DESCRIPTION: "RGB euclidean norm (legacy)"
-  DT_FILMIC_METHOD_LAST = 6, // this must always be greatest of the numbers above + 1
+  DT_FILMIC_METHOD_EUCLIDEAN_NORM_V2 = 5, // $DESCRIPTION: "RGB euclidean norm"
 } dt_iop_filmicrgb_methods_type_t;
 
 
@@ -2957,12 +2956,6 @@ void gui_update(dt_iop_module_t *self)
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->custom_grey), p->custom_grey);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->enable_highlight_reconstruction), p->enable_highlight_reconstruction);
 
-  if(p->preserve_color == DT_FILMIC_METHOD_EUCLIDEAN_NORM_V1 && dt_bauhaus_combobox_length(g->preserve_color) < DT_FILMIC_METHOD_LAST)
-  {
-    dt_bauhaus_combobox_add_full(g->preserve_color, _("RGB euclidean norm (legacy)"), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,
-                                 GINT_TO_POINTER(DT_FILMIC_METHOD_EUCLIDEAN_NORM_V1), NULL, TRUE);
-  }
-
   gui_changed(self, NULL, NULL);
 }
 
@@ -4359,7 +4352,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->preserve_color, _("ensure the original colors are preserved.\n"
                                                    "may reinforce chromatic aberrations and chroma noise,\n"
                                                    "so ensure they are properly corrected elsewhere."));
-  dt_bauhaus_combobox_remove_at(g->preserve_color, DT_FILMIC_METHOD_LAST - 1); // hide legacy Euclidean norm by default
+  dt_bauhaus_combobox_remove_at(g->preserve_color, DT_FILMIC_METHOD_EUCLIDEAN_NORM_V1); // hide legacy Euclidean norm by default
 
   // Curve type
   g->highlights = dt_bauhaus_combobox_from_params(self, "highlights");

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -2439,15 +2439,6 @@ void gui_update(struct dt_iop_module_t *self)
   dt_bauhaus_widget_set_quad_active(g->strength, FALSE);
   g->hlr_mask_mode = DT_HIGHLIGHTS_MASK_OFF;
 
-  const int menu_size = dt_bauhaus_combobox_length(g->mode);
-  const uint32_t filters = self->dev->image_storage.buf_dsc.filters;
-  const gboolean bayer = (filters != 0) && (filters != 9u);
-
-  const gboolean basic = ((filters == 9u && menu_size == 4) || (bayer && menu_size == 5));
-  dt_iop_highlights_params_t *p = (dt_iop_highlights_params_t *)self->params;
-  if(p->mode == DT_IOP_HIGHLIGHTS_INPAINT && basic)
-     dt_bauhaus_combobox_add_full(g->mode, _("reconstruct color"), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,
-                                      GINT_TO_POINTER(DT_IOP_HIGHLIGHTS_INPAINT), NULL, TRUE);
   gui_changed(self, NULL, NULL);
 }
 
@@ -2483,32 +2474,20 @@ void reload_defaults(dt_iop_module_t *self)
   {
     // rebuild the complete menu depending on sensor type and possibly active but obsolete mode
     const uint32_t filters = self->dev->image_storage.buf_dsc.filters;
-    const int menu_size = dt_bauhaus_combobox_length(g->mode);
-    for(int i = 0; i < menu_size; i++)
-      dt_bauhaus_combobox_remove_at(g->mode, 0);
+    dt_bauhaus_combobox_clear(g->mode);
 
-    dt_bauhaus_combobox_add_full(g->mode, _("inpaint opposed"), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,
-                                      GINT_TO_POINTER(DT_IOP_HIGHLIGHTS_OPPOSED), NULL, TRUE);
+    // add combo entries from introspection
+    dt_bauhaus_combobox_set_from_value(g->mode, DT_IOP_HIGHLIGHTS_OPPOSED);
 
     if(filters == 0)
-      dt_bauhaus_combobox_add_full(g->mode, _("clip highlights"), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,
-                                      GINT_TO_POINTER(DT_IOP_HIGHLIGHTS_CLIP), NULL, TRUE);
+      dt_bauhaus_combobox_set_from_value(g->mode, DT_IOP_HIGHLIGHTS_CLIP);
     else
     {
-      dt_bauhaus_combobox_add_full(g->mode, _("reconstruct in LCh"), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,
-                                      GINT_TO_POINTER(DT_IOP_HIGHLIGHTS_LCH), NULL, TRUE);
-      dt_bauhaus_combobox_add_full(g->mode, _("clip highlights"), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,
-                                      GINT_TO_POINTER(DT_IOP_HIGHLIGHTS_CLIP), NULL, TRUE);
-      dt_bauhaus_combobox_add_full(g->mode, _("segmentation based"), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,
-                                      GINT_TO_POINTER(DT_IOP_HIGHLIGHTS_SEGMENTS), NULL, TRUE);
-      if((filters != 0) && (filters != 9u))
-        dt_bauhaus_combobox_add_full(g->mode, _("guided laplacians"), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,
-                                      GINT_TO_POINTER(DT_IOP_HIGHLIGHTS_LAPLACIAN), NULL, TRUE);
-
-      dt_iop_highlights_params_t *p = (dt_iop_highlights_params_t *)self->params;
-      if(p->mode == DT_IOP_HIGHLIGHTS_INPAINT)
-        dt_bauhaus_combobox_add_full(g->mode, _("reconstruct color"), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,
-                                      GINT_TO_POINTER(DT_IOP_HIGHLIGHTS_INPAINT), NULL, TRUE);
+      dt_bauhaus_combobox_set_from_value(g->mode, DT_IOP_HIGHLIGHTS_LCH);
+      dt_bauhaus_combobox_set_from_value(g->mode, DT_IOP_HIGHLIGHTS_CLIP);
+      dt_bauhaus_combobox_set_from_value(g->mode, DT_IOP_HIGHLIGHTS_SEGMENTS);
+      if(filters != 9u)
+        dt_bauhaus_combobox_set_from_value(g->mode, DT_IOP_HIGHLIGHTS_LAPLACIAN);
     }
     dt_bauhaus_widget_set_quad_active(g->clip, FALSE);
     dt_bauhaus_widget_set_quad_active(g->candidating, FALSE);

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -59,12 +59,12 @@ static float highlights_clip_magics[6] = { 1.0f, 1.0f, 0.987f, 0.995f, 0.987f, 0
 
 typedef enum dt_iop_highlights_mode_t
 {
-  DT_IOP_HIGHLIGHTS_CLIP = 0,    // $DESCRIPTION: "clip highlights"
-  DT_IOP_HIGHLIGHTS_LCH = 1,     // $DESCRIPTION: "reconstruct in LCh"
-  DT_IOP_HIGHLIGHTS_INPAINT = 2, // $DESCRIPTION: "reconstruct color"
-  DT_IOP_HIGHLIGHTS_LAPLACIAN = 3, //$DESCRIPTION: "guided laplacians"
-  DT_IOP_HIGHLIGHTS_SEGMENTS = 4, // $DESCRIPTION: "segmentation based"
   DT_IOP_HIGHLIGHTS_OPPOSED = 5,  // $DESCRIPTION: "inpaint opposed"
+  DT_IOP_HIGHLIGHTS_LCH = 1,     // $DESCRIPTION: "reconstruct in LCh"
+  DT_IOP_HIGHLIGHTS_CLIP = 0,    // $DESCRIPTION: "clip highlights"
+  DT_IOP_HIGHLIGHTS_SEGMENTS = 4, // $DESCRIPTION: "segmentation based"
+  DT_IOP_HIGHLIGHTS_LAPLACIAN = 3, //$DESCRIPTION: "guided laplacians"
+  DT_IOP_HIGHLIGHTS_INPAINT = 2, // $DESCRIPTION: "reconstruct color"
 } dt_iop_highlights_mode_t;
 
 typedef enum dt_atrous_wavelets_scales_t
@@ -2476,18 +2476,20 @@ void reload_defaults(dt_iop_module_t *self)
     const uint32_t filters = self->dev->image_storage.buf_dsc.filters;
     dt_bauhaus_combobox_clear(g->mode);
 
-    // add combo entries from introspection
-    dt_bauhaus_combobox_set_from_value(g->mode, DT_IOP_HIGHLIGHTS_OPPOSED);
-
+    dt_introspection_type_enum_tuple_t *values = self->so->get_f("mode")->Enum.values;
     if(filters == 0)
-      dt_bauhaus_combobox_set_from_value(g->mode, DT_IOP_HIGHLIGHTS_CLIP);
+    {
+      dt_bauhaus_combobox_add_introspection(g->mode, NULL, values, DT_IOP_HIGHLIGHTS_OPPOSED,
+                                                                   DT_IOP_HIGHLIGHTS_OPPOSED);
+      dt_bauhaus_combobox_add_introspection(g->mode, NULL, values, DT_IOP_HIGHLIGHTS_CLIP,
+                                                                   DT_IOP_HIGHLIGHTS_CLIP);
+    }
     else
     {
-      dt_bauhaus_combobox_set_from_value(g->mode, DT_IOP_HIGHLIGHTS_LCH);
-      dt_bauhaus_combobox_set_from_value(g->mode, DT_IOP_HIGHLIGHTS_CLIP);
-      dt_bauhaus_combobox_set_from_value(g->mode, DT_IOP_HIGHLIGHTS_SEGMENTS);
-      if(filters != 9u)
-        dt_bauhaus_combobox_set_from_value(g->mode, DT_IOP_HIGHLIGHTS_LAPLACIAN);
+      dt_bauhaus_combobox_add_introspection(g->mode, NULL, values, DT_IOP_HIGHLIGHTS_OPPOSED,
+                                                                   filters == 9u
+                                                                   ? DT_IOP_HIGHLIGHTS_SEGMENTS
+                                                                   : DT_IOP_HIGHLIGHTS_LAPLACIAN);
     }
     dt_bauhaus_widget_set_quad_active(g->clip, FALSE);
     dt_bauhaus_widget_set_quad_active(g->candidating, FALSE);

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -75,33 +75,39 @@ typedef enum dt_iop_lens_modify_flag_t
 
 typedef enum dt_iop_lens_modflag_t
 {
-  DT_IOP_LENS_MODFLAG_NONE = 0,
-  DT_IOP_LENS_MODFLAG_ALL = DT_IOP_LENS_MODIFY_FLAG_DISTORTION | DT_IOP_LENS_MODIFY_FLAG_TCA | DT_IOP_LENS_MODIFY_FLAG_VIGNETTING,
-  DT_IOP_LENS_MODFLAG_DIST_TCA = DT_IOP_LENS_MODIFY_FLAG_DISTORTION | DT_IOP_LENS_MODIFY_FLAG_TCA,
-  DT_IOP_LENS_MODFLAG_DIST_VIGN = DT_IOP_LENS_MODIFY_FLAG_DISTORTION | DT_IOP_LENS_MODIFY_FLAG_VIGNETTING,
-  DT_IOP_LENS_MODFLAG_TCA_VIGN = DT_IOP_LENS_MODIFY_FLAG_TCA | DT_IOP_LENS_MODIFY_FLAG_VIGNETTING,
-  DT_IOP_LENS_MODFLAG_DIST = DT_IOP_LENS_MODIFY_FLAG_DISTORTION,
-  DT_IOP_LENS_MODFLAG_TCA = DT_IOP_LENS_MODIFY_FLAG_TCA,
-  DT_IOP_LENS_MODFLAG_VIGN = DT_IOP_LENS_MODIFY_FLAG_VIGNETTING,
+  DT_IOP_LENS_MODFLAG_NONE = 0, // $DESCRIPTION: "none"
+  DT_IOP_LENS_MODFLAG_ALL = DT_IOP_LENS_MODIFY_FLAG_DISTORTION | DT_IOP_LENS_MODIFY_FLAG_TCA | DT_IOP_LENS_MODIFY_FLAG_VIGNETTING, // $DESCRIPTION: "all"
+  DT_IOP_LENS_MODFLAG_DIST_TCA = DT_IOP_LENS_MODIFY_FLAG_DISTORTION | DT_IOP_LENS_MODIFY_FLAG_TCA, // $DESCRIPTION: "distortion & TCA"
+  DT_IOP_LENS_MODFLAG_DIST_VIGN = DT_IOP_LENS_MODIFY_FLAG_DISTORTION | DT_IOP_LENS_MODIFY_FLAG_VIGNETTING, // $DESCRIPTION: "distortion & vignetting"
+  DT_IOP_LENS_MODFLAG_TCA_VIGN = DT_IOP_LENS_MODIFY_FLAG_TCA | DT_IOP_LENS_MODIFY_FLAG_VIGNETTING, // $DESCRIPTION: "TCA & vignetting"
+  DT_IOP_LENS_MODFLAG_DIST = DT_IOP_LENS_MODIFY_FLAG_DISTORTION, // $DESCRIPTION: "only distortion"
+  DT_IOP_LENS_MODFLAG_TCA = DT_IOP_LENS_MODIFY_FLAG_TCA, // $DESCRIPTION: "only TCA"
+  DT_IOP_LENS_MODFLAG_VIGN = DT_IOP_LENS_MODIFY_FLAG_VIGNETTING, // $DESCRIPTION: "only vignetting"
 } dt_iop_lens_modflag_t;
 
 typedef enum dt_iop_lens_lenstype_t
 {
   DT_IOP_LENS_LENSTYPE_UNKNOWN = 0,
-  DT_IOP_LENS_LENSTYPE_RECTILINEAR = 1,
-  DT_IOP_LENS_LENSTYPE_FISHEYE = 2,
-  DT_IOP_LENS_LENSTYPE_PANORAMIC = 3,
-  DT_IOP_LENS_LENSTYPE_EQUIRECTANGULAR = 4,
-  DT_IOP_LENS_LENSTYPE_FISHEYE_ORTHOGRAPHIC = 5,
-  DT_IOP_LENS_LENSTYPE_FISHEYE_STEREOGRAPHIC = 6,
-  DT_IOP_LENS_LENSTYPE_FISHEYE_EQUISOLID = 7,
-  DT_IOP_LENS_LENSTYPE_FISHEYE_THOBY = 8
+  DT_IOP_LENS_LENSTYPE_RECTILINEAR = 1,           // $DESCRIPTION: "rectilinear"
+  DT_IOP_LENS_LENSTYPE_FISHEYE = 2,               // $DESCRIPTION: "fish-eye"
+  DT_IOP_LENS_LENSTYPE_PANORAMIC = 3,             // $DESCRIPTION: "panoramic"
+  DT_IOP_LENS_LENSTYPE_EQUIRECTANGULAR = 4,       // $DESCRIPTION: "equirectangular"
+  DT_IOP_LENS_LENSTYPE_FISHEYE_ORTHOGRAPHIC = 5,  // $DESCRIPTION: "orthographic"
+  DT_IOP_LENS_LENSTYPE_FISHEYE_STEREOGRAPHIC = 6, // $DESCRIPTION: "stereographic"
+  DT_IOP_LENS_LENSTYPE_FISHEYE_EQUISOLID = 7,     // $DESCRIPTION: "equisolid angle"
+  DT_IOP_LENS_LENSTYPE_FISHEYE_THOBY = 8,         // $DESCRIPTION: "thoby fish-eye"
 } dt_iop_lens_lenstype_t;
+
+typedef enum dt_iop_lens_mode_t
+{
+  DT_IOP_LENS_MODE_CORRECT = 0, // $DESCRIPTION: "correct"
+  DT_IOP_LENS_MODE_DISTORT = 1, // $DESCRIPTION: "distort"
+} dt_iop_lens_mode_t;
 
 typedef struct dt_iop_lens_params_t
 {
   dt_iop_lens_method_t method; // $DEFAULT: DT_IOP_LENS_METHOD_LENSFUN $DESCRIPTION: "correction method"
-  int modify_flags; // $DEFAULT: DT_IOP_LENS_MODFLAG_ALL $DESCRIPTION: "corrections"
+  dt_iop_lens_modflag_t modify_flags; // $DEFAULT: DT_IOP_LENS_MODFLAG_ALL $DESCRIPTION: "corrections"
 
   // NOTE: the options for lensfun and metadata correction methods should be
   // kept separate since also if similar their value have different effects.
@@ -109,13 +115,13 @@ typedef struct dt_iop_lens_params_t
   // the unique parameter in common is modify_flags
 
   // lensfun method parameters
-  int inverse; // $MIN: 0 $MAX: 1 $DEFAULT: 0 $DESCRIPTION: "mode"
+  dt_iop_lens_mode_t inverse; // $DEFAULT: DT_IOP_LENS_MODE_CORRECT $DESCRIPTION: "mode"
   float scale; // $MIN: 0.1 $MAX: 2.0 $DEFAULT: 1.0
   float crop;
   float focal;
   float aperture;
   float distance;
-  int target_geom; // $DEFAULT: DT_IOP_LENS_LENSTYPE_RECTILINEAR $DESCRIPTION: "geometry"
+  dt_iop_lens_lenstype_t target_geom; // $DEFAULT: DT_IOP_LENS_LENSTYPE_RECTILINEAR $DESCRIPTION: "target geometry"
   char camera[128];
   char lens[128];
   gboolean tca_override; // $DEFAULT: FALSE $DESCRIPTION: "TCA overwrite"
@@ -150,7 +156,6 @@ typedef struct dt_iop_lens_gui_data_t
   GtkWidget *find_lens_button;
   GtkWidget *find_camera_button;
   GtkWidget *cor_dist_ft, *cor_vig_ft, *cor_scale;
-  GList *modifiers;
   GtkLabel *message;
   int corrections_done;
   gboolean lensfun_trouble;
@@ -277,7 +282,7 @@ static int _modflags_to_lensfun_mods(int modify_flags)
   return mods;
 }
 
-static int _modflags_from_lensfun_mods(int lf_mods)
+static dt_iop_lens_modflag_t _modflags_from_lensfun_mods(int lf_mods)
 {
   int mods = 0;
 
@@ -285,10 +290,10 @@ static int _modflags_from_lensfun_mods(int lf_mods)
   mods |= lf_mods & LF_MODIFY_VIGNETTING ? DT_IOP_LENS_MODIFY_FLAG_VIGNETTING : 0;
   mods |= lf_mods & LF_MODIFY_TCA        ? DT_IOP_LENS_MODIFY_FLAG_TCA        : 0;
 
-  return mods;
+  return (dt_iop_lens_modflag_t)mods;
 }
 
-static int _lenstype_from_lensfun_lenstype(lfLensType lt)
+static dt_iop_lens_lenstype_t _lenstype_from_lensfun_lenstype(lfLensType lt)
 {
   switch(lt)
   {
@@ -347,7 +352,7 @@ int legacy_params(
     *n = *d; // start with a fresh copy of default parameters
 
     n->modify_flags = _modflags_from_lensfun_mods(o->modify_flags);
-    n->inverse = o->inverse;
+    n->inverse = (dt_iop_lens_mode_t)o->inverse;
     n->scale = o->scale;
     n->crop = o->crop;
     n->focal = o->focal;
@@ -398,7 +403,7 @@ int legacy_params(
     *n = *d; // start with a fresh copy of default parameters
 
     n->modify_flags = _modflags_from_lensfun_mods(o->modify_flags);
-    n->inverse = o->inverse;
+    n->inverse = (dt_iop_lens_mode_t)o->inverse;
     n->scale = o->scale;
     n->crop = o->crop;
     n->focal = o->focal;
@@ -448,7 +453,7 @@ int legacy_params(
     *n = *d; // start with a fresh copy of default parameters
 
     n->modify_flags = _modflags_from_lensfun_mods(o->modify_flags);
-    n->inverse = o->inverse;
+    n->inverse = (dt_iop_lens_mode_t)o->inverse;
     n->scale = o->scale;
     n->crop = o->crop;
     n->focal = o->focal;
@@ -499,7 +504,7 @@ int legacy_params(
 
     // The unique method in previous versions was lensfun
     n->modify_flags = _modflags_from_lensfun_mods(o->modify_flags);
-    n->inverse = o->inverse;
+    n->inverse = (dt_iop_lens_mode_t)o->inverse;
     n->scale = o->scale;
     n->crop = o->crop;
     n->focal = o->focal;
@@ -555,14 +560,14 @@ int legacy_params(
 
     // The unique method in previous versions was lensfun
     n->method = o->method;
-    n->modify_flags = o->modify_flags;
-    n->inverse = o->inverse;
+    n->modify_flags = (dt_iop_lens_modflag_t)o->modify_flags;
+    n->inverse = (dt_iop_lens_mode_t)o->inverse;
     n->scale = o->scale;
     n->crop = o->crop;
     n->focal = o->focal;
     n->aperture = o->aperture;
     n->distance = o->distance;
-    n->target_geom = o->target_geom;
+    n->target_geom = (dt_iop_lens_lenstype_t)o->target_geom;
     g_strlcpy(n->camera, o->camera, sizeof(n->camera));
     g_strlcpy(n->lens, o->lens, sizeof(n->lens));
     n->tca_override = o->tca_override;
@@ -2545,7 +2550,7 @@ void reload_defaults(dt_iop_module_t *module)
   d->target_geom = DT_IOP_LENS_LENSTYPE_RECTILINEAR;
 
   if(dt_image_is_monochrome(img))
-    d->modify_flags &= ~DT_IOP_LENS_MODIFY_FLAG_TCA;
+    d->modify_flags = DT_IOP_LENS_MODFLAG_DIST_VIGN;
 
   // init crop from lensfun db:
   char model[100]; // truncate often complex descriptions.
@@ -3313,15 +3318,6 @@ static void _autoscale_pressed_lf(GtkWidget *button, gpointer user_data)
   dt_bauhaus_slider_set(g->scale, scale);
 }
 
-static void _target_geometry_changed(GtkWidget *widget, gpointer user_data)
-{
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_lens_params_t *p = (dt_iop_lens_params_t *)self->params;
-
-  const int pos = dt_bauhaus_combobox_get(widget);
-  p->target_geom = (pos + DT_IOP_LENS_LENSTYPE_UNKNOWN + 1);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
 /* -- lensfun gui end -- */
 
 static void _display_errors(struct dt_iop_module_t *self)
@@ -3346,27 +3342,6 @@ static void _display_errors(struct dt_iop_module_t *self)
   }
 
   gtk_widget_queue_draw(self->widget);
-}
-
-static void _modflags_changed(GtkWidget *widget, gpointer user_data)
-{
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  if(darktable.gui->reset) return;
-
-  dt_iop_lens_params_t *p = (dt_iop_lens_params_t *)self->params;
-  dt_iop_lens_gui_data_t *g = (dt_iop_lens_gui_data_t *)self->gui_data;
-
-  const int pos = dt_bauhaus_combobox_get(widget);
-  for(GList *modifiers = g->modifiers;  modifiers; modifiers = g_list_next(modifiers))
-  {
-    dt_iop_lens_gui_modifier_t *mm = (dt_iop_lens_gui_modifier_t *)modifiers->data;
-    if(mm->pos == pos)
-    {
-      p->modify_flags = mm->modflag;
-      dt_dev_add_history_item(darktable.develop, self, TRUE);
-      break;
-    }
-  }
 }
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
@@ -3433,25 +3408,14 @@ static void _have_corrections_done(gpointer instance, gpointer user_data)
   const int corrections_done = g->corrections_done;
   dt_iop_gui_leave_critical_section(self);
 
-  const char empty_message[] = "";
-  char *message = (char *)empty_message;
+  dt_introspection_type_enum_tuple_t *modifiers = self->get_f("modify_flags")->Enum.values;
+  while(modifiers->name && modifiers->value != corrections_done)
+    modifiers++;
 
-  for(GList *modifiers = g->modifiers;
-      modifiers && self->enabled;
-      modifiers = g_list_next(modifiers))
-  {
-    dt_iop_lens_gui_modifier_t *mm = (dt_iop_lens_gui_modifier_t *)modifiers->data;
-    if(mm->modflag == corrections_done)
-    {
-      message = mm->name;
-      break;
-    }
-  }
+  const char *message = modifiers->name ? modifiers->description : "";
 
-  ++darktable.gui->reset;
-  gtk_label_set_text(g->message, message);
-  gtk_widget_set_tooltip_text(GTK_WIDGET(g->message), message);
-  --darktable.gui->reset;
+  gtk_label_set_text(g->message, Q_(message));
+  gtk_widget_set_tooltip_text(GTK_WIDGET(g->message), Q_(message));
 }
 
 static void _develop_ui_pipe_finished_callback(gpointer instance, gpointer user_data)
@@ -3467,67 +3431,11 @@ void gui_init(struct dt_iop_module_t *self)
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,
                             G_CALLBACK(_develop_ui_pipe_finished_callback), self);
 
-  g->modifiers = NULL;
-  g->camera = NULL;
-  g->camera_menu = NULL;
-  g->lens_menu = NULL;
-
   dt_iop_gui_enter_critical_section(self); // not actually needed,
                                            // we're the only one with
                                            // a ref to this instance
   g->corrections_done = -1;
   dt_iop_gui_leave_critical_section(self);
-
-  // initialize modflags options
-  int pos = -1;
-  dt_iop_lens_gui_modifier_t *modifier;
-  modifier = (dt_iop_lens_gui_modifier_t *)g_malloc0(sizeof(dt_iop_lens_gui_modifier_t));
-  dt_utf8_strlcpy(modifier->name, _("none"), sizeof(modifier->name));
-  g->modifiers = g_list_append(g->modifiers, modifier);
-  modifier->modflag = DT_IOP_LENS_MODFLAG_NONE;
-  modifier->pos = ++pos;
-
-  modifier = (dt_iop_lens_gui_modifier_t *)g_malloc0(sizeof(dt_iop_lens_gui_modifier_t));
-  dt_utf8_strlcpy(modifier->name, _("all"), sizeof(modifier->name));
-  g->modifiers = g_list_append(g->modifiers, modifier);
-  modifier->modflag = DT_IOP_LENS_MODFLAG_ALL;
-  modifier->pos = ++pos;
-
-  modifier = (dt_iop_lens_gui_modifier_t *)g_malloc0(sizeof(dt_iop_lens_gui_modifier_t));
-  dt_utf8_strlcpy(modifier->name, _("distortion & TCA"), sizeof(modifier->name));
-  g->modifiers = g_list_append(g->modifiers, modifier);
-  modifier->modflag = DT_IOP_LENS_MODFLAG_DIST_TCA;
-  modifier->pos = ++pos;
-
-  modifier = (dt_iop_lens_gui_modifier_t *)g_malloc0(sizeof(dt_iop_lens_gui_modifier_t));
-  dt_utf8_strlcpy(modifier->name, _("distortion & vignetting"), sizeof(modifier->name));
-  g->modifiers = g_list_append(g->modifiers, modifier);
-  modifier->modflag = DT_IOP_LENS_MODFLAG_DIST_VIGN;
-  modifier->pos = ++pos;
-
-  modifier = (dt_iop_lens_gui_modifier_t *)g_malloc0(sizeof(dt_iop_lens_gui_modifier_t));
-  dt_utf8_strlcpy(modifier->name, _("TCA & vignetting"), sizeof(modifier->name));
-  g->modifiers = g_list_append(g->modifiers, modifier);
-  modifier->modflag = DT_IOP_LENS_MODFLAG_TCA_VIGN;
-  modifier->pos = ++pos;
-
-  modifier = (dt_iop_lens_gui_modifier_t *)g_malloc0(sizeof(dt_iop_lens_gui_modifier_t));
-  dt_utf8_strlcpy(modifier->name, _("only distortion"), sizeof(modifier->name));
-  g->modifiers = g_list_append(g->modifiers, modifier);
-  modifier->modflag = DT_IOP_LENS_MODFLAG_DIST;
-  modifier->pos = ++pos;
-
-  modifier = (dt_iop_lens_gui_modifier_t *)g_malloc0(sizeof(dt_iop_lens_gui_modifier_t));
-  dt_utf8_strlcpy(modifier->name, _("only TCA"), sizeof(modifier->name));
-  g->modifiers = g_list_append(g->modifiers, modifier);
-  modifier->modflag = DT_IOP_LENS_MODFLAG_TCA;
-  modifier->pos = ++pos;
-
-  modifier = (dt_iop_lens_gui_modifier_t *)g_malloc0(sizeof(dt_iop_lens_gui_modifier_t));
-  dt_utf8_strlcpy(modifier->name, _("only vignetting"), sizeof(modifier->name));
-  g->modifiers = g_list_append(g->modifiers, modifier);
-  modifier->modflag = DT_IOP_LENS_MODFLAG_VIGN;
-  modifier->pos = ++pos;
 
   /* lensfun widget */
   // _from_params methods assign widgets to self->widget, so
@@ -3587,23 +3495,8 @@ void gui_init(struct dt_iop_module_t *self)
 #endif
 
   // target geometry
-  g->target_geom = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->target_geom, NULL, N_("geometry"));
-  gtk_box_pack_start(GTK_BOX(box_lf), g->target_geom, TRUE, TRUE, 0);
+  g->target_geom = dt_bauhaus_combobox_from_params(self, "target_geom");
   gtk_widget_set_tooltip_text(g->target_geom, _("target geometry"));
-  dt_bauhaus_combobox_add(g->target_geom, _("rectilinear"));
-  dt_bauhaus_combobox_add(g->target_geom, _("fish-eye"));
-  dt_bauhaus_combobox_add(g->target_geom, _("panoramic"));
-  dt_bauhaus_combobox_add(g->target_geom, _("equirectangular"));
-#if LF_VERSION >= ((0 << 24) | (2 << 16) | (6 << 8) | 0)
-  dt_bauhaus_combobox_add(g->target_geom, _("orthographic"));
-  dt_bauhaus_combobox_add(g->target_geom, _("stereographic"));
-  dt_bauhaus_combobox_add(g->target_geom, _("equisolid angle"));
-  dt_bauhaus_combobox_add(g->target_geom, _("thoby fish-eye"));
-#endif
-  g_signal_connect(G_OBJECT(g->target_geom), "value-changed",
-                   G_CALLBACK(_target_geometry_changed),
-                   (gpointer)self);
 
   // scale
   g->scale = dt_bauhaus_slider_from_params(self, N_("scale"));
@@ -3615,8 +3508,6 @@ void gui_init(struct dt_iop_module_t *self)
 
   // reverse direction
   g->reverse = dt_bauhaus_combobox_from_params(self, "inverse");
-  dt_bauhaus_combobox_add(g->reverse, _("correct"));
-  dt_bauhaus_combobox_add(g->reverse, _("distort"));
   gtk_widget_set_tooltip_text(g->reverse, _("correct distortions or apply them"));
 
   g->tca_override = dt_bauhaus_toggle_from_params(self, "tca_override");
@@ -3659,21 +3550,8 @@ void gui_init(struct dt_iop_module_t *self)
 
   // selector for correction type (modflags): one or more out of
   // distortion, TCA, vignetting
-  g->modflags = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->modflags, NULL, N_("corrections"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->modflags, TRUE, TRUE, 0);
+  g->modflags = dt_bauhaus_combobox_from_params(self, "modify_flags");
   gtk_widget_set_tooltip_text(g->modflags, _("which corrections to apply"));
-
-  GList *l = g->modifiers;
-  while(l)
-  {
-    modifier = (dt_iop_lens_gui_modifier_t *)l->data;
-    dt_bauhaus_combobox_add(g->modflags, modifier->name);
-    l = g_list_next(l);
-  }
-  dt_bauhaus_combobox_set(g->modflags, 0);
-  g_signal_connect(G_OBJECT(g->modflags), "value-changed",
-                   G_CALLBACK(_modflags_changed), (gpointer)self);
 
   g->methods = gtk_stack_new();
   gtk_stack_set_homogeneous(GTK_STACK(g->methods), FALSE);
@@ -3713,17 +3591,6 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_lens_gui_data_t *g = (dt_iop_lens_gui_data_t *)self->gui_data;
   dt_iop_lens_params_t *p = (dt_iop_lens_params_t *)self->params;
 
-  const int modflag = p->modify_flags;
-  for(GList *modifiers = g->modifiers; modifiers; modifiers = g_list_next(modifiers))
-  {
-    dt_iop_lens_gui_modifier_t *mm = (dt_iop_lens_gui_modifier_t *)modifiers->data;
-    if(mm->modflag == modflag)
-    {
-      dt_bauhaus_combobox_set(g->modflags, mm->pos);
-      break;
-    }
-  }
-
   dt_iop_lens_global_data_t *gd = (dt_iop_lens_global_data_t *)self->global_data;
   lfDatabase *dt_iop_lensfun_db = (lfDatabase *)gd->db;
 
@@ -3734,8 +3601,6 @@ void gui_update(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->camera_model, "");
   gtk_widget_set_tooltip_text(g->lens_model, "");
 
-  dt_bauhaus_combobox_set(g->target_geom, p->target_geom - LF_UNKNOWN - 1);
-  dt_bauhaus_combobox_set(g->reverse, p->inverse);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->tca_override), p->tca_override);
 
   const lfCamera **cam = NULL;
@@ -3772,24 +3637,15 @@ void gui_update(struct dt_iop_module_t *self)
     dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
   }
 
-
   gui_changed(self, NULL, NULL);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  dt_iop_lens_gui_data_t *g = (dt_iop_lens_gui_data_t *)self->gui_data;
-
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
                                      G_CALLBACK(_have_corrections_done), self);
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
                                      G_CALLBACK(_develop_ui_pipe_finished_callback), self);
-
-  while(g->modifiers)
-  {
-    g_free(g->modifiers->data);
-    g->modifiers = g_list_delete_link(g->modifiers, g->modifiers);
-  }
 
   IOP_GUI_FREE;
 }

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2642,13 +2642,11 @@ void reload_defaults(dt_iop_module_t *module)
   if(g)
   {
     dt_bauhaus_combobox_clear(g->methods_selector);
-
-    if(_have_embedded_metadata(module))
-      dt_bauhaus_combobox_set_from_value(g->methods_selector,
-                                         DT_IOP_LENS_METHOD_EMBEDDED_METADATA);
-
-    dt_bauhaus_combobox_set_from_value(g->methods_selector,
-                                       DT_IOP_LENS_METHOD_LENSFUN);
+    dt_bauhaus_combobox_add_introspection(g->methods_selector, NULL,
+                                          module->so->get_f("method")->Enum.values,
+                                          _have_embedded_metadata(module)
+                                          ? DT_IOP_LENS_METHOD_EMBEDDED_METADATA
+                                          : DT_IOP_LENS_METHOD_LENSFUN, -1);
 
     // if we have a gui -> reset corrections_done message
     dt_iop_gui_enter_critical_section(module);

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2636,20 +2636,14 @@ void reload_defaults(dt_iop_module_t *module)
   dt_iop_lens_gui_data_t *g = (dt_iop_lens_gui_data_t *)module->gui_data;
   if(g)
   {
-    // rebuild methods selector combbox with only available methods
-    const int menu_size = dt_bauhaus_combobox_length(g->methods_selector);
-    for(int i = 0; i < menu_size; i++)
-      dt_bauhaus_combobox_remove_at(g->methods_selector, 0);
+    dt_bauhaus_combobox_clear(g->methods_selector);
 
     if(_have_embedded_metadata(module))
-      dt_bauhaus_combobox_add_full(g->methods_selector,
-                                   _("embedded metadata"), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,
-                                   GINT_TO_POINTER(DT_IOP_LENS_METHOD_EMBEDDED_METADATA),
-                                   NULL, TRUE);
+      dt_bauhaus_combobox_set_from_value(g->methods_selector,
+                                         DT_IOP_LENS_METHOD_EMBEDDED_METADATA);
 
-    dt_bauhaus_combobox_add_full(g->methods_selector,
-                                 _("lensfun"), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,
-                                 GINT_TO_POINTER(DT_IOP_LENS_METHOD_LENSFUN), NULL, TRUE);
+    dt_bauhaus_combobox_set_from_value(g->methods_selector,
+                                       DT_IOP_LENS_METHOD_LENSFUN);
 
     // if we have a gui -> reset corrections_done message
     dt_iop_gui_enter_critical_section(module);

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -3424,7 +3424,6 @@ void gui_init(struct dt_iop_module_t *self)
   self->widget = dt_ui_notebook_page(g->notebook, N_("masking"), NULL);
 
   g->method = dt_bauhaus_combobox_from_params(self, "method");
-  dt_bauhaus_combobox_remove_at(g->method, DT_TONEEQ_LAST);
   gtk_widget_set_tooltip_text
     (g->method,
      _("preview the mask and chose the estimator that gives you the\n"


### PR DESCRIPTION
Fixes #13971 but be CAREFUL (see below).

This also tries to remove _one_ reason why a "_LAST" enum sometimes is needed, namely to check if a legacy value that by default is made unavailable needs to be added back when loading an image that uses it. This new approach checks in `dt_bauhaus_combobox_set_from_value` if a non-existing value is being set, in which case it tries to add it back from introspection.

Then also using this to "rebuild" some combos that are tailored in their `reload_defaults`.

This stuff is very tricky to test without "legacy images" and images that tick all the "special case" boxes. So I have basically done _NO_ testing on that; please fill that void (for all the modules touched in this PR).

I would like some actual code review on this as well, not just for "correctness" but also if this actually helps make the "API" more logical or what could be better alternatives. It sort of makes sense to me that some not always available options would be listed at the end (which also makes removing and adding them easy) but in for example the lens correction module this is intentionally not the case, requiring a full rebuild of the list of options.

Maybe an additional `dt_bauhaus_combobox_remove_value` (rather than `dt_bauhaus_combobox_remove_at`) and having `dt_bauhaus_combobox_set_from_value` try to insert at the same location could be worth it, but at the moment there are only very limited use cases so no real justification to add too much complexity (that wouldn't receive sufficient testing).

@flannelhead 

One argument _against_ using _LAST enums, btw, might be seen with `DT_ADAPTATION_LAST`. It appears in _many_ switch statements (to satisfy careful compilers) but is never actually used for example to size an array (as far as I can tell).