### PR TITLE
[actions] Fix inability of stale bot to process all issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -31,4 +31,4 @@ jobs:
         exempt-all-milestones: true
         exempt-pr-labels: 'bugfix,wip'
         exempt-issue-labels: 'scope: camera support,bugfix: wip'
-        operations-per-run: 500
+        operations-per-run: 800

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,6 +27,7 @@ jobs:
         stale-pr-label: 'no-pr-activity'
         days-before-stale: 60
         days-before-close: 365
+        ascending: true
         remove-stale-when-updated: true
         exempt-all-milestones: true
         exempt-pr-labels: 'bugfix,wip'


### PR DESCRIPTION
Looking at the oldest issues, you can see that some of them should definitely have been closed by the bot. On such issues, the last action was a year or more ago and there are no exemptions from processing (labels, in the presence of which we do not close the issue). But stale bot does not close them.

The reason is that the bot does not manage to process them. In the configuration of the bot, `operations-per-run: 500` was indicated, and we have had more than 7 hundred open issues in recent years. So, we need to raise the limit (to 800, for example).

Also, to avoid similar situations when the bot gradually loses the ability to work with the oldest issues, it is better to start processing issues from the oldest (`ascending: true`).

