### PR TITLE
eaw,c: optimize, remove SSE code

### DIFF
--- a/src/common/eaw.c
+++ b/src/common/eaw.c
@@ -22,9 +22,6 @@
 #include "control/control.h"     // needed by dwt.h
 #include "common/dwt.h"          // for dwt_interleave_rows
 #include <math.h>
-#if defined(__SSE__)
-#include <xmmintrin.h>
-#endif
 
 static inline void weight(const dt_aligned_pixel_t c1,
                               const dt_aligned_pixel_t c2,
@@ -51,30 +48,6 @@ static inline void weight(const dt_aligned_pixel_t c1,
   dt_vector_exp(sharpened, weight);				// { wl, wc, wc, 1 }
 }
 
-#if defined(__SSE2__)
-/* Computes the vector
- * (wl, wc, wc, 1)
- *
- * where:
- * wl = exp(-sharpen*SQR(c1[0] - c2[0]))
- *    = exp(-s*d1) (as noted in code comments below)
- * wc = exp(-sharpen*(SQR(c1[1] - c2[1]) + SQR(c1[2] - c2[2]))
- *    = exp(-s*(d2+d3)) (as noted in code comments below)
- */
-static const __m128 o111 DT_ALIGNED_ARRAY = { ~0, ~0, ~0, 0 };
-static inline __m128 weight_sse2(const __m128 *c1, const __m128 *c2, const float sharpen)
-{
-  const __m128 diff = *c1 - *c2;
-  const __m128 square = diff * diff;                                // (?, d3, d2, d1)
-  const __m128 square2 = _mm_shuffle_ps(square, square, _MM_SHUFFLE(3, 1, 2, 0)); // (?, d2, d3, d1)
-  __m128 added = square + square2;                                  // (?, d2+d3, d2+d3, 2*d1)
-  added = _mm_sub_ss(added, square);                                // (?, d2+d3, d2+d3, d1)
-  __m128 sharpened = added * _mm_set1_ps(-sharpen);                 // (?, -s*(d2+d3), -s*(d2+d3), -s*d1)
-  sharpened = _mm_and_ps(sharpened,o111);			    // (0, -s*(d2+d3), -s*(d2+d3), -s*d1)
-  return dt_fast_expf_sse2(sharpened);                              // (1, wc, wc, wl)
-}
-#endif
-
 #define SUM_PIXEL_CONTRIBUTION(ii, jj) 		                                                             \
   do                                                                                                         \
   {                                                                                                          \
@@ -92,28 +65,9 @@ static inline __m128 weight_sse2(const __m128 *c1, const __m128 *c2, const float
     }                                                                                                        \
   } while(0)
 
-#if defined(__SSE__)
-#define SUM_PIXEL_CONTRIBUTION_SSE(ii, jj)	                                                             \
-  do                                                                                                         \
-  {                                                                                                          \
-    const float f = filter[(ii)] * filter[(jj)];	                                                     \
-    const __m128 wp = weight_sse2(px, px2, sharpen);                                                         \
-    const __m128 w = f * wp;                                                                                 \
-    const __m128 pd = *px2 * w;                                                                              \
-    sum = sum + pd;                                                                                          \
-    wgt = wgt + w;                                                                                           \
-  } while(0)
-#endif
-
 #define SUM_PIXEL_PROLOGUE                                                                                   \
   dt_aligned_pixel_t sum = { 0.0f, 0.0f, 0.0f, 0.0f };                                                       \
   dt_aligned_pixel_t wgt = { 0.0f, 0.0f, 0.0f, 0.0f };
-
-#if defined(__SSE2__)
-#define SUM_PIXEL_PROLOGUE_SSE                                                                               \
-  __m128 sum = _mm_setzero_ps();                                                                             \
-  __m128 wgt = _mm_setzero_ps();
-#endif
 
 #define SUM_PIXEL_EPILOGUE                                                                                   \
   dt_aligned_pixel_t det;                                               				     \
@@ -128,28 +82,9 @@ static inline __m128 weight_sse2(const __m128 *c1, const __m128 *c2, const float
   pdetail += 4;                                                                                              \
   pcoarse += 4;
 
-#if defined(__SSE2__)
-#define SUM_PIXEL_EPILOGUE_SSE                                                                               \
-  sum = sum / wgt;                                                                                           \
-                                                                                                             \
-  _mm_stream_ps(pdetail, *px - sum);                                                                         \
-  _mm_stream_ps(pcoarse, sum);                                                                               \
-  px++;                                                                                                      \
-  pdetail += 4;                                                                                              \
-  pcoarse += 4;
-#endif
-
 void eaw_decompose(float *const restrict out, const float *const restrict in, float *const restrict detail,
                    const int scale, const float sharpen, const int32_t width, const int32_t height)
 {
-#if defined(__SSE2__)
-  if(darktable.codepath.SSE2)
-  {
-    eaw_decompose_sse2(out, in, detail, scale, sharpen, width, height);
-    return;
-  }
-#endif
-
   const int mult = 1 << scale;
   static const float filter[5] = { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
   const int boundary = 2 * mult;
@@ -231,92 +166,6 @@ void eaw_decompose(float *const restrict out, const float *const restrict in, fl
   }
 }
 
-#if defined(__SSE2__)
-void eaw_decompose_sse2(float *const restrict out, const float *const restrict in, float *const restrict detail,
-                        const int scale, const float sharpen, const int32_t width, const int32_t height)
-{
-  const int mult = 1 << scale;
-  static const float filter[5] = { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
-  const int boundary = 2 * mult;
-
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(detail, filter, height, in, sharpen, mult, boundary, out, width) \
-  schedule(static)
-#endif
-  for(int rowid = 0; rowid < height; rowid++)
-  {
-    const size_t j = dwt_interleave_rows(rowid, height, mult);
-    const __m128 *px = ((__m128 *)in) + (size_t)j * width;
-    const __m128 *px2;
-    float *pdetail = detail + (size_t)4 * j * width;
-    float *pcoarse = out + (size_t)4 * j * width;
-
-    // for the first and last 'boundary' rows, we have to use the macros with tests for the entire row;
-    //   for the central bulk, we only need to use those slower versions on the leftmost and rightmost pixels
-    const int lbound = (j < boundary || j >= height - boundary) ? width-boundary : boundary;
-
-    /* The first "2*mult" pixels need a boundary check because we might try to access past the left edge,
-     * which requires nearest pixel interpolation */
-    int i;
-    for(i = 0; i < lbound; i++)
-    {
-      SUM_PIXEL_PROLOGUE_SSE;
-      for(int jj = 0; jj < 5; jj++)
-      {
-        const int y = j + mult * (jj-2);
-        const int clamp_y = CLAMP(y,0,height-1);
-        for(int ii = 0; ii < 5; ii++)
-        {
-          int x = i + mult * ((ii)-2);
-          if(x < 0) x = 0;			// we might be looking beyond the left edge
-          px2 = ((__m128 *)in) + x + (size_t)clamp_y * width;
-          SUM_PIXEL_CONTRIBUTION_SSE(ii, jj);
-        }
-      }
-      SUM_PIXEL_EPILOGUE_SSE;
-    }
-
-    /* For pixels [2*mult, width-2*mult], we don't need to do any boundary checks */
-    for( ; i < width - boundary; i++)
-    {
-      SUM_PIXEL_PROLOGUE_SSE;
-      px2 = ((__m128 *)in) + i - 2 * mult + (size_t)(j - 2 * mult) * width;
-      for(int jj = 0; jj < 5; jj++)
-      {
-        for(int ii = 0; ii < 5; ii++)
-        {
-          SUM_PIXEL_CONTRIBUTION_SSE(ii, jj);
-          px2 += mult;
-        }
-        px2 += (width - 5) * mult;
-      }
-      SUM_PIXEL_EPILOGUE_SSE;
-    }
-
-    /* Last 2*mult pixels in the row require the boundary check again */
-    for( ; i < width; i++)
-    {
-      SUM_PIXEL_PROLOGUE_SSE;
-      for(int jj = 0; jj < 5; jj++)
-      {
-        const int y = j + mult * (jj-2);
-        const int clamp_y = CLAMP(y,0,height-1);
-        for(int ii = 0; ii < 5; ii++)
-        {
-          int x = i + mult * ((ii)-2);
-          if(x >= width) x = width-1;		// we might be looking beyond the right edge
-          px2 = ((__m128 *)in) + x + (size_t)clamp_y * width;
-          SUM_PIXEL_CONTRIBUTION_SSE(ii, jj);
-        }
-      }
-      SUM_PIXEL_EPILOGUE_SSE;
-    }
-  }
-  _mm_sfence();
-}
-#endif
-
 void eaw_synthesize(float *const out, const float *const in, const float *const restrict detail,
                     const float *const restrict threshold, const float *const restrict boost,
                     const int32_t width, const int32_t height)
@@ -368,12 +217,7 @@ static inline float dn_weight(const float *c1, const float *c2, const float inv_
 }
 
 typedef struct _aligned_pixel {
-  union {
-    dt_aligned_pixel_t v;
-#ifdef __SSE2__
-    __m128 sse;
-#endif
-  };
+  dt_aligned_pixel_t v;
 } _aligned_pixel;
 #ifdef _OPENMP
 static inline _aligned_pixel add_float4(_aligned_pixel acc, _aligned_pixel newval)
@@ -509,11 +353,6 @@ void eaw_dn_decompose(float *const restrict out, const float *const restrict in,
 #undef SUM_PIXEL_CONTRIBUTION
 #undef SUM_PIXEL_PROLOGUE
 #undef SUM_PIXEL_EPILOGUE
-
-
-#undef SUM_PIXEL_CONTRIBUTION_SSE
-#undef SUM_PIXEL_PROLOGUE_SSE
-#undef SUM_PIXEL_EPILOGUE_SSE
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/eaw.h
+++ b/src/common/eaw.h
@@ -35,9 +35,6 @@ void eaw_synthesize(float *const restrict out, const float *const restrict in, c
                     const float *const restrict thrsf, const float *const restrict boostf,
                     const int32_t width, const int32_t height);
 
-void eaw_decompose_sse2(float *const restrict out, const float *const restrict in, float *const restrict detail,
-                        const int scale, const float sharpen, const int32_t width, const int32_t height);
-
 typedef void((*eaw_dn_decompose_t)(float *const restrict out, const float *const restrict in, float *const restrict detail,
                                    dt_aligned_pixel_t sum_squared, const int scale, const float inv_sigma2,
                                    const int32_t width, const int32_t height));

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -352,29 +352,6 @@ static inline void dt_fast_expf_4wide(const float x[4], float result[4])
   }
 }
 
-#if defined(__SSE2__)
-#define ALIGNED(a) __attribute__((aligned(a)))
-#define VEC4(a)                                                                                              \
-  {                                                                                                          \
-    (a), (a), (a), (a)                                                                                       \
-  }
-
-/* SSE intrinsics version of dt_fast_expf */
-static const __m128 dt__fone ALIGNED(64) = VEC4(0x3f800000u);
-static const __m128 femo ALIGNED(64) = VEC4(0x00adf880u);
-static inline __m128 dt_fast_expf_sse2(const __m128 x)
-{
-  __m128 f = dt__fone + (x * femo);                 // f(n) = i1 + x(n)*(i2-i1)
-  __m128i i = _mm_cvtps_epi32(f);                   // i(n) = int(f(n))
-  __m128i mask = _mm_srai_epi32(i, 31);             // mask(n) = 0xffffffff if i(n) < 0
-  i = _mm_andnot_si128(mask, i);                    // i(n) = 0 if i(n) < 0
-  return _mm_castsi128_ps(i);                       // return *(float*)&i
-}
-#undef ALIGNED
-#undef VEC4
-
-#endif // __SSE2__
-
 // fast approximation of 2^-x for 0<x<126
 /****** if you change this function, you need to make the same change in data/kernels/{denoiseprofile,nlmeans}.cl ***/
 static inline float dt_fast_mexp2f(const float x)


### PR DESCRIPTION
After a number of attempts, I finally convinced the compiler to keep things in registers for the weight() function which is called 25 times per pixel at each scale (and thus consumes around 90% of the CPU time) when doing the wavelet decomposition.  That resulted in a 19% overall speedup for the contrast equalizer, so the SSE code could be removed.
```
Thr	M-AV	M-SSE	PR-AV
1	37.580	10.569	 8.466	-19.8%
2	18.833	 5.323	 4.273	-19.7%
4	 9.451	 2.698	 2.175	-19.3%
8	 4.778	 1.400	 1.133	-19.0%
16	 2.442	 0.748	 0.616	-17.6%
32	 1.287	 0.437	 0.367	-16.0%
64	 0.738	 0.432	 0.357	-17.3%
```
Passes integration test 0024 (and 0013, which was potentially affected by removal of some leftover SSE code in a different function).

