### PR TITLE
wrap degrees around when entered or horizon drawn

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2593,7 +2593,8 @@ static void _slider_add_step(GtkWidget *widget, float delta, guint state, gboole
     if(d->factor < 0 ? d->pos < 0.0001 : d->pos > 0.9999) d->max = d->max < d->soft_max ? d->min : d->soft_max;
     dt_bauhaus_slider_set(widget, value + delta);
   }
-  else if(!strcmp(d->format,"°") && (d->max - d->min) * d->factor == 360.0f
+  else if(!strcmp(d->format,"°")
+          && fabsf((d->max - d->min) * d->factor - 360.0f) < 1e-4
           && fabsf(value + delta)/(d->max - d->min) < 2)
     dt_bauhaus_slider_set(widget, value + delta);
   else

--- a/src/iop/blurs.c
+++ b/src/iop/blurs.c
@@ -50,10 +50,10 @@ typedef struct dt_iop_blurs_params_t
   int blades;              // $MIN: 3 $MAX: 11 $DEFAULT: 5 $DESCRIPTION: "diaphragm blades"
   float concavity;         // $MIN: 1. $MAX: 9.  $DEFAULT: 1. $DESCRIPTION: "concavity"
   float linearity;         // $MIN: 0. $MAX: 1.  $DEFAULT: 1. $DESCRIPTION: "linearity"
-  float rotation;          // $MIN: -1.57 $MAX: 1.57 $DEFAULT: 0. $DESCRIPTION: "rotation"
+  float rotation;          // $MIN: -M_PI_F/2. $MAX: M_PI_F/2. $DEFAULT: 0. $DESCRIPTION: "rotation"
 
   // motion blur params
-  float angle;             // $MIN: -3.14 $MAX: 3.14 $DEFAULT: 0. $DESCRIPTION: "direction"
+  float angle;             // $MIN: -M_PI_F $MAX: M_PI_F $DEFAULT: 0. $DESCRIPTION: "direction"
   float curvature;         // $MIN: -2.   $MAX: 2.   $DEFAULT: 0. $DESCRIPTION: "curvature"
   float offset;            // $MIN: -1.   $MAX: 1.   $DEFAULT: 0  $DESCRIPTION: "offset"
 


### PR DESCRIPTION
fixes #14008 and should also deal correctly with manually entered values.

Since this impacts _all_ degree and gradient sliders, it would be much appreciated if this got some testing (from @codingdave and others).