### PR TITLE
performance: optimize colorin, remove more SSE code

### DIFF
--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -124,7 +124,7 @@ static inline __m128 dt_prophotoRGB_to_XYZ_sse2(__m128 rgb)
 #endif
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(in,out)
+#pragma omp declare simd aligned(in,out : 16) aligned(matrix : 64)
 #endif
 static inline void dt_apply_transposed_color_matrix(const dt_aligned_pixel_t in, const dt_colormatrix_t matrix,
                                                     dt_aligned_pixel_t out)
@@ -136,7 +136,7 @@ static inline void dt_apply_transposed_color_matrix(const dt_aligned_pixel_t in,
 }
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(in,out)
+#pragma omp declare simd aligned(in,out,matrix_row0,matrix_row1,matrix_row2)
 #endif
 static inline void dt_apply_color_matrix_by_row(const dt_aligned_pixel_t in,
                                                 const dt_aligned_pixel_t matrix_row0,
@@ -619,6 +619,9 @@ static inline void dt_prophotorgb_to_Lab(const dt_aligned_pixel_t rgb, dt_aligne
   dt_XYZ_to_Lab(XYZ, Lab);
 }
 
+#ifdef _OPENMP
+#pragma omp declare simd aligned(rgb, Lab, cmatrix_row0, cmatrix_row1, cmatrix_row2)
+#endif
 static inline void dt_RGB_to_Lab(const dt_aligned_pixel_t rgb,
                                  const dt_aligned_pixel_t cmatrix_row0,
                                  const dt_aligned_pixel_t cmatrix_row1,
@@ -632,7 +635,7 @@ static inline void dt_RGB_to_Lab(const dt_aligned_pixel_t rgb,
 
 
 #ifdef _OPENMP
-#pragma omp declare simd
+#pragma omp declare simd aligned(RGB)
 #endif
 static inline float _dt_RGB_2_Hue(const dt_aligned_pixel_t RGB, const float max, const float delta)
 {

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -509,7 +509,7 @@ static inline void dt_vector_min(dt_aligned_pixel_t min,
                                  const dt_aligned_pixel_t v2)
 {
 #ifdef __SSE__
-  *((__m128*)min) = _mm_max_ps(*((__m128*)v1), *((__m128*)v2));
+  *((__m128*)min) = _mm_min_ps(*((__m128*)v1), *((__m128*)v2));
 #else
   for_each_channel(c)
     min[c] = MIN(v1[c], v2[c]);


### PR DESCRIPTION
Some further optimization work brings the performance on nonlinear profiles with gamut clipping on par with the SSE code, so remove the SSE version of that function.  The gap narrows for linear profiles with gamut clipping, but the plain C is still several percent slower, so that SSE code stays (for now).
```
Thr	M-SSE	M-AV	PR-AV
1	325.84	346.42	324.98	-0.2%
2	163.82	172.37	162.92	-0.5%
4	 84.24	 87.34	 83.41	-0.9%
8	 41.92	 45.34	 42.05	+0.3%
16	 21.40	 22.58	 21.33	-0.3%
32	 10.93	 11.70	 10.93	--
64	  9.19	  9.15	  8.94	-2%
```
Passes tests 0000, 0107, 0108, and 0109.
