### PR TITLE
po/mask manager mode - ensure state stays meaningful

### DIFF
--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -59,6 +59,9 @@ typedef enum dt_masks_state_t
   DT_MASKS_STATE_EXCLUSION = 1 << 6
 } dt_masks_state_t;
 
+#define DT_MASKS_STATE_OP (DT_MASKS_STATE_UNION | DT_MASKS_STATE_INTERSECTION \
+                           | DT_MASKS_STATE_DIFFERENCE | DT_MASKS_STATE_EXCLUSION)
+
 typedef enum dt_masks_property_t
 {
   DT_MASKS_PROPERTY_OPACITY,

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1443,7 +1443,7 @@ void dt_masks_set_edit_mode_single_form(struct dt_iop_module_t *module,
       (dt_masks_point_group_t *)malloc(sizeof(dt_masks_point_group_t));
     fpt->formid = formid;
     fpt->parentid = grid;
-    fpt->state = DT_MASKS_STATE_USE;
+    fpt->state = DT_MASKS_STATE_SHOW | DT_MASKS_STATE_USE;
     fpt->opacity = 1.0f;
     grp->points = g_list_append(grp->points, fpt);
   }

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1004,6 +1004,7 @@ static int _tree_button_pressed(GtkWidget *treeview,
     gboolean from_group = FALSE;
 
     gboolean is_first_row = FALSE;
+    gboolean is_last_row = FALSE;
 
     int grpid = 0;
     int depth = 0;
@@ -1024,10 +1025,18 @@ static int _tree_button_pressed(GtkWidget *treeview,
           grp = dt_masks_get_from_id(darktable.develop, grpid);
         }
 
-        // if depth > 1 then check if the selected item is the first in the
-        // group.
-        if(!gtk_tree_path_prev(it0))
+        // if depth > 1 then check if the selected item is the first
+        // or last in the group. This is used to enable/disable some
+        // feature only meaningful for rows with prev/next.
+
+        GtkTreeIter it;
+        gtk_tree_model_get_iter(model, &it, it0);
+        is_last_row = !gtk_tree_model_iter_next(model, &it);
+
+        if(!is_last_row && !gtk_tree_path_prev(it0))
+        {
           is_first_row = TRUE;
+        }
       }
 
       g_list_free_full(selected, (GDestroyNotify)gtk_tree_path_free);
@@ -1203,9 +1212,12 @@ static int _tree_button_pressed(GtkWidget *treeview,
       }
       gtk_menu_shell_append(menu, gtk_separator_menu_item_new());
       item = gtk_menu_item_new_with_label(_("move up"));
+      gtk_widget_set_sensitive(item, !is_first_row);
       g_signal_connect(item, "activate", (GCallback)_tree_moveup, self);
       gtk_menu_shell_append(menu, item);
+
       item = gtk_menu_item_new_with_label(_("move down"));
+      gtk_widget_set_sensitive(item, !is_last_row);
       g_signal_connect(item, "activate", (GCallback)_tree_movedown, self);
       gtk_menu_shell_append(menu, item);
     }

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -398,6 +398,8 @@ static void _set_iter_name(dt_lib_masks_t *lm,
     snprintf(str, sizeof(str), "%s %d%%", str2, (int)(opacity * 100));
   }
 
+  const gboolean show = state & DT_MASKS_STATE_SHOW;
+
   GdkPixbuf *icop = NULL;
   GdkPixbuf *icinv = NULL;
 
@@ -416,7 +418,7 @@ static void _set_iter_name(dt_lib_masks_t *lm,
   gtk_tree_store_set(GTK_TREE_STORE(model), iter,
                      TREE_TEXT, str,
                      TREE_IC_OP, icop,
-                     TREE_IC_OP_VISIBLE,(icop != NULL),
+                     TREE_IC_OP_VISIBLE, (icop != NULL) && show,
                      TREE_IC_INVERSE, icinv,
                      TREE_IC_INVERSE_VISIBLE, (icinv != NULL),
                      -1);
@@ -728,6 +730,59 @@ static void _tree_union(GtkButton *button, dt_lib_module_t *self)
   }
 }
 
+static void _swap_first_second_item_visibility(dt_lib_masks_t *lm,
+                                               GtkTreeIter *iter,
+                                               const int first_id,
+                                               const int second_id)
+{
+  GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
+
+  int grid = -1;
+  int id = -1;
+  _lib_masks_get_values(model, iter, NULL, &grid, &id);
+
+  dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, grid);
+
+  if(grp)
+  {
+    // we search the entries and change the state
+    // the new first entry is removed the SHOW state and
+    // the new second node is set SHOW state + UNION if no operator defined yet.
+    for(const GList *pts = grp->points; pts; pts = g_list_next(pts))
+    {
+      dt_masks_point_group_t *pt = (dt_masks_point_group_t *)pts->data;
+      gboolean changed = FALSE;
+      if(pt->formid == first_id)
+      {
+        pt->state &= ~DT_MASKS_STATE_SHOW;
+        changed = TRUE;
+      }
+      else if(pt->formid == second_id)
+      {
+        // ensure that at leat an operator is defined as we are
+        // going to show this mask operator.
+        if((pt->state & DT_MASKS_STATE_OP) == DT_MASKS_STATE_NONE)
+          pt->state |= DT_MASKS_STATE_UNION;
+        pt->state |= DT_MASKS_STATE_SHOW;
+        changed = TRUE;
+      }
+      if(changed)
+        _set_iter_name(lm,
+                       dt_masks_get_from_id(darktable.develop, id),
+                       pt->state, pt->opacity, model,
+                       iter);
+    }
+  }
+}
+
+static gboolean _is_first_tree_item(GtkTreeModel *model, GtkTreeIter *iter)
+{
+  GtkTreeIter *tmp = gtk_tree_iter_copy(iter);
+  const gboolean is_first_item = !gtk_tree_model_iter_previous(model, tmp);
+  gtk_tree_iter_free(tmp);
+  return is_first_item;
+}
+
 static void _tree_moveup(GtkButton *button, dt_lib_module_t *self)
 {
   dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
@@ -744,50 +799,25 @@ static void _tree_moveup(GtkButton *button, dt_lib_module_t *self)
   {
     GtkTreePath *item = (GtkTreePath *)items_iter->data;
     GtkTreeIter iter;
-    GtkTreeIter prev_iter;
+
     if(gtk_tree_model_get_iter(model, &iter, item))
     {
       int grid = -1;
       int id = -1;
       _lib_masks_get_values(model, &iter, NULL, &grid, &id);
 
-      prev_iter = *gtk_tree_iter_copy(&iter);
-      gtk_tree_model_iter_previous(model, &prev_iter);
+      GtkTreeIter *prev_iter = gtk_tree_iter_copy(&iter);
+      gtk_tree_model_iter_previous(model, prev_iter);
       int prev_grid = -1;
       int prev_id = -1;
-      _lib_masks_get_values(model, &prev_iter, NULL, &prev_grid, &prev_id);
+      _lib_masks_get_values(model, prev_iter, NULL, &prev_grid, &prev_id);
 
-      const gboolean is_first_item = !gtk_tree_model_iter_previous(model, &prev_iter);
-
-      if(is_first_item)
+      if(_is_first_tree_item(model, prev_iter))
       {
-        dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, grid);
-        if(grp)
-        {
-          // we search the entries and change the state
-          // the new first entry has a clear mask state and the
-          // new second node is set to UNION.
-          for(const GList *pts = grp->points; pts; pts = g_list_next(pts))
-          {
-            dt_masks_point_group_t *pt = (dt_masks_point_group_t *)pts->data;
-            gboolean changed = FALSE;
-            if(pt->formid == id)
-            {
-              pt->state = DT_MASKS_STATE_NONE;
-              changed = TRUE;
-            }
-            else if(pt->formid == prev_id)
-            {
-              pt->state = DT_MASKS_STATE_UNION;
-              changed = TRUE;
-            }
-            if(changed)
-              _set_iter_name(lm, dt_masks_get_from_id(darktable.develop, id),
-                             pt->state, pt->opacity, model,
-                             &iter);
-          }
-        }
+        _swap_first_second_item_visibility(lm, &iter, id, prev_id);
       }
+
+      gtk_tree_iter_free(prev_iter);
 
       dt_masks_form_move(dt_masks_get_from_id(darktable.develop, grid), id, 0);
     }
@@ -815,50 +845,25 @@ static void _tree_movedown(GtkButton *button, dt_lib_module_t *self)
   {
     GtkTreePath *item = (GtkTreePath *)items_iter->data;
     GtkTreeIter iter;
-    GtkTreeIter next_iter;
+
     if(gtk_tree_model_get_iter(model, &iter, item))
     {
       int grid = -1;
       int id = -1;
       _lib_masks_get_values(model, &iter, NULL, &grid, &id);
 
-      next_iter = *gtk_tree_iter_copy(&iter);
-      gtk_tree_model_iter_next(model, &next_iter);
+      GtkTreeIter *next_iter = gtk_tree_iter_copy(&iter);
+      gtk_tree_model_iter_next(model, next_iter);
       int next_grid = -1;
       int next_id = -1;
-      _lib_masks_get_values(model, &next_iter, NULL, &next_grid, &next_id);
+      _lib_masks_get_values(model, next_iter, NULL, &next_grid, &next_id);
 
-      const gboolean is_first_item = !gtk_tree_model_iter_previous(model, &iter);
-
-      if(is_first_item)
+      if(_is_first_tree_item(model, &iter))
       {
-        dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, grid);
-        if(grp)
-        {
-          // we search the entries and change the state
-          // the new first entry has a clear mask state and the
-          // new second node is set to UNION.
-          for(const GList *pts = grp->points; pts; pts = g_list_next(pts))
-          {
-            dt_masks_point_group_t *pt = (dt_masks_point_group_t *)pts->data;
-            gboolean changed = FALSE;
-            if(pt->formid == id)
-            {
-              pt->state = DT_MASKS_STATE_UNION;
-              changed = TRUE;
-            }
-            else if(pt->formid == next_id)
-            {
-              pt->state = DT_MASKS_STATE_NONE;
-              changed = TRUE;
-            }
-            if(changed)
-              _set_iter_name(lm, dt_masks_get_from_id(darktable.develop, id),
-                             pt->state, pt->opacity, model,
-                             &iter);
-          }
-        }
+        _swap_first_second_item_visibility(lm, &iter, next_id, id);
       }
+
+      gtk_tree_iter_free(next_iter);
 
       dt_masks_form_move(dt_masks_get_from_id(darktable.develop, grid), id, 1);
     }

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1254,14 +1254,14 @@ static gboolean _tree_restrict_select(GtkTreeSelection *selection,
   // now we unselect all members of selection with not the same parent node
   // idem for all those with a different depth
   int *indices = gtk_tree_path_get_indices(path);
-  int depth = gtk_tree_path_get_depth(path);
+  const int depth = gtk_tree_path_get_depth(path);
 
   GList *items = gtk_tree_selection_get_selected_rows(selection, NULL);
   GList *items_iter = items;
   while(items_iter)
   {
     GtkTreePath *item = (GtkTreePath *)items_iter->data;
-    int dd = gtk_tree_path_get_depth(item);
+    const int dd = gtk_tree_path_get_depth(item);
     int *ii = gtk_tree_path_get_indices(item);
     int ok = 1;
     if(dd != depth)

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1001,7 +1001,9 @@ static int _tree_button_pressed(GtkWidget *treeview,
 
     // we get all infos from selection
     const int nb = gtk_tree_selection_count_selected_rows(selection);
-    int from_group = 0;
+    gboolean from_group = FALSE;
+
+    gboolean is_first_row = FALSE;
 
     int grpid = 0;
     int depth = 0;
@@ -1021,10 +1023,18 @@ static int _tree_button_pressed(GtkWidget *treeview,
           _lib_masks_get_values(model, &iter, NULL, NULL, &grpid);
           grp = dt_masks_get_from_id(darktable.develop, grpid);
         }
+
+        // if depth > 1 then check if the selected item is the first in the
+        // group.
+        if(!gtk_tree_path_prev(it0))
+          is_first_row = TRUE;
       }
+
       g_list_free_full(selected, (GDestroyNotify)gtk_tree_path_free);
     }
-    if(depth > 1) from_group = 1;
+
+    if(depth > 1)
+      from_group = TRUE;
 
     if(nb == 0 || (grp && grp->type & DT_MASKS_GROUP))
     {
@@ -1170,16 +1180,24 @@ static int _tree_button_pressed(GtkWidget *treeview,
       if(nb == 1)
       {
         gtk_menu_shell_append(menu, gtk_separator_menu_item_new());
+
         item = gtk_menu_item_new_with_label(_("mode: union"));
+        gtk_widget_set_sensitive(item, !is_first_row);
         g_signal_connect(item, "activate", (GCallback)_tree_union, self);
         gtk_menu_shell_append(menu, item);
+
         item = gtk_menu_item_new_with_label(_("mode: intersection"));
+        gtk_widget_set_sensitive(item, !is_first_row);
         g_signal_connect(item, "activate", (GCallback)_tree_intersection, self);
         gtk_menu_shell_append(menu, item);
+
         item = gtk_menu_item_new_with_label(_("mode: difference"));
+        gtk_widget_set_sensitive(item, !is_first_row);
         g_signal_connect(item, "activate", (GCallback)_tree_difference, self);
         gtk_menu_shell_append(menu, item);
+
         item = gtk_menu_item_new_with_label(_("mode: exclusion"));
+        gtk_widget_set_sensitive(item, !is_first_row);
         g_signal_connect(item, "activate", (GCallback)_tree_exclusion, self);
         gtk_menu_shell_append(menu, item);
       }


### PR DESCRIPTION
Multiple fixes for #10770.

- When moving-up or moving-down shapes in the mask manager the new first node must have a clear state and the second one is reset to UNION.

- Disable move up/down depending on the location of the node.

- Disable mode selection for first item in a group.
