### PR TITLE
fix lua dt.gui.mimic in script section

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -3324,7 +3324,7 @@ static float _process_action(dt_action_t *action, int instance,
       return_value = definition->process(action_target, element, effect, move_size);
     }
 #ifdef USE_LUA
-    else if(action->owner == &darktable.control->actions_lua && definition)
+    else if(owner == &darktable.control->actions_lua && definition)
     {
       dt_lua_lock();
 


### PR DESCRIPTION
This is needed to make lua widget proxies work after the `script_manager_running_script` variable has been introduced in script_manager.lua, as discussed here
https://github.com/darktable-org/darktable/pull/13579#issuecomment-1437410150

@wpferguson do you have a timeline for this? It shouldn't hurt anybody who isn't using master and those who _are_ could give feedback on the problems introduced. Shortcuts not working until remapped maybe.

One thing I noticed is that the bauhaus widgets that script_manager sets up for itself now end up in the last module activated. So you'll want to define a dedicated `script_manager_running_script` value for the manager as well.