### PR TITLE
Simplify demosaicer code

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2310,19 +2310,6 @@
     <longdescription>adds a mode in denoiseprofile that allows to compute the variance after the generalized anscombe transform is performed</longdescription>
   </dtconfig>
   <dtconfig prefs="darkroom" section="general">
-    <name>plugins/darkroom/demosaic/quality</name>
-    <type>
-      <enum>
-        <option>always bilinear (fast)</option>
-        <option>default</option>
-        <option>full (possibly slow)</option>
-      </enum>
-    </type>
-    <default>default</default>
-    <shortdescription>demosaicing for zoomed out darkroom mode</shortdescription>
-    <longdescription>demosaicer when not viewing 1:1 in darkroom mode:\n - 'bilinear': is fast but slightly blurry.\n - 'default': uses the default demosaicer for the used sensor (RCD or Markesteijn).\n - 'full': will use exactly the settings as for full-size export.</longdescription>
-  </dtconfig>
-  <dtconfig prefs="darkroom" section="general">
     <name>preview_downsampling</name>
     <type>
       <enum>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1850,31 +1850,6 @@ void dt_configure_runtime_performance(const int old, char *info)
     dt_print(DT_DEBUG_DEV, "[dt_configure_runtime_performance] resourcelevel=%s\n", (sufficient) ? "default" : "small");
   }
 
-  if(!dt_conf_key_not_empty("plugins/darkroom/demosaic/quality"))
-  {
-    dt_conf_set_string("plugins/darkroom/demosaic/quality", (sufficient) ? "default" : "always bilinear (fast)");
-    dt_print(DT_DEBUG_DEV, "[dt_configure_runtime_performance] plugins/darkroom/demosaic/quality=%s",
-      (sufficient) ? "default" : "always bilinear (fast)");
-  }
-  else if(old == 2)
-  {
-    const gchar *demosaic_quality = dt_conf_get_string_const("plugins/darkroom/demosaic/quality");
-    if(!strcmp(demosaic_quality, "always bilinear (fast)"))
-    {
-      dt_conf_set_string("plugins/darkroom/demosaic/quality", "default");
-      dt_print(DT_DEBUG_DEV, "[dt_configure_runtime_performance] override: plugins/darkroom/demosaic/quality=default\n");
-    }
-  }
-  else if(old < 12)
-  {
-    const gchar *demosaic_quality = dt_conf_get_string_const("plugins/darkroom/demosaic/quality");
-    if(!strcmp(demosaic_quality, "at most RCD (reasonable)"))
-    {
-      dt_conf_set_string("plugins/darkroom/demosaic/quality", "default");
-      dt_print(DT_DEBUG_DEV, "[dt_configure_runtime_performance] override: plugins/darkroom/demosaic/quality=default\n");
-    }
-  }
-
   if(!dt_conf_key_not_empty("cache_disk_backend_full"))
   {
     char cachedir[PATH_MAX] = { 0 };


### PR DESCRIPTION
The `plugins/darkroom/demosaic/quality` conf key
 - didn't work correctly with all available demosaicers any more
 - could lead to visible differences while developing
 - had only a possibly marginal benefit after the pixelpipe cache improvements

so i removed it.

The new code still allows speedup via the fast downscaled approximated demosaicers
- in preview modes for a fast user interface while zoomin in & out
- for thumbnails with allowed low quality

Pixelpipe fast mode disables dual demosaicing and only processes the main demosaicer

