### PR TITLE
[actions] Fixed an inaccuracy in the stale bot message

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,8 +28,8 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been marked as stale due to inactivity for the last ${{ env.BEFORE_ISSUE_STALE }} days. It will be automatically closed in ${{ env.BEFORE_ISSUE_CLOSE }} days if no update occurs. Please check if the master branch has fixed it and report again or close the issue.'
         stale-pr-message: 'This pull request has been marked as stale due to inactivity for the last ${{ env.BEFORE_PR_STALE }} days. It will be automatically closed in ${{ env.BEFORE_PR_CLOSE }} days if no update occurs. Please verify it has no conflicts with the master branch and rebase if needed. Mention it now if you need help or give permission to other people to finish your work.'
-        close-issue-message: 'This issue was closed because it has been stalled for ${{ env.BEFORE_ISSUE_CLOSE }} days with no activity. Please check if the newest release or nightly build has it fixed. Please, create a new issue if the issue is not fixed.'
-        close-pr-message: 'This pull reguest was closed because it has been stalled for ${{ env.BEFORE_PR_CLOSE }} days with no activity.'
+        close-issue-message: 'This issue was closed because it has been inactive for ${{ env.BEFORE_ISSUE_CLOSE }} days since being marked as stale. Please check if the newest release or nightly build has it fixed. Please, create a new issue if the issue is not fixed.'
+        close-pr-message: 'This pull reguest was closed because it has been inactive for ${{ env.BEFORE_PR_CLOSE }} days since being marked as stale.'
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
         days-before-issue-stale: ${{ env.BEFORE_ISSUE_STALE }}


### PR DESCRIPTION
By activity in the context of the PR/issues lifecycle, we mean any explicit actions by the people involved, such as comments, setting milestones, labels, etc.

Assigning the "stale" label by this bot updates the timestamp of the last change, so after that this bot counts inactivity from the moment of labeling by the bot, and not from the moment when there was the last human activity.

The text has been changed to clarify that this is the number of days of inactivity since labeling, as human inactivity was even longer.

