### PR TITLE
add width and height fields to dt_lua_image_t

### DIFF
--- a/src/lua/image.c
+++ b/src/lua/image.c
@@ -514,6 +514,10 @@ int dt_lua_init_image(lua_State *L)
   luaA_struct_member(L, dt_image_t, filename, const char_filename_length);
   luaA_struct_member(L, dt_image_t, width, const int32_t);
   luaA_struct_member(L, dt_image_t, height, const int32_t);
+  luaA_struct_member(L, dt_image_t, final_width, const int32_t);
+  luaA_struct_member(L, dt_image_t, final_height, const int32_t);
+  luaA_struct_member(L, dt_image_t, p_width, const int32_t);
+  luaA_struct_member(L, dt_image_t, p_height, const int32_t);
   luaA_struct_member(L, dt_image_t, aspect_ratio, const float);
 
   luaA_struct_member_name(L, dt_image_t, geoloc.longitude, protected_double, longitude); // set to NAN if value is not set


### PR DESCRIPTION
Add the fields p_height, p_width, final_height and final_width to the dt_lua_image_t data type so that they can be used with the variable substitution functions, https://github.com/darktable-org/lua-scripts/pull/412