### PR TITLE
Add model metadata for the Canon EOS R6 Mark II.

### DIFF
--- a/src/imageio/imageio_libraw.c
+++ b/src/imageio/imageio_libraw.c
@@ -76,6 +76,13 @@ const model_map_t modelMap[] = {
   },
   {
     .exif_make = "Canon",
+    .exif_model = "Canon EOS R6m2",
+    .clean_make = "Canon",
+    .clean_model = "EOS R6 Mark II",
+    .clean_alias = "EOS R6 Mark II"
+  },
+  {
+    .exif_make = "Canon",
     .exif_model = "Canon EOS R3",
     .clean_make = "Canon",
     .clean_model = "EOS R3",


### PR DESCRIPTION
#14029