### PR TITLE
include darktable.h even on non-SSE builds

### DIFF
--- a/src/common/sse.h
+++ b/src/common/sse.h
@@ -14,10 +14,11 @@
 */
 #pragma once
 
+#include "common/darktable.h"
+
 #ifdef __SSE__
 
 #include <xmmintrin.h>
-#include "common/darktable.h"
 
 
 /**


### PR DESCRIPTION
Should fix the reported compile failure on arm64.
