### PR TITLE
focus collapsible section to stop moving off screen

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -72,6 +72,9 @@ static void bauhaus_request_focus(dt_bauhaus_widget_t *w)
 {
   if(w->module && w->module->type == DT_ACTION_TYPE_IOP_INSTANCE)
       dt_iop_request_focus((dt_iop_module_t *)w->module);
+  else if(dt_action_lib(w->module))
+    darktable.lib->gui_module = dt_action_lib(w->module);
+
   gtk_widget_set_state_flags(GTK_WIDGET(w), GTK_STATE_FLAG_FOCUSED, FALSE);
 }
 

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1406,6 +1406,8 @@ static gboolean _blendop_masks_modes_toggle(GtkToggleButton *button,
   if(darktable.gui->reset) return FALSE;
   dt_iop_gui_blend_data_t *data = module->blend_data;
 
+  dt_iop_request_focus(module);
+
   const gboolean was_toggled = !gtk_toggle_button_get_active(button);
   gtk_toggle_button_set_active(button, was_toggled);
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3344,6 +3344,11 @@ static void _collapse_button_changed(GtkDarktableToggleButton *widget, gpointer 
 {
   dt_gui_collapsible_section_t *cs = (dt_gui_collapsible_section_t *)user_data;
 
+  if(cs->module && cs->module->type == DT_ACTION_TYPE_IOP_INSTANCE)
+      dt_iop_request_focus((dt_iop_module_t *)cs->module);
+  else if(cs->module && cs->module->type == DT_ACTION_TYPE_LIB)
+    darktable.lib->gui_module = (struct dt_lib_module_t *)cs->module;
+
   const gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(cs->toggle));
   dtgtk_expander_set_expanded(DTGTK_EXPANDER(cs->expander), active);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(cs->toggle), dtgtk_cairo_paint_solid_arrow,
@@ -3378,12 +3383,16 @@ void dt_gui_hide_collapsible_section(dt_gui_collapsible_section_t *cs)
 }
 
 void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
-                                    const char *confname, const char *label, GtkBox *parent)
+                                    const char *confname,
+                                    const char *label,
+                                    GtkBox *parent,
+                                    dt_action_t *module)
 {
   const gboolean expanded = dt_conf_get_bool(confname);
 
   cs->confname = g_strdup(confname);
   cs->parent = parent;
+  cs->module = module;
 
   // collapsible section header
   GtkWidget *destdisp_head = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_BAUHAUS_SPACE);

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -155,6 +155,7 @@ typedef struct _gui_collapsible_section_t
   GtkWidget *toggle;    // toggle button
   GtkWidget *expander;  // the expanded
   GtkBox *container;    // the container for all widgets into the section
+  struct dt_action_t *module; // the lib or iop module that contains this section
 } dt_gui_collapsible_section_t;
 
 static inline cairo_surface_t *dt_cairo_image_surface_create(cairo_format_t format, int width, int height) {
@@ -456,8 +457,10 @@ void dt_gui_search_stop(GtkSearchEntry *entry, GtkWidget *widget);
 
 // create a collapsible section, insert in parent, return the container
 void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
-                                    const char *confname, const char *label,
-                                    GtkBox *parent);
+                                    const char *confname,
+                                    const char *label,
+                                    GtkBox *parent,
+                                    struct dt_action_t *module);
 // routine to be called from gui_update
 void dt_gui_update_collapsible_section(dt_gui_collapsible_section_t *cs);
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -6132,7 +6132,8 @@ void gui_init(struct dt_iop_module_t *self)
     (&g->cs,
      "plugins/darkroom/ashift/expand_values",
      _("manual perspective"),
-     GTK_BOX(main_box));
+     GTK_BOX(main_box),
+     DT_ACTION(self));
 
   self->widget = GTK_WIDGET(g->cs.container);
 

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -4449,7 +4449,8 @@ void gui_init(struct dt_iop_module_t *self)
     (&g->csspot,
      "plugins/darkroom/channelmixerrgb/expand_picker_mapping",
      _("spot color mapping"),
-     GTK_BOX(self->widget));
+     GTK_BOX(self->widget),
+     DT_ACTION(self));
 
   gtk_widget_set_tooltip_text
     (g->csspot.expander,
@@ -4609,7 +4610,8 @@ void gui_init(struct dt_iop_module_t *self)
     (&g->cs,
      "plugins/darkroom/channelmixerrgb/expand_values",
      _("calibrate with a color checker"),
-     GTK_BOX(self->widget));
+     GTK_BOX(self->widget),
+     DT_ACTION(self));
 
   gtk_widget_set_tooltip_text(g->cs.expander,
                               _("use a color checker target to autoset CAT and channels"));

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -1250,7 +1250,8 @@ void gui_init(struct dt_iop_module_t *self)
     (&g->cs,
      "plugins/darkroom/crop/expand_margins",
      _("margins"),
-     GTK_BOX(box_enabled));
+     GTK_BOX(box_enabled),
+     DT_ACTION(self));
 
   self->widget = GTK_WIDGET(g->cs.container);
 

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -1164,7 +1164,8 @@ void gui_init(struct dt_iop_module_t *self)
     (&g->cs,
      "plugins/darkroom/exposure/mapping",
      _("spot exposure mapping"),
-     GTK_BOX(self->widget));
+     GTK_BOX(self->widget),
+     DT_ACTION(self));
 
   gtk_widget_set_tooltip_text
     (g->cs.expander,

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -677,7 +677,8 @@ void gui_init(dt_iop_module_t *self)
     (&g->cs,
      "plugins/darkroom/sigmoid/expand_values",
      _("display luminance"),
-     GTK_BOX(self->widget));
+     GTK_BOX(self->widget),
+     DT_ACTION(self));
   gtk_widget_set_tooltip_text(g->cs.expander,
                                 _("set display black/white targets"));
   GtkWidget *main_box = self->widget;

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -2120,7 +2120,8 @@ void gui_init(struct dt_iop_module_t *self)
     (&g->cs,
      "plugins/darkroom/temperature/expand_coefficients",
      _("channel coefficients"),
-     GTK_BOX(box_enabled));
+     GTK_BOX(box_enabled),
+     DT_ACTION(self));
 
   self->widget = GTK_WIDGET(g->cs.container);
 

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -849,13 +849,15 @@ static void _do_select_new_clicked(GtkWidget *widget, dt_lib_module_t* self)
 static void _expander_create(dt_gui_collapsible_section_t *cs,
                              GtkBox *parent,
                              const char *label,
-                             const char *pref_key)
+                             const char *pref_key,
+                             dt_lib_module_t *self)
 {
   dt_gui_new_collapsible_section
     (cs,
      pref_key,
      label,
-     parent);
+     parent,
+     DT_ACTION(self));
 }
 
 static void _resize_dialog(GtkWidget *widget, dt_lib_module_t* self)
@@ -1645,7 +1647,7 @@ static void _set_expander_content(GtkWidget *rbox, dt_lib_module_t* self)
 
   // collapsible section
   _expander_create(&d->from.cs, GTK_BOX(import_patterns),
-                   _("naming rules"), "ui_last/session_expander_import");
+                   _("naming rules"), "ui_last/session_expander_import", NULL);
 
   // import patterns
   grid = GTK_GRID(gtk_grid_new());
@@ -2036,7 +2038,7 @@ void gui_init(dt_lib_module_t *self)
 
   // collapsible section
 
-  _expander_create(&d->cs, GTK_BOX(self->widget), _("parameters"), "ui_last/expander_import");
+  _expander_create(&d->cs, GTK_BOX(self->widget), _("parameters"), "ui_last/expander_import", self);
 
   GtkGrid *grid = GTK_GRID(gtk_grid_new());
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(5));

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -2007,7 +2007,8 @@ void gui_init(dt_lib_module_t *self)
     (&d->cs,
      "plugins/darkroom/masks/expand_properties",
      _("properties"),
-     GTK_BOX(self->widget));
+     GTK_BOX(self->widget),
+     DT_ACTION(self));
   d->none_label = dt_ui_label_new(_("no shapes selected"));
   gtk_box_pack_start(GTK_BOX(d->cs.container), d->none_label, FALSE, FALSE, 0);
   gtk_widget_show_all(GTK_WIDGET(d->cs.container));


### PR DESCRIPTION
When a collapsible section is expanded or collapsed in a module that is currently not the focused one, it may be forced off the screen because the panel will be scrolled to keep the _focused_ module visible.

This PR first assigns the focus to the lib or iop that contains the section, so it should remain visible even after resizing.

Same for blending masks type toggles.

Bauhaus now also focuses lib module when changed (as it did with iop). This is especially relevant for the export module.