### PR TITLE
Improved --dump-pipe option

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -430,13 +430,12 @@ void dt_dump_pfm_file(
   }
 
   char fname[PATH_MAX]= { 0 };
-  snprintf(fname, sizeof (fname), "%s/%04d_%s_%s_%s%s%s.%s",
+  snprintf(fname, sizeof (fname), "%s/%04d_%s_%s_%s%s.%s",
      path,
      written,
      modname,
      cpu ? "cpu" : "GPU", 
-     input ? "in_" : "",
-     output ? "out_" : "",
+     (input && output) ? "diff_" : ((!input && !output) ? "" : ((input) ? "in_" : "out_")),
      (bpp != 16) ? "M" : "C",
      (bpp==2) ? "ppm" : "pfm");
 


### PR DESCRIPTION
In many cases we want to check in vs output of a processing module, to reduce devs work to do that via a script or other we write a diff pfm file also.

This has the further advantage that dt knows about roi_in and roi_out so we can compare corresponding locations, something external tools can't do at all.

Supports 1 or 4 channels floats as data.