### PR TITLE
snapshots: Rework the snapshot buttons.

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -595,6 +595,7 @@ dialog .sidebar row:selected:hover label,
   font-size: 1.1em;
 }
 
+#snapshot-button entry,
 #iop-module-name
 {
   font-weight: lighter;
@@ -2303,4 +2304,23 @@ Details :
 #footer-toolbar scale
 {
   margin: 0.07em 0.28em;
+}
+
+/* The entry in the snapshot button must not be visible by default as we still want to see
+   a flat button. Only when flying over one can see that the area is editable */
+#snapshot-button entry
+{
+  background-color: @button_bg;
+  border: none;
+}
+
+#snapshot-button entry
+{
+  background-color: transparent;
+}
+
+#snapshot-button *
+{
+   padding-left: 1px;
+   padding-right: 1px;
 }


### PR DESCRIPTION
The button now contains 4 widgets:
  - num    : the corresponding history num
  - status : a column that contains an icon when the snapshot is from
             another image.
  - name   : the module name
  - label  : the module label (editable)

This makes the snapshot button UI cleaner and simplify quite a bit the implementation.

A bit of love for the snapshot module. The look is now:

![image](https://user-images.githubusercontent.com/467069/228293791-bfde9ea9-5d2f-4230-8adb-80432d45cf60.png)

The the arrow is the status about whether the snapshot is from the current image or another one.

![image](https://user-images.githubusercontent.com/467069/228294167-559a66f3-7e10-4b48-adee-a143ca5691be.png)

Numbers are properly aligned (using monospace font as for the history lib):

![image](https://user-images.githubusercontent.com/467069/228294450-154ee862-8d6d-4eae-84a5-b7c65438e3d8.png)

@wpferguson : There was one routine for Lua returning the full label. Now that the snapshot button has four internal widgets I have returned only the module's label (or snapshot name if renamed). That is maybe not the best, alternative options are:
- Include the module name + label
- Include the history num + module name + label

Let me know what you prefer.