### PR TITLE
restore wrapping of long tooltip lines without explicit line breaks

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1045,6 +1045,8 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget, gint x, gint y, gboolea
 
     GtkWidget *label = gtk_label_new(NULL);
     gtk_label_set_markup(GTK_LABEL(label), markup_text);
+    gtk_label_set_line_wrap(GTK_LABEL(label), TRUE);
+    gtk_label_set_max_width_chars(GTK_LABEL(label), 70);
     gtk_widget_set_halign(label, GTK_ALIGN_START);
 
     g_free(markup_text);


### PR DESCRIPTION
Restores wrapping of long tooltip lines that was broken by d39719d4a55820fabcd526a89c8fa8d0f095c4fe

![image](https://user-images.githubusercontent.com/1549490/228308919-8e5fb34b-a9ca-4bf6-a909-402f9bd00dd4.png)
