### PR TITLE
Various pixelpipe debug improvements & fixes

### DIFF
--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -68,28 +68,6 @@ static void _clear_lut_curves(dt_iop_order_iccprofile_info_t *const profile_info
   }
 }
 
-static char *_colorspace_to_name(dt_iop_colorspace_type_t type)
-{
-  switch(type)
-  {
-    case IOP_CS_NONE:
-      return "IOP_CS_NONE";
-    case IOP_CS_RAW:
-      return "IOP_CS_RAW";
-    case IOP_CS_LAB:
-      return "IOP_CS_LAB";
-    case IOP_CS_RGB:
-      return "IOP_CS_RGB";
-    case IOP_CS_LCH:
-      return "IOP_CS_LCH";
-    case IOP_CS_HSL:
-      return "IOP_CS_HSL";
-    case IOP_CS_JZCZHZ:
-      return "IOP_CS_JZCZHZ";
-  }
-  return "invalid IOP_CS";
-}
-
 static void _transform_from_to_rgb_lab_lcms2(
         const float *const image_in,
         float *const image_out,
@@ -629,7 +607,7 @@ static inline void _transform_matrix(struct dt_iop_module_t *self,
   {
     *converted_cst = cst_from;
     dt_print(DT_DEBUG_ALWAYS, "[_transform_matrix] invalid conversion from %s to %s\n",
-      _colorspace_to_name(cst_from), _colorspace_to_name(cst_to));
+      dt_iop_colorspace_to_name(cst_from), dt_iop_colorspace_to_name(cst_to));
   }
 }
 
@@ -1128,7 +1106,7 @@ void dt_ioppr_transform_image_colorspace(
     {
       dt_get_times(&end_time);
       dt_print(DT_DEBUG_ALWAYS, "[dt_ioppr_transform_image_colorspace] %s-->%s took %.3f secs (%.3f CPU) [%s %s]\n",
-          _colorspace_to_name(cst_from), _colorspace_to_name(cst_to),
+          dt_iop_colorspace_to_name(cst_from), dt_iop_colorspace_to_name(cst_to),
           end_time.clock - start_time.clock, end_time.user - start_time.user, self->op, self->multi_name);
     }
   }
@@ -1140,7 +1118,7 @@ void dt_ioppr_transform_image_colorspace(
     {
       dt_get_times(&end_time);
       dt_print(DT_DEBUG_ALWAYS, "[dt_ioppr_transform_image_colorspace] %s-->%s took %.3f secs (%.3f lcms2) [%s %s]\n",
-          _colorspace_to_name(cst_from), _colorspace_to_name(cst_to),
+          dt_iop_colorspace_to_name(cst_from), dt_iop_colorspace_to_name(cst_to),
           end_time.clock - start_time.clock, end_time.user - start_time.user, self->op, self->multi_name);
     }
   }
@@ -1148,7 +1126,7 @@ void dt_ioppr_transform_image_colorspace(
   if(*converted_cst == cst_from)
     dt_print(DT_DEBUG_ALWAYS, "[dt_ioppr_transform_image_colorspace] in `%s', profile `%s', invalid conversion from %s to %s\n",
       self->so->op, dt_colorspaces_get_name(profile_info->type, profile_info->filename),
-      _colorspace_to_name(cst_from), _colorspace_to_name(cst_to));
+      dt_iop_colorspace_to_name(cst_from), dt_iop_colorspace_to_name(cst_to));
 }
 
 
@@ -1393,7 +1371,7 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
       *converted_cst = cst_from;
       dt_print(DT_DEBUG_ALWAYS, "[dt_ioppr_transform_image_colorspace_cl] in `%s', profile `%s', invalid conversion from %s to %s\n",
         self->so->op, dt_colorspaces_get_name(profile_info->type, profile_info->filename),
-        _colorspace_to_name(cst_from), _colorspace_to_name(cst_to));
+        dt_iop_colorspace_to_name(cst_from), dt_iop_colorspace_to_name(cst_to));
       goto cleanup;
     }
 
@@ -1441,8 +1419,8 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
     if(darktable.unmuted & DT_DEBUG_PERF)
     {
       dt_get_times(&end_time);
-      dt_print(DT_DEBUG_ALWAYS, "image colorspace transform %s-->%s took %.3f secs (%.3f GPU) [%s %s]\n",
-          _colorspace_to_name(cst_from), _colorspace_to_name(cst_to),
+      dt_print(DT_DEBUG_ALWAYS, "[dt_ioppr_transform_image_colorspace_cl] %s-->%s took %.3f secs (%.3f GPU) [%s %s]\n",
+          dt_iop_colorspace_to_name(cst_from), dt_iop_colorspace_to_name(cst_to),
           end_time.clock - start_time.clock, end_time.user - start_time.user, self->op, self->multi_name);
     }
   }

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2020-2022 darktable developers.
+    Copyright (C) 2020-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -312,8 +312,13 @@ static inline void _transform_lcms2_rgb(const float *const image_in, float *cons
 }
 
 
-static inline int _init_unbounded_coeffs(float *const lutr, float *const lutg, float *const lutb,
-    float *const unbounded_coeffsr, float *const unbounded_coeffsg, float *const unbounded_coeffsb, const int lutsize)
+static inline int _init_unbounded_coeffs(float *const lutr,
+                                         float *const lutg,
+                                         float *const lutb,
+                                         float *const unbounded_coeffsr,
+                                         float *const unbounded_coeffsg,
+                                         float *const unbounded_coeffsb,
+                                         const int lutsize)
 {
   int nonlinearlut = 0;
   float *lut[3] = { lutr, lutg, lutb };
@@ -395,8 +400,10 @@ static inline void _apply_tonecurves(const float *const image_in, float *const i
 }
 
 
-static inline void _transform_rgb_to_lab_matrix(const float *const restrict image_in, float *const restrict image_out,
-                                                const int width, const int height,
+static inline void _transform_rgb_to_lab_matrix(const float *const restrict image_in,
+                                                float *const restrict image_out,
+                                                const int width,
+                                                const int height,
                                                 const dt_iop_order_iccprofile_info_t *const profile_info)
 {
   const int ch = 4;
@@ -444,9 +451,11 @@ static inline void _transform_rgb_to_lab_matrix(const float *const restrict imag
 }
 
 
-static inline void _transform_lab_to_rgb_matrix(const float *const image_in, float *const image_out, const int width,
-                                         const int height,
-                                         const dt_iop_order_iccprofile_info_t *const profile_info)
+static inline void _transform_lab_to_rgb_matrix(const float *const image_in,
+                                                float *const image_out,
+                                                const int width,
+                                                const int height,
+                                                const dt_iop_order_iccprofile_info_t *const profile_info)
 {
   const int ch = 4;
   const size_t stride = (size_t)width * height * ch;
@@ -649,7 +658,10 @@ void dt_ioppr_cleanup_profile_info(dt_iop_order_iccprofile_info_t *profile_info)
  * it can be called multiple time between init and cleanup
  * return 0 if OK, non zero otherwise
  */
-static int dt_ioppr_generate_profile_info(dt_iop_order_iccprofile_info_t *profile_info, const int type, const char *filename, const int intent)
+static int dt_ioppr_generate_profile_info(dt_iop_order_iccprofile_info_t *profile_info,
+                                          const int type,
+                                          const char *filename,
+                                          const int intent)
 {
   int err_code = 0;
   cmsHPROFILE *rgb_profile = NULL;
@@ -925,7 +937,8 @@ dt_iop_order_iccprofile_info_t *dt_ioppr_get_pipe_output_profile_info(struct dt_
   return pipe->output_profile_info;
 }
 
-dt_iop_order_iccprofile_info_t *dt_ioppr_get_pipe_current_profile_info(dt_iop_module_t *module, struct dt_dev_pixelpipe_t *pipe)
+dt_iop_order_iccprofile_info_t *dt_ioppr_get_pipe_current_profile_info(dt_iop_module_t *module,
+                                                                       struct dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_order_iccprofile_info_t *restrict color_profile;
 
@@ -1131,7 +1144,9 @@ void dt_ioppr_transform_image_colorspace(
 
 
 __DT_CLONE_TARGETS__
-void dt_ioppr_transform_image_colorspace_rgb(const float *const restrict image_in, float *const restrict image_out, const int width,
+void dt_ioppr_transform_image_colorspace_rgb(const float *const restrict image_in,
+                                             float *const restrict image_out,
+                                             const int width,
                                              const int height,
                                              const dt_iop_order_iccprofile_info_t *const profile_info_from,
                                              const dt_iop_order_iccprofile_info_t *const profile_info_to,
@@ -1185,8 +1200,7 @@ dt_colorspaces_cl_global_t *dt_colorspaces_init_cl_global()
   const int program = 23; // colorspaces.cl, from programs.conf
   g->kernel_colorspaces_transform_lab_to_rgb_matrix = dt_opencl_create_kernel(program, "colorspaces_transform_lab_to_rgb_matrix");
   g->kernel_colorspaces_transform_rgb_matrix_to_lab = dt_opencl_create_kernel(program, "colorspaces_transform_rgb_matrix_to_lab");
-  g->kernel_colorspaces_transform_rgb_matrix_to_rgb
-      = dt_opencl_create_kernel(program, "colorspaces_transform_rgb_matrix_to_rgb");
+  g->kernel_colorspaces_transform_rgb_matrix_to_rgb = dt_opencl_create_kernel(program, "colorspaces_transform_rgb_matrix_to_rgb");
   return g;
 }
 
@@ -1202,7 +1216,8 @@ void dt_colorspaces_free_cl_global(dt_colorspaces_cl_global_t *g)
   free(g);
 }
 
-void dt_ioppr_get_profile_info_cl(const dt_iop_order_iccprofile_info_t *const profile_info, dt_colorspaces_iccprofile_info_cl_t *profile_info_cl)
+void dt_ioppr_get_profile_info_cl(const dt_iop_order_iccprofile_info_t *const profile_info,
+                                  dt_colorspaces_iccprofile_info_cl_t *profile_info_cl)
 {
   for(int i = 0; i < 9; i++)
   {
@@ -1239,8 +1254,10 @@ cl_float *dt_ioppr_get_trc_cl(const dt_iop_order_iccprofile_info_t *const profil
 }
 
 cl_int dt_ioppr_build_iccprofile_params_cl(const dt_iop_order_iccprofile_info_t *const profile_info,
-                                           const int devid, dt_colorspaces_iccprofile_info_cl_t **_profile_info_cl,
-                                           cl_float **_profile_lut_cl, cl_mem *_dev_profile_info,
+                                           const int devid,
+                                           dt_colorspaces_iccprofile_info_cl_t **_profile_info_cl,
+                                           cl_float **_profile_lut_cl,
+                                           cl_mem *_dev_profile_info,
                                            cl_mem *_dev_profile_lut)
 {
   cl_int err = CL_SUCCESS;
@@ -1293,7 +1310,8 @@ cleanup:
 }
 
 void dt_ioppr_free_iccprofile_params_cl(dt_colorspaces_iccprofile_info_cl_t **_profile_info_cl,
-                                        cl_float **_profile_lut_cl, cl_mem *_dev_profile_info,
+                                        cl_float **_profile_lut_cl,
+                                        cl_mem *_dev_profile_info,
                                         cl_mem *_dev_profile_lut)
 {
   dt_colorspaces_iccprofile_info_cl_t *profile_info_cl = *_profile_info_cl;
@@ -1312,9 +1330,15 @@ void dt_ioppr_free_iccprofile_params_cl(dt_colorspaces_iccprofile_info_cl_t **_p
   *_dev_profile_lut = NULL;
 }
 
-int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const int devid, cl_mem dev_img_in,
-                                           cl_mem dev_img_out, const int width, const int height,
-                                           const int cst_from, const int cst_to, int *converted_cst,
+int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self,
+                                           const int devid,
+                                           cl_mem dev_img_in,
+                                           cl_mem dev_img_out,
+                                           const int width,
+                                           const int height,
+                                           const int cst_from,
+                                           const int cst_to,
+                                           int *converted_cst,
                                            const dt_iop_order_iccprofile_info_t *const profile_info)
 {
   cl_int err = CL_SUCCESS;
@@ -1460,8 +1484,11 @@ cleanup:
   return (err == CL_SUCCESS) ? TRUE : FALSE;
 }
 
-int dt_ioppr_transform_image_colorspace_rgb_cl(const int devid, cl_mem dev_img_in, cl_mem dev_img_out,
-                                               const int width, const int height,
+int dt_ioppr_transform_image_colorspace_rgb_cl(const int devid,
+                                               cl_mem dev_img_in,
+                                               cl_mem dev_img_out,
+                                               const int width,
+                                               const int height,
                                                const dt_iop_order_iccprofile_info_t *const profile_info_from,
                                                const dt_iop_order_iccprofile_info_t *const profile_info_to,
                                                const char *message)

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -1458,7 +1458,7 @@ gboolean dt_opencl_finish(const int devid)
 
   // take the opportunity to release some event handles, but without printing
   // summary statistics
-  cl_int success = dt_opencl_events_flush(devid, 0);
+  cl_int success = dt_opencl_events_flush(devid, FALSE);
 
   return (err == CL_SUCCESS && success == CL_COMPLETE);
 }
@@ -3188,18 +3188,10 @@ int dt_opencl_dev_roundup_height(int size, const int devid)
   return (size % roundup == 0 ? size : (size / roundup + 1) * roundup);
 }
 
-/** check if opencl is inited */
-int dt_opencl_is_inited(void)
-{
-  return darktable.opencl->inited;
-}
-
-
 /** check if opencl is enabled */
-int dt_opencl_is_enabled(void)
+gboolean dt_opencl_is_enabled(void)
 {
-  if(!darktable.opencl->inited) return FALSE;
-  return darktable.opencl->enabled;
+  return darktable.opencl->inited && darktable.opencl->enabled;
 }
 
 
@@ -3356,7 +3348,7 @@ cl_event *dt_opencl_events_get_slot(const int devid, const char *tag)
 
   // check if we would exceed the number of available event handles. In that case first flush existing handles
   if((*numevents - *eventsconsolidated + 1 > cl->dev[devid].event_handles) || (*numevents == *maxevents))
-    (void)dt_opencl_events_flush(devid, 0);
+    (void)dt_opencl_events_flush(devid, FALSE);
 
   // if no more space left in eventlist: grow buffer
   if(*numevents == *maxevents)
@@ -3477,7 +3469,7 @@ If "reset" is TRUE report summary info (would be CL_COMPLETE or last error code)
 print profiling info if needed.
 If "reset" is FALSE just store info (success value, profiling) from terminated events
 and release events for re-use by OpenCL driver. */
-cl_int dt_opencl_events_flush(const int devid, const int reset)
+cl_int dt_opencl_events_flush(const int devid, const gboolean reset)
 {
   dt_opencl_t *cl = darktable.opencl;
   if(!cl->inited || devid < 0) return FALSE;

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2022 darktable developers.
+    Copyright (C) 2010-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -383,11 +383,9 @@ int dt_opencl_enqueue_kernel_2d_args_internal(const int dev, const int kernel,
 /** launch kernel with specified dimension and defined local size! */
 int dt_opencl_enqueue_kernel_ndim_with_local(const int dev, const int kernel, const size_t *sizes,
                                            const size_t *local, const int dimensions);
-/** check if opencl is inited */
-int dt_opencl_is_inited(void);
 
 /** check if opencl is enabled */
-int dt_opencl_is_enabled(void);
+gboolean dt_opencl_is_enabled(void);
 
 /** disable opencl */
 void dt_opencl_disable(void);
@@ -521,7 +519,7 @@ void dt_opencl_events_wait_for(const int devid);
 
 /** Wait for events in eventlist to terminate, check for return status of events and
     report summary success info (CL_COMPLETE or last error code) */
-cl_int dt_opencl_events_flush(const int devid, const int reset);
+cl_int dt_opencl_events_flush(const int devid, const gboolean reset);
 
 /** display OpenCL profiling information. If summary is not 0, try to generate summarized info for kernels */
 void dt_opencl_events_profiling(const int devid, const int aggregated);
@@ -628,13 +626,9 @@ static inline int dt_opencl_enqueue_kernel_2d_with_local(const int dev, const in
 {
   return -1;
 }
-static inline int dt_opencl_is_inited(void)
+static inline gboolean dt_opencl_is_enabled(void)
 {
-  return 0;
-}
-static inline int dt_opencl_is_enabled(void)
-{
-  return 0;
+  return FALSE;
 }
 static inline void dt_opencl_disable(void)
 {
@@ -682,7 +676,7 @@ static inline void dt_opencl_events_reset(const int devid)
 static inline void dt_opencl_events_wait_for(const int devid)
 {
 }
-static inline int dt_opencl_events_flush(const int devid, const int reset)
+static inline int dt_opencl_events_flush(const int devid, const gboolean reset)
 {
   return 0;
 }

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -3524,6 +3524,28 @@ const char **dt_iop_set_description(dt_iop_module_t *module,
   return (const char **)str_out;
 }
 
+const char *dt_iop_colorspace_to_name(const dt_iop_colorspace_type_t type)
+{
+  switch(type)
+  {
+    case IOP_CS_NONE:
+      return "IOP_CS_NONE";
+    case IOP_CS_RAW:
+      return "IOP_CS_RAW";
+    case IOP_CS_LAB:
+      return "IOP_CS_LAB";
+    case IOP_CS_RGB:
+      return "IOP_CS_RGB";
+    case IOP_CS_LCH:
+      return "IOP_CS_LCH";
+    case IOP_CS_HSL:
+      return "IOP_CS_HSL";
+    case IOP_CS_JZCZHZ:
+      return "IOP_CS_JZCZHZ";
+  }
+  return "invalid IOP_CS";
+}
+
 gboolean dt_iop_have_required_input_format(const int req_ch,
                                            struct dt_iop_module_t *const module,
                                            const int ch,

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -560,6 +560,9 @@ const char **dt_iop_set_description(dt_iop_module_t *module,
                                     const char *process,
                                     const char *output);
 
+/** get a nice printable name. */
+const char *dt_iop_colorspace_to_name(const dt_iop_colorspace_type_t type);
+
 static inline dt_iop_gui_data_t *_iop_gui_alloc(dt_iop_module_t *module, size_t size)
 {
   // Align so that DT_ALIGNED_ARRAY may be used within gui_data struct

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1306,6 +1306,16 @@ static inline gboolean _check_module_now_important(dt_dev_pixelpipe_t *pipe,
   return (module->flags() & IOP_FLAGS_CACHE_IMPORTANT_NOW);
 }
 
+#ifdef HAVE_OPENCL
+static inline gboolean _opencl_pipe_is_inited(dt_dev_pixelpipe_t *pipe)
+{
+  return darktable.opencl->inited
+         && !darktable.opencl->stopped
+         && pipe->opencl_enabled
+         && (pipe->devid >= 0);
+}
+#endif
+
 // recursive helper for process:
 static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                                         dt_develop_t *dev,
@@ -1551,10 +1561,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
     **out_format = pipe->dsc = piece->dsc_out = piece->dsc_in;
 
 #ifdef HAVE_OPENCL
-    if(dt_opencl_is_inited()
-       && pipe->opencl_enabled
-       && pipe->devid >= 0
-       && (cl_mem_input != NULL))
+    if(_opencl_pipe_is_inited(pipe) && (cl_mem_input != NULL))
     {
       *cl_mem_output = cl_mem_input;
     }
@@ -1637,7 +1644,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
       = (input_format->cst != IOP_CS_RAW) ? dt_ioppr_get_pipe_work_profile_info(pipe) : NULL;
 
   /* do we have opencl at all? did user tell us to use it? did we get a resource? */
-  if(dt_opencl_is_inited() && pipe->opencl_enabled && pipe->devid >= 0)
+  if(_opencl_pipe_is_inited(pipe))
   {
     gboolean success_opencl = TRUE;
     dt_iop_colorspace_type_t input_cst_cl = input_format->cst;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1124,11 +1124,29 @@ static int pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
   const dt_iop_order_iccprofile_info_t *const work_profile
       = (input_format->cst != IOP_CS_RAW) ? dt_ioppr_get_pipe_work_profile_info(pipe) : NULL;
 
+  const int cst_from = input_format->cst;
+  const int cst_to = module->input_colorspace(module, pipe, piece);
+
+  if(darktable.unmuted & DT_DEBUG_PIPE)
+  {
+    const gboolean no_conversion = (cst_from == cst_to) || (work_profile == NULL)
+                    || (work_profile->type == DT_COLORSPACE_NONE);
+    if(!no_conversion)
+    {
+      char profiles[128] = { 0 };
+      snprintf(profiles, sizeof(profiles), "%s -> %s\n",
+        dt_iop_colorspace_to_name(cst_from), dt_iop_colorspace_to_name(cst_to));
+
+      dt_print_pipe(DT_DEBUG_PIPE,
+                  "transform colorspace CPU", piece->pipe, module->so->op, roi_in, roi_out, profiles);
+
+    }
+  }
+
   // transform to module input colorspace
   dt_ioppr_transform_image_colorspace
-    (module, input, input, roi_in->width, roi_in->height, input_format->cst,
-     module->input_colorspace(module, pipe, piece), &input_format->cst,
-     work_profile);
+    (module, input, input, roi_in->width, roi_in->height, cst_from,
+     cst_to, &input_format->cst, work_profile);
 
   if(dt_atomic_get_int(&pipe->shutdown))
     return 1;
@@ -1150,45 +1168,26 @@ static int pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
   const gboolean pfm_dump = darktable.dump_pfm_pipe
     && (piece->pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_EXPORT));
 
+  if(pfm_dump)
+    dt_dump_pipe_pfm(module->so->op, input,
+                     roi_in->width, roi_in->height, in_bpp,
+                     TRUE, dt_dev_pixelpipe_type_to_str(piece->pipe->type));
+
   if(!fitting && piece->process_tiling_ready)
   {
     dt_print_pipe(DT_DEBUG_PIPE,
                   "process TILE", piece->pipe, module->so->op, roi_in, roi_out, "\n");
-
-    if(pfm_dump)
-      dt_dump_pipe_pfm(module->so->op, input,
-                       roi_in->width, roi_in->height, in_bpp,
-                       TRUE, dt_dev_pixelpipe_type_to_str(piece->pipe->type));
-
     module->process_tiling(module, piece, input, *output, roi_in, roi_out, in_bpp);
 
-    if(pfm_dump)
-    {
-      dt_dump_pipe_pfm(module->so->op, *output,
-                       roi_out->width, roi_out->height, bpp,
-                       FALSE, dt_dev_pixelpipe_type_to_str(piece->pipe->type));
-      _dump_pipe_pfm_diff(module->so->op, input, roi_in, in_bpp, *output, roi_out, bpp,
-                                          dt_dev_pixelpipe_type_to_str(piece->pipe->type));
-    }
     *pixelpipe_flow |= (PIXELPIPE_FLOW_PROCESSED_ON_CPU | PIXELPIPE_FLOW_PROCESSED_WITH_TILING);
     *pixelpipe_flow &= ~(PIXELPIPE_FLOW_PROCESSED_ON_GPU);
   }
   else
   {
-    if(!fitting)
-      dt_print_pipe(DT_DEBUG_PIPE,
-                    "pixelpipe_process_on_CPU",
-                    piece->pipe, module->so->op, NULL, NULL,
-                    "Warning: processed without tiling even if memory requirements are not met\n");
-
     dt_print_pipe(DT_DEBUG_PIPE,
                   "pixelpipe_process_on_CPU",
-                  piece->pipe, module->so->op, roi_in, roi_out, "\n");
-
-    if(pfm_dump)
-      dt_dump_pipe_pfm(module->so->op, input,
-                       roi_in->width, roi_in->height, in_bpp,
-                       TRUE, dt_dev_pixelpipe_type_to_str(piece->pipe->type));
+                  piece->pipe, module->so->op, roi_in, roi_out,
+                  (fitting) ? "\n" : "Warning: processed without tiling even if memory requirements are not met\n");
 
     // this code section is for simplistic benchmarking via --bench-module
     if((piece->pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_EXPORT))
@@ -1220,17 +1219,17 @@ static int pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
     }
     module->process(module, piece, input, *output, roi_in, roi_out);
 
-    if(pfm_dump)
-    {
-      dt_dump_pipe_pfm(module->so->op, *output,
-                       roi_out->width, roi_out->height, bpp,
-                       FALSE, dt_dev_pixelpipe_type_to_str(piece->pipe->type));
-      _dump_pipe_pfm_diff(module->so->op, input, roi_in, in_bpp, *output, roi_out, bpp,
-                                          dt_dev_pixelpipe_type_to_str(piece->pipe->type));
-
-    }
     *pixelpipe_flow |= (PIXELPIPE_FLOW_PROCESSED_ON_CPU);
     *pixelpipe_flow &= ~(PIXELPIPE_FLOW_PROCESSED_ON_GPU | PIXELPIPE_FLOW_PROCESSED_WITH_TILING);
+  }
+
+  if(pfm_dump)
+  {
+    dt_dump_pipe_pfm(module->so->op, *output,
+                     roi_out->width, roi_out->height, bpp,
+                     FALSE, dt_dev_pixelpipe_type_to_str(piece->pipe->type));
+    _dump_pipe_pfm_diff(module->so->op, input, roi_in, in_bpp, *output, roi_out, bpp,
+                                          dt_dev_pixelpipe_type_to_str(piece->pipe->type));
   }
 
   // and save the output colorspace
@@ -1756,6 +1755,24 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         // transform to input colorspace
         if(success_opencl)
         {
+          const int cst_from = input_cst_cl;
+          const int cst_to = module->input_colorspace(module, pipe, piece);
+
+          if(darktable.unmuted & DT_DEBUG_PIPE)
+          {
+            const gboolean no_conversion = (cst_from == cst_to) || (work_profile == NULL)
+                            || (work_profile->type == DT_COLORSPACE_NONE);
+            if(!no_conversion)
+            {
+              char profiles[128] = { 0 };
+              snprintf(profiles, sizeof(profiles), "%s -> %s\n",
+                dt_iop_colorspace_to_name(cst_from), dt_iop_colorspace_to_name(cst_to));
+
+              dt_print_pipe(DT_DEBUG_PIPE,
+                  "transform colorspace CL", piece->pipe, module->so->op, &roi_in, roi_out, profiles);
+            }
+          }
+
           success_opencl =
             dt_ioppr_transform_image_colorspace_cl(module, piece->pipe->devid,
                                                    cl_mem_input, cl_mem_input,

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1307,7 +1307,7 @@ static inline gboolean _check_module_now_important(dt_dev_pixelpipe_t *pipe,
 }
 
 #ifdef HAVE_OPENCL
-static inline gboolean _opencl_pipe_is_inited(dt_dev_pixelpipe_t *pipe)
+static inline gboolean _opencl_pipe_isok(dt_dev_pixelpipe_t *pipe)
 {
   return darktable.opencl->inited
          && !darktable.opencl->stopped
@@ -1561,7 +1561,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
     **out_format = pipe->dsc = piece->dsc_out = piece->dsc_in;
 
 #ifdef HAVE_OPENCL
-    if(_opencl_pipe_is_inited(pipe) && (cl_mem_input != NULL))
+    if(_opencl_pipe_isok(pipe) && (cl_mem_input != NULL))
     {
       *cl_mem_output = cl_mem_input;
     }
@@ -1644,7 +1644,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
       = (input_format->cst != IOP_CS_RAW) ? dt_ioppr_get_pipe_work_profile_info(pipe) : NULL;
 
   /* do we have opencl at all? did user tell us to use it? did we get a resource? */
-  if(_opencl_pipe_is_inited(pipe))
+  if(_opencl_pipe_isok(pipe))
   {
     gboolean success_opencl = TRUE;
     dt_iop_colorspace_type_t input_cst_cl = input_format->cst;
@@ -2626,7 +2626,7 @@ restart:
                                               pieces, pos);
 
   // get status summary of opencl queue by checking the eventlist
-  const int oclerr = (pipe->devid >= 0) ? (dt_opencl_events_flush(pipe->devid, 1) != 0) : 0;
+  const int oclerr = (pipe->devid >= 0) ? (dt_opencl_events_flush(pipe->devid, TRUE) != 0) : 0;
 
   // Check if we had opencl errors ....  remark: opencl errors can
   // come in two ways: pipe->opencl_error is TRUE (and err is TRUE) OR


### PR DESCRIPTION
1. Added `transform colorspace` information for `-d pipe`
2. `dt_iop_colorspace_to_name()` moved to `imageop.c /the corresponding enum is defined there) and exposed
3. Fixed a subtle bug in `dt_dev_pixelpipe_process_rec()`, it does now also check for opencl not being stopped after errors

While being here
1. refactored opencl code using gboolean instead of int in some cases and removed unused function
2. code reduction for outputting pfm files in pixelpipe
3. Some reformatting 