### PR TITLE
Fix #14046 middle button zoom level

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1309,7 +1309,7 @@
     <type>bool</type>
     <default>true</default>
     <shortdescription>middle mouse button zooms to 200%</shortdescription>
-    <longdescription>when clicking the middle mouse button to zoom, the zoom level will cycle through 100%, 200% and then back to fit the screen. Otherwise it switches between fit to screen and 100%.</longdescription>
+    <longdescription>when clicking the middle mouse button to zoom, the zoom level will cycle through 100%, 200% and then back to fit the screen. Otherwise it switches between fit to screen and 100% and the 'ctrl' key can be used to control the zoom level.</longdescription>
   </dtconfig>
   <dtconfig prefs="darkroom" section="modules">
     <name>channel_display</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1304,6 +1304,13 @@
     <shortdescription>scroll down to increase mask parameters</shortdescription>
     <longdescription>when using the mouse scroll wheel to change mask parameters, scroll down to increase the mask size, feather size, opacity, brush hardness and gradient curvature\nby default scrolling up increases these parameters</longdescription>
   </dtconfig>
+  <dtconfig prefs="darkroom" section="general">
+    <name>darkroom/mouse/middle_button_cycle_zoom_to_200_percent</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>middle mouse button zooms to 200%</shortdescription>
+    <longdescription>when clicking the middle mouse button to zoom, the zoom level will cycle through 100%, 200% and then back to fit the screen. Otherwise it switches between fit to screen and 100%.</longdescription>
+  </dtconfig>
   <dtconfig prefs="darkroom" section="modules">
     <name>channel_display</name>
     <type>

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3722,14 +3722,9 @@ int button_pressed(dt_view_t *self,
     const float tscale = scale * ppd;
     closeup = 0;
 
-    const char *const key_zoom_level = "darkroom/mouse/middle_button_cycle_zoom_to_200_percent";
     // Get config so we can check if the user want to cycle through 100%->200%->FIT or
     // only switch between FIT<->100%.
-    if(!dt_conf_key_exists(key_zoom_level))
-    {
-      dt_conf_set_bool(key_zoom_level, 1); // Set default TRUE
-    }
-    const gboolean cycle_zoom_200 = dt_conf_get_bool(key_zoom_level);
+    const gboolean cycle_zoom_200 = dt_conf_get_bool("darkroom/mouse/middle_button_cycle_zoom_to_200_percent");
 
     if((tscale > 0.95f) && (tscale < 1.05f) && cycle_zoom_200) // we are at 100% and switch to 200%
     {

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3590,7 +3590,8 @@ int button_pressed(dt_view_t *self,
         const float delta_x = 0.01f;
         const float delta_y = delta_x * (float)dev->pipe->processed_width / (float)dev->pipe->processed_height;
 
-        // FIXME: here and in mouse move use to dt_lib_colorpicker_set_{box_area,point} interface? -- would require a different hack for figuring out base of the drag
+        // FIXME: here and in mouse move use to dt_lib_colorpicker_set_{box_area,point} interface? 
+        // -- would require a different hack for figuring out base of the drag
         // hack: for box pickers, these represent the "base" point being dragged
         sample->point[0] = zoom_x;
         sample->point[1] = zoom_y;
@@ -3711,19 +3712,13 @@ int button_pressed(dt_view_t *self,
   if(which == 2) // Middle mouse button
   {
     // zoom to 1:1 2:1 and back
-    int procw, proch;
     dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
     int closeup = dt_control_get_dev_closeup();
     float zoom_x = dt_control_get_dev_zoom_x();
     float zoom_y = dt_control_get_dev_zoom_y();
-    dt_dev_get_processed_size(dev, &procw, &proch);
     float scale = dt_dev_get_zoom_scale(dev, zoom, 1<<closeup, 0);
     const float ppd = darktable.gui->ppd;
     const gboolean low_ppd = (darktable.gui->ppd == 1);
-    const float mouse_off_x = x - 0.5f * dev->width;
-    const float mouse_off_y = y - 0.5f * dev->height;
-    zoom_x += mouse_off_x / (procw * scale);
-    zoom_y += mouse_off_y / (proch * scale);
     const float tscale = scale * ppd;
     closeup = 0;
 
@@ -3764,8 +3759,6 @@ int button_pressed(dt_view_t *self,
     dt_control_set_dev_zoom_scale(scale);
     dt_control_set_dev_closeup(closeup);
     scale = dt_dev_get_zoom_scale(dev, zoom, 1<<closeup, 0);
-    zoom_x -= mouse_off_x / (procw * scale);
-    zoom_y -= mouse_off_y / (proch * scale);
     dt_dev_check_zoom_bounds(dev, &zoom_x, &zoom_y, zoom, closeup, NULL, NULL);
     dt_control_set_dev_zoom(zoom);
     dt_control_set_dev_zoom_x(zoom_x);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3718,44 +3718,45 @@ int button_pressed(dt_view_t *self,
     float zoom_y = dt_control_get_dev_zoom_y();
     dt_dev_get_processed_size(dev, &procw, &proch);
     float scale = dt_dev_get_zoom_scale(dev, zoom, 1<<closeup, 0);
-    const float ppd = darktable.gui->ppd;
     const gboolean low_ppd = (darktable.gui->ppd == 1);
     const float mouse_off_x = x - 0.5f * dev->width;
     const float mouse_off_y = y - 0.5f * dev->height;
     zoom_x += mouse_off_x / (procw * scale);
     zoom_y += mouse_off_y / (proch * scale);
-    const float tscale = scale * ppd;
+    const float tscale = scale * darktable.gui->ppd;
     closeup = 0;
 
+    const float scalefit = dt_dev_get_zoom_scale(dev, DT_ZOOM_FIT, 1, 0) * darktable.gui->ppd;
+    const gboolean ctrl_pressed = dt_modifier_is(state, GDK_CONTROL_MASK);
+    
     // Get config so we can check if the user want to cycle through 100%->200%->FIT or
-    // only switch between FIT<->100%.
-    const gboolean cycle_zoom_200 = dt_conf_get_bool("darkroom/mouse/middle_button_cycle_zoom_to_200_percent");
+    // only switch between FIT<->100% unless ctrl key is pressed.
+    const gboolean cycle_zoom_200 = 
+          dt_conf_get_bool("darkroom/mouse/middle_button_cycle_zoom_to_200_percent");
 
-    if((tscale > 0.95f) && (tscale < 1.05f) && cycle_zoom_200) // we are at 100% and switch to 200%
+    // We are at 200% or above.
+    if(tscale > 1.9999f)
     {
-      zoom = DT_ZOOM_1;
-      scale = dt_dev_get_zoom_scale(dev, DT_ZOOM_1, 1.0, 0);
-      if(low_ppd) closeup = 1;
+      zoom = (cycle_zoom_200 || ctrl_pressed) ? DT_ZOOM_FIT : DT_ZOOM_1;
     }
-    else if(((tscale > 1.95f) && (tscale < 2.05f) && cycle_zoom_200) // Reset zoom switch to zoomfit
-            || (zoom != DT_ZOOM_FIT && !cycle_zoom_200))
+    else if(tscale > 0.9999f) // >= 100%
     {
-      zoom = DT_ZOOM_FIT;
-      scale = dt_dev_get_zoom_scale(dev, DT_ZOOM_FIT, 1.0, 0);
+      zoom = (cycle_zoom_200 || ctrl_pressed) ? DT_ZOOM_1 : DT_ZOOM_FIT;
+      closeup = (low_ppd && (cycle_zoom_200 || ctrl_pressed)) ? 1 : 0;
     }
-    else // other than 100 or 200% so zoom to 100 %
+    else if(((tscale > scalefit) || (tscale < scalefit)) && !cycle_zoom_200)
     {
-      if(low_ppd)
-      {
-        zoom = DT_ZOOM_1;
-        scale = dt_dev_get_zoom_scale(dev, DT_ZOOM_1, 1.0, 0);
-      }
-      else
-      {
-        zoom = DT_ZOOM_FREE;
-        scale = 1.0f / ppd;
-      }
+      zoom = ctrl_pressed ? DT_ZOOM_1 : DT_ZOOM_FIT;
     }
+    else
+    {
+      zoom = low_ppd ? DT_ZOOM_1 : DT_ZOOM_FREE;
+      if(!cycle_zoom_200)
+        closeup = low_ppd && ctrl_pressed ? 1 : 0;
+    }
+
+    scale = low_ppd ? dt_dev_get_zoom_scale(dev, zoom, 1, 0) : (1.0f / darktable.gui->ppd);
+
     dt_control_set_dev_zoom_scale(scale);
     dt_control_set_dev_closeup(closeup);
     scale = dt_dev_get_zoom_scale(dev, zoom, 1<<closeup, 0);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3590,8 +3590,7 @@ int button_pressed(dt_view_t *self,
         const float delta_x = 0.01f;
         const float delta_y = delta_x * (float)dev->pipe->processed_width / (float)dev->pipe->processed_height;
 
-        // FIXME: here and in mouse move use to dt_lib_colorpicker_set_{box_area,point} interface? 
-        // -- would require a different hack for figuring out base of the drag
+        // FIXME: here and in mouse move use to dt_lib_colorpicker_set_{box_area,point} interface? -- would require a different hack for figuring out base of the drag
         // hack: for box pickers, these represent the "base" point being dragged
         sample->point[0] = zoom_x;
         sample->point[1] = zoom_y;
@@ -3712,13 +3711,19 @@ int button_pressed(dt_view_t *self,
   if(which == 2) // Middle mouse button
   {
     // zoom to 1:1 2:1 and back
+    int procw, proch;
     dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
     int closeup = dt_control_get_dev_closeup();
     float zoom_x = dt_control_get_dev_zoom_x();
     float zoom_y = dt_control_get_dev_zoom_y();
+    dt_dev_get_processed_size(dev, &procw, &proch);
     float scale = dt_dev_get_zoom_scale(dev, zoom, 1<<closeup, 0);
     const float ppd = darktable.gui->ppd;
     const gboolean low_ppd = (darktable.gui->ppd == 1);
+    const float mouse_off_x = x - 0.5f * dev->width;
+    const float mouse_off_y = y - 0.5f * dev->height;
+    zoom_x += mouse_off_x / (procw * scale);
+    zoom_y += mouse_off_y / (proch * scale);
     const float tscale = scale * ppd;
     closeup = 0;
 
@@ -3754,6 +3759,8 @@ int button_pressed(dt_view_t *self,
     dt_control_set_dev_zoom_scale(scale);
     dt_control_set_dev_closeup(closeup);
     scale = dt_dev_get_zoom_scale(dev, zoom, 1<<closeup, 0);
+    zoom_x -= mouse_off_x / (procw * scale);
+    zoom_y -= mouse_off_y / (proch * scale);
     dt_dev_check_zoom_bounds(dev, &zoom_x, &zoom_y, zoom, closeup, NULL, NULL);
     dt_control_set_dev_zoom(zoom);
     dt_control_set_dev_zoom_x(zoom_x);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3707,7 +3707,8 @@ int button_pressed(dt_view_t *self,
     dt_control_change_cursor(GDK_HAND1);
     return 1;
   }
-  if(which == 2)
+
+  if(which == 2) // Middle mouse button
   {
     // zoom to 1:1 2:1 and back
     int procw, proch;
@@ -3725,13 +3726,24 @@ int button_pressed(dt_view_t *self,
     zoom_y += mouse_off_y / (proch * scale);
     const float tscale = scale * ppd;
     closeup = 0;
-    if((tscale > 0.95f) && (tscale < 1.05f)) // we are at 100% and switch to 200%
+
+    const char *const key_zoom_level = "darkroom/mouse/middle_button_cycle_zoom_to_200_percent";
+    // Get config so we can check if the user want to cycle through 100%->200%->FIT or
+    // only switch between FIT<->100%.
+    if(!dt_conf_key_exists(key_zoom_level))
+    {
+      dt_conf_set_bool(key_zoom_level, 1); // Set default TRUE
+    }
+    const gboolean cycle_zoom_200 = dt_conf_get_bool(key_zoom_level);
+
+    if((tscale > 0.95f) && (tscale < 1.05f) && cycle_zoom_200) // we are at 100% and switch to 200%
     {
       zoom = DT_ZOOM_1;
       scale = dt_dev_get_zoom_scale(dev, DT_ZOOM_1, 1.0, 0);
       if(low_ppd) closeup = 1;
     }
-    else if((tscale > 1.95f) && (tscale < 2.05f)) // at 200% so switch to zoomfit
+    else if(((tscale > 1.95f) && (tscale < 2.05f) && cycle_zoom_200) // Reset zoom switch to zoomfit
+            || (zoom != DT_ZOOM_FIT && !cycle_zoom_200))
     {
       zoom = DT_ZOOM_FIT;
       scale = dt_dev_get_zoom_scale(dev, DT_ZOOM_FIT, 1.0, 0);


### PR DESCRIPTION
Fix #14046 

1. Added option for the user to change middle mouse button zoom level.
2. Removed redundant variables and calculations.
3. Some reformatting.

This is my first 'Pull request' so if I have made any mistake(s) let me know.