### PR TITLE
New pixelpipe cache disabling option

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -140,6 +140,7 @@ static int usage(const char *argv0)
 #ifdef HAVE_OPENCL
   printf("  --disable-opencl\n");
 #endif
+  printf("  --disable-pipecache\n");
   printf("  --dump-pfm <modulea,moduleb>\n");
   printf("  --dump-pipe <modulea,moduleb>\n");
   printf("  --bench-module <modulea,moduleb>\n");
@@ -581,7 +582,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 #endif
 
   darktable.num_openmp_threads = dt_get_num_procs();
-
+  darktable.pipe_cache = TRUE;
   darktable.unmuted = 0;
   GSList *config_override = NULL;
   for(int k = 1; k < argc; k++)
@@ -967,6 +968,11 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 #ifdef HAVE_OPENCL
         exclude_opencl = TRUE;
 #endif
+        argv[k] = NULL;
+      }
+      else if(!strcmp(argv[k], "--disable-pipecache"))
+      {
+        darktable.pipe_cache = FALSE;
         argv[k] = NULL;
       }
       else if(!strcmp(argv[k], "--"))

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -356,6 +356,7 @@ typedef struct darktable_t
   GList *themes;
   int32_t unmuted_signal_dbg_acts;
   gboolean unmuted_signal_dbg[DT_SIGNAL_COUNT];
+  gboolean pipe_cache;
   GTimeZone *utc_tz;
   GDateTime *origin_gdt;
   struct dt_sys_resources_t dtresources;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -177,14 +177,14 @@ gboolean dt_dev_pixelpipe_init_dummy(dt_dev_pixelpipe_t *pipe,
 
 gboolean dt_dev_pixelpipe_init_preview(dt_dev_pixelpipe_t *pipe)
 {
-  const gboolean res = dt_dev_pixelpipe_init_cached(pipe, 0, 12, 0);
+  const gboolean res = dt_dev_pixelpipe_init_cached(pipe, 0, darktable.pipe_cache ? 12 : 2, 0);
   pipe->type = DT_DEV_PIXELPIPE_PREVIEW;
   return res;
 }
 
 gboolean dt_dev_pixelpipe_init_preview2(dt_dev_pixelpipe_t *pipe)
 {
-  const gboolean res = dt_dev_pixelpipe_init_cached(pipe, 0, 5, 0);
+  const gboolean res = dt_dev_pixelpipe_init_cached(pipe, 0, darktable.pipe_cache ? 5 : 2, 0);
   pipe->type = DT_DEV_PIXELPIPE_PREVIEW2;
   return res;
 }
@@ -192,7 +192,7 @@ gboolean dt_dev_pixelpipe_init_preview2(dt_dev_pixelpipe_t *pipe)
 gboolean dt_dev_pixelpipe_init(dt_dev_pixelpipe_t *pipe)
 {
   const size_t csize = MAX(64*1024*1024, darktable.dtresources.mipmap_memory / 4);
-  const gboolean res = dt_dev_pixelpipe_init_cached(pipe, 0, 64, csize);
+  const gboolean res = dt_dev_pixelpipe_init_cached(pipe, 0, darktable.pipe_cache ? 64 : 2, csize);
   pipe->type = DT_DEV_PIXELPIPE_FULL;
   return res;
 }


### PR DESCRIPTION
The pretty effective pixelpipe cache 
1. sometimes makes it hard to reproduce a reported issue
2. might itself introduce problems.

This pr introduces a new commandline debugging option `--disable-pipecache`

While the pipe caches are initialized this flag is checked and if disabled only two cachelines per pipe are allowed.
This is the same as for `export` pipe to allow at least a proper buffer swap.
