### PR TITLE
OpenCL and dynlib maintenance & fixes

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1296,8 +1296,8 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 #endif
 
   darktable.opencl = (dt_opencl_t *)calloc(1, sizeof(dt_opencl_t));
-#ifdef HAVE_OPENCL
   dt_opencl_init(darktable.opencl, exclude_opencl, print_statistics);
+#ifdef HAVE_OPENCL
   dt_opencl_update_settings();
 #endif
 

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -572,9 +572,11 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   darktable.tmp_directory = NULL;
   darktable.bench_module = NULL;
 
+  gboolean exclude_opencl = TRUE;
+  gboolean print_statistics = FALSE;
 #ifdef HAVE_OPENCL
-  gboolean exclude_opencl = FALSE;
-  gboolean print_statistics = (strstr(argv[0], "darktable-cltest") == NULL);
+  exclude_opencl = FALSE;
+  print_statistics = (strstr(argv[0], "darktable-cltest") == NULL);
 #endif
 
 #ifdef USE_LUA

--- a/src/common/dlopencl.c
+++ b/src/common/dlopencl.c
@@ -18,9 +18,9 @@
 
 #ifdef HAVE_OPENCL
 
+#include "common/dynload.h"
 #include "common/dlopencl.h"
 #include "common/darktable.h"
-#include "common/dynload.h"
 
 #include <assert.h>
 #include <signal.h>
@@ -41,7 +41,7 @@ static const char *ocllib[] = { "libOpenCL", "libOpenCL.so", "libOpenCL.so.1", N
 void dt_dlopencl_noop(void)
 {
   /* we should normally never get here */
-  dt_print(DT_DEBUG_OPENCL, "dt_dlopencl internal error: unsupported function call\n");
+  dt_print(DT_DEBUG_ALWAYS, "dt_dlopencl internal error: unsupported function call\n");
   raise(SIGABRT);
 }
 
@@ -50,12 +50,11 @@ void dt_dlopencl_noop(void)
 dt_dlopencl_t *dt_dlopencl_init(const char *name)
 {
   dt_gmodule_t *module = NULL;
-  dt_dlopencl_t *ocl;
+  dt_dlopencl_t *ocl = NULL;
   const char *library = NULL;
-  int success;
 
   /* check if our platform supports gmodules */
-  success = dt_gmodule_supported();
+  gboolean success = dt_gmodule_supported();
   if(!success) return NULL;
 
   /* try to load library. if a name is given check only that library - else iterate over default names. */
@@ -64,9 +63,9 @@ dt_dlopencl_t *dt_dlopencl_init(const char *name)
     library = name;
     module = dt_gmodule_open(library);
     if(module == NULL)
-      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[dt_dlopencl_init] could not find opencl runtime library '%s'\n", library);
+      dt_print(DT_DEBUG_OPENCL, "[dt_dlopencl_init] could not find specified opencl runtime library '%s'\n", library);
     else
-      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[dt_dlopencl_init] found opencl runtime library '%s'\n", library);
+      dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[dt_dlopencl_init] found specified opencl runtime library '%s'\n", library);
   }
   else
   {
@@ -76,43 +75,48 @@ dt_dlopencl_t *dt_dlopencl_init(const char *name)
       library = *iter;
       module = dt_gmodule_open(library);
       if(module == NULL)
-        dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[dt_dlopencl_init] could not find opencl runtime library '%s'\n", library);
+        dt_print(DT_DEBUG_OPENCL, "[dt_dlopencl_init] could not find default opencl runtime library '%s'\n", library);
       else
-        dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[dt_dlopencl_init] found opencl runtime library '%s'\n", library);
+        dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[dt_dlopencl_init] found default opencl runtime library '%s'\n", library);
       iter++;
     }
   }
 
   if(module == NULL)
     return NULL;
-  else
+
+  /* now bind symbols */
+  ocl = (dt_dlopencl_t *)malloc(sizeof(dt_dlopencl_t));
+
+  if(ocl == NULL)
   {
-    /* now bind symbols */
+    free(module);
+    return NULL;
+  }
+
+  ocl->symbols = (dt_dlopencl_symbols_t *)calloc(1, sizeof(dt_dlopencl_symbols_t));
+
+  if(ocl->symbols == NULL)
+  {
+    free(ocl);
+    free(module);
+    return NULL;
+  }
+
+  ocl->library = module->library;
+
+  /* assign noop function as a default to each function pointer */
+  void (**slist)(void) = (void (**)(void))ocl->symbols;
+
+  success = FALSE;
+
+  /* sanity check against padding */
+  if(sizeof(dt_dlopencl_symbols_t) % sizeof(void (*)(void)) == 0)
+  {
+    for(int k = 0; k < sizeof(dt_dlopencl_symbols_t) / sizeof(void (*)(void)); k++)
+      slist[k] = dt_dlopencl_noop;
+
     success = TRUE;
-    ocl = (dt_dlopencl_t *)malloc(sizeof(dt_dlopencl_t));
-
-    if(ocl == NULL)
-    {
-      free(module);
-      return NULL;
-    }
-
-    ocl->symbols = (dt_dlopencl_symbols_t *)calloc(1, sizeof(dt_dlopencl_symbols_t));
-
-    if(ocl->symbols == NULL)
-    {
-      free(ocl);
-      free(module);
-      return NULL;
-    }
-
-    ocl->library = module->library;
-
-    /* assign noop function as a default to each function pointer */
-    void (**slist)(void) = (void (**)(void))ocl->symbols;
-    /* sanity check against padding */
-    if(sizeof(dt_dlopencl_symbols_t) % sizeof(void (*)(void)) == 0)
-      for(int k = 0; k < sizeof(dt_dlopencl_symbols_t) / sizeof(void (*)(void)); k++) slist[k] = dt_dlopencl_noop;
 
     /* only bind needed symbols */
     success = success && dt_gmodule_symbol(module, "clGetPlatformIDs",
@@ -202,12 +206,12 @@ dt_dlopencl_t *dt_dlopencl_init(const char *name)
                                            (void (**)(void)) & ocl->symbols->dt_clGetMemObjectInfo);
     success = success && dt_gmodule_symbol(module, "clGetImageInfo",
                                            ((void (**)(void)) & ocl->symbols->dt_clGetImageInfo));
-
-    ocl->have_opencl = success;
-
-    if(!success)
-      dt_print(DT_DEBUG_OPENCL, "[opencl_init] could not load all required symbols from library\n");
   }
+
+  ocl->have_opencl = success;
+
+  if(!success)
+    dt_print(DT_DEBUG_OPENCL, "[opencl_init] could not load all required symbols from library\n");
 
   free(module);
 

--- a/src/common/dlopencl.h
+++ b/src/common/dlopencl.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2020 darktable developers.
+    Copyright (C) 2011-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -221,7 +221,7 @@ typedef struct dt_dlopencl_symbols_t
 
 typedef struct dt_dlopencl_t
 {
-  int have_opencl;
+  gboolean have_opencl;
   dt_dlopencl_symbols_t *symbols;
   char *library;
 } dt_dlopencl_t;

--- a/src/common/dynload.c
+++ b/src/common/dynload.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2020 darktable developers.
+    Copyright (C) 2011-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -24,7 +24,6 @@
 #include <string.h>
 #else //!__APPLE__
 #include <dlfcn.h>
-#include <glib.h>
 #endif //!__APPLE__
 
 #include "common/dynload.h"
@@ -32,11 +31,9 @@
 
 #ifndef __APPLE__
 /* check if gmodules is supported on this platform */
-int dt_gmodule_supported(void)
+gboolean dt_gmodule_supported(void)
 {
-  int success = g_module_supported();
-
-  return success;
+  return g_module_supported();
 }
 
 
@@ -71,16 +68,14 @@ dt_gmodule_t *dt_gmodule_open(const char *library)
 }
 
 
-/* get pointer to symbol */
-int dt_gmodule_symbol(dt_gmodule_t *module, const char *name, void (**pointer)(void))
+/* get pointer to symbol and return flag in case off success */
+gboolean dt_gmodule_symbol(dt_gmodule_t *module, const char *name, void (**pointer)(void))
 {
-  int success = g_module_symbol(module->gmodule, name, (gpointer)pointer);
-
-  return success;
+  return g_module_symbol(module->gmodule, name, (gpointer)pointer);
 }
 #else //!__APPLE__
 /* check if gmodules is supported on this platform */
-int dt_gmodule_supported(void)
+gboolean dt_gmodule_supported(void)
 {
   return TRUE;
 }
@@ -103,7 +98,7 @@ dt_gmodule_t *dt_gmodule_open(const char *library)
 }
 
 /* get pointer to symbol */
-int dt_gmodule_symbol(dt_gmodule_t *module, const char *name, void (**pointer)(void))
+gboolean dt_gmodule_symbol(dt_gmodule_t *module, const char *name, void (**pointer)(void))
 {
   *pointer = dlsym(module->gmodule, name);
 

--- a/src/common/dynload.h
+++ b/src/common/dynload.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2020 darktable developers.
+    Copyright (C) 2011-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -24,8 +24,9 @@
 #include "config.h"
 #endif
 
-#ifndef __APPLE__
 #include <glib.h>
+
+#ifndef __APPLE__
 #include <gmodule.h>
 #endif //!__APPLE__
 
@@ -41,13 +42,13 @@ typedef struct dt_gmodule_t
 
 
 /* check if gmodules is supported on this platform */
-int dt_gmodule_supported(void);
+gboolean dt_gmodule_supported(void);
 
 /* dynamically load library */
 dt_gmodule_t *dt_gmodule_open(const char *);
 
 /* get pointer to function */
-int dt_gmodule_symbol(dt_gmodule_t *, const char *, void (**)(void));
+gboolean dt_gmodule_symbol(dt_gmodule_t *, const char *, void (**)(void));
 
 #endif // HAVE_OPENCL
 

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -49,9 +49,13 @@
 #include <sys/stat.h>
 #include <zlib.h>
 
-static const char *dt_opencl_get_vendor_by_id(unsigned int id);
+static const char *_opencl_get_vendor_by_id(unsigned int id);
 static float _opencl_benchmark_gpu(const int devid, const size_t width, const size_t height, const int count, const float sigma);
 static float _opencl_benchmark_cpu(const size_t width, const size_t height, const int count, const float sigma);
+static gboolean _opencl_load_program(const int dev, const int prog, const char *filename, const char *binname,
+                           const char *cachedir, char *md5sum, char **includemd5, int *loaded_cached);
+static gboolean _opencl_build_program(const int dev, const int prog, const char *binname, const char *cachedir,
+                            char *md5sum, int loaded_cached);
 static char *_ascii_str_canonical(const char *in, char *out, int maxlen);
 /** parse a single token of priority string and store priorities in priority_list */
 static void _opencl_priority_parse(dt_opencl_t *cl, char *configstr, int *priority_list, int *mandatory);
@@ -114,24 +118,25 @@ const char *cl_errstr(cl_int error)
     case CL_INVALID_ARG_SIZE: return "CL_INVALID_ARG_SIZE";
     case CL_INVALID_KERNEL_ARGS: return "CL_INVALID_KERNEL_ARGS";
     case CL_INVALID_WORK_DIMENSION: return "CL_INVALID_WORK_DIMENSION";
-    case CL_INVALID_WORK_GROUP_SIZE: return"CL_INVALID_WORK_GROUP_SIZE";    
-    case CL_INVALID_WORK_ITEM_SIZE: return"CL_INVALID_WORK_ITEM_SIZE";    
-    case CL_INVALID_GLOBAL_OFFSET: return"CL_INVALID_GLOBAL_OFFSET";    
-    case CL_INVALID_EVENT_WAIT_LIST: return"CL_INVALID_EVENT_WAIT_LIST";    
-    case CL_INVALID_EVENT: return"CL_INVALID_EVENT";    
-    case CL_INVALID_OPERATION: return"CL_INVALID_OPERATION";    
-    case CL_INVALID_GL_OBJECT: return"CL_INVALID_GL_OBJECT";    
-    case CL_INVALID_BUFFER_SIZE: return"CL_INVALID_BUFFER_SIZE";    
-    case CL_INVALID_MIP_LEVEL: return"CL_INVALID_MIP_LEVEL";    
-    case CL_INVALID_GLOBAL_WORK_SIZE: return"CL_INVALID_GLOBAL_WORK_SIZE";    
-    case CL_INVALID_PROPERTY: return"CL_INVALID_PROPERTY";    
-    case CL_INVALID_IMAGE_DESCRIPTOR: return"CL_INVALID_IMAGE_DESCRIPTOR";    
-    case CL_INVALID_COMPILER_OPTIONS: return"CL_INVALID_COMPILER_OPTIONS";    
-    case CL_INVALID_LINKER_OPTIONS: return"CL_INVALID_LINKER_OPTIONS";    
+    case CL_INVALID_WORK_GROUP_SIZE: return"CL_INVALID_WORK_GROUP_SIZE";
+    case CL_INVALID_WORK_ITEM_SIZE: return"CL_INVALID_WORK_ITEM_SIZE";
+    case CL_INVALID_GLOBAL_OFFSET: return"CL_INVALID_GLOBAL_OFFSET";
+    case CL_INVALID_EVENT_WAIT_LIST: return"CL_INVALID_EVENT_WAIT_LIST";
+    case CL_INVALID_EVENT: return"CL_INVALID_EVENT";
+    case CL_INVALID_OPERATION: return"CL_INVALID_OPERATION";
+    case CL_INVALID_GL_OBJECT: return"CL_INVALID_GL_OBJECT";
+    case CL_INVALID_BUFFER_SIZE: return"CL_INVALID_BUFFER_SIZE";
+    case CL_INVALID_MIP_LEVEL: return"CL_INVALID_MIP_LEVEL";
+    case CL_INVALID_GLOBAL_WORK_SIZE: return"CL_INVALID_GLOBAL_WORK_SIZE";
+    case CL_INVALID_PROPERTY: return"CL_INVALID_PROPERTY";
+    case CL_INVALID_IMAGE_DESCRIPTOR: return"CL_INVALID_IMAGE_DESCRIPTOR";
+    case CL_INVALID_COMPILER_OPTIONS: return"CL_INVALID_COMPILER_OPTIONS";
+    case CL_INVALID_LINKER_OPTIONS: return"CL_INVALID_LINKER_OPTIONS";
     case CL_INVALID_DEVICE_PARTITION_COUNT: return"CL_INVALID_DEVICE_PARTITION_COUNT";
     case DT_OPENCL_DEFAULT_ERROR: return "DT_OPENCL_DEFAULT_ERROR";
     case DT_OPENCL_SYSMEM_ALLOCATION: return "DT_OPENCL_SYSMEM_ALLOCATION";
     case DT_OPENCL_PROCESS_CL: return "DT_OPENCL_PROCESS_CL";
+    case DT_OPENCL_NODEVICE: return "DT_OPENCL_NODEVICE";
     default: return "Unknown OpenCL error";
   }
 }
@@ -141,6 +146,18 @@ static inline void _check_clmem_err(const int devid, const cl_int err)
   if((err == CL_MEM_OBJECT_ALLOCATION_FAILURE) || (err == CL_OUT_OF_RESOURCES))
   darktable.opencl->dev[devid].runtime_error |= DT_OPENCL_TUNE_MEMSIZE;
 }
+
+static inline gboolean _cl_running(void)
+{
+  dt_opencl_t *cl = darktable.opencl;
+  return cl->inited && cl->enabled && !cl->stopped;
+} 
+
+static inline gboolean _cldev_running(const int devid)
+{
+  dt_opencl_t *cl = darktable.opencl;
+  return cl->inited && cl->enabled && !cl->stopped && (devid>=0);
+} 
 
 int dt_opencl_get_device_info(
         dt_opencl_t *cl,
@@ -204,22 +221,22 @@ error:
   return err;
 }
 
-int dt_opencl_avoid_atomics(const int devid)
+gboolean dt_opencl_avoid_atomics(const int devid)
 {
   dt_opencl_t *cl = darktable.opencl;
-  return (!cl->inited || devid < 0) ? 0 : cl->dev[devid].avoid_atomics;
+  return (!_cldev_running(devid)) ? FALSE : (cl->dev[devid].avoid_atomics ? TRUE : FALSE);
 }
 
 int dt_opencl_micro_nap(const int devid)
 {
   dt_opencl_t *cl = darktable.opencl;
-  return (!cl->inited || devid < 0) ? 0 : cl->dev[devid].micro_nap;
+  return (!_cldev_running(devid)) ? 0 : cl->dev[devid].micro_nap;
 }
 
 gboolean dt_opencl_use_pinned_memory(const int devid)
 {
   dt_opencl_t *cl = darktable.opencl;
-  if(!cl->inited || devid < 0) return FALSE;
+  if(!_cldev_running(devid)) return FALSE;
   return (cl->dev[devid].tuneactive & DT_OPENCL_TUNE_PINNED);
 }
 
@@ -231,14 +248,14 @@ void dt_opencl_write_device_config(const int devid)
   gchar dat[512] = { 0 };
   g_snprintf(key, 254, "%s%s", DT_CLDEVICE_HEAD, cl->dev[devid].cname);
   g_snprintf(dat, 510, "%i %i %i %i %i %i %i %i %f %.3f",
-    cl->dev[devid].avoid_atomics,
+    (cl->dev[devid].avoid_atomics) ? 1 : 0,
     cl->dev[devid].micro_nap,
     cl->dev[devid].pinned_memory & (DT_OPENCL_PINNING_ON | DT_OPENCL_PINNING_DISABLED),
     cl->dev[devid].clroundup_wd,
     cl->dev[devid].clroundup_ht,
     cl->dev[devid].event_handles,
-    cl->dev[devid].asyncmode & 1,
-    cl->dev[devid].disabled & 1,
+    (cl->dev[devid].asyncmode) ? 1 : 0,
+    (cl->dev[devid].disabled) ? 1 : 0,
     cl->dev[devid].benchmark,
     cl->dev[devid].advantage);
   dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[dt_opencl_write_device_config] writing data '%s' for '%s'\n", dat, key);
@@ -256,9 +273,10 @@ gboolean dt_opencl_read_device_config(const int devid)
 {
   if(devid < 0) return FALSE;
   dt_opencl_t *cl = darktable.opencl;
+  dt_opencl_device_t *cldid = &cl->dev[devid];
   gchar key[256] = { 0 };
   g_snprintf(key, 254, "%s%s", DT_CLDEVICE_HEAD, cl->dev[devid].cname);
-  
+
   const gboolean existing_device = dt_conf_key_not_empty(key);
   gboolean safety_ok = TRUE;
   if(existing_device)
@@ -282,16 +300,16 @@ gboolean dt_opencl_read_device_config(const int devid)
 
     if(safety_ok)
     {
-      cl->dev[devid].avoid_atomics = avoid_atomics;
-      cl->dev[devid].micro_nap = micro_nap;
-      cl->dev[devid].pinned_memory = pinned_memory;
-      cl->dev[devid].clroundup_wd = wd;
-      cl->dev[devid].clroundup_ht = ht;
-      cl->dev[devid].event_handles = event_handles;
-      cl->dev[devid].asyncmode = asyncmode;
-      cl->dev[devid].disabled = disabled;
-      cl->dev[devid].benchmark = benchmark;
-      cl->dev[devid].advantage = advantage;
+      cldid->avoid_atomics = avoid_atomics;
+      cldid->micro_nap = micro_nap;
+      cldid->pinned_memory = pinned_memory;
+      cldid->clroundup_wd = wd;
+      cldid->clroundup_ht = ht;
+      cldid->event_handles = event_handles;
+      cldid->asyncmode = asyncmode;
+      cldid->disabled = disabled;
+      cldid->benchmark = benchmark;
+      cldid->advantage = advantage;
     }
     else // if there is something wrong with the found conf key reset to defaults
     {
@@ -299,32 +317,33 @@ gboolean dt_opencl_read_device_config(const int devid)
     }
   }
   // do some safety housekeeping
-  cl->dev[devid].avoid_atomics &= 1;
-  cl->dev[devid].pinned_memory &= (DT_OPENCL_PINNING_ON | DT_OPENCL_PINNING_DISABLED);
-  if((cl->dev[devid].micro_nap < 0) || (cl->dev[devid].micro_nap > 1000000))
-    cl->dev[devid].micro_nap = 250;
-  if((cl->dev[devid].clroundup_wd < 2) || (cl->dev[devid].clroundup_wd > 512))
-    cl->dev[devid].clroundup_wd = 16;
-  if((cl->dev[devid].clroundup_ht < 2) || (cl->dev[devid].clroundup_ht > 512))
-    cl->dev[devid].clroundup_ht = 16;
-  if(cl->dev[devid].event_handles < 0)
-    cl->dev[devid].event_handles = 0x40000000;
-  cl->dev[devid].benchmark = fminf(1e6, fmaxf(0.0f, cl->dev[devid].benchmark));
 
-  cl->dev[devid].use_events = (cl->dev[devid].event_handles != 0) ? 1 : 0;
-  cl->dev[devid].asyncmode &= 1;
-  cl->dev[devid].disabled &= 1;
+  cldid->avoid_atomics = cldid->avoid_atomics ? TRUE : FALSE;
+  cldid->pinned_memory &= (DT_OPENCL_PINNING_ON | DT_OPENCL_PINNING_DISABLED);
+  if((cldid->micro_nap < 0) || (cldid->micro_nap > 1000000))
+    cldid->micro_nap = 250;
+  if((cldid->clroundup_wd < 2) || (cldid->clroundup_wd > 512))
+    cldid->clroundup_wd = 16;
+  if((cldid->clroundup_ht < 2) || (cldid->clroundup_ht > 512))
+    cldid->clroundup_ht = 16;
+  if(cldid->event_handles < 0)
+    cldid->event_handles = 0x40000000;
+  cldid->benchmark = fminf(1e6, fmaxf(0.0f, cl->dev[devid].benchmark));
 
-  cl->dev[devid].advantage = fmaxf(0.0f, cl->dev[devid].advantage);
+  cldid->use_events = cldid->event_handles ? TRUE : FALSE;
+  cldid->asyncmode =  cldid->asyncmode ? TRUE : FALSE;
+  cldid->disabled = cldid->disabled ? TRUE : FALSE;
+
+  cldid->advantage = fmaxf(0.0f, cldid->advantage);
 
   // Also take care of extended device data, these are not only device specific but also depend on the devid
-  g_snprintf(key, 254, "%s%s_id%i", DT_CLDEVICE_HEAD, cl->dev[devid].cname, devid);
+  g_snprintf(key, 254, "%s%s_id%i", DT_CLDEVICE_HEAD, cldid->cname, devid);
   if(dt_conf_key_not_empty(key))
   {
     const gchar *dat = dt_conf_get_string_const(key);
     int forced_headroom;
     sscanf(dat, "%i", &forced_headroom);
-    if(forced_headroom > 0) cl->dev[devid].forced_headroom = forced_headroom;
+    if(forced_headroom > 0) cldid->forced_headroom = forced_headroom;
   }
   else // this is used if updating to 4.0 or fresh installs; see commenting _opencl_get_unused_device_mem()
     cl->dev[devid].forced_headroom = 400;
@@ -342,13 +361,12 @@ static float dt_opencl_device_perfgain(const int devid)
 } 
 
 // returns 0 if all ok or an error if we failed to init this device
-static int dt_opencl_device_init(
-        dt_opencl_t *cl,
-        const int dev,
-        cl_device_id *devices,
-        const int k)
+static gboolean _opencl_device_init(dt_opencl_t *cl,
+                                    const int dev,
+                                    cl_device_id *devices,
+                                    const int k)
 {
-  int res;
+  gboolean res = FALSE;
   cl_int err;
 
   memset(cl->dev[dev].program, 0x0, sizeof(cl_program) * DT_OPENCL_MAX_PROGRAMS);
@@ -383,13 +401,13 @@ static int dt_opencl_device_init(
   cl->dev[dev].clroundup_ht = 16;
   cl->dev[dev].benchmark = 0.0f;
   cl->dev[dev].advantage = 0.0f;
-  cl->dev[dev].use_events = 1;
+  cl->dev[dev].use_events = TRUE;
   cl->dev[dev].event_handles = 128;
-  cl->dev[dev].asyncmode = 0;
-  cl->dev[dev].disabled = 0;
+  cl->dev[dev].asyncmode = FALSE;
+  cl->dev[dev].disabled = FALSE;
   cl->dev[dev].forced_headroom = 0;
-  cl->dev[dev].tuneactive = 0;
-  cl->dev[dev].runtime_error = 0;
+  cl->dev[dev].tuneactive = DT_OPENCL_TUNE_NOTHING;
+  cl->dev[dev].runtime_error = DT_OPENCL_TUNE_NOTHING;
   cl_device_id devid = cl->dev[dev].devid = devices[k];
 
   char *infostr = NULL;
@@ -436,7 +454,7 @@ static int dt_opencl_device_init(
   if(err != CL_SUCCESS)
   {
     dt_print_nts(DT_DEBUG_OPENCL, "  *** could not get vendor name of device %d: %s\n", k, cl_errstr(err));
-    res = -1;
+    res = TRUE;
     goto end;
   }
 
@@ -446,7 +464,7 @@ static int dt_opencl_device_init(
   if(err != CL_SUCCESS)
   {
     dt_print_nts(DT_DEBUG_OPENCL, "  *** could not get device name of device %d: %s\n", k, cl_errstr(err));
-    res = -1;
+    res = TRUE;
     goto end;
   }
 
@@ -493,8 +511,8 @@ static int dt_opencl_device_init(
   if(err != CL_SUCCESS)
   {
     dt_print_nts(DT_DEBUG_OPENCL, "   *** driver version not available *** %s\n", cl_errstr(err));   
-    res = -1;
-    cl->dev[dev].disabled |= 1;
+    res = TRUE;
+    cl->dev[dev].disabled |= TRUE;
     goto end;
   }
 
@@ -502,8 +520,8 @@ static int dt_opencl_device_init(
   if(err != CL_SUCCESS)
   {
     dt_print_nts(DT_DEBUG_OPENCL, "   *** device version not available *** %s\n", cl_errstr(err));   
-    res = -1;
-    cl->dev[dev].disabled |= 1;
+    res = TRUE;
+    cl->dev[dev].disabled |= TRUE;
     goto end;
   }
 
@@ -516,9 +534,6 @@ static int dt_opencl_device_init(
   (cl->dlocl->symbols->dt_clGetDeviceInfo)(devid, CL_DEVICE_MAX_MEM_ALLOC_SIZE, sizeof(cl_ulong),
                                            &(cl->dev[dev].max_mem_alloc), NULL);
   (cl->dlocl->symbols->dt_clGetDeviceInfo)(devid, CL_DEVICE_ENDIAN_LITTLE, sizeof(cl_bool), &little_endian, NULL);
-
-  cl->dev[dev].cltype = (unsigned int)type;
-
 
   if(!strncasecmp(vendor, "NVIDIA", 6))
   {
@@ -544,31 +559,31 @@ static int dt_opencl_device_init(
   if(is_cpu_device && newdevice)
   {
     dt_print_nts(DT_DEBUG_OPENCL, "   *** discarding new device as emulated by CPU ***\n");   
-    cl->dev[dev].disabled |= 1;
-    res = -1;
+    cl->dev[dev].disabled |= TRUE;
+    res = TRUE;
     goto end;
   }
 
   if(!device_available)
   {
     dt_print_nts(DT_DEBUG_OPENCL, "   *** device is not available ***\n");   
-    res = -1;
+    res = TRUE;
     goto end;
   }
 
   if(!image_support)
   {
     dt_print_nts(DT_DEBUG_OPENCL, "   *** The OpenCL driver doesn't provide image support. See also 'clinfo' output ***\n");   
-    res = -1;
-    cl->dev[dev].disabled |= 1;
+    res = TRUE;
+    cl->dev[dev].disabled |= TRUE;
     goto end;
   }
 
   if(!little_endian)
   {
     dt_print_nts(DT_DEBUG_OPENCL, "   *** device is not little endian ***\n");   
-    res = -1;
-    cl->dev[dev].disabled |= 1;
+    res = TRUE;
+    cl->dev[dev].disabled |= TRUE;
     goto end;
   }
 
@@ -578,12 +593,12 @@ static int dt_opencl_device_init(
   {
     dt_print_nts(DT_DEBUG_OPENCL, "   *** insufficient global memory (%" PRIu64 "MB) ***\n", 
                                    cl->dev[dev].max_global_mem / 1024 / 1024);   
-    res = -1;
-    cl->dev[dev].disabled |= 1;
+    res = TRUE;
+    cl->dev[dev].disabled |= TRUE;
     goto end;
   }
 
-  cl->dev[dev].vendor = strdup(dt_opencl_get_vendor_by_id(vendor_id));
+  cl->dev[dev].vendor = strdup(_opencl_get_vendor_by_id(vendor_id));
 
   const gboolean is_blacklisted = dt_opencl_check_driver_blacklist(deviceversion);
 
@@ -592,10 +607,10 @@ static int dt_opencl_device_init(
   {
     // To keep installations we look for the old blacklist conf key
     const gboolean old_blacklist = dt_conf_get_bool("opencl_disable_drivers_blacklist");
-    cl->dev[dev].disabled |= (old_blacklist) ? 0 : 1;
+    cl->dev[dev].disabled |= (old_blacklist) ? FALSE : TRUE;
     if(cl->dev[dev].disabled)
       dt_print_nts(DT_DEBUG_OPENCL, "   *** new device is blacklisted ***\n");   
-    res = -1;
+    res = TRUE;
     goto end;
   }
 
@@ -620,8 +635,8 @@ static int dt_opencl_device_init(
   else
   {
     dt_print_nts(DT_DEBUG_OPENCL, "   *** could not get maximum work item sizes ***\n");
-    res = -1;
-    cl->dev[dev].disabled |= 1;
+    res = TRUE;
+    cl->dev[dev].disabled |= TRUE;
     goto end;
   }
 
@@ -645,7 +660,7 @@ static int dt_opencl_device_init(
   if(cl->dev[dev].disabled)
   {
     dt_print_nts(DT_DEBUG_OPENCL, "   *** marked as disabled ***\n");
-    res = -1;
+    res = TRUE;
     goto end;
   }
 
@@ -655,7 +670,7 @@ static int dt_opencl_device_init(
   if(err != CL_SUCCESS)
   {
     dt_print_nts(DT_DEBUG_OPENCL, "   *** could not create context *** %s\n", cl_errstr(err));
-    res = -1;
+    res = TRUE;
     goto end;
   }
   // create a command queue for first device the context reported
@@ -664,7 +679,7 @@ static int dt_opencl_device_init(
   if(err != CL_SUCCESS)
   {
     dt_print_nts(DT_DEBUG_OPENCL, "   *** could not create command queue *** %s\n", cl_errstr(err));
-    res = -1;
+    res = TRUE;
     goto end;
   }
 
@@ -688,7 +703,7 @@ static int dt_opencl_device_init(
   if(g_mkdir_with_parents(cachedir, 0700) == -1)
   {
     dt_print_nts(DT_DEBUG_OPENCL, "   *** failed to create kernel directory `%s' ***\n", cachedir);
-    res = -1;
+    res = TRUE;
     goto end;
   }
 
@@ -734,7 +749,7 @@ static int dt_opencl_device_init(
   cl->dev[dev].options = g_strdup_printf("-w %s %s -D%s=1 -I%s",
                             my_option,
                             (cl->dev[dev].nvidia_sm_20 ? " -DNVIDIA_SM_20=1" : ""),
-                            dt_opencl_get_vendor_by_id(vendor_id), escapedkerneldir);
+                            _opencl_get_vendor_by_id(vendor_id), escapedkerneldir);
 
   dt_print_nts(DT_DEBUG_OPENCL, "   CL COMPILER OPTION:       %s\n", my_option);
 
@@ -805,13 +820,13 @@ static int dt_opencl_device_init(
       dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[dt_opencl_device_init] testing program `%s' ..\n", programname);
       int loaded_cached;
       char md5sum[33];
-      if(dt_opencl_load_program(dev, prog, filename, binname, cachedir, md5sum, includemd5, &loaded_cached)
-         && dt_opencl_build_program(dev, prog, binname, cachedir, md5sum, loaded_cached))
+      if(_opencl_load_program(dev, prog, filename, binname, cachedir, md5sum, includemd5, &loaded_cached)
+         && _opencl_build_program(dev, prog, binname, cachedir, md5sum, loaded_cached))
       {
         dt_print(DT_DEBUG_OPENCL, "[dt_opencl_device_init] failed to compile program `%s'!\n", programname);
         fclose(f);
         g_strfreev(tokens);
-        res = -1;
+        res = TRUE;
         goto end;
       }
 
@@ -826,11 +841,11 @@ static int dt_opencl_device_init(
   else
   {
     dt_print_nts(DT_DEBUG_OPENCL, "[dt_opencl_device_init] could not open `%s'!\n", filename);
-    res = -1;
+    res = TRUE;
     goto end;
   }
   for(int n = 0; n < DT_OPENCL_MAX_INCLUDES; n++) g_free(includemd5[n]);
-  res = 0;
+  res = FALSE;
 
 end:
   // we always write the device config to keep track of disabled devices
@@ -862,9 +877,9 @@ void dt_opencl_init(
         const gboolean print_statistics)
 {
   dt_pthread_mutex_init(&cl->lock, NULL);
-  cl->inited = 0;
-  cl->enabled = 0;
-  cl->stopped = 0;
+  cl->inited = FALSE;
+  cl->enabled = FALSE;
+  cl->stopped = FALSE;
   cl->error_count = 0;
   cl->print_statistics = print_statistics;
 
@@ -1033,10 +1048,9 @@ void dt_opencl_init(
   int dev = 0;
   for(int k = 0; k < num_devices; k++)
   {
-    const int res = dt_opencl_device_init(cl, dev, devices, k);
-    if(res != 0)
+    if(_opencl_device_init(cl, dev, devices, k))
       continue;
-    // increase dev only if dt_opencl_device_init was successful (res == 0)
+    // increase dev only if _opencl_device_init was successful
     ++dev;
   }
   free(devices);
@@ -1045,7 +1059,7 @@ void dt_opencl_init(
   if(dev > 0)
   {
     cl->num_devs = dev;
-    cl->inited = 1;
+    cl->inited = TRUE;
     cl->enabled = dt_conf_get_bool("opencl");
     memset(cl->mandatory, 0, sizeof(cl->mandatory));
     cl->dev_priority_image = (int *)malloc(sizeof(int) * (dev + 1));
@@ -1089,7 +1103,7 @@ finally:
     // make sure all active cl devices have a benchmark result
     for(int n = 0; n < cl->num_devs; n++)
     {
-      if((cl->dev[n].benchmark <= 0.0f) && (cl->dev[n].disabled == 0))
+      if((cl->dev[n].benchmark <= 0.0f) && (cl->dev[n].disabled == FALSE))
       {
         cl->dev[n].benchmark = _opencl_benchmark_gpu(n, 1024, 1024, 5, 100.0f);
         dt_opencl_write_device_config(n);
@@ -1114,7 +1128,7 @@ finally:
       float tgpumax = -INFINITY;
       for(int n = 0; n < cl->num_devs; n++)
       {
-        if((cl->dev[n].benchmark > 0.0f) && (cl->dev[n].disabled == 0))
+        if((cl->dev[n].benchmark > 0.0f) && (cl->dev[n].disabled == FALSE))
         {
           tgpumin = fminf(cl->dev[n].benchmark, tgpumin);
           tgpumax = fmaxf(cl->dev[n].benchmark, tgpumax);
@@ -1274,7 +1288,7 @@ void dt_opencl_cleanup(dt_opencl_t *cl)
   dt_pthread_mutex_destroy(&cl->lock);
 }
 
-static const char *dt_opencl_get_vendor_by_id(unsigned int id)
+static const char *_opencl_get_vendor_by_id(unsigned int id)
 {
   const char *vendor;
 
@@ -1477,11 +1491,11 @@ gboolean dt_opencl_finish_sync_pipe(const int devid, const int pipetype)
     return TRUE;
 }
 
-int dt_opencl_enqueue_barrier(const int devid)
+gboolean dt_opencl_enqueue_barrier(const int devid)
 {
   dt_opencl_t *cl = darktable.opencl;
-  if(!cl->inited || devid < 0) return -1;
-  return (cl->dlocl->symbols->dt_clEnqueueBarrier)(cl->dev[devid].cmd_queue);
+  if(!_cldev_running(devid)) return TRUE;
+  return ((cl->dlocl->symbols->dt_clEnqueueBarrier)(cl->dev[devid].cmd_queue)) ? TRUE : FALSE;
 }
 
 static int _take_from_list(int *list, int value)
@@ -1745,7 +1759,6 @@ int dt_opencl_lock_device(const int pipetype)
   dt_opencl_t *cl = darktable.opencl;
   if(!cl->inited) return -1;
 
-
   dt_pthread_mutex_lock(&cl->lock);
 
   size_t prio_size = sizeof(int) * (cl->num_devs + 1);
@@ -1910,7 +1923,8 @@ void dt_opencl_md5sum(const char **files, char **md5sums)
   }
 }
 
-int dt_opencl_load_program(
+// returns TRUE in case of an success
+static gboolean _opencl_load_program(
         const int dev,
         const int prog,
         const char *filename,
@@ -1930,7 +1944,7 @@ int dt_opencl_load_program(
   {
     dt_print(DT_DEBUG_OPENCL, "[opencl_load_source] invalid program number `%d' of file `%s'!\n", prog,
              filename);
-    return 0;
+    return FALSE;
   }
 
   if(cl->dev[dev].program_used[prog])
@@ -1938,11 +1952,11 @@ int dt_opencl_load_program(
     dt_print(DT_DEBUG_OPENCL,
              "[opencl_load_source] program number `%d' already in use when loading file `%s'!\n", prog,
              filename);
-    return 0;
+    return FALSE;
   }
 
   FILE *f = fopen_stat(filename, &filestat);
-  if(!f) return 0;
+  if(!f) return FALSE;
 
   size_t filesize = filestat.st_size;
   char *file = (char *)malloc(filesize + 2048);
@@ -1953,7 +1967,7 @@ int dt_opencl_load_program(
     free(file);
     dt_print(DT_DEBUG_OPENCL, "[opencl_load_source] could not read all of file `%s' for program number %d!\n",
       filename, prog);
-    return 0;
+    return FALSE;
   }
 
   char *start = file + filesize;
@@ -2073,7 +2087,7 @@ int dt_opencl_load_program(
     {
       dt_print(DT_DEBUG_OPENCL, "[opencl_load_source] could not create program from file `%s'! (%s)\n",
                filename, cl_errstr(err));
-      return 0;
+      return FALSE;
     }
     else
     {
@@ -2088,11 +2102,11 @@ int dt_opencl_load_program(
 
   dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[opencl_load_program] successfully loaded program from '%s' MD5: '%s'\n", filename, md5sum);
 
-  return 1;
+  return TRUE;
 }
 
 // return TRUE in case of an error condition
-gboolean dt_opencl_build_program(
+static gboolean _opencl_build_program(
         const int dev,
         const int prog,
         const char *binname,
@@ -2290,9 +2304,8 @@ void dt_opencl_free_kernel(const int kernel)
   dt_pthread_mutex_unlock(&cl->lock);
 }
 
-int dt_opencl_get_max_work_item_sizes(
-        const int dev,
-        size_t *sizes)
+/** return max size in sizes[3]. */
+int dt_opencl_get_max_work_item_sizes(const int dev, size_t *sizes)
 {
   dt_opencl_t *cl = darktable.opencl;
   if(!cl->inited || dev < 0) return -1;
@@ -2300,6 +2313,7 @@ int dt_opencl_get_max_work_item_sizes(
                                                   sizeof(size_t) * 3, sizes, NULL);
 }
 
+/** return max size per dimension in sizes[3] and max total size in workgroupsize */
 int dt_opencl_get_work_group_limits(
         const int dev,
         size_t *sizes,
@@ -2322,7 +2336,7 @@ int dt_opencl_get_work_group_limits(
   return dt_opencl_get_max_work_item_sizes(dev, sizes);
 }
 
-
+/** return max workgroup size for a specific kernel */
 int dt_opencl_get_kernel_work_group_size(
         const int dev,
         const int kernel,
@@ -2336,7 +2350,6 @@ int dt_opencl_get_kernel_work_group_size(
                                                            CL_KERNEL_WORK_GROUP_SIZE, sizeof(size_t),
                                                            kernelworkgroupsize, NULL);
 }
-
 
 int dt_opencl_set_kernel_arg(
         const int dev,
@@ -2408,7 +2421,7 @@ int dt_opencl_enqueue_kernel_ndim_with_local(
         const int dimensions)
 {
   dt_opencl_t *cl = darktable.opencl;
-  if(!cl->inited || dev < 0) return -1;
+  if(!_cldev_running(dev)) return DT_OPENCL_NODEVICE;
   if(kernel < 0 || kernel >= DT_OPENCL_MAX_KERNELS) return CL_INVALID_KERNEL;
 
   char buf[256] = { 0 };
@@ -2481,7 +2494,8 @@ int dt_opencl_read_host_from_device_rowpitch(
         const int height,
         const int rowpitch)
 {
-  if(!darktable.opencl->inited || devid < 0) return -1;
+  if(!_cldev_running(devid))
+    return DT_OPENCL_NODEVICE;
   const size_t origin[] = { 0, 0, 0 };
   const size_t region[] = { width, height, 1 };
   // blocking.
@@ -2508,7 +2522,8 @@ int dt_opencl_read_host_from_device_rowpitch_non_blocking(
         const int height,
         const int rowpitch)
 {
-  if(!darktable.opencl->inited || devid < 0) return -1;
+  if(!_cldev_running(devid))
+    return DT_OPENCL_NODEVICE;
   const size_t origin[] = { 0, 0, 0 };
   const size_t region[] = { width, height, 1 };
   // non-blocking.
@@ -2525,7 +2540,8 @@ int dt_opencl_read_host_from_device_raw(
         const int rowpitch,
         const int blocking)
 {
-  if(!darktable.opencl->inited) return -1;
+  if(!_cldev_running(devid))
+    return DT_OPENCL_NODEVICE;
 
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Read Image (from device to host)]");
 
@@ -2553,8 +2569,8 @@ int dt_opencl_write_host_to_device_rowpitch(
         const int height,
         const int rowpitch)
 {
-  if(!darktable.opencl->inited || devid < 0)
-    return -1;
+  if(!_cldev_running(devid))
+    return DT_OPENCL_NODEVICE;
 
   const size_t origin[] = { 0, 0, 0 };
   const size_t region[] = { width, height, 1 };
@@ -2581,8 +2597,8 @@ int dt_opencl_write_host_to_device_rowpitch_non_blocking(
         const int height,
         const int rowpitch)
 {
-  if(!darktable.opencl->inited || devid < 0)
-    return -1;
+  if(!_cldev_running(devid))
+    return DT_OPENCL_NODEVICE;
 
   const size_t origin[] = { 0, 0, 0 };
   const size_t region[] = { width, height, 1 };
@@ -2602,8 +2618,8 @@ int dt_opencl_write_host_to_device_raw(
         const int rowpitch,
         const int blocking)
 {
-  if(!darktable.opencl->inited)
-    return -1;
+  if(!_cldev_running(devid))
+    return DT_OPENCL_NODEVICE;
 
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Write Image (from host to device)]");
 
@@ -2622,8 +2638,8 @@ int dt_opencl_enqueue_copy_image(
         size_t *orig_dst,
         size_t *region)
 {
-  if(!darktable.opencl->inited || devid < 0)
-    return -1;
+  if(!_cldev_running(devid))
+    return DT_OPENCL_NODEVICE;
 
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Copy Image (on device)]");
   const cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyImage)(
@@ -2642,8 +2658,8 @@ int dt_opencl_enqueue_copy_image_to_buffer(
         size_t *region,
         size_t offset)
 {
-  if(!darktable.opencl->inited)
-    return -1;
+  if(!_cldev_running(devid))
+    return DT_OPENCL_NODEVICE;
 
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Copy Image to Buffer (on device)]");
   const cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyImageToBuffer)(
@@ -2663,8 +2679,8 @@ int dt_opencl_enqueue_copy_buffer_to_image(
         size_t *origin,
         size_t *region)
 {
-  if(!darktable.opencl->inited)
-    return -1;
+  if(!_cldev_running(devid))
+    return DT_OPENCL_NODEVICE;
 
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Copy Buffer to Image (on device)]");
   const cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyBufferToImage)(
@@ -2684,8 +2700,8 @@ int dt_opencl_enqueue_copy_buffer_to_buffer(
         size_t dstoffset,
         size_t size)
 {
-  if(!darktable.opencl->inited)
-    return -1;
+  if(!_cldev_running(devid))
+    return DT_OPENCL_NODEVICE;
 
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Copy Buffer to Buffer (on device)]");
   const cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyBuffer)(darktable.opencl->dev[devid].cmd_queue,
@@ -2705,8 +2721,8 @@ int dt_opencl_read_buffer_from_device(
         const size_t size,
         const int blocking)
 {
-  if(!darktable.opencl->inited)
-    return -1;
+  if(!_cldev_running(devid))
+    return DT_OPENCL_NODEVICE;
 
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Read Buffer (from device to host)]");
 
@@ -2722,8 +2738,8 @@ int dt_opencl_write_buffer_to_device(
         const size_t size,
         const int blocking)
 {
-  if(!darktable.opencl->inited)
-    return -1;
+  if(!_cldev_running(devid))
+    return DT_OPENCL_NODEVICE;
 
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Write Buffer (from host to device)]");
 
@@ -2737,7 +2753,7 @@ void *dt_opencl_copy_host_to_device_constant(
         const size_t size,
         void *host)
 {
-  if(!darktable.opencl->inited || devid < 0)
+  if(!_cldev_running(devid))
     return NULL;
 
   cl_int err = CL_SUCCESS;
@@ -2771,7 +2787,7 @@ void *dt_opencl_copy_host_to_device_rowpitch(
         const int bpp,
         const int rowpitch)
 {
-  if(!darktable.opencl->inited || devid < 0)
+  if(!_cldev_running(devid))
     return NULL;
 
   cl_int err = CL_SUCCESS;
@@ -2824,7 +2840,7 @@ void *dt_opencl_map_buffer(
         size_t offset,
         size_t size)
 {
-  if(!darktable.opencl->inited)
+  if(!_cldev_running(devid))
     return NULL;
 
   cl_int err = CL_SUCCESS;
@@ -2840,7 +2856,7 @@ void *dt_opencl_map_buffer(
 int dt_opencl_unmap_mem_object(const int devid, cl_mem mem_object, void *mapped_ptr)
 {
   if(!darktable.opencl->inited)
-    return -1;
+    return DT_OPENCL_NODEVICE;
 
   cl_event *eventp = dt_opencl_events_get_slot(devid, "[Unmap Mem Object]");
   cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueUnmapMemObject)(
@@ -2853,7 +2869,9 @@ int dt_opencl_unmap_mem_object(const int devid, cl_mem mem_object, void *mapped_
 
 void *dt_opencl_alloc_device(const int devid, const int width, const int height, const int bpp)
 {
-  if(!darktable.opencl->inited || devid < 0) return NULL;
+  if(!_cldev_running(devid))
+    return NULL;
+
   cl_int err = CL_SUCCESS;
   cl_image_format fmt;
   // guess pixel format from bytes per pixel
@@ -2889,7 +2907,7 @@ void *dt_opencl_alloc_device_use_host_pointer(
         const int rowpitch,
         void *host)
 {
-  if(!darktable.opencl->inited || devid < 0)
+  if(!_cldev_running(devid))
     return NULL;
 
   cl_int err = CL_SUCCESS;
@@ -2922,7 +2940,9 @@ void *dt_opencl_alloc_device_use_host_pointer(
 
 void *dt_opencl_alloc_device_buffer(const int devid, const size_t size)
 {
-  if(!darktable.opencl->inited) return NULL;
+  if(!_cldev_running(devid))
+    return NULL;
+
   cl_int err = CL_SUCCESS;
 
   cl_mem buf = (darktable.opencl->dlocl->symbols->dt_clCreateBuffer)(darktable.opencl->dev[devid].context,
@@ -2939,7 +2959,9 @@ void *dt_opencl_alloc_device_buffer(const int devid, const size_t size)
 
 void *dt_opencl_alloc_device_buffer_with_flags(const int devid, const size_t size, const int flags)
 {
-  if(!darktable.opencl->inited) return NULL;
+  if(!_cldev_running(devid))
+    return NULL;
+
   cl_int err = CL_SUCCESS;
 
   cl_mem buf = (darktable.opencl->dlocl->symbols->dt_clCreateBuffer)(darktable.opencl->dev[devid].context,
@@ -3022,7 +3044,9 @@ void dt_opencl_dump_pipe_pfm(const char* mod,
                              const gboolean input,
                              const char *pipe)
 {
-  if(!darktable.opencl->inited || devid < 0) return;
+  if(!_cldev_running(devid))
+    return;
+
   const int width = dt_opencl_get_image_width(img);
   const int height = dt_opencl_get_image_height(img);
   const int element_size = dt_opencl_get_image_element_size(img);
@@ -3075,15 +3099,15 @@ void dt_opencl_check_tuning(const int devid)
 {
   dt_sys_resources_t *res = &darktable.dtresources;
   dt_opencl_t *cl = darktable.opencl;
-  if(!cl->inited || devid < 0) return;
+  if(!_cldev_running(devid)) return;
 
   static int oldlevel = -999;
   static int oldtuned = -999;
 
-  const int tunemode = res->tunemode;
+  const dt_opencl_tunemode_t tunemode = res->tunemode;
   cl->dev[devid].tuneactive = tunemode & DT_OPENCL_TUNE_MEMSIZE;
 
-  const int pinmode = cl->dev[devid].pinned_memory;
+  const dt_opencl_pinmode_t pinmode = cl->dev[devid].pinned_memory;
   const gboolean safe_clmemsize = cl->dev[devid].max_global_mem < (size_t) (darktable.dtresources.total_memory / 16lu / cl->num_devs); 
   const gboolean want_pinned = (pinmode & DT_OPENCL_PINNING_ON) || (tunemode & DT_OPENCL_TUNE_PINNED);
 
@@ -3161,7 +3185,7 @@ gboolean dt_opencl_image_fits_device(
         const size_t overhead)
 {
   dt_opencl_t *cl = darktable.opencl;
-  if(!cl->inited || devid < 0) return FALSE;
+  if(!_cldev_running(devid)) return FALSE;
 
   const size_t required  = width * height * bpp;
   const size_t total = factor * required + overhead;
@@ -3178,14 +3202,24 @@ gboolean dt_opencl_image_fits_device(
 /** round size to a multiple of the value given in the device specifig config parameter clroundup_wd/ht */
 int dt_opencl_dev_roundup_width(int size, const int devid)
 {
-  const int roundup = darktable.opencl->dev[devid].clroundup_wd;
-  return (size % roundup == 0 ? size : (size / roundup + 1) * roundup);
+  if(_cldev_running(devid))
+  {
+    const int roundup = darktable.opencl->dev[devid].clroundup_wd;
+    return (size % roundup == 0 ? size : (size / roundup + 1) * roundup);
+  }
+  else
+    return 0;
 }
 
 int dt_opencl_dev_roundup_height(int size, const int devid)
 {
-  const int roundup = darktable.opencl->dev[devid].clroundup_ht;
-  return (size % roundup == 0 ? size : (size / roundup + 1) * roundup);
+  if(_cldev_running(devid))
+  {
+    const int roundup = darktable.opencl->dev[devid].clroundup_ht;
+    return (size % roundup == 0 ? size : (size / roundup + 1) * roundup);
+  }
+  else
+    return 0;
 }
 
 /** check if opencl is enabled */
@@ -3193,7 +3227,6 @@ gboolean dt_opencl_is_enabled(void)
 {
   return darktable.opencl->inited && darktable.opencl->enabled;
 }
-
 
 /** disable opencl */
 void dt_opencl_disable(void)
@@ -3206,10 +3239,7 @@ void dt_opencl_disable(void)
 /** runtime check for cl system running */
 gboolean dt_opencl_running(void)
 {
-  dt_opencl_t *cl = darktable.opencl;
-  if(!cl) return FALSE;
-  if(!cl->inited) return FALSE;
-  return (cl->enabled && !cl->stopped);
+  return _cl_running();
 }
 
 /** update enabled flag and profile with value from preferences */
@@ -3220,7 +3250,7 @@ void dt_opencl_update_settings(void)
   if(!cl->inited) return;
 
   cl->enabled = dt_conf_get_bool("opencl");
-  cl->stopped = 0;
+  cl->stopped = FALSE;
   cl->error_count = 0;
 
   dt_opencl_scheduling_profile_t profile = dt_opencl_get_scheduling_profile();

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2648,7 +2648,7 @@ restart:
     {
       // too frequent opencl errors encountered: this is a clear sign
       // of a broken setup. give up on opencl during this session.
-      darktable.opencl->stopped = 1;
+      darktable.opencl->stopped = TRUE;
       dt_print(DT_DEBUG_OPENCL,
                "[opencl] frequent opencl errors encountered; disabling opencl for this session!\n");
       dt_control_log


### PR DESCRIPTION
Work on code readability, stability & maintenance of opencl and dynamic libraries related stuff.
Hopefully catching more buggy libraries ...

- changed int to gboolean if code means bools
- use `dt_opencl_tunemode_t` and `dt_opencl_pinmode_t` instead of int in structs
- make sure the minimal `dt_opencl_t` struct is initialized if compiled without opencl
- fixed a number of opencl functions executing code even after the subsystem had been stopped because of many errors
- refactored some opencl code
- fixed sanity check while loading a library
- while initializing opencl the number of platforms could be wrong in case of errors
- if opencl is requested via preferences some important errors are reported via control log