### PR TITLE
RFC: Improve nvidia opencl performance via compiler flags

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1912,10 +1912,10 @@ void dt_configure_runtime_performance(const int old, char *info)
     g_strlcat(info, _("you may tune as before except 'magic'"), DT_PERF_INFOSIZE);
     g_strlcat(info, "\n\n", DT_PERF_INFOSIZE);
   }
-  else if(old < 13)
+  else if(old < 14)
   {
     g_strlcat(info, INFO_HEADER, DT_PERF_INFOSIZE);
-    g_strlcat(info, _("your OpenCL compiler settings for all devices have been reset to default."), DT_PERF_INFOSIZE);
+    g_strlcat(info, _("your OpenCL compiler settings for all devices have been reset to new default."), DT_PERF_INFOSIZE);
     g_strlcat(info, "\n\n", DT_PERF_INFOSIZE);
   }
 

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -161,7 +161,7 @@ extern "C" {
 // version of current performance configuration version
 // if you want to run an updated version of the performance configuration later
 // bump this number and make sure you have an updated logic in dt_configure_performance()
-#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 13
+#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 14
 #define DT_PERF_INFOSIZE 4096
 
 // every module has to define this:

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -914,7 +914,7 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
   const char* compile_opt = NULL;
 
   if(dt_conf_key_exists(compile_option_name_cname)
-     && (dt_conf_get_int("performance_configuration_version_completed") > 12))
+     && (dt_conf_get_int("performance_configuration_version_completed") > 13))
     compile_opt = dt_conf_get_string_const(compile_option_name_cname);
   else
   {

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -65,14 +65,14 @@ extern "C" {
 
 #define DT_OPENCL_DEFAULT_COMPILE_INTEL ("")
 #define DT_OPENCL_DEFAULT_COMPILE_AMD ("-cl-fast-relaxed-math")
-#define DT_OPENCL_DEFAULT_COMPILE_NVIDIA ("-cl-fast-relaxed-math")
+#define DT_OPENCL_DEFAULT_COMPILE_NVIDIA ("-cl-fast-relaxed-math -cl-mad-enable -cl-no-signed-zeros")
 #define DT_OPENCL_DEFAULT_COMPILE ("")
 #define DT_CLDEVICE_HEAD ("cldevice_v4_")
 
 // version for current darktable cl kernels
 // this is reflected in the kernel directory and allows to
 // enforce a new kernel compilation cycle
-#define DT_OPENCL_KERNELS 1
+#define DT_OPENCL_KERNELS 2
 
 typedef enum dt_opencl_memory_t
 {


### PR DESCRIPTION
The opencl compiler used somewhat 'standard' performance options for nvidia devices.

In addition to that we can use `-cl-mad-enable -cl-no-signed-zeros` for a somewhat improved performance.

- performance gain is approx 5-10% on my RTX 4000 card with 530.xx driver, gain depends on module
- testing the integration tests did no show any significamt difference vs old optimizing flags
- have been using these flags for some time without noticed issues

Instead of adding another option for "aggressive opencl compiler" i would opt for "new defaults" at least for nvidia cards as there are a number of people using master on these cards so we have a very good chance for negative feedback in case of unexpected problems so could possibly to a revert for release.

Alternative: keep as-is for known stability