### PR TITLE
[GUI] Use ngettext to ensure correct translation of text in the plural form

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -616,10 +616,13 @@ static void _pop_undo(gpointer user_data,
       *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(undogeotag->imgid));
       i++;
     }
-    if(i > 1) dt_control_log((action == DT_ACTION_UNDO)
-                              ? ngettext("geo-location undone for %d image", "geo-location undone for %d images", i)
-                              : ngettext("geo-location re-applied to %d image", "geo-location re-applied to %d images", i),
-                             i);
+    if(i > 1)
+      dt_control_log((action == DT_ACTION_UNDO)
+                     ? ngettext("geo-location undone for %d image",
+                                "geo-location undone for %d images", i)
+                     : ngettext("geo-location re-applied to %d image",
+                                "geo-location re-applied to %d images", i),
+                     i);
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
                                   DT_SIGNAL_GEOTAG_CHANGED, g_list_copy(*imgs), 0);
@@ -638,10 +641,13 @@ static void _pop_undo(gpointer user_data,
       *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(undodatetime->imgid));
       i++;
     }
-    if(i > 1) dt_control_log((action == DT_ACTION_UNDO)
-                              ? ngettext("date/time undone for %d image", "date/time undone for %d images", i)
-                              : ngettext("date/time re-applied to %d image", "date/time re-applied to %d images", i),
-                             i);
+    if(i > 1)
+      dt_control_log((action == DT_ACTION_UNDO)
+                     ? ngettext("date/time undone for %d image",
+                                "date/time undone for %d images", i)
+                     : ngettext("date/time re-applied to %d image",
+                                "date/time re-applied to %d images", i),
+                     i);
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
                                   DT_SIGNAL_IMAGE_INFO_CHANGED, g_list_copy(*imgs));

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -617,8 +617,9 @@ static void _pop_undo(gpointer user_data,
       i++;
     }
     if(i > 1) dt_control_log((action == DT_ACTION_UNDO)
-                              ? _("geo-location undone for %d images")
-                              : _("geo-location re-applied to %d images"), i);
+                              ? ngettext("geo-location undone for %d image", "geo-location undone for %d images", i)
+                              : ngettext("geo-location re-applied to %d image", "geo-location re-applied to %d images", i),
+                             i);
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
                                   DT_SIGNAL_GEOTAG_CHANGED, g_list_copy(*imgs), 0);
@@ -638,8 +639,9 @@ static void _pop_undo(gpointer user_data,
       i++;
     }
     if(i > 1) dt_control_log((action == DT_ACTION_UNDO)
-                              ? _("date/time undone for %d images")
-                              : _("date/time re-applied to %d images"), i);
+                              ? ngettext("date/time undone for %d image", "date/time undone for %d images", i)
+                              : ngettext("date/time re-applied to %d image", "date/time re-applied to %d images", i),
+                             i);
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
                                   DT_SIGNAL_IMAGE_INFO_CHANGED, g_list_copy(*imgs));


### PR DESCRIPTION
The singular form in the ngettext call will never be used for translation in the current code, but ngettext is needed to ensure the correct plural form in translations.