### PR TITLE
Large Overhaul of pixelpipe code

### DIFF
--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -282,7 +282,7 @@ void dt_color_picker_helper(const dt_iop_buffer_dsc_t *dsc,
                             const dt_iop_order_iccprofile_info_t *const profile)
 {
   dt_times_t start_time = { 0 }, end_time = { 0 };
-  if(darktable.unmuted & DT_DEBUG_PERF) dt_get_times(&start_time);
+  dt_get_perf_times(&start_time);
 
   if(dsc->channels == 4u)
   {

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -500,6 +500,18 @@ static inline void dt_get_times(dt_times_t *t)
   t->user = ru.ru_utime.tv_sec + ru.ru_utime.tv_usec * (1.0 / 1000000.0);
 }
 
+static inline void dt_get_perf_times(dt_times_t *t)
+{
+  if(darktable.unmuted & DT_DEBUG_PERF)
+  {
+    struct rusage ru;
+
+    getrusage(RUSAGE_SELF, &ru);
+    t->clock = dt_get_wtime();
+    t->user = ru.ru_utime.tv_sec + ru.ru_utime.tv_usec * (1.0 / 1000000.0);
+  }
+}
+
 void dt_show_times(const dt_times_t *start, const char *prefix);
 
 void dt_show_times_f(const dt_times_t *start, const char *prefix, const char *suffix, ...) __attribute__((format(printf, 3, 4)));

--- a/src/common/histogram.c
+++ b/src/common/histogram.c
@@ -216,7 +216,7 @@ void dt_histogram_helper(dt_dev_histogram_collection_params_t *histogram_params,
                          const dt_iop_order_iccprofile_info_t *const profile_info)
 {
   dt_times_t start_time = { 0 }, end_time = { 0 };
-  if(darktable.unmuted & DT_DEBUG_PERF) dt_get_times(&start_time);
+  dt_get_perf_times(&start_time);
 
   // all use 256 bins excepting:
   // levels in automatic mode which uses 16384

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -1277,7 +1277,7 @@ static void dt_interpolation_resample_plain(const struct dt_interpolation *itor,
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
                 "resample_plain", NULL, itor->name, roi_in, roi_out, "\n");
   dt_times_t start = { 0 }, mid = { 0 };
-  if(darktable.unmuted & DT_DEBUG_PERF) dt_get_times(&start);
+  dt_get_perf_times(&start);
 
   // Fast code path for 1:1 copy, only cropping area can change
   if(roi_out->scale == 1.f)
@@ -1321,7 +1321,7 @@ static void dt_interpolation_resample_plain(const struct dt_interpolation *itor,
     goto exit;
   }
 
-  if(darktable.unmuted & DT_DEBUG_PERF) dt_get_times(&mid);
+  dt_get_perf_times(&mid);
 
   const size_t height = roi_out->height;
   const size_t width = roi_out->width;
@@ -1522,7 +1522,7 @@ int dt_interpolation_resample_cl(const struct dt_interpolation *itor,
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
                 "resample_cl", NULL, itor->name, roi_in, roi_out, "\n");
   dt_times_t start = { 0 }, mid = { 0 };
-  if(darktable.unmuted & DT_DEBUG_PERF) dt_get_times(&start);
+  dt_get_perf_times(&start);
 
   // Fast code path for 1:1 copy, only cropping area can change
   if(roi_out->scale == 1.f)
@@ -1560,7 +1560,7 @@ int dt_interpolation_resample_cl(const struct dt_interpolation *itor,
     goto error;
   }
 
-  if(darktable.unmuted & DT_DEBUG_PERF) dt_get_times(&mid);
+  dt_get_perf_times(&mid);
 
   int hmaxtaps = -1, vmaxtaps = -1;
   for(int k = 0; k < roi_out->width; k++) hmaxtaps = MAX(hmaxtaps, hlength[k]);
@@ -1734,7 +1734,7 @@ static void dt_interpolation_resample_1c_plain(const struct dt_interpolation *it
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
                 "resample_1c_plain", NULL, itor->name, roi_in, roi_out, "\n");
   dt_times_t start = { 0 }, mid = { 0 };
-  if(darktable.unmuted & DT_DEBUG_PERF) dt_get_times(&start);
+  dt_get_perf_times(&start);
 
   // Fast code path for 1:1 copy, only cropping area can change
   if(roi_out->scale == 1.f)
@@ -1776,7 +1776,7 @@ static void dt_interpolation_resample_1c_plain(const struct dt_interpolation *it
     goto exit;
   }
 
-  if(darktable.unmuted & DT_DEBUG_PERF) dt_get_times(&mid);
+  dt_get_perf_times(&mid);
 
   // Process each output line
 #ifdef _OPENMP

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -1211,7 +1211,7 @@ int _get_multi_priority(dt_develop_t *dev,
   for(const GList *l = dev->iop; l; l = g_list_next(l))
   {
     const dt_iop_module_t *const restrict mod = (dt_iop_module_t *)l->data;
-    if((!only_disabled || mod->enabled == FALSE) && dt_iop_module_is(mod->so, operation))
+    if((!only_disabled || !mod->enabled) && dt_iop_module_is(mod->so, operation))
     {
       count++;
       if(count == n) return mod->multi_priority;

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -1108,7 +1108,7 @@ void dt_ioppr_transform_image_colorspace(
   }
 
   dt_times_t start_time = { 0 }, end_time = { 0 };
-  if(darktable.unmuted & DT_DEBUG_PERF) dt_get_times(&start_time);
+  dt_get_perf_times(&start_time);
 
   // matrix should be never NAN, this is only to test it against lcms2!
   if(!isnan(profile_info->matrix_in[0][0]) && !isnan(profile_info->matrix_out[0][0]))
@@ -1165,7 +1165,7 @@ void dt_ioppr_transform_image_colorspace_rgb(const float *const restrict image_i
   }
 
   dt_times_t start_time = { 0 }, end_time = { 0 };
-  if(darktable.unmuted & DT_DEBUG_PERF) dt_get_times(&start_time);
+  dt_get_perf_times(&start_time);
 
   if(!isnan(profile_info_from->matrix_in[0][0]) && !isnan(profile_info_from->matrix_out[0][0])
      && !isnan(profile_info_to->matrix_in[0][0]) && !isnan(profile_info_to->matrix_out[0][0]))
@@ -1376,7 +1376,7 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self,
   if(!isnan(profile_info->matrix_in[0][0]) && !isnan(profile_info->matrix_out[0][0]))
   {
     dt_times_t start_time = { 0 }, end_time = { 0 };
-    if(darktable.unmuted & DT_DEBUG_PERF) dt_get_times(&start_time);
+    dt_get_perf_times(&start_time);
 
     size_t origin[] = { 0, 0, 0 };
     size_t region[] = { width, height, 1 };
@@ -1544,7 +1544,7 @@ int dt_ioppr_transform_image_colorspace_rgb_cl(const int devid,
      && !isnan(profile_info_to->matrix_in[0][0]) && !isnan(profile_info_to->matrix_out[0][0]))
   {
     dt_times_t start_time = { 0 }, end_time = { 0 };
-    if(darktable.unmuted & DT_DEBUG_PERF) dt_get_times(&start_time);
+    dt_get_perf_times(&start_time);
 
     size_t origin[] = { 0, 0, 0 };
     size_t region[] = { width, height, 1 };

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -866,11 +866,11 @@ void dt_styles_apply_style_item(dt_develop_t *dev,
          * default_params. if user want to, he can disable it.
          */
         if(dt_iop_module_is(module->so, "flip")
-           && module->enabled == 0
+           && !module->enabled
            && labs(style_item->module_version) == 1)
         {
           memcpy(module->params, module->default_params, module->params_size);
-          module->enabled = 1;
+          module->enabled = TRUE;
         }
       }
       else

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2407,9 +2407,9 @@ void dt_dev_reprocess_all(dt_develop_t *dev)
     dev->pipe->changed |= DT_DEV_PIPE_SYNCH;
     dev->preview_pipe->changed |= DT_DEV_PIPE_SYNCH;
     dev->preview2_pipe->changed |= DT_DEV_PIPE_SYNCH;
-    dev->pipe->cache_obsolete = 1;
-    dev->preview_pipe->cache_obsolete = 1;
-    dev->preview2_pipe->cache_obsolete = 1;
+    dev->pipe->cache_obsolete = TRUE;
+    dev->preview_pipe->cache_obsolete = TRUE;
+    dev->preview2_pipe->cache_obsolete = TRUE;
 
     // invalidate buffers and force redraw of darkroom
     dt_dev_invalidate_all(dev);
@@ -2425,7 +2425,7 @@ void dt_dev_reprocess_center(dt_develop_t *dev)
   if(dev && dev->gui_attached)
   {
     dev->pipe->changed |= DT_DEV_PIPE_SYNCH;
-    dev->pipe->cache_obsolete = 1;
+    dev->pipe->cache_obsolete = TRUE;
 
     // invalidate buffers and force redraw of darkroom
     dt_dev_invalidate_all(dev);
@@ -2440,7 +2440,7 @@ void dt_dev_reprocess_preview(dt_develop_t *dev)
   if(darktable.gui->reset || !dev || !dev->gui_attached) return;
 
   dev->preview_pipe->changed |= DT_DEV_PIPE_SYNCH;
-  dev->preview_pipe->cache_obsolete = 1;
+  dev->preview_pipe->cache_obsolete = TRUE;
 
   dt_dev_invalidate_preview(dev);
   dt_control_queue_redraw_center();

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2288,18 +2288,17 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
        * default_params. if user want to, he can disable it.
        */
       if(dt_iop_module_is(hist->module->so, "flip")
-         && hist->enabled == 0
+         && !hist->enabled
          && labs(modversion) == 1)
       {
         memcpy(hist->params, hist->module->default_params, hist->module->params_size);
-        hist->enabled = 1;
+        hist->enabled = TRUE;
       }
     }
 
     // make sure that always-on modules are always on. duh.
-    if(hist->module->default_enabled == 1
-       && hist->module->hide_enable_button == 1)
-      hist->enabled = 1;
+    if(hist->module->default_enabled && hist->module->hide_enable_button)
+      hist->enabled = TRUE;
 
     dev->history = g_list_append(dev->history, hist);
     dev->history_end++;

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -127,14 +127,6 @@ typedef enum dt_dev_pixelpipe_display_mask_t
   DT_DEV_PIXELPIPE_DISPLAY_STICKY = 1 << 16
 } dt_dev_pixelpipe_display_mask_t;
 
-typedef enum dt_develop_detail_mmask_t
-{
-  DT_DEV_DETAIL_MASK_NONE = 0,
-  DT_DEV_DETAIL_MASK_REQUIRED = 1,
-  DT_DEV_DETAIL_MASK_DEMOSAIC = 2,
-  DT_DEV_DETAIL_MASK_RAWPREPARE = 4
-} dt_develop_detail_mask_t;
-
 typedef enum dt_clipping_preview_mode_t
 {
   DT_CLIPPING_PREVIEW_GAMUT = 0,

--- a/src/develop/format.h
+++ b/src/develop/format.h
@@ -51,7 +51,7 @@ typedef struct dt_iop_buffer_dsc_t
 
   struct
   {
-    int enabled;
+    gboolean enabled;
     dt_aligned_pixel_t coeffs;
   } temperature;
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -239,7 +239,7 @@ void dt_iop_default_init(dt_iop_module_t *module)
   module->params = (dt_iop_params_t *)calloc(1, param_size);
   module->default_params = (dt_iop_params_t *)calloc(1, param_size);
 
-  module->default_enabled = 0;
+  module->default_enabled = FALSE;
   module->has_trouble = FALSE;
   module->gui_data = NULL;
 
@@ -377,7 +377,7 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module,
   module->widget = NULL;
   module->header = NULL;
   module->off = NULL;
-  module->hide_enable_button = 0;
+  module->hide_enable_button = FALSE;
   module->has_trouble = FALSE;
   module->request_color_pick = DT_REQUEST_COLORPICK_OFF;
   module->request_histogram = DT_REQUEST_ONLY_IN_GUI;
@@ -400,7 +400,7 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module,
   module->histogram_middle_grey = FALSE;
   module->request_mask_display = DT_DEV_PIXELPIPE_DISPLAY_NONE;
   module->suppress_mask = 0;
-  module->enabled = module->default_enabled = 0; // all modules disabled by default.
+  module->enabled = module->default_enabled = FALSE; // all modules disabled by default.
   g_strlcpy(module->op, so->op, 20);
   module->raster_mask.source.users = g_hash_table_new(NULL, NULL);
   module->raster_mask.source.masks =
@@ -1067,7 +1067,7 @@ static void _gui_off_callback(GtkToggleButton *togglebutton, gpointer user_data)
   {
     if(gtk_toggle_button_get_active(togglebutton))
     {
-      module->enabled = 1;
+      module->enabled = TRUE;
 
       if(!basics && dt_conf_get_bool("darkroom/ui/activate_expand") && !module->expanded)
         dt_iop_gui_set_expanded(module, TRUE,
@@ -1077,7 +1077,7 @@ static void _gui_off_callback(GtkToggleButton *togglebutton, gpointer user_data)
     }
     else
     {
-      module->enabled = 0;
+      module->enabled = FALSE;
 
       //  if current module is set as the CAT instance, remove that setting
       if(module->dev->proxy.chroma_adaptation == module)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1943,12 +1943,12 @@ void dt_iop_commit_params(dt_iop_module_t *module,
 #ifdef HAVE_OPENCL
   // assume process_cl is ready, commit_params can overwrite this.
   if(module->process_cl)
-    piece->process_cl_ready = 1;
+    piece->process_cl_ready = TRUE;
 #endif // HAVE_OPENCL
 
   // register if module allows tiling, commit_params can overwrite this.
   if(module->flags() & IOP_FLAGS_ALLOW_TILING)
-    piece->process_tiling_ready = 1;
+    piece->process_tiling_ready = TRUE;
 
   if(darktable.unmuted & DT_DEBUG_PARAMS && module->so->get_introspection())
     _iop_validate_params(module->so->get_introspection()->field, params,

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -221,7 +221,7 @@ typedef struct dt_iop_module_t
   /** order of the module on the pipe. the pipe will be sorted by iop_order. */
   int iop_order;
   /** module sets this if the enable checkbox should be hidden. */
-  int32_t hide_enable_button;
+  gboolean hide_enable_button;
   /** set to DT_REQUEST_COLORPICK_MODULE if you want an input color
    * picked during next eval. gui mode only. */
   dt_dev_request_colorpick_flags_t request_color_pick;
@@ -253,8 +253,8 @@ typedef struct dt_iop_module_t
   gboolean histogram_middle_grey;
   /** the module is used in this develop module. */
   struct dt_develop_t *dev;
-  /** non zero if this node should be processed. */
-  int32_t enabled, default_enabled;
+  /** TRUE if this node should be processed. */
+  gboolean enabled, default_enabled;
   /** parameters for the operation. will be replaced by history revert. */
   dt_iop_params_t *params, *default_params;
   /** size of individual params struct. */

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1104,18 +1104,19 @@ static void _collect_histogram_on_CPU(dt_dev_pixelpipe_t *pipe,
   return;
 }
 
-static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
-                                    dt_develop_t *dev,
-                                    float *input,
-                                    dt_iop_buffer_dsc_t *input_format,
-                                    const dt_iop_roi_t *roi_in,
-                                    void **output,
-                                    dt_iop_buffer_dsc_t **out_format,
-                                    const dt_iop_roi_t *roi_out,
-                                    dt_iop_module_t *module,
-                                    dt_dev_pixelpipe_iop_t *piece,
-                                    dt_develop_tiling_t *tiling,
-                                    dt_pixelpipe_flow_t *pixelpipe_flow)
+static gboolean _pixelpipe_process_on_CPU(
+                 dt_dev_pixelpipe_t *pipe,
+                 dt_develop_t *dev,
+                 float *input,
+                 dt_iop_buffer_dsc_t *input_format,
+                 const dt_iop_roi_t *roi_in,
+                 void **output,
+                 dt_iop_buffer_dsc_t **out_format,
+                 const dt_iop_roi_t *roi_out,
+                 dt_iop_module_t *module,
+                 dt_dev_pixelpipe_iop_t *piece,
+                 dt_develop_tiling_t *tiling,
+                 dt_pixelpipe_flow_t *pixelpipe_flow)
 {
   if(dt_atomic_get_int(&pipe->shutdown))
     return TRUE;
@@ -1286,8 +1287,8 @@ static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
 
   if(dt_atomic_get_int(&pipe->shutdown))
     return TRUE;
-
-  return FALSE;
+  else
+    return FALSE;
 }
 
 static inline gboolean _check_good_pipe(dt_dev_pixelpipe_t *pipe)
@@ -1320,15 +1321,16 @@ static inline gboolean _opencl_pipe_isok(dt_dev_pixelpipe_t *pipe)
 #endif
 
 // recursive helper for process, returns TRUE in case of unfinished work or error
-static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
-                                        dt_develop_t *dev,
-                                        void **output,
-                                        void **cl_mem_output,
-                                        dt_iop_buffer_dsc_t **out_format,
-                                        const dt_iop_roi_t *roi_out,
-                                        GList *modules,
-                                        GList *pieces,
-                                        const int pos)
+static gboolean _dev_pixelpipe_process_rec(
+                 dt_dev_pixelpipe_t *pipe,
+                 dt_develop_t *dev,
+                 void **output,
+                 void **cl_mem_output,
+                 dt_iop_buffer_dsc_t **out_format,
+                 const dt_iop_roi_t *roi_out,
+                 GList *modules,
+                 GList *pieces,
+                 const int pos)
 {
   if(dt_atomic_get_int(&pipe->shutdown))
     return TRUE;
@@ -2411,13 +2413,14 @@ static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
 }
 
 
-gboolean dt_dev_pixelpipe_process_no_gamma(dt_dev_pixelpipe_t *pipe,
-                                      dt_develop_t *dev,
-                                      const int x,
-                                      const int y,
-                                      const int width,
-                                      const int height,
-                                      const float scale)
+gboolean dt_dev_pixelpipe_process_no_gamma(
+           dt_dev_pixelpipe_t *pipe,
+           dt_develop_t *dev,
+           const int x,
+           const int y,
+           const int width,
+           const int height,
+           const float scale)
 {
   // temporarily disable gamma mapping.
   GList *gammap = g_list_last(pipe->nodes);
@@ -2466,15 +2469,16 @@ void dt_dev_pixelpipe_disable_before(dt_dev_pixelpipe_t *pipe, const char *op)
 }
 
 // returns TRUE in case of error or early exit
-static gboolean _dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe,
-                                                     dt_develop_t *dev,
-                                                     void **output,
-                                                     void **cl_mem_output,
-                                                     dt_iop_buffer_dsc_t **out_format,
-                                                     const dt_iop_roi_t *roi_out,
-                                                     GList *modules,
-                                                     GList *pieces,
-                                                     const int pos)
+static gboolean _dev_pixelpipe_process_rec_and_backcopy(
+                  dt_dev_pixelpipe_t *pipe,
+                  dt_develop_t *dev,
+                  void **output,
+                  void **cl_mem_output,
+                  dt_iop_buffer_dsc_t **out_format,
+                  const dt_iop_roi_t *roi_out,
+                  GList *modules,
+                  GList *pieces,
+                  const int pos)
 {
   dt_pthread_mutex_lock(&pipe->busy_mutex);
   darktable.dtresources.group = 4 * darktable.dtresources.level;
@@ -2518,13 +2522,14 @@ static gboolean _dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe
   return ret;
 }
 
-gboolean dt_dev_pixelpipe_process(dt_dev_pixelpipe_t *pipe,
-                             dt_develop_t *dev,
-                             const int x,
-                             const int y,
-                             const int width,
-                             const int height,
-                             const float scale)
+gboolean dt_dev_pixelpipe_process(
+           dt_dev_pixelpipe_t *pipe,
+           dt_develop_t *dev,
+           const int x,
+           const int y,
+           const int width,
+           const int height,
+           const float scale)
 {
   pipe->processing = TRUE;
   pipe->opencl_enabled = dt_opencl_running();
@@ -2575,13 +2580,13 @@ restart:
     pipe, "", &roi, &roi, "\n");
 
   // run pixelpipe recursively and get error status
-  const gboolean err =
-    _dev_pixelpipe_process_rec_and_backcopy(pipe, dev, &buf, &cl_mem_out, &out_format,
-                                              &roi, modules,
-                                              pieces, pos);
+  const gboolean err = _dev_pixelpipe_process_rec_and_backcopy(
+                       pipe, dev, &buf, &cl_mem_out, &out_format, &roi, modules, pieces, pos);
 
   // get status summary of opencl queue by checking the eventlist
-  const gboolean oclerr = (pipe->devid >= 0) ? (dt_opencl_events_flush(pipe->devid, TRUE) != 0) : FALSE;
+  const gboolean oclerr = (pipe->devid >= 0)
+                          ? (dt_opencl_events_flush(pipe->devid, TRUE) != 0)
+                          : FALSE;
 
   // Check if we had opencl errors ....  remark: opencl errors can
   // come in two ways: pipe->opencl_error is TRUE (and err is TRUE) OR

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -470,7 +470,8 @@ void dt_dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, GList *
         if(!rawprep_img && active) piece->enabled = FALSE;
       }
 
-      if(piece->enabled != hist->enabled)
+//      if(piece->enabled != hist->enabled) // both are gboolean, don't do binary comp ?
+      if((piece->enabled && !hist->enabled) || (!piece->enabled && hist->enabled))
       {
         if(piece->enabled)
           dt_iop_set_module_trouble_message
@@ -2420,9 +2421,9 @@ gboolean dt_dev_pixelpipe_process_no_gamma(dt_dev_pixelpipe_t *pipe,
     gamma = (dt_dev_pixelpipe_iop_t *)gammap->data;
   }
 
-  if(gamma) gamma->enabled = 0;
+  if(gamma) gamma->enabled = FALSE;
   const gboolean ret = dt_dev_pixelpipe_process(pipe, dev, x, y, width, height, scale);
-  if(gamma) gamma->enabled = 1;
+  if(gamma) gamma->enabled = TRUE;
   return ret;
 }
 
@@ -2432,7 +2433,7 @@ void dt_dev_pixelpipe_disable_after(dt_dev_pixelpipe_t *pipe, const char *op)
   dt_dev_pixelpipe_iop_t *piece = (dt_dev_pixelpipe_iop_t *)nodes->data;
   while(!dt_iop_module_is(piece->module->so, op))
   {
-    piece->enabled = 0;
+    piece->enabled = FALSE;
     piece = NULL;
     nodes = g_list_previous(nodes);
     if(!nodes) break;
@@ -2446,7 +2447,7 @@ void dt_dev_pixelpipe_disable_before(dt_dev_pixelpipe_t *pipe, const char *op)
   dt_dev_pixelpipe_iop_t *piece = (dt_dev_pixelpipe_iop_t *)nodes->data;
   while(!dt_iop_module_is(piece->module->so, op))
   {
-    piece->enabled = 0;
+    piece->enabled = FALSE;
     piece = NULL;
     nodes = g_list_next(nodes);
     if(!nodes) break;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -26,7 +26,7 @@
 #include "develop/blend.h"
 #include "develop/format.h"
 #include "develop/imageop_math.h"
-#include "develop/pixelpipe.h"
+#include "develop/develop.h"
 #include "develop/tiling.h"
 #include "develop/masks.h"
 #include "gui/gtk.h"
@@ -208,7 +208,7 @@ gboolean dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe,
   pipe->processed_height = pipe->backbuf_height = pipe->iheight = pipe->final_height = 0;
   pipe->nodes = NULL;
   pipe->backbuf_size = size;
-  pipe->cache_obsolete = 0;
+  pipe->cache_obsolete = FALSE;
   pipe->backbuf = NULL;
   pipe->backbuf_scale = 0.0f;
   pipe->backbuf_zoom_x = 0.0f;
@@ -222,10 +222,10 @@ gboolean dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe,
   pipe->rawdetail_mask_data = NULL;
   pipe->want_detail_mask = DT_DEV_DETAIL_MASK_NONE;
 
-  pipe->processing = 0;
+  pipe->processing = FALSE;
   dt_atomic_set_int(&pipe->shutdown,FALSE);
-  pipe->opencl_error = 0;
-  pipe->tiling = 0;
+  pipe->opencl_error = FALSE;
+  pipe->tiling = FALSE;
   pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_NONE;
   pipe->bypass_blendif = 0;
   pipe->input_timestamp = 0;
@@ -367,9 +367,9 @@ void dt_dev_pixelpipe_rebuild(dt_develop_t *dev)
   dev->preview_pipe->changed |= DT_DEV_PIPE_REMOVE;
   dev->preview2_pipe->changed |= DT_DEV_PIPE_REMOVE;
 
-  dev->pipe->cache_obsolete = 1;
-  dev->preview_pipe->cache_obsolete = 1;
-  dev->preview2_pipe->cache_obsolete = 1;
+  dev->pipe->cache_obsolete = TRUE;
+  dev->preview_pipe->cache_obsolete = TRUE;
+  dev->preview2_pipe->cache_obsolete = TRUE;
 
   // invalidate buffers and force redraw of darkroom
   dt_dev_invalidate_all(dev);
@@ -410,8 +410,8 @@ void dt_dev_pixelpipe_create_nodes(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
     piece->pipe = pipe;
     piece->data = NULL;
     piece->hash = 0;
-    piece->process_cl_ready = 0;
-    piece->process_tiling_ready = 0;
+    piece->process_cl_ready = FALSE;
+    piece->process_tiling_ready = FALSE;
     piece->raster_masks = g_hash_table_new_full(g_direct_hash,
                                                 g_direct_equal, NULL, dt_free_align_ptr);
     memset(&piece->processed_roi_in, 0, sizeof(piece->processed_roi_in));
@@ -1030,7 +1030,7 @@ static void _pixelpipe_pick_samples(dt_develop_t *dev,
   }
 }
 
-// returns 1 if blend process need the module default colorspace
+// returns TRUE if blend process need the module default colorspace
 static gboolean _transform_for_blend(const dt_iop_module_t *const self,
                                      const dt_dev_pixelpipe_iop_t *const piece)
 {
@@ -1096,7 +1096,7 @@ static void _collect_histogram_on_CPU(dt_dev_pixelpipe_t *pipe,
   return;
 }
 
-static int pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
+static gboolean _pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
                                     dt_develop_t *dev,
                                     float *input,
                                     dt_iop_buffer_dsc_t *input_format,
@@ -1110,7 +1110,7 @@ static int pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
                                     dt_pixelpipe_flow_t *pixelpipe_flow)
 {
   if(dt_atomic_get_int(&pipe->shutdown))
-    return 1;
+    return TRUE;
 
   // the data buffers must always have a 64 alignment
   if((((uintptr_t)input) & 63) || (((uintptr_t)*output) & 63))
@@ -1149,12 +1149,12 @@ static int pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
      cst_to, &input_format->cst, work_profile);
 
   if(dt_atomic_get_int(&pipe->shutdown))
-    return 1;
+    return TRUE;
 
   _collect_histogram_on_CPU(pipe, dev, input, roi_in, module, piece, pixelpipe_flow);
 
   if(dt_atomic_get_int(&pipe->shutdown))
-    return 1;
+    return TRUE;
 
   const size_t in_bpp = dt_iop_buffer_dsc_to_bpp(input_format);
   const size_t bpp = dt_iop_buffer_dsc_to_bpp(*out_format);
@@ -1236,9 +1236,7 @@ static int pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
   pipe->dsc.cst = module->output_colorspace(module, pipe, piece);
 
   if(dt_atomic_get_int(&pipe->shutdown))
-  {
-    return 1;
-  }
+    return TRUE;
 
   // color picking for module
   if(_request_color_pick(pipe, dev, module))
@@ -1256,9 +1254,7 @@ static int pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
   }
 
   if(dt_atomic_get_int(&pipe->shutdown))
-  {
-    return 1;
-  }
+    return TRUE;
 
   // blend needs input/output images with default colorspace
   if(_transform_for_blend(module, piece))
@@ -1273,7 +1269,7 @@ static int pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
   }
 
   if(dt_atomic_get_int(&pipe->shutdown))
-    return 1;
+    return TRUE;
 
   /* process blending on CPU */
   dt_develop_blend_process(module, piece, input, *output, roi_in, roi_out);
@@ -1281,10 +1277,9 @@ static int pixelpipe_process_on_CPU(dt_dev_pixelpipe_t *pipe,
   *pixelpipe_flow &= ~(PIXELPIPE_FLOW_BLENDED_ON_GPU);
 
   if(dt_atomic_get_int(&pipe->shutdown))
-  {
-    return 1;
-  }
-  return 0; //no errors
+    return TRUE;
+
+  return FALSE;
 }
 
 static inline gboolean _check_good_pipe(dt_dev_pixelpipe_t *pipe)
@@ -1316,8 +1311,8 @@ static inline gboolean _opencl_pipe_isok(dt_dev_pixelpipe_t *pipe)
 }
 #endif
 
-// recursive helper for process:
-static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
+// recursive helper for process, returns TRUE in case of unfinished work or error
+static gboolean _dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                                         dt_develop_t *dev,
                                         void **output,
                                         void **cl_mem_output,
@@ -1328,7 +1323,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                                         const int pos)
 {
   if(dt_atomic_get_int(&pipe->shutdown))
-    return 1;
+    return TRUE;
 
   dt_iop_roi_t roi_in = *roi_out;
 
@@ -1354,7 +1349,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
     if(!piece->enabled
        || (dev->gui_module && dev->gui_module != module
            && dev->gui_module->operation_tags_filter() & module->operation_tags()))
-      return dt_dev_pixelpipe_process_rec(pipe, dev, output, cl_mem_output, out_format, &roi_in,
+      return _dev_pixelpipe_process_rec(pipe, dev, output, cl_mem_output, out_format, &roi_in,
                                           g_list_previous(modules), g_list_previous(pieces), pos - 1);
   }
 
@@ -1366,19 +1361,18 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
 
   // 1) if cached buffer is still available, return data
   if(dt_atomic_get_int(&pipe->shutdown))
-  {
-    return 1;
-  }
+    return TRUE;
+
   gboolean cache_available = FALSE;
   uint64_t basichash = 0;
   uint64_t hash = 0;
+
   // do not get gamma from cache on preview pipe so we can compute the final scope
-  // FIXME: better yet, don't even cache the gamma output in this case
-  // -- but then we'd need to allocate a temporary output buffer and
-  // garbage collect it
-  if(!(pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
-     || module == NULL
-     || !dt_iop_module_is(module->so, "gamma"))
+  const gboolean gamma_preview = (pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
+                              && (module != NULL)
+                              && dt_iop_module_is(module->so, "gamma");
+
+  if(!gamma_preview)
   {
     dt_dev_pixelpipe_cache_fullhash(pipe->image.id, roi_out, pipe, pos, &basichash, &hash);
     cache_available = dt_dev_pixelpipe_cache_available(&(pipe->cache), hash, bufsize);
@@ -1389,31 +1383,30 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                                output, out_format, (module) ? module->so->op : NULL, FALSE);
 
     if(dt_atomic_get_int(&pipe->shutdown))
-      return 1;
+      return TRUE;
 
     // we're done! as colorpicker/scopes only work on gamma iop
     // input -- which is unavailable via cache -- there's no need to
     // run these
-    return 0;
+    return FALSE;
   }
 
   // 2) if history changed or exit event, abort processing?
   // preview pipe: abort on all but zoom events (same buffer anyways)
-  if(dt_iop_breakpoint(dev, pipe)) return 1;
+  if(dt_iop_breakpoint(dev, pipe)) return TRUE;
   // if image has changed, stop now.
-  if(pipe == dev->pipe && dev->image_force_reload) return 1;
-  if(pipe == dev->preview_pipe && dev->preview_loading) return 1;
-  if(pipe == dev->preview2_pipe && dev->preview2_loading) return 1;
-  if(dev->gui_leaving) return 1;
+  if(pipe == dev->pipe && dev->image_force_reload) return TRUE;
+  if(pipe == dev->preview_pipe && dev->preview_loading) return TRUE;
+  if(pipe == dev->preview2_pipe && dev->preview2_loading) return TRUE;
+  if(dev->gui_leaving) return TRUE;
 
   // 3) input -> output
   if(!modules)
   {
     // 3a) import input array with given scale and roi
     if(dt_atomic_get_int(&pipe->shutdown))
-    {
-      return 1;
-    }
+      return TRUE;
+
     dt_times_t start;
     dt_get_times(&start);
     // we're looking for the full buffer
@@ -1470,18 +1463,16 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                     "initing base buffer [%s]", dt_dev_pixelpipe_type_to_str(pipe->type));
 
     if(dt_atomic_get_int(&pipe->shutdown))
-      return 1;
+      return TRUE;
 
-    return 0;
+    return FALSE;
   }
 
   // 3b) recurse and obtain output array in &input
 
   // get region of interest which is needed in input
   if(dt_atomic_get_int(&pipe->shutdown))
-  {
-    return 1;
-  }
+    return TRUE;
 
   module->modify_roi_in(module, piece, roi_out, &roi_in);
   if((darktable.unmuted & DT_DEBUG_PIPE) && memcmp(roi_out, &roi_in, sizeof(dt_iop_roi_t)))
@@ -1497,9 +1488,9 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
   piece->processed_roi_in = roi_in;
   piece->processed_roi_out = *roi_out;
 
-  if(dt_dev_pixelpipe_process_rec(pipe, dev, &input, &cl_mem_input, &input_format, &roi_in,
+  if(_dev_pixelpipe_process_rec(pipe, dev, &input, &cl_mem_input, &input_format, &roi_in,
                                   g_list_previous(modules), g_list_previous(pieces), pos - 1))
-    return 1;
+    return TRUE;
 
   const size_t in_bpp = dt_iop_buffer_dsc_to_bpp(input_format);
 
@@ -1513,9 +1504,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
 
   // reserve new cache line: output
   if(dt_atomic_get_int(&pipe->shutdown))
-  {
-    return 1;
-  }
+    return TRUE;
 
   gboolean important = FALSE;
   if(pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
@@ -1537,9 +1526,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                              output, out_format, module ? module->so->op : NULL, important);
 
   if(dt_atomic_get_int(&pipe->shutdown))
-  {
-    return 1;
-  }
+    return TRUE;
 
   dt_times_t start;
   dt_get_times(&start);
@@ -1591,7 +1578,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                  (size_t)in_bpp * roi_in.width);
 #endif
 
-    return 0;
+    return FALSE;
   }
 
 
@@ -1631,9 +1618,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
   assert(tiling.factor_cl > 0.0f);
 
   if(dt_atomic_get_int(&pipe->shutdown))
-  {
-    return 1;
-  }
+    return TRUE;
 
 #ifdef HAVE_OPENCL
 
@@ -1659,7 +1644,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
     /* general remark: in case of opencl errors within modules or
        out-of-memory on GPU, we transparently fall back to the
        respective cpu module and continue in pixelpipe. If we
-       encounter errors we set pipe->opencl_error=1, return this
+       encounter errors we set pipe->opencl_error=TRUE, return this
        function with value 1, and leave appropriate action to the
        calling function, which normally would restart pixelpipe
        without opencl.  Late errors are sometimes detected when trying
@@ -1737,7 +1722,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         if(dt_atomic_get_int(&pipe->shutdown))
         {
           dt_opencl_release_mem_object(cl_mem_input);
-          return 1;
+          return TRUE;
         }
 
         /* try to allocate GPU memory for output */
@@ -1817,9 +1802,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         }
 
         if(dt_atomic_get_int(&pipe->shutdown))
-        {
-          return 1;
-        }
+          return TRUE;
 
         /* now call process_cl of module; module should emit
            meaningful messages in case of error */
@@ -1887,7 +1870,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         if(dt_atomic_get_int(&pipe->shutdown))
         {
           dt_opencl_release_mem_object(cl_mem_input);
-          return 1;
+          return TRUE;
         }
 
         // color picking for module
@@ -1910,10 +1893,8 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         }
 
         if(dt_atomic_get_int(&pipe->shutdown))
-        {
-          return 1;
-        }
-
+           return TRUE;
+ 
         // blend needs input/output images with default colorspace
         if(success_opencl && _transform_for_blend(module, piece))
         {
@@ -1946,7 +1927,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         if(dt_atomic_get_int(&pipe->shutdown))
         {
           dt_opencl_release_mem_object(cl_mem_input);
-          return 1;
+          return TRUE;
         }
       }
       else if(piece->process_tiling_ready)
@@ -1971,8 +1952,8 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                      " copying back to cpu buffer: %s\n",
                      dt_dev_pixelpipe_type_to_str(pipe->type), cl_errstr(err));
             dt_opencl_release_mem_object(cl_mem_input);
-            pipe->opencl_error = 1;
-            return 1;
+            pipe->opencl_error = TRUE;
+            return TRUE;
           }
           else
             input_format->cst = input_cst_cl;
@@ -1982,10 +1963,8 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         }
 
         if(dt_atomic_get_int(&pipe->shutdown))
-        {
-          return 1;
-        }
-
+           return TRUE;
+ 
         // indirectly give gpu some air to breathe (and to do display related stuff)
         dt_iop_nap(dt_opencl_micro_nap(pipe->devid));
 
@@ -1999,9 +1978,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         }
 
         if(dt_atomic_get_int(&pipe->shutdown))
-        {
-          return 1;
-        }
+          return TRUE;
 
         // histogram collection for module
         if(success_opencl)
@@ -2010,9 +1987,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         }
 
         if(dt_atomic_get_int(&pipe->shutdown))
-        {
-          return 1;
-        }
+          return TRUE;
 
         /* now call process_tiling_cl of module; module should emit
            meaningful messages in case of error */
@@ -2028,9 +2003,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         }
 
         if(dt_atomic_get_int(&pipe->shutdown))
-        {
-          return 1;
-        }
+          return TRUE;
 
         // color picking for module
         if(success_opencl && _request_color_pick(pipe, dev, module))
@@ -2049,9 +2022,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         }
 
         if(dt_atomic_get_int(&pipe->shutdown))
-        {
-          return 1;
-        }
+           return TRUE;
 
         // blend needs input/output images with default colorspace
         if(success_opencl && _transform_for_blend(module, piece))
@@ -2070,9 +2041,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         }
 
         if(dt_atomic_get_int(&pipe->shutdown))
-        {
-          return 1;
-        }
+          return TRUE;
 
         /* do process blending on cpu (this is anyhow fast enough) */
         if(success_opencl)
@@ -2087,9 +2056,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
           success_opencl = dt_opencl_finish_sync_pipe(pipe->devid, pipe->type);
 
         if(dt_atomic_get_int(&pipe->shutdown))
-        {
-          return 1;
-        }
+          return TRUE;
       }
       else
       {
@@ -2101,7 +2068,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
       if(dt_atomic_get_int(&pipe->shutdown))
       {
         dt_opencl_release_mem_object(cl_mem_input);
-        return 1;
+        return TRUE;
       }
 
       // if(rand() % 20 == 0) success_opencl = FALSE; // Test code: simulate spurious failures
@@ -2157,7 +2124,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
           if(dt_atomic_get_int(&pipe->shutdown))
           {
             dt_opencl_release_mem_object(cl_mem_input);
-            return 1;
+            return TRUE;
           }
         }
 
@@ -2201,8 +2168,8 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                      " while copying back to cpu buffer: %s\n",
                      dt_dev_pixelpipe_type_to_str(pipe->type), cl_errstr(err));
             dt_opencl_release_mem_object(cl_mem_input);
-            pipe->opencl_error = 1;
-            return 1;
+            pipe->opencl_error = TRUE;
+            return TRUE;
           }
           else
             input_format->cst = input_cst_cl;
@@ -2213,15 +2180,13 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
           dt_opencl_release_mem_object(cl_mem_input);
           valid_input_on_gpu_only = FALSE;
         }
-        if(pixelpipe_process_on_CPU(pipe, dev, input, input_format, &roi_in, output, out_format,
+        if(_pixelpipe_process_on_CPU(pipe, dev, input, input_format, &roi_in, output, out_format,
                                     roi_out, module, piece, &tiling, &pixelpipe_flow))
-          return 1;
+          return TRUE;
       }
 
       if(dt_atomic_get_int(&pipe->shutdown))
-      {
-        return 1;
-      }
+        return TRUE;
     }
     else
     {
@@ -2247,8 +2212,8 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
                    " while copying back to cpu buffer: %s\n",
                    dt_dev_pixelpipe_type_to_str(pipe->type), cl_errstr(err));
           dt_opencl_release_mem_object(cl_mem_input);
-          pipe->opencl_error = 1;
-          return 1;
+          pipe->opencl_error = TRUE;
+          return TRUE;
         }
         else
           input_format->cst = input_cst_cl;
@@ -2260,9 +2225,9 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
         valid_input_on_gpu_only = FALSE;
       }
 
-      if(pixelpipe_process_on_CPU(pipe, dev, input, input_format, &roi_in, output, out_format,
+      if(_pixelpipe_process_on_CPU(pipe, dev, input, input_format, &roi_in, output, out_format,
                                   roi_out, module, piece, &tiling, &pixelpipe_flow))
-        return 1;
+        return TRUE;
     }
 
     /* input is still only on GPU? Let's invalidate CPU input buffer then */
@@ -2273,14 +2238,14 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
   {
     /* opencl is not inited or not enabled or we got no resource/device -> everything runs on cpu */
 
-    if(pixelpipe_process_on_CPU(pipe, dev, input, input_format, &roi_in, output, out_format, roi_out,
+    if(_pixelpipe_process_on_CPU(pipe, dev, input, input_format, &roi_in, output, out_format, roi_out,
                                 module, piece, &tiling, &pixelpipe_flow))
-      return 1;
+      return TRUE;
   }
 #else // HAVE_OPENCL
-  if(pixelpipe_process_on_CPU(pipe, dev, input, input_format, &roi_in, output, out_format, roi_out,
+  if(_pixelpipe_process_on_CPU(pipe, dev, input, input_format, &roi_in, output, out_format, roi_out,
                               module, piece, &tiling, &pixelpipe_flow))
-    return 1;
+    return TRUE;
 #endif // HAVE_OPENCL
 
   char histogram_log[32] = "";
@@ -2336,9 +2301,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
 #endif
   {
     if(dt_atomic_get_int(&pipe->shutdown))
-    {
-      return 1;
-    }
+      return TRUE;
 
 #ifdef HAVE_OPENCL
     if(*cl_mem_output != NULL)
@@ -2422,9 +2385,8 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
 
   // 4) colorpicker and scopes:
   if(dt_atomic_get_int(&pipe->shutdown))
-  {
-    return 1;
-  }
+    return TRUE;
+
   if(dev->gui_attached && !dev->gui_leaving
      && pipe == dev->preview_pipe
      && (dt_iop_module_is(module->so, "gamma"))) // only gamma provides meaningful RGB data
@@ -2452,13 +2414,13 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe,
   }
 
   if(dt_atomic_get_int(&pipe->shutdown))
-    return 1;
+    return TRUE;
 
-  return 0;
+  return FALSE;
 }
 
 
-int dt_dev_pixelpipe_process_no_gamma(dt_dev_pixelpipe_t *pipe,
+gboolean dt_dev_pixelpipe_process_no_gamma(dt_dev_pixelpipe_t *pipe,
                                       dt_develop_t *dev,
                                       const int x,
                                       const int y,
@@ -2478,11 +2440,9 @@ int dt_dev_pixelpipe_process_no_gamma(dt_dev_pixelpipe_t *pipe,
     gamma = (dt_dev_pixelpipe_iop_t *)gammap->data;
   }
 
-  if(gamma)
-    gamma->enabled = 0;
-  const int ret = dt_dev_pixelpipe_process(pipe, dev, x, y, width, height, scale);
-  if(gamma)
-    gamma->enabled = 1;
+  if(gamma) gamma->enabled = 0;
+  const gboolean ret = dt_dev_pixelpipe_process(pipe, dev, x, y, width, height, scale);
+  if(gamma) gamma->enabled = 1;
   return ret;
 }
 
@@ -2514,7 +2474,8 @@ void dt_dev_pixelpipe_disable_before(dt_dev_pixelpipe_t *pipe, const char *op)
   }
 }
 
-static int dt_dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe,
+// returns TRUE in case of error or early exit
+static gboolean _dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe,
                                                      dt_develop_t *dev,
                                                      void **output,
                                                      void **cl_mem_output,
@@ -2530,7 +2491,7 @@ static int dt_dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe,
   dt_opencl_check_tuning(pipe->devid);
 #endif
   pipe->next_important_module = FALSE;
-  int ret = dt_dev_pixelpipe_process_rec(pipe, dev, output, cl_mem_output, out_format,
+  gboolean ret = _dev_pixelpipe_process_rec(pipe, dev, output, cl_mem_output, out_format,
                                          roi_out, modules, pieces, pos);
 #ifdef HAVE_OPENCL
   // copy back final opencl buffer (if any) to CPU
@@ -2553,11 +2514,11 @@ static int dt_dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe,
       {
         /* this indicates a opencl problem earlier in the pipeline */
         dt_print(DT_DEBUG_OPENCL,
-                 "[dt_dev_pixelpipe_process_rec_and_backcopy] [%s]"
+                 "[_dev_pixelpipe_process_rec_and_backcopy] [%s]"
                  " late opencl error detected while copying back to cpu buffer: %s\n",
                  dt_dev_pixelpipe_type_to_str(pipe->type), cl_errstr(err));
-        pipe->opencl_error = 1;
-        ret = 1;
+        pipe->opencl_error = TRUE;
+        ret = TRUE;
       }
     }
   }
@@ -2566,8 +2527,7 @@ static int dt_dev_pixelpipe_process_rec_and_backcopy(dt_dev_pixelpipe_t *pipe,
   return ret;
 }
 
-
-int dt_dev_pixelpipe_process(dt_dev_pixelpipe_t *pipe,
+gboolean dt_dev_pixelpipe_process(dt_dev_pixelpipe_t *pipe,
                              dt_develop_t *dev,
                              const int x,
                              const int y,
@@ -2575,7 +2535,7 @@ int dt_dev_pixelpipe_process(dt_dev_pixelpipe_t *pipe,
                              const int height,
                              const float scale)
 {
-  pipe->processing = 1;
+  pipe->processing = TRUE;
   pipe->opencl_enabled = dt_opencl_running();
   pipe->devid = (pipe->opencl_enabled) ? dt_opencl_lock_device(pipe->type)
                                        : -1; // try to get/lock opencl resource
@@ -2606,7 +2566,7 @@ restart:
 
   // check if we should obsolete caches
   if(pipe->cache_obsolete) dt_dev_pixelpipe_cache_flush(&(pipe->cache));
-  pipe->cache_obsolete = 0;
+  pipe->cache_obsolete = FALSE;
 
   // mask display off as a starting point
   pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_NONE;
@@ -2620,13 +2580,13 @@ restart:
   dt_iop_buffer_dsc_t *out_format = &_out_format;
 
   // run pixelpipe recursively and get error status
-  const int err =
-    dt_dev_pixelpipe_process_rec_and_backcopy(pipe, dev, &buf, &cl_mem_out, &out_format,
+  const gboolean err =
+    _dev_pixelpipe_process_rec_and_backcopy(pipe, dev, &buf, &cl_mem_out, &out_format,
                                               &roi, modules,
                                               pieces, pos);
 
   // get status summary of opencl queue by checking the eventlist
-  const int oclerr = (pipe->devid >= 0) ? (dt_opencl_events_flush(pipe->devid, TRUE) != 0) : 0;
+  const gboolean oclerr = (pipe->devid >= 0) ? (dt_opencl_events_flush(pipe->devid, TRUE) != 0) : FALSE;
 
   // Check if we had opencl errors ....  remark: opencl errors can
   // come in two ways: pipe->opencl_error is TRUE (and err is TRUE) OR
@@ -2638,8 +2598,8 @@ restart:
     dt_opencl_release_mem_object(cl_mem_out);
     dt_opencl_unlock_device(pipe->devid); // release opencl resource
     dt_pthread_mutex_lock(&pipe->busy_mutex);
-    pipe->opencl_enabled = 0; // disable opencl for this pipe
-    pipe->opencl_error = 0;   // reset error status
+    pipe->opencl_enabled = FALSE; // disable opencl for this pipe
+    pipe->opencl_error = FALSE;   // reset error status
     pipe->devid = -1;
     dt_pthread_mutex_unlock(&pipe->busy_mutex);
 
@@ -2679,8 +2639,8 @@ restart:
   // ... and in case of other errors ...
   if(err)
   {
-    pipe->processing = 0;
-    return 1;
+    pipe->processing = FALSE;
+    return TRUE;
   }
 
   // terminate
@@ -2712,8 +2672,8 @@ restart:
 
   dt_dev_pixelpipe_cache_report(pipe);
 
-  pipe->processing = 0;
-  return 0;
+  pipe->processing = FALSE;
+  return FALSE;
 }
 
 void dt_dev_pixelpipe_flush_caches(dt_dev_pixelpipe_t *pipe)

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2486,8 +2486,8 @@ static gboolean _dev_pixelpipe_process_rec_and_backcopy(
   dt_opencl_check_tuning(pipe->devid);
 #endif
   pipe->next_important_module = FALSE;
-  gboolean ret = _dev_pixelpipe_process_rec(pipe, dev, output, cl_mem_output, out_format,
-                                         roi_out, modules, pieces, pos);
+  gboolean ret = _dev_pixelpipe_process_rec(
+                  pipe, dev, output, cl_mem_output, out_format, roi_out, modules, pieces, pos);
 #ifdef HAVE_OPENCL
   // copy back final opencl buffer (if any) to CPU
   if(ret)
@@ -2499,9 +2499,10 @@ static gboolean _dev_pixelpipe_process_rec_and_backcopy(
   {
     if(*cl_mem_output != NULL)
     {
-      cl_int err = dt_opencl_copy_device_to_host(pipe->devid, *output, *cl_mem_output,
-                                                 roi_out->width, roi_out->height,
-                                                 dt_iop_buffer_dsc_to_bpp(*out_format));
+      cl_int err = dt_opencl_copy_device_to_host(
+                    pipe->devid, *output, *cl_mem_output,
+                    roi_out->width, roi_out->height,
+                    dt_iop_buffer_dsc_to_bpp(*out_format));
       dt_opencl_release_mem_object(*cl_mem_output);
       *cl_mem_output = NULL;
 

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -52,7 +52,7 @@ typedef struct dt_dev_pixelpipe_iop_t
   struct dt_dev_pixelpipe_t *pipe; // the pipe this piece belongs to
   void *data;                      // to be used by the module to store stuff per pipe piece
   void *blendop_data;              // to be used by the module to store blendop per pipe piece
-  int enabled; // used to disable parts of the pipe for export, independent on module itself.
+  gboolean enabled; // used to disable parts of the pipe for export, independent on module itself.
 
   dt_dev_request_flags_t request_histogram;              // (bitwise) set if you want an histogram captured
   dt_dev_histogram_collection_params_t histogram_params; // set histogram generation params

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -167,7 +167,7 @@ typedef struct dt_dev_pixelpipe_t
   // should this pixelpipe display a mask in the end?
   int mask_display;
   // should this pixelpipe completely suppressed the blendif module?
-  int bypass_blendif;
+  gboolean bypass_blendif;
   // input data based on this timestamp:
   int input_timestamp;
   dt_dev_pixelpipe_type_t type;

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -726,7 +726,7 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self, struct dt_
     const size_t wd = tx * tile_wd + width > roi_in->width ? roi_in->width - tx * tile_wd : width;
     for(size_t ty = 0; ty < tiles_y; ty++)
     {
-      piece->pipe->tiling = 1;
+      piece->pipe->tiling = TRUE;
 
       const size_t ht = ty * tile_ht + height > roi_in->height ? roi_in->height - ty * tile_ht : height;
 
@@ -811,7 +811,7 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self, struct dt_
 
   if(input != NULL) dt_free_align(input);
   if(output != NULL) dt_free_align(output);
-  piece->pipe->tiling = 0;
+  piece->pipe->tiling = FALSE;
   return;
 
 error:
@@ -821,7 +821,7 @@ error:
 fallback:
   if(input != NULL) dt_free_align(input);
   if(output != NULL) dt_free_align(output);
-  piece->pipe->tiling = 0;
+  piece->pipe->tiling = FALSE;
   dt_print(DT_DEBUG_TILING,
            "[default_process_tiling_ptp] [%s] fall back to standard processing for module '%s'\n",
            dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op);
@@ -1000,7 +1000,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
   for(size_t tx = 0; tx < tiles_x; tx++)
     for(size_t ty = 0; ty < tiles_y; ty++)
     {
-      piece->pipe->tiling = 1;
+      piece->pipe->tiling = TRUE;
 
       /* the output dimensions of the good part of this specific tile */
       const size_t wd = (tx + 1) * tile_wd > roi_out->width ? (size_t)roi_out->width - tx * tile_wd : tile_wd;
@@ -1162,7 +1162,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
 
   if(input != NULL) dt_free_align(input);
   if(output != NULL) dt_free_align(output);
-  piece->pipe->tiling = 0;
+  piece->pipe->tiling = FALSE;
   return;
 
 error:
@@ -1172,7 +1172,7 @@ error:
 fallback:
   if(input != NULL) dt_free_align(input);
   if(output != NULL) dt_free_align(output);
-  piece->pipe->tiling = 0;
+  piece->pipe->tiling = FALSE;
   dt_print(DT_DEBUG_TILING,
            "[default_process_tiling_roi] [%s] fall back to standard processing for module '%s'\n",
            dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op);
@@ -1515,7 +1515,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
   for(size_t tx = 0; tx < tiles_x; tx++)
     for(size_t ty = 0; ty < tiles_y; ty++)
     {
-      piece->pipe->tiling = 1;
+      piece->pipe->tiling = TRUE;
 
       const size_t wd = tx * tile_wd + width > roi_in->width ? roi_in->width - tx * tile_wd : width;
       const size_t ht = ty * tile_ht + height > roi_in->height ? roi_in->height - ty * tile_ht : height;
@@ -1666,7 +1666,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
   dt_opencl_release_mem_object(pinned_output);
   dt_opencl_release_mem_object(input);
   dt_opencl_release_mem_object(output);
-  piece->pipe->tiling = 0;
+  piece->pipe->tiling = FALSE;
   return TRUE;
 
 error:
@@ -1678,7 +1678,7 @@ error:
   dt_opencl_release_mem_object(pinned_output);
   dt_opencl_release_mem_object(input);
   dt_opencl_release_mem_object(output);
-  piece->pipe->tiling = 0;
+  piece->pipe->tiling = FALSE;
   const gboolean pinning_error = (use_pinned_memory == FALSE) && dt_opencl_use_pinned_memory(devid);
   dt_print(DT_DEBUG_TILING | DT_DEBUG_OPENCL,
            "[default_process_tiling_opencl_ptp] [%s] couldn't run process_cl() for "
@@ -1910,7 +1910,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
   for(size_t tx = 0; tx < tiles_x; tx++)
     for(size_t ty = 0; ty < tiles_y; ty++)
     {
-      piece->pipe->tiling = 1;
+      piece->pipe->tiling = TRUE;
 
       /* the output dimensions of the good part of this specific tile */
       const size_t wd = (tx + 1) * tile_wd > roi_out->width ? (size_t)roi_out->width - tx * tile_wd : tile_wd;
@@ -2128,7 +2128,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
   dt_opencl_release_mem_object(pinned_output);
   dt_opencl_release_mem_object(input);
   dt_opencl_release_mem_object(output);
-  piece->pipe->tiling = 0;
+  piece->pipe->tiling = FALSE;
   return TRUE;
 
 error:
@@ -2140,7 +2140,7 @@ error:
   dt_opencl_release_mem_object(pinned_output);
   dt_opencl_release_mem_object(input);
   dt_opencl_release_mem_object(output);
-  piece->pipe->tiling = 0;
+  piece->pipe->tiling = FALSE;
   const gboolean pinning_error = (use_pinned_memory == FALSE) && dt_opencl_use_pinned_memory(devid);
   dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
            "[default_process_tiling_opencl_roi] [%s] couldn't run process_cl() "

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -283,7 +283,7 @@ static void _iop_color_picker_pickerdata_ready_callback(gpointer instance, dt_io
   // to work properly. This will force colorin to be run and it
   // will set the work_profile if needed.
   piece->pipe->changed |= DT_DEV_PIPE_REMOVE;
-  piece->pipe->cache_obsolete = 1;
+  piece->pipe->cache_obsolete = TRUE;
 
   // iops only need new picker data if the pointer has moved
   if(_record_point_area(picker))

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -1575,7 +1575,7 @@ static void _gui_presets_popup_menu_show_internal(dt_dev_operation_t op,
             || (op_params_size > 0
                 && !memcmp(params, op_params, MIN(op_params_size, params_size))))
        && !memcmp(bl_params, blendop_params, MIN(bl_params_size, sizeof(dt_develop_blend_params_t)))
-       && ((module->enabled && enabled) || (!module->enabled && !enabled)) // safe check gboolean vs int32_t
+       && (module->enabled && enabled)
        )
     {
       active_preset = cnt;

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -1575,7 +1575,8 @@ static void _gui_presets_popup_menu_show_internal(dt_dev_operation_t op,
             || (op_params_size > 0
                 && !memcmp(params, op_params, MIN(op_params_size, params_size))))
        && !memcmp(bl_params, blendop_params, MIN(bl_params_size, sizeof(dt_develop_blend_params_t)))
-       && module->enabled == enabled)
+       && ((module->enabled && enabled) || (!module->enabled && !enabled)) // safe check gboolean vs int32_t
+       )
     {
       active_preset = cnt;
       writeprotect = sqlite3_column_int(stmt, 2);

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -732,7 +732,7 @@ int dt_imageio_export_with_flags(const int32_t imgid,
   const int ht = img->height;
 
   dt_times_t start;
-  dt_get_times(&start);
+  dt_get_perf_times(&start);
   dt_dev_pixelpipe_t pipe;
   gboolean res = thumbnail_export
     ? dt_dev_pixelpipe_init_thumbnail(&pipe, wd, ht)
@@ -919,7 +919,7 @@ int dt_imageio_export_with_flags(const int32_t imgid,
 
   const int bpp = format->bpp(format_params);
 
-  dt_get_times(&start);
+  dt_get_perf_times(&start);
   if(high_quality_processing)
   {
     /*

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -948,7 +948,7 @@ int dt_imageio_export_with_flags(const int32_t imgid,
       }
     }
 
-    if(finalscale) finalscale->enabled = 0;
+    if(finalscale) finalscale->enabled = FALSE;
 
     // do the processing (8-bit with special treatment, to make sure we can use openmp further down):
     if(bpp == 8)
@@ -956,7 +956,7 @@ int dt_imageio_export_with_flags(const int32_t imgid,
     else
       dt_dev_pixelpipe_process_no_gamma(&pipe, &dev, 0, 0, processed_width, processed_height, scale);
 
-    if(finalscale) finalscale->enabled = 1;
+    if(finalscale) finalscale->enabled = TRUE;
   }
   dt_show_times(&start, thumbnail_export ? "[dev_process_thumbnail] pixel pipeline processing"
                                          : "[dev_process_export] pixel pipeline processing");

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5802,7 +5802,7 @@ void gui_update(struct dt_iop_module_t *self)
 void reload_defaults(dt_iop_module_t *module)
 {
   // our module is disabled by default
-  module->default_enabled = 0;
+  module->default_enabled = FALSE;
 
   int isflipped = 0;
   float f_length = DEFAULT_F_LENGTH;

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -299,7 +299,7 @@ void commit_params(struct dt_iop_module_t *self,
       (piece->process_cl_ready && !dt_opencl_avoid_atomics(pipe->devid));
 #endif
   if(d->mode == s_mode_local_laplacian)
-    piece->process_tiling_ready = 0; // can't deal with tiles, sorry.
+    piece->process_tiling_ready = FALSE; // can't deal with tiles, sorry.
 }
 
 

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1344,7 +1344,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
   dt_image_t *img = &pipe->image;
   const gboolean active = (dt_image_is_raw(img) && (img->buf_dsc.filters != 9u) && !(dt_image_is_monochrome(img)));
 
-  if(!active) piece->enabled = 0;
+  if(!active) piece->enabled = FALSE;
 
   d->iterations = p->iterations;
   d->avoidshift = p->avoidshift;

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -3070,7 +3070,7 @@ void commit_params(struct dt_iop_module_t *self,
            d->illuminant_type == DT_ILLUMINANT_DETECT_SURFACES ) && // WB extraction mode
            (piece->pipe->type & DT_DEV_PIXELPIPE_FULL) ) )
     {
-      piece->process_cl_ready = 0;
+      piece->process_cl_ready = FALSE;
     }
   }
 }

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -306,7 +306,7 @@ void init(dt_iop_module_t *module)
 {
   module->params = calloc(1, sizeof(dt_iop_rlce_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_rlce_params_t));
-  module->default_enabled = 0;
+  module->default_enabled = FALSE;
   module->params_size = sizeof(dt_iop_rlce_params_t);
   module->gui_data = NULL;
   *((dt_iop_rlce_params_t *)module->default_params) = (dt_iop_rlce_params_t){ 64, 1.25 };

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -831,7 +831,7 @@ void init(dt_iop_module_t *module)
 {
   module->params = calloc(1, sizeof(dt_iop_colorchecker_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colorchecker_params_t));
-  module->default_enabled = 0;
+  module->default_enabled = FALSE;
   module->params_size = sizeof(dt_iop_colorchecker_params_t);
   module->gui_data = NULL;
 

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1382,7 +1382,7 @@ void commit_params(struct dt_iop_module_t *self,
   d->lut[1][0] = -1.0f;
   d->lut[2][0] = -1.0f;
   d->nonlinearlut = 0;
-  piece->process_cl_ready = 1;
+  piece->process_cl_ready = TRUE;
   char datadir[PATH_MAX] = { 0 };
   dt_loc_get_datadir(datadir, sizeof(datadir));
 
@@ -1523,7 +1523,7 @@ void commit_params(struct dt_iop_module_t *self,
        (d->input, d->cmatrix, d->lut[0], d->lut[1], d->lut[2],
         LUT_SAMPLES))
     {
-      piece->process_cl_ready = 0;
+      piece->process_cl_ready = FALSE;
       d->cmatrix[0][0] = NAN;
       d->xform_cam_Lab = cmsCreateTransform(d->input, input_format, Lab,
                                             TYPE_LabA_FLT, p->intent, 0);
@@ -1549,7 +1549,7 @@ void commit_params(struct dt_iop_module_t *self,
                                                     d->lut[0], d->lut[1], d->lut[2],
                                                     LUT_SAMPLES))
     {
-      piece->process_cl_ready = 0;
+      piece->process_cl_ready = FALSE;
       d->cmatrix[0][0] = NAN;
       d->xform_cam_Lab = cmsCreateTransform(d->input, input_format, Lab,
                                             TYPE_LabA_FLT, p->intent, 0);
@@ -1592,7 +1592,7 @@ void commit_params(struct dt_iop_module_t *self,
                                                     d->lut[0], d->lut[1], d->lut[2],
                                                     LUT_SAMPLES))
     {
-      piece->process_cl_ready = 0;
+      piece->process_cl_ready = FALSE;
       d->cmatrix[0][0] = NAN;
       d->xform_cam_Lab = cmsCreateTransform(d->input, TYPE_RGBA_FLT, Lab,
                                             TYPE_LabA_FLT, p->intent, 0);

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1389,10 +1389,10 @@ void commit_params(struct dt_iop_module_t *self,
   dt_colorspaces_color_profile_type_t type = p->type;
   if(type == DT_COLORSPACE_LAB)
   {
-    piece->enabled = 0;
+    piece->enabled = FALSE;
     return;
   }
-  piece->enabled = 1;
+  piece->enabled = TRUE;
 
   if(type == DT_COLORSPACE_ENHANCED_MATRIX)
   {
@@ -1487,7 +1487,7 @@ void commit_params(struct dt_iop_module_t *self,
   {
     dt_print(DT_DEBUG_ALWAYS, "[colorin] input profile could not be generated!\n");
     dt_control_log(_("input profile could not be generated!"));
-    piece->enabled = 0;
+    piece->enabled = FALSE;
     return;
   }
 
@@ -1737,8 +1737,8 @@ void gui_update(struct dt_iop_module_t *self)
 // FIXME: update the gui when we add/remove the eprofile or ematrix
 void reload_defaults(dt_iop_module_t *module)
 {
-  module->default_enabled = 1;
-  module->hide_enable_button = 1;
+  module->default_enabled = TRUE;
+  module->hide_enable_button = TRUE;
 
   dt_iop_colorin_params_t *d = module->default_params;
 

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -837,8 +837,8 @@ void init(dt_iop_module_t *module)
 {
   dt_iop_default_init(module);
 
-  module->hide_enable_button = 1;
-  module->default_enabled = 1;
+  module->hide_enable_button = TRUE;
+  module->default_enabled = TRUE;
 }
 
 static void _preference_changed(gpointer instance, gpointer user_data)

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -608,7 +608,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   d->lut[0][0] = -1.0f;
   d->lut[1][0] = -1.0f;
   d->lut[2][0] = -1.0f;
-  piece->process_cl_ready = 1;
+  piece->process_cl_ready = TRUE;
 
   /* if we are exporting then check and set usage of override profile */
   if(pipe->type & DT_DEV_PIXELPIPE_EXPORT)
@@ -734,7 +734,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
                                                       LUT_SAMPLES))
   {
     d->cmatrix[0][0] = NAN;
-    piece->process_cl_ready = 0;
+    piece->process_cl_ready = FALSE;
     d->xform = cmsCreateProofingTransform(Lab, TYPE_LabA_FLT, output, output_format, softproof,
                                           out_intent, INTENT_RELATIVE_COLORIMETRIC, transformFlags);
   }
@@ -753,7 +753,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
                                                         LUT_SAMPLES))
     {
       d->cmatrix[0][0] = NAN;
-      piece->process_cl_ready = 0;
+      piece->process_cl_ready = FALSE;
 
       d->xform = cmsCreateProofingTransform(Lab, TYPE_LabA_FLT, output, output_format, softproof,
                                             out_intent, INTENT_RELATIVE_COLORIMETRIC, transformFlags);

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2572,7 +2572,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 #endif
 
   // display selection don't work with opencl
-  piece->process_cl_ready = (g && g->display_mask) ? 0 : 1;
+  piece->process_cl_ready = (g && g->display_mask) ? FALSE : TRUE;
   d->channel = (dt_iop_colorzones_channel_t)p->channel;
   d->mode = p->mode;
 

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2681,7 +2681,7 @@ void init(dt_iop_module_t *module)
 {
   module->params = calloc(1, sizeof(dt_iop_colorzones_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colorzones_params_t));
-  module->default_enabled = 0; // we're a rather slow and rare op.
+  module->default_enabled = FALSE;
   module->params_size = sizeof(dt_iop_colorzones_params_t);
   module->gui_data = NULL;
   module->request_histogram |= (DT_REQUEST_ON);

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -422,7 +422,7 @@ void process_display(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece
   }
 
   piece->pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_MASK;
-  piece->pipe->bypass_blendif = 1;
+  piece->pipe->bypass_blendif = TRUE;
 }
 
 void process_v1(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1035,49 +1035,49 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
   switch(d->demosaicing_method)
   {
     case DT_IOP_DEMOSAIC_PPG:
-      piece->process_cl_ready = 1;
+      piece->process_cl_ready = TRUE;
       break;
     case DT_IOP_DEMOSAIC_AMAZE:
-      piece->process_cl_ready = 0;
+      piece->process_cl_ready = FALSE;
       break;
     case DT_IOP_DEMOSAIC_VNG4:
-      piece->process_cl_ready = 1;
+      piece->process_cl_ready = TRUE;
       break;
     case DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME:
-      piece->process_cl_ready = 1;
+      piece->process_cl_ready = TRUE;
       break;
     case DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR:
-      piece->process_cl_ready = 1;
+      piece->process_cl_ready = TRUE;
       break;
     case DT_IOP_DEMOSAIC_RCD:
-      piece->process_cl_ready = 1;
+      piece->process_cl_ready = TRUE;
       break;
     case DT_IOP_DEMOSAIC_LMMSE:
-      piece->process_cl_ready = 0;
+      piece->process_cl_ready = FALSE;
       break;
     case DT_IOP_DEMOSAIC_RCD_VNG:
-      piece->process_cl_ready = 1;
+      piece->process_cl_ready = TRUE;
       break;
     case DT_IOP_DEMOSAIC_AMAZE_VNG:
-      piece->process_cl_ready = 0;
+      piece->process_cl_ready = FALSE;
       break;
     case DT_IOP_DEMOSAIC_MARKEST3_VNG:
-      piece->process_cl_ready = 1;
+      piece->process_cl_ready = TRUE;
       break;
     case DT_IOP_DEMOSAIC_VNG:
-      piece->process_cl_ready = 1;
+      piece->process_cl_ready = TRUE;
       break;
     case DT_IOP_DEMOSAIC_MARKESTEIJN:
-      piece->process_cl_ready = 1;
+      piece->process_cl_ready = TRUE;
       break;
     case DT_IOP_DEMOSAIC_MARKESTEIJN_3:
-      piece->process_cl_ready = 1;
+      piece->process_cl_ready = TRUE;
       break;
     case DT_IOP_DEMOSAIC_FDC:
-      piece->process_cl_ready = 0;
+      piece->process_cl_ready = FALSE;
       break;
     default:
-      piece->process_cl_ready = 0;
+      piece->process_cl_ready = FALSE;
   }
 
   // green-equilibrate over full image excludes tiling
@@ -1087,7 +1087,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
       || ((use_method & DT_DEMOSAIC_DUAL) && (d->dual_thrs > 0.0f))
       || (piece->pipe->want_detail_mask == (DT_DEV_DETAIL_MASK_REQUIRED | DT_DEV_DETAIL_MASK_DEMOSAIC)))
   {
-    piece->process_tiling_ready = 0;
+    piece->process_tiling_ready = FALSE;
   }
 
   if(self->dev->image_storage.flags & DT_IMAGE_4BAYER)

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -997,7 +997,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
   dt_iop_demosaic_params_t *p = (dt_iop_demosaic_params_t *)params;
   dt_iop_demosaic_data_t *d = (dt_iop_demosaic_data_t *)piece->data;
 
-  if(!(dt_image_is_raw(&pipe->image))) piece->enabled = 0;
+  if(!(dt_image_is_raw(&pipe->image))) piece->enabled = FALSE;
   d->green_eq = p->green_eq;
   d->color_smoothing = p->color_smoothing;
   d->median_thrs = p->median_thrs;
@@ -1129,7 +1129,7 @@ void reload_defaults(dt_iop_module_t *module)
   else
     d->demosaicing_method = DT_IOP_DEMOSAIC_RCD;
 
-  module->hide_enable_button = 1;
+  module->hide_enable_button = TRUE;
 
   module->default_enabled = dt_image_is_raw(&module->dev->image_storage);
   if(module->widget)

--- a/src/iop/equalizer.c
+++ b/src/iop/equalizer.c
@@ -219,7 +219,7 @@ void init(dt_iop_module_t *module)
 {
   module->params = calloc(1, sizeof(dt_iop_equalizer_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_equalizer_params_t));
-  module->default_enabled = 0; // we're a rather slow and rare op.
+  module->default_enabled = FALSE; // we're a rather slow and rare op.
   module->params_size = sizeof(dt_iop_equalizer_params_t);
   module->gui_data = NULL;
   dt_iop_equalizer_params_t *d = module->default_params;

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1296,7 +1296,7 @@ void init(dt_iop_module_t *module)
 {
   module->params = calloc(1, sizeof(dt_iop_filmic_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_filmic_params_t));
-  module->default_enabled = 0;
+  module->default_enabled = FALSE;
   module->params_size = sizeof(dt_iop_filmic_params_t);
   module->gui_data = NULL;
 

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -140,7 +140,7 @@ void commit_params(dt_iop_module_t *self,
                    dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
-  if(piece->pipe->type != DT_DEV_PIXELPIPE_EXPORT) piece->enabled = 0;
+  if(piece->pipe->type != DT_DEV_PIXELPIPE_EXPORT) piece->enabled = FALSE;
 }
 
 void init_pipe(dt_iop_module_t *self,
@@ -162,8 +162,8 @@ void init(dt_iop_module_t *self)
 {
   self->params = calloc(1, sizeof(dt_iop_finalscale_params_t));
   self->default_params = calloc(1, sizeof(dt_iop_finalscale_params_t));
-  self->default_enabled = 1;
-  self->hide_enable_button = 1;
+  self->default_enabled = TRUE;
+  self->hide_enable_button = TRUE;
   self->params_size = sizeof(dt_iop_finalscale_params_t);
   self->gui_data = NULL;
 }

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -506,7 +506,7 @@ void reload_defaults(dt_iop_module_t *self)
 
   d->orientation = ORIENTATION_NULL;
 
-  self->default_enabled = 1;
+  self->default_enabled = TRUE;
 
   if(self->dev->image_storage.legacy_flip.user_flip != 0
      && self->dev->image_storage.legacy_flip.user_flip != 0xff)

--- a/src/iop/gamma.c
+++ b/src/iop/gamma.c
@@ -392,8 +392,8 @@ void init(dt_iop_module_t *module)
   module->default_params = calloc(1, sizeof(dt_iop_gamma_params_t));
   module->params_size = sizeof(dt_iop_gamma_params_t);
   module->gui_data = NULL;
-  module->hide_enable_button = 1;
-  module->default_enabled = 1;
+  module->hide_enable_button = TRUE;
+  module->default_enabled = TRUE;
 }
 
 // clang-format off

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -546,7 +546,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   d->detail = p->detail;
 
   // drago needs the maximum L-value of the whole image so it must not use tiling
-  if(d->operator == OPERATOR_DRAGO) piece->process_tiling_ready = 0;
+  if(d->operator == OPERATOR_DRAGO) piece->process_tiling_ready = FALSE;
 
 #ifdef HAVE_OPENCL
   if(d->detail != 0.0f)

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -826,7 +826,7 @@ void commit_params(struct dt_iop_module_t *self,
   piece->process_cl_ready = ((d->mode == DT_IOP_HIGHLIGHTS_INPAINT) || (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS) || opplinear) ? 0 : 1;
 
   if((d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS) || (d->mode == DT_IOP_HIGHLIGHTS_OPPOSED))
-    piece->process_tiling_ready = 0;
+    piece->process_tiling_ready = FALSE;
 
   const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
 

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -423,7 +423,6 @@ int process_cl(struct dt_iop_module_t *self,
     if(g->hlr_mask_mode != DT_HIGHLIGHTS_MASK_OFF)
     {
       piece->pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
-      piece->pipe->type |= DT_DEV_PIXELPIPE_FAST;
       if(g->hlr_mask_mode == DT_HIGHLIGHTS_MASK_CLIPPED)
       {
         const float mclip = d->clip * highlights_clip_magics[d->mode];
@@ -650,7 +649,6 @@ void process(struct dt_iop_module_t *self,
     if(g->hlr_mask_mode != DT_HIGHLIGHTS_MASK_OFF)
     {
       piece->pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
-      piece->pipe->type |= DT_DEV_PIXELPIPE_FAST;
       if(g->hlr_mask_mode == DT_HIGHLIGHTS_MASK_CLIPPED)
       {
         process_visualize(piece, ivoid, ovoid, roi_in, roi_out, data);
@@ -823,7 +821,7 @@ void commit_params(struct dt_iop_module_t *self,
   */
   const gboolean opplinear = (d->mode == DT_IOP_HIGHLIGHTS_OPPOSED) && linear;
 
-  piece->process_cl_ready = ((d->mode == DT_IOP_HIGHLIGHTS_INPAINT) || (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS) || opplinear) ? 0 : 1;
+  piece->process_cl_ready = ((d->mode == DT_IOP_HIGHLIGHTS_INPAINT) || (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS) || opplinear) ? FALSE : TRUE;
 
   if((d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS) || (d->mode == DT_IOP_HIGHLIGHTS_OPPOSED))
     piece->process_tiling_ready = FALSE;

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -321,7 +321,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
   const dt_image_t *img = &pipe->image;
   const gboolean enabled = dt_image_is_raw(img) && !dt_image_is_monochrome(img);
 
-  if(!enabled || p->strength == 0.0) piece->enabled = 0;
+  if(!enabled || p->strength == 0.0) piece->enabled = FALSE;
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -459,10 +459,10 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
   for(int k = 0; k < 4; k++) d->color[k] = p->color[k];
 
   // x-trans images not implemented in OpenCL yet
-  if(pipe->image.buf_dsc.filters == 9u) piece->process_cl_ready = 0;
+  if(pipe->image.buf_dsc.filters == 9u) piece->process_cl_ready = FALSE;
 
   // 4Bayer images not implemented in OpenCL yet
-  if(self->dev->image_storage.flags & DT_IMAGE_4BAYER) piece->process_cl_ready = 0;
+  if(self->dev->image_storage.flags & DT_IMAGE_4BAYER) piece->process_cl_ready = FALSE;
 
   if(self->hide_enable_button) piece->enabled = 0;
 }

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -464,7 +464,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
   // 4Bayer images not implemented in OpenCL yet
   if(self->dev->image_storage.flags & DT_IMAGE_4BAYER) piece->process_cl_ready = FALSE;
 
-  if(self->hide_enable_button) piece->enabled = 0;
+  if(self->hide_enable_button) piece->enabled = FALSE;
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2338,7 +2338,7 @@ void commit_params(struct dt_iop_module_t *self,
     d->modify_flags &= ~DT_IOP_LENS_MODIFY_FLAG_TCA;
 
   // no OpenCL for LENS_METHOD_EMBEDDED_METADATA
-  piece->process_cl_ready = (d->method == DT_IOP_LENS_METHOD_EMBEDDED_METADATA) ? 0 : 1;
+  piece->process_cl_ready = (d->method == DT_IOP_LENS_METHOD_EMBEDDED_METADATA) ? FALSE : TRUE;
 
   if(d->method == DT_IOP_LENS_METHOD_LENSFUN)
   {

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -457,8 +457,8 @@ void init(dt_iop_module_t *module)
 {
   module->params = calloc(1, sizeof(dt_iop_overexposed_t));
   module->default_params = calloc(1, sizeof(dt_iop_overexposed_t));
-  module->hide_enable_button = 1;
-  module->default_enabled = 1;
+  module->hide_enable_button = TRUE;
+  module->default_enabled = TRUE;
   module->params_size = sizeof(dt_iop_overexposed_t);
   module->gui_data = NULL;
 }

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -519,7 +519,7 @@ void reload_defaults(dt_iop_module_t *module)
     gtk_stack_set_visible_child_name(GTK_STACK(module->widget), module->hide_enable_button ? "non_raw" : "raw");
   }
 
-  module->default_enabled = 0;
+  module->default_enabled = FALSE;
 }
 
 void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelpipe_t *pipe,
@@ -541,7 +541,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
   }
 
   if(!(dt_image_is_raw(&pipe->image)))
-    piece->enabled = 0;
+    piece->enabled = FALSE;
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -428,7 +428,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
 
   piece->enabled = dev->rawoverexposed.enabled && fullpipe && dev->gui_attached && sensorok;
 
-  if(image->buf_dsc.datatype != TYPE_UINT16 || !image->buf_dsc.filters) piece->enabled = 0;
+  if(image->buf_dsc.datatype != TYPE_UINT16 || !image->buf_dsc.filters) piece->enabled = FALSE;
 }
 
 void init_global(dt_iop_module_so_t *module)
@@ -467,8 +467,8 @@ void init(dt_iop_module_t *module)
 {
   module->params = calloc(1, sizeof(dt_iop_rawoverexposed_t));
   module->default_params = calloc(1, sizeof(dt_iop_rawoverexposed_t));
-  module->hide_enable_button = 1;
-  module->default_enabled = 1;
+  module->hide_enable_button = TRUE;
+  module->default_enabled = TRUE;
   module->params_size = sizeof(dt_iop_rawoverexposed_t);
   module->gui_data = NULL;
 }

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -786,7 +786,7 @@ void commit_params(
 
   if(!(dt_image_is_rawprepare_supported(&piece->pipe->image))
      || _image_is_normalized(&piece->pipe->image))
-    piece->enabled = 0;
+    piece->enabled = FALSE;
 
   if(piece->pipe->want_detail_mask == (DT_DEV_DETAIL_MASK_REQUIRED | DT_DEV_DETAIL_MASK_RAWPREPARE))
     piece->process_tiling_ready = FALSE;
@@ -822,7 +822,7 @@ void reload_defaults(dt_iop_module_t *self)
                                     .raw_white_point = image->raw_white_point,
                                     .flat_field = has_gainmaps ? FLAT_FIELD_EMBEDDED : FLAT_FIELD_OFF };
 
-  self->hide_enable_button = 1;
+  self->hide_enable_button = TRUE;
   self->default_enabled = dt_image_is_rawprepare_supported(image) && !_image_is_normalized(image);
 
   if(self->widget)

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -789,7 +789,7 @@ void commit_params(
     piece->enabled = 0;
 
   if(piece->pipe->want_detail_mask == (DT_DEV_DETAIL_MASK_REQUIRED | DT_DEV_DETAIL_MASK_RAWPREPARE))
-    piece->process_tiling_ready = 0;
+    piece->process_tiling_ready = FALSE;
 }
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -3573,7 +3573,7 @@ void process(struct dt_iop_module_t *self,
     for(size_t j = 0; j < (size_t)roi_rt->width * roi_rt->height * 4; j += 4) in_retouch[j + 3] = 0.f;
 
     piece->pipe->mask_display = g->mask_display ? DT_DEV_PIXELPIPE_DISPLAY_MASK : DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
-    piece->pipe->bypass_blendif = 1;
+    piece->pipe->bypass_blendif = TRUE;
     usr_data.mask_display = 1;
   }
 
@@ -4411,7 +4411,7 @@ int process_cl(struct dt_iop_module_t *self,
     if(err != CL_SUCCESS) goto cleanup;
 
     piece->pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_MASK;
-    piece->pipe->bypass_blendif = 1;
+    piece->pipe->bypass_blendif = TRUE;
     usr_data.mask_display = 1;
   }
 

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -334,7 +334,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
 
   // this should not be used for normal images
   // (i.e. for those, when this iop is off by default)
-  if((d->rx == 0u) && (d->ry == 0u)) piece->enabled = 0;
+  if((d->rx == 0u) && (d->ry == 0u)) piece->enabled = FALSE;
 }
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -237,7 +237,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelp
   d->y_scale = 1.0f;
 
   if(isnan(p->pixel_aspect_ratio) || p->pixel_aspect_ratio <= 0.0f || p->pixel_aspect_ratio == 1.0f)
-    piece->enabled = 0;
+    piece->enabled = FALSE;
 }
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -745,7 +745,7 @@ void init(dt_iop_module_t *module)
   module->default_params = calloc(1, sizeof(dt_iop_spots_params_t));
   // our module is disabled by default
   // by default:
-  module->default_enabled = 0;
+  module->default_enabled = FALSE;
   module->params_size = sizeof(dt_iop_spots_params_t);
   module->gui_data = NULL;
   // init defaults:

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -689,7 +689,7 @@ void commit_params(struct dt_iop_module_t *self,
 
   if(self->hide_enable_button)
   {
-    piece->enabled = 0;
+    piece->enabled = FALSE;
     return;
   }
 
@@ -1524,7 +1524,7 @@ void reload_defaults(dt_iop_module_t *module)
     dt_is_scene_referred()
     || (is_workflow_none && another_cat_defined);
 
-  module->default_enabled = 0;
+  module->default_enabled = FALSE;
   module->hide_enable_button = true_monochrome;
 
   // White balance module doesn't need to be enabled for true_monochrome raws (like
@@ -1538,7 +1538,7 @@ void reload_defaults(dt_iop_module_t *module)
     if(is_raw)
     {
       // raw images need wb:
-      module->default_enabled = 1;
+      module->default_enabled = TRUE;
 
       // if workflow = modern, only set WB coeffs equivalent to D65 illuminant
       // full chromatic adaptation is deferred to channelmixerrgb

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -700,7 +700,7 @@ void commit_params(struct dt_iop_module_t *self,
 
   // 4Bayer images not implemented in OpenCL yet
   if(self->dev->image_storage.flags & DT_IMAGE_4BAYER)
-    piece->process_cl_ready = 0;
+    piece->process_cl_ready = FALSE;
 
   if(g)
   {

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -594,7 +594,7 @@ void process(struct dt_iop_module_t *self,
     }
   }
 
-  piece->pipe->dsc.temperature.enabled = 1;
+  piece->pipe->dsc.temperature.enabled = TRUE;
   for(int k = 0; k < 4; k++)
   {
     piece->pipe->dsc.temperature.coeffs[k] = d->coeffs[k];
@@ -659,7 +659,7 @@ int process_cl(struct dt_iop_module_t *self,
   dt_opencl_release_mem_object(dev_coeffs);
   dt_opencl_release_mem_object(dev_xtrans);
 
-  piece->pipe->dsc.temperature.enabled = 1;
+  piece->pipe->dsc.temperature.enabled = TRUE;
   for(int k = 0; k < 4; k++)
   {
     piece->pipe->dsc.temperature.coeffs[k] = d->coeffs[k];

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -673,7 +673,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   for(int k = 0; k < 0x10000; k++) d->table[ch_a][k] = d->table[ch_a][k] * 256.0f - 128.0f;
   for(int k = 0; k < 0x10000; k++) d->table[ch_b][k] = d->table[ch_b][k] * 256.0f - 128.0f;
 
-  piece->process_cl_ready = 1;
+  piece->process_cl_ready = TRUE;
   if(p->tonecurve_autoscale_ab == DT_S_SCALE_AUTOMATIC_XYZ)
   {
     // derive curve for XYZ:

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -629,7 +629,7 @@ static int sanity_check(dt_iop_module_t *self)
     dt_print(DT_DEBUG_ALWAYS,
             "tone equalizer needs to be after distortion modules"
             " in the pipeline – disabled\n");
-    self->enabled = 0;
+    self->enabled = FALSE;
     dt_dev_add_history_item(darktable.develop, self, FALSE);
 
     if(self->dev->gui_attached)
@@ -3042,8 +3042,8 @@ static gboolean area_enter_leave_notify(GtkWidget *widget,
                                         GdkEventCrossing *event,
                                         dt_iop_module_t *self)
 {
-  if(darktable.gui->reset) return 1;
-  if(!self->enabled) return 0;
+  if(darktable.gui->reset) return TRUE;
+  if(!self->enabled) return FALSE;
 
   dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
 
@@ -3078,7 +3078,7 @@ static gboolean area_button_press(GtkWidget *widget,
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
 
-  if(darktable.gui->reset) return 1;
+  if(darktable.gui->reset) return TRUE;
 
   dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
 
@@ -3136,8 +3136,8 @@ static gboolean area_motion_notify(GtkWidget *widget,
                                    gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  if(darktable.gui->reset) return 1;
-  if(!self->enabled) return 0;
+  if(darktable.gui->reset) return TRUE;
+  if(!self->enabled) return FALSE;
 
   dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
   dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)self->params;
@@ -3191,8 +3191,8 @@ static gboolean area_button_release(GtkWidget *widget,
                                     gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  if(darktable.gui->reset) return 1;
-  if(!self->enabled) return 0;
+  if(darktable.gui->reset) return TRUE;
+  if(!self->enabled) return FALSE;
 
   dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
 
@@ -3233,7 +3233,7 @@ static gboolean notebook_button_press(GtkWidget *widget,
                                       gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  if(darktable.gui->reset) return 1;
+  if(darktable.gui->reset) return TRUE;
 
   // Give focus to module
   dt_iop_request_focus(self);
@@ -3241,7 +3241,7 @@ static gboolean notebook_button_press(GtkWidget *widget,
   // Unlock the colour picker so we can display our own custom cursor
   dt_iop_color_picker_reset(self, TRUE);
 
-  return 0;
+  return FALSE;
 }
 
 GSList *mouse_actions(struct dt_iop_module_t *self)

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -374,7 +374,7 @@ void init(dt_iop_module_t *module)
   dt_iop_default_init(module);
 
   // Any non-default settings; for example disabling the on/off switch:
-  module->hide_enable_button = 1;
+  module->hide_enable_button = TRUE;
   // To make this work correctly, you also need to hide the widgets, otherwise moving one
   // would enable the module anyway. The standard way is to set up a gtk_stack and show
   // the page that only has a label with an explanatory text when the module can't be used.
@@ -510,11 +510,11 @@ void reload_defaults(dt_iop_module_t *module)
   // As an example, switch off for non-raw images. The enable button was already hidden in init().
   if(!dt_image_is_raw(&module->dev->image_storage))
   {
-    module->default_enabled = 0;
+    module->default_enabled = FALSE;
   }
   else
   {
-    module->default_enabled = 1;
+    module->default_enabled = TRUE;
     d->checker_scale = 3; // something dependent on exif, for example.
   }
 

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -894,7 +894,7 @@ static void dt_lib_histogram_process(struct dt_lib_module_t *self, const float *
                                      const dt_iop_order_iccprofile_info_t *const profile_info_to)
 {
   dt_times_t start;
-  dt_get_times(&start);
+  dt_get_perf_times(&start);
 
   dt_lib_histogram_t *d = (dt_lib_histogram_t *)self->data;
 
@@ -1374,7 +1374,7 @@ static void _lib_histogram_draw_vectorscope(dt_lib_histogram_t *d, cairo_t *cr,
 static gboolean _drawable_draw_callback(GtkWidget *widget, cairo_t *crf, gpointer user_data)
 {
   dt_times_t start;
-  dt_get_times(&start);
+  dt_get_perf_times(&start);
 
   dt_lib_histogram_t *d = (dt_lib_histogram_t *)user_data;
   dt_develop_t *dev = darktable.develop;

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -4532,7 +4532,7 @@ static gboolean _second_window_configure_callback(GtkWidget *da,
     // pipe needs to be reconstructed
     dev->preview2_status = DT_DEV_PIXELPIPE_DIRTY;
     dev->preview2_pipe->changed |= DT_DEV_PIPE_REMOVE;
-    dev->preview2_pipe->cache_obsolete = 1;
+    dev->preview2_pipe->cache_obsolete = TRUE;
   }
   oldw = event->width;
   oldh = event->height;


### PR DESCRIPTION
Sorry, quite a number of changed files.

In the `dt_dev_pixelpipe_iop_t` and `dt_dev_pixelpipe_t` structs many `int` have been changed to `gboolean` if appopriate, also `int` to `dt_develop_detail_mask_t`

Functions ` dt_dev_pixelpipe_process()` and `dt_dev_pixelpipe_process_no_gamma()` now also return a `gboolean` flagging an error or ealy exit instead of an `int`

Make use of  `dt_iop_image_copy_by_size()` instead of a memcpy loop

EDIT for further commits:

Introduced `dt_get_perf_times(dt_times_t *t)` as a `dt_get_times()` variant testig for `DT_DEBUG_PERF` for code deduplication. Also at some places we used the timer without testing so losing cpu cycles.

dt_print_pipe() also gives information about masking and avoid_blending

Adding and modified pixelpipe debugging info for correctness

************************************************
Still trying to understand issues
1. #14058 
2. possibly #13826 
3. possibly #12913

From my tests so far they might all be related to `DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU` mode reading incorrect data and possibly wrong calculation in `gamma` module or taking wrong data for ceating the displayed cairo surface. Ideas about this:
1. The shortcut in pixelpipe checking to avoid un-neccessary module processing might be bad if a module does **not** have same roi_in as roi_out
2. The greyish output observed in #13826 can sometime be reproduced in hlr mode too. Possibly doing wrong processing in `gamma`
3. Maybe we can avoid using cached pixelpipe data at all if in passthru mode?

