### PR TITLE
po/masks arrows - better drawing

### DIFF
--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -893,6 +893,13 @@ void dt_masks_draw_anchor(cairo_t *cr,
                           const float x,
                           const float y);
 
+void dt_masks_closest_point(const int count,
+                            const float *points,
+                            const float px,
+                            const float py,
+                            float *x,
+                            float *y);
+
 void dt_masks_draw_arrow(cairo_t *cr,
                          const float from_x,
                          const float from_y,

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -893,6 +893,14 @@ void dt_masks_draw_anchor(cairo_t *cr,
                           const float x,
                           const float y);
 
+void dt_masks_draw_arrow(cairo_t *cr,
+                         const float from_x,
+                         const float from_y,
+                         const float to_x,
+                         const float to_y,
+                         const float zoom_scale,
+                         const gboolean touch_dest);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif /* __cplusplus */

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -918,6 +918,12 @@ void dt_masks_draw_arrow(cairo_t *cr,
                          const float zoom_scale,
                          const gboolean touch_dest);
 
+/* stroke the arrow on cr depending on selection */
+void dt_masks_stroke_arrow(cairo_t *cr,
+                           const dt_masks_form_gui_t *gui,
+                           const int group,
+                           const float zoom_scale);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif /* __cplusplus */

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -894,6 +894,7 @@ void dt_masks_draw_anchor(cairo_t *cr,
                           const float y);
 
 void dt_masks_closest_point(const int count,
+                            const int nb_ctrl,
                             const float *points,
                             const float px,
                             const float py,

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -893,6 +893,10 @@ void dt_masks_draw_anchor(cairo_t *cr,
                           const float x,
                           const float y);
 
+/* find the closest to point (px, py) in points array.
+   nb_ctrl is the number of points (control points) to
+   skip at the start of points.
+*/
 void dt_masks_closest_point(const int count,
                             const int nb_ctrl,
                             const float *points,
@@ -901,6 +905,11 @@ void dt_masks_closest_point(const int count,
                             float *x,
                             float *y);
 
+/* draw a line from -> to with an arrow at the end.
+   if touch_dest is true then the arrow will be at the
+   (to_x, to_y) location, otherwise a small space will
+   be left.
+*/
 void dt_masks_draw_arrow(cairo_t *cr,
                          const float from_x,
                          const float from_y,

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2749,19 +2749,7 @@ static void _brush_events_post_expose(cairo_t *cr,
                         zoom_scale,
                         FALSE);
 
-    cairo_set_dash(cr, dashed, 0, 0);
-    if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
-      cairo_set_line_width(cr, 2.5 / zoom_scale);
-    else
-      cairo_set_line_width(cr, 1.5 / zoom_scale);
-    dt_draw_set_color_overlay(cr, FALSE, 0.8);
-    cairo_stroke_preserve(cr);
-    if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
-      cairo_set_line_width(cr, 1.0 / zoom_scale);
-    else
-      cairo_set_line_width(cr, 0.5 / zoom_scale);
-    dt_draw_set_color_overlay(cr, TRUE, 0.8);
-    cairo_stroke(cr);
+    dt_masks_stroke_arrow(cr, gui, index, zoom_scale);
 
     // we draw the source
     cairo_set_dash(cr, dashed, 0, 0);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2743,8 +2743,12 @@ static void _brush_events_post_expose(cairo_t *cr,
   if(!gui->creation && gpt->source_count > nb * 3 + 2)
   {
     // we draw the line between source and dest
-    cairo_move_to(cr, gpt->source[2], gpt->source[3]);
-    cairo_line_to(cr, gpt->points[2], gpt->points[3]);
+    dt_masks_draw_arrow(cr,
+                        gpt->source[2], gpt->source[3],
+                        gpt->points[2], gpt->points[3],
+                        zoom_scale,
+                        FALSE);
+
     cairo_set_dash(cr, dashed, 0, 0);
     if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
       cairo_set_line_width(cr, 2.5 / zoom_scale);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -33,6 +33,15 @@
 #define BORDER_MIN 0.00005f
 #define BORDER_MAX 0.5f
 
+static void _brush_bounding_box(const float *const points,
+                                const float *const border,
+                                const int nb_corner,
+                                const int num_points,
+                                int *width,
+                                int *height,
+                                int *posx,
+                                int *posy);
+
 /** get squared distance of indexed point to line segment, taking
  * weighted payload data into account */
 static float _brush_point_line_distance2(const int index,
@@ -2742,10 +2751,43 @@ static void _brush_events_post_expose(cairo_t *cr,
   // draw the source if needed
   if(!gui->creation && gpt->source_count > nb * 3 + 2)
   {
-    // we draw the line between source and dest
+    float to_x = 0.0f;
+    float to_y = 0.0f;
+    float from_x = 0.0f;
+    float from_y = 0.0f;
+
+    int width = 0;
+    int height = 0;
+    int posx = 0;
+    int posy = 0;
+
+    // 1. find source brush bounding box
+    _brush_bounding_box(gpt->source, NULL, nb,
+                        gpt->source_count,
+                        &width, &height, &posx, &posy);
+
+    // 2. source area center
+    const float center_x = (float)posx + (float)width / 2.f;
+    const float center_y = (float)posy + (float)height / 2.f;
+
+    // 3. dest border, closest to source area center
+    dt_masks_closest_point(gpt->points_count,
+                           nb * 3,
+                           gpt->points,
+                           center_x, center_y,
+                           &to_x, &to_y);
+
+    // 4. source border, closest to point border
+    dt_masks_closest_point(gpt->source_count,
+                           nb * 3,
+                           gpt->source,
+                           to_x, to_y,
+                           &from_x, &from_y);
+
+    // 5. we draw the line between source and dest
     dt_masks_draw_arrow(cr,
-                        gpt->source[2], gpt->source[3],
-                        gpt->points[2], gpt->points[3],
+                        from_x, from_y,
+                        to_x, to_y,
                         zoom_scale,
                         FALSE);
 
@@ -2789,13 +2831,17 @@ static void _brush_bounding_box_raw(const float *const points,
 #endif
   for(int i = nb_corner * 3; i < num_points; i++)
   {
-    // we look at the borders
-    const float x = border[i * 2];
-    const float y = border[i * 2 + 1];
-    xmin = MIN(x, xmin);
-    xmax = MAX(x, xmax);
-    ymin = MIN(y, ymin);
-    ymax = MAX(y, ymax);
+    if(border)
+    {
+      // we look at the borders
+      const float x = border[i * 2];
+      const float y = border[i * 2 + 1];
+      xmin = MIN(x, xmin);
+      xmax = MAX(x, xmax);
+      ymin = MIN(y, ymin);
+      ymax = MAX(y, ymax);
+    }
+
     // we look at the brush too
     const float xx = points[i * 2];
     const float yy = points[i * 2 + 1];

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -941,14 +941,23 @@ static void _circle_events_post_expose(cairo_t *cr,
       else
         cangle = -(M_PI / 2) - cangle;
 
-      // (arrowx, arrowy) is the point of intersection
-      const float arrowx = gpt->points[0] + radius * cosf(cangle);
-      const float arrowy = gpt->points[1] + radius * sinf(cangle);
+      // (to_x, to_y) is the point of intersection
+      const float to_x = gpt->points[0] + radius * cosf(cangle);
+      const float to_y = gpt->points[1] + radius * sinf(cangle);
+
+      float from_x = 0.0f;
+      float from_y = 0.0f;
+
+      dt_masks_closest_point(gpt->source_count,
+                             0,
+                             gpt->source,
+                             to_x, to_y,
+                             &from_x, &from_y);
 
       // then draw two lines for the arrow itself
       dt_masks_draw_arrow(cr,
-                          gpt->source[0], gpt->source[1],
-                          arrowx, arrowy,
+                          from_x,from_y,
+                          to_x, to_y,
                           zoom_scale,
                           FALSE);
 

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -949,7 +949,7 @@ static void _circle_events_post_expose(cairo_t *cr,
       float from_y = 0.0f;
 
       dt_masks_closest_point(gpt->source_count,
-                             0,
+                             2,
                              gpt->source,
                              to_x, to_y,
                              &from_x, &from_y);

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -923,7 +923,6 @@ static void _circle_events_post_expose(cairo_t *cr,
   // draw the source if any
   if(gpt->source_count > 6)
   {
-    const float pr_d = darktable.develop->preview_downsampling;
     const float radius = fabs(gpt->points[2] - gpt->points[0]);
 
     // compute the dest inner circle intersection with the line from
@@ -942,21 +941,16 @@ static void _circle_events_post_expose(cairo_t *cr,
       else
         cangle = -(M_PI / 2) - cangle;
 
-      // (arrowx,arrowy) is the point of intersection, we move it
-      // (factor 1.11) a bit farther than the inner circle to avoid
-      // superposition.
-      const float arrowx = gpt->points[0] + 1.11 * radius * cosf(cangle);
-      const float arrowy = gpt->points[1] + 1.11 * radius * sinf(cangle);
+      // (arrowx, arrowy) is the point of intersection
+      const float arrowx = gpt->points[0] + radius * cosf(cangle);
+      const float arrowy = gpt->points[1] + radius * sinf(cangle);
 
-      cairo_move_to(cr, gpt->source[0], gpt->source[1]); // source center
-      cairo_line_to(cr, arrowx, arrowy);                 // dest border
-      // then draw to line for the arrow itself
-      const float arrow_scale = 6.0f * pr_d;
-      cairo_move_to(cr, arrowx + arrow_scale * cosf(cangle + (0.4f)),
-                    arrowy + arrow_scale * sinf(cangle + (0.4f)));
-      cairo_line_to(cr, arrowx, arrowy);
-      cairo_line_to(cr, arrowx + arrow_scale * cosf(cangle - (0.4f)),
-                    arrowy + arrow_scale * sinf(cangle - (0.4f)));
+      // then draw two lines for the arrow itself
+      dt_masks_draw_arrow(cr,
+                          gpt->source[0], gpt->source[1],
+                          arrowx, arrowy,
+                          zoom_scale,
+                          FALSE);
 
       cairo_set_dash(cr, dashed, 0, 0);
       if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -923,8 +923,6 @@ static void _circle_events_post_expose(cairo_t *cr,
   // draw the source if any
   if(gpt->source_count > 6)
   {
-    const float radius = fabs(gpt->points[2] - gpt->points[0]);
-
     // compute the dest inner circle intersection with the line from
     // source center to dest center.
     const float cdx = gpt->source[0] - gpt->points[0];
@@ -934,19 +932,17 @@ static void _circle_events_post_expose(cairo_t *cr,
     if(cdx != 0.0 && cdy != 0.0)
     {
       cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-      float cangle = atanf(cdx / cdy);
 
-      if(cdy > 0)
-        cangle = (M_PI / 2) - cangle;
-      else
-        cangle = -(M_PI / 2) - cangle;
-
-      // (to_x, to_y) is the point of intersection
-      const float to_x = gpt->points[0] + radius * cosf(cangle);
-      const float to_y = gpt->points[1] + radius * sinf(cangle);
-
+      float to_x = 0.0f;
+      float to_y = 0.0f;
       float from_x = 0.0f;
       float from_y = 0.0f;
+
+      dt_masks_closest_point(gpt->points_count,
+                             2,
+                             gpt->points,
+                             gpt->source[0], gpt->source[1],
+                             &to_x, &to_y);
 
       dt_masks_closest_point(gpt->source_count,
                              2,

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -957,19 +957,7 @@ static void _circle_events_post_expose(cairo_t *cr,
                           zoom_scale,
                           FALSE);
 
-      cairo_set_dash(cr, dashed, 0, 0);
-      if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
-        cairo_set_line_width(cr, 2.5 / zoom_scale);
-      else
-        cairo_set_line_width(cr, 1.5 / zoom_scale);
-      dt_draw_set_color_overlay(cr, FALSE, 0.8);
-      cairo_stroke_preserve(cr);
-      if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
-        cairo_set_line_width(cr, 1.0 / zoom_scale);
-      else
-        cairo_set_line_width(cr, 0.5 / zoom_scale);
-      dt_draw_set_color_overlay(cr, TRUE, 0.8);
-      cairo_stroke(cr);
+      dt_masks_stroke_arrow(cr, gui, index, zoom_scale);
     }
 
     // we only the main shape for the source, no borders

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1361,11 +1361,16 @@ static void _ellipse_events_post_expose(cairo_t *cr,
 
       float x = 0.0f, y = 0.0f;
 
-      float masks_border = dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, border));
-      int flags = dt_conf_get_int(DT_MASKS_CONF(form->type, ellipse, flags));
-      float radius_a = dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, radius_a));
-      float radius_b = dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, radius_b));
-      float rotation = dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, rotation));
+      const float masks_border =
+        dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, border));
+      const int flags =
+        dt_conf_get_int(DT_MASKS_CONF(form->type, ellipse, flags));
+      const float radius_a =
+        dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, radius_a));
+      const float radius_b =
+        dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, radius_b));
+      const float rotation =
+        dt_conf_get_float(DT_MASKS_CONF(form->type, ellipse, rotation));
 
       float pzx = gui->posx;
       float pzy = gui->posy;
@@ -1394,15 +1399,14 @@ static void _ellipse_events_post_expose(cairo_t *cr,
                                  rotation, &points, &points_count);
       if(draw && masks_border > 0.f)
       {
-        draw = _ellipse_get_points(
-            darktable.develop, x, y,
-            (flags & DT_MASKS_ELLIPSE_PROPORTIONAL
-             ? radius_a * (1.0f + masks_border)
-             : radius_a + masks_border),
-            (flags & DT_MASKS_ELLIPSE_PROPORTIONAL
-             ? radius_b * (1.0f + masks_border)
-             : radius_b + masks_border),
-            rotation, &border, &border_count);
+        draw = _ellipse_get_points(darktable.develop, x, y,
+                                   (flags & DT_MASKS_ELLIPSE_PROPORTIONAL
+                                    ? radius_a * (1.0f + masks_border)
+                                    : radius_a + masks_border),
+                                   (flags & DT_MASKS_ELLIPSE_PROPORTIONAL
+                                    ? radius_b * (1.0f + masks_border)
+                                    : radius_b + masks_border),
+                                   rotation, &border, &border_count);
       }
 
       if(draw && points_count >= 2)
@@ -1487,7 +1491,6 @@ static void _ellipse_events_post_expose(cairo_t *cr,
   // draw the source if any
   if(gpt->source_count > 10)
   {
-    const float pr_d = darktable.develop->preview_downsampling;
     // compute the dest inner ellipse intersection with the line from
     // source center to dest center.
     const float cdx = gpt->source[0] - gpt->points[0];
@@ -1563,16 +1566,11 @@ static void _ellipse_events_post_expose(cairo_t *cr,
         }
       }
 
-      cairo_move_to(cr, gpt->source[0], gpt->source[1]); // source center
-      cairo_line_to(cr, arrowx, arrowy);                 // dest border
-      // then draw to line for the arrow itself
-      const float arrow_scale = 6.0 * pr_d;
-
-      cairo_move_to(cr, arrowx + arrow_scale * cosf(cangle + (0.4)),
-                    arrowy + arrow_scale * sinf(cangle + (0.4)));
-      cairo_line_to(cr, arrowx, arrowy);
-      cairo_line_to(cr, arrowx + arrow_scale * cosf(cangle - (0.4)),
-                    arrowy + arrow_scale * sinf(cangle - (0.4)));
+      dt_masks_draw_arrow(cr,
+                          gpt->source[0], gpt->source[1],
+                          arrowx, arrowy,
+                          zoom_scale,
+                          FALSE);
 
       cairo_set_dash(cr, dashed, 0, 0);
       if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1523,19 +1523,7 @@ static void _ellipse_events_post_expose(cairo_t *cr,
                           zoom_scale,
                           FALSE);
 
-      cairo_set_dash(cr, dashed, 0, 0);
-      if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
-        cairo_set_line_width(cr, 2.5 / zoom_scale);
-      else
-        cairo_set_line_width(cr, 1.5 / zoom_scale);
-      dt_draw_set_color_overlay(cr, FALSE, 0.8);
-      cairo_stroke_preserve(cr);
-      if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
-        cairo_set_line_width(cr, 1.0 / zoom_scale);
-      else
-        cairo_set_line_width(cr, 0.5 / zoom_scale);
-      dt_draw_set_color_overlay(cr, TRUE, 0.8);
-      cairo_stroke(cr);
+      dt_masks_stroke_arrow(cr, gui, index, zoom_scale);
     }
 
     // we draw the source

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1503,7 +1503,9 @@ static void _ellipse_events_post_expose(cairo_t *cr,
       float arrowx = 0.0f;
       float arrowy = 0.0f;
 
-      dt_masks_closest_point(gpt->source_count, gpt->points,
+      dt_masks_closest_point(gpt->source_count,
+                             6,
+                             gpt->points,
                              gpt->source[0], gpt->source[1],
                              &arrowx, &arrowy);
       dt_masks_draw_arrow(cr,

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1500,17 +1500,26 @@ static void _ellipse_events_post_expose(cairo_t *cr,
     if(cdx != 0.0 && cdy != 0.0)
     {
       cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-      float arrowx = 0.0f;
-      float arrowy = 0.0f;
+      float to_x = 0.0f;
+      float to_y = 0.0f;
+      float from_x = 0.0f;
+      float from_y = 0.0f;
 
-      dt_masks_closest_point(gpt->source_count,
+      dt_masks_closest_point(gpt->points_count,
                              6,
                              gpt->points,
                              gpt->source[0], gpt->source[1],
-                             &arrowx, &arrowy);
+                             &to_x, &to_y);
+
+      dt_masks_closest_point(gpt->source_count,
+                             6,
+                             gpt->source,
+                             to_x, to_y,
+                             &from_x, &from_y);
+
       dt_masks_draw_arrow(cr,
-                          gpt->source[0], gpt->source[1],
-                          arrowx, arrowy,
+                          from_x, from_y,
+                          to_x, to_y,
                           zoom_scale,
                           FALSE);
 

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1500,72 +1500,12 @@ static void _ellipse_events_post_expose(cairo_t *cr,
     if(cdx != 0.0 && cdy != 0.0)
     {
       cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-      float cangle = atanf(cdx / cdy);
-
-      if(cdy > 0)
-        cangle = (M_PI / 2) - cangle;
-      else
-        cangle = -(M_PI / 2) - cangle;
-
-      // compute raidus a & radius b. at this stage this must be
-      // computed from the list of transformed point for drawing the
-      // ellipse.
-
-      const float bot_x = gpt->points[2];
-      const float bot_y = gpt->points[3];
-      const float rgt_x = gpt->points[6];
-      const float rgt_y = gpt->points[7];
-      const float cnt_x = gpt->points[0];
-      const float cnt_y = gpt->points[1];
-
-      const float adx = cnt_x - bot_x;
-      const float ady = cnt_y - bot_y;
-      const float a = sqrtf(adx * adx + ady * ady);
-
-      const float bdx = cnt_x - rgt_x;
-      const float bdy = cnt_y - rgt_y;
-      const float b = sqrtf(bdx * bdx + bdy * bdy);
-
-      // takes the biggest radius, should always been a as the points
-      // are arranged
-      const float radius = MAX(a, b);
-
-      // the top/left/bottom/right controls of the ellipse are not
-      // always at the same place in g->points[], it depends on the
-      // rotation of the ellipse which is not recorded anywhere. Let's
-      // use a stupid search to find the closest point on the border
-      // where to attach the arrow.
-
-      const float cosc = cosf(cangle);
-      const float sinc = sinf(cangle);
-      const float step = radius / 259.f;
-
-      float dist = FLT_MAX;
       float arrowx = 0.0f;
       float arrowy = 0.0f;
 
-      for(int k=1; k<gpt->source_count; k+=2)
-      {
-        const float px = gpt->points[k*2];
-        const float py = gpt->points[k*2 + 1];
-
-        float rr = 0.01f;
-        while(rr < radius)
-        {
-          const float epx = cnt_x + rr * cosc;
-          const float epy = cnt_y + rr * sinc;
-          const float edist = sqf(epx - px) + sqf(epy - py);
-
-          if(edist < dist)
-          {
-            dist = edist;
-            arrowx = cnt_x + (rr + 1.11) * cosc;
-            arrowy = cnt_y + (rr + 1.11) * sinc;
-          }
-          rr += step;
-        }
-      }
-
+      dt_masks_closest_point(gpt->source_count, gpt->points,
+                             gpt->source[0], gpt->source[1],
+                             &arrowx, &arrowy);
       dt_masks_draw_arrow(cr,
                           gpt->source[0], gpt->source[1],
                           arrowx, arrowy,

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2702,6 +2702,34 @@ void dt_masks_draw_arrow(cairo_t *cr,
   }
 }
 
+void dt_masks_stroke_arrow(cairo_t *cr,
+                           const dt_masks_form_gui_t *gui,
+                           const int group,
+                           const float zoom_scale)
+{
+  double dashed[] = { 4.0, 4.0 };
+  dashed[0] /= zoom_scale;
+  dashed[1] /= zoom_scale;
+
+  cairo_set_dash(cr, dashed, 0, 0);
+
+  if((gui->group_selected == group) && (gui->form_selected || gui->form_dragging))
+    cairo_set_line_width(cr, 2.5 / zoom_scale);
+  else
+    cairo_set_line_width(cr, 1.5 / zoom_scale);
+
+  dt_draw_set_color_overlay(cr, FALSE, 0.8);
+  cairo_stroke_preserve(cr);
+
+  if((gui->group_selected == group) && (gui->form_selected || gui->form_dragging))
+    cairo_set_line_width(cr, 1.0 / zoom_scale);
+  else
+    cairo_set_line_width(cr, 0.5 / zoom_scale);
+
+  dt_draw_set_color_overlay(cr, TRUE, 0.8);
+  cairo_stroke(cr);
+}
+
 void dt_masks_closest_point(const int count,
                             const int nb_ctrl,
                             const float *points,

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2658,37 +2658,49 @@ void dt_masks_draw_arrow(cairo_t *cr,
                          const gboolean touch_dest)
 {
   const float pr_d = darktable.develop->preview_downsampling;
+  const float dx = from_x - to_x;
+  const float dy = from_y - to_y;
+  const float size = sqf(dx*dx + dy*dy) * pr_d;
+  const float arrow_size = 24.0f * pr_d;
 
-  const float arrow_scale = (24.0f * pr_d) / sqrtf(3.f * zoom_scale);
+  const float arrow_scale = arrow_size / sqrtf(3.f * zoom_scale);
 
-  const float cdx = from_x - to_x;
-  const float cdy = from_y - to_y;
+  const gboolean draw_arrow = (size > 96.f * arrow_size);
 
-  float cangle = atanf(cdx / cdy);
+  float cangle = atanf(dx / dy);
 
-  if(cdy > 0)
+  if(dy > 0)
     cangle = (M_PI / 2) - cangle;
   else
     cangle = -(M_PI / 2) - cangle;
 
   // move a bit away from the path
-  const float x = to_x + (touch_dest ? 0.f : 5.f * cosf(cangle) / zoom_scale);
-  const float y = to_y + (touch_dest ? 0.f : 5.f * sinf(cangle) / zoom_scale);
+  const float x = to_x + (touch_dest
+                          ? 0.f
+                          : 5.f * cosf(cangle) / zoom_scale);
 
-  cairo_move_to(cr, from_x, from_y); // source center
-  cairo_line_to(cr, x, y);           // dest border + a bit of space
+  const float y = to_y + (touch_dest
+                          ? 0.f
+                          : 5.f * sinf(cangle) / zoom_scale);
 
-  // then draw to line for the arrow itself
+  cairo_move_to(cr, from_x, from_y); // start
+  cairo_line_to(cr, x, y);           // end + a bit of space
 
-  cairo_move_to(cr,
-                x + arrow_scale * cosf(cangle + (0.4)),
-                y + arrow_scale * sinf(cangle + (0.4)));
+  // no arrow when size too small
+  if(draw_arrow)
+  {
+    // then draw to line for the arrow itself
 
-  cairo_line_to(cr, x, y);
+    cairo_move_to(cr,
+                  x + arrow_scale * cosf(cangle + (0.4)),
+                  y + arrow_scale * sinf(cangle + (0.4)));
 
-  cairo_line_to(cr,
-                x + arrow_scale * cosf(cangle - (0.4)),
-                y + arrow_scale * sinf(cangle - (0.4)));
+    cairo_line_to(cr, x, y);
+
+    cairo_line_to(cr,
+                  x + arrow_scale * cosf(cangle - (0.4)),
+                  y + arrow_scale * sinf(cangle - (0.4)));
+  }
 }
 
 void dt_masks_closest_point(const int count,

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2660,12 +2660,11 @@ void dt_masks_draw_arrow(cairo_t *cr,
   const float pr_d = darktable.develop->preview_downsampling;
   const float dx = from_x - to_x;
   const float dy = from_y - to_y;
-  const float size = sqf(dx*dx + dy*dy) * pr_d;
   const float arrow_size = 24.0f * pr_d;
 
   const float arrow_scale = arrow_size / sqrtf(3.f * zoom_scale);
 
-  const gboolean draw_arrow = (size > 96.f * arrow_size);
+  const gboolean draw_arrow = TRUE;
 
   float cangle = atanf(dx / dy);
 

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2658,7 +2658,8 @@ void dt_masks_draw_arrow(cairo_t *cr,
                          const gboolean touch_dest)
 {
   const float pr_d = darktable.develop->preview_downsampling;
-  const float arrow_scale = (24.0f * pr_d) / zoom_scale;
+
+  const float arrow_scale = (24.0f * pr_d) / sqrtf(3.f * zoom_scale);
 
   const float cdx = from_x - to_x;
   const float cdy = from_y - to_y;
@@ -2671,8 +2672,8 @@ void dt_masks_draw_arrow(cairo_t *cr,
     cangle = -(M_PI / 2) - cangle;
 
   // move a bit away from the path
-  const float x = to_x + (touch_dest ? 0.f : 6.f * cosf(cangle) / zoom_scale);
-  const float y = to_y + (touch_dest ? 0.f : 6.f * sinf(cangle) / zoom_scale);
+  const float x = to_x + (touch_dest ? 0.f : 5.f * cosf(cangle) / zoom_scale);
+  const float y = to_y + (touch_dest ? 0.f : 5.f * sinf(cangle) / zoom_scale);
 
   cairo_move_to(cr, from_x, from_y); // source center
   cairo_line_to(cr, x, y);           // dest border + a bit of space
@@ -2691,6 +2692,7 @@ void dt_masks_draw_arrow(cairo_t *cr,
 }
 
 void dt_masks_closest_point(const int count,
+                            const int nb_ctrl,
                             const float *points,
                             const float px,
                             const float py,
@@ -2701,7 +2703,7 @@ void dt_masks_closest_point(const int count,
   *x = px;
   *y = py;
 
-  for(int i = 1; i < count; i++)
+  for(int i = nb_ctrl; i < count; i++)
   {
     const float dx = points[i * 2] - px;
     const float dy = points[i * 2 + 1] - py;

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2649,6 +2649,47 @@ void dt_masks_draw_anchor(cairo_t *cr,
   cairo_stroke(cr);
 }
 
+void dt_masks_draw_arrow(cairo_t *cr,
+                         const float from_x,
+                         const float from_y,
+                         const float to_x,
+                         const float to_y,
+                         const float zoom_scale,
+                         const gboolean touch_dest)
+{
+  const float pr_d = darktable.develop->preview_downsampling;
+  const float arrow_scale = (24.0f * pr_d) / zoom_scale;
+
+  const float cdx = from_x - to_x;
+  const float cdy = from_y - to_y;
+
+  float cangle = atanf(cdx / cdy);
+
+  if(cdy > 0)
+    cangle = (M_PI / 2) - cangle;
+  else
+    cangle = -(M_PI / 2) - cangle;
+
+  // move a bit away from the path
+  const float x = to_x + (touch_dest ? 0.f : 6.f * cosf(cangle) / zoom_scale);
+  const float y = to_y + (touch_dest ? 0.f : 6.f * sinf(cangle) / zoom_scale);
+
+  cairo_move_to(cr, from_x, from_y); // source center
+  cairo_line_to(cr, x, y);           // dest border + a bit of space
+
+  // then draw to line for the arrow itself
+
+  cairo_move_to(cr,
+                x + arrow_scale * cosf(cangle + (0.4)),
+                y + arrow_scale * sinf(cangle + (0.4)));
+
+  cairo_line_to(cr, x, y);
+
+  cairo_line_to(cr,
+                x + arrow_scale * cosf(cangle - (0.4)),
+                y + arrow_scale * sinf(cangle - (0.4)));
+}
+
 #include "detail.c"
 
 // clang-format off

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2690,6 +2690,32 @@ void dt_masks_draw_arrow(cairo_t *cr,
                 y + arrow_scale * sinf(cangle - (0.4)));
 }
 
+void dt_masks_closest_point(const int count,
+                            const float *points,
+                            const float px,
+                            const float py,
+                            float *x,
+                            float *y)
+{
+  float dist = FLT_MAX;
+  *x = px;
+  *y = py;
+
+  for(int i = 1; i < count; i++)
+  {
+    const float dx = points[i * 2] - px;
+    const float dy = points[i * 2 + 1] - py;
+
+    const float d = sqf(dx*dx + dy*dy);
+    if(d < dist)
+    {
+      *x = points[i * 2];
+      *y = points[i * 2 + 1];
+      dist = d;
+    }
+  }
+}
+
 #include "detail.c"
 
 // clang-format off

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -2366,8 +2366,12 @@ static void _path_events_post_expose(cairo_t *cr,
   if(!gui->creation && gpt->source_count > nb * 3 + 6)
   {
     // we draw the line between source and dest
-    cairo_move_to(cr, gpt->source[2], gpt->source[3]);
-    cairo_line_to(cr, gpt->points[2], gpt->points[3]);
+    dt_masks_draw_arrow(cr,
+                        gpt->source[2], gpt->source[3],
+                        to_x, to_y,
+                        zoom_scale,
+                        FALSE);
+
     cairo_set_dash(cr, dashed, 0, 0);
     if((gui->group_selected == index)
        && (gui->form_selected || gui->form_dragging))

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -2372,11 +2372,15 @@ static void _path_events_post_expose(cairo_t *cr,
     float from_x = 0.0f;
     float from_y = 0.0f;
 
-    dt_masks_closest_point(gpt->points_count, gpt->points,
+    dt_masks_closest_point(gpt->points_count,
+                           nb * 3,
+                           gpt->points,
                            gpt->source[2], gpt->source[3],
                            &to_x, &to_y);
 
-    dt_masks_closest_point(gpt->source_count, gpt->source,
+    dt_masks_closest_point(gpt->source_count,
+                           nb * 3,
+                           gpt->source,
                            to_x, to_y,
                            &from_x, &from_y);
 

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -2417,24 +2417,7 @@ static void _path_events_post_expose(cairo_t *cr,
                         zoom_scale,
                         FALSE);
 
-    cairo_set_dash(cr, dashed, 0, 0);
-    if((gui->group_selected == index)
-       && (gui->form_selected || gui->form_dragging))
-      cairo_set_line_width(cr, 2.5 / zoom_scale);
-    else
-      cairo_set_line_width(cr, 1.5 / zoom_scale);
-
-    dt_draw_set_color_overlay(cr, FALSE, 0.8);
-    cairo_stroke_preserve(cr);
-
-    if((gui->group_selected == index)
-       && (gui->form_selected || gui->form_dragging))
-      cairo_set_line_width(cr, 1.0 / zoom_scale);
-    else
-      cairo_set_line_width(cr, 0.5 / zoom_scale);
-
-    dt_draw_set_color_overlay(cr, TRUE, 0.8);
-    cairo_stroke(cr);
+    dt_masks_stroke_arrow(cr, gui, index, zoom_scale);
 
     // we draw the source
     cairo_set_dash(cr, dashed, 0, 0);

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -2369,14 +2369,20 @@ static void _path_events_post_expose(cairo_t *cr,
     // the arrow to cross the mask.
     float to_x = 0.0f;
     float to_y = 0.0f;
+    float from_x = 0.0f;
+    float from_y = 0.0f;
 
     dt_masks_closest_point(gpt->points_count, gpt->points,
                            gpt->source[2], gpt->source[3],
                            &to_x, &to_y);
 
+    dt_masks_closest_point(gpt->source_count, gpt->source,
+                           to_x, to_y,
+                           &from_x, &from_y);
+
     // we draw the line between source and dest
     dt_masks_draw_arrow(cr,
-                        gpt->source[2], gpt->source[3],
+                        from_x, from_y, // gpt->source[2], gpt->source[3],
                         to_x, to_y,
                         zoom_scale,
                         FALSE);

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -2365,6 +2365,15 @@ static void _path_events_post_expose(cairo_t *cr,
   // draw the source if needed
   if(!gui->creation && gpt->source_count > nb * 3 + 6)
   {
+    // look for the destination point closest to the source to avoid
+    // the arrow to cross the mask.
+    float to_x = 0.0f;
+    float to_y = 0.0f;
+
+    dt_masks_closest_point(gpt->points_count, gpt->points,
+                           gpt->source[2], gpt->source[3],
+                           &to_x, &to_y);
+
     // we draw the line between source and dest
     dt_masks_draw_arrow(cr,
                         gpt->source[2], gpt->source[3],


### PR DESCRIPTION
A bit of love for the masks arrows to/from the source & destination.

Before:
![image](https://user-images.githubusercontent.com/467069/229307095-da907076-fead-4eea-9c3e-1f76ac0a0ed2.png)

200%
![image](https://user-images.githubusercontent.com/467069/229307132-41e1541d-d827-4819-a8f2-dc63b8caef5f.png)

400% (tiny arrow):
![image](https://user-images.githubusercontent.com/467069/229307172-d4d0b8f1-5a00-4817-96a0-05342c5c8348.png)

After:
![image](https://user-images.githubusercontent.com/467069/229307297-7ccc66fe-ac0f-49cf-99b4-bb45a59d90e6.png)

200%:
![image](https://user-images.githubusercontent.com/467069/229307273-553040b9-21a5-4e98-9f9a-3c7a6affc622.png)

400% (tiny arrow):
![image](https://user-images.githubusercontent.com/467069/229307243-14e22da8-bdc8-4991-82b9-a52300d007a1.png)
