### PR TITLE
fix crash when checking a gui.action in other view from lua

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -3453,11 +3453,11 @@ float dt_action_process(const gchar *action, int instance, const gchar *element,
   }
 
   const dt_view_type_flags_t vws = _find_views(ac);
-  if(!(vws & darktable.view_manager->current_view->view(darktable.view_manager->current_view))
-     && !isnan(move_size))
+  if(!(vws & darktable.view_manager->current_view->view(darktable.view_manager->current_view)))
   {
-    dt_print(DT_DEBUG_ALWAYS,
-             "[dt_action_process] action '%s' not valid for current view\n", action);
+    if(!isnan(move_size))
+      dt_print(DT_DEBUG_ALWAYS,
+              "[dt_action_process] action '%s' not valid for current view\n", action);
     return NAN;
   }
 


### PR DESCRIPTION
fixes #14095

This fixes a recent change that allowed polling (i.e. asking result from but not changing) a gui.action from lua without writing an error. This allows simpler mimic scripts that only care about darkroom that otherwise would generate a long log when linked to midi devices (that continuously poll). But we should still immediately return nan without trying to process the action which occasionally (checking if an iop is enabled) causes problems.

@MStraeten would you kindly review and see if that solves your issue? And thanks for reporting.