### PR TITLE
Some updates on darkroom view related stuff

### DIFF
--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -21,6 +21,7 @@
 #include "common/iop_profile.h"
 #include "common/opencl.h"
 #include "develop/pixelpipe.h"
+#include "develop/masks.h"
 #include "dtgtk/button.h"
 #include "dtgtk/gradientslider.h"
 #include "gui/color_picker_proxy.h"
@@ -346,7 +347,7 @@ typedef struct dt_iop_gui_blend_data_t
   GtkWidget *masks_edit;
   GtkWidget *masks_polarity;
   int *masks_combo_ids;
-  int masks_shown;
+  dt_masks_edit_mode_t masks_shown;
 
   GtkWidget *raster_combo;
   GtkWidget *raster_polarity;

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -62,8 +62,8 @@ void dt_dev_init(dt_develop_t *dev, gboolean gui_attached)
   dev->average_delay = DT_DEV_AVERAGE_DELAY_START;
   dev->preview_average_delay = DT_DEV_PREVIEW_AVERAGE_DELAY_START;
   dev->preview2_average_delay = DT_DEV_PREVIEW_AVERAGE_DELAY_START;
-  dev->gui_leaving = 0;
-  dev->gui_synch = 0;
+  dev->gui_leaving = FALSE;
+  dev->gui_synch = FALSE;
   dt_pthread_mutex_init(&dev->history_mutex, NULL);
   dev->history_end = 0;
   dev->history = NULL; // empty list
@@ -580,8 +580,7 @@ void dt_dev_process_image_job(dt_develop_t *dev)
       dev->preview_status = DT_DEV_PIXELPIPE_DIRTY;
       dev->preview2_input_changed = TRUE;
       dev->preview2_status = DT_DEV_PIXELPIPE_DIRTY;
-      dev->gui_synch = 1; // notify gui thread we want to synch (call
-                          // gui_update in the modules)
+      dev->gui_synch = TRUE; // notify gui thread we want to synch (call gui_update in the modules)
       dev->preview_pipe->changed |= DT_DEV_PIPE_SYNCH;
       dev->preview2_pipe->changed |= DT_DEV_PIPE_SYNCH;
     }

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -149,8 +149,8 @@ typedef struct dt_develop_t
 {
   gboolean gui_attached; // != 0 if the gui should be notified of changes in hist stack and modules should be
                         // gui_init'ed.
-  int32_t gui_leaving;  // set if everything is scheduled to shut down.
-  int32_t gui_synch;    // set by the render threads if gui_update should be called in the modules.
+  gboolean gui_leaving;  // set if everything is scheduled to shut down.
+  gboolean gui_synch;    // set to TRUE by the render threads if gui_update should be called in the modules.
   int32_t focus_hash;   // determines whether to start a new history item or to merge down.
   gboolean preview_loading, preview2_loading, image_loading, history_updating, image_force_reload, first_load;
   gboolean preview_input_changed, preview2_input_changed;
@@ -211,7 +211,7 @@ typedef struct dt_develop_t
   GList *allforms;
 
   //full preview stuff
-  int full_preview;
+  gboolean full_preview;
   int full_preview_last_zoom, full_preview_last_closeup;
   float full_preview_last_zoom_x, full_preview_last_zoom_y;
   struct dt_iop_module_t *full_preview_last_module;

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1005,7 +1005,7 @@ static void _tree_selection_change(GtkTreeSelection *selection, dt_lib_masks_t *
              && !(module->flags() & IOP_FLAGS_NO_MASKS))
           {
             dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
-            bd->masks_shown = 1;
+            bd->masks_shown = DT_MASKS_EDIT_FULL;
             gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), TRUE);
             gtk_widget_queue_draw(bd->masks_edit);
           }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -81,7 +81,7 @@ static void _update_softproof_gamut_checking(dt_develop_t *d);
 
 /* signal handler for filmstrip image switching */
 static void _view_darkroom_filmstrip_activate_callback(gpointer instance,
-                                                       const int imgid,
+                                                       const int32_t imgid,
                                                        gpointer user_data);
 
 static void _dev_change_image(dt_develop_t *dev, const int32_t imgid);
@@ -177,11 +177,7 @@ void cleanup(dt_view_t *self)
 
 static dt_darkroom_layout_t _lib_darkroom_get_layout(dt_view_t *self)
 {
-  dt_develop_t *dev = (dt_develop_t *)self->data;
-  if(dev->iso_12646.enabled)
-    return DT_DARKROOM_LAYOUT_EDITING;
-  else
-    return DT_DARKROOM_LAYOUT_EDITING;
+  return DT_DARKROOM_LAYOUT_EDITING;
 }
 
 static cairo_filter_t _get_filtering_level(dt_develop_t *dev,
@@ -411,8 +407,8 @@ static void _darkroom_pickers_draw(dt_view_t *self,
 void expose(
     dt_view_t *self,
     cairo_t *cri,
-    int32_t width,
-    int32_t height,
+    const int32_t width,
+    const int32_t height,
     int32_t pointerx,
     int32_t pointery)
 {
@@ -420,10 +416,14 @@ void expose(
   cairo_save(cri);
 
   dt_develop_t *dev = (dt_develop_t *)self->data;
-  const int32_t tb = dev->border_size;
+
   // account for border, make it transparent for other modules called below:
-  pointerx -= tb;
-  pointery -= tb;
+  pointerx -= dev->border_size;
+  pointery -= dev->border_size;
+
+  const double tb = dev->border_size;
+  const double dwidth = width;
+  const double dheight = height;
 
   if(dev->gui_synch && !dev->image_loading)
   {
@@ -435,7 +435,7 @@ void expose(
       dt_iop_gui_update(module);
     }
     --darktable.gui->reset;
-    dev->gui_synch = 0;
+    dev->gui_synch = FALSE;
   }
 
   if(dev->image_status == DT_DEV_PIXELPIPE_DIRTY
@@ -467,19 +467,21 @@ void expose(
   const int closeup = dt_control_get_dev_closeup();
   const float backbuf_scale = dt_dev_get_zoom_scale(dev, zoom, 1.0f, 0) * darktable.gui->ppd;
 
+  // define and handle a cairo CAIRO_FORMAT_RGB24 surface here to make modules draw more fluently
   static cairo_surface_t *image_surface = NULL;
-  static int image_surface_width = 0, image_surface_height = 0, image_surface_imgid = -1;
-
+  static int image_surface_width = 0;
+  static int image_surface_height = 0;
+  static int32_t image_surface_imgid = -1;
+  // make a usable surface with requested width & height
   if(image_surface_width != width
      || image_surface_height != height
      || image_surface == NULL)
   {
-    // create double-buffered image to draw on, to make modules draw more fluently.
     image_surface_width = width;
     image_surface_height = height;
     if(image_surface) cairo_surface_destroy(image_surface);
     image_surface = dt_cairo_image_surface_create(CAIRO_FORMAT_RGB24, width, height);
-    image_surface_imgid = -1; // invalidate old stuff
+    image_surface_imgid = -1; // make sure the surface data are unknown
   }
   cairo_surface_t *surface;
   cairo_t *cr = cairo_create(image_surface);
@@ -508,15 +510,16 @@ void expose(
   }
 
   if(dev->pipe->output_backbuf                            // do we have an image?
-     && dev->pipe->output_imgid == dev->image_storage.id  // is the right image?
-     && dev->pipe->backbuf_scale == backbuf_scale    // is this the zoom scale we want to display?
-     && dev->pipe->backbuf_zoom_x == zoom_x && dev->pipe->backbuf_zoom_y == zoom_y)
+     && dev->pipe->output_imgid == dev->image_storage.id  // same image?
+     && dev->pipe->backbuf_scale == backbuf_scale         // same zoom scale?
+     && dev->pipe->backbuf_zoom_x == zoom_x
+     && dev->pipe->backbuf_zoom_y == zoom_y)
   {
     // draw image
     mutex = &dev->pipe->backbuf_mutex;
     dt_pthread_mutex_lock(mutex);
-    const float wd = dev->pipe->output_backbuf_width;
-    const float ht = dev->pipe->output_backbuf_height;
+    const size_t wd = dev->pipe->output_backbuf_width;
+    const size_t ht = dev->pipe->output_backbuf_height;
 
     surface = dt_view_create_surface(dev->pipe->output_backbuf, wd, ht);
 
@@ -547,10 +550,6 @@ void expose(
     mutex = &dev->preview_pipe->backbuf_mutex;
     dt_pthread_mutex_lock(mutex);
 
-    const float wd = dev->preview_pipe->output_backbuf_width;
-    const float ht = dev->preview_pipe->output_backbuf_height;
-    const float zoom_scale = dt_dev_get_zoom_scale(dev, zoom, 1<<closeup, 1);
-
     if(dev->iso_12646.enabled)
     {
       // force middle grey in background
@@ -568,22 +567,28 @@ void expose(
       // draw the white frame around picture
       const double ratio = dt_conf_get_float("darkroom/ui/iso12464_ratio");
       const double tbw = tb * (1.0 - ratio);
-      cairo_rectangle(cr, tbw, tbw, width - 2.0 * tbw, height - 2.0 * tbw);
+      cairo_rectangle(cr, tbw, tbw, dwidth - 2.0 * tbw, dheight - 2.0 * tbw);
       dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_ISO12646_FG);
       cairo_fill(cr);
     }
 
-    cairo_rectangle(cr, tb, tb, width-2*tb, height-2*tb);
+    cairo_rectangle(cr, tb, tb, dwidth - 2.0 * tb, dheight - 2.0 *tb);
     cairo_clip(cr);
 
-    surface = dt_view_create_surface(dev->preview_pipe->output_backbuf, wd, ht);
+    surface = dt_view_create_surface(dev->preview_pipe->output_backbuf,
+                                     dev->preview_pipe->output_backbuf_width,
+                                     dev->preview_pipe->output_backbuf_height);
 
-    cairo_translate(cr, width / 2.0, height / 2.0f);
+    const double zoom_scale = dt_dev_get_zoom_scale(dev, zoom, 1<<closeup, 1);
+    const double wd = dev->preview_pipe->output_backbuf_width;
+    const double ht = dev->preview_pipe->output_backbuf_height;
+
+    cairo_translate(cr, dwidth / 2.0, dheight / 2.0);
     cairo_scale(cr, zoom_scale, zoom_scale);
-    cairo_translate(cr, -.5f * wd - zoom_x * wd, -.5f * ht - zoom_y * ht);
+    cairo_translate(cr, -0.5 * wd - zoom_x * wd, - 0.5 * ht - zoom_y * ht);
 
-    cairo_rectangle(cr, 0, 0, wd, ht);
-    cairo_set_source_surface(cr, surface, 0, 0);
+    cairo_rectangle(cr, 0.0, 0.0, wd, ht);
+    cairo_set_source_surface(cr, surface, 0.0, 0.0);
     cairo_pattern_set_filter(cairo_get_source(cr), _get_filtering_level(dev, zoom, closeup));
     cairo_fill(cr);
     cairo_surface_destroy(surface);
@@ -637,8 +642,8 @@ void expose(
       pango_layout_set_font_description(layout, desc);
       pango_layout_set_text(layout, load_txt, -1);
       pango_layout_get_pixel_extents(layout, &ink, NULL);
-      const float xc = width / 2.0, yc = height * 0.85 - DT_PIXEL_APPLY_DPI(10), wd = ink.width * .5f;
-      cairo_move_to(cr, xc - wd, yc + 1. / 3. * fontsize - fontsize);
+      const double xc = dwidth / 2.0, yc = dheight * 0.85 - DT_PIXEL_APPLY_DPI(10), wd = ink.width * 0.5;
+      cairo_move_to(cr, xc - wd, yc + 1.0 / 3.0 * fontsize - fontsize);
       pango_cairo_layout_path(cr, layout);
       cairo_set_line_width(cr, 2.0);
       dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_LOG_BG);
@@ -683,18 +688,18 @@ void expose(
   {
     // we restrict the drawing to the image only
     // the drawing is done on the preview pipe reference
-    const float wd = dev->preview_pipe->backbuf_width;
-    const float ht = dev->preview_pipe->backbuf_height;
-    const float zoom_scale = dt_dev_get_zoom_scale(dev, zoom, 1 << closeup, 1);
+    const double wd = dev->preview_pipe->backbuf_width;
+    const double ht = dev->preview_pipe->backbuf_height;
+    const double zoom_scale = dt_dev_get_zoom_scale(dev, zoom, 1 << closeup, 1);
 
     cairo_save(cri);
     // don't draw guides on image margins
-    cairo_rectangle(cri, tb, tb, width - 2 * tb, height - 2 * tb);
+    cairo_rectangle(cri, tb, tb, dwidth - 2.0 * tb, dheight - 2.0 * tb);
     cairo_clip(cri);
     // switch to the preview reference
-    cairo_translate(cri, width / 2.0, height / 2.0);
+    cairo_translate(cri, dwidth / 2.0, dheight / 2.0);
     cairo_scale(cri, zoom_scale, zoom_scale);
-    cairo_translate(cri, -.5f * wd - zoom_x * wd, -.5f * ht - zoom_y * ht);
+    cairo_translate(cri, - 0.5f * wd - zoom_x * wd, - 0.5f * ht - zoom_y * ht);
     dt_guides_draw(cri, 0.0f, 0.0f, wd, ht, zoom_scale);
     cairo_restore(cri);
   }
@@ -764,15 +769,15 @@ void reset(dt_view_t *self)
   dt_control_set_dev_closeup(0);
 }
 
-int try_enter(dt_view_t *self)
+gboolean try_enter(dt_view_t *self)
 {
-  int32_t imgid = dt_act_on_get_main_image();
+  const int32_t imgid = dt_act_on_get_main_image();
 
   if(imgid < 0)
   {
     // fail :(
     dt_control_log(_("no image to open!"));
-    return 1;
+    return TRUE;
   }
 
   // this loads the image from db if needed:
@@ -792,7 +797,7 @@ int try_enter(dt_view_t *self)
   dt_image_cache_read_release(darktable.image_cache, img);
   darktable.develop->image_storage.id = imgid;
   darktable.develop->proxy.wb_coeffs[0] = 0.f;
-  return 0;
+  return FALSE;
 }
 
 #ifdef USE_LUA
@@ -1668,8 +1673,10 @@ static void _update_softproof_gamut_checking(dt_develop_t *d)
   g_signal_handlers_block_by_func(d->profile.softproof_button, _softproof_quickbutton_clicked, d);
   g_signal_handlers_block_by_func(d->profile.gamut_button, _gamut_quickbutton_clicked, d);
 
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->profile.softproof_button), darktable.color_profiles->mode == DT_PROFILE_SOFTPROOF);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->profile.gamut_button), darktable.color_profiles->mode == DT_PROFILE_GAMUTCHECK);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->profile.softproof_button),
+                               darktable.color_profiles->mode == DT_PROFILE_SOFTPROOF);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->profile.gamut_button),
+                               darktable.color_profiles->mode == DT_PROFILE_GAMUTCHECK);
 
   g_signal_handlers_unblock_by_func(d->profile.softproof_button, _softproof_quickbutton_clicked, d);
   g_signal_handlers_unblock_by_func(d->profile.gamut_button, _gamut_quickbutton_clicked, d);
@@ -2200,7 +2207,7 @@ static float _action_process_preview(gpointer target,
     }
   }
 
-  return lib->full_preview;
+  return (float)lib->full_preview;
 }
 
 const dt_action_def_t dt_action_def_preview
@@ -3059,7 +3066,7 @@ void enter(dt_view_t *self)
   dt_masks_change_form_gui(NULL);
   dev->form_gui->pipe_hash = 0;
   dev->form_gui->formid = 0;
-  dev->gui_leaving = 0;
+  dev->gui_leaving = FALSE;
   dev->gui_module = NULL;
 
   // change active image
@@ -3271,7 +3278,7 @@ void leave(dt_view_t *self)
   dt_pthread_mutex_lock(&dev->preview2_pipe_mutex);
   dt_pthread_mutex_lock(&dev->pipe_mutex);
 
-  dev->gui_leaving = 1;
+  dev->gui_leaving = TRUE;
 
   dt_dev_pixelpipe_cleanup_nodes(dev->pipe);
   dt_dev_pixelpipe_cleanup_nodes(dev->preview2_pipe);
@@ -4051,13 +4058,12 @@ static void second_window_expose(GtkWidget *widget,
                                  int32_t pointerx,
                                  int32_t pointery)
 {
-  cairo_set_source_rgb(cri, .2, .2, .2);
+  cairo_set_source_rgb(cri, 0.2, 0.2, 0.2);
   cairo_save(cri);
 
-  const int32_t tb = dev->second_window.border_size;
   // account for border, make it transparent for other modules called below:
-  pointerx -= tb;
-  pointery -= tb;
+  pointerx -= dev->second_window.border_size;
+  pointery -= dev->second_window.border_size;
 
   if(dev->preview2_status == DT_DEV_PIXELPIPE_DIRTY
      || dev->preview2_status == DT_DEV_PIXELPIPE_INVALID
@@ -4072,7 +4078,9 @@ static void second_window_expose(GtkWidget *widget,
   const float backbuf_scale = dt_second_window_get_zoom_scale(dev, zoom, 1.0f, 0) * dev->second_window.ppd;
 
   static cairo_surface_t *image_surface = NULL;
-  static int image_surface_width = 0, image_surface_height = 0, image_surface_imgid = -1;
+  static int image_surface_width = 0;
+  static int image_surface_height = 0;
+  static int32_t image_surface_imgid = -1;
 
   if(image_surface_width != width
      || image_surface_height != height
@@ -4087,6 +4095,7 @@ static void second_window_expose(GtkWidget *widget,
 
     image_surface_imgid = -1; // invalidate old stuff
   }
+
   cairo_surface_t *surface;
   cairo_t *cr = cairo_create(image_surface);
 
@@ -4098,8 +4107,8 @@ static void second_window_expose(GtkWidget *widget,
     // draw image
     mutex = &dev->preview2_pipe->backbuf_mutex;
     dt_pthread_mutex_lock(mutex);
-    const float wd = dev->preview2_pipe->output_backbuf_width;
-    const float ht = dev->preview2_pipe->output_backbuf_height;
+    const size_t wd = dev->preview2_pipe->output_backbuf_width;
+    const size_t ht = dev->preview2_pipe->output_backbuf_height;
 
     surface = dt_view_create_surface(dev->preview2_pipe->output_backbuf, wd, ht);
 
@@ -4118,22 +4127,24 @@ static void second_window_expose(GtkWidget *widget,
     mutex = &dev->preview_pipe->backbuf_mutex;
     dt_pthread_mutex_lock(mutex);
 
-    const float wd = dev->preview_pipe->output_backbuf_width;
-    const float ht = dev->preview_pipe->output_backbuf_height;
-    const float zoom_scale = dt_second_window_get_zoom_scale(dev, zoom, 1 << closeup, 1);
+    const double tb = dev->second_window.border_size;
+    const double wd = dev->preview_pipe->output_backbuf_width;
+    const double ht = dev->preview_pipe->output_backbuf_height;
+    const double zoom_scale = dt_second_window_get_zoom_scale(dev, zoom, 1 << closeup, 1);
+
     dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_DARKROOM_BG);
     cairo_paint(cr);
-    cairo_rectangle(cr, tb, tb, width - 2 * tb, height - 2 * tb);
+    cairo_rectangle(cr, tb, tb, width - 2.0 * tb, height - 2.0 * tb);
     cairo_clip(cr);
 
     surface = dt_view_create_surface(dev->preview_pipe->output_backbuf, wd, ht);
 
     cairo_translate(cr, width / 2.0, height / 2.0f);
     cairo_scale(cr, zoom_scale, zoom_scale);
-    cairo_translate(cr, -.5f * wd - zoom_x * wd, -.5f * ht - zoom_y * ht);
+    cairo_translate(cr, - 0.5f * wd - zoom_x * wd, - 0.5f * ht - zoom_y * ht);
     // avoid to draw the 1px garbage that sometimes shows up in the preview :(
-    cairo_rectangle(cr, 0, 0, wd - 1, ht - 1);
-    cairo_set_source_surface(cr, surface, 0, 0);
+    cairo_rectangle(cr, 0.0, 0.0, wd - 1.0, ht - 1.0);
+    cairo_set_source_surface(cr, surface, 0.0, 0.0);
     cairo_pattern_set_filter(cairo_get_source(cr), _get_second_window_filtering_level(dev, zoom, closeup));
     cairo_fill(cr);
     cairo_surface_destroy(surface);

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -802,9 +802,9 @@ void configure(dt_view_t *self, int wd, int ht)
   // dt_capture_t *lib=(dt_capture_t*)self->data;
 }
 
-int try_enter(dt_view_t *self)
+gboolean try_enter(dt_view_t *self)
 {
-  return 0;
+  return FALSE;
 }
 
 static void _view_map_signal_change_raise(gpointer user_data)

--- a/src/views/print.c
+++ b/src/views/print.c
@@ -315,19 +315,19 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
   }
 }
 
-int try_enter(dt_view_t *self)
+gboolean try_enter(dt_view_t *self)
 {
   dt_print_t *prt = (dt_print_t*)self->data;
 
   //  now check that there is at least one selected image
 
-  const int imgid = dt_act_on_get_main_image();
+  const int32_t imgid = dt_act_on_get_main_image();
 
   if(imgid < 0)
   {
     // fail :(
     dt_control_log(_("no image to open!"));
-    return 1;
+    return TRUE;
   }
 
   // this loads the image from db if needed:
@@ -349,7 +349,7 @@ int try_enter(dt_view_t *self)
   // we need to setup the selected image
   prt->imgs->imgid_to_load = imgid;
 
-  return 0;
+  return FALSE;
 }
 
 void enter(dt_view_t *self)

--- a/src/views/slideshow.c
+++ b/src/views/slideshow.c
@@ -409,17 +409,17 @@ void cleanup(dt_view_t *self)
   free(self->data);
 }
 
-int try_enter(dt_view_t *self)
+gboolean try_enter(dt_view_t *self)
 {
   /* verify that there are images to display */
   if(dt_collection_get_count(darktable.collection) != 0)
   {
-    return 0;
+    return FALSE;
   }
   else
   {
     dt_control_log(_("there are no images in this collection"));
-    return 1;
+    return TRUE;
   }
 }
 

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -440,13 +440,13 @@ void expose(dt_view_t *self, cairo_t *cri, int32_t width, int32_t height, int32_
   }
 }
 
-int try_enter(dt_view_t *self)
+gboolean try_enter(dt_view_t *self)
 {
   /* verify that camera supports tethering and is available */
-  if(dt_camctl_can_enter_tether_mode(darktable.camctl, NULL)) return 0;
+  if(dt_camctl_can_enter_tether_mode(darktable.camctl, NULL)) return FALSE;
 
   dt_control_log(_("no camera with tethering support available for use..."));
-  return 1;
+  return TRUE;
 }
 
 static void _capture_mipmaps_updated_signal_callback(gpointer instance, int imgid, gpointer user_data)

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -211,7 +211,7 @@ static void _remove_child(GtkWidget *child,GtkContainer *container)
     }
 }
 
-int dt_view_manager_switch(dt_view_manager_t *vm, const char *view_name)
+gboolean dt_view_manager_switch(dt_view_manager_t *vm, const char *view_name)
 {
   gboolean switching_to_none = *view_name == '\0';
   dt_view_t *new_view = NULL;
@@ -227,13 +227,13 @@ int dt_view_manager_switch(dt_view_manager_t *vm, const char *view_name)
         break;
       }
     }
-    if(!new_view) return 1; // the requested view doesn't exist
+    if(!new_view) return TRUE; // the requested view doesn't exist
   }
 
   return dt_view_manager_switch_by_view(vm, new_view);
 }
 
-int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
+gboolean dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
 {
   dt_view_t *old_view = vm->current_view;
   dt_view_t *new_view = (dt_view_t *)nv; // views belong to us, we can de-const them :-)
@@ -280,7 +280,7 @@ int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
 
     /* remove sticky accels window */
     if(vm->accels_window.window) dt_view_accels_hide(vm);
-    return 0;
+    return FALSE;
   }
 
   // invariant: new_view != NULL after this point
@@ -288,7 +288,7 @@ int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
 
   if(new_view->try_enter)
   {
-    const int error = new_view->try_enter(new_view);
+    const gboolean error = new_view->try_enter(new_view);
     if(error)
     {
       DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_VIEWMANAGER_VIEW_CANNOT_CHANGE, old_view, new_view);
@@ -399,7 +399,7 @@ int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
 
   // update toast visibility
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_TOAST_REDRAW);
-  return 0;
+  return FALSE;
 }
 
 const char *dt_view_manager_name(dt_view_manager_t *vm)

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2021 darktable developers.
+    Copyright (C) 2009-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -162,16 +162,22 @@ typedef enum dt_view_image_over_t
 } dt_view_image_over_t;
 
 /** returns an uppercase string of file extension **plus** some flag information **/
-char* dt_view_extend_modes_str(const char * name, const gboolean is_hdr, const gboolean is_bw, const gboolean is_bw_flow);
+char* dt_view_extend_modes_str(const char * name,
+                               const gboolean is_hdr,
+                               const gboolean is_bw,
+                               const gboolean is_bw_flow);
 /** expose an image and return a cair0_surface. */
-dt_view_surface_value_t dt_view_image_get_surface(int imgid, int width, int height, cairo_surface_t **surface,
+dt_view_surface_value_t dt_view_image_get_surface(int32_t imgid,
+                                                  int32_t width,
+                                                  int32_t height,
+                                                  cairo_surface_t **surface,
                                                   const gboolean quality);
 
 
 /** Set the selection bit to a given value for the specified image */
-void dt_view_set_selection(int imgid, int value);
+void dt_view_set_selection(int32_t imgid, int value);
 /** toggle selection of given image. */
-void dt_view_toggle_selection(int imgid);
+void dt_view_toggle_selection(int32_t imgid);
 
 /**
  * holds all relevant data needed to manage the view
@@ -312,7 +318,7 @@ typedef struct dt_view_manager_t
       void (*culling_preview_reload_overlays)(struct dt_view_t *view);
       gboolean (*get_preview_state)(struct dt_view_t *view);
       void (*set_preview_state)(struct dt_view_t *view, gboolean state, gboolean sticky, gboolean focus);
-      void (*change_offset)(struct dt_view_t *view, gboolean reset, gint imgid);
+      void (*change_offset)(struct dt_view_t *view, gboolean reset, int32_t imgid);
     } lighttable;
 
     /* tethering view proxy object */
@@ -344,7 +350,7 @@ typedef struct dt_view_manager_t
       gboolean (*remove_marker)(const dt_view_t *view, dt_geo_map_display_t type, GObject *marker);
       void (*add_location)(const dt_view_t *view, dt_map_location_data_t *p, const guint posid);
       void (*location_action)(const dt_view_t *view, const int action);
-      void (*drag_set_icon)(const dt_view_t *view, GdkDragContext *context, const int imgid, const int count);
+      void (*drag_set_icon)(const dt_view_t *view, GdkDragContext *context, const int32_t imgid, const int count);
       gboolean (*redraw)(gpointer user_data);
       gboolean (*display_selected)(gpointer user_data);
     } map;
@@ -369,9 +375,9 @@ void dt_view_manager_cleanup(dt_view_manager_t *vm);
 
 /** return translated name. */
 const char *dt_view_manager_name(dt_view_manager_t *vm);
-/** switch to this module. returns non-null if the module fails to change. */
-int dt_view_manager_switch(dt_view_manager_t *vm, const char *view_name);
-int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *new_view);
+/** switch to this module. returns TRUE if the module fails to change. */
+gboolean dt_view_manager_switch(dt_view_manager_t *vm, const char *view_name);
+gboolean dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *new_view);
 /** expose current module. */
 void dt_view_manager_expose(dt_view_manager_t *vm, cairo_t *cr, int32_t width, int32_t height,
                             int32_t pointerx, int32_t pointery);
@@ -432,7 +438,7 @@ GtkWidget *dt_view_filter_get_count(const dt_view_manager_t *vm);
 
 // active images functions
 void dt_view_active_images_reset(gboolean raise);
-void dt_view_active_images_add(int imgid, gboolean raise);
+void dt_view_active_images_add(int32_t imgid, gboolean raise);
 GSList *dt_view_active_images_get();
 
 /** get the lighttable current layout */
@@ -454,7 +460,7 @@ void dt_view_lighttable_culling_preview_refresh(dt_view_manager_t *vm);
 /** force refresh of culling and/or preview overlays */
 void dt_view_lighttable_culling_preview_reload_overlays(dt_view_manager_t *vm);
 /** sets the offset image (for culling and full preview) */
-void dt_view_lighttable_change_offset(dt_view_manager_t *vm, gboolean reset, gint imgid);
+void dt_view_lighttable_change_offset(dt_view_manager_t *vm, gboolean reset, int32_t imgid);
 
 /* accel window */
 void dt_view_accels_show(dt_view_manager_t *vm);
@@ -462,7 +468,7 @@ void dt_view_accels_hide(dt_view_manager_t *vm);
 void dt_view_accels_refresh(dt_view_manager_t *vm);
 
 /* audio */
-void dt_view_audio_start(dt_view_manager_t *vm, int imgid);
+void dt_view_audio_start(dt_view_manager_t *vm, int32_t imgid);
 void dt_view_audio_stop(dt_view_manager_t *vm);
 
 /*

--- a/src/views/view_api.h
+++ b/src/views/view_api.h
@@ -44,7 +44,7 @@ OPTIONAL(void, gui_init, struct dt_view_t *self);       // create gtk elements, 
 OPTIONAL(void, cleanup, struct dt_view_t *self);        // cleanup *data
 OPTIONAL(void, expose, struct dt_view_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t pointerx,
                        int32_t pointery);         // expose the module (gtk callback)
-OPTIONAL(int, try_enter, struct dt_view_t *self); // test if enter can succeed.
+OPTIONAL(gboolean, try_enter, struct dt_view_t *self); // test if enter can succeed.
 OPTIONAL(void, enter, struct dt_view_t *self);    // mode entered, this module got focus. return non-null on failure.
 OPTIONAL(void, leave, struct dt_view_t *self);    // mode left (is called after the new try_enter has succeeded).
 OPTIONAL(void, reset, struct dt_view_t *self);    // reset default appearance


### PR DESCRIPTION
The darkroom expose() variants avoid un-necessary int->float-double conversions for cairo functions. Some const added

Subtle stuff for dev->iso_12646.enabled

In all views
- imgid are int32_t

Some int changed to gboolean
 - gui_synch, gui_leaving
 - functions try_enter(), dt_view_manager_switch(), dt_view_manager_switch_by_view()

in struct dt_iop_gui_blend_data_t we define dt_masks_edit_mode_t masks_shown;
  for correctness