### PR TITLE
po/snap entry - ensure clean ellipsis

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2305,22 +2305,3 @@ Details :
 {
   margin: 0.07em 0.28em;
 }
-
-/* The entry in the snapshot button must not be visible by default as we still want to see
-   a flat button. Only when flying over one can see that the area is editable */
-#snapshot-button entry
-{
-  background-color: @button_bg;
-  border: none;
-}
-
-#snapshot-button entry
-{
-  background-color: transparent;
-}
-
-#snapshot-button *
-{
-   padding-left: 1px;
-   padding-right: 1px;
-}

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -956,7 +956,6 @@ GList *dt_history_get_items(const int32_t imgid,
   {
     if(strcmp((const char*)sqlite3_column_text(stmt, 1), "mask_manager") == 0) continue;
 
-    char name[512] = { 0 };
     dt_history_item_t *item = g_malloc(sizeof(dt_history_item_t));
     const char *op = (char *)sqlite3_column_text(stmt, 1);
     // first uint32_t of blend_params is the mode
@@ -968,21 +967,7 @@ GList *dt_history_get_items(const int32_t imgid,
 
     const char *mname = (char *)sqlite3_column_text(stmt, 3);
 
-    if(!mname
-       || strlen(mname) == 0
-       || strcmp(mname, "0") == 0)
-    {
-      g_snprintf(name, sizeof(name), "%s", dt_iop_get_localized_name(op));
-    }
-    else
-    {
-      g_snprintf(name, sizeof(name), "%s • %s%s%s",
-                 dt_iop_get_localized_name(op),
-                 markup ? "<small>" : "",
-                 (char *)mname,
-                 markup ? "</small>" : "");
-    }
-    item->name = g_strdup(name);
+    item->name = dt_history_get_name_label(dt_iop_get_localized_name(op), mname, markup);
     item->op = g_strdup(op);
     result = g_list_prepend(result, item);
   }

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -908,6 +908,26 @@ char *dt_history_item_as_string(const char *name, const gboolean enabled)
   return g_strconcat(enabled ? "●" : "○", "  ", name, NULL);
 }
 
+char *dt_history_get_name_label(const char *name,
+                                const char *label,
+                                const gboolean markup)
+{
+  if(!label
+     || strlen(label) == 0
+     || strcmp(label, "0") == 0)
+  {
+    return g_strdup_printf("%s", name);
+  }
+  else
+  {
+    return g_strdup_printf("%s • %s%s%s",
+                           name,
+                           markup ? "<small>" : "",
+                           label,
+                           markup ? "</small>" : "");
+  }
+}
+
 GList *dt_history_get_items(const int32_t imgid,
                             const gboolean enabled,
                             const gboolean markup)

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -132,6 +132,11 @@ typedef struct dt_history_item_t
   dt_develop_mask_mode_t mask_mode;
 } dt_history_item_t;
 
+/** returns the history name + label with markup */
+char *dt_history_get_name_label(const char *name,
+                                const char *label,
+                                const gboolean markup);
+
 /** get list of history items for image */
 GList *dt_history_get_items(const int32_t imgid,
                             const gboolean enabled,

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -1112,7 +1112,7 @@ static gchar *_lib_history_button_label(const dt_dev_history_item_t *item)
   else if(!item->multi_name[0] || strcmp(item->multi_name, "0") == 0)
     label = g_strdup(item->module->name());
   else
-    label = g_markup_printf_escaped("%s <small>• %s</small>",
+    label = g_markup_printf_escaped("%s • <small>%s</small>",
                                     item->module->name(), item->multi_name);
 
   return label;


### PR DESCRIPTION
Rework snapshot button.
    
A single widget containing the name & label is used to allow for
clean ellipsis.
    
Fixes #14104.

Also do some code refactoring to share the code to build a module name plus the instance if present. This with or
without markup.