### PR TITLE
mask sliders for size/feather use log scale

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1137,19 +1137,19 @@ void dt_bauhaus_widget_release_quad(GtkWidget *widget)
   }
 }
 
-static float _default_linear_curve(float value, dt_bauhaus_curve_t dir)
+static float _default_linear_curve(const float value, const dt_bauhaus_curve_t dir)
 {
   // regardless of dir: input <-> output
   return value;
 }
 
-static float _reverse_linear_curve(float value, dt_bauhaus_curve_t dir)
+static float _reverse_linear_curve(const float value, const dt_bauhaus_curve_t dir)
 {
   // regardless of dir: input <-> output
   return 1.0 - value;
 }
 
-float _curve_log10(float inval, dt_bauhaus_curve_t dir)
+static float _curve_log10(const float inval, const dt_bauhaus_curve_t dir)
 {
   if(dir == DT_BAUHAUS_SET)
     return log10f(inval * 999.0f + 1.0f) / 3.0f;

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1149,6 +1149,14 @@ static float _reverse_linear_curve(float value, dt_bauhaus_curve_t dir)
   return 1.0 - value;
 }
 
+float _curve_log10(float inval, dt_bauhaus_curve_t dir)
+{
+  if(dir == DT_BAUHAUS_SET)
+    return log10f(inval * 999.0f + 1.0f) / 3.0f;
+  else
+    return (expf(M_LN10 * inval * 3.0f) - 1.0f) / 999.0f;
+}
+
 GtkWidget *dt_bauhaus_slider_new(dt_iop_module_t *self)
 {
   return dt_bauhaus_slider_new_with_range(self, 0.0, 1.0, 0.1, 0.5, 3);
@@ -2585,13 +2593,16 @@ static void _slider_add_step(GtkWidget *widget, float delta, guint state, gboole
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)widget;
   dt_bauhaus_slider_data_t *d = &w->data.slider;
 
-  delta *= dt_bauhaus_slider_get_step(widget) * dt_accel_get_speed_multiplier(widget, state);
+  const float value = dt_bauhaus_slider_get(widget);
+
+  if(d->curve == _curve_log10)
+    delta = value * (powf(0.97f, - delta * dt_accel_get_speed_multiplier(widget, state)) - 1.0f);
+  else
+    delta *= dt_bauhaus_slider_get_step(widget) * dt_accel_get_speed_multiplier(widget, state);
 
   const float min_visible = powf(10.0f, -d->digits) / fabsf(d->factor);
   if(delta && fabsf(delta) < min_visible)
     delta = copysignf(min_visible, delta);
-
-  const float value = dt_bauhaus_slider_get(widget);
 
   if(force || dt_modifier_is(state, GDK_SHIFT_MASK | GDK_CONTROL_MASK))
   {
@@ -2750,6 +2761,8 @@ char *dt_bauhaus_slider_get_text(GtkWidget *w, float val)
 
 void dt_bauhaus_slider_set(GtkWidget *widget, float pos)
 {
+  if(isnan(pos)) return;
+
   // this is the public interface function, translate by bounds and call set_normalized
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(widget);
   if(w->type != DT_BAUHAUS_SLIDER) return;
@@ -2928,6 +2941,11 @@ void dt_bauhaus_slider_set_curve(GtkWidget *widget, float (*curve)(float value, 
   d->pos = curve(d->curve(d->pos, DT_BAUHAUS_GET), DT_BAUHAUS_SET);
 
   d->curve = curve;
+}
+
+void dt_bauhaus_slider_set_log_curve(GtkWidget *widget)
+{
+  dt_bauhaus_slider_set_curve(widget, _curve_log10);
 }
 
 static gboolean _bauhaus_slider_value_change_dragging(gpointer data);

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -48,8 +48,6 @@ extern "C" {
 
 extern GType DT_BAUHAUS_WIDGET_TYPE;
 
-#define DT_BAUHAUS_SLIDER_VALUE_CHANGED_DELAY_MAX 500
-#define DT_BAUHAUS_SLIDER_VALUE_CHANGED_DELAY_MIN 25
 #define DT_BAUHAUS_SLIDER_MAX_STOPS 20
 #define DT_BAUHAUS_COMBO_MAX_TEXT 180
 
@@ -333,6 +331,7 @@ void dt_bauhaus_slider_clear_stops(GtkWidget *widget);
 void dt_bauhaus_slider_set_default(GtkWidget *widget, float def);
 float dt_bauhaus_slider_get_default(GtkWidget *widget);
 void dt_bauhaus_slider_set_curve(GtkWidget *widget, float (*curve)(float value, dt_bauhaus_curve_t dir));
+void dt_bauhaus_slider_set_log_curve(GtkWidget *widget);
 
 // combobox:
 void dt_bauhaus_combobox_from_widget(struct dt_bauhaus_widget_t* widget,dt_iop_module_t *self);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -3271,6 +3271,11 @@ static void _brush_modify_property(dt_masks_form_t *const form,
         masks_border = MAX(BORDER_MIN, MIN(masks_border * ratio, BORDER_MAX));
         dt_conf_set_float(DT_MASKS_CONF(form->type, brush, border), masks_border);
 
+        if(gui->guipoints_count > 0)
+        {
+          dt_masks_dynbuf_set(gui->guipoints_payload, -4, masks_border);
+        }
+
         *sum += 2.0f * masks_border;
         *max = fminf(*max, BORDER_MAX / masks_border);
         *min = fmaxf(*min, BORDER_MIN / masks_border);
@@ -3303,6 +3308,11 @@ static void _brush_modify_property(dt_masks_form_t *const form,
           dt_conf_get_float(DT_MASKS_CONF(form->type, brush, hardness));
         masks_hardness = MAX(HARDNESS_MIN, MIN(masks_hardness * ratio, HARDNESS_MAX));
         dt_conf_set_float(DT_MASKS_CONF(form->type, brush, hardness), masks_hardness);
+
+        if(gui->guipoints_count > 0)
+        {
+          dt_masks_dynbuf_set(gui->guipoints_payload, -3, masks_hardness);
+        }
 
         *sum += masks_hardness;
         *max = fminf(*max, HARDNESS_MAX / masks_hardness);

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1225,8 +1225,10 @@ int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module,
 
       opacity = CLAMP(opacity + amount, 0.05f, 1.0f);
       dt_conf_set_float("plugins/darkroom/masks/opacity", opacity);
-      const int opacitypercent = opacity * 100;
-      dt_toast_log(_("opacity: %d%%"), opacitypercent);
+
+      dt_toast_log(_("opacity: %.0f%%"), opacity * 100);
+      dt_dev_masks_list_change(darktable.develop);
+
       ret = 1;
     }
 
@@ -1891,8 +1893,7 @@ float dt_masks_form_change_opacity(dt_masks_form_t *form,
       if(opacity != fpt->opacity)
       {
         fpt->opacity = opacity;
-        const int opacitypercent = opacity * 100;
-        dt_toast_log(_("opacity: %d%%"), opacitypercent);
+        dt_toast_log(_("opacity: %.0f%%"), opacity * 100);
         dt_dev_add_masks_history_item(darktable.develop, NULL, TRUE);
         dt_masks_update_image(darktable.develop);
       }

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5984,20 +5984,6 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
   }
 }
 
-static float log10_curve(float inval, dt_bauhaus_curve_t dir)
-{
-  float outval;
-  if(dir == DT_BAUHAUS_SET)
-  {
-    outval = log10f(inval * 999.0f + 1.0f) / 3.0f;
-  }
-  else
-  {
-    outval = (expf(M_LN10 * inval * 3.0f) - 1.0f) / 999.0f;
-  }
-  return outval;
-}
-
 static float log2_curve(float inval, dt_bauhaus_curve_t dir)
 {
   float outval;
@@ -6153,7 +6139,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->f_length = dt_bauhaus_slider_from_params(self, "f_length");
   dt_bauhaus_slider_set_soft_range(g->f_length, 10.0f, 1000.0f);
-  dt_bauhaus_slider_set_curve(g->f_length, log10_curve);
+  dt_bauhaus_slider_set_log_curve(g->f_length);
   dt_bauhaus_slider_set_digits(g->f_length, 0);
   dt_bauhaus_slider_set_format(g->f_length, " mm");
 


### PR DESCRIPTION
fixes #14079

Also adds opacity slider to mask manager during the creation of new shapes and allows size/hardness slider shortcuts to adjust these properties while drawing.

And fixes a few minor bugs/inconsistencies.

Release Note:
- the mask shape size/feather/hardness sliders in the masks manager module now display in log scale and scrolling over them makes relative adjustments, just like (Shift) scrolling over the shape itself. Ctrl or Shift will make fine or coarse adjustments, also with shortcuts if fallbacks are enabled. Shortcuts assigned to the sliders can be used to adjust brush size/hardness while drawing.