### PR TITLE
Fixes for pixelpipe cache related issues to mask visualizing

### DIFF
--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -55,15 +55,16 @@ gboolean dt_dev_pixelpipe_cache_init(dt_dev_pixelpipe_cache_t *cache, int entrie
 void dt_dev_pixelpipe_cache_cleanup(dt_dev_pixelpipe_cache_t *cache);
 
 /** creates a hopefully unique hash from the complete module stack up to the module-th. */
-uint64_t dt_dev_pixelpipe_cache_basichash(int imgid, struct dt_dev_pixelpipe_t *pipe, int module);
+uint64_t dt_dev_pixelpipe_cache_basichash(const int32_t imgid, struct dt_dev_pixelpipe_t *pipe, int module);
 /** creates a hopefully unique hash from the complete module stack up to the module-th, including current viewport. */
-uint64_t dt_dev_pixelpipe_cache_hash(int imgid, const struct dt_iop_roi_t *roi,
-                                     struct dt_dev_pixelpipe_t *pipe, int module);
+uint64_t dt_dev_pixelpipe_cache_hash(const int32_t imgid, const struct dt_iop_roi_t *roi,
+                                     struct dt_dev_pixelpipe_t *pipe, int position);
 /** return both of the above hashes */
-void dt_dev_pixelpipe_cache_fullhash(int imgid, const dt_iop_roi_t *roi, struct dt_dev_pixelpipe_t *pipe, int module,
+void dt_dev_pixelpipe_cache_fullhash(const int32_t imgid, const dt_iop_roi_t *roi,
+                                     struct dt_dev_pixelpipe_t *pipe, int position,
                                      uint64_t *basichash, uint64_t *fullhash);
 /** get the basichash for the last enabled module prior to the specified one */
-uint64_t dt_dev_pixelpipe_cache_basichash_prior(int imgid, struct dt_dev_pixelpipe_t *pipe,
+uint64_t dt_dev_pixelpipe_cache_basichash_prior(const int32_t imgid, struct dt_dev_pixelpipe_t *pipe,
                                                 const struct dt_iop_module_t *const module);
 
 /** returns a float data buffer in 'data' for the given hash from the cache, dsc is updated too.
@@ -75,7 +76,7 @@ gboolean dt_dev_pixelpipe_cache_get(struct dt_dev_pixelpipe_t *pipe, const uint6
                                const size_t size, void **data, struct dt_iop_buffer_dsc_t **dsc, char *modname, const gboolean important);
 
 /** test availability of a cache line without destroying another, if it is not found. */
-gboolean dt_dev_pixelpipe_cache_available(dt_dev_pixelpipe_cache_t *cache, const uint64_t hash, const size_t size);
+gboolean dt_dev_pixelpipe_cache_available(struct dt_dev_pixelpipe_t *pipe, const uint64_t hash, const size_t size);
 
 /** invalidates all cachelines. */
 void dt_dev_pixelpipe_cache_flush(dt_dev_pixelpipe_cache_t *cache);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1432,7 +1432,7 @@ static gboolean _dev_pixelpipe_process_rec(
   if(!gamma_preview)
   {
     dt_dev_pixelpipe_cache_fullhash(pipe->image.id, roi_out, pipe, pos, &basichash, &hash);
-    cache_available = dt_dev_pixelpipe_cache_available(&(pipe->cache), hash, bufsize);
+    cache_available = dt_dev_pixelpipe_cache_available(pipe, hash, bufsize);
   }
   if(cache_available)
   {


### PR DESCRIPTION
While using any of the mask visualizing modes we might do a quick bypassing in the pixelpipe so we don't want that data to be cached.

Checks all over the pixelpipe cache code look for such a condition and strictly avoid cache usage.

In the pixelpipe proxessing code

- we make sure we don't get data from cache while in masking mode
- checks for important are only done while in non-masking mode
- simpler check for fast bypassing masks visualizing data 


Some const additions and changes from int to int32_t
Some debugging info also contains module name

Likely fixes #14058
Likely fixes #13826
Hopefully fixes #12913
