### PR TITLE
masks: Code refactoring.

### DIFF
--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -618,6 +618,15 @@ float dt_masks_drag_factor(dt_masks_form_gui_t *gui,
                            const int k,
                            const gboolean border);
 
+float dt_masks_change_size(gboolean up,
+                           const float value,
+                           const float min,
+                           const float max);
+
+float dt_masks_change_rotation(gboolean up,
+                               const float value,
+                               const gboolean is_degree);
+
 /** allow to select a shape inside an iop */
 void dt_masks_select_form(struct dt_iop_module_t *module,
                           dt_masks_form_t *sel);

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -118,26 +118,23 @@ static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module,
   // add a preview when creating a circle
   if(gui->creation)
   {
-    float masks_size = dt_conf_get_float(DT_MASKS_CONF(form->type, circle, size));
-
     if(dt_modifier_is(state, GDK_SHIFT_MASK))
     {
-      float masks_border = dt_conf_get_float(DT_MASKS_CONF(form->type, circle, border));
-
-      if(up && masks_border < max_mask_border)
-        masks_border *= 1.0f / 0.97f;
-      else if(!up && masks_border > MIN_CIRCLE_BORDER)
-        masks_border *= 0.97f;
+      const float masks_border = dt_masks_change_size
+        (up,
+         dt_conf_get_float(DT_MASKS_CONF(form->type, circle, border)),
+         MIN_CIRCLE_BORDER, max_mask_border);
 
       dt_conf_set_float(DT_MASKS_CONF(form->type, circle, border), masks_border);
       dt_toast_log(_("feather size: %3.2f%%"), masks_border*100.0f);
     }
     else if(dt_modifier_is(state, 0))
     {
-      if(up && masks_size < max_mask_size)
-        masks_size *= 1.0f / 0.97f;
-      else if(!up && masks_size > MIN_CIRCLE_RADIUS)
-        masks_size *= 0.97f;
+      const float masks_size = dt_masks_change_size
+        (up,
+         dt_conf_get_float(DT_MASKS_CONF(form->type, circle, size)),
+         MIN_CIRCLE_RADIUS,
+         max_mask_size);
 
       dt_conf_set_float(DT_MASKS_CONF(form->type, circle, size), masks_size);
       dt_toast_log(_("size: %3.2f%%"), masks_size*100.0f);
@@ -165,12 +162,11 @@ static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module,
       // resize don't care where the mouse is inside a shape
       if(dt_modifier_is(state, GDK_SHIFT_MASK))
       {
-        if(up && circle->border < max_mask_border)
-          circle->border *= 1.0f / 0.97f;
-        else if(!up && circle->border > MIN_CIRCLE_BORDER)
-          circle->border *= 0.97f;
-        else
-          return 1;
+        circle->border = dt_masks_change_size
+          (up,
+           circle->border,
+           MIN_CIRCLE_BORDER, max_mask_border);
+
         dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
         dt_masks_gui_form_create(form, gui, index, module);
         dt_conf_set_float(DT_MASKS_CONF(form->type, circle, border), circle->border);
@@ -178,10 +174,11 @@ static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module,
       }
       else if(gui->edit_mode == DT_MASKS_EDIT_FULL)
       {
-        if(up && circle->radius < max_mask_size)
-          circle->radius *= 1.0f / 0.97f;
-        else if(!up && circle->radius > MIN_CIRCLE_RADIUS)
-          circle->radius *= 0.97f;
+        circle->radius = dt_masks_change_size
+          (up,
+           circle->radius,
+           MIN_CIRCLE_BORDER, max_mask_border);
+
         dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
         dt_masks_gui_form_create(form, gui, index, module);
         dt_conf_set_float(DT_MASKS_CONF(form->type, circle, size), circle->radius);

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2378,6 +2378,39 @@ float dt_masks_drag_factor(dt_masks_form_gui_t *gui,
   return s;
 }
 
+float dt_masks_change_size(gboolean up,
+                           const float value,
+                           const float min,
+                           const float max)
+{
+  const float v =
+    up
+    ? value / 0.97f
+    : value * 0.97f;
+
+  return CLAMP(v, min, max);
+}
+
+float dt_masks_change_rotation(gboolean up,
+                               const float value,
+                               const gboolean is_degree)
+{
+  const float step = 40.f;
+  const float incr = is_degree ? 360.f / step : 2.0f * DT_M_PI_F / step;
+  const float max  = is_degree ? 360.0        : M_PI_F;
+  const float v =
+    up
+    ? value + incr
+    : value - incr;
+
+  if(is_degree)
+    return fmodf(v + max, max);
+  else
+  {
+    return v > max ? v - (2.0f * max) : v;
+  }
+}
+
 // allow to select a shape inside an iop
 void dt_masks_select_form(struct dt_iop_module_t *module,
                           dt_masks_form_t *sel)

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -3199,16 +3199,10 @@ int scrolled(struct dt_iop_module_t *module,
       float radius = 0.0f, r = 0.0f, phi = 0.0f;
       get_stamp_params(module, &radius, &r, &phi);
 
-      float factor = 1.0f;
-      if(incr)
-        factor *= 1.0f / 0.97f;
-      else if(!incr && cabsf(warp->radius - warp->point) > 10.0f)
-        factor *= 0.97f;
+      r = dt_masks_change_size(incr, r, 10.0f, FLT_MAX);
+      radius = dt_masks_change_size(incr, radius, 10.0f, FLT_MAX);
 
-      r *= factor;
-      radius *= factor;
-
-      warp->radius = warp->point + (radius * factor);
+      warp->radius = warp->point + (dt_masks_change_size(incr, radius, 10.0f, FLT_MAX));
       warp->strength = warp->point + r * cexpf(phi * I);
 
       dt_conf_set_float(CONF_RADIUS, radius);
@@ -3218,13 +3212,8 @@ int scrolled(struct dt_iop_module_t *module,
     else if(dt_modifier_is(state, GDK_CONTROL_MASK))
     {
       //  change the strength direction
-      float phi = cargf(strength_v);
+      const float phi = dt_masks_change_rotation(incr, cargf(strength_v), FALSE);
       const float r = cabsf(strength_v);
-
-      if(incr)
-        phi += DT_M_PI_F / 16.0f;
-      else
-        phi -= DT_M_PI_F / 16.0f;
 
       warp->strength = warp->point + r * cexpf(phi * I);
       dt_conf_set_float(CONF_STRENGTH, r);
@@ -3235,12 +3224,7 @@ int scrolled(struct dt_iop_module_t *module,
     {
       //  change the strength
       const float phi = cargf(strength_v);
-      float r = cabsf(strength_v);
-
-      if(incr)
-        r *= 1.0f / 0.97f;
-      else
-        r *= 0.97f;
+      const float r = dt_masks_change_size(incr, cabsf(strength_v), 0.0001f, FLT_MAX);
 
       warp->strength = warp->point + r * cexpf(phi * I);
       dt_conf_set_float(CONF_STRENGTH, r);


### PR DESCRIPTION
Put all code changing size/rotation into specific routines. This ensure that the factor for the resize is shared and can be changed in a single place.