### PR TITLE
macOS: Bundle graphicsmagick without modules

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -177,6 +177,15 @@ jobs:
           # handle keg-only libs
           brew link --force libomp
           brew link --force libsoup@2
+      - name: Rebuild graphicsmagick without modules
+        run: |
+          export HOMEBREW_NO_INSTALL_FROM_API=1
+
+          gm_formula=`brew edit --print-path graphicsmagick`
+          cat $gm_formula | sed '/--with-modules/d' > gm_formula.tmp
+          mv gm_formula.tmp $gm_formula
+
+          brew reinstall --build-from-source graphicsmagick
       - name: Build and Install
           # todo: use linker which supports --wrap, ld.bfd and ld.gold support it
         run: |


### PR DESCRIPTION
On macOS homebrew graphicsmagick is installed with dynamic modules which are loaded on demand at runtime.
The path for that modules is hardcoded into the library `libGraphicsMagick.3.dylib`. When the macOS app bundle is created, the dynamic modules are not bundled, leading to crashes when importing file formats like dng.

The solution is to rebuild graphicsmagick without the option `--with-modules`.

This step takes a few additional minutes in the github action and it is not necessary for CI so I have only included it for building the nightly package.