### PR TITLE
Pixelpipe caching finally fixed (very hopefully)

### DIFF
--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -38,7 +38,7 @@ struct dt_iop_module_t;
 typedef struct dt_dev_history_item_t
 {
   struct dt_iop_module_t *module; // pointer to image operation module
-  int32_t enabled;                // switched respective module on/off
+  gboolean enabled;               // switched respective module on/off
   dt_iop_params_t *params;        // parameters for this operation
   struct dt_develop_blend_params_t *blend_params;
   char op_name[20];
@@ -48,7 +48,7 @@ typedef struct dt_dev_history_item_t
   gboolean multi_name_hand_edited;
   GList *forms;        // snapshot of dt_develop_t->forms
   int num;             // num of history on database
-  int32_t focus_hash;  // used to determine whether or not to start a
+  gboolean focus_hash;  // used to determine whether or not to start a
                        // new item or to merge down
 } dt_dev_history_item_t;
 
@@ -151,7 +151,7 @@ typedef struct dt_develop_t
                         // gui_init'ed.
   gboolean gui_leaving;  // set if everything is scheduled to shut down.
   gboolean gui_synch;    // set to TRUE by the render threads if gui_update should be called in the modules.
-  int32_t focus_hash;   // determines whether to start a new history item or to merge down.
+  gboolean focus_hash;   // determines whether to start a new history item or to merge down.
   gboolean preview_loading, preview2_loading, image_loading, history_updating, image_force_reload, first_load;
   gboolean preview_input_changed, preview2_input_changed;
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2544,7 +2544,7 @@ static void _display_mask_indicator_callback(GtkToggleButton *bt, dt_iop_module_
   const dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
 
   module->request_mask_display &= ~DT_DEV_PIXELPIPE_DISPLAY_MASK;
-  module->request_mask_display |= (is_active ? DT_DEV_PIXELPIPE_DISPLAY_MASK : 0);
+  module->request_mask_display |= (is_active ? DT_DEV_PIXELPIPE_DISPLAY_MASK : DT_DEV_PIXELPIPE_DISPLAY_NONE);
 
   // set the module show mask button too
   if(bd->showmask)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2133,7 +2133,7 @@ void dt_iop_request_focus(dt_iop_module_t *module)
   if(darktable.gui->reset || (out_focus_module == module)) return;
 
   darktable.develop->gui_module = module;
-  darktable.develop->focus_hash++;
+  darktable.develop->focus_hash = TRUE;
 
   /* lets lose the focus of previous focus module*/
   if(out_focus_module)

--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -55,15 +55,15 @@ gboolean dt_dev_pixelpipe_cache_init(dt_dev_pixelpipe_cache_t *cache, int entrie
 void dt_dev_pixelpipe_cache_cleanup(dt_dev_pixelpipe_cache_t *cache);
 
 /** creates a hopefully unique hash from the complete module stack up to the module-th. */
-uint64_t dt_dev_pixelpipe_cache_basichash(dt_imgid_t imgid, struct dt_dev_pixelpipe_t *pipe, int module);
+uint64_t dt_dev_pixelpipe_cache_basichash(const dt_imgid_t imgid, struct dt_dev_pixelpipe_t *pipe, int position);
 /** creates a hopefully unique hash from the complete module stack up to the module-th, including current viewport. */
-uint64_t dt_dev_pixelpipe_cache_hash(dt_imgid_t imgid, const struct dt_iop_roi_t *roi,
-                                     struct dt_dev_pixelpipe_t *pipe, int module);
+uint64_t dt_dev_pixelpipe_cache_hash(const dt_imgid_t imgid, const struct dt_iop_roi_t *roi,
+                                     struct dt_dev_pixelpipe_t *pipe, int position);
 /** return both of the above hashes */
-void dt_dev_pixelpipe_cache_fullhash(dt_imgid_t imgid, const dt_iop_roi_t *roi, struct dt_dev_pixelpipe_t *pipe, int module,
+void dt_dev_pixelpipe_cache_fullhash(const dt_imgid_t imgid, const dt_iop_roi_t *roi, struct dt_dev_pixelpipe_t *pipe, int position,
                                      uint64_t *basichash, uint64_t *fullhash);
 /** get the basichash for the last enabled module prior to the specified one */
-uint64_t dt_dev_pixelpipe_cache_basichash_prior(dt_imgid_t imgid, struct dt_dev_pixelpipe_t *pipe,
+uint64_t dt_dev_pixelpipe_cache_basichash_prior(const dt_imgid_t imgid, struct dt_dev_pixelpipe_t *pipe,
                                                 const struct dt_iop_module_t *const module);
 
 /** returns a float data buffer in 'data' for the given hash from the cache, dsc is updated too.
@@ -75,7 +75,7 @@ gboolean dt_dev_pixelpipe_cache_get(struct dt_dev_pixelpipe_t *pipe, const uint6
                                const size_t size, void **data, struct dt_iop_buffer_dsc_t **dsc, char *modname, const gboolean important);
 
 /** test availability of a cache line without destroying another, if it is not found. */
-gboolean dt_dev_pixelpipe_cache_available(dt_dev_pixelpipe_cache_t *cache, const uint64_t hash, const size_t size);
+gboolean dt_dev_pixelpipe_cache_available(struct dt_dev_pixelpipe_t *pipe, const uint64_t hash, const size_t size);
 
 /** invalidates all cachelines. */
 void dt_dev_pixelpipe_cache_flush(dt_dev_pixelpipe_cache_t *cache);
@@ -85,6 +85,9 @@ void dt_dev_pixelpipe_cache_flush_all_but(dt_dev_pixelpipe_cache_t *cache, uint6
 
 /** makes this buffer very important after it has been pulled from the cache. */
 void dt_dev_pixelpipe_cache_reweight(struct dt_dev_pixelpipe_t *pipe, void *data, const size_t size);
+
+/** markes this buffer as to be ignored */
+void dt_dev_pixelpipe_cache_unweight(struct dt_dev_pixelpipe_t *pipe, void *data);
 
 /** mark the given cache line pointer as invalid. */
 void dt_dev_pixelpipe_cache_invalidate(dt_dev_pixelpipe_cache_t *cache, void *data);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -65,7 +65,7 @@ typedef enum dt_pixelpipe_picker_source_t
 
 #include "develop/pixelpipe_cache.c"
 
-const char *dt_dev_pixelpipe_type_to_str(int pipe_type)
+const char *dt_dev_pixelpipe_type_to_str(const int pipe_type)
 {
   const gboolean fast = pipe_type & DT_DEV_PIXELPIPE_FAST;
   const char *r = NULL;
@@ -614,15 +614,6 @@ void dt_dev_pixelpipe_change(dt_dev_pixelpipe_t *pipe, struct dt_develop_t *dev)
                                   pipe->iwidth, pipe->iheight,
                                   &pipe->processed_width,
                                   &pipe->processed_height);
-}
-
-// TODO:
-void dt_dev_pixelpipe_add_node(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, int n)
-{
-}
-// TODO:
-void dt_dev_pixelpipe_remove_node(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, int n)
-{
 }
 
 static void _dump_pipe_pfm_diff(

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -161,7 +161,7 @@ gboolean dt_dev_pixelpipe_init_export(dt_dev_pixelpipe_t *pipe,
                                       const gboolean store_masks)
 {
   const gboolean res =
-    dt_dev_pixelpipe_init_cached(pipe, sizeof(float) * 4 * width * height, 2, 0);
+    dt_dev_pixelpipe_init_cached(pipe, sizeof(float) * 4 * width * height, DT_PIPECACHE_MIN, 0);
   pipe->type = DT_DEV_PIXELPIPE_EXPORT;
   pipe->levels = levels;
   pipe->store_all_raster_masks = store_masks;
@@ -173,7 +173,7 @@ gboolean dt_dev_pixelpipe_init_thumbnail(dt_dev_pixelpipe_t *pipe,
                                          const int32_t height)
 {
   const gboolean res =
-    dt_dev_pixelpipe_init_cached(pipe, sizeof(float) * 4 * width * height, 2, 0);
+    dt_dev_pixelpipe_init_cached(pipe, sizeof(float) * 4 * width * height, DT_PIPECACHE_MIN, 0);
   pipe->type = DT_DEV_PIXELPIPE_THUMBNAIL;
   return res;
 }
@@ -191,7 +191,7 @@ gboolean dt_dev_pixelpipe_init_dummy(dt_dev_pixelpipe_t *pipe,
 gboolean dt_dev_pixelpipe_init_preview(dt_dev_pixelpipe_t *pipe)
 {
   const gboolean res =
-    dt_dev_pixelpipe_init_cached(pipe, 0, darktable.pipe_cache ? 12 : 2, 0);
+    dt_dev_pixelpipe_init_cached(pipe, 0, darktable.pipe_cache ? 12 : DT_PIPECACHE_MIN, 0);
   pipe->type = DT_DEV_PIXELPIPE_PREVIEW;
   return res;
 }
@@ -199,7 +199,7 @@ gboolean dt_dev_pixelpipe_init_preview(dt_dev_pixelpipe_t *pipe)
 gboolean dt_dev_pixelpipe_init_preview2(dt_dev_pixelpipe_t *pipe)
 {
   const gboolean res =
-    dt_dev_pixelpipe_init_cached(pipe, 0, darktable.pipe_cache ? 5 : 2, 0);
+    dt_dev_pixelpipe_init_cached(pipe, 0, darktable.pipe_cache ? 5 : DT_PIPECACHE_MIN, 0);
   pipe->type = DT_DEV_PIXELPIPE_PREVIEW2;
   return res;
 }
@@ -208,7 +208,7 @@ gboolean dt_dev_pixelpipe_init(dt_dev_pixelpipe_t *pipe)
 {
   const size_t csize = MAX(64*1024*1024, darktable.dtresources.mipmap_memory / 4);
   const gboolean res =
-    dt_dev_pixelpipe_init_cached(pipe, 0, darktable.pipe_cache ? 64 : 2, csize);
+    dt_dev_pixelpipe_init_cached(pipe, 0, darktable.pipe_cache ? 64 : DT_PIPECACHE_MIN, csize);
   pipe->type = DT_DEV_PIXELPIPE_FULL;
   return res;
 }

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -451,7 +451,7 @@ void dt_dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe,
   dt_dev_pixelpipe_iop_t *piece = NULL;
 
   const dt_image_t *img      = &pipe->image;
-  const dt_imgid_t imgid        = img->id;
+  const dt_imgid_t imgid     = img->id;
   const gboolean rawprep_img = dt_image_is_rawprepare_supported(img);
   const gboolean raw_img     = dt_image_is_raw(img);
 
@@ -1327,7 +1327,7 @@ static gboolean _pixelpipe_process_on_CPU(
 static inline gboolean _check_good_pipe(dt_dev_pixelpipe_t *pipe)
 {
   return (pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW))
-         && (pipe->mask_display == 0);
+         && (pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_NONE);
 }
 
 static inline gboolean _check_module_next_important(dt_dev_pixelpipe_t *pipe,

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -289,15 +289,6 @@ void dt_dev_pixelpipe_disable_after(dt_dev_pixelpipe_t *pipe, const char *op);
 // disable given op and all that comes before it in the pipe:
 void dt_dev_pixelpipe_disable_before(dt_dev_pixelpipe_t *pipe, const char *op);
 
-
-// TODO: future application: remove/add modules from list, load from disk, user programmable etc
-void dt_dev_pixelpipe_add_node(dt_dev_pixelpipe_t *pipe,
-                               struct dt_develop_t *dev,
-                               const int n);
-void dt_dev_pixelpipe_remove_node(dt_dev_pixelpipe_t *pipe,
-                                  struct dt_develop_t *dev,
-                                  const int n);
-
 // helper function to pass a raster mask through a (so far) processed pipe
 float *dt_dev_get_raster_mask(const dt_dev_pixelpipe_t *pipe,
                               const struct dt_iop_module_t *raster_mask_source,

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -31,6 +31,8 @@
 extern "C" {
 #endif /* __cplusplus */
 
+#define DT_PIPECACHE_MIN 2
+
 /**
  * struct used by iop modules to connect to pixelpipe.
  * data can be used to store whatever private data and

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -153,7 +153,7 @@ typedef struct dt_dev_pixelpipe_t
   // we have to keep track of the next processing module to use an iop cacheline with high priority
   gboolean next_important_module;
 
-  int output_imgid;
+  dt_imgid_t output_imgid;
   // working?
   gboolean processing;
   // shutting down?


### PR DESCRIPTION
**A short summary how pixelpipe caching works**

The pixelpipe caching worked flawlessly as long as no mask_display was involved, that is defined in the pipe struct as mask_display.

It is set whenever we want some "special things" like masks visualized on the display, the gamma module is responsible for this.

The pixelpipe cache makes sure the data are valid by using a hash. Whenever we start processing a module we get a buffer (cacheline) via dt_dev_pixelpipe_cache_get() and keep the hash in the caching structs. The buffer is used for the module's processed **output**.

If we restart the pixelpipe, we check for existing cacheline buffers with the same hash and take that buffer as granted output of a module and avoid recalculating the whole pixelpipe until that point.

**The problem**
So - what's wrong with that / what did me take so long to understand? BTW, that's not new in the improved pixelpipe cache ...

The big point is, **we can and do change** the value of mask_display while processing the pixelpipe at every stage.
So we generate new data in the cacheline but as this data change is not refelected by an updated hash, we later might / certainly will re-use wrong data as valid!

**How has this been fixed?**

1. Whenever we are in mask_display mode we don't get a "regular" cacheline but use only the first two cachelines by swapping (as we do for exports). This is nice as we do not process most modules in mask_display mode but can do a shortcut. This way we reduce the cacheload and keep cachelines from non-mask_display mode valid, both lead to an improved hit rate.
2. The pixelpipe cache keeps track of mask_display mode and always sets dummy hashes so those lines will never be used by the regular pixelpipe.
3. After processing a module we take care of a change in mask_display. If in mask_display mode we have to in-validate the cacheline, dt_dev_pixelpipe_cache_unweight() is used for that.
4. The house-keeping of the cache had to be modified slightly to allow the "swapping" mode described above.

While being here
- imgid is now always int32_t
- many const added
- in some functions we had a parameter 'module', renamed to 'position' for understanding code
- simplified the next_important and important hint tracking
- slightly modified some debug info and added info about the mask_display