### PR TITLE
po/masks cleanup - code refactoring masks drawing in single routine - consistent display

### DIFF
--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -933,6 +933,15 @@ void dt_masks_stroke_arrow(cairo_t *cr,
                            const int group,
                            const float zoom_scale);
 
+/* set line width for the mask drawing depending on the status
+   border, source & selected
+*/
+void dt_masks_line_stroke(cairo_t *cr,
+                          const gboolean border,
+                          const gboolean source,
+                          const gboolean selected,
+                          const float zoom_scale);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif /* __cplusplus */

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -210,10 +210,10 @@ typedef struct dt_masks_functions_t
                        struct dt_masks_form_gui_t *gui,
                        const int index,
                        const int num_points,
-                       int *inside,
-                       int *inside_border,
+                       gboolean *inside,
+                       gboolean *inside_border,
                        int *near,
-                       int *inside_source,
+                       gboolean *inside_source,
                        float *dist);
   int (*get_points)(dt_develop_t *dev,
                     const float x,

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1206,7 +1206,9 @@ static void _brush_get_distance(const float x,
     for(int i = corner_count * 3; i < gpt->border_count; i++)
     {
       const float yy = gpt->border[i * 2 + 1];
-      if(((y<=yy && y>last) || (y>=yy && y<last)) && (gpt->border[i * 2] > x)) nb++;
+      if(((y<=yy && y>last) || (y>=yy && y<last))
+         && (gpt->border[i * 2] > x))
+        nb++;
       last = yy;
     }
     *inside = *inside_border = (nb & 1) == 1;
@@ -2382,7 +2384,10 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module,
                               gpt->points[k * 6 + 4],
                               gpt->points[k * 6 + 5],
                               &ffx, &ffy, TRUE);
-      if(pzx - ffx > -as && pzx - ffx < as && pzy - ffy > -as && pzy - ffy < as)
+      if(pzx - ffx > -as
+         && pzx - ffx < as
+         && pzy - ffy > -as
+         && pzy - ffy < as)
       {
         gui->feather_selected = k;
         dt_control_queue_redraw_center();
@@ -2477,7 +2482,7 @@ static void _brush_events_post_expose(cairo_t *cr,
     const float pr_d = darktable.develop->preview_downsampling;
     const float iwd = darktable.develop->preview_pipe->iwidth;
     const float iht = darktable.develop->preview_pipe->iheight;
-    const float min_iwd_iht= pr_d * MIN(iwd,iht);
+    const float min_iwd_iht = pr_d * MIN(iwd,iht);
 
     if(gui->guipoints_count == 0)
     {

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2666,8 +2666,6 @@ static void _brush_events_post_expose(cairo_t *cr,
   // draw path
   if(gpt->points_count > nb * 3 + 2)
   {
-    cairo_set_dash(cr, dashed, 0, 0);
-
     cairo_move_to(cr, gpt->points[nb * 6], gpt->points[nb * 6 + 1]);
     int seg = 1, seg2 = 0;
     for(int i = nb * 3; i < gpt->points_count; i++)
@@ -2678,22 +2676,13 @@ static void _brush_events_post_expose(cairo_t *cr,
          && gpt->points[i * 2] == gpt->points[seg * 6 + 2])
       {
         // this is the end of the last segment, so we have to draw it
-        if((gui->group_selected == index)
-           && (gui->form_selected || gui->form_dragging || gui->seg_selected == seg2))
-          cairo_set_line_width(cr, 5.0 / zoom_scale);
-        else
-          cairo_set_line_width(cr, 3.0 / zoom_scale);
-        dt_draw_set_color_overlay(cr, FALSE, 0.9);
-        cairo_stroke_preserve(cr);
-        if(gui->group_selected == index && gui->seg_selected == seg2)
-          cairo_set_line_width(cr, 5.0 / zoom_scale);
-        else if((gui->group_selected == index)
-           && (gui->form_selected || gui->form_dragging))
-          cairo_set_line_width(cr, 2.0 / zoom_scale);
-        else
-          cairo_set_line_width(cr, 1.0 / zoom_scale);
-        dt_draw_set_color_overlay(cr, TRUE, 0.8);
-        cairo_stroke(cr);
+
+        dt_masks_line_stroke
+          (cr, FALSE, FALSE,
+           (gui->group_selected == index)
+           && (gui->form_selected || gui->form_dragging || gui->seg_selected == seg2),
+           zoom_scale);
+
         // and we update the segment number
         seg = (seg + 1) % nb;
         seg2++;
@@ -2765,20 +2754,8 @@ static void _brush_events_post_expose(cairo_t *cr,
       cairo_line_to(cr, gpt->border[i * 2], gpt->border[i * 2 + 1]);
     }
     // we execute the drawing
-    if(gui->border_selected)
-      cairo_set_line_width(cr, 2.0 / zoom_scale);
-    else
-      cairo_set_line_width(cr, 1.0 / zoom_scale);
-    dt_draw_set_color_overlay(cr, FALSE, 0.8);
-    cairo_set_dash(cr, dashed, len, 0);
-    cairo_stroke_preserve(cr);
-    if(gui->border_selected)
-      cairo_set_line_width(cr, 2.0 / zoom_scale);
-    else
-      cairo_set_line_width(cr, 1.0 / zoom_scale);
-    dt_draw_set_color_overlay(cr, TRUE, 0.8);
-    cairo_set_dash(cr, dashed, len, 4);
-    cairo_stroke(cr);
+
+    dt_masks_line_stroke(cr, TRUE, FALSE, gui->border_selected, zoom_scale);
   }
 
   // draw the source if needed
@@ -2827,23 +2804,16 @@ static void _brush_events_post_expose(cairo_t *cr,
     dt_masks_stroke_arrow(cr, gui, index, zoom_scale);
 
     // we draw the source
-    cairo_set_dash(cr, dashed, 0, 0);
-    if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
-      cairo_set_line_width(cr, 2.5 / zoom_scale);
-    else
-      cairo_set_line_width(cr, 1.5 / zoom_scale);
-    dt_draw_set_color_overlay(cr, FALSE, 0.8);
+
     cairo_move_to(cr, gpt->source[nb * 6], gpt->source[nb * 6 + 1]);
     for(int i = nb * 3; i < gpt->source_count; i++)
       cairo_line_to(cr, gpt->source[i * 2], gpt->source[i * 2 + 1]);
     cairo_line_to(cr, gpt->source[nb * 6], gpt->source[nb * 6 + 1]);
-    cairo_stroke_preserve(cr);
-    if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
-      cairo_set_line_width(cr, 1.0 / zoom_scale);
-    else
-      cairo_set_line_width(cr, 0.5 / zoom_scale);
-    dt_draw_set_color_overlay(cr, TRUE, 0.8);
-    cairo_stroke(cr);
+
+    dt_masks_line_stroke
+      (cr, FALSE, TRUE,
+       (gui->group_selected == index) && (gui->form_selected || gui->form_dragging),
+       zoom_scale);
   }
 }
 

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1132,16 +1132,16 @@ static void _brush_get_distance(const float x,
                                 dt_masks_form_gui_t *gui,
                                 const int index,
                                 const int corner_count,
-                                int *inside,
-                                int *inside_border,
+                                gboolean *inside,
+                                gboolean *inside_border,
                                 int *near,
-                                int *inside_source,
+                                gboolean *inside_source,
                                 float *dist)
 {
   // initialise returned values
-  *inside_source = 0;
-  *inside = 0;
-  *inside_border = 0;
+  *inside_source = FALSE;
+  *inside = FALSE;
+  *inside_border = FALSE;
   *near = -1;
   *dist = FLT_MAX;
 
@@ -1182,16 +1182,16 @@ static void _brush_get_distance(const float x,
 
       if(*dist == dd && dd < as2)
       {
-        if(*inside == 0)
+        if(!*inside)
         {
           if(current_seg == 0)
-            *inside_source = corner_count - 1;
+            *inside_source = (corner_count - 1) > 0;
           else
-            *inside_source = current_seg - 1;
+            *inside_source = (current_seg - 1) > 0;
 
           if(*inside_source)
           {
-            *inside = 1;
+            *inside = TRUE;
           }
         }
       }
@@ -1209,7 +1209,7 @@ static void _brush_get_distance(const float x,
       if(((y<=yy && y>last) || (y>=yy && y<last)) && (gpt->border[i * 2] > x)) nb++;
       last = yy;
     }
-    *inside = *inside_border = (nb & 1);
+    *inside = *inside_border = (nb & 1) == 1;
   }
 
   // and we check if we are near a segment
@@ -2427,8 +2427,9 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module,
   }
 
   // are we inside the form or the borders or near a segment ???
-  int in, inb, near, ins;
+  gboolean in, inb, ins;
   float dist;
+  int near;
   _brush_get_distance(pzx, pzy, as, gui, index, nb, &in, &inb, &near, &ins, &dist);
   gui->seg_selected = near;
   if(near < 0)

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -29,6 +29,11 @@
 #define MIN_CIRCLE_RADIUS 0.0005f
 #define MIN_CIRCLE_BORDER 0.0005f
 
+static inline int _nb_ctrl_point(void)
+{
+  return 2;
+}
+
 static void _circle_get_distance(const float x,
                                  const float y,
                                  const float as,
@@ -665,7 +670,7 @@ static void _circle_draw_lines(const gboolean borders,
   if(points_count <= 6) return;
 
   cairo_move_to(cr, points[2], points[3]);
-  for(int i = 2; i < points_count; i++)
+  for(int i = _nb_ctrl_point(); i < points_count; i++)
   {
     cairo_line_to(cr, points[i * 2], points[i * 2 + 1]);
   }
@@ -924,13 +929,13 @@ static void _circle_events_post_expose(cairo_t *cr,
       float from_y = 0.0f;
 
       dt_masks_closest_point(gpt->points_count,
-                             2,
+                             _nb_ctrl_point(),
                              gpt->points,
                              gpt->source[0], gpt->source[1],
                              &to_x, &to_y);
 
       dt_masks_closest_point(gpt->source_count,
-                             2,
+                             _nb_ctrl_point(),
                              gpt->source,
                              to_x, to_y,
                              &from_x, &from_y);

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -35,17 +35,17 @@ static void _circle_get_distance(const float x,
                                  dt_masks_form_gui_t *gui,
                                  const int index,
                                  const int num_points,
-                                 int *inside,
-                                 int *inside_border,
+                                 gboolean *inside,
+                                 gboolean *inside_border,
                                  int *near,
-                                 int *inside_source,
+                                 gboolean *inside_source,
                                  float *dist)
 {
   (void)num_points; // unused arg, keep compiler from complaining
   // initialise returned values
-  *inside_source = 0;
-  *inside = 0;
-  *inside_border = 0;
+  *inside_source = FALSE;
+  *inside = FALSE;
+  *inside_border = FALSE;
   *near = -1;
   *dist = FLT_MAX;
 
@@ -58,8 +58,8 @@ static void _circle_get_distance(const float x,
   // we first check if we are inside the source form
   if(dt_masks_point_in_form_exact(x, y, gpt->source, 1, gpt->source_count))
   {
-    *inside_source = 1;
-    *inside = 1;
+    *inside_source = TRUE;
+    *inside = TRUE;
 
     // distance from source center
     const float cx = x - gpt->source[0];
@@ -92,7 +92,7 @@ static void _circle_get_distance(const float x,
   // we check if it's inside borders
   if(!dt_masks_point_in_form_exact(x, y, gpt->border, 1, gpt->border_count)) return;
 
-  *inside = 1;
+  *inside = TRUE;
   *near = 0;
 
   // and we check if it's inside form
@@ -585,7 +585,8 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module,
     const float as = DT_PIXEL_APPLY_DPI(5) / zoom_scale;
     const float x = pzx * darktable.develop->preview_pipe->backbuf_width;
     const float y = pzy * darktable.develop->preview_pipe->backbuf_height;
-    int in, inb, near, ins;
+    gboolean in, inb, ins;
+    int near;
     float dist;
     _circle_get_distance(x, y, as, gui, index, 0, &in, &inb, &near, &ins, &dist);
     if(ins)

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -654,7 +654,8 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module,
   return 0;
 }
 
-static void _circle_draw_lines(gboolean borders, gboolean source,
+static void _circle_draw_lines(const gboolean borders,
+                               const gboolean source,
                                cairo_t *cr, double *dashed,
                                const int len,
                                const gboolean selected,

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1196,7 +1196,8 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module,
 
     const float pts[8] = { xref, yref, x, y, 0, 0, gui->dx, gui->dy };
 
-    const float dv = atan2f(pts[3] - pts[1], pts[2] - pts[0]) - atan2f(-(pts[7] - pts[5]), -(pts[6] - pts[4]));
+    const float dv = atan2f(pts[3] - pts[1], pts[2] - pts[0])
+      - atan2f(-(pts[7] - pts[5]), -(pts[6] - pts[4]));
 
     float pts2[8] = { xref, yref, x, y, xref + 10.0f, yref, xref, yref + 10.0f };
     dt_dev_distort_backtransform(darktable.develop, pts2, 4);
@@ -1274,10 +1275,10 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module,
       {
         // prefer border points over shape itself in case of near
         // overlap for ease of pickup
-        if(x - gpt->border[i * 2] > -as
-           && x - gpt->border[i * 2] < as
-           && y - gpt->border[i * 2 + 1] > -as
-           && y - gpt->border[i * 2 + 1] < as)
+        if(x - gpt->border[i * 2] > -as*2.0f
+           && x - gpt->border[i * 2] < as*2.0f
+           && y - gpt->border[i * 2 + 1] > -as*2.0f
+           && y - gpt->border[i * 2 + 1] < as*2.0f)
         {
           gui->point_border_selected = i;
           break;

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -159,10 +159,10 @@ static void _ellipse_get_distance(const float x,
                                   const float as,
                                   dt_masks_form_gui_t *gui, int index,
                                   const int num_points,
-                                  int *inside,
-                                  int *inside_border,
+                                  gboolean *inside,
+                                  gboolean *inside_border,
                                   int *near,
-                                  int *inside_source,
+                                  gboolean *inside_source,
                                   float *dist)
 {
   (void)num_points; // unused arg, keep compiler from complaining
@@ -180,9 +180,9 @@ static void _ellipse_get_distance(const float x,
   {
     if(_ellipse_point_in_polygon(x, y, gpt->source + 10, gpt->source_count - 5) >= 0)
     {
-      *inside_source = 1;
-      *inside = 1;
-      *inside_border = 0;
+      *inside_source = TRUE;
+      *inside = TRUE;
+      *inside_border = FALSE;
       *near = -1;
 
       // get the minial dist for center & control points
@@ -214,18 +214,18 @@ static void _ellipse_get_distance(const float x,
   // we check if it's inside borders
   if(_ellipse_point_in_polygon(x, y, gpt->border + 10, gpt->border_count - 5) < 0)
   {
-    *inside = 0;
-    *inside_border = 0;
+    *inside = FALSE;
+    *inside_border = FALSE;
     *near = -1;
     return;
   }
 
-  *inside = 1;
+  *inside = TRUE;
   *near = 0;
-  *inside_border = 1;
+  *inside_border = TRUE;
 
   if(_ellipse_point_in_polygon(x, y, gpt->points + 10, gpt->points_count - 5) >= 0)
-    *inside_border = 0;
+    *inside_border = FALSE;
   if(_ellipse_point_close_to_path(x, y, as, gpt->points + 10, gpt->points_count - 5))
     *near = 1;
 }
@@ -1233,7 +1233,9 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module,
     const float x = pzx * darktable.develop->preview_pipe->backbuf_width;
     const float y = pzy * darktable.develop->preview_pipe->backbuf_height;
 
-    int in = 0, inb = 0, near = 0, ins = 0;
+    gboolean in = FALSE, inb = FALSE, ins = FALSE;
+    int near = 0;
+
     float dist = 0.0f;
     _ellipse_get_distance(x, y, as, gui, index, 0, &in, &inb, &near, &ins, &dist);
     if(ins)

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -26,6 +26,11 @@
 #include "develop/masks.h"
 #include "develop/openmp_maths.h"
 
+static inline int _nb_ctrl_point(void)
+{
+  return 6;
+}
+
 static inline void _ellipse_point_transform(const float xref,
                                             const float yref,
                                             const float x,
@@ -186,7 +191,7 @@ static void _ellipse_get_distance(const float x,
       *near = -1;
 
       // get the minial dist for center & control points
-      for(int k=0; k<5; k++)
+      for(int k=0; k<_nb_ctrl_point() - 1; k++)
       {
         const float cx = x - gpt->source[k * 2];
         const float cy = y - gpt->source[k * 2 + 1];
@@ -197,7 +202,7 @@ static void _ellipse_get_distance(const float x,
     }
   }
 
-  for(int k=0; k<5; k++)
+  for(int k=0; k<_nb_ctrl_point() - 1; k++)
   {
     const float cx = x - gpt->points[k * 2];
     const float cy = y - gpt->points[k * 2 + 1];
@@ -251,7 +256,7 @@ static void _ellipse_draw_shape(const gboolean borders,
 
   _ellipse_point_transform(xref, yref, points[10], points[11], sinr, cosr, &x, &y);
   cairo_move_to(cr, x, y);
-  for(int i = 6; i < points_count; i++)
+  for(int i = _nb_ctrl_point(); i < points_count; i++)
   {
     _ellipse_point_transform(xref, yref, points[i * 2], points[i * 2 + 1],
                              sinr, cosr, &x, &y);
@@ -1257,7 +1262,7 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module,
     {
       dt_masks_form_gui_points_t *gpt =
         (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
-      for(int i = 1; i < 5; i++)
+      for(int i = 1; i < _nb_ctrl_point() - 1; i++)
       {
         // prefer border points over shape itself in case of near
         // overlap for ease of pickup
@@ -1432,7 +1437,7 @@ static void _ellipse_events_post_expose(cairo_t *cr,
     const float sinr = sinf(r);
     const float cosr = cosf(r);
 
-    for(int i = 1; i < 5; i++)
+    for(int i = 1; i < _nb_ctrl_point() - 1; i++)
     {
       float x, y;
       _ellipse_point_transform(xref, yref, gpt->points[i * 2],
@@ -1465,13 +1470,13 @@ static void _ellipse_events_post_expose(cairo_t *cr,
       float from_y = 0.0f;
 
       dt_masks_closest_point(gpt->points_count,
-                             6,
+                             _nb_ctrl_point(),
                              gpt->points,
                              gpt->source[0], gpt->source[1],
                              &to_x, &to_y);
 
       dt_masks_closest_point(gpt->source_count,
-                             6,
+                             _nb_ctrl_point(),
                              gpt->source,
                              to_x, to_y,
                              &from_x, &from_y);

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -910,7 +910,8 @@ end:
   return res;
 }
 
-static void _gradient_draw_lines(gboolean borders, cairo_t *cr,
+static void _gradient_draw_lines(const gboolean borders,
+                                 cairo_t *cr,
                                  double *dashed,
                                  const float len,
                                  const gboolean selected,
@@ -989,7 +990,7 @@ static void _gradient_draw_lines(gboolean borders, cairo_t *cr,
   }
 }
 
-static void _gradient_draw_arrow(cairo_t *cr, double *dashed,
+static void _gradient_draw_arrow(cairo_t *cr,
                                  const float len,
                                  const gboolean selected,
                                  const gboolean border_selected,

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -26,6 +26,12 @@
 #include "develop/masks.h"
 #include "develop/openmp_maths.h"
 
+static inline int _nb_ctrl_point(void)
+{
+  return 3;
+}
+
+
 static void _gradient_get_distance(const float x,
                                    const float y,
                                    const float as,
@@ -54,7 +60,7 @@ static void _gradient_get_distance(const float x,
   float close_to_controls = FALSE;
 
   // compute distances with the three control points
-  for(int k = 0; k<3; k++)
+  for(int k = 0; k < _nb_ctrl_point(); k++)
   {
     const float dx = x - gpt->points[k * 2];
     const float dy = y - gpt->points[k * 2 + 1];
@@ -83,7 +89,7 @@ static void _gradient_get_distance(const float x,
   }
 
   // check if we are close to main line
-  for(int i = 3; i < gpt->points_count; i++)
+  for(int i = _nb_ctrl_point(); i < gpt->points_count; i++)
   {
     if((x - gpt->points[i * 2]) * (x - gpt->points[i * 2])
        + (y - gpt->points[i * 2 + 1]) * (y - gpt->points[i * 2 + 1]) < as2)
@@ -757,13 +763,12 @@ static int _gradient_get_points(dt_develop_t *dev,
   const float xstart = fabsf(curvature) > 1.0f ? -sqrtf(1.0f / fabsf(curvature)) : -1.0f;
   const float xdelta = -2.0f * xstart / (count - 3);
 
-//  gboolean in_frame = FALSE;
 #ifdef _OPENMP
 #pragma omp parallel for default(none) num_threads(nthreads)            \
     dt_omp_firstprivate(nthreads, pts, pts_count, count, cosv, sinv, xstart, xdelta, curvature, scale, x, y, wd,  \
                         ht, c_padded_size, points) schedule(static) if(count > 100)
 #endif
-  for(int i = 3; i < count; i++)
+  for(int i = _nb_ctrl_point(); i < count; i++)
   {
     const float xi = xstart + (i - 3) * xdelta;
     const float yi = curvature * xi * xi;
@@ -854,7 +859,7 @@ static int _gradient_get_pts_border(dt_develop_t *dev,
                                                 + (points_count2 - 3) + 1));
     if(*points == NULL) goto end;
     *points_count = (points_count1 - 3) + (points_count2 - 3) + 1;
-    for(int i = 3; i < points_count1; i++)
+    for(int i = _nb_ctrl_point(); i < points_count1; i++)
     {
       (*points)[k * 2] = points1[i * 2];
       (*points)[k * 2 + 1] = points1[i * 2 + 1];
@@ -862,7 +867,7 @@ static int _gradient_get_pts_border(dt_develop_t *dev,
     }
     (*points)[k * 2] = (*points)[k * 2 + 1] = INFINITY;
     k++;
-    for(int i = 3; i < points_count2; i++)
+    for(int i = _nb_ctrl_point(); i < points_count2; i++)
     {
       (*points)[k * 2] = points2[i * 2];
       (*points)[k * 2 + 1] = points2[i * 2 + 1];
@@ -877,7 +882,7 @@ static int _gradient_get_pts_border(dt_develop_t *dev,
     *points = dt_alloc_align_float((size_t)2 * ((points_count1 - 3)));
     if(*points == NULL) goto end;
     *points_count = points_count1 - 3;
-    for(int i = 3; i < points_count1; i++)
+    for(int i = _nb_ctrl_point(); i < points_count1; i++)
     {
       (*points)[k * 2] = points1[i * 2];
       (*points)[k * 2 + 1] = points1[i * 2 + 1];
@@ -893,7 +898,7 @@ static int _gradient_get_pts_border(dt_develop_t *dev,
     if(*points == NULL) goto end;
     *points_count = points_count2 - 3;
 
-    for(int i = 3; i < points_count2; i++)
+    for(int i = _nb_ctrl_point(); i < points_count2; i++)
     {
       (*points)[k * 2] = points2[i * 2];
       (*points)[k * 2 + 1] = points2[i * 2 + 1];
@@ -1162,7 +1167,7 @@ static int _gradient_get_area(const dt_iop_module_t *const module,
   float xmin = 0.0f, xmax = 0.0f, ymin = 0.0f, ymax = 0.0f;
   xmin = ymin = FLT_MAX;
   xmax = ymax = FLT_MIN;
-  for(int i = 0; i < 4; i++)
+  for(int i = 0; i < _nb_ctrl_point(); i++)
   {
     xmin = fminf(points[i * 2], xmin);
     xmax = fmaxf(points[i * 2], xmax);

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -32,16 +32,16 @@ static void _gradient_get_distance(const float x,
                                    dt_masks_form_gui_t *gui,
                                    const int index,
                                    const int num_points,
-                                   int *inside,
-                                   int *inside_border,
+                                   gboolean *inside,
+                                   gboolean *inside_border,
                                    int *near,
-                                   int *inside_source,
+                                   gboolean *inside_source,
                                    float *dist)
 {
   (void)num_points; // unused arg, keep compiler from complaining
   if(!gui) return;
 
-  *inside = *inside_border = *inside_source = 0;
+  *inside = *inside_border = *inside_source = FALSE;
   *near = -1;
   *dist = FLT_MAX;
 
@@ -67,7 +67,7 @@ static void _gradient_get_distance(const float x,
   // check if we are close to pivot or anchor
   if(close_to_controls)
   {
-    *inside = 1;
+    *inside = TRUE;
     return;
   }
 
@@ -77,7 +77,7 @@ static void _gradient_get_distance(const float x,
     if((x - gpt->border[i * 2]) * (x - gpt->border[i * 2])
        + (y - gpt->border[i * 2 + 1]) * (y - gpt->border[i * 2 + 1]) < as2)
     {
-      *inside_border = 1;
+      *inside_border = TRUE;
       return;
     }
   }
@@ -88,7 +88,7 @@ static void _gradient_get_distance(const float x,
     if((x - gpt->points[i * 2]) * (x - gpt->points[i * 2])
        + (y - gpt->points[i * 2 + 1]) * (y - gpt->points[i * 2 + 1]) < as2)
     {
-      *inside = 1;
+      *inside = TRUE;
       return;
     }
   }
@@ -635,7 +635,8 @@ static int _gradient_events_mouse_moved(struct dt_iop_module_t *module,
     const float as = DT_PIXEL_APPLY_DPI(20) / (pr_d * zoom_scale);
     const float x = pzx * darktable.develop->preview_pipe->backbuf_width;
     const float y = pzy * darktable.develop->preview_pipe->backbuf_height;
-    int in, inb, near, ins;
+    gboolean in, inb, ins;
+    int near;
     float dist;
     _gradient_get_distance(x, y, as, gui, index, 0, &in, &inb, &near, &ins, &dist);
 

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2796,6 +2796,40 @@ void dt_masks_closest_point(const int count,
   }
 }
 
+void dt_masks_line_stroke(cairo_t *cr,
+                          const gboolean border,
+                          const gboolean source,
+                          const gboolean selected,
+                          const float zoom_scale)
+{
+  const double size_border     = 1.0;
+  const double size_source     = 1.5;
+  const double size_mask       = 2.5;
+  const double factor_selected = 1.8;
+
+  double dashed[] = { 4.0, 4.0 };
+  dashed[0] /= zoom_scale;
+  dashed[1] /= zoom_scale;
+  const int len = sizeof(dashed) / sizeof(dashed[0]);
+
+  dt_draw_set_color_overlay(cr, FALSE, 0.8);
+  cairo_set_dash(cr, dashed, border ? len : 0, 0);
+
+  const double line_width =
+    (border ? size_border : (source ? size_source : size_mask))
+    * (selected ? factor_selected : 1.0);
+
+  cairo_set_line_width(cr, line_width / zoom_scale);
+
+  cairo_stroke_preserve(cr);
+
+  cairo_set_line_width(cr, (line_width / 2.0) / zoom_scale);
+
+  dt_draw_set_color_overlay(cr, TRUE, 0.8);
+  cairo_set_dash(cr, dashed, border ? len : 0, 4);
+  cairo_stroke(cr);
+}
+
 #include "detail.c"
 
 // clang-format off

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2337,7 +2337,9 @@ int dt_masks_point_in_form_near(const float x,
       if((yf <= y2 && yf > y1) || (yf >= y2 && yf < y1))
       {
         if(points[i * 2] > x) nb++;
-        if(points[i * 2] - x < distance && points[i * 2] - x > -distance) *near = 1;
+        if(points[i * 2] - x < distance
+           && points[i * 2] - x > -distance)
+          *near = i * 2;
       }
 
       if(next == start) break;

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2289,7 +2289,8 @@ int dt_masks_point_in_form_exact(const float x,
       }
       if(((yf <= y2 && yf > y1)
           || (yf >= y2 && yf < y1))
-         && (points[i * 2] > x)) nb++;
+         && (points[i * 2] > x))
+        nb++;
 
       if(next == start) break;
       i = next++;
@@ -2336,7 +2337,8 @@ int dt_masks_point_in_form_near(const float x,
       }
       if((yf <= y2 && yf > y1) || (yf >= y2 && yf < y1))
       {
-        if(points[i * 2] > x) nb++;
+        if(points[i * 2] > x)
+          nb++;
         if(points[i * 2] - x < distance
            && points[i * 2] - x > -distance)
           *near = i * 2;
@@ -2344,7 +2346,8 @@ int dt_masks_point_in_form_near(const float x,
 
       if(next == start) break;
       i = next++;
-      if(next >= points_count) next = start;
+      if(next >= points_count)
+        next = start;
     }
     return (nb & 1);
   }

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2805,14 +2805,14 @@ void dt_masks_line_stroke(cairo_t *cr,
   const double size_border     = 1.0;
   const double size_source     = 1.5;
   const double size_mask       = 2.5;
-  const double factor_selected = 1.8;
+  const double factor_selected = 1.9;
 
   double dashed[] = { 4.0, 4.0 };
   dashed[0] /= zoom_scale;
   dashed[1] /= zoom_scale;
   const int len = sizeof(dashed) / sizeof(dashed[0]);
 
-  dt_draw_set_color_overlay(cr, FALSE, 0.8);
+  dt_draw_set_color_overlay(cr, FALSE, selected ? 1.0 : 0.6);
   cairo_set_dash(cr, dashed, border ? len : 0, 0);
 
   const double line_width =
@@ -2825,7 +2825,7 @@ void dt_masks_line_stroke(cairo_t *cr,
 
   cairo_set_line_width(cr, (line_width / 2.0) / zoom_scale);
 
-  dt_draw_set_color_overlay(cr, TRUE, 0.8);
+  dt_draw_set_color_overlay(cr, TRUE, selected ? 1.0 : 0.6);
   cairo_set_dash(cr, dashed, border ? len : 0, 4);
   cairo_stroke(cr);
 }

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1065,7 +1065,8 @@ static void _path_get_distance(const float x,
       //because of self-intersection)
       if(isnan(gpt->points[i * 2]))
       {
-        if(isnan(gpt->points[i * 2 + 1])) break;
+        if(isnan(gpt->points[i * 2 + 1]))
+          break;
         i = (int)gpt->points[i * 2 + 1] - 1;
         continue;
       }
@@ -1096,7 +1097,9 @@ static void _path_get_distance(const float x,
           *near = current_seg - 1;
       }
 
-      if(((y<=yy && y>last) || (y>=yy && y<last)) && (gpt->points[i * 2] > x)) nb++;
+      if(((y<=yy && y>last) || (y>=yy && y<last))
+         && (gpt->points[i * 2] > x))
+        nb++;
 
       last = yy;
     }

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -990,16 +990,16 @@ static void _path_get_distance(const float x,
                                dt_masks_form_gui_t *gui,
                                const int index,
                                const int corner_count,
-                               int *inside,
-                               int *inside_border,
+                               gboolean *inside,
+                               gboolean *inside_border,
                                int *near,
-                               int *inside_source,
+                               gboolean *inside_source,
                                float *dist)
 {
   // initialise returned values
-  *inside_source = 0;
-  *inside = 0;
-  *inside_border = 0;
+  *inside_source = FALSE;
+  *inside = FALSE;
+  *inside_border = FALSE;
   *near = -1;
   *dist = FLT_MAX;
 
@@ -1012,8 +1012,8 @@ static void _path_get_distance(const float x,
   // we first check if we are inside the source form
   if(dt_masks_point_in_form_exact(x, y, gpt->source, corner_count * 6, gpt->source_count))
   {
-    *inside_source = 1;
-    *inside = 1;
+    *inside_source = TRUE;
+    *inside = TRUE;
 
     float x_min = FLT_MAX, y_min = FLT_MAX;
     float x_max = FLT_MIN, y_max = FLT_MIN;
@@ -1044,7 +1044,7 @@ static void _path_get_distance(const float x,
   if(!dt_masks_point_in_form_exact(x, y, gpt->border, corner_count * 3, gpt->border_count))
     return;
 
-  *inside = 1;
+  *inside = TRUE;
 
   // and we check if it's inside form
   if(gpt->points_count > 2 + corner_count * 3)
@@ -1107,7 +1107,8 @@ static void _path_get_distance(const float x,
     const float dd = sqf(cx) + sqf(cy);
     *dist = fminf(*dist, dd);
   }
-  else *inside_border = 1;
+  else
+    *inside_border = TRUE;
 }
 
 static int _path_get_points_border(dt_develop_t *dev,
@@ -2176,7 +2177,8 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module,
   }
 
   // are we inside the form or the borders or near a segment ???
-  int in = 0, inb = 0, near = 0, ins = 0;
+  gboolean in = FALSE, inb = FALSE, ins = FALSE;
+  int near = 0;
   float dist = 0;
   _path_get_distance(pzx, (int)pzy, as, gui, index, nb, &in, &inb, &near, &ins, &dist);
   gui->seg_selected = near;

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -2216,10 +2216,6 @@ static void _path_events_post_expose(cairo_t *cr,
                                      const int index,
                                      const int nb)
 {
-  double dashed[] = { 4.0, 4.0 };
-  dashed[0] /= zoom_scale;
-  dashed[1] /= zoom_scale;
-  const int len = sizeof(dashed) / sizeof(dashed[0]);
   if(!gui) return;
   dt_masks_form_gui_points_t *gpt =
     (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
@@ -2228,8 +2224,6 @@ static void _path_events_post_expose(cairo_t *cr,
   // draw path
   if(gpt->points_count > nb * 3 + 6)
   {
-    cairo_set_dash(cr, dashed, 0, 0);
-
     cairo_move_to(cr, gpt->points[nb * 6], gpt->points[nb * 6 + 1]);
     int seg = 1, seg2 = 0;
     for(int i = nb * 3; i < gpt->points_count; i++)
@@ -2240,20 +2234,12 @@ static void _path_events_post_expose(cairo_t *cr,
          && gpt->points[i * 2] == gpt->points[seg * 6 + 2])
       {
         // this is the end of the last segment, so we have to draw it
-        if((gui->group_selected == index)
-           && (gui->form_selected || gui->form_dragging || gui->seg_selected == seg2))
-          cairo_set_line_width(cr, 5.0 / zoom_scale);
-        else
-          cairo_set_line_width(cr, 3.0 / zoom_scale);
-        dt_draw_set_color_overlay(cr, FALSE, 0.8);
-        cairo_stroke_preserve(cr);
-        if((gui->group_selected == index)
-           && (gui->form_selected || gui->form_dragging || gui->seg_selected == seg2))
-          cairo_set_line_width(cr, 2.0 / zoom_scale);
-        else
-          cairo_set_line_width(cr, 1.0 / zoom_scale);
-        dt_draw_set_color_overlay(cr, TRUE, 0.8);
-        cairo_stroke(cr);
+
+        dt_masks_line_stroke
+          (cr, FALSE, FALSE,
+           (gui->group_selected == index)
+           && (gui->form_selected || gui->form_dragging || gui->seg_selected == seg2),
+           zoom_scale);
         // and we update the segment number
         seg = (seg + 1) % nb;
         seg2++;
@@ -2292,12 +2278,8 @@ static void _path_events_post_expose(cairo_t *cr,
                            &ffx, &ffy, gpt->clockwise);
     cairo_move_to(cr, gpt->points[k * 6 + 2], gpt->points[k * 6 + 3]);
     cairo_line_to(cr, ffx, ffy);
-    cairo_set_line_width(cr, 1.5 / zoom_scale);
-    dt_draw_set_color_overlay(cr, FALSE, 0.8);
-    cairo_stroke_preserve(cr);
-    cairo_set_line_width(cr, 0.75 / zoom_scale);
-    dt_draw_set_color_overlay(cr, TRUE, 0.8);
-    cairo_stroke(cr);
+
+    dt_masks_line_stroke(cr, TRUE, FALSE, FALSE, zoom_scale);
 
     if(k == gui->feather_dragging || k == gui->feather_selected)
       cairo_arc(cr, ffx, ffy, 3.0f / zoom_scale, 0, 2.0 * M_PI);
@@ -2334,20 +2316,7 @@ static void _path_events_post_expose(cairo_t *cr,
         cairo_line_to(cr, gpt->border[i * 2], gpt->border[i * 2 + 1]);
     }
     // we execute the drawing
-    if(gui->border_selected)
-      cairo_set_line_width(cr, 2.0 / zoom_scale);
-    else
-      cairo_set_line_width(cr, 1.0 / zoom_scale);
-    dt_draw_set_color_overlay(cr, FALSE, 0.8);
-    cairo_set_dash(cr, dashed, len, 0);
-    cairo_stroke_preserve(cr);
-    if(gui->border_selected)
-      cairo_set_line_width(cr, 2.0 / zoom_scale);
-    else
-      cairo_set_line_width(cr, 1.0 / zoom_scale);
-    dt_draw_set_color_overlay(cr, TRUE, 0.8);
-    cairo_set_dash(cr, dashed, len, 4);
-    cairo_stroke(cr);
+    dt_masks_line_stroke(cr, TRUE, FALSE, gui->border_selected, zoom_scale);
 
     // we draw the path segment by segment
     for(int k = 0; k < nb; k++)
@@ -2444,29 +2413,17 @@ static void _path_events_post_expose(cairo_t *cr,
     dt_masks_stroke_arrow(cr, gui, index, zoom_scale);
 
     // we draw the source
-    cairo_set_dash(cr, dashed, 0, 0);
-    if((gui->group_selected == index)
-       && (gui->form_selected || gui->form_dragging))
-      cairo_set_line_width(cr, 2.5 / zoom_scale);
-    else
-      cairo_set_line_width(cr, 1.5 / zoom_scale);
-
-    dt_draw_set_color_overlay(cr, FALSE, 0.8);
     cairo_move_to(cr, gpt->source[nb * 6], gpt->source[nb * 6 + 1]);
 
     for(int i = nb * 3; i < gpt->source_count; i++)
       cairo_line_to(cr, gpt->source[i * 2], gpt->source[i * 2 + 1]);
 
     cairo_line_to(cr, gpt->source[nb * 6], gpt->source[nb * 6 + 1]);
-    cairo_stroke_preserve(cr);
 
-    if((gui->group_selected == index)
-       && (gui->form_selected || gui->form_dragging))
-      cairo_set_line_width(cr, 1.0 / zoom_scale);
-    else
-      cairo_set_line_width(cr, 0.5 / zoom_scale);
-    dt_draw_set_color_overlay(cr, TRUE, 0.8);
-    cairo_stroke(cr);
+    dt_masks_line_stroke
+      (cr, FALSE, TRUE,
+       (gui->group_selected == index) && (gui->form_selected || gui->form_dragging),
+       zoom_scale);
   }
 }
 

--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2022 darktable developers.
+    Copyright (C) 2009-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -48,25 +48,34 @@ typedef struct dt_draw_curve_t
 } dt_draw_curve_t;
 
 /** set color based on gui overlay preference */
-static inline void dt_draw_set_color_overlay(cairo_t *cr, gboolean bright, double alpha)
+static inline void dt_draw_set_color_overlay(cairo_t *cr,
+                                             const gboolean bright,
+                                             const double alpha)
 {
-  double amt;
+  const double amt =
+    bright
+    ? 0.5 + darktable.gui->overlay_contrast * 0.5
+    : (1.0 - darktable.gui->overlay_contrast) * 0.5;
 
-  if(bright)
-    amt = 0.5 + darktable.gui->overlay_contrast * 0.5;
-  else
-    amt = (1.0 - darktable.gui->overlay_contrast) * 0.5;
-
-  cairo_set_source_rgba(cr, darktable.gui->overlay_red * amt, darktable.gui->overlay_green * amt, darktable.gui->overlay_blue * amt, alpha);
+  cairo_set_source_rgba(cr,
+                        darktable.gui->overlay_red * amt,
+                        darktable.gui->overlay_green * amt,
+                        darktable.gui->overlay_blue * amt, alpha);
 }
 
 /** draws a rating star
  */
-static inline void dt_draw_star(cairo_t *cr, float x, float y, float r1, float r2)
+static inline void dt_draw_star(cairo_t *cr,
+                                const float x,
+                                const float y,
+                                const float r1,
+                                const float r2)
 {
   const float d = 2.0 * M_PI * 0.1f;
+
   const float dx[10] = { sinf(0.0),   sinf(d),     sinf(2 * d), sinf(3 * d), sinf(4 * d),
                          sinf(5 * d), sinf(6 * d), sinf(7 * d), sinf(8 * d), sinf(9 * d) };
+
   const float dy[10] = { cosf(0.0),   cosf(d),     cosf(2 * d), cosf(3 * d), cosf(4 * d),
                          cosf(5 * d), cosf(6 * d), cosf(7 * d), cosf(8 * d), cosf(9 * d) };
 
@@ -79,13 +88,21 @@ static inline void dt_draw_star(cairo_t *cr, float x, float y, float r1, float r
   cairo_close_path(cr);
 }
 
-static inline void dt_draw_line(cairo_t *cr, float left, float top, float right, float bottom)
+static inline void dt_draw_line(cairo_t *cr,
+                                const float left,
+                                const float top,
+                                const float right,
+                                const float bottom)
 {
   cairo_move_to(cr, left, top);
   cairo_line_to(cr, right, bottom);
 }
 
-static inline void dt_draw_grid(cairo_t *cr, const int num, const int left, const int top, const int right,
+static inline void dt_draw_grid(cairo_t *cr,
+                                const int num,
+                                const int left,
+                                const int top,
+                                const int right,
                                 const int bottom)
 {
   float width = right - left;
@@ -93,36 +110,57 @@ static inline void dt_draw_grid(cairo_t *cr, const int num, const int left, cons
 
   for(int k = 1; k < num; k++)
   {
-    dt_draw_line(cr, left + k / (float)num * width, top, left + k / (float)num * width, bottom);
+    dt_draw_line(cr,
+                 left + k / (float)num * width,
+                 top,
+                 left + k / (float)num * width,
+                 bottom);
     cairo_stroke(cr);
-    dt_draw_line(cr, left, top + k / (float)num * height, right, top + k / (float)num * height);
+    dt_draw_line(cr,
+                 left,
+                 top + k / (float)num * height,
+                 right,
+                 top + k / (float)num * height);
     cairo_stroke(cr);
   }
 }
 
-static inline float dt_curve_to_mouse(const float x, const float zoom_factor, const float offset)
+static inline float dt_curve_to_mouse(const float x,
+                                      const float zoom_factor,
+                                      const float offset)
 {
   return (x - offset) * zoom_factor;
 }
 
 /* left, right, top, bottom are in curve coordinates [0..1] */
-static inline void dt_draw_grid_zoomed(cairo_t *cr, const int num, const float left, const float top,
-                                       const float right, const float bottom, const float width,
-                                       const float height, const float zoom_factor, const float zoom_offset_x,
+static inline void dt_draw_grid_zoomed(cairo_t *cr,
+                                       const int num,
+                                       const float left,
+                                       const float top,
+                                       const float right,
+                                       const float bottom,
+                                       const float width,
+                                       const float height,
+                                       const float zoom_factor,
+                                       const float zoom_offset_x,
                                        const float zoom_offset_y)
 {
   for(int k = 1; k < num; k++)
   {
-    dt_draw_line(cr, dt_curve_to_mouse(left + k / (float)num, zoom_factor, zoom_offset_x) * width,
-                 dt_curve_to_mouse(top, zoom_factor, zoom_offset_y) * -height,
-                 dt_curve_to_mouse(left + k / (float)num, zoom_factor, zoom_offset_x) * width,
-                 dt_curve_to_mouse(bottom, zoom_factor, zoom_offset_y) * -height);
+    dt_draw_line
+      (cr,
+       dt_curve_to_mouse(left + k / (float)num, zoom_factor, zoom_offset_x) * width,
+       dt_curve_to_mouse(top, zoom_factor, zoom_offset_y) * -height,
+       dt_curve_to_mouse(left + k / (float)num, zoom_factor, zoom_offset_x) * width,
+       dt_curve_to_mouse(bottom, zoom_factor, zoom_offset_y) * -height);
     cairo_stroke(cr);
 
-    dt_draw_line(cr, dt_curve_to_mouse(left, zoom_factor, zoom_offset_x) * width,
-                 dt_curve_to_mouse(top + k / (float)num, zoom_factor, zoom_offset_y) * -height,
-                 dt_curve_to_mouse(right, zoom_factor, zoom_offset_x) * width,
-                 dt_curve_to_mouse(top + k / (float)num, zoom_factor, zoom_offset_y) * -height);
+    dt_draw_line
+      (cr,
+       dt_curve_to_mouse(left, zoom_factor, zoom_offset_x) * width,
+       dt_curve_to_mouse(top + k / (float)num, zoom_factor, zoom_offset_y) * -height,
+       dt_curve_to_mouse(right, zoom_factor, zoom_offset_x) * width,
+       dt_curve_to_mouse(top + k / (float)num, zoom_factor, zoom_offset_y) * -height);
     cairo_stroke(cr);
   }
 }
@@ -130,20 +168,27 @@ static inline void dt_draw_grid_zoomed(cairo_t *cr, const int num, const float l
 #ifdef _OPENMP
 #pragma omp declare simd uniform(base)
 #endif
-static inline float dt_log_scale_axis(const float x, const float base)
+static inline float dt_log_scale_axis(const float x,
+                                      const float base)
 {
   return logf(x * (base - 1.0f) + 1.f) / logf(base);
 }
 
-static inline void dt_draw_loglog_grid(cairo_t *cr, const int num, const int left, const int top, const int right,
-                                       const int bottom, const float base)
+static inline void dt_draw_loglog_grid(cairo_t *cr,
+                                       const int num,
+                                       const int left,
+                                       const int top,
+                                       const int right,
+                                       const int bottom,
+                                       const float base)
 {
-  float width = right - left;
-  float height = bottom - top;
+  const float width = right - left;
+  const float height = bottom - top;
 
   for(int k = 1; k < num; k++)
   {
     const float x = dt_log_scale_axis(k / (float)num, base);
+
     dt_draw_line(cr, left + x * width, top, left + x * width, bottom);
     cairo_stroke(cr);
     dt_draw_line(cr, left, top + x * height, right, top + x * height);
@@ -151,32 +196,50 @@ static inline void dt_draw_loglog_grid(cairo_t *cr, const int num, const int lef
   }
 }
 
-static inline void dt_draw_semilog_x_grid(cairo_t *cr, const int num, const int left, const int top,
-                                          const int right, const int bottom, const float base)
+static inline void dt_draw_semilog_x_grid(cairo_t *cr,
+                                          const int num,
+                                          const int left,
+                                          const int top,
+                                          const int right,
+                                          const int bottom,
+                                          const float base)
 {
-  float width = right - left;
-  float height = bottom - top;
+  const float width = right - left;
+  const float height = bottom - top;
 
   for(int k = 1; k < num; k++)
   {
     const float x = dt_log_scale_axis(k / (float)num, base);
     dt_draw_line(cr, left + x * width, top, left + x * width, bottom);
     cairo_stroke(cr);
-    dt_draw_line(cr, left, top + k / (float)num * height, right, top + k / (float)num * height);
+    dt_draw_line(cr,
+                 left,
+                 top + k / (float)num * height,
+                 right,
+                 top + k / (float)num * height);
     cairo_stroke(cr);
   }
 }
 
-static inline void dt_draw_semilog_y_grid(cairo_t *cr, const int num, const int left, const int top,
-                                          const int right, const int bottom, const float base)
+static inline void dt_draw_semilog_y_grid(cairo_t *cr,
+                                          const int num,
+                                          const int left,
+                                          const int top,
+                                          const int right,
+                                          const int bottom,
+                                          const float base)
 {
-  float width = right - left;
-  float height = bottom - top;
+  const float width = right - left;
+  const float height = bottom - top;
 
   for(int k = 1; k < num; k++)
   {
     const float x = dt_log_scale_axis(k / (float)num, base);
-    dt_draw_line(cr, left + k / (float)num * width, top, left + k / (float)num * width, bottom);
+    dt_draw_line(cr,
+                 left + k / (float)num * width,
+                 top,
+                 left + k / (float)num * width,
+                 bottom);
     cairo_stroke(cr);
     dt_draw_line(cr, left, top + x * height, right, top + x * height);
     cairo_stroke(cr);
@@ -184,10 +247,14 @@ static inline void dt_draw_semilog_y_grid(cairo_t *cr, const int num, const int 
 }
 
 
-static inline void dt_draw_waveform_lines(cairo_t *cr, const int left, const int top, const int right,
-                                          const int bottom, const gboolean horizontal)
+static inline void dt_draw_waveform_lines(cairo_t *cr,
+                                          const int left,
+                                          const int top,
+                                          const int right,
+                                          const int bottom,
+                                          const gboolean horizontal)
 {
-  float width = right - left;
+  const float width = right - left;
   const float height = bottom - top;
   const int num = 9, middle = 5, white = 1;
   // FIXME: should this vary with ppd?
@@ -197,24 +264,37 @@ static inline void dt_draw_waveform_lines(cairo_t *cr, const int left, const int
 
   // FIXME: should be using DT_PIXEL_APPLY_DPI()?
   const double wd = cairo_get_line_width(cr);
+
   for(int k = 1; k < num; k++)
   {
     cairo_set_dash(cr, &dashes, k == white || k == middle, 0);
     cairo_set_line_width(cr, k == white ? wd * 3 : k == middle ? wd * 2 : wd);
     if(horizontal)
-      dt_draw_line(cr, left, top + k / (float)num * height, right, top + k / (float)num * height);
+      dt_draw_line(cr,
+                   left,
+                   top + k / (float)num * height,
+                   right,
+                   top + k / (float)num * height);
     else
-      dt_draw_line(cr, right - k / (float)num * width, top, right - k / (float)num * width, bottom);
+      dt_draw_line(cr,
+                   right - k / (float)num * width,
+                   top,
+                   right - k / (float)num * width,
+                   bottom);
     cairo_stroke(cr);
   }
 
   cairo_restore(cr);
 }
 
-static inline void dt_draw_vertical_lines(cairo_t *cr, const int num, const int left, const int top,
-                                          const int right, const int bottom)
+static inline void dt_draw_vertical_lines(cairo_t *cr,
+                                          const int num,
+                                          const int left,
+                                          const int top,
+                                          const int right,
+                                          const int bottom)
 {
-  float width = right - left;
+  const float width = right - left;
 
   for(int k = 1; k < num; k++)
   {
@@ -224,10 +304,14 @@ static inline void dt_draw_vertical_lines(cairo_t *cr, const int num, const int 
   }
 }
 
-static inline void dt_draw_horizontal_lines(cairo_t *cr, const int num, const int left, const int top,
-                                            const int right, const int bottom)
+static inline void dt_draw_horizontal_lines(cairo_t *cr,
+                                            const int num,
+                                            const int left,
+                                            const int top,
+                                            const int right,
+                                            const int bottom)
 {
-  float height = bottom - top;
+  const float height = bottom - top;
 
   for(int k = 1; k < num; k++)
   {
@@ -237,29 +321,46 @@ static inline void dt_draw_horizontal_lines(cairo_t *cr, const int num, const in
   }
 }
 
-static inline void dt_draw_endmarker(cairo_t *cr, const int width, const int height, const int left)
+static inline void dt_draw_endmarker(cairo_t *cr,
+                                     const int width,
+                                     const int height,
+                                     const int left)
 {
   // fibonacci spiral:
   float v[14] = { -8., 3., -8., 0., -13., 0., -13, 3., -13., 8., -8., 8., 0., 0. };
-  for(int k = 0; k < 14; k += 2) v[k] = v[k] * 0.01 + 0.5;
-  for(int k = 1; k < 14; k += 2) v[k] = v[k] * 0.03 + 0.5;
-  for(int k = 0; k < 14; k += 2) v[k] *= width;
-  for(int k = 1; k < 14; k += 2) v[k] *= height;
+
+  for(int k = 0; k < 14; k += 2)
+    v[k] = v[k] * 0.01 + 0.5;
+  for(int k = 1; k < 14; k += 2)
+    v[k] = v[k] * 0.03 + 0.5;
+  for(int k = 0; k < 14; k += 2)
+    v[k] *= width;
+  for(int k = 1; k < 14; k += 2)
+    v[k] *= height;
+
   if(left)
-    for(int k = 0; k < 14; k += 2) v[k] = width - v[k];
+    for(int k = 0; k < 14; k += 2)
+      v[k] = width - v[k];
+
   cairo_set_line_width(cr, 2.);
   cairo_set_source_rgb(cr, 0.3, 0.3, 0.3);
   cairo_move_to(cr, v[0], v[1]);
   cairo_curve_to(cr, v[2], v[3], v[4], v[5], v[6], v[7]);
   cairo_curve_to(cr, v[8], v[9], v[10], v[11], v[12], v[13]);
-  for(int k = 0; k < 14; k += 2) v[k] = width - v[k];
-  for(int k = 1; k < 14; k += 2) v[k] = height - v[k];
+
+  for(int k = 0; k < 14; k += 2)
+    v[k] = width - v[k];
+  for(int k = 1; k < 14; k += 2)
+    v[k] = height - v[k];
+
   cairo_curve_to(cr, v[10], v[11], v[8], v[9], v[6], v[7]);
   cairo_curve_to(cr, v[4], v[5], v[2], v[3], v[0], v[1]);
   cairo_stroke(cr);
 }
 
-static inline dt_draw_curve_t *dt_draw_curve_new(const float min, const float max, unsigned int type)
+static inline dt_draw_curve_t *dt_draw_curve_new(const float min,
+                                                 const float max,
+                                                 const unsigned int type)
 {
   dt_draw_curve_t *c = (dt_draw_curve_t *)malloc(sizeof(dt_draw_curve_t));
   c->csample.m_samplingRes = 0x10000;
@@ -281,33 +382,48 @@ static inline void dt_draw_curve_destroy(dt_draw_curve_t *c)
   free(c);
 }
 
-static inline void dt_draw_curve_set_point(dt_draw_curve_t *c, const int num, const float x, const float y)
+static inline void dt_draw_curve_set_point(dt_draw_curve_t *c,
+                                           const int num,
+                                           const float x,
+                                           const float y)
 {
   c->c.m_anchors[num].x = x;
   c->c.m_anchors[num].y = y;
 }
 
-static inline void dt_draw_curve_smaple_values(dt_draw_curve_t *c, const float min, const float max, const int res,
-                                               float *x, float *y)
+static inline void dt_draw_curve_smaple_values(dt_draw_curve_t *c,
+                                               const float min,
+                                               const float max,
+                                               const int res,
+                                               float *x,
+                                               float *y)
 {
   if(x)
   {
 #ifdef _OPENMP
-#pragma omp parallel for SIMD() default(none) dt_omp_firstprivate(res) shared(x) schedule(static)
+#pragma omp parallel for SIMD() default(none) \
+  dt_omp_firstprivate(res) shared(x) schedule(static)
 #endif
-    for(int k = 0; k < res; k++) x[k] = k * (1.0f / res);
+    for(int k = 0; k < res; k++)
+      x[k] = k * (1.0f / res);
   }
   if(y)
   {
 #ifdef _OPENMP
-#pragma omp parallel for SIMD() default(none) dt_omp_firstprivate(min, max, res) shared(y, c) schedule(static)
+#pragma omp parallel for SIMD() default(none) \
+  dt_omp_firstprivate(min, max, res) shared(y, c) schedule(static)
 #endif
-    for(int k = 0; k < res; k++) y[k] = min + (max - min) * c->csample.m_Samples[k] * (1.0f / 0x10000);
+    for(int k = 0; k < res; k++)
+      y[k] = min + (max - min) * c->csample.m_Samples[k] * (1.0f / 0x10000);
   }
 }
 
-static inline void dt_draw_curve_calc_values(dt_draw_curve_t *c, const float min, const float max, const int res,
-                                             float *x, float *y)
+static inline void dt_draw_curve_calc_values(dt_draw_curve_t *c,
+                                             const float min,
+                                             const float max,
+                                             const int res,
+                                             float *x,
+                                             float *y)
 {
   c->csample.m_samplingRes = res;
   c->csample.m_outputRes = 0x10000;
@@ -315,8 +431,12 @@ static inline void dt_draw_curve_calc_values(dt_draw_curve_t *c, const float min
   dt_draw_curve_smaple_values(c, min, max, res, x, y);
 }
 
-static inline void dt_draw_curve_calc_values_V2_nonperiodic(dt_draw_curve_t *c, const float min, const float max,
-                                                            const int res, float *x, float *y)
+static inline void dt_draw_curve_calc_values_V2_nonperiodic(dt_draw_curve_t *c,
+                                                            const float min,
+                                                            const float max,
+                                                            const int res,
+                                                            float *x,
+                                                            float *y)
 {
   c->csample.m_samplingRes = res;
   c->csample.m_outputRes = 0x10000;
@@ -324,8 +444,12 @@ static inline void dt_draw_curve_calc_values_V2_nonperiodic(dt_draw_curve_t *c, 
   dt_draw_curve_smaple_values(c, min, max, res, x, y);
 }
 
-static inline void dt_draw_curve_calc_values_V2_periodic(dt_draw_curve_t *c, const float min, const float max,
-                                                         const int res, float *x, float *y)
+static inline void dt_draw_curve_calc_values_V2_periodic(dt_draw_curve_t *c,
+                                                         const float min,
+                                                         const float max,
+                                                         const int res,
+                                                         float *x,
+                                                         float *y)
 {
   c->csample.m_samplingRes = res;
   c->csample.m_outputRes = 0x10000;
@@ -333,8 +457,13 @@ static inline void dt_draw_curve_calc_values_V2_periodic(dt_draw_curve_t *c, con
   dt_draw_curve_smaple_values(c, min, max, res, x, y);
 }
 
-static inline void dt_draw_curve_calc_values_V2(dt_draw_curve_t *c, const float min, const float max,
-                                                const int res, float *x, float *y, const gboolean periodic)
+static inline void dt_draw_curve_calc_values_V2(dt_draw_curve_t *c,
+                                                const float min,
+                                                const float max,
+                                                const int res,
+                                                float *x,
+                                                float *y,
+                                                const gboolean periodic)
 {
   if(periodic)
     dt_draw_curve_calc_values_V2_periodic(c, min, max, res, x, y);
@@ -347,6 +476,7 @@ static inline float dt_draw_curve_calc_value(dt_draw_curve_t *c, const float x)
   float xa[20], ya[20];
   float val = 0.f;
   float *ypp = NULL;
+
   for(int i = 0; i < c->c.m_numAnchors; i++)
   {
     xa[i] = c->c.m_anchors[i].x;
@@ -361,7 +491,9 @@ static inline float dt_draw_curve_calc_value(dt_draw_curve_t *c, const float x)
   return MIN(MAX(val, c->c.m_min_y), c->c.m_max_y);
 }
 
-static inline int dt_draw_curve_add_point(dt_draw_curve_t *c, const float x, const float y)
+static inline int dt_draw_curve_add_point(dt_draw_curve_t *c,
+                                          const float x,
+                                          const float y)
 {
   c->c.m_anchors[c->c.m_numAnchors].x = x;
   c->c.m_anchors[c->c.m_numAnchors].y = y;
@@ -370,26 +502,41 @@ static inline int dt_draw_curve_add_point(dt_draw_curve_t *c, const float x, con
 }
 
 // linear x linear y
-static inline void dt_draw_histogram_8_linxliny(cairo_t *cr, const uint32_t *hist, int32_t channels,
-                                                int32_t channel)
+static inline void dt_draw_histogram_8_linxliny(cairo_t *cr,
+                                                const uint32_t *hist,
+                                                const int32_t channels,
+                                                const int32_t channel)
 {
   cairo_move_to(cr, 0, 0);
-  for(int k = 0; k < 256; k++) cairo_line_to(cr, k, hist[channels * k + channel]);
+
+  for(int k = 0; k < 256; k++)
+    cairo_line_to(cr, k, hist[channels * k + channel]);
+
   cairo_line_to(cr, 255, 0);
   cairo_close_path(cr);
   cairo_fill(cr);
 }
 
-static inline void dt_draw_histogram_8_zoomed(cairo_t *cr, const uint32_t *hist, int32_t channels, int32_t channel,
-                                              const float zoom_factor, const float zoom_offset_x,
-                                              const float zoom_offset_y, gboolean linear)
+static inline void dt_draw_histogram_8_zoomed(cairo_t *cr,
+                                              const uint32_t *hist,
+                                              const int32_t channels,
+                                              const int32_t channel,
+                                              const float zoom_factor,
+                                              const float zoom_offset_x,
+                                              const float zoom_offset_y,
+                                              const gboolean linear)
 {
   cairo_move_to(cr, -zoom_offset_x, -zoom_offset_y);
+
   for(int k = 0; k < 256; k++)
   {
-    const float value = ((float)hist[channels * k + channel] - zoom_offset_y) * zoom_factor;
+    const float value =
+      ((float)hist[channels * k + channel] - zoom_offset_y) * zoom_factor;
     const float hist_value = value < 0 ? 0.f : value;
-    cairo_line_to(cr, ((float)k - zoom_offset_x) * zoom_factor, linear ? hist_value : logf(1.0f + hist_value));
+
+    cairo_line_to(cr,
+                  ((float)k - zoom_offset_x) * zoom_factor,
+                  linear ? hist_value : logf(1.0f + hist_value));
   }
   cairo_line_to(cr, (255.f - zoom_offset_x), -zoom_offset_y * zoom_factor);
   cairo_close_path(cr);
@@ -397,13 +544,18 @@ static inline void dt_draw_histogram_8_zoomed(cairo_t *cr, const uint32_t *hist,
 }
 
 // log x (scalable) & linear y
-static inline void dt_draw_histogram_8_logxliny(cairo_t *cr, const uint32_t *hist, int32_t channels,
-                                                int32_t channel, float base_log)
+static inline void dt_draw_histogram_8_logxliny(cairo_t *cr,
+                                                const uint32_t *hist,
+                                                const int32_t channels,
+                                                const int32_t channel,
+                                                const float base_log)
 {
   cairo_move_to(cr, 0, 0);
+
   for(int k = 0; k < 256; k++)
   {
-    const float x = logf((float)k / 255.0f * (base_log - 1.0f) + 1.0f) / logf(base_log) * 255.0f;
+    const float x =
+      logf((float)k / 255.0f * (base_log - 1.0f) + 1.0f) / logf(base_log) * 255.0f;
     const float y = hist[channels * k + channel];
     cairo_line_to(cr, x, y);
   }
@@ -413,13 +565,17 @@ static inline void dt_draw_histogram_8_logxliny(cairo_t *cr, const uint32_t *his
 }
 
 // log x (scalable) & log y
-static inline void dt_draw_histogram_8_logxlogy(cairo_t *cr, const uint32_t *hist, int32_t channels,
-                                                int32_t channel, float base_log)
+static inline void dt_draw_histogram_8_logxlogy(cairo_t *cr,
+                                                const uint32_t *hist,
+                                                const int32_t channels,
+                                                const int32_t channel,
+                                                const float base_log)
 {
   cairo_move_to(cr, 0, 0);
   for(int k = 0; k < 256; k++)
   {
-    const float x = logf((float)k / 255.0f * (base_log - 1.0f) + 1.0f) / logf(base_log) * 255.0f;
+    const float x =
+      logf((float)k / 255.0f * (base_log - 1.0f) + 1.0f) / logf(base_log) * 255.0f;
     const float y = logf(1.0 + hist[channels * k + channel]);
     cairo_line_to(cr, x, y);
   }
@@ -429,19 +585,26 @@ static inline void dt_draw_histogram_8_logxlogy(cairo_t *cr, const uint32_t *his
 }
 
 // linear x log y
-static inline void dt_draw_histogram_8_linxlogy(cairo_t *cr, const uint32_t *hist, int32_t channels,
-                                                int32_t channel)
+static inline void dt_draw_histogram_8_linxlogy(cairo_t *cr,
+                                                const uint32_t *hist,
+                                                const int32_t channels,
+                                                const int32_t channel)
 {
   cairo_move_to(cr, 0, 0);
-  for(int k = 0; k < 256; k++) cairo_line_to(cr, k, logf(1.0 + hist[channels * k + channel]));
+  for(int k = 0; k < 256; k++)
+    cairo_line_to(cr, k, logf(1.0 + hist[channels * k + channel]));
   cairo_line_to(cr, 255, 0);
   cairo_close_path(cr);
   cairo_fill(cr);
 }
 
 // log x (scalable)
-static inline void dt_draw_histogram_8_log_base(cairo_t *cr, const uint32_t *hist, int32_t channels,
-                                                int32_t channel, const gboolean linear, float base_log)
+static inline void dt_draw_histogram_8_log_base(cairo_t *cr,
+                                                const uint32_t *hist,
+                                                const int32_t channels,
+                                                const int32_t channel,
+                                                const gboolean linear,
+                                                const float base_log)
 {
 
   if(linear) // linear y
@@ -451,7 +614,10 @@ static inline void dt_draw_histogram_8_log_base(cairo_t *cr, const uint32_t *his
 }
 
 // linear x
-static inline void dt_draw_histogram_8(cairo_t *cr, const uint32_t *hist, int32_t channels, int32_t channel,
+static inline void dt_draw_histogram_8(cairo_t *cr,
+                                       const uint32_t *hist,
+                                       const int32_t channels,
+                                       const int32_t channel,
                                        const gboolean linear)
 {
   if(linear) // linear y
@@ -460,8 +626,11 @@ static inline void dt_draw_histogram_8(cairo_t *cr, const uint32_t *hist, int32_
     dt_draw_histogram_8_linxlogy(cr, hist, channels, channel);
 }
 
-/** transform a data blob from cairo's premultiplied rgba/bgra to GdkPixbuf's un-premultiplied bgra/rgba */
-static inline void dt_draw_cairo_to_gdk_pixbuf(uint8_t *data, unsigned int width, unsigned int height)
+/** transform a data blob from cairo's premultiplied rgba/bgra to
+ * GdkPixbuf's un-premultiplied bgra/rgba */
+static inline void dt_draw_cairo_to_gdk_pixbuf(uint8_t *data,
+                                               const unsigned int width,
+                                               const unsigned int height)
 {
   for(uint32_t y = 0; y < height; y++)
     for(uint32_t x = 0; x < width; x++)
@@ -480,7 +649,7 @@ static inline void dt_draw_cairo_to_gdk_pixbuf(uint8_t *data, unsigned int width
       // cairo uses premultiplied alpha, reverse that
       if(*a != 0)
       {
-        float inv_a = 255.0 / *a;
+        const float inv_a = 255.0 / *a;
         *r *= inv_a;
         *g *= inv_a;
         *b *= inv_a;
@@ -488,7 +657,8 @@ static inline void dt_draw_cairo_to_gdk_pixbuf(uint8_t *data, unsigned int width
     }
 }
 
-static inline void dt_cairo_perceptual_gradient(cairo_pattern_t *grad, double alpha)
+static inline void dt_cairo_perceptual_gradient(cairo_pattern_t *grad,
+                                                const double alpha)
 {
   // Create a linear gradient from black to white
   cairo_pattern_add_color_stop_rgba(grad, 0.0, 0.0, 0.0, 0.0, alpha);
@@ -496,8 +666,16 @@ static inline void dt_cairo_perceptual_gradient(cairo_pattern_t *grad, double al
 }
 
 static inline GdkPixbuf *dt_draw_paint_to_pixbuf
- (GtkWidget *widget, const guint pixbuf_size, const int flags,
-  void (*dtgtk_cairo_paint_fct)(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data))
+  (GtkWidget *widget,
+   const guint pixbuf_size,
+   const int flags,
+   void (*dtgtk_cairo_paint_fct)(cairo_t *cr,
+                                 const gint x,
+                                 const gint y,
+                                 const gint w,
+                                 const gint h,
+                                 const gint flags,
+                                 void *data))
 {
   GdkRGBA fg_color;
   GtkStyleContext *context = gtk_widget_get_style_context(widget);
@@ -510,12 +688,14 @@ static inline GdkPixbuf *dt_draw_paint_to_pixbuf
   gdk_cairo_set_source_rgba(cr, &fg_color);
   (*dtgtk_cairo_paint_fct)(cr, 0, 0, dim, dim, flags, NULL);
   cairo_destroy(cr);
+
   uint8_t *data = cairo_image_surface_get_data(cst);
   dt_draw_cairo_to_gdk_pixbuf(data, dim, dim);
   const size_t size = (size_t)dim * dim * 4;
   uint8_t *buf = (uint8_t *)malloc(size);
   memcpy(buf, data, size);
-  GdkPixbuf *pixbuf = gdk_pixbuf_new_from_data(buf, GDK_COLORSPACE_RGB, TRUE, 8, dim, dim, dim * 4,
+  GdkPixbuf *pixbuf = gdk_pixbuf_new_from_data(buf, GDK_COLORSPACE_RGB,
+                                               TRUE, 8, dim, dim, dim * 4,
                                                (GdkPixbufDestroyNotify)free, NULL);
   cairo_surface_destroy(cst);
   return pixbuf;
@@ -526,4 +706,3 @@ static inline GdkPixbuf *dt_draw_paint_to_pixbuf
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-


### PR DESCRIPTION
Mask drawing code refactoring.
    
The code to actually stroke the lines of a masks (masks, border, source)
is put into a single routine and shared for all masks. This ensure a
consistent drawing of the masks (line width, border, source). Also it
is now possible to change the rendering of all masks by changing a
single routine.

masks: Clean-up distance computation by using gboolean where possible.