### PR TITLE
fix wide panels jumping due to varying metadata

### DIFF
--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -806,7 +806,7 @@ void gui_init(dt_lib_module_t *self)
     //reported upstream to https://gitlab.gnome.org/GNOME/gtk/-/issues/4042
     //see also discussions on https://github.com/darktable-org/darktable/pull/10584
     gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(gtk_bin_get_child(GTK_BIN(swindow))),
-                                   GTK_POLICY_NEVER, GTK_POLICY_ALWAYS);
+                                   GTK_POLICY_EXTERNAL, GTK_POLICY_AUTOMATIC);
 
     gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(textview), GTK_WRAP_WORD_CHAR);
     gtk_text_view_set_accepts_tab(GTK_TEXT_VIEW(textview), FALSE);


### PR DESCRIPTION
fixes #14134

And also does away with the need to always show vertical scrollbars in metadata fields.

@elstoc would you be willing to test if this brings back the issue you previously had with the texview changing width (and causing ellipsizing of its label) while typing?

If it does not; I need advice on how to expand the commentary to keep it clear and useful (or to just remove it in the hope this thing never raises its ugly head again).