### PR TITLE
maintenance: remove INFINITY or replace by FLT_MAX

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -1382,8 +1382,8 @@ finally:
 
       // get minima and maxima of performance data of all active devices
       const float tcpu = cl->cpubenchmark;
-      float tgpumin = INFINITY;
-      float tgpumax = -INFINITY;
+      float tgpumin = FLT_MAX;
+      float tgpumax = -FLT_MAX;
       for(int n = 0; n < cl->num_devs; n++)
       {
         if((cl->dev[n].benchmark > 0.0f) && (cl->dev[n].disabled == FALSE))
@@ -1617,8 +1617,8 @@ static float _opencl_benchmark_gpu(const int devid,
   float *buf = NULL;
   dt_gaussian_cl_t *g = NULL;
 
-  const float Labmax[] = { INFINITY, INFINITY, INFINITY, INFINITY };
-  const float Labmin[] = { -INFINITY, -INFINITY, -INFINITY, -INFINITY };
+  const float Labmax[] = { FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX };
+  const float Labmin[] = { -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX };
 
   unsigned int *const tea_states = alloc_tea_states(dt_get_num_threads());
 
@@ -1684,7 +1684,7 @@ error:
   dt_free_align(buf);
   free_tea_states(tea_states);
   dt_opencl_release_mem_object(dev_mem);
-  return INFINITY;
+  return FLT_MAX;
 }
 
 static float _opencl_benchmark_cpu(
@@ -1697,8 +1697,8 @@ static float _opencl_benchmark_cpu(
   float *buf = NULL;
   dt_gaussian_t *g = NULL;
 
-  const float Labmax[] = { INFINITY, INFINITY, INFINITY, INFINITY };
-  const float Labmin[] = { -INFINITY, -INFINITY, -INFINITY, -INFINITY };
+  const float Labmax[] = { FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX };
+  const float Labmin[] = { -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX };
 
   const size_t nthreads = dt_get_num_threads();
   unsigned int *const tea_states = alloc_tea_states(nthreads);
@@ -1752,7 +1752,7 @@ error:
   dt_gaussian_free(g);
   dt_free_align(buf);
   free_tea_states(tea_states);
-  return INFINITY;
+  return FLT_MAX;
 }
 
 gboolean dt_opencl_finish(const int devid)

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -178,21 +178,21 @@ void dt_develop_blendif_process_parameters(float *const restrict parameters,
       // handle the case when one end is open to avoid clipping input/output values
       if(blendif_parameters[i * 4 + 0] <= 0.0f && blendif_parameters[i * 4 + 1] <= 0.0f)
       {
-        parameters[j + 0] = -INFINITY;
-        parameters[j + 1] = -INFINITY;
+        parameters[j + 0] = -FLT_MAX;
+        parameters[j + 1] = -FLT_MAX;
       }
       if(blendif_parameters[i * 4 + 2] >= 1.0f && blendif_parameters[i * 4 + 3] >= 1.0f)
       {
-        parameters[j + 2] = INFINITY;
-        parameters[j + 3] = INFINITY;
+        parameters[j + 2] = FLT_MAX;
+        parameters[j + 3] = FLT_MAX;
       }
     }
     else
     {
-      parameters[j + 0] = -INFINITY;
-      parameters[j + 1] = -INFINITY;
-      parameters[j + 2] = INFINITY;
-      parameters[j + 3] = INFINITY;
+      parameters[j + 0] = -FLT_MAX;
+      parameters[j + 1] = -FLT_MAX;
+      parameters[j + 2] = FLT_MAX;
+      parameters[j + 3] = FLT_MAX;
       parameters[j + 4] = 0.0f;
       parameters[j + 5] = 0.0f;
     }

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1093,7 +1093,7 @@ static void _update_gradient_slider_pickers(GtkWidget *callback_dummy,
 
     if((gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(data->colorpicker))
         || gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(data->colorpicker_set_values)))
-       && (raw_min[0] != INFINITY))
+       && (raw_min[0] != FLT_MAX))
     {
       float picker_mean[8], picker_min[8], picker_max[8];
       float cooked[8];

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -884,8 +884,8 @@ static void _pixelpipe_picker(dt_iop_module_t *module,
   // FIXME: don't need to initialize this if dt_color_picker_helper() does
   lib_colorpicker_stats pick =
     { { 0.0f, 0.0f, 0.0f, 0.0f },
-      { INFINITY, INFINITY, INFINITY, INFINITY },
-      { -INFINITY, -INFINITY, -INFINITY, -INFINITY } };
+      { FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX },
+      { -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX } };
 
   if(!_pixelpipe_picker_box(module, roi,
                             darktable.lib->proxy.colorpicker.primary_sample,
@@ -939,8 +939,8 @@ static void _pixelpipe_picker_cl(const int devid,
   {
     for_four_channels(k)
     {
-      picked_color_min[k] = INFINITY;
-      picked_color_max[k] = -INFINITY;
+      picked_color_min[k] = FLT_MAX;
+      picked_color_max[k] = -FLT_MAX;
       picked_color[k] = 0.0f;
     }
 
@@ -986,8 +986,8 @@ static void _pixelpipe_picker_cl(const int devid,
   // FIXME: don't need to initialize this if dt_color_picker_helper() does
   lib_colorpicker_stats pick =
     { { 0.0f, 0.0f, 0.0f, 0.0f },
-      { INFINITY, INFINITY, INFINITY, INFINITY },
-      { -INFINITY, -INFINITY, -INFINITY, -INFINITY } };
+      { FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX },
+      { -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX } };
 
   const dt_iop_order_iccprofile_info_t *const profile =
     dt_ioppr_get_pipe_current_profile_info(module, piece->pipe);

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5822,12 +5822,11 @@ void reload_defaults(dt_iop_module_t *module)
 
     // focal length should be available in exif data if lens is
     // electronically coupled to the camera
-    f_length = isfinite(img->exif_focal_length)
-      && img->exif_focal_length > 0.0f ? img->exif_focal_length : f_length;
+    f_length = (img->exif_focal_length > 0.0f && img->exif_focal_length <= 1000000.0f)
+      ? img->exif_focal_length : f_length;
     // crop factor of the camera is often not available and user will
     // need to set it manually in the gui
-    crop_factor = isfinite(img->exif_crop)
-      && img->exif_crop > 0.0f ? img->exif_crop : crop_factor;
+    crop_factor = (img->exif_crop > 0.0f && img->exif_crop <= 1000.0f) ? img->exif_crop : crop_factor;
   }
 
   // init defaults:

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -709,6 +709,10 @@ static inline double ldexpk(double x, int32_t q)
 
 static inline double xlog(double d)
 {
+  // since this is a local function and we know that xlog will only be
+  // called with values 1 <= d <= 65537, there is no need to check for
+  // d == INFINITY or d <= 0 and return +/-INFINITY or NAN.
+
   const int e = ilogbp1(d * 0.7071);
   const double m = ldexpk(d, -e);
 
@@ -725,12 +729,6 @@ static inline double xlog(double d)
   t = fma(t, x2, 2);
 
   x = x * t + 0.693147180559945286226764 * e;
-
-#if 0  // we know that xlog will only be called with values 1 <= d <= 65537
-  if(isinf(d)) x = INFINITY;
-  if(d < 0)    x = NAN;
-  if(d == 0)   x = -INFINITY;
-#endif
   return x;
 }
 

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -726,10 +726,11 @@ static inline double xlog(double d)
 
   x = x * t + 0.693147180559945286226764 * e;
 
+#if 0  // we know that xlog will only be called with values 1 <= d <= 65537
   if(isinf(d)) x = INFINITY;
   if(d < 0)    x = NAN;
   if(d == 0)   x = -INFINITY;
-
+#endif
   return x;
 }
 

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2021 darktable developers.
+    Copyright (C) 2021-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -260,8 +260,8 @@ static void get_manifolds(const float* const restrict in, const size_t width, co
   float *const restrict blurred_manifold_higher = dt_alloc_align_float(width * height * 4);
   float *const restrict blurred_manifold_lower = dt_alloc_align_float(width * height * 4);
 
-  dt_aligned_pixel_t max = {INFINITY, INFINITY, INFINITY, INFINITY};
-  dt_aligned_pixel_t min = {-INFINITY, -INFINITY, -INFINITY, 0.0f};
+  dt_aligned_pixel_t max = {FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX};
+  dt_aligned_pixel_t min = {-FLT_MAX, -FLT_MAX, -FLT_MAX, 0.0f};
   // start with a larger blur to estimate the manifolds if we refine them
   // later on
   const float blur_size = refine_manifolds ? sigma2 : sigma;
@@ -606,8 +606,8 @@ static void reduce_artifacts(const float* const restrict in,
   }
 
   float *const restrict blurred_in_out = dt_alloc_align_float(width * height * 4);
-  dt_aligned_pixel_t max = {INFINITY, INFINITY, INFINITY, INFINITY};
-  dt_aligned_pixel_t min = {0.0f, 0.0f, 0.0f, 0.0f};
+  const dt_aligned_pixel_t max = {FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX};
+  const dt_aligned_pixel_t min = {0.0f, 0.0f, 0.0f, 0.0f};
   dt_gaussian_t *g = dt_gaussian_init(width, height, 4, max, min, sigma, 0);
   if(!g) return;
   dt_gaussian_blur_4c(g, in_out, blurred_in_out);

--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -165,7 +165,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   dt_aligned_pixel_t RGBmax, RGBmin;
   for(int k = 0; k < 4; k++)
   {
-    RGBmax[k] = INFINITY;
+    RGBmax[k] = FLT_MAX;
     RGBmin[k] = 0.f;
   }
 
@@ -295,8 +295,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   if(unbound)
   {
-    for(int k = 0; k < 4; k++) RGBmax[k] = INFINITY;
-    for(int k = 0; k < 4; k++) RGBmin[k] = -INFINITY;
+    for(int k = 0; k < 4; k++) RGBmax[k] = FLT_MAX;
+    for(int k = 0; k < 4; k++) RGBmin[k] = -FLT_MAX;
   }
 
   if(d->lowpass_algo == LOWPASS_ALGO_GAUSSIAN)

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -901,7 +901,7 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
   float p[2], o[2];
   dt_boundingbox_t aabb = { roi_out_x + d->cix * so, roi_out_y + d->ciy * so, roi_out_x + d->cix * so + roi_out->width,
                   roi_out_y + d->ciy * so + roi_out->height };
-  dt_boundingbox_t aabb_in = { INFINITY, INFINITY, -INFINITY, -INFINITY };
+  dt_boundingbox_t aabb_in = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
   for(int c = 0; c < 4; c++)
   {
     // get corner points of roi_out

--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -180,8 +180,8 @@ void process(struct dt_iop_module_t *self,
 
   const dt_aligned_pixel_t slope = { 1.0f, d->a_steepness, d->b_steepness, 1.0f };
   const dt_aligned_pixel_t offset = { 0.0f, d->a_offset, d->b_offset, 0.0f };
-  const dt_aligned_pixel_t lowlimit = { -INFINITY, -128.0f, -128.0f, -INFINITY };
-  const dt_aligned_pixel_t highlimit = { INFINITY, 128.0f, 128.0f, INFINITY };
+  const dt_aligned_pixel_t lowlimit = { -FLT_MAX, -128.0f, -128.0f, -FLT_MAX };
+  const dt_aligned_pixel_t highlimit = { FLT_MAX, 128.0f, 128.0f, FLT_MAX };
 
   if(d->unbound)
   {

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -16,6 +16,14 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+// LensFun can return NAN on coordinate transforms, so we need to tell the compiler
+// that non-finite numbers are in use in this source file even if we have globally
+// enabled the finite-math-only optimization.  Otherwise, it may optimize away
+// conditionals based on isnan() or isfinite().
+#ifdef __GNUC__
+#pragma GCC optimize ("no-finite-math-only")
+#endif
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -244,8 +244,8 @@ int process_cl(struct dt_iop_module_t *self,
 
   if(unbound)
   {
-    for(int k = 0; k < 4; k++) Labmax[k] = INFINITY;
-    for(int k = 0; k < 4; k++) Labmin[k] = -INFINITY;
+    for(int k = 0; k < 4; k++) Labmax[k] = FLT_MAX;
+    for(int k = 0; k < 4; k++) Labmin[k] = -FLT_MAX;
   }
 
   if(d->lowpass_algo == LOWPASS_ALGO_GAUSSIAN)
@@ -394,8 +394,8 @@ void process(struct dt_iop_module_t *self,
   {
     for_four_channels(c)
     {
-      Labmax[c] = INFINITY;
-      Labmin[c] = -INFINITY;
+      Labmax[c] = FLT_MAX;
+      Labmin[c] = -FLT_MAX;
     }
   }
 

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2866,8 +2866,8 @@ static void rt_process_stats(struct dt_iop_module_t *self,
                              float levels[3])
 {
   const int size = width * height * ch;
-  float l_max = -INFINITY;
-  float l_min = INFINITY;
+  float l_max = -FLT_MAX;
+  float l_min = FLT_MAX;
   float l_sum = 0.f;
   int count = 0;
   const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
@@ -3260,8 +3260,8 @@ static void _retouch_blur(dt_iop_module_t *self,
 
   if(blur_type == DT_IOP_RETOUCH_BLUR_GAUSSIAN && fabsf(blur_radius) > 0.1f)
   {
-    float Labmax[] = { INFINITY, INFINITY, INFINITY, INFINITY };
-    float Labmin[] = { -INFINITY, -INFINITY, -INFINITY, -INFINITY };
+    static const float Labmax[] = { FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX };
+    static const float Labmin[] = { -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX };
 
     dt_gaussian_t *g = dt_gaussian_init(roi_mask_scaled->width, roi_mask_scaled->height, 4, Labmax, Labmin, sigma,
                                         DT_IOP_GAUSSIAN_ZERO);
@@ -4023,8 +4023,8 @@ static cl_int _retouch_blur_cl(const int devid,
 
   if(blur_type == DT_IOP_RETOUCH_BLUR_GAUSSIAN && fabsf(blur_radius) > 0.1f)
   {
-    float Labmax[] = { INFINITY, INFINITY, INFINITY, INFINITY };
-    float Labmin[] = { -INFINITY, -INFINITY, -INFINITY, -INFINITY };
+    static const float Labmax[] = { FLT_MAX, FLT_MAX, FLT_MAX, FLT_MAX };
+    static const float Labmin[] = { -FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX };
 
     dt_gaussian_cl_t *g = dt_gaussian_init_cl(devid, roi_mask_scaled->width, roi_mask_scaled->height, ch, Labmax,
                                               Labmin, sigma, DT_IOP_GAUSSIAN_ZERO);

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -1158,8 +1158,8 @@ static void _auto_levels(const float *const img, const int width, const int heig
     x_to = width - 1;
   }
 
-  float max = -INFINITY;
-  float min = INFINITY;
+  float max = -FLT_MAX;
+  float min = FLT_MAX;
 
   for(int y = y_from; y <= y_to; y++)
   {

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -242,7 +242,7 @@ void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const d
 
   dt_boundingbox_t aabb = { roi_out->x, roi_out->y, roi_out->x + roi_out->width, roi_out->y + roi_out->height };
 
-  dt_boundingbox_t aabb_in = { INFINITY, INFINITY, -INFINITY, -INFINITY };
+  dt_boundingbox_t aabb_in = { FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX };
 
   for(int c = 0; c < 4; c++)
   {

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -336,8 +336,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
     if(unbound_mask)
     {
-      for(int k = 0; k < 4; k++) Labmax[k] = INFINITY;
-      for(int k = 0; k < 4; k++) Labmin[k] = -INFINITY;
+      for(int k = 0; k < 4; k++) Labmax[k] = FLT_MAX;
+      for(int k = 0; k < 4; k++) Labmin[k] = -FLT_MAX;
     }
 
     dt_gaussian_t *g = dt_gaussian_init(width, height, ch, Labmax, Labmin, sigma, order);
@@ -506,8 +506,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
     if(unbound_mask)
     {
-      for(int k = 0; k < 4; k++) Labmax[k] = INFINITY;
-      for(int k = 0; k < 4; k++) Labmin[k] = -INFINITY;
+      for(int k = 0; k < 4; k++) Labmax[k] = FLT_MAX;
+      for(int k = 0; k < 4; k++) Labmin[k] = -FLT_MAX;
     }
 
     g = dt_gaussian_init_cl(devid, width, height, channels, Labmax, Labmin, sigma, order);

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -2549,10 +2549,10 @@ static void _view_map_center_on_image(dt_view_t *self, const int32_t imgid)
 static gboolean _view_map_center_on_image_list(dt_view_t *self, const char* table)
 {
   const dt_map_t *lib = (dt_map_t *)self->data;
-  double max_longitude = -INFINITY;
-  double max_latitude = -INFINITY;
-  double min_longitude = INFINITY;
-  double min_latitude = INFINITY;
+  double max_longitude = -FLT_MAX;
+  double max_latitude = -FLT_MAX;
+  double min_longitude = FLT_MAX;
+  double min_latitude = FLT_MAX;
   int count = 0;
 
   // clang-format off


### PR DESCRIPTION
Since having infinities in the pixelpipe is an error (there is an option to check and warn), using the range -FLT_MAX to +FLT_MAX instead of -INFINITY to +INFINITY as limits when no clamping is desired will preserve all valid values.

Similarly for finding minima and maxima (pixel values or bounding box corners), if there are any values at all, initializing to FLT_MAX will give the same results as INFINITY.

Eliminating INFINITY will (together with upcoming removal of NAN as marker values) enable use of additional optimizations through global -ffinite-math-only.