### PR TITLE
[maintenance] Further bug report template improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -115,7 +115,7 @@ body:
     id: system
     attributes:
       label: Describe your system?
-      description: Describe your general computer system (Gb of memory, Wayland or X11, GTK+, Intel or M1 or M2) that could be relevant to the issue.
+      description: Include any information about your computer system that you think may be relevant to your report (e.g., RAM size, Wayland or X11, the version of GTK+ with which darktable is linked).
 
   - type: dropdown
     id: GPU

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -76,7 +76,6 @@ body:
         - 'flatpak'
         - 'OSB'
         - 'self compiled'
-        - 'bought it'
         - 'an online forum'
     validations:
      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,15 +14,6 @@ body:
         Before raising a bug/issue please check that it has not already been reported by searching [GitHub Issues](https://github.com/darktable-org/darktable/issues?q=is%3Aissue).
         Some common issues are addressed in the [FAQ](https://www.darktable.org/about/faq/). 
         
-
-  - type: checkboxes
-    id: checklist
-    attributes:
-      label: Checklist
-      options:
-        - label: I have checked [GitHub Issues](https://github.com/darktable-org/darktable/issues?q=is%3Aissue) and my problem is **not** described there.
-          required: true
-
   - type: textarea
     id: bug_description
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -52,11 +52,11 @@ body:
         A log or backtrace will help us investigate your issue. If available please attach below. You can also attach a screenshot or screencast or any other useful information.
       placeholder: |
         Drag and drop logfile or backtrace file here, if available.
-        Copying the contents is okay for short logs (< 20 lines), but please put them in code blocks:
+        Copying the contents is okay for short logs (like < 20 lines or so), but please put them in code blocks:
         ```
         log here
         ```
-        You can also use pastebin.com or similar
+        You can also use pastebin.com or similar service.
   
   - type: input
     id: commit


### PR DESCRIPTION
The most important fix is the removal of the checkbox, by ticking which the user confirms that he did not find a duplicate among the existing issues.

Unfortunately, due to the shortcomings of the implementation of checkboxes in templates, GitHub believes that their presence automatically means the creation of tasks. But when the user assures that his bug report is not a duplicate, it is not a real task. The worst thing is not even that it's annoying to see such bogus tasks , the problem is that behind this "informational noise" we cannot distinguish issues that actually contain a real list of tasks.

By the way, GitHub [promises](https://github.com/orgs/community/discussions/5238#discussioncomment-3579076) that it is working on the implementation of checkboxes that are not tasks, so in the future it will be possible to return a "confirmation checkbox" to this template.

