### PR TITLE
Maintenance of imgid

### DIFF
--- a/src/common/database.c
+++ b/src/common/database.c
@@ -1238,7 +1238,7 @@ static int _upgrade_library_schema_step(dt_database_t *db, int version)
                 "[init] can't prepare selecting history for iop_order migration (v21)\n");
     // clang-format on
     GList *item_list = NULL;
-    int current_imgid = -1;
+    int32_t current_imgid = -1;
     int current_order_version = -1;
 
     gboolean has_row = (sqlite3_step(mig_stmt) == SQLITE_ROW);

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -90,8 +90,8 @@ void dt_history_delete_on_image(const int32_t imgid);
 void dt_history_delete_on_image_ext(const int32_t imgid, const gboolean undo);
 
 /** copy history from imgid and pasts on selected images, merge or overwrite... */
-gboolean dt_history_copy(const int imgid);
-gboolean dt_history_copy_parts(const int imgid);
+gboolean dt_history_copy(const int32_t imgid);
+gboolean dt_history_copy_parts(const int32_t imgid);
 gboolean dt_history_paste_on_list(const GList *list, gboolean undo);
 gboolean dt_history_paste_parts_on_list(const GList *list, gboolean undo);
 
@@ -104,7 +104,7 @@ static inline gboolean dt_history_module_skip_copy(const int flags)
 gboolean dt_history_load_and_apply_on_list(gchar *filename, const GList *list);
 
 /** load a dt file and applies to specified image */
-gboolean dt_history_load_and_apply(const int imgid,
+gboolean dt_history_load_and_apply(const int32_t imgid,
                                    gchar *filename,
                                    const gboolean history_only);
 

--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -206,7 +206,7 @@ void dt_image_cache_print(dt_image_cache_t *cache)
 dt_image_t *dt_image_cache_get(dt_image_cache_t *cache, const int32_t imgid, char mode)
 {
   if(imgid <= 0) return NULL;
-  dt_cache_entry_t *entry = dt_cache_get(&cache->cache, (uint32_t)imgid, mode);
+  dt_cache_entry_t *entry = dt_cache_get(&cache->cache, imgid, mode);
   ASAN_UNPOISON_MEMORY_REGION(entry->data, sizeof(dt_image_t));
   dt_image_t *img = (dt_image_t *)entry->data;
   img->cache_entry = entry;
@@ -216,7 +216,7 @@ dt_image_t *dt_image_cache_get(dt_image_cache_t *cache, const int32_t imgid, cha
 dt_image_t *dt_image_cache_testget(dt_image_cache_t *cache, const int32_t imgid, char mode)
 {
   if(imgid <= 0) return NULL;
-  dt_cache_entry_t *entry = dt_cache_testget(&cache->cache, (uint32_t)imgid, mode);
+  dt_cache_entry_t *entry = dt_cache_testget(&cache->cache, imgid, mode);
   if(!entry) return 0;
   ASAN_UNPOISON_MEMORY_REGION(entry->data, sizeof(dt_image_t));
   dt_image_t *img = (dt_image_t *)entry->data;
@@ -341,7 +341,9 @@ void dt_image_cache_set_change_timestamp(dt_image_cache_t *cache, const int32_t 
   dt_image_cache_write_release(cache, img, DT_IMAGE_CACHE_SAFE);
 }
 
-void dt_image_cache_set_change_timestamp_from_image(dt_image_cache_t *cache, const int32_t imgid, const int32_t sourceid)
+void dt_image_cache_set_change_timestamp_from_image(dt_image_cache_t *cache,
+                                                    const int32_t imgid,
+                                                    const int32_t sourceid)
 {
   if(imgid <= 0 || sourceid <= 0) return;
 

--- a/src/common/selection.h
+++ b/src/common/selection.h
@@ -31,15 +31,15 @@ void dt_selection_invert(struct dt_selection_t *selection);
 /** clears the selection */
 void dt_selection_clear(struct dt_selection_t *selection);
 /** adds imgid to the current selection */
-void dt_selection_select(struct dt_selection_t *selection, uint32_t imgid);
+void dt_selection_select(struct dt_selection_t *selection, int32_t imgid);
 /** removes imgid from the current selection */
-void dt_selection_deselect(struct dt_selection_t *selection, uint32_t imgid);
+void dt_selection_deselect(struct dt_selection_t *selection, int32_t imgid);
 /** clears current selection and adds imgid */
-void dt_selection_select_single(struct dt_selection_t *selection, uint32_t imgid);
+void dt_selection_select_single(struct dt_selection_t *selection, int32_t imgid);
 /** toggles selection of image in the current selection */
-void dt_selection_toggle(struct dt_selection_t *selection, uint32_t imgid);
+void dt_selection_toggle(struct dt_selection_t *selection, int32_t imgid);
 /** selects images range last_single_id to imgid */
-void dt_selection_select_range(struct dt_selection_t *selection, uint32_t imgid);
+void dt_selection_select_range(struct dt_selection_t *selection, int32_t imgid);
 /** selects all images from current collection */
 void dt_selection_select_all(struct dt_selection_t *selection);
 /** selects all images from filmroll of last single selected image */

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -138,7 +138,7 @@ static void _init_expansion(dt_variables_params_t *params, gboolean iterate)
   params->data->latitude = NAN;
   params->data->elevation = NAN;
   params->data->show_msec = dt_conf_get_bool("lighttable/ui/milliseconds");
-  if(params->imgid)
+  if(params->imgid > 0)
   {
     params->data->camera_maker = NULL;
     params->data->camera_alias = NULL;
@@ -210,7 +210,7 @@ static void _init_expansion(dt_variables_params_t *params, gboolean iterate)
 
 static void _cleanup_expansion(dt_variables_params_t *params)
 {
-  if(params->imgid)
+  if(params->imgid > 0)
   {
     if(params->data->datetime)
     {

--- a/src/common/variables.h
+++ b/src/common/variables.h
@@ -35,7 +35,7 @@ typedef struct dt_variables_params_t
   const gchar *jobcode;
 
   /** used for expanding variables such as $(IMAGE_WIDTH) $(IMAGE_HEIGHT). */
-  uint32_t imgid;
+  int32_t imgid;
 
   /** used as thread-safe sequence number. only used if >= 0. */
   int sequence;

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -626,7 +626,7 @@ static int _image_is_normalized(const dt_image_t *const image)
 
 static gboolean _image_set_rawcrops(
         dt_iop_module_t *self,
-        const uint32_t imgid,
+        const int32_t imgid,
         const int left,
         const int right,
         const int top,

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -901,7 +901,7 @@ static void _setup_selected_images_list(dt_lib_module_t *self)
                               -1, &stmt, NULL);
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
-    const uint32_t imgid = sqlite3_column_int(stmt, 0);
+    const int32_t imgid = sqlite3_column_int(stmt, 0);
     const dt_image_t *cimg = dt_image_cache_get(darktable.image_cache, imgid, 'r');
     char dt[DT_DATETIME_LENGTH];
     if(!cimg) continue;

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -227,8 +227,8 @@ static void _update(dt_lib_module_t *self)
   else
   {
     // exact one image to act on
-    const int imgid = dt_act_on_get_main_image();
-    if(imgid >= 0)
+    const int32_t imgid = dt_act_on_get_main_image();
+    if(imgid > 0)
     {
       dt_image_t *img = dt_image_cache_get(darktable.image_cache, imgid, 'r');
       const gboolean is_bw = (dt_image_monochrome_flags(img) != 0);

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1924,8 +1924,8 @@ static void _import_from_dialog_run(dt_lib_module_t* self)
         if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->recursive)))
           folder = dt_util_dstrcat(folder, "%%");
         _import_set_collection(folder);
-        const int imgid = dt_conf_get_int("ui_last/import_last_image");
-        if(unique && imgid != -1)
+        const int32_t imgid = dt_conf_get_int("ui_last/import_last_image");
+        if(unique && imgid > 0)
         {
           dt_control_set_mouse_over_id(imgid);
           dt_ctl_switch_mode_to("darkroom");

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -43,7 +43,7 @@ typedef struct dt_lib_snapshot_t
   char *module;
   char *label;
   dt_view_context_t ctx;
-  uint32_t imgid;
+  int32_t imgid;
   uint32_t history_end;
   uint32_t id;
   /* snapshot cairo surface */
@@ -491,7 +491,7 @@ static void _clear_snapshot_entry(dt_lib_snapshot_t *s)
   s->label = NULL;
 }
 
-static void _clear_snapshots(dt_lib_module_t *self, const uint32_t imgid)
+static void _clear_snapshots(dt_lib_module_t *self, const int32_t imgid)
 {
   dt_lib_snapshots_t *d = (dt_lib_snapshots_t *)self->data;
   d->selected = -1;
@@ -543,7 +543,7 @@ static void _signal_image_changed(gpointer instance, gpointer user_data)
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_snapshots_t *d = (dt_lib_snapshots_t *)self->data;
 
-  const uint32_t imgid = darktable.develop->image_storage.id;
+  const int32_t imgid = darktable.develop->image_storage.id;
 
   for(uint32_t k = 0; k < MAX_SNAPSHOT; k++)
   {

--- a/src/libs/tools/image_infos.c
+++ b/src/libs/tools/image_infos.c
@@ -85,8 +85,8 @@ void _lib_imageinfo_update_message(gpointer instance, dt_lib_module_t *self)
   dt_lib_imageinfo_t *d = (dt_lib_imageinfo_t *)self->data;
 
   // we grab the image
-  const int imgid = darktable.develop->image_storage.id;
-  if(imgid < 0) return;
+  const int32_t imgid = darktable.develop->image_storage.id;
+  if(imgid <= 0) return;
 
   // we compute the info line (we reuse the function used in export to disk)
   char input_dir[512] = { 0 };


### PR DESCRIPTION
The usage of an `imgid` all over dt code differs significantly, from my current understanding

- an `imgid` must always be a signed integer, by common usage we define as int32_t, at many places we use `gint` or `int` which doesn't matter on used 64bit platforms.
- a valid `imgid` is always greater than zero

At some places we used uint32_t which seems to be wrong for me

The tests for a valid imgid should then be (imgid > 0), at some places we tested by `(imgid != 0)` ...


I'd strongly like your feedback on this one. Do i oversee something or don't i understand the code here?

Maybe introducing a macro or inline function `gboolean dt_valid_imgid(int32_t)`