### PR TITLE
[RFC] eliminate NAN as marker value (part 1)

### DIFF
--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -2093,9 +2093,12 @@ static void dt_colorspaces_pseudoinverse(double (*in)[3], double (*out)[3], int 
     }
 }
 
-int dt_colorspaces_conversion_matrices_xyz(const float adobe_XYZ_to_CAM[4][3], float in_XYZ_to_CAM[9], double XYZ_to_CAM[4][3], double CAM_to_XYZ[3][4])
+int dt_colorspaces_conversion_matrices_xyz(const float adobe_XYZ_to_CAM[4][3],
+                                           float in_XYZ_to_CAM[9],
+                                           double XYZ_to_CAM[4][3],
+                                           double CAM_to_XYZ[3][4])
 {
-  if(!isnan(in_XYZ_to_CAM[0]))
+  if(!dt_is_valid_colormatrix(in_XYZ_to_CAM[0]))
   {
     for(int i = 0; i < 9; i++)
         XYZ_to_CAM[i/3][i%3] = (double) in_XYZ_to_CAM[i];
@@ -2104,7 +2107,7 @@ int dt_colorspaces_conversion_matrices_xyz(const float adobe_XYZ_to_CAM[4][3], f
   }
   else
   {
-    if(isnan(adobe_XYZ_to_CAM[0][0]))
+    if(!dt_is_valid_colormatrix(adobe_XYZ_to_CAM[0][0]))
       return FALSE;
 
     for(int i = 0; i < 4; i++)
@@ -2131,9 +2134,9 @@ int dt_colorspaces_conversion_matrices_rgb(const float adobe_XYZ_to_CAM[4][3],
   double RGB_to_CAM[4][3];
 
   float XYZ_to_CAM[4][3];
-  XYZ_to_CAM[0][0] = NAN;
+  dt_mark_colormatrix_invalid(&XYZ_to_CAM[0][0]);
 
-  if(embedded_matrix == NULL || isnan(embedded_matrix[0]))
+  if(embedded_matrix == NULL || !dt_is_valid_colormatrix(embedded_matrix[0]))
   {
     for(int k=0; k<4; k++)
       for(int i=0; i<3; i++)
@@ -2156,10 +2159,10 @@ int dt_colorspaces_conversion_matrices_rgb(const float adobe_XYZ_to_CAM[4][3],
     XYZ_to_CAM[2][2] = embedded_matrix[8];
   }
 
-  if(isnan(XYZ_to_CAM[0][0]))
+  if(!dt_is_valid_colormatrix(XYZ_to_CAM[0][0]))
     return FALSE;
 
-  const double RGB_to_XYZ[3][3] = {
+  static const double RGB_to_XYZ[3][3] = {
   // sRGB D65
     { 0.412453, 0.357580, 0.180423 },
     { 0.212671, 0.715160, 0.072169 },

--- a/src/common/dttypes.h
+++ b/src/common/dttypes.h
@@ -20,7 +20,7 @@
 
 // uncomment the next line to use something other than NAN to signal an invalid color matrix
 // leave commented out for backward compatibility in case some instances have been missed.
-#define NO_COLORMATRIX_NAN
+//#define NO_COLORMATRIX_NAN
 
 #include <float.h>
 #include <math.h>

--- a/src/common/dttypes.h
+++ b/src/common/dttypes.h
@@ -44,6 +44,23 @@ typedef DT_ALIGNED_PIXEL float dt_aligned_pixel_t[4];
 // a 3x3 matrix, padded to permit SSE instructions to be used for multiplication and addition
 typedef float DT_ALIGNED_ARRAY dt_colormatrix_t[4][4];
 
+// GCC 12.2 has a bug where it will erroneously generate a warning
+// about accessing 64 bytes in a 16-byte object when a dt_colormatrix_t
+// is passed to a function (this kills the compilation due to
+// -Werror).  The most elegant way to handle this is to suppress the
+// warning for the handfull of function calls the bug affects.
+#if __GNUC__ == 12
+#define GCC12_SUPPRESS_ERRONEOUS_STRINGOP_OVERFLOW_WARNING \
+  _Pragma("GCC push_options") \
+  _Pragma("GCC diagnostic ignored \"-Wstringop-overflow\"")
+
+#define GCC12_RESTORE_STRINGOP_OVERFLOW_WARNING \
+  _Pragma("GCC pop_options")
+#else
+#define GCC12_SUPPRESS_ERRONEOUS_STRINGOP_OVERFLOW_WARNING
+#define GCC12_RESTORE_STRINGOP_OVERFLOW_WARNING
+#endif
+
 // To be able to vectorize per-pixel loops, we need to operate on all four channels, but if the compiler does
 // not auto-vectorize, doing so increases computation by 1/3 for a channel which typically is ignored anyway.
 // Select the appropriate number of channels over which to loop to produce the fastest code.
@@ -164,6 +181,13 @@ static inline void pack_3xSSE_to_3x3(const dt_colormatrix_t input, float output[
   output[6] = input[2][0];
   output[7] = input[2][1];
   output[8] = input[2][2];
+}
+
+static inline void dt_colormatrix_copy(dt_colormatrix_t out, const dt_colormatrix_t in)
+{
+  for(size_t i = 0; i < 4; i++)
+    for_each_channel(c)
+      out[i][c] = in[i][c];
 }
 
 // vectorized multiplication of padded 3x3 matrices

--- a/src/common/dttypes.h
+++ b/src/common/dttypes.h
@@ -18,10 +18,11 @@
 
 #pragma once
 
-// ucomment the next line to use something other than NAN to signal an invalid color matrix
+// uncomment the next line to use something other than NAN to signal an invalid color matrix
 // leave commented out for backward compatibility in case some instances have been missed.
-//#define NO_COLORMATRIX_NAN
+#define NO_COLORMATRIX_NAN
 
+#include <float.h>
 #include <math.h>
 
 // When included by a C++ file, restrict qualifiers are not allowed

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1427,9 +1427,11 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
     // read embedded color matrix as used in DNGs
     {
       float colmatrix[3][12];
-      colmatrix[0][0] = colmatrix[1][0] = colmatrix[2][0] = NAN;
+      dt_mark_colormatrix_invalid(&colmatrix[0][0]);
+      dt_mark_colormatrix_invalid(&colmatrix[1][0]);
+      dt_mark_colormatrix_invalid(&colmatrix[2][0]);
       dt_dng_illuminant_t illu[3] = { DT_LS_Unknown, DT_LS_Unknown, DT_LS_Unknown };
-      img->d65_color_matrix[0] = NAN; // make sure for later testing
+      dt_mark_colormatrix_invalid(&img->d65_color_matrix[0]); // make sure for later testing
 
       // fallback later via `find_temperature_from_raw_coeffs` if there is no valid illuminant
 
@@ -1524,7 +1526,7 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
       if(sel_illu == -1)
         for(int i = 0; i < 3; ++i)
         {
-          if((illu[i] == DT_LS_Unknown) && !std::isnan(colmatrix[i][0]))
+	  if((illu[i] == DT_LS_Unknown) && dt_is_valid_colormatrix(colmatrix[i][0]))
           {
             sel_illu = i;
             sel_temp = D65temp;

--- a/src/common/illuminants.h
+++ b/src/common/illuminants.h
@@ -124,8 +124,15 @@ static inline float xy_to_CCT(const float x, const float y)
   // Valid for 3000 K to 50000 K
   // Reference : https://www.usna.edu/Users/oceano/raylee/papers/RLee_AO_CCTpaper.pdf
   // Warning : we throw a number ever if it's grossly off. You need to check the error later.
-  const float n = (x - 0.3366f)/(y - 0.1735f);
-  return -949.86315f + 6253.80338f * expf(-n / 0.92159f) + 28.70599f * expf(-n / 0.20039f) + 0.00004f * expf(-n / 0.07125f);
+  if(x < FLT_MAX)
+  {
+    const float n = (x - 0.3366f)/(y - 0.1735f);
+    return (-949.86315f + 6253.80338f * expf(-n / 0.92159f)
+            + 28.70599f * expf(-n / 0.20039f)
+            + 0.00004f * expf(-n / 0.07125f));
+  }
+  else // we were called with coordinates flagged as invalid
+    return 0.0f; // invalid chromaticity
 }
 
 
@@ -416,9 +423,9 @@ static int find_temperature_from_raw_coeffs(const dt_image_t *img, const dt_alig
 
   // Get the camera input profile (matrice of primaries)
   float XYZ_to_CAM[4][3];
-  XYZ_to_CAM[0][0] = NAN;
+  dt_mark_colormatrix_invalid(&XYZ_to_CAM[0][0]);
 
-  if(img->d65_color_matrix[0] < FLT_MAX)	// is the first element NAN?
+  if(dt_is_valid_colormatrix(img->d65_color_matrix[0]))
   {
     // keep in sync with reload_defaults from colorin.c
     // embedded matrix is used with higher priority than standard one
@@ -441,14 +448,14 @@ static int find_temperature_from_raw_coeffs(const dt_image_t *img, const dt_alig
         XYZ_to_CAM[k][i] = img->adobe_XYZ_to_CAM[k][i];
   }
 
-  if(!(XYZ_to_CAM[0][0] < FLT_MAX)) return FALSE; // fail if first element is NAN
+  if(!dt_is_valid_colormatrix(XYZ_to_CAM[0][0])) return FALSE;
 
   // Bloody input matrices define XYZ -> CAM transform, as if we often needed camera profiles to output
   // So we need to invert them. Here go your CPU cycles again.
   float CAM_to_XYZ[4][3];
-  CAM_to_XYZ[0][0] = NAN;
+  dt_mark_colormatrix_invalid(&CAM_to_XYZ[0][0]);
   matrice_pseudoinverse(XYZ_to_CAM, CAM_to_XYZ, 3);
-  if(!(CAM_to_XYZ[0][0] < FLT_MAX)) return FALSE; //fail if first element is NAN
+  if(!dt_is_valid_colormatrix(CAM_to_XYZ[0][0])) return FALSE;
 
   float x, y;
   WB_coeffs_to_illuminant_xy(CAM_to_XYZ, WB, &x, &y);

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -2005,7 +2005,7 @@ void dt_image_init(dt_image_t *img)
   img->raw_black_level = 0;
   for(uint8_t i = 0; i < 4; i++) img->raw_black_level_separate[i] = 0;
   img->raw_white_point = 16384; // 2^14
-  img->d65_color_matrix[0] = NAN;
+  dt_mark_colormatrix_invalid(img->d65_color_matrix);
   img->profile = NULL;
   img->profile_size = 0;
   img->colorspace = DT_IMAGE_COLORSPACE_NONE;
@@ -2023,7 +2023,7 @@ void dt_image_init(dt_image_t *img)
 
   for(int k=0; k<4; k++)
     for(int i=0; i<3; i++)
-      img->adobe_XYZ_to_CAM[k][i] = NAN;
+      dt_mark_colormatrix_invalid(&img->adobe_XYZ_to_CAM[k][i]);
 }
 
 void dt_image_refresh_makermodel(dt_image_t *img)

--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -102,7 +102,7 @@ void dt_image_cache_allocate(void *data,
     if(color_matrix)
       memcpy(img->d65_color_matrix, color_matrix, sizeof(img->d65_color_matrix));
     else
-      img->d65_color_matrix[0] = NAN;
+      dt_mark_colormatrix_invalid(img->d65_color_matrix);
     g_free(img->profile);
     img->profile = NULL;
     img->profile_size = 0;

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -779,26 +779,22 @@ static gboolean _ioppr_generate_profile_info(dt_iop_order_iccprofile_info_t *pro
                                                     profile_info->lut_in[0],
                                                     profile_info->lut_in[1],
                                                     profile_info->lut_in[2],
-                                                    profile_info->lutsize)
-       || dt_colorspaces_get_matrix_from_output_profile(rgb_profile, profile_info->matrix_out,
+                                                    profile_info->lutsize) == 0
+       && dt_is_valid_colormatrix(profile_info->matrix_in[0][0])
+       && dt_colorspaces_get_matrix_from_output_profile(rgb_profile, profile_info->matrix_out,
                                                         profile_info->lut_out[0],
                                                         profile_info->lut_out[1],
                                                         profile_info->lut_out[2],
-                                                        profile_info->lutsize))
-    {
-      _mark_as_nonmatrix_profile(profile_info);
-      _clear_lut_curves(profile_info);
-    }
-    else if(!dt_is_valid_colormatrix(profile_info->matrix_in[0][0])
-            || !dt_is_valid_colormatrix(profile_info->matrix_out[0][0]))
-    {
-      _mark_as_nonmatrix_profile(profile_info);
-      _clear_lut_curves(profile_info);
-    }
-    else
+                                                        profile_info->lutsize) == 0
+       && dt_is_valid_colormatrix(profile_info->matrix_out[0][0]))
     {
       transpose_3xSSE(profile_info->matrix_in, profile_info->matrix_in_transposed);
       transpose_3xSSE(profile_info->matrix_out, profile_info->matrix_out_transposed);
+    }
+    else
+    {
+      _mark_as_nonmatrix_profile(profile_info);
+      _clear_lut_curves(profile_info);
     }
   }
 

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -54,10 +54,10 @@
 
 static void _mark_as_nonmatrix_profile(dt_iop_order_iccprofile_info_t *const profile_info)
 {
-  profile_info->matrix_in[0][0] = NAN;
-  profile_info->matrix_in_transposed[0][0] = NAN;
-  profile_info->matrix_out[0][0] = NAN;
-  profile_info->matrix_out_transposed[0][0] = NAN;
+  dt_mark_colormatrix_invalid(&profile_info->matrix_in[0][0]);
+  dt_mark_colormatrix_invalid(&profile_info->matrix_in_transposed[0][0]);
+  dt_mark_colormatrix_invalid(&profile_info->matrix_out[0][0]);
+  dt_mark_colormatrix_invalid(&profile_info->matrix_out_transposed[0][0]);
 }
 
 static void _clear_lut_curves(dt_iop_order_iccprofile_info_t *const profile_info)
@@ -789,7 +789,8 @@ static gboolean _ioppr_generate_profile_info(dt_iop_order_iccprofile_info_t *pro
       _mark_as_nonmatrix_profile(profile_info);
       _clear_lut_curves(profile_info);
     }
-    else if(isnan(profile_info->matrix_in[0][0]) || isnan(profile_info->matrix_out[0][0]))
+    else if(!dt_is_valid_colormatrix(profile_info->matrix_in[0][0])
+            || !dt_is_valid_colormatrix(profile_info->matrix_out[0][0]))
     {
       _mark_as_nonmatrix_profile(profile_info);
       _clear_lut_curves(profile_info);
@@ -805,7 +806,8 @@ static gboolean _ioppr_generate_profile_info(dt_iop_order_iccprofile_info_t *pro
   // we do extrapolation for input values above 1.0f.
   // unfortunately we can only do this if we got the computation
   // in our hands, i.e. for the fast builtin-dt-matrix-profile path.
-  if(!isnan(profile_info->matrix_in[0][0]) && !isnan(profile_info->matrix_out[0][0]))
+  if(dt_is_valid_colormatrix(profile_info->matrix_in[0][0])
+     && dt_is_valid_colormatrix(profile_info->matrix_out[0][0]))
   {
     profile_info->nonlinearlut = _init_unbounded_coeffs(profile_info->lut_in[0],
                                                         profile_info->lut_in[1],
@@ -821,10 +823,11 @@ static gboolean _ioppr_generate_profile_info(dt_iop_order_iccprofile_info_t *pro
                            profile_info->unbounded_coeffs_out[1],
                            profile_info->unbounded_coeffs_out[2],
                            profile_info->lutsize);
+    error = FALSE;
   }
 
-  if(!isnan(profile_info->matrix_in[0][0])
-     && !isnan(profile_info->matrix_out[0][0])
+  if(dt_is_valid_colormatrix(profile_info->matrix_in[0][0])
+     && dt_is_valid_colormatrix(profile_info->matrix_out[0][0])
      && profile_info->nonlinearlut)
   {
     const dt_aligned_pixel_t rgb = { 0.1842f, 0.1842f, 0.1842f };
@@ -833,6 +836,7 @@ static gboolean _ioppr_generate_profile_info(dt_iop_order_iccprofile_info_t *pro
                                                            profile_info->unbounded_coeffs_in,
                                                            profile_info->lutsize,
                                                            profile_info->nonlinearlut);
+    error = FALSE;
   }
 
   return error;
@@ -940,12 +944,13 @@ dt_ioppr_set_pipe_work_profile_info(struct dt_develop_t *dev,
     dt_ioppr_add_profile_info_to_list(dev, type, filename, intent);
 
   if(profile_info == NULL
-     || isnan(profile_info->matrix_in[0][0])
-     || isnan(profile_info->matrix_out[0][0]))
+     || !dt_is_valid_colormatrix(profile_info->matrix_in[0][0])
+     || !dt_is_valid_colormatrix(profile_info->matrix_out[0][0]))
   {
-    dt_print(DT_DEBUG_PIPE,
-      "[dt_ioppr_set_pipe_work_profile_info] profile `%s' in `%s' replaced by linear Rec2020\n",
-      dt_colorspaces_get_name(type, NULL), filename);
+    dt_print(DT_DEBUG_ALWAYS,
+             "[dt_ioppr_set_pipe_work_profile_info] unsupported working profile %s %s, "
+             "it will be replaced with linear Rec2020\n",
+             dt_colorspaces_get_name(type, NULL), filename);
     profile_info = dt_ioppr_add_profile_info_to_list(dev, DT_COLORSPACE_LIN_REC2020, "", intent);
   }
   pipe->work_profile_info = profile_info;
@@ -1000,8 +1005,8 @@ dt_ioppr_set_pipe_output_profile_info(struct dt_develop_t *dev,
     dt_ioppr_add_profile_info_to_list(dev, type, filename, intent);
 
   if(profile_info == NULL
-     || isnan(profile_info->matrix_in[0][0])
-     || isnan(profile_info->matrix_out[0][0]))
+     || !dt_is_valid_colormatrix(profile_info->matrix_in[0][0])
+     || !dt_is_valid_colormatrix(profile_info->matrix_out[0][0]))
   {
     if(type != DT_COLORSPACE_DISPLAY)
     {
@@ -1223,8 +1228,9 @@ void dt_ioppr_transform_image_colorspace
   dt_times_t start_time = { 0 }, end_time = { 0 };
   dt_get_perf_times(&start_time);
 
-  // matrix should be never NAN, this is only to test it against lcms2!
-  if(!isnan(profile_info->matrix_in[0][0]) && !isnan(profile_info->matrix_out[0][0]))
+  // matrix should never be invalid, this is only to test it against lcms2!
+  if(dt_is_valid_colormatrix(profile_info->matrix_in[0][0])
+     && dt_is_valid_colormatrix(profile_info->matrix_out[0][0]))
   {
     _transform_matrix(self, image_in, image_out, width, height,
                       cst_from, cst_to, converted_cst, profile_info);
@@ -1294,8 +1300,10 @@ void dt_ioppr_transform_image_colorspace_rgb
   dt_times_t start_time = { 0 }, end_time = { 0 };
   dt_get_perf_times(&start_time);
 
-  if(!isnan(profile_info_from->matrix_in[0][0]) && !isnan(profile_info_from->matrix_out[0][0])
-     && !isnan(profile_info_to->matrix_in[0][0]) && !isnan(profile_info_to->matrix_out[0][0]))
+  if(dt_is_valid_colormatrix(profile_info_from->matrix_in[0][0])
+     && dt_is_valid_colormatrix(profile_info_from->matrix_out[0][0])
+     && dt_is_valid_colormatrix(profile_info_to->matrix_in[0][0])
+     && dt_is_valid_colormatrix(profile_info_to->matrix_out[0][0]))
   {
     _transform_matrix_rgb(image_in, image_out, width, height, profile_info_from, profile_info_to);
 
@@ -1517,7 +1525,8 @@ gboolean dt_ioppr_transform_image_colorspace_cl
   *converted_cst = cst_from;
 
   // if we have a matrix use opencl
-  if(!isnan(profile_info->matrix_in[0][0]) && !isnan(profile_info->matrix_out[0][0]))
+  if(dt_is_valid_colormatrix(profile_info->matrix_in[0][0])
+     && dt_is_valid_colormatrix(profile_info->matrix_out[0][0]))
   {
     dt_times_t start_time = { 0 }, end_time = { 0 };
     dt_get_perf_times(&start_time);
@@ -1707,8 +1716,10 @@ gboolean dt_ioppr_transform_image_colorspace_rgb_cl
   cl_mem matrix_cl = NULL;
 
   // if we have a matrix use opencl
-  if(!isnan(profile_info_from->matrix_in[0][0]) && !isnan(profile_info_from->matrix_out[0][0])
-     && !isnan(profile_info_to->matrix_in[0][0]) && !isnan(profile_info_to->matrix_out[0][0]))
+  if(dt_is_valid_colormatrix(profile_info_from->matrix_in[0][0])
+     && dt_is_valid_colormatrix(profile_info_from->matrix_out[0][0])
+     && dt_is_valid_colormatrix(profile_info_to->matrix_in[0][0])
+     && dt_is_valid_colormatrix(profile_info_to->matrix_out[0][0]))
   {
     dt_times_t start_time = { 0 }, end_time = { 0 };
     dt_get_perf_times(&start_time);

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -775,6 +775,8 @@ static gboolean _ioppr_generate_profile_info(dt_iop_order_iccprofile_info_t *pro
   // get the matrix
   if(rgb_profile)
   {
+    // work around false GCC12 warnings about accessing 64 bytes in a 16-byte parameter
+    GCC12_SUPPRESS_ERRONEOUS_STRINGOP_OVERFLOW_WARNING
     if(dt_colorspaces_get_matrix_from_input_profile(rgb_profile, profile_info->matrix_in,
                                                     profile_info->lut_in[0],
                                                     profile_info->lut_in[1],
@@ -796,6 +798,7 @@ static gboolean _ioppr_generate_profile_info(dt_iop_order_iccprofile_info_t *pro
       _mark_as_nonmatrix_profile(profile_info);
       _clear_lut_curves(profile_info);
     }
+    GCC12_RESTORE_STRINGOP_OVERFLOW_WARNING
   }
 
   // now try to initialize unbounded mode:

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -307,8 +307,8 @@ static inline float euclidean_norm(const dt_aligned_pixel_t vector)
 #endif
 static inline void downscale_vector(dt_aligned_pixel_t vector, const float scaling)
 {
-  // check zero or NaN
-  const int valid = (scaling > NORM_MIN) && !isnan(scaling);
+  // check that scaling is positive (NaN produces FALSE)
+  const int valid = (scaling > NORM_MIN);
   for(size_t c = 0; c < 3; c++)
     vector[c] = (valid) ? vector[c] / (scaling + NORM_MIN) : vector[c] / NORM_MIN;
 }
@@ -319,7 +319,8 @@ static inline void downscale_vector(dt_aligned_pixel_t vector, const float scali
 #endif
 static inline void upscale_vector(dt_aligned_pixel_t vector, const float scaling)
 {
-  const int valid = (scaling > NORM_MIN) && !isnan(scaling);
+  // check that scaling is positive (NaN produces FALSE)
+  const int valid = (scaling > NORM_MIN);
   for(size_t c = 0; c < 3; c++)
     vector[c] = (valid) ? vector[c] * (scaling + NORM_MIN) : vector[c] * NORM_MIN;
 }

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -370,7 +370,7 @@ static int dt_control_merge_hdr_process(dt_imageio_module_data_t *datai, const c
       d->wb_coeffs[i] = image.wb_coeffs[i];
     // give priority to DNG embedded matrix: see dt_colorspaces_conversion_matrices_xyz() and its call from
     // iop/temperature.c with image_storage.adobe_XYZ_to_CAM[][] and image_storage.d65_color_matrix[] as inputs
-    if(!isnan(image.d65_color_matrix[0]))
+    if(dt_is_valid_colormatrix(image.d65_color_matrix[0]))
     {
         for(int i = 0; i < 9; ++i)
           d->adobe_XYZ_to_CAM[i/3][i%3] = image.d65_color_matrix[i];

--- a/src/imageio/imageio_dng.h
+++ b/src/imageio/imageio_dng.h
@@ -205,7 +205,7 @@ static inline void _imageio_dng_write_tiff_header(
   b = _imageio_dng_make_tag(EXIF_TAG_WHITE_LEVEL, LONG, 1, white.u, buf, b, &cnt); /* WhiteLevel in float, actually. */
 
   // ColorMatrix1 try to get camera matrix else m[k] like before
-  if(!isnan(adobe_XYZ_to_CAM[0][0]))
+  if(dt_is_valid_colormatrix(adobe_XYZ_to_CAM[0][0]))
   {
     den = 10000;
     for(int k= 0; k < 3; k++)

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -698,13 +698,6 @@ static inline void _luma_chroma(const dt_aligned_pixel_t input,
   }
 }
 
-void dt_colormatrix_copy(dt_colormatrix_t out, const dt_colormatrix_t in)
-{
-  for(size_t i = 0; i < 4; i++)
-    for_each_channel(c)
-      out[i][c] = in[i][c];
-}
-
 #ifdef _OPENMP
 #pragma omp declare simd aligned(in, out, XYZ_to_RGB, RGB_to_XYZ, MIX : 64) aligned(illuminant, saturation, lightness, grey:16)
 #endif

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1740,7 +1740,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   if(self->dev && self->dev->pipe)
     output_profile = dt_ioppr_get_pipe_output_profile_info(self->dev->pipe);
 
-  if(!output_profile || isnan(output_profile->matrix_out[0][0]))
+  if(!output_profile || !dt_is_valid_colormatrix(output_profile->matrix_out[0][0]))
   {
     output_profile = dt_ioppr_add_profile_info_to_list(self->dev, DT_COLORSPACE_SRGB, "",
                                                        DT_INTENT_RELATIVE_COLORIMETRIC);

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1428,12 +1428,12 @@ void commit_params(struct dt_iop_module_t *self,
   }
 
   // prepare transformation matrix or lcms2 transforms as fallback
+  GCC12_SUPPRESS_ERRONEOUS_STRINGOP_OVERFLOW_WARNING
   if(d->nrgb)
   {
     // user wants us to clip to a given RGB profile
-    if(dt_colorspaces_get_matrix_from_input_profile
-       (d->input, d->cmatrix, d->lut[0], d->lut[1], d->lut[2],
-        LUT_SAMPLES))
+    if(dt_colorspaces_get_matrix_from_input_profile(d->input, d->cmatrix,
+                                                    d->lut[0], d->lut[1], d->lut[2], LUT_SAMPLES))
     {
       piece->process_cl_ready = FALSE;
       dt_mark_colormatrix_invalid(&d->cmatrix[0][0]);
@@ -1467,6 +1467,7 @@ void commit_params(struct dt_iop_module_t *self,
                                             TYPE_LabA_FLT, p->intent, 0);
     }
   }
+  GCC12_RESTORE_STRINGOP_OVERFLOW_WARNING
 
   // we might have failed generating the clipping transformations, check that:
   if(d->nrgb && ((!d->xform_cam_nrgb && !dt_is_valid_colormatrix(d->nmatrix[0][0]))
@@ -1500,6 +1501,7 @@ void commit_params(struct dt_iop_module_t *self,
     d->input = dt_colorspaces_get_profile(DT_COLORSPACE_LIN_REC709, "",
                                           DT_PROFILE_DIRECTION_IN)->profile;
     d->clear_input = FALSE;
+    GCC12_SUPPRESS_ERRONEOUS_STRINGOP_OVERFLOW_WARNING
     if(dt_colorspaces_get_matrix_from_input_profile(d->input, d->cmatrix,
                                                     d->lut[0], d->lut[1], d->lut[2],
                                                     LUT_SAMPLES))
@@ -1509,6 +1511,7 @@ void commit_params(struct dt_iop_module_t *self,
       d->xform_cam_Lab = cmsCreateTransform(d->input, TYPE_RGBA_FLT, Lab,
                                             TYPE_LabA_FLT, p->intent, 0);
     }
+    GCC12_RESTORE_STRINGOP_OVERFLOW_WARNING
   }
 
   d->nonlinearlut = FALSE;

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -533,8 +533,8 @@ static void _workicc_changed(GtkWidget *widget, gpointer user_data)
       dt_ioppr_add_profile_info_to_list(self->dev, p->type_work,
                                         p->filename_work, DT_INTENT_PERCEPTUAL);
     if(work_profile == NULL
-       || isnan(work_profile->matrix_in[0][0])
-       || isnan(work_profile->matrix_out[0][0]))
+       || !dt_is_valid_colormatrix(work_profile->matrix_in[0][0])
+       || !dt_is_valid_colormatrix(work_profile->matrix_out[0][0]))
     {
       dt_print(DT_DEBUG_ALWAYS, "[colorin] can't extract matrix from colorspace `%s',"
                " it will be replaced by Rec2020 RGB!\n", p->filename_work);
@@ -1204,7 +1204,7 @@ void process(struct dt_iop_module_t *self,
   {
     dt_iop_image_copy_by_size(ovoid, ivoid, roi_out->width, roi_out->height, piece->colors);
   }
-  else if(!isnan(d->cmatrix[0][0]))
+  else if(dt_is_valid_colormatrix(d->cmatrix[0][0]))
   {
     process_cmatrix(self, piece, ivoid, ovoid, roi_in, roi_out);
   }
@@ -1287,7 +1287,9 @@ void commit_params(struct dt_iop_module_t *self,
     d->xform_nrgb_Lab = NULL;
   }
 
-  d->cmatrix[0][0] = d->nmatrix[0][0] = d->lmatrix[0][0] = NAN;
+  dt_mark_colormatrix_invalid(&d->cmatrix[0][0]);
+  dt_mark_colormatrix_invalid(&d->nmatrix[0][0]);
+  dt_mark_colormatrix_invalid(&d->lmatrix[0][0]);
   d->lut[0][0] = -1.0f;
   d->lut[1][0] = -1.0f;
   d->lut[2][0] = -1.0f;
@@ -1339,7 +1341,7 @@ void commit_params(struct dt_iop_module_t *self,
   {
     // embedded matrix, hopefully D65
     const dt_image_t *cimg = dt_image_cache_get(darktable.image_cache, pipe->image.id, 'r');
-    if(isnan(cimg->d65_color_matrix[0]))
+    if(!dt_is_valid_colormatrix(cimg->d65_color_matrix[0]))
       type = DT_COLORSPACE_STANDARD_MATRIX;
     else
     {
@@ -1351,7 +1353,7 @@ void commit_params(struct dt_iop_module_t *self,
   }
   if(type == DT_COLORSPACE_STANDARD_MATRIX)
   {
-    if(isnan(pipe->image.adobe_XYZ_to_CAM[0][0]))
+    if(!dt_is_valid_colormatrix(pipe->image.adobe_XYZ_to_CAM[0][0]))
     {
       if(dt_image_is_matrix_correction_supported(&pipe->image))
       {
@@ -1434,7 +1436,7 @@ void commit_params(struct dt_iop_module_t *self,
         LUT_SAMPLES))
     {
       piece->process_cl_ready = FALSE;
-      d->cmatrix[0][0] = NAN;
+      dt_mark_colormatrix_invalid(&d->cmatrix[0][0]);
       d->xform_cam_Lab = cmsCreateTransform(d->input, input_format, Lab,
                                             TYPE_LabA_FLT, p->intent, 0);
       d->xform_cam_nrgb = cmsCreateTransform(d->input, input_format, d->nrgb,
@@ -1460,15 +1462,15 @@ void commit_params(struct dt_iop_module_t *self,
                                                     LUT_SAMPLES))
     {
       piece->process_cl_ready = FALSE;
-      d->cmatrix[0][0] = NAN;
+      dt_mark_colormatrix_invalid(&d->cmatrix[0][0]);
       d->xform_cam_Lab = cmsCreateTransform(d->input, input_format, Lab,
                                             TYPE_LabA_FLT, p->intent, 0);
     }
   }
 
   // we might have failed generating the clipping transformations, check that:
-  if(d->nrgb && ((!d->xform_cam_nrgb && isnan(d->nmatrix[0][0]))
-                 || (!d->xform_nrgb_Lab && isnan(d->lmatrix[0][0]))))
+  if(d->nrgb && ((!d->xform_cam_nrgb && !dt_is_valid_colormatrix(d->nmatrix[0][0]))
+                 || (!d->xform_nrgb_Lab && !dt_is_valid_colormatrix(d->lmatrix[0][0]))))
   {
     if(d->xform_cam_nrgb)
     {
@@ -1484,7 +1486,7 @@ void commit_params(struct dt_iop_module_t *self,
   }
 
   // user selected a non-supported input profile, check that:
-  if(!d->xform_cam_Lab && isnan(d->cmatrix[0][0]))
+  if(!d->xform_cam_Lab && !dt_is_valid_colormatrix(d->cmatrix[0][0]))
   {
     if(p->type == DT_COLORSPACE_FILE)
       dt_print(DT_DEBUG_ALWAYS, "[colorin] unsupported input profile `%s' has"
@@ -1503,7 +1505,7 @@ void commit_params(struct dt_iop_module_t *self,
                                                     LUT_SAMPLES))
     {
       piece->process_cl_ready = FALSE;
-      d->cmatrix[0][0] = NAN;
+      dt_mark_colormatrix_invalid(&d->cmatrix[0][0]);
       d->xform_cam_Lab = cmsCreateTransform(d->input, TYPE_RGBA_FLT, Lab,
                                             TYPE_LabA_FLT, p->intent, 0);
     }
@@ -1772,7 +1774,7 @@ void reload_defaults(dt_iop_module_t *module)
     d->type = DT_COLORSPACE_ADOBERGB;
   else if(dt_image_is_ldr(img))
     d->type = DT_COLORSPACE_SRGB;
-  else if(!isnan(img->d65_color_matrix[0])) // image is DNG, EXR, or RGBE
+  else if(dt_is_valid_colormatrix(img->d65_color_matrix[0])) // image is DNG, EXR, or RGBE
     d->type = DT_COLORSPACE_EMBEDDED_MATRIX;
   else if(dt_image_is_matrix_correction_supported(img)) // image is raw
     d->type = DT_COLORSPACE_STANDARD_MATRIX;
@@ -1815,7 +1817,7 @@ static void update_profile_list(dt_iop_module_t *self)
   }
   dt_image_cache_read_release(darktable.image_cache, cimg);
   // use the matrix embedded in some DNGs and EXRs
-  if(!isnan(self->dev->image_storage.d65_color_matrix[0]))
+  if(dt_is_valid_colormatrix(self->dev->image_storage.d65_color_matrix[0]))
   {
     dt_colorspaces_color_profile_t *prof
         = (dt_colorspaces_color_profile_t *)calloc(1, sizeof(dt_colorspaces_color_profile_t));
@@ -1826,7 +1828,7 @@ static void update_profile_list(dt_iop_module_t *self)
     prof->in_pos = ++pos;
   }
 
-  if(!isnan(self->dev->image_storage.adobe_XYZ_to_CAM[0][0])
+  if(dt_is_valid_colormatrix(self->dev->image_storage.adobe_XYZ_to_CAM[0][0])
      && !(self->dev->image_storage.flags & DT_IMAGE_4BAYER))
   {
     dt_colorspaces_color_profile_t *prof

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -729,15 +729,17 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
    */
 
   /* get matrix from profile, if softproofing or high quality exporting always go xform codepath */
+  GCC12_SUPPRESS_ERRONEOUS_STRINGOP_OVERFLOW_WARNING
   if(d->mode != DT_PROFILE_NORMAL || force_lcms2
-     || dt_colorspaces_get_matrix_from_output_profile(output, d->cmatrix, d->lut[0], d->lut[1], d->lut[2],
-                                                      LUT_SAMPLES))
+     || dt_colorspaces_get_matrix_from_output_profile(output, d->cmatrix,
+                                                      d->lut[0], d->lut[1], d->lut[2], LUT_SAMPLES))
   {
     dt_mark_colormatrix_invalid(&d->cmatrix[0][0]);
     piece->process_cl_ready = FALSE;
     d->xform = cmsCreateProofingTransform(Lab, TYPE_LabA_FLT, output, output_format, softproof,
                                           out_intent, INTENT_RELATIVE_COLORIMETRIC, transformFlags);
   }
+  GCC12_RESTORE_STRINGOP_OVERFLOW_WARNING
 
   // user selected a non-supported output profile, check that:
   if(!d->xform && !dt_is_valid_colormatrix(d->cmatrix[0][0]))
@@ -748,9 +750,10 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
              out_profile->name);
     output = dt_colorspaces_get_profile(DT_COLORSPACE_SRGB, "", DT_PROFILE_DIRECTION_OUT)->profile;
 
+    GCC12_SUPPRESS_ERRONEOUS_STRINGOP_OVERFLOW_WARNING
     if(d->mode != DT_PROFILE_NORMAL
-       || dt_colorspaces_get_matrix_from_output_profile(output, d->cmatrix, d->lut[0], d->lut[1], d->lut[2],
-                                                        LUT_SAMPLES))
+       || dt_colorspaces_get_matrix_from_output_profile(output, d->cmatrix,
+                                                        d->lut[0], d->lut[1], d->lut[2], LUT_SAMPLES))
     {
       dt_mark_colormatrix_invalid(&d->cmatrix[0][0]);
       piece->process_cl_ready = FALSE;
@@ -758,6 +761,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
       d->xform = cmsCreateProofingTransform(Lab, TYPE_LabA_FLT, output, output_format, softproof,
                                             out_intent, INTENT_RELATIVE_COLORIMETRIC, transformFlags);
     }
+    GCC12_RESTORE_STRINGOP_OVERFLOW_WARNING
   }
 
   if(out_type == DT_COLORSPACE_DISPLAY || out_type == DT_COLORSPACE_DISPLAY2)

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -730,7 +730,7 @@ static void _lib_histogram_process_vectorscope(dt_lib_histogram_t *d, const floa
   const dt_lib_histogram_vectorscope_type_t vs_type = d->vectorscope_type;
   const dt_lib_histogram_scale_t vs_scale = d->vectorscope_scale;
 
-  if(!vs_prof || isnan(vs_prof->matrix_in[0][0]))
+  if(!vs_prof || !dt_is_valid_colormatrix(vs_prof->matrix_in[0][0]))
   {
     dt_print(DT_DEBUG_ALWAYS,
              "[histogram] unsupported vectorscope profile %i %s, it will be replaced with linear Rec2020\n",


### PR DESCRIPTION
This PR consolidates all setting and testing of the "non-matrix" flag value for color profiles into a pair of inline functions, and then switches the actual marker value from NAN to -FLT_MAX.  It is a more general fix for #14100 and contributes to eventually being able to apply the -ffinite-math-only optimization globally.

Although the PR passes the integration tests, it needs more testing before merge as all of the integration tests use matrix color profiles.  The few ICC profiles I have which aren't matrix profiles cause the installed version of lcms2 to issue an error message and substitute a built-in matrix profile for sRGB....  So if anybody has LUT-based ICC profiles, I would appreciate test runs with various settings of input and output color profile modules.
