### PR TITLE
have lib views() return an enum instead of strings again

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -156,7 +156,7 @@ extern "C" {
 /* Helper to force stack vectors to be aligned on 64 bits blocks to enable AVX2 */
 #define DT_IS_ALIGNED(x) __builtin_assume_aligned(x, 64)
 
-#define DT_MODULE_VERSION 23 // version of dt's module interface
+#define DT_MODULE_VERSION 24 // version of dt's module interface
 
 // version of current performance configuration version
 // if you want to run an updated version of the performance configuration later

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1082,38 +1082,13 @@ static dt_view_type_flags_t _find_views(dt_action_t *action)
   case DT_ACTION_TYPE_IOP:
     vws = DT_VIEW_DARKROOM;
     break;
-  case DT_ACTION_TYPE_VIEW:
-    {
-      dt_view_t *view = (dt_view_t *)owner;
-
-      vws = view->view(view);
-    }
+  case DT_ACTION_TYPE_VIEW:;
+    dt_view_t *view = (dt_view_t *)owner;
+    vws = view->view(view);
     break;
-  case DT_ACTION_TYPE_LIB:
-    {
-      dt_lib_module_t *lib = (dt_lib_module_t *)owner;
-
-      const gchar **views = lib->views(lib);
-      while(*views)
-      {
-        if     (strcmp(*views, "lighttable") == 0)
-          vws |= DT_VIEW_LIGHTTABLE;
-        else if(strcmp(*views, "darkroom") == 0)
-          vws |= DT_VIEW_DARKROOM;
-        else if(strcmp(*views, "print") == 0)
-          vws |= DT_VIEW_PRINT;
-        else if(strcmp(*views, "slideshow") == 0)
-          vws |= DT_VIEW_SLIDESHOW;
-        else if(strcmp(*views, "map") == 0)
-          vws |= DT_VIEW_MAP;
-        else if(strcmp(*views, "tethering") == 0)
-          vws |= DT_VIEW_TETHERING;
-        else if(strcmp(*views, "*") == 0)
-          vws |= DT_VIEW_DARKROOM | DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING |
-                 DT_VIEW_MAP | DT_VIEW_PRINT | DT_VIEW_SLIDESHOW;
-        views++;
-      }
-    }
+  case DT_ACTION_TYPE_LIB:;
+    dt_lib_module_t *lib = (dt_lib_module_t *)owner;
+    vws = lib->views(lib);
     break;
   case DT_ACTION_TYPE_BLEND:
     vws = DT_VIEW_DARKROOM;
@@ -1122,8 +1097,7 @@ static dt_view_type_flags_t _find_views(dt_action_t *action)
     if(owner == &darktable.control->actions_fallbacks)
       vws = 0;
     else if(owner == &darktable.control->actions_lua)
-      vws = DT_VIEW_DARKROOM | DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING |
-            DT_VIEW_MAP | DT_VIEW_PRINT | DT_VIEW_SLIDESHOW;
+      vws = DT_VIEW_ALL;
     else if(owner == &darktable.control->actions_thumb)
     {
       vws = DT_VIEW_DARKROOM | DT_VIEW_MAP | DT_VIEW_TETHERING | DT_VIEW_PRINT;
@@ -1134,8 +1108,7 @@ static dt_view_type_flags_t _find_views(dt_action_t *action)
       dt_print(DT_DEBUG_ALWAYS, "[find_views] views for category '%s' unknown\n", owner->id);
     break;
   case DT_ACTION_TYPE_GLOBAL:
-    vws = DT_VIEW_DARKROOM | DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING |
-          DT_VIEW_MAP | DT_VIEW_PRINT | DT_VIEW_SLIDESHOW;
+    vws = DT_VIEW_ALL;
     break;
   default:
     break;

--- a/src/libs/backgroundjobs.c
+++ b/src/libs/backgroundjobs.c
@@ -52,10 +52,9 @@ const char *name(dt_lib_module_t *self)
   return _("background jobs");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"*", NULL};
-  return v;
+  return DT_VIEW_ALL;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/camera.c
+++ b/src/libs/camera.c
@@ -78,10 +78,9 @@ const char *name(dt_lib_module_t *self)
   return _("camera settings");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"tethering", NULL};
-  return v;
+  return DT_VIEW_TETHERING;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -372,10 +372,9 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
 }
 
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"lighttable", "map", "print", NULL};
-  return v;
+  return DT_VIEW_LIGHTTABLE | DT_VIEW_MAP | DT_VIEW_PRINT;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -71,10 +71,9 @@ const char *name(dt_lib_module_t *self)
   return _("color picker");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"darkroom", NULL};
-  return v;
+  return DT_VIEW_DARKROOM;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -61,10 +61,9 @@ const char *name(dt_lib_module_t *self)
   return _("history stack");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"lighttable", NULL};
-  return v;
+  return DT_VIEW_LIGHTTABLE;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -56,10 +56,9 @@ const char *name(dt_lib_module_t *self)
   return _("duplicate manager");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"darkroom", NULL};
-  return v;
+  return DT_VIEW_DARKROOM;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -154,15 +154,12 @@ const char *name(dt_lib_module_t *self)
   return _("export");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v1[] = {"lighttable", "darkroom", NULL};
-  static const char *v2[] = {"lighttable", NULL};
-
   if(dt_conf_get_bool("plugins/darkroom/export/visible"))
-    return v1;
+    return DT_VIEW_LIGHTTABLE | DT_VIEW_DARKROOM;
   else
-    return v2;
+    return DT_VIEW_LIGHTTABLE;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -615,10 +615,9 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
 }
 
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = { "lighttable", "map", "print", NULL };
-  return v;
+  return DT_VIEW_LIGHTTABLE | DT_VIEW_MAP | DT_VIEW_PRINT;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -141,14 +141,13 @@ const char *name(dt_lib_module_t *self)
   return _("geotagging");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
 #ifdef HAVE_MAP
-  static const char *v[] = {"lighttable", "map", NULL};
+  return DT_VIEW_LIGHTTABLE | DT_VIEW_MAP;
 #else
-  static const char *v[] = {"lighttable", NULL};
+  return DT_VIEW_LIGHTTABLE;
 #endif
-  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -242,10 +242,9 @@ const char *name(dt_lib_module_t *self)
   return _("scopes");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"darkroom", "tethering", NULL};
-  return v;
+  return DT_VIEW_DARKROOM | DT_VIEW_TETHERING;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -99,10 +99,9 @@ const char *name(dt_lib_module_t *self)
   return _("history");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"darkroom", NULL};
-  return v;
+  return DT_VIEW_DARKROOM;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -72,10 +72,9 @@ const char *name(dt_lib_module_t *self)
   return _("selected image[s]");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"lighttable", NULL};
-  return v;
+  return DT_VIEW_LIGHTTABLE;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -173,10 +173,9 @@ const char *name(dt_lib_module_t *self)
 }
 
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"lighttable", NULL};
-  return v;
+  return DT_VIEW_LIGHTTABLE;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/ioporder.c
+++ b/src/libs/ioporder.c
@@ -40,10 +40,9 @@ const char *name(dt_lib_module_t *self)
   return _("module order");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"darkroom", NULL};
-  return v;
+  return DT_VIEW_DARKROOM;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -69,12 +69,7 @@ gboolean dt_lib_is_visible_in_view(dt_lib_module_t *module, const dt_view_t *vie
     return FALSE;
   }
 
-  const char **views = module->views(module);
-  for(const char **iter = views; *iter; iter++)
-  {
-    if(!strcmp(*iter, "*") || !strcmp(*iter, view->module_name)) return TRUE;
-  }
-  return FALSE;
+  return module->views(module) & view->view(view);
 }
 
 /** calls module->cleanup and closes the dl connection. */

--- a/src/libs/lib_api.h
+++ b/src/libs/lib_api.h
@@ -43,7 +43,7 @@ struct dt_view_t;
 REQUIRED(const char *, name, struct dt_lib_module_t *self);
 
 /** get the views which the module should be loaded in. */
-REQUIRED(const char **, views, struct dt_lib_module_t *self);
+REQUIRED(enum dt_view_type_flags_t, views, struct dt_lib_module_t *self);
 /** get the container which the module should be placed in */
 REQUIRED(uint32_t, container, struct dt_lib_module_t *self);
 /** check if module should use a expander or not, default implementation

--- a/src/libs/live_view.c
+++ b/src/libs/live_view.c
@@ -107,10 +107,9 @@ const char *name(dt_lib_module_t *self)
   return _("live view");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"tethering", NULL};
-  return v;
+  return DT_VIEW_TETHERING;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -100,10 +100,9 @@ const char *name(dt_lib_module_t *self)
   return _("find location");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"map", NULL};
-  return v;
+  return DT_VIEW_MAP;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/map_locations.c
+++ b/src/libs/map_locations.c
@@ -36,10 +36,9 @@ const char *name(dt_lib_module_t *self)
   return _("locations");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"map", NULL};
-  return v;
+  return DT_VIEW_MAP;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/map_settings.c
+++ b/src/libs/map_settings.c
@@ -39,10 +39,9 @@ const char *name(dt_lib_module_t *self)
   return _("map settings");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"map", NULL};
-  return v;
+  return DT_VIEW_MAP;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -61,10 +61,9 @@ const char *name(dt_lib_module_t *self)
   return _("mask manager");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"darkroom", NULL};
-  return v;
+  return DT_VIEW_DARKROOM;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -63,10 +63,9 @@ const char *name(dt_lib_module_t *self)
   return _("metadata editor");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"lighttable", "tethering", NULL};
-  return v;
+  return DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -170,10 +170,9 @@ const char *name(dt_lib_module_t *self)
   return _("image information");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"*", NULL};
-  return v;
+  return DT_VIEW_ALL;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -192,10 +192,9 @@ const char *name(dt_lib_module_t *self)
   return _("modulegroups");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"darkroom", NULL};
-  return v;
+  return DT_VIEW_DARKROOM;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -74,10 +74,9 @@ const char *name(dt_lib_module_t *self)
   return _("navigation");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"darkroom", NULL};
-  return v;
+  return DT_VIEW_DARKROOM;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -46,10 +46,9 @@ const char *name(dt_lib_module_t *self)
   return _("print settings");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"print", NULL};
-  return v;
+  return DT_VIEW_PRINT;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/recentcollect.c
+++ b/src/libs/recentcollect.c
@@ -67,10 +67,9 @@ const char *name(dt_lib_module_t *self)
   return _("recently used collections");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = { "lighttable", "map", NULL };
-  return v;
+  return DT_VIEW_LIGHTTABLE | DT_VIEW_MAP;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/select.c
+++ b/src/libs/select.c
@@ -39,10 +39,9 @@ const char *name(dt_lib_module_t *self)
   return _("select");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"lighttable", NULL};
-  return v;
+  return DT_VIEW_LIGHTTABLE;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/session.c
+++ b/src/libs/session.c
@@ -47,10 +47,9 @@ const char *name(dt_lib_module_t *self)
   return _("session");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"tethering", NULL};
-  return v;
+  return DT_VIEW_TETHERING;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -92,10 +92,9 @@ const char *name(dt_lib_module_t *self)
   return _("snapshots");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"darkroom", NULL};
-  return v;
+  return DT_VIEW_DARKROOM;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -54,10 +54,9 @@ const char *name(dt_lib_module_t *self)
   return _("styles");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"lighttable", NULL};
-  return v;
+  return DT_VIEW_LIGHTTABLE;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -104,15 +104,12 @@ const char *name(dt_lib_module_t *self)
   return _("tagging");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v1[] = {"lighttable", "darkroom", "map", "tethering", NULL};
-  static const char *v2[] = {"lighttable", "map", "tethering", NULL};
-
   if(dt_conf_get_bool("plugins/darkroom/tagging/visible"))
-    return v1;
+    return DT_VIEW_LIGHTTABLE | DT_VIEW_DARKROOM | DT_VIEW_MAP | DT_VIEW_TETHERING;
   else
-    return v2;
+    return DT_VIEW_LIGHTTABLE | DT_VIEW_MAP | DT_VIEW_TETHERING;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/battery_indicator.c
+++ b/src/libs/tools/battery_indicator.c
@@ -38,10 +38,9 @@ const char *name(dt_lib_module_t *self)
   return _("battery indicator");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"*", NULL};
-  return v;
+  return DT_VIEW_ALL;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/colorlabels.c
+++ b/src/libs/tools/colorlabels.c
@@ -42,10 +42,9 @@ const char *name(dt_lib_module_t *self)
   return _("colorlabels");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"lighttable", "tethering", NULL};
-  return v;
+  return DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/darktable.c
+++ b/src/libs/tools/darktable.c
@@ -65,10 +65,9 @@ const char *name(dt_lib_module_t *self)
   return _("darktable");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"*", NULL};
-  return v;
+  return DT_VIEW_ALL;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -45,10 +45,9 @@ const char *name(dt_lib_module_t *self)
   return _("filmstrip");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"lighttable", "darkroom", "tethering", "map", "print", NULL};
-  return v;
+  return DT_VIEW_LIGHTTABLE | DT_VIEW_DARKROOM | DT_VIEW_TETHERING | DT_VIEW_MAP | DT_VIEW_PRINT;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -42,7 +42,7 @@ const char *name(dt_lib_module_t *self)
   return _("filter");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
   /* for now, show in all view due this affects filmroll too
 
@@ -50,8 +50,7 @@ const char **views(dt_lib_module_t *self)
            unloading/loading a module while switching views.
 
    */
-  static const char *v[] = {"*", NULL};
-  return v;
+  return DT_VIEW_ALL;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/gamepad.c
+++ b/src/libs/tools/gamepad.c
@@ -37,10 +37,9 @@ const char *name(dt_lib_module_t *self)
   return _("gamepad");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"*", NULL};
-  return v;
+  return DT_VIEW_ALL;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -61,10 +61,9 @@ const char *name(dt_lib_module_t *self)
   return _("preferences");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"*", NULL};
-  return v;
+  return DT_VIEW_ALL;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/hinter.c
+++ b/src/libs/tools/hinter.c
@@ -42,10 +42,9 @@ const char *name(dt_lib_module_t *self)
   return _("hinter");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"lighttable", "darkroom", "map", "tethering", NULL};
-  return v;
+  return DT_VIEW_LIGHTTABLE | DT_VIEW_DARKROOM | DT_VIEW_MAP | DT_VIEW_TETHERING;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/image_infos.c
+++ b/src/libs/tools/image_infos.c
@@ -40,19 +40,15 @@ const char *name(dt_lib_module_t *self)
   return _("image infos");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
   /* we handle the hidden case here */
   const gboolean is_hidden =
     dt_conf_is_equal("plugins/darkroom/image_infos_position", "hidden");
   if(is_hidden)
-  {
-    static const char *vv[] = { NULL };
-    return vv;
-  }
-
-  static const char *v[] = { "darkroom", NULL };
-  return v;
+    return DT_VIEW_NONE;
+  else
+    return DT_VIEW_DARKROOM;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -66,10 +66,9 @@ const char *name(dt_lib_module_t *self)
   return _("lighttable");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"lighttable", NULL};
-  return v;
+  return DT_VIEW_LIGHTTABLE;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/midi.c
+++ b/src/libs/tools/midi.c
@@ -41,10 +41,9 @@ const char *name(dt_lib_module_t *self)
   return _("midi");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"*", NULL};
-  return v;
+  return DT_VIEW_ALL;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/module_toolbox.c
+++ b/src/libs/tools/module_toolbox.c
@@ -46,10 +46,9 @@ const char *name(dt_lib_module_t *self)
   return _("module toolbox");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"darkroom", "lighttable", "tethering", NULL};
-  return v;
+  return DT_VIEW_DARKROOM | DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/ratings.c
+++ b/src/libs/tools/ratings.c
@@ -56,10 +56,9 @@ const char *name(dt_lib_module_t *self)
   return _("ratings");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"lighttable", "tethering", NULL};
-  return v;
+  return DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/timeline.c
+++ b/src/libs/tools/timeline.c
@@ -102,10 +102,9 @@ const char *name(dt_lib_module_t *self)
   return _("timeline");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = { "lighttable", NULL };
-  return v;
+  return DT_VIEW_LIGHTTABLE;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/view_toolbox.c
+++ b/src/libs/tools/view_toolbox.c
@@ -46,10 +46,9 @@ const char *name(dt_lib_module_t *self)
   return _("view toolbox");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"darkroom", "lighttable", "tethering", NULL};
-  return v;
+  return DT_VIEW_DARKROOM | DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/viewswitcher.c
+++ b/src/libs/tools/viewswitcher.c
@@ -60,10 +60,9 @@ const char *name(dt_lib_module_t *self)
   return _("viewswitcher");
 }
 
-const char **views(dt_lib_module_t *self)
+dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"*", NULL};
-  return v;
+  return DT_VIEW_ALL;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -51,16 +51,16 @@
 */
 typedef enum dt_view_type_flags_t
 {
-  DT_VIEW_NONE = 0,
-  DT_VIEW_LIGHTTABLE = 1,
-  DT_VIEW_DARKROOM = 2,
-  DT_VIEW_TETHERING = 4,
-  DT_VIEW_MAP = 8,
-  DT_VIEW_SLIDESHOW = 16,
-  DT_VIEW_PRINT = 32,
-  DT_VIEW_KNIGHT = 64,
-  DT_VIEW_ALL = DT_VIEW_LIGHTTABLE | DT_VIEW_DARKROOM | DT_VIEW_TETHERING | DT_VIEW_MAP |
-                DT_VIEW_SLIDESHOW | DT_VIEW_PRINT | DT_VIEW_KNIGHT,
+  DT_VIEW_NONE       = 0,
+  DT_VIEW_LIGHTTABLE = 1 << 0,
+  DT_VIEW_DARKROOM   = 1 << 1,
+  DT_VIEW_TETHERING  = 1 << 2,
+  DT_VIEW_MAP        = 1 << 3,
+  DT_VIEW_SLIDESHOW  = 1 << 4,
+  DT_VIEW_PRINT      = 1 << 5,
+  DT_VIEW_KNIGHT     = 1 << 6,
+  DT_VIEW_OTHER      = 1 << 30, // for your own unpublished user view
+  DT_VIEW_ALL        = ~DT_VIEW_NONE,
 } dt_view_type_flags_t;
 
 // flags that a view can set in flags()

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -49,15 +49,18 @@
     control which view the module should be available in also
     which placement in the panels the module have.
 */
-typedef enum
+typedef enum dt_view_type_flags_t
 {
+  DT_VIEW_NONE = 0,
   DT_VIEW_LIGHTTABLE = 1,
   DT_VIEW_DARKROOM = 2,
   DT_VIEW_TETHERING = 4,
   DT_VIEW_MAP = 8,
   DT_VIEW_SLIDESHOW = 16,
   DT_VIEW_PRINT = 32,
-  DT_VIEW_KNIGHT = 64
+  DT_VIEW_KNIGHT = 64,
+  DT_VIEW_ALL = DT_VIEW_LIGHTTABLE | DT_VIEW_DARKROOM | DT_VIEW_TETHERING | DT_VIEW_MAP |
+                DT_VIEW_SLIDESHOW | DT_VIEW_PRINT | DT_VIEW_KNIGHT,
 } dt_view_type_flags_t;
 
 // flags that a view can set in flags()
@@ -114,10 +117,6 @@ typedef struct dt_mouse_action_t
   dt_mouse_action_type_t action;
   gchar name[256];
 } dt_mouse_action_t;
-
-#define DT_VIEW_ALL                                                                              \
-  (DT_VIEW_LIGHTTABLE | DT_VIEW_DARKROOM | DT_VIEW_TETHERING | DT_VIEW_MAP | DT_VIEW_SLIDESHOW | \
-   DT_VIEW_PRINT | DT_VIEW_KNIGHT)
 
 /* maximum zoom factor for the lighttable */
 #define DT_LIGHTTABLE_MAX_ZOOM 25


### PR DESCRIPTION
For no good reason this morning I decided to address a minor annoyance of mine, namely that lib modules return the set of views they want to be shown in as a list of strings rather than a bitfield of enum `dt_view_type_flags_t`s. This requires looping over string comparisons when loading shortcuts files and executing gui.actions from lua and prevents spell checking during compile.

I assumed this was just a curious initial api decision, but when I was almost done realised this was intentionally introduced in https://github.com/darktable-org/darktable/commit/b0fa66a7b16f1502dfc38e35d96e66fdccc5a75d. This PR doesn't touch the loading or view changing logic where maybe the previous PR solved (or papered over?) an issue, so I don't think it is rebreaking anything (FLW).

I'm not really seeing the benefit of string comparison in making the interface more generic. You'll still need to have a pre-defined set of core views that the libs can refer to, it's just that now they can not be checked at compile time. Adding a view as an add-in (pano anyone?) would still require adding its name to many libs and/or allocate a new enum (which could also be done at run-time and from lua if the need for such a feature really existed). We're not likely to run out of bits in a uint32 any time soon.

So though I don't feel _strongly_ about this PR, I personally do feel it is the right thing to do. Opinions please.