### PR TITLE
RFC: Place mask sliders in top bar if not expanded in manager

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1354,6 +1354,12 @@ filechooser row:hover .sidebar-icon
   background-color: @range_bg_color;
 }
 
+/* set masks sliders in header toolbar */
+#header-toolbar #bauhaus-slider
+{
+  margin: 0em 0em;
+}
+
 /* and adjust label and color buttons, especially in header bar */
 .dt_quick_filter,
 #filter-sort-box label,

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -68,6 +68,11 @@ int position(const dt_lib_module_t *self)
   return 2001;
 }
 
+static GtkWidget *_lib_filter_get_stack(dt_lib_module_t *self)
+{
+  return self->widget;
+}
+
 static GtkWidget *_lib_filter_get_filter_box(dt_lib_module_t *self)
 {
   dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
@@ -97,32 +102,38 @@ void gui_init(dt_lib_module_t *self)
   dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)g_malloc0(sizeof(dt_lib_tool_filter_t));
   self->data = (void *)d;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_widget_set_valign(self->widget, GTK_ALIGN_CENTER);
+  GtkWidget *box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  gtk_widget_set_valign(box, GTK_ALIGN_CENTER);
+
+  self->widget = gtk_stack_new();
+  gtk_stack_add_named(GTK_STACK(self->widget), box, "noshapes");
+  gtk_stack_set_transition_type(GTK_STACK(self->widget), GTK_STACK_TRANSITION_TYPE_SLIDE_LEFT_RIGHT);
+  gtk_container_add(GTK_CONTAINER(self->widget), dt_bauhaus_slider_new(NULL));
 
   GtkWidget *bt = dtgtk_button_new(dtgtk_cairo_paint_filtering_menu, 0, NULL);
   gtk_widget_set_tooltip_text(bt, _("filter preferences"));
   g_signal_connect(G_OBJECT(bt), "button-press-event", G_CALLBACK(_pref_show), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), bt, FALSE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(box), bt, FALSE, TRUE, 0);
 
   d->filter_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_widget_set_name(d->filter_box, "header-rule-box");
-  gtk_box_pack_start(GTK_BOX(self->widget), d->filter_box, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(box), d->filter_box, FALSE, FALSE, 0);
 
   /* sort combobox */
   d->sort_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_widget_set_name(d->sort_box, "header-sort-box");
-  gtk_box_pack_start(GTK_BOX(self->widget), d->sort_box, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(box), d->sort_box, FALSE, FALSE, 0);
   GtkWidget *label = gtk_label_new(_("sort by"));
   gtk_box_pack_start(GTK_BOX(d->sort_box), label, TRUE, TRUE, 0);
 
   /* label to display selected count */
   d->count = gtk_label_new("");
   gtk_label_set_ellipsize(GTK_LABEL(d->count), PANGO_ELLIPSIZE_MIDDLE);
-  gtk_box_pack_start(GTK_BOX(self->widget), d->count, TRUE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(box), d->count, TRUE, FALSE, 0);
 
   /* initialize proxy */
   darktable.view_manager->proxy.filter.module = self;
+  darktable.view_manager->proxy.filter.get_stack = _lib_filter_get_stack;
   darktable.view_manager->proxy.filter.get_filter_box = _lib_filter_get_filter_box;
   darktable.view_manager->proxy.filter.get_sort_box = _lib_filter_get_sort_box;
   darktable.view_manager->proxy.filter.get_count = _lib_filter_get_count;

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1068,6 +1068,13 @@ void dt_view_filtering_show_pref_menu(const dt_view_manager_t *vm,
     vm->proxy.module_filtering.show_pref_menu(vm->proxy.module_filtering.module, bt);
 }
 
+GtkWidget *dt_view_filter_get_stack(const dt_view_manager_t *vm)
+{
+  if(vm->proxy.filter.module && vm->proxy.filter.get_stack)
+    return vm->proxy.filter.get_stack(vm->proxy.filter.module);
+  return NULL;
+}
+
 GtkWidget *dt_view_filter_get_filters_box(const dt_view_manager_t *vm)
 {
   if(vm->proxy.filter.module && vm->proxy.filter.get_filter_box)

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -264,6 +264,7 @@ typedef struct dt_view_manager_t
     struct
     {
       struct dt_lib_module_t *module;
+      GtkWidget *(*get_stack)(struct dt_lib_module_t *);
       GtkWidget *(*get_filter_box)(struct dt_lib_module_t *);
       GtkWidget *(*get_sort_box)(struct dt_lib_module_t *);
       GtkWidget *(*get_count)(struct dt_lib_module_t *);
@@ -514,6 +515,7 @@ void dt_view_collection_update_history_state(const dt_view_manager_t *vm);
 void dt_view_filtering_reset(const dt_view_manager_t *vm,
                              const gboolean smart_filter);
 void dt_view_filtering_show_pref_menu(const dt_view_manager_t *vm, GtkWidget *bt);
+GtkWidget *dt_view_filter_get_stack(const dt_view_manager_t *vm);
 GtkWidget *dt_view_filter_get_filters_box(const dt_view_manager_t *vm);
 GtkWidget *dt_view_filter_get_sort_box(const dt_view_manager_t *vm);
 GtkWidget *dt_view_filter_get_count(const dt_view_manager_t *vm);


### PR DESCRIPTION
Since discoverability of the masks property sliders for opacity/size/feather etc in the collapsible section of the mask manager is still an issue, as hightlighted for example by https://github.com/darktable-org/darktable/issues/14079, this PR places them in the top bar, temporarily replacing the filter tools there, which presumably are not essential (or even appropriate) while editing masks. If the section in the mask manager is expanded, the sliders will be shown there instead, so that gives a way to hide them completely (expand the section and collapse the mask manager).
![image](https://github.com/darktable-org/darktable/assets/1549490/ee3b078c-dc4f-42ca-bb50-899fe901a8a5)

Hiding the filter tools gives the space needed for the sliders, so this PR doesn't have the same problem #12705 had. Also limiting to just the toolbar and not mixing with a popup because the usefulness and complexity of that change may not be worth it (and it doesn't help discoverability). It _is_ already possibly to assign shortcuts to an individual slider and have that pop up even when toolbar and manager are hidden, but a popup with all sliders would require more study.

I think it would make sense to only show the filters and sort when the filmstrip is enabled (but always show the number of images and position of currently selected one, since that's useful when just moving for/backward) but that's a separate (and orthogonal) issue from this one.
