### PR TITLE
HLR segmentation maintenance

### DIFF
--- a/src/iop/hlreconstruct/segbased.c
+++ b/src/iop/hlreconstruct/segbased.c
@@ -135,7 +135,6 @@ static void _calc_plane_candidates(const float *plane,
   {
     seg->val1[id] = 0.0f;
     seg->val2[id] = 0.0f;
-    seg->ref[id] = 0;
     // avoid very small segments
     if((seg->ymax[id] - seg->ymin[id] > 2) && (seg->xmax[id] - seg->xmin[id] > 2))
     {
@@ -184,7 +183,6 @@ static void _calc_plane_candidates(const float *plane,
         {
           seg->val1[id] = fminf(clipval, sum / fmaxf(1.0f, pix));
           seg->val2[id] = refavg[testref];
-          seg->ref[id] = testref;
         }
       }
     }
@@ -488,8 +486,12 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece,
   const size_t pheight = dt_round_size(roi_in->height / 3, 2) + 2 * HL_BORDER;
   const size_t p_size =  dt_round_size((size_t) pwidth * pheight, 64);
 
-  float *fbuffer = dt_alloc_align_float((HL_FLOAT_PLANES) * p_size);
-  if(!fbuffer) return;
+  float *fbuffer = dt_alloc_align_float(HL_FLOAT_PLANES * p_size);
+  if(!fbuffer)
+  {
+    dt_print(DT_DEBUG_PIPE, "[process segmentation] can't allocate intermediate buffers\n");
+    return;
+  }
 
   float *plane[HL_FLOAT_PLANES];
   for(int i = 0; i < HL_FLOAT_PLANES; i++)
@@ -499,9 +501,21 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece,
   for(int i = 0; i < HL_RGB_PLANES; i++)
     refavg[i] = plane[HL_SEGMENT_PLANES + i];
 
+  gboolean segerror = FALSE;
+
   dt_iop_segmentation_t isegments[HL_SEGMENT_PLANES];
   for(int i = 0; i < HL_SEGMENT_PLANES; i++)
-    dt_segmentation_init_struct(&isegments[i], pwidth, pheight, HL_BORDER +1, segmentation_limit);
+    segerror |= dt_segmentation_init_struct(&isegments[i], pwidth, pheight, HL_BORDER, segmentation_limit);
+
+  if(segerror)
+  {
+    dt_print(DT_DEBUG_PIPE, "[process segmentation] can't allocate segmentation buffers\n");
+    for(int i = 0; i < HL_SEGMENT_PLANES; i++)
+      dt_segmentation_free_struct(&isegments[i]);
+
+    dt_free_align(fbuffer);
+    return;
+  }
 
   const int xshifter = ((filters != 9u) && (FC(0, 0, filters) == 1)) ? 1 : 2;
 
@@ -741,7 +755,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece,
             if((vmode == DT_HIGHLIGHTS_MASK_COMBINE) && isegment)
               output[odx] = (isegments[color].data[ppos] & DT_SEG_ID_MASK) ? 1.0f : 0.6f;
             else if((vmode == DT_HIGHLIGHTS_MASK_CANDIDATING) && goodseg)
-              output[odx] = (ppos == isegments[color].ref[pid]) ? 1.0f : 0.6f;
+              output[odx] = 1.0f;
             else if((vmode == DT_HIGHLIGHTS_MASK_STRENGTH) && allseg)
               output[odx] += strength * gradient[ppos];
           }

--- a/src/iop/hlreconstruct/segbased.c
+++ b/src/iop/hlreconstruct/segbased.c
@@ -505,7 +505,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece,
 
   dt_iop_segmentation_t isegments[HL_SEGMENT_PLANES];
   for(int i = 0; i < HL_SEGMENT_PLANES; i++)
-    segerror |= dt_segmentation_init_struct(&isegments[i], pwidth, pheight, HL_BORDER, segmentation_limit);
+    segerror |= dt_segmentation_init_struct(&isegments[i], pwidth, pheight, HL_BORDER+1, segmentation_limit);
 
   if(segerror)
   {

--- a/src/iop/hlreconstruct/segmentation.c
+++ b/src/iop/hlreconstruct/segmentation.c
@@ -38,21 +38,20 @@ typedef struct dt_pos_t
 
 typedef struct dt_iop_segmentation_t
 {
-  int *data;      // holding segment id's for every location
+  uint32_t *data; // holding segment id's for every location
+  uint32_t *tmp;  // pointer to temporary buffer used for morphological operations
   int *size;      // size of each segment
   int *xmin;      // bounding rectangle for each segment
   int *xmax;
   int *ymin;
   int *ymax;
-  size_t *ref;    // ref, val1 and val2 are free to be used by the segmentation user
-  float *val1;
+  float *val1;    // val1 and val2 are free to be used by the segmentation user
   float *val2;
   int nr;         // next index for found segments, starting with 2
   int border;     // while segmentizing we have a border region not used by the algo
   int slots;      // available segment id's
   int width;
   int height;
-  int *tmp;       // pointer to temporary buffer used for morphological operations
 } dt_iop_segmentation_t;
 
 typedef struct dt_ff_stack_t
@@ -84,19 +83,16 @@ static inline dt_pos_t * _pop_stack(dt_ff_stack_t *stack)
   return &stack->el[stack->pos];
 }
 
-static inline int _get_segment_id(dt_iop_segmentation_t *seg, const size_t loc)
+static inline uint32_t _get_segment_id(dt_iop_segmentation_t *seg, const size_t loc)
 {
   if(loc >= (size_t)(seg->width * seg->height))
-  {
-    dt_print(DT_DEBUG_ALWAYS,
-             "[_get_segment_id] out of range access loc=%zu in %ix%i\n",
-             loc, seg->width, seg->height);
     return 0;
-  }
-  return seg->data[loc] & (DT_SEG_ID_MASK-1);
+
+  const uint32_t id = seg->data[loc] & (DT_SEG_ID_MASK-1);
+  return ((id < seg->slots -1) && (id > 1)) ? id : 0;
 }
 
-static inline int _test_dilate(const int *img, const size_t i, const size_t w1, const int radius)
+static inline int _test_dilate(const uint32_t *img, const size_t i, const size_t w1, const int radius)
 {
   int retval = 0;
   retval = img[i-w1-1] | img[i-w1] | img[i-w1+1] |
@@ -204,8 +200,8 @@ static inline int _test_dilate(const int *img, const size_t i, const size_t w1, 
   return retval;
 }
 
-static inline void _dilating(const int *img,
-                             int *o,
+static inline void _dilating(const uint32_t *img,
+                             uint32_t *o,
                              const int w1,
                              const int height,
                              const int border,
@@ -219,11 +215,11 @@ static inline void _dilating(const int *img,
   for(size_t row = border; row < height - border; row++)
   {
     for(size_t col = border, i = row*w1 + col; col < w1 - border; col++, i++)
-      o[i] = _test_dilate(img, i, w1, radius);
+      o[i] = _test_dilate(img, i, w1, radius) ? 1 : 0;
   }
 }
 
-static inline int _test_erode(const int *img, const size_t i, const size_t w1, const int radius)
+static inline int _test_erode(const uint32_t *img, const size_t i, const size_t w1, const int radius)
 {
   int retval = 1;
   retval =     img[i-w1-1] & img[i-w1] & img[i-w1+1] &
@@ -332,8 +328,8 @@ static inline int _test_erode(const int *img, const size_t i, const size_t w1, c
   return retval;
 }
 
-static inline void _eroding(const int *img,
-                            int *o,
+static inline void _eroding(const uint32_t *img,
+                            uint32_t *o,
                             const int w1,
                             const int height,
                             const int border,
@@ -347,26 +343,26 @@ static inline void _eroding(const int *img,
   for(size_t row = border; row < height - border; row++)
   {
     for(size_t col = border, i = row*w1 + col; col < w1 - border; col++, i++)
-      o[i] = _test_erode(img, i, w1, radius);
+      o[i] = _test_erode(img, i, w1, radius) ? 1 : 0;
   }
 }
 
-static inline void _intimage_borderfill(int *d,
+static inline void _intimage_borderfill(uint32_t *d,
                                         const int width,
                                         const int height,
                                         const int val,
                                         const int border)
 {
+  const size_t di = (height - border - 1) * width;
   for(size_t i = 0; i < border * width; i++)
-    d[i] = val;
-  for(size_t i = (height - border - 1) * width; i < width*height; i++)
-    d[i] = val;
+    d[i] = d[i + di] = val;
+
   for(size_t row = border; row < height - border; row++)
   {
-    int *p1 = d + row*width;
-    int *p2 = d + (row+1)*width - border;
-    for(int i = 0; i < border; i++)
-      p1[i] = p2[i] = val;
+    const size_t j = row * width;
+    const size_t dj = width - border;
+    for(size_t i = 0; i < border; i++)
+      d[j+i] = d[j+i+dj] = val;
   }
 }
 
@@ -381,7 +377,7 @@ static gboolean _floodfill_segmentize(int yin,
   if(id >= seg->slots - 2) return FALSE;
 
   const int border = seg->border;
-  int *d = seg->data;
+  uint32_t *d = seg->data;
 
   int xp = 0;
   int yp = 0;
@@ -395,7 +391,6 @@ static gboolean _floodfill_segmentize(int yin,
   stack->pos = 0;
 
   seg->size[id] = 0;
-  seg->ref[id] = 0;
   seg->val1[id] = 0.0f;
   seg->val2[id] = 0.0f;
   seg->xmin[id] = min_x;
@@ -430,7 +425,7 @@ static gboolean _floodfill_segmentize(int yin,
           max_x = MAX(max_x, xp);
           min_y = MIN(min_y, yp);
           max_y = MAX(max_y, yp);
-          d[rp] = DT_SEG_ID_MASK + id;
+          d[rp] = DT_SEG_ID_MASK | id;
         }
       }
 
@@ -449,7 +444,7 @@ static gboolean _floodfill_segmentize(int yin,
           max_x = MAX(max_x, xp);
           min_y = MIN(min_y, yp);
           max_y = MAX(max_y, yp);
-          d[rp] = DT_SEG_ID_MASK + id;
+          d[rp] = DT_SEG_ID_MASK | id;
         }
       }
 
@@ -473,7 +468,7 @@ static gboolean _floodfill_segmentize(int yin,
             max_x = MAX(max_x, xp);
             min_y = MIN(min_y, yp);
             max_y = MAX(max_y, yp);
-            d[rp] = DT_SEG_ID_MASK + id;
+            d[rp] = DT_SEG_ID_MASK | id;
           }
           lastXUp = FALSE;
         }
@@ -493,7 +488,7 @@ static gboolean _floodfill_segmentize(int yin,
             max_x = MAX(max_x, xp);
             min_y = MIN(min_y, yp);
             max_y = MAX(max_y, yp);
-            d[rp] = DT_SEG_ID_MASK + id;
+            d[rp] = DT_SEG_ID_MASK | id;
           }
           lastXDown = FALSE;
         }
@@ -509,7 +504,7 @@ static gboolean _floodfill_segmentize(int yin,
         max_x = MAX(max_x, xp);
         min_y = MIN(min_y, yp);
         max_y = MAX(max_y, yp);
-        d[rp] = DT_SEG_ID_MASK + id;
+        d[rp] = DT_SEG_ID_MASK | id;
       }
 
       int xl = x - 1;
@@ -534,7 +529,7 @@ static gboolean _floodfill_segmentize(int yin,
             max_x = MAX(max_x, xp);
             min_y = MIN(min_y, yp);
             max_y = MAX(max_y, yp);
-            d[rp] = DT_SEG_ID_MASK + id;
+            d[rp] = DT_SEG_ID_MASK | id;
           }
           lastXUp = FALSE;
         }
@@ -554,7 +549,7 @@ static gboolean _floodfill_segmentize(int yin,
             max_x = MAX(max_x, xp);
             min_y = MIN(min_y, yp);
             max_y = MAX(max_y, yp);
-            d[rp] = DT_SEG_ID_MASK + id;
+            d[rp] = DT_SEG_ID_MASK | id;
           }
           lastXDown = FALSE;
         }
@@ -572,12 +567,13 @@ static gboolean _floodfill_segmentize(int yin,
         max_x = MAX(max_x, xp);
         min_y = MIN(min_y, yp);
         max_y = MAX(max_y, yp);
-        d[rp] = DT_SEG_ID_MASK + id;
+        d[rp] = DT_SEG_ID_MASK | id;
       }
       cnt++;
     }
   }
 
+  // safety
   seg->size[id] = cnt;
   seg->xmin[id] = min_x;
   seg->xmax[id] = max_x;
@@ -591,44 +587,45 @@ static gboolean _floodfill_segmentize(int yin,
     {
       for(int col = min_x-1; col <= max_x+1; col++)
       {
-        size_t loc = w*row + col;
+        size_t loc = (size_t)w*row + col;
         if(d[loc] == id)
           d[loc] = 1;
-        else if(d[loc] == (id + DT_SEG_ID_MASK))
+        else if(d[loc] == (id | DT_SEG_ID_MASK))
           d[loc] = 0;
       }
-    }  
+    }
     return FALSE;
   }
-  {
-    seg->nr += 1;
-    return TRUE;
-  }
+
+  seg->nr += 1;
+  return TRUE;
 }
 
 // User interface
 void dt_segmentize_plane(dt_iop_segmentation_t *seg)
 {
   dt_ff_stack_t stack;  
-  const size_t width = seg->width;
-  const size_t height = seg->height;
-  stack.size = width * height / 32;
+  const int width = seg->width;
+  const int height = seg->height;
+  stack.size = (size_t)width * height / 32;
   stack.el = dt_alloc_align(64, stack.size * sizeof(dt_pos_t));
   if(!stack.el)
   {
     dt_print(DT_DEBUG_ALWAYS, "[segmentize_plane] can't allocate segmentation stack\n");
     return;
   }
-  const size_t border = seg->border;
+  const int border = seg->border;
   int id = 2;
-  for(size_t row = border; row < height - border; row++)
+  for(int row = border; row < height - border; row++)
   {
-    for(size_t col = border; col < width - border; col++)
+    for(int col = border; col < width - border; col++)
     {
-      if(id >= (seg->slots - 2)) goto finish;
-      if(seg->data[width * row + col] == 1)
+      if(id >= (seg->slots - 2))
+        goto finish;
+      if(seg->data[(size_t)width * row + col] == 1)
       {
-        if(_floodfill_segmentize(row, col, seg, width, height, id, &stack)) id++;
+        if(_floodfill_segmentize(row, col, seg, width, height, id, &stack))
+          id++;
       }
     }
   }
@@ -644,96 +641,110 @@ void dt_segmentize_plane(dt_iop_segmentation_t *seg)
 
 void dt_segments_transform_dilate(dt_iop_segmentation_t *seg, const int radius)
 {
-  if(radius < 1) return;
-  int *img = seg->data;
+  uint32_t *img = seg->data;
   const int width = seg->width;
   const int height = seg->height;
   const int border = seg->border;
-  if(!seg->tmp) seg->tmp = dt_alloc_align(64, width * height * sizeof(int));
-  if(!seg->tmp) return;
-
+  const size_t bsize = (size_t) width * height * sizeof(uint32_t);
   _intimage_borderfill(img, width, height, 0, border);
+
+  if(radius < 1)
+    return;
+
   _dilating(img, seg->tmp, width, height, border, radius);
-  memcpy(img, seg->tmp, width*height * sizeof(int));
+  memcpy(img, seg->tmp, bsize);
+  _intimage_borderfill(img, width, height, 0, border);
 }
-  
+
 void dt_segments_transform_erode(dt_iop_segmentation_t *seg, const int radius)
 {
-  if(radius < 1) return;
-  int *img = seg->data;
+  uint32_t *img = seg->data;
   const int width = seg->width;
   const int height = seg->height;
   const int border = seg->border;
-  if(!seg->tmp) seg->tmp = dt_alloc_align(64, width * height * sizeof(int));
-  if(!seg->tmp) return;
+  const size_t bsize = (size_t) width * height * sizeof(uint32_t);
 
-  _intimage_borderfill(img, width, height, 1, border);
-  _eroding(img, seg->tmp, width, height, border, radius);
-  memcpy(img, seg->tmp, width*height * sizeof(int));
- _intimage_borderfill(img, width, height, 0, border);
-}
-  
-void dt_segments_transform_closing(dt_iop_segmentation_t *seg, const int radius)
-{
-  int *img = seg->data;
-  const int width = seg->width;
-  const int height = seg->height;
-  const int border = seg->border;
   if(radius < 1)
   {
     _intimage_borderfill(img, width, height, 0, border);
     return;
   }
-  if(!seg->tmp) seg->tmp = dt_alloc_align(64, width * height * sizeof(int));
-  if(!seg->tmp) return;
 
+  _intimage_borderfill(img, width, height, 1, border);
+  _eroding(img, seg->tmp, width, height, border, radius);
+  memcpy(img, seg->tmp, bsize);
   _intimage_borderfill(img, width, height, 0, border);
-  _dilating(img, seg->tmp, width, height, border, radius);
- 
-  _intimage_borderfill(seg->tmp, width, height, 1, border);
-  _eroding(seg->tmp, img, width, height, border, radius);
 }
 
-void dt_segmentation_init_struct(dt_iop_segmentation_t *seg,
-                                 const int width,
-                                 const int height,
-                                 const int border,
-                                 const int wanted_slots)
+void dt_segments_transform_closing(dt_iop_segmentation_t *seg, const int radius)
 {
-  const int slots = MIN(wanted_slots, DT_SEG_ID_MASK - 2);
-  if(slots != wanted_slots)
-    dt_print(DT_DEBUG_ALWAYS, "number of wanted seg slots %i exceeds maximum %i\n",
-             wanted_slots, DT_SEG_ID_MASK - 2);
+  uint32_t *img = seg->data;
+  const int width = seg->width;
+  const int height = seg->height;
+  const int border = seg->border;
+  _intimage_borderfill(img, width, height, 0, border);
 
-  seg->nr = 2;
-  seg->data =   dt_alloc_align(64, width * height * sizeof(int));
-  seg->size =   dt_alloc_align(64, slots * sizeof(int));
-  seg->xmin =   dt_alloc_align(64, slots * sizeof(int));
-  seg->xmax =   dt_alloc_align(64, slots * sizeof(int));
-  seg->ymin =   dt_alloc_align(64, slots * sizeof(int));
-  seg->ymax =   dt_alloc_align(64, slots * sizeof(int));
-  seg->ref =    dt_alloc_align(64, slots * sizeof(size_t));
-  seg->val1 =   dt_alloc_align_float(slots);
-  seg->val2 =   dt_alloc_align_float(slots);
-  seg->border = MAX(border, 8);
-  seg->slots = slots;
-  seg->width = width;
-  seg->height = height;
-  seg->tmp = NULL;
+  if(radius < 1)
+    return;
+
+  _dilating(img, seg->tmp, width, height, border, radius);
+
+  _intimage_borderfill(seg->tmp, width, height, 1, border);
+  _eroding(seg->tmp, img, width, height, border, radius);
+  _intimage_borderfill(img, width, height, 0, border);
 }
 
 void dt_segmentation_free_struct(dt_iop_segmentation_t *seg)
 {
   dt_free_align(seg->data);
+  dt_free_align(seg->tmp);
   dt_free_align(seg->size);
   dt_free_align(seg->xmin);
   dt_free_align(seg->ymin);
   dt_free_align(seg->xmax);
   dt_free_align(seg->ymax);
-  dt_free_align(seg->ref);
   dt_free_align(seg->val1);
   dt_free_align(seg->val2);
-  dt_free_align(seg->tmp);
+  memset(seg, 0, sizeof(dt_iop_segmentation_t)); 
+}
+
+// returns TRUE in case of errors
+gboolean dt_segmentation_init_struct(dt_iop_segmentation_t *seg,
+                                 const int width,
+                                 const int height,
+                                 const int border,
+                                 const int islots)
+{
+  memset(seg, 0, sizeof(dt_iop_segmentation_t)); 
+  const int slots = MAX(256, MIN(islots, DT_SEG_ID_MASK - 2));
+  const size_t bsize = (size_t) width * height * sizeof(uint32_t);
+
+  seg->data =   dt_alloc_align(64, bsize);
+  seg->tmp =    dt_alloc_align(64, bsize);
+  seg->size =   dt_alloc_align(64, slots * sizeof(int));
+  seg->xmin =   dt_alloc_align(64, slots * sizeof(int));
+  seg->xmax =   dt_alloc_align(64, slots * sizeof(int));
+  seg->ymin =   dt_alloc_align(64, slots * sizeof(int));
+  seg->ymax =   dt_alloc_align(64, slots * sizeof(int));
+  seg->val1 =   dt_alloc_align_float(slots);
+  seg->val2 =   dt_alloc_align_float(slots);
+
+  if(!seg->data || !seg->size
+                || !seg->xmin || !seg->xmax || !seg->ymin || !seg->ymax
+                || !seg->val2 || !seg->val2)
+  {
+    dt_segmentation_free_struct(seg);
+    return TRUE;
+  }
+
+  // allocation is fine so we now set starters
+  seg->nr = 2;
+  seg->border = border;
+  seg->slots = slots;
+  seg->width = width;
+  seg->height = height;
+  seg->val1[0] = seg->val2[0] = seg->val1[1] = seg->val2[1] = 0.0f;
+  return FALSE;
 }
 
 // clang-format off


### PR DESCRIPTION
Due to late reports still reporting "oversegmentation" i reinvestigated segmentation algorithm, the likely reason is not-fully initialized segmentation plane data.

- the plane data should be specified as uint32_t so we can safely do masking
- we properly initialize segmentation data and test for wrongful allocation, in that case we don't do the segmentation postprocessing
- the tmp handling stuff has been removed as we always use one of the morphs
- while doing the morphological operations we always return either 1 or 0 in case the initial data were not correct so avoid possibly wrong segment ids
- testing for a proper segment id makes sure that non-initialized data can't be accessed.