### PR TITLE
Dump pipe pfm fixes

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -472,7 +472,7 @@ void dt_dump_pfm_file(
     }
   }
 
-  dt_print(DT_DEBUG_ALWAYS, "%20s %s,  %dx%d, bpp=%d\n", head, fname, width, height, bpp);
+  dt_print(DT_DEBUG_ALWAYS, "%-20s %s,  %dx%d, bpp=%d\n", head, fname, width, height, bpp);
   fclose(f);
   written += 1;
 }

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1920,7 +1920,8 @@ static gboolean _dev_pixelpipe_process_rec(
             }
           }
           const gboolean pfm_dump = darktable.dump_pfm_pipe
-            && (piece->pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_EXPORT));
+            && (piece->pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_EXPORT))
+            && dt_str_commasubstring(darktable.dump_pfm_module, module->so->op);
 
           if(pfm_dump)
             dt_opencl_dump_pipe_pfm(module->so->op, pipe->devid, cl_mem_input,


### PR DESCRIPTION
- the first info text in the logfile should be printed left-aligned for readability
- the opencl dumping did not test for the module name :-( thus dumping all modules