### PR TITLE
exif: remove Xmp.dc.format key

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -371,7 +371,7 @@ const char *dt_xmp_keys[]
         "Xmp.darktable.version_name",         "Xmp.dc.creator",
         "Xmp.dc.publisher",                   "Xmp.dc.title",
         "Xmp.dc.description",                 "Xmp.dc.rights",
-        "Xmp.xmpMM.DerivedFrom" };
+        "Xmp.dc.format",                      "Xmp.xmpMM.DerivedFrom" };
 
 static const guint dt_xmp_keys_n = G_N_ELEMENTS(dt_xmp_keys);
 // the number of XmpBag XmpSeq keys that dt uses

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -2062,11 +2062,7 @@ int dt_exif_read_blob(uint8_t **buf,
         "Exif.Image.TileLength",
         "Exif.Image.TileOffsets",
         "Exif.Image.TileByteCounts",
-        "Exif.Image.PlanarConfiguration",
-        "Exif.Image.InterColorProfile",
-        "Exif.Image.TIFFEPStandardID",
-        "Exif.Image.DNGVersion",
-        "Exif.Image.DNGBackwardVersion"
+        "Exif.Image.PlanarConfiguration"
       };
       static const guint n_keys = G_N_ELEMENTS(keys);
       dt_remove_exif_keys(exifData, keys, n_keys);
@@ -2095,7 +2091,25 @@ int dt_exif_read_blob(uint8_t **buf,
         "Exif.Nikon3.Preview",
         "Exif.NikonPreview.JPEGInterchangeFormat",
 
+        // TIFF/EP & Exif stuff irrelevant after developing
+        "Exif.Image.CFARepeatPatternDim",
+        "Exif.Image.CFAPattern",
+        "Exif.Image.InterColorProfile",
+        "Exif.Image.SpectralSensitivity",
+        "Exif.Image.OECF",
+        "Exif.Image.SpatialFrequencyResponse",
+        "Exif.Image.Noise",
+        "Exif.Image.SensingMethod",
+        "Exif.Image.TIFFEPStandardID",
+        "Exif.Photo.SpectralSensitivity",
+        "Exif.Photo.OECF",
+        "Exif.Photo.SpatialFrequencyResponse",
+        "Exif.Photo.SensingMethod",
+        "Exif.Photo.CFAPattern",
+
         // DNG stuff that is irrelevant or misleading
+        "Exif.Image.DNGVersion",
+        "Exif.Image.DNGBackwardVersion",
         "Exif.Image.DNGPrivateData",
         "Exif.Image.DefaultBlackRender",
         "Exif.Image.DefaultCropOrigin",
@@ -2109,6 +2123,22 @@ int dt_exif_read_blob(uint8_t **buf,
         "Exif.Image.OpcodeList1",
         "Exif.Image.OpcodeList2",
         "Exif.Image.OpcodeList3",
+        "Exif.Image.AsShotNeutral",
+        "Exif.Image.AsShotWhiteXY",
+        "Exif.Image.BaselineExposure",
+        "Exif.Image.BaselineNoise",
+        "Exif.Image.BaselineSharpness",
+        "Exif.Image.LinearResponseLimit",
+        "Exif.Image.ShadowScale",
+        "Exif.Image.PreviewApplicationName",
+        "Exif.Image.PreviewApplicationVersion",
+        "Exif.Image.PreviewSettingsDigest",
+        "Exif.Image.PreviewColorSpace",
+        "Exif.Image.PreviewDateTime",
+        "Exif.Image.NoiseProfile",
+        "Exif.Image.NewRawImageDigest",
+        "Exif.Image.RawImageDigest",
+
         "Exif.Photo.MakerNote",
 
         // Pentax thumbnail data
@@ -2137,8 +2167,8 @@ int dt_exif_read_blob(uint8_t **buf,
 
         "Exif.Image.BaselineExposureOffset",
 
-         // Samsung makernote cleanup, the entries below have no
-         // relevance for exported images
+        // Samsung makernote cleanup, the entries below have no
+        // relevance for exported images
         "Exif.Samsung2.SensorAreas",
         "Exif.Samsung2.ColorSpace",
         "Exif.Samsung2.EncryptionKey",
@@ -2159,30 +2189,36 @@ int dt_exif_read_blob(uint8_t **buf,
       dt_remove_exif_keys(exifData, keys, n_keys);
     }
 
-      static const char *dngkeys[] = {
-        // Embedded color profile info
-        "Exif.Image.CalibrationIlluminant1",
-        "Exif.Image.CalibrationIlluminant2",
-        "Exif.Image.ColorMatrix1",
-        "Exif.Image.ColorMatrix2",
-        "Exif.Image.ForwardMatrix1",
-        "Exif.Image.ForwardMatrix2",
-        "Exif.Image.ProfileCalibrationSignature",
-        "Exif.Image.ProfileCopyright",
-        "Exif.Image.ProfileEmbedPolicy",
-        "Exif.Image.ProfileHueSatMapData1",
-        "Exif.Image.ProfileHueSatMapData2",
-        "Exif.Image.ProfileHueSatMapDims",
-        "Exif.Image.ProfileHueSatMapEncoding",
-        "Exif.Image.ProfileLookTableData",
-        "Exif.Image.ProfileLookTableDims",
-        "Exif.Image.ProfileLookTableEncoding",
-        "Exif.Image.ProfileName",
-        "Exif.Image.ProfileToneCurve",
-        "Exif.Image.ReductionMatrix1",
-        "Exif.Image.ReductionMatrix2"
-        };
-      static const guint n_dngkeys = G_N_ELEMENTS(dngkeys);
+    static const char *dngkeys[] = {
+      // Embedded color profile info
+      "Exif.Image.ColorMatrix1",
+      "Exif.Image.ColorMatrix2",
+      "Exif.Image.CameraCalibration1",
+      "Exif.Image.CameraCalibration2",
+      "Exif.Image.ReductionMatrix1",
+      "Exif.Image.ReductionMatrix2",
+      "Exif.Image.AnalogBalance",
+      "Exif.Image.CalibrationIlluminant1",
+      "Exif.Image.CalibrationIlluminant2",
+      "Exif.Image.CameraCalibrationSignature",
+      "Exif.Image.ProfileCalibrationSignature",
+      "Exif.Image.ExtraCameraProfiles",
+      "Exif.Image.AsShotProfileName",
+      "Exif.Image.ProfileName",
+      "Exif.Image.ProfileHueSatMapDims",
+      "Exif.Image.ProfileHueSatMapData1",
+      "Exif.Image.ProfileHueSatMapData2",
+      "Exif.Image.ProfileToneCurve",
+      "Exif.Image.ProfileEmbedPolicy",
+      "Exif.Image.ProfileCopyright",
+      "Exif.Image.ForwardMatrix1",
+      "Exif.Image.ForwardMatrix2",
+      "Exif.Image.ProfileLookTableDims",
+      "Exif.Image.ProfileLookTableData",
+      "Exif.Image.ProfileLookTableEncoding",
+      "Exif.Image.ProfileHueSatMapEncoding"
+    };
+    static const guint n_dngkeys = G_N_ELEMENTS(dngkeys);
     dt_remove_exif_keys(exifData, dngkeys, n_dngkeys);
 
     /* Write appropriate color space tag if using sRGB output */


### PR DESCRIPTION
Resolves https://github.com/darktable-org/darktable/issues/14126

Relnotes: "Do not export original raw file MIME type in XMP metadata. Fixes wrong detection of developed TIFFs as DNGs by some software or services. Also remove more raw specific Exif tags irrelevant to developed images."