### PR TITLE
make dragging sliders smoother by creating only one undo record

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -3197,6 +3197,8 @@ static gboolean dt_bauhaus_slider_button_press(GtkWidget *widget, GdkEventButton
     }
     else
     {
+      dt_dev_undo_start_record(darktable.develop);
+
       d->is_dragging = -1;
       if(!dt_modifier_is(event->state, 0))
         darktable.bauhaus->mouse_x = ex;
@@ -3225,6 +3227,8 @@ static gboolean dt_bauhaus_slider_button_release(GtkWidget *widget, GdkEventButt
     if(d->timeout_handle) g_source_remove(d->timeout_handle);
     d->timeout_handle = 0;
     dt_bauhaus_slider_set_normalized(w, d->pos);
+
+    dt_dev_undo_end_record(darktable.develop);
 
     return TRUE;
   }

--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -55,8 +55,6 @@ static GType pointer_trouble[] = { G_TYPE_POINTER, G_TYPE_STRING, G_TYPE_STRING 
 static GType collection_args[] = { G_TYPE_UINT, G_TYPE_UINT, G_TYPE_POINTER, G_TYPE_UINT };
 static GType image_export_arg[]
     = { G_TYPE_UINT, G_TYPE_STRING, G_TYPE_POINTER, G_TYPE_POINTER, G_TYPE_POINTER, G_TYPE_POINTER };
-static GType history_will_change_arg[]
-= { G_TYPE_POINTER, G_TYPE_UINT, G_TYPE_POINTER };
 static GType geotag_arg[] = { G_TYPE_POINTER, G_TYPE_UINT };
 
 // callback for the destructor of DT_SIGNAL_COLLECTION_CHANGED
@@ -151,8 +149,8 @@ static dt_signal_description _signal_description[DT_SIGNAL_COUNT] = {
     FALSE }, // DT_SIGNAL_DEVELOP_PREVIEW2_PIPE_FINISHED
   { "dt-develop-ui-pipe-finished", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
     FALSE }, // DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED
-  { "dt-develop-history-will-change", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 3,
-    history_will_change_arg, NULL, FALSE }, // DT_SIGNAL_DEVELOP_HISTORY_WILL_CHANGE
+  { "dt-develop-history-will-change", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
+    FALSE }, // DT_SIGNAL_DEVELOP_HISTORY_WILL_CHANGE
   { "dt-develop-history-change", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
     FALSE }, // DT_SIGNAL_DEVELOP_HISTORY_CHANGE
   { "dt-develop-history-invalidated", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -3487,13 +3487,7 @@ void dt_dev_undo_start_record(dt_develop_t *dev)
 
   /* record current history state : before change (needed for undo) */
   if(dev->gui_attached && cv->view((dt_view_t *)cv) == DT_VIEW_DARKROOM)
-  {
-    DT_DEBUG_CONTROL_SIGNAL_RAISE
-      (darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_WILL_CHANGE,
-       dt_history_duplicate(dev->history),
-       dev->history_end,
-       dt_ioppr_iop_order_copy_deep(dev->iop_order_list));
-  }
+    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_WILL_CHANGE);
 }
 
 void dt_dev_undo_end_record(dt_develop_t *dev)
@@ -3502,9 +3496,7 @@ void dt_dev_undo_end_record(dt_develop_t *dev)
 
   /* record current history state : after change (needed for undo) */
   if(dev->gui_attached && cv->view((dt_view_t *)cv) == DT_VIEW_DARKROOM)
-  {
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_CHANGE);
-  }
 }
 
 void dt_dev_image_ext(

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -525,11 +525,7 @@ static void _gui_delete_callback(GtkButton *button, dt_iop_module_t *module)
   if(!next) return; // what happened ???
 
   if(dev->gui_attached)
-    DT_DEBUG_CONTROL_SIGNAL_RAISE
-      (darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_WILL_CHANGE,
-       dt_history_duplicate(darktable.develop->history),
-       darktable.develop->history_end,
-       dt_ioppr_iop_order_copy_deep(darktable.develop->iop_order_list));
+    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_WILL_CHANGE);
 
   // we must pay attention if priority is 0
   const gboolean is_zero = (module->multi_priority == 0);
@@ -594,9 +590,7 @@ static void _gui_delete_callback(GtkButton *button, dt_iop_module_t *module)
 
   // we save the current state of history (with the new multi_priorities)
   if(dev->gui_attached)
-  {
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_CHANGE);
-  }
 
   // rebuild the accelerators (to point to an extant module)
   dt_iop_connect_accels_multi(module->so);

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -589,6 +589,7 @@ static void _pop_undo(gpointer user_data, dt_undo_type_t type,
     GList *history_temp = NULL;
     int hist_end = 0;
 
+    g_list_free_full(dev->iop_order_list, free);
     if(action == DT_ACTION_UNDO)
     {
       history_temp = dt_history_duplicate(hist->before_snapshot);
@@ -634,13 +635,11 @@ static void _pop_undo(gpointer user_data, dt_undo_type_t type,
     dt_pthread_mutex_lock(&dev->history_mutex);
 
     // set history and modules to dev
-    GList *history_temp2 = dev->history;
+    g_list_free_full(dev->history, dt_dev_free_history_item);
     dev->history = history_temp;
     dev->history_end = hist_end;
-    g_list_free_full(history_temp2, dt_dev_free_history_item);
-    GList *iop_temp2 = dev->iop;
+    g_list_free(dev->iop);
     dev->iop = iop_temp;
-    g_list_free(iop_temp2);
 
     // topology has changed
     if(pipe_remove)

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -57,7 +57,6 @@ typedef struct dt_lib_history_t
   int record_history_level; // set to +1 in signal DT_SIGNAL_DEVELOP_HISTORY_WILL_CHANGE
                             // and back to -1 in DT_SIGNAL_DEVELOP_HISTORY_CHANGE. We want
                             // to avoid multiple will-change before a change cb.
-  // previous_* below store values sent by signal DT_SIGNAL_DEVELOP_HISTORY_WILL_CHANGE
   GList *previous_snapshot;
   int previous_history_end;
   GList *previous_iop_order_list;
@@ -82,11 +81,7 @@ static gboolean _lib_history_button_clicked_callback(GtkWidget *widget,
 static void _lib_history_create_style_button_clicked_callback(GtkWidget *widget,
                                                               gpointer user_data);
 /* signal callback for history change */
-static void _lib_history_will_change_callback(gpointer instance,
-                                              GList *history,
-                                              const int history_end,
-                                              GList *iop_order_list,
-                                              gpointer user_data);
+static void _lib_history_will_change_callback(gpointer instance, gpointer user_data);
 
 static void _lib_history_change_callback(gpointer instance, gpointer user_data);
 
@@ -698,27 +693,18 @@ static void _lib_history_module_remove_callback(gpointer instance,
   dt_undo_iterate(darktable.undo, DT_UNDO_HISTORY, module, &_history_invalidate_cb);
 }
 
-static void _lib_history_will_change_callback(gpointer instance,
-                                              GList *history,
-                                              const int history_end,
-                                              GList *iop_order_list,
-                                              gpointer user_data)
+static void _lib_history_will_change_callback(gpointer instance, gpointer user_data)
 {
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_history_t *lib = (dt_lib_history_t *)self->data;
 
-  if(lib->record_undo && (lib->record_history_level == 0))
+  if(lib->record_history_level++ == 0 && lib->record_undo)
   {
-    // history is about to change, here we want to record as snapshot
-    // of the history for the undo record previous history
-    g_list_free_full(lib->previous_snapshot, free);
-    g_list_free_full(lib->previous_iop_order_list, free);
-    lib->previous_snapshot = history;
-    lib->previous_history_end = history_end;
-    lib->previous_iop_order_list = iop_order_list;
+    lib->previous_snapshot = dt_history_duplicate(darktable.develop->history);
+    lib->previous_history_end = darktable.develop->history_end;
+    lib->previous_iop_order_list =
+      dt_ioppr_iop_order_copy_deep(darktable.develop->iop_order_list);
   }
-
-  lib->record_history_level += 1;
 }
 
 static gchar *_lib_history_change_text(dt_introspection_field_t *field,
@@ -1122,16 +1108,17 @@ static void _lib_history_change_callback(gpointer instance, gpointer user_data)
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_history_t *d = (dt_lib_history_t *)self->data;
 
-
-  d->record_history_level -= 1;
-
-  if(d->record_undo == TRUE && (d->record_history_level == 0))
+  if(--d->record_history_level == 0 && d->record_undo == TRUE)
   {
     /* record undo/redo history snapshot */
     dt_undo_history_t *hist = malloc(sizeof(dt_undo_history_t));
-    hist->before_snapshot = dt_history_duplicate(d->previous_snapshot);
+    hist->before_snapshot = d->previous_snapshot;
     hist->before_end = d->previous_history_end;
-    hist->before_iop_order_list = dt_ioppr_iop_order_copy_deep(d->previous_iop_order_list);
+    hist->before_iop_order_list = d->previous_iop_order_list;
+
+    d->previous_snapshot = NULL;
+    d->previous_history_end = 0;
+    d->previous_iop_order_list = NULL;
 
     hist->after_snapshot = dt_history_duplicate(darktable.develop->history);
     hist->after_end = darktable.develop->history_end;


### PR DESCRIPTION
Now fixed up and working correctly, see https://github.com/darktable-org/darktable/pull/14177#issuecomment-1508683484

Following up from https://github.com/darktable-org/darktable/pull/14157#issuecomment-1502891964 this PR is purely meant for experimentation and discussion, which is hampered when doing it in an issue because it is harder for people to try out the code changes being discussed (or to clearly describe them).

The "problem" I'm highlighting here is that when dragging a slider, each mouse motion update triggers a history change _and_ an update of undo/redo information, which requires a full copy of the previous and new histories. This has three consequences:
- it creates a lag (only noticeable on slower computers presumably so the main developers won't notice)
- it uses a lot of memory? I'm not familiar with this whole subsystem, so don't know when/if ever this gets released/recycled.
- It makes undo somewhat useless, because for each drag, you have to press undo many times to get to the state before.

This PR experiments with bracketing a slider drag between `dt_dev_undo_start_record` and `dt_dev_undo_end_record` calls. This _should_ (and does) prevent intermediate undo points being created _during_ the drag. But unfortunately `dt_dev_undo_start_record` would still get called for each motion update and create a copy (only for it to be silently dropped, a memory leak, by the signal handler). So to see full the impact, I've removed those calls from `_dev_add_history_item` which means undo/redo is broking everywhere else that is not a slider drag (this is just an experiment!)

If this PR demonstrates a clear gain to be made, the following question is how deep changes need to be and what the wished for outcome would be. _Just_ fixing slider drags means we don't do anything about slider changes using scrolling, shortcuts or multiple clicks, since these don't have an overall beginning and end. Modules using graphs also wouldn't benefit, nor would drawn mask changes.

One suggestion could be to only create an undo point whenever a different "item" (widget, slider/combo, graph point, shape property) is modified compared to the previous change. Maybe with a timeout. This would either require calls to `dt_dev_undo_start_record` to receive an identifier of the current "item" or to figure it out for itself (using introspection? probably slow and it would need to intelligently decide what is one "item"). `dt_dev_add_history_item` gets called in 263 places so making it more intelligent everywhere is a no-go, but definitely bauhaus could switch to a more specific version and masks probably too.

I'm not sure if `dt_dev_undo_end_record` would still be needed in its current form. Maybe rather than updating after each change, a "redo" point would be created only when undoing to the last undo point?

Could we avoid making a full copy of history before deciding if we need it? This may need to limit this to the gui thread only so that we don't have to worry about thread safety/intermediate changes and don't need signals. But I'm not sure if changing history "outside" of the gui thread is supported (and working and used) currently anyway.