### PR TITLE
Postpone update of libs until visible and drawn

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -160,7 +160,7 @@ typedef int32_t dt_imgid_t;
 /* Helper to force stack vectors to be aligned on 64 bits blocks to enable AVX2 */
 #define DT_IS_ALIGNED(x) __builtin_assume_aligned(x, 64)
 
-#define DT_MODULE_VERSION 24 // version of dt's module interface
+#define DT_MODULE_VERSION 25 // version of dt's module interface
 
 // version of current performance configuration version
 // if you want to run an updated version of the performance configuration later

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2455,9 +2455,7 @@ static void _header_size_callback(GtkWidget *widget,
   g_list_free(children);
   g_free(config);
 
-  GtkAllocation header_allocation;
-  gtk_widget_get_allocation(header, &header_allocation);
-  if(header_allocation.width > 1) gtk_widget_size_allocate(header, &header_allocation);
+  dt_gui_widget_reallocate_now(header);
 }
 
 gboolean dt_iop_show_hide_header_buttons(dt_iop_module_t *module,

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3314,6 +3314,14 @@ void dt_gui_draw_rounded_rectangle(cairo_t *cr, float width, float height, float
   cairo_fill(cr);
 }
 
+void dt_gui_widget_reallocate_now(GtkWidget *widget)
+{
+  GtkAllocation allocation = {};
+  gtk_widget_get_allocation(widget, &allocation);
+  if(allocation.width > 1)
+    gtk_widget_size_allocate(widget, &allocation);
+}
+
 gboolean dt_gui_search_start(GtkWidget *widget, GdkEventKey *event, GtkSearchEntry *entry)
 {
   if(gtk_search_entry_handle_event(entry, (GdkEvent *)event))

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -449,6 +449,8 @@ void dt_gui_menu_popup(GtkMenu *menu, GtkWidget *button, GdkGravity widget_ancho
 
 void dt_gui_draw_rounded_rectangle(cairo_t *cr, float width, float height, float x, float y);
 
+void dt_gui_widget_reallocate_now(GtkWidget *widget);
+
 // event handler for "key-press-event" of GtkTreeView to decide if focus switches to GtkSearchEntry
 gboolean dt_gui_search_start(GtkWidget *widget, GdkEventKey *event, GtkSearchEntry *entry);
 

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2210,6 +2210,12 @@ static void _lib_collect_update_history_visibility(dt_lib_module_t *self)
   gtk_widget_set_visible(d->history_box, !hide);
 }
 
+void gui_update(dt_lib_module_t *self)
+{
+  dt_lib_collect_t *d = (dt_lib_collect_t *)self->data;
+  update_view(d->rule + d->active_rule);
+}
+
 static void _lib_collect_gui_update(dt_lib_module_t *self)
 {
   dt_lib_collect_t *d = (dt_lib_collect_t *)self->data;
@@ -2275,7 +2281,7 @@ static void _lib_collect_gui_update(dt_lib_module_t *self)
 
   // update list of proposals
   d->active_rule = active;
-  update_view(d->rule + d->active_rule);
+  dt_lib_gui_queue_update(self);
   --darktable.gui->reset;
 }
 

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -171,9 +171,8 @@ uint32_t container(dt_lib_module_t *self)
     return DT_UI_CONTAINER_PANEL_RIGHT_CENTER;
 }
 
-static void _update(dt_lib_module_t *self)
+void gui_update(dt_lib_module_t *self)
 {
-  dt_lib_cancel_postponed_update(self);
   const dt_lib_export_t *d = (dt_lib_export_t *)self->data;
 
   const gboolean has_act_on = (dt_act_on_get_images_nb(TRUE, FALSE) > 0);
@@ -188,19 +187,19 @@ static void _update(dt_lib_module_t *self)
 
 static void _image_selection_changed_callback(gpointer instance, dt_lib_module_t *self)
 {
-  _update(self);
+  dt_lib_gui_queue_update(self);
 }
 
 static void _collection_updated_callback(gpointer instance, dt_collection_change_t query_change,
                                          dt_collection_properties_t changed_property, gpointer imgs, int next,
                                          dt_lib_module_t *self)
 {
-  _update(self);
+  dt_lib_gui_queue_update(self);
 }
 
 static void _mouse_over_image_callback(gpointer instance, dt_lib_module_t *self)
 {
-  dt_lib_queue_postponed_update(self, _update);
+  dt_lib_gui_queue_update(self);
 }
 
 gboolean _is_int(double value)
@@ -590,7 +589,7 @@ void gui_reset(dt_lib_module_t *self)
   dt_imageio_module_storage_t *mstorage = dt_imageio_get_storage();
   if(mstorage) mstorage->gui_reset(mstorage);
 
-  _update(self);
+  dt_lib_gui_queue_update(self);
 }
 
 static void set_format_by_name(dt_lib_export_t *d, const char *name)
@@ -1053,7 +1052,6 @@ void set_preferences(void *menu, dt_lib_module_t *self)
 void gui_init(dt_lib_module_t *self)
 {
   dt_lib_export_t *d = (dt_lib_export_t *)malloc(sizeof(dt_lib_export_t));
-  self->timeout_handle = 0;
   self->data = (void *)d;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
@@ -1375,7 +1373,6 @@ void gui_init(dt_lib_module_t *self)
 
 void gui_cleanup(dt_lib_module_t *self)
 {
-  dt_lib_cancel_postponed_update(self);
   dt_lib_export_t *d = (dt_lib_export_t *)self->data;
 
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_on_storage_list_changed), self);

--- a/src/libs/lib.h
+++ b/src/libs/lib.h
@@ -100,10 +100,8 @@ typedef struct dt_lib_module_t
   GtkWidget *widget;
   /** expander containing the widget. */
   GtkWidget *expander;
-  /** callback for delayed update after user interaction */
-  void (*_postponed_update)(struct dt_lib_module_t *self);
-  /** ID of timer for delayed callback */
-  guint timeout_handle;
+  /** does gui need to be updated if visible */
+  gboolean gui_uptodate;
 
   GtkWidget *arrow;
   GtkWidget *reset_button;
@@ -119,6 +117,8 @@ GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module);
 void dt_lib_gui_set_expanded(dt_lib_module_t *module, gboolean expanded);
 /** get the expanded state of a plugin */
 gboolean dt_lib_gui_get_expanded(dt_lib_module_t *module);
+/** queue plugin gui to be updated if visible */
+void dt_lib_gui_queue_update(dt_lib_module_t *module);
 
 extern const struct dt_action_def_t dt_action_def_lib;
 
@@ -140,11 +140,6 @@ gchar *dt_lib_get_localized_name(const gchar *plugin_name);
 /** add or replace a preset for this operation. */
 void dt_lib_presets_add(const char *name, const char *plugin_name, const int32_t version, const void *params,
                         const int32_t params_size, gboolean readonly);
-
-/** queue a delayed call of update function after user interaction */
-void dt_lib_queue_postponed_update(dt_lib_module_t *mod, void (*update_fn)(dt_lib_module_t *self));
-/** cancel any previously-queued callback */
-void dt_lib_cancel_postponed_update(dt_lib_module_t *mod);
 
 // apply a preset to the given module
 gboolean dt_lib_presets_apply(const gchar *preset, const gchar *module_name, int module_version);

--- a/src/libs/lib_api.h
+++ b/src/libs/lib_api.h
@@ -60,6 +60,10 @@ REQUIRED(void, gui_init, struct dt_lib_module_t *self);
 REQUIRED(void, gui_cleanup, struct dt_lib_module_t *self);
 /** reset to defaults. */
 OPTIONAL(void, gui_reset, struct dt_lib_module_t *self);
+/** update libs gui when visible
+    triggered by dt_lib_gui_queue_update.
+    don't use for widgets accessible via actions when hidden. */
+OPTIONAL(void, gui_update, struct dt_lib_module_t *self);
 
 /** entering a view, only called if lib is displayed on the new view */
 OPTIONAL(void, view_enter, struct dt_lib_module_t *self, struct dt_view_t *old_view, struct dt_view_t *new_view);

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1621,7 +1621,7 @@ GList *_lib_masks_get_selected(dt_lib_module_t *self)
   return res;
 }
 
-static void _lib_masks_recreate_list(dt_lib_module_t *self)
+void gui_update(dt_lib_module_t *self)
 {
   /* first destroy all buttons in list */
   dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
@@ -1629,7 +1629,6 @@ static void _lib_masks_recreate_list(dt_lib_module_t *self)
   if(darktable.gui->reset) return;
 
   ++darktable.gui->reset;
-  // if(lm->treeview) gtk_widget_destroy(lm->treeview);
 
   // if a treeview is already present, let's get the currently selected items
   // as we are going to recreate the tree.
@@ -1712,7 +1711,21 @@ static void _lib_masks_recreate_list(dt_lib_module_t *self)
 
   --darktable.gui->reset;
 
+  dt_gui_widget_reallocate_now(lm->treeview);
+}
+
+static void _lib_masks_recreate_list(dt_lib_module_t *self)
+{
+  dt_lib_masks_t *lm = self->data;
+  dt_lib_gui_queue_update(self);
+
+  if(darktable.gui->reset) return;
+  ++darktable.gui->reset;
+
   _update_all_properties(lm);
+
+  --darktable.gui->reset;
+
 }
 
 static gboolean _update_foreach(GtkTreeModel *model,

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -462,7 +462,7 @@ static int lua_update_metadata(lua_State*L);
 #endif
 
 /* update all values to reflect mouse over image id or no data at all */
-static void _metadata_view_update_values(dt_lib_module_t *self)
+void gui_update(dt_lib_module_t *self)
 {
   int32_t mouse_over_id = dt_control_get_mouse_over_id();
   int32_t count = 0;
@@ -1035,7 +1035,7 @@ static void _jump_to_accel(dt_action_t *data)
 static void _mouse_over_image_callback(gpointer instance, gpointer user_data)
 {
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
-  if(dt_control_running()) _metadata_view_update_values(self);
+  if(dt_control_running()) dt_lib_gui_queue_update(self);
 }
 
 static char *_get_current_configuration(dt_lib_module_t *self)

--- a/src/libs/select.c
+++ b/src/libs/select.c
@@ -55,7 +55,7 @@ typedef struct dt_lib_select_t
       *select_untouched_button;
 } dt_lib_select_t;
 
-static void _update(dt_lib_module_t *self)
+void gui_update(dt_lib_module_t *self)
 {
   dt_lib_select_t *d = (dt_lib_select_t *)self->data;
 
@@ -75,7 +75,7 @@ static void _update(dt_lib_module_t *self)
 
 static void _image_selection_changed_callback(gpointer instance, dt_lib_module_t *self)
 {
-  _update(self);
+  dt_lib_gui_queue_update(self);
 #ifdef USE_LUA
   dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
     0, NULL,NULL,
@@ -88,7 +88,7 @@ static void _collection_updated_callback(gpointer instance, dt_collection_change
                                          dt_collection_properties_t changed_property, gpointer imgs, int next,
                                          dt_lib_module_t *self)
 {
-  _update(self);
+  dt_lib_gui_queue_update(self);
 }
 
 static void button_clicked(GtkWidget *widget, gpointer user_data)
@@ -157,8 +157,6 @@ void gui_init(dt_lib_module_t *self)
                             G_CALLBACK(_image_selection_changed_callback), self);
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
                             G_CALLBACK(_collection_updated_callback), self);
-
-  _update(self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)

--- a/src/libs/tools/timeline.c
+++ b/src/libs/tools/timeline.c
@@ -805,7 +805,11 @@ static void _lib_timeline_collection_changed(gpointer instance, dt_collection_ch
                                              dt_collection_properties_t changed_property, gpointer imgs, int next,
                                              gpointer user_data)
 {
-  dt_lib_module_t *self = (dt_lib_module_t *)user_data;
+  dt_lib_gui_queue_update(user_data);
+}
+
+void gui_update(dt_lib_module_t *self)
+{
   dt_lib_timeline_t *strip = (dt_lib_timeline_t *)self->data;
 
   // we read the collect bounds
@@ -820,7 +824,6 @@ static void _lib_timeline_collection_changed(gpointer instance, dt_collection_ch
   // in any case we redraw the strip (to reflect any selected image change)
   cairo_surface_destroy(strip->surface);
   strip->surface = NULL;
-  gtk_widget_queue_draw(strip->timeline);
 }
 
 
@@ -1419,9 +1422,6 @@ void gui_init(dt_lib_module_t *self)
                    self);
 
   gtk_box_pack_start(GTK_BOX(self->widget), d->timeline, TRUE, TRUE, 0);
-
-  // we update the selection with actual collect rules
-  _lib_timeline_collection_changed(NULL, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL, -1, self);
 
   gtk_widget_show_all(self->widget);
   /* initialize view manager proxy */


### PR DESCRIPTION
Restarting the delayed gui update part of #10846 with a more generic and centrally supported approach that introduces the `gui_update` optional member function for libs. This will only get called when the lib is visible (i.e. itself nor its panel hidden). An update is triggered by calling `dt_lib_gui_queue_update` (usually from signal handlers) and again is only processed if the panel is visible or when it gets unhidden.

Submitting this now because I wanted to use the framework for the history and masks modules as well. They completely tear down their lists and rebuild them on each update and since this framework does that in the "draw" signal, a fix was required to avoid flickering (otherwise the new widgets would only get allocated just before the _next_ draw but by then another update might have been received leading to drawing possibly getting postponed forever). I'm hopeful that the workaround also fixes the issue mentioned here https://github.com/darktable-org/darktable/pull/14157#issuecomment-1501154422. @zisoft would you be willing to test?

This PR _only_ introduces the delayed widget update (and integrates a previous mechanism, `dt_lib_queue_postponed_update` with the same purpose). The other changes in #10846 optimising/changing collection signals have not been included in order to simplify testing. I believe the issue with filmstrips not refreshing is not happening here. @ralfbrown would you want to revisit/rebase (preferably after this gets merged)?