### PR TITLE
po/masks edit - another (and probably last for 4.4) usability enhacement for the masks

### DIFF
--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -95,14 +95,17 @@ static void _circle_get_distance(const float x,
   *dist = fminf(*dist, bd);
 
   // we check if it's inside borders
-  if(!dt_masks_point_in_form_exact(x, y, gpt->border, 1, gpt->border_count)) return;
+  if(!dt_masks_point_in_form_near(x, y, gpt->border, 1, gpt->border_count, as, near))
+  {
+    if(*near != -1)
+      *inside_border = TRUE;
+    else
+      return;
+  }
+  else
+    *inside_border= TRUE;
 
   *inside = TRUE;
-  *near = 0;
-
-  // and we check if it's inside form
-  *inside_border = !(dt_masks_point_in_form_near(x, y, gpt->points, 1,
-                                                 gpt->points_count, as, near));
 }
 
 static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module,

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2311,10 +2311,11 @@ int dt_masks_point_in_form_near(const float x,
                                 int *near)
 {
   // we use ray casting algorithm to avoid most problems with
-  // horizontal segments, y should be rounded as int so that there's
-  // very little chance than y==points...
+  // horizontal segments.
 
-  // TODO : distance is only evaluated in x, not y...
+  const float distance2 = sqf(distance);
+
+  *near = -1;
 
   if(points_count > 2 + points_start)
   {
@@ -2326,8 +2327,14 @@ int dt_masks_point_in_form_near(const float x,
     int nb = 0;
     for(int i = start, next = start + 1; i < points_count;)
     {
+      const float x1 = points[i * 2];
       const float y1 = points[i * 2 + 1];
       const float y2 = points[next * 2 + 1];
+      const float dd = sqf(x1 - x) + sqf(y1 - y);
+
+      if(dd < distance2)
+        *near = i * 2;
+
       //if we need to jump to skip points (in case of deleted point,
       //because of self-intersection)
       if(isnan(points[next * 2]))
@@ -2338,11 +2345,8 @@ int dt_masks_point_in_form_near(const float x,
       if((y <= y2 && y > y1)
          || (y >= y2 && y < y1))
       {
-        if(points[i * 2] > x)
+        if(x1 > x)
           nb++;
-        if(points[i * 2] - x < distance
-           && points[i * 2] - x > -distance)
-          *near = i * 2;
       }
 
       if(next == start) break;

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1046,9 +1046,19 @@ static void _path_get_distance(const float x,
   }
 
   // we check if it's inside borders
-  if(!dt_masks_point_in_form_exact(x, y, gpt->border,
-                                   _nb_ctrl_point(corner_count), gpt->border_count))
-    return;
+  if(!dt_masks_point_in_form_near(x, y, gpt->border,
+                                  _nb_ctrl_point(corner_count), gpt->border_count,
+                                  as, near))
+  {
+    if(*near != -1)
+    {
+      *inside_border = TRUE;
+    }
+    else
+      return;
+  }
+  else
+    *inside_border = TRUE;
 
   *inside = TRUE;
 
@@ -1058,7 +1068,6 @@ static void _path_get_distance(const float x,
     const float as2 = sqf(as);
     float last = gpt->points[gpt->points_count * 2 - 1];
     int nb = 0;
-    int near_form = 0;
     int current_seg = 1;
 
     float x_min = FLT_MAX, y_min = FLT_MAX;
@@ -1095,7 +1104,6 @@ static void _path_get_distance(const float x,
 
       if(dd < as2)
       {
-        near_form = 1;
         if(current_seg == 0)
           *near = corner_count - 1;
         else
@@ -1108,7 +1116,6 @@ static void _path_get_distance(const float x,
 
       last = yy;
     }
-    *inside_border = !((nb & 1) || (near_form));
 
     const float cx = x - (x_min + (x_max - x_min) / 2.0f);
     const float cy = y - (y_min + (y_max - y_min) / 2.0f);
@@ -2190,6 +2197,8 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module,
   float dist = 0;
   _path_get_distance(pzx, pzy, as, gui, index, nb, &in, &inb, &near, &ins, &dist);
   gui->seg_selected = near;
+
+  // no segment selected, set form or source selection
   if(near < 0)
   {
     if(ins)


### PR DESCRIPTION
masks: Allow for small border distance to select control point.
    
It was somewhat difficult to select the border control for a path,
circle or ellipse because it was necessary to be inside the border.
That is, the cursor had to be inside the border to be able to drag
the control points. So half of the control point (the part outside
of the border) was inactive making it hard to select.
    
This is now fixed by allowing a small distance from from the border
to be able to select a control point.


This was the last point I wanted to fix. With all my last changes in masks the usability has greatly improved and the display for all mask is now consistent.