### PR TITLE
Show the full-frame equivalent focal length in the image information module

### DIFF
--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -739,12 +739,12 @@ void gui_update(dt_lib_module_t *self)
 
       case md_exif_focal_length:
         if(img->exif_crop && (img->exif_crop != 1.0f))
-          (void)g_snprintf(text, sizeof(text), "%.0f mm (%.0f mm FF equiv, crop %.0f)",
+          (void)g_snprintf(text, sizeof(text), _("%.0f mm (%.0f mm FF equiv, crop %.0f)"),
                            (double)img->exif_focal_length,
                            (double)img->exif_crop * img->exif_focal_length,
                            (double)img->exif_crop);
         else
-          (void)g_snprintf(text, sizeof(text), "%.0f mm", (double)img->exif_focal_length);
+          (void)g_snprintf(text, sizeof(text), _("%.0f mm"), (double)img->exif_focal_length);
         _metadata_update_value(md_exif_focal_length, text, self);
         break;
 

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -739,12 +739,12 @@ void gui_update(dt_lib_module_t *self)
 
       case md_exif_focal_length:
         if(img->exif_crop && (img->exif_crop != 1.0f))
-          (void)g_snprintf(text, sizeof(text), _("%.0f mm (%.0f mm FF equiv, crop %.0f)"),
+          (void)g_snprintf(text, sizeof(text), _("%.1f mm (%.1f mm FF equiv, crop %.1f)"),
                            (double)img->exif_focal_length,
                            (double)img->exif_crop * img->exif_focal_length,
                            (double)img->exif_crop);
         else
-          (void)g_snprintf(text, sizeof(text), _("%.0f mm"), (double)img->exif_focal_length);
+          (void)g_snprintf(text, sizeof(text), _("%.1f mm"), (double)img->exif_focal_length);
         _metadata_update_value(md_exif_focal_length, text, self);
         break;
 

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2022 darktable developers.
+    Copyright (C) 2011-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -738,7 +738,13 @@ void gui_update(dt_lib_module_t *self)
         break;
 
       case md_exif_focal_length:
-        (void)g_snprintf(text, sizeof(text), "%.0f mm", (double)img->exif_focal_length);
+        if(img->exif_crop && (img->exif_crop != 1.0f))
+          (void)g_snprintf(text, sizeof(text), "%.0f mm (%.0f mm FF equiv, crop %.0f)",
+                           (double)img->exif_focal_length,
+                           (double)img->exif_crop * img->exif_focal_length,
+                           (double)img->exif_crop);
+        else
+          (void)g_snprintf(text, sizeof(text), "%.0f mm", (double)img->exif_focal_length);
         _metadata_update_value(md_exif_focal_length, text, self);
         break;
 


### PR DESCRIPTION
Closes #14155.

Additional information is not shown when we know that the sensor is full-frame, this will obviously be redundant. Also, image metadata does not always directly contain data on the equivalent focal length. In some cases, such information can be calculated from other available data (this is the case, for example, with Canon cameras), but this is a separate issue.

Also added precision to the displayed focal length. Even for camera zoom lenses, the focal length will not always be a whole number. As for the actual focal length of optics in smartphones, it is several times shorter. Therefore, if the true focal length for the smartphone image was, say, 1.9 mm, and we discarded the decimal part and showed it as 1 mm, then in percentage terms this is a huge inaccuracy.
