### PR TITLE
Fixed an inaccuracy in the description of the introduced change

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -555,8 +555,8 @@ The following is a summary of the main features added to darktable
 
 - Set imported EXR image size to the extent of valid data window only.
 
-- Properly translate the collection names in the recent collection
-  history pop-up.
+- Properly translate collection sort names in the recent collection
+  sort history pop-up.
 
 ## Lua
 


### PR DESCRIPTION
This refers to the description of the fix from #14179.
The translation was fixed not for collection names, but for sort names in collection filters.