### PR TITLE
maintenance: eliminate NaN as marker value (part 2)

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -16,6 +16,14 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+// dt_calculator_solve returns NAN on ill-formed input, so we need to tell the compiler
+// that non-finite numbers are in use in this source file even if we have globally
+// enabled the finite-math-only optimization.  Otherwise, it may optimize away
+// conditionals based on isnan() or isfinite().
+#ifdef __GNUC__
+#pragma GCC optimize ("no-finite-math-only")
+#endif
+
 #include "bauhaus/bauhaus.h"
 #include "common/calculator.h"
 #include "common/darktable.h"

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1995,7 +1995,7 @@ void dt_image_init(dt_image_t *img)
   g_strlcpy(img->filename, "(unknown)", sizeof(img->filename));
   img->exif_crop = 1.0;
   img->exif_exposure = 0;
-  img->exif_exposure_bias = NAN;
+  img->exif_exposure_bias = DT_EXIF_TAG_UNINITIALIZED;
   img->exif_aperture = 0;
   img->exif_iso = 0;
   img->exif_focal_length = 0;
@@ -3006,11 +3006,10 @@ float dt_image_get_exposure_bias(const struct dt_image_t *image_storage)
   if((image_storage) && (image_storage->exif_exposure_bias))
   {
     // sanity checks because I don't trust exif tags too much
-    if(image_storage->exif_exposure_bias == NAN
+    if(image_storage->exif_exposure_bias == DT_EXIF_TAG_UNINITIALIZED
        || image_storage->exif_exposure_bias != image_storage->exif_exposure_bias
-       || isnan(image_storage->exif_exposure_bias)
        || CLAMP(image_storage->exif_exposure_bias, -5.0f, 5.0f) != image_storage->exif_exposure_bias)
-      return 0.0f; // isnan
+      return 0.0f;
     else
       return CLAMP(image_storage->exif_exposure_bias, -5.0f, 5.0f);
   }

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -127,6 +127,8 @@ typedef enum dt_exif_image_orientation_t
   EXIF_ORIENTATION_TRANSVERSE        = 7
 } dt_exif_image_orientation_t;
 
+#define DT_EXIF_TAG_UNINITIALIZED (-FLT_MAX)
+
 typedef enum dt_image_orientation_t
 {
   ORIENTATION_NULL    = -1,     //-1, or autodetect

--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -118,7 +118,7 @@ void dt_image_cache_allocate(void *data,
     if(sqlite3_column_type(stmt, 28) == SQLITE_FLOAT)
       img->exif_exposure_bias = sqlite3_column_double(stmt, 28);
     else
-      img->exif_exposure_bias = NAN;
+      img->exif_exposure_bias = DT_EXIF_TAG_UNINITIALIZED;
     img->import_timestamp = sqlite3_column_int64(stmt, 29);
     img->change_timestamp = sqlite3_column_int64(stmt, 30);
     img->export_timestamp = sqlite3_column_int64(stmt, 31);

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -130,7 +130,7 @@ static void _init_expansion(dt_variables_params_t *params, gboolean iterate)
   params->data->version = 0;
   params->data->stars = 0;
   params->data->exif_exposure = 0.0f;
-  params->data->exif_exposure_bias = NAN;
+  params->data->exif_exposure_bias = DT_EXIF_TAG_UNINITIALIZED;
   params->data->exif_aperture = 0.0f;
   params->data->exif_focal_length = 0.0f;
   params->data->exif_focus_distance = 0.0f;
@@ -384,7 +384,7 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
   else if(_has_prefix(variable, "EXIF.EXPOSURE.BIAS")
           || _has_prefix(variable, "EXIF_EXPOSURE_BIAS"))
   {
-    if(!isnan(params->data->exif_exposure_bias))
+    if(params->data->exif_exposure_bias != DT_EXIF_TAG_UNINITIALIZED)
       result = g_strdup_printf("%+.2f", params->data->exif_exposure_bias);
   }
   else if(_has_prefix(variable, "EXIF.EXPOSURE")

--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2019-2021 darktable developers.
+    Copyright (C) 2019-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,14 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+// dt_calculator_solve returns NAN on ill-formed input, so we need to tell the compiler
+// that non-finite numbers are in use in this source file even if we have globally
+// enabled the finite-math-only optimization.  Otherwise, it may optimize away
+// conditionals based on isnan() or isfinite().
+#ifdef __GNUC__
+#pragma GCC optimize ("no-finite-math-only")
+#endif
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -396,6 +396,10 @@ typedef struct dt_masks_form_gui_t
   uint64_t pipe_hash;
 } dt_masks_form_gui_t;
 
+/** special value to indicate an invalid or unitialized coordinate (replaces */
+/** former use of NAN and isnan() by the most negative float) **/
+#define DT_INVALID_COORDINATE (-FLT_MAX)
+
 /** the shape-specific function tables */
 extern const dt_masks_functions_t dt_masks_functions_circle;
 extern const dt_masks_functions_t dt_masks_functions_ellipse;

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -244,8 +244,8 @@ static void _brush_border_get_XY(const float p0x,
   // so we can have the resulting point
   if(dx == 0 && dy == 0)
   {
-    *xb = NAN;
-    *yb = NAN;
+    *xb = DT_INVALID_COORDINATE;
+    *yb = DT_INVALID_COORDINATE;
     return;
   }
   const float l = 1.0f / sqrtf(dx * dx + dy * dy);
@@ -597,7 +597,7 @@ static void _brush_points_recurs(float *p1,
   const gboolean withpayload = (dpayload != NULL);
 
   // we calculate points if needed
-  if(isnan(points_min[0]))
+  if(points_min[0] == DT_INVALID_COORDINATE)
   {
     _brush_border_get_XY(p1[0], p1[1], p1[2], p1[3],
                          p2[2], p2[3], p2[0], p2[1], tmin,
@@ -605,7 +605,7 @@ static void _brush_points_recurs(float *p1,
                          points_min,
                          points_min + 1, border_min, border_min + 1);
   }
-  if(isnan(points_max[0]))
+  if(points_max[0] == DT_INVALID_COORDINATE)
   {
     _brush_border_get_XY(p1[0], p1[1], p1[2], p1[3],
                          p2[2], p2[3], p2[0], p2[1], tmax,
@@ -631,12 +631,12 @@ static void _brush_points_recurs(float *p1,
 
     if(withborder)
     {
-      if(isnan(border_max[0]))
+      if(border_max[0] == DT_INVALID_COORDINATE)
       {
         border_max[0] = border_min[0];
         border_max[1] = border_min[1];
       }
-      else if(isnan(border_min[0]))
+      else if(border_min[0] == DT_INVALID_COORDINATE)
       {
         border_min[0] = border_max[0];
         border_min[1] = border_max[1];
@@ -670,7 +670,8 @@ static void _brush_points_recurs(float *p1,
 
   // we split in two part
   double tx = (tmin + tmax) / 2.0;
-  float c[2] = { NAN, NAN }, b[2] = { NAN, NAN };
+  float c[2] = { DT_INVALID_COORDINATE, DT_INVALID_COORDINATE };
+  float b[2] = { DT_INVALID_COORDINATE, DT_INVALID_COORDINATE };
   float rc[2], rb[2], rp[2];
   _brush_points_recurs(p1, p2, tmin, tx, points_min, c,
                        border_min, b, rc, rb, rp, dpoints, dborder, dpayload);
@@ -961,10 +962,10 @@ static int _brush_get_pts_border(dt_develop_t *dev,
     // and we determine all points by recursion (to be sure the
     // distance between 2 points is <=1)
     float rc[2], rb[2], rp[2];
-    float bmin[2] = { NAN, NAN };
-    float bmax[2] = { NAN, NAN };
-    float cmin[2] = { NAN, NAN };
-    float cmax[2] = { NAN, NAN };
+    float bmin[2] = { DT_INVALID_COORDINATE, DT_INVALID_COORDINATE };
+    float bmax[2] = { DT_INVALID_COORDINATE, DT_INVALID_COORDINATE };
+    float cmin[2] = { DT_INVALID_COORDINATE, DT_INVALID_COORDINATE };
+    float cmax[2] = { DT_INVALID_COORDINATE, DT_INVALID_COORDINATE };
 
     _brush_points_recurs(p1, p2, 0.0, 1.0, cmin, cmax,
                          bmin, bmax, rc, rb, rp, dpoints, dborder, dpayload);
@@ -978,9 +979,9 @@ static int _brush_get_pts_border(dt_develop_t *dev,
 
     if(dborder)
     {
-      if(isnan(rb[0]))
+      if(rb[0] == DT_INVALID_COORDINATE)
       {
-        if(isnan(dt_masks_dynbuf_get(dborder, -2)))
+        if(dt_masks_dynbuf_get(dborder, -2) == DT_INVALID_COORDINATE)
         {
           dt_masks_dynbuf_set(dborder, -2, dt_masks_dynbuf_get(dborder, -4));
           dt_masks_dynbuf_set(dborder, -1, dt_masks_dynbuf_get(dborder, -3));
@@ -998,7 +999,7 @@ static int _brush_get_pts_border(dt_develop_t *dev,
       _brush_border_get_XY(p3[0], p3[1], p3[2], p3[3],
                            p4[2], p4[3], p4[0], p4[1], 0, p3[4], cmin, cmin + 1,
                            bmax, bmax + 1);
-      if(isnan(bmax[0]))
+      if(bmax[0] == DT_INVALID_COORDINATE)
       {
         _brush_border_get_XY(p3[0], p3[1], p3[2], p3[3],
                              p4[2], p4[3], p4[0], p4[1], 0.0001, p3[4], cmin,

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2270,8 +2270,8 @@ int dt_masks_point_in_form_exact(const float x,
 
   if(points_count > 2 + points_start)
   {
-    const int start = isnan(points[points_start * 2])
-      && !isnan(points[points_start * 2 + 1])
+    const int start = (points[points_start * 2] == DT_INVALID_COORDINATE
+                       && points[points_start * 2 + 1] != DT_INVALID_COORDINATE)
          ? points[points_start * 2 + 1]
          : points_start;
 
@@ -2283,9 +2283,9 @@ int dt_masks_point_in_form_exact(const float x,
       const float y2 = points[next * 2 + 1];
       //if we need to skip points (in case of deleted point, because
       //of self-intersection)
-      if(isnan(points[next * 2]))
+      if(points[next * 2] == DT_INVALID_COORDINATE)
       {
-        next = isnan(y2) ? start : (int)y2;
+        next = (y2 == DT_INVALID_COORDINATE) ? start : (int)y2;
         continue;
       }
       if(((y <= y2 && y > y1)
@@ -2320,7 +2320,7 @@ int dt_masks_point_in_form_near(const float x,
   if(points_count > 2 + points_start)
   {
     const int start =
-      isnan(points[points_start * 2]) && !isnan(points[points_start * 2 + 1])
+      (points[points_start * 2] == DT_INVALID_COORDINATE && points[points_start * 2 + 1] != DT_INVALID_COORDINATE)
       ? points[points_start * 2 + 1]
       : points_start;
 
@@ -2337,9 +2337,9 @@ int dt_masks_point_in_form_near(const float x,
 
       //if we need to jump to skip points (in case of deleted point,
       //because of self-intersection)
-      if(isnan(points[next * 2]))
+      if(points[next * 2] == DT_INVALID_COORDINATE)
       {
-        next = isnan(y2) ? start : (int)y2;
+        next = (y2 == DT_INVALID_COORDINATE) ? start : (int)y2;
         continue;
       }
       if((y <= y2 && y > y1)

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -113,8 +113,8 @@ static void _path_border_get_XY(const float p0x,
   // so we can have the resulting point
   if(dx == 0 && dy == 0)
   {
-    *xb = NAN;
-    *yb = NAN;
+    *xb = DT_INVALID_COORDINATE;
+    *yb = DT_INVALID_COORDINATE;
     return;
   }
   const double l = 1.0 / sqrt(dx * dx + dy * dy);
@@ -415,14 +415,14 @@ static void _path_points_recurs(float *p1,
                                 const int withborder)
 {
   // we calculate points if needed
-  if(isnan(path_min[0]))
+  if(path_min[0] == DT_INVALID_COORDINATE)
   {
     _path_border_get_XY(p1[0], p1[1], p1[2], p1[3], p2[2], p2[3], p2[0], p2[1], tmin,
                         p1[4] + (p2[4] - p1[4]) * tmin * tmin * (3.0 - 2.0 * tmin),
                         path_min, path_min + 1,
                         border_min, border_min + 1);
   }
-  if(isnan(path_max[0]))
+  if(path_max[0] == DT_INVALID_COORDINATE)
   {
     _path_border_get_XY(p1[0], p1[1], p1[2], p1[3], p2[2], p2[3], p2[0], p2[1], tmax,
                         p1[4] + (p2[4] - p1[4]) * tmax * tmax * (3.0 - 2.0 * tmax),
@@ -456,7 +456,8 @@ static void _path_points_recurs(float *p1,
 
   // we split in two part
   double tx = (tmin + tmax) / 2.0;
-  float c[2] = { NAN, NAN }, b[2] = { NAN, NAN };
+  float c[2] = { DT_INVALID_COORDINATE, DT_INVALID_COORDINATE };
+  float b[2] = { DT_INVALID_COORDINATE, DT_INVALID_COORDINATE };
   float rc[2] = { 0 }, rb[2] = { 0 };
   _path_points_recurs(p1, p2, tmin, tx, path_min, c, border_min, b, rc, rb,
                       dpoints, dborder, withborder);
@@ -480,7 +481,7 @@ static int _path_find_self_intersection(dt_masks_dynbuf_t *inter,
 
   for(int i = _nb_ctrl_point(nb_corners); i < border_count; i++)
   {
-    if(isnan(border[i * 2]) || isnan(border[i * 2 + 1]))
+    if((border[i * 2] == DT_INVALID_COORDINATE) || (border[i * 2 + 1] == DT_INVALID_COORDINATE))
     {
       border[i * 2] = border[i * 2 - 2];
       border[i * 2 + 1] = border[i * 2 - 1];
@@ -767,10 +768,10 @@ static int _path_get_pts_border(dt_develop_t *dev,
     // and we determine all points by recursion (to be sure the
     // distance between 2 points is <=1)
     float rc[2] = { 0 }, rb[2] = { 0 };
-    float bmin[2] = { NAN, NAN };
-    float bmax[2] = { NAN, NAN };
-    float cmin[2] = { NAN, NAN };
-    float cmax[2] = { NAN, NAN };
+    float bmin[2] = { DT_INVALID_COORDINATE, DT_INVALID_COORDINATE };
+    float bmax[2] = { DT_INVALID_COORDINATE, DT_INVALID_COORDINATE };
+    float cmin[2] = { DT_INVALID_COORDINATE, DT_INVALID_COORDINATE };
+    float cmax[2] = { DT_INVALID_COORDINATE, DT_INVALID_COORDINATE };
 
     _path_points_recurs(p1, p2, 0.0, 1.0, cmin, cmax, bmin, bmax,
                         rc, rb, dpoints, dborder, border && (nb >= 3));
@@ -789,9 +790,9 @@ static int _path_get_pts_border(dt_develop_t *dev,
 
     if(dborder)
     {
-      if(isnan(rb[0]))
+      if(rb[0] == DT_INVALID_COORDINATE)
       {
-        if(isnan(dt_masks_dynbuf_get(dborder, - 2)))
+        if(dt_masks_dynbuf_get(dborder, - 2) == DT_INVALID_COORDINATE)
         {
           dt_masks_dynbuf_set(dborder, -2, dt_masks_dynbuf_get(dborder, -4));
           dt_masks_dynbuf_set(dborder, -1, dt_masks_dynbuf_get(dborder, -3));
@@ -812,12 +813,12 @@ static int _path_get_pts_border(dt_develop_t *dev,
     {
       // we get the next point (start of the next segment) t=0.00001f
       // to workaround rounding effects with full optimization that
-      // result in bmax[0] NOT being set to NAN when t=0 and the two
-      // points in p3 are identical (as is the case on a control node
-      // set to sharp corner)
+      // result in bmax[0] NOT being set to DT_INVALID_COORDINATE when
+      // t=0 and the two points in p3 are identical (as is the case on
+      // a control node set to sharp corner)
       _path_border_get_XY(p3[0], p3[1], p3[2], p3[3], p4[2], p4[3], p4[0], p4[1],
                           0.00001f, p3[4], cmin, cmin + 1, bmax, bmax + 1);
-      if(isnan(bmax[0]))
+      if(bmax[0] == DT_INVALID_COORDINATE)
       {
         _path_border_get_XY(p3[0], p3[1], p3[2], p3[3], p4[2], p4[3], p4[0], p4[1],
                             0.00001f, p3[4], cmin, cmin + 1, bmax, bmax + 1);
@@ -943,23 +944,23 @@ static int _path_get_pts_border(dt_develop_t *dev,
           const int w = (dt_masks_dynbuf_buffer(intersections))[ i * 2 + 1];
           if(v <= w)
           {
-            (*border)[v * 2] = NAN;
+            (*border)[v * 2] = DT_INVALID_COORDINATE;
             (*border)[v * 2 + 1] = w;
           }
           else
           {
             if(w > _nb_ctrl_point(nb))
             {
-              if(isnan((*border)[nb * 6]) && isnan((*border)[nb * 6 + 1]))
+              if(((*border)[nb * 6] == DT_INVALID_COORDINATE) && ((*border)[nb * 6 + 1] == DT_INVALID_COORDINATE))
                 (*border)[nb * 6 + 1] = w;
-              else if(isnan((*border)[nb * 6]))
+              else if((*border)[nb * 6] == DT_INVALID_COORDINATE)
                 (*border)[nb * 6 + 1] = MAX((*border)[nb * 6 + 1], w);
               else
                 (*border)[nb * 6 + 1] = w;
-              (*border)[nb * 6] = NAN;
+              (*border)[nb * 6] = DT_INVALID_COORDINATE;
             }
-            (*border)[v * 2] = NAN;
-            (*border)[v * 2 + 1] = NAN;
+            (*border)[v * 2] = DT_INVALID_COORDINATE;
+            (*border)[v * 2 + 1] = DT_INVALID_COORDINATE;
           }
         }
       }
@@ -1075,9 +1076,9 @@ static void _path_get_distance(const float x,
     {
       //if we need to jump to skip points (in case of deleted point,
       //because of self-intersection)
-      if(isnan(gpt->points[i * 2]))
+      if(gpt->points[i * 2] == DT_INVALID_COORDINATE)
       {
-        if(isnan(gpt->points[i * 2 + 1]))
+        if(gpt->points[i * 2 + 1] == DT_INVALID_COORDINATE)
           break;
         i = (int)gpt->points[i * 2 + 1] - 1;
         continue;
@@ -2301,9 +2302,9 @@ static void _path_events_post_expose(cairo_t *cr,
     int dep = 1;
     for(int i = _nb_ctrl_point(nb); i < gpt->border_count; i++)
     {
-      if(isnan(gpt->border[i * 2]))
+      if(gpt->border[i * 2] == DT_INVALID_COORDINATE)
       {
-        if(isnan(gpt->border[i * 2 + 1])) break;
+        if(gpt->border[i * 2 + 1] == DT_INVALID_COORDINATE) break;
         i = gpt->border[i * 2 + 1] - 1;
         continue;
       }
@@ -2446,9 +2447,9 @@ static void _path_bounding_box_raw(const float *const points,
     // we look at the borders
     const float xx = border[i * 2];
     const float yy = border[i * 2 + 1];
-    if(isnan(xx))
+    if(xx == DT_INVALID_COORDINATE)
     {
-     if(isnan(yy)) break; // that means we have to skip the end of the border path
+     if(yy == DT_INVALID_COORDINATE) break; // that means we have to skip the end of the border path
       i = yy - 1;
       continue;
     }
@@ -2799,9 +2800,9 @@ static int _path_get_mask(const dt_iop_module_t *const module,
 
     // now we check p1 value to know if we have to skip a part
     if(next == i) next = 0;
-    while(isnan(pf1[0]))
+    while(pf1[0] == DT_INVALID_COORDINATE)
     {
-      if(isnan(pf1[1]))
+      if(pf1[1] == DT_INVALID_COORDINATE)
         next = i - 1;
       else
         next = p1[1];
@@ -3090,9 +3091,9 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
   {
     const float xx = border[2 * i];
     const float yy = border[2 * i + 1];
-    if(isnan(xx))
+    if(xx == DT_INVALID_COORDINATE)
     {
-      if(isnan(yy)) break; // that means we have to skip the end of the border path
+      if(yy == DT_INVALID_COORDINATE) break; // that means we have to skip the end of the border path
       i = yy - 1;
       continue;
     }
@@ -3152,9 +3153,9 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
   {
     const float xx = border[i * 2];
     const float yy = border[i * 2 + 1];
-    if(isnan(xx))
+    if(xx == DT_INVALID_COORDINATE)
     {
-      if(isnan(yy)) break; // that means we have to skip the end of the border path
+      if(yy == DT_INVALID_COORDINATE) break; // that means we have to skip the end of the border path
       i = yy - 1;
       continue;
     }
@@ -3363,9 +3364,9 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
 
       // now we check p1 value to know if we have to skip a part
       if(next == i) next = 0;
-      while(isnan(pf1[0]))
+      while(pf1[0] == DT_INVALID_COORDINATE)
       {
-        if(isnan(pf1[1]))
+        if(pf1[1] == DT_INVALID_COORDINATE)
           next = i - 1;
         else
           next = p1[1];

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -115,6 +115,7 @@ typedef struct dt_iop_exposure_global_data_t
   int kernel_exposure;
 } dt_iop_exposure_global_data_t;
 
+#define EXPOSURE_CORRECTION_UNDEFINED (-FLT_MAX)
 
 const char *name()
 {
@@ -392,7 +393,7 @@ static void _compute_correction(dt_iop_module_t *self,
 {
   const dt_iop_exposure_params_t *const p = (const dt_iop_exposure_params_t *const)p1;
 
-  *correction = NAN;
+  *correction = EXPOSURE_CORRECTION_UNDEFINED;
 
   if(histogram == NULL) return;
 
@@ -647,7 +648,7 @@ void gui_update(struct dt_iop_module_t *self)
 
   gtk_label_set_text(g->deflicker_used_EC, "");
   dt_iop_gui_enter_critical_section(self);
-  g->deflicker_computed_exposure = NAN;
+  g->deflicker_computed_exposure = EXPOSURE_CORRECTION_UNDEFINED;
   dt_iop_gui_leave_critical_section(self);
 
   switch(p->mode)
@@ -935,7 +936,7 @@ static gboolean _show_computed(gpointer user_data)
   dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
 
   dt_iop_gui_enter_critical_section(self);
-  if(!isnan(g->deflicker_computed_exposure))
+  if(g->deflicker_computed_exposure != EXPOSURE_CORRECTION_UNDEFINED)
   {
     gchar *str = g_strdup_printf(_("%.2f EV"), g->deflicker_computed_exposure);
 
@@ -1141,7 +1142,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(hbox1), GTK_WIDGET(g->deflicker_used_EC), FALSE, FALSE, 0);
 
   dt_iop_gui_enter_critical_section(self);
-  g->deflicker_computed_exposure = NAN;
+  g->deflicker_computed_exposure = EXPOSURE_CORRECTION_UNDEFINED;
   dt_iop_gui_leave_critical_section(self);
 
   gtk_box_pack_start(GTK_BOX(vbox_deflicker), GTK_WIDGET(hbox1), FALSE, FALSE, 0);

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -542,7 +542,7 @@ static float _get_exposure_bias(const struct dt_iop_module_t *self)
     bias = self->dev->image_storage.exif_exposure_bias;
 
   // sanity checks, don't trust exif tags too much
-  if(!isnan(bias))
+  if(bias != DT_EXIF_TAG_UNINITIALIZED)
     return CLAMP(bias, -5.0f, 5.0f);
   else
     return 0.0f;

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -174,7 +174,7 @@ static inline void process_drago(struct dt_iop_module_t *self, dt_dev_pixelpipe_
   /* precalcs */
   const float eps = 0.0001f;
   float lwmax;
-  float tmp_lwmax = NAN;
+  float tmp_lwmax = -FLT_MAX;
 
   // Drago needs the absolute Lmax value of the image. In pixelpipe FULL we can not reliably get this value
   // as the pixelpipe might only see part of the image (region of interest). Therefore we try to get lwmax from
@@ -186,7 +186,7 @@ static inline void process_drago(struct dt_iop_module_t *self, dt_dev_pixelpipe_
     dt_iop_gui_leave_critical_section(self);
 
     // note that the case 'hash == 0' on first invocation in a session implies that g->lwmax
-    // is NAN which initiates special handling below to avoid inconsistent results. in all
+    // is -FLT_MAX which initiates special handling below to avoid inconsistent results. in all
     // other cases we make sure that the preview pipe has left us with proper readings for
     // lwmax. if data are not yet there we need to wait (with timeout).
     if(hash != 0 && !dt_dev_sync_pixelpipe_hash(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, &self->gui_lock, &g->hash))
@@ -198,7 +198,7 @@ static inline void process_drago(struct dt_iop_module_t *self, dt_dev_pixelpipe_
   }
 
   // in all other cases we calculate lwmax here
-  if(isnan(tmp_lwmax))
+  if(tmp_lwmax == -FLT_MAX)
   {
     lwmax = eps;
 #ifdef _OPENMP
@@ -350,7 +350,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   if(d->operator== OPERATOR_DRAGO)
   {
     const float eps = 0.0001f;
-    float tmp_lwmax = NAN;
+    float tmp_lwmax = -FLT_MAX;
 
     // see comments in process() about lwmax value
     if(self->dev->gui_attached && g && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
@@ -366,7 +366,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
       dt_iop_gui_leave_critical_section(self);
     }
 
-    if(isnan(tmp_lwmax))
+    if(tmp_lwmax == -FLT_MAX)
     {
       dt_opencl_local_buffer_t flocopt
         = (dt_opencl_local_buffer_t){ .xoffset = 0, .xfactor = 1, .yoffset = 0, .yfactor = 1,
@@ -610,7 +610,7 @@ void gui_update(struct dt_iop_module_t *self)
   gui_changed(self, NULL, 0);
 
   dt_iop_gui_enter_critical_section(self);
-  g->lwmax = NAN;
+  g->lwmax = -FLT_MAX;
   g->hash = 0;
   dt_iop_gui_leave_critical_section(self);
 }
@@ -619,7 +619,7 @@ void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_global_tonemap_gui_data_t *g = IOP_GUI_ALLOC(global_tonemap);
 
-  g->lwmax = NAN;
+  g->lwmax = -FLT_MAX;
   g->hash = 0;
 
   g->operator = dt_bauhaus_combobox_from_params(self, N_("operator"));

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -42,6 +42,9 @@
 #include "libs/colorpicker.h"
 
 #define DT_GUI_CURVE_EDITOR_INSET DT_PIXEL_APPLY_DPI(5)
+// special marker value for uninitialized (and thus invalid) levels.  Use this in preference
+// to NAN so that we can enable optimizations from -ffinite-math-only.
+#define DT_LEVELS_UNINIT (-FLT_MAX)
 
 DT_MODULE_INTROSPECTION(2, dt_iop_levels_params_t)
 
@@ -198,7 +201,7 @@ static void dt_iop_levels_compute_levels_automatic(dt_dev_pixelpipe_iop_t *piece
   for(int k = 0; k < 3; k++)
   {
     thr[k] = (float)total * d->percentiles[k] / 100.0f;
-    d->levels[k] = NAN;
+    d->levels[k] = DT_LEVELS_UNINIT;
   }
 
   if(piece->histogram == NULL) return;
@@ -211,19 +214,20 @@ static void dt_iop_levels_compute_levels_automatic(dt_dev_pixelpipe_iop_t *piece
 
     for(int k = 0; k < 3; k++)
     {
-      if(isnan(d->levels[k]) && (n >= thr[k]))
+      if(d->levels[k] == DT_LEVELS_UNINIT && (n >= thr[k]))
       {
         d->levels[k] = (float)i / (float)(piece->histogram_stats.bins_count - 1);
       }
     }
   }
   // for numerical reasons sometimes the threshold is sharp but in float and n is size_t.
-  // in this case we want to make sure we don't keep nan:
-  if(isnan(d->levels[2])) d->levels[2] = 1.0f;
+  // in this case we want to make sure we don't keep the marker that it is uninitialized:
+  if(d->levels[2] == DT_LEVELS_UNINIT)
+    d->levels[2] = 1.0f;
 
   // compute middle level from min and max levels
   float center = d->percentiles[1] / 100.0f;
-  if(!isnan(d->levels[0]) && !isnan(d->levels[2]))
+  if(d->levels[0] != DT_LEVELS_UNINIT && d->levels[2] != DT_LEVELS_UNINIT)
     d->levels[1] = (1.0f - center) * d->levels[0] + center * d->levels[2];
 }
 
@@ -340,8 +344,9 @@ static void commit_params_late(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
       compute_lut(piece);
     }
 
-    if((piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW) || isnan(d->levels[0]) || isnan(d->levels[1])
-       || isnan(d->levels[2]))
+    if((piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
+       || d->levels[0] == DT_LEVELS_UNINIT || d->levels[1] == DT_LEVELS_UNINIT
+       || d->levels[2] == DT_LEVELS_UNINIT)
     {
       dt_iop_levels_compute_levels_automatic(piece);
       compute_lut(piece);
@@ -501,9 +506,9 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
     d->percentiles[1] = p->gray;
     d->percentiles[2] = p->white;
 
-    d->levels[0] = NAN;
-    d->levels[1] = NAN;
-    d->levels[2] = NAN;
+    d->levels[0] = DT_LEVELS_UNINIT;
+    d->levels[1] = DT_LEVELS_UNINIT;
+    d->levels[2] = DT_LEVELS_UNINIT;
 
     // commit_params_late() will compute LUT later
   }
@@ -556,9 +561,9 @@ void gui_update(dt_iop_module_t *self)
   gui_changed(self, g->mode, 0);
 
   dt_iop_gui_enter_critical_section(self);
-  g->auto_levels[0] = NAN;
-  g->auto_levels[1] = NAN;
-  g->auto_levels[2] = NAN;
+  g->auto_levels[0] = DT_LEVELS_UNINIT;
+  g->auto_levels[1] = DT_LEVELS_UNINIT;
+  g->auto_levels[2] = DT_LEVELS_UNINIT;
   g->hash = 0;
   dt_iop_gui_leave_critical_section(self);
 
@@ -600,9 +605,9 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_levels_gui_data_t *c = IOP_GUI_ALLOC(levels);
 
   dt_iop_gui_enter_critical_section(self);
-  c->auto_levels[0] = NAN;
-  c->auto_levels[1] = NAN;
-  c->auto_levels[2] = NAN;
+  c->auto_levels[0] = DT_LEVELS_UNINIT;
+  c->auto_levels[1] = DT_LEVELS_UNINIT;
+  c->auto_levels[2] = DT_LEVELS_UNINIT;
   c->hash = 0;
   dt_iop_gui_leave_critical_section(self);
 

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1338,7 +1338,7 @@ void gui_update(struct dt_iop_module_t *self)
     }
   }
 
-  if(!found || isnan(g->mod_temp)) // reset or initialize user-defined
+  if(!found || g->mod_temp != -FLT_MAX) // reset or initialize user-defined
   {
     g->mod_temp = tempK;
     g->mod_tint = tint;
@@ -2082,7 +2082,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->finetune, _("fine tune camera's white balance setting"));
   gtk_box_pack_start(box_enabled, g->finetune, TRUE, TRUE, 0);
 
-  g->mod_temp = NAN;
+  g->mod_temp = -FLT_MAX;
   for(int k = 0; k < 4; k++)
   {
     g->daylight_wb[k] = 1.0;

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1297,22 +1297,17 @@ static int compute_channels_factors(const float factors[PIXEL_CHAN],
   // approximation for x = { CHANNELS }
   assert(PIXEL_CHAN == 8);
 
-  int valid = 1;
-
   #ifdef _OPENMP
   #pragma omp parallel for simd default(none) schedule(static) \
-    aligned(factors, out, centers_params:64) dt_omp_firstprivate(factors, out, sigma, centers_params) shared(valid)
+    aligned(factors, out, centers_params:64) dt_omp_firstprivate(factors, out, sigma, centers_params)
   #endif
   for(int i = 0; i < CHANNELS; ++i)
   {
-     // Compute the new channels factors
+    // Compute the new channels factors; pixel_correction clamps the factors, so we don't
+    // need to check for validity here
     out[i] = pixel_correction(centers_params[i], factors, sigma);
-
-    // check they are in [-2, 2] EV and not NAN
-    if(isnan(out[i]) || out[i] < 0.25f || out[i] > 4.0f) valid = 0;
   }
-
-  return valid;
+  return 1;
 }
 
 
@@ -2462,7 +2457,7 @@ void gui_post_expose(struct dt_iop_module_t *self,
 
   dt_iop_gui_leave_critical_section(self);
 
-  if(isnan(correction) || isnan(exposure_in)) return; // something went wrong
+  if(isnan(exposure_in)) return; // something went wrong
 
   // Rescale and shift Cairo drawing coordinates
   const float wd = dev->preview_pipe->backbuf_width;

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -730,7 +730,7 @@ void gui_update(dt_lib_module_t *self)
 
       case md_exif_exposure_bias:
         g_strlcpy(text, NODATA_STRING, sizeof(text));
-        if(!(isnan(img->exif_exposure_bias)))
+        if(img->exif_exposure_bias != DT_EXIF_TAG_UNINITIALIZED)
         {
           (void)g_snprintf(text, sizeof(text), _("%+.2f EV"), (double)img->exif_exposure_bias);
         }


### PR DESCRIPTION
More work toward being able to globally enable -ffinite-math-only.
