### PR TITLE
Don't crash when applying style from Lua in darkroom mode

### DIFF
--- a/src/lua/styles.c
+++ b/src/lua/styles.c
@@ -19,7 +19,6 @@
 #include "lua/styles.h"
 #include "common/debug.h"
 #include "common/styles.h"
-#include "gui/accelerators.h"
 #include "lua/glist.h"
 #include "lua/image.h"
 #include "lua/types.h"

--- a/src/lua/styles.c
+++ b/src/lua/styles.c
@@ -261,7 +261,7 @@ int dt_lua_style_apply(lua_State *L)
   }
 
   if(darktable.develop && darktable.develop->image_storage.id == imgid)
-    dt_print(DT_DEBUG_LUA, "LUA ERROR : %s can't called from darkroom view.  Use darktable.gui.action() instead\n", __FUNCTION__);
+    dt_print(DT_DEBUG_LUA, "LUA ERROR : %s can't be called from darkroom view.  Use darktable.gui.action() instead\n", __FUNCTION__);
   else
   {
     dt_styles_apply_to_image(style.name, FALSE, FALSE, imgid);

--- a/src/lua/styles.c
+++ b/src/lua/styles.c
@@ -19,6 +19,7 @@
 #include "lua/styles.h"
 #include "common/debug.h"
 #include "common/styles.h"
+#include "gui/accelerators.h"
 #include "lua/glist.h"
 #include "lua/image.h"
 #include "lua/types.h"
@@ -259,8 +260,14 @@ int dt_lua_style_apply(lua_State *L)
     luaA_to(L, dt_style_t, &style, 1);
     luaA_to(L, dt_lua_image_t, &imgid, 2);
   }
-  dt_styles_apply_to_image(style.name, FALSE, FALSE, imgid);
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+
+  if(darktable.develop && darktable.develop->image_storage.id == imgid)
+    dt_print(DT_DEBUG_LUA, "LUA ERROR : %s can't called from darkroom view.  Use darktable.gui.action() instead\n", __FUNCTION__);
+  else
+  {
+    dt_styles_apply_to_image(style.name, FALSE, FALSE, imgid);
+    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+  }
   return 1;
 }
 


### PR DESCRIPTION
Lua isn't supposed to be used to process images in darkroom mode.  Using the function `darktable.styles.apply()` in darkroom mode causes darktable to crash.  

Added a test to determine if the function is being called from darkroom mode, and return an error message if that's the case.

`darktable.gui.action()` can be used to apply a style in darkroom mode since it's actually using the GUI to apply the style rather than trying to do it internally.

Fixes #13985 