### PR TITLE
More cleanup of struct dt_iop_module_t

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1330,7 +1330,7 @@ static gboolean _blendop_blendif_showmask_clicked(GtkToggleButton *button,
 
   if(event->button == 1)
   {
-    const int has_mask_display =
+    const gboolean has_mask_display =
       module->request_mask_display
       & (DT_DEV_PIXELPIPE_DISPLAY_MASK
          | DT_DEV_PIXELPIPE_DISPLAY_CHANNEL);
@@ -1349,7 +1349,7 @@ static gboolean _blendop_blendif_showmask_clicked(GtkToggleButton *button,
       module->request_mask_display |= DT_DEV_PIXELPIPE_DISPLAY_MASK;
     else
       module->request_mask_display |=
-        (has_mask_display ? 0 : DT_DEV_PIXELPIPE_DISPLAY_MASK);
+        (has_mask_display ? DT_DEV_PIXELPIPE_DISPLAY_NONE : DT_DEV_PIXELPIPE_DISPLAY_MASK);
 
     gtk_toggle_button_set_active
       (button,
@@ -3322,7 +3322,7 @@ void dt_iop_gui_blending_lose_focus(dt_iop_module_t *module)
   if(darktable.gui->reset) return;
   if(!module) return;
 
-  const int has_mask_display =
+  const gboolean has_mask_display =
     module->request_mask_display
     & (DT_DEV_PIXELPIPE_DISPLAY_MASK | DT_DEV_PIXELPIPE_DISPLAY_CHANNEL);
 

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -3270,7 +3270,7 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
     // (re)set the header mask indicator too
     if(module->mask_indicator)
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->mask_indicator), FALSE);
-    module->suppress_mask = 0;
+    module->suppress_mask = FALSE;
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->suppress), FALSE);
 
     _box_set_visible(bd->bottom_box, FALSE);
@@ -3326,7 +3326,7 @@ void dt_iop_gui_blending_lose_focus(dt_iop_module_t *module)
     module->request_mask_display
     & (DT_DEV_PIXELPIPE_DISPLAY_MASK | DT_DEV_PIXELPIPE_DISPLAY_CHANNEL);
 
-  const int suppress = module->suppress_mask;
+  const gboolean suppress = module->suppress_mask;
 
   if((module->flags() & IOP_FLAGS_SUPPORTS_BLENDING) && module->blend_data)
   {
@@ -3334,7 +3334,7 @@ void dt_iop_gui_blending_lose_focus(dt_iop_module_t *module)
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->showmask), FALSE);
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->suppress), FALSE);
     module->request_mask_display = DT_DEV_PIXELPIPE_DISPLAY_NONE;
-    module->suppress_mask = 0;
+    module->suppress_mask = FALSE;
 
     // (re)set the header mask indicator too
     ++darktable.gui->reset;

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -99,34 +99,6 @@ typedef enum dt_dev_pixelpipe_status_t
   DT_DEV_PIXELPIPE_INVALID = 3  // pixelpipe has finished; invalid result
 } dt_dev_pixelpipe_status_t;
 
-typedef enum dt_dev_pixelpipe_display_mask_t
-{
-  DT_DEV_PIXELPIPE_DISPLAY_NONE = 0,
-  DT_DEV_PIXELPIPE_DISPLAY_MASK = 1 << 0,
-  DT_DEV_PIXELPIPE_DISPLAY_CHANNEL = 1 << 1,
-  DT_DEV_PIXELPIPE_DISPLAY_OUTPUT = 1 << 2,
-  DT_DEV_PIXELPIPE_DISPLAY_L = 1 << 3,
-  DT_DEV_PIXELPIPE_DISPLAY_a = 2 << 3,
-  DT_DEV_PIXELPIPE_DISPLAY_b = 3 << 3,
-  DT_DEV_PIXELPIPE_DISPLAY_R = 4 << 3,
-  DT_DEV_PIXELPIPE_DISPLAY_G = 5 << 3,
-  DT_DEV_PIXELPIPE_DISPLAY_B = 6 << 3,
-  DT_DEV_PIXELPIPE_DISPLAY_GRAY = 7 << 3,
-  DT_DEV_PIXELPIPE_DISPLAY_LCH_C = 8 << 3,
-  DT_DEV_PIXELPIPE_DISPLAY_LCH_h = 9 << 3,
-  DT_DEV_PIXELPIPE_DISPLAY_HSL_H = 10 << 3,
-  DT_DEV_PIXELPIPE_DISPLAY_HSL_S = 11 << 3,
-  DT_DEV_PIXELPIPE_DISPLAY_HSL_l = 12 << 3,
-  DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Jz = 13 << 3,
-  DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Cz = 14 << 3,
-  DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_hz = 15 << 3,
-  DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU = 16 << 3, // show module's output
-                                               // without processing
-                                               // by later iops
-  DT_DEV_PIXELPIPE_DISPLAY_ANY = 0xff << 2,
-  DT_DEV_PIXELPIPE_DISPLAY_STICKY = 1 << 16
-} dt_dev_pixelpipe_display_mask_t;
-
 typedef enum dt_clipping_preview_mode_t
 {
   DT_CLIPPING_PREVIEW_GAMUT = 0,

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -399,7 +399,7 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module,
     module->histogram_max[2] = module->histogram_max[3] = 0;
   module->histogram_middle_grey = FALSE;
   module->request_mask_display = DT_DEV_PIXELPIPE_DISPLAY_NONE;
-  module->suppress_mask = 0;
+  module->suppress_mask = FALSE;
   module->enabled = module->default_enabled = FALSE; // all modules disabled by default.
   g_strlcpy(module->op, so->op, 20);
   module->raster_mask.source.users = g_hash_table_new(NULL, NULL);

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -232,7 +232,7 @@ typedef struct dt_iop_module_t
   dt_dev_pixelpipe_display_mask_t request_mask_display;
   /** set to 1 if you want the blendif mask to be suppressed in the
    * module in focus. gui mode only. */
-  int32_t suppress_mask;
+  gboolean suppress_mask;
   /** place to store the picked color of module input. */
   dt_aligned_pixel_t picked_color, picked_color_min, picked_color_max;
   /** place to store the picked color of module output (before blending). */

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -229,7 +229,7 @@ typedef struct dt_iop_module_t
   dt_dev_request_flags_t request_histogram;
   /** set to 1 if you want the mask to be transferred into alpha
    * channel during next eval. gui mode only. */
-  int request_mask_display;
+  dt_dev_pixelpipe_display_mask_t request_mask_display;
   /** set to 1 if you want the blendif mask to be suppressed in the
    * module in focus. gui mode only. */
   int32_t suppress_mask;

--- a/src/develop/pixelpipe.h
+++ b/src/develop/pixelpipe.h
@@ -51,6 +51,34 @@ typedef enum dt_dev_request_flags_t
   DT_REQUEST_EXPANDED = 1 << 2 // 
 } dt_dev_request_flags_t;
 
+typedef enum dt_dev_pixelpipe_display_mask_t
+{
+  DT_DEV_PIXELPIPE_DISPLAY_NONE = 0,
+  DT_DEV_PIXELPIPE_DISPLAY_MASK = 1 << 0,
+  DT_DEV_PIXELPIPE_DISPLAY_CHANNEL = 1 << 1,
+  DT_DEV_PIXELPIPE_DISPLAY_OUTPUT = 1 << 2,
+  DT_DEV_PIXELPIPE_DISPLAY_L = 1 << 3,
+  DT_DEV_PIXELPIPE_DISPLAY_a = 2 << 3,
+  DT_DEV_PIXELPIPE_DISPLAY_b = 3 << 3,
+  DT_DEV_PIXELPIPE_DISPLAY_R = 4 << 3,
+  DT_DEV_PIXELPIPE_DISPLAY_G = 5 << 3,
+  DT_DEV_PIXELPIPE_DISPLAY_B = 6 << 3,
+  DT_DEV_PIXELPIPE_DISPLAY_GRAY = 7 << 3,
+  DT_DEV_PIXELPIPE_DISPLAY_LCH_C = 8 << 3,
+  DT_DEV_PIXELPIPE_DISPLAY_LCH_h = 9 << 3,
+  DT_DEV_PIXELPIPE_DISPLAY_HSL_H = 10 << 3,
+  DT_DEV_PIXELPIPE_DISPLAY_HSL_S = 11 << 3,
+  DT_DEV_PIXELPIPE_DISPLAY_HSL_l = 12 << 3,
+  DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Jz = 13 << 3,
+  DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_Cz = 14 << 3,
+  DT_DEV_PIXELPIPE_DISPLAY_JzCzhz_hz = 15 << 3,
+  DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU = 16 << 3, // show module's output
+                                               // without processing
+                                               // by later iops
+  DT_DEV_PIXELPIPE_DISPLAY_ANY = 0xff << 2,
+  DT_DEV_PIXELPIPE_DISPLAY_STICKY = 1 << 16
+} dt_dev_pixelpipe_display_mask_t;
+
 // params to be used to collect histogram
 typedef struct dt_dev_histogram_collection_params_t
 {


### PR DESCRIPTION
1. Properly define `dt_dev_pixelpipe_display_mask_t request_mask_display;` instead of an int
2. `suppress_mask` should be a gboolean