### PR TITLE
determine visibility of multiinstance menu when showing

### DIFF
--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -1071,7 +1071,6 @@ void _styles_apply_to_image_ext(const char *name,
     {
       dt_dev_reload_history_items(darktable.develop);
       dt_dev_modulegroups_set(darktable.develop, dt_dev_modulegroups_get(darktable.develop));
-      dt_dev_modules_update_multishow(darktable.develop);
     }
 
     /* update xmp file */

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1265,9 +1265,6 @@ void dt_dev_reload_history_items(dt_develop_t *dev)
   // set the module list order
   dt_dev_reorder_gui_module_list(dev);
 
-  // we update show params for multi-instances for each other instances
-  dt_dev_modules_update_multishow(dev);
-
   dt_unlock_image(dev->image_storage.id);
 }
 
@@ -2861,59 +2858,6 @@ void dt_dev_module_remove(dt_develop_t *dev, dt_iop_module_t *module)
                                   DT_SIGNAL_DEVELOP_MODULE_REMOVE, module);
     /* redraw */
     dt_control_queue_redraw_center();
-  }
-}
-
-void _dev_module_update_multishow(dt_develop_t *dev, struct dt_iop_module_t *module)
-{
-  // We count the number of other instances
-  int nb_instances = 0;
-  for(GList *modules = dev->iop; modules; modules = g_list_next(modules))
-  {
-    dt_iop_module_t *mod = (dt_iop_module_t *)modules->data;
-
-    if(mod->instance == module->instance) nb_instances++;
-  }
-
-  dt_iop_module_t *mod_prev = dt_iop_gui_get_previous_visible_module(module);
-  dt_iop_module_t *mod_next = dt_iop_gui_get_next_visible_module(module);
-
-  const gboolean move_next =
-    (mod_next && mod_next->iop_order != INT_MAX)
-    ? dt_ioppr_check_can_move_after_iop(dev->iop, module, mod_next)
-    : -1.0;
-  const gboolean move_prev =
-    (mod_prev && mod_prev->iop_order != INT_MAX)
-    ? dt_ioppr_check_can_move_before_iop(dev->iop, module, mod_prev)
-    : -1.0;
-
-  module->multi_show_new = !(module->flags() & IOP_FLAGS_ONE_INSTANCE);
-  module->multi_show_close = (nb_instances > 1);
-  if(mod_next)
-    module->multi_show_up = move_next;
-  else
-    module->multi_show_up = 0;
-  if(mod_prev)
-    module->multi_show_down = move_prev;
-  else
-    module->multi_show_down = 0;
-}
-
-void dt_dev_modules_update_multishow(dt_develop_t *dev)
-{
-  if(darktable.unmuted & DT_DEBUG_IOPORDER)
-    dt_ioppr_check_iop_order(dev, 0, "dt_dev_modules_update_multishow");
-
-  for(GList *modules = dev->iop; modules; modules = g_list_next(modules))
-  {
-    dt_iop_module_t *mod = (dt_iop_module_t *)modules->data;
-
-    // only for visible modules
-    GtkWidget *expander = mod->expander;
-    if(expander && gtk_widget_is_visible(expander))
-    {
-      _dev_module_update_multishow(dev, mod);
-    }
   }
 }
 

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -461,10 +461,6 @@ struct dt_iop_module_t *dt_dev_module_duplicate(dt_develop_t *dev,
                                                 struct dt_iop_module_t *base);
 /** remove an existent module */
 void dt_dev_module_remove(dt_develop_t *dev, struct dt_iop_module_t *module);
-/** update "show" values of the multi instance part (show_move, show_delete, ...) */
-void dt_dev_module_update_multishow(dt_develop_t *dev, struct dt_iop_module_t *module);
-/** same, but for all modules */
-void dt_dev_modules_update_multishow(dt_develop_t *dev);
 /** generates item multi-instance name */
 gchar *dt_history_item_get_name(const struct dt_iop_module_t *module);
 

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -324,10 +324,6 @@ typedef struct dt_iop_module_t
   int multi_priority; // user may change this
   char multi_name[128]; // user may change this name
   gboolean multi_name_hand_edited;
-  gboolean multi_show_close;
-  gboolean multi_show_up;
-  gboolean multi_show_down;
-  gboolean multi_show_new;
   GtkWidget *multimenu_button;
 
   /** delayed-event handling */

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -977,9 +977,6 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
 
   }
 
-  // now that visibility has been updated set multi-show
-  dt_dev_modules_update_multishow(darktable.develop);
-
   // we show eventual basic panel but only if no text in the search box
   if(d->current == DT_MODULEGROUP_BASICS && !(text_entered && text_entered[0] != '\0')) _basics_show(self);
 }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2955,9 +2955,6 @@ static void _on_drag_data_received(GtkWidget *widget,
     gtk_box_reorder_child(dt_ui_get_container(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER),
         module_src->expander, g_value_get_int(&gv));
 
-    // we update the headers
-    dt_dev_modules_update_multishow(module_src->dev);
-
     dt_dev_add_history_item(module_src->dev, module_src, TRUE);
 
     if(darktable.unmuted & DT_DEBUG_IOPORDER)
@@ -3137,9 +3134,6 @@ void enter(dt_view_t *self)
         dt_iop_request_focus(module);
     }
   }
-
-  // update module multishow state now modules are loaded
-  dt_dev_modules_update_multishow(dev);
 
   // image should be there now.
   float zoom_x, zoom_y;


### PR DESCRIPTION
Rather than calculating the visibility of the items in the multi-instance menu for move up/down, new and delete for all modules every time anything changes anywhere, who not just calculate it when the user actually wants to perform any of those actions?

Apologies; my brain didn't engage once while mechanically putting together this PR so maybe I'm just being incredibly dim, but somehow it seems to work.

There's so much stuff in the gui that gets done so many times over and over again, it is not really worth trying to weed all of them out and I'm not sure why I decided to tackle this one. But when something needs to be updated everywhere, there's always that chance that it gets forgotten somewhere.

`dt_ioppr_check_iop_order` feels like a debug routine that got left in production. It can be handy to spot thinking errors when messing with the actual module order, but maybe it can be switched off for the release build?

