### PR TITLE
[GUI] Do not truncate EXIF_FOCAL_LENGTH

### DIFF
--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -405,7 +405,7 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
 
   else if(_has_prefix(variable, "EXIF.FOCAL.LENGTH")
           || _has_prefix(variable, "EXIF_FOCAL_LENGTH"))
-    result = g_strdup_printf("%d", (int)params->data->exif_focal_length);
+    result = g_strdup_printf("%.1f", params->data->exif_focal_length);
 
   else if(_has_prefix(variable, "EXIF.FOCUS.DISTANCE")
           || _has_prefix(variable, "EXIF_FOCUS_DISTANCE"))


### PR DESCRIPTION
We should not truncate the value of  `$(EXIF_FOCAL_LENGTH)` by casting it to an integer. This led to situations where the values of the focal length in the image information module and on the thumbnail could differ. For example, Apple iPad Pro (10.5) reports that its focal length = 3.99 mm, in the module it is displayed as 4 mm, and on the thumbnails, due to truncation caused by cast is shown as 3 mm.

After this fix, the information on the thumbnail and in the module will be identical.