### PR TITLE
po/invert masks - remove invert masks from drawn mask UI

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -1412,6 +1412,34 @@ static uint32_t _blend_legacy_blend_mode(uint32_t legacy_blend_mode)
   return (blend_reverse ? DEVELOP_BLEND_REVERSE : 0) | blend_mode;
 }
 
+static void _fix_masks_combine(dt_develop_blend_params_t *bp)
+{
+  // only for drawn masks where DEVELOP_COMBINE_INV has been
+  // deprecated.
+
+  if(bp->mask_mode & DEVELOP_MASK_MASK)
+  {
+    // if set we replace it with DEVELOP_COMBINE_MASKS_POS
+    // both DEVELOP_COMBINE_INV & DEVELOP_COMBINE_MASKS_POS are giving
+    // the very same result.
+    const gboolean m_inv = bp->mask_combine & DEVELOP_COMBINE_INV;
+    const gboolean m_pos = bp->mask_combine & DEVELOP_COMBINE_MASKS_POS;
+
+    if(m_inv && !m_pos)
+    {
+      // remove INV add POS to give the same effect
+      bp->mask_combine &= ~DEVELOP_COMBINE_INV;
+      bp->mask_combine |= DEVELOP_COMBINE_MASKS_POS;
+    }
+    else if(m_inv && m_pos)
+    {
+      // both set, remove INV and remove POS, invert of invert is a nop
+      bp->mask_combine &= ~DEVELOP_COMBINE_INV;
+      bp->mask_combine &= ~DEVELOP_COMBINE_MASKS_POS;
+    }
+  }
+}
+
 /** update blendop params from older versions */
 int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const old_params,
                                    const int old_version, void *new_params, const int new_version,
@@ -1435,7 +1463,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
     return 0;
   }
 
-  if(old_version == 1 && new_version == 11)
+  if(old_version == 1 && new_version == 12)
   {
     /** blend legacy parameters version 1 */
     typedef struct dt_develop_blend_params1_t
@@ -1458,7 +1486,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
     return 0;
   }
 
-  if(old_version == 2 && new_version == 11)
+  if(old_version == 2 && new_version == 12)
   {
     /** blend legacy parameters version 2 */
     typedef struct dt_develop_blend_params2_t
@@ -1496,7 +1524,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
     return 0;
   }
 
-  if(old_version == 3 && new_version == 11)
+  if(old_version == 3 && new_version == 12)
   {
     /** blend legacy parameters version 3 */
     typedef struct dt_develop_blend_params3_t
@@ -1532,7 +1560,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
     return 0;
   }
 
-  if(old_version == 4 && new_version == 11)
+  if(old_version == 4 && new_version == 12)
   {
     /** blend legacy parameters version 4 */
     typedef struct dt_develop_blend_params4_t
@@ -1567,11 +1595,10 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
     n->blur_radius = o->radius;
     n->blendif = o->blendif & ~(1u << DEVELOP_BLENDIF_active); // knock out old unused "active" flag
     memcpy(n->blendif_parameters, o->blendif_parameters, sizeof(float) * 4 * DEVELOP_BLENDIF_SIZE);
-
     return 0;
   }
 
-  if(old_version == 5 && new_version == 11)
+  if(old_version == 5 && new_version == 12)
   {
     /** blend legacy parameters version 5 (identical to version 6)*/
     typedef struct dt_develop_blend_params5_t
@@ -1615,11 +1642,11 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
     n->blendif = (o->blendif & (1u << DEVELOP_BLENDIF_active) ? o->blendif | 31 : o->blendif)
                  & ~(1u << DEVELOP_BLENDIF_active);
     memcpy(n->blendif_parameters, o->blendif_parameters, sizeof(float) * 4 * DEVELOP_BLENDIF_SIZE);
-
+    _fix_masks_combine(n);
     return 0;
   }
 
-  if(old_version == 6 && new_version == 11)
+  if(old_version == 6 && new_version == 12)
   {
     /** blend legacy parameters version 6 (identical to version 7) */
     typedef struct dt_develop_blend_params6_t
@@ -1658,10 +1685,11 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
     n->blur_radius = o->radius;
     n->blendif = o->blendif;
     memcpy(n->blendif_parameters, o->blendif_parameters, sizeof(float) * 4 * DEVELOP_BLENDIF_SIZE);
+    _fix_masks_combine(n);
     return 0;
   }
 
-  if(old_version == 7 && new_version == 11)
+  if(old_version == 7 && new_version == 12)
   {
     /** blend legacy parameters version 7 */
     typedef struct dt_develop_blend_params7_t
@@ -1700,10 +1728,11 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
     n->blur_radius = o->radius;
     n->blendif = o->blendif;
     memcpy(n->blendif_parameters, o->blendif_parameters, sizeof(float) * 4 * DEVELOP_BLENDIF_SIZE);
+    _fix_masks_combine(n);
     return 0;
   }
 
-  if(old_version == 8 && new_version == 11)
+  if(old_version == 8 && new_version == 12)
   {
     /** blend legacy parameters version 8 */
     typedef struct dt_develop_blend_params8_t
@@ -1754,10 +1783,11 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
     n->contrast = o->contrast;
     n->brightness = o->brightness;
     memcpy(n->blendif_parameters, o->blendif_parameters, sizeof(float) * 4 * DEVELOP_BLENDIF_SIZE);
+    _fix_masks_combine(n);
     return 0;
   }
 
-  if(old_version == 9 && new_version == 11)
+  if(old_version == 9 && new_version == 12)
   {
     /** blend legacy parameters version 9 */
     typedef struct dt_develop_blend_params9_t
@@ -1817,10 +1847,11 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
     n->raster_mask_instance = o->raster_mask_instance;
     n->raster_mask_id = o->raster_mask_id;
     n->raster_mask_invert = o->raster_mask_invert;
+    _fix_masks_combine(n);
     return 0;
   }
 
-  if(old_version == 10 && new_version == 11)
+  if(old_version == 10 && new_version == 12)
   {
     /** blend legacy parameters version 10 */
     typedef struct dt_develop_blend_params10_t
@@ -1893,9 +1924,22 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
     n->raster_mask_instance = o->raster_mask_instance;
     n->raster_mask_id = o->raster_mask_id;
     n->raster_mask_invert = o->raster_mask_invert;
+
+    _fix_masks_combine(n);
+
     return 0;
   }
+  if(old_version == 11 && new_version == 12)
+  {
+    if(length != sizeof(dt_develop_blend_params_t)) return 1;
 
+    dt_develop_blend_params_t *o = (dt_develop_blend_params_t *)old_params;
+    dt_develop_blend_params_t *n = (dt_develop_blend_params_t *)new_params;
+
+    *n = *o;
+    _fix_masks_combine(n);
+    return 0;
+  }
   return 1;
 }
 

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -26,7 +26,7 @@
 #include "dtgtk/gradientslider.h"
 #include "gui/color_picker_proxy.h"
 
-#define DEVELOP_BLEND_VERSION (11)
+#define DEVELOP_BLEND_VERSION (12)
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -319,7 +319,6 @@ typedef struct dt_iop_gui_blend_data_t
   GtkWidget *blend_modes_combo;
   GtkWidget *blend_modes_blend_order;
   GtkWidget *blend_mode_parameter_slider;
-  GtkWidget *masks_invert_combo;
   GtkWidget *opacity_slider;
   GtkWidget *masks_feathering_guide_combo;
   GtkWidget *feathering_radius_slider;
@@ -485,4 +484,3 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -620,15 +620,10 @@ static void _blendop_masks_mode_callback(const unsigned int mask_mode,
         (data->masks_combine_combo,
          data->module->blend_params->mask_combine
           & (DEVELOP_COMBINE_INV | DEVELOP_COMBINE_INCL));
-      gtk_widget_hide(GTK_WIDGET(data->masks_invert_combo));
       gtk_widget_show(GTK_WIDGET(data->masks_combine_combo));
     }
     else
     {
-      dt_bauhaus_combobox_set_from_value
-        (data->masks_invert_combo,
-         data->module->blend_params->mask_combine & DEVELOP_COMBINE_INV);
-      gtk_widget_show(GTK_WIDGET(data->masks_invert_combo));
       gtk_widget_hide(GTK_WIDGET(data->masks_combine_combo));
     }
 
@@ -793,21 +788,6 @@ static void _blendop_masks_combine_callback(GtkWidget *combo,
     _blendop_blendif_update_tab(data->module, data->tab);
   }
 
-  _blendif_clean_output_channels(data->module);
-  dt_dev_add_history_item(darktable.develop, data->module, TRUE);
-}
-
-static void _blendop_masks_invert_callback(GtkWidget *combo,
-                                           dt_iop_gui_blend_data_t *data)
-{
-  const unsigned int invert =
-    GPOINTER_TO_UINT(dt_bauhaus_combobox_get_data(data->masks_invert_combo))
-    & DEVELOP_COMBINE_INV;
-
-  if(invert)
-    data->module->blend_params->mask_combine |= DEVELOP_COMBINE_INV;
-  else
-    data->module->blend_params->mask_combine &= ~DEVELOP_COMBINE_INV;
   _blendif_clean_output_channels(data->module);
   dt_dev_add_history_item(darktable.develop, data->module, TRUE);
 }
@@ -3192,9 +3172,6 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
   dt_bauhaus_combobox_set_from_value
     (bd->masks_combine_combo,
      module->blend_params->mask_combine & (DEVELOP_COMBINE_INV | DEVELOP_COMBINE_INCL));
-  dt_bauhaus_combobox_set_from_value
-    (bd->masks_invert_combo,
-     module->blend_params->mask_combine & DEVELOP_COMBINE_INV);
   dt_bauhaus_slider_set(bd->opacity_slider, module->blend_params->opacity);
   dt_bauhaus_combobox_set_from_value
     (bd->masks_feathering_guide_combo,
@@ -3231,12 +3208,10 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
   {
     if(bd->blendif_inited && (mask_mode & DEVELOP_MASK_CONDITIONAL))
     {
-      gtk_widget_hide(GTK_WIDGET(bd->masks_invert_combo));
       gtk_widget_show(GTK_WIDGET(bd->masks_combine_combo));
     }
     else
     {
-      gtk_widget_show(GTK_WIDGET(bd->masks_invert_combo));
       gtk_widget_hide(GTK_WIDGET(bd->masks_combine_combo));
     }
 
@@ -3559,14 +3534,6 @@ void dt_iop_gui_init_blending(GtkWidget *iopw,
     dt_gui_add_help_link(GTK_WIDGET(bd->masks_combine_combo),
                          dt_get_help_url("masks_combined"));
 
-    bd->masks_invert_combo = _combobox_new_from_list
-      (module,
-       N_("invert mask"),
-       dt_develop_invert_mask_names, NULL,
-       _("apply mask in normal or inverted mode"));
-    g_signal_connect(G_OBJECT(bd->masks_invert_combo), "value-changed",
-                     G_CALLBACK(_blendop_masks_invert_callback), bd);
-
     bd->details_slider = dt_bauhaus_slider_new_with_range(module, -1.0f, 1.0f, 0, 0.0f, 2);
     dt_bauhaus_widget_set_label(bd->details_slider, N_("blend"), N_("details threshold"));
     dt_bauhaus_slider_set_format(bd->details_slider, "%");
@@ -3686,8 +3653,6 @@ void dt_iop_gui_init_blending(GtkWidget *iopw,
     bd->bottom_box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
     gtk_box_pack_start(GTK_BOX(bd->bottom_box),
                        GTK_WIDGET(bd->masks_combine_combo), TRUE, TRUE, 0);
-    gtk_box_pack_start(GTK_BOX(bd->bottom_box),
-                       GTK_WIDGET(bd->masks_invert_combo), TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->bottom_box),
                        hbox, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->bottom_box),


### PR DESCRIPTION
Two parts on this:

- blend: Remove the invert masks for drawn masks.

The toggle polarity does the same and is common to all blend modes.

- blend: deprecate DEVELOP_COMBINE_INV and update legacy history.

As DEVELOP_COMBINE_INV is deprecaded and no more accessible from
UI we ensure it doesn't get set (and inaccessible). So we replace
it by DEVELOP_COMBINE_MASKS_POS.
    
Better fix for #14213, closes #14214.
