### PR TITLE
import: fix already imported check

### DIFF
--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -703,9 +703,9 @@ static guint _import_set_file_list(const gchar *folder, const int folder_lgth,
           gboolean already_imported = FALSE;
           if(d->import_case == DT_IMPORT_INPLACE)
           {
-            /* check if image is already imported, using previously fetched filroll id */
+            /* check if image is already imported, using previously fetched filmroll id */
             if(filmroll_id != -1)
-              already_imported = dt_image_get_id(filmroll_id, filename) != -1 ? TRUE : FALSE;
+              already_imported = dt_image_get_id(filmroll_id, filename) == NO_IMGID ? FALSE : TRUE;
           }
           else
           {


### PR DESCRIPTION
In commit d5b2d8f8 dt_image_get_id returns NO_IMGID (0) instead of -1. Fix the check in import.c or all the images will be marked as already imported if at least one of that filmroll was already imported.