### PR TITLE
Avoid crash when applying styles from lua in darkroom

### DIFF
--- a/src/lua/styles.c
+++ b/src/lua/styles.c
@@ -261,7 +261,7 @@ int dt_lua_style_apply(lua_State *L)
   }
 
   if(darktable.develop && darktable.develop->image_storage.id == imgid)
-    dt_print(DT_DEBUG_LUA, "LUA ERROR : %s can't be called from darkroom view.  Use darktable.gui.action() instead\n", __FUNCTION__);
+    dt_print(DT_DEBUG_LUA, "LUA ERROR : %s can't called from darkroom view.  Use darktable.gui.action() instead\n", __FUNCTION__);
   else
   {
     dt_styles_apply_to_image(style.name, FALSE, FALSE, imgid);

--- a/src/lua/styles.c
+++ b/src/lua/styles.c
@@ -259,14 +259,8 @@ int dt_lua_style_apply(lua_State *L)
     luaA_to(L, dt_style_t, &style, 1);
     luaA_to(L, dt_lua_image_t, &imgid, 2);
   }
-
-  if(darktable.develop && darktable.develop->image_storage.id == imgid)
-    dt_print(DT_DEBUG_LUA, "LUA ERROR : %s can't called from darkroom view.  Use darktable.gui.action() instead\n", __FUNCTION__);
-  else
-  {
-    dt_styles_apply_to_image(style.name, FALSE, FALSE, imgid);
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
-  }
+  dt_styles_apply_to_image(style.name, FALSE, FALSE, imgid);
+  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
   return 1;
 }
 

--- a/src/lua/styles.c
+++ b/src/lua/styles.c
@@ -345,6 +345,7 @@ int dt_lua_init_styles(lua_State *L)
   lua_pushcclosure(L, dt_lua_type_member_common, 1);
   dt_lua_type_register_const_type(L, type_id, "create");
   lua_pushcfunction(L, dt_lua_style_apply);
+  dt_lua_gtk_wrap(L);
   lua_pushcclosure(L, dt_lua_type_member_common, 1);
   dt_lua_type_register_const_type(L, type_id, "apply");
   lua_pushcfunction(L, dt_lua_style_import);


### PR DESCRIPTION
revert previous workaround and make sure dt_styles_apply_to_image is run in gui thread