### PR TITLE
Modify masking code to use `typedef dt_mask_id_t`

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -157,6 +157,10 @@ typedef int32_t dt_imgid_t;
 #define NO_IMGID (0)
 #define dt_is_valid_imgid(n) ((n) > NO_IMGID)
 
+typedef int32_t dt_mask_id_t;
+#define NO_MASKID (0)
+#define dt_is_valid_maskid(n) ((n) > NO_MASKID)
+
 /* Helper to force stack vectors to be aligned on 64 bits blocks to enable AVX2 */
 #define DT_IS_ALIGNED(x) __builtin_assume_aligned(x, 64)
 

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -259,12 +259,12 @@ static dt_iop_module_t *_search_list_iop_by_module(GList *modules_list,
 }
 
 // fills used with formid, if it is a group it recurs and fill all sub-forms
-static void _fill_used_forms(GList *forms_list, const int formid, int *used, const int nb)
+static void _fill_used_forms(GList *forms_list, const dt_mask_id_t formid, int *used, const int nb)
 {
   // first, we search for the formid in used table
   for(int i = 0; i < nb; i++)
   {
-    if(used[i] == 0)
+    if(used[i] == NO_MASKID)
     {
       // we store the formid
       used[i] = formid;

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -1442,7 +1442,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
     {
       uint32_t mode;
       float opacity;
-      uint32_t mask_id;
+      dt_mask_id_t mask_id;
     } dt_develop_blend_params1_t;
 
     if(length != sizeof(dt_develop_blend_params1_t)) return 1;
@@ -1468,7 +1468,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
       /** mixing opacity */
       float opacity;
       /** id of mask in current pipeline */
-      uint32_t mask_id;
+      dt_mask_id_t mask_id;
       /** blendif mask */
       uint32_t blendif;
       /** blendif parameters */
@@ -1506,7 +1506,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
       /** mixing opacity */
       float opacity;
       /** id of mask in current pipeline */
-      uint32_t mask_id;
+      dt_mask_id_t mask_id;
       /** blendif mask */
       uint32_t blendif;
       /** blendif parameters */
@@ -1542,7 +1542,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
       /** mixing opacity */
       float opacity;
       /** id of mask in current pipeline */
-      uint32_t mask_id;
+      dt_mask_id_t mask_id;
       /** blendif mask */
       uint32_t blendif;
       /** blur radius */
@@ -1585,7 +1585,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
       /** how masks are combined */
       uint32_t mask_combine;
       /** id of mask in current pipeline */
-      uint32_t mask_id;
+      dt_mask_id_t mask_id;
       /** blendif mask */
       uint32_t blendif;
       /** blur radius */
@@ -1633,7 +1633,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
       /** how masks are combined */
       uint32_t mask_combine;
       /** id of mask in current pipeline */
-      uint32_t mask_id;
+      dt_mask_id_t mask_id;
       /** blendif mask */
       uint32_t blendif;
       /** blur radius */
@@ -1675,7 +1675,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
       /** how masks are combined */
       uint32_t mask_combine;
       /** id of mask in current pipeline */
-      uint32_t mask_id;
+      dt_mask_id_t mask_id;
       /** blendif mask */
       uint32_t blendif;
       /** blur radius */
@@ -1717,7 +1717,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
       /** how masks are combined */
       uint32_t mask_combine;
       /** id of mask in current pipeline */
-      uint32_t mask_id;
+      dt_mask_id_t mask_id;
       /** blendif mask */
       uint32_t blendif;
       /** feathering radius */
@@ -1772,7 +1772,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
       /** how masks are combined */
       uint32_t mask_combine;
       /** id of mask in current pipeline */
-      uint32_t mask_id;
+      dt_mask_id_t mask_id;
       /** blendif mask */
       uint32_t blendif;
       /** feathering radius */
@@ -1791,7 +1791,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
       float blendif_parameters[4 * DEVELOP_BLENDIF_SIZE];
       dt_dev_operation_t raster_mask_source;
       int raster_mask_instance;
-      int raster_mask_id;
+      dt_mask_id_t raster_mask_id;
       gboolean raster_mask_invert;
     } dt_develop_blend_params9_t;
 
@@ -1839,7 +1839,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
       /** how masks are combined */
       uint32_t mask_combine;
       /** id of mask in current pipeline */
-      uint32_t mask_id;
+      dt_mask_id_t mask_id;
       /** blendif mask */
       uint32_t blendif;
       /** feathering radius */
@@ -1859,7 +1859,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
       float blendif_boost_factors[DEVELOP_BLENDIF_SIZE];
       dt_dev_operation_t raster_mask_source;
       int raster_mask_instance;
-      int raster_mask_id;
+      dt_mask_id_t raster_mask_id;
       gboolean raster_mask_invert;
     } dt_develop_blend_params10_t;
 

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -193,7 +193,7 @@ typedef struct dt_develop_blend_params_t
   /** how masks are combined */
   uint32_t mask_combine;
   /** id of mask in current pipeline */
-  uint32_t mask_id;
+  dt_mask_id_t mask_id;
   /** blendif mask */
   uint32_t blendif;
   /** feathering radius */
@@ -215,7 +215,7 @@ typedef struct dt_develop_blend_params_t
   float blendif_boost_factors[DEVELOP_BLENDIF_SIZE];
   dt_dev_operation_t raster_mask_source;
   int raster_mask_instance;
-  int raster_mask_id;
+  dt_mask_id_t raster_mask_id;
   gboolean raster_mask_invert;
 } dt_develop_blend_params_t;
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2739,9 +2739,10 @@ void dt_dev_masks_list_update(dt_develop_t *dev)
   if(dev->proxy.masks.module && dev->proxy.masks.list_update)
     dev->proxy.masks.list_update(dev->proxy.masks.module);
 }
+
 void dt_dev_masks_list_remove(dt_develop_t *dev,
-                              const int formid,
-                              const int parentid)
+                              dt_mask_id_t formid,
+                              dt_mask_id_t parentid)
 {
   if(dev->proxy.masks.module && dev->proxy.masks.list_remove)
     dev->proxy.masks.list_remove(dev->proxy.masks.module, formid, parentid);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2749,7 +2749,7 @@ void dt_dev_masks_list_remove(dt_develop_t *dev,
 }
 void dt_dev_masks_selection_change(dt_develop_t *dev,
                                    struct dt_iop_module_t *module,
-                                   const int selectid)
+                                   const dt_mask_id_t selectid)
 {
   if(dev->proxy.masks.module && dev->proxy.masks.selection_change)
     dev->proxy.masks.selection_change(dev->proxy.masks.module, module, selectid);

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -246,7 +246,7 @@ typedef struct dt_develop_t
       /* selected forms change */
       void (*selection_change)(struct dt_lib_module_t *self,
                                struct dt_iop_module_t *module,
-                               const int selectid);
+                               const dt_mask_id_t selectid);
     } masks;
 
     // what is the ID of the module currently doing pipeline chromatic
@@ -460,7 +460,7 @@ void dt_dev_masks_list_update(dt_develop_t *dev);
 void dt_dev_masks_list_remove(dt_develop_t *dev, dt_mask_id_t formid, dt_mask_id_t parentid);
 void dt_dev_masks_selection_change(dt_develop_t *dev,
                                    struct dt_iop_module_t *module,
-                                   const int selectid);
+                                   const dt_mask_id_t selectid);
 
 /*
  * multi instances

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -241,7 +241,7 @@ typedef struct dt_develop_t
       struct dt_lib_module_t *module;
       /* treview list refresh */
       void (*list_change)(struct dt_lib_module_t *self);
-      void (*list_remove)(struct dt_lib_module_t *self, int formid, int parentid);
+      void (*list_remove)(struct dt_lib_module_t *self, dt_mask_id_t formid, dt_mask_id_t parentid);
       void (*list_update)(struct dt_lib_module_t *self);
       /* selected forms change */
       void (*selection_change)(struct dt_lib_module_t *self,
@@ -457,7 +457,7 @@ void dt_dev_average_delay_update(const dt_times_t *start, uint32_t *average_dela
  */
 void dt_dev_masks_list_change(dt_develop_t *dev);
 void dt_dev_masks_list_update(dt_develop_t *dev);
-void dt_dev_masks_list_remove(dt_develop_t *dev, int formid, int parentid);
+void dt_dev_masks_list_remove(dt_develop_t *dev, dt_mask_id_t formid, dt_mask_id_t parentid);
 void dt_dev_masks_selection_change(dt_develop_t *dev,
                                    struct dt_iop_module_t *module,
                                    const int selectid);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -798,9 +798,9 @@ dt_iop_module_t *dt_iop_gui_duplicate(dt_iop_module_t *base, const gboolean copy
       if(module->flags() & IOP_FLAGS_SUPPORTS_BLENDING)
       {
         dt_iop_commit_blend_params(module, base->blend_params);
-        if(base->blend_params->mask_id > 0)
+        if(dt_is_valid_maskid(base->blend_params->mask_id))
         {
-          module->blend_params->mask_id = 0;
+          module->blend_params->mask_id = NO_MASKID;
           dt_masks_iop_use_same_as(module, base);
         }
       }
@@ -2107,7 +2107,7 @@ static void _gui_reset_callback(GtkButton *button,
      || !dt_gui_presets_autoapply_for_module(module))
   {
     // if a drawn mask is set, remove it from the list
-    if(module->blend_params->mask_id > 0)
+    if(dt_is_valid_maskid(module->blend_params->mask_id))
     {
       dt_masks_form_t *grp =
         dt_masks_get_from_id(darktable.develop, module->blend_params->mask_id);

--- a/src/develop/lightroom.c
+++ b/src/develop/lightroom.c
@@ -221,7 +221,7 @@ typedef struct dt_lr_develop_blend_params_t
   /** mixing opacity */
   float opacity;
   /** id of mask in current pipeline */
-  uint32_t mask_id;
+  dt_mask_id_t mask_id;
   /** blendif mask */
   uint32_t blendif;
   /** blur radius */

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -171,8 +171,8 @@ typedef struct dt_masks_point_gradient_t
 /** structure used to store all forms's id for a group */
 typedef struct dt_masks_point_group_t
 {
-  int formid;
-  int parentid;
+  dt_mask_id_t formid;
+  dt_mask_id_t parentid;
   int state;
   float opacity;
 } dt_masks_point_group_t;
@@ -265,7 +265,7 @@ typedef struct dt_masks_functions_t
                      const double pressure,
                      const int which,
                      struct dt_masks_form_t *form,
-                     const int parentid,
+                     const dt_imgid_t parentid,
                      struct dt_masks_form_gui_t *gui,
                      const int index);
   int (*mouse_scrolled)(struct dt_iop_module_t *module,
@@ -274,7 +274,7 @@ typedef struct dt_masks_functions_t
                         const int up,
                         uint32_t state,
                         struct dt_masks_form_t *form,
-                        const int parentid,
+                        const dt_imgid_t parentid,
                         struct dt_masks_form_gui_t *gui,
                         const int index);
   int (*button_pressed)(struct dt_iop_module_t *module,
@@ -285,7 +285,7 @@ typedef struct dt_masks_functions_t
                         const int type,
                         const uint32_t state,
                         struct dt_masks_form_t *form,
-                        const int parentid,
+                        const dt_imgid_t parentid,
                         struct dt_masks_form_gui_t *gui,
                         const int index);
   int (*button_released)(struct dt_iop_module_t *module,
@@ -294,7 +294,7 @@ typedef struct dt_masks_functions_t
                          const int which,
                          const uint32_t state,
                          struct dt_masks_form_t *form,
-                         const int parentid,
+                         const dt_imgid_t parentid,
                          struct dt_masks_form_gui_t *gui,
                          const int index);
   void (*post_expose)(cairo_t *cr,
@@ -316,7 +316,7 @@ typedef struct dt_masks_form_t
   // name of the form
   char name[128];
   // id used to store the form
-  int formid;
+  dt_mask_id_t formid;
   // version of the form
   int version;
 } dt_masks_form_t;
@@ -392,7 +392,7 @@ typedef struct dt_masks_form_gui_t
   dt_masks_pressure_sensitivity_t pressure_sensitivity;
 
   // ids
-  int formid;
+  dt_mask_id_t formid;
   uint64_t pipe_hash;
 } dt_masks_form_gui_t;
 
@@ -495,9 +495,9 @@ dt_masks_form_t *dt_masks_create_ext(dt_masks_type_t type);
 /** replace dev->forms with forms */
 void dt_masks_replace_current_forms(dt_develop_t *dev, GList *forms);
 /** returns a form with formid == id from a list of forms */
-dt_masks_form_t *dt_masks_get_from_id_ext(GList *forms, int id);
+dt_masks_form_t *dt_masks_get_from_id_ext(GList *forms, dt_mask_id_t id);
 /** returns a form with formid == id from dev->forms */
-dt_masks_form_t *dt_masks_get_from_id(dt_develop_t *dev, int id);
+dt_masks_form_t *dt_masks_get_from_id(dt_develop_t *dev, dt_mask_id_t id);
 
 /** read the forms from the db */
 void dt_masks_read_masks_history(dt_develop_t *dev, const dt_imgid_t imgid);
@@ -574,7 +574,7 @@ dt_masks_edit_mode_t dt_masks_get_edit_mode(struct dt_iop_module_t *module);
 void dt_masks_set_edit_mode(struct dt_iop_module_t *module,
                             dt_masks_edit_mode_t value);
 void dt_masks_set_edit_mode_single_form(struct dt_iop_module_t *module,
-                                        const int formid,
+                                        const dt_mask_id_t formid,
                                         const dt_masks_edit_mode_t value);
 void dt_masks_iop_update(struct dt_iop_module_t *module);
 void dt_masks_iop_combo_populate(GtkWidget *w,
@@ -589,13 +589,13 @@ void dt_masks_form_remove(struct dt_iop_module_t *module,
                           dt_masks_form_t *grp,
                           dt_masks_form_t *form);
 float dt_masks_form_change_opacity(dt_masks_form_t *form,
-                                   const int parentid,
+                                   const dt_imgid_t parentid,
                                    const float amount);
 void dt_masks_form_move(dt_masks_form_t *grp,
-                        const int formid,
+                        const dt_mask_id_t formid,
                         const int up);
 int dt_masks_form_duplicate(dt_develop_t *dev,
-                            const int formid);
+                            const dt_mask_id_t formid);
 /* returns a duplicate tof form, including the formid */
 dt_masks_form_t *dt_masks_dup_masks_form(const dt_masks_form_t *form);
 /* duplicate the list of forms, replace item in the list with form with the same formid */

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1332,7 +1332,7 @@ static int _brush_events_mouse_scrolled(struct dt_iop_module_t *module,
                                         const int up,
                                         const uint32_t state,
                                         dt_masks_form_t *form,
-                                        const int parentid,
+                                        const dt_mask_id_t parentid,
                                         dt_masks_form_gui_t *gui,
                                         const int index)
 {
@@ -1490,7 +1490,7 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module,
                                         const int type,
                                         const uint32_t state,
                                         dt_masks_form_t *form,
-                                        const int parentid,
+                                        const dt_mask_id_t parentid,
                                         dt_masks_form_gui_t *gui,
                                         const int index)
 {
@@ -1723,7 +1723,7 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module,
     if(g_list_shorter_than(form->points, 3))
     {
       // if the form doesn't below to a group, we don't delete it
-      if(parentid <= 0) return 1;
+      if(!dt_is_valid_maskid(parentid)) return 1;
 
       // we hide the form
       if(!(darktable.develop->form_visible->type & DT_MASKS_GROUP))
@@ -1790,7 +1790,7 @@ static int _brush_events_button_pressed(struct dt_iop_module_t *module,
     }
     return 1;
   }
-  else if(which == 3 && parentid > 0 && gui->edit_mode == DT_MASKS_EDIT_FULL)
+  else if(which == 3 && dt_is_valid_maskid(parentid) && gui->edit_mode == DT_MASKS_EDIT_FULL)
   {
     // we hide the form
     if(!(darktable.develop->form_visible->type & DT_MASKS_GROUP))
@@ -1831,7 +1831,7 @@ static int _brush_events_button_released(struct dt_iop_module_t *module,
                                          const int which,
                                          const uint32_t state,
                                          dt_masks_form_t *form,
-                                         const int parentid,
+                                         const dt_mask_id_t parentid,
                                          dt_masks_form_gui_t *gui,
                                          const int index)
 {
@@ -2193,7 +2193,7 @@ static int _brush_events_mouse_moved(struct dt_iop_module_t *module,
                                      const double pressure,
                                      const int which,
                                      dt_masks_form_t *form,
-                                     const int parentid,
+                                     const dt_mask_id_t parentid,
                                      dt_masks_form_gui_t *gui,
                                      const int index)
 {

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -114,7 +114,7 @@ static int _circle_events_mouse_scrolled(struct dt_iop_module_t *module,
                                          const int up,
                                          const uint32_t state,
                                          dt_masks_form_t *form,
-                                         const int parentid,
+                                         const dt_mask_id_t parentid,
                                          dt_masks_form_gui_t *gui,
                                          const int index)
 {
@@ -210,7 +210,7 @@ static int _circle_events_button_pressed(struct dt_iop_module_t *module,
                                          const int type,
                                          const uint32_t state,
                                          dt_masks_form_t *form,
-                                         const int parentid,
+                                         const dt_mask_id_t parentid,
                                          dt_masks_form_gui_t *gui,
                                          const int index)
 {
@@ -394,12 +394,12 @@ static int _circle_events_button_released(struct dt_iop_module_t *module,
                                           const int which,
                                           const uint32_t state,
                                           dt_masks_form_t *form,
-                                          const int parentid,
+                                          const dt_mask_id_t parentid,
                                           dt_masks_form_gui_t *gui,
                                           const int index)
 {
   if(which == 3
-     && parentid > 0
+     && dt_is_valid_maskid(parentid)
      && gui->edit_mode == DT_MASKS_EDIT_FULL)
   {
     // we hide the form
@@ -525,7 +525,7 @@ static int _circle_events_mouse_moved(struct dt_iop_module_t *module,
                                       const double pressure,
                                       const int which,
                                       dt_masks_form_t *form,
-                                      const int parentid,
+                                      const dt_mask_id_t parentid,
                                       dt_masks_form_gui_t *gui,
                                       const int index)
 {

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -431,7 +431,7 @@ static int _ellipse_events_mouse_scrolled(struct dt_iop_module_t *module,
                                           const int up,
                                           const uint32_t state,
                                           dt_masks_form_t *form,
-                                          const int parentid,
+                                          const dt_mask_id_t parentid,
                                           dt_masks_form_gui_t *gui,
                                           const int index)
 {
@@ -571,7 +571,7 @@ static int _ellipse_events_button_pressed(struct dt_iop_module_t *module,
                                           const int type,
                                           const uint32_t state,
                                           dt_masks_form_t *form,
-                                          const int parentid,
+                                          const dt_mask_id_t parentid,
                                           dt_masks_form_gui_t *gui,
                                           const int index)
 {
@@ -767,12 +767,12 @@ static int _ellipse_events_button_released(struct dt_iop_module_t *module,
                                            const int which,
                                            const uint32_t state,
                                            dt_masks_form_t *form,
-                                           const int parentid,
+                                           const dt_mask_id_t parentid,
                                            dt_masks_form_gui_t *gui,
                                            const int index)
 {
   if(which == 3
-     && parentid > 0
+     && dt_is_valid_maskid(parentid)
      && gui->edit_mode == DT_MASKS_EDIT_FULL)
   {
     // we hide the form
@@ -1004,7 +1004,7 @@ static int _ellipse_events_mouse_moved(struct dt_iop_module_t *module,
                                        const double pressure,
                                        const int which,
                                        dt_masks_form_t *form,
-                                       const int parentid,
+                                       const dt_mask_id_t parentid,
                                        dt_masks_form_gui_t *gui,
                                        const int index)
 {

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -113,7 +113,7 @@ static int _gradient_events_mouse_scrolled(struct dt_iop_module_t *module,
                                            const int up,
                                            const uint32_t state,
                                            dt_masks_form_t *form,
-                                           const int parentid,
+                                           const dt_mask_id_t parentid,
                                            dt_masks_form_gui_t *gui,
                                            const int index)
 {
@@ -201,7 +201,7 @@ static int _gradient_events_button_pressed(struct dt_iop_module_t *module,
                                            const int type,
                                            const uint32_t state,
                                            dt_masks_form_t *form,
-                                           const int parentid,
+                                           const dt_mask_id_t parentid,
                                            dt_masks_form_gui_t *gui,
                                            const int index)
 {
@@ -341,12 +341,12 @@ static int _gradient_events_button_released(struct dt_iop_module_t *module,
                                             const int which,
                                             const uint32_t state,
                                             dt_masks_form_t *form,
-                                            const int parentid,
+                                            const dt_mask_id_t parentid,
                                             dt_masks_form_gui_t *gui,
                                             const int index)
 {
   if(which == 3
-     && parentid > 0
+     && dt_is_valid_maskid(parentid)
      && gui->edit_mode == DT_MASKS_EDIT_FULL)
   {
     // we hide the form
@@ -563,7 +563,7 @@ static int _gradient_events_mouse_moved(struct dt_iop_module_t *module,
                                         const double pressure,
                                         const int which,
                                         dt_masks_form_t *form,
-                                        const int parentid,
+                                        const dt_mask_id_t parentid,
                                         dt_masks_form_gui_t *gui,
                                         const int index)
 {

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1138,7 +1138,7 @@ static int _path_events_mouse_scrolled(struct dt_iop_module_t *module,
                                        const int up,
                                        const uint32_t state,
                                        dt_masks_form_t *form,
-                                       const int parentid,
+                                       const dt_mask_id_t parentid,
                                        dt_masks_form_gui_t *gui,
                                        const int index)
 {
@@ -1297,7 +1297,7 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module,
                                        const int type,
                                        const uint32_t state,
                                        dt_masks_form_t *form,
-                                       const int parentid,
+                                       const dt_mask_id_t parentid,
                                        dt_masks_form_gui_t *gui,
                                        const int index)
 {
@@ -1625,7 +1625,7 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module,
     if(g_list_shorter_than(form->points, 4))
     {
       // if the form doesn't belong to a group, we don't delete it
-      if(parentid <= 0) return 1;
+      if(!dt_is_valid_maskid(parentid)) return 1;
 
       // we hide the form
       if(!(darktable.develop->form_visible->type & DT_MASKS_GROUP))
@@ -1700,7 +1700,7 @@ static int _path_events_button_pressed(struct dt_iop_module_t *module,
     return 1;
   }
   else if(which == 3
-          && parentid > 0
+          && dt_is_valid_maskid(parentid)
           && gui->edit_mode == DT_MASKS_EDIT_FULL)
   {
     // we hide the form
@@ -1742,7 +1742,7 @@ static int _path_events_button_released(struct dt_iop_module_t *module,
                                         const int which,
                                         const uint32_t state,
                                         dt_masks_form_t *form,
-                                        const int parentid,
+                                        const dt_mask_id_t parentid,
                                         dt_masks_form_gui_t *gui,
                                         const int index)
 {
@@ -1909,7 +1909,7 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module,
                                     const double pressure,
                                     const int which,
                                     dt_masks_form_t *form,
-                                    const int parentid,
+                                    const dt_mask_id_t parentid,
                                     dt_masks_form_gui_t *gui,
                                     const int index)
 {

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2872,7 +2872,7 @@ void dt_dev_pixelpipe_get_dimensions(dt_dev_pixelpipe_t *pipe,
 
 float *dt_dev_get_raster_mask(const dt_dev_pixelpipe_t *pipe,
                               const dt_iop_module_t *raster_mask_source,
-                              const int raster_mask_id,
+                              const dt_mask_id_t raster_mask_id,
                               const dt_iop_module_t *target_module,
                               gboolean *free_mask)
 {

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -296,7 +296,7 @@ void dt_dev_pixelpipe_disable_before(dt_dev_pixelpipe_t *pipe, const char *op);
 // helper function to pass a raster mask through a (so far) processed pipe
 float *dt_dev_get_raster_mask(const dt_dev_pixelpipe_t *pipe,
                               const struct dt_iop_module_t *raster_mask_source,
-                              const int raster_mask_id,
+                              const dt_mask_id_t raster_mask_id,
                               const struct dt_iop_module_t *target_module,
                               gboolean *free_mask);
 // some helper functions related to the details mask interface

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1867,7 +1867,7 @@ static gboolean _lib_masks_selection_change_r(GtkTreeModel *model,
 
 static void _lib_masks_selection_change(dt_lib_module_t *self,
                                         struct dt_iop_module_t *module,
-                                        const int selectid)
+                                        const dt_mask_id_t selectid)
 {
   dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
   if(!lm->treeview) return;

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -173,7 +173,7 @@ static void _property_changed(GtkWidget *widget, dt_masks_property_t prop)
          || (dev->mask_form_selected_id && dev->mask_form_selected_id != sel->formid))
         continue;;
 
-      if(prop == DT_MASKS_PROPERTY_OPACITY && fpt->parentid)
+      if(prop == DT_MASKS_PROPERTY_OPACITY && dt_is_valid_maskid(fpt->parentid))
       {
         const float new_opacity = dt_masks_form_change_opacity(sel, fpt->parentid,
                                                          value - d->last_value[prop]);
@@ -255,7 +255,7 @@ static void _lib_masks_get_values(GtkTreeModel *model,
                                   GtkTreeIter *iter,
                                   dt_iop_module_t **module,
                                   int *groupid,
-                                  int *formid)
+                                  dt_mask_id_t *formid)
 {
   // returns module & groupid & formid if requested
   if(module ) gtk_tree_model_get(model, iter, TREE_MODULE, module, -1);
@@ -324,7 +324,7 @@ static void _tree_add_exist(GtkButton *button, dt_masks_form_t *grp)
 {
   if(!grp || !(grp->type & DT_MASKS_GROUP)) return;
   // we get the new formid
-  const int id = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(button), "formid"));
+  const dt_mask_id_t id = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(button), "formid"));
   dt_iop_module_t *module = g_object_get_data(G_OBJECT(button), "module");
 
   // we add the form in this group
@@ -361,10 +361,10 @@ static void _tree_group(GtkButton *button, dt_lib_module_t *self)
     GtkTreeIter iter;
     if(gtk_tree_model_get_iter(model, &iter, item))
     {
-      int id = -1;
+      dt_mask_id_t id = NO_MASKID;
       _lib_masks_get_values(model, &iter, NULL, NULL, &id);
 
-      if(id > 0)
+      if(dt_is_valid_maskid(id))
       {
         dt_masks_point_group_t *fpt =
           (dt_masks_point_group_t *)malloc(sizeof(dt_masks_point_group_t));
@@ -573,8 +573,8 @@ static void _tree_difference(GtkButton *button, dt_lib_module_t *self)
     GtkTreeIter iter;
     if(gtk_tree_model_get_iter(model, &iter, item))
     {
-      int grid = -1;
-      int id = -1;
+      dt_mask_id_t grid = NO_MASKID;
+      dt_mask_id_t id = NO_MASKID;
       _lib_masks_get_values(model, &iter, NULL, &grid, &id);
 
       dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, grid);
@@ -634,8 +634,8 @@ static void _tree_exclusion(GtkButton *button, dt_lib_module_t *self)
     GtkTreeIter iter;
     if(gtk_tree_model_get_iter(model, &iter, item))
     {
-      int grid = -1;
-      int id = -1;
+      dt_mask_id_t grid = NO_MASKID;
+      dt_mask_id_t id = NO_MASKID;
       _lib_masks_get_values(model, &iter, NULL, &grid, &id);
 
       dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, grid);
@@ -696,8 +696,8 @@ static void _tree_union(GtkButton *button, dt_lib_module_t *self)
 
     if(gtk_tree_model_get_iter(model, &iter, item))
     {
-      int grid = -1;
-      int id = -1;
+      dt_mask_id_t grid = NO_MASKID;
+      dt_mask_id_t id = NO_MASKID;
       _lib_masks_get_values(model, &iter, NULL, &grid, &id);
 
       dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, grid);
@@ -742,13 +742,13 @@ static void _tree_union(GtkButton *button, dt_lib_module_t *self)
 
 static void _swap_first_second_item_visibility(dt_lib_masks_t *lm,
                                                GtkTreeIter *iter,
-                                               const int first_id,
-                                               const int second_id)
+                                               const dt_mask_id_t first_id,
+                                               const dt_mask_id_t second_id)
 {
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(lm->treeview));
 
-  int grid = -1;
-  int id = -1;
+  dt_mask_id_t grid = NO_MASKID;
+  dt_mask_id_t id = NO_MASKID;
   _lib_masks_get_values(model, iter, NULL, &grid, &id);
 
   dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, grid);
@@ -812,14 +812,14 @@ static void _tree_moveup(GtkButton *button, dt_lib_module_t *self)
 
     if(gtk_tree_model_get_iter(model, &iter, item))
     {
-      int grid = -1;
-      int id = -1;
+      dt_mask_id_t grid = NO_IMGID;
+      dt_mask_id_t id = NO_IMGID;
       _lib_masks_get_values(model, &iter, NULL, &grid, &id);
 
       GtkTreeIter *prev_iter = gtk_tree_iter_copy(&iter);
       gtk_tree_model_iter_previous(model, prev_iter);
-      int prev_grid = -1;
-      int prev_id = -1;
+      dt_mask_id_t prev_grid = NO_IMGID;
+      dt_mask_id_t prev_id = NO_IMGID;
       _lib_masks_get_values(model, prev_iter, NULL, &prev_grid, &prev_id);
 
       if(_is_first_tree_item(model, prev_iter))
@@ -1026,7 +1026,7 @@ static void _tree_selection_change(GtkTreeSelection *selection, dt_lib_masks_t *
   g_list_free_full(items, (GDestroyNotify)gtk_tree_path_free);
 
   dt_masks_form_t *grp2 = dt_masks_create(DT_MASKS_GROUP);
-  grp2->formid = 0;
+  grp2->formid = NO_MASKID;
   dt_masks_group_ungroup(grp2, grp);
 
   // don't call dt_masks_change_form_gui because it triggers a selection change again
@@ -1410,7 +1410,7 @@ static gboolean _tree_query_tooltip(GtkWidget *widget,
   return show;
 }
 
-static void _is_form_used(const int formid,
+static void _is_form_used(const dt_mask_id_t formid,
                           dt_masks_form_t *grp,
                           char *text,
                           const size_t text_length,
@@ -1560,12 +1560,12 @@ static void _lib_masks_list_recurs(GtkTreeStore *treestore,
 gboolean _find_mask_iter_by_values(GtkTreeModel *model,
                                    GtkTreeIter *iter,
                                    const dt_iop_module_t *module,
-                                   const int formid,
+                                   const dt_mask_id_t formid,
                                    const int level)
 {
   do
   {
-    int fid = -1;
+    dt_mask_id_t fid = NO_MASKID;
     dt_iop_module_t *mod;
     _lib_masks_get_values(model, iter, &mod, NULL, &fid);
     gboolean found = (fid == formid)
@@ -1782,8 +1782,8 @@ static gboolean _remove_foreach(GtkTreeModel *model,
 {
   if(!iter) return 0;
   GList **rl = (GList **)data;
-  const int refid = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(model), "formid"));
-  const int refgid = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(model), "groupid"));
+  const dt_mask_id_t refid = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(model), "formid"));
+  const dt_mask_id_t refgid = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(model), "groupid"));
 
   int grid = -1;
   int id = -1;
@@ -1797,7 +1797,7 @@ static gboolean _remove_foreach(GtkTreeModel *model,
   return 0;
 }
 
-static void _lib_masks_remove_item(dt_lib_module_t *self, int formid, int parentid)
+static void _lib_masks_remove_item(dt_lib_module_t *self, dt_mask_id_t formid, dt_mask_id_t parentid)
 {
   dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
   // for each node , we refresh the string
@@ -1829,7 +1829,7 @@ static gboolean _lib_masks_selection_change_r(GtkTreeModel *model,
                                               GtkTreeSelection *selection,
                                               GtkTreeIter *iter,
                                               struct dt_iop_module_t *module,
-                                              const int selectid,
+                                              const dt_mask_id_t selectid,
                                               const int level)
 {
   gboolean found = FALSE;
@@ -1837,7 +1837,7 @@ static gboolean _lib_masks_selection_change_r(GtkTreeModel *model,
   GtkTreeIter i = *iter;
   do
   {
-    int id = -1;
+    dt_mask_id_t id = NO_MASKID;
     dt_iop_module_t *mod;
     _lib_masks_get_values(model, &i, &mod, NULL, &id);
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3063,7 +3063,7 @@ void enter(dt_view_t *self)
   }
   dt_masks_change_form_gui(NULL);
   dev->form_gui->pipe_hash = 0;
-  dev->form_gui->formid = 0;
+  dev->form_gui->formid = NO_MASKID;
   dev->gui_leaving = FALSE;
   dev->gui_module = NULL;
 


### PR DESCRIPTION
Currently we a number of "int variants" for an identifier of mask & forms. Introducing

```
typedef int32_t dt_mask_id_t;
#define NO_MASKID (0)
#define dt_is_valid_maskid(n) ((n) > NO_MASKID)
```

in `darktable.h`, all masking & blending code uses them too.

(Got into this while checking and understanding roi_aware blending - atm not possible in some cases or even crashing)