### PR TITLE
Revert my wrong replacement for Bayer4 term

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -573,7 +573,7 @@ The following is a summary of the main features added to darktable
 - Properly translate collection sort names in the recent collection
   sort history pop-up.
 
-- Fix dual demosaicing options for Quad Bayer sensor cameras where
+- Fix dual demosaicing options for 4-color Bayer sensor cameras where
   only VNG4 and PassThrough are supported.
 
 - Do not truncate focal length on thumbnails to avoid loss of


### PR DESCRIPTION
However, since Bayer4 is a term that is unknown to the general public (it is almost impossible to find it by searching the Internet), and the release notes are for users to read, it has been changed to a more understandable one, this time correctly.

Thanks to @kmilos for spotting the error.