### PR TITLE
rawprepare: enable per-color black control for non-CFA images

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -167,8 +167,10 @@ rawprepare_4f(read_only image2d_t in, write_only image2d_t out,
 
   if(x >= width || y >= height) return;
 
+  const float4 black4 = (const float4)(black[0], black[1], black[2], black[3]);
+  const float4 div4 = (const float4)(div[0], div[1], div[2], div[3]);
   float4 pixel = read_imagef(in, sampleri, (int2)(x + cx, y + cy));
-  pixel.xyz = (pixel.xyz - black[0]) / div[0];
+  pixel.xyz = (pixel.xyz - black4.xyz) / div4.xyz;
 
   write_imagef(out, (int2)(x, y), pixel);
 }

--- a/src/imageio/imageio_rawspeed.cc
+++ b/src/imageio/imageio_rawspeed.cc
@@ -248,7 +248,7 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
       }
       black /= 4.0f;
 
-      img->raw_black_level = CLAMP(black, 0, UINT16_MAX);
+      img->raw_black_level = CLAMP(roundf(black), 0, UINT16_MAX);
     }
 
     /*


### PR DESCRIPTION
@jenshannoschwalm This is kinda related to https://github.com/darktable-org/rawspeed/issues/215 (rawspeed still needs to parse and pass on all the channels for non-CFA DNGs) and e.g. https://github.com/darktable-org/darktable/issues/14221.

At least this should enable the required flexibility for tweaking individual channels manually.

~~Q: was not sure about aligned access, so used `vload4` instead of casting, which might hurt performance, so please review and comment.~~