### PR TITLE
Add support for Behringer X-Touch Compact

### DIFF
--- a/src/libs/tools/gamepad.c
+++ b/src/libs/tools/gamepad.c
@@ -57,16 +57,16 @@ int position(const dt_lib_module_t *self)
   return 1;
 }
 
-typedef struct gamepad_device
+typedef struct dt_gamepad_device_t
 {
   dt_input_device_t id;
   SDL_GameController *controller;
   Uint32 timestamp;
   int value[SDL_CONTROLLER_AXIS_MAX];
   int location[SDL_CONTROLLER_AXIS_MAX];
-} gamepad_device;
+} dt_gamepad_device_t;
 
-const char *button_names[]
+static const char *_button_names[]
   = { N_("button a"), N_("button b"), N_("button x"), N_("button y"),
       N_("button back"), N_("button guide"), N_("button start"),
       N_("left stick"), N_("right stick"), N_("left shoulder"), N_("right shoulder"),
@@ -75,17 +75,19 @@ const char *button_names[]
       N_("left trigger"), N_("right trigger"),
       NULL };
 
-gchar *key_to_string(const guint key, const gboolean display)
+static gchar *_key_to_string(const guint key,
+                             const gboolean display)
 {
-  const gchar *name = key < SDL_CONTROLLER_BUTTON_MAX + 2 ? button_names[key] : N_("invalid gamepad button");
+  const gchar *name = key < SDL_CONTROLLER_BUTTON_MAX + 2 ? _button_names[key] : N_("invalid gamepad button");
   return g_strdup(display ? _(name) : name);
 }
 
-gboolean string_to_key(const gchar *string, guint *key)
+static gboolean _string_to_key(const gchar *string,
+                               guint *key)
 {
   *key = 0;
-  while(button_names[*key])
-    if(!strcmp(button_names[*key], string))
+  while(_button_names[*key])
+    if(!strcmp(_button_names[*key], string))
       return TRUE;
     else
       (*key)++;
@@ -93,22 +95,24 @@ gboolean string_to_key(const gchar *string, guint *key)
   return FALSE;
 }
 
-const char *move_names[]
+static const char *_move_names[]
   = { N_("left x"), N_("left y"), N_("right x"), N_("right y"),
       N_("left diagonal"), N_("left skew"), N_("right diagonal"), N_("right skew"),
       NULL };
 
-gchar *move_to_string(const guint move, const gboolean display)
+static gchar *_move_to_string(const guint move,
+                              const gboolean display)
 {
-  const gchar *name = move < SDL_CONTROLLER_AXIS_MAX + 4 /* diagonals */ ? move_names[move] : N_("invalid gamepad axis");
+  const gchar *name = move < SDL_CONTROLLER_AXIS_MAX + 4 /* diagonals */ ? _move_names[move] : N_("invalid gamepad axis");
   return g_strdup(display ? _(name) : name);
 }
 
-gboolean string_to_move(const gchar *string, guint *move)
+static gboolean _string_to_move(const gchar *string,
+                                guint *move)
 {
   *move = 0;
-  while(move_names[*move])
-    if(!strcmp(move_names[*move], string))
+  while(_move_names[*move])
+    if(!strcmp(_move_names[*move], string))
       return TRUE;
     else
       (*move)++;
@@ -116,17 +120,18 @@ gboolean string_to_move(const gchar *string, guint *move)
   return FALSE;
 }
 
-const dt_input_driver_definition_t driver_definition
-  = { "game", key_to_string, string_to_key, move_to_string, string_to_move };
+static const dt_input_driver_definition_t _driver_definition
+  = { "game", _key_to_string, _string_to_key, _move_to_string, _string_to_move };
 
-static gboolean pump_events(gpointer user_data)
+static gboolean _pump_events(gpointer user_data)
 {
   SDL_PumpEvents();
 
   return G_SOURCE_CONTINUE;
 }
 
-void process_axis_timestep(gamepad_device *gamepad, Uint32 timestamp)
+static void _process_axis_timestep(dt_gamepad_device_t *gamepad,
+                                   const Uint32 timestamp)
 {
   if(timestamp > gamepad->timestamp)
   {
@@ -141,9 +146,10 @@ void process_axis_timestep(gamepad_device *gamepad, Uint32 timestamp)
   gamepad->timestamp = timestamp;
 }
 
-void process_axis_and_send(gamepad_device *gamepad, Uint32 timestamp)
+static void _process_axis_and_send(dt_gamepad_device_t *gamepad,
+                                   const Uint32 timestamp)
 {
-  process_axis_timestep(gamepad, timestamp);
+  _process_axis_timestep(gamepad, timestamp);
 
   const gdouble step_size = 32768 * 1000 / 5; // FIXME configurable, x & y separately
 
@@ -182,15 +188,14 @@ void process_axis_and_send(gamepad_device *gamepad, Uint32 timestamp)
   }
 }
 
-static gboolean poll_gamepad_devices(gpointer user_data)
+static gboolean _poll_devices(gpointer user_data)
 {
-//  dt_input_device_t id = GPOINTER_TO_INT(user_data);
   dt_lib_module_t *self = user_data;
 
   SDL_Event event;
   int num_events = 0;
 
-  gamepad_device *gamepad = NULL;
+  dt_gamepad_device_t *gamepad = NULL;
   SDL_JoystickID prev_which = -1;
 
   while(SDL_PollEvent(&event) > 0 )
@@ -203,7 +208,7 @@ static gboolean poll_gamepad_devices(gpointer user_data)
       SDL_GameController *controller = SDL_GameControllerFromInstanceID(prev_which);
       gamepad = NULL;
       for(GSList *gamepads = self->data; gamepads; gamepads = gamepads->next)
-        if(((gamepad_device *)(gamepads->data))->controller == controller)
+        if(((dt_gamepad_device_t *)(gamepads->data))->controller == controller)
         {
           gamepad = gamepads->data;
           break;
@@ -215,13 +220,13 @@ static gboolean poll_gamepad_devices(gpointer user_data)
     {
     case SDL_CONTROLLERBUTTONDOWN:
       dt_print(DT_DEBUG_INPUT, "SDL button down event time %d id %d button %hhd state %hhd\n", event.cbutton.timestamp, event.cbutton.which, event.cbutton.button, event.cbutton.state);
-      process_axis_and_send(gamepad, event.cbutton.timestamp);
+      _process_axis_and_send(gamepad, event.cbutton.timestamp);
       dt_shortcut_key_press(gamepad->id, event.cbutton.timestamp, event.cbutton.button);
 
       break;
     case SDL_CONTROLLERBUTTONUP:
       dt_print(DT_DEBUG_INPUT, "SDL button up event time %d id %d button %hhd state %hhd\n", event.cbutton.timestamp, event.cbutton.which, event.cbutton.button, event.cbutton.state);
-      process_axis_and_send(gamepad, event.cbutton.timestamp);
+      _process_axis_and_send(gamepad, event.cbutton.timestamp);
       dt_shortcut_key_release(gamepad->id, event.cbutton.timestamp, event.cbutton.button);
       break;
     case SDL_CONTROLLERAXISMOTION:
@@ -244,7 +249,7 @@ static gboolean poll_gamepad_devices(gpointer user_data)
       }
       else
       {
-        process_axis_timestep(gamepad, event.caxis.timestamp);
+        _process_axis_timestep(gamepad, event.caxis.timestamp);
         gamepad->value[event.caxis.axis] = event.caxis.value;
       }
       break;
@@ -253,23 +258,23 @@ static gboolean poll_gamepad_devices(gpointer user_data)
     }
   }
 
-  for(GSList *gamepads = self->data; gamepads; gamepads = gamepads->next) process_axis_and_send(gamepads->data, SDL_GetTicks());
+  for(GSList *gamepads = self->data; gamepads; gamepads = gamepads->next) _process_axis_and_send(gamepads->data, SDL_GetTicks());
 
   if(num_events) dt_print(DT_DEBUG_INPUT, "sdl num_events: %d time: %u\n", num_events, SDL_GetTicks());
   return G_SOURCE_CONTINUE;
 }
 
-void gamepad_open_devices(dt_lib_module_t *self)
+static void _gamepad_open_devices(dt_lib_module_t *self)
 {
   if(SDL_Init(SDL_INIT_GAMECONTROLLER))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[gamepad_open_devices] ERROR initialising SDL\n");
+    dt_print(DT_DEBUG_ALWAYS, "[_gamepad_open_devices] ERROR initialising SDL\n");
     return;
   }
   else
-    dt_print(DT_DEBUG_INPUT, "[gamepad_open_devices] SDL initialized\n");
+    dt_print(DT_DEBUG_INPUT, "[_gamepad_open_devices] SDL initialized\n");
 
-  dt_input_device_t id = dt_register_input_driver(self, &driver_definition);
+  dt_input_device_t id = dt_register_input_driver(self, &_driver_definition);
 
   for(int i = 0; i < SDL_NumJoysticks() && i < 10; i++)
   {
@@ -279,17 +284,17 @@ void gamepad_open_devices(dt_lib_module_t *self)
 
       if(!controller)
       {
-        dt_print(DT_DEBUG_ALWAYS, "[gamepad_open_devices] ERROR opening game controller '%s'\n",
+        dt_print(DT_DEBUG_ALWAYS, "[_gamepad_open_devices] ERROR opening game controller '%s'\n",
                  SDL_GameControllerNameForIndex(i));
         continue;
       }
       else
       {
-        dt_print(DT_DEBUG_ALWAYS, "[gamepad_open_devices] opened game controller '%s'\n",
+        dt_print(DT_DEBUG_ALWAYS, "[_gamepad_open_devices] opened game controller '%s'\n",
                  SDL_GameControllerNameForIndex(i));
       }
 
-      gamepad_device *gamepad = (gamepad_device *)g_malloc0(sizeof(gamepad_device));
+      dt_gamepad_device_t *gamepad = (dt_gamepad_device_t *)g_malloc0(sizeof(dt_gamepad_device_t));
 
       gamepad->controller = controller;
       gamepad->id = id++;
@@ -299,24 +304,24 @@ void gamepad_open_devices(dt_lib_module_t *self)
   }
   if(self->data)
   {
-    g_timeout_add(10, poll_gamepad_devices, self);
-    g_timeout_add_full(G_PRIORITY_HIGH, 5, pump_events, self, NULL);
+    g_timeout_add(10, _poll_devices, self);
+    g_timeout_add_full(G_PRIORITY_HIGH, 5, _pump_events, self, NULL);
   }
 }
 
-void gamepad_device_free(gamepad_device *gamepad)
+static void _gamepad_device_free(dt_gamepad_device_t *gamepad)
 {
   SDL_GameControllerClose(gamepad->controller);
 
   g_free(gamepad);
 }
 
-void gamepad_close_devices(dt_lib_module_t *self)
+static void _gamepad_close_devices(dt_lib_module_t *self)
 {
-  g_source_remove_by_user_data(self); // poll_gamepad_devices
-  g_source_remove_by_user_data(self); // pump_events
+  g_source_remove_by_user_data(self); // _poll_devices
+  g_source_remove_by_user_data(self); // _pump_events
 
-  g_slist_free_full(self->data, (void (*)(void *))gamepad_device_free);
+  g_slist_free_full(self->data, (void (*)(void *))_gamepad_device_free);
   self->data = NULL;
 
   // Don't call SDL_Quit here because reinitialising using SDL_Init won't work
@@ -331,12 +336,12 @@ void gui_init(dt_lib_module_t *self)
   }
   self->data = NULL;
 
-  gamepad_open_devices(self);
+  _gamepad_open_devices(self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
 {
-  gamepad_close_devices(self);
+  _gamepad_close_devices(self);
 }
 
 #endif // HAVE_SDL

--- a/src/libs/tools/midi.c
+++ b/src/libs/tools/midi.c
@@ -61,7 +61,7 @@ int position(const dt_lib_module_t *self)
   return 1;
 }
 
-typedef struct midi_device
+typedef struct dt_midi_device_t
 {
   dt_input_device_t   id;
   const PmDeviceInfo *info;
@@ -77,27 +77,30 @@ typedef struct midi_device
 
   int                 last_controller, last_received, last_diff, num_identical;
 
-  gchar               behringer;
-} midi_device;
+  gchar               behringer; // (X)-Touch (M)ini/(C)ompact/(E)tended/(O)ne/BC(F/R)2000
+} dt_midi_device_t;
 
-const char *note_names[] = { "C","C#","D","D#","E","F","F#","G","G#","A","A#","B", NULL };
+static const char *_note_names[] = { "C","C#","D","D#","E","F","F#","G","G#","A","A#","B", NULL };
 
-gchar *key_to_string(const guint key, const gboolean display)
+static gchar *_key_to_string(const guint key,
+                             const gboolean display)
 {
   // The MIDI note range is from C−1 (note #0) to G9 (note #127).
-  return g_strdup_printf("%s%d", note_names[key % 12], (int)key / 12 - 1);
+  return g_strdup_printf(display ? "%s%d (%d)" : "%s%d",
+                         _note_names[key % 12], (int)key / 12 - 1, key);
 }
 
-gboolean string_to_key(const gchar *string, guint *key)
+static gboolean _string_to_key(const gchar *string,
+                               guint *key)
 {
   int octave = 0;
   char name[3];
 
   if(sscanf(string, "%2[ABCDEFG#]%d", name, &octave) == 2)
   {
-    for(int note = 0; note_names[note]; note++)
+    for(int note = 0; _note_names[note]; note++)
     {
-      if(!strcmp(name, note_names[note]))
+      if(!strcmp(name, _note_names[note]))
       {
         *key = note + 12 * (octave + 1);
         return TRUE;
@@ -108,21 +111,26 @@ gboolean string_to_key(const gchar *string, guint *key)
   return FALSE;
 }
 
-gchar *move_to_string(const guint move, const gboolean display)
+static gchar *_move_to_string(const guint move,
+                              const gboolean display)
 {
   return g_strdup_printf("CC%u", move);
 }
 
-gboolean string_to_move(const gchar *string, guint *move)
+static gboolean _string_to_move(const gchar *string,
+                                guint *move)
 {
   return sscanf(string, "CC%u", move) == 1;
 }
 
-gboolean key_to_move(dt_lib_module_t *self, const dt_input_device_t id, const guint key, guint *move)
+static gboolean _key_to_move(dt_lib_module_t *self,
+                             const dt_input_device_t id,
+                             const guint key,
+                             guint *move)
 {
   for(GSList *devices = self->data; devices; devices = devices->next)
   {
-    const midi_device *midi = devices->data;
+    const dt_midi_device_t *midi = devices->data;
     if(midi->id != id) continue;
 
     if(midi->behringer == 'M')
@@ -131,6 +139,19 @@ gboolean key_to_move(dt_lib_module_t *self, const dt_input_device_t id, const gu
         *move = key + 1;
       else if(key >= 24 && key < 32)
         *move = key - 13;
+      else
+        return FALSE;
+    }
+    else if(midi->behringer == 'C')
+    {
+      if(key < 16)
+        *move = key + 10;
+      else if(key >= 40 && key < 49)
+        *move = key - 39;
+      else if(key >= 55 && key < 71)
+        *move = key -18;
+      else if(key >= 95 && key < 104)
+        *move = key - 67;
       else
         return FALSE;
     }
@@ -143,10 +164,14 @@ gboolean key_to_move(dt_lib_module_t *self, const dt_input_device_t id, const gu
   return TRUE;
 }
 
-const dt_input_driver_definition_t driver_definition
-  = { "midi", key_to_string, string_to_key, move_to_string, string_to_move, key_to_move };
+static const dt_input_driver_definition_t _driver_definition
+  = { "midi", _key_to_string, _string_to_key, _move_to_string, _string_to_move, _key_to_move };
 
-void midi_write(midi_device *midi, gint channel, gint type, gint key, gint velocity)
+static void _midi_write(dt_midi_device_t *midi,
+                        const gint channel,
+                        const gint type,
+                        const gint key,
+                        const gint velocity)
 {
   if(midi->portmidi_out)
   {
@@ -161,7 +186,9 @@ void midi_write(midi_device *midi, gint channel, gint type, gint key, gint veloc
   }
 }
 
-gint calculate_move(midi_device *midi, gint controller, gint velocity)
+static gint _calculate_move(dt_midi_device_t *midi,
+                            const gint controller,
+                            const gint velocity)
 {
   switch(midi->encoding)
   {
@@ -250,7 +277,9 @@ gint calculate_move(midi_device *midi, gint controller, gint velocity)
   }
 }
 
-void midi_write_bcontrol(midi_device *midi, gchar seq, gchar *str)
+static void _midi_write_bcontrol(dt_midi_device_t *midi,
+                                 const gchar seq,
+                                 gchar *str)
 {
   // sysex string contains zeros so can't use standard string handling and Pm_WriteSysEx
   unsigned char sysex[100];
@@ -270,7 +299,10 @@ void midi_write_bcontrol(midi_device *midi, gchar seq, gchar *str)
   g_free(str);
 }
 
-void update_with_move(midi_device *midi, PmTimestamp timestamp, gint controller, float move)
+static void _update_with_move(dt_midi_device_t *midi,
+                              const PmTimestamp timestamp,
+                              const gint controller,
+                              const float move)
 {
   float new_position = dt_shortcut_move(midi->id, timestamp, controller, move);
 
@@ -281,29 +313,43 @@ void update_with_move(midi_device *midi, PmTimestamp timestamp, gint controller,
     : new_position >= DT_VALUE_PATTERN_PLUS_MINUS ? 3
     : 1;
 
-  if(midi->behringer == 'M'
-     && (midi->first_key == 8 ? controller <  9 /* layer A */
-         : controller > 10 /* layer B */))
+  static const int light_codes[] = { 1, 1 /* pan */, 2 /* fan */, 4 /* trim */};
+
+  if(midi->behringer == 'M')
   {
-    static const int light_codes[] = { 1, 1 /* pan */, 2 /* fan */, 4 /* trim */};
-
-    // Light pattern always for 1-8 range, but CC=1-8 (bank A) or 11-18 (bank B).
-    midi_write(midi, 0, 0xB, controller % 10, light_codes[new_pattern]);
+    if(midi->first_key == 8
+       ? controller <  9 /* layer A */
+       : controller > 10 /* layer B */)
+    {
+      // Light pattern always for 1-8 range, but CC=1-8 (bank A) or 11-18 (bank B).
+      _midi_write(midi, 0, 0xB, controller % 10, light_codes[new_pattern]);
+    }
   }
-
-  if(new_pattern != midi->rotor_lights[controller])
+  else if(midi->behringer == 'C')
+  {
+    if(midi->first_key == 16
+       ? (controller >= 10 && controller <= 25) /* layer A */
+       : (controller >= 37 && controller <= 52) /* layer B */)
+    {
+      // Light pattern always for 10-25 range, but CC=10-25 (bank A) or 37-52 (bank B).
+      _midi_write(midi, 1, 0xB, controller % 27, light_codes[new_pattern]);
+    }
+  }
+  else if(new_pattern != midi->rotor_lights[controller])
   {
     midi->rotor_lights[controller] = new_pattern;
-    if(strchr("RF", midi->behringer) && controller < 32 && midi->portmidi_out)
-    {
-      static const gchar *light_codes[] = { "1dot/off", "12dot", "bar", "pan" };
 
-      midi_write_bcontrol(midi, 0, g_strdup_printf("$rev %c", midi->behringer));
-      midi_write_bcontrol(midi, 1, g_strdup_printf("$encoder %d", controller + 1));
-      midi_write_bcontrol(midi, 2, g_strdup_printf("  .easypar CC 1 %d 0 127 absolute", controller));
-      midi_write_bcontrol(midi, 3, g_strdup_printf("  .mode %s", light_codes[new_pattern]));
-      midi_write_bcontrol(midi, 4, g_strdup_printf("  .showvalue on"));
-      midi_write_bcontrol(midi, 5, g_strdup_printf("$end"));
+    if((midi->behringer == 'R' || midi->behringer == 'F')
+       && controller < 32 && midi->portmidi_out)
+    {
+      static const gchar *bcontrol_codes[] = { "1dot/off", "12dot", "bar", "pan" };
+
+      _midi_write_bcontrol(midi, 0, g_strdup_printf("$rev %c", midi->behringer));
+      _midi_write_bcontrol(midi, 1, g_strdup_printf("$encoder %d", controller + 1));
+      _midi_write_bcontrol(midi, 2, g_strdup_printf("  .easypar CC 1 %d 0 127 absolute", controller));
+      _midi_write_bcontrol(midi, 3, g_strdup_printf("  .mode %s", bcontrol_codes[new_pattern]));
+      _midi_write_bcontrol(midi, 4, g_strdup_printf("  .showvalue on"));
+      _midi_write_bcontrol(midi, 5, g_strdup_printf("$end"));
     }
   }
 
@@ -326,7 +372,7 @@ void update_with_move(midi_device *midi, PmTimestamp timestamp, gint controller,
     const int c = - new_position;
     if(c > 1)
     {
-      if(midi->behringer == 'M')
+      if(midi->behringer == 'M' || midi->behringer == 'C')
         rotor_position = fmodf(c * 10.5f - (c > 13 ? 140.1f : 8.6f), 128);
       else
         rotor_position = fmodf(c * 9.0f - 10.f, 128);
@@ -338,16 +384,17 @@ void update_with_move(midi_device *midi, PmTimestamp timestamp, gint controller,
   }
 
   midi->last_known[controller] = rotor_position;
-  midi_write(midi, midi->channel, 0xB, controller, rotor_position);
-//dt_print(DT_DEBUG_INPUT, "Controller: Channel %d, controller %d, position: %d\n", midi->channel, controller, rotor_position);
+  _midi_write(midi, midi->channel, 0xB, controller, rotor_position);
+
+  // dt_print(DT_DEBUG_INPUT, "Controller: Channel %d, controller %d, position: %d\n", midi->channel, controller, rotor_position);
 }
 
-static gboolean poll_midi_devices(gpointer user_data)
+static gboolean _poll_devices(gpointer user_data)
 {
   dt_lib_module_t *self = user_data;
   for(GSList *devices = self->data; devices; devices = devices->next)
   {
-    midi_device *midi = devices->data;
+    dt_midi_device_t *midi = devices->data;
 
     PmEvent event[EVENT_BUFFER_SIZE];
     const int num_events = Pm_Read(midi->portmidi_in, event, EVENT_BUFFER_SIZE);
@@ -369,17 +416,17 @@ static gboolean poll_midi_devices(gpointer user_data)
 
       midi->channel = event_status & 0x0F;
 
-      gboolean x_touch_mini_layer_B = FALSE;
+      gboolean layer_B = FALSE;
 
       switch(event_type)
       {
       case 0x9:  // note on
         dt_print(DT_DEBUG_INPUT, "Note On: Channel %d, Data1 %d\n", midi->channel, event_data1);
 
-        x_touch_mini_layer_B = event_data1 > 23;
+        layer_B = event_data1 > (midi->behringer == 'M' ? 23 : 54);
 
         const int key_num = event_data1 - midi->first_key + 1;
-        if(key_num > midi->num_keys && midi->behringer != 'M')
+        if(key_num > midi->num_keys && !midi->behringer)
           midi->num_keys = key_num;
 
         dt_shortcut_key_press(midi->id, event[i].timestamp, event_data1);
@@ -387,42 +434,53 @@ static gboolean poll_midi_devices(gpointer user_data)
       case 0x8:  // note off
         dt_print(DT_DEBUG_INPUT, "Note Off: Channel %d, Data1 %d\n", midi->channel, event_data1);
 
-        x_touch_mini_layer_B = event_data1 > 23;
+        layer_B = event_data1 > (midi->behringer == 'M' ? 23 : 54);
 
         dt_shortcut_key_release(midi->id, event[i].timestamp, event_data1);
         break;
       case 0xb:  // controllers, sustain
-        x_touch_mini_layer_B = event_data1 > 9;
+        if(midi->behringer == 'C' && event_data1 > 100) // ignore fader touch
+        {
+          layer_B = event_data1 > 110;
+          break;
+        }
+
+        layer_B = event_data1 > (midi->behringer == 'M' ? 9 : 27);
 
         int accum = 0;
         for(int j = i; j < num_events; j++)
+        {
           if(Pm_MessageStatus(event[j].message) == event_status &&
              Pm_MessageData1(event[j].message) == event_data1)
           {
             event_data2 = Pm_MessageData2(event[j].message);
             dt_print(DT_DEBUG_INPUT, "Controller: Channel %d, Data1 %d, Data2 %d\n", midi->channel, event_data1, event_data2);
 
-            accum += calculate_move(midi, event_data1, event_data2);
+            accum += _calculate_move(midi, event_data1, event_data2);
             event[j].message = 0; // don't process again later
           }
+        }
 
         const int knob_num = event_data1 - midi->first_knob + 1;
         if(knob_num > midi->num_knobs)
           midi->num_knobs = knob_num;
 
-        update_with_move(midi, event[i].timestamp, event_data1, accum);
+        _update_with_move(midi, event[i].timestamp, event_data1, accum);
 
         break;
       default:
-        continue; // x_touch_mini_layer_B has not been set
+        continue; // layer_B has not been set
       }
 
-      if(midi->behringer == 'M'
-         && midi->first_key != (x_touch_mini_layer_B ? 32 : 8))
+      if(midi->behringer == 'M' || midi->behringer == 'C')
       {
-        midi->first_key = x_touch_mini_layer_B ? 32 : 8;
+        guint8 old_first = midi->first_key;
+        midi->first_key = midi->behringer == 'M'
+                        ? (layer_B ? 32 :  8)
+                        : (layer_B ? 71 : 16); // 'C'
 
-        for(int j = 1; j <= 18 ; j++) midi->last_known[j] = -1;
+        if(midi->first_key != old_first)
+          for(int j = 1; j <= midi->num_knobs ; j++) midi->last_known[j] = -1;
       }
     }
   }
@@ -430,17 +488,17 @@ static gboolean poll_midi_devices(gpointer user_data)
   return G_SOURCE_CONTINUE;
 }
 
-void midi_open_devices(dt_lib_module_t *self)
+static void _midi_open_devices(dt_lib_module_t *self)
 {
   if(Pm_Initialize())
   {
-    dt_print(DT_DEBUG_ALWAYS, "[midi_open_devices] ERROR initialising PortMidi\n");
+    dt_print(DT_DEBUG_ALWAYS, "[_midi_open_devices] ERROR initialising PortMidi\n");
     return;
   }
   else
-    dt_print(DT_DEBUG_INPUT, "[midi_open_devices] PortMidi initialized\n");
+    dt_print(DT_DEBUG_INPUT, "[_midi_open_devices] PortMidi initialized\n");
 
-  dt_input_device_t id = dt_register_input_driver(self, &driver_definition);
+  dt_input_device_t id = dt_register_input_driver(self, &_driver_definition);
 
   const char *devices_string = dt_conf_get_string_const("plugins/midi/devices");
   gchar **dev_strings = g_strsplit(devices_string, ",", 0);
@@ -450,7 +508,7 @@ void midi_open_devices(dt_lib_module_t *self)
   for(int i = 0; i < Pm_CountDevices(); i++)
   {
     const PmDeviceInfo *info = Pm_GetDeviceInfo(i);
-    dt_print(DT_DEBUG_INPUT, "[midi_open_devices] found midi device '%s' via '%s'\n", info->name, info->interf);
+    dt_print(DT_DEBUG_INPUT, "[_midi_open_devices] found midi device '%s' via '%s'\n", info->name, info->interf);
 
     if(info->input && !strstr(info->name, "Midi Through Port"))
     {
@@ -499,33 +557,57 @@ void midi_open_devices(dt_lib_module_t *self)
 
       if(error < 0)
       {
-        dt_print(DT_DEBUG_ALWAYS, "[midi_open_devices] ERROR opening midi device '%s' via '%s'\n",
+        dt_print(DT_DEBUG_ALWAYS, "[_midi_open_devices] ERROR opening midi device '%s' via '%s'\n",
                  info->name, info->interf);
         continue;
       }
       else
       {
-        dt_print(DT_DEBUG_INPUT, "[midi_open_devices] opened midi device '%s' via '%s' as midi%d\n",
+        dt_print(DT_DEBUG_INPUT, "[_midi_open_devices] opened midi device '%s' via '%s' as midi%d\n",
                  info->name, info->interf, dev);
       }
 
-      midi_device *midi = (midi_device *)g_malloc0(sizeof(midi_device));
+      dt_midi_device_t *midi = (dt_midi_device_t *)g_malloc0(sizeof(dt_midi_device_t));
 
       midi->id          = id + dev;
       midi->info        = info;
       midi->portmidi_in = stream_in;
-
-      midi->behringer = strstr(info->name, "X-TOUCH MINI") ? 'M'
-                      : strstr(info->name, "BCR2000"     ) ? 'R'
-                      : strstr(info->name, "BCF2000"     ) ? 'F'
-                      : 0 /* (X)-Touch (C)ompact/(E)tended/(O)ne */;
-
       midi->encoding    = encoding;
-      midi->num_knobs   = midi->behringer == 'M' ? 18 : midi->behringer ? 32 : 0;
-      midi->first_knob  = midi->behringer == 'M' ?  1 : 0;
-      midi->num_keys    = midi->behringer == 'M' ? 16 : num_keys;
-      midi->first_key   = midi->behringer == 'M' ?  8 : 0;
-      midi->first_light = 0;
+      midi->num_keys    = num_keys;
+
+      if(strstr(info->name, "X-TOUCH MINI"))
+      {
+        midi->behringer =  'M';
+        midi->num_knobs =   18;
+        midi->first_knob =   1;
+        midi->num_keys =    16;
+        midi->first_key =    8;
+        midi->channel =     10;
+      }
+      else if(strstr(info->name, "X-TOUCH COMPACT"))
+       {
+        midi->behringer =  'C';
+        midi->num_knobs =   52;
+        midi->first_knob =   1;
+        midi->num_keys =    39;
+        midi->first_key =   16;
+      }
+      else if(strstr(info->name, "BCR2000"))
+      {
+        midi->behringer =  'R';
+        midi->num_knobs =   56;
+        midi->num_keys =    26;
+        midi->first_key =   32;
+        midi->first_light = 32;
+      }
+      else if(strstr(info->name, "BCF2000"))
+      {
+        midi->behringer =  'F';
+        midi->num_knobs =   40;
+        midi->num_keys =    26;
+        midi->first_key =   32;
+        midi->first_light = 32;
+      }
 
       midi->num_identical = midi->behringer || encoding ? 0 : 5; // countdown "relative down" moves received before switching to relative mode
       midi->last_received = -1;
@@ -547,10 +629,10 @@ void midi_open_devices(dt_lib_module_t *self)
 
   g_strfreev(dev_strings);
 
-  if(self->data) g_timeout_add(10, poll_midi_devices, self);
+  if(self->data) g_timeout_add(10, _poll_devices, self);
 }
 
-void midi_device_free(midi_device *midi)
+static void _midi_device_free(dt_midi_device_t *midi)
 {
   Pm_Close(midi->portmidi_in);
 
@@ -562,30 +644,35 @@ void midi_device_free(midi_device *midi)
   g_free(midi);
 }
 
-void midi_close_devices(dt_lib_module_t *self)
+static void _midi_close_devices(dt_lib_module_t *self)
 {
   g_source_remove_by_user_data(self);
 
-  g_slist_free_full(self->data, (void (*)(void *))midi_device_free);
+  g_slist_free_full(self->data, (void (*)(void *))_midi_device_free);
   self->data = NULL;
 
   Pm_Terminate();
 }
 
-//static void callback_image_changed(gpointer instance, gpointer user_data)
-static gboolean _timeout_midi_update(gpointer user_data)
+static gboolean _update_devices(gpointer user_data)
 {
   GSList *devices = (GSList *)((dt_lib_module_t *)user_data)->data;
   while(devices)
   {
-    midi_device *midi = devices->data;
+    dt_midi_device_t *midi = devices->data;
 
     for(int i = 0; i < midi->num_knobs && midi->portmidi_out; i++)
-      update_with_move(midi, 0, i + midi->first_knob, NAN);
+      _update_with_move(midi, 0, i + midi->first_knob, NAN);
 
+    gint global = midi->behringer == 'M' ? 0
+                : midi->behringer == 'C' ? 1
+                : midi->channel;
     for(int i = 0; i < midi->num_keys && midi->portmidi_out; i++)
-      midi_write(midi, midi->behringer == 'M' ? 0 : midi->channel, 0x9,
-                 i + midi->first_light, dt_shortcut_key_active(midi->id, i + midi->first_key));
+    {
+      _midi_write(midi, global, 0x9, i + midi->first_light,
+                  dt_shortcut_key_active(midi->id, i + midi->first_key)
+                  ? (midi->behringer == 'C' ? 2 : 1) : 0);
+    }
 
     devices = devices->next;
   }
@@ -604,28 +691,16 @@ void gui_init(dt_lib_module_t *self)
   }
   self->data = NULL;
 
-  midi_open_devices(self);
+  _midi_open_devices(self);
 
-  g_timeout_add(250, _timeout_midi_update, self);
-
-  // dt_control_signal_connect(darktable.signals, DT_SIGNAL_DEVELOP_IMAGE_CHANGED,
-  //                           G_CALLBACK(callback_image_changed), self);
-
-  // dt_control_signal_connect(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_CHANGE,
-  //                           G_CALLBACK(callback_image_changed), self);
+  g_timeout_add(250, _update_devices, self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
 {
   g_source_remove_by_user_data(self);
 
-  // dt_control_signal_disconnect(darktable.signals,
-  //                              G_CALLBACK(callback_image_changed), self);
-
-  // dt_control_signal_disconnect(darktable.signals,
-  //                              G_CALLBACK(callback_image_changed), self);
-
-  midi_close_devices(self);
+  _midi_close_devices(self);
 }
 
 #endif // HAVE_PORTMIDI


### PR DESCRIPTION
And clean up of gamepad and midi code.

Similar to X-Touch Mini:
- The ring of lights around the encoders use a pattern indicating the slider range (0-100%, -x to +x and other). Encoders mapped to combos show 1 light for 1st turn and 2 for 2nd.
- Button lights indicate status (on/off) of mapped widget.
- When fallbacks are enabled, pressing an encoder knob resets the widget it is mapped to. For the nine faders the buttons underneath light up when they are set to a non-default value and pressing them resets. But all of these buttons can be explicitly mapped to something else.

The X-Touch Universal, Extender and One use another configuration mechanism again (and are crazy expensive) so will not be supported (except for standard midi functionality).

This also makes sure that resetting a combobox doesn't select the first line if it is an insensitive header. I guess that's a bug fix.

