### PR TITLE
Fix crash in history tooltip for already deleted item

### DIFF
--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -681,6 +681,9 @@ static void _lib_history_will_change_callback(gpointer instance, gpointer user_d
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_history_t *lib = (dt_lib_history_t *)self->data;
 
+  gtk_container_foreach(GTK_CONTAINER(lib->history_box),
+                        (GtkCallback)gtk_widget_set_has_tooltip, NULL);
+
   if(lib->record_history_level++ == 0 && lib->record_undo)
   {
     /* record undo/redo history snapshot */


### PR DESCRIPTION
The buttons in the darkroom history list attach a tooltip handler and hand it a direct pointer to their underlying history item, so when the user hovers over it, they see the values that changed. The tooltip handler gets called for every mouse move over a widget, not just after the timeout period when the tooltip should actually be _shown_. It seems it even gets called _before_ the widgets gets drawn, if a refresh was requested.

So with the recent change that postpones updating the button-list so it doesn't happen multiple times before it is actually drawn, there is a window where the item pointers passed to the tooltip handler are no longer valid and this causes crashes.
This can easily be triggered:
- add a lot of changes to the history
- select "original" 
- "compress history stack"-
- quickly moving the mouse upwards over the list of now defunct items.

This PR fixes the issue by immediately switching off the tooltips when being notified that the history will change.