### PR TITLE
Remove use of nan as signal in shortcuts/actions

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -3420,7 +3420,7 @@ static float _action_process_slider(gpointer target, dt_action_element_t element
   dt_bauhaus_widget_t *bhw = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &bhw->data.slider;
 
-  if(!isnan(move_size))
+  if(DT_PERFORM_ACTION(move_size))
   {
     switch(element)
     {
@@ -3534,7 +3534,7 @@ static float _action_process_combo(gpointer target, dt_action_element_t element,
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)widget;
   int value = dt_bauhaus_combobox_get(widget);
 
-  if(!isnan(move_size))
+  if(DT_PERFORM_ACTION(move_size))
   {
     if(element == DT_ACTION_ELEMENT_BUTTON || !w->data.combobox.entries->len)
     {
@@ -3625,8 +3625,8 @@ static float _action_process_focus_slider(gpointer target, dt_action_element_t e
   if(_find_nth_bauhaus(&widget, &element, DT_BAUHAUS_SLIDER))
     return _action_process_slider(widget, DT_ACTION_ELEMENT_VALUE, effect, move_size);
 
-  if(!isnan(move_size)) dt_action_widget_toast(target, NULL, _("not that many sliders"));
-  return NAN;
+  if(DT_PERFORM_ACTION(move_size)) dt_action_widget_toast(target, NULL, _("not that many sliders"));
+  return DT_ACTION_NOT_VALID;
 }
 
 static float _action_process_focus_combo(gpointer target, dt_action_element_t element, dt_action_effect_t effect, float move_size)
@@ -3635,8 +3635,8 @@ static float _action_process_focus_combo(gpointer target, dt_action_element_t el
   if(_find_nth_bauhaus(&widget, &element, DT_BAUHAUS_COMBOBOX))
     return _action_process_combo(widget, DT_ACTION_ELEMENT_SELECTION, effect, move_size);
 
-  if(!isnan(move_size)) dt_action_widget_toast(target, NULL, _("not that many dropdowns"));
-  return NAN;
+  if(DT_PERFORM_ACTION(move_size)) dt_action_widget_toast(target, NULL, _("not that many dropdowns"));
+  return DT_ACTION_NOT_VALID;
 }
 
 static float _action_process_focus_button(gpointer target, dt_action_element_t element, dt_action_effect_t effect, float move_size)
@@ -3644,14 +3644,14 @@ static float _action_process_focus_button(gpointer target, dt_action_element_t e
   GtkWidget *widget = ((dt_iop_module_t *)target)->widget;
   if(_find_nth_bauhaus(&widget, &element, DT_BAUHAUS_BUTTON))
   {
-    if(!isnan(move_size))
+    if(DT_PERFORM_ACTION(move_size))
       _action_process_button(widget, effect);
 
     return dt_bauhaus_widget_get_quad_active(widget);
   }
 
-  if(!isnan(move_size)) dt_action_widget_toast(target, NULL, _("not that many buttons"));
-  return NAN;
+  if(DT_PERFORM_ACTION(move_size)) dt_action_widget_toast(target, NULL, _("not that many buttons"));
+  return DT_ACTION_NOT_VALID;
 }
 
 static const dt_action_element_def_t _action_elements_slider[]

--- a/src/common/action.h
+++ b/src/common/action.h
@@ -20,6 +20,11 @@
 
 #include <glib.h>
 
+#define DT_READ_ACTION_ONLY -FLT_MAX
+#define DT_ACTION_NOT_VALID -FLT_MAX
+#define DT_PERFORM_ACTION(move_size) (move_size != DT_READ_ACTION_ONLY)
+#define DT_ACTION_IS_INVALID(value) (value == DT_ACTION_NOT_VALID)
+
 typedef enum dt_action_type_t
 {
   DT_ACTION_TYPE_CATEGORY,

--- a/src/common/action.h
+++ b/src/common/action.h
@@ -20,10 +20,10 @@
 
 #include <glib.h>
 
-#define DT_READ_ACTION_ONLY -FLT_MAX
-#define DT_ACTION_NOT_VALID -FLT_MAX
-#define DT_PERFORM_ACTION(move_size) (move_size != DT_READ_ACTION_ONLY)
-#define DT_ACTION_IS_INVALID(value) (value == DT_ACTION_NOT_VALID)
+#define DT_READ_ACTION_ONLY (-FLT_MAX)
+#define DT_ACTION_NOT_VALID (-FLT_MAX)
+#define DT_PERFORM_ACTION(move_size) ((move_size) != DT_READ_ACTION_ONLY)
+#define DT_ACTION_IS_INVALID(value) ((value) == DT_ACTION_NOT_VALID)
 
 typedef enum dt_action_type_t
 {

--- a/src/common/colorlabels.c
+++ b/src/common/colorlabels.c
@@ -281,9 +281,9 @@ const char *dt_colorlabels_to_string(int label)
 
 static float _action_process_color_label(gpointer target, dt_action_element_t element, dt_action_effect_t effect, float move_size)
 {
-  float return_value = NAN;
+  float return_value = DT_ACTION_NOT_VALID;
 
-  if(!isnan(move_size))
+  if(DT_PERFORM_ACTION(move_size))
   {
     GList *imgs = dt_act_on_get_images(FALSE, TRUE, FALSE);
     dt_colorlabels_toggle_label_on_list(imgs, element ? element - 1 : 5, TRUE);

--- a/src/common/ratings.c
+++ b/src/common/ratings.c
@@ -230,9 +230,9 @@ enum
 
 static float _action_process_rating(gpointer target, dt_action_element_t element, dt_action_effect_t effect, float move_size)
 {
-  float return_value = NAN;
+  float return_value = DT_ACTION_NOT_VALID;
 
-  if(!isnan(move_size))
+  if(DT_PERFORM_ACTION(move_size))
   {
     if(element != DT_VIEW_REJECT)
     {

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -45,7 +45,7 @@
 
 static float _action_process_accels_show(gpointer target, dt_action_element_t element, dt_action_effect_t effect, float move_size)
 {
-  if(!isnan(move_size))
+  if(DT_PERFORM_ACTION(move_size))
   {
     if(darktable.view_manager->accels_window.window == NULL)
     {
@@ -75,7 +75,7 @@ static float _action_process_modifiers(gpointer target, dt_action_element_t elem
 {
   GdkModifierType mask = 1;
   if(element) mask <<= element + 1; // ctrl = 4, alt = 8
-  if(!isnan(move_size))
+  if(DT_PERFORM_ACTION(move_size))
   {
     if(dt_modifier_shortcuts & mask)
     {

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -3598,7 +3598,7 @@ static float _action_process(gpointer target,
 {
   dt_iop_module_t *module = target;
 
-  if(!isnan(move_size))
+  if(DT_PERFORM_ACTION(move_size))
   {
     switch(element)
     {

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -89,7 +89,7 @@ dt_input_device_t dt_register_input_driver(dt_lib_module_t *module, const dt_inp
 void dt_shortcut_key_press(dt_input_device_t id, const guint time, const guint key);
 void dt_shortcut_key_release(dt_input_device_t id, const guint time, const guint key);
 gboolean dt_shortcut_key_active(dt_input_device_t id, const guint key);
-float dt_shortcut_move(dt_input_device_t id, const guint time, const guint move, const double size);
+float dt_shortcut_move(dt_input_device_t id, const guint time, const guint move, const float move_size);
 
 typedef enum dt_shortcut_flag_t
 {

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2810,7 +2810,7 @@ static float _action_process_tabs(gpointer target, dt_action_element_t element, 
 {
   GtkNotebook *notebook = GTK_NOTEBOOK(target);
   GtkWidget *reset_page = gtk_notebook_get_nth_page(notebook, element);
-  if(!isnan(move_size))
+  if(DT_PERFORM_ACTION(move_size))
   {
     switch(effect)
     {
@@ -2841,7 +2841,7 @@ static float _action_process_tabs(gpointer target, dt_action_element_t element, 
 
   const int c = gtk_notebook_get_current_page(notebook);
 
-  if(!isnan(move_size))
+  if(DT_PERFORM_ACTION(move_size))
     dt_action_widget_toast(NULL, GTK_WIDGET(notebook),
                            gtk_notebook_get_tab_label_text(notebook, gtk_notebook_get_nth_page(notebook, c)));
 
@@ -2865,7 +2865,7 @@ static float _action_process_focus_tabs(gpointer target, dt_action_element_t ele
   if(notebook)
     return _action_process_tabs(notebook, element, effect, move_size);
 
-  if(!isnan(move_size)) dt_action_widget_toast(target, NULL, _("does not contain pages"));
+  if(DT_PERFORM_ACTION(move_size)) dt_action_widget_toast(target, NULL, _("does not contain pages"));
   return NAN;
 }
 

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1542,7 +1542,7 @@ static float _action_process_equalizer(gpointer target, dt_action_element_t elem
                 : ch1 == atrous_c ? atrous_ct
                 : ch1;
 
-  if(!isnan(move_size))
+  if(DT_PERFORM_ACTION(move_size))
   {
     gchar *toast = NULL;
 

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2291,7 +2291,7 @@ static float _action_process_zones(gpointer target, dt_action_element_t element,
                      ? curve[node].y
                      : dt_draw_curve_calc_value(c->minmax_curve[ch], x);
 
-  if(!isnan(move_size))
+  if(DT_PERFORM_ACTION(move_size))
   {
     float bottop = -1e6;
     switch(effect)

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -944,7 +944,7 @@ static float _action_process(gpointer target, dt_action_element_t element, dt_ac
   dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
   dt_iop_rgblevels_params_t *p = (dt_iop_rgblevels_params_t *)self->params;
 
-  if(!isnan(move_size))
+  if(DT_PERFORM_ACTION(move_size))
   {
     float bottop = -1e6;
     switch(effect)

--- a/src/libs/filters/colors.c
+++ b/src/libs/filters/colors.c
@@ -220,7 +220,7 @@ static gboolean _colors_enter_notify(GtkWidget *widget, GdkEventCrossing *event,
 
 static float _action_process_colors(gpointer target, dt_action_element_t element, dt_action_effect_t effect, float move_size)
 {
-  if(!target) return NAN;
+  if(!target) return DT_ACTION_NOT_VALID;
 
   _widgets_colors_t *colors = g_object_get_data(G_OBJECT(target), "colors_self");
   GtkWidget *w = element ? colors->colors[element - 1] : colors->operator;
@@ -228,7 +228,7 @@ static float _action_process_colors(gpointer target, dt_action_element_t element
   const int mask_k = (1 << (element - 1)) | (1 << (element - 1 + 12));
   int mask = _get_mask(rule->raw_text) & (element ? mask_k : CL_AND_MASK);
 
-  if(!isnan(move_size))
+  if(DT_PERFORM_ACTION(move_size))
   {
     GdkEventButton e = { .state = effect == DT_ACTION_EFFECT_TOGGLE_CTRL ? GDK_CONTROL_MASK : 0 };
 

--- a/src/libs/filters/rating_range.c
+++ b/src/libs/filters/rating_range.c
@@ -190,7 +190,7 @@ enum
 
 static float _action_process_ratings(gpointer target, dt_action_element_t element, dt_action_effect_t effect, float move_size)
 {
-  if(!target) return NAN;
+  if(!target) return DT_ACTION_NOT_VALID;
 
   double new_value = element - 1.0;
   GtkDarktableRangeSelect *range = target;
@@ -198,7 +198,7 @@ static float _action_process_ratings(gpointer target, dt_action_element_t elemen
   double max = range->select_max_r;
   dt_range_bounds_t bounds = range->bounds;
 
-  if(!isnan(move_size))
+  if(DT_PERFORM_ACTION(move_size))
   {
     switch(effect)
     {

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -1209,7 +1209,7 @@ static float _action_process(gpointer target, dt_action_element_t element, dt_ac
 {
   dt_lib_module_t *module = target;
 
-  if(!isnan(move_size))
+  if(DT_PERFORM_ACTION(move_size))
   {
     switch(element)
     {

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -295,7 +295,7 @@ static float _action_process_preview(gpointer target, dt_action_element_t elemen
   dt_lib_module_t *self = darktable.view_manager->proxy.lighttable.module;
   dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
 
-  if(!isnan(move_size))
+  if(DT_PERFORM_ACTION(move_size))
   {
     if(dt_view_lighttable_preview_state(darktable.view_manager))
     {

--- a/src/libs/tools/midi.c
+++ b/src/libs/tools/midi.c
@@ -307,7 +307,7 @@ static void _update_with_move(dt_midi_device_t *midi,
   float new_position = dt_shortcut_move(midi->id, timestamp, controller, move);
 
   const int new_pattern =
-    isnan(new_position) ? 1
+    DT_ACTION_IS_INVALID(new_position) ? 1
     : fmodf(new_position, DT_VALUE_PATTERN_ACTIVE) == DT_VALUE_PATTERN_SUM ? 2
     : new_position >= DT_VALUE_PATTERN_PERCENTAGE ? 2
     : new_position >= DT_VALUE_PATTERN_PLUS_MINUS ? 3
@@ -353,6 +353,9 @@ static void _update_with_move(dt_midi_device_t *midi,
     }
   }
 
+  if(DT_ACTION_IS_INVALID(new_position))
+    return;
+
   int rotor_position = 0;
   if(new_position >= 0)
   {
@@ -367,7 +370,7 @@ static void _update_with_move(dt_midi_device_t *midi,
       }
     }
   }
-  else if(!isnan(new_position))
+  else
   {
     const int c = - new_position;
     if(c > 1)
@@ -377,10 +380,6 @@ static void _update_with_move(dt_midi_device_t *midi,
       else
         rotor_position = fmodf(c * 9.0f - 10.f, 128);
     }
-  }
-  else
-  {
-    /*if(midi->last_known[controller] == 0)*/ return;
   }
 
   midi->last_known[controller] = rotor_position;
@@ -662,7 +661,7 @@ static gboolean _update_devices(gpointer user_data)
     dt_midi_device_t *midi = devices->data;
 
     for(int i = 0; i < midi->num_knobs && midi->portmidi_out; i++)
-      _update_with_move(midi, 0, i + midi->first_knob, NAN);
+      _update_with_move(midi, 0, i + midi->first_knob, DT_READ_ACTION_ONLY);
 
     gint global = midi->behringer == 'M' ? 0
                 : midi->behringer == 'C' ? 1

--- a/src/lua/gui.c
+++ b/src/lua/gui.c
@@ -122,17 +122,22 @@ static int _action_cb(lua_State *L)
   const gchar *element = lua_type(L, arg) == LUA_TSTRING ? luaL_checkstring(L, arg++) : NULL;
   const gchar *effect = lua_type(L, arg) == LUA_TSTRING ? luaL_checkstring(L, arg++) : NULL;
 
-  float move_size = NAN;
+  float move_size = DT_READ_ACTION_ONLY;
 
   if(lua_type(L, arg) == LUA_TSTRING && strlen(luaL_checkstring(L, arg)) == 0)
-    arg++; // "" -> NAN
+    arg++; // "" -> DT_READ_ACTION_ONLY
   else if(lua_type(L, arg) != LUA_TNONE)
     move_size = luaL_checknumber(L, arg++);
+  if(dt_isnan(move_size))
+    move_size = DT_READ_ACTION_ONLY;
 
   if(lua_type(L, arg) == LUA_TNUMBER)
     instance = luaL_checkinteger(L, arg++);
 
   float ret_val = dt_action_process(action, instance, element, effect, move_size);
+
+  if(DT_ACTION_IS_INVALID(ret_val))
+    ret_val = NAN;
 
   lua_pushnumber(L, ret_val);
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2118,7 +2118,7 @@ static float _action_process_skip_mouse(gpointer target,
                                         const dt_action_effect_t effect,
                                         const float move_size)
 {
-  if(!isnan(move_size))
+  if(DT_PERFORM_ACTION(move_size))
   {
     switch(effect)
     {
@@ -2153,7 +2153,7 @@ static float _action_process_preview(gpointer target,
 {
   dt_develop_t *lib = darktable.view_manager->proxy.darkroom.view->data;
 
-  if(!isnan(move_size))
+  if(DT_PERFORM_ACTION(move_size))
   {
     if(lib->full_preview)
     {
@@ -2223,7 +2223,7 @@ static float _action_process_move(gpointer target,
 {
   dt_develop_t *dev = darktable.view_manager->proxy.darkroom.view->data;
 
-  if(!isnan(move_size))
+  if(DT_PERFORM_ACTION(move_size))
   {
     dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
     const int closeup = dt_control_get_dev_closeup();

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -635,7 +635,7 @@ static float _action_process_infos(gpointer target, const dt_action_element_t el
   dt_view_t *self = darktable.view_manager->proxy.lighttable.view;
   dt_library_t *lib = (dt_library_t *)self->data;
 
-  if(!isnan(move_size))
+  if(DT_PERFORM_ACTION(move_size))
   {
     if(effect != DT_ACTION_EFFECT_ON)
     {
@@ -673,7 +673,7 @@ enum
 
 static float _action_process_move(gpointer target, dt_action_element_t element, dt_action_effect_t effect, float move_size)
 {
-  if(isnan(move_size)) return 0; // FIXME return should be relative position
+  if(!DT_PERFORM_ACTION(move_size)) return 0; // FIXME return should be relative position
 
   int action = GPOINTER_TO_INT(target);
 


### PR DESCRIPTION
In order to prepare for the disablement of `isnan()`

As discussed here https://github.com/darktable-org/darktable/pull/14253#discussion_r1171425169 this has consequences for Lua, since the value is received from `dt.gui.mimic` and passed to `dt.gui.action`  and possibly received back from `dt.gui.action` and might need intermediate checking. Could change back&forth to NAN if that is the best solution. @wpferguson ?