### PR TITLE
maintenance: isfinite ->  dt_isfinite

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -19,6 +19,7 @@
 #include "bauhaus/bauhaus.h"
 #include "common/calculator.h"
 #include "common/darktable.h"
+#include "common/math.h"
 #include "control/conf.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
@@ -29,7 +30,6 @@
 #include "osx/osx.h"
 #endif
 
-#include <math.h>
 #include <strings.h>
 
 #include <pango/pangocairo.h>
@@ -3071,7 +3071,8 @@ static gboolean dt_bauhaus_popup_key_press(GtkWidget *widget, GdkEventKey *event
         // unnormalized input, user was typing this:
         const float old_value = dt_bauhaus_slider_get_val(GTK_WIDGET(darktable.bauhaus->current));
         const float new_value = dt_calculator_solve(old_value, darktable.bauhaus->keys);
-        if(isfinite(new_value)) dt_bauhaus_slider_set_val(GTK_WIDGET(darktable.bauhaus->current), new_value);
+        if(dt_isfinite(new_value))
+          dt_bauhaus_slider_set_val(GTK_WIDGET(darktable.bauhaus->current), new_value);
         darktable.bauhaus->keys_cnt = 0;
         memset(darktable.bauhaus->keys, 0, sizeof(darktable.bauhaus->keys));
         dt_bauhaus_hide_popup();
@@ -3333,14 +3334,16 @@ void dt_bauhaus_vimkey_exec(const char *input)
       old_value = dt_bauhaus_slider_get(w);
       new_value = dt_calculator_solve(old_value, input);
       dt_print(DT_DEBUG_ALWAYS, " = %f\n", new_value);
-      if(isfinite(new_value)) dt_bauhaus_slider_set(w, new_value);
+      if(dt_isfinite(new_value))
+        dt_bauhaus_slider_set(w, new_value);
       break;
     case DT_BAUHAUS_COMBOBOX:
       // TODO: what about text as entry?
       old_value = dt_bauhaus_combobox_get(w);
       new_value = dt_calculator_solve(old_value, input);
       dt_print(DT_DEBUG_ALWAYS, " = %f\n", new_value);
-      if(isfinite(new_value)) dt_bauhaus_combobox_set(w, new_value);
+      if(dt_isfinite(new_value))
+        dt_bauhaus_combobox_set(w, new_value);
       break;
     default:
       break;

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -18,6 +18,7 @@
 
 #include "common/darktable.h"
 #include "common/debug.h"
+#include "common/math.h"
 #include "common/styles.h"
 #include "common/undo.h"
 #include "control/conf.h"
@@ -805,7 +806,7 @@ static gchar *_lib_history_change_text(dt_introspection_field_t *field,
     }
     break;
   case DT_INTROSPECTION_TYPE_FLOAT:
-    if(*(float*)o != *(float*)p && (isfinite(*(float*)o) || isfinite(*(float*)p)))
+    if(*(float*)o != *(float*)p && (dt_isfinite(*(float*)o) || dt_isfinite(*(float*)p)))
       return g_strdup_printf("%s\t%.4f\t\u2192\t%.4f", d, *(float*)o, *(float*)p);
     break;
   case DT_INTROSPECTION_TYPE_INT:


### PR DESCRIPTION
Replace all calls to `isfinite` with calls to the new optimization-safe `dt_isfinite`.