### PR TITLE
maintenance: isinf -> dt_isinf

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -37,7 +37,6 @@
 #include "gui/color_picker_proxy.h"
 
 #include <assert.h>
-#include <math.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -2441,7 +2440,7 @@ static gboolean _dev_pixelpipe_process_rec(
           const float f = ((float *)(*output))[k];
           if(isnan(f))
             hasnan = 1;
-          else if(isinf(f))
+          else if(dt_isinf(f))
             hasinf = 1;
           else
           {
@@ -2478,7 +2477,7 @@ static gboolean _dev_pixelpipe_process_rec(
         const float f = ((float *)(*output))[k];
         if(isnan(f))
           hasnan = 1;
-        else if(isinf(f))
+        else if(dt_isinf(f))
           hasinf = 1;
         else
         {


### PR DESCRIPTION
Replace all (two) calls to isinf by calls to the new optimization-safe dt_isinf.