### PR TITLE
Fixing details mask #14257

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -245,7 +245,7 @@ static void _refine_with_detail_mask(struct dt_iop_module_t *self,
                                      const struct dt_iop_roi_t *const roi_out,
                                      const float level)
 {
-  if(level == 0.0f) return;
+  if(feqf(level, 0.0f, 1e-6)) return;
 
   const gboolean detail = (level > 0.0f);
   const float threshold = _detail_mask_threshold(level, detail);
@@ -682,7 +682,7 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self,
                                         const float level,
                                         const int devid)
 {
-  if(level == 0.0f) return;
+  if(feqf(level, 0.0f, 1e-6)) return;
 
   const int detail = (level > 0.0f);
   const float threshold = _detail_mask_threshold(level, detail);

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -288,12 +288,12 @@ extern const dt_introspection_type_enum_tuple_t dt_develop_invert_mask_names[];
 /** blend gui data */
 typedef struct dt_iop_gui_blend_data_t
 {
-  int blendif_support;
-  int blend_inited;
-  int blendif_inited;
-  int masks_support;
-  int masks_inited;
-  int raster_inited;
+  gboolean blendif_support;
+  gboolean blend_inited;
+  gboolean blendif_inited;
+  gboolean masks_support;
+  gboolean masks_inited;
+  gboolean raster_inited;
 
   dt_develop_blend_colorspace_t csp;
   dt_iop_module_t *module;

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2133,7 +2133,7 @@ static gboolean _blendop_blendif_enter(GtkWidget *widget,
 
   dt_iop_gui_blend_data_t *data = module->blend_data;
 
-  dt_dev_pixelpipe_display_mask_t mode = 0;
+  dt_dev_pixelpipe_display_mask_t mode = DT_DEV_PIXELPIPE_DISPLAY_NONE;
 
   // depending on shift modifiers we activate channel and/or mask display
   if(dt_modifier_is(event->state, GDK_SHIFT_MASK | GDK_CONTROL_MASK))
@@ -2640,7 +2640,7 @@ void dt_iop_gui_init_blendif(GtkWidget *blendw, dt_iop_module_t *module)
     g_signal_connect(G_OBJECT(bd->colorpicker_set_values), "toggled",
                      G_CALLBACK(_update_gradient_slider_pickers), module);
 
-    bd->blendif_inited = 1;
+    bd->blendif_inited = TRUE;
   }
 }
 
@@ -2788,7 +2788,7 @@ void dt_iop_gui_init_masks(GtkWidget *blendw, dt_iop_module_t *module)
     gtk_box_pack_start(GTK_BOX(bd->masks_box), GTK_WIDGET(hbox), TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->masks_box), GTK_WIDGET(abox), TRUE, TRUE, 0);
 
-    bd->masks_inited = 1;
+    bd->masks_inited = TRUE;
   }
 }
 
@@ -2945,7 +2945,7 @@ void dt_iop_gui_init_raster(GtkWidget *blendw, dt_iop_module_t *module)
 
     gtk_box_pack_start(GTK_BOX(bd->raster_box), GTK_WIDGET(hbox), TRUE, TRUE, 0);
 
-    bd->raster_inited = 1;
+    bd->raster_inited = TRUE;
   }
 }
 
@@ -3676,7 +3676,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw,
     gtk_widget_set_name(GTK_WIDGET(bd->bottom_box), "blending-box");
     gtk_widget_set_name(GTK_WIDGET(iopw), "blending-wrapper");
 
-    bd->blend_inited = 1;
+    bd->blend_inited = TRUE;
 
     ++darktable.bauhaus->skip_accel;
     --darktable.gui->reset;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -330,8 +330,6 @@ void dt_dev_pixelpipe_cleanup(dt_dev_pixelpipe_t *pipe)
   pipe->output_imgid = NO_IMGID;
   pipe->next_important_module = FALSE;
 
-  dt_dev_clear_rawdetail_mask(pipe);
-
   if(pipe->forms)
   {
     g_list_free_full(pipe->forms, (void (*)(void *))dt_masks_free_form);
@@ -365,6 +363,9 @@ void dt_dev_pixelpipe_cleanup_nodes(dt_dev_pixelpipe_t *pipe)
   }
   g_list_free(pipe->nodes);
   pipe->nodes = NULL;
+
+  dt_dev_clear_rawdetail_mask(pipe);
+
   // also cleanup iop here
   if(pipe->iop)
   {

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -519,7 +519,7 @@ void dt_dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe,
       {
         const dt_develop_blend_params_t *const bp =
           (const dt_develop_blend_params_t *)piece->blendop_data;
-        if(bp->details != 0.0f)
+        if(!feqf(bp->details, 0.0f, 1e-6))
           pipe->want_detail_mask |= DT_DEV_DETAIL_MASK_REQUIRED;
       }
     }
@@ -2985,7 +2985,7 @@ gboolean dt_dev_write_rawdetail_mask(dt_dev_pixelpipe_iop_t *piece,
                                      const int mode)
 {
   dt_dev_pixelpipe_t *p = piece->pipe;
-  if((p->want_detail_mask & DT_DEV_DETAIL_MASK_REQUIRED) == 0)
+  if(!(p->want_detail_mask & DT_DEV_DETAIL_MASK_REQUIRED))
   {
     if(p->rawdetail_mask_data)
       dt_dev_clear_rawdetail_mask(p);
@@ -3032,7 +3032,7 @@ gboolean dt_dev_write_rawdetail_mask_cl(dt_dev_pixelpipe_iop_t *piece,
                                         const int mode)
 {
   dt_dev_pixelpipe_t *p = piece->pipe;
-  if((p->want_detail_mask & DT_DEV_DETAIL_MASK_REQUIRED) == 0)
+  if(!(p->want_detail_mask & DT_DEV_DETAIL_MASK_REQUIRED))
   {
     if(p->rawdetail_mask_data)
       dt_dev_clear_rawdetail_mask(p);
@@ -3117,7 +3117,7 @@ float *dt_dev_distort_detail_mask(const dt_dev_pixelpipe_t *pipe,
 {
   if(!pipe->rawdetail_mask_data) return NULL;
   gboolean valid = FALSE;
-  const int check = pipe->want_detail_mask & ~DT_DEV_DETAIL_MASK_REQUIRED;
+  const dt_develop_detail_mask_t check = pipe->want_detail_mask & ~DT_DEV_DETAIL_MASK_REQUIRED;
 
   GList *source_iter;
   for(source_iter = pipe->nodes; source_iter; source_iter = g_list_next(source_iter))

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -169,7 +169,7 @@ typedef struct dt_dev_pixelpipe_t
   // running in a tiling context?
   gboolean tiling;
   // should this pixelpipe display a mask in the end?
-  int mask_display;
+  dt_dev_pixelpipe_display_mask_t mask_display;
   // should this pixelpipe completely suppressed the blendif module?
   gboolean bypass_blendif;
   // input data based on this timestamp:

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -695,7 +695,7 @@ static void _process_lf(dt_iop_module_t *self,
 
   const int ch = piece->colors;
   const int ch_width = ch * roi_in->width;
-  const int mask_display = piece->pipe->mask_display;
+  const dt_dev_pixelpipe_display_mask_t mask_display = piece->pipe->mask_display;
 
   const unsigned int pixelformat = ch == 3
     ? LF_CR_3(RED, GREEN, BLUE)

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -223,7 +223,7 @@ typedef struct dt_iop_toneequalizer_gui_data_t
   float step; // scrolling step
 
   // 14 int to pack - contiguous memory
-  int mask_display;
+  gboolean mask_display;
   int max_histogram;
   int buf_width;
   int buf_height;
@@ -1981,7 +1981,7 @@ static void show_luminance_mask_callback(GtkWidget *togglebutton,
   {
     dt_control_log(_("cannot display masks when the blending mask is displayed"));
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->show_luminance_mask), FALSE);
-    g->mask_display = 0;
+    g->mask_display = FALSE;
     return;
   }
   else
@@ -3275,7 +3275,7 @@ static void _develop_ui_pipe_started_callback(gpointer instance,
   {
     // if module is not active, disable mask preview
     dt_iop_gui_enter_critical_section(self);
-    g->mask_display = 0;
+    g->mask_display = FALSE;
     dt_iop_gui_leave_critical_section(self);
   }
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -952,7 +952,7 @@ static void _dev_change_image(dt_develop_t *dev, const dt_imgid_t imgid)
   // commit image ops to db
   dt_dev_write_history(dev);
 
-  const int32_t new_imgid = dev->image_storage.id;
+  const dt_imgid_t new_imgid = dev->image_storage.id;
 
   // be sure light table will update the thumbnail
   if(!dt_history_hash_is_mipmap_synced(new_imgid))


### PR DESCRIPTION
Due to the pixelpipe cache improvements we got aware of a bug in the rawdetails masking code via #14257.

Basically the details mask must be deallocated whenever we cleanup the pixelpipe nodes (not the whole pixelpipe).

While investigating the issue some other fixes have been done.

Fixes #14257