### PR TITLE
opencl: use also platform name to distinguish devices

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -2010,6 +2010,21 @@ void dt_configure_runtime_performance(const int old, char *info)
     g_strlcat(info, "\n\n", DT_PERF_INFOSIZE);
   }
 
+  if(old < 14)
+  {
+    g_strlcat(info, INFO_HEADER, DT_PERF_INFOSIZE);
+    g_strlcat(info, _("OpenCL global config parameters 'per device' data has been recreated with an updated name."), DT_PERF_INFOSIZE);
+    g_strlcat(info, "\n", DT_PERF_INFOSIZE);
+    g_strlcat(info, _("you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"), DT_PERF_INFOSIZE);
+    g_strlcat(info, "\n  ", DT_PERF_INFOSIZE);
+    g_strlcat(info, _(" 'avoid_atomics' 'micro_nap' 'pinned_memory' 'roundupwd' 'roundupht' 'eventhandles' 'async' 'disable' 'magic'"), DT_PERF_INFOSIZE);
+    g_strlcat(info, "\n", DT_PERF_INFOSIZE);
+    g_strlcat(info, _("you may tune as before except 'magic'"), DT_PERF_INFOSIZE);
+    g_strlcat(info, "\n", DT_PERF_INFOSIZE);
+    g_strlcat(info, _("If you're using device names in 'opencl_device_priority' you should update them to the new names."), DT_PERF_INFOSIZE);
+    g_strlcat(info, "\n\n", DT_PERF_INFOSIZE);
+  }
+
   #undef INFO_HEADER
 }
 

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -169,7 +169,7 @@ typedef int32_t dt_mask_id_t;
 // version of current performance configuration version
 // if you want to run an updated version of the performance configuration later
 // bump this number and make sure you have an updated logic in dt_configure_performance()
-#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 13
+#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 14
 #define DT_PERF_INFOSIZE 4096
 
 // every module has to define this:

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -67,7 +67,7 @@ extern "C" {
 #define DT_OPENCL_DEFAULT_COMPILE_AMD ("-cl-fast-relaxed-math")
 #define DT_OPENCL_DEFAULT_COMPILE_NVIDIA ("-cl-fast-relaxed-math")
 #define DT_OPENCL_DEFAULT_COMPILE ("")
-#define DT_CLDEVICE_HEAD ("cldevice_v4_")
+#define DT_CLDEVICE_HEAD ("cldevice_v5_")
 
 // version for current darktable cl kernels
 // this is reflected in the kernel directory and allows to
@@ -142,7 +142,7 @@ typedef struct dt_opencl_device_t
   int maxeventslot;
   int nvidia_sm_20;
   const char *vendor;
-  const char *name;
+  const char *fullname;
   const char *cname;
   const char *options;
   cl_int summary;


### PR DESCRIPTION
* A device fullname is generated as platform_name + device_name.
* Device canonical name is the canonicalized device fullname.
* The device cached kernels uses the device fullname.
* opencl_checksum is calculated also considering the platform_name.
* Debug messages reports the device fullname.
* If platform name cannot be determined it'll default to
  "unknownplatform"
* Since Mesa platform device names contains also environment data (llvm
  version, kernel version etc...) strip them from the device name.
* Rename some variables to better represent their meaning.
* Bump DT_DEVICE_HEAD version to ("cldevice_v5_").
* Bumped DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION to 14 and add message
  to show what changed.

@jenshannoschwalm

This will help to distinguish between devices with the same name provided by multiple platforms (like mesa clover and mesa rusticl).
As you know it won't help to obtain unique device names since it's quite impossible. Additionally the mesa device name will change also with the same device since it contains information that will change at the change of the environment (kernel version, llvm version). i.e `AMD Radeon RX 5700 (navi10, LLVM 15.0.7, DRM 3.49, 6.2.10-arch1-1)`

As an example this is the output of darktable-cltest on my system (a single device provided by 3 platforms: mesa clover, mesa rusticl, amd rocm opencl):

```
> RUSTICL_ENABLE=radeonsi ./bin/darktable-cltest -d opencl
     0.0479 [dt_get_sysresource_level] switched to 3 as `unrestricted'
     0.0479   total mem:       31968MB
     0.0479   mipmap cache:    3996MB
     0.0479   available mem:   511494MB
     0.0479   singlebuff:      31968MB
     0.0479   OpenCL tune mem: WANTED
     0.0479   OpenCL pinned:   WANTED
[opencl_init] opencl related configuration options:
[opencl_init] opencl: ON
[opencl_init] opencl_scheduling_profile: 'default'
[opencl_init] opencl_library: 'default path'
[opencl_init] opencl_device_priority: '+*/+*/+*/+*/+*'
[opencl_init] opencl_mandatory_timeout: 40000
[opencl_init] opencl library 'libOpenCL' found on your system and loaded
[opencl_init] found 3 platforms
[opencl_init] found 3 devices

[dt_opencl_device_init]
   DEVICE:                   0: 'AMD Radeon RX 5700 (navi10, LLVM 15.0.7, DRM 3.49, 6.2.10-arch1-1)'
   PLATFORM NAME & VENDOR:   Clover, Mesa
   CANONICAL NAME:           clover_amdradeonrx5700navi10llvm1507drm3496210arch11
   DRIVER VERSION:           23.1.0-devel
   DEVICE VERSION:           OpenCL 1.1 Mesa 23.1.0-devel
   DEVICE_TYPE:              GPU
   *** The OpenCL driver doesn't provide image support. See also 'clinfo' output ***

[dt_opencl_device_init]
   DEVICE:                   1: 'AMD Radeon RX 5700 (navi10, LLVM 15.0.7, DRM 3.49, 6.2.10-arch1-1)'
   PLATFORM NAME & VENDOR:   rusticl, Mesa/X.org
   CANONICAL NAME:           rusticl_amdradeonrx5700navi10llvm1507drm3496210arch11
   DRIVER VERSION:           23.1.0-devel
   DEVICE VERSION:           OpenCL 3.0
   DEVICE_TYPE:              GPU
   GLOBAL MEM SIZE:          8192 MB
   MAX MEM ALLOC:            2048 MB
   MAX IMAGE SIZE:           16384 x 16384
   MAX WORK GROUP SIZE:      1024
   MAX WORK ITEM DIMENSIONS: 3
   MAX WORK ITEM SIZES:      [ 1024 1024 1024 ]
   ASYNC PIXELPIPE:          NO
   PINNED MEMORY TRANSFER:   WANTED
   MEMORY TUNING:            WANTED
   FORCED HEADROOM:          400
   AVOID ATOMICS:            NO
   MICRO NAP:                250
   ROUNDUP WIDTH:            16
   ROUNDUP HEIGHT:           16
   CHECK EVENT HANDLES:      128
   TILING ADVANTAGE:         0.000
   DEFAULT DEVICE:           NO
   KERNEL BUILD DIRECTORY:   /home/sgotti/git/github.com/darktable-org/darktable/build/share/darktable/kernels
   KERNEL DIRECTORY:         /home/sgotti/.cache/darktable/cached_v1_kernels_for_rusticl_AMDRadeonRX5700navi10LLVM1507DRM3496210arch11_2310devel
   CL COMPILER OPTION:       -cl-fast-relaxed-math
   KERNEL LOADING TIME:       0.4783 sec

[dt_opencl_device_init]
   DEVICE:                   2: 'gfx1010:xnack-'
   PLATFORM NAME & VENDOR:   AMD Accelerated Parallel Processing, Advanced Micro Devices, Inc.
   CANONICAL NAME:           amdacceleratedparallelprocessing_gfx1010xnack
   DRIVER VERSION:           3513.0 (HSA1.1,LC)
   DEVICE VERSION:           OpenCL 2.0
   DEVICE_TYPE:              GPU
   GLOBAL MEM SIZE:          8176 MB
   MAX MEM ALLOC:            6950 MB
   MAX IMAGE SIZE:           16384 x 16384
   MAX WORK GROUP SIZE:      256
   MAX WORK ITEM DIMENSIONS: 3
   MAX WORK ITEM SIZES:      [ 1024 1024 1024 ]
   ASYNC PIXELPIPE:          NO
   PINNED MEMORY TRANSFER:   WANTED
   MEMORY TUNING:            WANTED
   FORCED HEADROOM:          400
   AVOID ATOMICS:            NO
   MICRO NAP:                250
   ROUNDUP WIDTH:            16
   ROUNDUP HEIGHT:           16
   CHECK EVENT HANDLES:      128
   TILING ADVANTAGE:         0.000
   DEFAULT DEVICE:           NO
   KERNEL BUILD DIRECTORY:   /home/sgotti/git/github.com/darktable-org/darktable/build/share/darktable/kernels
   KERNEL DIRECTORY:         /home/sgotti/.cache/darktable/cached_v1_kernels_for_AMDAcceleratedParallelProcessing_gfx1010xnack_35130HSA11LC
   CL COMPILER OPTION:       -cl-fast-relaxed-math
   KERNEL LOADING TIME:       0.0237 sec
[opencl_init] OpenCL successfully initialized. Internal numbers and names of available devices:
[opencl_init]           0       'rusticl, AMD Radeon RX 5700 (navi10, LLVM 15.0.7, DRM 3.49, 6.2.10-arch1-1)'
[opencl_init]           1       'AMD Accelerated Parallel Processing, gfx1010:xnack-'
[opencl_init] FINALLY: opencl is AVAILABLE and ENABLED.
[opencl_init] set scheduling profile to default.
[dt_opencl_update_priorities] these are your device priorities:
[dt_opencl_update_priorities]           image   preview export  thumbs  preview2
[dt_opencl_update_priorities]           0       0       0       0       0
[dt_opencl_update_priorities]           1       1       1       1       1
[dt_opencl_update_priorities] show if opencl use is mandatory for a given pixelpipe:
[dt_opencl_update_priorities]           image   preview export  thumbs  preview2
[dt_opencl_update_priorities]           1       1       1       1       1
[opencl_synchronization_timeout] synchronization timeout set to 200
[dt_opencl_update_priorities] these are your device priorities:
[dt_opencl_update_priorities]           image   preview export  thumbs  preview2
[dt_opencl_update_priorities]           0       0       0       0       0
[dt_opencl_update_priorities]           1       1       1       1       1
[dt_opencl_update_priorities] show if opencl use is mandatory for a given pixelpipe:
[dt_opencl_update_priorities]           image   preview export  thumbs  preview2
[dt_opencl_update_priorities]           1       1       1       1       1
[opencl_synchronization_timeout] synchronization timeout set to 200
```