### PR TITLE
fix selection start with shift-click

### DIFF
--- a/src/common/selection.c
+++ b/src/common/selection.c
@@ -285,8 +285,12 @@ void dt_selection_select_range(dt_selection_t *selection, dt_imgid_t imgid)
 {
   if(!selection->collection) return;
 
-  // selecting a range requires at least one image to be selected already
-  if(!dt_collection_get_selected_count(darktable.collection)) return;
+  // if no selection is made, add the selected image to the selection and return
+  if(!dt_collection_get_selected_count(darktable.collection))
+  {
+    dt_selection_select(selection, imgid);
+    return;
+  }
 
   /* get start and end rows for range selection */
   sqlite3_stmt *stmt;


### PR DESCRIPTION
fixes #14265 

This PR fixes the following behaviours:

- When selecting an image in lighttable with shift-click, nothing happened. Now a shift-click on the first image adds this image to the selection like a simple left-click
- When an image is selected and shift-clicking on another image which is prior to the selected image, nothing happened. Now the selection range is correctly set, no matter if the second clicked image is prior or after the first selected image.