### PR TITLE
fix first image of collection as selection start

### DIFF
--- a/src/common/selection.c
+++ b/src/common/selection.c
@@ -313,7 +313,7 @@ void dt_selection_select_range(dt_selection_t *selection, dt_imgid_t imgid)
   sqlite3_finalize(stmt);
 
   // if imgid not in collection, nothing to do
-  if(er < 1) return;
+  if(er < 0) return;
 
   // if last_single_id not in collection, we either use last selected image or first collected one
   int srid = selection->last_single_id;


### PR DESCRIPTION
In addition to PR #14269 this fixes the very first image of the collection cannot be shift-clicked as selection end.

Steps to reproduce:

- In lighttable load a collection with some images
- click on the third image to select it
- shift-click on the very first image to mark the selection range --> nothing happens

Reason for this bug: 

Selection end range `er` is initialitzed with `-1`. Selecting the first image sets `er` to `0`.

Later on, the function returns if `er < 1`:

```
// if imgid not in collection, nothing to do
  if(er < 1) return;
```