### PR TITLE
maintenance: isnan -> dt_isnan in misc files (NAN removal, part 6)

### DIFF
--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -16,14 +16,6 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-// dt_calculator_solve returns NAN on ill-formed input, so we need to tell the compiler
-// that non-finite numbers are in use in this source file even if we have globally
-// enabled the finite-math-only optimization.  Otherwise, it may optimize away
-// conditionals based on isnan() or isfinite().
-#ifdef __GNUC__
-#pragma GCC optimize ("no-finite-math-only")
-#endif
-
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -1934,7 +1934,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
     n->brightness = o->brightness;
     // fix intermediate devel versions for details mask and initialize n->details to proper values if something was wrong
     memcpy(&n->details, &o->reserved, sizeof(float));
-    if(isnan(n->details)) n->details = 0.0f;
+    if(dt_isnan(n->details)) n->details = 0.0f;
     n->details = fminf(1.0f, fmaxf(-1.0f, n->details));
 
     memcpy(n->blendif_parameters, o->blendif_parameters, sizeof(float) * 4 * DEVELOP_BLENDIF_SIZE);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1861,7 +1861,7 @@ gboolean _iop_validate_params(dt_introspection_field_t *field,
     }
     break;
   case DT_INTROSPECTION_TYPE_FLOAT:
-    all_ok = isnan(*(float*)p)
+    all_ok = dt_isnan(*(float*)p)
       || ((*(float*)p >= field->Float.Min && *(float*)p <= field->Float.Max));
     break;
   case DT_INTROSPECTION_TYPE_INT:

--- a/src/develop/openmp_maths.h
+++ b/src/develop/openmp_maths.h
@@ -118,8 +118,7 @@ static inline float v_sumf(const float vector[3])
 static inline float fmaxabsf(const float a, const float b)
 {
   // Find the max in absolute value and return it with its sign
-  return (fabsf(a) > fabsf(b) && !isnan(a)) ? a :
-                                            (isnan(b)) ? 0.f : b;
+  return (fabsf(a) > fabsf(b)) ? a : (dt_isnan(b)) ? 0.f : b;
 }
 
 
@@ -129,8 +128,7 @@ static inline float fmaxabsf(const float a, const float b)
 static inline float fminabsf(const float a, const float b)
 {
   // Find the min in absolute value and return it with its sign
-  return (fabsf(a) < fabsf(b) && !isnan(a)) ? a :
-                                            (isnan(b)) ? 0.f : b;
+  return (fabsf(a) < fabsf(b)) ? a : (dt_isnan(b)) ? 0.f : b;
 }
 
 

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2432,14 +2432,14 @@ static gboolean _dev_pixelpipe_process_rec(
     {
       int hasinf = 0, hasnan = 0;
       dt_aligned_pixel_t min = { FLT_MAX };
-      dt_aligned_pixel_t max = { FLT_MIN };
+      dt_aligned_pixel_t max = { -FLT_MAX };
 
       for(int k = 0; k < 4 * roi_out->width * roi_out->height; k++)
       {
         if((k & 3) < 3)
         {
           const float f = ((float *)(*output))[k];
-          if(isnan(f))
+          if(dt_isnan(f))
             hasnan = 1;
           else if(dt_isinf(f))
             hasinf = 1;
@@ -2471,12 +2471,12 @@ static gboolean _dev_pixelpipe_process_rec(
     {
       int hasinf = 0, hasnan = 0;
       float min = FLT_MAX;
-      float max = FLT_MIN;
+      float max = -FLT_MAX;
 
       for(int k = 0; k < roi_out->width * roi_out->height; k++)
       {
         const float f = ((float *)(*output))[k];
-        if(isnan(f))
+        if(dt_isnan(f))
           hasnan = 1;
         else if(dt_isinf(f))
           hasinf = 1;

--- a/src/dtgtk/gradientslider.c
+++ b/src/dtgtk/gradientslider.c
@@ -600,7 +600,7 @@ static gboolean _gradient_slider_draw(GtkWidget *widget, cairo_t *cr)
   cairo_set_source_rgba(cr, color.red, color.green, color.blue, 1.0);
 
   // do we have a picker value to draw?
-  if(!isnan(gslider->picker[0]))
+  if(!dt_isnan(gslider->picker[0]))
   {
     int vx_min = _scale_to_screen(widget, CLAMP(gslider->picker[1], 0.0, 1.0));
     int vx_max = _scale_to_screen(widget, CLAMP(gslider->picker[2], 0.0, 1.0));

--- a/src/imageio/imageio_libraw.c
+++ b/src/imageio/imageio_libraw.c
@@ -295,7 +295,7 @@ dt_imageio_retval_t dt_imageio_open_libraw(dt_image_t *img, const char *filename
   // but seems to be the best available. LibRaw crx decoder can actually
   // decode the raw data, but internal metadata like wb_coeffs, crops etc.
   // are not populated into libraw structure, or image is not of CFA type.
-  if(raw->rawdata.color.cam_mul[0] == 0.0f || isnan(raw->rawdata.color.cam_mul[0]) || !raw->rawdata.raw_image)
+  if(raw->rawdata.color.cam_mul[0] == 0.0f || dt_isnan(raw->rawdata.color.cam_mul[0]) || !raw->rawdata.raw_image)
   {
     dt_print(DT_DEBUG_ALWAYS, "[libraw_open] detected unsupported image `%s'\n", img->filename);
     goto error;

--- a/src/imageio/imageio_libraw.c
+++ b/src/imageio/imageio_libraw.c
@@ -18,6 +18,7 @@
 
 #ifdef HAVE_LIBRAW
 #include "common/darktable.h"
+#include "common/math.h"
 #include "imageio_common.h"
 #include "imageio_gm.h"
 #include "develop/develop.h"

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -229,8 +229,8 @@ static void _property_changed(GtkWidget *widget, dt_masks_property_t prop)
       min += sum / count;
     }
 
-    if(isnan(min)) min = _masks_properties[prop].min;
-    if(isnan(max)) max = _masks_properties[prop].max;
+    if(dt_isnan(min)) min = _masks_properties[prop].min;
+    if(dt_isnan(max)) max = _masks_properties[prop].max;
     dt_bauhaus_slider_set_soft_range(widget, min, max);
 
     dt_bauhaus_slider_set(widget, sum / count);

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -757,7 +757,7 @@ void gui_update(dt_lib_module_t *self)
         {
           (void)g_snprintf(text, sizeof(text), _("infinity"));
         }
-        else if(!(isnan(img->exif_focus_distance) || (fpclassify(img->exif_focus_distance) == FP_ZERO) ))
+        else if(!(dt_isnan(img->exif_focus_distance) || (fpclassify(img->exif_focus_distance) == FP_ZERO) ))
         {
           (void)g_snprintf(text, sizeof(text), _("%.2f m"), (double)img->exif_focus_distance);
         }


### PR DESCRIPTION
Convert calls to isnan() to optimization-safe dt_isnan().  Not all calls have been replaced to avoid conflicting with other pending PRs (once everything is merged, there should be no more direct isnan() calls in these files).
