### PR TITLE
tagging: Ensure categeory & private are initialized (4.2.x)

### DIFF
--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -1809,8 +1809,8 @@ static void _pop_menu_dictionary_edit_tag(GtkWidget *menuitem, dt_lib_module_t *
   gtk_box_pack_end(GTK_BOX(box), entry, TRUE, TRUE, 0);
 
   gint flags = 0;
-  GtkWidget *category;
-  GtkWidget *private;
+  GtkWidget *category = NULL;
+  GtkWidget *private = NULL;
   GtkTextBuffer *buffer = NULL;
   if(tagid)
   {


### PR DESCRIPTION
This ensure that it is always initialized in all code path.

Fixes #13909 in the 4.2.x stable branch