### PR TITLE
style: fix export/import overwrite message.

### DIFF
--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -441,7 +441,7 @@ static void _export_clicked(GtkWidget *w, gpointer user_data)
 
             // contents for dialog
             GtkWidget *content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog_overwrite_export));
-            sprintf(overwrite_str, _("style `%s' already exists.\ndo you want to overwrite existing style?\n"), (char*)style->data);
+            sprintf(overwrite_str, _("style `%s' already exists.\ndo you want to overwrite existing style?\n"), stylename);
             GtkWidget *label = gtk_label_new(overwrite_str);
             GtkWidget *overwrite_dialog_check_button = gtk_check_button_new_with_label(_("apply this option to all existing styles"));
 
@@ -624,7 +624,7 @@ static void _import_clicked(GtkWidget *w, gpointer user_data)
 
             // contents for dialog
             GtkWidget *content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog_overwrite_import));
-            sprintf(overwrite_str, _("style `%s' already exists.\ndo you want to overwrite existing style?\n"), (char*)filename->data);
+            sprintf(overwrite_str, _("style `%s' already exists.\ndo you want to overwrite existing style?\n"), bname);
             GtkWidget *label = gtk_label_new(overwrite_str);
             GtkWidget *overwrite_dialog_check_button = gtk_check_button_new_with_label(_("apply this option to all existing styles"));
 


### PR DESCRIPTION
Fix the export/import overwrite messages by printing the already
existing destination file name when exporting and the destination
stylename when importing.

Export:

Currently when exporting a style where the destination file already
exists we got:

```
style 'stylename' already exists.
```

With this patch we have

```
style '/path/to/style.dtstyle' already exists.
```

Import:

Currently when importing a style where the destination style already exists
we got:

```
style '/path/to/style.dtstyle' already exists.
```

With this patch we have

```
style 'stylename' already exists.
```


@TurboGit 
Just asking here but will open a new issue if you prefer:
The config keys to not ask for overwrite anymore is `plugins/lighttable/style/ask_before_delete_style`
but its name is not related to overwrite but to style deletion.

Perhaps a different config key like `plugins/lighttable/style/ask_before_overwrite_style` that affects both file overwrite on export and style overwrite on import could be better (or to be pedant two different keys for import overwrite and export overwrite).