### PR TITLE
Various fixes related to details mask

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -289,7 +289,7 @@ static void _refine_with_detail_mask(struct dt_iop_module_t *self,
   schedule(simd:static) aligned(mask, warp_mask : 64)
  #endif
   for(size_t idx =0; idx < msize; idx++)
-    mask[idx] = mask[idx] * warp_mask[idx];
+    mask[idx] = mask[idx] * CLIP(warp_mask[idx]);
   dt_free_align(warp_mask);
 
   return;
@@ -481,7 +481,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self,
   float *const restrict _mask = dt_alloc_align_float(obuffsize);
 
   dt_print_pipe(DT_DEBUG_PIPE,
-     "dt_develop_blend_process on CPU",
+     "dt_develop_blend on CPU",
      piece->pipe, self->so->op, roi_in, roi_out, 
      _mask ? "\n" : "could not allocate buffer for blending\n");
 
@@ -804,9 +804,8 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self,
   schedule(simd:static) aligned(mask, warp_mask : 64)
  #endif
   for(size_t idx = 0; idx < msize; idx++)
-  {
-    mask[idx] = mask[idx] * warp_mask[idx];
-  }
+    mask[idx] = mask[idx] * CLIP(warp_mask[idx]);
+
   dt_free_align(warp_mask);
   return;
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2604,7 +2604,7 @@ static gboolean _mask_indicator_tooltip(GtkWidget *treeview,
     else if(mm & DEVELOP_MASK_RASTER)
       type=_("raster mask");
     else
-      dt_print(DT_DEBUG_ALWAYS, "unknown mask mode '%u' in module '%s'\n", mm, module->op);
+      dt_print(DT_DEBUG_PARAMS, "unknown mask mode '%u' in module '%s'\n", mm, module->op);
     gchar *part1 = g_strdup_printf(_("this module has a `%s'"), type);
     gchar *part2 = NULL;
     if(raster && module->raster_mask.sink.source)

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -123,8 +123,14 @@ uint64_t dt_dev_pixelpipe_cache_basichash(
 
   // we use the the imgid and pipe type for the hash
   const uint32_t hashing_pipemode[2] = {(uint32_t)imgid, (uint32_t)pipe->type };
-  const char *pstr = (const char *)hashing_pipemode;
+
+  char *pstr = (char *)hashing_pipemode;
   for(size_t ip = 0; ip < sizeof(hashing_pipemode); ip++)
+    hash = ((hash << 5) + hash) ^ pstr[ip];
+
+  // also use the details mask roi
+  pstr = (char *)&pipe->rawdetail_mask_roi;
+  for(size_t ip = 0; ip < sizeof(dt_iop_roi_t); ip++)
     hash = ((hash << 5) + hash) ^ pstr[ip];
 
   // go through all modules up to position and compute a hash using the operation and params.


### PR DESCRIPTION
1. Most important, the pixelpipe cache related issues should be fixed
2. For thumbnails we always ensure full scale generation if a detail mask has been used, otherwise the output might be visually different by far too much
3. Some improved debugging output;
  a) `-d pipe` should be used for writing the masks here too
  b) `dt_print_pipe()` writes roi data whatever is available 