### PR TITLE
Don't silently swallow image change request while pipe active

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -703,6 +703,8 @@ static inline void _dt_dev_load_raw(dt_develop_t *dev, const dt_imgid_t imgid)
   const dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'r');
   dev->image_storage = *image;
   dt_image_cache_read_release(darktable.image_cache, image);
+
+  dev->requested_id = dev->image_storage.id;
 }
 
 void dt_dev_reload_image(dt_develop_t *dev, const dt_imgid_t imgid)

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -156,6 +156,7 @@ typedef struct dt_develop_t
   // calling into the cache explicitly. this should never be accessed directly, but
   // by the iop through the copy their respective pixelpipe holds, for thread-safety.
   dt_image_t image_storage;
+  dt_imgid_t requested_id;
 
   // history stack
   dt_pthread_mutex_t history_mutex;


### PR DESCRIPTION
In the darkroom, image change requests (space/backspace/click in filmstrip) are quietly ignored if we are "busy" (loading an image or calculating one of the pipes). This can make figuring out whether your request will eventually be honoured annoying (and lead to repeating clicks/key presses "just to be sure" and having to keep doing this until something happens).

This PR will save the current state of the image as soon as a change is requested, will then keep retrying to load the new one and, when eventually it succeeds, discard any changes and undo records that happened in between on the old image. This means one could request multiple image changes while the first one hasn't processed yet (space space moves forward two images) so the "currently requested" image is now separate from "currently loaded" image.

It can take a while for the image to be changed, but at least you don't have to stay around for it and can be "confident" that it will eventually happen.

In a next phase, it would be nice if the pipes were interruptible as soon as we know we don't care about the result anymore. There is an `image_force_reload` flag that seems to aim for that, but only in the main pipe and it doesn't seem to work. I'd like to reduce the chance of this PR causing hangs/crashes so possible improvements could be added later.