### PR TITLE
masks: Ensure the gui_module is set when editing masks.

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1600,9 +1600,10 @@ static gboolean _blendop_masks_show_and_edit(GtkWidget *widget,
 
   if(event->button == 1)
   {
+    dt_iop_request_focus(self);
+
     ++darktable.gui->reset;
 
-    dt_iop_request_focus(self);
     dt_iop_color_picker_reset(self, FALSE);
 
     dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop,


### PR DESCRIPTION
Fix display of mask when clicking on the edit masks icon without having given the focus to the module first. This fix mask display in some cases when switching module's group.

Fixes #14192.