### PR TITLE
Handle fuji X-Trans I/II/III embedded lens metadata

### DIFF
--- a/src/common/image.h
+++ b/src/common/image.h
@@ -164,7 +164,7 @@ typedef union dt_image_correction_data_t
   struct {
     int nc;
     float cropf;
-    float knots[9], distortion[9], ca_r[9], ca_b[9], vignetting[9];
+    float knots[11], distortion[11], ca_r[11], ca_b[11], vignetting[11];
   } fuji;
   struct {
     int planes;


### PR DESCRIPTION
The number of knots of the spline is 11 (and probably always fixed from 0 to 1 in 0.1 steps) instead of 9 of X-Trans IV/V. The CA metadata skips the first knot (0).

Use the same crop mode logic like done for X-Trans IV/V also if looks like it doesn't exist on these cameras.

@jenshannoschwalm @TurboGit currently WIP since more testing are needed and perhaps someone else that takes a look at the metadata. Currently I tested various X-Trans I/II/III images available on https://raw.pixls.us