### PR TITLE
Again work on pixelpipe cache ( #14291)

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -319,14 +319,14 @@ void dt_dev_process_preview_job(dt_develop_t *dev)
   {
     dt_dev_pixelpipe_cleanup_nodes(dev->preview_pipe);
     dt_dev_pixelpipe_create_nodes(dev->preview_pipe, dev);
-    dt_dev_pixelpipe_flush_caches(dev->preview_pipe);
+    dt_dev_pixelpipe_cache_flush(dev->preview_pipe);
     dev->preview_loading = FALSE;
   }
 
   // if raw loaded, get new mipf
   if(dev->preview_input_changed)
   {
-    dt_dev_pixelpipe_flush_caches(dev->preview_pipe);
+    dt_dev_pixelpipe_cache_flush(dev->preview_pipe);
     dev->preview_input_changed = FALSE;
   }
 
@@ -440,14 +440,14 @@ void dt_dev_process_preview2_job(dt_develop_t *dev)
   {
     dt_dev_pixelpipe_cleanup_nodes(dev->preview2_pipe);
     dt_dev_pixelpipe_create_nodes(dev->preview2_pipe, dev);
-    dt_dev_pixelpipe_flush_caches(dev->preview2_pipe);
+    dt_dev_pixelpipe_cache_flush(dev->preview2_pipe);
     dev->preview2_loading = FALSE;
   }
 
   // if raw loaded, get new mipf
   if(dev->preview2_input_changed)
   {
-    dt_dev_pixelpipe_flush_caches(dev->preview2_pipe);
+    dt_dev_pixelpipe_cache_flush(dev->preview2_pipe);
     dev->preview2_input_changed = 0;
   }
 
@@ -573,7 +573,7 @@ void dt_dev_process_image_job(dt_develop_t *dev)
     // init pixel pipeline
     dt_dev_pixelpipe_cleanup_nodes(dev->pipe);
     dt_dev_pixelpipe_create_nodes(dev->pipe, dev);
-    if(dev->image_force_reload) dt_dev_pixelpipe_flush_caches(dev->pipe);
+    if(dev->image_force_reload) dt_dev_pixelpipe_cache_flush(dev->pipe);
     dev->image_force_reload = FALSE;
     if(dev->gui_attached)
     {

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -3444,7 +3444,7 @@ void dt_iop_refresh_center(dt_iop_module_t *module)
     // invalidate the pixelpipe cache except for the output of the prior module
     const uint64_t hash =
       dt_dev_pixelpipe_cache_basichash_prior(dev->pipe->image.id, dev->pipe, module);
-    dt_dev_pixelpipe_cache_flush_all_but(&dev->pipe->cache, hash);
+    dt_dev_pixelpipe_cache_flush_all_but(dev->pipe, hash);
     //ensure that commit_params gets called to pick up any GUI changes
     dev->pipe->changed |= DT_DEV_PIPE_SYNCH;
     dt_dev_invalidate(dev);
@@ -3462,7 +3462,7 @@ void dt_iop_refresh_preview(dt_iop_module_t *module)
     const uint64_t hash =
       dt_dev_pixelpipe_cache_basichash_prior(dev->pipe->image.id,
                                              dev->preview_pipe, module);
-    dt_dev_pixelpipe_cache_flush_all_but(&dev->preview_pipe->cache, hash);
+    dt_dev_pixelpipe_cache_flush_all_but(dev->preview_pipe, hash);
     //ensure that commit_params gets called to pick up any GUI changes
     dev->pipe->changed |= DT_DEV_PIPE_SYNCH;
     dt_dev_invalidate_all(dev);
@@ -3480,7 +3480,7 @@ void dt_iop_refresh_preview2(dt_iop_module_t *module)
     const uint64_t hash =
       dt_dev_pixelpipe_cache_basichash_prior(dev->pipe->image.id,
                                              dev->preview2_pipe, module);
-    dt_dev_pixelpipe_cache_flush_all_but(&dev->preview2_pipe->cache, hash);
+    dt_dev_pixelpipe_cache_flush_all_but(dev->preview2_pipe, hash);
     //ensure that commit_params gets called to pick up any GUI changes
     dev->pipe->changed |= DT_DEV_PIPE_SYNCH;
     dt_dev_invalidate_all(dev);

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -492,7 +492,7 @@ void dt_dev_pixelpipe_cache_invalidate_later(
 
   for(int k = DT_PIPECACHE_MIN; k < cache->entries; k++)
   {
-    if(cache->ioporder[k] > order)
+    if(cache->ioporder[k] >= order)
     {
       cache->basichash[k] = -1;
       cache->hash[k] = -1;

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -31,11 +31,13 @@ static inline int _to_mb(size_t m)
 }
 
 gboolean dt_dev_pixelpipe_cache_init(
-           dt_dev_pixelpipe_cache_t *cache,
+           struct dt_dev_pixelpipe_t *pipe,
            const int entries,
            const size_t size,
            const size_t limit)
 {
+  dt_dev_pixelpipe_cache_t *cache = &(pipe->cache);
+
   cache->entries = entries;
   cache->allmem = cache->queries = cache->misses = 0;
   cache->memlimit = limit;
@@ -92,8 +94,10 @@ gboolean dt_dev_pixelpipe_cache_init(
   return FALSE;
 }
 
-void dt_dev_pixelpipe_cache_cleanup(dt_dev_pixelpipe_cache_t *cache)
+void dt_dev_pixelpipe_cache_cleanup(struct dt_dev_pixelpipe_t *pipe)
 {
+  dt_dev_pixelpipe_cache_t *cache = &(pipe->cache);
+
   for(int k = 0; k < cache->entries; k++)
   {
     dt_free_align(cache->data[k]);
@@ -443,8 +447,10 @@ gboolean dt_dev_pixelpipe_cache_get(
   return TRUE;
 }
 
-void dt_dev_pixelpipe_cache_flush(dt_dev_pixelpipe_cache_t *cache)
+void dt_dev_pixelpipe_cache_flush(struct dt_dev_pixelpipe_t *pipe)
 {
+  dt_dev_pixelpipe_cache_t *cache = &(pipe->cache);
+
   // we don't use zero here for "swapping pipelines" having only two lines
   cache->queries = cache->misses = cache->queries & 1;
   for(int k = DT_PIPECACHE_MIN; k < cache->entries; k++)
@@ -458,9 +464,11 @@ void dt_dev_pixelpipe_cache_flush(dt_dev_pixelpipe_cache_t *cache)
 }
 
 void dt_dev_pixelpipe_cache_flush_all_but(
-        dt_dev_pixelpipe_cache_t *cache,
-        uint64_t basichash)
+        struct dt_dev_pixelpipe_t *pipe,
+        const uint64_t basichash)
 {
+  dt_dev_pixelpipe_cache_t *cache = &(pipe->cache);
+
   for(int k = DT_PIPECACHE_MIN; k < cache->entries; k++)
   {
     if(cache->basichash[k] == basichash)
@@ -478,6 +486,7 @@ void dt_dev_pixelpipe_cache_invalidate_later(
         struct dt_iop_module_t *module)
 {
   dt_dev_pixelpipe_cache_t *cache = &(pipe->cache);
+
   const int32_t order = module ? module->iop_order : 0;
   if(order < 1) return;
 

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -49,6 +49,7 @@ gboolean dt_dev_pixelpipe_cache_init(
   cache->hash = (uint64_t *)calloc(entries, sizeof(uint64_t));
   cache->used = (int32_t *)calloc(entries, sizeof(int32_t));
   cache->modname = (char **)calloc(entries, sizeof(char *));
+  cache->ioporder = (int32_t *)calloc(entries, sizeof(int32_t));
 
   for(int k = 0; k < entries; k++)
   {
@@ -58,6 +59,7 @@ gboolean dt_dev_pixelpipe_cache_init(
     cache->hash[k] = -1;
     cache->used[k] = 1;
     cache->modname[k] = NULL;
+    cache->ioporder[k] = 0;
   }
   if(!size) return TRUE;
 
@@ -111,6 +113,8 @@ void dt_dev_pixelpipe_cache_cleanup(dt_dev_pixelpipe_cache_t *cache)
   cache->size = NULL;
   free(cache->modname);
   cache->modname = NULL;
+  free(cache->ioporder);
+  cache->ioporder = NULL;
 }
 
 uint64_t dt_dev_pixelpipe_cache_basichash(
@@ -319,8 +323,7 @@ static gboolean _get_by_hash(
           const uint64_t hash,
           const size_t size,
           void **data,
-          dt_iop_buffer_dsc_t **dsc,
-          const char *const name)
+          dt_iop_buffer_dsc_t **dsc)
 {
   dt_dev_pixelpipe_cache_t *cache = &(pipe->cache);
   for(int k = DT_PIPECACHE_MIN; k < cache->entries; k++)
@@ -350,9 +353,10 @@ static gboolean _get_by_hash(
         ASAN_POISON_MEMORY_REGION(*data, cache->size[k]);
         ASAN_UNPOISON_MEMORY_REGION(*data, size);
 
-        dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe_cache_get", pipe, name, NULL, NULL,
-          "HIT line%3i, age %4i at %p hash%22" PRIu64 ", basic%22" PRIu64 "\n",
-          k, cache->used[k], cache->data[k], cache->hash[k], cache->basichash[k]); 
+        dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe_cache_get",
+          pipe, cache->modname[k], NULL, NULL,
+          "HIT line%3i, iop%3i, age %4i at %p hash%22" PRIu64 ", basic%22" PRIu64 "\n",
+          k, cache->ioporder[k], cache->used[k], cache->data[k], cache->hash[k], cache->basichash[k]); 
 
         // in case of a hit it's always good to further keep the cacheline as important
         cache->used[k] = -cache->entries;
@@ -371,7 +375,7 @@ gboolean dt_dev_pixelpipe_cache_get(
            const size_t size,
            void **data,
            dt_iop_buffer_dsc_t **dsc,
-           char *name,
+           struct dt_iop_module_t *module,
            const gboolean important)
 {
   dt_dev_pixelpipe_cache_t *cache = &(pipe->cache);
@@ -380,7 +384,7 @@ gboolean dt_dev_pixelpipe_cache_get(
     cache->used[k]++; // age all entries
 
   // cache keeps history and we have a cache hit, so no new buffer
-  if(cache->entries > DT_PIPECACHE_MIN && _get_by_hash(pipe, hash, size, data, dsc, name))
+  if(cache->entries > DT_PIPECACHE_MIN && _get_by_hash(pipe, hash, size, data, dsc))
     return FALSE;
 
   // We need a fresh buffer as there was no hit.
@@ -424,10 +428,12 @@ gboolean dt_dev_pixelpipe_cache_get(
   cache->hash[cline]      = masking ? -1 : hash;
   cache->used[cline]      = masking ? 8 * VERY_OLD_CACHE_WEIGHT
                                     : (important ? -cache->entries : 0);
-  cache->modname[cline] = name;
+  cache->modname[cline]   = module  ? module->so->op : NULL;
+  cache->ioporder[cline]  = module  ? module->iop_order : 0;
   cache->misses++;
 
-  dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "pixelpipe_cache_get", pipe, name, NULL, NULL,
+  dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "pixelpipe_cache_get",
+    pipe, cache->modname[cline], NULL, NULL,
     "%s %s line%3i, age %4i at %p. hash%22" PRIu64 ", basic%22" PRIu64 "\n",
      newdata ? "new" : "   ",
      important ? "important" : (masking ? "masking  " : "         "),
@@ -446,6 +452,7 @@ void dt_dev_pixelpipe_cache_flush(dt_dev_pixelpipe_cache_t *cache)
     cache->basichash[k] = -1;
     cache->hash[k] = -1;
     cache->used[k] = VERY_OLD_CACHE_WEIGHT;
+    cache->ioporder[k] = 0;
     ASAN_POISON_MEMORY_REGION(cache->data[k], cache->size[k]);
   }
 }
@@ -461,11 +468,32 @@ void dt_dev_pixelpipe_cache_flush_all_but(
     cache->basichash[k] = -1;
     cache->hash[k] = -1;
     cache->used[k] = VERY_OLD_CACHE_WEIGHT;
+    cache->ioporder[k] = 0;
     ASAN_POISON_MEMORY_REGION(cache->data[k], cache->size[k]);
   }
 }
 
-void dt_dev_pixelpipe_cache_reweight(
+void dt_dev_pixelpipe_cache_invalidate_later(
+        struct dt_dev_pixelpipe_t *pipe,
+        struct dt_iop_module_t *module)
+{
+  dt_dev_pixelpipe_cache_t *cache = &(pipe->cache);
+  const int32_t order = module ? module->iop_order : 0;
+  if(order < 1) return;
+
+  for(int k = DT_PIPECACHE_MIN; k < cache->entries; k++)
+  {
+    if(cache->ioporder[k] > order)
+    {
+      cache->basichash[k] = -1;
+      cache->hash[k] = -1;
+      cache->used[k] = 8 * cache->used[k];
+      cache->ioporder[k] = 0;
+    }
+  }
+}
+
+void dt_dev_pixelpipe_important_cacheline(
        struct dt_dev_pixelpipe_t *pipe,
        void *data,
        const size_t size)
@@ -473,14 +501,16 @@ void dt_dev_pixelpipe_cache_reweight(
   dt_dev_pixelpipe_cache_t *cache = &(pipe->cache);
   for(int k = DT_PIPECACHE_MIN; k < cache->entries; k++)
   {
-    if((cache->data[k] == data) && (size == cache->size[k]))
+    if((cache->data[k] == data)
+        && (size == cache->size[k])
+        && (cache->used[k] < 8 * VERY_OLD_CACHE_WEIGHT))
       cache->used[k] = -cache->entries;
   }
 }
 
-void dt_dev_pixelpipe_cache_unweight(
-       struct dt_dev_pixelpipe_t *pipe,
-       void *data)
+void dt_dev_pixelpipe_invalidate_cacheline(struct dt_dev_pixelpipe_t *pipe,
+                                           void *data,
+                                           const gboolean invalid)
 {
   dt_dev_pixelpipe_cache_t *cache = &(pipe->cache);
   for(int k = DT_PIPECACHE_MIN; k < cache->entries; k++)
@@ -489,21 +519,8 @@ void dt_dev_pixelpipe_cache_unweight(
     {
       cache->basichash[k] = -1;
       cache->hash[k] = -1;
-      cache->used[k] = 8 * VERY_OLD_CACHE_WEIGHT;
-    }
-  }
-}
-
-void dt_dev_pixelpipe_cache_invalidate(dt_dev_pixelpipe_cache_t *cache, void *data)
-{
-  for(int k = DT_PIPECACHE_MIN; k < cache->entries; k++)
-  {
-    if(cache->data[k] == data)
-    {
-      cache->basichash[k] = -1;
-      cache->hash[k] = -1;
-      cache->used[k] = VERY_OLD_CACHE_WEIGHT;
-      ASAN_POISON_MEMORY_REGION(cache->data[k], cache->size[k]);
+      cache->used[k] = VERY_OLD_CACHE_WEIGHT * (invalid ? 8 : 1);
+      cache->ioporder[k] = 0;
     }
   }
 }

--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -52,16 +52,16 @@ typedef struct dt_dev_pixelpipe_cache_t
 /** constructs a new cache with given cache line count (entries) and float buffer entry size in bytes.
   \param[out] returns 0 if fail to allocate mem cache.
 */
-gboolean dt_dev_pixelpipe_cache_init(dt_dev_pixelpipe_cache_t *cache, int entries, size_t size, size_t limit);
-void dt_dev_pixelpipe_cache_cleanup(dt_dev_pixelpipe_cache_t *cache);
+gboolean dt_dev_pixelpipe_cache_init(struct dt_dev_pixelpipe_t *pipe, const int entries, const size_t size, const size_t limit);
+void dt_dev_pixelpipe_cache_cleanup(struct dt_dev_pixelpipe_t *pipe);
 
 /** creates a hopefully unique hash from the complete module stack up to the module-th. */
-uint64_t dt_dev_pixelpipe_cache_basichash(const dt_imgid_t imgid, struct dt_dev_pixelpipe_t *pipe, int position);
+uint64_t dt_dev_pixelpipe_cache_basichash(const dt_imgid_t imgid, struct dt_dev_pixelpipe_t *pipe, const int position);
 /** creates a hopefully unique hash from the complete module stack up to the module-th, including current viewport. */
 uint64_t dt_dev_pixelpipe_cache_hash(const dt_imgid_t imgid, const struct dt_iop_roi_t *roi,
-                                     struct dt_dev_pixelpipe_t *pipe, int position);
+                                     struct dt_dev_pixelpipe_t *pipe, const int position);
 /** return both of the above hashes */
-void dt_dev_pixelpipe_cache_fullhash(const dt_imgid_t imgid, const dt_iop_roi_t *roi, struct dt_dev_pixelpipe_t *pipe, int position,
+void dt_dev_pixelpipe_cache_fullhash(const dt_imgid_t imgid, const dt_iop_roi_t *roi, struct dt_dev_pixelpipe_t *pipe, const int position,
                                      uint64_t *basichash, uint64_t *fullhash);
 /** get the basichash for the last enabled module prior to the specified one */
 uint64_t dt_dev_pixelpipe_cache_basichash_prior(const dt_imgid_t imgid, struct dt_dev_pixelpipe_t *pipe,
@@ -79,10 +79,10 @@ gboolean dt_dev_pixelpipe_cache_get(struct dt_dev_pixelpipe_t *pipe, const uint6
 gboolean dt_dev_pixelpipe_cache_available(struct dt_dev_pixelpipe_t *pipe, const uint64_t hash, const size_t size);
 
 /** invalidates all cachelines. */
-void dt_dev_pixelpipe_cache_flush(dt_dev_pixelpipe_cache_t *cache);
+void dt_dev_pixelpipe_cache_flush(struct dt_dev_pixelpipe_t *pipe);
 
 /** invalidates all cachelines except those containing items for the given module/parameter combination */
-void dt_dev_pixelpipe_cache_flush_all_but(dt_dev_pixelpipe_cache_t *cache, uint64_t basichash);
+void dt_dev_pixelpipe_cache_flush_all_but(struct dt_dev_pixelpipe_t *pipe, const uint64_t basichash);
 
 /** invalidates all cachelines for modules with at least the same iop_order */
 void dt_dev_pixelpipe_cache_invalidate_later(struct dt_dev_pixelpipe_t *pipe, struct dt_iop_module_t *module);

--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -41,6 +41,7 @@ typedef struct dt_dev_pixelpipe_cache_t
   uint64_t *basichash;
   uint64_t *hash;
   int32_t *used;
+  int32_t *ioporder;
   // debugging helpers
   char **modname; 
   // profiling:
@@ -72,7 +73,7 @@ uint64_t dt_dev_pixelpipe_cache_basichash_prior(const dt_imgid_t imgid, struct d
   Returned flag is TRUE for a new buffer
 */
 gboolean dt_dev_pixelpipe_cache_get(struct dt_dev_pixelpipe_t *pipe, const uint64_t basichash, const uint64_t hash,
-                               const size_t size, void **data, struct dt_iop_buffer_dsc_t **dsc, char *modname, const gboolean important);
+                               const size_t size, void **data, struct dt_iop_buffer_dsc_t **dsc, struct dt_iop_module_t *module, const gboolean important);
 
 /** test availability of a cache line without destroying another, if it is not found. */
 gboolean dt_dev_pixelpipe_cache_available(struct dt_dev_pixelpipe_t *pipe, const uint64_t hash, const size_t size);
@@ -83,14 +84,14 @@ void dt_dev_pixelpipe_cache_flush(dt_dev_pixelpipe_cache_t *cache);
 /** invalidates all cachelines except those containing items for the given module/parameter combination */
 void dt_dev_pixelpipe_cache_flush_all_but(dt_dev_pixelpipe_cache_t *cache, uint64_t basichash);
 
+/** invalidates all cachelines for modules with at least the same iop_order */
+void dt_dev_pixelpipe_cache_invalidate_later(struct dt_dev_pixelpipe_t *pipe, struct dt_iop_module_t *module);
+
 /** makes this buffer very important after it has been pulled from the cache. */
-void dt_dev_pixelpipe_cache_reweight(struct dt_dev_pixelpipe_t *pipe, void *data, const size_t size);
+void dt_dev_pixelpipe_important_cacheline(struct dt_dev_pixelpipe_t *pipe, void *data, const size_t size);
 
-/** markes this buffer as to be ignored */
-void dt_dev_pixelpipe_cache_unweight(struct dt_dev_pixelpipe_t *pipe, void *data);
-
-/** mark the given cache line pointer as invalid. */
-void dt_dev_pixelpipe_cache_invalidate(dt_dev_pixelpipe_cache_t *cache, void *data);
+/** mark the given cache line as invalid or to be ignored */
+void dt_dev_pixelpipe_invalidate_cacheline(struct dt_dev_pixelpipe_t *pipe, void *data, const gboolean invalid);
 
 /** print out cache lines/hashes and do a cache cleanup */
 void dt_dev_pixelpipe_cache_report(struct dt_dev_pixelpipe_t *pipe);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -264,7 +264,7 @@ gboolean dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe,
   pipe->input_profile_info = NULL;
   pipe->output_profile_info = NULL;
 
-  return dt_dev_pixelpipe_cache_init(&(pipe->cache), entries, size, memlimit);
+  return dt_dev_pixelpipe_cache_init(pipe, entries, size, memlimit);
 }
 
 static void get_output_format(
@@ -319,7 +319,7 @@ void dt_dev_pixelpipe_cleanup(dt_dev_pixelpipe_t *pipe)
   // blocks while busy and sets shutdown bit:
   dt_dev_pixelpipe_cleanup_nodes(pipe);
   // so now it's safe to clean up cache:
-  dt_dev_pixelpipe_cache_cleanup(&(pipe->cache));
+  dt_dev_pixelpipe_cache_cleanup(pipe);
   dt_pthread_mutex_unlock(&pipe->backbuf_mutex);
 
   dt_pthread_mutex_destroy(&(pipe->backbuf_mutex));
@@ -2695,7 +2695,7 @@ gboolean dt_dev_pixelpipe_process(
 restart:
 
   // check if we should obsolete caches
-  if(pipe->cache_obsolete) dt_dev_pixelpipe_cache_flush(&(pipe->cache));
+  if(pipe->cache_obsolete) dt_dev_pixelpipe_cache_flush(pipe);
   pipe->cache_obsolete = FALSE;
 
   // mask display off as a starting point
@@ -2755,7 +2755,7 @@ restart:
       dt_capabilities_remove("opencl");
     }
 
-    dt_dev_pixelpipe_flush_caches(pipe);
+    dt_dev_pixelpipe_cache_flush(pipe);
     dt_dev_pixelpipe_change(pipe, dev);
 
     dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_OPENCL,
@@ -2817,11 +2817,6 @@ restart:
 
   pipe->processing = FALSE;
   return FALSE;
-}
-
-void dt_dev_pixelpipe_flush_caches(dt_dev_pixelpipe_t *pipe)
-{
-  dt_dev_pixelpipe_cache_flush(&pipe->cache);
 }
 
 void dt_dev_pixelpipe_get_dimensions(dt_dev_pixelpipe_t *pipe,

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -39,7 +39,6 @@ extern "C" {
  * will be freed at the end.
  */
 struct dt_iop_module_t;
-struct dt_dev_raster_mask_t;
 struct dt_iop_order_iccprofile_info_t;
 
 typedef struct dt_dev_pixelpipe_raster_mask_t

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -41,12 +41,6 @@ extern "C" {
 struct dt_iop_module_t;
 struct dt_iop_order_iccprofile_info_t;
 
-typedef struct dt_dev_pixelpipe_raster_mask_t
-{
-  int id; // 0 is reserved for the reusable masks written in blend.c
-  float *mask;
-} dt_dev_pixelpipe_raster_mask_t;
-
 typedef struct dt_dev_pixelpipe_iop_t
 {
   struct dt_iop_module_t *module;  // the module in the dev operation stack
@@ -75,7 +69,7 @@ typedef struct dt_dev_pixelpipe_iop_t
   // the following are used internally for caching:
   dt_iop_buffer_dsc_t dsc_in, dsc_out;
 
-  GHashTable *raster_masks; // GList* of dt_dev_pixelpipe_raster_mask_t
+  GHashTable *raster_masks;
 } dt_dev_pixelpipe_iop_t;
 
 typedef enum dt_dev_pixelpipe_change_t

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -253,9 +253,6 @@ void dt_dev_pixelpipe_get_dimensions(dt_dev_pixelpipe_t *pipe,
 // destroys all allocated data.
 void dt_dev_pixelpipe_cleanup(dt_dev_pixelpipe_t *pipe);
 
-// flushes all cached data. useful if input pixels unexpectedly change.
-void dt_dev_pixelpipe_flush_caches(dt_dev_pixelpipe_t *pipe);
-
 // wrapper for cleanup_nodes, create_nodes, synch_all and synch_top,
 // decides upon changed event which one to take on. also locks
 // dev->history_mutex.

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3232,7 +3232,7 @@ static int _do_get_structure_auto(dt_iop_module_t *module,
   {
     dt_control_log(_("data pending - please repeat"));
     // force to reprocess the preview, otherwise the buffer is ko
-    dt_dev_pixelpipe_flush_caches(module->dev->preview_pipe);
+    dt_dev_pixelpipe_cache_flush(module->dev->preview_pipe);
     dt_dev_reprocess_preview(module->dev);
     goto error;
   }
@@ -3284,7 +3284,7 @@ static void _do_get_structure_lines(dt_iop_module_t *self)
   {
     dt_control_log(_("data pending - please repeat"));
     // force to reprocess the preview, otherwise the buffer is ko
-    dt_dev_pixelpipe_flush_caches(self->dev->preview_pipe);
+    dt_dev_pixelpipe_cache_flush(self->dev->preview_pipe);
     dt_dev_reprocess_preview(self->dev);
     return;
   }
@@ -3332,7 +3332,7 @@ static void _do_get_structure_quad(dt_iop_module_t *self)
   {
     dt_control_log(_("data pending - please repeat"));
     // force to reprocess the preview, otherwise the buffer is ko
-    dt_dev_pixelpipe_flush_caches(self->dev->preview_pipe);
+    dt_dev_pixelpipe_cache_flush(self->dev->preview_pipe);
     dt_dev_reprocess_preview(self->dev);
     return;
   }
@@ -5445,7 +5445,7 @@ void gui_reset(struct dt_iop_module_t *self)
   _gui_update_structure_states(self, NULL);
   // force to reprocess the preview, otherwise the buffer is ko
   dt_dev_invalidate_all(self->dev);
-  dt_dev_pixelpipe_flush_caches(self->dev->preview_pipe);
+  dt_dev_pixelpipe_cache_flush(self->dev->preview_pipe);
 }
 
 static void cropmode_callback(GtkWidget *widget, gpointer user_data)

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -2047,6 +2047,7 @@ void process(struct dt_iop_module_t *self,
         dt_iop_gui_enter_critical_section(self);
         _auto_detect_WB(in, data->illuminant_type, roi_in->width, roi_in->height,
                         ch, RGB_to_XYZ, g->XYZ);
+        dt_dev_pixelpipe_cache_invalidate_later(piece->pipe, self);
         dt_iop_gui_leave_critical_section(self);
       }
 


### PR DESCRIPTION
Fixes #14291 

Another of those issues related to pixelpipe cache.
Here we change some module params (this new data is not reflected by a modified hash for the following modules in the pipe) but output of later modules in the pipe "seem" to be valid still.

In this pr

1. Some function parameter changes
2. Adding iop_order to the cache struct so we
3. A new function invalidating all cachelines with a higher iop_order. This might be very useful in other modules doing some clever stuff ...
4. Issue in channelmixer rgb auto modes should be fixed by using the new function