### PR TITLE
Remove the date-time sanitizer

### DIFF
--- a/src/imageio/imageio_exr.cc
+++ b/src/imageio/imageio_exr.cc
@@ -127,7 +127,6 @@ dt_imageio_retval_t dt_imageio_open_exr(dt_image_t *img, const char *filename, d
       {
         // utcOffset can be ignored for now, see dt_datetime_exif_to_numbers()
         char *datetime = strdup(Imf::capDate(header).c_str());
-        dt_exif_sanitize_datetime(datetime);
         dt_datetime_exif_to_img(img, datetime);
         free(datetime);
       }


### PR DESCRIPTION
Fixes #14244.


We are removing the `dt_exif_sanitize_datetime()` function because a closer look at this function and the corresponding execution paths makes it clear that it does things that are either unnecessary or wrong (and the wrong ones are then fixed right before parsing).

More precisely:

- Replacing the letter `T` between the date and time parts with a space is unnecessary, since we are using a function for parsing that expects a string in ISO8601 format, where this letter is a valid separator
- Replacing supposedly incorrect date component separators with `:` (Exif date format) is itself incorrect, as the parsing function will expect ISO8601 separators there, i.e. `-`.
Even if you correct the error and replace with `-`, it will be redundant, since such a replacement is already done immediately before calling `g_date_time_new_from_iso8601()` and it is done correctly there (that is, in specific positions of the string, and not by looping over the entire string, which was unnecessary and led to issues).
