### PR TITLE
allow double-middle-press to cycle through fit-100-200 zoom

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3710,7 +3710,7 @@ int button_pressed(dt_view_t *self,
     return 1;
   }
 
-  if(which == 2) // Middle mouse button
+  if(which == 2  && type == GDK_BUTTON_PRESS) // Middle mouse button
   {
     // zoom to 1:1 2:1 and back
     int procw, proch;


### PR DESCRIPTION
A tiny trivial follow up to #14064
If `preferences/darkroom/middle mouse button zooms to 200%` is selected, it would be assumed that you could zoom from `100% `directly to `fit` (skipping 200%) by quickly twice ("double") clicking the middle mouse button. However, what happens is that GDK sends _three_ events, `GDK_BUTTON_PRESS`, `GDK_BUTTON_PRESS` and `GDK_DOUBLE_BUTTON_PRESS`, so we go full circle. This PR simply ignores the duplicate event on the double press.