### PR TITLE
optimize edge-aware wavelets for contrast equalizer

### DIFF
--- a/src/common/eaw.h
+++ b/src/common/eaw.h
@@ -29,11 +29,22 @@ typedef void((*eaw_synthesize_t)(float *const out, const float *const in, const 
                                  const float *const restrict thrsf, const float *const restrict boostf,
                                  const int32_t width, const int32_t height));
 
-void eaw_decompose(float *const restrict out, const float *const restrict in, float *const restrict detail,
-                   const int scale, const float sharpen, const int32_t width, const int32_t height) ;
-void eaw_synthesize(float *const restrict out, const float *const restrict in, const float *const restrict detail,
-                    const float *const restrict thrsf, const float *const restrict boostf,
-                    const int32_t width, const int32_t height);
+void eaw_decompose_and_synthesize(float *const restrict out,
+                                  const float *const restrict in,
+                                  float *const restrict accum,
+                                  const int scale,
+                                  const float sharpen,
+                                  const dt_aligned_pixel_t threshold,
+                                  const dt_aligned_pixel_t boost,
+                                  const ssize_t width,
+                                  const ssize_t height) ;
+void eaw_synthesize(float *const restrict out,
+                    const float *const restrict in,
+                    const float *const restrict detail,
+                    const float *const restrict thrsf,
+                    const float *const restrict boostf,
+                    const int32_t width,
+                    const int32_t height);
 
 typedef void((*eaw_dn_decompose_t)(float *const restrict out, const float *const restrict in, float *const restrict detail,
                                    dt_aligned_pixel_t sum_squared, const int scale, const float inv_sigma2,

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -495,6 +495,38 @@ static inline void dt_vector_powf(const dt_aligned_pixel_t input,
 #endif
 }
 
+static inline void dt_vector_add(dt_aligned_pixel_t sum,
+                                 const dt_aligned_pixel_t v1,
+                                 const dt_aligned_pixel_t v2)
+{
+  for_four_channels(c, aligned(sum,v1,v2))
+    sum[c] = v1[c] + v2[c];
+}
+
+static inline void dt_vector_sub(dt_aligned_pixel_t diff,
+                                 const dt_aligned_pixel_t v1,
+                                 const dt_aligned_pixel_t v2)
+{
+  for_four_channels(c, aligned(diff,v1,v2))
+    diff[c] = v1[c] - v2[c];
+}
+
+static inline void dt_vector_mul(dt_aligned_pixel_t result,
+                                 const dt_aligned_pixel_t v1,
+                                 const dt_aligned_pixel_t v2)
+{
+  for_four_channels(c, aligned(result,v1,v2))
+    result[c] = v1[c] * v2[c];
+}
+
+static inline void dt_vector_div(dt_aligned_pixel_t result,
+                                 const dt_aligned_pixel_t v1,
+                                 const dt_aligned_pixel_t v2)
+{
+  for_four_channels(c, aligned(result,v1,v2))
+    result[c] = v1[c] / v2[c];
+}
+
 static inline void dt_vector_min(dt_aligned_pixel_t min,
                                  const dt_aligned_pixel_t v1,
                                  const dt_aligned_pixel_t v2)

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -249,8 +249,7 @@ static int get_scales(float (*thrs)[4], float (*boost)[4], float *sharp, const d
 /* just process the supplied image buffer, upstream default_process_tiling() does the rest */
 static void process_wavelets(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                              const void *const i, void *const o, const dt_iop_roi_t *const roi_in,
-                             const dt_iop_roi_t *const roi_out, const eaw_decompose_t decompose,
-                             const eaw_synthesize_t synthesize)
+                             const dt_iop_roi_t *const roi_out)
 {
   dt_iop_atrous_data_t *d = (dt_iop_atrous_data_t *)piece->data;
   dt_aligned_pixel_t thrs[MAX_NUM_SCALES];
@@ -279,11 +278,10 @@ static void process_wavelets(struct dt_iop_module_t *self, struct dt_dev_pixelpi
   }
 
   float *const restrict out = (float*)o;
-  float *restrict detail = NULL;
   float *restrict tmp = NULL;
   float *restrict tmp2 = NULL;
 
-  if(!dt_iop_alloc_image_buffers(self, roi_in, roi_out, 4, &tmp, 4, &tmp2, 4, &detail, 0))
+  if(!dt_iop_alloc_image_buffers(self, roi_in, roi_out, 4, &tmp, 4, &tmp2, 0))
   {
     dt_iop_copy_image_roi(out, i, piece->colors, roi_in, roi_out, TRUE);
     return;
@@ -299,8 +297,8 @@ static void process_wavelets(struct dt_iop_module_t *self, struct dt_dev_pixelpi
   // that we don't need to store it past the current scale's iteration
   for(int scale = 0; scale < max_scale; scale++)
   {
-    decompose(buf2, buf1, detail, scale, sharp[scale], width, height);
-    synthesize(out, out, detail, thrs[scale], boost[scale], width, height);
+    eaw_decompose_and_synthesize(buf2, buf1, out, scale, sharp[scale], thrs[scale],
+                                 boost[scale], width, height);
     if(scale == 0) buf1 = (float *)tmp2; // now switch to second scratch for buffer ping-pong between buf1 and buf2
     float *buf3 = buf2;
     buf2 = buf1;
@@ -309,12 +307,13 @@ static void process_wavelets(struct dt_iop_module_t *self, struct dt_dev_pixelpi
 
   // add in the final residue
 #ifdef _OPENMP
-#pragma omp simd aligned(buf1, out : 64)
+#pragma omp parallel for simd aligned(buf1, out : 64) \
+  dt_omp_firstprivate(width, height, buf1, out) \
+  schedule(simd:static) num_threads(MIN(dt_get_num_threads(),16))
 #endif
   for(size_t k = 0; k < (size_t)4 * width * height; k++)
     out[k] += buf1[k];
 
-  dt_free_align(detail);
   dt_free_align(tmp);
   dt_free_align(tmp2);
   return;
@@ -323,7 +322,7 @@ static void process_wavelets(struct dt_iop_module_t *self, struct dt_dev_pixelpi
 void process(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
              void *const o, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
-  process_wavelets(self, piece, i, o, roi_in, roi_out, eaw_decompose, eaw_synthesize);
+  process_wavelets(self, piece, i, o, roi_in, roi_out);
 }
 
 #ifdef HAVE_OPENCL
@@ -587,7 +586,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   const int max_scale = get_scales(thrs, boost, sharp, d, roi_in, piece);
   const int max_filter_radius = 2 * (1 << max_scale); // 2 * 2^max_scale
 
-  tiling->factor = 5.0f;                // in + out + 2*tmp + details
+  tiling->factor = 4.0f;                // in + out + 2*tmp
   tiling->factor_cl = 3.0f + max_scale; // in + out + tmp + scale buffers
   tiling->maxbuf = 1.0f;
   tiling->maxbuf_cl = 1.0f;


### PR DESCRIPTION
Merge the decompose and synthesize passes, since nothing is done in between.  This reduces memory traffic which helps performance at higher thread counts.

Perform a number of other optimizations, as well as tweaks to keep the compiler from spilling values to RAM.

Passes integration test 0024.
```
Thr	Master	PR
1	4300.99	4306.58	 +0.1%
2	2180.76 2170.35	 -0.4%
4	1128.66 1094.23	 -3.0%
8	 599.00  558.62	 -6.7%
16	 339.51  291.06	-14.2%
32	 226.11  170.30	-24.6%
64	 220.58	 153.69	-30.3%
```
