### PR TITLE
disable right-drag-rotate in snapshot

### DIFF
--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -380,7 +380,7 @@ int button_pressed(struct dt_lib_module_t *self,
     return 0;
   }
 
-  if(d->selected >= 0 && which == 1)
+  if(d->selected >= 0 && which != GDK_BUTTON_MIDDLE)
   {
     if(d->on_going) return 1;
 


### PR DESCRIPTION
#13402 allowed both middle click zoom and right-drag rotate when showing a snapshot side-by-side, but the button-release would get swallowed when drawing a horizon line (so it was hard to get rid of the angle display) and if it was drawn behind the snapshot portion, it would not be visible. This trivial fix treats a right-drag like a left-drag (i.e. it moves the divider line) except, as usual when the "a" key is held.