### PR TITLE
colorchecker: fix -Werror=stringop-overflow=

### DIFF
--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -721,17 +721,17 @@ void commit_params(struct dt_iop_module_t *self,
     {
       // calculate coefficients for L channel
       for(int i=0;i<N;i++) b[i] = p->target_L[i];
-      for(int i=N;i<N+4;i++) b[i] = 0;
+      for(int i=N;i<N4;i++) b[i] = 0;
       gauss_solve_triangular(A, pivot, b, N4);
       for(int i=0;i<N+4;i++) d->coeff_L[i] = b[i];
       // calculate coefficients for a channel
       for(int i=0;i<N;i++) b[i] = p->target_a[i];
-      for(int i=N;i<N+4;i++) b[i] = 0;
+      for(int i=N;i<N4;i++) b[i] = 0;
       gauss_solve_triangular(A, pivot, b, N4);
       for(int i=0;i<N+4;i++) d->coeff_a[i] = b[i];
       // calculate coefficients for b channel
       for(int i=0;i<N;i++) b[i] = p->target_b[i];
-      for(int i=N;i<N+4;i++) b[i] = 0;
+      for(int i=N;i<N4;i++) b[i] = 0;
       gauss_solve_triangular(A, pivot, b, N4);
       for(int i=0;i<N+4;i++) d->coeff_b[i] = b[i];
     }


### PR DESCRIPTION
Thanks @parafin it doesn't seem to complain when looping over A w/ N4 indeed... @victoryforce Shall we try this instead of https://github.com/darktable-org/darktable/pull/14317?