### PR TITLE
[GUI] Write a letter in a shortcut in lower case

### DIFF
--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -369,7 +369,7 @@ static void _update_buttons(dt_lib_module_t *self)
                                                  : _("apply geo-location"));
   gtk_widget_set_tooltip_text(d->map.apply_gpx_button,
                               d->offset ? _("apply offset and geo-location to matching images"
-                                            "\ndouble operation: two ctrl-Z to undo")
+                                            "\ndouble operation: two ctrl-z to undo")
                                         : _("apply geo-location to matching images"));
   gtk_widget_set_sensitive(d->map.apply_gpx_button, d->map.nb_imgs);
   gtk_widget_set_sensitive(d->map.select_button,


### PR DESCRIPTION
It is better to write the letter in a shortcut in lower case to avoid confusion with a shifted letter. Also, this is how all shortcuts are recorded in the shortcut help window, so it is better for consistency as well.