### PR TITLE
[RFC] Lens fix metadata scaling and fuji spline

### DIFF
--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1784,8 +1784,6 @@ static float _get_autoscale_md(dt_iop_module_t *self,
                                dt_iop_lens_params_t *p)
 {
   const dt_image_t *img = &(self->dev->image_storage);
-  if(img->exif_correction_type == CORRECTION_TYPE_DNG)
-    return 1.0f;
 
   // FIXME: get those from rawprepare IOP somehow !!!
   const float iwd2 = 0.5f *(img->width - img->crop_x - img->crop_right),


### PR DESCRIPTION
@jenshannoschwalm @FreddieWitherden
This is quite complex (at least for me) and could be totally wrong (I could have made only wrong assumptions). I'll try to explain it with some examples.
These can be split in two different PR/issues but to be able to explain this I had to keep them together.

---
**First issue**: Playing with the scaling slider introduced in #12880 I noticed something strange. Changing the scale value also changes to distortion effect.

Correction with auto calculated scale value
![current_default_autocalc_scale](https://user-images.githubusercontent.com/1690273/234550442-95eedf44-4b68-4ab1-8210-f7ea7e588d1f.png)

Correction with scale value set to 0.9
![current_scale_0 9](https://user-images.githubusercontent.com/1690273/234550494-9a939bef-a59c-4025-a6f6-b5b631d38118.png)

As you can see the distortion correction is totally different.

I assumed that scaling is the same as in lensfun (scale the image) and autoscaling is just the optimal value to not see the black parts caused by distortion correction.
If that assumption is correct than the issue is that the scale value is applied during spline generation by multipling the cor_rgb spline output values. So for the same input value we'll get different output values that will change the distortion effect.

So I made the first patch **lens: fix metadata scaling logic** where, instead of affecting the spline with the scale, the scale is done in process_md (and all the related functions: modify_roi_in, distortion_transform, distortion_backtransform and
distor_mask).

Correction with auto calculated scale value
![scale_fix_default_autocalc_scale](https://user-images.githubusercontent.com/1690273/234551480-f10b5c0f-c1fc-4c36-b4b8-f7fe5f213a13.png)

Correction with scale value set to 0.9
![scale_fix_scale_0 9](https://user-images.githubusercontent.com/1690273/234551507-187c450d-81a9-44d1-9afa-f9737895bd0b.png)

OOC jpeg
![ooc_jpeg](https://user-images.githubusercontent.com/1690273/234552249-3eb3eae9-0083-48bb-a58c-44bdf9e15a63.png)

Now the scale value scales the image keeping the same distortion. 

---
So the Fuji related patch **lens: fix fuji spline calculation**:

If you look at the borders of the last fuji corrected image (after the scale patch) you'll see that it's a bit more distorted than the one without the patch (because the spline is not affected by the scale value) and also completely wrong at the corners.
Additionally you'll see the last part is linear and not curved, this is related to the images metadata of this image (I'll explain it better if you want) and will be transitively fixed by this patch.

This patch is based on a theory that could be totally wrong.

These are the fuji metadata distortion values of the example image:
```
Geometric Distortion Params     : 416.5555556 0.3535211268 0.5 0.6126760563 0.7070422535 0.7908450704 0.8661971831 0.9352112676 1 1.06056338 -0.4689941406 -1.19178772 -2.002914429 -2.89112854 -3.877334595 -4.99041748 -6.241638184 -7.568359375 -7.568359375
```

We have for radius 1 a value of -7.568359375. This was reverse engineered by @FreddieWitherden as the percentage of correction that the value requires.

**The main point is that** the metadata lens correction logic uses the distortion spline to map from a destination radius to the source radius.

My theory is that the fuji metadata values (and so the generated spline) are related to the source image radius and not the destination radius like currently done. So the formulas will be:

$R{in} = R_{out} \cdot (1 + \frac{k}{100})$

So for a radius of 1 we should "move" it to:
$R_{out} =  \frac{1}{(1 + \frac{-7.568359375}{100})} = 1.081880613$

So this patch converts the spline knots (x) from source radius to destination radius and calculates the related coefficients (y) (the algorithm is just experimental and could be changed/improved).

Correction with auto calculated scale value
![scale_fuji_fix_default_autocalc_scale](https://user-images.githubusercontent.com/1690273/234554726-36c754db-4881-47f7-be74-278a94cc600e.png)

Correction with scale value set to 0.9
![scale_fuji_fix_scale_0 9](https://user-images.githubusercontent.com/1690273/234554753-62d33f4b-2b13-41d1-a70c-6adf2822f23b.png)

Additionally, I just converted the example image using adobe dng converter that adds a warprectilinear opcode 3 and it's handled by darktable thanks to PR #12880 . Well, the output image are practically identical (ignore vignetting not corrected by dng).

Correction with embedded metadata using dng warprectilinear:
![dng_warprectilinear](https://user-images.githubusercontent.com/1690273/234788789-4ed800a7-316c-419f-b204-a054e3386462.png)

Now this images look much better corrected and:
* It's very similar to the lensfun correction.
**But**
* **The strange thing** is that it looks also much better than the ooc jpeg (that's one of the reason why I'm not sure what I did is right since this means that the fuji ooc correction are not right/perfect).
* So, perhaps, using the ooc jpeg as a reference for reverse engineering the metadata logic isn't the right thing to do.

Additionally this patch adds a knot with no corrections if a there isn't a knot for the center (radius 0) (XTransIV/V metadata doesn't provide a 0 knot so the interpolation will distort the central part of the image more than what's needed. Injecting a 0 knot with no correction improves the center distortion.)

## Other included patches

`lens: fix _get_autoscale_md logic`:  This fixes a not perfect autoscale calculation that will lead to not using all the available image for fuji/sony corrections. We should only consider the borders when calculating the scale. See the commit description for more details.

`lens: use _get_autoscale_md value also for dng corrections`: with dng correction you can see in some images some pixels of the black border. This is probably due to some rounding errors when converting from the polynomial to the spline. So execute _get_autoscale_md also for dng correction.


@jenshannoschwalm @FreddieWitherden I'd like to know your thoughts on this.

If it looks good, after some more improvements etc.., there'll be also the need to keep backward compatibility with current edits.