### PR TITLE
Add help buttons to a few dialogs and preferences tabs

### DIFF
--- a/src/common/usermanual_url.c
+++ b/src/common/usermanual_url.c
@@ -34,6 +34,7 @@ dt_help_url urls_db[] =
   {"filter",                     NULL},
   {"colorlabels",                "lighttable/digital-asset-management/star-color/#color-labels"},
   {"import",                     "module-reference/utility-modules/lighttable/import/"},
+  {"import_dialog",              "module-reference/utility-modules/lighttable/import/#import-dialog"},
   {"select",                     "module-reference/utility-modules/lighttable/select/"},
   {"image",                      "module-reference/utility-modules/lighttable/selected-image/"},
   {"copy_history",               "module-reference/utility-modules/lighttable/history-stack/"},
@@ -46,6 +47,7 @@ dt_help_url urls_db[] =
   {"recentcollect",              "module-reference/utility-modules/shared/recent-collections/"},
   {"metadata_view",              "module-reference/utility-modules/shared/image-information/"},
   {"export",                     "module-reference/utility-modules/shared/export/"},
+  {"export_dialog",              "module-reference/utility-modules/shared/export/#metadata-preferences"},
   {"histogram",                  "module-reference/utility-modules/shared/histogram/"},
   {"navigation",                 "module-reference/utility-modules/darkroom/navigation/"},
   {"snapshots",                  "module-reference/utility-modules/darkroom/snapshots/"},
@@ -92,6 +94,9 @@ dt_help_url urls_db[] =
   {"overexposed",                "module-reference/utility-modules/darkroom/clipping/"},
   {"softproof",                  "module-reference/utility-modules/darkroom/soft-proof/"},
   {"gamut",                      "module-reference/utility-modules/darkroom/gamut/"},
+  {"shortcuts",                  "preferences-settings/shortcuts/"},
+  {"presets",                    "preferences-settings/presets/"},
+  {"css_tweaks",                 "preferences-settings/general/#css-theme-modifications"},
 
   // iop links
   {"ashift",                     "module-reference/processing-modules/rotate-perspective/"},
@@ -174,7 +179,7 @@ dt_help_url urls_db[] =
   {"zonesystem",                 "module-reference/processing-modules/zone-system/"},
 };
 
-char *dt_get_help_url(char *name)
+char *dt_get_help_url(const char *name)
 {
   if(name==NULL) return NULL;
 

--- a/src/common/usermanual_url.h
+++ b/src/common/usermanual_url.h
@@ -20,7 +20,7 @@
 
 #include <string.h>
 
-char *dt_get_help_url(char *name);
+char *dt_get_help_url(const char *name);
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -590,7 +590,7 @@ static void _add_wrapped_box(GtkWidget *container,
   gtk_container_add(GTK_CONTAINER(event_box), revealer);
   gtk_container_add(GTK_CONTAINER(container), event_box);
   // event box is needed so that one can click into the area to get help
-  dt_gui_add_help_link(event_box, dt_get_help_url(help_url));
+  dt_gui_add_help_link(event_box, help_url);
 }
 
 static void _box_set_visible(GtkBox *box, gboolean visible)
@@ -3509,7 +3509,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw,
     g_signal_connect(G_OBJECT(bd->blend_modes_combo), "value-changed",
                      G_CALLBACK(_blendop_blend_mode_callback), bd);
     dt_gui_add_help_link(GTK_WIDGET(bd->blend_modes_combo),
-                         dt_get_help_url("masks_blending_op"));
+                         "masks_blending_op");
     gtk_box_pack_start(GTK_BOX(blend_modes_hbox), bd->blend_modes_combo, TRUE, TRUE, 0);
 
     bd->blend_modes_blend_order = dt_iop_togglebutton_new
@@ -3557,7 +3557,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw,
     g_signal_connect(G_OBJECT(bd->masks_combine_combo), "value-changed",
                      G_CALLBACK(_blendop_masks_combine_callback), bd);
     dt_gui_add_help_link(GTK_WIDGET(bd->masks_combine_combo),
-                         dt_get_help_url("masks_combined"));
+                         "masks_combined");
 
     bd->masks_invert_combo = _combobox_new_from_list
       (module,
@@ -3669,7 +3669,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw,
                        GTK_WIDGET(presets_button), FALSE, FALSE, 0);
     gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(bd->masks_modes_box), FALSE, FALSE, 0);
     dt_gui_add_help_link(GTK_WIDGET(bd->masks_modes_box),
-                         dt_get_help_url("masks_blending"));
+                         "masks_blending");
     gtk_widget_set_name(GTK_WIDGET(bd->masks_modes_box), "blending-tabs");
 
     bd->top_box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2819,7 +2819,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
                    G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_INSTANCE));
 
-  dt_gui_add_help_link(expander, dt_get_help_url(module->op));
+  dt_gui_add_help_link(expander, module->op);
 
   /* add reset button */
   hw[IOP_MODULE_RESET] = dtgtk_button_new(dtgtk_cairo_paint_reset, 0, NULL);
@@ -2879,9 +2879,9 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   for(int i = 0; i < IOP_MODULE_LAST; i++)
     if(hw[i]) dt_action_define(&module->so->actions, NULL, NULL, hw[i], NULL);
 
-  dt_gui_add_help_link(header, dt_get_help_url("module_header"));
+  dt_gui_add_help_link(header, "module_header");
   // for the module label, point to module specific help page
-  dt_gui_add_help_link(hw[IOP_MODULE_LABEL], dt_get_help_url(module->op));
+  dt_gui_add_help_link(hw[IOP_MODULE_LABEL], module->op);
 
   gtk_widget_set_halign(hw[IOP_MODULE_LABEL], GTK_ALIGN_START);
   gtk_widget_set_halign(hw[IOP_MODULE_INSTANCE], GTK_ALIGN_END);
@@ -2903,7 +2903,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
   dt_guides_init_module_widget(iopw, module);
   dt_iop_gui_init_blending(iopw, module);
   dt_gui_add_class(module->widget, "dt_plugin_ui_main");
-  dt_gui_add_help_link(module->widget, dt_get_help_url(module->op));
+  dt_gui_add_help_link(module->widget, module->op);
   gtk_widget_hide(iopw);
 
   module->expander = expander;

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -912,7 +912,7 @@ dt_culling_t *dt_culling_new(dt_culling_mode_t mode)
   table->zoom_ratio = IMG_TO_FIT;
   table->widget = gtk_layout_new(NULL, NULL);
   dt_gui_add_class(table->widget, "dt_fullview");
-  // TODO dt_gui_add_help_link(table->widget, dt_get_help_url("lighttable_filemanager"));
+  // TODO dt_gui_add_help_link(table->widget, "lighttable_filemanager");
 
   // overlays
   gchar *otxt = g_strdup_printf("plugins/lighttable/overlays/culling/%d", table->mode);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1997,7 +1997,7 @@ dt_thumbtable_t *dt_thumbtable_new()
   dt_thumbtable_t *table =
     (dt_thumbtable_t *)calloc(1, sizeof(dt_thumbtable_t));
   table->widget = gtk_layout_new(NULL, NULL);
-  dt_gui_add_help_link(table->widget, dt_get_help_url("lighttable_filemanager"));
+  dt_gui_add_help_link(table->widget, "lighttable_filemanager");
 
   // get thumb generation pref for reference in case of change
   const char *tx = dt_conf_get_string_const("plugins/lighttable/thumbnail_hq_min_level");
@@ -2343,17 +2343,17 @@ void dt_thumbtable_set_parent(dt_thumbtable_t *table,
     if(mode == DT_THUMBTABLE_MODE_FILEMANAGER)
     {
       gtk_widget_set_name(table->widget, "thumbtable-filemanager");
-      dt_gui_add_help_link(table->widget, dt_get_help_url("lighttable_filemanager"));
+      dt_gui_add_help_link(table->widget, "lighttable_filemanager");
     }
     else if(mode == DT_THUMBTABLE_MODE_FILMSTRIP)
     {
       gtk_widget_set_name(table->widget, "thumbtable-filmstrip");
-      dt_gui_add_help_link(table->widget, dt_get_help_url("filmstrip"));
+      dt_gui_add_help_link(table->widget, "filmstrip");
     }
     else if(mode == DT_THUMBTABLE_MODE_ZOOM)
     {
       gtk_widget_set_name(table->widget, "thumbtable-zoom");
-      dt_gui_add_help_link(table->widget, dt_get_help_url("lighttable_zoomable"));
+      dt_gui_add_help_link(table->widget, "lighttable_zoomable");
     }
 
     // if needed, we block/unblock drag and drop

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -2687,6 +2687,12 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
   g_signal_connect(button, "toggled", G_CALLBACK(_fallbacks_toggled), shortcuts_view);
   gtk_box_pack_start(GTK_BOX(button_bar), button, TRUE, FALSE, 0);
 
+  button = gtk_button_new_with_label(_("help"));
+  gtk_widget_set_tooltip_text(button, _("open help page for shortcuts"));
+  dt_gui_add_help_link(button, "shortcuts");
+  g_signal_connect(button, "clicked", G_CALLBACK(dt_gui_show_help), NULL);
+  gtk_box_pack_end(GTK_BOX(button_bar), button, FALSE, FALSE, 0);
+
   button = gtk_button_new_with_label(_("restore..."));
   gtk_widget_set_tooltip_text(button, _("restore default shortcuts or previous state"));
   g_signal_connect(button, "clicked", G_CALLBACK(_restore_clicked), NULL);

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -411,6 +411,8 @@ char *dt_gui_show_standalone_string_dialog(const char *title, const char *markup
 gboolean dt_gui_show_yes_no_dialog(const char *title, const char *format, ...);
 
 void dt_gui_add_help_link(GtkWidget *widget, const char *link);
+char *dt_gui_get_help_url(GtkWidget *widget);
+void dt_gui_show_help(GtkWidget *widget);
 
 // load a CSS theme
 void dt_gui_load_theme(const char *theme);

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -411,10 +411,15 @@ static void init_tab_general(GtkWidget *dialog, GtkWidget *stack, dt_gui_themetw
   gtk_container_add(GTK_CONTAINER(scroll), tw->css_text_view);
   gtk_box_pack_start(GTK_BOX(usercssbox), scroll, TRUE, TRUE, 0);
 
+  GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  GtkWidget *button = gtk_button_new_with_label(_("help"));
+  gtk_widget_set_tooltip_text(button, _("open help page for CSS tweaks"));
+  dt_gui_add_help_link(button, "css_tweaks");
+  g_signal_connect(button, "clicked", G_CALLBACK(dt_gui_show_help), NULL);
+  gtk_box_pack_end(GTK_BOX(hbox), button, FALSE, FALSE, 0);
   tw->save_button = gtk_button_new_with_label(C_("usercss", "save CSS and apply"));
   g_signal_connect(G_OBJECT(tw->save_button), "clicked", G_CALLBACK(save_usercss_callback), tw);
   g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(usercss_dialog_callback), tw);
-  GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_pack_end(GTK_BOX(hbox), tw->save_button, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(usercssbox), hbox, FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(tw->save_button, _("click to save and apply the CSS tweaks entered in this editor"));
@@ -860,7 +865,12 @@ static void init_tab_presets(GtkWidget *stack)
   g_signal_connect(G_OBJECT(tree), "key-press-event", G_CALLBACK(dt_gui_search_start), search_presets);
   gtk_tree_view_set_search_entry(tree, GTK_ENTRY(search_presets));
 
-  GtkWidget *button = gtk_button_new_with_label(C_("preferences", "import..."));
+  GtkWidget *button = gtk_button_new_with_label(_("help"));
+  dt_gui_add_help_link(button, "presets");
+  g_signal_connect(button, "clicked", G_CALLBACK(dt_gui_show_help), NULL);
+  gtk_box_pack_end(GTK_BOX(hbox), button, FALSE, FALSE, 0);
+
+  button = gtk_button_new_with_label(C_("preferences", "import..."));
   gtk_box_pack_end(GTK_BOX(hbox), button, FALSE, TRUE, 0);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(import_preset), (gpointer)model);
 

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -402,7 +402,7 @@ void gui_init(dt_lib_module_t *self)
      pastemode_combobox_changed, self,
      N_("append"),     // DT_COPY_HISTORY_APPEND
      N_("overwrite")); // DT_COPY_HISTORY_OVERWRITE
-  dt_gui_add_help_link(d->pastemode, dt_get_help_url("history"));
+  dt_gui_add_help_link(d->pastemode, "history");
   gtk_grid_attach(grid, d->pastemode, 0, line++, 6, 1);
 
   d->load_button = dt_action_button_new

--- a/src/libs/export_metadata.c
+++ b/src/libs/export_metadata.c
@@ -289,6 +289,11 @@ char *dt_lib_export_metadata_configuration_dialog(char *metadata_presets, const 
   d->dialog = dialog;
   g_signal_connect(dialog, "key-press-event", G_CALLBACK(dt_handle_dialog_enter), NULL);
 
+  GtkWidget *help = gtk_dialog_add_button(GTK_DIALOG(dialog), _("help"), GTK_RESPONSE_NONE); //GTK_RESPONSE_HELP aligns left
+  dt_gui_add_help_link(help, "export_dialog");
+  g_signal_handlers_disconnect_by_data(help, dialog);
+  g_signal_connect(help, "clicked", G_CALLBACK(dt_gui_show_help), NULL);
+
   gtk_window_set_default_size(GTK_WINDOW(dialog), 300, -1);
   GtkWidget *area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -2124,7 +2124,7 @@ void gui_init(dt_lib_module_t *self)
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_widget_set_name(self->widget, "module-filtering");
   dt_gui_add_class(self->widget, "dt_big_btn_canvas");
-  dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
+  dt_gui_add_help_link(self->widget, self->plugin_name);
 
   d->nb_rules = 0;
   d->params = (dt_lib_filtering_params_t *)g_malloc0(sizeof(dt_lib_filtering_params_t));

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -458,7 +458,7 @@ void gui_init(dt_lib_module_t *self)
   static struct dt_action_def_t notebook_def = { };
   self->widget = GTK_WIDGET(dt_ui_notebook_new(&notebook_def));
   dt_action_define(DT_ACTION(self), NULL, N_("page"), GTK_WIDGET(self->widget), &notebook_def);
-  dt_gui_add_help_link(self->widget, dt_get_help_url("image"));
+  dt_gui_add_help_link(self->widget, "image");
 
   GtkWidget *page1 = dt_ui_notebook_page(GTK_NOTEBOOK(self->widget), N_("images"), NULL);
   GtkWidget *page2 = dt_ui_notebook_page(GTK_NOTEBOOK(self->widget), N_("metadata"), NULL);

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -277,7 +277,7 @@ void _lib_import_ui_devices_update(dt_lib_module_t *self)
         d->camera = camera;
         g_signal_connect(G_OBJECT(ib), "clicked", G_CALLBACK(_lib_import_from_camera_callback), self);
         gtk_widget_set_halign(gtk_bin_get_child(GTK_BIN(ib)), GTK_ALIGN_CENTER);
-        dt_gui_add_help_link(ib, dt_get_help_url("import_camera"));
+        dt_gui_add_help_link(ib, "import_camera");
       }
       if(camera->can_tether == TRUE)
       {
@@ -285,14 +285,14 @@ void _lib_import_ui_devices_update(dt_lib_module_t *self)
         d->tethered_shoot = GTK_BUTTON(tb);
         g_signal_connect(G_OBJECT(tb), "clicked", G_CALLBACK(_lib_import_tethered_callback), camera);
         gtk_widget_set_halign(gtk_bin_get_child(GTK_BIN(tb)), GTK_ALIGN_CENTER);
-        dt_gui_add_help_link(tb, dt_get_help_url("import_camera"));
+        dt_gui_add_help_link(tb, "import_camera");
       }
 
       gtk_box_pack_start(GTK_BOX(vbx), (um = gtk_button_new_with_label(_("unmount camera"))), FALSE, FALSE, 0);
       d->unmount_camera = GTK_BUTTON(um);
       g_signal_connect(G_OBJECT(um), "clicked", G_CALLBACK(_lib_import_unmount_callback), camera);
       gtk_widget_set_halign(gtk_bin_get_child(GTK_BIN(um)), GTK_ALIGN_CENTER);
-      dt_gui_add_help_link(um, dt_get_help_url("mount_camera"));
+      dt_gui_add_help_link(um, "mount_camera");
 
       gtk_box_pack_start(GTK_BOX(d->devices), vbx, FALSE, FALSE, 0);
     }
@@ -323,7 +323,7 @@ void _lib_import_ui_devices_update(dt_lib_module_t *self)
 
       g_signal_connect(G_OBJECT(im), "clicked", G_CALLBACK(_lib_import_mount_callback), camera);
       gtk_widget_set_halign(gtk_bin_get_child(GTK_BIN(im)), GTK_ALIGN_CENTER);
-      dt_gui_add_help_link(im, dt_get_help_url("mount_camera"));
+      dt_gui_add_help_link(im, "mount_camera");
 
       gtk_box_pack_start(GTK_BOX(d->devices), vbx, FALSE, FALSE, 0);
     }
@@ -1702,6 +1702,12 @@ static void _import_from_dialog_new(dt_lib_module_t* self)
       _("cancel"), GTK_RESPONSE_CANCEL,
       _(_import_text[d->import_case]), GTK_RESPONSE_ACCEPT,
       NULL);
+
+  GtkWidget *help = gtk_dialog_add_button(GTK_DIALOG(d->from.dialog), _("help"),
+                                          GTK_RESPONSE_NONE); //GTK_RESPONSE_HELP aligns left
+  dt_gui_add_help_link(help, "import_dialog");
+  g_signal_handlers_disconnect_by_data(help, d->from.dialog);
+  g_signal_connect(help, "clicked", G_CALLBACK(dt_gui_show_help), NULL);
 
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(d->from.dialog);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -3879,6 +3879,12 @@ static void _manage_show_window(dt_lib_module_t *self)
 
   // reset button
   hb2 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+
+  GtkWidget *help = gtk_button_new_with_label(_("help"));
+  dt_gui_add_help_link(help, "modulegroups");
+  g_signal_connect(help, "clicked", G_CALLBACK(dt_gui_show_help), NULL);
+  gtk_box_pack_end(GTK_BOX(hb2), help, FALSE, FALSE, 0);
+
   d->preset_reset_btn = gtk_button_new_with_label(_("reset"));
   g_signal_connect(G_OBJECT(d->preset_reset_btn), "button-press-event", G_CALLBACK(_manage_editor_reset), self);
   gtk_box_pack_end(GTK_BOX(hb2), d->preset_reset_btn, FALSE, TRUE, 0);

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -2285,7 +2285,7 @@ void gui_init(dt_lib_module_t *self)
     (dt_lib_print_settings_t*)malloc(sizeof(dt_lib_print_settings_t));
   self->data = d;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
-  dt_gui_add_help_link(self->widget, dt_get_help_url("print_overview"));
+  dt_gui_add_help_link(self->widget, "print_overview");
 
   char datadir[PATH_MAX] = { 0 };
   char confdir[PATH_MAX] = { 0 };
@@ -2384,7 +2384,7 @@ void gui_init(dt_lib_module_t *self)
 
   label = dt_ui_section_label_new(C_("section", "printer"));
   gtk_box_pack_start(GTK_BOX(self->widget), label, TRUE, TRUE, 0);
-  dt_gui_add_help_link(self->widget, dt_get_help_url("print_settings_printer"));
+  dt_gui_add_help_link(self->widget, "print_settings_printer");
   d->printers = dt_bauhaus_combobox_new_action(DT_ACTION(self));
 
   gtk_box_pack_start(GTK_BOX(self->widget), d->printers, TRUE, TRUE, 0);
@@ -2493,7 +2493,7 @@ void gui_init(dt_lib_module_t *self)
 
   label = dt_ui_section_label_new(C_("section", "page"));
   gtk_box_pack_start(GTK_BOX(self->widget), label, TRUE, TRUE, 0);
-  dt_gui_add_help_link(self->widget, dt_get_help_url("print_settings_page"));
+  dt_gui_add_help_link(self->widget, "print_settings_page");
 
   //// papers
 
@@ -2640,7 +2640,7 @@ void gui_init(dt_lib_module_t *self)
 
   label = dt_ui_section_label_new(C_("section", "image layout"));
   gtk_box_pack_start(GTK_BOX(self->widget), label, TRUE, TRUE, 0);
-  dt_gui_add_help_link(self->widget, dt_get_help_url("print_image_layout"));
+  dt_gui_add_help_link(self->widget, "print_image_layout");
 
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hboxdim), TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hboxinfo), TRUE, TRUE, 0);
@@ -2756,7 +2756,7 @@ void gui_init(dt_lib_module_t *self)
 
   label = dt_ui_section_label_new(C_("section", "print settings"));
   gtk_box_pack_start(GTK_BOX(self->widget), label, TRUE, TRUE, 0);
-  dt_gui_add_help_link(self->widget, dt_get_help_url("print_settings"));
+  dt_gui_add_help_link(self->widget, "print_settings");
 
   //  Add export profile combo
 
@@ -2879,7 +2879,7 @@ void gui_init(dt_lib_module_t *self)
                                            GDK_KEY_p, GDK_CONTROL_MASK);
   d->print_button = GTK_BUTTON(button);
   gtk_box_pack_start(GTK_BOX(self->widget), button, TRUE, TRUE, 0);
-  dt_gui_add_help_link(button, dt_get_help_url("print_settings_button"));
+  dt_gui_add_help_link(button, "print_settings_button");
 
   g_free(system_profile_dir);
   g_free(user_profile_dir);

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -18,7 +18,6 @@
 
 #include "common/collection.h"
 #include "common/darktable.h"
-#include "common/l10n.h"
 #include "control/conf.h"
 #include "control/control.h"
 #include "dtgtk/button.h"
@@ -547,42 +546,6 @@ static void _lib_filter_grouping_button_clicked(GtkWidget *widget, gpointer user
 #endif // USE_LUA
 }
 
-// TODO: this doesn't work for all widgets. the reason being that the GtkEventBox we put libs/iops into catches events.
-static char *get_help_url(GtkWidget *widget)
-{
-  while(widget)
-  {
-    // if the widget doesn't have a help url set go up the widget hierarchy to find a parent that has an url
-    gchar *help_url = g_object_get_data(G_OBJECT(widget), "dt-help-url");
-
-    if(help_url)
-      return help_url;
-
-    // TODO: shall we cross from libs/iops to the core gui? if not, here is the place to break out of the loop
-
-    widget = gtk_widget_get_parent(widget);
-  }
-
-  return NULL;
-}
-
-static char *_get_base_url()
-{
-  const gboolean use_default_url =
-    dt_conf_get_bool("context_help/use_default_url");
-  const char *c_base_url = dt_confgen_get("context_help/url", DT_DEFAULT);
-  char *base_url = dt_conf_get_string("context_help/url");
-
-  if(use_default_url)
-  {
-    // want to use default URL, reset darktablerc
-    dt_conf_set_string("context_help/url", c_base_url);
-    return g_strdup(c_base_url);
-  }
-  else
-    return base_url;
-}
-
 static void _main_do_event_help(GdkEvent *event, gpointer data)
 {
   dt_lib_tool_preferences_t *d = (dt_lib_tool_preferences_t *)data;
@@ -600,132 +563,7 @@ static void _main_do_event_help(GdkEvent *event, gpointer data)
         if(event_widget == d->help_button)
           break;
 
-        // TODO: When the widget doesn't have a help url set we should probably look at the parent(s)
-        gchar *help_url = get_help_url(event_widget);
-        if(help_url && *help_url)
-        {
-          GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-          dt_print(DT_DEBUG_CONTROL, "[context help] opening `%s'\n", help_url);
-          char *base_url = _get_base_url();
-
-          // The base_url is: docs.darktable.org/usermanual
-          // The full format for the documentation pages is:
-          //    <base-url>/<ver>/<lang>[/path/to/page]
-          // Where:
-          //   <ver>  = development | 3.6 | 3.8 ...
-          //   <lang> = en / fr ...              (default = en)
-
-          // in case of a standard release, append the dt version to the url
-          if(dt_is_dev_version())
-          {
-            base_url = dt_util_dstrcat(base_url, "development/");
-          }
-          else
-          {
-            char *ver = dt_version_major_minor();
-            base_url = dt_util_dstrcat(base_url, "%s/", ver);
-            g_free(ver);
-          }
-
-          char *last_base_url = dt_conf_get_string("context_help/last_url");
-
-          // if url is https://www.darktable.org/usermanual/,
-          // it is the old deprecated url and we need to update it
-          if(!last_base_url
-             || !*last_base_url
-             || (strcmp(base_url, last_base_url) != 0))
-          {
-            g_free(last_base_url);
-            last_base_url = base_url;
-
-            // ask the user if darktable.org may be accessed
-            if(dt_gui_show_yes_no_dialog(_("access the online usermanual?"),
-                                         _("do you want to access `%s'?"), last_base_url))
-            {
-              dt_conf_set_string("context_help/last_url", last_base_url);
-            }
-            else
-            {
-              g_free(base_url);
-              base_url = NULL;
-            }
-          }
-          if(base_url)
-          {
-            char *lang = "en";
-            GError *error = NULL;
-
-            // array of languages the usermanual supports.
-            // NULL MUST remain the last element of the array
-            const char *supported_languages[] =
-              { "en", "fr", "de", "eo", "es", "gl", "it", "pl", "pt-br", "uk", NULL };
-            int lang_index = 0;
-            gboolean is_language_supported = FALSE;
-
-            if(darktable.l10n != NULL)
-            {
-              dt_l10n_language_t *language = NULL;
-              if(darktable.l10n->selected != -1)
-                  language = (dt_l10n_language_t *)g_list_nth(darktable.l10n->languages, darktable.l10n->selected)->data;
-              if(language != NULL)
-                lang = language->code;
-              while(supported_languages[lang_index])
-              {
-                gchar *nlang = g_strdup(lang);
-
-                // try lang as-is
-                if(!g_ascii_strcasecmp(nlang, supported_languages[lang_index]))
-                {
-                  is_language_supported = TRUE;
-                }
-
-                if(!is_language_supported)
-                {
-                  // keep only first part up to _
-                  for(gchar *p = nlang; *p; p++)
-                    if(*p == '_') *p = '\0';
-
-                  if(!g_ascii_strcasecmp(nlang, supported_languages[lang_index]))
-                  {
-                    is_language_supported = TRUE;
-                  }
-                }
-
-                g_free(nlang);
-                if(is_language_supported) break;
-
-                lang_index++;
-              }
-            }
-
-            // language not found, default to EN
-            if(!is_language_supported) lang_index = 0;
-
-            char *url = g_build_path("/", base_url, supported_languages[lang_index], help_url, NULL);
-
-            // TODO: call the web browser directly so that file:// style base for local installs works
-            const gboolean uri_success = gtk_show_uri_on_window(GTK_WINDOW(win), url, gtk_get_current_event_time(), &error);
-            g_free(base_url);
-            g_free(url);
-            if(uri_success)
-            {
-              dt_control_log(_("help url opened in web browser"));
-            }
-            else
-            {
-              dt_control_log(_("error while opening help url in web browser"));
-              if(error != NULL) // uri_success being FALSE should guarantee that
-              {
-                fprintf (stderr, "unable to read file: %s\n", error->message);
-                g_error_free (error);
-              }
-            }
-          }
-        }
-        else
-        {
-          dt_control_log(_("there is no help available for this element"));
-        }
+        dt_gui_show_help(event_widget);
       }
       handled = TRUE;
       break;
@@ -746,8 +584,7 @@ static void _main_do_event_help(GdkEvent *event, gpointer data)
       GtkWidget *event_widget = gtk_get_event_widget(event);
       if(event_widget)
       {
-        gchar *help_url = get_help_url(event_widget);
-        if(help_url)
+        if(dt_gui_get_help_url(event_widget))
         {
           // TODO: find a better way to tell the user that the hovered widget has a help link
           dt_cursor_t cursor = event->type == GDK_ENTER_NOTIFY ? GDK_QUESTION_ARROW : GDK_X_CURSOR;

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -364,7 +364,7 @@ void gui_init(dt_lib_module_t *self)
   d->layout_filemanager = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_grid, 0, NULL);
   ac = dt_action_define(ltv, NULL, N_("toggle filemanager layout"), d->layout_filemanager, NULL);
   dt_action_register(ac, NULL, _lib_lighttable_key_accel_toggle_filemanager, 0, 0);
-  dt_gui_add_help_link(d->layout_filemanager, dt_get_help_url("layout_filemanager"));
+  dt_gui_add_help_link(d->layout_filemanager, "layout_filemanager");
   gtk_widget_set_tooltip_text(d->layout_filemanager, _("click to enter filemanager layout."));
   g_signal_connect(G_OBJECT(d->layout_filemanager), "button-release-event",
                    G_CALLBACK(_lib_lighttable_layout_btn_release), self);
@@ -373,7 +373,7 @@ void gui_init(dt_lib_module_t *self)
   d->layout_zoomable = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_zoom, 0, NULL);
   ac = dt_action_define(ltv, NULL, N_("toggle zoomable lighttable layout"), d->layout_zoomable, NULL);
   dt_action_register(ac, NULL, _lib_lighttable_key_accel_toggle_zoomable, 0, 0);
-  dt_gui_add_help_link(d->layout_zoomable, dt_get_help_url("layout_zoomable"));
+  dt_gui_add_help_link(d->layout_zoomable, "layout_zoomable");
   gtk_widget_set_tooltip_text(d->layout_zoomable, _("click to enter zoomable lighttable layout."));
   g_signal_connect(G_OBJECT(d->layout_zoomable), "button-release-event",
                    G_CALLBACK(_lib_lighttable_layout_btn_release), self);
@@ -382,7 +382,7 @@ void gui_init(dt_lib_module_t *self)
   d->layout_culling_fix = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_culling_fixed, 0, NULL);
   ac = dt_action_define(ltv, NULL, N_("toggle culling mode"), d->layout_culling_fix, NULL);
   dt_action_register(ac, NULL, _lib_lighttable_key_accel_toggle_culling_mode, GDK_KEY_x, 0);
-  dt_gui_add_help_link(d->layout_culling_fix, dt_get_help_url("layout_culling"));
+  dt_gui_add_help_link(d->layout_culling_fix, "layout_culling");
   g_signal_connect(G_OBJECT(d->layout_culling_fix), "button-release-event",
                    G_CALLBACK(_lib_lighttable_layout_btn_release), self);
   gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_culling_fix, TRUE, TRUE, 0);
@@ -390,7 +390,7 @@ void gui_init(dt_lib_module_t *self)
   d->layout_culling_dynamic = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_culling_dynamic, 0, NULL);
   ac = dt_action_define(ltv, NULL, N_("toggle culling dynamic mode"), d->layout_culling_dynamic, NULL);
   dt_action_register(ac, NULL, _lib_lighttable_key_accel_toggle_culling_dynamic_mode, GDK_KEY_x, GDK_CONTROL_MASK);
-  dt_gui_add_help_link(d->layout_culling_dynamic, dt_get_help_url("layout_culling"));
+  dt_gui_add_help_link(d->layout_culling_dynamic, "layout_culling");
   g_signal_connect(G_OBJECT(d->layout_culling_dynamic), "button-release-event",
                    G_CALLBACK(_lib_lighttable_layout_btn_release), self);
   gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_culling_dynamic, TRUE, TRUE, 0);
@@ -400,7 +400,7 @@ void gui_init(dt_lib_module_t *self)
   dt_shortcut_register(ac, DT_ACTION_ELEMENT_DEFAULT, DT_ACTION_EFFECT_HOLD_TOGGLE, GDK_KEY_f, 0);
   dt_shortcut_register(ac, DT_ACTION_ELEMENT_DEFAULT, DT_ACTION_EFFECT_HOLD, GDK_KEY_w, 0);
   dt_shortcut_register(ac, DT_ACTION_ELEMENT_FOCUS_DETECT, DT_ACTION_EFFECT_HOLD, GDK_KEY_w, GDK_CONTROL_MASK);
-  dt_gui_add_help_link(d->layout_preview, dt_get_help_url("layout_preview"));
+  dt_gui_add_help_link(d->layout_preview, "layout_preview");
   g_signal_connect(G_OBJECT(d->layout_preview), "button-release-event",
                    G_CALLBACK(_lib_lighttable_layout_btn_release), self);
   gtk_box_pack_start(GTK_BOX(d->layout_box), d->layout_preview, TRUE, TRUE, 0);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2314,7 +2314,7 @@ void gui_init(dt_view_t *self)
   gtk_widget_set_tooltip_text(favorite_presets, _("quick access to presets"));
   g_signal_connect(G_OBJECT(favorite_presets), "clicked", G_CALLBACK(_darkroom_ui_favorite_presets_popupmenu),
                    NULL);
-  dt_gui_add_help_link(favorite_presets, dt_get_help_url("favorite_presets"));
+  dt_gui_add_help_link(favorite_presets, "favorite_presets");
   dt_view_manager_view_toolbox_add(darktable.view_manager, favorite_presets, DT_VIEW_DARKROOM);
 
   /* create quick styles popup menu tool */
@@ -2322,7 +2322,7 @@ void gui_init(dt_view_t *self)
   dt_action_define(sa, NULL, N_("quick access to styles"), styles, &dt_action_def_button);
   g_signal_connect(G_OBJECT(styles), "clicked", G_CALLBACK(_darkroom_ui_apply_style_popupmenu), NULL);
   gtk_widget_set_tooltip_text(styles, _("quick access for applying any of your styles"));
-  dt_gui_add_help_link(styles, dt_get_help_url("bottom_panel_styles"));
+  dt_gui_add_help_link(styles, "bottom_panel_styles");
   dt_view_manager_view_toolbox_add(darktable.view_manager, styles, DT_VIEW_DARKROOM);
 
   /* create second window display button */
@@ -2355,7 +2355,7 @@ void gui_init(dt_view_t *self)
     g_signal_connect(G_OBJECT(dev->rawoverexposed.button), "clicked",
                      G_CALLBACK(_rawoverexposed_quickbutton_clicked), dev);
     dt_view_manager_module_toolbox_add(darktable.view_manager, dev->rawoverexposed.button, DT_VIEW_DARKROOM);
-    dt_gui_add_help_link(dev->rawoverexposed.button, dt_get_help_url("rawoverexposed"));
+    dt_gui_add_help_link(dev->rawoverexposed.button, "rawoverexposed");
 
     // and the popup window
     dev->rawoverexposed.floating_window = gtk_popover_new(dev->rawoverexposed.button);
@@ -2405,7 +2405,7 @@ void gui_init(dt_view_t *self)
     g_signal_connect(G_OBJECT(dev->overexposed.button), "clicked",
                      G_CALLBACK(_overexposed_quickbutton_clicked), dev);
     dt_view_manager_module_toolbox_add(darktable.view_manager, dev->overexposed.button, DT_VIEW_DARKROOM);
-    dt_gui_add_help_link(dev->overexposed.button, dt_get_help_url("overexposed"));
+    dt_gui_add_help_link(dev->overexposed.button, "overexposed");
 
     // and the popup window
     dev->overexposed.floating_window = gtk_popover_new(dev->overexposed.button);
@@ -2471,7 +2471,7 @@ void gui_init(dt_view_t *self)
     g_signal_connect(G_OBJECT(dev->profile.softproof_button), "clicked",
                      G_CALLBACK(_softproof_quickbutton_clicked), dev);
     dt_view_manager_module_toolbox_add(darktable.view_manager, dev->profile.softproof_button, DT_VIEW_DARKROOM);
-    dt_gui_add_help_link(dev->profile.softproof_button, dt_get_help_url("softproof"));
+    dt_gui_add_help_link(dev->profile.softproof_button, "softproof");
 
     // the gamut check button
     dev->profile.gamut_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_gamut_check, 0, NULL);
@@ -2482,7 +2482,7 @@ void gui_init(dt_view_t *self)
     g_signal_connect(G_OBJECT(dev->profile.gamut_button), "clicked",
                      G_CALLBACK(_gamut_quickbutton_clicked), dev);
     dt_view_manager_module_toolbox_add(darktable.view_manager, dev->profile.gamut_button, DT_VIEW_DARKROOM);
-    dt_gui_add_help_link(dev->profile.gamut_button, dt_get_help_url("gamut"));
+    dt_gui_add_help_link(dev->profile.gamut_button, "gamut");
 
     // and the popup window, which is shared between the two profile buttons
     dev->profile.floating_window = gtk_popover_new(NULL);

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -338,16 +338,16 @@ gboolean dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *
       /* if we didn't get an expander let's add the widget */
       if(!w) w = plugin->widget;
 
-      dt_gui_add_help_link(w, dt_get_help_url(plugin->plugin_name));
+      dt_gui_add_help_link(w, plugin->plugin_name);
       // some plugins help links depend on the view
       if(!strcmp(plugin->plugin_name,"module_toolbox")
         || !strcmp(plugin->plugin_name,"view_toolbox"))
       {
         dt_view_type_flags_t view_type = new_view->view(new_view);
         if(view_type == DT_VIEW_LIGHTTABLE)
-          dt_gui_add_help_link(w, dt_get_help_url("lighttable_mode"));
+          dt_gui_add_help_link(w, "lighttable_mode");
         if(view_type == DT_VIEW_DARKROOM)
-          dt_gui_add_help_link(w, dt_get_help_url("darkroom_bottom_panel"));
+          dt_gui_add_help_link(w, "darkroom_bottom_panel");
       }
 
       /* set expanded if last mode was that */


### PR DESCRIPTION
When a dialog is active, it is not possible to enable the "help" pointer in the global toolbox, so opening the online manual was not supported.

This would have been a trivial enough change, except that the code to open pages in the online help was embedded inside the event handler for the contextual help pointer. Now split off and moved to gtk.c (because that's where `dt_gui_add_help_link` already lived).

Buttons added to general, shortcuts and presets tabs in preferences and import, export and modulegroups dialogs.