### PR TITLE
liquify: optimize and clean up code

### DIFF
--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -32,7 +32,6 @@
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "iop/iop_api.h"
-#undef NDEBUG
 #include <assert.h>
 #include <cairo.h>
 #include <complex.h>

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -20,6 +20,7 @@
 #include "config.h"
 #endif
 #include "bauhaus/bauhaus.h"
+#include "common/imagebuf.h"
 #include "common/interpolation.h"
 #include "common/opencl.h"
 #include "common/math.h"
@@ -31,6 +32,7 @@
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "iop/iop_api.h"
+#undef NDEBUG
 #include <assert.h>
 #include <cairo.h>
 #include <complex.h>
@@ -928,11 +930,12 @@ static void compute_round_stamp_extent(cairo_rectangle_int_t *const restrict sta
   Our stamp is stored in a rectangular region.
 */
 
-static void build_round_stamp(float complex **pstamp,
-                               cairo_rectangle_int_t *const restrict stamp_extent,
-                               const dt_liquify_warp_t *const restrict warp)
+/*static*/ void apply_round_stamp(cairo_rectangle_int_t *const restrict stamp_extent,
+                              const dt_liquify_warp_t *const restrict warp,
+                              float complex *global_map,
+                              const cairo_rectangle_int_t *const restrict global_map_extent)
 {
-  const int iradius = round(cabsf(warp->radius - warp->point));
+  const size_t iradius = round(cabsf(warp->radius - warp->point));
   assert(iradius > 0);
 
   stamp_extent->x = stamp_extent->y = -iradius;
@@ -943,24 +946,30 @@ static void build_round_stamp(float complex **pstamp,
   float complex strength = 0.5f * (warp->strength - warp->point);
   strength = (warp->status & DT_LIQUIFY_STATUS_INTERPOLATED) ?
     (strength * STAMP_RELOCATION) : strength;
-  const float abs_strength = cabsf(strength);
-
-  float complex *restrict stamp =
-    calloc(sizeof(float complex), (size_t)stamp_extent->width * stamp_extent->height);
+  const float abs_strength
+    = cabsf(strength) * (warp->type == DT_LIQUIFY_WARP_TYPE_RADIAL_SHRINK ? -1.0f : 1.0f);
 
   // lookup table: map of distance from center point => warp
-  const int table_size = iradius * LOOKUP_OVERSAMPLE;
+  const size_t table_size = iradius * LOOKUP_OVERSAMPLE;
   const float *const restrict lookup_table =
     build_lookup_table(table_size, warp->control1, warp->control2);
-  if(!stamp || !lookup_table)
+  if(!lookup_table)
   {
-    *pstamp = stamp;
     dt_free_align((void*)lookup_table);
     dt_print(DT_DEBUG_ALWAYS,"[liquify] out of memory, round stamp skipped\n");
     return;
   }
-  // points into buffer at the center of the circle
-  float complex *const center = stamp + 2 * iradius * iradius + 2 * iradius;
+
+  cairo_rectangle_int_t mmext = *stamp_extent;
+  mmext.x += (int) round(crealf(warp->point));
+  mmext.y += (int) round(cimagf(warp->point));
+
+  // point into the global distortion map at the center of the circle
+  const size_t global_width = global_map_extent->width;
+  float complex *const center
+    = (global_map
+       + (mmext.y + iradius - global_map_extent->y) * global_width
+       + mmext.x + iradius - global_map_extent->x);
 
   // The expensive operation here is hypotf ().  By dividing the
   // circle in quadrants and doing only the inside we have to calculate
@@ -969,55 +978,58 @@ static void build_round_stamp(float complex **pstamp,
   // doesn't work for OSX see issue #7349
   #if defined(_OPENMP) && !defined(__APPLE__)
   #pragma omp parallel for schedule(static) default(none) \
-    dt_omp_firstprivate(iradius, strength, abs_strength, table_size)   \
-    dt_omp_sharedconst(center, warp, stamp_extent, lookup_table, LOOKUP_OVERSAMPLE)
+    dt_omp_firstprivate(iradius, strength, abs_strength, table_size, global_width) \
+    dt_omp_sharedconst(center, warp, lookup_table, LOOKUP_OVERSAMPLE, global_map_extent)
   #endif
-
-  for(int y = 0; y <= iradius; y++)
+  for(size_t y = 0; y <= iradius; y++)
   {
-    for(int x = 0; x <= iradius; x++)
+    const float complex y_i = y * I;
+    const float complex minus_y_i = -y * I;
+    const float y2 = y*y;
+    for(size_t x = 0; x <= iradius; x++)
     {
       // faster than hypotf(), and we know we won't have overflow or denormals
-      const float dist = sqrtf(x*x + y*y);
-      const int idist = round(dist * LOOKUP_OVERSAMPLE);
+      const float dist = sqrtf((float)x*x + y2);
+      const size_t idist = round(dist * LOOKUP_OVERSAMPLE);
       if(idist >= table_size)
         // idist will only grow bigger in this row
         break;
 
       // pointers into the 4 quadrants of the circle
       // quadrant count is ccw from positive x-axis
-      float complex *const q1 = center - y * stamp_extent->width + x;
-      float complex *const q2 = center - y * stamp_extent->width - x;
-      float complex *const q3 = center + y * stamp_extent->width - x;
-      float complex *const q4 = center + y * stamp_extent->width + x;
+      float complex *const q1 = center - y * global_width + x;
+      float complex *const q2 = center - y * global_width - x;
+      float complex *const q3 = center + y * global_width - x;
+      float complex *const q4 = center + y * global_width + x;
 
-      float abs_lookup = abs_strength * lookup_table[idist] / iradius;
-
-      switch(warp->type)
+      if(warp->type == DT_LIQUIFY_WARP_TYPE_LINEAR)
       {
-         case DT_LIQUIFY_WARP_TYPE_RADIAL_GROW:
-           *q1 = abs_lookup * ( x - y * I);
-           *q2 = abs_lookup * (-x - y * I);
-           *q3 = abs_lookup * (-x + y * I);
-           *q4 = abs_lookup * ( x + y * I);
-           break;
-
-         case DT_LIQUIFY_WARP_TYPE_RADIAL_SHRINK:
-           *q1 = -abs_lookup * ( x - y * I);
-           *q2 = -abs_lookup * (-x - y * I);
-           *q3 = -abs_lookup * (-x + y * I);
-           *q4 = -abs_lookup * ( x + y * I);
-           break;
-
-         default:
-           *q1 = *q2 = *q3 = *q4 = strength * lookup_table[idist];
-           break;
+        const float complex w_strength = -strength * lookup_table[idist];
+        *q1 += w_strength;
+        if(x!=0)
+          *q2 += w_strength;
+        if(x!=0&&y!=0)
+          *q3 += w_strength;
+        if(y!=0)
+          *q4 += w_strength;
+      }
+      else
+      {
+        // DT_LIQUIFY_WARP_TYPE_RADIAL_GROW or _SHRINK
+        // abs_strength is negative for _SHRINK
+        const float abs_lookup = abs_strength * lookup_table[idist] / iradius;
+        *q1 += abs_lookup * ( x + minus_y_i);
+        if(x!=0)
+          *q2 += abs_lookup * (-x + minus_y_i);
+        if(x!=0&&y!=0)
+          *q3 += abs_lookup * (-x + y_i);
+        if(y!=0)
+          *q4 += abs_lookup * ( x + y_i);
       }
     }
   }
 
-  dt_free_align((void *) lookup_table);
-  *pstamp = stamp;
+  dt_free_align((void*) lookup_table);
 }
 
 /*
@@ -1030,7 +1042,7 @@ static void build_round_stamp(float complex **pstamp,
   encompassing all our paths.
 */
 
-static void add_to_global_distortion_map
+/*static*/ void add_to_global_distortion_map
   (float complex *global_map,
    const cairo_rectangle_int_t *const restrict global_map_extent,
    const dt_liquify_warp_t *const restrict warp,
@@ -1046,19 +1058,30 @@ static void add_to_global_distortion_map
   cairo_region_get_extents(mmreg, &cmmext);
   free(mmreg);
 
-  #ifdef _OPENMP
-  #pragma omp parallel for schedule (static) default (shared)
-  #endif
+  const size_t cmm_width = cmmext.width;
+  const size_t cmm_x = cmmext.x;
+  const size_t cmm_height = cmmext.height;
+  const size_t cmm_y = cmmext.y;
+  const size_t mm_width = mmext.width;
+  const size_t mm_x = mmext.y;
+  const size_t mm_y = mmext.y;
+  const size_t global_width = global_map_extent->width;
+  const size_t global_x = global_map_extent->x;
+  const size_t global_y = global_map_extent->y;
 
-  for(int y = cmmext.y; y < cmmext.y + cmmext.height; y++)
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(stamp, global_map, cmm_x, cmm_y, cmm_width, cmm_height, \
+                      mm_x, mm_y, mm_width, global_x, global_y, global_width) \
+  schedule(static)
+#endif
+  for(size_t y = cmm_y; y < cmm_y + cmm_height; y++)
   {
-    const float complex *const srcrow = stamp + ((y - mmext.y) * mmext.width);
-    float complex *const destrow = global_map
-      + ((y - global_map_extent->y) * global_map_extent->width);
-
-    for(int x = cmmext.x; x < cmmext.x + cmmext.width; x++)
+    const float complex *const srcrow = stamp + ((y - mm_y) * mm_width);
+    float complex *const destrow = global_map + ((y - global_y) * global_width);
+    for(int x = cmm_x; x < cmm_x + cmm_width; x++)
     {
-      destrow[x - global_map_extent->x] -= srcrow[x - mmext.x];
+      destrow[x - global_x] -= srcrow[x - mm_x];
     }
   }
 }
@@ -1084,28 +1107,27 @@ static void _apply_global_distortion_map(struct dt_iop_module_t *module,
   const struct dt_interpolation * const interpolation =
     dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
 
-  #ifdef _OPENMP
-  #pragma omp parallel for schedule (static) default (shared)
-  #endif
+  const size_t min_y = MAX(roi_out->y, extent->y);
+  const size_t max_y = MIN(roi_out->y + roi_out->height, extent->y + extent->height);
 
-  for(int y = extent->y; y < extent->y + extent->height; y++)
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(in, out, map, ch, ch_width, extent, roi_in, roi_out, \
+                      min_y, max_y, interpolation)                       \
+  schedule(static)
+#endif
+  for(size_t y = min_y; y < max_y; y++)
   {
-    // point inside roi_out ?
-    if(y >= roi_out->y && y < roi_out->y + roi_out->height)
+    const size_t min_x = MAX(roi_out->x, extent->x);
+    const size_t max_x = MIN(roi_out->x + roi_out->width, extent->x + extent->width);
+    const float complex *row = map + (y - extent->y) * extent->width + (min_x - extent->x);
+    float* out_sample = out + ch * ((y - roi_out->y) * roi_out->width - roi_out->x);
+    for(size_t x = min_x; x < max_x; x++)
     {
-      const float complex *row = map + (y - extent->y) * extent->width;
-      float* out_sample = out + ((y - roi_out->y) * roi_out->width +
-                               extent->x - roi_out->x) * ch;
-      for(int x = extent->x; x < extent->x + extent->width; x++)
+      if(*row != 0) // point actually warped?
       {
-        if(
-          // point inside roi_out ?
-          (x >= roi_out->x && x < roi_out->x + roi_out->width) &&
-          // point actually warped ?
-          (*row != 0))
-        {
-          if(ch == 1)
-            *out_sample = dt_interpolation_compute_sample(interpolation,
+        if(ch == 1)
+          out_sample[x] = dt_interpolation_compute_sample(interpolation,
                                                           in,
                                                           x + crealf(*row) - roi_in->x,
                                                           y + cimagf(*row) - roi_in->y,
@@ -1113,21 +1135,19 @@ static void _apply_global_distortion_map(struct dt_iop_module_t *module,
                                                           roi_in->height,
                                                           ch,
                                                           ch_width);
-          else
-            dt_interpolation_compute_pixel4c(
-              interpolation,
-              in,
-              out_sample,
-              x + crealf(*row) - roi_in->x,
-              y + cimagf(*row) - roi_in->y,
-              roi_in->width,
-              roi_in->height,
-              ch_width);
+        else
+          dt_interpolation_compute_pixel4c(
+            interpolation,
+            in,
+            out_sample + ch*x,
+            x + crealf(*row) - roi_in->x,
+            y + cimagf(*row) - roi_in->y,
+            roi_in->width,
+            roi_in->height,
+            ch_width);
 
-        }
-        ++row;
-        out_sample += ch;
       }
+      ++row;
     }
   }
 }
@@ -1188,11 +1208,8 @@ static float complex *create_global_distortion_map(const cairo_rectangle_int_t *
   for(const GSList *i = interpolated; i; i = g_slist_next(i))
   {
     const dt_liquify_warp_t *warp = ((dt_liquify_warp_t *) i->data);
-    float complex *stamp = NULL;
     cairo_rectangle_int_t r;
-    build_round_stamp(&stamp, &r, warp);
-    add_to_global_distortion_map(map, map_extent, warp, stamp, &r);
-    free((void *) stamp);
+    apply_round_stamp(&r, warp, map, map_extent);
   }
 
   if(inverted)
@@ -1203,10 +1220,11 @@ static float complex *create_global_distortion_map(const cairo_rectangle_int_t *
     // copy map into imap(inverted map).
     // imap [ n + dx(map[n]) , n + dy(map[n]) ] = -map[n]
 
-    #ifdef _OPENMP
-    #pragma omp parallel for schedule (static) default (shared)
-    #endif
-
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(map, map_extent, imap)  \
+  schedule(static)
+#endif
     for(int y = 0; y <  map_extent->height; y++)
     {
       const float complex *const row = map + y * map_extent->width;
@@ -1230,10 +1248,11 @@ static float complex *create_global_distortion_map(const cairo_rectangle_int_t *
     // distortion mask is only used to compute a final displacement of
     // points.
 
-    #ifdef _OPENMP
-    #pragma omp parallel for schedule (static) default (shared)
-    #endif
-
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(imap, map_extent) \
+  schedule(static)
+#endif
     for(int y = 0; y <  map_extent->height; y++)
     {
       float complex *const row = imap + y * map_extent->width;
@@ -1460,33 +1479,17 @@ void distort_mask(struct dt_iop_module_t *self,
                   const dt_iop_roi_t *const roi_out)
 {
   // 1. copy the whole image (we'll change only a small part of it)
-
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(in, out, roi_in, roi_out) \
-  schedule(static)
-#endif
-  for(int i = 0; i < roi_out->height; i++)
-  {
-    float *destrow = out + (size_t) i * roi_out->width;
-    const float *srcrow = in
-      + (size_t) (roi_in->width * (i + roi_out->y - roi_in->y) + roi_out->x - roi_in->x);
-
-    memcpy(destrow, srcrow, sizeof(float) * roi_out->width);
-  }
+  dt_iop_copy_image_roi(out, in, 1, roi_in, roi_out, 1);
 
   // 2. build the distortion map
-
   cairo_rectangle_int_t map_extent;
   float complex *map = NULL;
   _build_global_distortion_map(self, piece, roi_in->scale, FALSE,
                                roi_out, &map_extent, FALSE, &map);
-
   if(map == NULL)
     return;
 
   // 3. apply the map
-
   if(map_extent.width != 0 && map_extent.height != 0)
   {
     const int ch = piece->colors;
@@ -1496,7 +1499,6 @@ void distort_mask(struct dt_iop_module_t *self,
   }
 
   dt_free_align((void *) map);
-
 }
 
 void process(struct dt_iop_module_t *module,
@@ -1506,42 +1508,21 @@ void process(struct dt_iop_module_t *module,
              const dt_iop_roi_t *const roi_in,
              const dt_iop_roi_t *const roi_out)
 {
+  if(!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, module, piece->colors,
+                                        in, out, roi_in, roi_out))
+    return;
   // 1. copy the whole image (we'll change only a small part of it)
-
-  const int ch = piece->colors;
-  assert(ch == 4);
-
-  const int height = MIN(roi_in->height, roi_out->height);
-  const int width = MIN(roi_in->width, roi_out->width);
-
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(ch, height, in, out, roi_in, roi_out, width) \
-  schedule(static)
-#endif
-  for(int i = 0; i < height; i++)
-  {
-    float *destrow = (float *)out + (size_t)ch * i * roi_out->width;
-    const float *srcrow = (float *)in
-      + (size_t)ch * (roi_in->width * (i + roi_out->y - roi_in->y)
-                      + roi_out->x - roi_in->x);
-
-    memcpy(destrow, srcrow, sizeof(float) * ch * width);
-  }
+  dt_iop_copy_image_roi(out, in, piece->colors, roi_in, roi_out, 1);
 
   // 2. build the distortion map
-
   cairo_rectangle_int_t map_extent;
   float complex *map = NULL;
-
   _build_global_distortion_map(module, piece, roi_in->scale, FALSE,
                                roi_out, &map_extent, FALSE, &map);
-
   if(map == NULL)
     return;
 
   // 3. apply the map
-
   if(map_extent.width != 0 && map_extent.height != 0)
     _apply_global_distortion_map(module, piece, in, out, roi_in, roi_out, map, &map_extent);
 


### PR DESCRIPTION
Combine computing the stamp and applying it to reduce memory traffic (for a roughly two-fold speedup) while building the distortion map.  Since the distortion map is built by the CPU even on the OpenCL code path, this will also speed up the module when running on GPU.

Reduce looping in apply_global_distortion_map.

Remove some now-unused code.

Passes integration test 0036.
```
Thr	Master	PR
1	220.80	177.09	-19.7%
2	158.93	111.89	-29.6%
4	120.79	 71.01	-41.2%
8	 95.86	 49.99	-47.8%
16	 85.72	 39.46	-53.9%
32	 80.15	 36.76	-54.1%
64	 97.36	 43.69	-55.1%
```
