### PR TITLE
squash some more GCC 13 warnings

### DIFF
--- a/data/kernels/CMakeLists.txt
+++ b/data/kernels/CMakeLists.txt
@@ -1,8 +1,8 @@
 #
 # install opencl kernel source files
 #
-FILE(GLOB DT_OPENCL_KERNELS "*.cl" "common.h")
-FILE(GLOB DT_OPENCL_EXTRA "programs.conf" "rgb_norms.h" "noise_generator.h" "color_conversion.h" "colorspace.h")
+FILE(GLOB DT_OPENCL_KERNELS "*.cl")
+FILE(GLOB DT_OPENCL_EXTRA "programs.conf" "common.h" "rgb_norms.h" "noise_generator.h" "color_conversion.h" "colorspace.h")
 
 add_custom_target(testcompile_opencl_kernels ALL)
 

--- a/src/iop/Permutohedral.h
+++ b/src/iop/Permutohedral.h
@@ -429,7 +429,7 @@ public:
    *    vd_ : dimensionality of value vectors
    * nData_ : number of points in the input
    */
-  PermutohedralLattice(size_t nData_, int nThreads_ = 1, size_t grid_points = ~0L) : nData(nData_), nThreads(nThreads_)
+  PermutohedralLattice(size_t nData_, size_t nThreads_ = 1, size_t grid_points = ~0L) : nData(nData_), nThreads(nThreads_)
   {
     // Allocate storage for various arrays
     float *scaleFactorTmp = new float[D];
@@ -473,7 +473,7 @@ public:
     size_t points = ((D+1) * nData) < effective_MP ? ((D+1) * nData) : effective_MP;
 
     hashTables = new HashTable[nThreads];
-    for(int i = 0; i < nThreads; i++)
+    for(size_t i = 0; i < nThreads; i++)
     {
        hashTables[i].setSize(points / nThreads);
     }
@@ -647,7 +647,7 @@ public:
     size_t total_grows = hashTables[0].auto_grow;
     size_t init_bytes = hashTables[0].init_alloc;
     size_t total_entries = hashTables[0].size();
-    for(int i = 1; i < nThreads; i++)
+    for(size_t i = 1; i < nThreads; i++)
     {
        alloc_entries += hashTables[i].maxFill();
        total_entries += hashTables[i].size();
@@ -660,7 +660,7 @@ public:
     /* Merge the multiple hash tables into one, creating an offset remap table. */
     int **offset_remap = new int *[nThreads];
     size_t remap_bytes = 0;
-    for(int i = 1; i < nThreads; i++)
+    for(size_t i = 1; i < nThreads; i++)
     {
       const Key *oldKeys = hashTables[i].getKeys();
       const Value *oldVals = hashTables[i].getValues();
@@ -700,7 +700,7 @@ public:
       }
     }
 
-    for(int i = 1; i < nThreads; i++) delete[] offset_remap[i];
+    for(size_t i = 1; i < nThreads; i++) delete[] offset_remap[i];
     delete[] offset_remap;
   }
 
@@ -779,7 +779,7 @@ public:
 
 private:
   size_t nData;
-  int nThreads;
+  size_t nThreads;
   const float *scaleFactor;
   const int *canonical;
 


### PR DESCRIPTION
The first one is not really from GCC 13 (Clang 16?), but handle it anyway:
```
[  171s] [  6%] Test-compiling OpenCL program common.h
[  171s] cd "/home/abuild/rpmbuild/BUILD/darktable-4.3.0~git1998.1246514a/build/share/darktable/kernels" && /usr/bin/clang-16.0 -cc1 -cl-std=CL1.2 -isystem /usr/lib64/clang/16/include -finclude-default-header -I/home/abuild/rpmbuild/BUILD/darktable-4.3.0~git1998.1246514a/data/kernels /home/abuild/rpmbuild/BUILD/darktable-4.3.0~git1998.1246514a/data/kernels/common.h
[  171s] /home/abuild/rpmbuild/BUILD/darktable-4.3.0~git1998.1246514a/data/kernels/common.h:19:9: warning: #pragma once in main file [-Wpragma-once-outside-header]
[  171s] #pragma once
[  171s]         ^
[  171s] 1 warning generated.
```

and 2 instances of 
```
[  285s] In member function '__ct ',
[  285s]     inlined from 'process' at /home/abuild/rpmbuild/BUILD/darktable-4.3.0~git1998.1246514a/src/iop/tonemap.cc:115:65:
[  285s] /home/abuild/rpmbuild/BUILD/darktable-4.3.0~git1998.1246514a/src/iop/Permutohedral.h:475:18: warning: argument 1 value '18446744073709551615' exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
[  285s]   475 |     hashTables = new HashTable[nThreads];
[  285s]       |                  ^
[  285s] /usr/include/c++/13/new: In function 'process':
[  285s] /usr/include/c++/13/new:128:26: note: in a call to allocation function 'operator new []' declared here
[  285s]   128 | _GLIBCXX_NODISCARD void* operator new[](std::size_t) _GLIBCXX_THROW (std::bad_alloc)
[  285s]       |                          ^
```

