### PR TITLE
CI: tweak Windows jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,16 +163,17 @@ jobs:
           cd "${SRC_DIR}/src/tests/integration/"
           ./run.sh --no-opencl --no-deltae --fast-fail
 
-  Win64:
-    name: Win64.${{ matrix.compiler.compiler }}.${{ matrix.target }}.${{ matrix.btype }}.${{ matrix.generator }}
+  Windows:
+    name: Windows.${{ matrix.msystem }}.${{ matrix.target }}.${{ matrix.btype }}.${{ matrix.generator }}
     runs-on: windows-latest
     strategy:
       fail-fast: true
       matrix:
         btype:
           - Debug
-        compiler:
-          - { compiler: GNU,  CC: gcc,   CXX: g++ }
+        msystem:
+          #- CLANG64
+          - UCRT64
         target:
           - skiptest
         generator:
@@ -183,8 +184,6 @@ jobs:
       run:
         shell: msys2 {0}
     env:
-      CC: ${{ matrix.compiler.CC }}
-      CXX: ${{ matrix.compiler.CXX }}
       SRC_DIR: ${{ github.workspace }}/src
       BUILD_DIR: ${{ github.workspace }}/build
       INSTALL_PREFIX: ${{ github.workspace }}/install
@@ -196,9 +195,8 @@ jobs:
     steps:
       - uses: msys2/setup-msys2@v2
         with:
-          msystem: ucrt64
+          msystem: ${{ matrix.msystem }}
           install: >-
-            base-devel
             git
             intltool
             po4a
@@ -256,7 +254,6 @@ jobs:
           cmake -E make_directory "${INSTALL_PREFIX}"
           $(cygpath ${SRC_DIR})/.ci/ci-script.sh
       - name: Check if it runs
-        if: ${{success() && matrix.compiler.compiler == 'GNU' }} # LLVM build on windws for some reason breaks in imageio_rawspeed...
         run: |
           $(cygpath ${INSTALL_PREFIX})/bin/darktable.exe --version || true
           $(cygpath ${INSTALL_PREFIX})/bin/darktable-cli.exe --version || true
@@ -274,7 +271,7 @@ jobs:
                  --conf plugins/lighttable/export/iccintent=0
 
   macOS:
-    name: macOS.${{ matrix.compiler.compiler }}.${{ matrix.build.xcode }}.${{ matrix.target }}.${{ matrix.generator }}
+    name: macOS.${{ matrix.compiler.compiler }}.${{ matrix.build.xcode }}.${{ matrix.target }}.${{ matrix.btype }}.${{ matrix.generator }}
     runs-on: ${{ matrix.build.os }}
     strategy:
       fail-fast: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,37 +9,38 @@ permissions:
   contents: read
 
 jobs:
-  Win64:
+  Windows:
     if: github.repository == 'darktable-org/darktable' || github.event_name == 'workflow_dispatch'
-    name: Nightly darktable win64
+    name: Nightly darktable Windows
     runs-on: windows-latest
     strategy:
       fail-fast: true
       matrix:
-        btype: [Release]
-        compiler:
-          - { compiler: GNU,  CC: gcc,   CXX: g++ }
+        btype:
+          - Release
+        msystem:
+          - UCRT64
+        target:
+          - skiptest
+        generator:
+          - Ninja
         eco: [-DBINARY_PACKAGE_BUILD=ON]
-        target: [skiptest]
     defaults:
       run:
         shell: msys2 {0}
     env:
-      CC: ${{ matrix.compiler.CC }}
-      CXX: ${{ matrix.compiler.CXX }}
       SRC_DIR: ${{ github.workspace }}/src
       BUILD_DIR: ${{ github.workspace }}/build
       INSTALL_PREFIX: ${{ github.workspace }}/install
       ECO: ${{ matrix.eco }}
       CMAKE_BUILD_TYPE: ${{ matrix.btype }}
-      GENERATOR: Ninja
       TARGET: ${{ matrix.target }}
+      GENERATOR: ${{ matrix.generator }}
     steps:
       - uses: msys2/setup-msys2@v2
         with:
-          msystem: ucrt64
+          msystem: ${{ matrix.msystem }}
           install: >-
-            base-devel
             git
             intltool
             po4a
@@ -103,6 +104,7 @@ jobs:
       - name: Check if it runs
         run: |
           $(cygpath ${INSTALL_PREFIX})/bin/darktable.exe --version || true
+          echo "Testing RUN!"
           $(cygpath ${INSTALL_PREFIX})/bin/darktable-cli.exe \
                  --width 2048 --height 2048 \
                  --hq true --apply-custom-presets false \
@@ -119,7 +121,7 @@ jobs:
           cd "${BUILD_DIR}"
           cmake --build "${BUILD_DIR}" --target package
       - name: Get version info
-        run: |      
+        run: |
           cd ${SRC_DIR}
           echo "VERSION=$(git describe --tags | sed 's/^release-//;s/-/+/;s/-/~/;s/rc/~rc/')" >> $GITHUB_ENV
           ([[ ${MSYSTEM_CARCH} == x86_64 ]] && echo "SYSTEM=win64" || echo "SYSTEM=woa64") >> $GITHUB_ENV
@@ -212,7 +214,7 @@ jobs:
         run: |
           ./src/packaging/macosx/4_make_hb_darktable_dmg.sh
       - name: Get version info
-        run: |      
+        run: |
           cd ${{ env.SRC_DIR }}
           echo "VERSION=$(git describe --tags | sed 's/^release-//;s/-/+/;s/-/~/;s/rc/~rc/')-$(arch)" >> $GITHUB_ENV
       - name: Package upload
@@ -222,4 +224,3 @@ jobs:
           name: darktable-${{ env.VERSION }}.dmg
           path: ${{ env.INSTALL_PREFIX }}/darktable-${{ env.VERSION }}.dmg
           retention-days: 2
-


### PR DESCRIPTION
Mainly cosmetic, with one significant change: switch to using [MSYSTEM environment](https://www.msys2.org/docs/environments/) directly which has a pre-determined toolchain (this can easily enable adding CLANG64, CLANGARM64 in the future to the matrix...)