### PR TITLE
show toast with name of last midi device opened

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -3102,6 +3102,8 @@ void dt_shortcuts_load(const gchar *ext, const gboolean clear)
 
 void dt_shortcuts_reinitialise(dt_action_t *action)
 {
+  dt_control_log(_("reinitialising input devices"));
+
   for(GSList *d = darktable.control->input_drivers; d; d = d->next)
   {
     const dt_input_driver_definition_t *driver = d->data;
@@ -3118,8 +3120,6 @@ void dt_shortcuts_reinitialise(dt_action_t *action)
   FILE *f = g_fopen(actions_file, "wb");
   _dump_actions(f, darktable.control->actions);
   fclose(f);
-
-  dt_control_log(_("input devices reinitialised"));
 }
 
 void dt_shortcuts_select_view(dt_view_type_flags_t view)

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -795,7 +795,7 @@ static void dt_lib_init_module(void *m)
   if(darktable.gui)
   {
     module->gui_init(module);
-    g_object_ref_sink(module->widget);
+    if(module->widget) g_object_ref_sink(module->widget);
 
     if(module->gui_update)
       g_signal_connect(G_OBJECT(module->widget), "draw",

--- a/src/libs/tools/gamepad.c
+++ b/src/libs/tools/gamepad.c
@@ -39,22 +39,12 @@ const char *name(dt_lib_module_t *self)
 
 dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  return DT_VIEW_ALL;
+  return DT_VIEW_NONE;
 }
 
 uint32_t container(dt_lib_module_t *self)
 {
   return DT_UI_CONTAINER_PANEL_TOP_CENTER;
-}
-
-int expandable(dt_lib_module_t *self)
-{
-  return 0;
-}
-
-int position(const dt_lib_module_t *self)
-{
-  return 1;
 }
 
 typedef struct dt_gamepad_device_t
@@ -329,11 +319,6 @@ static void _gamepad_close_devices(dt_lib_module_t *self)
 
 void gui_init(dt_lib_module_t *self)
 {
-  if(!self->widget)
-  {
-    self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-    gtk_widget_set_no_show_all(self->widget, TRUE);
-  }
   self->data = NULL;
 
   _gamepad_open_devices(self);

--- a/src/libs/tools/midi.c
+++ b/src/libs/tools/midi.c
@@ -43,22 +43,12 @@ const char *name(dt_lib_module_t *self)
 
 dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  return DT_VIEW_ALL;
+  return DT_VIEW_NONE;
 }
 
 uint32_t container(dt_lib_module_t *self)
 {
   return DT_UI_CONTAINER_PANEL_TOP_CENTER;
-}
-
-int expandable(dt_lib_module_t *self)
-{
-  return 0;
-}
-
-int position(const dt_lib_module_t *self)
-{
-  return 1;
 }
 
 typedef struct dt_midi_device_t
@@ -564,6 +554,8 @@ static void _midi_open_devices(dt_lib_module_t *self)
       {
         dt_print(DT_DEBUG_INPUT, "[_midi_open_devices] opened midi device '%s' via '%s' as midi%d\n",
                  info->name, info->interf, dev);
+        if(!cur_dev || !*cur_dev)
+          dt_control_log(_("%s opened as midi%d"), info->name, dev);
       }
 
       dt_midi_device_t *midi = (dt_midi_device_t *)g_malloc0(sizeof(dt_midi_device_t));
@@ -683,11 +675,6 @@ void gui_init(dt_lib_module_t *self)
 {
   dt_capabilities_add("midi");
 
-  if(!self->widget)
-  {
-    self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-    gtk_widget_set_no_show_all(self->widget, TRUE);
-  }
   self->data = NULL;
 
   _midi_open_devices(self);


### PR DESCRIPTION
This shows a toast with the name of the last opened midi device _if its order isn't specified in `preferences/miscellaneous/order or exclude MIDI devices`_. This makes it easier to know what (part of) a name to add there. If multiple devices are opened, only the last one will show (since previous toasts get overwritten). Adding it with a fixed position to the pref will then cause the next one to show in the toast after reinitialising with SHIFT+CTRL+ALT+I