### PR TITLE
RFC: Hide/show masks using right mouse button on canvas.

### DIFF
--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -185,6 +185,8 @@ typedef struct dt_develop_t
   GList *forms;
   struct dt_masks_form_t *form_visible;
   struct dt_masks_form_gui_t *form_gui;
+  gboolean was_in_creation; // flag to pass state between button
+                            // pressed/released
   // all forms to be linked here for cleanup:
   GList *allforms;
 

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1819,7 +1819,7 @@ void dt_masks_form_remove(struct dt_iop_module_t *module,
 
   // if we are here that mean we have to permanently delete this form
   // we drop the form from all modules
-  int form_removed = 0;
+  gboolean form_removed = FALSE;
   for(GList *iops = darktable.develop->iop; iops; iops = g_list_next(iops))
   {
     dt_iop_module_t *m = (dt_iop_module_t *)iops->data;
@@ -1854,7 +1854,7 @@ void dt_masks_form_remove(struct dt_iop_module_t *module,
           }
           if(ok)
           {
-            form_removed = 1;
+            form_removed = TRUE;
             dt_masks_iop_update(m);
             dt_masks_update_image(darktable.develop);
             if(iopgrp->points == NULL) dt_masks_form_remove(m, NULL, iopgrp);
@@ -1870,7 +1870,7 @@ void dt_masks_form_remove(struct dt_iop_module_t *module,
     if(f->formid == id)
     {
       darktable.develop->forms = g_list_remove(darktable.develop->forms, f);
-      form_removed = 1;
+      form_removed = TRUE;
       break;
     }
   }

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1795,6 +1795,8 @@ void dt_masks_form_remove(struct dt_iop_module_t *module,
       dt_masks_iop_update(module);
       dt_masks_update_image(darktable.develop);
     }
+    dt_toast_log(_("'%s' removed"), form->name);
+
     if(ok && grp->points == NULL) dt_masks_form_remove(module, NULL, grp);
     return;
   }

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5174,7 +5174,7 @@ int button_released(struct dt_iop_module_t *self,
     float dx = pts[0] - pts[2];
     float dy = pts[1] - pts[3];
     if(sqrt(dx * dx + dy * dy) /* zoom_scale */ < DT_PIXEL_APPLY_DPI(25))
-      return TRUE;
+      return FALSE;
 
     if(dx < 0)
     {


### PR DESCRIPTION
Now that all masks have control points to change the size, feathering, segments, control nodes... It is easier to stay over the canvas and be able to show/hide the masks instead of having to click on the blending gui button.

This makes the general masks handling consistent with the liquify masks where it is already possible to use the right mouse button to show/hide masks.

Long time ago this idea was rejected because a right mouse button would remove the forms. But we need to be over it (or a nodes for the path) and when it is displayed to actually remove the mask. Yet it seems perfectly usable and not error prone, and if this happens we still have the undo to recover the masks (undo a mask at the time this idea was rejected was not implemented).