### PR TITLE
Bugfix: pixelpipe cache versus raster mask 

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -725,11 +725,11 @@ void dt_develop_blend_process(struct dt_iop_module_t *self,
   // TODO: should we skip raster masks?
   if(piece->pipe->store_all_raster_masks || dt_iop_is_raster_mask_used(self, 0))
   {
-    g_hash_table_replace(piece->raster_masks, GINT_TO_POINTER(0), _mask);
+    g_hash_table_replace(piece->raster_masks, GINT_TO_POINTER(NO_MASKID), _mask);
   }
   else
   {
-    g_hash_table_remove(piece->raster_masks, GINT_TO_POINTER(0));
+    g_hash_table_remove(piece->raster_masks, GINT_TO_POINTER(NO_MASKID));
     dt_free_align(_mask);
   }
 }
@@ -1371,7 +1371,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self,
 
   // check if we should store the mask for export or use in subsequent modules
   // TODO: should we skip raster masks?
-  if(piece->pipe->store_all_raster_masks || dt_iop_is_raster_mask_used(self, 0))
+  if(piece->pipe->store_all_raster_masks || dt_iop_is_raster_mask_used(self, NO_MASKID))
   {
     //  get back final mask from the device to store it for later use
     if(!(mask_mode & DEVELOP_MASK_RASTER))
@@ -1380,11 +1380,11 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self,
                                           owidth, oheight, sizeof(float));
       if(err != CL_SUCCESS) goto error;
     }
-    g_hash_table_replace(piece->raster_masks, GINT_TO_POINTER(0), _mask);
+    g_hash_table_replace(piece->raster_masks, GINT_TO_POINTER(NO_MASKID), _mask);
     }
   else
   {
-    g_hash_table_remove(piece->raster_masks, GINT_TO_POINTER(0));
+    g_hash_table_remove(piece->raster_masks, GINT_TO_POINTER(NO_MASKID));
     dt_free_align(_mask);
   }
 

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -279,8 +279,8 @@ static void _refine_with_detail_mask(struct dt_iop_module_t *self,
   dt_dev_pixelpipe_t *p = piece->pipe;
   if(p->rawdetail_mask_data == NULL) return;
 
-  const int iwidth  = p->rawdetail_mask_roi.width;
-  const int iheight = p->rawdetail_mask_roi.height;
+  const int iwidth  = p->detail_width;
+  const int iheight = p->detail_height;
   const int owidth  = roi_out->width;
   const int oheight = roi_out->height;
   dt_print_pipe(DT_DEBUG_PIPE,
@@ -756,8 +756,8 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self,
   dt_dev_pixelpipe_t *p = piece->pipe;
   if(p->rawdetail_mask_data == NULL) return;
 
-  const int iwidth  = p->rawdetail_mask_roi.width;
-  const int iheight = p->rawdetail_mask_roi.height;
+  const int iwidth  = p->detail_width;
+  const int iheight = p->detail_height;
   const int owidth  = roi_out->width;
   const int oheight = roi_out->height;
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_OPENCL,

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -130,17 +130,20 @@ uint64_t dt_dev_pixelpipe_cache_basichash(
   uint64_t hash = 5381;
 
   // we use the the imgid and pipe type for the hash
-  const uint32_t hashing_pipemode[2] = {(uint32_t)imgid, (uint32_t)pipe->type };
+  const uint32_t hashing_pipemode[3] = {(uint32_t)imgid,
+                                        (uint32_t)pipe->type,
+                                        (uint32_t)pipe->want_detail_mask };
 
   char *pstr = (char *)hashing_pipemode;
   for(size_t ip = 0; ip < sizeof(hashing_pipemode); ip++)
     hash = ((hash << 5) + hash) ^ pstr[ip];
 
-  // also use the details mask roi
+/*
+  // also use the details mask roi?
   pstr = (char *)&pipe->rawdetail_mask_roi;
   for(size_t ip = 0; ip < sizeof(dt_iop_roi_t); ip++)
     hash = ((hash << 5) + hash) ^ pstr[ip];
-
+*/
   // go through all modules up to position and compute a hash using the operation and params.
   GList *pieces = pipe->nodes;
   for(int k = 0; k < position && pieces; k++)

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -82,14 +82,6 @@ typedef enum dt_dev_pixelpipe_change_t
   DT_DEV_PIPE_ZOOMED = 1 << 3 // zoom event, preview pipe does not need changes
 } dt_dev_pixelpipe_change_t;
 
-typedef enum dt_develop_detail_mask_t
-{
-  DT_DEV_DETAIL_MASK_NONE = 0,
-  DT_DEV_DETAIL_MASK_REQUIRED = 1,
-  DT_DEV_DETAIL_MASK_DEMOSAIC = 2,
-  DT_DEV_DETAIL_MASK_RAWPREPARE = 4
-} dt_develop_detail_mask_t;
-
 /**
  * this encapsulates the pixelpipe.
  * a develop module will need several of these:
@@ -140,10 +132,11 @@ typedef struct dt_dev_pixelpipe_t
   int final_width, final_height;
 
   // the data for the luminance mask are kept in a buffer written by demosaic or rawprepare
-  // as we have to scale the mask later ke keep roi at that stage
+  // as we have to scale the mask later we keep size at that stage
   float *rawdetail_mask_data;
-  struct dt_iop_roi_t rawdetail_mask_roi;
-  dt_develop_detail_mask_t want_detail_mask;
+  int detail_width;
+  int detail_height;
+  gboolean want_detail_mask;
 
   // we have to keep track of the next processing module to use an iop cacheline with high priority
   gboolean next_important_module;
@@ -295,12 +288,12 @@ void dt_dev_clear_rawdetail_mask(dt_dev_pixelpipe_t *pipe);
 gboolean dt_dev_write_rawdetail_mask(dt_dev_pixelpipe_iop_t *piece,
                                      float *const rgb,
                                      const dt_iop_roi_t *const roi_in,
-                                     const int mode);
+                                     const gboolean mode);
 #ifdef HAVE_OPENCL
 gboolean dt_dev_write_rawdetail_mask_cl(dt_dev_pixelpipe_iop_t *piece,
                                         cl_mem in,
                                         const dt_iop_roi_t *const roi_in,
-                                        const int mode);
+                                        const gboolean mode);
 #endif
 
 /* specialized version of dt_print for pixelpipe debugging */
@@ -313,7 +306,7 @@ void dt_print_pipe(dt_debug_thread_t thread,
                    const char *msg, ...);
 
 // helper function writing the pipe-processed ctmask data to dest
-float *dt_dev_distort_detail_mask(const dt_dev_pixelpipe_t *pipe,
+float *dt_dev_distort_detail_mask(dt_dev_pixelpipe_t *pipe,
                                   float *src,
                                   const struct dt_iop_module_t *target_module);
 

--- a/src/iop/demosaicing/basics.c
+++ b/src/iop/demosaicing/basics.c
@@ -637,7 +637,8 @@ static int process_default_cl(
       }
     }
 
-    dt_dev_write_rawdetail_mask_cl(piece, dev_aux, roi_in, DT_DEV_DETAIL_MASK_DEMOSAIC);
+    if(piece->pipe->want_detail_mask)
+      dt_dev_write_rawdetail_mask_cl(piece, dev_aux, roi_in, TRUE);
 
     if(scaled)
     {

--- a/src/iop/demosaicing/rcd.c
+++ b/src/iop/demosaicing/rcd.c
@@ -786,7 +786,8 @@ static int process_rcd_cl(
     dt_opencl_release_mem_object(dev_green_eq);
     dev_green_eq = cfa = rgb0 = rgb1 = rgb2 = VH_dir = PQ_dir = VP_diff = HQ_diff = NULL;
 
-    dt_dev_write_rawdetail_mask_cl(piece, dev_aux, roi_in, DT_DEV_DETAIL_MASK_DEMOSAIC);
+    if(piece->pipe->want_detail_mask)
+      dt_dev_write_rawdetail_mask_cl(piece, dev_aux, roi_in, TRUE);
 
     if(scaled)
     {

--- a/src/iop/demosaicing/vng.c
+++ b/src/iop/demosaicing/vng.c
@@ -630,7 +630,9 @@ static int process_vng_cl(
         CLARG(dev_tmp), CLARG(dev_aux), CLARG(width), CLARG(height));
       if(err != CL_SUCCESS) goto error;
     }
-    dt_dev_write_rawdetail_mask_cl(piece, dev_aux, roi_in, DT_DEV_DETAIL_MASK_DEMOSAIC);
+
+    if(piece->pipe->want_detail_mask)
+      dt_dev_write_rawdetail_mask_cl(piece, dev_aux, roi_in, TRUE);
 
     if(scaled)
     {

--- a/src/iop/demosaicing/xtrans.c
+++ b/src/iop/demosaicing/xtrans.c
@@ -2192,7 +2192,9 @@ static int process_markesteijn_cl(
       dt_opencl_release_mem_object(dev_edge_out);
       dev_edge_in = dev_edge_out = NULL;
     }
-    dt_dev_write_rawdetail_mask_cl(piece, dev_tmp, roi_in, DT_DEV_DETAIL_MASK_DEMOSAIC);
+
+    if(piece->pipe->want_detail_mask)
+      dt_dev_write_rawdetail_mask_cl(piece, dev_tmp, roi_in, TRUE);
 
     if(scaled)
     {

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -478,7 +478,8 @@ void process(
     }
   }
 
-  dt_dev_write_rawdetail_mask(piece, (float *const)ovoid, roi_in, DT_DEV_DETAIL_MASK_RAWPREPARE);
+  if(!dt_image_is_raw(&piece->pipe->image) && piece->pipe->want_detail_mask)
+    dt_dev_write_rawdetail_mask(piece, (float *const)ovoid, roi_in, FALSE);
 
   for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
 }
@@ -589,9 +590,11 @@ int process_cl(
 
   for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
 
-  err = dt_dev_write_rawdetail_mask_cl(piece, dev_out, roi_in, DT_DEV_DETAIL_MASK_RAWPREPARE);
-  if(err != CL_SUCCESS) goto error;
-
+  if(!dt_image_is_raw(&piece->pipe->image) && piece->pipe->want_detail_mask)
+  {
+    err = dt_dev_write_rawdetail_mask_cl(piece, dev_out, roi_in, FALSE);
+    if(err != CL_SUCCESS) goto error;
+  }
   return TRUE;
 
 error:
@@ -779,7 +782,7 @@ void commit_params(
      || _image_is_normalized(&piece->pipe->image))
     piece->enabled = FALSE;
 
-  if(piece->pipe->want_detail_mask == (DT_DEV_DETAIL_MASK_REQUIRED | DT_DEV_DETAIL_MASK_RAWPREPARE))
+  if(piece->pipe->want_detail_mask)
     piece->process_tiling_ready = FALSE;
 }
 


### PR DESCRIPTION
We have #14271 indicating a problems with details masks.

The whole details-mask thing got some love leading to easier understanding what's going on there.
There is now only `gboolean want_detail_mask` in `struct dt_dev_pixelpipe_t` that is set to `TRUE` if we use a dual-demosaicing mode or the "details threshold" if refining a mask. If this is set, either `demosaic` (for raws) or `rawprepare` for sraws writes the scharr-mask. Simpler interface, nothing changed in color maths ...

But- this didn't solve the issue, in fact there was nothing wrong there, just not understandable what happens.

The issue reported could also be triggered by other raster mask dependencies, so what happened? The content of the source raster mask is not reflected in cache hashes later in the pipe, so we could take non-valid cachelines.
What is done here, whenever we update a raster mask, all later cachelines are invalidated.

Another old bug fixed, was just very difficult to trigger with 5 cachelines so got un-noticed.

Fixes #14271 @s7habo