### PR TITLE
switch off -Wstringop-overflow for gcc 13

### DIFF
--- a/src/iop/CMakeLists.txt
+++ b/src/iop/CMakeLists.txt
@@ -164,3 +164,9 @@ endif(APPLE)
 
 set_property(GLOBAL PROPERTY DT_PLUGIN_IOPS ${_iop_list})
 set_property(GLOBAL PROPERTY DT_PLUGIN_IOPS_VISIBLE_BY_DEFAULT ${_iop_default_visible_list})
+
+# workaround for GCC 13
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 13)
+  target_compile_options(colorchecker PRIVATE -Wno-error=stringop-overflow)
+  target_compile_options(demosaic PRIVATE -Wno-error=stringop-overflow)
+endif()


### PR DESCRIPTION
Addresses part of https://github.com/darktable-org/darktable/issues/14057 for 4.2.x branch

As agreed in https://github.com/darktable-org/darktable/pull/14334#issuecomment-1524773064