### PR TITLE
[GUI] POTFILES.in: Add missing wb_presets.c

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -128,6 +128,7 @@ src/common/ratings.c
 src/common/styles.c
 src/common/utility.c
 src/common/variables.c
+src/common/wb_presets.c
 src/control/control.c
 src/control/crawler.c
 src/control/jobs/camera_jobs.c


### PR DESCRIPTION
This fix will allow the white balance preset names of cameras to be translated.

However, I have one more suggestion. It doesn't seem very logical to me that the names of these presets are converted to lower case to match the classic dt style. These names are actually what the user (photographer) sees in the menu of his camera when setting it up. And these names in the menu, of course, are not written in lower case. I would put these names in the category of ones we don't lowercase: preset names, it's like proper names.

If this proposal is accepted, I will make another fix and then darktable.pot should not be updated until the second fix.
