### PR TITLE
Force a resize immediately after a delayed list update

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3496,6 +3496,7 @@ void dt_gui_widget_reallocate_now(GtkWidget *widget)
   gtk_widget_get_allocation(widget, &allocation);
   if(allocation.width > 1)
     gtk_widget_size_allocate(widget, &allocation);
+  gtk_widget_queue_resize(widget);
 }
 
 gboolean dt_gui_search_start(GtkWidget *widget, GdkEventKey *event, GtkSearchEntry *entry)


### PR DESCRIPTION
Forcing an immediate (within the same draw cycle) allocation of a newly updated list with its previous size (https://github.com/darktable-org/darktable/pull/14287) breaks the automatic resizing of the list based on its content (#14356). So now _do_ initially reallocate the same size after updating the content of the list, but _also_ flag it as needing to update its allocation again. Seems to work (even if it doesn't fully make sense to me, because the resize in `_resize_wrap_draw` is triggered by the "draw" event, not the "size-allocate" event).

Fixes #14356.