### PR TITLE
highpass.c: optimize code

### DIFF
--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -291,9 +291,6 @@ void process(struct dt_iop_module_t *self,
   const float *const in = (float *)ivoid;
   float *out = (float *)ovoid;
 
-  /* the blend code at the end assumes at least 4 channels, and we never get more than four */
-  assert(piece->colors == ch);
-
 /* create inverted image and then blur */
 /* since we use only the L channel, pack the values together instead of every fourth float */
 /* to reduce cache pressure and memory bandwidth during the blur operation */


### PR DESCRIPTION
Optimize the code in the final blend loop and increase the proportion which is performed in parallel.

Passes test 0028.
```
Thr	Master	PR
1	237.14	233.96	 -1.3%
2	129.80	125.55	 -3.3%
4	 75.25	 69.10	 -8.1%
8	 52.33	 42.99	-17.8%
16	 40.93	 31.12	-23.9%
32	 37.99	 24.99	-34.2%
64	 41.37	 31.71	-23.3%
```
