### PR TITLE
add auto-vectorized log2 and exp2 functions

### DIFF
--- a/src/common/math.h
+++ b/src/common/math.h
@@ -484,15 +484,11 @@ static inline void dt_vector_powf(const dt_aligned_pixel_t input,
                                   const dt_aligned_pixel_t power,
                                   dt_aligned_pixel_t output)
 {
-#ifdef __SSE__
-    *((__m128*)output) = _mm_pow_ps(*((__m128*)input), *((__m128*)power));
-#else
-    for_four_channels(c)
-    {
-      // Apply the transfer function of the display
-      output[c] = powf(input[c], power[c]);
-    }
-#endif
+  dt_aligned_pixel_t log;
+  dt_vector_log2(input, log);
+  for_each_channel(c)
+    log[c] *= power[c];
+  dt_vector_exp2(log, output);
 }
 
 static inline void dt_vector_add(dt_aligned_pixel_t sum,

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -519,7 +519,7 @@ static inline void dt_vector_exp2(const dt_aligned_pixel_t input, dt_aligned_pix
   // clamp the exponent to the suported range
   static const dt_aligned_pixel_t lower_bound = { -126.99999f, -126.99999f, -126.99999f, -126.99999f };
   static const dt_aligned_pixel_t upper_bound = {  129.00000f,  129.00000f,  129.00000f,  129.00000f };
-  static const dt_aligned_pixel_t half = { 0.5f, 0.5f, 0.5f, 0.5f };
+  static const dt_aligned_pixel_t v_half = { 0.5f, 0.5f, 0.5f, 0.5f };
   dt_aligned_pixel_t x;
   dt_vector_min(x, input, upper_bound);
   dt_vector_max(x, x, lower_bound);
@@ -527,7 +527,7 @@ static inline void dt_vector_exp2(const dt_aligned_pixel_t input, dt_aligned_pix
   // split the input value into fraction and exponent
   dt_aligned_pixel_t x_adj;
   for_four_channels(c)
-    x_adj[c] = x[c] - half[c];
+    x_adj[c] = x[c] - v_half[c];
   dt_aligned_pixel_t ipart;
   dt_vector_round(x_adj, ipart);
   dt_aligned_pixel_t fpart;

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -25,6 +25,12 @@
 
 #define NORM_MIN 1.52587890625e-05f // norm can't be < to 2^(-16)
 
+// select speed vs accuracy tradeoff
+// supported values for EXP_POLY_DEGREE are 4 and 5
+#define EXP_POLY_DEGREE 4
+// supported vlaues for LOG_POLY_DEGREE are 5 and 6
+#define LOG_POLY_DEGREE 5
+
 // work around missing standard math.h symbols
 /** ln(10) */
 #ifndef M_LN10
@@ -56,7 +62,6 @@
 // clamp value to lie between mn and mx
 // Nan-safe: NaN compares false and will result in mn
 #define CLAMPF(a, mn, mx) ((a) >= (mn) ? ((a) <= (mx) ? (a) : (mx)) : (mn))
-//#define CLAMPF(a, mn, mx) ((a) < (mn) ? (mn) : ((a) > (mx) ? (mx) : (a)))
 
 static inline float clamp_range_f(const float x, const float low, const float high)
 {
@@ -414,32 +419,77 @@ static inline float ceil_fast(const float x)
   }
 }
 
+static inline void dt_vector_min(dt_aligned_pixel_t min,
+                                 const dt_aligned_pixel_t v1,
+                                 const dt_aligned_pixel_t v2)
+{
+#ifdef __SSE__
+  *((__m128*)min) = _mm_min_ps(*((__m128*)v1), *((__m128*)v2));
+#else
+  for_four_channel(c)
+    min[c] = MIN(v1[c], v2[c]);
+#endif
+}
+
+static inline void dt_vector_max(dt_aligned_pixel_t max,
+                                 const dt_aligned_pixel_t v1,
+                                 const dt_aligned_pixel_t v2)
+{
+#ifdef __SSE__
+  *((__m128*)max) = _mm_max_ps(*((__m128*)v1), *((__m128*)v2));
+#else
+  for_four_channel(c)
+    max[c] = MAX(v1[c], v2[c]);
+#endif
+}
+
+static inline void dt_vector_round(const dt_aligned_pixel_t input, dt_aligned_pixel_t rounded)
+{
+  // unfortunately, casting to int truncates toward zero, so we need to use an SSE intrinsic to
+  // make the compiler convert with rounding instead
+#ifdef __SSE2__
+  *((__m128*)rounded) = _mm_cvtepi32_ps(_mm_cvtps_epi32(*((__m128*)input)));
+#else
+  for_four_channels(c)
+    rounded[c] = roundf(input[c]);
+#endif
+}
+
 static inline void dt_vector_log2(const dt_aligned_pixel_t x, dt_aligned_pixel_t res)
 {
-#ifdef __SSE2__
-  *((__m128*)res) = _mm_log2_ps(*((__m128*)x));
+  // split input value into exponent and mantissa
+  union { float f[4]; uint32_t i[4]; } mant, vx = { .f = { x[0], x[1], x[2], x[3] } };
+  dt_aligned_pixel_t exp;
+  for_four_channels(c)
+  {
+    mant.i[c] = (vx.i[c] & 0x007FFFFF) | 0x3F800000;
+    exp[c] = (float)((vx.i[c] & 0x7F800000) >> 23) - 127;
+  }
+  // evaluate polynomial fit of log2(x)/(x-1).  Coefficients chosen for minimax fit in [1, 2[
+  // These coefficients can be generated with
+  // http://www.boost.org/doc/libs/1_36_0/libs/math/doc/sf_and_dist/html/math_toolkit/toolkit/internals2/minimax.html
+  dt_aligned_pixel_t logmant;
+  for_four_channels(c)
+  {
+#if LOG_POLY_DEGREE == 6
+    logmant[c] = ((((((-0.0344359067839062357313f)
+                      * mant.f[c] + 0.318212422185251071475f)
+                     * mant.f[c] - 1.23152682416275988241f)
+                    * mant.f[c] + 2.59883907202499966007f)
+                   * mant.f[c] - 3.32419399085241980044f)
+                  * mant.f[c] + 3.11578814719469302614f);
+#elif LOG_POLY_DEGREE == 5
+    logmant[c] = (((((0.0596515482674574969533f)
+                     * mant.f[c] - 0.465725644288844778798f)
+                    * mant.f[c] + 1.48116647521213171641f)
+                   * mant.f[c] - 2.52074962577807006663f)
+                  * mant.f[c] + 2.8882704548164776201f);
 #else
-  union { float f[4]; uint32_t i[4]; } vx = { .f = { x[0], x[1], x[2], x[3] } };
-  union { uint32_t i[4]; float f[4]; } mx;
-
-#ifdef _OPENMP
-#pragma omp simd aligned(x, res)
+#error Unsupported value for LOG_POLY_DEGREE
 #endif
-  for(size_t c = 0; c < 4; c++)
-  {
-  mx.i[c] = vx.i[c] & 0x007FFFFF;
   }
-#ifdef _OPENMP
-#pragma omp simd aligned(x, res)
-#endif
-  for(size_t c = 0; c < 4; c++)
-  {
-  float y = vx.i[c];
-  float f = mx.f[c];
-  y *= 1.1920928955078125e-7f;
-  res[c] = (y - 124.22551499f - (1.498030302f * f) - 1.72587999f / (0.3520887068f + f));
-  }
-#endif
+  for_four_channels(c)
+    res[c] = (logmant[c] * (mant.f[c] - 1.0f)) + exp[c];
 }
 
 static inline void dt_vector_exp(const dt_aligned_pixel_t x, dt_aligned_pixel_t result)
@@ -460,15 +510,55 @@ static inline void dt_vector_exp(const dt_aligned_pixel_t x, dt_aligned_pixel_t 
   }
 }
 
-static inline void dt_vector_exp2(const dt_aligned_pixel_t x, dt_aligned_pixel_t res)
+static inline void dt_vector_exp2(const dt_aligned_pixel_t input, dt_aligned_pixel_t res)
 {
-#ifdef __SSE2__
-  *((__m128*)res) = _mm_exp2_ps(*((__m128*)x));
+  // plain C implementation of _mm_exp2_ps from sse.h
+  // clamp the exponent to the suported range
+  static const dt_aligned_pixel_t lower_bound = { -126.99999f, -126.99999f, -126.99999f, -126.99999f };
+  static const dt_aligned_pixel_t upper_bound = {  129.00000f,  129.00000f,  129.00000f,  129.00000f };
+  static const dt_aligned_pixel_t half = { 0.5f, 0.5f, 0.5f, 0.5f };
+  dt_aligned_pixel_t x;
+  dt_vector_min(x, input, upper_bound);
+  dt_vector_max(x, x, lower_bound);
+  // split the input value into fraction and exponent
+  dt_aligned_pixel_t x_adj;
+  for_four_channels(c)
+    x_adj[c] = x[c] - half[c];
+  dt_aligned_pixel_t ipart;
+  dt_vector_round(x_adj, ipart);
+  union { uint32_t i[4]; float f[4]; } expipart;
+  dt_aligned_pixel_t fpart;
+  for_four_channels(c)
+  {
+    fpart[c] = x[c] - ipart[c];
+  }
+  // compute the multiplier 2^ipart by directly building the corresponding float value
+  for_four_channels(c)
+  {
+    expipart.i[c] = (127 + (int)ipart[c]) << 23;
+  }
+  // evaluate the nth-degree polynomial (coefficients chosen for minimax fit on [-0.5, 0.5[ )
+  dt_aligned_pixel_t expfpart;
+  for_four_channels(c)
+  {
+#if EXP_POLY_DEGREE == 5
+    expfpart[c] = (((((1.8775767e-3f * fpart[c] + 8.9893397e-3f)
+                      * fpart[c] + 5.5826318e-2f)
+                     * fpart[c] + 2.4015361e-1f)
+                    * fpart[c] + 6.9315308e-1f)
+                   * fpart[c] + 9.99999994e-1f);
+#elif EXP_POLY_DEGREE == 4
+    expfpart[c] = ((((1.3534167e-2f * fpart[c] + 5.2011464e-2f)
+                     * fpart[c] + 2.4144275e-1f)
+                    * fpart[c] + 6.9300383e-1f)
+                   * fpart[c] + 1.0000026f);
 #else
-  //TODO: plain C implementation of _mm_exp2_ps from sse.h
-  for_four_channels(c,aligned(x,res))
-    res[c] = exp2f(x[c]);
+#error Unsupported value for EXP_POLY_DEGREE
 #endif
+  }
+  // scale the result using the integer portion of the original input
+  for_four_channels(c, aligned(res))
+    res[c] = expipart.f[c] * expfpart[c];
 }
 
 static inline void dt_vector_exp10(const dt_aligned_pixel_t x, dt_aligned_pixel_t res)
@@ -484,9 +574,10 @@ static inline void dt_vector_powf(const dt_aligned_pixel_t input,
                                   const dt_aligned_pixel_t power,
                                   dt_aligned_pixel_t output)
 {
+  // x**p == 2^( log2(x) * p)
   dt_aligned_pixel_t log;
   dt_vector_log2(input, log);
-  for_each_channel(c)
+  for_four_channels(c)
     log[c] *= power[c];
   dt_vector_exp2(log, output);
 }
@@ -523,29 +614,6 @@ static inline void dt_vector_div(dt_aligned_pixel_t result,
     result[c] = v1[c] / v2[c];
 }
 
-static inline void dt_vector_min(dt_aligned_pixel_t min,
-                                 const dt_aligned_pixel_t v1,
-                                 const dt_aligned_pixel_t v2)
-{
-#ifdef __SSE__
-  *((__m128*)min) = _mm_min_ps(*((__m128*)v1), *((__m128*)v2));
-#else
-  for_each_channel(c)
-    min[c] = MIN(v1[c], v2[c]);
-#endif
-}
-
-static inline void dt_vector_max(dt_aligned_pixel_t max,
-                                 const dt_aligned_pixel_t v1,
-                                 const dt_aligned_pixel_t v2)
-{
-#ifdef __SSE__
-  *((__m128*)max) = _mm_max_ps(*((__m128*)v1), *((__m128*)v2));
-#else
-  for_each_channel(c)
-    max[c] = MAX(v1[c], v2[c]);
-#endif
-}
 
 static inline float dt_vector_channel_max(const dt_aligned_pixel_t pixel)
 {
@@ -564,7 +632,7 @@ static inline void dt_vector_clip(dt_aligned_pixel_t values)
   static const __m128 one = { 1.0f, 1.0f, 1.0f, 1.0f };
   *((__m128*)values) = _mm_min_ps(_mm_max_ps(*((__m128*)values), zero), one);
 #else
-  for_each_channel(c)
+  for_four_channel(c)
     values[c] = CLIP(values[c]);
 #endif
 }

--- a/src/common/sse.h
+++ b/src/common/sse.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2017-2020 darktable developers.
+    Copyright (C) 2017-2023 darktable developers.
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
@@ -119,11 +119,6 @@ static inline __m128 _mm_log2_ps(__m128 x)
 static inline __m128 _mm_pow_ps(__m128 x, __m128 y)
 {
   return _mm_exp2_ps(_mm_mul_ps(_mm_log2_ps(x), y));
-}
-
-static inline __m128 _mm_pow_ps1(__m128 x, float y)
-{
-  return _mm_exp2_ps(_mm_mul_ps(_mm_log2_ps(x), _mm_set1_ps(y)));
 }
 
 #endif /* __SSE__ */

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -296,6 +296,9 @@ void init_presets(dt_iop_module_so_t *self)
              "gz11eJxjYGBgkGAAgRNODGiAEV0AJ2iwh+CRxQcA5qIZBA==", 8);
 }
 
+static const dt_aligned_pixel_t zero = { 0.0f, 0.0f, 0.0f, 0.0f };
+static const dt_aligned_pixel_t one = { 1.0f, 1.0f, 1.0f, 1.0f };
+
 #ifdef _OPENMP
 #pragma omp declare simd simdlen(4)
 #endif
@@ -315,7 +318,8 @@ static inline void _apply_CDL(dt_aligned_pixel_t x,
 {
   dt_aligned_pixel_t res;
   for_each_channel(c)
-    res[c] = MAX(slope[c] * x[c] + offset[c], 0.0f);
+    res[c] = slope[c] * x[c] + offset[c];
+  dt_vector_max(res, res, zero);	// clip away negatives
   dt_vector_powf(res, power, x);
 }
 
@@ -323,8 +327,9 @@ static inline void _apply_fulcrum_contrast(dt_aligned_pixel_t rgb,
                                            const dt_aligned_pixel_t grey,
                                            const dt_aligned_pixel_t contrast_power)
 {
+  dt_vector_max(rgb, rgb, zero);	// clip away negatives
   for_each_channel(c)
-    rgb[c] = MAX(rgb[c], 0.0f) / grey[c];
+    rgb[c] /= grey[c];
   dt_vector_powf(rgb, contrast_power, rgb);
   for_each_channel(c)
     rgb[c] *= grey[c];
@@ -352,9 +357,9 @@ static void _process_legacy(const dt_aligned_pixel_t in,
     for_each_channel(c)
     {
       // lift gamma gain - apply lift and gain
-      rgb[c] = ((( rgb[c]  - 1.0f) * lift[c]) + 1.0f) * gain[c];
-      rgb[c] = MAX(rgb[c], 0.0f);
+      rgb[c] = ((( rgb[c] - one[c]) * lift[c]) + one[c]) * gain[c];
     }
+    dt_vector_max(rgb, rgb, zero);  // clip away negatives
     // lift gamma gain - apply gamma
     dt_vector_powf(rgb, gamma_inv, rgb);
 
@@ -374,24 +379,16 @@ static void _apply_lgg(dt_aligned_pixel_t rgb,
                        const dt_aligned_pixel_t gamma_inv,
                        const dt_aligned_pixel_t gain)
 {
-  for_each_channel(c)
-  {
-    // clip away negatives
-    rgb[c] = MAX(rgb[c], 0.0f);
-  }
+  dt_vector_max(rgb, rgb, zero);  	// clip away negatives
   // RGB gamma correction
   static const dt_aligned_pixel_t power = { 1.0f/2.2f, 1.0f/2.2f, 1.0f/2.2f, 1.0f/2.2f };
   dt_vector_powf(rgb, power, rgb);
   for_each_channel(c)
   {
     // lift gamma gain - apply lift and gain
-    rgb[c] = ((( rgb[c]  - 1.0f) * lift[c]) + 1.0f) * gain[c];
+    rgb[c] = ((( rgb[c] - one[c]) * lift[c]) + one[c]) * gain[c];
   }
-  for_each_channel(c)
-  {
-    // clip away negatives
-    rgb[c] = MAX(rgb[c], 0.0f);
-  }
+  dt_vector_max(rgb, rgb, zero);	// clip away negatives
   dt_vector_powf(rgb, gamma_inv, rgb);
 }
 
@@ -433,8 +430,8 @@ static void _process_lgg_sse(const dt_aligned_pixel_t in,
   const int run_saturation = fabsf(saturation - 1.0f) > 1e-6;
   const int run_saturation_out = fabsf(saturation_out - 1.0f) > 1e-6;
   const int run_contrast = fabsf(contrast_power[0] - 1.0f) > 1e-6;
-  const __m128 zero = _mm_setzero_ps();
-  const __m128 one = _mm_set1_ps(1.0);
+  const __m128 mm_zero = _mm_setzero_ps();
+  const __m128 mm_one = _mm_set1_ps(1.0);
   const __m128 gamma_inv_RGB = _mm_set1_ps(1.0f/2.2f);
   const __m128 lift = _mm_load_ps(lift_);
   const __m128 gamma_inv = _mm_load_ps(gamma_inv_);
@@ -458,11 +455,11 @@ static void _process_lgg_sse(const dt_aligned_pixel_t in,
     }
 
     // RGB gamma adjustment
-    rgb = _mm_pow_ps(_mm_max_ps(rgb, zero), gamma_inv_RGB);
+    rgb = _mm_pow_ps(_mm_max_ps(rgb, mm_zero), gamma_inv_RGB);
 
     // regular lift gamma gain
-    rgb = ((rgb - one) * lift + one) * gain;
-    rgb = _mm_max_ps(rgb, zero);
+    rgb = ((rgb - mm_one) * lift + mm_one) * gain;
+    rgb = _mm_max_ps(rgb, mm_zero);
     rgb = _mm_pow_ps(rgb, gamma_inv);
 
     // adjust main saturation output
@@ -476,7 +473,7 @@ static void _process_lgg_sse(const dt_aligned_pixel_t in,
     // fulcrum contrast
     if(run_contrast)
     {
-      rgb = _mm_max_ps(rgb, zero);
+      rgb = _mm_max_ps(rgb, mm_zero);
       rgb = _mm_pow_ps(rgb / grey, contrast) * grey;
     }
 
@@ -572,7 +569,7 @@ static void _process_sop_sse(const dt_aligned_pixel_t in,
   const int run_saturation = fabsf(saturation - 1.0f) > 1e-6;
   const int run_saturation_out = fabsf(saturation_out - 1.0f) > 1e-6;
   const int run_contrast = fabsf(contrast_amt - 1.0f) > 1e-6;
-  const __m128 zero = _mm_setzero_ps();
+  const __m128 mm_zero = _mm_setzero_ps();
   const __m128 lift = _mm_load_ps(lift_);
   const __m128 gamma = _mm_load_ps(gamma_);
   const __m128 gain = _mm_load_ps(gain_);
@@ -598,7 +595,7 @@ static void _process_sop_sse(const dt_aligned_pixel_t in,
         rgb = rgb * gain + lift;
 
         //power
-        rgb = _mm_max_ps(rgb, zero);
+        rgb = _mm_max_ps(rgb, mm_zero);
         rgb = _mm_pow_ps(rgb, gamma);
 
         // adjust main saturation output
@@ -612,7 +609,7 @@ static void _process_sop_sse(const dt_aligned_pixel_t in,
         // fulcrum contrast
         if(run_contrast)
         {
-          rgb = _mm_max_ps(rgb, zero);
+          rgb = _mm_max_ps(rgb, mm_zero);
           rgb = _mm_pow_ps(rgb / grey, contrast) * grey;
         }
 
@@ -637,7 +634,7 @@ static void _process_sop(const dt_aligned_pixel_t in,
                          const float contrast,
                          const dt_aligned_pixel_t contrast_power)
 {
-#ifdef __SSE2__ 
+#ifdef __SSE2__
   if(darktable.codepath.SSE2)
   {
     _process_sop_sse(in, out, npixels, lift, gamma, gain, grey, saturation,


### PR DESCRIPTION
This PR has been sitting around for a month because I hadn't gotten it to run faster for all modules (preliminary testing had modules making heavy use of `dt_vector_powf` running between 2% faster and 3% slower).  The cases where it runs faster would be due to the compiler being able to use FMA instructions unlike the SSE intrinsics code, while I suspect that the cases where it runs slower are due to GCC10 spilling to RAM instead of keeping values in vector registers.  I believe GCC12 is much less prone to that.

Systems with auto-vectorization but without SSE (e.g. amd64) should see a nice speedup since dt_vector_powf will now actually compute the values in parallel.

All integration tests produce output identical to master.
