### PR TITLE
maintenance: use sqr()/sqrt() instead of pow() where possible

### DIFF
--- a/src/common/rgb_norms.h
+++ b/src/common/rgb_norms.h
@@ -1,6 +1,6 @@
 /*
  *    This file is part of darktable,
- *    Copyright (C) 2019-2020 darktable developers.
+ *    Copyright (C) 2019-2023 darktable developers.
  *
  *    darktable is free software: you can redistribute it and/or modify
  *    it under the terms of the GNU General Public License as published by
@@ -56,7 +56,7 @@ static inline float dt_rgb_norm(const float *in, const int norm, const dt_iop_or
   }
   else if (norm == DT_RGB_NORM_NORM)
   {
-    return powf(in[0] * in[0] + in[1] * in[1] + in[2] * in[2], 0.5f);
+    return sqrtf(in[0] * in[0] + in[1] * in[1] + in[2] * in[2]);
   }
   else if (norm == DT_RGB_NORM_POWER)
   {

--- a/src/iop/hlreconstruct/segbased.c
+++ b/src/iop/hlreconstruct/segbased.c
@@ -109,7 +109,7 @@ static inline float _local_std_deviation(const float *p, const int w)
 
 static float _calc_weight(const float *s, const size_t loc, const int w, const float clipval)
 {
-  const float smoothness = fmaxf(0.0f, 1.0f - 10.0f * powf(_local_std_deviation(&s[loc], w), 0.5f));
+  const float smoothness = fmaxf(0.0f, 1.0f - 10.0f * sqrtf(_local_std_deviation(&s[loc], w)));
   float val = 0.0f;
   for(int y = -1; y < 2; y++)
   {

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -247,12 +247,14 @@ void init_presets(dt_iop_module_so_t *self)
   for(int k = 0; k < 7; k++) p.curve_nodes[DT_IOP_RGBCURVE_R][k].y = linear_L[k];
 
   // Gamma 2.0 - no contrast
-  for(int k = 1; k < 6; k++) p.curve_nodes[DT_IOP_RGBCURVE_R][k].y = powf(linear_L[k], 2.0f);
+  for(int k = 1; k < 6; k++)
+    p.curve_nodes[DT_IOP_RGBCURVE_R][k].y = (linear_L[k] * linear_L[k]);
   dt_gui_presets_add_generic(_("gamma 2.0"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_DISPLAY);
 
   // Gamma 0.5 - no contrast
-  for(int k = 1; k < 6; k++) p.curve_nodes[DT_IOP_RGBCURVE_R][k].y = powf(linear_L[k], 0.5f);
+  for(int k = 1; k < 6; k++)
+    p.curve_nodes[DT_IOP_RGBCURVE_R][k].y = sqrtf(linear_L[k]);
   dt_gui_presets_add_generic(_("gamma 0.5"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_DISPLAY);
 

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -598,12 +598,14 @@ void init_presets(dt_iop_module_so_t *self)
   for(int k = 0; k < 7; k++) p.tonecurve[ch_L][k].y = linear_L[k];
 
   // Gamma 2.0 - no contrast
-  for(int k = 1; k < 6; k++) p.tonecurve[ch_L][k].y = powf(linear_L[k], 2.0f);
+  for(int k = 1; k < 6; k++)
+    p.tonecurve[ch_L][k].y = linear_L[k] * linear_L[k];
   dt_gui_presets_add_generic(_("gamma 2.0"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_DISPLAY);
 
   // Gamma 0.5 - no contrast
-  for(int k = 1; k < 6; k++) p.tonecurve[ch_L][k].y = powf(linear_L[k], 0.5f);
+  for(int k = 1; k < 6; k++)
+    p.tonecurve[ch_L][k].y = sqrtf(linear_L[k]);
   dt_gui_presets_add_generic(_("gamma 0.5"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_DISPLAY);
 


### PR DESCRIPTION
A simple multiplication is *way* faster than pow(x,2), and sqrt is faster than pow(x,0.5).
