### PR TITLE
Pipe maintenance and cache fixes (4)

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -167,6 +167,7 @@ typedef int32_t dt_imgid_t;
 typedef int32_t dt_mask_id_t;
 #define INVALID_MASKID (-1)
 #define NO_MASKID (0)
+#define BLEND_RASTER_ID (0)
 // testing for a valid form
 #define dt_is_valid_maskid(n) ((n) > NO_MASKID)
 

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -1175,7 +1175,7 @@ static void dt_interpolation_resample_plain(const struct dt_interpolation *itor,
   int r;
 
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
-                "resample_plain", NULL, itor->name, roi_in, roi_out, "\n");
+                "resample_plain", NULL, NULL, roi_in, roi_out, "%s\n",itor->name);
   dt_times_t start = { 0 }, mid = { 0 };
   dt_get_perf_times(&start);
 
@@ -1420,7 +1420,7 @@ int dt_interpolation_resample_cl(const struct dt_interpolation *itor,
   cl_mem dev_vmeta = NULL;
 
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
-                "resample_cl", NULL, itor->name, roi_in, roi_out, "\n");
+                "resample_cl", NULL, NULL, roi_in, roi_out, "%s\n", itor->name);
   dt_times_t start = { 0 }, mid = { 0 };
   dt_get_perf_times(&start);
 
@@ -1632,7 +1632,7 @@ static void dt_interpolation_resample_1c_plain(const struct dt_interpolation *it
   int r;
 
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
-                "resample_1c_plain", NULL, itor->name, roi_in, roi_out, "\n");
+                "resample_1c_plain", NULL, NULL, roi_in, roi_out, "%s\n", itor->name);
   dt_times_t start = { 0 }, mid = { 0 };
   dt_get_perf_times(&start);
 

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1104,7 +1104,7 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
   {
     // downsample
     dt_print_pipe(DT_DEBUG_PIPE,
-                  "mipmap clip and zoom", NULL, "", &roi_in, &roi_out, "\n");
+                  "mipmap clip and zoom", NULL, NULL, &roi_in, &roi_out, "\n");
     dt_iop_clip_and_zoom(out, (const float *)buf.buf, &roi_out, &roi_in, roi_out.width, roi_in.width);
   }
 

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -59,7 +59,7 @@ static dt_develop_blend_params_t _default_blendop_params
           0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f,
           0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f },
         { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f },
-        { 0 }, 0, 0, FALSE };
+        { 0 }, 0, INVALID_MASKID, FALSE };
 
 static inline dt_develop_blend_colorspace_t
 _blend_default_module_blend_colorspace(dt_iop_module_t *module,
@@ -730,14 +730,14 @@ void dt_develop_blend_process(struct dt_iop_module_t *self,
 
   // check if we should store the mask for export or use in subsequent modules
   // TODO: should we skip raster masks?
-  if(piece->pipe->store_all_raster_masks || dt_iop_is_raster_mask_used(self, NO_MASKID))
+  if(piece->pipe->store_all_raster_masks || dt_iop_is_raster_mask_used(self, BLEND_RASTER_ID))
   {
-    g_hash_table_replace(piece->raster_masks, GINT_TO_POINTER(NO_MASKID), _mask);
+    g_hash_table_replace(piece->raster_masks, GINT_TO_POINTER(BLEND_RASTER_ID), _mask);
     dt_dev_pixelpipe_cache_invalidate_later(piece->pipe, self);
   }
   else
   {
-    g_hash_table_remove(piece->raster_masks, GINT_TO_POINTER(NO_MASKID));
+    g_hash_table_remove(piece->raster_masks, GINT_TO_POINTER(BLEND_RASTER_ID));
     dt_free_align(_mask);
   }
 }
@@ -1384,7 +1384,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self,
 
   // check if we should store the mask for export or use in subsequent modules
   // TODO: should we skip raster masks?
-  if(piece->pipe->store_all_raster_masks || dt_iop_is_raster_mask_used(self, NO_MASKID))
+  if(piece->pipe->store_all_raster_masks || dt_iop_is_raster_mask_used(self, BLEND_RASTER_ID))
   {
     //  get back final mask from the device to store it for later use
     if(!(mask_mode & DEVELOP_MASK_RASTER))
@@ -1393,12 +1393,12 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self,
                                           owidth, oheight, sizeof(float));
       if(err != CL_SUCCESS) goto error;
     }
-    g_hash_table_replace(piece->raster_masks, GINT_TO_POINTER(NO_MASKID), _mask);
+    g_hash_table_replace(piece->raster_masks, GINT_TO_POINTER(BLEND_RASTER_ID), _mask);
     dt_dev_pixelpipe_cache_invalidate_later(piece->pipe, self);
   }
   else
   {
-    g_hash_table_remove(piece->raster_masks, GINT_TO_POINTER(NO_MASKID));
+    g_hash_table_remove(piece->raster_masks, GINT_TO_POINTER(BLEND_RASTER_ID));
     dt_free_align(_mask);
   }
 

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2866,7 +2866,7 @@ static void _raster_value_changed_callback(GtkWidget *widget,
 
   if(entry->module)
   {
-    reprocess = dt_iop_is_raster_mask_used(entry->module, 0) == FALSE;
+    reprocess = dt_iop_is_raster_mask_used(entry->module, BLEND_RASTER_ID) == FALSE;
     g_hash_table_add(entry->module->raster_mask.source.users, module);
 
     // update blend_params!
@@ -2880,7 +2880,7 @@ static void _raster_value_changed_callback(GtkWidget *widget,
     memset(module->blend_params->raster_mask_source, 0,
            sizeof(module->blend_params->raster_mask_source));
     module->blend_params->raster_mask_instance = 0;
-    module->blend_params->raster_mask_id = NO_MASKID;
+    module->blend_params->raster_mask_id = INVALID_MASKID;
   }
 
   dt_dev_add_history_item(module->dev, module, TRUE);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -391,7 +391,6 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module,
   module->multi_priority = 0;
   module->multi_name_hand_edited = FALSE;
   module->iop_order = 0;
-  module->cache_next_important = FALSE;
   for(int k = 0; k < 3; k++)
   {
     module->picked_color[k] = module->picked_output_color[k] = 0.0f;

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -413,7 +413,8 @@ void dt_iop_commit_params(dt_iop_module_t *module,
                           struct dt_develop_blend_params_t *blendop_params,
                           struct dt_dev_pixelpipe_t *pipe,
                           struct dt_dev_pixelpipe_iop_t *piece);
-void dt_iop_commit_blend_params(dt_iop_module_t *module,
+
+dt_iop_module_t *dt_iop_commit_blend_params(dt_iop_module_t *module,
                                 const struct dt_develop_blend_params_t *blendop_params);
 /** make sure the raster mask is advertised if available */
 void dt_iop_set_mask_mode(dt_iop_module_t *module, int mask_mode);

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -132,9 +132,8 @@ typedef enum dt_iop_flags_t
   IOP_FLAGS_ALLOW_FAST_PIPE = 1 << 12,   // Module can work with a fast pipe
   IOP_FLAGS_UNSAFE_COPY = 1 << 13,       // Unsafe to copy as part of history
   IOP_FLAGS_GUIDES_SPECIAL_DRAW = 1 << 14, // handle the grid drawing directly
-  IOP_FLAGS_GUIDES_WIDGET = 1 << 15,       // require the guides widget
-  IOP_FLAGS_CACHE_IMPORTANT_NOW = 1 << 16, // hints for higher priority in iop cache
-  IOP_FLAGS_CACHE_IMPORTANT_NEXT = 1 << 17
+  IOP_FLAGS_GUIDES_WIDGET = 1 << 15,     // require the guides widget
+  IOP_FLAGS_CACHE_IMPORTANT = 1 << 16    // hints for higher priority in iop cache
 } dt_iop_flags_t;
 
 /** status of a module*/
@@ -335,8 +334,6 @@ typedef struct dt_iop_module_t
                         void *const o,
                         const struct dt_iop_roi_t *const roi_in,
                         const struct dt_iop_roi_t *const roi_out);
-  // hint for higher io cache priority
-  gboolean cache_next_important;
   // introspection related data
   gboolean have_introspection;
 } dt_iop_module_t;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -107,7 +107,7 @@ const char *dt_dev_pixelpipe_type_to_str(const int pipe_type)
 void dt_print_pipe(dt_debug_thread_t thread,
                    const char *title,
                    dt_dev_pixelpipe_t *pipe,
-                   const char *mod,
+                   struct dt_iop_module_t *module,
                    const dt_iop_roi_t *roi_in,
                    const dt_iop_roi_t *roi_out,
                    const char *msg, ...)
@@ -117,25 +117,31 @@ void dt_print_pipe(dt_debug_thread_t thread,
     if(((darktable.unmuted & thread) & ~DT_DEBUG_VERBOSE) == 0) return;
     if((thread & DT_DEBUG_VERBOSE) && !(darktable.unmuted & DT_DEBUG_VERBOSE)) return;
   }
+  if(pipe
+      && !(thread & DT_DEBUG_VERBOSE)
+      && (pipe->type & (DT_DEV_PIXELPIPE_PREVIEW | DT_DEV_PIXELPIPE_PREVIEW)) )
+    return;
+
   char buf[3][128];
-  char vbuf[2048] = { 0 };
-  char roi[512] = { 0 };
-  char roo[512] = { 0 };
+  char vbuf[1024] = { 0 };
+  char roi[128] = { 0 };
+  char roo[128] = { 0 };
   char name[128] = { 0 };
   char masking[64] = { 0 };
 
   snprintf(buf[0], sizeof(buf[0]), "%.4f", dt_get_wtime() - darktable.start_wtime);
   snprintf(buf[1], sizeof(buf[1]), "[%s]", title);
-  snprintf(buf[2], sizeof(buf[2]), "%s", mod);
+  snprintf(buf[2], sizeof(buf[2]), "%s%s",
+    module ? module->name() : "",
+    module ? dt_iop_get_instance_name(module) : "");
   if(roi_in)
     snprintf(roi, sizeof(roi),
-             "(%4i/%4i) %4ix%4i scale=%.4f%s",
-             roi_in->x, roi_in->y, roi_in->width, roi_in->height, roi_in->scale,
-             roi_in && roi_out ? " -> " : "");
+             "(%4i/%4i) %4ix%4i scale=%.4f",
+             roi_in->x, roi_in->y, roi_in->width, roi_in->height, roi_in->scale);
   if(roi_out)
   {
     snprintf(roo, sizeof(roo),
-             "(%4i/%4i) %4ix%4i scale=%.4f",
+             " --> (%4i/%4i) %4ix%4i scale=%.4f",
              roi_out->x, roi_out->y, roi_out->width, roi_out->height, roi_out->scale);
   }
 
@@ -153,7 +159,7 @@ void dt_print_pipe(dt_debug_thread_t thread,
   vsnprintf(vbuf, sizeof(vbuf), msg, ap);
   va_end(ap);
 
-  printf("%11s %-28s %-14s %-20s %s%s%s %s",
+  printf("%11s %-28s %-14s %-24s %s%s%s %s",
          buf[0], buf[1], name, buf[2], roi, roo, masking, vbuf);
   fflush(stdout);
 }
@@ -507,11 +513,18 @@ void dt_dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe,
                " of image.\nlikely introduced by applying a preset, style or"
                " history copy&paste"),
              NULL);
-        dt_print(DT_DEBUG_PARAMS,
-                 "[pixelpipe_synch] [%s] enabling mismatch for module `%s' in image %i\n",
-          dt_dev_pixelpipe_type_to_str(pipe->type), piece->module->op, imgid);
+
+        dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe synch problem",
+          pipe, piece->module, NULL, NULL,
+          "piece enabling mismatch for image %i, piece hash%22" PRIu64 ", \n",
+          imgid, piece->hash); 
       }
+
       dt_iop_commit_params(hist->module, hist->params, hist->blend_params, pipe, piece);
+
+      dt_print_pipe(DT_DEBUG_PIPE, "committed params",
+          pipe, piece->module, NULL, NULL,
+          "piece hash%22" PRIu64 ", \n", piece->hash); 
 
       if(piece->blendop_data)
       {
@@ -1165,7 +1178,7 @@ static gboolean _pixelpipe_process_on_CPU(
 
       dt_print_pipe(DT_DEBUG_PIPE,
                     "transform colorspace CPU",
-                    piece->pipe, module->so->op, roi_in, roi_out, profiles);
+                    piece->pipe, module, roi_in, roi_out, profiles);
 
     }
   }
@@ -1205,7 +1218,7 @@ static gboolean _pixelpipe_process_on_CPU(
   if(!fitting && piece->process_tiling_ready)
   {
     dt_print_pipe(DT_DEBUG_PIPE,
-                  "process TILE", piece->pipe, module->so->op, roi_in, roi_out, "\n");
+                  "process TILE", piece->pipe, module, roi_in, roi_out, "\n");
     module->process_tiling(module, piece, input, *output, roi_in, roi_out, in_bpp);
 
     *pixelpipe_flow |= (PIXELPIPE_FLOW_PROCESSED_ON_CPU
@@ -1216,10 +1229,11 @@ static gboolean _pixelpipe_process_on_CPU(
   {
     dt_print_pipe(DT_DEBUG_PIPE,
        "pixelpipe_process_on_CPU",
-       piece->pipe, module->so->op, roi_in, roi_out,
-       (fitting)
-       ? "\n"
-       : "Warning: processed without tiling even if memory requirements are not met\n");
+       piece->pipe, module, roi_in, roi_out, "piece hash%22" PRIu64 ", %s\n",
+       piece->hash,
+       (fitting) ? ""
+                 : "processed without tiling even if memory requirements are not met"
+       );
 
     // this code section is for simplistic benchmarking via --bench-module
     if((piece->pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_EXPORT))
@@ -1436,8 +1450,7 @@ static gboolean _dev_pixelpipe_process_rec(
       return TRUE;
 
     dt_print_pipe(DT_DEBUG_PIPE,
-                  "pixelpipe data: from cache", pipe, module ? module->so->op : "",
-                  &roi_in, roi_out, "\n");
+                  "pixelpipe data: from cache", pipe, module, &roi_in, roi_out, "\n");
     // we're done! as colorpicker/scopes only work on gamma iop
     // input -- which is unavailable via cache -- there's no need to
     // run these
@@ -1470,8 +1483,7 @@ static gboolean _dev_pixelpipe_process_rec(
     {
       *output = pipe->input;
       dt_print_pipe(DT_DEBUG_PIPE,
-                    "pixelpipe data: full", pipe, module ? module->so->op : "",
-                    &roi_in, roi_out, "\n");
+                    "pixelpipe data: full", pipe, module, &roi_in, roi_out, "\n");
     }
     else if(dt_dev_pixelpipe_cache_get(pipe, basichash, hash, bufsize,
                                        output, out_format, NULL, FALSE))
@@ -1487,8 +1499,7 @@ static gboolean _dev_pixelpipe_process_rec(
         const int cp_height = MIN(roi_out->height, pipe->iheight - in_y);
         dt_print_pipe(DT_DEBUG_PIPE,
           (cp_width > 0) ? "pixelpipe data: 1:1 copied" : "pixelpipe data: 1:1 none",
-          pipe, module ? module->so->op : "",
-          &roi_in, roi_out, "bpp=%d\n", bpp);
+          pipe, module, &roi_in, roi_out, "bpp=%d\n", bpp);
         if(cp_width > 0)
         {
 #ifdef _OPENMP
@@ -1511,8 +1522,7 @@ static gboolean _dev_pixelpipe_process_rec(
         roi_in.height = pipe->iheight;
         roi_in.scale = 1.0f;
         dt_print_pipe(DT_DEBUG_PIPE,
-          "pixelpipe data: clip&zoom", pipe, module ? module->so->op : "",
-          &roi_in, roi_out, "\n");
+          "pixelpipe data: clip&zoom", pipe, module, &roi_in, roi_out, "\n");
         dt_iop_clip_and_zoom(*output, pipe->input, roi_out, &roi_in,
                              roi_out->width, pipe->iwidth);
       }
@@ -1536,8 +1546,7 @@ static gboolean _dev_pixelpipe_process_rec(
   module->modify_roi_in(module, piece, roi_out, &roi_in);
   if((darktable.unmuted & DT_DEBUG_PIPE) && memcmp(roi_out, &roi_in, sizeof(dt_iop_roi_t)))
     dt_print_pipe(DT_DEBUG_PIPE,
-                  "modify roi IN", piece->pipe, module ? module->so->op : "",
-                  &roi_in, roi_out, "\n");
+                  "modify roi IN", piece->pipe, module, &roi_in, roi_out, "\n");
   // recurse to get actual data of input buffer
 
   dt_iop_buffer_dsc_t _input_format = { 0 };
@@ -1607,8 +1616,7 @@ static gboolean _dev_pixelpipe_process_rec(
      && !memcmp(&roi_in, roi_out, sizeof(struct dt_iop_roi_t)))
   {
     dt_print_pipe(DT_DEBUG_PIPE,
-                    "pixelpipe bypass", pipe, module ? module->so->op : "",
-                    &roi_in, roi_out, "\n");
+                    "pixelpipe bypass", pipe, module, &roi_in, roi_out, "\n");
     // since we're not actually running the module, the output format
     // is the same as the input format
     **out_format = pipe->dsc = piece->dsc_out = piece->dsc_in;
@@ -1816,8 +1824,7 @@ static gboolean _dev_pixelpipe_process_rec(
                 dt_iop_colorspace_to_name(cst_from), dt_iop_colorspace_to_name(cst_to));
 
               dt_print_pipe(DT_DEBUG_PIPE,
-                            "transform colorspace CL", piece->pipe, module->so->op,
-                            &roi_in, roi_out, profiles);
+                            "transform colorspace CL", piece->pipe, module, &roi_in, roi_out, profiles);
             }
           }
 
@@ -1873,7 +1880,8 @@ static gboolean _dev_pixelpipe_process_rec(
         {
           dt_print_pipe(DT_DEBUG_PIPE,
                         "pixelpipe_process_CL",
-                        piece->pipe, module->so->op, &roi_in, roi_out, "\n");
+                        piece->pipe, module, &roi_in, roi_out,
+                        "piece hash%22" PRIu64 ", \n", piece->hash);
 
           // this code section is for simplistic benchmarking via --bench-module
           if((piece->pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_EXPORT))
@@ -2384,7 +2392,7 @@ static gboolean _dev_pixelpipe_process_rec(
      && (module->request_histogram & DT_REQUEST_EXPANDED);
 
   if(needs_histo)
-    dt_print_pipe(DT_DEBUG_PIPE, "internal histogram", pipe, module->so->op, NULL, NULL, "\n");
+    dt_print_pipe(DT_DEBUG_PIPE, "internal histogram", pipe, module, NULL, NULL, "\n");
 
   if((pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_NONE) && !needs_histo)
   {
@@ -2703,7 +2711,7 @@ restart:
 
   dt_print_pipe(DT_DEBUG_PIPE,
     (pipe->devid >= 0) ? "pixelpipe starting CL" : "pixelpipe starting on CPU",
-    pipe, "", &roi, &roi, "\n");
+    pipe, NULL, &roi, &roi, "\n");
 
   // run pixelpipe recursively and get error status
   const gboolean err = _dev_pixelpipe_process_rec_and_backcopy(pipe, dev, &buf,
@@ -2751,7 +2759,7 @@ restart:
     dt_dev_pixelpipe_change(pipe, dev);
 
     dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_OPENCL,
-      "pixelpipe restarting on CPU", pipe, "", &roi, &roi, "\n");
+      "pixelpipe restarting on CPU", pipe, NULL, &roi, &roi, "\n");
 
     goto restart; // try again (this time without opencl)
   }
@@ -2805,7 +2813,7 @@ restart:
 
   dt_dev_pixelpipe_cache_report(pipe);
 
-  dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe finished", pipe, "", &roi, &roi, "\n");
+  dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe finished", pipe, NULL, &roi, &roi, "\n\n");
 
   pipe->processing = FALSE;
   return FALSE;
@@ -2836,11 +2844,6 @@ void dt_dev_pixelpipe_get_dimensions(dt_dev_pixelpipe_t *pipe,
             && dev->gui_module->operation_tags_filter() & module->operation_tags()))
     {
       module->modify_roi_out(module, piece, &roi_out, &roi_in);
-      if((darktable.unmuted & DT_DEBUG_PIPE)
-         && memcmp(&roi_out, &roi_in, sizeof(dt_iop_roi_t)))
-        dt_print_pipe(DT_DEBUG_PIPE,
-                      "check pipe dimension",
-                      piece->pipe, module->so->op, &roi_in, &roi_out, "\n");
     }
     else
     {
@@ -2873,7 +2876,7 @@ void dt_dev_pixelpipe_get_dimensions(dt_dev_pixelpipe_t *pipe,
 float *dt_dev_get_raster_mask(const struct dt_dev_pixelpipe_iop_t *piece,
                               const dt_iop_module_t *raster_mask_source,
                               const dt_mask_id_t raster_mask_id,
-                              const dt_iop_module_t *target_module,
+                              dt_iop_module_t *target_module,
                               gboolean *free_mask)
 {
   if(!raster_mask_source)
@@ -2897,9 +2900,9 @@ float *dt_dev_get_raster_mask(const struct dt_dev_pixelpipe_iop_t *piece,
          target_module->name(), raster_mask_source->name());
 
       dt_print(DT_DEBUG_ALWAYS,
-               "module `%s' can't get raster mask from module `%s'"
+               "module `%s' can't get raster mask id=%i from module `%s'"
                " as that is processed later in the pixel pipe\n",
-               target_module->so->op, raster_mask_source->so->op);
+               target_module->name(), raster_mask_id, raster_mask_source->name());
       return NULL;
     }
 
@@ -2913,14 +2916,31 @@ float *dt_dev_get_raster_mask(const struct dt_dev_pixelpipe_iop_t *piece,
     const dt_dev_pixelpipe_iop_t *source_piece =
       (dt_dev_pixelpipe_iop_t *)source_iter->data;
 
-    if(source_piece
-       && source_piece->enabled) // there might be stale masks from
-                                 // disabled modules left over. don't
-                                 // use those!
+    const gboolean source_enabled = source_piece && source_piece->enabled;
+/* there might be stale masks from disabled modules left over.
+   don't use those!
+*/
+    if(!source_enabled)
+    {
+      dt_print_pipe(DT_DEBUG_PIPE,
+         "no raster used", piece->pipe, piece->module, NULL, NULL,
+         "source module `%s%s' is disabled\n",
+         raster_mask_source->name(), dt_iop_get_instance_name(raster_mask_source));
+      return NULL;
+    }
+    else
     {
       raster_mask = g_hash_table_lookup(source_piece->raster_masks,
                                         GINT_TO_POINTER(raster_mask_id));
-      if(raster_mask)
+      if(!raster_mask)
+      {
+        dt_print_pipe(DT_DEBUG_PIPE,
+          "no raster mask found", piece->pipe, piece->module, NULL, NULL,
+          "raster mask seems to be lost in module `%s%s'\n",
+          raster_mask_source->name(), dt_iop_get_instance_name(raster_mask_source));
+        return NULL;
+      }
+      else
       {
         for(GList *iter = g_list_next(source_iter); iter; iter = g_list_next(iter))
         {
@@ -2961,8 +2981,8 @@ float *dt_dev_get_raster_mask(const struct dt_dev_pixelpipe_iop_t *piece,
               else
               {
                 dt_print_pipe(DT_DEBUG_ALWAYS,
-                      "distort raster mask",
-                      piece->pipe, module->module->op,
+                      "no distort raster mask",
+                      piece->pipe, module->module,
                       &module->processed_roi_in, &module->processed_roi_out,
                       "skipped transforming mask due to lack of memory\n");
                 return NULL;
@@ -2976,9 +2996,9 @@ float *dt_dev_get_raster_mask(const struct dt_dev_pixelpipe_iop_t *piece,
             {
               dt_print_pipe(DT_DEBUG_ALWAYS,
                       "distort raster mask",
-                      piece->pipe, module->module->op,
+                      piece->pipe, module->module,
                       &module->processed_roi_in, &module->processed_roi_out,
-                      "misses distort_mask()\n");
+                      "misses distort_mask() function\n");
               return NULL;
             }
           }
@@ -2989,6 +3009,12 @@ float *dt_dev_get_raster_mask(const struct dt_dev_pixelpipe_iop_t *piece,
       }
     }
   }
+
+  dt_print_pipe(DT_DEBUG_PIPE,
+      "got raster mask", piece->pipe, target_module, NULL, NULL,
+      "from module `%s%s' %s\n",
+      raster_mask_source->name(), dt_iop_get_instance_name(raster_mask_source),
+      *free_mask ? "distorted" : "");
 
   return raster_mask;
 }
@@ -3024,7 +3050,7 @@ gboolean dt_dev_write_rawdetail_mask(dt_dev_pixelpipe_iop_t *piece,
                                   wboff ? 1.0f : p->dsc.temperature.coeffs[2]};
   dt_masks_calc_rawdetail_mask(rgb, mask, tmp, width, height, wb);
   dt_free_align(tmp);
-  dt_print_pipe(DT_DEBUG_PIPE, "write detail mask on CPU", p, "", roi_in, NULL, "\n");
+  dt_print_pipe(DT_DEBUG_PIPE, "write detail mask on CPU", p, NULL, roi_in, NULL, "\n");
   return FALSE;
 
   error:
@@ -3092,7 +3118,7 @@ gboolean dt_dev_write_rawdetail_mask_cl(dt_dev_pixelpipe_iop_t *piece,
 
   dt_opencl_release_mem_object(out);
   dt_opencl_release_mem_object(tmp);
-  dt_print_pipe(DT_DEBUG_PIPE, "write detail mask on GPU", p, "", roi_in, NULL, "\n");
+  dt_print_pipe(DT_DEBUG_PIPE, "write detail mask on GPU", p, NULL, roi_in, NULL, "\n");
   return FALSE;
 
   error:
@@ -3182,7 +3208,7 @@ float *dt_dev_distort_detail_mask(dt_dev_pixelpipe_t *pipe,
                     || module->processed_roi_in.y != module->processed_roi_out.y))
               dt_print_pipe(DT_DEBUG_ALWAYS,
                       "distort raster mask",
-                      pipe, module->module->op,
+                      pipe, module->module,
                       &module->processed_roi_in, &module->processed_roi_out,
                       "misses distort_mask()\n");
 

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2381,20 +2381,8 @@ static gboolean _dev_pixelpipe_process_rec(
      && (module->request_histogram & DT_REQUEST_EXPANDED);
 
   if(needs_histo)
+  {
     dt_print_pipe(DT_DEBUG_PIPE, "internal histogram", pipe, module, NULL, NULL, "\n");
-
-  if((pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_NONE) && !needs_histo)
-  {
-    if(module && module == darktable.develop->gui_module)
-    {
-      // give the input buffer to the currently focused plugin more weight.
-      // the user is likely to change that one soon, so keep it in cache.
-      dt_dev_pixelpipe_important_cacheline(pipe, input, roi_in.width * roi_in.height * in_bpp);
-    }
-  }
-
-  if(needs_histo)
-  {
     pipe->nocache = TRUE;
     dt_dev_pixelpipe_invalidate_cacheline(pipe, *output, FALSE);
   }

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -92,7 +92,7 @@ typedef struct dt_dev_pixelpipe_t
 {
   // store history/zoom caches
   dt_dev_pixelpipe_cache_t cache;
-  // set to non-zero in order to obsolete old cache entries on next pixelpipe run
+  // set to TRUE in order to obsolete old cache entries on next pixelpipe run
   gboolean cache_obsolete;
   // input buffer
   float *input;
@@ -280,7 +280,7 @@ void dt_dev_pixelpipe_disable_before(dt_dev_pixelpipe_t *pipe, const char *op);
 float *dt_dev_get_raster_mask(const struct dt_dev_pixelpipe_iop_t *piece,
                               const struct dt_iop_module_t *raster_mask_source,
                               const dt_mask_id_t raster_mask_id,
-                              const struct dt_iop_module_t *target_module,
+                              struct dt_iop_module_t *target_module,
                               gboolean *free_mask);
 // some helper functions related to the details mask interface
 void dt_dev_clear_rawdetail_mask(dt_dev_pixelpipe_t *pipe);
@@ -300,7 +300,7 @@ gboolean dt_dev_write_rawdetail_mask_cl(dt_dev_pixelpipe_iop_t *piece,
 void dt_print_pipe(dt_debug_thread_t thread,
                    const char *title,
                    dt_dev_pixelpipe_t *pipe,
-                   const char *mod,
+                   struct dt_iop_module_t *mod,
                    const dt_iop_roi_t *roi_in,
                    const dt_iop_roi_t *roi_out,
                    const char *msg, ...);

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -138,8 +138,6 @@ typedef struct dt_dev_pixelpipe_t
   int detail_height;
   gboolean want_detail_mask;
 
-  // we have to keep track of the next processing module to use an iop cacheline with high priority
-  gboolean next_important_module;
   // avoid cached data for processed module
   gboolean nocache;
 

--- a/src/imageio/format/exr.cc
+++ b/src/imageio/format/exr.cc
@@ -310,15 +310,11 @@ icc_end:
 
         header.channels().insert(layername, Imf::Channel(pixel_type, 1, 1, true));
 
-        gboolean free_mask = TRUE;
+        gboolean free_mask;
         float *raster_mask = dt_dev_get_raster_mask(piece, piece->module, GPOINTER_TO_INT(key), NULL, &free_mask);
 
         if(!raster_mask)
-        {
-          // this should never happen
-          dt_print(DT_DEBUG_ALWAYS, "[exr export] error: can't get raster mask from `%s'\n", piece->module->name());
           return 1;
-        }
 
         if(pixel_type == Imf::PixelType::FLOAT)
         {

--- a/src/imageio/format/xcf.c
+++ b/src/imageio/format/xcf.c
@@ -171,15 +171,11 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
       g_hash_table_iter_init(&rm_iter, piece->raster_masks);
       while(g_hash_table_iter_next(&rm_iter, &key, &value))
       {
-        gboolean free_mask = TRUE;
+        gboolean free_mask;
         float *raster_mask = dt_dev_get_raster_mask(piece, piece->module, GPOINTER_TO_INT(key), NULL, &free_mask);
 
         if(!raster_mask)
-        {
-          // this should never happen
-          dt_print(DT_DEBUG_ALWAYS, "error: can't get raster mask from `%s'\n", piece->module->name());
-          goto exit;
-        }
+           goto exit;
 
         xcf_add_channel(xcf);
         xcf_set(xcf, XCF_PROP, XCF_PROP_VISIBLE, 0);

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -190,7 +190,7 @@ const char **description(struct dt_iop_module_t *self)
 
 int flags()
 {
-  return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING;
+  return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_CACHE_IMPORTANT;
 }
 
 int default_group()
@@ -555,8 +555,6 @@ void process(struct dt_iop_module_t *self,
   const struct dt_iop_order_iccprofile_info_t *const work_profile
       = dt_ioppr_get_pipe_current_profile_info(self, piece->pipe);
   if(work_profile == NULL) return; // no point
-
-  self->cache_next_important = TRUE; // The cpu code is pretty heavy stuff so an importance hint
 
   // work profile can't be fetched in commit_params since it is not yet initialised
   // work_profile->matrix_in === RGB_to_XYZ

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -144,7 +144,7 @@ int default_group()
 
 int flags()
 {
-  return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_ONE_INSTANCE | IOP_FLAGS_CACHE_IMPORTANT_NEXT;
+  return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_ONE_INSTANCE;
 }
 
 int default_colorspace(dt_iop_module_t *self,

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -617,7 +617,7 @@ int process_cl(struct dt_iop_module_t *self,
   cl_mem dev_g = NULL, dev_b = NULL, dev_coeffs = NULL;
 
   dt_print_pipe(DT_DEBUG_PARAMS,
-    "matrix conversion on GPU", piece->pipe, self ? self->so->op : "",
+    "matrix conversion on GPU", piece->pipe, self,
                     roi_in, roi_out, "`%s'\n", dt_colorspaces_get_name(d->type, NULL));
   int kernel;
   float cmat[9], lmat[9];
@@ -1197,7 +1197,7 @@ void process(struct dt_iop_module_t *self,
     d->blue_mapping && dt_image_is_matrix_correction_supported(&piece->pipe->image);
 
   dt_print_pipe(DT_DEBUG_PARAMS,
-    "matrix conversion on CPU", piece->pipe, self ? self->so->op : "",
+    "matrix conversion on CPU", piece->pipe, self,
                     roi_in, roi_out, "`%s'\n", dt_colorspaces_get_name(d->type, NULL));
 
   if(d->type == DT_COLORSPACE_LAB)

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -695,7 +695,7 @@ void process(
     if(scaled)
     {
       roi = *roi_out;
-      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi", piece->pipe, self->so->op, roi_in, roi_out, "\n");
+      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi", piece->pipe, self, roi_in, roi_out, "\n");
       dt_iop_clip_and_zoom_roi((float *)o, tmp, &roi, &roo, roi.width, roo.width);
       dt_free_align(tmp);
     }
@@ -855,7 +855,7 @@ int process_cl(
 
   if(scaled)
   {
-    dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self->so->op, roi_in, roi_out, "\n");
+    dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self, roi_in, roi_out, "\n");
     // scale aux buffer to output buffer
     const int err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
     if(err != CL_SUCCESS)

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -303,7 +303,7 @@ int default_group()
 
 int flags()
 {
-  return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_ONE_INSTANCE | IOP_FLAGS_FENCE;
+  return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_ONE_INSTANCE | IOP_FLAGS_FENCE | IOP_FLAGS_CACHE_IMPORTANT;
 }
 
 int default_colorspace(dt_iop_module_t *self,

--- a/src/iop/demosaicing/basics.c
+++ b/src/iop/demosaicing/basics.c
@@ -642,7 +642,7 @@ static int process_default_cl(
 
     if(scaled)
     {
-      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self->so->op, roi_in, roi_out, "\n");
+      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self, roi_in, roi_out, "\n");
       // scale aux buffer to output buffer
       err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
       if(err != CL_SUCCESS) goto error;

--- a/src/iop/demosaicing/rcd.c
+++ b/src/iop/demosaicing/rcd.c
@@ -791,7 +791,7 @@ static int process_rcd_cl(
 
     if(scaled)
     {
-      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self->so->op, roi_in, roi_out, "\n");
+      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self, roi_in, roi_out, "\n");
       // scale aux buffer to output buffer
       err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
       if(err != CL_SUCCESS) goto error;

--- a/src/iop/demosaicing/vng.c
+++ b/src/iop/demosaicing/vng.c
@@ -636,7 +636,7 @@ static int process_vng_cl(
 
     if(scaled)
     {
-      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self->so->op, roi_in, roi_out, "\n");
+      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self, roi_in, roi_out, "\n");
       // scale temp buffer to output buffer
       err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
       if(err != CL_SUCCESS) goto error;

--- a/src/iop/demosaicing/xtrans.c
+++ b/src/iop/demosaicing/xtrans.c
@@ -2198,7 +2198,7 @@ static int process_markesteijn_cl(
 
     if(scaled)
     {
-      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self->so->op, roi_in, roi_out, "\n");
+      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self, roi_in, roi_out, "\n");
       // scale temp buffer to output buffer
       err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_tmp, roi_out, roi_in);
       if(err != CL_SUCCESS) goto error;

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -155,7 +155,7 @@ int default_group()
 
 int flags()
 {
-  return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING;
+  return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_CACHE_IMPORTANT;
 }
 
 int default_colorspace(dt_iop_module_t *self,
@@ -1374,9 +1374,6 @@ void process(dt_iop_module_t *self,
     num_steps_to_reach_equivalent_sigma(B_SPLINE_SIGMA, final_radius);
   const int scales = CLAMP(diffusion_scales, 1, MAX_NUM_SCALES);
 
-  self->cache_next_important =
-    ((data->iterations * (data->radius + data->radius_center)) > 16);
-
   gboolean out_of_memory = FALSE;
 
   // wavelets scales buffers
@@ -1649,9 +1646,6 @@ int process_cl(struct dt_iop_module_t *self,
   const int diffusion_scales =
     num_steps_to_reach_equivalent_sigma(B_SPLINE_SIGMA, final_radius);
   const int scales = CLAMP(diffusion_scales, 1, MAX_NUM_SCALES);
-
-  self->cache_next_important =
-    ((data->iterations * (data->radius + data->radius_center)) > 16);
 
   // wavelets scales buffers
   cl_mem HF[MAX_NUM_SCALES];

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -110,7 +110,7 @@ int process_cl(struct dt_iop_module_t *self,
   const int devid = piece->pipe->devid;
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_IMAGEIO,
                 "clip_and_zoom_roi CL",
-                piece->pipe, self->so->op, roi_in, roi_out, "device=%i\n", devid);
+                piece->pipe, self, roi_in, roi_out, "device=%i\n", devid);
   const cl_int err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_in, roi_out, roi_in);
   if(err != CL_SUCCESS)
   {
@@ -131,7 +131,7 @@ void process(dt_iop_module_t *self,
              const dt_iop_roi_t *const roi_out)
 {
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_IMAGEIO,
-                "clip_and_zoom_roi", piece->pipe, self->so->op, roi_in, roi_out, "\n");
+                "clip_and_zoom_roi", piece->pipe, self, roi_in, roi_out, "\n");
   dt_iop_clip_and_zoom_roi(ovoid, ivoid, roi_out, roi_in, roi_out->width, roi_in->width);
 }
 

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -828,21 +828,13 @@ void commit_params(struct dt_iop_module_t *self,
 
   const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
 
-  // check for heavy computing here to possibly give an iop cache hint
-  gboolean heavy = (((d->mode == DT_IOP_HIGHLIGHTS_LAPLACIAN) && ((d->iterations * 1<<(2+d->scales)) >= 256))
-                  || (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS));
-
   dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
   if(g)
   {
     // the clipped visualizer for linears is not implemented in cl
     if((g->hlr_mask_mode == DT_HIGHLIGHTS_MASK_CLIPPED) && linear && fullpipe)
       piece->process_cl_ready = FALSE;
-    // only give a heavy hint if we are not in masking mode
-    if(g->hlr_mask_mode != DT_HIGHLIGHTS_MASK_OFF)
-      heavy = FALSE;
   }
-  self->cache_next_important = heavy;
 }
 
 void init_global(dt_iop_module_so_t *module)

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -303,7 +303,7 @@ const char **description(struct dt_iop_module_t *self)
 
 int default_group()
 {
-  return IOP_GROUP_CORRECT | IOP_GROUP_EFFECTS;
+  return IOP_GROUP_CORRECT | IOP_GROUP_EFFECTS | IOP_FLAGS_CACHE_IMPORTANT;
 }
 
 int flags()

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -219,7 +219,7 @@ int default_group()
 
 int flags()
 {
-  return IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_NO_MASKS | IOP_FLAGS_GUIDES_WIDGET;
+  return IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_NO_MASKS | IOP_FLAGS_GUIDES_WIDGET | IOP_FLAGS_CACHE_IMPORTANT;
 }
 
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)


### PR DESCRIPTION
Quite a large one, many files touched.

In short:
1. Improved dt_debug_pipe() function, takes other parameters for improved output
2. Fixes pixelpipe cache issues related to raster masks, see #14271 
3. Simpler cache important hints (better performance)

In detail:
**Use new dt_print_pipe() interface**

The dt_print_pipe() got a slightly modified parameter interface.
It now takes `struct dt_iop_module_t *module` as a parameter instead of a constant string representing the module name. This allows more informative output of module names. All callers modifed.

As the info is mostly too overwhelming we don't write info for previews by default but must enable that via `-d verbose`
We also report piece->hash for committed params
Improved handling and debug reporting of raster masks.
Proper checks for free_mask while using dt_dev_get_raster_mask()
Also we don't need specific debugging messages there as reported while getting the mask.
Also - as the hash for the cache is uint64_t it doesn't make sense to set it to -1


**A raster mask story**

Basically the design of `GHashTable *raster_masks` in dt_dev_pixelpipe_iop_t allows different kinds of raster masks, so far we only use those we generate while blending.
To keep memory pressure low, we don't always keep the raster masks but take care of `source` and `target` of raster masks.
The gui and history interfaces make sure, only consumed masks - there is an active target - are saved as raster masks.

There have been two flaws in this design
1. The use of raster_mask_id. (The returned in the hash table is 0, all functions doing some housekeeping on raster masks now use the abstract BLEND_RASTER_ID to show what this about. If there is no valid mask, we set raster_mask_id to the invalid id.
2. The big one - there was an interference between the above design and the pixelpipe cache.
   In short: If you select positions in the history stack that don't include a consumer (target) of a raster mask, it will **not** be written. BUT: while processing the pipe we write cachelines.
Now we switch on a module consuming the raster mask. While committing parameters for every module the `source module` is told to write the mask, good.
But while processing the pipes, we possibly find valid cachelines and so avoid reprocessing
To fix this, we avoid "always full reprocessing". While committing blend parameters we watch out for adding a `target` for a `raster source` module. If so, we invalidate all following cachelines.

**Rework the pixelpipe cache important hints**

After a long time of testing and while investigating pipe cache issues it became obvious, that the `next important` hints didn't improve hit rate as hoped, in fact they sometimes lead to hit rate drops - this depended on the used modules.
So that	interface has been stripped off.

Instead, we have some modules giving hints for important cache lines

1. demosaic as the most basic module for raw images, all parameters in- or before that module will likely not be changed while developing any more, so a safe bet.
2. Modules that are notorious for taking a lot of computer cycles all have a hint now,
   a) colorbalancergb as that is pretty slow at least on cpus and a used module in many cases.
   b) diffuse&sharpen, retouch and liquify for sure too.
3. gamma is important for full pipeline (switched on internally)
4. Expanded modules also use important cachelines. EDIT: that is precisely module-in-focus
