### PR TITLE
Fix gdb backtrace logging on crash

### DIFF
--- a/src/common/system_signal_handling.c
+++ b/src/common/system_signal_handling.c
@@ -101,7 +101,8 @@ static void _dt_sigsegv_handler(int param)
   dt_loc_get_datadir(datadir, sizeof(datadir));
   gchar *pid_arg = g_strdup_printf("%d", (int)getpid());
   gchar *comm_arg = g_strdup_printf("%s/gdb_commands", datadir);
-  gchar *log_arg = g_strdup_printf("set logging on %s", name_used);
+  gchar *logenable = g_strdup_printf("set logging enabled on");
+  gchar *setlogfile = g_strdup_printf("set logging file %s", name_used);
 
   if((pid = fork()) != -1)
   {
@@ -116,7 +117,7 @@ static void _dt_sigsegv_handler(int param)
     }
     else
     {
-      if(execlp("gdb", "gdb", darktable.progname, pid_arg, "-batch", "-ex", log_arg, "-x", comm_arg, NULL))
+      if(execlp("gdb", "gdb", darktable.progname, pid_arg, "-batch", "-ex", setlogfile, "-ex", logenable, "-x", comm_arg, NULL))
       {
         delete_file = TRUE;
         g_printerr("an error occurred while trying to execute gdb. please check if gdb is installed on your "
@@ -133,7 +134,8 @@ static void _dt_sigsegv_handler(int param)
   if(delete_file) g_unlink(name_used);
   g_free(pid_arg);
   g_free(comm_arg);
-  g_free(log_arg);
+  g_free(logenable);
+  g_free(setlogfile);
   g_free(name_used);
 
   /* pass it further to the old handler*/

--- a/src/common/system_signal_handling.c
+++ b/src/common/system_signal_handling.c
@@ -55,8 +55,8 @@ typedef void(dt_signal_handler_t)(int);
 static dt_signal_handler_t *_dt_sigsegv_old_handler = NULL;
 #endif
 
-// deer graphicsmagick, please stop messing with the stuff that you should not be touching at all.
-// based on GM's InitializeMagickSignalHandlers() and MagickSignalHandlerMessage()
+// Dear GraphicsMagick, please stop messing with the stuff that you should not be touching at all.
+// Based on GM's InitializeMagickSignalHandlers() and MagickSignalHandlerMessage()
 #if !defined(_WIN32)
 static const int _signals_to_preserve[] = { SIGHUP,  SIGINT,  SIGQUIT, SIGILL,  SIGABRT, SIGBUS, SIGFPE,
                                             SIGPIPE, SIGALRM, SIGTERM, SIGCHLD, SIGXCPU, SIGXFSZ };

--- a/src/common/system_signal_handling.c
+++ b/src/common/system_signal_handling.c
@@ -117,11 +117,12 @@ static void _dt_sigsegv_handler(int param)
     }
     else
     {
-      if(execlp("gdb", "gdb", darktable.progname, pid_arg, "-batch", "-ex", setlogfile, "-ex", logenable, "-x", comm_arg, NULL))
+      if(execlp("gdb", "gdb", darktable.progname, pid_arg, "-batch",
+                "-ex", setlogfile, "-ex", logenable, "-x", comm_arg, NULL))
       {
         delete_file = TRUE;
-        g_printerr("an error occurred while trying to execute gdb. please check if gdb is installed on your "
-                   "system.\n");
+        g_printerr("an error occurred while trying to execute gdb. "
+                   "please check if gdb is installed on your system.\n");
       }
     }
   }
@@ -172,10 +173,11 @@ static LONG WINAPI dt_toplevel_exception_handler(PEXCEPTION_POINTERS pExceptionI
   }
   else
   {
-    gchar *exception_message = g_strdup_printf("An unhandled exception occurred.\nBacktrace will be written to: %s "
-                                               "after you click on the OK button.\nIf you report this issue, "
-                                               "please share this backtrace with the developers.\n",
-                                               name_used);
+    gchar *exception_message = g_strdup_printf
+      ("An unhandled exception occurred.\nBacktrace will be written to: %s "
+       "after you click on the OK button.\nIf you report this issue, "
+       "please share this backtrace with the developers.\n",
+       name_used);
     wchar_t *wexception_message = g_utf8_to_utf16(exception_message, -1, NULL, NULL, NULL);
     MessageBoxW(0, wexception_message, L"Error!", MB_OK);
     g_free(exception_message);
@@ -248,8 +250,8 @@ void dt_set_signal_handlers()
   Set up exception handler for backtrace on Windows
   Works when there is NO SIGSEGV handler installed
 
-  SetUnhandledExceptionFilter handler must be saved on the first invocation
-  as GraphicsMagick is overwriting SetUnhandledExceptionFilter and all other signals in InitializeMagick()
+  SetUnhandledExceptionFilter handler must be saved on the first invocation as GraphicsMagick
+  is overwriting SetUnhandledExceptionFilter and all other signals in InitializeMagick()
   Eventually InitializeMagick() should be fixed upstream not to ignore existing exception handlers
   */
 


### PR DESCRIPTION
Currently, the function of recording debug information in the event of a program crash to the backtrace file does not work. The problem is that we are using the wrong gdb command syntax (filename is not allowed in it, it must be a separate command). As a result, the command was rejected, logging to the file was not allowed, and we could only see the backtrace in the terminal.

This fix introduces the correct commands that ensure writing to the file whose name is given to the user. Also, PR contains reformatting of the code, and... although GraphicsMagick is certainly a beast, but let's not call it a deer (it's in the comments).