### PR TITLE
Mostly fixes retouch opacity slider jumpy dragging

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -90,6 +90,7 @@ static void _combobox_next_sensitive(dt_bauhaus_widget_t *w, int delta, const gb
 {
   dt_bauhaus_combobox_data_t *d = &w->data.combobox;
 
+  delta *= dt_accel_get_speed_multiplier(GTK_WIDGET(w), 0);
   int new_pos = d->active;
   int step = delta > 0 ? 1 : -1;
   int cur = new_pos + step;
@@ -2976,7 +2977,7 @@ static void _bauhaus_slider_value_change(dt_bauhaus_widget_t *w)
   if(!GTK_IS_WIDGET(w)) return;
 
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  if(d->is_changed && !d->timeout_handle && !darktable.gui->reset)
+  if(d->is_changed && !d->timeout_handle)
   {
     if(w->field)
     {
@@ -3004,17 +3005,17 @@ static void _bauhaus_slider_value_change(dt_bauhaus_widget_t *w)
     _highlight_changed_notebook_tab(GTK_WIDGET(w), NULL);
     g_signal_emit_by_name(G_OBJECT(w), "value-changed");
     d->is_changed = 0;
-  }
 
-  if(d->is_changed && d->is_dragging && !d->timeout_handle)
-    d->timeout_handle = g_idle_add(_bauhaus_slider_value_change_dragging, w);
+    if(d->is_dragging)
+      d->timeout_handle = g_idle_add(_bauhaus_slider_value_change_dragging, w);
+  }
 }
 
 static gboolean _bauhaus_slider_value_change_dragging(gpointer data)
 {
   dt_bauhaus_widget_t *w = data;
   w->data.slider.timeout_handle = 0;
-  _bauhaus_slider_value_change(data);
+  _bauhaus_slider_value_change(w);
   return G_SOURCE_REMOVE;
 }
 
@@ -3030,9 +3031,11 @@ static void dt_bauhaus_slider_set_normalized(dt_bauhaus_widget_t *w, float pos)
   rpos = (rpos - d->min) / (d->max - d->min);
   d->pos = d->curve(rpos, DT_BAUHAUS_SET);
   gtk_widget_queue_draw(GTK_WIDGET(w));
-  d->is_changed = -1;
-
-  _bauhaus_slider_value_change(w);
+  if(!darktable.gui->reset)
+  {
+    d->is_changed = -1;
+    _bauhaus_slider_value_change(w);
+  }
 }
 
 static gboolean dt_bauhaus_popup_key_press(GtkWidget *widget, GdkEventKey *event, gpointer user_data)

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -553,15 +553,6 @@ static void rt_masks_form_change_opacity(dt_iop_module_t *self, dt_mask_id_t for
   }
 }
 
-static float rt_masks_form_get_opacity(dt_iop_module_t *self, dt_mask_id_t formid)
-{
-  dt_masks_point_group_t *grpt = rt_get_mask_point_group(self, formid);
-  if(grpt)
-    return grpt->opacity;
-  else
-    return 1.0f;
-}
-
 static void rt_paste_forms_from_scale(dt_iop_retouch_params_t *p,
                                       const int source_scale,
                                       const int dest_scale)
@@ -1659,7 +1650,9 @@ void gui_post_expose (struct dt_iop_module_t *self,
   if(shape_id > 0)
   {
     ++darktable.gui->reset;
-    dt_bauhaus_slider_set(g->sl_mask_opacity, rt_masks_form_get_opacity(self, shape_id));
+    dt_masks_point_group_t *grpt = rt_get_mask_point_group(self, shape_id);
+    if(grpt)
+      dt_bauhaus_slider_set(g->sl_mask_opacity, grpt->opacity);
     --darktable.gui->reset;
   }
 }


### PR DESCRIPTION
This should hopefully improve #11724

(One of) The issue(s) was that the opacity slider value would be "set" based on the active shapes opacity at the moment it was redrawn. This "set" should not try to update the "real" opacity, but "dragging" (even when not moving) would trigger a delayed update routine, which noticed that the value was "changed" (even if it wasn't actually different) and updated the opacity based on this new value anyway. This would trigger a redraw, which would redraw the screen which would update the value again etc. So that explains the continued calculation while "dragging".

Sometimes (?) while redrawing the shape can not be found, so the slider would be set to 100% (?). Should not matter if it later gets updated with the correct value, but while scrolling the incorrect one could be used for the next move. Probably cause for most of the jumping although there's probably some good old races in there too. Which would not be easy to fix. The slider in the mask manager behaves better.

Also adds per-widget speed adjustments for combos as mentioned here https://github.com/darktable-org/darktable/issues/12365#issuecomment-1529057321