### PR TITLE
colorbalancergb: improve vectorization and other optimizations

### DIFF
--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -902,10 +902,10 @@ static inline void dt_XYZ_2_JzAzBz(const dt_aligned_pixel_t XYZ_D65, dt_aligned_
   const float p = 134.034375f; // 1.7 x 2523 / 2^5
   const float d = -0.56f;
   const float d0 = 1.6295499532821566e-11f;
-  static const dt_colormatrix_t M = {
-      { 0.41478972f, 0.579999f, 0.0146480f, 0.0f },
-      { -0.2015100f, 1.120649f, 0.0531008f, 0.0f },
-      { -0.0166008f, 0.264800f, 0.6684799f, 0.0f },
+  static const dt_colormatrix_t M_transposed = {
+      { 0.41478972f, -0.2015100f, -0.0166008f, 0.0f },
+      { 0.57999900f,  1.1206490f,  0.2648000f, 0.0f },
+      { 0.01464800f,  0.0531008f,  0.6684799f, 0.0f },
   };
   static const dt_colormatrix_t A_transposed = {
       { 0.5f,       3.524000f,  0.199076f, 0.0f },
@@ -922,19 +922,16 @@ static inline void dt_XYZ_2_JzAzBz(const dt_aligned_pixel_t XYZ_D65, dt_aligned_
   XYZ[2] = XYZ_D65[2];
 
   // X'Y'Z -> L'M'S'
-#ifdef _OPENMP
-#pragma omp simd aligned(LMS, XYZ:16) aligned(M:64)
-#endif
-  for(int i = 0; i < 3; i++)
-  {
-    LMS[i] = M[i][0] * XYZ[0] + M[i][1] * XYZ[1] + M[i][2] * XYZ[2];
-    LMS[i] = powf(fmaxf(LMS[i] / 10000.f, 0.0f), n);
-    LMS[i] = powf((c1 + c2 * LMS[i]) / (1.0f + c3 * LMS[i]), p);
-  }
+  dt_apply_transposed_color_matrix(XYZ, M_transposed, LMS);
+  dt_vector_mul1(LMS, LMS, 1.0f/10000.0f);
+  dt_vector_clipneg(LMS);
+  dt_vector_pow1(LMS, n, LMS);
+  for_each_channel(i, aligned(LMS))
+    LMS[i] = (c1 + c2 * LMS[i]) / (1.0f + c3 * LMS[i]);
+  dt_vector_pow1(LMS, p, LMS);
 
   // L'M'S' -> Izazbz
-  for_each_channel(c)
-    JzAzBz[c] = A_transposed[0][c] * LMS[0] + A_transposed[1][c] * LMS[1] + A_transposed[2][c] * LMS[2];
+  dt_apply_transposed_color_matrix(LMS, A_transposed, JzAzBz);
   // Iz -> Jz
   JzAzBz[0] = fmaxf(((1.0f + d) * JzAzBz[0]) / (1.0f + d * JzAzBz[0]) - d0, 0.f);
 }
@@ -946,7 +943,7 @@ static inline void dt_JzAzBz_2_JzCzhz(const dt_aligned_pixel_t JzAzBz, dt_aligne
 {
   float var_H = atan2f(JzAzBz[2], JzAzBz[1]) / (2.0f * DT_M_PI_F);
   JzCzhz[0] = JzAzBz[0];
-  JzCzhz[1] = hypotf(JzAzBz[1], JzAzBz[2]);
+  JzCzhz[1] = dt_fast_hypotf(JzAzBz[1], JzAzBz[2]);
   JzCzhz[2] = var_H >= 0.0f ? var_H : 1.0f + var_H;
 }
 
@@ -974,42 +971,37 @@ static inline void dt_JzAzBz_2_XYZ(const dt_aligned_pixel_t JzAzBz, dt_aligned_p
   const float p_inv = 1.0f / 134.034375f; // 1.7 x 2523 / 2^5
   const float d = -0.56f;
   const float d0 = 1.6295499532821566e-11f;
-  const dt_colormatrix_t MI = {
-      {  1.9242264357876067f, -1.0047923125953657f,  0.0376514040306180f, 0.0f },
-      {  0.3503167620949991f,  0.7264811939316552f, -0.0653844229480850f, 0.0f },
-      { -0.0909828109828475f, -0.3127282905230739f,  1.5227665613052603f, 0.0f },
+  static const dt_colormatrix_t AI_trans = {
+      {  1.0f,                 1.0f,                 1.0f,                0.0f },
+      {  0.1386050432715393f, -0.1386050432715393f, -0.0960192420263190f, 0.0f },
+      {  0.0580473161561189f, -0.0580473161561189f, -0.8118918960560390f, 0.0f },
   };
-  const dt_colormatrix_t AI = {
-      {  1.0f,  0.1386050432715393f,  0.0580473161561189f, 0.0f },
-      {  1.0f, -0.1386050432715393f, -0.0580473161561189f, 0.0f },
-      {  1.0f, -0.0960192420263190f, -0.8118918960560390f, 0.0f },
+  static const dt_colormatrix_t MI_trans = {
+      {  1.9242264357876067f,  0.3503167620949991f, -0.0909828109828475f, 0.0f },
+      { -1.0047923125953657f,  0.7264811939316552f, -0.3127282905230739f, 0.0f },
+      {  0.0376514040306180f, -0.0653844229480850f,  1.5227665613052603f, 0.0f },
   };
 
-  dt_aligned_pixel_t XYZ = { 0.0f, 0.0f, 0.0f, 0.0f };
-  dt_aligned_pixel_t LMS = { 0.0f, 0.0f, 0.0f, 0.0f };
   dt_aligned_pixel_t IzAzBz = { 0.0f, 0.0f, 0.0f, 0.0f };
-
   IzAzBz[0] = JzAzBz[0] + d0;
   IzAzBz[0] = fmaxf(IzAzBz[0] / (1.0f + d - d * IzAzBz[0]), 0.f);
   IzAzBz[1] = JzAzBz[1];
   IzAzBz[2] = JzAzBz[2];
 
   // IzAzBz -> LMS
-#ifdef _OPENMP
-#pragma omp simd aligned(LMS, IzAzBz:16) aligned(AI:64)
-#endif
-  for(int i = 0; i < 3; i++)
-  {
-    LMS[i] = AI[i][0] * IzAzBz[0] + AI[i][1] * IzAzBz[1] + AI[i][2] * IzAzBz[2];
-    LMS[i] = powf(fmaxf(LMS[i], 0.0f), p_inv);
-    LMS[i] = 10000.f * powf(fmaxf((c1 - LMS[i]) / (c3 * LMS[i] - c2), 0.0f), n_inv);
-  }
+  dt_aligned_pixel_t LMS;
+  dt_apply_transposed_color_matrix(IzAzBz,AI_trans, LMS);
+  dt_vector_clipneg(LMS);
+  dt_vector_pow1(LMS, p_inv, LMS);
+  for_each_channel(i, aligned(LMS))
+    LMS[i] = (c1 - LMS[i]) / (c3 * LMS[i] - c2);
+  dt_vector_clipneg(LMS);
+  dt_vector_pow1(LMS, n_inv, LMS);
+  dt_vector_mul1(LMS, LMS, 10000.0f);
 
   // LMS -> X'Y'Z
-#ifdef _OPENMP
-#pragma omp simd aligned(LMS, XYZ:16) aligned(MI:64)
-#endif
-  for(int i = 0; i < 3; i++) XYZ[i] = MI[i][0] * LMS[0] + MI[i][1] * LMS[1] + MI[i][2] * LMS[2];
+  dt_aligned_pixel_t XYZ;
+  dt_apply_transposed_color_matrix(LMS, MI_trans, XYZ);
 
   // X'Y'Z -> XYZ_D65
   XYZ_D65[0] = (XYZ[0] + (b - 1.0f) * XYZ[2]) / b;
@@ -1059,22 +1051,22 @@ static inline void LMS_to_XYZ(const dt_aligned_pixel_t LMS, dt_aligned_pixel_t X
 * https://doi.org/10.2352/issn.2169-2629.2019.27.38
 */
 
-static const dt_colormatrix_t filmlightRGB_D65_to_LMS_D65
-    = { { 0.95f, 0.38f, 0.00f, 0.f },
-        { 0.05f, 0.62f, 0.03f, 0.f },
-        { 0.00f, 0.00f, 0.97f, 0.f } };
+static const dt_colormatrix_t filmlightRGB_D65_to_LMS_D65_trans
+    = { { 0.95f, 0.05f, 0.00f, 0.f },
+        { 0.38f, 0.62f, 0.00f, 0.f },
+        { 0.00f, 0.03f, 0.97f, 0.f } };
 
-static const dt_colormatrix_t LMS_D65_to_filmlightRGB_D65
-    = { {  1.0877193f, -0.66666667f,  0.02061856f, 0.f },
-        { -0.0877193f,  1.66666667f, -0.05154639f, 0.f },
-        {         0.f,          0.f,  1.03092784f, 0.f } };
+static const dt_colormatrix_t LMS_D65_to_filmlightRGB_D65_trans
+    = { {  1.08771930f, -0.0877193f,          0.f, 0.f },
+        { -0.66666667f,  1.66666667f,         0.f, 0.f },
+        {  0.02061856f, -0.05154639f, 1.03092784f, 0.f } };
 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(LMS, RGB: 16)
 #endif
 static inline void gradingRGB_to_LMS(const dt_aligned_pixel_t RGB, dt_aligned_pixel_t LMS)
 {
-  dot_product(RGB, filmlightRGB_D65_to_LMS_D65, LMS);
+  dt_apply_transposed_color_matrix(RGB, filmlightRGB_D65_to_LMS_D65_trans, LMS);
 }
 
 #ifdef _OPENMP
@@ -1082,7 +1074,7 @@ static inline void gradingRGB_to_LMS(const dt_aligned_pixel_t RGB, dt_aligned_pi
 #endif
 static inline void LMS_to_gradingRGB(const dt_aligned_pixel_t LMS, dt_aligned_pixel_t RGB)
 {
-  dot_product(LMS, LMS_D65_to_filmlightRGB_D65, RGB);
+  dt_apply_transposed_color_matrix(LMS, LMS_D65_to_filmlightRGB_D65_trans, RGB);
 }
 
 

--- a/src/common/dttypes.h
+++ b/src/common/dttypes.h
@@ -174,6 +174,18 @@ static inline void dt_colormatrix_mul(dt_colormatrix_t dst, const dt_colormatrix
   }
 }
 
+static inline void dt_colormatrix_transpose(dt_colormatrix_t dst,
+                                            const dt_colormatrix_t src)
+{
+  for_four_channels(c)
+  {
+    dst[0][c] = src[c][0];
+    dst[1][c] = src[c][1];
+    dst[2][c] = src[c][2];
+    dst[3][c] = src[c][3];
+  }
+}
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -584,6 +584,14 @@ static inline void dt_vector_powf(const dt_aligned_pixel_t input,
   dt_vector_exp2(log, output);
 }
 
+static inline void dt_vector_pow1(const dt_aligned_pixel_t input,
+                                  const float power,
+                                  dt_aligned_pixel_t output)
+{
+  const dt_aligned_pixel_t vpower = { power, power, power, power };
+  dt_vector_powf(input, vpower, output);
+}
+
 static inline void dt_vector_add(dt_aligned_pixel_t sum,
                                  const dt_aligned_pixel_t v1,
                                  const dt_aligned_pixel_t v2)
@@ -608,6 +616,14 @@ static inline void dt_vector_mul(dt_aligned_pixel_t result,
     result[c] = v1[c] * v2[c];
 }
 
+static inline void dt_vector_mul1(dt_aligned_pixel_t result,
+                                 const dt_aligned_pixel_t in,
+                                 const float scale)
+{
+  for_four_channels(c, aligned(result,in))
+    result[c] = in[c] * scale;
+}
+
 static inline void dt_vector_div(dt_aligned_pixel_t result,
                                  const dt_aligned_pixel_t v1,
                                  const dt_aligned_pixel_t v2)
@@ -616,6 +632,13 @@ static inline void dt_vector_div(dt_aligned_pixel_t result,
     result[c] = v1[c] / v2[c];
 }
 
+static inline void dt_vector_div1(dt_aligned_pixel_t result,
+                                 const dt_aligned_pixel_t in,
+                                 const float divisor)
+{
+  for_four_channels(c, aligned(result,in))
+    result[c] = in[c] / divisor;
+}
 
 static inline float dt_vector_channel_max(const dt_aligned_pixel_t pixel)
 {
@@ -633,6 +656,12 @@ static inline void dt_vector_clip(dt_aligned_pixel_t values)
   static const dt_aligned_pixel_t one = { 1.0f, 1.0f, 1.0f, 1.0f };
   dt_vector_max(values, values, zero);
   dt_vector_min(values, values, one);
+}
+
+static inline void dt_vector_clipneg(dt_aligned_pixel_t values)
+{
+  static const dt_aligned_pixel_t zero = { 0.0f, 0.0f, 0.0f, 0.0f };
+  dt_vector_max(values, values, zero);
 }
 
 /** Compute approximate sines, four at a time.


### PR DESCRIPTION
Transposed color matrices to use vectorizable matrix multiplications, vectorized powf() calls, used dt_fast_hypotf to avoid function calls, etc.
Yields 17% speedup using the newer UCS saturation formula, and 33% using the older JzAzBz saturation formula.  I see additional possible speedups by generating lookup tables and using approximate exponentiation functions, but this PR is the low-hanging fruit giving most of the speedup.

Passes tests 0083, 0093, and 0103.

Using JzAzBz saturation formula:
```
Thr	Master	PR
1	5563.95	3706.48	-33.3%
2	2788.23	1860.80	-33.2%
4	1396.71	 948.37	-32.0%
8	 701.75	 468.62	-33.2%
16	 352.17	 235.45	-33.1%
32	 179.90	 120.27	-33.1%
64	 120.45	  75.87	-37.0%
```
Using UCS saturation formula:
```
Thr	Master	PR
1	5052.46	4172.56	-17.4%
2	2535.63	2092.42	-17.4%
4	1270.48	1049.65	-17.3%
8	 642.33	 532.26	-17.1%
16	 322.20	 266.97	-17.1%
32	 166.92	 135.18	-19.0%
64	 111.12	  87.49	-21.2%
```
