### PR TITLE
colorcal: transpose color-adaptation matrices for vectorization

### DIFF
--- a/src/common/chromatic_adaptation.h
+++ b/src/common/chromatic_adaptation.h
@@ -41,9 +41,19 @@ static const dt_colormatrix_t XYZ_to_Bradford_LMS = { {  0.8951f,  0.2664f, -0.1
                                                       { -0.7502f,  1.7135f,  0.0367f, 0.f },
                                                       {  0.0389f, -0.0685f,  1.0296f, 0.f } };
 
+static const dt_colormatrix_t XYZ_to_Bradford_LMS_trans =
+  { {  0.8951f, -0.7502f,  0.0389f, 0.f },
+    {  0.2664f,  1.7135f, -0.0685f, 0.f },
+    { -0.1614f,  0.0367f,  1.0296f, 0.f } };
+
 static const dt_colormatrix_t Bradford_LMS_to_XYZ = { {  0.9870f, -0.1471f,  0.1600f, 0.f },
                                                       {  0.4323f,  0.5184f,  0.0493f, 0.f },
                                                       { -0.0085f,  0.0400f,  0.9685f, 0.f } };
+
+static const dt_colormatrix_t Bradford_LMS_to_XYZ_trans =
+  { {  0.9870f,  0.4323f, -0.0085f, 0.f },
+    { -0.1471f,  0.5184f,  0.0400f, 0.f },
+    {  0.1600f,  0.0493f,  0.9685f, 0.f } };
 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ, LMS:16)
@@ -51,7 +61,7 @@ static const dt_colormatrix_t Bradford_LMS_to_XYZ = { {  0.9870f, -0.1471f,  0.1
 static inline void convert_XYZ_to_bradford_LMS(const dt_aligned_pixel_t XYZ, dt_aligned_pixel_t LMS)
 {
   // Warning : needs XYZ normalized with Y - you need to downscale before
-  dot_product(XYZ, XYZ_to_Bradford_LMS, LMS);
+  dt_apply_transposed_color_matrix(XYZ, XYZ_to_Bradford_LMS_trans, LMS);
 }
 
 static inline void make_RGB_to_Bradford_LMS(const dt_colormatrix_t rgb, dt_colormatrix_t lms)
@@ -65,7 +75,7 @@ static inline void make_RGB_to_Bradford_LMS(const dt_colormatrix_t rgb, dt_color
 static inline void convert_bradford_LMS_to_XYZ(const dt_aligned_pixel_t LMS, dt_aligned_pixel_t XYZ)
 {
   // Warning : output XYZ normalized with Y - you need to upscale later
-  dot_product(LMS, Bradford_LMS_to_XYZ, XYZ);
+  dt_apply_transposed_color_matrix(LMS, Bradford_LMS_to_XYZ_trans, XYZ);
 }
 
 static inline void make_Bradford_LMS_to_RGB(const dt_colormatrix_t lms_to_rgb, dt_colormatrix_t rgb)
@@ -86,9 +96,19 @@ static const dt_colormatrix_t XYZ_to_CAT16_LMS = { {  0.401288f, 0.650173f, -0.0
                                                    { -0.250268f, 1.204414f,  0.045854f, 0.f },
                                                    { -0.002079f, 0.048952f,  0.953127f, 0.f } };
 
+static const dt_colormatrix_t XYZ_to_CAT16_LMS_trans =
+  { {  0.401288f, -0.250268f, -0.002079f, 0.f },
+    {  0.650173f,  1.204414f,  0.048952f, 0.f },
+    { -0.051461f,  0.045854f,  0.953127f, 0.f } };
+
 static const dt_colormatrix_t CAT16_LMS_to_XYZ = { {  1.862068f, -1.011255f,  0.149187f, 0.f },
                                                    {  0.38752f ,  0.621447f, -0.008974f, 0.f },
                                                    { -0.015841f, -0.034123f,  1.049964f, 0.f } };
+
+static const dt_colormatrix_t CAT16_LMS_to_XYZ_trans =
+  { {  1.862068f,  0.38752f , -0.015841f, 0.f },
+    { -1.011255f,  0.621447f, -0.034123f, 0.f },
+    {  0.149187f, -0.008974f,  1.049964f, 0.f } };
 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ, LMS:16)
@@ -96,7 +116,7 @@ static const dt_colormatrix_t CAT16_LMS_to_XYZ = { {  1.862068f, -1.011255f,  0.
 static inline void convert_XYZ_to_CAT16_LMS(const dt_aligned_pixel_t XYZ, dt_aligned_pixel_t LMS)
 {
   // Warning : needs XYZ normalized with Y - you need to downscale before
-  dot_product(XYZ, XYZ_to_CAT16_LMS, LMS);
+  dt_apply_transposed_color_matrix(XYZ, XYZ_to_CAT16_LMS_trans, LMS);
 }
 
 static inline void make_RGB_to_CAT16_LMS(const dt_colormatrix_t rgb, dt_colormatrix_t lms)
@@ -110,7 +130,7 @@ static inline void make_RGB_to_CAT16_LMS(const dt_colormatrix_t rgb, dt_colormat
 static inline void convert_CAT16_LMS_to_XYZ(const dt_aligned_pixel_t LMS, dt_aligned_pixel_t XYZ)
 {
   // Warning : output XYZ normalized with Y - you need to upscale later
-  dot_product(LMS, CAT16_LMS_to_XYZ, XYZ);
+  dt_apply_transposed_color_matrix(LMS, CAT16_LMS_to_XYZ_trans, XYZ);
 }
 
 static inline void make_CAT16_LMS_to_RGB(const dt_colormatrix_t lms_to_rgb, dt_colormatrix_t rgb)
@@ -388,27 +408,37 @@ static const dt_colormatrix_t XYZ_D50_to_D65_CAT16
         { -5.40518733e-03f, 1.00666069e+00f, -1.75551955e-03f, 0.f },
         { -4.03920992e-04f, 1.50768030e-02f, 1.30210211e+00f, 0.f } };
 
-static const dt_colormatrix_t XYZ_D50_to_D65_Bradford
-    = { { 0.95547342f, -0.02309845f, 0.06325924f, 0.f },
-        { -0.02836971f, 1.00999540f, 0.02104144f, 0.f },
-        { 0.01231401f, -0.02050765f, 1.33036593f, 0.f } };
+static const dt_colormatrix_t XYZ_D50_to_D65_CAT16_trans
+    = { {  9.89466254e-01f, -5.40518733e-03f, -4.03920992e-04f, 0.f },
+        { -4.00304626e-02f,  1.00666069e+00f,  1.50768030e-02f, 0.f },
+        {  4.40530317e-02f, -1.75551955e-03f,  1.30210211e+00f, 0.f } };
+
+static const dt_colormatrix_t XYZ_D50_to_D65_Bradford_trans
+    = { {  0.95547342f, -0.02836971f,  0.01231401f, 0.f },
+        { -0.02309845f,  1.00999540f, -0.02050765f, 0.f },
+        {  0.06325924f,  0.02104144f,  1.33036593f, 0.f } };
 
 static const dt_colormatrix_t XYZ_D65_to_D50_CAT16
     = { { 1.01085433e+00f, 4.07086103e-02f, -3.41445825e-02f, 0.f },
         { 5.42814201e-03f, 9.93581926e-01f, 1.15592039e-03f, 0.f },
         { 2.50722468e-04f, -1.14918759e-02f, 7.67964947e-01f, 0.f } };
 
-static const dt_colormatrix_t XYZ_D65_to_D50_Bradford
-    = { { 1.04792979f, 0.02294687f, -0.05019227f, 0.f },
-        { 0.02962781f, 0.99043443f, -0.0170738f, 0.f },
-        { -0.00924304f, 0.01505519f, 0.75187428f, 0.f } };
+static const dt_colormatrix_t XYZ_D65_to_D50_CAT16_trans
+    = { {  1.01085433e+00f,  5.42814201e-03f,  2.50722468e-04f, 0.f },
+        {  4.07086103e-02f,  9.93581926e-01f, -1.14918759e-02f, 0.f },
+        { -3.41445825e-02f,  1.15592039e-03f,  7.67964947e-01f, 0.f } };
+
+static const dt_colormatrix_t XYZ_D65_to_D50_Bradford_trans
+    = { {  1.04792979f,  0.02962781f, -0.00924304f, 0.f },
+        {  0.02294687f,  0.99043443f,  0.01505519f,  0.f },
+        { -0.05019227f, -0.0170738f,   0.75187428f, 0.f } };
 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(XYZ_in, XYZ_out:16)
 #endif
 static inline void XYZ_D50_to_D65(const dt_aligned_pixel_t XYZ_in, dt_aligned_pixel_t XYZ_out)
 {
-  dot_product(XYZ_in, XYZ_D50_to_D65_CAT16, XYZ_out);
+  dt_apply_transposed_color_matrix(XYZ_in, XYZ_D50_to_D65_CAT16_trans, XYZ_out);
 }
 
 #ifdef _OPENMP
@@ -416,13 +446,16 @@ static inline void XYZ_D50_to_D65(const dt_aligned_pixel_t XYZ_in, dt_aligned_pi
 #endif
 static inline void XYZ_D65_to_D50(const dt_aligned_pixel_t XYZ_in, dt_aligned_pixel_t XYZ_out)
 {
-  dot_product(XYZ_in, XYZ_D65_to_D50_CAT16, XYZ_out);
+  dt_apply_transposed_color_matrix(XYZ_in, XYZ_D65_to_D50_CAT16_trans, XYZ_out);
 }
 
 /* Helper function to directly chroma-adapt a pixel in CIE XYZ 1931 2° */
 
-static inline void chroma_adapt_pixel(const dt_aligned_pixel_t in, dt_aligned_pixel_t out,
-                                      const dt_aligned_pixel_t illuminant, const dt_adaptation_t adaptation, const float p)
+static inline void chroma_adapt_pixel(const dt_aligned_pixel_t in,
+                                      dt_aligned_pixel_t out,
+                                      const dt_aligned_pixel_t illuminant,
+                                      const dt_adaptation_t adaptation,
+                                      const float p)
 {
 
   // intermediate temp buffers

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -1022,10 +1022,20 @@ static const dt_colormatrix_t XYZ_D65_to_LMS_2006_D65
         { -0.394427f, 1.175800f, 0.106423f, 0.f },
         { 0.064856f, -0.076250f, 0.559067f, 0.f } };
 
+static const dt_colormatrix_t XYZ_D65_to_LMS_2006_D65_trans
+    = { {  0.257085f, -0.394427f,  0.064856f, 0.f },
+        {  0.859943f,  1.175800f, -0.076250f, 0.f },
+        { -0.031061f,  0.106423f,  0.559067f, 0.f } };
+
 static const dt_colormatrix_t LMS_2006_D65_to_XYZ_D65
     = { { 1.80794659f, -1.29971660f, 0.34785879f, 0.f },
         { 0.61783960f, 0.39595453f, -0.04104687f, 0.f },
         { -0.12546960f, 0.20478038f, 1.74274183f, 0.f } };
+
+static const dt_colormatrix_t LMS_2006_D65_to_XYZ_D65_trans
+    = { {  1.80794659f,  0.61783960f, -0.12546960f, 0.f },
+        { -1.29971660f,  0.39595453f,  0.20478038f, 0.f },
+        {  0.34785879f, -0.04104687f,  1.74274183f, 0.f } };
 
 
 #ifdef _OPENMP
@@ -1033,7 +1043,7 @@ static const dt_colormatrix_t LMS_2006_D65_to_XYZ_D65
 #endif
 static inline void XYZ_to_LMS(const dt_aligned_pixel_t XYZ, dt_aligned_pixel_t LMS)
 {
-  dot_product(XYZ, XYZ_D65_to_LMS_2006_D65, LMS);
+  dt_apply_transposed_color_matrix(XYZ, XYZ_D65_to_LMS_2006_D65_trans, LMS);
 }
 
 #ifdef _OPENMP
@@ -1041,7 +1051,7 @@ static inline void XYZ_to_LMS(const dt_aligned_pixel_t XYZ, dt_aligned_pixel_t L
 #endif
 static inline void LMS_to_XYZ(const dt_aligned_pixel_t LMS, dt_aligned_pixel_t XYZ)
 {
-  dot_product(LMS, LMS_2006_D65_to_XYZ_D65, XYZ);
+  dt_apply_transposed_color_matrix(LMS, LMS_2006_D65_to_XYZ_D65_trans, XYZ);
 }
 
 /*

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -706,7 +706,7 @@ static inline void _loop_switch(const float *const restrict in,
                                 const dt_adaptation_t kind,
                                 const dt_iop_channelmixer_rgb_version_t version)
 {
-  dt_colormatrix_t RGB_to_LMS;
+  dt_colormatrix_t RGB_to_LMS = { { 0.0f, 0.0f, 0.0f, 0.0f } };
   dt_colormatrix_t MIX_to_XYZ;
   switch (kind)
   {

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -707,7 +707,7 @@ static inline void _loop_switch(const float *const restrict in,
                                 const dt_iop_channelmixer_rgb_version_t version)
 {
   dt_colormatrix_t RGB_to_LMS = { { 0.0f, 0.0f, 0.0f, 0.0f } };
-  dt_colormatrix_t MIX_to_XYZ;
+  dt_colormatrix_t MIX_to_XYZ = { { 0.0f, 0.0f, 0.0f, 0.0f } };
   switch (kind)
   {
     case DT_ADAPTATION_FULL_BRADFORD:

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -735,11 +735,20 @@ static inline void _loop_switch(const float *const restrict in,
     for_each_channel(c)
       min_value[c] = -FLT_MAX;
 
+  dt_colormatrix_t RGB_to_XYZ_trans;
+  dt_colormatrix_transpose(RGB_to_XYZ_trans, RGB_to_XYZ);
+  dt_colormatrix_t RGB_to_LMS_trans;
+  dt_colormatrix_transpose(RGB_to_LMS_trans, RGB_to_LMS);
+  dt_colormatrix_t MIX_to_XYZ_trans;
+  dt_colormatrix_transpose(MIX_to_XYZ_trans, MIX_to_XYZ);
+  dt_colormatrix_t XYZ_to_RGB_trans;
+  dt_colormatrix_transpose(XYZ_to_RGB_trans, XYZ_to_RGB);
+
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(width, height, min_value, in, out, XYZ_to_RGB, RGB_to_XYZ, \
-                      RGB_to_LMS, MIX_to_XYZ, illuminant, \
-                      saturation, lightness, grey, p, gamut, clip, \
+  dt_omp_firstprivate(width, height, min_value, in, out, XYZ_to_RGB_trans, \
+                      RGB_to_XYZ_trans, RGB_to_LMS_trans, MIX_to_XYZ_trans, \
+                      illuminant, saturation, lightness, grey, p, gamut, clip, \
                       apply_grey, kind, version)                   \
   schedule(static)
 #endif
@@ -759,7 +768,7 @@ static inline void _loop_switch(const float *const restrict in,
       case DT_ADAPTATION_FULL_BRADFORD:
       {
         // Convert from RGB to XYZ
-        dot_product(temp_two, RGB_to_XYZ, temp_one);
+        dt_apply_transposed_color_matrix(temp_two, RGB_to_XYZ_trans, temp_one);
         const float Y = temp_one[1];
 
         // Convert to LMS
@@ -774,7 +783,7 @@ static inline void _loop_switch(const float *const restrict in,
       case DT_ADAPTATION_LINEAR_BRADFORD:
       {
         // Convert from RGB to XYZ to LMS
-        dot_product(temp_two, RGB_to_LMS, temp_one);
+        dt_apply_transposed_color_matrix(temp_two, RGB_to_LMS_trans, temp_one);
 
         // Do white balance
         bradford_adapt_D50(temp_one, illuminant, p, FALSE, temp_two);
@@ -783,7 +792,7 @@ static inline void _loop_switch(const float *const restrict in,
       case DT_ADAPTATION_CAT16:
       {
         // Convert from RGB to XYZ
-        dot_product(temp_two, RGB_to_LMS, temp_one);
+        dt_apply_transposed_color_matrix(temp_two, RGB_to_LMS_trans, temp_one);
 
         // Do white balance
         // force full-adaptation
@@ -793,7 +802,7 @@ static inline void _loop_switch(const float *const restrict in,
       case DT_ADAPTATION_XYZ:
       {
         // Convert from RGB to XYZ
-        dot_product(temp_two, RGB_to_XYZ, temp_one);
+        dt_apply_transposed_color_matrix(temp_two, RGB_to_XYZ_trans, temp_one);
 
         // Do white balance in XYZ
         XYZ_adapt_D50(temp_one, illuminant, temp_two);
@@ -810,7 +819,7 @@ static inline void _loop_switch(const float *const restrict in,
     }
 
     // Compute the 3D mix - this is a rotation + homothety of the vector base
-    dot_product(temp_two, MIX_to_XYZ, temp_one);
+    dt_apply_transposed_color_matrix(temp_two, MIX_to_XYZ_trans, temp_one);
 
     /* FROM HERE WE ARE MANDATORILY IN XYZ - DATA IS IN temp_one */
 
@@ -833,7 +842,7 @@ static inline void _loop_switch(const float *const restrict in,
       default:
       {
         // Convert from XYZ to RGB
-        dot_product(temp_two, XYZ_to_RGB, temp_one);
+        dt_apply_transposed_color_matrix(temp_two, XYZ_to_RGB_trans, temp_one);
         break;
       }
     }
@@ -881,7 +890,7 @@ static inline void _loop_switch(const float *const restrict in,
         default:
         {
           // Convert from RBG to XYZ
-          dot_product(temp_two, RGB_to_XYZ, temp_one);
+          dt_apply_transposed_color_matrix(temp_two, RGB_to_XYZ_trans, temp_one);
           break;
         }
       }
@@ -894,7 +903,7 @@ static inline void _loop_switch(const float *const restrict in,
           temp_one[c] = fmaxf(temp_one[c], 0.0f);
 
       // Convert back to RGB
-      dot_product(temp_one, XYZ_to_RGB, temp_two);
+      dt_apply_transposed_color_matrix(temp_one, XYZ_to_RGB_trans, temp_two);
 
       if(clip)
         for(size_t c = 0; c < DT_PIXEL_SIMD_CHANNELS; c++)

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -725,6 +725,7 @@ static inline void _loop_switch(const float *const restrict in,
       break;
     case DT_ADAPTATION_RGB:
     case DT_ADAPTATION_LAST:
+    default:
       // RGB_to_LMS not applied, since we are not adapting WB
       dt_colormatrix_mul(MIX_to_XYZ, RGB_to_XYZ, MIX);
       break;


### PR DESCRIPTION
Transpose the color matrices to enable use of the vectorizable dt_apply_transposed_color_matrix() instead of the unvectorizable dot_product().

Passes all integration tests using Color Calibration, including those specifically targeting the module: 0085, 0126, 0127, and 0128.

Yields 11-17% speedup, depending on adaptation model, on top of the recent speedups from other optimizations.
```
adaptation: CAT16 (default)
Thr	Master	PR
1	1181.99	1028.22	-13.0%
2	 593.67	 515.55	-13.1%
4	 296.69	 257.43	-13.2%
8	 148.59	 129.31	-12.9%
16	  74.49	  64.54	-13.3%
32	  37.91	  32.57	-14.0%
64	  24.11	  19.54	-18.9%

adaptation: linear Bradford
Thr	Master	PR
1	1189.47	1033.11	-13.1%
2	 596.17	 517.57	-13.1%
4	 298.32	 258.69	-13.2%
8	 149.46	 129.48	-12.7%
16	  74.67	  64.87	-13.1%
32	  37.96	  32.72	-13.8%
64	  23.46	  20.18	-13.9%

adaptation: nonlinear Bradford
Thr	Master	PR
1	1548.68	1377.33	-11.0%
2	 775.30	 689.17	-11.1%
4	 388.68	 344.85	-11.2%
8	 194.46	 172.36	-11.3%
16	  97.56	  86.50	-11.3%
32	  49.51	  43.45	-12.2%
64	  30.70	  25.01	-18.5%

adaptation: XYZ
Thr	Master	PR
1	1049.81	870.03	-17.1%
2	 525.63	435.54	-17.1%
4	 263.20	217.85	-17.2%
8	 131.69	108.97	-17.2%
16	  66.09	 54.74	-17.1%
32	  33.66	 27.76	-17.5%
64	  21.50	 18.32	-14.7%
```