### PR TITLE
Remove the implementation code of the function missing from ancient OS releases

### DIFF
--- a/src/common/system_signal_handling.c
+++ b/src/common/system_signal_handling.c
@@ -68,20 +68,6 @@ static LPTOP_LEVEL_EXCEPTION_FILTER _dt_exceptionfilter_old_handler = NULL;
 #define _NUM_SIGNALS_TO_PRESERVE (sizeof(_signals_to_preserve) / sizeof(_signals_to_preserve[0]))
 static dt_signal_handler_t *_orig_sig_handlers[_NUM_SIGNALS_TO_PRESERVE] = { NULL };
 
-#if(defined(__FreeBSD_version) && (__FreeBSD_version < 800071)) || (defined(OpenBSD) && (OpenBSD < 201305))       \
-    || defined(__SUNOS__)
-static int dprintf(int fd, const char *fmt, ...) __attribute__((format(printf, 2, 3)))
-{
-  va_list ap;
-  FILE *f = fdopen(fd, "a");
-  va_start(ap, fmt);
-  int rc = vfprintf(f, fmt, ap);
-  fclose(f);
-  va_end(ap);
-  return rc;
-}
-#endif
-
 #if !defined(__APPLE__) && !defined(_WIN32)
 static void _dt_sigsegv_handler(int param)
 {


### PR DESCRIPTION
Currently, dt has quite high requirements for the versions of mandatory tools and libraries. For example, even the conditionally sufficient gcc 10 (could compile the program after fixing checks in a series of places) was released in 2020. Thus, dt is already simply incompatible with much older releases of operating systems that are no longer supported and do not receive version updates that are mandatory for dt.

Regarding this PR, which removes the implementation code of a function missing in very old OS releases:

- FreeBSD version value 800071 [is actually a revision of FreeBSD 8 from __2009__](https://docs.freebsd.org/en/books/porters-handbook/versions/)
- OpenBSD version value 201305 looks like it refers to May __2013__ when OpenBSD 5.3 was released. [And indeed, the dprintf function appeared in this version of the OS.](http://man.openbsd.org/OpenBSD-5.4/printf.3)
- The dprintf function appeared in [Solaris 11.4](https://docs.oracle.com/cd/E88353_01/html/E37843/dprintf-3c.html), released in __2018__.

So the bottom line is we can safely delete the code as it will never be used.
