### PR TITLE
Stop zoom and geo entries swallowing shortcuts

### DIFF
--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -1587,8 +1587,9 @@ static gboolean _datetime_key_pressed(GtkWidget *entry, GdkEventKey *event, dt_l
       g_signal_emit_by_name(d->dt.widget[0], "changed");
       return FALSE;
 
-    default: // block everything else
-      return TRUE;
+    default: // let shortcut system deal with everything else
+      g_signal_stop_emission_by_name(entry, "key-press-event");
+      return FALSE;
   }
 }
 

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -535,8 +535,9 @@ static gboolean _lib_lighttable_zoom_entry_changed(GtkWidget *entry, GdkEventKey
     case GDK_KEY_BackSpace:
       return FALSE;
 
-    default: // block everything else
-      return TRUE;
+    default: // let shortcut system deal with everything else
+      g_signal_stop_emission_by_name(entry, "key-press-event");
+      return FALSE;
   }
 }
 


### PR DESCRIPTION
The key press handlers for the zoom entry in lighttable (next to the zoom slider) and the geotagging time/date entries would claim that they handled any non-numerical input to avoid the default handler from putting them in the text. But this also blocks the shortcut system from trying to interpret them (since the widget already "dealt with it"). Now any key the widget isn't interested in is treated as a possible shortcut, like with other focused entry widgets.