### PR TITLE
Rework the default modules for different workflows.

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1725,7 +1725,7 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
                "  ELSE (ROW_NUMBER() OVER (PARTITION BY operation ORDER BY operation) - 1)"
                " END",
            preset_table[legacy],
-           is_display_referred?"":"basecurve");
+           is_display_referred ? "" : "basecurve");
   // clang-format on
   // query for all modules at once:
   sqlite3_stmt *stmt;
@@ -1988,7 +1988,7 @@ void _dev_write_history(dt_develop_t *dev, const dt_imgid_t imgid)
 }
 
 // helper function for debug strings
-char * _print_validity(gboolean state)
+char *_print_validity(gboolean state)
 {
   if(state)
     return "ok";

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1350,7 +1350,8 @@ void dt_iop_cleanup_histogram(gpointer data, gpointer user_data)
 
 static void _init_presets(dt_iop_module_so_t *module_so)
 {
-  if(module_so->init_presets) module_so->init_presets(module_so);
+  if(module_so->init_presets)
+    module_so->init_presets(module_so);
 
   // this seems like a reasonable place to check for and update legacy
   // presets.
@@ -1414,14 +1415,14 @@ static void _init_presets(dt_iop_module_so_t *module_so)
 
       dt_print(DT_DEBUG_PARAMS,
                "[imageop_init_presets] found version %d for '%s' preset '%s'\n",
-        old_params_version, module_so->op, name);
+               old_params_version, module_so->op, name);
 
       DT_DEBUG_SQLITE3_PREPARE_V2
         (dt_database_get(darktable.db),
          "UPDATE data.presets"
          " SET op_version=?1"
          " WHERE operation=?2 AND name=?3", -1,
-                                  &stmt2, NULL);
+         &stmt2, NULL);
       DT_DEBUG_SQLITE3_BIND_INT(stmt2, 1, old_params_version);
       DT_DEBUG_SQLITE3_BIND_TEXT(stmt2, 2, module_so->op, -1, SQLITE_TRANSIENT);
       DT_DEBUG_SQLITE3_BIND_TEXT(stmt2, 3, name, -1, SQLITE_TRANSIENT);
@@ -1735,8 +1736,10 @@ void dt_iop_unload_modules_so()
   while(darktable.iop)
   {
     dt_iop_module_so_t *module = (dt_iop_module_so_t *)darktable.iop->data;
-    if(module->cleanup_global) module->cleanup_global(module);
-    if(module->module) g_module_close(module->module);
+    if(module->cleanup_global)
+      module->cleanup_global(module);
+    if(module->module)
+      g_module_close(module->module);
     free(darktable.iop->data);
     darktable.iop = g_list_delete_link(darktable.iop, darktable.iop);
   }

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -203,6 +203,8 @@ typedef struct dt_iop_module_so_t
 
   // introspection related data
   gboolean have_introspection;
+  // contains preset which are depending on preference (workflow)
+  gboolean pref_based_presets;
 } dt_iop_module_so_t;
 
 typedef struct dt_iop_module_t

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -553,11 +553,11 @@ const char **dt_iop_set_description(dt_iop_module_t *module,
 /** get a nice printable name. */
 const char *dt_iop_colorspace_to_name(const dt_iop_colorspace_type_t type);
 
-static inline dt_iop_gui_data_t *_iop_gui_alloc(dt_iop_module_t *module, size_t size)
+static inline dt_iop_gui_data_t *_iop_gui_alloc(dt_iop_module_t *module, const size_t size)
 {
   // Align so that DT_ALIGNED_ARRAY may be used within gui_data struct
   module->gui_data = (dt_iop_gui_data_t*)dt_calloc_align(64, size);
-  dt_pthread_mutex_init(&module->gui_lock,NULL);
+  dt_pthread_mutex_init(&module->gui_lock, NULL);
   return module->gui_data;
 }
 #define IOP_GUI_ALLOC(module) \

--- a/src/gui/presets.h
+++ b/src/gui/presets.h
@@ -24,10 +24,10 @@
 // variants are negated to keep existing presets
 typedef enum dt_gui_presets_format_flag_t
 {
-  FOR_LDR = 1 << 0,
-  FOR_RAW = 1 << 1,
-  FOR_HDR = 1 << 2,
-  FOR_NOT_MONO = 1 << 3,
+  FOR_LDR       = 1 << 0,
+  FOR_RAW       = 1 << 1,
+  FOR_HDR       = 1 << 2,
+  FOR_NOT_MONO  = 1 << 3,
   FOR_NOT_COLOR = 1 << 4
 } dt_gui_presets_format_flag_t;
 

--- a/src/gui/presets.h
+++ b/src/gui/presets.h
@@ -28,7 +28,8 @@ typedef enum dt_gui_presets_format_flag_t
   FOR_RAW       = 1 << 1,
   FOR_HDR       = 1 << 2,
   FOR_NOT_MONO  = 1 << 3,
-  FOR_NOT_COLOR = 1 << 4
+  FOR_NOT_COLOR = 1 << 4,
+  FOR_MATRIX    = 1 << 5
 } dt_gui_presets_format_flag_t;
 
 enum // Lib and iop presets

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -516,6 +516,25 @@ void init_presets(dt_iop_module_so_t *self)
 
   // sql commit
   dt_database_release_transaction(darktable.db);
+
+  // auto-applied display-referred default
+  self->pref_based_presets = TRUE;
+
+  const gboolean is_display_referred = dt_is_display_referred();
+
+  if(is_display_referred)
+  {
+    dt_gui_presets_add_generic
+      (_("display-referred default"), self->op, self->version(),
+       NULL, 0,
+       1, DEVELOP_BLEND_CS_RGB_DISPLAY);
+
+    dt_gui_presets_update_ldr(_("display-referred default"), self->op,
+                              self->version(), FOR_RAW);
+
+    dt_gui_presets_update_autoapply(_("display-referred default"),
+                                    self->op, self->version(), TRUE);
+  }
 }
 
 static float exposure_increment(float stops, int e, float fusion, float bias)

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -334,7 +334,7 @@ void init_presets(dt_iop_module_so_t *self)
        1, DEVELOP_BLEND_CS_RGB_SCENE);
 
     dt_gui_presets_update_ldr(_("scene-referred default"), self->op,
-                              self->version(), FOR_RAW);
+                              self->version(), FOR_MATRIX);
 
     dt_gui_presets_update_autoapply(_("scene-referred default"),
                                     self->op, self->version(), TRUE);

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -321,6 +321,27 @@ int legacy_params(dt_iop_module_t *self,
 
 void init_presets(dt_iop_module_so_t *self)
 {
+  // auto-applied scene-referred default
+  self->pref_based_presets = TRUE;
+
+  const gboolean is_scene_referred = dt_is_scene_referred();
+
+  if(is_scene_referred)
+  {
+    dt_gui_presets_add_generic
+      (_("scene-referred default"), self->op, self->version(),
+       NULL, 0,
+       1, DEVELOP_BLEND_CS_RGB_SCENE);
+
+    dt_gui_presets_update_ldr(_("scene-referred default"), self->op,
+                              self->version(), FOR_RAW);
+
+    dt_gui_presets_update_autoapply(_("scene-referred default"),
+                                    self->op, self->version(), TRUE);
+  }
+
+  // others
+
   dt_iop_channelmixer_rgb_params_t p;
   memset(&p, 0, sizeof(p));
 

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -273,6 +273,8 @@ int legacy_params(dt_iop_module_t *self,
 
 void init_presets(dt_iop_module_so_t *self)
 {
+  self->pref_based_presets = TRUE;
+
   dt_gui_presets_add_generic
     (_("magic lantern defaults"), self->op,
      self->version(),
@@ -284,22 +286,24 @@ void init_presets(dt_iop_module_so_t *self)
                                  .compensate_exposure_bias = FALSE},
      sizeof(dt_iop_exposure_params_t), 1, DEVELOP_BLEND_CS_RGB_DISPLAY);
 
+  const gboolean is_scene_referred = dt_is_scene_referred();
 
-  // For scene-referred workflow, since filmic doesn't brighten as base curve does,
-  // we need an initial exposure boost. This preset has the same value as what is
-  // auto-applied (see reload_default below) for scene-referred workflow.
-  dt_gui_presets_add_generic
-    (_("scene-referred default"), self->op, self->version(),
-     &(dt_iop_exposure_params_t){.mode = EXPOSURE_MODE_MANUAL,
-                                 .black = -0.000244140625f,
-                                 .exposure = 0.7f,
-                                 .deflicker_percentile = 50.0f,
-                                 .deflicker_target_level = -4.0f,
-                                 .compensate_exposure_bias = TRUE},
-     sizeof(dt_iop_exposure_params_t), 1, DEVELOP_BLEND_CS_RGB_SCENE);
+  if(is_scene_referred)
+  {
+    // For scene-referred workflow, since filmic doesn't brighten as base curve does,
+    // we need an initial exposure boost. This preset has the same value as what is
+    // auto-applied (see reload_default below) for scene-referred workflow.
+    dt_gui_presets_add_generic
+      (_("scene-referred default"), self->op, self->version(),
+       NULL, 0,
+       1, DEVELOP_BLEND_CS_RGB_SCENE);
 
-  dt_gui_presets_update_ldr(_("scene-referred default"), self->op,
-                            self->version(), FOR_RAW);
+    dt_gui_presets_update_ldr(_("scene-referred default"), self->op,
+                              self->version(), FOR_RAW);
+
+    dt_gui_presets_update_autoapply(_("scene-referred default"),
+                                    self->op, self->version(), TRUE);
+  }
 }
 
 void reload_defaults(dt_iop_module_t *module)

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -271,7 +271,7 @@ int legacy_params(dt_iop_module_t *self,
   return 1;
 }
 
-void init_presets (dt_iop_module_so_t *self)
+void init_presets(dt_iop_module_so_t *self)
 {
   dt_gui_presets_add_generic
     (_("magic lantern defaults"), self->op,

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -3082,6 +3082,28 @@ void reload_defaults(dt_iop_module_t *module)
   }
 }
 
+void init_presets(dt_iop_module_so_t *self)
+{
+  // auto-applied scene-referred default
+  self->pref_based_presets = TRUE;
+
+  const char *workflow = dt_conf_get_string_const("plugins/darkroom/workflow");
+  const gboolean auto_apply_filmic = strcmp(workflow, "scene-referred (filmic)") == 0;
+
+  if(auto_apply_filmic)
+  {
+    dt_gui_presets_add_generic
+      (_("scene-referred default"), self->op, self->version(),
+       NULL, 0,
+       1, DEVELOP_BLEND_CS_RGB_SCENE);
+
+    dt_gui_presets_update_ldr(_("scene-referred default"), self->op,
+                              self->version(), FOR_RAW);
+
+    dt_gui_presets_update_autoapply(_("scene-referred default"),
+                                    self->op, self->version(), TRUE);
+  }
+}
 
 void init_global(dt_iop_module_so_t *module)
 {

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -121,6 +121,28 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
 
 void init_presets(dt_iop_module_so_t *self)
 {
+  // auto-applied scene-referred default
+  self->pref_based_presets = TRUE;
+
+  const char *workflow = dt_conf_get_string_const("plugins/darkroom/workflow");
+  const gboolean auto_apply_sigmoid = strcmp(workflow, "scene-referred (sigmoid)") == 0;
+
+  if(auto_apply_sigmoid)
+  {
+    dt_gui_presets_add_generic
+      (_("scene-referred default"), self->op, self->version(),
+       NULL, 0,
+       1, DEVELOP_BLEND_CS_RGB_SCENE);
+
+    dt_gui_presets_update_ldr(_("scene-referred default"), self->op,
+                              self->version(), FOR_RAW);
+
+    dt_gui_presets_update_autoapply(_("scene-referred default"),
+                                    self->op, self->version(), TRUE);
+  }
+
+  // others
+
   dt_iop_sigmoid_params_t p;
   p.display_white_target = 100.0f;
   p.display_black_target = 0.0152f;


### PR DESCRIPTION
Instead of hard coding the module to load in develop each module now set a default presets based on the current workflow. This preset is auto-load and auto-init (using module's default). We so take advantage of the recent default preset rework to further simplify the code.

As for the lib modules the iop preset can be declared as based on preferences and will be updated any time a preferences is changed. This in turn avoids having to quit darktable to get the proper presets. 

As a side note, avoiding global knowledge is a good thing for maintenance and avoiding messing with large and hard to read conditionals.

For this to work also for the Color Calibration module a new preset filter FOR_MATRIX has been added. This is not currently exposed on the preset UI filter, if it proves to be of general use it will be added in a separate PR.