### PR TITLE
RFC: Masks manager: Change order (hierarchy) of shapes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -77,7 +77,7 @@ body:
         - 'darktable.org'
         - 'distro packaging'
         - 'flatpak'
-        - 'OSB'
+        - 'OBS'
         - 'self compiled'
         - 'an online forum'
     validations:

--- a/src/libs/ioporder.c
+++ b/src/libs/ioporder.c
@@ -70,7 +70,8 @@ void update(dt_lib_module_t *self)
     gtk_box_pack_start(GTK_BOX(dtgtk_expander_get_header(DTGTK_EXPANDER(self->expander))),
                        d->widget, TRUE, TRUE, 0);
 
-    gtk_widget_destroy(self->arrow);
+    if(self->arrow)
+      gtk_widget_destroy(self->arrow);
     self->arrow = NULL;
   }
 

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -825,7 +825,6 @@ static void _tree_moveup(GtkButton *button, dt_lib_module_t *self)
       if(_is_last_tree_item(model, &iter))
       {
         _swap_last_secondlast_item_visibility(lm, &iter, id, prev_id);
-        // _swap_first_second_item_visibility(lm, &iter, id, prev_id);
       }
 
       gtk_tree_iter_free(prev_iter);
@@ -872,7 +871,6 @@ static void _tree_movedown(GtkButton *button, dt_lib_module_t *self)
       if(_is_last_tree_item(model, next_iter))
       {
         _swap_last_secondlast_item_visibility(lm, &iter, next_id, id);
-        // _swap_first_second_item_visibility(lm, &iter, next_id, id);
       }
 
       gtk_tree_iter_free(next_iter);
@@ -1493,7 +1491,17 @@ static void _lib_masks_list_recurs(GtkTreeStore *treestore,
   {
     // we just add it to the tree
     GtkTreeIter child;
-    gtk_tree_store_prepend(treestore, &child, toplevel);
+
+    if (toplevel)
+    {
+      // place groups on top
+      gtk_tree_store_prepend(treestore, &child, toplevel);
+    }
+    else
+    {
+      gtk_tree_store_append(treestore, &child, toplevel);
+    }
+
     gtk_tree_store_set(treestore, &child,
                        TREE_TEXT, str,
                        TREE_MODULE, module,

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1501,14 +1501,15 @@ static void _lib_masks_list_recurs(GtkTreeStore *treestore,
     {
       // skip all groups first
       GtkTreeModel *model = GTK_TREE_MODEL(treestore);
+      int pos = 0;
       GtkTreeIter iter;
       gtk_tree_model_get_iter_first(model, &iter);
-      int pos = 0;
 
-      while (gtk_tree_model_iter_has_child(model, &iter)) {
-        ++pos;
-        gtk_tree_model_iter_next(model, &iter);
-      }
+      do
+      {
+        if (gtk_tree_model_iter_has_child(model, &iter))
+          ++pos;
+      } while(gtk_tree_model_iter_next(model, &iter));
 
       // insert the child immediately after the last group
       gtk_tree_store_insert(treestore, &child, NULL, pos);

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1494,12 +1494,24 @@ static void _lib_masks_list_recurs(GtkTreeStore *treestore,
 
     if (toplevel)
     {
-      // place groups on top
+      // we are within a group
       gtk_tree_store_prepend(treestore, &child, toplevel);
     }
     else
     {
-      gtk_tree_store_append(treestore, &child, toplevel);
+      // skip all groups first
+      GtkTreeModel *model = GTK_TREE_MODEL(treestore);
+      GtkTreeIter iter;
+      gtk_tree_model_get_iter_first(model, &iter);
+      int pos = 0;
+
+      while (gtk_tree_model_iter_has_child(model, &iter)) {
+        ++pos;
+        gtk_tree_model_iter_next(model, &iter);
+      }
+
+      // insert the child immediately after the last group
+      gtk_tree_store_insert(treestore, &child, NULL, pos);
     }
 
     gtk_tree_store_set(treestore, &child,

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -509,7 +509,7 @@ static void _tree_intersection(GtkButton *button, dt_lib_module_t *self)
   GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(lm->treeview));
   gboolean change = FALSE;
   GList *items = gtk_tree_selection_get_selected_rows(selection, NULL);
-  for(const GList *items_iter = items; items_iter; items_iter = g_list_next(items_iter))
+  for(const GList *items_iter = g_list_last(items); items_iter; items_iter = g_list_previous(items_iter))
   {
     GtkTreePath *item = (GtkTreePath *)items_iter->data;
     GtkTreeIter iter;
@@ -1287,22 +1287,22 @@ static int _tree_button_pressed(GtkWidget *treeview,
         gtk_menu_shell_append(menu, gtk_separator_menu_item_new());
 
         item = gtk_menu_item_new_with_label(_("mode: union"));
-        gtk_widget_set_sensitive(item, !is_first_row);
+        gtk_widget_set_sensitive(item, !is_last_row);
         g_signal_connect(item, "activate", (GCallback)_tree_union, self);
         gtk_menu_shell_append(menu, item);
 
         item = gtk_menu_item_new_with_label(_("mode: intersection"));
-        gtk_widget_set_sensitive(item, !is_first_row);
+        gtk_widget_set_sensitive(item, !is_last_row);
         g_signal_connect(item, "activate", (GCallback)_tree_intersection, self);
         gtk_menu_shell_append(menu, item);
 
         item = gtk_menu_item_new_with_label(_("mode: difference"));
-        gtk_widget_set_sensitive(item, !is_first_row);
+        gtk_widget_set_sensitive(item, !is_last_row);
         g_signal_connect(item, "activate", (GCallback)_tree_difference, self);
         gtk_menu_shell_append(menu, item);
 
         item = gtk_menu_item_new_with_label(_("mode: exclusion"));
-        gtk_widget_set_sensitive(item, !is_first_row);
+        gtk_widget_set_sensitive(item, !is_last_row);
         g_signal_connect(item, "activate", (GCallback)_tree_exclusion, self);
         gtk_menu_shell_append(menu, item);
       }
@@ -1491,7 +1491,7 @@ static void _lib_masks_list_recurs(GtkTreeStore *treestore,
   {
     // we just add it to the tree
     GtkTreeIter child;
-    gtk_tree_store_append(treestore, &child, toplevel);
+    gtk_tree_store_prepend(treestore, &child, toplevel);
     gtk_tree_store_set(treestore, &child,
                        TREE_TEXT, str,
                        TREE_MODULE, module,
@@ -1528,7 +1528,7 @@ static void _lib_masks_list_recurs(GtkTreeStore *treestore,
 
     // we add the group node to the tree
     GtkTreeIter child;
-    gtk_tree_store_append(treestore, &child, toplevel);
+    gtk_tree_store_prepend(treestore, &child, toplevel);
     gtk_tree_store_set(treestore, &child,
                        TREE_TEXT, str,
                        TREE_MODULE, module,


### PR DESCRIPTION
fixes #14154 

At first I was unsure if it makes sense to reverse the order of the shapes but I must admit that I get used to it after a few minutes of use.

So please test and decide.

Proposal for the release notes text:
Reverse the sort order of the shapes in mask manager groups so that the lowest ranking shape is at the bottom of the group.
