### PR TITLE
[GUI] Text capitalizing fixes

### DIFF
--- a/src/common/color_vocabulary.c
+++ b/src/common/color_vocabulary.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2022 darktable developers.
+    Copyright (C) 2022-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -93,7 +93,7 @@ const char *Lch_to_color_name(dt_aligned_pixel_t color)
       { .name = _("Thai"),             .ethnicity = ETHNIE_THAI },
       { .name = _("Kurdish"),          .ethnicity = ETHNIE_KURDISH },
       { .name = _("Caucasian"),        .ethnicity = ETHNIE_CAUCASIAN },
-      { .name = _("African-american"), .ethnicity = ETHNIE_AFRICAN_AM },
+      { .name = _("African-American"), .ethnicity = ETHNIE_AFRICAN_AM },
       { .name = _("Mexican"),          .ethnicity = ETHNIE_MEXICAN } };
 
   const skin_color_t skin[SKINS] = {

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -1,22 +1,22 @@
 /*
- * This file is part of darktable,
- * Copyright (C) 2019-2023 darktable developers.
- *
- *  Copyright (c) 2019      Andreas Schneider
- *
- *  darktable is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  darktable is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with darktable.  If not, see <http://www.gnu.org/licenses/>.
- */
+    This file is part of darktable,
+    Copyright (C) 2019-2023 darktable developers.
+
+    Copyright (c) 2019      Andreas Schneider
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -786,7 +786,7 @@ void gui_init(dt_imageio_module_format_t *self)
   DT_BAUHAUS_COMBOBOX_NEW_FULL(gui->color_mode, self, NULL, N_("color mode"),
                                _("saving as grayscale will reduce the size for black & white images"),
                                color_mode, color_mode_changed, self,
-                               N_("rgb colors"), N_("grayscale"));
+                               N_("RGB colors"), N_("grayscale"));
 
   gtk_box_pack_start(GTK_BOX(self->widget),
                      gui->color_mode,

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -885,7 +885,7 @@ void gui_init(dt_imageio_module_format_t *self)
 
   // shortfile option combo box
   DT_BAUHAUS_COMBOBOX_NEW_FULL(gui->shortfiles, self, NULL, N_("b&w image"), NULL, shortmode,
-                               shortfile_combobox_changed, self, N_("write rgb colors"), N_("write grayscale"));
+                               shortfile_combobox_changed, self, N_("write RGB colors"), N_("write grayscale"));
   dt_bauhaus_combobox_set_default(gui->shortfiles,
                                   dt_confgen_get_int("plugins/imageio/format/tiff/shortfile", DT_DEFAULT));
   gtk_box_pack_start(GTK_BOX(self->widget), gui->shortfiles, TRUE, TRUE, 0);

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -40,7 +41,7 @@ DT_MODULE_INTROSPECTION(1, dt_iop_sigmoid_params_t)
 typedef enum dt_iop_sigmoid_methods_type_t
 {
   DT_SIGMOID_METHOD_PER_CHANNEL = 0,     // $DESCRIPTION: "per channel"
-  DT_SIGMOID_METHOD_RGB_RATIO = 1,     // $DESCRIPTION: "rgb ratio"
+  DT_SIGMOID_METHOD_RGB_RATIO = 1,     // $DESCRIPTION: "RGB ratio"
 } dt_iop_sigmoid_methods_type_t;
 
 

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include <stdint.h>
 
 #include "bauhaus/bauhaus.h"
@@ -144,7 +145,7 @@ dt_lib_histogram_color_harmony_t dt_color_harmonies[DT_LIB_HISTOGRAM_HARMONY_N] 
 const gchar *dt_lib_histogram_scope_type_names[DT_LIB_HISTOGRAM_SCOPE_N] =
 { N_("vectorscope"),
   N_("waveform"),
-  N_("rgb parade"),
+  N_("RGB parade"),
   N_("histogram")
 };
 

--- a/src/libs/live_view.c
+++ b/src/libs/live_view.c
@@ -290,8 +290,8 @@ void gui_init(dt_lib_module_t *self)
   dt_shortcut_register(dt_action_section(DT_ACTION(self), N_("toggle live view")), 0, 0, GDK_KEY_v, 0);
   lib->live_view_zoom = NEW_BUTTON(, dtgtk_cairo_paint_zoom, 0, _zoom_live_view_clicked, lib, N_("zoom live view")); // TODO: see _zoom_live_view_clicked
   dt_shortcut_register(dt_action_section(DT_ACTION(self), N_("zoom live view")), 0, 0, GDK_KEY_w, 0);
-  lib->rotate_ccw = NEW_BUTTON(, dtgtk_cairo_paint_refresh, 0, _rotate_ccw, lib, N_("rotate 90 degrees ccw"));
-  lib->rotate_cw = NEW_BUTTON(,dtgtk_cairo_paint_refresh, CPF_DIRECTION_UP, _rotate_cw, lib, N_("rotate 90 degrees cw"));
+  lib->rotate_ccw = NEW_BUTTON(, dtgtk_cairo_paint_refresh, 0, _rotate_ccw, lib, N_("rotate 90 degrees CCW"));
+  lib->rotate_cw = NEW_BUTTON(,dtgtk_cairo_paint_refresh, CPF_DIRECTION_UP, _rotate_cw, lib, N_("rotate 90 degrees CW"));
   lib->flip = NEW_BUTTON(toggle, dtgtk_cairo_paint_flip, CPF_DIRECTION_UP, _toggle_flip_clicked, lib, N_("flip live view horizontally"));
 
   // focus buttons


### PR DESCRIPTION
As I already wrote, I still refrain from capitalizing rgb in module names, fearing that RGB in capital letters would dominate the actual module names written in all lower case. All other uses of this word have been corrected.