### PR TITLE
Improved dt_print_pipe() interface

### DIFF
--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -1175,7 +1175,7 @@ static void dt_interpolation_resample_plain(const struct dt_interpolation *itor,
   int r;
 
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
-                "resample_plain", NULL, itor->name, roi_in, roi_out, "\n");
+                "resample_plain", NULL, NULL, roi_in, roi_out, "%s\n",itor->name);
   dt_times_t start = { 0 }, mid = { 0 };
   dt_get_perf_times(&start);
 
@@ -1420,7 +1420,7 @@ int dt_interpolation_resample_cl(const struct dt_interpolation *itor,
   cl_mem dev_vmeta = NULL;
 
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
-                "resample_cl", NULL, itor->name, roi_in, roi_out, "\n");
+                "resample_cl", NULL, NULL, roi_in, roi_out, "%s\n", itor->name);
   dt_times_t start = { 0 }, mid = { 0 };
   dt_get_perf_times(&start);
 
@@ -1632,7 +1632,7 @@ static void dt_interpolation_resample_1c_plain(const struct dt_interpolation *it
   int r;
 
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
-                "resample_1c_plain", NULL, itor->name, roi_in, roi_out, "\n");
+                "resample_1c_plain", NULL, NULL, roi_in, roi_out, "%s\n", itor->name);
   dt_times_t start = { 0 }, mid = { 0 };
   dt_get_perf_times(&start);
 

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1104,7 +1104,7 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
   {
     // downsample
     dt_print_pipe(DT_DEBUG_PIPE,
-                  "mipmap clip and zoom", NULL, "", &roi_in, &roi_out, "\n");
+                  "mipmap clip and zoom", NULL, NULL, &roi_in, &roi_out, "\n");
     dt_iop_clip_and_zoom(out, (const float *)buf.buf, &roi_out, &roi_in, roi_out.width, roi_in.width);
   }
 

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -285,7 +285,7 @@ static void _refine_with_detail_mask(struct dt_iop_module_t *self,
   const int oheight = roi_out->height;
   dt_print_pipe(DT_DEBUG_PIPE,
        "refine_detail_mask on CPU",
-       piece->pipe, self->so->op, roi_in, roi_out, "\n");
+       piece->pipe, self, roi_in, roi_out, "\n");
 
   const size_t bufsize = (size_t)MAX(iwidth * iheight, owidth * oheight);
 
@@ -481,7 +481,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self,
   {
     dt_print_pipe(DT_DEBUG_PIPE,
                   "dt_develop_blend on CPU",
-                  piece->pipe, self->so->op, roi_in, roi_out,
+                  piece->pipe, self, roi_in, roi_out,
                   "skip blending, work area mismatch\n");
     return;
   }
@@ -521,7 +521,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self,
   {
     dt_print_pipe(DT_DEBUG_PIPE,
        "dt_develop_blend on CPU",
-       piece->pipe, self->so->op, roi_in, roi_out,
+       piece->pipe, self, roi_in, roi_out,
        "could not allocate buffer for blending\n");
     return;
   }
@@ -542,12 +542,6 @@ void dt_develop_blend_process(struct dt_iop_module_t *self,
                                                 self->raster_mask.sink.source,
                                                 self->raster_mask.sink.id,
                                                 self, &free_mask);
-
-    dt_print_pipe(DT_DEBUG_PIPE,
-      "blend raster mask on CPU",
-      piece->pipe, self->so->op, roi_in, roi_out,
-      "%sraster mask found\n", raster_mask ? "" : "**no** ");
-
     if(raster_mask)
     {
       // invert if required
@@ -579,7 +573,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self,
   {
     dt_print_pipe(DT_DEBUG_PIPE,
        "blend with form on CPU",
-       piece->pipe, self->so->op, roi_in, roi_out,
+       piece->pipe, self, roi_in, roi_out,
        "\n");
     // we blend with a drawn and/or parametric mask
 
@@ -774,7 +768,7 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self,
   const int oheight = roi_out->height;
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_OPENCL,
        "refine_detail_mask on GPU",
-       piece->pipe, self->so->op, roi_in, roi_out, "\n");
+       piece->pipe, self, roi_in, roi_out, "\n");
 
   lum = dt_alloc_align_float((size_t)iwidth * iheight);
   tmp = dt_opencl_alloc_device(devid, iwidth, iheight, sizeof(float));
@@ -939,7 +933,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self,
   {
     dt_print_pipe(DT_DEBUG_PIPE,
                   "dt_develop_blend on GPU",
-                  piece->pipe, self->so->op, roi_in, roi_out,
+                  piece->pipe, self, roi_in, roi_out,
                   "skip OpenCL blending, work area mismatch\n");
     return TRUE;
   }
@@ -982,7 +976,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self,
   {
     dt_print_pipe(DT_DEBUG_PIPE,
        "dt_develop_blend on GPU",
-       piece->pipe, self->so->op, roi_in, roi_out,
+       piece->pipe, self, roi_in, roi_out,
        "could not allocate buffer for blending\n");
    return FALSE;
   }
@@ -1098,12 +1092,6 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self,
                                                 self->raster_mask.sink.source,
                                                 self->raster_mask.sink.id,
                                                 self, &free_mask);
-
-    dt_print_pipe(DT_DEBUG_PIPE,
-      "blend raster mask on GPU",
-      piece->pipe, self->so->op, roi_in, roi_out,
-      "%sraster mask found\n", raster_mask ? "" : "**no** ");
-
     if(raster_mask)
     {
       // invert if required
@@ -1145,8 +1133,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self,
   {
     dt_print_pipe(DT_DEBUG_PIPE,
        "blend with form on GPU",
-       piece->pipe, self->so->op, roi_in, roi_out,
-       "\n");
+       piece->pipe, self, roi_in, roi_out, "\n");
     // we blend with a drawn and/or parametric mask
 
     // get the drawn mask if there is one

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2031,12 +2031,6 @@ void dt_iop_commit_params(dt_iop_module_t *module,
     piece->hash = hash;
 
     free(str);
-
-    dt_print(DT_DEBUG_PARAMS,
-             "[dt_iop_commit_params] [%s] committed for %s with hash %lu\n",
-             dt_dev_pixelpipe_type_to_str(pipe->type),
-             module->op,
-             (long unsigned int)piece->hash);
   }
 }
 

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -92,7 +92,7 @@ typedef struct dt_dev_pixelpipe_t
 {
   // store history/zoom caches
   dt_dev_pixelpipe_cache_t cache;
-  // set to non-zero in order to obsolete old cache entries on next pixelpipe run
+  // set to TRUE in order to obsolete old cache entries on next pixelpipe run
   gboolean cache_obsolete;
   // input buffer
   float *input;
@@ -300,7 +300,7 @@ gboolean dt_dev_write_rawdetail_mask_cl(dt_dev_pixelpipe_iop_t *piece,
 void dt_print_pipe(dt_debug_thread_t thread,
                    const char *title,
                    dt_dev_pixelpipe_t *pipe,
-                   const char *mod,
+                   const struct dt_iop_module_t *mod,
                    const dt_iop_roi_t *roi_in,
                    const dt_iop_roi_t *roi_out,
                    const char *msg, ...);

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -617,7 +617,7 @@ int process_cl(struct dt_iop_module_t *self,
   cl_mem dev_g = NULL, dev_b = NULL, dev_coeffs = NULL;
 
   dt_print_pipe(DT_DEBUG_PARAMS,
-    "matrix conversion on GPU", piece->pipe, self ? self->so->op : "",
+    "matrix conversion on GPU", piece->pipe, self,
                     roi_in, roi_out, "`%s'\n", dt_colorspaces_get_name(d->type, NULL));
   int kernel;
   float cmat[9], lmat[9];
@@ -1197,7 +1197,7 @@ void process(struct dt_iop_module_t *self,
     d->blue_mapping && dt_image_is_matrix_correction_supported(&piece->pipe->image);
 
   dt_print_pipe(DT_DEBUG_PARAMS,
-    "matrix conversion on CPU", piece->pipe, self ? self->so->op : "",
+    "matrix conversion on CPU", piece->pipe, self,
                     roi_in, roi_out, "`%s'\n", dt_colorspaces_get_name(d->type, NULL));
 
   if(d->type == DT_COLORSPACE_LAB)

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -695,7 +695,7 @@ void process(
     if(scaled)
     {
       roi = *roi_out;
-      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi", piece->pipe, self->so->op, roi_in, roi_out, "\n");
+      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi", piece->pipe, self, roi_in, roi_out, "\n");
       dt_iop_clip_and_zoom_roi((float *)o, tmp, &roi, &roo, roi.width, roo.width);
       dt_free_align(tmp);
     }
@@ -855,7 +855,7 @@ int process_cl(
 
   if(scaled)
   {
-    dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self->so->op, roi_in, roi_out, "\n");
+    dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self, roi_in, roi_out, "\n");
     // scale aux buffer to output buffer
     const int err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
     if(err != CL_SUCCESS)

--- a/src/iop/demosaicing/basics.c
+++ b/src/iop/demosaicing/basics.c
@@ -642,7 +642,7 @@ static int process_default_cl(
 
     if(scaled)
     {
-      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self->so->op, roi_in, roi_out, "\n");
+      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self, roi_in, roi_out, "\n");
       // scale aux buffer to output buffer
       err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
       if(err != CL_SUCCESS) goto error;

--- a/src/iop/demosaicing/rcd.c
+++ b/src/iop/demosaicing/rcd.c
@@ -791,7 +791,7 @@ static int process_rcd_cl(
 
     if(scaled)
     {
-      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self->so->op, roi_in, roi_out, "\n");
+      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self, roi_in, roi_out, "\n");
       // scale aux buffer to output buffer
       err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
       if(err != CL_SUCCESS) goto error;

--- a/src/iop/demosaicing/vng.c
+++ b/src/iop/demosaicing/vng.c
@@ -636,7 +636,7 @@ static int process_vng_cl(
 
     if(scaled)
     {
-      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self->so->op, roi_in, roi_out, "\n");
+      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self, roi_in, roi_out, "\n");
       // scale temp buffer to output buffer
       err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
       if(err != CL_SUCCESS) goto error;

--- a/src/iop/demosaicing/xtrans.c
+++ b/src/iop/demosaicing/xtrans.c
@@ -2198,7 +2198,7 @@ static int process_markesteijn_cl(
 
     if(scaled)
     {
-      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self->so->op, roi_in, roi_out, "\n");
+      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self, roi_in, roi_out, "\n");
       // scale temp buffer to output buffer
       err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_tmp, roi_out, roi_in);
       if(err != CL_SUCCESS) goto error;

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -110,7 +110,7 @@ int process_cl(struct dt_iop_module_t *self,
   const int devid = piece->pipe->devid;
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_IMAGEIO,
                 "clip_and_zoom_roi CL",
-                piece->pipe, self->so->op, roi_in, roi_out, "device=%i\n", devid);
+                piece->pipe, self, roi_in, roi_out, "device=%i\n", devid);
   const cl_int err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_in, roi_out, roi_in);
   if(err != CL_SUCCESS)
   {
@@ -131,7 +131,7 @@ void process(dt_iop_module_t *self,
              const dt_iop_roi_t *const roi_out)
 {
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_IMAGEIO,
-                "clip_and_zoom_roi", piece->pipe, self->so->op, roi_in, roi_out, "\n");
+                "clip_and_zoom_roi", piece->pipe, self, roi_in, roi_out, "\n");
   dt_iop_clip_and_zoom_roi(ovoid, ivoid, roi_out, roi_in, roi_out->width, roi_in->width);
 }
 


### PR DESCRIPTION
The dt_print_pipe() got a slightly modified parameter interface. It now takes a pointer to `dt_iop_module_t *module` as a parameter instead of a string representing the module name.

This allows much more informative output like module names, multiple instances are taken care of. All calling functions modifed.

Some minor refactoring while getting the raster mask and improved debugging output why something might go wrong.