### PR TITLE
Pixelpipe cache maintenance again

### DIFF
--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -42,11 +42,10 @@ typedef struct dt_dev_pixelpipe_cache_t
   uint64_t *hash;
   int32_t *used;
   int32_t *ioporder;
-  // debugging helpers
-  char **modname; 
+  uint64_t calls;
   // profiling:
-  uint64_t queries;
-  uint64_t misses;
+  uint64_t tests;
+  uint64_t hits;
 } dt_dev_pixelpipe_cache_t;
 
 /** constructs a new cache with given cache line count (entries) and float buffer entry size in bytes.
@@ -76,7 +75,7 @@ gboolean dt_dev_pixelpipe_cache_get(struct dt_dev_pixelpipe_t *pipe, const uint6
                                const size_t size, void **data, struct dt_iop_buffer_dsc_t **dsc, struct dt_iop_module_t *module, const gboolean important);
 
 /** test availability of a cache line without destroying another, if it is not found. */
-gboolean dt_dev_pixelpipe_cache_available(struct dt_dev_pixelpipe_t *pipe, const uint64_t hash, const size_t size);
+gboolean dt_dev_pixelpipe_cache_available(struct dt_dev_pixelpipe_t *pipe, const uint64_t hash, const uint64_t basichash, const size_t size);
 
 /** invalidates all cachelines. */
 void dt_dev_pixelpipe_cache_flush(struct dt_dev_pixelpipe_t *pipe);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -271,6 +271,7 @@ gboolean dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe,
   pipe->work_profile_info = NULL;
   pipe->input_profile_info = NULL;
   pipe->output_profile_info = NULL;
+  pipe->runs = 0;
 
   return dt_dev_pixelpipe_cache_init(pipe, entries, size, memlimit);
 }
@@ -1439,7 +1440,7 @@ static gboolean _dev_pixelpipe_process_rec(
   {
     dt_dev_pixelpipe_cache_fullhash(pipe->image.id, roi_out, pipe, pos, &basichash, &hash);
     // dt_dev_pixelpipe_cache_available() tests for masking mode and returns FALSE in that case
-    cache_available = dt_dev_pixelpipe_cache_available(pipe, hash, bufsize);
+    cache_available = dt_dev_pixelpipe_cache_available(pipe, hash, basichash, bufsize);
   }
   if(cache_available)
   {
@@ -2665,6 +2666,7 @@ gboolean dt_dev_pixelpipe_process(
 {
   pipe->processing = TRUE;
   pipe->nocache = FALSE;
+  pipe->runs++;
   pipe->opencl_enabled = dt_opencl_running();
   pipe->devid = (pipe->opencl_enabled) ? dt_opencl_lock_device(pipe->type)
                                        : -1; // try to get/lock opencl resource

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -94,6 +94,7 @@ typedef struct dt_dev_pixelpipe_t
   dt_dev_pixelpipe_cache_t cache;
   // set to TRUE in order to obsolete old cache entries on next pixelpipe run
   gboolean cache_obsolete;
+  uint64_t runs; // used only for pixelpipe cache statistics
   // input buffer
   float *input;
   // width and height of input buffer


### PR DESCRIPTION
- making sure we always test for basic & full hash
- as the hashes are uint64_t it doesn't make sense to set them to -1, instead to zero which is also treated as an invalid hash
- getting rid of the module names, this is handled much better now via the improved dt_print_pipe()

The hitrate measuring has not given very useful results and has been modified here.

We calculate HITs while checking for an available cacheline when processing the pipe versus pixelpipe runs.
I think this is the best we can do now for checking efficiacy of any strategy of "importance"