### PR TITLE
FilmicRGB optimization

### DIFF
--- a/src/common/gamut_mapping.h
+++ b/src/common/gamut_mapping.h
@@ -1,6 +1,6 @@
 /*
    This file is part of darktable,
-   Copyright (C) 2022 darktable developers.
+   Copyright (C) 2022-2023 darktable developers.
 
    darktable is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -117,15 +117,17 @@ static inline float Ych_max_chroma_without_negatives(const dt_colormatrix_t matr
 
 
 #ifdef _OPENMP
-#pragma omp declare simd uniform(matrix) aligned(in, out:16) aligned(matrix:64)
+#pragma omp declare simd uniform(matrix_trans) aligned(in, out:16) aligned(matrix_trans:64)
 #endif
-static inline void RGB_to_Ych(const dt_aligned_pixel_t in, const dt_colormatrix_t matrix, dt_aligned_pixel_t out)
+static inline void RGB_to_Ych(const dt_aligned_pixel_t in,
+                              const dt_colormatrix_t matrix_trans,
+                              dt_aligned_pixel_t out)
 {
   dt_aligned_pixel_t LMS = { 0.f };
   dt_aligned_pixel_t Yrg = { 0.f };
 
   // go from pipeline RGB to CIE 2006 LMS D65
-  dot_product(in, matrix, LMS);
+  dt_apply_transposed_color_matrix(in, matrix_trans, LMS);
 
   // go from CIE LMS 2006 to Kirk/Filmlight Yrg
   LMS_to_Yrg(LMS, Yrg);
@@ -136,9 +138,11 @@ static inline void RGB_to_Ych(const dt_aligned_pixel_t in, const dt_colormatrix_
 
 
 #ifdef _OPENMP
-#pragma omp declare simd uniform(matrix) aligned(in, out:16) aligned(matrix:64)
+#pragma omp declare simd uniform(matrix_trans) aligned(in, out:16) aligned(matrix_trans:64)
 #endif
-static inline void Ych_to_RGB(const dt_aligned_pixel_t in, const dt_colormatrix_t matrix, dt_aligned_pixel_t out)
+static inline void Ych_to_RGB(const dt_aligned_pixel_t in,
+                              const dt_colormatrix_t matrix_trans,
+                              dt_aligned_pixel_t out)
 {
   dt_aligned_pixel_t LMS = { 0.f };
   dt_aligned_pixel_t Yrg = { 0.f };
@@ -150,7 +154,7 @@ static inline void Ych_to_RGB(const dt_aligned_pixel_t in, const dt_colormatrix_
   Yrg_to_LMS(Yrg, LMS);
 
   // go from CIE LMS 2006 to pipeline RGB
-  dot_product(LMS, matrix, out);
+  dt_apply_transposed_color_matrix(LMS, matrix_trans, out);
 }
 
 

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -15,6 +15,15 @@
    You should have received a copy of the GNU General Public License
    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+/** Note :
+ * we use finite-math-only and fast-math because divisions by zero are manually avoided in the code
+ * fp-contract=fast enables hardware-accelerated Fused Multiply-Add
+**/
+#if defined(__GNUC__)
+#pragma GCC optimize("finite-math-only", "fp-contract=fast", "fast-math", "no-math-errno")
+#endif
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -93,19 +102,6 @@ DT_MODULE_INTROSPECTION(6, dt_iop_filmicrgb_params_t)
  * */
 
 
-/** Note :
- * we use finite-math-only and fast-math because divisions by zero are manually avoided in the code
- * fp-contract=fast enables hardware-accelerated Fused Multiply-Add
- * the rest is loop reorganization and vectorization optimization
- **/
-#if defined(__GNUC__)
-#pragma GCC optimize("unroll-loops", "tree-loop-if-convert", "tree-loop-distribution", "no-strict-aliasing",      \
-                     "loop-interchange", "loop-nest-optimize", "tree-loop-im", "unswitch-loops",                  \
-                     "tree-loop-ivcanon", "ira-loop-pressure", "split-ivs-in-unroller",                           \
-                     "variable-expansion-in-unroller", "split-loops", "ivopts", "predictive-commoning",           \
-                     "tree-loop-linear", "loop-block", "loop-strip-mine", "finite-math-only", "fp-contract=fast", \
-                     "fast-math", "no-math-errno")
-#endif
 
 
 typedef enum dt_iop_filmicrgb_methods_type_t

--- a/src/tests/unittests/iop/test_filmicrgb.c
+++ b/src/tests/unittests/iop/test_filmicrgb.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2020 darktable developers.
+    Copyright (C) 2020-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -244,7 +244,7 @@ static void test_log_tonemapping_v2(void **state)
   ti = testimg_gen_grey_space(TESTIMG_STD_WIDTH);
   for_testimg_pixels_p_xy(ti)
   {
-    float ret = log_tonemapping_v2(p[0], grey, black, dyn_range);
+    float ret = log_tonemapping_v2_1ch(p[0], grey, black, dyn_range);
     TR_DEBUG("%e => %e", p[0], ret);
     float exp = testimg_val_to_log(p[0]);
     if(exp < MIN)

--- a/src/tests/unittests/iop/test_filmicrgb.c
+++ b/src/tests/unittests/iop/test_filmicrgb.c
@@ -263,7 +263,7 @@ static void test_log_tonemapping_v2(void **state)
   ti = testimg_gen_grey_space(TESTIMG_STD_WIDTH);
   for_testimg_pixels_p_xy(ti)
   {
-    float ret = log_tonemapping_v2(p[0], (grey / 2.0f), black, dyn_range);
+    float ret = log_tonemapping_v2_1ch(p[0], (grey / 2.0f), black, dyn_range);
     TR_DEBUG("%e => %e", p[0], ret);
     float exp = testimg_val_to_log(p[0] * 2.0f);  // *2.0 means +1EV
     if(exp < MIN)
@@ -285,7 +285,7 @@ static void test_log_tonemapping_v2(void **state)
   ti = testimg_gen_grey_max_dr();
   for_testimg_pixels_p_xy(ti)
   {
-    float ret = log_tonemapping_v2(p[0], grey, black, dyn_range);
+    float ret = log_tonemapping_v2_1ch(p[0], grey, black, dyn_range);
     TR_DEBUG("{%e, %e, %e, %e} => %e", p[0], p[1], p[2], p[3], ret);
     assert_true(ret >= MIN);
     assert_true(ret <= MAX);
@@ -297,7 +297,7 @@ static void test_log_tonemapping_v2(void **state)
   ti = testimg_gen_grey_max_dr_neg();
   for_testimg_pixels_p_xy(ti)
   {
-    float ret = log_tonemapping_v2(p[0], grey, black, dyn_range);
+    float ret = log_tonemapping_v2_1ch(p[0], grey, black, dyn_range);
     TR_DEBUG("{%e, %e, %e, %e} => %e", p[0], p[1], p[2], p[3], ret);
     assert_true(ret >= MIN);
     assert_true(ret <= MAX);


### PR DESCRIPTION
Improved vectorization, compiler optimizations, and transposed matrices to make multiplications for colorspace conversion vectorizable.  Also reformatted function headers where I was making other changes.
Yields speedups of 10-18% on v3/v4/v5 and 40-45% on v6/v7 (which are much slower to begin with due to the colorspace conversions for gamut clipping).

Passes integration tests, including the new ones in the pending PR in the darktable-tests repo.

