### PR TITLE
Allow w:h entry in bauhaus slider popup, direct user there for custom aspect ratios in Framing module

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -3050,7 +3050,7 @@ static gboolean dt_bauhaus_popup_key_press(GtkWidget *widget, GdkEventKey *event
       if(darktable.bauhaus->keys_cnt + 2 < 64
          && (event->keyval == GDK_KEY_space || event->keyval == GDK_KEY_KP_Space ||              // SPACE
              event->keyval == GDK_KEY_percent ||                                                 // %
-             (event->string[0] >= 40 && event->string[0] <= 57) ||                               // ()+-*/.,0-9
+             (event->string[0] >= 40 && event->string[0] <= 58) ||                               // ()+-*/.,0-9:
              event->keyval == GDK_KEY_asciicircum || event->keyval == GDK_KEY_dead_circumflex || // ^
              event->keyval == GDK_KEY_X || event->keyval == GDK_KEY_x))                          // Xx
       {

--- a/src/common/calculator.c
+++ b/src/common/calculator.c
@@ -112,6 +112,7 @@ static token_t *get_token(parser_state_t *self)
         token->data.operator= O_MULTIPLY;
         return token;
       case '/':
+      case ':':
         self->p++;
         token->type = T_OPERATOR;
         token->data.operator= O_DIVISION;

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -937,7 +937,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->size, _("size of the border in percent of the full image"));
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL(g->aspect, self, NULL, N_("aspect"),
-                               _("select the aspect ratio or right click and type your own (w:h)"),
+                               _("select the aspect ratio (right click on slider below to type your own w:h)"),
                                0, aspect_changed, self,
                                N_("image"),
                                N_("3:1"),
@@ -956,11 +956,11 @@ void gui_init(struct dt_iop_module_t *self)
                                N_("square"),
                                N_("constant border"),
                                N_("custom..."));
-  dt_bauhaus_combobox_set_editable(g->aspect, 1);
+  dt_bauhaus_combobox_set_editable(g->aspect, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), g->aspect, TRUE, TRUE, 0);
 
   g->aspect_slider = dt_bauhaus_slider_from_params(self, "aspect");
-  gtk_widget_set_tooltip_text(g->aspect_slider, _("set the custom aspect ratio"));
+  gtk_widget_set_tooltip_text(g->aspect_slider, _("set the custom aspect ratio (right click to enter number or w:h)"));
 
   g->aspect_orient = dt_bauhaus_combobox_from_params(self, "aspect_orient");
   gtk_widget_set_tooltip_text(g->aspect_orient, _("aspect ratio orientation of the image with border"));


### PR DESCRIPTION
Although setting the dropdown to "non-editable" doesn't prevent the user from typing arbitrary text into the dropdown menu, it won't be displayed once the menu collapses.  Update the tooltips for both the dropdown and slider to direct the user to right-clicking on the slider and entering w:h there for custom aspect ratios.
