### PR TITLE
RFC: right-click hints in slider tooltips

### DIFF
--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -1111,7 +1111,9 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->exposure = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,
                                     dt_bauhaus_slider_from_params(self, N_("exposure")));
-  gtk_widget_set_tooltip_text(g->exposure, _("adjust the exposure correction"));
+  gtk_widget_set_tooltip_text(g->exposure,
+                              _("adjust the exposure correction.  Right-click to\n"
+                                "type a specific value between -18 and +18."));
   dt_bauhaus_slider_set_digits(g->exposure, 3);
   dt_bauhaus_slider_set_format(g->exposure, _(" EV"));
   dt_bauhaus_slider_set_soft_range(g->exposure, -3.0, 4.0);


### PR DESCRIPTION
Given how many users are unaware of the right-click options (and soft vs hard limits) for sliders, I think it would be useful to have hints in the tooltips for some key frequently-used sliders which don't already have long texts in their tooltips.

This PR has an example for the exposure slider in the Exposure module.  Other candidates would be the temperature slider in color calibration (which currently does not have a tooltip), the temperature slider in white balance, the constrast slider in sigmoid, the global vibrance and contrast sliders in colorbalancergb, and similar.  The filmicrgb white/black sliders already have lengthy texts, so we wouldn't want to add the hint there even though those are also heavily used.
