### PR TITLE
po/rework lib header label

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -812,22 +812,22 @@ void dt_image_update_final_size(const dt_imgid_t imgid)
                                     darktable.develop->pipe->iwidth,
                                     darktable.develop->pipe->iheight,
                                     &ww, &hh);
-  }
 
-  dt_image_t *imgtmp = dt_image_cache_get(darktable.image_cache, imgid, 'w');
+    dt_image_t *imgtmp = dt_image_cache_get(darktable.image_cache, imgid, 'w');
 
-  if(ww == imgtmp->final_width
-     && hh == imgtmp->final_height)
-  {
-    dt_cache_release(&darktable.image_cache->cache, imgtmp->cache_entry);
-  }
-  else
-  {
-    imgtmp->final_width = ww;
-    imgtmp->final_height = hh;
-    dt_image_cache_write_release(darktable.image_cache, imgtmp, DT_IMAGE_CACHE_RELAXED);
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_METADATA_UPDATE);
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_IMAGE_CHANGED);
+    if(ww == imgtmp->final_width
+       && hh == imgtmp->final_height)
+    {
+      dt_cache_release(&darktable.image_cache->cache, imgtmp->cache_entry);
+    }
+    else
+    {
+      imgtmp->final_width = ww;
+      imgtmp->final_height = hh;
+      dt_image_cache_write_release(darktable.image_cache, imgtmp, DT_IMAGE_CACHE_RELAXED);
+      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_METADATA_UPDATE);
+      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_IMAGE_CHANGED);
+    }
   }
 }
 

--- a/src/libs/ioporder.c
+++ b/src/libs/ioporder.c
@@ -136,8 +136,14 @@ void update(dt_lib_module_t *self)
 
 static void _image_loaded_callback(gpointer instance, gpointer user_data)
 {
-  dt_lib_module_t *self = (dt_lib_module_t *)user_data;
-  update(self);
+  // only in darkroom, so let's avoid any update when in lighttable
+  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
+
+  if(cv->view(cv) == DT_VIEW_DARKROOM)
+  {
+    dt_lib_module_t *self = (dt_lib_module_t *)user_data;
+    update(self);
+  }
 }
 
 void gui_init(dt_lib_module_t *self)

--- a/src/libs/ioporder.c
+++ b/src/libs/ioporder.c
@@ -32,7 +32,6 @@ typedef struct dt_lib_ioporder_t
 {
   int current_mode;
   GList *last_custom_iop_order;
-  GtkWidget *widget;
 } dt_lib_ioporder_t;
 
 const char *name(dt_lib_module_t *self)
@@ -58,22 +57,6 @@ int position(const dt_lib_module_t *self)
 void update(dt_lib_module_t *self)
 {
   dt_lib_ioporder_t *d = (dt_lib_ioporder_t *)self->data;
-
-  if(!d->widget)
-  {
-    if(!self->expander) return;
-
-    d->widget = gtk_label_new("");
-    g_signal_connect(G_OBJECT(d->widget), "destroy",
-                     G_CALLBACK(gtk_widget_destroyed), &d->widget);
-    gtk_widget_show(d->widget);
-    gtk_box_pack_start(GTK_BOX(dtgtk_expander_get_header(DTGTK_EXPANDER(self->expander))),
-                       d->widget, TRUE, TRUE, 0);
-
-    if(self->arrow)
-      gtk_widget_destroy(self->arrow);
-    self->arrow = NULL;
-  }
 
   const dt_iop_order_t kind =
     dt_ioppr_get_iop_order_list_kind(darktable.develop->iop_order_list);
@@ -107,7 +90,7 @@ void update(dt_lib_module_t *self)
 
       if(!strcmp(iop_order_list, iop_list_text))
       {
-        gtk_label_set_text(GTK_LABEL(d->widget), name);
+        dt_lib_gui_set_label(self, name);
         d->current_mode = index;
         found = TRUE;
         g_free(iop_list_text);
@@ -124,13 +107,13 @@ void update(dt_lib_module_t *self)
     if(!found)
     {
       d->current_mode = DT_IOP_ORDER_CUSTOM;
-      gtk_label_set_text(GTK_LABEL(d->widget), _(dt_iop_order_string(d->current_mode)));
+      dt_lib_gui_set_label(self, _(dt_iop_order_string(d->current_mode)));
     }
   }
   else
   {
     d->current_mode = kind;
-    gtk_label_set_text(GTK_LABEL(d->widget), _(dt_iop_order_string(d->current_mode)));
+    dt_lib_gui_set_label(self, _(dt_iop_order_string(d->current_mode)));
   }
 }
 
@@ -152,8 +135,8 @@ void gui_init(dt_lib_module_t *self)
 
   self->data = (void *)d;
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  self->no_control_widgets = TRUE;
 
-  d->widget = NULL; // initialise in first update when header has been set up
   d->current_mode = -1;
   d->last_custom_iop_order = NULL;
 
@@ -167,9 +150,6 @@ void gui_init(dt_lib_module_t *self)
 
 void gui_cleanup(dt_lib_module_t *self)
 {
-  dt_lib_ioporder_t *d = (dt_lib_ioporder_t *)self->data;
-
-  if(d->widget) gtk_widget_destroy(d->widget);
   free(self->data);
   self->data = NULL;
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
@@ -197,10 +177,7 @@ void gui_reset(dt_lib_module_t *self)
     dt_dev_pixelpipe_rebuild(darktable.develop);
 
     d->current_mode = DT_IOP_ORDER_V30;
-    if(d->widget)
-      gtk_label_set_text(GTK_LABEL(d->widget),
-                         _(dt_iop_order_string(d->current_mode)));
-
+    dt_lib_gui_set_label(self, _(dt_iop_order_string(d->current_mode)));
     g_list_free_full(iop_order_list, free);
   }
 }

--- a/src/libs/lib.h
+++ b/src/libs/lib.h
@@ -110,11 +110,13 @@ typedef struct dt_lib_module_t
   /** does gui need to be updated if visible */
   gboolean gui_uptodate;
 
+  GtkWidget *label;
   GtkWidget *arrow;
   GtkWidget *reset_button;
   GtkWidget *presets_button;
 
   gboolean pref_based_presets;
+  gboolean no_control_widgets;
 } dt_lib_module_t;
 
 void dt_lib_init(dt_lib_t *lib);
@@ -143,6 +145,10 @@ void dt_lib_set_visible(dt_lib_module_t *module,
 /** check if a plugin is to be shown in a given view */
 gboolean dt_lib_is_visible_in_view(dt_lib_module_t *module,
                                    const dt_view_t *view);
+
+/** set module label */
+void dt_lib_gui_set_label(dt_lib_module_t *module,
+                          const char *label);
 
 /** returns the localized plugin name for a given plugin_name. must not be freed. */
 gchar *dt_lib_get_localized_name(const gchar *plugin_name);


### PR DESCRIPTION
Three parts:

1.
    ioporder: Rework the label in module's header.
    
    A new optional label is now used and a generic routine is
    implemented to modify the module's label.

2.
    ioporder: Call update only when in darkroom.
    
    The widget is not in other view and may not be properly initialized.
    
    Fix crash, possible fixes fully #14409.
3.
    image: If it is not possible to get the dimensions, do not update to 0.