### PR TITLE
denoise(profiled) optimizations: matrix mult, nontemporal writes, vectorization

### DIFF
--- a/src/common/eaw.c
+++ b/src/common/eaw.c
@@ -275,14 +275,15 @@ static inline _aligned_pixel add_float4(_aligned_pixel acc, _aligned_pixel newva
 
 #undef SUM_PIXEL_EPILOGUE
 #define SUM_PIXEL_EPILOGUE                                                                                   \
+  dt_aligned_pixel_t det;									             \
   for_each_channel(c)      										     \
   {													     \
     sum[c] /= wgt[c];                                                   				     \
     pcoarse[c] = sum[c];                                                                                     \
-    const float det = (px[c] - sum[c]);									     \
-    pdetail[c] = det;    		                                              			     \
-    sum_sq.v[c] += (det*det);					                                             \
+    det[c] = (px[c] - sum[c]);									             \
+    sum_sq.v[c] += (det[c]*det[c]);					                                     \
   }                                                                       				     \
+  copy_pixel_nontemporal(pdetail, det);                                                                      \
   px += 4;                                                                                                   \
   pdetail += 4;                                                                                              \
   pcoarse += 4;

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -42,6 +42,8 @@
 #include <math.h>
 #include <stdlib.h>
 
+//#define VECTORIZE_POWF
+
 // which version of the non-local means code should be used?  0=old
 // (this file), 1=new (src/common/nlmeans_core.c)
 #define USE_NEW_IMPL_CL 0
@@ -832,8 +834,7 @@ static inline void precondition(const float *const in,
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(buf, npixels, in, sigma2_plus_3_8) \
-  shared(a) \
+  dt_omp_firstprivate(buf, npixels, in, sigma2_plus_3_8, a)       \
   schedule(static)
 #endif
   for(size_t j = 0; j < 4U * npixels; j += 4)
@@ -862,8 +863,7 @@ static inline void backtransform(float *const buf,
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(buf, npixels, sigma2_plus_1_8, sqrt_3_2)   \
-  shared(a) \
+  dt_omp_firstprivate(buf, npixels, sigma2_plus_1_8, sqrt_3_2, a) \
   schedule(static)
 #endif
   for(size_t j = 0; j < 4U * npixels; j += 4)
@@ -923,17 +923,23 @@ static inline void precondition_v2(const float *const in,
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(npixels, buf, in, b, wb) \
-  dt_omp_sharedconst(expon, denom) \
+  dt_omp_firstprivate(npixels, buf, in, b, wb, expon, denom) \
   schedule(static)
 #endif
   for(size_t j = 0; j < 4U * npixels; j += 4)
   {
+    dt_aligned_pixel_t scaled;
+    for_each_channel(c,aligned(in,wb))
+      scaled[c] = MAX(in[j+c] / wb[c] + b, 0.0f);
     dt_aligned_pixel_t precond;
-    for_each_channel(c,aligned(in,buf,wb))
-    {
-      precond[c] = 2.0f * powf(MAX(in[j+c] / wb[c] + b, 0.0f), expon[c]) / denom[c];
-    }
+#ifdef VECTORIZE_POWF
+    dt_vector_powf(scaled, expon, precond);
+#else
+    for_each_channel(c,aligned(scaled,expon))
+      precond[c] = powf(scaled[c], expon[c]);
+#endif
+    for_each_channel(c,aligned(denom))
+      precond[c] = 2.0f * precond[c] / denom[c];
     copy_pixel_nontemporal(buf + j, precond);
   }
   dt_omploop_sfence(); // ensure that nontemporal writes complete before we read the output
@@ -1019,19 +1025,27 @@ static inline void backtransform_v2(float *const buf,
                                      1.0f };
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(npixels, buf, b, bias, wb)   \
-  dt_omp_sharedconst(expon,denom) \
+  dt_omp_firstprivate(npixels, buf, b, bias, wb, expon, denom)        \
   schedule(static)
 #endif
   for(size_t j = 0; j < 4U * npixels; j += 4)
   {
+    dt_aligned_pixel_t z1;
     for_each_channel(c,aligned(buf,wb))
     {
       const float x = MAX(buf[j+c], 0.0f);
       const float delta = x * x + bias;
-      const float z1 = (x + sqrtf(MAX(delta, 0.0f))) / denom[c];
-      buf[j+c] = wb[c] * (powf(z1, expon[c]) - b);
+      z1[c] = (x + sqrtf(MAX(delta, 0.0f))) / denom[c];
     }
+    dt_aligned_pixel_t back;
+#ifdef VECTORIZE_POWF
+    dt_vector_powf(z1, expon, back);
+#else
+    for_each_channel(c)
+      back[c] = powf(z1[c], expon[c]);
+#endif
+    for_each_channel(c,aligned(buf))
+      buf[j+c] = wb[c] * (back[c] - b);
   }
 }
 
@@ -1051,17 +1065,23 @@ static inline void precondition_Y0U0V0(const float *const in,
                                      1.0f };
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(buf, ht, in, wd, b, toY0U0V0_trans) \
-  dt_omp_sharedconst(expon, scale) \
+  dt_omp_firstprivate(buf, ht, in, wd, b, toY0U0V0_trans, expon, scale)      \
   schedule(static)
 #endif
   for(size_t j = 0; j < (size_t)4 * ht * wd; j += 4)
   {
     dt_aligned_pixel_t tmp; // "unused" fourth element enables vectorization
+#ifdef VECTORIZE_POWF
+    dt_aligned_pixel_t clamped;
     for_each_channel(c,aligned(in))
-    {
+      clamped[c] = MAX(in[j+c] + b, 0.0f);
+    dt_vector_powf(clamped, expon, tmp);
+    for_each_channel(c,aligned(scale))
+      tmp[c] *= scale[c];
+#else
+    for_each_channel(c,aligned(in))
       tmp[c] = powf(MAX(in[j+c] + b, 0.0f), expon[c]) * scale[c];
-    }
+#endif
     dt_aligned_pixel_t yuv;
     dt_apply_transposed_color_matrix(tmp, toY0U0V0_trans, yuv);
     copy_pixel_nontemporal(buf + j, yuv);
@@ -1099,13 +1119,21 @@ static inline void backtransform_Y0U0V0(float *const buf,
   {
     dt_aligned_pixel_t rgb = { 0.0f }; // "unused" fourth element enables vectorization
     dt_apply_transposed_color_matrix(buf + j, toRGB_trans, rgb);
+    dt_aligned_pixel_t z1;
     for_each_channel(c,aligned(buf))
     {
       const float x = MAX(rgb[c], 0.0f);
       const float delta = x * x + bias_wb[c];
-      const float z1 = (x + sqrtf(MAX(delta, 0.0f))) * scale[c];
-      buf[j+c] = powf(z1, expon[c]) - b;
+      z1[c] = (x + sqrtf(MAX(delta, 0.0f))) * scale[c];
     }
+#ifdef VECTORIZE_POWF
+    dt_vector_powf(z1, expon, z1);
+#else
+    for_each_channel(c,aligned(expon))
+      z1[c] = powf(z1[c], expon[c]);
+#endif
+    for_each_channel(c,aligned(buf))
+      buf[j+c] = z1[c] - b;
   }
 }
 

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -929,11 +929,14 @@ static inline void precondition_v2(const float *const in,
 #endif
   for(size_t j = 0; j < 4U * npixels; j += 4)
   {
+    dt_aligned_pixel_t precond;
     for_each_channel(c,aligned(in,buf,wb))
     {
-      buf[j+c] = 2.0f * powf(MAX(in[j+c] / wb[c] + b, 0.0f), expon[c]) / denom[c];
+      precond[c] = 2.0f * powf(MAX(in[j+c] / wb[c] + b, 0.0f), expon[c]) / denom[c];
     }
+    copy_pixel_nontemporal(buf + j, precond);
   }
+  dt_omploop_sfence(); // ensure that nontemporal writes complete before we read the output
 }
 
 // this backtransform aims at being a low bias backtransform
@@ -1039,7 +1042,7 @@ static inline void precondition_Y0U0V0(const float *const in,
                                        const float a,
                                        const dt_aligned_pixel_t p,
                                        const float b,
-                                       const dt_colormatrix_t toY0U0V0)
+                                       const dt_colormatrix_t toY0U0V0_trans)
 {
   const dt_aligned_pixel_t expon = { -p[0] / 2 + 1, -p[1] / 2 + 1, -p[2] / 2 + 1, 1.0f };
   const dt_aligned_pixel_t scale = { 2.0f / ((-p[0] + 2) * sqrtf(a)),
@@ -1048,7 +1051,7 @@ static inline void precondition_Y0U0V0(const float *const in,
                                      1.0f };
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(buf, ht, in, wd, b, toY0U0V0) \
+  dt_omp_firstprivate(buf, ht, in, wd, b, toY0U0V0_trans) \
   dt_omp_sharedconst(expon, scale) \
   schedule(static)
 #endif
@@ -1059,17 +1062,11 @@ static inline void precondition_Y0U0V0(const float *const in,
     {
       tmp[c] = powf(MAX(in[j+c] + b, 0.0f), expon[c]) * scale[c];
     }
-    for(int c = 0; c < 3; c++)
-    {
-      float sum = 0.0f;
-      for_each_channel(k,aligned(toY0U0V0))
-      {
-        sum += toY0U0V0[c][k] * tmp[k];
-      }
-      buf[j+c] = sum;
-    }
-    buf[j+3] = 0;
+    dt_aligned_pixel_t yuv;
+    dt_apply_transposed_color_matrix(tmp, toY0U0V0_trans, yuv);
+    copy_pixel_nontemporal(buf + j, yuv);
   }
+  dt_omploop_sfence(); // ensure that nontemporal writes complete before we read the output
 }
 
 static inline void backtransform_Y0U0V0(float *const buf,
@@ -1080,7 +1077,7 @@ static inline void backtransform_Y0U0V0(float *const buf,
                                         const float b,
                                         const float bias,
                                         const dt_aligned_pixel_t wb,
-                                        const dt_colormatrix_t toRGB)
+                                        const dt_colormatrix_t toRGB_trans)
 {
   const dt_aligned_pixel_t bias_wb = { bias * wb[0], bias * wb[1], bias * wb[2], 0.0f };
 
@@ -1095,19 +1092,13 @@ static inline void backtransform_Y0U0V0(float *const buf,
                                      1.0f };
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(buf, ht, wd, b, bias_wb, toRGB, expon, scale)  \
+  dt_omp_firstprivate(buf, ht, wd, b, bias_wb, toRGB_trans, expon, scale)  \
   schedule(static)
 #endif
   for(size_t j = 0; j < (size_t)4 * ht * wd; j += 4)
   {
     dt_aligned_pixel_t rgb = { 0.0f }; // "unused" fourth element enables vectorization
-    for(int k = 0; k < 3; k++)
-    {
-      for_each_channel(c,aligned(toRGB,buf))
-      {
-        rgb[k] += toRGB[k][c] * buf[j+c];
-      }
-    }
+    dt_apply_transposed_color_matrix(buf + j, toRGB_trans, rgb);
     for_each_channel(c,aligned(buf))
     {
       const float x = MAX(rgb[c], 0.0f);
@@ -1411,14 +1402,16 @@ static void process_wavelets(struct dt_iop_module_t *self,
     DT_IOP_DENOISE_PROFILE_P_FULCRUM / powf(DT_IOP_DENOISE_PROFILE_P_FULCRUM, d->shadows);
 
   // conversion to Y0U0V0 space as defined in Secrets of image denoising cuisine
-  dt_colormatrix_t toY0U0V0 = { { 1.0f/3.0f, 1.0f/3.0f, 1.0f/3.0f },
-                                { 0.5f,      0.0f,      -0.5f },
-                                {  0.25f,     -0.5f,     0.25f } };
+  dt_colormatrix_t toY0U0V0 = { { 1.0f/3.0f, 1.0f/3.0f, 1.0f/3.0f, 0.0f },
+                                {  0.5f,      0.0f,    -0.5f,      0.0f },
+                                {  0.25f,    -0.5f,     0.25f,     0.0f },
+                                {  0.0f,      0.0f,     0.0f,      0.0f } };
 
   // "unused" fourth element enables vectorization:
-  dt_colormatrix_t toRGB = { { 0.0f, 0.0f, 0.0f },
-                             { 0.0f, 0.0f, 0.0f },
-                             { 0.0f, 0.0f, 0.0f } };
+  dt_colormatrix_t toRGB = { { 0.0f, 0.0f, 0.0f, 0.0f },
+                             { 0.0f, 0.0f, 0.0f, 0.0f },
+                             { 0.0f, 0.0f, 0.0f, 0.0f },
+                             { 0.0f, 0.0f, 0.0f, 0.0f }};
   set_up_conversion_matrices(toY0U0V0, toRGB, wb);
 
   // more strength in Y0U0V0 in order to get a similar smoothing as in other modes
@@ -1431,6 +1424,13 @@ static void process_wavelets(struct dt_iop_module_t *self,
       toY0U0V0[k][c] /= (d->strength * compensate_strength * in_scale);
       toRGB[k][c] *= (d->strength * compensate_strength * in_scale);
     }
+  // make transposed copies of the conversion matrices for more efficient
+  // vectorized multiplication
+  dt_colormatrix_t toY0U0V0_trans;
+  dt_colormatrix_transpose(toY0U0V0_trans,toY0U0V0);
+  dt_colormatrix_t toRGB_trans;
+  dt_colormatrix_transpose(toRGB_trans,toRGB);
+  
   for_each_channel(i)
     wb[i] *= d->strength * compensate_strength * in_scale;
 
@@ -1452,7 +1452,7 @@ static void process_wavelets(struct dt_iop_module_t *self,
     precondition_Y0U0V0(in, precond, width, height,
                         d->a[1] * compensate_p,
                         p, d->b[1],
-                        toY0U0V0);
+                        toY0U0V0_trans);
   }
 
   debug_dump_PFM(piece, "transformed", precond, width, height, 0);
@@ -1503,7 +1503,7 @@ static void process_wavelets(struct dt_iop_module_t *self,
   else
   {
     backtransform_Y0U0V0(out, width, height, d->a[1] * compensate_p,
-                         p, d->b[1], d->bias - 0.5 * logf(in_scale), wb, toRGB);
+                         p, d->b[1], d->bias - 0.5 * logf(in_scale), wb, toRGB_trans);
   }
 
   dt_free_align(buf);


### PR DESCRIPTION
I've left a compile-time option for whether to use dt_vector_powf or powf() in a loop, as the former changes results slightly though it is faster.  The default is to use powf, which yields ~2% speedup, compared to 5-9%.

Passes tests 0013, 0027, and (new) 0143.
```
denoise(profiled) - wavelets, Y0U0V0 (test 0013)
Thr	Master	PR-vec[*]  	 PR-powf
1	10817.5	10301.3	-4.7%	10598.4	-2.0%
2	5472.20	5196.43	-5.0%	5360.11	-2.0%
4	2792.50	2654.43	-4.9%	2733.82	-2.1%
8	1444.03	1374.99	-4.7%	1414.67	-2.0%
16	 779.87	 744.40	-4.5%	 766.01	-1.7%
32	 468.23	 449.11	-4.1%	 456.08	-2.6%
64	 353.54	 337.49	-4.5%	 341.76	-3.3%

denoise(profiled) - wavelets, RGB (test 0143)
Thr	Master	PR-vec		PR-powf
1	6804.78	6146.60	-9.6%	6669.11	-1.9%
2	3446.80	ܵ3120.85	-9.4%	3382.79	-1.8%
4	1765.88	1603.28	-9.2%	1735.25	-1.7%
8	 935.59	 853.97	-8.7%	 917.54	-1.9%
16	 527.28	 481.41	-8.6%	 513.48	-2.0%
32	 336.25	 305.21	-9.2%	 323.97	-3.6%
64	 276.53	 255.61	-7.7%	 263.71	-4.0%
```
[*] PR-vec = use dt_vector_powf, PR-powf = use powf() loop.