### PR TITLE
work around GPhoto2 crashing dt by disabling device scans during imports

### DIFF
--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -1003,7 +1003,7 @@ void *dt_update_cameras_thread(void *ptr)
   }
   while(dt_control_running())
   {
-    g_usleep(100000);
+    g_usleep(250000);  // 1/4 second
     dt_camctl_t *camctl = (dt_camctl_t *)darktable.camctl;
 
     const dt_view_t *cv = (darktable.view_manager)
@@ -1013,13 +1013,20 @@ void *dt_update_cameras_thread(void *ptr)
     if(camctl)
     {
       if((camctl->import_ui == FALSE) && (cv && (cv->view(cv) == DT_VIEW_LIGHTTABLE)))
+//TODO:  && import module is expanded and visible
       {
         camctl->ticker += 1;
         if((camctl->ticker & camctl->tickmask) == 0)
+        {
+          // we've rolled over the current scan interval, so check for
+          // new/removed cameras and decide how long to wait until the
+          // next scan based on the result: one second if there was a
+          // change, eight seconds if not
           camctl->tickmask = (dt_camctl_update_cameras(camctl)) ? 0x03 : 0x1F;
+        }
       }
       else
-        camctl->tickmask = 3; // want to be responsive right after other modes are done
+        camctl->tickmask = 3; // want to be responsive right after other modes are done - scan in one second
     }
   }
   return 0;

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1961,17 +1961,21 @@ static void _lib_import_from_callback(GtkWidget *widget, dt_lib_module_t* self)
 {
   dt_lib_import_t *d = (dt_lib_import_t *)self->data;
   d->import_case = (widget == GTK_WIDGET(d->import_inplace)) ? DT_IMPORT_INPLACE : DT_IMPORT_COPY;
+#ifdef HAVE_GPHOTO2
   // on some systems, GPhoto2 is somewhat prone to crashing while
   // scanning for new devices; this manifests as a crash during long
   // import sessions.  So disable the scan while we're importing, even
   // though we aren't using GPhoto2 to do the importing
   struct dt_camctl_t *camctl = (dt_camctl_t *)darktable.camctl;
   camctl->import_ui = TRUE;
+#endif
   _import_from_dialog_new(self);
   _import_from_dialog_run(self);
   _import_from_dialog_free(self);
+#ifdef HAVE_GPHOTO2
   // OK to resume periodic scans for new GPhoto2 devices
   camctl->import_ui = FALSE;
+#endif
 }
 
 #ifdef HAVE_GPHOTO2

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1961,9 +1961,17 @@ static void _lib_import_from_callback(GtkWidget *widget, dt_lib_module_t* self)
 {
   dt_lib_import_t *d = (dt_lib_import_t *)self->data;
   d->import_case = (widget == GTK_WIDGET(d->import_inplace)) ? DT_IMPORT_INPLACE : DT_IMPORT_COPY;
+  // on some systems, GPhoto2 is somewhat prone to crashing while
+  // scanning for new devices; this manifests as a crash during long
+  // import sessions.  So disable the scan while we're importing, even
+  // though we aren't using GPhoto2 to do the importing
+  dt_camctl_t *camctl = (dt_camctl_t *)darktable.camctl;
+  camctl->import_ui = TRUE;
   _import_from_dialog_new(self);
   _import_from_dialog_run(self);
   _import_from_dialog_free(self);
+  // OK to resume periodic scans for new GPhoto2 devices
+  camctl->import_ui = FALSE;
 }
 
 #ifdef HAVE_GPHOTO2

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1965,7 +1965,7 @@ static void _lib_import_from_callback(GtkWidget *widget, dt_lib_module_t* self)
   // scanning for new devices; this manifests as a crash during long
   // import sessions.  So disable the scan while we're importing, even
   // though we aren't using GPhoto2 to do the importing
-  dt_camctl_t *camctl = (dt_camctl_t *)darktable.camctl;
+  struct dt_camctl_t *camctl = (dt_camctl_t *)darktable.camctl;
   camctl->import_ui = TRUE;
   _import_from_dialog_new(self);
   _import_from_dialog_run(self);


### PR DESCRIPTION
...and by slowing down the scan rate.

This commit changes the interval for the background scan for added/removed cameras while lighttable view is active from every 3.2 seconds to every 8 seconds.  In various circumstances, the code was using an 0.4 second interval for responsiveness; that is now 1.0 seconds.

In addition, the existing mechanism to suppress scans while importing from camera (using GPhoto2) is also used to suppress scans while the add-to-library/copy-and-import window is open.

These changes mitigate the reported crashes on MacOS Ventura caused by a broken dylib loader. (#13221)

A more complete fix would also disable the scan whenever the import module is collapsed or hidden (e.g. left panel collapsed).

See also #14314.
