### PR TITLE
Fix "RGB parade" spelling in config to avoid histogram mode resetting

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2957,7 +2957,7 @@
       <enum>
         <option>vectorscope</option>
         <option>waveform</option>
-        <option>rgb parade</option>
+        <option>RGB parade</option>
         <option>histogram</option>
       </enum>
     </type>


### PR DESCRIPTION
Fixes #14428. It was a stupid thinko to intentionally not change the spelling in the config option. The lesson is that even seemingly simple changes should not be proposed in PR when you are tired. Another thought with a fresh mind is always worth it.
