### PR TITLE
Details mask refactoring and fixes

### DIFF
--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -671,17 +671,11 @@ void dt_masks_blur_9x9(float *const src,
                        const int width,
                        const int height,
                        const float sigma);
-void dt_masks_calc_rawdetail_mask(float *const src,
-                                  float *const out,
-                                  float *const tmp,
-                                  const int width,
-                                  const int height,
+gboolean dt_masks_calc_rawdetail_mask(dt_dev_detail_mask_t *details,
+                                  float *const src,
                                   const dt_aligned_pixel_t wb);
-void dt_masks_calc_detail_mask(float *const src,
+gboolean dt_masks_calc_detail_mask(dt_dev_detail_mask_t *details,
                                float *const out,
-                               float *const tmp,
-                               const int width,
-                               const int height,
                                const float threshold,
                                const gboolean detail);
 

--- a/src/develop/masks/detail.c
+++ b/src/develop/masks/detail.c
@@ -430,14 +430,18 @@ int dt_masks_blur_fast(float *const restrict src,
   return 6;
 }
 
-void dt_masks_calc_rawdetail_mask(float *const restrict src,
-                                  float *const restrict mask,
-                                  float *const restrict tmp,
-                                  const int width,
-                                  const int height,
+gboolean dt_masks_calc_rawdetail_mask(dt_dev_detail_mask_t *details,
+                                  float *const restrict src,
                                   const dt_aligned_pixel_t wb)
 {
-  const size_t msize = width * height;
+  const int width = details->roi.width;
+  const int height = details->roi.height;
+  float *mask = details->data;
+
+  const size_t msize = (size_t)width * height;
+  float *tmp = dt_alloc_align_float(msize);
+  if(!tmp) return TRUE;
+
 #ifdef _OPENMP
   #pragma omp parallel for simd default(none) \
   dt_omp_firstprivate(tmp, src, msize, wb) \
@@ -474,6 +478,8 @@ void dt_masks_calc_rawdetail_mask(float *const restrict src,
     }
   }
   dt_masks_extend_border(mask, width, height, 1);
+  dt_free_align(tmp);
+  return FALSE;
 }
 
 static inline float _calcBlendFactor(float val, float threshold)
@@ -484,15 +490,16 @@ static inline float _calcBlendFactor(float val, float threshold)
     return 1.0f / (1.0f + dt_fast_expf(16.0f - (16.0f / threshold) * val));
 }
 
-void dt_masks_calc_detail_mask(float *const restrict src,
+gboolean dt_masks_calc_detail_mask(dt_dev_detail_mask_t *details,
                                float *const restrict out,
-                               float *const restrict tmp,
-                               const int width,
-                               const int height,
                                const float threshold,
                                const gboolean detail)
 {
-  const size_t msize = width * height;
+  const size_t msize = (size_t) details->roi.width * details->roi.height;
+  float *tmp = dt_alloc_align_float(msize);
+  if(!tmp) return TRUE;
+
+  float *src = details->data;
 #ifdef _OPENMP
   #pragma omp parallel for simd default(none) \
   dt_omp_firstprivate(src, tmp, msize, threshold, detail, out) \
@@ -503,7 +510,9 @@ void dt_masks_calc_detail_mask(float *const restrict src,
     const float blend = CLIP(_calcBlendFactor(src[idx], threshold));
     tmp[idx] = detail ? blend : 1.0f - blend;
   }
-  dt_masks_blur_9x9(tmp, out, width, height, 2.0f);
+  dt_masks_blur_9x9(tmp, out, details->roi.width, details->roi.height, 2.0f);
+  dt_free_align(tmp);
+  return FALSE;
 }
 #undef FAST_BLUR_5
 #undef FAST_BLUR_9

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -212,8 +212,12 @@ void dt_dev_pixelpipe_cache_fullhash(
 {
   uint64_t hash = *basichash = dt_dev_pixelpipe_cache_basichash(imgid, pipe, position);
   // also include roi data
-  const char *str = (const char *)roi;
+  char *str = (char *)roi;
   for(size_t i = 0; i < sizeof(dt_iop_roi_t); i++)
+    hash = ((hash << 5) + hash) ^ str[i];
+
+  str = (char *)&pipe->details.hash;
+  for(size_t i = 0; i < sizeof(uint64_t); i++)
     hash = ((hash << 5) + hash) ^ str[i];
   *fullhash = hash;
 }

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -82,6 +82,13 @@ typedef enum dt_dev_pixelpipe_change_t
   DT_DEV_PIPE_ZOOMED = 1 << 3 // zoom event, preview pipe does not need changes
 } dt_dev_pixelpipe_change_t;
 
+typedef struct dt_dev_detail_mask_t
+{
+  dt_iop_roi_t roi;
+  uint64_t hash;
+  float *data;
+} dt_dev_detail_mask_t;
+
 /**
  * this encapsulates the pixelpipe.
  * a develop module will need several of these:
@@ -133,13 +140,12 @@ typedef struct dt_dev_pixelpipe_t
 
   // the data for the luminance mask are kept in a buffer written by demosaic or rawprepare
   // as we have to scale the mask later we keep size at that stage
-  float *rawdetail_mask_data;
-  int detail_width;
-  int detail_height;
   gboolean want_detail_mask;
+  struct dt_dev_detail_mask_t details;
 
   // we have to keep track of the next processing module to use an iop cacheline with high priority
   gboolean next_important_module;
+
   // avoid cached data for processed module
   gboolean nocache;
 
@@ -254,6 +260,8 @@ void dt_dev_pixelpipe_synch_top(dt_dev_pixelpipe_t *pipe, struct dt_develop_t *d
 // force a rebuild of the pipe, needed when a module order is changed for example
 void dt_dev_pixelpipe_rebuild(struct dt_develop_t *dev);
 
+// switch on details mask processing
+void dt_dev_pixelpipe_usedetails(dt_dev_pixelpipe_t *pipe);
 // process region of interest of pixels. returns TRUE if pipe was altered during processing.
 gboolean dt_dev_pixelpipe_process(dt_dev_pixelpipe_t *pipe,
                              struct dt_develop_t *dev,

--- a/src/iop/demosaicing/vng.c
+++ b/src/iop/demosaicing/vng.c
@@ -631,7 +631,7 @@ static int process_vng_cl(
       if(err != CL_SUCCESS) goto error;
     }
 
-    if(piece->pipe->want_detail_mask)
+    if(piece->pipe->want_detail_mask && !(data->demosaicing_method & DT_DEMOSAIC_DUAL))
       dt_dev_write_rawdetail_mask_cl(piece, dev_aux, roi_in, TRUE);
 
     if(scaled)


### PR DESCRIPTION
While "playing" in the history list there could be wrong details mask data. (offset wrong)

This pr keeps all details-ralated data in a struct `dt_dev_detail_mask_t` holding the used input roi, a pointer to mask-data and a hash.

Doing so allowed some code refactoring, details related functions use the struct instead of passed arguments.

Implemented dt_dev_pixelpipe_usedetails(), it switches mask on and tests if already in use, if not invalidating pixelpipe cache.

The full hash for the pixelpipe cacheline includes the details-hash too.

A bugfix: while dual-demosaicing the details mask was wronfully written by the softened vng which was just bad.

A performance fix: While dual-demosaicing we don't have to re-calculate full details but can use the already available scharr mask.