### PR TITLE
filmicrgb: further optimize highlight reconsruction

### DIFF
--- a/src/common/bspline.h
+++ b/src/common/bspline.h
@@ -1,3 +1,21 @@
+/*
+   This file is part of darktable,
+   Copyright (C) 2021-2023 darktable developers.
+
+   darktable is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   darktable is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 #pragma once
 
 #include "common/darktable.h"

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -30,12 +30,9 @@
 #include "bauhaus/bauhaus.h"
 #include "common/colorspaces_inline_conversions.h"
 #include "common/chromatic_adaptation.h"
-#include "common/darktable.h"
 #include "common/bspline.h"
-#include "common/dwt.h"
 #include "common/gamut_mapping.h"
 #include "common/image.h"
-#include "common/iop_profile.h"
 #include "common/opencl.h"
 #include "control/control.h"
 #include "develop/develop.h"
@@ -43,7 +40,6 @@
 #include "develop/imageop_gui.h"
 #include "develop/imageop_math.h"
 #include "develop/noise_generator.h"
-#include "develop/openmp_maths.h"
 #include "develop/tiling.h"
 #include "dtgtk/button.h"
 #include "dtgtk/drawingarea.h"
@@ -59,7 +55,6 @@
 #include "gui/draw.h"
 
 #include <assert.h>
-#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2121,8 +2121,10 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   const gboolean run_fast = !data->enable_highlight_reconstruction || piece->pipe->type & DT_DEV_PIXELPIPE_FAST;
 
   // without reconstruction: in + out + 1ch_mask
-  // with reconstruction: in + out + 2 * tmp + 2 * LF + temp + ratios + 1ch_mask
-  tiling->factor = run_fast ? 2.25f : 8.25f;
+  // with reconstruction: in + out + reconst + inpaint + 2 * scales + temp + 1ch_mask
+  // with HQ reconstruction: in + out + reconst + inpaint + tmp + 2 * scales + temp + ratios + 1ch_mask + 1ch_norms
+  const float hq = data->high_quality_reconstruction > 0 ? 1.25f : 0.0f;
+  tiling->factor = run_fast ? 2.25f : (7.25f + hq);
   tiling->factor_cl = run_fast ? 9.0f : 9.0f;
 
   tiling->maxbuf = 1.0f;

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1265,28 +1265,6 @@ static inline void init_reconstruct(const float *const restrict in,
   dt_omploop_sfence();  // ensure that nontemporal write complete before we attempt to read the output
 }
 
-
-static inline void wavelets_detail_level(const float *const detail,
-                                         const float *const restrict LF,
-                                         float *const HF,
-                                         const size_t width,
-                                         const size_t height)
-{
-#ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
-  dt_omp_firstprivate(width, height, HF, LF, detail)   \
-  schedule(simd:static) \
-  aligned(HF, LF, detail : 64)
-#endif
-  for(size_t k = 0; k < height * width; k++)
-  {
-    dt_aligned_pixel_t pix_out;
-    for_each_channel(c, aligned(detail, LF))
-      pix_out[c] = detail[4*k + c] - LF[4*k + c];
-    copy_pixel(HF + 4*k, pix_out);
-  }
-}
-
 static int get_scales(const dt_iop_roi_t *roi_in, const dt_dev_pixelpipe_iop_t *const piece)
 {
   /* How many wavelets scales do we need to compute at current zoom level ?


### PR DESCRIPTION
Reduce memory traffic by adding nontemporal writes and merging phases to eliminate an intermediate buffer (tweak tiling->factor accordingly).  Some other code cleanup.

Gains an additional 8% over the previous speedups when doing reconstruction and passes all integration tests using filmicrgb, particularly 0037.
```
Thr	prev	Master		this-PR		overall
1	6171.58	3983.58	-35.4%	3652.72	 -8.3%	-40.8%
2	3199.25	2121.93	-33.6%	1928.45	 -9.1%	-39.7%	
4	1681.62	1164.45	-30.7%	1066.96	 -8.3%	-36.5%
8	 980.49	 759.19	-22.5%	 703.88	 -7.2%	-28.2%
16	 765.19	 628.13	-17.9%	 576.79	 -8.8%	-24.6%
32	 715.03	 605.32	-15.3%	 549.03	 -9.2%	-23.2%
64	 829.34	 698.77	-15.7%	 622.63	-10.8%	-24.9%
```
