### PR TITLE
don't mark multi-level action path as translatable

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2528,7 +2528,7 @@ void dt_iop_gui_init_blendif(GtkWidget *blendw, dt_iop_module_t *module)
        _("pick GUI color from image\n"
          "ctrl+click or right-click to select an area"));
     gtk_widget_set_name(bd->colorpicker, "keep-active");
-    dt_action_define_iop(module, N_("blend`pickers"), N_("show color"), bd->colorpicker, &dt_action_def_toggle);
+    dt_action_define_iop(module, "blend`pickers", N_("show color"), bd->colorpicker, &dt_action_def_toggle);
 
     bd->colorpicker_set_values =
       dt_color_picker_new(module, DT_COLOR_PICKER_AREA | DT_COLOR_PICKER_IO, header);
@@ -2540,7 +2540,7 @@ void dt_iop_gui_init_blendif(GtkWidget *blendw, dt_iop_module_t *module)
        _("set the range based on an area from the image\n"
          "drag to use the input image\n"
          "ctrl+drag to use the output image"));
-    dt_action_define_iop(module, N_("blend`pickers"), N_("set range"), bd->colorpicker_set_values, &dt_action_def_toggle);
+    dt_action_define_iop(module, "blend`pickers", N_("set range"), bd->colorpicker_set_values, &dt_action_def_toggle);
 
     GtkWidget *btn = dt_iop_togglebutton_new(module, "blend`tools",
                                              N_("invert all channel's polarities"), NULL,


### PR DESCRIPTION
This isn't supposed to work anyway; the translations are picked up from the same section names being marked for translation elsewhere (same as with "blend\`tools" and "blend\`shapes") and "blend" is just a marker string that gets mapped to the `<blending>` virtual module.