### PR TITLE
grain.c: optimize

### DIFF
--- a/src/iop/grain.c
+++ b/src/iop/grain.c
@@ -533,7 +533,6 @@ void process(struct dt_iop_module_t *self,
       out[0] = in[0] + dt_lut_lookup_2d_1c(data->grain_lut, (noise * strength) * GRAIN_LIGHTNESS_STRENGTH_SCALE, in[0] / 100.0f);
       out[1] = in[1];
       out[2] = in[2];
-//      out[3] = in[3];
 
       out += 4;
       in += 4;


### PR DESCRIPTION
Change data types and literal types to avoid implicit typecasts.
Precompute modulus on lookup table.
Constify, and a bit of code reformatting.

Passes test 0059 in about 15% less time.  I also looked at adding fast-math, finite-math-only, fp-contract=fast, no-math-errno optimization options; those got another 3% speedup but cause the test to fail with max dE 3.5 and most pixels changed (actually, the same results as testing with build-type Release instead of RelWithDebInfo, just even faster than Release without those optimization flags).

Because of the relatively small extra gain at the cost of changing the output, I have not included the optimization flags in the PR, but present the benchmark results below.
```
Thr	Master	PR		fastmath
1	1407.55	1194.64	-15.1%	1144.32	-18.7%
2	 705.26	 598.10	-15.1%	 573.06	-18.7%
4	 353.00	 299.02	-15.2%	 287.41	-18.5%
8	 176.47	 149.91	-15.0%	 143.90	-18.4%
16	  88.54	  75.19	-15.0%	  72.61	-18.0%
32	  45.50	  38.38	-15.6%	  37.11	-18.4%
64	  32.14	  25.08	-21.9%	  24.50	-23.7%
```
