### PR TITLE
Some details mask related fixes

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -551,11 +551,11 @@ void dt_develop_blend_process(struct dt_iop_module_t *self,
       {
 #ifdef _OPENMP
   #pragma omp parallel for simd default(none) aligned(mask, raster_mask:64)\
-        dt_omp_firstprivate(obuffsize, mask, opacity, raster_mask) \
+        dt_omp_firstprivate(obuffsize, mask, raster_mask) \
         schedule(static)
 #endif
         for(size_t i = 0; i < obuffsize; i++)
-          mask[i] = (1.0 - raster_mask[i]) * opacity;
+          mask[i] = 1.0 - raster_mask[i];
       }
       else
       {
@@ -1069,12 +1069,11 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self,
       if(d->raster_mask_invert)
       {
 #ifdef _OPENMP
-  #pragma omp parallel for default(none) \
-        dt_omp_firstprivate(obuffsize, mask, opacity) \
-        shared(raster_mask)
+  #pragma omp parallel for simd default(none) aligned(mask, raster_mask:64)\
+        dt_omp_firstprivate(obuffsize, mask, raster_mask)
 #endif
         for(size_t i = 0; i < obuffsize; i++)
-          mask[i] = (1.0f - raster_mask[i]) * opacity;
+          mask[i] = 1.0f - raster_mask[i];
       }
       else
       {

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -798,7 +798,7 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self,
 
   float blurmat[13];
   dt_masks_blur_9x9_coeff(blurmat, 2.0f);
-  cl_mem dev_blurmat = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 13, blurmat);
+  cl_mem dev_blurmat = dt_opencl_copy_host_to_device_constant(devid, sizeof(blurmat), blurmat);
   if(dev_blurmat != NULL)
   {
     err = dt_opencl_enqueue_kernel_2d_args

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -276,8 +276,13 @@ static void _refine_with_detail_mask(struct dt_iop_module_t *self,
   float *warp_mask = NULL;
 
   dt_dev_pixelpipe_t *p = piece->pipe;
-  if(p->details.data == NULL) return;
-
+  if(p->details.data == NULL)
+  {
+    dt_print_pipe(DT_DEBUG_PIPE,
+       "refine_detail_mask on CPU",
+       piece->pipe, self, roi_in, roi_out, "no mask data available\n");
+    return;
+  }
   const int iwidth  = p->details.roi.width;
   const int iheight = p->details.roi.height;
   const int owidth  = roi_out->width;
@@ -748,7 +753,7 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self,
 {
   if(feqf(level, 0.0f, 1e-6)) return;
 
-  const int detail = (level > 0.0f);
+  const gboolean detail = (level > 0.0f);
   const float threshold = _detail_mask_threshold(level, detail);
   float *lum = NULL;
   cl_mem tmp = NULL;
@@ -757,12 +762,15 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self,
   cl_int err = DT_OPENCL_DEFAULT_ERROR;
 
   dt_dev_pixelpipe_t *p = piece->pipe;
-  if(p->details.data == NULL) return;
-
+  if(p->details.data == NULL)
+  {
+    dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_OPENCL,
+       "refine_detail_mask on GPU",
+       piece->pipe, self, roi_in, roi_out, "no detail data available\n");
+    return;
+  }
   const int iwidth  = p->details.roi.width;
   const int iheight = p->details.roi.height;
-  const int owidth  = roi_out->width;
-  const int oheight = roi_out->height;
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_OPENCL,
        "refine_detail_mask on GPU",
        piece->pipe, self, roi_in, roi_out, "\n");
@@ -776,97 +784,57 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self,
 
   err = dt_opencl_write_host_to_device(devid, p->details.data, tmp,
                                        iwidth, iheight, sizeof(float));
-  if(err != CL_SUCCESS)
+  if(err != CL_SUCCESS) goto error;
+
+  err = dt_opencl_enqueue_kernel_2d_args
+        (devid, darktable.opencl->blendop->kernel_read_mask, iwidth, iheight,
+         CLARG(out), CLARG(tmp), CLARG(iwidth), CLARG(iheight));
+  if(err != CL_SUCCESS) goto error;
+
+  err = dt_opencl_enqueue_kernel_2d_args
+        (devid, darktable.opencl->blendop->kernel_calc_blend, iwidth, iheight,
+          CLARG(out), CLARG(blur), CLARG(iwidth), CLARG(iheight), CLARG(threshold), CLARG(detail));
+  if(err != CL_SUCCESS) goto error;
+
+  float blurmat[13];
+  dt_masks_blur_9x9_coeff(blurmat, 2.0f);
+  cl_mem dev_blurmat = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 13, blurmat);
+  if(dev_blurmat != NULL)
   {
-    dt_print(DT_DEBUG_OPENCL,
-             "[refine_detail_mask_cl] write rawdetail_mask_data: %s\n",
-             cl_errstr(err));
+    err = dt_opencl_enqueue_kernel_2d_args
+          (devid, darktable.opencl->blendop->kernel_mask_blur, iwidth, iheight,
+           CLARG(blur), CLARG(out), CLARG(iwidth), CLARG(iheight), CLARG(dev_blurmat));
+    dt_opencl_release_mem_object(dev_blurmat);
+    if(err != CL_SUCCESS) goto error;
+
+    err = dt_opencl_enqueue_kernel_2d_args
+          (devid, darktable.opencl->blendop->kernel_write_mask, iwidth, iheight,
+           CLARG(out), CLARG(tmp), CLARG(iwidth), CLARG(iheight));
+    if(err != CL_SUCCESS) goto error;
+
+    err = dt_opencl_read_host_from_device(devid, lum, tmp, iwidth, iheight, sizeof(float));
+    if(err != CL_SUCCESS) goto error;
+  }
+  else
+  {
+    err = DT_OPENCL_DEFAULT_ERROR;
     goto error;
   }
-
-  {
-    const int kernel = darktable.opencl->blendop->kernel_read_mask;
-    err = dt_opencl_enqueue_kernel_2d_args(devid, kernel, iwidth, iheight,
-      CLARG(out), CLARG(tmp), CLARG(iwidth), CLARG(iheight));
-    if(err != CL_SUCCESS)
-    {
-      dt_print(DT_DEBUG_OPENCL,
-               "[refine_detail_mask_cl] kernel_read_mask: %s\n",
-               cl_errstr(err));
-      goto error;
-    }
-  }
-
-  {
-    const int kernel = darktable.opencl->blendop->kernel_calc_blend;
-    err = dt_opencl_enqueue_kernel_2d_args(devid, kernel, iwidth, iheight,
-                                           CLARG(out), CLARG(blur),
-                                           CLARG(iwidth), CLARG(iheight),
-                                           CLARG(threshold), CLARG(detail));
-    if(err != CL_SUCCESS)
-    {
-      dt_print(DT_DEBUG_OPENCL,
-               "[refine_detail_mask_cl] kernel_calc_blend: %s\n",
-               cl_errstr(err));
-      goto error;
-    }
-  }
-
-  {
-    float blurmat[13];
-    dt_masks_blur_9x9_coeff(blurmat, 2.0f);
-    cl_mem dev_blurmat = NULL;
-    dev_blurmat =
-      dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 13, blurmat);
-    if(dev_blurmat != NULL)
-    {
-      const int clkernel = darktable.opencl->blendop->kernel_mask_blur;
-      err = dt_opencl_enqueue_kernel_2d_args(devid, clkernel, iwidth, iheight,
-        CLARG(blur), CLARG(out), CLARG(iwidth), CLARG(iheight), CLARG(dev_blurmat));
-      dt_opencl_release_mem_object(dev_blurmat);
-      if(err != CL_SUCCESS)
-      {
-        dt_print(DT_DEBUG_OPENCL,
-                 "[refine_detail_mask_cl] kernel_mask_blur: %s\n",
-                 cl_errstr(err));
-        goto error;
-      }
-    }
-    else
-    {
-      dt_opencl_release_mem_object(dev_blurmat);
-      goto error;
-    }
-  }
-
-  {
-    const int kernel = darktable.opencl->blendop->kernel_write_mask;
-    err = dt_opencl_enqueue_kernel_2d_args(devid, kernel, iwidth, iheight,
-      CLARG(out), CLARG(tmp), CLARG(iwidth), CLARG(iheight));
-    if(err != CL_SUCCESS)
-    {
-      dt_print(DT_DEBUG_OPENCL,
-               "[refine_detail_mask_cl] kernel_write_mask: %s\n",
-               cl_errstr(err));
-      goto error;
-    }
-  }
-
-  err = dt_opencl_read_host_from_device(devid, lum, tmp, iwidth, iheight, sizeof(float));
-  if(err != CL_SUCCESS) goto error;
 
   dt_opencl_release_mem_object(tmp);
   dt_opencl_release_mem_object(blur);
   dt_opencl_release_mem_object(out);
-  tmp = blur = out = NULL;
 
-  // here we have the slightly blurred full detail available
+  // here we have the slightly blurred full detail mask available
   float *warp_mask = dt_dev_distort_detail_mask(p, lum, self);
-  if(warp_mask == NULL) goto error;
+  if(warp_mask == NULL)
+  {
+    err = DT_OPENCL_DEFAULT_ERROR;
+    goto error;
+  }
   dt_free_align(lum);
-  lum = NULL;
 
-  const size_t msize = (size_t)owidth * oheight;
+  const size_t msize = (size_t)roi_out->width * roi_out->height;
 #ifdef _OPENMP
   #pragma omp parallel for simd default(none) \
   dt_omp_firstprivate(mask, warp_mask, msize) \
@@ -880,6 +848,10 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self,
 
   error:
   dt_control_log(_("detail mask CL blending problem"));
+  dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_OPENCL,
+       "refine_with_detail_mask on GPU",
+        piece->pipe, self, roi_in, roi_out, "OpenCL error: %s\n", cl_errstr(err));
+
   dt_free_align(lum);
   dt_opencl_release_mem_object(tmp);
   dt_opencl_release_mem_object(blur);

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -551,11 +551,11 @@ void dt_develop_blend_process(struct dt_iop_module_t *self,
       {
 #ifdef _OPENMP
   #pragma omp parallel for simd default(none) aligned(mask, raster_mask:64)\
-        dt_omp_firstprivate(obuffsize, mask, raster_mask) \
+        dt_omp_firstprivate(obuffsize, opacity, mask, raster_mask) \
         schedule(static)
 #endif
         for(size_t i = 0; i < obuffsize; i++)
-          mask[i] = 1.0 - raster_mask[i];
+          mask[i] = (1.0f - raster_mask[i]) * opacity;
       }
       else
       {
@@ -1070,10 +1070,10 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self,
       {
 #ifdef _OPENMP
   #pragma omp parallel for simd default(none) aligned(mask, raster_mask:64)\
-        dt_omp_firstprivate(obuffsize, mask, raster_mask)
+        dt_omp_firstprivate(obuffsize, opacity, mask, raster_mask)
 #endif
         for(size_t i = 0; i < obuffsize; i++)
-          mask[i] = 1.0f - raster_mask[i];
+          mask[i] = (1.0f - raster_mask[i]) * opacity;
       }
       else
       {

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -25,6 +25,7 @@
 #include "dtgtk/button.h"
 #include "dtgtk/gradientslider.h"
 #include "gui/color_picker_proxy.h"
+#include "common/imagebuf.h"
 
 #define DEVELOP_BLEND_VERSION (12)
 

--- a/src/develop/masks/detail.c
+++ b/src/develop/masks/detail.c
@@ -495,9 +495,19 @@ gboolean dt_masks_calc_detail_mask(dt_dev_detail_mask_t *details,
                                const float threshold,
                                const gboolean detail)
 {
+  if((details->roi.width <= 0)
+     || (details->roi.height <= 0)
+     || !details->data
+     || (details->hash == 0))
+    return TRUE;
+
   const size_t msize = (size_t) details->roi.width * details->roi.height;
   float *tmp = dt_alloc_align_float(msize);
-  if(!tmp) return TRUE;
+  if(!tmp)
+  {
+    memset(out, 0, msize * sizeof(float));
+    return TRUE;
+  }
 
   float *src = details->data;
 #ifdef _OPENMP
@@ -510,7 +520,9 @@ gboolean dt_masks_calc_detail_mask(dt_dev_detail_mask_t *details,
     const float blend = CLIP(_calcBlendFactor(src[idx], threshold));
     tmp[idx] = detail ? blend : 1.0f - blend;
   }
-  dt_masks_blur_9x9(tmp, out, details->roi.width, details->roi.height, 2.0f);
+  // for very small images the blurring should be slightly less to have an effect at all
+  const float blurring = (MIN(details->roi.width, details->roi.height) < 500) ? 1.5f : 2.0f;
+  dt_masks_blur_9x9(tmp, out, details->roi.width, details->roi.height, blurring);
   dt_free_align(tmp);
   return FALSE;
 }

--- a/src/develop/masks/detail.c
+++ b/src/develop/masks/detail.c
@@ -505,7 +505,7 @@ gboolean dt_masks_calc_detail_mask(dt_dev_detail_mask_t *details,
   float *tmp = dt_alloc_align_float(msize);
   if(!tmp)
   {
-    memset(out, 0, msize * sizeof(float));
+    dt_iop_image_fill(out, 0.0f, details->roi.width, details->roi.height, 1);
     return TRUE;
   }
 

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -3136,7 +3136,6 @@ gboolean dt_dev_write_rawdetail_mask_cl(dt_dev_pixelpipe_iop_t *piece,
   dt_print_pipe(DT_DEBUG_ALWAYS,
            "write detail mask on GPU", p, NULL, roi_in, NULL,
            "couldn't write detail mask: %s\n", cl_errstr(err));
-  dt_dev_clear_rawdetail_mask(p);
   dt_opencl_release_mem_object(out);
   dt_opencl_release_mem_object(tmp);
   dt_dev_clear_rawdetail_mask(p);

--- a/src/iop/demosaicing/dual.c
+++ b/src/iop/demosaicing/dual.c
@@ -65,8 +65,8 @@ static void dual_demosaic(
     piece->pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
 #ifdef _OPENMP
   #pragma omp parallel for simd default(none) \
-  dt_omp_firstprivate(blend, rgb_data, vng_image, width, height) \
-  schedule(simd:static) aligned(blend, vng_image, rgb_data : 64)
+  dt_omp_firstprivate(blend, rgb_data, width, height) \
+  schedule(simd:static) aligned(blend, rgb_data : 64)
 #endif
     for(int idx = 0; idx < width * height; idx++)
     {

--- a/src/iop/demosaicing/vng.c
+++ b/src/iop/demosaicing/vng.c
@@ -631,7 +631,7 @@ static int process_vng_cl(
       if(err != CL_SUCCESS) goto error;
     }
 
-    if(piece->pipe->want_detail_mask && !(data->demosaicing_method & DT_DEMOSAIC_DUAL))
+    if(piece->pipe->want_detail_mask && data->demosaicing_method == DT_IOP_DEMOSAIC_VNG)
       dt_dev_write_rawdetail_mask_cl(piece, dev_aux, roi_in, TRUE);
 
     if(scaled)


### PR DESCRIPTION
Be more defensive if no details mask data are available or can't be processed
- possibly write mask data to zero
- avoid processing at all if no valid hash or size of detail roi

Some improvements of debugging output via dt_print_pipe

An internal improvement is related to processing of very small images like previews. We do some blurring of the detail mask while blending, the strength of this blurring has been decreased for such data to have an effect at all.