### PR TITLE
Fix metadata loss in metadata editor

### DIFF
--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -498,7 +498,7 @@ static gboolean _lost_focus(GtkWidget *textview,
   }
   else
   {
-    _write_metadata(textview, self);
+    _write_metadata(GTK_TEXT_VIEW(textview), self);
   }
   
   return FALSE;

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -496,6 +496,11 @@ static gboolean _lost_focus(GtkWidget *textview,
     _set_text_buffer(buffer, _("<leave unchanged>"));
     _text_set_italic(GTK_TEXT_VIEW(textview), TRUE);
   }
+  else
+  {
+    _write_metadata(textview, self);
+  }
+  
   return FALSE;
 }
 

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -571,9 +571,9 @@ static void _mouse_over_image_callback(gpointer instance,
 {
   dt_lib_metadata_t *d = (dt_lib_metadata_t *)self->data;
   // if editing don't lose the current entry
-  const int32_t img = dt_control_get_mouse_over_id();
+  const dt_imgid_t imgid = dt_control_get_mouse_over_id();
 
-  if(img == 0)
+  if(!dt_is_valid_imgid(imgid))
   { // exits thumbnails zone
     for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
       _restore_edited_textview(i, d);

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -504,6 +504,13 @@ static gboolean _lost_focus(GtkWidget *textview,
   return FALSE;
 }
 
+int mouse_leave(struct dt_lib_module_t *self)
+{
+  _write_metadata(NULL, self);
+  
+  return 0;
+}
+
 int position(const dt_lib_module_t *self)
 {
   return 510;

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -573,7 +573,7 @@ static void _mouse_over_image_callback(gpointer instance,
   // if editing don't lose the current entry
   const int32_t img = dt_control_get_mouse_over_id();
 
-  if(img == -1)
+  if(img == 0)
   { // exits thumbnails zone
     for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
       _restore_edited_textview(i, d);


### PR DESCRIPTION
fixes #13829 

To avoid data loss the metadata entered in a textview is written when the textview loses focus.

