### PR TITLE
[maintenance] Enhance appimage script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ on:
         - "data/style/**"
         - "data/themes/**"
         - "data/watermarks/**"
+        - "tools/*"
         - "**.md"
   pull_request:
     branches:
@@ -33,6 +34,7 @@ on:
         - "data/style/**"
         - "data/themes/**"
         - "data/watermarks/**"
+        - "tools/*"
         - "**.md"
 
 permissions:

--- a/tools/appimage-build-script.sh
+++ b/tools/appimage-build-script.sh
@@ -13,17 +13,18 @@ fi
 rm -rf {build,AppDir}
 mkdir {build,AppDir}
 
-cd build
-
 # For AppImage we have to install app in /usr subfolder of the AppDir
-
 export DESTDIR=../AppDir
-cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DBINARY_PACKAGE_BUILD=1 -DDONT_USE_INTERNAL_LUA=Off
-cmake --build . --target install --parallel $(nproc)
+# The CLI parameters of this script will be passed verbatim to build.sh.
+# This allows you to conveniently manage the enabling/disabling of various features.
+# For example, you can easily build darktable with support for ImageMagick instead of GraphicsMagick
+# by running this script with the parameters `--disable-graphicsmagick --enable-imagemagick`
+./build.sh --build-dir ./build/ --prefix /usr --build-type Release $@ --install -- "-DBINARY_PACKAGE_BUILD=1 -DDONT_USE_INTERNAL_LUA=Off -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
 
 # Sanitize path to executable in org.darktable.darktable.desktop (it will be handled by AppImage).
 # In fact, most desktop files do not include the full path to the program in the Exec field
 # (relying on the OS's path lookup functionality). When we'll do the same, this hack can be removed.
+cd build
 sed -i 's/\/usr\/bin\///' ../AppDir/usr/share/applications/org.darktable.darktable.desktop
 
 # Since linuxdeploy is itself an AppImage, we don't rely on it being installed on the build system, but download it every time


### PR DESCRIPTION
Usability improvement to darktable AppImage build script. We now use build.sh in this script to be able to use its CLI options.

Also, disabling CI launch on script changes in the tools directory is piggybacked in this PR. These scripts aren't used or compiled in CI, so running CI for them is just a waste of time.