### PR TITLE
monochrome.c and bilateral.c: optimize

### DIFF
--- a/src/common/bilateral.h
+++ b/src/common/bilateral.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2020 darktable developers.
+    Copyright (C) 2012-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -26,6 +26,7 @@ typedef struct dt_bilateral_t
   int width, height;
   int numslices, sliceheight, slicerows; //height--in input image, rows--in grid
   float sigma_s, sigma_r;
+  float sigma_s_inv, sigma_r_inv;  // reciprocals of sigma_s and sigma_r to avoid divisions
   float *buf __attribute__((aligned(64)));
 } __attribute__((packed)) dt_bilateral_t;
 


### PR DESCRIPTION
Eliminate some divisions by precomputing reciprocals and  tweak OpenMP pragmas both in the monochrome module proper and in the bilateral filter it uses.

Passes test 0017 in up to 12% less time (saturates memory bus at around 8 threads, so improvement drops rather early).
```
Thr	Master	PR
1	260.01	227.83	-12.3%
2	131.60	115.69	-12.0%
4	 68.74	 62.38	 -9.2%
8	 40.49	 37.85	 -6.5%
16	 27.66	 26.67	 -3.5%
32	 22.57	 21.99	 -2.5%
64	 24.84	 24.25	 -2.3%
```
Because the bilateral filter is faster now, numerous other modules will see a bit of speedup: local contrast, shadows & highlights, lowpass, perspective correction, color mapping, globaltonemap, censorize, perspective correction.  I benchmarked shadows&highlights using the bilateral filter as an example:
```
Thr	Master	PR
1	438.56	415.65	-5.2%
2	219.84	209.91	-4.5%
4	110.05	104.72	-4.8%
8	 56.47	 53.39	-5.4%
16	 28.73	 26.93	-6.2%
32	 17.57	 17.00	-3.2%
64	 18.60	 18.40	-1.0%
```
I ran all of the integration tests using the above modules with both master and the PR.  Results were identical on 0002, 0015, 0017, 0018, 0021, 0031, 0035, 0074, 0075, 0076, 0090, 0101, 0102, 0110, 0111, 0112, and 0137.  Max dE increased marginally on 0016 (0.90468 to 1.06059) and 0019 (1.09748 to 1.10978).
