### PR TITLE
[GUI] Remove a capital letter that does not fit the style

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1309,7 +1309,7 @@
     <type>bool</type>
     <default>true</default>
     <shortdescription>middle mouse button zooms to 200%</shortdescription>
-    <longdescription>when clicking the middle mouse button to zoom, the zoom level will cycle through 100%, 200% and then back to fit the screen. Otherwise it switches between fit to screen and 100% and the 'ctrl' key can be used to control the zoom level.</longdescription>
+    <longdescription>when clicking the middle mouse button to zoom, the zoom level will cycle through 100%, 200% and then back to fit the screen. otherwise it switches between fit to screen and 100% and the 'ctrl' key can be used to control the zoom level.</longdescription>
   </dtconfig>
   <dtconfig prefs="darkroom" section="modules">
     <name>channel_display</name>


### PR DESCRIPTION
I really don't like to offer this kind of PR, because starting a sentence with a lowercase letter after the period of the previous sentence looks very eccentric. But that's the current style, and even more I hate the inconsistency in the interface.