### PR TITLE
lens: fix dng knot calculation

### DIFF
--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1722,7 +1722,7 @@ static int _init_coeffs_md(const dt_image_t *img,
 
     for(int i = 0; i < nc; i++)
     {
-      const float r = (float) i / (float) (nc);
+      const float r = (float) i / (float) (nc - 1);
       knots[i] = r;
       if(cor_rgb) cor_rgb[0][i] = cor_rgb[1][i] = cor_rgb[2][i] = 1.0f;
       if(vig)     vig[i] = 1.0f;


### PR DESCRIPTION
The current interpolation function doesn't extrapolate out of bounds points but returns the first/last value.

without this patch, with nc = 16 (MAXKNOTS = 16), r is calculated as:

for(int i = 0; i < nc; i++)
    const float r = (float) i / (float) (nc);

so it'll span from 0 to 15/16 (0.9375)

All the point between 0.9375 and 1 will get the same value (value at 0.9375).

This will create bad/strange distortion corrections at the corners with barrel distortions.

With this fix the knots will span from 0 to 1.
