### PR TITLE
Update hidden module button sensitivity on shortcut

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -237,6 +237,8 @@ static float _action_process_button(gpointer target,
 {
   if(!gtk_widget_get_realized(target)) gtk_widget_realize(target);
 
+  dt_lib_gui_update(g_object_get_data(G_OBJECT(target), "module"));
+
   if(DT_PERFORM_ACTION(move_size) && gtk_widget_is_sensitive(target))
   {
     if(effect != DT_ACTION_EFFECT_ACTIVATE
@@ -4750,6 +4752,7 @@ GtkWidget *dt_action_button_new(dt_lib_module_t *self,
     if(accel_key && (self->actions.type != DT_ACTION_TYPE_IOP_INSTANCE
                      || darktable.control->accel_initialising))
       dt_shortcut_register(ac, 0, 0, accel_key, mods);
+    g_object_set_data(G_OBJECT(button), "module", self);
   }
 
   return button;

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -822,10 +822,7 @@ static gboolean _lib_draw_callback(GtkWidget *widget,
                                    gpointer cr,
                                    dt_lib_module_t *self)
 {
-  if(!self->gui_uptodate && self->gui_update)
-    self->gui_update(self);
-
-  self->gui_uptodate = TRUE;
+  dt_lib_gui_update(self);
 
   return FALSE;
 }
@@ -834,6 +831,15 @@ void dt_lib_gui_queue_update(dt_lib_module_t *module)
 {
   module->gui_uptodate = FALSE;
   gtk_widget_queue_draw(module->widget);
+}
+
+void dt_lib_gui_update(dt_lib_module_t *module)
+{
+  if(module && module->gui_update && !module->gui_uptodate)
+  {
+    module->gui_update(module);
+    module->gui_uptodate = TRUE;
+  }
 }
 
 static void dt_lib_init_module(void *m)

--- a/src/libs/lib.h
+++ b/src/libs/lib.h
@@ -131,6 +131,7 @@ void dt_lib_gui_set_expanded(dt_lib_module_t *module,
 gboolean dt_lib_gui_get_expanded(dt_lib_module_t *module);
 /** queue plugin gui to be updated if visible */
 void dt_lib_gui_queue_update(dt_lib_module_t *module);
+void dt_lib_gui_update(dt_lib_module_t *module);
 
 extern const struct dt_action_def_t dt_action_def_lib;
 


### PR DESCRIPTION
fixes #14453

Since #14187 the status of buttons isn't updated when the module they are in is collapsed, since they are not visible anyway. But shortcuts check their status so they need to be updated before possibly ignoring the shortcut.