### PR TITLE
borders.c: Allow w:h entry in bauhaus popup, direct user there for custom aspect ratios

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -3050,7 +3050,7 @@ static gboolean dt_bauhaus_popup_key_press(GtkWidget *widget, GdkEventKey *event
       if(darktable.bauhaus->keys_cnt + 2 < 64
          && (event->keyval == GDK_KEY_space || event->keyval == GDK_KEY_KP_Space ||              // SPACE
              event->keyval == GDK_KEY_percent ||                                                 // %
-             (event->string[0] >= 40 && event->string[0] <= 57) ||                               // ()+-*/.,0-9
+             (event->string[0] >= 40 && event->string[0] <= 58) ||                               // ()+-*/.,0-9:
              event->keyval == GDK_KEY_asciicircum || event->keyval == GDK_KEY_dead_circumflex || // ^
              event->keyval == GDK_KEY_X || event->keyval == GDK_KEY_x))                          // Xx
       {

--- a/src/common/calculator.c
+++ b/src/common/calculator.c
@@ -37,6 +37,7 @@ typedef enum operators_t
   O_DIVISION,
   O_MODULO,
   O_POWER,
+  O_RATIO,
   O_LEFTROUND,
   O_RIGHTROUND,
 } operators_t;
@@ -125,6 +126,11 @@ static token_t *get_token(parser_state_t *self)
         self->p++;
         token->type = T_OPERATOR;
         token->data.operator= O_POWER;
+        return token;
+      case ':':
+        self->p++;
+        token->type = T_OPERATOR;
+        token->data.operator= O_RATIO;
         return token;
       case '(':
         self->p++;
@@ -220,7 +226,9 @@ static float parse_multiplicative_expression(parser_state_t *self)
   {
     const operators_t operator= self->token->data.operator;
 
-    if(operator!= O_MULTIPLY &&operator!= O_DIVISION &&operator!= O_MODULO) return left;
+    if(operator != O_MULTIPLY && operator != O_DIVISION && operator != O_MODULO
+      && operator != O_RATIO)
+      return left;
 
     free(self->token);
     self->token = get_token(self);
@@ -233,6 +241,8 @@ static float parse_multiplicative_expression(parser_state_t *self)
       left /= right;
     else if(operator== O_MODULO)
       left = fmodf(left, right);
+    else if(operator == O_RATIO)
+      left = MAX(left,right) / MIN(left,right);
   }
 
   return left;
@@ -343,6 +353,7 @@ float dt_calculator_solve(const float x, const char *formula)
       //       case O_DIVISION:
       //       case O_MODULO:
       //       case O_POWER:
+      //       case O_RATIO:
       //         operator = self->token->data.operator;
       //         free(self->token);
       //         self->token = get_token(self);
@@ -362,6 +373,7 @@ float dt_calculator_solve(const float x, const char *formula)
   //     case O_DIVISION: result = x / res; break;
   //     case O_MODULO: result = fmodf(x, res); break;
   //     case O_POWER: result = powf(x, res); break;
+  //     case O_RATIO: result = max(x,res) / min(X,res); break;
   //     default: break;
   //   }
 

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -58,8 +58,8 @@ typedef enum dt_iop_orientation_t
 
 static const float _aspect_ratios[]
   = { DT_IOP_BORDERS_ASPECT_IMAGE_VALUE,
-      3.0f, 95.0f / 33.0f, 2.0f, 16.0f / 9.0f, 5.0f / 3.0f, PHI, 3.0f / 2.0f,
-      297.0f / 210.0f, M_SQRT2, 7.0f / 5.0f, 4.0f / 3.0f, 14.0f / 11.0f,
+      3.0f, 95.0f / 33.0f, 2.39f, 2.0f, 16.0f / 9.0f, 5.0f / 3.0f, 14.0f / 8.5f, PHI, 3.0f / 2.0f,
+      297.0f / 210.0f, M_SQRT2, 7.0f / 5.0f, 4.0f / 3.0f, 11.0f / 8.5f, 14.0f / 11.0f,
       5.0f / 4.0f, 1.0f, DT_IOP_BORDERS_ASPECT_CONSTANT_VALUE };
 static const float _pos_h_ratios[] = { 0.5f, 1.0f / 3.0f, 3.0f / 8.0f, 5.0f / 8.0f, 2.0f / 3.0f };
 static const float _pos_v_ratios[] = { 0.5f, 1.0f / 3.0f, 3.0f / 8.0f, 5.0f / 8.0f, 2.0f / 3.0f };
@@ -937,20 +937,23 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->size, _("size of the border in percent of the full image"));
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL(g->aspect, self, NULL, N_("aspect"),
-                               _("select the aspect ratio or right click and type your own (w:h)"),
+                               _("select the aspect ratio (right click on slider below to type your own w:h)"),
                                0, aspect_changed, self,
                                N_("image"),
                                N_("3:1"),
                                N_("95:33"),
+                               N_("Cinemascope 2.39:1"),
                                N_("2:1"),
                                N_("16:9"),
                                N_("5:3"),
+                               N_("US Legal 8.5x14"),
                                N_("golden cut"),
                                N_("3:2 (4x6, 10x15cm)"),
                                N_("A4"),
                                N_("DIN"),
                                N_("7:5"),
                                N_("4:3"),
+                               N_("US Letter 8.5x11"),
                                N_("14:11"),
                                N_("5:4 (8x10)"),
                                N_("square"),
@@ -960,7 +963,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), g->aspect, TRUE, TRUE, 0);
 
   g->aspect_slider = dt_bauhaus_slider_from_params(self, "aspect");
-  gtk_widget_set_tooltip_text(g->aspect_slider, _("set the custom aspect ratio"));
+  gtk_widget_set_tooltip_text(g->aspect_slider, _("set the custom aspect ratio (right click to enter number or w:h)"));
 
   g->aspect_orient = dt_bauhaus_combobox_from_params(self, "aspect_orient");
   gtk_widget_set_tooltip_text(g->aspect_orient, _("aspect ratio orientation of the image with border"));

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -58,8 +58,8 @@ typedef enum dt_iop_orientation_t
 
 static const float _aspect_ratios[]
   = { DT_IOP_BORDERS_ASPECT_IMAGE_VALUE,
-      3.0f, 95.0f / 33.0f, 2.39f, 2.0f, 16.0f / 9.0f, 5.0f / 3.0f, 14.0f / 8.5f, PHI, 3.0f / 2.0f,
-      297.0f / 210.0f, M_SQRT2, 7.0f / 5.0f, 4.0f / 3.0f, 11.0f / 8.5f, 14.0f / 11.0f,
+      3.0f, 95.0f / 33.0f, 2.39f, 2.0f, 16.0f / 9.0f, 5.0f / 3.0f, 14.0f / 8.5f, PHI, 16.0f / 10.0f,
+      3.0f / 2.0f, 297.0f / 210.0f, M_SQRT2, 7.0f / 5.0f, 4.0f / 3.0f, 11.0f / 8.5f, 14.0f / 11.0f,
       5.0f / 4.0f, 1.0f, DT_IOP_BORDERS_ASPECT_CONSTANT_VALUE };
 static const float _pos_h_ratios[] = { 0.5f, 1.0f / 3.0f, 3.0f / 8.0f, 5.0f / 8.0f, 2.0f / 3.0f };
 static const float _pos_v_ratios[] = { 0.5f, 1.0f / 3.0f, 3.0f / 8.0f, 5.0f / 8.0f, 2.0f / 3.0f };
@@ -948,6 +948,7 @@ void gui_init(struct dt_iop_module_t *self)
                                N_("5:3"),
                                N_("US Legal 8.5x14"),
                                N_("golden cut"),
+                               N_("16:10"),
                                N_("3:2 (4x6, 10x15cm)"),
                                N_("A4"),
                                N_("DIN"),
@@ -959,7 +960,7 @@ void gui_init(struct dt_iop_module_t *self)
                                N_("square"),
                                N_("constant border"),
                                N_("custom..."));
-  dt_bauhaus_combobox_set_editable(g->aspect, 1);
+  dt_bauhaus_combobox_set_editable(g->aspect, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), g->aspect, TRUE, TRUE, 0);
 
   g->aspect_slider = dt_bauhaus_slider_from_params(self, "aspect");

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -942,7 +942,7 @@ void gui_init(struct dt_iop_module_t *self)
                                N_("image"),
                                N_("3:1"),
                                N_("95:33"),
-                               N_("Cinemascope 2.39:1"),
+                               N_("CinemaScope 2.39:1"),
                                N_("2:1"),
                                N_("16:9"),
                                N_("5:3"),


### PR DESCRIPTION
Take 2.  Loses the automatic orientation change but avoids all the attendant messiness encountered in #14414 from trying to handle aspect ratios < 1.  When the user enters **w:h**, the computed ratio will always be at least 1.0 because the larger of w&h will be divided by the smaller (in contrast to entering w/h). 

This PR also adds three additional predefined aspect ratios (Cinemascope, US Letter, US Legal).
