### PR TITLE
box filters: tune optimization flags, tweak OpenMP directives

### DIFF
--- a/src/common/box_filters.c
+++ b/src/common/box_filters.c
@@ -16,6 +16,10 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#ifdef __GNUC__
+#pragma GCC optimize ("finite-math-only", "no-math-errno", "fp-contract=fast", "fast-math")
+#endif
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -29,10 +33,6 @@
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
 
-#ifdef __GNUC__
-#pragma GCC optimize ("finite-math-only")
-#endif
-
 static void _blur_horizontal_1ch(float *const restrict buf,
     const int height,
     const int width,
@@ -42,8 +42,7 @@ static void _blur_horizontal_1ch(float *const restrict buf,
 {
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(radius, height, width, padded_size) \
-  dt_omp_sharedconst(buf, scanlines) \
+  dt_omp_firstprivate(radius, height, width, padded_size, buf, scanlines) \
   schedule(static)
 #endif
   for(int y = 0; y < height; y++)
@@ -106,8 +105,7 @@ static void _blur_horizontal_2ch(float *const restrict buf,
 {
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(radius, height, width, padded_size)   \
-  dt_omp_sharedconst(buf, scanlines) \
+  dt_omp_firstprivate(radius, height, width, padded_size, buf, scanlines) \
   schedule(static)
 #endif
   for(int y = 0; y < height; y++)
@@ -384,8 +382,7 @@ static void _blur_horizontal_4ch(float *const restrict buf,
 {
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(radius, height, width, padded_size) \
-  dt_omp_sharedconst(buf, scanlines) \
+  dt_omp_firstprivate(radius, height, width, padded_size, buf, scanlines) \
   schedule(static)
 #endif
   for(int y = 0; y < height; y++)
@@ -929,9 +926,7 @@ static void _blur_vertical_1ch(float *const restrict buf,
 {
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(radius, height, width, padded_size) \
-  shared(darktable) \
-  dt_omp_sharedconst(buf, scanlines) \
+  dt_omp_firstprivate(radius, height, width, padded_size, buf, scanlines) \
   schedule(static)
 #endif
   for(int x = 0; x < width; x += 16)
@@ -1022,8 +1017,7 @@ static void box_mean_vert_1ch_Kahan(float *const buf,
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(width, height, radius, padded_size) \
-  dt_omp_sharedconst(buf, scratch_buf) \
+  dt_omp_firstprivate(width, height, radius, padded_size, buf, scratch_buf) \
   schedule(static)
 #endif
   for(size_t col = 0; col < width; col += 16)
@@ -1060,8 +1054,7 @@ static void dt_box_mean_4ch_Kahan(float *const buf,
     float *const restrict scanlines = dt_alloc_perthread_float(4*width,&padded_size);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(width, height, radius, padded_size) \
-  dt_omp_sharedconst(buf, scanlines) \
+  dt_omp_firstprivate(width, height, radius, padded_size, buf, scanlines) \
   schedule(static)
 #endif
     for(size_t row = 0; row < height; row++)
@@ -1306,8 +1299,7 @@ static void box_max_1ch(float *const buf,
   float *const restrict scratch_buffers = dt_alloc_perthread_float(scratch_size,&allocsize);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(w, width, height, buf, allocsize) \
-  dt_omp_sharedconst(scratch_buffers) \
+  dt_omp_firstprivate(w, width, height, buf, allocsize, scratch_buffers) \
   schedule(static)
 #endif
   for(size_t row = 0; row < height; row++)
@@ -1318,8 +1310,7 @@ static void box_max_1ch(float *const buf,
   }
 #ifdef _OPENMP
 #pragma omp parallel for default(none)           \
-  dt_omp_firstprivate(w, width, height, buf, allocsize, eff_height) \
-  dt_omp_sharedconst(scratch_buffers) \
+  dt_omp_firstprivate(w, width, height, buf, allocsize, eff_height, scratch_buffers) \
   schedule(static)
 #endif
   for(int col = 0; col < (width & ~15); col += 16)
@@ -1466,8 +1457,7 @@ static void box_min_1ch(float *const buf,
   float *const restrict scratch_buffers = dt_alloc_perthread_float(scratch_size,&allocsize);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(w, width, height, buf, allocsize) \
-  dt_omp_sharedconst(scratch_buffers) \
+  dt_omp_firstprivate(w, width, height, buf, allocsize, scratch_buffers) \
   schedule(static)
 #endif
   for(size_t row = 0; row < height; row++)
@@ -1478,8 +1468,7 @@ static void box_min_1ch(float *const buf,
   }
 #ifdef _OPENMP
 #pragma omp parallel for default(none)           \
-  dt_omp_firstprivate(w, width, height, buf,allocsize, eff_height) \
-  dt_omp_sharedconst(scratch_buffers) \
+  dt_omp_firstprivate(w, width, height, buf,allocsize, eff_height, scratch_buffers) \
   schedule(static)
 #endif
   for(size_t col = 0; col < (width & ~15); col += 16)


### PR DESCRIPTION
(Sort-of follow-up to #13876.) Box filters are used by the hazeremoval, highpass, bloom, and soften IOPs and by guided filters.  Adding the fast-math option got a big boost on single-channel box mean (while creating minimal difference in output); everything else I tried tweaking was within measurement error, though I left in the switch from declaring pointer variables `shared` to declaring them `firstprivate` in OpenMP directives.  The four-channel box mean used by Soften got very little improvement, with differences barely above measurement error.

Passes tests 0026, 0028, 0050, and 0051.  Because of the large number of memory transfers done by the filters, the performance improvement drops rapidly as more threads are added, but this PR does get 31-32% improvement on highpass and bloom running on four threads, and 5% on haze removal at four threads from improved optimizations by the compiler.

```
haze removal (test 0026)   [1-channel box min / box max]
Thr	Master	PR
1	1208.65	1108.20	-8.3%
2	 688.73	 645.32	-6.3%
4	 404.90	 383.47	-5.2%
8	 266.71	 251.36	-5.7%
16	 194.06	 191.26	-1.4%
32	 180.40	 177.82	-1.4%
64	 222.00	 221.91	-0.0%

highpass (test 0028)	[1-channel box mean]
Thr	Master	PR
1	235.81	140.45	-40.4%
2	127.54	 81.99	-35.7%
4	 69.35	 47.24	-31.8%
8	 43.18	 32.02	-25.8%
16	 31.49	 25.36	-19.4%
32	 25.53	 23.15	 -9.3%
64	 32.05	 32.64	 +1.8%

bloom (test 0050)	[1-channel box mean]
Thr	Master	PR
1	252.95	163.47	-35.3%
2	133.87	 87.09	-34.9%
4	 71.56	 48.39	-32.3%
8	 42.23	 30.47	-27.8%
16	 29.51	 23.91	-18.9%
32	 24.71	 23.16	 -6.2%
64	 28.59	 28.12	 -1.6%

soften (test 0051)	[4-channel box mean]
Thr	Master	PR
1	851.59	857.10	+0.6%
2	448.79	442.42	-1.4%
4	239.36	238.62	-0.3%
8	129.11	128.41	-0.5%
16	 90.47	 89.86	-0.6%
32	 81.51	 80.54	-1.1%
64	 96.87	 95.44	-1.4%
```