### PR TITLE
Redesign pixelpipe cache importance

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1036,6 +1036,8 @@ static void _dev_add_history_item_ext(
       dev->preview2_pipe->changed |= DT_DEV_PIPE_TOP_CHANGED;
     }
   }
+  if((module->enabled) && (!no_image))
+    module->iopcache_hint = TRUE;
 }
 
 const dt_dev_history_item_t *dt_dev_get_history_item(dt_develop_t *dev, const char *op)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -391,7 +391,6 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module,
   module->multi_priority = 0;
   module->multi_name_hand_edited = FALSE;
   module->iop_order = 0;
-  module->cache_next_important = FALSE;
   for(int k = 0; k < 3; k++)
   {
     module->picked_color[k] = module->picked_output_color[k] = 0.0f;
@@ -412,6 +411,7 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module,
     g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, g_free);
   module->raster_mask.sink.source = NULL;
   module->raster_mask.sink.id = INVALID_MASKID;
+  module->iopcache_hint = FALSE;
 
   // only reference cached results of dlopen:
   module->module = so->module;

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -132,9 +132,7 @@ typedef enum dt_iop_flags_t
   IOP_FLAGS_ALLOW_FAST_PIPE = 1 << 12,   // Module can work with a fast pipe
   IOP_FLAGS_UNSAFE_COPY = 1 << 13,       // Unsafe to copy as part of history
   IOP_FLAGS_GUIDES_SPECIAL_DRAW = 1 << 14, // handle the grid drawing directly
-  IOP_FLAGS_GUIDES_WIDGET = 1 << 15,       // require the guides widget
-  IOP_FLAGS_CACHE_IMPORTANT_NOW = 1 << 16, // hints for higher priority in iop cache
-  IOP_FLAGS_CACHE_IMPORTANT_NEXT = 1 << 17
+  IOP_FLAGS_GUIDES_WIDGET = 1 << 15       // require the guides widget
 } dt_iop_flags_t;
 
 /** status of a module*/
@@ -316,6 +314,9 @@ typedef struct dt_iop_module_t
   GtkWidget *guides_toggle;
   GtkWidget *guides_combo;
 
+  /** Last user action changed any module parameter via history? */
+  gboolean iopcache_hint;
+
   /** flag in case the module has troubles (bad settings) - if TRUE,
    * show a warning sign next to module label */
   gboolean has_trouble;
@@ -337,8 +338,6 @@ typedef struct dt_iop_module_t
                         void *const o,
                         const struct dt_iop_roi_t *const roi_in,
                         const struct dt_iop_roi_t *const roi_out);
-  // hint for higher io cache priority
-  gboolean cache_next_important;
   // introspection related data
   gboolean have_introspection;
 } dt_iop_module_t;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -341,7 +341,6 @@ void dt_dev_pixelpipe_cleanup(dt_dev_pixelpipe_t *pipe)
   pipe->output_backbuf_width = 0;
   pipe->output_backbuf_height = 0;
   pipe->output_imgid = NO_IMGID;
-  pipe->next_important_module = FALSE;
 
   if(pipe->forms)
   {
@@ -1344,27 +1343,6 @@ static gboolean _pixelpipe_process_on_CPU(
     return FALSE;
 }
 
-static inline gboolean _check_good_pipe(dt_dev_pixelpipe_t *pipe)
-{
-  return (pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW))
-         && (pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_NONE);
-}
-
-static inline gboolean _check_module_next_important(dt_dev_pixelpipe_t *pipe,
-                                                    dt_iop_module_t *module)
-{
-  if(!_check_good_pipe(pipe)) return FALSE;
-  return ((module->flags() & IOP_FLAGS_CACHE_IMPORTANT_NEXT)
-          || module->cache_next_important);
-}
-
-static inline gboolean _check_module_now_important(dt_dev_pixelpipe_t *pipe,
-                                                   dt_iop_module_t *module)
-{
-  if(!_check_good_pipe(pipe)) return FALSE;
-  return (module->flags() & IOP_FLAGS_CACHE_IMPORTANT_NOW);
-}
-
 #ifdef HAVE_OPENCL
 static inline gboolean _opencl_pipe_isok(dt_dev_pixelpipe_t *pipe)
 {
@@ -1593,13 +1571,8 @@ static gboolean _dev_pixelpipe_process_rec(
   if((pipe->type & DT_DEV_PIXELPIPE_FULL)
       && module
       && (pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_NONE))
-  {
     important = (dt_iop_module_is(module->so, "gamma"));
-    important |= _check_module_now_important(pipe, module);
-    // we might have a hint from the previous module for being important
-    important |= pipe->next_important_module;
-  }
-  pipe->next_important_module = FALSE;
+
   dt_dev_pixelpipe_cache_get(pipe, basichash, hash, bufsize,
                              output, out_format, module, important);
 
@@ -2177,9 +2150,9 @@ static gboolean _dev_pixelpipe_process_rec(
       /* finally check, if we were successful */
       if(success_opencl)
       {
-        /* Nice, everything went fine */
+        /* Nice, everything went fine
 
-        /* Copying device buffers back to host memory is an expensive
+           Copying device buffers back to host memory is an expensive
            operation but is required for the iop cache.  As the gpu
            memory is very restricted we can't use that for a cache.
            The iop cache hit rate is much more important for the UI
@@ -2188,10 +2161,14 @@ static gboolean _dev_pixelpipe_process_rec(
 
              a) for the currently focused iop, as that is the iop
                 which is most likely to change next
-             b) if there is a hint for a module doing heavy processing.
-             c) only for full or preview pipe
-        */
-        if((module == darktable.develop->gui_module) || important)
+             b) if there is a hint for changed parameters in history via the flag
+             c) we got an important hint for some special cases
+       */
+
+        if(darktable.develop->gui_attached
+           && ((module == darktable.develop->gui_module)
+                || important
+                || module->iopcache_hint))
         {
           /* write back input into cache for faster re-usal (full pipe or preview) */
           if(cl_mem_input != NULL
@@ -2392,34 +2369,32 @@ static gboolean _dev_pixelpipe_process_rec(
   // in case we get this buffer from the cache in the future, cache some stuff:
   **out_format = piece->dsc_out = pipe->dsc;
 
-  const gboolean needs_histo = module
+  // special cases for active modules with available gui
+  if(module
      && darktable.develop->gui_attached
-     && module->expanded
-     && module->enabled
-     && (pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW))
-     && (module->request_histogram & DT_REQUEST_EXPANDED);
-
-  if(needs_histo)
-    dt_print_pipe(DT_DEBUG_PIPE, "internal histogram", pipe, module, NULL, NULL, "\n");
-
-  if((pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_NONE) && !needs_histo)
+     && module->enabled)
   {
-    if(module && module == darktable.develop->gui_module)
+    // Possibly give the input buffer of the current module more weight
+    // as the user is likely to change that one soon (again), so keep it in cache.
+    if((pipe->type & DT_DEV_PIXELPIPE_FULL)
+        && (pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_NONE)
+        && ((module == darktable.develop->gui_module) || module->iopcache_hint))
     {
-      // give the input buffer to the currently focused plugin more weight.
-      // the user is likely to change that one soon, so keep it in cache.
+      dt_print_pipe(DT_DEBUG_PIPE, "UI hints importance", pipe, module, &roi_in, roi_out,
+        "%s\n", module->iopcache_hint ? "last history change" : "module in focus");
+
       dt_dev_pixelpipe_important_cacheline(pipe, input, roi_in.width * roi_in.height * in_bpp);
+      module->iopcache_hint = FALSE;
     }
 
-    // we check for an important hint after processing the module as we
-    // want to track a runtime hint too.
-    pipe->next_important_module = _check_module_next_important(pipe, module);
-  }
-
-  if(needs_histo)
-  {
-    pipe->nocache = TRUE;
-    dt_dev_pixelpipe_invalidate_cacheline(pipe, *output, FALSE);
+    if(module->expanded
+       && (pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW))
+       && (module->request_histogram & DT_REQUEST_EXPANDED))
+    {
+      dt_print_pipe(DT_DEBUG_PIPE, "internal histogram", pipe, module, &roi_in, roi_out, "\n");
+      pipe->nocache = TRUE;
+      dt_dev_pixelpipe_invalidate_cacheline(pipe, *output, FALSE);
+    }
   }
 
   // warn on NaN or infinity
@@ -2440,7 +2415,7 @@ static gboolean _dev_pixelpipe_process_rec(
     if((*out_format)->datatype == TYPE_FLOAT
        && (*out_format)->channels == 4)
     {
-      int hasinf = 0, hasnan = 0;
+      gboolean hasinf = FALSE, hasnan = FALSE;
       dt_aligned_pixel_t min = { FLT_MAX };
       dt_aligned_pixel_t max = { -FLT_MAX };
 
@@ -2450,9 +2425,9 @@ static gboolean _dev_pixelpipe_process_rec(
         {
           const float f = ((float *)(*output))[k];
           if(dt_isnan(f))
-            hasnan = 1;
+            hasnan = TRUE;
           else if(dt_isinf(f))
-            hasinf = 1;
+            hasinf = TRUE;
           else
           {
             min[k & 3] = fmin(f, min[k & 3]);
@@ -2479,7 +2454,7 @@ static gboolean _dev_pixelpipe_process_rec(
     }
     else if((*out_format)->datatype == TYPE_FLOAT && (*out_format)->channels == 1)
     {
-      int hasinf = 0, hasnan = 0;
+      gboolean hasinf = FALSE, hasnan = FALSE;
       float min = FLT_MAX;
       float max = -FLT_MAX;
 
@@ -2487,9 +2462,9 @@ static gboolean _dev_pixelpipe_process_rec(
       {
         const float f = ((float *)(*output))[k];
         if(dt_isnan(f))
-          hasnan = 1;
+          hasnan = TRUE;
         else if(dt_isinf(f))
-          hasinf = 1;
+          hasinf = TRUE;
         else
         {
           min = fmin(f, min);
@@ -2624,7 +2599,6 @@ static gboolean _dev_pixelpipe_process_rec_and_backcopy(
 #ifdef HAVE_OPENCL
   dt_opencl_check_tuning(pipe->devid);
 #endif
-  pipe->next_important_module = FALSE;
   gboolean ret = _dev_pixelpipe_process_rec(pipe, dev, output,
                                             cl_mem_output, out_format, roi_out,
                                             modules, pieces, pos);

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -144,9 +144,6 @@ typedef struct dt_dev_pixelpipe_t
   gboolean want_detail_mask;
   struct dt_dev_detail_mask_t details;
 
-  // we have to keep track of the next processing module to use an iop cacheline with high priority
-  gboolean next_important_module;
-
   // avoid cached data for processed module
   gboolean nocache;
 

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -556,7 +556,6 @@ void process(struct dt_iop_module_t *self,
       = dt_ioppr_get_pipe_current_profile_info(self, piece->pipe);
   if(work_profile == NULL) return; // no point
 
-  self->cache_next_important = TRUE; // The cpu code is pretty heavy stuff so an importance hint
 
   // work profile can't be fetched in commit_params since it is not yet initialised
   // work_profile->matrix_in === RGB_to_XYZ

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -144,7 +144,7 @@ int default_group()
 
 int flags()
 {
-  return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_ONE_INSTANCE | IOP_FLAGS_CACHE_IMPORTANT_NEXT;
+  return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_ONE_INSTANCE;
 }
 
 int default_colorspace(dt_iop_module_t *self,

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1374,9 +1374,6 @@ void process(dt_iop_module_t *self,
     num_steps_to_reach_equivalent_sigma(B_SPLINE_SIGMA, final_radius);
   const int scales = CLAMP(diffusion_scales, 1, MAX_NUM_SCALES);
 
-  self->cache_next_important =
-    ((data->iterations * (data->radius + data->radius_center)) > 16);
-
   gboolean out_of_memory = FALSE;
 
   // wavelets scales buffers
@@ -1649,9 +1646,6 @@ int process_cl(struct dt_iop_module_t *self,
   const int diffusion_scales =
     num_steps_to_reach_equivalent_sigma(B_SPLINE_SIGMA, final_radius);
   const int scales = CLAMP(diffusion_scales, 1, MAX_NUM_SCALES);
-
-  self->cache_next_important =
-    ((data->iterations * (data->radius + data->radius_center)) > 16);
 
   // wavelets scales buffers
   cl_mem HF[MAX_NUM_SCALES];

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -828,21 +828,9 @@ void commit_params(struct dt_iop_module_t *self,
 
   const gboolean fullpipe = piece->pipe->type & DT_DEV_PIXELPIPE_FULL;
 
-  // check for heavy computing here to possibly give an iop cache hint
-  gboolean heavy = (((d->mode == DT_IOP_HIGHLIGHTS_LAPLACIAN) && ((d->iterations * 1<<(2+d->scales)) >= 256))
-                  || (d->mode == DT_IOP_HIGHLIGHTS_SEGMENTS));
-
   dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
-  if(g)
-  {
-    // the clipped visualizer for linears is not implemented in cl
-    if((g->hlr_mask_mode == DT_HIGHLIGHTS_MASK_CLIPPED) && linear && fullpipe)
-      piece->process_cl_ready = FALSE;
-    // only give a heavy hint if we are not in masking mode
-    if(g->hlr_mask_mode != DT_HIGHLIGHTS_MASK_OFF)
-      heavy = FALSE;
-  }
-  self->cache_next_important = heavy;
+  if(g && (g->hlr_mask_mode == DT_HIGHLIGHTS_MASK_CLIPPED) && linear && fullpipe)
+    piece->process_cl_ready = FALSE;
 }
 
 void init_global(dt_iop_module_so_t *module)


### PR DESCRIPTION
In the current desing we tried to give modules output buffers some higher cache priority via fixed rules. This works fine in some cases, in other cases this fails miserably. Also Pascal hinted concerns about safety & stability.

So let's rethink the "importance strategy".

In fact this is all about the user interface and the only thing we can take for sure is:

IF the user changed a parameter in a module there is a very good chance that there we be another change of parameters in the same module pretty soon (just think about sliders)

So we want the **input** cacheline of that module to be available afterwards.

We had the strategy of "module in focus" to do so, in this pr we extend that rule by adding a hint in `_dev_add_history_item_ext()`

While using opencl we make sure that these input cachelines are written.

Overall
- a much better cache hit rate
- more respnsiveness in UI
- less code complexity