### PR TITLE
Prevent crash in collection filter rule list fixes #14009

### DIFF
--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -1341,6 +1341,7 @@ static void _filters_gui_update(dt_lib_module_t *self)
       gtk_widget_destroy(d->rule[i].w_main);
       d->rule[i].w_main = NULL;
       d->rule[i].w_special_box = NULL;
+      d->rule[i].w_pin = NULL;
     }
   }
 


### PR DESCRIPTION
In some circumstances not making a pin button for the date/time collection filters can cause a crash.

See issue #14009.
1. To reproduce reset left panel collection filters and set to preset "initial setting".
Delete the last rule "search" by pressing the x button in the rule header.
Create a new rule "capture date". The new date rule will be created without initializing a pin button in the dt_lib_filtering_rule_t struct previously inhabited by the search rule. But the pointer to the now invalid pin button from the search rule remains in rule->w_pin and later an if(rule->w_pin) test passes and gtk_toggle_button_set_active is called on invalid memory.

2. If the new "capture date" rule is created before any rule above it is deleted and the rule immediately above it has a pin icon. Then when a rule above the "capture date" rule is deleted it will move up one step in the list and gain the pin button of the previous rule. This does not cause a crash and pin button works. It's just not hidden anymore. This also works the other way around, rules with a pin icon will lose it if they move to a slot previously occupied by a pin-less rule.

Setting w_pin to NULL when destroying rules in _filters_gui_update in this patch attempts to prevent the crash in 1.
It does not fix 2. or the underlying problem that header/button data doesn't follow the rule when it moves around in the collection rule list.