### PR TITLE
Internal handling of dual-demosaic OpenCL scaling problem

### DIFF
--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -1408,7 +1408,7 @@ int dt_interpolation_resample_cl(const struct dt_interpolation *itor,
   int *vmeta = NULL;
 
   int r;
-  cl_int err = -999;
+  cl_int err = DT_OPENCL_DEFAULT_ERROR;
 
   cl_mem dev_hindex = NULL;
   cl_mem dev_hlength = NULL;
@@ -1503,9 +1503,7 @@ int dt_interpolation_resample_cl(const struct dt_interpolation *itor,
     // the vertical workgroupsize; there is no point in continuing on
     // the GPU - that would be way too slow; let's delegate the stuff
     // to the CPU then.
-    dt_print(DT_DEBUG_OPENCL,
-             "[dt_interpolation_resample_cl] resampling plan cannot"
-             " efficiently be run on the GPU - fall back to CPU.\n");
+    err = DT_OPENCL_PROCESS_CL;
     goto error;
   }
 
@@ -1585,9 +1583,8 @@ error:
   dt_opencl_release_mem_object(dev_vmeta);
   dt_free_align(hlength);
   dt_free_align(vlength);
-  dt_print(DT_DEBUG_ALWAYS,
-           "[dt_interpolation_resample_cl] couldn't enqueue kernel! %s\n",
-           cl_errstr(err));
+  dt_print_pipe(DT_DEBUG_OPENCL, "interpolation_resample_cl", NULL, NULL, roi_in, roi_out,
+      "Error: %s\n", cl_errstr(err));
   return err;
 }
 

--- a/src/iop/demosaicing/dual.c
+++ b/src/iop/demosaicing/dual.c
@@ -139,7 +139,7 @@ gboolean dual_demosaic_cl(
 
   float blurmat[13];
   dt_masks_blur_9x9_coeff(blurmat, 2.0f);
-  dev_blurmat = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 13, blurmat);
+  dev_blurmat = dt_opencl_copy_host_to_device_constant(devid, sizeof(blurmat), blurmat);
 
   err = dt_opencl_enqueue_kernel_2d_args(devid, darktable.opencl->blendop->kernel_mask_blur, width, height,
       CLARG(mask), CLARG(tmp), CLARG(width), CLARG(height), CLARG(dev_blurmat));


### PR DESCRIPTION
As reported in #14447 we sometimes run into a problem, this comes down to workload restrictions in  `dt_interpolation_resample_cl()`.

Instead of a late fallback to cpu we do this internally here as we are sure the benefit is much larger than a reprocess due to the prepending twice demosaicing.

Also added more internal debugging information.

Confessing i don't understand the implementation and if or how we could overcome the problem.