### PR TITLE
Add 5th masks combine mode "sum"

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1381,12 +1381,24 @@ static gboolean _blendop_masks_modes_none_clicked(GtkWidget *button,
 
 static gboolean _blendop_masks_modes_toggle(GtkToggleButton *button,
                                             dt_iop_module_t *module,
-                                            const unsigned int mask_mode)
+                                            unsigned int mask_mode)
 {
   if(darktable.gui->reset) return FALSE;
   dt_iop_gui_blend_data_t *data = module->blend_data;
 
   dt_iop_request_focus(module);
+
+  // test if need to add drawn or parametric mask
+  if(!button)
+  {
+    if(module->blend_params->mask_mode & (mask_mode | DEVELOP_MASK_RASTER))
+      return FALSE;
+
+    mask_mode |= module->blend_params->mask_mode | DEVELOP_MASK_ENABLED;
+    button = g_list_nth_data(data->masks_modes_toggles,
+                            g_list_index(data->masks_modes,
+                                          GUINT_TO_POINTER(mask_mode)));
+  }
 
   const gboolean was_toggled = !gtk_toggle_button_get_active(button);
   gtk_toggle_button_set_active(button, was_toggled);
@@ -1563,6 +1575,8 @@ static gboolean _blendop_masks_add_shape(GtkWidget *widget,
   }
 
   if(this < 0) return FALSE;
+
+  _blendop_masks_modes_toggle(NULL, self, DEVELOP_MASK_MASK);
 
   // set all shape buttons to inactive
   for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -57,11 +57,14 @@ typedef enum dt_masks_state_t
   DT_MASKS_STATE_UNION = 1 << 3,
   DT_MASKS_STATE_INTERSECTION = 1 << 4,
   DT_MASKS_STATE_DIFFERENCE = 1 << 5,
-  DT_MASKS_STATE_EXCLUSION = 1 << 6
+  DT_MASKS_STATE_EXCLUSION = 1 << 6,
+  DT_MASKS_STATE_SUM = 1 << 7,
+  DT_MASKS_STATE_OP = DT_MASKS_STATE_UNION
+                    | DT_MASKS_STATE_INTERSECTION
+                    | DT_MASKS_STATE_DIFFERENCE
+                    | DT_MASKS_STATE_SUM
+                    | DT_MASKS_STATE_EXCLUSION
 } dt_masks_state_t;
-
-#define DT_MASKS_STATE_OP (DT_MASKS_STATE_UNION | DT_MASKS_STATE_INTERSECTION \
-                           | DT_MASKS_STATE_DIFFERENCE | DT_MASKS_STATE_EXCLUSION)
 
 typedef enum dt_masks_property_t
 {

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -389,7 +389,13 @@ void dt_masks_gui_form_save_creation(dt_develop_t *dev,
     grpt->formid = form->formid;
     grpt->parentid = grp->formid;
     grpt->state = DT_MASKS_STATE_SHOW | DT_MASKS_STATE_USE;
-    if(grp->points) grpt->state |= DT_MASKS_STATE_UNION;
+    if(grp->points)
+    {
+      if(form->type == DT_MASKS_BRUSH)
+        grpt->state |= DT_MASKS_STATE_SUM;
+      else
+        grpt->state |= DT_MASKS_STATE_UNION;
+    }
     grpt->opacity = dt_conf_get_float("plugins/darkroom/masks/opacity");
     grp->points = g_list_append(grp->points, grpt);
     // we save the group

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -939,6 +939,34 @@ void dtgtk_cairo_paint_masks_difference(cairo_t *cr, gint x, gint y, gint w, gin
   cairo_stroke(cr);
 }
 
+void dtgtk_cairo_paint_masks_sum(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  // note : as the icon is not square, we don't want PREAMBLE macro
+  // we want 2 round of radius R that intersect in the middle,
+  // so the width needs R + R*0.8 + R*0.8 + R = R*3.6
+  // with a safety belt of *0.95 to be sure the stroke is draw inside the area
+  const float r = fminf(w / 3.6, h / 2.0) * 0.95;
+  const float padding_left = (w - r * 3.6) / 2.0;
+
+  // we draw the outline of the 2 circles
+  cairo_save(cr);
+  cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, .3);
+  cairo_arc(cr, padding_left + r, h / 2.0, r, 0, 2.0 * M_PI);
+  cairo_arc(cr, padding_left + r * 2.6, h / 2.0, r, 0, 2.0 * M_PI);
+  cairo_fill(cr);
+  cairo_restore(cr);
+
+  // we draw the intersection of the 2 circles we slightly different radius so they are more visible
+  cairo_push_group(cr);
+  cairo_arc(cr, padding_left + r * 1.3, h / 2.0, r * 0.85, 0, 2.0 * M_PI);
+  cairo_fill(cr);
+  cairo_set_operator(cr, CAIRO_OPERATOR_IN);
+  cairo_arc(cr, padding_left + r * 2.3, h / 2.0, r * 0.85, 0, 2.0 * M_PI);
+  cairo_fill(cr);
+  cairo_pop_group_to_source(cr);
+  cairo_paint(cr);
+}
+
 void dtgtk_cairo_paint_masks_exclusion(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   // note : as the icon is not square, we don't want PREAMBLE macro

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -293,6 +293,8 @@ void dtgtk_cairo_paint_masks_union(cairo_t *cr, gint x, gint y, gint w, gint h, 
 void dtgtk_cairo_paint_masks_intersection(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint an op difference icon for masks */
 void dtgtk_cairo_paint_masks_difference(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** Paint an op sum icon for masks */
+void dtgtk_cairo_paint_masks_sum(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint an op exclusion icon for masks */
 void dtgtk_cairo_paint_masks_exclusion(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a used icon for masks */


### PR DESCRIPTION
![image](https://github.com/darktable-org/darktable/assets/1549490/e1f78261-156f-4519-970c-4ab4ed09f0bf)
As suggested here https://github.com/darktable-org/darktable/pull/14464#issuecomment-1542426589 (2nd topic) this would allow dodging and burning by layering several brush strokes with low opacity on top of each other.
![image](https://github.com/darktable-org/darktable/assets/1549490/cb2b67a8-fe62-41ab-bcd8-a2c65af551f4)

What would still be required is for the combine mode to be set in advance or be taken from the top/last existing shape. At the moment it defaults to union (and it is not possible to change it for multiple items at once). Or maybe when drawing brushes in continuous (ctrl+) mode, with less than 100% opacity, the combine mode could default to "sum"?

This PR also removes duplication in `_tree_inverse`/`_tree_union`/`_tree_intersection` etc and replaces them with one `_tree_operation`, but I have a small doubt here: `_tree_intersection` deviated from the pattern in that it traversed the list from `g_list_last` backwards. I don't see why that would (or should) make a difference, but maybe I'm missing something?