### PR TITLE
Early CPU fallback in dt_interpolation_resample_cl()

### DIFF
--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -1408,7 +1408,7 @@ int dt_interpolation_resample_cl(const struct dt_interpolation *itor,
   int *vmeta = NULL;
 
   int r;
-  cl_int err = -999;
+  cl_int err = DT_OPENCL_DEFAULT_ERROR;
 
   cl_mem dev_hindex = NULL;
   cl_mem dev_hlength = NULL;
@@ -1503,9 +1503,7 @@ int dt_interpolation_resample_cl(const struct dt_interpolation *itor,
     // the vertical workgroupsize; there is no point in continuing on
     // the GPU - that would be way too slow; let's delegate the stuff
     // to the CPU then.
-    dt_print(DT_DEBUG_OPENCL,
-             "[dt_interpolation_resample_cl] resampling plan cannot"
-             " efficiently be run on the GPU - fall back to CPU.\n");
+    err = DT_OPENCL_PROCESS_CL;
     goto error;
   }
 
@@ -1585,9 +1583,8 @@ error:
   dt_opencl_release_mem_object(dev_vmeta);
   dt_free_align(hlength);
   dt_free_align(vlength);
-  dt_print(DT_DEBUG_ALWAYS,
-           "[dt_interpolation_resample_cl] couldn't enqueue kernel! %s\n",
-           cl_errstr(err));
+  dt_print_pipe(DT_DEBUG_OPENCL, "interpolation_resample_cl", NULL, NULL, roi_in, roi_out,
+      "Error: %s\n", cl_errstr(err));
   return err;
 }
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -830,27 +830,13 @@ int process_cl(
   dt_opencl_release_mem_object(low_image);
   low_image = NULL;
 
-  if(roi_in->width == roi_out->width && roi_in->height == roi_out->height)
-  {
-    dt_print_pipe(DT_DEBUG_PIPE, "copy_dual_cl", piece->pipe, self, roi_in, roi_out, "\n");
-    size_t origin[] = { 0, 0, 0 };
-    size_t region[] = { roi_in->width, roi_in->height, 1 };
-    const int err = dt_opencl_enqueue_copy_image(devid, high_image, dev_out, origin, origin, region);
-    if(err != CL_SUCCESS)
-      retval = FALSE;
-  }
-  else
-  {
-    dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_dual_cl", piece->pipe, self, roi_in, roi_out, "\n");
-    const int err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, high_image, roi_out, roi_in);
-    if(err != CL_SUCCESS)
-      retval = FALSE;
-  }
+  if(dt_iop_clip_and_zoom_roi_cl(devid, dev_out, high_image, roi_out, roi_in) == CL_SUCCESS)
+    retval = TRUE;
+
   finish:
   dt_opencl_release_mem_object(high_image);
   dt_opencl_release_mem_object(low_image);
 
-  if(!retval) dt_control_log(_("[dual demosaic_cl] internal problem"));
   return retval;
 }
 #endif

--- a/src/iop/demosaicing/dual.c
+++ b/src/iop/demosaicing/dual.c
@@ -139,7 +139,7 @@ gboolean dual_demosaic_cl(
 
   float blurmat[13];
   dt_masks_blur_9x9_coeff(blurmat, 2.0f);
-  dev_blurmat = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 13, blurmat);
+  dev_blurmat = dt_opencl_copy_host_to_device_constant(devid, sizeof(blurmat), blurmat);
 
   err = dt_opencl_enqueue_kernel_2d_args(devid, darktable.opencl->blendop->kernel_mask_blur, width, height,
       CLARG(mask), CLARG(tmp), CLARG(width), CLARG(height), CLARG(dev_blurmat));


### PR DESCRIPTION
Due to "vertical number of taps exceeds the vertical workgroupsize" problems we sometimes run into issues like reported in #14447

This PR does an early internal cpu fallback via a copy->scale-on-cpu->copy cycle which is costly buth nevertheless still much better than reprocessing the whole iop code in a late pipeline fallback.

To make sure we avoid other error conditions we test for the generating error condition.

Fixes #14447
Improves performance for equivalent conditions using that code like all demosaicers and finalscale.