### PR TITLE
Fix _raster_value_changed_callback()

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2850,6 +2850,9 @@ static void _raster_value_changed_callback(GtkWidget *widget,
 {
   raster_combo_entry_t *entry = dt_bauhaus_combobox_get_data(widget);
 
+  if(!entry)
+    return;
+
   // nothing to do
   if(entry->module == module->raster_mask.sink.source
      && entry->id == module->raster_mask.sink.id)


### PR DESCRIPTION
If there is no *entry we must return immediately

Fixes #14466