### PR TITLE
[imageio] Implementation of optional rejection of all non-raw files instead of JPEG files

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1010,11 +1010,11 @@
     <longdescription>only select images that have not already been imported</longdescription>
   </dtconfig>
   <dtconfig ui="yes">
-    <name>ui_last/import_ignore_jpegs</name>
+    <name>ui_last/import_ignore_nonraws</name>
     <type>bool</type>
     <default>false</default>
-    <shortdescription>ignore JPEG images</shortdescription>
-    <longdescription>when having raw+JPEG images together in one directory it makes no sense to import both. with this flag one can ignore all JPEGs found.</longdescription>
+    <shortdescription>ignore non-raw images</shortdescription>
+    <longdescription>if enabled, only raw files will be allowed to import. non-raw files will not be visible in the dialog and will not be imported.</longdescription>
   </dtconfig>
   <dtconfig ui="yes">
     <name>ui_last/import_apply_metadata</name>

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -406,13 +406,13 @@ dt_imgid_t dt_image_get_id(const uint32_t film_id,
 /** imports a new image from raw/etc file and adds it to the data base and image cache. Use from threads other than lua.*/
 dt_imgid_t dt_image_import(int32_t film_id,
                            const char *filename,
-                           const gboolean override_ignore_jpegs,
+                           const gboolean override_ignore_nonraws,
                            const gboolean raise_signals);
 /** imports a new image from raw/etc file and adds it to the data base
  * and image cache. Use from lua thread.*/
 dt_imgid_t dt_image_import_lua(const int32_t film_id,
                                const char *filename,
-                               const gboolean override_ignore_jpegs);
+                               const gboolean override_ignore_nonraws);
 /** removes the given image from the database. */
 void dt_image_remove(const dt_imgid_t imgid);
 /** duplicates the given image in the database with the duplicate

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -106,6 +106,16 @@ static const gchar *_supported_ldr[]
 static const gchar *_supported_hdr[]
     = { "avif", "exr", "hdr", "heic", "heif", "hif", "jxl", "pfm", NULL };
 
+gboolean dt_imageio_is_raw_by_extension(const char *extension)
+{
+  const char *ext = g_str_has_prefix(extension, ".") ? extension + 1 : extension;
+  for(const char **i = _supported_raw; *i != NULL; i++)
+  {
+    if(!g_ascii_strncasecmp(ext, *i, strlen(*i))) return TRUE;
+  }
+  return FALSE;
+}
+
 // get the type of image from its extension
 dt_image_flags_t dt_imageio_get_type_from_extension(const char *extension)
 {

--- a/src/imageio/imageio_common.h
+++ b/src/imageio/imageio_common.h
@@ -58,6 +58,8 @@ typedef enum dt_imageio_levels_t
   IMAGEIO_CHANNEL_MASK = 0xFF00
 } dt_imageio_levels_t;
 
+// Check that the image is raw by file extension
+gboolean dt_imageio_is_raw_by_extension(const char *extension);
 // Checks that the image is indeed an ldr image
 gboolean dt_imageio_is_ldr(const char *filename);
 // checks that the image has a monochrome preview attached


### PR DESCRIPTION
Fixes #13486.

This fix is necessary, primarily, not even to support the workflow described in the linked issue. For some time there have been cameras (EOS-1D X Mark III, just as one example) that, as a cooked pair to raw images, can shoot not only images in JPEG format, but also in HEIF format. So these days the implementation of ignoring JPEG only is simply outdated.
