### PR TITLE
Raster mask glitches

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -219,7 +219,7 @@ void dt_develop_blendif_process_parameters(float *const restrict parameters,
 }
 
 // See function definition in blend.h for important information
-int dt_develop_blendif_init_masking_profile
+gboolean dt_develop_blendif_init_masking_profile
   (struct dt_dev_pixelpipe_iop_t *piece,
    dt_iop_order_iccprofile_info_t *blending_profile,
    const dt_develop_blend_colorspace_t cst)
@@ -235,7 +235,7 @@ int dt_develop_blendif_init_masking_profile
   const dt_iop_order_iccprofile_info_t *const profile = (cst == DEVELOP_BLEND_CS_RGB_SCENE)
       ? dt_ioppr_get_pipe_current_profile_info(piece->module, piece->pipe)
       : dt_ioppr_get_iop_work_profile_info(piece->module, piece->module->dev->iop);
-  if(!profile) return 0;
+  if(!profile) return FALSE;
 
   memcpy(blending_profile, profile, sizeof(dt_iop_order_iccprofile_info_t));
   for(size_t y = 0; y < 3; y++)
@@ -250,7 +250,7 @@ int dt_develop_blendif_init_masking_profile
     }
   }
 
-  return 1;
+  return TRUE;
 }
 
 static inline float _detail_mask_threshold(const float level,
@@ -546,6 +546,9 @@ void dt_develop_blend_process(struct dt_iop_module_t *self,
                                                 self, &free_mask);
     if(raster_mask)
     {
+      dt_print_pipe(DT_DEBUG_PIPE,
+         "blend raster on CPU",
+         piece->pipe, self, roi_in, roi_out, "%s\n", d->raster_mask_invert ? "inverted" : "");
       // invert if required
       if(d->raster_mask_invert)
       {
@@ -566,17 +569,16 @@ void dt_develop_blend_process(struct dt_iop_module_t *self,
     }
     else
     {
-      // fallback for when the raster mask couldn't be applied
-      const float value = d->raster_mask_invert ? 0.0 : 1.0;
-      dt_iop_image_fill(mask, value, owidth, oheight, 1);  // mask[k] = value;
+      // fallback if no raster mask is applied
+      dt_iop_image_fill(mask, 0.0f, owidth, oheight, 1);  // mask[k] = value;
     }
   }
   else
   {
+    const gboolean inverted = (d->mask_combine & DEVELOP_COMBINE_MASKS_POS);
     dt_print_pipe(DT_DEBUG_PIPE,
        "blend with form on CPU",
-       piece->pipe, self, roi_in, roi_out,
-       "\n");
+       piece->pipe, self, roi_in, roi_out, "%s\n", inverted ? "inverted" : "");
     // we blend with a drawn and/or parametric mask
 
     // get the drawn mask if there is one
@@ -588,7 +590,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self,
     {
       dt_masks_group_render_roi(self, piece, form, roi_out, mask);
 
-      if(d->mask_combine & DEVELOP_COMBINE_MASKS_POS)
+      if(inverted)
       {
         // if we have a mask and this flag is set -> invert the mask
         dt_iop_image_invert(mask, 1.0f, owidth, oheight, 1); // mask[k] = 1.0f - mask[k];
@@ -599,7 +601,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self,
     {
       // no form defined but drawn mask active
       // we fill the buffer with 1.0f or 0.0f depending on mask_combine
-      const float fill = (d->mask_combine & DEVELOP_COMBINE_MASKS_POS) ? 0.0f : 1.0f;
+      const float fill = inverted ? 0.0f : 1.0f;
       dt_iop_image_fill(mask, fill, owidth, oheight, 1); //mask[k] = fill;
     }
     else
@@ -865,7 +867,7 @@ static inline void _blend_process_cl_exchange(cl_mem *a, cl_mem *b)
   *b = tmp;
 }
 
-int dt_develop_blend_process_cl(struct dt_iop_module_t *self,
+gboolean dt_develop_blend_process_cl(struct dt_iop_module_t *self,
                                 struct dt_dev_pixelpipe_iop_t *piece,
                                 cl_mem dev_in,
                                 cl_mem dev_out,
@@ -1023,7 +1025,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self,
   if(dev_mask_1 == NULL) goto error;
 
   dt_iop_order_iccprofile_info_t profile;
-  const int use_profile =
+  const gboolean use_profile =
     dt_develop_blendif_init_masking_profile(piece, &profile, blend_csp);
 
   err = dt_ioppr_build_iccprofile_params_cl(use_profile ? &profile : NULL,
@@ -1054,6 +1056,9 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self,
   }
   else if(mask_mode & DEVELOP_MASK_RASTER)
   {
+    dt_print_pipe(DT_DEBUG_PIPE,
+       "blend raster CL",
+       piece->pipe, self, roi_in, roi_out, "%s\n", d->raster_mask_invert ? "inverted" : "");
     /* use a raster mask from another module earlier in the pipe
        dt_dev_get_raster_mask() sets a flag if the returned mask has been
        distorted and thus must be deallocated by the caller
@@ -1084,9 +1089,8 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self,
     }
     else
     {
-      // fallback for when the raster mask couldn't be applied
-      const float value = d->raster_mask_invert ? 0.0 : 1.0;
-      dt_iop_image_fill(mask, value, owidth, oheight, 1); //mask[k] = value;
+      // fallback if no raster mask is applied
+      dt_iop_image_fill(mask, 0.0f, owidth, oheight, 1); //mask[k] = value;
     }
 
     err = dt_opencl_write_host_to_device(devid, mask, dev_mask_1,
@@ -1101,9 +1105,10 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self,
   }
   else
   {
+    const gboolean inverted = (d->mask_combine & DEVELOP_COMBINE_MASKS_POS);
     dt_print_pipe(DT_DEBUG_PIPE,
-       "blend with form on GPU",
-       piece->pipe, self, roi_in, roi_out, "\n");
+       "blend with form CL",
+       piece->pipe, self, roi_in, roi_out, "%s\n", inverted ? "inverted" : "");
     // we blend with a drawn and/or parametric mask
 
     // get the drawn mask if there is one
@@ -1115,7 +1120,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self,
     {
       dt_masks_group_render_roi(self, piece, form, roi_out, mask);
 
-      if(d->mask_combine & DEVELOP_COMBINE_MASKS_POS)
+      if(inverted)
       {
         // if we have a mask and this flag is set -> invert the mask
         dt_iop_image_invert(mask, 1.0f, owidth, oheight, 1); //mask[k] = 1.0f - mask[k]
@@ -1126,7 +1131,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self,
     {
       // no form defined but drawn mask active
       // we fill the buffer with 1.0f or 0.0f depending on mask_combine
-      const float fill = (d->mask_combine & DEVELOP_COMBINE_MASKS_POS) ? 0.0f : 1.0f;
+      const float fill = inverted ? 0.0f : 1.0f;
       dt_iop_image_fill(mask, fill, owidth, oheight, 1); //mask[k] = fill;
     }
     else

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -433,7 +433,7 @@ void dt_develop_blendif_process_parameters(float *const parameters,
  *
  * The initialized profile may only be used to convert from RGB to XYZ.
  */
-int dt_develop_blendif_init_masking_profile
+gboolean dt_develop_blendif_init_masking_profile
   (struct dt_dev_pixelpipe_iop_t *piece,
    dt_iop_order_iccprofile_info_t *blending_profile,
    const dt_develop_blend_colorspace_t cst);
@@ -522,7 +522,7 @@ gboolean blend_color_picker_apply(dt_iop_module_t *module,
 
 #ifdef HAVE_OPENCL
 /** apply blend for opencl modules*/
-int dt_develop_blend_process_cl(struct dt_iop_module_t *self,
+gboolean dt_develop_blend_process_cl(struct dt_iop_module_t *self,
                                 struct dt_dev_pixelpipe_iop_t *piece,
                                 cl_mem dev_in, cl_mem dev_out,
                                 const struct dt_iop_roi_t *roi_in,

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2885,7 +2885,7 @@ static void _raster_value_changed_callback(GtkWidget *widget,
   }
 
   module->raster_mask.sink.source = entry->module;
-  module->raster_mask.sink.id = entry->id;
+  module->raster_mask.sink.id = entry->module ? entry->id : INVALID_MASKID;
 
   gboolean reprocess = FALSE;
 

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2833,6 +2833,9 @@ static void _raster_combo_populate(GtkWidget *w,
 
   int i = 1;
 
+  dt_iop_gui_blend_data_t *bd = module->blend_data;
+  gtk_widget_set_sensitive(bd->raster_polarity, FALSE);
+
   for(GList* iter = darktable.develop->iop; iter; iter = g_list_next(iter))
   {
     dt_iop_module_t *iop = (dt_iop_module_t *)iter->data;
@@ -2853,7 +2856,10 @@ static void _raster_combo_populate(GtkWidget *w,
       dt_bauhaus_combobox_add_full(w, modulename,
                                    DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, entry, free, TRUE);
       if(iop == module->raster_mask.sink.source && module->raster_mask.sink.id == id)
+      {
         dt_bauhaus_combobox_set(w, i);
+        gtk_widget_set_sensitive(bd->raster_polarity, TRUE);
+      }
       i++;
     }
   }
@@ -2883,6 +2889,7 @@ static void _raster_value_changed_callback(GtkWidget *widget,
 
   gboolean reprocess = FALSE;
 
+  dt_iop_gui_blend_data_t *bd = module->blend_data;
   if(entry->module)
   {
     reprocess = dt_iop_is_raster_mask_used(entry->module, BLEND_RASTER_ID) == FALSE;
@@ -2893,6 +2900,8 @@ static void _raster_value_changed_callback(GtkWidget *widget,
            sizeof(module->blend_params->raster_mask_source));
     module->blend_params->raster_mask_instance = entry->module->multi_priority;
     module->blend_params->raster_mask_id = entry->id;
+
+    gtk_widget_set_sensitive(bd->raster_polarity, TRUE);
   }
   else
   {
@@ -2900,6 +2909,7 @@ static void _raster_value_changed_callback(GtkWidget *widget,
            sizeof(module->blend_params->raster_mask_source));
     module->blend_params->raster_mask_instance = 0;
     module->blend_params->raster_mask_id = INVALID_MASKID;
+    gtk_widget_set_sensitive(bd->raster_polarity, FALSE);
   }
 
   dt_dev_add_history_item(module->dev, module, TRUE);

--- a/src/develop/blends/blendif_rgb_hsl.c
+++ b/src/develop/blends/blendif_rgb_hsl.c
@@ -290,7 +290,7 @@ void dt_develop_blendif_rgb_hsl_make_mask(struct dt_dev_pixelpipe_iop_t *piece, 
     dt_develop_blendif_process_parameters(parameters, d);
 
     dt_iop_order_iccprofile_info_t blend_profile;
-    const int use_profile = dt_develop_blendif_init_masking_profile(piece, &blend_profile,
+    const gboolean use_profile = dt_develop_blendif_init_masking_profile(piece, &blend_profile,
                                                                     DEVELOP_BLEND_CS_RGB_DISPLAY);
     const dt_iop_order_iccprofile_info_t *profile = use_profile ? &blend_profile : NULL;
 
@@ -1399,7 +1399,7 @@ void dt_develop_blendif_rgb_hsl_blend(struct dt_dev_pixelpipe_iop_t *piece,
   if(request_mask_display & DT_DEV_PIXELPIPE_DISPLAY_ANY)
   {
     dt_iop_order_iccprofile_info_t blend_profile;
-    const int use_profile = dt_develop_blendif_init_masking_profile(piece, &blend_profile,
+    const gboolean use_profile = dt_develop_blendif_init_masking_profile(piece, &blend_profile,
                                                                     DEVELOP_BLEND_CS_RGB_DISPLAY);
     const dt_iop_order_iccprofile_info_t *profile = use_profile ? &blend_profile : NULL;
     const float *const restrict boost_factors = d->blendif_boost_factors;

--- a/src/develop/blends/blendif_rgb_jzczhz.c
+++ b/src/develop/blends/blendif_rgb_jzczhz.c
@@ -1044,7 +1044,7 @@ void dt_develop_blendif_rgb_jzczhz_blend(struct dt_dev_pixelpipe_iop_t *piece, c
   if(request_mask_display & DT_DEV_PIXELPIPE_DISPLAY_ANY)
   {
     dt_iop_order_iccprofile_info_t blend_profile;
-    const int use_profile = dt_develop_blendif_init_masking_profile(piece, &blend_profile,
+    const gboolean use_profile = dt_develop_blendif_init_masking_profile(piece, &blend_profile,
                                                                     DEVELOP_BLEND_CS_RGB_SCENE);
     const dt_iop_order_iccprofile_info_t *profile = use_profile ? &blend_profile : NULL;
     const float *const restrict boost_factors = d->blendif_boost_factors;


### PR DESCRIPTION
1. The raster mask polarity button should only be visible if a raster mask has been selected.

2. If there is no raster mask selected the mask should be zero.