### PR TITLE
Use safe value for INVALID_CACHEHASH

### DIFF
--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 
 #define VERY_OLD_CACHE_WEIGHT 1000
-#define INVALID_CACHEHASH 0
+#define INVALID_CACHEHASH ULLONG_MAX
 
 static inline int _to_mb(size_t m)
 {


### PR DESCRIPTION
As modules might return a hash of zero we use ULLONG_MAX instead of 0 as an 'invalid' marker.