### PR TITLE
correct inverted validity test

### DIFF
--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -2098,7 +2098,7 @@ int dt_colorspaces_conversion_matrices_xyz(const float adobe_XYZ_to_CAM[4][3],
                                            double XYZ_to_CAM[4][3],
                                            double CAM_to_XYZ[3][4])
 {
-  if(!dt_is_valid_colormatrix(in_XYZ_to_CAM[0]))
+  if(dt_is_valid_colormatrix(in_XYZ_to_CAM[0]))
   {
     for(int i = 0; i < 9; i++)
         XYZ_to_CAM[i/3][i%3] = (double) in_XYZ_to_CAM[i];


### PR DESCRIPTION
Fixes #14498.  #14143 accidentally reversed the sense of a test by not removing the negation when switching from isnan() to dt_is_valid_colormatrix().
