### PR TITLE
po/UI lang - fix part of ui being translated

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1139,6 +1139,9 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   // initialize the config backend. this needs to be done first...
   darktable.conf = (dt_conf_t *)calloc(1, sizeof(dt_conf_t));
 
+  // set the interface language and prepare selection for prefs & confgen
+  darktable.l10n = dt_l10n_init(darktablerc, init_gui);
+
   // initialize the configuration default/min/max
   dt_confgen_init();
 
@@ -1146,9 +1149,6 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   dt_conf_init(darktable.conf, darktablerc, config_override);
 
   g_slist_free_full(config_override, g_free);
-
-  // set the interface language and prepare selection for prefs
-  darktable.l10n = dt_l10n_init(init_gui);
 
   const int last_configure_version =
     dt_conf_get_int("performance_configuration_version_completed");

--- a/src/common/l10n.c
+++ b/src/common/l10n.c
@@ -308,13 +308,32 @@ end:
 #endif // HAVE_ISO_CODES
 }
 
-dt_l10n_t *dt_l10n_init(gboolean init_list)
+gchar *_l10n_get_value(const gchar *key, const gchar *value)
+{
+  const gchar *search_key = "ui_last/gui_language";
+  if(!g_strcmp0(key, search_key))
+    return g_strdup(value);
+  else
+    return NULL;
+}
+
+gchar *_l10n_get_language(const gchar *filename)
+{
+  gchar *lang = dt_conf_read_values(filename, _l10n_get_value);
+  if(lang)
+    return lang;
+  else
+    return g_strdup("C");
+}
+
+dt_l10n_t *dt_l10n_init(const gchar *filename, const gboolean init_list)
 {
   dt_l10n_t *result = (dt_l10n_t *)calloc(1, sizeof(dt_l10n_t));
   result->selected = -1;
   result->sys_default = -1;
 
-  gchar *ui_lang = dt_conf_get_string("ui_last/gui_language");
+  gchar *ui_lang = _l10n_get_language(filename);
+
   const char *old_env = g_getenv("LANGUAGE");
 
 #if defined(_WIN32)
@@ -469,4 +488,3 @@ const char *dt_l10n_get_name(const dt_l10n_language_t *language)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/common/l10n.c
+++ b/src/common/l10n.c
@@ -44,7 +44,8 @@ static gchar* _dt_full_locale_name(const char *locale)
   {
     if(error)
     {
-      dt_print(DT_DEBUG_ALWAYS, "[l10n] couldn't check locale: '%s'\n", error->message);
+      dt_print(DT_DEBUG_ALWAYS,
+               "[l10n] couldn't check locale: '%s'\n", error->message);
       g_error_free(error);
     }
   }
@@ -60,7 +61,7 @@ static gchar* _dt_full_locale_name(const char *locale)
         if(g_str_has_prefix(locales[j], locale))
         {
           // return first found variant - this is most likelly the best one
-          gchar *ret=g_strdup(locales[j]);
+          gchar *ret = g_strdup(locales[j]);
           g_strfreev(locales);
           return ret;
         }
@@ -125,11 +126,13 @@ static void get_language_names(GList *languages)
 #if defined(_WIN32) && !defined(MSYS2_INSTALL)
   char datadir[PATH_MAX] = { 0 };
   dt_loc_get_datadir(datadir, sizeof(datadir));
-  filename = g_build_filename(datadir, "..",  "iso-codes", "json", "iso_639-2.json", NULL);
+  filename = g_build_filename(datadir, "..",  "iso-codes",
+                              "json", "iso_639-2.json", NULL);
 #else
 #ifdef __APPLE__
   if(res_path)
-    filename = g_build_filename(res_path, "share",  "iso-codes", "json", "iso_639-2.json", NULL);
+    filename = g_build_filename(res_path, "share",  "iso-codes",
+                                "json", "iso_639-2.json", NULL);
   else
 #endif
   filename = g_build_filename(ISO_CODES_LOCATION, "iso_639-2.json", NULL);
@@ -137,8 +140,10 @@ static void get_language_names(GList *languages)
 
   if(!g_file_test(filename, G_FILE_TEST_EXISTS))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[l10n] error: can't open iso-codes file `%s'\n"
-             "                   there won't be nicely translated language names in the preferences.\n", filename);
+    dt_print(DT_DEBUG_ALWAYS,
+             "[l10n] error: can't open iso-codes file `%s'\n"
+             "                   there won't be nicely translated language names"
+             " in the preferences.\n", filename);
     goto end;
   }
 
@@ -165,7 +170,9 @@ static void get_language_names(GList *languages)
   parser = json_parser_new();
   if(!json_parser_load_from_file(parser, filename, &error))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[l10n] error: parsing json from `%s' failed\n%s\n", filename, error->message);
+    dt_print(DT_DEBUG_ALWAYS,
+             "[l10n] error: parsing json from `%s' failed\n%s\n",
+             filename, error->message);
     goto end;
   }
 
@@ -173,7 +180,8 @@ static void get_language_names(GList *languages)
   JsonNode *root = json_parser_get_root(parser);
   if(!root)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[l10n] error: can't get root node of `%s'\n", filename);
+    dt_print(DT_DEBUG_ALWAYS,
+             "[l10n] error: can't get root node of `%s'\n", filename);
     goto end;
   }
 
@@ -181,7 +189,8 @@ static void get_language_names(GList *languages)
 
   if(!json_reader_read_member(reader, "639-2"))
   {
-    dt_print(DT_DEBUG_ALWAYS, "[l10n] error: unexpected layout of `%s'\n", filename);
+    dt_print(DT_DEBUG_ALWAYS,
+             "[l10n] error: unexpected layout of `%s'\n", filename);
     goto end;
   }
 
@@ -193,13 +202,14 @@ static void get_language_names(GList *languages)
 
   char *saved_locale = strdup(setlocale(LC_ALL, NULL));
 
-  int n_elements = json_reader_count_elements(reader);
+  const int n_elements = json_reader_count_elements(reader);
   for(int i = 0; i < n_elements; i++)
   {
     json_reader_read_element(reader, i);
     if(!json_reader_is_object(reader))
     {
-      dt_print(DT_DEBUG_ALWAYS, "[l10n] error: unexpected layout of `%s' (element %d)\n", filename, i);
+      dt_print(DT_DEBUG_ALWAYS,
+               "[l10n] error: unexpected layout of `%s' (element %d)\n", filename, i);
       free(saved_locale);
       saved_locale = NULL;
       goto end;
@@ -224,7 +234,8 @@ static void get_language_names(GList *languages)
       for(GList *iter = languages; iter; iter = g_list_next(iter))
       {
         dt_l10n_language_t *language = (dt_l10n_language_t *)iter->data;
-        if(!g_strcmp0(language->base_code, alpha_2) || !g_strcmp0(language->base_code, alpha_3))
+        if(!g_strcmp0(language->base_code, alpha_2)
+           || !g_strcmp0(language->base_code, alpha_3))
         {
           // code taken in parts from GIMP's gimplanguagestore-parser.c
           g_setenv("LANGUAGE", language->code, TRUE);
@@ -255,9 +266,13 @@ static void get_language_names(GList *languages)
             g_free(tmp);
           }
 
-          // we initialize the name to the language code to have something on systems lacking iso-codes, so free it!
+          // we initialize the name to the language code to have
+          // something on systems lacking iso-codes, so free it!
           g_free(language->name);
-          language->name = g_strdup_printf("%s (%s)%s", localized_name, language->code, language->is_default ? " *" : "");
+          language->name = g_strdup_printf("%s (%s)%s",
+                                           localized_name,
+                                           language->code,
+                                           language->is_default ? " *" : "");
           g_free(localized_name);
 
           // we can't break out of the loop here. at least pt is in our list twice!
@@ -265,7 +280,8 @@ static void get_language_names(GList *languages)
       }
     }
     else
-      dt_print(DT_DEBUG_ALWAYS, "[l10n] error: element %d has no name, skipping\n", i);
+      dt_print(DT_DEBUG_ALWAYS,
+               "[l10n] error: element %d has no name, skipping\n", i);
 
     json_reader_end_element(reader);
   }
@@ -302,7 +318,8 @@ dt_l10n_t *dt_l10n_init(gboolean init_list)
   const char *old_env = g_getenv("LANGUAGE");
 
 #if defined(_WIN32)
-  // get the default locale if no language preference was specified in the config file
+  // get the default locale if no language preference was specified in
+  // the config file
   if(!ui_lang || !*ui_lang)
   {
     const wchar_t *wcLocaleName = NULL;
@@ -321,19 +338,22 @@ dt_l10n_t *dt_l10n_init(gboolean init_list)
 #endif // defined (_WIN32)
 
 
-  // prepare the list of available gui translations from which the user can pick in prefs
+  // prepare the list of available gui translations from which the
+  // user can pick in prefs
   if(init_list)
   {
     dt_l10n_language_t *selected = NULL;
     dt_l10n_language_t *sys_default = NULL;
 
-    dt_l10n_language_t *language = (dt_l10n_language_t *)calloc(1, sizeof(dt_l10n_language_t));
+    dt_l10n_language_t *language =
+      (dt_l10n_language_t *)calloc(1, sizeof(dt_l10n_language_t));
     language->code = g_strdup("C");
     language->base_code = g_strdup("C");
     language->name = g_strdup("English");
     result->languages = g_list_append(result->languages, language);
 
-    if(g_strcmp0(ui_lang, "C") == 0) selected = language;
+    if(g_strcmp0(ui_lang, "C") == 0)
+      selected = language;
 
     const gchar * const * default_languages = g_get_language_names();
 
@@ -345,13 +365,15 @@ dt_l10n_t *dt_l10n_init(gboolean init_list)
       const gchar *locale;
       while((locale = g_dir_read_name(dir)))
       {
-        gchar *testname = g_build_filename(localedir, locale, "LC_MESSAGES", GETTEXT_PACKAGE ".mo", NULL);
+        gchar *testname = g_build_filename(localedir, locale,
+                                           "LC_MESSAGES", GETTEXT_PACKAGE ".mo", NULL);
         if(g_file_test(testname, G_FILE_TEST_EXISTS))
         {
           language = (dt_l10n_language_t *)calloc(1, sizeof(dt_l10n_language_t));
           result->languages = g_list_prepend(result->languages, language);
 
-          // some languages have a regional part in the filename, we don't want that for name lookup
+          // some languages have a regional part in the filename, we
+          // don't want that for name lookup
           char *delimiter = strchr(locale, '_');
           if(delimiter)
             language->base_code = g_strndup(locale, delimiter - locale);
@@ -361,7 +383,8 @@ dt_l10n_t *dt_l10n_init(gboolean init_list)
           if(delimiter)
           {
             char *tmp = language->base_code;
-            language->base_code = g_strndup(language->base_code, delimiter - language->base_code);
+            language->base_code = g_strndup(language->base_code,
+                                            delimiter - language->base_code);
             g_free(tmp);
           }
 
@@ -380,7 +403,8 @@ dt_l10n_t *dt_l10n_init(gboolean init_list)
           }
 
           language->code = g_strdup(locale);
-          language->name = g_strdup_printf("%s%s", locale, language->is_default ? " *" : "");
+          language->name = g_strdup_printf("%s%s", locale,
+                                           language->is_default ? " *" : "");
 
           if(g_strcmp0(ui_lang, language->code) == 0)
             selected = language;
@@ -390,7 +414,8 @@ dt_l10n_t *dt_l10n_init(gboolean init_list)
       g_dir_close(dir) ;
     }
     else
-      dt_print(DT_DEBUG_ALWAYS, "[l10n] error: can't open directory `%s'\n", localedir);
+      dt_print(DT_DEBUG_ALWAYS,
+               "[l10n] error: can't open directory `%s'\n", localedir);
 
     // default to English if no other language matched
     if(!sys_default)
@@ -405,8 +430,8 @@ dt_l10n_t *dt_l10n_init(gboolean init_list)
     // now try to find language names and translations!
     get_language_names(result->languages);
 
-    // set the requested gui language.
-    // this has to happen before sorting the list as the sort result may depend on the language.
+    // set the requested gui language.  this has to happen before
+    // sorting the list as the sort result may depend on the language.
     set_locale(ui_lang, old_env);
 
     // sort the list of languages

--- a/src/common/l10n.h
+++ b/src/common/l10n.h
@@ -34,7 +34,7 @@ typedef struct dt_l10n_t
   int sys_default;
 } dt_l10n_t;
 
-dt_l10n_t *dt_l10n_init(gboolean init_list);
+dt_l10n_t *dt_l10n_init(const gchar *filename, const gboolean init_list);
 
 const char *dt_l10n_get_name(const dt_l10n_language_t *language);
 // clang-format off
@@ -42,4 +42,3 @@ const char *dt_l10n_get_name(const dt_l10n_language_t *language);
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/control/conf.h
+++ b/src/control/conf.h
@@ -133,6 +133,12 @@ const char *dt_confgen_get_tooltip(const char *name);
 gboolean dt_conf_is_default(const char *name);
 gchar* dt_conf_expand_default_dir(const char *dir);
 
+/** read filename and call callback() for every key/valye pair. if callback() returns non
+    NULL, the value is returned by dt_conf_read_values. This may be used to look for a
+    a specific value in filename */
+gchar *dt_conf_read_values(const char *filename,
+                           gchar* (*callback)(const gchar *key, const gchar *value));
+
 #ifdef __cplusplus
 } // extern "C"
 #endif /* __cplusplus */
@@ -142,4 +148,3 @@ gchar* dt_conf_expand_default_dir(const char *dir);
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/control/conf.h
+++ b/src/control/conf.h
@@ -93,10 +93,12 @@ int dt_conf_get_and_sanitize_int(const char *name, int min, int max);
 int64_t dt_conf_get_and_sanitize_int64(const char *name, int64_t min, int64_t max);
 float dt_conf_get_and_sanitize_float(const char *name, float min, float max);
 int dt_conf_get_bool(const char *name);
-// get the configuration string without duplicating it; the returned string will be invalidated by any
-// subsequent dt_conf_set_string call
+// get the configuration string without duplicating it; the returned
+// string will be invalidated by any subsequent dt_conf_set_string
+// call
 const char *dt_conf_get_string_const(const char *name);
-// get a freshly-allocated duplicate of the configuration string; safe to use even if calling dt_conf_set_string
+// get a freshly-allocated duplicate of the configuration string; safe
+// to use even if calling dt_conf_set_string
 gchar *dt_conf_get_string(const char *name);
 gboolean dt_conf_get_folder_to_file_chooser(const char *name, GtkFileChooser *chooser);
 gboolean dt_conf_is_equal(const char *name, const char *value);


### PR DESCRIPTION
1.    Fix translation by ensuring the set language is read earlier.
    
    The language in darktablerc was set after reading the confgen and
    conf preferences. This was breaking the UI by having the strings in
    XML configuration file darktableconfig.xml.in using the OS default
    language.
    
    Now the language (and only the language) is read from darktablerc
    and set in l10n initialization which is called earlier in
    darktable initialization.
    
    Fixes #14513.

2.    conf: Code refactoring.
    
    Introduce a way to walk all conf Key/values. A callback is now used
    to set the corresponding key into the hash table.
    
    This is to reuse the parsing in another context.
    
    Part of #14513.
