### PR TITLE
3 Raster mask fixes

### DIFF
--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -433,7 +433,7 @@ void dt_develop_blendif_process_parameters(float *const parameters,
  *
  * The initialized profile may only be used to convert from RGB to XYZ.
  */
-int dt_develop_blendif_init_masking_profile
+gboolean dt_develop_blendif_init_masking_profile
   (struct dt_dev_pixelpipe_iop_t *piece,
    dt_iop_order_iccprofile_info_t *blending_profile,
    const dt_develop_blend_colorspace_t cst);
@@ -522,7 +522,7 @@ gboolean blend_color_picker_apply(dt_iop_module_t *module,
 
 #ifdef HAVE_OPENCL
 /** apply blend for opencl modules*/
-int dt_develop_blend_process_cl(struct dt_iop_module_t *self,
+gboolean dt_develop_blend_process_cl(struct dt_iop_module_t *self,
                                 struct dt_dev_pixelpipe_iop_t *piece,
                                 cl_mem dev_in, cl_mem dev_out,
                                 const struct dt_iop_roi_t *roi_in,

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2879,7 +2879,7 @@ static void _raster_value_changed_callback(GtkWidget *widget,
   }
 
   module->raster_mask.sink.source = entry->module;
-  module->raster_mask.sink.id = entry->id;
+  module->raster_mask.sink.id = entry->module ? entry->id : INVALID_MASKID;
 
   gboolean reprocess = FALSE;
 

--- a/src/develop/blends/blendif_rgb_hsl.c
+++ b/src/develop/blends/blendif_rgb_hsl.c
@@ -290,7 +290,7 @@ void dt_develop_blendif_rgb_hsl_make_mask(struct dt_dev_pixelpipe_iop_t *piece, 
     dt_develop_blendif_process_parameters(parameters, d);
 
     dt_iop_order_iccprofile_info_t blend_profile;
-    const int use_profile = dt_develop_blendif_init_masking_profile(piece, &blend_profile,
+    const gboolean use_profile = dt_develop_blendif_init_masking_profile(piece, &blend_profile,
                                                                     DEVELOP_BLEND_CS_RGB_DISPLAY);
     const dt_iop_order_iccprofile_info_t *profile = use_profile ? &blend_profile : NULL;
 
@@ -1399,7 +1399,7 @@ void dt_develop_blendif_rgb_hsl_blend(struct dt_dev_pixelpipe_iop_t *piece,
   if(request_mask_display & DT_DEV_PIXELPIPE_DISPLAY_ANY)
   {
     dt_iop_order_iccprofile_info_t blend_profile;
-    const int use_profile = dt_develop_blendif_init_masking_profile(piece, &blend_profile,
+    const gboolean use_profile = dt_develop_blendif_init_masking_profile(piece, &blend_profile,
                                                                     DEVELOP_BLEND_CS_RGB_DISPLAY);
     const dt_iop_order_iccprofile_info_t *profile = use_profile ? &blend_profile : NULL;
     const float *const restrict boost_factors = d->blendif_boost_factors;

--- a/src/develop/blends/blendif_rgb_jzczhz.c
+++ b/src/develop/blends/blendif_rgb_jzczhz.c
@@ -1044,7 +1044,7 @@ void dt_develop_blendif_rgb_jzczhz_blend(struct dt_dev_pixelpipe_iop_t *piece, c
   if(request_mask_display & DT_DEV_PIXELPIPE_DISPLAY_ANY)
   {
     dt_iop_order_iccprofile_info_t blend_profile;
-    const int use_profile = dt_develop_blendif_init_masking_profile(piece, &blend_profile,
+    const gboolean use_profile = dt_develop_blendif_init_masking_profile(piece, &blend_profile,
                                                                     DEVELOP_BLEND_CS_RGB_SCENE);
     const dt_iop_order_iccprofile_info_t *profile = use_profile ? &blend_profile : NULL;
     const float *const restrict boost_factors = d->blendif_boost_factors;


### PR DESCRIPTION
1. In case a raster mask is requested but there is none for any reason use a zero-filled buffer.
2. In case we can't copy a raster mask from cl-buffer to host we can't use that and report an error
3. If we select a raster mask via the menu we ensure an invalid mask-id if no source module was selected

While being here a few int->gbooleans modifications