### PR TITLE
Fix raster mask source handling

### DIFF
--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -1235,11 +1235,11 @@ void dt_ioppr_transform_image_colorspace
     {
       dt_get_times(&end_time);
       dt_print(DT_DEBUG_ALWAYS,
-               "[dt_ioppr_transform_image_colorspace] %s-->%s took %.3f secs (%.3f CPU) [%s %s]\n",
+               "[dt_ioppr_transform_image_colorspace] %s-->%s took %.3f secs (%.3f CPU) [%s%s]\n",
                dt_iop_colorspace_to_name(cst_from), dt_iop_colorspace_to_name(cst_to),
                end_time.clock - start_time.clock,
                end_time.user - start_time.user,
-               self->op, self->multi_name);
+               self->op, dt_iop_get_instance_id(self));
     }
   }
   else
@@ -1251,19 +1251,19 @@ void dt_ioppr_transform_image_colorspace
     {
       dt_get_times(&end_time);
       dt_print(DT_DEBUG_ALWAYS,
-               "[dt_ioppr_transform_image_colorspace] %s-->%s took %.3f secs (%.3f lcms2) [%s %s]\n",
+               "[dt_ioppr_transform_image_colorspace] %s-->%s took %.3f secs (%.3f lcms2) [%s%s]\n",
                dt_iop_colorspace_to_name(cst_from), dt_iop_colorspace_to_name(cst_to),
                end_time.clock - start_time.clock,
                end_time.user - start_time.user,
-               self->op, self->multi_name);
+               self->op, dt_iop_get_instance_id(self));
     }
   }
 
   if(*converted_cst == cst_from)
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_ioppr_transform_image_colorspace] in `%s', profile `%s',"
+             "[dt_ioppr_transform_image_colorspace] in `%s%s', profile `%s',"
              " invalid conversion from %s to %s\n",
-             self->so->op,
+             self->op, dt_iop_get_instance_id(self),
              dt_colorspaces_get_name(profile_info->type, profile_info->filename),
              dt_iop_colorspace_to_name(cst_from),
              dt_iop_colorspace_to_name(cst_to));
@@ -1545,9 +1545,10 @@ gboolean dt_ioppr_transform_image_colorspace_cl
       err = CL_INVALID_KERNEL;
       *converted_cst = cst_from;
       dt_print(DT_DEBUG_ALWAYS,
-               "[dt_ioppr_transform_image_colorspace_cl] in `%s', profile `%s',"
+               "[dt_ioppr_transform_image_colorspace_cl] in `%s%s', profile `%s',"
                " invalid conversion from %s to %s\n",
-               self->so->op, dt_colorspaces_get_name(profile_info->type, profile_info->filename),
+               self->op, dt_iop_get_instance_id(self),
+               dt_colorspaces_get_name(profile_info->type, profile_info->filename),
                dt_iop_colorspace_to_name(cst_from),
                dt_iop_colorspace_to_name(cst_to));
       goto cleanup;
@@ -1601,11 +1602,11 @@ gboolean dt_ioppr_transform_image_colorspace_cl
     {
       dt_get_times(&end_time);
       dt_print(DT_DEBUG_ALWAYS,
-               "[dt_ioppr_transform_image_colorspace_cl] %s-->%s took %.3f secs (%.3f GPU) [%s %s]\n",
+               "[dt_ioppr_transform_image_colorspace_cl] %s-->%s took %.3f secs (%.3f GPU) [%s%s]\n",
                dt_iop_colorspace_to_name(cst_from), dt_iop_colorspace_to_name(cst_to),
                end_time.clock - start_time.clock,
                end_time.user - start_time.user,
-               self->op, self->multi_name);
+               self->op, dt_iop_get_instance_id(self));
     }
   }
   else

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -1594,7 +1594,7 @@ static void _fix_masks_combine(dt_develop_blend_params_t *bp)
 }
 
 /** update blendop params from older versions */
-int dt_develop_blend_legacy_params(dt_iop_module_t *module,
+gboolean dt_develop_blend_legacy_params(dt_iop_module_t *module,
                                    const void *const old_params,
                                    const int old_version,
                                    void *new_params,
@@ -1618,7 +1618,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module,
     dt_develop_blend_params_t *n = (dt_develop_blend_params_t *)new_params;
 
     *n = default_display_blend_params;
-    return 0;
+    return FALSE;
   }
 
   if(old_version == 1 && new_version == 12)
@@ -1643,7 +1643,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module,
     n->blend_mode = _blend_legacy_blend_mode(o->mode);
     n->opacity = o->opacity;
     n->mask_id = o->mask_id;
-    return 0;
+    return FALSE;
   }
 
   if(old_version == 2 && new_version == 12)
@@ -1684,7 +1684,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module,
                                     // 2; also switch off old "active" bit
     for(int i = 0; i < (4 * 8); i++) n->blendif_parameters[i] = o->blendif_parameters[i];
 
-    return 0;
+    return FALSE;
   }
 
   if(old_version == 3 && new_version == 12)
@@ -1725,7 +1725,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module,
     memcpy(n->blendif_parameters, o->blendif_parameters,
            sizeof(float) * 4 * DEVELOP_BLENDIF_SIZE);
 
-    return 0;
+    return FALSE;
   }
 
   if(old_version == 4 && new_version == 12)
@@ -1768,7 +1768,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module,
     n->blendif = o->blendif & ~(1u << DEVELOP_BLENDIF_active);
     memcpy(n->blendif_parameters, o->blendif_parameters,
            sizeof(float) * 4 * DEVELOP_BLENDIF_SIZE);
-    return 0;
+    return FALSE;
   }
 
   if(old_version == 5 && new_version == 12)
@@ -1820,7 +1820,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module,
     memcpy(n->blendif_parameters, o->blendif_parameters,
            sizeof(float) * 4 * DEVELOP_BLENDIF_SIZE);
     _fix_masks_combine(n);
-    return 0;
+    return FALSE;
   }
 
   if(old_version == 6 && new_version == 12)
@@ -1865,7 +1865,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module,
     memcpy(n->blendif_parameters, o->blendif_parameters,
            sizeof(float) * 4 * DEVELOP_BLENDIF_SIZE);
     _fix_masks_combine(n);
-    return 0;
+    return FALSE;
   }
 
   if(old_version == 7 && new_version == 12)
@@ -1910,7 +1910,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module,
     memcpy(n->blendif_parameters, o->blendif_parameters,
            sizeof(float) * 4 * DEVELOP_BLENDIF_SIZE);
     _fix_masks_combine(n);
-    return 0;
+    return FALSE;
   }
 
   if(old_version == 8 && new_version == 12)
@@ -1967,7 +1967,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module,
     memcpy(n->blendif_parameters, o->blendif_parameters,
            sizeof(float) * 4 * DEVELOP_BLENDIF_SIZE);
     _fix_masks_combine(n);
-    return 0;
+    return FALSE;
   }
 
   if(old_version == 9 && new_version == 12)
@@ -2008,7 +2008,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module,
       gboolean raster_mask_invert;
     } dt_develop_blend_params9_t;
 
-    if(length != sizeof(dt_develop_blend_params9_t)) return 1;
+    if(length != sizeof(dt_develop_blend_params9_t)) return TRUE;
 
     dt_develop_blend_params9_t *o = (dt_develop_blend_params9_t *)old_params;
     dt_develop_blend_params_t *n = (dt_develop_blend_params_t *)new_params;
@@ -2033,7 +2033,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module,
     n->raster_mask_id = o->raster_mask_id;
     n->raster_mask_invert = o->raster_mask_invert;
     _fix_masks_combine(n);
-    return 0;
+    return FALSE;
   }
 
   if(old_version == 10 && new_version == 12)
@@ -2079,7 +2079,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module,
       gboolean raster_mask_invert;
     } dt_develop_blend_params10_t;
 
-    if(length != sizeof(dt_develop_blend_params10_t)) return 1;
+    if(length != sizeof(dt_develop_blend_params10_t)) return TRUE;
 
     dt_develop_blend_params10_t *o = (dt_develop_blend_params10_t *)old_params;
     dt_develop_blend_params_t *n = (dt_develop_blend_params_t *)new_params;
@@ -2116,7 +2116,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module,
 
     _fix_masks_combine(n);
 
-    return 0;
+    return FALSE;
   }
   if(old_version == 11 && new_version == 12)
   {
@@ -2127,12 +2127,12 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module,
 
     *n = *o;
     _fix_masks_combine(n);
-    return 0;
+    return FALSE;
   }
-  return 1;
+  return TRUE;
 }
 
-int dt_develop_blend_legacy_params_from_so(dt_iop_module_so_t *module_so,
+gboolean dt_develop_blend_legacy_params_from_so(dt_iop_module_so_t *module_so,
                                            const void *const old_params,
                                            const int old_version,
                                            void *new_params,
@@ -2144,18 +2144,18 @@ int dt_develop_blend_legacy_params_from_so(dt_iop_module_so_t *module_so,
   if(dt_iop_load_module_by_so(module, module_so, NULL))
   {
     free(module);
-    return 1;
+    return TRUE;
   }
 
   if(module->params_size == 0)
   {
     dt_iop_cleanup_module(module);
     free(module);
-    return 1;
+    return TRUE;
   }
 
   // convert the old blend params to new
-  const int res = dt_develop_blend_legacy_params(module, old_params, old_version,
+  const gboolean res = dt_develop_blend_legacy_params(module, old_params, old_version,
                                                  new_params, dt_develop_blend_version(),
                                                  length);
   dt_iop_cleanup_module(module);

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -743,7 +743,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self,
   {
     g_hash_table_remove(piece->raster_masks, GINT_TO_POINTER(BLEND_RASTER_ID));
     dt_free_align(_mask);
-    dt_print_pipe(DT_DEBUG_PIPE,
+    dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
        "clear raster mask on CPU", piece->pipe, self, roi_in, roi_out, "\n");
   }
 }
@@ -1382,7 +1382,7 @@ gboolean dt_develop_blend_process_cl(struct dt_iop_module_t *self,
   {
     g_hash_table_remove(piece->raster_masks, GINT_TO_POINTER(BLEND_RASTER_ID));
     dt_free_align(_mask);
-    dt_print_pipe(DT_DEBUG_PIPE,
+    dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
        "clear raster mask CL", piece->pipe, self, roi_in, roi_out, "\n");
   }
 

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -397,13 +397,13 @@ gboolean dt_develop_blend_params_is_all_zero(const void *params,
                                              const size_t length);
 
 /** update blendop params from older versions */
-int dt_develop_blend_legacy_params(dt_iop_module_t *module,
+gboolean dt_develop_blend_legacy_params(dt_iop_module_t *module,
                                    const void *const old_params,
                                    const int old_version,
                                    void *new_params,
                                    const int new_version,
                                    const int length);
-int dt_develop_blend_legacy_params_from_so(dt_iop_module_so_t *module_so,
+gboolean dt_develop_blend_legacy_params_from_so(dt_iop_module_so_t *module_so,
                                            const void *const old_params,
                                            const int old_version,
                                            void *new_params,

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -608,7 +608,7 @@ static void _blendop_masks_mode_callback(const unsigned int mask_mode,
 
   _box_set_visible(data->top_box, mask_mode & DEVELOP_MASK_ENABLED);
 
-  dt_iop_set_mask_mode(data->module, mask_mode);
+  dt_iop_advertise_rastermask(data->module, mask_mode);
 
   if((mask_mode & DEVELOP_MASK_ENABLED)
      && ((data->masks_inited && (mask_mode & DEVELOP_MASK_MASK))

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -373,7 +373,7 @@ int dt_iop_load_module_so(void *m, const char *libname, const char *module_name)
   return 0;
 }
 
-int dt_iop_load_module_by_so(dt_iop_module_t *module,
+gboolean dt_iop_load_module_by_so(dt_iop_module_t *module,
                              dt_iop_module_so_t *so,
                              dt_develop_t *dev)
 {
@@ -460,10 +460,10 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module,
   {
     dt_print(DT_DEBUG_ALWAYS,
              "[iop_load_module] `%s' needs to have a params size > 0!\n", so->op);
-    return 1; // empty params hurt us in many places, just add a dummy value
+    return TRUE; // empty params hurt us in many places, just add a dummy value
   }
   module->enabled = module->default_enabled; // apply (possibly new) default.
-  return 0;
+  return FALSE;
 }
 
 void dt_iop_init_pipe(struct dt_iop_module_t *module,
@@ -1675,7 +1675,7 @@ void dt_iop_load_modules_so(void)
                                   (gpointer)(darktable.iop));
 }
 
-int dt_iop_load_module(dt_iop_module_t *module,
+gboolean dt_iop_load_module(dt_iop_module_t *module,
                        dt_iop_module_so_t *module_so,
                        dt_develop_t *dev)
 {
@@ -1683,9 +1683,9 @@ int dt_iop_load_module(dt_iop_module_t *module,
   if(dt_iop_load_module_by_so(module, module_so, dev))
   {
     free(module);
-    return 1;
+    return TRUE;
   }
-  return 0;
+  return FALSE;
 }
 
 GList *dt_iop_load_modules_ext(dt_develop_t *dev, const gboolean no_image)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1771,9 +1771,9 @@ void dt_iop_unload_modules_so()
   }
 }
 
-void dt_iop_set_mask_mode(dt_iop_module_t *module, int mask_mode)
+void dt_iop_advertise_rastermask(dt_iop_module_t *module, int mask_mode)
 {
-  static const int key = 0;
+  static const int key = BLEND_RASTER_ID;
   // showing raster masks doesn't make sense, one can use the original
   // source instead. or does it?
   if(mask_mode & DEVELOP_MASK_ENABLED && !(mask_mode & DEVELOP_MASK_RASTER))
@@ -1804,7 +1804,7 @@ dt_iop_module_t *dt_iop_commit_blend_params(dt_iop_module_t *module,
     module->blend_params->blend_cst =
       dt_develop_blend_default_module_blend_colorspace(module);
   }
-  dt_iop_set_mask_mode(module, blendop_params->mask_mode);
+  dt_iop_advertise_rastermask(module, blendop_params->mask_mode);
 
   // If we use default blending parameters or don't have a dev
   // we don't manage raster mask users

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1831,7 +1831,7 @@ dt_iop_module_t *dt_iop_commit_blend_params(dt_iop_module_t *module,
         module->raster_mask.sink.id = blendop_params->raster_mask_id;
         dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
            "commit_blend_params", NULL, module, NULL, NULL, "raster mask from '%s%s', %s\n",
-           candidate->name(), dt_iop_get_instance_name(candidate),
+           candidate->op, dt_iop_get_instance_id(candidate),
            in_use ? "in_use" : "new");
         return in_use ? NULL : candidate;
       }
@@ -3484,6 +3484,11 @@ const char *dt_iop_get_instance_name(const dt_iop_module_t *module)
   return (module->multi_priority > 0 || module->multi_name_hand_edited)
     ? module->multi_name
     : "";
+}
+const char *dt_iop_get_instance_id(const dt_iop_module_t *module)
+{
+  const char *ids[] = { "", ".1", ".2", ".3", ".4", ".5", ".6", ".x" };
+  return ids[MIN(module->multi_priority, 7)];
 }
 
 void dt_iop_refresh_center(dt_iop_module_t *module)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1788,16 +1788,16 @@ void dt_iop_set_mask_mode(dt_iop_module_t *module, int mask_mode)
 }
 
 /* make sure that blend_params are in sync with the iop struct
-   Also watch out for a raster mask source module to get it's first `target`
-   entry, if so we invalidate all cachelines from modules with a higher iop order.
-   To support this, dt_iop_commit_blend_params() either returns NULL or the source module.
+   1. Handling of raster mask users must only be done if we don't use module's default
+      blending parameters.
+   2. Also watch out for a raster mask source module to get it's first `target`
+      entry, if so we should invalidate all cachelines from modules with a higher iop order
+      in dt_iop_commit_blend_params() callers.
+      To support this, dt_iop_commit_blend_params() either returns NULL or the source module.
 */
 dt_iop_module_t *dt_iop_commit_blend_params(dt_iop_module_t *module,
                                 const dt_develop_blend_params_t *blendop_params)
 {
-  if(module->raster_mask.sink.source)
-    g_hash_table_remove(module->raster_mask.sink.source->raster_mask.source.users, module);
-
   memcpy(module->blend_params, blendop_params, sizeof(dt_develop_blend_params_t));
   if(blendop_params->blend_cst == DEVELOP_BLEND_CS_NONE)
   {
@@ -1806,26 +1806,47 @@ dt_iop_module_t *dt_iop_commit_blend_params(dt_iop_module_t *module,
   }
   dt_iop_set_mask_mode(module, blendop_params->mask_mode);
 
-  if(module->dev)
+  // If we use default blending parameters or don't have a dev
+  // we don't manage raster mask users
+  if(blendop_params == module->default_blendop_params
+     || module->dev == NULL)
+    return NULL;
+
+  for(GList *iter = module->dev->iop; iter; iter = g_list_next(iter))
   {
-    for(GList *iter = module->dev->iop; iter; iter = g_list_next(iter))
+    dt_iop_module_t *candidate = (dt_iop_module_t *)iter->data;
+    if(dt_iop_module_is(candidate->so, blendop_params->raster_mask_source))
     {
-      dt_iop_module_t *m = (dt_iop_module_t *)iter->data;
-      if(dt_iop_module_is(m->so, blendop_params->raster_mask_source))
+      if(candidate->multi_priority == blendop_params->raster_mask_instance)
       {
-        if(m->multi_priority == blendop_params->raster_mask_instance)
-        {
-          const gboolean in_use = dt_iop_is_raster_mask_used(m, blendop_params->raster_mask_id);
-          g_hash_table_insert(m->raster_mask.source.users,
-                              module, GINT_TO_POINTER(blendop_params->raster_mask_id));
-          module->raster_mask.sink.source = m;
-          module->raster_mask.sink.id = blendop_params->raster_mask_id;
-          return in_use ? NULL : m;
-        }
+        /* we check for the candidate already being used as a raster mask source
+           - this means it will write it's blend output as the raster mask
+           to avoid invalidation of the pixelpipe cache if it's already in use
+        */
+        const gboolean in_use = dt_iop_is_raster_mask_used(candidate, blendop_params->raster_mask_id);
+        g_hash_table_insert(candidate->raster_mask.source.users,
+                            module,
+                            GINT_TO_POINTER(blendop_params->raster_mask_id));
+        module->raster_mask.sink.source = candidate;
+        module->raster_mask.sink.id = blendop_params->raster_mask_id;
+        dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
+           "commit_blend_params", NULL, module, NULL, NULL, "raster mask from '%s%s', %s\n",
+           candidate->name(), dt_iop_get_instance_name(candidate),
+           in_use ? "in_use" : "new");
+        return in_use ? NULL : candidate;
       }
     }
   }
 
+  /* We don't use a raster mask as source so we will remove this module as a user from the hash table
+     and set sink source and id to default == 'nothing'
+  */
+  if(module->raster_mask.sink.source)
+  {
+    dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
+        "commit_blend_params", NULL, module, NULL, NULL, "clear raster mask sink\n");
+    g_hash_table_remove(module->raster_mask.sink.source->raster_mask.source.users, module);
+  }
   module->raster_mask.sink.source = NULL;
   module->raster_mask.sink.id = INVALID_MASKID;
   return NULL;

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -422,7 +422,7 @@ void dt_iop_commit_params(dt_iop_module_t *module,
 dt_iop_module_t *dt_iop_commit_blend_params(dt_iop_module_t *module,
                                 const struct dt_develop_blend_params_t *blendop_params);
 /** make sure the raster mask is advertised if available */
-void dt_iop_set_mask_mode(dt_iop_module_t *module, int mask_mode);
+void dt_iop_advertise_rastermask(dt_iop_module_t *module, int mask_mode);
 /** creates a label widget for the expander, with callback to enable/disable this module. */
 void dt_iop_gui_set_expander(dt_iop_module_t *module);
 /** get the widget of plugin ui in expander */

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -489,7 +489,7 @@ gboolean dt_iop_is_first_instance(GList *modules, dt_iop_module_t *module);
     for instance 0 or if hand-edited. Otherwise the name is the empty string.
  */
 const char *dt_iop_get_instance_name(const dt_iop_module_t *module);
-
+const char *dt_iop_get_instance_id(const dt_iop_module_t *module);
 /** get module flags, works in dev and lt mode */
 int dt_iop_get_module_flags(const char *op);
 

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -353,13 +353,13 @@ void dt_iop_load_modules_so(void);
 /** cleans up the dlopen refs. */
 void dt_iop_unload_modules_so(void);
 /** load a module for a given .so */
-int dt_iop_load_module_by_so(dt_iop_module_t *module,
+gboolean dt_iop_load_module_by_so(dt_iop_module_t *module,
                              dt_iop_module_so_t *so,
                              struct dt_develop_t *dev);
 /** returns a list of instances referencing stuff loaded in load_modules_so. */
 GList *dt_iop_load_modules_ext(struct dt_develop_t *dev, gboolean no_image);
 GList *dt_iop_load_modules(struct dt_develop_t *dev);
-int dt_iop_load_module(dt_iop_module_t *module,
+gboolean dt_iop_load_module(dt_iop_module_t *module,
                        dt_iop_module_so_t *module_so,
                        struct dt_develop_t *dev);
 /** calls module->cleanup and closes the dl connection. */

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2210,7 +2210,7 @@ static gboolean _dev_pixelpipe_process_rec(
         /* Bad luck, opencl failed. Let's clean up and fall back to cpu module */
         dt_print_pipe(DT_DEBUG_OPENCL,
            "pixelpipe_process_CL", pipe, module, &roi_in, roi_out, "%s\n",
-                "couldn't run module on GPG, falling back to CPU");
+                "couldn't run module on GPU, falling back to CPU");
 
         // fprintf(stderr, "[opencl_pixelpipe 4] module '%s' running on cpu\n", module->op);
 

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -578,8 +578,8 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self, struct dt_
   void *input = NULL;
   void *output = NULL;
   dt_print(DT_DEBUG_TILING,
-           "[default_process_tiling_ptp] [%s] **** tiling module '%s' for image with size %dx%d --> %dx%d\n",
-           dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op,
+           "[default_process_tiling_ptp] [%s] **** tiling module '%s%s' for image with size %dx%d --> %dx%d\n",
+           dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self),
            roi_in->width, roi_in->height, roi_out->width, roi_out->height);
   dt_iop_buffer_dsc_t dsc;
   self->output_format(self, piece->pipe, piece, &dsc);
@@ -599,9 +599,9 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self, struct dt_
      && (tiling.overhead < 0.2f * roi_in->width * roi_in->height * max_bpp))
   {
     dt_print(DT_DEBUG_TILING,
-             "[default_process_tiling_ptp] [%s]  no need to use tiling for module '%s' "
+             "[default_process_tiling_ptp] [%s]  no need to use tiling for module '%s%s' "
              "as no real memory saving to be expected\n",
-             dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op);
+             dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
     goto fallback;
   }
 
@@ -688,8 +688,9 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self, struct dt_
   if(tiles_x * tiles_y > _maximum_number_tiles())
   {
     dt_print(DT_DEBUG_TILING,
-             "[default_process_tiling_ptp] [%s] gave up tiling for module '%s'. too many tiles: %d x %d\n",
-             dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, tiles_x, tiles_y);
+             "[default_process_tiling_ptp] [%s] gave up tiling for module '%s%s'. too many tiles: %d x %d\n",
+             dt_dev_pixelpipe_type_to_str(piece->pipe->type),
+             self->op, dt_iop_get_instance_id(self), tiles_x, tiles_y);
     goto error;
   }
 
@@ -702,16 +703,16 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self, struct dt_
   if(input == NULL)
   {
     dt_print(DT_DEBUG_TILING,
-             "[default_process_tiling_ptp] [%s] could not alloc input buffer for module '%s'\n",
-             dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op);
+             "[default_process_tiling_ptp] [%s] could not alloc input buffer for module '%s%s'\n",
+             dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
     goto error;
   }
   output = dt_alloc_align(64, (size_t)width * height * out_bpp);
   if(output == NULL)
   {
     dt_print(DT_DEBUG_TILING,
-             "[default_process_tiling_ptp] [%s]  could not alloc output buffer for module '%s'\n",
-             dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op);
+             "[default_process_tiling_ptp] [%s]  could not alloc output buffer for module '%s%s'\n",
+             dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
     goto error;
   }
 
@@ -773,8 +774,9 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self, struct dt_
       {
         if(tx + ty > 0 && fabs(processed_maximum_new[k] - piece->pipe->dsc.processed_maximum[k]) > 1.0e-6f)
           dt_print(DT_DEBUG_TILING,
-                   "[default_process_tiling_ptp] [%s] processed_maximum[%d] differs between tiles in module '%s'\n",
-                   dt_dev_pixelpipe_type_to_str(piece->pipe->type), k, self->op);
+                   "[default_process_tiling_ptp] [%s] processed_maximum[%d] differs between tiles in module '%s%s'\n",
+                   dt_dev_pixelpipe_type_to_str(piece->pipe->type), k,
+                   self->op, dt_iop_get_instance_id(self));
         processed_maximum_new[k] = piece->pipe->dsc.processed_maximum[k];
       }
 
@@ -823,8 +825,8 @@ fallback:
   if(output != NULL) dt_free_align(output);
   piece->pipe->tiling = FALSE;
   dt_print(DT_DEBUG_TILING,
-           "[default_process_tiling_ptp] [%s] fall back to standard processing for module '%s'\n",
-           dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op);
+           "[default_process_tiling_ptp] [%s] fall back to standard processing for module '%s%s'\n",
+           dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
   self->process(self, piece, ivoid, ovoid, roi_in, roi_out);
   return;
 }
@@ -842,9 +844,10 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
   void *output = NULL;
 
   dt_print(DT_DEBUG_TILING,
-           "[default_process_tiling_roi] [%s] **** tiling module '%s' for "
+           "[default_process_tiling_roi] [%s] **** tiling module '%s%s' for "
            "image input size %dx%d --> %dx%d\n",
-           dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op,
+           dt_dev_pixelpipe_type_to_str(piece->pipe->type),
+           self->op, dt_iop_get_instance_id(self),
            roi_in->width, roi_in->height, roi_out->width, roi_out->height);
   _print_roi(roi_in, "module roi_in");
   _print_roi(roi_out, "module roi_out");
@@ -876,8 +879,8 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
   {
     dt_print(DT_DEBUG_TILING,
              "[default_process_tiling_roi] [%s] no need to use tiling for module "
-             "'%s' as no memory saving is expected\n",
-             dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op);
+             "'%s%s' as no memory saving is expected\n",
+             dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
     goto fallback;
   }
 
@@ -973,8 +976,9 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
   if(tiles_x * tiles_y > _maximum_number_tiles())
   {
     dt_print(DT_DEBUG_TILING,
-             "[default_process_tiling_roi] [%s] gave up tiling for module '%s'. too many tiles: %d x %d\n",
-             dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, tiles_x, tiles_y);
+             "[default_process_tiling_roi] [%s] gave up tiling for module '%s%s'. too many tiles: %d x %d\n",
+             dt_dev_pixelpipe_type_to_str(piece->pipe->type),
+             self->op, dt_iop_get_instance_id(self), tiles_x, tiles_y);
     goto error;
   }
 
@@ -1050,8 +1054,8 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
       {
         dt_print(DT_DEBUG_TILING,
                  "[default_process_tiling_roi] [%s] can not handle requested roi's. "
-                 "tiling for module '%s' not possible.\n",
-                 dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op);
+                 "tiling for module '%s%s' not possible.\n",
+                 dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
         goto error;
       }
 
@@ -1097,16 +1101,16 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
       if(input == NULL)
       {
         dt_print(DT_DEBUG_TILING,
-                 "[default_process_tiling_roi] [%s] could not alloc input buffer for module '%s'\n",
-                 dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op);
+                 "[default_process_tiling_roi] [%s] could not alloc input buffer for module '%s%s'\n",
+                 dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
         goto error;
       }
       output = dt_alloc_align(64, (size_t)oroi_full.width * oroi_full.height * out_bpp);
       if(output == NULL)
       {
         dt_print(DT_DEBUG_TILING,
-                 "[default_process_tiling_roi] [%s] could not alloc output buffer for module '%s'\n",
-                 dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op);
+                 "[default_process_tiling_roi] [%s] could not alloc output buffer for module '%s%s'\n",
+                 dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
         goto error;
       }
 
@@ -1133,8 +1137,8 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
       {
         if(tx + ty > 0 && fabs(processed_maximum_new[k] - piece->pipe->dsc.processed_maximum[k]) > 1.0e-6f)
           dt_print(DT_DEBUG_TILING,
-                   "[default_process_tiling_roi] processed_maximum[%d] differs between tiles in module '%s'\n",
-                   k, self->op);
+                   "[default_process_tiling_roi] processed_maximum[%d] differs between tiles in module '%s%s'\n",
+                   k, self->op, dt_iop_get_instance_id(self));
         processed_maximum_new[k] = piece->pipe->dsc.processed_maximum[k];
       }
 
@@ -1174,8 +1178,8 @@ fallback:
   if(output != NULL) dt_free_align(output);
   piece->pipe->tiling = FALSE;
   dt_print(DT_DEBUG_TILING,
-           "[default_process_tiling_roi] [%s] fall back to standard processing for module '%s'\n",
-           dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op);
+           "[default_process_tiling_roi] [%s] fall back to standard processing for module '%s%s'\n",
+           dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
   self->process(self, piece, ivoid, ovoid, roi_in, roi_out);
   return;
 }
@@ -1330,9 +1334,9 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
   void *output_buffer = NULL;
 
   dt_print(DT_DEBUG_TILING,
-           "[default_process_tiling_cl_ptp] [%s] **** tiling module '%s' "
+           "[default_process_tiling_cl_ptp] [%s] **** tiling module '%s%s' "
            "for image with size %dx%d --> %dx%d\n",
-           dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op,
+           dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self),
            roi_in->width, roi_in->height, roi_out->width, roi_out->height);
 
   dt_iop_buffer_dsc_t dsc;
@@ -1434,9 +1438,10 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
   if(tiles_x * tiles_y > _maximum_number_tiles())
   {
     dt_print(DT_DEBUG_TILING,
-             "[default_process_tiling_cl_ptp] [%s] aborted tiling for module '%s'. "
+             "[default_process_tiling_cl_ptp] [%s] aborted tiling for module '%s%s'. "
              "too many tiles: %d x %d\n",
-             dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, tiles_x, tiles_y);
+             dt_dev_pixelpipe_type_to_str(piece->pipe->type),
+             self->op, dt_iop_get_instance_id(self), tiles_x, tiles_y);
     return FALSE;
   }
 
@@ -1460,8 +1465,8 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
     {
       dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
                "[default_process_tiling_cl_ptp] could not alloc pinned "
-               "input buffer for module '%s'\n",
-               self->op);
+               "input buffer for module '%s%s'\n",
+               self->op, dt_iop_get_instance_id(self));
       use_pinned_memory = FALSE;
     }
   }
@@ -1475,8 +1480,8 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
     {
       dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
                "[default_process_tiling_cl_ptp] [%s] could not map pinned input buffer to host "
-               "memory for module '%s'\n",
-               dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op);
+               "memory for module '%s%s'\n",
+               dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
       use_pinned_memory = FALSE;
     }
   }
@@ -1490,8 +1495,8 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
     {
       dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
                "[default_process_tiling_cl_ptp] could not alloc pinned output "
-               "buffer for module '%s'\n",
-               self->op);
+               "buffer for module '%s%s'\n",
+               self->op, dt_iop_get_instance_id(self));
       use_pinned_memory = FALSE;
     }
   }
@@ -1505,8 +1510,8 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
     {
       dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
                "[default_process_tiling_cl_ptp] [%s] could not map pinned output buffer to host "
-               "memory for module '%s'\n",
-               dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op);
+               "memory for module '%s%s'\n",
+               dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
       use_pinned_memory = FALSE;
     }
   }
@@ -1595,8 +1600,8 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
       {
         if(tx + ty > 0 && fabs(processed_maximum_new[k] - piece->pipe->dsc.processed_maximum[k]) > 1.0e-6f)
           dt_print(DT_DEBUG_TILING,
-                   "[default_process_tiling_cl_ptp] [%s] processed_maximum[%d] differs between tiles in module '%s'\n",
-                   dt_dev_pixelpipe_type_to_str(piece->pipe->type), k, self->op);
+                   "[default_process_tiling_cl_ptp] [%s] processed_maximum[%d] differs between tiles in module '%s%s'\n",
+                   dt_dev_pixelpipe_type_to_str(piece->pipe->type), k, self->op, dt_iop_get_instance_id(self));
         processed_maximum_new[k] = piece->pipe->dsc.processed_maximum[k];
       }
 
@@ -1682,8 +1687,8 @@ error:
   const gboolean pinning_error = (use_pinned_memory == FALSE) && dt_opencl_use_pinned_memory(devid);
   dt_print(DT_DEBUG_TILING | DT_DEBUG_OPENCL,
            "[default_process_tiling_opencl_ptp] [%s] couldn't run process_cl() for "
-           "module '%s' in tiling mode:%s %s\n",
-           dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op,
+           "module '%s%s' in tiling mode:%s %s\n",
+           dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self),
            (pinning_error) ? " pinning problem" : "", cl_errstr(err));
   if(pinning_error) darktable.opencl->dev[devid].runtime_error |= DT_OPENCL_TUNE_PINNED;
   return FALSE;
@@ -1706,9 +1711,9 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
   void *output_buffer = NULL;
 
   dt_print(DT_DEBUG_TILING,
-           "[default_process_tiling_cl_roi] [%s] **** tiling module '%s' "
+           "[default_process_tiling_cl_roi] [%s] **** tiling module '%s%s' "
            "for image with input size %dx%d --> %dx%d\n",
-           dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op,
+           dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self),
            roi_in->width, roi_in->height, roi_out->width, roi_out->height);
   _print_roi(roi_in, "module roi_in");
   _print_roi(roi_out, "module roi_out");
@@ -1824,8 +1829,9 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
   if(tiles_x * tiles_y > _maximum_number_tiles())
   {
     dt_print(DT_DEBUG_TILING,
-             "[default_process_tiling_cl_roi] [%s] aborted tiling for module '%s'. too many tiles: %dx%d\n",
-             dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, tiles_x, tiles_y);
+             "[default_process_tiling_cl_roi] [%s] aborted tiling for module '%s%s'. too many tiles: %dx%d\n",
+             dt_dev_pixelpipe_type_to_str(piece->pipe->type),
+             self->op, dt_iop_get_instance_id(self), tiles_x, tiles_y);
     return FALSE;
   }
 
@@ -1855,8 +1861,8 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
     if(pinned_input == NULL)
     {
       dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
-               "[default_process_tiling_cl_roi] [%s] could not alloc pinned input buffer for module '%s'\n",
-               dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op);
+               "[default_process_tiling_cl_roi] [%s] could not alloc pinned input buffer for module '%s%s'\n",
+               dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
       use_pinned_memory = FALSE;
     }
   }
@@ -1870,8 +1876,8 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
     {
       dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
                "[default_process_tiling_cl_roi] [%s] could not map pinned input buffer to host "
-               "memory for module '%s'\n",
-               dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op);
+               "memory for module '%s%s'\n",
+               dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
       use_pinned_memory = FALSE;
     }
   }
@@ -1884,8 +1890,8 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
     if(pinned_output == NULL)
     {
       dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
-               "[default_process_tiling_cl_roi] [%s] could not alloc pinned output buffer for module '%s'\n",
-               dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op);
+               "[default_process_tiling_cl_roi] [%s] could not alloc pinned output buffer for module '%s%s'\n",
+               dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
       use_pinned_memory = FALSE;
     }
   }
@@ -1899,8 +1905,8 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
     {
       dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
                "[default_process_tiling_cl_roi] [%s] could not map pinned output buffer to host "
-               "memory for module '%s'\n",
-               dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op);
+               "memory for module '%s%s'\n",
+               dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
       use_pinned_memory = FALSE;
     }
   }
@@ -1960,8 +1966,8 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
       {
         dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
                  "[default_process_tiling_cl_roi] [%s] can not handle requested roi's tiling "
-                 "for module '%s' not possible.\n",
-                 dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op);
+                 "for module '%s%s' not possible.\n",
+                 dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
         goto error;
       }
 
@@ -2075,8 +2081,8 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
         if(tx + ty > 0 && fabs(processed_maximum_new[k] - piece->pipe->dsc.processed_maximum[k]) > 1.0e-6f)
           dt_print(DT_DEBUG_TILING,
                    "[default_process_tiling_cl_roi] [%s] processed_maximum[%d] "
-                   "differs between tiles in module '%s'\n",
-                   dt_dev_pixelpipe_type_to_str(piece->pipe->type), k, self->op);
+                   "differs between tiles in module '%s%s'\n",
+                   dt_dev_pixelpipe_type_to_str(piece->pipe->type), k, self->op, dt_iop_get_instance_id(self));
         processed_maximum_new[k] = piece->pipe->dsc.processed_maximum[k];
       }
 
@@ -2144,8 +2150,9 @@ error:
   const gboolean pinning_error = (use_pinned_memory == FALSE) && dt_opencl_use_pinned_memory(devid);
   dt_print(DT_DEBUG_OPENCL | DT_DEBUG_TILING,
            "[default_process_tiling_opencl_roi] [%s] couldn't run process_cl() "
-           "for module '%s' in tiling mode:%s %s\n",
-           dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op,
+           "for module '%s%s' in tiling mode:%s %s\n",
+           dt_dev_pixelpipe_type_to_str(piece->pipe->type),
+           self->op, dt_iop_get_instance_id(self),
            (pinning_error) ? " pinning problem" : "", cl_errstr(err));
   if(pinning_error) darktable.opencl->dev[devid].runtime_error |= DT_OPENCL_TUNE_PINNED;
   return FALSE;


### PR DESCRIPTION
Problem in `*dt_iop_commit_blend_params()`

This function is called either
1. with module's default blending parameters or
2. specific raster mask data.

Only in case 2 we should modify the raster mask users hash table.

Doing so in both cases possibly resulted in a loss of knowledge about raster mask targets in the raster mask source (writing) module so the mask's recipient reported a "lost" mask.

Fixes #14393
Fixes #14271

See the reported issues for examples what went wrong. As a short remineder
1. Adding color pickers and hovering over those widgets was  the easiest way to trigger issues.
2. Walking through history was another trigger (much less likely to happen)