### PR TITLE
[GUI] Fix display of ICC version in locales with decimal comma

### DIFF
--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1892,7 +1892,9 @@ void reload_defaults(dt_iop_module_t *module)
         iccCopyr = "";
       }
 
-      cmsFloat64Number iccVersion = cmsGetProfileVersion(cmsprofile);
+      const guint8 iccMajorVersion = cmsGetEncodedICCversion(cmsprofile) >> 24;
+      const guint8 iccMinorVersion = (cmsGetEncodedICCversion(cmsprofile) << 8) >> 28;
+
       char *iccType = "";
 
       if(cmsIsMatrixShaper(cmsprofile))
@@ -1902,13 +1904,13 @@ void reload_defaults(dt_iop_module_t *module)
 
       char *tooltip = g_markup_printf_escaped(_("embedded ICC profile properties:\n\n"
                                                 "name: <b>%s</b>\n"
-                                                "version: <b>%g</b>\n"
+                                                "version: <b>%d.%d</b>\n"
                                                 "type: <b>%s</b>\n"
                                                 "manufacturer: <b>%s</b>\n"
                                                 "model: <b>%s</b>\n"
                                                 "copyright: <b>%s</b>\n\n%s"),
                                               iccDesc,
-                                              iccVersion,
+                                              iccMajorVersion, iccMinorVersion,
                                               iccType,
                                               iccManuf,
                                               iccModel,


### PR DESCRIPTION
Returning the version as a float is the craziest API design decision I've seen in my entire life. The strange idea was that when we print this floating-point number, it looks like a version number, with the decimal separator looking like a dot separating the major and minor versions. Unfortunately, whoever came up with it forgot that decimal separator can be different from the point.

In fact, it's much better to replace the `cmsGetProfileVersion` call with `cmsGetEncodedICCversion` (which, by the way, simply returns the value of the version field without any floating-point math) and apply a couple of bit-shift operations.
