### PR TITLE
maintenance: remove bogus pointer alignment directives

### DIFF
--- a/src/common/bspline.h
+++ b/src/common/bspline.h
@@ -203,7 +203,7 @@ inline static void decompose_2D_Bspline(const float *const in,
   for(size_t row = 0; row < height; row++)
   {
     // get a thread-private one-row temporary buffer
-    float *restrict DT_ALIGNED_ARRAY const temp = dt_get_perthread(tempbuf, padded_size);
+    float *restrict const temp = dt_get_perthread(tempbuf, padded_size);
     // interleave the order in which we process the rows so that we minimize cache misses
     const size_t i = dwt_interleave_rows(row, height, mult);
     // Convolve B-spline filter over columns: for each pixel in the current row, compute vertical blur

--- a/src/iop/cacorrectrgb.c
+++ b/src/iop/cacorrectrgb.c
@@ -589,7 +589,7 @@ static void reduce_artifacts(const float* const restrict in,
 {
   // in_out contains the 2 guided channels of in, and the 2 guided channels of out
   // it allows to blur all channels in one 4-channel gaussian blur instead of 2
-  float *const restrict DT_ALIGNED_PIXEL in_out = dt_alloc_align_float(width * height * 4);
+  float *const restrict in_out = dt_alloc_align_float(width * height * 4);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(in, out, in_out, width, height, guide)        \

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1161,8 +1161,7 @@ static inline gint wavelets_process(const float *const restrict in,
   float *restrict residual; // will store the temp buffer containing the last step of blur
   // allocate a one-row temporary buffer for the decomposition
   size_t padded_size;
-  float *const DT_ALIGNED_ARRAY tempbuf =
-    dt_alloc_perthread_float(4 * width, &padded_size); //TODO: alloc in caller
+  float *const restrict tempbuf = dt_alloc_perthread_float(4 * width, &padded_size); //TODO: alloc in caller
   for(int s = 0; s < scales; ++s)
   {
     /* fprintf(stdout, "Wavelet decompose : scale %i\n", s); */

--- a/src/iop/hlreconstruct/laplacian.c
+++ b/src/iop/hlreconstruct/laplacian.c
@@ -472,7 +472,8 @@ static inline void heat_PDE_diffusion(const float *const restrict high_freq,
         }
 
         // Compute the laplacian in the direction parallel to the steepest gradient on the norm
-        float DT_ALIGNED_ARRAY anisotropic_kernel_isophote[9] = { 0.25f, 0.5f, 0.25f, 0.5f, -3.f, 0.5f, 0.25f, 0.5f, 0.25f };
+        static const float DT_ALIGNED_ARRAY anisotropic_kernel_isophote[9]
+          = { 0.25f, 0.5f, 0.25f, 0.5f, -3.f, 0.5f, 0.25f, 0.5f, 0.25f };
 
         // Convolve the filter to get the laplacian
         dt_aligned_pixel_t laplacian_HF = { 0.f, 0.f, 0.f, 0.f };
@@ -549,7 +550,7 @@ static inline gint wavelets_process(const float *const restrict in,
 
   // allocate a one-row temporary buffer for the decomposition
   size_t padded_size;
-  float *const DT_ALIGNED_ARRAY tempbuf = dt_alloc_perthread_float(4 * width, &padded_size); //TODO: alloc in caller
+  float *const tempbuf = dt_alloc_perthread_float(4 * width, &padded_size); //TODO: alloc in caller
   for(int s = 0; s < scales; ++s)
   {
     //dt_print(DT_DEBUG_ALWAYS, "CPU Wavelet decompose : scale %i\n", s);


### PR DESCRIPTION
Fixes #13729, what remains of the noted irrelevant alignment directives after other changes and cleanups since that issue was opened.