### PR TITLE
[GUI] Reword color profile tooltips for greater clarity

### DIFF
--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1850,7 +1850,8 @@ void reload_defaults(dt_iop_module_t *module)
     char *system_profile_dir = g_build_filename(datadir, "color", "in", NULL);
     char *user_profile_dir = g_build_filename(confdir, "color", "in", NULL);
     char *tooltip_part_profile_dirs =
-      g_strdup_printf(_("darktable loads external ICC profiles from\n%s\nand\n%s"),
+      g_strdup_printf(_("darktable loads external ICC profiles from\n%s\n"
+                        "or, if this directory does not exist, from\n%s"),
                       user_profile_dir, system_profile_dir);
     g_free(system_profile_dir);
     g_free(user_profile_dir);

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -898,7 +898,9 @@ void gui_init(struct dt_iop_module_t *self)
 
   char *system_profile_dir = g_build_filename(datadir, "color", "out", NULL);
   char *user_profile_dir = g_build_filename(confdir, "color", "out", NULL);
-  char *tooltip = g_strdup_printf(_("ICC profiles in %s or %s"), user_profile_dir, system_profile_dir);
+  char *tooltip = g_strdup_printf(_("darktable loads external ICC profiles from\n%s\n"
+                                    "or, if this directory does not exist, from\n%s"),
+                                  user_profile_dir, system_profile_dir);
   gtk_widget_set_tooltip_text(g->output_profile, tooltip);
   g_free(system_profile_dir);
   g_free(user_profile_dir);

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -1225,7 +1225,9 @@ void gui_init(dt_lib_module_t *self)
 
   char *system_profile_dir = g_build_filename(datadir, "color", "out", NULL);
   char *user_profile_dir = g_build_filename(confdir, "color", "out", NULL);
-  char *tooltip = g_strdup_printf(_("output ICC profiles in %s or %s"), user_profile_dir, system_profile_dir);
+  char *tooltip = g_strdup_printf(_("darktable loads output ICC profiles from\n%s\n"
+                                    "or, if this directory does not exist, from\n%s"),
+                                  user_profile_dir, system_profile_dir);
   gtk_widget_set_tooltip_text(d->profile, tooltip);
   g_free(system_profile_dir);
   g_free(user_profile_dir);

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -2449,7 +2449,8 @@ void gui_init(dt_lib_module_t *self)
   }
   dt_bauhaus_combobox_set(d->pprofile, combo_idx);
 
-  char *tooltip = g_strdup_printf(_("printer ICC profiles in %s or %s"),
+  char *tooltip = g_strdup_printf(_("darktable loads printer ICC profiles from\n%s\n"
+                                    "or, if this directory does not exist, from\n%s"),
                                   user_profile_dir, system_profile_dir);
   gtk_widget_set_tooltip_text(d->pprofile, tooltip);
   g_free(tooltip);
@@ -2798,7 +2799,8 @@ void gui_init(dt_lib_module_t *self)
 
   dt_bauhaus_combobox_set(d->profile, combo_idx);
 
-  tooltip = g_strdup_printf(_("output ICC profiles in %s or %s"),
+  tooltip = g_strdup_printf(_("darktable loads output ICC profiles from\n%s\n"
+                              "or, if this directory does not exist, from\n%s"),
                             user_profile_dir, system_profile_dir);
   gtk_widget_set_tooltip_text(d->profile, tooltip);
   g_free(tooltip);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2608,16 +2608,24 @@ void gui_init(dt_view_t *self)
 
     char *system_profile_dir = g_build_filename(datadir, "color", "out", NULL);
     char *user_profile_dir = g_build_filename(confdir, "color", "out", NULL);
-    char *tooltip = g_strdup_printf(_("display ICC profiles in %s or %s"), user_profile_dir, system_profile_dir);
+    char *tooltip = g_strdup_printf(_("darktable loads display ICC profiles from\n%s\n"
+                                      "or, if this directory does not exist, from\n%s"),
+                                    user_profile_dir, system_profile_dir);
     gtk_widget_set_tooltip_text(display_profile, tooltip);
     g_free(tooltip);
-    tooltip = g_strdup_printf(_("preview display ICC profiles in %s or %s"), user_profile_dir, system_profile_dir);
+    tooltip = g_strdup_printf(_("darktable loads preview display ICC profiles from\n%s\n"
+                                "or, if this directory does not exist, from\n%s"),
+                              user_profile_dir, system_profile_dir);
     gtk_widget_set_tooltip_text(display2_profile, tooltip);
     g_free(tooltip);
-    tooltip = g_strdup_printf(_("softproof ICC profiles in %s or %s"), user_profile_dir, system_profile_dir);
+    tooltip = g_strdup_printf(_("darktable loads softproof ICC profiles from\n%s\n"
+                                "or, if this directory does not exist, from\n%s"),
+                              user_profile_dir, system_profile_dir);
     gtk_widget_set_tooltip_text(softproof_profile, tooltip);
     g_free(tooltip);
-    tooltip = g_strdup_printf(_("histogram and color picker ICC profiles in %s or %s"), user_profile_dir, system_profile_dir);
+    tooltip = g_strdup_printf(_("darktable loads histogram and color picker ICC profiles from\n%s\n"
+                                "or, if this directory does not exist, from\n%s"),
+                              user_profile_dir, system_profile_dir);
     gtk_widget_set_tooltip_text(histogram_profile, tooltip);
     g_free(tooltip);
     g_free(system_profile_dir);

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2021 darktable developers.
+    Copyright (C) 2009-2023 darktable developers.
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
@@ -1228,10 +1228,14 @@ void gui_init(dt_view_t *self)
 
   char *system_profile_dir = g_build_filename(datadir, "color", "out", NULL);
   char *user_profile_dir = g_build_filename(confdir, "color", "out", NULL);
-  char *tooltip = g_strdup_printf(_("display ICC profiles in %s or %s"), user_profile_dir, system_profile_dir);
+  char *tooltip = g_strdup_printf(_("darktable loads display ICC profiles from\n%s\n"
+                                    "or, if this directory does not exist, from\n%s"),
+                                  user_profile_dir, system_profile_dir);
   gtk_widget_set_tooltip_text(display_profile, tooltip);
   g_free(tooltip);
-  tooltip = g_strdup_printf(_("preview display ICC profiles in %s or %s"), user_profile_dir, system_profile_dir);
+  tooltip = g_strdup_printf(_("darktable loads preview display ICC profiles from\n%s\n"
+                              "or, if this directory does not exist, from\n%s"),
+                            user_profile_dir, system_profile_dir);
   gtk_widget_set_tooltip_text(display2_profile, tooltip);
   g_free(tooltip);
   g_free(system_profile_dir);


### PR DESCRIPTION
The new wording accurately conveys to the user information about the described directories and the order of working with them.

Disadvantages of previous choice of words:

- "ICC profiles in %s or %s" reads like there are some ICC profiles in these directories. This is not true, these are only directories in which the user can place such files and the program will be able to load them from there.
- There was no information about the order in which these directories were processed. The new text explains that the [user directory overrides the directory from the darktable installation](https://github.com/darktable-org/darktable/blob/master/src/common/colorspaces.c#L1147).
