### PR TITLE
borders.c: add search aliases

### DIFF
--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -187,6 +187,11 @@ const char *name()
   return _("framing");
 }
 
+const char *aliases()
+{
+  return _("borders|uncrop|expand canvas");
+}
+
 const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("add solid borders or margins around the picture"),

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -189,7 +189,7 @@ const char *name()
 
 const char *aliases()
 {
-  return _("borders|uncrop|expand canvas");
+  return _("borders|enlarge canvas|expand canvas");
 }
 
 const char **description(struct dt_iop_module_t *self)


### PR DESCRIPTION
Add aliases to the framing module to make it easier to find, especially for those seeking an "uncrop" operation.

Fix #10259, as far as the uncrop option is concerned (filling the extra area must still be done manually).