### PR TITLE
[GUI] Reformat the message to achieve a better distribution of line lengths

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2857,8 +2857,8 @@ float *dt_dev_get_raster_mask(const struct dt_dev_pixelpipe_iop_t *piece,
        || (candidate->module->iop_order >= target_module->iop_order))
     {
       dt_control_log
-        (_("module `%s' can't get raster mask from module `%s'\n"
-           "as that is processed later in the pixel pipe.\n"
+        (_("module '%s' can't get raster mask from module\n"
+           "'%s' as that is processed later in the pixel pipe.\n"
            "raster mask is ignored."),
          target_module->name(), raster_mask_source->name());
 


### PR DESCRIPTION
A very minor fix, but nonetheless.

It is worth reformatting the message a little, moving the name of the second module to the second line, because in the breakdown as it is now, two names of real modules instead of printf templates will make the first line much longer than the following ones.