### PR TITLE
[GUI] Reword the trashing/deletion error dialog

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -857,8 +857,8 @@ static gboolean _dt_delete_dialog_main_thread(gpointer user_data)
       GTK_MESSAGE_QUESTION,
       GTK_BUTTONS_NONE,
       modal_dialog->send_to_trash
-        ? _("could not send %s to trash%s\n%s\n\n do you want to physically delete the file from disk without using trash?")
-        : _("could not physically delete from disk %s%s\n%s"),
+        ? _("could not send %s to trash%s\n%s\n\n do you want to delete the file from disk without using trash?")
+        : _("could not delete from disk %s%s\n%s"),
       modal_dialog->filename,
       modal_dialog->error_message != NULL ? ": " : "",
       modal_dialog->error_message != NULL ? modal_dialog->error_message : "");
@@ -874,8 +874,8 @@ static gboolean _dt_delete_dialog_main_thread(gpointer user_data)
 
   if(modal_dialog->send_to_trash)
   {
-    gtk_dialog_add_button(GTK_DIALOG(dialog), _("_yes, physically delete"), _DT_DELETE_DIALOG_CHOICE_DELETE);
-    gtk_dialog_add_button(GTK_DIALOG(dialog), _("_no, only remove from library"), _DT_DELETE_DIALOG_CHOICE_REMOVE);
+    gtk_dialog_add_button(GTK_DIALOG(dialog), _("_delete permanently"), _DT_DELETE_DIALOG_CHOICE_DELETE);
+    gtk_dialog_add_button(GTK_DIALOG(dialog), _("_remove from library"), _DT_DELETE_DIALOG_CHOICE_REMOVE);
   }
   else
   {


### PR DESCRIPTION
In response to @dterrahe's [invitation](https://github.com/darktable-org/darktable/pull/14451#issuecomment-1542068965) to improve the text, here is my suggestion for improvement:

- It is better to get rid of redundant words that do not add clarity. The shorter the better. Without the word "physically" the text loses nothing in comprehensibility.
- It is better to get rid of the words "no" and "yes". This will help to narrow down too wide answer buttons, and for the user's mind, this is an extra word-answer that _ties his attention to the question_. Whereas it is easier for the user when the reply button is self-contained.
- Likewise, it is better to choose accelerators that emphasize action verbs, i.e. "d" for _delete and "r" for _remove. Using "y" and "n" (for _yes and _no) force the user to recall how the question is worded.
- It is better to put the action verb first in order to immediately catch the user's attention. That is, I would formulate the first two buttons as `_delete permanently` and `_remove from library`.