### PR TITLE
fix collect history position saving

### DIFF
--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -263,6 +263,9 @@ void dt_collection_move_before(const dt_imgid_t image_id, GList * selected_image
 /* initialize memory table */
 void dt_collection_memory_update();
 
+/** save the current collection for recentcollect module and collect history */
+void dt_collection_history_save();
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1550,6 +1550,9 @@ static void _dt_collection_changed_callback(gpointer instance,
 {
   if(!user_data) return;
   dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
+
+  dt_collection_history_save();
+
   if(query_change == DT_COLLECTION_CHANGE_RELOAD)
   {
     dt_imgid_t old_hover = dt_control_get_mouse_over_id();
@@ -1749,11 +1752,13 @@ static void _dt_collection_changed_callback(gpointer instance,
   }
   else
   {
-    // otherwise we reset the offset to the beginning
-    table->offset = 1;
+    // otherwise we reset the offset to the wanted position or the beginning
+    const int nextpos = MAX(dt_conf_get_int("plugins/lighttable/collect/history_next_pos"), 1);
+    table->offset = nextpos;
     table->offset_imgid = _thumb_get_imgid(table->offset);
-    dt_conf_set_int("plugins/lighttable/collect/history_pos0", 1);
-    dt_conf_set_int("lighttable/zoomable/last_offset", 1);
+    dt_conf_set_int("plugins/lighttable/collect/history_pos0", nextpos);
+    dt_conf_set_int("plugins/lighttable/collect/history_next_pos", 0);
+    dt_conf_set_int("lighttable/zoomable/last_offset", nextpos);
     dt_conf_set_int("lighttable/zoomable/last_pos_x", 0);
     dt_conf_set_int("lighttable/zoomable/last_pos_y", 0);
     dt_thumbtable_full_redraw(table, TRUE);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -765,7 +765,7 @@ static gboolean _move(dt_thumbtable_t *table,
   }
 
   // and we store it
-  dt_conf_set_int("plugins/lighttable/recentcollect/pos0", table->offset);
+  dt_conf_set_int("plugins/lighttable/collect/history_pos0", table->offset);
   if(table->mode == DT_THUMBTABLE_MODE_ZOOM)
   {
     dt_conf_set_int("lighttable/zoomable/last_offset", table->offset);
@@ -868,7 +868,7 @@ static void _zoomable_zoom(dt_thumbtable_t *table,
   dt_thumbnail_t *first = (dt_thumbnail_t *)table->list->data;
   table->offset = first->rowid;
   table->offset_imgid = first->imgid;
-  dt_conf_set_int("plugins/lighttable/recentcollect/pos0", table->offset);
+  dt_conf_set_int("plugins/lighttable/collect/history_pos0", table->offset);
   dt_conf_set_int("lighttable/zoomable/last_offset", table->offset);
   dt_conf_set_int("lighttable/zoomable/last_pos_x", table->thumbs_area.x);
   dt_conf_set_int("lighttable/zoomable/last_pos_y", table->thumbs_area.y);
@@ -1701,8 +1701,7 @@ static void _dt_collection_changed_callback(gpointer instance,
     else
       table->offset_imgid = _thumb_get_imgid(1);
     table->offset = MAX(1, nrow);
-    if(offset_changed)
-      dt_conf_set_int("plugins/lighttable/recentcollect/pos0", table->offset);
+    if(offset_changed) dt_conf_set_int("plugins/lighttable/collect/history_pos0", table->offset);
     if(offset_changed && table->mode == DT_THUMBTABLE_MODE_ZOOM)
       dt_conf_set_int("lighttable/zoomable/last_offset", table->offset);
 
@@ -1753,7 +1752,7 @@ static void _dt_collection_changed_callback(gpointer instance,
     // otherwise we reset the offset to the beginning
     table->offset = 1;
     table->offset_imgid = _thumb_get_imgid(table->offset);
-    dt_conf_set_int("plugins/lighttable/recentcollect/pos0", 1);
+    dt_conf_set_int("plugins/lighttable/collect/history_pos0", 1);
     dt_conf_set_int("lighttable/zoomable/last_offset", 1);
     dt_conf_set_int("lighttable/zoomable/last_pos_x", 0);
     dt_conf_set_int("lighttable/zoomable/last_pos_y", 0);
@@ -2006,7 +2005,7 @@ dt_thumbtable_t *dt_thumbtable_new()
   dt_gui_add_class(table->widget, cl);
   g_free(cl);
 
-  table->offset = MAX(1, dt_conf_get_int("plugins/lighttable/recentcollect/pos0"));
+  table->offset = MAX(1, dt_conf_get_int("plugins/lighttable/collect/history_pos0"));
 
   // set widget signals
   gtk_widget_set_events(table->widget,
@@ -2427,7 +2426,7 @@ gboolean dt_thumbtable_set_offset(dt_thumbtable_t *table,
   if(offset < 1 || offset == table->offset)
     return FALSE;
   table->offset = offset;
-  dt_conf_set_int("plugins/lighttable/recentcollect/pos0", table->offset);
+  dt_conf_set_int("plugins/lighttable/collect/history_pos0", table->offset);
   if(redraw) dt_thumbtable_full_redraw(table, TRUE);
   return TRUE;
 }
@@ -2917,7 +2916,7 @@ static gboolean _zoomable_key_move(dt_thumbtable_t *table,
   dt_thumbnail_t *first = (dt_thumbnail_t *)table->list->data;
   table->offset = first->rowid;
   table->offset_imgid = first->imgid;
-  dt_conf_set_int("plugins/lighttable/recentcollect/pos0", table->offset);
+  dt_conf_set_int("plugins/lighttable/collect/history_pos0", table->offset);
   dt_conf_set_int("lighttable/zoomable/last_offset", table->offset);
   dt_conf_set_int("lighttable/zoomable/last_pos_x", table->thumbs_area.x);
   dt_conf_set_int("lighttable/zoomable/last_pos_y", table->thumbs_area.y);

--- a/src/libs/recentcollect.c
+++ b/src/libs/recentcollect.c
@@ -38,14 +38,15 @@ DT_MODULE(1)
 /** this module stores recently used image collection queries and displays
  * them as one-click buttons to the user. */
 
-static int _conf_get_max_items()
+static int _conf_get_max_saved_items()
 {
-  return (dt_conf_get_int("plugins/lighttable/recentcollect/max_items"));
+  return (MAX(dt_conf_get_int("plugins/lighttable/recentcollect/max_items"),
+              dt_conf_get_int("plugins/lighttable/collect/history_max")));
 }
 
-static int _conf_get_num_items()
+static int _conf_get_max_shown_items()
 {
-  return (dt_conf_get_int("plugins/lighttable/recentcollect/num_items"));
+  return (dt_conf_get_int("plugins/lighttable/recentcollect/max_items"));
 }
 
 typedef struct dt_lib_recentcollect_item_t
@@ -159,7 +160,7 @@ static void _button_pressed(GtkButton *button, gpointer user_data)
   if(!found) return;
 
   char confname[200];
-  snprintf(confname, sizeof(confname), "plugins/lighttable/recentcollect/line%1d", linenumber);
+  snprintf(confname, sizeof(confname), "plugins/lighttable/collect/history%1d", linenumber);
   const char *line = dt_conf_get_string_const(confname);
   if(line)
   {
@@ -177,11 +178,6 @@ static void _lib_recentcollection_updated(gpointer instance, dt_collection_chang
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_recentcollect_t *d = (dt_lib_recentcollect_t *)self->data;
   dt_thumbtable_t *table = dt_ui_thumbtable(darktable.gui->ui);
-  // serialize, check for recently used
-  char confname[200] = { 0 };
-
-  char buf[4096];
-  if(dt_collection_serialize(buf, sizeof(buf), FALSE)) return;
 
   // is the current position, i.e. the one to be stored with the old collection (pos0, pos1-to-be)
   uint32_t curr_pos = table->offset;
@@ -189,74 +185,25 @@ static void _lib_recentcollection_updated(gpointer instance, dt_collection_chang
 
   if(!d->inited)
   {
-    new_pos = dt_conf_get_int("plugins/lighttable/recentcollect/pos0");
+    new_pos = dt_conf_get_int("plugins/lighttable/collect/history_pos0");
     d->inited = 1;
     dt_thumbtable_set_offset(table, new_pos, TRUE);
   }
   else if(curr_pos != -1)
   {
-    dt_conf_set_int("plugins/lighttable/recentcollect/pos0", curr_pos);
+    dt_conf_set_int("plugins/lighttable/collect/history_pos0", curr_pos);
   }
 
-  int n = -1;
-  for(int k = 0; k < CLAMPS(_conf_get_num_items(), 0, _conf_get_max_items()); k++)
-  {
-    // is it already in the current list?
-    snprintf(confname, sizeof(confname), "plugins/lighttable/recentcollect/line%1d", k);
-    const char *line = dt_conf_get_string_const(confname);
-    if(!line) continue;
-    if(!strcmp(line, buf))
-    {
-      snprintf(confname, sizeof(confname), "plugins/lighttable/recentcollect/pos%1d", k);
-      new_pos = dt_conf_get_int(confname);
-      n = k;
-      break;
-    }
-  }
-  if(n < 0)
-  {
-    const int num_items = CLAMPS(_conf_get_num_items(), 0, _conf_get_max_items());
+  dt_collection_history_save();
 
-    if(num_items < _conf_get_max_items())
-    {
-      // new, unused entry
-      n = num_items;
-      dt_conf_set_int("plugins/lighttable/recentcollect/num_items", num_items + 1);
-    }
-    else
-    {
-      // kill least recently used entry:
-      n = num_items - 1;
-    }
-  }
-  if(n >= 0 && n < _conf_get_max_items())
-  {
-    // sort n to the top
-    for(int k = n; k > 0; k--)
-    {
-      snprintf(confname, sizeof(confname), "plugins/lighttable/recentcollect/line%1d", k - 1);
-      const gchar *line1 = dt_conf_get_string_const(confname);
-      snprintf(confname, sizeof(confname), "plugins/lighttable/recentcollect/pos%1d", k - 1);
-      uint32_t pos1 = dt_conf_get_int(confname);
-      if(line1 && line1[0] != '\0')
-      {
-        snprintf(confname, sizeof(confname), "plugins/lighttable/recentcollect/line%1d", k);
-        dt_conf_set_string(confname, line1);
-        snprintf(confname, sizeof(confname), "plugins/lighttable/recentcollect/pos%1d", k);
-        dt_conf_set_int(confname, pos1);
-      }
-    }
-    dt_conf_set_string("plugins/lighttable/recentcollect/line0", buf);
-    dt_conf_set_int("plugins/lighttable/recentcollect/pos0",
-                    (new_pos != -1 ? new_pos : (curr_pos != -1 ? curr_pos : 0)));
-  }
   // update button descriptions:
+  char confname[200] = { 0 };
   GList *current = d->items;
   for(int k = 0; current; k++)
   {
     char str[2048] = { 0 };
     dt_lib_recentcollect_item_t *item = (dt_lib_recentcollect_item_t *)current->data;
-    snprintf(confname, sizeof(confname), "plugins/lighttable/recentcollect/line%1d", k);
+    snprintf(confname, sizeof(confname), "plugins/lighttable/collect/history%1d", k);
     const char *line2 = dt_conf_get_string_const(confname);
     if(line2 && line2[0] != '\0') pretty_print(line2, str, sizeof(str));
     gtk_widget_set_tooltip_text(item->button, str);
@@ -275,11 +222,15 @@ static void _lib_recentcollection_updated(gpointer instance, dt_collection_chang
   }
 
   current = d->items;
-  for(int k = 0; k < CLAMPS(_conf_get_num_items(), 0, _conf_get_max_items()); k++)
+  for(int k = 0; k < CLAMPS(_conf_get_max_shown_items(), 0, _conf_get_max_saved_items()); k++)
   {
     dt_lib_recentcollect_item_t *item = (dt_lib_recentcollect_item_t *)current->data;
-    gtk_widget_set_no_show_all(item->button, FALSE);
-    gtk_widget_set_visible(item->button, TRUE);
+    const gchar *line = gtk_button_get_label(GTK_BUTTON(item->button));
+    if(line && line[0] != '\0')
+    {
+      gtk_widget_set_no_show_all(item->button, FALSE);
+      gtk_widget_set_visible(item->button, TRUE);
+    }
     current = g_list_next(current);
   }
 
@@ -301,13 +252,13 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
 #endif
   gtk_widget_show_all(dialog);
 
-  const int old_nb_items = _conf_get_max_items(); // preserve previous value
+  const int old_nb_items = _conf_get_max_saved_items(); // preserve previous value
 
   if(gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT)
   {
     dt_lib_recentcollect_t *d = self->data;
 
-    const int new_nb_items = _conf_get_max_items();
+    const int new_nb_items = _conf_get_max_saved_items();
     const int delta = new_nb_items - old_nb_items;
     if(delta < 0)
     {
@@ -316,9 +267,9 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
       while(current)
       {
         dt_lib_recentcollect_item_t *item = (dt_lib_recentcollect_item_t *)current->data;
-        snprintf(confname, sizeof(confname), "plugins/lighttable/recentcollect/line%1d", item->confid);
+        snprintf(confname, sizeof(confname), "plugins/lighttable/collect/history%1d", item->confid);
         dt_conf_set_string(confname, "");
-        snprintf(confname, sizeof(confname), "plugins/lighttable/recentcollect/pos%1d", item->confid);
+        snprintf(confname, sizeof(confname), "plugins/lighttable/collect/history_pos%1d", item->confid);
         dt_conf_set_int(confname, 0);
         gtk_widget_destroy(item->button);
         free(item);
@@ -326,8 +277,6 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
         current = g_list_next(current);
         d->items = g_list_delete_link(d->items, old);
       }
-      const int num_items = dt_conf_get_int("plugins/lighttable/recentcollect/num_items");
-      dt_conf_set_int("plugins/lighttable/recentcollect/num_items", MIN(num_items, new_nb_items));
     }
     if(delta > 0)
     {
@@ -366,14 +315,13 @@ void set_preferences(void *menu, dt_lib_module_t *self)
 
 void gui_reset(dt_lib_module_t *self)
 {
-  dt_conf_set_int("plugins/lighttable/recentcollect/num_items", 0);
   char confname[200] = { 0 };
 
-  for(int k = 0; k < _conf_get_max_items(); k++)
+  for(int k = 0; k < _conf_get_max_saved_items(); k++)
   {
-    snprintf(confname, sizeof(confname), "plugins/lighttable/recentcollect/line%1d", k);
+    snprintf(confname, sizeof(confname), "plugins/lighttable/collect/history%1d", k);
     dt_conf_set_string(confname, "");
-    snprintf(confname, sizeof(confname), "plugins/lighttable/recentcollect/pos%1d", k);
+    snprintf(confname, sizeof(confname), "plugins/lighttable/collect/history_pos%1d", k);
     dt_conf_set_int(confname, 0);
   }
   _lib_recentcollection_updated(NULL, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL, -1, self);
@@ -400,7 +348,7 @@ void gui_init(dt_lib_module_t *self)
   d->inited = 0;
 
   // add buttons in the list, set them all to invisible
-  for(int k = 0; k < _conf_get_max_items(); k++)
+  for(int k = 0; k < _conf_get_max_shown_items(); k++)
   {
     dt_lib_recentcollect_item_t *item = (dt_lib_recentcollect_item_t *)malloc(sizeof(dt_lib_recentcollect_item_t));
     d->items = g_list_append(d->items, item);
@@ -426,7 +374,7 @@ void gui_init(dt_lib_module_t *self)
 void gui_cleanup(dt_lib_module_t *self)
 {
   const int curr_pos = dt_ui_thumbtable(darktable.gui->ui)->offset;
-  dt_conf_set_int("plugins/lighttable/recentcollect/pos0", curr_pos);
+  dt_conf_set_int("plugins/lighttable/collect/history_pos0", curr_pos);
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_lib_recentcollection_updated), self);
   free(self->data);
   self->data = NULL;


### PR DESCRIPTION
while debugging a recent issue, I noticed that the lighttable image offset save with the collect history (or the recentcollect entry) is broken for a very long time...

This restore the feature, with some refactoring and code deduplication.