### PR TITLE
Properly apply Sigmoid or FilmicRGB to matrix based pictures.

### DIFF
--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -3250,7 +3250,7 @@ void init_presets(dt_iop_module_so_t *self)
        1, DEVELOP_BLEND_CS_RGB_SCENE);
 
     dt_gui_presets_update_ldr(_("scene-referred default"), self->op,
-                              self->version(), FOR_RAW);
+                              self->version(), FOR_RAW | FOR_MATRIX);
 
     dt_gui_presets_update_autoapply(_("scene-referred default"),
                                     self->op, self->version(), TRUE);

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -136,7 +136,7 @@ void init_presets(dt_iop_module_so_t *self)
        1, DEVELOP_BLEND_CS_RGB_SCENE);
 
     dt_gui_presets_update_ldr(_("scene-referred default"), self->op,
-                              self->version(), FOR_RAW);
+                              self->version(), FOR_RAW | FOR_MATRIX);
 
     dt_gui_presets_update_autoapply(_("scene-referred default"),
                                     self->op, self->version(), TRUE);

--- a/src/libs/ioporder.c
+++ b/src/libs/ioporder.c
@@ -203,7 +203,7 @@ void init_presets(dt_lib_module_t *self)
   params = dt_ioppr_serialize_iop_order_list(list, &size);
   dt_lib_presets_add(_("v3.0 for RAW input (default)"), self->plugin_name, self->version(),
                      (const char *)params, (int32_t)size, TRUE,
-                     is_display_referred ? 0 : FOR_RAW);
+                     is_display_referred ? 0 : FOR_RAW | FOR_MATRIX);
 
   list = dt_ioppr_get_iop_order_list_version(DT_IOP_ORDER_V30_JPG);
   params = dt_ioppr_serialize_iop_order_list(list, &size);


### PR DESCRIPTION
Also, ensure that the IOP order used for such images is RAW and not the JPEG one.

Fixes #14558.