### PR TITLE
[GUI] More correct text about ICC files in color profile widget tooltips

### DIFF
--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -1192,15 +1192,15 @@ void dt_ioppr_get_histogram_profile_type(dt_colorspaces_color_profile_type_t *pr
   }
 }
 
-gchar *dt_ioppr_get_location_tooltip(const char *for_name)
+gchar *dt_ioppr_get_location_tooltip(const char *subdir, const char *for_name)
 {
   char datadir[PATH_MAX] = { 0 };
   char confdir[PATH_MAX] = { 0 };
   dt_loc_get_datadir(datadir, sizeof(datadir));
   dt_loc_get_user_config_dir(confdir, sizeof(confdir));
 
-  char *system_profile_dir = g_build_filename(datadir, "color", "out", NULL);
-  char *user_profile_dir = g_build_filename(confdir, "color", "out", NULL);
+  char *system_profile_dir = g_build_filename(datadir, "color", subdir, NULL);
+  char *user_profile_dir = g_build_filename(confdir, "color", subdir, NULL);
   char *tooltip = g_strdup_printf
     (_("darktable loads %s from\n<b>%s</b>\n"
        "or, if this directory does not exist, from\n<b>%s</b>"),

--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -153,7 +153,7 @@ void dt_ioppr_get_histogram_profile_type(dt_colorspaces_color_profile_type_t *pr
 /* Returns the tooltip with the location of the profile for for_name
    which can be softproof, input, output...
 */
-gchar *dt_ioppr_get_location_tooltip(const char *for_name);
+gchar *dt_ioppr_get_location_tooltip(const char *subdir, const char *for_name);
 
 /** transforms image from cst_from to cst_to colorspace using profile_info */
 void dt_ioppr_transform_image_colorspace

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -2094,7 +2094,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   dt_bauhaus_combobox_set(g->work_combobox, 0);
   {
-    char *tooltip = dt_ioppr_get_location_tooltip("out", _("external ICC profiles"));
+    char *tooltip = dt_ioppr_get_location_tooltip("out", _("working ICC profiles"));
     gtk_widget_set_tooltip_markup(g->work_combobox, tooltip);
     g_free(tooltip);
   }

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1841,7 +1841,7 @@ void reload_defaults(dt_iop_module_t *module)
   if(g)
   {
     char *tooltip_part_profile_dirs =
-      dt_ioppr_get_location_tooltip(_("external ICC profiles"));
+      dt_ioppr_get_location_tooltip("in", _("external ICC profiles"));
 
     // In case of embedded ICC profile we will modify tooltip with the
     // profile info, otherwise reset tooltip to generic text.
@@ -2094,7 +2094,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   dt_bauhaus_combobox_set(g->work_combobox, 0);
   {
-    char *tooltip = dt_ioppr_get_location_tooltip(_("external ICC profiles"));
+    char *tooltip = dt_ioppr_get_location_tooltip("out", _("external ICC profiles"));
     gtk_widget_set_tooltip_markup(g->work_combobox, tooltip);
     g_free(tooltip);
   }

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -890,7 +890,7 @@ void gui_init(struct dt_iop_module_t *self)
     if(prof->out_pos > -1) dt_bauhaus_combobox_add(g->output_profile, prof->name);
   }
 
-  char *tooltip = dt_ioppr_get_location_tooltip(_("external ICC profiles"));
+  char *tooltip = dt_ioppr_get_location_tooltip("out", _("external ICC profiles"));
   gtk_widget_set_tooltip_markup(g->output_profile, tooltip);
   g_free(tooltip);
 

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -890,7 +890,7 @@ void gui_init(struct dt_iop_module_t *self)
     if(prof->out_pos > -1) dt_bauhaus_combobox_add(g->output_profile, prof->name);
   }
 
-  char *tooltip = dt_ioppr_get_location_tooltip("out", _("external ICC profiles"));
+  char *tooltip = dt_ioppr_get_location_tooltip("out", _("export ICC profiles"));
   gtk_widget_set_tooltip_markup(g->output_profile, tooltip);
   g_free(tooltip);
 

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -1217,7 +1217,7 @@ void gui_init(dt_lib_module_t *self)
 
   dt_bauhaus_combobox_set(d->profile, 0);
 
-  char *tooltip = dt_ioppr_get_location_tooltip(_("output ICC profiles"));
+  char *tooltip = dt_ioppr_get_location_tooltip("out", _("output ICC profiles"));
   gtk_widget_set_tooltip_markup(d->profile, tooltip);
   g_free(tooltip);
 

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -2441,7 +2441,7 @@ void gui_init(dt_lib_module_t *self)
   }
   dt_bauhaus_combobox_set(d->pprofile, combo_idx);
 
-  char *tooltip = dt_ioppr_get_location_tooltip(_("printer ICC profiles"));
+  char *tooltip = dt_ioppr_get_location_tooltip("out", _("printer ICC profiles"));
   gtk_widget_set_tooltip_markup(d->pprofile, tooltip);
   g_free(tooltip);
 
@@ -2789,7 +2789,7 @@ void gui_init(dt_lib_module_t *self)
 
   dt_bauhaus_combobox_set(d->profile, combo_idx);
 
-  tooltip = dt_ioppr_get_location_tooltip(_("output ICC profiles"));
+  tooltip = dt_ioppr_get_location_tooltip("out", _("output ICC profiles"));
   gtk_widget_set_tooltip_markup(d->profile, tooltip);
   g_free(tooltip);
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2602,19 +2602,19 @@ void gui_init(dt_view_t *self)
       }
     }
 
-    char *tooltip = dt_ioppr_get_location_tooltip(_("display ICC profiles"));
+    char *tooltip = dt_ioppr_get_location_tooltip("out", _("display ICC profiles"));
     gtk_widget_set_tooltip_markup(display_profile, tooltip);
     g_free(tooltip);
 
-    tooltip = dt_ioppr_get_location_tooltip(_("preview display ICC profiles"));
+    tooltip = dt_ioppr_get_location_tooltip("out", _("preview display ICC profiles"));
     gtk_widget_set_tooltip_markup(display2_profile, tooltip);
     g_free(tooltip);
 
-    tooltip = dt_ioppr_get_location_tooltip(_("softproof ICC profiles"));
+    tooltip = dt_ioppr_get_location_tooltip("out", _("softproof ICC profiles"));
     gtk_widget_set_tooltip_markup(softproof_profile, tooltip);
     g_free(tooltip);
 
-    tooltip = dt_ioppr_get_location_tooltip(_("histogram and color picker ICC profiles"));
+    tooltip = dt_ioppr_get_location_tooltip("out", _("histogram and color picker ICC profiles"));
     gtk_widget_set_tooltip_markup(histogram_profile, tooltip);
     g_free(tooltip);
 

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1222,11 +1222,11 @@ void gui_init(dt_view_t *self)
     }
   }
 
-  char *tooltip = dt_ioppr_get_location_tooltip(_("display ICC profiles"));
+  char *tooltip = dt_ioppr_get_location_tooltip("out", _("display ICC profiles"));
   gtk_widget_set_tooltip_markup(display_profile, tooltip);
   g_free(tooltip);
 
-  tooltip = dt_ioppr_get_location_tooltip(_("preview display ICC profiles"));
+  tooltip = dt_ioppr_get_location_tooltip("out", _("preview display ICC profiles"));
   gtk_widget_set_tooltip_markup(display2_profile, tooltip);
   g_free(tooltip);
 


### PR DESCRIPTION
Fixed location of ICC files for input color profile. Some descriptions of profile purpose have also been made more correct, namely:
when referring to the ICC file for the input profile, we call it external to emphasize that the ICC profile can be embedded in the image, so the input profile in a separate file is an external profile to the image. The word "external" is inappropriate in the tooltip of the working and export profile, this has been fixed.
