### PR TITLE
Add colorspace handling to debugging log

### DIFF
--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -412,9 +412,11 @@ gboolean dt_dev_pixelpipe_cache_get(
   // cache keeps history and we have a cache hit, so no new buffer
   if(cache->entries > DT_PIPECACHE_MIN && _get_by_hash(pipe, hash, basichash, size, data, dsc))
   {
+    const dt_iop_buffer_dsc_t *cdsc = *dsc;
     dt_print_pipe(DT_DEBUG_PIPE, "cache HIT",
           pipe, module, NULL, NULL,
-          "hash%22" PRIu64 ", basic%22" PRIu64 "\n", hash, basichash); 
+          "%s, hash%22" PRIu64 ", basic%22" PRIu64 "\n",
+          dt_iop_colorspace_to_name(cdsc->cst), hash, basichash); 
     return FALSE;
   }
   // We need a fresh buffer as there was no hit.
@@ -460,9 +462,11 @@ gboolean dt_dev_pixelpipe_cache_get(
                                     : (important ? -cache->entries : 0);
   cache->ioporder[cline]  = module  ? module->iop_order : 0;
 
+  const dt_iop_buffer_dsc_t *cdsc = *dsc;
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "pixelpipe_cache_get",
     pipe, module, NULL, NULL,
-    "%s %s line%3i, age %4i at %p. hash%22" PRIu64 ", basic%22" PRIu64 "\n",
+    "%s %s %s line%3i, age %4i at %p. hash%22" PRIu64 ", basic%22" PRIu64 "\n",
+     dt_iop_colorspace_to_name(cdsc->cst),
      newdata ? "new" : "   ",
      important ? "important" : (masking ? "masking  " : "         "),
      cline, cache->used[cline],


### PR DESCRIPTION
As we have some very strange issues reported, discussed and so far only partially fixed (see #14271) this adds some debugging info about colorspace.

1. processing a module always tells input colorspace, if this is changed via processing like colorin, demosaic this conversion is also displayed.
2. Explicit report of colorspace transformation as requested by input of module data
3. As there might be cache related issues - if we have a hit and avoid reprocessing the pixelpipe we must be sure the correct colorspace is fed into the pipeline at this point - we report the colorspace taken from cache data

Some minor improvements while being here.

There is a lengthy discussion there. In short a way to reproduce the issue
1. Empty history
2. In standard exposure module create a parametric mask in g channel (can can also do other channels btw) 
3. make that mask exclusive&inverted
4. open contrast equalizer, set up some blurring and use the raster mask generated via exposure.
5. in most cases it is sufficient to go back to lightable and back to darkroom. The preview window might be just black and missing data in histogram.

The surprising thing is in the logs (please note there has been no data taken from the pipe cache so far)
```
    21.0775 [pixelpipe_process_CL]       [preview]      exposure               (   0/   0)  900x1200 scale=1.0000 --> (   0/   0)  900x1200 scale=1.0000 IOP_CS_RGB
    21.0784 [blend with form CL]         [preview]      exposure               (   0/   0)  900x1200 scale=1.0000 --> (   0/   0)  900x1200 scale=1.0000 
    21.0856 [write raster mask CL]       [preview]      exposure               (   0/   0)  900x1200 scale=1.0000 --> (   0/   0)  900x1200 scale=1.0000 
    21.0871 [transform colorspace CL]    [preview]      colorin                (   0/   0)  900x1200 scale=1.0000 --> (   0/   0)  900x1200 scale=1.0000 IOP_CS_LAB -> IOP_CS_RGB
    21.0894 [pixelpipe_process_CL]       [preview]      colorin                (   0/   0)  900x1200 scale=1.0000 --> (   0/   0)  900x1200 scale=1.0000 IOP_CS_RGB -> IOP_CS_LAB
    21.0908 [transform colorspace CL]    [preview]      channelmixerrgb        (   0/   0)  900x1200 scale=1.0000 --> (   0/   0)  900x1200 scale=1.0000 IOP_CS_LAB -> IOP_CS_RGB
    21.0929 [pixelpipe_process_CL]       [preview]      channelmixerrgb        (   0/   0)  900x1200 scale=1.0000 --> (   0/   0)  900x1200 scale=1.0000 IOP_CS_RGB
    21.0938 [transform colorspace CL]    [preview]      atrous                 (   0/   0)  900x1200 scale=1.0000 --> (   0/   0)  900x1200 scale=1.0000 IOP_CS_RGB -> IOP_CS_LAB
    21.0958 [pixelpipe_process_CL]       [preview]      atrous                 (   0/   0)  900x1200 scale=1.0000 --> (   0/   0)  900x1200 scale=1.0000 IOP_CS_LAB
    21.1057 [blend raster CL]            [preview]      atrous                 (   0/   0)  900x1200 scale=1.0000 --> (   0/   0)  900x1200 scale=1.0000 
    21.1057 [got raster mask]            [preview]      atrous                  from module `exposure' 
    21.1087 [transform colorspace CL]    [preview]      colorbalancergb        (   0/   0)  900x1200 scale=1.0000 --> (   0/   0)  900x1200 scale=1.0000 IOP_CS_LAB -> IOP_CS_RGB

```

The surprise is in the line at `21.0871`. When starting to process colorin it finds data in ` IOP_CS_LAB` which is just wrong, last written data was alwas in `RGB` If you have a look at the main `canvas` everything is visually alright, also there is no-such-wrong conversion taken place. 

1. We have not seen this full pixelpipe
2. We can't reproduce if the mask is generated in another instance of exposure (There are more details about issue-triggering issues in the issue)

@TurboGit might be good to merge if only to keep track on this issue.

Pascal and maybe also @AlicVB as you have worked on masks - are there "any bells ringing"? 
