### PR TITLE
[GUI] Assorted string fixes

### DIFF
--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -3470,10 +3470,10 @@ static void _path_set_hint_message(const dt_masks_form_gui_t *const gui,
                                    const size_t msgbuf_len)
 {
   if(gui->creation && g_list_length(form->points) < 4)
-    g_strlcat(msgbuf, _("<b>add node</b>: click, <b>add sharp node</b>:ctrl+click\n"
+    g_strlcat(msgbuf, _("<b>add node</b>: click, <b>add sharp node</b>: ctrl+click\n"
                         "<b>cancel</b>: right-click"), msgbuf_len);
   else if(gui->creation)
-    g_strlcat(msgbuf, _("<b>add node</b>: click, <b>add sharp node</b>:ctrl+click\n"
+    g_strlcat(msgbuf, _("<b>add node</b>: click, <b>add sharp node</b>: ctrl+click\n"
                         "<b>finish path</b>: right-click"), msgbuf_len);
   else if(gui->point_selected >= 0)
     g_strlcat(msgbuf, _("<b>move node</b>: drag, <b>remove node</b>: right-click\n"

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3841,7 +3841,7 @@ void gui_init(dt_iop_module_t *self)
                                 "in undersmoothing of the green channel in\n"
                                 "wavelets mode, combined with a bad handling\n"
                                 "of white balance coefficients, and a bug in\n"
-                                "non local means normalization resulting in\n"
+                                "non-local means normalization resulting in\n"
                                 "undersmoothing when patch size was increased.\n"
                                 "enabling this option will change the denoising\n"
                                 "you get. once enabled, you won't be able to\n"

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -97,13 +97,13 @@ typedef enum dt_iop_lens_lenstype_t
 {
   DT_IOP_LENS_LENSTYPE_UNKNOWN = 0,
   DT_IOP_LENS_LENSTYPE_RECTILINEAR = 1,           // $DESCRIPTION: "rectilinear"
-  DT_IOP_LENS_LENSTYPE_FISHEYE = 2,               // $DESCRIPTION: "fish-eye"
+  DT_IOP_LENS_LENSTYPE_FISHEYE = 2,               // $DESCRIPTION: "fisheye"
   DT_IOP_LENS_LENSTYPE_PANORAMIC = 3,             // $DESCRIPTION: "panoramic"
   DT_IOP_LENS_LENSTYPE_EQUIRECTANGULAR = 4,       // $DESCRIPTION: "equirectangular"
   DT_IOP_LENS_LENSTYPE_FISHEYE_ORTHOGRAPHIC = 5,  // $DESCRIPTION: "orthographic"
   DT_IOP_LENS_LENSTYPE_FISHEYE_STEREOGRAPHIC = 6, // $DESCRIPTION: "stereographic"
   DT_IOP_LENS_LENSTYPE_FISHEYE_EQUISOLID = 7,     // $DESCRIPTION: "equisolid angle"
-  DT_IOP_LENS_LENSTYPE_FISHEYE_THOBY = 8,         // $DESCRIPTION: "Thoby fish-eye"
+  DT_IOP_LENS_LENSTYPE_FISHEYE_THOBY = 8,         // $DESCRIPTION: "Thoby fisheye"
 } dt_iop_lens_lenstype_t;
 
 typedef enum dt_iop_lens_mode_t


### PR DESCRIPTION
Two comments:
- non- is a prefix in English, so it should not be written as a separate word. Both "non-local" and "nonlocal" are equally valid spellings, but in all other places in dt we consistently write this word with a hyphen.
- [fisheye as a single word without a hyphen is the most used spelling](https://books.google.com/ngrams/graph?content=fisheye%2C%5Bfish+-+eye%5D%2C%22+fish+eye+%22&year_start=1800&year_end=2019&corpus=en-2019&smoothing=3)