### PR TITLE
print_settings: higher quality of images in center area

### DIFF
--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1894,7 +1894,9 @@ void gui_post_expose(struct dt_lib_module_t *self,
   cairo_set_source_rgba(cr, 1, .2, .2, 0.6);
   cairo_set_dash(cr, NULL, 0, 0);
 
-  const float scaler = 1.0f / darktable.gui->ppd_thb;
+  // image is not drawn aligned to pixel, hence will look blurry
+  // unless request higher-res version then scale it down
+  const float scaler = 0.5f / darktable.gui->ppd_thb;
 
   for(int k=0; k<ps->imgs.count; k++)
   {
@@ -1912,7 +1914,7 @@ void gui_post_expose(struct dt_lib_module_t *self,
       dt_printing_get_screen_pos(&ps->imgs, img, &screen);
 
       const dt_view_surface_value_t res =
-        dt_view_image_get_surface(img->imgid, screen.width, screen.height, &surf, TRUE);
+        dt_view_image_get_surface(img->imgid, screen.width * 2.0f, screen.height * 2.0f, &surf, TRUE);
 
       if(res != DT_VIEW_SURFACE_OK)
       {


### PR DESCRIPTION
This fixes images looking noticeably more blurry in print view compared to darkroom view.

Images in the print view's center area are drawn aligned to a page measurements, rather than pixel-aligned to screen. Hence they look slightly blurry (especially compared to the same image in darkroom view). A bit higher quality source image improves things. Hence this PR makes the code request a more detailed mipmap when drawing each image. (Using a better pattern filter doesn't seem to make any visual improvement, hence no change here from the default.)

An alternative would be to round x/y translation to nearest pixel, at the cost of slightly less visually accurate page layout. But the scaled-down higher quality mipmap looks much better.

For comparison, here is a detail of an image in print view using the code without this PR:

![Screenshot from 2023-05-24 17-19-06](https://github.com/darktable-org/darktable/assets/2311860/87fa651a-091f-402a-929e-e20bbe5ab516)

Here is the same using the code with this PR:

![Screenshot from 2023-05-24 17-18-24](https://github.com/darktable-org/darktable/assets/2311860/b89d1f7b-0726-4e41-8183-536d024d9541)

Here is how that same section of the image looks in darkroom view:

![image](https://github.com/darktable-org/darktable/assets/2311860/400472cb-8007-47d3-ad4a-e66becb8228d)

All these images are on a relatively lo-dpi monitor.

Granted, this PR also makes the creation of mipmaps to draw print view a bit slower, but as this work only needs to be done once per image, this could be an acceptable cost.