### PR TITLE
More debugging output for colorspace and raster masks

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1823,15 +1823,17 @@ dt_iop_module_t *dt_iop_commit_blend_params(dt_iop_module_t *module,
     {
       if(candidate->multi_priority == blendop_params->raster_mask_instance)
       {
-        g_hash_table_insert(candidate->raster_mask.source.users,
+        const gboolean new = g_hash_table_insert(candidate->raster_mask.source.users,
                             module,
                             GINT_TO_POINTER(blendop_params->raster_mask_id));
         module->raster_mask.sink.source = candidate;
         module->raster_mask.sink.id = blendop_params->raster_mask_id;
-        dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
+        dt_print_pipe(DT_DEBUG_PIPE,
                       "commit_blend_params",
-                      NULL, module, NULL, NULL, "raster mask from '%s%s', %s\n",
-                      candidate->op, dt_iop_get_instance_id(candidate));
+                      NULL, module, NULL, NULL, "raster mask from '%s%s' %s\n",
+                      candidate->op, dt_iop_get_instance_id(candidate),
+                      new ? "new" : "existing");
+
         return candidate;
       }
     }
@@ -1844,7 +1846,7 @@ dt_iop_module_t *dt_iop_commit_blend_params(dt_iop_module_t *module,
   dt_iop_module_t *sink_source = module->raster_mask.sink.source;
   if(sink_source)
   {
-    dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
+    dt_print_pipe(DT_DEBUG_PIPE,
                   "commit_blend_params",
                   NULL, module, NULL, NULL, "clear raster mask source '%s%s'\n",
                   sink_source->op, dt_iop_get_instance_id(sink_source));


### PR DESCRIPTION
More debugging output for colorspace and raster masks.

ready to be merged from my side.

The good point regarding #14566 and #14271, this pr doesn't fix it but i think i know what's going wrong.
It's in the pixelpipe cache code, in short: we might have two consecutive modules using the same cacheline! 

Will fix this over the long weekend ...  