### PR TITLE
Expand on the Lightroom note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ darktable is an open source photography workflow application and non-destructive
 
 ![screenshot_lighttable](https://user-images.githubusercontent.com/45535283/148689197-e53dd75f-32f1-4297-9a0f-a9547fd4e7c7.jpg)
 
-darktable is **not** a free Adobe® Lightroom® replacement.
+darktable is **not** a free Adobe® Lightroom® replacement. Instead, it [...]
 
 [https://www.darktable.org/](https://www.darktable.org/ "darktable homepage")
 


### PR DESCRIPTION
As a potential darktable user, I want to figure out how it compares to the other options:  Lightroom, Gimp, Capture One, Pixelmator, Mechanic, etc.

The README currently has the note,

> darktable is **not** a free Adobe® Lightroom® replacement.

But for me this creates more questions than it answers: Why isn't it? Will it be? Is it aimed at different use cases? Is it intended to be used _alongside_ Lightroom? How would darktable fit in with the other tools I use?

So this PR is to start the conversation about this onboarding aspect: How would we finish the above statement about Lightroom? Even a simple "because..." clause would be really helpful.