### PR TITLE
[GUI] Replace the questionable word with the most commonly used one

### DIFF
--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -641,13 +641,13 @@ void gui_init(dt_iop_module_t *self)
       = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "shadows_range"));
   dt_bauhaus_slider_set_soft_max(g->shadows_range, 0.0);
   dt_bauhaus_slider_set_format(g->shadows_range, _(" EV"));
-  gtk_widget_set_tooltip_text(g->shadows_range, _("number of stops between middle gray and pure black\nthis is a reading a posemeter would give you on the scene"));
+  gtk_widget_set_tooltip_text(g->shadows_range, _("number of stops between middle gray and pure black\nthis is a reading a light meter would give you on the scene"));
 
   g->dynamic_range
       = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "dynamic_range"));
   dt_bauhaus_slider_set_soft_range(g->dynamic_range, 0.5, 16.0);
   dt_bauhaus_slider_set_format(g->dynamic_range, _(" EV"));
-  gtk_widget_set_tooltip_text(g->dynamic_range, _("number of stops between pure black and pure white\nthis is a reading a posemeter would give you on the scene"));
+  gtk_widget_set_tooltip_text(g->dynamic_range, _("number of stops between pure black and pure white\nthis is a reading a light meter would give you on the scene"));
 
   gtk_box_pack_start(GTK_BOX(vbox_log), dt_ui_section_label_new(C_("section", "optimize automatically")), FALSE, FALSE, 0);
 


### PR DESCRIPTION
The word `posemeter` is not even just rarely used. It is simply not found in the corpus of the English language, which can be verified by searching on Google Books Ngram. Apparently, this word is a non-normative direct transfer of the French `posemètre` into English.

I have replaced this word with the [most commonly used name of the corresponding device in the English language](https://books.google.com/ngrams/graph?content=posemeter%2Cexponometer%2Clightmeter%2C%5Blight+meter%5D%2C%5Bexposure+meter%5D&year_start=1800&year_end=2019&corpus=en-2019&smoothing=3).