### PR TITLE
Fixes for pixelpipe cache 4.4

### DIFF
--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -349,18 +349,18 @@ static gboolean _get_by_hash(
     {
       /* We check for situation with a hash identity but buffer sizes don't match.
            This could happen because of "hash overlaps" or other situations where the hash
-           doesn't reflect the complete status. (or we have a bug in dt)
-         Also we don't use cached data while bypassing modules because of mask visualizing.
-           In both cases we don't want to simply realloc or alike as these data could possibly
-           still be used in the pipe.
-           Instead we make sure the cleanup after running the pixelpipe can free it but it
-           won't be taken in this pixelpipe process.
-           We do so by setting cache->used[k] to something very high.
+           doesn't reflect the complete status. (or we have another bug in dt)
+         Also we don't use cached data while bypassing modules because of mask visualizing
+           or we have pipe->nocache set to TRUE
+         In these cases we don't want to simply realloc or alike as these data could possibly
+         still be used in the pipe.
+         Instead we make sure the cleanup after running the pixelpipe can free it but it
+         won't be taken in this pixelpipe process.
       */
       if((cache->size[k] != size) || pipe->mask_display || pipe->nocache)
       {
         cache->hash[k] = cache->basichash[k] = INVALID_CACHEHASH;
-        cache->used[k] = +VERY_OLD_CACHE_WEIGHT;
+        cache->used[k] = VERY_OLD_CACHE_WEIGHT;
       }
       else
       {

--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -90,7 +90,7 @@ void dt_dev_pixelpipe_cache_invalidate_later(struct dt_dev_pixelpipe_t *pipe, st
 void dt_dev_pixelpipe_important_cacheline(struct dt_dev_pixelpipe_t *pipe, void *data, const size_t size);
 
 /** mark the given cache line as invalid or to be ignored */
-void dt_dev_pixelpipe_invalidate_cacheline(struct dt_dev_pixelpipe_t *pipe, void *data, const gboolean invalid);
+void dt_dev_pixelpipe_invalidate_cacheline(struct dt_dev_pixelpipe_t *pipe, void *data);
 
 /** print out cache lines/hashes and do a cache cleanup */
 void dt_dev_pixelpipe_cache_report(struct dt_dev_pixelpipe_t *pipe);

--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -78,19 +78,19 @@ gboolean dt_dev_pixelpipe_cache_get(struct dt_dev_pixelpipe_t *pipe, const uint6
 gboolean dt_dev_pixelpipe_cache_available(struct dt_dev_pixelpipe_t *pipe, const uint64_t hash, const uint64_t basichash, const size_t size);
 
 /** invalidates all cachelines. */
-void dt_dev_pixelpipe_cache_flush(struct dt_dev_pixelpipe_t *pipe);
+void dt_dev_pixelpipe_cache_flush(const struct dt_dev_pixelpipe_t *pipe);
 
 /** invalidates all cachelines except those containing items for the given module/parameter combination */
-void dt_dev_pixelpipe_cache_flush_all_but(struct dt_dev_pixelpipe_t *pipe, const uint64_t basichash);
+void dt_dev_pixelpipe_cache_flush_all_but(const struct dt_dev_pixelpipe_t *pipe, const uint64_t basichash);
 
 /** invalidates all cachelines for modules with at least the same iop_order */
-void dt_dev_pixelpipe_cache_invalidate_later(struct dt_dev_pixelpipe_t *pipe, struct dt_iop_module_t *module);
+void dt_dev_pixelpipe_cache_invalidate_later(const struct dt_dev_pixelpipe_t *pipe, const struct dt_iop_module_t *module);
 
 /** makes this buffer very important after it has been pulled from the cache. */
-void dt_dev_pixelpipe_important_cacheline(struct dt_dev_pixelpipe_t *pipe, void *data, const size_t size);
+void dt_dev_pixelpipe_important_cacheline(const struct dt_dev_pixelpipe_t *pipe, const void *data, const size_t size);
 
 /** mark the given cache line as invalid or to be ignored */
-void dt_dev_pixelpipe_invalidate_cacheline(struct dt_dev_pixelpipe_t *pipe, void *data);
+void dt_dev_pixelpipe_invalidate_cacheline(const struct dt_dev_pixelpipe_t *pipe, const void *data);
 
 /** print out cache lines/hashes and do a cache cleanup */
 void dt_dev_pixelpipe_cache_report(struct dt_dev_pixelpipe_t *pipe);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2141,7 +2141,8 @@ static gboolean _dev_pixelpipe_process_rec(
         */
         important_cl =
            (pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_NONE)
-           && (pipe->type == DT_DEV_PIXELPIPE_FULL) // ignored in fast mode
+           && ((pipe->type == DT_DEV_PIXELPIPE_FULL) // ignored in fast mode
+              || (pipe->type == DT_DEV_PIXELPIPE_PREVIEW))
            && darktable.develop->gui_attached
            && ((module == darktable.develop->gui_module)
                 || module->iopcache_hint

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2287,7 +2287,7 @@ static gboolean _dev_pixelpipe_process_rec(
 
     /* input is still only on GPU? Let's invalidate CPU input buffer then */
     if(valid_input_on_gpu_only)
-      dt_dev_pixelpipe_invalidate_cacheline(pipe, input, TRUE);
+      dt_dev_pixelpipe_invalidate_cacheline(pipe, input);
   }
   else
   {
@@ -2307,7 +2307,7 @@ static gboolean _dev_pixelpipe_process_rec(
 #endif // HAVE_OPENCL
 
   if(pipe->mask_display != DT_DEV_PIXELPIPE_DISPLAY_NONE)
-    dt_dev_pixelpipe_invalidate_cacheline(pipe, *output, FALSE);
+    dt_dev_pixelpipe_invalidate_cacheline(pipe, *output);
 
   char histogram_log[32] = "";
   if(!(pixelpipe_flow & PIXELPIPE_FLOW_HISTOGRAM_NONE))
@@ -2346,7 +2346,7 @@ static gboolean _dev_pixelpipe_process_rec(
     // as the user is likely to change that one soon (again), so keep it in cache.
     // Also do this if the clbuffer has been actively written
     const gboolean has_focus = (module == darktable.develop->gui_module);
-    if((pipe->type & DT_DEV_PIXELPIPE_FULL)
+    if((pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW))
         && (pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_NONE)
         && (has_focus || module->iopcache_hint || important_cl))
     {
@@ -2365,7 +2365,7 @@ static gboolean _dev_pixelpipe_process_rec(
     {
       dt_print_pipe(DT_DEBUG_PIPE, "internal histogram", pipe, module, &roi_in, roi_out, "\n");
       pipe->nocache = TRUE;
-      dt_dev_pixelpipe_invalidate_cacheline(pipe, *output, FALSE);
+      dt_dev_pixelpipe_invalidate_cacheline(pipe, *output);
     }
   }
 


### PR DESCRIPTION
1. Fixing a big issue related to possibly returning the	same cacheline for in & output of a module. We might have used a number of cachelines already (for example by a previous run of the same image) and some of them might have been marked as invalid. In such a situation dt_dev_pixelpipe_cache_get() might have returned a wrong cacheline, especially it returned the same line for output as the module had for input.

3. Code refactoring and deduplication for invalidating a cacheline
4. slightly less verbose and improved debug log


See: #14271 #14556 
