### PR TITLE
Bump blendop to v13 and migrate to new version.

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -1637,7 +1637,7 @@ gboolean dt_develop_blend_legacy_params(dt_iop_module_t *module,
     return FALSE;
   }
 
-  if(old_version == 1 && new_version == 12)
+  if(old_version == 1 && new_version == 13)
   {
     /** blend legacy parameters version 1 */
     typedef struct dt_develop_blend_params1_t
@@ -1662,7 +1662,7 @@ gboolean dt_develop_blend_legacy_params(dt_iop_module_t *module,
     return FALSE;
   }
 
-  if(old_version == 2 && new_version == 12)
+  if(old_version == 2 && new_version == 13)
   {
     /** blend legacy parameters version 2 */
     typedef struct dt_develop_blend_params2_t
@@ -1703,7 +1703,7 @@ gboolean dt_develop_blend_legacy_params(dt_iop_module_t *module,
     return FALSE;
   }
 
-  if(old_version == 3 && new_version == 12)
+  if(old_version == 3 && new_version == 13)
   {
     /** blend legacy parameters version 3 */
     typedef struct dt_develop_blend_params3_t
@@ -1744,7 +1744,7 @@ gboolean dt_develop_blend_legacy_params(dt_iop_module_t *module,
     return FALSE;
   }
 
-  if(old_version == 4 && new_version == 12)
+  if(old_version == 4 && new_version == 13)
   {
     /** blend legacy parameters version 4 */
     typedef struct dt_develop_blend_params4_t
@@ -1787,7 +1787,7 @@ gboolean dt_develop_blend_legacy_params(dt_iop_module_t *module,
     return FALSE;
   }
 
-  if(old_version == 5 && new_version == 12)
+  if(old_version == 5 && new_version == 13)
   {
     /** blend legacy parameters version 5 (identical to version 6)*/
     typedef struct dt_develop_blend_params5_t
@@ -1839,7 +1839,7 @@ gboolean dt_develop_blend_legacy_params(dt_iop_module_t *module,
     return FALSE;
   }
 
-  if(old_version == 6 && new_version == 12)
+  if(old_version == 6 && new_version == 13)
   {
     /** blend legacy parameters version 6 (identical to version 7) */
     typedef struct dt_develop_blend_params6_t
@@ -1884,7 +1884,7 @@ gboolean dt_develop_blend_legacy_params(dt_iop_module_t *module,
     return FALSE;
   }
 
-  if(old_version == 7 && new_version == 12)
+  if(old_version == 7 && new_version == 13)
   {
     /** blend legacy parameters version 7 */
     typedef struct dt_develop_blend_params7_t
@@ -1929,7 +1929,7 @@ gboolean dt_develop_blend_legacy_params(dt_iop_module_t *module,
     return FALSE;
   }
 
-  if(old_version == 8 && new_version == 12)
+  if(old_version == 8 && new_version == 13)
   {
     /** blend legacy parameters version 8 */
     typedef struct dt_develop_blend_params8_t
@@ -1986,7 +1986,7 @@ gboolean dt_develop_blend_legacy_params(dt_iop_module_t *module,
     return FALSE;
   }
 
-  if(old_version == 9 && new_version == 12)
+  if(old_version == 9 && new_version == 13)
   {
     /** blend legacy parameters version 9 */
     typedef struct dt_develop_blend_params9_t
@@ -2046,13 +2046,13 @@ gboolean dt_develop_blend_legacy_params(dt_iop_module_t *module,
     memcpy(n->raster_mask_source, o->raster_mask_source,
            sizeof(n->raster_mask_source));
     n->raster_mask_instance = o->raster_mask_instance;
-    n->raster_mask_id = o->raster_mask_id;
+    n->raster_mask_id = o->raster_mask_source[0] ? o->raster_mask_id : INVALID_MASKID;
     n->raster_mask_invert = o->raster_mask_invert;
     _fix_masks_combine(n);
     return FALSE;
   }
 
-  if(old_version == 10 && new_version == 12)
+  if(old_version == 10 && new_version == 13)
   {
     /** blend legacy parameters version 10 */
     typedef struct dt_develop_blend_params10_t
@@ -2127,14 +2127,14 @@ gboolean dt_develop_blend_legacy_params(dt_iop_module_t *module,
     memcpy(n->raster_mask_source, o->raster_mask_source,
            sizeof(n->raster_mask_source));
     n->raster_mask_instance = o->raster_mask_instance;
-    n->raster_mask_id = o->raster_mask_id;
+    n->raster_mask_id = o->raster_mask_source[0] ? o->raster_mask_id : INVALID_MASKID;
     n->raster_mask_invert = o->raster_mask_invert;
 
     _fix_masks_combine(n);
 
     return FALSE;
   }
-  if(old_version == 11 && new_version == 12)
+  if(old_version == 11 && new_version == 13)
   {
     if(length != sizeof(dt_develop_blend_params_t)) return 1;
 
@@ -2143,6 +2143,18 @@ gboolean dt_develop_blend_legacy_params(dt_iop_module_t *module,
 
     *n = *o;
     _fix_masks_combine(n);
+    n->raster_mask_id = o->raster_mask_source[0] ? o->raster_mask_id : INVALID_MASKID;
+    return FALSE;
+  }
+  if(old_version == 12 && new_version == 13)
+  {
+    if(length != sizeof(dt_develop_blend_params_t)) return 1;
+
+    dt_develop_blend_params_t *o = (dt_develop_blend_params_t *)old_params;
+    dt_develop_blend_params_t *n = (dt_develop_blend_params_t *)new_params;
+
+    *n = *o;
+    n->raster_mask_id = o->raster_mask_source[0] ? o->raster_mask_id : INVALID_MASKID;
     return FALSE;
   }
   return TRUE;

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -27,7 +27,7 @@
 #include "gui/color_picker_proxy.h"
 #include "common/imagebuf.h"
 
-#define DEVELOP_BLEND_VERSION (12)
+#define DEVELOP_BLEND_VERSION (13)
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This is needed to set the raster_mask_id to INVALID_MASKID when no raster mask is used.

Fixes #14590.