### PR TITLE
[GUI] Reword the middle mouse button configuration tooltip

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1309,7 +1309,7 @@
     <type>bool</type>
     <default>true</default>
     <shortdescription>middle mouse button zooms to 200%</shortdescription>
-    <longdescription>when clicking the middle mouse button to zoom, the zoom level will cycle through 100%, 200% and then back to fit the screen. otherwise it switches between fit to screen and 100% and the 'ctrl' key can be used to control the zoom level.</longdescription>
+    <longdescription>if enabled, the zoom level will cycle between 100%, 200% and fit to viewport on middle mouse clicks. if disabled, it will toggle between viewport size and 100%, and the 'ctrl' key can be used to control the zoom level.</longdescription>
   </dtconfig>
   <dtconfig prefs="darkroom" section="modules">
     <name>channel_display</name>


### PR DESCRIPTION
In the original text, there was no clear and explicit description of what will happen when the preference is disabled, what will happen when it is enabled. The first sentence actually described what would happen when the box was checked, but it was implicit. The second sentence begins with "otherwise", that is, again, there is no explicit text. Of course, you can understand all this after thinking a little about what you read, but this is not a very good description.

In addition, the word "screen" was used here in a very unusual meaning, as "the central panel of the editor, where the edited image or part of it is displayed." But that's exactly what the term "viewport" is for.
