### PR TITLE
Visualize rastermasks & blend mask header

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -512,7 +512,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self,
                                  && self->dev->gui_attached
                                  && (self == self->dev->gui_module)
                                  && (piece->pipe == self->dev->pipe)
-                                 && (mask_mode & DEVELOP_MASK_MASK_CONDITIONAL);
+                                 && (mask_mode != DEVELOP_MASK_ENABLED);
 
   // obtaining the list of mask operations to perform
   _develop_mask_post_processing post_operations[3];
@@ -967,7 +967,7 @@ gboolean dt_develop_blend_process_cl(struct dt_iop_module_t *self,
                                  && self->dev->gui_attached
                                  && (self == self->dev->gui_module)
                                  && (piece->pipe == self->dev->pipe)
-                                 && (mask_mode & DEVELOP_MASK_MASK_CONDITIONAL);
+                                 && (mask_mode != DEVELOP_MASK_ENABLED);
 
   // obtaining the list of mask operations to perform
   _develop_mask_post_processing post_operations[3];

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -486,20 +486,19 @@ void dt_develop_blend_process(struct dt_iop_module_t *self,
     return;
   }
 
+  const gboolean valid_request =
+      self->dev->gui_attached
+      && (self == self->dev->gui_module)
+      && (piece->pipe == self->dev->pipe);
+
   // does user want us to display a specific channel?
   const dt_dev_pixelpipe_display_mask_t request_mask_display =
-    (self->dev->gui_attached
-      && (self == self->dev->gui_module)
-      && (piece->pipe == self->dev->pipe)
-      && (mask_mode & DEVELOP_MASK_MASK_CONDITIONAL))
+      valid_request && (mask_mode & DEVELOP_MASK_MASK_CONDITIONAL)
         ? self->request_mask_display
         : DT_DEV_PIXELPIPE_DISPLAY_NONE;
 
   const dt_dev_pixelpipe_display_mask_t request_raster_display =
-    (self->dev->gui_attached
-      && (self == self->dev->gui_module)
-      && (piece->pipe == self->dev->pipe)
-      && (mask_mode & DEVELOP_MASK_RASTER))
+      valid_request && (mask_mode & DEVELOP_MASK_RASTER)
         ? self->request_mask_display
         : DT_DEV_PIXELPIPE_DISPLAY_NONE;
 
@@ -509,10 +508,8 @@ void dt_develop_blend_process(struct dt_iop_module_t *self,
 
   // check if mask should be suppressed temporarily (i.e. just set to global opacity value)
   const gboolean suppress_mask = self->suppress_mask
-                                 && self->dev->gui_attached
-                                 && (self == self->dev->gui_module)
-                                 && (piece->pipe == self->dev->pipe)
-                                 && (mask_mode != DEVELOP_MASK_ENABLED);
+                                 && valid_request
+                                 && (mask_mode & ~DEVELOP_MASK_ENABLED);
 
   // obtaining the list of mask operations to perform
   _develop_mask_post_processing post_operations[3];
@@ -940,20 +937,19 @@ gboolean dt_develop_blend_process_cl(struct dt_iop_module_t *self,
   // only non-zero if mask_display was set by an _earlier_ module
   const dt_dev_pixelpipe_display_mask_t mask_display = piece->pipe->mask_display;
 
+  const gboolean valid_request =
+      self->dev->gui_attached
+      && (self == self->dev->gui_module)
+      && (piece->pipe == self->dev->pipe);
+
   // does user want us to display a specific channel?
-  const dt_dev_pixelpipe_display_mask_t request_mask_display
-      = (self->dev->gui_attached
-         && (self == self->dev->gui_module)
-         && (piece->pipe == self->dev->pipe)
-         && (mask_mode & DEVELOP_MASK_MASK_CONDITIONAL))
-            ? self->request_mask_display
-            : DT_DEV_PIXELPIPE_DISPLAY_NONE;
+  const dt_dev_pixelpipe_display_mask_t request_mask_display =
+      valid_request && (mask_mode & DEVELOP_MASK_MASK_CONDITIONAL)
+        ? self->request_mask_display
+        : DT_DEV_PIXELPIPE_DISPLAY_NONE;
 
   const dt_dev_pixelpipe_display_mask_t request_raster_display =
-    (self->dev->gui_attached
-      && (self == self->dev->gui_module)
-      && (piece->pipe == self->dev->pipe)
-      && (mask_mode & DEVELOP_MASK_RASTER))
+      valid_request && (mask_mode & DEVELOP_MASK_RASTER)
         ? self->request_mask_display
         : DT_DEV_PIXELPIPE_DISPLAY_NONE;
 
@@ -961,13 +957,10 @@ gboolean dt_develop_blend_process_cl(struct dt_iop_module_t *self,
   const dt_develop_blend_colorspace_t blend_csp = d->blend_cst;
   const dt_iop_colorspace_type_t cst = dt_develop_blend_colorspace(piece, IOP_CS_NONE);
 
-  // check if mask should be suppressed temporarily (i.e. just set to global
-  // opacity value)
+  // check if mask should be suppressed temporarily (i.e. just set to global opacity value)
   const gboolean suppress_mask = self->suppress_mask
-                                 && self->dev->gui_attached
-                                 && (self == self->dev->gui_module)
-                                 && (piece->pipe == self->dev->pipe)
-                                 && (mask_mode != DEVELOP_MASK_ENABLED);
+                                 && valid_request
+                                 && (mask_mode & ~DEVELOP_MASK_ENABLED);
 
   // obtaining the list of mask operations to perform
   _develop_mask_post_processing post_operations[3];

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -495,6 +495,14 @@ void dt_develop_blend_process(struct dt_iop_module_t *self,
         ? self->request_mask_display
         : DT_DEV_PIXELPIPE_DISPLAY_NONE;
 
+  const dt_dev_pixelpipe_display_mask_t request_raster_display =
+    (self->dev->gui_attached
+      && (self == self->dev->gui_module)
+      && (piece->pipe == self->dev->pipe)
+      && (mask_mode & DEVELOP_MASK_RASTER))
+        ? self->request_mask_display
+        : DT_DEV_PIXELPIPE_DISPLAY_NONE;
+
   // get channel max values depending on colorspace
   const dt_develop_blend_colorspace_t blend_csp = d->blend_cst;
   const dt_iop_colorspace_type_t cst = dt_develop_blend_colorspace(piece, IOP_CS_NONE);
@@ -739,6 +747,11 @@ void dt_develop_blend_process(struct dt_iop_module_t *self,
   {
     piece->pipe->mask_display = request_mask_display;
   }
+  else if(request_raster_display
+          & (DT_DEV_PIXELPIPE_DISPLAY_MASK | DT_DEV_PIXELPIPE_DISPLAY_CHANNEL))
+  {
+    piece->pipe->mask_display = request_raster_display;
+  }
 
   // check if we should store the mask for export or use in subsequent modules
   // TODO: should we skip raster masks?
@@ -935,6 +948,14 @@ gboolean dt_develop_blend_process_cl(struct dt_iop_module_t *self,
          && (mask_mode & DEVELOP_MASK_MASK_CONDITIONAL))
             ? self->request_mask_display
             : DT_DEV_PIXELPIPE_DISPLAY_NONE;
+
+  const dt_dev_pixelpipe_display_mask_t request_raster_display =
+    (self->dev->gui_attached
+      && (self == self->dev->gui_module)
+      && (piece->pipe == self->dev->pipe)
+      && (mask_mode & DEVELOP_MASK_RASTER))
+        ? self->request_mask_display
+        : DT_DEV_PIXELPIPE_DISPLAY_NONE;
 
   // get channel max values depending on colorspace
   const dt_develop_blend_colorspace_t blend_csp = d->blend_cst;
@@ -1375,6 +1396,11 @@ gboolean dt_develop_blend_process_cl(struct dt_iop_module_t *self,
      & (DT_DEV_PIXELPIPE_DISPLAY_MASK | DT_DEV_PIXELPIPE_DISPLAY_CHANNEL))
   {
     piece->pipe->mask_display = request_mask_display;
+  }
+  else if(request_raster_display
+          & (DT_DEV_PIXELPIPE_DISPLAY_MASK | DT_DEV_PIXELPIPE_DISPLAY_CHANNEL))
+  {
+    piece->pipe->mask_display = request_raster_display;
   }
 
 

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -351,6 +351,7 @@ typedef struct dt_iop_gui_blend_data_t
 
   GtkWidget *raster_combo;
   GtkWidget *raster_polarity;
+  GtkWidget *raster_show;
 
   int control_button_pressed;
   dt_pthread_mutex_t lock;

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -351,7 +351,6 @@ typedef struct dt_iop_gui_blend_data_t
 
   GtkWidget *raster_combo;
   GtkWidget *raster_polarity;
-  GtkWidget *raster_show;
 
   int control_button_pressed;
   dt_pthread_mutex_t lock;

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1354,41 +1354,6 @@ static gboolean _blendop_blendif_showmask_clicked(GtkToggleButton *button,
   return TRUE;
 }
 
-/*
-static gboolean _blendop_blendif_showraster_clicked(GtkToggleButton *button,
-                                                  GdkEventButton *event,
-                                                  dt_iop_module_t *module)
-{
-  if(darktable.gui->reset) return TRUE;
-
-  if(event->button == 1)
-  {
-    const gboolean active = !gtk_toggle_button_get_active(button);
-    gtk_toggle_button_set_active(button, active);
-
-    module->request_mask_display = active ? DT_DEV_PIXELPIPE_DISPLAY_MASK | DT_DEV_PIXELPIPE_DISPLAY_CHANNEL
-                                          : DT_DEV_PIXELPIPE_DISPLAY_NONE;
-
-    if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), TRUE);
-
-    ++darktable.gui->reset;
-
-    // (re)set the header mask indicator too
-    if(module->mask_indicator)
-      gtk_toggle_button_set_active
-        (GTK_TOGGLE_BUTTON(module->mask_indicator),
-         module->request_mask_display != DT_DEV_PIXELPIPE_DISPLAY_NONE);
-
-    --darktable.gui->reset;
-
-    dt_iop_request_focus(module);
-    dt_iop_refresh_center(module);
-  }
-
-  return TRUE;
-}
-*/
-
 static gboolean _blendop_masks_modes_none_clicked(GtkWidget *button,
                                                   GdkEventButton *event,
                                                   dt_iop_module_t *module)

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -3491,24 +3491,15 @@ void dt_iop_gui_init_blending(GtkWidget *iopw,
                         g_list_index(bd->masks_modes,
                                      (gconstpointer)DEVELOP_MASK_DISABLED)));
 
-    GtkWidget *obox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    gtk_box_set_homogeneous(GTK_BOX(obox), FALSE);
-    bd->opacity_slider = dt_bauhaus_slider_new_with_range(module, 0.0, 100.0, 0, 100.0, 0);
-    dt_bauhaus_widget_set_quad_visibility(bd->opacity_slider, FALSE);
-    dt_bauhaus_widget_set_field(bd->opacity_slider,
-                                &module->blend_params->opacity,
-                                DT_INTROSPECTION_TYPE_FLOAT);
-    dt_bauhaus_widget_set_label(bd->opacity_slider, N_("blend"), N_("opacity"));
-    dt_bauhaus_slider_set_format(bd->opacity_slider, "%");
-    module->fusion_slider = bd->opacity_slider;
-    gtk_widget_set_tooltip_text(bd->opacity_slider,
-                                _("set the opacity of the blending"));
-    gtk_box_pack_start(GTK_BOX(obox), GTK_WIDGET(bd->opacity_slider), TRUE, TRUE, 0);
+    // global section holding the eye and showmask buttons
+    GtkWidget *gbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+    gtk_box_pack_start(GTK_BOX(gbox), dt_ui_label_new(_("blend mask")), TRUE, TRUE, 0);
+    dt_gui_add_class(gbox, "dt_section_label");
 
     bd->showmask = dt_iop_togglebutton_new(module, "blend`tools",
                                            N_("display mask and/or color channel"), NULL,
                                            G_CALLBACK(_blendop_blendif_showmask_clicked),
-                                           FALSE, 0, 0, dtgtk_cairo_paint_showmask, obox);
+                                           FALSE, 0, 0, dtgtk_cairo_paint_showmask, gbox);
     gtk_widget_set_tooltip_text
       (bd->showmask,
        _("display mask and/or color channel.\n"
@@ -3520,20 +3511,19 @@ void dt_iop_gui_init_blending(GtkWidget *iopw,
     bd->suppress = dt_iop_togglebutton_new(module, "blend`tools",
                                            N_("temporarily switch off blend mask"), NULL,
                                            G_CALLBACK(_blendop_blendif_suppress_toggled),
-                                           FALSE, 0, 0, dtgtk_cairo_paint_eye_toggle, obox);
+                                           FALSE, 0, 0, dtgtk_cairo_paint_eye_toggle, gbox);
     gtk_widget_set_tooltip_text
       (bd->suppress,
        _("temporarily switch off blend mask.\n"
          "only for module in focus"));
     dt_gui_add_class(bd->suppress, "dt_transparent_background");
 
-
     GtkWidget *blend_modes_hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
     bd->blend_modes_combo = dt_bauhaus_combobox_new(module);
     dt_action_t * ac = dt_bauhaus_widget_set_label(bd->blend_modes_combo,
                                                    N_("blend"),
-                                                   N_("blend mode"));
+                                                   N_("mode"));
     dt_bauhaus_combobox_add_introspection(bd->blend_modes_combo, ac,
                                           dt_develop_blend_mode_names, -1, -1);
     gtk_widget_set_tooltip_text(bd->blend_modes_combo, _("choose blending mode"));
@@ -3563,13 +3553,23 @@ void dt_iop_gui_init_blending(GtkWidget *iopw,
                                 DT_INTROSPECTION_TYPE_FLOAT);
     dt_bauhaus_widget_set_label(bd->blend_mode_parameter_slider,
                                 N_("blend"),
-                                N_("blend fulcrum"));
+                                N_("fulcrum"));
     dt_bauhaus_slider_set_format(bd->blend_mode_parameter_slider, _(" EV"));
     dt_bauhaus_slider_set_soft_range(bd->blend_mode_parameter_slider, -3.0, 3.0);
     gtk_widget_set_tooltip_text(bd->blend_mode_parameter_slider,
                                 _("adjust the fulcrum used by some blending"
                                   " operations"));
     gtk_widget_set_visible(bd->blend_mode_parameter_slider, FALSE);
+
+    bd->opacity_slider = dt_bauhaus_slider_new_with_range(module, 0.0, 100.0, 0, 100.0, 0);
+    dt_bauhaus_widget_set_field(bd->opacity_slider,
+                                &module->blend_params->opacity,
+                                DT_INTROSPECTION_TYPE_FLOAT);
+    dt_bauhaus_widget_set_label(bd->opacity_slider, N_("blend"), N_("opacity"));
+    dt_bauhaus_slider_set_format(bd->opacity_slider, "%");
+    gtk_widget_set_tooltip_text(bd->opacity_slider,
+                                _("set the opacity of the blending"));
+    module->fusion_slider = bd->opacity_slider;
 
     bd->masks_combine_combo = _combobox_new_from_list
       (module,
@@ -3647,7 +3647,6 @@ void dt_iop_gui_init_blending(GtkWidget *iopw,
     gtk_box_pack_start(GTK_BOX(hbox), dt_ui_label_new(_("mask refinement")), TRUE, TRUE, 0);
     dt_gui_add_class(hbox, "dt_section_label");
 
-
     GtkWidget *box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
     gtk_box_pack_start(GTK_BOX(iopw), GTK_WIDGET(box), TRUE, TRUE, 0);
 
@@ -3658,18 +3657,17 @@ void dt_iop_gui_init_blending(GtkWidget *iopw,
     {
       gtk_box_pack_start(GTK_BOX(bd->masks_modes_box), GTK_WIDGET(l->data), TRUE, TRUE, 0);
     }
-    gtk_box_pack_start(GTK_BOX(bd->masks_modes_box),
-                       GTK_WIDGET(presets_button), FALSE, FALSE, 0);
+
+    gtk_box_pack_start(GTK_BOX(bd->masks_modes_box), GTK_WIDGET(presets_button), FALSE, FALSE, 0);
     gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(bd->masks_modes_box), FALSE, FALSE, 0);
-    dt_gui_add_help_link(GTK_WIDGET(bd->masks_modes_box),
-                         "masks_blending");
+    dt_gui_add_help_link(GTK_WIDGET(bd->masks_modes_box), "masks_blending");
     gtk_widget_set_name(GTK_WIDGET(bd->masks_modes_box), "blending-tabs");
 
     bd->top_box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
+    gtk_box_pack_start(GTK_BOX(bd->top_box), gbox, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->top_box), blend_modes_hbox, TRUE, TRUE, 0);
-    gtk_box_pack_start(GTK_BOX(bd->top_box),
-                       bd->blend_mode_parameter_slider, TRUE, TRUE, 0);
-    gtk_box_pack_start(GTK_BOX(bd->top_box), obox, TRUE, TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(bd->top_box), bd->blend_mode_parameter_slider, TRUE, TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(bd->top_box), bd->opacity_slider, TRUE, TRUE, 0);
     _add_wrapped_box(box, bd->top_box, NULL);
 
     dt_iop_gui_init_masks(iopw, module);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1365,7 +1365,7 @@ static gboolean _blendop_blendif_showraster_clicked(GtkToggleButton *button,
     const gboolean active = !gtk_toggle_button_get_active(button);
     gtk_toggle_button_set_active(button, active);
 
-    module->request_mask_display = active ? DT_DEV_PIXELPIPE_DISPLAY_MASK
+    module->request_mask_display = active ? DT_DEV_PIXELPIPE_DISPLAY_MASK | DT_DEV_PIXELPIPE_DISPLAY_CHANNEL
                                           : DT_DEV_PIXELPIPE_DISPLAY_NONE;
 
     if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), TRUE);
@@ -3369,6 +3369,7 @@ void dt_iop_gui_blending_lose_focus(dt_iop_module_t *module)
     dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->showmask), FALSE);
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->suppress), FALSE);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->raster_show), FALSE);
     module->request_mask_display = DT_DEV_PIXELPIPE_DISPLAY_NONE;
     module->suppress_mask = FALSE;
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2652,17 +2652,13 @@ static void _display_mask_indicator_callback(GtkToggleButton *bt, dt_iop_module_
 
   const gboolean is_active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(bt));
   const dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
-  const gboolean raster = module->blend_params->mask_mode & DEVELOP_MASK_RASTER;
 
   module->request_mask_display &= ~DT_DEV_PIXELPIPE_DISPLAY_MASK;
   module->request_mask_display |= (is_active ? DT_DEV_PIXELPIPE_DISPLAY_MASK : DT_DEV_PIXELPIPE_DISPLAY_NONE);
 
   // set the module show mask button too
   if(bd->showmask)
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->showmask), !raster && is_active);
-
-  if(bd->raster_show)
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->raster_show), raster && is_active);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->showmask), is_active);
 
   dt_iop_request_focus(module);
   dt_iop_refresh_center(module);


### PR DESCRIPTION
Related to #14389 

While taking raster masks in module (A) it's tedious to look for the mask generated in the module (B).

In #14389 we had the good argument that a mask-visualizing-button should be graphically close to the masking stuff. So i took this approach introducing an extra button having it right at where we select the origin of the raster mask.
 
![Bildschirmfoto vom 2023-06-01 06-40-20](https://github.com/darktable-org/darktable/assets/50982232/489dc4da-2c80-4766-9031-f1318d35e080)



The mask indicator as seen here is also supported.

![Bildschirmfoto vom 2023-06-01 06-40-36](https://github.com/darktable-org/darktable/assets/50982232/1953c1c5-1f73-4669-8393-c8e358127467)


