### PR TITLE
focus (and reposition) lib with mouse

### DIFF
--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -827,18 +827,6 @@ static gboolean _lib_draw_callback(GtkWidget *widget,
   return FALSE;
 }
 
-static gboolean _lib_mouse_leave_callback(GtkWidget *widget,
-                                          GdkEventCrossing *e,
-                                          gpointer user_data)
-{
-  dt_lib_module_t *self = (dt_lib_module_t *)user_data;
-
-  if(self->mouse_leave)
-    self->mouse_leave(self);
-
-  return TRUE;
-}
-
 void dt_lib_gui_queue_update(dt_lib_module_t *module)
 {
   module->gui_uptodate = FALSE;
@@ -1079,7 +1067,6 @@ GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module)
 
   GtkWidget *expander = dtgtk_expander_new(header, module->widget);
   GtkWidget *header_evb = dtgtk_expander_get_header_event_box(DTGTK_EXPANDER(expander));
-  GtkWidget *body_evb = dtgtk_expander_get_body_event_box(DTGTK_EXPANDER(expander));
   GtkWidget *pluginui_frame = dtgtk_expander_get_frame(DTGTK_EXPANDER(expander));
 
   /* setup the header box */
@@ -1089,10 +1076,6 @@ GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module)
   g_signal_connect(G_OBJECT(header_evb), "enter-notify-event",
                    G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_SHOW));
-
-  /* connect mouse button callbacks for focus and presets */
-  g_signal_connect(G_OBJECT(body_evb), "leave-notify-event",
-                   G_CALLBACK(_lib_mouse_leave_callback), module);
 
   /*
    * initialize the header widgets

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -1045,6 +1045,17 @@ static gboolean _header_enter_notify_callback(GtkWidget *eventbox,
   return FALSE;
 }
 
+static gboolean _body_enter_leave_callback(GtkWidget *widget,
+                                            GdkEventCrossing *e,
+                                            gpointer user_data)
+{
+  // set or clear focused module when entering or leaving (not when opening popup)
+  if(e->detail != GDK_NOTIFY_INFERIOR && e->mode == GDK_CROSSING_NORMAL)
+    darktable.lib->gui_module = e->type == GDK_ENTER_NOTIFY ? user_data : NULL;
+
+  return FALSE;
+}
+
 GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module)
 {
   /* check if module is expandable */
@@ -1067,6 +1078,7 @@ GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module)
 
   GtkWidget *expander = dtgtk_expander_new(header, module->widget);
   GtkWidget *header_evb = dtgtk_expander_get_header_event_box(DTGTK_EXPANDER(expander));
+  GtkWidget *body_evb = dtgtk_expander_get_body_event_box(DTGTK_EXPANDER(expander));
   GtkWidget *pluginui_frame = dtgtk_expander_get_frame(DTGTK_EXPANDER(expander));
 
   /* setup the header box */
@@ -1076,6 +1088,12 @@ GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module)
   g_signal_connect(G_OBJECT(header_evb), "enter-notify-event",
                    G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_SHOW));
+
+  /* (un)focus module when entering/leaving body */
+  g_signal_connect(G_OBJECT(body_evb), "enter-notify-event",
+                   G_CALLBACK(_body_enter_leave_callback), module);
+  g_signal_connect(G_OBJECT(body_evb), "leave-notify-event",
+                   G_CALLBACK(_body_enter_leave_callback), module);
 
   /*
    * initialize the header widgets


### PR DESCRIPTION
fixes #14526 by taking away focus from a lib when the mouse leaves it. This avoids the module continuing to be repositioned when its size changes (for example because the mouse hovers over a different image in the lighttable).

In implementing this, I noticed that #14445 and #14465 misinterpreted the meaning of the `mouse_leave` function (which deals with the mouse leaving the center widget, not the module widget) and fixed this by attaching a leave handler to the metadata module widget directly).

@ansluk would you be able to test if this solves your issue?