### PR TITLE
[CI] Upload nightly builds to the Releases page

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -255,7 +255,7 @@ jobs:
         if: ${{ success() }}
         uses: actions/upload-artifact@v3
         with:
-          name: darktable-${{ env.VERSION }}-${{ env.SYSTEM }}.exe
+          name: Darktable.Nightly.Windows
           path: ${{ env.BUILD_DIR }}/darktable-${{ env.VERSION }}-${{ env.SYSTEM }}.exe
           retention-days: 2
 
@@ -347,6 +347,51 @@ jobs:
         if: ${{ success() }}
         uses: actions/upload-artifact@v3
         with:
-          name: darktable-${{ env.VERSION }}.dmg
+          name: Darktable.Nightly.macOS
           path: ${{ env.INSTALL_PREFIX }}/darktable-${{ env.VERSION }}.dmg
           retention-days: 2
+
+  upload_to_release:
+    permissions:
+      # We need write permission to update the nightly tag
+      contents: write
+    runs-on: ubuntu-latest
+    needs: [AppImage, Windows, macOS]
+    steps:
+      - name: Download AppImage artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: Darktable.Nightly.AppImage
+      - name: Download Windows artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: Darktable.Nightly.Windows
+      - name: Download macOS artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: Darktable.Nightly.macOS
+      - name: Update nightly release
+        uses: andelf/nightly-release@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: nightly
+          prerelease: true
+          name: 'Darktable nightly build $$'
+          body: |
+            This is a nightly build of Darktable.
+
+            You can use this if you want to try new features without waiting for releases.
+            From time to time, in development builds, old difficult-to-reproduce bugs are
+            fixed, but it is also true that in the development process with the introduction
+            of new complex code, the stability of the program may suffer compared to
+            official releases, so **use it with caution**!
+
+            Also, new versions can make changes to the database schema, so it's best to run
+            them with a separate library.
+
+            Please help us improve Darktable by reporting any issues you encounter! :wink:
+          files: |
+            Darktable-*.AppImage
+            darktable-*.dmg
+            darktable-*.exe


### PR DESCRIPTION
This is important for two reasons:

- Artifacts on the Releases page have more visibility and the page has a permanent URL that can be linked elsewhere.
- Those users who do not have a Github account can download artifacts only from the Release page (artifacts on the Action result page are not available to them).

This (+ distro-independent AppImage builds) should encourage more users to work with dt development builds.