### PR TITLE
fix padding for modules with top level event box

### DIFF
--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -534,8 +534,7 @@ static void _update_layout(dt_lib_module_t *self)
                             dt_conf_get_int(setting) & DT_METADATA_FLAG_HIDDEN;
     g_free(setting);
 
-    GtkWidget *label = gtk_grid_get_child_at(GTK_GRID(gtk_bin_get_child(GTK_BIN(self->widget))), 0, i);
-    gtk_widget_set_visible(label, !hidden);
+    gtk_widget_set_visible(d->label[i], !hidden);
     GtkWidget *current = GTK_WIDGET(d->textview[i]);
     gtk_widget_set_visible(gtk_widget_get_parent(current), !hidden);
 
@@ -839,8 +838,10 @@ void gui_init(dt_lib_module_t *self)
   self->data = (void *)d;
 
   GtkGrid *grid = GTK_GRID(gtk_grid_new());
-  self->widget = gtk_event_box_new();
-  gtk_container_add(GTK_CONTAINER(self->widget), GTK_WIDGET(grid));
+  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  GtkWidget *evbox = gtk_event_box_new();
+  gtk_container_add(GTK_CONTAINER(self->widget), evbox);
+  gtk_container_add(GTK_CONTAINER(evbox), GTK_WIDGET(grid));
   gtk_grid_set_row_spacing(grid, DT_PIXEL_APPLY_DPI(5));
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(10));
 
@@ -917,7 +918,7 @@ void gui_init(dt_lib_module_t *self)
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
                             G_CALLBACK(_collection_updated_callback), self);
 
-  g_signal_connect(G_OBJECT(self->widget), "leave-notify-event",
+  g_signal_connect(G_OBJECT(evbox), "leave-notify-event",
                    G_CALLBACK(_lib_mouse_leave_callback), self);
 
   gtk_widget_show_all(self->widget);

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -1351,7 +1351,9 @@ void gui_init(dt_lib_module_t *self)
   d->grid = child_grid_window;
   gtk_grid_set_column_spacing(GTK_GRID(child_grid_window), DT_PIXEL_APPLY_DPI(5));
 
-  self->widget = dt_ui_resize_wrap(child_grid_window, 200, "plugins/lighttable/metadata_view/windowheight");
+  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  gtk_container_add(GTK_CONTAINER(self->widget),
+                    dt_ui_resize_wrap(child_grid_window, 200, "plugins/lighttable/metadata_view/windowheight"));
 
   gtk_widget_show_all(d->grid);
   gtk_widget_set_no_show_all(d->grid, TRUE);

--- a/src/libs/recentcollect.c
+++ b/src/libs/recentcollect.c
@@ -325,7 +325,9 @@ void gui_init(dt_lib_module_t *self)
   self->data = (void *)d;
 
   GtkWidget *box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  self->widget = dt_ui_resize_wrap(box, 50, "plugins/lighttable/recentcollect/windowheight");
+  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  gtk_container_add(GTK_CONTAINER(self->widget),
+                    dt_ui_resize_wrap(box, 50, "plugins/lighttable/recentcollect/windowheight"));
   d->box = box;
   d->inited = 0;
 


### PR DESCRIPTION
fixes #14631 for image information, metadata editor and recently used collections.