### PR TITLE
[CI] Remove the nightly tag after release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -395,3 +395,13 @@ jobs:
             Darktable-*.AppImage
             darktable-*.dmg
             darktable-*.exe
+
+      # We want our development builds to report the version relative to the latest unstable tag.
+      # The 'nightly' tag will interfere with this, so we'll have to remove it.
+      # Released artifacts will be available on the main Releases page, just not under the Tags section.
+      - name: Delete nightly tag
+        uses: nbelingheri/delete-tag@v0.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: nightly


### PR DESCRIPTION
Fixes #14650.

Creating 'nightly' tag is just a tool to create release artifacts, it doesn't make much sense in the repository. The test showed that we can remove this tag after creating the release artifacts and they will be preserved. In the Tags section, of course, they will not be there, since it contains a list of pages with links to artifacts of _existing_ tags only. However, the artifacts will be preserved on the general Releases page.

The only side effect is that source code archives will not be added to the list of artifacts. Which in my opinion is even better.
