### PR TITLE
Enable macos default keyboard shortcuts in homebrew build

### DIFF
--- a/packaging/macosx/3_make_hb_darktable_package.sh
+++ b/packaging/macosx/3_make_hb_darktable_package.sh
@@ -271,6 +271,12 @@ done
 cp defaults.list "$dtResourcesDir"/share/applications/
 cp open.desktop "$dtResourcesDir"/share/applications/
 
+# Add gtk Mac theme (to enable default macos keyboard shortcuts)
+if [[ ! -d "$dtResourcesDir"/share/themes/Mac/gtk-3.0 ]]; then
+    mkdir -p "$dtResourcesDir"/share/themes/Mac/gtk-3.0
+fi
+cp -L "$homebrewHome"/share/themes/Mac/gtk-3.0/gtk-keys.css "$dtResourcesDir"/share/themes/Mac/gtk-3.0/
+
 # Sign app bundle
 if [ -n "$CODECERT" ]; then
     # Use certificate if one has been provided


### PR DESCRIPTION
PREREQUISITE

- macOS 13.4 Ventura, probably valid as well for earlier versions
- m1 (arm), probably valid as well for Intel
- homebrew-based build environment

STEPS TO REPRODUCE

1. Build darktable from source using homebrew build instructions (or take the official release from GitHub, e.g. `darktable-4.2.1_arm64.dmg`) 
2. Start darktable
3. Click into some textfield to edit content (e.g. lighttable => export => target storage, file on disk => file path)

CURRENT BEHAVIOUR

Only Linux-like keyboard shortcuts can be used to edit text, e.g. Copy (`<Control> + <c>`), Cut (`<Control> + <x>`), Paste (`<Control> + <v>`).

This is confusing as applications on macOS commonly use `<Command>` instead of `<Control>`.

EXPECTED BEHAVIOUR

Default macOS keyboard shortcuts can be used to edit text, e.g. Copy (`<Command> + <c>`), Cut (`<Command> + <x>`), Paste (`<Command> + <v>`).

PROPOSED FIX

Use the default keyboard bindings as defined by the Mac theme of `gtk-3.0`. Could be worth to consider also for the official MacPorts-based build.

REFERENCES

RawTherapee is doing it the same way: https://github.com/Beep6581/RawTherapee/blob/be2d5ce11face17acb3c9f0ab6e9b56ff13d4dae/tools/osx/macosx_bundle.sh#L252