### PR TITLE
Revive maps view (osm-gps-map) in homebrew-based build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,9 +135,10 @@ if(APPLE)
     string(STRIP "${HOMEBREW_PREFIX}" HOMEBREW_PREFIX)
     message("-- Homebrew detected, setting CMAKE_PREFIX_PATH to ${HOMEBREW_PREFIX}")
     LIST(APPEND CMAKE_PREFIX_PATH ${HOMEBREW_PREFIX})
-    # Explicitly add llvm and icu4c to prefix path
+    # Explicitly add llvm, icu4c, and libsoup version 2 to prefix path
     LIST(APPEND CMAKE_PREFIX_PATH ${HOMEBREW_PREFIX}/opt/llvm)
     LIST(APPEND CMAKE_PREFIX_PATH ${HOMEBREW_PREFIX}/opt/icu4c)
+    LIST(APPEND CMAKE_PREFIX_PATH ${HOMEBREW_PREFIX}/opt/libsoup@2)
   else()
     message("-- Setting CMAKE_PREFIX_PATH to prefer MacPorts and/or user-installed libraries over system ones")
     LIST(APPEND CMAKE_PREFIX_PATH /opt/local /usr/local)


### PR DESCRIPTION
PREREQUISITE

- macOS 13.4 Ventura, probably as well valid for earlier versions
- m1 (arm), probably as well valid for Intel
- homebrew-based build environment

STEPS TO REPRODUCE

1. Build darktable from source using homebrew build instructions 
2. Generate app bundle and start darktable
3. Open map view in darktable

CURRENT BEHAVIOUR

map view is not available.

During build configuration the package `osm-gps-map` is not found.

```
-- The following OPTIONAL packages have not been found:
[...]
 * OSMGpsMap
[...]
```

Accordingly the map view is deactivated / not available after successful build.

When checking via `pkg-config --cflags --libs osmgpsmap-1.0` the root cause can be revealed:

```
Package libsoup-2.4 was not found in the pkg-config search path.
Perhaps you should add the directory containing `libsoup-2.4.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libsoup-2.4', required by 'osmgpsmap-1.0', not found
```

EXPECTED BEHAVIOUR

map view is available and can be used.

During build configuration the package `osm-gps-map` is found.

```
-- The following OPTIONAL packages have been found:
[...]
 * OSMGpsMap
[...]
```

PROPOSED FIX

<del>Help cmake to find libsoup which fails due to the homebrew-specific naming of the legacy libsoup version 2 as "libsoup@2". `libsoup@2` is a requirement of the `osm-gps-map` package.</del>

Update `1_install_hb_dependencies.sh` to properly link multiple packages.