### PR TITLE
Fix lmmse crashing on improper dsc.processed_maximum data

### DIFF
--- a/src/iop/demosaicing/lmmse.c
+++ b/src/iop/demosaicing/lmmse.c
@@ -201,9 +201,9 @@ static void lmmse_demosaic(
   // refinement steps
   const int refine = (mode > 2) ? mode - 2 : 0;
 
-  const float scaler = fmaxf(piece->pipe->dsc.processed_maximum[0],
-                             fmaxf(piece->pipe->dsc.processed_maximum[1],
-                                   piece->pipe->dsc.processed_maximum[2]));
+  const float scaler = fmaxf(1.0f, fmaxf(piece->pipe->dsc.processed_maximum[0],
+                                   fmaxf(piece->pipe->dsc.processed_maximum[1],
+                                   piece->pipe->dsc.processed_maximum[2])));
   const float revscaler = 1.0f / scaler;
 
   const int num_vertical =   1 + (height - 2 * LMMSE_OVERLAP -1) / LMMSE_TILEVALID;


### PR DESCRIPTION
We should make sure here but the problem is in the temperature module.

Will have a look for a 4.4 fix in temperature module too.