### PR TITLE
Fix un-initialized user modified temperature

### DIFF
--- a/src/common/illuminants.h
+++ b/src/common/illuminants.h
@@ -229,7 +229,7 @@ static inline void illuminant_CCT_to_RGB(const float t, dt_aligned_pixel_t RGB)
 
 
 // Fetch image from pipeline and read EXIF for camera RAW WB coeffs
-static inline int find_temperature_from_raw_coeffs(const dt_image_t *img, const dt_aligned_pixel_t custom_wb,
+static inline gboolean find_temperature_from_raw_coeffs(const dt_image_t *img, const dt_aligned_pixel_t custom_wb,
                                                    float *chroma_x, float *chroma_y);
 
 
@@ -398,13 +398,13 @@ static inline void matrice_pseudoinverse(float (*in)[3], float (*out)[3], int si
 }
 
 
-static int find_temperature_from_raw_coeffs(const dt_image_t *img, const dt_aligned_pixel_t custom_wb,
+static gboolean find_temperature_from_raw_coeffs(const dt_image_t *img, const dt_aligned_pixel_t custom_wb,
                                             float *chroma_x, float *chroma_y)
 {
   if(img == NULL) return FALSE;
   if(!dt_image_is_matrix_correction_supported(img)) return FALSE;
 
-  int has_valid_coeffs = TRUE;
+  gboolean has_valid_coeffs = TRUE;
   const int num_coeffs = (img->flags & DT_IMAGE_4BAYER) ? 4 : 3;
 
   // Check coeffs

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1617,6 +1617,9 @@ void reload_defaults(dt_iop_module_t *module)
     g->as_shot_wb[3] /= g->as_shot_wb[1];
     g->as_shot_wb[1] = 1.0;
 
+    for(int k = 0; k < 4; k++)
+      g->mod_coeff[k] = g->daylight_wb[k];
+
     float TempK, tint;
     mul2temp(module, d, &TempK, &tint);
 

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -165,7 +165,7 @@ static inline void _temp_array_from_params(double a[4],
   a[3] = p->g2;
 }
 
-static int ignore_missing_wb(dt_image_t *img)
+static gboolean _ignore_missing_wb(dt_image_t *img)
 {
   // Ignore files that end with "-hdr.dng" since these are broken files we
   // generated without any proper WB tagged
@@ -1368,7 +1368,7 @@ void gui_update(struct dt_iop_module_t *self)
   gtk_widget_queue_draw(self->widget);
 }
 
-static int calculate_bogus_daylight_wb(dt_iop_module_t *module, double bwb[4])
+static gboolean calculate_bogus_daylight_wb(dt_iop_module_t *module, double bwb[4])
 {
   if(!dt_image_is_matrix_correction_supported(&module->dev->image_storage))
   {
@@ -1377,7 +1377,7 @@ static int calculate_bogus_daylight_wb(dt_iop_module_t *module, double bwb[4])
     bwb[1] = 1.0;
     bwb[3] = 1.0;
 
-    return 0;
+    return FALSE;
   }
 
   double mul[4];
@@ -1392,10 +1392,10 @@ static int calculate_bogus_daylight_wb(dt_iop_module_t *module, double bwb[4])
     bwb[1] = 1.0;
     bwb[3] = mul[3] / mul[1];
 
-    return 0;
+    return FALSE;
   }
 
-  return 1;
+  return TRUE;
 }
 
 static void prepare_matrices(dt_iop_module_t *module)
@@ -1450,7 +1450,7 @@ static void find_coeffs(dt_iop_module_t *module, double coeffs[4])
     return;
   }
 
-  if(!ignore_missing_wb(&(module->dev->image_storage)))
+  if(!_ignore_missing_wb(&(module->dev->image_storage)))
   {
     //  only display this if we have a sample, otherwise it is better to keep
     //  on screen the more important message about missing sample and the way
@@ -2086,7 +2086,8 @@ void gui_init(struct dt_iop_module_t *self)
   for(int k = 0; k < 4; k++)
   {
     g->daylight_wb[k] = 1.0;
-    g->as_shot_wb[k] = 1.f;
+    g->as_shot_wb[k] = 1.0;
+    g->mod_coeff[k] = 1.0;
   }
 
   GtkWidget *temp_label_box = gtk_event_box_new();


### PR DESCRIPTION
To reproduce the issue: start with a fresh raw image history and switch to "user defined"; please note the coeffs are zero in this case. (Originally reported via #14669)

Done here:
1. while investigation a few int->gboolean conversions
2. Initialize g->mod_coeff[k] at start

Fixes #14669