### PR TITLE
[CI] Revert to keeping nightly tag in the repository

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -397,13 +397,3 @@ jobs:
             Darktable-*.AppImage
             darktable-*.dmg
             darktable-*.exe
-
-      # We want our development builds to report the version relative to the latest unstable tag.
-      # The 'nightly' tag will interfere with this, so we'll have to remove it.
-      # Released artifacts will be available on the main Releases page, just not under the Tags section.
-      - name: Delete nightly tag
-        uses: nbelingheri/delete-tag@v0.3.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: nightly


### PR DESCRIPTION
Prerequisite: PR #14677 must be accepted, as it is required for proper darktable versioning when the repository has the nightly tag.

I have already written about the list of drawbacks that we would have to tolerate when removing the tag: https://github.com/darktable-org/darktable/pull/14677#issuecomment-1582789165

But additional testing revealed that removing the tag would simply be a broken solution. It turns out that we won't be able to automatically replace the old tag release with the new one (which is the point of nightly releases) if the tag is removed. Old releases without tags would not be replaced by the new nightly and these releases would accumulate on the Releases page. This is absolutely unacceptable.
