### PR TITLE
Manifest G'MIC support in "darktable --version" output

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -668,6 +668,12 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
                "  gPhoto2 support disabled\n"
 #endif
 
+#ifdef HAVE_GMIC
+               "  G'MIC support enabled (compressed LUTs will be supported)\n"
+#else
+               "  G'MIC support disabled (compressed LUTs will not be supported)\n"
+#endif
+
 #ifdef HAVE_GRAPHICSMAGICK
                "  GraphicsMagick support enabled\n"
 #else


### PR DESCRIPTION
This will allow the user to quickly understand whether compressed LUTs are supported by the darktable build.