### PR TITLE
print: bugfix, don't enter print view when discovering printers

### DIFF
--- a/src/common/cups_print.c
+++ b/src/common/cups_print.c
@@ -57,9 +57,21 @@ extern void cupsFreeDestInfo() __attribute__((weak_import));
 
 typedef struct dt_prtctl_t
 {
-  void (*cb)(dt_printer_info_t *, void *);
+  void (*cb_exec)(dt_printer_info_t *, void *);
+  void (*cb_state)(gboolean running, void *user_data);
   void *user_data;
 } dt_prtctl_t;
+
+static void _state_changed_callback(dt_job_t *job, dt_job_state_t state)
+{
+  const dt_prtctl_t *const pctl = dt_control_job_get_params(job);
+  if(pctl->cb_state)
+  {
+    const gboolean running =
+      (state == DT_JOB_STATE_RUNNING || state == DT_JOB_STATE_QUEUED);
+    pctl->cb_state(running, pctl->user_data);
+  }
+}
 
 // initialize the pinfo structure
 void dt_init_print_info(dt_print_info_t *pinfo)
@@ -156,7 +168,7 @@ static int _dest_cb(void *user_data, unsigned flags, cups_dest_t *dest)
     dt_printer_info_t pr;
     memset(&pr, 0, sizeof(pr));
     dt_get_printer_info(dest->name, &pr);
-    if(pctl->cb) pctl->cb(&pr, pctl->user_data);
+    if(pctl->cb_exec) pctl->cb_exec(&pr, pctl->user_data);
     dt_print(DT_DEBUG_PRINT, "[print] new printer %s found\n", dest->name);
   }
   else
@@ -200,7 +212,9 @@ void dt_printers_abort_discovery(void)
   _cancel = 1;
 }
 
-void dt_printers_discovery(void (*cb)(dt_printer_info_t *pr, void *user_data), void *user_data)
+void dt_printers_discovery(void (*cb)(dt_printer_info_t *pr, void *user_data),
+                           void (*cb_state)(gboolean running, void *user_data),
+                           void *user_data)
 {
   // asynchronously checks for available printers
   dt_job_t *job = dt_control_job_create(&_detect_printers_callback, "detect connected printers");
@@ -208,10 +222,12 @@ void dt_printers_discovery(void (*cb)(dt_printer_info_t *pr, void *user_data), v
   {
     dt_prtctl_t *prtctl = g_malloc0(sizeof(dt_prtctl_t));
 
-    prtctl->cb = cb;
+    prtctl->cb_exec = cb;
+    prtctl->cb_state = cb_state;
     prtctl->user_data = user_data;
 
     dt_control_job_set_params(job, prtctl, g_free);
+    dt_control_job_set_state_callback(job, &_state_changed_callback);
     dt_control_add_job(darktable.control, DT_JOB_QUEUE_SYSTEM_BG, job);
   }
 }

--- a/src/common/cups_print.h
+++ b/src/common/cups_print.h
@@ -70,7 +70,9 @@ typedef struct dt_print_info_t
 } dt_print_info_t;
 
 // Asynchronous printer discovery, cb will be called for each printer found
-void dt_printers_discovery(void (*cb)(dt_printer_info_t *pr, void *user_data), void *user_data);
+void dt_printers_discovery(void (*cb)(dt_printer_info_t *pr, void *user_data),
+                           void (*cb_state)(gboolean running, void *user_data),
+                           void *user_data);
 void dt_printers_abort_discovery(void);
 
 // initialize the pinfo structure

--- a/src/libs/lib.h
+++ b/src/libs/lib.h
@@ -83,6 +83,16 @@ typedef struct dt_lib_t
       gboolean is_linear;
     } histogram;
 
+#ifdef HAVE_PRINT
+    /** Print settings processing hooks */
+    struct
+    {
+      // FIXME: if do printer discovery work in main print view, maybe this isn't necessary
+      struct dt_lib_module_t *module;
+      gboolean (*printer_discovery_running)(struct dt_lib_module_t *self);
+    } print_settings;
+#endif
+
     struct
     {
       struct dt_lib_module_t *module;

--- a/src/views/print.c
+++ b/src/views/print.c
@@ -346,6 +346,16 @@ gboolean try_enter(dt_view_t *self)
 {
   dt_print_t *prt = (dt_print_t*)self->data;
 
+  // if discovery job is still running and populating the comboboxes,
+  // weird things can happen including mis-initialized GUI or even a
+  // crash in drawing a widget
+  if(darktable.lib->proxy.print_settings.printer_discovery_running(darktable.lib->proxy.print_settings.module))
+  {
+    // FIXME: a less modal possibility would be to hide relevant print settings widgets until they are populated
+    dt_control_log(_("scanning printers, please try again to enter print view in a few moments"));
+    return TRUE;
+  }
+
   //  now check that there is at least one selected image
 
   const dt_imgid_t imgid = dt_act_on_get_main_image();


### PR DESCRIPTION
Otherwise weird GUI things can happen or even segfaults, as there are two threads altering the GUI. One can be displaying the print settings in the right panel while the other is populating combo boxes with printer info.

Note that a more user-friendly fix may be to hide the relevant widgets (printers, papers, media) while they are being populated. That would also open up a route to having a printers refresh button (or regular background refresh job) which would allow for detecting if a printer is plugged in or turned on after darktable is started. This also would obviate having to use lib->proxy.print.

I don't think this is a release critical bug for v4.4. I only came across it because I'm testing some print view changes, and kept starting up darktable with an image selected and hitting "p" right away to enter print view -- not typical usage. And even then I think I'm only seeing this because there are a couple CUPS printers showing up via network, which take a few seconds to load. Also as noted above, there may be a more elegant way to fix this.