### PR TITLE
[CI/CD] Support appimage zsync update

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -132,7 +132,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: Darktable.Nightly.AppImage
-          path: ${{ env.BUILD_DIR }}/Darktable-*.AppImage
+          path: ${{ env.BUILD_DIR }}/Darktable-*.AppImage*
           retention-days: 1
 
   Windows:
@@ -394,6 +394,6 @@ jobs:
 
             Please help us improve Darktable by reporting any issues you encounter! :wink:
           files: |
-            Darktable-*.AppImage
+            Darktable-*.AppImage*
             darktable-*.dmg
             darktable-*.exe

--- a/tools/appimage-build-script.sh
+++ b/tools/appimage-build-script.sh
@@ -39,4 +39,6 @@ export DEPLOY_GTK_VERSION=3
 export VERSION=$(sh ../tools/get_git_version_string.sh)
 export DISABLE_COPYRIGHT_FILES_DEPLOYMENT=1
 
+export UPDATE_INFORMATION="gh-releases-zsync|darktable-org|darktable|nightly|Darktable-*-x86_64.AppImage.zsync"
+
 ./linuxdeploy-x86_64.AppImage --appdir ../AppDir --plugin gtk --output appimage


### PR DESCRIPTION
This makes Darktable AppImage easily and efficiently updateable using delta updates.
