### PR TITLE
fully hide metadata fields without leaving margin

### DIFF
--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -534,10 +534,10 @@ static void _update_layout(dt_lib_module_t *self)
                             dt_conf_get_int(setting) & DT_METADATA_FLAG_HIDDEN;
     g_free(setting);
 
-    gtk_widget_set_visible(d->label[i], !hidden);
-    GtkWidget *current = GTK_WIDGET(d->textview[i]);
-    gtk_widget_set_visible(gtk_widget_get_parent(current), !hidden);
+    gtk_widget_set_visible(gtk_widget_get_parent(d->label[i]), !hidden);
+    gtk_widget_set_visible(d->swindow[i], !hidden);
 
+    GtkWidget *current = GTK_WIDGET(d->textview[i]);
     if(!hidden)
     {
       if(!first) first = previous = current;
@@ -842,7 +842,7 @@ void gui_init(dt_lib_module_t *self)
   GtkWidget *evbox = gtk_event_box_new();
   gtk_container_add(GTK_CONTAINER(self->widget), evbox);
   gtk_container_add(GTK_CONTAINER(evbox), GTK_WIDGET(grid));
-  gtk_grid_set_row_spacing(grid, DT_PIXEL_APPLY_DPI(5));
+  gtk_grid_set_row_spacing(grid, DT_PIXEL_APPLY_DPI(0));
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(10));
 
   for(int i = 0; i < DT_METADATA_NUMBER; i++)


### PR DESCRIPTION
#13418 (and then #14634) caused metadata fields not to be completely hidden when disabled in the preferences; an eventbox remained, which then triggered the addition of the default grid row spacing, causing uneven spacing where hidden fields were present. Fixed here and the row spacing removed completely since the vertical size drag space now already provides the same function.
![image](https://github.com/darktable-org/darktable/assets/1549490/7f3642bb-d0db-46fd-906d-4d07e2dae948)![image](https://github.com/darktable-org/darktable/assets/1549490/850941e5-0163-40f1-b695-b5172ee85145)
![image](https://github.com/darktable-org/darktable/assets/1549490/79c4c3f7-8132-4ec0-ad1f-be4cc5084ffc)


