### PR TITLE
CI: fix macOS architecture string

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -344,7 +344,7 @@ jobs:
       - name: Get version info
         run: |
           cd ${{ env.SRC_DIR }}
-          echo "VERSION=$(git describe --tags --match release-* | sed 's/^release-//;s/-/+/;s/-/~/;s/rc/~rc/')-$(arch)" >> $GITHUB_ENV
+          echo "VERSION=$(git describe --tags --match release-* | sed 's/^release-//;s/-/+/;s/-/~/;s/rc/~rc/')-$(uname -m)" >> $GITHUB_ENV
       - name: Package upload
         if: ${{ success() }}
         uses: actions/upload-artifact@v3

--- a/packaging/macosx/1_install_hb_dependencies.sh
+++ b/packaging/macosx/1_install_hb_dependencies.sh
@@ -12,7 +12,7 @@ if ! [ -x "$(command -v brew)" ]; then
     echo 'Homebrew not found. Follow instructions as provided by https://brew.sh/ to install it.' >&2
     exit 1
 else
-    echo "Found homebrew running in $(arch)-based environment."
+    echo "Found homebrew running in $(uname -m)-based environment."
 fi
 
 # Make sure that homebrew is up-to-date

--- a/packaging/macosx/4_make_hb_darktable_dmg.sh
+++ b/packaging/macosx/4_make_hb_darktable_dmg.sh
@@ -48,7 +48,7 @@ echo '
 chmod -Rf go-w /Volumes/"${PROGN}"
 sync
 hdiutil detach ${device}
-DMG="${PROGN}-$(git describe --tags --match release-* | sed 's/^release-//;s/-/+/;s/-/~/;s/rc/~rc/')-$(arch)"
+DMG="${PROGN}-$(git describe --tags --match release-* | sed 's/^release-//;s/-/+/;s/-/~/;s/rc/~rc/')-$(uname -m)"
 hdiutil convert "pack.temp.dmg" -format UDZO -imagekey zlib-level=9 -o "${DMG}"
 rm -f pack.temp.dmg
 


### PR DESCRIPTION
The `arch` command on macOS gives a deprecated result "i386" which can lead to misinterpretations for the package file name.

`uname -m` gives correct architecture string "x86_64"
