### PR TITLE
Bugfix dt_ioppr_transform_image_colorspace_cl()

### DIFF
--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -1516,12 +1516,12 @@ gboolean dt_ioppr_transform_image_colorspace_cl
   if(profile_info == NULL)
   {
     *converted_cst = cst_from;
-    return FALSE;
+    return TRUE;
   }
   if(profile_info->type == DT_COLORSPACE_NONE)
   {
     *converted_cst = cst_from;
-    return FALSE;
+    return TRUE;
   }
 
   const size_t ch = 4;


### PR DESCRIPTION
Two conditions here
1. `cst_from == cst_to`
2. `profile_info == NULL` wronfully returned a FALSE thus forcing a CPU fallback.

To reproduce apply exposure on a true monochrome image and watch `-d pipe -d opencl`