### PR TITLE
allow preview via shortcut when no image hovered

### DIFF
--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -308,13 +308,10 @@ static float _action_process_preview(gpointer target, dt_action_element_t elemen
     {
       if(effect != DT_ACTION_EFFECT_OFF)
       {
-        if(dt_is_valid_imgid(dt_control_get_mouse_over_id()))
-        {
-          const gboolean sticky = effect == DT_ACTION_EFFECT_HOLD_TOGGLE;
-          const gboolean focus = element == DT_ACTION_ELEMENT_FOCUS_DETECT;
+        const gboolean sticky = effect == DT_ACTION_EFFECT_HOLD_TOGGLE;
+        const gboolean focus = element == DT_ACTION_ELEMENT_FOCUS_DETECT;
 
-          dt_view_lighttable_set_preview_state(darktable.view_manager, TRUE, sticky, focus);
-        }
+        dt_view_lighttable_set_preview_state(darktable.view_manager, TRUE, sticky, focus);
       }
     }
 


### PR DESCRIPTION
fixes #14725

This drops the requirement that an image in the lighttable needs to have the mouse hovered over it before allowing to switch into sticky preview mode. This was carried over from previous code that only enforced this for hold/quick preview. This PR does no longer enforce it there either. As I don't see why the requirement should really have been there, so I see no problem with removing it, but maybe someone can justify it?