### PR TITLE
Ensure supported OpenCL device version

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -735,6 +735,25 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
     goto end;
   }
 
+  if(strlen(deviceversion) < 9)
+  {
+     dt_print_nts(DT_DEBUG_OPENCL,
+                 "   *** no proper device version ***\n");
+    res = TRUE;
+    goto end;
+  }
+  else
+  {
+    if((strncmp(deviceversion+7, "1.0", 3) == 0)
+      || (strncmp(deviceversion+7, "1.1", 3) == 0))
+    {
+      dt_print_nts(DT_DEBUG_OPENCL,
+                 "   *** insufficient device version ***\n");
+      res = TRUE;
+      goto end;
+    }
+  }
+
   if(!device_available)
   {
     dt_print_nts(DT_DEBUG_OPENCL,


### PR DESCRIPTION
We didn't check for unsupported device versions 1.0 and 1.1, (wasn't even aware that versions still might be around)

Devices with 1.0 or 1.1 OpenCL version must be rejected.

