### PR TITLE
[CI/CD] Avoid the Azure Ubuntu mirror in the nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Install compiler ${{ matrix.compiler.compiler }}
         run: |
+          # Remove azure mirror because it is unreliable and sometimes unpredictably leads to failed CI
+          sudo sed -i 's/azure\.//' /etc/apt/sources.list
           sudo apt-get update
           sudo apt-get -y install \
             ${{ matrix.compiler.packages }}


### PR DESCRIPTION
This fix is necessary due to the unreliability of the mirror and is the same as in PR #13305: we ensure that this mirror is not present in /etc/apt/sources.list.

@TurboGit The last nightly was unsuccessful due to Azure mirror failure, so please accept this PR today.