### PR TITLE
[maintenance] Get rid of USE_LENSFUN option

### DIFF
--- a/.ci/ci-script.sh
+++ b/.ci/ci-script.sh
@@ -115,7 +115,6 @@ case "$TARGET" in
       -DUSE_OPENEXR=OFF \
       -DBUILD_PRINT=OFF \
       -DBUILD_RS_IDENTIFY=OFF \
-      -DUSE_LENSFUN=OFF \
       -DUSE_GMIC=OFF \
       -DUSE_LIBSECRET=OFF \
       $ECO "$SRC_DIR" || (cat "$BUILD_DIR"/CMakeFiles/CMakeOutput.log; cat "$BUILD_DIR"/CMakeFiles/CMakeError.log)
@@ -142,7 +141,6 @@ case "$TARGET" in
       -DUSE_OPENEXR=OFF \
       -DBUILD_PRINT=OFF \
       -DBUILD_RS_IDENTIFY=OFF \
-      -DUSE_LENSFUN=OFF \
       -DUSE_GMIC=OFF \
       -DUSE_LIBSECRET=OFF \
       -DBUILD_SSE2_CODEPATHS=OFF \

--- a/DefineOptions.cmake
+++ b/DefineOptions.cmake
@@ -35,7 +35,6 @@ option(BUILD_BATTERY_INDICATOR "Add an icon to the top toolbar showing the state
 option(BUILD_MSYS2_INSTALL "Build an MSYS2 version of the install, aka for Windows platform, but without dependency installs" OFF)
 option(BUILD_NOISE_TOOLS "Build tools for generating noise profiles" OFF)
 option(BUILD_CURVE_TOOLS "Build tools for generating base and tone curves" OFF)
-option(USE_LENSFUN "Enable LensFun support" ON)
 option(USE_GMIC "Use G'MIC image processing framework." ON)
 option(USE_ICU "Use ICU - International Components for Unicode." ON)
 option(USE_GAME "Build 1st April easter egg game" ON)


### PR DESCRIPTION
Lensfun is now mandatory, so this option is useless.
