### PR TITLE
liquify: fix corruption in grow/shrink modes

### DIFF
--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -977,7 +977,6 @@ static void apply_round_stamp(const dt_liquify_warp_t *const restrict warp,
   for(size_t y = 0; y <= iradius; y++)
   {
     const float complex y_i = y * I;
-    const float complex minus_y_i = -y * I;
     const float y2 = y*y;
     for(size_t x = 0; x <= iradius; x++)
     {
@@ -1011,13 +1010,13 @@ static void apply_round_stamp(const dt_liquify_warp_t *const restrict warp,
         // DT_LIQUIFY_WARP_TYPE_RADIAL_GROW or _SHRINK
         // abs_strength is negative for _SHRINK
         const float abs_lookup = abs_strength * lookup_table[idist] / iradius;
-        *q1 += abs_lookup * ( x + minus_y_i);
+        *q1 += abs_lookup * (x - y_i);
         if(x!=0)
-          *q2 += abs_lookup * (-x + minus_y_i);
+          *q2 -= abs_lookup * (x + y_i);
         if(x!=0&&y!=0)
-          *q3 += abs_lookup * (-x + y_i);
+          *q3 -= abs_lookup * (x - y_i);
         if(y!=0)
-          *q4 += abs_lookup * ( x + y_i);
+          *q4 += abs_lookup * (x + y_i);
       }
     }
   }


### PR DESCRIPTION
Fixes #14760.  Must be a compiler optimization error, since all I did for the fix is rearrange the minus signs....
