### PR TITLE
make metadata editor save changes before showing data for different image

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -369,7 +369,7 @@ textview
 
 .combo,
 entry,
-.dt_metadata_multi,
+#dt-metadata-multi,
 textview
 {
   padding: 0.07em 0.28em;   /* be sure to keep 0.07em padding, at least to scrolledwindow textview part. part of workaround just below */
@@ -1607,6 +1607,18 @@ progressbar progress
   color: @disabled_fg_color;
 }
 
+#dt-metadata-changed
+{
+  font-style: italic;
+  text-decoration-line: underline;
+}
+
+#dt-metadata-multi
+{
+  font-style: italic;
+  margin: 0.07em; /* match textview */
+}
+
 /*---------------------
   - Set color pickers -
   ---------------------*/
@@ -1821,17 +1833,6 @@ treeview#delete-dialog:selected
    border-top: 2.4em solid @plugin_bg_color;
 }
 
-.dt_metadata_changed
-{
-  font-style: italic;
-  text-decoration-line: underline;
-}
-
-.dt_metadata_multi
-{
-  font-style: italic;
-  margin: 0.07em; /* match textview */
-}
 
 /*** --- Thumbtable css part ---
 

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1820,6 +1820,17 @@ treeview#delete-dialog:selected
    border-top: 2.4em solid @plugin_bg_color;
 }
 
+.dt_metadata_changed
+{
+  font-style: italic;
+  text-decoration-line: underline;
+}
+
+.dt_metadata_multi
+{
+  font-style: italic;
+}
+
 /*** --- Thumbtable css part ---
 
 Hierarchy :

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -369,6 +369,7 @@ textview
 
 .combo,
 entry,
+.dt_metadata_multi,
 textview
 {
   padding: 0.07em 0.28em;   /* be sure to keep 0.07em padding, at least to scrolledwindow textview part. part of workaround just below */
@@ -1829,6 +1830,7 @@ treeview#delete-dialog:selected
 .dt_metadata_multi
 {
   font-style: italic;
+  margin: 0.07em; /* match textview */
 }
 
 /*** --- Thumbtable css part ---

--- a/src/common/usermanual_url.c
+++ b/src/common/usermanual_url.c
@@ -41,6 +41,7 @@ dt_help_url urls_db[] =
   {"styles",                     "module-reference/utility-modules/lighttable/styles/#module-controls"},
   {"timeline",                   "module-reference/utility-modules/lighttable/timeline/"},
   {"metadata",                   "module-reference/utility-modules/shared/metadata-editor/"},
+  {"metadata_preferences",       "module-reference/utility-modules/shared/metadata-editor/#preferences"},
   {"tagging",                    "module-reference/utility-modules/shared/tagging/"},
   {"geotagging",                 "module-reference/utility-modules/shared/geotagging/"},
   {"collect",                    "module-reference/utility-modules/shared/collections/"},

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -99,10 +99,7 @@ static void _textbuffer_changed(GtkTextBuffer *buffer, dt_lib_metadata_t *d)
                                   : metadata[0] != 0;
       g_free(metadata);
 
-      if(this_changed)
-        dt_gui_add_class(d->label[i], "dt_metadata_changed");
-      else if(d->label[i])
-        dt_gui_remove_class(d->label[i], "dt_metadata_changed");
+      gtk_widget_set_name(d->label[i], this_changed ? "dt-metadata-changed" : NULL);
 
       gtk_container_foreach(GTK_CONTAINER(d->textview[i]),
                             (GtkCallback)gtk_widget_set_visible,
@@ -702,7 +699,7 @@ void gui_init(dt_lib_module_t *self)
     g_object_set_data(G_OBJECT(textview), "tv_multiple", GINT_TO_POINTER(FALSE));
 
     GtkWidget *unchanged = gtk_label_new("<leave unchanged>");
-    dt_gui_add_class(unchanged, "dt_metadata_multi");
+    gtk_widget_set_name(unchanged, "dt-metadata-multi");
     gtk_text_view_add_child_in_window(GTK_TEXT_VIEW(textview), unchanged, GTK_TEXT_WINDOW_WIDGET, 0, 0);
 
     d->setting_name[i] = g_strdup_printf("plugins/lighttable/metadata/%s_text_height", name);

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -717,8 +717,9 @@ void gui_init(dt_lib_module_t *self)
     //while resizing the panel or typing into the widget
     //reported upstream to https://gitlab.gnome.org/GNOME/gtk/-/issues/4042
     //see also discussions on https://github.com/darktable-org/darktable/pull/10584
-    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(gtk_bin_get_child(GTK_BIN(swindow))),
-                                   GTK_POLICY_EXTERNAL, GTK_POLICY_AUTOMATIC);
+    GtkScrolledWindow *realsw = GTK_SCROLLED_WINDOW(gtk_widget_get_parent(textview));
+    gtk_scrolled_window_set_policy(realsw, GTK_POLICY_EXTERNAL, GTK_POLICY_AUTOMATIC);
+    gtk_scrolled_window_set_min_content_width(realsw, DT_PIXEL_APPLY_DPI(30));
 
     gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(textview), GTK_WRAP_WORD_CHAR);
     gtk_text_view_set_accepts_tab(GTK_TEXT_VIEW(textview), FALSE);


### PR DESCRIPTION
The metadata editor has several usability issues and patches that unsuccessfully try to fix them. Basically, while editing metadata for a selected image, those changes can be lost when a different image is selected (or even hovered over, thanks to ActOn). Attempts to reduce the data loss saw data being committed when tabbing to another field or moving the mouse about, but that only "works" when the user is actually manipulating the editor with the mouse. When the mouse is over the lighttable but the focus still in a metadata field, any typing will potentially be lost (another "fix" for this that temporary saves and restores edits is unintuitive and unreliable). Moving the mouse across the editor while a large number of images are selected causes apparently multiple updates or at least a significant slowdown. The apply button is useless because just moving the mouse towards it causes a commit. I'm not trying to be exhaustive or exact here; I think anybody who uses the editor has learned to be careful not to fall foul of its quirks.

IMHO the correct way of preventing data loss when loading data for a different image is to save the data _before_ loading data for a different image. This is exactly what this PR does. There is no need to commit on tab or mouse move anymore and it is even possible to have a working cancel button (that can undo changes to multiple fields while they haven't been applied yet). Esc also cancels and Enter (or pressing apply) commits without the need to change selection. It also brings the focus back to the lighttable, so it is now possible to change metadata for a set of images without using the mouse at all, using the arrow keys, the new shortcuts to metadata fields also introduced in this PR and Enter. Don't leave the mouse over the lighttable though, because it will reset the ActOn image each time.

Also thanks to ActOn one still has to be careful while moving the mouse over the lighttable, because if the hovered image is outside the current selection, its metadata will be shown and any edited changes will be committed first. If this wasn't the intention, then now undo (ctrl+z) does seem to work more reliably than it did before. 

Fields and buttons are deactivated when no selected images or changes.

Also fixes errors in log on very narrow panels where the textview got crushed by setting minimum width (labels will ellipsize).

@nilvus a few classes were added to style the labels to indicate "changed" (I've left it as italic+underlined for now in order to avoid discussions not relevant to this PR) and `"<leave unchanged>"`.