### PR TITLE
Fix various typos

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -869,7 +869,7 @@ improvements and enhancements:
 - Added an `aspect_ratio` field to `dt_lua_image_t` for image
   orientation retrieval support.
 
-- `dt_lua_image_t` now repects the "show time in milliseconds" setting
+- `dt_lua_image_t` now respects the "show time in milliseconds" setting
   in lighttable preferences and will return `exif_datetime_taken` with
   milliseconds when enabled.
 

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3614,7 +3614,7 @@
     <type>float</type>
     <default>10</default>
     <shortdescription>the interval within which same widget changes are merged for undo</shortdescription>
-    <longdescription>when continously manipulating the same widget (slider, curve) no new undo records are created during this time</longdescription>
+    <longdescription>when continuously manipulating the same widget (slider, curve) no new undo records are created during this time</longdescription>
   </dtconfig>
   <dtconfig>
     <name>darkroom/undo/review_secs</name>

--- a/src/control/conf.h
+++ b/src/control/conf.h
@@ -133,7 +133,7 @@ const char *dt_confgen_get_tooltip(const char *name);
 gboolean dt_conf_is_default(const char *name);
 gchar* dt_conf_expand_default_dir(const char *dir);
 
-/** read filename and call callback() for every key/valye pair. if callback() returns non
+/** read filename and call callback() for every key/value pair. if callback() returns non
     NULL, the value is returned by dt_conf_read_values. This may be used to look for a
     a specific value in filename */
 gchar *dt_conf_read_values(const char *filename,

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -3532,7 +3532,7 @@ void dt_dev_image_ext(const dt_imgid_t imgid,
 
   dt_dev_process_image_job(&dev);
 
-  // record resulting image and dimentions
+  // record resulting image and dimensions
 
   const uint32_t bufsize =
     sizeof(uint32_t) * dev.pipe->backbuf_width * dev.pipe->backbuf_height;

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -611,7 +611,7 @@ static inline void copy_pixel_nontemporal(
 
 // after writing data using copy_pixel_nontemporal, it is necessary to
 // ensure that the writes have completed before attempting reads from
-// a different core.  This function produces the required memmory
+// a different core.  This function produces the required memory
 // fence to ensure proper visibility
 static inline void dt_sfence()
 {

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -399,8 +399,8 @@ typedef struct dt_masks_form_gui_t
   uint64_t pipe_hash;
 } dt_masks_form_gui_t;
 
-/** special value to indicate an invalid or unitialized coordinate (replaces */
-/** former use of NAN and isnan() by the most negative float) **/
+/** special value to indicate an invalid or uninitialized coordinate */
+/** (replaces former use of NAN and isnan() by the most negative float) **/
 #define DT_INVALID_COORDINATE (-FLT_MAX)
 
 /** the shape-specific function tables */

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2852,7 +2852,7 @@ void dt_masks_line_stroke(cairo_t *cr,
 
   cairo_stroke_preserve(cr);
 
-  // second the forground draw, lighter (same size as darker if selected)
+  // second the foreground draw, lighter (same size as darker if selected)
   cairo_set_line_width
     (cr, (line_width / (selected && !border ? 1.0 : 2.0)));
 

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -577,7 +577,7 @@ void dt_dev_pixelpipe_cache_checkmem(struct dt_dev_pixelpipe_t *pipe)
   size_t freed = 0;
 
   int invalid = 0;
-  // We should always free cachelines maked as not valid
+  // We should always free cachelines marked as not valid
   for(int k = DT_PIPECACHE_MIN; k < cache->entries; k++)
   {
     if((cache->data[k] != NULL) && (cache->hash[k] == UNUSED_CACHEHASH))

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1156,7 +1156,7 @@ static gboolean _pixelpipe_process_on_CPU(
   // the data buffers must always have a 64 alignment
   if((((uintptr_t)input) & 63) || (((uintptr_t)*output) & 63))
     dt_print(DT_DEBUG_ALWAYS,
-             "[pixelpipe_process_on_CPU] buffer aligment problem: IN=%p OUT=%p\n",
+             "[pixelpipe_process_on_CPU] buffer alignment problem: IN=%p OUT=%p\n",
              input, *output);
 
   // Fetch RGB working profile
@@ -1873,7 +1873,7 @@ static gboolean _dev_pixelpipe_process_rec(
               }
               else
                 dt_print(DT_DEBUG_ALWAYS,
-                         "[bench module GPU] [%s] `%s' finished without sucess\n",
+                         "[bench module GPU] [%s] `%s' finished without success\n",
                          full ? "full" : "export", module->op);
               darktable.unmuted = old_muted;
             }

--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -784,7 +784,7 @@ static void _popup_date_tree_selection_change(GtkTreeView *self, GtkDarktableRan
     }
 
     GMatchInfo *match_info;
-    // we capture each date componenent
+    // we capture each date component
     GRegex *regex = g_regex_new(
         "^\\s*(\\d{4})?(?::(\\d{2}))?(?::(\\d{2}))?(?: (\\d{2}))?(?::(\\d{2}))?(?::(\\d{2}))?\\s*$", 0, 0, NULL);
     g_regex_match_full(regex, text, -1, 0, 0, &match_info, NULL);

--- a/src/imageio/imageio_heif.c
+++ b/src/imageio/imageio_heif.c
@@ -163,7 +163,7 @@ dt_imageio_retval_t dt_imageio_open_heif(dt_image_t *img,
   img->flags &= ~DT_IMAGE_RAW;
   img->flags &= ~DT_IMAGE_S_RAW;
 
-  // Get decoded pixel values bit depth (ths is used to scale values to [0..1] range)
+  // Get decoded pixel values bit depth (this is used to scale values to [0..1] range)
   const int decoded_values_bit_depth = heif_image_get_bits_per_pixel_range(heif_img, heif_channel_interleaved);
   // Get original pixel values bit depth by querying the luma channel depth (this may differ from decoded values bit depth)
   const int original_values_bit_depth = heif_image_handle_get_luma_bits_per_pixel(handle);

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1626,7 +1626,7 @@ static inline void filmic_desaturate_v4(const dt_aligned_pixel_t Ych_original,
                                         dt_aligned_pixel_t Ych_final,
                                         const float saturation)
 {
-  // Note : Ych is normalized trough the LMS conversion,
+  // Note : Ych is normalized through the LMS conversion,
   // meaning c is actually a saturation (saturation ~= chroma / brightness).
   // So copy-pasting c and h from a different Y is equivalent to
   // tonemapping with a norm, which is equivalent to doing exposure compensation :

--- a/src/iop/hlreconstruct/segmentation.c
+++ b/src/iop/hlreconstruct/segmentation.c
@@ -653,7 +653,7 @@ gboolean dt_segmentation_init_struct(dt_iop_segmentation_t *seg,
     return TRUE;
   }
 
-  // allocation is fine so we now define struct data and initialize first two ununsed lines for safety
+  // allocation is fine so we now define struct data and initialize first two unused lines for safety
   seg->nr = 2;
   seg->border = border;
   seg->slots = slots;

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2165,7 +2165,7 @@ static int _init_coeffs_md_v2(const dt_image_t *img,
   }
 
   // calculate the optimal scaling value to show the maximum
-  // visibile image box after distortion correction
+  // visible image box after distortion correction
   // It does so by walking from the normalized radius [0, 1] at the shorter image
   // border to 1.
   // TODO(sgotti) Theoretically, since the distortion function should always be

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -191,7 +191,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
    * f(scene_zero) = display_black_target
    * f(scene_grey) = MIDDLE_GREY
    * f(scene_inf)  = display_white_target
-   * Slope at scene_grey independet of skewness i.e. only changed by the contrast parameter.
+   * Slope at scene_grey independent of skewness i.e. only changed by the contrast parameter.
    */
 
   // Calculate a reference slope for no skew and a normalized display

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -437,7 +437,7 @@ int mouse_moved(dt_lib_module_t *self,
 {
   dt_lib_snapshots_t *d = (dt_lib_snapshots_t *)self->data;
 
-  // if panning, do not hanlde here, let darkroom do the job
+  // if panning, do not handle here, let darkroom do the job
   if(d->panning) return 0;
 
   if(d->selected >= 0)

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -2199,7 +2199,7 @@ static void _track_add_point(OsmGpsMapTrack *track, OsmGpsMapPoint *point, OsmGp
   }
   else
   {
-    /* the line must be splitted in order to seek the geodesic line */
+    /* the line must be split in order to seek the geodesic line */
     OsmGpsMapPoint *ith_point;
     double f, ith_lat, ith_lon;
     const int n_segments = ceil(d / DT_MINIMUM_DISTANCE_FOR_GEODESIC);

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1596,7 +1596,7 @@ void dt_view_paint_pixbuf(
     h = processed_height * ((float)w / (float)processed_width);
   }
 
-  // adjust dimention if needed
+  // adjust dimension if needed
   if(w > width)
   {
     const int32_t ow = w;

--- a/tools/diff_lua_api.lua
+++ b/tools/diff_lua_api.lua
@@ -1,7 +1,7 @@
 #!/usr/bin/env lua
 
 --[[
-Takes two mandatory and one optiona argument
+Takes two mandatory and one optional argument
 * a file containing a dump of the old API
 * a file containing a dump of the new API
 * optionally "true" or "nodes"


### PR DESCRIPTION
Found via `codespell -q 3 -S ./.git,*.patch,*.po,*.pot,*.svg,./src/external,./src/common,./data/pswp,./tools/lua_doc/old_api -L ba,bloc,blocs,bu,childrens,childs,detailled,dinamic,eacg,fpt,hist,initiales,ist,inout,liquify,nd,nin,mye,residental,ro,uint,ue,webp,wirth`