### PR TITLE
Fix to ensure build with libxml2 2.11 where xmlParseEntity is deprecated

### DIFF
--- a/src/develop/lightroom.c
+++ b/src/develop/lightroom.c
@@ -1091,7 +1091,7 @@ gboolean dt_lightroom_import(dt_imgid_t imgid, dt_develop_t *dev, gboolean iauto
 
   // Parse xml document
 
-  doc = xmlParseEntity(pathname);
+  doc = xmlReadFile(pathname, NULL, 0);
 
   if(doc == NULL)
   {


### PR DESCRIPTION
Starting with a version of libxml2 that contains [this commit](https://gitlab.gnome.org/GNOME/libxml2/-/commit/51035c539edf67de93ced3cf037bb1f2b298e526), we won't be able to compile dt because the deprecation warning will be treated as an error.