### PR TITLE
Access image change_timestamp from lua

### DIFF
--- a/src/lua/configuration.h
+++ b/src/lua/configuration.h
@@ -38,10 +38,11 @@
 // 3.8.0 was 8.0.0 (moved to lua 5.4 and added some events)
 // 4.2.0 was 9.0.0 (view toolbox functions and snapshot filename removed)
 // 4.4.0 was 9.1.0 (added mimic and dt_lua_image_t changes)
+// 4.6.0 was 9.2.0 (added change_timestamp to dt_image_t)
 /* incompatible API change */
 #define LUA_API_VERSION_MAJOR 9
 /* backward compatible API change */
-#define LUA_API_VERSION_MINOR 1
+#define LUA_API_VERSION_MINOR 2
 /* bugfixes that should not change anything to the API */
 #define LUA_API_VERSION_PATCH 0
 /* suffix for unstable version */

--- a/src/lua/image.c
+++ b/src/lua/image.c
@@ -345,6 +345,16 @@ static int exif_datetime_taken_member(lua_State *L)
   }
 }
 
+static int change_timestamp_member(lua_State *L)
+{
+  const dt_image_t *my_image = checkreadimage(L, 1);
+  char sdt[50] = {0};
+  dt_datetime_gtimespan_to_local(sdt, sizeof(sdt), my_image->change_timestamp, FALSE, TRUE);
+  lua_pushstring(L, sdt);
+  releasereadimage(L, my_image);
+  return 1;
+}
+
 static int local_copy_member(lua_State *L)
 {
   if(lua_gettop(L) != 3)
@@ -584,6 +594,8 @@ int dt_lua_init_image(lua_State *L)
   }
   lua_pushcfunction(L, exif_datetime_taken_member);
   dt_lua_type_register(L, dt_lua_image_t, "exif_datetime_taken");
+  lua_pushcfunction(L, change_timestamp_member);
+  dt_lua_type_register(L, dt_lua_image_t, "change_timestamp");
   // metadata
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
   {


### PR DESCRIPTION
Added a change_timestamp member to access the image change timestamp.

Bumped API version to 9.2.0.

Fixes #14782.

print_change_timestamp.lua script attached for testing.  

To test:

Install the script and start it.  Select an image with or without a change timestamp.  Click the print change timestamp button in the selected image(s) module.  Timestamp will print on the screen (or an empty timestamp if it's not set).
[print_change_timestamp.zip](https://github.com/darktable-org/darktable/files/11861699/print_change_timestamp.zip)
