### PR TITLE
filmicrgb: don't desat/resat in v7 gamut mapping

### DIFF
--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2036,7 +2036,7 @@ static inline void filmic_v5(const float *const restrict in, float *const restri
 
     gamut_mapping(Ych_final, Ych_original, pix_out, input_matrix_trans, output_matrix, output_matrix_trans,
                   export_input_matrix_trans, export_output_matrix, export_output_matrix_trans,
-                  display_black, display_white, data->saturation, use_output_profile);
+                  display_black, display_white, 0.0f, use_output_profile);
     copy_pixel_nontemporal(out + k, pix_out);
   }
   dt_omploop_sfence();	// ensure that nontemporal writes complete before we attempt to read output


### PR DESCRIPTION
Fixes #14791 (I hope - I don't have OpenCL and haven't had a chance to build a v4.2 executable).
The saturation difference was missed because the integration test for Filmic v7 (0138) uses the default "mix" value, which yields data->saturation == 0.  Would be worth adding another with the mix slider at one extreme or the other to catch such regressions in the future.

