### PR TITLE
Fix workflow default auto-presets.

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1704,12 +1704,20 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
            "       ('ioporder', 'metadata', 'modulegroups', 'export',"
            "        'tagging', 'collect', '%s')"
            // select all user's auto presets or the hard-coded presets (for the workflow)
-           // if non auto-presets for the same operation found.
+           // if non auto-presets for the same operation and matching
+           // camera/lens/focal/format/exposure found.
            "   AND (writeprotect = 0"
            "        OR (SELECT NOT EXISTS"
            "             (SELECT op"
            "              FROM presets"
-           "              WHERE autoapply = 1 AND operation = op AND writeprotect = 0)))"
+           "              WHERE autoapply = 1 AND operation = op AND writeprotect = 0"
+           "                    AND ((?2 LIKE model AND ?3 LIKE maker)"
+           "                         OR (?4 LIKE model AND ?5 LIKE maker))"
+           "                    AND ?6 LIKE lens AND ?7 BETWEEN iso_min AND iso_max"
+           "                    AND ?8 BETWEEN exposure_min AND exposure_max"
+           "                    AND ?9 BETWEEN aperture_min AND aperture_max"
+           "                    AND ?10 BETWEEN focal_length_min AND focal_length_max"
+           "                    AND (format = 0 OR (format&?11 != 0 AND ~format&?12 != 0)))))"
            " ORDER BY writeprotect DESC, LENGTH(model), LENGTH(maker), LENGTH(lens)",
            // auto module:
            //  ON  : we take as the preset label either the multi-name


### PR DESCRIPTION
When checking if a default auto-preset is to be used properly check that user's preset do apply to the current image. That is for the camera/lens/iso/exposure/aperture of the image.

Fixes #14799.