### PR TITLE
color picker: pass in pipe (not piece) via picker ready signal

### DIFF
--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -518,7 +518,7 @@ void dt_iop_gui_blending_reload_defaults(dt_iop_module_t *module);
 
 gboolean blend_color_picker_apply(dt_iop_module_t *module,
                                   GtkWidget *picker,
-                                  dt_dev_pixelpipe_iop_t *piece);
+                                  dt_dev_pixelpipe_t *pipe);
 
 #ifdef HAVE_OPENCL
 /** apply blend for opencl modules*/

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1695,7 +1695,7 @@ static gboolean _blendop_masks_polarity_callback(GtkToggleButton *togglebutton,
 
 gboolean blend_color_picker_apply(dt_iop_module_t *module,
                                   GtkWidget *picker,
-                                  dt_dev_pixelpipe_iop_t *piece)
+                                  dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_gui_blend_data_t *data = module->blend_data;
 
@@ -1742,7 +1742,7 @@ gboolean blend_color_picker_apply(dt_iop_module_t *module,
     const dt_iop_colorspace_type_t cst = _blendif_colorpicker_cst(data);
     const dt_iop_order_iccprofile_info_t *work_profile =
       (blend_csp == DEVELOP_BLEND_CS_RGB_SCENE)
-        ? dt_ioppr_get_pipe_current_profile_info(piece->module, piece->pipe)
+        ? dt_ioppr_get_pipe_current_profile_info(module, pipe)
         : dt_ioppr_get_iop_work_profile_info(module, module->dev->iop);
 
     gboolean reverse_hues = FALSE;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1298,7 +1298,7 @@ static gboolean _pixelpipe_process_on_CPU(
                       pipe->dsc.cst, PIXELPIPE_PICKER_OUTPUT);
 
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                  DT_SIGNAL_CONTROL_PICKERDATA_READY, module, piece);
+                                  DT_SIGNAL_CONTROL_PICKERDATA_READY, module, pipe);
   }
 
   if(dt_atomic_get_int(&pipe->shutdown))
@@ -1925,7 +1925,7 @@ static gboolean _dev_pixelpipe_process_rec(
                                PIXELPIPE_PICKER_OUTPUT);
 
           DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                        DT_SIGNAL_CONTROL_PICKERDATA_READY, module, piece);
+                                        DT_SIGNAL_CONTROL_PICKERDATA_READY, module, pipe);
         }
 
         if(dt_atomic_get_int(&pipe->shutdown))
@@ -2061,7 +2061,7 @@ static gboolean _dev_pixelpipe_process_rec(
                             PIXELPIPE_PICKER_OUTPUT);
 
           DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                        DT_SIGNAL_CONTROL_PICKERDATA_READY, module, piece);
+                                        DT_SIGNAL_CONTROL_PICKERDATA_READY, module, pipe);
         }
 
         if(dt_atomic_get_int(&pipe->shutdown))

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -271,7 +271,9 @@ dt_iop_colorspace_type_t dt_iop_color_picker_get_active_cst(dt_iop_module_t *mod
     return IOP_CS_NONE;
 }
 
-static void _iop_color_picker_pickerdata_ready_callback(gpointer instance, dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece,
+static void _iop_color_picker_pickerdata_ready_callback(gpointer instance,
+                                                        dt_iop_module_t *module,
+                                                        dt_dev_pixelpipe_t *pipe,
                                                         gpointer user_data)
 {
   // an iop colorpicker receives new data from the pixelpipe
@@ -282,15 +284,16 @@ static void _iop_color_picker_pickerdata_ready_callback(gpointer instance, dt_io
   // modules between colorin & colorout may need the work_profile
   // to work properly. This will force colorin to be run and it
   // will set the work_profile if needed.
-  piece->pipe->changed |= DT_DEV_PIPE_REMOVE;
-  piece->pipe->cache_obsolete = TRUE;
+  // FIXME: is this overdoing it? see #14812
+  pipe->changed |= DT_DEV_PIPE_REMOVE;
+  pipe->cache_obsolete = TRUE;
 
   // iops only need new picker data if the pointer has moved
   if(_record_point_area(picker))
   {
-    if(!module->blend_data || !blend_color_picker_apply(module, picker->colorpick, piece))
+    if(!module->blend_data || !blend_color_picker_apply(module, picker->colorpick, pipe))
       if(module->color_picker_apply)
-        module->color_picker_apply(module, picker->colorpick, piece);
+        module->color_picker_apply(module, picker->colorpick, pipe);
   }
 }
 

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -460,13 +460,14 @@ void cleanup_global(dt_iop_module_so_t *module)
   module->data = NULL;
 }
 
-void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
+                        dt_dev_pixelpipe_t *pipe)
 {
   if(darktable.gui->reset) return;
   dt_iop_basicadj_params_t *p = (dt_iop_basicadj_params_t *)self->params;
   dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)self->gui_data;
 
-  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_current_profile_info(self, piece->pipe);
+  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_current_profile_info(self, pipe);
   p->middle_grey = (work_profile) ? (dt_ioppr_get_rgb_matrix_luminance(self->picked_color,
                                                                        work_profile->matrix_in,
                                                                        work_profile->lut_in,

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -735,7 +735,8 @@ void init_presets(dt_iop_module_so_t *self)
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_NONE);
 }
 
-void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
+                        dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -4352,10 +4352,10 @@ void _auto_set_illuminant(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe)
 
 void color_picker_apply(dt_iop_module_t *self,
                         GtkWidget *picker,
-                        dt_dev_pixelpipe_iop_t *piece)
+                        dt_dev_pixelpipe_t *pipe)
 {
   if(darktable.gui->reset) return;
-  _auto_set_illuminant(self, piece->pipe);
+  _auto_set_illuminant(self, pipe);
 }
 
 

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1405,7 +1405,8 @@ static void apply_autoluma(dt_iop_module_t *self)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
+                        dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   if     (picker == g->hue_lift)

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1345,10 +1345,10 @@ void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelp
   piece->data = NULL;
 }
 
-void pipe_RGB_to_Ych(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const dt_aligned_pixel_t RGB,
+void pipe_RGB_to_Ych(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, const dt_aligned_pixel_t RGB,
                      dt_aligned_pixel_t Ych)
 {
-  const struct dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_current_profile_info(self, piece->pipe);
+  const struct dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_current_profile_info(self, pipe);
   if(work_profile == NULL) return; // no point
 
   dt_aligned_pixel_t XYZ_D50 = { 0.f };
@@ -1362,15 +1362,16 @@ void pipe_RGB_to_Ych(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const
 }
 
 
-void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
+                        dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_colorbalancergb_gui_data_t *g = (dt_iop_colorbalancergb_gui_data_t *)self->gui_data;
   dt_iop_colorbalancergb_params_t *p = (dt_iop_colorbalancergb_params_t *)self->params;
 
   dt_aligned_pixel_t Ych = { 0.f };
   dt_aligned_pixel_t max_Ych = { 0.f };
-  pipe_RGB_to_Ych(self, piece, (const float *)self->picked_color, Ych);
-  pipe_RGB_to_Ych(self, piece, (const float *)self->picked_color_max, max_Ych);
+  pipe_RGB_to_Ych(self, pipe, (const float *)self->picked_color, Ych);
+  pipe_RGB_to_Ych(self, pipe, (const float *)self->picked_color_max, max_Ych);
   const float picked_hue = get_hue_angle_from_Ych(Ych);
   const float hue = RAD_TO_DEG(picked_hue) + 180.f;   // take the opponent color
 

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -938,7 +938,7 @@ void cleanup_global(dt_iop_module_so_t *module)
 
 void color_picker_apply(dt_iop_module_t *self,
                         GtkWidget *picker,
-                        dt_dev_pixelpipe_iop_t *piece)
+                        dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_colorchecker_gui_data_t *g =
     (dt_iop_colorchecker_gui_data_t *)self->gui_data;

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -228,7 +228,8 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   }
 }
 
-void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
+                        dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_colorize_gui_data_t *g = (dt_iop_colorize_gui_data_t *)self->gui_data;
   dt_iop_colorize_params_t *p = (dt_iop_colorize_params_t *)self->params;

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2178,7 +2178,8 @@ static void _display_mask_callback(GtkToggleButton *togglebutton, dt_iop_module_
   dt_iop_refresh_center(module);
 }
 
-void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
+                        dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)self->gui_data;
   if(picker == g->colorpicker_set_values)

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -877,10 +877,10 @@ static void _auto_set_exposure(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe)
 
 void color_picker_apply(dt_iop_module_t *self,
                         GtkWidget *picker,
-                        dt_dev_pixelpipe_iop_t *piece)
+                        dt_dev_pixelpipe_t *pipe)
 {
   if(darktable.gui->reset) return;
-  _auto_set_exposure(self, piece->pipe);
+  _auto_set_exposure(self, pipe);
 }
 
 

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -745,7 +745,8 @@ static void apply_autotune(dt_iop_module_t *self)
   gtk_widget_queue_draw(self->widget);
 }
 
-void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
+                        dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
   if     (picker == g->grey_point_source)

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2756,7 +2756,8 @@ static void apply_autotune(dt_iop_module_t *self)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
+                        dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
 

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -450,10 +450,8 @@ static inline void _update_saturation_slider_end_color(GtkWidget *slider, float 
   dt_bauhaus_slider_set_stop(slider, 1.0, rgb[0], rgb[1], rgb[2]);
 }
 
-void color_picker_apply(
-	dt_iop_module_t *self,
-        GtkWidget *picker,
-        dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
+                        dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)self->gui_data;
   dt_iop_graduatednd_params_t *p = (dt_iop_graduatednd_params_t *)self->params;

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -163,7 +163,8 @@ static void gui_update_from_coeffs(dt_iop_module_t *self)
   gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(g->colorpicker), &color);
 }
 
-void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
+                        dt_dev_pixelpipe_t *pipe)
 {
   static dt_aligned_pixel_t old = { 0.0f, 0.0f, 0.0f, 0.0f };
 

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -117,7 +117,7 @@ OPTIONAL(void, gui_reset, struct dt_iop_module_t *self);
 /** construct widget. */
 OPTIONAL(void, gui_init, struct dt_iop_module_t *self);
 /** apply color picker results */
-OPTIONAL(void, color_picker_apply, struct dt_iop_module_t *self, struct _GtkWidget *picker, struct dt_dev_pixelpipe_iop_t *piece);
+OPTIONAL(void, color_picker_apply, struct dt_iop_module_t *self, struct _GtkWidget *picker, struct dt_dev_pixelpipe_t *pipe);
 /** called by standard widget callbacks after value changed */
 OPTIONAL(void, gui_changed, struct dt_iop_module_t *self, GtkWidget *widget, void *previous);
 /** destroy widget. */

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -250,7 +250,8 @@ static void compute_lut(dt_dev_pixelpipe_iop_t *piece)
   }
 }
 
-void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
+                        dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)self->gui_data;
   dt_iop_levels_params_t *p = (dt_iop_levels_params_t *)self->params;

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -411,7 +411,8 @@ static gboolean dt_iop_monochrome_draw(GtkWidget *widget, cairo_t *crf, gpointer
   return TRUE;
 }
 
-void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
+                        dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_monochrome_params_t *p = (dt_iop_monochrome_params_t *)self->params;
 

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -804,7 +804,8 @@ static void apply_auto_exposure(dt_iop_module_t *self)
 }
 
 
-void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
+                        dt_dev_pixelpipe_t *pipe)
 {
   if(darktable.gui->reset) return;
   dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -462,7 +462,8 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   }
 }
 
-void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
+                        dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
   if     (picker == g->grey_point)

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -237,7 +237,8 @@ void gui_update(struct dt_iop_module_t *self)
   dtgtk_gradient_slider_set_value(g->center, p->center);
 }
 
-void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
+                        dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_relight_gui_data_t *g = (dt_iop_relight_gui_data_t *)self->gui_data;
   float mean, min, max;

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1568,7 +1568,7 @@ static void rt_gslider_changed(GtkDarktableGradientSlider *gslider,
 
 void color_picker_apply(dt_iop_module_t *self,
                         GtkWidget *picker,
-                        dt_dev_pixelpipe_iop_t *piece)
+                        dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -487,7 +487,8 @@ static inline int _add_node_from_picker(dt_iop_rgbcurve_params_t *p, const float
   return _add_node(p->curve_nodes[ch], &p->curve_num_nodes[ch], x, y);
 }
 
-void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
+                        dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
   if(picker == g->colorpicker_set_values)
@@ -496,7 +497,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
     const dt_iop_rgbcurve_params_t *const d = (dt_iop_rgbcurve_params_t *)self->default_params;
 
     const int ch = g->channel;
-    const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
+    const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(pipe);
 
     // reset current curve
     p->curve_num_nodes[ch] = d->curve_num_nodes[ch];

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -754,7 +754,8 @@ static void _color_picker_callback(GtkWidget *button, dt_iop_module_t *self)
   _turn_select_region_off(self);
 }
 
-void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
+                        dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
   dt_iop_rgblevels_params_t *p = (dt_iop_rgblevels_params_t *)self->params;

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -367,7 +367,8 @@ static void colorpick_callback(GtkColorButton *widget, dt_iop_module_t *self)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
+                        dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_splittoning_gui_data_t *g = (dt_iop_splittoning_gui_data_t *)self->gui_data;
   dt_iop_splittoning_params_t *p = (dt_iop_splittoning_params_t *)self->params;

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1887,9 +1887,8 @@ static void preset_tune_callback(GtkWidget *widget, dt_iop_module_t *self)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-void color_picker_apply(dt_iop_module_t *self,
-                        GtkWidget *picker,
-                        dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
+                        dt_dev_pixelpipe_t *pipe)
 {
   if(darktable.gui->reset) return;
 

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -961,7 +961,8 @@ static float to_lin(const float x, const float base, const int ch, const int sem
   }
 }
 
-void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
+                        dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_tonecurve_global_data_t *gd = (dt_iop_tonecurve_global_data_t *)self->global_data;
 

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -448,7 +448,8 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   // go in reload_defaults (if they depend on the image) or gui_init.
 }
 
-void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
+                        dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_useless_params_t *p = (dt_iop_useless_params_t *)self->params;
   dt_iop_useless_gui_data_t *g = (dt_iop_useless_gui_data_t *)self->gui_data;

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -973,7 +973,8 @@ static void watermark_callback(GtkWidget *tb, gpointer user_data)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
+                        dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_watermark_gui_data_t *g = (dt_iop_watermark_gui_data_t *)self->gui_data;
   dt_iop_watermark_params_t *p = (dt_iop_watermark_params_t *)self->params;


### PR DESCRIPTION
We previously received `piece`, and from that derived the current `pipe`. Instead just pass the current `pipe` via `DT_SIGNAL_CONTROL_PICKERDATA_READY`.

In one case we derived the current `module` from the passed-in `piece`, but as we are already sending `module` via the signal, just use that directly.

Besides it being repetitious to pass in `piece`, the danger is that in the interim between the signal being raised and processed, `piece` could no longer be a valid pointer due to the pixelpipe being recreated. As we currently trigger recreates every time data is received, via `DT_DEV_PIPE_REMOVE`, this is a very real risk.

This may fix #14812. But note that there's more work to be done, as we shouldn't need to recreate the entire pixelpipe and wipe the cache every time we receive color picker data. At the very least this slows down work when editing with the per-iop colorpicker active.

Also note that colorpicker always runs in preview pipe, hence it's repetitious (if future-looking) to even pass around the current `pipe` value.