### PR TITLE
RFC: Simple way to autosave xmp and database

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -271,9 +271,9 @@
   <dtconfig prefs="storage" section="XMP">
     <name>autosave_interval</name>
     <type>int</type>
-    <default>0</default>
+    <default>10</default>
     <shortdescription>try to save history while developing</shortdescription>
-    <longdescription>If zero (default) autosaving is disabled, otherwise it's time in seconds. Autosaving might be disabled on slow drives.</longdescription>
+    <longdescription>if zero (default) autosaving is disabled, otherwise it's time in seconds. autosaving might be disabled on slow drives.</longdescription>
   </dtconfig>
   <dtconfig prefs="misc" section="tags">
     <name>omit_tag_hierarchy</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -268,6 +268,13 @@
     <shortdescription>store XMP tags in compressed format</shortdescription>
     <longdescription>entries in XMP tags can get rather large and may exceed the available space to store the history stack in output files.\nthis option allows XMP tags to be compressed and save space.</longdescription>
   </dtconfig>
+  <dtconfig prefs="storage" section="XMP">
+    <name>autosave_interval</name>
+    <type>int</type>
+    <default>0</default>
+    <shortdescription>try to save history while developing</shortdescription>
+    <longdescription>If zero (default) autosaving is disabled, otherwise it's time in seconds. Autosaving might be disabled on slow drives.</longdescription>
+  </dtconfig>
   <dtconfig prefs="misc" section="tags">
     <name>omit_tag_hierarchy</name>
     <type>bool</type>

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1053,13 +1053,15 @@ static void _dev_add_history_item_ext(
     dt_image_write_sidecar_file(dev->image_storage.id);
     last = now;
 
-    // if the above writing to database and xmp took too long we disable automatic mode
     const double spent = dt_get_wtime() - now;
+    dt_print(DT_DEBUG_DEV, "autosave history took %fsec\n", spent);
+
+    // if writing to database and the xmp took too long we disable automatic mode for this session
     if(spent > 0.5)
+    {
       proper_timing = FALSE;
-    dt_print(DT_DEBUG_DEV, "autosave history took %fsec%s\n",
-      spent,
-      proper_timing ? "" : ", now disabled because of very slow drive/system");
+      dt_control_log(_("Autosaving history has been disabled for this session because of a slow drive used"));
+    }
   }
 }
 


### PR DESCRIPTION
We might like to have the xmp and database saved regularly while developing an image in darkroom to have at least an indermediate status available if a dt crash happened.

While thinking about this, for sure we wouldn't accept a "solution"
- that impairs UI performance noticably
- be in our way on network or very slow drives

This pr
1. Hooks into `_dev_add_history_item_ext()`
2. looks if the last autosaving was longer ago than an interval (preference set in seconds)
3. if so writes xmp and does a database entry update (edited)
4. if writing took more than 0.5 sec don't autosave again (for slow drives)
5. default would be OFF (0 seconds)

Tested this here for some days on fedora 38 using an NVMe ssd and a nfs drive.

What do you think? Any suggestions? Any don't do it this way?

See #7830