### PR TITLE
sigmoid: code cleanup

### DIFF
--- a/data/kernels/sigmoid.cl
+++ b/data/kernels/sigmoid.cl
@@ -136,7 +136,8 @@ static inline void _preserve_hue_and_energy(float *pix_io,
                                             const float hue_preservation)
 {
   // Naive Hue correction of the middle channel
-  const float midscale = (pix_io[order.mid] - pix_io[order.min]) / (pix_io[order.max] - pix_io[order.min]);
+  const float chroma = pix_io[order.max] - pix_io[order.min];
+  const float midscale = chroma != 0.f ? (pix_io[order.mid] - pix_io[order.min]) / chroma : 0.f;
   const float full_hue_correction =
     per_channel[order.min] + (per_channel[order.max] - per_channel[order.min]) * midscale;
   const float naive_hue_mid =
@@ -144,7 +145,8 @@ static inline void _preserve_hue_and_energy(float *pix_io,
 
   const float per_channel_energy = per_channel[0] + per_channel[1] + per_channel[2];
   const float naive_hue_energy = per_channel[order.min] + naive_hue_mid + per_channel[order.max];
-  const float blend_factor = 2.0f * pix_io[order.min] / (pix_io[order.min] + pix_io[order.mid]);
+  const float pix_in_min_plus_mid = pix_io[order.min] + pix_io[order.mid];
+  const float blend_factor = pix_in_min_plus_mid != 0.f ? 2.0f * pix_io[order.min] / pix_in_min_plus_mid : 0.f;
   const float energy_target = blend_factor * per_channel_energy + (1.0f - blend_factor) * naive_hue_energy;
 
   // Preserve hue constrained to maintain the same energy as the per channel result

--- a/data/kernels/sigmoid.cl
+++ b/data/kernels/sigmoid.cl
@@ -145,11 +145,11 @@ static inline void _preserve_hue_and_energy(float *pix_io,
   const float per_channel_energy = per_channel[order.min] + per_channel[order.mid] + per_channel[order.max];
   const float naive_hue_energy = per_channel[order.min] + naive_hue_mid + per_channel[order.max];
   const float blend_factor = 2.0f * pix_io[order.min] / (pix_io[order.min] + pix_io[order.mid]);
+  const float energy_target = blend_factor * per_channel_energy + (1.0f - blend_factor) * naive_hue_energy;
 
   // Preserve hue constrained to maintain the same energy as the per channel result
   if (naive_hue_mid <= per_channel[order.mid])
   {
-    const float energy_target = blend_factor * per_channel_energy + (1.0f - blend_factor) * naive_hue_energy;
     const float corrected_mid =
       ((1.0f - hue_preservation) * per_channel[order.mid] + hue_preservation *
       (midscale * per_channel[order.max] + (1.0f - midscale) * (energy_target - per_channel[order.max]))) /
@@ -160,7 +160,6 @@ static inline void _preserve_hue_and_energy(float *pix_io,
   }
   else
   {
-    const float energy_target = blend_factor * per_channel_energy + (1.0f - blend_factor) * naive_hue_energy;
     const float corrected_mid =
       ((1.0f - hue_preservation) * per_channel[order.mid] +
       hue_preservation * (per_channel[order.min] * (1.0f - midscale) +

--- a/data/kernels/sigmoid.cl
+++ b/data/kernels/sigmoid.cl
@@ -142,7 +142,7 @@ static inline void _preserve_hue_and_energy(float *pix_io,
   const float naive_hue_mid =
     (1.0f - hue_preservation) * per_channel[order.mid] + hue_preservation * full_hue_correction;
 
-  const float per_channel_energy = per_channel[order.min] + per_channel[order.mid] + per_channel[order.max];
+  const float per_channel_energy = per_channel[0] + per_channel[1] + per_channel[2];
   const float naive_hue_energy = per_channel[order.min] + naive_hue_mid + per_channel[order.max];
   const float blend_factor = 2.0f * pix_io[order.min] / (pix_io[order.min] + pix_io[order.mid]);
   const float energy_target = blend_factor * per_channel_energy + (1.0f - blend_factor) * naive_hue_energy;

--- a/data/kernels/sigmoid.cl
+++ b/data/kernels/sigmoid.cl
@@ -182,36 +182,6 @@ static inline void _preserve_hue_and_energy(float *pix_io,
 }
 
 kernel void
-sigmoid_loglogistic_per_channel (read_only image2d_t in,
-                                 write_only image2d_t out,
-                                 const int width,
-                                 const int height,
-                                 const float white_target,
-                                 const float paper_exp,
-                                 const float film_fog,
-                                 const float contrast_power,
-                                 const float skew_power)
-{
-  const unsigned int x = get_global_id(0);
-  const unsigned int y = get_global_id(1);
-
-  if(x >= width || y >= height) return;
-
-  float4 i = read_imagef(in, sampleri, (int2)(x, y));
-  float alpha = i.w;
-
-  // Force negative values to zero
-  i = _desaturate_negative_values(i);
-
-  i = _generalized_loglogistic_sigmoid_vector(i, white_target, paper_exp, film_fog, contrast_power, skew_power);
-
-  // Copy over the alpha channel
-  i.w = alpha;
-
-  write_imagef(out, (int2)(x, y), i);
-}
-
-kernel void
 sigmoid_loglogistic_per_channel_interpolated (read_only image2d_t in,
                                               write_only image2d_t out,
                                               const int width,

--- a/data/kernels/sigmoid.cl
+++ b/data/kernels/sigmoid.cl
@@ -173,16 +173,16 @@ static inline void _preserve_hue_and_energy(float *pix_io,
 }
 
 kernel void
-sigmoid_loglogistic_per_channel_interpolated (read_only image2d_t in,
-                                              write_only image2d_t out,
-                                              const int width,
-                                              const int height,
-                                              const float white_target,
-                                              const float paper_exp,
-                                              const float film_fog,
-                                              const float contrast_power,
-                                              const float skew_power,
-                                              const float hue_preservation)
+sigmoid_loglogistic_per_channel (read_only image2d_t in,
+                                 write_only image2d_t out,
+                                 const int width,
+                                 const int height,
+                                 const float white_target,
+                                 const float paper_exp,
+                                 const float film_fog,
+                                 const float contrast_power,
+                                 const float skew_power,
+                                 const float hue_preservation)
 {
   const unsigned int x = get_global_id(0);
   const unsigned int y = get_global_id(1);

--- a/data/kernels/sigmoid.cl
+++ b/data/kernels/sigmoid.cl
@@ -135,15 +135,6 @@ static inline void _preserve_hue_and_energy(float *pix_io,
                                             const dt_iop_sigmoid_value_order_t order,
                                             const float hue_preservation)
 {
-  if (per_channel[order.max] - per_channel[order.min] < 1e-9f ||
-    per_channel[order.mid] - per_channel[order.min] < 1e-9f )
-  {
-    pix_io[0] = per_channel[0];
-    pix_io[1] = per_channel[1];
-    pix_io[2] = per_channel[2];
-    return;  // Nothing to fix
-  }
-
   // Naive Hue correction of the middle channel
   const float full_hue_correction =
     per_channel[order.min] + ((per_channel[order.max] - per_channel[order.min]) *

--- a/data/kernels/sigmoid.cl
+++ b/data/kernels/sigmoid.cl
@@ -136,16 +136,15 @@ static inline void _preserve_hue_and_energy(float *pix_io,
                                             const float hue_preservation)
 {
   // Naive Hue correction of the middle channel
+  const float midscale = (pix_io[order.mid] - pix_io[order.min]) / (pix_io[order.max] - pix_io[order.min]);
   const float full_hue_correction =
-    per_channel[order.min] + ((per_channel[order.max] - per_channel[order.min]) *
-    (pix_io[order.mid] - pix_io[order.min]) / (pix_io[order.max] - pix_io[order.min]));
+    per_channel[order.min] + (per_channel[order.max] - per_channel[order.min]) * midscale;
   const float naive_hue_mid =
     (1.0f - hue_preservation) * per_channel[order.mid] + hue_preservation * full_hue_correction;
 
   const float per_channel_energy = per_channel[order.min] + per_channel[order.mid] + per_channel[order.max];
   const float naive_hue_energy = per_channel[order.min] + naive_hue_mid + per_channel[order.max];
   const float blend_factor = 2.0f * pix_io[order.min] / (pix_io[order.min] + pix_io[order.mid]);
-  const float midscale = (pix_io[order.mid] - pix_io[order.min]) / (pix_io[order.max] - pix_io[order.min]);
 
   // Preserve hue constrained to maintain the same energy as the per channel result
   if (naive_hue_mid <= per_channel[order.mid])

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -173,7 +173,7 @@ static inline float generalized_loglogistic_sigmoid(const float value, const flo
 {
   const float clamped_value = fmaxf(value, 0.0f);
   // The following equation can be derived as a model for film + paper but it has a pole at 0
-  // magnitude * powf(1.0 + paper_exp * powf(film_fog + value, -film_power), -paper_power);
+  // magnitude * powf(1.0f + paper_exp * powf(film_fog + value, -film_power), -paper_power);
   // Rewritten on a stable around zero form:
   const float film_response = powf(film_fog + clamped_value, film_power);
   const float paper_response = magnitude * powf(film_response / (paper_exp + film_response), paper_power);
@@ -196,7 +196,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   // Calculate a reference slope for no skew and a normalized display
   const float ref_film_power = params->middle_grey_contrast;
   const float ref_paper_power = 1.0f;
-  const float ref_magnitude = 1.0;
+  const float ref_magnitude = 1.0f;
   const float ref_film_fog = 0.0f;
   const float ref_paper_exposure = powf(ref_film_fog + MIDDLE_GREY, ref_film_power) * ((ref_magnitude / MIDDLE_GREY) - 1.0f);
   const float delta = 1e-6f;
@@ -397,27 +397,27 @@ static inline void preserve_hue_and_energy(const dt_aligned_pixel_t pix_in, cons
   const float chroma = pix_in[order.max] - pix_in[order.min];
   const float midscale = chroma != 0.f ? (pix_in[order.mid] - pix_in[order.min]) / chroma : 0.f;
   const float full_hue_correction = per_channel[order.min] + (per_channel[order.max] - per_channel[order.min]) * midscale;
-  const float naive_hue_mid = (1.0 - hue_preservation) * per_channel[order.mid] + hue_preservation * full_hue_correction;
+  const float naive_hue_mid = (1.0f - hue_preservation) * per_channel[order.mid] + hue_preservation * full_hue_correction;
 
   const float per_channel_energy = per_channel[0] + per_channel[1] + per_channel[2];
   const float naive_hue_energy = per_channel[order.min] + naive_hue_mid + per_channel[order.max];
   const float pix_in_min_plus_mid = pix_in[order.min] + pix_in[order.mid];
-  const float blend_factor = pix_in_min_plus_mid != 0.f ? 2.0 * pix_in[order.min] / pix_in_min_plus_mid : 0.f;
-  const float energy_target = blend_factor * per_channel_energy + (1.0 - blend_factor) * naive_hue_energy;
+  const float blend_factor = pix_in_min_plus_mid != 0.f ? 2.0f * pix_in[order.min] / pix_in_min_plus_mid : 0.f;
+  const float energy_target = blend_factor * per_channel_energy + (1.0f - blend_factor) * naive_hue_energy;
 
   // Preserve hue constrained to maintain the same energy as the per channel result
   if (naive_hue_mid <= per_channel[order.mid])
   {
-    const float corrected_mid = ((1.0 - hue_preservation) * per_channel[order.mid] + hue_preservation * (midscale * per_channel[order.max] + (1.0 - midscale) * (energy_target - per_channel[order.max])))
-                                / (1.0 + hue_preservation * (1.0 - midscale));
+    const float corrected_mid = ((1.0f - hue_preservation) * per_channel[order.mid] + hue_preservation * (midscale * per_channel[order.max] + (1.0f - midscale) * (energy_target - per_channel[order.max])))
+                                / (1.0f + hue_preservation * (1.0f - midscale));
     pix_out[order.min] = energy_target - per_channel[order.max] - corrected_mid;
     pix_out[order.mid] = corrected_mid;
     pix_out[order.max] = per_channel[order.max];
   }
   else
   {
-    const float corrected_mid = ((1.0 - hue_preservation) * per_channel[order.mid] + hue_preservation * (per_channel[order.min] * (1.0f - midscale) + midscale * (energy_target - per_channel[order.min])))
-                                / (1.0 + hue_preservation * midscale);
+    const float corrected_mid = ((1.0f - hue_preservation) * per_channel[order.mid] + hue_preservation * (per_channel[order.min] * (1.0f - midscale) + midscale * (energy_target - per_channel[order.min])))
+                                / (1.0f + hue_preservation * midscale);
     pix_out[order.min] = per_channel[order.min];
     pix_out[order.mid] = corrected_mid;
     pix_out[order.max] = energy_target - per_channel[order.min] - corrected_mid;

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -393,15 +393,6 @@ void process_loglogistic_rgb_ratio(dt_dev_pixelpipe_iop_t *piece, const void *co
 static inline void preserve_hue_and_energy(const dt_aligned_pixel_t pix_in, const dt_aligned_pixel_t per_channel, dt_aligned_pixel_t pix_out,
     const dt_iop_sigmoid_value_order_t order, const float hue_preservation)
 {
-  if (per_channel[order.max] - per_channel[order.min] < 1e-9 ||
-      per_channel[order.mid] - per_channel[order.min] < 1e-9 )
-  {
-    pix_out[order.min] = per_channel[order.min];
-    pix_out[order.mid] = per_channel[order.mid];
-    pix_out[order.max] = per_channel[order.max];
-    return;  // Nothing to fix
-  }
-
   // Naive Hue correction of the middle channel
   const float full_hue_correction = per_channel[order.min] + ((per_channel[order.max] - per_channel[order.min]) * (pix_in[order.mid] - pix_in[order.min]) / (pix_in[order.max] - pix_in[order.min]));
   const float naive_hue_mid = (1.0 - hue_preservation) * per_channel[order.mid] + hue_preservation * full_hue_correction;

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -398,7 +398,7 @@ static inline void preserve_hue_and_energy(const dt_aligned_pixel_t pix_in, cons
   const float full_hue_correction = per_channel[order.min] + (per_channel[order.max] - per_channel[order.min]) * midscale;
   const float naive_hue_mid = (1.0 - hue_preservation) * per_channel[order.mid] + hue_preservation * full_hue_correction;
 
-  const float per_channel_energy = per_channel[order.min] + per_channel[order.mid] + per_channel[order.max];
+  const float per_channel_energy = per_channel[0] + per_channel[1] + per_channel[2];
   const float naive_hue_energy = per_channel[order.min] + naive_hue_mid + per_channel[order.max];
   const float blend_factor = 2.0 * pix_in[order.min] / (pix_in[order.min] + pix_in[order.mid]);
   const float energy_target = blend_factor * per_channel_energy + (1.0 - blend_factor) * naive_hue_energy;

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -394,13 +394,13 @@ static inline void preserve_hue_and_energy(const dt_aligned_pixel_t pix_in, cons
     const dt_iop_sigmoid_value_order_t order, const float hue_preservation)
 {
   // Naive Hue correction of the middle channel
-  const float full_hue_correction = per_channel[order.min] + ((per_channel[order.max] - per_channel[order.min]) * (pix_in[order.mid] - pix_in[order.min]) / (pix_in[order.max] - pix_in[order.min]));
+  const float midscale = (pix_in[order.mid] - pix_in[order.min]) / (pix_in[order.max] - pix_in[order.min]);
+  const float full_hue_correction = per_channel[order.min] + (per_channel[order.max] - per_channel[order.min]) * midscale;
   const float naive_hue_mid = (1.0 - hue_preservation) * per_channel[order.mid] + hue_preservation * full_hue_correction;
 
   const float per_channel_energy = per_channel[order.min] + per_channel[order.mid] + per_channel[order.max];
   const float naive_hue_energy = per_channel[order.min] + naive_hue_mid + per_channel[order.max];
   const float blend_factor = 2.0 * pix_in[order.min] / (pix_in[order.min] + pix_in[order.mid]);
-  const float midscale = (pix_in[order.mid] - pix_in[order.min]) / (pix_in[order.max] - pix_in[order.min]);
 
   // Preserve hue constrained to maintain the same energy as the per channel result
   if (naive_hue_mid <= per_channel[order.mid])

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -394,13 +394,15 @@ static inline void preserve_hue_and_energy(const dt_aligned_pixel_t pix_in, cons
     const dt_iop_sigmoid_value_order_t order, const float hue_preservation)
 {
   // Naive Hue correction of the middle channel
-  const float midscale = (pix_in[order.mid] - pix_in[order.min]) / (pix_in[order.max] - pix_in[order.min]);
+  const float chroma = pix_in[order.max] - pix_in[order.min];
+  const float midscale = chroma != 0.f ? (pix_in[order.mid] - pix_in[order.min]) / chroma : 0.f;
   const float full_hue_correction = per_channel[order.min] + (per_channel[order.max] - per_channel[order.min]) * midscale;
   const float naive_hue_mid = (1.0 - hue_preservation) * per_channel[order.mid] + hue_preservation * full_hue_correction;
 
   const float per_channel_energy = per_channel[0] + per_channel[1] + per_channel[2];
   const float naive_hue_energy = per_channel[order.min] + naive_hue_mid + per_channel[order.max];
-  const float blend_factor = 2.0 * pix_in[order.min] / (pix_in[order.min] + pix_in[order.mid]);
+  const float pix_in_min_plus_mid = pix_in[order.min] + pix_in[order.mid];
+  const float blend_factor = pix_in_min_plus_mid != 0.f ? 2.0 * pix_in[order.min] / pix_in_min_plus_mid : 0.f;
   const float energy_target = blend_factor * per_channel_energy + (1.0 - blend_factor) * naive_hue_energy;
 
   // Preserve hue constrained to maintain the same energy as the per channel result

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -401,11 +401,11 @@ static inline void preserve_hue_and_energy(const dt_aligned_pixel_t pix_in, cons
   const float per_channel_energy = per_channel[order.min] + per_channel[order.mid] + per_channel[order.max];
   const float naive_hue_energy = per_channel[order.min] + naive_hue_mid + per_channel[order.max];
   const float blend_factor = 2.0 * pix_in[order.min] / (pix_in[order.min] + pix_in[order.mid]);
+  const float energy_target = blend_factor * per_channel_energy + (1.0 - blend_factor) * naive_hue_energy;
 
   // Preserve hue constrained to maintain the same energy as the per channel result
   if (naive_hue_mid <= per_channel[order.mid])
   {
-    const float energy_target = blend_factor * per_channel_energy + (1.0 - blend_factor) * naive_hue_energy;
     const float corrected_mid = ((1.0 - hue_preservation) * per_channel[order.mid] + hue_preservation * (midscale * per_channel[order.max] + (1.0 - midscale) * (energy_target - per_channel[order.max])))
                                 / (1.0 + hue_preservation * (1.0 - midscale));
     pix_out[order.min] = energy_target - per_channel[order.max] - corrected_mid;
@@ -414,7 +414,6 @@ static inline void preserve_hue_and_energy(const dt_aligned_pixel_t pix_in, cons
   }
   else
   {
-    const float energy_target = blend_factor * per_channel_energy + (1.0 - blend_factor) * naive_hue_energy;
     const float corrected_mid = ((1.0 - hue_preservation) * per_channel[order.mid] + hue_preservation * (per_channel[order.min] * (1.0f - midscale) + midscale * (energy_target - per_channel[order.min])))
                                 / (1.0 + hue_preservation * midscale);
     pix_out[order.min] = per_channel[order.min];

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -78,7 +78,7 @@ typedef struct dt_iop_sigmoid_gui_data_t
 
 typedef struct dt_iop_sigmoid_global_data_t
 {
-  int kernel_sigmoid_loglogistic_per_channel_interpolated;
+  int kernel_sigmoid_loglogistic_per_channel;
   int kernel_sigmoid_loglogistic_rgb_ratio;
 } dt_iop_sigmoid_global_data_t;
 
@@ -424,8 +424,8 @@ static inline void preserve_hue_and_energy(const dt_aligned_pixel_t pix_in, cons
   }
 }
 
-void process_loglogistic_per_channel_interpolated(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
-                             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+void process_loglogistic_per_channel(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+                                     const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_sigmoid_data_t *module_data = (dt_iop_sigmoid_data_t *)piece->data;
 
@@ -482,7 +482,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
   if (module_data->color_processing == DT_SIGMOID_METHOD_PER_CHANNEL)
   {
-    process_loglogistic_per_channel_interpolated(piece, ivoid, ovoid, roi_in, roi_out);
+    process_loglogistic_per_channel(piece, ivoid, ovoid, roi_in, roi_out);
   }
   else // DT_SIGMOID_METHOD_RGB_RATIO
   {
@@ -515,7 +515,7 @@ int process_cl(struct dt_iop_module_t *self,
   if (d->color_processing == DT_SIGMOID_METHOD_PER_CHANNEL)
   {
     const float hue_preservation = d->hue_preservation;
-    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_sigmoid_loglogistic_per_channel_interpolated,
+    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_sigmoid_loglogistic_per_channel,
                                            width, height,
                                            CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height),
                                            CLARG(white_target), CLARG(paper_exp),
@@ -551,15 +551,15 @@ void init_global(dt_iop_module_so_t *module)
     (dt_iop_sigmoid_global_data_t *)malloc(sizeof(dt_iop_sigmoid_global_data_t));
 
   module->data = gd;
-  gd->kernel_sigmoid_loglogistic_per_channel_interpolated =
-    dt_opencl_create_kernel(program, "sigmoid_loglogistic_per_channel_interpolated");
+  gd->kernel_sigmoid_loglogistic_per_channel =
+    dt_opencl_create_kernel(program, "sigmoid_loglogistic_per_channel");
   gd->kernel_sigmoid_loglogistic_rgb_ratio = dt_opencl_create_kernel(program, "sigmoid_loglogistic_rgb_ratio");
 }
 
 void cleanup_global(dt_iop_module_so_t *module)
 {
   dt_iop_sigmoid_global_data_t *gd = (dt_iop_sigmoid_global_data_t *)module->data;
-  dt_opencl_free_kernel(gd->kernel_sigmoid_loglogistic_per_channel_interpolated);
+  dt_opencl_free_kernel(gd->kernel_sigmoid_loglogistic_per_channel);
   dt_opencl_free_kernel(gd->kernel_sigmoid_loglogistic_rgb_ratio);
   free(module->data);
   module->data = NULL;


### PR DESCRIPTION
Cleanup around the hue preservation code in sigmoid.

* Remove the separate path for case when the hue preservation parameter is near zero
* Reuse some calculation results in the hue preservation code
* Refine handling of special cases / avoiding of NaNs in the hue preservation code. Now there are explicit checks in divisions where the denominator might be zero
* Replace some double-precision number literals with single-precision ones

The main aim was to remove the separate processing path / OpenCL kernel for the hue_preservation = 0 case. I've been discussing the possibility of adding custom tone mapping primaries to the module with @jandren, and this cleanup paves the way for that.

Integration test is clean.
```
Test 0097-sigmoid
      Image mire1.cr2
      CPU & GPU version differ by 22836 pixels
      CPU vs. GPU report :
      ----------------------------------
      Max dE                   : 1.52457
      Avg dE                   : 0.00372
      Std dE                   : 0.04458
      ----------------------------------
      Pixels below avg + 0 std : 99.18 %
      Pixels below avg + 1 std : 99.18 %
      Pixels below avg + 3 std : 99.21 %
      Pixels below avg + 6 std : 99.35 %
      Pixels below avg + 9 std : 99.46 %
      ----------------------------------
      Pixels above tolerance   : 0.00 %
 
      Expected CPU vs. current CPU report :
      ----------------------------------
      Max dE                   : 1.31436
      Avg dE                   : 0.00012
      Std dE                   : 0.00811
      ----------------------------------
      Pixels below avg + 0 std : 99.97 %
      Pixels below avg + 1 std : 99.97 %
      Pixels below avg + 3 std : 99.97 %
      Pixels below avg + 6 std : 99.97 %
      Pixels below avg + 9 std : 99.97 %
      ----------------------------------
      Pixels above tolerance   : 0.00 %
 
  OK
```

This would probably deserve a review from @jandren.