### PR TITLE
print: fix snap to grid for cm/inch units

### DIFF
--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1503,7 +1503,7 @@ static void _snap_to_grid(dt_lib_print_settings_t *ps,
   {
     // V lines
     const float step =
-      gtk_spin_button_get_value(GTK_SPIN_BUTTON(ps->grid_size)) * units[ps->unit];
+      gtk_spin_button_get_value(GTK_SPIN_BUTTON(ps->grid_size)) / units[ps->unit];
 
     // only display the grid if a step of 5 pixels
     const float diff = DT_PIXEL_APPLY_DPI(5);


### PR DESCRIPTION
Previously it only worked for mm. Fixes #14855.

As noted, the grid also doesn't display when "display grid" measurement is sufficiently small. This is on purpose in the code (it is coded to require > 5 pixels between grid lines). It might be nice to have some sort of feedback for when the grid disappears, though (e.g. display dots at grid points).