### PR TITLE
highlights: Makes DT_IOP_HIGHLIGHTS_OPPOSED the default method.

### DIFF
--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -107,7 +107,7 @@ typedef enum dt_highlights_mask_t
 typedef struct dt_iop_highlights_params_t
 {
   // params of v1
-  dt_iop_highlights_mode_t mode; // $DEFAULT: DT_IOP_HIGHLIGHTS_CLIP $DESCRIPTION: "method"
+  dt_iop_highlights_mode_t mode; // $DEFAULT: DT_IOP_HIGHLIGHTS_OPPOSED $DESCRIPTION: "method"
   float blendL; // unused $DEFAULT: 1.0
   float blendC; // unused $DEFAULT: 0.0
   float strength; // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "strength"


### PR DESCRIPTION
This part in the introspection circuitry was missing.

Fixes #14050.