### PR TITLE
RFC: Safer handling of shared opencl memory

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -792,6 +792,7 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
   (cl->dlocl->symbols->dt_clGetDeviceInfo)
     (devid, CL_DEVICE_GLOBAL_MEM_SIZE, sizeof(cl_ulong),
      &(cl->dev[dev].max_global_mem), NULL);
+
   if(cl->dev[dev].max_global_mem < (uint64_t)512ul * 1024ul * 1024ul)
   {
     dt_print_nts(DT_DEBUG_OPENCL,
@@ -821,6 +822,15 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
   dt_print_nts(DT_DEBUG_OPENCL,
                "   GLOBAL MEM SIZE:          %.0f MB\n",
                (double)cl->dev[dev].max_global_mem / 1024.0 / 1024.0);
+  // let us use up to a quarter of global memory for shared mem devices and report it
+  if(shared_clmem)
+  {
+    cl->dev[dev].max_global_mem = MIN(cl->dev[dev].max_global_mem, darktable.dtresources.total_memory / 4);
+    dt_print_nts(DT_DEBUG_OPENCL,
+               "   GLOBAL MEM SIZE (shared): %.0f MB\n",
+               (double)cl->dev[dev].max_global_mem / 1024.0 / 1024.0);
+  }
+
   dt_print_nts(DT_DEBUG_OPENCL,
                "   MAX MEM ALLOC:            %.0f MB\n",
                (double)cl->dev[dev].max_mem_alloc / 1024.0 / 1024.0);

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -200,6 +200,11 @@ typedef struct dt_opencl_device_t
   // also used for blacklisted drivers
   gboolean disabled;
 
+  // keep track of devices using shared system memory. If so
+  // 1. available device memory is restricted and
+  // 2. available system memory knows about "taking away"
+  gboolean shared_clmem;
+
   // Some devices are known to be unused by other apps so there is no need to test for available memory at all.
   int forced_headroom;
 


### PR DESCRIPTION
We have OpenCL devices using no dedicated memory but share it with the ram available for all applications.
As dt might want a lot of system memory for cpu processing and caches it is safer to control the amount of memory that might be used for the CL device to avoid swapping as that is worse than tiling or fallbacks to cpu. 
Also avoids some oom kiils in some situations.

This PR includes 2 commits:
1. Tests for such a situation and reports via log, this would be nice to have even without commit 2 for issue reporting
2. suggests to restrict the CL memory to 1/4 of system memory for such devices



