### PR TITLE
[imageio] Avoid overflow when counting the number of pixels in the QOI loader

### DIFF
--- a/src/imageio/imageio_qoi.c
+++ b/src/imageio/imageio_qoi.c
@@ -31,7 +31,9 @@
 #include "develop/imageop.h"
 #include "imageio/imageio_common.h"
 
-dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *mbuf)
+dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
+                                        const char *filename,
+                                        dt_mipmap_buffer_t *mbuf)
 {
   FILE *f = g_fopen(filename, "rb");
   if(!f)
@@ -46,14 +48,16 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img, const char *filename, d
 
   void *read_buffer = g_malloc(filesize);
 
-  // Let's check whether the entire content of the file should be read into the buffer. If we see that it's a
-  // non-QOI file, we'll save time by avoiding unnecessary reading of a potentially large file into the buffer.
+  // Let's check whether the entire content of the file should be read into the buffer.
+  // If we see that it's a non-QOI file, we'll save time by avoiding unnecessary reading
+  // of a potentially large file into the buffer.
   if(fread(read_buffer, 1, 4, f) != 4)
   {
     fclose(f);
     g_free(read_buffer);
     dt_print(DT_DEBUG_ALWAYS, "[qoi_open] failed to read from %s\n", filename);
-    return DT_IMAGEIO_FILE_NOT_FOUND;  // if we can't read even first 4 bytes, it's more like file disappeared
+    // if we can't read even first 4 bytes, it's more like file disappeared
+    return DT_IMAGEIO_FILE_NOT_FOUND;
   }
   if(memcmp(read_buffer, "qoif", 4) != 0)
   {
@@ -64,7 +68,9 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img, const char *filename, d
   {
     fclose(f);
     g_free(read_buffer);
-    dt_print(DT_DEBUG_ALWAYS, "[qoi_open] failed to read %zu bytes from %s\n", filesize, filename);
+    dt_print(DT_DEBUG_ALWAYS,
+             "[qoi_open] failed to read %zu bytes from %s\n",
+             filesize, filename);
     return DT_IMAGEIO_LOAD_FAILED;
   }
   fclose(f);
@@ -95,7 +101,9 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img, const char *filename, d
   if(!mipbuf)
   {
     g_free(read_buffer);
-    dt_print(DT_DEBUG_ALWAYS, "[qoi_open] could not alloc full buffer for image: %s\n", img->filename);
+    dt_print(DT_DEBUG_ALWAYS,
+             "[qoi_open] could not alloc full buffer for image: %s\n",
+             img->filename);
     return DT_IMAGEIO_CACHE_FULL;
   }
 

--- a/src/imageio/imageio_qoi.c
+++ b/src/imageio/imageio_qoi.c
@@ -101,15 +101,16 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img, const char *filename, d
 
   uint8_t intval;
   float floatval;
+  const size_t npixels = (size_t)desc.width * desc.height;
 
 #ifdef _OPENMP
 #pragma omp parallel for private(intval, floatval)
 #endif
-  for(int i=0; i < desc.width * desc.height * 4; i++)
+  for(size_t index = 0; index < npixels * 4; index++)
   {
-    intval = *(int_RGBA_buf+i);
+    intval = *(int_RGBA_buf + index);
     floatval = intval / 255.f;
-    *(mipbuf+i) = floatval;
+    *(mipbuf + index) = floatval;
   }
 
   img->buf_dsc.cst = IOP_CS_RGB;


### PR DESCRIPTION
This is a rather theoretical issue with current computer hardware, since we are unlikely to be able to load (not to mention process) on computers with the currently common amount of memory an image of such a size that it would cause an overflow in the current code. But, none the less. Someday the hardware will allow this...