### PR TITLE
Fix last pixels in colorin cpu code

### DIFF
--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -922,7 +922,7 @@ static void process_cmatrix_fastpath(struct dt_iop_module_t *self,
 {
   const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
   assert(piece->colors == 4);
-  const int clipping = (d->nrgb != NULL);
+  const gboolean clipping = (d->nrgb != NULL);
 
   const size_t npixels = (size_t)roi_out->width * roi_out->height;
   const float *const restrict in = (float*)ivoid;
@@ -932,7 +932,7 @@ static void process_cmatrix_fastpath(struct dt_iop_module_t *self,
   // figure out the number of pixels each thread needs to process
   // round up to a multiple of 4 pixels so that each chunk starts aligned(64)
   const size_t nthreads = dt_get_num_threads();
-  const size_t chunksize = 4 * (((npixels / nthreads) + 3) / 4);
+  const size_t chunksize = 4 * (((npixels / nthreads) + 4) / 4);
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(in, out, npixels, chunksize, nthreads, d, clipping)  \
   schedule(static)
@@ -1092,7 +1092,7 @@ static void process_cmatrix_proper(struct dt_iop_module_t *self,
 {
   const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
   assert(piece->colors == 4);
-  const int clipping = (d->nrgb != NULL);
+  const gboolean clipping = (d->nrgb != NULL);
 
   const size_t npixels = (size_t)roi_out->width * roi_out->height;
   const float *const restrict in = (float*)ivoid;
@@ -1102,7 +1102,7 @@ static void process_cmatrix_proper(struct dt_iop_module_t *self,
   // figure out the number of pixels each thread needs to process
   // round up to a multiple of 4 pixels so that each chunk starts aligned(64)
   const size_t nthreads = dt_get_num_threads();
-  const size_t chunksize = 4 * (((npixels / nthreads) + 3) / 4);
+  const size_t chunksize = 4 * (((npixels / nthreads) + 4) / 4);
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(in, out, npixels, chunksize, nthreads, clipping, d) \
   schedule(static)


### PR DESCRIPTION
For some combinations of roi_out width&height and darkroom canvas the calculation of chunksize is too small leading to some pixels at the lower-right border to be left out from calculation.

To trigger the issue take any image (bright to see better) scale preview to 800 or 1600% and while playing with the darkroom canvas size watch out for black or wrong-colored pixels at the lower-right border as here
![Bildschirmfoto vom 2023-07-13 22-31-57](https://github.com/darktable-org/darktable/assets/50982232/87c930fb-f766-4f05-8cd3-1862c4a3d648)

This pr chose one way to fix, possibly increase chunksize by 4 in such case. The alternative would have been to check for real-work for the thread with highest id which would be slower.

@ralfbrown another one for you to look at ...