### PR TITLE
fix chunksize computation

### DIFF
--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -770,7 +770,7 @@ void process(struct dt_iop_module_t *self,
   // figure out the number of pixels each thread needs to process
   // round up to a multiple of 4 pixels so that each chunk starts aligned(64)
   const size_t nthreads = dt_get_num_threads();
-  const size_t chunksize = 4 * (((npixels / nthreads) + 3) / 4);
+  const size_t chunksize = 4 * ((((npixels + nthreads -1) / nthreads) + 3) / 4);
 #pragma omp parallel for simd default(none)                             \
   dt_omp_firstprivate(in, out, mode, npixels, nthreads, chunksize, \
                       grey, saturation, saturation_out, lift, lift_sop, \

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -503,7 +503,7 @@ static void _transform_lcms(const dt_iop_colorout_data_t *const d,
   // figure out the number of pixels each thread needs to process
   // round up to a multiple of 4 pixels so that each chunk starts aligned(64)
   const size_t nthreads = dt_get_num_threads();
-  const size_t chunksize = 4 * (((npixels / nthreads) + 3) / 4);
+  const size_t chunksize = 4 * ((((npixels + nthreads - 1) / nthreads) + 3) / 4);
 #pragma omp parallel for default(none)                                  \
     dt_omp_firstprivate(in, out, npixels, chunksize, nthreads, d, gamutcheck) \
     schedule(static)


### PR DESCRIPTION
Fix the omission of rounding-up for colorout and legacy colorbalance corresponding to that found in #14886, which fixes a failure to process the last few pixels in the last row of the image under certain circumstances.