### PR TITLE
[maintenance] AppImage build sctipt tweaks

### DIFF
--- a/tools/appimage-build-script.sh
+++ b/tools/appimage-build-script.sh
@@ -42,4 +42,7 @@ export DISABLE_COPYRIGHT_FILES_DEPLOYMENT=1
 # Instruct LDAI (LinuxDeploy AppImage plugin) to embed AppImage update information
 export LDAI_UPDATE_INFORMATION="gh-releases-zsync|darktable-org|darktable|nightly|Darktable-*-x86_64.AppImage.zsync"
 
+# Skip checking AppStream metadata for issues (temporarily, as the site is currently down and the verification will fail)
+export LDAI_NO_APPSTREAM=1
+
 ./linuxdeploy-x86_64.AppImage --appdir ../AppDir --plugin gtk --output appimage

--- a/tools/appimage-build-script.sh
+++ b/tools/appimage-build-script.sh
@@ -39,6 +39,7 @@ export DEPLOY_GTK_VERSION=3
 export VERSION=$(sh ../tools/get_git_version_string.sh)
 export DISABLE_COPYRIGHT_FILES_DEPLOYMENT=1
 
-export UPDATE_INFORMATION="gh-releases-zsync|darktable-org|darktable|nightly|Darktable-*-x86_64.AppImage.zsync"
+# Instruct LDAI (LinuxDeploy AppImage plugin) to embed AppImage update information
+export LDAI_UPDATE_INFORMATION="gh-releases-zsync|darktable-org|darktable|nightly|Darktable-*-x86_64.AppImage.zsync"
 
 ./linuxdeploy-x86_64.AppImage --appdir ../AppDir --plugin gtk --output appimage


### PR DESCRIPTION
@TurboGit Please accept this PR today if possible as it contains a fix that addresses the cause of the nightly build failing (darktable.org is currently down and AppStream metadata verification will fail making the entire AppImage creation process fail).
