### PR TITLE
remove delaying of module name update based on preset

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1130,8 +1130,6 @@ static void _dev_add_history_item(dt_develop_t *dev,
     &&!dt_iop_is_hidden(module)
     && module->enabled
     && !module->multi_name_hand_edited
-    && module->instance_name
-    && gtk_widget_get_visible(module->instance_name)
     && dt_conf_get_bool("darkroom/ui/auto_module_name_update"))
   {
     const gboolean is_default_params =

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -317,9 +317,6 @@ typedef struct dt_iop_module_t
   gboolean multi_name_hand_edited;
   GtkWidget *multimenu_button;
 
-  /** delayed-event handling */
-  guint label_recompute_handle;
-
   void (*process_plain)(struct dt_iop_module_t *self,
                         struct dt_dev_pixelpipe_iop_t *piece,
                         const void *const i,

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -911,14 +911,6 @@ static gboolean _dev_load_requested_image(gpointer user_data);
 
 static void _dev_change_image(dt_develop_t *dev, const dt_imgid_t imgid)
 {
-  // deactivate module label timer if set
-  if(darktable.develop->gui_module
-     && darktable.develop->gui_module->label_recompute_handle)
-  {
-    g_source_remove(darktable.develop->gui_module->label_recompute_handle);
-    darktable.develop->gui_module->label_recompute_handle = 0;
-  }
-
   // Pipe reset needed when changing image
   // FIXME: synch with dev_init() and dev_cleanup() instead of redoing it
   dev->proxy.chroma_adaptation = NULL;


### PR DESCRIPTION
@TurboGit
Currently, checking whether module params match a preset and setting the instance name based on it (if not hand edited) is done in a delayed callback triggered from commit_params. Besides the delay in the visual update, this also can trigger double undo records. And sometimes recreates those after the user presses undo:

- if I start from a blank history stack, with exposure matching "scene-referred default" and 
- then change the exposure once by clicking somewhere (the multi label is now set to ""), 
- pressing undo once restores the label, 
- but doesn't change back the value, 
- and after a moment the label is cleared again. 
- I can press undo indefinitely (as long as I leave a pause in between).

commit_params is also called repeatedly for modules that were not changed at all when setting up the pipe, so I'm sometimes seeing labels change for other modules than the one I'm editing. Presumably this also offsets the savings from only querying presets with a delay.

This PR attempts to simplify things. I'm not seeing a noticeable slowdown from it and no side-effects, but I haven't looked at what happens when styles are applied or possibly other situations where you might want the label recalculated or cleared because, to be honest, I'm not exactly sure what is _intended_ to happen in many of those cases (and therefore whether the current behavior is maybe sometimes inappropriate and should not be reproduced).
For example, I would expect when clicking on a previous entry in history that the module multi label (on the right side) reflects whether that history item matches a preset, but restoring of the multi-label does not happen.

It might also be possible to clean up cases where the multi-label might first be explicitly set and then recalculated anyway when creating a history record; I haven't looked for such cases.
