### PR TITLE
Visualize crop area in retouch 

### DIFF
--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -107,6 +107,15 @@ typedef enum dt_clipping_preview_mode_t
   DT_CLIPPING_PREVIEW_SATURATION = 3
 } dt_clipping_preview_mode_t;
 
+// We require a bitflag for each supported module
+typedef enum dt_cropexpose_mod_t
+{
+  DT_DEV_CROP_NONE = 0,
+  DT_DEV_CROP_RETOUCH = 1 << 0,
+  DT_DEV_CROP_ASHIFT = 1 << 1,
+  DT_DEV_CROP_LIQUIFY = 1 << 2
+} dt_cropexpose_mod_t;
+
 typedef struct dt_dev_proxy_exposure_t
 {
   struct dt_iop_module_t *module;
@@ -138,7 +147,9 @@ typedef struct dt_develop_t
   uint32_t average_delay;
   uint32_t preview_average_delay;
   uint32_t preview2_average_delay;
-  struct dt_iop_module_t *gui_module; // this module claims gui expose/event callbacks.
+  struct dt_iop_module_t *gui_module;  // this module claims gui expose/event callbacks.
+  struct dt_iop_module_t *crop_module; // set by dt_dev_pixelpipe_synch() if an enabled crop module is included in history
+  dt_cropexpose_mod_t crop_request;    // set by the modules requesting crop_module expose
   float preview_downsampling;         // < 1.0: optionally downsample preview
 
   // width, height: dimensions of window

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -472,6 +472,10 @@ void dt_dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe,
       const gboolean active = hist->enabled;
       piece->enabled = active;
 
+      // the last crop module in the pixelpipe might handle the exposing if enabled 
+      if(dt_iop_module_is(piece->module->so, "crop"))
+        dev->crop_module = active ? piece->module : NULL;
+
       // Styles, presets or history copy&paste might set history items
       // not appropriate for the image.  Fixing that seemed to be
       // almost impossible after long discussions but at least we can
@@ -537,6 +541,7 @@ void dt_dev_pixelpipe_synch_all(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
 {
   dt_pthread_mutex_lock(&pipe->busy_mutex);
 
+  dev->crop_module = NULL;
   dt_print(DT_DEBUG_PARAMS,
            "[pixelpipe] [%s] synch all modules with defaults_params\n",
            dt_dev_pixelpipe_type_to_str(pipe->type));

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -219,7 +219,7 @@ int default_group()
 
 int flags()
 {
-  return IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_NO_MASKS;
+  return IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_NO_MASKS | IOP_FLAGS_GUIDES_SPECIAL_DRAW;
 }
 
 dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
@@ -227,6 +227,12 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
                                             dt_dev_pixelpipe_iop_t *piece)
 {
   return IOP_CS_RGB;
+}
+
+int operation_tags_filter()
+{
+  // switch off clipping and decoration, we want to see the full image.
+  return IOP_TAG_CLIPPING;
 }
 
 int legacy_params(dt_iop_module_t *self,
@@ -2227,6 +2233,9 @@ void gui_focus(struct dt_iop_module_t *self,
        || g->suppress_mask)
       dt_iop_refresh_center(self);
   }
+
+  if(!darktable.develop->image_loading)
+    self->dev->crop_request = (self->dev->crop_request & ~DT_DEV_CROP_RETOUCH) | (in ? DT_DEV_CROP_RETOUCH : DT_DEV_CROP_NONE);
 }
 
 void tiling_callback(struct dt_iop_module_t *self,

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -665,7 +665,7 @@ void expose(
   if(image_surface_imgid == dev->image_storage.id)
   {
     cairo_destroy(cr);
-    cairo_set_source_surface(cri, image_surface, 0, 0);
+    cairo_set_source_surface(cri, image_surface, 0.0, 0.0);
     cairo_paint(cri);
   }
 
@@ -728,13 +728,27 @@ void expose(
   {
     if(dev->form_visible && display_masks)
       dt_masks_events_post_expose(dev->gui_module, cri, width, height, pointerx, pointery);
-    // module
-    if(dev->gui_module && dev->gui_module != dev->proxy.rotate
+
+    // gui active module
+    if(dev->gui_module
+       && dev->gui_module != dev->proxy.rotate
        && dev->gui_module->gui_post_expose
        && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS)
     {
       cairo_save(cri);
       dev->gui_module->gui_post_expose(dev->gui_module, cri,
+                                       width, height, pointerx, pointery);
+      cairo_restore(cri);
+    }
+
+    // the post expose of crop needs special care
+    if(dev->crop_module
+       && dev->gui_module != dev->proxy.rotate
+       && dev->crop_request != 0
+       && dev->crop_module->gui_post_expose)
+    {
+      cairo_save(cri);
+      dev->crop_module->gui_post_expose(dev->crop_module, cri,
                                        width, height, pointerx, pointery);
       cairo_restore(cri);
     }


### PR DESCRIPTION
We want to expand to full image and also visualize the 'crop' area in `retouch` module while developing.

This pr implements an additional post_expose step specific for the crop module handled at pixelpipe runtime serving requests by other modules - implemented for retouch so far.

As i am not sure how visibility for that expose is handled _best_ i chose a lesser strength-of-effect for _outside_ region than in crop module expanded but still visible.

Would love feedback on
1. usability
2. implementation (for me this less hacky than i guessed it might be) but i suspect there might be a better way