### PR TITLE
Retouch module should not have the internal guide widget

### DIFF
--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -219,7 +219,7 @@ int default_group()
 
 int flags()
 {
-  return IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_NO_MASKS | IOP_FLAGS_GUIDES_WIDGET;
+  return IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_NO_MASKS;
 }
 
 dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,


### PR DESCRIPTION
As the user will almost never be interested in guides while working in retouch module we should not offer that widget internally
- less distraction from what this module does
- less vertical space