### PR TITLE
Do not install man pages in Windows

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -5,4 +5,6 @@ set(DOC_FILES README.md ../AUTHORS TRANSLATORS.md ../LICENSE)
 install(FILES ${DOC_FILES} DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT DTDocuments)
 
 # Build manual page
-add_subdirectory(man)
+if (WIN32 AND NOT BUILD_MSYS2_INSTALL)
+  add_subdirectory(man)
+endif()


### PR DESCRIPTION
Windows does not have a man pages reader, so there is no point in installing them.