### PR TITLE
lut3d: fix crash on unsupported LUTs

### DIFF
--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -755,8 +755,8 @@ uint16_t calculate_clut_cube(const char *const filepath, float **clut)
       {
         if(strtod(token[1], NULL) != 0.0f)
         {
-          dt_print(DT_DEBUG_ALWAYS, "[lut3d] DOMAIN MIN != 0.0 is not supported\n");
-          dt_control_log(_("DOMAIN MIN != 0.0 is not supported"));
+          dt_print(DT_DEBUG_ALWAYS, "[lut3d] DOMAIN MIN other than 0 is not supported\n");
+          dt_control_log(_("DOMAIN MIN other than 0 is not supported"));
           if(lclut) dt_free_align(lclut);
           free(line);
           fclose(cube_file);
@@ -767,8 +767,8 @@ uint16_t calculate_clut_cube(const char *const filepath, float **clut)
       {
         if(strtod(token[1], NULL) != 1.0f)
         {
-          dt_print(DT_DEBUG_ALWAYS, "[lut3d] DOMAIN MAX != 1.0 is not supported\n");
-          dt_control_log(_("DOMAIN MAX != 1.0 is not supported"));
+          dt_print(DT_DEBUG_ALWAYS, "[lut3d] DOMAIN MAX other than 1 is not supported\n");
+          dt_control_log(_("DOMAIN MAX other than 1 is not supported"));
           if(lclut) dt_free_align(lclut);
           free(line);
           fclose(cube_file);

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -755,22 +755,24 @@ uint16_t calculate_clut_cube(const char *const filepath, float **clut)
       {
         if(strtod(token[1], NULL) != 0.0f)
         {
-          dt_print(DT_DEBUG_ALWAYS, "[lut3d] DOMAIN MIN <> 0.0 is not supported\n");
-          dt_control_log(_("DOMAIN MIN <> 0.0 is not supported"));
+          dt_print(DT_DEBUG_ALWAYS, "[lut3d] DOMAIN MIN != 0.0 is not supported\n");
+          dt_control_log(_("DOMAIN MIN != 0.0 is not supported"));
           if(lclut) dt_free_align(lclut);
           free(line);
           fclose(cube_file);
+          return 0;
         }
       }
       else if(strcmp("DOMAIN_MAX", token[0]) == 0)
       {
         if(strtod(token[1], NULL) != 1.0f)
         {
-          dt_print(DT_DEBUG_ALWAYS, "[lut3d] DOMAIN MAX <> 1.0 is not supported\n");
-          dt_control_log(_("DOMAIN MAX <> 1.0 is not supported"));
+          dt_print(DT_DEBUG_ALWAYS, "[lut3d] DOMAIN MAX != 1.0 is not supported\n");
+          dt_control_log(_("DOMAIN MAX != 1.0 is not supported"));
           if(lclut) dt_free_align(lclut);
           free(line);
           fclose(cube_file);
+          return 0;
         }
       }
       else if(strcmp("LUT_1D_SIZE", token[0]) == 0)


### PR DESCRIPTION
Due to a missing "return 0", the lut3d module would crash dt with a double-free error if the LUT had a DOMAIN_MIN other than 0.0 or DOMAIN_MAX other than 1.0.

This commit also modifies the associated error messages to eliminate a Gtk error caused by it attempting to interpret the "<>" in the message as markup.