### PR TITLE
Add -d expose debugging option

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -131,7 +131,7 @@ static int usage(const char *argv0)
   printf("  --configdir <user config directory>\n");
   printf("  -d {act_on,cache,camctl,camsupport,control,dev,imageio,\n");
   printf("      input,ioporder,lighttable,lua,masks,memory,nan,opencl,params,\n");
-  printf("      perf,print,pwstorage,signal,sql,tiling,undo,verbose,pipe,\n");
+  printf("      perf,print,pwstorage,signal,sql,tiling,undo,verbose,pipe,expose\n");
   printf("      all,common (-d dev,imageio,masks,opencl,params,pipe)}\n");
   printf("  --d-signal <signal> \n");
   printf("  --d-signal-act <all,raise,connect,disconnect");
@@ -855,6 +855,8 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
           darktable.unmuted |= DT_DEBUG_VERBOSE;
         else if(!strcmp(argv[k + 1], "pipe"))
           darktable.unmuted |= DT_DEBUG_PIPE;
+        else if(!strcmp(argv[k + 1], "expose"))
+          darktable.unmuted |= DT_DEBUG_EXPOSE;
         else
           return usage(argv[0]);
         k++;

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -296,6 +296,7 @@ typedef enum dt_debug_thread_t
   DT_DEBUG_TILING         = 1 << 23,
   DT_DEBUG_VERBOSE        = 1 << 24,
   DT_DEBUG_PIPE           = 1 << 25,
+  DT_DEBUG_EXPOSE         = 1 << 26,
   DT_DEBUG_ALL            = 0xffffffff & ~DT_DEBUG_VERBOSE,
   DT_DEBUG_COMMON         = DT_DEBUG_OPENCL | DT_DEBUG_DEV | DT_DEBUG_MASKS | DT_DEBUG_PARAMS | DT_DEBUG_IMAGEIO | DT_DEBUG_PIPE,
 } dt_debug_thread_t;

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -469,8 +469,8 @@ void expose(
     --darktable.gui->reset;
     dev->gui_synch = FALSE;
   }
-
-  dt_print(DT_DEBUG_EXPOSE, "[darkroom expose] initial requests: %s%s%s%s\n",
+  if(darktable.unmuted & DT_DEBUG_EXPOSE)
+    dt_print(DT_DEBUG_EXPOSE, "[darkroom expose] initial requests: %s%s%s%s\n",
       _full_request(dev)     ? " full" : "",
       _preview_request(dev)  ? " preview" : "",
       _preview2_request(dev) ? " preview_2" : "",
@@ -491,7 +491,8 @@ void expose(
     dt_dev_process_preview2(dev);
   }
 
-  dt_print(DT_DEBUG_EXPOSE, "[darkroom expose] requests after pipe jobs: %s%s%s%s\n",
+  if(darktable.unmuted & DT_DEBUG_EXPOSE)
+    dt_print(DT_DEBUG_EXPOSE, "[darkroom expose] requests after pipe jobs: %s%s%s%s\n",
       _full_request(dev)     ? " full" : "",
       _preview_request(dev)  ? " preview" : "",
       _preview2_request(dev) ? " preview_2" : "",
@@ -714,11 +715,12 @@ void expose(
   /* if we are in full preview mode, we don"t want anything else than the image */
   if(dev->full_preview)
   {
-    dt_print(DT_DEBUG_EXPOSE, "[darkroom expose] full preview finished, remaining requests: %s%s%s%s\n\n",
-      _full_request(dev)     ? " full" : "",
-      _preview_request(dev)  ? " preview" : "",
-      _preview2_request(dev) ? " preview_2" : "",
-      _any_request(dev)      ? "" : "none");
+    if(darktable.unmuted & DT_DEBUG_EXPOSE)
+      dt_print(DT_DEBUG_EXPOSE, "[darkroom expose] full preview finished, remaining requests: %s%s%s%s\n\n",
+        _full_request(dev)     ? " full" : "",
+        _preview_request(dev)  ? " preview" : "",
+        _preview2_request(dev) ? " preview_2" : "",
+        _any_request(dev)      ? "" : "none");
     return;
   }
 
@@ -825,7 +827,8 @@ void expose(
     pango_font_description_free(desc);
     g_object_unref(layout);
   }
-  dt_print(DT_DEBUG_EXPOSE, "[darkroom expose] finished, remaining requests: %s%s%s%s\n\n",
+  if(darktable.unmuted & DT_DEBUG_EXPOSE)
+    dt_print(DT_DEBUG_EXPOSE, "[darkroom expose] finished, remaining requests: %s%s%s%s\n\n",
       _full_request(dev)     ? " full" : "",
       _preview_request(dev)  ? " preview" : "",
       _preview2_request(dev) ? " preview_2" : "",


### PR DESCRIPTION
To investigate the pixelpipe & signalling workflow we need more debugging information what `expose()` in darkroom.c is supposed to do and when this is happening.

- added the `-d expose` option (DT_DEBUG_EXPOSE) as an addition to `-d pipe` and `-d signal` to allow concentration in the logfiles.
- added output in darkroom `expose()`
- minor refactoring checking for pipe-jobs to be done