### PR TITLE
Fix the calculation of resizable widgets based on linesize of contents

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3160,6 +3160,11 @@ static const dt_action_def_t _action_def_focus_tabs
       DT_ACTION_ELEMENTS_NUM(tabs),
       NULL, TRUE };
 
+static void _get_height_if_visible(GtkWidget *w, gint *height)
+{
+  if(gtk_widget_get_visible(w)) *height = gtk_widget_get_allocated_height(w);
+}
+
 static gint _get_container_row_heigth(GtkWidget *w)
 {
   gint height = DT_PIXEL_APPLY_DPI(10);
@@ -3188,13 +3193,7 @@ static gint _get_container_row_heigth(GtkWidget *w)
     g_object_unref(layout);
   }
   else
-  {
-    GtkWidget *child = dt_gui_container_first_child(GTK_CONTAINER(w));
-    if(child)
-    {
-      height = gtk_widget_get_allocated_height(child);
-    }
-  }
+    gtk_container_foreach(GTK_CONTAINER(w), (GtkCallback)_get_height_if_visible, &height);
 
   return height;
 }
@@ -3226,14 +3225,17 @@ static gboolean _resize_wrap_draw(GtkWidget *w, void *cr, const char *config_str
   height += increment - 1;
   height -= height % increment;
 
-  GtkBorder padding;
-  gtk_style_context_get_padding(gtk_widget_get_style_context(sw),
-                                gtk_widget_get_state_flags(sw),
+  GtkBorder padding, margin;
+  gtk_style_context_get_padding(gtk_widget_get_style_context(w),
+                                gtk_widget_get_state_flags(w),
                                 &padding);
+  gtk_style_context_get_margin(gtk_widget_get_style_context(sw),
+                               gtk_widget_get_state_flags(sw),
+                               &margin);
 
   gint old_height = 0;
   gtk_widget_get_size_request(sw, NULL, &old_height);
-  const gint new_height = height + padding.top + padding.bottom + (GTK_IS_TEXT_VIEW(w) ? 2 : 0);
+  const gint new_height = height + padding.top + padding.bottom + margin.top + margin.bottom;
   if(new_height != old_height)
   {
     gtk_widget_set_size_request(sw, -1, new_height);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -68,7 +68,6 @@
 
 #define DT_UI_PANEL_MODULE_SPACING 0
 #define DT_UI_PANEL_BOTTOM_DEFAULT_SIZE 120
-#define DT_RESIZE_HANDLE_SIZE DT_PIXEL_APPLY_DPI(5)
 
 typedef enum dt_gui_view_switch_t
 {

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -36,6 +36,8 @@ extern "C" {
  * DPI */
 #define DT_PIXEL_APPLY_DPI(value) ((value) * darktable.gui->dpi_factor)
 
+#define DT_RESIZE_HANDLE_SIZE DT_PIXEL_APPLY_DPI(5)
+
 typedef struct dt_gui_widgets_t
 {
 

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1038,7 +1038,7 @@ static gboolean area_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
   const int inset = INSET;
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
-  int width = allocation.width, height = allocation.height;
+  int width = allocation.width, height = allocation.height - DT_RESIZE_HANDLE_SIZE;
   cairo_surface_t *cst = dt_cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
   // clear bg, match color of the notebook tabs:
@@ -1329,7 +1329,7 @@ static gboolean area_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
   cairo_set_source_surface(crf, cst, 0, 0);
   cairo_paint(crf);
   cairo_surface_destroy(cst);
-  return TRUE;
+  return FALSE;
 }
 
 static gboolean area_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
@@ -1340,7 +1340,7 @@ static gboolean area_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpo
   const int inset = INSET;
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
-  const int height = allocation.height - 2 * inset;
+  const int height = allocation.height - 2 * inset - DT_RESIZE_HANDLE_SIZE;
   const int width = allocation.width - 2 * inset;
   if(!c->dragging) c->mouse_x = CLAMP(event->x - inset, 0, width) / (float)width;
   c->mouse_y = 1.0 - CLAMP(event->y - inset, 0, height) / (float)height;
@@ -1440,7 +1440,7 @@ static gboolean area_button_press(GtkWidget *widget, GdkEventButton *event, gpoi
     const int inset = INSET;
     GtkAllocation allocation;
     gtk_widget_get_allocation(widget, &allocation);
-    const int height = allocation.height - 2 * inset;
+    const int height = allocation.height - 2 * inset - DT_RESIZE_HANDLE_SIZE;
     const int width = allocation.width - 2 * inset;
     c->mouse_pick
         = dt_draw_curve_calc_value(c->minmax_curve, CLAMP(event->x - inset, 0, width) / (float)width);

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -585,7 +585,7 @@ void process(struct dt_iop_module_t *self,
   dt_colormatrix_mul(input_matrix, XYZ_D65_to_LMS_2006_D65, output_matrix);
   dt_colormatrix_t input_matrix_trans;
   dt_colormatrix_transpose(input_matrix_trans, input_matrix);
-  
+
   // Premultiply the output matrix
 
   /* What we do here is equivalent to :
@@ -1690,7 +1690,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
   cairo_surface_destroy(cst);
   g_object_unref(layout);
   pango_font_description_free(desc);
-  return TRUE;
+  return FALSE;
 }
 
 

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -1406,7 +1406,7 @@ static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_modu
   cairo_set_source_surface(crf, cst, 0, 0);
   cairo_paint(crf);
   cairo_surface_destroy(cst);
-  return TRUE;
+  return FALSE;
 }
 
 static gboolean _bottom_area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_module_t *self)

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1458,7 +1458,7 @@ static void process_wavelets(struct dt_iop_module_t *self,
   dt_colormatrix_transpose(toY0U0V0_trans,toY0U0V0);
   dt_colormatrix_t toRGB_trans;
   dt_colormatrix_transpose(toRGB_trans,toRGB);
-  
+
   for_each_channel(i)
     wb[i] *= d->strength * compensate_strength * in_scale;
 
@@ -3540,7 +3540,7 @@ static gboolean denoiseprofile_draw(GtkWidget *widget,
   cairo_set_source_surface(crf, cst, 0, 0);
   cairo_paint(crf);
   cairo_surface_destroy(cst);
-  return TRUE;
+  return FALSE;
 }
 
 static gboolean denoiseprofile_motion_notify(GtkWidget *widget,

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -3385,6 +3385,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
 
   // Cache the graph objects to avoid recomputing all the view at each redraw
   gtk_widget_get_allocation(widget, &g->allocation);
+  g->allocation.height -= DT_RESIZE_HANDLE_SIZE;
 
   cairo_surface_t *cst =
     dt_cairo_image_surface_create(CAIRO_FORMAT_ARGB32, g->allocation.width, g->allocation.height);
@@ -4222,7 +4223,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
   cairo_surface_destroy(cst);
   g_object_unref(layout);
   pango_font_description_free(desc);
-  return TRUE;
+  return FALSE;
 }
 
 static gboolean area_button_press(GtkWidget *widget, GdkEventButton *event, gpointer user_data)

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -714,7 +714,7 @@ static gboolean dt_iop_levels_area_draw(GtkWidget *widget, cairo_t *crf, gpointe
   const int inset = DT_GUI_CURVE_EDITOR_INSET;
   GtkAllocation allocation;
   gtk_widget_get_allocation(GTK_WIDGET(c->area), &allocation);
-  int width = allocation.width, height = allocation.height;
+  int width = allocation.width, height = allocation.height - DT_RESIZE_HANDLE_SIZE;
   cairo_surface_t *cst = dt_cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
 
@@ -810,7 +810,7 @@ static gboolean dt_iop_levels_area_draw(GtkWidget *widget, cairo_t *crf, gpointe
   cairo_set_source_surface(crf, cst, 0, 0);
   cairo_paint(crf);
   cairo_surface_destroy(cst);
-  return TRUE;
+  return FALSE;
 }
 
 /**
@@ -872,7 +872,7 @@ static gboolean dt_iop_levels_motion_notify(GtkWidget *widget, GdkEventMotion *e
   const int inset = DT_GUI_CURVE_EDITOR_INSET;
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
-  int height = allocation.height - 2 * inset, width = allocation.width - 2 * inset;
+  int height = allocation.height - 2 * inset - DT_RESIZE_HANDLE_SIZE, width = allocation.width - 2 * inset;
   if(!c->dragging)
   {
     c->mouse_x = CLAMP(event->x - inset, 0, width);

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -500,7 +500,7 @@ static gboolean lowlight_draw(GtkWidget *widget, cairo_t *crf, gpointer user_dat
   const int inset = DT_IOP_LOWLIGHT_INSET;
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
-  int width = allocation.width, height = allocation.height;
+  int width = allocation.width, height = allocation.height - DT_RESIZE_HANDLE_SIZE;
   cairo_surface_t *cst = dt_cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
 
@@ -673,7 +673,7 @@ static gboolean lowlight_draw(GtkWidget *widget, cairo_t *crf, gpointer user_dat
   cairo_set_source_surface(crf, cst, 0, 0);
   cairo_paint(crf);
   cairo_surface_destroy(cst);
-  return TRUE;
+  return FALSE;
 }
 
 static gboolean lowlight_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
@@ -684,7 +684,7 @@ static gboolean lowlight_motion_notify(GtkWidget *widget, GdkEventMotion *event,
   const int inset = DT_IOP_LOWLIGHT_INSET;
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
-  int height = allocation.height - 2 * inset, width = allocation.width - 2 * inset;
+  int height = allocation.height - 2 * inset - DT_RESIZE_HANDLE_SIZE, width = allocation.width - 2 * inset;
   if(!c->dragging) c->mouse_x = CLAMP(event->x - inset, 0, width) / (float)width;
   c->mouse_y = 1.0 - CLAMP(event->y - inset, 0, height) / (float)height;
   if(c->dragging)
@@ -753,7 +753,7 @@ static gboolean lowlight_button_press(GtkWidget *widget, GdkEventButton *event, 
     const int inset = DT_IOP_LOWLIGHT_INSET;
     GtkAllocation allocation;
     gtk_widget_get_allocation(widget, &allocation);
-    int height = allocation.height - 2 * inset, width = allocation.width - 2 * inset;
+    int height = allocation.height - 2 * inset - DT_RESIZE_HANDLE_SIZE, width = allocation.width - 2 * inset;
     c->mouse_pick
         = dt_draw_curve_calc_value(c->transition_curve, CLAMP(event->x - inset, 0, width) / (float)width);
     c->mouse_pick -= 1.0 - CLAMP(event->y - inset, 0, height) / (float)height;

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -770,7 +770,7 @@ static gboolean rawdenoise_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
   cairo_set_source_surface(crf, cst, 0, 0);
   cairo_paint(crf);
   cairo_surface_destroy(cst);
-  return TRUE;
+  return FALSE;
 }
 
 static gboolean rawdenoise_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -380,7 +380,7 @@ static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_modu
   const int inset = DT_GUI_CURVE_EDITOR_INSET;
   GtkAllocation allocation;
   gtk_widget_get_allocation(GTK_WIDGET(c->area), &allocation);
-  int width = allocation.width, height = allocation.height;
+  int width = allocation.width, height = allocation.height - DT_RESIZE_HANDLE_SIZE;
   cairo_surface_t *cst = dt_cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
 
@@ -501,7 +501,7 @@ static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_modu
   cairo_set_source_surface(crf, cst, 0, 0);
   cairo_paint(crf);
   cairo_surface_destroy(cst);
-  return TRUE;
+  return FALSE;
 }
 
 static void _rgblevels_move_handle(dt_iop_module_t *self, const int handle_move, const float new_pos, float *levels,
@@ -552,7 +552,7 @@ static gboolean _area_motion_notify_callback(GtkWidget *widget, GdkEventMotion *
   const int inset = DT_GUI_CURVE_EDITOR_INSET;
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
-  int height = allocation.height - 2 * inset, width = allocation.width - 2 * inset;
+  int height = allocation.height - 2 * inset - DT_RESIZE_HANDLE_SIZE, width = allocation.width - 2 * inset;
   if(!c->dragging)
   {
     c->mouse_x = CLAMP(event->x - inset, 0, width);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -1490,7 +1490,7 @@ static gboolean _drawable_draw_callback(GtkWidget *widget, cairo_t *crf, gpointe
   cairo_surface_destroy(cst);
 
   dt_show_times_f(&start, "[histogram]", "scope draw");
-  return TRUE;
+  return FALSE;
 }
 
 static gboolean _drawable_motion_notify_callback(GtkWidget *widget, GdkEventMotion *event,

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -320,7 +320,7 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget,
   cairo_paint(crf);
   cairo_surface_destroy(cst);
 
-  return TRUE;
+  return FALSE;
 }
 
 void _lib_navigation_set_position(dt_lib_module_t *self,

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -671,7 +671,7 @@ void gui_init(dt_lib_module_t *self)
   char localtmpdir[PATH_MAX] = { 0 };
   dt_loc_get_tmp_dir(localtmpdir, sizeof(localtmpdir));
 
-  for(int k = MAX_SNAPSHOT-1; k >= 0; k--)
+  for(int k = 0; k < MAX_SNAPSHOT; k++)
   {
     _clear_snapshot_entry(&d->snapshot[k]);
 
@@ -718,7 +718,7 @@ void gui_init(dt_lib_module_t *self)
                      G_CALLBACK(_lib_button_button_pressed_callback), self);
 
     /* add button to snapshot box */
-    gtk_box_pack_start(GTK_BOX(d->snapshots_box), d->snapshot[k].button, FALSE, FALSE, 0);
+    gtk_box_pack_end(GTK_BOX(d->snapshots_box), d->snapshot[k].button, FALSE, FALSE, 0);
 
     /* prevent widget to show on external show all */
     gtk_widget_set_no_show_all(d->snapshot[k].button, TRUE);


### PR DESCRIPTION
Split off from #14765.

This avoids split lines with some font sizes.

Also add some space at the bottom for the draggable area in some drawable areas so that picking up nodes there is easier. Besides correctly returns FALSE from the draw events to stop stopping additional handlers from drawing over the result.