### PR TITLE
Fix culling thumb placement

### DIFF
--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1466,6 +1466,8 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table,
 
 static gboolean _thumbs_compute_positions(dt_culling_t *table)
 {
+  // This code computes sizes and positions of thumbnails in culling view mode
+
   if(!gtk_widget_get_visible(table->widget)) return FALSE;
   if(!table->list) return FALSE;
 
@@ -1480,14 +1482,16 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
     return TRUE;
   }
 
-  int sum_w = 0, max_h = 0, max_w = 0;
+  int total_thumb_width = 0, max_thumb_height = 0, max_thumb_width = 0;
+  float avg_thumb_aspect_r = 0;
 
+  // variables to hold vertical and horizontal width of all thumbnails after their final placement
+  // as well as horizontal and vertical spacing distance between thumbnails (1 = lowest value possible. Will be scaled up later)
   unsigned int total_width = 0, total_height = 0;
-  int distance = 1;
-  float avg_ratio = 0;
+  int spacing = 1;
 
-  // reinit size and positions and get max values
-  int count = 0;
+  // reinit size and positions of each thumbnail, remember size from biggest thumbnail, calculate average thumbnail ratio
+  int number_of_thumbs  = 0;
   for(GList *l = table->list; l; l = g_list_next(l))
   {
     dt_thumbnail_t *thumb = (dt_thumbnail_t *)l->data;
@@ -1496,125 +1500,215 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
     thumb->height = (gint)(1 / sqrt(aspect_ratio) * 100);
     thumb->x = thumb->y = 0;
 
-    sum_w += thumb->width;
-    max_w = MAX(max_w, thumb->width);
-    max_h = MAX(max_h, thumb->height);
-    avg_ratio += thumb->width / (float)thumb->height;
-    count++;
+    total_thumb_width  += thumb->width;
+    max_thumb_width = MAX(max_thumb_width, thumb->width);
+    max_thumb_height = MAX(max_thumb_height, thumb->height);
+    avg_thumb_aspect_r += thumb->width / (float)thumb->height;
+    number_of_thumbs++;
   }
+  avg_thumb_aspect_r /= number_of_thumbs;
+  
+  // estimate a good start value for number of rows and columns to use in thumbnail placement by taking the square root
+  //  of the number of thumbnails. E.g. 9 thumbnails: probably 3x3. Prefer wide configuration e.g. 8 thumbnails: 3x2
+  int thumbs_per_row, thumbs_per_row_new, thumbs_per_col, thumbs_per_col_new;
+  thumbs_per_row = thumbs_per_row_new = ceil(sqrt(number_of_thumbs ));
+  thumbs_per_col = thumbs_per_col_new = (number_of_thumbs  + thumbs_per_row - 1) / thumbs_per_row;
 
-  avg_ratio /= count;
+  float screen_aspect_r = table->view_width / (float)table->view_height;
+  float thumb_placement_ratio, thumb_placement_ratio_new;
+  thumb_placement_ratio = thumb_placement_ratio_new = thumbs_per_row / (float)thumbs_per_col;
 
-  int per_row, tmp_per_row, per_col, tmp_per_col;
-  per_row = tmp_per_row = ceil(sqrt(count));
-  per_col = tmp_per_col = (count + per_row - 1) / per_row;
-
-  float tmp_slot_ratio, slot_ratio;
-  tmp_slot_ratio = slot_ratio =
-    (table->view_width / (float)per_row) / (table->view_height / (float)per_col);
-
+  // increase and decrease number of thumbs per row and calculate how the resulting ratio of placed thumbnails
+  //  compares to the ratio of the available screen space. Ideally both aspect ratios are equal.
+  //  Iterate until the best configuration has been found.
+  //  Note: The average thumbnail aspect ratio from the previous step is not equal to the actual thumbnail ratio
+  //        since it does not take into account thumbnail rotation or thumbs with different aspect ratios.
+  //        That means we are just doing an approximation here.
+  float old_deviation, new_deviation, punishment_weight, new_punishment_weight, old_deviation_punished, new_deviation_punished;
   do
   {
-    per_row = tmp_per_row;
-    per_col = tmp_per_col;
-    slot_ratio = tmp_slot_ratio;
-
-    if(avg_ratio > slot_ratio)
+    thumbs_per_row = thumbs_per_row_new;
+    thumbs_per_col = thumbs_per_col_new;
+    thumb_placement_ratio = thumb_placement_ratio_new;
+    
+    // if the ratio of placed thumbnails is bigger than the screen aspect ratio (they take too much horizontal space)
+    //  reduce number of images per row by 1 and vice versa.
+    if(thumb_placement_ratio * avg_thumb_aspect_r > screen_aspect_r)
     {
-      tmp_per_row = per_row - 1;
+      thumbs_per_row_new = thumbs_per_row - 1;
     }
     else
     {
-      tmp_per_row = per_row + 1;
+      thumbs_per_row_new = thumbs_per_row + 1;
     }
 
-    if(tmp_per_row == 0) break;
+    if(thumbs_per_row_new == 0) break;
 
-    tmp_per_col = (count + tmp_per_row - 1) / tmp_per_row;
+    // update column cound and placement ratio
+    thumbs_per_col_new = (number_of_thumbs  + thumbs_per_row_new - 1) / thumbs_per_row_new;
+    thumb_placement_ratio_new = thumbs_per_row_new / (float)thumbs_per_col_new;
 
-    tmp_slot_ratio =
-      (table->view_width / (float)tmp_per_row) / (table->view_height / (float)tmp_per_col);
+  // calculate old and new deviation between screen ratio and ratio of placed thumbnails
+  // 1.0 means that screen and placement ratio are equal (perfect match)
+  // the further away from 1.0 we get, the worse. There are not negative values.
+  old_deviation = _absmul(thumb_placement_ratio * avg_thumb_aspect_r, screen_aspect_r);
+  new_deviation = _absmul(thumb_placement_ratio_new * avg_thumb_aspect_r, screen_aspect_r);
 
-  } while(per_row > 0
-          && per_row <= count
-          && _absmul(tmp_slot_ratio, avg_ratio) < _absmul(slot_ratio, avg_ratio));
+  // Punish old and new configuration for not-full last rows (if they have any)
+  //  E.g. we could place 4 images in a 2x2 or 3x2 configuration, but in 3x2 there will be only 1 image in the last row
+  //  even though there is room for 3. So we punish the placement ratio of the 3x2 configuration for the 2 empty slots by
+  //  multiplying it with (1 + free_spots_row/total_spots/row) = (1 + 2/3) = 1.66
+  //  this prefers a configurations with well filled rows unless it is a lot better to place one image alone in a row.
+  punishment_weight = (1 + (thumbs_per_row - ((number_of_thumbs-1)%thumbs_per_row + 1))/((float)thumbs_per_row));
+  new_punishment_weight = (1 + (thumbs_per_row_new - ((number_of_thumbs-1)%thumbs_per_row_new + 1))/((float)thumbs_per_row_new));
+
+  // if all thumbs are placed in a single row or column, the weight from above formula will be 1.0 (=no punishment)
+  //  this can cause the algorithm to be biased towards single row/column configurations - so we add some punishment manually
+  if(thumbs_per_col == 1 || thumbs_per_row == 1)
+    punishment_weight = 1.5;
+  if(thumbs_per_col_new == 1 || thumbs_per_row_new == 1)
+    new_punishment_weight = 1.5;
+
+  // apply weight factor
+  old_deviation_punished = old_deviation * punishment_weight;
+  new_deviation_punished = new_deviation * new_punishment_weight;
+
+  // try to improve as long as row-count bigger than 0
+  //  AND row-count lower or equal total number of thumbs
+  //  AND the resulting deviation from a perfect placement is lower than before
+  //  --> stop when we make negative progress
+  } while(thumbs_per_row > 0
+          && thumbs_per_row <= number_of_thumbs 
+          && new_deviation_punished < old_deviation_punished);
+  
+  // Now we have a good estimation how many thumbnails SHOULD fit in each row and column.
+  // Actual placement might differ
+
+  // Vertical image stacking:
+  //  Vertical stacking is only allowed if the heigth of the biggest thumbnail is more than the height of 2 or more thumbs combined.
+  //  for example: we have three images and image 3 is higher than heights of image 1 and 2 combined 
+  //  [  1  ] | 3 |                                                         | 3 |
+  //  [  2  ] | 3 |      instead of this placement -->    [  1  ]  [  2  ]  | 3 |
+  //          | 3 |                                                         | 3 |
+  // in this case, images 1 and 2 would be stacked in one slot and image 3 will be placed in a new slot alone.
+  // if all images have similar heigths, they will not be stacked and placed in a separate slot.
+
+  // Note: Stacking only make sense for images in the same row as the portrait image. 
+  //       The algorithm does not check for this so unneccessary stacking can occur.
 
   GList *slots = NULL;
 
-  // Vertical layout
+  // loop through all thumbs
   for(GList *l = table->list; l; l = g_list_next(l))
   {
     dt_thumbnail_t *thumb = (dt_thumbnail_t *)l->data;
     GList *slot_iter = slots;
+
+    // start placing thumbs into slots
     for(; slot_iter; slot_iter = slot_iter->next)
     {
       GList *slot = (GList *)slot_iter->data;
       // Calculate current total height of slot
-      int slot_h = distance;
+      int slot_heigth = 0;
+      
       for(GList *slot_cw_iter = slot;
           slot_cw_iter;
           slot_cw_iter = g_list_next(slot_cw_iter))
       {
         dt_thumbnail_t *slot_cw = (dt_thumbnail_t *)slot_cw_iter->data;
-        slot_h = slot_h + slot_cw->height + distance;
+        slot_heigth = slot_heigth + slot_cw->height + spacing;
       }
-      // Add window to slot if the slot height after adding the window
-      // doesn't exceed max window height
-      if(slot_h + distance + thumb->height < max_h)
+      slot_heigth -= spacing;
+
+      // Add thumbnail to slot if the slot height after adding the thumbnail
+      // doesn't exceed the height of the highest thumbnail
+      if(slot_heigth + spacing + thumb->height < max_thumb_height)
       {
         slot_iter->data = g_list_append(slot, thumb);
         break;
       }
     }
-    // Otherwise, create a new slot with only this window
-    if(!slot_iter) slots = g_list_prepend(slots, g_list_prepend(NULL, thumb));
+    // Otherwise, create a new slot with only this thumbnail
+    if(!slot_iter)
+    {
+      slots = g_list_prepend(slots, g_list_prepend(NULL, thumb));
+    }
+    
   }
   slots = g_list_reverse(slots);  // list was built in reverse order, so un-reverse it
 
+  // create a nested list to hold all thumbnails in their final placement in rows
   GList *rows = g_list_append(NULL, NULL);
   {
-    int row_y = 0, x = 0, row_h = 0;
-    int max_row_w = sum_w / per_col;
+    int row_y = 0, thumb_x = 0, row_heigth = 0;
+    int row_width_limit = total_thumb_width / number_of_thumbs * thumbs_per_row; // tbd: wrong assumption. Row could be longer, since we do scale everything later
+
+    // work with one slot at a time
     for(GList *slot_iter = slots; slot_iter; slot_iter = g_list_next(slot_iter))
     {
       GList *slot = (GList *)slot_iter->data;
 
-      // Max width of windows in the slot
-      int slot_max_w = 0;
+      // Calculate max width and total height of thumbs in the slot so that all thumbs can be centered within the slot
+      int slot_max_thumb_width = 0, slot_total_heigth = 0;
       for(GList *slot_cw_iter = slot;
           slot_cw_iter;
           slot_cw_iter = g_list_next(slot_cw_iter))
       {
         dt_thumbnail_t *cw = (dt_thumbnail_t *)slot_cw_iter->data;
-        slot_max_w = MAX(slot_max_w, cw->width);
+        slot_max_thumb_width = MAX(slot_max_thumb_width, cw->width);
+        slot_total_heigth = slot_total_heigth + cw->height + spacing;
       }
+      // don't include bottom spacing in height calculation
+      slot_total_heigth -= spacing;
 
-      int y = row_y;
-      for(GList *slot_cw_iter = slot;
-          slot_cw_iter;
-          slot_cw_iter = g_list_next(slot_cw_iter))
+      // if slot is about to be placed outside of allocated horizonal space, place the slot in a new row
+      //  we allow for 20% tolerance to account for the influence of images with mixed aspect ratios in the math
+      gboolean create_new_row = false;
+      if(thumb_x + slot_max_thumb_width > row_width_limit * 1.2)
       {
-        dt_thumbnail_t *cw = (dt_thumbnail_t *)slot_cw_iter->data;
-        cw->x = x + (slot_max_w - cw->width) / 2;
-        cw->y = y;
-        y += cw->height + distance;
-        rows->data = g_list_append(rows->data, cw);
+        create_new_row = true;
+        // if this is the last image and we are about to place it in a new row,
+        //  check if the aspect ratio of thumbnail placement is better if we keep the thumbnail in the previous row 
+        if(!slot_iter->next)
+        {
+          float ratio_same_row = _absmul((thumb_x + slot_max_thumb_width) / (float)MAX(row_heigth, slot_total_heigth), table->view_width / (float)table->view_height);
+          float ratio_new_row = _absmul(MAX(thumb_x, slot_max_thumb_width) / (float)(row_heigth + slot_total_heigth), table->view_width / (float)table->view_height);
+          if(ratio_new_row > ratio_same_row)
+          {
+            create_new_row = false;
+          }
+        }
       }
-
-      row_h = MAX(row_h, y - row_y);
-      total_height = MAX(total_height, y);
-      x += slot_max_w + distance;
-      total_width = MAX(total_width, x);
-
-      if(x > max_row_w)
+      
+      if(create_new_row)
       {
-        x = 0;
-        row_y += row_h;
-        row_h = 0;
+        thumb_x = 0;
+        row_y += row_heigth;
+        row_heigth = 0;
         rows = g_list_append(rows, 0);
         rows = rows->next; // keep rows pointing at last element to
                            // avoid quadratic runtime
       }
+
+      int thumb_y = row_y;
+
+      // loop through all images assigned to a slot and calculate their placement
+      //  place all of them within the same row
+      for(GList *slot_cw_iter = slot;
+          slot_cw_iter;
+          slot_cw_iter = g_list_next(slot_cw_iter))
+      {
+        dt_thumbnail_t *cw = (dt_thumbnail_t *)slot_cw_iter->data;
+        cw->x = thumb_x + (slot_max_thumb_width - cw->width) / 2; // x position should be horizontally centered within the slot
+        cw->y = thumb_y;                                // y position starts at 0
+        thumb_y += cw->height + spacing;               // and is increased by the heigth of the thumb + spacing of spacing for placing the next image of the slot
+        rows->data = g_list_append(rows->data, cw); // append thumbnail to row
+      }
+      row_heigth = MAX(row_heigth, thumb_y - row_y);
+      total_height = MAX(total_height, thumb_y);        // update total height of all thumbs combined as we fill column by column with thumbnails
+      thumb_x += slot_max_thumb_width + spacing;
+      total_width = MAX(total_width, thumb_x);          // update total width of all thumbs combined as we fill column by column with thumbnails
+
       g_list_free(slot);
     }
     g_list_free(slots);
@@ -1625,35 +1719,36 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
                              // constructed list, so move it back to
                              // the start
 
-  total_width -= distance;
-  total_height -= distance;
+  // once we placed all images, we can remove the space at the right and the bottom
+  total_width -= spacing;
+  total_height -= spacing;
 
+  //int thumb_iter_counter = 0;
   for(const GList *iter = rows; iter; iter = g_list_next(iter))
   {
     GList *row = (GList *)iter->data;
-    int row_w = 0, xoff;
-    int max_rh = 0;
+    int row_width = 0, xoff;
+    int max_row_heigth = 0;
 
     for(GList *slot_cw_iter = row;
         slot_cw_iter;
         slot_cw_iter = g_list_next(slot_cw_iter))
     {
       dt_thumbnail_t *cw = (dt_thumbnail_t *)slot_cw_iter->data;
-      row_w = MAX(row_w, cw->x + cw->width);
-      max_rh = MAX(max_rh, cw->height);
+      row_width = MAX(row_width, cw->x + cw->width);
+      max_row_heigth = MAX(max_row_heigth, cw->height); //tbd: this is wrong for stacked images, should be (cw->y - row_y + cw->heigth)
     }
 
-    xoff = (total_width - row_w) / 2;
+    xoff = (total_width - row_width) / 2;
 
     for(GList *cw_iter = row; cw_iter; cw_iter = g_list_next(cw_iter))
     {
       dt_thumbnail_t *cw = (dt_thumbnail_t *)cw_iter->data;
       cw->x += xoff;
-      cw->height = max_rh;
+      cw->height = max_row_heigth; // tbd: this is wrong for stacked images in a slot. Their height should be max_row_heigth*(thumb_height/stack_height)
     }
     g_list_free(row);
   }
-
   g_list_free(rows);
 
   float factor = (float)(table->view_width - 1) / total_width;
@@ -1663,6 +1758,7 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
   const int xoff = (table->view_width - (float)total_width * factor) / 2;
   const int yoff = (table->view_height - (float)total_height * factor) / 2;
 
+  // scale everything to match the size of your screen
   for(GList *l = table->list; l; l = g_list_next(l))
   {
     dt_thumbnail_t *thumb = (dt_thumbnail_t *)l->data;


### PR DESCRIPTION
This is an attempt to fix a very old issue #2565 which could not be done because the original code author left.

The problem is messed up thumb placement in culling view when displaying images with mixed aspect ratios.

This PR does not address the request to scroll culling `row by row`.

original             |  fixed
:-------------------------:|:-------------------------:
![image](https://github.com/darktable-org/darktable/assets/2805109/631bf341-4b83-41a1-874d-8f616b3fb4d6)  |  ![image](https://github.com/darktable-org/darktable/assets/2805109/82ebedfd-711f-4586-a771-047cdc61dcb9)
![image](https://github.com/darktable-org/darktable/assets/2805109/3e701e2c-dc78-4604-bc52-f4757752331b) | ![image](https://github.com/darktable-org/darktable/assets/2805109/0d8b33c8-ed37-4330-9a2f-8c56ad04b234)

Test files:
[culling_aspect_example.zip](https://github.com/darktable-org/darktable/files/12198006/culling_aspect_example.zip)

Changes:
* Added comments to legacy code to explain what it does
* Renamed most variables because they were too cryptic
* Fixed thumbnails overflowing a row by checking for position of thumbnail END instead of its beginning
* Added 20% tolerance to row width to fit a more optimal number of thumbs in a row (was an issue if aspect ratios where not the same)
* Added punishment factor to placements where the last row of thumbnails would not be populated completely. The more empty the last row is - the worse