### PR TITLE
New "overwrite if changed" option for disk export

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1439,14 +1439,6 @@ static int32_t dt_control_export_job_run(dt_job_t *job)
     // update the message. initialize_store() might have changed the number of images
     dt_control_job_set_progress_message(job, message);
 
-    // remove 'changed' tag from image
-    if(dt_tag_detach(tagid, imgid, FALSE, FALSE)) tag_change = TRUE;
-    // make sure the 'exported' tag is set on the image
-    if(dt_tag_attach(etagid, imgid, FALSE, FALSE)) tag_change = TRUE;
-
-    /* register export timestamp in cache */
-    dt_image_cache_set_export_timestamp(darktable.image_cache, imgid);
-
     // check if image still exists:
     const dt_image_t *image = dt_image_cache_get(darktable.image_cache, (int32_t)imgid, 'r');
     if(image)
@@ -1468,6 +1460,17 @@ static int32_t dt_control_export_job_run(dt_job_t *job)
                            settings->export_masks, settings->icc_type, settings->icc_filename, settings->icc_intent,
                            &metadata) != 0)
           dt_control_job_cancel(job);
+        else
+        {
+          // remove 'changed' tag from image
+          if(dt_tag_detach(tagid, imgid, FALSE, FALSE)) tag_change = TRUE;
+
+          // make sure the 'exported' tag is set on the image
+          if(dt_tag_attach(etagid, imgid, FALSE, FALSE)) tag_change = TRUE;
+
+          /* register export timestamp in cache */
+          dt_image_cache_set_export_timestamp(darktable.image_cache, imgid);
+        }
       }
     }
 


### PR DESCRIPTION
These two patches add a new "overwrite if changed" option to the "on conflict" dropdown in the disk export module. This comes in very handy when one wants to re-export all images that have changed since the last export.

Note that the first patch changes at what point in time image tags (changed, exported, export timestamp) are being updated during export. In current master, they are updated when the export of an image starts, and regardless if the export actually ends up being successful. This makes it impossible for the new "overwrite if changed" code to compare export_timestamp to change_timestamp to decide if the image should be exported, because export_timestamp would by definition always be more recent than change_timestamp. The tags therefore are now updated 

I believe the old behaviour was not correct. There has to be at least a check if the export was actually successful, which doesn't happen without this patch. But it's still not perfect, the flags are now still updated if the export is skipped. mstorage->store(..) is currently only expected to return 0 (success) or !=0 (failure), with !=0 causing the job controller to stop the whole export.  So there is no defined way to communicate back to the job controller that the image was skipped and therefore the tags should not be updated, but the whole export should still continue. Anyways, the new code is IMO still slightly more correct than the old one. I have a couple of ideas how to fully fix the code, but I'm not sure if API/ABI changes in this area would break anything (e.g. Lua scripts). 

Since the second patch increases the disk export module version to 4, I would be happy to discuss other possible improvements to the disk module to keep the legacy_params() conversion function as small as possible. About half of the new code is actually required to convert the parameters from module version 3...