### PR TITLE
Retouch and liquify usabilty,expand and show crop

### DIFF
--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -260,8 +260,16 @@ typedef struct dt_develop_t
     // is the WB module using D65 illuminant and not doing full chromatic adaptation ?
     gboolean wb_is_D65;
     dt_aligned_pixel_t wb_coeffs;
-
   } proxy;
+
+
+  // for exposing the crop
+  struct
+  {
+    // set by dt_dev_pixelpipe_synch() if an enabled crop module is included in history
+    struct dt_iop_module_t *exposer; 
+    struct dt_iop_module_t *requester;
+  } cropping;
 
   // for the overexposure indicator
   struct

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -104,7 +104,7 @@ typedef enum dt_iop_tags_t
   IOP_TAG_NONE = 0,
   IOP_TAG_DISTORT = 1 << 0,
   IOP_TAG_DECORATION = 1 << 1,
-  IOP_TAG_CLIPPING = 1 << 2,
+  IOP_TAG_CROPPING = 1 << 2,
 
   // might be some other filters togglable by user?
   // IOP_TAG_SLOW       = 1<<3,
@@ -132,7 +132,8 @@ typedef enum dt_iop_flags_t
   IOP_FLAGS_ALLOW_FAST_PIPE = 1 << 12,   // Module can work with a fast pipe
   IOP_FLAGS_UNSAFE_COPY = 1 << 13,       // Unsafe to copy as part of history
   IOP_FLAGS_GUIDES_SPECIAL_DRAW = 1 << 14, // handle the grid drawing directly
-  IOP_FLAGS_GUIDES_WIDGET = 1 << 15       // require the guides widget
+  IOP_FLAGS_GUIDES_WIDGET = 1 << 15,      // require the guides widget
+  IOP_FLAGS_CROP_EXPOSER = 1 << 16        // offers crop exposing
 } dt_iop_flags_t;
 
 /** status of a module*/

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -472,6 +472,10 @@ void dt_dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe,
       const gboolean active = hist->enabled;
       piece->enabled = active;
 
+      // the last crop module in the pixelpipe might handle the exposing if enabled 
+      if(piece->module->flags() & IOP_FLAGS_CROP_EXPOSER)
+        dev->cropping.exposer = active ? piece->module : NULL;
+
       // Styles, presets or history copy&paste might set history items
       // not appropriate for the image.  Fixing that seemed to be
       // almost impossible after long discussions but at least we can
@@ -537,6 +541,7 @@ void dt_dev_pixelpipe_synch_all(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
 {
   dt_pthread_mutex_lock(&pipe->busy_mutex);
 
+  dev->cropping.exposer = NULL;
   dt_print(DT_DEBUG_PARAMS,
            "[pixelpipe] [%s] synch all modules with defaults_params\n",
            dt_dev_pixelpipe_type_to_str(pipe->type));

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -153,8 +153,8 @@ int operation_tags()
 
 int operation_tags_filter()
 {
-  // switch off clipping and decoration, we want to see the full image.
-  return IOP_TAG_DECORATION | IOP_TAG_CLIPPING;
+  // switch off cropping and decoration, we want to see the full image.
+  return IOP_TAG_DECORATION | IOP_TAG_CROPPING;
 }
 
 dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -336,13 +336,13 @@ int flags()
 
 int operation_tags()
 {
-  return IOP_TAG_DISTORT | IOP_TAG_CLIPPING;
+  return IOP_TAG_DISTORT | IOP_TAG_CROPPING;
 }
 
 int operation_tags_filter()
 {
   // switch off watermark, it gets confused.
-  return IOP_TAG_DECORATION | IOP_TAG_CLIPPING;
+  return IOP_TAG_DECORATION | IOP_TAG_CROPPING;
 }
 
 dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -1379,7 +1379,7 @@ void gui_post_expose(struct dt_iop_module_t *self,
   pzx += 0.5f;
   pzy += 0.5f;
 
-  const double fillc = external ? 0.75 : 0.2;
+  const double fillc = external ? 0.9 : 0.2;
   const double dashes = (external ? 0.3 : 0.5) * DT_PIXEL_APPLY_DPI(5.0) / zoom_scale;
   const double effect = external ? 0.6 : 1.0;
 

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -1383,7 +1383,7 @@ void gui_post_expose(struct dt_iop_module_t *self,
   const double dashes = (external ? 0.3 : 0.5) * DT_PIXEL_APPLY_DPI(5.0) / zoom_scale;
   const double effect = external ? 0.6 : 1.0;
 
-  if(_set_max_clip(self))
+  if(_set_max_clip(self) && !external)
   {
     cairo_set_source_rgba(cr, fillc, fillc, fillc, 1.0 - fillc);
     cairo_set_fill_rule(cr, CAIRO_FILL_RULE_EVEN_ODD);

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -156,12 +156,12 @@ int flags()
 {
   return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_TILING_FULL_ROI
     | IOP_FLAGS_ONE_INSTANCE | IOP_FLAGS_ALLOW_FAST_PIPE
-    | IOP_FLAGS_GUIDES_SPECIAL_DRAW | IOP_FLAGS_GUIDES_WIDGET;
+    | IOP_FLAGS_GUIDES_SPECIAL_DRAW | IOP_FLAGS_GUIDES_WIDGET | IOP_FLAGS_CROP_EXPOSER;
 }
 
 int operation_tags()
 {
-  return IOP_TAG_DISTORT | IOP_TAG_CLIPPING;
+  return IOP_TAG_DISTORT | IOP_TAG_CROPPING;
 }
 
 int operation_tags_filter()
@@ -1350,8 +1350,14 @@ void gui_post_expose(struct dt_iop_module_t *self,
   dt_develop_t *dev = self->dev;
   dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)self->gui_data;
 
-  // we don't do anything if the image is not ready
-  if(!g->preview_ready) return;
+  // is this expose enforced by another module in focus?
+  const gboolean external = dev->cropping.exposer
+                        &&  dev->cropping.requester
+                        && (dev->cropping.exposer != dev->cropping.requester);
+
+  // we don't do anything if the image is not ready within crop module
+  // and we don't have visualizing enforced by other modules
+  if(!(g->preview_ready || external)) return;
 
   _aspect_apply(self, GRAB_HORIZONTAL);
 
@@ -1367,16 +1373,19 @@ void gui_post_expose(struct dt_iop_module_t *self,
   cairo_scale(cr, zoom_scale, zoom_scale);
   cairo_translate(cr, -.5f * wd - zoom_x * wd, -.5f * ht - zoom_y * ht);
 
-  const double dashes = DT_PIXEL_APPLY_DPI(5.0) / zoom_scale;
-
   // draw cropping window
   float pzx, pzy;
   dt_dev_get_pointer_zoom_pos(dev, pointerx, pointery, &pzx, &pzy);
   pzx += 0.5f;
   pzy += 0.5f;
+
+  const double fillc = external ? 0.75 : 0.2;
+  const double dashes = (external ? 0.3 : 0.5) * DT_PIXEL_APPLY_DPI(5.0) / zoom_scale;
+  const double effect = external ? 0.6 : 1.0;
+
   if(_set_max_clip(self))
   {
-    cairo_set_source_rgba(cr, .2, .2, .2, .8);
+    cairo_set_source_rgba(cr, fillc, fillc, fillc, 1.0 - fillc);
     cairo_set_fill_rule(cr, CAIRO_FILL_RULE_EVEN_ODD);
     cairo_rectangle(cr, g->clip_max_x * wd, g->clip_max_y * ht,
                         g->clip_max_w * wd, g->clip_max_h * ht);
@@ -1384,13 +1393,16 @@ void gui_post_expose(struct dt_iop_module_t *self,
                         g->clip_w * wd, g->clip_h * ht);
     cairo_fill(cr);
   }
+
   if(g->clip_x > .0f || g->clip_y > .0f || g->clip_w < 1.0f || g->clip_h < 1.0f)
   {
-    cairo_set_line_width(cr, dashes / 2.0);
+    cairo_set_line_width(cr, dashes);
     cairo_rectangle(cr, g->clip_x * wd, g->clip_y * ht, g->clip_w * wd, g->clip_h * ht);
-    dt_draw_set_color_overlay(cr, TRUE, 1.0);
+    dt_draw_set_color_overlay(cr, TRUE, effect);
     cairo_stroke(cr);
   }
+
+  if(external) return;
 
   // draw cropping window dimensions if first mouse button is pressed
   if(darktable.control->button_down && darktable.control->button_down_which == 1)

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -3672,7 +3672,6 @@ static gboolean btn_make_radio_callback(GtkToggleButton *btn,
 void gui_update(dt_iop_module_t *self)
 {
   update_warp_count(self);
-  self->dev->cropping.requester = (self->expanded) ? self : NULL;
 }
 
 void gui_init(dt_iop_module_t *self)

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -308,12 +308,18 @@ int default_group()
 
 int flags()
 {
-  return IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_GUIDES_WIDGET;
+  return IOP_FLAGS_SUPPORTS_BLENDING;
 }
 
 int operation_tags()
 {
    return IOP_TAG_DISTORT;
+}
+
+int operation_tags_filter()
+{
+  // switch off cropping, we want to see the full image.
+  return IOP_TAG_DECORATION | IOP_TAG_CROPPING;
 }
 
 dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
@@ -2795,14 +2801,15 @@ static gboolean btn_make_radio_callback(GtkToggleButton *btn,
                                         GdkEventButton *event,
                                         dt_iop_module_t *module);
 
-void gui_focus(struct dt_iop_module_t *module,
+void gui_focus(struct dt_iop_module_t *self,
                const gboolean in)
 {
   if(!in)
   {
     dt_collection_hint_message(darktable.collection);
-    btn_make_radio_callback(NULL, NULL, module);
+    btn_make_radio_callback(NULL, NULL, self);
   }
+  self->dev->cropping.requester = (in && !darktable.develop->image_loading) ? self : NULL;
 }
 
 static void sync_pipe(struct dt_iop_module_t *module,
@@ -3662,9 +3669,10 @@ static gboolean btn_make_radio_callback(GtkToggleButton *btn,
   return TRUE;
 }
 
-void gui_update(dt_iop_module_t *module)
+void gui_update(dt_iop_module_t *self)
 {
-  update_warp_count(module);
+  update_warp_count(self);
+  self->dev->cropping.requester = (self->expanded) ? self : NULL;
 }
 
 void gui_init(dt_iop_module_t *self)

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2382,8 +2382,6 @@ void gui_update(dt_iop_module_t *self)
   for(int i = 0; i < 3; i++)
     dlevels[i] = p->preview_levels[i];
   dtgtk_gradient_slider_multivalue_set_values(g->preview_levels_gslider, dlevels);
-
-  self->dev->cropping.requester = (self->expanded) ? self : NULL;
 }
 
 void change_image(struct dt_iop_module_t *self)

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -229,6 +229,12 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
   return IOP_CS_RGB;
 }
 
+int operation_tags_filter()
+{
+  // switch off cropping and decoration, we want to see the full image.
+  return IOP_TAG_DECORATION | IOP_TAG_CROPPING;
+}
+
 int legacy_params(dt_iop_module_t *self,
                   const void *const old_params,
                   const int old_version,
@@ -2227,6 +2233,7 @@ void gui_focus(struct dt_iop_module_t *self,
        || g->suppress_mask)
       dt_iop_refresh_center(self);
   }
+  self->dev->cropping.requester = (in && !darktable.develop->image_loading) ? self : NULL;
 }
 
 void tiling_callback(struct dt_iop_module_t *self,
@@ -2375,6 +2382,8 @@ void gui_update(dt_iop_module_t *self)
   for(int i = 0; i < 3; i++)
     dlevels[i] = p->preview_levels[i];
   dtgtk_gradient_slider_multivalue_set_values(g->preview_levels_gslider, dlevels);
+
+  self->dev->cropping.requester = (self->expanded) ? self : NULL;
 }
 
 void change_image(struct dt_iop_module_t *self)

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -412,6 +412,11 @@ static inline gboolean _full_request(dt_develop_t *dev)
      || dev->pipe->input_timestamp < dev->preview_pipe->input_timestamp;
 } 
 
+static inline gboolean _full_ready(dt_develop_t *dev)
+{
+  return dev->image_status == DT_DEV_PIXELPIPE_VALID;
+}
+
 static inline gboolean _preview_request(dt_develop_t *dev)
 {
   return
@@ -548,11 +553,13 @@ void expose(
     dt_view_set_scrollbar(self, zx, -0.5 + boxw/2, 0.5, boxw/2, zy, -0.5+ boxh/2, 0.5, boxh/2);
   }
 
-  if(dev->pipe->output_backbuf                            // do we have an image?
+  const gboolean expose_full = 
+        dev->pipe->output_backbuf                         // do we have an image?
      && dev->pipe->output_imgid == dev->image_storage.id  // same image?
      && dev->pipe->backbuf_scale == backbuf_scale         // same zoom scale?
      && dev->pipe->backbuf_zoom_x == zoom_x
-     && dev->pipe->backbuf_zoom_y == zoom_y)
+     && dev->pipe->backbuf_zoom_y == zoom_y;
+  if(expose_full)
   {
     dt_print(DT_DEBUG_EXPOSE, "[darkroom expose] draw image\n");
     // draw image
@@ -708,7 +715,7 @@ void expose(
   if(image_surface_imgid == dev->image_storage.id)
   {
     cairo_destroy(cr);
-    cairo_set_source_surface(cri, image_surface, 0, 0);
+    cairo_set_source_surface(cri, image_surface, 0.0, 0.0);
     cairo_paint(cri);
   }
 
@@ -758,14 +765,6 @@ void expose(
     cairo_restore(cri);
   }
 
-  // display mask if we have a current module activated or if the
-  // masks manager module is expanded
-
-  const gboolean display_masks =
-    (dev->gui_module && dev->gui_module->enabled
-     && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS)
-    || dt_lib_gui_get_expanded(dt_lib_get_module("masks"));
-
   // draw colorpicker for in focus module or execute module callback hook
   // FIXME: draw picker in gui_post_expose() hook in
   // libs/colorpicker.c -- catch would be that live samples would
@@ -781,21 +780,46 @@ void expose(
   }
   else
   {
+    // display mask if we have a current module activated or if the
+    // masks manager module is expanded
+    const gboolean display_masks =
+      (dev->gui_module
+      && dev->gui_module->enabled
+      && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS)
+    || dt_lib_gui_get_expanded(dt_lib_get_module("masks"));
+
     if(dev->form_visible && display_masks)
     {
       dt_print(DT_DEBUG_EXPOSE, "[darkroom expose] masks post expose\n");
       dt_masks_events_post_expose(dev->gui_module, cri, width, height, pointerx, pointery);
     }
-    // module
-    if(dev->gui_module && dev->gui_module != dev->proxy.rotate
-       && dev->gui_module->gui_post_expose
-       && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS)
+
+    // true if anything could be exposed
+    if(dev->gui_module && dev->gui_module != dev->proxy.rotate)
     {
-      dt_print(DT_DEBUG_EXPOSE, "[darkroom expose] gui_post_expose [%s]\n", dev->gui_module->op);
-      cairo_save(cri);
-      dev->gui_module->gui_post_expose(dev->gui_module, cri,
+      // the cropping.exposer->gui_post_expose needs special care
+      if(expose_full
+        && dev->cropping.exposer
+        && dev->cropping.requester
+        && dev->cropping.exposer->gui_post_expose)
+      {
+        dt_print(DT_DEBUG_EXPOSE, "[darkroom expose] cropper post_expose [%s]\n", dev->cropping.exposer->op);
+        cairo_save(cri);
+        dev->cropping.exposer->gui_post_expose(dev->cropping.exposer, cri,
                                        width, height, pointerx, pointery);
-      cairo_restore(cri);
+        cairo_restore(cri);
+      }
+
+      // gui active module
+      if(dev->gui_module->gui_post_expose
+       && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS)
+      {
+        dt_print(DT_DEBUG_EXPOSE, "[darkroom expose] gui_post_expose [%s]\n", dev->gui_module->op);
+        cairo_save(cri);
+        dev->gui_module->gui_post_expose(dev->gui_module, cri,
+                                       width, height, pointerx, pointery);
+        cairo_restore(cri);
+      }
     }
   }
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -412,11 +412,6 @@ static inline gboolean _full_request(dt_develop_t *dev)
      || dev->pipe->input_timestamp < dev->preview_pipe->input_timestamp;
 } 
 
-static inline gboolean _full_ready(dt_develop_t *dev)
-{
-  return dev->image_status == DT_DEV_PIXELPIPE_VALID;
-}
-
 static inline gboolean _preview_request(dt_develop_t *dev)
 {
   return


### PR DESCRIPTION
A new feature "cropper exposing" has been added to the pixelpipe, some modules want to show full image data instead of the area left by the crop module.

The UI is simple, if a module having this feature is expanded, it will always show uncropped data plus a slim rectangle showing the crop area plus the outer parts dimmed.

1.  we keep track of crop-exposure requesting and the exposing module, this is done - as for the proxies - in `struct dt_develop_t` as
```
    struct
  	{
      // set by dt_dev_pixelpipe_synch() if an enabled crop module is included in history
    	struct dt_iop_module_t *exposer;
    	struct dt_iop_module_t *requester;
    } cropping;
```
2.  The new `IOP_FLAGS_CROP_EXPOSER` advertises a module an a `cropping.exposer` while checking for enabled modules in the pixelpipe and either sets it to NULL or the exposing module.
3.  darkroom `expose()` got some work to call `dev->cropping.exposer->gui_post_expose()` in case we found a valid exposer and a feature-supporting module has asked via setting `cropping.requester`
4.  The crop module's `gui_post_expose()` has been tuned to better support either a) old-mode serving the crop module itself b) usage as `cropping.exposer`, here we make the effect less pronouncing

To support the above system, a requesting module must:
1. make sure the normal cropping is diabled by implementing a `operation_tags_filter()` including `IOP_TAG_CROPPING`
2. set `cropping.requester` in `gui_focus()` either to `NULL` or `self`
3. same for `gui_update()` EDIT: not necessary as we only expand on _in focus_ status

Some notes:
- Also tried `ashift` as a `cropping.exposer`, works but really distracting due to the rotation
- the darkroom expose does not "flicker" any more but we expose the cropper visualize only for full pixelpipe doing the job.
- Feature implemented for `retouch` and `liquify` yet


_______________________________________________________________
1. As only rarely using these modules myself i might oversee issues, couldn't find any so far. @elstoc 
2. replaces #14915 
3. looks like (overprocess module for debug session)
![Bildschirmfoto vom 2023-07-30 18-23-57](https://github.com/darktable-org/darktable/assets/50982232/c6701d9d-1896-457c-8bf0-cc297d2b986d)

