### PR TITLE
reenable macOS nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -264,7 +264,7 @@ jobs:
           retention-days: 2
 
   macOS:
-    if: 0 && (github.repository == 'darktable-org/darktable' || github.event_name == 'workflow_dispatch')
+    if: github.repository == 'darktable-org/darktable' || github.event_name == 'workflow_dispatch'
     name: Nightly darktable macOS
     runs-on: ${{ matrix.build.os }}
     strategy:
@@ -305,10 +305,15 @@ jobs:
           brew tap Homebrew/bundle
           cd src/.ci
           export HOMEBREW_NO_INSTALL_UPGRADE=1
+          export HOMEBREW_NO_INSTALL_CLEANUP=1
           brew bundle --verbose || true
           # handle keg-only libs
           brew link --force libomp
           brew link --force libsoup@2
+      - name: Downgrade libjpeg-turbo
+        run: |
+          brew uninstall --ignore-dependencies libjpeg-turbo
+          brew link libjpeg-turbo --overwrite
       - name: Rebuild graphicsmagick without modules
         run: |
           export HOMEBREW_NO_INSTALL_FROM_API=1
@@ -360,8 +365,7 @@ jobs:
       # We need write permission to update the nightly tag
       contents: write
     runs-on: ubuntu-latest
-    #needs: [AppImage, Windows, macOS]
-    needs: [AppImage, Windows]
+    needs: [AppImage, Windows, macOS]
     steps:
       - name: Download AppImage artifact
         uses: actions/download-artifact@v3
@@ -371,10 +375,10 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: Darktable.Nightly.Windows
-      # - name: Download macOS artifact
-      #   uses: actions/download-artifact@v3
-      #   with:
-      #     name: Darktable.Nightly.macOS
+      - name: Download macOS artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: Darktable.Nightly.macOS
       - name: Update nightly release
         uses: andelf/nightly-release@main
         env:
@@ -402,5 +406,5 @@ jobs:
             __Please help us improve Darktable by reporting any issues you encounter!__ :wink:
           files: |
             Darktable-*.AppImage*
-            # darktable-*.dmg
+            darktable-*.dmg
             darktable-*.exe


### PR DESCRIPTION
fixes #14939 

Background:
libjpeg-turbo was recently updated to version 3.0.0 which causes compile errors when rebuilding GraphicsMagick.
The bug is fixed in GraphicsMagick 1.4.0 but this version is not released yet.

To get the nightly builds for macOS back on track this PR downgrades libjpeg-turbo back to version 2.1.5.1.

I will keep an eye on GraphicsMagick releases and as soon as 1.4.0 gets released I will provide another PR.
