### PR TITLE
Getting rid of OpenCL 1.1 functions

### DIFF
--- a/src/common/dlopencl.c
+++ b/src/common/dlopencl.c
@@ -141,8 +141,8 @@ dt_dlopencl_t *dt_dlopencl_init(const char *name)
                                            (void (**)(void)) & ocl->symbols->dt_clCreateKernel);
     success = success && dt_gmodule_symbol(module, "clCreateBuffer",
                                            (void (**)(void)) & ocl->symbols->dt_clCreateBuffer);
-    success = success && dt_gmodule_symbol(module, "clCreateImage2D",
-                                           (void (**)(void)) & ocl->symbols->dt_clCreateImage2D);
+    success = success && dt_gmodule_symbol(module, "clCreateImage",
+                                           (void (**)(void)) & ocl->symbols->dt_clCreateImage);
     success = success && dt_gmodule_symbol(module, "clEnqueueWriteBuffer",
                                            (void (**)(void)) & ocl->symbols->dt_clEnqueueWriteBuffer);
     success = success && dt_gmodule_symbol(module, "clSetKernelArg",
@@ -184,8 +184,6 @@ dt_dlopencl_t *dt_dlopencl_init(const char *name)
                                            (void (**)(void)) & ocl->symbols->dt_clGetEventProfilingInfo);
     success = success && dt_gmodule_symbol(module, "clGetKernelInfo",
                                            (void (**)(void)) & ocl->symbols->dt_clGetKernelInfo);
-    success = success && dt_gmodule_symbol(module, "clEnqueueBarrier",
-                                           (void (**)(void)) & ocl->symbols->dt_clEnqueueBarrier);
     success = success && dt_gmodule_symbol(module, "clGetKernelWorkGroupInfo",
                                            (void (**)(void)) & ocl->symbols->dt_clGetKernelWorkGroupInfo);
     success = success && dt_gmodule_symbol(module, "clEnqueueReadBuffer",

--- a/src/common/dlopencl.h
+++ b/src/common/dlopencl.h
@@ -49,10 +49,8 @@ typedef cl_int (*dt_clSetCommandQueueProperty_t)(cl_command_queue, cl_command_qu
                                                  cl_command_queue_properties *);
 typedef cl_mem (*dt_clCreateBuffer_t)(cl_context, cl_mem_flags, size_t, void *, cl_int *);
 typedef cl_mem (*dt_clCreateSubBuffer_t)(cl_mem, cl_mem_flags, cl_buffer_create_type, const void *, cl_int *);
-typedef cl_mem (*dt_clCreateImage2D_t)(cl_context, cl_mem_flags, const cl_image_format *, size_t, size_t,
-                                       size_t, void *, cl_int *);
-typedef cl_mem (*dt_clCreateImage3D_t)(cl_context, cl_mem_flags, const cl_image_format *, size_t, size_t,
-                                       size_t, size_t, size_t, void *, cl_int *);
+typedef cl_mem (*dt_clCreateImage_t)(cl_context context, cl_mem_flags flags, const cl_image_format *image_format,
+                                     const cl_image_desc *image_desc, void *host_ptr, cl_int *errcode_ret);
 typedef cl_int (*dt_clRetainMemObject_t)(cl_mem);
 typedef cl_int (*dt_clReleaseMemObject_t)(cl_mem);
 typedef cl_int (*dt_clGetSupportedImageFormats_t)(cl_context, cl_mem_flags, cl_mem_object_type, cl_uint,
@@ -138,7 +136,6 @@ typedef cl_int (*dt_clEnqueueNativeKernel_t)(cl_command_queue, void (*user_func)
                                              const cl_event *, cl_event *);
 typedef cl_int (*dt_clEnqueueMarker_t)(cl_command_queue, cl_event *);
 typedef cl_int (*dt_clEnqueueWaitForEvents_t)(cl_command_queue, cl_uint, const cl_event *);
-typedef cl_int (*dt_clEnqueueBarrier_t)(cl_command_queue);
 
 typedef struct dt_dlopencl_symbols_t
 {
@@ -158,8 +155,7 @@ typedef struct dt_dlopencl_symbols_t
   dt_clSetCommandQueueProperty_t dt_clSetCommandQueueProperty;
   dt_clCreateBuffer_t dt_clCreateBuffer;
   dt_clCreateSubBuffer_t dt_clCreateSubBuffer;
-  dt_clCreateImage2D_t dt_clCreateImage2D;
-  dt_clCreateImage3D_t dt_clCreateImage3D;
+  dt_clCreateImage_t dt_clCreateImage;
   dt_clRetainMemObject_t dt_clRetainMemObject;
   dt_clReleaseMemObject_t dt_clReleaseMemObject;
   dt_clGetSupportedImageFormats_t dt_clGetSupportedImageFormats;
@@ -214,7 +210,6 @@ typedef struct dt_dlopencl_symbols_t
   dt_clEnqueueNativeKernel_t dt_clEnqueueNativeKernel;
   dt_clEnqueueMarker_t dt_clEnqueueMarker;
   dt_clEnqueueWaitForEvents_t dt_clEnqueueWaitForEvents;
-  dt_clEnqueueBarrier_t dt_clEnqueueBarrier;
 } dt_dlopencl_symbols_t;
 
 

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -305,9 +305,6 @@ int dt_opencl_finish(const int devid);
 /** cleans up command queue if in synchron mode or while exporting, returns TRUE in case of success */
 gboolean dt_opencl_finish_sync_pipe(const int devid, const int pipetype);
 
-/** enqueues a synchronization point. */
-gboolean dt_opencl_enqueue_barrier(const int devid);
-
 /** locks a device for your thread's exclusive use and returns it's id */
 int dt_opencl_lock_device(const int pipetype);
 
@@ -564,10 +561,6 @@ static inline gboolean dt_opencl_finish(const int devid)
 static inline gboolean dt_opencl_finish_sync_pipe(const int devid, const int pipetype)
 {
   return FALSE;
-}
-static inline gboolean dt_opencl_enqueue_barrier(const int devid)
-{
-  return -1;
 }
 static inline int dt_opencl_lock_device(const int dev)
 {


### PR DESCRIPTION
Some OpenCL functions used by dt have been deprecated even for V. 1.2, some bug reports seem to imply that some drivers might not correctly implement those. So let's get rid of them for the sake of correctness.

1. `clEnqueueBarrier()` and `clCreateImage3D()` have not been used in the codebase anyway
2. `clCreateImage2D()` has been removed too
3. code uses the V 1.2 (and later) compliant `clCreateImage()` version