### PR TITLE
More finishing touches for the shortcuts system

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -542,7 +542,7 @@ static gboolean dt_bauhaus_popup_button_press(GtkWidget *widget, GdkEventButton 
 
 static void dt_bauhaus_window_show(GtkWidget *w, gpointer user_data)
 {
-  gtk_grab_add(GTK_WIDGET(user_data));
+  gtk_grab_add(GTK_WIDGET(w));
 }
 
 static void dt_bh_init(DtBauhausWidget *class)
@@ -740,9 +740,10 @@ void dt_bauhaus_init()
                                                        | darktable.gui->scroll_mask);
 
   GObject *window = G_OBJECT(darktable.bauhaus->popup_window), *area = G_OBJECT(darktable.bauhaus->popup_area);
+  g_signal_connect(window, "event", G_CALLBACK(dt_shortcut_dispatcher), NULL);
   g_signal_connect(window, "show", G_CALLBACK(dt_bauhaus_window_show), area);
   g_signal_connect(area, "draw", G_CALLBACK(dt_bauhaus_popup_draw), NULL);
-  g_signal_connect(area, "motion-notify-event", G_CALLBACK(dt_bauhaus_popup_motion_notify), NULL);
+  g_signal_connect(window, "motion-notify-event", G_CALLBACK(dt_bauhaus_popup_motion_notify), NULL);
   g_signal_connect(area, "leave-notify-event", G_CALLBACK(dt_bauhaus_popup_leave_notify), NULL);
   g_signal_connect(area, "button-press-event", G_CALLBACK(dt_bauhaus_popup_button_press), NULL);
   g_signal_connect(area, "button-release-event", G_CALLBACK (dt_bauhaus_popup_button_release), NULL);
@@ -2459,7 +2460,7 @@ void dt_bauhaus_hide_popup()
 {
   if(darktable.bauhaus->current)
   {
-    gtk_grab_remove(darktable.bauhaus->popup_area);
+    gtk_grab_remove(darktable.bauhaus->popup_window);
     gtk_widget_hide(darktable.bauhaus->popup_window);
     gtk_window_set_attached_to(GTK_WINDOW(darktable.bauhaus->popup_window), NULL);
     darktable.bauhaus->current = NULL;

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -88,11 +88,11 @@ static float _widget_get_quad_width(dt_bauhaus_widget_t *w)
     return .0f;
 }
 
-static void _combobox_next_sensitive(dt_bauhaus_widget_t *w, int delta, const gboolean mute)
+static void _combobox_next_sensitive(dt_bauhaus_widget_t *w, int delta, guint state, const gboolean mute)
 {
   dt_bauhaus_combobox_data_t *d = &w->data.combobox;
 
-  delta *= dt_accel_get_speed_multiplier(GTK_WIDGET(w), 0);
+  delta *= dt_accel_get_speed_multiplier(GTK_WIDGET(w), state);
   int new_pos = d->active;
   int step = delta > 0 ? 1 : -1;
   int cur = new_pos + step;
@@ -323,7 +323,7 @@ static void _combobox_popup_scroll(int amt)
   const dt_bauhaus_combobox_data_t *d = &darktable.bauhaus->current->data.combobox;
   int old_value = d->active;
 
-  _combobox_next_sensitive(darktable.bauhaus->current, amt, d->mute_scrolling);
+  _combobox_next_sensitive(darktable.bauhaus->current, amt, 0, d->mute_scrolling);
 
   gint wx = 0, wy = 0;
   const int skip = darktable.bauhaus->line_height;
@@ -2674,7 +2674,7 @@ static gboolean _widget_scroll(GtkWidget *widget, GdkEventScroll *event)
         _slider_add_step(widget, - delta_y, event->state, force);
     }
     else
-      _combobox_next_sensitive(w, delta_y, FALSE);
+      _combobox_next_sensitive(w, delta_y, 0, FALSE);
   }
   return TRUE; // Ensure that scrolling the combobox cannot move side panel
 }
@@ -2702,7 +2702,7 @@ static gboolean _widget_key_press(GtkWidget *widget, GdkEventKey *event)
       if(w->type == DT_BAUHAUS_SLIDER)
         _slider_add_step(widget, delta, event->state, FALSE);
       else
-        _combobox_next_sensitive(w, delta, FALSE);
+        _combobox_next_sensitive(w, delta, 0, FALSE);
 
       return TRUE;
     case GDK_KEY_Return:
@@ -3518,7 +3518,7 @@ static float _action_process_combo(gpointer target, dt_action_element_t element,
       move_size *= - 1;
     case DT_ACTION_EFFECT_NEXT:
       ++darktable.gui->reset;
-      _combobox_next_sensitive(w, move_size, FALSE);
+      _combobox_next_sensitive(w, move_size, GDK_MODIFIER_MASK, FALSE);
       --darktable.gui->reset;
 
       g_idle_add(_combobox_idle_value_changed, widget);

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -49,7 +49,7 @@ extern "C" {
 extern GType DT_BAUHAUS_WIDGET_TYPE;
 
 #define DT_BAUHAUS_SLIDER_MAX_STOPS 20
-#define DT_BAUHAUS_COMBO_MAX_TEXT 180
+#define DT_BAUHAUS_MAX_TEXT 180
 
 typedef enum dt_bauhaus_type_t
 {
@@ -212,7 +212,7 @@ typedef struct dt_bauhaus_t
   int change_active;
   float mouse_line_distance;
   // key input buffer
-  char keys[64];
+  char keys[DT_BAUHAUS_MAX_TEXT];
   int keys_cnt;
   // our custom signals
   guint signals[DT_BAUHAUS_LAST_SIGNAL];
@@ -282,9 +282,6 @@ void dt_bauhaus_widget_reset(GtkWidget *widget);
 
 // update all bauhaus widgets in an iop module from their params fields
 void dt_bauhaus_update_module(dt_iop_module_t *self);
-
-void dt_bauhaus_hide_popup();
-void dt_bauhaus_show_popup(GtkWidget *w);
 
 // slider:
 GtkWidget *dt_bauhaus_slider_new(dt_iop_module_t *self);

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -216,8 +216,6 @@ typedef struct dt_bauhaus_t
   int keys_cnt;
   // our custom signals
   guint signals[DT_BAUHAUS_LAST_SIGNAL];
-  // flag set on button press indicating that popup should be hidden in button release handler
-  gboolean hiding;
 
   // initialise or connect accelerators in set_label
   int skip_accel;

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -3241,6 +3241,30 @@ void dtgtk_cairo_paint_shortcut(cairo_t *cr, gint x, gint y, gint w, gint h, gin
 {
   PREAMBLE(1.15, 1, 0, 0)
 
+  // plus or minus
+  if(flags & (CPF_DIRECTION_UP | CPF_DIRECTION_DOWN))
+  {
+    cairo_set_line_width(cr, .06);
+    cairo_set_line_cap(cr, CAIRO_LINE_CAP_SQUARE);
+
+    cairo_move_to(cr, 1.1, .4);
+    cairo_line_to(cr, 1.3, .4);
+
+    if(flags == CPF_DIRECTION_UP)
+    {
+      cairo_move_to(cr, 1.2, .3);
+      cairo_line_to(cr, 1.2, .5);
+    }
+
+    cairo_save(cr);
+    cairo_set_source_rgb(cr, 1., 1., 1.);
+    cairo_set_line_width(cr, .15);
+    cairo_stroke_preserve(cr);
+    cairo_restore(cr);
+
+    cairo_stroke(cr);
+  }
+
   //keyboard outline
   cairo_set_line_width(cr, .05);
   cairo_set_line_join(cr, CAIRO_LINE_JOIN_ROUND);
@@ -3250,6 +3274,14 @@ void dtgtk_cairo_paint_shortcut(cairo_t *cr, gint x, gint y, gint w, gint h, gin
   cairo_line_to(cr, .1, .73);
   cairo_line_to(cr, .9, .73);
   cairo_line_to(cr, .9, .27);
+
+  if(data)
+  {
+    cairo_save(cr);
+    cairo_set_source_rgb(cr, 1., 1., 1.);
+    cairo_fill_preserve(cr);
+    cairo_restore(cr);
+  }
 
   cairo_stroke(cr);
 

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1072,8 +1072,8 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget,
       markup_text = g_markup_printf_escaped("%s\n%s\n%s%s\n%s",
                                             _("press keys with mouse click and scroll or move combinations to create a shortcut"),
                                             _("click to open shortcut configuration"),
-                                            add_remove_qap > 0 ? _("ctrl+click to add to quick access panel\n") :
-                                            add_remove_qap < 0 ? _("ctrl+click to remove from quick access panel\n")  : "",
+                                            add_remove_qap == CPF_DIRECTION_UP   ? _("ctrl+click to add to quick access panel\n") :
+                                            add_remove_qap == CPF_DIRECTION_DOWN ? _("ctrl+click to remove from quick access panel\n")  : "",
                                             _("scroll to change default speed"),
                                             _("right click to exit mapping mode"));
     }
@@ -2654,6 +2654,12 @@ static void _import_clicked(GtkButton *button, gpointer user_data)
   dt_shortcuts_save(NULL, FALSE);
 }
 
+static void _notice_clicked(GtkWidget *button, gpointer user_data)
+{
+  gtk_widget_hide(button);
+  dt_conf_set_bool("accel/hide_notice", TRUE);
+}
+
 GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
 {
   // Save the shortcuts before editing
@@ -2858,6 +2864,25 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
   gtk_box_pack_end(GTK_BOX(button_bar), button, FALSE, FALSE, 0);
 
   GtkWidget *top_level = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  if(!dt_conf_get_bool("accel/hide_notice"))
+  {
+    button = gtk_button_new_with_label(
+      _("The recommended way to assign shortcuts to visual elements is the <b>visual shortcut mapping</b> mode.\n"
+        "This is switched on by toggling the <i>\"keyboard\"</i> button next to preferences in the top panel. "
+        "In this mode, clicking on a widget or area will open this dialog with the appropriate selection for advanced configuration.\n"
+        "Multiple shortcuts can be assigned to the same action. "
+        "This is especially useful if it has multiple <i>elements</i>, like the module buttons or the colorpickers attached to sliders. "
+        "However, with <i>fallbacks</i> enabled one can use the same simple shortcuts and "
+        "change their <i>element</i> or <i>effect</i> by adding mouse clicks."));
+    gtk_widget_set_tooltip_text(button, _("click to dismiss this notice permanently"));
+    gtk_widget_set_hexpand(button, TRUE);
+    GtkLabel *label = GTK_LABEL(gtk_bin_get_child(GTK_BIN(button)));
+    gtk_label_set_use_markup(label, TRUE);
+    gtk_label_set_line_wrap(label, TRUE);
+    gtk_label_set_xalign(label, 0);
+    g_signal_connect(button, "clicked", G_CALLBACK(_notice_clicked), NULL);
+    gtk_box_pack_start(GTK_BOX(top_level), button, FALSE, FALSE, 0);
+  }
   gtk_box_pack_start(GTK_BOX(top_level), container, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(top_level), button_bar, FALSE, FALSE, 0);
 

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -2894,12 +2894,12 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
   if(!dt_conf_get_bool("accel/hide_notice"))
   {
     button = gtk_button_new_with_label(
-      _("The recommended way to assign shortcuts to visual elements is the <b>visual shortcut mapping</b> mode.\n"
-        "This is switched on by toggling the <i>\"keyboard\"</i> button next to preferences in the top panel. "
-        "In this mode, clicking on a widget or area will open this dialog with the appropriate selection for advanced configuration.\n"
-        "Multiple shortcuts can be assigned to the same action. "
-        "This is especially useful if it has multiple <i>elements</i>, like the module buttons or the colorpickers attached to sliders. "
-        "However, with <i>fallbacks</i> enabled one can use the same simple shortcuts and "
+      _("the recommended way to assign shortcuts to visual elements is the <b>visual shortcut mapping</b> mode.\n"
+        "this is switched on by toggling the <i>\"keyboard\"</i> button next to preferences in the top panel. "
+        "in this mode, clicking on a widget or area will open this dialog with the appropriate selection for advanced configuration.\n"
+        "multiple shortcuts can be assigned to the same action. "
+        "this is especially useful if it has multiple <i>elements</i>, like the module buttons or the colorpickers attached to sliders. "
+        "however, with <i>fallbacks</i> enabled one can use the same simple shortcuts and "
         "change their <i>element</i> or <i>effect</i> by adding mouse clicks."));
     gtk_widget_set_tooltip_text(button, _("click to dismiss this notice permanently"));
     gtk_widget_set_hexpand(button, TRUE);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -233,6 +233,8 @@ static gchar *_panels_get_view_path(char *suffix)
 {
   if(!darktable.view_manager) return NULL;
   const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
+  if(!cv) return NULL;
+
   // in lighttable, we store panels states per layout
   char lay[32] = "";
   if(g_strcmp0(cv->module_name, "lighttable") == 0)
@@ -845,10 +847,6 @@ void dt_gui_store_last_preset(const char *name)
   darktable.gui->last_preset = g_strdup(name);
 }
 
-static void _gui_noop_action_callback(dt_action_t *action)
-{
-}
-
 static void _gui_switch_view_key_accel_callback(dt_action_t *action)
 {
   dt_ctl_switch_mode_to(action->id);
@@ -1178,9 +1176,6 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   g_signal_connect(G_OBJECT(widget), "configure-event", G_CALLBACK(_window_configure), NULL);
   g_signal_connect(G_OBJECT(widget), "event", G_CALLBACK(dt_shortcut_dispatcher), NULL);
   g_signal_override_class_handler("query-tooltip", gtk_widget_get_type(), G_CALLBACK(dt_shortcut_tooltip_callback));
-
-  //an action that does nothing - used for overriding/removing default shortcuts
-  dt_action_register(&darktable.control->actions_global, N_("no-op"), _gui_noop_action_callback, 0, 0);
 
   ac = dt_action_section(&darktable.control->actions_global, N_("switch views"));
   dt_action_register(ac, N_("tethering"), _gui_switch_view_key_accel_callback, GDK_KEY_t, 0);

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -75,7 +75,7 @@ typedef struct dt_iop_borders_params_t
   float color[3];           // border color $DEFAULT: 1.0
   float aspect;             /* aspect ratio of the outer frame w/h
                                $MIN: 1.0 $MAX: 3.0 $DEFAULT: DT_IOP_BORDERS_ASPECT_CONSTANT_VALUE $DESCRIPTION: "aspect ratio" */
-  char aspect_text[20];     /* aspect ratio of the outer frame w/h (user string version)
+  char aspect_text[20];     /* UNUSED aspect ratio of the outer frame w/h (user string version)
                                DEFAULT: "constant border" */
   dt_iop_orientation_t aspect_orient;        /* aspect ratio orientation
                                $DEFAULT: 0 $DESCRIPTION: "orientation" */
@@ -83,11 +83,11 @@ typedef struct dt_iop_borders_params_t
                                $MIN: 0.0 $MAX: 0.5 $DEFAULT: 0.1 $DESCRIPTION: "border size" */
   float pos_h;              /* picture horizontal position ratio into the final image
                                $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.5 $DESCRIPTION: "horizontal offset" */
-  char pos_h_text[20];      /* picture horizontal position ratio into the final image (user string version)
+  char pos_h_text[20];      /* UNUSED picture horizontal position ratio into the final image (user string version)
                                DEFAULT: "1/2" */
   float pos_v;              /* picture vertical position ratio into the final image
                                $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.5 $DESCRIPTION: "vertical offset"*/
-  char pos_v_text[20];      /* picture vertical position ratio into the final image (user string version)
+  char pos_v_text[20];      /* UNUSED picture vertical position ratio into the final image (user string version)
                                DEFAULT: "1/2" */
   float frame_size;         /* frame line width relative to border width
                                $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "frame line size" */
@@ -785,14 +785,8 @@ static void aspect_changed(GtkWidget *combo, dt_iop_module_t *self)
   dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
   const int which = dt_bauhaus_combobox_get(combo);
-  const char *text = dt_bauhaus_combobox_get_text(combo);
-  if(which == dt_bauhaus_combobox_length(combo)-1)
+  if(which < DT_IOP_BORDERS_ASPECT_COUNT)
   {
-    g_strlcpy(p->aspect_text, text, sizeof(p->aspect_text));
-  }
-  else if(which < DT_IOP_BORDERS_ASPECT_COUNT)
-  {
-    g_strlcpy(p->aspect_text, text, sizeof(p->aspect_text));
     p->aspect = _aspect_ratios[which];
     ++darktable.gui->reset;
     dt_bauhaus_slider_set(g->aspect_slider,p->aspect);
@@ -807,14 +801,8 @@ static void position_h_changed(GtkWidget *combo, dt_iop_module_t *self)
   dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
   const int which = dt_bauhaus_combobox_get(combo);
-  const char *text = dt_bauhaus_combobox_get_text(combo);
-  if(which == dt_bauhaus_combobox_length(combo)-1)
+  if(which < DT_IOP_BORDERS_POSITION_H_COUNT)
   {
-    g_strlcpy(p->aspect_text, text, sizeof(p->aspect_text));
-  }
-  else if(which < DT_IOP_BORDERS_POSITION_H_COUNT)
-  {
-    g_strlcpy(p->pos_h_text, text, sizeof(p->pos_h_text));
     p->pos_h = _pos_h_ratios[which];
     ++darktable.gui->reset;
     dt_bauhaus_slider_set(g->pos_h_slider,p->pos_h);
@@ -829,14 +817,8 @@ static void position_v_changed(GtkWidget *combo, dt_iop_module_t *self)
   dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
   const int which = dt_bauhaus_combobox_get(combo);
-  const char *text = dt_bauhaus_combobox_get_text(combo);
-  if(which == dt_bauhaus_combobox_length(combo)-1)
+  if(which < DT_IOP_BORDERS_POSITION_V_COUNT)
   {
-    g_strlcpy(p->aspect_text, text, sizeof(p->aspect_text));
-  }
-  else if(which < DT_IOP_BORDERS_POSITION_V_COUNT)
-  {
-    g_strlcpy(p->pos_v_text, text, sizeof(p->pos_v_text));
     p->pos_v = _pos_v_ratios[which];
     ++darktable.gui->reset;
     dt_bauhaus_slider_set(g->pos_v_slider,p->pos_v);
@@ -861,7 +843,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     }
     dt_bauhaus_combobox_set(g->aspect, k);
   }
-  else if(!w || w == g->pos_h_slider)
+  if(!w || w == g->pos_h_slider)
   {
     for(k = 0; k < DT_IOP_BORDERS_POSITION_H_COUNT; k++)
     {
@@ -870,7 +852,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     }
     dt_bauhaus_combobox_set(g->pos_h, k);
   }
-  else if(!w || w == g->pos_v_slider)
+  if(!w || w == g->pos_v_slider)
   {
     for(k = 0; k < DT_IOP_BORDERS_POSITION_V_COUNT; k++)
     {
@@ -945,7 +927,8 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->size, _("size of the border in percent of the full image"));
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL(g->aspect, self, NULL, N_("aspect"),
-                               _("select the aspect ratio (right click on slider below to type your own w:h)"),
+                               _("select the aspect ratio\n"
+                                 "(right click on slider below to type your own w:h)"),
                                0, aspect_changed, self,
                                N_("image"),
                                N_("3:1"),
@@ -968,32 +951,30 @@ void gui_init(struct dt_iop_module_t *self)
                                N_("square"),
                                N_("constant border"),
                                N_("custom..."));
-  dt_bauhaus_combobox_set_editable(g->aspect, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), g->aspect, TRUE, TRUE, 0);
 
   g->aspect_slider = dt_bauhaus_slider_from_params(self, "aspect");
-  gtk_widget_set_tooltip_text(g->aspect_slider, _("set the custom aspect ratio (right click to enter number or w:h)"));
+  gtk_widget_set_tooltip_text(g->aspect_slider, _("set the custom aspect ratio\n"
+                                                  "(right click to enter number or w:h)"));
 
   g->aspect_orient = dt_bauhaus_combobox_from_params(self, "aspect_orient");
   gtk_widget_set_tooltip_text(g->aspect_orient, _("aspect ratio orientation of the image with border"));
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL(g->pos_h, self, NULL, N_("horizontal position"),
-                               _("select the horizontal position ratio relative to top "
-                                 "or right click and type your own (y:h)"),
+                               _("select the horizontal position ratio relative to top\n"
+                                 "(right click on slider below to type your own x:w)"),
                                0, position_h_changed, self,
                                N_("center"), N_("1/3"), N_("3/8"), N_("5/8"), N_("2/3"), N_("custom..."));
-  dt_bauhaus_combobox_set_editable(g->pos_h, 1);
   gtk_box_pack_start(GTK_BOX(self->widget), g->pos_h, TRUE, TRUE, 0);
 
   g->pos_h_slider = dt_bauhaus_slider_from_params(self, "pos_h");
   gtk_widget_set_tooltip_text(g->pos_h_slider, _("custom horizontal position"));
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL(g->pos_v, self, NULL, N_("vertical position"),
-                               _("select the vertical position ratio relative to left "
-                                 "or right click and type your own (x:w)"),
+                               _("select the vertical position ratio relative to left\n"
+                                 "(right click on slider below to type your own y:h)"),
                                0, position_v_changed, self,
                                N_("center"), N_("1/3"), N_("3/8"), N_("5/8"), N_("2/3"), N_("custom..."));
-  dt_bauhaus_combobox_set_editable(g->pos_v, 1);
   gtk_box_pack_start(GTK_BOX(self->widget), g->pos_v, TRUE, TRUE, 0);
 
   g->pos_v_slider = dt_bauhaus_slider_from_params(self, "pos_v");
@@ -1038,18 +1019,6 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->frame_picker), _("pick frame line color from image"));
   dt_action_define_iop(self, N_("pickers"), N_("frame line color"), g->frame_picker, &dt_action_def_toggle);
   gtk_box_pack_start(GTK_BOX(self->widget), box, TRUE, TRUE, 0);
-}
-
-
-void init(dt_iop_module_t *self)
-{
-  dt_iop_default_init(self);
-
-  dt_iop_borders_params_t *defaults = self->default_params;
-
-  g_strlcpy(defaults->aspect_text, "constant border", sizeof(defaults->aspect_text));
-  g_strlcpy(defaults->pos_h_text, "1/2", sizeof(defaults->pos_h_text));
-  g_strlcpy(defaults->pos_v_text, "1/2", sizeof(defaults->pos_v_text));
 }
 
 // clang-format off

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -3278,7 +3278,7 @@ void gui_init(dt_lib_module_t *self)
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE, G_CALLBACK(view_set_click), self);
 
   dt_action_register(DT_ACTION(self), N_("jump back to previous collection"), _history_previous, GDK_KEY_k,
-                     GDK_CONTROL_MASK);
+                     GDK_CONTROL_MASK | GDK_SHIFT_MASK);
 }
 
 void gui_cleanup(dt_lib_module_t *self)

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2218,7 +2218,7 @@ static int _lib_modulegroups_basics_module_toggle_action(dt_lib_module_t *self, 
     _manage_direct_save(self);
   }
 
-  return found_item ? -1 : 1;
+  return found_item ? CPF_DIRECTION_DOWN : CPF_DIRECTION_UP;
 }
 
 static int _lib_modulegroups_basics_module_toggle(dt_lib_module_t *self, GtkWidget *widget, gboolean doit)

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -108,7 +108,7 @@ typedef struct dt_lib_modulegroups_group_t
 
 typedef struct dt_lib_modulegroups_t
 {
-  uint32_t current;
+  int32_t current;
   GtkWidget *text_entry;
   GtkWidget *hbox_buttons;
   GtkWidget *active_btn;
@@ -226,6 +226,7 @@ static GtkWidget *_buttons_get_from_pos(dt_lib_module_t *self, const int pos)
 
 static void _text_entry_changed_callback(GtkEntry *entry, dt_lib_module_t *self)
 {
+  if(darktable.gui->reset) return;
   _lib_modulegroups_update_iop_visibility(self);
 }
 
@@ -830,9 +831,8 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
   dt_print(DT_DEBUG_IOPORDER, "[lib_modulegroups_update_iop_visibility] modulegroups\n");
 
   // update basic button selection too
-  g_signal_handlers_block_matched(d->basic_btn, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, _lib_modulegroups_toggle, NULL);
+  ++darktable.gui->reset;
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->basic_btn), d->current == DT_MODULEGROUP_BASICS);
-  g_signal_handlers_unblock_matched(d->basic_btn, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, _lib_modulegroups_toggle, NULL);
 
   /* only show module group as selected if not currently searching */
   if((d->show_search || d->force_show_module) && d->current != DT_MODULEGROUP_NONE)
@@ -841,16 +841,13 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
     if(bt)
     {
       /* toggle button visibility without executing callback */
-      g_signal_handlers_block_matched(bt, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, _lib_modulegroups_toggle, NULL);
-
       if((text_entered && text_entered[0] != '\0') || d->force_show_module)
         gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bt), FALSE);
       else
         gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bt), TRUE);
-
-      g_signal_handlers_unblock_matched(bt, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, _lib_modulegroups_toggle, NULL);
     }
   }
+  --darktable.gui->reset;
 
   // hide deprecated message. it will be shown after if needed
   gtk_widget_set_visible(d->deprecated, FALSE);
@@ -983,21 +980,18 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
 
 static void _lib_modulegroups_toggle(GtkWidget *button, gpointer user_data)
 {
+  if(darktable.gui->reset) return;
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_modulegroups_t *d = (dt_lib_modulegroups_t *)self->data;
   const gchar *text_entered = (gtk_widget_is_visible(GTK_WIDGET(d->hbox_search_box)))
                                   ? gtk_entry_get_text(GTK_ENTRY(d->text_entry))
                                   : NULL;
 
-  /* block all button callbacks */
-  const int ngroups = g_list_length(d->groups);
-  for(int k = 0; k <= ngroups; k++)
-    g_signal_handlers_block_matched(_buttons_get_from_pos(self, k), G_SIGNAL_MATCH_FUNC, 0, 0, NULL,
-                                    _lib_modulegroups_toggle, NULL);
-  g_signal_handlers_block_matched(d->basic_btn, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, _lib_modulegroups_toggle, NULL);
+  ++darktable.gui->reset;
 
   /* deactivate all buttons */
   int gid = 0;
+  const int ngroups = g_list_length(d->groups);
   for(int k = 0; k <= ngroups; k++)
   {
     const GtkWidget *bt = _buttons_get_from_pos(self, k);
@@ -1019,19 +1013,11 @@ static void _lib_modulegroups_toggle(GtkWidget *button, gpointer user_data)
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(_buttons_get_from_pos(self, gid)), TRUE);
   }
 
-  /* unblock all button callbacks */
-  for(int k = 0; k <= ngroups; k++)
-    g_signal_handlers_unblock_matched(_buttons_get_from_pos(self, k), G_SIGNAL_MATCH_FUNC, 0, 0, NULL,
-                                      _lib_modulegroups_toggle, NULL);
-  g_signal_handlers_unblock_matched(d->basic_btn, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, _lib_modulegroups_toggle, NULL);
-
   /* clear search text */
   if(gtk_widget_is_visible(GTK_WIDGET(d->hbox_search_box)))
-  {
-    g_signal_handlers_block_matched(d->text_entry, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, _text_entry_changed_callback, NULL);
     gtk_entry_set_text(GTK_ENTRY(d->text_entry), "");
-    g_signal_handlers_unblock_matched(d->text_entry, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, _text_entry_changed_callback, NULL);
-  }
+
+  --darktable.gui->reset;
 
   /* update visibility */
   d->force_show_module = NULL;
@@ -2751,6 +2737,25 @@ static void _dt_dev_image_changed_callback(gpointer instance, dt_lib_module_t *s
 
 }
 
+static gboolean _scroll_group_buttons(GtkWidget *widget,
+                                      GdkEventScroll *event,
+                                      dt_lib_module_t *self)
+{
+  dt_lib_modulegroups_t *d = self->data;
+  int delta;
+  if(dt_gui_get_scroll_unit_delta(event, &delta))
+  {
+    GtkWidget *adjacent = d->current == DT_MODULEGROUP_BASICS && delta < 0
+                        ? d->active_btn
+                        : d->current <= DT_MODULEGROUP_ACTIVE_PIPE && delta > 0
+                        ? d->basic_btn
+                        : _buttons_get_from_pos(self, d->current - delta);
+    if(adjacent) gtk_button_clicked(GTK_BUTTON(adjacent));
+  }
+
+  return TRUE;
+}
+
 void gui_init(dt_lib_module_t *self)
 {
   /* initialize ui widgets */
@@ -2766,7 +2771,11 @@ void gui_init(dt_lib_module_t *self)
 
   // groups
   d->hbox_groups = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_box_pack_start(GTK_BOX(d->hbox_buttons), d->hbox_groups, TRUE, TRUE, 0);
+  GtkWidget *scrollbox = gtk_event_box_new();
+  gtk_container_add(GTK_CONTAINER(scrollbox), d->hbox_groups);
+  g_signal_connect(scrollbox, "scroll-event", G_CALLBACK(_scroll_group_buttons), self);
+  gtk_widget_add_events(scrollbox, darktable.gui->scroll_mask);
+  gtk_box_pack_start(GTK_BOX(d->hbox_buttons), scrollbox, TRUE, TRUE, 0);
 
   // basic group button
   d->basic_btn = dtgtk_togglebutton_new(dtgtk_cairo_paint_modulegroup_basics, 0, NULL);
@@ -2926,18 +2935,15 @@ static void _buttons_update(dt_lib_module_t *self)
   }
 
   // last, if d->current still valid, we select it otherwise the first one
-  int cur = d->current;
-  d->current = DT_MODULEGROUP_NONE;
-  if(cur > g_list_length(d->groups) && cur != DT_MODULEGROUP_BASICS) cur = DT_MODULEGROUP_ACTIVE_PIPE;
-  if(cur == DT_MODULEGROUP_BASICS && !d->basics_show) cur = DT_MODULEGROUP_ACTIVE_PIPE;
-  if(cur == DT_MODULEGROUP_ACTIVE_PIPE)
+  if(d->current == DT_MODULEGROUP_BASICS ? !d->basics_show : d->current > g_list_length(d->groups))
+    d->current = DT_MODULEGROUP_ACTIVE_PIPE;
+  if(d->current == DT_MODULEGROUP_ACTIVE_PIPE)
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->active_btn), TRUE);
-  else if(cur == DT_MODULEGROUP_BASICS)
+  else if(d->current == DT_MODULEGROUP_BASICS)
   {
     if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->basic_btn)))
     {
       // we need to manually refresh the list
-      d->current = DT_MODULEGROUP_BASICS;
       _lib_modulegroups_update_iop_visibility(self);
     }
     else
@@ -2945,7 +2951,8 @@ static void _buttons_update(dt_lib_module_t *self)
   }
   else
   {
-    dt_lib_modulegroups_group_t *gr = (dt_lib_modulegroups_group_t *)g_list_nth_data(d->groups, cur - 1);
+    dt_lib_modulegroups_group_t *gr = (dt_lib_modulegroups_group_t *)g_list_nth_data(d->groups, d->current - 1);
+    d->current = DT_MODULEGROUP_NONE;
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(gr->button), TRUE);
   }
 }

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -654,12 +654,13 @@ static void _show_shortcuts_prefs(GtkWidget *w)
     gtk_window_resize(GTK_WINDOW(shortcuts_dialog), _shortcuts_dialog_posize.w, _shortcuts_dialog_posize.h);
   }
   g_signal_connect(G_OBJECT(shortcuts_dialog), "configure-event", G_CALLBACK(_resize_shortcuts_dialog), NULL);
+  gtk_widget_show_all(shortcuts_dialog); // separately show_all content later, otherwise activates first treeview
 
   //grab the content area of the dialog
   GtkWidget *content = gtk_dialog_get_content_area(GTK_DIALOG(shortcuts_dialog));
   gtk_box_pack_start(GTK_BOX(content), dt_shortcuts_prefs(w), TRUE, TRUE, 0);
+  gtk_widget_show_all(content);
 
-  gtk_widget_show_all(shortcuts_dialog);
   gtk_dialog_run(GTK_DIALOG(shortcuts_dialog));
   gtk_widget_destroy(shortcuts_dialog);
 }

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -618,26 +618,33 @@ static gboolean _resize_shortcuts_dialog(GtkWidget *widget, GdkEvent *event, gpo
 
 static void _set_mapping_mode_cursor(GtkWidget *widget)
 {
-  GdkCursorType cursor = GDK_DIAMOND_CROSS;
+  GdkDisplay *display = gdk_display_get_default();
+  GdkWindow *window = gtk_widget_get_window(dt_ui_main_window(darktable.gui->ui));
+  GdkCursor *cursor = NULL;
 
   if(GTK_IS_EVENT_BOX(widget)) widget = gtk_bin_get_child(GTK_BIN(widget));
 
   if(widget && !strcmp(gtk_widget_get_name(widget), "module-header"))
-    cursor = GDK_BASED_ARROW_DOWN;
+    cursor = gdk_cursor_new_for_display(display, GDK_BASED_ARROW_DOWN);
   else if(dt_action_widget(darktable.control->mapping_widget)
           && darktable.develop)
   {
-    switch(dt_dev_modulegroups_basics_module_toggle(darktable.develop, widget, FALSE))
-    {
-    case  1: cursor = GDK_SB_UP_ARROW; break;
-    case -1: cursor = GDK_SB_DOWN_ARROW; break;
-    default: cursor = GDK_BOX_SPIRAL;
-    }
-  }
+    guint size = gdk_display_get_default_cursor_size(display);
+    cairo_surface_t *surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, size * 1.5, size);
+    cairo_t *cr = cairo_create(surface);
 
-  dt_control_allow_change_cursor();
-  dt_control_change_cursor(cursor);
-  dt_control_forbid_change_cursor();
+    dtgtk_cairo_paint_flags_t flags = dt_dev_modulegroups_basics_module_toggle(darktable.develop, widget, FALSE);
+    dtgtk_cairo_paint_shortcut(cr, 0, 0, size, size, flags, GINT_TO_POINTER(TRUE));
+    cursor = gdk_cursor_new_from_surface(display, surface, size/2, size/2);
+    cairo_surface_destroy(surface);
+
+    gdk_window_set_cursor(window, NULL); // work around bug where gtk seems to buffer surface cursors
+  }
+  else
+    cursor = gdk_cursor_new_for_display(display, GDK_DIAMOND_CROSS);
+
+  gdk_window_set_cursor(window, cursor);
+  g_object_unref(cursor);
 }
 
 static void _show_shortcuts_prefs(GtkWidget *w)
@@ -763,6 +770,8 @@ static void _lib_keymap_button_clicked(GtkWidget *widget, gpointer user_data)
 {
   if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)))
   {
+    dt_control_forbid_change_cursor();
+    _set_mapping_mode_cursor(widget);
     gdk_event_handler_set(_main_do_event_keymap, user_data, NULL);
   }
   else

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -59,8 +59,9 @@ typedef enum dt_view_type_flags_t
   DT_VIEW_SLIDESHOW  = 1 << 4,
   DT_VIEW_PRINT      = 1 << 5,
   DT_VIEW_KNIGHT     = 1 << 6,
+  DT_VIEW_FALLBACK   = 1 << 29,
   DT_VIEW_OTHER      = 1 << 30, // for your own unpublished user view
-  DT_VIEW_ALL        = ~DT_VIEW_NONE,
+  DT_VIEW_ALL        = ~DT_VIEW_FALLBACK,
 } dt_view_type_flags_t;
 
 // flags that a view can set in flags()


### PR DESCRIPTION
I. It is now possible to disable ("delete") default shortcuts and fallbacks and have them _stay_ disabled after a restart. This is done by moving them to a separate shortcut category "disabled defaults". "deleting" them from there restores them to their active state (possibly after confirmation to overwrite any conflicting shortcuts that had been defined replacing them). The other shortcut categories ("in active view"/"in other views"/"fallbacks"/"speed adjustments") have been renamed for clarity. The _no-op_ action (which previously could be used to overwrite a default shortcut with "nothing" and thereby disable it) has been removed as it is no longer needed. This new approach works better with fallbacks; you can now define "e" as exposure and have ctrl+e make small adjustments. It also exposed a double definition of ctrl+k as both the collections "history" button and "jump back to previous collection". The latter now has been moved to ctrl+shift+k, but will still be in existing users shortcutsrc file as ctrl+k as well, so "history" will show up as a disabled default. Deleting (restoring) it from there will overwrite the double definition.
![image](https://github.com/darktable-org/darktable/assets/1549490/d7be4ea9-fe41-46ce-ac64-eb62dd9b7d46)

II. The "keyboard" icon in the shortcut mapping mode button is now also used as the mouse cursor when in mapping mode, which closes #9483. If a widget can be added to or removed from the quick access panel, a + or - is added to the mouse cursor.
![image](https://github.com/darktable-org/darktable/assets/1549490/e4101c41-5453-4376-8f01-f69d03e4ba5a)

III. A text is added to the shortcuts dialog (whether embedded in preferences or freestanding) to explain that shortcut mapping mode may be faster. Clicking on it removes so it does not permanently take up space. This may have more success being read than a tooltip or manual entry.
![image](https://github.com/darktable-org/darktable/assets/1549490/2b419d58-a7e0-4392-8cff-1be475d43751)

IV. The ability to assign separate shortcuts to an up and down move has been extended. This works with key+scroll wheel as well as mouse moves, which could be a left/right or diagonal, and gamepad joystick moves or midi encoder turns.  Previously only the same action/widget was supported (so you could already assign different dropdown items to `key+scroll up` and `key+scroll down`). Now this works for any combination of single effect shortcuts that are active in the same views. So if you assign a "command" action to a key+move shortcut, if you assign the same shortcut again (but with opposite move) to a different command, you will be asked if you want to split (and if not, if you want to overwrite). If you map a move to a slider or combo, you can change the _effect_ and then assign the opposite move to a different effect. As an example, the `b` key (which toggles the panel expander indicators) can be overloaded to toggle hiding the top/bottom/left/right side panels by moving the mouse up/down/left/right while holding the key.
![image](https://github.com/darktable-org/darktable/assets/1549490/aff467a2-e45f-4f3a-90ce-88d1b9a3fb44)

V. This always created the problem that if a key+move shortcut was assigned to a slider or combo popup, the repeating key would immediately start filling the popup. This has now been resolved by linking the bauhaus popup into the shortcut dispatcher. This means shortcuts and keys not handled by the popup, like full screen or panel hiding, will continue to work as normal. As a silly exercise you can quickly check all hue and chroma values in the color balance module even when it is hidden by pressing r and moving the mouse in a circle after defining these shortcuts:
![image](https://github.com/darktable-org/darktable/assets/1549490/047b4fd8-9ef8-4cc3-a3f6-0e03aec0077f)

VI. It also meant the bauhaus popup keyboard input had to be fixed to correctly indicate what was being handled by it. During that work I improved (imho) the filtering of combobox items when typing. Previously this only matched on the start of items (which made it less useful for multiple items starting with RGB for example). Now it matches any part of the item and only fades (rather than completely removes) unmatched items. This means group headings are still visible and makes what's going on more clear. If only one item is remaining, pressing Enter selects it. Otherwise arrow keys and scroll wheel moves between them. Pressing Enter now (re)opens the popup for a focused slider or dropdown widget, so it is quicker to make a correction or try a few different values one after another.
<img src="https://github.com/darktable-org/darktable/assets/1549490/71f570e7-4297-4322-a043-50dd9a9c065c" width="30%" height="30%"><img src="https://github.com/darktable-org/darktable/assets/1549490/779cf769-07e0-4732-940e-7bf76612f783" width="30%" height="30%"><img src="https://github.com/darktable-org/darktable/assets/1549490/ac5a3c96-aaec-4e28-ba17-b5fc2faaed25" width="30%" height="30%">

VII. Some refinements to fallbacks. For example, if a key is assigned to a specific value in a slider or combo (using _effects_), then pressing the key will select that value but holding the key and scrolling still adjusts the value as it normally would if no specific value was selected (fast or slow if shift or ctrl held).

VIII. In the darkroom, you can now switch between module groups using the scroll wheel (just like you can with other notebook tabs). This can be useful when you are in mapping mode and you want to setup shortcuts for several modules at once; clicking on a module group to find the module you want would open the shortcuts dialog.