### PR TITLE
Bump CL kernel version directory

### DIFF
--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -72,7 +72,7 @@ extern "C" {
 // version for current darktable cl kernels
 // this is reflected in the kernel directory and allows to
 // enforce a new kernel compilation cycle
-#define DT_OPENCL_KERNELS 1
+#define DT_OPENCL_KERNELS 2
 
 typedef enum dt_opencl_memory_t
 {


### PR DESCRIPTION
After lately changing cl kernels we should enforce user installations to update the cl kernels without further user actions.