### PR TITLE
Collapsible section for lens fine-tuning and hide blend fulcrum

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -729,13 +729,13 @@ static void _blendop_blend_mode_callback(GtkWidget *combo,
 
     if(_blendif_blend_parameter_enabled(data->blend_modes_csp, bp->blend_mode))
     {
-      gtk_widget_set_sensitive(data->blend_mode_parameter_slider, TRUE);
+      gtk_widget_show(data->blend_mode_parameter_slider);
     }
     else
     {
       bp->blend_parameter = 0.0f;
       dt_bauhaus_slider_set(data->blend_mode_parameter_slider, bp->blend_parameter);
-      gtk_widget_set_sensitive(data->blend_mode_parameter_slider, FALSE);
+      gtk_widget_hide(data->blend_mode_parameter_slider);
     }
     dt_dev_add_history_item(darktable.develop, data->module, TRUE);
   }
@@ -3193,12 +3193,10 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
 
   dt_bauhaus_slider_set(bd->blend_mode_parameter_slider,
                         module->blend_params->blend_parameter);
-  gtk_widget_set_sensitive
+  gtk_widget_set_visible
     (bd->blend_mode_parameter_slider,
      _blendif_blend_parameter_enabled(bd->blend_modes_csp,
                                       module->blend_params->blend_mode));
-  gtk_widget_set_visible(bd->blend_mode_parameter_slider,
-                         bd->blend_modes_csp == DEVELOP_BLEND_CS_RGB_SCENE);
 
   dt_bauhaus_combobox_set_from_value
     (bd->masks_combine_combo,


### PR DESCRIPTION
Combined PR for two ui consistency improvements:
- create a collapsible section for lens correction fine-tuning parameters. And also put them, and the manual vignette correction parameters, in their own sections for action and history.
![image](https://github.com/darktable-org/darktable/assets/1549490/061a8d88-c94b-47d8-bde4-9fee16dd0d69)
- hide the blend fulcrum slider, like is done everywhere else in the ui when a widget is not applicable, rather than just making it insensitive . 