### PR TITLE
Simplify the fast mask blurring code

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -825,7 +825,7 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self,
   if(err != CL_SUCCESS) goto error;
 
   float blurmat[13];
-  dt_masks_blur_9x9_coeff(blurmat, 2.0f);
+  dt_masks_blur_coeff(blurmat, 2.0f);
   cl_mem dev_blurmat = dt_opencl_copy_host_to_device_constant(devid, sizeof(blurmat), blurmat);
   if(dev_blurmat != NULL)
   {

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -668,12 +668,14 @@ void dt_masks_extend_border(float *const mask,
                             const int width,
                             const int height,
                             const int border);
-void dt_masks_blur_9x9_coeff(float *coeffs, const float sigma);
-void dt_masks_blur_9x9(float *const src,
+void dt_masks_blur_coeff(float *coeffs, const float sigma);
+void dt_masks_blur(float *const src,
                        float *const out,
                        const int width,
                        const int height,
-                       const float sigma);
+                       const float sigma,
+                       const float gain,
+                       const float clip);
 gboolean dt_masks_calc_rawdetail_mask(dt_dev_detail_mask_t *details,
                                   float *const src,
                                   const dt_aligned_pixel_t wb);
@@ -681,16 +683,6 @@ gboolean dt_masks_calc_detail_mask(dt_dev_detail_mask_t *details,
                                float *const out,
                                const float threshold,
                                const gboolean detail);
-
-/** the output data are blurred-val * gain and are clipped to be within 0 to clip
-    The returned int might be used to expand the border as this depends on sigma */
-int dt_masks_blur_fast(float *const src,
-                       float *const out,
-                       const int width,
-                       const int height,
-                       const float sigma,
-                       const float gain,
-                       const float clip);
 
 /** return the list of possible mouse actions */
 GSList *dt_masks_mouse_actions(dt_masks_form_t *form);

--- a/src/iop/demosaicing/dual.c
+++ b/src/iop/demosaicing/dual.c
@@ -138,7 +138,7 @@ gboolean dual_demosaic_cl(
   if(err != CL_SUCCESS) goto finish;
 
   float blurmat[13];
-  dt_masks_blur_9x9_coeff(blurmat, 2.0f);
+  dt_masks_blur_coeff(blurmat, 2.0f);
   dev_blurmat = dt_opencl_copy_host_to_device_constant(devid, sizeof(blurmat), blurmat);
 
   err = dt_opencl_enqueue_kernel_2d_args(devid, darktable.opencl->blendop->kernel_mask_blur, width, height,

--- a/src/iop/hlreconstruct/segbased.c
+++ b/src/iop/hlreconstruct/segbased.c
@@ -664,7 +664,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece,
       }
     }
     dt_masks_extend_border(tmp, pwidth, pheight, segall->border);
-    dt_masks_blur_fast(tmp, luminance, pwidth, pheight, 1.2f, 1.0f, 20.0f);
+    dt_masks_blur(tmp, luminance, pwidth, pheight, 1.2f, 1.0f, 20.0f);
     dt_masks_extend_border(luminance, pwidth, pheight, segall->border);
   }
 
@@ -686,7 +686,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece,
           _segment_gradients(distance, recout, tmp, recovery_mode, segall, id, recovery_close);
       }
 
-      dt_masks_blur_fast(recout, gradient, pwidth, pheight, 1.2f, 1.0f, 20.0f);
+      dt_masks_blur(recout, gradient, pwidth, pheight, 1.2f, 1.0f, 20.0f);
       // possibly add some noise
       const float noise_level = data->noise_level;
       if(noise_level > 0.0f)


### PR DESCRIPTION
As we don't require large sigmas in the fast gaussian blurring mask code, some code parts could be removed.