### PR TITLE
Redesign of dt_iop_copy_image_roi() - bugfix

### DIFF
--- a/src/common/imagebuf.h
+++ b/src/common/imagebuf.h
@@ -107,15 +107,14 @@ static inline void dt_iop_image_copy_by_size(float *const __restrict__ out,
 
 // Copy an image buffer, specifying the region of interest.  The
 // output RoI may be larger than the input RoI, in which case the
-// result is optionally padded with zeros.  If the output RoI is
-// smaller than the input RoI, only a portion of the input buffer will
-// be copied.
+// result is padded with zeros.
+// If the output RoI is smaller than the input RoI, only a portion of
+// the input buffer will be copied.
 void dt_iop_copy_image_roi(float *const __restrict__ out,
                            const float *const __restrict__ in,
                            const size_t ch,
                            const dt_iop_roi_t *const __restrict__ roi_in,
-                           const dt_iop_roi_t *const __restrict__ roi_out,
-                           const int zero_pad);
+                           const dt_iop_roi_t *const __restrict__ roi_out);
 
 // Copy one image buffer to another, multiplying each element by the
 // specified scale factor

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -664,7 +664,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self,
           float *const restrict guide = dt_alloc_align_float(obuffsize * ch);
           if(guide)
           {
-            dt_iop_copy_image_roi(guide, (float *restrict)ivoid, ch, roi_in, roi_out, 0);
+            dt_iop_copy_image_roi(guide, (float *restrict)ivoid, ch, roi_in, roi_out);
             _develop_blend_process_feather(guide, mask, owidth, oheight, ch, guide_weight,
                                            d->feathering_radius,
                                            roi_out->scale / piece->iscale);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -3543,7 +3543,7 @@ gboolean dt_iop_have_required_input_format(const int req_ch,
   else
   {
     // copy the input buffer to the output
-    dt_iop_copy_image_roi(ovoid, ivoid, ch, roi_in, roi_out, TRUE);
+    dt_iop_copy_image_roi(ovoid, ivoid, ch, roi_in, roi_out);
     // and set the module's trouble message
     if(module)
       dt_iop_set_module_trouble_message

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -302,7 +302,7 @@ static void process_wavelets(struct dt_iop_module_t *self,
 
   if(!dt_iop_alloc_image_buffers(self, roi_in, roi_out, 4, &tmp, 4, &tmp2, 0))
   {
-    dt_iop_copy_image_roi(out, i, piece->colors, roi_in, roi_out, TRUE);
+    dt_iop_copy_image_roi(out, i, piece->colors, roi_in, roi_out);
     return;
   }
 

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1271,7 +1271,7 @@ void process_fusion(struct dt_iop_module_t *self,
     comb[k] = dt_alloc_align_float((size_t)4 * w * h);
     if(!col[k] || !comb[k])
     {
-      dt_iop_copy_image_roi(ovoid, ivoid, piece->colors, roi_in, roi_out, 0);
+      dt_iop_copy_image_roi(ovoid, ivoid, piece->colors, roi_in, roi_out);
       dt_print(DT_DEBUG_ALWAYS,"[basecurve] process_fusion out of memory, skipping\n");
       goto cleanup;
     }

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -114,7 +114,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   if(!dt_iop_alloc_image_buffers(self, roi_in, roi_out, 1, &blurlightness, 0))
   {
     // out of memory, so just copy image through to output
-    dt_iop_copy_image_roi(ovoid, ivoid, piece->colors, roi_in, roi_out, TRUE);
+    dt_iop_copy_image_roi(ovoid, ivoid, piece->colors, roi_in, roi_out);
     return;
   }
 

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -270,7 +270,7 @@ void process(
   float *out = dt_alloc_align_float(roi_in->width * roi_in->height);
   if(!out)
   {
-    dt_iop_copy_image_roi(ovoid, ivoid, piece->colors, roi_in, roi_out, 0);
+    dt_iop_copy_image_roi(ovoid, ivoid, piece->colors, roi_in, roi_out);
     dt_print(DT_DEBUG_ALWAYS,"[cacorrect] out of memory, skipping\n");
     return;
   }
@@ -1285,7 +1285,7 @@ void process(
 #endif
   for(size_t row = 0; row < roi_out->height; row++)
   {
-    for(size_t col = 0; col < roi_out->width; col++) 
+    for(size_t col = 0; col < roi_out->width; col++)
     {
       const size_t ox = row * roi_out->width + col;
       const size_t irow = row + roi_out->y;
@@ -1336,7 +1336,7 @@ void distort_mask(
         const dt_iop_roi_t *const roi_in,
         const dt_iop_roi_t *const roi_out)
 {
-  dt_iop_copy_image_roi(out, in, 1, roi_in, roi_out, TRUE);
+  dt_iop_copy_image_roi(out, in, 1, roi_in, roi_out);
 }
 
 void reload_defaults(dt_iop_module_t *module)

--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -145,7 +145,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
                                  4 | DT_IMGSZ_INPUT, &temp,
                                  0, NULL))
   {
-    dt_iop_copy_image_roi(ovoid, ivoid, piece->colors, roi_in, roi_out, 0);
+    dt_iop_copy_image_roi(ovoid, ivoid, piece->colors, roi_in, roi_out);
     return;
   }
   dt_iop_censorize_data_t *data = (dt_iop_censorize_data_t *)piece->data;

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -338,7 +338,7 @@ void distort_mask(struct dt_iop_module_t *self,
                   const dt_iop_roi_t *const roi_in,
                   const dt_iop_roi_t *const roi_out)
 {
-  dt_iop_copy_image_roi(out, in, 1, roi_in, roi_out, TRUE);
+  dt_iop_copy_image_roi(out, in, 1, roi_in, roi_out);
 }
 
 // 1st pass: how large would the output be, given this input roi?
@@ -389,7 +389,7 @@ void process(struct dt_iop_module_t *self,
              const dt_iop_roi_t *const roi_in,
              const dt_iop_roi_t *const roi_out)
 {
-  dt_iop_copy_image_roi(ovoid, ivoid, 4, roi_in, roi_out, TRUE);
+  dt_iop_copy_image_roi(ovoid, ivoid, 4, roi_in, roi_out);
 }
 
 #ifdef HAVE_OPENCL

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1411,7 +1411,7 @@ static void process_wavelets(struct dt_iop_module_t *self,
 
   if(!dt_iop_alloc_image_buffers(self, roi_in, roi_out, 4, &precond, 4, &tmp, 4, &buf, 0))
   {
-    dt_iop_copy_image_roi(out, in, piece->colors, roi_in, roi_out, TRUE);
+    dt_iop_copy_image_roi(out, in, piece->colors, roi_in, roi_out);
     return;
   }
 

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1337,7 +1337,7 @@ void process(dt_iop_module_t *self,
   if(fastmode)
   {
     const size_t ch = piece->colors;
-    dt_iop_copy_image_roi(ovoid, ivoid, ch, roi_in, roi_out, TRUE);
+    dt_iop_copy_image_roi(ovoid, ivoid, ch, roi_in, roi_out);
     return;
   }
 
@@ -1362,7 +1362,7 @@ void process(dt_iop_module_t *self,
                                  0, NULL))
   {
     dt_print(DT_DEBUG_ALWAYS,"[diffuse] out of memory, skipping\n");
-    dt_iop_copy_image_roi(ovoid, ivoid, piece->colors, roi_in, roi_out, 0);
+    dt_iop_copy_image_roi(ovoid, ivoid, piece->colors, roi_in, roi_out);
     return;
   }
   const float scale = fmaxf(piece->iscale / roi_in->scale, 1.f);

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -285,7 +285,7 @@ void distort_mask(
         const dt_iop_roi_t *const roi_in,
         const dt_iop_roi_t *const roi_out)
 {
-  dt_iop_copy_image_roi(out, in, 1, roi_in, roi_out, TRUE);
+  dt_iop_copy_image_roi(out, in, 1, roi_in, roi_out);
 }
 
 /* inpaint opposed and segmentation based algorithms want the whole image for proper calculation

--- a/src/iop/hlreconstruct/laplacian.c
+++ b/src/iop/hlreconstruct/laplacian.c
@@ -637,7 +637,7 @@ static void process_laplacian_bayer(struct dt_iop_module_t *self,
                                  4 | DT_IMGSZ_INPUT, &clipping_mask,
                                  0, NULL))
   {
-    dt_iop_copy_image_roi(ovoid, ivoid, piece->colors, roi_in, roi_out, 0);
+    dt_iop_copy_image_roi(ovoid, ivoid, piece->colors, roi_in, roi_out);
     return;
   }
 
@@ -653,7 +653,7 @@ static void process_laplacian_bayer(struct dt_iop_module_t *self,
   {
     dt_free_align(interpolated);
     dt_free_align(clipping_mask);
-    dt_iop_copy_image_roi(ovoid, ivoid, piece->colors, roi_in, roi_out, 0);
+    dt_iop_copy_image_roi(ovoid, ivoid, piece->colors, roi_in, roi_out);
     return;
   }
 

--- a/src/iop/hlreconstruct/opposed.c
+++ b/src/iop/hlreconstruct/opposed.c
@@ -32,7 +32,7 @@
    Failures of the algorithm (color casts) are in most cases related to
     a) very large differences between optimal white balance coefficients vs what we have as D65 in the darktable pipeline
     b) complicated lightings so the gradients are not well related
-    c) a wrong whitepoint setting in the rawprepare module. 
+    c) a wrong whitepoint setting in the rawprepare module.
     d) the maths might not be best
 
    Again the algorithm has been developed in collaboration by @garagecoder and @Iain from gmic team and @jenshannoschwalm from dt.
@@ -124,7 +124,7 @@ static void _process_linear_opposed(
   const dt_aligned_pixel_t icoeffs = { wbon ? dsc->temperature.coeffs[0] : 1.0f,
                                        wbon ? dsc->temperature.coeffs[1] : 1.0f,
                                        wbon ? dsc->temperature.coeffs[2] : 1.0f};
-  const dt_aligned_pixel_t clips = { clipval * icoeffs[0], clipval * icoeffs[1], clipval * icoeffs[2]}; 
+  const dt_aligned_pixel_t clips = { clipval * icoeffs[0], clipval * icoeffs[1], clipval * icoeffs[2]};
 
   const size_t mwidth  = roi_in->width / 3;
   const size_t mheight = roi_in->height / 3;
@@ -151,7 +151,7 @@ static void _process_linear_opposed(
       for(size_t col = 1; col < roi_in->width -1; col++)
       {
         const size_t idx = (row * roi_in->width + col) * 4;
-        const size_t mdx = _raw_to_cmap(mwidth, row, col); 
+        const size_t mdx = _raw_to_cmap(mwidth, row, col);
         for_three_channels(c)
         {
           if((input[idx] >= clips[c]) && (mask[c*msize + mdx] == 0))
@@ -201,7 +201,7 @@ static void _process_linear_opposed(
           const size_t idx = (row * roi_in->width + col) * 4;
           for_three_channels(c)
           {
-            const float inval = input[idx+c]; 
+            const float inval = input[idx+c];
             if((inval > 0.2f * clips[c]) && (inval < clips[c]) && (mask[(c+3) * msize + _raw_to_cmap(mwidth, row, col)]))
             {
               sums[c] += inval - _calc_linear_refavg(&input[idx], c);
@@ -272,7 +272,7 @@ static float *_process_opposed(
       chrominance[c] = img_oppchroma[c];
     if(!img_oppclipped && !keep)
     {
-      dt_iop_copy_image_roi(output, input, 1, roi_in, roi_out, 0);
+      dt_iop_copy_image_roi(output, input, 1, roi_in, roi_out);
       return NULL;
     }
   }
@@ -320,7 +320,7 @@ static float *_process_opposed(
         /* We want to use the photosites closely around clipped data to be taken into account.
          The mask buffers holds data for each color channel, we dilate the mask buffer slightly
          to get those locations.
-         If there are no clipped locations we keep the chrominance correction at 0 but make it valid 
+         If there are no clipped locations we keep the chrominance correction at 0 but make it valid
         */
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
@@ -339,7 +339,7 @@ static float *_process_opposed(
         }
 
         const dt_aligned_pixel_t lo_clips = { 0.2f * clips[0], 0.2f * clips[1], 0.2f * clips[2], 1.0f };
-       /* After having the surrounding mask for each color channel we can calculate the chrominance corrections. */ 
+       /* After having the surrounding mask for each color channel we can calculate the chrominance corrections. */
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(input, roi_in, xtrans, clips, lo_clips, mask, filters, msize, mwidth) \
@@ -352,7 +352,7 @@ static float *_process_opposed(
           {
             const size_t idx = row * roi_in->width + col;
             const int color = (filters == 9u) ? FCxtrans(row, col, roi_in, xtrans) : FC(row, col, filters);
-            const float inval = input[idx]; 
+            const float inval = input[idx];
 
             /* we only use the unclipped photosites very close the true clipped data to calculate the chrominance offset */
             if((inval < clips[color]) && (inval > lo_clips[color])
@@ -418,7 +418,7 @@ static float *_process_opposed(
 #endif
   for(size_t row = 0; row < roi_out->height; row++)
   {
-    for(size_t col = 0; col < roi_out->width; col++) 
+    for(size_t col = 0; col < roi_out->width; col++)
     {
       const size_t odx = row * roi_out->width + col;
       const size_t irow = row + roi_out->y;
@@ -430,7 +430,7 @@ static float *_process_opposed(
         if(tmpout)
           oval = tmpout[ix];
         else
-        { 
+        {
           const int color = (filters == 9u) ? FCxtrans(irow, icol, roi_in, xtrans) : FC(irow, icol, filters);
           oval = MAX(0.0f, input[ix]);
           if(oval >= clips[color])
@@ -543,7 +543,7 @@ static cl_int process_opposed_cl(
             CLARG(dev_in), CLARG(dev_outmask), CLARG(dev_accu),
             CLARG(roi_in->width), CLARG(roi_in->height),
             CLARG(msize), CLARG(mwidth),
-            CLARG(filters), CLARG(dev_xtrans), CLARG(dev_clips)); 
+            CLARG(filters), CLARG(dev_xtrans), CLARG(dev_clips));
 
     err = dt_opencl_enqueue_kernel_ndim_with_local(devid, gd->kernel_highlights_chroma, sizes, NULL, 1);
     if(err != CL_SUCCESS) goto error;

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2642,7 +2642,7 @@ static void _process_md(struct dt_iop_module_t *self,
   dt_iop_lens_data_t *d = (dt_iop_lens_data_t *)piece->data;
 
   if(!d->nc || d->modify_flags == DT_IOP_LENS_MODFLAG_NONE)
-    return dt_iop_copy_image_roi((float *)ovoid, (float *)ivoid, 4, roi_in, roi_out, TRUE);
+    return dt_iop_copy_image_roi((float *)ovoid, (float *)ivoid, 4, roi_in, roi_out);
 
   const float inv_scale_md = 1.0f / d->scale_md;
   const float w2 = 0.5f * roi_in->scale * piece->buf_in.width;

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1421,7 +1421,7 @@ void distort_mask(struct dt_iop_module_t *self,
                   const dt_iop_roi_t *const roi_out)
 {
   // 1. copy the whole image (we'll change only a small part of it)
-  dt_iop_copy_image_roi(out, in, 1, roi_in, roi_out, 1);
+  dt_iop_copy_image_roi(out, in, 1, roi_in, roi_out);
 
   // 2. build the distortion map
   cairo_rectangle_int_t map_extent;
@@ -1454,7 +1454,7 @@ void process(struct dt_iop_module_t *module,
                                         in, out, roi_in, roi_out))
     return;
   // 1. copy the whole image (we'll change only a small part of it)
-  dt_iop_copy_image_roi(out, in, piece->colors, roi_in, roi_out, 1);
+  dt_iop_copy_image_roi(out, in, piece->colors, roi_in, roi_out);
 
   // 2. build the distortion map
   cairo_rectangle_int_t map_extent;

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -404,7 +404,7 @@ void process(struct dt_iop_module_t *self,
     dt_gaussian_t *g = dt_gaussian_init(width, height, 4, Labmax, Labmin, sigma, order);
     if(!g)
     {
-      dt_iop_copy_image_roi(out, in, piece->colors, roi_in, roi_out, TRUE);
+      dt_iop_copy_image_roi(out, in, piece->colors, roi_in, roi_out);
       return;
     }
     dt_gaussian_blur_4c(g, in, out);
@@ -419,7 +419,7 @@ void process(struct dt_iop_module_t *self,
     dt_bilateral_t *b = dt_bilateral_init(width, height, sigma_s, sigma_r);
     if(!b)
     {
-      dt_iop_copy_image_roi(out, in, piece->colors, roi_in, roi_out, TRUE);
+      dt_iop_copy_image_roi(out, in, piece->colors, roi_in, roi_out);
       return;
     }
     dt_bilateral_splat(b, in);

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -128,7 +128,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   float *restrict img_tmp = NULL;
   if(!dt_iop_alloc_image_buffers(self, roi_in, roi_out, ch, &img_tmp, 0))
   {
-    dt_iop_copy_image_roi(ovoid, ivoid, ch, roi_in, roi_out, TRUE);
+    dt_iop_copy_image_roi(ovoid, ivoid, ch, roi_in, roi_out);
     dt_control_log(_("module overexposed failed in buffer allocation"));
     return;
   }
@@ -154,7 +154,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   else
   {
     dt_print(DT_DEBUG_ALWAYS, "[overexposed process] can't create transform profile\n");
-    dt_iop_copy_image_roi(ovoid, ivoid, ch, roi_in, roi_out, TRUE);
+    dt_iop_copy_image_roi(ovoid, ivoid, ch, roi_in, roi_out);
     dt_control_log(_("module overexposed failed in color conversion"));
     goto process_finish;
   }

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -258,7 +258,7 @@ void distort_mask(
         const dt_iop_roi_t *const roi_in,
         const dt_iop_roi_t *const roi_out)
 {
-  dt_iop_copy_image_roi(out, in, 1, roi_in, roi_out, TRUE);
+  dt_iop_copy_image_roi(out, in, 1, roi_in, roi_out);
 }
 
 // we're not scaling here (bayer input), so just crop borders

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -148,7 +148,7 @@ void distort_mask(
         const dt_iop_roi_t *const roi_in,
         const dt_iop_roi_t *const roi_out)
 {
-  dt_iop_copy_image_roi(out, in, 1, roi_in, roi_out, TRUE);
+  dt_iop_copy_image_roi(out, in, 1, roi_in, roi_out);
 }
 
 void modify_roi_out(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t *roi_out,

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -291,7 +291,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
                                   1 | DT_IMGSZ_WIDTH | DT_IMGSZ_PERTHREAD, &tmp, &padded_size,
                                   0))
   {
-    dt_iop_copy_image_roi(ovoid, ivoid, 4, roi_in, roi_out, TRUE);
+    dt_iop_copy_image_roi(ovoid, ivoid, 4, roi_in, roi_out);
     return;
   }
 
@@ -305,7 +305,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   if(!mat)
   {
     dt_print(DT_DEBUG_ALWAYS,"[sharpen] out of memory\n");
-    dt_iop_copy_image_roi(ovoid, ivoid, 4, roi_in, roi_out, TRUE);
+    dt_iop_copy_image_roi(ovoid, ivoid, 4, roi_in, roi_out);
     return;
   }
   const float *const restrict in = (float*)ivoid;

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -570,7 +570,7 @@ void _process(struct dt_iop_module_t *self,
   dt_develop_blend_params_t *bp = piece->blendop_data;
 
 // we don't modify most of the image:
-  dt_iop_copy_image_roi(out, in, ch, roi_in, roi_out, 0);
+  dt_iop_copy_image_roi(out, in, ch, roi_in, roi_out);
 
   // iterate through all forms
   dt_masks_form_t *grp = dt_masks_get_from_id_ext(piece->pipe->forms, bp->mask_id);

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -204,7 +204,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
 
 #if 0
 /** optional, always needed if tiling is permitted by setting IOP_FLAGS_ALLOW_TILING
-    Also define this if the module uses more memory on the OpenCl device than the in& output buffers. 
+    Also define this if the module uses more memory on the OpenCl device than the in& output buffers.
 */
 void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                      const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
@@ -318,7 +318,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       // been allocated have been freed, and the module's trouble flag has been set.  We can simply pass
       // through the input image and return now, since there isn't anything else we need to clean up at
       // this point.
-      dt_iop_copy_image_roi(ovoid, ivoid, ch, roi_in, roi_out, TRUE);
+      dt_iop_copy_image_roi(ovoid, ivoid, ch, roi_in, roi_out);
       return;
     }
   }


### PR DESCRIPTION
We don't require - don't want - the padding zero flag in this function as we always want to make data written do data of roi_out avoiding uninitilized data like NaN in out.

All data with no according data in roi_in data are filled with zero.

Fixes #15019

Follows #15029