### PR TITLE
imageop: Also rebuild pixelpipe for operation_tags_filter.

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2171,7 +2171,10 @@ void dt_iop_request_focus(dt_iop_module_t *module)
                                GTK_STATE_FLAG_NORMAL, TRUE);
 
     if(out_focus_module->operation_tags_filter())
+    {
       dt_dev_invalidate_all(darktable.develop);
+      dt_dev_pixelpipe_rebuild(darktable.develop);
+    }
 
     dt_iop_connect_accels_multi(out_focus_module->so);
 
@@ -2199,7 +2202,10 @@ void dt_iop_request_focus(dt_iop_module_t *module)
                                GTK_STATE_FLAG_SELECTED, TRUE);
 
     if(module->operation_tags_filter())
+    {
       dt_dev_invalidate_all(darktable.develop);
+      dt_dev_pixelpipe_rebuild(darktable.develop);
+    }
 
     dt_iop_connect_accels_multi(module->so);
 


### PR DESCRIPTION
Fixes #15036.