### PR TITLE
support incremental update of iop legacy params

### DIFF
--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -826,15 +826,11 @@ void dt_styles_apply_style_item(dt_develop_t *dev,
              || module->params_size != style_item->params_size
              || strcmp(style_item->operation, module->op)))
       {
-        int legacy_ret = 1;
-
-        if(module->legacy_params)
-          legacy_ret =
-            module->legacy_params(module, style_item->params,
-                                  labs(style_item->module_version),
-                                  module->params, labs(module->version()));
-        else
-          legacy_ret = 0;
+        const int legacy_ret =
+          dt_iop_legacy_params
+          (module,
+           style_item->params, style_item->params_size, style_item->module_version,
+           &module->params, module->version());
 
         if(legacy_ret == 1)
         {

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2398,9 +2398,8 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
     }
     else
     {
-      if(!hist->module->legacy_params
-         || hist->module->legacy_params(hist->module, module_params, labs(modversion),
-                                        hist->params, labs(hist->module->version())) == 1)
+      if(dt_iop_legacy_params(hist->module, module_params, modversion,
+                              hist->params, hist->module->version()) == 1)
       {
         dt_print(DT_DEBUG_ALWAYS,
                  "[dev_read_history] module `%s' version mismatch: history"

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2398,8 +2398,10 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
     }
     else
     {
-      if(dt_iop_legacy_params(hist->module, module_params, modversion,
-                              hist->params, hist->module->version()) == 1)
+      if(dt_iop_legacy_params
+         (hist->module,
+          module_params, param_length, modversion,
+          &hist->params, hist->module->version()) == 1)
       {
         dt_print(DT_DEBUG_ALWAYS,
                  "[dev_read_history] module `%s' version mismatch: history"

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1330,6 +1330,27 @@ void dt_iop_cleanup_histogram(gpointer data, gpointer user_data)
   module->histogram_stats.pixels = 0;
 }
 
+int dt_iop_legacy_params(dt_iop_module_t *module,
+                         const void *const old_params,
+                         const int old_version,
+                         void *new_params,
+                         const int new_version)
+{
+  int ret = 0;
+
+  if(module->legacy_params)
+  {
+    ret = module->legacy_params(module, old_params, old_version,
+                                new_params, new_version);
+  }
+  else
+  {
+    ret = 1;
+  }
+
+  return ret;
+}
+
 static void _init_presets(dt_iop_module_so_t *module_so)
 {
   if(module_so->init_presets)
@@ -1434,8 +1455,8 @@ static void _init_presets(dt_iop_module_so_t *module_so)
       {
         // convert the old params to new
         const int legacy_ret =
-          module->legacy_params(module, old_params, old_params_version,
-                                new_params, module_version);
+          dt_iop_legacy_params(module, old_params, old_params_version,
+                               new_params, module_version);
 
         if(legacy_ret == 1)
         {
@@ -1445,7 +1466,7 @@ static void _init_presets(dt_iop_module_so_t *module_so)
           free(module);
           continue;
         }
-        else if (legacy_ret == -1)
+        else if(legacy_ret == -1)
           auto_init = TRUE;
       }
       else

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1332,23 +1332,54 @@ void dt_iop_cleanup_histogram(gpointer data, gpointer user_data)
 
 int dt_iop_legacy_params(dt_iop_module_t *module,
                          const void *const old_params,
+                         const int32_t old_params_size,
                          const int old_version,
-                         void *new_params,
-                         const int new_version)
+                         void **new_params,
+                         int new_version)
 {
   int ret = 0;
+  gboolean auto_init = FALSE;
 
   if(module->legacy_params)
   {
-    ret = module->legacy_params(module, old_params, old_version,
-                                new_params, new_version);
+    int cversion = old_version;
+    void *oparams = malloc(old_params_size);
+    memcpy(oparams, old_params, old_params_size);
+    void *params = NULL;
+    int version = new_version;
+    int32_t params_size = 0;
+
+    while(cversion < new_version)
+    {
+      params = NULL;
+      ret = module->legacy_params(module, oparams, cversion,
+                                  &params, &params_size, &version);
+
+      if(ret == 1)
+      {
+        free(oparams);
+        return ret;
+      }
+      if(ret == -1)
+        auto_init = TRUE;
+
+      cversion = version;
+      free(oparams);
+      oparams = params;
+    }
+
+    if(params)
+    {
+      memcpy(*new_params, params, params_size);
+      free(params);
+    }
   }
   else
   {
     ret = 1;
   }
 
-  return ret;
+  return auto_init ? -1 : ret;
 }
 
 static void _init_presets(dt_iop_module_so_t *module_so)
@@ -1455,8 +1486,8 @@ static void _init_presets(dt_iop_module_so_t *module_so)
       {
         // convert the old params to new
         const int legacy_ret =
-          dt_iop_legacy_params(module, old_params, old_params_version,
-                               new_params, module_version);
+          dt_iop_legacy_params(module, old_params, old_params_size, old_params_version,
+                               &new_params, module_version);
 
         if(legacy_ret == 1)
         {
@@ -1475,8 +1506,8 @@ static void _init_presets(dt_iop_module_so_t *module_so)
       dt_print(DT_DEBUG_ALWAYS,
                "[imageop_init_presets] updating '%s' preset '%s'"
                " from version %d to version %d\nto:'%s'",
-              module_so->op, name, old_params_version, module_version,
-              dt_exif_xmp_encode(new_params, new_params_size, NULL));
+               module_so->op, name, old_params_version, module_version,
+               dt_exif_xmp_encode(new_params, new_params_size, NULL));
 
       // and write the new params back to the database
       sqlite3_stmt *stmt2;

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -349,6 +349,12 @@ gboolean dt_iop_load_module(dt_iop_module_t *module,
                        struct dt_develop_t *dev);
 /** calls module->cleanup and closes the dl connection. */
 void dt_iop_cleanup_module(dt_iop_module_t *module);
+/** migrate legacy params */
+int dt_iop_legacy_params(dt_iop_module_t *module,
+                         const void *const old_params,
+                         const int old_version,
+                         void *new_params,
+                         const int new_version);
 /** initialize pipe. */
 void dt_iop_init_pipe(struct dt_iop_module_t *module,
                       struct dt_dev_pixelpipe_t *pipe,

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -352,9 +352,10 @@ void dt_iop_cleanup_module(dt_iop_module_t *module);
 /** migrate legacy params */
 int dt_iop_legacy_params(dt_iop_module_t *module,
                          const void *const old_params,
+                         const int32_t old_params_size,
                          const int old_version,
-                         void *new_params,
-                         const int new_version);
+                         void **new_params,
+                         int new_version);
 /** initialize pipe. */
 void dt_iop_init_pipe(struct dt_iop_module_t *module,
                       struct dt_dev_pixelpipe_t *pipe,

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -460,43 +460,70 @@ typedef struct dt_iop_ashift_global_data_t
 int legacy_params(dt_iop_module_t *self,
                   const void *const old_params,
                   const int old_version,
-                  void *new_params,
-                  const int new_version)
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 1 && new_version == 5)
+  typedef struct dt_iop_ashift_params_v5_t
   {
-    typedef struct dt_iop_ashift_params1_t
+    float rotation;
+    float lensshift_v;
+    float lensshift_h;
+    float shear;
+    float f_length;
+    float crop_factor;
+    float orthocorr;
+    float aspect;
+    dt_iop_ashift_mode_t mode;
+    dt_iop_ashift_crop_t cropmode;
+    float cl;
+    float cr;
+    float ct;
+    float cb;
+    float last_drawn_lines[MAX_SAVED_LINES * 4];
+    int last_drawn_lines_count;
+    float last_quad_lines[8];
+  } dt_iop_ashift_params_v5_t;
+
+  if(old_version == 1)
+  {
+    typedef struct dt_iop_ashift_params_v1_t
     {
       float rotation;
       float lensshift_v;
       float lensshift_h;
       int toggle;
-    } dt_iop_ashift_params1_t;
+    } dt_iop_ashift_params_v1_t;
 
-    const dt_iop_ashift_params1_t *old = old_params;
-    dt_iop_ashift_params_t *new = new_params;
-    new->rotation = old->rotation;
-    new->lensshift_v = old->lensshift_v;
-    new->lensshift_h = old->lensshift_h;
-    new->shear = 0.0f;
-    new->f_length = DEFAULT_F_LENGTH;
-    new->crop_factor = 1.0f;
-    new->orthocorr = 100.0f;
-    new->aspect = 1.0f;
-    new->mode = ASHIFT_MODE_GENERIC;
-    new->cropmode = ASHIFT_CROP_OFF;
-    new->cl = 0.0f;
-    new->cr = 1.0f;
-    new->ct = 0.0f;
-    new->cb = 1.0f;
-    for(int i = 0; i < MAX_SAVED_LINES * 4; i++) new->last_drawn_lines[i] = 0.0f;
-    for(int i = 0; i < 8; i++) new->last_quad_lines[i] = 0.0f;
-    new->last_drawn_lines_count = 0;
+    const dt_iop_ashift_params_v1_t *o = old_params;
+    dt_iop_ashift_params_v5_t *n =
+      (dt_iop_ashift_params_v5_t *)malloc(sizeof(dt_iop_ashift_params_v5_t));
+    n->rotation = o->rotation;
+    n->lensshift_v = o->lensshift_v;
+    n->lensshift_h = o->lensshift_h;
+    n->shear = 0.0f;
+    n->f_length = DEFAULT_F_LENGTH;
+    n->crop_factor = 1.0f;
+    n->orthocorr = 100.0f;
+    n->aspect = 1.0f;
+    n->mode = ASHIFT_MODE_GENERIC;
+    n->cropmode = ASHIFT_CROP_OFF;
+    n->cl = 0.0f;
+    n->cr = 1.0f;
+    n->ct = 0.0f;
+    n->cb = 1.0f;
+    for(int i = 0; i < MAX_SAVED_LINES * 4; i++) n->last_drawn_lines[i] = 0.0f;
+    for(int i = 0; i < 8; i++) n->last_quad_lines[i] = 0.0f;
+    n->last_drawn_lines_count = 0;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_ashift_params_v5_t);
+    *new_version = 5;
     return 0;
   }
-  if(old_version == 2 && new_version == 5)
+  if(old_version == 2)
   {
-    typedef struct dt_iop_ashift_params2_t
+    typedef struct dt_iop_ashift_params_v2_t
     {
       float rotation;
       float lensshift_v;
@@ -507,32 +534,37 @@ int legacy_params(dt_iop_module_t *self,
       float aspect;
       dt_iop_ashift_mode_t mode;
       int toggle;
-    } dt_iop_ashift_params2_t;
+    } dt_iop_ashift_params_v2_t;
 
-    const dt_iop_ashift_params2_t *old = old_params;
-    dt_iop_ashift_params_t *new = new_params;
-    new->rotation = old->rotation;
-    new->lensshift_v = old->lensshift_v;
-    new->lensshift_h = old->lensshift_h;
-    new->shear = 0.0f;
-    new->f_length = old->f_length;
-    new->crop_factor = old->crop_factor;
-    new->orthocorr = old->orthocorr;
-    new->aspect = old->aspect;
-    new->mode = old->mode;
-    new->cropmode = ASHIFT_CROP_OFF;
-    new->cl = 0.0f;
-    new->cr = 1.0f;
-    new->ct = 0.0f;
-    new->cb = 1.0f;
-    for(int i = 0; i < MAX_SAVED_LINES * 4; i++) new->last_drawn_lines[i] = 0.0f;
-    for(int i = 0; i < 8; i++) new->last_quad_lines[i] = 0.0f;
-    new->last_drawn_lines_count = 0;
+    const dt_iop_ashift_params_v2_t *o = old_params;
+    dt_iop_ashift_params_v5_t *n =
+      (dt_iop_ashift_params_v5_t *)malloc(sizeof(dt_iop_ashift_params_v5_t));
+    n->rotation = o->rotation;
+    n->lensshift_v = o->lensshift_v;
+    n->lensshift_h = o->lensshift_h;
+    n->shear = 0.0f;
+    n->f_length = o->f_length;
+    n->crop_factor = o->crop_factor;
+    n->orthocorr = o->orthocorr;
+    n->aspect = o->aspect;
+    n->mode = o->mode;
+    n->cropmode = ASHIFT_CROP_OFF;
+    n->cl = 0.0f;
+    n->cr = 1.0f;
+    n->ct = 0.0f;
+    n->cb = 1.0f;
+    for(int i = 0; i < MAX_SAVED_LINES * 4; i++) n->last_drawn_lines[i] = 0.0f;
+    for(int i = 0; i < 8; i++) n->last_quad_lines[i] = 0.0f;
+    n->last_drawn_lines_count = 0;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_ashift_params_v5_t);
+    *new_version = 5;
     return 0;
   }
-  if(old_version == 3 && new_version == 5)
+  if(old_version == 3)
   {
-    typedef struct dt_iop_ashift_params3_t
+    typedef struct dt_iop_ashift_params_v3_t
     {
       float rotation;
       float lensshift_v;
@@ -548,32 +580,37 @@ int legacy_params(dt_iop_module_t *self,
       float cr;
       float ct;
       float cb;
-    } dt_iop_ashift_params3_t;
+    } dt_iop_ashift_params_v3_t;
 
-    const dt_iop_ashift_params3_t *old = old_params;
-    dt_iop_ashift_params_t *new = new_params;
-    new->rotation = old->rotation;
-    new->lensshift_v = old->lensshift_v;
-    new->lensshift_h = old->lensshift_h;
-    new->shear = 0.0f;
-    new->f_length = old->f_length;
-    new->crop_factor = old->crop_factor;
-    new->orthocorr = old->orthocorr;
-    new->aspect = old->aspect;
-    new->mode = old->mode;
-    new->cropmode = old->cropmode;
-    new->cl = old->cl;
-    new->cr = old->cr;
-    new->ct = old->ct;
-    new->cb = old->cb;
-    for(int i = 0; i < MAX_SAVED_LINES * 4; i++) new->last_drawn_lines[i] = 0.0f;
-    for(int i = 0; i < 8; i++) new->last_quad_lines[i] = 0.0f;
-    new->last_drawn_lines_count = 0;
+    const dt_iop_ashift_params_v3_t *o = old_params;
+    dt_iop_ashift_params_v5_t *n =
+      (dt_iop_ashift_params_v5_t *)malloc(sizeof(dt_iop_ashift_params_v5_t));
+    n->rotation = o->rotation;
+    n->lensshift_v = o->lensshift_v;
+    n->lensshift_h = o->lensshift_h;
+    n->shear = 0.0f;
+    n->f_length = o->f_length;
+    n->crop_factor = o->crop_factor;
+    n->orthocorr = o->orthocorr;
+    n->aspect = o->aspect;
+    n->mode = o->mode;
+    n->cropmode = o->cropmode;
+    n->cl = o->cl;
+    n->cr = o->cr;
+    n->ct = o->ct;
+    n->cb = o->cb;
+    for(int i = 0; i < MAX_SAVED_LINES * 4; i++) n->last_drawn_lines[i] = 0.0f;
+    for(int i = 0; i < 8; i++) n->last_quad_lines[i] = 0.0f;
+    n->last_drawn_lines_count = 0;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_ashift_params_v5_t);
+    *new_version = 5;
     return 0;
   }
-  if(old_version == 4 && new_version == 5)
+  if(old_version == 4)
   {
-    typedef struct dt_iop_ashift_params4_t
+    typedef struct dt_iop_ashift_params_v4_t
     {
       float rotation;
       float lensshift_v;
@@ -590,27 +627,32 @@ int legacy_params(dt_iop_module_t *self,
       float cr;
       float ct;
       float cb;
-    } dt_iop_ashift_params4_t;
+    } dt_iop_ashift_params_v4_t;
 
-    const dt_iop_ashift_params4_t *old = old_params;
-    dt_iop_ashift_params_t *new = new_params;
-    new->rotation = old->rotation;
-    new->lensshift_v = old->lensshift_v;
-    new->lensshift_h = old->lensshift_h;
-    new->shear = old->shear;
-    new->f_length = old->f_length;
-    new->crop_factor = old->crop_factor;
-    new->orthocorr = old->orthocorr;
-    new->aspect = old->aspect;
-    new->mode = old->mode;
-    new->cropmode = old->cropmode;
-    new->cl = old->cl;
-    new->cr = old->cr;
-    new->ct = old->ct;
-    new->cb = old->cb;
-    for(int i = 0; i < MAX_SAVED_LINES * 4; i++) new->last_drawn_lines[i] = 0.0f;
-    for(int i = 0; i < 8; i++) new->last_quad_lines[i] = 0.0f;
-    new->last_drawn_lines_count = 0;
+    const dt_iop_ashift_params_v4_t *o = old_params;
+    dt_iop_ashift_params_v5_t *n =
+      (dt_iop_ashift_params_v5_t *)malloc(sizeof(dt_iop_ashift_params_v5_t));
+    n->rotation = o->rotation;
+    n->lensshift_v = o->lensshift_v;
+    n->lensshift_h = o->lensshift_h;
+    n->shear = o->shear;
+    n->f_length = o->f_length;
+    n->crop_factor = o->crop_factor;
+    n->orthocorr = o->orthocorr;
+    n->aspect = o->aspect;
+    n->mode = o->mode;
+    n->cropmode = o->cropmode;
+    n->cl = o->cl;
+    n->cr = o->cr;
+    n->ct = o->ct;
+    n->cb = o->cb;
+    for(int i = 0; i < MAX_SAVED_LINES * 4; i++) n->last_drawn_lines[i] = 0.0f;
+    for(int i = 0; i < 8; i++) n->last_quad_lines[i] = 0.0f;
+    n->last_drawn_lines_count = 0;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_ashift_params_v5_t);
+    *new_version = 5;
     return 0;
   }
 

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -157,10 +157,19 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
 int legacy_params(dt_iop_module_t *self,
                   const void *const old_params,
                   const int old_version,
-                  void *new_params,
-                  const int new_version)
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 1 && new_version == 2)
+  typedef struct dt_iop_atrous_params_v2_t
+  {
+    int32_t octaves;
+    float x[atrous_none][BANDS];
+    float y[atrous_none][BANDS];
+    float mix;
+  } dt_iop_atrous_params_v2_t;
+
+  if(old_version == 1)
   {
     typedef struct dt_iop_atrous_params_v1_t
     {
@@ -169,14 +178,16 @@ int legacy_params(dt_iop_module_t *self,
       float y[atrous_none][BANDS]; // $DEFAULT: 0.5
     } dt_iop_atrous_params_v1_t;
 
-    dt_iop_atrous_params_v1_t *o = (dt_iop_atrous_params_v1_t *)old_params;
-    dt_iop_atrous_params_t *n = (dt_iop_atrous_params_t *)new_params;
-    const dt_iop_atrous_params_t *const d = (dt_iop_atrous_params_t *)self->default_params;
-
-    *n = *d; // start with a fresh copy of default parameters
+    const dt_iop_atrous_params_v1_t *o = (dt_iop_atrous_params_v1_t *)old_params;
+    dt_iop_atrous_params_v2_t *n =
+      (dt_iop_atrous_params_v2_t *)malloc(sizeof(dt_iop_atrous_params_v2_t));
 
     memcpy(n, o, sizeof(dt_iop_atrous_params_v1_t));
     n->mix = 1.0f;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_atrous_params_v2_t);
+    *new_version = 2;
     return 0;
   }
 

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -76,27 +76,47 @@ typedef struct dt_iop_basecurve_params_t
   dt_iop_rgb_norms_t preserve_colors; /* $DEFAULT: DT_RGB_NORM_LUMINANCE $DESCRIPTION: "preserve colors" */
 } dt_iop_basecurve_params_t;
 
-int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
-                  void *new_params, const int new_version)
+int legacy_params(dt_iop_module_t *self,
+                  const void *const old_params,
+                  const int old_version,
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 1 && new_version == 6)
+  typedef struct dt_iop_basecurve_params_v6_t
   {
-    typedef struct dt_iop_basecurve_params1_t
+    // three curves (c, ., .) with max number of nodes
+    // the other two are reserved, maybe we'll have cam rgb at some point.
+    dt_iop_basecurve_node_t basecurve[3][MAXNODES];
+    int basecurve_nodes[3];
+    int basecurve_type[3];
+    int exposure_fusion;
+    float exposure_stops;
+    float exposure_bias;
+    dt_iop_rgb_norms_t preserve_colors;
+  } dt_iop_basecurve_params_v6_t;
+
+ if(old_version == 1)
+  {
+    typedef struct dt_iop_basecurve_params_v1_t
     {
       float tonecurve_x[6], tonecurve_y[6];
       int tonecurve_preset;
-    } dt_iop_basecurve_params1_t;
+    } dt_iop_basecurve_params_v1_t;
 
-    dt_iop_basecurve_params1_t *o = (dt_iop_basecurve_params1_t *)old_params;
-    dt_iop_basecurve_params_t *n = (dt_iop_basecurve_params_t *)new_params;
+    const dt_iop_basecurve_params_v1_t *o = (dt_iop_basecurve_params_v1_t *)old_params;
+    dt_iop_basecurve_params_v6_t *n =
+      (dt_iop_basecurve_params_v6_t *)malloc(sizeof(dt_iop_basecurve_params_v6_t));
 
     // start with a fresh copy of default parameters
     // unfortunately default_params aren't inited at this stage.
-    *n = (dt_iop_basecurve_params_t){ {
-                                        { { 0.0, 0.0 }, { 1.0, 1.0 } },
-                                      },
-                                      { 2, 3, 3 },
-                                      { MONOTONE_HERMITE, MONOTONE_HERMITE, MONOTONE_HERMITE } , 0, 1};
+    *n = (dt_iop_basecurve_params_v6_t)
+      { {
+          { { 0.0, 0.0 }, { 1.0, 1.0 } },
+        },
+        { 2, 3, 3 },
+        { MONOTONE_HERMITE, MONOTONE_HERMITE, MONOTONE_HERMITE } , 0, 1};
+
     for(int k = 0; k < 6; k++) n->basecurve[0][k].x = o->tonecurve_x[k];
     for(int k = 0; k < 6; k++) n->basecurve[0][k].y = o->tonecurve_y[k];
     n->basecurve_nodes[0] = 6;
@@ -105,31 +125,36 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     n->exposure_stops = 1;
     n->exposure_bias = 1.0;
     n->preserve_colors = DT_RGB_NORM_NONE;
+
+    *new_params_size = sizeof(dt_iop_basecurve_params_v6_t);
+    *new_version = 6;
     return 0;
   }
-  if(old_version == 2 && new_version == 6)
+  if(old_version == 2)
   {
-    typedef struct dt_iop_basecurve_params2_t
+    typedef struct dt_iop_basecurve_params_v2_t
     {
       // three curves (c, ., .) with max number of nodes
       // the other two are reserved, maybe we'll have cam rgb at some point.
       dt_iop_basecurve_node_t basecurve[3][MAXNODES];
       int basecurve_nodes[3];
       int basecurve_type[3];
-    } dt_iop_basecurve_params2_t;
+    } dt_iop_basecurve_params_v2_t;
 
-    dt_iop_basecurve_params2_t *o = (dt_iop_basecurve_params2_t *)old_params;
-    dt_iop_basecurve_params_t *n = (dt_iop_basecurve_params_t *)new_params;
-    memcpy(n, o, sizeof(dt_iop_basecurve_params2_t));
+    dt_iop_basecurve_params_v2_t *o = (dt_iop_basecurve_params_v2_t *)old_params;
+    dt_iop_basecurve_params_v6_t *n =
+      (dt_iop_basecurve_params_v6_t *)malloc(sizeof(dt_iop_basecurve_params_v6_t));
+
+    memcpy(n, o, sizeof(dt_iop_basecurve_params_v2_t));
     n->exposure_fusion = 0;
     n->exposure_stops = 1;
     n->exposure_bias = 1.0;
     n->preserve_colors = DT_RGB_NORM_NONE;
     return 0;
   }
-  if(old_version == 3 && new_version == 6)
+  if(old_version == 3)
   {
-    typedef struct dt_iop_basecurve_params3_t
+    typedef struct dt_iop_basecurve_params_v3_t
     {
       // three curves (c, ., .) with max number of nodes
       // the other two are reserved, maybe we'll have cam rgb at some point.
@@ -138,20 +163,25 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
       int basecurve_type[3];
       int exposure_fusion;  // number of exposure fusion steps
       float exposure_stops; // number of stops between fusion images
-    } dt_iop_basecurve_params3_t;
+    } dt_iop_basecurve_params_v3_t;
 
-    dt_iop_basecurve_params3_t *o = (dt_iop_basecurve_params3_t *)old_params;
-    dt_iop_basecurve_params_t *n = (dt_iop_basecurve_params_t *)new_params;
-    memcpy(n, o, sizeof(dt_iop_basecurve_params3_t));
-    n->exposure_stops = (o->exposure_fusion == 0 && o->exposure_stops == 0) ? 1.0f : o->exposure_stops;
+    dt_iop_basecurve_params_v3_t *o = (dt_iop_basecurve_params_v3_t *)old_params;
+    dt_iop_basecurve_params_v6_t *n =
+      (dt_iop_basecurve_params_v6_t *)malloc(sizeof(dt_iop_basecurve_params_v6_t));
+    memcpy(n, o, sizeof(dt_iop_basecurve_params_v3_t));
+    n->exposure_stops =
+      (o->exposure_fusion == 0 && o->exposure_stops == 0) ? 1.0f : o->exposure_stops;
     n->exposure_bias = 1.0;
     n->preserve_colors = DT_RGB_NORM_NONE;
+
+    *new_params_size = sizeof(dt_iop_basecurve_params_v6_t);
+    *new_version = 6;
     return 0;
   }
-  if(old_version == 4 && new_version == 6)
+  if(old_version == 4)
   {
     // same as v3 but semantics/defaults changed
-    typedef struct dt_iop_basecurve_params4_t
+    typedef struct dt_iop_basecurve_params_v4_t
     {
       // three curves (c, ., .) with max number of nodes
       // the other two are reserved, maybe we'll have cam rgb at some point.
@@ -160,18 +190,23 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
       int basecurve_type[3];
       int exposure_fusion;  // number of exposure fusion steps
       float exposure_stops; // number of stops between fusion images
-    } dt_iop_basecurve_params4_t;
+    } dt_iop_basecurve_params_v4_t;
 
-    dt_iop_basecurve_params4_t *o = (dt_iop_basecurve_params4_t *)old_params;
-    dt_iop_basecurve_params_t *n = (dt_iop_basecurve_params_t *)new_params;
-    memcpy(n, o, sizeof(dt_iop_basecurve_params4_t));
+    dt_iop_basecurve_params_v4_t *o = (dt_iop_basecurve_params_v4_t *)old_params;
+    dt_iop_basecurve_params_v6_t *n =
+      (dt_iop_basecurve_params_v6_t *)malloc(sizeof(dt_iop_basecurve_params_v6_t));
+
+    memcpy(n, o, sizeof(dt_iop_basecurve_params_v4_t));
     n->exposure_bias = 1.0;
     n->preserve_colors = DT_RGB_NORM_NONE;
+
+    *new_params_size = sizeof(dt_iop_basecurve_params_v6_t);
+    *new_version = 6;
     return 0;
   }
-  if(old_version == 5 && new_version == 6)
+  if(old_version == 5)
   {
-    typedef struct dt_iop_basecurve_params5_t
+    typedef struct dt_iop_basecurve_params_v5_t
     {
       // three curves (c, ., .) with max number of nodes
       // the other two are reserved, maybe we'll have cam rgb at some point.
@@ -181,12 +216,16 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
       int exposure_fusion;    // number of exposure fusion steps
       float exposure_stops;   // number of stops between fusion images
       float exposure_bias;    // whether to do exposure-fusion with over or under-exposure
-    } dt_iop_basecurve_params5_t;
+    } dt_iop_basecurve_params_v5_t;
 
-    dt_iop_basecurve_params5_t *o = (dt_iop_basecurve_params5_t *)old_params;
-    dt_iop_basecurve_params_t *n = (dt_iop_basecurve_params_t *)new_params;
-    memcpy(n, o, sizeof(dt_iop_basecurve_params5_t));
+    dt_iop_basecurve_params_v5_t *o = (dt_iop_basecurve_params_v5_t *)old_params;
+    dt_iop_basecurve_params_v6_t *n =
+      (dt_iop_basecurve_params_v6_t *)malloc(sizeof(dt_iop_basecurve_params_v6_t));
+    memcpy(n, o, sizeof(dt_iop_basecurve_params_v5_t));
     n->preserve_colors = DT_RGB_NORM_NONE;
+
+    *new_params_size = sizeof(dt_iop_basecurve_params_v6_t);
+    *new_version = 6;
     return 0;
   }
   return 1;

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -93,10 +93,31 @@ typedef struct dt_iop_basicadj_global_data_t
   int kernel_basicadj;
 } dt_iop_basicadj_global_data_t;
 
-int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,
-                  const int new_version)
+int legacy_params(dt_iop_module_t *self,
+                  const void *const old_params,
+                  const int old_version,
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 1 && new_version == 2)
+  typedef struct dt_iop_basicadj_params_v2_t
+  {
+    float black_point;
+
+    float exposure;
+    float hlcompr;
+
+    float hlcomprthresh;
+    float contrast;
+    dt_iop_rgb_norms_t preserve_colors;
+    float middle_grey;
+    float brightness;
+    float saturation;
+    float vibrance;
+    float clip;
+  } dt_iop_basicadj_params_v2_t;
+
+  if(old_version == 1)
   {
     typedef struct dt_iop_basicadj_params_v1_t
     {
@@ -113,7 +134,8 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     } dt_iop_basicadj_params_v1_t;
 
     const dt_iop_basicadj_params_v1_t *old = old_params;
-    dt_iop_basicadj_params_t *new = new_params;
+    dt_iop_basicadj_params_v2_t *new =
+      (dt_iop_basicadj_params_v2_t *)malloc(sizeof(dt_iop_basicadj_params_v2_t));
 
     new->black_point = old->black_point;
     new->exposure = old->exposure;
@@ -126,6 +148,10 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     new->saturation = old->saturation;
     new->clip = old->clip;
     new->vibrance = 0;
+
+    *new_params = new;
+    *new_params_size = sizeof(dt_iop_basicadj_params_v2_t);
+    *new_version = 2;
     return 0;
   }
   return 1;
@@ -1557,4 +1583,3 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -56,25 +56,7 @@ typedef struct dt_iop_bilat_params_t
   float sigma_s; // $MIN: 0.0 $MAX: 100.0 $DEFAULT: 0.5 shadows 100 & spatial 1 100 50
   float detail;  // $MIN: -1.0 $MAX: 4.0 $DEFAULT: 0.25
   float midtone; // $MIN: 0.001 $MAX: 1.0 $DEFAULT: 0.5 $DESCRIPTION: "midtone range"
-}
-dt_iop_bilat_params_t;
-
-typedef struct dt_iop_bilat_params_v2_t
-{
-  uint32_t mode;
-  float sigma_r;
-  float sigma_s;
-  float detail;
-}
-dt_iop_bilat_params_v2_t;
-
-typedef struct dt_iop_bilat_params_v1_t
-{
-  float sigma_r;
-  float sigma_s;
-  float detail;
-}
-dt_iop_bilat_params_v1_t;
+} dt_iop_bilat_params_t;
 
 typedef dt_iop_bilat_params_t dt_iop_bilat_data_t;
 
@@ -87,8 +69,7 @@ typedef struct dt_iop_bilat_gui_data_t
   GtkWidget *range;
   GtkWidget *detail;
   GtkWidget *mode;
-}
-dt_iop_bilat_gui_data_t;
+} dt_iop_bilat_gui_data_t;
 
 // this returns a translatable name
 const char *name()
@@ -127,29 +108,65 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
 int legacy_params(dt_iop_module_t *self,
                   const void *const old_params,
                   const int old_version,
-                  void *new_params,
-                  const int new_version)
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 2 && new_version == 3)
+  typedef struct dt_iop_bilat_params_v3_t
   {
-    const dt_iop_bilat_params_v2_t *p2 = old_params;
-    dt_iop_bilat_params_t *p = new_params;
-    p->detail  = p2->detail;
-    p->sigma_r = p2->sigma_r;
-    p->sigma_s = p2->sigma_s;
-    p->midtone = 0.2f;
-    p->mode    = p2->mode;
+    dt_iop_bilat_mode_t mode;
+    float sigma_r;
+    float sigma_s;
+    float detail;
+    float midtone;
+  } dt_iop_bilat_params_v3_t;
+
+  if(old_version == 1)
+  {
+    typedef struct dt_iop_bilat_params_v1_t
+    {
+      float sigma_r;
+      float sigma_s;
+      float detail;
+    } dt_iop_bilat_params_v1_t;
+
+    const dt_iop_bilat_params_v1_t *o = old_params;
+    dt_iop_bilat_params_v3_t *n =
+      (dt_iop_bilat_params_v3_t *)malloc(sizeof(dt_iop_bilat_params_v3_t));
+    n->detail  = o->detail;
+    n->sigma_r = o->sigma_r;
+    n->sigma_s = o->sigma_s;
+    n->midtone = 0.2f;
+    n->mode    = s_mode_bilateral;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_bilat_params_v3_t);
+    *new_version = 3;
     return 0;
   }
-  else if(old_version == 1 && new_version == 3)
+
+  if(old_version == 2)
   {
-    const dt_iop_bilat_params_v1_t *p1 = old_params;
-    dt_iop_bilat_params_t *p = new_params;
-    p->detail  = p1->detail;
-    p->sigma_r = p1->sigma_r;
-    p->sigma_s = p1->sigma_s;
-    p->midtone = 0.2f;
-    p->mode    = s_mode_bilateral;
+    typedef struct dt_iop_bilat_params_v2_t
+    {
+      uint32_t mode;
+      float sigma_r;
+      float sigma_s;
+      float detail;
+    } dt_iop_bilat_params_v2_t;
+
+    const dt_iop_bilat_params_v2_t *o = old_params;
+    dt_iop_bilat_params_v3_t *n =
+      (dt_iop_bilat_params_v3_t *)malloc(sizeof(dt_iop_bilat_params_v3_t));
+    n->detail  = o->detail;
+    n->sigma_r = o->sigma_r;
+    n->sigma_s = o->sigma_s;
+    n->midtone = 0.2f;
+    n->mode    = o->mode;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_bilat_params_v3_t);
+    *new_version = 3;
     return 0;
   }
   return 1;

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -99,14 +99,29 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
   return IOP_CS_RAW;
 }
 
-int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
-                  void *new_params, const int new_version)
+int legacy_params(dt_iop_module_t *self,
+                  const void *const old_params,
+                  const int old_version,
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 1 && new_version == 2)
+  typedef struct dt_iop_cacorrect_params_v2_t
   {
-    dt_iop_cacorrect_params_t *n = (dt_iop_cacorrect_params_t *)new_params;
+    gboolean avoidshift;
+    dt_iop_cacorrect_multi_t iterations;
+  } dt_iop_cacorrect_params_v2_t;
+
+  if(old_version == 1)
+  {
+    dt_iop_cacorrect_params_v2_t *n =
+      (dt_iop_cacorrect_params_v2_t *)malloc(sizeof(dt_iop_cacorrect_params_v2_t));
     n->avoidshift = FALSE;
     n->iterations = 1;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_cacorrect_params_v2_t);
+    *new_version = 2;
     return 0;
   }
   return 1;
@@ -1285,7 +1300,7 @@ void process(
 #endif
   for(size_t row = 0; row < roi_out->height; row++)
   {
-    for(size_t col = 0; col < roi_out->width; col++) 
+    for(size_t col = 0; col < roi_out->width; col++)
     {
       const size_t ox = row * roi_out->width + col;
       const size_t irow = row + roi_out->y;
@@ -1434,4 +1449,3 @@ void gui_init(dt_iop_module_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -103,14 +103,37 @@ typedef enum _grab_region_t
 /* calculate the aspect ratios for current image */
 static void keystone_type_populate(struct dt_iop_module_t *self, gboolean with_applied, int select);
 
-int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
-                  void *new_params, const int new_version)
+int legacy_params(dt_iop_module_t *self,
+                  const void *const old_params,
+                  const int old_version,
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(new_version <= old_version) return 1;
-  if(new_version != 5) return 1;
+  typedef struct dt_iop_clipping_params_v5_t
+  {
+    float angle;
+    float cx;
+    float cy;
+    float cw;
+    float ch;
+    float k_h, k_v;
+    float kxa;
+    float kya;
+    float kxb;
+    float kyb;
+    float kxc;
+    float kyc;
+    float kxd;
+    float kyd;
+    int k_type, k_sym;
+    int k_apply;
+    gboolean crop_auto;
+    int ratio_n;
+    int ratio_d;
+  } dt_iop_clipping_params_v5_t;
 
-  dt_iop_clipping_params_t *n = (dt_iop_clipping_params_t *)new_params;
-  if(old_version == 2 && new_version == 5)
+  if(old_version == 2)
   {
     union {
         float f;
@@ -123,6 +146,8 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     } old_params_t;
 
     const old_params_t *o = (old_params_t *)old_params;
+    dt_iop_clipping_params_v5_t *n =
+      (dt_iop_clipping_params_v5_t *)malloc(sizeof(dt_iop_clipping_params_v5_t));
 
     k.f = o->k_h;
     int is_horizontal;
@@ -155,11 +180,16 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     n->k_apply = 0;
     n->crop_auto = 1;
 
-    // will be computed later, -2 here is used to detect uninitialized value, -1 is already used for no
-    // clipping.
+    // will be computed later, -2 here is used to detect uninitialized
+    // value, -1 is already used for no clipping.
     n->ratio_d = n->ratio_n = -2;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_clipping_params_v5_t);
+    *new_version = 5;
+    return 0;
   }
-  if(old_version == 3 && new_version == 5)
+  if(old_version == 3)
   {
     // old structure def
     typedef struct old_params_t
@@ -168,6 +198,8 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     } old_params_t;
 
     const old_params_t *o = (old_params_t *)old_params;
+    dt_iop_clipping_params_v5_t *n =
+      (dt_iop_clipping_params_v5_t *)malloc(sizeof(dt_iop_clipping_params_v5_t));
 
     n->angle = o->angle, n->cx = o->cx, n->cy = o->cy, n->cw = o->cw, n->ch = o->ch;
     n->k_h = o->k_h, n->k_v = o->k_v;
@@ -183,11 +215,16 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     n->k_apply = 0;
     n->crop_auto = 1;
 
-    // will be computed later, -2 here is used to detect uninitialized value, -1 is already used for no
-    // clipping.
+    // will be computed later, -2 here is used to detect uninitialized
+    // value, -1 is already used for no clipping.
     n->ratio_d = n->ratio_n = -2;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_clipping_params_v5_t);
+    *new_version = 5;
+    return 0;
   }
-  if(old_version == 4 && new_version == 5)
+  if(old_version == 4)
   {
     typedef struct old_params_t
     {
@@ -198,6 +235,8 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     } old_params_t;
 
     const old_params_t *o = (old_params_t *)old_params;
+    dt_iop_clipping_params_v5_t *n =
+      (dt_iop_clipping_params_v5_t *)malloc(sizeof(dt_iop_clipping_params_v5_t));
 
     n->angle = o->angle, n->cx = o->cx, n->cy = o->cy, n->cw = o->cw, n->ch = o->ch;
     n->k_h = o->k_h, n->k_v = o->k_v;
@@ -208,12 +247,17 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     n->k_apply = o->k_apply;
     n->crop_auto = o->crop_auto;
 
-    // will be computed later, -2 here is used to detect uninitialized value, -1 is already used for no
-    // clipping.
+    // will be computed later, -2 here is used to detect uninitialized
+    // value, -1 is already used for no clipping.
     n->ratio_d = n->ratio_n = -2;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_clipping_params_v5_t);
+    *new_version = 5;
+    return 0;
   }
 
-  return 0;
+  return 1;
 }
 
 typedef struct dt_iop_clipping_gui_data_t
@@ -3354,4 +3398,3 @@ GSList *mouse_actions(struct dt_iop_module_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -205,46 +205,113 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
   return IOP_CS_RGB;
 }
 
-int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,
-                  const int new_version)
+int legacy_params(dt_iop_module_t *self,
+                  const void *const old_params,
+                  const int old_version,
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 1 && new_version == 5)
+  typedef struct dt_iop_colorbalancergb_params_v5_t
+  {
+    /* params of v1 */
+    float shadows_Y;
+    float shadows_C;
+    float shadows_H;
+    float midtones_Y;
+    float midtones_C;
+    float midtones_H;
+    float highlights_Y;
+    float highlights_C;
+    float highlights_H;
+    float global_Y;
+    float global_C;
+    float global_H;
+    float shadows_weight;
+    float white_fulcrum;
+    float highlights_weight;
+    float chroma_shadows;
+    float chroma_highlights;
+    float chroma_global;
+    float chroma_midtones;
+    float saturation_global;
+    float saturation_highlights;
+    float saturation_midtones;
+    float saturation_shadows;
+    float hue_angle;
+
+    /* params of v2 */
+    float brilliance_global;
+    float brilliance_highlights;
+    float brilliance_midtones;
+    float brilliance_shadows;
+
+    /* params of v3 */
+    float mask_grey_fulcrum;
+
+    /* params of v4 */
+    float vibrance;
+    float grey_fulcrum;
+    float contrast;
+
+    /* params of v5 */
+    dt_iop_colorbalancrgb_saturation_t saturation_formula;
+
+    /* add future params after this so the legacy params import can use a blind memcpy */
+  } dt_iop_colorbalancergb_params_v5_t;
+
+  dt_iop_colorbalancergb_params_v5_t default_v5 =
+    { 0.0f,  0.0f,  0.0f,  0.0f,    0.0f,
+      0.0f,  0.0f,  0.0f,  0.0f,    0.0f,
+      0.0f,  0.0f,  1.0f,  0.0f,    1.0f,
+      0.0f,  0.0f,  0.0f,  0.0f,    0.0f,
+      0.0f,  0.0f,  0.0f,  0.0f,    0.0f,
+      0.0f,  0.0f,  0.0f,  0.1845f, 0.0f,
+      0.0f,  0.0f,  1
+    };
+
+  if(old_version == 1)
   {
     typedef struct dt_iop_colorbalancergb_params_v1_t
     {
-      float shadows_Y;             // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
-      float shadows_C;             // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
-      float shadows_H;             // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
-      float midtones_Y;            // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
-      float midtones_C;            // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
-      float midtones_H;            // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
-      float highlights_Y;          // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
-      float highlights_C;          // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
-      float highlights_H;          // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
-      float global_Y;              // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
-      float global_C;              // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
-      float global_H;              // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
-      float shadows_weight;        // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "tonal weight"
-      float white_fulcrum;       // $MIN: -6.0 $MAX:   6.0 $DEFAULT: 0.0 $DESCRIPTION: "fulcrum"
-      float highlights_weight;     // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "tonal weight"
-      float chroma_shadows;        // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "shadows"
-      float chroma_highlights;     // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "highlights"
-      float chroma_global;         // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "global"
-      float chroma_midtones;       // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "mid-tones"
-      float saturation_global;     // $MIN: -5.0 $MAX: 5.0 $DEFAULT: 0.0 $DESCRIPTION: "saturation global"
-      float saturation_highlights; // $MIN: -0.2 $MAX: 0.2 $DEFAULT: 0.0 $DESCRIPTION: "highlights"
-      float saturation_midtones;   // $MIN: -0.2 $MAX: 0.2 $DEFAULT: 0.0 $DESCRIPTION: "mid-tones"
-      float saturation_shadows;    // $MIN: -0.2 $MAX: 0.2 $DEFAULT: 0.0 $DESCRIPTION: "shadows"
-      float hue_angle;             // $MIN: -180. $MAX: 180. $DEFAULT: 0.0 $DESCRIPTION: "hue shift"
+      float shadows_Y;
+      float shadows_C;
+      float shadows_H;
+      float midtones_Y;
+      float midtones_C;
+      float midtones_H;
+      float highlights_Y;
+      float highlights_C;
+      float highlights_H;
+      float global_Y;
+      float global_C;
+      float global_H;
+      float shadows_weight;
+      float white_fulcrum;
+      float highlights_weight;
+      float chroma_shadows;
+      float chroma_highlights;
+      float chroma_global;
+      float chroma_midtones;
+      float saturation_global;
+      float saturation_highlights;
+      float saturation_midtones;
+      float saturation_shadows;
+      float hue_angle;
     } dt_iop_colorbalancergb_params_v1_t;
 
+    const dt_iop_colorbalancergb_params_v1_t *o =
+      (dt_iop_colorbalancergb_params_v1_t *)old_params;
+    dt_iop_colorbalancergb_params_v5_t *n =
+      (dt_iop_colorbalancergb_params_v5_t *)
+      malloc(sizeof(dt_iop_colorbalancergb_params_v5_t));
+
     // Init params with defaults
-    memcpy(new_params, self->default_params, sizeof(dt_iop_colorbalancergb_params_t));
+    memcpy(n, &default_v5, sizeof(dt_iop_colorbalancergb_params_v5_t));
 
     // Copy the common part of the params struct
-    memcpy(new_params, old_params, sizeof(dt_iop_colorbalancergb_params_v1_t));
+    memcpy(n, o, sizeof(dt_iop_colorbalancergb_params_v1_t));
 
-    dt_iop_colorbalancergb_params_t *n = (dt_iop_colorbalancergb_params_t *)new_params;
     n->saturation_global /= 180.f / M_PI;
     n->mask_grey_fulcrum = 0.1845f;
     n->vibrance = 0.f;
@@ -252,172 +319,196 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     n->contrast = 0.f;
     n->saturation_formula = DT_COLORBALANCE_SATURATION_JZAZBZ;
 
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_colorbalancergb_params_v5_t);
+    *new_version = 5;
     return 0;
   }
 
-  if(old_version == 2 && new_version == 5)
+  if(old_version == 2)
   {
     typedef struct dt_iop_colorbalancergb_params_v2_t
     {
       /* params of v1 */
-      float shadows_Y;             // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
-      float shadows_C;             // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
-      float shadows_H;             // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
-      float midtones_Y;            // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
-      float midtones_C;            // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
-      float midtones_H;            // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
-      float highlights_Y;          // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
-      float highlights_C;          // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
-      float highlights_H;          // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
-      float global_Y;              // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
-      float global_C;              // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
-      float global_H;              // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
-      float shadows_weight;        // $MIN:  0.0 $MAX:   3.0 $DEFAULT: 1.0 $DESCRIPTION: "shadows fall-off"
-      float white_fulcrum;         // $MIN: -6.0 $MAX:   6.0 $DEFAULT: 0.0 $DESCRIPTION: "white pivot"
-      float highlights_weight;     // $MIN:  0.0 $MAX:   3.0 $DEFAULT: 1.0 $DESCRIPTION: "highlights fall-off"
-      float chroma_shadows;        // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "shadows"
-      float chroma_highlights;     // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "highlights"
-      float chroma_global;         // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "global"
-      float chroma_midtones;       // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "mid-tones"
-      float saturation_global;     // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "global"
-      float saturation_highlights; // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "highlights"
-      float saturation_midtones;   // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "mid-tones"
-      float saturation_shadows;    // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "shadows"
-      float hue_angle;             // $MIN: -180. $MAX: 180. $DEFAULT: 0.0 $DESCRIPTION: "hue shift"
+      float shadows_Y;
+      float shadows_C;
+      float shadows_H;
+      float midtones_Y;
+      float midtones_C;
+      float midtones_H;
+      float highlights_Y;
+      float highlights_C;
+      float highlights_H;
+      float global_Y;
+      float global_C;
+      float global_H;
+      float shadows_weight;
+      float white_fulcrum;
+      float highlights_weight;
+      float chroma_shadows;
+      float chroma_highlights;
+      float chroma_global;
+      float chroma_midtones;
+      float saturation_global;
+      float saturation_highlights;
+      float saturation_midtones;
+      float saturation_shadows;
+      float hue_angle;
 
       /* params of v2 */
-      float brilliance_global;     // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "global"
-      float brilliance_highlights; // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "highlights"
-      float brilliance_midtones;   // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "mid-tones"
-      float brilliance_shadows;    // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "shadows"
-
+      float brilliance_global;
+      float brilliance_highlights;
+      float brilliance_midtones;
+      float brilliance_shadows;
     } dt_iop_colorbalancergb_params_v2_t;
 
+    const dt_iop_colorbalancergb_params_v2_t *o =
+      (dt_iop_colorbalancergb_params_v2_t *)old_params;
+    dt_iop_colorbalancergb_params_v5_t *n =
+      (dt_iop_colorbalancergb_params_v5_t *)
+      malloc(sizeof(dt_iop_colorbalancergb_params_v5_t));
+
     // Init params with defaults
-    memcpy(new_params, self->default_params, sizeof(dt_iop_colorbalancergb_params_t));
+    memcpy(n, &default_v5, sizeof(dt_iop_colorbalancergb_params_v5_t));
 
     // Copy the common part of the params struct
-    memcpy(new_params, old_params, sizeof(dt_iop_colorbalancergb_params_v2_t));
+    memcpy(n, o, sizeof(dt_iop_colorbalancergb_params_v2_t));
 
-    dt_iop_colorbalancergb_params_t *n = (dt_iop_colorbalancergb_params_t *)new_params;
     n->mask_grey_fulcrum = 0.1845f;
     n->vibrance = 0.f;
     n->grey_fulcrum = 0.1845f;
     n->contrast = 0.f;
     n->saturation_formula = DT_COLORBALANCE_SATURATION_JZAZBZ;
 
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_colorbalancergb_params_v5_t);
+    *new_version = 5;
     return 0;
   }
-  if(old_version == 3 && new_version == 5)
+  if(old_version == 3)
   {
     typedef struct dt_iop_colorbalancergb_params_v3_t
     {
       /* params of v1 */
-      float shadows_Y;             // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
-      float shadows_C;             // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
-      float shadows_H;             // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
-      float midtones_Y;            // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
-      float midtones_C;            // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
-      float midtones_H;            // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
-      float highlights_Y;          // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
-      float highlights_C;          // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
-      float highlights_H;          // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
-      float global_Y;              // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "luminance"
-      float global_C;              // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma"
-      float global_H;              // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "hue"
-      float shadows_weight;        // $MIN:  0.0 $MAX:   3.0 $DEFAULT: 1.0 $DESCRIPTION: "shadows fall-off"
-      float white_fulcrum;         // $MIN: -16.0 $MAX:   16.0 $DEFAULT: 0.0 $DESCRIPTION: "white fulcrum"
-      float highlights_weight;     // $MIN:  0.0 $MAX:   3.0 $DEFAULT: 1.0 $DESCRIPTION: "highlights fall-off"
-      float chroma_shadows;        // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "shadows"
-      float chroma_highlights;     // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "highlights"
-      float chroma_global;         // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "global"
-      float chroma_midtones;       // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "mid-tones"
-      float saturation_global;     // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "global"
-      float saturation_highlights; // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "highlights"
-      float saturation_midtones;   // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "mid-tones"
-      float saturation_shadows;    // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "shadows"
-      float hue_angle;             // $MIN: -180. $MAX: 180. $DEFAULT: 0.0 $DESCRIPTION: "hue shift"
+      float shadows_Y;
+      float shadows_C;
+      float shadows_H;
+      float midtones_Y;
+      float midtones_C;
+      float midtones_H;
+      float highlights_Y;
+      float highlights_C;
+      float highlights_H;
+      float global_Y;
+      float global_C;
+      float global_H;
+      float shadows_weight;
+      float white_fulcrum;
+      float highlights_weight;
+      float chroma_shadows;
+      float chroma_highlights;
+      float chroma_global;
+      float chroma_midtones;
+      float saturation_global;
+      float saturation_highlights;
+      float saturation_midtones;
+      float saturation_shadows;
+      float hue_angle;
 
       /* params of v2 */
-      float brilliance_global;     // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "global"
-      float brilliance_highlights; // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "highlights"
-      float brilliance_midtones;   // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "mid-tones"
-      float brilliance_shadows;    // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "shadows"
+      float brilliance_global;
+      float brilliance_highlights;
+      float brilliance_midtones;
+      float brilliance_shadows;
 
       /* params of v3 */
-      float mask_grey_fulcrum;     // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.1845 $DESCRIPTION: "middle-gray fulcrum"
-
+      float mask_grey_fulcrum;
     } dt_iop_colorbalancergb_params_v3_t;
 
+    const dt_iop_colorbalancergb_params_v3_t *o =
+      (dt_iop_colorbalancergb_params_v3_t *)old_params;
+    dt_iop_colorbalancergb_params_v5_t *n =
+      (dt_iop_colorbalancergb_params_v5_t *)
+      malloc(sizeof(dt_iop_colorbalancergb_params_v5_t));
+
     // Init params with defaults
-    memcpy(new_params, self->default_params, sizeof(dt_iop_colorbalancergb_params_t));
+    memcpy(n, &default_v5, sizeof(dt_iop_colorbalancergb_params_v5_t));
 
     // Copy the common part of the params struct
-    memcpy(new_params, old_params, sizeof(dt_iop_colorbalancergb_params_v3_t));
+    memcpy(n, o, sizeof(dt_iop_colorbalancergb_params_v3_t));
 
-    dt_iop_colorbalancergb_params_t *n = (dt_iop_colorbalancergb_params_t *)new_params;
     n->vibrance = 0.f;
     n->grey_fulcrum = 0.1845f;
     n->contrast = 0.f;
     n->saturation_formula = DT_COLORBALANCE_SATURATION_JZAZBZ;
 
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_colorbalancergb_params_v5_t);
+    *new_version = 5;
     return 0;
   }
-  if(old_version == 4 && new_version == 5)
+  if(old_version == 4)
   {
     typedef struct dt_iop_colorbalancergb_params_v4_t
     {
       /* params of v1 */
-      float shadows_Y;             // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "lift luminance"
-      float shadows_C;             // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "lift chroma"
-      float shadows_H;             // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "lift hue"
-      float midtones_Y;            // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "power luminance"
-      float midtones_C;            // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "power chroma"
-      float midtones_H;            // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "power hue"
-      float highlights_Y;          // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "gain luminance"
-      float highlights_C;          // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "gain chroma"
-      float highlights_H;          // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "gain hue"
-      float global_Y;              // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "offset luminance"
-      float global_C;              // $MIN:  0.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "offset chroma"
-      float global_H;              // $MIN:  0.0 $MAX: 360.0 $DEFAULT: 0.0 $DESCRIPTION: "offset hue"
-      float shadows_weight;        // $MIN:  0.0 $MAX:   3.0 $DEFAULT: 1.0 $DESCRIPTION: "shadows fall-off"
-      float white_fulcrum;         // $MIN: -16.0 $MAX: 16.0 $DEFAULT: 0.0 $DESCRIPTION: "white fulcrum"
-      float highlights_weight;     // $MIN:  0.0 $MAX:   3.0 $DEFAULT: 1.0 $DESCRIPTION: "highlights fall-off"
-      float chroma_shadows;        // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma shadows"
-      float chroma_highlights;     // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma highlights"
-      float chroma_global;         // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma global"
-      float chroma_midtones;       // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "chroma mid-tones"
-      float saturation_global;     // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "saturation global"
-      float saturation_highlights; // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "saturation highlights"
-      float saturation_midtones;   // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "saturation mid-tones"
-      float saturation_shadows;    // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "saturation shadows"
-      float hue_angle;             // $MIN: -180. $MAX: 180. $DEFAULT: 0.0 $DESCRIPTION: "hue shift"
+      float shadows_Y;
+      float shadows_C;
+      float shadows_H;
+      float midtones_Y;
+      float midtones_C;
+      float midtones_H;
+      float highlights_Y;
+      float highlights_C;
+      float highlights_H;
+      float global_Y;
+      float global_C;
+      float global_H;
+      float shadows_weight;
+      float white_fulcrum;
+      float highlights_weight;
+      float chroma_shadows;
+      float chroma_highlights;
+      float chroma_global;
+      float chroma_midtones;
+      float saturation_global;
+      float saturation_highlights;
+      float saturation_midtones;
+      float saturation_shadows;
+      float hue_angle;
 
       /* params of v2 */
-      float brilliance_global;     // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "brilliance global"
-      float brilliance_highlights; // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "brilliance highlights"
-      float brilliance_midtones;   // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "brilliance mid-tones"
-      float brilliance_shadows;    // $MIN: -1.0 $MAX:   1.0 $DEFAULT: 0.0 $DESCRIPTION: "brilliance shadows"
+      float brilliance_global;
+      float brilliance_highlights;
+      float brilliance_midtones;
+      float brilliance_shadows;
 
       /* params of v3 */
-      float mask_grey_fulcrum;     // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.1845 $DESCRIPTION: "mask middle-gray fulcrum"
+      float mask_grey_fulcrum;
 
       /* params of v4 */
-      float vibrance;         // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0 $DESCRIPTION: "global vibrance"
-      float grey_fulcrum;     // $MIN:  0.0 $MAX: 1.0 $DEFAULT: 0.1845 $DESCRIPTION: "contrast gray fulcrum"
-      float contrast;         // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0. $DESCRIPTION: "contrast"
-
+      float vibrance;
+      float grey_fulcrum;
+      float contrast;
     } dt_iop_colorbalancergb_params_v4_t;
 
+    const dt_iop_colorbalancergb_params_v4_t *o =
+      (dt_iop_colorbalancergb_params_v4_t *)old_params;
+    dt_iop_colorbalancergb_params_v5_t *n =
+      (dt_iop_colorbalancergb_params_v5_t *)
+      malloc(sizeof(dt_iop_colorbalancergb_params_v5_t));
+
     // Init params with defaults
-    memcpy(new_params, self->default_params, sizeof(dt_iop_colorbalancergb_params_t));
+    memcpy(n, &default_v5, sizeof(dt_iop_colorbalancergb_params_v5_t));
 
     // Copy the common part of the params struct
-    memcpy(new_params, old_params, sizeof(dt_iop_colorbalancergb_params_v4_t));
+    memcpy(n, o, sizeof(dt_iop_colorbalancergb_params_v4_t));
 
-    dt_iop_colorbalancergb_params_t *n = (dt_iop_colorbalancergb_params_t *)new_params;
     n->saturation_formula = DT_COLORBALANCE_SATURATION_JZAZBZ;
 
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_colorbalancergb_params_v5_t);
+    *new_version = 5;
     return 0;
   }
 

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -150,13 +150,24 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
   return IOP_CS_LAB;
 }
 
-int legacy_params(
-    dt_iop_module_t  *self,
-    const void *const old_params,
-    const int         old_version,
-    void             *new_params,
-    const int         new_version)
+int legacy_params(dt_iop_module_t *self,
+                  const void *const old_params,
+                  const int old_version,
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
+  typedef struct dt_iop_colorchecker_params_v2_t
+  {
+    float source_L[MAX_PATCHES];
+    float source_a[MAX_PATCHES];
+    float source_b[MAX_PATCHES];
+    float target_L[MAX_PATCHES];
+    float target_a[MAX_PATCHES];
+    float target_b[MAX_PATCHES];
+    int32_t num_patches;
+  } dt_iop_colorchecker_params_v2_t;
+
   static const float colorchecker_Lab_v1[] = {
     39.19, 13.76,  14.29,  // dark skin
     65.18, 19.00,  17.32,  // light skin
@@ -184,30 +195,34 @@ int legacy_params(
     21.46, 0.06,   -0.95,  // black
   };
 
-  typedef struct dt_iop_colorchecker_params_v1_t
+  if(old_version == 1)
   {
-    float target_L[24];
-    float target_a[24];
-    float target_b[24];
-  } dt_iop_colorchecker_params_v1_t;
-
-  if(old_version == 1 && new_version == 2)
-  {
-    dt_iop_colorchecker_params_v1_t *p1 =
-      (dt_iop_colorchecker_params_v1_t *)old_params;
-    dt_iop_colorchecker_params_t  *p2 =
-      (dt_iop_colorchecker_params_t  *)new_params;
-
-    p2->num_patches = 24;
-    for(int k=0;k<24;k++)
+    typedef struct dt_iop_colorchecker_params_v1_t
     {
-      p2->target_L[k] = p1->target_L[k];
-      p2->target_a[k] = p1->target_a[k];
-      p2->target_b[k] = p1->target_b[k];
-      p2->source_L[k] = colorchecker_Lab_v1[3 * k + 0];
-      p2->source_a[k] = colorchecker_Lab_v1[3 * k + 1];
-      p2->source_b[k] = colorchecker_Lab_v1[3 * k + 2];
+      float target_L[24];
+      float target_a[24];
+      float target_b[24];
+    } dt_iop_colorchecker_params_v1_t;
+
+    const dt_iop_colorchecker_params_v1_t *o =
+      (dt_iop_colorchecker_params_v1_t *)old_params;
+    dt_iop_colorchecker_params_v2_t  *n =
+      (dt_iop_colorchecker_params_v2_t  *)malloc(sizeof(dt_iop_colorchecker_params_v2_t));
+
+    n->num_patches = 24;
+    for(int k=0; k<24; k++)
+    {
+      n->target_L[k] = o->target_L[k];
+      n->target_a[k] = o->target_a[k];
+      n->target_b[k] = o->target_b[k];
+      n->source_L[k] = colorchecker_Lab_v1[3 * k + 0];
+      n->source_a[k] = colorchecker_Lab_v1[3 * k + 1];
+      n->source_b[k] = colorchecker_Lab_v1[3 * k + 2];
     }
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_colorchecker_params_v2_t);
+    *new_version = 2;
     return 0;
   }
   return 1;

--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -36,14 +36,6 @@
 
 DT_MODULE_INTROSPECTION(2, dt_iop_colorcontrast_params_t)
 
-typedef struct dt_iop_colorcontrast_params1_t
-{
-  float a_steepness;
-  float a_offset;
-  float b_steepness;
-  float b_offset;
-} dt_iop_colorcontrast_params1_t;
-
 typedef struct dt_iop_colorcontrast_params_t
 {
   float a_steepness; // $MIN: 0.0 $MAX: 5.0 $DEFAULT: 1.0 $DESCRIPTION: "green-magenta contrast"
@@ -120,19 +112,42 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
 int legacy_params(dt_iop_module_t *self,
                   const void *const old_params,
                   const int old_version,
-                  void *new_params,
-                  const int new_version)
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 1 && new_version == 2)
+  typedef struct dt_iop_colorcontrast_params_v2_t
   {
-    const dt_iop_colorcontrast_params1_t *old = old_params;
-    dt_iop_colorcontrast_params_t *new = new_params;
+    float a_steepness;
+    float a_offset;
+    float b_steepness;
+    float b_offset;
+    int unbound;
+  } dt_iop_colorcontrast_params_v2_t;
 
-    new->a_steepness = old->a_steepness;
-    new->a_offset = old->a_offset;
-    new->b_steepness = old->b_steepness;
-    new->b_offset = old->b_offset;
-    new->unbound = 0;
+  if(old_version == 1)
+  {
+    typedef struct dt_iop_colorcontrast_params_v1_t
+    {
+      float a_steepness;
+      float a_offset;
+      float b_steepness;
+      float b_offset;
+    } dt_iop_colorcontrast_params_v1_t;
+
+    const dt_iop_colorcontrast_params_v1_t *o = old_params;
+    dt_iop_colorcontrast_params_v2_t *n =
+      (dt_iop_colorcontrast_params_v2_t *)malloc(sizeof(dt_iop_colorcontrast_params_v2_t));
+
+    n->a_steepness = o->a_steepness;
+    n->a_offset = o->a_offset;
+    n->b_steepness = o->b_steepness;
+    n->b_offset = o->b_offset;
+    n->unbound = 0;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_colorcontrast_params_v2_t);
+    *new_version = 2;
     return 0;
   }
   return 1;

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -196,12 +196,25 @@ static void _resolve_work_profile(dt_colorspaces_color_profile_type_t *work_type
 int legacy_params(dt_iop_module_t *self,
                   const void *const old_params,
                   const int old_version,
-                  void *new_params,
-                  const int new_version)
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
+  typedef struct dt_iop_colorin_params_v7_t
+  {
+    dt_colorspaces_color_profile_type_t type;
+    char filename[DT_IOP_COLOR_ICC_LEN];
+    dt_iop_color_intent_t intent;
+    dt_iop_color_normalize_t normalize;
+    gboolean blue_mapping;
+    // working color profile
+    dt_colorspaces_color_profile_type_t type_work;
+    char filename_work[DT_IOP_COLOR_ICC_LEN];
+  } dt_iop_colorin_params_v7_t;
+
 #define DT_IOP_COLOR_ICC_LEN_V5 100
 
-  if(old_version == 1 && new_version == 7)
+  if(old_version == 1)
   {
     typedef struct dt_iop_colorin_params_v1_t
     {
@@ -210,7 +223,8 @@ int legacy_params(dt_iop_module_t *self,
     } dt_iop_colorin_params_v1_t;
 
     const dt_iop_colorin_params_v1_t *old = (dt_iop_colorin_params_v1_t *)old_params;
-    dt_iop_colorin_params_t *new = (dt_iop_colorin_params_t *)new_params;
+    dt_iop_colorin_params_v7_t *new =
+      (dt_iop_colorin_params_v7_t *)malloc(sizeof(dt_iop_colorin_params_v7_t));
     memset(new, 0, sizeof(*new));
 
     if(!strcmp(old->iccprofile, "eprofile"))
@@ -251,9 +265,13 @@ int legacy_params(dt_iop_module_t *self,
     new->blue_mapping = TRUE;
     new->type_work = DT_COLORSPACE_LIN_REC709;
     new->filename_work[0] = '\0';
+
+    *new_params = new;
+    *new_params_size = sizeof(dt_iop_colorin_params_v7_t);
+    *new_version = 7;
     return 0;
   }
-  if(old_version == 2 && new_version == 7)
+  if(old_version == 2)
   {
     typedef struct dt_iop_colorin_params_v2_t
     {
@@ -263,7 +281,8 @@ int legacy_params(dt_iop_module_t *self,
     } dt_iop_colorin_params_v2_t;
 
     const dt_iop_colorin_params_v2_t *old = (dt_iop_colorin_params_v2_t *)old_params;
-    dt_iop_colorin_params_t *new = (dt_iop_colorin_params_t *)new_params;
+    dt_iop_colorin_params_v7_t *new =
+      (dt_iop_colorin_params_v7_t *)malloc(sizeof(dt_iop_colorin_params_v7_t));
     memset(new, 0, sizeof(*new));
 
     if(!strcmp(old->iccprofile, "eprofile"))
@@ -304,9 +323,13 @@ int legacy_params(dt_iop_module_t *self,
     new->blue_mapping = TRUE;
     new->type_work = DT_COLORSPACE_LIN_REC709;
     new->filename_work[0] = '\0';
+
+    *new_params = new;
+    *new_params_size = sizeof(dt_iop_colorin_params_v7_t);
+    *new_version = 7;
     return 0;
   }
-  if(old_version == 3 && new_version == 7)
+  if(old_version == 3)
   {
     typedef struct dt_iop_colorin_params_v3_t
     {
@@ -317,7 +340,8 @@ int legacy_params(dt_iop_module_t *self,
     } dt_iop_colorin_params_v3_t;
 
     const dt_iop_colorin_params_v3_t *old = (dt_iop_colorin_params_v3_t *)old_params;
-    dt_iop_colorin_params_t *new = (dt_iop_colorin_params_t *)new_params;
+    dt_iop_colorin_params_v7_t *new =
+      (dt_iop_colorin_params_v7_t *)malloc(sizeof(dt_iop_colorin_params_v7_t));
     memset(new, 0, sizeof(*new));
 
     if(!strcmp(old->iccprofile, "eprofile"))
@@ -359,9 +383,12 @@ int legacy_params(dt_iop_module_t *self,
     new->type_work = DT_COLORSPACE_LIN_REC709;
     new->filename_work[0] = '\0';
 
+    *new_params = new;
+    *new_params_size = sizeof(dt_iop_colorin_params_v7_t);
+    *new_version = 7;
     return 0;
   }
-  if(old_version == 4 && new_version == 7)
+  if(old_version == 4)
   {
     typedef struct dt_iop_colorin_params_v4_t
     {
@@ -373,7 +400,8 @@ int legacy_params(dt_iop_module_t *self,
     } dt_iop_colorin_params_v4_t;
 
     const dt_iop_colorin_params_v4_t *old = (dt_iop_colorin_params_v4_t *)old_params;
-    dt_iop_colorin_params_t *new = (dt_iop_colorin_params_t *)new_params;
+    dt_iop_colorin_params_v7_t *new =
+      (dt_iop_colorin_params_v7_t *)malloc(sizeof(dt_iop_colorin_params_v7_t));
     memset(new, 0, sizeof(*new));
 
     new->type = old->type;
@@ -384,9 +412,13 @@ int legacy_params(dt_iop_module_t *self,
     new->type_work = DT_COLORSPACE_LIN_REC709;
     new->filename_work[0] = '\0';
 
+
+    *new_params = new;
+    *new_params_size = sizeof(dt_iop_colorin_params_v7_t);
+    *new_version = 7;
     return 0;
   }
-  if(old_version == 5 && new_version == 7)
+  if(old_version == 5)
   {
     typedef struct dt_iop_colorin_params_v5_t
     {
@@ -401,7 +433,8 @@ int legacy_params(dt_iop_module_t *self,
     } dt_iop_colorin_params_v5_t;
 
     const dt_iop_colorin_params_v5_t *old = (dt_iop_colorin_params_v5_t *)old_params;
-    dt_iop_colorin_params_t *new = (dt_iop_colorin_params_t *)new_params;
+    dt_iop_colorin_params_v7_t *new =
+      (dt_iop_colorin_params_v7_t *)malloc(sizeof(dt_iop_colorin_params_v7_t));
     memset(new, 0, sizeof(*new));
 
     new->type = old->type;
@@ -413,9 +446,12 @@ int legacy_params(dt_iop_module_t *self,
     g_strlcpy(new->filename_work, old->filename_work, sizeof(new->filename_work));
     _resolve_work_profile(&new->type_work, new->filename_work);
 
+    *new_params = new;
+    *new_params_size = sizeof(dt_iop_colorin_params_v7_t);
+    *new_version = 7;
     return 0;
   }
-  if(old_version == 6 && new_version == 7)
+  if(old_version == 6)
   {
     // The structure is equal to to v7 (current) but a new version is
     // introduced to convert invalid working profile choice to the
@@ -433,10 +469,14 @@ int legacy_params(dt_iop_module_t *self,
     } dt_iop_colorin_params_v6_t;
 
     const dt_iop_colorin_params_v6_t *old = (dt_iop_colorin_params_v6_t *)old_params;
-    dt_iop_colorin_params_t *new = (dt_iop_colorin_params_t *)new_params;
+    dt_iop_colorin_params_v7_t *new =
+      (dt_iop_colorin_params_v7_t *)malloc(sizeof(dt_iop_colorin_params_v7_t));
     memcpy(new, old, sizeof(*new));
     _resolve_work_profile(&new->type_work, new->filename_work);
 
+    *new_params = new;
+    *new_params_size = sizeof(dt_iop_colorin_params_v7_t);
+    *new_version = 7;
     return 0;
   }
   return 1;

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -42,15 +42,6 @@
 
 DT_MODULE_INTROSPECTION(2, dt_iop_colorize_params_t)
 
-// legacy parameters of version 1 of module
-typedef struct dt_iop_colorize_params1_t
-{
-  float hue;
-  float saturation;
-  float source_lightness_mix;
-  float lightness;
-} dt_iop_colorize_params1_t;
-
 typedef struct dt_iop_colorize_params_t
 {
   float hue;                  // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 0.0
@@ -110,19 +101,45 @@ const char **description(struct dt_iop_module_t *self)
                                       _("non-linear, Lab, display-referred"));
 }
 
-int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
-                  void *new_params, const int new_version)
+int legacy_params(dt_iop_module_t *self,
+                  const void *const old_params,
+                  const int old_version,
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 1 && new_version == 2)
+  typedef struct dt_iop_colorize_params_v2_t
   {
-    const dt_iop_colorize_params1_t *old = old_params;
-    dt_iop_colorize_params_t *new = new_params;
+    float hue;
+    float saturation;
+    float source_lightness_mix;
+    float lightness;
+    int version;
+  } dt_iop_colorize_params_v2_t;
 
-    new->hue = old->hue;
-    new->saturation = old->saturation;
-    new->source_lightness_mix = old->source_lightness_mix;
-    new->lightness = old->lightness;
-    new->version = 1;
+  if(old_version == 1)
+  {
+    typedef struct dt_iop_colorize_params_v1_t
+    {
+      float hue;
+      float saturation;
+      float source_lightness_mix;
+      float lightness;
+    } dt_iop_colorize_params_v1_t;
+
+    const dt_iop_colorize_params_v1_t *o = old_params;
+    dt_iop_colorize_params_v2_t *n =
+      (dt_iop_colorize_params_v2_t *)malloc(sizeof(dt_iop_colorize_params_v2_t));
+
+    n->hue = o->hue;
+    n->saturation = o->saturation;
+    n->source_lightness_mix = o->source_lightness_mix;
+    n->lightness = o->lightness;
+    n->version = 1;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_colorize_params_v2_t);
+    *new_version = 2;
     return 0;
   }
   return 1;
@@ -363,4 +380,3 @@ void gui_init(struct dt_iop_module_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -54,21 +54,6 @@ typedef enum dt_iop_colorreconstruct_precedence_t
   COLORRECONSTRUCT_PRECEDENCE_HUE     // $DESCRIPTION: "hue" use a specific hue as weighting factor
 } dt_iop_colorreconstruct_precedence_t;
 
-typedef struct dt_iop_colorreconstruct_params1_t
-{
-  float threshold;
-  float spatial;
-  float range;
-} dt_iop_colorreconstruct_params1_t;
-
-typedef struct dt_iop_colorreconstruct_params2_t
-{
-  float threshold;
-  float spatial;
-  float range;
-  dt_iop_colorreconstruct_precedence_t precedence;
-} dt_iop_colorreconstruct_params2_t;
-
 typedef struct dt_iop_colorreconstruct_params_t
 {
   float threshold; // $MIN: 50.0 $MAX: 150.0 $DEFAULT: 100.0
@@ -157,29 +142,67 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
   return IOP_CS_LAB;
 }
 
-int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
-                  void *new_params, const int new_version)
+int legacy_params(dt_iop_module_t *self,
+                  const void *const old_params,
+                  const int old_version,
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 1 && new_version == 3)
+  typedef struct dt_iop_colorreconstruct_params_v3_t
   {
-    const dt_iop_colorreconstruct_params1_t *old = old_params;
-    dt_iop_colorreconstruct_params_t *new = new_params;
+    float threshold;
+    float spatial;
+    float range;
+    float hue;
+    dt_iop_colorreconstruct_precedence_t precedence;
+  } dt_iop_colorreconstruct_params_v3_t;
+
+  if(old_version == 1)
+  {
+    typedef struct dt_iop_colorreconstruct_params_v1_t
+    {
+      float threshold;
+      float spatial;
+      float range;
+    } dt_iop_colorreconstruct_params_v1_t;
+
+    const dt_iop_colorreconstruct_params_v1_t *old = old_params;
+    dt_iop_colorreconstruct_params_v3_t *new =
+      (dt_iop_colorreconstruct_params_v3_t *)malloc(sizeof(dt_iop_colorreconstruct_params_v3_t));
     new->threshold = old->threshold;
     new->spatial = old->spatial;
     new->range = old->range;
     new->precedence = COLORRECONSTRUCT_PRECEDENCE_NONE;
     new->hue = 0.66f;
+
+    *new_params = new;
+    *new_params_size = sizeof(dt_iop_colorreconstruct_params_v3_t);
+    *new_version = 3;
     return 0;
   }
-  else if(old_version == 2 && new_version == 3)
+  else if(old_version == 2)
   {
-    const dt_iop_colorreconstruct_params2_t *old = old_params;
-    dt_iop_colorreconstruct_params_t *new = new_params;
+    typedef struct dt_iop_colorreconstruct_params_v2_t
+    {
+      float threshold;
+      float spatial;
+      float range;
+      dt_iop_colorreconstruct_precedence_t precedence;
+    } dt_iop_colorreconstruct_params_v2_t;
+
+    const dt_iop_colorreconstruct_params_v2_t *old = old_params;
+    dt_iop_colorreconstruct_params_v3_t *new =
+      (dt_iop_colorreconstruct_params_v3_t *)malloc(sizeof(dt_iop_colorreconstruct_params_v3_t));
     new->threshold = old->threshold;
     new->spatial = old->spatial;
     new->range = old->range;
     new->precedence = old->precedence;
     new->hue = 0.66f;
+
+    *new_params = new;
+    *new_params_size = sizeof(dt_iop_colorreconstruct_params_v3_t);
+    *new_version = 3;
     return 0;
   }
   return 1;
@@ -1282,4 +1305,3 @@ void gui_cleanup(struct dt_iop_module_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -165,21 +165,38 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
   return IOP_CS_LAB;
 }
 
-int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,
-                  const int new_version)
+int legacy_params(dt_iop_module_t *self,
+                  const void *const old_params,
+                  const int old_version,
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
+  typedef struct dt_iop_colorzones_params_v5_t
+  {
+    dt_iop_colorzones_channel_t channel;
+    // three curves (L, C, h) with max number of nodes
+    dt_iop_colorzones_node_t curve[DT_IOP_COLORZONES_MAX_CHANNELS][DT_IOP_COLORZONES_MAXNODES];
+    int curve_num_nodes[DT_IOP_COLORZONES_MAX_CHANNELS];
+    int curve_type[DT_IOP_COLORZONES_MAX_CHANNELS];
+    float strength;
+    dt_iop_colorzones_modes_t mode;
+    int splines_version;
+  } dt_iop_colorzones_params_v5_t;
+
 #define DT_IOP_COLORZONES1_BANDS 6
 
-  if(old_version == 1 && new_version == 5)
+  if(old_version == 1)
   {
-    typedef struct dt_iop_colorzones_params1_t
+    typedef struct dt_iop_colorzones_params_v1_t
     {
       int32_t channel;
       float equalizer_x[3][DT_IOP_COLORZONES1_BANDS], equalizer_y[3][DT_IOP_COLORZONES1_BANDS];
-    } dt_iop_colorzones_params1_t;
+    } dt_iop_colorzones_params_v1_t;
 
-    const dt_iop_colorzones_params1_t *old = old_params;
-    dt_iop_colorzones_params_t *new = new_params;
+    const dt_iop_colorzones_params_v1_t *old = old_params;
+    dt_iop_colorzones_params_v5_t *new =
+      (dt_iop_colorzones_params_v5_t *)malloc(sizeof(dt_iop_colorzones_params_v5_t));
 
     new->channel = old->channel;
 
@@ -217,18 +234,23 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     new->strength = 0.0f;
     new->mode = DT_IOP_COLORZONES_MODE_SMOOTH;
     new->splines_version = DT_IOP_COLORZONES_SPLINES_V1;
+
+    *new_params = new;
+    *new_params_size = sizeof(dt_iop_colorzones_params_v5_t);
+    *new_version = 5;
     return 0;
   }
-  if(old_version == 2 && new_version == 5)
+  if(old_version == 2)
   {
-    typedef struct dt_iop_colorzones_params2_t
+    typedef struct dt_iop_colorzones_params_v2_t
     {
       int32_t channel;
       float equalizer_x[3][DT_IOP_COLORZONES_BANDS], equalizer_y[3][DT_IOP_COLORZONES_BANDS];
-    } dt_iop_colorzones_params2_t;
+    } dt_iop_colorzones_params_v2_t;
 
-    const dt_iop_colorzones_params2_t *old = old_params;
-    dt_iop_colorzones_params_t *new = new_params;
+    const dt_iop_colorzones_params_v2_t *old = old_params;
+    dt_iop_colorzones_params_v5_t *new =
+      (dt_iop_colorzones_params_v5_t *)malloc(sizeof(dt_iop_colorzones_params_v5_t));
     new->channel = old->channel;
 
     for(int b = 0; b < DT_IOP_COLORZONES_BANDS; b++)
@@ -245,19 +267,24 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     new->strength = 0.0f;
     new->mode = DT_IOP_COLORZONES_MODE_SMOOTH;
     new->splines_version = DT_IOP_COLORZONES_SPLINES_V1;
+
+    *new_params = new;
+    *new_params_size = sizeof(dt_iop_colorzones_params_v5_t);
+    *new_version = 5;
     return 0;
   }
-  if(old_version == 3 && new_version == 5)
+  if(old_version == 3)
   {
-    typedef struct dt_iop_colorzones_params3_t
+    typedef struct dt_iop_colorzones_params_v3_t
     {
       int32_t channel;
       float equalizer_x[3][DT_IOP_COLORZONES_BANDS], equalizer_y[3][DT_IOP_COLORZONES_BANDS];
       float strength;
-    } dt_iop_colorzones_params3_t;
+    } dt_iop_colorzones_params_v3_t;
 
-    const dt_iop_colorzones_params3_t *old = old_params;
-    dt_iop_colorzones_params_t *new = new_params;
+    const dt_iop_colorzones_params_v3_t *old = old_params;
+    dt_iop_colorzones_params_v5_t *new =
+      (dt_iop_colorzones_params_v5_t *)malloc(sizeof(dt_iop_colorzones_params_v5_t));
     new->channel = old->channel;
 
     for(int b = 0; b < DT_IOP_COLORZONES_BANDS; b++)
@@ -276,11 +303,15 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     new->strength = old->strength;
     new->mode = DT_IOP_COLORZONES_MODE_SMOOTH;
     new->splines_version = DT_IOP_COLORZONES_SPLINES_V1;
+
+    *new_params = new;
+    *new_params_size = sizeof(dt_iop_colorzones_params_v5_t);
+    *new_version = 5;
     return 0;
   }
-  if(old_version == 4 && new_version == 5)
+  if(old_version == 4)
   {
-    typedef struct dt_iop_colorzones_params4_t
+    typedef struct dt_iop_colorzones_params_v4_t
     {
       int32_t channel;
       dt_iop_colorzones_node_t curve[DT_IOP_COLORZONES_MAX_CHANNELS][DT_IOP_COLORZONES_MAXNODES];
@@ -288,10 +319,11 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
       int curve_type[DT_IOP_COLORZONES_MAX_CHANNELS];
       float strength;
       int mode;
-    } dt_iop_colorzones_params4_t;
+    } dt_iop_colorzones_params_v4_t;
 
-    const dt_iop_colorzones_params4_t *old = old_params;
-    dt_iop_colorzones_params_t *new = new_params;
+    const dt_iop_colorzones_params_v4_t *old = old_params;
+    dt_iop_colorzones_params_v5_t *new =
+      (dt_iop_colorzones_params_v5_t *)malloc(sizeof(dt_iop_colorzones_params_v5_t));
     new->channel = old->channel;
 
     for(int i = 0; i < DT_IOP_COLORZONES_MAXNODES; i++)
@@ -310,6 +342,10 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     new->strength = old->strength;
     new->mode = old->mode;
     new->splines_version = DT_IOP_COLORZONES_SPLINES_V1;
+
+    *new_params = new;
+    *new_params_size = sizeof(dt_iop_colorzones_params_v5_t);
+    *new_version = 5;
     return 0;
   }
 #undef DT_IOP_COLORZONES1_BANDS

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -118,15 +118,6 @@ typedef struct dt_iop_crop_data_t
   float cx, cy, cw, ch; // crop window
 } dt_iop_crop_data_t;
 
-int legacy_params(dt_iop_module_t *self,
-                  const void *const old_params,
-                  const int old_version,
-                  void *new_params,
-                  const int new_version)
-{
-  return 0;
-}
-
 const char *name()
 {
   return _("crop");

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -231,11 +231,16 @@ static void debug_dump_PFM(const dt_dev_pixelpipe_iop_t *const piece,
   dt_dump_pfm(name, buf, width, height,  4 * sizeof(float), "denoiseprofile");
 }
 
-int legacy_params(dt_iop_module_t *self,
-                  const void *const old_params,
-                  const int old_version,
-                  void *new_params,
-                  const int new_version)
+/* old legacy_params routine used up to v11
+   this is now called into the legacy_params supporting incremental
+   updates. It was too risky to rewrite the old legacy params support
+   as it is a very tricky code.
+*/
+int legacy_params_to11(dt_iop_module_t *self,
+                       const void *const old_params,
+                       const int old_version,
+                       void *new_params,
+                       const int new_version)
 {
   typedef struct dt_iop_denoiseprofile_params_v1_t
   {
@@ -424,7 +429,7 @@ int legacy_params(dt_iop_module_t *self,
     if(old_version < 4)
     {
       // first update to v4
-      if(legacy_params(self, old_params, old_version, &v4, 4))
+      if(legacy_params_to11(self, old_params, old_version, &v4, 4))
         return 1;
     }
     else
@@ -456,7 +461,7 @@ int legacy_params(dt_iop_module_t *self,
     if(old_version < 5)
     {
       // first update to v5
-      if(legacy_params(self, old_params, old_version, &v5, 5)) return 1;
+      if(legacy_params_to11(self, old_params, old_version, &v5, 5)) return 1;
     }
     else
       memcpy(&v5, old_params, sizeof(v5)); // was v5 already
@@ -488,7 +493,7 @@ int legacy_params(dt_iop_module_t *self,
     if(old_version < 6)
     {
       // first update to v6
-      if(legacy_params(self, old_params, old_version, &v6, 6)) return 1;
+      if(legacy_params_to11(self, old_params, old_version, &v6, 6)) return 1;
     }
     else
       memcpy(&v6, old_params, sizeof(v6)); // was v6 already
@@ -525,7 +530,7 @@ int legacy_params(dt_iop_module_t *self,
     if(old_version < 7)
     {
       // first update to v7
-      if(legacy_params(self, old_params, old_version, &v7, 7)) return 1;
+      if(legacy_params_to11(self, old_params, old_version, &v7, 7)) return 1;
     }
     else
       memcpy(&v7, old_params, sizeof(v7)); // was v7 already
@@ -563,7 +568,7 @@ int legacy_params(dt_iop_module_t *self,
     if(old_version < 8)
     {
       // first update to v8
-      if(legacy_params(self, old_params, old_version, &v8, 8)) return 1;
+      if(legacy_params_to11(self, old_params, old_version, &v8, 8)) return 1;
     }
     else
       memcpy(&v8, old_params, sizeof(v8)); // was v8 already
@@ -609,7 +614,7 @@ int legacy_params(dt_iop_module_t *self,
     if(old_version < 9)
     {
       // first update to v9
-      if(legacy_params(self, old_params, old_version, &v9, 9)) return 1;
+      if(legacy_params_to11(self, old_params, old_version, &v9, 9)) return 1;
     }
     else
       memcpy(&v9, old_params, sizeof(v9)); // was v9 already
@@ -658,7 +663,7 @@ int legacy_params(dt_iop_module_t *self,
     dt_iop_denoiseprofile_params_t *v11 = new_params;
     if(old_version < 10)
     {
-      if(legacy_params(self, old_params, old_version, v11, 10)) return 1;
+      if(legacy_params_to11(self, old_params, old_version, v11, 10)) return 1;
     }
     else
       memcpy(v11, old_params, sizeof(*v11)); // was v10 already
@@ -676,6 +681,53 @@ int legacy_params(dt_iop_module_t *self,
   }
   return 1;
 }
+
+int legacy_params(dt_iop_module_t *self,
+                  const void *const old_params,
+                  const int old_version,
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
+{
+  typedef struct dt_iop_denoiseprofile_params_v11_t
+  {
+    float radius;
+    float nbhood;
+    float strength;
+    float shadows;
+    float bias;
+    float scattering;
+    float central_pixel_weight;
+    float overshooting;
+    float a[3], b[3];
+    dt_iop_denoiseprofile_mode_t mode;
+    float x[DT_DENOISE_PROFILE_NONE][DT_IOP_DENOISE_PROFILE_BANDS];
+    float y[DT_DENOISE_PROFILE_NONE][DT_IOP_DENOISE_PROFILE_BANDS];
+    gboolean wb_adaptive_anscombe;
+    gboolean fix_anscombe_and_nlmeans_norm;
+    gboolean use_new_vst;
+    dt_iop_denoiseprofile_wavelet_mode_t wavelet_color_mode;
+  } dt_iop_denoiseprofile_params_v11_t;
+
+  if(old_version < 11)
+  {
+    *new_params = (dt_iop_denoiseprofile_params_v11_t *)
+      malloc(sizeof(dt_iop_denoiseprofile_params_v11_t));
+
+    const int ret = legacy_params_to11(self,
+                                       old_params,
+                                       old_version,
+                                       *new_params,
+                                       11);
+
+    *new_params_size = sizeof(dt_iop_denoiseprofile_params_v11_t);
+    *new_version = 11;
+    return ret;
+  }
+
+  return 1;
+}
+
 
 void init_presets(dt_iop_module_so_t *self)
 {

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -168,10 +168,36 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
 int legacy_params(dt_iop_module_t *self,
                   const void *const old_params,
                   const int old_version,
-                  void *new_params,
-                  const int new_version)
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 1 && new_version == 2)
+  typedef struct dt_iop_diffuse_params_v2_t
+  {
+    // global parameters
+    int iterations;
+    float sharpness;
+    int radius;
+    float regularization;
+    float variance_threshold;
+
+    float anisotropy_first;
+    float anisotropy_second;
+    float anisotropy_third;
+    float anisotropy_fourth;
+
+    float threshold;
+
+    float first;
+    float second;
+    float third;
+    float fourth;
+
+    // v2
+    int radius_center;
+  } dt_iop_diffuse_params_v2_t;
+
+  if(old_version == 1)
   {
     typedef struct dt_iop_diffuse_params_v1_t
     {
@@ -195,11 +221,9 @@ int legacy_params(dt_iop_module_t *self,
       float fourth;
     } dt_iop_diffuse_params_v1_t;
 
-    dt_iop_diffuse_params_v1_t *o = (dt_iop_diffuse_params_v1_t *)old_params;
-    dt_iop_diffuse_params_t *n = (dt_iop_diffuse_params_t *)new_params;
-    const dt_iop_diffuse_params_t *const d = (dt_iop_diffuse_params_t *)self->default_params;
-
-    *n = *d; // start with a fresh copy of default parameters
+    const dt_iop_diffuse_params_v1_t *o = (dt_iop_diffuse_params_v1_t *)old_params;
+    dt_iop_diffuse_params_v2_t *n =
+      (dt_iop_diffuse_params_v2_t *)malloc(sizeof(dt_iop_diffuse_params_v2_t));
 
     // copy common parameters
     memcpy(n, o, sizeof(dt_iop_diffuse_params_v1_t));
@@ -207,6 +231,9 @@ int legacy_params(dt_iop_module_t *self,
     // init only new parameters
     n->radius_center = 0;
 
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_diffuse_params_v2_t);
+    *new_version = 2;
     return 0;
   }
   return 1;

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -168,28 +168,44 @@ static void _exposure_set_black(struct dt_iop_module_t *self,
 int legacy_params(dt_iop_module_t *self,
                   const void *const old_params,
                   const int old_version,
-                  void *new_params,
-                  const int new_version)
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 2 && new_version == 6)
+  typedef struct dt_iop_exposure_params_v6_t
+  {
+    dt_iop_exposure_mode_t mode;
+    float black;
+    float exposure;
+    float deflicker_percentile;
+    float deflicker_target_level;
+    gboolean compensate_exposure_bias;
+  } dt_iop_exposure_params_v6_t;
+
+  if(old_version == 2)
   {
     typedef struct dt_iop_exposure_params_v2_t
     {
       float black, exposure, gain;
     } dt_iop_exposure_params_v2_t;
 
-    dt_iop_exposure_params_v2_t *o = (dt_iop_exposure_params_v2_t *)old_params;
-    dt_iop_exposure_params_t *n = (dt_iop_exposure_params_t *)new_params;
-    const dt_iop_exposure_params_t *const d = (dt_iop_exposure_params_t *)self->default_params;
+    const dt_iop_exposure_params_v2_t *o = (dt_iop_exposure_params_v2_t *)old_params;
+    dt_iop_exposure_params_v6_t *n =
+      (dt_iop_exposure_params_v6_t *)malloc(sizeof(dt_iop_exposure_params_v6_t));
 
-    *n = *d; // start with a fresh copy of default parameters
-
+    n->mode = EXPOSURE_MODE_MANUAL;
     n->black = o->black;
     n->exposure = o->exposure;
     n->compensate_exposure_bias = FALSE;
+    n->deflicker_percentile = 50.0f;
+    n->deflicker_target_level = -4.0f;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_exposure_params_v6_t);
+    *new_version = 6;
     return 0;
   }
-  if(old_version == 3 && new_version == 6)
+  if(old_version == 3)
   {
     typedef struct dt_iop_exposure_params_v3_t
     {
@@ -198,11 +214,9 @@ int legacy_params(dt_iop_module_t *self,
       float deflicker_percentile, deflicker_target_level;
     } dt_iop_exposure_params_v3_t;
 
-    dt_iop_exposure_params_v3_t *o = (dt_iop_exposure_params_v3_t *)old_params;
-    dt_iop_exposure_params_t *n = (dt_iop_exposure_params_t *)new_params;
-    const dt_iop_exposure_params_t *const d = (dt_iop_exposure_params_t *)self->default_params;
-
-    *n = *d; // start with a fresh copy of default parameters
+    const dt_iop_exposure_params_v3_t *o = (dt_iop_exposure_params_v3_t *)old_params;
+    dt_iop_exposure_params_v6_t *n =
+      (dt_iop_exposure_params_v6_t *)malloc(sizeof(dt_iop_exposure_params_v6_t));
 
     n->mode = o->deflicker ? EXPOSURE_MODE_DEFLICKER : EXPOSURE_MODE_MANUAL;
     n->black = o->black;
@@ -210,9 +224,13 @@ int legacy_params(dt_iop_module_t *self,
     n->deflicker_percentile = o->deflicker_percentile;
     n->deflicker_target_level = o->deflicker_target_level;
     n->compensate_exposure_bias = FALSE;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_exposure_params_v6_t);
+    *new_version = 6;
     return 0;
   }
-  if(old_version == 4 && new_version == 6)
+  if(old_version == 4)
   {
     typedef enum dt_iop_exposure_deflicker_histogram_source_t {
       DEFLICKER_HISTOGRAM_SOURCE_THUMBNAIL,
@@ -228,11 +246,9 @@ int legacy_params(dt_iop_module_t *self,
       dt_iop_exposure_deflicker_histogram_source_t deflicker_histogram_source;
     } dt_iop_exposure_params_v4_t;
 
-    dt_iop_exposure_params_v4_t *o = (dt_iop_exposure_params_v4_t *)old_params;
-    dt_iop_exposure_params_t *n = (dt_iop_exposure_params_t *)new_params;
-    const dt_iop_exposure_params_t *const d = (dt_iop_exposure_params_t *)self->default_params;
-
-    *n = *d; // start with a fresh copy of default parameters
+    const dt_iop_exposure_params_v4_t *o = (dt_iop_exposure_params_v4_t *)old_params;
+    dt_iop_exposure_params_v6_t *n =
+      (dt_iop_exposure_params_v6_t *)malloc(sizeof(dt_iop_exposure_params_v6_t));
 
     n->mode = o->mode;
     n->black = o->black;
@@ -242,9 +258,13 @@ int legacy_params(dt_iop_module_t *self,
     // deflicker_histogram_source is dropped. this does change output,
     // but deflicker still was not publicly released at that point
     n->compensate_exposure_bias = FALSE;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_exposure_params_v6_t);
+    *new_version = 6;
     return 0;
   }
-  if(old_version == 5 && new_version == 6)
+  if(old_version == 5)
   {
     typedef struct dt_iop_exposure_params_v5_t
     {
@@ -254,11 +274,9 @@ int legacy_params(dt_iop_module_t *self,
       float deflicker_percentile, deflicker_target_level;
     } dt_iop_exposure_params_v5_t;
 
-    dt_iop_exposure_params_v5_t *o = (dt_iop_exposure_params_v5_t *)old_params;
-    dt_iop_exposure_params_t *n = (dt_iop_exposure_params_t *)new_params;
-    const dt_iop_exposure_params_t *const d = (dt_iop_exposure_params_t *)self->default_params;
-
-    *n = *d; // start with a fresh copy of default parameters
+    const dt_iop_exposure_params_v5_t *o = (dt_iop_exposure_params_v5_t *)old_params;
+    dt_iop_exposure_params_v6_t *n =
+      (dt_iop_exposure_params_v6_t *)malloc(sizeof(dt_iop_exposure_params_v6_t));
 
     n->mode = o->mode;
     n->black = o->black;
@@ -266,6 +284,10 @@ int legacy_params(dt_iop_module_t *self,
     n->deflicker_percentile = o->deflicker_percentile;
     n->deflicker_target_level = o->deflicker_target_level;
     n->compensate_exposure_bias = FALSE;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_exposure_params_v6_t);
+    *new_version = 6;
     return 0;
   }
   return 1;

--- a/src/iop/grain.c
+++ b/src/iop/grain.c
@@ -85,10 +85,22 @@ typedef struct dt_iop_grain_data_t
 } dt_iop_grain_data_t;
 
 
-int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,
-                  const int new_version)
+int legacy_params(dt_iop_module_t *self,
+                  const void *const old_params,
+                  const int old_version,
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 1 && new_version == 2)
+  typedef struct dt_iop_grain_params_v2_t
+  {
+    _dt_iop_grain_channel_t channel;
+    float scale;
+    float strength;
+    float midtones_bias;
+  } dt_iop_grain_params_v2_t;
+
+  if(old_version == 1)
   {
     typedef struct dt_iop_grain_params_v1_t
     {
@@ -98,13 +110,17 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     } dt_iop_grain_params_v1_t;
 
     const dt_iop_grain_params_v1_t *o = old_params;
-    dt_iop_grain_params_t *n = new_params;
+    dt_iop_grain_params_v2_t *n =
+      (dt_iop_grain_params_v2_t *)malloc(sizeof(dt_iop_grain_params_v2_t));
 
     n->channel = o->channel;
     n->scale = o->scale;
     n->strength = o->strength;
     n->midtones_bias = 0.0; // it produces the same results as the old version
 
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_grain_params_v2_t);
+    *new_version = 2;
     return 0;
   }
   return 1;
@@ -597,4 +613,3 @@ void gui_init(struct dt_iop_module_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -202,19 +202,44 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
 int legacy_params(dt_iop_module_t *self,
                   const void *const old_params,
                   const int old_version,
-                  void *new_params,
-                  const int new_version)
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 1 && new_version == 4)
+  typedef struct dt_iop_highlights_params_v4_t
   {
-    /*
-      params of v2 :
-        float clip
-      + params of v3
-      + params of v4
-    */
-    memcpy(new_params, old_params, sizeof(dt_iop_highlights_params_t) - 5 * sizeof(float) - 2 * sizeof(int) - sizeof(dt_atrous_wavelets_scales_t));
-    dt_iop_highlights_params_t *n = (dt_iop_highlights_params_t *)new_params;
+    // params of v1
+    dt_iop_highlights_mode_t mode;
+    float blendL;
+    float blendC;
+    float strength;
+    // params of v2
+    float clip;
+    // params of v3
+    float noise_level;
+    int iterations;
+    dt_atrous_wavelets_scales_t scales;
+    float candidating;
+    float combine;
+    dt_recovery_mode_t recovery;
+    // params of v4
+    float solid_color;
+  } dt_iop_highlights_params_v4_t;
+
+  if(old_version == 1)
+  {
+    typedef struct dt_iop_highlights_params_v1_t
+    {
+      dt_iop_highlights_mode_t mode;
+      float blendL, blendC, blendh;
+      float strength;
+    } dt_iop_highlights_params_v1_t;
+
+    const dt_iop_highlights_params_v1_t *o = (dt_iop_highlights_params_v1_t *)old_params;
+    dt_iop_highlights_params_v4_t *n =
+      (dt_iop_highlights_params_v4_t *)malloc(sizeof(dt_iop_highlights_params_v4_t));
+    memcpy(n, o, sizeof(dt_iop_highlights_params_v1_t));
+
     n->clip = 1.0f;
     n->noise_level = 0.0f;
     n->candidating = 0.4f;
@@ -224,22 +249,27 @@ int legacy_params(dt_iop_module_t *self,
     n->scales = 5;
     n->solid_color = 0.f;
     n->strength = 0.0f;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_highlights_params_v4_t);
+    *new_version = 4;
     return 0;
   }
-  if(old_version == 2 && new_version == 4)
+  if(old_version == 2)
   {
-    /*
-      params of v3 :
-        float noise_level;
-        int iterations;
-        dt_atrous_wavelets_scales_t scales;
-        float candidating;
-        float combine;
-        int recovery;
-      + params of v4
-    */
-    memcpy(new_params, old_params, sizeof(dt_iop_highlights_params_t) - 4 * sizeof(float) - 2 * sizeof(int) - sizeof(dt_atrous_wavelets_scales_t));
-    dt_iop_highlights_params_t *n = (dt_iop_highlights_params_t *)new_params;
+    typedef struct dt_iop_highlights_params_v2_t
+    {
+      dt_iop_highlights_mode_t mode;
+      float blendL, blendC, blendh;
+      float strength;
+      float clip;
+    } dt_iop_highlights_params_v2_t;
+
+    const dt_iop_highlights_params_v2_t *o = (dt_iop_highlights_params_v2_t *)old_params;
+    dt_iop_highlights_params_v4_t *n =
+      (dt_iop_highlights_params_v4_t *)malloc(sizeof(dt_iop_highlights_params_v4_t));
+    memcpy(n, o, sizeof(dt_iop_highlights_params_v2_t));
+
     n->noise_level = 0.0f;
     n->candidating = 0.4f;
     n->combine = 2.f;
@@ -248,18 +278,38 @@ int legacy_params(dt_iop_module_t *self,
     n->scales = 5;
     n->solid_color = 0.f;
     n->strength = 0.0f;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_highlights_params_v4_t);
+    *new_version = 4;
     return 0;
   }
-  if(old_version == 3 && new_version == 4)
+  if(old_version == 3)
   {
-    /*
-      params of v4 :
-        float solid_color;
-    */
-    memcpy(new_params, old_params, sizeof(dt_iop_highlights_params_t) - sizeof(float));
-    dt_iop_highlights_params_t *n = (dt_iop_highlights_params_t *)new_params;
+    typedef struct dt_iop_highlights_params_v3_t
+    {
+      dt_iop_highlights_mode_t mode;
+      float blendL, blendC, blendh;
+      float strength;
+      float noise_level;
+      int iterations;
+      dt_atrous_wavelets_scales_t scales;
+      float candidating;
+      float combine;
+      dt_recovery_mode_t recovery;
+    } dt_iop_highlights_params_v3_t;
+
+    const dt_iop_highlights_params_v3_t *o = (dt_iop_highlights_params_v3_t *)old_params;
+    dt_iop_highlights_params_v4_t *n =
+      (dt_iop_highlights_params_v4_t *)malloc(sizeof(dt_iop_highlights_params_v4_t));
+    memcpy(n, o, sizeof(dt_iop_highlights_params_v3_t));
+
     n->solid_color = 0.f;
     n->strength = 0.0f;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_highlights_params_v4_t);
+    *new_version = 4;
     return 0;
   }
 

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -164,8 +164,13 @@ OPTIONAL(void, modify_roi_in, struct dt_iop_module_t *self, struct dt_dev_pixelp
                               const struct dt_iop_roi_t *roi_out, struct dt_iop_roi_t *roi_in);
 OPTIONAL(void, modify_roi_out, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                                struct dt_iop_roi_t *roi_out, const struct dt_iop_roi_t *roi_in);
-OPTIONAL(int, legacy_params, struct dt_iop_module_t *self, const void *const old_params, const int old_version,
-                             void *new_params, const int new_version);
+OPTIONAL(int, legacy_params,
+         struct dt_iop_module_t *self,
+         const void *const old_params,
+         const int old_version,
+         void **new_params,
+         int32_t *new_params_size,
+         int *new_version);
 // allow to select a shape inside an iop
 OPTIONAL(void, masks_selection_changed, struct dt_iop_module_t *self, const int form_selected_id);
 
@@ -232,4 +237,3 @@ OPTIONAL(void, set_preferences, void *menu, struct dt_iop_module_t *self);
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -52,34 +52,6 @@ typedef enum dt_iop_lowpass_algo_t
   LOWPASS_ALGO_BILATERAL // $DESCRIPTION: "bilateral filter"
 } dt_iop_lowpass_algo_t;
 
-/* legacy version 1 params */
-typedef struct dt_iop_lowpass_params1_t
-{
-  dt_gaussian_order_t order;
-  float radius;
-  float contrast;
-  float saturation;
-} dt_iop_lowpass_params1_t;
-
-typedef struct dt_iop_lowpass_params2_t
-{
-  dt_gaussian_order_t order;
-  float radius;
-  float contrast;
-  float brightness;
-  float saturation;
-} dt_iop_lowpass_params2_t;
-
-typedef struct dt_iop_lowpass_params3_t
-{
-  dt_gaussian_order_t order;
-  float radius;
-  float contrast;
-  float brightness;
-  float saturation;
-  int unbound;
-} dt_iop_lowpass_params3_t;
-
 typedef struct dt_iop_lowpass_params_t
 {
   dt_gaussian_order_t order; // $DEFAULT: 0
@@ -157,13 +129,34 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
 int legacy_params(dt_iop_module_t *self,
                   const void *const old_params,
                   const int old_version,
-                  void *new_params,
-                  const int new_version)
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 1 && new_version == 4)
+  typedef struct dt_iop_lowpass_params_v4_t
   {
-    const dt_iop_lowpass_params1_t *old = old_params;
-    dt_iop_lowpass_params_t *new = new_params;
+    dt_gaussian_order_t order;
+    float radius;
+    float contrast;
+    float brightness;
+    float saturation;
+    dt_iop_lowpass_algo_t lowpass_algo;
+    int unbound;
+  } dt_iop_lowpass_params_v4_t;
+
+  if(old_version == 1)
+  {
+    typedef struct dt_iop_lowpass_params_v1_t
+    {
+      dt_gaussian_order_t order;
+      float radius;
+      float contrast;
+      float saturation;
+    } dt_iop_lowpass_params_v1_t;
+
+    const dt_iop_lowpass_params_v1_t *old = old_params;
+    dt_iop_lowpass_params_v4_t *new =
+      (dt_iop_lowpass_params_v4_t *)malloc(sizeof(dt_iop_lowpass_params_v4_t));
     new->order = old->order;
     new->radius = fabs(old->radius);
     new->contrast = old->contrast;
@@ -172,12 +165,25 @@ int legacy_params(dt_iop_module_t *self,
     new->lowpass_algo = old->radius < 0.0f ? LOWPASS_ALGO_BILATERAL : LOWPASS_ALGO_GAUSSIAN;
     new->unbound = 0;
 
+    *new_params = new;
+    *new_params_size = sizeof(dt_iop_lowpass_params_v4_t);
+    *new_version = 4;
     return 0;
   }
-  if(old_version == 2 && new_version == 4)
+  if(old_version == 2)
   {
-    const dt_iop_lowpass_params2_t *old = old_params;
-    dt_iop_lowpass_params_t *new = new_params;
+    typedef struct dt_iop_lowpass_params_v2_t
+    {
+      dt_gaussian_order_t order;
+      float radius;
+      float contrast;
+      float brightness;
+      float saturation;
+    } dt_iop_lowpass_params_v2_t;
+
+    const dt_iop_lowpass_params_v2_t *old = old_params;
+    dt_iop_lowpass_params_v4_t *new =
+      (dt_iop_lowpass_params_v4_t *)malloc(sizeof(dt_iop_lowpass_params_v4_t));
     new->order = old->order;
     new->radius = fabs(old->radius);
     new->contrast = old->contrast;
@@ -186,12 +192,26 @@ int legacy_params(dt_iop_module_t *self,
     new->lowpass_algo = old->radius < 0.0f ? LOWPASS_ALGO_BILATERAL : LOWPASS_ALGO_GAUSSIAN;
     new->unbound = 0;
 
+    *new_params = new;
+    *new_params_size = sizeof(dt_iop_lowpass_params_v4_t);
+    *new_version = 4;
     return 0;
   }
-  if(old_version == 3 && new_version == 4)
+  if(old_version == 3)
   {
-    const dt_iop_lowpass_params3_t *old = old_params;
-    dt_iop_lowpass_params_t *new = new_params;
+    typedef struct dt_iop_lowpass_params_v3_t
+    {
+      dt_gaussian_order_t order;
+      float radius;
+      float contrast;
+      float brightness;
+      float saturation;
+      int unbound;
+    } dt_iop_lowpass_params_v3_t;
+
+    const dt_iop_lowpass_params_v3_t *old = old_params;
+    dt_iop_lowpass_params_v4_t *new =
+      (dt_iop_lowpass_params_v4_t *)malloc(sizeof(dt_iop_lowpass_params_v4_t));
     new->order = old->order;
     new->radius = fabs(old->radius);
     new->contrast = old->contrast;
@@ -200,6 +220,9 @@ int legacy_params(dt_iop_module_t *self,
     new->lowpass_algo = old->radius < 0.0f ? LOWPASS_ALGO_BILATERAL : LOWPASS_ALGO_GAUSSIAN;
     new->unbound = old->unbound;
 
+    *new_params = new;
+    *new_params_size = sizeof(dt_iop_lowpass_params_v4_t);
+    *new_version = 4;
     return 0;
   }
   return 1;
@@ -599,4 +622,3 @@ void gui_init(struct dt_iop_module_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/mask_manager.c
+++ b/src/iop/mask_manager.c
@@ -63,15 +63,28 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
   return IOP_CS_RGB;
 }
 
-int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
-                  void *new_params, const int new_version)
+int legacy_params(dt_iop_module_t *self,
+                  const void *const old_params,
+                  const int old_version,
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 1 && new_version == 2)
+  typedef struct dt_iop_mask_manager_params_v2_t
   {
-    dt_iop_mask_manager_params_t *n = (dt_iop_mask_manager_params_t *)new_params;
-    const dt_iop_mask_manager_params_t *const d = (dt_iop_mask_manager_params_t *)self->default_params;
+    int dummy;
+  } dt_iop_mask_manager_params_v2_t;
 
-    *n = *d; // start with a fresh copy of default parameters
+  if(old_version == 1)
+  {
+    dt_iop_mask_manager_params_v2_t *n =
+      (dt_iop_mask_manager_params_v2_t *)malloc(sizeof(dt_iop_mask_manager_params_v2_t));
+
+    n->dummy = 0;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_mask_manager_params_v2_t);
+    *new_version = 2;
     return 0;
   }
   return 1;
@@ -129,4 +142,3 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -103,15 +103,39 @@ const char **description(struct dt_iop_module_t *self)
                                       _("non-linear, Lab, display-referred"));
 }
 
-int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
-                  void *new_params, const int new_version)
+int legacy_params(dt_iop_module_t *self,
+                  const void *const old_params,
+                  const int old_version,
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 1 && new_version == 2)
+  typedef struct dt_iop_monochrome_params_v2_t
   {
-    dt_iop_monochrome_params_t *p1 = (dt_iop_monochrome_params_t *)old_params;
-    dt_iop_monochrome_params_t *p2 = (dt_iop_monochrome_params_t *)new_params;
-    memcpy(p2, p1, sizeof(dt_iop_monochrome_params_t) - sizeof(float));
-    p2->highlights = 0.0f;
+    float a;
+    float b;
+    float size;
+    float highlights;
+  } dt_iop_monochrome_params_v2_t;
+
+  if(old_version == 1)
+  {
+    typedef struct dt_iop_monochrome_params_v1_t
+    {
+      float a;
+      float b;
+      float size;
+    } dt_iop_monochrome_params_v1_t;
+
+    const dt_iop_monochrome_params_v1_t *o = (dt_iop_monochrome_params_v1_t *)old_params;
+    dt_iop_monochrome_params_v2_t *n =
+      (dt_iop_monochrome_params_v2_t *)malloc(sizeof(dt_iop_monochrome_params_v2_t));
+    memcpy(n, o, sizeof(dt_iop_monochrome_params_v1_t));
+    n->highlights = 0.0f;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_monochrome_params_v2_t);
+    *new_version = 2;
     return 0;
   }
   return 1;
@@ -583,4 +607,3 @@ void gui_cleanup(struct dt_iop_module_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -43,12 +43,6 @@
 // and includes version information about compile-time dt
 DT_MODULE_INTROSPECTION(2, dt_iop_nlmeans_params_t)
 
-typedef struct dt_iop_nlmeans_params_v1_t
-{
-  float luma;
-  float chroma;
-} dt_iop_nlmeans_params_v1_t;
-
 typedef struct dt_iop_nlmeans_params_t
 {
   // these are stored in db.
@@ -105,17 +99,41 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
   return IOP_CS_LAB;
 }
 
-int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
-                  void *new_params, const int new_version)
+int legacy_params(dt_iop_module_t *self,
+                  const void *const old_params,
+                  const int old_version,
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 1 && new_version == 2)
+  typedef struct dt_iop_nlmeans_params_v2_t
   {
-    dt_iop_nlmeans_params_v1_t *o = (dt_iop_nlmeans_params_v1_t *)old_params;
-    dt_iop_nlmeans_params_t *n = (dt_iop_nlmeans_params_t *)new_params;
+    float radius;
+    float strength;
+    float luma;
+    float chroma;
+  } dt_iop_nlmeans_params_v2_t;
+
+  if(old_version == 1)
+  {
+    typedef struct dt_iop_nlmeans_params_v1_t
+    {
+      float luma;
+      float chroma;
+    } dt_iop_nlmeans_params_v1_t;
+
+    const dt_iop_nlmeans_params_v1_t *o = (dt_iop_nlmeans_params_v1_t *)old_params;
+    dt_iop_nlmeans_params_v2_t *n =
+      (dt_iop_nlmeans_params_v2_t *)malloc(sizeof(dt_iop_nlmeans_params_v2_t));
+
     n->luma = o->luma;
     n->chroma = o->chroma;
     n->strength = 100.0f;
     n->radius = 3;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_nlmeans_params_v2_t);
+    *new_version = 2;
     return 0;
   }
   return 1;
@@ -477,4 +495,3 @@ void gui_init(dt_iop_module_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -88,15 +88,6 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
   return IOP_CS_RGB;
 }
 
-
-int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
-                  void *new_params, const int new_version)
-{
-  // we do no longer have module params in here and just ignore any legacy entries
-  return 0;
-}
-
-
 // void init_key_accels(dt_iop_module_so_t *self)
 // {
 //   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "lower threshold"));
@@ -470,4 +461,3 @@ void init(dt_iop_module_t *module)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -164,10 +164,25 @@ void init_presets(dt_iop_module_so_t *self)
 }
 
 
-int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,
-                  const int new_version)
+int legacy_params(dt_iop_module_t *self,
+                  const void *const old_params,
+                  const int old_version,
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 1 && new_version == 2)
+  typedef struct dt_iop_profilegamma_params_v2_t
+  {
+    dt_iop_profilegamma_mode_t mode;
+    float linear;
+    float gamma;
+    float dynamic_range;
+    float grey_point;
+    float shadows_range;
+    float security_factor;
+  } dt_iop_profilegamma_params_v2_t;
+
+  if(old_version == 1)
   {
     typedef struct dt_iop_profilegamma_params_v1_t
     {
@@ -175,15 +190,22 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
       float gamma;
     } dt_iop_profilegamma_params_v1_t;
 
-    dt_iop_profilegamma_params_v1_t *o = (dt_iop_profilegamma_params_v1_t *)old_params;
-    dt_iop_profilegamma_params_t *n = (dt_iop_profilegamma_params_t *)new_params;
-    const dt_iop_profilegamma_params_t *const d = (dt_iop_profilegamma_params_t *)self->default_params;
-
-    *n = *d; // start with a fresh copy of default parameters
+    const dt_iop_profilegamma_params_v1_t *o =
+      (dt_iop_profilegamma_params_v1_t *)old_params;
+    dt_iop_profilegamma_params_v2_t *n =
+      (dt_iop_profilegamma_params_v2_t *)malloc(sizeof(dt_iop_profilegamma_params_v2_t));
 
     n->linear = o->linear;
     n->gamma = o->gamma;
     n->mode = PROFILEGAMMA_GAMMA;
+    n->dynamic_range = 10.0f;
+    n->grey_point = 18.0f;
+    n->shadows_range = -5.0f;
+    n->security_factor = 0.0f;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_profilegamma_params_v2_t);
+    *new_version = 2;
     return 0;
   }
   return 1;
@@ -680,4 +702,3 @@ void gui_init(dt_iop_module_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -89,21 +89,31 @@ typedef struct dt_iop_rawdenoise_global_data_t
 {
 } dt_iop_rawdenoise_global_data_t;
 
-int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,
-                  const int new_version)
+int legacy_params(dt_iop_module_t *self,
+                  const void *const old_params,
+                  const int old_version,
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 1 && new_version == 2)
+  typedef struct dt_iop_rawdenoise_params_v2_t
   {
-    // Since first version, the dt_iop_params_t struct have new members
-    // at the end of the struct.
-    // Yet, the beginning of the struct is exactly the same:
-    // threshold is still the first member of the struct.
-    // This allows to define the variable o with dt_iop_rawdenoise_params_t
-    // as long as we don't try to access new members on o.
-    // In other words, o can be seen as a dt_iop_rawdenoise_params_t
-    // with no allocated space for the new member.
-    dt_iop_rawdenoise_params_t *o = (dt_iop_rawdenoise_params_t *)old_params;
-    dt_iop_rawdenoise_params_t *n = (dt_iop_rawdenoise_params_t *)new_params;
+    float threshold;
+    float x[DT_RAWDENOISE_NONE][DT_IOP_RAWDENOISE_BANDS];
+    float y[DT_RAWDENOISE_NONE][DT_IOP_RAWDENOISE_BANDS];
+  } dt_iop_rawdenoise_params_v2_t;
+
+  if(old_version == 1)
+  {
+    typedef struct dt_iop_rawdenoise_params_v1_t
+    {
+      float threshold;
+    } dt_iop_rawdenoise_params_v1_t;
+
+    const dt_iop_rawdenoise_params_v1_t *o = (dt_iop_rawdenoise_params_v1_t *)old_params;
+    dt_iop_rawdenoise_params_v2_t *n =
+      (dt_iop_rawdenoise_params_v2_t *)malloc(sizeof(dt_iop_rawdenoise_params_v2_t));
+
     n->threshold = o->threshold;
     for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
     {
@@ -113,6 +123,10 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
         n->y[ch][k] = 0.5f;
       }
     }
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_rawdenoise_params_v2_t);
+    *new_version = 2;
     return 0;
   }
   return 1;
@@ -957,4 +971,3 @@ void gui_cleanup(dt_iop_module_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -125,11 +125,11 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
 int legacy_params(dt_iop_module_t *self,
                   const void *const old_params,
                   const int old_version,
-                  void *new_params,
-                  const int new_version)
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  typedef struct dt_iop_rawprepare_params_t dt_iop_rawprepare_params_v2_t;
-  typedef struct dt_iop_rawprepare_params_v1_t
+  typedef struct dt_iop_rawprepare_params_v2_t
   {
     int32_t left;
     int32_t top;
@@ -137,14 +137,30 @@ int legacy_params(dt_iop_module_t *self,
     int32_t bottom;
     uint16_t raw_black_level_separate[4];
     uint16_t raw_white_point;
-  } dt_iop_rawprepare_params_v1_t;
+    dt_iop_rawprepare_flat_field_t flat_field;
+  } dt_iop_rawprepare_params_v2_t;
 
-  if(old_version == 1 && new_version == 2)
+  if(old_version == 1)
   {
-    dt_iop_rawprepare_params_v1_t *o = (dt_iop_rawprepare_params_v1_t *)old_params;
-    dt_iop_rawprepare_params_v2_t *n = (dt_iop_rawprepare_params_v2_t *)new_params;
+    typedef struct dt_iop_rawprepare_params_v1_t
+    {
+      int32_t left;
+      int32_t top;
+      int32_t right;
+      int32_t bottom;
+      uint16_t raw_black_level_separate[4];
+      uint16_t raw_white_point;
+    } dt_iop_rawprepare_params_v1_t;
+
+    const dt_iop_rawprepare_params_v1_t *o = (dt_iop_rawprepare_params_v1_t *)old_params;
+    dt_iop_rawprepare_params_v2_t *n =
+      (dt_iop_rawprepare_params_v2_t *)malloc(sizeof(dt_iop_rawprepare_params_v2_t));
     memcpy(n, o, sizeof *o);
     n->flat_field = FLAT_FIELD_OFF;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_rawprepare_params_v2_t);
+    *new_version = 2;
     return 0;
   }
 

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -238,10 +238,32 @@ int operation_tags_filter()
 int legacy_params(dt_iop_module_t *self,
                   const void *const old_params,
                   const int old_version,
-                  void *new_params,
-                  const int new_version)
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 1 && new_version == 3)
+  typedef struct dt_iop_retouch_params_v3_t
+  {
+    dt_iop_retouch_form_data_t rt_forms[RETOUCH_NO_FORMS]; // array of masks index and additional data
+
+    dt_iop_retouch_algo_type_t algorithm; // $DEFAULT: DT_IOP_RETOUCH_HEAL clone, heal, blur, fill
+
+    int num_scales;       // $DEFAULT: 0 number of wavelets scales
+    int curr_scale;       // $DEFAULT: 0 current wavelet scale
+    int merge_from_scale; // $DEFAULT: 0
+
+    float preview_levels[3];
+
+    dt_iop_retouch_blur_types_t blur_type; // $DEFAULT: DT_IOP_RETOUCH_BLUR_GAUSSIAN $DESCRIPTION: "blur type" gaussian, bilateral
+    float blur_radius; // $MIN: 0.1 $MAX: 200.0 $DEFAULT: 10.0 $DESCRIPTION: "blur radius" radius for blur algorithm
+
+    dt_iop_retouch_fill_modes_t fill_mode; // $DEFAULT: DT_IOP_RETOUCH_FILL_ERASE $DESCRIPTION: "fill mode" mode for fill algorithm, erase or fill with color
+    float fill_color[3];   // $DEFAULT: 0.0 color for fill algorithm
+    float fill_brightness; // $MIN: -1.0 $MAX: 1.0 $DESCRIPTION: "brightness" value to be added to the color
+    int max_heal_iter;     // $DEFAULT: 2000 $DESCRIPTION: "max_iter" number of iterations for heal algorithm
+  } dt_iop_retouch_params_v3_t;
+
+  if(old_version == 1)
   {
     typedef struct dt_iop_retouch_form_data_v1_t
     {
@@ -279,11 +301,10 @@ int legacy_params(dt_iop_module_t *self,
       float fill_brightness; // $MIN: -1.0 $MAX: 1.0 $DESCRIPTION: "brightness" value to be added to the color
     } dt_iop_retouch_params_v1_t;
 
-    dt_iop_retouch_params_v1_t *o = (dt_iop_retouch_params_v1_t *)old_params;
-    dt_iop_retouch_params_t *n = (dt_iop_retouch_params_t *)new_params;
-    const dt_iop_retouch_params_t *const d = (dt_iop_retouch_params_t *)self->default_params;
+    const dt_iop_retouch_params_v1_t *o = (dt_iop_retouch_params_v1_t *)old_params;
+    dt_iop_retouch_params_v3_t *n =
+      (dt_iop_retouch_params_v3_t *)malloc(sizeof(dt_iop_retouch_params_v3_t));
 
-    *n = *d; // start with a fresh copy of default parameters
     for(int i = 0; i < RETOUCH_NO_FORMS; i++)
     {
       dt_iop_retouch_form_data_v1_t of = o->rt_forms[i];
@@ -316,9 +337,13 @@ int legacy_params(dt_iop_module_t *self,
 
     n->max_heal_iter = 1000;
 
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_retouch_params_v3_t);
+    *new_version = 3;
     return 0;
   }
-  if(old_version == 2 && new_version == 3)
+
+  if(old_version == 2)
   {
     typedef struct dt_iop_retouch_params_v2_t
     {
@@ -340,16 +365,17 @@ int legacy_params(dt_iop_module_t *self,
       float fill_brightness; // $MIN: -1.0 $MAX: 1.0 $DESCRIPTION: "brightness" value to be added to the color
     } dt_iop_retouch_params_v2_t;
 
-    dt_iop_retouch_params_v2_t *o = (dt_iop_retouch_params_v2_t *)old_params;
-    dt_iop_retouch_params_t *n = (dt_iop_retouch_params_t *)new_params;
-    const dt_iop_retouch_params_t *const d = (dt_iop_retouch_params_t *)self->default_params;
-
-    *n = *d; // start with a fresh copy of default parameters
+    const dt_iop_retouch_params_v2_t *o = (dt_iop_retouch_params_v2_t *)old_params;
+    dt_iop_retouch_params_v3_t *n =
+      (dt_iop_retouch_params_v3_t *)malloc(sizeof(dt_iop_retouch_params_v3_t));
 
     memcpy(n, o, sizeof(dt_iop_retouch_params_v2_t));
 
     n->max_heal_iter = 1000;
 
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_retouch_params_v3_t);
+    *new_version = 3;
     return 0;
   }
   return 1;

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -66,61 +66,6 @@ typedef enum dt_iop_shadhi_algo_t
   SHADHI_ALGO_BILATERAL // $DESCRIPTION: "bilateral filter"
 } dt_iop_shadhi_algo_t;
 
-/* legacy version 1 params */
-typedef struct dt_iop_shadhi_params1_t
-{
-  dt_gaussian_order_t order;
-  float radius;
-  float shadows;
-  float reserved1;
-  float highlights;
-  float reserved2;
-  float compress;
-} dt_iop_shadhi_params1_t;
-
-/* legacy version 2 params */
-typedef struct dt_iop_shadhi_params2_t
-{
-  dt_gaussian_order_t order;
-  float radius;
-  float shadows;
-  float reserved1;
-  float highlights;
-  float reserved2;
-  float compress;
-  float shadows_ccorrect;
-  float highlights_ccorrect;
-} dt_iop_shadhi_params2_t;
-
-typedef struct dt_iop_shadhi_params3_t
-{
-  dt_gaussian_order_t order;
-  float radius;
-  float shadows;
-  float reserved1;
-  float highlights;
-  float reserved2;
-  float compress;
-  float shadows_ccorrect;
-  float highlights_ccorrect;
-  unsigned int flags;
-} dt_iop_shadhi_params3_t;
-
-typedef struct dt_iop_shadhi_params4_t
-{
-  dt_gaussian_order_t order;
-  float radius;
-  float shadows;
-  float whitepoint;
-  float highlights;
-  float reserved2;
-  float compress;
-  float shadows_ccorrect;
-  float highlights_ccorrect;
-  unsigned int flags;
-  float low_approximation;
-} dt_iop_shadhi_params4_t;
-
 typedef struct dt_iop_shadhi_params_t
 {
   dt_gaussian_order_t order; // $DEFAULT: DT_IOP_GAUSSIAN_ZERO
@@ -202,13 +147,45 @@ const char **description(struct dt_iop_module_t *self)
                                       _("non-linear, Lab, display-referred"));
 }
 
-int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
-                  void *new_params, const int new_version)
+int legacy_params(dt_iop_module_t *self,
+                  const void *const old_params,
+                  const int old_version,
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 1 && new_version == 5)
+  typedef struct dt_iop_shadhi_params_v5_t
   {
-    const dt_iop_shadhi_params1_t *old = old_params;
-    dt_iop_shadhi_params_t *new = new_params;
+    dt_gaussian_order_t order;
+    float radius;
+    float shadows;
+    float whitepoint;
+    float highlights;
+    float reserved2;
+    float compress;
+    float shadows_ccorrect;
+    float highlights_ccorrect;
+    unsigned int flags;
+    float low_approximation;
+    dt_iop_shadhi_algo_t shadhi_algo;
+  } dt_iop_shadhi_params_v5_t;
+
+  if(old_version == 1)
+  {
+    typedef struct dt_iop_shadhi_params_v1_t
+    {
+      dt_gaussian_order_t order;
+      float radius;
+      float shadows;
+      float reserved1;
+      float highlights;
+      float reserved2;
+      float compress;
+    } dt_iop_shadhi_params_v1_t;
+
+    const dt_iop_shadhi_params_v1_t *old = old_params;
+    dt_iop_shadhi_params_v5_t *new =
+      (dt_iop_shadhi_params_v5_t *)malloc(sizeof(dt_iop_shadhi_params_v5_t));
     new->order = old->order;
     new->radius = fabs(old->radius);
     new->shadows = 0.5f * old->shadows;
@@ -221,12 +198,30 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     new->highlights_ccorrect = 0.0f;
     new->low_approximation = 0.01f;
     new->shadhi_algo = old->radius < 0.0f ? SHADHI_ALGO_BILATERAL : SHADHI_ALGO_GAUSSIAN;
+
+    *new_params = new;
+    *new_params_size = sizeof(dt_iop_shadhi_params_v5_t);
+    *new_version = 5;
     return 0;
   }
-  else if(old_version == 2 && new_version == 5)
+  else if(old_version == 2)
   {
-    const dt_iop_shadhi_params2_t *old = old_params;
-    dt_iop_shadhi_params_t *new = new_params;
+    typedef struct dt_iop_shadhi_params_v2_t
+    {
+      dt_gaussian_order_t order;
+      float radius;
+      float shadows;
+      float reserved1;
+      float highlights;
+      float reserved2;
+      float compress;
+      float shadows_ccorrect;
+      float highlights_ccorrect;
+    } dt_iop_shadhi_params_v2_t;
+
+    const dt_iop_shadhi_params_v2_t *old = old_params;
+    dt_iop_shadhi_params_v5_t *new =
+      (dt_iop_shadhi_params_v5_t *)malloc(sizeof(dt_iop_shadhi_params_v5_t));
     new->order = old->order;
     new->radius = fabs(old->radius);
     new->shadows = old->shadows;
@@ -239,12 +234,31 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     new->flags = 0;
     new->low_approximation = 0.01f;
     new->shadhi_algo = old->radius < 0.0f ? SHADHI_ALGO_BILATERAL : SHADHI_ALGO_GAUSSIAN;
+
+    *new_params = new;
+    *new_params_size = sizeof(dt_iop_shadhi_params_v5_t);
+    *new_version = 5;
     return 0;
   }
-  else if(old_version == 3 && new_version == 5)
+  else if(old_version == 3)
   {
-    const dt_iop_shadhi_params3_t *old = old_params;
-    dt_iop_shadhi_params_t *new = new_params;
+    typedef struct dt_iop_shadhi_params_v3_t
+    {
+      dt_gaussian_order_t order;
+      float radius;
+      float shadows;
+      float reserved1;
+      float highlights;
+      float reserved2;
+      float compress;
+      float shadows_ccorrect;
+      float highlights_ccorrect;
+      unsigned int flags;
+    } dt_iop_shadhi_params_v3_t;
+
+    const dt_iop_shadhi_params_v3_t *old = old_params;
+    dt_iop_shadhi_params_v5_t *new =
+      (dt_iop_shadhi_params_v5_t *)malloc(sizeof(dt_iop_shadhi_params_v5_t));
     new->order = old->order;
     new->radius = fabs(old->radius);
     new->shadows = old->shadows;
@@ -257,12 +271,32 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     new->flags = old->flags;
     new->low_approximation = 0.01f;
     new->shadhi_algo = old->radius < 0.0f ? SHADHI_ALGO_BILATERAL : SHADHI_ALGO_GAUSSIAN;
+
+    *new_params = new;
+    *new_params_size = sizeof(dt_iop_shadhi_params_v5_t);
+    *new_version = 5;
     return 0;
   }
-  else if(old_version == 4 && new_version == 5)
+  else if(old_version == 4)
   {
-    const dt_iop_shadhi_params4_t *old = old_params;
-    dt_iop_shadhi_params_t *new = new_params;
+    typedef struct dt_iop_shadhi_params_v4_t
+    {
+      dt_gaussian_order_t order;
+      float radius;
+      float shadows;
+      float whitepoint;
+      float highlights;
+      float reserved2;
+      float compress;
+      float shadows_ccorrect;
+      float highlights_ccorrect;
+      unsigned int flags;
+      float low_approximation;
+    } dt_iop_shadhi_params_v4_t;
+
+    const dt_iop_shadhi_params_v4_t *old = old_params;
+    dt_iop_shadhi_params_v5_t *new =
+      (dt_iop_shadhi_params_v5_t *)malloc(sizeof(dt_iop_shadhi_params_v5_t));
     new->order = old->order;
     new->radius = fabs(old->radius);
     new->shadows = old->shadows;
@@ -275,6 +309,10 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     new->flags = old->flags;
     new->low_approximation = old->low_approximation;
     new->shadhi_algo = old->radius < 0.0f ? SHADHI_ALGO_BILATERAL : SHADHI_ALGO_GAUSSIAN;
+
+    *new_params = new;
+    *new_params_size = sizeof(dt_iop_shadhi_params_v5_t);
+    *new_version = 5;
     return 0;
   }
   return 1;
@@ -697,4 +735,3 @@ void gui_init(struct dt_iop_module_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -123,10 +123,19 @@ typedef struct dt_iop_temperature_preset_data_t
 int legacy_params(dt_iop_module_t *self,
                   const void *const old_params,
                   const int old_version,
-                  void *new_params,
-                  const int new_version)
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 2 && new_version == 3)
+  typedef struct dt_iop_temperature_params_v3_t
+  {
+    float red;
+    float green;
+    float blue;
+    float g2;
+  } dt_iop_temperature_params_v3_t;
+
+  if(old_version == 2)
   {
     typedef struct dt_iop_temperature_params_v2_t
     {
@@ -134,14 +143,18 @@ int legacy_params(dt_iop_module_t *self,
       float coeffs[3];
     } dt_iop_temperature_params_v2_t;
 
-    dt_iop_temperature_params_v2_t *o = (dt_iop_temperature_params_v2_t *)old_params;
-    dt_iop_temperature_params_t *n = (dt_iop_temperature_params_t *)new_params;
+    const dt_iop_temperature_params_v2_t *o = (dt_iop_temperature_params_v2_t *)old_params;
+    dt_iop_temperature_params_v3_t *n =
+      (dt_iop_temperature_params_v3_t *)malloc(sizeof(dt_iop_temperature_params_v3_t));
 
     n->red = o->coeffs[0];
     n->green = o->coeffs[1];
     n->blue = o->coeffs[2];
     n->g2 = NAN;
 
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_temperature_params_v3_t);
+    *new_version = 3;
     return 0;
   }
   return 1;

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -347,10 +347,33 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
 int legacy_params(dt_iop_module_t *self,
                   const void *const old_params,
                   const int old_version,
-                  void *new_params,
-                  const int new_version)
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 1 && new_version == 2)
+  typedef struct dt_iop_toneequalizer_params_v2_t
+  {
+    float noise;
+    float ultra_deep_blacks;
+    float deep_blacks;
+    float blacks;
+    float shadows;
+    float midtones;
+    float highlights;
+    float whites;
+    float speculars;
+    float blending;
+    float smoothing;
+    float feathering;
+    float quantization;
+    float contrast_boost;
+    float exposure_boost;
+    dt_iop_toneequalizer_filter_t details;
+    dt_iop_luminance_mask_method_t method;
+    int iterations;
+  } dt_iop_toneequalizer_params_v2_t;
+
+  if(old_version == 1)
   {
     typedef struct dt_iop_toneequalizer_params_v1_t
     {
@@ -362,14 +385,10 @@ int legacy_params(dt_iop_module_t *self,
       dt_iop_luminance_mask_method_t method;
     } dt_iop_toneequalizer_params_v1_t;
 
-    dt_iop_toneequalizer_params_v1_t *o =
+    const dt_iop_toneequalizer_params_v1_t *o =
       (dt_iop_toneequalizer_params_v1_t *)old_params;
-    dt_iop_toneequalizer_params_t *n =
-      (dt_iop_toneequalizer_params_t *)new_params;
-    const dt_iop_toneequalizer_params_t *const d =
-      (dt_iop_toneequalizer_params_t *)self->default_params;
-
-    *n = *d; // start with a fresh copy of default parameters
+    dt_iop_toneequalizer_params_v2_t *n =
+      (dt_iop_toneequalizer_params_v2_t *)malloc(sizeof(dt_iop_toneequalizer_params_v2_t));
 
     // Olds params
     n->noise = o->noise;
@@ -392,8 +411,12 @@ int legacy_params(dt_iop_module_t *self,
     n->method = o->method;
 
     // New params
-    n->quantization = 0.01f;
+    n->quantization = 0.0f;
     n->smoothing = sqrtf(2.0f);
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_toneequalizer_params_v2_t);
+    *new_version = 2;
     return 0;
   }
   return 1;

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -46,15 +46,6 @@ typedef struct dt_iop_velvia_params_t
   float bias;     // $MIN: 0.0 $MAX: 1.0 $DEFAULT: 1.0 $DESCRIPTION: "mid-tones bias"
 } dt_iop_velvia_params_t;
 
-/* legacy version 1 params */
-typedef struct dt_iop_velvia_params1_t
-{
-  float saturation;
-  float vibrance;
-  float luminance;
-  float clarity;
-} dt_iop_velvia_params1_t;
-
 typedef struct dt_iop_velvia_gui_data_t
 {
   GtkBox *vbox;
@@ -110,15 +101,38 @@ const char **description(struct dt_iop_module_t *self)
                                       _("linear, RGB, scene-referred"));
 }
 
-int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
-                  void *new_params, const int new_version)
+int legacy_params(dt_iop_module_t *self,
+                  const void *const old_params,
+                  const int old_version,
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 1 && new_version == 2)
+  typedef struct dt_iop_velvia_params_v2_t
   {
-    const dt_iop_velvia_params1_t *old = old_params;
-    dt_iop_velvia_params_t *new = new_params;
-    new->strength = old->saturation * old->vibrance / 100.0f;
-    new->bias = old->luminance;
+    float strength;
+    float bias;
+  } dt_iop_velvia_params_v2_t;
+
+  if(old_version == 1)
+  {
+    typedef struct dt_iop_velvia_params_v1_t
+    {
+      float saturation;
+      float vibrance;
+      float luminance;
+      float clarity;
+    } dt_iop_velvia_params_v1_t;
+
+    const dt_iop_velvia_params_v1_t *o = old_params;
+    dt_iop_velvia_params_v2_t *n =
+      (dt_iop_velvia_params_v2_t *)malloc(sizeof(dt_iop_velvia_params_v2_t));
+    n->strength = o->saturation * o->vibrance / 100.0f;
+    n->bias = o->luminance;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_velvia_params_v2_t);
+    *new_version = 2;
     return 0;
   }
   return 1;
@@ -291,4 +305,3 @@ void gui_init(struct dt_iop_module_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -150,10 +150,40 @@ typedef enum dt_iop_watermark_base_scale_v2_t
   DT_SCALE_SMALLER_BORDER = 2 // $DESCRIPTION: "smaller border"
 } dt_iop_watermark_base_scale_v2_t;
 
-int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
-                  void *new_params, const int new_version)
+int legacy_params(dt_iop_module_t *self,
+                  const void *const old_params,
+                  const int old_version,
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
-  if(old_version == 1 && new_version == 6)
+  typedef struct dt_iop_watermark_params_v6_t
+  {
+    /** opacity value of rendering watermark */
+    float opacity;
+    /** scale value of rendering watermark */
+    float scale;
+    /** Pixel independent xoffset, 0 to 1 */
+    float xoffset;
+    /** Pixel independent yoffset, 0 to 1 */
+    float yoffset;
+    /** Alignment value 0-8 3x3 */
+    int alignment;
+    /** Rotation **/
+    float rotate;
+    dt_iop_watermark_base_scale_t scale_base;
+    dt_iop_watermark_img_scale_t scale_img;
+    dt_iop_watermark_svg_scale_t scale_svg;
+    char filename[64];
+    /* simple text */
+    char text[512];
+    /* text color */
+    float color[3];
+    /* text font */
+    char font[64];
+  } dt_iop_watermark_params_v6_t;
+
+  if(old_version == 1)
   {
     typedef struct dt_iop_watermark_params_v1_t
     {
@@ -170,11 +200,10 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
       char filename[64];
     } dt_iop_watermark_params_v1_t;
 
-    dt_iop_watermark_params_v1_t *o = (dt_iop_watermark_params_v1_t *)old_params;
-    dt_iop_watermark_params_t *n = (dt_iop_watermark_params_t *)new_params;
-    const dt_iop_watermark_params_t *const d = (dt_iop_watermark_params_t *)self->default_params;
-
-    *n = *d; // start with a fresh copy of default parameters
+    const dt_iop_watermark_params_v1_t *o = (dt_iop_watermark_params_v1_t *)old_params;
+    dt_iop_watermark_params_v6_t *n =
+      (dt_iop_watermark_params_v6_t *)
+      malloc(sizeof(dt_iop_watermark_params_v6_t));
 
     n->opacity = o->opacity;
     n->scale = o->scale;
@@ -187,9 +216,13 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     g_strlcpy(n->text, "", sizeof(n->text));
     g_strlcpy(n->font, "DejaVu Sans 10", sizeof(n->font));
     n->color[0] = n->color[1] = n->color[2] = 0;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_watermark_params_v6_t);
+    *new_version = 6;
     return 0;
   }
-  else if(old_version == 2 && new_version == 6)
+  else if(old_version == 2)
   {
     typedef struct dt_iop_watermark_params_v2_t
     {
@@ -207,11 +240,10 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
       char filename[64];
     } dt_iop_watermark_params_v2_t;
 
-    dt_iop_watermark_params_v2_t *o = (dt_iop_watermark_params_v2_t *)old_params;
-    dt_iop_watermark_params_t *n = (dt_iop_watermark_params_t *)new_params;
-    const dt_iop_watermark_params_t *const d = (dt_iop_watermark_params_t *)self->default_params;
-
-    *n = *d; // start with a fresh copy of default parameters
+    const dt_iop_watermark_params_v2_t *o = (dt_iop_watermark_params_v2_t *)old_params;
+    dt_iop_watermark_params_v6_t *n =
+      (dt_iop_watermark_params_v6_t *)
+      malloc(sizeof(dt_iop_watermark_params_v6_t));
 
     n->opacity = o->opacity;
     n->scale = o->scale;
@@ -224,9 +256,13 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     g_strlcpy(n->text, "", sizeof(n->text));
     g_strlcpy(n->font, "DejaVu Sans 10", sizeof(n->font));
     n->color[0] = n->color[1] = n->color[2] = 0;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_watermark_params_v6_t);
+    *new_version = 6;
     return 0;
   }
-  else if(old_version == 3 && new_version == 6)
+  else if(old_version == 3)
   {
     typedef struct dt_iop_watermark_params_v3_t
     {
@@ -246,11 +282,10 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
       char filename[64];
     } dt_iop_watermark_params_v3_t;
 
-    dt_iop_watermark_params_v3_t *o = (dt_iop_watermark_params_v3_t *)old_params;
-    dt_iop_watermark_params_t *n = (dt_iop_watermark_params_t *)new_params;
-    const dt_iop_watermark_params_t *const d = (dt_iop_watermark_params_t *)self->default_params;
-
-    *n = *d; // start with a fresh copy of default parameters
+    const dt_iop_watermark_params_v3_t *o = (dt_iop_watermark_params_v3_t *)old_params;
+    dt_iop_watermark_params_v6_t *n =
+      (dt_iop_watermark_params_v6_t *)
+      malloc(sizeof(dt_iop_watermark_params_v6_t));
 
     n->opacity = o->opacity;
     n->scale = o->scale;
@@ -264,9 +299,13 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     g_strlcpy(n->text, "", sizeof(n->text));
     g_strlcpy(n->font, "DejaVu Sans 10", sizeof(n->font));
     n->color[0] = n->color[1] = n->color[2] = 0;
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_watermark_params_v6_t);
+    *new_version = 6;
     return 0;
   }
-  else if(old_version == 4 && new_version == 6)
+  else if(old_version == 4)
   {
     typedef struct dt_iop_watermark_params_v4_t
     {
@@ -292,11 +331,10 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
       char font[64];
     } dt_iop_watermark_params_v4_t;
 
-    dt_iop_watermark_params_v4_t *o = (dt_iop_watermark_params_v4_t *)old_params;
-    dt_iop_watermark_params_t *n = (dt_iop_watermark_params_t *)new_params;
-    const dt_iop_watermark_params_t *const d = (dt_iop_watermark_params_t *)self->default_params;
-
-    *n = *d; // start with a fresh copy of default parameters
+    const dt_iop_watermark_params_v4_t *o = (dt_iop_watermark_params_v4_t *)old_params;
+    dt_iop_watermark_params_v6_t *n =
+      (dt_iop_watermark_params_v6_t *)
+      malloc(sizeof(dt_iop_watermark_params_v6_t));
 
     n->opacity = o->opacity;
     n->scale = o->scale;
@@ -312,9 +350,13 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     n->color[0] = o->color[0];
     n->color[1] = o->color[1];
     n->color[2] = o->color[2];
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_watermark_params_v6_t);
+    *new_version = 6;
     return 0;
   }
-  else if(old_version == 5 && new_version == 6)
+  else if(old_version == 5)
   {
     typedef struct dt_iop_watermark_params_v5_t
     {
@@ -340,11 +382,10 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
       char font[64];
     } dt_iop_watermark_params_v5_t;
 
-    dt_iop_watermark_params_v5_t *o = (dt_iop_watermark_params_v5_t *)old_params;
-    dt_iop_watermark_params_t *n = (dt_iop_watermark_params_t *)new_params;
-    const dt_iop_watermark_params_t *const d = (dt_iop_watermark_params_t *)self->default_params;
-
-    *n = *d; // start with a fresh copy of default parameters
+    const dt_iop_watermark_params_v5_t *o = (dt_iop_watermark_params_v5_t *)old_params;
+    dt_iop_watermark_params_v6_t *n =
+      (dt_iop_watermark_params_v6_t *)
+      malloc(sizeof(dt_iop_watermark_params_v6_t));
 
     n->opacity = o->opacity;
     n->scale = o->scale;
@@ -360,6 +401,10 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     n->color[0] = o->color[0];
     n->color[1] = o->color[1];
     n->color[2] = o->color[2];
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_watermark_params_v6_t);
+    *new_version = 6;
     return 0;
   }
   return 1;


### PR DESCRIPTION
Add incremental update of params for IOP. Following the PR for format & storage this is in the same line. More we wait to do that more we introduce fragile code that could breaks old edits.

This is Draft, the code base is there and two IOP have been migrated.

At least it advertise the fact that no more old legacy_params should be merged until this is done.