### PR TITLE
Relnotes: remove some suspended Samsung models

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -115,7 +115,7 @@ improvements and enhancements:
 
 ### Optional
 
-- ???
+- Bump libavif to 0.9.2
 
 ## RawSpeed changes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -157,11 +157,7 @@ are available on raw.pixls.us:
 - Panasonic DMC-FX150
 - Pentax Q10
 - Phase One IQ250
-- Samsung GX10
-- Samsung GX20
 - Samsung EK-GN120
-- Samsung SM-G920F
-- Samsung SM-G935F
 - Sinar Hy6/ Sinarback eXact
 - ST Micro STV680
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -138,6 +138,7 @@ improvements and enhancements:
 - Fujifilm lossy RAFs
 - Nikon high efficiency NEFs
 - Samsung Expert RAW DNGs
+- Sony downsized lossless ARWs ("M" for full-frame, "S" for full-frame & APS-C)
 
 ### Suspended Support
 


### PR DESCRIPTION
Changes merged into rawspeed already, but not pushed to dt yet.