### PR TITLE
3 OpenCL stability fixes

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -333,7 +333,7 @@
     </type>
     <default>nothing</default>
     <shortdescription>tune OpenCL performance</shortdescription>
-    <longdescription>allows runtime tuning of OpenCL devices:\n - 'memory size': uses a fixed headroom (400MB as default),\n - 'memory transfer': tries a faster memory access mode (pinned memory) used for tiling.</longdescription>
+    <longdescription>possibly tune performance of OpenCL devices:\nyou are strongly advised to leave this at `nothing` unless you fully understand what this is about\n - 'memory size': darktable uses all memory of your device except some fixed safety margin (600MB headroom).\n    expect severe problems if your system makes use of your graphics card otherwise.\n - 'memory transfer': tries a different memory access mode (pinned memory) used for tiling.\n    only in a few cases this will improve performance,\n    you should always do precise benchmarking before leaving this 'on'.</longdescription>
   </dtconfig>
   <dtconfig>
     <name>opencl_library</name>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1464,7 +1464,9 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 
     // initialize undo struct
     darktable.undo = dt_undo_init();
-  }
+
+    dt_opencl_wrong_platforms();
+}
 
   dt_print(DT_DEBUG_MEMORY, "[memory] after successful startup\n");
   dt_print_mem_usage();

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -459,7 +459,7 @@ gboolean dt_opencl_read_device_config(const int devid)
   }
   else // this is used if updating to 4.0 or fresh installs; see
        // commenting _opencl_get_unused_device_mem()
-    cl->dev[devid].forced_headroom = 400;
+    cl->dev[devid].forced_headroom = 600;
   dt_opencl_write_device_config(devid);
   return !existing_device || !safety_ok;
 }

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -542,6 +542,7 @@ typedef struct dt_opencl_t
   gboolean inited;
   gboolean enabled;
   gboolean stopped;
+  gboolean wrong_platforms;
   int error_count;
 } dt_opencl_t;
 

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -143,6 +143,7 @@ typedef struct dt_opencl_device_t
   int nvidia_sm_20;
   const char *vendor;
   const char *fullname;
+  const char *platform;
   const char *cname;
   const char *options;
   cl_int summary;
@@ -226,6 +227,7 @@ typedef struct dt_opencl_t
   gboolean print_statistics;
   gboolean enabled;
   gboolean stopped;
+  gboolean wrong_platforms;
   int num_devs;
   int error_count;
   int opencl_synchronization_timeout;
@@ -293,7 +295,8 @@ int dt_opencl_get_device_info(dt_opencl_t *cl, cl_device_id device, cl_device_in
 
 /** inits the opencl subsystem. */
 void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboolean print_statistics);
-
+/** reporting an error for buggy OpenCL installations*/
+void dt_opencl_wrong_platforms(void);
 /** cleans up the opencl subsystem. */
 void dt_opencl_cleanup(dt_opencl_t *cl);
 
@@ -547,9 +550,14 @@ static inline void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl
   cl->inited = FALSE;
   cl->enabled = FALSE;
   cl->stopped = FALSE;
+  cl->wrong_platforms = FALSE;
   cl->error_count = 0;
   dt_conf_set_bool("opencl", FALSE);
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] this version of darktable was built without opencl support\n");
+}
+
+static inline void dt_opencl_wrong_platforms(void)
+{
 }
 static inline void dt_opencl_cleanup(dt_opencl_t *cl)
 {


### PR DESCRIPTION
While reading a number of OpenCL related dt "issues" here at github and pixls.us i saw a repeated pattern of problems i tried to fix by this pr.

1. Todays operating systems and apps like firefox use more OpenCL resources than a few years ago, the "headroom" default of 400 seems to be on the low side now, to achieve more stability for new users / installs this has been bumped to 600
2. Often new users seem to understand that the tuning options are good to set to `on`. (yes @elstoc you have warned about this :-) Tried to give more info in the tooltips why this is mostly not good.
3. In some cases with failing OpenCL (most notably on windows but also arch) people installed as many drivers as they could find which is wrong if there is more than one driver _per device_. darktable now checks for such a condition and a) gives a warning check box with some info - this wont be shown again after confirmation b) disables opencl for the session.
