### PR TITLE
Blacklist D3D12 Microsoft drivers in opencl_drivers_blacklist.h

### DIFF
--- a/src/common/opencl_drivers_blacklist.h
+++ b/src/common/opencl_drivers_blacklist.h
@@ -36,6 +36,7 @@ static const gchar *bad_opencl_drivers[] =
 */
 #if defined _WIN32
   "neo",
+  "D3D12",
 #endif
   NULL
 


### PR DESCRIPTION
Many Windows users report issues with OpenCL using darktable. See: https://github.com/darktable-org/darktable/issues/14997 and https://github.com/darktable-org/darktable/issues/14731 and many others.

One common element is a duplicate driver from Microsoft as part of their Direct12 mapping layers. This PR will blacklist these Microsoft drivers so we only use the ones provided by the GPU vendors. Hopefully this will reduce issues for Windows users. 