### PR TITLE
Only one driver per OpenCL device

### DIFF
--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -143,6 +143,7 @@ typedef struct dt_opencl_device_t
   int nvidia_sm_20;
   const char *vendor;
   const char *fullname;
+  const char *platform;
   const char *cname;
   const char *options;
   cl_int summary;


### PR DESCRIPTION
As mentioned in related #15044 by @gi-man and commented by @dterrahe in closed #15043 we have multiple reports  here and in pixls.us about darktable malfunctioning with opencl.

There are bad drivers - so an upstream issue - but also many reports related to the _"multiple platforms use same device"_ problem. This is a dt issue for sure as we currently try to make use of **all** devices from **all** platforms.  And it's not only related to windows, especially for AMD and arch there are multiple reports.

This pr implements a strategy to use _only one platform per device_.

1. While initializing the opencl devices we also keep track of the platform making this device available.

2. This allows to check for multiple platforms/drivers per device which is always wrong and would certainly lead to severe problems and dt crashing/failing.

3. While adding a device for a platform we check if there was already a platform / driver using such a card and if so, that card won't be made available for the tested platform, also we leave a note in the log.

4. The OpenCL specs tell nothing about priority of platforms so for now we can't do better than _"first platform found gets it"_. 
5. Anyway better than failing later and inspected logfiles support this strategy.