### PR TITLE
cacorrect: performance optimization

### DIFF
--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -248,16 +248,6 @@ static gboolean _LinEqSolve(ssize_t nDim, double *pfMatr, double *pfVect, double
 // end of linear equation solver
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-static inline void _pixsort(float *a, float *b)
-{
-  if(*a > *b)
-  {
-    float temp = *a;
-    *a = *b;
-    *b = temp;
-  }
-}
-
 void process(
         struct dt_iop_module_t *self,
         dt_dev_pixelpipe_iop_t *piece,
@@ -827,39 +817,36 @@ void process(
                   p[6] = blockshifts[(vblock + 1) * hblsz + hblock - 1][c][dir];
                   p[7] = blockshifts[(vblock + 1) * hblsz + hblock][c][dir];
                   p[8] = blockshifts[(vblock + 1) * hblsz + hblock + 1][c][dir];
-                  _pixsort(&p[1], &p[2]);
-                  _pixsort(&p[4], &p[5]);
-                  _pixsort(&p[7], &p[8]);
-                  _pixsort(&p[0], &p[1]);
-                  _pixsort(&p[3], &p[4]);
-                  _pixsort(&p[6], &p[7]);
-                  _pixsort(&p[1], &p[2]);
-                  _pixsort(&p[4], &p[5]);
-                  _pixsort(&p[7], &p[8]);
-#if 0
-                  _pixsort(&p[0], &p[3]);
-                  _pixsort(&p[5], &p[8]);
-                  _pixsort(&p[4], &p[7]);
-                  _pixsort(&p[3], &p[6]);
-                  _pixsort(&p[1], &p[4]);
-                  _pixsort(&p[2], &p[5]);
-                  _pixsort(&p[4], &p[7]);
-                  _pixsort(&p[4], &p[2]);
-                  _pixsort(&p[6], &p[4]);
-                  _pixsort(&p[4], &p[2]);
-                  bstemp[dir] = p[4];
-#else
-                  p[3] = MAX(p[0],p[3]);
-                  p[5] = MIN(p[5],p[8]);
-                  _pixsort(&p[4], &p[7]);
-                  p[6] = MAX(p[3],p[6]);
-                  p[4] = MAX(p[1],p[4]);
-                  p[2] = MIN(p[2],p[5]);
-                  p[4] = MIN(p[4],p[7]);
-                  _pixsort(&p[4], &p[2]);
-                  _pixsort(&p[6], &p[4]);
-                  bstemp[dir] = MIN(p[2],p[4]);
-#endif
+                  float p1 = MIN(p[1], p[2]);
+                  float p2 = MAX(p[1], p[2]);
+                  float p4 = MIN(p[4], p[5]);
+                  float p5 = MAX(p[4], p[5]);
+                  float p7 = MIN(p[7], p[8]);
+                  float p8 = MAX(p[7], p[8]);
+                  float p0 = MIN(p[0], p1);
+                  float p1a = MAX(p[0], p1);
+                  float p3 = MIN(p[3], p4);
+                  float p4a = MAX(p[3], p4);
+                  float p6 = MIN(p[6], p7);
+                  float p7a = MAX(p[6], p7);
+                  p1 = MIN(p1a, p2);
+                  p2 = MAX(p1a, p2);
+                  p4 = MIN(p4a, p5);
+                  p5 = MAX(p4a, p5);
+                  p7 = MIN(p7a, p8);
+                  p8 = MAX(p7a, p8);
+                  p3 = MAX(p0,p3);
+                  p5 = MIN(p5, p8);
+                  p7a = MAX(p4, p7);
+                  p4 = MIN(p4, p7);
+                  p6 = MAX(p3, p6);
+                  p4 = MAX(p1, p4);
+                  p2 = MIN(p2, p5);
+                  p4a = MIN(p4, p7a);
+                  p4 = MIN(p4a, p2);
+                  p2 = MAX(p4a, p2);
+                  p4 = MAX(p6, p4);
+                  bstemp[dir] = MIN(p2,p4);
                 }
 
                 // now prepare coefficient matrix; use only data points within caautostrength/2 std devs of

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -378,7 +378,8 @@ void process(
 #ifdef _OPENMP
 #pragma omp parallel default(none) \
   dt_omp_firstprivate(in, out, height, width, filters, processpasstwo, hblsz, vblsz, \
-                      blockwt, blockshifts, blockvar, Gtmp, RawDataTmp)                  \
+                      blockwt, blockshifts, blockvar, Gtmp, RawDataTmp, caautostrength, \
+                      border, border2, eps, eps2, v1, v2, v3, v4, ts, tsh) \
   shared(numpar, polyord, fitparams, blockdenom, blockave, blocksqave)
   // if any of the above shared are made firstprivate, we get the wrong answer
 #endif

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -155,7 +155,7 @@ int legacy_params(dt_iop_module_t *self,
 //
 ////////////////////////////////////////////////////////////////
 //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-static gboolean _LinEqSolve(int nDim, double *pfMatr, double *pfVect, double *pfSolution)
+static gboolean _LinEqSolve(ssize_t nDim, double *pfMatr, double *pfVect, double *pfSolution)
 {
   //==============================================================================
   // return 1 if system not solving, 0 if system solved
@@ -173,7 +173,7 @@ static gboolean _LinEqSolve(int nDim, double *pfMatr, double *pfVect, double *pf
   double fMaxElem;
   double fAcc;
 
-  int i, j, k, m;
+  ssize_t i, j, k, m;
 
   for(k = 0; k < (nDim - 1); k++)
   { // base row of matrix
@@ -831,6 +831,7 @@ void process(
                   _pixsort(&p[1], &p[2]);
                   _pixsort(&p[4], &p[5]);
                   _pixsort(&p[7], &p[8]);
+#if 0
                   _pixsort(&p[0], &p[3]);
                   _pixsort(&p[5], &p[8]);
                   _pixsort(&p[4], &p[7]);
@@ -842,6 +843,18 @@ void process(
                   _pixsort(&p[6], &p[4]);
                   _pixsort(&p[4], &p[2]);
                   bstemp[dir] = p[4];
+#else
+                  p[3] = MAX(p[0],p[3]);
+                  p[5] = MIN(p[5],p[8]);
+                  _pixsort(&p[4], &p[7]);
+                  p[6] = MAX(p[3],p[6]);
+                  p[4] = MAX(p[1],p[4]);
+                  p[2] = MIN(p[2],p[5]);
+                  p[4] = MIN(p[4],p[7]);
+                  _pixsort(&p[4], &p[2]);
+                  _pixsort(&p[6], &p[4]);
+                  bstemp[dir] = MIN(p[2],p[4]);
+#endif
                 }
 
                 // now prepare coefficient matrix; use only data points within caautostrength/2 std devs of


### PR DESCRIPTION
Some optimization I hadn't entirely finished for 4.4 (I think there's still a few percent additional improvement possible).  Making it a PR now because I'm about to enter my busy half-year and probably won't have a chance to do more with it until spring.

Passes integration test 0084, maxDE = 1.25 (from rounding going the other way on 237 pixels compared to reference)
```
Thr	Master	Current
1	2662.51	2410.70	 -9.4%
2	1398.31	1273.36	 -8.9%
4	 767.99	 702.38	 -8.5%
8	 452.60	 405.07	-10.5%
16	 303.99	 268.73	-11.6%
32	 262.92	 224.81	-14.4%
64	 341.99	 301.35	-11.8%
```
