### PR TITLE
geotagging: eliminate Gtk null-pointer warning

### DIFF
--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -1351,8 +1351,11 @@ static void _refresh_image_datetime(dt_lib_module_t *self)
   _display_datetime(&d->dt0, datetime, FALSE, self);
   if(locked)
   {
-    GDateTime *datetime2 = g_date_time_add(datetime, d->offset);
-    _new_datetime(datetime2, self);
+    if (datetime)
+    {
+      GDateTime *datetime2 = g_date_time_add(datetime, d->offset);
+      _new_datetime(datetime2, self);
+    }
   }
   else
   {


### PR DESCRIPTION
When the "lock" button in the geotagging module (Lighttable view) is active, moving the mouse pointer out of an image thumbnail to an empty part of the thumbtable or out of the thumbtable entirely results in a null-pointer warning from g_date_time_add as the module tries to update its information  from a nonexistent image.  This PR adds a guard to eliminate the offending call.
