### PR TITLE
Don't block UI during opencl initialisation

### DIFF
--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -268,6 +268,10 @@ typedef struct dt_opencl_t
 
   // global kernels for guided filter.
   struct dt_guided_filter_cl_global_t *guided_filter;
+
+  // saved kernel info for deferred initialisation
+  int program_saved[DT_OPENCL_MAX_KERNELS];
+  const char *name_saved[DT_OPENCL_MAX_KERNELS];
 } dt_opencl_t;
 
 /** description of memory requirements of local buffer

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -699,7 +699,7 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
   else if(_has_prefix(variable, "OPENCL.ACTIVATED")
           || _has_prefix(variable, "OPENCL_ACTIVATED"))
   {
-    if(dt_opencl_is_enabled())
+    if(dt_opencl_running())
       result = g_strdup(_("yes"));
     else
       result = g_strdup(_("no"));

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -337,12 +337,6 @@ int dt_iop_load_module_so(void *m, const char *libname, const char *module_name)
   if(!module->modify_roi_in) module->modify_roi_in = _iop_modify_roi_in;
   if(!module->modify_roi_out) module->modify_roi_out = _iop_modify_roi_out;
 
-  #ifdef HAVE_OPENCL
-  if(!module->process_tiling_cl)
-    module->process_tiling_cl = darktable.opencl->inited ? default_process_tiling_cl : NULL;
-  if(!darktable.opencl->inited) module->process_cl = NULL;
-  #endif // HAVE_OPENCL
-
   module->process_plain = module->process;
   module->process = default_process;
 

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -86,28 +86,28 @@ DEFAULT(int, operation_tags_filter, void);
 
 /** what do the iop want as an input? */
 DEFAULT(void, input_format, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                             struct dt_dev_pixelpipe_iop_t *piece, struct dt_iop_buffer_dsc_t *dsc);
+                            struct dt_dev_pixelpipe_iop_t *piece, struct dt_iop_buffer_dsc_t *dsc);
 /** what will it output? */
 DEFAULT(void, output_format, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                              struct dt_dev_pixelpipe_iop_t *piece, struct dt_iop_buffer_dsc_t *dsc);
+                             struct dt_dev_pixelpipe_iop_t *piece, struct dt_iop_buffer_dsc_t *dsc);
 
 /** what default colorspace this iop use? */
 REQUIRED(dt_iop_colorspace_type_t, default_colorspace, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                                  struct dt_dev_pixelpipe_iop_t *piece);
+                                   struct dt_dev_pixelpipe_iop_t *piece);
 /** what input colorspace it expects? */
 DEFAULT(dt_iop_colorspace_type_t, input_colorspace, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                                struct dt_dev_pixelpipe_iop_t *piece);
+                                  struct dt_dev_pixelpipe_iop_t *piece);
 /** what will it output? */
 DEFAULT(dt_iop_colorspace_type_t, output_colorspace, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                                 struct dt_dev_pixelpipe_iop_t *piece);
+                                  struct dt_dev_pixelpipe_iop_t *piece);
 /** what colorspace the blend module operates with? */
 DEFAULT(dt_iop_colorspace_type_t, blend_colorspace, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                                struct dt_dev_pixelpipe_iop_t *piece);
+                                  struct dt_dev_pixelpipe_iop_t *piece);
 
 /** report back info for tiling: memory usage and overlap. Memory usage: factor * input_size + overhead */
 DEFAULT(void, tiling_callback, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                                const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out,
-                                struct dt_develop_tiling_t *tiling);
+                               const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out,
+                               struct dt_develop_tiling_t *tiling);
 
 /** callback methods for gui. */
 /** synch gtk interface with gui params, if necessary. */
@@ -146,12 +146,12 @@ DEFAULT(void, cleanup, struct dt_iop_module_t *self);
 
 /** this inits the piece of the pipe, allocing piece->data as necessary. */
 DEFAULT(void, init_pipe, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                          struct dt_dev_pixelpipe_iop_t *piece);
+                         struct dt_dev_pixelpipe_iop_t *piece);
 /** this resets the params to factory defaults. used at the beginning of each history synch. */
 /** this commits (a mutex will be locked to synch pipe/gui) the given history params to the pixelpipe piece.
  */
 DEFAULT(void, commit_params, struct dt_iop_module_t *self, dt_iop_params_t *params, struct dt_dev_pixelpipe_t *pipe,
-                              struct dt_dev_pixelpipe_iop_t *piece);
+                             struct dt_dev_pixelpipe_iop_t *piece);
 /** this is the chance to update default parameters, after the full raw is loaded. */
 OPTIONAL(void, reload_defaults, struct dt_iop_module_t *self);
 /** called after the image has changed in darkroom */
@@ -159,7 +159,7 @@ OPTIONAL(void, change_image, struct dt_iop_module_t *self);
 
 /** this destroys all resources needed by the piece of the pixelpipe. */
 DEFAULT(void, cleanup_pipe, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                             struct dt_dev_pixelpipe_iop_t *piece);
+                            struct dt_dev_pixelpipe_iop_t *piece);
 OPTIONAL(void, modify_roi_in, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                               const struct dt_iop_roi_t *roi_out, struct dt_iop_roi_t *roi_in);
 OPTIONAL(void, modify_roi_out, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
@@ -180,8 +180,8 @@ REQUIRED(void, process, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_io
                         const struct dt_iop_roi_t *const roi_out);
 /** a tiling variant of process(). */
 DEFAULT(void, process_tiling, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
-                               void *const o, const struct dt_iop_roi_t *const roi_in,
-                               const struct dt_iop_roi_t *const roi_out, const int bpp);
+                              void *const o, const struct dt_iop_roi_t *const roi_in,
+                              const struct dt_iop_roi_t *const roi_out, const int bpp);
 
 #ifdef HAVE_OPENCL
 /** the opencl equivalent of process(). */
@@ -189,9 +189,9 @@ OPTIONAL(int, process_cl, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_
                           cl_mem dev_out, const struct dt_iop_roi_t *const roi_in,
                           const struct dt_iop_roi_t *const roi_out);
 /** a tiling variant of process_cl(). */
-OPTIONAL(int, process_tiling_cl, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
-                                 void *const o, const struct dt_iop_roi_t *const roi_in,
-                                 const struct dt_iop_roi_t *const roi_out, const int bpp);
+DEFAULT(int, process_tiling_cl, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
+                                void *const o, const struct dt_iop_roi_t *const roi_in,
+                                const struct dt_iop_roi_t *const roi_out, const int bpp);
 #endif
 
 /** this functions are used for distort iop
@@ -199,10 +199,10 @@ OPTIONAL(int, process_tiling_cl, struct dt_iop_module_t *self, struct dt_dev_pix
  * size is 2*points_count */
 /** points before the iop is applied => point after processed */
 DEFAULT(int, distort_transform, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, float *points,
-                                 size_t points_count);
+                                size_t points_count);
 /** reverse points after the iop is applied => point before process */
 DEFAULT(int, distort_backtransform, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, float *points,
-                                     size_t points_count);
+                                    size_t points_count);
 
 OPTIONAL(void, distort_mask, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const float *const in,
                              float *const out, const struct dt_iop_roi_t *const roi_in, const struct dt_iop_roi_t *const roi_out);


### PR DESCRIPTION
During dt startup OpenCL initialisation can take a "long" time (on Windows) when programs need to be (re)compiled (after a fresh install or driver update). During this time, there is no visual feedback as the UI has not yet come up, so it looks as if the program is stuck (especially under Windows where command line feedback isn't available). This PR executes the initialisation (and possibly compilation) in a separate thread, so the UI can come up and log toasts can be shown to report progress.

![image](https://github.com/darktable-org/darktable/assets/1549490/005a4a81-e0da-4682-8e0f-79df08a1d905)

This requires `dt_opencl_create_kernel` to be deferred, because during module (and kernel) initialization the program compilation is not guaranteed to have finished yet. As a consequence, removing and reinserting kernels (and reusing their id) is not supported (but this wasn't used anyway). The existing code potentially created problems (mismatching kernel ids) if creating a kernel failed on one device but succeeded on another; that should work now.

The `OPENCL.ACTIVATED` variable now catches if initialisation succeeded but OpenCl was disabled later anyway because too many errors were generated. Hence you can use a pattern for the image information line in the darkroom like
`<span alpha='1%'>$(OPENCL_ACTIVATED/no/<span foreground='red' weight='heavy' size='xx-large' alpha='100%'>OPENCL ACTIVATION FAILED</span>$(NL))</span> $(EXIF_EXPOSURE) • f/$(EXIF_APERTURE) • $(EXIF_FOCAL_LENGTH) mm • $(EXIF_ISO) ISO`
and have it indicate whether _currently_ OpenCl should be working (although you may need to click on a thumbnail or something to have it update). This will also give a warning when switching to the darkroom too quickly when OpenCl is not ready yet (but will switch on later).