### PR TITLE
map.c: optimize dbscan code

### DIFF
--- a/src/views/map.c
+++ b/src/views/map.c
@@ -2883,12 +2883,9 @@ static void _dbscan_spread(unsigned int index)
   for(unsigned int i = 0; i < db.spreads->num_members; i++)
   {
     dt_geo_position_t *d = &db.points[db.spreads->index[i]];
-//    if(d->cluster_id < 0) // NOISE or UNCLASSIFIED - but only those are included in the list anyway
-    {
-      db.seeds->index[db.seeds->num_members] = db.spreads->index[i];
-      db.seeds->num_members++;
-      d->cluster_id = db.cluster_id;
-    }
+    db.seeds->index[db.seeds->num_members] = db.spreads->index[i];
+    db.seeds->num_members++;
+    d->cluster_id = db.cluster_id; // only NOISE/UNCLASSIFIED are in the list
   }
 }
 

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -2839,14 +2839,18 @@ static void _get_epsilon_neighbours(epsilon_neighbours_t *en, unsigned int index
 {
   // points are ordered by longitude
   // limit the exploration to epsilon east and west
+  const double x = db.points[index].x;
+  const double min_x = x - db.epsilon;
+  const double max_x = x + db.epsilon;
+  const double y = db.points[index].y;
   // west
-  for(int i = index; i < db.num_points; ++i)
+  for(int i = index+1; i < db.num_points; ++i)
   {
-    if(i == index || db.points[i].cluster_id >= 0)
-      continue;
-    if((db.points[i].x - db.points[index].x) > db.epsilon)
+    if(db.points[i].x > max_x)
       break;
-    if(fabs(db.points[i].y - db.points[index].y) > db.epsilon)
+    if(db.points[i].cluster_id >= 0)	// skip points which have already been assigned to a cluster
+      continue;
+    if(fabs(db.points[i].y - y) > db.epsilon)
       continue;
     else
     {
@@ -2855,13 +2859,13 @@ static void _get_epsilon_neighbours(epsilon_neighbours_t *en, unsigned int index
     }
   }
   // east
-  for(int i = index; i >= 0; --i)
+  for(int i = index-1; i >= 0; --i)
   {
-    if(i == (int)index || db.points[i].cluster_id >= 0)
-      continue;
-    if((db.points[index].x - db.points[i].x) > db.epsilon)
+    if(db.points[i].x < min_x)
       break;
-    if(fabs(db.points[index].y - db.points[i].y) > db.epsilon)
+    if(db.points[i].cluster_id >= 0)	// skip points which have already been assigned to a cluster
+      continue;
+    if(fabs(y - db.points[i].y) > db.epsilon)
       continue;
     else
     {
@@ -2879,7 +2883,7 @@ static void _dbscan_spread(unsigned int index)
   for(unsigned int i = 0; i < db.spreads->num_members; i++)
   {
     dt_geo_position_t *d = &db.points[db.spreads->index[i]];
-    if(d->cluster_id == NOISE || d->cluster_id == UNCLASSIFIED)
+//    if(d->cluster_id < 0) // NOISE or UNCLASSIFIED - but only those are included in the list anyway
     {
       db.seeds->index[db.seeds->num_members] = db.spreads->index[i];
       db.seeds->num_members++;


### PR DESCRIPTION
Yields ~25% speedup, which becomes noticeable when there are >50k images being clustered for the map view.  (The clustering runtime is not quite quadratic -- 55k points goes from 0.8 seconds to 0.55, while 359k goes from 25.9 sec to 18.8.)