### PR TITLE
Pan at full resolution and fix iso12646 white border jumps

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -247,8 +247,6 @@ void dt_dev_process_preview(dt_develop_t *dev)
 
 void dt_dev_process_preview2(dt_develop_t *dev)
 {
-  if(!dev->gui_attached) return;
-  if(!(dev->second_window.widget && GTK_IS_WIDGET(dev->second_window.widget))) return;
   const int err = dt_control_add_job_res(darktable.control,
                                          dt_dev_process_preview2_job_create(dev),
                                          DT_CTL_WORKER_ZOOM_2);

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -230,7 +230,7 @@ void gui_post_expose(dt_lib_module_t *self,
 
   if(d->preview_surf)
     dt_view_paint_surface(cri, width, height, d->preview_surf,
-                          d->processed_width, d->processed_height, DT_WINDOW_MAIN);
+                          d->processed_width, d->processed_height, DT_WINDOW_MAIN, 0, 0, 0);
 }
 
 static void _thumb_remove(gpointer user_data)

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1710,21 +1710,23 @@ void dt_view_paint_surface(cairo_t *cr,
 
   cairo_translate(cr, 0.5 * width, 0.5 * height);
 
-  const double maxw = MIN(0.5 * width - tb, 0.5 * wd * zoom_scale);
-  const double maxh = MIN(0.5 * height - tb, 0.5 * ht * zoom_scale);
+  gboolean matching = dev->preview_pipe->output_imgid == dev->image_storage.id;
+
+  const double maxw = MIN(width - tb * 2, matching ? wd * zoom_scale : processed_width * (1<<closeup));
+  const double maxh = MIN(height - tb * 2, matching ? ht * zoom_scale : processed_height * (1<<closeup));
 
   if(dev->iso_12646.enabled
      && window != DT_WINDOW_SLIDESHOW)
   {
     // draw the white frame around picture
-    const double ratio = dt_conf_get_float("darkroom/ui/iso12464_ratio");
+    const double ratio = dt_conf_get_float("darkroom/ui/iso12464_ratio") * 2;
     const double borw = maxw + tb * ratio, borh = maxh + tb * ratio;
-    cairo_rectangle(cr, -borw, -borh, 2.0 * borw, 2.0 * borh);
+    cairo_rectangle(cr, -0.5 * borw, -0.5 * borh, borw, borh);
     dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_ISO12646_FG);
     cairo_fill(cr);
   }
 
-  cairo_rectangle(cr, -maxw, -maxh, 2.0 * maxw, 2.0 * maxh);
+  cairo_rectangle(cr, -0.5 * maxw, -0.5 * maxh, maxw, maxh);
   cairo_clip(cr);
 
   cairo_scale(cr, zoom_scale, zoom_scale);
@@ -1733,7 +1735,7 @@ void dt_view_paint_surface(cairo_t *cr,
 
   double back_scale = buf_scale == 0 ? 1.0 : backbuf_scale / buf_scale;
 
-  if(back_scale < 1.0 || offset_x != zoom_x || offset_y != zoom_y)
+  if(matching && (back_scale < 1.0 || offset_x != zoom_x || offset_y != zoom_y))
   {
     dt_print(DT_DEBUG_EXPOSE, "[darkroom expose] draw preview\n");
     // draw preview

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1666,66 +1666,106 @@ void dt_view_paint_surface(cairo_t *cr,
                            cairo_surface_t *surface,
                            const size_t processed_width,
                            const size_t processed_height,
-                           const dt_window_t window)
+                           const dt_window_t window,
+                           const float buf_scale,
+                           const double offset_x,
+                           const double offset_y)
 {
   dt_develop_t *dev = darktable.develop;
 
-  const dt_dev_zoom_t zoom =
-    (window == DT_WINDOW_MAIN || window == DT_WINDOW_SLIDESHOW)
-    ? dt_control_get_dev_zoom()
-    : dt_second_window_get_dev_zoom(dev);
-  const int closeup =
-    (window == DT_WINDOW_MAIN || window == DT_WINDOW_SLIDESHOW)
-    ? dt_control_get_dev_closeup()
-    : dt_second_window_get_dev_closeup(dev);
-  const float zoom_scale =
-    (window == DT_WINDOW_MAIN || window == DT_WINDOW_SLIDESHOW)
-    ? dt_dev_get_zoom_scale(dev, zoom, 1<<closeup, 1)
-    : dt_second_window_get_zoom_scale(dev, zoom, 1<<closeup, 1);
-  const float ppd =
-    (window == DT_WINDOW_MAIN || window == DT_WINDOW_SLIDESHOW)
-    ? darktable.gui->ppd
-    : dev->second_window.ppd;
+  gboolean second = window == DT_WINDOW_SECOND;
+  const float zoom_x        = second ? dt_second_window_get_dev_zoom_x(dev) : dt_control_get_dev_zoom_x();
+  const float zoom_y        = second ? dt_second_window_get_dev_zoom_y(dev) : dt_control_get_dev_zoom_y();
+  const dt_dev_zoom_t zoom  = second ? dt_second_window_get_dev_zoom(dev) : dt_control_get_dev_zoom();
+  const int closeup         = second ? dt_second_window_get_dev_closeup(dev) : dt_control_get_dev_closeup();
+  const float zoom_scale    = second ? dt_second_window_get_zoom_scale(dev, zoom, 1<<closeup, 1)
+                                     : dt_dev_get_zoom_scale(dev, zoom, 1<<closeup, 1);
+  const float backbuf_scale = second ? dt_second_window_get_zoom_scale(dev, zoom, 1.0f, 0) * dev->second_window.ppd
+                                     : dt_dev_get_zoom_scale(dev, zoom, 1.0f, 0) * darktable.gui->ppd;
+  const float ppd           = second ? dev->second_window.ppd : darktable.gui->ppd;
+  const double tb           = second ? dev->second_window.border_size : dev->border_size;
 
   const float sw = (float)processed_width / ppd;
   const float sh = (float)processed_height / ppd;
 
+  const double wd = dev->preview_pipe->processed_width;
+  const double ht = dev->preview_pipe->processed_height;
+
   cairo_save(cr);
 
-  cairo_translate(cr, ceilf(.5f * (width - sw)), ceilf(.5f * (height - sh)));
-  if(closeup)
+  if(dev->iso_12646.enabled)
   {
-    const double scale = 1<<closeup;
-    cairo_scale(cr, scale, scale);
-    cairo_translate(cr, -(.5 - 0.5/scale) * sw, -(.5 - 0.5/scale) * sh);
+    // force middle grey in background
+    dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_ISO12646_BG);
   }
+  else
+  {
+    if(dev->full_preview)
+      dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_DARKROOM_PREVIEW_BG);
+    else
+      dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_DARKROOM_BG);
+  }
+
+  cairo_paint(cr);
+
+  cairo_translate(cr, 0.5 * width, 0.5 * height);
+
+  const double maxw = MIN(0.5 * width - tb, 0.5 * wd * zoom_scale);
+  const double maxh = MIN(0.5 * height - tb, 0.5 * ht * zoom_scale);
 
   if(dev->iso_12646.enabled
      && window != DT_WINDOW_SLIDESHOW)
   {
     // draw the white frame around picture
-    const int bs = dev->border_size;
     const double ratio = dt_conf_get_float("darkroom/ui/iso12464_ratio");
-    const double tbw = bs * ratio;
-    cairo_rectangle(cr, -tbw, -tbw, sw + 2.0 * tbw, sh + 2.0 * tbw);
+    const double borw = maxw + tb * ratio, borh = maxh + tb * ratio;
+    cairo_rectangle(cr, -borw, -borh, 2.0 * borw, 2.0 * borh);
     dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_ISO12646_FG);
     cairo_fill(cr);
   }
 
-  cairo_surface_set_device_scale(surface, ppd, ppd);
+  cairo_rectangle(cr, -maxw, -maxh, 2.0 * maxw, 2.0 * maxh);
+  cairo_clip(cr);
 
-  cairo_set_source_surface (cr, surface, 0, 0);
-  cairo_pattern_set_filter
-    (cairo_get_source(cr),
-     zoom_scale >= 0.9999f ? CAIRO_FILTER_FAST : darktable.gui->dr_filter_image);
-  cairo_paint(cr);
+  cairo_scale(cr, zoom_scale, zoom_scale);
 
-  if(darktable.gui->show_focus_peaking
-     && window != DT_WINDOW_SLIDESHOW)
+  cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_FAST);
+
+  gboolean same_scale = buf_scale == 0 || buf_scale == backbuf_scale;
+
+  if(!same_scale || offset_x != zoom_x || offset_y != zoom_y)
   {
-    cairo_scale(cr, 1. / ppd, 1. / ppd);
-    dt_focuspeaking(cr, processed_width, processed_height,
-                    cairo_image_surface_get_data(surface));
+    dt_print(DT_DEBUG_EXPOSE, "[darkroom expose] draw preview\n");
+    // draw preview
+    dt_pthread_mutex_t *mutex = &dev->preview_pipe->backbuf_mutex;
+    dt_pthread_mutex_lock(mutex);
+
+    cairo_surface_t *preview = dt_view_create_surface(dev->preview_pipe->output_backbuf, wd, ht);
+
+    cairo_set_source_surface(cr, preview, -0.5 * wd - zoom_x * wd, - 0.5 * ht - zoom_y * ht - 0.5);
+    cairo_paint(cr);
+
+    cairo_surface_destroy(preview);
+
+    dt_pthread_mutex_unlock(mutex);
+  }
+
+  if(same_scale)
+  {
+    cairo_scale(cr, 1.0 / zoom_scale * (1<<closeup), 1.0 / zoom_scale * (1<<closeup));
+    cairo_surface_set_device_scale(surface, ppd, ppd);
+    cairo_translate(cr, (offset_x - zoom_x) * dev->pipe->processed_width * backbuf_scale - 0.5 * sw,
+                        (offset_y - zoom_y) * dev->pipe->processed_height * backbuf_scale - 0.5 * sh);
+    cairo_set_source_surface(cr, surface, 0, 0);
+    cairo_paint(cr);
+
+    if(darktable.gui->show_focus_peaking
+      && window != DT_WINDOW_SLIDESHOW)
+    {
+      cairo_scale(cr, 1. / ppd, 1. / ppd);
+      dt_focuspeaking(cr, processed_width, processed_height,
+                      cairo_image_surface_get_data(surface));
+    }
   }
 
   cairo_restore(cr);
@@ -1752,7 +1792,7 @@ void dt_view_paint_buffer(cairo_t *cr,
   cairo_surface_t *surface = dt_view_create_surface(buffer,
                                                     processed_width, processed_height);
   dt_view_paint_surface(cr, width, height, surface,
-                        processed_width, processed_height, window);
+                        processed_width, processed_height, window, 0, 0, 0);
   cairo_surface_destroy(surface);
 }
 

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -639,7 +639,10 @@ void dt_view_paint_surface(cairo_t *cr,
                            cairo_surface_t *surface,
                            const size_t processed_width,
                            const size_t processed_height,
-                           const dt_window_t window);
+                           const dt_window_t window,
+                           const float buf_scale,
+                           const double offset_x,
+                           const double offset_y);
 
 typedef uint64_t dt_view_context_t;
 


### PR DESCRIPTION
When zoomed into the central darkroom image or secondary preview window, you can drag the image to move it around. As soon as the available full size preview no longer matches the location on screen, we instead get a low resolution preview upscaled to fill the window, while the full size preview is being recalculated. This causes a jump to a blocky image and a jump back to quality image when done.

This PR instead continues to use the high res buffered image but correctly repositions it and temporarily fills the rest of the image (the corners) with the upscaled preview. When an updated high res image arrives it is being used, even if we have continued to move around in the mean time; it probably still better covers the window than the original one.

This PR also fixes issues (https://github.com/darktable-org/darktable/pull/13441#issuecomment-1405491024) with the size of the white border when iso12646 color assessment is turned on; this was done differently while in low res and high res modes and in the secondary window (only in high res), causing jumps/flashes when the calculation completed.

Double buffering was removed from `dt_view_paint_surface` because gtk3 now takes care of this for all widget repainting.

A lot of confusing/obfuscating/duplicate code around zoom scale and border calculation was removed. Obviously much more could be done here.

EDIT: use same approach for zooming in/out.
