### PR TITLE
darktable.css macOS roboto patch

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -840,7 +840,7 @@ menuitem > arrow
 /* fix for multiinstance menu rendering for Roboto font on macos and external diplays */
 menuitem label
 {
-padding: 0.01em;
+padding: 0.01em 0.42em;
 }
 
 /* then spacing around bauhaus widgets */

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -837,6 +837,12 @@ menuitem > arrow
   padding-right: 0.42em;
 }
 
+/* fix for multiinstance menu rendering for Roboto font on macos and external diplays */
+menuitem label
+{
+padding: 0.01em;
+}
+
 /* then spacing around bauhaus widgets */
 .dt_bauhaus
 {

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -837,12 +837,6 @@ menuitem > arrow
   padding-right: 0.42em;
 }
 
-/* fix for multiinstance menu rendering for Roboto font on macos and external diplays */
-menuitem label
-{
-padding: 0.01em 0.42em;
-}
-
 /* then spacing around bauhaus widgets */
 .dt_bauhaus
 {
@@ -850,6 +844,7 @@ padding: 0.01em 0.42em;
 }
 
 /* and set menuitem related to sort of combobox like metadata presets in import module */
+menuitem label,
 #view-dropdown button,
 #view-dropdown menuitem,
 #view-label


### PR DESCRIPTION
fixes #15083
seems to be specific for use of roboto font requested by darktable-elegant-darker.css 

please check with different display fonts and platforms