### PR TITLE
[GUI] Minor grammar fix: word order

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2953,7 +2953,7 @@ dt_iop_module_t *dt_dev_module_duplicate_ext(dt_develop_t *dev,
   {
     dt_print(DT_DEBUG_ALWAYS,
              "[dt_dev_module_duplicate] can't move new instance after the base one\n");
-    dt_control_log(_("module duplicate, can't move new instance after the base one\n"));
+    dt_control_log(_("duplicate module, can't move new instance after the base one\n"));
   }
 
   // that's all. rest of insertion is gui work !


### PR DESCRIPTION
The word "duplicate" is an adjective here and in this phrase it is an attributive (not a predicative) adjective and shoud be placed before the noun.