### PR TITLE
sigmoid: introduce custom primaries ("AgX-like" processing)

### DIFF
--- a/data/kernels/sigmoid.cl
+++ b/data/kernels/sigmoid.cl
@@ -16,6 +16,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "colorspace.h"
 #include "common.h"
 
 typedef struct dt_iop_sigmoid_value_order_t
@@ -182,7 +183,9 @@ sigmoid_loglogistic_per_channel (read_only image2d_t in,
                                  const float film_fog,
                                  const float contrast_power,
                                  const float skew_power,
-                                 const float hue_preservation)
+                                 const float hue_preservation,
+                                 constant const float *const pipe_to_rendering,
+                                 constant const float *const rendering_to_pipe)
 {
   const unsigned int x = get_global_id(0);
   const unsigned int y = get_global_id(1);
@@ -194,6 +197,9 @@ sigmoid_loglogistic_per_channel (read_only image2d_t in,
 
   // Force negative values to zero
   i = _desaturate_negative_values(i);
+
+  // Convert to rendering primaries
+  i = matrix_product_float4(i, pipe_to_rendering);
   float pix_array[3] = {i.x, i.y, i.z};
 
   i = _generalized_loglogistic_sigmoid_vector(i, white_target, paper_exp, film_fog, contrast_power, skew_power);
@@ -205,6 +211,8 @@ sigmoid_loglogistic_per_channel (read_only image2d_t in,
   _preserve_hue_and_energy(pix_array, per_channel, pixel_value_order, hue_preservation);
 
   i.xyz = (float3)(pix_array[0], pix_array[1], pix_array[2]);
+  i = matrix_product_float4(i, rendering_to_pipe);
+
   // Copy over the alpha channel
   i.w = alpha;
 

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -770,23 +770,25 @@ void gui_init(dt_iop_module_t *self)
   self->widget = GTK_WIDGET(g->primaries_section.container);
   dt_iop_module_t *sect = DT_IOP_SECTION_FOR_PARAMS(self, N_("primaries"));
 
-#define setup_color_combo(color, inset_tooltip, rotation_tooltip)   \
-  slider = dt_bauhaus_slider_from_params(sect, #color "_inset");    \
-  dt_bauhaus_slider_set_format(slider, "%");                        \
-  dt_bauhaus_slider_set_digits(slider, 1);                          \
-  dt_bauhaus_slider_set_factor(slider, 100.f);                      \
-  dt_bauhaus_slider_set_soft_range(slider, 0.f, 0.5f);              \
-  gtk_widget_set_tooltip_text(slider, inset_tooltip);               \
-                                                                    \
-  slider = dt_bauhaus_slider_from_params(sect, #color "_rotation"); \
-  dt_bauhaus_slider_set_format(slider, "°");                        \
-  dt_bauhaus_slider_set_digits(slider, 1);                          \
-  dt_bauhaus_slider_set_factor(slider, 180.f / DT_M_PI_F);          \
+#define setup_color_combo(color, r, g, b, inset_tooltip, rotation_tooltip) \
+  slider = dt_bauhaus_slider_from_params(sect, #color "_inset");           \
+  dt_bauhaus_slider_set_format(slider, "%");                               \
+  dt_bauhaus_slider_set_digits(slider, 1);                                 \
+  dt_bauhaus_slider_set_factor(slider, 100.f);                             \
+  dt_bauhaus_slider_set_soft_range(slider, 0.f, 0.5f);                     \
+  dt_bauhaus_slider_set_stop(slider, 0.f, r, g, b);                        \
+  gtk_widget_set_tooltip_text(slider, inset_tooltip);                      \
+                                                                           \
+  slider = dt_bauhaus_slider_from_params(sect, #color "_rotation");        \
+  dt_bauhaus_slider_set_format(slider, "°");                               \
+  dt_bauhaus_slider_set_digits(slider, 1);                                 \
+  dt_bauhaus_slider_set_factor(slider, 180.f / DT_M_PI_F);                 \
+  dt_bauhaus_slider_set_stop(slider, 0.f, r, g, b);                        \
   gtk_widget_set_tooltip_text(slider, rotation_tooltip); 
 
-  setup_color_combo(red, _("red primary inset"), _("red primary rotation"));
-  setup_color_combo(green, _("green primary inset"), _("green primary rotation"));
-  setup_color_combo(blue, _("blue primary inset"), _("blue primary rotation"));
+  setup_color_combo(red, 1.0f, 0.0f, 0.0f, _("red primary inset"), _("red primary rotation"));
+  setup_color_combo(green, 0.0f, 1.0f, 0.0f, _("green primary inset"), _("green primary rotation"));
+  setup_color_combo(blue, 0.0f, 0.0f, 1.0f, _("blue primary inset"), _("blue primary rotation"));
 
   slider = dt_bauhaus_slider_from_params(sect, "purity");
   dt_bauhaus_slider_set_format(slider, "%");

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -786,9 +786,10 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_stop(slider, 0.f, r, g, b);                        \
   gtk_widget_set_tooltip_text(slider, rotation_tooltip); 
 
-  setup_color_combo(red, 1.0f, 0.0f, 0.0f, _("red primary inset"), _("red primary rotation"));
-  setup_color_combo(green, 0.0f, 1.0f, 0.0f, _("green primary inset"), _("green primary rotation"));
-  setup_color_combo(blue, 0.0f, 0.0f, 1.0f, _("blue primary inset"), _("blue primary rotation"));
+  const float desaturation = 0.2f;
+  setup_color_combo(red, 1.f - desaturation, desaturation, desaturation, _("red primary inset"), _("red primary rotation"));
+  setup_color_combo(green, desaturation, 1.f - desaturation, desaturation, _("green primary inset"), _("green primary rotation"));
+  setup_color_combo(blue, desaturation, desaturation, 1.f - desaturation, _("blue primary inset"), _("blue primary rotation"));
 
   slider = dt_bauhaus_slider_from_params(sect, "purity");
   dt_bauhaus_slider_set_format(slider, "%");

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -42,19 +42,19 @@ DT_MODULE_INTROSPECTION(2, dt_iop_sigmoid_params_t)
 
 typedef enum dt_iop_sigmoid_methods_type_t
 {
-  DT_SIGMOID_METHOD_PER_CHANNEL = 0,     // $DESCRIPTION: "per channel"
-  DT_SIGMOID_METHOD_RGB_RATIO = 1,     // $DESCRIPTION: "RGB ratio"
+  DT_SIGMOID_METHOD_PER_CHANNEL = 0, // $DESCRIPTION: "per channel"
+  DT_SIGMOID_METHOD_RGB_RATIO = 1,   // $DESCRIPTION: "RGB ratio"
 } dt_iop_sigmoid_methods_type_t;
 
 
 typedef struct dt_iop_sigmoid_params_t
 {
-  float middle_grey_contrast;  // $MIN: 0.1  $MAX: 10.0 $DEFAULT: 1.5 $DESCRIPTION: "contrast"
-  float contrast_skewness;     // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "skew"
-  float display_white_target;  // $MIN: 20.0  $MAX: 1600.0 $DEFAULT: 100.0 $DESCRIPTION: "target white"
-  float display_black_target;  // $MIN: 0.0  $MAX: 15.0 $DEFAULT: 0.0152 $DESCRIPTION: "target black"
-  dt_iop_sigmoid_methods_type_t color_processing;  // $DEFAULT: DT_SIGMOID_METHOD_PER_CHANNEL $DESCRIPTION: "color processing"
-  float hue_preservation;                          // $MIN: 0.0 $MAX: 100.0 $DEFAULT: 100.0 $DESCRIPTION: "preserve hue"
+  float middle_grey_contrast; // $MIN: 0.1  $MAX: 10.0 $DEFAULT: 1.5 $DESCRIPTION: "contrast"
+  float contrast_skewness;    // $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "skew"
+  float display_white_target; // $MIN: 20.0  $MAX: 1600.0 $DEFAULT: 100.0 $DESCRIPTION: "target white"
+  float display_black_target; // $MIN: 0.0  $MAX: 15.0 $DEFAULT: 0.0152 $DESCRIPTION: "target black"
+  dt_iop_sigmoid_methods_type_t color_processing; // $DEFAULT: DT_SIGMOID_METHOD_PER_CHANNEL $DESCRIPTION: "color processing"
+  float hue_preservation; // $MIN: 0.0 $MAX: 100.0 $DEFAULT: 100.0 $DESCRIPTION: "preserve hue"
   float red_inset;        // $MIN:  0.0  $MAX: 0.99 $DEFAULT: 0.0 $DESCRIPTION: "red inset"
   float red_rotation;     // $MIN: -0.4  $MAX: 0.4  $DEFAULT: 0.0 $DESCRIPTION: "red rotation"
   float green_inset;      // $MIN:  0.0  $MAX: 0.99 $DEFAULT: 0.0 $DESCRIPTION: "green inset"
@@ -64,8 +64,12 @@ typedef struct dt_iop_sigmoid_params_t
   float purity;           // $MIN:  0.0  $MAX: 1.0  $DEFAULT: 0.0 $DESCRIPTION: "recover purity"
 } dt_iop_sigmoid_params_t;
 
-int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void **new_params,
-                  int32_t *new_params_size, int *new_version)
+int legacy_params(dt_iop_module_t *self,
+                  const void *const old_params,
+                  const int old_version,
+                  void **new_params,
+                  int32_t *new_params_size,
+                  int *new_version)
 {
   typedef struct dt_iop_sigmoid_params_v2_t
   {
@@ -99,8 +103,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     } dt_iop_sigmoid_params_v1_t;
 
     // Copy the common part of the params struct
-    dt_iop_sigmoid_params_v2_t *n =
-      (dt_iop_sigmoid_params_v2_t *)calloc(1, sizeof(dt_iop_sigmoid_params_v2_t));
+    dt_iop_sigmoid_params_v2_t *n = (dt_iop_sigmoid_params_v2_t *)calloc(1, sizeof(dt_iop_sigmoid_params_v2_t));
     memcpy(n, old_params, sizeof(dt_iop_sigmoid_params_v1_t));
 
     *new_params = n;
@@ -154,13 +157,12 @@ const char *aliases()
 
 const char **description(struct dt_iop_module_t *self)
 {
-  return dt_iop_set_description(self, _("apply a view transform to make a image displayable\n"
-                                        "on a screen or print. uses a robust and smooth\n"
-                                        "tone curve with optional color preservation methods."),
-                                      _("corrective and creative"),
-                                      _("linear, RGB, scene-referred"),
-                                      _("non-linear, RGB"),
-                                      _("linear, RGB, display-referred"));
+  return dt_iop_set_description(self,
+                                _("apply a view transform to make a image displayable\n"
+                                  "on a screen or print. uses a robust and smooth\n"
+                                  "tone curve with optional color preservation methods."),
+                                _("corrective and creative"), _("linear, RGB, scene-referred"),
+                                _("non-linear, RGB"), _("linear, RGB, display-referred"));
 }
 
 int flags()
@@ -190,16 +192,12 @@ void init_presets(dt_iop_module_so_t *self)
 
   if(auto_apply_sigmoid)
   {
-    dt_gui_presets_add_generic
-      (_("scene-referred default"), self->op, self->version(),
-       NULL, 0,
-       1, DEVELOP_BLEND_CS_RGB_SCENE);
+    dt_gui_presets_add_generic(_("scene-referred default"), self->op, self->version(), NULL, 0, 1,
+                               DEVELOP_BLEND_CS_RGB_SCENE);
 
-    dt_gui_presets_update_ldr(_("scene-referred default"), self->op,
-                              self->version(), FOR_RAW | FOR_MATRIX);
+    dt_gui_presets_update_ldr(_("scene-referred default"), self->op, self->version(), FOR_RAW | FOR_MATRIX);
 
-    dt_gui_presets_update_autoapply(_("scene-referred default"),
-                                    self->op, self->version(), TRUE);
+    dt_gui_presets_update_autoapply(_("scene-referred default"), self->op, self->version(), TRUE);
   }
 
   // others
@@ -212,17 +210,20 @@ void init_presets(dt_iop_module_so_t *self)
   p.middle_grey_contrast = 1.22f;
   p.contrast_skewness = 0.65f;
   p.hue_preservation = 100.0f;
-  dt_gui_presets_add_generic(_("neutral gray"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
+  dt_gui_presets_add_generic(_("neutral gray"), self->op, self->version(), &p, sizeof(p), 1,
+                             DEVELOP_BLEND_CS_RGB_SCENE);
 
   p.middle_grey_contrast = 1.6f;
   p.contrast_skewness = -0.2f;
   p.hue_preservation = 0.0f;
-  dt_gui_presets_add_generic(_("ACES 100-nit like"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
+  dt_gui_presets_add_generic(_("ACES 100-nit like"), self->op, self->version(), &p, sizeof(p), 1,
+                             DEVELOP_BLEND_CS_RGB_SCENE);
 
   p.middle_grey_contrast = 1.0f;
   p.contrast_skewness = 0.0f;
   p.color_processing = DT_SIGMOID_METHOD_RGB_RATIO;
-  dt_gui_presets_add_generic(_("Reinhard"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
+  dt_gui_presets_add_generic(_("Reinhard"), self->op, self->version(), &p, sizeof(p), 1,
+                             DEVELOP_BLEND_CS_RGB_SCENE);
 
   const float DEG_TO_RAD = DT_M_PI_F / 180.f;
   p.middle_grey_contrast = 1.4f;
@@ -243,8 +244,12 @@ void init_presets(dt_iop_module_so_t *self)
 #ifdef _OPENMP
 #pragma omp declare simd uniform(magnitude, paper_exp, film_fog, film_power, paper_power)
 #endif
-static inline float generalized_loglogistic_sigmoid(const float value, const float magnitude, const float paper_exp,
-                                                    const float film_fog, const float film_power, const float paper_power)
+static inline float _generalized_loglogistic_sigmoid(const float value,
+                                                     const float magnitude,
+                                                     const float paper_exp,
+                                                     const float film_fog,
+                                                     const float film_power,
+                                                     const float paper_power)
 {
   const float clamped_value = fmaxf(value, 0.0f);
   // The following equation can be derived as a model for film + paper but it has a pole at 0
@@ -257,7 +262,10 @@ static inline float generalized_loglogistic_sigmoid(const float value, const flo
   return dt_isnan(paper_response) ? magnitude : paper_response;
 }
 
-void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+void commit_params(dt_iop_module_t *self,
+                   dt_iop_params_t *p1,
+                   dt_dev_pixelpipe_t *pipe,
+                   dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_sigmoid_params_t *params = (dt_iop_sigmoid_params_t *)p1;
   dt_iop_sigmoid_data_t *module_data = (dt_iop_sigmoid_data_t *)piece->data;
@@ -273,10 +281,15 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   const float ref_paper_power = 1.0f;
   const float ref_magnitude = 1.0f;
   const float ref_film_fog = 0.0f;
-  const float ref_paper_exposure = powf(ref_film_fog + MIDDLE_GREY, ref_film_power) * ((ref_magnitude / MIDDLE_GREY) - 1.0f);
+  const float ref_paper_exposure
+      = powf(ref_film_fog + MIDDLE_GREY, ref_film_power) * ((ref_magnitude / MIDDLE_GREY) - 1.0f);
   const float delta = 1e-6f;
-  const float ref_slope = (generalized_loglogistic_sigmoid(MIDDLE_GREY + delta, ref_magnitude, ref_paper_exposure, ref_film_fog, ref_film_power, ref_paper_power) -
-                           generalized_loglogistic_sigmoid(MIDDLE_GREY - delta, ref_magnitude, ref_paper_exposure, ref_film_fog, ref_film_power, ref_paper_power)) / 2.0f / delta;
+  const float ref_slope
+      = (_generalized_loglogistic_sigmoid(MIDDLE_GREY + delta, ref_magnitude, ref_paper_exposure, ref_film_fog,
+                                          ref_film_power, ref_paper_power)
+         - _generalized_loglogistic_sigmoid(MIDDLE_GREY - delta, ref_magnitude, ref_paper_exposure, ref_film_fog,
+                                            ref_film_power, ref_paper_power))
+        / 2.0f / delta;
 
   // Add skew
   module_data->paper_power = powf(5.0f, -params->contrast_skewness);
@@ -284,10 +297,15 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   // Slope at low film power
   const float temp_film_power = 1.0f;
   const float temp_white_target = 0.01f * params->display_white_target;
-  const float temp_white_grey_relation = powf(temp_white_target / MIDDLE_GREY, 1.0f / module_data->paper_power) - 1.0f;
+  const float temp_white_grey_relation
+      = powf(temp_white_target / MIDDLE_GREY, 1.0f / module_data->paper_power) - 1.0f;
   const float temp_paper_exposure = powf(MIDDLE_GREY, temp_film_power) * temp_white_grey_relation;
-  const float temp_slope = (generalized_loglogistic_sigmoid(MIDDLE_GREY + delta, temp_white_target, temp_paper_exposure, ref_film_fog, temp_film_power, module_data->paper_power) -
-                            generalized_loglogistic_sigmoid(MIDDLE_GREY - delta, temp_white_target, temp_paper_exposure, ref_film_fog, temp_film_power, module_data->paper_power)) / 2.0f / delta;
+  const float temp_slope
+      = (_generalized_loglogistic_sigmoid(MIDDLE_GREY + delta, temp_white_target, temp_paper_exposure,
+                                          ref_film_fog, temp_film_power, module_data->paper_power)
+         - _generalized_loglogistic_sigmoid(MIDDLE_GREY - delta, temp_white_target, temp_paper_exposure,
+                                            ref_film_fog, temp_film_power, module_data->paper_power))
+        / 2.0f / delta;
 
   // Figure out what film power fulfills the target slope
   // (linear when assuming display_black = 0.0)
@@ -296,11 +314,16 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   // Calculate the other parameters now that both film and paper power is known
   module_data->white_target = 0.01f * params->display_white_target;
   module_data->black_target = 0.01f * params->display_black_target;
-  const float white_grey_relation = powf(module_data->white_target / MIDDLE_GREY, 1.0f / module_data->paper_power) - 1.0f;
-  const float white_black_relation = powf(module_data->black_target / module_data->white_target, -1.0f / module_data->paper_power) - 1.0f;
+  const float white_grey_relation
+      = powf(module_data->white_target / MIDDLE_GREY, 1.0f / module_data->paper_power) - 1.0f;
+  const float white_black_relation
+      = powf(module_data->black_target / module_data->white_target, -1.0f / module_data->paper_power) - 1.0f;
 
-  module_data->film_fog = MIDDLE_GREY * powf(white_grey_relation, 1.0f / module_data->film_power) / (powf(white_black_relation, 1.0f / module_data->film_power) - powf(white_grey_relation, 1.0f / module_data->film_power));
-  module_data->paper_exposure = powf(module_data->film_fog + MIDDLE_GREY, module_data->film_power) * white_grey_relation;
+  module_data->film_fog = MIDDLE_GREY * powf(white_grey_relation, 1.0f / module_data->film_power)
+                          / (powf(white_black_relation, 1.0f / module_data->film_power)
+                             - powf(white_grey_relation, 1.0f / module_data->film_power));
+  module_data->paper_exposure
+      = powf(module_data->film_fog + MIDDLE_GREY, module_data->film_power) * white_grey_relation;
 
   module_data->color_processing = params->color_processing;
   module_data->hue_preservation = fminf(fmaxf(0.01f * params->hue_preservation, 0.0f), 1.0f);
@@ -323,7 +346,8 @@ static void _calculate_adjusted_primaries(const dt_iop_sigmoid_data_t *const mod
   //
   // References:
   // AgX by Troy Sobotka - https://github.com/sobotka/AgX-S2O3
-  // Related discussions on Blender Artists forums - https://blenderartists.org/t/feedback-development-filmic-baby-step-to-a-v2/1361663
+  // Related discussions on Blender Artists forums -
+  // https://blenderartists.org/t/feedback-development-filmic-baby-step-to-a-v2/1361663
   //
   // The idea is to "inset" the work RGB data toward achromatic
   // along spectral lines before per-channel curves. This makes
@@ -333,10 +357,12 @@ static void _calculate_adjusted_primaries(const dt_iop_sigmoid_data_t *const mod
   // and achieve a favourable shift towards yellow.
   float custom_primaries[3][2];
   for(size_t i = 0; i < 3; i++)
-    dt_rotate_and_scale_primary(pipe_work_profile, 1.f - module_data->inset[i], module_data->rotation[i], i, custom_primaries[i]);
+    dt_rotate_and_scale_primary(pipe_work_profile, 1.f - module_data->inset[i], module_data->rotation[i], i,
+                                custom_primaries[i]);
 
   dt_colormatrix_t custom_to_XYZ;
-  dt_make_transposed_matrices_from_primaries_and_whitepoint(custom_primaries, pipe_work_profile->whitepoint, custom_to_XYZ);
+  dt_make_transposed_matrices_from_primaries_and_whitepoint(custom_primaries, pipe_work_profile->whitepoint,
+                                                            custom_to_XYZ);
   dt_colormatrix_mul(pipe_to_rendering, custom_to_XYZ, pipe_work_profile->matrix_out_transposed);
 
   for(size_t i = 0; i < 3; i++)
@@ -345,7 +371,8 @@ static void _calculate_adjusted_primaries(const dt_iop_sigmoid_data_t *const mod
     dt_rotate_and_scale_primary(pipe_work_profile, scaling, module_data->rotation[i], i, custom_primaries[i]);
   }
 
-  dt_make_transposed_matrices_from_primaries_and_whitepoint(custom_primaries, pipe_work_profile->whitepoint, custom_to_XYZ);
+  dt_make_transposed_matrices_from_primaries_and_whitepoint(custom_primaries, pipe_work_profile->whitepoint,
+                                                            custom_to_XYZ);
   dt_colormatrix_t tmp;
   dt_colormatrix_mul(tmp, custom_to_XYZ, pipe_work_profile->matrix_out_transposed);
   mat3SSEinv(rendering_to_pipe, tmp);
@@ -354,7 +381,7 @@ static void _calculate_adjusted_primaries(const dt_iop_sigmoid_data_t *const mod
 #ifdef _OPENMP
 #pragma omp declare simd
 #endif
-static inline void desaturate_negative_values(const dt_aligned_pixel_t pix_in, dt_aligned_pixel_t pix_out)
+static inline void _desaturate_negative_values(const dt_aligned_pixel_t pix_in, dt_aligned_pixel_t pix_out)
 {
   const float pixel_average = fmaxf((pix_in[0] + pix_in[1] + pix_in[2]) / 3.0f, 0.0f);
   const float min_value = fminf(fminf(pix_in[0], pix_in[1]), pix_in[2]);
@@ -372,30 +399,30 @@ typedef struct dt_iop_sigmoid_value_order_t
   size_t max;
 } dt_iop_sigmoid_value_order_t;
 
-static void pixel_channel_order(const dt_aligned_pixel_t pix_in, dt_iop_sigmoid_value_order_t *pixel_value_order)
+static void _pixel_channel_order(const dt_aligned_pixel_t pix_in, dt_iop_sigmoid_value_order_t *pixel_value_order)
 {
-  if (pix_in[0] >= pix_in[1])
+  if(pix_in[0] >= pix_in[1])
   {
-    if (pix_in[1] > pix_in[2])
-    {  // Case 1: r >= g >  b
+    if(pix_in[1] > pix_in[2])
+    { // Case 1: r >= g >  b
       pixel_value_order->max = 0;
       pixel_value_order->mid = 1;
       pixel_value_order->min = 2;
     }
-    else if (pix_in[2] > pix_in[0])
-    {  // Case 2: b >  r >= g
+    else if(pix_in[2] > pix_in[0])
+    { // Case 2: b >  r >= g
       pixel_value_order->max = 2;
       pixel_value_order->mid = 0;
       pixel_value_order->min = 1;
     }
-    else if (pix_in[2] > pix_in[1])
-    {  // Case 3: r >= b >  g
+    else if(pix_in[2] > pix_in[1])
+    { // Case 3: r >= b >  g
       pixel_value_order->max = 0;
       pixel_value_order->mid = 2;
       pixel_value_order->min = 1;
     }
     else
-    {  // Case 4: r == g == b
+    { // Case 4: r == g == b
       // No change of the middle value, just assign something.
       pixel_value_order->max = 0;
       pixel_value_order->mid = 1;
@@ -404,20 +431,20 @@ static void pixel_channel_order(const dt_aligned_pixel_t pix_in, dt_iop_sigmoid_
   }
   else
   {
-    if (pix_in[0] >= pix_in[2])
-    {  // Case 5: g >  r >= b
+    if(pix_in[0] >= pix_in[2])
+    { // Case 5: g >  r >= b
       pixel_value_order->max = 1;
       pixel_value_order->mid = 0;
       pixel_value_order->min = 2;
     }
-    else if (pix_in[2] > pix_in[1])
-    {  // Case 6: b >  g >  r
+    else if(pix_in[2] > pix_in[1])
+    { // Case 6: b >  g >  r
       pixel_value_order->max = 2;
       pixel_value_order->mid = 1;
       pixel_value_order->min = 0;
     }
     else
-    {  // Case 7: g >= b >  r
+    { // Case 7: g >= b >  r
       pixel_value_order->max = 1;
       pixel_value_order->mid = 2;
       pixel_value_order->min = 0;
@@ -425,8 +452,11 @@ static void pixel_channel_order(const dt_aligned_pixel_t pix_in, dt_iop_sigmoid_
   }
 }
 
-void process_loglogistic_rgb_ratio(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
-                                   const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+void process_loglogistic_rgb_ratio(dt_dev_pixelpipe_iop_t *piece,
+                                   const void *const ivoid,
+                                   void *const ovoid,
+                                   const dt_iop_roi_t *const roi_in,
+                                   const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_sigmoid_data_t *module_data = (dt_iop_sigmoid_data_t *)piece->data;
   const float *const in = (const float *)ivoid;
@@ -441,10 +471,9 @@ void process_loglogistic_rgb_ratio(dt_dev_pixelpipe_iop_t *piece, const void *co
   const float skew_power = module_data->paper_power;
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(npixels, white_target, black_target, paper_exp, film_fog, contrast_power, skew_power) \
-  dt_omp_sharedconst(in, out) \
-  schedule(static)
+#pragma omp parallel for default(none)                                                                            \
+    dt_omp_firstprivate(npixels, white_target, black_target, paper_exp, film_fog, contrast_power, skew_power)     \
+    dt_omp_sharedconst(in, out) schedule(static)
 #endif
   for(size_t k = 0; k < 4 * npixels; k += 4)
   {
@@ -454,13 +483,14 @@ void process_loglogistic_rgb_ratio(dt_dev_pixelpipe_iop_t *piece, const void *co
     dt_aligned_pixel_t pix_in_strict_positive;
 
     // Force negative values to zero
-    desaturate_negative_values(pix_in, pix_in_strict_positive);
+    _desaturate_negative_values(pix_in, pix_in_strict_positive);
 
     // Preserve color ratios by applying the tone curve on a luma estimate and then scale the RGB tripplet uniformly
     const float luma = (pix_in_strict_positive[0] + pix_in_strict_positive[1] + pix_in_strict_positive[2]) / 3.0f;
-    const float mapped_luma = generalized_loglogistic_sigmoid(luma, white_target, paper_exp, film_fog, contrast_power, skew_power);
+    const float mapped_luma
+        = _generalized_loglogistic_sigmoid(luma, white_target, paper_exp, film_fog, contrast_power, skew_power);
 
-    if (luma > 1e-9)
+    if(luma > 1e-9)
     {
       const float scaling_factor = mapped_luma / luma;
       for_each_channel(c, aligned(pix_in_strict_positive, pix_out))
@@ -478,22 +508,30 @@ void process_loglogistic_rgb_ratio(dt_dev_pixelpipe_iop_t *piece, const void *co
 
     // RGB index order sorted by value;
     dt_iop_sigmoid_value_order_t pixel_value_order;
-    pixel_channel_order(pre_out, &pixel_value_order);
+    _pixel_channel_order(pre_out, &pixel_value_order);
     const float pixel_min = pre_out[pixel_value_order.min];
     const float pixel_max = pre_out[pixel_value_order.max];
 
     // Chroma relative display gamut and scene "mapping" gamut.
     const float epsilon = 1e-6;
-    const float display_border_vs_chroma_white = (white_target - mapped_luma) / (pixel_max - mapped_luma + epsilon); // "Distance" to max channel = white_target
-    const float display_border_vs_chroma_black = (black_target - mapped_luma) / (pixel_min - mapped_luma - epsilon); // "Distance" to min_channel = black_target
+    const float display_border_vs_chroma_white
+        = (white_target - mapped_luma)
+          / (pixel_max - mapped_luma + epsilon); // "Distance" to max channel = white_target
+    const float display_border_vs_chroma_black
+        = (black_target - mapped_luma)
+          / (pixel_min - mapped_luma - epsilon); // "Distance" to min_channel = black_target
     const float display_border_vs_chroma = fminf(display_border_vs_chroma_white, display_border_vs_chroma_black);
-    const float chroma_vs_mapping_border = (mapped_luma - pixel_min) / (mapped_luma + epsilon); // "Distance" to min channel = 0.0
+    const float chroma_vs_mapping_border
+        = (mapped_luma - pixel_min) / (mapped_luma + epsilon); // "Distance" to min channel = 0.0
 
     // Hyperbolic gamut compression
-    // Small chroma values, i.e., colors close to the acromatic axis are preserved while large chroma values are compressed.
+    // Small chroma values, i.e., colors close to the acromatic axis are preserved while large chroma values are
+    // compressed.
 
     const float pixel_chroma_adjustment = 1.0f / (chroma_vs_mapping_border * display_border_vs_chroma + epsilon);
-    const float hyperbolic_chroma = 2.0f * chroma_vs_mapping_border / (1.0f - chroma_vs_mapping_border * chroma_vs_mapping_border + epsilon) * pixel_chroma_adjustment;
+    const float hyperbolic_chroma = 2.0f * chroma_vs_mapping_border
+                                    / (1.0f - chroma_vs_mapping_border * chroma_vs_mapping_border + epsilon)
+                                    * pixel_chroma_adjustment;
 
     const float hyperbolic_z = sqrtf(hyperbolic_chroma * hyperbolic_chroma + 1.0f);
     const float chroma_factor = hyperbolic_chroma / (1.0f + hyperbolic_z) * display_border_vs_chroma;
@@ -510,14 +548,19 @@ void process_loglogistic_rgb_ratio(dt_dev_pixelpipe_iop_t *piece, const void *co
 
 // Linear interpolation of hue that also preserve sum of channels
 // Assumes hue_preservation strictly in range [0, 1]
-static inline void preserve_hue_and_energy(const dt_aligned_pixel_t pix_in, const dt_aligned_pixel_t per_channel, dt_aligned_pixel_t pix_out,
-    const dt_iop_sigmoid_value_order_t order, const float hue_preservation)
+static inline void _preserve_hue_and_energy(const dt_aligned_pixel_t pix_in,
+                                            const dt_aligned_pixel_t per_channel,
+                                            dt_aligned_pixel_t pix_out,
+                                            const dt_iop_sigmoid_value_order_t order,
+                                            const float hue_preservation)
 {
   // Naive Hue correction of the middle channel
   const float chroma = pix_in[order.max] - pix_in[order.min];
   const float midscale = chroma != 0.f ? (pix_in[order.mid] - pix_in[order.min]) / chroma : 0.f;
-  const float full_hue_correction = per_channel[order.min] + (per_channel[order.max] - per_channel[order.min]) * midscale;
-  const float naive_hue_mid = (1.0f - hue_preservation) * per_channel[order.mid] + hue_preservation * full_hue_correction;
+  const float full_hue_correction
+      = per_channel[order.min] + (per_channel[order.max] - per_channel[order.min]) * midscale;
+  const float naive_hue_mid
+      = (1.0f - hue_preservation) * per_channel[order.mid] + hue_preservation * full_hue_correction;
 
   const float per_channel_energy = per_channel[0] + per_channel[1] + per_channel[2];
   const float naive_hue_energy = per_channel[order.min] + naive_hue_mid + per_channel[order.max];
@@ -526,9 +569,12 @@ static inline void preserve_hue_and_energy(const dt_aligned_pixel_t pix_in, cons
   const float energy_target = blend_factor * per_channel_energy + (1.0f - blend_factor) * naive_hue_energy;
 
   // Preserve hue constrained to maintain the same energy as the per channel result
-  if (naive_hue_mid <= per_channel[order.mid])
+  if(naive_hue_mid <= per_channel[order.mid])
   {
-    const float corrected_mid = ((1.0f - hue_preservation) * per_channel[order.mid] + hue_preservation * (midscale * per_channel[order.max] + (1.0f - midscale) * (energy_target - per_channel[order.max])))
+    const float corrected_mid = ((1.0f - hue_preservation) * per_channel[order.mid]
+                                 + hue_preservation
+                                       * (midscale * per_channel[order.max]
+                                          + (1.0f - midscale) * (energy_target - per_channel[order.max])))
                                 / (1.0f + hue_preservation * (1.0f - midscale));
     pix_out[order.min] = energy_target - per_channel[order.max] - corrected_mid;
     pix_out[order.mid] = corrected_mid;
@@ -536,7 +582,10 @@ static inline void preserve_hue_and_energy(const dt_aligned_pixel_t pix_in, cons
   }
   else
   {
-    const float corrected_mid = ((1.0f - hue_preservation) * per_channel[order.mid] + hue_preservation * (per_channel[order.min] * (1.0f - midscale) + midscale * (energy_target - per_channel[order.min])))
+    const float corrected_mid = ((1.0f - hue_preservation) * per_channel[order.mid]
+                                 + hue_preservation
+                                       * (per_channel[order.min] * (1.0f - midscale)
+                                          + midscale * (energy_target - per_channel[order.min])))
                                 / (1.0f + hue_preservation * midscale);
     pix_out[order.min] = per_channel[order.min];
     pix_out[order.mid] = corrected_mid;
@@ -544,8 +593,10 @@ static inline void preserve_hue_and_energy(const dt_aligned_pixel_t pix_in, cons
   }
 }
 
-void process_loglogistic_per_channel(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
-                                     const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+void process_loglogistic_per_channel(dt_dev_pixelpipe_iop_t *piece,
+                                     const void *const ivoid, void *const ovoid,
+                                     const dt_iop_roi_t *const roi_in,
+                                     const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_sigmoid_data_t *module_data = (dt_iop_sigmoid_data_t *)piece->data;
 
@@ -565,11 +616,9 @@ void process_loglogistic_per_channel(dt_dev_pixelpipe_iop_t *piece, const void *
   _calculate_adjusted_primaries(module_data, pipe_work_profile, pipe_to_rendering, rendering_to_pipe);
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(npixels, white_target, paper_exp, film_fog, contrast_power, skew_power, hue_preservation, \
-                      pipe_to_rendering, rendering_to_pipe) \
-  dt_omp_sharedconst(in, out) \
-  schedule(static)
+#pragma omp parallel for default(none)                                                                            \
+    dt_omp_firstprivate(npixels, white_target, paper_exp, film_fog, contrast_power, skew_power, hue_preservation, \
+                            pipe_to_rendering, rendering_to_pipe) dt_omp_sharedconst(in, out) schedule(static)
 #endif
   for(size_t k = 0; k < 4 * npixels; k += 4)
   {
@@ -579,21 +628,23 @@ void process_loglogistic_per_channel(dt_dev_pixelpipe_iop_t *piece, const void *
     dt_aligned_pixel_t per_channel;
 
     // Force negative values to zero
-    desaturate_negative_values(pix_in, pix_in_strict_positive);
+    _desaturate_negative_values(pix_in, pix_in_strict_positive);
 
     dt_aligned_pixel_t rendering_RGB;
     dt_apply_transposed_color_matrix(pix_in_strict_positive, pipe_to_rendering, rendering_RGB);
 
     for_each_channel(c, aligned(rendering_RGB, per_channel))
     {
-      per_channel[c] = generalized_loglogistic_sigmoid(rendering_RGB[c], white_target, paper_exp, film_fog, contrast_power, skew_power);
+      per_channel[c] = _generalized_loglogistic_sigmoid(rendering_RGB[c], white_target, paper_exp, film_fog,
+                                                        contrast_power, skew_power);
     }
 
     // Hue correction by scaling the middle value relative to the max and min values.
     dt_iop_sigmoid_value_order_t pixel_value_order;
     dt_aligned_pixel_t per_channel_hue_corrected;
-    pixel_channel_order(rendering_RGB, &pixel_value_order);
-    preserve_hue_and_energy(rendering_RGB, per_channel, per_channel_hue_corrected, pixel_value_order, hue_preservation);
+    _pixel_channel_order(rendering_RGB, &pixel_value_order);
+    _preserve_hue_and_energy(rendering_RGB, per_channel, per_channel_hue_corrected, pixel_value_order,
+                             hue_preservation);
     dt_apply_transposed_color_matrix(per_channel_hue_corrected, rendering_to_pipe, pix_out);
 
     // Copy over the alpha channel
@@ -601,16 +652,18 @@ void process_loglogistic_per_channel(dt_dev_pixelpipe_iop_t *piece, const void *
   }
 }
 
-
-
 /** process, all real work is done here. */
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
-             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+void process(struct dt_iop_module_t *self,
+             dt_dev_pixelpipe_iop_t *piece,
+             const void *const ivoid,
+             void *const ovoid,
+             const dt_iop_roi_t *const roi_in,
+             const dt_iop_roi_t *const roi_out)
 {
   // this is called for preview and full pipe separately, each with its own pixelpipe piece.
   dt_iop_sigmoid_data_t *module_data = (dt_iop_sigmoid_data_t *)piece->data;
 
-  if (module_data->color_processing == DT_SIGMOID_METHOD_PER_CHANNEL)
+  if(module_data->color_processing == DT_SIGMOID_METHOD_PER_CHANNEL)
   {
     process_loglogistic_per_channel(piece, ivoid, ovoid, roi_in, roi_out);
   }
@@ -643,39 +696,37 @@ int process_cl(struct dt_iop_module_t *self,
   const float skew_power = d->paper_power;
 
   const dt_iop_order_iccprofile_info_t *pipe_work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
-  dt_colormatrix_t pipe_to_rendering_transposed, rendering_to_pipe_transposed, pipe_to_rendering, rendering_to_pipe;
+  dt_colormatrix_t pipe_to_rendering_transposed, rendering_to_pipe_transposed, pipe_to_rendering,
+      rendering_to_pipe;
   _calculate_adjusted_primaries(d, pipe_work_profile, pipe_to_rendering_transposed, rendering_to_pipe_transposed);
   transpose_3xSSE(pipe_to_rendering_transposed, pipe_to_rendering);
   transpose_3xSSE(rendering_to_pipe_transposed, rendering_to_pipe);
-  cl_mem dev_pipe_to_rendering = dt_opencl_copy_host_to_device_constant(devid, sizeof(pipe_to_rendering), pipe_to_rendering);
-  cl_mem dev_rendering_to_pipe = dt_opencl_copy_host_to_device_constant(devid, sizeof(rendering_to_pipe), rendering_to_pipe);
+  cl_mem dev_pipe_to_rendering
+      = dt_opencl_copy_host_to_device_constant(devid, sizeof(pipe_to_rendering), pipe_to_rendering);
+  cl_mem dev_rendering_to_pipe
+      = dt_opencl_copy_host_to_device_constant(devid, sizeof(rendering_to_pipe), rendering_to_pipe);
   if(dev_pipe_to_rendering == NULL || dev_rendering_to_pipe == NULL)
   {
     dt_print(DT_DEBUG_OPENCL, "[opencl_sigmoid] couldn't allocate memory!\n");
     goto cleanup;
   }
 
-  if (d->color_processing == DT_SIGMOID_METHOD_PER_CHANNEL)
+  if(d->color_processing == DT_SIGMOID_METHOD_PER_CHANNEL)
   {
     const float hue_preservation = d->hue_preservation;
-    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_sigmoid_loglogistic_per_channel,
-                                           width, height,
-                                           CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height),
-                                           CLARG(white_target), CLARG(paper_exp),
-                                           CLARG(film_fog), CLARG(contrast_power),
-                                           CLARG(skew_power), CLARG(hue_preservation),
-                                           CLARG(dev_pipe_to_rendering), CLARG(dev_rendering_to_pipe));
+    err = dt_opencl_enqueue_kernel_2d_args(
+        devid, gd->kernel_sigmoid_loglogistic_per_channel, width, height, CLARG(dev_in), CLARG(dev_out),
+        CLARG(width), CLARG(height), CLARG(white_target), CLARG(paper_exp), CLARG(film_fog), CLARG(contrast_power),
+        CLARG(skew_power), CLARG(hue_preservation), CLARG(dev_pipe_to_rendering), CLARG(dev_rendering_to_pipe));
   }
   else
   {
     const float black_target = d->black_target;
 
-    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_sigmoid_loglogistic_rgb_ratio,
-                                           width, height,
+    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_sigmoid_loglogistic_rgb_ratio, width, height,
                                            CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height),
                                            CLARG(white_target), CLARG(black_target), CLARG(paper_exp),
-                                           CLARG(film_fog), CLARG(contrast_power),
-                                           CLARG(skew_power));
+                                           CLARG(film_fog), CLARG(contrast_power), CLARG(skew_power));
   }
 
 cleanup:
@@ -683,17 +734,15 @@ cleanup:
   dt_opencl_release_mem_object(dev_rendering_to_pipe);
   return err;
 }
-#endif //HAVE_OPENCL
+#endif // HAVE_OPENCL
 
 void init_global(dt_iop_module_so_t *module)
 {
   const int program = 36; // sigmoid.cl, from programs.conf
-  dt_iop_sigmoid_global_data_t *gd  =
-    (dt_iop_sigmoid_global_data_t *)malloc(sizeof(dt_iop_sigmoid_global_data_t));
+  dt_iop_sigmoid_global_data_t *gd = (dt_iop_sigmoid_global_data_t *)malloc(sizeof(dt_iop_sigmoid_global_data_t));
 
   module->data = gd;
-  gd->kernel_sigmoid_loglogistic_per_channel =
-    dt_opencl_create_kernel(program, "sigmoid_loglogistic_per_channel");
+  gd->kernel_sigmoid_loglogistic_per_channel = dt_opencl_create_kernel(program, "sigmoid_loglogistic_per_channel");
   gd->kernel_sigmoid_loglogistic_rgb_ratio = dt_opencl_create_kernel(program, "sigmoid_loglogistic_rgb_ratio");
 }
 
@@ -757,38 +806,36 @@ void gui_init(dt_iop_module_t *self)
   GtkWidget *main_box = self->widget;
 
   // primaries collapsible section
-  dt_gui_new_collapsible_section
-    (&g->primaries_section,
-     "plugins/darkroom/sigmoid/expand_primaries",
-     _("primaries"),
-     GTK_BOX(main_box),
-     DT_ACTION(self));
-  gtk_widget_set_tooltip_text(g->primaries_section.expander,
-                                _("set custom primaries"));
+  dt_gui_new_collapsible_section(&g->primaries_section, "plugins/darkroom/sigmoid/expand_primaries",
+                                 _("primaries"), GTK_BOX(main_box), DT_ACTION(self));
+  gtk_widget_set_tooltip_text(g->primaries_section.expander, _("set custom primaries"));
 
   self->widget = GTK_WIDGET(g->primaries_section.container);
   dt_iop_module_t *sect = DT_IOP_SECTION_FOR_PARAMS(self, N_("primaries"));
 
-#define SETUP_COLOR_COMBO(color, r, g, b, inset_tooltip, rotation_tooltip) \
-  slider = dt_bauhaus_slider_from_params(sect, #color "_inset");           \
-  dt_bauhaus_slider_set_format(slider, "%");                               \
-  dt_bauhaus_slider_set_digits(slider, 1);                                 \
-  dt_bauhaus_slider_set_factor(slider, 100.f);                             \
-  dt_bauhaus_slider_set_soft_range(slider, 0.f, 0.5f);                     \
-  dt_bauhaus_slider_set_stop(slider, 0.f, r, g, b);                        \
-  gtk_widget_set_tooltip_text(slider, inset_tooltip);                      \
-                                                                           \
-  slider = dt_bauhaus_slider_from_params(sect, #color "_rotation");        \
-  dt_bauhaus_slider_set_format(slider, "°");                               \
-  dt_bauhaus_slider_set_digits(slider, 1);                                 \
-  dt_bauhaus_slider_set_factor(slider, 180.f / DT_M_PI_F);                 \
-  dt_bauhaus_slider_set_stop(slider, 0.f, r, g, b);                        \
-  gtk_widget_set_tooltip_text(slider, rotation_tooltip); 
+#define SETUP_COLOR_COMBO(color, r, g, b, inset_tooltip, rotation_tooltip)                                        \
+  slider = dt_bauhaus_slider_from_params(sect, #color "_inset");                                                  \
+  dt_bauhaus_slider_set_format(slider, "%");                                                                      \
+  dt_bauhaus_slider_set_digits(slider, 1);                                                                        \
+  dt_bauhaus_slider_set_factor(slider, 100.f);                                                                    \
+  dt_bauhaus_slider_set_soft_range(slider, 0.f, 0.5f);                                                            \
+  dt_bauhaus_slider_set_stop(slider, 0.f, r, g, b);                                                               \
+  gtk_widget_set_tooltip_text(slider, inset_tooltip);                                                             \
+                                                                                                                  \
+  slider = dt_bauhaus_slider_from_params(sect, #color "_rotation");                                               \
+  dt_bauhaus_slider_set_format(slider, "°");                                                                      \
+  dt_bauhaus_slider_set_digits(slider, 1);                                                                        \
+  dt_bauhaus_slider_set_factor(slider, 180.f / DT_M_PI_F);                                                        \
+  dt_bauhaus_slider_set_stop(slider, 0.f, r, g, b);                                                               \
+  gtk_widget_set_tooltip_text(slider, rotation_tooltip);
 
   const float desaturation = 0.2f;
-  SETUP_COLOR_COMBO(red, 1.f - desaturation, desaturation, desaturation, _("red primary inset"), _("red primary rotation"));
-  SETUP_COLOR_COMBO(green, desaturation, 1.f - desaturation, desaturation, _("green primary inset"), _("green primary rotation"));
-  SETUP_COLOR_COMBO(blue, desaturation, desaturation, 1.f - desaturation, _("blue primary inset"), _("blue primary rotation"));
+  SETUP_COLOR_COMBO(red, 1.f - desaturation, desaturation, desaturation, _("red primary inset"),
+                    _("red primary rotation"));
+  SETUP_COLOR_COMBO(green, desaturation, 1.f - desaturation, desaturation, _("green primary inset"),
+                    _("green primary rotation"));
+  SETUP_COLOR_COMBO(blue, desaturation, desaturation, 1.f - desaturation, _("blue primary inset"),
+                    _("blue primary rotation"));
 #undef SETUP_COLOR_COMBO
 
   slider = dt_bauhaus_slider_from_params(sect, "purity");
@@ -798,14 +845,9 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(slider, _("recover some of the original purity after the inset"));
 
   // display luminance section
-  dt_gui_new_collapsible_section
-    (&g->display_luminance_section,
-     "plugins/darkroom/sigmoid/expand_values",
-     _("display luminance"),
-     GTK_BOX(main_box),
-     DT_ACTION(self));
-  gtk_widget_set_tooltip_text(g->display_luminance_section.expander,
-                                _("set display black/white targets"));
+  dt_gui_new_collapsible_section(&g->display_luminance_section, "plugins/darkroom/sigmoid/expand_values",
+                                 _("display luminance"), GTK_BOX(main_box), DT_ACTION(self));
+  gtk_widget_set_tooltip_text(g->display_luminance_section.expander, _("set display black/white targets"));
 
   self->widget = GTK_WIDGET(g->display_luminance_section.container);
 


### PR DESCRIPTION
This PR introduces support for custom primaries to the _sigmoid_ module. This work is based on Troy Sobotka's AgX that was first introduced [here](https://blenderartists.org/t/feedback-development-filmic-baby-step-to-a-v2/1361663) (thanks a ton for all the interesting discussions during the past year or so @sobotka).

For reference, Blender is going to implement similar processing to replace the current default Filmic processing (which is quite different from darktable's filmic at its current shape). https://projects.blender.org/blender/blender/pulls/106355

@jandren also hinted at the possibility of introducing custom primaries [over a year ago](https://discuss.pixls.us/t/new-sigmoid-scene-to-display-mapping/22635/479#what-could-be-better-7). This can be considered a candidate implementation.

The flow is as follows:
1. Ensure the input tristimulus is within the working profile gamut footprint (this step already existed within _sigmoid_ process)
2. Change to custom primaries
3. Apply per-channel curves
4. Change back to working primaries

The idea is to affect the look given by the per-channel process by modifying the used primaries. An interface is provided where the user can specify the primaries with respect to the current working primaries:
![sigmoid_primaries](https://github.com/darktable-org/darktable/assets/5001906/ab48088e-6bcd-4523-bdd3-828896a306ae)
When all the sliders are at zero, the result is the same as mapping with the working primaries (as sigmoid currently does).

"Inset" is a scaling of the primaries in the CIE xy plane. When the primaries are scaled out, the input signal then appears "inset" in the new primaries, i.e. is less pure with respect to the primaries. This causes "cross talk" between the RGB channels. When this signal is fed to the per-channel mechanics, the result is favourable handling of bright, saturated lights. This is something that filmic and sigmoid often seem to struggle with, which can be especially seen with e.g. LED lights. Even more importantly, it gives a smooth desaturation in the high values, avoiding excess skewing towards obvious, saturated "rat-piss yellow".

Additionally, the primaries can be rotated. The per-channel mechanics, without any hue preservation applied afterwards, cause a skew toward the secondary colours (cyan, magenta, yellow) in the high values. Rotation of the primaries allow to control the _point of convergence_, i.e. _which_ yellow, magenta and cyan the high values converge to. The blue primary rotation is particularly important - a slight rotation from the Rec.2020 blue counteracts the Abney effect but also shifts the yellow convergence point to a more pleasant place. Rotating the red primary can give a favourable flight towards yellow that makes e.g. fire, sunset etc. look more natural.

Finally, there is a "purity" slider that allows (partially) restoring the inset at the output. If you set e.g. all the inset sliders to 15% and purity to 15%, conversion from working space to custom primaries and back is a perfect roundtrip. In some cases is useful not to restore all of the original purity, in order to avoid posterization.

There is a preset "smooth" (for the lack of a better word) introduced that gives (IMO) sensible values to the custom primaries when Rec.2020 is used as the working space. It is also a tiny bit less contrasty and less saturated look than the current sigmoid defaults. The preset is intended as a "set-and-forget" one (at least that's the way I'm using it), but it is neat to have the control available in the hidden section.

Some examples, comparing between the "smooth" preset and comparable settings (same contrast and skew, hue preservation disabled) with the new sliders at zero (except for purity at -10% to compensate for the slightly desaturated, opinionated look of the new preset).

Left is the new code with custom primaries set, right is the result of using the pipe working primaries (Rec.2020).

[Rec.709 sweep](https://github.com/sobotka/Testing_Imagery/blob/main/Sweep_sRGB_Linear_Half_Zip.exr)

| smooth preset | Rec.2020 primaries |
--- | ---
| ![Sweep_sRGB_Linear_Half_Zip](https://github.com/darktable-org/darktable/assets/5001906/aa424207-74e8-48ca-9d1a-8aed6713e76f) | ![Sweep_sRGB_Linear_Half_Zip_01](https://github.com/darktable-org/darktable/assets/5001906/176d9fbf-8e7c-4f30-85c6-d142d1ddbc5a) |

[A study in blue](https://discuss.pixls.us/t/a-study-in-blue/21706) (licensed under CC-BY-NC-SA 4.0 by Egocentrix)

| smooth preset | Rec.2020 primaries |
--- | ---
| ![RPN_Kick-In_20180830_3392_01](https://github.com/darktable-org/darktable/assets/5001906/c6a79add-beca-480c-8790-af3346e088d3) | ![RPN_Kick-In_20180830_3392_02](https://github.com/darktable-org/darktable/assets/5001906/1d047e57-52f5-451e-a429-38d89b0c508e) |

[Fire image](https://discuss.pixls.us/t/lets-learn-filmic-rgb-your-one-stop-shop-to-understanding-filmic-based-approach-to-edits/23843/22) (licensed under CC-BY-NC-SA by Bastian Bechtold)

| smooth preset | Rec.2020 primaries |
--- | ---
| ![DSCF6544](https://github.com/darktable-org/darktable/assets/5001906/8d511d35-b0b6-47e9-84b7-8b8e0f8f37fa) | ![DSCF6544_01](https://github.com/darktable-org/darktable/assets/5001906/d09d7b79-f02a-4e0b-b421-4571c628bbeb) |

[Sunset on ferry](https://discuss.pixls.us/t/playraw-sunset-on-ferry/4646) (by Andreas Weigl)

| smooth preset | Rec.2020 primaries |
--- | ---
| ![IMG_3129_07](https://github.com/darktable-org/darktable/assets/5001906/88d7bb67-735e-45fa-b847-a55762cf8e48) | ![IMG_3129_08](https://github.com/darktable-org/darktable/assets/5001906/8a02a6e5-1de8-4333-b6b8-d09c819d5951) |

[Sunflower image](https://discuss.pixls.us/t/comparing-filmic-color-science-v5-v6/31646) (licensed under CC-BY-NC-SA by Josema)

| smooth preset | Rec.2020 primaries |
--- | ---
| ![DSC09445](https://github.com/darktable-org/darktable/assets/5001906/e06f9831-4913-4644-9de3-640c4d0cd1a5) | ![DSC09445_01](https://github.com/darktable-org/darktable/assets/5001906/8e1de569-1d23-4e0b-a4a1-95d7dfac6972) |

As you can see, the effect is fairly subtle, but for some images it makes all the difference.

Hoping to get some folks to test and discuss this before this is considered for merging. Also, please let me know if you have better names for the new controls or preset in mind. I'm also happy to provide more examples of processed images in case you have troublesome ones at hand.

Requesting @jandren to kindly review this addition :)