### PR TITLE
Rework OpenCL code and preferences

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -322,18 +322,11 @@
     <longdescription>defines how preview and full pixelpipe tasks are scheduled on OpenCL enabled systems:\n - 'default': GPU processes full and CPU processes preview pipe (adaptable by config parameters),\n - 'multiple GPUs': process both pixelpipes in parallel on two different GPUs,\n - 'very fast GPU': process both pixelpipes sequentially on the GPU.</longdescription>
   </dtconfig>
   <dtconfig prefs="processing" section="cpugpu" capability="opencl">
-    <name>opencl_tuning_mode</name>
-    <type>
-      <enum>
-        <option>nothing</option>
-        <option>memory size</option>
-        <option>memory transfer</option>
-        <option>memory size and transfer</option>
-      </enum>
-    </type>
-    <default>nothing</default>
-    <shortdescription>tune OpenCL performance</shortdescription>
-    <longdescription>allows runtime tuning of OpenCL devices:\n - 'memory size': uses a fixed headroom (400MB as default),\n - 'memory transfer': tries a faster memory access mode (pinned memory) used for tiling.</longdescription>
+    <name>opencl_tune_headroom</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>use all device memory</shortdescription>
+    <longdescription>if enabled darktable will use all device memory except a safety margin (headroom, default is 600Mb)</longdescription>
   </dtconfig>
   <dtconfig>
     <name>opencl_library</name>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1560,13 +1560,14 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   return 0;
 }
 
+
 void dt_get_sysresource_level()
 {
   static int oldlevel = -999;
-  static int oldtunecl = -999;
+  static int oldtunehead = -999;
 
   dt_sys_resources_t *res = &darktable.dtresources;
-  const int tunecl = dt_opencl_get_tuning_mode();
+  const gboolean tunehead = dt_conf_get_bool("opencl_tune_headroom");
   int level = 1;
   const char *config = dt_conf_get_string_const("resourcelevel");
   /** These levels must correspond with preferences in xml.in
@@ -1587,10 +1588,10 @@ void dt_get_sysresource_level()
     else if(!strcmp(config, "mini"))         level = -2;
     else if(!strcmp(config, "notebook"))     level = -3;
   }
-  const gboolean mod = ((level != oldlevel) || (oldtunecl != tunecl));
+  const gboolean mod = ((level != oldlevel) || (oldtunehead != tunehead));
   res->level = oldlevel = level;
-  oldtunecl = tunecl;
-  res->tunemode = tunecl;
+  oldtunehead = tunehead;
+  res->tunehead = tunehead;
   if(mod && (darktable.unmuted & (DT_DEBUG_MEMORY | DT_DEBUG_OPENCL | DT_DEBUG_DEV)))
   {
     const int oldgrp = res->group;
@@ -1610,14 +1611,7 @@ void dt_get_sysresource_level()
     dt_print(DT_DEBUG_ALWAYS,
              "  singlebuff:      %luMB\n",
              dt_get_singlebuffer_mem() / 1024lu / 1024lu);
-#ifdef HAVE_OPENCL
-    dt_print(DT_DEBUG_ALWAYS,
-             "  OpenCL tune mem: %s\n",
-             ((tunecl & DT_OPENCL_TUNE_MEMSIZE) && (level >= 0)) ? "WANTED" : "OFF");
-    dt_print(DT_DEBUG_ALWAYS,
-             "  OpenCL pinned:   %s\n",
-             ((tunecl & DT_OPENCL_TUNE_PINNED) && (level >= 0)) ? "WANTED" : "OFF");
-#endif
+
     res->group = oldgrp;
   }
 }

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -315,7 +315,7 @@ typedef struct dt_sys_resources_t
   int *refresource; // for the debug resource modes we use fixed settings
   int group;
   int level;
-  int tunemode;
+  gboolean tunehead;
 } dt_sys_resources_t;
 
 typedef struct darktable_t

--- a/src/common/nvidia_gpus.h
+++ b/src/common/nvidia_gpus.h
@@ -256,11 +256,11 @@ static const char *nvidia_gpus[] = {
 };
 #endif
 
-int dt_nvidia_gpu_supports_sm_20(const char *model)
+gboolean dt_nvidia_gpu_supports_sm_20(const char *model)
 {
 #ifdef __APPLE__
   // on Mac OSX the OpenCL driver does not seem to support inline asm - even with recent NVIDIA GPUs
-  return 0;
+  return FALSE;
 #else
   int i = 0;
   while(nvidia_gpus[2 * i] != NULL)
@@ -268,12 +268,12 @@ int dt_nvidia_gpu_supports_sm_20(const char *model)
     if(!strcasecmp(model, nvidia_gpus[2 * i]))
     {
       if(nvidia_gpus[2 * i + 1][0] >= '2') return 1;
-      return 0;
+      return FALSE;
     }
     i++;
   }
   // if we don't know the device, it's probably too new and all good.
-  return 1;
+  return TRUE;
 #endif
 }
 // clang-format off

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2973,8 +2973,7 @@ void *dt_opencl_copy_host_to_device_constant(const int devid,
 
 void *dt_opencl_copy_host_to_device(const int devid,
                                     void *host,
-                                    const int
-                                    width,
+                                    const int width,
                                     const int height,
                                     const int bpp)
 {
@@ -3112,8 +3111,7 @@ void *dt_opencl_alloc_device(const int devid,
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
              "[opencl alloc_device] could not alloc img buffer on device %d: %s\n",
-             devid,
-             cl_errstr(err));
+             devid, cl_errstr(err));
 
   _check_clmem_err(devid, err);
   dt_opencl_memory_statistics(devid, dev, OPENCL_MEMORY_ADD);
@@ -3155,8 +3153,8 @@ void *dt_opencl_alloc_device_use_host_pointer(const int devid,
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
              "[opencl alloc_device_use_host_pointer]"
-             " could not alloc img buffer on device %d: %s\n", devid,
-             cl_errstr(err));
+             " could not allocate imgage on device %d: %s\n",
+             devid, cl_errstr(err));
 
   _check_clmem_err(devid, err);
   dt_opencl_memory_statistics(devid, dev, OPENCL_MEMORY_ADD);
@@ -3178,8 +3176,7 @@ void *dt_opencl_alloc_device_buffer(const int devid, const size_t size)
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
              "[opencl alloc_device_buffer] could not alloc buffer on device %d: %s\n",
-             devid,
-             cl_errstr(err));
+             devid, cl_errstr(err));
 
   _check_clmem_err(devid, err);
   dt_opencl_memory_statistics(devid, buf, OPENCL_MEMORY_ADD);
@@ -3201,9 +3198,8 @@ void *dt_opencl_alloc_device_buffer_with_flags(const int devid,
      flags, size, NULL, &err);
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl alloc_device_buffer] could not alloc buffer on device %d: %d\n",
-             devid,
-             err);
+             "[opencl alloc_device_buffer] could not allocate buffer on device %d: %s\n",
+             devid, cl_errstr(err));
 
   _check_clmem_err(devid, err);
   dt_opencl_memory_statistics(devid, buf, OPENCL_MEMORY_ADD);
@@ -3211,7 +3207,7 @@ void *dt_opencl_alloc_device_buffer_with_flags(const int devid,
   return buf;
 }
 
-size_t dt_opencl_get_mem_object_size(cl_mem mem)
+size_t dt_opencl_get_mem_object_size(const cl_mem mem)
 {
   size_t size;
   if(mem == NULL) return 0;
@@ -3222,7 +3218,7 @@ size_t dt_opencl_get_mem_object_size(cl_mem mem)
   return (err == CL_SUCCESS) ? size : 0;
 }
 
-int dt_opencl_get_mem_context_id(cl_mem mem)
+int dt_opencl_get_mem_context_id(const cl_mem mem)
 {
   cl_context context;
   if(mem == NULL) return -1;
@@ -3241,7 +3237,7 @@ int dt_opencl_get_mem_context_id(cl_mem mem)
   return -1;
 }
 
-int dt_opencl_get_image_width(cl_mem mem)
+int dt_opencl_get_image_width(const cl_mem mem)
 {
   size_t size;
   if(mem == NULL) return 0;
@@ -3253,7 +3249,7 @@ int dt_opencl_get_image_width(cl_mem mem)
   return (err == CL_SUCCESS) ? (int)size : 0;
 }
 
-int dt_opencl_get_image_height(cl_mem mem)
+int dt_opencl_get_image_height(const cl_mem mem)
 {
   size_t size;
   if(mem == NULL) return 0;
@@ -3265,7 +3261,7 @@ int dt_opencl_get_image_height(cl_mem mem)
   return (err == CL_SUCCESS) ? (int)size : 0;
 }
 
-int dt_opencl_get_image_element_size(cl_mem mem)
+int dt_opencl_get_image_element_size(const cl_mem mem)
 {
   size_t size;
   if(mem == NULL) return 0;
@@ -3302,7 +3298,7 @@ void dt_opencl_dump_pipe_pfm(const char* mod,
   }
 }
 
-void dt_opencl_memory_statistics(int devid, cl_mem mem, dt_opencl_memory_t action)
+void dt_opencl_memory_statistics(int devid, const cl_mem mem, const dt_opencl_memory_t action)
 {
   if(!((darktable.unmuted & DT_DEBUG_MEMORY) && (darktable.unmuted & DT_DEBUG_OPENCL)))
     return;

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -320,7 +320,7 @@ error:
 gboolean dt_opencl_avoid_atomics(const int devid)
 {
   dt_opencl_t *cl = darktable.opencl;
-  return (!_cldev_running(devid)) ? FALSE : (cl->dev[devid].avoid_atomics ? TRUE : FALSE);
+  return (!_cldev_running(devid)) ? FALSE : cl->dev[devid].avoid_atomics;
 }
 
 int dt_opencl_micro_nap(const int devid)
@@ -344,14 +344,14 @@ void dt_opencl_write_device_config(const int devid)
   gchar dat[512] = { 0 };
   g_snprintf(key, 254, "%s%s", DT_CLDEVICE_HEAD, cl->dev[devid].cname);
   g_snprintf(dat, 510, "%i %i %i %i %i %i %i %i 0.0 %.3f",
-    (cl->dev[devid].avoid_atomics) ? 1 : 0,
+    cl->dev[devid].avoid_atomics,
     cl->dev[devid].micro_nap,
     cl->dev[devid].pinned_memory & (DT_OPENCL_PINNING_ON | DT_OPENCL_PINNING_DISABLED),
     cl->dev[devid].clroundup_wd,
     cl->dev[devid].clroundup_ht,
     cl->dev[devid].event_handles,
-    (cl->dev[devid].asyncmode) ? 1 : 0,
-    (cl->dev[devid].disabled) ? 1 : 0,
+    cl->dev[devid].asyncmode,
+    cl->dev[devid].disabled,
     cl->dev[devid].advantage);
   dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
            "[dt_opencl_write_device_config] writing data '%s' for '%s'\n", dat, key);
@@ -417,7 +417,6 @@ gboolean dt_opencl_read_device_config(const int devid)
   }
   // do some safety housekeeping
 
-  cldid->avoid_atomics = cldid->avoid_atomics ? TRUE : FALSE;
   cldid->pinned_memory &= (DT_OPENCL_PINNING_ON | DT_OPENCL_PINNING_DISABLED);
   if((cldid->micro_nap < 0) || (cldid->micro_nap > 1000000))
     cldid->micro_nap = 250;
@@ -431,6 +430,7 @@ gboolean dt_opencl_read_device_config(const int devid)
   cldid->use_events = cldid->event_handles ? TRUE : FALSE;
   cldid->asyncmode =  cldid->asyncmode ? TRUE : FALSE;
   cldid->disabled = cldid->disabled ? TRUE : FALSE;
+  cldid->avoid_atomics = cldid->avoid_atomics ? TRUE : FALSE;
 
   cldid->advantage = fmaxf(0.0f, cldid->advantage);
 
@@ -476,7 +476,7 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
   cl->dev[dev].totallost = 0;
   cl->dev[dev].summary = CL_COMPLETE;
   cl->dev[dev].used_global_mem = 0;
-  cl->dev[dev].nvidia_sm_20 = 0;
+  cl->dev[dev].nvidia_sm_20 = FALSE;
   cl->dev[dev].vendor = NULL;
   cl->dev[dev].fullname = NULL;
   cl->dev[dev].cname = NULL;
@@ -485,7 +485,7 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
   cl->dev[dev].peak_memory = 0;
   cl->dev[dev].used_available = 0;
   // setting sane/conservative defaults at first
-  cl->dev[dev].avoid_atomics = 0;
+  cl->dev[dev].avoid_atomics = FALSE;
   cl->dev[dev].micro_nap = 250;
   cl->dev[dev].pinned_memory = DT_OPENCL_PINNING_OFF;
   cl->dev[dev].clroundup_wd = 16;

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -833,18 +833,15 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
                "   ASYNC PIXELPIPE:          %s\n", cl->dev[dev].asyncmode ? "YES" : "NO");
   dt_print_nts(DT_DEBUG_OPENCL,
                "   PINNED MEMORY TRANSFER:   %s\n", cl->dev[dev].pinned_memory ? "YES" : "NO");
-  dt_print_nts(DT_DEBUG_OPENCL,
-               "   HEADROOM:                 %s\n", resrc->tunehead ? "USED" : "NO");
-  dt_print_nts(DT_DEBUG_OPENCL,
-               "   HEADROOM:                 %iMb\n", cl->dev[dev].headroom);
+  if(resrc->tunehead)
+    dt_print_nts(DT_DEBUG_OPENCL,
+               "   USE HEADROOM:             %iMb\n", cl->dev[dev].headroom);
   dt_print_nts(DT_DEBUG_OPENCL,
                "   AVOID ATOMICS:            %s\n", cl->dev[dev].avoid_atomics ? "YES" : "NO");
   dt_print_nts(DT_DEBUG_OPENCL,
                "   MICRO NAP:                %i\n", cl->dev[dev].micro_nap);
   dt_print_nts(DT_DEBUG_OPENCL,
-               "   ROUNDUP WIDTH:            %i\n", cl->dev[dev].clroundup_wd);
-  dt_print_nts(DT_DEBUG_OPENCL,
-               "   ROUNDUP HEIGHT:           %i\n", cl->dev[dev].clroundup_ht);
+               "   ROUNDUP WIDTH & HEIGHT    %ix%i\n", cl->dev[dev].clroundup_wd, cl->dev[dev].clroundup_ht);
   dt_print_nts(DT_DEBUG_OPENCL,
                "   CHECK EVENT HANDLES:      %i\n", cl->dev[dev].event_handles);
   dt_print_nts(DT_DEBUG_OPENCL,
@@ -1169,6 +1166,7 @@ void dt_opencl_init(
   cl->dlocl = dt_dlopencl_init(library);
   if(cl->dlocl == NULL)
   {
+    logerror = "no working opencl library found";
     dt_print_nts(DT_DEBUG_OPENCL,
                  "[opencl_init] no working opencl library found."
                  " Continue with opencl disabled\n");
@@ -1314,6 +1312,7 @@ void dt_opencl_init(
   {
     if(devices)
       free(devices);
+    logerror = "no OpenCL devices found";
     goto finally;
   }
 
@@ -1356,6 +1355,7 @@ void dt_opencl_init(
   }
   else
   {
+    logerror = "no suitable OpenCL devices found";
     dt_print_nts(DT_DEBUG_OPENCL, "[opencl_init] no suitable devices found.\n");
   }
 

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -140,7 +140,7 @@ typedef struct dt_opencl_device_t
   int totalsuccess;
   int totallost;
   int maxeventslot;
-  int nvidia_sm_20;
+  gboolean nvidia_sm_20;
   const char *vendor;
   const char *fullname;
   const char *cname;
@@ -157,7 +157,7 @@ typedef struct dt_opencl_device_t
   // pixelpipe processing will be done on CPU for the affected modules.
   // useful (only for very old devices) if your OpenCL implementation freezes/crashes on atomics or if
   // they are processed with a bad performance.
-  int avoid_atomics;
+  gboolean avoid_atomics;
 
   // pause OpenCL processing for this number of microseconds from time to time
   int micro_nap;
@@ -296,9 +296,10 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboole
 void dt_opencl_cleanup(dt_opencl_t *cl);
 
 const char *cl_errstr(cl_int error);
+
 /** both finish functions return TRUE in case of success */
 /** cleans up command queue. */
-int dt_opencl_finish(const int devid);
+gboolean dt_opencl_finish(const int devid);
 
 /** cleans up command queue if in synchron mode or while exporting, returns TRUE in case of success */
 gboolean dt_opencl_finish_sync_pipe(const int devid, const int pipetype);

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -104,12 +104,6 @@ typedef enum dt_opencl_tunemode_t
   DT_OPENCL_TUNE_PINNED  = 2
 } dt_opencl_tunemode_t;
 
-typedef enum dt_opencl_pinmode_t
-{
-  DT_OPENCL_PINNING_OFF = 0,
-  DT_OPENCL_PINNING_ON = 1,
-  DT_OPENCL_PINNING_DISABLED = 2
-} dt_opencl_pinmode_t;
 
 /**
  * to support multi-gpu and mixed systems with cpu support,
@@ -151,8 +145,6 @@ typedef struct dt_opencl_device_t
   size_t used_available;
   // flags what tuning modes should be used
   dt_opencl_tunemode_t tuneactive; 
-  // flags detected errors
-  dt_opencl_tunemode_t runtime_error;
   // if set to TRUE darktable will not use OpenCL kernels which contain atomic operations (example bilateral).
   // pixelpipe processing will be done on CPU for the affected modules.
   // useful (only for very old devices) if your OpenCL implementation freezes/crashes on atomics or if
@@ -167,13 +159,13 @@ typedef struct dt_opencl_device_t
   // this can often be avoided by using indirect transfers via pinned memory,
   // other devices have more efficient direct memory transfer implementations.
   // We can't predict on solid grounds if a device belongs to the first or second group,
-  // also pinned mem transfer requires slightly more video ram plus system memory. 
-  // this holds a bitmask defined by dt_opencl_pinmode_t
-  // the device specific conf key might hold
-  // 0 -> disabled by default; might be switched on by tune for performance
-  // 1 -> enabled by default
-  // 2 -> disabled under all circumstances. This could/should be used if we give away / ship specific keys for buggy systems 
-  dt_opencl_pinmode_t pinned_memory;
+  // also pinned mem transfer requires slightly more video ram plus system memory.
+  // If TRUE in the device-specific conf pinned transfer is enabled
+  gboolean pinned_memory;
+
+  // flags reporting cl runtime error conditions
+  gboolean pinned_error;
+  gboolean clmem_error;
 
   // in OpenCL processing round width/height of global work groups to a multiple of these values.
   // reasonable values are powers of 2. this parameter can have high impact on OpenCL performance.

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -146,8 +146,6 @@ typedef struct dt_opencl_device_t
   const char *cname;
   const char *options;
   cl_int summary;
-  // the benchmark value must not be changed by the user
-  float benchmark;
   size_t memory_in_use;
   size_t peak_memory;
   size_t used_available;
@@ -200,11 +198,9 @@ typedef struct dt_opencl_device_t
   // also used for blacklisted drivers
   gboolean disabled;
 
-  // Some devices are known to be unused by other apps so there is no need to test for available memory at all.
+  // Some devices are known to be unused by other apps so they can use all memory.
   int forced_headroom;
 
-  // As the benchmarks are not good enough to calculate tiled-gpu vs untiled-cpu we have a parameter exposed
-  // in the cldevice conf key to balance this
   float advantage;  
 } dt_opencl_device_t;
 
@@ -240,8 +236,6 @@ typedef struct dt_opencl_t
   dt_opencl_device_t *dev;
   dt_dlopencl_t *dlocl;
 
-  // we want the cpu benchmark to be available
-  float cpubenchmark;
   // global kernels for blending operations.
   struct dt_blendop_cl_global_t *blendop;
 

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -87,7 +87,7 @@ static inline int _align_close(int n, int a)
   return n + shift;
 }
 
-/* 
+/*
   _maximum_number_tiles is the assumed maximum sane number of tiles
   if during tiling this number is exceeded darktable assumes that tiling is not possible and falls back
   to untiled processing - with all system memory limits taking full effect.
@@ -1684,13 +1684,13 @@ error:
   dt_opencl_release_mem_object(input);
   dt_opencl_release_mem_object(output);
   piece->pipe->tiling = FALSE;
-  const gboolean pinning_error = (use_pinned_memory == FALSE) && dt_opencl_use_pinned_memory(devid);
+  const gboolean pinning_error = !use_pinned_memory && dt_opencl_use_pinned_memory(devid);
   dt_print(DT_DEBUG_TILING | DT_DEBUG_OPENCL,
            "[default_process_tiling_opencl_ptp] [%s] couldn't run process_cl() for "
            "module '%s%s' in tiling mode:%s %s\n",
            dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self),
            (pinning_error) ? " pinning problem" : "", cl_errstr(err));
-  if(pinning_error) darktable.opencl->dev[devid].runtime_error |= DT_OPENCL_TUNE_PINNED;
+  if(pinning_error) darktable.opencl->dev[devid].pinned_error = TRUE;
   return FALSE;
 }
 
@@ -2154,7 +2154,7 @@ error:
            dt_dev_pixelpipe_type_to_str(piece->pipe->type),
            self->op, dt_iop_get_instance_id(self),
            (pinning_error) ? " pinning problem" : "", cl_errstr(err));
-  if(pinning_error) darktable.opencl->dev[devid].runtime_error |= DT_OPENCL_TUNE_PINNED;
+  if(pinning_error) darktable.opencl->dev[devid].pinned_error = TRUE;
   return FALSE;
 }
 


### PR DESCRIPTION
Code maintenance, cleanup and simplifications for less user problems.

1. The benchmarking for cpu and gpu path didn't work in any reliable way for some years now. As that part was only relevant to switch between "default" and "fast gpu" mode it seemed irrelevant and the code has been removed. New installs default to "default" now.
2. The selection of tuning modes lead to many user reports / issues with clearly wrong understanding. As the pinned mode is a) only relevant for few devices b) requires careful testing c) added code complexity and is d) clearly specific for a device the selection of "transfer tune" has been removed. Can of course be defined in the device conf entry.
3. The "tune for headroom" is a bool in preferences now
4. Improved log
5. Some code maintenance with added const and err->message usage.