### PR TITLE
New module: primaries

### DIFF
--- a/data/kernels/extended.cl
+++ b/data/kernels/extended.cl
@@ -1124,3 +1124,17 @@ colorchecker (read_only image2d_t in, write_only image2d_t out, const int width,
 
   write_imagef (out, (int2)(x, y), opixel);
 }
+
+kernel void
+primaries(read_only image2d_t in, write_only image2d_t out,
+          const int width, const int height,
+          constant const float *const matrix)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  if(x >= width || y >= height) return;
+
+  const float4 ipixel = read_imagef(in, sampleri, (int2)(x, y));
+  const float4 opixel = matrix_product_float4(ipixel, matrix);
+  write_imagef(out, (int2)(x, y), opixel);
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ FILE(GLOB SOURCE_FILES
   "common/colorlabels.c"
   "common/colorspaces.c"
   "common/curve_tools.c"
+  "common/custom_primaries.c"
   "common/splines.cpp"
   "common/curl_tools.c"
   "common/darktable.c"

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -16,10 +16,12 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "common/colorspaces_inline_conversions.h"
 #include "common/colorspaces.h"
 #include "common/colormatrices.c"
 #include "common/darktable.h"
 #include "common/debug.h"
+#include "common/dttypes.h"
 #include "common/file_location.h"
 #include "common/math.h"
 #include "common/matrices.h"
@@ -29,6 +31,7 @@
 #include "control/control.h"
 #include "develop/imageop.h"
 
+#include <lcms2.h>
 #include <strings.h>
 
 #ifdef USE_COLORDGTK
@@ -2548,6 +2551,32 @@ void dt_colorspaces_rgb_to_cygm(float *out,
   }
 }
 
+void cmsCIEXYZ_to_xy(const cmsCIEXYZ *const cmsXYZ, float xy[2])
+{
+  dt_aligned_pixel_t XYZ = { cmsXYZ->X, cmsXYZ->Y, cmsXYZ->Z, 0.f };
+  dt_aligned_pixel_t xyY;
+  dt_XYZ_to_xyY(XYZ, xyY);
+  xy[0] = xyY[0];
+  xy[1] = xyY[1];
+}
+
+gboolean dt_colorspaces_get_primaries_and_whitepoint_from_profile(cmsHPROFILE prof, float primaries[3][2],
+                                                                  float whitepoint[2])
+{
+  cmsCIEXYZ *red_color = cmsReadTag(prof, cmsSigRedColorantTag);
+  cmsCIEXYZ *green_color = cmsReadTag(prof, cmsSigGreenColorantTag);
+  cmsCIEXYZ *blue_color = cmsReadTag(prof, cmsSigBlueColorantTag);
+  cmsCIEXYZ *white_color = cmsReadTag(prof, cmsSigMediaWhitePointTag);
+
+  if(!red_color || !green_color || !blue_color || !white_color) return FALSE;
+
+  cmsCIEXYZ_to_xy(red_color, primaries[0]);
+  cmsCIEXYZ_to_xy(green_color, primaries[1]);
+  cmsCIEXYZ_to_xy(blue_color, primaries[2]);
+  cmsCIEXYZ_to_xy(white_color, whitepoint);
+
+  return TRUE;
+}
 
 void dt_make_transposed_matrices_from_primaries_and_whitepoint(const float primaries[3][2],
                                                                const float whitepoint[2],

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -406,6 +406,11 @@ void dt_colorspaces_rgb_to_cygm(float *out,
                                 const int num,
                                 const double RGB_to_CAM[4][3]);
 
+/** Calculate RGB <-> XYZ matrices from the given primaries and whitepoint */
+void dt_make_transposed_matrices_from_primaries_and_whitepoint(const float primaries[3][2],
+                                                               const float whitepoint[2],
+                                                               dt_colormatrix_t RGB_to_XYZ_transposed);
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -406,6 +406,9 @@ void dt_colorspaces_rgb_to_cygm(float *out,
                                 const int num,
                                 const double RGB_to_CAM[4][3]);
 
+gboolean dt_colorspaces_get_primaries_and_whitepoint_from_profile(cmsHPROFILE prof, float primaries[3][2],
+                                                                  float whitepoint[2]);
+
 /** Calculate RGB <-> XYZ matrices from the given primaries and whitepoint */
 void dt_make_transposed_matrices_from_primaries_and_whitepoint(const float primaries[3][2],
                                                                const float whitepoint[2],

--- a/src/common/custom_primaries.c
+++ b/src/common/custom_primaries.c
@@ -1,0 +1,77 @@
+/*
+ *    This file is part of darktable,
+ *    Copyright (C) 2023 darktable developers.
+ *
+ *    darktable is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    darktable is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/custom_primaries.h"
+#include <float.h>
+
+
+static inline float _determinant(const float a, const float b, const float c, const float d)
+{
+  return a * d - b * c;
+}
+
+static inline float _intersect_line_segments(const float x1, const float y1, const float x2, const float y2,
+                                             const float x3, const float y3, const float x4, const float y4)
+{
+  const float denominator = _determinant(x1 - x2, x3 - x4, y1 - y2, y3 - y4);
+  if(denominator == 0.f) return FLT_MAX; // lines don't intersect
+
+  const float t = _determinant(x1 - x3, x3 - x4, y1 - y3, y3 - y4) / denominator;
+  if(t >= 0.f) return t;
+  return FLT_MAX; // intersection is in the wrong direction
+}
+
+static inline float _find_distance_to_edge(const dt_iop_order_iccprofile_info_t *const profile,
+                                           const float cos_angle, const float sin_angle)
+{
+  const float x1 = profile->whitepoint[0];
+  const float y1 = profile->whitepoint[1];
+  const float x2 = x1 + cos_angle;
+  const float y2 = y1 + sin_angle;
+
+  float distance_to_edge = FLT_MAX;
+  for(size_t i = 0; i < 3; i++)
+  {
+    const size_t next_i = i == 2 ? 0 : i + 1;
+    const float x3 = profile->primaries[i][0];
+    const float y3 = profile->primaries[i][1];
+    const float x4 = profile->primaries[next_i][0];
+    const float y4 = profile->primaries[next_i][1];
+    const float distance = _intersect_line_segments(x1, y1, x2, y2, x3, y3, x4, y4);
+    if(distance < distance_to_edge) distance_to_edge = distance;
+  }
+
+  return distance_to_edge;
+}
+
+void dt_rotate_and_scale_primary(const dt_iop_order_iccprofile_info_t *const profile, const float scaling,
+                                 const float rotation, size_t primary_index, float new_xy[2])
+{
+  // Generate a custom set of tone mapping primaries by scaling
+  // and rotating the primaries of the given profile.
+  const float dx = profile->primaries[primary_index][0] - profile->whitepoint[0];
+  const float dy = profile->primaries[primary_index][1] - profile->whitepoint[1];
+  const float angle = atan2f(dy, dx) + rotation;
+  const float cos_angle = cosf(angle);
+  const float sin_angle = sinf(angle);
+  const float distance_to_edge = _find_distance_to_edge(profile, cos_angle, sin_angle);
+  const float dx_new = scaling * distance_to_edge * cos_angle;
+  const float dy_new = scaling * distance_to_edge * sin_angle;
+  new_xy[0] = dx_new + profile->whitepoint[0];
+  new_xy[1] = dy_new + profile->whitepoint[1];
+}

--- a/src/common/custom_primaries.h
+++ b/src/common/custom_primaries.h
@@ -1,0 +1,29 @@
+/*
+ *    This file is part of darktable,
+ *    Copyright (C) 2023 darktable developers.
+ *
+ *    darktable is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    darktable is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/iop_profile.h"
+#include "dttypes.h"
+
+// Make a set of custom primaries starting from the primaries of the given profile.
+// Rotate the chromaticity angles about the white point,
+// along the profile gamut footprint boundary by the given amounts.
+// Then scale them by the given amounts.
+void dt_rotate_and_scale_primary(const dt_iop_order_iccprofile_info_t *const profile, const float scaling,
+                                 const float rotation, size_t primary_index, float new_xy[2]);

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -116,6 +116,7 @@ const dt_iop_order_entry_t legacy_order[] = {
   { {27.5f }, "negadoctor", 0},
   { {27.5f }, "blurs", 0},
   { {27.5f }, "basicadj", 0},
+  { {27.5f }, "primaries", 0},
   { {28.0f }, "colorreconstruct", 0},
   { {29.0f }, "colorchecker", 0},
   { {30.0f }, "defringe", 0},
@@ -214,6 +215,7 @@ const dt_iop_order_entry_t v30_order[] = {
                                      // after scanner input color
                                      // profile
   { {28.5f }, "blurs", 0},           // physically-accurate blurs (motion and lens)
+  { {28.5f }, "primaries", 0},
   { {29.0f }, "nlmeans", 0},         // signal processing (denoising)
                                      //    -> needs a signal as scene-referred as possible (even if it works in Lab)
   { {30.0f }, "colorchecker", 0},    // calibration to "neutral" exchange colour space
@@ -324,6 +326,7 @@ const dt_iop_order_entry_t v30_jpg_order[] = {
   { { 28.5f }, "censorize", 0 },
   { { 28.5f }, "negadoctor", 0 },   // Cineon film encoding comes after scanner input color profile
   { { 28.5f }, "blurs", 0 },        // physically-accurate blurs (motion and lens)
+  { { 28.5f }, "primaries", 0},
   { { 29.0f }, "nlmeans", 0 },      // signal processing (denoising)
                                     //    -> needs a signal as scene-referred as possible (even if it works in Lab)
   { { 30.0f }, "colorchecker", 0 }, // calibration to "neutral" exchange colour space
@@ -907,6 +910,7 @@ GList *dt_ioppr_get_iop_order_list(const dt_imgid_t imgid,
           _insert_before(iop_order_list, "nlmeans", "negadoctor");
           _insert_before(iop_order_list, "negadoctor", "channelmixerrgb");
           _insert_before(iop_order_list, "negadoctor", "censorize");
+          _insert_before(iop_order_list, "negadoctor", "primaries");
           _insert_before(iop_order_list, "rgbcurve", "colorbalancergb");
           _insert_before(iop_order_list, "ashift", "cacorrectrgb");
           _insert_before(iop_order_list, "graduatednd", "crop");

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -790,6 +790,8 @@ static gboolean _ioppr_generate_profile_info(dt_iop_order_iccprofile_info_t *pro
     {
       transpose_3xSSE(profile_info->matrix_in, profile_info->matrix_in_transposed);
       transpose_3xSSE(profile_info->matrix_out, profile_info->matrix_out_transposed);
+      dt_colorspaces_get_primaries_and_whitepoint_from_profile(rgb_profile, profile_info->primaries,
+                                                               profile_info->whitepoint);
     }
     else
     {

--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -22,6 +22,7 @@
 #include "common/colorspaces_inline_conversions.h"
 #include "common/colorspaces.h"
 #include "common/file_location.h"
+#include "common/dttypes.h"
 #include "develop/imageop.h"
 
 #ifdef HAVE_CONFIG_H
@@ -53,6 +54,8 @@ typedef struct dt_iop_order_iccprofile_info_t
   float grey;
   dt_colormatrix_t matrix_in_transposed;  // same as matrix_in, but stored such as to permit vectorization
   dt_colormatrix_t matrix_out_transposed; // same as matrix_out, but stored such as to permit vectorization
+  float primaries[3][2];
+  float whitepoint[2];
 } dt_iop_order_iccprofile_info_t;
 
 /** must be called before using profile_info, default lutsize = 0 */

--- a/src/iop/CMakeLists.txt
+++ b/src/iop/CMakeLists.txt
@@ -150,6 +150,7 @@ add_iop(cacorrectrgb "cacorrectrgb.c")
 add_iop(diffuse "diffuse.c")
 add_iop(blurs "blurs.c")
 add_iop(sigmoid "sigmoid.c")
+add_iop(primaries "primaries.c")
 
 if(Rsvg2_FOUND)
   add_iop(watermark "watermark.c")

--- a/src/iop/primaries.c
+++ b/src/iop/primaries.c
@@ -153,16 +153,13 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   if(dev_matrix == NULL)
   {
     dt_print(DT_DEBUG_OPENCL, "[opencl_primaries] couldn't allocate memory!\n");
-    return FALSE;
+    return DT_OPENCL_DEFAULT_ERROR;
   }
 
   cl_int err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_primaries, width, height, CLARG(dev_in),
                                                 CLARG(dev_out), CLARG(width), CLARG(height), CLARG(dev_matrix));
-  if(err != CL_SUCCESS)
-    dt_print(DT_DEBUG_OPENCL, "[opencl_primaries] couldn't enqueue kernel! %s\n", cl_errstr(err));
-
   dt_opencl_release_mem_object(dev_matrix);
-  return err == CL_SUCCESS;
+  return err;
 }
 #endif
 

--- a/src/iop/primaries.c
+++ b/src/iop/primaries.c
@@ -1,0 +1,385 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2023 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "bauhaus/bauhaus.h"
+#include "common/custom_primaries.h"
+#include "develop/imageop.h"
+#include "develop/imageop_gui.h"
+#include "gui/color_picker_proxy.h"
+#include "gui/gtk.h"
+#include "iop/iop_api.h"
+
+#include <gtk/gtk.h>
+#include <stdlib.h>
+
+// Linear (matrix) transformation of the RGB data based on user-defined
+// rotations and scalings of the working space primaries.
+// The process is linear (basic channel mixing) but the parametrization
+// used here is potentially useful.
+//
+// Allows tinting of the achromatic axis as well,
+// thanks to idea from Troy Sobotka at:
+// https://github.com/sobotka/SB2383-Configuration-Generation
+
+DT_MODULE_INTROSPECTION(1, dt_iop_primaries_params_t)
+
+static const float RAD_TO_DEG = 180.f / DT_M_PI_F;
+
+typedef struct dt_iop_primaries_params_t
+{
+  float achromatic_tint_hue;    // $MIN: -3.14 $MAX: 3.14 $DEFAULT: 0.0 $DESCRIPTION: "tint hue"
+  float achromatic_tint_purity; // $MIN: 0.0 $MAX: 0.99 $DEFAULT: 0.0 $DESCRIPTION: "tint purity"
+  float red_hue;                // $MIN: -3.14 $MAX: 3.14 $DEFAULT: 0.0 $DESCRIPTION: "red hue"
+  float red_purity;             // $MIN: 0.01 $MAX: 5.0 $DEFAULT: 1.0 $DESCRIPTION: "red purity"
+  float green_hue;              // $MIN: -3.14 $MAX: 3.14 $DEFAULT: 0.0 $DESCRIPTION: "green hue"
+  float green_purity;           // $MIN: 0.01 $MAX: 5.0 $DEFAULT: 1.0 $DESCRIPTION: "green purity"
+  float blue_hue;               // $MIN: -3.14 $MAX: 3.14 $DEFAULT: 0.0 $DESCRIPTION: "blue hue"
+  float blue_purity;            // $MIN: 0.01 $MAX: 5.0 $DEFAULT: 1.0 $DESCRIPTION: "blue purity"
+} dt_iop_primaries_params_t;
+
+typedef struct dt_iop_primaries_gui_data_t
+{
+  GtkWidget *achromatic_tint_hue, *achromatic_tint_purity, *red_hue, *red_purity, *green_hue, *green_purity,
+      *blue_hue, *blue_purity;
+  const dt_iop_order_iccprofile_info_t *painted_work_profile, *painted_display_profile;
+} dt_iop_primaries_gui_data_t;
+
+typedef struct dt_iop_primaries_global_data_t
+{
+  int kernel_primaries;
+} dt_iop_primaries_global_data_t;
+
+const char *name()
+{
+  return _("rgb primaries");
+}
+
+int flags()
+{
+  return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING;
+}
+
+int default_group()
+{
+  return IOP_GROUP_COLOR | IOP_GROUP_GRADING;
+}
+
+dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe,
+                                            dt_dev_pixelpipe_iop_t *piece)
+{
+  return IOP_CS_RGB;
+}
+
+static void _calculate_adjustment_matrix(const dt_iop_primaries_params_t *const params,
+                                         const dt_iop_order_iccprofile_info_t *const pipe_work_profile,
+                                         dt_colormatrix_t matrix)
+{
+  float custom_primaries[3][2];
+  const float scaling[3] = { params->red_purity, params->green_purity, params->blue_purity };
+  const float rotation[3] = { params->red_hue, params->green_hue, params->blue_hue };
+  for(size_t i = 0; i < 3; i++)
+    dt_rotate_and_scale_primary(pipe_work_profile, scaling[i], rotation[i], i, custom_primaries[i]);
+
+  float whitepoint[2];
+  dt_rotate_and_scale_primary(pipe_work_profile, params->achromatic_tint_purity, params->achromatic_tint_hue, 0,
+                              whitepoint);
+
+  dt_colormatrix_t RGB_TO_XYZ;
+  dt_make_transposed_matrices_from_primaries_and_whitepoint(custom_primaries, whitepoint, RGB_TO_XYZ);
+  dt_colormatrix_mul(matrix, RGB_TO_XYZ, pipe_work_profile->matrix_out_transposed);
+}
+
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+  dt_iop_primaries_params_t *params = (dt_iop_primaries_params_t *)piece->data;
+
+  if(!dt_iop_have_required_input_format(4 /*we need full-color pixels*/, self, piece->colors, ivoid, ovoid, roi_in,
+                                        roi_out))
+    return;
+
+  const dt_iop_order_iccprofile_info_t *pipe_work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
+  dt_colormatrix_t matrix;
+  _calculate_adjustment_matrix(params, pipe_work_profile, matrix);
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) schedule(static) shared(matrix) dt_omp_firstprivate(ivoid, ovoid, roi_out)
+#endif
+  for(size_t k = 0; k < 4 * roi_out->width * roi_out->height; k += 4)
+  {
+    const float *const restrict in = ((const float *)ivoid) + k;
+    float *const restrict out = ((float *)ovoid) + k;
+
+    dt_apply_transposed_color_matrix(in, matrix, out);
+    out[3] = in[3];
+  }
+}
+
+#ifdef HAVE_OPENCL
+int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+  dt_iop_primaries_params_t *params = (dt_iop_primaries_params_t *)piece->data;
+  dt_iop_primaries_global_data_t *gd = (dt_iop_primaries_global_data_t *)self->global_data;
+
+  const int devid = piece->pipe->devid;
+  const int width = roi_in->width;
+  const int height = roi_in->height;
+
+  const dt_iop_order_iccprofile_info_t *pipe_work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
+  dt_colormatrix_t transposed_matrix, matrix;
+  _calculate_adjustment_matrix(params, pipe_work_profile, transposed_matrix);
+  transpose_3xSSE(transposed_matrix, matrix);
+
+  cl_mem dev_matrix = dt_opencl_copy_host_to_device_constant(devid, sizeof(matrix), matrix);
+  if(dev_matrix == NULL)
+  {
+    dt_print(DT_DEBUG_OPENCL, "[opencl_primaries] couldn't allocate memory!\n");
+    return FALSE;
+  }
+
+  cl_int err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_primaries, width, height, CLARG(dev_in),
+                                                CLARG(dev_out), CLARG(width), CLARG(height), CLARG(dev_matrix));
+  if(err != CL_SUCCESS)
+    dt_print(DT_DEBUG_OPENCL, "[opencl_primaries] couldn't enqueue kernel! %s\n", cl_errstr(err));
+
+  dt_opencl_release_mem_object(dev_matrix);
+  return err == CL_SUCCESS;
+}
+#endif
+
+static void _rotated_primary_to_display_RGB(const dt_iop_order_iccprofile_info_t *work_profile,
+                                            const dt_iop_order_iccprofile_info_t *display_profile,
+                                            const dt_iop_order_iccprofile_info_t *sRGB_profile,
+                                            const size_t primary_index, const float angle, const float desaturate,
+                                            dt_aligned_pixel_t display_RGB)
+{
+  dt_aligned_pixel_t xyY = { 0.f }, XYZ, RGB;
+  dt_rotate_and_scale_primary(work_profile, 1.f, angle, primary_index, xyY);
+  // Luminance doesn't matter - it will change in the normalization in the end of the function.
+  xyY[2] = 1.f;
+  dt_xyY_to_XYZ(xyY, XYZ);
+  dt_apply_transposed_color_matrix(XYZ, sRGB_profile->matrix_out_transposed, RGB);
+
+  // Bring the value to the sRGB hull and desaturate a bit.
+  // This is done in sRGB to avoid eyesore for those with wide-gamut displays.
+  const float min_value = MIN(MIN(RGB[0], RGB[1]), RGB[2]);
+  const float offset = -MIN(min_value, 0.f) + desaturate;
+  for_each_channel(c) RGB[c] += offset;
+
+  // To display RGB. Bring to the hull and normalize to 1.
+  dt_apply_transposed_color_matrix(RGB, sRGB_profile->matrix_in_transposed, XYZ);
+  dt_apply_transposed_color_matrix(XYZ, display_profile->matrix_out_transposed, RGB);
+  const float display_min_value = MIN(MIN(RGB[0], RGB[1]), RGB[2]);
+  const float display_offset = -MIN(display_min_value, 0.f);
+  const float display_max_value = MAX(MAX(RGB[0], RGB[1]), RGB[2]) + display_offset;
+  const float scale = 1.f / display_max_value;
+  for_each_channel(c) display_RGB[c] = scale * (RGB[c] + display_offset);
+}
+
+static void _apply_trc_if_nonlinear(const dt_iop_order_iccprofile_info_t *display_profile,
+                                    const dt_aligned_pixel_t linear_RGB, dt_aligned_pixel_t RGB)
+{
+  // Apply tone response curve if any
+  if(display_profile->nonlinearlut)
+    dt_ioppr_apply_trc(linear_RGB, RGB, display_profile->lut_out, display_profile->unbounded_coeffs_out,
+                       display_profile->lutsize);
+  else
+    copy_pixel(RGB, linear_RGB);
+}
+
+static void _paint_hue_slider(const dt_iop_order_iccprofile_info_t *work_profile,
+                              const dt_iop_order_iccprofile_info_t *display_profile,
+                              const dt_iop_order_iccprofile_info_t *sRGB_profile, const size_t primary_index,
+                              GtkWidget *slider)
+{
+  const float hard_min = dt_bauhaus_slider_get_hard_min(slider);
+  const float hard_max = dt_bauhaus_slider_get_hard_max(slider);
+  const float range = hard_max - hard_min;
+  for(int i = 0; i < DT_BAUHAUS_SLIDER_MAX_STOPS; i++)
+  {
+    const float stop = (float)i / (float)(DT_BAUHAUS_SLIDER_MAX_STOPS - 1);
+    const float angle = hard_min + stop * range;
+    dt_aligned_pixel_t linear_RGB, RGB;
+    _rotated_primary_to_display_RGB(work_profile, display_profile, sRGB_profile, primary_index, angle, 0.4f,
+                                    linear_RGB);
+    _apply_trc_if_nonlinear(display_profile, linear_RGB, RGB);
+    dt_bauhaus_slider_set_stop(slider, stop, RGB[0], RGB[1], RGB[2]);
+  }
+  gtk_widget_queue_draw(GTK_WIDGET(slider));
+}
+
+static void _paint_purity_slider(const dt_iop_order_iccprofile_info_t *work_profile,
+                                 const dt_iop_order_iccprofile_info_t *display_profile,
+                                 const dt_iop_order_iccprofile_info_t *sRGB_profile, const size_t primary_index,
+                                 GtkWidget *hue_slider, GtkWidget *purity_slider)
+{
+  const float angle = dt_bauhaus_slider_get(hue_slider);
+  dt_aligned_pixel_t linear_RGB, RGB;
+  _rotated_primary_to_display_RGB(work_profile, display_profile, sRGB_profile, primary_index, angle, 0.4f,
+                                  linear_RGB);
+  const float luminance = scalar_product(linear_RGB, display_profile->matrix_in[1]);
+  _apply_trc_if_nonlinear(display_profile, linear_RGB, RGB);
+  dt_bauhaus_slider_set_stop(purity_slider, 0.0, luminance, luminance, luminance);
+  dt_bauhaus_slider_set_stop(purity_slider, 1.f, RGB[0], RGB[1], RGB[2]);
+  gtk_widget_queue_draw(GTK_WIDGET(purity_slider));
+}
+
+void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
+{
+  if(!self->dev || !self->dev->pipe) return;
+
+  dt_iop_primaries_gui_data_t *g = (dt_iop_primaries_gui_data_t *)self->gui_data;
+
+  const dt_iop_order_iccprofile_info_t *work_profile
+      = dt_ioppr_get_pipe_current_profile_info(self, self->dev->pipe);
+  const dt_iop_order_iccprofile_info_t *display_profile = dt_ioppr_get_pipe_output_profile_info(self->dev->pipe);
+  if(!work_profile || !display_profile) return; // couldn't fetch profiles, can't paint the sliders
+
+  const gboolean repaint_all_sliders
+      = !w || work_profile != g->painted_work_profile || display_profile != g->painted_display_profile;
+
+  const dt_iop_order_iccprofile_info_t *sRGB_profile
+      = dt_ioppr_add_profile_info_to_list(self->dev, DT_COLORSPACE_SRGB, "", DT_INTENT_RELATIVE_COLORIMETRIC);
+
+  if(repaint_all_sliders)
+  {
+    _paint_hue_slider(work_profile, display_profile, sRGB_profile, 0, g->red_hue);
+    _paint_hue_slider(work_profile, display_profile, sRGB_profile, 1, g->green_hue);
+    _paint_hue_slider(work_profile, display_profile, sRGB_profile, 2, g->blue_hue);
+    // Achromatic tint angle is anchored at the red primary
+    _paint_hue_slider(work_profile, display_profile, sRGB_profile, 0, g->achromatic_tint_hue);
+
+    g->painted_work_profile = work_profile;
+    g->painted_display_profile = display_profile;
+  }
+
+  if(repaint_all_sliders || w == g->red_hue)
+    _paint_purity_slider(work_profile, display_profile, sRGB_profile, 0, g->red_hue, g->red_purity);
+  if(repaint_all_sliders || w == g->green_hue)
+    _paint_purity_slider(work_profile, display_profile, sRGB_profile, 1, g->green_hue, g->green_purity);
+  if(repaint_all_sliders || w == g->blue_hue)
+    _paint_purity_slider(work_profile, display_profile, sRGB_profile, 2, g->blue_hue, g->blue_purity);
+  if(repaint_all_sliders || w == g->achromatic_tint_hue)
+    _paint_purity_slider(work_profile, display_profile, sRGB_profile, 0, g->achromatic_tint_hue,
+                         g->achromatic_tint_purity);
+}
+
+static void _signal_profile_user_changed(gpointer instance, uint8_t profile_type, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  gui_changed(self, NULL, NULL);
+}
+
+static void _signal_profile_changed(gpointer instance, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  gui_changed(self, NULL, NULL);
+}
+
+static GtkWidget *_setup_hue_slider(dt_iop_module_t *self, const char *param_name, const char *tooltip)
+{
+  GtkWidget *slider = dt_bauhaus_slider_from_params(self, param_name);
+  dt_bauhaus_slider_set_format(slider, "°");
+  dt_bauhaus_slider_set_digits(slider, 1);
+  dt_bauhaus_slider_set_factor(slider, RAD_TO_DEG);
+  dt_bauhaus_slider_set_soft_range(slider, -20.f / RAD_TO_DEG, 20.f / RAD_TO_DEG);
+  gtk_widget_set_tooltip_text(slider, tooltip);
+  return slider;
+}
+
+static GtkWidget *_setup_purity_slider(dt_iop_module_t *self, const char *param_name, const char *tooltip)
+{
+  GtkWidget *slider = dt_bauhaus_slider_from_params(self, param_name);
+  dt_bauhaus_slider_set_format(slider, "%");
+  dt_bauhaus_slider_set_digits(slider, 1);
+  dt_bauhaus_slider_set_factor(slider, 100.f);
+  dt_bauhaus_slider_set_offset(slider, -100.f);
+  dt_bauhaus_slider_set_soft_range(slider, 0.5f, 1.5f);
+  gtk_widget_set_tooltip_text(slider, tooltip);
+  return slider;
+}
+
+void gui_init(dt_iop_module_t *self)
+{
+  dt_iop_primaries_gui_data_t *g = IOP_GUI_ALLOC(primaries);
+
+  g->red_hue = _setup_hue_slider(self, "red_hue", _("red primary hue"));
+  g->red_purity = _setup_purity_slider(self, "red_purity", _("red primary purity"));
+  g->green_hue = _setup_hue_slider(self, "green_hue", _("green primary hue"));
+  g->green_purity = _setup_purity_slider(self, "green_purity", _("green primary purity"));
+  g->blue_hue = _setup_hue_slider(self, "blue_hue", _("blue primary hue"));
+  g->blue_purity = _setup_purity_slider(self, "blue_purity", _("blue primary purity"));
+
+  g->achromatic_tint_hue = dt_bauhaus_slider_from_params(self, "achromatic_tint_hue");
+  dt_bauhaus_slider_set_format(g->achromatic_tint_hue, "°");
+  dt_bauhaus_slider_set_digits(g->achromatic_tint_hue, 1);
+  dt_bauhaus_slider_set_factor(g->achromatic_tint_hue, RAD_TO_DEG);
+  gtk_widget_set_tooltip_text(g->achromatic_tint_hue, _("tint hue"));
+
+  g->achromatic_tint_purity = dt_bauhaus_slider_from_params(self, "achromatic_tint_purity");
+  dt_bauhaus_slider_set_format(g->achromatic_tint_purity, "%");
+  dt_bauhaus_slider_set_digits(g->achromatic_tint_purity, 1);
+  dt_bauhaus_slider_set_factor(g->achromatic_tint_purity, 100.f);
+  dt_bauhaus_slider_set_soft_range(g->achromatic_tint_purity, 0.f, 0.2f);
+  gtk_widget_set_tooltip_text(g->achromatic_tint_purity, _("tint purity"));
+
+  g->painted_work_profile = NULL;
+  g->painted_display_profile = NULL;
+
+  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
+                                  G_CALLBACK(_signal_profile_user_changed), self);
+  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_CHANGED,
+                                  G_CALLBACK(_signal_profile_changed), self);
+  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,
+                                  G_CALLBACK(_signal_profile_changed), self);
+}
+
+void gui_cleanup(struct dt_iop_module_t *self)
+{
+  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_signal_profile_user_changed), self);
+  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_signal_profile_changed), self);
+
+  IOP_GUI_FREE;
+}
+
+void init_global(dt_iop_module_so_t *module)
+{
+  const int program = 8; // extended.cl, from programs.conf
+  dt_iop_primaries_global_data_t *gd
+      = (dt_iop_primaries_global_data_t *)malloc(sizeof(dt_iop_primaries_global_data_t));
+  module->data = gd;
+  gd->kernel_primaries = dt_opencl_create_kernel(program, "primaries");
+}
+
+void cleanup_global(dt_iop_module_so_t *module)
+{
+  dt_iop_primaries_global_data_t *gd = (dt_iop_primaries_global_data_t *)module->data;
+  dt_opencl_free_kernel(gd->kernel_primaries);
+  free(module->data);
+  module->data = NULL;
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on


### PR DESCRIPTION
# New module: _primaries_

A tool to adjust the hue and purity of the image RGB primaries, i.e. which red, green and blue they represent.

The process is a linear operation:

1. The input RGB values are "reinterpreted" in the new primaries chosen by the user
2. A 3x3 transformation matrix is applied to the RGB to transform it back to the pipe working primaries

Thus, the module is a channel mixer with different interface.

In addition to the primaries, a "tint" control is added for changing the whitepoint.

## Why?

There's a valid counterargument that this functionality overlaps with the _color calibration_ module. Hence it is worth considering thoroughly whether this is a good addition. Some points in favour of this module:

* There has been interest in colour grading with the channel mixer, as demonstrated by e.g. @s7habo's excellent videos. However, some may find a regular channel mixer a bit difficult to use. Direct control over the primary hues and purities makes things a bit easier to grasp.
* This control also makes it very easy to adjust e.g. skin tones
* Despite the underlying math being the same, channel mixer controls allow more generic control over the mixing matrix than this module. Hence this can't be implemented as a view or mode in the existing channel mixer / color calibration module.
* The underlying code is remarkably simple and small, the most of it is just GUI code. I have no plans to add more functionalities.

## A bit of theory

The nice part of this parametrization is that the achromatic axis isn't affected - what's grey remains gray after adjustments. Also, the opponency relationships between the colours are preserved under this adjustment. If you increase the purity of the blue primary, the opponent yellow's intensity increases to balance things out. If you twist the blue hue toward cyan, the opponent yellow is twisted toward orange.

Even though the sliders refer "red", "green" and "blue", all adjustments are global and affect the colourimetry of the image. Hence this is not at all a similar tool as _color zones_ and the like. This is mostly suitable for small adjustments but is also kind of forgiving as there are practically no artefacts produced due to the underlying operation being linear.

## Suggested use cases and examples

Use this before _sigmoid_ or _filmic_ for small adjustments to camera colourimetry. Use this after _sigmoid_ or _filmic_ to apply creative edits. In particular, used after those modules, this one is able to tint the white parts of the image as well. Before the tone mapping, the tint control acts just like white balance.

Fine tuning skin tones ([image](https://discuss.pixls.us/t/playraw-mairi-troisieme/967) by Pat David, licensed under CC-BY-NC-SA). The fine-grained control of the primaries makes it easy to get the skin tones _right there_. The difference is subtle and you might have to flip between the images to observe it, but it certainly makes a difference. I've found it notably easy to do such subtle adjustments via this kind of an interface.

before | after | settings
--- | --- | ---
![Mairi_Troisieme_01](https://github.com/darktable-org/darktable/assets/5001906/7a731a6a-7ffa-484d-8abe-ca26604922bb) | ![Mairi_Troisieme](https://github.com/darktable-org/darktable/assets/5001906/4ae4c8cc-13fb-46e7-bd71-d58ea3331370) | ![mairi_primaries](https://github.com/darktable-org/darktable/assets/5001906/1118ed72-fdd1-4b74-906b-bfbb8924cb10)

Simple teal and orange look ([image](https://discuss.pixls.us/t/sunflower-sagas-and-solutions/33292) by Brian Poindexter, licensed under CC-BY-SA). Rotating the blue primary also affects the opponent yellow.

before | after | settings
--- | --- | ---
![0L0A3314_03](https://github.com/darktable-org/darktable/assets/5001906/639c1513-54f7-4d44-a6fc-a1e05f9b0cde) | ![0L0A3314_02](https://github.com/darktable-org/darktable/assets/5001906/917b39a5-c3e5-4d16-9794-2b95b5a3c4f6) | ![sunflower_primaries](https://github.com/darktable-org/darktable/assets/5001906/a417b28d-259c-4872-b114-aa5330d648cd)

## Request for comments

For those who use a channel mixer or would like to use it - would this make your job easier? Please try this out :) Would appreciate some comments from e.g. @s7habo who is an expert of channel mixing.

## Further development ideas

Work out presets for typical colour grading use cases.

Ps. note that the three first commits in this PR are the same as in https://github.com/darktable-org/darktable/pull/15104 (supporting code). The module itself is only 380 lines, counting whitespace.
