### PR TITLE
Fix incorrect use of dt_print in email export target

### DIFF
--- a/src/imageio/storage/email.c
+++ b/src/imageio/storage/email.c
@@ -285,10 +285,9 @@ void finalize_store(dt_imageio_module_storage_t *self,
 
   argv[argc] = NULL;
 
-  dt_print(DT_DEBUG_ALWAYS, "[email] launching '");
-  for(int k=0; k<argc; k++)
-    dt_print(DT_DEBUG_ALWAYS, " %s", argv[k]);
-  dt_print(DT_DEBUG_ALWAYS, "'\n");
+  gchar *cmdline = g_strjoinv(" ", argv);
+  dt_print(DT_DEBUG_ALWAYS, "[email] launching '%s'\n", cmdline);
+  g_free(cmdline);
 
   gint exit_status = 0;
 

--- a/src/imageio/storage/email.c
+++ b/src/imageio/storage/email.c
@@ -286,7 +286,7 @@ void finalize_store(dt_imageio_module_storage_t *self,
   argv[argc] = NULL;
 
   gchar *cmdline = g_strjoinv(" ", argv);
-  dt_print(DT_DEBUG_ALWAYS, "[email] launching '%s'\n", cmdline);
+  dt_print(DT_DEBUG_IMAGEIO, "[email] launching '%s'\n", cmdline);
   g_free(cmdline);
 
   gint exit_status = 0;


### PR DESCRIPTION
We're forming a string to print here with multiple function calls, so the dt_print function isn't appropriate here because it adds a timestamp to each segment of the output string.