### PR TITLE
macOS Quick fix Update cacorrect.c

### DIFF
--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -375,7 +375,7 @@ void process(
   for(size_t it = 0; it < iterations && processpasstwo; it++)
   {
 
-#ifdef _OPENMP
+#if defined(_OPENMP) && !defined(__APPLE__)
 #pragma omp parallel default(none) \
   dt_omp_firstprivate(in, out, height, width, filters, processpasstwo, hblsz, vblsz, \
                       blockwt, blockshifts, blockvar, Gtmp, RawDataTmp, caautostrength, \


### PR DESCRIPTION
workaround for #15116 (until there's something better ...) 
disabling openmp avoids freezing dt when applying raw ca correction.

fixes #15116