### PR TITLE
Major process_cl() maintenance update

### DIFF
--- a/src/common/bilateralcl.c
+++ b/src/common/bilateralcl.c
@@ -156,22 +156,19 @@ dt_bilateral_cl_t *dt_bilateral_init_cl(const int devid,
 
 cl_int dt_bilateral_splat_cl(dt_bilateral_cl_t *b, cl_mem in)
 {
-  cl_int err = -666;
   size_t sizes[] = { ROUNDUP(b->width, b->blocksizex), ROUNDUP(b->height, b->blocksizey), 1 };
   size_t local[] = { b->blocksizex, b->blocksizey, 1 };
   dt_opencl_set_kernel_args(b->devid, b->global->kernel_splat, 0, CLARG(in), CLARG(b->dev_grid),
     CLARG(b->width), CLARG(b->height), CLARG(b->size_x), CLARG(b->size_y), CLARG(b->size_z), CLARG(b->sigma_s),
     CLARG(b->sigma_r), CLLOCAL(b->blocksizex * b->blocksizey * sizeof(int)), CLLOCAL(b->blocksizex * b->blocksizey * 8 * sizeof(float)));
-  err = dt_opencl_enqueue_kernel_2d_with_local(b->devid, b->global->kernel_splat, sizes, local);
-  return err;
+  return dt_opencl_enqueue_kernel_2d_with_local(b->devid, b->global->kernel_splat, sizes, local);
 }
 
 cl_int dt_bilateral_blur_cl(dt_bilateral_cl_t *b)
 {
-  cl_int err = -666;
   size_t sizes[3] = { 0, 0, 1 };
 
-  err = dt_opencl_enqueue_copy_buffer_to_buffer(b->devid, b->dev_grid, b->dev_grid_tmp, 0, 0,
+  cl_int err = dt_opencl_enqueue_copy_buffer_to_buffer(b->devid, b->dev_grid, b->dev_grid_tmp, 0, 0,
                                                 sizeof(float) * b->size_x * b->size_y * b->size_z);
   if(err != CL_SUCCESS) return err;
 
@@ -203,16 +200,13 @@ cl_int dt_bilateral_blur_cl(dt_bilateral_cl_t *b)
   sizes[1] = ROUNDUPDHT(b->size_y, b->devid);
   dt_opencl_set_kernel_args(b->devid, b->global->kernel_blur_line_z, 0, CLARG(b->dev_grid_tmp), CLARG(b->dev_grid),
     CLARG(stride1), CLARG(stride2), CLARG(stride3), CLARG(b->size_x), CLARG(b->size_y), CLARG(b->size_z));
-  err = dt_opencl_enqueue_kernel_2d(b->devid, b->global->kernel_blur_line_z, sizes);
-  return err;
+  return dt_opencl_enqueue_kernel_2d(b->devid, b->global->kernel_blur_line_z, sizes);
 }
 
 cl_int dt_bilateral_slice_to_output_cl(dt_bilateral_cl_t *b, cl_mem in, cl_mem out, const float detail)
 {
-  cl_int err = -666;
-  cl_mem tmp = NULL;
-
-  tmp = dt_opencl_alloc_device(b->devid, b->width, b->height, sizeof(float) * 4);
+  cl_int err = DT_OPENCL_DEFAULT_ERROR;
+  cl_mem tmp = dt_opencl_alloc_device(b->devid, b->width, b->height, sizeof(float) * 4);
   if(tmp == NULL) goto error;
 
   size_t origin[] = { 0, 0, 0 };
@@ -224,9 +218,6 @@ cl_int dt_bilateral_slice_to_output_cl(dt_bilateral_cl_t *b, cl_mem in, cl_mem o
     CLARG(in), CLARG(tmp), CLARG(out), CLARG(b->dev_grid), CLARG(b->width), CLARG(b->height), CLARG(b->size_x),
     CLARG(b->size_y), CLARG(b->size_z), CLARG(b->sigma_s), CLARG(b->sigma_r), CLARG(detail));
 
-  dt_opencl_release_mem_object(tmp);
-  return err;
-
 error:
   dt_opencl_release_mem_object(tmp);
   return err;
@@ -234,11 +225,9 @@ error:
 
 cl_int dt_bilateral_slice_cl(dt_bilateral_cl_t *b, cl_mem in, cl_mem out, const float detail)
 {
-  cl_int err = -666;
-  err = dt_opencl_enqueue_kernel_2d_args(b->devid, b->global->kernel_slice, b->width, b->height,
+  return dt_opencl_enqueue_kernel_2d_args(b->devid, b->global->kernel_slice, b->width, b->height,
     CLARG(in), CLARG(out), CLARG(b->dev_grid), CLARG(b->width), CLARG(b->height), CLARG(b->size_x),
     CLARG(b->size_y), CLARG(b->size_z), CLARG(b->sigma_s), CLARG(b->sigma_r), CLARG(detail));
-  return err;
 }
 
 void dt_bilateral_free_cl_global(dt_bilateral_cl_global_t *b)

--- a/src/common/dwt.c
+++ b/src/common/dwt.c
@@ -893,18 +893,16 @@ static cl_int dwt_wavelet_decompose_cl(cl_mem img, dwt_params_cl_t *const p, _dw
   }
 
 cleanup:
-  if(layers) dt_opencl_release_mem_object(layers);
-  if(merged_layers) dt_opencl_release_mem_object(merged_layers);
-  if(temp) dt_opencl_release_mem_object(temp);
-  if(buffer[1]) dt_opencl_release_mem_object(buffer[1]);
+  dt_opencl_release_mem_object(layers);
+  dt_opencl_release_mem_object(merged_layers);
+  dt_opencl_release_mem_object(temp);
+  dt_opencl_release_mem_object(buffer[1]);
 
   return err;
 }
 
 cl_int dwt_decompose_cl(dwt_params_cl_t *p, _dwt_layer_func_cl layer_func)
 {
-  cl_int err = CL_SUCCESS;
-
   // this is a zoom scale, not a wavelet scale
   if(p->preview_scale <= 0.f) p->preview_scale = 1.f;
 
@@ -929,9 +927,7 @@ cl_int dwt_decompose_cl(dwt_params_cl_t *p, _dwt_layer_func_cl layer_func)
   }
 
   // call the actual decompose
-  err = dwt_wavelet_decompose_cl(p->image, p, layer_func);
-
-  return err;
+  return dwt_wavelet_decompose_cl(p->image, p, layer_func);
 }
 
 #endif

--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -55,20 +55,20 @@ typedef struct color_image
 } color_image;
 
 // allocate space for n-component image of size width x height
-static inline color_image new_color_image(int width, int height, int ch)
+static inline color_image _new_color_image(int width, int height, int ch)
 {
   return (color_image){ dt_alloc_align_float((size_t)width * height * ch), width, height, ch };
 }
 
 // free space for n-component image
-static inline void free_color_image(color_image *img_p)
+static inline void _free_color_image(color_image *img_p)
 {
   dt_free_align(img_p->data);
   img_p->data = NULL;
 }
 
 // get a pointer to pixel number 'i' within the image
-static inline float *get_color_pixel(color_image img, size_t i)
+static inline float *_get_color_pixel(color_image img, size_t i)
 {
   return img.data + i * img.stride;
 }
@@ -82,8 +82,15 @@ static inline float *get_color_pixel(color_image img, size_t i)
 //    6 variance (R-R, R-G, R-B, G-G, G-B, B-B)
 // for computational efficiency, we'll pack them into a four-channel image and a 9-channel image
 // image instead of running 13 separate box filters: guide+input, R/G/B/R-R/R-G/R-B/G-G/G-B/B-B.
-static void guided_filter_tiling(color_image imgg, gray_image img, gray_image img_out, tile target, const int w,
-                                 const float eps, const float guide_weight, const float min, const float max)
+static void _guided_filter_tiling(color_image imgg,
+                                  gray_image img,
+                                  gray_image img_out,
+                                  tile target,
+                                  const int w,
+                                  const float eps,
+                                  const float guide_weight,
+                                  const float min,
+                                  const float max)
 {
   const tile source = { max_i(target.left - 2 * w, 0), min_i(target.right + 2 * w, imgg.width),
                         max_i(target.lower - 2 * w, 0), min_i(target.upper + 2 * w, imgg.height) };
@@ -105,8 +112,8 @@ static void guided_filter_tiling(color_image imgg, gray_image img, gray_image im
 #define VAR_GG 6
 #define VAR_BB 8
 #define VAR_GB 7
-  color_image mean = new_color_image(width, height, 4);
-  color_image variance = new_color_image(width, height, 9);
+  color_image mean = _new_color_image(width, height, 4);
+  color_image variance = _new_color_image(width, height, 9);
   const size_t img_dimen = mean.width;
   size_t img_bak_sz;
   float *img_bak = dt_alloc_perthread_float(9*img_dimen, &img_bak_sz);
@@ -122,7 +129,7 @@ static void guided_filter_tiling(color_image imgg, gray_image img, gray_image im
     for(int i_imgg = source.left; i_imgg < source.right; i_imgg++)
     {
       size_t i = i_imgg - source.left;
-      const float *pixel_ = get_color_pixel(imgg, i_imgg + (size_t)j_imgg * imgg.width);
+      const float *pixel_ = _get_color_pixel(imgg, i_imgg + (size_t)j_imgg * imgg.width);
       dt_aligned_pixel_t pixel =
         { pixel_[0] * guide_weight, pixel_[1] * guide_weight, pixel_[2] * guide_weight, pixel_[3] * guide_weight };
       const float input = img.data[i_imgg + (size_t)j_imgg * img.width];
@@ -160,12 +167,12 @@ static void guided_filter_tiling(color_image imgg, gray_image img, gray_image im
 #endif
   for(size_t i = 0; i < size; i++)
   {
-    const float *meanpx = get_color_pixel(mean, i);
+    const float *meanpx = _get_color_pixel(mean, i);
     const float inp_mean = meanpx[INP_MEAN];
     const float guide_r = meanpx[GUIDE_MEAN_R];
     const float guide_g = meanpx[GUIDE_MEAN_G];
     const float guide_b = meanpx[GUIDE_MEAN_B];
-    float *const varpx = get_color_pixel(variance, i);
+    float *const varpx = _get_color_pixel(variance, i);
     // solve linear system of equations of size 3x3 via Cramer's rule
     // symmetric coefficient matrix
     const float Sigma_0_0 = varpx[VAR_RR] - (guide_r * guide_r) + eps;
@@ -203,7 +210,7 @@ static void guided_filter_tiling(color_image imgg, gray_image img, gray_image im
       a_r_ = 0.f;
       a_g_ = 0.f;
       a_b_ = 0.f;
-      b_ = get_color_pixel(mean, i)[INP_MEAN];
+      b_ = _get_color_pixel(mean, i)[INP_MEAN];
     }
     // now data of imgg_mean_? is no longer needed, we can safely overwrite aliasing arrays
     a_b.data[4*i+A_RED] = a_r_;
@@ -211,7 +218,7 @@ static void guided_filter_tiling(color_image imgg, gray_image img, gray_image im
     a_b.data[4*i+A_BLUE] = a_b_;
     a_b.data[4*i+B] = b_;
   }
-  free_color_image(&variance);
+  _free_color_image(&variance);
 
   dt_box_mean(a_b.data, a_b.height, a_b.width, a_b.stride|BOXFILTER_KAHAN_SUM, w, 1);
 
@@ -229,17 +236,17 @@ static void guided_filter_tiling(color_image imgg, gray_image img, gray_image im
     size_t k = (target.left - source.left) + (size_t)(j_imgg - source.lower) * width;
     for(int i_imgg = target.left; i_imgg < target.right; i_imgg++, k++, l++)
     {
-      const float *pixel = get_color_pixel(imgg, l);
-      const float *px_ab = get_color_pixel(a_b, k);
+      const float *pixel = _get_color_pixel(imgg, l);
+      const float *px_ab = _get_color_pixel(a_b, k);
       float res = guide_weight * (px_ab[A_RED] * pixel[0] + px_ab[A_GREEN] * pixel[1] + px_ab[A_BLUE] * pixel[2]);
       res += px_ab[B];
       img_out.data[i_imgg + (size_t)j_imgg * imgg.width] = CLAMP(res, min, max);
     }
   }
-  free_color_image(&mean);
+  _free_color_image(&mean);
 }
 
-static int compute_tile_height(const int height, const int w)
+static int _compute_tile_height(const int height, const int w)
 {
   int tile_h = max_i(3 * w, GF_TILE_SIZE);
 #if 0 // enabling the below doesn't make any measureable speed difference, but does cause a handful of pixels
@@ -264,7 +271,7 @@ static int compute_tile_height(const int height, const int w)
   return tile_h;
 }
 
-static int compute_tile_width(const int width, const int w)
+static int _compute_tile_width(const int width, const int w)
 {
   int tile_w = max_i(3 * w, GF_TILE_SIZE);
 #if 0 // enabling the below doesn't make any measureable speed difference, but does cause a handful of pixels
@@ -289,12 +296,17 @@ static int compute_tile_width(const int width, const int w)
   return tile_w;
 }
 
-void guided_filter(const float *const guide, const float *const in, float *const out, const int width,
-                   const int height, const int ch,
-                   const int w,              // window size
-                   const float sqrt_eps,     // regularization parameter
-                   const float guide_weight, // to balance the amplitudes in the guiding image and the input image
-                   const float min, const float max)
+void guided_filter(const float *const guide,
+                    const float *const in,
+                    float *const out,
+                    const int width,
+                    const int height,
+                    const int ch,
+                    const int w,              // window size
+                    const float sqrt_eps,     // regularization parameter
+                    const float guide_weight, // to balance the amplitudes in the guiding image and the input image
+                    const float min,
+                    const float max)
 {
   assert(ch >= 3);
   assert(w >= 1);
@@ -302,8 +314,8 @@ void guided_filter(const float *const guide, const float *const in, float *const
   color_image img_guide = (color_image){ (float *)guide, width, height, ch };
   gray_image img_in = (gray_image){ (float *)in, width, height };
   gray_image img_out = (gray_image){ out, width, height };
-  const int tile_width = compute_tile_width(width,w);
-  const int tile_height = compute_tile_height(height,w);
+  const int tile_width = _compute_tile_width(width,w);
+  const int tile_height = _compute_tile_height(height,w);
   const float eps = sqrt_eps * sqrt_eps; // this is the regularization parameter of the original papers
 
   for(int j = 0; j < height; j += tile_height)
@@ -311,7 +323,7 @@ void guided_filter(const float *const guide, const float *const in, float *const
     for(int i = 0; i < width; i += tile_width)
     {
       tile target = { i, min_i(i + tile_width, width), j, min_i(j + tile_height, height) };
-      guided_filter_tiling(img_guide, img_in, img_out, target, w, eps, guide_weight, min, max);
+      _guided_filter_tiling(img_guide, img_in, img_out, target, w, eps, guide_weight, min, max);
     }
   }
 }
@@ -351,8 +363,14 @@ void dt_guided_filter_free_cl_global(dt_guided_filter_cl_global_t *g)
 }
 
 
-static int cl_split_rgb(const int devid, const int width, const int height, cl_mem guide, cl_mem imgg_r,
-                        cl_mem imgg_g, cl_mem imgg_b, const float guide_weight)
+static int _cl_split_rgb(const int devid,
+                          const int width,
+                          const int height,
+                          cl_mem guide,
+                          cl_mem imgg_r,
+                          cl_mem imgg_g,
+                          cl_mem imgg_b,
+                          const float guide_weight)
 {
   const int kernel = darktable.opencl->guided_filter->kernel_guided_filter_split_rgb;
   return dt_opencl_enqueue_kernel_2d_args(devid, kernel, width, height,
@@ -360,8 +378,13 @@ static int cl_split_rgb(const int devid, const int width, const int height, cl_m
 }
 
 
-static int cl_box_mean(const int devid, const int width, const int height, const int w, cl_mem in, cl_mem out,
-                       cl_mem temp)
+static int _cl_box_mean(const int devid,
+                        const int width,
+                        const int height,
+                        const int w,
+                        cl_mem in,
+                        cl_mem out,
+                        cl_mem temp)
 {
   const int kernel_x = darktable.opencl->guided_filter->kernel_guided_filter_box_mean_x;
   dt_opencl_set_kernel_args(devid, kernel_x, 0, CLARG(width), CLARG(height), CLARG(in), CLARG(temp), CLARG(w));
@@ -376,8 +399,14 @@ static int cl_box_mean(const int devid, const int width, const int height, const
 }
 
 
-static int cl_covariances(const int devid, const int width, const int height, cl_mem guide, cl_mem in,
-                          cl_mem cov_imgg_img_r, cl_mem cov_imgg_img_g, cl_mem cov_imgg_img_b,
+static int _cl_covariances(const int devid,
+                          const int width,
+                          const int height,
+                          cl_mem guide,
+                          cl_mem in,
+                          cl_mem cov_imgg_img_r,
+                          cl_mem cov_imgg_img_g,
+                          cl_mem cov_imgg_img_b,
                           const float guide_weight)
 {
   const int kernel = darktable.opencl->guided_filter->kernel_guided_filter_guided_filter_covariances;
@@ -387,9 +416,17 @@ static int cl_covariances(const int devid, const int width, const int height, cl
 }
 
 
-static int cl_variances(const int devid, const int width, const int height, cl_mem guide, cl_mem var_imgg_rr,
-                        cl_mem var_imgg_rg, cl_mem var_imgg_rb, cl_mem var_imgg_gg, cl_mem var_imgg_gb,
-                        cl_mem var_imgg_bb, const float guide_weight)
+static int _cl_variances(const int devid,
+                          const int width,
+                          const int height,
+                          cl_mem guide,
+                          cl_mem var_imgg_rr,
+                          cl_mem var_imgg_rg,
+                          cl_mem var_imgg_rb,
+                          cl_mem var_imgg_gg,
+                          cl_mem var_imgg_gb,
+                          cl_mem var_imgg_bb,
+                          const float guide_weight)
 {
   const int kernel = darktable.opencl->guided_filter->kernel_guided_filter_guided_filter_variances;
   return dt_opencl_enqueue_kernel_2d_args(devid, kernel, width, height,
@@ -398,8 +435,14 @@ static int cl_variances(const int devid, const int width, const int height, cl_m
 }
 
 
-static int cl_update_covariance(const int devid, const int width, const int height, cl_mem in, cl_mem out,
-                                cl_mem a, cl_mem b, float eps)
+static int _cl_update_covariance(const int devid,
+                                  const int width,
+                                  const int height,
+                                  cl_mem in,
+                                  cl_mem out,
+                                  cl_mem a,
+                                  cl_mem b,
+                                  float eps)
 {
   const int kernel = darktable.opencl->guided_filter->kernel_guided_filter_update_covariance;
   return dt_opencl_enqueue_kernel_2d_args(devid, kernel, width, height,
@@ -407,11 +450,26 @@ static int cl_update_covariance(const int devid, const int width, const int heig
 }
 
 
-static int cl_solve(const int devid, const int width, const int height, cl_mem img_mean, cl_mem imgg_mean_r,
-                    cl_mem imgg_mean_g, cl_mem imgg_mean_b, cl_mem cov_imgg_img_r, cl_mem cov_imgg_img_g,
-                    cl_mem cov_imgg_img_b, cl_mem var_imgg_rr, cl_mem var_imgg_rg, cl_mem var_imgg_rb,
-                    cl_mem var_imgg_gg, cl_mem var_imgg_gb, cl_mem var_imgg_bb, cl_mem a_r, cl_mem a_g, cl_mem a_b,
-                    cl_mem b)
+static int _cl_solve(const int devid,
+                      const int width,
+                      const int height,
+                      cl_mem img_mean,
+                      cl_mem imgg_mean_r,
+                      cl_mem imgg_mean_g,
+                      cl_mem imgg_mean_b,
+                      cl_mem cov_imgg_img_r,
+                      cl_mem cov_imgg_img_g,
+                      cl_mem cov_imgg_img_b,
+                      cl_mem var_imgg_rr,
+                      cl_mem var_imgg_rg,
+                      cl_mem var_imgg_rb,
+                      cl_mem var_imgg_gg,
+                      cl_mem var_imgg_gb,
+                      cl_mem var_imgg_bb,
+                      cl_mem a_r,
+                      cl_mem a_g,
+                      cl_mem a_b,
+                      cl_mem b)
 {
   const int kernel = darktable.opencl->guided_filter->kernel_guided_filter_solve;
   return dt_opencl_enqueue_kernel_2d_args(devid, kernel, width, height,
@@ -422,9 +480,18 @@ static int cl_solve(const int devid, const int width, const int height, cl_mem i
 }
 
 
-static int cl_generate_result(const int devid, const int width, const int height, cl_mem guide, cl_mem a_r,
-                              cl_mem a_g, cl_mem a_b, cl_mem b, cl_mem out, const float guide_weight,
-                              const float min, const float max)
+static int _cl_generate_result(const int devid,
+                                const int width,
+                                const int height,
+                                cl_mem guide,
+                                cl_mem a_r,
+                                cl_mem a_g,
+                                cl_mem a_b,
+                                cl_mem b,
+                                cl_mem out,
+                                const float guide_weight,
+                                const float min,
+                                const float max)
 {
   const int kernel = darktable.opencl->guided_filter->kernel_guided_filter_generate_result;
   return dt_opencl_enqueue_kernel_2d_args(devid, kernel, width, height,
@@ -433,13 +500,19 @@ static int cl_generate_result(const int devid, const int width, const int height
 }
 
 
-static int guided_filter_cl_impl(int devid, cl_mem guide, cl_mem in, cl_mem out, const int width, const int height,
-                                 const int ch,
-                                 const int w,              // window size
-                                 const float sqrt_eps,     // regularization parameter
-                                 const float guide_weight, // to balance the amplitudes in the guiding image and
+static int _guided_filter_cl_impl(int devid,
+                                  cl_mem guide,
+                                  cl_mem in,
+                                  cl_mem out,
+                                  const int width,
+                                  const int height,
+                                  const int ch,
+                                  const int w,              // window size
+                                  const float sqrt_eps,     // regularization parameter
+                                  const float guide_weight, // to balance the amplitudes in the guiding image and
                                                            // the input// image
-                                 const float min, const float max)
+                                  const float min,
+                                  const float max)
 {
   const float eps = sqrt_eps * sqrt_eps; // this is the regularization parameter of the original papers
 
@@ -463,7 +536,7 @@ static int guided_filter_cl_impl(int devid, cl_mem guide, cl_mem in, cl_mem out,
   void *a_b = dt_opencl_alloc_device(devid, width, height, (int)sizeof(float));
   void *b = temp2;
 
-  int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
+  cl_int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
   if(temp1 == NULL || temp2 == NULL ||                                                        //
      imgg_mean_r == NULL || imgg_mean_g == NULL || imgg_mean_b == NULL || img_mean == NULL || //
      cov_imgg_img_r == NULL || cov_imgg_img_g == NULL || cov_imgg_img_b == NULL ||            //
@@ -474,82 +547,80 @@ static int guided_filter_cl_impl(int devid, cl_mem guide, cl_mem in, cl_mem out,
     goto error;
   }
 
-  err = cl_split_rgb(devid, width, height, guide, imgg_mean_r, imgg_mean_g, imgg_mean_b, guide_weight);
+  err = _cl_split_rgb(devid, width, height, guide, imgg_mean_r, imgg_mean_g, imgg_mean_b, guide_weight);
   if(err != CL_SUCCESS) goto error;
 
-  err = cl_box_mean(devid, width, height, w, in, img_mean, temp1);
+  err = _cl_box_mean(devid, width, height, w, in, img_mean, temp1);
   if(err != CL_SUCCESS) goto error;
-  err = cl_box_mean(devid, width, height, w, imgg_mean_r, imgg_mean_r, temp1);
+  err = _cl_box_mean(devid, width, height, w, imgg_mean_r, imgg_mean_r, temp1);
   if(err != CL_SUCCESS) goto error;
-  err = cl_box_mean(devid, width, height, w, imgg_mean_g, imgg_mean_g, temp1);
+  err = _cl_box_mean(devid, width, height, w, imgg_mean_g, imgg_mean_g, temp1);
   if(err != CL_SUCCESS) goto error;
-  err = cl_box_mean(devid, width, height, w, imgg_mean_b, imgg_mean_b, temp1);
+  err = _cl_box_mean(devid, width, height, w, imgg_mean_b, imgg_mean_b, temp1);
   if(err != CL_SUCCESS) goto error;
 
-  err = cl_covariances(devid, width, height, guide, in, cov_imgg_img_r, cov_imgg_img_g, cov_imgg_img_b,
+  err = _cl_covariances(devid, width, height, guide, in, cov_imgg_img_r, cov_imgg_img_g, cov_imgg_img_b,
                        guide_weight);
   if(err != CL_SUCCESS) goto error;
 
-  err = cl_variances(devid, width, height, guide, var_imgg_rr, var_imgg_rg, var_imgg_rb, var_imgg_gg, var_imgg_gb,
+  err = _cl_variances(devid, width, height, guide, var_imgg_rr, var_imgg_rg, var_imgg_rb, var_imgg_gg, var_imgg_gb,
                      var_imgg_bb, guide_weight);
   if(err != CL_SUCCESS) goto error;
 
-  err = cl_box_mean(devid, width, height, w, cov_imgg_img_r, temp2, temp1);
+  err = _cl_box_mean(devid, width, height, w, cov_imgg_img_r, temp2, temp1);
   if(err != CL_SUCCESS) goto error;
-  err = cl_update_covariance(devid, width, height, temp2, cov_imgg_img_r, imgg_mean_r, img_mean, 0.f);
+  err = _cl_update_covariance(devid, width, height, temp2, cov_imgg_img_r, imgg_mean_r, img_mean, 0.f);
   if(err != CL_SUCCESS) goto error;
-  err = cl_box_mean(devid, width, height, w, cov_imgg_img_g, temp2, temp1);
+  err = _cl_box_mean(devid, width, height, w, cov_imgg_img_g, temp2, temp1);
   if(err != CL_SUCCESS) goto error;
-  err = cl_update_covariance(devid, width, height, temp2, cov_imgg_img_g, imgg_mean_g, img_mean, 0.f);
+  err = _cl_update_covariance(devid, width, height, temp2, cov_imgg_img_g, imgg_mean_g, img_mean, 0.f);
   if(err != CL_SUCCESS) goto error;
-  err = cl_box_mean(devid, width, height, w, cov_imgg_img_b, temp2, temp1);
+  err = _cl_box_mean(devid, width, height, w, cov_imgg_img_b, temp2, temp1);
   if(err != CL_SUCCESS) goto error;
-  err = cl_update_covariance(devid, width, height, temp2, cov_imgg_img_b, imgg_mean_b, img_mean, 0.f);
+  err = _cl_update_covariance(devid, width, height, temp2, cov_imgg_img_b, imgg_mean_b, img_mean, 0.f);
   if(err != CL_SUCCESS) goto error;
-  err = cl_box_mean(devid, width, height, w, var_imgg_rr, temp2, temp1);
+  err = _cl_box_mean(devid, width, height, w, var_imgg_rr, temp2, temp1);
   if(err != CL_SUCCESS) goto error;
-  err = cl_update_covariance(devid, width, height, temp2, var_imgg_rr, imgg_mean_r, imgg_mean_r, eps);
+  err = _cl_update_covariance(devid, width, height, temp2, var_imgg_rr, imgg_mean_r, imgg_mean_r, eps);
   if(err != CL_SUCCESS) goto error;
-  err = cl_box_mean(devid, width, height, w, var_imgg_rg, temp2, temp1);
+  err = _cl_box_mean(devid, width, height, w, var_imgg_rg, temp2, temp1);
   if(err != CL_SUCCESS) goto error;
-  err = cl_update_covariance(devid, width, height, temp2, var_imgg_rg, imgg_mean_r, imgg_mean_g, 0.f);
+  err = _cl_update_covariance(devid, width, height, temp2, var_imgg_rg, imgg_mean_r, imgg_mean_g, 0.f);
   if(err != CL_SUCCESS) goto error;
-  err = cl_box_mean(devid, width, height, w, var_imgg_rb, temp2, temp1);
+  err = _cl_box_mean(devid, width, height, w, var_imgg_rb, temp2, temp1);
   if(err != CL_SUCCESS) goto error;
-  err = cl_update_covariance(devid, width, height, temp2, var_imgg_rb, imgg_mean_r, imgg_mean_b, 0.f);
+  err = _cl_update_covariance(devid, width, height, temp2, var_imgg_rb, imgg_mean_r, imgg_mean_b, 0.f);
   if(err != CL_SUCCESS) goto error;
-  err = cl_box_mean(devid, width, height, w, var_imgg_gg, temp2, temp1);
+  err = _cl_box_mean(devid, width, height, w, var_imgg_gg, temp2, temp1);
   if(err != CL_SUCCESS) goto error;
-  err = cl_update_covariance(devid, width, height, temp2, var_imgg_gg, imgg_mean_g, imgg_mean_g, eps);
+  err = _cl_update_covariance(devid, width, height, temp2, var_imgg_gg, imgg_mean_g, imgg_mean_g, eps);
   if(err != CL_SUCCESS) goto error;
-  err = cl_box_mean(devid, width, height, w, var_imgg_gb, temp2, temp1);
+  err = _cl_box_mean(devid, width, height, w, var_imgg_gb, temp2, temp1);
   if(err != CL_SUCCESS) goto error;
-  err = cl_update_covariance(devid, width, height, temp2, var_imgg_gb, imgg_mean_g, imgg_mean_b, 0.f);
+  err = _cl_update_covariance(devid, width, height, temp2, var_imgg_gb, imgg_mean_g, imgg_mean_b, 0.f);
   if(err != CL_SUCCESS) goto error;
-  err = cl_box_mean(devid, width, height, w, var_imgg_bb, temp2, temp1);
+  err = _cl_box_mean(devid, width, height, w, var_imgg_bb, temp2, temp1);
   if(err != CL_SUCCESS) goto error;
-  err = cl_update_covariance(devid, width, height, temp2, var_imgg_bb, imgg_mean_b, imgg_mean_b, eps);
+  err = _cl_update_covariance(devid, width, height, temp2, var_imgg_bb, imgg_mean_b, imgg_mean_b, eps);
   if(err != CL_SUCCESS) goto error;
 
-  err = cl_solve(devid, width, height, img_mean, imgg_mean_r, imgg_mean_g, imgg_mean_b, cov_imgg_img_r,
+  err = _cl_solve(devid, width, height, img_mean, imgg_mean_r, imgg_mean_g, imgg_mean_b, cov_imgg_img_r,
                  cov_imgg_img_g, cov_imgg_img_b, var_imgg_rr, var_imgg_rg, var_imgg_rb, var_imgg_gg, var_imgg_gb,
                  var_imgg_bb, a_r, a_g, a_b, b);
   if(err != CL_SUCCESS) goto error;
 
-  err = cl_box_mean(devid, width, height, w, a_r, a_r, temp1);
+  err = _cl_box_mean(devid, width, height, w, a_r, a_r, temp1);
   if(err != CL_SUCCESS) goto error;
-  err = cl_box_mean(devid, width, height, w, a_g, a_g, temp1);
+  err = _cl_box_mean(devid, width, height, w, a_g, a_g, temp1);
   if(err != CL_SUCCESS) goto error;
-  err = cl_box_mean(devid, width, height, w, a_b, a_b, temp1);
+  err = _cl_box_mean(devid, width, height, w, a_b, a_b, temp1);
   if(err != CL_SUCCESS) goto error;
-  err = cl_box_mean(devid, width, height, w, b, b, temp1);
+  err = _cl_box_mean(devid, width, height, w, b, b, temp1);
   if(err != CL_SUCCESS) goto error;
 
-  err = cl_generate_result(devid, width, height, guide, a_r, a_g, a_b, b, out, guide_weight, min, max);
+  err = _cl_generate_result(devid, width, height, guide, a_r, a_g, a_b, b, out, guide_weight, min, max);
 
 error:
-  if(err != CL_SUCCESS) dt_print(DT_DEBUG_OPENCL, "[guided filter] error: %s\n", cl_errstr(err));
-
   dt_opencl_release_mem_object(a_r);
   dt_opencl_release_mem_object(a_g);
   dt_opencl_release_mem_object(a_b);
@@ -568,21 +639,27 @@ error:
   dt_opencl_release_mem_object(imgg_mean_b);
   dt_opencl_release_mem_object(temp1);
   dt_opencl_release_mem_object(temp2);
-
   return err;
 }
 
 
-static void guided_filter_cl_fallback(int devid, cl_mem guide, cl_mem in, cl_mem out, const int width,
-                                      const int height, const int ch,
+static int _guided_filter_cl_fallback(int devid,
+                                      cl_mem guide,
+                                      cl_mem in,
+                                      cl_mem out,
+                                      const int width,
+                                      const int height,
+                                      const int ch,
                                       const int w,              // window size
                                       const float sqrt_eps,     // regularization parameter
                                       const float guide_weight, // to balance the amplitudes in the guiding image
                                                                 // and the input// image
-                                      const float min, const float max)
+                                      const float min,
+                                      const float max)
 {
   // fall-back implementation: copy data from device memory to host memory and perform filter
   // by CPU until there is a proper OpenCL implementation
+  cl_int err = DT_OPENCL_SYSMEM_ALLOCATION;
   float *guide_host = dt_alloc_align(64, sizeof(*guide_host) * width * height * ch);
   float *in_host = dt_alloc_align(64, sizeof(*in_host) * width * height);
   float *out_host = dt_alloc_align(64, sizeof(*out_host) * width * height);
@@ -590,10 +667,11 @@ static void guided_filter_cl_fallback(int devid, cl_mem guide, cl_mem in, cl_mem
   if(!guide_host || !in_host || !out_host)
     goto error;
 
-  cl_int err = dt_opencl_read_host_from_device(devid, guide_host, guide, width, height, ch * sizeof(float));
+  err = dt_opencl_read_host_from_device(devid, guide_host, guide, width, height, ch * sizeof(float));
   if(err != CL_SUCCESS) goto error;
   err = dt_opencl_read_host_from_device(devid, in_host, in, width, height, sizeof(float));
   if(err != CL_SUCCESS) goto error;
+
   guided_filter(guide_host, in_host, out_host, width, height, ch, w, sqrt_eps, guide_weight, min, max);
   err = dt_opencl_write_host_to_device(devid, out_host, out, width, height, sizeof(float));
 
@@ -601,16 +679,23 @@ error:
   dt_free_align(guide_host);
   dt_free_align(in_host);
   dt_free_align(out_host);
+  return err;
 }
 
 
-void guided_filter_cl(int devid, cl_mem guide, cl_mem in, cl_mem out, const int width, const int height,
+void guided_filter_cl(int devid,
+                      cl_mem guide,
+                      cl_mem in,
+                      cl_mem out,
+                      const int width,
+                      const int height,
                       const int ch,
                       const int w,              // window size
                       const float sqrt_eps,     // regularization parameter
                       const float guide_weight, // to balance the amplitudes in the guiding image and the input
                                                 // image
-                      const float min, const float max)
+                      const float min,
+                      const float max)
 {
   assert(ch >= 3);
   assert(w >= 1);
@@ -618,13 +703,18 @@ void guided_filter_cl(int devid, cl_mem guide, cl_mem in, cl_mem out, const int 
   // estimate required memory for OpenCL code path with a safety factor of 1.25
   const gboolean fits = dt_opencl_image_fits_device(devid, width, height, sizeof(float), 18.0f * 1.25f, 0);
 
-  int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
+  cl_int err =  DT_OPENCL_DEFAULT_ERROR;
   if(fits)
-    err = guided_filter_cl_impl(devid, guide, in, out, width, height, ch, w, sqrt_eps, guide_weight, min, max);
+  {
+    err = _guided_filter_cl_impl(devid, guide, in, out, width, height, ch, w, sqrt_eps, guide_weight, min, max);
+    if(err != CL_SUCCESS)
+      dt_print(DT_DEBUG_OPENCL, "[guided filter] opencl error %s\n", cl_errstr(err));
+  }
   if(err != CL_SUCCESS)
   {
-    dt_print(DT_DEBUG_OPENCL, "[guided filter] fall back to cpu implementation due to insufficient gpu memory\n");
-    guided_filter_cl_fallback(devid, guide, in, out, width, height, ch, w, sqrt_eps, guide_weight, min, max);
+    err = _guided_filter_cl_fallback(devid, guide, in, out, width, height, ch, w, sqrt_eps, guide_weight, min, max);
+    if(err != CL_SUCCESS)
+      dt_print(DT_DEBUG_OPENCL, "[guided filter] opencl cpu fallback error %s\n", cl_errstr(err));
   }
 }
 

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -1438,23 +1438,14 @@ int dt_interpolation_resample_cl(const struct dt_interpolation *itor,
                             CLLOCAL(hmaxtaps * sizeof(int)),
                             CLLOCAL(vblocksize * 4 * sizeof(float)));
   err = dt_opencl_enqueue_kernel_2d_with_local(devid, kernel, sizes, local);
-  if(err != CL_SUCCESS) goto error;
-
-  dt_opencl_release_mem_object(dev_hindex);
-  dt_opencl_release_mem_object(dev_hlength);
-  dt_opencl_release_mem_object(dev_hkernel);
-  dt_opencl_release_mem_object(dev_hmeta);
-  dt_opencl_release_mem_object(dev_vindex);
-  dt_opencl_release_mem_object(dev_vlength);
-  dt_opencl_release_mem_object(dev_vkernel);
-  dt_opencl_release_mem_object(dev_vmeta);
-  dt_free_align(hlength);
-  dt_free_align(vlength);
-
-  _show_2_times(&start, &mid, "resample_cl");
-  return CL_SUCCESS;
 
 error:
+  if(err == CL_SUCCESS)
+    _show_2_times(&start, &mid, "resample_cl");
+  else
+    dt_print_pipe(DT_DEBUG_OPENCL, "interpolation_resample_cl", NULL, NULL, roi_in, roi_out,
+      "Error: %s\n", cl_errstr(err));
+
   dt_opencl_release_mem_object(dev_hindex);
   dt_opencl_release_mem_object(dev_hlength);
   dt_opencl_release_mem_object(dev_hkernel);
@@ -1465,8 +1456,6 @@ error:
   dt_opencl_release_mem_object(dev_vmeta);
   dt_free_align(hlength);
   dt_free_align(vlength);
-  dt_print_pipe(DT_DEBUG_OPENCL, "interpolation_resample_cl", NULL, NULL, roi_in, roi_out,
-      "Error: %s\n", cl_errstr(err));
   return err;
 }
 

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -1445,10 +1445,7 @@ cl_int dt_ioppr_build_iccprofile_params_cl(const dt_iop_order_iccprofile_info_t 
     dev_profile_lut = dt_opencl_copy_host_to_device(devid, profile_lut_cl, 256, 256 * 6,
                                                     sizeof(float));
     if(dev_profile_lut == NULL)
-    {
       err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-      goto cleanup;
-    }
   }
   else
   {
@@ -1457,10 +1454,7 @@ cl_int dt_ioppr_build_iccprofile_params_cl(const dt_iop_order_iccprofile_info_t 
     dev_profile_lut = dt_opencl_copy_host_to_device(devid, profile_lut_cl, 1, 1 * 6,
                                                     sizeof(float));
     if(dev_profile_lut == NULL)
-    {
       err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-      goto cleanup;
-    }
   }
 
 cleanup:
@@ -1528,7 +1522,7 @@ gboolean dt_ioppr_transform_image_colorspace_cl
 
   const size_t ch = 4;
   float *src_buffer = NULL;
-  int in_place = (dev_img_in == dev_img_out);
+  const gboolean in_place = (dev_img_in == dev_img_out);
 
   int kernel_transform = 0;
   cl_mem dev_tmp = NULL;
@@ -1650,8 +1644,6 @@ gboolean dt_ioppr_transform_image_colorspace_cl
 
     err = dt_opencl_write_host_to_device(devid, src_buffer, dev_img_out,
                                          width, height, ch * sizeof(float));
-    if(err != CL_SUCCESS)
-      goto cleanup;
   }
 
 cleanup:
@@ -1659,18 +1651,15 @@ cleanup:
     dt_print(DT_DEBUG_OPENCL,
              "[dt_ioppr_transform_image_colorspace_cl] had error: %s\n", cl_errstr(err));
 
-  if(src_buffer)
-    dt_free_align(src_buffer);
+  dt_free_align(src_buffer);
   if(dev_tmp && in_place)
     dt_opencl_release_mem_object(dev_tmp);
-  if(dev_profile_info)
-    dt_opencl_release_mem_object(dev_profile_info);
-  if(dev_lut)
-    dt_opencl_release_mem_object(dev_lut);
+  dt_opencl_release_mem_object(dev_profile_info);
+  dt_opencl_release_mem_object(dev_lut);
   if(lut_cl)
     free(lut_cl);
 
-  return (err == CL_SUCCESS) ? TRUE : FALSE;
+  return (err == CL_SUCCESS);
 }
 
 gboolean dt_ioppr_transform_image_colorspace_rgb_cl
@@ -1854,8 +1843,6 @@ gboolean dt_ioppr_transform_image_colorspace_rgb_cl
 
     err = dt_opencl_write_host_to_device(devid, src_buffer_out, dev_img_out,
                                          width, height, ch * sizeof(float));
-    if(err != CL_SUCCESS)
-      goto cleanup;
   }
 
 cleanup:
@@ -1863,30 +1850,20 @@ cleanup:
     dt_print(DT_DEBUG_OPENCL,
              "[dt_ioppr_transform_image_colorspace_rgb_cl] had error: %s\n", cl_errstr(err));
 
-  if(src_buffer_in)
-    dt_free_align(src_buffer_in);
-  if(src_buffer_out)
-    dt_free_align(src_buffer_out);
-  if(dev_tmp && in_place)
-    dt_opencl_release_mem_object(dev_tmp);
+  dt_free_align(src_buffer_in);
+  dt_free_align(src_buffer_out);
 
-  if(dev_profile_info_from)
-    dt_opencl_release_mem_object(dev_profile_info_from);
-  if(dev_lut_from)
-    dt_opencl_release_mem_object(dev_lut_from);
-  if(lut_from_cl)
-    free(lut_from_cl);
-
-  if(dev_profile_info_to)
-    dt_opencl_release_mem_object(dev_profile_info_to);
-  if(dev_lut_to)
-    dt_opencl_release_mem_object(dev_lut_to);
-  if(lut_to_cl)
-    free(lut_to_cl);
-
+  dt_opencl_release_mem_object(dev_profile_info_from);
+  dt_opencl_release_mem_object(dev_lut_from);
+  dt_opencl_release_mem_object(dev_profile_info_to);
+  dt_opencl_release_mem_object(dev_lut_to);
   dt_opencl_release_mem_object(matrix_cl);
 
-  return (err == CL_SUCCESS) ? TRUE : FALSE;
+  if(dev_tmp && in_place) dt_opencl_release_mem_object(dev_tmp);
+  if(lut_from_cl) free(lut_from_cl);
+  if(lut_to_cl) free(lut_to_cl);
+
+  return (err == CL_SUCCESS);
 }
 #endif
 

--- a/src/common/locallaplaciancl.c
+++ b/src/common/locallaplaciancl.c
@@ -126,11 +126,9 @@ cl_int dt_local_laplacian_cl(
     cl_mem input,               // input buffer in some Labx or yuvx format
     cl_mem output)              // output buffer with colour
 {
-  cl_int err = -666;
+  if(b->bwidth <= 1 || b->bheight <= 1) return DT_OPENCL_DEFAULT_ERROR;
 
-  if(b->bwidth <= 1 || b->bheight <= 1) return err;
-
-  err = dt_opencl_enqueue_kernel_2d_args(b->devid, b->global->kernel_pad_input, b->bwidth, b->bheight,
+  cl_int err = dt_opencl_enqueue_kernel_2d_args(b->devid, b->global->kernel_pad_input, b->bwidth, b->bheight,
     CLARG(input), CLARG(b->dev_padded[0]), CLARG(b->width), CLARG(b->height), CLARG(b->max_supp), CLARG(b->bwidth),
     CLARG(b->bheight));
   if(err != CL_SUCCESS) goto error;
@@ -184,12 +182,10 @@ cl_int dt_local_laplacian_cl(
   // read back processed L channel and copy colours:
   err = dt_opencl_enqueue_kernel_2d_args(b->devid, b->global->kernel_write_back, b->width, b->height,
     CLARG(input), CLARG(b->dev_output[0]), CLARG(output), CLARG(b->max_supp), CLARG(b->width), CLARG(b->height));
-  if(err != CL_SUCCESS) goto error;
-
-  return CL_SUCCESS;
 
 error:
-  dt_print(DT_DEBUG_OPENCL, "[local laplacian cl] couldn't enqueue kernel! %s\n", cl_errstr(err));
+  if(err != CL_SUCCESS)
+    dt_print(DT_DEBUG_OPENCL, "[local laplacian cl] error %s\n", cl_errstr(err));
   return err;
 }
 

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -791,7 +791,7 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self,
   }
   const int iwidth  = p->scharr.roi.width;
   const int iheight = p->scharr.roi.height;
-  dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_OPENCL,
+  dt_print_pipe(DT_DEBUG_PIPE,
        "refine_detail_mask on GPU",
        piece->pipe, self, roi_in, roi_out, "\n");
 

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2664,10 +2664,12 @@ restart:
   dt_iop_buffer_dsc_t _out_format = { 0 };
   dt_iop_buffer_dsc_t *out_format = &_out_format;
 
+#ifdef HAVE_OPENCL
   if(pipe->devid >= 0)
     dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe starting CL", pipe, NULL, &roi, &roi, "device=%i (%s)\n",
       pipe->devid, darktable.opencl->dev[pipe->devid].cname);
   else
+#endif
     dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe starting on CPU", pipe, NULL, &roi, &roi, "\n");
 
   // run pixelpipe recursively and get error status

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1856,8 +1856,8 @@ static gboolean _dev_pixelpipe_process_rec(
               for(int i = 0; i < 100; i++)
               {
                 if(success)
-                  success = module->process_cl(module, piece, cl_mem_input, *cl_mem_output,
-                                               &roi_in, roi_out);
+                  success = (module->process_cl(module, piece, cl_mem_input, *cl_mem_output,
+                                               &roi_in, roi_out)) >= CL_SUCCESS;
               }
               if(success)
               {
@@ -1885,8 +1885,16 @@ static gboolean _dev_pixelpipe_process_rec(
             dt_opencl_dump_pipe_pfm(module->op, pipe->devid, cl_mem_input,
                                     TRUE, dt_dev_pixelpipe_type_to_str(piece->pipe->type));
 
-          success_opencl = module->process_cl(module, piece, cl_mem_input, *cl_mem_output,
+          const int err = module->process_cl(module, piece, cl_mem_input, *cl_mem_output,
                                               &roi_in, roi_out);
+          success_opencl = err >= CL_SUCCESS;
+
+          if(!success_opencl)
+            dt_print_pipe(DT_DEBUG_OPENCL,
+              "Error: process_CL", piece->pipe, module, &roi_in, roi_out,
+              "device=%i (%s), %s\n",
+              pipe->devid, darktable.opencl->dev[pipe->devid].cname, cl_errstr(err));
+
           if(success_opencl && pfm_dump)
             dt_opencl_dump_pipe_pfm(module->op, pipe->devid, *cl_mem_output,
                                     FALSE, dt_dev_pixelpipe_type_to_str(piece->pipe->type));
@@ -1979,10 +1987,9 @@ static gboolean _dev_pixelpipe_process_rec(
         if(cl_mem_input != NULL)
         {
           /* copy back to CPU buffer, then clean unneeded buffer */
-          const cl_int err = dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input,
+          if(dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input,
                                                            roi_in.width, roi_in.height,
-                                                           in_bpp);
-          if(err != CL_SUCCESS)
+                                                           in_bpp) != CL_SUCCESS)
           {
             dt_print_pipe(DT_DEBUG_OPENCL,
               "pixelpipe process CL", pipe, module, &roi_in, roi_out, "%s\n",
@@ -2030,8 +2037,16 @@ static gboolean _dev_pixelpipe_process_rec(
            meaningful messages in case of error */
         if(success_opencl)
         {
-          success_opencl = module->process_tiling_cl(module, piece, input, *output,
+          const int err = module->process_tiling_cl(module, piece, input, *output,
                                                      &roi_in, roi_out, in_bpp);
+          success_opencl = err >= CL_SUCCESS;
+
+          if(!success_opencl)
+            dt_print_pipe(DT_DEBUG_OPENCL,
+              "Error: process_tiling_CL", piece->pipe, module, &roi_in, roi_out,
+              "device=%i (%s), %s\n",
+              pipe->devid, darktable.opencl->dev[pipe->devid].cname, cl_errstr(err));
+
           pixelpipe_flow |= (PIXELPIPE_FLOW_PROCESSED_ON_GPU
                              | PIXELPIPE_FLOW_PROCESSED_WITH_TILING);
           pixelpipe_flow &= ~(PIXELPIPE_FLOW_PROCESSED_ON_CPU);
@@ -2147,11 +2162,11 @@ static gboolean _dev_pixelpipe_process_rec(
           if(cl_mem_input != NULL)
           {
             /* copy input to host memory, so we can find it in cache */
-            const cl_int err = dt_opencl_copy_device_to_host(pipe->devid, input,
-                                                             cl_mem_input,
-                                                             roi_in.width,
-                                                             roi_in.height, in_bpp);
-            if(err != CL_SUCCESS)
+            if(dt_opencl_copy_device_to_host(pipe->devid, input,
+                                             cl_mem_input,
+                                             roi_in.width,
+                                             roi_in.height,
+                                             in_bpp) != CL_SUCCESS)
             {
               important_cl = FALSE;
               dt_print_pipe(DT_DEBUG_OPENCL,
@@ -2162,7 +2177,7 @@ static gboolean _dev_pixelpipe_process_rec(
             }
             else
             {
-              dt_print_pipe(DT_DEBUG_OPENCL,
+              dt_print_pipe(DT_DEBUG_PIPE,
                 "pixelpipe process CL", pipe, module, &roi_in, roi_out, "cl input data to host\n");
               /* success: cache line is valid now, so we will not need
                  to invalidate it later */
@@ -2209,10 +2224,9 @@ static gboolean _dev_pixelpipe_process_rec(
           /* copy back to host memory, then clean no longer needed opencl buffer.
              important info: in order to make this possible, opencl modules must
              not spoil their input buffer, even in case of errors. */
-          const cl_int err = dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input,
-                                                           roi_in.width, roi_in.height,
-                                                           in_bpp);
-          if(err != CL_SUCCESS)
+          if(dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input,
+                                           roi_in.width, roi_in.height,
+                                           in_bpp) != CL_SUCCESS)
           {
             dt_print_pipe(DT_DEBUG_OPENCL,
               "pixelpipe process CL", pipe, module, &roi_in, roi_out, "%s\n",
@@ -2247,11 +2261,9 @@ static gboolean _dev_pixelpipe_process_rec(
       /* cleanup unneeded opencl buffer, and copy back to CPU buffer */
       if(cl_mem_input != NULL)
       {
-        const cl_int err = dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input,
-                                                         roi_in.width, roi_in.height,
-                                                         in_bpp);
-
-        if(err != CL_SUCCESS)
+        if(dt_opencl_copy_device_to_host(pipe->devid, input, cl_mem_input,
+                                         roi_in.width, roi_in.height,
+                                         in_bpp) != CL_SUCCESS)
         {
           dt_print_pipe(DT_DEBUG_OPENCL,
             "pixelpipe process CL", pipe, module, &roi_in, roi_out, "%s\n",
@@ -2653,7 +2665,8 @@ restart:
   dt_iop_buffer_dsc_t *out_format = &_out_format;
 
   if(pipe->devid >= 0)
-    dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe starting CL", pipe, NULL, &roi, &roi, "device=%i\n", pipe->devid);
+    dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe starting CL", pipe, NULL, &roi, &roi, "device=%i (%s)\n",
+      pipe->devid, darktable.opencl->dev[pipe->devid].cname);
   else
     dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe starting on CPU", pipe, NULL, &roi, &roi, "\n");
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3740,7 +3740,7 @@ int process_cl(struct dt_iop_module_t *self,
     size_t region[] = { width, height, 1 };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
     if(err != CL_SUCCESS) goto error;
-    return TRUE;
+    return CL_SUCCESS;
   }
 
   float ihomograph[3][3];
@@ -3794,16 +3794,10 @@ int process_cl(struct dt_iop_module_t *self,
      CLARG(iwidth), CLARG(iheight), CLARRAY(2, iroi),
      CLARRAY(2, oroi),
      CLARG(in_scale), CLARG(out_scale), CLARRAY(2, clip), CLARG(dev_homo));
-  if(err != CL_SUCCESS) goto error;
-
-  dt_opencl_release_mem_object(dev_homo);
-  return TRUE;
 
 error:
   dt_opencl_release_mem_object(dev_homo);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_ashift] couldn't enqueue kernel! %s\n",
-           cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -5,8 +5,7 @@
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
+    (at your option) any later version
     darktable is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -479,24 +478,13 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     (devid, gd->kernel_addbuffers, 0, CLARG(dev_out), CLARG(dev_buf1));
 
   err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_addbuffers, sizes);
-  if(err != CL_SUCCESS) goto error;
-
-  dt_opencl_finish_sync_pipe(devid, piece->pipe->type);
-
-  dt_opencl_release_mem_object(dev_filter);
-  dt_opencl_release_mem_object(dev_tmp);
-  dt_opencl_release_mem_object(dev_tmp2);
-  dt_opencl_release_mem_object(dev_detail);
-  return TRUE;
 
 error:
   dt_opencl_release_mem_object(dev_filter);
   dt_opencl_release_mem_object(dev_tmp);
   dt_opencl_release_mem_object(dev_tmp2);
   dt_opencl_release_mem_object(dev_detail);
-  dt_print(DT_DEBUG_OPENCL,
-           "[opencl_atrous] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 
 #else // ======== old, memory-hungry implementation ========================================================
@@ -624,22 +612,13 @@ int process_cl(struct dt_iop_module_t *self,
 
   dt_opencl_finish_sync_pipe(devid, piece->pipe->type);
 
-  dt_opencl_release_mem_object(dev_filter);
-  dt_opencl_release_mem_object(dev_tmp);
-  for(int k = 0; k < max_scale; k++)
-    dt_opencl_release_mem_object(dev_detail[k]);
-  free(dev_detail);
-  return TRUE;
-
 error:
   dt_opencl_release_mem_object(dev_filter);
   dt_opencl_release_mem_object(dev_tmp);
   for(int k = 0; k < max_scale; k++)
     dt_opencl_release_mem_object(dev_detail[k]);
   free(dev_detail);
-  dt_print(DT_DEBUG_OPENCL,
-           "[opencl_atrous] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif // USE_NEW_CL
 

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -1410,22 +1410,14 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     CLARG(contrast), CLARG(process_saturation_vibrance), CLARG(saturation), CLARG(vibrance), CLARG(process_hlcompr),
     CLARG(hlcomp), CLARG(hlrange), CLARG(middle_grey), CLARG(inv_middle_grey), CLARG(dev_profile_info),
     CLARG(dev_profile_lut), CLARG(use_work_profile));
-  if(err != CL_SUCCESS)
-  {
-    dt_print(DT_DEBUG_ALWAYS, "[basicadj process_cl] error %i enqueue kernel\n", err);
-    goto cleanup;
-  }
 
 cleanup:
-  if(dev_gamma) dt_opencl_release_mem_object(dev_gamma);
-  if(dev_contrast) dt_opencl_release_mem_object(dev_contrast);
+  dt_opencl_release_mem_object(dev_gamma);
+  dt_opencl_release_mem_object(dev_contrast);
   dt_ioppr_free_iccprofile_params_cl(&profile_info_cl, &profile_lut_cl, &dev_profile_info, &dev_profile_lut);
 
-  if(src_buffer) dt_free_align(src_buffer);
-
-  if(err != CL_SUCCESS) dt_print(DT_DEBUG_OPENCL, "[opencl_basicadj] couldn't enqueue kernel! %s\n", cl_errstr(err));
-
-  return (err == CL_SUCCESS) ? TRUE : FALSE;
+  dt_free_align(src_buffer);
+  return err;
 }
 #endif
 

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -225,14 +225,9 @@ int process_cl(struct dt_iop_module_t *self,
     err = dt_bilateral_blur_cl(b);
     if(err != CL_SUCCESS) goto error;
     err = dt_bilateral_slice_cl(b, dev_in, dev_out, d->detail);
-    if(err != CL_SUCCESS) goto error;
-    dt_bilateral_free_cl(b);
-    return TRUE;
 error:
     dt_bilateral_free_cl(b);
-    dt_print(DT_DEBUG_OPENCL,
-             "[opencl_bilateral] couldn't enqueue kernel! %s\n", cl_errstr(err));
-    return FALSE;
+    return err;
   }
   else // mode == s_mode_local_laplacian
   {
@@ -242,10 +237,10 @@ error:
     if(!b) goto error_ll;
     if(dt_local_laplacian_cl(b, dev_in, dev_out) != CL_SUCCESS) goto error_ll;
     dt_local_laplacian_free_cl(b);
-    return TRUE;
+    return CL_SUCCESS;
 error_ll:
     dt_local_laplacian_free_cl(b);
-    return FALSE;
+    return CL_INVALID_KERNEL;
   }
 }
 #endif

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -285,17 +285,11 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dt_opencl_set_kernel_args(devid, gd->kernel_bloom_mix, 0, CLARG(dev_in), CLARG(dev_tmp1), CLARG(dev_out),
     CLARG(width), CLARG(height));
   err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_bloom_mix, sizes);
-  if(err != CL_SUCCESS) goto error;
-
-  for(int i = 0; i < NUM_BUCKETS; i++)
-    dt_opencl_release_mem_object(dev_tmp[i]);
-  return TRUE;
 
 error:
   for(int i = 0; i < NUM_BUCKETS; i++)
     dt_opencl_release_mem_object(dev_tmp[i]);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_bloom] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/blurs.c
+++ b/src/iop/blurs.c
@@ -649,8 +649,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dt_iop_blurs_params_t *p = (dt_iop_blurs_params_t *)piece->data;
   dt_iop_blurs_global_data_t *const gd = (dt_iop_blurs_global_data_t *)self->global_data;
 
-  cl_int err = DT_OPENCL_DEFAULT_ERROR;
-
+  cl_int err = DT_OPENCL_SYSMEM_ALLOCATION;
+  cl_mem kernel_cl = NULL;
   const int devid = piece->pipe->devid;
   const int width = roi_in->width;
   const int height = roi_in->height;
@@ -662,25 +662,18 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const size_t kernel_width = 2 * radius + 1;
 
   float *const restrict kernel = dt_alloc_align_float(kernel_width * kernel_width);
-  build_pixel_kernel(kernel, kernel_width, kernel_width, p);
-
-  cl_mem kernel_cl = dt_opencl_copy_host_to_device(devid, kernel, kernel_width, kernel_width, sizeof(float));
-
-  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_blurs_convolve, width, height,
-    CLARG(dev_in), CLARG(kernel_cl), CLARG(dev_out), CLARG(roi_out->width), CLARG(roi_out->height),
-    CLARG(radius));
-  if(err != CL_SUCCESS) goto error;
-
-  // cleanup and exit on success
+  if(kernel)
+  {
+    build_pixel_kernel(kernel, kernel_width, kernel_width, p);
+    kernel_cl = dt_opencl_copy_host_to_device(devid, kernel, kernel_width, kernel_width, sizeof(float));
+    if(kernel_cl)
+      err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_blurs_convolve, width, height,
+        CLARG(dev_in), CLARG(kernel_cl), CLARG(dev_out), CLARG(roi_out->width), CLARG(roi_out->height),
+        CLARG(radius));
+  }
   dt_free_align(kernel);
   dt_opencl_release_mem_object(kernel_cl);
-  return TRUE;
-
-error:
-  if(kernel) dt_free_align(kernel);
-  if(kernel_cl) dt_opencl_release_mem_object(kernel_cl);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_blurs] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 
 void init_global(dt_iop_module_so_t *module)

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -719,13 +719,9 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   // copy original input from dev_in -> dev_out as starting point
   err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, iorigin, oorigin, region);
-  if(err != CL_SUCCESS) goto error;
-
-  return TRUE;
 
 error:
-  dt_print(DT_DEBUG_OPENCL, "[opencl_borders] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -351,15 +351,6 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_lowpass_mix, width, height,
     CLARG(dev_tmp), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(saturation), CLARG(dev_cm),
     CLARG(dev_ccoeffs), CLARG(dev_lm), CLARG(dev_lcoeffs), CLARG(unbound));
-  if(err != CL_SUCCESS) goto error;
-
-  dt_opencl_release_mem_object(dev_tmp);
-  dt_opencl_release_mem_object(dev_lcoeffs);
-  dt_opencl_release_mem_object(dev_lm);
-  dt_opencl_release_mem_object(dev_ccoeffs);
-  dt_opencl_release_mem_object(dev_cm);
-
-  return TRUE;
 
 error:
   if(g) dt_gaussian_free_cl(g);
@@ -370,8 +361,7 @@ error:
   dt_opencl_release_mem_object(dev_lm);
   dt_opencl_release_mem_object(dev_ccoeffs);
   dt_opencl_release_mem_object(dev_cm);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_lowpass] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 
 void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -432,18 +432,11 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_channelmixer, width, height,
     CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(operation_mode), CLARG(dev_hsl_matrix),
     CLARG(dev_rgb_matrix));
-  if(err != CL_SUCCESS) goto error;
-
-  dt_opencl_release_mem_object(dev_hsl_matrix);
-  dt_opencl_release_mem_object(dev_rgb_matrix);
-
-  return TRUE;
 
 error:
   dt_opencl_release_mem_object(dev_hsl_matrix);
   dt_opencl_release_mem_object(dev_rgb_matrix);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_channelmixer] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1129,7 +1129,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
         crkernel = gd->kernel_clip_rotate_lanczos3;
         break;
       default:
-        return FALSE;
+        return err;
     }
 
     int roi[2] = { roi_in->x, roi_in->y };
@@ -1160,14 +1160,10 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
       CLARG(roi_in->width), CLARG(roi_in->height), CLARG(roi), CLARG(roo), CLARG(roi_in->scale), CLARG(roi_out->scale),
       CLARG(d->flip), CLARG(t), CLARG(k), CLARG(m), CLARG(k_space), CLARG(ka), CLARG(maa), CLARG(mbb));
     err = dt_opencl_enqueue_kernel_2d(devid, crkernel, sizes);
-    if(err != CL_SUCCESS) goto error;
   }
 
-  return TRUE;
-
 error:
-  dt_print(DT_DEBUG_OPENCL, "[opencl_clipping] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/colisa.c
+++ b/src/iop/colisa.c
@@ -148,21 +148,13 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     CLARG(height), CLARG(saturation), CLARG(dev_cm), CLARG(dev_ccoeffs), CLARG(dev_lm), CLARG(dev_lcoeffs));
 
   err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_colisa, sizes);
-  if(err != CL_SUCCESS) goto error;
-
-  dt_opencl_release_mem_object(dev_lcoeffs);
-  dt_opencl_release_mem_object(dev_lm);
-  dt_opencl_release_mem_object(dev_ccoeffs);
-  dt_opencl_release_mem_object(dev_cm);
-  return TRUE;
 
 error:
   dt_opencl_release_mem_object(dev_lcoeffs);
   dt_opencl_release_mem_object(dev_lm);
   dt_opencl_release_mem_object(dev_ccoeffs);
   dt_opencl_release_mem_object(dev_cm);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_colisa] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -828,7 +828,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
         CLARG(grey));
       err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_colorbalance, sizes);
       if(err != CL_SUCCESS) goto error;
-      return TRUE;
+      return CL_SUCCESS;
 
       break;
     }
@@ -856,7 +856,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
         CLARG(grey), CLARG(saturation_out));
       err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_colorbalance_lgg, sizes);
       if(err != CL_SUCCESS) goto error;
-      return TRUE;
+      return CL_SUCCESS;
 
       break;
     }
@@ -884,15 +884,14 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
         CLARG(grey), CLARG(saturation_out));
       err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_colorbalance_cdl, sizes);
       if(err != CL_SUCCESS) goto error;
-      return TRUE;
+      return CL_SUCCESS;
 
       break;
     }
   }
 
 error:
-  dt_print(DT_DEBUG_OPENCL, "[opencl_colorbalance] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -562,19 +562,10 @@ int process_cl(struct dt_iop_module_t *self,
                                          CLARG(width), CLARG(height),
                                          CLARG(num_patches),
                                          CLARG(dev_params));
-  if(err != CL_SUCCESS) goto error;
-
-  dt_opencl_release_mem_object(dev_params);
-  free(params);
-  return TRUE;
-
 error:
   free(params);
   dt_opencl_release_mem_object(dev_params);
-  dt_print(DT_DEBUG_OPENCL,
-           "[opencl_colorchecker] couldn't enqueue kernel! %s\n",
-           cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -255,19 +255,10 @@ int process_cl(struct dt_iop_module_t *self,
   const float offset[4] = { 0.0f, data->a_offset, data->b_offset, 0.0f };
   const int unbound = data->unbound;
 
-  const cl_int err =
-    dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_colorcontrast, width, height,
+  return dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_colorcontrast, width, height,
                                      CLARG(dev_in), CLARG(dev_out),
                                      CLARG(width), CLARG(height),
                                      CLARG(scale), CLARG(offset), CLARG(unbound));
-
-  if(err != CL_SUCCESS) goto error;
-  return TRUE;
-
-error:
-  dt_print(DT_DEBUG_OPENCL,
-           "[opencl_colorcontrast] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
 }
 #endif
 

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -164,22 +164,13 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dt_iop_colorcorrection_data_t *d = (dt_iop_colorcorrection_data_t *)piece->data;
   dt_iop_colorcorrection_global_data_t *gd = (dt_iop_colorcorrection_global_data_t *)self->global_data;
 
-  cl_int err = DT_OPENCL_DEFAULT_ERROR;
   const int devid = piece->pipe->devid;
-
   const int width = roi_out->width;
   const int height = roi_out->height;
 
-  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_colorcorrection, width, height,
+  return dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_colorcorrection, width, height,
     CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(d->saturation), CLARG(d->a_scale),
     CLARG(d->a_base), CLARG(d->b_scale), CLARG(d->b_base));
-  if(err != CL_SUCCESS) goto error;
-
-  return TRUE;
-
-error:
-  dt_print(DT_DEBUG_OPENCL, "[opencl_colorcorrection] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
 }
 #endif
 

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -690,7 +690,7 @@ int process_cl(struct dt_iop_module_t *self,
     size_t region[] = { roi_in->width, roi_in->height, 1 };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
     if(err != CL_SUCCESS) goto error;
-    return TRUE;
+    return CL_SUCCESS;
   }
 
   dev_m = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 9, cmat);
@@ -713,16 +713,6 @@ int process_cl(struct dt_iop_module_t *self,
                                          CLARG(dev_m), CLARG(dev_l), CLARG(dev_r),
                                          CLARG(dev_g), CLARG(dev_b),
                                          CLARG(blue_mapping), CLARG(dev_coeffs));
-  if(err != CL_SUCCESS) goto error;
-  dt_opencl_release_mem_object(dev_m);
-  dt_opencl_release_mem_object(dev_l);
-  dt_opencl_release_mem_object(dev_r);
-  dt_opencl_release_mem_object(dev_g);
-  dt_opencl_release_mem_object(dev_b);
-  dt_opencl_release_mem_object(dev_coeffs);
-
-  return TRUE;
-
 error:
   dt_opencl_release_mem_object(dev_m);
   dt_opencl_release_mem_object(dev_l);
@@ -730,9 +720,7 @@ error:
   dt_opencl_release_mem_object(dev_g);
   dt_opencl_release_mem_object(dev_b);
   dt_opencl_release_mem_object(dev_coeffs);
-  dt_print(DT_DEBUG_OPENCL,
-           "[opencl_colorin] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -188,7 +188,6 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dt_iop_colorize_data_t *data = (dt_iop_colorize_data_t *)piece->data;
   dt_iop_colorize_global_data_t *gd = (dt_iop_colorize_global_data_t *)self->global_data;
 
-  cl_int err = DT_OPENCL_DEFAULT_ERROR;
   const int devid = piece->pipe->devid;
   const int width = roi_in->width;
   const int height = roi_in->height;
@@ -198,14 +197,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const float b = data->b;
   const float mix = data->mix;
 
-  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_colorize, width, height,
+  return dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_colorize, width, height,
     CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(mix), CLARG(L), CLARG(a), CLARG(b));
-  if(err != CL_SUCCESS) goto error;
-  return TRUE;
-
-error:
-  dt_print(DT_DEBUG_OPENCL, "[opencl_colorize] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
 }
 #endif
 

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -704,24 +704,12 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_mapping, width, height,
       CLARG(dev_in), CLARG(dev_tmp), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(data->n), CLARG(dev_target_mean),
       CLARG(dev_source_mean), CLARG(dev_var_ratio), CLARG(dev_mapio));
-    if(err != CL_SUCCESS) goto error;
-
-    dt_opencl_release_mem_object(dev_tmp);
-    dt_opencl_release_mem_object(dev_target_hist);
-    dt_opencl_release_mem_object(dev_source_ihist);
-    dt_opencl_release_mem_object(dev_target_mean);
-    dt_opencl_release_mem_object(dev_source_mean);
-    dt_opencl_release_mem_object(dev_var_ratio);
-    dt_opencl_release_mem_object(dev_mapio);
-    return TRUE;
   }
   else
   {
     size_t origin[] = { 0, 0, 0 };
     size_t region[] = { width, height, 1 };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
-    if(err != CL_SUCCESS) goto error;
-    return TRUE;
   }
 
 error:
@@ -733,8 +721,7 @@ error:
   dt_opencl_release_mem_object(dev_source_mean);
   dt_opencl_release_mem_object(dev_var_ratio);
   dt_opencl_release_mem_object(dev_mapio);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_colormapping] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -336,7 +336,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     size_t region[] = { roi_in->width, roi_in->height, 1 };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
     if(err != CL_SUCCESS) goto error;
-    return TRUE;
+    return CL_SUCCESS;
   }
 
 
@@ -356,14 +356,6 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_colorout, width, height,
     CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(dev_m), CLARG(dev_r), CLARG(dev_g),
     CLARG(dev_b), CLARG(dev_coeffs));
-  if(err != CL_SUCCESS) goto error;
-  dt_opencl_release_mem_object(dev_m);
-  dt_opencl_release_mem_object(dev_r);
-  dt_opencl_release_mem_object(dev_g);
-  dt_opencl_release_mem_object(dev_b);
-  dt_opencl_release_mem_object(dev_coeffs);
-
-  return TRUE;
 
 error:
   dt_opencl_release_mem_object(dev_m);
@@ -371,8 +363,7 @@ error:
   dt_opencl_release_mem_object(dev_g);
   dt_opencl_release_mem_object(dev_b);
   dt_opencl_release_mem_object(dev_coeffs);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_colorout] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -1098,13 +1098,9 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     dt_iop_gui_leave_critical_section(self);
   }
 
-  dt_iop_colorreconstruct_bilateral_free_cl(b);
-  return TRUE;
-
 error:
   dt_iop_colorreconstruct_bilateral_free_cl(b);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_colorreconstruction] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -594,18 +594,11 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(d->channel), CLARG(dev_L), CLARG(dev_a),
     CLARG(dev_b));
 
-  if(err != CL_SUCCESS) goto error;
-  dt_opencl_release_mem_object(dev_L);
-  dt_opencl_release_mem_object(dev_a);
-  dt_opencl_release_mem_object(dev_b);
-  return TRUE;
-
 error:
   dt_opencl_release_mem_object(dev_L);
   dt_opencl_release_mem_object(dev_a);
   dt_opencl_release_mem_object(dev_b);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_colorzones] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -393,15 +393,8 @@ int process_cl(struct dt_iop_module_t *self,
 {
   size_t origin[] = { 0, 0, 0 };
   size_t region[] = { roi_out->width, roi_out->height, 1 };
-  cl_int err = dt_opencl_enqueue_copy_image(piece->pipe->devid, dev_in, dev_out,
+  return dt_opencl_enqueue_copy_image(piece->pipe->devid, dev_in, dev_out,
                                             origin, origin, region);
-  if(err != CL_SUCCESS) goto error;
-
-  return TRUE;
-
-error:
-  dt_print(DT_DEBUG_OPENCL, "[opencl_crop] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
 }
 #endif
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -810,7 +810,7 @@ int process_cl(
      demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_COLOR )
   {
     if(!process_default_cl(self, piece, dev_in, dev_out, roi_in, roi_out, demosaicing_method))
-      return FALSE;
+      return DT_OPENCL_PROCESS_CL;
   }
   else if((demosaicing_method & ~DT_DEMOSAIC_DUAL) == DT_IOP_DEMOSAIC_RCD)
   {
@@ -822,19 +822,19 @@ int process_cl(
     else
     {
      if(!process_rcd_cl(self, piece, dev_in, dev_out, roi_in, roi_out, TRUE))
-       return FALSE;
+       return DT_OPENCL_PROCESS_CL;
     }
   }
   else if(demosaicing_method == DT_IOP_DEMOSAIC_VNG4 || demosaicing_method == DT_IOP_DEMOSAIC_VNG)
   {
     if(!process_vng_cl(self, piece, dev_in, dev_out, roi_in, roi_out, TRUE, FALSE))
-      return FALSE;
+      return DT_OPENCL_PROCESS_CL;
   }
   else if((demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN || demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN_3) &&
     !(qual_flags & DT_DEMOSAIC_FULL_SCALE))
   {
     if(!process_vng_cl(self, piece, dev_in, dev_out, roi_in, roi_out, TRUE, qual_flags & DT_DEMOSAIC_ONLY_VNG_LINEAR))
-      return FALSE;
+      return DT_OPENCL_PROCESS_CL;
   }
   else if(((demosaicing_method & ~DT_DEMOSAIC_DUAL) == DT_IOP_DEMOSAIC_MARKESTEIJN ) ||
           ((demosaicing_method & ~DT_DEMOSAIC_DUAL) == DT_IOP_DEMOSAIC_MARKESTEIJN_3))
@@ -847,13 +847,13 @@ int process_cl(
     else
     {
       if(!process_markesteijn_cl(self, piece, dev_in, dev_out, roi_in, roi_out, TRUE))
-        return FALSE;
+        return DT_OPENCL_PROCESS_CL;
     }
   }
   else
   {
     dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] demosaicing method %d not yet supported by opencl code\n", demosaicing_method);
-    return FALSE;
+    return DT_OPENCL_PROCESS_CL;
   }
 
   if(!dual)
@@ -884,7 +884,7 @@ int process_cl(
   dt_opencl_release_mem_object(high_image);
   dt_opencl_release_mem_object(low_image);
 
-  return retval;
+  return retval ? CL_SUCCESS : DT_OPENCL_PROCESS_CL;
 }
 #endif
 

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -518,12 +518,8 @@ int process_cl(struct dt_iop_module_t *self,
   if(err != CL_SUCCESS) goto error;
   for(int k = 0; k < 3; k++) piece->pipe->dsc.processed_maximum[k] *= d->scale;
 
-  return TRUE;
-
 error:
-  dt_print(DT_DEBUG_OPENCL,
-           "[opencl_exposure] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -591,16 +591,11 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(dynamic_range), CLARG(shadows_range),
     CLARG(grey), CLARG(dev_table), CLARG(diff_table), CLARG(contrast), CLARG(power), CLARG(preserve_color),
     CLARG(saturation));
-  if(err != CL_SUCCESS) goto error;
-  dt_opencl_release_mem_object(dev_table);
-  dt_opencl_release_mem_object(diff_table);
-  return TRUE;
 
 error:
   dt_opencl_release_mem_object(dev_table);
   dt_opencl_release_mem_object(diff_table);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_filmic] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2569,7 +2569,7 @@ int process_cl(struct dt_iop_module_t *self,
       err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_filmic_show_mask, sizes);
       dt_opencl_release_mem_object(mask);
       dt_ioppr_free_iccprofile_params_cl(&profile_info_cl, &profile_lut_cl, &dev_profile_info, &dev_profile_lut);
-      return TRUE;
+      return err;
     }
   }
 
@@ -2671,7 +2671,7 @@ int process_cl(struct dt_iop_module_t *self,
   dt_opencl_release_mem_object(output_matrix_cl);
   dt_opencl_release_mem_object(export_input_matrix_cl);
   dt_opencl_release_mem_object(export_output_matrix_cl);
-  return TRUE;
+  return CL_SUCCESS;
 
 error:
   dt_ioppr_free_iccprofile_params_cl(&profile_info_cl, &profile_lut_cl, &dev_profile_info, &dev_profile_lut);
@@ -2685,8 +2685,7 @@ error:
   dt_opencl_release_mem_object(export_input_matrix_cl);
   dt_opencl_release_mem_object(export_output_matrix_cl);
   dt_opencl_release_mem_object(clipped);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_filmicrgb] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -104,23 +104,14 @@ int process_cl(struct dt_iop_module_t *self,
   {
     dt_print(DT_DEBUG_OPENCL,
              "[opencl_finalscale] upscaling not yet supported by opencl code\n");
-    return FALSE;
+    return DT_OPENCL_PROCESS_CL;
   }
 
   const int devid = piece->pipe->devid;
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_IMAGEIO,
                 "clip_and_zoom_roi CL",
                 piece->pipe, self, roi_in, roi_out, "device=%i\n", devid);
-  const cl_int err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_in, roi_out, roi_in);
-  if(err != CL_SUCCESS)
-  {
-    dt_print(DT_DEBUG_OPENCL,
-             "[opencl_finalscale] couldn't `dt_iop_clip_and_zoom_roi_cl`: %s\n",
-             cl_errstr(err));
-    return FALSE;
-  }
-
-  return TRUE;
+  return dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_in, roi_out, roi_in);
 }
 #endif
 

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -403,22 +403,14 @@ int process_cl(struct dt_iop_module_t *self,
 {
   const dt_iop_flip_data_t *data = (dt_iop_flip_data_t *)piece->data;
   const dt_iop_flip_global_data_t *gd = (dt_iop_flip_global_data_t *)self->global_data;
-  cl_int err = DT_OPENCL_DEFAULT_ERROR;
 
   const int devid = piece->pipe->devid;
   const int width = roi_in->width;
   const int height = roi_in->height;
   const int orientation = data->orientation;
 
-  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_flip, width, height,
+  return dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_flip, width, height,
     CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(orientation));
-
-  if(err != CL_SUCCESS) goto error;
-  return TRUE;
-
-error:
-  dt_print(DT_DEBUG_OPENCL, "[opencl_flip] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
 }
 #endif
 

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -526,15 +526,14 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     dt_bilateral_free_cl(b);
   }
 
-  return TRUE;
+  return CL_SUCCESS;
 
 error:
   if(b) dt_bilateral_free_cl(b);
   dt_opencl_release_mem_object(dev_m);
   dt_opencl_release_mem_object(dev_r);
   dt_free_align(maximum);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_global_tonemap] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -974,7 +974,6 @@ int process_cl(struct dt_iop_module_t *self,
   dt_iop_graduatednd_data_t *data = (dt_iop_graduatednd_data_t *)piece->data;
   dt_iop_graduatednd_global_data_t *gd = (dt_iop_graduatednd_global_data_t *)self->global_data;
 
-  cl_int err = DT_OPENCL_DEFAULT_ERROR;
   const int devid = piece->pipe->devid;
   const int width = roi_in->width;
   const int height = roi_in->height;
@@ -1011,15 +1010,9 @@ int process_cl(struct dt_iop_module_t *self,
 
   int kernel = density > 0 ? gd->kernel_graduatedndp : gd->kernel_graduatedndm;
 
-  err = dt_opencl_enqueue_kernel_2d_args(devid, kernel, width, height,
+  return dt_opencl_enqueue_kernel_2d_args(devid, kernel, width, height,
     CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARRAY(4, data->color), CLARG(density),
     CLARG(length_base), CLARG(length_inc_x), CLARG(length_inc_y));
-  if(err != CL_SUCCESS) goto error;
-  return TRUE;
-
-error:
-  dt_print(DT_DEBUG_OPENCL, "[opencl_graduatednd] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
 }
 #endif
 

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -222,7 +222,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
   if(old_version == 1 && new_version == 2)
   {
     //FIXME: copy from old version and add compatibility flag
-    
+
   }
   return 0;
 }
@@ -830,7 +830,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dt_opencl_release_mem_object(trans_map);
   dt_opencl_release_mem_object(trans_map_filtered);
 
-  return TRUE;
+  return CL_SUCCESS;
 }
 #endif
 

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -513,7 +513,7 @@ int process_cl(struct dt_iop_module_t *self,
 
         dt_opencl_release_mem_object(dev_clips);
         dt_opencl_release_mem_object(dev_xtrans);
-        return TRUE;
+        return CL_SUCCESS;
       }
     }
   }
@@ -601,15 +601,12 @@ int process_cl(struct dt_iop_module_t *self,
   }
 
   dt_opencl_release_mem_object(dev_xtrans);
-  return TRUE;
+  return CL_SUCCESS;
 
   error:
   dt_opencl_release_mem_object(dev_clips);
   dt_opencl_release_mem_object(dev_xtrans);
-  dt_print_pipe(DT_DEBUG_OPENCL | DT_DEBUG_PIPE,
-    "opencl_highlights error", piece->pipe, self, roi_in, roi_out,
-    "error: %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -238,19 +238,12 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dt_opencl_set_kernel_args(devid, gd->kernel_highpass_mix, 0, CLARG(dev_in), CLARG(dev_tmp), CLARG(dev_out),
     CLARG(width), CLARG(height), CLARG(contrast_scale));
   err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_highpass_mix, sizes);
-  if(err != CL_SUCCESS) goto error;
-
-  dt_opencl_release_mem_object(dev_m);
-  dt_opencl_release_mem_object(dev_tmp);
-  free(mat);
-  return TRUE;
 
 error:
   dt_opencl_release_mem_object(dev_m);
   dt_opencl_release_mem_object(dev_tmp);
   free(mat);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_highpass] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/hlreconstruct/laplacian.c
+++ b/src/iop/hlreconstruct/laplacian.c
@@ -920,8 +920,6 @@ error:
   if(LF_even) dt_opencl_release_mem_object(LF_even);
   if(LF_odd) dt_opencl_release_mem_object(LF_odd);
   if(HF) dt_opencl_release_mem_object(HF);
-
-  dt_print(DT_DEBUG_OPENCL, "[opencl_highlights] couldn't enqueue kernel! %s\n", cl_errstr(err));
   return err;
 }
 

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -398,7 +398,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   }
 
   dev_color = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3, film_rgb_f);
-  if(dev_color == NULL) goto error;
+  if(dev_color == NULL) goto finish;
 
   const int width = roi_in->width;
   const int height = roi_in->height;
@@ -406,16 +406,11 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   err = dt_opencl_enqueue_kernel_2d_args(devid, kernel, width, height,
     CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(dev_color), CLARG(filters), CLARG(roi_out->x),
     CLARG(roi_out->y));
-  if(err != CL_SUCCESS) goto error;
 
+finish:
   dt_opencl_release_mem_object(dev_color);
   for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
-  return TRUE;
-
-error:
-  dt_opencl_release_mem_object(dev_color);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_invert] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2016-2021 darktable developers.
+    Copyright (C) 2016-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by
@@ -189,7 +189,10 @@ DEFAULT(void, process_tiling, struct dt_iop_module_t *self, struct dt_dev_pixelp
                               const struct dt_iop_roi_t *const roi_out, const int bpp);
 
 #ifdef HAVE_OPENCL
-/** the opencl equivalent of process(). */
+/** the opencl equivalent of process().
+ *   Both process_xx_cl() functions return a CL error code with CL_SUCCESS signalling ok.
+ *   Please note: until 4.4 this int was in fact used as a gboolean with TRUE set if the function worked fine.
+*/
 OPTIONAL(int, process_cl, struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in,
                           cl_mem dev_out, const struct dt_iop_roi_t *const roi_in,
                           const struct dt_iop_roi_t *const roi_out);

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1341,7 +1341,7 @@ static int _process_cl_lf(struct dt_iop_module_t *self,
   {
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, oregion);
     if(err != CL_SUCCESS) goto error;
-    return TRUE;
+    return CL_SUCCESS;
   }
 
   switch(interpolation->id)
@@ -1359,7 +1359,7 @@ static int _process_cl_lf(struct dt_iop_module_t *self,
       ldkernel = gd->kernel_lens_distort_lanczos3;
       break;
     default:
-      return FALSE;
+      return DT_OPENCL_PROCESS_CL;
   }
 
   tmpbuf = (float *)dt_alloc_align(64, tmpbuflen);
@@ -1521,20 +1521,12 @@ static int _process_cl_lf(struct dt_iop_module_t *self,
     }
   }
 
-  dt_opencl_release_mem_object(dev_tmpbuf);
-  dt_opencl_release_mem_object(dev_tmp);
-  if(tmpbuf != NULL) dt_free_align(tmpbuf);
-  if(modifier != NULL) delete modifier;
-  return TRUE;
-
 error:
   dt_opencl_release_mem_object(dev_tmp);
   dt_opencl_release_mem_object(dev_tmpbuf);
-  if(tmpbuf != NULL) dt_free_align(tmpbuf);
+  dt_free_align(tmpbuf);
   if(modifier != NULL) delete modifier;
-  dt_print(DT_DEBUG_OPENCL,
-           "[opencl_lens] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -466,16 +466,10 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_levels, width, height,
     CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(dev_lut), CLARG(d->levels[0]),
     CLARG(d->levels[2]), CLARG(d->in_inv_gamma));
-  if(err != CL_SUCCESS) goto error;
-
-  dt_opencl_release_mem_object(dev_lut);
-
-  return TRUE;
 
 error:
   dt_opencl_release_mem_object(dev_lut);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_levels] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1619,7 +1619,7 @@ int process_cl(struct dt_iop_module_t *module,
     size_t dest[]   = { 0, 0, 0 };
     size_t extent[] = { width, height, 1 };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, src, dest, extent);
-    if(err != CL_SUCCESS) goto error;
+    if(err != CL_SUCCESS) return err;
   }
 
   // 2. build the distortion map
@@ -1629,21 +1629,14 @@ int process_cl(struct dt_iop_module_t *module,
                                roi_out, &map_extent, FALSE, &map);
 
   if(map == NULL)
-    return TRUE;
+    return CL_SUCCESS;
 
   // 3. apply the map
   if(map_extent.width != 0 && map_extent.height != 0)
     err = _apply_global_distortion_map_cl(module, piece, dev_in,
                                           dev_out, roi_in, roi_out, map, &map_extent);
   dt_free_align((void *) map);
-  if(err != CL_SUCCESS) goto error;
-
-  return TRUE;
-
-error:
-  dt_print(DT_DEBUG_OPENCL,
-           "[opencl_liquify] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 
 #endif

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -211,19 +211,14 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dt_Lab_to_XYZ(Lab_sw, XYZ_sw);
 
   dev_m = dt_opencl_copy_host_to_device(devid, d->lut, 256, 256, sizeof(float));
-  if(dev_m == NULL) goto error;
+  if(dev_m == NULL) goto finish;
 
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_lowlight, width, height,
     CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(XYZ_sw), CLARG(dev_m));
-  if(err != CL_SUCCESS) goto error;
 
+finish:
   dt_opencl_release_mem_object(dev_m);
-  return TRUE;
-
-error:
-  dt_opencl_release_mem_object(dev_m);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_lowlight] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -321,15 +321,6 @@ int process_cl(struct dt_iop_module_t *self,
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_lowpass_mix, width, height,
     CLARG(dev_tmp), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(saturation), CLARG(dev_cm),
     CLARG(dev_ccoeffs), CLARG(dev_lm), CLARG(dev_lcoeffs), CLARG(unbound));
-  if(err != CL_SUCCESS) goto error;
-
-  dt_opencl_release_mem_object(dev_tmp);
-  dt_opencl_release_mem_object(dev_lcoeffs);
-  dt_opencl_release_mem_object(dev_lm);
-  dt_opencl_release_mem_object(dev_ccoeffs);
-  dt_opencl_release_mem_object(dev_cm);
-
-  return TRUE;
 
 error:
   if(g) dt_gaussian_free_cl(g);
@@ -340,8 +331,7 @@ error:
   dt_opencl_release_mem_object(dev_lm);
   dt_opencl_release_mem_object(dev_ccoeffs);
   dt_opencl_release_mem_object(dev_cm);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_lowpass] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -1025,7 +1025,6 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     clut_cl = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3 * level * level * level, (void *)clut);
     if(clut_cl == NULL)
     {
-      dt_print(DT_DEBUG_ALWAYS, "[lut3d process_cl] error allocating memory\n");
       err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
       goto cleanup;
     }
@@ -1052,17 +1051,10 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
       CLARG(height));
     err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_lut3d_none, sizes);
   }
-  if(err != CL_SUCCESS)
-  {
-    dt_print(DT_DEBUG_ALWAYS, "[lut3d process_cl] error %i enqueue kernel\n", err);
-    goto cleanup;
-  }
 
 cleanup:
-  if(clut_cl) dt_opencl_release_mem_object(clut_cl);
-
-  if(err != CL_SUCCESS) dt_print(DT_DEBUG_OPENCL, "[opencl_lut3d] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return (err == CL_SUCCESS) ? TRUE : FALSE;
+  dt_opencl_release_mem_object(clut_cl);
+  return err;
 }
 #endif
 

--- a/src/iop/mask_manager.c
+++ b/src/iop/mask_manager.c
@@ -101,21 +101,13 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
                const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
-  cl_int err = DT_OPENCL_DEFAULT_ERROR;
   const int devid = piece->pipe->devid;
   const int width = roi_in->width;
   const int height = roi_in->height;
 
   size_t origin[] = { 0, 0, 0 };
   size_t region[] = { width, height, 1 };
-  err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
-  if(err != CL_SUCCESS) goto error;
-
-  return TRUE;
-
-error:
-  dt_print(DT_DEBUG_OPENCL, "[opencl_mask_manage] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
 }
 #endif
 

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -281,16 +281,11 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_monochrome, width, height,
     CLARG(dev_in), CLARG(dev_tmp), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(d->a), CLARG(d->b),
     CLARG(sigma2), CLARG(d->highlights));
-  if(err != CL_SUCCESS) goto error;
-
-  dt_opencl_release_mem_object(dev_tmp);
-  return TRUE;
 
 error:
   dt_opencl_release_mem_object(dev_tmp);
-  dt_bilateral_free_cl(b);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_monochrome] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  if(b) dt_bilateral_free_cl(b);
+  return err;
 }
 #endif
 

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -376,21 +376,13 @@ int process_cl(struct dt_iop_module_t *const self, dt_dev_pixelpipe_iop_t *const
   const dt_iop_negadoctor_data_t *const d = (dt_iop_negadoctor_data_t *)piece->data;
   const dt_iop_negadoctor_global_data_t *const gd = (dt_iop_negadoctor_global_data_t *)self->global_data;
 
-  cl_int err = DT_OPENCL_DEFAULT_ERROR;
-
   const int devid = piece->pipe->devid;
   const int width = roi_in->width;
   const int height = roi_in->height;
 
-  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_negadoctor, width, height,
+  return dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_negadoctor, width, height,
     CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(d->Dmin), CLARG(d->wb_high),
     CLARG(d->offset), CLARG(d->exposure), CLARG(d->black), CLARG(d->gamma), CLARG(d->soft_clip), CLARG(d->soft_clip_comp));
-  if(err != CL_SUCCESS) goto error;
-    return TRUE;
-
-error:
-  dt_print(DT_DEBUG_OPENCL, "[opencl_negadoctor] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
 }
 #endif
 

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -349,7 +349,6 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   if(dev_tmp == NULL)
   {
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-    dt_print(DT_DEBUG_ALWAYS, "[overexposed process_cl] error allocating memory for color transformation\n");
     dt_control_log(_("module overexposed failed in buffer allocation"));
     goto error;
   }
@@ -386,14 +385,10 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     CLARG(dev_in), CLARG(dev_out), CLARG(dev_tmp), CLARG(width), CLARG(height), CLARG(lower), CLARG(upper),
     CLARRAY(4, lower_color), CLARRAY(4, upper_color),
     CLARG(dev_profile_info), CLARG(dev_profile_lut), CLARG(use_work_profile), CLARG(mode));
-  if(err != CL_SUCCESS) goto error;
-  if(dev_tmp) dt_opencl_release_mem_object(dev_tmp);
-  return TRUE;
 
 error:
-  if(dev_tmp) dt_opencl_release_mem_object(dev_tmp);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_overexposed] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  dt_opencl_release_mem_object(dev_tmp);
+  return err;
 }
 #endif
 

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -238,8 +238,6 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
       CLARG(width), CLARG(height), CLARG(dynamic_range), CLARG(shadows_range), CLARG(grey));
 
     err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_profilegamma_log, sizes);
-    if(err != CL_SUCCESS) goto error;
-    return TRUE;
   }
   else if(d->mode == PROFILEGAMMA_GAMMA)
   {
@@ -253,21 +251,12 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
       CLARG(height), CLARG(dev_table), CLARG(dev_coeffs));
 
     err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_profilegamma, sizes);
-    if(err != CL_SUCCESS)
-    {
-      dt_opencl_release_mem_object(dev_table);
-      dt_opencl_release_mem_object(dev_coeffs);
-      goto error;
-    }
-
-    dt_opencl_release_mem_object(dev_table);
-    dt_opencl_release_mem_object(dev_coeffs);
-    return TRUE;
   }
 
 error:
-  dt_print(DT_DEBUG_OPENCL, "[opencl_profilegamma] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  dt_opencl_release_mem_object(dev_table);
+  dt_opencl_release_mem_object(dev_coeffs);
+  return err;
 }
 #endif
 

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -361,17 +361,6 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     dt_opencl_set_kernel_args(devid, kernel, 11, CLARRAY(4, color));
 
   err = dt_opencl_enqueue_kernel_2d(devid, kernel, sizes);
-  if(err != CL_SUCCESS) goto error;
-
-  dt_opencl_release_mem_object(dev_xtrans);
-  dt_opencl_release_mem_object(dev_colors);
-  dt_opencl_release_mem_object(dev_thresholds);
-  dt_opencl_release_mem_object(dev_coord);
-  dt_free_align(coordbuf);
-  dt_opencl_release_mem_object(dev_raw);
-  dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
-
-  return TRUE;
 
 error:
   dt_opencl_release_mem_object(dev_xtrans);
@@ -381,8 +370,7 @@ error:
   dt_free_align(coordbuf);
   dt_opencl_release_mem_object(dev_raw);
   dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_rawoverexposed] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -161,7 +161,6 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dt_iop_relight_data_t *data = (dt_iop_relight_data_t *)piece->data;
   dt_iop_relight_global_data_t *gd = (dt_iop_relight_global_data_t *)self->global_data;
 
-  cl_int err = DT_OPENCL_DEFAULT_ERROR;
   const int devid = piece->pipe->devid;
   const int width = roi_in->width;
   const int height = roi_in->height;
@@ -170,14 +169,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const float wings = data->width;
   const float ev = data->ev;
 
-  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_relight, width, height,
+  return dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_relight, width, height,
     CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(center), CLARG(wings), CLARG(ev));
-  if(err != CL_SUCCESS) goto error;
-  return TRUE;
-
-error:
-  dt_print(DT_DEBUG_OPENCL, "[opencl_relight] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
 }
 #endif
 

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -4886,9 +4886,6 @@ int process_cl(struct dt_iop_module_t *self,
                                   sizeof(float) * ch * roi_rt->width * roi_rt->height);
   if(in_retouch == NULL)
   {
-    dt_print(DT_DEBUG_OPENCL,
-             "[retouch process_cl] error allocating memory for wavelet"
-             " decompose on device %d\n", devid);
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
@@ -4924,9 +4921,6 @@ int process_cl(struct dt_iop_module_t *self,
                          roi_in->scale / piece->iscale);
   if(dwt_p == NULL)
   {
-    dt_print(DT_DEBUG_OPENCL,
-             "[retouch process_cl] error initializing wavelet"
-             " decompose on device %d\n", devid);
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
@@ -5029,13 +5023,9 @@ int process_cl(struct dt_iop_module_t *self,
 cleanup:
   if(dwt_p) dt_dwt_free_cl(dwt_p);
 
-  if(in_retouch) dt_opencl_release_mem_object(in_retouch);
+  dt_opencl_release_mem_object(in_retouch);
 
-  if(err != CL_SUCCESS)
-    dt_print(DT_DEBUG_OPENCL,
-             "[opencl_retouch] couldn't enqueue kernel! %s\n", cl_errstr(err));
-
-  return (err == CL_SUCCESS) ? TRUE : FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1650,76 +1650,39 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
                                             &dev_profile_info, &dev_profile_lut);
   if(err != CL_SUCCESS) goto cleanup;
 
+  err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
   dev_r = dt_opencl_copy_host_to_device(devid, d->table[DT_IOP_RGBCURVE_R], 256, 256, sizeof(float));
-  if(dev_r == NULL)
-  {
-    dt_print(DT_DEBUG_ALWAYS, "[rgbcurve process_cl] error allocating memory 1\n");
-    err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-    goto cleanup;
-  }
+  if(dev_r == NULL) goto cleanup;
 
   dev_g = dt_opencl_copy_host_to_device(devid, d->table[DT_IOP_RGBCURVE_G], 256, 256, sizeof(float));
-  if(dev_g == NULL)
-  {
-    dt_print(DT_DEBUG_ALWAYS, "[rgbcurve process_cl] error allocating memory 2\n");
-    err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-    goto cleanup;
-  }
+  if(dev_g == NULL) goto cleanup;
 
   dev_b = dt_opencl_copy_host_to_device(devid, d->table[DT_IOP_RGBCURVE_B], 256, 256, sizeof(float));
-  if(dev_b == NULL)
-  {
-    dt_print(DT_DEBUG_ALWAYS, "[rgbcurve process_cl] error allocating memory 3\n");
-    err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-    goto cleanup;
-  }
+  if(dev_b == NULL) goto cleanup;
 
   dev_coeffs_r = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3, d->unbounded_coeffs[0]);
-  if(dev_coeffs_r == NULL)
-  {
-    dt_print(DT_DEBUG_ALWAYS, "[rgbcurve process_cl] error allocating memory 4\n");
-    err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-    goto cleanup;
-  }
+  if(dev_coeffs_r == NULL) goto cleanup;
 
   dev_coeffs_g = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3, d->unbounded_coeffs[1]);
-  if(dev_coeffs_g == NULL)
-  {
-    dt_print(DT_DEBUG_ALWAYS, "[rgbcurve process_cl] error allocating memory 5\n");
-    err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-    goto cleanup;
-  }
+  if(dev_coeffs_g == NULL) goto cleanup;
 
   dev_coeffs_b = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 12, d->unbounded_coeffs[2]);
-  if(dev_coeffs_b == NULL)
-  {
-    dt_print(DT_DEBUG_ALWAYS, "[rgbcurve process_cl] error allocating memory 6\n");
-    err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-    goto cleanup;
-  }
+  if(dev_coeffs_b == NULL) goto cleanup;
 
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_rgbcurve, width, height,
     CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(dev_r), CLARG(dev_g), CLARG(dev_b),
     CLARG(dev_coeffs_r), CLARG(dev_coeffs_g), CLARG(dev_coeffs_b), CLARG(autoscale), CLARG(preserve_colors),
     CLARG(dev_profile_info), CLARG(dev_profile_lut), CLARG(use_work_profile));
-  if(err != CL_SUCCESS)
-  {
-    dt_print(DT_DEBUG_ALWAYS, "[rgbcurve process_cl] error %i enqueue kernel\n", err);
-    goto cleanup;
-  }
 
 cleanup:
-  if(dev_r) dt_opencl_release_mem_object(dev_r);
-  if(dev_g) dt_opencl_release_mem_object(dev_g);
-  if(dev_b) dt_opencl_release_mem_object(dev_b);
-  if(dev_coeffs_r) dt_opencl_release_mem_object(dev_coeffs_r);
-  if(dev_coeffs_g) dt_opencl_release_mem_object(dev_coeffs_g);
-  if(dev_coeffs_b) dt_opencl_release_mem_object(dev_coeffs_b);
+  dt_opencl_release_mem_object(dev_r);
+  dt_opencl_release_mem_object(dev_g);
+  dt_opencl_release_mem_object(dev_b);
+  dt_opencl_release_mem_object(dev_coeffs_r);
+  dt_opencl_release_mem_object(dev_coeffs_g);
+  dt_opencl_release_mem_object(dev_coeffs_b);
   dt_ioppr_free_iccprofile_params_cl(&profile_info_cl, &profile_lut_cl, &dev_profile_info, &dev_profile_lut);
-
-  if(err != CL_SUCCESS) dt_print(DT_DEBUG_OPENCL, "[opencl_rgbcurve] couldn't enqueue kernel! %s\n", cl_errstr(err));
-
-  return (err == CL_SUCCESS) ? TRUE : FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -1525,21 +1525,18 @@ int process_cl(dt_iop_module_t *self,
   dev_lutr = dt_opencl_copy_host_to_device(devid, d->lut[0], 256, 256, sizeof(float));
   if(dev_lutr == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[rgblevels process_cl] error allocating memory 1\n");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
   dev_lutg = dt_opencl_copy_host_to_device(devid, d->lut[1], 256, 256, sizeof(float));
   if(dev_lutg == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[rgblevels process_cl] error allocating memory 2\n");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
   dev_lutb = dt_opencl_copy_host_to_device(devid, d->lut[2], 256, 256, sizeof(float));
   if(dev_lutb == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[rgblevels process_cl] error allocating memory 3\n");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
@@ -1548,7 +1545,6 @@ int process_cl(dt_iop_module_t *self,
     (devid, sizeof(float) * 3 * 3, (float *)d->params.levels);
   if(dev_levels == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[rgblevels process_cl] error allocating memory 4\n");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
@@ -1557,7 +1553,6 @@ int process_cl(dt_iop_module_t *self,
     (devid, sizeof(float) * 3, (float *)d->inv_gamma);
   if(dev_inv_gamma == NULL)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[rgblevels process_cl] error allocating memory 5\n");
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto cleanup;
   }
@@ -1574,29 +1569,18 @@ int process_cl(dt_iop_module_t *self,
      CLARG(dev_lutr), CLARG(dev_lutg), CLARG(dev_lutb),
      CLARG(dev_levels), CLARG(dev_inv_gamma), CLARG(dev_profile_info),
      CLARG(dev_profile_lut), CLARG(use_work_profile));
-  if(err != CL_SUCCESS)
-  {
-    dt_print(DT_DEBUG_ALWAYS,
-             "[rgblevels process_cl] error %i enqueue kernel\n", err);
-    goto cleanup;
-  }
 
 cleanup:
-  if(dev_lutr) dt_opencl_release_mem_object(dev_lutr);
-  if(dev_lutg) dt_opencl_release_mem_object(dev_lutg);
-  if(dev_lutb) dt_opencl_release_mem_object(dev_lutb);
-  if(dev_levels) dt_opencl_release_mem_object(dev_levels);
-  if(dev_inv_gamma) dt_opencl_release_mem_object(dev_inv_gamma);
+  dt_opencl_release_mem_object(dev_lutr);
+  dt_opencl_release_mem_object(dev_lutg);
+  dt_opencl_release_mem_object(dev_lutb);
+  dt_opencl_release_mem_object(dev_levels);
+  dt_opencl_release_mem_object(dev_inv_gamma);
   dt_ioppr_free_iccprofile_params_cl(&profile_info_cl,
                                      &profile_lut_cl, &dev_profile_info, &dev_profile_lut);
 
-  if(src_buffer) dt_free_align(src_buffer);
-
-  if(err != CL_SUCCESS) dt_print(DT_DEBUG_OPENCL,
-                                 "[opencl_rgblevels] couldn't enqueue kernel! %s\n",
-                                 cl_errstr(err));
-
-  return (err == CL_SUCCESS) ? TRUE : FALSE;
+  dt_free_align(src_buffer);
+  return err;
 }
 #endif
 

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -597,17 +597,12 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     CLARG(shadows_ccorrect), CLARG(highlights_ccorrect), CLARG(flags), CLARG(unbound_mask), CLARG(low_approximation),
     CLARG(whitepoint));
   err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_shadows_highlights_mix, sizes);
-  if(err != CL_SUCCESS) goto error;
-
-  dt_opencl_release_mem_object(dev_tmp);
-  return TRUE;
 
 error:
   if(g) dt_gaussian_free_cl(g);
   if(b) dt_bilateral_free_cl(b);
   dt_opencl_release_mem_object(dev_tmp);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_shadows&highlights] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -148,7 +148,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     size_t region[] = { width, height, 1 };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
     if(err != CL_SUCCESS) goto error;
-    return TRUE;
+    return CL_SUCCESS;
   }
 
   // special case handling: very small image with one or two dimensions below 2*rad+1 => no sharpening,
@@ -159,7 +159,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     size_t region[] = { width, height, 1 };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
     if(err != CL_SUCCESS) goto error;
-    return TRUE;
+    return CL_SUCCESS;
   }
 
   const float sigma2 = (1.0f / (2.5 * 2.5)) * (d->radius * roi_in->scale / piece->iscale)
@@ -234,19 +234,12 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dt_opencl_set_kernel_args(devid, gd->kernel_sharpen_mix, 0, CLARG(dev_in), CLARG(dev_tmp), CLARG(dev_out),
     CLARG(width), CLARG(height), CLARG(d->amount), CLARG(d->threshold));
   err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_sharpen_mix, sizes);
-  if(err != CL_SUCCESS) goto error;
-
-  dt_opencl_release_mem_object(dev_m);
-  dt_opencl_release_mem_object(dev_tmp);
-  dt_free_align(mat);
-  return TRUE;
 
 error:
   dt_opencl_release_mem_object(dev_m);
   dt_opencl_release_mem_object(dev_tmp);
   dt_free_align(mat);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_sharpen] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -523,8 +523,6 @@ int process_cl(struct dt_iop_module_t *self,
                                            CLARG(white_target), CLARG(paper_exp),
                                            CLARG(film_fog), CLARG(contrast_power),
                                            CLARG(skew_power), CLARG(hue_preservation));
-    if(err != CL_SUCCESS) goto error;
-    return TRUE;
   }
   else
   {
@@ -536,13 +534,8 @@ int process_cl(struct dt_iop_module_t *self,
                                            CLARG(white_target), CLARG(black_target), CLARG(paper_exp),
                                            CLARG(film_fog), CLARG(contrast_power),
                                            CLARG(skew_power));
-    if(err != CL_SUCCESS) goto error;
-    return TRUE;
   }
-
-  error:
-  dt_print(DT_DEBUG_OPENCL, "[opencl_sigmoid] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif //HAVE_OPENCL
 

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -222,7 +222,6 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dt_iop_splittoning_data_t *d = (dt_iop_splittoning_data_t *)piece->data;
   dt_iop_splittoning_global_data_t *gd = (dt_iop_splittoning_global_data_t *)self->global_data;
 
-  cl_int err = DT_OPENCL_DEFAULT_ERROR;
   const int devid = piece->pipe->devid;
 
   const int width = roi_out->width;
@@ -235,16 +234,10 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const float highlight_hue = d->highlight_hue;
   const float highlight_saturation = d->highlight_saturation;
 
-  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_splittoning, width, height,
+  return dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_splittoning, width, height,
     CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(compress), CLARG(balance), CLARG(shadow_hue),
     CLARG(shadow_saturation), CLARG(highlight_hue), CLARG(highlight_saturation));
-  if(err != CL_SUCCESS) goto error;
-  return TRUE;
-
-error:
-  dt_print(DT_DEBUG_OPENCL, "[opencl_splittoning] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
-}
+ }
 #endif
 
 

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -671,9 +671,6 @@ int process_cl(struct dt_iop_module_t *self,
     CLARG(roi_out->x), CLARG(roi_out->y), CLARG(dev_xtrans));
   if(err != CL_SUCCESS) goto error;
 
-  dt_opencl_release_mem_object(dev_coeffs);
-  dt_opencl_release_mem_object(dev_xtrans);
-
   piece->pipe->dsc.temperature.enabled = TRUE;
   for(int k = 0; k < 4; k++)
   {
@@ -682,14 +679,11 @@ int process_cl(struct dt_iop_module_t *self,
       d->coeffs[k] * piece->pipe->dsc.processed_maximum[k];
     self->dev->proxy.wb_coeffs[k] = d->coeffs[k];
   }
-  return TRUE;
 
 error:
   dt_opencl_release_mem_object(dev_coeffs);
   dt_opencl_release_mem_object(dev_xtrans);
-  dt_print(DT_DEBUG_OPENCL,
-           "[opencl_white_balance] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -357,15 +357,6 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     CLARG(autoscale_ab), CLARG(unbound_ab), CLARG(dev_coeffs_L), CLARG(dev_coeffs_ab), CLARG(low_approximation),
     CLARG(preserve_colors), CLARG(dev_profile_info), CLARG(dev_profile_lut));
 
-  if(err != CL_SUCCESS) goto error;
-  dt_opencl_release_mem_object(dev_L);
-  dt_opencl_release_mem_object(dev_a);
-  dt_opencl_release_mem_object(dev_b);
-  dt_opencl_release_mem_object(dev_coeffs_L);
-  dt_opencl_release_mem_object(dev_coeffs_ab);
-  dt_ioppr_free_iccprofile_params_cl(&profile_info_cl, &profile_lut_cl, &dev_profile_info, &dev_profile_lut);
-  return TRUE;
-
 error:
   dt_opencl_release_mem_object(dev_L);
   dt_opencl_release_mem_object(dev_a);
@@ -373,8 +364,7 @@ error:
   dt_opencl_release_mem_object(dev_coeffs_L);
   dt_opencl_release_mem_object(dev_coeffs_ab);
   dt_ioppr_free_iccprofile_params_cl(&profile_info_cl, &profile_lut_cl, &dev_profile_info, &dev_profile_lut);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_tonecurve] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 /*

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -225,20 +225,13 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     size_t origin[] = { 0, 0, 0 };
     size_t region[] = { width, height, 1 };
     err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
-    if(err != CL_SUCCESS) goto error;
   }
   else
   {
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_velvia, width, height,
       CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(strength), CLARG(bias));
-    if(err != CL_SUCCESS) goto error;
   }
-
-  return TRUE;
-
-error:
-  dt_print(DT_DEBUG_OPENCL, "[opencl_velvia] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 

--- a/src/iop/vibrance.c
+++ b/src/iop/vibrance.c
@@ -144,7 +144,6 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 {
   dt_iop_vibrance_data_t *data = (dt_iop_vibrance_data_t *)piece->data;
   dt_iop_vibrance_global_data_t *gd = (dt_iop_vibrance_global_data_t *)self->global_data;
-  cl_int err = DT_OPENCL_DEFAULT_ERROR;
 
   const int devid = piece->pipe->devid;
   const int width = roi_in->width;
@@ -152,16 +151,9 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   const float amount = data->amount * 0.01f;
 
-  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_vibrance, width, height,
+  return dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_vibrance, width, height,
     CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(amount));
-  if(err != CL_SUCCESS) goto error;
-
-  return TRUE;
-
-error:
-  dt_print(DT_DEBUG_OPENCL, "[opencl_vibrance] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
-}
+ }
 #endif
 
 

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -824,7 +824,6 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dt_iop_vignette_data_t *data = (dt_iop_vignette_data_t *)piece->data;
   dt_iop_vignette_global_data_t *gd = (dt_iop_vignette_global_data_t *)self->global_data;
 
-  cl_int err = DT_OPENCL_DEFAULT_ERROR;
   const int devid = piece->pipe->devid;
   const int width = roi_out->width;
   const int height = roi_out->height;
@@ -897,17 +896,10 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const float saturation = data->saturation;
   const int unbound = data->unbound;
 
-  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_vignette, width, height,
+  return dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_vignette, width, height,
     CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(scale), CLARG(roi_center_scaled_f),
     CLARG(expt), CLARG(dscale), CLARG(fscale), CLARG(brightness), CLARG(saturation), CLARG(dither),
     CLARG(unbound));
-  if(err != CL_SUCCESS) goto error;
-
-  return TRUE;
-
-error:
-  dt_print(DT_DEBUG_OPENCL, "[opencl_vignette] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
 }
 #endif
 

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -354,16 +354,10 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_zonesystem, width, height,
     CLARG(dev_in), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(size), CLARG(dev_zmo), CLARG(dev_zms));
 
-  if(err != CL_SUCCESS) goto error;
-  dt_opencl_release_mem_object(dev_zmo);
-  dt_opencl_release_mem_object(dev_zms);
-  return TRUE;
-
 error:
   dt_opencl_release_mem_object(dev_zmo);
   dt_opencl_release_mem_object(dev_zms);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_zonesystem] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  return err;
 }
 #endif
 


### PR DESCRIPTION
In `iop_api.c` we define the `process_cl()` and it's tiling variant to return an int. This was in fact used as a bool. 

Until now all `process_cl()` functions handled error conditions internally, possibly gave some error logging output and and left the bool for either ok or an internal problem.

From now on the result of `process_cl()` is a standard OpenCL error code, the callers in pixelpipe and tiling code understand this and give some proper debugging output about the module name and the retuned error.

This allows a much simpler finishing code in many modules. Some modules got additional checks.

While being here also the code for iop_profile and guided filters have been modified accordingly. 

 