### PR TITLE
introduce dt_view_get_current

### DIFF
--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -1006,13 +1006,9 @@ void *dt_update_cameras_thread(void *ptr)
     g_usleep(250000);  // 1/4 second
     dt_camctl_t *camctl = (dt_camctl_t *)darktable.camctl;
 
-    const dt_view_t *cv = (darktable.view_manager)
-      ? dt_view_manager_get_current_view(darktable.view_manager)
-      : NULL;
-
     if(camctl)
     {
-      if((camctl->import_ui == FALSE) && (cv && (cv->view(cv) == DT_VIEW_LIGHTTABLE)))
+      if(camctl->import_ui == FALSE && dt_view_get_current() == DT_VIEW_LIGHTTABLE)
 //TODO:  && import module is expanded and visible
       {
         camctl->ticker += 1;

--- a/src/common/colorlabels.c
+++ b/src/common/colorlabels.c
@@ -289,8 +289,7 @@ static float _action_process_color_label(gpointer target, dt_action_element_t el
     dt_colorlabels_toggle_label_on_list(imgs, element ? element - 1 : 5, TRUE);
 
     // if we are in darkroom we show a message as there might be no other indication
-    const dt_view_t *v = dt_view_manager_get_current_view(darktable.view_manager);
-    if(v->view(v) == DT_VIEW_DARKROOM && g_list_is_singleton(imgs) && darktable.develop->preview_pipe)
+    if(dt_view_get_current() == DT_VIEW_DARKROOM && g_list_is_singleton(imgs) && darktable.develop->preview_pipe)
     {
       // we verify that the image is the active one
       const int id = GPOINTER_TO_INT(imgs->data);

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -885,8 +885,7 @@ gboolean dt_history_copy_and_paste_on_image(const dt_imgid_t imgid,
   dt_lock_image_pair(imgid, dest_imgid);
 
   // be sure the current history is written before pasting some other history data
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  if(cv->view((dt_view_t *)cv) == DT_VIEW_DARKROOM)
+  if(dt_view_get_current() == DT_VIEW_DARKROOM)
     dt_dev_write_history(darktable.develop);
 
   dt_undo_lt_history_t *hist = dt_history_snapshot_item_init();
@@ -1916,10 +1915,7 @@ gboolean dt_history_paste_on_list(const GList *list, const gboolean undo)
 
   // In darkroom and if there is a copy of the iop-order we need to rebuild the pipe
   // to take into account the possible new order of modules.
-
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-
-  if(cv->view(cv) == DT_VIEW_DARKROOM)
+  if(dt_view_get_current() == DT_VIEW_DARKROOM)
   {
     dt_dev_pixelpipe_rebuild(darktable.develop);
   }
@@ -1971,10 +1967,7 @@ gboolean dt_history_paste_parts_on_list(const GList *list, gboolean undo)
   // In darkroom and if there is a copy of the iop-order we need to
   // rebuild the pipe to take into account the possible new order of
   // modules.
-
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-
-  if(cv->view(cv) == DT_VIEW_DARKROOM)
+  if(dt_view_get_current() == DT_VIEW_DARKROOM)
   {
     dt_dev_pixelpipe_rebuild(darktable.develop);
   }

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -982,9 +982,8 @@ dt_image_orientation_t dt_image_get_orientation(const dt_imgid_t imgid)
 void dt_image_flip(const dt_imgid_t imgid, const int32_t cw)
 {
   // this is light table only:
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
   if(darktable.develop->image_storage.id == imgid
-     && cv->view((dt_view_t *)cv) == DT_VIEW_DARKROOM)
+     && dt_view_get_current() == DT_VIEW_DARKROOM)
     return;
 
   dt_undo_lt_history_t *hist = dt_history_snapshot_item_init();

--- a/src/common/ratings.c
+++ b/src/common/ratings.c
@@ -257,8 +257,7 @@ static float _action_process_rating(gpointer target, dt_action_element_t element
     dt_ratings_apply_on_list(imgs, element, TRUE);
 
     // if we are in darkroom we show a message as there might be no other indication
-    const dt_view_t *v = dt_view_manager_get_current_view(darktable.view_manager);
-    if(v->view(v) == DT_VIEW_DARKROOM && g_list_is_singleton(imgs) && darktable.develop->preview_pipe)
+    if(dt_view_get_current() == DT_VIEW_DARKROOM && g_list_is_singleton(imgs) && darktable.develop->preview_pipe)
     {
       // we verify that the image is the active one
       const int id = GPOINTER_TO_INT(imgs->data);

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -96,10 +96,9 @@ void dt_style_item_free(gpointer data)
 
 static void _apply_style_shortcut_callback(dt_action_t *action)
 {
-  const dt_view_t *v = dt_view_manager_get_current_view(darktable.view_manager);
   GList *imgs = dt_act_on_get_images(TRUE, TRUE, FALSE);
 
-  if(v->view(v) == DT_VIEW_DARKROOM)
+  if(dt_view_get_current() == DT_VIEW_DARKROOM)
   {
     const dt_imgid_t imgid = GPOINTER_TO_INT(imgs->data);
     dt_styles_apply_to_dev(action->label, imgid);
@@ -645,8 +644,7 @@ void dt_styles_apply_to_list(const char *name, const GList *list, gboolean dupli
   /* write current history changes so nothing gets lost,
      do that only in the darkroom as there is nothing to be saved
      when in the lighttable (and it would write over current history stack) */
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  if(cv->view(cv) == DT_VIEW_DARKROOM) dt_dev_write_history(darktable.develop);
+  if(dt_view_get_current() == DT_VIEW_DARKROOM) dt_dev_write_history(darktable.develop);
 
   const int mode = dt_conf_get_int("plugins/lighttable/style/applymode");
   const gboolean is_overwrite = (mode == DT_STYLE_HISTORY_OVERWRITE);
@@ -702,8 +700,7 @@ void dt_multiple_styles_apply_to_list(GList *styles,
   /* write current history changes so nothing gets lost,
      do that only in the darkroom as there is nothing to be saved
      when in the lighttable (and it would write over current history stack) */
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  if(cv->view((dt_view_t *)cv) == DT_VIEW_DARKROOM)
+  if(dt_view_get_current() == DT_VIEW_DARKROOM)
     dt_dev_write_history(darktable.develop);
 
   if(!styles && !list)

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -3623,10 +3623,8 @@ void dt_second_window_check_zoom_bounds(dt_develop_t *dev,
 
 void dt_dev_undo_start_record(dt_develop_t *dev)
 {
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-
   /* record current history state : before change (needed for undo) */
-  if(dev->gui_attached && cv->view((dt_view_t *)cv) == DT_VIEW_DARKROOM)
+  if(dev->gui_attached && dt_view_get_current() == DT_VIEW_DARKROOM)
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
                                   DT_SIGNAL_DEVELOP_HISTORY_WILL_CHANGE);
 
@@ -3635,10 +3633,8 @@ void dt_dev_undo_start_record(dt_develop_t *dev)
 
 void dt_dev_undo_end_record(dt_develop_t *dev)
 {
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-
   /* record current history state : after change (needed for undo) */
-  if(dev->gui_attached && cv->view((dt_view_t *)cv) == DT_VIEW_DARKROOM)
+  if(dev->gui_attached && dt_view_get_current() == DT_VIEW_DARKROOM)
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_CHANGE);
 }
 

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -601,9 +601,8 @@ static gboolean _event_image_draw(GtkWidget *widget,
 
   // if we have a rgbbuf but the thumb is not anymore the darkroom main one
   dt_develop_t *dev = darktable.develop;
-  const dt_view_t *v = dt_view_manager_get_current_view(darktable.view_manager);
   if(thumb->img_surf_preview
-     && (v->view(v) != DT_VIEW_DARKROOM
+     && (dt_view_get_current() != DT_VIEW_DARKROOM
          || !dev->preview_pipe->output_backbuf
          || dev->preview_pipe->output_imgid != thumb->imgid))
   {
@@ -628,7 +627,7 @@ static gboolean _event_image_draw(GtkWidget *widget,
     _thumb_set_image_area(thumb, IMG_TO_FIT);
     gtk_widget_get_size_request(thumb->w_image_box, &image_w, &image_h);
 
-    if(v->view(v) == DT_VIEW_DARKROOM
+    if(dt_view_get_current() == DT_VIEW_DARKROOM
        && dev->preview_pipe->output_imgid == thumb->imgid
        && dev->preview_pipe->output_backbuf)
     {
@@ -1182,8 +1181,7 @@ static void _dt_preview_updated_callback(gpointer instance, gpointer user_data)
   dt_thumbnail_t *thumb = (dt_thumbnail_t *)user_data;
   if(!gtk_widget_is_visible(thumb->w_main)) return;
 
-  const dt_view_t *v = dt_view_manager_get_current_view(darktable.view_manager);
-  if(v->view(v) == DT_VIEW_DARKROOM
+  if(dt_view_get_current() == DT_VIEW_DARKROOM
      && (thumb->img_surf_preview
          || darktable.develop->preview_pipe->output_imgid == thumb->imgid)
      && darktable.develop->preview_pipe->output_backbuf)

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1735,8 +1735,7 @@ static void _dt_collection_changed_callback(gpointer instance,
     if(dt_is_valid_imgid(old_hover) && dt_is_valid_imgid(next))
     {
       // except for darkroom when mouse is not in filmstrip (the active image primes)
-      const dt_view_t *v = dt_view_manager_get_current_view(darktable.view_manager);
-      if(table->mouse_inside || v->view(v) != DT_VIEW_DARKROOM)
+      if(table->mouse_inside || dt_view_get_current() != DT_VIEW_DARKROOM)
       {
         in_list = FALSE;
         gboolean in_list_next = FALSE;

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1136,8 +1136,7 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget,
       description = g_markup_escape_text(_(element_name), -1);
   }
 
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  const dt_view_type_flags_t current_view = cv ? cv->view(cv) : DT_VIEW_NONE;
+  const dt_view_type_flags_t current_view = dt_view_get_current();
   int num_shortcuts = 0;
   for(GSequenceIter *iter = g_sequence_get_begin_iter(darktable.control->shortcuts);
       !g_sequence_iter_is_end(iter);
@@ -1397,13 +1396,9 @@ static gboolean _insert_shortcut(dt_shortcut_t *shortcut,
 
   dt_shortcut_t *s = calloc(sizeof(dt_shortcut_t), 1);
   *s = *shortcut;
-  dt_view_type_flags_t real_views = s->views = _find_views(s->action);
+  const dt_view_type_flags_t real_views = s->views = _find_views(s->action);
 
-  const dt_view_t *vw = NULL;
-  if(darktable.view_manager)
-    vw = dt_view_manager_get_current_view(darktable.view_manager);
-
-  dt_view_type_flags_t view = vw && vw->view ? vw->view(vw) : DT_VIEW_LIGHTTABLE;
+  const dt_view_type_flags_t view = dt_view_get_current();
 
   guint replaced_direction = 0;
 
@@ -1989,8 +1984,7 @@ static gboolean _view_key_pressed(GtkWidget *widget, GdkEventKey *event, gpointe
 
 static void _add_shortcuts_to_tree()
 {
-  const dt_view_t *vw = dt_view_manager_get_current_view(darktable.view_manager);
-  dt_view_type_flags_t view = vw && vw->view ? vw->view(vw) : DT_VIEW_LIGHTTABLE;
+  const dt_view_type_flags_t view = dt_view_get_current();
 
   for(dt_shortcut_category_t i = 0; i < DT_SHORTCUT_CATEGORY_LAST; i++)
     gtk_tree_store_insert_with_values(_shortcuts_store, NULL, NULL, -1, 0, GINT_TO_POINTER(i), -1);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -834,17 +834,12 @@ void dt_gui_gtk_quit()
 gboolean dt_gui_quit_callback(GtkWidget *widget, GdkEvent *event, gpointer user_data)
 {
   // if we are in lighttable preview mode, then just exit preview instead of closing dt
-  if(!darktable.view_manager)
-    dt_control_quit();
+  if(dt_view_get_current() == DT_VIEW_LIGHTTABLE
+      && dt_view_lighttable_preview_state(darktable.view_manager))
+    dt_view_lighttable_set_preview_state(darktable.view_manager, FALSE, FALSE, FALSE);
   else
-  {
-    const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-    if(cv && g_strcmp0(cv->module_name, "lighttable") == 0
-       && dt_view_lighttable_preview_state(darktable.view_manager))
-      dt_view_lighttable_set_preview_state(darktable.view_manager, FALSE, FALSE, FALSE);
-    else
-      dt_control_quit();
-  }
+    dt_control_quit();
+
   return TRUE;
 }
 

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -170,8 +170,7 @@ dt_view_type_flags_t views(dt_lib_module_t *self)
 
 uint32_t container(dt_lib_module_t *self)
 {
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  if(cv->view((dt_view_t *)cv) == DT_VIEW_DARKROOM)
+  if(dt_view_get_current() == DT_VIEW_DARKROOM)
     return DT_UI_CONTAINER_PANEL_LEFT_CENTER;
   else
     return DT_UI_CONTAINER_PANEL_RIGHT_CENTER;
@@ -287,8 +286,7 @@ static void _export_button_clicked(GtkWidget *widget, dt_lib_export_t *d)
   /* write current history changes so nothing gets lost, do that only
      in the darkroom as there is nothing to be saved when in the
      lighttable (and it would write over current history stack) */
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  if(cv->view(cv) == DT_VIEW_DARKROOM) dt_dev_write_history(darktable.develop);
+  if(dt_view_get_current() == DT_VIEW_DARKROOM) dt_dev_write_history(darktable.develop);
 
   char style[128] = { 0 };
 

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -922,8 +922,7 @@ static void dt_lib_histogram_process(struct dt_lib_module_t *self, const float *
   // FIXME: only need to do colorspace conversion below on roi
   // FIXME: if the only time we use roi in histogram to limit area is here, and whenever we use tether there is no colorpicker (true?), and if we're always doing a colorspace transform in darkroom and clip to roi during conversion, then can get rid of all roi code for common/histogram?
   // when darkroom colorpicker is active, gui_module is set to colorout
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  if(cv->view(cv) == DT_VIEW_DARKROOM && darktable.lib->proxy.colorpicker.restrict_histogram)
+  if(dt_view_get_current() == DT_VIEW_DARKROOM && darktable.lib->proxy.colorpicker.restrict_histogram)
   {
     const dt_colorpicker_sample_t *const sample = darktable.lib->proxy.colorpicker.primary_sample;
     dt_iop_color_picker_t *proxy = darktable.lib->proxy.colorpicker.picker_proxy;
@@ -1452,8 +1451,7 @@ static gboolean _drawable_draw_callback(GtkWidget *widget, cairo_t *crf, gpointe
   dt_pthread_mutex_lock(&d->lock);
   // darkroom view: draw scope so long as preview pipe is finished
   // tether view: draw whatever has come in from tether
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  if(cv->view(cv) == DT_VIEW_TETHERING || dev->image_storage.id == dev->preview_pipe->output_imgid)
+  if(dt_view_get_current() == DT_VIEW_TETHERING || dev->image_storage.id == dev->preview_pipe->output_imgid)
   {
     const uint8_t mask[3] = { d->red, d->green, d->blue };
     switch(d->scope_type)
@@ -1527,8 +1525,7 @@ static gboolean _drawable_motion_notify_callback(GtkWidget *widget, GdkEventMoti
     const float posx = x / (float)(allocation.width);
     const float posy = y / (float)(allocation.height);
     const dt_lib_histogram_highlight_t prior_highlight = d->highlight;
-    const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-    const gboolean hooks_available = (cv->view(cv) == DT_VIEW_DARKROOM) && dt_dev_exposure_hooks_available(dev);
+    const gboolean hooks_available = (dt_view_get_current() == DT_VIEW_DARKROOM) && dt_dev_exposure_hooks_available(dev);
 
     // FIXME: make just one tooltip for the widget depending on whether it is draggable or not, and set it when enter the view
     gchar *tip = g_strdup_printf("%s\n", _(dt_lib_histogram_scope_type_names[d->scope_type]));
@@ -1843,8 +1840,7 @@ static void _scope_type_changed(dt_lib_histogram_t *d)
   else
   {
     // generate data for changed scope and trigger widget redraw
-    const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-    if(cv->view(cv) == DT_VIEW_DARKROOM)
+    if(dt_view_get_current() == DT_VIEW_DARKROOM)
       dt_dev_process_preview(darktable.develop);
     else
       dt_control_queue_redraw_center();
@@ -1902,8 +1898,7 @@ static void _scope_view_clicked(GtkWidget *button, dt_lib_histogram_t *d)
       dt_unreachable_codepath();
   }
   // trigger new process from scratch
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  if(cv->view(cv) == DT_VIEW_DARKROOM)
+  if(dt_view_get_current() == DT_VIEW_DARKROOM)
     dt_dev_process_preview(darktable.develop);
   else
     dt_control_queue_redraw_center();
@@ -1917,8 +1912,7 @@ static void _colorspace_clicked(GtkWidget *button, dt_lib_histogram_t *d)
   _vectorscope_view_update(d);
   // trigger new process from scratch depending on whether CIELuv or JzAzBz
   // FIXME: it would be nice as with other scopes to make the initial processing independent of the view
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  if(cv->view(cv) == DT_VIEW_DARKROOM)
+  if(dt_view_get_current() == DT_VIEW_DARKROOM)
     dt_dev_process_preview(darktable.develop);
   else
     dt_control_queue_redraw_center();

--- a/src/libs/ioporder.c
+++ b/src/libs/ioporder.c
@@ -120,9 +120,7 @@ void update(dt_lib_module_t *self)
 static void _image_loaded_callback(gpointer instance, gpointer user_data)
 {
   // only in darkroom, so let's avoid any update when in lighttable
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-
-  if(cv->view(cv) == DT_VIEW_DARKROOM)
+  if(dt_view_get_current() == DT_VIEW_DARKROOM)
   {
     dt_lib_module_t *self = (dt_lib_module_t *)user_data;
     update(self);

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -468,8 +468,7 @@ void gui_update(dt_lib_module_t *self)
 
   if(!dt_is_valid_imgid(mouse_over_id))
   {
-     const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-    if(cv->view(cv) == DT_VIEW_DARKROOM)
+    if(dt_view_get_current() == DT_VIEW_DARKROOM)
     {
        mouse_over_id = darktable.develop->image_storage.id;
     }

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -115,8 +115,7 @@ dt_view_type_flags_t views(dt_lib_module_t *self)
 
 uint32_t container(dt_lib_module_t *self)
 {
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  if(cv->view((dt_view_t *)cv) == DT_VIEW_DARKROOM)
+  if(dt_view_get_current() == DT_VIEW_DARKROOM)
     return DT_UI_CONTAINER_PANEL_LEFT_CENTER;
   else
     return DT_UI_CONTAINER_PANEL_RIGHT_CENTER;

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -185,13 +185,13 @@ static void _overlays_show_popup(GtkWidget *button, dt_lib_module_t *self)
   gboolean show = FALSE;
 
   // thumbnails part
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
+  const dt_view_type_flags_t cv = dt_view_get_current();
   gboolean thumbs_state;
-  if(g_strcmp0(cv->module_name, "slideshow") == 0)
+  if(cv == DT_VIEW_SLIDESHOW)
   {
     thumbs_state = FALSE;
   }
-  else if(g_strcmp0(cv->module_name, "lighttable") == 0)
+  else if(cv == DT_VIEW_LIGHTTABLE)
   {
     if(dt_view_lighttable_preview_state(darktable.view_manager)
        || dt_view_lighttable_get_layout(darktable.view_manager) == DT_LIGHTTABLE_LAYOUT_CULLING)
@@ -265,7 +265,7 @@ static void _overlays_show_popup(GtkWidget *button, dt_lib_module_t *self)
   }
 
   // and we do the same for culling/preview if needed
-  if(g_strcmp0(cv->module_name, "lighttable") == 0
+  if(cv == DT_VIEW_LIGHTTABLE
      && (dt_view_lighttable_preview_state(darktable.view_manager)
          || dt_view_lighttable_get_layout(darktable.view_manager) == DT_LIGHTTABLE_LAYOUT_CULLING))
   {

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1054,6 +1054,16 @@ void dt_view_toggle_selection(const dt_imgid_t imgid)
   }
 }
 
+dt_view_type_flags_t dt_view_get_current(void)
+{
+  if(!darktable.view_manager) return DT_VIEW_LIGHTTABLE;
+
+  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
+  if(!cv || ! cv->view) return DT_VIEW_LIGHTTABLE;
+
+  return cv->view(cv);
+}
+
 /**
  * \brief Reset filter
  */
@@ -1754,7 +1764,7 @@ void dt_view_paint_surface(cairo_t *cr,
   cairo_translate(cr, (offset_x - zoom_x) * dev->pipe->processed_width * buf_scale - 0.5 * processed_width,
                       (offset_y - zoom_y) * dev->pipe->processed_height * buf_scale - 0.5 * processed_height);
   cairo_set_source_surface(cr, surface, 0, 0);
-  cairo_pattern_set_filter(cairo_get_source(cr), 
+  cairo_pattern_set_filter(cairo_get_source(cr),
                            zoom_scale >= 0.9999f ? CAIRO_FILTER_FAST : darktable.gui->dr_filter_image);
   cairo_paint(cr);
 

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -179,6 +179,8 @@ void dt_view_set_selection(const dt_imgid_t imgid,
                            const int value);
 /** toggle selection of given image. */
 void dt_view_toggle_selection(const dt_imgid_t imgid);
+/** get the type of the currently active view in darktable.view_manager. */
+dt_view_type_flags_t dt_view_get_current(void);
 
 /**
  * holds all relevant data needed to manage the view


### PR DESCRIPTION
I'm sorry but someone had to do it. At least now this consistently checks against NULL pointers etc.

I know this breaks the fiction that we could have several independent view managers all with their separate sets of view, but that ships been around the world a few times.