### PR TITLE
improve bauhaus popup behaviour

### DIFF
--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -136,7 +136,7 @@ typedef union dt_bauhaus_data_t
 typedef struct dt_bauhaus_widget_t DtBauhausWidget;
 typedef struct dt_bauhaus_widget_class_t DtBauhausWidgetClass;
 
-typedef void (*dt_bauhaus_quad_paint_f)(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+typedef DTGTKCairoPaintIconFunc dt_bauhaus_quad_paint_f;
 
 // our new widget and its private members, inheriting from drawing area:
 typedef struct dt_bauhaus_widget_t
@@ -206,14 +206,13 @@ typedef struct dt_bauhaus_t
   // time when the popup window was opened. this is sortof a hack to
   // detect `double clicks between windows' to reset the combobox.
   guint32 opentime;
-  // pointer position when popup window is closed
-  float end_mouse_x, end_mouse_y;
-  // used to determine whether the user crossed the line already.
-  int change_active;
+  // used to determine whether the user crossed the line or made a change already.
+  gboolean change_active;
   float mouse_line_distance;
   // key input buffer
   char keys[DT_BAUHAUS_MAX_TEXT];
   int keys_cnt;
+  int unique_match;
   // our custom signals
   guint signals[DT_BAUHAUS_LAST_SIGNAL];
 
@@ -238,7 +237,7 @@ typedef struct dt_bauhaus_t
   int cursor_blink_counter;
 
   // colors for sliders and comboboxes
-  GdkRGBA color_fg, color_fg_insensitive, color_bg, color_border, indicator_border, color_fill;
+  GdkRGBA color_fg, color_fg_hover, color_fg_insensitive, color_bg, color_border, indicator_border, color_fill;
 
   // colors for graphs
   GdkRGBA graph_bg, graph_exterior, graph_border, graph_fg, graph_grid, graph_fg_active, graph_overlay, inset_histogram;
@@ -247,7 +246,6 @@ typedef struct dt_bauhaus_t
 } dt_bauhaus_t;
 
 #define DT_BAUHAUS_SPACE 0
-
 
 void dt_bauhaus_init();
 void dt_bauhaus_cleanup();
@@ -263,6 +261,7 @@ void dt_bauhaus_widget_set_section(GtkWidget *w, const gboolean is_section);
 // set the label text:
 dt_action_t *dt_bauhaus_widget_set_label(GtkWidget *w, const char *section, const char *label);
 const char* dt_bauhaus_widget_get_label(GtkWidget *w);
+void dt_bauhaus_widget_hide_label(GtkWidget *w);
 // attach a custom painted quad to the space at the right side (overwriting the default icon if any):
 void dt_bauhaus_widget_set_quad_paint(GtkWidget *w, dt_bauhaus_quad_paint_f f, int paint_flags, void *paint_data);
 // make this quad a toggle button:
@@ -287,7 +286,6 @@ GtkWidget *dt_bauhaus_slider_new_with_range(dt_iop_module_t *self, float min, fl
                                             float defval, int digits);
 GtkWidget *dt_bauhaus_slider_new_with_range_and_feedback(dt_iop_module_t *self, float min, float max,
                                                          float step, float defval, int digits, int feedback);
-
 GtkWidget *dt_bauhaus_slider_from_widget(struct dt_bauhaus_widget_t* widget, dt_iop_module_t *self, float min, float max,
                                          float step, float defval, int digits, int feedback);
 GtkWidget *dt_bauhaus_slider_new_action(dt_action_t *self, float min, float max, float step,
@@ -330,7 +328,7 @@ void dt_bauhaus_slider_set_curve(GtkWidget *widget, float (*curve)(float value, 
 void dt_bauhaus_slider_set_log_curve(GtkWidget *widget);
 
 // combobox:
-void dt_bauhaus_combobox_from_widget(struct dt_bauhaus_widget_t* widget,dt_iop_module_t *self);
+GtkWidget *dt_bauhaus_combobox_from_widget(struct dt_bauhaus_widget_t* widget, dt_iop_module_t *self);
 GtkWidget *dt_bauhaus_combobox_new(dt_iop_module_t *self);
 GtkWidget *dt_bauhaus_combobox_new_action(dt_action_t *self);
 GtkWidget *dt_bauhaus_combobox_new_full(dt_action_t *action, const char *section, const char *label, const char *tip,

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3548,14 +3548,16 @@ static void _collapse_button_changed(GtkDarktableToggleButton *widget, gpointer 
   dt_conf_set_bool(cs->confname, active);
 }
 
-static void _collapse_expander_click(GtkWidget *widget, GdkEventButton *e, gpointer user_data)
+static gboolean _collapse_expander_click(GtkWidget *widget, GdkEventButton *e, gpointer user_data)
 {
-  if(e->type == GDK_2BUTTON_PRESS || e->type == GDK_3BUTTON_PRESS) return;
+  if(e->button != 1) return FALSE;
 
   dt_gui_collapsible_section_t *cs = (dt_gui_collapsible_section_t *)user_data;
 
   const gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(cs->toggle));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(cs->toggle), !active);
+
+  return TRUE;
 }
 
 void dt_gui_update_collapsible_section(dt_gui_collapsible_section_t *cs)
@@ -3612,7 +3614,7 @@ void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
   g_signal_connect(G_OBJECT(cs->toggle), "toggled",
                    G_CALLBACK(_collapse_button_changed), cs);
 
-  g_signal_connect(G_OBJECT(header_evb), "button-release-event",
+  g_signal_connect(G_OBJECT(header_evb), "button-press-event",
                    G_CALLBACK(_collapse_expander_click), cs);
 }
 

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -1882,7 +1882,8 @@ static gboolean _sort_init(_widgets_sort_t *sort, const dt_collection_sort_t sor
     else
       sort->sort = dt_bauhaus_combobox_new(NULL);
     dt_action_t *ac = dt_bauhaus_widget_set_label(sort->sort, NULL, _("sort order"));
-    DT_BAUHAUS_WIDGET(sort->sort)->show_label = FALSE;
+    dt_bauhaus_widget_hide_label(sort->sort);
+    dt_bauhaus_combobox_mute_scrolling(sort->sort);
     gtk_widget_set_tooltip_text(sort->sort, _("determine the sort order of shown images"));
     g_signal_connect(G_OBJECT(sort->sort), "value-changed", G_CALLBACK(_sort_combobox_changed), sort);
     gtk_box_pack_start(GTK_BOX(sort->box), sort->sort, TRUE, TRUE, 0);

--- a/src/libs/filters/grouping.c
+++ b/src/libs/filters/grouping.c
@@ -168,7 +168,7 @@ static void _grouping_widget_init(dt_lib_filtering_rule_t *rule, const dt_collec
                                _("select the type of grouped image to filter"), 0, _grouping_changed,
                                grouping, N_("all images"), N_("ungrouped images"), N_("grouped images"),
                                N_("group leaders"), N_("group followers"));
-  DT_BAUHAUS_WIDGET(grouping->combo)->show_label = FALSE;
+  dt_bauhaus_widget_hide_label(grouping->combo);
 
   if(top)
     gtk_box_pack_start(GTK_BOX(rule->w_special_box_top), grouping->combo, TRUE, TRUE, 0);

--- a/src/libs/filters/history.c
+++ b/src/libs/filters/history.c
@@ -152,7 +152,7 @@ static void _history_widget_init(dt_lib_filtering_rule_t *rule, const dt_collect
   history->combo
       = dt_bauhaus_combobox_new_full(DT_ACTION(self), N_("rules"), N_("history"), _("filter on history state"), 0,
                                      (GtkCallback)_history_changed, history, _history_names);
-  DT_BAUHAUS_WIDGET(history->combo)->show_label = FALSE;
+  dt_bauhaus_widget_hide_label(history->combo);
 
   if(top)
     gtk_box_pack_start(GTK_BOX(rule->w_special_box_top), history->combo, TRUE, TRUE, 0);

--- a/src/libs/filters/local_copy.c
+++ b/src/libs/filters/local_copy.c
@@ -141,7 +141,7 @@ static void _local_copy_widget_init(dt_lib_filtering_rule_t *rule, const dt_coll
   local_copy->combo = dt_bauhaus_combobox_new_full(
       DT_ACTION(self), N_("rules"), N_("local copy"), _("local copied state filter"), 0,
       (GtkCallback)_local_copy_changed, local_copy, _local_copy_names);
-  DT_BAUHAUS_WIDGET(local_copy->combo)->show_label = FALSE;
+  dt_bauhaus_widget_hide_label(local_copy->combo);
 
   if(top)
     gtk_box_pack_start(GTK_BOX(rule->w_special_box_top), local_copy->combo, TRUE, TRUE, 0);

--- a/src/libs/filters/module_order.c
+++ b/src/libs/filters/module_order.c
@@ -160,7 +160,7 @@ static void _module_order_widget_init(dt_lib_filtering_rule_t *rule, const dt_co
   module_order->combo = dt_bauhaus_combobox_new_full(
       DT_ACTION(self), N_("rules"), N_("module order"), _("filter images based on their module order"), 0,
       (GtkCallback)_module_order_changed, module_order, (const char **)_module_order_names);
-  DT_BAUHAUS_WIDGET(module_order->combo)->show_label = FALSE;
+  dt_bauhaus_widget_hide_label(module_order->combo);
 
   if(top)
     gtk_box_pack_start(GTK_BOX(rule->w_special_box_top), module_order->combo, TRUE, TRUE, 0);

--- a/src/libs/filters/rating.c
+++ b/src/libs/filters/rating.c
@@ -199,7 +199,7 @@ static void _rating_widget_init(dt_lib_filtering_rule_t *rule, const dt_collecti
   DT_BAUHAUS_COMBOBOX_NEW_FULL(rating_legacy->comparator, self, N_("rules"), N_("comparator"),
                                _("filter by images rating"), 3, _rating_legacy_changed, rating_legacy, "<", "≤",
                                "=", "≥", ">", "≠");
-  DT_BAUHAUS_WIDGET(rating_legacy->comparator)->show_label = FALSE;
+  dt_bauhaus_widget_hide_label(rating_legacy->comparator);
   gtk_widget_set_halign(rating_legacy->comparator, GTK_ALIGN_START);
   gtk_widget_set_no_show_all(rating_legacy->comparator, TRUE);
   dt_gui_add_class(rating_legacy->comparator, "dt_transparent_background");
@@ -210,7 +210,7 @@ static void _rating_widget_init(dt_lib_filtering_rule_t *rule, const dt_collecti
   DT_BAUHAUS_COMBOBOX_NEW_FULL(rating_legacy->stars, self, N_("rules"), N_("ratings"), _("filter by images rating"), 0,
                                _rating_legacy_changed, rating_legacy, N_("all"), N_("unstarred only"), "★", "★ ★",
                                "★ ★ ★", "★ ★ ★ ★", "★ ★ ★ ★ ★", N_("rejected only"), N_("all except rejected"));
-  DT_BAUHAUS_WIDGET(rating_legacy->stars)->show_label = FALSE;
+  dt_bauhaus_widget_hide_label(rating_legacy->stars);
   // we increase the left padding of the 5 star entry to be sure it's visible with the comparator on top
   // we do that here to not cause trouble with shortcuts
   dt_bauhaus_combobox_set_entry_label(rating_legacy->stars, 6, "           ★ ★ ★ ★ ★");

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -114,9 +114,11 @@ static void _lib_navigation_control_redraw_callback(gpointer instance,
                          ? g_strdup(_("small"))
                          : g_strdup_printf("%.0f%%", cur_scale * 100 * darktable.gui->ppd);
   ++darktable.gui->reset;
-  dt_bauhaus_combobox_set(d->zoom, -1);
   if(!dt_bauhaus_combobox_set_from_text(d->zoom, zoomline))
+  {
     dt_bauhaus_combobox_set_text(d->zoom, zoomline);
+    dt_bauhaus_combobox_set(d->zoom, -1);
+  }
   --darktable.gui->reset;
   g_free(zoomline);
 
@@ -203,7 +205,7 @@ void gui_init(dt_lib_module_t *self)
                        GDK_KEY_2, GDK_MOD1_MASK);
 
   dt_bauhaus_combobox_set_editable(d->zoom, TRUE);
-  DT_BAUHAUS_WIDGET(d->zoom)->show_label = FALSE;
+  dt_bauhaus_widget_hide_label(d->zoom);
   gtk_widget_set_halign(d->zoom, GTK_ALIGN_END);
   gtk_widget_set_valign(d->zoom, GTK_ALIGN_END);
   gtk_widget_set_name(d->zoom, "nav-zoom");


### PR DESCRIPTION
I wasn't _really_ happy with my fix for https://github.com/darktable-org/darktable/pull/14991#pullrequestreview-1560391240 and also still annoyed by a bunch of other inconsistent behaviors of sliders and combos, so here is another final round of bauhaus fixes.

Basically this removes a bunch of duplications and merges more of mouse handling in the popup for sliders and combos. Most of the actual value changes are now dealt with in `motion_notify`; `button_press` hands over to it and `button_release` just closes the popup if appropriate. 
* you can now "scroll" through all the values in a combo with a left mouse drag (and see the effect while you do so, just like you would when scrolling through the list of an open popup). May be especially useful for tablet/pen users.
* This also works if you immediately keep dragging after clicking on the combo widget to open the popup. So for example an on/off combo can be very quickly flipped by clicking and flicking the mouse down or up. Again tablet users may like that it requires only one click instead of two.
* The "mute scrolling mode" that is used for the collect module dropdowns is now more consistent in that the selected value always gets activated when the popup closes. It used to be that when you change the selection by scrolling and then close the popup by moving the mouse away from it, the shown selection wasn't consistent with what was in the list view below it.  
This mode may now be more useful for combos that trigger lengthy refreshes; I've set it for the sort order drop down as well.
* when the value of a combo changes while the popup is open, it gets correctly updated and shifted. This could happen when (midi) shortcuts are used, but also for example in "color calibration" when scrolling through the list of "illuminant" modes and hitting "detect from image"; it would select another entry but not move the popup so you'd end up scrolling off it.
* The slider popup will now switch to dragging mode when left-clicking, so you can see what value you'll get when you release the mouse. You can drag around before you do.
* colorpicker etc buttons now get a highlight when they are hovered over
* some general code quality improvements; `dt_bauhaus_widget_hide_label` instead of directly changing the field, standard function naming and using class handlers instead of separately setting different ones for each created combo or slider.
* Collapsible sections now open/close on mouse button _press_, rather than _release_ so they don't get inadvertently triggered when a bauhaus popup was closed after a press but before release.
