### PR TITLE
colorspaces: add Display P3 built-in support

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -119,6 +119,7 @@ static void icc_types()
   fprintf(stderr, " HLG_REC2020\n");
   fprintf(stderr, " PQ_P3\n");
   fprintf(stderr, " HLG_P3\n");
+  fprintf(stderr, " DISPLAY_P3\n");
 }
 
 #define ICC_FROM_STR(name) if(!strcmp(option, #name)) return DT_COLORSPACE_ ## name;
@@ -151,6 +152,7 @@ static dt_colorspaces_color_profile_type_t get_icc_type(const char* option)
   ICC_FROM_STR(HLG_REC2020);
   ICC_FROM_STR(PQ_P3);
   ICC_FROM_STR(HLG_P3);
+  ICC_FROM_STR(DISPLAY_P3);
   return DT_COLORSPACE_LAST;
 }
 #undef ICC_FROM_STR
@@ -775,4 +777,3 @@ int main(int argc, char *arg[])
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -93,7 +93,8 @@ typedef enum dt_colorspaces_color_profile_type_t
   DT_COLORSPACE_HLG_REC2020 = 23,
   DT_COLORSPACE_PQ_P3 = 24,
   DT_COLORSPACE_HLG_P3 = 25,
-  DT_COLORSPACE_LAST = 26
+  DT_COLORSPACE_DISPLAY_P3 = 26,
+  DT_COLORSPACE_LAST = 27
 } dt_colorspaces_color_profile_type_t;
 
 typedef enum dt_colorspaces_color_mode_t
@@ -367,4 +368,3 @@ void dt_colorspaces_rgb_to_cygm(float *out, int num, double RGB_to_CAM[4][3]);
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -330,6 +330,11 @@ int write_image(struct dt_imageio_module_data_t *data,
       image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_HLG;
       image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL;
       break;
+    case DT_COLORSPACE_DISPLAY_P3:
+      image->colorPrimaries = AVIF_COLOR_PRIMARIES_SMPTE432;
+      image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_SRGB;
+      image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL;
+      break;
     default:
       break;
   }

--- a/src/imageio/format/jxl.c
+++ b/src/imageio/format/jxl.c
@@ -246,6 +246,10 @@ int write_image(struct dt_imageio_module_data_t *data, const char *filename, con
       color_encoding.primaries = JXL_PRIMARIES_P3;
       color_encoding.transfer_function = JXL_TRANSFER_FUNCTION_HLG;
       break;
+    case DT_COLORSPACE_DISPLAY_P3:
+      color_encoding.primaries = JXL_PRIMARIES_P3;
+      color_encoding.transfer_function = JXL_TRANSFER_FUNCTION_SRGB;
+      break;
     default:
       write_color_natively = FALSE;
       break;


### PR DESCRIPTION
From Wikipedia: "Since iPhone 7, the built in camera creates images tagged with the Display P3 ICC profile."

Also, seems more and more image formats (AVIF/HEIF, JPEG XL, even [new PNG spec](https://w3c.github.io/PNG-spec/#cICP-chunk)) are pushing/switching to more compact CICP profile tagging rather than embedding ICC, so we need this (potentially popular?) profile as built-in (or ability for on-the fly profile generation from CICP).