### PR TITLE
disable rotate&perspective structure modes on focus loss

### DIFF
--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -6020,6 +6020,8 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
     }
     else
     {
+      _gui_update_structure_states(self, NULL);
+      _do_clean_structure(self, p, TRUE);
       _commit_crop_box(p, g);
     }
   }

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -1818,7 +1818,7 @@ static gboolean _area_motion_notify_callback(GtkWidget *widget, GdkEventMotion *
   c->mouse_x = CLAMP(event->x - inset, 0, width) / (float)width;
   c->mouse_y = 1.0 - CLAMP(event->y - inset, 0, height) / (float)height;
 
-  darktable.control->element = 7 * _mouse_to_curve(c->mouse_x, c->zoom_factor, c->offset_x) + 0.5f;
+  darktable.control->element = (int)(8.0 * _mouse_to_curve(c->mouse_x, c->zoom_factor, c->offset_x) + 0.5f) % 8;
 
   // move a node
   if(event->state & GDK_BUTTON1_MASK)
@@ -2311,7 +2311,7 @@ static float _action_process_zones(gpointer target, dt_action_element_t element,
   int ch = c->channel;
   const int nodes = p->curve_num_nodes[ch];
   dt_iop_colorzones_node_t *curve = p->curve[ch];
-  float x = (float)element / 7.0;
+  float x = (float)element / 8.0;
 
   gboolean close_enough = FALSE;
   int node = 0;

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -433,7 +433,9 @@ static void _basics_on_off_callback2(GtkWidget *widget, GdkEventButton *e, dt_li
   }
 }
 
-static void _sync_visibility(GtkWidget *widget, dt_lib_modulegroups_basic_item_t *item)
+static void _sync_visibility(GtkWidget *widget,
+                             GParamSpec *pspec,
+                             dt_lib_modulegroups_basic_item_t *item)
 {
   if(widget == item->temp_widget)
     gtk_widget_set_visible(item->widget, gtk_widget_get_visible(item->temp_widget));
@@ -593,19 +595,13 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
     gtk_widget_set_tooltip_text(item->widget, txt);
     g_free(txt);
 
-    gtk_widget_add_events(item->widget     , GDK_VISIBILITY_NOTIFY_MASK);
-    g_signal_connect(item->widget     , "show", G_CALLBACK(_sync_visibility), item);
-    g_signal_connect(item->widget     , "hide", G_CALLBACK(_sync_visibility), item);
-    gtk_widget_add_events(item->old_parent , GDK_VISIBILITY_NOTIFY_MASK);
-    g_signal_connect(item->old_parent , "show", G_CALLBACK(_sync_visibility), item);
-    g_signal_connect(item->old_parent , "hide", G_CALLBACK(_sync_visibility), item);
-    gtk_widget_add_events(item->temp_widget, GDK_VISIBILITY_NOTIFY_MASK);
-    g_signal_connect(item->temp_widget, "show", G_CALLBACK(_sync_visibility), item);
-    g_signal_connect(item->temp_widget, "hide", G_CALLBACK(_sync_visibility), item);
+    g_signal_connect(item->widget      , "notify::visible", G_CALLBACK(_sync_visibility), item);
+    g_signal_connect(item->old_parent  , "notify::visible", G_CALLBACK(_sync_visibility), item);
+    g_signal_connect(item->temp_widget , "notify::visible", G_CALLBACK(_sync_visibility), item);
     g_signal_connect(G_OBJECT(item->temp_widget), "destroy", G_CALLBACK(gtk_widget_destroyed), &item->temp_widget);
     g_signal_connect_swapped(G_OBJECT(item->temp_widget), "destroy", G_CALLBACK(_basics_remove_widget), item);
 
-    _sync_visibility(item->widget, item);
+    _sync_visibility(item->widget, NULL, item);
   }
 
   // if it's the first widget of a module, we need to create the module box structure


### PR DESCRIPTION
fixes #15131

Also fixes the colors/curve points in colorzones that can be manipulated via shortcuts. Used to have both 0 and 360 (which really are the same point).