### PR TITLE
Bugfix: Use intel OpenCL platform aliases

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -333,7 +333,7 @@
     <type>bool</type>
     <default>${DEFCONFIG_NONAPPLE}</default>
     <shortdescription>Intel HD</shortdescription>
-    <longdescription>Intel(R) OpenCL HD Graphics (vendor provided)</longdescription>
+    <longdescription>Intel(R) OpenCL HD Graphics and Intel(R) OpenCL Graphics (vendor provided)</longdescription>
   </dtconfig>
   <dtconfig prefs="processing" section="platform" capability="nonapple" restart="true">
     <name>clplatform_nvidiacuda</name>

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -1246,6 +1246,11 @@ void dt_opencl_init(
 
       if(dt_conf_key_exists(platform_key))
         valid_platform = dt_conf_get_bool(platform_key);
+      /* In some cases it is safe to assume platform aliases instead of adding
+          an additional conf key or falling back to clplatform_other
+      */
+      else if(strcmp(platform_key, "clplatform_intelropenclgraphics") == 0)
+        valid_platform = dt_conf_get_bool("clplatform_intelropenclhdgraphics");
       else
         valid_platform = dt_conf_get_bool("clplatform_other");
     }


### PR DESCRIPTION
It is safe to make the intel non-HD OpenCL platform also available via the HD conf key.

Fixes #15150 