### PR TITLE
macOS: Provide an application menu

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -138,6 +138,7 @@ FILE(GLOB SOURCE_FILES
   "dtgtk/thumbnail_btn.c"
   "dtgtk/thumbtable.c"
   "dtgtk/togglebutton.c"
+  "gui/about.c"
   "gui/accelerators.c"
   "gui/gtkentry.c"
   "gui/guides.c"
@@ -1042,3 +1043,17 @@ if(USE_LIBRAW AND NOT (DONT_USE_INTERNAL_LIBRAW AND libraw_FOUND))
   add_subdirectory(external/LibRaw-cmake)
   target_link_libraries(lib_darktable PRIVATE libraw::libraw)
 endif()
+
+add_custom_command(
+  DEPENDS ${CMAKE_SOURCE_DIR}/tools/authors_h.sh ${CMAKE_SOURCE_DIR}/AUTHORS
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/tools/darktable_authors.h
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/tools/
+  COMMAND bash ${CMAKE_SOURCE_DIR}/tools/authors_h.sh ${CMAKE_SOURCE_DIR}/AUTHORS ${CMAKE_CURRENT_BINARY_DIR}/tools/darktable_authors.h
+  COMMENT "Generating authors.h for about dialog."
+)
+
+add_custom_target(
+  generate_authors_h ALL
+  DEPENDS ${CMAKE_SOURCE_DIR}/tools/authors_h.sh ${CMAKE_SOURCE_DIR}/AUTHORS ${CMAKE_CURRENT_BINARY_DIR}/tools/darktable_authors.h
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)

--- a/src/common/usermanual_url.c
+++ b/src/common/usermanual_url.c
@@ -26,6 +26,7 @@ typedef struct _help_url
 
 dt_help_url urls_db[] =
 {
+  {"document_root",              "/"},
   {"ratings",                    "lighttable/digital-asset-management/star-color/#star-ratings"},
   {"layout_filemanager",         "lighttable/lighttable-modes/filemanager/"},
   {"layout_zoomable",            "lighttable/lighttable-modes/zoomable-lighttable/"},

--- a/src/gui/about.c
+++ b/src/gui/about.c
@@ -1,0 +1,68 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2010-2023 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "gui/gtk.h"
+#include "about.h"
+#ifdef GDK_WINDOWING_QUARTZ
+#include "osx/osx.h"
+#endif
+
+void darktable_show_about_dialog()
+{
+  GtkWidget *dialog = gtk_about_dialog_new();
+  gtk_widget_set_name (dialog, "about-dialog");
+#ifdef GDK_WINDOWING_QUARTZ
+  dt_osx_disallow_fullscreen(dialog);
+#endif
+  gtk_about_dialog_set_program_name(GTK_ABOUT_DIALOG(dialog), PACKAGE_NAME);
+  gtk_about_dialog_set_version(GTK_ABOUT_DIALOG(dialog), darktable_package_version);
+  char *copyright = g_strdup_printf(_("copyright (c) the authors 2009-%s"), darktable_last_commit_year);
+  gtk_about_dialog_set_copyright(GTK_ABOUT_DIALOG(dialog), copyright);
+  g_free(copyright);
+  gtk_about_dialog_set_comments(GTK_ABOUT_DIALOG(dialog),
+                                _("organize and develop images from digital cameras"));
+  gtk_about_dialog_set_website(GTK_ABOUT_DIALOG(dialog), "https://www.darktable.org/");
+  gtk_about_dialog_set_website_label(GTK_ABOUT_DIALOG(dialog), "website");
+  dt_logo_season_t season = dt_util_get_logo_season();
+  char *icon;
+  if(season != DT_LOGO_SEASON_NONE)
+    icon = g_strdup_printf("darktable-%d", (int)season);
+  else
+    icon = g_strdup("darktable");
+  gtk_about_dialog_set_logo_icon_name(GTK_ABOUT_DIALOG(dialog), icon);
+  g_free(icon);
+
+  const char *str = _("all those of you that made previous releases possible");
+
+#include "tools/darktable_authors.h"
+
+  const char *final[] = {str, NULL };
+  gtk_about_dialog_add_credit_section (GTK_ABOUT_DIALOG(dialog), _("and..."), final);
+
+  gtk_about_dialog_set_translator_credits(GTK_ABOUT_DIALOG(dialog), _("translator-credits"));
+
+  gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)));
+  gtk_dialog_run(GTK_DIALOG(dialog));
+  gtk_widget_destroy(dialog);
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/gui/about.h
+++ b/src/gui/about.h
@@ -1,0 +1,19 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2010-2023 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+void darktable_show_about_dialog();

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -45,6 +45,7 @@
 #include "gui/presets.h"
 #include "views/view.h"
 #include "gui/about.h"
+#include "gui/preferences.h"
 
 #include <gdk/gdkkeysyms.h>
 #ifdef GDK_WINDOWING_WAYLAND
@@ -1073,6 +1074,10 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
                    G_CALLBACK(darktable_show_about_dialog), NULL);
   gtkosx_application_insert_app_menu_item(OSXApp, mi_about, 0);
 
+  GtkWidget *mi_prefs = gtk_menu_item_new_with_label (_("preferences"));
+  g_signal_connect(G_OBJECT(mi_prefs), "activate",
+                   G_CALLBACK(dt_gui_preferences_show), NULL);
+  gtkosx_application_insert_app_menu_item(OSXApp, mi_prefs, 1);
 
 #endif
   g_signal_connect(G_OBJECT(OSXApp), "NSApplicationBlockTermination", G_CALLBACK(_osx_quit_callback), NULL);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1054,12 +1054,6 @@ void dt_open_url(const char* url)
   }
 }
 
-static void _open_url(GtkWidget *widget, gpointer url)
-{
-  dt_open_url((const char *) url);
-}
-
-
 #ifdef MAC_INTEGRATION
 static void _osx_ctl_switch_mode_to(GtkWidget *mi, gpointer mode)
 {
@@ -1075,6 +1069,10 @@ static void _osx_add_view_menu_item(GtkWidget* menu, const char* label, gpointer
                    G_CALLBACK(_osx_ctl_switch_mode_to), mode);
 }
 
+static void _open_url(GtkWidget *widget, gpointer url)
+{
+  dt_open_url((const char *) url);
+}
 #endif
 
 int dt_gui_gtk_init(dt_gui_gtk_t *gui)

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -44,6 +44,7 @@
 #include "control/signal.h"
 #include "gui/presets.h"
 #include "views/view.h"
+#include "gui/about.h"
 
 #include <gdk/gdkkeysyms.h>
 #ifdef GDK_WINDOWING_WAYLAND
@@ -1064,6 +1065,15 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   GtkosxApplication *OSXApp = g_object_new(GTKOSX_TYPE_APPLICATION, NULL);
   gtkosx_application_set_menu_bar(
       OSXApp, GTK_MENU_SHELL(gtk_menu_bar_new())); // needed for default entries to show up
+
+  // GTK translates the item with index 0 automatically so no need to localize.
+  // Furthermore, the application name (darktable) is automatically appended.
+  GtkWidget *mi_about = gtk_menu_item_new_with_label ("About");
+  g_signal_connect(G_OBJECT(mi_about), "activate",
+                   G_CALLBACK(darktable_show_about_dialog), NULL);
+  gtkosx_application_insert_app_menu_item(OSXApp, mi_about, 0);
+
+
 #endif
   g_signal_connect(G_OBJECT(OSXApp), "NSApplicationBlockTermination", G_CALLBACK(_osx_quit_callback), NULL);
   g_signal_connect(G_OBJECT(OSXApp), "NSApplicationOpenFile", G_CALLBACK(_osx_openfile_callback), NULL);

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -201,6 +201,7 @@ static inline GdkPixbuf *dt_gdk_pixbuf_new_from_file_at_size(const char *filenam
 void dt_gui_add_class(GtkWidget *widget, const gchar *class_name);
 void dt_gui_remove_class(GtkWidget *widget, const gchar *class_name);
 
+void dt_open_url(const char *url);
 int dt_gui_gtk_init(dt_gui_gtk_t *gui);
 void dt_gui_gtk_run(dt_gui_gtk_t *gui);
 void dt_gui_gtk_cleanup(dt_gui_gtk_t *gui);

--- a/src/libs/CMakeLists.txt
+++ b/src/libs/CMakeLists.txt
@@ -5,20 +5,6 @@ include(manage-symbol-visibility)
 add_definitions(-include common/module_api.h)
 add_definitions(-include libs/lib_api.h)
 
-add_custom_command(
-  DEPENDS ${CMAKE_SOURCE_DIR}/tools/authors_h.sh ${CMAKE_SOURCE_DIR}/AUTHORS
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/tools/darktable_authors.h
-  COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/tools/
-  COMMAND bash ${CMAKE_SOURCE_DIR}/tools/authors_h.sh ${CMAKE_SOURCE_DIR}/AUTHORS ${CMAKE_CURRENT_BINARY_DIR}/tools/darktable_authors.h
-  COMMENT "Generating authors.h for about dialog."
-)
-
-add_custom_target(
-  generate_authors_h ALL
-  DEPENDS ${CMAKE_SOURCE_DIR}/tools/authors_h.sh ${CMAKE_SOURCE_DIR}/AUTHORS ${CMAKE_CURRENT_BINARY_DIR}/tools/darktable_authors.h
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-)
-
 # The modules
 set(MODULES import export copy_history styles tagging image select collect recentcollect filtering metadata metadata_view navigation histogram history snapshots modulegroups backgroundjobs colorpicker masks session duplicate ioporder)
 

--- a/src/libs/tools/darktable.c
+++ b/src/libs/tools/darktable.c
@@ -27,9 +27,7 @@
 #include "gui/gtk.h"
 #include "libs/lib.h"
 #include "libs/lib_api.h"
-#ifdef GDK_WINDOWING_QUARTZ
-#include "osx/osx.h"
-#endif
+#include "gui/about.h"
 
 #include <librsvg/rsvg.h>
 // ugh, ugly hack. why do people break stuff all the time?
@@ -57,8 +55,6 @@ static gboolean _lib_darktable_draw_callback(GtkWidget *widget, cairo_t *cr, gpo
 /* button press callback */
 static gboolean _lib_darktable_button_press_callback(GtkWidget *widget, GdkEventButton *event,
                                                      gpointer user_data);
-/* show the about dialog */
-static void _lib_darktable_show_about_dialog();
 
 const char *name(dt_lib_module_t *self)
 {
@@ -268,47 +264,8 @@ static gboolean _lib_darktable_button_press_callback(GtkWidget *widget, GdkEvent
                                                      gpointer user_data)
 {
   /* show about box */
-  _lib_darktable_show_about_dialog();
+  darktable_show_about_dialog();
   return TRUE;
-}
-
-static void _lib_darktable_show_about_dialog()
-{
-  GtkWidget *dialog = gtk_about_dialog_new();
-  gtk_widget_set_name (dialog, "about-dialog");
-#ifdef GDK_WINDOWING_QUARTZ
-  dt_osx_disallow_fullscreen(dialog);
-#endif
-  gtk_about_dialog_set_program_name(GTK_ABOUT_DIALOG(dialog), PACKAGE_NAME);
-  gtk_about_dialog_set_version(GTK_ABOUT_DIALOG(dialog), darktable_package_version);
-  char *copyright = g_strdup_printf(_("copyright (c) the authors 2009-%s"), darktable_last_commit_year);
-  gtk_about_dialog_set_copyright(GTK_ABOUT_DIALOG(dialog), copyright);
-  g_free(copyright);
-  gtk_about_dialog_set_comments(GTK_ABOUT_DIALOG(dialog),
-                                _("organize and develop images from digital cameras"));
-  gtk_about_dialog_set_website(GTK_ABOUT_DIALOG(dialog), "https://www.darktable.org/");
-  gtk_about_dialog_set_website_label(GTK_ABOUT_DIALOG(dialog), "website");
-  dt_logo_season_t season = dt_util_get_logo_season();
-  char *icon;
-  if(season != DT_LOGO_SEASON_NONE)
-    icon = g_strdup_printf("darktable-%d", (int)season);
-  else
-    icon = g_strdup("darktable");
-  gtk_about_dialog_set_logo_icon_name(GTK_ABOUT_DIALOG(dialog), icon);
-  g_free(icon);
-
-  const char *str = _("all those of you that made previous releases possible");
-
-#include "tools/darktable_authors.h"
-
-  const char *final[] = {str, NULL };
-  gtk_about_dialog_add_credit_section (GTK_ABOUT_DIALOG(dialog), _("and..."), final);
-
-  gtk_about_dialog_set_translator_credits(GTK_ABOUT_DIALOG(dialog), _("translator-credits"));
-
-  gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)));
-  gtk_dialog_run(GTK_DIALOG(dialog));
-  gtk_widget_destroy(dialog);
 }
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py


### PR DESCRIPTION
On macOS, each application has an application menu, filling the top row of the screen.

So far, darktable on Mac has this menu, but with only one usable item: "Quit darktable"

Although darktable not really needs an application menu we should fulfill the minimum of Apple's human interface guidelines regarding the app menu.

This PR provides this menu and makes the darktable feeling on macOS a little more "macOS like".

<img width="348" alt="Bildschirmfoto 2023-09-02 um 12 05 19" src="https://github.com/darktable-org/darktable/assets/4083281/49178462-3477-44ff-a529-b0a73e85a392">\

<img width="339" alt="Bildschirmfoto 2023-09-02 um 12 05 31" src="https://github.com/darktable-org/darktable/assets/4083281/f49129f8-07b0-410c-a8d4-1ae3770f0b65">\

<img width="566" alt="Bildschirmfoto 2023-09-02 um 12 05 46" src="https://github.com/darktable-org/darktable/assets/4083281/e0e6e8fd-2f5c-4651-bdeb-5fd0641c2902">

