### PR TITLE
Enable further exposing if there is a color picker enabled

### DIFF
--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2478,7 +2478,8 @@ void dt_masks_draw_clone_source_pos(cairo_t *cr,
   dashed[1] /= zoom_scale;
 
   cairo_set_dash(cr, dashed, 0, 0);
-  cairo_set_line_width(cr, 3.0 / zoom_scale);
+  const double lwidth = (dt_iop_color_picker_is_visible(darktable.develop) ? 0.5 : 1.0) / zoom_scale;
+  cairo_set_line_width(cr, 3.0 * lwidth);
   cairo_set_source_rgba(cr, .3, .3, .3, .8);
 
   cairo_move_to(cr, x + dx, y);
@@ -2487,7 +2488,7 @@ void dt_masks_draw_clone_source_pos(cairo_t *cr,
   cairo_line_to(cr, x, y - dy);
   cairo_stroke_preserve(cr);
 
-  cairo_set_line_width(cr, 1.0 / zoom_scale);
+  cairo_set_line_width(cr, lwidth);
   cairo_set_source_rgba(cr, .8, .8, .8, .8);
   cairo_stroke(cr);
 }
@@ -2696,7 +2697,8 @@ void dt_masks_draw_anchor(cairo_t *cr,
                   anchor_size,
                   anchor_size);
   cairo_fill_preserve(cr);
-  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(selected ? 2.0 : 1.0) / zoom_scale);
+  const double lwidth = (dt_iop_color_picker_is_visible(darktable.develop) ? 0.5 : 1.0) / zoom_scale;
+  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(selected ? 2.0 : 1.0) * lwidth);
   dt_draw_set_color_overlay(cr, FALSE, 0.8);
   cairo_stroke(cr);
 }
@@ -2714,7 +2716,8 @@ void dt_masks_draw_ctrl(cairo_t *cr,
   dt_draw_set_color_overlay(cr, TRUE, 0.8);
   cairo_fill_preserve(cr);
 
-  cairo_set_line_width(cr, 1.0 / zoom_scale);
+  const double lwidth = (dt_iop_color_picker_is_visible(darktable.develop) ? 0.5 : 1.0) / zoom_scale;
+  cairo_set_line_width(cr, lwidth);
   dt_draw_set_color_overlay(cr, FALSE, 0.8);
   cairo_stroke(cr);
 }
@@ -2780,18 +2783,19 @@ void dt_masks_stroke_arrow(cairo_t *cr,
   double dashed[] = { 0, 0 };
   cairo_set_dash(cr, dashed, 0, 0);
 
+  const double lwidth = (dt_iop_color_picker_is_visible(darktable.develop) ? 0.5 : 1.0) / zoom_scale;
   if((gui->group_selected == group) && (gui->form_selected || gui->form_dragging))
-    cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2.5) / zoom_scale);
+    cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2.5) * lwidth);
   else
-    cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.5) / zoom_scale);
+    cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.5) * lwidth);
 
   dt_draw_set_color_overlay(cr, FALSE, 0.8);
   cairo_stroke_preserve(cr);
 
   if((gui->group_selected == group) && (gui->form_selected || gui->form_dragging))
-    cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.0) / zoom_scale);
+    cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.0) * lwidth);
   else
-    cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(0.5) / zoom_scale);
+    cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(0.5) * lwidth);
 
   dt_draw_set_color_overlay(cr, TRUE, 0.8);
   cairo_stroke(cr);
@@ -2844,17 +2848,17 @@ void dt_masks_line_stroke(cairo_t *cr,
   dt_draw_set_color_overlay(cr, FALSE, selected ? 0.8 : 0.5);
   cairo_set_dash(cr, dashed, border ? len : 0, 0);
 
+  const double lwidth = (dt_iop_color_picker_is_visible(darktable.develop) ? 0.5 : 1.0) / zoom_scale;
   const double line_width =
     ((border ? size_border : (source ? size_source : size_mask))
-     * (selected ? factor_selected : 1.0)) / zoom_scale;
+     * (selected ? factor_selected : 1.0)) * lwidth;
 
   cairo_set_line_width(cr, line_width);
 
   cairo_stroke_preserve(cr);
 
   // second the foreground draw, lighter (same size as darker if selected)
-  cairo_set_line_width
-    (cr, (line_width / (selected && !border ? 1.0 : 2.0)));
+  cairo_set_line_width(cr, (line_width / (selected && !border ? 1.0 : 2.0)));
 
   dt_draw_set_color_overlay(cr, TRUE, selected ? 0.9 : 0.6);
   cairo_set_dash(cr, dashed, border ? len : 0, 4);

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -2671,7 +2671,10 @@ void gui_post_expose(struct dt_iop_module_t *self,
   cairo_scale(cr, zoom_scale, zoom_scale);
   cairo_translate(cr, -.5f * wd - zoom_x * wd, -.5f * ht - zoom_y * ht);
 
-  cairo_set_line_width(cr, 2.0 / zoom_scale);
+  const gboolean showhandle = dt_iop_color_picker_is_visible(darktable.develop) == FALSE;
+  const double lwidth = (showhandle ? 1.0 : 0.5) / zoom_scale;
+
+  cairo_set_line_width(cr, 2.0 * lwidth);
   const double origin = 9. / zoom_scale;
   const double destination = 18. / zoom_scale;
 
@@ -2697,19 +2700,22 @@ void gui_post_expose(struct dt_iop_module_t *self,
       cairo_stroke(cr);
     }
 
-    // draw outline circle
-    cairo_set_source_rgba(cr, 1., 1., 1., 1.);
-    cairo_arc(cr, g->box[k].x, g->box[k].y, 8. / zoom_scale, 0, 2. * M_PI);
-    cairo_stroke(cr);
+    if(showhandle)
+    {
+      // draw outline circle
+      cairo_set_source_rgba(cr, 1., 1., 1., 1.);
+      cairo_arc(cr, g->box[k].x, g->box[k].y, 8. / zoom_scale, 0, 2. * M_PI);
+      cairo_stroke(cr);
 
-    // draw black dot
-    cairo_set_source_rgba(cr, 0., 0., 0., 1.);
-    cairo_arc(cr, g->box[k].x, g->box[k].y, 1.5 / zoom_scale, 0, 2. * M_PI);
-    cairo_fill(cr);
+      // draw black dot
+      cairo_set_source_rgba(cr, 0., 0., 0., 1.);
+      cairo_arc(cr, g->box[k].x, g->box[k].y, 1.5 / zoom_scale, 0, 2. * M_PI);
+      cairo_fill(cr);
+    }
   }
 
   // draw symmetry axes
-  cairo_set_line_width(cr, 1.5 / zoom_scale);
+  cairo_set_line_width(cr, 1.5 * lwidth);
   cairo_set_source_rgba(cr, 1., 1., 1., 1.);
   const point_t top_ideal = { 0.5f, 1.f };
   const point_t top = apply_homography(top_ideal, g->homography);
@@ -2787,9 +2793,9 @@ void gui_post_expose(struct dt_iop_module_t *self,
       }
     }
 
-    cairo_set_line_width(cr, 5.0 / zoom_scale);
+    cairo_set_line_width(cr, 5.0 * lwidth);
     cairo_stroke_preserve(cr);
-    cairo_set_line_width(cr, 2.0 / zoom_scale);
+    cairo_set_line_width(cr, 2.0 * lwidth);
     cairo_set_source_rgba(cr, 1., 1., 1., 1.);
     cairo_stroke(cr);
 

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -1338,6 +1338,7 @@ void gui_post_expose(struct dt_iop_module_t *self,
   const gboolean external = dev->cropping.exposer
                         &&  dev->cropping.requester
                         && (dev->cropping.exposer != dev->cropping.requester);
+  const gboolean dimmed = dt_iop_color_picker_is_visible(dev) || external;
 
   // we don't do anything if the image is not ready within crop module
   // and we don't have visualizing enforced by other modules
@@ -1363,11 +1364,11 @@ void gui_post_expose(struct dt_iop_module_t *self,
   pzx += 0.5f;
   pzy += 0.5f;
 
-  const double fillc = external ? 0.9 : 0.2;
-  const double dashes = (external ? 0.3 : 0.5) * DT_PIXEL_APPLY_DPI(5.0) / zoom_scale;
-  const double effect = external ? 0.6 : 1.0;
+  const double fillc = dimmed ? 0.9 : 0.2;
+  const double dashes = (dimmed ? 0.3 : 0.5) * DT_PIXEL_APPLY_DPI(5.0) / zoom_scale;
+  const double effect = dimmed ? 0.6 : 1.0;
 
-  if(_set_max_clip(self) && !external)
+  if(_set_max_clip(self) && !dimmed)
   {
     cairo_set_source_rgba(cr, fillc, fillc, fillc, 1.0 - fillc);
     cairo_set_fill_rule(cr, CAIRO_FILL_RULE_EVEN_ODD);
@@ -1386,7 +1387,7 @@ void gui_post_expose(struct dt_iop_module_t *self,
     cairo_stroke(cr);
   }
 
-  if(external) return;
+  if(dimmed) return;
 
   // draw cropping window dimensions if first mouse button is pressed
   if(darktable.control->button_down && darktable.control->button_down_which == 1)

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -516,11 +516,12 @@ void gui_post_expose(
 
   const float xa = g->xa * wd, xb = g->xb * wd, ya = g->ya * ht, yb = g->yb * ht;
   // the lines
+  const double lwidth = (dt_iop_color_picker_is_visible(darktable.develop) ? 0.5 : 1.0) / zoom_scale;
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
   if(g->selected == 3 || g->dragging == 3)
-    cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(5.0) / zoom_scale);
+    cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(5.0) * lwidth);
   else
-    cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(3.0) / zoom_scale);
+    cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(3.0) * lwidth);
   dt_draw_set_color_overlay(cr, FALSE, 0.8);
 
   cairo_move_to(cr, xa, ya);
@@ -528,14 +529,16 @@ void gui_post_expose(
   cairo_stroke(cr);
 
   if(g->selected == 3 || g->dragging == 3)
-    cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2.0) / zoom_scale);
+    cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2.0) * lwidth);
   else
-    cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.0) / zoom_scale);
+    cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.0) * lwidth);
   dt_draw_set_color_overlay(cr, TRUE, 0.8);
   cairo_move_to(cr, xa, ya);
   cairo_line_to(cr, xb, yb);
   cairo_stroke(cr);
 
+  if(dt_iop_color_picker_is_visible(darktable.develop))
+    return;
   // the extremities
   const float pr_d = darktable.develop->preview_downsampling;
   float x1, y1, x2, y2;
@@ -551,7 +554,7 @@ void gui_post_expose(
   cairo_line_to(cr, x1, y1);
   cairo_line_to(cr, x2, y2);
   cairo_close_path(cr);
-  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.0) / zoom_scale);
+  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.0) * lwidth);
   if(g->selected == 1 || g->dragging == 1)
     dt_draw_set_color_overlay(cr, TRUE, 1.0);
   else
@@ -573,7 +576,7 @@ void gui_post_expose(
   cairo_line_to(cr, x1, y1);
   cairo_line_to(cr, x2, y2);
   cairo_close_path(cr);
-  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.0) / zoom_scale);
+  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.0) * lwidth);
   if(g->selected == 2 || g->dragging == 2)
     dt_draw_set_color_overlay(cr, TRUE, 1.0);
   else

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1731,7 +1731,7 @@ static void set_line_width(cairo_t *cr,
                            dt_liquify_ui_width_enum_t w)
 {
   const double width = get_ui_width(scale, w);
-  cairo_set_line_width(cr, width);
+  cairo_set_line_width(cr, width * (dt_iop_color_picker_is_visible(darktable.develop) ? 0.5 : 1.0));
 }
 
 static gboolean detect_drag(const dt_iop_liquify_gui_data_t *g,
@@ -1855,6 +1855,7 @@ static void _draw_paths(dt_iop_module_t *module,
 
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
 
+  const gboolean showhandle = dt_iop_color_picker_is_visible(darktable.develop) == FALSE;
   // do not display any iterpolated items as slow when:
   //   - we are dragging (pan)
   //   - the button one is pressed
@@ -2020,7 +2021,7 @@ static void _draw_paths(dt_iop_module_t *module,
 
       if(data->header.type == DT_LIQUIFY_PATH_CURVE_TO_V1)
       {
-        if(layer == DT_LIQUIFY_LAYER_CTRLPOINT1_HANDLE &&
+        if(layer == DT_LIQUIFY_LAYER_CTRLPOINT1_HANDLE && showhandle &&
             !(prev && prev->header.node_type == DT_LIQUIFY_NODE_TYPE_AUTOSMOOTH))
         {
           THINLINE; FG_COLOR;
@@ -2028,7 +2029,7 @@ static void _draw_paths(dt_iop_module_t *module,
           cairo_line_to(cr, crealf(data->node.ctrl1), cimagf(data->node.ctrl1));
           cairo_stroke(cr);
         }
-        if(layer == DT_LIQUIFY_LAYER_CTRLPOINT2_HANDLE &&
+        if(layer == DT_LIQUIFY_LAYER_CTRLPOINT2_HANDLE && showhandle &&
             data->header.node_type != DT_LIQUIFY_NODE_TYPE_AUTOSMOOTH)
         {
           THINLINE; FG_COLOR;
@@ -2058,7 +2059,7 @@ static void _draw_paths(dt_iop_module_t *module,
 
       const dt_liquify_warp_t *warp  = &data->warp;
 
-      if(layer == DT_LIQUIFY_LAYER_RADIUSPOINT_HANDLE)
+      if(layer == DT_LIQUIFY_LAYER_RADIUSPOINT_HANDLE && showhandle)
       {
         draw_circle(cr, point, 2.0 * cabsf(warp->radius - point));
         THICKLINE; FG_COLOR;
@@ -2076,7 +2077,7 @@ static void _draw_paths(dt_iop_module_t *module,
         cairo_stroke(cr);
       }
 
-      if(layer == DT_LIQUIFY_LAYER_HARDNESSPOINT1_HANDLE)
+      if(layer == DT_LIQUIFY_LAYER_HARDNESSPOINT1_HANDLE && showhandle)
       {
         draw_circle(cr, point, 2.0 * cabsf(warp->radius - point) * warp->control1);
         THICKLINE; FG_COLOR;
@@ -2085,7 +2086,7 @@ static void _draw_paths(dt_iop_module_t *module,
         cairo_stroke(cr);
       }
 
-      if(layer == DT_LIQUIFY_LAYER_HARDNESSPOINT2_HANDLE)
+      if(layer == DT_LIQUIFY_LAYER_HARDNESSPOINT2_HANDLE && showhandle)
       {
         draw_circle(cr, point, 2.0 * cabsf(warp->radius - point) * warp->control2);
         THICKLINE; FG_COLOR;
@@ -2116,7 +2117,7 @@ static void _draw_paths(dt_iop_module_t *module,
         cairo_stroke(cr);
       }
 
-      if(layer == DT_LIQUIFY_LAYER_STRENGTHPOINT_HANDLE)
+      if(layer == DT_LIQUIFY_LAYER_STRENGTHPOINT_HANDLE && showhandle)
       {
         cairo_move_to(cr, crealf(point), cimagf(point));
         if(warp->type == DT_LIQUIFY_WARP_TYPE_LINEAR)

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -329,6 +329,8 @@ static void draw_overlay(cairo_t *cr, float x, float y, float fx, float fy, int 
   cairo_restore(cr);
   cairo_stroke(cr);
 
+  if(dt_iop_color_picker_is_visible(darktable.develop))
+    return;
   // the handles
   const float radius_sel = DT_PIXEL_APPLY_DPI(6.0) / zoom_scale;
   const float radius_reg = DT_PIXEL_APPLY_DPI(4.0) / zoom_scale;
@@ -447,10 +449,11 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   int grab = get_grab(pzx * wd - vignette_x, pzy * ht - vignette_y, vignette_w, -vignette_h, vignette_fx,
                       -vignette_fy, zoom_scale);
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(3.0) / zoom_scale);
+  const double lwidth = (dt_iop_color_picker_is_visible(darktable.develop) ? 0.5 : 1.0) / zoom_scale;
+  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(3.0) * lwidth);
   dt_draw_set_color_overlay(cr, FALSE, 0.8);
   draw_overlay(cr, vignette_w, vignette_h, vignette_fx, vignette_fy, grab, zoom_scale);
-  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.0) / zoom_scale);
+  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.0) * lwidth);
   dt_draw_set_color_overlay(cr, TRUE, 0.8);
   draw_overlay(cr, vignette_w, vignette_h, vignette_fx, vignette_fy, grab, zoom_scale);
 }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -649,48 +649,45 @@ void expose(
     _darkroom_pickers_draw(self, cri, width, height, zoom, closeup, zoom_x, zoom_y,
                            &samples, TRUE);
   }
-  else
-  {
-    // display mask if we have a current module activated or if the
-    // masks manager module is expanded
-    const gboolean display_masks =
-      (dev->gui_module
+  // display mask if we have a current module activated or if the
+  // masks manager module is expanded
+  const gboolean display_masks =
+    (dev->gui_module
       && dev->gui_module->enabled
       && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS)
     || dt_lib_gui_get_expanded(dt_lib_get_module("masks"));
 
-    if(dev->form_visible && display_masks)
+  if(dev->form_visible && display_masks)
+  {
+    dt_print(DT_DEBUG_EXPOSE, "[darkroom expose] masks post expose\n");
+    dt_masks_events_post_expose(dev->gui_module, cri, width, height, pointerx, pointery);
+  }
+
+  // true if anything could be exposed
+  if(dev->gui_module && dev->gui_module != dev->proxy.rotate)
+  {
+    // the cropping.exposer->gui_post_expose needs special care
+    if(expose_full
+      && dev->cropping.exposer
+      && dev->cropping.requester
+      && dev->cropping.exposer->gui_post_expose)
     {
-      dt_print(DT_DEBUG_EXPOSE, "[darkroom expose] masks post expose\n");
-      dt_masks_events_post_expose(dev->gui_module, cri, width, height, pointerx, pointery);
+      dt_print(DT_DEBUG_EXPOSE, "[darkroom expose] cropper post_expose [%s]\n", dev->cropping.exposer->op);
+      cairo_save(cri);
+      dev->cropping.exposer->gui_post_expose(dev->cropping.exposer, cri,
+                                     width, height, pointerx, pointery);
+      cairo_restore(cri);
     }
 
-    // true if anything could be exposed
-    if(dev->gui_module && dev->gui_module != dev->proxy.rotate)
+    // gui active module
+    if(dev->gui_module->gui_post_expose
+     && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS)
     {
-      // the cropping.exposer->gui_post_expose needs special care
-      if(expose_full
-        && dev->cropping.exposer
-        && dev->cropping.requester
-        && dev->cropping.exposer->gui_post_expose)
-      {
-        dt_print(DT_DEBUG_EXPOSE, "[darkroom expose] cropper post_expose [%s]\n", dev->cropping.exposer->op);
-        cairo_save(cri);
-        dev->cropping.exposer->gui_post_expose(dev->cropping.exposer, cri,
-                                       width, height, pointerx, pointery);
-        cairo_restore(cri);
-      }
-
-      // gui active module
-      if(dev->gui_module->gui_post_expose
-       && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS)
-      {
-        dt_print(DT_DEBUG_EXPOSE, "[darkroom expose] gui_post_expose [%s]\n", dev->gui_module->op);
-        cairo_save(cri);
-        dev->gui_module->gui_post_expose(dev->gui_module, cri,
-                                       width, height, pointerx, pointery);
-        cairo_restore(cri);
-      }
+      dt_print(DT_DEBUG_EXPOSE, "[darkroom expose] gui_post_expose [%s]\n", dev->gui_module->op);
+      cairo_save(cri);
+      dev->gui_module->gui_post_expose(dev->gui_module, cri,
+                                     width, height, pointerx, pointery);
+      cairo_restore(cri);
     }
   }
 
@@ -3409,12 +3406,15 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
   y -= tb;
   // masks
   if(dev->form_visible
-     && !darktable.develop->darkroom_skip_mouse_events)
+     && !darktable.develop->darkroom_skip_mouse_events
+     && !dt_iop_color_picker_is_visible(dev))
     handled = dt_masks_events_mouse_moved(dev->gui_module, x, y, pressure, which);
   if(handled) return;
+
   // module
   if(dev->gui_module && dev->gui_module->mouse_moved
      && !darktable.develop->darkroom_skip_mouse_events
+     && !dt_iop_color_picker_is_visible(dev)
      && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS)
     handled = dev->gui_module->mouse_moved(dev->gui_module, x, y, pressure, which);
   if(handled) return;


### PR DESCRIPTION
If there is an active global color picker the darkroom expose would prohibit further modules to expose what they want.

I think this is not nevessary.

EDIT: See below for updates ...

Fixes #15157