### PR TITLE
Revamp OpenCL process_cl() usage, part 2

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -3086,22 +3086,21 @@ gboolean dt_dev_write_scharr_mask_cl(dt_dev_pixelpipe_iop_t *piece,
     hash = ((hash << 5) + hash) ^ str[i];
   p->scharr.hash = hash;
 
-  dt_opencl_release_mem_object(out);
-  dt_opencl_release_mem_object(tmp);
   dt_print_pipe(DT_DEBUG_PIPE, "write scharr mask CL", p, NULL, roi_in, NULL, "\n");
   if(darktable.dump_pfm_module && (piece->pipe->type & DT_DEV_PIXELPIPE_EXPORT))
     dt_dump_pfm("scharr_cl", mask, width, height, sizeof(float), "detail");
 
-  return FALSE;
-
   error:
-  dt_print_pipe(DT_DEBUG_ALWAYS,
+  if(err != CL_SUCCESS)
+  {
+    dt_print_pipe(DT_DEBUG_ALWAYS,
            "write scharr mask CL", p, NULL, roi_in, NULL,
            "couldn't write scharr mask: %s\n", cl_errstr(err));
+    dt_dev_clear_scharr_mask(p);
+  }
   dt_opencl_release_mem_object(out);
   dt_opencl_release_mem_object(tmp);
-  dt_dev_clear_scharr_mask(p);
-  return TRUE;
+  return err;
 }
 #endif
 

--- a/src/iop/demosaicing/dual.c
+++ b/src/iop/demosaicing/dual.c
@@ -147,7 +147,7 @@ gboolean dual_demosaic_cl(
   dt_opencl_release_mem_object(mask);
   dt_opencl_release_mem_object(tmp);
   dt_opencl_release_mem_object(dev_blurmat);
-  return (err == CL_SUCCESS);
+  return err;
 }
 #endif
 

--- a/src/iop/demosaicing/rcd.c
+++ b/src/iop/demosaicing/rcd.c
@@ -685,15 +685,21 @@ static int process_rcd_cl(
     dev_tmp = NULL;
 
     cfa = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
+    if(cfa == NULL) goto error;
     VH_dir = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
+    if(VH_dir == NULL) goto error;
     PQ_dir = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
+    if(PQ_dir == NULL) goto error;
     VP_diff = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
+    if(VP_diff== NULL) goto error;
     HQ_diff = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
+    if(HQ_diff == NULL) goto error;
     rgb0 = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
+    if(rgb0 == NULL) goto error;
     rgb1 = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
+    if(rgb1 == NULL) goto error;
     rgb2 = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
-    if(rgb2 == NULL || cfa == NULL || VH_dir == NULL || PQ_dir == NULL || VP_diff == NULL || HQ_diff == NULL || rgb0 == NULL || rgb1 == NULL)
-      goto error;
+    if(rgb2 == NULL) goto error;
 
     {
       // populate data

--- a/src/iop/demosaicing/rcd.c
+++ b/src/iop/demosaicing/rcd.c
@@ -622,7 +622,8 @@ static int process_rcd_cl(
     {
       dev_green_eq = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float));
       if(dev_green_eq == NULL) goto error;
-      if(!green_equilibration_cl(self, piece, dev_in, dev_green_eq, roi_in)) goto error;
+      err = green_equilibration_cl(self, piece, dev_in, dev_green_eq, roi_in);
+      if(err != CL_SUCCESS) goto error;
       dev_in = dev_green_eq;
     }
 
@@ -684,21 +685,15 @@ static int process_rcd_cl(
     dev_tmp = NULL;
 
     cfa = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
-    if(cfa == NULL) goto error;
     VH_dir = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
-    if(VH_dir == NULL) goto error;
     PQ_dir = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
-    if(PQ_dir == NULL) goto error;
     VP_diff = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
-    if(VP_diff == NULL) goto error;
     HQ_diff = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
-    if(HQ_diff == NULL) goto error;
     rgb0 = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
-    if(rgb0 == NULL) goto error;
     rgb1 = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
-    if(rgb1 == NULL) goto error;
     rgb2 = dt_opencl_alloc_device_buffer(devid, sizeof(float) * roi_in->width * roi_in->height);
-    if(rgb2 == NULL) goto error;
+    if(rgb2 == NULL || cfa == NULL || VH_dir == NULL || PQ_dir == NULL || VP_diff == NULL || HQ_diff == NULL || rgb0 == NULL || rgb1 == NULL)
+      goto error;
 
     {
       // populate data
@@ -794,7 +789,6 @@ static int process_rcd_cl(
       dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self, roi_in, roi_out, "\n");
       // scale aux buffer to output buffer
       err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
-      if(err != CL_SUCCESS) goto error;
     }
   }
   else
@@ -808,7 +802,6 @@ static int process_rcd_cl(
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_zoom_half_size, width, height,
       CLARG(dev_pix), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(zero), CLARG(zero), CLARG(roi_in->width),
       CLARG(roi_in->height), CLARG(roi_out->scale), CLARG(piece->pipe->dsc.filters));
-    if(err != CL_SUCCESS) goto error;
   }
 
   if(dev_aux != dev_out) dt_opencl_release_mem_object(dev_aux);
@@ -816,12 +809,7 @@ static int process_rcd_cl(
 
   // color smoothing
   if((data->color_smoothing) && smooth)
-  {
-    if(!color_smoothing_cl(self, piece, dev_out, dev_out, roi_out, data->color_smoothing))
-      goto error;
-  }
-
-  return TRUE;
+    err = color_smoothing_cl(self, piece, dev_out, dev_out, roi_out, data->color_smoothing);
 
 error:
   if(dev_aux != dev_out) dt_opencl_release_mem_object(dev_aux);
@@ -835,9 +823,10 @@ error:
   dt_opencl_release_mem_object(PQ_dir);
   dt_opencl_release_mem_object(VP_diff);
   dt_opencl_release_mem_object(HQ_diff);
-  dev_aux = dev_green_eq = dev_tmp = cfa = rgb0 = rgb1 = rgb2 = VH_dir = PQ_dir = VP_diff = HQ_diff = NULL;
-  dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] rcd couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+
+  if(err != CL_SUCCESS)
+    dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] rcd problem '%s'\n", cl_errstr(err));
+  return err;
 }
 
 #endif

--- a/src/iop/demosaicing/vng.c
+++ b/src/iop/demosaicing/vng.c
@@ -668,41 +668,6 @@ static int process_vng_cl(
     }
   }
 
-  if(dev_aux != dev_out) dt_opencl_release_mem_object(dev_aux);
-  dev_aux = NULL;
-
-  dt_opencl_release_mem_object(dev_tmp);
-  dev_tmp = NULL;
-
-  dt_opencl_release_mem_object(dev_xtrans);
-  dev_xtrans = NULL;
-
-  dt_opencl_release_mem_object(dev_lookup);
-  dev_lookup = NULL;
-
-  free(lookup);
-
-  dt_opencl_release_mem_object(dev_code);
-  dev_code = NULL;
-
-  dt_opencl_release_mem_object(dev_ips);
-  dev_ips = NULL;
-
-  dt_opencl_release_mem_object(dev_green_eq);
-  dev_green_eq = NULL;
-
-  free(ips);
-  ips = NULL;
-
-  // color smoothing
-  if((data->color_smoothing) && smooth)
-  {
-    if(!color_smoothing_cl(self, piece, dev_out, dev_out, roi_out, data->color_smoothing))
-      goto error;
-  }
-
-  return TRUE;
-
 error:
   if(dev_aux != dev_out) dt_opencl_release_mem_object(dev_aux);
   dt_opencl_release_mem_object(dev_tmp);
@@ -713,8 +678,12 @@ error:
   dt_opencl_release_mem_object(dev_ips);
   dt_opencl_release_mem_object(dev_green_eq);
   free(ips);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] couldn't enqueue kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  if(data->color_smoothing && smooth)
+    err =color_smoothing_cl(self, piece, dev_out, dev_out, roi_out, data->color_smoothing);
+
+  if(err != CL_SUCCESS)
+    dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] vng problem '%s'\n", cl_errstr(err));
+  return err;
 }
 
 #endif

--- a/src/iop/demosaicing/xtrans.c
+++ b/src/iop/demosaicing/xtrans.c
@@ -2172,8 +2172,8 @@ static int process_markesteijn_cl(
       if(err != CL_SUCCESS) goto error;
 
       // VNG processing
-      if(!process_vng_cl(self, piece, dev_edge_in, dev_edge_out, &roi, &roi, smooth, qual_flags & DT_DEMOSAIC_ONLY_VNG_LINEAR))
-        goto error;
+      err = process_vng_cl(self, piece, dev_edge_in, dev_edge_out, &roi, &roi, smooth, qual_flags & DT_DEMOSAIC_ONLY_VNG_LINEAR);
+      if(err != CL_SUCCESS) goto error;
 
       // adjust for "good" part, dropping linear border where possible
       iorigin[0] += edges[n][4];
@@ -2226,12 +2226,9 @@ static int process_markesteijn_cl(
 
   // color smoothing
   if(data->color_smoothing)
-  {
-    if(!color_smoothing_cl(self, piece, dev_out, dev_out, roi_out, data->color_smoothing))
-      goto error;
-  }
+    err = color_smoothing_cl(self, piece, dev_out, dev_out, roi_out, data->color_smoothing);
 
-  return TRUE;
+  return err;
 
 error:
   if(dev_tmp != dev_out) dt_opencl_release_mem_object(dev_tmp);
@@ -2252,8 +2249,8 @@ error:
   dt_opencl_release_mem_object(dev_aux);
   dt_opencl_release_mem_object(dev_edge_in);
   dt_opencl_release_mem_object(dev_edge_out);
-  dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] couldn't enqueue process_markesteijn_cl kernel! %s\n", cl_errstr(err));
-  return FALSE;
+  dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] markesteijn problem '%s'\n", cl_errstr(err));
+  return err;
 }
 
 #endif

--- a/src/iop/hlreconstruct/laplacian.c
+++ b/src/iop/hlreconstruct/laplacian.c
@@ -898,28 +898,18 @@ static cl_int process_laplacian_bayer_cl(struct dt_iop_module_t *self,
     CLARG(dev_in), CLARG(interpolated), CLARG(clipping_mask), CLARG(dev_out),
     CLARG(wb_cl), CLARG(filters), CLARG(width), CLARG(height));
   err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_highlights_remosaic_and_replace, sizes);
-  if(err != CL_SUCCESS) goto error;
-
-  // cleanup and exit on success
-  if(wb_cl) dt_opencl_release_mem_object(wb_cl);
-  if(interpolated) dt_opencl_release_mem_object(interpolated);
-  if(clipping_mask) dt_opencl_release_mem_object(clipping_mask);
-  if(temp) dt_opencl_release_mem_object(temp);
-  if(LF_even) dt_opencl_release_mem_object(LF_even);
-  if(LF_odd) dt_opencl_release_mem_object(LF_odd);
-  if(HF) dt_opencl_release_mem_object(HF);
-  dt_opencl_release_mem_object(ds_clipping_mask);
-  dt_opencl_release_mem_object(ds_interpolated);
-  return err;
 
 error:
-  if(wb_cl) dt_opencl_release_mem_object(wb_cl);
-  if(interpolated) dt_opencl_release_mem_object(interpolated);
-  if(clipping_mask) dt_opencl_release_mem_object(clipping_mask);
-  if(temp) dt_opencl_release_mem_object(temp);
-  if(LF_even) dt_opencl_release_mem_object(LF_even);
-  if(LF_odd) dt_opencl_release_mem_object(LF_odd);
-  if(HF) dt_opencl_release_mem_object(HF);
+  dt_opencl_release_mem_object(wb_cl);
+  dt_opencl_release_mem_object(interpolated);
+  dt_opencl_release_mem_object(ds_clipping_mask);
+  dt_opencl_release_mem_object(ds_interpolated);
+  dt_opencl_release_mem_object(clipping_mask);
+
+  dt_opencl_release_mem_object(temp);
+  dt_opencl_release_mem_object(LF_even);
+  dt_opencl_release_mem_object(LF_odd);
+  dt_opencl_release_mem_object(HF);
   return err;
 }
 

--- a/src/iop/hlreconstruct/opposed.c
+++ b/src/iop/hlreconstruct/opposed.c
@@ -469,7 +469,7 @@ static cl_int process_opposed_cl(
 
   dt_aligned_pixel_t clips = { clipval * icoeffs[0], clipval * icoeffs[1], clipval * icoeffs[2], 1.0f};
 
-  cl_int err = DT_OPENCL_DEFAULT_ERROR;
+  cl_int err = DT_OPENCL_SYSMEM_ALLOCATION;
   cl_mem dev_chrominance = NULL;
   cl_mem dev_xtrans = NULL;
   cl_mem dev_clips = NULL;
@@ -527,6 +527,7 @@ static cl_int process_opposed_cl(
             CLARG(msize), CLARG(mwidth), CLARG(mheight));
     if(err != CL_SUCCESS) goto error;
 
+    err = DT_OPENCL_SYSMEM_ALLOCATION;
     const size_t accusize = sizeof(float) * 6 * iheight;
     dev_accu = dt_opencl_alloc_device_buffer(devid, accusize);
     if(dev_accu == NULL) goto error;
@@ -581,6 +582,7 @@ static cl_int process_opposed_cl(
     }
   }
 
+  err = DT_OPENCL_SYSMEM_ALLOCATION;
   dev_chrominance = dt_opencl_copy_host_to_device_constant(devid, 4 * sizeof(float), chrominance);
   if(dev_chrominance == NULL) goto error;
 
@@ -593,21 +595,8 @@ static cl_int process_opposed_cl(
           CLARG(dev_clips),
           CLARG(dev_chrominance),
           CLARG(fastcopymode));
-  if(err != CL_SUCCESS) goto error;
-
-  dt_opencl_release_mem_object(dev_clips);
-  dt_opencl_release_mem_object(dev_xtrans);
-  dt_opencl_release_mem_object(dev_chrominance);
-  dt_opencl_release_mem_object(dev_inmask);
-  dt_opencl_release_mem_object(dev_outmask);
-  dt_opencl_release_mem_object(dev_accu);
-  dt_free_align(claccu);
-  return CL_SUCCESS;
 
   error:
-  // just in case the last error was generated via a copy function
-  if(err == CL_SUCCESS) err = DT_OPENCL_DEFAULT_ERROR;
-
   dt_opencl_release_mem_object(dev_clips);
   dt_opencl_release_mem_object(dev_xtrans);
   dt_opencl_release_mem_object(dev_chrominance);

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -591,34 +591,27 @@ int process_cl(
        CLARG(map_size), CLARG(im_to_rel), CLARG(rel_to_map), CLARG(map_origin));
   }
   err = dt_opencl_enqueue_kernel_2d(devid, kernel, sizes);
-  if(err != CL_SUCCESS) goto finish;
-
-  dt_opencl_release_mem_object(dev_sub);
-  dt_opencl_release_mem_object(dev_div);
-  dev_sub = NULL;
-  dev_div = NULL;
-  for(int i = 0; i < 4; i++)
-  {
-    dt_opencl_release_mem_object(dev_gainmap[i]);
-    dev_gainmap[i] = NULL;
-  }
-  if(piece->pipe->dsc.filters)
-  {
-    piece->pipe->dsc.filters =
-      dt_rawspeed_crop_dcraw_filters(self->dev->image_storage.buf_dsc.filters, csx, csy);
-    _adjust_xtrans_filters(piece->pipe, csx, csy);
-  }
-
-  for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
-
-  if(!dt_image_is_raw(&piece->pipe->image) && piece->pipe->want_detail_mask)
-    err = dt_dev_write_scharr_mask_cl(piece, dev_out, roi_in, FALSE);
 
 finish:
   dt_opencl_release_mem_object(dev_sub);
   dt_opencl_release_mem_object(dev_div);
+
   for(int i = 0; i < 4; i++)
     dt_opencl_release_mem_object(dev_gainmap[i]);
+
+  if(err == CL_SUCCESS)
+  {
+    if(piece->pipe->dsc.filters)
+    {
+      piece->pipe->dsc.filters =
+        dt_rawspeed_crop_dcraw_filters(self->dev->image_storage.buf_dsc.filters, csx, csy);
+      _adjust_xtrans_filters(piece->pipe, csx, csy);
+    }
+    for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
+    if(!dt_image_is_raw(&piece->pipe->image) && piece->pipe->want_detail_mask)
+      err = dt_dev_write_scharr_mask_cl(piece, dev_out, roi_in, FALSE);
+  }
+
   return err;
 }
 #endif


### PR DESCRIPTION
All demosaicer and highlight reconstruct algorithms have been made using error codes instead of bools.

1. Reduced code complexity again
2. more clear error codes reported
3. a mem leak in laplacian highlights in case of an error has been fixed