### PR TITLE
Replace cl_device_v5 with cldevice_v5 in all hint messages

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -5972,8 +5972,8 @@ msgstr ""
 
 #: ../src/common/darktable.c:2026
 msgid ""
-"you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"
-msgstr "data 'na zařízení' najdete v 'cl_device_v5_canonical-name'. obsah je:"
+"you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
+msgstr "data 'na zařízení' najdete v 'cldevice_v5_canonical-name'. obsah je:"
 
 #: ../src/common/darktable.c:2032
 msgid ""

--- a/po/darktable.pot
+++ b/po/darktable.pot
@@ -5781,7 +5781,7 @@ msgstr ""
 
 #: ../src/common/darktable.c:1990
 msgid ""
-"instead you will find 'per device' data in 'cl_device_v5_canonical-name'. "
+"instead you will find 'per device' data in 'cldevice_v5_canonical-name'. "
 "content is:"
 msgstr ""
 
@@ -5809,7 +5809,7 @@ msgstr ""
 
 #: ../src/common/darktable.c:2009 ../src/common/darktable.c:2024
 msgid ""
-"you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"
+"you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
 msgstr ""
 
 #: ../src/common/darktable.c:2015

--- a/po/de.po
+++ b/po/de.po
@@ -5598,8 +5598,8 @@ msgid "some global config parameters relevant for OpenCL performance are not use
 msgstr "einige für OpenCL Leistung relevante globale Konfigurationsparameter werden nicht mehr verwendet."
 
 #: ../src/common/darktable.c:1990
-msgid "instead you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"
-msgstr "Stattdessen stehen die gerätespezifischen Daten in „cl_device_v5_canonical-name“. Inhalte sind:"
+msgid "instead you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
+msgstr "Stattdessen stehen die gerätespezifischen Daten in „cldevice_v5_canonical-name“. Inhalte sind:"
 
 #: ../src/common/darktable.c:1992 ../src/common/darktable.c:2011 ../src/common/darktable.c:2026
 #| msgid ""
@@ -5624,8 +5624,8 @@ msgid "OpenCL global config parameters 'per device' data has been recreated with
 msgstr "Die globalen OpenCL-Konfigurationsparameter „per device“ wurden mit einem aktualisierten Namen neu erstellt"
 
 #: ../src/common/darktable.c:2009 ../src/common/darktable.c:2024
-msgid "you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"
-msgstr "Die „per device“-Daten befinden sich in „cl_device_v5_canonical-name“. Inhalt ist:"
+msgid "you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
+msgstr "Die „per device“-Daten befinden sich in „cldevice_v5_canonical-name“. Inhalt ist:"
 
 #: ../src/common/darktable.c:2015
 msgid "If you're using device names in 'opencl_device_priority' you should update them to the new names."

--- a/po/en@truecase.po
+++ b/po/en@truecase.po
@@ -6040,10 +6040,10 @@ msgstr ""
 
 #: ../src/common/darktable.c:1990
 msgid ""
-"instead you will find 'per device' data in 'cl_device_v5_canonical-name'. "
+"instead you will find 'per device' data in 'cldevice_v5_canonical-name'. "
 "content is:"
 msgstr ""
-"Instead you will find 'per device' data in 'cl_device_v5_canonical-name'. "
+"Instead you will find 'per device' data in 'cldevice_v5_canonical-name'. "
 "Content is:"
 
 #: ../src/common/darktable.c:1992 ../src/common/darktable.c:2011
@@ -6075,9 +6075,9 @@ msgstr ""
 
 #: ../src/common/darktable.c:2009 ../src/common/darktable.c:2024
 msgid ""
-"you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"
+"you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
 msgstr ""
-"You will find 'per device' data in 'cl_device_v5_canonical-name'. Content is:"
+"You will find 'per device' data in 'cldevice_v5_canonical-name'. Content is:"
 
 #: ../src/common/darktable.c:2015
 msgid ""

--- a/po/es.po
+++ b/po/es.po
@@ -6015,7 +6015,7 @@ msgstr ""
 
 #: ../src/common/darktable.c:2010
 msgid ""
-"you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"
+"you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
 msgstr ""
 "Sin embargo, encontrará los datos «por dispositivo» en "
 "\"cldevice_v5_canonical-name\". El contenido es :"

--- a/po/fi.po
+++ b/po/fi.po
@@ -5974,9 +5974,9 @@ msgstr ""
 
 #: ../src/common/darktable.c:2010
 msgid ""
-"you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"
+"you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
 msgstr ""
-"Niiden sijaan löydät 'per device' tiedot 'cl_device_v5_canonical-name' "
+"Niiden sijaan löydät 'per device' tiedot 'cldevice_v5_canonical-name' "
 "paikasta. Sisältö on:"
 
 #: ../src/common/darktable.c:2016

--- a/po/fr.po
+++ b/po/fr.po
@@ -6126,7 +6126,7 @@ msgstr ""
 
 #: ../src/common/darktable.c:1990
 msgid ""
-"instead you will find 'per device' data in 'cl_device_v5_canonical-name'. "
+"instead you will find 'per device' data in 'cldevice_v5_canonical-name'. "
 "content is:"
 msgstr ""
 "À la place les données par périphérique se trouvent dans "
@@ -6163,7 +6163,7 @@ msgstr ""
 
 #: ../src/common/darktable.c:2009 ../src/common/darktable.c:2024
 msgid ""
-"you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"
+"you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
 msgstr ""
 "Les données « par périphérique » se trouvent dans « cldevice_v5_canonical-"
 "name ». Le contenu en est :"

--- a/po/he.po
+++ b/po/he.po
@@ -5868,8 +5868,8 @@ msgstr ""
 
 #: ../src/common/darktable.c:2010
 msgid ""
-"you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"
-msgstr "תמצא נתונים 'per device' ב 'cl_device_v5_canonical-name'. התוכן הוא:"
+"you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
+msgstr "תמצא נתונים 'per device' ב 'cldevice_v5_canonical-name'. התוכן הוא:"
 
 #: ../src/common/darktable.c:2016
 msgid ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -5978,9 +5978,9 @@ msgstr ""
 
 #: ../src/common/darktable.c:2010
 msgid ""
-"you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"
+"you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
 msgstr ""
-"helyettük a „per device” adatot keresse a „cl_device_v5_canonical-name” "
+"helyettük a „per device” adatot keresse a „cldevice_v5_canonical-name” "
 "alatt. a tartalma:"
 
 #: ../src/common/darktable.c:2016

--- a/po/it.po
+++ b/po/it.po
@@ -6125,9 +6125,9 @@ msgstr ""
 
 #: ../src/common/darktable.c:2010
 msgid ""
-"you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"
+"you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
 msgstr ""
-"Troverai i dati 'per dispositivoì in 'cl_device_v5_canonical-name'. Il"
+"Troverai i dati 'per dispositivoì in 'cldevice_v5_canonical-name'. Il"
 " contenuto è:"
 
 #: ../src/common/darktable.c:2016

--- a/po/ja.po
+++ b/po/ja.po
@@ -5965,9 +5965,9 @@ msgstr ""
 
 #: ../src/common/darktable.c:2010
 msgid ""
-"you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"
+"you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
 msgstr ""
-"「デバイスごとの」データが'cl_device_v5_canonical-name'にあります。その内容は"
+"「デバイスごとの」データが'cldevice_v5_canonical-name'にあります。その内容は"
 "以下の通りです"
 
 #: ../src/common/darktable.c:2016

--- a/po/pl.po
+++ b/po/pl.po
@@ -5955,8 +5955,8 @@ msgstr ""
 
 #: ../src/common/darktable.c:2010
 msgid ""
-"you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"
-msgstr "zobaczysz 'per device' w 'cl_device_v5_canonical-name'. zawartość to:"
+"you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
+msgstr "zobaczysz 'per device' w 'cldevice_v5_canonical-name'. zawartość to:"
 
 #: ../src/common/darktable.c:2016
 msgid ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -6087,9 +6087,9 @@ msgstr ""
 
 #: ../src/common/darktable.c:1990
 msgid ""
-"instead you will find 'per device' data in 'cl_device_v5_canonical-name'. "
+"instead you will find 'per device' data in 'cldevice_v5_canonical-name'. "
 "content is:"
-msgstr "ao invés disso você encontrará dados 'por dispositivo' em 'cl_device_v5_canonical-name'. o conteúdo é:"
+msgstr "ao invés disso você encontrará dados 'por dispositivo' em 'cldevice_v5_canonical-name'. o conteúdo é:"
 
 #: ../src/common/darktable.c:1992 ../src/common/darktable.c:2011
 #: ../src/common/darktable.c:2026
@@ -6119,9 +6119,9 @@ msgstr ""
 
 #: ../src/common/darktable.c:2009 ../src/common/darktable.c:2024
 msgid ""
-"you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"
+"you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
 msgstr ""
-"você encontrará dados 'por dispositivo' em 'cl_device_v5_canonical-name'. o "
+"você encontrará dados 'por dispositivo' em 'cldevice_v5_canonical-name'. o "
 "conteúdo é:"
 
 #: ../src/common/darktable.c:2015

--- a/po/ru.po
+++ b/po/ru.po
@@ -5912,7 +5912,7 @@ msgstr ""
 
 #: ../src/common/darktable.c:2010
 msgid ""
-"you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"
+"you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
 msgstr ""
 "Вместо этого вы найдете данные «по устройству» в «cl_device_v4_canonical-"
 "name». Содержание:"

--- a/po/sl.po
+++ b/po/sl.po
@@ -6029,7 +6029,7 @@ msgstr ""
 
 #: ../src/common/darktable.c:2010
 msgid ""
-"you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"
+"you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
 msgstr ""
 "podatke 'po napravi' boste našli v 'cl_device_v4_canonical-name'. vsebina je:"
 

--- a/po/sq.po
+++ b/po/sq.po
@@ -5941,9 +5941,9 @@ msgstr ""
 
 #: ../src/common/darktable.c:2010
 msgid ""
-"you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"
+"you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
 msgstr ""
-"të dhënat e 'aparatit' gjenden në 'cl_device_v5_canonical-name'. përmbajtja "
+"të dhënat e 'aparatit' gjenden në 'cldevice_v5_canonical-name'. përmbajtja "
 "është:"
 
 #: ../src/common/darktable.c:2016

--- a/po/tr.po
+++ b/po/tr.po
@@ -5976,9 +5976,9 @@ msgstr ""
 
 #: ../src/common/darktable.c:2010
 msgid ""
-"you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"
+"you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
 msgstr ""
-"\"cl_device_v5_canonical-name\" içinde \"cihaz başına\" verileri "
+"\"cldevice_v5_canonical-name\" içinde \"cihaz başına\" verileri "
 "bulacaksınız. içerik:"
 
 #: ../src/common/darktable.c:2016

--- a/po/uk.po
+++ b/po/uk.po
@@ -6099,11 +6099,11 @@ msgstr ""
 
 #: ../src/common/darktable.c:1990
 msgid ""
-"instead you will find 'per device' data in 'cl_device_v5_canonical-name'. "
+"instead you will find 'per device' data in 'cldevice_v5_canonical-name'. "
 "content is:"
 msgstr ""
 "Замість цього ви знайдете окремі дані для пристроїв у "
-"'cl_device_v5_canonical-name'. Зміст:"
+"'cldevice_v5_canonical-name'. Зміст:"
 
 #: ../src/common/darktable.c:1992 ../src/common/darktable.c:2011
 #: ../src/common/darktable.c:2026
@@ -6135,9 +6135,9 @@ msgstr ""
 
 #: ../src/common/darktable.c:2009 ../src/common/darktable.c:2024
 msgid ""
-"you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"
+"you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
 msgstr ""
-"Ви знайдете окремі дані для пристроїв у 'cl_device_v5_canonical-name'. Зміст:"
+"Ви знайдете окремі дані для пристроїв у 'cldevice_v5_canonical-name'. Зміст:"
 
 #: ../src/common/darktable.c:2015
 msgid ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -5821,9 +5821,9 @@ msgstr "按设备设置 OpenCL 全局配置的选项名称在此版本更新后�
 
 #: ../src/common/darktable.c:2010
 msgid ""
-"you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"
+"you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
 msgstr ""
-"请使用“cl_device_v5_canonical-name”中的“per device”数据替代。其内容是："
+"请使用“cldevice_v5_canonical-name”中的“per device”数据替代。其内容是："
 
 #: ../src/common/darktable.c:2016
 msgid ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -5914,8 +5914,8 @@ msgstr "OpenCL 整體參數「每個設備」的設定已經依更新的名稱�
 
 #: ../src/common/darktable.c:2024
 msgid ""
-"you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"
-msgstr "可以在「cl_device_v5_canonical-name」中找到「per device」數據如下："
+"you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"
+msgstr "可以在「cldevice_v5_canonical-name」中找到「per device」數據如下："
 
 #: ../src/common/darktable.c:2030
 msgid ""

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1987,7 +1987,7 @@ void dt_configure_runtime_performance(const int old, char *info)
     g_strlcat(info, INFO_HEADER, DT_PERF_INFOSIZE);
     g_strlcat(info, _("some global config parameters relevant for OpenCL performance are not used any longer."), DT_PERF_INFOSIZE);
     g_strlcat(info, "\n", DT_PERF_INFOSIZE);
-    g_strlcat(info, _("instead you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"), DT_PERF_INFOSIZE);
+    g_strlcat(info, _("instead you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"), DT_PERF_INFOSIZE);
     g_strlcat(info, "\n  ", DT_PERF_INFOSIZE);
     g_strlcat(info, _(" 'avoid_atomics' 'micro_nap' 'pinned_memory' 'roundupwd' 'roundupht' 'eventhandles' 'async' 'disable' 'magic' 'advantage' 'unified'"), DT_PERF_INFOSIZE);
     g_strlcat(info, "\n", DT_PERF_INFOSIZE);
@@ -2006,7 +2006,7 @@ void dt_configure_runtime_performance(const int old, char *info)
     g_strlcat(info, INFO_HEADER, DT_PERF_INFOSIZE);
     g_strlcat(info, _("OpenCL global config parameters 'per device' data has been recreated with an updated name."), DT_PERF_INFOSIZE);
     g_strlcat(info, "\n", DT_PERF_INFOSIZE);
-    g_strlcat(info, _("you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"), DT_PERF_INFOSIZE);
+    g_strlcat(info, _("you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"), DT_PERF_INFOSIZE);
     g_strlcat(info, "\n  ", DT_PERF_INFOSIZE);
     g_strlcat(info, _(" 'avoid_atomics' 'micro_nap' 'pinned_memory' 'roundupwd' 'roundupht' 'eventhandles' 'async' 'disable' 'magic' 'advantage' 'unified'"), DT_PERF_INFOSIZE);
     g_strlcat(info, "\n", DT_PERF_INFOSIZE);
@@ -2021,7 +2021,7 @@ void dt_configure_runtime_performance(const int old, char *info)
     g_strlcat(info, INFO_HEADER, DT_PERF_INFOSIZE);
     g_strlcat(info, _("OpenCL 'per device' config data have been automatically extended by 'unified-rate'."), DT_PERF_INFOSIZE);
     g_strlcat(info, "\n", DT_PERF_INFOSIZE);
-    g_strlcat(info, _("you will find 'per device' data in 'cl_device_v5_canonical-name'. content is:"), DT_PERF_INFOSIZE);
+    g_strlcat(info, _("you will find 'per device' data in 'cldevice_v5_canonical-name'. content is:"), DT_PERF_INFOSIZE);
     g_strlcat(info, "\n  ", DT_PERF_INFOSIZE);
     g_strlcat(info, _(" 'avoid_atomics' 'micro_nap' 'pinned_memory' 'roundupwd' 'roundupht' 'eventhandles' 'async' 'disable' 'magic' 'advantage' 'unified'"), DT_PERF_INFOSIZE);
     g_strlcat(info, "\n\n", DT_PERF_INFOSIZE);


### PR DESCRIPTION
darktablerc uses the prefix cldevice_v5_, not cl_device_v5_. Actual example from my darktablerc:
```
cldevice_v5_nvidiacudanvidiageforcegtx10606gb=0 250 0 16 16 128 0 0 0.000 0.000 0.250
```