### PR TITLE
further improvements to thumbnail placement in culling

### DIFF
--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1598,8 +1598,7 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
         (max_slot_heigth - spacing * (g_list_length(slot) - 1)) / (float)slot_heigth;
       
       // limit scaling so that width does not increase by more than 20%
-      if((thumb->width/(float)thumb->height) * stack_heigth_factor < 1.20)
-        stack_heigth_factor = 1.20 / (thumb->width/(float)thumb->height);
+      stack_heigth_factor = MIN(stack_heigth_factor, table->view_width / (float)thumb->width);
       thumb->height *= stack_heigth_factor;
       thumb->width *= stack_heigth_factor;
 

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1488,7 +1488,7 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
   // reinit size and positions of each thumbnail, remember size from biggest thumbnail, calculate average thumbnail ratio
   int max_thumb_height = 0;
 
-    for(GList *l = table->list; l; l = g_list_next(l))
+  for(GList *l = table->list; l; l = g_list_next(l))
   {
     dt_thumbnail_t *thumb = (dt_thumbnail_t *)l->data;
     const float aspect_ratio = thumb->aspect_ratio;
@@ -1502,12 +1502,12 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
   // Vertical image stacking:
   //  Vertical stacking is only allowed if the heigth of the biggest thumbnail is more than the height
   //  of 2 or more thumbs combined.
-  //  for example: we have three images and image 3 is higher than heights of image 1 and 2 combined
-  //  [  1  ] | 3 |                                                         | 3 |
-  //  [  2  ] | 3 |      instead of this placement -->    [  1  ]  [  2  ]  | 3 |
-  //          | 3 |                                                         | 3 |
-  // in this case, images 1 and 2 would be stacked in one slot and image 3 will be placed in a new slot alone.
-  // if all images have similar heigths, they will not be stacked and placed in a separate slot.
+  //  for example: we have three images and image 2 is higher than heights of image 1 and 3 combined
+  //  [  1  ] | 2 |                                                | 2 |
+  //  [  3  ] | 2 |      instead of this placement -->    [  1  ]  | 2 |  [  3  ]
+  //          | 2 |                                                | 2 |
+  // in this case, images 1 and 3 would be stacked in one slot and image 2 will be placed in a new slot alone.
+  // if all images have similar heigths, they will not be stacked and placed in separate slots.
 
   // Note: Stacking only make sense for images in the same row as the portrait image.
   //       The algorithm does not check for this so unneccessary stacking can occur.
@@ -1562,12 +1562,9 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
   slots = g_list_reverse(slots);  // list was built in reverse order, so un-reverse it
 
 
-
-
-
   // finished assigning thumbnails to slots
   // we also know max slot height, so we can now scale all slots to this heigth
-  // and calculate average slot heigth and width
+  // and then calculate average slot heigth and width
   int slot_counter = 0;
   float avg_slot_aspect_r = 0.0f;
   int total_slot_width = 0;
@@ -1605,7 +1602,6 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
       
       // limit scaling so that width does not increase to more than twice the average thumbnail width
       stack_heigth_factor = MIN(stack_heigth_factor, 2 * avg_thumb_width / (float)thumb->width);
-      //stack_heigth_factor = 1.0;
       thumb->height *= stack_heigth_factor;
       thumb->width *= stack_heigth_factor;
 
@@ -1621,16 +1617,11 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
     avg_slot_width += (scaled_slot_width - avg_slot_width) / (float)thumb_counter;
   }
   total_slot_width -= spacing;
-
-
-
   
 
   // variables to hold vertical and horizontal width of all thumbnails after their final placement
-  
   unsigned int total_width = 0;
   unsigned int total_height = 0;
-
 
   // estimate a good start value for number of rows and columns to use in thumbnail placement by taking the square root
   //  of the number of thumbnails. E.g. 9 thumbnails: probably 3x3. Prefer wide configuration e.g. 8 thumbnails: 3x2
@@ -1786,9 +1777,7 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
           );
 
           if(ratio_new_row > ratio_same_row)
-          {
             create_new_row = FALSE;
-          }
         }
       }
 

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1562,7 +1562,6 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
   slots = g_list_reverse(slots);  // list was built in reverse order, so un-reverse it
   const int number_of_slots = g_list_length(slots);
 
-
   // finished assigning thumbnails to slots
   // we also know max slot height, so we can now scale all slots to this heigth
   // and then calculate average slot heigth and width
@@ -1587,7 +1586,7 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
       slot_thumb_iter;
       slot_thumb_iter = g_list_next(slot_thumb_iter))
     {
-      dt_thumbnail_t *thumb = (dt_thumbnail_t *)slot_thumb_iter->data;
+      const dt_thumbnail_t *thumb = (dt_thumbnail_t *)slot_thumb_iter->data;
       slot_heigth += thumb->height + spacing;
     }
     slot_heigth -= spacing;
@@ -1627,7 +1626,6 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
     avg_slot_width += (scaled_slot_width - avg_slot_width) / (float)thumb_counter;
   }
   total_slot_width -= spacing;
-  
 
   // variables to hold vertical and horizontal width of all thumbnails after their final placement
   unsigned int planned_total_width = total_slot_width;
@@ -1654,8 +1652,8 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
     if(row_cnt_tmp == 0 || row_cnt_tmp > slot_counter)
       break;
 
-    float planned_total_width_tmp = total_slot_width / (float) row_cnt_tmp;
-    int planned_total_height_tmp = row_cnt_tmp * max_slot_heigth;
+    const float planned_total_width_tmp = total_slot_width / (float) row_cnt_tmp;
+    const int planned_total_height_tmp = row_cnt_tmp * max_slot_heigth;
 
     deviation_tmp = _absmul(planned_total_width_tmp / (float)planned_total_height_tmp, screen_aspect_r);
 
@@ -1684,7 +1682,7 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
           slot_thumb_iter;
           slot_thumb_iter = g_list_next(slot_thumb_iter))
       {
-        dt_thumbnail_t *thumb = (dt_thumbnail_t *)slot_thumb_iter->data;
+        const dt_thumbnail_t *thumb = (dt_thumbnail_t *)slot_thumb_iter->data;
         slot_max_thumb_width = MAX(slot_max_thumb_width, thumb->width);
         slot_total_heigth = slot_total_heigth + thumb->height + spacing;
       }
@@ -1783,7 +1781,7 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
         slot_thumb_iter;
         slot_thumb_iter = g_list_next(slot_thumb_iter))
       {
-        dt_thumbnail_t *thumb = (dt_thumbnail_t *)slot_thumb_iter->data;
+        const dt_thumbnail_t *thumb = (dt_thumbnail_t *)slot_thumb_iter->data;
         row_width = MAX(row_width, thumb->x + thumb->width + spacing);
         slot_heigth += thumb->height + spacing;
       }
@@ -1806,7 +1804,7 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
         slot_thumb_iter;
         slot_thumb_iter = g_list_next(slot_thumb_iter))
       {
-        dt_thumbnail_t *thumb = (dt_thumbnail_t *)slot_thumb_iter->data;
+        const dt_thumbnail_t *thumb = (dt_thumbnail_t *)slot_thumb_iter->data;
         slot_heigth += thumb->height + spacing;
       }
       slot_heigth -= spacing;

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1794,11 +1794,16 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
       }
       slot_height -= spacing;
 
+      // Scale up thumbnails so that they take up all available vertical space
       for(GList *cw_iter = slot; cw_iter; cw_iter = g_list_next(cw_iter))
       {
         dt_thumbnail_t *cw = (dt_thumbnail_t *)cw_iter->data;
+        const float stack_heigth_factor = 
+          (max_row_heigth - spacing * (g_list_length(slot) - 1)) / (float)slot_height;
+        cw->height *= stack_heigth_factor;
+        cw->width *= stack_heigth_factor;
+
         cw->x += xoff;
-        cw->height = (max_row_heigth - g_list_length(slot)-1) * cw->height / slot_height;
       }
       g_list_free(slot);
     }

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1594,8 +1594,12 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
       slot_thumb_iter = g_list_next(slot_thumb_iter))
     {
       dt_thumbnail_t *thumb = (dt_thumbnail_t *)slot_thumb_iter->data;
-      const float stack_heigth_factor = 
+      float stack_heigth_factor = 
         (max_slot_heigth - spacing * (g_list_length(slot) - 1)) / (float)slot_heigth;
+      
+      // limit scaling so that width does not increase by more than 20%
+      if((thumb->width/(float)thumb->height) * stack_heigth_factor < 1.20)
+        stack_heigth_factor = 1.20 / (thumb->width/(float)thumb->height);
       thumb->height *= stack_heigth_factor;
       thumb->width *= stack_heigth_factor;
 

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1834,14 +1834,17 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
   total_width -= spacing;
   total_height -= spacing;
 
-  for(const GList *iter = rows; iter; iter = g_list_next(iter))
+  // loop through all thumbnails to apply offsets for final positioning
+  // loop through rows
+  for(const GList *row_iter = rows; row_iter; row_iter = g_list_next(row_iter))
   {
-    GList *row = (GList *)iter->data;
+    GList *row = (GList *)row_iter->data;
     int row_width = 0;
+    int row_heigth = 0;
     int xoff = 0;
     int yoff = 0;
 
-    // loop through slots of the row to calculate row width and max_row_heigth
+    // loop through slots of the row
     for(GList *slot_iter = row;
         slot_iter;
         slot_iter = g_list_next(slot_iter))
@@ -1850,8 +1853,8 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
       int slot_heigth = 0;
 
       // loop through thumbs of the slot
-      // to calculate slot heigth and update row width
-      // which is used for xoffset of row
+      // to calculate slot heigth and update row width and heigth
+      // which is used for xoffset of row and yoffset of individual thumbs
       for(GList *slot_thumb_iter = slot;
         slot_thumb_iter;
         slot_thumb_iter = g_list_next(slot_thumb_iter))
@@ -1861,14 +1864,7 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
         slot_heigth += thumb->height + spacing;
       }
       slot_heigth -= spacing;
-      yoff = (max_slot_heigth - slot_heigth) / 2;
-
-      // center all thumbnails vertically in a slot
-      for(GList *slot_thumb_iter = slot; slot_thumb_iter; slot_thumb_iter = g_list_next(slot_thumb_iter))
-      {
-        dt_thumbnail_t *thumb = (dt_thumbnail_t *)slot_thumb_iter->data;
-        thumb->y += yoff;
-      }
+      row_heigth = MAX(row_heigth, slot_heigth);
     }
     xoff = (total_width - row_width) / 2;
 
@@ -1879,11 +1875,24 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
     {
       GList *slot = (GList *)slot_iter->data;
 
-      // Scale up thumbnails so that they take up all available vertical space
+      // calculate vertical offset
+      int slot_heigth = 0;
+      for(GList *slot_thumb_iter = slot;
+        slot_thumb_iter;
+        slot_thumb_iter = g_list_next(slot_thumb_iter))
+      {
+        dt_thumbnail_t *thumb = (dt_thumbnail_t *)slot_thumb_iter->data;
+        slot_heigth += thumb->height + spacing;
+      }
+      slot_heigth -= spacing;
+      yoff = (row_heigth - slot_heigth) / 2;
+
+      // Apply vertical and horizontal offsets
       for(GList *slot_thumb_iter = slot; slot_thumb_iter; slot_thumb_iter = g_list_next(slot_thumb_iter))
       {
         dt_thumbnail_t *thumb = (dt_thumbnail_t *)slot_thumb_iter->data;
         thumb->x += xoff;
+        thumb->y += yoff;
       }
       g_list_free(slot);
     }

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1560,6 +1560,7 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
     }
   }
   slots = g_list_reverse(slots);  // list was built in reverse order, so un-reverse it
+  const int number_of_slots = g_list_length(slots);
 
 
   // finished assigning thumbnails to slots
@@ -1600,8 +1601,17 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
       float stack_heigth_factor = 
         (max_slot_heigth - spacing * (g_list_length(slot) - 1)) / (float)slot_heigth;
       
-      // limit scaling so that width does not increase to more than twice the average thumbnail width
-      stack_heigth_factor = MIN(stack_heigth_factor, 2 * avg_thumb_width / (float)thumb->width);
+      if(number_of_slots == 2)
+      {
+        // limit scaling factor to 20% if only two images are displayed so that slight differences are corrected
+        // but portrait and landscape orientation are displayed at similar sizes 
+        stack_heigth_factor = MIN(stack_heigth_factor, 1.2);
+      }
+      else
+      {
+        // limit scaling so that width does not increase to more than twice the average thumbnail width
+        stack_heigth_factor = MIN(stack_heigth_factor, 2 * avg_thumb_width / (float)thumb->width);
+      }
       thumb->height *= stack_heigth_factor;
       thumb->width *= stack_heigth_factor;
 


### PR DESCRIPTION
@ Reviewer: I have not cleaned up / squashed the commits yet because I want to get the functionality of this PR approved first before I do a final cleaning. Since I changed many code lines I will try to organize this in a way to make review easier.


This is a follow up PR to #14966 which left a few issues unaddressed.
* sometimes images do not have the same height (see #12875)
* 'stacking' functionality was completely borked

Fixed issues:
* Stacking now works as intended without overlapping thumbnails or leaving the screen. To reproduce, display 3 or more thumbnails where the combined height of 2 thumbnails is smaller than the third.

original             |  fixed
:-------------------------:|:-------------------------:
![image](https://github.com/darktable-org/darktable/assets/2805109/aa672724-270d-4af6-9cf1-b2afbf430dbf)  |  ![image](https://github.com/darktable-org/darktable/assets/2805109/37148d7a-1a87-4480-87b9-3509f4f41416)

* Thumbnails are now scaled to equal height. 
To avoid gigantic thumbnails when scaling very slim thumbnails, I limited this to 2 times the average thumbnail width.
This does even out slight differences (example 1) but also makes better use of the available space when displaying mixed aspect ratios of portrait and landscape images (example 2)

original             |  fixed
:-------------------------:|:-------------------------:
![image](https://github.com/darktable-org/darktable/assets/2805109/fe8bc399-06c2-4034-8786-a81a1e659dbd)  |  ![image](https://github.com/darktable-org/darktable/assets/2805109/2d83f148-c501-4c8b-a694-8a386a38cffd)
![image](https://github.com/darktable-org/darktable/assets/2805109/1cc8e72b-5308-4b53-8515-6fe58b10004a)  |  ![image](https://github.com/darktable-org/darktable/assets/2805109/7053ac6a-b858-45f9-8079-e9947dbafc82)

I personally found this irritating when looking at only 2 images (one a landscape and the other a portrait) since the landscape will appear to be bigger than the portrait. Therefore I limited scaling to 20% if only 2 images are displayed. This does even out small differences but portrait and landscape will not be scaled to the same height.

without 20% limit (just a test, I do not like this)            |  with 20% limit (my final implementation - looks like before)
:-------------------------:|:-------------------------:
![image](https://github.com/darktable-org/darktable/assets/2805109/e4cd311f-5292-4a18-b219-b87c50fc500c)  | ![image](https://github.com/darktable-org/darktable/assets/2805109/dca69f80-1846-4c59-bf0e-18d8229fc797)


* Scaling all images to the same height allowed me to simplify the thumbnail placement algorithm and achieve better placement results in some situations

original             |  fixed
:-------------------------:|:-------------------------:
![image](https://github.com/darktable-org/darktable/assets/2805109/23e7592c-bdb3-4764-9472-9b0cb3647f32)  |  ![image](https://github.com/darktable-org/darktable/assets/2805109/116061ee-80b1-4d4a-9ae4-30d9b2e50e01)
 