### PR TITLE
[CMake] fix dependency for generate_authors_h

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1046,6 +1046,9 @@ if(USE_LIBRAW AND NOT (DONT_USE_INTERNAL_LIBRAW AND libraw_FOUND))
   target_link_libraries(lib_darktable PRIVATE libraw::libraw)
 endif()
 
+#
+# generate the authors file
+#
 add_custom_command(
   DEPENDS ${CMAKE_SOURCE_DIR}/tools/authors_h.sh ${CMAKE_SOURCE_DIR}/AUTHORS
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/tools/darktable_authors.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -932,6 +932,7 @@ set_source_files_properties(${DARKTABLE_BINDIR}/version_gen.c PROPERTIES GENERAT
 add_dependencies(lib_darktable generate_conf)
 add_dependencies(lib_darktable generate_version)
 add_dependencies(lib_darktable generate_preferences)
+add_dependencies(lib_darktable generate_authors_h)
 
 if(APPLE)
   set_target_properties(lib_darktable PROPERTIES MACOSX_RPATH TRUE)

--- a/src/libs/CMakeLists.txt
+++ b/src/libs/CMakeLists.txt
@@ -56,7 +56,6 @@ add_library(ioporder MODULE "ioporder.c")
 add_library(viewswitcher MODULE "tools/viewswitcher.c")
 
 add_library(darktable_label MODULE "tools/darktable.c")
-add_dependencies(darktable_label generate_authors_h)
 
 add_library(colorlabels MODULE "tools/colorlabels.c")
 add_library(ratings MODULE "tools/ratings.c")


### PR DESCRIPTION
fixes #15178 

Fixed the dependency for `generate_authors_h` for the now separated `src/gui/about.c`