### PR TITLE
disable global colorpicker on any focus change request

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2201,6 +2201,9 @@ void dt_iop_request_focus(dt_iop_module_t *module)
   dt_develop_t *dev = darktable.develop;
   dt_iop_module_t *out_focus_module = dev->gui_module;
 
+  // disable global color picker on any focus change request
+  dt_iop_color_picker_reset(NULL, TRUE);
+
   if(darktable.gui->reset || (out_focus_module == module)) return;
 
   dev->gui_module = module;

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3841,6 +3841,7 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
   // module
   if(dev->gui_module && dev->gui_module->scrolled
      && !darktable.develop->darkroom_skip_mouse_events
+     && !dt_iop_color_picker_is_visible(dev)
      && dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS)
     handled = dev->gui_module->scrolled(dev->gui_module, x, y, up, state);
   if(handled) return;


### PR DESCRIPTION
Fixes #15157
Alternative to #15170.

This PR aggressively disables the global color picker on any widget focus change request. With the aim of avoiding most instances of the user wanting to interact with, say, crop handles or mask shapes, but being prevented from doing so because they forgot that the global color picker was still active. If the global picker is then activated anyway, also prevent mouse cursor shape changes that suggest that another control in the background is still active too (like for example the crop handles mentioned in #15157).

Please provide feedback and indicate a preference for either this approach or #15170 which still allows the other background control to be partly visible while blocking interaction with it and thereby making clear that the color picker is active and overriding.

Please also report any clashes that the simplistic approach of this PR doesn't address.

EDIT: I should make clear that this and #15170 need not be mutually exclusive. For the times when the user intentionally engages the global picker again after the change here has disabled it, it is possible to then have the other canvasses exposed in a less obtrusive manner (as #15170 does). That I personally don't see the benefit (because at that point the user is well aware what they are doing) and wonder if it wouldn't be annoying to, for example, have to switch off masks explicitly if you _don't_ want to see them without being able to interact, which if combined with _this_ PR would mean having to reenable to global picker again too, doesn't preclude finishing that work as well.