### PR TITLE
png: store color encoding as cICP chunk as well

### DIFF
--- a/src/imageio/format/png.c
+++ b/src/imageio/format/png.c
@@ -170,8 +170,12 @@ int write_image(dt_imageio_module_data_t *p_tmp, const char *filename, const voi
 
   // metadata has to be written before the pixels
 
-  // embed icc profile
-  cmsHPROFILE out_profile = dt_colorspaces_get_output_profile(imgid, over_type, over_filename)->profile;
+  // determine the actual (export vs colorout) color profile used
+  const dt_colorspaces_color_profile_t *cp = dt_colorspaces_get_output_profile(imgid, over_type, over_filename);
+  cmsHPROFILE out_profile = cp->profile;
+
+#ifdef PNG_iCCP_SUPPORTED
+  // embed ICC profile regardless of cICP later (compliant readers shall check cICP first)
   uint32_t len = 0;
   cmsSaveProfileToMem(out_profile, NULL, &len);
   if(len > 0)
@@ -193,6 +197,7 @@ int write_image(dt_imageio_module_data_t *p_tmp, const char *filename, const voi
       free(buf);
     }
   }
+#endif
 
   // write exif data
   if(exif && exif_len > 0)
@@ -213,6 +218,71 @@ int write_image(dt_imageio_module_data_t *p_tmp, const char *filename, const voi
   }
 
   png_write_info(png_ptr, info_ptr);
+
+#if(PNG_LIBPNG_VER >= 10500)
+  /*
+   * If possible, we want libpng to save the color encoding in a new
+   * cICP chunk as well (see https://www.w3.org/TR/png-3/#cICP-chunk).
+   * If we are unable to find the required color encoding data we have
+   * anyway provided an iCCP chunk (and hope we could at least do that!).
+   *
+   * Must come after png_write_info() for the time being.
+   * TODO: use known cICP chunk write support API once added to libpng
+   */
+  png_byte data[4] = {
+    DT_CICP_COLOR_PRIMARIES_UNSPECIFIED, DT_CICP_TRANSFER_CHARACTERISTICS_UNSPECIFIED,
+    DT_CICP_MATRIX_COEFFICIENTS_IDENTITY,
+    1, // full range
+  };
+
+  switch(cp->type)
+  {
+    case DT_COLORSPACE_SRGB:
+      data[0] = DT_CICP_COLOR_PRIMARIES_REC709;
+      data[1] = DT_CICP_TRANSFER_CHARACTERISTICS_SRGB;
+      break;
+    case DT_COLORSPACE_REC709:
+      data[0] = DT_CICP_COLOR_PRIMARIES_REC709;
+      data[1] = DT_CICP_TRANSFER_CHARACTERISTICS_REC709;
+      break;
+    case DT_COLORSPACE_LIN_REC709:
+      data[0] = DT_CICP_COLOR_PRIMARIES_REC709;
+      data[1] = DT_CICP_TRANSFER_CHARACTERISTICS_LINEAR;
+      break;
+    case DT_COLORSPACE_LIN_REC2020:
+      data[0] = DT_CICP_COLOR_PRIMARIES_REC2020;
+      data[1] = DT_CICP_TRANSFER_CHARACTERISTICS_LINEAR;
+      break;
+    case DT_COLORSPACE_PQ_REC2020:
+      data[0] = DT_CICP_COLOR_PRIMARIES_REC2020;
+      data[1] = DT_CICP_TRANSFER_CHARACTERISTICS_PQ;
+      break;
+    case DT_COLORSPACE_HLG_REC2020:
+      data[0] = DT_CICP_COLOR_PRIMARIES_REC2020;
+      data[1] = DT_CICP_TRANSFER_CHARACTERISTICS_HLG;
+      break;
+    case DT_COLORSPACE_PQ_P3:
+      data[0] = DT_CICP_COLOR_PRIMARIES_P3;
+      data[1] = DT_CICP_TRANSFER_CHARACTERISTICS_PQ;
+      break;
+    case DT_COLORSPACE_HLG_P3:
+      data[0] = DT_CICP_COLOR_PRIMARIES_P3;
+      data[1] = DT_CICP_TRANSFER_CHARACTERISTICS_HLG;
+      break;
+    case DT_COLORSPACE_DISPLAY_P3:
+      data[0] = DT_CICP_COLOR_PRIMARIES_P3;
+      data[1] = DT_CICP_TRANSFER_CHARACTERISTICS_SRGB;
+      break;
+    default:
+      break;
+  }
+
+  if(data[0] != DT_CICP_COLOR_PRIMARIES_UNSPECIFIED && data[1] != DT_CICP_TRANSFER_CHARACTERISTICS_UNSPECIFIED)
+  {
+    const png_byte chunk_name[5] = "cICP";
+    png_write_chunk(png_ptr, chunk_name, data, 4);
+  }
+#endif
 
   /*
    * Get rid of filler (OR ALPHA) bytes, pack XRGB/RGBX/ARGB/RGBA into
@@ -459,8 +529,7 @@ void *legacy_params(dt_imageio_module_format_t *self,
 void *get_params(dt_imageio_module_format_t *self)
 {
   dt_imageio_png_t *d = (dt_imageio_png_t *)calloc(1, sizeof(dt_imageio_png_t));
-  const char *bpp = dt_conf_get_string_const("plugins/imageio/format/png/bpp");
-  d->bpp = atoi(bpp);
+  d->bpp = dt_conf_get_int("plugins/imageio/format/png/bpp");
   if(d->bpp != 8 && d->bpp != 16)
     d->bpp = 8;
 
@@ -557,8 +626,7 @@ void gui_init(dt_imageio_module_format_t *self)
 {
   dt_imageio_png_gui_t *gui = (dt_imageio_png_gui_t *)malloc(sizeof(dt_imageio_png_gui_t));
   self->gui_data = (void *)gui;
-  const char *conf_bpp = dt_conf_get_string_const("plugins/imageio/format/png/bpp");
-  int bpp = atoi(conf_bpp);
+  const int bpp = dt_conf_get_int("plugins/imageio/format/png/bpp");
 
   // PNG compression level might actually be zero!
   int compression = 5;


### PR DESCRIPTION
This adds PNG spec 3rd ed. export support to complement https://github.com/darktable-org/darktable/pull/12237

Relnotes: "Exported PNG files now include a CICP encoded color profile in addition to ICC if possible"