### PR TITLE
Fix escapedkerneldir for OpenCL kernels on Linux/ARM64

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -930,7 +930,7 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
            "%s" G_DIR_SEPARATOR_S "programs.conf", kerneldir);
 
   char *escapedkerneldir = NULL;
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !(defined(__linux__) && defined(__aarch64__))
   escapedkerneldir = g_strdup_printf("\"%s\"", kerneldir);
 #else
   escapedkerneldir = dt_util_str_replace(kerneldir, " ", "\\ ");


### PR DESCRIPTION
Issue #15067.

On Armbian/aarch64 double quotes are interpreted literally, resulting in nonexisting `escapedkerneldir` path.

Add (__linux__ && __aarch64__) to compiler directive to not add double quotes for escapedkerneldir.

Tested with Armbian (23.8.1) aarch64 on Orange Pi 5B with Mali-G610 GPU.

```
$ /opt/darktable/bin/darktable-cltest
     0.0362 [dt_get_sysresource_level] switched to 1 as `default'
     0.0363   total mem:       15969MB
     0.0363   mipmap cache:    1996MB
     0.0363   available mem:   7984MB
     0.0363   singlebuff:      124MB
[opencl_init] opencl related configuration options:
[opencl_init] opencl: ON
[opencl_init] opencl_scheduling_profile: 'default'
[opencl_init] opencl_library: 'default path'
[opencl_init] opencl_device_priority: '*/!0,*/*/*/!0,*'
[opencl_init] opencl_mandatory_timeout: 400
[opencl_init] opencl library 'libOpenCL' found on your system and loaded
arm_release_ver: g13p0-01eac0, rk_so_ver: 3
[opencl_init] found 1 platform
[opencl_init] found 1 device

[dt_opencl_device_init]
   DEVICE:                   0: 'Mali-G610 r0p0'
   PLATFORM NAME & VENDOR:   ARM Platform, ARM
   CANONICAL NAME:           armplatformmalig610r0p0
   DRIVER VERSION:           3.0
   DEVICE VERSION:           OpenCL 3.0 v1.g13p0-01eac0.a8b6f0c7e1f83c654c60d1775112dbe4
   DEVICE_TYPE:              GPU, unified mem
   GLOBAL MEM SIZE:          15963 MB
   MAX MEM ALLOC:            15963 MB
   MAX IMAGE SIZE:           65536 x 65536
   MAX WORK GROUP SIZE:      1024
   MAX WORK ITEM DIMENSIONS: 3
   MAX WORK ITEM SIZES:      [ 1024 1024 1024 ]
   ASYNC PIXELPIPE:          NO
   PINNED MEMORY TRANSFER:   NO
   AVOID ATOMICS:            NO
   MICRO NAP:                250
   ROUNDUP WIDTH & HEIGHT    16x16
   CHECK EVENT HANDLES:      128
   TILING ADVANTAGE:         0.000
   DEFAULT DEVICE:           NO
   KERNEL BUILD DIRECTORY:   /opt/darktable/share/darktable/kernels
   KERNEL DIRECTORY:         /home/mdadmin/.cache/darktable/cached_v2_kernels_for_ARMPlatformMaliG610r0p0_30
   CL COMPILER OPTION:       
   KERNEL LOADING TIME:       0.0078 sec
[opencl_init] OpenCL successfully initialized. Internal numbers and names of available devices:
[opencl_init]           0       'ARM Platform Mali-G610 r0p0'
[opencl_init] FINALLY: opencl is AVAILABLE and ENABLED.
```