### PR TITLE
Display color-picker samples even if global picker not selected.

### DIFF
--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -401,14 +401,12 @@ static gboolean _sample_enter_callback(GtkWidget *widget,
                                        GdkEvent *event,
                                        dt_colorpicker_sample_t *sample)
 {
-  if(darktable.lib->proxy.colorpicker.picker_proxy)
-  {
-    darktable.lib->proxy.colorpicker.selected_sample = sample;
-    if(darktable.lib->proxy.colorpicker.display_samples)
-      dt_dev_invalidate_all(darktable.develop);
+  darktable.lib->proxy.colorpicker.selected_sample = sample;
 
-    dt_control_queue_redraw_center();
-  }
+  if(darktable.lib->proxy.colorpicker.display_samples)
+    dt_dev_invalidate_all(darktable.develop);
+
+  dt_control_queue_redraw_center();
 
   return FALSE;
 }


### PR DESCRIPTION
This has bothered me since some time. When hovering the global color-picker it was needed to have selected the picker to have the on-canvas sample area displayed. This is now not needed making it easier to work with the stored samples.