### PR TITLE
interpolation aligning fix and maintenance

### DIFF
--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -91,7 +91,7 @@ static void _show_2_times(const dt_times_t *start,
  * @param idx index to filter
  * @param length length of line
  */
-static inline ssize_t clip(ssize_t i,
+static inline ssize_t _clip(ssize_t i,
                        const ssize_t min,
                        const ssize_t max,
                        enum border_mode mode)
@@ -147,7 +147,7 @@ static inline ssize_t clip(ssize_t i,
   return i;
 }
 
-static inline void prepare_tap_boundaries(int *tap_first,
+static inline void _prepare_tap_boundaries(int *tap_first,
                                           int *tap_last,
                                           const enum border_mode mode,
                                           const int filterwidth,
@@ -170,21 +170,6 @@ static inline void prepare_tap_boundaries(int *tap_first,
   }
 }
 
-/** Make sure an aligned chunk will not misalign its following chunk
- * proposing an adapted length
- *
- * @param l Length required for current chunk
- * @param align Required alignment for next chunk
- *
- * @return Required length for keeping alignment ok if chaining data chunks
- */
-static inline size_t increase_for_alignment(const size_t l,
-                                            size_t align)
-{
-  align -= 1;
-  return (l + align) & (~align);
-}
-
 /* --------------------------------------------------------------------------
  * Interpolation kernels
  * ------------------------------------------------------------------------*/
@@ -193,7 +178,7 @@ static inline size_t increase_for_alignment(const size_t l,
  * Bilinear interpolation
  * ------------------------------------------------------------------------*/
 
-static float maketaps_bilinear(float *taps,
+static float _maketaps_bilinear(float *taps,
                                const size_t num_taps,
                                const float  width,
                                const float first_tap,
@@ -225,7 +210,7 @@ static float maketaps_bilinear(float *taps,
  * Bicubic interpolation
  * ------------------------------------------------------------------------*/
 
-static float maketaps_bicubic(float *taps,
+static float _maketaps_bicubic(float *taps,
                               const size_t num_taps,
                               const float  width,
                               const float first_tap,
@@ -337,7 +322,7 @@ lanczos(const float width, const float t)
  * the range -width < t < width so we can additionally avoid the
  * range check.  */
 
-static float maketaps_lanczos(float *taps,
+static float _maketaps_lanczos(float *taps,
                               const size_t num_taps,
                               const float width,
                               const float first_tap,
@@ -424,22 +409,22 @@ static const struct dt_interpolation dt_interpolator[] = {
   {.id = DT_INTERPOLATION_BILINEAR,
    .name = "bilinear",
    .width = 1,
-   .maketaps = &maketaps_bilinear,
+   .maketaps = &_maketaps_bilinear,
   },
   {.id = DT_INTERPOLATION_BICUBIC,
    .name = "bicubic",
    .width = 2,
-   .maketaps = &maketaps_bicubic,
+   .maketaps = &_maketaps_bicubic,
   },
   {.id = DT_INTERPOLATION_LANCZOS2,
    .name = "lanczos2",
    .width = 2,
-   .maketaps = &maketaps_lanczos,
+   .maketaps = &_maketaps_lanczos,
   },
   {.id = DT_INTERPOLATION_LANCZOS3,
    .name = "lanczos3",
    .width = 3,
-   .maketaps = &maketaps_lanczos,
+   .maketaps = &_maketaps_lanczos,
   },
 };
 
@@ -447,7 +432,7 @@ static const struct dt_interpolation dt_interpolator[] = {
  * Kernel utility methods
  * ------------------------------------------------------------------------*/
 
-static inline float compute_upsampling_kernel(const struct dt_interpolation *itor,
+static inline float _compute_upsampling_kernel(const struct dt_interpolation *itor,
                                               float *kernel,
                                               int *first,
                                               float t)
@@ -482,7 +467,7 @@ static inline float compute_upsampling_kernel(const struct dt_interpolation *ito
  * @param first [out] index of the first sample for which the kernel is to be applied
  * @param outoinratio [in] "out samples" over "in samples" ratio
  * @param xout [in] Output coordinate */
-static inline void compute_downsampling_kernel(const struct dt_interpolation *itor,
+static inline void _compute_downsampling_kernel(const struct dt_interpolation *itor,
                                                int *taps,
                                                int *first,
                                                float *kernel,
@@ -534,12 +519,12 @@ float dt_interpolation_compute_sample(const struct dt_interpolation *itor,
 {
   assert(itor->width < (MAX_HALF_FILTER_WIDTH + 1));
 
-  float kernelh[MAX_KERNEL_REQ] __attribute__((aligned(SSE_ALIGNMENT)));
-  float kernelv[MAX_KERNEL_REQ] __attribute__((aligned(SSE_ALIGNMENT)));
+  float DT_ALIGNED_ARRAY kernelh[MAX_KERNEL_REQ];
+  float DT_ALIGNED_ARRAY kernelv[MAX_KERNEL_REQ];
 
   // Compute both horizontal and vertical kernels
-  float normh = compute_upsampling_kernel(itor, kernelh, NULL, x);
-  float normv = compute_upsampling_kernel(itor, kernelv, NULL, y);
+  float normh = _compute_upsampling_kernel(itor, kernelh, NULL, x);
+  float normv = _compute_upsampling_kernel(itor, kernelv, NULL, y);
 
   int ix = (int)x;
   int iy = (int)y;
@@ -585,23 +570,23 @@ float dt_interpolation_compute_sample(const struct dt_interpolation *itor,
 
     int xtap_first;
     int xtap_last;
-    prepare_tap_boundaries(&xtap_first, &xtap_last,
+    _prepare_tap_boundaries(&xtap_first, &xtap_last,
                            bordermode, 2 * itor->width, ix, width);
 
     int ytap_first;
     int ytap_last;
-    prepare_tap_boundaries(&ytap_first, &ytap_last,
+    _prepare_tap_boundaries(&ytap_first, &ytap_last,
                            bordermode, 2 * itor->width, iy, height);
 
     // Apply the kernel
     float s = 0.f;
     for(ssize_t i = ytap_first; i < ytap_last; i++)
     {
-      const ssize_t clip_y = clip(iy + i, 0, height - 1, bordermode);
+      const ssize_t clip_y = _clip(iy + i, 0, height - 1, bordermode);
       float h = 0.0f;
       for(ssize_t j = xtap_first; j < xtap_last; j++)
       {
-        const ssize_t clip_x = clip(ix + j, 0, width - 1, bordermode);
+        const ssize_t clip_x = _clip(ix + j, 0, width - 1, bordermode);
         const float *ipixel = in + clip_y * linestride + clip_x * samplestride;
         h += kernelh[j] * ipixel[0];
       }
@@ -634,12 +619,12 @@ void dt_interpolation_compute_pixel4c(const struct dt_interpolation *itor,
   assert(itor->width < (MAX_HALF_FILTER_WIDTH + 1));
 
   // Quite a bit of space for kernels
-  float kernelh[MAX_KERNEL_REQ] __attribute__((aligned(SSE_ALIGNMENT)));
-  float kernelv[MAX_KERNEL_REQ] __attribute__((aligned(SSE_ALIGNMENT)));
+  float DT_ALIGNED_ARRAY kernelh[MAX_KERNEL_REQ];
+  float DT_ALIGNED_ARRAY kernelv[MAX_KERNEL_REQ];
 
   // Compute both horizontal and vertical kernels
-  float normh = compute_upsampling_kernel(itor, kernelh, NULL, x);
-  float normv = compute_upsampling_kernel(itor, kernelv, NULL, y);
+  float normh = _compute_upsampling_kernel(itor, kernelh, NULL, x);
+  float normv = _compute_upsampling_kernel(itor, kernelv, NULL, y);
 
   // Precompute the inverse of the filter norm for later use
   const float oonorm = (1.f / (normh * normv));
@@ -696,24 +681,24 @@ void dt_interpolation_compute_pixel4c(const struct dt_interpolation *itor,
 
     int xtap_first;
     int xtap_last;
-    prepare_tap_boundaries(&xtap_first, &xtap_last,
+    _prepare_tap_boundaries(&xtap_first, &xtap_last,
                            bordermode, 2 * itor->width, ix, width);
 
     int ytap_first;
     int ytap_last;
-    prepare_tap_boundaries(&ytap_first, &ytap_last,
+    _prepare_tap_boundaries(&ytap_first, &ytap_last,
                            bordermode, 2 * itor->width, iy, height);
 
     // Apply the kernel
     dt_aligned_pixel_t pixel = { 0.0f, 0.0f, 0.0f, 0.0f };
     for(ssize_t i = ytap_first; i < ytap_last; i++)
     {
-      const ssize_t clip_y = clip(iy + i, 0, height - 1, bordermode);
+      const ssize_t clip_y = _clip(iy + i, 0, height - 1, bordermode);
       dt_aligned_pixel_t h = { 0.0f, 0.0f, 0.0f, 0.0f };
       const float *ipixel = in + clip_y * linestride;
       for(ssize_t j = xtap_first; j < xtap_last; j++)
       {
-        const ssize_t clip_x = clip(ix + j, 0, width - 1, bordermode);
+        const ssize_t clip_x = _clip(ix + j, 0, width - 1, bordermode);
         dt_aligned_pixel_t inpx;
         copy_pixel(inpx, ipixel + 4 * clip_x);
         const float kern = kernelh[j];
@@ -729,6 +714,8 @@ void dt_interpolation_compute_pixel4c(const struct dt_interpolation *itor,
   }
   else
   {
+    dt_print(DT_DEBUG_PIPE, "[dt_interpolation_compute_pixel4c] problem at (%i,%i) in %xx%i",
+      ix, iy, width, height);
     for_each_channel(c,aligned(out))
       out[c] = 0.0f;
   }
@@ -846,9 +833,9 @@ const struct dt_interpolation *dt_interpolation_new(enum dt_interpolation_type t
  * @param pmeta [out] Array of int triplets (length, kernel, index) telling where to
  *        start for an arbitrary
  * out position meta[3*out]
- * @return 0 for success, !0 for failure
+ * @return FALSE for success, TRUE for failure
  */
-static int prepare_resampling_plan(const struct dt_interpolation *itor,
+static gboolean _prepare_resampling_plan(const struct dt_interpolation *itor,
                                    const int in,
                                    const int in_x0,
                                    const int out,
@@ -871,7 +858,7 @@ static int prepare_resampling_plan(const struct dt_interpolation *itor,
   if(scale == 1.f)
   {
     // No resampling required
-    return 0;
+    return FALSE;
   }
 
   // Compute common upsampling/downsampling memory requirements
@@ -890,20 +877,16 @@ static int prepare_resampling_plan(const struct dt_interpolation *itor,
   int nlengths = out;
   const int nindex = maxtapsapixel * out;
   const int nkernel = maxtapsapixel * out;
-  const size_t lengthreq = increase_for_alignment(nlengths * sizeof(int), SSE_ALIGNMENT);
-  const size_t indexreq = increase_for_alignment(nindex * sizeof(int), SSE_ALIGNMENT);
-  const size_t kernelreq = increase_for_alignment(nkernel * sizeof(float), SSE_ALIGNMENT);
-  const size_t scratchreq = maxtapsapixel * sizeof(float) + 4 * sizeof(float);
+  const size_t lengthreq = dt_round_size(nlengths * sizeof(int), SSE_ALIGNMENT);
+  const size_t indexreq = dt_round_size(nindex * sizeof(int), SSE_ALIGNMENT);
+  const size_t kernelreq = dt_round_size(nkernel * sizeof(float), SSE_ALIGNMENT);
+  const size_t scratchreq = dt_round_size(maxtapsapixel * sizeof(float) + 4 * sizeof(float), SSE_ALIGNMENT);
   // NB: because sse versions compute four taps a time
-  const size_t metareq = pmeta ? 3 * sizeof(int) * out : 0;
+  const size_t metareq = dt_round_size(pmeta ? 4 * sizeof(int) * out : 0, SSE_ALIGNMENT);
 
-  void *blob = NULL;
   const size_t totalreq = kernelreq + lengthreq + indexreq + scratchreq + metareq;
-  blob = dt_alloc_align(SSE_ALIGNMENT, totalreq);
-  if(!blob)
-  {
-    return 1;
-  }
+  void *blob = dt_alloc_align(SSE_ALIGNMENT, totalreq);
+  if(!blob) return TRUE;
 
   int *lengths = (int *)blob;
   blob = (char *)blob + lengthreq;
@@ -943,13 +926,13 @@ static int prepare_resampling_plan(const struct dt_interpolation *itor,
 
       // Compute the filter kernel at that position
       int first;
-      (void)compute_upsampling_kernel(itor, scratchpad, &first, fx);
+      (void)_compute_upsampling_kernel(itor, scratchpad, &first, fx);
 
       /* Check lower and higher bound pixel index and skip as many pixels as
        * necessary to fall into range */
       int tap_first;
       int tap_last;
-      prepare_tap_boundaries(&tap_first, &tap_last, bordermode, 2 * itor->width, first, in);
+      _prepare_tap_boundaries(&tap_first, &tap_last, bordermode, 2 * itor->width, first, in);
 
       // Track number of taps that will be used
       lengths[lidx++] = tap_last - tap_first;
@@ -970,7 +953,7 @@ static int prepare_resampling_plan(const struct dt_interpolation *itor,
       for(int tap = tap_first; tap < tap_last; tap++)
       {
         kernel[kidx++] = scratchpad[tap] * norm;
-        index[iidx++] = clip(first++, 0, in - 1, bordermode);
+        index[iidx++] = _clip(first++, 0, in - 1, bordermode);
       }
     }
   }
@@ -992,13 +975,13 @@ static int prepare_resampling_plan(const struct dt_interpolation *itor,
       // Compute downsampling kernel centered on output position
       int taps;
       int first;
-      compute_downsampling_kernel(itor, &taps, &first, scratchpad, NULL, scale, out_x0 + x);
+      _compute_downsampling_kernel(itor, &taps, &first, scratchpad, NULL, scale, out_x0 + x);
 
       /* Check lower and higher bound pixel index and skip as many pixels as
        * necessary to fall into range */
       int tap_first;
       int tap_last;
-      prepare_tap_boundaries(&tap_first, &tap_last, bordermode, taps, first, in);
+      _prepare_tap_boundaries(&tap_first, &tap_last, bordermode, taps, first, in);
 
       // Track number of taps that will be used
       lengths[lidx++] = tap_last - tap_first;
@@ -1019,7 +1002,7 @@ static int prepare_resampling_plan(const struct dt_interpolation *itor,
       for(int tap = tap_first; tap < tap_last; tap++)
       {
         kernel[kidx++] = scratchpad[tap] * norm;
-        index[iidx++] = clip(first++, 0, in - 1, bordermode);
+        index[iidx++] = _clip(first++, 0, in - 1, bordermode);
       }
     }
   }
@@ -1033,7 +1016,7 @@ static int prepare_resampling_plan(const struct dt_interpolation *itor,
     *pmeta = meta;
   }
 
-  return 0;
+  return FALSE;
 }
 
 static void dt_interpolation_resample_plain(const struct dt_interpolation *itor,
@@ -1054,7 +1037,6 @@ static void dt_interpolation_resample_plain(const struct dt_interpolation *itor,
 
   const int32_t in_stride_floats = in_stride / sizeof(float);
   const int32_t out_stride_floats = out_stride / sizeof(float);
-  int r;
 
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
                 "resample_plain", NULL, NULL, roi_in, roi_out, "%s\n",itor->name);
@@ -1087,21 +1069,15 @@ static void dt_interpolation_resample_plain(const struct dt_interpolation *itor,
   // Generic non 1:1 case... much more complicated :D
 
   // Prepare resampling plans once and for all
-  r = prepare_resampling_plan(itor, roi_in->width, roi_in->x,
+  if(_prepare_resampling_plan(itor, roi_in->width, roi_in->x,
                               roi_out->width, roi_out->x, roi_out->scale,
-                              &hlength, &hkernel, &hindex, NULL);
-  if(r)
-  {
+                              &hlength, &hkernel, &hindex, NULL))
     goto exit;
-  }
 
-  r = prepare_resampling_plan(itor, roi_in->height, roi_in->y,
+  if(_prepare_resampling_plan(itor, roi_in->height, roi_in->y,
                               roi_out->height, roi_out->y, roi_out->scale,
-                              &vlength, &vkernel, &vindex, &vmeta);
-  if(r)
-  {
+                              &vlength, &vkernel, &vindex, &vmeta))
     goto exit;
-  }
 
   dt_get_perf_times(&mid);
 
@@ -1289,7 +1265,6 @@ int dt_interpolation_resample_cl(const struct dt_interpolation *itor,
   float *vkernel = NULL;
   int *vmeta = NULL;
 
-  int r;
   cl_int err = DT_OPENCL_DEFAULT_ERROR;
 
   cl_mem dev_hindex = NULL;
@@ -1323,24 +1298,18 @@ int dt_interpolation_resample_cl(const struct dt_interpolation *itor,
     return CL_SUCCESS;
   }
 
-// Generic non 1:1 case... much more complicated :D
+  // Generic non 1:1 case... much more complicated :D
 
   // Prepare resampling plans once and for all
-  r = prepare_resampling_plan(itor, roi_in->width, roi_in->x,
+  if(_prepare_resampling_plan(itor, roi_in->width, roi_in->x,
                               roi_out->width, roi_out->x, roi_out->scale,
-                              &hlength, &hkernel, &hindex, &hmeta);
-  if(r)
-  {
+                              &hlength, &hkernel, &hindex, &hmeta))
     goto error;
-  }
 
-  r = prepare_resampling_plan(itor, roi_in->height, roi_in->y,
+  if(_prepare_resampling_plan(itor, roi_in->height, roi_in->y,
                               roi_out->height, roi_out->y, roi_out->scale,
-                              &vlength, &vkernel, &vindex, &vmeta);
-  if(r)
-  {
+                              &vlength, &vkernel, &vindex, &vmeta))
     goto error;
-  }
 
   dt_get_perf_times(&mid);
 
@@ -1385,7 +1354,7 @@ int dt_interpolation_resample_cl(const struct dt_interpolation *itor,
     // the vertical workgroupsize; there is no point in continuing on
     // the GPU - that would be way too slow; let's delegate the stuff
     // to the CPU then.
-    err = DT_OPENCL_PROCESS_CL;
+    err = CL_INVALID_WORK_GROUP_SIZE;
     goto error;
   }
 
@@ -1442,7 +1411,7 @@ int dt_interpolation_resample_cl(const struct dt_interpolation *itor,
 error:
   if(err == CL_SUCCESS)
     _show_2_times(&start, &mid, "resample_cl");
-  else
+  else if(err != CL_INVALID_WORK_GROUP_SIZE)
     dt_print_pipe(DT_DEBUG_OPENCL, "interpolation_resample_cl", NULL, NULL, roi_in, roi_out,
       "Error: %s\n", cl_errstr(err));
 
@@ -1497,8 +1466,6 @@ static void dt_interpolation_resample_1c_plain(const struct dt_interpolation *it
   float *vkernel = NULL;
   int *vmeta = NULL;
 
-  int r;
-
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
                 "resample_1c_plain", NULL, NULL, roi_in, roi_out, "%s\n", itor->name);
   dt_times_t start = { 0 }, mid = { 0 };
@@ -1528,21 +1495,15 @@ static void dt_interpolation_resample_1c_plain(const struct dt_interpolation *it
   // Generic non 1:1 case... much more complicated :D
 
   // Prepare resampling plans once and for all
-  r = prepare_resampling_plan(itor, roi_in->width, roi_in->x,
+  if(_prepare_resampling_plan(itor, roi_in->width, roi_in->x,
                               roi_out->width, roi_out->x, roi_out->scale,
-                              &hlength, &hkernel, &hindex, NULL);
-  if(r)
-  {
+                              &hlength, &hkernel, &hindex, NULL))
     goto exit;
-  }
 
-  r = prepare_resampling_plan(itor, roi_in->height, roi_in->y,
+  if(_prepare_resampling_plan(itor, roi_in->height, roi_in->y,
                               roi_out->height, roi_out->y, roi_out->scale,
-                              &vlength, &vkernel, &vindex, &vmeta);
-  if(r)
-  {
+                              &vlength, &vkernel, &vindex, &vmeta))
     goto exit;
-  }
 
   dt_get_perf_times(&mid);
 

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -167,10 +167,10 @@ int dt_iop_clip_and_zoom_roi_cl(int devid, cl_mem dev_out, cl_mem dev_in, const 
 {
   const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
   cl_int err = dt_interpolation_resample_roi_cl(itor, devid, dev_out, roi_out, dev_in, roi_in);
-  if(err == DT_OPENCL_PROCESS_CL)
+  if(err == CL_INVALID_WORK_GROUP_SIZE)
   {
     // We ran into a "vertical number of taps exceeds the vertical workgroupsize" problem
-    // Instead of redoing the whole thing later we do an internal fallback to cpu here 
+    // Instead of redoing the whole thing later we do an internal fallback to cpu here
     float *in = dt_alloc_align_float((size_t)roi_in->width * roi_in->height * 4);
     float *out = dt_alloc_align_float((size_t)roi_out->width * roi_out->height * 4);
     if(out && in)
@@ -182,11 +182,16 @@ int dt_iop_clip_and_zoom_roi_cl(int devid, cl_mem dev_out, cl_mem dev_in, const 
         dt_iop_clip_and_zoom_roi(out, in, roi_out, roi_in, 0, 0);
         err = dt_opencl_write_host_to_device
               (devid, out, dev_out, roi_out->width, roi_out->height, 4 * sizeof(float));
-        if(err == CL_SUCCESS)
-          dt_print_pipe(DT_DEBUG_OPENCL, "clip_and_zoom_roi_cl", NULL, NULL, roi_in, roi_out,
-            "did fast cpu fallback\n");
       }
+
     }
+    if(err == CL_SUCCESS)
+      dt_print_pipe(DT_DEBUG_OPENCL, "clip_and_zoom_roi_cl", NULL, NULL, roi_in, roi_out,
+          "did fast cpu fallback\n");
+    else
+      dt_print_pipe(DT_DEBUG_OPENCL, "clip_and_zoom_roi_cl", NULL, NULL, roi_in, roi_out,
+          "fast cpu fallback failing: %s\n", cl_errstr(err));
+
     dt_free_align(in);
     dt_free_align(out);
   }


### PR DESCRIPTION
While investigating #15198 , #15185 and a crash i observed here with wrong scaling of a mask i checked interpolation code. Not sure if the wrong aligning fixed here might be the culprit but at least this seems plausible as a) related to lanc3 and b) a strong downscaling ratio. 

1. use DT_ALIGNED_ARRAY instead of special aligning function
2. fix aligning for
   - 'scratchreq', could be non-aligned depending on maxtaps
   - 'metareq', should hold 4 for vectorizing 
3. style fixes, underscores for static functions
4. pass workgroup size opencl error for correctness.
5. some debug log improvements