### PR TITLE
avoid  double image when unfocusing crop

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3508,10 +3508,11 @@ int button_pressed(dt_view_t *self,
   x -= tb;
   y -= tb;
 
-  if(darktable.develop->darkroom_skip_mouse_events && type == GDK_BUTTON_PRESS)
+  if(darktable.develop->darkroom_skip_mouse_events)
   {
     if(which == 1)
     {
+      if(type == GDK_2BUTTON_PRESS) return 0;
       dt_control_change_cursor(GDK_HAND1);
       return 1;
     }


### PR DESCRIPTION
Since #15084 when switching focus away from the crop module, sometimes the cropped area is incorrectly overlaid on top of the uncropped full image view, until it is fully recalculated.
![image](https://github.com/darktable-org/darktable/assets/1549490/973c84ee-6f90-4327-abec-616aab19977f)
This fixes that by shifting the high-res image out of sight, so the upscaled preview image is used instead; first the cropped one, then the uncropped one or, depending on which pipe finishes first, immediately the full recalculated image.

EDIT: while testing crop, a lot, I found it annoying that it (as many other modes) disables double-click to return to lighttable. For other such temporarily overridden mouse actions, like pan/zoom/rotate you can hold "a" ("force pan/zoom/rotate with mouse")  to access them. It seemed intuitive to me that this would also apply to double-click, so have added that small change to this PR.