### PR TITLE
[CI/CD] Unbreak macOS nightly build environment

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -356,7 +356,7 @@ jobs:
       # We need write permission to update the nightly tag
       contents: write
     runs-on: ubuntu-latest
-    needs: [AppImage, Windows]
+    needs: [AppImage, Windows, macOS]
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -303,11 +303,11 @@ jobs:
       - name: Install Base Dependencies
         run: |
           brew update > /dev/null || true
-          # brew upgrade || true        # no need for a very time-consuming upgrade of ALL packages
+          # brew upgrade || true        # No need for a very time-consuming upgrade of ALL packages
+          brew upgrade gd               # See https://github.com/Homebrew/homebrew-core/issues/141766
           brew tap Homebrew/bundle
           cd src/.ci
           export HOMEBREW_NO_INSTALL_UPGRADE=1
-          export HOMEBREW_NO_INSTALL_CLEANUP=1
           brew bundle --verbose || true
           # handle keg-only libs
           brew link --force libomp


### PR DESCRIPTION
The last two runs of the nightly build for macOS failed (the reason is currently still visible in the GitHub Actions run logs).

I still don't want to run a full upgrade of all the packages installed in the runner (`brew upgrade`), as this is a long and generally unnecessary process and it also upgrades many packages that are not used for the darktable build. But at the moment, in order to correctly install the build environment packages, you must first upgrade the gd package installed in the runner. See https://github.com/Homebrew/homebrew-core/issues/141766

Also removed HOMEBREW_NO_INSTALL_CLEANUP as it is not needed.

In addition, it turned out that the publication of nightly artifacts for other platforms, even if the build for macOS fails (which happens from time to time), is not implemented reliably. Yes, if the build for macOS is unsuccessful, builds for other platforms will be published. But if a macOS build succeeds but finishes last, it won't be published because the publish artifacts step will run earlier. So I made the publication dependent on the success of the build for all platforms again.

EDIT: I tested the success of the macOS build with these fixes by manually running it on my fork. If possible, it would be nice to accept this PR before tonight's nightly launch.