### PR TITLE
fix several minor issues with dialog boxes

### DIFF
--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -51,7 +51,7 @@
 @define-color bauhaus_fg_insensitive alpha(@bauhaus_fg, 0.5);
 
 /* GTK Buttons and tabs */
-@define-color button_bg @grey_55;
+@define-color button_bg shade(@grey_55,0.95);
 @define-color button_hover_bg @grey_70;
 @define-color button_hover_fg @grey_30;
 

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1669,6 +1669,7 @@ progressbar progress
   ------------------------------------------------------------------*/
 /*** All states options are designed below, active, hover, selected, disabled and check states ***/
 /* Main states */
+.default, /* dialog button that activates with Enter */
 .dt_history_items:active,
 .dt_history_items:checked,
 button:active,
@@ -1682,7 +1683,6 @@ entry:checked,
 filechooser *:selected,
 menuitem:active,
 menuitem:selected,
-messagedialog .default,  /* this show that a button in confirmation action pop-up has the focus (no by default) */
 treeview *:selected:not(check),
 treeview *:checked:not(check),
 #main-histogram .dt_module_btn:checked:not(.rgb_toggle)

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1522,7 +1522,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
       not_again = dt_gui_show_standalone_yes_no_dialog
         (_("configuration information"),
          config_info,
-         _("show this information again"), _("understood"));
+         _("_show this information again"), _("_understood"));
 
     if(not_again || (last_configure_version == 0))
       dt_conf_set_int("performance_configuration_version_completed",

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -3093,14 +3093,14 @@ void dt_database_show_error(const dt_database_t *db)
     // clang-format on
 
     gboolean delete_lockfiles = dt_gui_show_standalone_yes_no_dialog(_("error starting darktable"),
-                                        label_text, _("cancel"), _("delete database lock files"));
+                                        label_text, _("_cancel"), _("_delete database lock files"));
 
     if(delete_lockfiles)
     {
       gboolean really_delete_lockfiles =
         dt_gui_show_standalone_yes_no_dialog
         (_("are you sure?"),
-         _("\ndo you really want to delete the lock files?\n"), _("no"), _("yes"));
+         _("\ndo you really want to delete the lock files?\n"), _("_no"), _("_yes"));
       if(really_delete_lockfiles)
       {
         int status = 0;
@@ -3118,14 +3118,14 @@ void dt_database_show_error(const dt_database_t *db)
         if(status==0)
           dt_gui_show_standalone_yes_no_dialog(_("done"),
                                         _("\nsuccessfully deleted the lock files.\nyou can now restart darktable\n"),
-                                        _("ok"), NULL);
+                                        _("_ok"), NULL);
         else
           dt_gui_show_standalone_yes_no_dialog
             (_("error"), g_markup_printf_escaped(
               _("\nat least one file could not be removed.\n"
                 "you may try to manually delete the files <i>data.db.lock</i> and <i>library.db.lock</i>\n"
                 "in folder <a href=\"file:///%s\">%s</a>.\n"), lck_dirname, lck_dirname),
-             _("ok"), NULL);
+             _("_ok"), NULL);
       }
     }
 
@@ -3340,7 +3340,7 @@ void ask_for_upgrade(const gchar *dbname, const gboolean has_gui)
 
   gboolean shall_we_update_the_db =
     dt_gui_show_standalone_yes_no_dialog(_("darktable - schema migration"), label_text,
-                                         _("close darktable"), _("upgrade database"));
+                                         _("_close darktable"), _("_upgrade database"));
 
   g_free(label_text);
 
@@ -3661,12 +3661,9 @@ start:
         dialog = gtk_dialog_new_with_buttons(_("darktable - error opening database"),
                                             NULL,
                                             dflags,
-                                            _("close darktable"),
-                                            GTK_RESPONSE_CLOSE,
-                                            _("attempt restore"),
-                                            GTK_RESPONSE_ACCEPT,
-                                            _("delete database"),
-                                            GTK_RESPONSE_REJECT,
+                                            _("_close darktable"), GTK_RESPONSE_CLOSE,
+                                            _("_attempt restore"), GTK_RESPONSE_ACCEPT,
+                                            _("_delete database"), GTK_RESPONSE_REJECT,
                                             NULL);
         gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
         label_options = _("do you want to close darktable now to manually restore\n"
@@ -3679,10 +3676,8 @@ start:
         dialog = gtk_dialog_new_with_buttons(_("darktable - error opening database"),
                                             NULL,
                                             dflags,
-                                            _("close darktable"),
-                                            GTK_RESPONSE_CLOSE,
-                                            _("delete database"),
-                                            GTK_RESPONSE_REJECT,
+                                            _("_close darktable"), GTK_RESPONSE_CLOSE,
+                                            _("_delete database"), GTK_RESPONSE_REJECT,
                                             NULL);
         gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_CLOSE);
         label_options = _("do you want to close darktable now to manually restore\n"
@@ -3848,12 +3843,9 @@ start:
       dialog = gtk_dialog_new_with_buttons(_("darktable - error opening database"),
                                           NULL,
                                           dflags,
-                                          _("close darktable"),
-                                          GTK_RESPONSE_CLOSE,
-                                          _("attempt restore"),
-                                          GTK_RESPONSE_ACCEPT,
-                                          _("delete database"),
-                                          GTK_RESPONSE_REJECT,
+                                          _("_close darktable"), GTK_RESPONSE_CLOSE,
+                                          _("_attempt restore"), GTK_RESPONSE_ACCEPT,
+                                          _("_delete database"), GTK_RESPONSE_REJECT,
                                           NULL);
       gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
       label_options = _("do you want to close darktable now to manually restore\n"
@@ -3866,10 +3858,8 @@ start:
       dialog = gtk_dialog_new_with_buttons(_("darktable - error opening database"),
                                           NULL,
                                           dflags,
-                                          _("close darktable"),
-                                          GTK_RESPONSE_CLOSE,
-                                          _("delete database"),
-                                          GTK_RESPONSE_REJECT,
+                                          _("_close darktable"), GTK_RESPONSE_CLOSE,
+                                          _("_delete database"), GTK_RESPONSE_REJECT,
                                           NULL);
       gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_CLOSE);
       label_options = _("do you want to close darktable now to manually restore\n"

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2522,7 +2522,7 @@ gboolean dt_gui_show_standalone_yes_no_dialog(const char *title, const char *mar
 
   if(no_text)
   {
-    button = gtk_button_new_with_label(no_text);
+    button = gtk_button_new_with_mnemonic(no_text);
     result.button_no = button;
     g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_yes_no_button_handler), &result);
     gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, TRUE, 0);
@@ -2530,7 +2530,7 @@ gboolean dt_gui_show_standalone_yes_no_dialog(const char *title, const char *mar
 
   if(yes_text)
   {
-    button = gtk_button_new_with_label(yes_text);
+    button = gtk_button_new_with_mnemonic(yes_text);
     result.button_yes = button;
     g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_yes_no_button_handler), &result);
     gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, TRUE, 0);

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -558,14 +558,14 @@ static void _presets_show_edit_dialog(dt_gui_presets_edit_dialog_t *g,
   char title[1024];
   snprintf(title, sizeof(title), _("edit `%s' for module `%s'"),
            g->original_name, g->module_name);
-  GtkWidget *dialog = gtk_dialog_new_with_buttons
-    (title, g->parent, GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL,
-     _("_export..."), GTK_RESPONSE_YES,
-     _("delete"), GTK_RESPONSE_REJECT,
-     _("_cancel"), GTK_RESPONSE_CANCEL,
-     _("_ok"), GTK_RESPONSE_OK, NULL);
+  GtkWidget *dialog = gtk_dialog_new_with_buttons(title, g->parent,
+                                                  GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL,
+                                                  _("_export..."), GTK_RESPONSE_YES,
+                                                  _("_delete"), GTK_RESPONSE_REJECT,
+                                                  _("_cancel"), GTK_RESPONSE_CANCEL,
+                                                  _("_ok"), GTK_RESPONSE_OK, NULL);
   dt_gui_dialog_add_help(GTK_DIALOG(dialog), "preset_dialog");
-  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
+  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_OK);
 
   g->dialog = dialog;
 
@@ -579,6 +579,7 @@ static void _presets_show_edit_dialog(dt_gui_presets_edit_dialog_t *g,
 
   g->name = GTK_ENTRY(gtk_entry_new());
   gtk_entry_set_text(g->name, g->original_name);
+  gtk_entry_set_width_chars(g->name, 10 + g_utf8_strlen(title, -1));
   if(allow_name_change)
     gtk_entry_set_activates_default(g->name, TRUE);
   else

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -488,6 +488,13 @@ static gint _g_list_find_module_by_name(gconstpointer a, gconstpointer b)
   return strncmp(((dt_iop_module_t *)a)->op, b, strlen(((dt_iop_module_t *)a)->op));
 }
 
+static void _name_changed(GtkEntry *entry,
+                          GtkDialog *dialog)
+{
+  const gchar *name = gtk_entry_get_text(entry);
+  gtk_dialog_set_response_sensitive(dialog, GTK_RESPONSE_ACCEPT, name && *name);
+}
+
 static void _gui_styles_dialog_run(gboolean edit, const char *name, dt_imgid_t imgid)
 {
   char title[512];
@@ -514,11 +521,12 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, dt_imgid_t i
   GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
   GtkDialog *dialog = GTK_DIALOG(
       gtk_dialog_new_with_buttons(title, GTK_WINDOW(window), GTK_DIALOG_DESTROY_WITH_PARENT,
-                                   _("select _all"),  GTK_RESPONSE_YES,
+                                  _("select _all"),  GTK_RESPONSE_YES,
                                   _("select _none"), GTK_RESPONSE_NONE,
                                   _("_cancel"), GTK_RESPONSE_REJECT,
-                                 _("_save"), GTK_RESPONSE_ACCEPT, NULL));
+                                  _("_save"), GTK_RESPONSE_ACCEPT, NULL));
   dt_gui_dialog_add_help(dialog, "styles");
+  gtk_dialog_set_default_response(dialog, GTK_RESPONSE_ACCEPT);
 
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(GTK_WIDGET(dialog));
@@ -547,11 +555,15 @@ static void _gui_styles_dialog_run(gboolean edit, const char *name, dt_imgid_t i
   sd->name = gtk_entry_new();
   gtk_entry_set_placeholder_text(GTK_ENTRY(sd->name), _("name"));
   gtk_widget_set_tooltip_text(sd->name, _("enter a name for the new style"));
+  gtk_entry_set_activates_default(GTK_ENTRY(sd->name), TRUE);
+  gtk_dialog_set_response_sensitive(dialog, GTK_RESPONSE_ACCEPT, FALSE);
+  g_signal_connect(sd->name, "changed", G_CALLBACK(_name_changed), dialog);
 
   sd->description = gtk_entry_new();
   gtk_entry_set_placeholder_text(GTK_ENTRY(sd->description), _("description"));
   gtk_widget_set_tooltip_text(sd->description,
                               _("enter a description for the new style, this description is searchable"));
+  gtk_entry_set_activates_default(GTK_ENTRY(sd->description), TRUE);
 
   /*set values*/
   if(edit && name)

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2920,8 +2920,9 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
   GtkWidget *dialog = gtk_dialog_new_with_buttons(_("collections settings"), GTK_WINDOW(win),
                                                   GTK_DIALOG_DESTROY_WITH_PARENT,
-                                                 _("cancel"), GTK_RESPONSE_NONE,
-                                                 _("save"), GTK_RESPONSE_ACCEPT, NULL);
+                                                  _("_cancel"), GTK_RESPONSE_NONE,
+                                                  _("_save"), GTK_RESPONSE_ACCEPT, NULL);
+  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
   dt_prefs_init_dialog_collect(dialog);
   g_signal_connect(dialog, "key-press-event", G_CALLBACK(dt_handle_dialog_enter), NULL);
 

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -806,9 +806,10 @@ static void _preview_gpx_file(GtkWidget *widget, dt_lib_module_t *self)
 {
   dt_lib_geotagging_t *d = (dt_lib_geotagging_t *)self->data;
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  GtkWidget *dialog = gtk_dialog_new_with_buttons(
-            _("GPX file track segments"), GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT,
-            _("done"), GTK_RESPONSE_CANCEL, NULL);
+  GtkWidget *dialog = gtk_dialog_new_with_buttons(_("GPX file track segments"), GTK_WINDOW(win),
+                                                  GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                  _("_done"), GTK_RESPONSE_CANCEL, NULL);
+  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_CANCEL);
 
   gchar *filedir = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(widget));
   struct dt_gpx_t *gpx = dt_gpx_new(filedir);

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1699,11 +1699,12 @@ static void _import_from_dialog_new(dt_lib_module_t* self)
   dt_lib_import_t *d = (dt_lib_import_t *)self->data;
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
 
-  d->from.dialog = gtk_dialog_new_with_buttons
-    ( _(_import_text[d->import_case]), NULL, GTK_DIALOG_MODAL,
-      _("cancel"), GTK_RESPONSE_CANCEL,
-      _(_import_text[d->import_case]), GTK_RESPONSE_ACCEPT,
-      NULL);
+  d->from.dialog = gtk_dialog_new_with_buttons(_(_import_text[d->import_case]), NULL,
+                                               GTK_DIALOG_MODAL,
+                                               _("_cancel"), GTK_RESPONSE_CANCEL,
+                                               _(_import_text[d->import_case]), GTK_RESPONSE_ACCEPT,
+                                               NULL);
+  gtk_dialog_set_default_response(GTK_DIALOG(d->from.dialog), GTK_RESPONSE_ACCEPT);
   dt_gui_dialog_add_help(GTK_DIALOG(d->from.dialog), "import_dialog");
 
 #ifdef GDK_WINDOWING_QUARTZ
@@ -1808,6 +1809,9 @@ static void _import_from_dialog_new(dt_lib_module_t* self)
   {
     gtk_widget_show_all(d->from.dialog);
   }
+
+  // make sure no buttons focused, so default button is marked
+  gtk_window_set_focus(GTK_WINDOW(d->from.dialog), NULL);
 }
 
 static void _import_set_collection(const char *dirname)
@@ -1975,7 +1979,7 @@ static void _lib_import_from_callback(GtkWidget *widget, dt_lib_module_t* self)
                "\nfurther information can be found in the darktable manual."
                "\n\ninspect darktable preferences -> import."
                "\ncheck and possibly correct the 'base directory naming pattern'"),
-            _("show this information again"), _("understood & done"));
+            _("_show this information again"), _("_understood & done"));
       if(understood)
         dt_conf_set_bool("setup_import_directory", TRUE);
       else

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -461,10 +461,12 @@ static void _menuitem_preferences(GtkMenuItem *menuitem,
                                   dt_lib_module_t *self)
 {
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  GtkWidget *dialog = gtk_dialog_new_with_buttons
-    (_("metadata settings"), GTK_WINDOW(win),
-     GTK_DIALOG_DESTROY_WITH_PARENT, _("default"), GTK_RESPONSE_YES,
-     _("cancel"), GTK_RESPONSE_NONE, _("save"), GTK_RESPONSE_ACCEPT, NULL);
+  GtkWidget *dialog = gtk_dialog_new_with_buttons(_("metadata settings"), GTK_WINDOW(win),
+                                                  GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                  _("_default"), GTK_RESPONSE_YES,
+                                                  _("_cancel"), GTK_RESPONSE_NONE,
+                                                  _("_save"), GTK_RESPONSE_ACCEPT, NULL);
+  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
   dt_gui_dialog_add_help(GTK_DIALOG(dialog), "metadata_preferences");
   g_signal_connect(dialog, "key-press-event", G_CALLBACK(dt_handle_dialog_enter), NULL);
   GtkWidget *area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
@@ -519,6 +521,9 @@ static void _menuitem_preferences(GtkMenuItem *menuitem,
     (_("visible"), renderer,
      "active", DT_METADATA_PREF_COL_VISIBLE, NULL);
   gtk_tree_view_append_column(GTK_TREE_VIEW(view), column);
+  GtkTreePath *first = gtk_tree_path_new_first ();
+  gtk_tree_view_set_cursor(GTK_TREE_VIEW(view), first, column, FALSE);
+  gtk_tree_path_free(first);
   GtkWidget *header = gtk_tree_view_column_get_button(column);
   gtk_widget_set_tooltip_text(header,
                 _("tick if the corresponding metadata is of interest for you"

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -1201,8 +1201,11 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
 
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
   GtkWidget *dialog = gtk_dialog_new_with_buttons(_("metadata settings"), GTK_WINDOW(win),
-                                       GTK_DIALOG_DESTROY_WITH_PARENT, _("default"), GTK_RESPONSE_YES,
-                                       _("cancel"), GTK_RESPONSE_NONE, _("save"), GTK_RESPONSE_ACCEPT, NULL);
+                                                  GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                  _("_default"), GTK_RESPONSE_YES,
+                                                  _("_cancel"), GTK_RESPONSE_NONE,
+                                                  _("_save"), GTK_RESPONSE_ACCEPT, NULL);
+  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
   g_signal_connect(dialog, "key-press-event", G_CALLBACK(dt_handle_dialog_enter), NULL);
   GtkWidget *area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 
@@ -1248,6 +1251,9 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
   column = gtk_tree_view_column_new_with_attributes(_("visible"), renderer,
                                                     "active", DT_METADATA_PREF_COL_VISIBLE, NULL);
   gtk_tree_view_append_column(GTK_TREE_VIEW(view), column);
+  GtkTreePath *first = gtk_tree_path_new_first ();
+  gtk_tree_view_set_cursor(GTK_TREE_VIEW(view), first, column, FALSE);
+  gtk_tree_path_free(first);
 
   // drag & drop
   gtk_tree_view_set_reorderable(GTK_TREE_VIEW(view), TRUE);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -3400,33 +3400,30 @@ static void _preset_autoapply_changed(dt_gui_presets_edit_dialog_t *g)
   d->editor_reset = FALSE;
 }
 
-static void _manage_editor_preset_name_verify(GtkWidget *tb, dt_lib_module_t *self)
+static void _manage_editor_preset_name_verify(GtkWidget *tb,
+                                              gpointer params[])
 {
-  GList *names = (GList *)g_object_get_data(G_OBJECT(tb), "existing_names");
-  GtkWidget *lb = (GtkWidget *)g_object_get_data(G_OBJECT(tb), "existing_label");
-  GtkWidget *bt_ok = (GtkWidget *)g_object_get_data(G_OBJECT(tb), "ok_btn");
+  GtkDialog *dialog = params[0];
+  GList *names = params[1];
+  GtkWidget *warning_label = params[2];
+
   const gchar *txt = gtk_entry_get_text(GTK_ENTRY(tb));
+  gboolean good = *txt;
 
   // we don't want empty name
-  if(!g_strcmp0(txt, ""))
+  if(good)
   {
-    gtk_widget_set_visible(lb, TRUE);
-    gtk_widget_set_sensitive(bt_ok, FALSE);
-    return;
-  }
-
-  for(const GList *l = names; l; l = g_list_next(l))
-  {
-    gchar *tx = (gchar *)l->data;
-    if(!g_strcmp0(tx, txt))
+    for(const GList *l = names; l; l = g_list_next(l))
     {
-      gtk_widget_set_visible(lb, TRUE);
-      gtk_widget_set_sensitive(bt_ok, FALSE);
-      return;
+      if(!g_strcmp0(l->data, txt))
+      {
+        good = FALSE;
+        break;
+      }
     }
   }
-  gtk_widget_set_visible(lb, FALSE);
-  gtk_widget_set_sensitive(bt_ok, TRUE);
+  gtk_widget_set_visible(warning_label, !good);
+  gtk_dialog_set_response_sensitive(dialog, GTK_RESPONSE_OK, good);
 }
 
 static void _manage_editor_preset_action(GtkWidget *btn, dt_lib_module_t *self)
@@ -3464,26 +3461,26 @@ static void _manage_editor_preset_action(GtkWidget *btn, dt_lib_module_t *self)
   sqlite3_finalize(stmt);
 
   gint res = GTK_RESPONSE_OK;
-  GtkWidget *dialog
-      = gtk_dialog_new_with_buttons(_("rename preset"), GTK_WINDOW(d->dialog), GTK_DIALOG_DESTROY_WITH_PARENT,
-                                    _("cancel"), GTK_RESPONSE_CANCEL, _("rename"), GTK_RESPONSE_OK, NULL);
+  GtkWidget *dialog = gtk_dialog_new_with_buttons(_("rename preset"), GTK_WINDOW(d->dialog),
+                                                  GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                  _("_cancel"), GTK_RESPONSE_CANCEL,
+                                                  _("_rename"), GTK_RESPONSE_OK, NULL);
+  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_OK);
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(dialog);
 #endif
-  GtkWidget *bt_ok = gtk_dialog_get_widget_for_response(GTK_DIALOG(dialog), GTK_RESPONSE_OK);
   GtkWidget *content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
   gtk_box_pack_start(GTK_BOX(content_area), gtk_label_new(_("new preset name:")), FALSE, TRUE, 0);
   GtkWidget *lb = gtk_label_new(_("a preset with this name already exists!"));
   GtkWidget *tb = gtk_entry_new();
-  gtk_entry_set_text(GTK_ENTRY(tb), new_name);
-  g_object_set_data(G_OBJECT(tb), "existing_names", names);
-  g_object_set_data(G_OBJECT(tb), "existing_label", lb);
-  g_object_set_data(G_OBJECT(tb), "ok_btn", bt_ok);
-  g_signal_connect(G_OBJECT(tb), "changed", G_CALLBACK(_manage_editor_preset_name_verify), self);
+  gtk_entry_set_activates_default(GTK_ENTRY(tb), TRUE);
+  gtk_entry_set_width_chars(GTK_ENTRY(tb), 10 + g_utf8_strlen(gtk_window_get_title(GTK_WINDOW(dialog)), -1));
+  gpointer verify_params[] = {dialog, names, lb};
+  g_signal_connect(G_OBJECT(tb), "changed", G_CALLBACK(_manage_editor_preset_name_verify), verify_params);
   gtk_box_pack_start(GTK_BOX(content_area), tb, FALSE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(content_area), lb, FALSE, TRUE, 0);
   gtk_widget_show_all(content_area);
-  _manage_editor_preset_name_verify(tb, self);
+  gtk_entry_set_text(GTK_ENTRY(tb), new_name);
   res = gtk_dialog_run(GTK_DIALOG(dialog));
 
   g_free(new_name);

--- a/src/libs/recentcollect.c
+++ b/src/libs/recentcollect.c
@@ -224,8 +224,10 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
   char confname[200];
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
   GtkWidget *dialog = gtk_dialog_new_with_buttons(_("recent collections settings"), GTK_WINDOW(win),
-                                                  GTK_DIALOG_DESTROY_WITH_PARENT, _("cancel"), GTK_RESPONSE_NONE,
-                                                  _("save"), GTK_RESPONSE_ACCEPT, NULL);
+                                                  GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                  _("_cancel"), GTK_RESPONSE_NONE,
+                                                  _("_save"), GTK_RESPONSE_ACCEPT, NULL);
+  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
   dt_prefs_init_dialog_recentcollect(dialog);
   g_signal_connect(dialog, "key-press-event", G_CALLBACK(dt_handle_dialog_enter), NULL);
 

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -434,10 +434,12 @@ static void _export_clicked(GtkWidget *w, gpointer user_data)
 
           if(dt_conf_get_bool("plugins/lighttable/style/ask_before_delete_style"))
           {
-            GtkWidget *dialog_overwrite_export = gtk_dialog_new_with_buttons(_("overwrite style?"), GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT,
-                _("cancel"), GTK_RESPONSE_CANCEL,
-                _("skip"), GTK_RESPONSE_NONE,
-                _("overwrite"), GTK_RESPONSE_ACCEPT, NULL);
+            GtkWidget *dialog_overwrite_export = gtk_dialog_new_with_buttons(_("overwrite style?"), GTK_WINDOW(win),
+                                                                             GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                                             _("_cancel"), GTK_RESPONSE_CANCEL,
+                                                                             _("_skip"), GTK_RESPONSE_NONE,
+                                                                             _("_overwrite"), GTK_RESPONSE_ACCEPT, NULL);
+            gtk_dialog_set_default_response(GTK_DIALOG(dialog_overwrite_export), GTK_RESPONSE_CANCEL);
 
             // contents for dialog
             GtkWidget *content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog_overwrite_export));
@@ -617,10 +619,12 @@ static void _import_clicked(GtkWidget *w, gpointer user_data)
           // use security check/option
           if(dt_conf_get_bool("plugins/lighttable/style/ask_before_delete_style"))
           {
-            GtkWidget *dialog_overwrite_import = gtk_dialog_new_with_buttons(_("overwrite style?"), GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT,
-                _("cancel"), GTK_RESPONSE_CANCEL,
-                _("skip"), GTK_RESPONSE_NONE,
-                _("overwrite"), GTK_RESPONSE_ACCEPT, NULL);
+            GtkWidget *dialog_overwrite_import = gtk_dialog_new_with_buttons(_("overwrite style?"), GTK_WINDOW(win),
+                                                                             GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                                             _("_cancel"), GTK_RESPONSE_CANCEL,
+                                                                             _("_skip"), GTK_RESPONSE_NONE,
+                                                                             _("_overwrite"), GTK_RESPONSE_ACCEPT, NULL);
+            gtk_dialog_set_default_response(GTK_DIALOG(dialog_overwrite_import), GTK_RESPONSE_CANCEL);
 
             // contents for dialog
             GtkWidget *content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog_overwrite_import));

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -1479,8 +1479,11 @@ static void _pop_menu_dictionary_delete_tag(GtkWidget *menuitem, dt_lib_module_t
   if(img_count > 0 || dt_conf_get_bool("plugins/lighttable/tagging/ask_before_delete_tag"))
   {
     GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-    GtkWidget *dialog = gtk_dialog_new_with_buttons(_("delete tag?"), GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT,
-                                  _("cancel"), GTK_RESPONSE_NONE, _("delete"), GTK_RESPONSE_YES, NULL);
+    GtkWidget *dialog = gtk_dialog_new_with_buttons(_("delete tag?"), GTK_WINDOW(win),
+                                                    GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                    _("_cancel"), GTK_RESPONSE_NONE,
+                                                    _("_delete"), GTK_RESPONSE_YES, NULL);
+    gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_NONE);
     gtk_window_set_default_size(GTK_WINDOW(dialog), 300, -1);
     GtkWidget *area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
     GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
@@ -1567,8 +1570,11 @@ static void _pop_menu_dictionary_delete_node(GtkWidget *menuitem, dt_lib_module_
   if(tag_count == 0) return;
 
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  GtkWidget *dialog = gtk_dialog_new_with_buttons( _("delete node?"), GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT,
-                                _("cancel"), GTK_RESPONSE_NONE, _("delete"), GTK_RESPONSE_YES, NULL);
+  GtkWidget *dialog = gtk_dialog_new_with_buttons(_("delete node?"), GTK_WINDOW(win),
+                                                  GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                  _("_cancel"), GTK_RESPONSE_NONE,
+                                                  _("_delete"), GTK_RESPONSE_YES, NULL);
+  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_NONE);
   gtk_window_set_default_size(GTK_WINDOW(dialog), 300, -1);
   GtkWidget *area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
@@ -1628,6 +1634,13 @@ static void _pop_menu_dictionary_delete_node(GtkWidget *menuitem, dt_lib_module_
   g_free(tagname);
 }
 
+static void _name_changed(GtkEntry *entry,
+                          GtkDialog *dialog)
+{
+  const gchar *name = gtk_entry_get_text(entry);
+  gtk_dialog_set_response_sensitive(dialog, GTK_RESPONSE_YES, name && *name);
+}
+
 // create tag allows the user to create a single tag, which can be an element of the hierarchy or not
 static void _pop_menu_dictionary_create_tag(GtkWidget *menuitem, dt_lib_module_t *self)
 {
@@ -1648,8 +1661,11 @@ static void _pop_menu_dictionary_create_tag(GtkWidget *menuitem, dt_lib_module_t
         DT_LIB_TAGGING_COL_PATH, &path, DT_LIB_TAGGING_COL_ID, &tagid, -1);
 
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  GtkWidget *dialog = gtk_dialog_new_with_buttons(_("create tag"), GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT,
-                                       _("cancel"), GTK_RESPONSE_NONE, _("save"), GTK_RESPONSE_YES, NULL);
+  GtkWidget *dialog = gtk_dialog_new_with_buttons(_("create tag"), GTK_WINDOW(win),
+                                                  GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                  _("_cancel"), GTK_RESPONSE_NONE,
+                                                  _("_save"), GTK_RESPONSE_YES, NULL);
+  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_YES);
   gtk_window_set_default_size(GTK_WINDOW(dialog), 300, -1);
   GtkWidget *area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
@@ -1661,6 +1677,9 @@ static void _pop_menu_dictionary_create_tag(GtkWidget *menuitem, dt_lib_module_t
   label = gtk_label_new(_("name: "));
   gtk_box_pack_start(GTK_BOX(box), label, FALSE, TRUE, 0);
   GtkWidget *entry = gtk_entry_new();
+  gtk_entry_set_activates_default(GTK_ENTRY(entry), TRUE);
+  gtk_dialog_set_response_sensitive(GTK_DIALOG(dialog), GTK_RESPONSE_YES, FALSE);
+  g_signal_connect(entry, "changed", G_CALLBACK(_name_changed), dialog);
   gtk_box_pack_end(GTK_BOX(box), entry, TRUE, TRUE, 0);
 
   GtkWidget *category;
@@ -1778,8 +1797,11 @@ static void _pop_menu_dictionary_edit_tag(GtkWidget *menuitem, dt_lib_module_t *
   }
 
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  GtkWidget *dialog = gtk_dialog_new_with_buttons(_("edit"), GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT,
-                                       _("cancel"), GTK_RESPONSE_NONE, _("save"), GTK_RESPONSE_YES, NULL);
+  GtkWidget *dialog = gtk_dialog_new_with_buttons(_("edit"), GTK_WINDOW(win),
+                                                  GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                  _("_cancel"), GTK_RESPONSE_NONE,
+                                                  _("_save"), GTK_RESPONSE_YES, NULL);
+  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_YES);
   gtk_window_set_default_size(GTK_WINDOW(dialog), 300, -1);
   GtkWidget *area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
@@ -1808,6 +1830,8 @@ static void _pop_menu_dictionary_edit_tag(GtkWidget *menuitem, dt_lib_module_t *
   label = gtk_label_new(_("name: "));
   gtk_box_pack_start(GTK_BOX(box), label, FALSE, TRUE, 0);
   GtkWidget *entry = gtk_entry_new();
+  gtk_entry_set_activates_default(GTK_ENTRY(entry), TRUE);
+  g_signal_connect(entry, "changed", G_CALLBACK(_name_changed), dialog);
   gtk_entry_set_text(GTK_ENTRY(entry), subtag ? subtag : tagname);
   gtk_box_pack_end(GTK_BOX(box), entry, TRUE, TRUE, 0);
 
@@ -2052,8 +2076,11 @@ static void _pop_menu_dictionary_change_path(GtkWidget *menuitem, dt_lib_module_
   if(tag_count == 0) return;
 
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  GtkWidget *dialog = gtk_dialog_new_with_buttons(_("change path"), GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT,
-                                       _("cancel"), GTK_RESPONSE_NONE, _("save"), GTK_RESPONSE_YES, NULL);
+  GtkWidget *dialog = gtk_dialog_new_with_buttons(_("change path"), GTK_WINDOW(win),
+                                                  GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                  _("_cancel"), GTK_RESPONSE_NONE,
+                                                  _("_save"), GTK_RESPONSE_YES, NULL);
+  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_YES);
   gtk_window_set_default_size(GTK_WINDOW(dialog), 300, -1);
   GtkWidget *area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
@@ -2078,6 +2105,7 @@ static void _pop_menu_dictionary_change_path(GtkWidget *menuitem, dt_lib_module_
   g_free(text);
 
   GtkWidget *entry = gtk_entry_new();
+  gtk_entry_set_activates_default(GTK_ENTRY(entry), TRUE);
   gtk_entry_set_text(GTK_ENTRY(entry), tagname);
   gtk_box_pack_start(GTK_BOX(vbox), entry, FALSE, TRUE, 0);
 
@@ -3467,9 +3495,10 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
   GtkWidget *dialog = gtk_dialog_new_with_buttons(_("tagging settings"), GTK_WINDOW(win),
                                                   GTK_DIALOG_DESTROY_WITH_PARENT,
-                                                 _("cancel"), GTK_RESPONSE_NONE,
-                                                 _("save"), GTK_RESPONSE_ACCEPT, NULL);
+                                                  _("_cancel"), GTK_RESPONSE_NONE,
+                                                  _("_save"), GTK_RESPONSE_ACCEPT, NULL);
   g_signal_connect(dialog, "key-press-event", G_CALLBACK(dt_handle_dialog_enter), NULL);
+  gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
   dt_prefs_init_dialog_tagging(dialog);
 
 #ifdef GDK_WINDOWING_QUARTZ


### PR DESCRIPTION
closes #14787

This adds `gtk_dialog_set_default_response` to a few dialog boxes (and fixes it for presets where it no longer linked to the correct code after changes were made there). Some dialogs were already using a key handler to active the response on Enter/KP_Enter, but this would not give a hint to gtk which button should be marked as the default. (It also makes it less clear which button got pressed because the dialog closes immediately rather than with a small delay during which the button lights up).

@Nilvus as discussed in #14787, could you have a look at the CSS to style `.default` buttons distinctively? While you are looking; I'm noticing some strange behavior in the tagging module; when I right click on a tag and select "edit..." the dialog comes up looking normal. When I then press Del (which deletes the whole tag name and therefore disables the "save" button, that button moves down a little bit, leaving two superimposed buttons. Probably a gtk bug but maybe workaroundable in CSS?

Actually, that disabling the "save" button when the name is empty is new in this PR and also added for styles.

The presets and modulegroups edit dialog boxes are made wider if their title is long. Normally gtk ellipsizes a windows title and there's no way (as far as I know) to make the window scale with its title. This change is instead resizing the Entry _within_ the window, but of course that won't work perfectly if the fonts sizes are different.

The export metadata dialogs can now be resized and this will correctly resize the treeviews within them.

When the add to library/import dialog opened, I got a lot of "GFileInfo created without standard::is-hidden" messages on the command line. I believe this is now fixed. I have not tested if hidden files are now correctly filtered out (or whether the comment in the source that "g_file_info_get_is_hidden() always returns 0 on macOS" was possibly related to this).

In the metadata_view ("image information") preferences dialog the second column ("visible") is now focused. This has the advantage that you can use the up/down arrow keys to go to a different row and then press the space bar to toggle the option. Previously you had to know that you had to press the _right_ arrow key first too. Same in metadata.

EDIT: until @Nilvus provides updated CSS you might temporarily test with something silly like
```
.default
{
  background-color: transparent;
}
```
to be able to distinguish the default button in dialogs.