### PR TITLE
Lens module work

### DIFF
--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -4415,6 +4415,8 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->scale), "quad-pressed",
                    G_CALLBACK(_autoscale_pressed_lf), self);
   gtk_widget_set_tooltip_text(g->scale, _("auto scale"));
+  dt_bauhaus_widget_set_quad_tooltip(g->scale,
+    "automatic scale to available image size due to lensfun data");
 
   // reverse direction
   g->reverse = dt_bauhaus_combobox_from_params(self, "inverse");
@@ -4482,6 +4484,8 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->scale_md), "quad-pressed",
                    G_CALLBACK(_autoscale_pressed_md), self);
   gtk_widget_set_tooltip_text(g->scale_md, _("image scaling"));
+  dt_bauhaus_widget_set_quad_tooltip(g->scale_md,
+    "automatic scale to available image size");
 
   // main widget
   GtkWidget *main_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
@@ -4535,6 +4539,8 @@ void gui_init(struct dt_iop_module_t *self)
   g->v_strength = dt_bauhaus_slider_from_params(sect, "v_strength");
   gtk_widget_set_tooltip_text(g->v_strength,
       _("amount of the applied optical vignetting correction"));
+  dt_bauhaus_widget_set_quad_tooltip(g->v_strength,
+    "show applied optical vignette correction mask");
   dt_bauhaus_slider_set_format(g->v_strength, "%");
   dt_bauhaus_slider_set_digits(g->v_strength, 1);
   dt_bauhaus_widget_set_quad_paint(g->v_strength, dtgtk_cairo_paint_showmask, 0, NULL);


### PR DESCRIPTION
1. The code for using embedded metadata get's a full OpenCL implementation. Tested on available machines and even if the cpu code is pretty fast already this code has been worth the effort.
2. In some cases we don't have proper lens correction data at all but still want to use the manually controlled vignette correction. To support this a new mode "only manual vignette" has been added