### PR TITLE
reset bauhaus to auto preset with ctrl+dblclick and add quad tooltip

### DIFF
--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -160,6 +160,8 @@ typedef struct dt_bauhaus_widget_t
   gboolean show_extended_label;
   // callback function to draw the quad icon
   dt_bauhaus_quad_paint_f quad_paint;
+  // tooltip to show when mouse is over the quad section
+  gchar *tooltip;
   // minimal modifiers for paint function.
   int quad_paint_flags;
   // data for the paint callback
@@ -272,13 +274,16 @@ void dt_bauhaus_widget_set_quad_active(GtkWidget *w, int active);
 int dt_bauhaus_widget_get_quad_active(GtkWidget *w);
 // set quad visibility:
 void dt_bauhaus_widget_set_quad_visibility(GtkWidget *w, const gboolean visible);
+// set a tooltip for the quad button:
+void dt_bauhaus_widget_set_quad_tooltip(GtkWidget *w, const gchar *text);
+// get the tooltip for widget or quad button:
+gchar *dt_bauhaus_widget_get_tooltip_markup(GtkWidget *widget, dt_action_element_t element);
 // set pointer to iop params field:
 void dt_bauhaus_widget_set_field(GtkWidget *w, gpointer field, dt_introspection_type_t field_type);
+// update one bauhaus widget or all widgets in a module from the provided (blend)params
+void dt_bauhaus_update_from_field(dt_iop_module_t *module, GtkWidget *w, gpointer params, gpointer blend_params);
 // reset widget to default value
 void dt_bauhaus_widget_reset(GtkWidget *widget);
-
-// update all bauhaus widgets in an iop module from their params fields
-void dt_bauhaus_update_module(dt_iop_module_t *self);
 
 // slider:
 GtkWidget *dt_bauhaus_slider_new(dt_iop_module_t *self);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2101,7 +2101,7 @@ void dt_iop_gui_update(dt_iop_module_t *module)
   {
     if(module->gui_data)
     {
-      dt_bauhaus_update_module(module);
+      dt_bauhaus_update_from_field(module, NULL, NULL, NULL);
 
       if(module->params && module->gui_update)
       {
@@ -2145,7 +2145,7 @@ static void _gui_reset_callback(GtkButton *button,
   // If Ctrl was not pressed, or no auto-presets were applied, reset the module parameters
   if(!(event
        && dt_modifier_is(event->state, GDK_CONTROL_MASK))
-     || !dt_gui_presets_autoapply_for_module(module))
+     || !dt_gui_presets_autoapply_for_module(module, NULL))
   {
     // if a drawn mask is set, remove it from the list
     if(dt_is_valid_maskid(module->blend_params->mask_id))

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -992,7 +992,7 @@ gboolean dt_shortcut_tooltip_callback(GtkWidget *widget,
   int show_element = 0;
   dt_shortcut_t lua_shortcut = { .speed = 1.0 };
 
-  gchar *original_markup = gtk_widget_get_tooltip_markup(widget);
+  gchar *original_markup = dt_bauhaus_widget_get_tooltip_markup(widget, darktable.control->element);
   gchar *preset_name = g_object_get_data(G_OBJECT(widget), "dt-preset-name");
   const gchar *widget_name = gtk_widget_get_name(widget);
 

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -389,6 +389,7 @@ static GtkWidget *_color_picker_new(dt_iop_module_t *module,
   {
     dt_bauhaus_widget_set_quad_paint(w, dtgtk_cairo_paint_colorpicker, 0, NULL);
     dt_bauhaus_widget_set_quad_toggle(w, TRUE);
+    dt_bauhaus_widget_set_quad_tooltip(w, _("pick color from image"));
     _init_picker(color_picker, module, flags, w);
     if(init_cst)
       color_picker->picker_cst = cst;

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -559,8 +559,8 @@ static void _presets_show_edit_dialog(dt_gui_presets_edit_dialog_t *g,
   GtkWidget *dialog = gtk_dialog_new_with_buttons
     (title, g->parent, GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL,
      _("_export..."), GTK_RESPONSE_YES,
-     _("delete"), GTK_RESPONSE_REJECT, 
-     _("_cancel"), GTK_RESPONSE_CANCEL, 
+     _("delete"), GTK_RESPONSE_REJECT,
+     _("_cancel"), GTK_RESPONSE_CANCEL,
      _("_ok"), GTK_RESPONSE_OK, NULL);
   dt_gui_dialog_add_help(GTK_DIALOG(dialog), "preset_dialog");
   gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
@@ -1167,8 +1167,10 @@ void dt_gui_presets_apply_adjacent_preset(dt_iop_module_t *module,
   g_free(name);
 }
 
-gboolean dt_gui_presets_autoapply_for_module(dt_iop_module_t *module)
+gboolean dt_gui_presets_autoapply_for_module(dt_iop_module_t *module, GtkWidget *widget)
 {
+  if(!module || module->actions != DT_ACTION_TYPE_IOP_INSTANCE) return FALSE;
+
   dt_image_t *image = &module->dev->image_storage;
 
   const gboolean is_display_referred = dt_is_display_referred();
@@ -1178,7 +1180,7 @@ gboolean dt_gui_presets_autoapply_for_module(dt_iop_module_t *module)
   char query[2024];
   // clang-format off
   snprintf(query, sizeof(query),
-     "SELECT name"
+     "SELECT name, op_params, blendop_params"
      " FROM data.presets"
      " WHERE operation = ?1"
      "        AND ((autoapply=1"
@@ -1233,8 +1235,20 @@ gboolean dt_gui_presets_autoapply_for_module(dt_iop_module_t *module)
   gboolean applied = FALSE;
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
-    const char *name = (const char *)sqlite3_column_text(stmt, 0);
-    dt_gui_presets_apply_preset(name, module);
+    if(widget)
+    {
+      dt_iop_params_t *params = (dt_iop_params_t *)sqlite3_column_blob(stmt, 1);
+      dt_develop_blend_params_t *blend_params = (dt_iop_params_t *)sqlite3_column_blob(stmt, 2);
+      if(sqlite3_column_bytes(stmt, 1) == module->params_size
+         && sqlite3_column_bytes(stmt, 2) == sizeof(dt_develop_blend_params_t))
+        dt_bauhaus_update_from_field(module, widget, params, blend_params);
+    }
+    else
+    {
+      const char *name = (const char *)sqlite3_column_text(stmt, 0);
+      dt_gui_presets_apply_preset(name, module);
+    }
+
     applied = TRUE;
   }
   sqlite3_finalize(stmt);

--- a/src/gui/presets.h
+++ b/src/gui/presets.h
@@ -159,7 +159,7 @@ void dt_gui_presets_apply_preset(const gchar* name, dt_iop_module_t *module);
 void dt_gui_presets_apply_adjacent_preset(dt_iop_module_t *module, const int direction);
 
 /** apply any auto presets that are appropriate for the current module **/
-gboolean dt_gui_presets_autoapply_for_module(dt_iop_module_t *module);
+gboolean dt_gui_presets_autoapply_for_module(dt_iop_module_t *module, GtkWidget *widget);
 
 void dt_gui_presets_show_iop_edit_dialog(const char *name_in,
                                          dt_iop_module_t *module,

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -287,7 +287,7 @@ int write_image(struct dt_imageio_module_data_t *data,
   /*
    * Set these in advance so any upcoming RGB -> YUV use the proper
    * coefficients.
-   * 
+   *
    * If possible, we want libavif to save the color encoding in its own format,
    * rather than embedding the ICC profile, which is possible.
    * If we are unable to find the required color encoding data we will just
@@ -855,7 +855,6 @@ void gui_init(dt_imageio_module_format_t *self)
                                                   dt_confgen_get_int("plugins/imageio/format/avif/quality", DT_DEFAULT), /* default */
                                                   0); /* digits */
   dt_bauhaus_widget_set_label(gui->quality,  NULL, N_("quality"));
-  dt_bauhaus_slider_set_default(gui->quality, dt_confgen_get_int("plugins/imageio/format/avif/quality", DT_DEFAULT));
   dt_bauhaus_slider_set_format(gui->quality, "%");
 
   gtk_widget_set_tooltip_text(gui->quality,

--- a/src/imageio/format/j2k.c
+++ b/src/imageio/format/j2k.c
@@ -672,7 +672,6 @@ void gui_init(dt_imageio_module_format_t *self)
                                                   dt_confgen_get_int("plugins/imageio/format/j2k/quality", DT_DEFAULT),
                                                   0);
   dt_bauhaus_widget_set_label(gui->quality, NULL, N_("quality"));
-  dt_bauhaus_slider_set_default(gui->quality, dt_confgen_get_int("plugins/imageio/format/j2k/quality", DT_DEFAULT));
   if(quality_last > 0 && quality_last <= 100) dt_bauhaus_slider_set(gui->quality, quality_last);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(gui->quality), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(gui->quality), "value-changed", G_CALLBACK(quality_changed), NULL);

--- a/src/imageio/format/jpeg.c
+++ b/src/imageio/format/jpeg.c
@@ -475,7 +475,6 @@ void gui_init(dt_imageio_module_format_t *self)
                                                 dt_confgen_get_int("plugins/imageio/format/jpeg/quality", DT_DEFAULT),
                                                 0);
   dt_bauhaus_widget_set_label(g->quality, NULL, N_("quality"));
-  dt_bauhaus_slider_set_default(g->quality, dt_confgen_get_int("plugins/imageio/format/jpeg/quality", DT_DEFAULT));
   dt_bauhaus_slider_set(g->quality, dt_conf_get_int("plugins/imageio/format/jpeg/quality"));
   gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(g->quality), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->quality), "value-changed", G_CALLBACK(quality_changed), NULL);

--- a/src/imageio/format/webp.c
+++ b/src/imageio/format/webp.c
@@ -423,7 +423,6 @@ void gui_init(dt_imageio_module_format_t *self)
                                                   dt_confgen_get_int("plugins/imageio/format/webp/quality", DT_DEFAULT),
                                                   0);
   dt_bauhaus_widget_set_label(gui->quality, NULL, N_("quality"));
-  dt_bauhaus_slider_set_default(gui->quality, dt_confgen_get_int("plugins/imageio/format/webp/quality", DT_DEFAULT));
   dt_bauhaus_slider_set_format(gui->quality, "%");
   gtk_widget_set_tooltip_text(gui->quality, _("for lossy, 0 gives the smallest size and 100 the best quality.\n"
                                               "for lossless, 0 is the fastest but gives larger files compared\n"

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -1253,10 +1253,9 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->target_spot), "draw", G_CALLBACK(_target_color_draw), self);
   gtk_box_pack_start(GTK_BOX(vvbox), g->target_spot, TRUE, TRUE, 0);
 
-  g->lightness_spot = dt_bauhaus_slider_new_with_range(self, 0., 100., 0, 0, 1);
+  g->lightness_spot = dt_bauhaus_slider_new_with_range(self, 0., 100., 0, 50.f, 1);
   dt_bauhaus_widget_set_label(g->lightness_spot, NULL, N_("lightness"));
   dt_bauhaus_slider_set_format(g->lightness_spot, "%");
-  dt_bauhaus_slider_set_default(g->lightness_spot, 50.f);
   gtk_box_pack_start(GTK_BOX(vvbox), GTK_WIDGET(g->lightness_spot), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->lightness_spot), "value-changed",
                    G_CALLBACK(_spot_settings_changed_callback), self);


### PR DESCRIPTION
This adds two functionalities to bauhaus:
- `dt_bauhaus_widget_set_quad_tooltip` to set a separate tooltip for the "quad" (button) on the right side of bauhaus sliders and combos. Previously it would always just show the same tooltip as the widget itself, which could be less than informing. This fixes #15235 (or at least it will as soon as @jenshannoschwalm uses it to add more useful tooltips). Color pickers now automatically get the tooltip _"pick color from image"_ (but this can be overriden of course). Please provide feedback if this is undesirable/can be improved.
![image](https://github.com/darktable-org/darktable/assets/1549490/0c1e84f5-0c2a-476c-91c0-299c082bdc7c)
There is no `_markup` equivalent for now; I feel it isn't likely to be needed (we don't want overengineered tooltips) but it would be _very_ easy to add if it is.

- mimicing the functionality to reset an iop module to its auto-applied presets by holding **ctrl** while clicking the reset button, you can now hold **ctrl** while double-clicking an individual slider or combo to reset just that one widget to its auto-applied value.

Plus a few general cleanups.