### PR TITLE
Improved OpenCL platform error reports

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -93,6 +93,8 @@ static void dt_opencl_apply_scheduling_profile(dt_opencl_scheduling_profile_t pr
 /** set opencl specific synchronization timeout */
 static void dt_opencl_set_synchronization_timeout(int value);
 
+static cl_event *_opencl_events_get_slot(const int devid, const char *tag);
+
 const char *cl_errstr(cl_int error)
 {
   switch(error)
@@ -1152,57 +1154,52 @@ void dt_opencl_init(
 
   if(exclude_opencl)
   {
-    dt_print_nts(DT_DEBUG_OPENCL,
+    dt_print(DT_DEBUG_OPENCL,
                  "[opencl_init] opencl disabled due to explicit user request\n");
     goto finally;
   }
 
-  dt_print_nts(DT_DEBUG_OPENCL,
-               "[opencl_init] opencl related configuration options:\n");
-  dt_print_nts(DT_DEBUG_OPENCL,
-               "[opencl_init] opencl: %s\n", opencl_requested ? "ON" : "OFF" );
-  const char *str = dt_conf_get_string_const("opencl_scheduling_profile");
-  dt_print_nts(DT_DEBUG_OPENCL,
-               "[opencl_init] opencl_scheduling_profile: '%s'\n", str);
+  if(!opencl_requested)
+    dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl disabled via darktable preferences\n");
+
   // look for explicit definition of opencl_runtime library in preferences
   const char *library = dt_conf_get_string_const("opencl_library");
-  dt_print_nts(DT_DEBUG_OPENCL,
-               "[opencl_init] opencl_library: '%s'\n",
-               (strlen(library) == 0) ? "default path" : library);
-  str = dt_conf_get_string_const("opencl_device_priority");
-  dt_print_nts(DT_DEBUG_OPENCL,
-               "[opencl_init] opencl_device_priority: '%s'\n", str);
-  dt_print_nts(DT_DEBUG_OPENCL,
-               "[opencl_init] opencl_mandatory_timeout: %d\n",
-               dt_conf_get_int("opencl_mandatory_timeout"));
 
   // dynamically load opencl runtime and bind required symbols and test it
   cl->dlocl = dt_dlopencl_init(library);
   if(cl->dlocl == NULL)
   {
     logerror = "no working opencl library found";
-    dt_print_nts(DT_DEBUG_OPENCL,
-                 "[opencl_init] no working opencl library found."
-                 " Continue with opencl disabled\n");
+    dt_print(DT_DEBUG_OPENCL,
+                 "[opencl_init] no working opencl '%s' library found."
+                 " Continue with opencl disabled\n",
+                 (strlen(library) == 0) ? "default path" : library);
     goto finally;
   }
   else
   {
-    dt_print_nts(DT_DEBUG_OPENCL,
-                 "[opencl_init] opencl library '%s' found on your system and loaded\n",
-                 cl->dlocl->library);
+    dt_print(DT_DEBUG_OPENCL,
+                 "[opencl_init] opencl library '%s' found on your system and loaded, preference '%s'\n",
+                 cl->dlocl->library,
+                 (strlen(library) == 0) ? "default path" : library);
   }
 
   all_platforms = malloc(sizeof(cl_platform_id) * DT_OPENCL_MAX_PLATFORMS);
   all_num_devices = malloc(sizeof(cl_uint) * DT_OPENCL_MAX_PLATFORMS);
 
   cl_uint num_platforms = 0;
+  logerror =  "platform detection failed. some possible reasons:\n"
+              "  - OpenCL ICD (ocl-icd) missing,\n"
+              "  - previous OpenCL errors leading to blocked devices,\n"
+              "  - power management problems,\n"
+              "  - buggy drivers,\n"
+              "  - no OpenCL driver installed.";
+
   cl_int err = (cl->dlocl->symbols->dt_clGetPlatformIDs)(0, NULL, &num_platforms);
   if((err != CL_SUCCESS) || (num_platforms == 0))
   {
-    logerror = "no platform detected - Fix the OpenCL installation or add a driver";
-    dt_print_nts(DT_DEBUG_OPENCL,
-                 "[opencl_init] no platform (%i) detected: %s\n", num_platforms, cl_errstr(err));
+    dt_print(DT_DEBUG_OPENCL,
+                 "[opencl_init] %i platforms detected, error: %s\n", num_platforms, cl_errstr(err));
     goto finally;
   }
 
@@ -1211,19 +1208,18 @@ void dt_opencl_init(
     (DT_OPENCL_MAX_PLATFORMS, all_platforms, &num_platforms);
   if(err != CL_SUCCESS)
   {
-    logerror = "couldn't get platforms - Fix the OpenCL installation or add a driver";
-    dt_print_nts(DT_DEBUG_OPENCL,
-                 "[opencl_init] could not get platforms: %s\n", cl_errstr(err));
+    dt_print(DT_DEBUG_OPENCL,
+                 "[opencl_init] could not get platforms IDs: %s\n", cl_errstr(err));
+    goto finally;
+  }
+  if(num_platforms == 0)
+  {
+    dt_print(DT_DEBUG_OPENCL, "[opencl_init] no opencl platform available\n");
     goto finally;
   }
 
-  if(num_platforms == 0)
-  {
-    logerror = "couldn't get platforms - Fix the OpenCL installation or add a driver";
-    dt_print_nts(DT_DEBUG_OPENCL, "[opencl_init] no opencl platform available\n");
-    goto finally;
-  }
-  dt_print_nts(DT_DEBUG_OPENCL, "[opencl_init] found %d platform%s\n", num_platforms,
+  logerror = NULL;
+  dt_print(DT_DEBUG_OPENCL, "[opencl_init] found %d platform%s\n", num_platforms,
            num_platforms > 1 ? "s" : "");
 
   for(int n = 0; n < num_platforms; n++)
@@ -1270,17 +1266,17 @@ void dt_opencl_init(
     {
       if(!valid_platform)
       {
-        dt_print_nts(DT_DEBUG_OPENCL,
+        dt_print(DT_DEBUG_OPENCL,
           "[check platform] platform '%s' with key '%s' is NOT active\n",
           platform_name, platform_key);
       }
       else if((errn == CL_SUCCESS) && (errv == CL_SUCCESS))
-        dt_print_nts(DT_DEBUG_OPENCL,
+        dt_print(DT_DEBUG_OPENCL,
                      "[opencl_init] no devices found for %s (vendor) - %s (name)\n",
                      platform_vendor, platform_name);
       else
       {
-        dt_print_nts(DT_DEBUG_OPENCL,
+        dt_print(DT_DEBUG_OPENCL,
                      "[opencl_init] no devices found for unknown platform\n");
         logerror = "no devices found for unknown platform";
       }
@@ -1295,7 +1291,7 @@ void dt_opencl_init(
       if(err != CL_SUCCESS)
       {
         all_num_devices[n] = 0;
-        dt_print_nts(DT_DEBUG_OPENCL,
+        dt_print(DT_DEBUG_OPENCL,
                      "[opencl_init] could not get profile for platform '%s': %s\n",
                      platform_name, cl_errstr(err));
       }
@@ -1304,7 +1300,7 @@ void dt_opencl_init(
         if(strcmp("FULL_PROFILE", profile) != 0)
         {
           all_num_devices[n] = 0;
-          dt_print_nts(DT_DEBUG_OPENCL,
+          dt_print(DT_DEBUG_OPENCL,
                        "[opencl_init] platform '%s' is not FULL_PROFILE\n",
                        platform_name);
         }
@@ -1326,8 +1322,8 @@ void dt_opencl_init(
       free(cl->dev);
       cl->dev = NULL;
       free(devices);
-      dt_print_nts(DT_DEBUG_OPENCL, "[opencl_init] could not allocate memory\n");
-      logerror = "memory allocation problem";
+      dt_print(DT_DEBUG_OPENCL, "[opencl_init] could not allocate memory for device resources\n");
+      logerror = "not enough memory for OpenCL devices";
       goto finally;
     }
   }
@@ -1346,7 +1342,7 @@ void dt_opencl_init(
       if(err != CL_SUCCESS)
       {
         num_devices -= all_num_devices[n];
-        dt_print_nts(DT_DEBUG_OPENCL,
+        dt_print(DT_DEBUG_OPENCL,
                      "[opencl_init] could not get devices list: %s\n",
                      cl_errstr(err));
       }
@@ -1399,7 +1395,7 @@ void dt_opencl_init(
 
     dt_print_nts(DT_DEBUG_OPENCL,
                  "[opencl_init] OpenCL successfully initialized."
-                 " Internal numbers and names of available devices:\n");
+                 " internal numbers and names of available devices:\n");
     for(int i = 0; i < dev; i++)
       dt_print_nts(DT_DEBUG_OPENCL, "[opencl_init]\t\t%d\t'%s'\n", i, cl->dev[i].fullname);
   }
@@ -1410,9 +1406,20 @@ void dt_opencl_init(
   }
 
 finally:
-  dt_print_nts(DT_DEBUG_OPENCL,
+  dt_print(DT_DEBUG_OPENCL,
                "[opencl_init] FINALLY: opencl is %sAVAILABLE and %sENABLED.\n",
                cl->inited ? "" : "NOT ", cl->enabled ? "" : "NOT ");
+  if(cl->inited && cl->enabled)
+  {
+    // report some global settings if up & running
+    dt_print_nts(DT_DEBUG_OPENCL, "[opencl_init] opencl_scheduling_profile: '%s'\n",
+                dt_conf_get_string_const("opencl_scheduling_profile"));
+    dt_print_nts(DT_DEBUG_OPENCL, "[opencl_init] opencl_device_priority: '%s'\n",
+                dt_conf_get_string_const("opencl_device_priority"));
+    dt_print_nts(DT_DEBUG_OPENCL,
+               "[opencl_init] opencl_mandatory_timeout: %d\n",
+               dt_conf_get_int("opencl_mandatory_timeout"));
+  }
 
   if(logerror && opencl_requested)
     dt_control_log(_("OpenCL initializing problem:\n%s"), logerror);
@@ -2463,7 +2470,7 @@ static gboolean _opencl_build_program(const int dev,
       free(devices);
     if(err != CL_SUCCESS)
       dt_print(DT_DEBUG_OPENCL,
-               "[dt_opencl_build_program] problems while writing cl files\n");
+               "[dt_opencl_build_program] problems while writing OpenCL kernel files\n");
   }
 
   return err != CL_SUCCESS;
@@ -2670,7 +2677,7 @@ int dt_opencl_enqueue_kernel_ndim_with_local(const int dev,
   if(darktable.unmuted & DT_DEBUG_OPENCL)
     (cl->dlocl->symbols->dt_clGetKernelInfo)(cl->dev[dev].kernel[kernel],
                                              CL_KERNEL_FUNCTION_NAME, 256, buf, NULL);
-  cl_event *eventp = dt_opencl_events_get_slot(dev, buf);
+  cl_event *eventp = _opencl_events_get_slot(dev, buf);
   cl_int err = (cl->dlocl->symbols->dt_clEnqueueNDRangeKernel)(cl->dev[dev].cmd_queue,
                                                                cl->dev[dev].kernel[kernel],
                                                                dimensions, NULL, sizes,
@@ -2786,7 +2793,7 @@ int dt_opencl_read_host_from_device_raw(
   if(!_cldev_running(devid))
     return DT_OPENCL_NODEVICE;
 
-  cl_event *eventp = dt_opencl_events_get_slot(devid,
+  cl_event *eventp = _opencl_events_get_slot(devid,
                                                "[Read Image (from device to host)]");
 
   return (darktable.opencl->dlocl->symbols->dt_clEnqueueReadImage)
@@ -2867,7 +2874,7 @@ int dt_opencl_write_host_to_device_raw(const int devid,
   if(!_cldev_running(devid))
     return DT_OPENCL_NODEVICE;
 
-  cl_event *eventp = dt_opencl_events_get_slot(devid,
+  cl_event *eventp = _opencl_events_get_slot(devid,
                                                "[Write Image (from host to device)]");
 
   const cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueWriteImage)
@@ -2889,7 +2896,7 @@ int dt_opencl_enqueue_copy_image(const int devid,
   if(!_cldev_running(devid))
     return DT_OPENCL_NODEVICE;
 
-  cl_event *eventp = dt_opencl_events_get_slot(devid, "[Copy Image (on device)]");
+  cl_event *eventp = _opencl_events_get_slot(devid, "[Copy Image (on device)]");
   const cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyImage)
     (darktable.opencl->dev[devid].cmd_queue, src, dst, orig_src, orig_dst,
      region, 0, NULL, eventp);
@@ -2913,7 +2920,7 @@ int dt_opencl_enqueue_copy_image_to_buffer(
   if(!_cldev_running(devid))
     return DT_OPENCL_NODEVICE;
 
-  cl_event *eventp = dt_opencl_events_get_slot(devid, "[Copy Image to Buffer (on device)]");
+  cl_event *eventp = _opencl_events_get_slot(devid, "[Copy Image to Buffer (on device)]");
   const cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyImageToBuffer)
     (darktable.opencl->dev[devid].cmd_queue, src_image, dst_buffer, origin,
      region, offset, 0, NULL, eventp);
@@ -2937,7 +2944,7 @@ int dt_opencl_enqueue_copy_buffer_to_image(
   if(!_cldev_running(devid))
     return DT_OPENCL_NODEVICE;
 
-  cl_event *eventp = dt_opencl_events_get_slot(devid, "[Copy Buffer to Image (on device)]");
+  cl_event *eventp = _opencl_events_get_slot(devid, "[Copy Buffer to Image (on device)]");
   const cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyBufferToImage)
     (darktable.opencl->dev[devid].cmd_queue, src_buffer, dst_image, offset,
      origin, region, 0, NULL, eventp);
@@ -2962,7 +2969,7 @@ int dt_opencl_enqueue_copy_buffer_to_buffer(
     return DT_OPENCL_NODEVICE;
 
   cl_event *eventp =
-    dt_opencl_events_get_slot(devid, "[Copy Buffer to Buffer (on device)]");
+    _opencl_events_get_slot(devid, "[Copy Buffer to Buffer (on device)]");
   const cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueCopyBuffer)
     (darktable.opencl->dev[devid].cmd_queue,
      src_buffer, dst_buffer, srcoffset,
@@ -2985,7 +2992,7 @@ int dt_opencl_read_buffer_from_device(const int devid,
   if(!_cldev_running(devid))
     return DT_OPENCL_NODEVICE;
 
-  cl_event *eventp = dt_opencl_events_get_slot
+  cl_event *eventp = _opencl_events_get_slot
     (devid, "[Read Buffer (from device to host)]");
 
   return (darktable.opencl->dlocl->symbols->dt_clEnqueueReadBuffer)
@@ -3004,7 +3011,7 @@ int dt_opencl_write_buffer_to_device(const int devid,
   if(!_cldev_running(devid))
     return DT_OPENCL_NODEVICE;
 
-  cl_event *eventp = dt_opencl_events_get_slot
+  cl_event *eventp = _opencl_events_get_slot
     (devid, "[Write Buffer (from host to device)]");
 
   return (darktable.opencl->dlocl->symbols->dt_clEnqueueWriteBuffer)
@@ -3114,7 +3121,7 @@ void *dt_opencl_map_buffer(const int devid,
 
   cl_int err = CL_SUCCESS;
   void *ptr;
-  cl_event *eventp = dt_opencl_events_get_slot(devid, "[Map Buffer]");
+  cl_event *eventp = _opencl_events_get_slot(devid, "[Map Buffer]");
   ptr = (darktable.opencl->dlocl->symbols->dt_clEnqueueMapBuffer)
     (darktable.opencl->dev[devid].cmd_queue, buffer,
      blocking ? CL_TRUE : CL_FALSE,
@@ -3135,7 +3142,7 @@ int dt_opencl_unmap_mem_object(const int devid,
   if(!darktable.opencl->inited)
     return DT_OPENCL_NODEVICE;
 
-  cl_event *eventp = dt_opencl_events_get_slot(devid, "[Unmap Mem Object]");
+  cl_event *eventp = _opencl_events_get_slot(devid, "[Unmap Mem Object]");
   cl_int err = (darktable.opencl->dlocl->symbols->dt_clEnqueueUnmapMemObject)
     (darktable.opencl->dev[devid].cmd_queue, mem_object, mapped_ptr, 0, NULL, eventp);
 
@@ -3219,7 +3226,7 @@ void *dt_opencl_alloc_device_use_host_pointer(const int devid,
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
              "[opencl alloc_device_use_host_pointer]"
-             " could not allocate imgage on device %d: %s\n",
+             " could not allocate cl image on device %d: %s\n",
              devid, cl_errstr(err));
 
   _check_clmem_err(devid, err);
@@ -3241,7 +3248,7 @@ void *dt_opencl_alloc_device_buffer(const int devid, const size_t size)
      CL_MEM_READ_WRITE, size, NULL, &err);
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl alloc_device_buffer] could not alloc buffer on device %d: %s\n",
+             "[opencl alloc_device_buffer] could not allocate cl buffer on device %d: %s\n",
              devid, cl_errstr(err));
 
   _check_clmem_err(devid, err);
@@ -3264,7 +3271,7 @@ void *dt_opencl_alloc_device_buffer_with_flags(const int devid,
      flags, size, NULL, &err);
   if(err != CL_SUCCESS)
     dt_print(DT_DEBUG_OPENCL,
-             "[opencl alloc_device_buffer] could not allocate buffer on device %d: %s\n",
+             "[opencl alloc_device_buffer] could not allocate cl buffer on device %d: %s\n",
              devid, cl_errstr(err));
 
   _check_clmem_err(devid, err);
@@ -3626,7 +3633,7 @@ static void dt_opencl_apply_scheduling_profile(dt_opencl_scheduling_profile_t pr
  * are locked upstream */
 
 /** get next free slot in eventlist (and manage size of eventlist) */
-cl_event *dt_opencl_events_get_slot(const int devid, const char *tag)
+static cl_event *_opencl_events_get_slot(const int devid, const char *tag)
 {
   dt_opencl_t *cl = darktable.opencl;
   if(!cl->inited || devid < 0) return NULL;
@@ -3655,7 +3662,7 @@ cl_event *dt_opencl_events_get_slot(const int devid, const char *tag)
       *eventlist = NULL;
       *eventtags = NULL;
       dt_print(DT_DEBUG_OPENCL,
-               "[dt_opencl_events_get_slot] NO eventlist for device %i\n", devid);
+               "[opencl_events_get_slot] NO eventlist for device %i\n", devid);
       return NULL;
     }
     *maxevents = newevents;
@@ -3694,7 +3701,7 @@ cl_event *dt_opencl_events_get_slot(const int devid, const char *tag)
     if(!neweventlist || !neweventtags)
     {
       dt_print(DT_DEBUG_OPENCL,
-               "[dt_opencl_events_get_slot] NO new eventlist with size %i for device %i\n",
+               "[opencl_events_get_slot] NO new eventlist with size %i for device %i\n",
                newevents, devid);
       free(neweventlist);
       free(neweventtags);
@@ -3762,7 +3769,7 @@ void dt_opencl_events_reset(const int devid)
 /** Wait for events in eventlist to terminate -> this is a blocking
     synchronization point!  Does not flush eventlist. Side effect:
     might adjust numevents. */
-void dt_opencl_events_wait_for(const int devid)
+static void _opencl_events_wait_for(const int devid)
 {
   dt_opencl_t *cl = darktable.opencl;
   if(!cl->inited || devid < 0) return;
@@ -3800,109 +3807,9 @@ void dt_opencl_events_wait_for(const int devid)
        cl_errstr(err), devid);
 }
 
-
-/** Wait for events in eventlist to terminate, check for return status
-    and profiling info of events.  If "reset" is TRUE report summary
-    info (would be CL_COMPLETE or last error code) and print profiling
-    info if needed.  If "reset" is FALSE just store info (success
-    value, profiling) from terminated events and release events for
-    re-use by OpenCL driver. */
-cl_int dt_opencl_events_flush(const int devid, const gboolean reset)
-{
-  dt_opencl_t *cl = darktable.opencl;
-  if(!cl->inited || devid < 0) return FALSE;
-  if(!cl->dev[devid].use_events) return FALSE;
-
-  cl_event **eventlist = &(cl->dev[devid].eventlist);
-  dt_opencl_eventtag_t **eventtags = &(cl->dev[devid].eventtags);
-  int *numevents = &(cl->dev[devid].numevents);
-  int *eventsconsolidated = &(cl->dev[devid].eventsconsolidated);
-  int *lostevents = &(cl->dev[devid].lostevents);
-  int *totalsuccess = &(cl->dev[devid].totalsuccess);
-
-  cl_int *summary = &(cl->dev[devid].summary);
-
-  if(*eventlist == NULL || *numevents == 0)
-    return CL_COMPLETE; // nothing to do, no news is good news
-
-  // Wait for command queue to terminate (side effect: might adjust *numevents)
-  dt_opencl_events_wait_for(devid);
-
-  // now check return status and profiling data of all newly terminated events
-  for(int k = *eventsconsolidated; k < *numevents; k++)
-  {
-    cl_int err;
-    char *tag = (*eventtags)[k].tag;
-    cl_int *retval = &((*eventtags)[k].retval);
-
-    // get return value of event
-    err = (cl->dlocl->symbols->dt_clGetEventInfo)((*eventlist)[k],
-                                                  CL_EVENT_COMMAND_EXECUTION_STATUS,
-                                                  sizeof(cl_int), retval, NULL);
-    if(err != CL_SUCCESS)
-    {
-      dt_print(DT_DEBUG_OPENCL,
-               "[opencl_events_flush] could not get event info for '%s': %s\n",
-               tag[0] == '\0' ? "<?>" : tag, cl_errstr(err));
-    }
-    else if(*retval != CL_COMPLETE)
-    {
-      dt_print(DT_DEBUG_OPENCL, "[opencl_events_flush] execution of '%s' %s: %d\n",
-               tag[0] == '\0' ? "<?>" : tag,
-               *retval == CL_COMPLETE ? "was successful" : "failed",
-               *retval);
-      *summary = *retval;
-    }
-    else
-      (*totalsuccess)++;
-
-    if(darktable.unmuted & DT_DEBUG_PERF)
-    {
-      // get profiling info of event (only if darktable was called with '-d perf')
-      cl_ulong start;
-      cl_ulong end;
-      cl_int errs = (cl->dlocl->symbols->dt_clGetEventProfilingInfo)(
-          (*eventlist)[k], CL_PROFILING_COMMAND_START, sizeof(cl_ulong), &start, NULL);
-      cl_int erre = (cl->dlocl->symbols->dt_clGetEventProfilingInfo)
-        ((*eventlist)[k], CL_PROFILING_COMMAND_END,
-         sizeof(cl_ulong), &end, NULL);
-      if(errs == CL_SUCCESS && erre == CL_SUCCESS)
-      {
-        (*eventtags)[k].timelapsed = end - start;
-      }
-      else
-      {
-        (*eventtags)[k].timelapsed = 0;
-        (*lostevents)++;
-      }
-    }
-    else
-      (*eventtags)[k].timelapsed = 0;
-
-    // finally release event to be re-used by driver
-    (cl->dlocl->symbols->dt_clReleaseEvent)((*eventlist)[k]);
-    (*eventsconsolidated)++;
-  }
-
-  cl_int result = *summary;
-
-  // do we want to get rid of all stored info?
-  if(reset)
-  {
-    // output profiling info if wanted
-    if(darktable.unmuted & DT_DEBUG_PERF) dt_opencl_events_profiling(devid, 1);
-
-    // reset eventlist structures to empty state
-    dt_opencl_events_reset(devid);
-  }
-
-  return result == CL_COMPLETE ? 0 : result;
-}
-
-
 /** display OpenCL profiling information. If "aggregated" is TRUE, try
  * to generate summarized info for each kernel */
-void dt_opencl_events_profiling(const int devid, const int aggregated)
+static void _opencl_events_profiling(const int devid, const gboolean aggregated)
 {
   dt_opencl_t *cl = darktable.opencl;
   if(!cl->inited || devid < 0) return;
@@ -3991,12 +3898,109 @@ void dt_opencl_events_profiling(const int devid, const int aggregated)
            "[opencl_profiling] spent %7.4f seconds totally in"
            " command queue (with %d event%s missing)\n",
            (double)total, *lostevents, *lostevents == 1 ? "" : "s");
-
   free(timings);
   free(tags);
-
-  return;
 }
+
+/** Wait for events in eventlist to terminate, check for return status
+    and profiling info of events.  If "reset" is TRUE report summary
+    info (would be CL_COMPLETE or last error code) and print profiling
+    info if needed.  If "reset" is FALSE just store info (success
+    value, profiling) from terminated events and release events for
+    re-use by OpenCL driver. */
+cl_int dt_opencl_events_flush(const int devid, const gboolean reset)
+{
+  dt_opencl_t *cl = darktable.opencl;
+  if(!cl->inited || devid < 0) return FALSE;
+  if(!cl->dev[devid].use_events) return FALSE;
+
+  cl_event **eventlist = &(cl->dev[devid].eventlist);
+  dt_opencl_eventtag_t **eventtags = &(cl->dev[devid].eventtags);
+  int *numevents = &(cl->dev[devid].numevents);
+  int *eventsconsolidated = &(cl->dev[devid].eventsconsolidated);
+  int *lostevents = &(cl->dev[devid].lostevents);
+  int *totalsuccess = &(cl->dev[devid].totalsuccess);
+
+  cl_int *summary = &(cl->dev[devid].summary);
+
+  if(*eventlist == NULL || *numevents == 0)
+    return CL_COMPLETE; // nothing to do, no news is good news
+
+  // Wait for command queue to terminate (side effect: might adjust *numevents)
+  _opencl_events_wait_for(devid);
+
+  // now check return status and profiling data of all newly terminated events
+  for(int k = *eventsconsolidated; k < *numevents; k++)
+  {
+    cl_int err;
+    char *tag = (*eventtags)[k].tag;
+    cl_int *retval = &((*eventtags)[k].retval);
+
+    // get return value of event
+    err = (cl->dlocl->symbols->dt_clGetEventInfo)((*eventlist)[k],
+                                                  CL_EVENT_COMMAND_EXECUTION_STATUS,
+                                                  sizeof(cl_int), retval, NULL);
+    if(err != CL_SUCCESS)
+    {
+      dt_print(DT_DEBUG_OPENCL,
+               "[opencl_events_flush] could not get event info for '%s': %s\n",
+               tag[0] == '\0' ? "<?>" : tag, cl_errstr(err));
+    }
+    else if(*retval != CL_COMPLETE)
+    {
+      dt_print(DT_DEBUG_OPENCL, "[opencl_events_flush] execution of '%s' %s: %d\n",
+               tag[0] == '\0' ? "<?>" : tag,
+               *retval == CL_COMPLETE ? "was successful" : "failed",
+               *retval);
+      *summary = *retval;
+    }
+    else
+      (*totalsuccess)++;
+
+    if(darktable.unmuted & DT_DEBUG_PERF)
+    {
+      // get profiling info of event (only if darktable was called with '-d perf')
+      cl_ulong start;
+      cl_ulong end;
+      cl_int errs = (cl->dlocl->symbols->dt_clGetEventProfilingInfo)(
+          (*eventlist)[k], CL_PROFILING_COMMAND_START, sizeof(cl_ulong), &start, NULL);
+      cl_int erre = (cl->dlocl->symbols->dt_clGetEventProfilingInfo)
+        ((*eventlist)[k], CL_PROFILING_COMMAND_END,
+         sizeof(cl_ulong), &end, NULL);
+      if(errs == CL_SUCCESS && erre == CL_SUCCESS)
+      {
+        (*eventtags)[k].timelapsed = end - start;
+      }
+      else
+      {
+        (*eventtags)[k].timelapsed = 0;
+        (*lostevents)++;
+      }
+    }
+    else
+      (*eventtags)[k].timelapsed = 0;
+
+    // finally release event to be re-used by driver
+    (cl->dlocl->symbols->dt_clReleaseEvent)((*eventlist)[k]);
+    (*eventsconsolidated)++;
+  }
+
+  cl_int result = *summary;
+
+  // do we want to get rid of all stored info?
+  if(reset)
+  {
+    // output profiling info if wanted
+    if(darktable.unmuted & DT_DEBUG_PERF) _opencl_events_profiling(devid, 1);
+
+    // reset eventlist structures to empty state
+    dt_opencl_events_reset(devid);
+  }
+
+  return result == CL_COMPLETE ? 0 : result;
+}
+
+
 
 static int nextpow2(const int n)
 {

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -481,22 +481,12 @@ cl_ulong dt_opencl_get_device_memalloc(const int devid);
 int dt_opencl_dev_roundup_width(int size, const int devid);
 int dt_opencl_dev_roundup_height(int size, const int devid);
 
-/** get next free slot in eventlist and manage size of eventlist */
-cl_event *dt_opencl_events_get_slot(const int devid, const char *tag);
-
 /** reset eventlist to empty state */
 void dt_opencl_events_reset(const int devid);
-
-/** Wait for events in eventlist to terminate -> this is a blocking synchronization point
-    Does not flush eventlist */
-void dt_opencl_events_wait_for(const int devid);
 
 /** Wait for events in eventlist to terminate, check for return status of events and
     report summary success info (CL_COMPLETE or last error code) */
 cl_int dt_opencl_events_flush(const int devid, const gboolean reset);
-
-/** display OpenCL profiling information. If summary is not 0, try to generate summarized info for kernels */
-void dt_opencl_events_profiling(const int devid, const int aggregated);
 
 /** utility function to calculate optimal work group dimensions for a given kernel */
 int dt_opencl_local_buffer_opt(const int devid, const int kernel, dt_opencl_local_buffer_t *factors);
@@ -620,22 +610,12 @@ static inline size_t dt_opencl_get_device_memalloc(const int devid)
 static inline void dt_opencl_release_mem_object(void *mem)
 {
 }
-static inline void *dt_opencl_events_get_slot(const int devid, const char *tag)
-{
-  return NULL;
-}
 static inline void dt_opencl_events_reset(const int devid)
-{
-}
-static inline void dt_opencl_events_wait_for(const int devid)
 {
 }
 static inline int dt_opencl_events_flush(const int devid, const gboolean reset)
 {
   return 0;
-}
-static inline void dt_opencl_events_profiling(const int devid, const int aggregated)
-{
 }
 
 #ifdef __cplusplus

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1742,7 +1742,7 @@ static gboolean _dev_pixelpipe_process_rec(
             {
               dt_print_pipe(DT_DEBUG_OPENCL,
                 "pixelpipe process CL", pipe, module, &roi_in, roi_out, "%s\n",
-                  "couldn't copy image to opencl device");
+                  "couldn't copy image to OpenCL device");
               success_opencl = FALSE;
             }
           }
@@ -2683,9 +2683,10 @@ restart:
                           ? (dt_opencl_events_flush(pipe->devid, TRUE) != 0)
                           : FALSE;
 
-  // Check if we had opencl errors ....  remark: opencl errors can
-  // come in two ways: pipe->opencl_error is TRUE (and err is TRUE) OR
-  // oclerr is TRUE
+  // Check if we had opencl errors,
+  // remark: opencl errors can come in two ways:
+  // processed pipe->opencl_error checked via 'err'
+  // OpenCL events so oclerr is TRUE
 
   if(oclerr || (err && pipe->opencl_error))
   {
@@ -2699,7 +2700,7 @@ restart:
     dt_pthread_mutex_unlock(&pipe->busy_mutex);
 
     darktable.opencl->error_count++; // increase error count
-    if(darktable.opencl->error_count >= DT_OPENCL_MAX_ERRORS)
+    if(darktable.opencl->error_count == DT_OPENCL_MAX_ERRORS)
     {
       // too frequent opencl errors encountered: this is a clear sign
       // of a broken setup. give up on opencl during this session.
@@ -2708,8 +2709,12 @@ restart:
                "[opencl] frequent opencl errors encountered; disabling"
                " opencl for this session!\n");
       dt_control_log
-        (_("darktable discovered problems with your OpenCL setup;"
-           " disabling OpenCL for this session!"));
+        (_("OpenCL errors encountered; disabling OpenCL for this session!"
+           " likely problems:\n"
+           "  - OpenCL out of resources due to preference settings. please try with defaults,\n"
+           "  - buggy driver for some devive. please run darktable with `-d opencl' to identify,\n"
+           "  - some drivers (for small or old devices) don't support proper number of events,\n"
+           "  - too small headroom settings while using 'use all device memory'."));
       // also remove "opencl" from capabilities so that the preference entry is greyed out
       dt_capabilities_remove("opencl");
     }


### PR DESCRIPTION
While checking for OpenCL platforms and devices give some better logs and UI hints.

1. As there are timing problems while checking for platforms and devices tell the times in the log
2. more detailed info
3. Report dt preference settings after initializing successfully
4. If there are problems while initializing OpenCL related to platforms or drivers give some plausible reasons via `dt_control_log()`
5. More precise user tips if too many opencl error have been detected
6. some internal opencl functions have been removed from exposing and marked as static 