### PR TITLE
macOS: Fix packaging for ARM architecture

### DIFF
--- a/packaging/macosx/3_make_hb_darktable_package.sh
+++ b/packaging/macosx/3_make_hb_darktable_package.sh
@@ -85,7 +85,7 @@ function reset_exec_path {
         oToolLoader=$(otool -l "$1" 2>/dev/null | grep '@loader_path' | cut -d\( -f1 | sed 's/^[[:blank:]]*path[[:blank:]]*//;s/[[:blank:]]*$//' )
         if [[ "$oToolLoader" == "@loader_path/../lib/darktable" ]]; then
             echo "Resetting loader path for libdarktable.dylib of <$1>"
-            install_name_tool -rpath @loader_path/../lib/darktable @loader_path/../Resources/lib/darktable "$1"
+            install_name_tool -rpath @loader_path/../lib/darktable @loader_path/../Resources/lib/darktable "$1" || true
         fi
     fi
 
@@ -110,14 +110,14 @@ function reset_exec_path {
             echo "Resetting executable path for dependency <$hbDependency> of <$1>"
 
             # Set correct executable path
-            install_name_tool -change "$hbDependency" "@executable_path/../Resources/lib/$dynDepOrigFile" "$1"
+            install_name_tool -change "$hbDependency" "@executable_path/../Resources/lib/$dynDepOrigFile" "$1"  || true
 
             # Check for loader path
             oToolLoader=$(otool -L "$1" 2>/dev/null | grep '@loader_path' | grep $dynDepOrigFile | cut -d\( -f1 | sed 's/^[[:blank:]]*//;s/[[:blank:]]*$//' ) || true
             if [[ -n "$oToolLoader" ]]; then
                 echo "Resetting loader path for dependency <$hbDependency> of <$1>"
                 oToolLoaderNew=$(echo $oToolLoader | sed "s#@loader_path/##" | sed "s#../../../../opt/.*##")
-                install_name_tool -change "$oToolLoader" "@loader_path/${oToolLoaderNew}${dynDepOrigFile}" "$1"
+                install_name_tool -change "$oToolLoader" "@loader_path/${oToolLoaderNew}${dynDepOrigFile}" "$1"  || true
             fi
         done
 
@@ -135,7 +135,7 @@ function reset_exec_path {
         echo "Resetting library ID of <$1>"
 
         # Set correct library id
-        install_name_tool -id "@executable_path/../Resources/lib/$libraryOrigFile" "$1"
+        install_name_tool -id "@executable_path/../Resources/lib/$libraryOrigFile" "$1"  || true
     fi
 }
 


### PR DESCRIPTION
For packaging, the included libraries need to be modified (executable_path, loader_path, library_ID) using `install_name_tool`. On macOS ARM architecture, the tool throws out a warning:

`install_name_tool: warning: changes being made to the file will invalidate the code signature in: ...`

The warning doesn't hurt but it broke the package building script.

Fixes #15201 