### PR TITLE
imageio: synchronize wording for grayscale output, AVIF updates

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1044,7 +1044,7 @@
   <dtconfig>
     <name>ui_last/import_last_folder_descending</name>
     <type>bool</type>
-    <default>FALSE</default>
+    <default>false</default>
     <shortdescription>folders display order in folder pane</shortdescription>
     <longdescription/>
   </dtconfig>
@@ -2627,8 +2627,8 @@
   </dtconfig>
   <dtconfig>
     <name>plugins/imageio/format/tiff/shortfile</name>
-    <type min="0" max="1">int</type>
-    <default>0</default>
+    <type>bool</type>
+    <default>false</default>
     <shortdescription/>
     <longdescription/>
   </dtconfig>
@@ -2737,8 +2737,8 @@
   </dtconfig>
   <dtconfig>
     <name>plugins/imageio/format/avif/color_mode</name>
-    <type min="0" max="1">int</type>
-    <default>0</default>
+    <type>bool</type>
+    <default>false</default>
     <shortdescription/>
     <longdescription/>
   </dtconfig>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2751,15 +2751,15 @@
   </dtconfig>
   <dtconfig>
     <name>plugins/imageio/format/avif/compression_type</name>
-    <type min="0">int</type>
-    <default>0</default>
+    <type min="0" max="1">int</type>
+    <default>1</default>
     <shortdescription/>
     <longdescription/>
   </dtconfig>
   <dtconfig>
     <name>plugins/imageio/format/avif/quality</name>
-    <type min="5" max="100">int</type>
-    <default>92</default>
+    <type min="0" max="100">int</type>
+    <default>90</default>
     <shortdescription/>
     <longdescription/>
   </dtconfig>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2737,7 +2737,7 @@
   </dtconfig>
   <dtconfig>
     <name>plugins/imageio/format/avif/color_mode</name>
-    <type min="0">int</type>
+    <type min="0" max="1">int</type>
     <default>0</default>
     <shortdescription/>
     <longdescription/>

--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -301,7 +301,7 @@ float dt_conf_get_and_sanitize_float(const char *name, float min, float max)
 int dt_conf_get_bool(const char *name)
 {
   const char *str = dt_conf_get_var(name);
-  const int val = (str[0] == 'T') || (str[0] == 't');
+  const int val = (str[0] != 'F') && (str[0] != 'f') && (str[0] != '0');
   return val;
 }
 

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -636,10 +636,6 @@ void *get_params(dt_imageio_module_format_t *self)
       break;
     case AVIF_COMP_LOSSY:
       d->quality = dt_conf_get_int("plugins/imageio/format/avif/quality");
-      if(d->quality > 100)
-      {
-        d->quality = 100;
-      }
       break;
   }
 
@@ -828,7 +824,7 @@ void gui_init(dt_imageio_module_format_t *self)
   gui->compression_type = dt_bauhaus_combobox_new_action(DT_ACTION(self));
   dt_bauhaus_widget_set_label(gui->compression_type,
                               NULL,
-                              N_("compression type"));
+                              N_("compression"));
   dt_bauhaus_combobox_add(gui->compression_type,
                           _(avif_get_compression_string(AVIF_COMP_LOSSLESS)));
   dt_bauhaus_combobox_add(gui->compression_type,
@@ -837,6 +833,9 @@ void gui_init(dt_imageio_module_format_t *self)
 
   gtk_widget_set_tooltip_text(gui->compression_type,
           _("the compression for the image"));
+
+  dt_bauhaus_combobox_set_default(gui->compression_type,
+                                  dt_confgen_get_int("plugins/imageio/format/avif/compression_type", DT_DEFAULT));
 
   gtk_box_pack_start(GTK_BOX(self->widget),
                      gui->compression_type,
@@ -854,23 +853,20 @@ void gui_init(dt_imageio_module_format_t *self)
                                                   dt_confgen_get_int("plugins/imageio/format/avif/quality", DT_DEFAULT), /* default */
                                                   0); /* digits */
   dt_bauhaus_widget_set_label(gui->quality,  NULL, N_("quality"));
-  dt_bauhaus_slider_set_format(gui->quality, "%");
 
   gtk_widget_set_tooltip_text(gui->quality,
           _("the quality of an image, less quality means fewer details.\n"
             "\n"
-            "the following applies only to lossy setting\n"
+            "the following applies only to lossy setting.\n"
             "\n"
-            "pixelformat based on quality:\n"
+            "pixel format based on quality:\n"
             "\n"
-            "    91% - 100% -> YUV444\n"
-            "    81% -  90% -> YUV422\n"
-            "     5% -  80% -> YUV420\n"));
+            "    91 - 100 -> YUV444\n"
+            "    81 -  90 -> YUV422\n"
+            "     5 -  80 -> YUV420\n"));
 
-  if(quality > 0 && quality <= 100)
-  {
-      dt_bauhaus_slider_set(gui->quality, quality);
-  }
+  dt_bauhaus_slider_set(gui->quality, quality);
+
   gtk_box_pack_start(GTK_BOX(self->widget), gui->quality, TRUE, TRUE, 0);
 
   gtk_widget_set_visible(gui->quality, compression_type != AVIF_COMP_LOSSLESS);

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -500,11 +500,9 @@ int write_image(struct dt_imageio_module_data_t *data,
 #if AVIF_VERSION >= 1000000
       encoder->quality = d->quality;
 #else
-      encoder->maxQuantizer = 100 - d->quality;
-      encoder->maxQuantizer = CLAMP(encoder->maxQuantizer, 0, 63);
-
-      encoder->minQuantizer = 64 - d->quality;
-      encoder->minQuantizer = CLAMP(encoder->minQuantizer, 0, 63);
+      const int quantizer = ((100 - d->quality) * AVIF_QUANTIZER_WORST_QUALITY + 50) / 100;
+      encoder->minQuantizer = CLAMP(quantizer - 5, AVIF_QUANTIZER_BEST_QUALITY, AVIF_QUANTIZER_WORST_QUALITY);
+      encoder->maxQuantizer = CLAMP(quantizer + 5, AVIF_QUANTIZER_BEST_QUALITY, AVIF_QUANTIZER_WORST_QUALITY);
 #endif
       break;
   }

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -626,7 +626,7 @@ void *get_params(dt_imageio_module_format_t *self)
   if(d->bit_depth != 10 && d->bit_depth != 12)
     d->bit_depth = 8;
 
-  d->color_mode = dt_conf_get_int("plugins/imageio/format/avif/color_mode");
+  d->color_mode = dt_conf_get_bool("plugins/imageio/format/avif/color_mode");
   d->compression_type = dt_conf_get_int("plugins/imageio/format/avif/compression_type");
 
   switch(d->compression_type)
@@ -732,7 +732,7 @@ static void color_mode_changed(GtkWidget *widget, gpointer user_data)
 {
   const enum avif_color_mode_e color_mode = dt_bauhaus_combobox_get(widget);
 
-  dt_conf_set_int("plugins/imageio/format/avif/color_mode", color_mode);
+  dt_conf_set_bool("plugins/imageio/format/avif/color_mode", color_mode);
 }
 
 static void tiling_changed(GtkWidget *widget, gpointer user_data)
@@ -764,7 +764,7 @@ void gui_init(dt_imageio_module_format_t *self)
   dt_imageio_avif_gui_t *gui =
       (dt_imageio_avif_gui_t *)malloc(sizeof(dt_imageio_avif_gui_t));
   const uint32_t bit_depth = dt_conf_get_int("plugins/imageio/format/avif/bpp");
-  const enum avif_color_mode_e color_mode = dt_conf_get_int("plugins/imageio/format/avif/color_mode");
+  const enum avif_color_mode_e color_mode = dt_conf_get_bool("plugins/imageio/format/avif/color_mode");
   const enum avif_tiling_e tiling = !dt_conf_get_bool("plugins/imageio/format/avif/tiling");
   const enum avif_compression_type_e compression_type = dt_conf_get_int("plugins/imageio/format/avif/compression_type");
   const uint32_t quality = dt_conf_get_int("plugins/imageio/format/avif/quality");
@@ -803,7 +803,7 @@ void gui_init(dt_imageio_module_format_t *self)
                                color_mode_changed, self, N_("no"), N_("yes"));
 
   dt_bauhaus_combobox_set_default(gui->color_mode,
-                                  dt_confgen_get_int("plugins/imageio/format/avif/color_mode", DT_DEFAULT));
+                                  dt_confgen_get_bool("plugins/imageio/format/avif/color_mode", DT_DEFAULT));
 
   gtk_box_pack_start(GTK_BOX(self->widget), gui->color_mode, TRUE, TRUE, 0);
 
@@ -900,7 +900,7 @@ void gui_reset(dt_imageio_module_format_t *self)
   dt_imageio_avif_gui_t *gui = (dt_imageio_avif_gui_t *)self->gui_data;
 
   const uint32_t bit_depth = dt_confgen_get_int("plugins/imageio/format/avif/bpp", DT_DEFAULT);
-  const enum avif_color_mode_e color_mode = dt_confgen_get_int("plugins/imageio/format/avif/color_mode", DT_DEFAULT);
+  const enum avif_color_mode_e color_mode = dt_confgen_get_bool("plugins/imageio/format/avif/color_mode", DT_DEFAULT);
   const enum avif_tiling_e tiling = !dt_confgen_get_bool("plugins/imageio/format/avif/tiling", DT_DEFAULT);
   const enum avif_compression_type_e compression_type = dt_confgen_get_int("plugins/imageio/format/avif/compression_type", DT_DEFAULT);
   const uint32_t quality = dt_confgen_get_int("plugins/imageio/format/avif/quality", DT_DEFAULT);

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -486,18 +486,26 @@ int write_image(struct dt_imageio_module_data_t *data,
       /* It isn't recommend to use the extremities */
       encoder->speed = AVIF_SPEED_SLOWEST + 1;
 
+#if AVIF_VERSION >= 1000000
+      encoder->quality = AVIF_QUALITY_LOSSLESS;
+#else
       encoder->minQuantizer = AVIF_QUANTIZER_LOSSLESS;
       encoder->maxQuantizer = AVIF_QUANTIZER_LOSSLESS;
-
+#endif
       break;
+
     case AVIF_COMP_LOSSY:
       encoder->speed = AVIF_SPEED_DEFAULT;
 
+#if AVIF_VERSION >= 1000000
+      encoder->quality = d->quality;
+#else
       encoder->maxQuantizer = 100 - d->quality;
       encoder->maxQuantizer = CLAMP(encoder->maxQuantizer, 0, 63);
 
       encoder->minQuantizer = 64 - d->quality;
       encoder->minQuantizer = CLAMP(encoder->minQuantizer, 0, 63);
+#endif
       break;
   }
 

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -346,6 +346,9 @@ int write_image(struct dt_imageio_module_data_t *data,
       break;
   }
 
+  if(format == AVIF_PIXEL_FORMAT_YUV444 && d->compression_type == AVIF_COMP_LOSSLESS)
+    image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_IDENTITY;
+
   dt_print(DT_DEBUG_IMAGEIO, "[avif colorprofile profile: %s]\n", dt_colorspaces_get_name(cp->type, filename));
 
   if(!have_nclx)

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -798,16 +798,15 @@ void gui_init(dt_imageio_module_format_t *self)
   /*
    * Color mode combo box
    */
-  DT_BAUHAUS_COMBOBOX_NEW_FULL(gui->color_mode, self, NULL, N_("color mode"),
-                               _("saving as grayscale will reduce the size for black & white images"),
-                               color_mode, color_mode_changed, self,
-                               N_("RGB colors"), N_("grayscale"));
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(gui->color_mode, self, NULL, N_("b&w as grayscale"),
+                               _("saving as grayscale will reduce the size for black & white images"), color_mode,
+                               color_mode_changed, self, N_("no"), N_("yes"));
 
-  gtk_box_pack_start(GTK_BOX(self->widget),
-                     gui->color_mode,
-                     TRUE,
-                     TRUE,
-                     0);
+  dt_bauhaus_combobox_set_default(gui->color_mode,
+                                  dt_confgen_get_int("plugins/imageio/format/avif/color_mode", DT_DEFAULT));
+
+  gtk_box_pack_start(GTK_BOX(self->widget), gui->color_mode, TRUE, TRUE, 0);
+
   /*
    * Tiling combo box
    */

--- a/src/imageio/format/j2k.c
+++ b/src/imageio/format/j2k.c
@@ -598,7 +598,6 @@ void *get_params(dt_imageio_module_format_t *self)
   d->bpp = 12; // can be 8, 12 or 16
   d->preset = dt_conf_get_int("plugins/imageio/format/j2k/preset");
   d->quality = dt_conf_get_int("plugins/imageio/format/j2k/quality");
-  if(d->quality <= 0 || d->quality > 100) d->quality = 100;
   return d;
 }
 
@@ -672,7 +671,7 @@ void gui_init(dt_imageio_module_format_t *self)
                                                   dt_confgen_get_int("plugins/imageio/format/j2k/quality", DT_DEFAULT),
                                                   0);
   dt_bauhaus_widget_set_label(gui->quality, NULL, N_("quality"));
-  if(quality_last > 0 && quality_last <= 100) dt_bauhaus_slider_set(gui->quality, quality_last);
+  dt_bauhaus_slider_set(gui->quality, quality_last);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(gui->quality), TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(gui->quality), "value-changed", G_CALLBACK(quality_changed), NULL);
 

--- a/src/imageio/format/jpeg.c
+++ b/src/imageio/format/jpeg.c
@@ -383,7 +383,6 @@ void *get_params(dt_imageio_module_format_t *self)
   // adjust this if more params are stored (subsampling etc)
   dt_imageio_jpeg_t *d = (dt_imageio_jpeg_t *)calloc(1, sizeof(dt_imageio_jpeg_t));
   d->quality = dt_conf_get_int("plugins/imageio/format/jpeg/quality");
-  if(d->quality <= 0 || d->quality > 100) d->quality = 100;
   return d;
 }
 

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -923,8 +923,9 @@ void gui_init(dt_imageio_module_format_t *self)
   gtk_widget_set_no_show_all(gui->compresslevel, TRUE);
 
   // shortfile option combo box
-  DT_BAUHAUS_COMBOBOX_NEW_FULL(gui->shortfiles, self, NULL, N_("b&w image"), NULL, shortmode,
-                               shortfile_combobox_changed, self, N_("write RGB colors"), N_("write grayscale"));
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(gui->shortfiles, self, NULL, N_("b&w as grayscale"),
+                               _("saving as grayscale will reduce the size for black & white images"), shortmode,
+                               shortfile_combobox_changed, self, N_("no"), N_("yes"));
   dt_bauhaus_combobox_set_default(gui->shortfiles,
                                   dt_confgen_get_int("plugins/imageio/format/tiff/shortfile", DT_DEFAULT));
   gtk_box_pack_start(GTK_BOX(self->widget), gui->shortfiles, TRUE, TRUE, 0);

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -748,7 +748,7 @@ void *get_params(dt_imageio_module_format_t *self)
 #endif
   d->compress = dt_conf_get_int("plugins/imageio/format/tiff/compress");
   d->compresslevel = dt_conf_get_int("plugins/imageio/format/tiff/compresslevel");
-  d->shortfile = dt_conf_get_int("plugins/imageio/format/tiff/shortfile");
+  d->shortfile = dt_conf_get_bool("plugins/imageio/format/tiff/shortfile");
 
   return d;
 }
@@ -832,7 +832,7 @@ static void pixelformat_combobox_changed(GtkWidget *widget, gpointer user_data)
 static void shortfile_combobox_changed(GtkWidget *widget, gpointer user_data)
 {
   const int mode = dt_bauhaus_combobox_get(widget);
-  dt_conf_set_int("plugins/imageio/format/tiff/shortfile", mode);
+  dt_conf_set_bool("plugins/imageio/format/tiff/shortfile", mode);
 }
 
 static void compress_combobox_changed(GtkWidget *widget, dt_imageio_tiff_gui_t *gui)
@@ -874,7 +874,7 @@ void gui_init(dt_imageio_module_format_t *self)
 #endif
   const int compress = dt_conf_get_int("plugins/imageio/format/tiff/compress");
   const int compresslevel = dt_conf_get_int("plugins/imageio/format/tiff/compresslevel");
-  const int shortmode = dt_conf_get_int("plugins/imageio/format/tiff/shortfile");
+  const int shortmode = dt_conf_get_bool("plugins/imageio/format/tiff/shortfile");
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
@@ -927,7 +927,7 @@ void gui_init(dt_imageio_module_format_t *self)
                                _("saving as grayscale will reduce the size for black & white images"), shortmode,
                                shortfile_combobox_changed, self, N_("no"), N_("yes"));
   dt_bauhaus_combobox_set_default(gui->shortfiles,
-                                  dt_confgen_get_int("plugins/imageio/format/tiff/shortfile", DT_DEFAULT));
+                                  dt_confgen_get_bool("plugins/imageio/format/tiff/shortfile", DT_DEFAULT));
   gtk_box_pack_start(GTK_BOX(self->widget), gui->shortfiles, TRUE, TRUE, 0);
 }
 
@@ -951,7 +951,7 @@ void gui_reset(dt_imageio_module_format_t *self)
   dt_bauhaus_combobox_set(gui->compress, dt_confgen_get_int("plugins/imageio/format/tiff/compress", DT_DEFAULT));
   dt_bauhaus_slider_set(gui->compresslevel,
                         dt_confgen_get_int("plugins/imageio/format/tiff/compresslevel", DT_DEFAULT));
-  dt_bauhaus_combobox_set(gui->shortfiles, dt_confgen_get_int("plugins/imageio/format/tiff/shortfile", DT_DEFAULT));
+  dt_bauhaus_combobox_set(gui->shortfiles, dt_confgen_get_bool("plugins/imageio/format/tiff/shortfile", DT_DEFAULT));
 }
 
 int flags(dt_imageio_module_data_t *data)

--- a/src/imageio/format/webp.c
+++ b/src/imageio/format/webp.c
@@ -411,7 +411,7 @@ void gui_init(dt_imageio_module_format_t *self)
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
-  DT_BAUHAUS_COMBOBOX_NEW_FULL(gui->compression, self, NULL, N_("compression type"), NULL,
+  DT_BAUHAUS_COMBOBOX_NEW_FULL(gui->compression, self, NULL, N_("compression"), NULL,
                                comp_type, compression_changed, self,
                                N_("lossy"), N_("lossless"));
   gtk_box_pack_start(GTK_BOX(self->widget), gui->compression, TRUE, TRUE, 0);
@@ -423,11 +423,10 @@ void gui_init(dt_imageio_module_format_t *self)
                                                   dt_confgen_get_int("plugins/imageio/format/webp/quality", DT_DEFAULT),
                                                   0);
   dt_bauhaus_widget_set_label(gui->quality, NULL, N_("quality"));
-  dt_bauhaus_slider_set_format(gui->quality, "%");
   gtk_widget_set_tooltip_text(gui->quality, _("for lossy, 0 gives the smallest size and 100 the best quality.\n"
                                               "for lossless, 0 is the fastest but gives larger files compared\n"
                                               "to the slowest 100."));
-  if(quality >= 0 && quality <= 100) dt_bauhaus_slider_set(gui->quality, quality);
+  dt_bauhaus_slider_set(gui->quality, quality);
   gtk_box_pack_start(GTK_BOX(self->widget), gui->quality, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(gui->quality), "value-changed", G_CALLBACK(quality_changed), NULL);
 


### PR DESCRIPTION
Marginally address https://github.com/darktable-org/darktable/issues/9266 by unifying the interface across formats (AVIF and TIFF so far).