### PR TITLE
macOS: Update homebrew build instructions

### DIFF
--- a/packaging/macosx/BUILD_hb.txt
+++ b/packaging/macosx/BUILD_hb.txt
@@ -1,6 +1,6 @@
 How to make disk image with darktable application bundle from source (using Homebrew):
 
-0). Install Homebrew (instructions and prerequisites can be found on official website https://brew.sh/), ideally use default installation path (/opt/homebrew for arm64, /usr/local for i386).
+0). Install Homebrew (instructions and prerequisites can be found on official website https://brew.sh/), ideally use default installation path (/opt/homebrew for arm64, /usr/local for x86_64).
 
 1). Install required homebrew packages:
      $ 1_install_hb_dependencies.sh
@@ -18,7 +18,7 @@ How to make disk image with darktable application bundle from source (using Home
 4). Generate DMG image from application bundle:
      $ 4_make_hb_darktable_dmg.sh
 
-The final result is a DMG file: darktable-<current version>+<latest commit>-{arm64|i386}.dmg
+The final result is a DMG file: darktable-<current version>+<latest commit>-{arm64|x86_64}.dmg
 
 All binaries, the MacOS app bundle and the DMG file are created in build/macosx.
 
@@ -33,8 +33,8 @@ MACOS SECURITY:
 - As the DMG is not notarized and the app bundle may not even be properly signed, it is still possible to install/run darktable at your own risk. To do so make sure to run "$ xattr -d com.apple.quarantine <darktable-app>.dmg" on the DMG before installing.
 
 NOTES:
-- It will be automatically build for the architecture you are currently on, either Apple Silicon (arm64) or Intel (i386).
-- If you want to build for i386 on arm64 see https://stackoverflow.com/questions/64951024/how-can-i-run-two-isolated-installations-of-homebrew/68443301#68443301 about how to handle both environments in parallel.
+- It will be automatically build for the architecture you are currently on, either Apple Silicon (arm64) or Intel (x86_64).
+- If you want to build for x86_64 on arm64 see https://stackoverflow.com/questions/64951024/how-can-i-run-two-isolated-installations-of-homebrew/68443301#68443301 about how to handle both environments in parallel.
 - After creating the darktable application bundle (step 3) you can directly run the result by executing:
      $ build/macosx/package/darktable.app/Contents/MacOS/darktable --configdir .config/darktable/ --cachedir .cache/darktable/
 


### PR DESCRIPTION
Update the architecture string (i386 --> x86_64) in the build instructions.