### PR TITLE
Fix translatable strings

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -1169,7 +1169,7 @@ void dt_opencl_init(
   cl->dlocl = dt_dlopencl_init(library);
   if(cl->dlocl == NULL)
   {
-    logerror = "no working opencl library found";
+    logerror = _("no working opencl library found");
     dt_print(DT_DEBUG_OPENCL,
                  "[opencl_init] no working opencl '%s' library found."
                  " Continue with opencl disabled\n",
@@ -1188,12 +1188,12 @@ void dt_opencl_init(
   all_num_devices = malloc(sizeof(cl_uint) * DT_OPENCL_MAX_PLATFORMS);
 
   cl_uint num_platforms = 0;
-  logerror =  "platform detection failed. some possible reasons:\n"
+  logerror= _("platform detection failed. some possible reasons:\n"
               "  - OpenCL ICD (ocl-icd) missing,\n"
               "  - previous OpenCL errors leading to blocked devices,\n"
               "  - power management problems,\n"
               "  - buggy drivers,\n"
-              "  - no OpenCL driver installed.";
+              "  - no OpenCL driver installed.");
 
   cl_int err = (cl->dlocl->symbols->dt_clGetPlatformIDs)(0, NULL, &num_platforms);
   if((err != CL_SUCCESS) || (num_platforms == 0))
@@ -1278,7 +1278,7 @@ void dt_opencl_init(
       {
         dt_print(DT_DEBUG_OPENCL,
                      "[opencl_init] no devices found for unknown platform\n");
-        logerror = "no devices found for unknown platform";
+        logerror = _("no devices found for unknown platform");
       }
       all_num_devices[n] = 0;
     }
@@ -1323,7 +1323,7 @@ void dt_opencl_init(
       cl->dev = NULL;
       free(devices);
       dt_print(DT_DEBUG_OPENCL, "[opencl_init] could not allocate memory for device resources\n");
-      logerror = "not enough memory for OpenCL devices";
+      logerror = _("not enough memory for OpenCL devices");
       goto finally;
     }
   }
@@ -1358,7 +1358,7 @@ void dt_opencl_init(
   {
     if(devices)
       free(devices);
-    logerror = "no OpenCL devices found";
+    logerror = _("no OpenCL devices found");
     goto finally;
   }
 
@@ -1401,7 +1401,7 @@ void dt_opencl_init(
   }
   else
   {
-    logerror = "no suitable OpenCL devices found";
+    logerror = _("no suitable OpenCL devices found");
     dt_print_nts(DT_DEBUG_OPENCL, "[opencl_init] no suitable devices found.\n");
   }
 

--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -299,7 +299,7 @@ static int32_t dt_camera_import_job_run(dt_job_t *job)
 
   if(!dt_import_session_ready(params->shared.session))
   {
-    dt_control_log("Failed to import images from camera.");
+    dt_control_log(_("failed to import images from camera."));
     return 1;
   }
 

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -3177,7 +3177,7 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
     if(!_add_blendmode_combo(bd->blend_modes_combo, blend_mode, blend_mode))
     {
       // should never happen: unknown blend mode
-      dt_control_log("unknown blend mode '%d' in module '%s'", blend_mode, module->op);
+      dt_control_log(_("unknown blend mode '%d' in module '%s'"), blend_mode, module->op);
       module->blend_params->blend_mode = DEVELOP_BLEND_NORMAL2;
       blend_mode = DEVELOP_BLEND_NORMAL2;
     }

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -4164,7 +4164,7 @@ static void _delay_for_double_triple(guint time, guint is_key)
   else if(break_stuck && !_sc.button)
   {
     _ungrab_grab_widget();
-    dt_control_log("short key press resets stuck keys");
+    dt_control_log(_("short key press resets stuck keys"));
     return;
   }
   else if((is_key ? _sc.press : _sc.click) & DT_SHORTCUT_TRIPLE)

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -1155,8 +1155,8 @@ void gui_init(struct dt_iop_module_t *self)
                                 "you might use this for tuning 'laplacian', 'inpaint opposed' or 'segmentation' modes,\n"
                                 "especially if camera white point is incorrect."));
   dt_bauhaus_widget_set_quad_tooltip(g->clip,
-    "visualize clipped highlights in a false color representation.\n"
-    "the effective clipping level also depends on the reconstruction method.");
+    _("visualize clipped highlights in a false color representation.\n"
+    "the effective clipping level also depends on the reconstruction method."));
   dt_bauhaus_widget_set_quad_paint(g->clip, dtgtk_cairo_paint_showmask, 0, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->clip, TRUE);
   dt_bauhaus_widget_set_quad_active(g->clip, FALSE);
@@ -1168,7 +1168,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->combine, _("combine closely related clipped segments by morphological operations.\n"
                                             "this often leads to improved color reconstruction for tiny segments before dark background."));
   dt_bauhaus_widget_set_quad_tooltip(g->combine,
-    "visualize the combined segments in a false color representation.");
+    _("visualize the combined segments in a false color representation."));
   dt_bauhaus_widget_set_quad_paint(g->combine, dtgtk_cairo_paint_showmask, 0, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->combine, TRUE);
   dt_bauhaus_widget_set_quad_active(g->combine, FALSE);
@@ -1178,7 +1178,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->candidating, _("select inpainting after segmentation analysis.\n"
                                                 "increase to favor candidates found in segmentation analysis, decrease for opposed means inpainting."));
   dt_bauhaus_widget_set_quad_tooltip(g->candidating,
-    "visualize segments that are considered to have a good candidate in a false color representation.");
+    _("visualize segments that are considered to have a good candidate in a false color representation."));
   dt_bauhaus_slider_set_format(g->candidating, "%");
   dt_bauhaus_slider_set_digits(g->candidating, 0);
   dt_bauhaus_widget_set_quad_paint(g->candidating, dtgtk_cairo_paint_showmask, 0, NULL);
@@ -1193,8 +1193,9 @@ void gui_init(struct dt_iop_module_t *self)
                                              "the flat modes ignore narrow unclipped structures (like powerlines) to keep highlights rebuilt and avoid gradients."));
 
   g->strength = dt_bauhaus_slider_from_params(self, "strength");
-  gtk_widget_set_tooltip_text(g->strength, _("set strength of rebuilding in regions with all photosites clipped.\n"
-                                             "the mask buttons shows the effect that is added to already reconstructed data."));
+  gtk_widget_set_tooltip_text(g->strength, _("set strength of rebuilding in regions with all photosites clipped."));
+  dt_bauhaus_widget_set_quad_tooltip(g->strength,
+    _("show the effect that is added to already reconstructed data."));
   dt_bauhaus_slider_set_format(g->strength, "%");
   dt_bauhaus_slider_set_digits(g->strength, 0);
   dt_bauhaus_widget_set_quad_paint(g->strength, dtgtk_cairo_paint_showmask, 0, NULL);

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -4416,7 +4416,7 @@ void gui_init(struct dt_iop_module_t *self)
                    G_CALLBACK(_autoscale_pressed_lf), self);
   gtk_widget_set_tooltip_text(g->scale, _("auto scale"));
   dt_bauhaus_widget_set_quad_tooltip(g->scale,
-    "automatic scale to available image size due to lensfun data");
+    _("automatic scale to available image size due to lensfun data"));
 
   // reverse direction
   g->reverse = dt_bauhaus_combobox_from_params(self, "inverse");
@@ -4485,7 +4485,7 @@ void gui_init(struct dt_iop_module_t *self)
                    G_CALLBACK(_autoscale_pressed_md), self);
   gtk_widget_set_tooltip_text(g->scale_md, _("image scaling"));
   dt_bauhaus_widget_set_quad_tooltip(g->scale_md,
-    "automatic scale to available image size");
+    _("automatic scale to available image size"));
 
   // main widget
   GtkWidget *main_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
@@ -4540,7 +4540,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->v_strength,
       _("amount of the applied optical vignetting correction"));
   dt_bauhaus_widget_set_quad_tooltip(g->v_strength,
-    "show applied optical vignette correction mask");
+    _("show applied optical vignette correction mask"));
   dt_bauhaus_slider_set_format(g->v_strength, "%");
   dt_bauhaus_slider_set_digits(g->v_strength, 1);
   dt_bauhaus_widget_set_quad_paint(g->v_strength, dtgtk_cairo_paint_showmask, 0, NULL);

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -303,12 +303,12 @@ static void _export_button_clicked(GtkWidget *widget, dt_lib_export_t *d)
 
   if(format_index == -1)
   {
-    dt_control_log("invalid format for export selected");
+    dt_control_log(_("invalid format for export selected"));
     return;
   }
   if(storage_index == -1)
   {
-    dt_control_log("invalid storage for export selected");
+    dt_control_log(_("invalid storage for export selected"));
     return;
   }
 


### PR DESCRIPTION
Some strings exposed via dt_control_log() or tooltips should be multi_language.