### PR TITLE
build prefs layout from xml and use bauhaus combo

### DIFF
--- a/data/darktableconfig.dtd
+++ b/data/darktableconfig.dtd
@@ -1,9 +1,20 @@
-<!ELEMENT dtconfiglist (dtconfig)*>
+<!ELEMENT dtconfiglist (dttab*, dtconfig*)>
+
+<!ELEMENT dttab (section)+>
+<!ATTLIST dttab
+	name ID #REQUIRED
+        title CDATA #REQUIRED
+>
+<!ELEMENT section EMPTY>
+<!ATTLIST section
+	name ID #IMPLIED
+        title CDATA #REQUIRED
+>
+
 <!ELEMENT dtconfig (name,type,default,capability?,shortdescription?,longdescription?)>
 <!ATTLIST dtconfig
-	prefs (import|lighttable|darkroom|otherviews|processing|security|cpugpu|storage|misc) #IMPLIED
-        section
-        (import|session|interface|other|tags|geoloc|slideshow|cpugpu|opencl|platform|database|XMP|accel|general|modules|thumbs) #IMPLIED
+	prefs IDREF #IMPLIED
+        section IDREF #IMPLIED
         dialog (collect|recentcollect|import|tagging) #IMPLIED
         ui (yes|no) #IMPLIED
         restart (true|false) #IMPLIED

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -45,7 +45,7 @@
     <type>bool</type>
     <default>true</default>
     <shortdescription>prefer focused instance</shortdescription>
-    <longdescription>if an instance of the module has focus, apply shortcut to that instance\nnote: blending shortcuts always apply to the focused instance</longdescription>
+    <longdescription>where multiple instances of a module are present, apply shortcuts to the instance that has focus\nif none are focused, the preferences below control rules that are followed (in order) to decide which module instance shortcuts will be applied to.\nnote: blending shortcuts always apply to the focused instance</longdescription>
   </dtconfig>
   <dtconfig prefs="misc" section="accel">
     <name>accel/prefer_expanded</name>
@@ -106,6 +106,18 @@
     <default>true</default>
     <shortdescription>load default shortcuts at startup</shortdescription>
     <longdescription>load default shortcuts before user settings. switch off to prevent deleted defaults returning</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>accel/show_tab_in_prefs</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>show the shortcuts configuration tab in the preferences dialog</shortdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>accel/hide_notice</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>don't show advice in shortcuts dialog</shortdescription>
   </dtconfig>
   <dtconfig>
     <name>bauhaus/scale</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1,6 +1,39 @@
 <?xml version="1.0"?>
 <!DOCTYPE dtconfiglist SYSTEM "darktableconfig.dtd">
 <dtconfiglist>
+  <dttab name="import" title="import">
+    <section name="session" title="session options"/>
+  </dttab>
+  <dttab name="lighttable" title="lighttable">
+    <section title="general"/>
+    <section name="thumbs" title="thumbnails"/>
+  </dttab>
+  <dttab name="darkroom" title="darkroom">
+    <section title="general"/>
+    <section name="modules" title="modules"/>
+  </dttab>
+  <dttab name="processing" title="processing">
+    <section name="general" title="image processing"/>
+    <section name="cpugpu" title="CPU / memory"/>
+    <section name="opencl" title="OpenCL"/>
+    <section name="platform" title="OpenCL drivers"/>
+  </dttab>
+  <dttab name="security" title="security">
+    <section title="general"/>
+    <section name="other" title="other"/>
+  </dttab>
+  <dttab name="storage" title="storage">
+    <section name="database" title="database"/>
+    <section name="XMP" title="XMP"/>
+  </dttab>
+  <dttab name="misc" title="miscellaneous">
+    <section name="interface" title="interface"/>
+    <section name="tags" title="tags"/>
+    <section name="accel" title="shortcuts with multiple instances"/>
+    <section name="geoloc" title="map / geolocalization view"/>
+    <section name="slideshow" title="slideshow view"/>
+  </dttab>
+
   <dtconfig>
     <name>themes/usercss</name>
     <type>bool</type>
@@ -152,7 +185,7 @@
     <shortdescription>maximum width of the side panels in pixels</shortdescription>
     <longdescription>(needs a restart)</longdescription>
   </dtconfig>
-  <dtconfig prefs="otherviews" section="slideshow">
+  <dtconfig prefs="misc" section="slideshow">
     <name>slideshow_delay</name>
     <type>int</type>
     <default>5</default>
@@ -2041,7 +2074,7 @@
     <shortdescription>max polygon points</shortdescription>
     <longdescription>limit the number of points imported with polygon in find location module</longdescription>
   </dtconfig>
-  <dtconfig prefs="otherviews" section="geoloc">
+  <dtconfig prefs="misc" section="geoloc">
     <name>plugins/lighttable/metadata_view/pretty_location</name>
     <type>bool</type>
     <default>true</default>

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1100,8 +1100,13 @@ treeview header label
   margin-right: 1.75em;
 }
 
-#preferences-notebook combobox,
-#preferences-notebook spinbutton,
+#preference_non_default
+{
+  font-weight: bolder;
+  margin: 0.07em;
+  min-width: 1em;
+}
+
 #preset-controls entry,
 #shortcut-controls entry
 {
@@ -1767,6 +1772,7 @@ treeview *:active
   color: @field_active_fg;
 }
 
+#preferences-box .dt_bauhaus,
 treeview check:selected
 {
   background-color: @button_bg;

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -2699,6 +2699,9 @@ static void _import_clicked(GtkButton *button, gpointer user_data)
 
 static void _notice_clicked(GtkWidget *button, gpointer user_data)
 {
+  static int times = 0;
+  if(++times < 3) return;
+
   gtk_widget_hide(button);
   dt_conf_set_bool("accel/hide_notice", TRUE);
 }
@@ -2914,12 +2917,12 @@ GtkWidget *dt_shortcuts_prefs(GtkWidget *widget)
     button = gtk_button_new_with_label(
       _("the recommended way to assign shortcuts to visual elements is the <b>visual shortcut mapping</b> mode.\n"
         "this is switched on by toggling the <i>\"keyboard\"</i> button next to preferences in the top panel. "
-        "in this mode, clicking on a widget or area will open this dialog with the appropriate selection for advanced configuration.\n"
+        "in this mode, clicking on a widget or area will open this dialog with the appropriate selection for advanced configuration.\n\n"
         "multiple shortcuts can be assigned to the same action. "
         "this is especially useful if it has multiple <i>elements</i>, like the module buttons or the colorpickers attached to sliders. "
         "however, with <i>fallbacks</i> enabled one can use the same simple shortcuts and "
-        "change their <i>element</i> or <i>effect</i> by adding mouse clicks."));
-    gtk_widget_set_tooltip_text(button, _("click to dismiss this notice permanently"));
+        "change their <i>element</i> or <i>effect</i> by adding mouse clicks.\n\n"
+        "<i>click <b> three times </b> to dismiss this notice permanently</i>"));
     gtk_widget_set_hexpand(button, TRUE);
     GtkLabel *label = GTK_LABEL(gtk_bin_get_child(GTK_BIN(button)));
     gtk_label_set_use_markup(label, TRUE);

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -901,7 +901,8 @@ static void init_tab_presets(GtkWidget *stack)
 
 static void init_tab_accels(GtkWidget *stack)
 {
-  gtk_stack_add_titled(GTK_STACK(stack), dt_shortcuts_prefs(NULL), _("shortcuts"), _("shortcuts"));
+  if(dt_conf_get_bool("accel/show_tab_in_prefs"))
+    gtk_stack_add_titled(GTK_STACK(stack), dt_shortcuts_prefs(NULL), _("shortcuts"), _("shortcuts"));
 }
 
 static void _delete_line_and_empty_parent(GtkTreeModel *model, GtkTreeIter *iter)

--- a/src/gui/preferences.h
+++ b/src/gui/preferences.h
@@ -26,21 +26,18 @@ GtkWidget *dt_gui_preferences_bool(GtkGrid *grid, const char *key, const guint c
                                    const guint line, const gboolean swap);
 GtkWidget *dt_gui_preferences_int(GtkGrid *grid, const char *key, const guint col,
                                   const guint line);
-GtkWidget *dt_gui_preferences_enum(GtkGrid *grid, const char *key, const guint col,
-                                   const guint line);
+GtkWidget *dt_gui_preferences_enum(dt_action_t *action, const char *key);
 GtkWidget *dt_gui_preferences_string(GtkGrid *grid, const char *key, const guint col,
                                      const guint line);
 
 // update widget with current preference
 void dt_gui_preferences_bool_update(GtkWidget *widget);
 void dt_gui_preferences_int_update(GtkWidget *widget);
-void dt_gui_preferences_enum_update(GtkWidget *widget);
 void dt_gui_preferences_string_update(GtkWidget *widget);
 
 // reset widget to default value
 void dt_gui_preferences_bool_reset(GtkWidget *widget);
 void dt_gui_preferences_int_reset(GtkWidget *widget);
-void dt_gui_preferences_enum_reset(GtkWidget *widget);
 void dt_gui_preferences_string_reset(GtkWidget *widget);
 
 // clang-format off

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -3228,7 +3228,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), d->history_box, TRUE, TRUE, 0);
   // dummy widget just to ensure alignment of history button  with those in filtering lib
   gtk_box_pack_start(GTK_BOX(d->history_box), gtk_drawing_area_new(), TRUE, TRUE, 0);
-  GtkWidget *btn = dt_action_button_new(self, _("history"), G_CALLBACK(_history_show), self,
+  GtkWidget *btn = dt_action_button_new(self, N_("history"), G_CALLBACK(_history_show), self,
                                         _("revert to a previous set of rules"), GDK_KEY_k, GDK_CONTROL_MASK);
   gtk_box_pack_start(GTK_BOX(d->history_box), btn, TRUE, TRUE, 0);
   gtk_widget_show_all(d->history_box);

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -2231,10 +2231,10 @@ void gui_init(dt_lib_module_t *self)
   GtkWidget *bhbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_set_homogeneous(GTK_BOX(bhbox), TRUE);
   gtk_box_pack_start(GTK_BOX(self->widget), bhbox, TRUE, TRUE, 0);
-  GtkWidget *btn = dt_action_button_new(self, _("new rule"), G_CALLBACK(_event_rule_append), self,
+  GtkWidget *btn = dt_action_button_new(self, N_("new rule"), G_CALLBACK(_event_rule_append), self,
                                         _("append new rule to collect images"), 0, 0);
   gtk_box_pack_start(GTK_BOX(bhbox), btn, TRUE, TRUE, 0);
-  btn = dt_action_button_new(self, _("history"), G_CALLBACK(_event_history_show), self,
+  btn = dt_action_button_new(self, N_("history"), G_CALLBACK(_event_history_show), self,
                              _("revert to a previous set of rules"), 0, 0);
   gtk_box_pack_start(GTK_BOX(bhbox), btn, TRUE, TRUE, 0);
   gtk_widget_show_all(bhbox);
@@ -2251,10 +2251,10 @@ void gui_init(dt_lib_module_t *self)
   bhbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_set_homogeneous(GTK_BOX(bhbox), TRUE);
   gtk_box_pack_start(GTK_BOX(self->widget), bhbox, TRUE, TRUE, 0);
-  btn = dt_action_button_new(self, _("new sort"), G_CALLBACK(_sort_show_add_popup), self,
+  btn = dt_action_button_new(self, N_("new sort"), G_CALLBACK(_sort_show_add_popup), self,
                              _("append new sort to order images"), 0, 0);
   gtk_box_pack_start(GTK_BOX(bhbox), btn, TRUE, TRUE, 0);
-  btn = dt_action_button_new(self, _("history"), G_CALLBACK(_sort_history_show), self,
+  btn = dt_action_button_new(self, N_("history"), G_CALLBACK(_sort_history_show), self,
                              _("revert to a previous set of sort orders"), 0, 0);
   gtk_box_pack_start(GTK_BOX(bhbox), btn, TRUE, TRUE, 0);
   gtk_widget_show_all(bhbox);

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -29,6 +29,7 @@
 #include "gui/accelerators.h"
 #include "gui/draw.h"
 #include "gui/gtk.h"
+#include "gui/preferences.h"
 #include "gui/styles.h"
 #include "libs/lib.h"
 #include "libs/lib_api.h"
@@ -109,19 +110,6 @@ const struct
       [ DT_MASKS_PROPERTY_CURVATURE] = { N_("curvature"), "%", -1, 1, FALSE },
       [ DT_MASKS_PROPERTY_COMPRESSION] = { N_("compression"), "%", 0.0001, 1, TRUE },
 };
-
-static const gchar *_pressure_sensitivity_names[] = { N_("off"),
-                                                      N_("hardness (relative)"),
-                                                      N_("hardness (absolute)"),
-                                                      N_("opacity (relative)"),
-                                                      N_("opacity (absolute)"),
-                                                      N_("brush size (relative)"),
-                                                      NULL };
-
-static const gchar *_brush_smoothing_names[] = { N_("low"),
-                                                 N_("medium"),
-                                                 N_("high"),
-                                                 NULL };
 
 gboolean _timeout_show_all_feathers(gpointer userdata)
 {
@@ -269,18 +257,6 @@ static void _update_all_properties(dt_lib_masks_t *self)
 
   gtk_widget_set_visible(self->pressure, drawing_brush && darktable.gui->have_pen_pressure);
   gtk_widget_set_visible(self->smoothing, drawing_brush);
-}
-
-static void _pressure_changed(GtkWidget *widget, gpointer user_data)
-{
-  dt_conf_set_string("pressure_sensitivity",
-                     _pressure_sensitivity_names[dt_bauhaus_combobox_get(widget)]);
-}
-
-static void _smoothing_changed(GtkWidget *widget, gpointer user_data)
-{
-  dt_conf_set_string("brush_smoothing",
-                     _brush_smoothing_names[dt_bauhaus_combobox_get(widget)]);
 }
 
 static void _lib_masks_get_values(GtkTreeModel *model,
@@ -1949,34 +1925,12 @@ void gui_init(dt_lib_module_t *self)
                      G_CALLBACK(_property_changed), GINT_TO_POINTER(i));
   }
 
-  const char *psens = dt_conf_get_string_const("pressure_sensitivity");
-  int pos = 0;
-  for(int i = 0; _pressure_sensitivity_names[i]; i++)
-    if(!g_strcmp0(_pressure_sensitivity_names[i], psens)) pos = i;
-
-  d->pressure =
-    dt_bauhaus_combobox_new_full(DT_ACTION(self),
-                                 N_("properties"),
-                                 N_("pressure"),
-                                 _("pen pressure control for brush masks\n"
-                                   "'off': pressure reading ignored,\n"
-                                   "'hardness'/'opacity'/'brush size': pressure reading controls specified attribute,\n"
-                                   "'absolute'/'relative': pressure reading is taken directly as attribute value or multiplied with pre-defined setting."),
-                                 pos, _pressure_changed, NULL, _pressure_sensitivity_names);
+  d->pressure = dt_gui_preferences_enum(DT_ACTION(self), "pressure_sensitivity");
+  dt_bauhaus_widget_set_label(d->pressure, N_("properties"), N_("pressure"));
   gtk_box_pack_start(GTK_BOX(d->cs.container), d->pressure, FALSE, FALSE, 0);
 
-  const char *bsmooth = dt_conf_get_string_const("brush_smoothing");
-  pos = 0;
-  for(int i = 0; _brush_smoothing_names[i]; i++)
-    if(!g_strcmp0(_brush_smoothing_names[i], bsmooth)) pos = i;
-
-  d->smoothing =
-    dt_bauhaus_combobox_new_full(DT_ACTION(self),
-                                 N_("properties"),
-                                 N_("smoothing"),
-                                 _("smoothing of brush strokes\n"
-                                   "stronger smoothing leads to fewer nodes and easier editing but with lower control of accuracy."),
-                                 pos, _smoothing_changed, NULL, _brush_smoothing_names);
+  d->smoothing = dt_gui_preferences_enum(DT_ACTION(self), "brush_smoothing");
+  dt_bauhaus_widget_set_label(d->smoothing, N_("properties"), N_("smoothing"));
   gtk_box_pack_start(GTK_BOX(d->cs.container), d->smoothing, FALSE, FALSE, 0);
 
   // set proxy functions

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1478,9 +1478,8 @@ void dt_view_accels_show(dt_view_manager_t *vm)
 
   GtkWidget *vb = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   vm->accels_window.sticky_btn = dtgtk_button_new(dtgtk_cairo_paint_multiinstance, 0, NULL);
-  g_object_set(G_OBJECT(vm->accels_window.sticky_btn), "tooltip-text",
-               _("switch to a classic window which will stay open after key release"),
-               (char *)NULL);
+  gtk_widget_set_tooltip_text(vm->accels_window.sticky_btn,
+                              _("switch to a classic window which will stay open after key release"));
   g_signal_connect(G_OBJECT(vm->accels_window.sticky_btn), "button-press-event",
                    G_CALLBACK(_accels_window_sticky),
                    vm);

--- a/tools/generate_darktablerc_conf.xsl
+++ b/tools/generate_darktablerc_conf.xsl
@@ -18,6 +18,8 @@
 
 #include "control/conf.h"
 
+#define WRAP_TRANSLATION(text)
+
 static void _insert_default(const char *name, const char *value)
 {
   dt_confgen_value_t *item = (dt_confgen_value_t *)g_hash_table_lookup(darktable.conf->x_confgen, name);
@@ -236,23 +238,25 @@ void dt_confgen_init()
   <xsl:variable name="uui" select="../@ui"/>
 
   <xsl:text>   _insert_shortdescription("</xsl:text><xsl:value-of select="../name" />
+
   <xsl:if test="not($uui)">
     <xsl:text>", "</xsl:text>
   </xsl:if>
   <xsl:if test="$uui = 'yes'">
-    <xsl:text>", _("</xsl:text>
+    <xsl:text>", N_("</xsl:text>
   </xsl:if>
 
   <xsl:value-of select="."/>
 
   <xsl:if test="not($uui)">
-    <xsl:text>");</xsl:text>
+    <xsl:text>");
+</xsl:text>
   </xsl:if>
   <xsl:if test="$uui = 'yes'">
-    <xsl:text>"));</xsl:text>
+    <xsl:text>"));
+</xsl:text>
   </xsl:if>
 
-  <xsl:text>&#xA;</xsl:text>
 </xsl:template>
 
 <xsl:template match="longdescription">
@@ -266,19 +270,20 @@ void dt_confgen_init()
   </xsl:if>
 
   <xsl:if test="$uui = 'yes' and $des != ''">
-    <xsl:text>", _("</xsl:text>
+    <xsl:text>", N_("</xsl:text>
   </xsl:if>
 
   <xsl:value-of select="."/>
 
   <xsl:if test="not($uui) or $des = ''">
-    <xsl:text>");</xsl:text>
+    <xsl:text>");
+</xsl:text>
   </xsl:if>
   <xsl:if test="$uui = 'yes' and $des != ''">
-    <xsl:text>"));</xsl:text>
+    <xsl:text>"));
+</xsl:text>
   </xsl:if>
 
-  <xsl:text>&#xA;</xsl:text>
 </xsl:template>
 
 <xsl:template match="default">
@@ -296,11 +301,9 @@ void dt_confgen_init()
 <xsl:template match="enum" mode="value">
   <xsl:for-each select="option">
     <xsl:if test="number(.) != .">
-      <xsl:text>   const char *</xsl:text>
-      <xsl:value-of select="generate-id(.)" />
-      <xsl:text> = C_("preferences", "</xsl:text>
+      <xsl:text>   WRAP_TRANSLATION(C_("preferences", "</xsl:text>
       <xsl:value-of select="." />
-      <xsl:text>");&#xA;</xsl:text>
+      <xsl:text>"));&#xA;</xsl:text>
     </xsl:if>
   </xsl:for-each>
 </xsl:template>

--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -5,42 +5,12 @@
   <xsl:variable name="lowercase" select="'abcdefghijklmnopqrstuvwxyz'" />
   <xsl:variable name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'" />
   <!-- The start of the gui generating functions -->
-  <xsl:variable name="tab_start"> (GtkWidget *dialog, GtkWidget *stack, const char *title)
-{
-  GtkWidget *widget, *label, *labelev, *viewport, *box;
-  GtkWidget *grid = gtk_grid_new();
-  gtk_grid_set_row_spacing(GTK_GRID(grid), DT_PIXEL_APPLY_DPI(3));
-  gtk_grid_set_column_spacing(GTK_GRID(grid), DT_PIXEL_APPLY_DPI(5));
-  gtk_widget_set_valign(grid, GTK_ALIGN_START);
-  int line = 0;
-  char tooltip[1024];
-  GtkWidget *tab_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  GtkWidget *scroll = gtk_scrolled_window_new(NULL, NULL);
-  gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
-  viewport = gtk_viewport_new(NULL, NULL);
-  gtk_viewport_set_shadow_type(GTK_VIEWPORT(viewport), GTK_SHADOW_NONE); // doesn't seem to work from gtkrc
-  GtkWidget *help = gtk_button_new_with_label(_("?"));
-  gtk_widget_set_halign(help, GTK_ALIGN_END);
-  g_object_set_data_full(G_OBJECT(help), "dt-help-url",
-                         g_strdup_printf("preferences-settings/%s/", title), g_free);
-  g_signal_connect(help, "clicked", G_CALLBACK(dt_gui_show_help), NULL);
-  gtk_box_pack_start(GTK_BOX(tab_box), scroll, TRUE, TRUE, 0);
-  gtk_container_add(GTK_CONTAINER(scroll), viewport);
-  gtk_container_add(GTK_CONTAINER(viewport), grid);
-  gtk_box_pack_end(GTK_BOX(tab_box), help, FALSE, FALSE, 0);
-  gtk_stack_add_titled(GTK_STACK(stack), tab_box, _(title), _(title));
-
-</xsl:variable>
-
-  <xsl:variable name="tab_end">
-  gtk_widget_show_all(stack);
-}
-</xsl:variable>
 
 <xsl:variable name="dialog_start">(GtkWidget *dialog)
 {
   GtkWidget *widget, *label, *labelev, *viewport, *box;
   GtkWidget *grid = gtk_grid_new();
+  GtkSizeGroup *widget_group = gtk_size_group_new(GTK_SIZE_GROUP_BOTH);
   gtk_grid_set_row_spacing(GTK_GRID(grid), DT_PIXEL_APPLY_DPI(3));
   gtk_grid_set_column_spacing(GTK_GRID(grid), DT_PIXEL_APPLY_DPI(5));
   gtk_widget_set_valign(grid, GTK_ALIGN_START);
@@ -51,9 +21,10 @@
 </xsl:variable>
 
 <xsl:variable name="dialog_end">
+  g_object_unref(widget_group);
   gtk_box_pack_start(GTK_BOX(area), grid, FALSE, FALSE, 0);
   return grid;
-  }
+}
 </xsl:variable>
 
   <xsl:param name="HAVE_OPENCL">1</xsl:param>
@@ -71,6 +42,7 @@
 #include <gtk/gtk.h>
 #include "control/conf.h"
 #include "common/calculator.h"
+#include "gui/preferences.h"
 
 #define NON_DEF_CHAR "●"
 
@@ -80,8 +52,8 @@ static gboolean handle_enter_key(GtkWidget *widget, GdkEvent *event, gpointer da
 
   gdk_event_get_keyval ((GdkEvent*)event, &keyval);
 
-  if (keyval == GDK_KEY_Return || keyval == GDK_KEY_KP_Enter)
-     return TRUE;
+  if(keyval == GDK_KEY_Return || keyval == GDK_KEY_KP_Enter)
+    return TRUE;
   return FALSE;
 }
 
@@ -89,22 +61,17 @@ static void set_widget_label_default(GtkWidget *widget, const char *confstr, Gtk
 {
   gboolean is_default = TRUE;
 
-  if (GTK_IS_CHECK_BUTTON(widget))
+  if(GTK_IS_CHECK_BUTTON(widget))
   {
     const gboolean c_default = dt_confgen_get_bool(confstr, DT_DEFAULT);
     const gboolean c_state = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
     is_default = (c_state == c_default);
   }
-  else if(GTK_IS_COMBO_BOX(widget))
+  else if(DT_IS_BAUHAUS_WIDGET(widget))
   {
-    const gchar *c_default = dt_confgen_get(confstr, DT_DEFAULT);
-    GtkTreeIter iter;
-    GtkTreeModel *model = gtk_combo_box_get_model(GTK_COMBO_BOX(widget));
-    const gint active = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
-    gchar *c_state = NULL;
-    gtk_tree_model_iter_nth_child(model, &iter, NULL, active);
-    gtk_tree_model_get(model, &iter, 0, &c_state, -1);
-    is_default = (g_strcmp0(c_state, c_default) == 0);
+    const int v_default = dt_bauhaus_combobox_get_default(widget);
+    const int v_state = GPOINTER_TO_INT(dt_bauhaus_combobox_get_data(widget));
+    is_default = (v_state == v_default);
   }
   else if(GTK_IS_SPIN_BUTTON(widget))
   {
@@ -135,13 +102,13 @@ static void set_widget_label_default(GtkWidget *widget, const char *confstr, Gtk
   {
     // replace * with space
     gtk_label_set_text(GTK_LABEL(label), "");
-    g_object_set(label, "tooltip-text", NULL, (gchar *)0);
+    gtk_widget_set_tooltip_text(label, NULL);
   }
   else
   {
     // replace space with *
     gtk_label_set_text(GTK_LABEL(label), NON_DEF_CHAR);
-    g_object_set(label, "tooltip-text", _("this setting has been modified"), (gchar *)0);
+    gtk_widget_set_tooltip_text(label, _("this setting has been modified"));
   }
 }
 
@@ -152,7 +119,7 @@ gboolean restart_required = FALSE;
 
   <xsl:for-each select="./dtconfiglist/dtconfig[@prefs or @dialog]">
     <xsl:if test="name != 'opencl' or $HAVE_OPENCL=1">
-      <xsl:text>static gboolean&#xA;reset_widget_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text> (GtkWidget *label, GdkEventButton *event, GtkWidget *widget)&#xA;{&#xA;  if(event->type == GDK_2BUTTON_PRESS)&#xA;  {&#xA;</xsl:text>
+      <xsl:text>static gboolean&#xA;reset_widget_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text> (GtkWidget *label, GdkEventButton *event, GtkWidget *widget)&#xA;{&#xA;  if(event->type == GDK_2BUTTON_PRESS)&#xA;  {</xsl:text>
       <xsl:apply-templates select="." mode="reset"/>
       <xsl:text>&#xA;    return TRUE;&#xA;  }&#xA;  return FALSE;&#xA;}&#xA;&#xA;</xsl:text>
     </xsl:if>
@@ -177,6 +144,7 @@ gboolean restart_required = FALSE;
       <xsl:text>  }&#xA;</xsl:text>
       <xsl:text>  gtk_widget_set_can_focus(GTK_WIDGET(dialog), TRUE);&#xA;</xsl:text>
       <xsl:text>  gtk_widget_grab_focus(GTK_WIDGET(dialog));&#xA;</xsl:text>
+
       <xsl:apply-templates select="." mode="change"/>
       <xsl:text>&#xA;}&#xA;&#xA;</xsl:text>
     </xsl:if>
@@ -190,321 +158,72 @@ gboolean restart_required = FALSE;
       <xsl:text>  restart_required = TRUE;&#xA;</xsl:text>
     </xsl:if>
     <xsl:apply-templates select="type" mode="factor"/>
-    <xsl:text>  set_widget_label_default(widget, "</xsl:text>
+    <xsl:text>
+  set_widget_label_default(widget, "</xsl:text>
     <xsl:value-of select="name"/><xsl:text>", GTK_WIDGET(user_data), factor);</xsl:text>
     <xsl:text>&#xA;}&#xA;&#xA;</xsl:text>
   </xsl:for-each>
 
   <!-- preferences tabs -->
 
-  <!-- lighttable -->
+<xsl:text>
+static void init_tab_generated(GtkWidget *dialog, GtkWidget *stack)
+{
+  GtkSizeGroup *widget_group = gtk_size_group_new(GTK_SIZE_GROUP_BOTH);</xsl:text>
 
-  <xsl:text>&#xA;static void&#xA;init_tab_lighttable</xsl:text><xsl:value-of select="$tab_start"/>
+<xsl:for-each select="/dtconfiglist/dttab">
+  <xsl:variable name="pref" select="@name"/>
 
-  <!-- general section -->
   <xsl:text>
+  {
+    GtkWidget *widget, *label, *labelev, *viewport, *box;
+    GtkWidget *grid = gtk_grid_new();
+    gtk_grid_set_row_spacing(GTK_GRID(grid), DT_PIXEL_APPLY_DPI(3));
+    gtk_grid_set_column_spacing(GTK_GRID(grid), DT_PIXEL_APPLY_DPI(5));
+    gtk_widget_set_valign(grid, GTK_ALIGN_START);
+    int line = 0;
+    char tooltip[1024];
+    GtkWidget *tab_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+    GtkWidget *scroll = gtk_scrolled_window_new(NULL, NULL);
+    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
+    viewport = gtk_viewport_new(NULL, NULL);
+    gtk_viewport_set_shadow_type(GTK_VIEWPORT(viewport), GTK_SHADOW_NONE); // doesn't seem to work from gtkrc
+    GtkWidget *help = gtk_button_new_with_label(_("?"));
+    gtk_widget_set_halign(help, GTK_ALIGN_END);
+    g_object_set_data_full(G_OBJECT(help), "dt-help-url",
+                          g_strdup("preferences-settings/</xsl:text><xsl:value-of select="@title"/><xsl:text>/"), g_free);
+    g_signal_connect(help, "clicked", G_CALLBACK(dt_gui_show_help), NULL);
+    gtk_box_pack_start(GTK_BOX(tab_box), scroll, TRUE, TRUE, 0);
+    gtk_container_add(GTK_CONTAINER(scroll), viewport);
+    gtk_container_add(GTK_CONTAINER(viewport), grid);
+    gtk_box_pack_end(GTK_BOX(tab_box), help, FALSE, FALSE, 0);
+    gtk_stack_add_titled(GTK_STACK(stack), tab_box,
+                         _("</xsl:text><xsl:value-of select="@title"/><xsl:text>"), _("</xsl:text><xsl:value-of select="@title"/><xsl:text>"));</xsl:text>
+
+  <xsl:for-each select="./section">
+    <xsl:variable name="section" select="@name"/>
+    <xsl:text>
     {
-      GtkWidget *seclabel = gtk_label_new(_("general"));
+      GtkWidget *seclabel = gtk_label_new(_("</xsl:text><xsl:value-of select="@title"/><xsl:text>"));
       GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
       gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
       gtk_widget_set_name(lbox, "pref_section");
       gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
-    }
-  </xsl:text>
+    }</xsl:text>
 
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='lighttable' and @section='general']">
-    <xsl:apply-templates select="." mode="tab_block"/>
-  </xsl:for-each>
-
-  <!-- module section -->
-
-  <xsl:text>
-   {
-      GtkWidget *seclabel = gtk_label_new(_("thumbnails"));
-      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_name(lbox, "pref_section");
-      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
-   }
-  </xsl:text>
-
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='lighttable' and @section='thumbs']">
-    <xsl:apply-templates select="." mode="tab_block"/>
-  </xsl:for-each>
-
-  <xsl:value-of select="$tab_end" />
-
-  <!-- darkroom -->
-
-  <xsl:text>&#xA;static void&#xA;init_tab_darkroom</xsl:text><xsl:value-of select="$tab_start"/>
-
-  <!-- general section -->
-  <xsl:text>
-    {
-      GtkWidget *seclabel = gtk_label_new(_("general"));
-      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_name(lbox, "pref_section");
-      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
-    }
-  </xsl:text>
-
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='darkroom' and @section='general']">
-    <xsl:apply-templates select="." mode="tab_block"/>
-  </xsl:for-each>
-
-  <!-- module section -->
-
-  <xsl:text>
-   {
-      GtkWidget *seclabel = gtk_label_new(_("modules"));
-      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_name(lbox, "pref_section");
-      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
-   }
-  </xsl:text>
-
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='darkroom' and @section='modules']">
-    <xsl:apply-templates select="." mode="tab_block"/>
-  </xsl:for-each>
-
-  <xsl:value-of select="$tab_end" />
-
-  <!-- processing -->
-
-  <xsl:text>&#xA;static void&#xA;init_tab_processing</xsl:text><xsl:value-of select="$tab_start"/>
-
-  <xsl:text>
-    {
-      GtkWidget *seclabel = gtk_label_new(_("image processing"));
-      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_name(lbox, "pref_section");
-      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
-    }
-  </xsl:text>
-
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='processing' and @section='general']">
-    <xsl:apply-templates select="." mode="tab_block"/>
-  </xsl:for-each>
-
-  <!-- cpu/gpu/memory -->
-
-  <xsl:text>
-    {
-      GtkWidget *seclabel = gtk_label_new(_("CPU / memory"));
-      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_name(lbox, "pref_section");
-      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
-    }
-  </xsl:text>
-
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='processing' and @section='cpugpu']">
-    <xsl:apply-templates select="." mode="tab_block"/>
-  </xsl:for-each>
-
-  <xsl:text>
-    {
-      GtkWidget *seclabel = gtk_label_new(_("OpenCL"));
-      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_name(lbox, "pref_section");
-      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
-    }
-  </xsl:text>
-
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='processing' and @section='opencl']">
-    <xsl:if test="$HAVE_OPENCL=1">
+    <xsl:for-each select="/dtconfiglist/dtconfig[((@section != 'general' and @section = $section) or
+                                                  (@section  = 'general' and @prefs = $pref) and ($section = 'general' or not($section)))
+                                                 and (name != 'opencl' or $HAVE_OPENCL = 1)]">
       <xsl:apply-templates select="." mode="tab_block"/>
-    </xsl:if>
+    </xsl:for-each>
   </xsl:for-each>
-
   <xsl:text>
-    {
-      GtkWidget *seclabel = gtk_label_new(_("OpenCL drivers"));
-      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_name(lbox, "pref_section");
-      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
-    }
-  </xsl:text>
-
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='processing' and @section='platform']">
-    <xsl:if test="$HAVE_OPENCL=1">
-      <xsl:apply-templates select="." mode="tab_block"/>
-    </xsl:if>
-  </xsl:for-each>
-
-  <xsl:value-of select="$tab_end" />
-
-
-  <!-- security -->
-
-  <xsl:text>&#xA;static void&#xA;init_tab_security</xsl:text><xsl:value-of select="$tab_start"/>
-
-  <!-- general (confirmations) section -->
+  }</xsl:text>
+</xsl:for-each>
   <xsl:text>
-    {
-      GtkWidget *seclabel = gtk_label_new(_("general"));
-      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_name(lbox, "pref_section");
-      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
-    }
-  </xsl:text>
 
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='security' and @section='general']">
-    <xsl:apply-templates select="." mode="tab_block"/>
-  </xsl:for-each>
-
-  <!-- others section -->
-  <xsl:text>
-   {
-      GtkWidget *seclabel = gtk_label_new(_("other"));
-      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_name(lbox, "pref_section");
-      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
-   }
-  </xsl:text>
-
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='security' and @section='other']">
-    <xsl:apply-templates select="." mode="tab_block"/>
-  </xsl:for-each>
-  <xsl:value-of select="$tab_end" />
-
-  <!-- storage -->
-
-  <xsl:text>&#xA;static void&#xA;init_tab_storage</xsl:text><xsl:value-of select="$tab_start"/>
-
-<xsl:text>
-   {
-      GtkWidget *seclabel = gtk_label_new(_("database"));
-      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_name(lbox, "pref_section");
-      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
-   }
-</xsl:text>
-
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='storage' and @section='database']">
-    <xsl:apply-templates select="." mode="tab_block"/>
-  </xsl:for-each>
-<xsl:text>
-   {
-      GtkWidget *seclabel = gtk_label_new(_("XMP"));
-      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_name(lbox, "pref_section");
-      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
-   }
-</xsl:text>
-
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='storage' and @section='XMP']">
-    <xsl:apply-templates select="." mode="tab_block"/>
-  </xsl:for-each>
-  <xsl:value-of select="$tab_end" />
-
-  <!-- miscellaneous -->
-
-  <xsl:text>&#xA;static void&#xA;init_tab_misc</xsl:text><xsl:value-of select="$tab_start"/>
-<xsl:text>
-   {
-      GtkWidget *seclabel = gtk_label_new(_("interface"));
-      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_name(lbox, "pref_section");
-      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
-   }
-</xsl:text>
-
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='misc' and @section='interface']">
-    <xsl:apply-templates select="." mode="tab_block"/>
-  </xsl:for-each>
-<xsl:text>
-   {
-      GtkWidget *seclabel = gtk_label_new(_("tags"));
-      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_name(lbox, "pref_section");
-      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
-   }
-</xsl:text>
-
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='misc' and @section='tags']">
-    <xsl:apply-templates select="." mode="tab_block"/>
-  </xsl:for-each>
-
-<xsl:text>
-   {
-      GtkWidget *seclabel = gtk_label_new(_("shortcuts with multiple instances"));
-      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_name(lbox, "pref_section");
-      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
-      g_object_set(lbox,  "tooltip-text", _("where multiple module instances are present, these preferences control rules that are applied (in order) to decide which module instance shortcuts will be applied to"), (gchar *)0);
-   }
-</xsl:text>
-
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='misc' and @section='accel']">
-    <xsl:apply-templates select="." mode="tab_block"/>
-  </xsl:for-each>
-
-  <!-- other views -->
-
-  <xsl:text>
-   {
-      GtkWidget *seclabel = gtk_label_new(_("map / geolocalization view"));
-      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_name(lbox, "pref_section");
-      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
-   }
-  </xsl:text>
-
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='otherviews' and @section='geoloc']">
-    <xsl:apply-templates select="." mode="tab_block"/>
-  </xsl:for-each>
-
-  <!-- slideshow section -->
-  <xsl:text>
-   {
-      GtkWidget *seclabel = gtk_label_new(_("slideshow view"));
-      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_name(lbox, "pref_section");
-      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
-   }
-</xsl:text>
-
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='otherviews' and @section='slideshow']">
-    <xsl:apply-templates select="." mode="tab_block"/>
-  </xsl:for-each>
-  <xsl:value-of select="$tab_end" />
-
-  <!-- import -->
-
-  <xsl:text>&#xA;static void&#xA;init_tab_import</xsl:text><xsl:value-of select="$tab_start"/>
-
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='import' and @section='import']">
-          <xsl:apply-templates select="." mode="tab_block"/>
-  </xsl:for-each>
-<xsl:text>
-   {
-      GtkWidget *seclabel = gtk_label_new(_("session options"));
-      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_name(lbox, "pref_section");
-      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
-   }
-</xsl:text>
-
-  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='import' and @section='session']">
-          <xsl:apply-templates select="." mode="tab_block"/>
-  </xsl:for-each>
-  <xsl:value-of select="$tab_end" />
+  g_object_unref(widget_group);
+}</xsl:text>
 
   <!-- dialog: collect -->
 
@@ -557,98 +276,98 @@ gboolean restart_required = FALSE;
     else
     {
        labdef = gtk_label_new(NON_DEF_CHAR);
-       g_object_set(labdef, "tooltip-text", _("this setting has been modified"), (gchar *)0);
+       gtk_widget_set_tooltip_text(labdef, _("this setting has been modified"));
     }
     gtk_widget_set_name(labdef, "preference_non_default");
-    label = gtk_label_new(_("</xsl:text><xsl:value-of select="shortdescription"/><xsl:text>"));
-    gtk_widget_set_halign(label, GTK_ALIGN_START);
+    label = gtk_label_new_with_mnemonic(_("</xsl:text><xsl:value-of select="shortdescription"/><xsl:text>"));
+    gtk_label_set_xalign(GTK_LABEL(label), .0);
     labelev = gtk_event_box_new();
     gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
     gtk_container_add(GTK_CONTAINER(labelev), label);
 </xsl:text>
   <xsl:apply-templates select="." mode="tab"/>
-  <xsl:text>    gtk_event_box_set_visible_window(GTK_EVENT_BOX(labelev), FALSE);</xsl:text>
+  <xsl:text>
+    gtk_event_box_set_visible_window(GTK_EVENT_BOX(labelev), FALSE);</xsl:text>
   <xsl:if test="longdescription != ''">
     <xsl:if test="contains(longdescription,'%')">
       <xsl:text>
     /* xgettext:no-c-format */</xsl:text>
     </xsl:if>
-    <xsl:text>&#xA;    g_object_set(widget, "tooltip-text", _("</xsl:text><xsl:value-of select="longdescription"/><xsl:text>"), (gchar *)0);</xsl:text>
+      <xsl:text>
+    gtk_widget_set_tooltip_text(widget, _("</xsl:text><xsl:value-of select="longdescription"/><xsl:text>"));</xsl:text>
   </xsl:if>
-        <xsl:choose>
-                <xsl:when test="@capability">
-                        <xsl:text>
-    GtkWidget *notavailable = gtk_label_new(_("not available"));
-    gtk_widget_set_halign(notavailable, GTK_ALIGN_START);
-    gtk_widget_set_sensitive(notavailable, FALSE);
-    g_object_set(notavailable, "tooltip-text", _("not available on this system"), (gchar *)0);
-    gtk_widget_set_sensitive(labelev, dt_capabilities_check("</xsl:text><xsl:value-of select="@capability"/><xsl:text>"));
-    gtk_widget_set_sensitive(widget, dt_capabilities_check("</xsl:text><xsl:value-of select="@capability"/><xsl:text>"));
+    <xsl:if test="@capability">
+      <xsl:text>
     if(!dt_capabilities_check("</xsl:text><xsl:value-of select="@capability"/><xsl:text>"))
-      g_object_set(labelev, "tooltip-text", _("not available on this system"), (gchar *)0);
-    gtk_grid_attach(GTK_GRID(grid), labelev, 0, line, 1, 1);
-    gtk_grid_attach(GTK_GRID(grid), dt_capabilities_check("</xsl:text><xsl:value-of select="@capability"/><xsl:text>") ? box : notavailable, 2, line++, 1, 1);
-    g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(reset_widget_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), (gpointer)widget);
-</xsl:text>
-                </xsl:when>
-                <xsl:otherwise>
-                        <xsl:text>
+    {
+      gtk_widget_destroy(widget);
+      widget = gtk_label_new(_("not available"));
+      gtk_widget_set_halign(widget, GTK_ALIGN_START);
+      gtk_widget_set_tooltip_text(labelev, _("not available on this system"));
+      gtk_widget_set_tooltip_text(widget, _("not available on this system"));
+      gtk_widget_set_sensitive(labelev, FALSE);
+      gtk_widget_set_sensitive(widget, FALSE);
+    }</xsl:text>
+    </xsl:if>
+    <xsl:text>
     gtk_widget_set_name(widget, "</xsl:text><xsl:value-of select="name"/><xsl:text>");
     gtk_grid_attach(GTK_GRID(grid), labelev, 0, line, 1, 1);
     gtk_grid_attach(GTK_GRID(grid), labdef, 1, line, 1, 1);
-    gtk_grid_attach(GTK_GRID(grid), box, 2, line++, 1, 1);
+    gtk_grid_attach(GTK_GRID(grid), widget, 2, line++, 1, 1);
+    gtk_label_set_mnemonic_widget(GTK_LABEL(label), widget);
     g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(reset_widget_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), (gpointer)widget);
-</xsl:text>
-                </xsl:otherwise>
-        </xsl:choose>
-  <xsl:text>
-  }
-</xsl:text>
+  }</xsl:text>
 </xsl:template>
 
 <!-- Rules handling code specific for different types -->
 
 <!-- RESET -->
   <xsl:template match="dtconfig[type='string']" mode="reset">
-    <xsl:text>    gtk_entry_set_text(GTK_ENTRY(widget), "</xsl:text><xsl:value-of select="default"/><xsl:text>");</xsl:text>
+    <xsl:text>
+    gtk_entry_set_text(GTK_ENTRY(widget), "</xsl:text><xsl:value-of select="default"/><xsl:text>");</xsl:text>
   </xsl:template>
 
   <xsl:template match="dtconfig[type='longstring']" mode="reset">
-     <xsl:text>
-        gtk_text_buffer_set_text(gtk_text_view_get_buffer(GTK_TEXT_VIEW(widget)), "</xsl:text><xsl:value-of select="default"/><xsl:text>", strlen("</xsl:text><xsl:value-of select="default"/><xsl:text>"));
-     </xsl:text>
+    <xsl:text>
+    gtk_text_buffer_set_text(gtk_text_view_get_buffer(GTK_TEXT_VIEW(widget)), "</xsl:text><xsl:value-of select="default"/><xsl:text>", strlen("</xsl:text><xsl:value-of select="default"/><xsl:text>"));</xsl:text>
   </xsl:template>
 
   <xsl:template match="dtconfig[type='int']" mode="reset">
     <xsl:text>  </xsl:text><xsl:apply-templates select="type" mode="factor"/>
-    <xsl:text>    gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), </xsl:text><xsl:value-of select="default"/><xsl:text> * factor);</xsl:text>
+    <xsl:text>
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), </xsl:text><xsl:value-of select="default"/><xsl:text> * factor);</xsl:text>
   </xsl:template>
 
   <xsl:template match="dtconfig[type='int64']" mode="reset">
     <xsl:text>  </xsl:text><xsl:apply-templates select="type" mode="factor"/>
-    <xsl:text>    gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), </xsl:text><xsl:value-of select="default"/><xsl:text> * factor);</xsl:text>
+    <xsl:text>
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), </xsl:text><xsl:value-of select="default"/><xsl:text> * factor);</xsl:text>
   </xsl:template>
 
   <xsl:template match="dtconfig[type='float']" mode="reset">
     <xsl:text>  </xsl:text><xsl:apply-templates select="type" mode="factor"/>
-    <xsl:text>    gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), </xsl:text><xsl:value-of select="default"/><xsl:text> * factor);</xsl:text>
+    <xsl:text>
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), </xsl:text><xsl:value-of select="default"/><xsl:text> * factor);</xsl:text>
   </xsl:template>
 
   <xsl:template match="dtconfig[type='bool']" mode="reset">
-    <xsl:text>    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), </xsl:text><xsl:value-of select="translate(default, $lowercase, $uppercase)"/><xsl:text>);</xsl:text>
+    <xsl:text>
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), </xsl:text><xsl:value-of select="translate(default, $lowercase, $uppercase)"/><xsl:text>);</xsl:text>
   </xsl:template>
 
   <xsl:template match="dtconfig[type/enum]" mode="reset">
     <xsl:variable name="default" select="default"/>
     <xsl:for-each select="./type/enum/option">
       <xsl:if test="$default = .">
-        <xsl:text>    gtk_combo_box_set_active(GTK_COMBO_BOX(widget), </xsl:text><xsl:value-of select="position()-1"/><xsl:text>);</xsl:text>
+    <xsl:text>
+    dt_bauhaus_widget_reset(widget);</xsl:text>
       </xsl:if>
     </xsl:for-each>
   </xsl:template>
 
   <xsl:template match="dtconfig[type='dir']" mode="reset">
-    <xsl:text>    gchar *path = dt_conf_expand_default_dir("</xsl:text><xsl:value-of select="default"/><xsl:text>");
+    <xsl:text>
+    gchar *path = dt_conf_expand_default_dir("</xsl:text><xsl:value-of select="default"/><xsl:text>");
     dt_conf_set_string("</xsl:text><xsl:value-of select="name"/><xsl:text>", path);
     g_free(path);
     path = dt_conf_get_string("</xsl:text><xsl:value-of select="name"/><xsl:text>");
@@ -658,61 +377,62 @@ gboolean restart_required = FALSE;
 
 <!-- CALLBACK -->
   <xsl:template match="dtconfig[type='string']" mode="change">
-    <xsl:text>  dt_conf_set_string("</xsl:text><xsl:value-of select="name"/><xsl:text>", gtk_entry_get_text(GTK_ENTRY(widget)));</xsl:text>
+  <xsl:text>
+  dt_conf_set_string("</xsl:text><xsl:value-of select="name"/><xsl:text>", gtk_entry_get_text(GTK_ENTRY(widget)));</xsl:text>
   </xsl:template>
 
   <xsl:template match="dtconfig[type='longstring']" mode="change">
-     <xsl:text>
-        GtkTextIter start, end;
-        GtkTextBuffer *buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(widget));
-        gtk_text_buffer_get_start_iter(buffer, &amp;start);
-        gtk_text_buffer_get_end_iter(buffer, &amp;end);
-        dt_conf_set_string("</xsl:text><xsl:value-of select="name"/><xsl:text>", gtk_text_buffer_get_text(buffer, &amp;start, &amp;end, FALSE));
-     </xsl:text>
+  <xsl:text>
+  GtkTextIter start, end;
+  GtkTextBuffer *buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(widget));
+  gtk_text_buffer_get_start_iter(buffer, &amp;start);
+  gtk_text_buffer_get_end_iter(buffer, &amp;end);
+  dt_conf_set_string("</xsl:text><xsl:value-of select="name"/><xsl:text>", gtk_text_buffer_get_text(buffer, &amp;start, &amp;end, FALSE));</xsl:text>
   </xsl:template>
 
   <xsl:template match="dtconfig[type='int']" mode="change">
     <xsl:apply-templates select="type" mode="factor"/>
-    <xsl:text>  dt_conf_set_int("</xsl:text><xsl:value-of select="name"/><xsl:text>", gtk_spin_button_get_value(GTK_SPIN_BUTTON(widget)) / factor);</xsl:text>
+  <xsl:text>
+  dt_conf_set_int("</xsl:text><xsl:value-of select="name"/><xsl:text>", gtk_spin_button_get_value(GTK_SPIN_BUTTON(widget)) / factor);</xsl:text>
   </xsl:template>
 
   <xsl:template match="dtconfig[type='int64']" mode="change">
     <xsl:apply-templates select="type" mode="factor"/>
-    <xsl:text>  dt_conf_set_int64("</xsl:text><xsl:value-of select="name"/><xsl:text>", gtk_spin_button_get_value(GTK_SPIN_BUTTON(widget)) / factor);</xsl:text>
+  <xsl:text>
+  dt_conf_set_int64("</xsl:text><xsl:value-of select="name"/><xsl:text>", gtk_spin_button_get_value(GTK_SPIN_BUTTON(widget)) / factor);</xsl:text>
   </xsl:template>
 
   <xsl:template match="dtconfig[type='float']" mode="change">
     <xsl:apply-templates select="type" mode="factor"/>
-    <xsl:text>  dt_conf_set_float("</xsl:text><xsl:value-of select="name"/><xsl:text>", gtk_spin_button_get_value(GTK_SPIN_BUTTON(widget)) / factor);</xsl:text>
+  <xsl:text>
+  dt_conf_set_float("</xsl:text><xsl:value-of select="name"/><xsl:text>", gtk_spin_button_get_value(GTK_SPIN_BUTTON(widget)) / factor);</xsl:text>
   </xsl:template>
 
   <xsl:template match="dtconfig[type='bool']" mode="change">
-    <xsl:text>  dt_conf_set_bool("</xsl:text><xsl:value-of select="name"/><xsl:text>", gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));</xsl:text>
+  <xsl:text>
+  dt_conf_set_bool("</xsl:text><xsl:value-of select="name"/><xsl:text>", gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));</xsl:text>
   </xsl:template>
 
   <xsl:template match="dtconfig[type/enum]" mode="change">
-    <xsl:text>  GtkTreeIter iter;
-  if(gtk_combo_box_get_active_iter(GTK_COMBO_BOX(widget), &amp;iter))
-  {
-    gchar *s = NULL;
-    gtk_tree_model_get(gtk_combo_box_get_model(GTK_COMBO_BOX(widget)), &amp;iter, 0, &amp;s, -1);
-    dt_conf_set_string("</xsl:text><xsl:value-of select="name"/><xsl:text>", s);
-    g_free(s);
-  }</xsl:text>
+  <xsl:text>
+  const gchar *index = dt_bauhaus_combobox_get_data(widget);
+  gchar *s = g_strndup(index, strchr(index, ']') - index);
+  dt_conf_set_string("</xsl:text><xsl:value-of select="name"/><xsl:text>", s);
+  g_free(s);</xsl:text>
   </xsl:template>
 
   <xsl:template match="dtconfig[type='dir']" mode="change">
-    <xsl:text>  gchar *folder = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(widget));
+  <xsl:text>
+  gchar *folder = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(widget));
   dt_conf_set_string("</xsl:text><xsl:value-of select="name"/><xsl:text>", folder);
   g_free(folder);</xsl:text>
   </xsl:template>
 
 <!-- TAB -->
   <xsl:template match="dtconfig[type='longstring']" mode="tab">
-  <xsl:text>    GtkTextBuffer *buffer = gtk_text_buffer_new(NULL);
+    <xsl:text>
+    GtkTextBuffer *buffer = gtk_text_buffer_new(NULL);
     widget = gtk_text_view_new_with_buffer(buffer);
-    box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    gtk_box_pack_start(GTK_BOX(box), widget, TRUE, TRUE, 0);
     gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(widget), GTK_WRAP_WORD);
     gtk_text_view_set_accepts_tab(GTK_TEXT_VIEW(widget), FALSE);
     gtk_widget_set_halign(widget, GTK_ALIGN_FILL);
@@ -723,195 +443,160 @@ gboolean restart_required = FALSE;
     g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     g_signal_connect(G_OBJECT(widget), "key-press-event", G_CALLBACK(handle_enter_key), NULL);
     snprintf(tooltip, 1024, _("double click to reset to `%s'"), "</xsl:text><xsl:value-of select="default"/><xsl:text>");
-    g_object_set(labelev,  "tooltip-text", tooltip, (gchar *)0);
-</xsl:text>
+    gtk_widget_set_tooltip_text(labelev, tooltip);</xsl:text>
   </xsl:template>
   <xsl:template match="dtconfig[type='string']" mode="tab">
-    <xsl:text>    widget = gtk_entry_new();
-    box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    gtk_box_pack_start(GTK_BOX(box), widget, TRUE, TRUE, 0);
+    <xsl:text>
+    widget = gtk_entry_new();
     gtk_widget_set_halign(widget, GTK_ALIGN_FILL);
     gtk_widget_set_hexpand(widget, TRUE);
     gchar *setting = dt_conf_get_string("</xsl:text><xsl:value-of select="name"/><xsl:text>");
     gtk_entry_set_text(GTK_ENTRY(widget), setting);
     g_free(setting);
-    </xsl:text>
-    <xsl:text>g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);</xsl:text>
-    <xsl:text>
+    gtk_label_set_mnemonic_widget(GTK_LABEL(label), widget);
+    g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);
     g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     snprintf(tooltip, 1024, _("double click to reset to `%s'"), "</xsl:text><xsl:value-of select="default"/><xsl:text>");
-    g_object_set(labelev,  "tooltip-text", tooltip, (gchar *)0);
-</xsl:text>
+    gtk_widget_set_tooltip_text(labelev,  tooltip);</xsl:text>
   </xsl:template>
 
   <xsl:template match="dtconfig[type='dir']" mode="tab">
-    <xsl:text>    widget = gtk_file_chooser_button_new(_("select directory"), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER);
-    box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    gtk_box_pack_start(GTK_BOX(box), widget, TRUE, TRUE, 0);
+    <xsl:text>
+    widget = gtk_file_chooser_button_new(_("select directory"), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER);
     gtk_file_chooser_button_set_width_chars(GTK_FILE_CHOOSER_BUTTON(widget), 20);
     gtk_widget_set_halign(widget, GTK_ALIGN_FILL);
     gtk_widget_set_hexpand(widget, TRUE);
     gchar *setting = dt_conf_get_string("</xsl:text><xsl:value-of select="name"/><xsl:text>");
     gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(widget), setting);
     g_free(setting);
-    </xsl:text>
-    <xsl:text>g_signal_connect(G_OBJECT(widget), "selection-changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);</xsl:text>
-    <xsl:text>
+    g_signal_connect(G_OBJECT(widget), "selection-changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);
     g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     gchar *default_path = dt_conf_expand_default_dir("</xsl:text><xsl:value-of select="default"/><xsl:text>");
     snprintf(tooltip, 1024, _("double click to reset to `%s'"), default_path);
     g_free(default_path);
-    g_object_set(labelev,  "tooltip-text", tooltip, (gchar *)0);
-    </xsl:text>
+    gtk_widget_set_tooltip_text(labelev, tooltip);</xsl:text>
   </xsl:template>
 
   <xsl:template match="dtconfig[type='int']" mode="tab">
-    <xsl:text>    gint min = G_MININT;&#xA;    gint max = G_MAXINT;&#xA;</xsl:text>
+    <xsl:text>
+    gint min = G_MININT;
+    gint max = G_MAXINT;</xsl:text>
     <xsl:apply-templates select="type" mode="range"/>
-    <xsl:text>  </xsl:text><xsl:apply-templates select="type" mode="factor"/>
-    <xsl:text>    double tmp;
+    <xsl:apply-templates select="type" mode="factor"/>
+    <xsl:text>
+    double tmp;
     tmp = min * (double)factor; min = tmp;
     tmp = max * (double)factor; max = tmp;
     widget = gtk_spin_button_new_with_range(min, max, 1);
-    box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    gtk_box_pack_start(GTK_BOX(box), widget, FALSE, FALSE, 0);
-    gtk_widget_set_hexpand(widget, FALSE);
+    gtk_widget_set_halign(widget, GTK_ALIGN_START);
+    gtk_size_group_add_widget(widget_group, widget);
     gtk_spin_button_set_digits(GTK_SPIN_BUTTON(widget), 0);
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), dt_conf_get_int("</xsl:text><xsl:value-of select="name"/><xsl:text>") * factor);
-    </xsl:text>
-    <xsl:text>g_signal_connect(G_OBJECT(widget), "value-changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);</xsl:text>
-    <xsl:text>
+    g_signal_connect(G_OBJECT(widget), "value-changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);
     g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     snprintf(tooltip, 1024, _("double click to reset to `%d'"), (int)(</xsl:text><xsl:value-of select="default"/><xsl:text> * factor));
-    g_object_set(labelev,  "tooltip-text", tooltip, (gchar *)0);
-</xsl:text>
+    gtk_widget_set_tooltip_text(labelev, tooltip);</xsl:text>
   </xsl:template>
 
   <xsl:template match="dtconfig[type='int64']" mode="tab">
-    <xsl:text>    gint64 min = G_MININT64;&#xA;    gint64 max = G_MAXINT64;&#xA;</xsl:text>
+    <xsl:text>
+    gint64 min = G_MININT64;
+    gint64 max = G_MAXINT64;</xsl:text>
     <xsl:apply-templates select="type" mode="range"/>
     <xsl:text>  </xsl:text><xsl:apply-templates select="type" mode="factor"/>
-    <xsl:text>    min *= factor; max *= factor;
+    <xsl:text>
+    min *= factor; max *= factor;
     widget = gtk_spin_button_new_with_range(min, max, 1);
-    box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    gtk_box_pack_start(GTK_BOX(box), widget, FALSE, FALSE, 0);
-    gtk_widget_set_hexpand(widget, FALSE);
+    gtk_widget_set_halign(widget, GTK_ALIGN_START);
+    gtk_size_group_add_widget(widget_group, widget);
     gtk_spin_button_set_digits(GTK_SPIN_BUTTON(widget), 0);
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), dt_conf_get_int64("</xsl:text><xsl:value-of select="name"/><xsl:text>") * factor);
-    </xsl:text>
-    <xsl:text>g_signal_connect(G_OBJECT(widget), "value-changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);</xsl:text>
-    <xsl:text>
+    g_signal_connect(G_OBJECT(widget), "value-changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);
     g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     char value[100];
     snprintf(value, 100, "%"G_GINT64_FORMAT"",(gint64)(</xsl:text><xsl:value-of select="default"/><xsl:text> * factor));
     snprintf(tooltip, 1024, _("double click to reset to `%s'"), value);
-    g_object_set(labelev,  "tooltip-text", tooltip, (gchar *)0);
-</xsl:text>
+    gtk_widget_set_tooltip_text(labelev, tooltip);</xsl:text>
   </xsl:template>
 
   <xsl:template match="dtconfig[type='float']" mode="tab">
-    <xsl:text>    float min = -1000000000.0f;&#xA;    float max = 1000000000.0f;&#xA;</xsl:text>
+    <xsl:text>
+    float min = -1000000000.0f;
+    float max = 1000000000.0f;</xsl:text>
     <xsl:apply-templates select="type" mode="range"/>
-    <xsl:text>  </xsl:text><xsl:apply-templates select="type" mode="factor"/>
-    <xsl:text>    min *= factor; max *= factor;
+    <xsl:apply-templates select="type" mode="factor"/>
+    <xsl:text>
+    min *= factor; max *= factor;
     widget = gtk_spin_button_new_with_range(min, max, 0.001f);
-    box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    gtk_box_pack_start(GTK_BOX(box), widget, FALSE, FALSE, 0);
-    gtk_widget_set_hexpand(widget, FALSE);
     gtk_spin_button_set_digits(GTK_SPIN_BUTTON(widget), 5);
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), dt_conf_get_float("</xsl:text><xsl:value-of select="name"/><xsl:text>") * factor);
-    </xsl:text>
-    <xsl:text>g_signal_connect(G_OBJECT(widget), "value-changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);</xsl:text>
-    <xsl:text>
+    g_signal_connect(G_OBJECT(widget), "value-changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);
     g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     snprintf(tooltip, 1024, _("double click to reset to `%.03f'"), </xsl:text><xsl:value-of select="default"/><xsl:text> * factor);
-    g_object_set(labelev,  "tooltip-text", tooltip, (gchar *)0);
-</xsl:text>
+    gtk_widget_set_tooltip_text(labelev, tooltip);</xsl:text>
   </xsl:template>
 
-    <xsl:template match="dtconfig[type='bool']" mode="tab">
-    <xsl:text>    widget = gtk_check_button_new();
-    box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    gtk_box_pack_start(GTK_BOX(box), widget, FALSE, FALSE, 0);
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), dt_conf_get_bool("</xsl:text><xsl:value-of select="name"/><xsl:text>"));
-    </xsl:text>
-    <xsl:text>g_signal_connect(G_OBJECT(widget), "toggled", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);</xsl:text>
+  <xsl:template match="dtconfig[type='bool']" mode="tab">
     <xsl:text>
+    widget = gtk_check_button_new();
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), dt_conf_get_bool("</xsl:text><xsl:value-of select="name"/><xsl:text>"));
+    g_signal_connect(G_OBJECT(widget), "toggled", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);
     g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     snprintf(tooltip, 1024, _("double click to reset to `%s'"), C_("preferences", "</xsl:text><xsl:value-of select="translate(default, $lowercase, $uppercase)"/><xsl:text>"));
-    g_object_set(labelev,  "tooltip-text", tooltip, (gchar *)0);
-</xsl:text>
+    gtk_widget_set_tooltip_text(labelev, tooltip);</xsl:text>
   </xsl:template>
 
   <xsl:template match="dtconfig[type/enum]" mode="tab">
-    <xsl:text>    GtkTreeIter iter;
-    GtkListStore *store = gtk_list_store_new(2, G_TYPE_STRING, G_TYPE_STRING);
-    gchar *str = dt_conf_get_string("</xsl:text><xsl:value-of select="name"/><xsl:text>");
-    gint pos = -1;
-</xsl:text>
+    <xsl:text>
+    widget = dt_gui_preferences_enum(NULL, "</xsl:text><xsl:value-of select="name"/><xsl:text>");</xsl:text>
     <xsl:for-each select="./type/enum/option">
-        <xsl:if test="@capability">
-          <xsl:text>if(dt_capabilities_check("</xsl:text><xsl:value-of select="@capability"/><xsl:text>")) {</xsl:text>
-        </xsl:if>
+      <xsl:sort select="position()" order="descending"/>
+      <xsl:if test="@capability">
         <xsl:text>
-        gtk_list_store_append(store, &amp;iter);
-        gtk_list_store_set(store, &amp;iter, 0, "</xsl:text><xsl:value-of select="."/><xsl:text>", 1, C_("preferences", "</xsl:text><xsl:value-of select="."/><xsl:text>"), -1);
-        if(pos == -1 &amp;&amp; strcmp(str, "</xsl:text><xsl:value-of select="."/><xsl:text>") == 0)
-          pos = </xsl:text><xsl:value-of select="position()-1" /><xsl:text>;
-      </xsl:text>
-        <xsl:if test="@capability">
-          <xsl:text>}
-          </xsl:text>
-        </xsl:if>
+    if(!dt_capabilities_check("</xsl:text><xsl:value-of select="@capability"/><xsl:text>"))
+      dt_bauhaus_combobox_remove_at(widget, </xsl:text><xsl:value-of select="last()-position()"/><xsl:text>);</xsl:text>
+      </xsl:if>
     </xsl:for-each>
     <xsl:text>
-
-    g_free(str);
-
-    widget = gtk_combo_box_new_with_model(GTK_TREE_MODEL(store));
-    gtk_widget_set_hexpand(widget, FALSE);
-    g_object_unref(store);
-    GtkCellRenderer *renderer = gtk_cell_renderer_text_new();
-    gtk_cell_renderer_set_padding(renderer, 0, 0);
-    gtk_cell_layout_pack_start(GTK_CELL_LAYOUT(widget), renderer, TRUE);
-    gtk_cell_layout_set_attributes(GTK_CELL_LAYOUT(widget), renderer, "text", 1, NULL);
-    gtk_combo_box_set_active(GTK_COMBO_BOX(widget), pos);
-    box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    gtk_box_pack_start(GTK_BOX(box), widget, FALSE, FALSE, 0);
-    </xsl:text>
-    <xsl:text> g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);</xsl:text>
-    <xsl:text>
+    gtk_widget_set_halign(widget, GTK_ALIGN_START);
+    gtk_size_group_add_widget(widget_group, widget);
+    g_signal_connect(G_OBJECT(widget), "value-changed", G_CALLBACK(preferences_changed_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), labdef);
     g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     snprintf(tooltip, 1024, _("double click to reset to `%s'"), C_("preferences", "</xsl:text><xsl:value-of select="default"/><xsl:text>"));
-    g_object_set(labelev,  "tooltip-text", tooltip, (gchar *)0);
-</xsl:text>
+    gtk_widget_set_tooltip_text(labelev, tooltip);</xsl:text>
   </xsl:template>
 
 <!-- Grab min/max from input. Is there a better way? -->
   <xsl:template match="type[@min and @max]" mode="range" priority="5">
-    <xsl:text>    min = </xsl:text><xsl:value-of select="@min"/><xsl:text>;&#xA;</xsl:text>
-    <xsl:text>    max = </xsl:text><xsl:value-of select="@max"/><xsl:text>;&#xA;</xsl:text>
+    <xsl:text>
+    min = </xsl:text><xsl:value-of select="@min"/><xsl:text>;
+    max = </xsl:text><xsl:value-of select="@max"/><xsl:text>;</xsl:text>
   </xsl:template>
 
   <xsl:template match="type[@min]" mode="range" priority="3">
-    <xsl:text>    min = </xsl:text><xsl:value-of select="@min"/><xsl:text>;&#xA;</xsl:text>
+    <xsl:text>
+    min = </xsl:text><xsl:value-of select="@min"/><xsl:text>;</xsl:text>
   </xsl:template>
 
   <xsl:template match="type[@max]" mode="range" priority="3">
-    <xsl:text>    max = </xsl:text><xsl:value-of select="@max"/><xsl:text>;&#xA;</xsl:text>
+    <xsl:text>
+    max = </xsl:text><xsl:value-of select="@max"/><xsl:text>;</xsl:text>
   </xsl:template>
 
   <xsl:template match="type" mode="range"  priority="1">
-    <xsl:text>    min = 0;&#xA;</xsl:text>
+    <xsl:text>
+    min = 0;</xsl:text>
   </xsl:template>
 
 <!-- Also look for the factor used in the GUI. -->
   <xsl:template match="type[@factor]" mode="factor" priority="3">
-    <xsl:text>  float factor = </xsl:text><xsl:value-of select="@factor"/><xsl:text>;&#xA;</xsl:text>
+  <xsl:text>
+  float factor = </xsl:text><xsl:value-of select="@factor"/><xsl:text>;</xsl:text>
   </xsl:template>
 
   <xsl:template match="type" mode="factor"  priority="1">
-    <xsl:text>  float factor = 1.0f;&#xA;</xsl:text>
+    <xsl:text>
+    float factor = 1.0f;</xsl:text>
   </xsl:template>
 
 


### PR DESCRIPTION
The preferences dialog is generated from an xml description using an xsl script. There was a bunch of boilerplate for each tab and section. Now these are generated automatically from a section at the start of the xml, which in theory makes it easier for people to customise their own preference dialog (or add a tab with hidden options). But it should generally help maintainance.

Also changed to using bauhaus comboboxes for preference options. With the latest fixes in place I prefer it over the gtk one and the small differences can get annoying when you expect things to work a certain way. This also makes it easier to integrate combos that expose a preference/darktablerc option in a lib module (for example in masks or maps) without breaking cohesion.

Labels in preferences now also support mnemonics. I've added a few for demonstration purposes in the darkroom tab; hold the ALT key to see the first letter of some of the options light up and pressing that letter allows toggling the option or selecting the entry. This could be automated to always pick the first letter (if multiple lines share the same mnemonic it should go around them). But customising might give better usability or this might not appeal at all.

Also fixed a small regression from #11559 that made the "changed" marker in prefs not fixed size, so toggling an option where all others are at default would cause the right columns to move. And corrected some translation markers to not break shortcuts between language switches.

All in all quite a significant change so please help testing.