### PR TITLE
Backthread calculating mipmaps while in lighttable without user activity

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -231,19 +231,12 @@
     <shortdescription>prefer performance over quality</shortdescription>
     <longdescription>if switched on, thumbnails and previews are rendered at lower quality but 4 times faster</longdescription>
   </dtconfig>
-  <dtconfig prefs="processing" section="cpugpu">
-    <name>cache_disk_backend</name>
-    <type>bool</type>
-    <default>true</default>
-    <shortdescription>enable disk backend for thumbnail cache</shortdescription>
-    <longdescription>if enabled, write thumbnails to disk (.cache/darktable/) when evicted from the memory cache.\nnote that this can take a lot of memory (several gigabytes for 20k images) and will never delete cached thumbnails again.\nit's safe though to delete these manually, if you want. light table performance will be increased greatly when browsing a lot.\nto generate all thumbnails of your entire collection offline, run 'darktable-generate-cache'.</longdescription>
-  </dtconfig>
-  <dtconfig prefs="processing" section="cpugpu">
-    <name>cache_disk_backend_full</name>
-    <type>bool</type>
-    <default>false</default>
-    <shortdescription>enable disk backend for full preview cache</shortdescription>
-    <longdescription>if enabled, write full preview to disk (.cache/darktable/) when evicted from the memory cache.\nnote that this can take a lot of memory (several gigabytes for 20k images) and will never delete cached thumbnails again.\nit's safe though to delete these manually, if you want.\nlight table performance will be increased greatly when zooming image in full preview mode.</longdescription>
+  <dtconfig>
+    <name>backthumbs_inactivity</name>
+    <type>float</type>
+    <default>5.0</default>
+    <shortdescription>inactivity time</shortdescription>
+    <longdescription>user inactivity time (seconds) while being in lighttable before a thumbnail generation might start</longdescription>
   </dtconfig>
   <dtconfig>
     <name>cache_color_managed</name>
@@ -1340,6 +1333,45 @@
     <default>720p</default>
     <shortdescription>high quality processing from size</shortdescription>
     <longdescription>if the thumbnail size is greater than this value, it will be processed using the full quality rendering path (better but slower).\nif you want all thumbnails and pre-rendered images in best quality you should choose the *always* option.\n(more comments in the manual)</longdescription>
+  </dtconfig>
+  <dtconfig prefs="lighttable" section="thumbs">
+    <name>cache_disk_backend</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>enable disk backend for thumbnail cache</shortdescription>
+    <longdescription>if enabled, write thumbnails to disk (.cache/darktable/) when evicted from the memory cache.\nnote that this can take a lot of memory (several gigabytes for 20k images) and will never delete cached thumbnails again.\nit's safe though to delete these manually, if you want. light table performance will be increased greatly when browsing a lot.\nto generate all thumbnails of your entire collection offline, run 'darktable-generate-cache'.</longdescription>
+  </dtconfig>
+  <dtconfig prefs="lighttable" section="thumbs">
+    <name>cache_disk_backend_full</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>enable disk backend for full preview cache</shortdescription>
+    <longdescription>if enabled, write full preview to disk (.cache/darktable/) when evicted from the memory cache.\nnote that this can take a lot of memory (several gigabytes for 20k images) and will never delete cached thumbnails again.\nit's safe though to delete these manually, if you want.\nlight table performance will be increased greatly when zooming image in full preview mode.</longdescription>
+  </dtconfig>
+  <dtconfig prefs="lighttable" section="thumbs">
+    <name>backthumbs_mipsize</name>
+    <type>
+      <enum>
+        <option>never</option>
+        <option>small</option>
+        <option>VGA</option>
+        <option>720p</option>
+        <option>1080p</option>
+        <option>WQXGA</option>
+        <option>4k</option>
+        <option>5K</option>
+      </enum>
+    </type>
+    <default>never</default>
+    <shortdescription>generate thumbs in background</shortdescription>
+    <longdescription>if 'cache_disk_backend' is enabled thumbnails/mipmaps up to the selected size are generated while user is inactive in lighttable.</longdescription>
+  </dtconfig>
+  <dtconfig prefs="lighttable" section="thumbs">
+    <name>backthumbs_initialize</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>reset backthumbs</shortdescription>
+    <longdescription>you might reset the backthumbs database in case you have removed any thumbnails manually from the mipmap cache.</longdescription>
   </dtconfig>
   <dtconfig prefs="lighttable" section="thumbs">
     <name>plugins/lighttable/thumbnail_sizes</name>

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -317,6 +317,16 @@ typedef struct dt_sys_resources_t
   gboolean tunehead;
 } dt_sys_resources_t;
 
+typedef struct dt_backthumb_t
+{
+  double time;
+  double idle;
+  gboolean writing;
+  gboolean service;
+  gboolean running;
+  int32_t mipsize;
+} dt_backthumb_t;
+
 typedef struct darktable_t
 {
   dt_codepath_t codepath;
@@ -378,6 +388,7 @@ typedef struct darktable_t
   GTimeZone *utc_tz;
   GDateTime *origin_gdt;
   struct dt_sys_resources_t dtresources;
+  struct dt_backthumb_t backthumbs;
 } darktable_t;
 
 typedef struct

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -498,7 +498,7 @@ gboolean dt_history_merge_module_into_history(dt_develop_t *dev_dest,
       // we will copy only used forms
       // record the masks used by this module
       if(mod_src->flags() & IOP_FLAGS_SUPPORTS_BLENDING
-         && mod_src->blend_params->mask_id > 0)
+         && dt_is_valid_maskid(mod_src->blend_params->mask_id))
       {
         nbf = g_list_length(dev_src->forms);
         forms_used_replace = calloc(nbf, sizeof(int));

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1679,6 +1679,7 @@ static uint32_t _image_import_internal(const int32_t film_id,
     return id;
   }
 
+  dt_set_backthumb_time(0.0);
   // also need to set the no-legacy bit, to make sure we get the right presets (new ones)
   uint32_t flags = dt_conf_get_int("ui_last/import_initial_rating");
   flags |= DT_IMAGE_NO_LEGACY_PRESETS;

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -2158,7 +2158,7 @@ int32_t dt_image_rename(const dt_imgid_t imgid, const int32_t filmid, const gcha
       // would return wrong version!
       while(dup_list)
       {
-        const int id = GPOINTER_TO_INT(dup_list->data);
+        const dt_imgid_t id = GPOINTER_TO_INT(dup_list->data);
         dt_image_t *img = dt_image_cache_get(darktable.image_cache, id, 'w');
         img->film_id = filmid;
         if(newname) g_strlcpy(img->filename, newname, DT_MAX_FILENAME_LEN);
@@ -2784,9 +2784,9 @@ void dt_image_synch_xmps(const GList *img)
   }
 }
 
-void dt_image_synch_xmp(const int32_t selected)
+void dt_image_synch_xmp(const dt_imgid_t selected)
 {
-  if(selected > 0)
+  if(dt_is_valid_imgid(selected))
     dt_image_write_sidecar_file(selected);
   else
   {

--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -194,10 +194,10 @@ void dt_import_session_unref(struct dt_import_session_t *self)
 
 void dt_import_session_import(struct dt_import_session_t *self)
 {
-  const int32_t id = dt_image_import(self->film->id, self->current_filename, TRUE, TRUE);
-  if(id)
+  const dt_imgid_t imgid = dt_image_import(self->film->id, self->current_filename, TRUE, TRUE);
+  if(dt_is_valid_imgid(imgid))
   {
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, id);
+    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, imgid);
     dt_control_queue_redraw();
   }
 }

--- a/src/common/undo.c
+++ b/src/common/undo.c
@@ -20,6 +20,7 @@
 #include "common/collection.h"
 #include "common/darktable.h"
 #include "common/image.h"
+#include "common/image_cache.h"
 #include "control/control.h"
 #include <glib.h>   // for GList, gpointer, g_list_prepend
 #include <stdlib.h> // for NULL, malloc, free
@@ -280,11 +281,12 @@ static void _undo_do_undo_redo(dt_undo_t *self,
     imgs = g_list_sort(imgs, _images_list_cmp);
     // remove duplicates
     for(const GList *img = imgs; img; img = g_list_next(img))
+    {
+      // udpate xmp is done via set_change_timestamp
+      dt_image_cache_set_change_timestamp(darktable.image_cache, GPOINTER_TO_INT(img->data));
       while(img->next && img->data == img->next->data)
         imgs = g_list_delete_link(imgs, img->next);
-    // udpate xmp for updated images
-
-    dt_image_synch_xmps(imgs);
+    }
   }
 
   dt_collection_update_query(darktable.collection,

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -30,6 +30,7 @@
 #endif
 
 #include "control/jobs.h"
+#include "control/crawler.h"
 #include "control/progress.h"
 #include "libs/lib.h"
 #include <gtk/gtk.h>

--- a/src/control/crawler.c
+++ b/src/control/crawler.c
@@ -840,6 +840,181 @@ void dt_control_crawler_show_image_list(GList *images)
                    G_CALLBACK(dt_control_crawler_response_callback), gui);
 }
 
+/* backthumb crawler */
+
+/*
+  we use these checks while
+    a) creating mipmaps and
+    b) checking the database
+  to make sure
+    a) resources are made available again as soon as possible and
+    b) we can quit darktable almost immediately if application quits
+*/
+static inline gboolean _lighttable_silent(void)
+{
+  return dt_view_get_current() == DT_VIEW_LIGHTTABLE
+      && dt_get_wtime() > darktable.backthumbs.time;
+}
+
+static inline gboolean _still_thumbing(void)
+{
+  return darktable.backthumbs.running
+      && _lighttable_silent()
+      && darktable.backthumbs.mipsize != DT_MIPMAP_NONE;
+}
+
+static void _update_img_thumbs(const dt_imgid_t imgid,
+                              const dt_mipmap_size_t max_mip,
+                              const int64_t stamp)
+{
+  for(dt_mipmap_size_t k = max_mip;
+        k >= DT_MIPMAP_1 && _still_thumbing();
+        k--)
+  {
+    dt_mipmap_buffer_t buf;
+    dt_mipmap_cache_get(darktable.mipmap_cache, &buf, imgid, k, DT_MIPMAP_BLOCKING, 'r');
+    dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
+  }
+  if(!_still_thumbing())
+    return;
+
+  // we have written all thumbs now so it's safe to write timestamp and mipsize
+  sqlite3_stmt *stmt;
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "UPDATE main.images"
+                              " SET thumb_maxmip = ?2, thumb_timestamp = ?3"
+                              " WHERE id = ?1",
+                              -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, max_mip);
+  DT_DEBUG_SQLITE3_BIND_INT64(stmt, 3, stamp);
+  sqlite3_step(stmt);
+  sqlite3_finalize(stmt);
+
+  dt_mimap_cache_evict(darktable.mipmap_cache, imgid);
+
+  // we have this in darktable-generate-cache but is it really good/necessary?
+  // dt_history_hash_set_mipmap(imgid);
+}
+
+static int _update_all_thumbs(const dt_mipmap_size_t max_mip)
+{
+  int missed = 0;
+  int updated = 0;
+  sqlite3_stmt *stmt;
+
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "SELECT id, import_timestamp, change_timestamp"
+                              " FROM main.images"
+                              " WHERE thumb_timestamp < import_timestamp"
+                              "  OR thumb_timestamp < change_timestamp"
+                              "  OR thumb_maxmip < ?1",
+                                -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, max_mip);
+  while(sqlite3_step(stmt) == SQLITE_ROW && _still_thumbing())
+  {
+    const dt_imgid_t imgid = sqlite3_column_int(stmt, 0);
+    const int64_t stamp = MAX(sqlite3_column_int64(stmt, 1), sqlite3_column_int64(stmt, 2));
+
+    char path[PATH_MAX] = { 0 };
+    gboolean from_cache = FALSE;
+    dt_image_full_path(imgid, path, sizeof(path), &from_cache);
+    const gboolean available = dt_util_test_image_file(path);
+
+    if(available)
+    {
+      _update_img_thumbs(imgid, max_mip, stamp);
+      updated++;
+    }
+    else
+    {
+      missed++;
+      dt_print(DT_DEBUG_CACHE, "[thumb crawler] '%s' id=%d NOT available\n", path, imgid);
+    }
+  }
+  sqlite3_finalize(stmt);
+
+  dt_print(DT_DEBUG_CACHE,
+    "[thumb crawler] max_mip=%d, %d thumbs updated, %d not found, %s.\n",
+      max_mip, updated, missed,
+      _still_thumbing() ? "all done" : "interrupted by user activity");
+
+  return updated;
+}
+
+static void _reinitialize_thumbs_database(void)
+{
+  dt_conf_set_bool("backthumbs_initialize", FALSE);
+
+  dt_print(DT_DEBUG_CACHE, "[thumb crawler] initialize database\n");
+
+  sqlite3_stmt *stmt;
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "UPDATE main.images"
+                              " SET thumb_maxmip = 0, thumb_timestamp = -1",
+                              -1, &stmt, NULL);
+  sqlite3_step(stmt);
+  sqlite3_finalize(stmt);
+  darktable.backthumbs.service = FALSE;
+}
+
+/* public */
+void dt_set_backthumb_time(const double next)
+{
+  dt_backthumb_t *bt = &darktable.backthumbs;
+  if(next > 0.5)
+    bt->time = dt_get_wtime() + next;
+  else
+    bt->time = fmax(bt->time, dt_get_wtime() + bt->idle);
+}
+
+void dt_update_thumbs_thread(void *p)
+{
+  dt_pthread_setname("thumbs_update");
+  dt_print(DT_DEBUG_CACHE, "[thumb crawler] started\n");
+  dt_backthumb_t *bt = &darktable.backthumbs;
+
+  bt->idle = (double)dt_conf_get_float("backthumbs_inactivity");
+  bt->writing = dt_conf_get_bool("cache_disk_backend");
+  bt->service = FALSE;
+  bt->running = TRUE;
+  const char *mipsize = dt_conf_get_string_const("backthumbs_mipsize");
+  bt->mipsize = dt_mipmap_cache_get_min_mip_from_pref(mipsize);
+
+  dt_set_backthumb_time(5.0);
+  int updated = 0;
+
+  // return if any thumbcache dir is not writable
+  for(dt_mipmap_size_t k = DT_MIPMAP_1; k <= DT_MIPMAP_7; k++)
+  {
+    char dirname[PATH_MAX] = { 0 };
+    snprintf(dirname, sizeof(dirname), "%s.d/%d", darktable.mipmap_cache->cachedir, k);
+    if(g_mkdir_with_parents(dirname, 0750))
+    {
+      dt_print(DT_DEBUG_CACHE, "[thumb crawler] can't create mipmap dir '%s'\n", dirname);
+      return;
+    }
+  }
+
+  while(bt->running)
+  {
+    for(int i = 0; i < 12 && bt->running && !bt->service; i++)
+      g_usleep(250000);
+
+    if(!bt->running)
+      break;
+
+    if(bt->service)
+      _reinitialize_thumbs_database();
+
+    if(_lighttable_silent()
+        && bt->writing
+        && bt->mipsize != DT_MIPMAP_NONE)
+      updated += _update_all_thumbs(bt->mipsize);
+  }
+  dt_print(DT_DEBUG_CACHE, "[thumb crawler] closing, %d mipmaps updated\n", updated);
+}
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/control/crawler.h
+++ b/src/control/crawler.h
@@ -36,6 +36,9 @@ GList *dt_control_crawler_run();
 // show a popup with the images, let the user decide what to do and free the list afterwards
 void dt_control_crawler_show_image_list(GList *images);
 
+// background thread updating all thumbnails is there is no user activity while being in lightroom
+void dt_update_thumbs_thread(void *ptr);
+void dt_set_backthumb_time(const double offset);
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -769,6 +769,9 @@ int dt_imageio_export_with_flags(const dt_imgid_t imgid,
   const gboolean buf_is_downscaled =
     (thumbnail_export && dt_conf_get_bool("ui/performance"));
 
+  if(!thumbnail_export)
+    dt_set_backthumb_time(600.0); // make sure we don't interfere
+
   dt_mipmap_buffer_t buf;
   if(buf_is_downscaled)
     dt_mipmap_cache_get(darktable.mipmap_cache, &buf, imgid,
@@ -1241,6 +1244,8 @@ int dt_imageio_export_with_flags(const dt_imgid_t imgid,
                                   format_params, storage, storage_params);
   }
 
+  if(!thumbnail_export)
+    dt_set_backthumb_time(5.0);
   return 0; // success
 
 error:
@@ -1248,6 +1253,9 @@ error:
 error_early:
   dt_dev_cleanup(&dev);
   dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
+
+  if(!thumbnail_export)
+    dt_set_backthumb_time(5.0);
   return 1;
 }
 

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1935,7 +1935,7 @@ static void _import_from_dialog_run(dt_lib_module_t* self)
           folder = dt_util_dstrcat(folder, "%%");
         _import_set_collection(folder);
         const dt_imgid_t imgid = dt_conf_get_int("ui_last/import_last_image");
-        if(unique && imgid > 0)
+        if(unique && dt_is_valid_imgid(imgid))
         {
           dt_control_set_mouse_over_id(imgid);
           dt_ctl_switch_mode_to("darkroom");

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -259,6 +259,8 @@ gboolean dt_view_manager_switch_by_view(dt_view_manager_t *vm,
   // reset the cursor to the default one
   dt_control_change_cursor(GDK_LEFT_PTR);
 
+  dt_set_backthumb_time(0.0);
+
   // destroy old module list
 
   /* clear the undo list, for now we do this unconditionally. At some


### PR DESCRIPTION
Something itching me for some time; can we generate mipmaps in the darktable backround without the `generate-cache` tool? 

EDIT (27/09): for the first time reader updated this from latest commits:
EDIT (03.10); updated introduction
EDIT (06.10); fixed database conversion, just one hidden conf
EDIT (09.10); simpler timing code, only non-starting if memory database is used.
EDIT (13.10); fixed undo problems, less processing footprint, preference changes caught by callback


**WARNING: this PR does a database bump which is not finalized to make a backup first!**
_________________________________________________________________________________________
Backthread calculating mipmaps while in lighttable without user activity

While being in lighttable mode users are not always active.
In those situations (being silent) we might calculate the mipmaps/thumbnails
as we otherwise could do via 'darktable-generate-cache'.
Thumbnail creation should only be done in lighttable mode as we don't want
resources to be used elsewhere.

In gui preferences we have 'generate thumbs in background' defaulting to never,
the user might select the maximum generated mipmaps/thumbs.
The "reset backthumbs" option re-initializes the thumbs database. (might be used
after manually deleting mipmaps from the cache or after database problems)

Being inactive is checked via 'gboolean _lighttable_silent(void)' returning TRUE if
1. we are in lighttable mode
2. mouse has not been used for a while
3. we have not delayed backthumbs action by other means like ex- or import.

We have a background idling job that looks for images without available mipmaps.
This thread is only started if
1. gui is active
2. we have found a minimal sufficient system (4 threads and 8GB)

To make the background thread somewhat efficient
1. We keep track of thumb_timestamp and thumb_mipmap size in the database
2. If interrupted by user activity, the backthread will go into idling mode
3. All thumb related settings in preferences are received via DT_SIGNAL_PREFERENCES_CHANGE
   and are kept for low cpu footprint in a struct.
4. lighttable_mode is tested via DT_VIEW_LIGHTTABLE
5. backthumbs_time is set whenever ther is more urgent pending work like
   a) when moving the mouse while being in lighttable
   b) some mouse click in lighttable
   c) view has been switched
   d) while export or import of images
   e) we do some mipmaps cleanup

The check for "user activity", `dt_lighttable_silent()` will only be TRUE if
1. we are in DT_VIEW_LIGHTTABLE
2. current time is higher than backthumbs.time

Issues and ideas:
1. Do we care about darktable being the selected application, the idea was:
   If a user wants to game or do any other stuff that requires all resources
   it might be good to keep idling.
_______________________________________________________________________________________________________________