### PR TITLE
[GUI] Typo fix and some rewording

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2710,7 +2710,7 @@ restart:
                " opencl for this session!\n");
       dt_control_log
         (_("OpenCL errors encountered; disabling OpenCL for this session!"
-           " likely problems:\n"
+           " some possible causes:\n"
            "  - OpenCL out of resources due to preference settings. please try with defaults,\n"
            "  - buggy driver for some device. please run darktable with `-d opencl' to identify,\n"
            "  - some drivers (for small or old devices) don't support proper number of events,\n"

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2713,7 +2713,7 @@ restart:
            " some possible causes:\n"
            "  - OpenCL out of resources due to preference settings. please try with defaults,\n"
            "  - buggy driver for some device. please run darktable with `-d opencl' to identify,\n"
-           "  - some drivers (for small or old devices) don't support proper number of events,\n"
+           "  - some drivers don't support needed number of events,\n"
            "  - too small headroom settings while using 'use all device memory'."));
       // also remove "opencl" from capabilities so that the preference entry is greyed out
       dt_capabilities_remove("opencl");

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2712,7 +2712,7 @@ restart:
         (_("OpenCL errors encountered; disabling OpenCL for this session!"
            " likely problems:\n"
            "  - OpenCL out of resources due to preference settings. please try with defaults,\n"
-           "  - buggy driver for some devive. please run darktable with `-d opencl' to identify,\n"
+           "  - buggy driver for some device. please run darktable with `-d opencl' to identify,\n"
            "  - some drivers (for small or old devices) don't support proper number of events,\n"
            "  - too small headroom settings while using 'use all device memory'."));
       // also remove "opencl" from capabilities so that the preference entry is greyed out


### PR DESCRIPTION
The first commit is a typo correction. There are also certain rewordings in the same text, made for greater clarity and unambiguousness. Since this is a more subjective part, it is done in separate commits to simplify possible PR editing.

@jenshannoschwalm Am I correct in understanding that the word "small" meant low performance, not form factor?
