### PR TITLE
Avoid dt_dev_pixelpipe_rebuild() if not necessary in focus in&out

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2196,6 +2196,17 @@ static gboolean _presets_scroll_callback(GtkWidget *widget,
   return TRUE;
 }
 
+static gboolean _iop_any_with_tag(const int optag)
+{
+  for(GList *modules = darktable.develop->iop; modules; modules = g_list_next(modules))
+  {
+    const dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
+    if(module->enabled && (optag & module->operation_tags()))
+      return TRUE;
+  }
+  return FALSE;
+}
+
 void dt_iop_request_focus(dt_iop_module_t *module)
 {
   dt_develop_t *dev = darktable.develop;
@@ -2271,14 +2282,23 @@ void dt_iop_request_focus(dt_iop_module_t *module)
      && darktable.view_manager->accels_window.sticky)
     dt_view_accels_refresh(darktable.view_manager);
 
-  if((out_focus_module && out_focus_module->operation_tags_filter())
-     || (module && module->operation_tags_filter()))
+  const int op_filter =
+          (out_focus_module ? out_focus_module->operation_tags_filter() : 0)
+      ||  (module ? module->operation_tags_filter() : 0);
+  const int op_tags =
+          (out_focus_module ? out_focus_module->operation_tags() : 0)
+      ||  (module ? module->operation_tags() : 0);
+
+  if((op_tags & IOP_TAG_CROPPING)
+    || ((op_filter & IOP_TAG_CROPPING)
+          && _iop_any_with_tag(IOP_TAG_CROPPING))
+    || ((op_filter & ~IOP_TAG_CROPPING)
+          && _iop_any_with_tag(op_filter & ~IOP_TAG_CROPPING)))
   {
-    dt_dev_invalidate_all(dev);
     dt_dev_pixelpipe_rebuild(dev);
     // don't use previous image as overlay
-    if(dev->pipe) dev->pipe->backbuf_zoom_x = 1000;
-    if(dev->preview2_pipe) dev->preview2_pipe->backbuf_zoom_x = 1000;
+    // if(dev->pipe) dev->pipe->backbuf_zoom_x = 1000;
+    // if(dev->preview2_pipe) dev->preview2_pipe->backbuf_zoom_x = 1000;
   }
 
   // update guides button state

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2283,17 +2283,22 @@ void dt_iop_request_focus(dt_iop_module_t *module)
     dt_view_accels_refresh(darktable.view_manager);
 
   const int op_filter =
-          (out_focus_module ? out_focus_module->operation_tags_filter() : 0)
-      ||  (module ? module->operation_tags_filter() : 0);
+        (out_focus_module ? out_focus_module->operation_tags_filter() : 0)
+      | (module ? module->operation_tags_filter() : 0);
   const int op_tags =
-          (out_focus_module ? out_focus_module->operation_tags() : 0)
-      ||  (module ? module->operation_tags() : 0);
+        (out_focus_module ? out_focus_module->operation_tags() : 0)
+      | (module ? module->operation_tags() : 0);
 
-  if((op_tags & IOP_TAG_CROPPING)
-    || ((op_filter & IOP_TAG_CROPPING)
+  const gboolean rebuild =
+        (op_tags & IOP_TAG_CROPPING)
+    ||  ((op_filter & IOP_TAG_CROPPING)
           && _iop_any_with_tag(IOP_TAG_CROPPING))
-    || ((op_filter & ~IOP_TAG_CROPPING)
-          && _iop_any_with_tag(op_filter & ~IOP_TAG_CROPPING)))
+    ||  ((op_filter & ~IOP_TAG_CROPPING)
+          && _iop_any_with_tag(op_filter & ~IOP_TAG_CROPPING));
+
+  dt_print(DT_DEBUG_PIPE, "[dt_iop_request_focus] op_tags=%d, op_filter=%d, rebuild pipe: %s\n",
+                  op_tags, op_filter, rebuild ? "yes" : "no");
+  if(rebuild)
   {
     dt_dev_pixelpipe_rebuild(dev);
     // don't use previous image as overlay

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2297,8 +2297,8 @@ void dt_iop_request_focus(dt_iop_module_t *module)
   {
     dt_dev_pixelpipe_rebuild(dev);
     // don't use previous image as overlay
-    // if(dev->pipe) dev->pipe->backbuf_zoom_x = 1000;
-    // if(dev->preview2_pipe) dev->preview2_pipe->backbuf_zoom_x = 1000;
+    if(dev->pipe) dev->pipe->backbuf_zoom_x = 1000;
+    if(dev->preview2_pipe) dev->preview2_pipe->backbuf_zoom_x = 1000;
   }
 
   // update guides button state


### PR DESCRIPTION
`dt_iop_request_focus()` checks the modules focussing in & out, if there are modules affected that disabled others via `operation_tags_filter()` we need to `dt_dev_pixelpipe_rebuild(dev)`.

More careful testing avoids this for example if there is no cropping module in the pixelpipe and the focused module wants that to be disabled.

Fixes #15286 

@dterrahe and @TurboGit could you test & review?

1. The backbuf_zoom_x trick seems not necessary now ? Can you confirm?
2. As `dt_dev_pixelpipe_rebuild()` calls `dt_dev_invalidate_all()` anyway i removed that here. I looked more into: Can we avoid rebuilding & invalidating __all__ but only partly but that by far out of reach. 