### PR TITLE
collection query cleanup (part 2)

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -316,33 +316,19 @@ int dt_collection_update(const dt_collection_t *collection)
                "       FROM main.film_rolls) ON film_id = film_rolls_id");
       // clang-format on
     }
-    if(collection->params.sorts[DT_COLLECTION_SORT_TITLE]
-       && collection->params.sorts[DT_COLLECTION_SORT_DESCRIPTION])
+    if(collection->params.sorts[DT_COLLECTION_SORT_TITLE])
     {
-      // clang-format off
       selq_post = dt_util_dstrcat
         (selq_post,
-        " LEFT OUTER JOIN main.meta_data AS m"
-        "   ON mi.id = m.id AND (m.key = %d OR m.key = %d)",
-        DT_METADATA_XMP_DC_TITLE, DT_METADATA_XMP_DC_DESCRIPTION);
-      // clang-format on
+        " LEFT OUTER JOIN main.meta_data AS mt ON mi.id = mt.id AND mt.key = %d",
+        DT_METADATA_XMP_DC_TITLE);
     }
-    else
+    if(collection->params.sorts[DT_COLLECTION_SORT_DESCRIPTION])
     {
-      if(collection->params.sorts[DT_COLLECTION_SORT_TITLE])
-      {
-        selq_post = dt_util_dstrcat
-          (selq_post,
-          " LEFT OUTER JOIN main.meta_data AS m ON mi.id = m.id AND m.key = %d",
-          DT_METADATA_XMP_DC_TITLE);
-      }
-      if(collection->params.sorts[DT_COLLECTION_SORT_DESCRIPTION])
-      {
-        selq_post = dt_util_dstrcat
-          (selq_post,
-          " LEFT OUTER JOIN main.meta_data AS m ON mi.id = m.id AND m.key = %d",
-          DT_METADATA_XMP_DC_DESCRIPTION);
-      }
+      selq_post = dt_util_dstrcat
+        (selq_post,
+        " LEFT OUTER JOIN main.meta_data AS md ON mi.id = md.id AND md.key = %d",
+        DT_METADATA_XMP_DC_DESCRIPTION);
     }
   }
 
@@ -733,11 +719,11 @@ static gchar *_dt_collection_get_sort_text(const dt_collection_sort_t sort,
       break;
 
     case DT_COLLECTION_SORT_TITLE:
-      sq = g_strdup_printf("m.value%s", (sortorder) ? " DESC" : "");
+      sq = g_strdup_printf("mt.value%s", (sortorder) ? " DESC" : "");
       break;
 
     case DT_COLLECTION_SORT_DESCRIPTION:
-      sq = g_strdup_printf("m.value%s", (sortorder) ? " DESC" : "");
+      sq = g_strdup_printf("md.value%s", (sortorder) ? " DESC" : "");
       break;
 
     case DT_COLLECTION_SORT_ASPECT_RATIO:

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1880,7 +1880,7 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
     case DT_COLLECTION_PROP_GROUPING: // grouping
       if(!g_strcmp0(escaped_text, "$NO_GROUP"))
       {
-        query = g_strdup("(id = group_id AND "
+        query = g_strdup("(mi.id = group_id AND "
                          "NOT EXISTS(SELECT 1 AS group_count"
                          "           FROM main.images AS gc"
                          "           WHERE gc.group_id = mi.group_id AND gc.id != mi.id))");
@@ -1900,15 +1900,15 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       }
       else if(!g_strcmp0(escaped_text, "$FOLLOWER"))
       {
-        query = g_strdup("(id != group_id)");
+        query = g_strdup("(mi.id != group_id)");
       }
       else if(!g_strcmp0(escaped_text, _("group leaders"))) // used in collect.c
       {
-        query = g_strdup("(id = group_id)");
+        query = g_strdup("(mi.id = group_id)");
       }
       else if(!g_strcmp0(escaped_text, _("group followers"))) // used in collect.c
       {
-        query = g_strdup("(id != group_id)");
+        query = g_strdup("(mi.id != group_id)");
       }
       else // by default, we select all the images
       {

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -241,7 +241,7 @@ static void _dt_collection_set_selq_pre_sort(const dt_collection_t *collection,
   // clang-format off
   *selq_pre = dt_util_dstrcat
     (*selq_pre,
-     "SELECT DISTINCT mi.id"
+     "SELECT DISTINCT sel.id"
      "  FROM (SELECT %s"
      "        FROM main.images AS mi"
      "        %s%s"
@@ -310,7 +310,7 @@ int dt_collection_update(const dt_collection_t *collection)
      * representative image wasn't filtered out.  This is important,
      * because otherwise it may be impossible to collapse the group
      * again. */
-    wq = dt_util_dstrcat(wq, " OR (id = %d)", darktable.gui->expanded_group_id);
+    wq = dt_util_dstrcat(wq, " OR (mi.id = %d)", darktable.gui->expanded_group_id);
   }
 
   // get all the sort items
@@ -329,7 +329,7 @@ int dt_collection_update(const dt_collection_t *collection)
 
   /* build select part includes where */
   _dt_collection_set_selq_pre_sort(collection, &selq_pre);
-  selq_post = g_strdup(") AS mi");
+  selq_post = g_strdup(") AS sel");
 
   if(collection->params.query_flags & COLLECTION_QUERY_USE_SORT)
   {
@@ -337,7 +337,7 @@ int dt_collection_update(const dt_collection_t *collection)
     if(collection->params.sorts[DT_COLLECTION_SORT_COLOR])
     {
       selq_post = dt_util_dstrcat
-        (selq_post, " LEFT OUTER JOIN main.color_labels AS b ON mi.id = b.imgid");
+        (selq_post, " LEFT OUTER JOIN main.color_labels AS b ON sel.id = b.imgid");
     }
     if(collection->params.sorts[DT_COLLECTION_SORT_PATH])
     {
@@ -351,14 +351,14 @@ int dt_collection_update(const dt_collection_t *collection)
     {
       selq_post = dt_util_dstrcat
         (selq_post,
-        " LEFT OUTER JOIN main.meta_data AS mt ON mi.id = mt.id AND mt.key = %d",
+        " LEFT OUTER JOIN main.meta_data AS mt ON sel.id = mt.id AND mt.key = %d",
         DT_METADATA_XMP_DC_TITLE);
     }
     if(collection->params.sorts[DT_COLLECTION_SORT_DESCRIPTION])
     {
       selq_post = dt_util_dstrcat
         (selq_post,
-        " LEFT OUTER JOIN main.meta_data AS md ON mi.id = md.id AND md.key = %d",
+        " LEFT OUTER JOIN main.meta_data AS md ON sel.id = md.id AND md.key = %d",
         DT_METADATA_XMP_DC_DESCRIPTION);
     }
   }
@@ -728,7 +728,7 @@ static gchar *_dt_collection_get_sort_text(const dt_collection_sort_t sort,
       break;
 
     case DT_COLLECTION_SORT_ID:
-      sq = g_strdup_printf("mi.id%s", (sortorder) ? " DESC" : "");
+      sq = g_strdup_printf("sel.id%s", (sortorder) ? " DESC" : "");
       break;
 
     case DT_COLLECTION_SORT_COLOR:
@@ -736,7 +736,7 @@ static gchar *_dt_collection_get_sort_text(const dt_collection_sort_t sort,
       break;
 
     case DT_COLLECTION_SORT_GROUP:
-      sq = g_strdup_printf("group_id%s, mi.id-group_id != 0, mi.id",
+      sq = g_strdup_printf("group_id%s, sel.id-group_id != 0, sel.id",
                            (sortorder) ? " DESC" : "");
       break;
 
@@ -769,7 +769,7 @@ static gchar *_dt_collection_get_sort_text(const dt_collection_sort_t sort,
     case DT_COLLECTION_SORT_NONE:
     default: /*fall through for default*/
       // shouldn't happen
-      sq = g_strdup("mi.id");
+      sq = g_strdup("sel.id");
       break;
   }
 
@@ -859,7 +859,7 @@ static uint32_t _dt_collection_compute_count(const dt_collection_t *collection,
   gchar *count_query = NULL;
 
   gchar *fq = g_strstr_len(query, strlen(query), "FROM");
-  count_query = g_strdup_printf("SELECT COUNT(DISTINCT mi.id) %s", fq);
+  count_query = g_strdup_printf("SELECT COUNT(DISTINCT sel.id) %s", fq);
 
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), count_query, -1, &stmt, NULL);
   if(collection->params.query_flags & COLLECTION_QUERY_USE_LIMIT)

--- a/src/libs/filters/grouping.c
+++ b/src/libs/filters/grouping.c
@@ -109,7 +109,7 @@ static gboolean _grouping_update(dt_lib_filtering_rule_t *rule)
   g_snprintf(query, sizeof(query),
                    "SELECT gr_count, COUNT(gr_count) "
                    " FROM (SELECT COUNT(*) AS gr_count "
-                   "        FROM main.images "
+                   "        FROM main.images AS mi"
                    "        WHERE %s "
                    "        GROUP BY group_id)"
                    " GROUP BY gr_count "

--- a/src/libs/filters/rating_range.c
+++ b/src/libs/filters/rating_range.c
@@ -33,13 +33,9 @@ static gboolean _rating_range_update(dt_lib_filtering_rule_t *rule)
   // clang-format off
   g_snprintf(query, sizeof(query),
              "SELECT CASE WHEN (flags & 8) == 8 THEN -1 ELSE (flags & 7) END AS rating,"
-             " COUNT(*) AS count, mk.name AS maker, md.name AS model, ln.name AS lens, cm.maker || ' ' || cm.model AS camera"
-             " FROM main.images AS mi, main.makers AS mk, main.models AS md, main.lens AS ln, main.cameras AS cm"
-             " WHERE mi.maker_id = mk.id"
-             "   AND mi.model_id = md.id"
-             "   AND mi.lens_id = ln.id"
-             "   AND mi.camera_id = cm.id"
-             "   AND %s"
+             " COUNT(*) AS count"
+             " FROM main.images AS mi"
+             " WHERE %s"
              " GROUP BY rating"
              " ORDER BY rating",
              rule->lib->last_where_ext);


### PR DESCRIPTION
Another pass to cleanup and optimize collection query : 
- Simply final query text for more readability (avoid unneeded `1=1` etc)
- some refactoring to remove code duplication
- final query of only 1 form (currently there's 2 form, depending if we need to join some tables for sorting or not)
- reduce the number of loaded field to the minimum, depending of the sorting orders

This also fix 2 issues found during the testing : 
- issue with title / description sort order (to reproduce, sort by title and then sort by description...)
- issue with the grouping filter (leftover of the recent `mi` alias change)