### PR TITLE
Add 'fullthumb_maxmip' to main.history_hash

### DIFF
--- a/src/common/database.c
+++ b/src/common/database.c
@@ -2935,7 +2935,7 @@ static void _create_library_schema(dt_database_t *db)
   sqlite3_exec(db->handle, "CREATE TABLE main.module_order (imgid INTEGER PRIMARY KEY, version INTEGER, iop_list VARCHAR)",
                NULL, NULL, NULL);
   sqlite3_exec(db->handle, "CREATE TABLE main.history_hash (imgid INTEGER PRIMARY KEY, "
-               "basic_hash BLOB, auto_hash BLOB, current_hash BLOB, mipmap_hash BLOB, "
+               "basic_hash BLOB, auto_hash BLOB, current_hash BLOB, mipmap_hash BLOB, fullthumb_hash BLOB, fullthumb_maxmip INTEGER, "
                "FOREIGN KEY(imgid) REFERENCES images(id) ON UPDATE CASCADE ON DELETE CASCADE)",
                NULL, NULL, NULL);
 

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -48,7 +48,7 @@
 
 // whenever _create_*_schema() gets changed you HAVE to bump this version and add an update path to
 // _upgrade_*_schema_step()!
-#define CURRENT_DATABASE_VERSION_LIBRARY 42
+#define CURRENT_DATABASE_VERSION_LIBRARY 43
 #define CURRENT_DATABASE_VERSION_DATA    10
 
 // #define USE_NESTED_TRANSACTIONS
@@ -2491,6 +2491,12 @@ static int _upgrade_library_schema_step(dt_database_t *db, int version)
     sqlite3_exec(db->handle, "PRAGMA foreign_keys = ON", NULL, NULL, NULL);
 
     new_version = 42;
+  }
+  else if(version == 42)
+  {
+    TRY_EXEC("ALTER TABLE main.history_hash ADD COLUMN fullthumb_maxmip INTEGER default 0",
+             "[init] can't add fullthumb_maxmip column\n");
+    new_version = 43;
   }
   else
     new_version = version; // should be the fallback so that calling code sees that we are in an infinite loop


### PR DESCRIPTION
Another requisite for the thumb crawler updater.

Required for efficient work
1. support for non-restart changing of thumbs_size in preferences
2. less file access checking for existing thumbs and thus less regeneration

As i learned how to do that myself - correct?