### PR TITLE
RFC: trying to fix #15324

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2296,8 +2296,10 @@ void dt_iop_request_focus(dt_iop_module_t *module)
     ||  ((op_filter & ~IOP_TAG_CROPPING)
           && _iop_any_with_tag(op_filter & ~IOP_TAG_CROPPING));
 
-  dt_print(DT_DEBUG_PIPE, "[dt_iop_request_focus] op_tags=%d, op_filter=%d, rebuild pipe: %s\n",
-                  op_tags, op_filter, rebuild ? "yes" : "no");
+  dt_print(DT_DEBUG_PIPE,
+    "[dt_iop_request_focus] op_tags=%d, op_filter=%d, rebuild: %s, focus in: '%s' out: '%s'\n",
+                  op_tags, op_filter, rebuild ? "yes" : "no",
+                  module ? module->op : "none", out_focus_module ? out_focus_module->op : "none");
   if(rebuild)
   {
     dt_dev_pixelpipe_rebuild(dev);

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -138,7 +138,7 @@ int flags()
 {
   return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_TILING_FULL_ROI | IOP_FLAGS_ONE_INSTANCE
     | IOP_FLAGS_ALLOW_FAST_PIPE
-    | IOP_FLAGS_GUIDES_SPECIAL_DRAW | IOP_FLAGS_GUIDES_WIDGET;
+    | IOP_FLAGS_GUIDES_SPECIAL_DRAW | IOP_FLAGS_GUIDES_WIDGET | IOP_FLAGS_CROP_EXPOSER;
 }
 
 int default_group()
@@ -148,7 +148,7 @@ int default_group()
 
 int operation_tags()
 {
-  return IOP_TAG_DISTORT;
+  return IOP_TAG_DISTORT | IOP_TAG_CROPPING;
 }
 
 int operation_tags_filter()

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -152,7 +152,7 @@ int flags()
 
 int operation_tags()
 {
-  return IOP_TAG_DISTORT | IOP_TAG_CROPPING;
+  return IOP_TAG_CROPPING;
 }
 
 int operation_tags_filter()

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -692,7 +692,11 @@ void expose(
   }
 
   if(dev->proxy.rotate)
+  {
+    dt_print(DT_DEBUG_EXPOSE, "[darkroom expose] proxy rotate [%s]%s\n",
+      dev->proxy.rotate->op, dev->proxy.rotate->gui_post_expose ? "possible" : "no available function");
     dev->proxy.rotate->gui_post_expose(dev->proxy.rotate, cri, width, height, pointerx, pointery);
+  }
 
   // indicate if we are in gamut check or softproof mode
   if(darktable.color_profiles->mode != DT_PROFILE_NORMAL)


### PR DESCRIPTION
1. Added some debugging info
2. Fixing tag and filter tags

@TurboGit and @dterrahe just pushing this for further discussions and tests.

There is something going on i absolutely don't understand.

The scenario described in #15324 ...

Use `-d expose -d pipe` to watch. Putting ashift to focus leaves us without __seen__ frame & lines, although the log shows ashift should do gui_expose. It does in fact but the test for "in focus" is wrong. (Likely just the symptom.

Maybe you have an idea what goes wrong.