### PR TITLE
move some preferences and check display profile capabilities

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -28,7 +28,6 @@
   </dttab>
   <dttab name="misc" title="miscellaneous">
     <section name="interface" title="interface"/>
-    <section name="tags" title="tags"/>
     <section name="accel" title="shortcuts with multiple instances"/>
     <section name="geoloc" title="map / geolocalization view"/>
     <section name="slideshow" title="slideshow view"/>
@@ -320,7 +319,7 @@
     <shortdescription>save history while developing</shortdescription>
     <longdescription>save history periodically (interval in seconds), if set to zero auto-saving is disabled. auto-saving might be disabled on slow drives.</longdescription>
   </dtconfig>
-  <dtconfig prefs="misc" section="tags">
+  <dtconfig prefs="storage" section="XMP">
     <name>omit_tag_hierarchy</name>
     <type>bool</type>
     <default>false</default>
@@ -2314,6 +2313,19 @@
     <shortdescription>always use LittleCMS 2 to apply output color profile</shortdescription>
     <longdescription>this is slower than the default.</longdescription>
   </dtconfig>
+  <dtconfig prefs="processing" section="general" capability="xatom">
+    <name>ui_last/display_profile_source</name>
+    <type>
+      <enum>
+        <option>all</option>
+        <option>xatom</option>
+        <option capability="colord">colord</option>
+      </enum>
+    </type>
+    <default>all</default>
+    <shortdescription>method to use for getting the display profile</shortdescription>
+    <longdescription>this option allows to force a specific means of getting the current display profile.\nthis is useful when one alternative gives wrong results</longdescription>
+  </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/export/high_quality_processing</name>
     <type>bool</type>
@@ -3394,19 +3406,6 @@
     <type>string</type>
     <default>darktable-elegant-grey</default>
     <shortdescription>darktable theme</shortdescription>
-  </dtconfig>
-  <dtconfig prefs="misc" section="interface">
-    <name>ui_last/display_profile_source</name>
-    <type>
-      <enum>
-        <option>all</option>
-        <option>xatom</option>
-        <option>colord</option>
-      </enum>
-    </type>
-    <default>all</default>
-    <shortdescription>method to use for getting the display profile</shortdescription>
-    <longdescription>this option allows to force a specific means of getting the current display profile.\nthis is useful when one alternative gives wrong results</longdescription>
   </dtconfig>
   <dtconfig>
     <name>metadata/resolution</name>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -519,33 +519,33 @@ static char *_get_version_string(void)
   char *version = g_strdup_printf("this is %s\ncopyright (c) 2009-%s johannes hanika\n"
                "%s\n\ncompile options:\n"
                "  bit depth is %zu bit\n"
-               "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s",
+               "%s%s%s",
                darktable_package_string,
                darktable_last_commit_year,
                PACKAGE_BUGREPORT,
                CHAR_BIT * sizeof(void *),
 #ifdef _DEBUG
-               "  debug build\n",
+               "  debug build\n"
 #else
-               "  normal build\n",
+               "  normal build\n"
 #endif
 
 #if defined(__SSE2__) && defined(__SSE__)
-               "  SSE2 optimizations enabled\n",
+               "  SSE2 optimizations enabled\n"
 #else
-               "  SSE2 optimizations unavailable\n",
+               "  SSE2 optimizations unavailable\n"
 #endif
 
 #ifdef _OPENMP
-               "  OpenMP support enabled\n",
+               "  OpenMP support enabled\n"
 #else
-               "  OpenMP support disabled\n",
+               "  OpenMP support disabled\n"
 #endif
 
 #ifdef HAVE_OPENCL
-               "  OpenCL support enabled\n",
+               "  OpenCL support enabled\n"
 #else
-               "  OpenCL support disabled\n",
+               "  OpenCL support disabled\n"
 #endif
 
 #ifdef USE_LUA
@@ -556,72 +556,72 @@ static char *_get_version_string(void)
 #endif
 
 #ifdef USE_COLORDGTK
-               "  Colord support enabled\n",
+               "  Colord support enabled\n"
 #else
-               "  Colord support disabled\n",
+               "  Colord support disabled\n"
 #endif
 
 #ifdef HAVE_GPHOTO2
-               "  gPhoto2 support enabled\n",
+               "  gPhoto2 support enabled\n"
 #else
-               "  gPhoto2 support disabled\n",
+               "  gPhoto2 support disabled\n"
 #endif
 
 #ifdef HAVE_GMIC
-               "  G'MIC support enabled (compressed LUTs will be supported)\n",
+               "  G'MIC support enabled (compressed LUTs will be supported)\n"
 #else
-               "  G'MIC support disabled (compressed LUTs will not be supported)\n",
+               "  G'MIC support disabled (compressed LUTs will not be supported)\n"
 #endif
 
 #ifdef HAVE_GRAPHICSMAGICK
-               "  GraphicsMagick support enabled\n",
+               "  GraphicsMagick support enabled\n"
 #else
-               "  GraphicsMagick support disabled\n",
+               "  GraphicsMagick support disabled\n"
 #endif
 
 #ifdef HAVE_IMAGEMAGICK
-               "  ImageMagick support enabled\n",
+               "  ImageMagick support enabled\n"
 #else
-               "  ImageMagick support disabled\n",
+               "  ImageMagick support disabled\n"
 #endif
 
 #ifdef HAVE_LIBAVIF
-               "  libavif support enabled\n",
+               "  libavif support enabled\n"
 #else
-               "  libavif support disabled\n",
+               "  libavif support disabled\n"
 #endif
 
 #ifdef HAVE_LIBHEIF
-               "  libheif support enabled\n",
+               "  libheif support enabled\n"
 #else
-               "  libheif support disabled\n",
+               "  libheif support disabled\n"
 #endif
 
 #ifdef HAVE_LIBJXL
-               "  libjxl support enabled\n",
+               "  libjxl support enabled\n"
 #else
-               "  libjxl support disabled\n",
+               "  libjxl support disabled\n"
 #endif
 
 #ifdef HAVE_OPENJPEG
-               "  OpenJPEG support enabled\n",
+               "  OpenJPEG support enabled\n"
 #else
-               "  OpenJPEG support disabled\n",
+               "  OpenJPEG support disabled\n"
 #endif
 
 #ifdef HAVE_OPENEXR
-               "  OpenEXR support enabled\n",
+               "  OpenEXR support enabled\n"
 #else
-               "  OpenEXR support disabled\n",
+               "  OpenEXR support disabled\n"
 #endif
 
 #ifdef HAVE_WEBP
-               "  WebP support enabled\n",
+               "  WebP support enabled\n"
 #else
-               "  WebP support disabled\n",
+               "  WebP support disabled\n"
 #endif
 
-      "");
+  );
 
   return version;
 }
@@ -1547,6 +1547,12 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   dt_capabilities_add("nonapple");
 #endif
 
+#ifdef GDK_WINDOWING_X11
+  dt_capabilities_add("xatom");
+#endif
+#ifdef USE_COLORDGTK
+  dt_capabilities_add("colord");
+#endif
 
   dt_print(DT_DEBUG_CONTROL,
            "[dt_init] startup took %f seconds\n", dt_get_wtime() - start_wtime);


### PR DESCRIPTION
As suggested here https://github.com/darktable-org/darktable/pull/15285#issuecomment-1731979978 some preference options could be moved around:
The miscellaneous/tags section only contained one option that concerned xmps -> moved to storage/xmp

The display profile option in misc/interface was moved to processing/general, but only shown if running under X (otherwise there's only the system default method). And if colord is not available, it is hidden too.
Yes, I realise that one can have an argument about whether this is really a processing or an interface option, but I feel that it is more likely to be found next to the LittleCMS option rather than below the "position of scopes module". If I'm wrong, I'll happily change this back.