### PR TITLE
 Giving a 5-star rating to protected (read-only) images on import #14797 

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1007,6 +1007,13 @@
     <longdescription>initial star rating for all images when importing a filmroll</longdescription>
   </dtconfig>
   <dtconfig ui="yes">
+    <name>ui_last/red_only_set_max_rathing</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>if read only give 5-stars</shortdescription>
+    <longdescription>when file is read only give 5-stars rating, it overrides 'initial rating'</longdescription>
+  </dtconfig>
+  <dtconfig ui="yes">
     <name>ui_last/ignore_exif_rating</name>
     <type>bool</type>
     <default>false</default>

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1834,6 +1834,11 @@ static uint32_t _image_import_internal(const int32_t film_id,
 
   const gboolean res = dt_exif_xmp_read(img, dtfilename, 0);
 
+  if(!dt_conf_get_bool("ui_last/ignore_exif_rating") && dt_conf_get_bool("ui_last/red_only_set_max_rathing"))
+  {
+    if(g_access(normalized_filename, W_OK) != 0)
+      img->flags |= DT_VIEW_STAR_5;
+  }
   // write through to db, but not to xmp.
   dt_image_cache_write_release(darktable.image_cache, img, DT_IMAGE_CACHE_RELAXED);
 


### PR DESCRIPTION
Read-only files are imported with a 5-star rating. This rating is overwritten if in exif data are rating and ignore exif ratin is no checked.