### PR TITLE
[GUI] Remove unnecessary text in tooltip

### DIFF
--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -866,7 +866,7 @@ void gui_init(dt_imageio_module_format_t *self)
   gtk_widget_set_tooltip_text(gui->quality,
           _("the quality of an image, less quality means fewer details.\n"
             "\n"
-            "pixel format based on quality:\n"
+            "pixel format is based on quality:\n"
             "\n"
             "    91 - 100 -> YUV444\n"
             "    81 -  90 -> YUV422\n"

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -866,8 +866,6 @@ void gui_init(dt_imageio_module_format_t *self)
   gtk_widget_set_tooltip_text(gui->quality,
           _("the quality of an image, less quality means fewer details.\n"
             "\n"
-            "the following applies only to lossy setting.\n"
-            "\n"
             "pixel format based on quality:\n"
             "\n"
             "    91 - 100 -> YUV444\n"


### PR DESCRIPTION
The widget to which the tooltip is attached is shown only if lossy compression is selected. Therefore, it makes absolutely no sense to write in the tooltip itself that it applies only to the lossy mode.