### PR TITLE
Fix flicker effect while module gets focus

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2278,8 +2278,17 @@ void dt_iop_request_focus(dt_iop_module_t *module)
   if(tags_filter)
   {
     dt_dev_pixelpipe_rebuild(dev);
-    // We don't want to use previous image as overlay to avoid some flicker if we have
-    // any active module in the pipe having an operation_tag excluded by combined tags_filter.
+    /*  We don't want to use previous image as overlay to avoid some flicker if we have
+        any active module in the pipe having an operation_tag excluded by combined tags_filter.
+        FIXME later as a reminder. We can either
+        a) leave out the following section; this leads to a flicker related to the pipes
+            writing onto the main canvas one ofter the other.
+        b) use the "set backbuf_zoom_x = 1000" trick in all cases. This currently
+            leads to a displacement flicker, easy to observe when getting retouch in-focus
+            without any active crop module.
+        c) only use the b) variant if there _is_ a module possibly processing what the
+            tags_filter switches on/off in the pixelpipe.
+    */
     for(GList *modules = dev->iop; modules; modules = g_list_next(modules))
     {
       const dt_iop_module_t *tmodule = (dt_iop_module_t *)modules->data;

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2273,14 +2273,23 @@ void dt_iop_request_focus(dt_iop_module_t *module)
      && darktable.view_manager->accels_window.sticky)
     dt_view_accels_refresh(darktable.view_manager);
 
-  if((out_focus_module && out_focus_module->operation_tags_filter())
-     || (module && module->operation_tags_filter()))
+  const int tags_filter = (out_focus_module ? out_focus_module->operation_tags_filter() : 0)
+                        | (module ? module->operation_tags_filter() : 0);
+  if(tags_filter)
   {
-    dt_dev_invalidate_all(dev);
     dt_dev_pixelpipe_rebuild(dev);
-    // don't use previous image as overlay
-    if(dev->full.pipe) dev->full.pipe->backbuf_zoom_x = 1000;
-    if(dev->preview2.pipe) dev->preview2.pipe->backbuf_zoom_x = 1000;
+    // We don't want to use previous image as overlay to avoid some flicker if we have
+    // any active module in the pipe having an operation_tag excluded by combined tags_filter.
+    for(GList *modules = dev->iop; modules; modules = g_list_next(modules))
+    {
+      const dt_iop_module_t *tmodule = (dt_iop_module_t *)modules->data;
+      if(tmodule->enabled && (tmodule->operation_tags() & tags_filter))
+      {
+        if(dev->full.pipe) dev->full.pipe->backbuf_zoom_x = 1000;
+        if(dev->preview2.pipe) dev->preview2.pipe->backbuf_zoom_x = 1000;
+        break;
+      }
+    }
   }
 
   // update guides button state

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -673,7 +673,11 @@ void expose(
     }
   }
 
-  _module_gui_post_expose(dev->proxy.rotate, cri, width, height, pzx, pzy, zoom_scale);
+  if(dev->proxy.rotate)
+  {
+    dt_print(DT_DEBUG_EXPOSE, "[darkroom expose] proxy rotate gui_post_expose [%s]\n", dev->proxy.rotate->op);
+    _module_gui_post_expose(dev->proxy.rotate, cri, width, height, pzx, pzy, zoom_scale);
+  }
 
   cairo_restore(cri);
 


### PR DESCRIPTION
Avoid the deflicker trick by checking for processed operation tags. Does not change the pixelpipe code in any way, only does the "trick" in required cases.

See for reference & discussion: #15331 #15306 #15290
Should fix #15324 #15286

1. If any of the focus_out or focus_in modules has a bit in `operation_tags_filter()` set we must call `dt_dev_pixelpipe_rebuild(dev)` to make sure pixelpipe gets information what modules / transformations will be required and processed accordingly.
2. The deflicker "trick" avoids using the preview output as overlay for smoother UI experience but introduces some minor displacement leading to a jitter effect.
3. Until now we did this even if there is no enabled module in the pixelpipe that would like us to use this trick.
4. Now we test all modules for such a requirement and only do so in that case.

5. Added debug info about proxy-rotate-gui_post_expose

@TurboGit and @dterrahe i think i got it. Could you test for both issues ...