### PR TITLE
control & jobs maintenance

### DIFF
--- a/src/control/control.h
+++ b/src/control/control.h
@@ -183,7 +183,7 @@ typedef struct dt_control_t
   double last_expose_time;
 
   // job management
-  int32_t running;
+  gboolean running;
   gboolean export_scheduled;
   dt_pthread_mutex_t queue_mutex, cond_mutex, run_mutex;
   pthread_cond_t cond;
@@ -250,27 +250,27 @@ void dt_control_cleanup(dt_control_t *s);
 void dt_control_quit();
 
 /** get threadsafe running state. */
-int dt_control_running();
+gboolean dt_control_running();
 
 // thread-safe interface between core and gui.
 // is the locking really needed?
 dt_imgid_t dt_control_get_mouse_over_id();
-void dt_control_set_mouse_over_id(dt_imgid_t value);
+void dt_control_set_mouse_over_id(const dt_imgid_t value);
 
 float dt_control_get_dev_zoom_x();
-void dt_control_set_dev_zoom_x(float value);
+void dt_control_set_dev_zoom_x(const float value);
 
 float dt_control_get_dev_zoom_y();
-void dt_control_set_dev_zoom_y(float value);
+void dt_control_set_dev_zoom_y(const float value);
 
 float dt_control_get_dev_zoom_scale();
-void dt_control_set_dev_zoom_scale(float value);
+void dt_control_set_dev_zoom_scale(const float value);
 
 int dt_control_get_dev_closeup();
-void dt_control_set_dev_closeup(int value);
+void dt_control_set_dev_closeup(const int value);
 
 dt_dev_zoom_t dt_control_get_dev_zoom();
-void dt_control_set_dev_zoom(dt_dev_zoom_t value);
+void dt_control_set_dev_zoom(const dt_dev_zoom_t value);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/control/jobs.h
+++ b/src/control/jobs.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2020 darktable developers.
+    Copyright (C) 2009-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -85,8 +85,8 @@ struct dt_control_t;
 void dt_control_jobs_init(struct dt_control_t *control);
 void dt_control_jobs_cleanup(struct dt_control_t *control);
 
-int dt_control_add_job(struct dt_control_t *control, dt_job_queue_t queue_id, dt_job_t *job);
-int32_t dt_control_add_job_res(struct dt_control_t *s, dt_job_t *job, int32_t res);
+gboolean dt_control_add_job(struct dt_control_t *control, dt_job_queue_t queue_id, dt_job_t *job);
+gboolean dt_control_add_job_res(struct dt_control_t *s, dt_job_t *job, int32_t res);
 
 int32_t dt_control_get_threadid();
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -230,7 +230,7 @@ float dt_dev_get_preview_downsampling()
 void dt_dev_process_image(dt_develop_t *dev)
 {
   if(!dev->gui_attached || dev->pipe->processing) return;
-  const int err
+  const gboolean err
       = dt_control_add_job_res(darktable.control,
                                dt_dev_process_image_job_create(dev), DT_CTL_WORKER_ZOOM_1);
   if(err) dt_print(DT_DEBUG_ALWAYS, "[dev_process_image] job queue exceeded!\n");
@@ -239,7 +239,7 @@ void dt_dev_process_image(dt_develop_t *dev)
 void dt_dev_process_preview(dt_develop_t *dev)
 {
   if(!dev->gui_attached) return;
-  const int err = dt_control_add_job_res(darktable.control,
+  const gboolean err = dt_control_add_job_res(darktable.control,
                                          dt_dev_process_preview_job_create(dev),
                                          DT_CTL_WORKER_ZOOM_FILL);
   if(err) dt_print(DT_DEBUG_ALWAYS, "[dev_process_preview] job queue exceeded!\n");
@@ -247,7 +247,7 @@ void dt_dev_process_preview(dt_develop_t *dev)
 
 void dt_dev_process_preview2(dt_develop_t *dev)
 {
-  const int err = dt_control_add_job_res(darktable.control,
+  const gboolean err = dt_control_add_job_res(darktable.control,
                                          dt_dev_process_preview2_job_create(dev),
                                          DT_CTL_WORKER_ZOOM_2);
   if(err) dt_print(DT_DEBUG_ALWAYS, "[dev_process_preview2] job queue exceeded!\n");


### PR DESCRIPTION
1. conversion various int types to gboolean where appropriate
2. come const added
3. a few float to double conversions while we want them for cairo stuff anyway
4. static functions with a leading underscore
5. some reformatting
6. explicit imgid struct and naming in a few cases
7. in some cases it's better to use dt_print_nts instead of dt_print()