### PR TITLE
[CI/CD] Unbreak nightly AppImage build env preparation by removing the non-installable openexr package

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -104,7 +104,6 @@ jobs:
             libheif-dev \
             libimath-dev \
             libjxl-dev \
-            libopenexr-dev \
             x11proto-dev \
             libxfixes-dev;
       - uses: actions/checkout@v4


### PR DESCRIPTION
The savoury1 PPA has dependency issues, so we have no other options at this time.