### PR TITLE
macOS: Set ninja as build generator for homebrew builds

### DIFF
--- a/packaging/macosx/2_build_hb_darktable_default.sh
+++ b/packaging/macosx/2_build_hb_darktable_default.sh
@@ -29,4 +29,4 @@ if [[ -d "$buildDir" ]]; then
 fi
 
 # Clean build here
-../../build.sh --install --build-type Release --prefix "$installDir" -- $options
+../../build.sh --install --build-generator Ninja --build-type Release --prefix "$installDir" -- $options


### PR DESCRIPTION
Set Ninja as default build generator for homebrew based builds to improve build performance.