### PR TITLE
imageio: OpenMP accelerate TIFF and JP2 export

### DIFF
--- a/src/imageio/format/j2k.c
+++ b/src/imageio/format/j2k.c
@@ -395,9 +395,15 @@ int write_image(dt_imageio_module_data_t *j2k_tmp, const char *filename, const v
 //        }
 //        break;
       case 12:
-        for(int i = 0; i < w * h; i++)
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(in, w, h, image, numcomps) \
+  schedule(simd:static) \
+  collapse(2)
+#endif
+        for(int i = 0; i < w * h; ++i)
         {
-          for(int k = 0; k < numcomps; k++)
+          for(int k = 0; k < numcomps; ++k)
             image->comps[k].data[i] = DOWNSAMPLE_FLOAT_TO_12BIT(in[i * 4 + k]);
         }
         break;

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -165,67 +165,85 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
    As there might be pipeline errors at the border we leave them alone.
    After these checks layers can be used later on.
 */
-  uint16_t layers = 3;  // default are rgb images
+  volatile uint16_t layers = 3;  // default are rgb images
 
-  if((d->global.height > 4) && (d->global.width > 4) && d->shortfile)
+  if(d->shortfile && (d->global.height > 4) && (d->global.width > 4))
   {
     layers = 1;    // let's now assume a grayscale
     if(d->bpp == 32 || (d->bpp == 16 && d->pixelformat))
     {
-      for(int y = 1; y < d->global.height-1; y++)
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(in_void, d) \
+  shared(layers) \
+  schedule(simd:static) \
+  collapse(2)
+#endif
+      for(int y = 1; y < d->global.height - 1; ++y)
       {
-        float *in = (float *)in_void + (size_t)4 * y * d->global.width;
-        for(int x = 1; x < d->global.width-1; x++, in += 4)
+        for(int x = 1; x < d->global.width - 1; ++x)
         {
-          if((fabsf(fmaxf(in[0], 0.001f) / fmaxf(in[1], 0.001f)) > 1.01f) ||
-             (fabsf(fmaxf(in[0], 0.001f) / fmaxf(in[2], 0.001f)) > 1.01f) ||
-             (fabsf(fmaxf(in[1], 0.001f) / fmaxf(in[2], 0.001f)) > 1.01f))
+          if(layers == 3) continue;
+          float *in = (float *)in_void + (size_t)(4 * (y * d->global.width + x));
+          if((fabsf(fmaxf(in[0], 0.001f) / fmaxf(in[1], 0.001f)) > 1.01f)
+             || (fabsf(fmaxf(in[0], 0.001f) / fmaxf(in[2], 0.001f)) > 1.01f)
+             || (fabsf(fmaxf(in[1], 0.001f) / fmaxf(in[2], 0.001f)) > 1.01f))
           {
             layers = 3;
-            goto checkdone;
           }
         }
       }
     }
     else if(d->bpp == 16 && !d->pixelformat)
     {
-      for(int y = 1; y < d->global.height-1; y++)
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(in_void, d) \
+  shared(layers) \
+  schedule(simd:static) \
+  collapse(2)
+#endif
+      for(int y = 1; y < d->global.height - 1; ++y)
       {
-        uint16_t *in = (uint16_t *)in_void + (size_t)4 * y * d->global.width;
-        for(int x = 1; x < d->global.width-1; x++, in += 4)
+        for(int x = 1; x < d->global.width - 1; ++x)
         {
-          if((abs(in[0] - in[1]) > 100) ||
-             (abs(in[0] - in[2]) > 100) ||
-             (abs(in[1] - in[2]) > 100))
+          if(layers == 3) continue;
+          uint16_t *in = (uint16_t *)in_void + (size_t)(4 * (y * d->global.width + x));
+          if((abs((int)in[0] - (int)in[1]) > 165) || (abs((int)in[0] - (int)in[2]) > 165)
+             || (abs((int)in[1] - (int)in[2]) > 165))
           {
             layers = 3;
-            goto checkdone;
           }
         }
       }
     }
     else // 8bpp
     {
-      for(int y = 1; y < d->global.height-1; y++)
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(in_void, d) \
+  shared(layers) \
+  schedule(simd:static) \
+  collapse(2)
+#endif
+      for(int y = 1; y < d->global.height - 1; ++y)
       {
-        uint8_t *in = (uint8_t *)in_void + (size_t)4 * y * d->global.width;
-        for(int x = 1; x < d->global.width-1; x++, in += 4)
+        for(int x = 1; x < d->global.width - 1; ++x)
         {
-          if((abs(in[0] - in[1]) > 5) ||
-             (abs(in[0] - in[2]) > 5) ||
-             (abs(in[1] - in[2]) > 5))
+          if(layers == 3) continue;
+          uint8_t *in = (uint8_t *)in_void + (size_t)(4 * (y * d->global.width + x));
+          if((abs((int)in[0] - (int)in[1]) > 2) || (abs((int)in[0] - (int)in[2]) > 2)
+             || (abs((int)in[1] - (int)in[2]) > 2))
           {
             layers = 3;
-            goto checkdone;
           }
         }
       }
     }
   }
 
-  checkdone:
-  if(layers == 1)
-    dt_control_log(_("will export as a grayscale image"));
+  if(d->shortfile && layers == 3)
+    dt_control_log(_("not a b&w image, will not export as grayscale"));
 
   TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, layers);
   TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, (uint16_t)d->bpp);


### PR DESCRIPTION
Includes some TIFF B&W detection threshold changes to approx 1pc (marginally related to https://github.com/darktable-org/darktable/issues/9266)