### PR TITLE
RFC: Extend preference "create sidecar files: after edit"

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -298,7 +298,7 @@
     </type>
     <default>on import</default>
     <shortdescription>create sidecar files</shortdescription>
-    <longdescription>the sidecar files hold information about all your development steps to allow flawless re-importing of image files.\n\ndepending on the selected mode sidecar files will be created:\n - 'never'\n - 'on import': immediately after importing the image\n - 'after edit': after any user change on the image.</longdescription>
+    <longdescription>the sidecar files hold information about all your development steps to allow flawless re-importing of image files.\n\ndepending on the selected mode sidecar files will be created:\n - 'never'\n - 'on import': immediately after importing the image\n - 'after edit': after any user change on the image or adding tags.</longdescription>
   </dtconfig>
   <dtconfig prefs="storage" section="XMP">
     <name>compress_xmp_tags</name>

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -2711,6 +2711,15 @@ int dt_image_local_copy_reset(const dt_imgid_t imgid)
 // *******************************************************
 // xmp stuff
 // *******************************************************
+static gboolean _any_altered_data(const dt_imgid_t imgid)
+{
+  if(dt_image_altered(imgid))
+    return TRUE;
+
+  const uint32_t tags = dt_tag_count_attached(imgid, TRUE);
+
+  return (tags > 0);
+}
 
 gboolean dt_image_write_sidecar_file(const dt_imgid_t imgid)
 {
@@ -2740,7 +2749,7 @@ gboolean dt_image_write_sidecar_file(const dt_imgid_t imgid)
 
   // the sidecar is written only if required
   if((xmp_mode == DT_WRITE_XMP_ALWAYS)
-     || ((xmp_mode == DT_WRITE_XMP_LAZY) && dt_image_altered(imgid)))
+     || ((xmp_mode == DT_WRITE_XMP_LAZY) && _any_altered_data(imgid)))
   {
     dt_image_path_append_version(imgid, filename, sizeof(filename));
     g_strlcat(filename, ".xmp", sizeof(filename));


### PR DESCRIPTION
There have been user requests about this and for me the idea

"Adding a tag to an image should be understood as an edit action too"

seems valid. I would propose to expand the understanding of this setting instead of introducing another option "after edit or tagging"

See #15330 #14913 but there are others ... 