### PR TITLE
[CI/CD] Bring back the temporarily removed libopenexr-dev for the AppImage build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -103,6 +103,7 @@ jobs:
             libgphoto2-dev \
             libheif-dev \
             libimath-dev \
+            libopenexr-dev \
             libjxl-dev \
             x11proto-dev \
             libxfixes-dev;


### PR DESCRIPTION
The check shows that the dependency problem has been fixed and this package is now installable again.
