### PR TITLE
Fix line-breaks in metadata description field

### DIFF
--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -327,12 +327,7 @@ static gboolean _key_pressed(GtkWidget *textview,
   {
     case GDK_KEY_Return:
     case GDK_KEY_KP_Enter:
-      if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
-      {
-        // insert new line
-        event->state &= ~GDK_CONTROL_MASK;  //TODO: on Mac, remap Ctrl to Cmd key
-      }
-      else
+      if(!dt_modifier_is(event->state, GDK_CONTROL_MASK))
       {
         gtk_button_clicked(GTK_BUTTON(d->apply_button));
         return TRUE;


### PR DESCRIPTION
Manual handling of CTRL+Enter keystrokes in meta-data description field is not necesary anymore in new gtk versions and even causes issues on ubuntu 22.04 using gtk3 version 3.24.33, see ticket https://github.com/darktable-org/darktable/issues/14877.
Removing it solves the issue and enables CTRL+Enter keystrokes again. Also gtk seems to handle CTRL+Enter as newline as can be experienced in the  big css textview. 

Some background and explanation from @dterrahe in issue I created (https://github.com/darktable-org/darktable/issues/14877#issuecomment-1669477084)
> Normally, when typing an enter into a textview, the widget key handler inserts a new line. However, for the metadata fields we want enter to commit all the changes, so that's what the else of the dt_modifier_is(event->state, GDK_CONTROL_MASK) test does. To still enable newlines, we also check for ctrl+enter which we then want to be handled by the textview as if it was a normal enter (hence, insert a new line). If I now type an enter or ctrl+enter in any other textview, they do the same thing, but it seems that sometime in the past ctrl+enter would not work, so the ctrl needed to be stripped off the event before letting it be filtered by the IMContext and (if that doesn't fully deal with it) be handled by the widget event handler by returning FALSE. That's what the event->state &= ~GDK_CONTROL_MASK; does. It might not be needed as, since I said above, these days it seems that textviews accept enter and ctrl+enter interchangeably as a new line. 

Fixes https://github.com/darktable-org/darktable/issues/14877