### PR TITLE
Some fixes of '--version' code and output

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -641,7 +641,7 @@ static char *_get_version_string(void)
 char *version = g_strdup_printf("darktable %s\nCopyright (C) 2012-%s Johannes Hanika and other contributors.\n\n"
                "Compile options:\n"
                "  Bit depth              -> %zu bit\n"
-               "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n"
+               "%s%s%s\n"
                "See %s for detailed documentation.\n"
                "See %s to report bugs.\n",
                darktable_package_version,
@@ -649,27 +649,27 @@ char *version = g_strdup_printf("darktable %s\nCopyright (C) 2012-%s Johannes Ha
                CHAR_BIT * sizeof(void *),
 
 #ifdef _DEBUG
-               "  Debug                  -> ENABLED\n",
+               "  Debug                  -> ENABLED\n"
 #else
-               "  Debug                  -> DISABLED\n",
+               "  Debug                  -> DISABLED\n"
 #endif
 
 #if defined(__SSE2__) && defined(__SSE__)
-               "  SSE2 optimizations     -> ENABLED\n",
+               "  SSE2 optimizations     -> ENABLED\n"
 #else
-               "  SSE2 optimizations     -> DISABLED\n",
+               "  SSE2 optimizations     -> DISABLED\n"
 #endif
 
 #ifdef _OPENMP
-               "  OpenMP                 -> ENABLED\n",
+               "  OpenMP                 -> ENABLED\n"
 #else
-               "  OpenMP                 -> DISABLED\n",
+               "  OpenMP                 -> DISABLED\n"
 #endif
 
 #ifdef HAVE_OPENCL
-               "  OpenCL                 -> ENABLED\n",
+               "  OpenCL                 -> ENABLED\n"
 #else
-               "  OpenCL                 -> DISABLED\n",
+               "  OpenCL                 -> DISABLED\n"
 #endif
 
 #ifdef USE_LUA
@@ -679,63 +679,63 @@ char *version = g_strdup_printf("darktable %s\nCopyright (C) 2012-%s Johannes Ha
 #endif
 
 #ifdef USE_COLORDGTK
-               "  Colord                 -> ENABLED\n",
+               "  Colord                 -> ENABLED\n"
 #else
-               "  Colord                 -> DISABLED\n",
+               "  Colord                 -> DISABLED\n"
 #endif
 
 #ifdef HAVE_GPHOTO2
-               "  gPhoto2                -> ENABLED\n",
+               "  gPhoto2                -> ENABLED\n"
 #else
-               "  gPhoto2                -> DISABLED\n",
+               "  gPhoto2                -> DISABLED\n"
 #endif
 
 #ifdef HAVE_GMIC
-               "  GMIC                   -> ENABLED  - Compressed LUTs supported\n",
+               "  GMIC                   -> ENABLED  - Compressed LUTs supported\n"
 #else
-               "  GMIC                   -> DISABLED - Compressed LUTs NOT supported\n",
+               "  GMIC                   -> DISABLED - Compressed LUTs NOT supported\n"
 #endif
 
 #ifdef HAVE_GRAPHICSMAGICK
-               "  GraphicsMagick         -> ENABLED\n",
+               "  GraphicsMagick         -> ENABLED\n"
 #else
-               "  GraphicsMagick         -> DISABLED\n",
+               "  GraphicsMagick         -> DISABLED\n"
 #endif
 
 #ifdef HAVE_IMAGEMAGICK
-               "  ImageMagick            -> ENABLED\n",
+               "  ImageMagick            -> ENABLED\n"
 #else 
-               "  ImageMagick            -> DISABLED\n",
+               "  ImageMagick            -> DISABLED\n"
 #endif
 
 #ifdef HAVE_LIBAVIF
-               "  libavif                -> ENABLED\n",
+               "  libavif                -> ENABLED\n"
 #else
-               "  libavif                -> DISABLED\n",
+               "  libavif                -> DISABLED\n"
 #endif
 
 #ifdef HAVE_LIBHEIF
-               "  libheif                -> ENABLED\n",
+               "  libheif                -> ENABLED\n"
 #else
-               "  libheif                -> DISABLED\n",
+               "  libheif                -> DISABLED\n"
 #endif
 
 #ifdef HAVE_LIBJXL
-               "  libjxl                 -> ENABLED\n",
+               "  libjxl                 -> ENABLED\n"
 #else
-               "  libjxl                 -> DISABLED\n",
+               "  libjxl                 -> DISABLED\n"
 #endif
 
 #ifdef HAVE_OPENJPEG
-               "  OpenJPEG               -> ENABLED\n",
+               "  OpenJPEG               -> ENABLED\n"
 #else
-               "  OpenJPEG               -> DISABLED\n",
+               "  OpenJPEG               -> DISABLED\n"
 #endif
 
 #ifdef HAVE_OPENEXR
-               "  OpenEXR                -> ENABLED\n",
+               "  OpenEXR                -> ENABLED\n"
 #else
-               "  OpenEXR                -> DISABLED\n",
+               "  OpenEXR                -> DISABLED\n"
 #endif
 
 #ifdef HAVE_WEBP

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -675,7 +675,7 @@ char *version = g_strdup_printf("darktable %s\nCopyright (C) 2012-%s Johannes Ha
 #ifdef USE_LUA
                "  Lua                    -> ENABLED  - API version ", lua_api_version,
 #else
-               "  Lua                    -> DISABLED - API version", "NOT AVAILABLE",
+               "  Lua                    -> DISABLED - API version ", "NOT AVAILABLE",
 #endif
 
 #ifdef USE_COLORDGTK


### PR DESCRIPTION
- Reduced the number of `%s` formats to simplify the code and its possible changes and increase the readability of the code
- Fixed missing space in `--version` text in case of disabled Lua
