### PR TITLE
po/collect sorting - full rework of the collect display/sorting/order

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -755,11 +755,11 @@
     <name>plugins/collect/filmroll_sort</name>
     <type>
       <enum>
-        <option>id</option>
-        <option>folder</option>
+        <option>chronological</option>
+        <option>folder name</option>
       </enum>
     </type>
-    <default>id</default>
+    <default>chronological</default>
     <shortdescription>sort film rolls by</shortdescription>
     <longdescription>sets the collections-list order for film rolls</longdescription>
   </dtconfig>

--- a/po/darktable.pot
+++ b/po/darktable.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-09 13:19+0200\n"
+"POT-Creation-Date: 2023-10-09 20:33+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -121,12 +121,12 @@ msgstr ""
 
 #: ../build/bin/conf_gen.h:761 ../build/bin/preferences_gen.h:8144
 msgctxt "preferences"
-msgid "id"
+msgid "chronological"
 msgstr ""
 
 #: ../build/bin/conf_gen.h:762
 msgctxt "preferences"
-msgid "folder"
+msgid "folder name"
 msgstr ""
 
 #: ../build/bin/conf_gen.h:776
@@ -2194,7 +2194,7 @@ msgstr ""
 #: ../src/gui/guides.c:712 ../src/iop/basecurve.c:2214
 #: ../src/iop/channelmixerrgb.c:4695 ../src/iop/clipping.c:1941
 #: ../src/iop/clipping.c:2134 ../src/iop/clipping.c:2149
-#: ../src/iop/retouch.c:507 ../src/libs/collect.c:1914
+#: ../src/iop/retouch.c:507 ../src/libs/collect.c:2043
 #: ../src/libs/colorpicker.c:51 ../src/libs/export.c:1101
 #: ../src/libs/filters/module_order.c:158 ../src/libs/histogram.c:132
 #: ../src/libs/live_view.c:311 ../src/libs/print_settings.c:2835
@@ -2506,7 +2506,7 @@ msgstr ""
 #: ../src/iop/channelmixer.c:637 ../src/iop/channelmixer.c:647
 #: ../src/iop/channelmixerrgb.c:4637 ../src/iop/colorzones.c:2499
 #: ../src/iop/temperature.c:1946 ../src/iop/temperature.c:2141
-#: ../src/libs/collect.c:1797 ../src/libs/filters/colors.c:260
+#: ../src/libs/collect.c:1916 ../src/libs/filters/colors.c:260
 #: ../src/libs/histogram.c:2689
 msgid "red"
 msgstr ""
@@ -2519,7 +2519,7 @@ msgstr ""
 #: ../src/iop/channelmixer.c:638 ../src/iop/channelmixer.c:653
 #: ../src/iop/channelmixerrgb.c:4638 ../src/iop/colorzones.c:2502
 #: ../src/iop/temperature.c:1930 ../src/iop/temperature.c:1948
-#: ../src/iop/temperature.c:2142 ../src/libs/collect.c:1797
+#: ../src/iop/temperature.c:2142 ../src/libs/collect.c:1916
 #: ../src/libs/filters/colors.c:262 ../src/libs/histogram.c:2680
 msgid "green"
 msgstr ""
@@ -2532,7 +2532,7 @@ msgstr ""
 #: ../src/iop/channelmixer.c:639 ../src/iop/channelmixer.c:659
 #: ../src/iop/channelmixerrgb.c:4639 ../src/iop/colorzones.c:2504
 #: ../src/iop/temperature.c:1950 ../src/iop/temperature.c:2143
-#: ../src/libs/collect.c:1797 ../src/libs/filters/colors.c:263
+#: ../src/libs/collect.c:1916 ../src/libs/filters/colors.c:263
 #: ../src/libs/histogram.c:2671
 msgid "blue"
 msgstr ""
@@ -3247,7 +3247,7 @@ msgstr ""
 
 #. history
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:232
-#: ../src/common/collection.c:1394 ../src/libs/collect.c:1751
+#: ../src/common/collection.c:1394 ../src/libs/collect.c:1863
 #: ../src/libs/filters/history.c:38
 msgid "basic"
 msgstr ""
@@ -4035,7 +4035,7 @@ msgstr ""
 #: ../src/dtgtk/range.c:1763 ../src/gui/accelerators.c:2526
 #: ../src/gui/accelerators.c:2606 ../src/gui/gtk.c:1315 ../src/gui/gtk.c:3229
 #: ../src/imageio/format/pdf.c:645 ../src/iop/denoiseprofile.c:3713
-#: ../src/iop/rawdenoise.c:909 ../src/libs/collect.c:3075
+#: ../src/iop/rawdenoise.c:909 ../src/libs/collect.c:3413
 #: ../src/libs/filtering.c:1521 ../src/libs/filters/colors.c:157
 #: ../src/libs/filters/colors.c:265 ../src/libs/filters/rating.c:211
 msgid "all"
@@ -4883,7 +4883,7 @@ msgstr ""
 #: ../src/gui/presets.c:565 ../src/gui/styles_dialog.c:526
 #: ../src/imageio/storage/disk.c:198 ../src/imageio/storage/gallery.c:150
 #: ../src/imageio/storage/latex.c:146 ../src/iop/lut3d.c:1560
-#: ../src/libs/collect.c:408 ../src/libs/collect.c:2923
+#: ../src/libs/collect.c:425 ../src/libs/collect.c:3242
 #: ../src/libs/copy_history.c:115 ../src/libs/export_metadata.c:276
 #: ../src/libs/geotagging.c:929 ../src/libs/import.c:1510
 #: ../src/libs/import.c:1614 ../src/libs/import.c:1706
@@ -4899,7 +4899,7 @@ msgid "_cancel"
 msgstr ""
 
 #: ../src/chart/main.c:504 ../src/gui/preferences.c:1081
-#: ../src/gui/styles_dialog.c:527 ../src/libs/collect.c:2924
+#: ../src/gui/styles_dialog.c:527 ../src/libs/collect.c:3243
 #: ../src/libs/export_metadata.c:277 ../src/libs/metadata.c:468
 #: ../src/libs/metadata_view.c:1207 ../src/libs/recentcollect.c:229
 #: ../src/libs/styles.c:392 ../src/libs/tagging.c:1667
@@ -5117,7 +5117,7 @@ msgstr ""
 msgid "print time"
 msgstr ""
 
-#: ../src/common/collection.c:621 ../src/libs/collect.c:3231
+#: ../src/common/collection.c:621 ../src/libs/collect.c:3586
 #: ../src/libs/filtering.c:2237 ../src/libs/filtering.c:2257
 #: ../src/libs/filters/history.c:153 ../src/libs/history.c:92
 msgid "history"
@@ -5192,34 +5192,34 @@ msgstr ""
 #: ../src/common/collection.c:1376 ../src/common/colorlabels.c:334
 #: ../src/develop/lightroom.c:836 ../src/gui/guides.c:732
 #: ../src/iop/colorzones.c:2501 ../src/iop/temperature.c:1936
-#: ../src/libs/collect.c:1797 ../src/libs/filters/colors.c:261
+#: ../src/libs/collect.c:1916 ../src/libs/filters/colors.c:261
 msgid "yellow"
 msgstr ""
 
 #: ../src/common/collection.c:1382 ../src/common/color_vocabulary.c:339
 #: ../src/common/colorlabels.c:337 ../src/iop/colorzones.c:2505
-#: ../src/libs/collect.c:1797 ../src/libs/filters/colors.c:264
+#: ../src/libs/collect.c:1916 ../src/libs/filters/colors.c:264
 msgid "purple"
 msgstr ""
 
-#: ../src/common/collection.c:1400 ../src/libs/collect.c:1751
+#: ../src/common/collection.c:1400 ../src/libs/collect.c:1863
 #: ../src/libs/filters/history.c:38
 msgid "auto applied"
 msgstr ""
 
-#: ../src/common/collection.c:1406 ../src/libs/collect.c:1751
+#: ../src/common/collection.c:1406 ../src/libs/collect.c:1863
 #: ../src/libs/filters/history.c:38
 msgid "altered"
 msgstr ""
 
 #: ../src/common/collection.c:1424 ../src/common/collection.c:1535
-#: ../src/libs/collect.c:1169 ../src/libs/collect.c:1333
-#: ../src/libs/collect.c:1357 ../src/libs/collect.c:1476
-#: ../src/libs/collect.c:2440
+#: ../src/libs/collect.c:1242 ../src/libs/collect.c:1426
+#: ../src/libs/collect.c:1452 ../src/libs/collect.c:1592
+#: ../src/libs/collect.c:2662
 msgid "not tagged"
 msgstr ""
 
-#: ../src/common/collection.c:1425 ../src/libs/collect.c:1357
+#: ../src/common/collection.c:1425 ../src/libs/collect.c:1452
 #: ../src/libs/map_locations.c:742
 msgid "tagged"
 msgstr ""
@@ -5229,27 +5229,33 @@ msgid "tagged*"
 msgstr ""
 
 #. local copy
-#: ../src/common/collection.c:1460 ../src/libs/collect.c:1765
+#: ../src/common/collection.c:1460 ../src/libs/collect.c:1883
 #: ../src/libs/filters/local_copy.c:38
 msgid "not copied locally"
 msgstr ""
 
-#: ../src/common/collection.c:1465 ../src/libs/collect.c:1765
+#: ../src/common/collection.c:1465 ../src/libs/collect.c:1882
 #: ../src/libs/filters/local_copy.c:38
 msgid "copied locally"
 msgstr ""
 
-#: ../src/common/collection.c:1905 ../src/libs/collect.c:1886
+#. if its undefined
+#: ../src/common/collection.c:1507 ../src/common/collection.c:1619
+#: ../src/libs/collect.c:2209 ../src/libs/collect.c:2210
+msgid "unnamed"
+msgstr ""
+
+#: ../src/common/collection.c:1905 ../src/libs/collect.c:2013
 #: ../src/libs/filters/grouping.c:147 ../src/libs/filters/grouping.c:170
 msgid "group leaders"
 msgstr ""
 
-#: ../src/common/collection.c:1909 ../src/libs/collect.c:1886
+#: ../src/common/collection.c:1909 ../src/libs/collect.c:2013
 #: ../src/libs/filters/grouping.c:150 ../src/libs/filters/grouping.c:170
 msgid "group followers"
 msgstr ""
 
-#: ../src/common/collection.c:2066 ../src/libs/collect.c:1967
+#: ../src/common/collection.c:2066 ../src/libs/collect.c:2100
 msgid "not defined"
 msgstr ""
 
@@ -10603,7 +10609,7 @@ msgstr ""
 msgid "select preset(s) to import"
 msgstr ""
 
-#: ../src/gui/preferences.c:1042 ../src/libs/collect.c:408
+#: ../src/gui/preferences.c:1042 ../src/libs/collect.c:425
 #: ../src/libs/copy_history.c:115 ../src/libs/geotagging.c:930
 #: ../src/libs/import.c:1510 ../src/libs/import.c:1614 ../src/libs/styles.c:529
 msgid "_open"
@@ -18979,54 +18985,67 @@ msgstr ""
 msgid "WB"
 msgstr ""
 
-#: ../src/libs/collect.c:151
+#: ../src/libs/collect.c:164
 msgid "collections"
 msgstr ""
 
-#: ../src/libs/collect.c:407
+#: ../src/libs/collect.c:424
 msgid "search filmroll"
 msgstr ""
 
-#: ../src/libs/collect.c:490
+#: ../src/libs/collect.c:507
 #, c-format
 msgid "problem selecting new path for the filmroll in %s"
 msgstr ""
 
-#: ../src/libs/collect.c:555
+#: ../src/libs/collect.c:579
 msgid "search filmroll..."
 msgstr ""
 
-#: ../src/libs/collect.c:559
+#: ../src/libs/collect.c:584
 msgid "remove..."
 msgstr ""
 
-#: ../src/libs/collect.c:1228
+#: ../src/libs/collect.c:1310
 msgid "uncategorized"
 msgstr ""
 
-#: ../src/libs/collect.c:2146
+#: ../src/libs/collect.c:2172 ../src/libs/filters/rating_range.c:99
+#: ../src/libs/filters/rating_range.c:126
+#: ../src/libs/filters/rating_range.c:131
+#: ../src/libs/filters/rating_range.c:275
+msgid "rejected"
+msgstr ""
+
+#: ../src/libs/collect.c:2175 ../src/libs/filters/rating_range.c:101
+#: ../src/libs/filters/rating_range.c:126
+#: ../src/libs/filters/rating_range.c:276
+msgid "not rated"
+msgstr ""
+
+#: ../src/libs/collect.c:2359
 msgid "use <, <=, >, >=, <>, =, [;] as operators"
 msgstr ""
 
-#: ../src/libs/collect.c:2150
+#: ../src/libs/collect.c:2363
 msgid ""
 "use <, <=, >, >=, <>, =, [;] as operators\n"
 "star rating: 0-5\n"
 "rejected images: -1"
 msgstr ""
 
-#: ../src/libs/collect.c:2157
+#: ../src/libs/collect.c:2371
 msgid ""
 "use <, <=, >, >=, <>, =, [;] as operators\n"
 "type dates in the form: YYYY:MM:DD hh:mm:ss.sss (only the year is mandatory)"
 msgstr ""
 
-#: ../src/libs/collect.c:2164
+#: ../src/libs/collect.c:2378
 #, no-c-format
 msgid "use `%' as wildcard and `,' to separate values"
 msgstr ""
 
-#: ../src/libs/collect.c:2170
+#: ../src/libs/collect.c:2385
 #, no-c-format
 msgid ""
 "use `%' as wildcard\n"
@@ -19035,7 +19054,7 @@ msgid ""
 "ctrl+click to include only sub-hierarchies (suffix `|%')"
 msgstr ""
 
-#: ../src/libs/collect.c:2182
+#: ../src/libs/collect.c:2398
 #, no-c-format
 msgid ""
 "use `%' as wildcard\n"
@@ -19044,7 +19063,7 @@ msgid ""
 "ctrl+click to include only sub-locations (suffix `|%')"
 msgstr ""
 
-#: ../src/libs/collect.c:2194
+#: ../src/libs/collect.c:2411
 #, no-c-format
 msgid ""
 "use `%' as wildcard\n"
@@ -19053,52 +19072,52 @@ msgid ""
 "ctrl+click to include only sub-folders (suffix `|%')"
 msgstr ""
 
-#: ../src/libs/collect.c:2205
+#: ../src/libs/collect.c:2422
 #, no-c-format
 msgid "use `%' as wildcard"
 msgstr ""
 
-#: ../src/libs/collect.c:2271 ../src/libs/collect.c:2285
-#: ../src/libs/collect.c:2808
+#: ../src/libs/collect.c:2488 ../src/libs/collect.c:2502
+#: ../src/libs/collect.c:3111
 msgid "clear this rule"
 msgstr ""
 
-#: ../src/libs/collect.c:2275
+#: ../src/libs/collect.c:2492
 msgid "clear this rule or add new rules"
 msgstr ""
 
-#: ../src/libs/collect.c:2814
+#: ../src/libs/collect.c:3117
 msgid "narrow down search"
 msgstr ""
 
-#: ../src/libs/collect.c:2819
+#: ../src/libs/collect.c:3124
 msgid "add more images"
 msgstr ""
 
-#: ../src/libs/collect.c:2824
+#: ../src/libs/collect.c:3131
 msgid "exclude images"
 msgstr ""
 
-#: ../src/libs/collect.c:2831
+#: ../src/libs/collect.c:3140
 msgid "change to: and"
 msgstr ""
 
-#: ../src/libs/collect.c:2836
+#: ../src/libs/collect.c:3147
 msgid "change to: or"
 msgstr ""
 
-#: ../src/libs/collect.c:2841
+#: ../src/libs/collect.c:3154
 msgid "change to: except"
 msgstr ""
 
 #. the different categories
-#: ../src/libs/collect.c:2867 ../src/libs/filtering.c:883
+#: ../src/libs/collect.c:3184 ../src/libs/filtering.c:883
 #: ../src/libs/filtering.c:950 ../src/libs/filtering.c:1620
 #: ../src/libs/filtering.c:1964
 msgid "files"
 msgstr ""
 
-#: ../src/libs/collect.c:2872 ../src/libs/export_metadata.c:301
+#: ../src/libs/collect.c:3189 ../src/libs/export_metadata.c:301
 #: ../src/libs/filtering.c:888 ../src/libs/filtering.c:955
 #: ../src/libs/filtering.c:1628 ../src/libs/filtering.c:1968
 #: ../src/libs/image.c:494 ../src/libs/image.c:632 ../src/libs/image.c:644
@@ -19106,50 +19125,50 @@ msgstr ""
 msgid "metadata"
 msgstr ""
 
-#: ../src/libs/collect.c:2891 ../src/libs/filtering.c:909
+#: ../src/libs/collect.c:3208 ../src/libs/filtering.c:909
 #: ../src/libs/filtering.c:976 ../src/libs/filtering.c:1966
 msgid "times"
 msgstr ""
 
-#: ../src/libs/collect.c:2899 ../src/libs/filtering.c:917
+#: ../src/libs/collect.c:3216 ../src/libs/filtering.c:917
 #: ../src/libs/filtering.c:984 ../src/libs/filtering.c:1652
 msgid "capture details"
 msgstr ""
 
-#: ../src/libs/collect.c:2908 ../src/libs/filtering.c:926
+#: ../src/libs/collect.c:3225 ../src/libs/filtering.c:926
 #: ../src/libs/filtering.c:993 ../src/libs/filtering.c:1664
 #: ../src/libs/filtering.c:1970 ../src/libs/tools/darktable.c:61
 msgid "darktable"
 msgstr ""
 
-#: ../src/libs/collect.c:2921
+#: ../src/libs/collect.c:3240
 msgid "collections settings"
 msgstr ""
 
-#: ../src/libs/collect.c:2945 ../src/libs/export.c:1126
+#: ../src/libs/collect.c:3267 ../src/libs/export.c:1126
 #: ../src/libs/metadata.c:620 ../src/libs/metadata_view.c:1323
 #: ../src/libs/recentcollect.c:295 ../src/libs/tagging.c:3522
 msgid "preferences..."
 msgstr ""
 
-#: ../src/libs/collect.c:3050 ../src/libs/filtering.c:1494
+#: ../src/libs/collect.c:3388 ../src/libs/filtering.c:1494
 msgid "AND"
 msgstr ""
 
-#: ../src/libs/collect.c:3055 ../src/libs/filtering.c:1499
+#: ../src/libs/collect.c:3393 ../src/libs/filtering.c:1499
 msgid "OR"
 msgstr ""
 
 #. case DT_LIB_COLLECT_MODE_AND_NOT:
-#: ../src/libs/collect.c:3060 ../src/libs/filtering.c:1504
+#: ../src/libs/collect.c:3398 ../src/libs/filtering.c:1504
 msgid "BUT NOT"
 msgstr ""
 
-#: ../src/libs/collect.c:3232 ../src/libs/filtering.c:2238
+#: ../src/libs/collect.c:3588 ../src/libs/filtering.c:2238
 msgid "revert to a previous set of rules"
 msgstr ""
 
-#: ../src/libs/collect.c:3289
+#: ../src/libs/collect.c:3671
 msgid "jump back to previous collection"
 msgstr ""
 
@@ -20001,18 +20020,6 @@ msgstr ""
 
 #: ../src/libs/filters/rating_range.c:61 ../src/libs/filters/rating_range.c:76
 msgid "not rated only"
-msgstr ""
-
-#: ../src/libs/filters/rating_range.c:99 ../src/libs/filters/rating_range.c:126
-#: ../src/libs/filters/rating_range.c:131
-#: ../src/libs/filters/rating_range.c:275
-msgid "rejected"
-msgstr ""
-
-#: ../src/libs/filters/rating_range.c:101
-#: ../src/libs/filters/rating_range.c:126
-#: ../src/libs/filters/rating_range.c:276
-msgid "not rated"
 msgstr ""
 
 #: ../src/libs/filters/rating_range.c:117

--- a/po/fr.po
+++ b/po/fr.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: darktable 3.9\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-09 13:19+0200\n"
-"PO-Revision-Date: 2023-10-09 13:25+0200\n"
+"POT-Creation-Date: 2023-10-09 20:33+0200\n"
+"PO-Revision-Date: 2023-10-09 20:33+0200\n"
 "Last-Translator: Pascal Obry <pascal@obry.net>\n"
 "Language-Team: \n"
 "Language: fr_FR\n"
@@ -11,7 +11,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.3.2\n"
+"X-Generator: Poedit 3.4\n"
 
 #: ../build/bin/conf_gen.h:174
 msgctxt "preferences"
@@ -117,13 +117,13 @@ msgstr "GPU très rapide"
 
 #: ../build/bin/conf_gen.h:761 ../build/bin/preferences_gen.h:8144
 msgctxt "preferences"
-msgid "id"
-msgstr "Numéro"
+msgid "chronological"
+msgstr "Chronologique"
 
 #: ../build/bin/conf_gen.h:762
 msgctxt "preferences"
-msgid "folder"
-msgstr "Dossier"
+msgid "folder name"
+msgstr "Nom de dossier"
 
 #: ../build/bin/conf_gen.h:776
 msgctxt "preferences"
@@ -2491,7 +2491,7 @@ msgstr "Préserver les couleurs"
 #: ../src/gui/guides.c:712 ../src/iop/basecurve.c:2214
 #: ../src/iop/channelmixerrgb.c:4695 ../src/iop/clipping.c:1941
 #: ../src/iop/clipping.c:2134 ../src/iop/clipping.c:2149
-#: ../src/iop/retouch.c:507 ../src/libs/collect.c:1914
+#: ../src/iop/retouch.c:507 ../src/libs/collect.c:2043
 #: ../src/libs/colorpicker.c:51 ../src/libs/export.c:1101
 #: ../src/libs/filters/module_order.c:158 ../src/libs/histogram.c:132
 #: ../src/libs/live_view.c:311 ../src/libs/print_settings.c:2835
@@ -2803,7 +2803,7 @@ msgstr "Aberrations chromatiques importantes"
 #: ../src/iop/channelmixer.c:637 ../src/iop/channelmixer.c:647
 #: ../src/iop/channelmixerrgb.c:4637 ../src/iop/colorzones.c:2499
 #: ../src/iop/temperature.c:1946 ../src/iop/temperature.c:2141
-#: ../src/libs/collect.c:1797 ../src/libs/filters/colors.c:260
+#: ../src/libs/collect.c:1916 ../src/libs/filters/colors.c:260
 #: ../src/libs/histogram.c:2689
 msgid "red"
 msgstr "Rouge"
@@ -2816,7 +2816,7 @@ msgstr "Rouge"
 #: ../src/iop/channelmixer.c:638 ../src/iop/channelmixer.c:653
 #: ../src/iop/channelmixerrgb.c:4638 ../src/iop/colorzones.c:2502
 #: ../src/iop/temperature.c:1930 ../src/iop/temperature.c:1948
-#: ../src/iop/temperature.c:2142 ../src/libs/collect.c:1797
+#: ../src/iop/temperature.c:2142 ../src/libs/collect.c:1916
 #: ../src/libs/filters/colors.c:262 ../src/libs/histogram.c:2680
 msgid "green"
 msgstr "Vert"
@@ -2829,7 +2829,7 @@ msgstr "Vert"
 #: ../src/iop/channelmixer.c:639 ../src/iop/channelmixer.c:659
 #: ../src/iop/channelmixerrgb.c:4639 ../src/iop/colorzones.c:2504
 #: ../src/iop/temperature.c:1950 ../src/iop/temperature.c:2143
-#: ../src/libs/collect.c:1797 ../src/libs/filters/colors.c:263
+#: ../src/libs/collect.c:1916 ../src/libs/filters/colors.c:263
 #: ../src/libs/histogram.c:2671
 msgid "blue"
 msgstr "Bleu"
@@ -3546,7 +3546,7 @@ msgstr "Markesteijn 3 passes + VNG"
 
 #. history
 #: ../build/lib/darktable/plugins/introspection_demosaic.c:232
-#: ../src/common/collection.c:1394 ../src/libs/collect.c:1751
+#: ../src/common/collection.c:1394 ../src/libs/collect.c:1863
 #: ../src/libs/filters/history.c:38
 msgid "basic"
 msgstr "Basique"
@@ -4334,7 +4334,7 @@ msgstr "Vignettage manuel seulement"
 #: ../src/dtgtk/range.c:1763 ../src/gui/accelerators.c:2526
 #: ../src/gui/accelerators.c:2606 ../src/gui/gtk.c:1315 ../src/gui/gtk.c:3229
 #: ../src/imageio/format/pdf.c:645 ../src/iop/denoiseprofile.c:3713
-#: ../src/iop/rawdenoise.c:909 ../src/libs/collect.c:3075
+#: ../src/iop/rawdenoise.c:909 ../src/libs/collect.c:3413
 #: ../src/libs/filtering.c:1521 ../src/libs/filters/colors.c:157
 #: ../src/libs/filters/colors.c:265 ../src/libs/filters/rating.c:211
 msgid "all"
@@ -5190,7 +5190,7 @@ msgstr "Menu déroulant"
 #: ../src/gui/presets.c:565 ../src/gui/styles_dialog.c:526
 #: ../src/imageio/storage/disk.c:198 ../src/imageio/storage/gallery.c:150
 #: ../src/imageio/storage/latex.c:146 ../src/iop/lut3d.c:1560
-#: ../src/libs/collect.c:408 ../src/libs/collect.c:2923
+#: ../src/libs/collect.c:425 ../src/libs/collect.c:3242
 #: ../src/libs/copy_history.c:115 ../src/libs/export_metadata.c:276
 #: ../src/libs/geotagging.c:929 ../src/libs/import.c:1510
 #: ../src/libs/import.c:1614 ../src/libs/import.c:1706
@@ -5206,7 +5206,7 @@ msgid "_cancel"
 msgstr "_Annuler"
 
 #: ../src/chart/main.c:504 ../src/gui/preferences.c:1081
-#: ../src/gui/styles_dialog.c:527 ../src/libs/collect.c:2924
+#: ../src/gui/styles_dialog.c:527 ../src/libs/collect.c:3243
 #: ../src/libs/export_metadata.c:277 ../src/libs/metadata.c:468
 #: ../src/libs/metadata_view.c:1207 ../src/libs/recentcollect.c:229
 #: ../src/libs/styles.c:392 ../src/libs/tagging.c:1667
@@ -5450,7 +5450,7 @@ msgstr "Date d’exportation"
 msgid "print time"
 msgstr "Date d’impression"
 
-#: ../src/common/collection.c:621 ../src/libs/collect.c:3231
+#: ../src/common/collection.c:621 ../src/libs/collect.c:3586
 #: ../src/libs/filtering.c:2237 ../src/libs/filtering.c:2257
 #: ../src/libs/filters/history.c:153 ../src/libs/history.c:92
 msgid "history"
@@ -5525,34 +5525,34 @@ msgstr "Rechercher"
 #: ../src/common/collection.c:1376 ../src/common/colorlabels.c:334
 #: ../src/develop/lightroom.c:836 ../src/gui/guides.c:732
 #: ../src/iop/colorzones.c:2501 ../src/iop/temperature.c:1936
-#: ../src/libs/collect.c:1797 ../src/libs/filters/colors.c:261
+#: ../src/libs/collect.c:1916 ../src/libs/filters/colors.c:261
 msgid "yellow"
 msgstr "Jaune"
 
 #: ../src/common/collection.c:1382 ../src/common/color_vocabulary.c:339
 #: ../src/common/colorlabels.c:337 ../src/iop/colorzones.c:2505
-#: ../src/libs/collect.c:1797 ../src/libs/filters/colors.c:264
+#: ../src/libs/collect.c:1916 ../src/libs/filters/colors.c:264
 msgid "purple"
 msgstr "Violet"
 
-#: ../src/common/collection.c:1400 ../src/libs/collect.c:1751
+#: ../src/common/collection.c:1400 ../src/libs/collect.c:1863
 #: ../src/libs/filters/history.c:38
 msgid "auto applied"
 msgstr "Appliqué automatiquement"
 
-#: ../src/common/collection.c:1406 ../src/libs/collect.c:1751
+#: ../src/common/collection.c:1406 ../src/libs/collect.c:1863
 #: ../src/libs/filters/history.c:38
 msgid "altered"
 msgstr "Développées"
 
 #: ../src/common/collection.c:1424 ../src/common/collection.c:1535
-#: ../src/libs/collect.c:1169 ../src/libs/collect.c:1333
-#: ../src/libs/collect.c:1357 ../src/libs/collect.c:1476
-#: ../src/libs/collect.c:2440
+#: ../src/libs/collect.c:1242 ../src/libs/collect.c:1426
+#: ../src/libs/collect.c:1452 ../src/libs/collect.c:1592
+#: ../src/libs/collect.c:2662
 msgid "not tagged"
 msgstr "Non positionnée"
 
-#: ../src/common/collection.c:1425 ../src/libs/collect.c:1357
+#: ../src/common/collection.c:1425 ../src/libs/collect.c:1452
 #: ../src/libs/map_locations.c:742
 msgid "tagged"
 msgstr "Positionnée"
@@ -5562,27 +5562,33 @@ msgid "tagged*"
 msgstr "Positionnée*"
 
 #. local copy
-#: ../src/common/collection.c:1460 ../src/libs/collect.c:1765
+#: ../src/common/collection.c:1460 ../src/libs/collect.c:1883
 #: ../src/libs/filters/local_copy.c:38
 msgid "not copied locally"
 msgstr "Non copiée localement"
 
-#: ../src/common/collection.c:1465 ../src/libs/collect.c:1765
+#: ../src/common/collection.c:1465 ../src/libs/collect.c:1882
 #: ../src/libs/filters/local_copy.c:38
 msgid "copied locally"
 msgstr "Copiée localement"
 
-#: ../src/common/collection.c:1905 ../src/libs/collect.c:1886
+#. if its undefined
+#: ../src/common/collection.c:1507 ../src/common/collection.c:1619
+#: ../src/libs/collect.c:2209 ../src/libs/collect.c:2210
+msgid "unnamed"
+msgstr "Sans nom"
+
+#: ../src/common/collection.c:1905 ../src/libs/collect.c:2013
 #: ../src/libs/filters/grouping.c:147 ../src/libs/filters/grouping.c:170
 msgid "group leaders"
 msgstr "Tête de groupe"
 
-#: ../src/common/collection.c:1909 ../src/libs/collect.c:1886
+#: ../src/common/collection.c:1909 ../src/libs/collect.c:2013
 #: ../src/libs/filters/grouping.c:150 ../src/libs/filters/grouping.c:170
 msgid "group followers"
 msgstr "Membres du groupe"
 
-#: ../src/common/collection.c:2066 ../src/libs/collect.c:1967
+#: ../src/common/collection.c:2066 ../src/libs/collect.c:2100
 msgid "not defined"
 msgstr "Non défini"
 
@@ -11397,7 +11403,7 @@ msgstr "Échec d’importation du préréglage « %s »"
 msgid "select preset(s) to import"
 msgstr "Sélectionne le(s) préréglage(s) à importer"
 
-#: ../src/gui/preferences.c:1042 ../src/libs/collect.c:408
+#: ../src/gui/preferences.c:1042 ../src/libs/collect.c:425
 #: ../src/libs/copy_history.c:115 ../src/libs/geotagging.c:930
 #: ../src/libs/import.c:1510 ../src/libs/import.c:1614 ../src/libs/styles.c:529
 msgid "_open"
@@ -20880,39 +20886,52 @@ msgstr "Vitesse d’obturation"
 msgid "WB"
 msgstr "BdB"
 
-#: ../src/libs/collect.c:151
+#: ../src/libs/collect.c:164
 msgid "collections"
 msgstr "Collections"
 
-#: ../src/libs/collect.c:407
+#: ../src/libs/collect.c:424
 msgid "search filmroll"
 msgstr "Rechercher une pellicule"
 
-#: ../src/libs/collect.c:490
+#: ../src/libs/collect.c:507
 #, c-format
 msgid "problem selecting new path for the filmroll in %s"
 msgstr ""
 "Problème lors de la sélection d’un nouveau chemin pour la pellicule située "
 "dans %s"
 
-#: ../src/libs/collect.c:555
+#: ../src/libs/collect.c:579
 msgid "search filmroll..."
 msgstr "Rechercher une pellicule"
 
 # lorsque l’action n’engendre pas de suppression physique, on emploie le terme "enlever"
-#: ../src/libs/collect.c:559
+#: ../src/libs/collect.c:584
 msgid "remove..."
 msgstr "Enlever"
 
-#: ../src/libs/collect.c:1228
+#: ../src/libs/collect.c:1310
 msgid "uncategorized"
 msgstr "Sans catégorie"
 
-#: ../src/libs/collect.c:2146
+#: ../src/libs/collect.c:2172 ../src/libs/filters/rating_range.c:99
+#: ../src/libs/filters/rating_range.c:126
+#: ../src/libs/filters/rating_range.c:131
+#: ../src/libs/filters/rating_range.c:275
+msgid "rejected"
+msgstr "Rejeté"
+
+#: ../src/libs/collect.c:2175 ../src/libs/filters/rating_range.c:101
+#: ../src/libs/filters/rating_range.c:126
+#: ../src/libs/filters/rating_range.c:276
+msgid "not rated"
+msgstr "Sans note"
+
+#: ../src/libs/collect.c:2359
 msgid "use <, <=, >, >=, <>, =, [;] as operators"
 msgstr "Utiliser <, ≤, >, ≥, <>, =, [;] comme opérateurs"
 
-#: ../src/libs/collect.c:2150
+#: ../src/libs/collect.c:2363
 msgid ""
 "use <, <=, >, >=, <>, =, [;] as operators\n"
 "star rating: 0-5\n"
@@ -20922,7 +20941,7 @@ msgstr ""
 "Étoiles : 0-5\n"
 "Images rejetées : –1"
 
-#: ../src/libs/collect.c:2157
+#: ../src/libs/collect.c:2371
 msgid ""
 "use <, <=, >, >=, <>, =, [;] as operators\n"
 "type dates in the form: YYYY:MM:DD hh:mm:ss.sss (only the year is mandatory)"
@@ -20931,12 +20950,12 @@ msgstr ""
 "Entrer les dates au format «  aaaa:mm:jj hh:mm:ss.sss » (seule l’année est "
 "requise)."
 
-#: ../src/libs/collect.c:2164
+#: ../src/libs/collect.c:2378
 #, no-c-format
 msgid "use `%' as wildcard and `,' to separate values"
 msgstr "Utiliser « % » en caractère joker et « , » pour séparer les valeurs"
 
-#: ../src/libs/collect.c:2170
+#: ../src/libs/collect.c:2385
 #, no-c-format
 msgid ""
 "use `%' as wildcard\n"
@@ -20950,7 +20969,7 @@ msgstr ""
 " • Maj+clic pour inclure seulement la hiérarchie courante (sans suffixe),\n"
 " • Ctrl+clic pour inclure les sous-hiérarchies seulement (suffixe « |% »)."
 
-#: ../src/libs/collect.c:2182
+#: ../src/libs/collect.c:2398
 #, no-c-format
 msgid ""
 "use `%' as wildcard\n"
@@ -20964,7 +20983,7 @@ msgstr ""
 " • Maj+clic pour inclure seulement l’emplacement courant (sans suffixe),\n"
 " • Ctrl+clic pour inclure les sous-emplacements seulement (suffixe « |% »)."
 
-#: ../src/libs/collect.c:2194
+#: ../src/libs/collect.c:2411
 #, no-c-format
 msgid ""
 "use `%' as wildcard\n"
@@ -20978,52 +20997,52 @@ msgstr ""
 " • Maj+clic pour inclure seulement le dossiercourant (sans suffixe),\n"
 " • Ctrl+clic pour inclure les sous-dossiers seulement (suffixe « |% »)."
 
-#: ../src/libs/collect.c:2205
+#: ../src/libs/collect.c:2422
 #, no-c-format
 msgid "use `%' as wildcard"
 msgstr "Utiliser « % » en caractère joker"
 
-#: ../src/libs/collect.c:2271 ../src/libs/collect.c:2285
-#: ../src/libs/collect.c:2808
+#: ../src/libs/collect.c:2488 ../src/libs/collect.c:2502
+#: ../src/libs/collect.c:3111
 msgid "clear this rule"
 msgstr "Supprimer cette condition"
 
-#: ../src/libs/collect.c:2275
+#: ../src/libs/collect.c:2492
 msgid "clear this rule or add new rules"
 msgstr "Supprimer cette condition ou en ajouter une nouvelle"
 
-#: ../src/libs/collect.c:2814
+#: ../src/libs/collect.c:3117
 msgid "narrow down search"
 msgstr "Affiner la recherche"
 
-#: ../src/libs/collect.c:2819
+#: ../src/libs/collect.c:3124
 msgid "add more images"
 msgstr "Inclure des images"
 
-#: ../src/libs/collect.c:2824
+#: ../src/libs/collect.c:3131
 msgid "exclude images"
 msgstr "Exclure des images"
 
-#: ../src/libs/collect.c:2831
+#: ../src/libs/collect.c:3140
 msgid "change to: and"
 msgstr "Changer en « et »"
 
-#: ../src/libs/collect.c:2836
+#: ../src/libs/collect.c:3147
 msgid "change to: or"
 msgstr "Changer en « ou »"
 
-#: ../src/libs/collect.c:2841
+#: ../src/libs/collect.c:3154
 msgid "change to: except"
 msgstr "Changer en « sauf »"
 
 #. the different categories
-#: ../src/libs/collect.c:2867 ../src/libs/filtering.c:883
+#: ../src/libs/collect.c:3184 ../src/libs/filtering.c:883
 #: ../src/libs/filtering.c:950 ../src/libs/filtering.c:1620
 #: ../src/libs/filtering.c:1964
 msgid "files"
 msgstr "Fichiers"
 
-#: ../src/libs/collect.c:2872 ../src/libs/export_metadata.c:301
+#: ../src/libs/collect.c:3189 ../src/libs/export_metadata.c:301
 #: ../src/libs/filtering.c:888 ../src/libs/filtering.c:955
 #: ../src/libs/filtering.c:1628 ../src/libs/filtering.c:1968
 #: ../src/libs/image.c:494 ../src/libs/image.c:632 ../src/libs/image.c:644
@@ -21031,50 +21050,50 @@ msgstr "Fichiers"
 msgid "metadata"
 msgstr "Métadonnées"
 
-#: ../src/libs/collect.c:2891 ../src/libs/filtering.c:909
+#: ../src/libs/collect.c:3208 ../src/libs/filtering.c:909
 #: ../src/libs/filtering.c:976 ../src/libs/filtering.c:1966
 msgid "times"
 msgstr "Dates"
 
-#: ../src/libs/collect.c:2899 ../src/libs/filtering.c:917
+#: ../src/libs/collect.c:3216 ../src/libs/filtering.c:917
 #: ../src/libs/filtering.c:984 ../src/libs/filtering.c:1652
 msgid "capture details"
 msgstr "Détails de prise de vue"
 
-#: ../src/libs/collect.c:2908 ../src/libs/filtering.c:926
+#: ../src/libs/collect.c:3225 ../src/libs/filtering.c:926
 #: ../src/libs/filtering.c:993 ../src/libs/filtering.c:1664
 #: ../src/libs/filtering.c:1970 ../src/libs/tools/darktable.c:61
 msgid "darktable"
 msgstr "darktable"
 
-#: ../src/libs/collect.c:2921
+#: ../src/libs/collect.c:3240
 msgid "collections settings"
 msgstr "Préférences des collections"
 
-#: ../src/libs/collect.c:2945 ../src/libs/export.c:1126
+#: ../src/libs/collect.c:3267 ../src/libs/export.c:1126
 #: ../src/libs/metadata.c:620 ../src/libs/metadata_view.c:1323
 #: ../src/libs/recentcollect.c:295 ../src/libs/tagging.c:3522
 msgid "preferences..."
 msgstr "Préférences…"
 
-#: ../src/libs/collect.c:3050 ../src/libs/filtering.c:1494
+#: ../src/libs/collect.c:3388 ../src/libs/filtering.c:1494
 msgid "AND"
 msgstr "ET"
 
-#: ../src/libs/collect.c:3055 ../src/libs/filtering.c:1499
+#: ../src/libs/collect.c:3393 ../src/libs/filtering.c:1499
 msgid "OR"
 msgstr "OU"
 
 #. case DT_LIB_COLLECT_MODE_AND_NOT:
-#: ../src/libs/collect.c:3060 ../src/libs/filtering.c:1504
+#: ../src/libs/collect.c:3398 ../src/libs/filtering.c:1504
 msgid "BUT NOT"
 msgstr "SAUF"
 
-#: ../src/libs/collect.c:3232 ../src/libs/filtering.c:2238
+#: ../src/libs/collect.c:3588 ../src/libs/filtering.c:2238
 msgid "revert to a previous set of rules"
 msgstr "Basculer vers une règle précédente"
 
-#: ../src/libs/collect.c:3289
+#: ../src/libs/collect.c:3671
 msgid "jump back to previous collection"
 msgstr "Aller à la collection précédente"
 
@@ -22029,18 +22048,6 @@ msgstr "Tout sauf rejetées"
 #: ../src/libs/filters/rating_range.c:61 ../src/libs/filters/rating_range.c:76
 msgid "not rated only"
 msgstr "Seulement sans note"
-
-#: ../src/libs/filters/rating_range.c:99 ../src/libs/filters/rating_range.c:126
-#: ../src/libs/filters/rating_range.c:131
-#: ../src/libs/filters/rating_range.c:275
-msgid "rejected"
-msgstr "Rejeter"
-
-#: ../src/libs/filters/rating_range.c:101
-#: ../src/libs/filters/rating_range.c:126
-#: ../src/libs/filters/rating_range.c:276
-msgid "not rated"
-msgstr "Sans note"
 
 #: ../src/libs/filters/rating_range.c:117
 msgid "only"
@@ -25827,6 +25834,14 @@ msgstr "Créer une fenêtre flottante persistante"
 #: ../src/views/view.c:1535
 msgid "mouse actions"
 msgstr "Actions de la souris"
+
+#~ msgctxt "preferences"
+#~ msgid "id"
+#~ msgstr "Numéro"
+
+#~ msgctxt "preferences"
+#~ msgid "folder"
+#~ msgstr "Dossier"
 
 #~ msgid ""
 #~ "if an instance of the module has focus, apply shortcut to that instance\n"

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1504,7 +1504,7 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       for(int i = 0; i < g_strv_length(elems); i++)
       {
         // if its undefined
-        if(!g_strcmp0(elems[i], "UNSET"))
+        if(!g_strcmp0(elems[i], _("unnamed")))
         {
           // clang-format off
           query = dt_util_dstrcat(query, "%scamera_id IN (SELECT id"
@@ -1616,7 +1616,7 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       elems = g_strsplit(escaped_text, ",", -1);
       for(int i = 0; i < g_strv_length(elems); i++)
       {
-        if(!g_strcmp0(elems[i], "UNSET"))
+        if(!g_strcmp0(elems[i], _("unnamed")))
         {
           query = dt_util_dstrcat
             (query,

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1971,7 +1971,7 @@ static void _list_view(dt_lib_collect_rule_t *dr)
                    " FROM main.images AS mi"
                    " WHERE %s"
                    " GROUP BY iso"
-                   " ORDER BY iso",
+                   " ORDER BY iso ASC",
                    where_ext);
         // clang-format on
         break;
@@ -1983,7 +1983,7 @@ static void _list_view(dt_lib_collect_rule_t *dr)
                    " FROM main.images AS mi"
                    " WHERE %s"
                    " GROUP BY aperture"
-                   " ORDER BY aperture",
+                   " ORDER BY aperture ASC",
                    where_ext);
         // clang-format on
         break;
@@ -2064,7 +2064,7 @@ static void _list_view(dt_lib_collect_rule_t *dr)
                    "  ON mo.imgid = mi.id"
                    " WHERE %s"
                    " GROUP BY ver"
-                   " ORDER BY ver",
+                   " ORDER BY ver ASC",
                    orders, where_ext);
           // clang-format on
           g_free(orders);
@@ -2081,7 +2081,7 @@ static void _list_view(dt_lib_collect_rule_t *dr)
                      " FROM main.images AS mi"
                      " WHERE %s"
                      " GROUP BY rating"
-                     " ORDER BY rating", where_ext);
+                     " ORDER BY rating ASC", where_ext);
           // clang-format on
         }
         break;

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1314,6 +1314,7 @@ static void _tree_view(dt_lib_collect_rule_t *dr)
   dt_lib_collect_t *d = get_collect(dr);
   const int property = _combo_get_active_collection(dr->combo);
   char *format_separator = "";
+  gboolean sorting_always_asc = TRUE;
 
   switch(property)
   {
@@ -1331,6 +1332,7 @@ static void _tree_view(dt_lib_collect_rule_t *dr)
     case DT_COLLECTION_PROP_EXPORT_TIMESTAMP:
     case DT_COLLECTION_PROP_PRINT_TIMESTAMP:
       format_separator = "%s:";
+      sorting_always_asc = FALSE;
       break;
   }
 
@@ -1559,7 +1561,7 @@ static void _tree_view(dt_lib_collect_rule_t *dr)
     // this order should not be altered. the right feeding of the tree relies on it.
     sorted_names = g_list_sort(sorted_names, sort_folder_tag);
     const gboolean sort_descend = dt_conf_get_bool("plugins/collect/descending");
-    if(!sort_descend)
+    if(sorting_always_asc || !sort_descend)
       sorted_names = g_list_reverse(sorted_names);
 
     const gboolean no_uncategorized =

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2114,8 +2114,8 @@ static void _list_view(dt_lib_collect_rule_t *dr)
                      "            WHERE key = %d)"
                      "  ON id = meta_data_id"
                      " WHERE %s"
-                     " GROUP BY value"
-                     " ORDER BY force_order, value",
+                     " GROUP BY lower(value)"
+                     " ORDER BY force_order ASC, lower(value) ASC",
                      _("not defined"), keyid, where_ext);
             // clang-format on
           }

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -135,15 +135,28 @@ typedef struct _range_t
 } _range_t;
 
 static void _lib_collect_gui_update(dt_lib_module_t *self);
+
 static void _lib_folders_update_collection(const gchar *filmroll);
+
 static void entry_changed(GtkEntry *entry, dt_lib_collect_rule_t *dr);
-static void collection_updated(gpointer instance, dt_collection_change_t query_change,
-                               dt_collection_properties_t changed_property, gpointer imgs, int next,
+
+static void collection_updated(gpointer instance,
+                               dt_collection_change_t query_change,
+                               dt_collection_properties_t changed_property,
+                               gpointer imgs,
+                               int next,
                                gpointer self);
-static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTreeViewColumn *col,
-                                     GdkEventButton *event, dt_lib_collect_t *d);
-static int is_time_property(int property);
+
+static void row_activated_with_event(GtkTreeView *view,
+                                     GtkTreePath *path,
+                                     GtkTreeViewColumn *col,
+                                     GdkEventButton *event,
+                                     dt_lib_collect_t *d);
+
+static int _is_time_property(const int property);
+
 static void _populate_collect_combo(GtkWidget *w);
+
 int last_state = 0;
 
 const char *name(dt_lib_module_t *self)
@@ -305,8 +318,6 @@ static void _lib_collect_update_params(dt_lib_collect_t *d)
     {
       g_strlcpy(p->rule[i].string, string, PARAM_STRING_SIZE);
     }
-
-    // fprintf(stderr,"[%i] %d,%d,%s\n",i, p->rule[i].item, p->rule[i].mode,  p->rule[i].string);
   }
 
   p->rules = active + 1;
@@ -323,7 +334,9 @@ void *get_params(dt_lib_module_t *self, int *size)
   return p;
 }
 
-int set_params(dt_lib_module_t *self, const void *params, int size)
+int set_params(dt_lib_module_t *self,
+               const void *params,
+               const int size)
 {
   /* update conf settings from params */
   dt_lib_collect_params_t *p = (dt_lib_collect_params_t *)params;
@@ -344,7 +357,8 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
     snprintf(confname, sizeof(confname), "plugins/lighttable/collect/string%1u", i);
     dt_conf_set_string(confname, p->rule[i].string);
 
-    /* if one of the rules is a rating filter, the view rating filter will be reset to all */
+    /* if one of the rules is a rating filter, the view rating filter
+     * will be reset to all */
     if(p->rule[i].item == DT_COLLECTION_PROP_RATING)
     {
       reset_view_filter = TRUE;
@@ -367,7 +381,9 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
   _lib_collect_gui_update(self);
 
   /* update view */
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
+  dt_collection_update_query(darktable.collection,
+                             DT_COLLECTION_CHANGE_NEW_QUERY,
+                             DT_COLLECTION_PROP_UNDEF, NULL);
   return 0;
 }
 
@@ -382,7 +398,8 @@ uint32_t container(dt_lib_module_t *self)
   return DT_UI_CONTAINER_PANEL_LEFT_CENTER;
 }
 
-static void view_popup_menu_onSearchFilmroll(GtkWidget *menuitem, gpointer userdata)
+static void view_popup_menu_onSearchFilmroll(GtkWidget *menuitem,
+                                             gpointer userdata)
 {
   GtkTreeView *treeview = GTK_TREE_VIEW(userdata);
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
@@ -493,7 +510,8 @@ error:
   g_free(new_path);
 }
 
-static void view_popup_menu_onRemove(GtkWidget *menuitem, gpointer userdata)
+static void view_popup_menu_onRemove(GtkWidget *menuitem,
+                                     gpointer userdata)
 {
   GtkTreeView *treeview = GTK_TREE_VIEW(userdata);
 
@@ -523,22 +541,26 @@ static void view_popup_menu_onRemove(GtkWidget *menuitem, gpointer userdata)
        " WHERE film_id IN (SELECT id FROM main.film_rolls WHERE folder LIKE '%s%%')",
        filmroll_path);
     // clang-format on
+
     DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), fullq, NULL, NULL, NULL);
     g_free(filmroll_path);
 
     if(dt_control_remove_images())
     {
-      gtk_tree_model_filter_convert_iter_to_child_iter(GTK_TREE_MODEL_FILTER(model), &model_iter, &iter);
+      gtk_tree_model_filter_convert_iter_to_child_iter
+        (GTK_TREE_MODEL_FILTER(model), &model_iter, &iter);
 
       if(gtk_tree_model_get_flags(model) == GTK_TREE_MODEL_LIST_ONLY)
       {
-        gtk_list_store_remove(GTK_LIST_STORE(gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(model))),
-                              &model_iter);
+        gtk_list_store_remove
+          (GTK_LIST_STORE(gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(model))),
+           &model_iter);
       }
       else
       {
-        gtk_tree_store_remove(GTK_TREE_STORE(gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(model))),
-                              &model_iter);
+        gtk_tree_store_remove
+          (GTK_TREE_STORE(gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(model))),
+           &model_iter);
       }
     }
 
@@ -546,30 +568,37 @@ static void view_popup_menu_onRemove(GtkWidget *menuitem, gpointer userdata)
   }
 }
 
-static void view_popup_menu(GtkWidget *treeview, GdkEventButton *event, dt_lib_collect_t *d)
+static void view_popup_menu(GtkWidget *treeview,
+                            GdkEventButton *event,
+                            dt_lib_collect_t *d)
 {
   GtkWidget *menu, *menuitem;
 
   menu = gtk_menu_new();
 
   menuitem = gtk_menu_item_new_with_label(_("search filmroll..."));
-  g_signal_connect(menuitem, "activate", (GCallback)view_popup_menu_onSearchFilmroll, treeview);
+  g_signal_connect(menuitem, "activate",
+                   (GCallback)view_popup_menu_onSearchFilmroll, treeview);
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
 
   menuitem = gtk_menu_item_new_with_label(_("remove..."));
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
-  g_signal_connect(menuitem, "activate", (GCallback)view_popup_menu_onRemove, treeview);
+  g_signal_connect(menuitem, "activate",
+                   (GCallback)view_popup_menu_onRemove, treeview);
 
   gtk_widget_show_all(GTK_WIDGET(menu));
 
   gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent *)event);
 }
 
-static gboolean view_onButtonPressed(GtkWidget *treeview, GdkEventButton *event, dt_lib_collect_t *d)
+static gboolean view_onButtonPressed(GtkWidget *treeview,
+                                     GdkEventButton *event,
+                                     dt_lib_collect_t *d)
 {
   /* Get tree path for row that was clicked */
   GtkTreePath *path = NULL;
-  const gboolean get_path = gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(treeview), (gint)event->x, (gint)event->y,
+  const gboolean get_path = gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(treeview),
+                                                          (gint)event->x, (gint)event->y,
                                                           &path, NULL, NULL, NULL);
 
   if(event->type == GDK_DOUBLE_BUTTON_PRESS || d->singleclick)
@@ -588,10 +617,13 @@ static gboolean view_onButtonPressed(GtkWidget *treeview, GdkEventButton *event,
   GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(treeview));
   if(get_path && dt_modifier_is(event->state, GDK_SHIFT_MASK)
      && gtk_tree_selection_count_selected_rows(selection) > 0
-     && (d->view_rule == DT_COLLECTION_PROP_DAY || is_time_property(d->view_rule)
-         || d->view_rule == DT_COLLECTION_PROP_APERTURE || d->view_rule == DT_COLLECTION_PROP_FOCAL_LENGTH
-         || d->view_rule == DT_COLLECTION_PROP_ISO || d->view_rule == DT_COLLECTION_PROP_EXPOSURE
-         || d->view_rule == DT_COLLECTION_PROP_ASPECT_RATIO || d->view_rule == DT_COLLECTION_PROP_RATING))
+     && (d->view_rule == DT_COLLECTION_PROP_DAY || _is_time_property(d->view_rule)
+         || d->view_rule == DT_COLLECTION_PROP_APERTURE
+         || d->view_rule == DT_COLLECTION_PROP_FOCAL_LENGTH
+         || d->view_rule == DT_COLLECTION_PROP_ISO
+         || d->view_rule == DT_COLLECTION_PROP_EXPOSURE
+         || d->view_rule == DT_COLLECTION_PROP_ASPECT_RATIO
+         || d->view_rule == DT_COLLECTION_PROP_RATING))
   {
     // range selection
     GList *sels = gtk_tree_selection_get_selected_rows(selection, NULL);
@@ -616,9 +648,11 @@ static gboolean view_onButtonPressed(GtkWidget *treeview, GdkEventButton *event,
   }
 
   // case of a context-menu (folder/filmroll)
-  if(((d->view_rule == DT_COLLECTION_PROP_FOLDERS) || (d->view_rule == DT_COLLECTION_PROP_FILMROLL))
+  if(((d->view_rule == DT_COLLECTION_PROP_FOLDERS)
+      || (d->view_rule == DT_COLLECTION_PROP_FILMROLL))
      && (event->type == GDK_BUTTON_PRESS && event->button == 3)
-     && !(dt_modifier_is(event->state, GDK_SHIFT_MASK) || dt_modifier_is(event->state, GDK_CONTROL_MASK)))
+     && !(dt_modifier_is(event->state, GDK_SHIFT_MASK)
+          || dt_modifier_is(event->state, GDK_CONTROL_MASK)))
   {
     row_activated_with_event(GTK_TREE_VIEW(treeview), path, NULL, event, d);
     view_popup_menu(treeview, event, d);
@@ -631,7 +665,8 @@ static gboolean view_onButtonPressed(GtkWidget *treeview, GdkEventButton *event,
   if((!d->singleclick && event->type == GDK_2BUTTON_PRESS && event->button == 1)
      || (d->singleclick && event->type == GDK_BUTTON_PRESS && event->button == 1)
      || (!d->singleclick && event->type == GDK_BUTTON_PRESS && event->button == 1
-         && (dt_modifier_is(event->state, GDK_SHIFT_MASK) || dt_modifier_is(event->state, GDK_CONTROL_MASK))))
+         && (dt_modifier_is(event->state, GDK_SHIFT_MASK)
+             || dt_modifier_is(event->state, GDK_CONTROL_MASK))))
   {
     row_activated_with_event(GTK_TREE_VIEW(treeview), path, NULL, event, d);
 
@@ -657,11 +692,15 @@ static gboolean view_onPopupMenu(GtkWidget *treeview, dt_lib_collect_t *d)
 
 static dt_lib_collect_t *get_collect(dt_lib_collect_rule_t *r)
 {
-  dt_lib_collect_t *d = (dt_lib_collect_t *)(((char *)r) - r->num * sizeof(dt_lib_collect_rule_t));
+  dt_lib_collect_t *d =
+    (dt_lib_collect_t *)(((char *)r) - r->num * sizeof(dt_lib_collect_rule_t));
   return d;
 }
 
-static gboolean list_select(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data)
+static gboolean list_select(GtkTreeModel *model,
+                            GtkTreePath *path,
+                            GtkTreeIter *iter,
+                            gpointer data)
 {
   dt_lib_collect_rule_t *dr = (dt_lib_collect_rule_t *)data;
   dt_lib_collect_t *d = get_collect(dr);
@@ -685,7 +724,10 @@ static gboolean list_select(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter 
   return FALSE;
 }
 
-static gboolean range_select(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data)
+static gboolean range_select(GtkTreeModel *model,
+                             GtkTreePath *path,
+                             GtkTreeIter *iter,
+                             gpointer data)
 {
   _range_t *range = (_range_t *)data;
   gchar *str = NULL;
@@ -720,7 +762,10 @@ static gboolean range_select(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter
   return FALSE;
 }
 
-static gboolean _datetime_range_select(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data)
+static gboolean _datetime_range_select(GtkTreeModel *model,
+                                       GtkTreePath *path,
+                                       GtkTreeIter *iter,
+                                       gpointer data)
 {
   dt_lib_collect_rule_t *dr = (dt_lib_collect_rule_t *)data;
   gchar *str;
@@ -728,7 +773,9 @@ static gboolean _datetime_range_select(GtkTreeModel *model, GtkTreePath *path, G
   gtk_tree_model_get(model, iter, DT_LIB_COLLECT_COL_PATH, &str, -1);
   const GTimeSpan nb = dt_datetime_exif_to_gtimespan(str);
   g_free(str);
-  GTimeSpan target = dr->datetime_range.path1 == NULL ? dr->datetime_range.nb1 : dr->datetime_range.nb2;
+  GTimeSpan target = dr->datetime_range.path1 == NULL
+    ? dr->datetime_range.nb1
+    : dr->datetime_range.nb2;
 
   if(nb >= target)
   {
@@ -747,7 +794,8 @@ int _combo_get_active_collection(GtkWidget *combo)
   return GPOINTER_TO_UINT(dt_bauhaus_combobox_get_data(combo)) - 1;
 }
 
-gboolean _combo_set_active_collection(GtkWidget *combo, const int property)
+gboolean _combo_set_active_collection(GtkWidget *combo,
+                                      const int property)
 {
   const gboolean found = dt_bauhaus_combobox_set_from_value(combo, property + 1);
   // make sure we have a valid collection
@@ -755,7 +803,10 @@ gboolean _combo_set_active_collection(GtkWidget *combo, const int property)
   return found;
 }
 
-static gboolean tree_expand(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data)
+static gboolean tree_expand(GtkTreeModel *model,
+                            GtkTreePath *path,
+                            GtkTreeIter *iter,
+                            gpointer data)
 {
   dt_lib_collect_rule_t *dr = (dt_lib_collect_rule_t *)data;
   gchar *str = NULL;
@@ -807,13 +858,18 @@ static gboolean tree_expand(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter 
   return expanded; // if we expanded the path, we can stop iteration (saves half on average)
 }
 
-static gboolean list_match_string(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data)
+static gboolean list_match_string(GtkTreeModel *model,
+                                  GtkTreePath *path,
+                                  GtkTreeIter *iter,
+                                  gpointer data)
 {
   dt_lib_collect_rule_t *dr = (dt_lib_collect_rule_t *)data;
   gchar *str = NULL;
   gboolean visible = FALSE;
   gboolean was_visible;
-  gtk_tree_model_get(model, iter, DT_LIB_COLLECT_COL_PATH, &str, DT_LIB_COLLECT_COL_VISIBLE, &was_visible, -1);
+  gtk_tree_model_get(model, iter,
+                     DT_LIB_COLLECT_COL_PATH, &str,
+                     DT_LIB_COLLECT_COL_VISIBLE, &was_visible, -1);
 
   gchar *haystack = g_utf8_strdown(str, -1);
   const gchar *needle = dr->searchstring;
@@ -903,17 +959,23 @@ static gboolean list_match_string(GtkTreeModel *model, GtkTreePath *path, GtkTre
   g_free(str);
 
   if(visible != was_visible)
-    gtk_list_store_set(GTK_LIST_STORE(model), iter, DT_LIB_COLLECT_COL_VISIBLE, visible, -1);
+    gtk_list_store_set(GTK_LIST_STORE(model), iter,
+                       DT_LIB_COLLECT_COL_VISIBLE, visible, -1);
   return FALSE;
 }
 
-static gboolean tree_match_string(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data)
+static gboolean tree_match_string(GtkTreeModel *model,
+                                  GtkTreePath *path,
+                                  GtkTreeIter *iter,
+                                  gpointer data)
 {
   dt_lib_collect_rule_t *dr = (dt_lib_collect_rule_t *)data;
   gchar *str = NULL;
   gboolean cur_state, visible;
 
-  gtk_tree_model_get(model, iter, DT_LIB_COLLECT_COL_PATH, &str, DT_LIB_COLLECT_COL_VISIBLE, &cur_state, -1);
+  gtk_tree_model_get(model, iter,
+                     DT_LIB_COLLECT_COL_PATH, &str,
+                     DT_LIB_COLLECT_COL_VISIBLE, &cur_state, -1);
 
   if(dr->typing == FALSE && !cur_state)
   {
@@ -923,13 +985,14 @@ static gboolean tree_match_string(GtkTreeModel *model, GtkTreePath *path, GtkTre
   {
     gchar *haystack = dr->sensitive ? g_strdup(str) : g_utf8_strdown(str, -1);
     const int property = _combo_get_active_collection(dr->combo);
-    if(is_time_property(property) || property == DT_COLLECTION_PROP_DAY)
+    if(_is_time_property(property) || property == DT_COLLECTION_PROP_DAY)
     {
       // handle of numeric value, which can have some operator before the text
       visible = TRUE;
       if(dr->datetime_range.nb1)
       {
         const GTimeSpan nb = dt_datetime_exif_to_gtimespan(haystack);
+
         if(!dr->datetime_range.operator)
           visible = (nb >= dr->datetime_range.nb1 && nb <= dr->datetime_range.nb2);
         else if(strcmp(dr->datetime_range.operator, ">") == 0)
@@ -961,7 +1024,10 @@ static gboolean tree_match_string(GtkTreeModel *model, GtkTreePath *path, GtkTre
   return FALSE;
 }
 
-static gboolean tree_reveal_func(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data)
+static gboolean tree_reveal_func(GtkTreeModel *model,
+                                 GtkTreePath *path,
+                                 GtkTreeIter *iter,
+                                 gpointer data)
 {
   gboolean state;
   GtkTreeIter parent, child = *iter;
@@ -972,7 +1038,8 @@ static gboolean tree_reveal_func(GtkTreeModel *model, GtkTreePath *path, GtkTree
   while(gtk_tree_model_iter_parent(model, &parent, &child))
   {
     gtk_tree_model_get(model, &parent, DT_LIB_COLLECT_COL_VISIBLE, &state, -1);
-    gtk_tree_store_set(GTK_TREE_STORE(model), &parent, DT_LIB_COLLECT_COL_VISIBLE, TRUE, -1);
+    gtk_tree_store_set(GTK_TREE_STORE(model), &parent,
+                       DT_LIB_COLLECT_COL_VISIBLE, TRUE, -1);
     child = parent;
   }
 
@@ -997,7 +1064,8 @@ static void _lib_folders_update_collection(const gchar *filmroll)
     gchar *complete_query = g_strdup_printf(
                           "DELETE FROM main.selected_images WHERE imgid NOT IN (%s)",
                           cquery);
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), complete_query, -1, &stmt, NULL);
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                                complete_query, -1, &stmt, NULL);
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, 0);
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, -1);
     sqlite3_step(stmt);
@@ -1011,7 +1079,9 @@ static void _lib_folders_update_collection(const gchar *filmroll)
   if(!darktable.collection->clone)
   {
     dt_collection_memory_update();
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED, DT_COLLECTION_CHANGE_NEW_QUERY,
+    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
+                                  DT_SIGNAL_COLLECTION_CHANGED,
+                                  DT_COLLECTION_CHANGE_NEW_QUERY,
                                   DT_COLLECTION_PROP_UNDEF, (GList *)NULL, -1);
   }
 }
@@ -1066,7 +1136,8 @@ static GtkTreeModel *_create_filtered_model(GtkTreeModel *model, dt_lib_collect_
           break;
         }
       }
-      if(gtk_tree_model_iter_n_children(model, level > 0 ? &iter : NULL) != 1) break;
+      if(gtk_tree_model_iter_n_children(model, level > 0 ? &iter : NULL) != 1)
+        break;
 
       gtk_tree_model_iter_children(model, &child, level > 0 ? &iter : NULL);
       iter = child;
@@ -1091,7 +1162,8 @@ static GtkTreeModel *_create_filtered_model(GtkTreeModel *model, dt_lib_collect_
   filter = gtk_tree_model_filter_new(model, path);
   gtk_tree_path_free(path);
 
-  gtk_tree_model_filter_set_visible_column(GTK_TREE_MODEL_FILTER(filter), DT_LIB_COLLECT_COL_VISIBLE);
+  gtk_tree_model_filter_set_visible_column(GTK_TREE_MODEL_FILTER(filter),
+                                           DT_LIB_COLLECT_COL_VISIBLE);
 
   return filter;
 }
@@ -1179,13 +1251,18 @@ static char *tag_collate_key(char *tag)
 }
 
 
-void tree_count_show(GtkTreeViewColumn *col, GtkCellRenderer *renderer, GtkTreeModel *model, GtkTreeIter *iter,
+void tree_count_show(GtkTreeViewColumn *col,
+                     GtkCellRenderer *renderer,
+                     GtkTreeModel *model,
+                     GtkTreeIter *iter,
                      gpointer data)
 {
   gchar *name;
   guint count;
 
-  gtk_tree_model_get(model, iter, DT_LIB_COLLECT_COL_TEXT, &name, DT_LIB_COLLECT_COL_COUNT, &count, -1);
+  gtk_tree_model_get(model, iter,
+                     DT_LIB_COLLECT_COL_TEXT, &name,
+                     DT_LIB_COLLECT_COL_COUNT, &count, -1);
   if(!count)
   {
     g_object_set(renderer, "text", name, NULL);
@@ -1200,9 +1277,13 @@ void tree_count_show(GtkTreeViewColumn *col, GtkCellRenderer *renderer, GtkTreeM
   g_free(name);
 }
 
-static void _expand_select_tree_path(GtkTreePath *path1, GtkTreePath *path2, dt_lib_collect_t *d)
+static void _expand_select_tree_path(GtkTreePath *path1,
+                                     GtkTreePath *path2,
+                                     dt_lib_collect_t *d)
 {
-  GtkTreePath *p1 = gtk_tree_model_filter_convert_child_path_to_path(GTK_TREE_MODEL_FILTER(d->treefilter), path1);
+  GtkTreePath *p1 =
+    gtk_tree_model_filter_convert_child_path_to_path(GTK_TREE_MODEL_FILTER(d->treefilter),
+                                                     path1);
   GtkTreePath *p2 = path2 ? gtk_tree_model_filter_convert_child_path_to_path(GTK_TREE_MODEL_FILTER(d->treefilter), path2) : NULL;
   GtkTreePath *p3 = NULL;
   GtkTreeIter iter;
@@ -1226,7 +1307,8 @@ static void _expand_select_tree_path(GtkTreePath *path1, GtkTreePath *path2, dt_
 }
 
 static const char *UNCATEGORIZED_TAG = N_("uncategorized");
-static void tree_view(dt_lib_collect_rule_t *dr)
+
+static void _tree_view(dt_lib_collect_rule_t *dr)
 {
   // update related list
   dt_lib_collect_t *d = get_collect(dr);
@@ -1254,10 +1336,13 @@ static void tree_view(dt_lib_collect_rule_t *dr)
 
   set_properties(dr);
 
-  GtkTreeModel *model = gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(d->treefilter));
-  // since we'll be inserting elements in the same order that we want them displayed, there is no need for the
-  // overhead of having the tree view sort itself
-  gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(model), GTK_TREE_SORTABLE_UNSORTED_SORT_COLUMN_ID,
+  GtkTreeModel *model =
+    gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(d->treefilter));
+  // since we'll be inserting elements in the same order that we want
+  // them displayed, there is no need for the overhead of having the
+  // tree view sort itself
+  gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(model),
+                                       GTK_TREE_SORTABLE_UNSORTED_SORT_COLUMN_ID,
                                        GTK_SORT_ASCENDING);
 
   if(d->view_rule != property)
@@ -1275,22 +1360,24 @@ static void tree_view(dt_lib_collect_rule_t *dr)
 
     /* query construction */
     gchar *where_ext = dt_collection_get_extended_where(darktable.collection, dr->num);
-    gchar *query = 0;
+    gchar *query = NULL;
     switch(property)
     {
       case DT_COLLECTION_PROP_FOLDERS:
         // clang-format off
-        query = g_strdup_printf("SELECT folder, film_rolls_id, COUNT(*) AS count, status"
-                                " FROM main.images AS mi"
-                                " JOIN (SELECT fr.id AS film_rolls_id, folder, status"
-                                "       FROM main.film_rolls AS fr"
-                                "       JOIN memory.film_folder AS ff"
-                                "       ON fr.id = ff.id)"
-                                "   ON film_id = film_rolls_id "
-                                " WHERE %s"
-                                " GROUP BY folder, film_rolls_id", where_ext);
+        query = g_strdup_printf
+          ("SELECT folder, film_rolls_id, COUNT(*) AS count, status"
+           " FROM main.images AS mi"
+           " JOIN (SELECT fr.id AS film_rolls_id, folder, status"
+           "       FROM main.film_rolls AS fr"
+           "       JOIN memory.film_folder AS ff"
+           "       ON fr.id = ff.id)"
+           "   ON film_id = film_rolls_id "
+           " WHERE %s"
+           " GROUP BY folder, film_rolls_id", where_ext);
           // clang-format on
         break;
+
       case DT_COLLECTION_PROP_TAG:
       {
         const gboolean is_insensitive =
@@ -1298,75 +1385,84 @@ static void tree_view(dt_lib_collect_rule_t *dr)
 
         if(is_insensitive)
           // clang-format off
-          query = g_strdup_printf("SELECT name, 1 AS tagid, SUM(count) AS count"
-                                  " FROM (SELECT tagid, COUNT(*) as count"
-                                  "   FROM main.images AS mi"
-                                  "   JOIN main.tagged_images"
-                                  "     ON id = imgid "
-                                  "   WHERE %s"
-                                  "   GROUP BY tagid)"
-                                  " JOIN (SELECT lower(name) AS name, id AS tag_id FROM data.tags)"
-                                  "   ON tagid = tag_id"
-                                  "   GROUP BY name", where_ext);
+          query = g_strdup_printf
+            ("SELECT name, 1 AS tagid, SUM(count) AS count"
+             " FROM (SELECT tagid, COUNT(*) as count"
+             "   FROM main.images AS mi"
+             "   JOIN main.tagged_images"
+             "     ON id = imgid "
+             "   WHERE %s"
+             "   GROUP BY tagid)"
+             " JOIN (SELECT lower(name) AS name, id AS tag_id FROM data.tags)"
+             "   ON tagid = tag_id"
+             "   GROUP BY name", where_ext);
           // clang-format on
         else
           // clang-format off
-          query = g_strdup_printf("SELECT name, tagid, count"
-                                  " FROM (SELECT tagid, COUNT(*) AS count"
-                                  "  FROM main.images AS mi"
-                                  "  JOIN main.tagged_images"
-                                  "     ON id = imgid "
-                                  "  WHERE %s"
-                                  "  GROUP BY tagid)"
-                                  " JOIN (SELECT name, id AS tag_id FROM data.tags)"
-                                  "   ON tagid = tag_id"
-                                  , where_ext);
+          query = g_strdup_printf
+            ("SELECT name, tagid, count"
+             " FROM (SELECT tagid, COUNT(*) AS count"
+             "  FROM main.images AS mi"
+             "  JOIN main.tagged_images"
+             "     ON id = imgid "
+             "  WHERE %s"
+             "  GROUP BY tagid)"
+             " JOIN (SELECT name, id AS tag_id FROM data.tags)"
+             "   ON tagid = tag_id"
+             , where_ext);
           // clang-format on
 
         // clang-format off
-        query = dt_util_dstrcat(query, " UNION ALL "
-                                       "SELECT '%s' AS name, 0 as id, COUNT(*) AS count "
-                                       "FROM main.images AS mi "
-                                       "WHERE mi.id NOT IN"
-                                       "  (SELECT DISTINCT imgid FROM main.tagged_images AS ti"
-                                       "   WHERE ti.tagid NOT IN memory.darktable_tags)",
-                                _("not tagged"));
+        query = dt_util_dstrcat
+          (query, " UNION ALL "
+           "SELECT '%s' AS name, 0 as id, COUNT(*) AS count "
+           "FROM main.images AS mi "
+           "WHERE mi.id NOT IN"
+           "  (SELECT DISTINCT imgid FROM main.tagged_images AS ti"
+           "   WHERE ti.tagid NOT IN memory.darktable_tags)",
+           _("not tagged"));
         // clang-format on
       }
       break;
+
       case DT_COLLECTION_PROP_GEOTAGGING:
         // clang-format off
-        query = g_strdup_printf("SELECT "
-                                " CASE WHEN mi.longitude IS NULL"
-                                "           OR mi.latitude IS null THEN \'%s\'"
-                                "      ELSE CASE WHEN ta.imgid IS NULL THEN \'%s\'"
-                                "                ELSE \'%s\' || ta.tagname"
-                                "                END"
-                                "      END AS name,"
-                                " ta.tagid AS tag_id, COUNT(*) AS count"
-                                " FROM main.images AS mi"
-                                " LEFT JOIN (SELECT imgid, t.id AS tagid, SUBSTR(t.name, %d) AS tagname"
-                                "   FROM main.tagged_images AS ti"
-                                "   JOIN data.tags AS t"
-                                "     ON ti.tagid = t.id"
-                                "   JOIN data.locations AS l"
-                                "     ON l.tagid = t.id"
-                                "   ) AS ta ON ta.imgid = mi.id"
-                                " WHERE %s"
-                                " GROUP BY name, tag_id",
-                                _("not tagged"), _("tagged"), _("tagged"),
-                                (int)strlen(dt_map_location_data_tag_root()) + 1, where_ext);
+        query = g_strdup_printf
+          ("SELECT "
+           " CASE WHEN mi.longitude IS NULL"
+           "           OR mi.latitude IS null THEN \'%s\'"
+           "      ELSE CASE WHEN ta.imgid IS NULL THEN \'%s\'"
+           "                ELSE \'%s\' || ta.tagname"
+           "                END"
+           "      END AS name,"
+           " ta.tagid AS tag_id, COUNT(*) AS count"
+           " FROM main.images AS mi"
+           " LEFT JOIN (SELECT imgid, t.id AS tagid, SUBSTR(t.name, %d) AS tagname"
+           "   FROM main.tagged_images AS ti"
+           "   JOIN data.tags AS t"
+           "     ON ti.tagid = t.id"
+           "   JOIN data.locations AS l"
+           "     ON l.tagid = t.id"
+           "   ) AS ta ON ta.imgid = mi.id"
+           " WHERE %s"
+           " GROUP BY name, tag_id",
+           _("not tagged"), _("tagged"), _("tagged"),
+           (int)strlen(dt_map_location_data_tag_root()) + 1, where_ext);
         // clang-format on
         break;
+
       case DT_COLLECTION_PROP_DAY:
         // clang-format off
-        query = g_strdup_printf("SELECT (datetime_taken / 86400000000) * 86400000000 AS date, 1, COUNT(*) AS count"
-                                " FROM main.images AS mi"
-                                " WHERE datetime_taken IS NOT NULL AND datetime_taken <> 0"
-                                " AND %s"
-                                " GROUP BY date", where_ext);
+        query = g_strdup_printf
+          ("SELECT (datetime_taken / 86400000000) * 86400000000 AS date, 1,"
+           "        COUNT(*) AS count"
+           " FROM main.images AS mi"
+           " WHERE datetime_taken IS NOT NULL AND datetime_taken <> 0"
+           " AND %s"
+           " GROUP BY date", where_ext);
         // clang-format on
         break;
+
       case DT_COLLECTION_PROP_TIME:
       case DT_COLLECTION_PROP_IMPORT_TIMESTAMP:
       case DT_COLLECTION_PROP_CHANGE_TIMESTAMP:
@@ -1378,11 +1474,21 @@ static void tree_view(dt_lib_collect_rule_t *dr)
 
         switch(local_property)
         {
-          case DT_COLLECTION_PROP_TIME: colname = "datetime_taken" ; break ;
-          case DT_COLLECTION_PROP_IMPORT_TIMESTAMP: colname = "import_timestamp" ; break ;
-          case DT_COLLECTION_PROP_CHANGE_TIMESTAMP: colname = "change_timestamp" ; break ;
-          case DT_COLLECTION_PROP_EXPORT_TIMESTAMP: colname = "export_timestamp" ; break ;
-          case DT_COLLECTION_PROP_PRINT_TIMESTAMP: colname = "print_timestamp" ; break ;
+          case DT_COLLECTION_PROP_TIME:
+            colname = "datetime_taken";
+            break;
+          case DT_COLLECTION_PROP_IMPORT_TIMESTAMP:
+            colname = "import_timestamp";
+            break;
+          case DT_COLLECTION_PROP_CHANGE_TIMESTAMP:
+            colname = "change_timestamp";
+            break;
+          case DT_COLLECTION_PROP_EXPORT_TIMESTAMP:
+            colname = "export_timestamp";
+            break;
+          case DT_COLLECTION_PROP_PRINT_TIMESTAMP:
+            colname = "print_timestamp";
+            break;
         }
         // clang-format off
         query = g_strdup_printf("SELECT %s AS date, 1, COUNT(*) AS count"
@@ -1410,7 +1516,7 @@ static void tree_view(dt_lib_collect_rule_t *dr)
     while(sqlite3_step(stmt) == SQLITE_ROW)
     {
       char *name;
-      if(is_time_property(property) || property == DT_COLLECTION_PROP_DAY)
+      if(_is_time_property(property) || property == DT_COLLECTION_PROP_DAY)
       {
         char sdt[DT_DATETIME_EXIF_LENGTH] = {0};
         dt_datetime_gtimespan_to_exif(sdt, sizeof(sdt), sqlite3_column_int64(stmt, 0));
@@ -1442,20 +1548,24 @@ static void tree_view(dt_lib_collect_rule_t *dr)
       tuple->name = name;
       tuple->collate_key = collate_key;
       tuple->count = count;
-      tuple->status = property == DT_COLLECTION_PROP_FOLDERS ? sqlite3_column_int(stmt, 3) : -1;
+      tuple->status = property == DT_COLLECTION_PROP_FOLDERS
+                        ? sqlite3_column_int(stmt, 3)
+                        : -1;
       sorted_names = g_list_prepend(sorted_names, tuple);
     }
     sqlite3_finalize(stmt);
     g_free(query);
+
     // this order should not be altered. the right feeding of the tree relies on it.
     sorted_names = g_list_sort(sorted_names, sort_folder_tag);
     const gboolean sort_descend = dt_conf_get_bool("plugins/collect/descending");
     if(!sort_descend)
       sorted_names = g_list_reverse(sorted_names);
 
-    gboolean no_uncategorized = (property == DT_COLLECTION_PROP_TAG)
-                                    ? dt_conf_get_bool("plugins/lighttable/tagging/no_uncategorized")
-                                    : TRUE;
+    const gboolean no_uncategorized =
+      (property == DT_COLLECTION_PROP_TAG)
+      ? dt_conf_get_bool("plugins/lighttable/tagging/no_uncategorized")
+      : TRUE;
 
     for(GList *names = sorted_names; names; names = g_list_next(names))
     {
@@ -1469,7 +1579,10 @@ static void tree_view(dt_lib_collect_rule_t *dr)
       gboolean uncategorized_found = FALSE;
       if(!no_uncategorized && strchr(name, '|') == NULL)
       {
-        char *next_name = g_strdup(names->next ? ((name_key_tuple_t *)names->next->data)->name : "");
+        char *next_name = g_strdup(names->next
+                                   ? ((name_key_tuple_t *)names->next->data)->name
+                                   : "");
+
         if(strlen(next_name) >= strlen(name) + 1 && next_name[strlen(name)] == '|')
           next_name[strlen(name)] = '\0';
 
@@ -1478,18 +1591,22 @@ static void tree_view(dt_lib_collect_rule_t *dr)
           /* add uncategorized root iter if not exists */
           if(!uncategorized.stamp)
           {
-            gtk_tree_store_insert_with_values(GTK_TREE_STORE(model), &uncategorized, NULL, -1,
-                                              DT_LIB_COLLECT_COL_TEXT, _(UNCATEGORIZED_TAG),
-                                              DT_LIB_COLLECT_COL_PATH, "", DT_LIB_COLLECT_COL_VISIBLE, TRUE,
-                                              DT_LIB_COLLECT_COL_INDEX, index, -1);
+            gtk_tree_store_insert_with_values
+              (GTK_TREE_STORE(model), &uncategorized, NULL, -1,
+               DT_LIB_COLLECT_COL_TEXT, _(UNCATEGORIZED_TAG),
+               DT_LIB_COLLECT_COL_PATH, "", DT_LIB_COLLECT_COL_VISIBLE, TRUE,
+               DT_LIB_COLLECT_COL_INDEX, index, -1);
             index++;
           }
 
           /* adding an uncategorized tag */
-          gtk_tree_store_insert_with_values(GTK_TREE_STORE(model), &temp, &uncategorized, 0,
-                                            DT_LIB_COLLECT_COL_TEXT, name,
-                                            DT_LIB_COLLECT_COL_PATH, name, DT_LIB_COLLECT_COL_VISIBLE, TRUE,
-                                            DT_LIB_COLLECT_COL_COUNT, count, DT_LIB_COLLECT_COL_INDEX, index, -1);
+          gtk_tree_store_insert_with_values
+            (GTK_TREE_STORE(model), &temp, &uncategorized, 0,
+             DT_LIB_COLLECT_COL_TEXT, name,
+             DT_LIB_COLLECT_COL_PATH, name,
+             DT_LIB_COLLECT_COL_VISIBLE, TRUE,
+             DT_LIB_COLLECT_COL_COUNT, count,
+             DT_LIB_COLLECT_COL_INDEX, index, -1);
           uncategorized_found = TRUE;
           index++;
         }
@@ -1503,7 +1620,7 @@ static void tree_view(dt_lib_collect_rule_t *dr)
           tokens = split_path(name);
         else if(property == DT_COLLECTION_PROP_DAY)
           tokens = g_strsplit(name, ":", -1);
-        else if(is_time_property(property))
+        else if(_is_time_property(property))
           tokens = g_strsplit_set(name, ": ", 4);
         else
           tokens = g_strsplit(name, "|", -1);
@@ -1545,27 +1662,31 @@ static void tree_view(dt_lib_collect_rule_t *dr)
             GtkTreeIter iter;
 
             pth = dt_util_dstrcat(pth, format_separator, *token);
-            if(is_time_property(property) && !*(token + 1)) pth[10] = ' ';
+            if(_is_time_property(property) && !*(token + 1)) pth[10] = ' ';
 
             gchar *pth2 = g_strdup(pth);
             pth2[strlen(pth2) - 1] = '\0';
-            gtk_tree_store_insert_with_values(GTK_TREE_STORE(model), &iter, common_length > 0 ? &parent : NULL, 0,
-                                              DT_LIB_COLLECT_COL_TEXT, *token,
-                                              DT_LIB_COLLECT_COL_PATH, pth2, DT_LIB_COLLECT_COL_VISIBLE, TRUE,
-                                              DT_LIB_COLLECT_COL_COUNT, (*(token + 1)?0:count),
-                                              DT_LIB_COLLECT_COL_INDEX, index,
-                                              DT_LIB_COLLECT_COL_UNREACHABLE, (*(token + 1) ? 0 : !status), -1);
+            gtk_tree_store_insert_with_values
+              (GTK_TREE_STORE(model), &iter, common_length > 0 ? &parent : NULL, 0,
+               DT_LIB_COLLECT_COL_TEXT, *token,
+               DT_LIB_COLLECT_COL_PATH, pth2, DT_LIB_COLLECT_COL_VISIBLE, TRUE,
+               DT_LIB_COLLECT_COL_COUNT, (*(token + 1)?0:count),
+               DT_LIB_COLLECT_COL_INDEX, index,
+               DT_LIB_COLLECT_COL_UNREACHABLE, (*(token + 1) ? 0 : !status), -1);
             index++;
             // also add the item count to parents
-            if((property == DT_COLLECTION_PROP_DAY || is_time_property(property)) && !*(token + 1))
+            if((property == DT_COLLECTION_PROP_DAY
+                || _is_time_property(property)) && !*(token + 1))
             {
               guint parentcount;
               GtkTreeIter parent2, child = iter;
 
               while(gtk_tree_model_iter_parent(model, &parent2, &child))
               {
-                gtk_tree_model_get(model, &parent2, DT_LIB_COLLECT_COL_COUNT, &parentcount, -1);
-                gtk_tree_store_set(GTK_TREE_STORE(model), &parent2, DT_LIB_COLLECT_COL_COUNT, count + parentcount, -1);
+                gtk_tree_model_get(model, &parent2,
+                                   DT_LIB_COLLECT_COL_COUNT, &parentcount, -1);
+                gtk_tree_store_set(GTK_TREE_STORE(model), &parent2,
+                                   DT_LIB_COLLECT_COL_COUNT, count + parentcount, -1);
                 child = parent2;
               }
             }
@@ -1592,7 +1713,7 @@ static void tree_view(dt_lib_collect_rule_t *dr)
     d->treefilter = _create_filtered_model(model, dr);
 
     GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(d->view));
-    if(property == DT_COLLECTION_PROP_DAY || is_time_property(property))
+    if(property == DT_COLLECTION_PROP_DAY || _is_time_property(property))
     {
       gtk_tree_selection_set_mode(selection, GTK_SELECTION_MULTIPLE);
     }
@@ -1615,7 +1736,7 @@ static void tree_view(dt_lib_collect_rule_t *dr)
   gtk_tree_view_collapse_all(d->view);
 
   // prepare datetime entry data
-  if(is_time_property(property) || property == DT_COLLECTION_PROP_DAY)
+  if(_is_time_property(property) || property == DT_COLLECTION_PROP_DAY)
   {
     gchar *number1, *number2;
     dt_collection_split_operator_datetime(gtk_entry_get_text(GTK_ENTRY(dr->text)),
@@ -1630,9 +1751,12 @@ static void tree_view(dt_lib_collect_rule_t *dr)
 
   dr->sensitive = (property == DT_COLLECTION_PROP_TAG &&
      dt_conf_is_equal("plugins/lighttable/tagging/case_sensitivity", "sensitive"));
-  gchar *needle = dr->sensitive ? g_strdup(gtk_entry_get_text(GTK_ENTRY(dr->text)))
-                                : g_utf8_strdown(gtk_entry_get_text(GTK_ENTRY(dr->text)), -1);
-  if(g_str_has_suffix(needle, "%")) needle[strlen(needle) - 1] = '\0';
+  gchar *needle = dr->sensitive
+    ? g_strdup(gtk_entry_get_text(GTK_ENTRY(dr->text)))
+    : g_utf8_strdown(gtk_entry_get_text(GTK_ENTRY(dr->text)), -1);
+
+  if(g_str_has_suffix(needle, "%"))
+    needle[strlen(needle) - 1] = '\0';
   dr->startwildcard = needle[0] == '%';
   dr->searchstring =  needle[0] == '%' ? &needle[1] : needle;
   dr->expanded_path = NULL;
@@ -1643,7 +1767,7 @@ static void tree_view(dt_lib_collect_rule_t *dr)
 
   if(!needle[0]) {} // do nothing
   // select/expand items corresponding to entry
-  else if(property == DT_COLLECTION_PROP_DAY || is_time_property(property))
+  else if(property == DT_COLLECTION_PROP_DAY || _is_time_property(property))
   {
     if(strcmp(dr->datetime_range.operator, "[]") == 0)
     {
@@ -1673,7 +1797,7 @@ static void tree_view(dt_lib_collect_rule_t *dr)
   g_free(needle);
 }
 
-static void list_view(dt_lib_collect_rule_t *dr)
+static void _list_view(dt_lib_collect_rule_t *dr)
 {
   // update related list
   dt_lib_collect_t *d = get_collect(dr);
@@ -1681,7 +1805,8 @@ static void list_view(dt_lib_collect_rule_t *dr)
 
   set_properties(dr);
 
-  GtkTreeModel *model = gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(d->listfilter));
+  GtkTreeModel *model =
+    gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(d->listfilter));
   if(d->view_rule != property)
   {
     sqlite3_stmt *stmt;
@@ -1720,9 +1845,12 @@ static void list_view(dt_lib_collect_rule_t *dr)
           gchar *value_path = g_strdup_printf("\"%s\"", value);
 
           gtk_list_store_append(GTK_LIST_STORE(model), &iter);
-          gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_LIB_COLLECT_COL_TEXT, value,
-                             DT_LIB_COLLECT_COL_ID, index, DT_LIB_COLLECT_COL_TOOLTIP, value,
-                             DT_LIB_COLLECT_COL_PATH, value_path, DT_LIB_COLLECT_COL_VISIBLE, TRUE,
+          gtk_list_store_set(GTK_LIST_STORE(model), &iter,
+                             DT_LIB_COLLECT_COL_TEXT, value,
+                             DT_LIB_COLLECT_COL_ID, index,
+                             DT_LIB_COLLECT_COL_TOOLTIP, value,
+                             DT_LIB_COLLECT_COL_PATH, value_path,
+                             DT_LIB_COLLECT_COL_VISIBLE, TRUE,
                              DT_LIB_COLLECT_COL_COUNT, count,
                              -1);
 
@@ -1762,7 +1890,9 @@ static void list_view(dt_lib_collect_rule_t *dr)
                    " FROM main.images AS mi "
                    " WHERE %s"
                    " GROUP BY lcp ORDER BY lcp ASC",
-                   DT_IMAGE_LOCAL_COPY, _("copied locally"),  _("not copied locally"), where_ext);
+                   DT_IMAGE_LOCAL_COPY,
+                   _("copied locally"),
+                   _("not copied locally"), where_ext);
         // clang-format on
         break;
 
@@ -1784,7 +1914,7 @@ static void list_view(dt_lib_collect_rule_t *dr)
                    "         WHEN 1 THEN '%s'"
                    "         WHEN 2 THEN '%s'"
                    "         WHEN 3 THEN '%s'"
-                   "         WHEN 4 THEN '%s' "
+                   "         WHEN 4 THEN '%s'"
                    "         ELSE ''"
                    "       END, color, COUNT(*) AS count"
                    " FROM main.images AS mi"
@@ -1813,7 +1943,8 @@ static void list_view(dt_lib_collect_rule_t *dr)
       case DT_COLLECTION_PROP_FOCAL_LENGTH: // focal length
         // clang-format off
         g_snprintf(query, sizeof(query),
-                   "SELECT CAST(focal_length AS INTEGER) AS focal_length, 1, COUNT(*) AS count"
+                   "SELECT CAST(focal_length AS INTEGER) AS focal_length, 1,"
+                   "       COUNT(*) AS count"
                    " FROM main.images AS mi"
                    " WHERE %s"
                    " GROUP BY CAST(focal_length AS INTEGER)"
@@ -1852,7 +1983,7 @@ static void list_view(dt_lib_collect_rule_t *dr)
                    "SELECT CASE"
                    "         WHEN (exposure < 0.4) THEN '1/' || CAST(1/exposure + 0.9 AS INTEGER) "
                    "         ELSE ROUND(exposure,2) || '\"'"
-                   "       END as _exposure, 1, COUNT(*) AS count"
+                   "       END AS _exposure, 1, COUNT(*) AS count"
                    " FROM main.images AS mi"
                    " WHERE %s"
                    " GROUP BY _exposure"
@@ -1892,7 +2023,9 @@ static void list_view(dt_lib_collect_rule_t *dr)
         snprintf(query, sizeof(query),
                  "SELECT m.name AS module_name, 1, COUNT(*) AS count"
                  " FROM main.images AS mi"
-                 " JOIN (SELECT DISTINCT imgid, operation FROM main.history WHERE enabled = 1) AS h"
+                 " JOIN (SELECT DISTINCT imgid, operation"
+                 "       FROM main.history"
+                 "       WHERE enabled = 1) AS h"
                  "  ON h.imgid = mi.id"
                  " JOIN memory.darktable_iop_names AS m"
                  "  ON m.operation = h.operation"
@@ -1931,7 +2064,8 @@ static void list_view(dt_lib_collect_rule_t *dr)
         {
         // clang-format off
           g_snprintf(query, sizeof(query),
-                     "SELECT CASE WHEN (flags & 8) == 8 THEN -1 ELSE (flags & 7) END AS rating, 1,"
+                     "SELECT CASE WHEN (flags & 8) == 8"
+                     "        THEN -1 ELSE (flags & 7) END AS rating, 1,"
                      " COUNT(*) AS count"
                      " FROM main.images AS mi"
                      " WHERE %s"
@@ -1945,7 +2079,8 @@ static void list_view(dt_lib_collect_rule_t *dr)
         if(property >= DT_COLLECTION_PROP_METADATA
            && property < DT_COLLECTION_PROP_METADATA + DT_METADATA_NUMBER)
         {
-          const int keyid = dt_metadata_get_keyid_by_display_order(property - DT_COLLECTION_PROP_METADATA);
+          const int keyid = dt_metadata_get_keyid_by_display_order
+            (property - DT_COLLECTION_PROP_METADATA);
           const char *name = (gchar *)dt_metadata_get_name(keyid);
           char *setting = g_strdup_printf("plugins/lighttable/metadata/%s_flag", name);
           const gboolean hidden = dt_conf_get_int(setting) & DT_METADATA_FLAG_HIDDEN;
@@ -1959,7 +2094,9 @@ static void list_view(dt_lib_collect_rule_t *dr)
                      " 1, COUNT(*) AS count,"
                      " CASE WHEN value IS NULL THEN 0 ELSE 1 END AS force_order"
                      " FROM main.images AS mi"
-                     " LEFT JOIN (SELECT id AS meta_data_id, value FROM main.meta_data WHERE key = %d)"
+                     " LEFT JOIN (SELECT id AS meta_data_id, value"
+                     "            FROM main.meta_data"
+                     "            WHERE key = %d)"
                      "  ON id = meta_data_id"
                      " WHERE %s"
                      " GROUP BY value"
@@ -1972,7 +2109,8 @@ static void list_view(dt_lib_collect_rule_t *dr)
         // filmroll
         {
           gchar *order_by = NULL;
-          const char *filmroll_sort = dt_conf_get_string_const("plugins/collect/filmroll_sort");
+          const char *filmroll_sort =
+            dt_conf_get_string_const("plugins/collect/filmroll_sort");
           if(strcmp(filmroll_sort, "id") == 0)
             order_by = g_strdup("film_rolls_id DESC");
           else
@@ -2023,14 +2161,19 @@ static void list_view(dt_lib_collect_rule_t *dr)
         // replace invalid utf8 characters if any
         gchar *text = g_strdup(value);
         gchar *ptr = text;
-        while(!g_utf8_validate(ptr, -1, (const gchar **)&ptr)) ptr[0] = '?';
+        while(!g_utf8_validate(ptr, -1, (const gchar **)&ptr))
+          ptr[0] = '?';
 
         gchar *escaped_text = g_markup_escape_text(text, -1);
 
-        gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_LIB_COLLECT_COL_TEXT, folder,
-                           DT_LIB_COLLECT_COL_ID, sqlite3_column_int(stmt, 1), DT_LIB_COLLECT_COL_TOOLTIP,
-                           escaped_text, DT_LIB_COLLECT_COL_PATH, value, DT_LIB_COLLECT_COL_VISIBLE, TRUE,
-                           DT_LIB_COLLECT_COL_COUNT, count, DT_LIB_COLLECT_COL_UNREACHABLE, status,
+        gtk_list_store_set(GTK_LIST_STORE(model), &iter,
+                           DT_LIB_COLLECT_COL_TEXT, folder,
+                           DT_LIB_COLLECT_COL_ID, sqlite3_column_int(stmt, 1),
+                           DT_LIB_COLLECT_COL_TOOLTIP, escaped_text,
+                           DT_LIB_COLLECT_COL_PATH, value,
+                           DT_LIB_COLLECT_COL_VISIBLE, TRUE,
+                           DT_LIB_COLLECT_COL_COUNT, count,
+                           DT_LIB_COLLECT_COL_UNREACHABLE, status,
                            -1);
 
         g_free(text);
@@ -2044,9 +2187,12 @@ static void list_view(dt_lib_collect_rule_t *dr)
     d->listfilter = _create_filtered_model(model, dr);
 
     GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(d->view));
-    if(property == DT_COLLECTION_PROP_APERTURE || property == DT_COLLECTION_PROP_FOCAL_LENGTH
-       || property == DT_COLLECTION_PROP_ISO || property == DT_COLLECTION_PROP_EXPOSURE
-       || property == DT_COLLECTION_PROP_ASPECT_RATIO || property == DT_COLLECTION_PROP_RATING)
+    if(property == DT_COLLECTION_PROP_APERTURE
+       || property == DT_COLLECTION_PROP_FOCAL_LENGTH
+       || property == DT_COLLECTION_PROP_ISO
+       || property == DT_COLLECTION_PROP_EXPOSURE
+       || property == DT_COLLECTION_PROP_ASPECT_RATIO
+       || property == DT_COLLECTION_PROP_RATING)
     {
       gtk_tree_selection_set_mode(selection, GTK_SELECTION_MULTIPLE);
     }
@@ -2066,16 +2212,22 @@ static void list_view(dt_lib_collect_rule_t *dr)
 
   // if needed, we restrict the tree to matching entries
   if(dr->typing
-     && (property == DT_COLLECTION_PROP_CAMERA || property == DT_COLLECTION_PROP_FILENAME
-         || property == DT_COLLECTION_PROP_FILMROLL || property == DT_COLLECTION_PROP_LENS
-         || property == DT_COLLECTION_PROP_APERTURE || property == DT_COLLECTION_PROP_FOCAL_LENGTH
-         || property == DT_COLLECTION_PROP_ISO || property == DT_COLLECTION_PROP_MODULE
-         || property == DT_COLLECTION_PROP_ORDER || property == DT_COLLECTION_PROP_RATING
+     && (property == DT_COLLECTION_PROP_CAMERA
+         || property == DT_COLLECTION_PROP_FILENAME
+         || property == DT_COLLECTION_PROP_FILMROLL
+         || property == DT_COLLECTION_PROP_LENS
+         || property == DT_COLLECTION_PROP_APERTURE
+         || property == DT_COLLECTION_PROP_FOCAL_LENGTH
+         || property == DT_COLLECTION_PROP_ISO
+         || property == DT_COLLECTION_PROP_MODULE
+         || property == DT_COLLECTION_PROP_ORDER
+         || property == DT_COLLECTION_PROP_RATING
          || (property >= DT_COLLECTION_PROP_METADATA
              && property < DT_COLLECTION_PROP_METADATA + DT_METADATA_NUMBER)))
   {
     gchar *needle = g_utf8_strdown(gtk_entry_get_text(GTK_ENTRY(dr->text)), -1);
-    if(g_str_has_suffix(needle, "%")) needle[strlen(needle) - 1] = '\0';
+    if(g_str_has_suffix(needle, "%"))
+      needle[strlen(needle) - 1] = '\0';
     dr->searchstring = needle;
     gtk_tree_model_foreach(model, (GtkTreeModelForeachFunc)list_match_string, dr);
     dr->searchstring = NULL;
@@ -2084,16 +2236,20 @@ static void list_view(dt_lib_collect_rule_t *dr)
   // we update list selection
   gtk_tree_selection_unselect_all(gtk_tree_view_get_selection(d->view));
 
-  if(property == DT_COLLECTION_PROP_APERTURE || property == DT_COLLECTION_PROP_FOCAL_LENGTH
-     || property == DT_COLLECTION_PROP_ISO || property == DT_COLLECTION_PROP_EXPOSURE
-     || property == DT_COLLECTION_PROP_ASPECT_RATIO || property == DT_COLLECTION_PROP_RATING)
+  if(property == DT_COLLECTION_PROP_APERTURE
+     || property == DT_COLLECTION_PROP_FOCAL_LENGTH
+     || property == DT_COLLECTION_PROP_ISO
+     || property == DT_COLLECTION_PROP_EXPOSURE
+     || property == DT_COLLECTION_PROP_ASPECT_RATIO
+     || property == DT_COLLECTION_PROP_RATING)
   {
     // test selection range [xxx;xxx]
     GRegex *regex;
     GMatchInfo *match_info;
 
     regex = g_regex_new("^\\s*\\[\\s*(.*)\\s*;\\s*(.*)\\s*\\]\\s*$", 0, 0, NULL);
-    g_regex_match_full(regex, gtk_entry_get_text(GTK_ENTRY(dr->text)), -1, 0, 0, &match_info, NULL);
+    g_regex_match_full(regex, gtk_entry_get_text(GTK_ENTRY(dr->text)), -1, 0, 0,
+                       &match_info, NULL);
     const int match_count = g_match_info_get_match_count(match_info);
 
     if(match_count == 3)
@@ -2105,7 +2261,8 @@ static void list_view(dt_lib_collect_rule_t *dr)
       gtk_tree_model_foreach(d->listfilter, (GtkTreeModelForeachFunc)range_select, range);
       if(range->path1 && range->path2)
       {
-        gtk_tree_selection_select_range(gtk_tree_view_get_selection(d->view), range->path1, range->path2);
+        gtk_tree_selection_select_range(gtk_tree_view_get_selection(d->view),
+                                        range->path1, range->path2);
       }
       g_free(range->start);
       g_free(range->stop);
@@ -2127,20 +2284,24 @@ static void update_view(dt_lib_collect_rule_t *dr)
 {
   const int property = _combo_get_active_collection(dr->combo);
 
-  if(property == DT_COLLECTION_PROP_FOLDERS || property == DT_COLLECTION_PROP_TAG
-     || property == DT_COLLECTION_PROP_GEOTAGGING || property == DT_COLLECTION_PROP_DAY
-     || is_time_property(property))
-    tree_view(dr);
+  if(property == DT_COLLECTION_PROP_FOLDERS
+     || property == DT_COLLECTION_PROP_TAG
+     || property == DT_COLLECTION_PROP_GEOTAGGING
+     || property == DT_COLLECTION_PROP_DAY
+     || _is_time_property(property))
+    _tree_view(dr);
   else
-    list_view(dr);
+    _list_view(dr);
 }
 
 static void _set_tooltip(dt_lib_collect_rule_t *d)
 {
   const int property = _combo_get_active_collection(d->combo);
 
-  if(property == DT_COLLECTION_PROP_APERTURE || property == DT_COLLECTION_PROP_FOCAL_LENGTH
-     || property == DT_COLLECTION_PROP_ISO || property == DT_COLLECTION_PROP_ASPECT_RATIO
+  if(property == DT_COLLECTION_PROP_APERTURE
+     || property == DT_COLLECTION_PROP_FOCAL_LENGTH
+     || property == DT_COLLECTION_PROP_ISO
+     || property == DT_COLLECTION_PROP_ASPECT_RATIO
      || property == DT_COLLECTION_PROP_EXPOSURE)
   {
     gtk_widget_set_tooltip_text(d->text, _("use <, <=, >, >=, <>, =, [;] as operators"));
@@ -2151,11 +2312,12 @@ static void _set_tooltip(dt_lib_collect_rule_t *d)
                                            "star rating: 0-5\n"
                                            "rejected images: -1"));
   }
-  else if(property == DT_COLLECTION_PROP_DAY || is_time_property(property))
+  else if(property == DT_COLLECTION_PROP_DAY || _is_time_property(property))
   {
-    gtk_widget_set_tooltip_text(d->text,
-                                _("use <, <=, >, >=, <>, =, [;] as operators\n"
-                                  "type dates in the form: YYYY:MM:DD hh:mm:ss.sss (only the year is mandatory)"));
+    gtk_widget_set_tooltip_text
+      (d->text,
+       _("use <, <=, >, >=, <>, =, [;] as operators\n"
+         "type dates in the form: YYYY:MM:DD hh:mm:ss.sss (only the year is mandatory)"));
   }
   else if(property == DT_COLLECTION_PROP_FILENAME)
   {
@@ -2165,39 +2327,42 @@ static void _set_tooltip(dt_lib_collect_rule_t *d)
   }
   else if(property == DT_COLLECTION_PROP_TAG)
   {
-    gtk_widget_set_tooltip_text(d->text,
-                                /* xgettext:no-c-format */
-                                _("use `%' as wildcard\n"
-                                  /* xgettext:no-c-format */
-                                  "click to include hierarchy + sub-hierarchies (suffix `*')\n"
-                                  /* xgettext:no-c-format */
-                                  "shift+click to include only the current hierarchy (no suffix)\n"
-                                  /* xgettext:no-c-format */
-                                  "ctrl+click to include only sub-hierarchies (suffix `|%')"));
+    gtk_widget_set_tooltip_text
+      (d->text,
+       /* xgettext:no-c-format */
+       _("use `%' as wildcard\n"
+         /* xgettext:no-c-format */
+         "click to include hierarchy + sub-hierarchies (suffix `*')\n"
+         /* xgettext:no-c-format */
+         "shift+click to include only the current hierarchy (no suffix)\n"
+         /* xgettext:no-c-format */
+         "ctrl+click to include only sub-hierarchies (suffix `|%')"));
   }
   else if(property == DT_COLLECTION_PROP_GEOTAGGING)
   {
-    gtk_widget_set_tooltip_text(d->text,
-                                /* xgettext:no-c-format */
-                                _("use `%' as wildcard\n"
-                                  /* xgettext:no-c-format */
-                                  "click to include location + sub-locations (suffix `*')\n"
-                                  /* xgettext:no-c-format */
-                                  "shift+click to include only the current location (no suffix)\n"
-                                  /* xgettext:no-c-format */
-                                  "ctrl+click to include only sub-locations (suffix `|%')"));
+    gtk_widget_set_tooltip_text
+      (d->text,
+       /* xgettext:no-c-format */
+       _("use `%' as wildcard\n"
+         /* xgettext:no-c-format */
+         "click to include location + sub-locations (suffix `*')\n"
+         /* xgettext:no-c-format */
+         "shift+click to include only the current location (no suffix)\n"
+         /* xgettext:no-c-format */
+         "ctrl+click to include only sub-locations (suffix `|%')"));
   }
   else if(property == DT_COLLECTION_PROP_FOLDERS)
   {
-    gtk_widget_set_tooltip_text(d->text,
-                                /* xgettext:no-c-format */
-                                _("use `%' as wildcard\n"
-                                  /* xgettext:no-c-format */
-                                  "click to include current + sub-folders (suffix `*')\n"
-                                  /* xgettext:no-c-format */
-                                  "shift+click to include only the current folder (no suffix)\n"
-                                  /* xgettext:no-c-format */
-                                  "ctrl+click to include only sub-folders (suffix `|%')"));
+    gtk_widget_set_tooltip_text
+      (d->text,
+       /* xgettext:no-c-format */
+       _("use `%' as wildcard\n"
+         /* xgettext:no-c-format */
+         "click to include current + sub-folders (suffix `*')\n"
+         /* xgettext:no-c-format */
+         "shift+click to include only the current folder (no suffix)\n"
+         /* xgettext:no-c-format */
+         "ctrl+click to include only sub-folders (suffix `|%')"));
   }
   else
   {
@@ -2307,7 +2472,8 @@ void gui_reset(dt_lib_module_t *self)
   dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
 }
 
-static void combo_changed(GtkWidget *combo, dt_lib_collect_rule_t *d)
+static void combo_changed(GtkWidget *combo,
+                          dt_lib_collect_rule_t *d)
 {
   if(darktable.gui->reset) return;
   g_signal_handlers_block_matched(d->text, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, entry_changed, NULL);
@@ -2319,7 +2485,7 @@ static void combo_changed(GtkWidget *combo, dt_lib_collect_rule_t *d)
 
   if(property == DT_COLLECTION_PROP_FOLDERS || property == DT_COLLECTION_PROP_TAG
      || property == DT_COLLECTION_PROP_GEOTAGGING || property == DT_COLLECTION_PROP_DAY
-     || is_time_property(property))
+     || _is_time_property(property))
   {
     d->typing = FALSE;
   }
@@ -2396,9 +2562,13 @@ static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTr
       }
     }
     else if(gtk_tree_selection_count_selected_rows(selection) > 1
-            && (item == DT_COLLECTION_PROP_DAY || is_time_property(item) || item == DT_COLLECTION_PROP_APERTURE
-                || item == DT_COLLECTION_PROP_FOCAL_LENGTH || item == DT_COLLECTION_PROP_ISO
-                || item == DT_COLLECTION_PROP_EXPOSURE || item == DT_COLLECTION_PROP_ASPECT_RATIO
+            && (item == DT_COLLECTION_PROP_DAY
+                || _is_time_property(item)
+                || item == DT_COLLECTION_PROP_APERTURE
+                || item == DT_COLLECTION_PROP_FOCAL_LENGTH
+                || item == DT_COLLECTION_PROP_ISO
+                || item == DT_COLLECTION_PROP_EXPOSURE
+                || item == DT_COLLECTION_PROP_ASPECT_RATIO
                 || item == DT_COLLECTION_PROP_RATING))
     {
       /* this is a range selection */
@@ -2450,16 +2620,23 @@ static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTr
   }
   g_list_free_full(sels, (GDestroyNotify)gtk_tree_path_free);
 
-  g_signal_handlers_block_matched(d->rule[active].text, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, entry_changed, NULL);
+  g_signal_handlers_block_matched(d->rule[active].text,
+                                  G_SIGNAL_MATCH_FUNC, 0, 0, NULL, entry_changed, NULL);
   gtk_entry_set_text(GTK_ENTRY(d->rule[active].text), text);
   gtk_editable_set_position(GTK_EDITABLE(d->rule[active].text), -1);
-  g_signal_handlers_unblock_matched(d->rule[active].text, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, entry_changed, NULL);
+  g_signal_handlers_unblock_matched(d->rule[active].text,
+                                    G_SIGNAL_MATCH_FUNC, 0, 0, NULL, entry_changed, NULL);
   g_free(text);
 
-  if(item == DT_COLLECTION_PROP_TAG || (item == DT_COLLECTION_PROP_FOLDERS && !force_update_view)
-     || item == DT_COLLECTION_PROP_DAY || is_time_property(item) || item == DT_COLLECTION_PROP_COLORLABEL
-     || item == DT_COLLECTION_PROP_GEOTAGGING || item == DT_COLLECTION_PROP_HISTORY
-     || item == DT_COLLECTION_PROP_LOCAL_COPY || item == DT_COLLECTION_PROP_GROUPING)
+  if(item == DT_COLLECTION_PROP_TAG
+     || (item == DT_COLLECTION_PROP_FOLDERS && !force_update_view)
+     || item == DT_COLLECTION_PROP_DAY
+     || _is_time_property(item)
+     || item == DT_COLLECTION_PROP_COLORLABEL
+     || item == DT_COLLECTION_PROP_GEOTAGGING
+     || item == DT_COLLECTION_PROP_HISTORY
+     || item == DT_COLLECTION_PROP_LOCAL_COPY
+     || item == DT_COLLECTION_PROP_GROUPING)
   {
     set_properties(d->rule + active); // we just have to set the selection
   }
@@ -2468,15 +2645,21 @@ static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTr
 
   dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(collection_updated),
                                   darktable.view_manager->proxy.module_collect.module);
-  if(order) DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGES_ORDER_CHANGE, order);
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
+  if(order)
+    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
+                                  DT_SIGNAL_IMAGES_ORDER_CHANGE, order);
+
+  dt_collection_update_query(darktable.collection,
+                             DT_COLLECTION_CHANGE_NEW_QUERY,
+                             DT_COLLECTION_PROP_UNDEF, NULL);
   dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(collection_updated),
                                     darktable.view_manager->proxy.module_collect.module);
   gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));
   dt_control_queue_redraw_center();
 }
 
-static void entry_activated(GtkWidget *entry, dt_lib_collect_rule_t *d)
+static void entry_activated(GtkWidget *entry,
+                            dt_lib_collect_rule_t *d)
 {
   GtkTreeView *view;
   GtkTreeModel *model;
@@ -2487,9 +2670,11 @@ static void entry_activated(GtkWidget *entry, dt_lib_collect_rule_t *d)
 
   const int property = _combo_get_active_collection(d->combo);
 
-  if(property != DT_COLLECTION_PROP_FOLDERS && property != DT_COLLECTION_PROP_TAG
-     && property != DT_COLLECTION_PROP_GEOTAGGING && property != DT_COLLECTION_PROP_DAY
-     && !is_time_property(property))
+  if(property != DT_COLLECTION_PROP_FOLDERS
+     && property != DT_COLLECTION_PROP_TAG
+     && property != DT_COLLECTION_PROP_GEOTAGGING
+     && property != DT_COLLECTION_PROP_DAY
+     && !_is_time_property(property))
   {
     view = c->view;
     model = gtk_tree_view_get_model(GTK_TREE_VIEW(view));
@@ -2505,26 +2690,35 @@ static void entry_activated(GtkWidget *entry, dt_lib_collect_rule_t *d)
         gchar *text;
         gtk_tree_model_get(model, &iter, DT_LIB_COLLECT_COL_PATH, &text, -1);
 
-        g_signal_handlers_block_matched(d->text, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, entry_changed, NULL);
+        g_signal_handlers_block_matched(d->text,
+                                        G_SIGNAL_MATCH_FUNC,
+                                        0, 0, NULL, entry_changed, NULL);
         gtk_entry_set_text(GTK_ENTRY(d->text), text);
         gtk_editable_set_position(GTK_EDITABLE(d->text), -1);
-        g_signal_handlers_unblock_matched(d->text, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, entry_changed, NULL);
+        g_signal_handlers_unblock_matched(d->text,
+                                          G_SIGNAL_MATCH_FUNC,
+                                          0, 0, NULL, entry_changed, NULL);
         g_free(text);
         update_view(d);
       }
     }
   }
-  dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(collection_updated),
+  dt_control_signal_block_by_func(darktable.signals,
+                                  G_CALLBACK(collection_updated),
                                   darktable.view_manager->proxy.module_collect.module);
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
-  dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(collection_updated),
+  dt_collection_update_query(darktable.collection,
+                             DT_COLLECTION_CHANGE_NEW_QUERY,
+                             DT_COLLECTION_PROP_UNDEF, NULL);
+  dt_control_signal_unblock_by_func(darktable.signals,
+                                    G_CALLBACK(collection_updated),
                                     darktable.view_manager->proxy.module_collect.module);
   d->typing = FALSE;
 
   dt_control_queue_redraw_center();
 }
 
-static void entry_changed(GtkEntry *entry, dt_lib_collect_rule_t *dr)
+static void entry_changed(GtkEntry *entry,
+                          dt_lib_collect_rule_t *dr)
 {
   dr->typing = TRUE;
   update_view(dr);
@@ -2535,7 +2729,9 @@ int position(const dt_lib_module_t *self)
   return 400;
 }
 
-static gboolean entry_focus_in_callback(GtkWidget *w, GdkEventFocus *event, dt_lib_collect_rule_t *d)
+static gboolean entry_focus_in_callback(GtkWidget *w,
+                                        GdkEventFocus *event,
+                                        dt_lib_collect_rule_t *d)
 {
   dt_lib_collect_t *c = get_collect(d);
   if(c->active_rule != d->num)
@@ -2547,7 +2743,8 @@ static gboolean entry_focus_in_callback(GtkWidget *w, GdkEventFocus *event, dt_l
   return FALSE;
 }
 
-static void menuitem_mode(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d)
+static void menuitem_mode(GtkMenuItem *menuitem,
+                          dt_lib_collect_rule_t *d)
 {
   // add next row with and operator
   const int _a = dt_conf_get_int("plugins/lighttable/collect/num_rules");
@@ -2556,7 +2753,8 @@ static void menuitem_mode(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d)
   {
     char confname[200] = { 0 };
     snprintf(confname, sizeof(confname), "plugins/lighttable/collect/mode%1d", active);
-    const dt_lib_collect_mode_t mode = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(menuitem), "menuitem_mode"));
+    const dt_lib_collect_mode_t mode =
+      GPOINTER_TO_INT(g_object_get_data(G_OBJECT(menuitem), "menuitem_mode"));
     dt_conf_set_int(confname, mode);
     snprintf(confname, sizeof(confname), "plugins/lighttable/collect/string%1d", active);
     dt_conf_set_string(confname, "");
@@ -2565,10 +2763,13 @@ static void menuitem_mode(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d)
     c->active_rule = active;
     c->view_rule = -1;
   }
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
+  dt_collection_update_query(darktable.collection,
+                             DT_COLLECTION_CHANGE_NEW_QUERY,
+                             DT_COLLECTION_PROP_UNDEF, NULL);
 }
 
-static void menuitem_mode_change(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d)
+static void menuitem_mode_change(GtkMenuItem *menuitem,
+                                 dt_lib_collect_rule_t *d)
 {
   // add next row with and operator
   const int num = d->num + 1;
@@ -2576,16 +2777,23 @@ static void menuitem_mode_change(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d
   {
     char confname[200] = { 0 };
     snprintf(confname, sizeof(confname), "plugins/lighttable/collect/mode%1d", num);
-    const dt_lib_collect_mode_t mode = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(menuitem), "menuitem_mode"));
+    const dt_lib_collect_mode_t mode =
+      GPOINTER_TO_INT(g_object_get_data(G_OBJECT(menuitem), "menuitem_mode"));
     dt_conf_set_int(confname, mode);
   }
   dt_lib_collect_t *c = get_collect(d);
   c->view_rule = -1;
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
+  dt_collection_update_query(darktable.collection,
+                             DT_COLLECTION_CHANGE_NEW_QUERY,
+                             DT_COLLECTION_PROP_UNDEF, NULL);
 }
 
-static void collection_updated(gpointer instance, dt_collection_change_t query_change,
-                               dt_collection_properties_t changed_property, gpointer imgs, int next, gpointer self)
+static void collection_updated(gpointer instance,
+                               dt_collection_change_t query_change,
+                               dt_collection_properties_t changed_property,
+                               gpointer imgs,
+                               int next,
+                               gpointer self)
 {
   dt_lib_module_t *dm = (dt_lib_module_t *)self;
   dt_lib_collect_t *d = (dt_lib_collect_t *)dm->data;
@@ -2596,10 +2804,12 @@ static void collection_updated(gpointer instance, dt_collection_change_t query_c
 
   // determine if we want to refresh the tree or not
   gboolean refresh = TRUE;
-  if(query_change == DT_COLLECTION_CHANGE_RELOAD && changed_property != DT_COLLECTION_PROP_UNDEF)
+  if(query_change == DT_COLLECTION_CHANGE_RELOAD
+     && changed_property != DT_COLLECTION_PROP_UNDEF)
   {
-    // if we only reload the collection, that means that we don't change the query itself
-    // so we only rebuild the treeview if a used property has changed
+    // if we only reload the collection, that means that we don't
+    // change the query itself so we only rebuild the treeview if a
+    // used property has changed
     refresh = FALSE;
     for(int i = 0; i <= d->active_rule; i++)
     {
@@ -2616,13 +2826,16 @@ static void collection_updated(gpointer instance, dt_collection_change_t query_c
 }
 
 
-static void filmrolls_updated(gpointer instance, gpointer self)
+static void filmrolls_updated(gpointer instance,
+                              gpointer self)
 {
   // TODO: We should update the count of images here
   _lib_collect_gui_update(self);
 }
 
-static void filmrolls_imported(gpointer instance, int film_id, gpointer self)
+static void filmrolls_imported(gpointer instance,
+                               const int film_id,
+                               gpointer self)
 {
   dt_lib_module_t *dm = (dt_lib_module_t *)self;
   dt_lib_collect_t *d = (dt_lib_collect_t *)dm->data;
@@ -2633,12 +2846,16 @@ static void filmrolls_imported(gpointer instance, int film_id, gpointer self)
   _lib_collect_gui_update(self);
 }
 
-static void preferences_changed(gpointer instance, gpointer self)
+static void preferences_changed(gpointer instance,
+                                gpointer self)
 {
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF, NULL);
+  dt_collection_update_query(darktable.collection,
+                             DT_COLLECTION_CHANGE_RELOAD,
+                             DT_COLLECTION_PROP_UNDEF, NULL);
 }
 
-static void filmrolls_removed(gpointer instance, gpointer self)
+static void filmrolls_removed(gpointer instance,
+                              gpointer self)
 {
   dt_lib_module_t *dm = (dt_lib_module_t *)self;
   dt_lib_collect_t *d = (dt_lib_collect_t *)dm->data;
@@ -2652,7 +2869,8 @@ static void filmrolls_removed(gpointer instance, gpointer self)
   _lib_collect_gui_update(self);
 }
 
-static void tag_changed(gpointer instance, gpointer self)
+static void tag_changed(gpointer instance,
+                        gpointer self)
 {
   dt_lib_module_t *dm = (dt_lib_module_t *)self;
   dt_lib_collect_t *d = (dt_lib_collect_t *)dm->data;
@@ -2663,33 +2881,44 @@ static void tag_changed(gpointer instance, gpointer self)
     d->rule[d->active_rule].typing = FALSE;
 
     // need to reload collection since we have tags as active collection filter
-    dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(collection_updated),
+    dt_control_signal_block_by_func(darktable.signals,
+                                    G_CALLBACK(collection_updated),
                                     darktable.view_manager->proxy.module_collect.module);
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_TAG, NULL);
-    dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(collection_updated),
+    dt_collection_update_query(darktable.collection,
+                               DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_TAG, NULL);
+    dt_control_signal_unblock_by_func(darktable.signals,
+                                      G_CALLBACK(collection_updated),
                                       darktable.view_manager->proxy.module_collect.module);
   }
   else
   {
-    // currently tag filter isn't the one selected but it might be in one of rules. needs check
+    // currently tag filter isn't the one selected but it might be in
+    // one of rules. needs check
     gboolean needs_update = FALSE;
     for(int i = 0; i < d->nb_rules && !needs_update; i++)
     {
-      needs_update = needs_update || _combo_get_active_collection(d->rule[i].combo) == DT_COLLECTION_PROP_TAG;
+      needs_update = needs_update
+        || _combo_get_active_collection(d->rule[i].combo) == DT_COLLECTION_PROP_TAG;
     }
     if(needs_update)
     {
       // we have tags as one of rules, needs reload.
-      dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(collection_updated),
+      dt_control_signal_block_by_func(darktable.signals,
+                                      G_CALLBACK(collection_updated),
                                       darktable.view_manager->proxy.module_collect.module);
-      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_TAG, NULL);
-      dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(collection_updated),
+      dt_collection_update_query(darktable.collection,
+                                 DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_TAG, NULL);
+      dt_control_signal_unblock_by_func(darktable.signals,
+                                        G_CALLBACK(collection_updated),
                                         darktable.view_manager->proxy.module_collect.module);
     }
   }
 }
 
-static void _geotag_changed(gpointer instance, GList *imgs, const int locid, gpointer self)
+static void _geotag_changed(gpointer instance,
+                            GList *imgs,
+                            const int locid,
+                            gpointer self)
 {
   // if locid <> NULL this event doesn't concern collect module
   if(!locid)
@@ -2697,24 +2926,30 @@ static void _geotag_changed(gpointer instance, GList *imgs, const int locid, gpo
     dt_lib_module_t *dm = (dt_lib_module_t *)self;
     dt_lib_collect_t *d = (dt_lib_collect_t *)dm->data;
     // update tree
-    if(_combo_get_active_collection(d->rule[d->active_rule].combo) == DT_COLLECTION_PROP_GEOTAGGING)
+    if(_combo_get_active_collection(d->rule[d->active_rule].combo)
+       == DT_COLLECTION_PROP_GEOTAGGING)
     {
       d->view_rule = -1;
       d->rule[d->active_rule].typing = FALSE;
       _lib_collect_gui_update(self);
 
       //need to reload collection since we have geotags as active collection filter
-      dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(collection_updated),
+      dt_control_signal_block_by_func(darktable.signals,
+                                      G_CALLBACK(collection_updated),
                                       darktable.view_manager->proxy.module_collect.module);
-      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_GEOTAGGING,
+      dt_collection_update_query(darktable.collection,
+                                 DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_GEOTAGGING,
                                  NULL);
-      dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(collection_updated),
+      dt_control_signal_unblock_by_func(darktable.signals,
+                                        G_CALLBACK(collection_updated),
                                         darktable.view_manager->proxy.module_collect.module);
     }
   }
 }
 
-static void metadata_changed(gpointer instance, int type, gpointer self)
+static void metadata_changed(gpointer instance,
+                             int type,
+                             gpointer self)
 {
   dt_lib_module_t *dm = (dt_lib_module_t *)self;
   dt_lib_collect_t *d = (dt_lib_collect_t *)dm->data;
@@ -2724,20 +2959,28 @@ static void metadata_changed(gpointer instance, int type, gpointer self)
     // hidden/shown metadata have changed - update the collection list
     for(int i = 0; i < MAX_RULES; i++)
     {
-      g_signal_handlers_block_matched(d->rule[i].combo, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, combo_changed, NULL);
+      g_signal_handlers_block_matched(d->rule[i].combo,
+                                      G_SIGNAL_MATCH_FUNC, 0, 0, NULL,
+                                      combo_changed, NULL);
       const int property = _combo_get_active_collection(d->rule[i].combo);
       dt_bauhaus_combobox_clear(d->rule[i].combo);
       _populate_collect_combo(d->rule[i].combo);
       if(property != -1 && !_combo_set_active_collection(d->rule[i].combo, property))
       {
         // this one has been hidden - remove entry
-        g_signal_handlers_block_matched(d->rule[i].text, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, entry_changed, NULL);
+        g_signal_handlers_block_matched(d->rule[i].text,
+                                        G_SIGNAL_MATCH_FUNC, 0, 0, NULL,
+                                        entry_changed, NULL);
         gtk_entry_set_text(GTK_ENTRY(d->rule[i].text), "");
-        g_signal_handlers_unblock_matched(d->rule[i].text, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, entry_changed, NULL);
+        g_signal_handlers_unblock_matched(d->rule[i].text,
+                                          G_SIGNAL_MATCH_FUNC, 0, 0, NULL,
+                                          entry_changed, NULL);
         d->rule[i].typing = FALSE;
         set_properties(&d->rule[i]);
       }
-      g_signal_handlers_unblock_matched(d->rule[i].combo, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, combo_changed, NULL);
+      g_signal_handlers_unblock_matched(d->rule[i].combo,
+                                        G_SIGNAL_MATCH_FUNC, 0, 0, NULL,
+                                        combo_changed, NULL);
     }
   }
 
@@ -2747,12 +2990,15 @@ static void metadata_changed(gpointer instance, int type, gpointer self)
      || (prop >= DT_COLLECTION_PROP_METADATA
          && prop < DT_COLLECTION_PROP_METADATA + DT_METADATA_NUMBER))
   {
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_METADATA,
+    dt_collection_update_query(darktable.collection,
+                               DT_COLLECTION_CHANGE_RELOAD,
+                               DT_COLLECTION_PROP_METADATA,
                                NULL);
   }
 }
 
-static void menuitem_clear(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d)
+static void menuitem_clear(GtkMenuItem *menuitem,
+                           dt_lib_collect_rule_t *d)
 {
   // remove this row, or if 1st, clear text entry box
   const int _a = dt_conf_get_int("plugins/lighttable/collect/num_rules");
@@ -2793,12 +3039,17 @@ static void menuitem_clear(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d)
   }
 
   c->view_rule = -1;
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
+  dt_collection_update_query(darktable.collection,
+                             DT_COLLECTION_CHANGE_NEW_QUERY,
+                             DT_COLLECTION_PROP_UNDEF, NULL);
 }
 
-static gboolean popup_button_callback(GtkWidget *widget, GdkEventButton *event, dt_lib_collect_rule_t *d)
+static gboolean popup_button_callback(GtkWidget *widget,
+                                      GdkEventButton *event,
+                                      dt_lib_collect_rule_t *d)
 {
-  if(event->button != 1) return FALSE;
+  if(event->button != 1)
+    return FALSE;
 
   GtkWidget *menu = gtk_menu_new();
   GtkWidget *mi;
@@ -2812,36 +3063,48 @@ static gboolean popup_button_callback(GtkWidget *widget, GdkEventButton *event, 
   if(d->num == active - 1)
   {
     mi = gtk_menu_item_new_with_label(_("narrow down search"));
-    g_object_set_data(G_OBJECT(mi), "menuitem_mode", GINT_TO_POINTER(DT_LIB_COLLECT_MODE_AND));
+    g_object_set_data(G_OBJECT(mi), "menuitem_mode",
+                      GINT_TO_POINTER(DT_LIB_COLLECT_MODE_AND));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
-    g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_mode), d);
+    g_signal_connect(G_OBJECT(mi), "activate",
+                     G_CALLBACK(menuitem_mode), d);
 
     mi = gtk_menu_item_new_with_label(_("add more images"));
-    g_object_set_data(G_OBJECT(mi), "menuitem_mode", GINT_TO_POINTER(DT_LIB_COLLECT_MODE_OR));
+    g_object_set_data(G_OBJECT(mi), "menuitem_mode",
+                      GINT_TO_POINTER(DT_LIB_COLLECT_MODE_OR));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
-    g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_mode), d);
+    g_signal_connect(G_OBJECT(mi), "activate",
+                     G_CALLBACK(menuitem_mode), d);
 
     mi = gtk_menu_item_new_with_label(_("exclude images"));
-    g_object_set_data(G_OBJECT(mi), "menuitem_mode", GINT_TO_POINTER(DT_LIB_COLLECT_MODE_AND_NOT));
+    g_object_set_data(G_OBJECT(mi), "menuitem_mode",
+                      GINT_TO_POINTER(DT_LIB_COLLECT_MODE_AND_NOT));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
-    g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_mode), d);
+    g_signal_connect(G_OBJECT(mi), "activate",
+                     G_CALLBACK(menuitem_mode), d);
   }
   else if(d->num < active - 1)
   {
     mi = gtk_menu_item_new_with_label(_("change to: and"));
-    g_object_set_data(G_OBJECT(mi), "menuitem_mode", GINT_TO_POINTER(DT_LIB_COLLECT_MODE_AND));
+    g_object_set_data(G_OBJECT(mi), "menuitem_mode",
+                      GINT_TO_POINTER(DT_LIB_COLLECT_MODE_AND));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
-    g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_mode_change), d);
+    g_signal_connect(G_OBJECT(mi), "activate",
+                     G_CALLBACK(menuitem_mode_change), d);
 
     mi = gtk_menu_item_new_with_label(_("change to: or"));
-    g_object_set_data(G_OBJECT(mi), "menuitem_mode", GINT_TO_POINTER(DT_LIB_COLLECT_MODE_OR));
+    g_object_set_data(G_OBJECT(mi), "menuitem_mode",
+                      GINT_TO_POINTER(DT_LIB_COLLECT_MODE_OR));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
-    g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_mode_change), d);
+    g_signal_connect(G_OBJECT(mi), "activate",
+                     G_CALLBACK(menuitem_mode_change), d);
 
     mi = gtk_menu_item_new_with_label(_("change to: except"));
-    g_object_set_data(G_OBJECT(mi), "menuitem_mode", GINT_TO_POINTER(DT_LIB_COLLECT_MODE_AND_NOT));
+    g_object_set_data(G_OBJECT(mi), "menuitem_mode",
+                      GINT_TO_POINTER(DT_LIB_COLLECT_MODE_AND_NOT));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
-    g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_mode_change), d);
+    g_signal_connect(G_OBJECT(mi), "activate",
+                     G_CALLBACK(menuitem_mode_change), d);
   }
 
   gtk_widget_show_all(GTK_WIDGET(menu));
@@ -2851,7 +3114,8 @@ static gboolean popup_button_callback(GtkWidget *widget, GdkEventButton *event, 
   return TRUE;
 }
 
-static void view_set_click(gpointer instance, gpointer user_data)
+static void view_set_click(gpointer instance,
+                           gpointer user_data)
 {
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_collect_t *d = (dt_lib_collect_t *)self->data;
@@ -2861,7 +3125,8 @@ static void view_set_click(gpointer instance, gpointer user_data)
 static void _populate_collect_combo(GtkWidget *w)
 {
 #define ADD_COLLECT_ENTRY(value)                                                              \
-  dt_bauhaus_combobox_add_full(w, dt_collection_name(value), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, \
+  dt_bauhaus_combobox_add_full(w, dt_collection_name(value), \
+                               DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT,         \
                                GUINT_TO_POINTER(value + 1), NULL, TRUE)
 
     dt_bauhaus_combobox_add_section(w, _("files"));
@@ -2915,13 +3180,15 @@ static void _populate_collect_combo(GtkWidget *w)
 #undef ADD_COLLECT_ENTRY
 }
 
-void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
+void _menuitem_preferences(GtkMenuItem *menuitem,
+                           dt_lib_module_t *self)
 {
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  GtkWidget *dialog = gtk_dialog_new_with_buttons(_("collections settings"), GTK_WINDOW(win),
-                                                  GTK_DIALOG_DESTROY_WITH_PARENT,
-                                                  _("_cancel"), GTK_RESPONSE_NONE,
-                                                  _("_save"), GTK_RESPONSE_ACCEPT, NULL);
+  GtkWidget *dialog = gtk_dialog_new_with_buttons
+    (_("collections settings"), GTK_WINDOW(win),
+     GTK_DIALOG_DESTROY_WITH_PARENT,
+     _("_cancel"), GTK_RESPONSE_NONE,
+     _("_save"), GTK_RESPONSE_ACCEPT, NULL);
   gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
   dt_prefs_init_dialog_collect(dialog);
   g_signal_connect(dialog, "key-press-event", G_CALLBACK(dt_handle_dialog_enter), NULL);
@@ -2937,17 +3204,23 @@ void _menuitem_preferences(GtkMenuItem *menuitem, dt_lib_module_t *self)
     dt_view_collection_update_history_state(darktable.view_manager);
   }
   gtk_widget_destroy(dialog);
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL);
+  dt_collection_update_query(darktable.collection,
+                             DT_COLLECTION_CHANGE_NEW_QUERY,
+                             DT_COLLECTION_PROP_UNDEF, NULL);
 }
 
-void set_preferences(void *menu, dt_lib_module_t *self)
+void set_preferences(void *menu,
+                     dt_lib_module_t *self)
 {
   GtkWidget *mi = gtk_menu_item_new_with_label(_("preferences..."));
   g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_menuitem_preferences), self);
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
 }
 
-static gint _sort_model_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIter *b, dt_lib_module_t *self)
+static gint _sort_model_func(GtkTreeModel *model,
+                             GtkTreeIter *a,
+                             GtkTreeIter *b,
+                             dt_lib_module_t *self)
 {
   gint ia, ib;
   gtk_tree_model_get(model, a, DT_LIB_COLLECT_COL_INDEX, &ia, -1);
@@ -2956,32 +3229,38 @@ static gint _sort_model_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIter *b
 }
 
 #ifdef _WIN32
-void _mount_changed(GVolumeMonitor *volume_monitor, GMount *mount, dt_lib_module_t *self)
+void _mount_changed(GVolumeMonitor *volume_monitor,
+                    GMount *mount,
+                    dt_lib_module_t *self)
 #else
-void _mount_changed(GUnixMountMonitor *monitor, dt_lib_module_t *self)
+void _mount_changed(GUnixMountMonitor *monitor,
+                    dt_lib_module_t *self)
 #endif
 {
   dt_lib_collect_t *d = (dt_lib_collect_t *)self->data;
   dt_film_set_folder_status();
-  // very rough update (rebuild the view). As these events are not too many that remains acceptable
-  // adding film_id to treeview and listview would be cleaner to update just the parameter "reachable"
+  // very rough update (rebuild the view). As these events are not too
+  // many that remains acceptable adding film_id to treeview and
+  // listview would be cleaner to update just the parameter
+  // "reachable"
   dt_lib_collect_rule_t *dr = d->rule + d->active_rule;
   const int property = _combo_get_active_collection(dr->combo);
   if(property == DT_COLLECTION_PROP_FOLDERS)
   {
     d->rule[d->active_rule].typing = FALSE;
     d->view_rule = -1;
-    tree_view(dr);
+    _tree_view(dr);
   }
   else if(property == DT_COLLECTION_PROP_FILMROLL)
   {
     d->rule[d->active_rule].typing = FALSE;
     d->view_rule = -1;
-    list_view(dr);
+    _list_view(dr);
   }
 }
 
-static void _history_apply(GtkWidget *widget, dt_lib_module_t *self)
+static void _history_apply(GtkWidget *widget,
+                           dt_lib_module_t *self)
 {
   const int hid = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget), "history"));
   if(hid < 0 || hid >= dt_conf_get_int("plugins/lighttable/collect/history_max")) return;
@@ -2993,7 +3272,8 @@ static void _history_apply(GtkWidget *widget, dt_lib_module_t *self)
   const char *line = dt_conf_get_string_const(confname);
   if(line && line[0] != '\0')
   {
-    // we store the wanted offset which will be set by thumbtable on collection_change signal
+    // we store the wanted offset which will be set by thumbtable on
+    // collection_change signal
     dt_conf_set_int("plugins/lighttable/collect/history_next_pos", pos);
 
     const int prev_property = dt_conf_get_int("plugins/lighttable/collect/item0");
@@ -3002,24 +3282,30 @@ static void _history_apply(GtkWidget *widget, dt_lib_module_t *self)
     // for the tag property we need to adjust the order accordingly
     const int new_property = dt_conf_get_int("plugins/lighttable/collect/item0");
     gchar *order = NULL;
-    if(prev_property != DT_COLLECTION_PROP_TAG && new_property == DT_COLLECTION_PROP_TAG)
+    if(prev_property != DT_COLLECTION_PROP_TAG
+       && new_property == DT_COLLECTION_PROP_TAG)
     {
       // save global order
       char buf[4096] = { 0 };
       dt_collection_sort_serialize(buf, sizeof(buf));
       dt_conf_set_string("plugins/lighttable/collect/lastorder", buf);
     }
-    else if(prev_property == DT_COLLECTION_PROP_TAG && new_property != DT_COLLECTION_PROP_TAG)
+    else if(prev_property == DT_COLLECTION_PROP_TAG
+            && new_property != DT_COLLECTION_PROP_TAG)
     {
       // restore global order
       order = dt_conf_get_string("plugins/lighttable/collect/lastorder");
       dt_collection_set_tag_id((dt_collection_t *)darktable.collection, 0);
     }
-    if(order) DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGES_ORDER_CHANGE, order);
+    if(order)
+      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
+                                    DT_SIGNAL_IMAGES_ORDER_CHANGE, order);
   }
 }
 
-static void _history_pretty_print(const char *buf, char *out, size_t outsize)
+static void _history_pretty_print(const char *buf,
+                                  char *out,
+                                  size_t outsize)
 {
   memset(out, 0, outsize);
 
@@ -3078,7 +3364,8 @@ static void _history_pretty_print(const char *buf, char *out, size_t outsize)
       else
         pretty = g_markup_escape_text(str, -1);
 
-      c = snprintf(out, outsize, "<b>%s</b> %s", item < DT_COLLECTION_PROP_LAST ? dt_collection_name(item) : "???",
+      c = snprintf(out, outsize, "<b>%s</b> %s",
+                   item < DT_COLLECTION_PROP_LAST ? dt_collection_name(item) : "???",
                    pretty);
       g_free(pretty);
       out += c;
@@ -3089,7 +3376,8 @@ static void _history_pretty_print(const char *buf, char *out, size_t outsize)
   }
 }
 
-static void _history_show(GtkWidget *widget, gpointer user_data)
+static void _history_show(GtkWidget *widget,
+                          gpointer user_data)
 {
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   // we show a popup with all the history entries
@@ -3159,19 +3447,23 @@ void gui_init(dt_lib_module_t *self)
     gtk_widget_set_name(GTK_WIDGET(box), "lib-dtbutton");
 
     d->rule[i].combo = dt_bauhaus_combobox_new(NULL);
-    dt_bauhaus_combobox_set_selected_text_align(d->rule[i].combo, DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
+    dt_bauhaus_combobox_set_selected_text_align(d->rule[i].combo,
+                                                DT_BAUHAUS_COMBOBOX_ALIGN_LEFT);
     _populate_collect_combo(d->rule[i].combo);
     dt_bauhaus_combobox_mute_scrolling(d->rule[i].combo);
-    if(_combo_get_active_collection(d->rule[i].combo) == DT_COLLECTION_PROP_MODULE) has_iop_name_rule = TRUE;
+    if(_combo_get_active_collection(d->rule[i].combo) == DT_COLLECTION_PROP_MODULE)
+      has_iop_name_rule = TRUE;
 
-    g_signal_connect(G_OBJECT(d->rule[i].combo), "value-changed", G_CALLBACK(combo_changed), d->rule + i);
+    g_signal_connect(G_OBJECT(d->rule[i].combo), "value-changed",
+                     G_CALLBACK(combo_changed), d->rule + i);
     gtk_box_pack_start(box, d->rule[i].combo, FALSE, TRUE, 0);
 
     w = gtk_entry_new();
     gtk_entry_set_max_width_chars(GTK_ENTRY(w), 10);
     d->rule[i].text = w;
     gtk_widget_add_events(w, GDK_FOCUS_CHANGE_MASK);
-    g_signal_connect(G_OBJECT(w), "focus-in-event", G_CALLBACK(entry_focus_in_callback), d->rule + i);
+    g_signal_connect(G_OBJECT(w), "focus-in-event",
+                     G_CALLBACK(entry_focus_in_callback), d->rule + i);
 
     /* xgettext:no-c-format */
     gtk_widget_add_events(w, GDK_KEY_PRESS_MASK);
@@ -3184,7 +3476,8 @@ void gui_init(dt_lib_module_t *self)
     dt_gui_add_class(GTK_WIDGET(w), "dt_big_btn_canvas");
     d->rule[i].button = w;
     gtk_widget_set_events(w, GDK_BUTTON_PRESS_MASK);
-    g_signal_connect(G_OBJECT(w), "button-press-event", G_CALLBACK(popup_button_callback), d->rule + i);
+    g_signal_connect(G_OBJECT(w), "button-press-event",
+                     G_CALLBACK(popup_button_callback), d->rule + i);
     gtk_box_pack_start(box, w, FALSE, FALSE, 0);
   }
 
@@ -3192,7 +3485,8 @@ void gui_init(dt_lib_module_t *self)
   d->view_rule = -1;
   d->view = view;
   gtk_tree_view_set_headers_visible(view, FALSE);
-  g_signal_connect(G_OBJECT(view), "button-press-event", G_CALLBACK(view_onButtonPressed), d);
+  g_signal_connect(G_OBJECT(view), "button-press-event",
+                   G_CALLBACK(view_onButtonPressed), d);
   g_signal_connect(G_OBJECT(view), "popup-menu", G_CALLBACK(view_onPopupMenu), d);
 
   GtkTreeViewColumn *col = gtk_tree_view_column_new();
@@ -3200,26 +3494,34 @@ void gui_init(dt_lib_module_t *self)
   GtkCellRenderer *renderer = gtk_cell_renderer_text_new();
   gtk_tree_view_column_pack_start(col, renderer, TRUE);
   gtk_tree_view_column_set_cell_data_func(col, renderer, tree_count_show, NULL, NULL);
-  g_object_set(renderer, "strikethrough", TRUE, "ellipsize", PANGO_ELLIPSIZE_MIDDLE, (gchar *)0);
-  gtk_tree_view_column_add_attribute(col, renderer, "strikethrough-set", DT_LIB_COLLECT_COL_UNREACHABLE);
+  g_object_set(renderer, "strikethrough", TRUE, "ellipsize",
+               PANGO_ELLIPSIZE_MIDDLE, (gchar *)0);
+  gtk_tree_view_column_add_attribute(col, renderer, "strikethrough-set",
+                                     DT_LIB_COLLECT_COL_UNREACHABLE);
 
-  GtkTreeModel *listmodel = GTK_TREE_MODEL(gtk_list_store_new(DT_LIB_COLLECT_NUM_COLS, G_TYPE_STRING, G_TYPE_UINT,
-                                                              G_TYPE_STRING, G_TYPE_STRING, G_TYPE_BOOLEAN,
-                                                              G_TYPE_BOOLEAN, G_TYPE_UINT, G_TYPE_UINT));
+  GtkTreeModel *listmodel = GTK_TREE_MODEL
+    (gtk_list_store_new
+     (DT_LIB_COLLECT_NUM_COLS, G_TYPE_STRING, G_TYPE_UINT,
+      G_TYPE_STRING, G_TYPE_STRING, G_TYPE_BOOLEAN,
+      G_TYPE_BOOLEAN, G_TYPE_UINT, G_TYPE_UINT));
   gtk_tree_sortable_set_sort_func(GTK_TREE_SORTABLE(listmodel), DT_LIB_COLLECT_COL_INDEX,
                                   (GtkTreeIterCompareFunc)_sort_model_func, self, NULL);
   d->listfilter = gtk_tree_model_filter_new(listmodel, NULL);
-  gtk_tree_model_filter_set_visible_column(GTK_TREE_MODEL_FILTER(d->listfilter), DT_LIB_COLLECT_COL_VISIBLE);
+  gtk_tree_model_filter_set_visible_column
+    (GTK_TREE_MODEL_FILTER(d->listfilter), DT_LIB_COLLECT_COL_VISIBLE);
 
-  GtkTreeModel *treemodel = GTK_TREE_MODEL(gtk_tree_store_new(DT_LIB_COLLECT_NUM_COLS, G_TYPE_STRING, G_TYPE_UINT,
-                                                              G_TYPE_STRING, G_TYPE_STRING, G_TYPE_BOOLEAN,
-                                                              G_TYPE_BOOLEAN, G_TYPE_UINT, G_TYPE_UINT));
+  GtkTreeModel *treemodel = GTK_TREE_MODEL
+    (gtk_tree_store_new(DT_LIB_COLLECT_NUM_COLS, G_TYPE_STRING, G_TYPE_UINT,
+                        G_TYPE_STRING, G_TYPE_STRING, G_TYPE_BOOLEAN,
+                        G_TYPE_BOOLEAN, G_TYPE_UINT, G_TYPE_UINT));
   d->treefilter = gtk_tree_model_filter_new(treemodel, NULL);
-  gtk_tree_model_filter_set_visible_column(GTK_TREE_MODEL_FILTER(d->treefilter), DT_LIB_COLLECT_COL_VISIBLE);
+  gtk_tree_model_filter_set_visible_column(GTK_TREE_MODEL_FILTER(d->treefilter),
+                                           DT_LIB_COLLECT_COL_VISIBLE);
   g_object_unref(treemodel);
 
   gtk_box_pack_start(GTK_BOX(self->widget),
-                     dt_ui_resize_wrap(GTK_WIDGET(view), 200, "plugins/lighttable/collect/windowheight"), TRUE,
+                     dt_ui_resize_wrap(GTK_WIDGET(view), 200,
+                                       "plugins/lighttable/collect/windowheight"), TRUE,
                      TRUE, 0);
 
   // the bottom buttons for the rules
@@ -3228,8 +3530,11 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), d->history_box, TRUE, TRUE, 0);
   // dummy widget just to ensure alignment of history button  with those in filtering lib
   gtk_box_pack_start(GTK_BOX(d->history_box), gtk_drawing_area_new(), TRUE, TRUE, 0);
-  GtkWidget *btn = dt_action_button_new(self, N_("history"), G_CALLBACK(_history_show), self,
-                                        _("revert to a previous set of rules"), GDK_KEY_k, GDK_CONTROL_MASK);
+  GtkWidget *btn = dt_action_button_new(self,
+                                        N_("history"),
+                                        G_CALLBACK(_history_show), self,
+                                        _("revert to a previous set of rules"),
+                                        GDK_KEY_k, GDK_CONTROL_MASK);
   gtk_box_pack_start(GTK_BOX(d->history_box), btn, TRUE, TRUE, 0);
   gtk_widget_show_all(d->history_box);
   gtk_widget_set_no_show_all(d->history_box, TRUE);
@@ -3245,48 +3550,74 @@ void gui_init(dt_lib_module_t *self)
   if(_combo_get_active_collection(d->rule[0].combo) == DT_COLLECTION_PROP_TAG)
   {
     const char *tag = dt_conf_get_string_const("plugins/lighttable/collect/string0");
-    dt_collection_set_tag_id((dt_collection_t *)darktable.collection, dt_tag_get_tag_id_by_name(tag));
+    dt_collection_set_tag_id((dt_collection_t *)darktable.collection,
+                             dt_tag_get_tag_id_by_name(tag));
   }
 
 #ifdef _WIN32
   d->vmonitor = g_volume_monitor_get();
-  g_signal_connect(G_OBJECT(d->vmonitor), "mount-changed", G_CALLBACK(_mount_changed), self);
-  g_signal_connect(G_OBJECT(d->vmonitor), "mount-added", G_CALLBACK(_mount_changed), self);
+  g_signal_connect(G_OBJECT(d->vmonitor), "mount-changed",
+                   G_CALLBACK(_mount_changed), self);
+  g_signal_connect(G_OBJECT(d->vmonitor), "mount-added",
+                   G_CALLBACK(_mount_changed), self);
 #else
   d->vmonitor = g_unix_mount_monitor_get();
-  g_signal_connect(G_OBJECT(d->vmonitor), "mounts-changed", G_CALLBACK(_mount_changed), self);
+  g_signal_connect(G_OBJECT(d->vmonitor), "mounts-changed",
+                   G_CALLBACK(_mount_changed), self);
 #endif
 
-  // force redraw collection images because of late update of the table memory.darktable_iop_names
+  // force redraw collection images because of late update of the
+  // table memory.darktable_iop_names
   if(has_iop_name_rule)
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_MODULE, NULL);
+    dt_collection_update_query(darktable.collection,
+                               DT_COLLECTION_CHANGE_RELOAD,
+                               DT_COLLECTION_PROP_MODULE, NULL);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED, G_CALLBACK(collection_updated),
-                            self);
+  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
+                                  DT_SIGNAL_COLLECTION_CHANGED,
+                                  G_CALLBACK(collection_updated),
+                                  self);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED, G_CALLBACK(filmrolls_updated),
-                            self);
+  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
+                                  DT_SIGNAL_FILMROLLS_CHANGED,
+                                  G_CALLBACK(filmrolls_updated),
+                                  self);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE, G_CALLBACK(preferences_changed),
-                            self);
+  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
+                                  DT_SIGNAL_PREFERENCES_CHANGE,
+                                  G_CALLBACK(preferences_changed),
+                                  self);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_FILMROLLS_IMPORTED, G_CALLBACK(filmrolls_imported),
-                            self);
+  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
+                                  DT_SIGNAL_FILMROLLS_IMPORTED,
+                                  G_CALLBACK(filmrolls_imported),
+                                  self);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_FILMROLLS_REMOVED, G_CALLBACK(filmrolls_removed),
-                            self);
+  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
+                                  DT_SIGNAL_FILMROLLS_REMOVED,
+                                  G_CALLBACK(filmrolls_removed),
+                                  self);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_TAG_CHANGED, G_CALLBACK(tag_changed),
-                            self);
+  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
+                                  DT_SIGNAL_TAG_CHANGED,
+                                  G_CALLBACK(tag_changed),
+                                  self);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED, G_CALLBACK(_geotag_changed),
-                            self);
+  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
+                                  DT_SIGNAL_GEOTAG_CHANGED,
+                                  G_CALLBACK(_geotag_changed),
+                                  self);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_METADATA_CHANGED, G_CALLBACK(metadata_changed), self);
+  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
+                                  DT_SIGNAL_METADATA_CHANGED,
+                                  G_CALLBACK(metadata_changed), self);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE, G_CALLBACK(view_set_click), self);
+  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
+                                  DT_SIGNAL_PREFERENCES_CHANGE,
+                                  G_CALLBACK(view_set_click), self);
 
-  dt_action_register(DT_ACTION(self), N_("jump back to previous collection"), _history_previous, GDK_KEY_k,
+  dt_action_register(DT_ACTION(self), N_("jump back to previous collection"),
+                     _history_previous, GDK_KEY_k,
                      GDK_CONTROL_MASK | GDK_SHIFT_MASK);
 }
 
@@ -3294,14 +3625,22 @@ void gui_cleanup(dt_lib_module_t *self)
 {
   dt_lib_collect_t *d = (dt_lib_collect_t *)self->data;
 
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(collection_updated), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(filmrolls_updated), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(filmrolls_imported), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(preferences_changed), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(filmrolls_removed), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(tag_changed), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_geotag_changed), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(view_set_click), self);
+  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
+                                     G_CALLBACK(collection_updated), self);
+  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
+                                     G_CALLBACK(filmrolls_updated), self);
+  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
+                                     G_CALLBACK(filmrolls_imported), self);
+  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
+                                     G_CALLBACK(preferences_changed), self);
+  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
+                                     G_CALLBACK(filmrolls_removed), self);
+  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
+                                     G_CALLBACK(tag_changed), self);
+  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
+                                     G_CALLBACK(_geotag_changed), self);
+  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
+                                     G_CALLBACK(view_set_click), self);
   darktable.view_manager->proxy.module_collect.module = NULL;
   free(d->params);
 
@@ -3317,10 +3656,12 @@ void gui_cleanup(dt_lib_module_t *self)
   self->data = NULL;
 }
 
-static int is_time_property(int property)
+static int _is_time_property(int property)
 {
-  return (property == DT_COLLECTION_PROP_TIME || property == DT_COLLECTION_PROP_IMPORT_TIMESTAMP
-          || property == DT_COLLECTION_PROP_CHANGE_TIMESTAMP || property == DT_COLLECTION_PROP_EXPORT_TIMESTAMP
+  return (property == DT_COLLECTION_PROP_TIME
+          || property == DT_COLLECTION_PROP_IMPORT_TIMESTAMP
+          || property == DT_COLLECTION_PROP_CHANGE_TIMESTAMP
+          || property == DT_COLLECTION_PROP_EXPORT_TIMESTAMP
           || property == DT_COLLECTION_PROP_PRINT_TIMESTAMP);
 }
 
@@ -3380,7 +3721,8 @@ static int filter_cb(lua_State *L)
 
 static int mode_member(lua_State *L)
 {
-  dt_lib_collect_params_rule_t *rule = luaL_checkudata(L, 1, "dt_lib_collect_params_rule_t");
+  dt_lib_collect_params_rule_t *rule =
+    luaL_checkudata(L, 1, "dt_lib_collect_params_rule_t");
 
   if(lua_gettop(L) > 2)
   {
@@ -3390,14 +3732,17 @@ static int mode_member(lua_State *L)
     return 0;
   }
 
-  const dt_lib_collect_mode_t tmp = rule->mode; // temp buffer because of bitfield in the original struct
+  const dt_lib_collect_mode_t tmp = rule->mode; // temp buffer because
+                                                // of bitfield in the
+                                                // original struct
   luaA_push(L, dt_lib_collect_mode_t, &tmp);
   return 1;
 }
 
 static int item_member(lua_State *L)
 {
-  dt_lib_collect_params_rule_t *rule = luaL_checkudata(L, 1, "dt_lib_collect_params_rule_t");
+  dt_lib_collect_params_rule_t *rule =
+    luaL_checkudata(L, 1, "dt_lib_collect_params_rule_t");
 
   if(lua_gettop(L) > 2)
   {
@@ -3407,14 +3752,19 @@ static int item_member(lua_State *L)
     return 0;
   }
 
-  const dt_collection_properties_t tmp = rule->item; // temp buffer because of bitfield in the original struct
+  const dt_collection_properties_t tmp = rule->item; // temp buffer
+                                                     // because of
+                                                     // bitfield in
+                                                     // the original
+                                                     // struct
   luaA_push(L, dt_collection_properties_t, &tmp);
   return 1;
 }
 
 static int data_member(lua_State *L)
 {
-  dt_lib_collect_params_rule_t *rule = luaL_checkudata(L, 1, "dt_lib_collect_params_rule_t");
+  dt_lib_collect_params_rule_t *rule =
+    luaL_checkudata(L, 1, "dt_lib_collect_params_rule_t");
 
   if(lua_gettop(L) > 2)
   {
@@ -3422,7 +3772,8 @@ static int data_member(lua_State *L)
     const char*data = luaL_checklstring(L, 3, &tgt_size);
     if(tgt_size > PARAM_STRING_SIZE)
     {
-      return luaL_error(L, "string '%s' too long (max is %d)", data, PARAM_STRING_SIZE);
+      return luaL_error(L, "string '%s' too long (max is %d)",
+                        data, PARAM_STRING_SIZE);
     }
     g_strlcpy(rule->string, data, sizeof(rule->string));
     return 0;

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2170,18 +2170,48 @@ static void _list_view(dt_lib_collect_rule_t *dr)
       DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
       while(sqlite3_step(stmt) == SQLITE_ROW)
       {
+        const gchar *value = (gchar *)sqlite3_column_text(stmt, 0);
         const char *folder = (const char *)sqlite3_column_text(stmt, 0);
+        const int count = sqlite3_column_int(stmt, 2);
+
         if(folder == NULL) continue; // safeguard against degenerated db entries
 
         gtk_list_store_append(GTK_LIST_STORE(model), &iter);
         int status = 0;
+
         if(property == DT_COLLECTION_PROP_FILMROLL)
         {
           folder = dt_image_film_roll_name(folder);
           status = !sqlite3_column_int(stmt, 3);
         }
-        const gchar *value = (gchar *)sqlite3_column_text(stmt, 0);
-        const int count = sqlite3_column_int(stmt, 2);
+        else if (property == DT_COLLECTION_PROP_RATING)
+        {
+          const int rating = sqlite3_column_int(stmt, 0);
+          switch(rating)
+          {
+             case -1:
+               folder = _("rejected");
+               break;
+             case 0:
+               folder = _("not rated");
+               break;
+             case 1:
+               folder = "★";
+               break;
+             case 2:
+               folder = "★★";
+               break;
+             case 3:
+               folder = "★★★";
+               break;
+             case 4:
+               folder = "★★★★";
+               break;
+             case 5:
+               folder = "★★★★★";
+               break;
+          }
+        }
 
         // replace invalid utf8 characters if any
         gchar *text = g_strdup(value);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1946,8 +1946,8 @@ static void _list_view(dt_lib_collect_rule_t *dr)
                    "  FROM main.images AS mi, main.lens AS ln"
                    "  WHERE mi.lens_id = ln.id"
                    "    AND %s"
-                   "  GROUP BY lens"
-                   "  ORDER BY lens", where_ext);
+                   "  GROUP BY lower(lens)"
+                   "  ORDER BY lower(lens)", where_ext);
         // clang-format on
         break;
 

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2020,11 +2020,15 @@ static void _list_view(dt_lib_collect_rule_t *dr)
                    "SELECT CASE"
                    "         WHEN id = group_id THEN '%s'"
                    "         ELSE '%s'"
-                   "       END as group_leader, 1, COUNT(*) AS count"
+                   "       END as group_leader, 1, COUNT(*) AS count,"
+                   "       CASE"
+                   "         WHEN id = group_id THEN '0'"
+                   "         ELSE '1'"
+                   "       END AS force_order"
                    " FROM main.images AS mi"
                    " WHERE %s"
-                   " GROUP BY group_leader"
-                   " ORDER BY group_leader ASC",
+                   " GROUP BY force_order"
+                   " ORDER BY force_order ASC",
                    _("group leaders"),  _("group followers"), where_ext);
         // clang-format on
         break;

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2009,8 +2009,8 @@ static void _list_view(dt_lib_collect_rule_t *dr)
                    "SELECT filename, 1, COUNT(*) AS count"
                    " FROM main.images AS mi"
                    " WHERE %s"
-                   " GROUP BY filename"
-                   " ORDER BY filename", where_ext);
+                   " GROUP BY lower(filename)"
+                   " ORDER BY lower(filename) ASC", where_ext);
         // clang-format on
         break;
 

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2126,11 +2126,13 @@ static void _list_view(dt_lib_collect_rule_t *dr)
         // filmroll
         {
           gchar *order_by = NULL;
-          const char *filmroll_sort =
-            dt_conf_get_string_const("plugins/collect/filmroll_sort");
+
+          const gboolean is_chronological =
+            dt_conf_is_equal("plugins/collect/filmroll_sort", "chronological");
+
           const gboolean sort_descending = dt_conf_get_bool("plugins/collect/descending");
 
-          if(strcmp(filmroll_sort, "chronological") == 0)
+          if(is_chronological)
           {
             if(sort_descending)
               order_by = g_strdup("film_rolls_id DESC");

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2041,8 +2041,8 @@ static void _list_view(dt_lib_collect_rule_t *dr)
                  " JOIN memory.darktable_iop_names AS m"
                  "  ON m.operation = h.operation"
                  " WHERE %s"
-                 " GROUP BY module_name"
-                 " ORDER BY module_name",
+                 " GROUP BY lower(module_name)"
+                 " ORDER BY lower(module_name) ASC",
                  where_ext);
         // clang-format on
         break;

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1869,13 +1869,19 @@ static void _list_view(dt_lib_collect_rule_t *dr)
                    "       WHEN auto_hash == current_hash THEN '%s'"
                    "       WHEN current_hash IS NOT NULL THEN '%s'"
                    "       ELSE '%s'"
-                   "     END as altered, 1, COUNT(*) AS count"
+                   "     END as altered, 1, COUNT(*) AS count,"
+                   "     CASE"
+                   "       WHEN basic_hash == current_hash THEN 0"
+                   "       WHEN auto_hash == current_hash THEN 1"
+                   "       WHEN current_hash IS NOT NULL THEN 3"
+                   "       ELSE 2"
+                   "     END AS force_order"
                    " FROM main.images AS mi"
                    " LEFT JOIN (SELECT DISTINCT imgid, basic_hash, auto_hash, current_hash"
                    "            FROM main.history_hash) ON id = imgid"
                    " WHERE %s"
-                   " GROUP BY altered"
-                   " ORDER BY altered ASC",
+                   " GROUP BY force_order"
+                   " ORDER BY force_order",
                    _("basic"), _("auto applied"), _("altered"), _("basic"), where_ext);
         // clang-format on
         break;

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1830,8 +1830,8 @@ static void _list_view(dt_lib_collect_rule_t *dr)
            "  FROM main.images AS mi, main.cameras AS cm"
            "  WHERE mi.camera_id = cm.id"
            "    AND %s "
-           "  GROUP BY camera"
-           "  ORDER BY camera", where_ext);
+           "  GROUP BY lower(camera)"
+           "  ORDER BY lower(camera)", where_ext);
         // clang-format on
 
         DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1892,13 +1892,18 @@ static void _list_view(dt_lib_collect_rule_t *dr)
                    "SELECT CASE "
                    "         WHEN (flags & %d) THEN '%s'"
                    "         ELSE '%s'"
-                   "       END as lcp, 1, COUNT(*) AS count"
+                   "       END as lcp, 1, COUNT(*) AS count,"
+                   "       CASE "
+                   "         WHEN (flags & %d) THEN 0"
+                   "         ELSE 1"
+                   "       END as force_order"
                    " FROM main.images AS mi "
                    " WHERE %s"
-                   " GROUP BY lcp ORDER BY lcp ASC",
+                   " GROUP BY force_order ORDER BY force_order",
                    DT_IMAGE_LOCAL_COPY,
                    _("copied locally"),
-                   _("not copied locally"), where_ext);
+                   _("not copied locally"),
+                   DT_IMAGE_LOCAL_COPY, where_ext);
         // clang-format on
         break;
 

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1934,7 +1934,7 @@ static void _list_view(dt_lib_collect_rule_t *dr)
                    " ON id = color_labels_id "
                    " WHERE %s"
                    " GROUP BY color"
-                   " ORDER BY color DESC",
+                   " ORDER BY color ASC",
                    _("red"), _("yellow"), _("green"), _("blue"), _("purple"), where_ext);
         // clang-format on
         break;

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2126,13 +2126,19 @@ static void _list_view(dt_lib_collect_rule_t *dr)
           gchar *order_by = NULL;
           const char *filmroll_sort =
             dt_conf_get_string_const("plugins/collect/filmroll_sort");
-          if(strcmp(filmroll_sort, "id") == 0)
-            order_by = g_strdup("film_rolls_id DESC");
-          else
-            if(dt_conf_get_bool("plugins/collect/descending"))
-              order_by = g_strdup("folder DESC");
+          const gboolean sort_descending = dt_conf_get_bool("plugins/collect/descending");
+
+          if(strcmp(filmroll_sort, "chronological") == 0)
+          {
+            if(sort_descending)
+              order_by = g_strdup("film_rolls_id DESC");
             else
-              order_by = g_strdup("folder");
+              order_by = g_strdup("film_rolls_id");
+          }
+          else
+          {
+            order_by = g_strdup("lower(folder) ASC");
+          }
 
           // clang-format off
           g_snprintf(query, sizeof(query),

--- a/src/libs/filters/camera.c
+++ b/src/libs/filters/camera.c
@@ -103,8 +103,11 @@ void _camera_tree_update(_widgets_camera_t *camera)
     else
     {
       gtk_list_store_append(GTK_LIST_STORE(name_model), &iter);
-      gtk_list_store_set(GTK_LIST_STORE(name_model), &iter, TREE_COL_TEXT, value, TREE_COL_TOOLTIP, value,
-                         TREE_COL_PATH, value_path, TREE_COL_COUNT, count, -1);
+      gtk_list_store_set(GTK_LIST_STORE(name_model), &iter,
+                         TREE_COL_TEXT, value,
+                         TREE_COL_TOOLTIP, value,
+                         TREE_COL_PATH, value_path,
+                         TREE_COL_COUNT, count, -1);
     }
     g_free(value_path);
   }

--- a/src/libs/filters/camera.c
+++ b/src/libs/filters/camera.c
@@ -117,8 +117,11 @@ void _camera_tree_update(_widgets_camera_t *camera)
   if(unset > 0)
   {
     gtk_list_store_append(GTK_LIST_STORE(name_model), &iter);
-    gtk_list_store_set(GTK_LIST_STORE(name_model), &iter, TREE_COL_TEXT, "UNSET", TREE_COL_TOOLTIP,
-                       _("no camera defined."), TREE_COL_PATH, "UNSET", TREE_COL_COUNT, unset, -1);
+    gtk_list_store_set(GTK_LIST_STORE(name_model), &iter,
+                       TREE_COL_TEXT, _("unnamed"),
+                       TREE_COL_TOOLTIP, _("no camera defined."),
+                       TREE_COL_PATH, _("unnamed"),
+                       TREE_COL_COUNT, unset, -1);
   }
   camera->tree_ok = TRUE;
 }

--- a/src/libs/filters/camera.c
+++ b/src/libs/filters/camera.c
@@ -80,7 +80,7 @@ void _camera_tree_update(_widgets_camera_t *camera)
 
   // clang-format off
   g_snprintf(query, sizeof(query),
-             "SELECT cm.maker || ' ' || cm.model AS camera, COUNT(*) AS count"
+             "SELECT TRIM(cm.maker || ' ' || cm.model) AS camera, COUNT(*) AS count"
              " FROM main.images AS mi, main.cameras AS cm"
              " WHERE mi.camera_id = cm.id AND %s"
              " GROUP BY camera"

--- a/src/libs/filters/lens.c
+++ b/src/libs/filters/lens.c
@@ -80,7 +80,10 @@ void _lens_tree_update(_widgets_lens_t *lens)
 
   // clang-format off
   g_snprintf(query, sizeof(query),
-             "SELECT ln.name AS lens, COUNT(*) AS count"
+             "SELECT CASE LOWER(TRIM(ln.name))"
+             "         WHEN 'n/a' THEN ''"
+             "         ELSE ln.name"
+             "       END AS lens, COUNT(*) AS count"
              " FROM main.images AS mi, main.lens AS ln"
              " WHERE mi.lens_id = ln.id AND %s"
              " GROUP BY lens"
@@ -92,10 +95,10 @@ void _lens_tree_update(_widgets_lens_t *lens)
   int unset = 0;
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
-    char *name = (char *)sqlite3_column_text(stmt, 0);
+    const char *name = (char *)sqlite3_column_text(stmt, 0);
     const int count = sqlite3_column_int(stmt, 1);
 
-    if(!name || !g_strcmp0(g_strstrip(name), "") || !g_strcmp0(g_utf8_strup(g_strstrip(name), -1), "N/A"))
+    if(!name || !g_strcmp0(name, ""))
     {
       unset += count;
     }

--- a/src/libs/filters/lens.c
+++ b/src/libs/filters/lens.c
@@ -120,8 +120,11 @@ void _lens_tree_update(_widgets_lens_t *lens)
   if(unset > 0)
   {
     gtk_list_store_append(GTK_LIST_STORE(name_model), &iter);
-    gtk_list_store_set(GTK_LIST_STORE(name_model), &iter, TREE_COL_TEXT, "UNSET", TREE_COL_TOOLTIP,
-                       _("no lens defined."), TREE_COL_PATH, "UNSET", TREE_COL_COUNT, unset, -1);
+    gtk_list_store_set(GTK_LIST_STORE(name_model), &iter,
+                       TREE_COL_TEXT, _("unnamed"),
+                       TREE_COL_TOOLTIP, _("no lens defined."),
+                       TREE_COL_PATH, _("unnamed"),
+                       TREE_COL_COUNT, unset, -1);
   }
   lens->tree_ok = TRUE;
 }

--- a/src/libs/filters/lens.c
+++ b/src/libs/filters/lens.c
@@ -103,8 +103,11 @@ void _lens_tree_update(_widgets_lens_t *lens)
     {
       gchar *value_path = g_strdup_printf("\"%s\"", name);
       gtk_list_store_append(GTK_LIST_STORE(name_model), &iter);
-      gtk_list_store_set(GTK_LIST_STORE(name_model), &iter, TREE_COL_TEXT, name, TREE_COL_TOOLTIP, name,
-                         TREE_COL_PATH, value_path, TREE_COL_COUNT, count, -1);
+      gtk_list_store_set(GTK_LIST_STORE(name_model), &iter,
+                         TREE_COL_TEXT, name,
+                         TREE_COL_TOOLTIP, name,
+                         TREE_COL_PATH, value_path,
+                         TREE_COL_COUNT, count, -1);
       g_free(value_path);
     }
   }


### PR DESCRIPTION
The main part is:

- All date/time can be reversed (older or newer first). Also the folder
can be reversed when sorted according to their id (chronological).
 So all collection entry having a chronological order can be reversed.
    
- All other data are sorted alphabetically and using a non case sensitive
order.

But also:

- Color label entries (the color name) are now displayed the same order as in the GUI and do not depends on translation.
- Group, local copy and history entries are using a stable output non depending on translation.
- The Film-roll collection is now respecting the sort and ordering as for folders when the sorting preference is set to `folder name`.
- A new entry "unnamed" for camera and lens regroups the camera/lens without name (it used to be a simple space). This is now consistent with the filtering module and the text is now translatable.

Some memory leaks fixed.