### PR TITLE
[CI] Remove the macOS 11 build from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,6 @@ jobs:
         build:
           - { os: macos-12,    xcode: 14.2,   deployment: 12.5 } # LLVM14
           - { os: macos-12,    xcode: 13.4,   deployment: 12.0 } # LLVM13
-          - { os: macos-11,    xcode: 13.2.1, deployment: 11.3 } # LLVM12
         compiler:
           - { compiler: XCode,   CC: cc, CXX: c++ }
         btype: [ Debug ]


### PR DESCRIPTION
Some time ago, when building for macOS 11, Homebrew began to issue the following warnings:
```
Warning: You are using macOS 11.
We (and Apple) do not provide support for this old version.
It is expected behaviour that some formulae will fail to build in this old version.
It is expected behaviour that Homebrew will be buggy and slow.
Do not create any issues about this on Homebrew's GitHub repositories.
Do not create any issues even if you think this message is unrelated.
Any opened issues will be immediately closed without response.
Do not ask for help from Homebrew or its maintainers on social media.
You may ask for help in Homebrew's discussions but are unlikely to receive a response.
Try to figure out the problem yourself and submit a fix as a pull request.
We will review it but may or may not accept it.
```

This warning is another reason why there is no point in checking the build of darktable on this outdated version of macOS, which will definitely cease to be supported by  ̷T̷h̷e̷ ̷E̷v̷i̷l̷ ̷E̷m̷p̷i̷r̷e̷  Apple even before the release of darktable 4.6.

Although Apple does not want to specify the end-of-support dates for macOS releases officially, the history of previous releases shows that support does not last longer than 3 years. macOS 11 was released November 12, 2020. Therefore, it makes no sense to release darktable 4.6 for macOS 11 and, accordingly, it makes no sense to use this version of the OS in CI.