### PR TITLE
[CI/CD] Cancel nightly workflow if build for any platform failed

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  actions: write  # We need this to be able to cancel workflow if job fails
 
 jobs:
   AppImage:
@@ -107,6 +108,9 @@ jobs:
             libjxl-dev \
             x11proto-dev \
             libxfixes-dev;
+      - name: Cancel workflow if job fails
+        if: ${{ failure() }}
+        uses: andymckay/cancel-action@0.3
       - uses: actions/checkout@v4
         with:
           ref: ${{ env.BRANCH }}
@@ -217,6 +221,9 @@ jobs:
             sqlite3:p
             zlib:p
           update: false
+      - name: Cancel workflow if job fails
+        if: ${{ failure() }}
+        uses: andymckay/cancel-action@0.3
       - run: git config --global core.autocrlf input
         shell: bash
       - uses: actions/checkout@v4
@@ -315,6 +322,9 @@ jobs:
       - name: use ImageMagick 6
         run: |
           brew link --overwrite --force imagemagick@6
+      - name: Cancel workflow if job fails
+        if: ${{ failure() }}
+        uses: andymckay/cancel-action@0.3
       - name: Build and Install
           # todo: use linker which supports --wrap, ld.bfd and ld.gold support it
         run: |


### PR DESCRIPTION
I used to make fixes to the nightly workflow to publish successful builds even when the build for one of the platforms failed.
After some thought, I now believe that this is not the best solution.

It's better to have for some time a slightly older nightly build for all platforms than not to provide build for some platform. Therefore, the publish step now requires the success of the build jobs for all platforms.

But in case of failure of any of the builds, there is no point in continuing other builds wasting resources, since their artifacts will not be published anyway.