### PR TITLE
RFC: Possibly write sidecars after "any user edit"

### DIFF
--- a/src/common/image.h
+++ b/src/common/image.h
@@ -100,6 +100,8 @@ typedef enum
   DT_IMAGE_MONOCHROME_BAYER = 1 << 19,
   // image has a flag set to use the monochrome workflow in the modules supporting it
   DT_IMAGE_MONOCHROME_WORKFLOW = 1 << 20,
+  // image got any change for metadata, geoloc or alike after import
+  DT_IMAGE_USER_ACTION = 1 << 21,
 } dt_image_flags_t;
 
 typedef enum dt_image_colorspace_t
@@ -356,6 +358,10 @@ int dt_image_monochrome_flags(const dt_image_t *img);
 /** returns true if the image has been tested to be monochrome and the
  * image wants monochrome workflow */
 gboolean dt_image_use_monochrome_workflow(const dt_image_t *img);
+
+/* helper supporting after-import-edits */
+void dt_image_user_action(const dt_imgid_t imgid);
+
 /** returns the image filename */
 char *dt_image_get_filename(const dt_imgid_t imgid);
 /** returns the full path name where the image was imported

--- a/src/common/ratings.c
+++ b/src/common/ratings.c
@@ -72,6 +72,7 @@ static void _ratings_apply_to_image(const dt_imgid_t imgid, const int rating)
       image->flags = (image->flags & ~(DT_IMAGE_REJECTED | DT_VIEW_RATINGS_MASK))
         | (DT_VIEW_RATINGS_MASK & new_rating);
     }
+    image->flags |= DT_IMAGE_USER_ACTION;
     // synch through:
     dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);
   }

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -289,7 +289,13 @@ static void _write_metadata(dt_lib_module_t *self)
     DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
                                   DT_SIGNAL_METADATA_CHANGED, DT_METADATA_SIGNAL_NEW_VALUE);
 
-    dt_image_synch_xmps(d->last_act_on);
+
+    for(const GList *imgs = d->last_act_on; imgs; imgs = g_list_next(imgs))
+    {
+      const dt_imgid_t imgid = GPOINTER_TO_INT(imgs->data);
+      dt_image_user_action(imgid);
+      dt_image_write_sidecar_file(imgid);
+    }
   }
 
   g_list_free(d->last_act_on);


### PR DESCRIPTION
Second round of possibly writing a sidecar because of "any user edit action" while preferences setting is "after edit".

Some users would like to write the xmp sidecars after "any actively user action" if the option for writing sidecars has been set to "after edit" instead of only history change or added tag.

Caught user actions are: star rating, metadata, geo location. All just used if user action was **after import** 

Thought about this again; personally i am not sure about it as it doesn't meet my personal workflow but there seem to be quite a number of users with quite good arguments, so implemented it and ready for discussion: "Do we want this?" or "just drop this PR"?


