### PR TITLE
[CI/CD] Switch the macOS nightly build to macOS 12

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -280,7 +280,7 @@ jobs:
       fail-fast: true
       matrix:
         build:
-          - { os: macos-11, xcode: 13.2.1, deployment: 11.3 }
+          - { os: macos-12, xcode: 14.2, deployment: 12.5 }
         compiler:
           - { compiler: XCode,   CC: cc, CXX: c++ }
         btype: [ Release ]


### PR DESCRIPTION
The build on macOS 11 is extremely unreliable, it periodically has problems with installing the package database. Also, process of installing packages is extremely slow, taking over an hour or even an hour and a half (!) instead of the usual few minutes. All this was __promised__ by the Homebrew maintainers, by the way: `"Homebrew will be buggy and slow"`.

Also, since the next release, darktable 4.6, won't support macOS 11, building development snapshots compatible with macOS 11 doesn't make much sense at the moment.
