### PR TITLE
Fix backthumbs crawler

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2526,8 +2526,8 @@ void gui_init(dt_view_t *self)
     // update the gui when the preferences changed (i.e. show intent when using lcms2)
     DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
                               G_CALLBACK(_preference_changed), (gpointer)display_intent);
-    DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE, G_CALLBACK(_preference_changed),
-                              (gpointer)display2_intent);
+    DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
+                              G_CALLBACK(_preference_changed), (gpointer)display2_intent);
     // and when profiles change
     DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
                               G_CALLBACK(_display_profile_changed), (gpointer)display_profile);


### PR DESCRIPTION
If we change some preference setting related to thumbs or resetting the database we make sure the crawler does not update thumbs in the background to avoid database fighting.

To reproduce the issue fixed here, change settings how the thumbs are generated plus reset database. You could end up in a completely unresponsive situation.