### PR TITLE
Thumbtable glist improve

### DIFF
--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1343,11 +1343,25 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table,
       }
       dt_thumbnail_t *thumb;
       if(table->mode == DT_CULLING_MODE_PREVIEW)
-        thumb = dt_thumbnail_new(nw, nh, table->zoom_ratio, nid, nrow, table->overlays,
-                                 DT_THUMBNAIL_CONTAINER_PREVIEW, table->show_tooltips);
+        thumb = dt_thumbnail_new(nw,
+                                 nh,
+                                 table->zoom_ratio,
+                                 nid,
+                                 nrow,
+                                 table->overlays,
+                                 DT_THUMBNAIL_CONTAINER_PREVIEW,
+                                 table->show_tooltips,
+                                 DT_THUMBNAIL_SELECTION_UNKNOWN);
       else
-        thumb = dt_thumbnail_new(nw, nh, table->zoom_ratio, nid, nrow, table->overlays,
-                                 DT_THUMBNAIL_CONTAINER_CULLING, table->show_tooltips);
+        thumb = dt_thumbnail_new(nw,
+                                 nh,
+                                 table->zoom_ratio,
+                                 nid,
+                                 nrow,
+                                 table->overlays,
+                                 DT_THUMBNAIL_CONTAINER_CULLING,
+                                 table->show_tooltips,
+                                 DT_THUMBNAIL_SELECTION_UNKNOWN);
 
       thumb->display_focus = table->focus;
       thumb->sel_mode = DT_THUMBNAIL_SEL_MODE_DISABLED;
@@ -1423,11 +1437,25 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table,
           }
           dt_thumbnail_t *thumb;
           if(table->mode == DT_CULLING_MODE_PREVIEW)
-            thumb = dt_thumbnail_new(nw, nh, table->zoom_ratio, nid, nrow, table->overlays,
-                                     DT_THUMBNAIL_CONTAINER_PREVIEW, table->show_tooltips);
+            thumb = dt_thumbnail_new(nw,
+                                     nh,
+                                     table->zoom_ratio,
+                                     nid,
+                                     nrow,
+                                     table->overlays,
+                                     DT_THUMBNAIL_CONTAINER_PREVIEW,
+                                     table->show_tooltips,
+                                     DT_THUMBNAIL_SELECTION_UNKNOWN);
           else
-            thumb = dt_thumbnail_new(nw, nh, table->zoom_ratio, nid, nrow, table->overlays,
-                                     DT_THUMBNAIL_CONTAINER_CULLING, table->show_tooltips);
+            thumb = dt_thumbnail_new(nw,
+                                     nh,
+                                     table->zoom_ratio,
+                                     nid,
+                                     nrow,
+                                     table->overlays,
+                                     DT_THUMBNAIL_CONTAINER_CULLING,
+                                     table->show_tooltips,
+                                     DT_THUMBNAIL_SELECTION_UNKNOWN);
 
           thumb->display_focus = table->focus;
           thumb->sel_mode = DT_THUMBNAIL_SEL_MODE_DISABLED;

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -1128,12 +1128,7 @@ void dt_thumbnail_update_selection(dt_thumbnail_t *thumb)
     selected = TRUE;
 
   // if there's a change, update the thumb
-  if(selected != thumb->selected)
-  {
-    thumb->selected = selected;
-    _thumb_update_icons(thumb);
-    gtk_widget_queue_draw(thumb->w_main);
-  }
+  dt_thumbnail_set_selection(thumb, selected);
 }
 
 static void _dt_selection_changed_callback(gpointer instance, gpointer user_data)
@@ -1647,7 +1642,8 @@ dt_thumbnail_t *dt_thumbnail_new(const int width,
                                  const int rowid,
                                  const dt_thumbnail_overlay_t over,
                                  const dt_thumbnail_container_t container,
-                                 const gboolean tooltip)
+                                 const gboolean tooltip,
+                                 const dt_thumbnail_selection_t sel)
 {
   dt_thumbnail_t *thumb = calloc(1, sizeof(dt_thumbnail_t));
   thumb->width = width;
@@ -1689,7 +1685,10 @@ dt_thumbnail_t *dt_thumbnail_new(const int width,
 
   // let's see if the images are selected or active or mouse_overed
   _dt_active_images_callback(NULL, thumb);
-  _dt_selection_changed_callback(NULL, thumb);
+  if (sel == DT_THUMBNAIL_SELECTION_UNKNOWN)
+    _dt_selection_changed_callback(NULL, thumb);
+  else
+    thumb->selected = sel;
   if(dt_control_get_mouse_over_id() == thumb->imgid)
     dt_thumbnail_set_mouseover(thumb, TRUE);
 
@@ -2327,6 +2326,15 @@ void dt_thumbnail_surface_destroy(dt_thumbnail_t *thumb)
       cairo_surface_destroy(thumb->img_surf);
   thumb->img_surf = NULL;
   thumb->img_surf_dirty = TRUE;
+}
+
+void dt_thumbnail_set_selection(dt_thumbnail_t *thumb,
+                                const gboolean selected)
+{
+  if(thumb->selected == selected) return;
+  thumb->selected = selected;
+  _thumb_update_icons(thumb);
+  gtk_widget_queue_draw(thumb->w_main);
 }
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/dtgtk/thumbnail.h
+++ b/src/dtgtk/thumbnail.h
@@ -62,6 +62,13 @@ typedef enum dt_thumbnail_selection_mode_t
   DT_THUMBNAIL_SEL_MODE_MOD_ONLY    // user can only change selection with mouse AND CTRL or SHIFT
 } dt_thumbnail_selection_mode_t;
 
+typedef enum dt_thumbnail_selection_t
+{
+  DT_THUMBNAIL_SELECTION_UNSELECTED= 0, // value should stay 0 to be equivalent to FALSE
+  DT_THUMBNAIL_SELECTION_SELECTED= 1,   // user should stay 1 to be equivalent to TRUE
+  DT_THUMBNAIL_SELECTION_UNKNOWN
+} dt_thumbnail_selection_t;
+
 typedef struct
 {
   dt_imgid_t imgid, rowid;
@@ -146,8 +153,15 @@ typedef struct
   gboolean busy; // should we show the busy message ?
 } dt_thumbnail_t;
 
-dt_thumbnail_t *dt_thumbnail_new(int width, int height, float zoom_ratio, dt_imgid_t imgid, int rowid, dt_thumbnail_overlay_t over,
-                                 dt_thumbnail_container_t container, gboolean tooltip);
+dt_thumbnail_t *dt_thumbnail_new(int width,
+                                 int height,
+                                 float zoom_ratio,
+                                 dt_imgid_t imgid,
+                                 int rowid,
+                                 dt_thumbnail_overlay_t over,
+                                 dt_thumbnail_container_t container,
+                                 gboolean tooltip,
+                                 const dt_thumbnail_selection_t sel);
 void dt_thumbnail_destroy(dt_thumbnail_t *thumb);
 GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb, float zoom_ratio);
 void dt_thumbnail_resize(dt_thumbnail_t *thumb, int width, int height, gboolean force, float zoom_ratio);
@@ -163,6 +177,9 @@ void dt_thumbnail_update_infos(dt_thumbnail_t *thumb);
 
 // check if the image is selected and set its state and background
 void dt_thumbnail_update_selection(dt_thumbnail_t *thumb);
+// force the selected state of a thumb
+void dt_thumbnail_set_selection(dt_thumbnail_t *thumb,
+                                const gboolean selected);
 
 // force image recomputing
 void dt_thumbnail_image_refresh(dt_thumbnail_t *thumb);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -2327,12 +2327,6 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table,
     g_list_free(table->list);
     table->list = NULL;
 
-  /*      ("SELECT mi.rowid, mi.imgid, si.imgid"
-       " FROM memory.collected_images AS mi"
-       " LEFT JOIN main.selected_images AS si"
-       "   ON mi.imgid = si.imgid"
-       " WHERE mi.rowid>=%d LIMIT %d",*/
-
     // we add the thumbs
     int nbnew = 0;
     gchar *query

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -287,9 +287,15 @@ static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *sel
     GtkWidget *hb = gtk_grid_new();
     const dt_imgid_t imgid = sqlite3_column_int(stmt, 1);
     dt_gui_add_class(hb, "dt_overlays_always");
-    dt_thumbnail_t *thumb = dt_thumbnail_new(100, 100, IMG_TO_FIT, imgid, -1,
+    dt_thumbnail_t *thumb = dt_thumbnail_new(100,
+                                             100,
+                                             IMG_TO_FIT,
+                                             imgid,
+                                             -1,
                                              DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL,
-                                             DT_THUMBNAIL_CONTAINER_LIGHTTABLE, TRUE);
+                                             DT_THUMBNAIL_CONTAINER_LIGHTTABLE,
+                                             TRUE,
+                                             DT_THUMBNAIL_SELECTION_UNSELECTED);
     thumb->sel_mode = DT_THUMBNAIL_SEL_MODE_DISABLED;
     thumb->disable_mouseover = TRUE;
     thumb->disable_actions = TRUE;


### PR DESCRIPTION
this is a follow up of @TurboGit #15454 PR...

This contains the following : 
- implements @dterrahe and @ralfbrown suggestions (avoid some list traversals)
- avoid some other list traversal in `dt_thumbtable_full_redraw`
- change how the selection state is handled in `dt_thumbtable_full_redraw` by query it directly from start. Here, I have a x8 speedup, although not really noticeable, because timings are very low...
- fix the selection state of new thumbs during scroll

I put this PR as draft for now, in order to : 
- search for more GList optimizations if I can find some (help welcome)
- port recent changes to culling/full preview