### PR TITLE
Don't block "copy & import" if the user chooses to show the initial message next time

### DIFF
--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2022 darktable developers.
+    Copyright (C) 2011-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -1986,8 +1986,6 @@ static void _lib_import_from_callback(GtkWidget *widget, dt_lib_module_t* self)
             _("_show this information again"), _("_understood & done"));
       if(understood)
         dt_conf_set_bool("setup_import_directory", TRUE);
-      else
-        return;
     }
   }
 


### PR DESCRIPTION
Currently, if the user chooses "show this information again", it blocks the "copy & import" dialog from opening. It's just not what it's expected to be.