### PR TITLE
[CI] Add Clang to Windows matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,9 @@ jobs:
       matrix:
         btype:
           - Debug
+        compiler:
+          - { compiler: GNU,  CC: gcc,   CXX: g++ }
+          - { compiler: LLVM, CC: clang, CXX: clang++ }
         msystem:
           #- CLANG64
           - UCRT64
@@ -190,6 +193,8 @@ jobs:
       run:
         shell: msys2 {0}
     env:
+      CC: ${{ matrix.compiler.CC }}
+      CXX: ${{ matrix.compiler.CXX }}
       SRC_DIR: ${{ github.workspace }}/src
       BUILD_DIR: ${{ github.workspace }}/build
       INSTALL_PREFIX: ${{ github.workspace }}/install
@@ -208,6 +213,7 @@ jobs:
             po4a
           pacboy: >-
             cc:p
+            clang:p
             cmake:p
             cmocka:p
             libxslt:p
@@ -243,6 +249,7 @@ jobs:
             omp:p
             openexr:p
             openjpeg2:p
+            openmp:p
             osm-gps-map:p
             portmidi:p
             pugixml:p

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ permissions:
 jobs:
 
   Linux:
-    name: Linux.${{ matrix.os.code }}.${{ matrix.compiler.compiler }}.${{ matrix.target }}.${{ matrix.btype }}.${{ matrix.generator }}
+    name: Linux.${{ matrix.compiler.compiler }}
     runs-on: ${{ matrix.os.label }}
     strategy:
       fail-fast: true
@@ -168,7 +168,7 @@ jobs:
           ./run.sh --no-opencl --no-deltae --fast-fail
 
   Windows:
-    name: Windows.${{ matrix.msystem }}.${{ matrix.target }}.${{ matrix.btype }}.${{ matrix.generator }}
+    name: Windows.${{ matrix.compiler.compiler }}
     runs-on: windows-latest
     strategy:
       fail-fast: true
@@ -282,7 +282,7 @@ jobs:
                  --conf plugins/lighttable/export/iccintent=0
 
   macOS:
-    name: macOS.${{ matrix.compiler.compiler }}.${{ matrix.build.xcode }}.${{ matrix.target }}.${{ matrix.btype }}.${{ matrix.generator }}
+    name: macOS.${{ matrix.compiler.compiler }}.${{ matrix.build.xcode }}
     runs-on: ${{ matrix.build.os }}
     strategy:
       fail-fast: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
         target:
           - build
         generator:
-          #- Unix Makefiles
           - Ninja
     env:
       CC: ${{ matrix.compiler.CC }}
@@ -181,12 +180,10 @@ jobs:
           - { compiler: GNU,  CC: gcc,   CXX: g++ }
           - { compiler: LLVM, CC: clang, CXX: clang++ }
         msystem:
-          #- CLANG64
           - UCRT64
         target:
           - skiptest
         generator:
-          #- MSYS Makefiles
           - Ninja
         eco: [-DDONT_USE_INTERNAL_LIBRAW=ON]
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,6 @@ jobs:
           - { label: ubuntu-latest, code: latest }
         compiler:
           - { compiler: GNU13,  CC: gcc-13,   CXX: g++-13,     packages: gcc-13 g++-13 }
-          - { compiler: LLVM15, CC: clang-15, CXX: clang++-15, packages: clang-15 libomp-15-dev llvm-15-dev libc++-15-dev libc++abi1-15 lld-15 clang-tools-15 mlir-15-tools libmlir-15-dev}
         btype:
           - Release
         target:


### PR DESCRIPTION
Clang in MSYS2 is and always will be newer than in Ubuntu runners.

At the moment, this means going from Clang 15 to Clang 16.