### PR TITLE
g_timeout_add... fct return a guint not a int

### DIFF
--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -334,7 +334,7 @@ typedef struct dt_iop_gui_blend_data_t
   int tab;
   int altmode[8][2];
   dt_dev_pixelpipe_display_mask_t save_for_leave;
-  int timeout_handle;
+  guint timeout_handle;
   GtkNotebook *channel_tabs;
   gboolean output_channels_shown;
 

--- a/src/dtgtk/thumbnail.h
+++ b/src/dtgtk/thumbnail.h
@@ -132,10 +132,10 @@ typedef struct
 
   dt_thumbnail_overlay_t over;  // type of overlays
   int overlay_timeout_duration; // for hover_block overlay, we hide the it after a delay
-  int overlay_timeout_id;       // id of the g_source timeout fct
+  guint overlay_timeout_id;       // id of the g_source timeout fct
   gboolean tooltip;             // should we show the tooltip ?
 
-  int expose_again_timeout_id;  // source id of the expose_again timeout
+  guint expose_again_timeout_id;  // source id of the expose_again timeout
 
   // specific for culling and preview
   gboolean zoomable;   // can we zoom in/out the thumbnail (used for culling/preview)

--- a/src/dtgtk/thumbtable.h
+++ b/src/dtgtk/thumbtable.h
@@ -101,7 +101,7 @@ typedef struct dt_thumbtable_t
   int pref_hq;
 
   // scroll timeout values
-  int scroll_timeout_id;
+  guint scroll_timeout_id;
   float scroll_value;
 } dt_thumbtable_t;
 

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -145,7 +145,7 @@ typedef struct dt_lib_import_t
     GtkTreeView *folderview;
     GtkTreeViewColumn *foldercol;
     GtkTreeIter iter;
-    int event;
+    guint event;
     guint nb;
     GdkPixbuf *eye;
     GtkTreeViewColumn *pixcol;

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -65,7 +65,7 @@ typedef struct dt_lib_snapshots_t
   int selected;
   dt_lib_snapshot_params_t params;
   gboolean snap_requested;
-  int expose_again_timeout_id;
+  guint expose_again_timeout_id;
 
   /* current active snapshots */
   uint32_t num_snapshots;
@@ -159,6 +159,7 @@ static gboolean _snap_expose_again(gpointer user_data)
 {
   dt_lib_snapshots_t *d = (dt_lib_snapshots_t *)user_data;
 
+  d->expose_again_timeout_id = 0;
   d->snap_requested = TRUE;
   dt_control_queue_redraw_center();
   return FALSE;
@@ -197,7 +198,7 @@ void gui_post_expose(dt_lib_module_t *self,
       snap->width  = d->params.width;
       snap->height = d->params.height;
       d->snap_requested = FALSE;
-      d->expose_again_timeout_id = -1;
+      d->expose_again_timeout_id = 0;
     }
 
     // if ctx has changed, get a new snapshot at the right zoom
@@ -214,7 +215,7 @@ void gui_post_expose(dt_lib_module_t *self,
 
       snap->ctx = ctx;
       if(!d->panning && dev->darkroom_mouse_in_center_area) d->snap_requested = TRUE;
-      if(d->expose_again_timeout_id != -1) g_source_remove(d->expose_again_timeout_id);
+      if(d->expose_again_timeout_id != 0) g_source_remove(d->expose_again_timeout_id);
       d->expose_again_timeout_id = g_timeout_add(150, _snap_expose_again, d);
     }
 
@@ -646,7 +647,7 @@ void gui_init(dt_lib_module_t *self)
   d->panning = FALSE;
   d->selected = -1;
   d->snap_requested = FALSE;
-  d->expose_again_timeout_id = -1;
+  d->expose_again_timeout_id = 0;
   d->num_snapshots = 0;
 
   /* initialize ui containers */

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -63,9 +63,13 @@ typedef struct dt_lib_tagging_t
   struct
   {
     gchar *tagname;
-    GtkTreePath *path, *lastpath;
-    int expand_timeout, scroll_timeout, last_y;
-    gboolean root, tag_source;
+    GtkTreePath *path;
+    GtkTreePath *lastpath;
+    guint expand_timeout;
+    guint scroll_timeout;
+    int last_y;
+    gboolean root;
+    gboolean tag_source;
   } drag;
   gboolean update_selected_tags;
 } dt_lib_tagging_t;

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -81,7 +81,7 @@ typedef struct dt_map_t
   int max_images_drawn;
   dt_map_box_t bbox;
   int time_out;
-  int timeout_event_source;
+  guint timeout_event_source;
   int thumbnail;
   dt_map_image_t *last_hovered_entry;
   struct


### PR DESCRIPTION
Ensure value issued from a `g_timeout_add....` fct is store as a guint and not an int.
This has been spotted by @dterrahe in https://github.com/darktable-org/darktable/issues/15470#issuecomment-1774255937