### PR TITLE
Fix the text of one of the choices in initial dialog for "copy & import"

### DIFF
--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1983,7 +1983,7 @@ static void _lib_import_from_callback(GtkWidget *widget, dt_lib_module_t* self)
                "\nfurther information can be found in the darktable manual."
                "\n\ninspect darktable preferences -> import."
                "\ncheck and possibly correct the 'base directory naming pattern'"),
-            _("_show this information again"), _("_understood & done"));
+            _("_come back & check"), _("_understood & done"));
       if(understood)
         dt_conf_set_bool("setup_import_directory", TRUE);
       else


### PR DESCRIPTION
This is an alternative to the fix proposed in #15463. In it, we do not change the logic of dialog behavior to match the text on the button, but on the contrary, we change the text to match the behavior.