### PR TITLE
Rework temperature and channelmixerrgb

### DIFF
--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2021 darktable developers.
+    Copyright (C) 2009-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -144,6 +144,32 @@ typedef struct dt_dev_viewport_t
   gboolean input_changed;
 } dt_dev_viewport_t;
 
+/* keep track on what and where we do chromatic adaptation, used
+  a)  to display warnings in GUI of modules that should probably not be doing
+      white balance
+  b)  missing required white balance
+  c)  allow late correction of as-shot or modified coeffs to D65 in color-input
+      but keep processing until then with more reliable (at least for highlights,
+      raw chromatic aberrations and more.
+  d)  avoids keeping of fixed data in temperature gui data
+  e)  we have 3 coefficients kept here
+      - the currently used wb_coeffs in temperature module
+      - D65coeffs and as_shot are read from exif data
+  f)  - late_correction set by temperature if we want to process data as following
+      If we use the new DT_IOP_TEMP_D65_LATE mode in temperature.c and don#t have
+      any temp parameters changes later we can calc correction coeffs to modify
+      as_shot rgb data to D65
+*/
+typedef struct dt_dev_chroma_t
+{
+  struct dt_iop_module_t *temperature;  // always available for GUI reports
+  struct dt_iop_module_t *adaptation;   // set if one module is processing this without blending
+
+  double wb_coeffs[4];                  // data actually used by the pipe
+  double D65coeffs[4];                  // both read from exif data or "best guess"
+  double as_shot[4];
+  gboolean late_correction;
+} dt_dev_chroma_t;
 
 typedef struct dt_develop_t
 {
@@ -273,18 +299,9 @@ typedef struct dt_develop_t
                                struct dt_iop_module_t *module,
                                const dt_mask_id_t selectid);
     } masks;
-
-    // what is the ID of the module currently doing pipeline chromatic
-    // adaptation ?  this is to prevent multiple modules/instances
-    // from doing white balance globally.  only used to display
-    // warnings in GUI of modules that should probably not be doing
-    // white balance
-    struct dt_iop_module_t *chroma_adaptation;
-
-    // is the WB module using D65 illuminant and not doing full chromatic adaptation ?
-    gboolean wb_is_D65;
-    dt_aligned_pixel_t wb_coeffs;
   } proxy;
+
+  dt_dev_chroma_t chroma;
 
   // for exposing the crop
   struct
@@ -660,6 +677,12 @@ void dt_dev_image_ext(const dt_imgid_t imgid,
                       const int border_size,
                       const gboolean iso_12646,
                       const int32_t snapshot_id);
+
+
+gboolean dt_dev_equal_chroma(const float *f, const double *d);
+gboolean dt_dev_D65_chroma(const dt_develop_t *dev);
+void dt_dev_reset_chroma(dt_develop_t *dev);
+void dt_dev_init_chroma(dt_develop_t *dev);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1114,8 +1114,8 @@ static void _gui_off_callback(GtkToggleButton *togglebutton, gpointer user_data)
       module->enabled = FALSE;
 
       //  if current module is set as the CAT instance, remove that setting
-      if(module->dev->proxy.chroma_adaptation == module)
-        module->dev->proxy.chroma_adaptation = NULL;
+      if(module->dev->chroma.adaptation == module)
+        module->dev->chroma.adaptation = NULL;
 
       dt_dev_add_history_item(module->dev, module, FALSE);
 

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -166,6 +166,7 @@ typedef struct dt_iop_channelmixer_rgb_gui_data_t
   gboolean run_validation;      // order a profile validation at next pipeline recompute
   gboolean profile_ready;       // notify that a profile is ready to be applied
   gboolean checker_ready;       // notify that a checker bounding box is ready to be used
+  gboolean is_blending;         // it this instance blending?
   dt_colormatrix_t mix;
 
   gboolean is_profiling_started;
@@ -589,11 +590,11 @@ void init_presets(dt_iop_module_so_t *self)
 }
 
 
-static int _get_white_balance_coeff(struct dt_iop_module_t *self,
+static gboolean _get_white_balance_coeff(struct dt_iop_module_t *self,
                                     dt_aligned_pixel_t custom_wb)
 {
   // Init output with a no-op
-  for(size_t k = 0; k < 4; k++) custom_wb[k] = 1.f;
+  for_four_channels(k) custom_wb[k] = 1.f;
 
   if(!dt_image_is_matrix_correction_supported(&self->dev->image_storage)) return 1;
 
@@ -614,20 +615,18 @@ static int _get_white_balance_coeff(struct dt_iop_module_t *self,
     bwb[1] = 1.0;
   }
   else
-  {
-    return 1;
-  }
+     return TRUE;
 
   // Second, if the temperature module is not using these, for example
   // because they are wrong and user made a correct preset, find the
   // WB adaptation ratio
-  if(self->dev->proxy.wb_coeffs[0] != 0.f)
+  const dt_dev_chroma_t *chr = &self->dev->chroma;
+  if(chr->wb_coeffs[0] > 1.0 || chr->wb_coeffs[1] > 1.0 || chr->wb_coeffs[2] > 1.0)
   {
-    for(size_t k = 0; k < 4; k++)
-      custom_wb[k] = bwb[k] / self->dev->proxy.wb_coeffs[k];
+    for_four_channels(k)
+      custom_wb[k] = bwb[k] / chr->wb_coeffs[k];
   }
-
-  return 0;
+  return FALSE;
 }
 
 
@@ -1196,21 +1195,26 @@ static inline void _auto_detect_WB(const float *const restrict in,
 
 static void _declare_cat_on_pipe(struct dt_iop_module_t *self, const gboolean preset)
 {
-  // Advertise to the pipeline that we are doing chromatic adaptation here
+  // Avertise in dev->chroma that we are doing chromatic adaptation here
   // preset = TRUE allows to capture the CAT a priori at init time
-  dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
+  const dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
+  const dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  if(!g) return;
+
+  dt_dev_chroma_t *chr = &self->dev->chroma;
 
   if((self->enabled
+      && !g->is_blending
       && !(p->adaptation == DT_ADAPTATION_RGB
            || p->illuminant == DT_ILLUMINANT_PIPE)) || preset)
   {
     // We do CAT here so we need to register this instance as CAT-handler.
-    if(self->dev->proxy.chroma_adaptation == NULL)
+    if(chr->adaptation == NULL)
     {
       // We are the first to try to register, let's go !
-      self->dev->proxy.chroma_adaptation = self;
+      chr->adaptation = self;
     }
-    else if(self->dev->proxy.chroma_adaptation == self)
+    else if(chr->adaptation == self)
     {
     }
     else
@@ -1218,35 +1222,25 @@ static void _declare_cat_on_pipe(struct dt_iop_module_t *self, const gboolean pr
       // Another instance already registered.
       // If we are lower in the pipe than it, register in its place.
       if(dt_iop_is_first_instance(self->dev->iop, self))
-        self->dev->proxy.chroma_adaptation = self;
+        chr->adaptation = self;
     }
   }
   else
   {
-    if(self->dev->proxy.chroma_adaptation != NULL)
+    if(chr->adaptation != NULL)
     {
       // We do NOT do CAT here.
       // Deregister this instance as CAT-handler if it previously registered
-      if(self->dev->proxy.chroma_adaptation == self)
-        self->dev->proxy.chroma_adaptation = NULL;
+      if(chr->adaptation == self)
+        chr->adaptation = NULL;
     }
   }
 }
-
-static inline gboolean _is_another_module_cat_on_pipe(struct dt_iop_module_t *self)
-{
-  dt_iop_channelmixer_rgb_gui_data_t *g =
-    (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
-  if(!g) return FALSE;
-  return self->dev->proxy.chroma_adaptation && self->dev->proxy.chroma_adaptation != self;
-}
-
 
 static void _update_illuminants(struct dt_iop_module_t *self);
 static void _update_approx_cct(struct dt_iop_module_t *self);
 static void _update_illuminant_color(struct dt_iop_module_t *self);
 static void _paint_temperature_background(struct dt_iop_module_t *self);
-
 
 static void _check_if_close_to_daylight(const float x,
                                         const float y,
@@ -2018,50 +2012,101 @@ void validate_color_checker(const float *const restrict in,
   dt_free_align(patches);
 }
 
-static void _check_for_wb_issue_and_set_trouble_message(struct dt_iop_module_t *self,
-                                                        dt_dev_pixelpipe_iop_t *piece)
+static void _set_trouble_messages(struct dt_iop_module_t *self)
 {
-  dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
-  if(self->enabled
-     && !(p->illuminant == DT_ILLUMINANT_PIPE || p->adaptation == DT_ADAPTATION_RGB)
-     && !dt_image_is_monochrome(&self->dev->image_storage))
+  const dt_iop_channelmixer_rgb_params_t *p = (dt_iop_channelmixer_rgb_params_t *)self->params;
+  const dt_iop_channelmixer_rgb_gui_data_t *g = (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
+  const dt_develop_t *dev = self->dev;
+  const dt_dev_chroma_t *chr = &dev->chroma;
+
+  if(!chr->temperature || !g) return;
+  if(!chr->adaptation)
   {
-    // this module instance is doing chromatic adaptation
-    const dt_develop_blend_params_t *d =
-       piece ? (const dt_develop_blend_params_t *)piece->blendop_data : NULL;
-    const dt_develop_mask_mode_t mask_mode = d ? d->mask_mode : DEVELOP_MASK_DISABLED;
-    const gboolean is_blending = (mask_mode & DEVELOP_MASK_ENABLED)
-                              && (mask_mode >= DEVELOP_MASK_MASK);
-    // Don't show the trouble message if some mask blending is used, that is very likely intended.
-    if(_is_another_module_cat_on_pipe(self) && !is_blending)
-    {
-      // our second biggest problem : another channelmixerrgb instance is doing CAT
-      // earlier in the pipe and we don't use masking here.
-      dt_iop_set_module_trouble_message
-        (self, _("double CAT applied"),
-         _("you have 2 instances or more of color calibration,\n"
-           "all performing chromatic adaptation.\n"
-           "this can lead to inconsistencies, unless you\n"
-           "use them with masks or know what you are doing."),
-         "double CAT applied");
-      return;
-    }
-    else if(!self->dev->proxy.wb_is_D65)
-    {
-      // our first and biggest problem : white balance module is being
-      // clever with WB coeffs
-      dt_iop_set_module_trouble_message
-        (self, _("white balance module error"),
-         _("the white balance module is not using the camera\n"
-           "reference illuminant, which will cause issues here\n"
-           "with chromatic adaptation. either set it to reference\n"
-           "or disable chromatic adaptation here."),
-         "white balance error");
-      return;
-    }
+    dt_iop_set_module_trouble_message(chr->temperature, NULL, NULL, NULL);
+    dt_iop_set_module_trouble_message(self, NULL, NULL, NULL);
+    return;
   }
 
-  dt_iop_set_module_trouble_message(self, NULL, NULL, NULL);
+  const gboolean temp_enabled = chr->wb_coeffs[0] > 1.0 || chr->wb_coeffs[1] > 1.0 || chr->wb_coeffs[2] > 1.0;
+  const gboolean valid = self->enabled
+                      && !(p->illuminant == DT_ILLUMINANT_PIPE || p->adaptation == DT_ADAPTATION_RGB)
+                      && !dt_image_is_monochrome(&dev->image_storage);
+
+  dt_print(DT_DEBUG_PARAMS, "[chroma trouble data %d] D65=%s.  NOW %.3f %.3f %.3f, D65 %.3f %.3f %.3f, AS-SHOT %.3f %.3f %.3f\n",
+    self->multi_priority,
+    dt_dev_D65_chroma(dev) ? "YES" : "NO",
+    chr->wb_coeffs[0], chr->wb_coeffs[1], chr->wb_coeffs[2],
+    chr->D65coeffs[0], chr->D65coeffs[1], chr->D65coeffs[2],
+    chr->as_shot[0], chr->as_shot[1], chr->as_shot[2]);
+
+  if(valid && chr->adaptation != self && temp_enabled && !g->is_blending)
+  {
+    // our second biggest problem : another channelmixerrgb instance is doing CAT
+    // earlier in the pipe and we don't use masking here.
+    dt_iop_set_module_trouble_message
+      (self,
+        _("double CAT applied"),
+        _("you have 2 instances or more of color calibration,\n"
+          "all providing chromatic adaptation.\n"
+          "this can lead to inconsistencies unless you\n"
+          "use them with masks or know what you are doing."),
+        "double CAT applied");
+    return;
+  }
+
+  if(valid && chr->adaptation == self && temp_enabled && !dt_dev_D65_chroma(dev))
+  {
+    // our first and biggest problem : white balance module is being
+    // clever with WB coeffs
+    dt_iop_set_module_trouble_message
+      (chr->temperature,
+        _("white balance applied twice"),
+        _("the color calibration module is enabled and already provides\n"
+          "chromatic adaptation.\n"
+          "set the white balance here to camera reference (D65)\n"
+          "or disable chromatic adaptation in color calibration."),
+        "double application of white balance");
+
+    dt_iop_set_module_trouble_message
+      (self,
+        _("white balance module error"),
+        _("the white balance module is not using the camera\n"
+          "reference illuminant, which will cause issues here\n"
+          "with chromatic adaptation. either set it to reference\n"
+          "or disable chromatic adaptation here."),
+        "white balance is not using reference illuminant");
+    return;
+  }
+
+  if(valid && chr->adaptation && !temp_enabled && chr->temperature->default_enabled)
+  {
+    // our third and minor prooblem: white balance module is not active but default_enabled
+    // and we do chromatic adaptation in color calibration
+    dt_iop_set_module_trouble_message
+      (chr->temperature,
+        _("white balance missing"),
+        _("this module is not providing a valid reference illuminent\n"
+          "causing chromatic adaptation issues in color calibration.\n"
+          "enable this module and either set it to reference\n"
+          "or disable chromatic adaptation in color calibration."),
+        "white balance disabled but required");
+
+    dt_iop_set_module_trouble_message
+      (self,
+        _("white balance missing"),
+        _("the white balance module is not providing a valid reference\n"
+          "illuminant causing issues with chromatic adaptation here.\n"
+          "enable white balance and either set it to reference\n"
+          "or disable chromatic adaptation here."),
+        "white balance missing for color calibration");
+    return;
+  }
+
+  if(chr->adaptation && chr->adaptation == self)
+  {
+    dt_iop_set_module_trouble_message(chr->temperature, NULL, NULL, NULL);
+    dt_iop_set_module_trouble_message(self, NULL, NULL, NULL);
+  }
 }
 
 void process(struct dt_iop_module_t *self,
@@ -2085,11 +2130,8 @@ void process(struct dt_iop_module_t *self,
     return; // image has been copied through to output and module's
             // trouble flag has been updated
 
-  _declare_cat_on_pipe(self, FALSE);
-
-  // dt_iop_have_required_input_format() has reset the trouble message.
-  // we must set it again in case of any trouble.
-  _check_for_wb_issue_and_set_trouble_message(self, piece);
+  if(piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
+    _declare_cat_on_pipe(self, FALSE);
 
   dt_colormatrix_t RGB_to_XYZ;
   dt_colormatrix_t XYZ_to_RGB;
@@ -2260,11 +2302,8 @@ int process_cl(struct dt_iop_module_t *self,
   const struct dt_iop_order_iccprofile_info_t *const work_profile =
     dt_ioppr_get_pipe_current_profile_info(self, piece->pipe);
 
-  _declare_cat_on_pipe(self, FALSE);
-
-  // dt_iop_have_required_input_format() has reset the trouble message.
-  // we must set it again in case of any trouble.
-  _check_for_wb_issue_and_set_trouble_message(self, piece);
+  if(piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
+    _declare_cat_on_pipe(self, FALSE);
 
   if(d->illuminant_type == DT_ILLUMINANT_CAMERA)
   {
@@ -3012,6 +3051,7 @@ static void _preview_pipe_finished_callback(gpointer instance, gpointer user_dat
   dt_iop_gui_enter_critical_section(self);
   gtk_label_set_markup(GTK_LABEL(g->label_delta_E), g->delta_E_label_text);
   dt_iop_gui_leave_critical_section(self);
+  if(g) _set_trouble_messages(self);
 }
 
 void commit_params(struct dt_iop_module_t *self,
@@ -3128,8 +3168,13 @@ void commit_params(struct dt_iop_module_t *self,
       piece->process_cl_ready = FALSE;
     }
   }
-}
 
+  // if this module has some mask applied we assume it's safe so give no warning
+  const dt_develop_blend_params_t *b = (const dt_develop_blend_params_t *)piece->blendop_data;
+  const dt_develop_mask_mode_t mask_mode = b ? b->mask_mode : DEVELOP_MASK_DISABLED;
+  const gboolean is_blending = (mask_mode & DEVELOP_MASK_ENABLED) && (mask_mode >= DEVELOP_MASK_MASK);
+  if(g) g->is_blending = is_blending;
+}
 
 static void _update_illuminants(dt_iop_module_t *self)
 {
@@ -3732,7 +3777,7 @@ void cleanup_pipe(struct dt_iop_module_t *self,
                   dt_dev_pixelpipe_t *pipe,
                   dt_dev_pixelpipe_iop_t *piece)
 {
-  self->dev->proxy.chroma_adaptation = NULL;
+  dt_dev_reset_chroma(self->dev);
   dt_free_align(piece->data);
   piece->data = NULL;
 }
@@ -3858,8 +3903,8 @@ void reload_defaults(dt_iop_module_t *module)
 
   // check if we could register
   const gboolean CAT_already_applied =
-    (module->dev->proxy.chroma_adaptation != NULL)      // CAT exists
-    && (module->dev->proxy.chroma_adaptation != module) // and it is not us
+    (module->dev->chroma.adaptation != NULL)      // CAT exists
+    && (module->dev->chroma.adaptation != module) // and it is not us
     && (!dt_image_is_monochrome(img));
 
   module->default_enabled = FALSE;
@@ -4111,9 +4156,6 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   gtk_widget_set_sensitive(g->adaptation, p->illuminant != DT_ILLUMINANT_CAMERA);
 
   _declare_cat_on_pipe(self, FALSE);
-
-  if(!self->dev->proxy.wb_is_D65 || !self->enabled)
-    _check_for_wb_issue_and_set_trouble_message(self, NULL);
 
   --darktable.gui->reset;
 }

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -56,11 +56,10 @@ DT_MODULE_INTROSPECTION(3, dt_iop_temperature_params_t)
 #define DT_IOP_LOWEST_TINT 0.135
 #define DT_IOP_HIGHEST_TINT 2.326
 
-#define DT_COEFF_EPS 0.00001f
-
 #define DT_IOP_NUM_OF_STD_TEMP_PRESETS 4
 
 // If you reorder presets combo, change this consts
+#define DT_IOP_TEMP_UNKNOWN -1
 #define DT_IOP_TEMP_AS_SHOT 0
 #define DT_IOP_TEMP_SPOT 1
 #define DT_IOP_TEMP_USER 2
@@ -70,15 +69,15 @@ static void gui_sliders_update(struct dt_iop_module_t *self);
 
 typedef struct dt_iop_temperature_params_t
 {
-  float red;    // $MIN: 0.0 $MAX: 8.0
-  float green;  // $MIN: 0.0 $MAX: 8.0
-  float blue;   // $MIN: 0.0 $MAX: 8.0
-  float g2;     // $MIN: 0.0 $MAX: 8.0 $DESCRIPTION: "emerald"
+  float red;     // $MIN: 0.0 $MAX: 8.0
+  float green;   // $MIN: 0.0 $MAX: 8.0
+  float blue;    // $MIN: 0.0 $MAX: 8.0
+  float various; // $MIN: 0.0 $MAX: 8.0
 } dt_iop_temperature_params_t;
 
 typedef struct dt_iop_temperature_gui_data_t
 {
-  GtkWidget *scale_k, *scale_tint, *scale_r, *scale_g, *scale_b, *scale_g2;
+  GtkWidget *scale_k, *scale_tint, *scale_r, *scale_g, *scale_b, *scale_y;
   GtkWidget *presets;
   GtkWidget *finetune;
   GtkWidget *buttonbar;
@@ -90,13 +89,11 @@ typedef struct dt_iop_temperature_gui_data_t
   GtkWidget *balance_label;
   int preset_cnt;
   int preset_num[54];
-  double daylight_wb[4];
-  double as_shot_wb[4];
   double mod_coeff[4];
   float mod_temp, mod_tint;
   double XYZ_to_CAM[4][3], CAM_to_XYZ[3][4];
-  int colored_sliders;
-  int blackbody_is_confusing;
+  gboolean colored_sliders;
+  gboolean blackbody_is_confusing;
   gboolean button_bar_visible;
   dt_gui_collapsible_section_t cs;
 } dt_iop_temperature_gui_data_t;
@@ -132,7 +129,7 @@ int legacy_params(dt_iop_module_t *self,
     float red;
     float green;
     float blue;
-    float g2;
+    float various;
   } dt_iop_temperature_params_v3_t;
 
   if(old_version == 2)
@@ -150,7 +147,7 @@ int legacy_params(dt_iop_module_t *self,
     n->red = o->coeffs[0];
     n->green = o->coeffs[1];
     n->blue = o->coeffs[2];
-    n->g2 = NAN;
+    n->various = NAN;
 
     *new_params = n;
     *new_params_size = sizeof(dt_iop_temperature_params_v3_t);
@@ -163,19 +160,17 @@ int legacy_params(dt_iop_module_t *self,
 static inline void _temp_params_from_array(dt_iop_temperature_params_t *p,
                                            const double a[4])
 {
-  p->red = a[0];
-  p->green = a[1];
-  p->blue = a[2];
-  p->g2 = a[3];
+  float *coeffs = (float *)p;
+  for_four_channels(c)
+    coeffs[c] = (float)a[c];
 }
 
 static inline void _temp_array_from_params(double a[4],
                                            const dt_iop_temperature_params_t *p)
 {
-  a[0] = p->red;
-  a[1] = p->green;
-  a[2] = p->blue;
-  a[3] = p->g2;
+  float *coeffs = (float *)p;
+  for_four_channels(c)
+   a[c] = coeffs[c];
 }
 
 static gboolean _ignore_missing_wb(dt_image_t *img)
@@ -610,12 +605,13 @@ void process(struct dt_iop_module_t *self,
   }
 
   piece->pipe->dsc.temperature.enabled = TRUE;
-  for(int k = 0; k < 4; k++)
+  self->dev->chroma.temperature = self;
+  for_four_channels(k)
   {
     piece->pipe->dsc.temperature.coeffs[k] = d->coeffs[k];
     piece->pipe->dsc.processed_maximum[k] =
       d->coeffs[k] * piece->pipe->dsc.processed_maximum[k];
-    self->dev->proxy.wb_coeffs[k] = d->coeffs[k];
+    self->dev->chroma.wb_coeffs[k] = d->coeffs[k];
   }
 }
 
@@ -672,12 +668,13 @@ int process_cl(struct dt_iop_module_t *self,
   if(err != CL_SUCCESS) goto error;
 
   piece->pipe->dsc.temperature.enabled = TRUE;
-  for(int k = 0; k < 4; k++)
+  self->dev->chroma.temperature = self;
+  for_four_channels(k)
   {
     piece->pipe->dsc.temperature.coeffs[k] = d->coeffs[k];
     piece->pipe->dsc.processed_maximum[k] =
       d->coeffs[k] * piece->pipe->dsc.processed_maximum[k];
-    self->dev->proxy.wb_coeffs[k] = d->coeffs[k];
+    self->dev->chroma.wb_coeffs[k] = d->coeffs[k];
   }
 
 error:
@@ -694,33 +691,30 @@ void commit_params(struct dt_iop_module_t *self,
 {
   dt_iop_temperature_params_t *p = (dt_iop_temperature_params_t *)p1;
   dt_iop_temperature_data_t *d = (dt_iop_temperature_data_t *)piece->data;
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
+  float *tcoeffs = (float *)p;
+
+  if(self->hide_enable_button)
+    piece->enabled = FALSE;
+
+  dt_dev_chroma_t *chr = &self->dev->chroma;
 
   if(self->hide_enable_button)
   {
-    piece->enabled = FALSE;
+    for_four_channels(k)
+      chr->wb_coeffs[k] = 1.0;
     return;
   }
 
-  d->coeffs[0] = p->red;
-  d->coeffs[1] = p->green;
-  d->coeffs[2] = p->blue;
-  d->coeffs[3] = p->g2;
+  for_four_channels(k)
+  {
+    d->coeffs[k] = tcoeffs[k];
+    chr->wb_coeffs[k] = piece->enabled ? d->coeffs[k] : 1.0;
+  }
 
   // 4Bayer images not implemented in OpenCL yet
   if(self->dev->image_storage.flags & DT_IMAGE_4BAYER)
     piece->process_cl_ready = FALSE;
 
-  if(g)
-  {
-    // advertise on the pipe if coeffs are D65 for validity check
-    gboolean is_D65 = TRUE;
-    for(int c = 0; c < 3; c++)
-      if(!feqf(d->coeffs[c], (float)g->daylight_wb[c], DT_COEFF_EPS))
-        is_D65 = FALSE;
-
-    self->dev->proxy.wb_is_D65 = is_D65;
-  }
 }
 
 void init_pipe(struct dt_iop_module_t *self,
@@ -902,11 +896,11 @@ void color_rgb_sliders(struct dt_iop_module_t *self)
   dt_bauhaus_slider_clear_stops(g->scale_r);
   dt_bauhaus_slider_clear_stops(g->scale_g);
   dt_bauhaus_slider_clear_stops(g->scale_b);
-  dt_bauhaus_slider_clear_stops(g->scale_g2);
+  dt_bauhaus_slider_clear_stops(g->scale_y);
   dt_bauhaus_slider_set_feedback(g->scale_r, !color_rgb);
   dt_bauhaus_slider_set_feedback(g->scale_g, !color_rgb);
   dt_bauhaus_slider_set_feedback(g->scale_b, !color_rgb);
-  dt_bauhaus_slider_set_feedback(g->scale_g2, !color_rgb);
+  dt_bauhaus_slider_set_feedback(g->scale_y, !color_rgb);
 
   if(!color_rgb) return;
 
@@ -925,8 +919,8 @@ void color_rgb_sliders(struct dt_iop_module_t *self)
     dt_bauhaus_slider_set_stop(g->scale_b, 0.0, 0.0, 0.0, 0.0);
     dt_bauhaus_slider_set_stop(g->scale_b, 1.0, 0.0, 0.0, 1.0);
 
-    dt_bauhaus_slider_set_stop(g->scale_g2, 0.0, 0.0, 0.0, 0.0);
-    dt_bauhaus_slider_set_stop(g->scale_g2, 1.0, 0.0, 1.0, 0.0);
+    dt_bauhaus_slider_set_stop(g->scale_y, 0.0, 0.0, 0.0, 0.0);
+    dt_bauhaus_slider_set_stop(g->scale_y, 1.0, 0.0, 1.0, 0.0);
   }
   if(!g->blackbody_is_confusing)
   {
@@ -949,12 +943,13 @@ void color_rgb_sliders(struct dt_iop_module_t *self)
   }
   else
   {
+     const dt_dev_chroma_t *chr = &self->dev->chroma;
     //real (ish)
     //we consider daylight wb to be "reference white"
     const double white[3] = {
-      1.0/g->daylight_wb[0],
-      1.0/g->daylight_wb[1],
-      1.0/g->daylight_wb[2],
+      1.0 / chr->D65coeffs[0],
+      1.0 / chr->D65coeffs[1],
+      1.0 / chr->D65coeffs[2],
     };
 
     const float rchanmul = dt_bauhaus_slider_get(g->scale_r);
@@ -967,8 +962,8 @@ void color_rgb_sliders(struct dt_iop_module_t *self)
     dt_bauhaus_slider_set_stop
       (g->scale_r, 0.0, white[0]*0.0, white[1]*gchanmul, white[2]*bchanmul);
     dt_bauhaus_slider_set_stop
-      (g->scale_r, g->daylight_wb[0]/rchanmulmax,
-       white[0]*g->daylight_wb[0], white[1]*gchanmul, white[2]*bchanmul);
+      (g->scale_r, chr->D65coeffs[0]/rchanmulmax,
+       white[0]*chr->D65coeffs[0], white[1]*gchanmul, white[2]*bchanmul);
     dt_bauhaus_slider_set_stop
       (g->scale_r, 1.0, white[0]*1.0,
        white[1]*(gchanmul/gchanmulmax), white[2]*(bchanmul/bchanmulmax));
@@ -976,8 +971,8 @@ void color_rgb_sliders(struct dt_iop_module_t *self)
     dt_bauhaus_slider_set_stop
       (g->scale_g, 0.0, white[0]*rchanmul, white[1]*0.0, white[2]*bchanmul);
     dt_bauhaus_slider_set_stop
-      (g->scale_g, g->daylight_wb[1]/bchanmulmax,
-       white[0]*rchanmul, white[1]*g->daylight_wb[1], white[2]*bchanmul);
+      (g->scale_g, chr->D65coeffs[1]/bchanmulmax,
+       white[0]*rchanmul, white[1]*chr->D65coeffs[1], white[2]*bchanmul);
     dt_bauhaus_slider_set_stop
       (g->scale_g, 1.0, white[0]*(rchanmul/rchanmulmax),
        white[1]*1.0, white[2]*(bchanmul/bchanmulmax));
@@ -985,8 +980,8 @@ void color_rgb_sliders(struct dt_iop_module_t *self)
     dt_bauhaus_slider_set_stop
       (g->scale_b, 0.0, white[0]*rchanmul, white[1]*gchanmul, white[2]*0.0);
     dt_bauhaus_slider_set_stop
-      (g->scale_b, g->daylight_wb[2]/bchanmulmax,
-       white[0]*rchanmul, white[1]*gchanmul, white[2]*g->daylight_wb[2]);
+      (g->scale_b, chr->D65coeffs[2]/bchanmulmax,
+       white[0]*rchanmul, white[1]*gchanmul, white[2]*chr->D65coeffs[2]);
     dt_bauhaus_slider_set_stop
       (g->scale_b, 1.0, white[0]*(rchanmul/rchanmulmax),
        white[1]*(gchanmul/gchanmulmax), white[2]*1.0);
@@ -1014,24 +1009,25 @@ void color_temptint_sliders(struct dt_iop_module_t *self)
   const double temp_step = (double)(DT_IOP_HIGHEST_TEMPERATURE - DT_IOP_LOWEST_TEMPERATURE) / (DT_BAUHAUS_SLIDER_MAX_STOPS - 1.0);
   const double tint_step = (double)(DT_IOP_HIGHEST_TINT - DT_IOP_LOWEST_TINT)
     / (DT_BAUHAUS_SLIDER_MAX_STOPS - 1.0);
-  const int blackbody_is_confusing = g->blackbody_is_confusing;
+  const gboolean blackbody_is_confusing = g->blackbody_is_confusing;
 
   const float cur_temp = dt_bauhaus_slider_get(g->scale_k);
   const float cur_tint = dt_bauhaus_slider_get(g->scale_tint);
 
+  const dt_dev_chroma_t *chr = &self->dev->chroma;
   //we consider daylight wb to be "reference white"
   const double dayligh_white[3] = {
-    1.0/g->daylight_wb[0],
-    1.0/g->daylight_wb[1],
-    1.0/g->daylight_wb[2],
+    1.0 / chr->D65coeffs[0],
+    1.0 / chr->D65coeffs[1],
+    1.0 / chr->D65coeffs[2],
   };
 
   double cur_coeffs[4] = {0.0};
   temp2mul(self, cur_temp, 1.0, cur_coeffs);
   const double cur_white[3] = {
-    1.0/cur_coeffs[0],
-    1.0/cur_coeffs[1],
-    1.0/cur_coeffs[2],
+    1.0 / cur_coeffs[0],
+    1.0 / cur_coeffs[1],
+    1.0 / cur_coeffs[2],
   };
 
   if(blackbody_is_confusing)
@@ -1140,44 +1136,6 @@ void color_temptint_sliders(struct dt_iop_module_t *self)
   }
 }
 
-static void _display_wb_error(struct dt_iop_module_t *self)
-{
-  // this module instance is doing chromatic adaptation
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
-  if(g == NULL) return;
-
-  ++darktable.gui->reset;
-
-  if(self->dev->proxy.chroma_adaptation != NULL
-     && !self->dev->proxy.wb_is_D65
-     && !dt_image_is_monochrome(&self->dev->image_storage))
-  {
-    // our second biggest problem : another module is doing CAT elsewhere in the pipe
-    dt_iop_set_module_trouble_message
-      (self,
-       _("white balance applied twice"),
-       _("the color calibration module is enabled,\n"
-         "and performing chromatic adaptation.\n"
-         "set the white balance here to camera reference (D65)\n"
-         "or disable chromatic adaptation in color calibration."),
-       "double application of white balance");
-  }
-  else
-  {
-    // no longer in trouble
-    dt_iop_set_module_trouble_message(self, NULL, NULL, NULL);
-  }
-
-  --darktable.gui->reset;
-}
-
-
-void gui_focus(struct dt_iop_module_t *self, gboolean in)
-{
-  _display_wb_error(self);
-}
-
-
 void gui_update(struct dt_iop_module_t *self)
 {
   dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
@@ -1204,27 +1162,24 @@ void gui_update(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set(g->scale_r, p->red);
   dt_bauhaus_slider_set(g->scale_g, p->green);
   dt_bauhaus_slider_set(g->scale_b, p->blue);
-  dt_bauhaus_slider_set(g->scale_g2, p->g2);
+  dt_bauhaus_slider_set(g->scale_y, p->various);
 
-  dt_bauhaus_combobox_set(g->presets, -1);
+  dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_UNKNOWN);
   dt_bauhaus_slider_set(g->finetune, 0);
 
   gboolean show_finetune = FALSE;
 
   gboolean found = FALSE;
-
+  const dt_dev_chroma_t *chr = &self->dev->chroma;
   // is this a "as shot" white balance?
-  if(feqf(p->red, g->as_shot_wb[0], DT_COEFF_EPS)
-     && feqf(p->green, g->as_shot_wb[1], DT_COEFF_EPS)
-     && feqf(p->blue, g->as_shot_wb[2], DT_COEFF_EPS))
+  if(dt_dev_equal_chroma((float *)p, chr->as_shot))
   {
     dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_AS_SHOT);
     found = TRUE;
   }
+
   // is this a "D65 white balance"?
-  else if(feqf(p->red, (float)g->daylight_wb[0], DT_COEFF_EPS)
-          && feqf(p->green, (float)g->daylight_wb[1], DT_COEFF_EPS)
-          && feqf(p->blue, (float)g->daylight_wb[2], DT_COEFF_EPS))
+  else if(dt_dev_equal_chroma((float *)p, chr->D65coeffs))
   {
     dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_D65);
     found = TRUE;
@@ -1245,9 +1200,7 @@ void gui_update(struct dt_iop_module_t *self)
           i++)
       {
         const dt_wb_data *wbp = dt_wb_preset(i);
-        if(feqf(p->red, (float)wbp->channels[0], DT_COEFF_EPS)
-           && feqf(p->green, (float)wbp->channels[1], DT_COEFF_EPS)
-           && feqf(p->blue, (float)wbp->channels[2], DT_COEFF_EPS))
+        if(dt_dev_equal_chroma((float *)p, wbp->channels))
         {
           // got exact match!
           dt_bauhaus_combobox_set(g->presets, j);
@@ -1309,9 +1262,7 @@ void gui_update(struct dt_iop_module_t *self)
             dt_wb_preset_interpolate(dt_wb_preset(i - 1),
                                      dt_wb_preset(i), &interpolated);
 
-            if(feqf(p->red, (float)interpolated.channels[0], DT_COEFF_EPS)
-               && feqf(p->green, (float)interpolated.channels[1], DT_COEFF_EPS)
-               && feqf(p->blue, (float)interpolated.channels[2], DT_COEFF_EPS))
+            if(dt_dev_equal_chroma((float *)p, interpolated.channels))
             {
               // got exact match!
 
@@ -1369,8 +1320,6 @@ void gui_update(struct dt_iop_module_t *self)
   color_temptint_sliders(self);
   color_rgb_sliders(self);
   color_finetuning_slider(self);
-
-  _display_wb_error(self);
 
   dt_gui_update_collapsible_section(&g->cs);
 
@@ -1455,7 +1404,8 @@ static void find_coeffs(dt_iop_module_t *module, double coeffs[4])
   }
   if(ok)
   {
-    for(int k = 0; k < 4; k++) coeffs[k] = img->wb_coeffs[k];
+    for_four_channels(k)
+      coeffs[k] = img->wb_coeffs[k];
     return;
   }
 
@@ -1476,7 +1426,8 @@ static void find_coeffs(dt_iop_module_t *module, double coeffs[4])
   if(!calculate_bogus_daylight_wb(module, bwb))
   {
     // found camera matrix and used it to calculate bogus daylight wb
-    for(int c = 0; c < 4; c++) coeffs[c] = bwb[c];
+    for_four_channels(c)
+      coeffs[c] = bwb[c];
     return;
   }
 
@@ -1506,7 +1457,10 @@ static void find_coeffs(dt_iop_module_t *module, double coeffs[4])
 void reload_defaults(dt_iop_module_t *module)
 {
   dt_iop_temperature_params_t *d = module->default_params;
-  *d = (dt_iop_temperature_params_t){ 1.0, 1.0, 1.0, 1.0 };
+
+  float *dcoeffs = (float *)d;
+  for_four_channels(k)
+    dcoeffs[k] = 1.0f;
 
   // we might be called from presets update infrastructure => there is no image
   if(!module->dev || !dt_is_valid_imgid(module->dev->image_storage.id))
@@ -1537,9 +1491,65 @@ void reload_defaults(dt_iop_module_t *module)
   module->default_enabled = FALSE;
   module->hide_enable_button = true_monochrome;
 
+  // we want these data in all cases to keep them in dev->chroma
+  double daylights[4] = {1.0, 1.0, 1.0, 1.0 };
+  double as_shot[4] = {1.0, 1.0, 1.0, 1.0 };
+
+  // to have at least something and definitely not crash
+  _temp_array_from_params(daylights, d);
+
+  if(!calculate_bogus_daylight_wb(module, daylights))
+  {
+    // found camera matrix and used it to calculate bogus daylight wb
+  }
+  else
+  {
+    // if we didn't find anything for daylight wb, look for a wb
+    // preset with appropriate name.  we're normalizing that to be D65
+    for(int i = 0; i < dt_wb_presets_count(); i++)
+    {
+      const dt_wb_data *wbp = dt_wb_preset(i);
+
+      if(!strcmp(wbp->make, module->dev->image_storage.camera_maker)
+         && !strcmp(wbp->model, module->dev->image_storage.camera_model)
+         && (!strcmp(wbp->name, "Daylight")  //??? PO
+             || !strcmp(wbp->name, "DirectSunlight"))
+         && wbp->tuning == 0)
+      {
+        for_four_channels(k)
+          daylights[k] = wbp->channels[k];
+        break;
+      }
+    }
+  }
+
+  // Store EXIF WB coeffs
+  if(is_raw)
+  {
+    find_coeffs(module, as_shot);
+    as_shot[0] /= as_shot[1];
+    as_shot[2] /= as_shot[1];
+    as_shot[3] /= as_shot[1];
+    as_shot[1] = 1.0;
+  }
+
+  dt_dev_chroma_t *chr = &module->dev->chroma;
+  for_four_channels(k)
+  {
+    chr->as_shot[k] = as_shot[k];
+    chr->D65coeffs[k] = daylights[k];
+  }
+
+  dt_print(DT_DEBUG_PARAMS, "[dt_iop_reload_defaults] temperature: D65 %.3f %.3f %.3f, AS-SHOT %.3f %.3f %.3f\n",
+    daylights[0], daylights[1], daylights[2], as_shot[0], as_shot[1], as_shot[2]);
+
+  // this is a single instance module always exposed to dev->chroma
+  chr->temperature = module;
+
   // White balance module doesn't need to be enabled for true_monochrome raws (like
   // for leica monochrom cameras). prepare_matrices is a noop as well, as there
   // isn't a color matrix, so we can skip that as well.
+
   if(!true_monochrome)
   {
     if(module->gui_data) prepare_matrices(module);
@@ -1555,19 +1565,19 @@ void reload_defaults(dt_iop_module_t *module)
       double coeffs[4] = { 0 };
       if(is_modern && !calculate_bogus_daylight_wb(module, coeffs))
       {
-        d->red = coeffs[0]/coeffs[1];
-        d->blue = coeffs[2]/coeffs[1];
-        d->g2 = coeffs[3]/coeffs[1];
-        d->green = 1.0f;
+        dcoeffs[0] = coeffs[0]/coeffs[1];
+        dcoeffs[2] = coeffs[2]/coeffs[1];
+        dcoeffs[3] = coeffs[3]/coeffs[1];
+        dcoeffs[1] = 1.0f;
       }
       else
       {
         // do best to find starting coeffs
         find_coeffs(module, coeffs);
-        d->red = coeffs[0]/coeffs[1];
-        d->blue = coeffs[2]/coeffs[1];
-        d->g2 = coeffs[3]/coeffs[1];
-        d->green = 1.0f;
+        dcoeffs[0] = coeffs[0]/coeffs[1];
+        dcoeffs[2] = coeffs[2]/coeffs[1];
+        dcoeffs[3] = coeffs[3]/coeffs[1];
+        dcoeffs[1] = 1.0f;
       }
     }
   }
@@ -1580,54 +1590,13 @@ void reload_defaults(dt_iop_module_t *module)
     gtk_stack_set_visible_child_name(GTK_STACK(module->widget),
                                      module->hide_enable_button ? "disabled" : "enabled");
 
-    dt_bauhaus_slider_set_default(g->scale_r, d->red);
-    dt_bauhaus_slider_set_default(g->scale_g, d->green);
-    dt_bauhaus_slider_set_default(g->scale_b, d->blue);
-    dt_bauhaus_slider_set_default(g->scale_g2, d->g2);
+    dt_bauhaus_slider_set_default(g->scale_r, dcoeffs[0]);
+    dt_bauhaus_slider_set_default(g->scale_g, dcoeffs[1]);
+    dt_bauhaus_slider_set_default(g->scale_b, dcoeffs[2]);
+    dt_bauhaus_slider_set_default(g->scale_y, dcoeffs[3]);
 
-    // to have at least something and definitely not crash
-    _temp_array_from_params(g->daylight_wb, d);
-
-    if(!calculate_bogus_daylight_wb(module, g->daylight_wb))
-    {
-      // found camera matrix and used it to calculate bogus daylight wb
-    }
-    else
-    {
-      // if we didn't find anything for daylight wb, look for a wb
-      // preset with appropriate name.  we're normalizing that to be
-      // D65
-      for(int i = 0; i < dt_wb_presets_count(); i++)
-      {
-        const dt_wb_data *wbp = dt_wb_preset(i);
-
-        if(!strcmp(wbp->make, module->dev->image_storage.camera_maker)
-           && !strcmp(wbp->model, module->dev->image_storage.camera_model)
-           && (!strcmp(wbp->name, "Daylight")  //??? PO
-               || !strcmp(wbp->name, "DirectSunlight"))
-           && wbp->tuning == 0)
-        {
-
-          for(int k = 0; k < 4; k++)
-            g->daylight_wb[k] = wbp->channels[k];
-          break;
-        }
-      }
-    }
-
-    // Store EXIF WB coeffs
-    if(is_raw)
-      find_coeffs(module, g->as_shot_wb);
-    else
-      g->as_shot_wb[0] = g->as_shot_wb[1] = g->as_shot_wb[2] = g->as_shot_wb[3] = 1.f;
-
-    g->as_shot_wb[0] /= g->as_shot_wb[1];
-    g->as_shot_wb[2] /= g->as_shot_wb[1];
-    g->as_shot_wb[3] /= g->as_shot_wb[1];
-    g->as_shot_wb[1] = 1.0;
-
-    for(int k = 0; k < 4; k++)
-      g->mod_coeff[k] = g->daylight_wb[k];
+    for_four_channels(k)
+       g->mod_coeff[k] = daylights[k];
 
     float TempK, tint;
     mul2temp(module, d, &TempK, &tint);
@@ -1711,8 +1680,6 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   mul2temp(self, p, &g->mod_temp, &g->mod_tint);
 
   dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_USER);
-
-  _display_wb_error(self);
 }
 
 static gboolean btn_toggled(GtkWidget *togglebutton,
@@ -1761,13 +1728,14 @@ static void preset_tune_callback(GtkWidget *widget, dt_iop_module_t *self)
                                pos == DT_IOP_TEMP_D65);
 
   gboolean show_finetune = FALSE;
+  dt_dev_chroma_t *chr = &self->dev->chroma;
 
   switch(pos)
   {
-    case -1: // just un-setting.
+    case DT_IOP_TEMP_UNKNOWN: // just un-setting.
       return;
     case DT_IOP_TEMP_AS_SHOT: // as shot wb
-      _temp_params_from_array(p, g->as_shot_wb);
+      _temp_params_from_array(p, chr->as_shot);
       break;
     case DT_IOP_TEMP_SPOT: // from image area wb, expose callback will set p->rgbg2.
       if(!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->colorpicker)))
@@ -1783,7 +1751,7 @@ static void preset_tune_callback(GtkWidget *widget, dt_iop_module_t *self)
       _temp_params_from_array(p, g->mod_coeff);
       break;
     case DT_IOP_TEMP_D65: // camera reference d65
-      _temp_params_from_array(p, g->daylight_wb);
+      _temp_params_from_array(p, chr->D65coeffs);
       break;
     default: // camera WB presets
     {
@@ -1864,7 +1832,7 @@ static void preset_tune_callback(GtkWidget *widget, dt_iop_module_t *self)
 
   gtk_widget_set_visible(GTK_WIDGET(g->finetune), show_finetune);
 
-  if(self->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
+  if(self->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), TRUE);
 
   float TempK, tint;
 
@@ -1879,12 +1847,13 @@ static void preset_tune_callback(GtkWidget *widget, dt_iop_module_t *self)
   }
 
   ++darktable.gui->reset;
+  float *pcoeffs = (float *)p;
   dt_bauhaus_slider_set(g->scale_k, TempK);
   dt_bauhaus_slider_set(g->scale_tint, tint);
-  dt_bauhaus_slider_set(g->scale_r, p->red);
-  dt_bauhaus_slider_set(g->scale_g, p->green);
-  dt_bauhaus_slider_set(g->scale_b, p->blue);
-  dt_bauhaus_slider_set(g->scale_g2, p->g2);
+  dt_bauhaus_slider_set(g->scale_r, pcoeffs[0]);
+  dt_bauhaus_slider_set(g->scale_g, pcoeffs[1]);
+  dt_bauhaus_slider_set(g->scale_b, pcoeffs[2]);
+  dt_bauhaus_slider_set(g->scale_y, pcoeffs[3]);
   --darktable.gui->reset;
 
   color_temptint_sliders(self);
@@ -1901,20 +1870,17 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
 
   dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
   dt_iop_temperature_params_t *p = (dt_iop_temperature_params_t *)self->params;
+  float *pcoeffs = (float *)p;
 
   // capture gui color picked event.
   if(self->picked_color_max[0] < self->picked_color_min[0]) return;
   const float *grayrgb = self->picked_color;
 
   // normalize green:
-  p->green = grayrgb[1] > 0.001f ? 1.0f / grayrgb[1] : 1.0f;
-  p->red  = fmaxf(0.0f,
-                  fminf(8.0f, (grayrgb[0] > 0.001f ? 1.0f / grayrgb[0] : 1.0f) / p->green));
-  p->blue = fmaxf(0.0f,
-                  fminf(8.0f, (grayrgb[2] > 0.001f ? 1.0f / grayrgb[2] : 1.0f) / p->green));
-  p->g2   = fmaxf(0.0f,
-                  fminf(8.0f, (grayrgb[3] > 0.001f ? 1.0f / grayrgb[3] : 1.0f) / p->green));
-  p->green = 1.0;
+  const float gnormal = grayrgb[1] > 0.001f ? 1.0f / grayrgb[1] : 1.0f;
+  for_four_channels(c)
+    pcoeffs[c]  = fmaxf(0.0f,fminf(8.0f,(grayrgb[c] > 0.001f ? 1.0f / grayrgb[c] : 1.0f) / gnormal));
+  pcoeffs[1] = 1.0f;
 
   dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_SPOT);
 }
@@ -1933,11 +1899,11 @@ static void gui_sliders_update(struct dt_iop_module_t *self)
     gtk_widget_set_tooltip_text(g->scale_g, _("magenta channel coefficient"));
     dt_bauhaus_widget_set_label(g->scale_b, NULL, N_("cyan"));
     gtk_widget_set_tooltip_text(g->scale_b, _("cyan channel coefficient"));
-    dt_bauhaus_widget_set_label(g->scale_g2, NULL, N_("yellow"));
-    gtk_widget_set_tooltip_text(g->scale_g2, _("yellow channel coefficient"));
+    dt_bauhaus_widget_set_label(g->scale_y, NULL, N_("yellow"));
+    gtk_widget_set_tooltip_text(g->scale_y, _("yellow channel coefficient"));
 
     gtk_box_reorder_child(GTK_BOX(g->cs.container), g->scale_b, 0);
-    gtk_box_reorder_child(GTK_BOX(g->cs.container), g->scale_g2, 1);
+    gtk_box_reorder_child(GTK_BOX(g->cs.container), g->scale_y, 1);
     gtk_box_reorder_child(GTK_BOX(g->cs.container), g->scale_g, 2);
     gtk_box_reorder_child(GTK_BOX(g->cs.container), g->scale_r, 3);
   }
@@ -1949,16 +1915,16 @@ static void gui_sliders_update(struct dt_iop_module_t *self)
     gtk_widget_set_tooltip_text(g->scale_g, _("green channel coefficient"));
     dt_bauhaus_widget_set_label(g->scale_b, NULL, N_("blue"));
     gtk_widget_set_tooltip_text(g->scale_b, _("blue channel coefficient"));
-    dt_bauhaus_widget_set_label(g->scale_g2, NULL, N_("emerald"));
-    gtk_widget_set_tooltip_text(g->scale_g2, _("emerald channel coefficient"));
+    dt_bauhaus_widget_set_label(g->scale_y, NULL, N_("emerald"));
+    gtk_widget_set_tooltip_text(g->scale_y, _("emerald channel coefficient"));
 
     gtk_box_reorder_child(GTK_BOX(g->cs.container), g->scale_r, 0);
     gtk_box_reorder_child(GTK_BOX(g->cs.container), g->scale_g, 1);
     gtk_box_reorder_child(GTK_BOX(g->cs.container), g->scale_b, 2);
-    gtk_box_reorder_child(GTK_BOX(g->cs.container), g->scale_g2, 3);
+    gtk_box_reorder_child(GTK_BOX(g->cs.container), g->scale_y, 3);
   }
 
-  gtk_widget_set_visible(GTK_WIDGET(g->scale_g2), (img->flags & DT_IMAGE_4BAYER));
+  gtk_widget_set_visible(GTK_WIDGET(g->scale_y), (img->flags & DT_IMAGE_4BAYER));
 }
 
 static void temp_label_click(GtkWidget *label,
@@ -2002,8 +1968,8 @@ static void _preference_changed(gpointer instance, gpointer user_data)
   dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
 
   const char *config = dt_conf_get_string_const("plugins/darkroom/temperature/colored_sliders");
-  g->colored_sliders = g_strcmp0(config, "no color"); // true if config != "no color"
-  g->blackbody_is_confusing = g->colored_sliders && g_strcmp0(config, "illuminant color"); // true if config != "illuminant color"
+  g->colored_sliders = g_strcmp0(config, "no color") ? TRUE : FALSE;
+  g->blackbody_is_confusing = g->colored_sliders && (g_strcmp0(config, "illuminant color") ? TRUE : FALSE);
 
   g->button_bar_visible = dt_conf_get_bool("plugins/darkroom/temperature/button_bar");
   gtk_widget_set_visible(g->buttonbar, g->button_bar_visible);
@@ -2013,18 +1979,9 @@ static void _preference_changed(gpointer instance, gpointer user_data)
   color_finetuning_slider(self);
 }
 
-static void _develop_ui_pipe_finished_callback(gpointer instance, gpointer user_data)
-{
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  _display_wb_error(self);
-}
-
 void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_temperature_gui_data_t *g = IOP_GUI_ALLOC(temperature);
-
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,
-                            G_CALLBACK(_develop_ui_pipe_finished_callback), self);
 
   const char *config =
     dt_conf_get_string_const("plugins/darkroom/temperature/colored_sliders");
@@ -2032,7 +1989,7 @@ void gui_init(struct dt_iop_module_t *self)
   // true if config != "illuminant color"
   g->blackbody_is_confusing = g->colored_sliders && g_strcmp0(config, "illuminant color");
 
-  const int feedback = g->colored_sliders ? 0 : 1;
+  const gboolean feedback = g->colored_sliders ? FALSE : TRUE;
   g->button_bar_visible = dt_conf_get_bool("plugins/darkroom/temperature/button_bar");
 
   GtkBox *box_enabled = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
@@ -2094,12 +2051,8 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(box_enabled, g->finetune, TRUE, TRUE, 0);
 
   g->mod_temp = -FLT_MAX;
-  for(int k = 0; k < 4; k++)
-  {
-    g->daylight_wb[k] = 1.0;
-    g->as_shot_wb[k] = 1.0;
+  for_four_channels(k)
     g->mod_coeff[k] = 1.0;
-  }
 
   GtkWidget *temp_label_box = gtk_event_box_new();
   g->temp_label = dt_ui_section_label_new(C_("section", "scene illuminant temp"));
@@ -2141,13 +2094,13 @@ void gui_init(struct dt_iop_module_t *self)
   g->scale_r = dt_bauhaus_slider_from_params(self, N_("red"));
   g->scale_g = dt_bauhaus_slider_from_params(self, N_("green"));
   g->scale_b = dt_bauhaus_slider_from_params(self, N_("blue"));
-  g->scale_g2 = dt_bauhaus_slider_from_params(self, "g2");
+  g->scale_y = dt_bauhaus_slider_from_params(self, N_("various"));
   dt_bauhaus_slider_set_digits(g->scale_r, 3);
   dt_bauhaus_slider_set_digits(g->scale_g, 3);
   dt_bauhaus_slider_set_digits(g->scale_b, 3);
-  dt_bauhaus_slider_set_digits(g->scale_g2, 3);
+  dt_bauhaus_slider_set_digits(g->scale_y, 3);
 
-  gtk_widget_set_no_show_all(g->scale_g2, TRUE);
+  gtk_widget_set_no_show_all(g->scale_y, TRUE);
 
   g_signal_connect(G_OBJECT(g->scale_k), "value-changed",
                    G_CALLBACK(temp_tint_callback), self);
@@ -2180,8 +2133,6 @@ void gui_cleanup(struct dt_iop_module_t *self)
   self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
                                      G_CALLBACK(_preference_changed), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_develop_ui_pipe_finished_callback), self);
 
   IOP_GUI_FREE;
 }
@@ -2203,7 +2154,6 @@ void gui_reset(struct dt_iop_module_t *self)
   color_finetuning_slider(self);
   color_rgb_sliders(self);
   color_temptint_sliders(self);
-  _display_wb_error(self);
 }
 
 // clang-format off

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -1216,7 +1216,6 @@ static void _lib_history_truncate(const gboolean compress)
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);
 
-  darktable.develop->proxy.chroma_adaptation = NULL;
   dt_dev_reload_history_items(darktable.develop);
   dt_dev_undo_end_record(darktable.develop);
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -746,7 +746,8 @@ gboolean try_enter(dt_view_t *self)
   // and drop the lock again.
   dt_image_cache_read_release(darktable.image_cache, img);
   darktable.develop->image_storage.id = imgid;
-  darktable.develop->proxy.wb_coeffs[0] = 0.f;
+
+  dt_dev_reset_chroma(darktable.develop);
   return FALSE;
 }
 
@@ -770,9 +771,7 @@ static void _dev_change_image(dt_develop_t *dev, const dt_imgid_t imgid)
 {
   // Pipe reset needed when changing image
   // FIXME: synch with dev_init() and dev_cleanup() instead of redoing it
-  dev->proxy.chroma_adaptation = NULL;
-  dev->proxy.wb_is_D65 = TRUE;
-  dev->proxy.wb_coeffs[0] = 0.f;
+  dt_dev_reset_chroma(dev);
 
   // change active image
   g_slist_free(darktable.view_manager->active_images);


### PR DESCRIPTION
This implements a
`chroma` struct in dev (like a proxy) holding all required and available white balance data for the current image (D65, as_shot and currently used) allowing runtime

a) check - are we using D65?
b) access of modules to the other coeffs for improved results c) easier and safe checks for chroma correction related trouble messages

@TurboGit for you as this might be easier to review.
It's a stripped down version of #15461, this should not change anything in current master behaviour except safer message generation and keeping data in the dev chroma struct. The other pr could be rebased on this after possibly getting merged.

Fixes #14518
