### PR TITLE
fix crash when entering Chinese in bauhaus popup

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -3348,7 +3348,7 @@ static gboolean _popup_key_press(GtkWidget *widget,
         _slider_add_step(GTK_WIDGET(w), delta, event->state, FALSE);
       break;
     default:
-      if(!g_utf8_validate(event->string, -1, NULL)) return FALSE;
+      if(!event->string || !g_utf8_validate(event->string, -1, NULL)) return FALSE;
       const gunichar c = g_utf8_get_char(event->string);
       if(!g_unichar_isprint(c)) return FALSE;
       const long int char_width = g_utf8_next_char(event->string) - event->string;


### PR DESCRIPTION
fixes #15485

You still can't type Chinese in a combobox popup, but shouldn't crash (just ignores).

At least, this is with my limited testing and without much understanding of how Chinese IMEs work. if you can still make it crash, please provide clear instructions how I can reproduce on Win11 with a US keyboard layout.

Many thanks for reporting (and, in advance, for testing).

