### PR TITLE
Introduce as-shot to later D65 workflow

### DIFF
--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -2301,6 +2301,49 @@ void dtgtk_cairo_paint_bulb(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
   FINISH
 }
 
+void dtgtk_cairo_paint_bulb_mod(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(0.95, 1, 0, -0.05)
+
+  const float line_width = 0.1;
+
+  cairo_rectangle(cr, 0.78, 0.950, .22, 0.22);
+  if(flags & CPF_ACTIVE)
+  {
+    cairo_stroke_preserve(cr);
+    cairo_fill(cr);
+  }
+  else
+    cairo_stroke(cr);
+
+  // glass
+  cairo_arc_negative(cr, 0.5, 0.38, 0.4, 1., M_PI - 1.);
+  cairo_close_path(cr);
+
+  if(flags & CPF_ACTIVE)
+  {
+    cairo_stroke_preserve(cr);
+    cairo_fill(cr);
+  }
+  else
+  {
+    cairo_stroke(cr);
+    cairo_arc(cr, 0.5, 0.38, 0.2, -M_PI / 3.0, -M_PI / 6.);
+    cairo_stroke(cr);
+  }
+
+  // screw
+  cairo_move_to(cr, 0.33, 0.38 + 0.36 + 1 * line_width);
+  cairo_line_to(cr, 0.67, 0.38 + 0.36 + 1 * line_width);
+  cairo_stroke(cr);
+
+  // nib
+  cairo_arc(cr, 0.5, 0.38 + 0.36 + 2. * line_width, 2.0 * line_width, 0, M_PI);
+  cairo_fill(cr);
+
+  FINISH
+}
+
 
 void dtgtk_cairo_paint_rawoverexposed(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -183,6 +183,8 @@ void dtgtk_cairo_paint_overexposed(cairo_t *cr, gint x, gint y, gint w, gint h, 
 void dtgtk_cairo_paint_rawoverexposed(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint a light bulb */
 void dtgtk_cairo_paint_bulb(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** paint a modified light bulb */
+void dtgtk_cairo_paint_bulb_mod(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint a gamut check icon */
 void dtgtk_cairo_paint_gamut_check(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint a soft proofing icon */

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -2093,7 +2093,7 @@ void gui_init(struct dt_iop_module_t *self)
                                             N_("settings"),
                                             N_("as shot to reference"), NULL,
                                             G_CALLBACK(btn_toggled), FALSE, 0, 0,
-                                            dtgtk_cairo_paint_bulb, NULL);
+                                            dtgtk_cairo_paint_bulb_mod, NULL);
   gtk_widget_set_tooltip_text
     (g->btn_d65_late,
      _("set white balance to as shot and later correct to camera reference point,\nin most cases it should be D65"));


### PR DESCRIPTION
Replaces #15461 so maybe read discussions there 

Please note that temperature module version is increased in the PR


The current modern chroma correction workflow assumes "camera reference point" (nomally D65) has the best available data for temperature coeffs as preliminary for all modules in the pixelpipe before colorin. There we change to working profile and continue work for best visual quality until the "color calibration" module.

There is one drawback with this approach. Some modules in the pipe would like to have "perfect white balance" correction - the rgb channels all have the same value for any greytone.

Examples:
1. Some hightlights reconstruction algos take the other channels or surrounding data into account and modify data "towards white".
2. raw chromatic aberration correction also iterates from channel differences. Good "white is white" coeffs help significantly here.
3. Some demosaicers also have slightly improved output on pixelpeeping level.
4. ...

In short - how does it work?

```
was: data(rgb) -> temperature(*D65)     -> ModA -> ModB ...                   ->colorin
now: data(rgb) -> temperature(*as_shot) -> ModA -> ModB ... -> *(D65/as_shot) ->colorin
```