### PR TITLE
Restrict effect of operation_tags_filter() & operation_tags()

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -3122,7 +3122,7 @@ int dt_dev_distort_transform_locked(dt_develop_t *dev,
        && !(dev->gui_module
             && dev->gui_module != module
             && (dev->gui_module->operation_tags_filter() & module->operation_tags())
-            && (pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW))))
+            && (pipe->type & DT_DEV_PIXELPIPE_BASIC)))
     {
       module->distort_transform(module, piece, points, points_count);
     }

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -3119,8 +3119,10 @@ int dt_dev_distort_transform_locked(dt_develop_t *dev,
                && module->iop_order <= iop_order)
            || (transf_direction == DT_DEV_TRANSFORM_DIR_BACK_EXCL
                && module->iop_order < iop_order))
-       && !(dev->gui_module && dev->gui_module != module
-            && (dev->gui_module->operation_tags_filter() & module->operation_tags())))
+       && !(dev->gui_module
+            && dev->gui_module != module
+            && (dev->gui_module->operation_tags_filter() & module->operation_tags())
+            && (pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW))))
     {
       module->distort_transform(module, piece, points, points_count);
     }
@@ -3175,8 +3177,10 @@ int dt_dev_distort_backtransform_locked(dt_develop_t *dev,
                && module->iop_order <= iop_order)
            || (transf_direction == DT_DEV_TRANSFORM_DIR_BACK_EXCL
                && module->iop_order < iop_order))
-       && !(dev->gui_module && dev->gui_module != module
-            && (dev->gui_module->operation_tags_filter() & module->operation_tags())))
+       && !(dev->gui_module
+            && dev->gui_module != module
+            && (dev->gui_module->operation_tags_filter() & module->operation_tags())
+            && (pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW))))
     {
       module->distort_backtransform(module, piece, points, points_count);
     }

--- a/src/develop/pixelpipe.h
+++ b/src/develop/pixelpipe.h
@@ -40,7 +40,8 @@ typedef enum dt_dev_pixelpipe_type_t
   DT_DEV_PIXELPIPE_SCREEN    = DT_DEV_PIXELPIPE_PREVIEW | DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW2,
   DT_DEV_PIXELPIPE_ANY       = DT_DEV_PIXELPIPE_EXPORT | DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW
                                | DT_DEV_PIXELPIPE_THUMBNAIL | DT_DEV_PIXELPIPE_PREVIEW2,
-  DT_DEV_PIXELPIPE_FAST      = 1 << 8
+  DT_DEV_PIXELPIPE_FAST      = 1 << 8,
+  DT_DEV_PIXELPIPE_BASIC     = DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW
 } dt_dev_pixelpipe_type_t;
 
 /** when to collect histogram */
@@ -49,7 +50,7 @@ typedef enum dt_dev_request_flags_t
   DT_REQUEST_NONE = 0,
   DT_REQUEST_ON = 1 << 0,
   DT_REQUEST_ONLY_IN_GUI = 1 << 1,
-  DT_REQUEST_EXPANDED = 1 << 2 // 
+  DT_REQUEST_EXPANDED = 1 << 2 //
 } dt_dev_request_flags_t;
 
 typedef enum dt_dev_pixelpipe_display_mask_t

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -134,8 +134,15 @@ static uint64_t _dev_pixelpipe_cache_basichash(
   {
     dt_dev_pixelpipe_iop_t *piece = (dt_dev_pixelpipe_iop_t *)pieces->data;
     dt_develop_t *dev = piece->module->dev;
-    if(!(dev->gui_module && dev->gui_module != piece->module
-         && (dev->gui_module->operation_tags_filter() & piece->module->operation_tags())))
+
+    // don't take skipped modules into account
+    const gboolean skipped =
+      dev->gui_module
+      && dev->gui_module != piece->module
+      && (dev->gui_module->operation_tags_filter() & piece->module->operation_tags())
+      && (pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW));
+
+    if(!skipped)
     {
       hash = ((hash << 5) + hash) ^ piece->hash;
       if(piece->module->request_color_pick != DT_REQUEST_COLORPICK_OFF)

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1353,7 +1353,7 @@ static inline gboolean _skip_piece_on_tags(const dt_dev_pixelpipe_iop_t *piece)
   return piece->module->dev->gui_module
       && piece->module->dev->gui_module != piece->module
       && (piece->module->dev->gui_module->operation_tags_filter() & piece->module->operation_tags())
-      && (piece->pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW));
+      && (piece->pipe->type & DT_DEV_PIXELPIPE_BASIC);
 }
 
 // recursive helper for process, returns TRUE in case of unfinished work or error
@@ -2356,7 +2356,7 @@ static gboolean _dev_pixelpipe_process_rec(
     // as the user is likely to change that one soon (again), so keep it in cache.
     // Also do this if the clbuffer has been actively written
     const gboolean has_focus = (module == darktable.develop->gui_module);
-    if((pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW))
+    if((pipe->type & DT_DEV_PIXELPIPE_BASIC)
         && (pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_NONE)
         && (has_focus || module->write_input_hint || important_cl))
     {
@@ -2370,7 +2370,7 @@ static gboolean _dev_pixelpipe_process_rec(
     module->write_input_hint = FALSE;
 
     if(module->expanded
-       && (pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW))
+       && (pipe->type & DT_DEV_PIXELPIPE_BASIC)
        && (module->request_histogram & DT_REQUEST_EXPANDED))
     {
       dt_print_pipe(DT_DEBUG_PIPE, "internal histogram", pipe, module, &roi_in, roi_out, "\n");

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4139,7 +4139,9 @@ static int call_distort_transform(dt_develop_t *dev,
     dt_dev_distort_get_iop_pipe(self->dev, self->dev->preview_pipe, self);
   if(!piece) return ret;
   if(piece->module == self && /*piece->enabled && */  //see note below
-     !(dev->gui_module && dev->gui_module->operation_tags_filter() & piece->module->operation_tags()))
+     !(dev->gui_module
+        && (dev->gui_module->operation_tags_filter() & piece->module->operation_tags())
+        && (pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW))))
   {
     ret = piece->module->distort_transform(piece->module, piece, points, points_count);
   }

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4141,7 +4141,7 @@ static int call_distort_transform(dt_develop_t *dev,
   if(piece->module == self && /*piece->enabled && */  //see note below
      !(dev->gui_module
         && (dev->gui_module->operation_tags_filter() & piece->module->operation_tags())
-        && (pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW))))
+        && (pipe->type & DT_DEV_PIXELPIPE_BASIC)))
   {
     ret = piece->module->distort_transform(piece->module, piece, points, points_count);
   }

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -407,7 +407,7 @@ void commit_params(struct dt_iop_module_t *self,
   dt_iop_crop_params_t *p = (dt_iop_crop_params_t *)p1;
   dt_iop_crop_data_t *d = (dt_iop_crop_data_t *)piece->data;
 
-  if(_gui_has_focus(self))
+  if(_gui_has_focus(self) && (pipe->type & DT_DEV_PIXELPIPE_BASIC))
   {
     d->cx = 0.0f;
     d->cy = 0.0f;

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2208,6 +2208,7 @@ void cleanup_global(dt_iop_module_so_t *module)
 void gui_focus(struct dt_iop_module_t *self,
                const gboolean in)
 {
+  self->dev->cropping.requester = NULL;
   if(self->enabled
      && !darktable.develop->full.pipe->loading)
   {
@@ -2215,6 +2216,7 @@ void gui_focus(struct dt_iop_module_t *self,
 
     if(in)
     {
+      self->dev->cropping.requester = self;
       dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->blend_data;
       //only show shapes if shapes exist
       dt_masks_form_t *grp =
@@ -2260,7 +2262,6 @@ void gui_focus(struct dt_iop_module_t *self,
        || g->suppress_mask)
       dt_iop_refresh_center(self);
   }
-  self->dev->cropping.requester = (in && !darktable.develop->full.pipe->loading) ? self : NULL;
 }
 
 void tiling_callback(struct dt_iop_module_t *self,


### PR DESCRIPTION
Combining operation_tags_filter() & module->operation_tags() is used at several places
to skip a piece effect. This was implemented as valid for all pixelpipes.

We ensure that only DT_DEV_PIXELPIPE_FULL and DT_DEV_PIXELPIPE_PREVIEW pixelpipes
avoid / skip this piece
- in pixelpipe processing
- for calculating the cache hash
- while distorting

Fixes #15501