### PR TITLE
Simplify importance_hint

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -902,7 +902,7 @@ static void _dev_add_history_item_ext(dt_develop_t *dev,
     }
   }
   if((module->enabled) && (!no_image))
-    module->write_input_hint = TRUE;
+    dev->history_last_module = module;
 
   // possibly save database and sidecar file
   if(dev->autosaving)

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -192,7 +192,10 @@ typedef struct dt_develop_t
   dt_pthread_mutex_t history_mutex;
   int32_t history_end;
   GList *history;
+  // some modules don't want to add new history items while active
   gboolean history_postpone_invalidate;
+  // avoid checking for latest added module into history via list traversal
+  struct dt_iop_module_t *history_last_module;
 
   // operations pipeline
   int32_t iop_instance;

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -409,7 +409,6 @@ gboolean dt_iop_load_module_by_so(dt_iop_module_t *module,
     g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, g_free);
   module->raster_mask.sink.source = NULL;
   module->raster_mask.sink.id = INVALID_MASKID;
-  module->write_input_hint = FALSE;
 
   // only reference cached results of dlopen:
   module->module = so->module;

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -302,9 +302,6 @@ typedef struct dt_iop_module_t
   GtkWidget *guides_toggle;
   GtkWidget *guides_combo;
 
-  /** Last user action changed any module parameter via history? */
-  gboolean  write_input_hint;
-
   /** flag in case the module has troubles (bad settings) - if TRUE,
    * show a warning sign next to module label */
   gboolean has_trouble;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2149,9 +2149,9 @@ static gboolean _dev_pixelpipe_process_rec(
            (pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_NONE)
            && ((pipe->type == DT_DEV_PIXELPIPE_FULL) // ignored in fast mode
               || (pipe->type == DT_DEV_PIXELPIPE_PREVIEW))
-           && darktable.develop->gui_attached
+           && dev->gui_attached
            && ((module == darktable.develop->gui_module)
-                || module->write_input_hint
+                || darktable.develop->history_last_module == module
                 || dt_iop_module_is(module->so, "colorout"));
 
         if(important_cl)
@@ -2349,16 +2349,17 @@ static gboolean _dev_pixelpipe_process_rec(
     const gboolean has_focus = (module == darktable.develop->gui_module);
     if((pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW))
         && (pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_NONE)
-        && (has_focus || module->write_input_hint || important_cl))
+        && (has_focus || darktable.develop->history_last_module == module || important_cl))
     {
       dt_print_pipe(DT_DEBUG_PIPE, "importance hints", pipe, module, &roi_in, roi_out, "%s%s%s\n",
-        module->write_input_hint ? "input_hint " : "",
+        darktable.develop->history_last_module == module ? "input_hint " : "",
         has_focus ? "focus " : "",
         important_cl ? "cldata" : "");
       dt_dev_pixelpipe_important_cacheline(pipe, input, roi_in.width * roi_in.height * in_bpp);
     }
 
-    module->write_input_hint = FALSE;
+    if(pipe->type & DT_DEV_PIXELPIPE_FULL)
+      darktable.develop->history_last_module = NULL;
 
     if(module->expanded
        && (pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW))


### PR DESCRIPTION
While changing some module's parameters while not being in_focus (for example by shortcuts) we want this information because
- we want the input cacheline of the module with high priority because it's likely to be used again pretty soon
- cl devices want to write clbuffer to the cache too

Instead of keeping that information local in the module we keep track of it in dev, lower memory footprint and more logical.