### PR TITLE
Another round of OpenCL stability fixes

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -2203,6 +2203,12 @@ void dt_configure_runtime_performance(const int old, char *info)
     g_strlcat(info, _(" 'avoid_atomics' 'micro_nap' 'pinned_memory' 'roundupwd' 'roundupht' 'eventhandles' 'async' 'disable' 'magic' 'advantage' 'unified'"), DT_PERF_INFOSIZE);
     g_strlcat(info, "\n\n", DT_PERF_INFOSIZE);
   }
+
+  else if(old < 16)
+  {
+    g_strlcat(info, INFO_HEADER, DT_PERF_INFOSIZE);
+    g_strlcat(info, _("OpenCL 'per device' compiler settings might have been updated.\n\n"), DT_PERF_INFOSIZE);
+  }
   #undef INFO_HEADER
 }
 

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -179,7 +179,7 @@ typedef int32_t dt_mask_id_t;
 // version of current performance configuration version
 // if you want to run an updated version of the performance configuration later
 // bump this number and make sure you have an updated logic in dt_configure_runtime_performance()
-#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 15
+#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 16
 #define DT_PERF_INFOSIZE 4096
 
 // every module has to define this:

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -31,6 +31,7 @@
 #define DT_OPENCL_MAX_INCLUDES 7
 #define DT_OPENCL_VENDOR_AMD 4098
 #define DT_OPENCL_VENDOR_NVIDIA 4318
+#define DT_OPENCL_VENDOR_APPLE 16940800
 #define DT_OPENCL_VENDOR_INTEL 0x8086u
 #define DT_OPENCL_CBUFFSIZE 1024
 #define DT_OPENCL_DEFAULT_HEADROOM 600
@@ -64,16 +65,14 @@ extern "C" {
 #define ROUNDUPDWD(a, b) dt_opencl_dev_roundup_width(a, b)
 #define ROUNDUPDHT(a, b) dt_opencl_dev_roundup_height(a, b)
 
-#define DT_OPENCL_DEFAULT_COMPILE_INTEL ("")
-#define DT_OPENCL_DEFAULT_COMPILE_AMD ("-cl-fast-relaxed-math")
-#define DT_OPENCL_DEFAULT_COMPILE_NVIDIA ("-cl-fast-relaxed-math")
-#define DT_OPENCL_DEFAULT_COMPILE ("")
+#define DT_OPENCL_DEFAULT_COMPILE_DEFAULT ("")
+#define DT_OPENCL_DEFAULT_COMPILE_OPTI ("-cl-fast-relaxed-math")
 #define DT_CLDEVICE_HEAD ("cldevice_v5_")
 
 // version for current darktable cl kernels
 // this is reflected in the kernel directory and allows to
 // enforce a new kernel compilation cycle
-#define DT_OPENCL_KERNELS 2
+#define DT_OPENCL_KERNELS 3
 
 typedef enum dt_opencl_memory_t
 {
@@ -129,7 +128,6 @@ typedef struct dt_opencl_device_t
   int totallost;
   int maxeventslot;
   gboolean nvidia_sm_20;
-  const char *vendor;
   const char *fullname;
   const char *cname;
   const char *options;


### PR DESCRIPTION
Until now the OpenCL compiler flags were derived from the vendor_id, this is a device depending integer, some vendors have that fixed.

We had this in dt for long, it's not the best way to do as we might have several drivers for the device, some have been proven to be stable (if working and properly installed) also using some optimizing flags.

This pr implements a different strategy, drivers that are know "as good"
- nvidia cuda, the amd driver and apple

get optimizing flags, the others default to `default`

Alse we get rid of opencl dev->vendor as it was not used at all.

cl kernel version has been bumped to enforce a new compilation

@MStraeten @zisoft running good?
@piratenpanda fine on standard amd?