### PR TITLE
fix infinite "working..." on colorpicker

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -429,7 +429,7 @@ restart:
   dt_dev_average_delay_update(&start, &pipe->average_delay);
 
   // maybe we got zoomed/panned in the meantime?
-  if(pipe->changed != DT_DEV_PIPE_UNCHANGED) goto restart;
+  if(port && pipe->changed != DT_DEV_PIPE_UNCHANGED) goto restart;
 
   pipe->status = DT_DEV_PIXELPIPE_VALID;
   pipe->loading = FALSE;


### PR DESCRIPTION
fixes #15512

@AxelG-DE would you please check if this fixes the issue for you?

@pehar1 this only tries to address the first issue, not your second one; please open a separate github issue to discuss the "continuous working flickering when 100% zoomed in corner of navigation module" problem. Unless this PR (unexpectely) makes that disappear too...