### PR TITLE
imageio: tweak support for CICP mistagged sRGB files (AVIF/HEIF/PNG)

### DIFF
--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -2213,6 +2213,9 @@ dt_colorspaces_color_profile_type_t dt_colorspaces_cicp_to_type
           switch(cicp->matrix_coefficients)
           {
             case DT_CICP_MATRIX_COEFFICIENTS_IDENTITY: /* support RGB (4:4:4 or lossless) */
+            case DT_CICP_MATRIX_COEFFICIENTS_REC709:
+            case DT_CICP_MATRIX_COEFFICIENTS_SYCC:
+            case DT_CICP_MATRIX_COEFFICIENTS_REC601:
             case DT_CICP_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
             case DT_CICP_MATRIX_COEFFICIENTS_UNSPECIFIED:
               return DT_COLORSPACE_PQ_P3;
@@ -2228,6 +2231,9 @@ dt_colorspaces_color_profile_type_t dt_colorspaces_cicp_to_type
           switch(cicp->matrix_coefficients)
           {
             case DT_CICP_MATRIX_COEFFICIENTS_IDENTITY: /* support RGB (4:4:4 or lossless) */
+            case DT_CICP_MATRIX_COEFFICIENTS_REC709:
+            case DT_CICP_MATRIX_COEFFICIENTS_SYCC:
+            case DT_CICP_MATRIX_COEFFICIENTS_REC601:
             case DT_CICP_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
             case DT_CICP_MATRIX_COEFFICIENTS_UNSPECIFIED:
               return DT_COLORSPACE_HLG_P3;
@@ -2243,6 +2249,9 @@ dt_colorspaces_color_profile_type_t dt_colorspaces_cicp_to_type
           switch(cicp->matrix_coefficients)
           {
             case DT_CICP_MATRIX_COEFFICIENTS_IDENTITY: /* support RGB (4:4:4 or lossless) */
+            case DT_CICP_MATRIX_COEFFICIENTS_REC709:
+            case DT_CICP_MATRIX_COEFFICIENTS_SYCC:
+            case DT_CICP_MATRIX_COEFFICIENTS_REC601:
             case DT_CICP_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
             case DT_CICP_MATRIX_COEFFICIENTS_UNSPECIFIED:
               return DT_COLORSPACE_DISPLAY_P3;

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -2090,6 +2090,7 @@ dt_colorspaces_color_profile_type_t dt_colorspaces_cicp_to_type
           switch(cicp->matrix_coefficients)
           {
             case DT_CICP_MATRIX_COEFFICIENTS_IDENTITY: /* support RGB (4:4:4 or lossless) */
+            case DT_CICP_MATRIX_COEFFICIENTS_REC709: /* support incorrectly tagged files */
             case DT_CICP_MATRIX_COEFFICIENTS_SYCC:
             case DT_CICP_MATRIX_COEFFICIENTS_REC601: /* support equivalents just in case of mistagging */
             case DT_CICP_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL: /* support incorrectly tagged files */

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -299,7 +299,7 @@ int write_image(struct dt_imageio_module_data_t *data,
     case DT_COLORSPACE_SRGB:
       image->colorPrimaries = AVIF_COLOR_PRIMARIES_BT709;
       image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_SRGB;
-      image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT470BG;
+      image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT601;
       break;
     case DT_COLORSPACE_REC709:
       image->colorPrimaries = AVIF_COLOR_PRIMARIES_BT709;

--- a/src/imageio/imageio_avif.c
+++ b/src/imageio/imageio_avif.c
@@ -269,21 +269,13 @@ int dt_imageio_avif_read_profile(const char *filename, uint8_t **out, dt_colorsp
     if(avif_image.colorPrimaries == AVIF_COLOR_PRIMARIES_BT709)
     {
       gboolean over = FALSE;
-      /* mistagged sRGB AVIFs exported before dt 3.8 */
-      if(avif_image.transferCharacteristics == AVIF_TRANSFER_CHARACTERISTICS_SRGB
-         && avif_image.matrixCoefficients == AVIF_MATRIX_COEFFICIENTS_BT709)
-      {
-        /* must be code value 5 (IEC 61966-2-1 sYCC) */
-        cicp->matrix_coefficients = AVIF_MATRIX_COEFFICIENTS_BT470BG;
-        over =  TRUE;
-      }
       /* mistagged Rec. 709 AVIFs exported before dt 3.6 */
-      else if(avif_image.transferCharacteristics == AVIF_TRANSFER_CHARACTERISTICS_BT470M
+      if(avif_image.transferCharacteristics == AVIF_TRANSFER_CHARACTERISTICS_BT470M
          && avif_image.matrixCoefficients == AVIF_MATRIX_COEFFICIENTS_BT709)
       {
         /* must be actual Rec. 709 instead of 2.2 gamma*/
         cicp->transfer_characteristics = AVIF_TRANSFER_CHARACTERISTICS_BT709;
-        over =  TRUE;
+        over = TRUE;
       }
 
       if(over)


### PR DESCRIPTION
Looks like the 1/13/1 combo is a common one and not only produced in dt<3.8 AVIFs

See e.g. https://github.com/AOMediaCodec/libavif/wiki/CICP