### PR TITLE
Improve pixelpipe & expose debug log

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -3513,6 +3513,7 @@ void dt_dev_image(const dt_imgid_t imgid,
   dev.gui_attached = FALSE;
   dt_dev_pixelpipe_t *pipe = dev.full.pipe;
 
+  pipe->type |= DT_DEV_PIXELPIPE_IMAGE;
   // load image and set history_end
 
   dt_dev_load_image_ext(&dev, imgid, snapshot_id);

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -652,6 +652,11 @@ gboolean dt_dev_is_D65_chroma(const dt_develop_t *dev);
 void dt_dev_reset_chroma(dt_develop_t *dev);
 void dt_dev_init_chroma(dt_develop_t *dev);
 
+static inline struct dt_iop_module_t *dt_dev_gui_module(void)
+{
+  return darktable.develop ? darktable.develop->gui_module : NULL;
+}
+
 #ifdef __cplusplus
 } // extern "C"
 #endif /* __cplusplus */

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1083,7 +1083,7 @@ static gboolean _gui_off_button_press(GtkWidget *w, GdkEventButton *e, gpointer 
   dt_iop_module_t *module = (dt_iop_module_t *)user_data;
   if(!darktable.gui->reset && dt_modifier_is(e->state, GDK_CONTROL_MASK))
   {
-    dt_iop_request_focus(darktable.develop->gui_module == module ? NULL : module);
+    dt_iop_request_focus(dt_dev_gui_module() == module ? NULL : module);
     return TRUE;
   }
   return FALSE;
@@ -3121,7 +3121,7 @@ static void _show_module_callback(dt_iop_module_t *module)
 
 static void _request_module_focus_callback(dt_iop_module_t * module)
 {
-  dt_iop_request_focus(darktable.develop->gui_module == module ? NULL : module);
+  dt_iop_request_focus(dt_dev_gui_module() == module ? NULL : module);
 }
 
 static void _enable_module_callback(dt_iop_module_t *module)
@@ -3361,10 +3361,12 @@ dt_iop_module_t *dt_iop_get_module_preferred_instance(dt_iop_module_so_t *module
   dt_iop_module_t *accel_mod = NULL;  // The module to which accelerators are to be attached
 
   // if any instance has focus, use that one
-  if(prefer_focused && darktable.develop->gui_module
-     && (darktable.develop->gui_module->so == module
+  dt_iop_module_t *gui_module = dt_dev_gui_module();
+  if(prefer_focused
+      && gui_module
+      && (gui_module->so == module
          || DT_ACTION(module) == &darktable.control->actions_focus))
-    accel_mod = darktable.develop->gui_module;
+    accel_mod = gui_module;
   else
   {
     int best_score = -1;
@@ -3712,7 +3714,7 @@ static float _action_process(gpointer target,
   }
 
   return element == DT_ACTION_ELEMENT_FOCUS
-    ? darktable.develop->gui_module == module
+    ? dt_dev_gui_module() == module
     : (element == DT_ACTION_ELEMENT_ENABLE
        ? module->off && gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(module->off))
        : (element == DT_ACTION_ELEMENT_SHOW

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1333,7 +1333,7 @@ void dt_masks_change_form_gui(dt_masks_form_t *newform)
 void dt_masks_reset_form_gui(void)
 {
   dt_masks_change_form_gui(NULL);
-  const dt_iop_module_t *m = darktable.develop->gui_module;
+  const dt_iop_module_t *m = dt_dev_gui_module();
   if(m
      && (m->flags() & IOP_FLAGS_SUPPORTS_BLENDING)
      && !(m->flags() & IOP_FLAGS_NO_MASKS)
@@ -2430,7 +2430,7 @@ void dt_masks_select_form(struct dt_iop_module_t *module,
   if(selection_changed)
   {
     if(!module && darktable.develop->mask_form_selected_id == 0)
-      module = darktable.develop->gui_module;
+      module = dt_dev_gui_module();
     if(module)
     {
       if(module->masks_selection_changed)

--- a/src/develop/pixelpipe.h
+++ b/src/develop/pixelpipe.h
@@ -41,6 +41,7 @@ typedef enum dt_dev_pixelpipe_type_t
   DT_DEV_PIXELPIPE_ANY       = DT_DEV_PIXELPIPE_EXPORT | DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW
                                | DT_DEV_PIXELPIPE_THUMBNAIL | DT_DEV_PIXELPIPE_PREVIEW2,
   DT_DEV_PIXELPIPE_FAST      = 1 << 8,
+  DT_DEV_PIXELPIPE_IMAGE     = 1 << 9,  // special additional flag used by dt_dev_image()
   DT_DEV_PIXELPIPE_BASIC     = DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW
 } dt_dev_pixelpipe_type_t;
 

--- a/src/dtgtk/togglebutton.c
+++ b/src/dtgtk/togglebutton.c
@@ -58,8 +58,8 @@ static gboolean _togglebutton_draw(GtkWidget *widget, cairo_t *cr)
     flags &= ~CPF_ACTIVE;
 
   /* update focus state paint flag */
-  const gboolean hasfocus = ((DTGTK_TOGGLEBUTTON(widget)->icon_data == darktable.develop->gui_module)
-                         && darktable.develop->gui_module);
+  const gboolean hasfocus = ((DTGTK_TOGGLEBUTTON(widget)->icon_data == dt_dev_gui_module())
+                         && dt_dev_gui_module());
   if(hasfocus)
     flags |= CPF_FOCUS;
   else

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -3579,7 +3579,7 @@ static float _process_action(dt_action_t *action,
 
     if(owner == &darktable.control->actions_focus)
     {
-      action_target = darktable.develop->gui_module;
+      action_target = dt_dev_gui_module();
       if(!action_target)
         return return_value;
     }
@@ -4924,8 +4924,8 @@ float dt_accel_get_speed_multiplier(GtkWidget *widget, guint state)
 // FIXME possibly just find correct widget for each shortcut execution, rather than updating for each focus change etc
 void dt_accel_connect_instance_iop(dt_iop_module_t *module)
 {
-  const gboolean focused = darktable.develop->gui_module
-                           && darktable.develop->gui_module->so == module->so;
+  const dt_iop_module_t *gui_module = dt_dev_gui_module();
+  const gboolean focused = gui_module && gui_module->so == module->so;
   const dt_action_t *const blend = &darktable.control->actions_blend;
   for(GSList *w = module->widget_list; w; w = w->next)
   {

--- a/src/gui/guides.c
+++ b/src/gui/guides.c
@@ -772,7 +772,7 @@ void dt_guides_draw(cairo_t *cr, const float left, const float top, const float 
 {
   const double dashes = DT_PIXEL_APPLY_DPI(5.0) / zoom_scale;
 
-  dt_iop_module_t *module = darktable.develop->gui_module;
+  dt_iop_module_t *module = dt_dev_gui_module();
 
   // first, we check if we need to show the guides or not
   gchar *key = _conf_get_path("global", "show", NULL);

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -2037,10 +2037,9 @@ static void _set_trouble_messages(struct dt_iop_module_t *self)
     && !(p->illuminant == DT_ILLUMINANT_PIPE || p->adaptation == DT_ADAPTATION_RGB)
     && !dt_image_is_monochrome(&dev->image_storage);
 
-  dt_print(DT_DEBUG_PARAMS,
-           "[chroma trouble data %d] D65=%s.  "
-           "NOW %.3f %.3f %.3f, D65 %.3f %.3f %.3f, AS-SHOT %.3f %.3f %.3f\n",
-    self->multi_priority,
+  dt_print_pipe(DT_DEBUG_PARAMS, "chroma trouble data",
+      NULL, self, NULL, NULL,
+      "D65=%s.  NOW %.3f %.3f %.3f, D65 %.3f %.3f %.3f, AS-SHOT %.3f %.3f %.3f\n",
     dt_dev_is_D65_chroma(dev) ? "YES" : "NO",
     chr->wb_coeffs[0], chr->wb_coeffs[1], chr->wb_coeffs[2],
     chr->D65coeffs[0], chr->D65coeffs[1], chr->D65coeffs[2],

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1732,7 +1732,6 @@ void dt_view_paint_surface(cairo_t *cr,
   if(dev->preview_pipe->output_imgid == dev->image_storage.id
      && (port == &dev->full || port == &dev->preview2))
   {
-    dt_print(DT_DEBUG_EXPOSE, "[dt_view_paint_surface] draw preview\n");
     // draw preview
     float wd, ht;
     dt_dev_get_preview_size(dev, &wd, &ht);
@@ -1745,6 +1744,15 @@ void dt_view_paint_surface(cairo_t *cr,
     cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_FAST);
     cairo_paint(cr);
 
+    dt_print_pipe(DT_DEBUG_EXPOSE,
+        "dt_view_paint_surface",
+         dev->preview_pipe, NULL, NULL, NULL,
+         "size %dx%d. processed %dx%d. buf %dx%d scale=%.3f. surface %dx%d. zoom x=%.3f y=%.3f scale=%.3f\n",
+         width, height,
+         processed_width, processed_height,
+         buf_width, buf_height, buf_scale,
+         dev->preview_pipe->backbuf_height, dev->preview_pipe->backbuf_width,
+         buf_zoom_x, buf_zoom_y, zoom_scale);
     cairo_surface_destroy(preview);
   }
 
@@ -1753,6 +1761,15 @@ void dt_view_paint_surface(cairo_t *cr,
   if(port->pipe->output_imgid == dev->image_storage.id
      || dev->preview_pipe->output_imgid != dev->image_storage.id)
   {
+    dt_print_pipe(DT_DEBUG_EXPOSE,
+        "dt_view_paint_surface",
+         port->pipe, NULL, NULL, NULL,
+         "size %dx%d. processed %dx%d. buf %dx%d scale=%.3f. surface %dx%d. zoom x=%.3f y=%.3f scale=%.3f\n",
+         width, height,
+         processed_width, processed_height,
+         buf_width, buf_height, buf_scale,
+         buf_width, buf_height,
+         buf_zoom_x, buf_zoom_y, zoom_scale);
     cairo_scale(cr, back_scale / zoom_scale, back_scale / zoom_scale);
     cairo_translate(cr, (offset_x - zoom_x) * processed_width * buf_scale - 0.5 * buf_width,
                         (offset_y - zoom_y) * processed_height * buf_scale - 0.5 * buf_height);


### PR DESCRIPTION
The 'dt_dev_image()' uses the full pixelpipe but certainly does things in a slightly different way. A new DT_DEV_PIXELPIPE_IMAGE flag has been added, it's set by dt_dev_image and the pixelpipe-type to string conversion respects this and tells in pixelpipe logging.

Since late darkroom expose changes the debug log was not helpful any more. dt_view_paint_surface() does debug log internally.

Introduced inline struct dt_iop_module_t *dt_dev_gui_module(void) as a shorter and more readable form.

@TurboGit and @dterrahe still investigating the uncrop-expand and snapshot issue. 

At least found and fixed a bug that did stupid post expose for the proxy rotater.