### PR TITLE
Introduce debug log macros

### DIFF
--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -633,9 +633,13 @@ static void _camctl_unlock(const dt_camctl_t *c)
   camctl->active_camera = NULL;
   dt_pthread_mutex_BAD_unlock(&camctl->lock);
   if(cam)
+  {
     dt_print(DT_DEBUG_CAMCTL, "[camera_control] camera control un-locked for %s\n", cam->model);
+  }
   else
+  {
     dt_print(DT_DEBUG_CAMCTL, "[camera_control] camera control un-locked for unknown camera\n");
+  }
   _dispatch_control_status(c, CAMERA_CONTROL_AVAILABLE);
 }
 
@@ -1225,7 +1229,9 @@ void dt_camctl_import(const dt_camctl_t *c, const dt_camera_t *cam, GList *image
     }
 
     if(!g_file_set_contents(output, data, size, NULL))
+    {
        dt_print(DT_DEBUG_CAMCTL, "[camera_control] failed to write file %s\n", output);
+    }
     else
       _dispatch_camera_image_downloaded(c, cam, folder, filename, output);
 

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1921,7 +1921,7 @@ void dt_cleanup()
       been started with -d verbose
    b) 'thread' may be identical to DT_DEBUG_ALWAYS to write output
 */
-void dt_print(dt_debug_thread_t thread, const char *msg, ...)
+void dt_print_ext(dt_debug_thread_t thread, const char *msg, ...)
 {
   if(thread != DT_DEBUG_ALWAYS)
   {
@@ -1941,7 +1941,7 @@ void dt_print(dt_debug_thread_t thread, const char *msg, ...)
   fflush(stdout);
 }
 
-void dt_print_nts(dt_debug_thread_t thread, const char *msg, ...)
+void dt_print_nts_ext(dt_debug_thread_t thread, const char *msg, ...)
 {
   if(thread != DT_DEBUG_ALWAYS)
   {

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -164,6 +164,14 @@ typedef int32_t dt_imgid_t;
   INVALID_MASKID is used while testing in mask manager
 */
 
+/*
+  for performance reasons the debug log functions should only be called if there is ANY
+  flag in unmuted at all.
+*/
+#define dt_print_pipe if(darktable.unmuted) dt_print_pipe_ext
+#define dt_print if(darktable.unmuted) dt_print_ext
+#define dt_print_nts if(darktable.unmuted) dt_print_nts_ext
+
 typedef int32_t dt_mask_id_t;
 #define INVALID_MASKID (-1)
 #define NO_MASKID (0)
@@ -406,12 +414,12 @@ int dt_init(int argc, char *argv[],
 
 void dt_get_sysresource_level();
 void dt_cleanup();
-void dt_print(dt_debug_thread_t thread,
+void dt_print_ext(dt_debug_thread_t thread,
               const char *msg, ...)
   __attribute__((format(printf, 2, 3)));
 
 /* same as above but without time stamp : nts = no time stamp */
-void dt_print_nts(dt_debug_thread_t thread,
+void dt_print_nts_ext(dt_debug_thread_t thread,
                   const char *msg, ...)
   __attribute__((format(printf, 2, 3)));
 

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -3790,9 +3790,13 @@ start:
   {
     dt_print(DT_DEBUG_ALWAYS, "[init] could not find database ");
     if(dbname)
+    {
       dt_print(DT_DEBUG_ALWAYS, "`%s'!\n", dbname);
+    }
     else
+    {
       dt_print(DT_DEBUG_ALWAYS, "\n");
+    }
     dt_print(DT_DEBUG_ALWAYS, "[init] maybe your %s/darktablerc is corrupt?\n", datadir);
     dt_loc_get_datadir(dbfilename_library, sizeof(dbfilename_library));
     dt_print(DT_DEBUG_ALWAYS, "[init] try `cp %s/darktablerc %s/darktablerc'\n",
@@ -3986,9 +3990,13 @@ start:
       dt_print(DT_DEBUG_ALWAYS, "[init] deleting `%s' on user request", dbfilename_data);
 
       if(g_unlink(dbfilename_data) == 0)
+      {
         dt_print(DT_DEBUG_ALWAYS, " ... ok\n");
+      }
       else
+      {
         dt_print(DT_DEBUG_ALWAYS, " ... failed\n");
+      }
 
       if(resp == GTK_RESPONSE_ACCEPT && data_snap)
       {
@@ -4012,9 +4020,13 @@ start:
             if(fd < 0 || !g_close(fd, &gerror)) copy_status = FALSE;
           }
           if(copy_status)
+          {
             dt_print(DT_DEBUG_ALWAYS, " success!\n");
+          }
           else
+          {
             dt_print(DT_DEBUG_ALWAYS, " failed!\n");
+          }
 
           g_object_unref(src);
           g_object_unref(dest);
@@ -4166,9 +4178,13 @@ start:
     dt_print(DT_DEBUG_ALWAYS, "[init] deleting `%s' on user request", dbfilename_library);
 
     if(g_unlink(dbfilename_library) == 0)
+    {
       dt_print(DT_DEBUG_ALWAYS, " ... ok\n");
+    }
     else
+    {
       dt_print(DT_DEBUG_ALWAYS, " ... failed\n");
+    }
 
     if(resp == GTK_RESPONSE_ACCEPT && data_snap)
     {
@@ -4192,9 +4208,13 @@ start:
           if(fd < 0 || !g_close(fd, &gerror)) copy_status = FALSE;
         }
         if(copy_status)
+        {
           dt_print(DT_DEBUG_ALWAYS, " success!\n");
+        }
         else
+        {
           dt_print(DT_DEBUG_ALWAYS, " failed!\n");
+        }
         g_object_unref(src);
         g_object_unref(dest);
       }

--- a/src/common/dlopencl.c
+++ b/src/common/dlopencl.c
@@ -63,9 +63,13 @@ dt_dlopencl_t *dt_dlopencl_init(const char *name)
     library = name;
     module = dt_gmodule_open(library);
     if(module == NULL)
+    {
       dt_print(DT_DEBUG_OPENCL, "[dt_dlopencl_init] could not find specified opencl runtime library '%s'\n", library);
+    }
     else
+    {
       dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[dt_dlopencl_init] found specified opencl runtime library '%s'\n", library);
+    }
   }
   else
   {
@@ -75,9 +79,13 @@ dt_dlopencl_t *dt_dlopencl_init(const char *name)
       library = *iter;
       module = dt_gmodule_open(library);
       if(module == NULL)
+      {
         dt_print(DT_DEBUG_OPENCL, "[dt_dlopencl_init] could not find default opencl runtime library '%s'\n", library);
+      }
       else
+      {
         dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE, "[dt_dlopencl_init] found default opencl runtime library '%s'\n", library);
+      }
       iter++;
     }
   }

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -1270,9 +1270,11 @@ void dt_opencl_init(
                  platform_name, platform_key);
       }
       else if((errn == CL_SUCCESS) && (errv == CL_SUCCESS))
+      {
         dt_print(DT_DEBUG_OPENCL,
                  "[opencl_init] no devices found for %s (vendor) - %s (name)\n",
                  platform_vendor, platform_name);
+      }
       else
       {
         dt_print(DT_DEBUG_OPENCL,
@@ -2330,11 +2332,15 @@ static gboolean _opencl_build_program(const int dev,
     (program, 1, &(cl->dev[dev].devid), cl->dev[dev].options, 0, 0);
 
   if(err != CL_SUCCESS)
+  {
     dt_print(DT_DEBUG_OPENCL,
              "[opencl_build_program] could not build program: %s\n", cl_errstr(err));
+  }
   else
+  {
     dt_print(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE,
              "[opencl_build_program] successfully built program\n");
+  }
 
   cl_build_status build_status;
   (cl->dlocl->symbols->dt_clGetProgramBuildInfo)(program, cl->dev[dev].devid,

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -220,8 +220,10 @@ int dt_iop_clip_and_zoom_roi_cl(int devid,
 
     }
     if(err == CL_SUCCESS)
+    {
       dt_print_pipe(DT_DEBUG_OPENCL, "clip_and_zoom_roi_cl", NULL, NULL, roi_in, roi_out,
           "did fast cpu fallback\n");
+    }
     else
       dt_print_pipe(DT_DEBUG_OPENCL, "clip_and_zoom_roi_cl", NULL, NULL, roi_in, roi_out,
           "fast cpu fallback failing: %s\n", cl_errstr(err));

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -90,7 +90,7 @@ const char *dt_dev_pixelpipe_type_to_str(const int pipe_type)
 #undef PT_STR
 }
 
-void dt_print_pipe(dt_debug_thread_t thread,
+void dt_print_pipe_ext(dt_debug_thread_t thread,
                    const char *title,
                    const dt_dev_pixelpipe_t *pipe,
                    const struct dt_iop_module_t *module,
@@ -2666,8 +2666,10 @@ restart:
 
 #ifdef HAVE_OPENCL
   if(pipe->devid >= 0)
+  {
     dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe starting CL", pipe, NULL, &roi, &roi, "device=%i (%s)\n",
       pipe->devid, darktable.opencl->dev[pipe->devid].cname);
+  }
   else
 #endif
     dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe starting on CPU", pipe, NULL, &roi, &roi, "\n");

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -313,7 +313,7 @@ gboolean dt_dev_write_scharr_mask_cl(dt_dev_pixelpipe_iop_t *piece,
 #endif
 
 /* specialized version of dt_print for pixelpipe debugging */
-void dt_print_pipe(dt_debug_thread_t thread,
+void dt_print_pipe_ext(dt_debug_thread_t thread,
                    const char *title,
                    const dt_dev_pixelpipe_t *pipe,
                    const struct dt_iop_module_t *mod,

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -885,14 +885,20 @@ int dt_imageio_export_with_flags(const dt_imgid_t imgid,
     if(use_style)
     {
       if(appending)
+      {
         dt_print(DT_DEBUG_ALWAYS,
                  "appending style `%s'\n", format_params->style);
+      }
       else
+      {
         dt_print(DT_DEBUG_ALWAYS,
                  "overwrite style `%s'\n", format_params->style);
+      }
     }
     else
+    {
       dt_print(DT_DEBUG_ALWAYS,"\n");
+    }
 
     int cnt = 0;
     for(GList *nodes = pipe.nodes; nodes; nodes = g_list_next(nodes))

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -385,7 +385,7 @@ void process(
 #pragma omp parallel default(none) \
   dt_omp_firstprivate(in, out, height, width, filters, processpasstwo, hblsz, vblsz, \
                       blockwt, blockshifts, blockvar, Gtmp, RawDataTmp, caautostrength, \
-                      border, border2, eps, eps2, v1, v2, v3, v4, ts, tsh) \
+                      border, border2, eps, eps2, v1, v2, v3, v4, ts, tsh, darktable) \
   shared(numpar, polyord, fitparams, blockdenom, blockave, blocksqave)
   // if any of the above shared are made firstprivate, we get the wrong answer
 #endif

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1488,11 +1488,15 @@ void commit_params(struct dt_iop_module_t *self,
   if(!d->xform_cam_Lab && !dt_is_valid_colormatrix(d->cmatrix[0][0]))
   {
     if(p->type == DT_COLORSPACE_FILE)
+    {
       dt_print(DT_DEBUG_ALWAYS, "[colorin] unsupported input profile `%s' has"
                " been replaced by linear Rec709 RGB!\n", p->filename);
+    }
     else
+    {
       dt_print(DT_DEBUG_ALWAYS, "[colorin] unsupported input profile has been"
                " replaced by linear Rec709 RGB!\n");
+    }
     dt_control_log(_("unsupported input profile has been replaced by linear Rec709 RGB!"));
     if(d->input && d->clear_input) dt_colorspaces_cleanup_profile(d->input);
     d->nrgb = NULL;

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -379,19 +379,23 @@ static gboolean _check_deleted_instances(dt_develop_t *dev,
           else
           {
             if(mod_in_history && mod_next_in_history)
+            {
               dt_print(DT_DEBUG_ALWAYS,
                   "[_check_deleted_instances] found duplicate module"
                   " %s %s (%i) and %s %s (%i) both in history\n",
                   mod->op, mod->multi_name, mod->multi_priority,
                   mod_next->op, mod_next->multi_name,
                   mod_next->multi_priority);
+            }
             else
+            {
               dt_print(DT_DEBUG_ALWAYS,
                   "[_check_deleted_instances] found duplicate module"
                   " %s %s (%i) and %s %s (%i) none in history\n",
                   mod->op, mod->multi_name, mod->multi_priority,
                   mod_next->op, mod_next->multi_name,
                   mod_next->multi_priority);
+            }
           }
         }
       }

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1736,14 +1736,6 @@ void dt_view_paint_surface(cairo_t *cr,
     float wd, ht;
     dt_dev_get_preview_size(dev, &wd, &ht);
 
-    cairo_surface_t *preview = dt_view_create_surface(dev->preview_pipe->backbuf,
-                                                      dev->preview_pipe->backbuf_width,
-                                                      dev->preview_pipe->backbuf_height);
-    cairo_set_source_surface(cr, preview, (preview_x - zoom_x) * wd - 0.5 * dev->preview_pipe->backbuf_width,
-                                          (preview_y - zoom_y) * ht - 0.5 * dev->preview_pipe->backbuf_height);
-    cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_FAST);
-    cairo_paint(cr);
-
     dt_print_pipe(DT_DEBUG_EXPOSE,
         "dt_view_paint_surface",
          dev->preview_pipe, NULL, NULL, NULL,
@@ -1753,6 +1745,14 @@ void dt_view_paint_surface(cairo_t *cr,
          buf_width, buf_height, buf_scale,
          dev->preview_pipe->backbuf_height, dev->preview_pipe->backbuf_width,
          buf_zoom_x, buf_zoom_y, zoom_scale);
+    cairo_surface_t *preview = dt_view_create_surface(dev->preview_pipe->backbuf,
+                                                      dev->preview_pipe->backbuf_width,
+                                                      dev->preview_pipe->backbuf_height);
+    cairo_set_source_surface(cr, preview, (preview_x - zoom_x) * wd - 0.5 * dev->preview_pipe->backbuf_width,
+                                          (preview_y - zoom_y) * ht - 0.5 * dev->preview_pipe->backbuf_height);
+    cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_FAST);
+    cairo_paint(cr);
+
     cairo_surface_destroy(preview);
   }
 


### PR DESCRIPTION
All debugging output should only be done if there is ANY flag set in darktable.unmuted

Instead of adding an 'if(darktable.unmuted)` before every dt_print() variant we redefine the functions names and introduce macros that do that for us.