### PR TITLE
[GUI] The most common spelling of "bit depth" is without a hyphen

### DIFF
--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -109,7 +109,7 @@ const char *name()
 
 const char *aliases()
 {
-  return _("dithering|posterization|reduce bit-depth");
+  return _("dithering|posterization|reduce bit depth");
 }
 
 const char **description(struct dt_iop_module_t *self)
@@ -808,4 +808,3 @@ void gui_init(struct dt_iop_module_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -516,8 +516,8 @@ uint16_t calculate_clut_haldclut(dt_iop_lut3d_params_t *const p, const char *con
            png.height, png.color_type, png.bit_depth);
   if(png.bit_depth !=8 && png.bit_depth != 16)
   {
-    dt_print(DT_DEBUG_ALWAYS, "[lut3d] png bit-depth %d not supported\n", png.bit_depth);
-    dt_control_log(_("png bit-depth %d not supported"), png.bit_depth);
+    dt_print(DT_DEBUG_ALWAYS, "[lut3d] png bit depth %d is not supported\n", png.bit_depth);
+    dt_control_log(_("png bit depth %d is not supported"), png.bit_depth);
     fclose(png.f);
     png_destroy_read_struct(&png.png_ptr, &png.info_ptr, NULL);
     return 0;


### PR DESCRIPTION
See [usage stats in the English corpus](https://books.google.com/ngrams/graph?content=bit+depth%2C%5Bbit+-+depth%5D&year_start=1800&year_end=2019&corpus=en-2019&smoothing=3). Also, in other places of the UI, we write without a hyphen, so this is an increase in consistency.