### PR TITLE
borders: Allow for a 0% size border.

### DIFF
--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -451,7 +451,6 @@ void modify_roi_out(struct dt_iop_module_t *self,
   dt_iop_borders_data_t *d = (dt_iop_borders_data_t *)piece->data;
 
   const float size = fabsf(d->size);
-  if(size == 0) return;
 
   const gboolean is_constant_border = d->aspect == DT_IOP_BORDERS_ASPECT_CONSTANT_VALUE;
 


### PR DESCRIPTION
This is not a no-op as depending on the aspect ratio set we may have borders on width or height.

Fixes #15528.