### PR TITLE
snapshots: Remove snapshots for removed images.

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1470,6 +1470,8 @@ void dt_image_remove(const dt_imgid_t imgid)
 
   // also clear all thumbnails in mipmap_cache.
   dt_mipmap_cache_remove(darktable.mipmap_cache, imgid);
+
+  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGE_REMOVED, imgid, 0);
 }
 
 gboolean dt_image_altered(const dt_imgid_t imgid)

--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -161,6 +161,8 @@ static dt_signal_description _signal_description[DT_SIGNAL_COUNT] = {
     FALSE }, // DT_SIGNAL_DEVELOP_MODULE_MOVED
   { "dt-develop-image-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
     FALSE }, // DT_SIGNAL_DEVELOP_IMAGE_CHANGE
+  { "dt-image-removed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__UINT, 1, uint_arg, NULL,
+    FALSE }, // DT_SIGNAL_IMAGE_REMOVED
   { "dt-control-profile-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
     FALSE }, // DT_SIGNAL_CONTROL_PROFILE_CHANGED
   { "dt-control-profile-user-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__UINT, 1, uint_arg, NULL,

--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -191,6 +191,9 @@ typedef enum dt_signal_t
   /** \brief This signal is raised when image is changed in darkroom */
   DT_SIGNAL_DEVELOP_IMAGE_CHANGED,
 
+  /** \brief This signal is raised when image is removed from database */
+  DT_SIGNAL_IMAGE_REMOVED,
+
   /** \brief This signal is raised when the screen profile has changed
   no param, no returned value
     */

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -38,6 +38,8 @@ DT_MODULE(1)
 typedef struct dt_lib_snapshot_t
 {
   GtkWidget *button;
+  GtkWidget *num;
+  GtkWidget *status;
   GtkWidget *name;
   GtkWidget *entry;
   char *module;
@@ -464,119 +466,6 @@ static void _lib_snapshots_toggle_last(dt_action_t *action)
        !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->snapshot[index].button)));
 }
 
-static void _clear_snapshot_entry(dt_lib_snapshot_t *s)
-{
-  s->ctx = 0;
-  s->imgid = NO_IMGID;
-  s->history_end = -1;
-
-  if(s->button)
-  {
-    GtkWidget *lstatus = _lib_snapshot_button_get_item(s->button, _SNAPSHOT_BUTTON_STATUS);
-    gtk_widget_set_tooltip_text(s->button, "");
-    gtk_widget_set_tooltip_text(lstatus, "");
-  }
-
-  g_free(s->module);
-  g_free(s->label);
-  dt_free_align(s->buf);
-  s->module = NULL;
-  s->label = NULL;
-  s->buf = NULL;
-}
-
-static void _clear_snapshots(dt_lib_module_t *self, const dt_imgid_t imgid)
-{
-  dt_lib_snapshots_t *d = (dt_lib_snapshots_t *)self->data;
-  d->selected = -1;
-  d->snap_requested = FALSE;
-
-  for(uint32_t k = 0; k < d->num_snapshots; k++)
-  {
-    dt_lib_snapshot_t *s = &d->snapshot[k];
-
-    _clear_snapshot_entry(s);
-    gtk_widget_hide(s->button);
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(s->button), FALSE);
-  }
-
-  d->num_snapshots = 0;
-  gtk_widget_set_sensitive(d->take_button, TRUE);
-
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db),
-                        "DELETE FROM memory.history_snapshot", NULL, NULL, NULL);
-
-  dt_control_queue_redraw_center();
-}
-
-void gui_reset(dt_lib_module_t *self)
-{
-  _clear_snapshots(self, -1);
-}
-
-static void _signal_profile_changed(gpointer instance,
-                                    const uint8_t profile_type,
-                                    gpointer user_data)
-{
-  // when the display profile is changed, make sure we recreate the snapshot
-  if(profile_type == DT_COLORSPACES_PROFILE_TYPE_DISPLAY)
-  {
-    dt_lib_module_t *self = (dt_lib_module_t *)user_data;
-    dt_lib_snapshots_t *d = (dt_lib_snapshots_t *)self->data;
-
-    if(d->selected >= 0)
-      d->snap_requested = TRUE;
-
-    dt_control_queue_redraw_center();
-  }
-}
-
-static void _signal_image_changed(gpointer instance, gpointer user_data)
-{
-  dt_lib_module_t *self = (dt_lib_module_t *)user_data;
-  dt_lib_snapshots_t *d = (dt_lib_snapshots_t *)self->data;
-
-  const dt_imgid_t imgid = darktable.develop->image_storage.id;
-
-  for(uint32_t k = 0; k < MAX_SNAPSHOT; k++)
-  {
-    dt_lib_snapshot_t *s = &d->snapshot[k];
-
-    if(!dt_is_valid_imgid(s->imgid))
-      continue;
-
-    GtkWidget *b = d->snapshot[k].button;
-    GtkWidget *st = _lib_snapshot_button_get_item(b, _SNAPSHOT_BUTTON_STATUS);
-
-    char stat[8] = { 0 };
-
-    if(s->imgid == imgid)
-    {
-      g_strlcpy(stat, " ", sizeof(stat));
-
-      gtk_widget_set_tooltip_text(b, "");
-      gtk_widget_set_tooltip_text(st, "");
-    }
-    else
-    {
-      g_strlcpy(stat, "↗", sizeof(stat));
-
-      char tooltip[128] = { 0 };
-      // tooltip
-      char *name = dt_image_get_filename(s->imgid);
-      snprintf(tooltip, sizeof(tooltip),
-               _("↗ %s '%s'"), _("this snapshot was taken from"), name);
-      g_free(name);
-      gtk_widget_set_tooltip_text(b, tooltip);
-      gtk_widget_set_tooltip_text(st, tooltip);
-    }
-
-    gtk_label_set_text(GTK_LABEL(st), stat);
-  }
-
-  dt_control_queue_redraw_center();
-}
-
 static int _look_for_widget(dt_lib_module_t *self, GtkWidget *widget, gboolean entry)
 {
   dt_lib_snapshots_t *d = (dt_lib_snapshots_t *)self->data;
@@ -628,6 +517,200 @@ static gboolean _lib_button_button_pressed_callback(GtkWidget *widget,
   return gtk_widget_has_focus(d->snapshot[index].entry);
 }
 
+static void _init_snapshot_entry(dt_lib_module_t *self, dt_lib_snapshot_t *s)
+{
+  /* create snapshot button */
+  s->button = gtk_toggle_button_new();
+  gtk_widget_set_name(s->button, "snapshot-button");
+  g_signal_connect(G_OBJECT(s->button), "toggled",
+                   G_CALLBACK(_lib_snapshots_toggled_callback), self);
+  g_signal_connect(G_OBJECT(s->button), "button-press-event",
+                   G_CALLBACK(_lib_button_button_pressed_callback), self);
+
+  s->num = gtk_label_new("");
+  gtk_widget_set_name(s->num, "history-number");
+  dt_gui_add_class(s->num, "dt_monospace");
+
+  s->status = gtk_label_new("");
+  dt_gui_add_class(s->status, "dt_monospace");
+
+  s->name = gtk_label_new("");
+  gtk_label_set_ellipsize(GTK_LABEL(s->name), PANGO_ELLIPSIZE_MIDDLE);
+  gtk_widget_set_halign(s->name, GTK_ALIGN_START);
+
+  s->entry = gtk_entry_new();
+  gtk_widget_set_halign(s->entry, GTK_ALIGN_START);
+  g_signal_connect(G_OBJECT(s->entry), "activate",
+                   G_CALLBACK(_entry_activated_callback), self);
+}
+
+static void _clear_snapshot_entry(dt_lib_snapshot_t *s)
+{
+  s->ctx = 0;
+  s->imgid = NO_IMGID;
+  s->history_end = -1;
+
+  if(s->button)
+  {
+    GtkWidget *lstatus = _lib_snapshot_button_get_item(s->button, _SNAPSHOT_BUTTON_STATUS);
+    gtk_widget_set_tooltip_text(s->button, "");
+    gtk_widget_set_tooltip_text(lstatus, "");
+    gtk_widget_hide(s->button);
+  }
+
+  g_free(s->module);
+  g_free(s->label);
+  dt_free_align(s->buf);
+  s->module = NULL;
+  s->label = NULL;
+  s->buf = NULL;
+
+  // and delete corresponding entry from the database
+
+  sqlite3_stmt *stmt;
+
+  DT_DEBUG_SQLITE3_PREPARE_V2
+    (dt_database_get(darktable.db),
+     "DELETE FROM memory.history_snapshot"
+     " WHERE id = ?1",
+     -1, &stmt, NULL);
+
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, s->id);
+  sqlite3_step(stmt);
+  sqlite3_finalize(stmt);
+}
+
+static void _clear_snapshots(dt_lib_module_t *self)
+{
+  dt_lib_snapshots_t *d = (dt_lib_snapshots_t *)self->data;
+  d->selected = -1;
+  d->snap_requested = FALSE;
+
+  for(uint32_t k = 0; k < d->num_snapshots; k++)
+  {
+    dt_lib_snapshot_t *s = &d->snapshot[k];
+
+    _clear_snapshot_entry(s);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(s->button), FALSE);
+  }
+
+  d->num_snapshots = 0;
+  gtk_widget_set_sensitive(d->take_button, TRUE);
+
+  dt_control_queue_redraw_center();
+}
+
+void gui_reset(dt_lib_module_t *self)
+{
+  _clear_snapshots(self);
+}
+
+static void _signal_profile_changed(gpointer instance,
+                                    const uint8_t profile_type,
+                                    gpointer user_data)
+{
+  // when the display profile is changed, make sure we recreate the snapshot
+  if(profile_type == DT_COLORSPACES_PROFILE_TYPE_DISPLAY)
+  {
+    dt_lib_module_t *self = (dt_lib_module_t *)user_data;
+    dt_lib_snapshots_t *d = (dt_lib_snapshots_t *)self->data;
+
+    if(d->selected >= 0)
+      d->snap_requested = TRUE;
+
+    dt_control_queue_redraw_center();
+  }
+}
+
+static void _remove_snapshot_entry(dt_lib_module_t *self, const uint32_t index)
+{
+  dt_lib_snapshots_t *d = (dt_lib_snapshots_t *)self->data;
+
+  //  First clean the entry
+  _clear_snapshot_entry(&d->snapshot[index]);
+
+  //  Repack all entries
+  for(uint32_t k = index; k < MAX_SNAPSHOT-1; k++)
+  {
+    memcpy(&d->snapshot[k], &d->snapshot[k+1], sizeof(dt_lib_snapshot_t));
+  }
+
+  //  And finaly clear last entry
+  _clear_snapshot_entry(&d->snapshot[MAX_SNAPSHOT-1]);
+  //  And dedup widgets by initializing the last entry
+  _init_snapshot_entry(self, &d->snapshot[MAX_SNAPSHOT-1]);
+
+  //  We have one less snapshot
+  d->num_snapshots--;
+}
+
+static void _signal_image_removed(gpointer instance, dt_imgid_t imgid, gpointer user_data)
+{
+  dt_lib_module_t *self = (dt_lib_module_t *)user_data;
+  dt_lib_snapshots_t *d = (dt_lib_snapshots_t *)self->data;
+
+  uint32_t k = 0;
+
+  while(k < MAX_SNAPSHOT)
+  {
+    dt_lib_snapshot_t *s = &d->snapshot[k];
+
+    if(s->imgid == imgid)
+    {
+      _remove_snapshot_entry(self, k);
+      dt_control_log(_("snapshots for removed image have been deleted"));
+    }
+    else
+      k++;
+  }
+}
+
+static void _signal_image_changed(gpointer instance, gpointer user_data)
+{
+  dt_lib_module_t *self = (dt_lib_module_t *)user_data;
+  dt_lib_snapshots_t *d = (dt_lib_snapshots_t *)self->data;
+
+  const dt_imgid_t imgid = darktable.develop->image_storage.id;
+
+  for(uint32_t k = 0; k < MAX_SNAPSHOT; k++)
+  {
+    dt_lib_snapshot_t *s = &d->snapshot[k];
+
+    if(!dt_is_valid_imgid(s->imgid))
+      continue;
+
+    GtkWidget *b = d->snapshot[k].button;
+    GtkWidget *st = _lib_snapshot_button_get_item(b, _SNAPSHOT_BUTTON_STATUS);
+
+    char stat[8] = { 0 };
+
+    if(s->imgid == imgid)
+    {
+      g_strlcpy(stat, " ", sizeof(stat));
+
+      gtk_widget_set_tooltip_text(b, "");
+      gtk_widget_set_tooltip_text(st, "");
+    }
+    else
+    {
+      g_strlcpy(stat, "↗", sizeof(stat));
+
+      char tooltip[128] = { 0 };
+      // tooltip
+      char *name = dt_image_get_filename(s->imgid);
+      snprintf(tooltip, sizeof(tooltip),
+               _("↗ %s '%s'"), _("this snapshot was taken from"), name);
+      g_free(name);
+      gtk_widget_set_tooltip_text(b, tooltip);
+      gtk_widget_set_tooltip_text(st, tooltip);
+    }
+
+    gtk_label_set_text(GTK_LABEL(st), stat);
+  }
+
+  dt_control_queue_redraw_center();
+}
+
 void gui_init(dt_lib_module_t *self)
 {
   /* initialize ui widgets */
@@ -667,55 +750,32 @@ void gui_init(dt_lib_module_t *self)
 
   for(int k = 0; k < MAX_SNAPSHOT; k++)
   {
-    _clear_snapshot_entry(&d->snapshot[k]);
+    dt_lib_snapshot_t *s = &d->snapshot[k];
 
-    /* create snapshot button */
-    d->snapshot[k].button = gtk_toggle_button_new();
-    gtk_widget_set_name(d->snapshot[k].button, "snapshot-button");
-
-    // 4 items inside, num, status, name, label
-    GtkWidget *num = gtk_label_new("");
-    gtk_widget_set_name(num, "history-number");
-    dt_gui_add_class(num, "dt_monospace");
-
-    GtkWidget *status = gtk_label_new("");
-    dt_gui_add_class(status, "dt_monospace");
-
-    GtkWidget *name = gtk_label_new("");
-    gtk_label_set_ellipsize(GTK_LABEL(name), PANGO_ELLIPSIZE_MIDDLE);
-    gtk_widget_set_halign(name, GTK_ALIGN_START);
-    d->snapshot[k].name = name;
-
-    GtkWidget *entry = gtk_entry_new();
-    gtk_widget_set_halign(entry, GTK_ALIGN_START);
-    d->snapshot[k].entry = entry;
-    g_signal_connect(G_OBJECT(entry), "activate",
-                     G_CALLBACK(_entry_activated_callback), self);
+    _clear_snapshot_entry(s);
+    _init_snapshot_entry(self, s);
 
     GtkWidget *box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
-    gtk_box_pack_start(GTK_BOX(box), num, FALSE, FALSE, 0);
-    gtk_box_pack_start(GTK_BOX(box), status, FALSE, FALSE, 0);
-    gtk_box_pack_start(GTK_BOX(box), name, TRUE, TRUE, 0);
-    gtk_box_pack_start(GTK_BOX(box), entry, TRUE, TRUE, 0);
+    // 4 items inside box, num, status, name, label
+
+    gtk_box_pack_start(GTK_BOX(box), s->num, FALSE, FALSE, 0);
+    gtk_box_pack_start(GTK_BOX(box), s->status, FALSE, FALSE, 0);
+    gtk_box_pack_start(GTK_BOX(box), s->name, TRUE, TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(box), s->entry, TRUE, TRUE, 0);
 
     gtk_widget_show_all(box);
 
     // hide entry, will be used only when editing
-    gtk_widget_hide(entry);
+    gtk_widget_hide(s->entry);
 
-    gtk_container_add(GTK_CONTAINER(d->snapshot[k].button), box);
-
-    g_signal_connect(G_OBJECT(d->snapshot[k].button), "toggled",
-                     G_CALLBACK(_lib_snapshots_toggled_callback), self);
-    g_signal_connect(G_OBJECT(d->snapshot[k].button), "button-press-event",
-                     G_CALLBACK(_lib_button_button_pressed_callback), self);
+    gtk_container_add(GTK_CONTAINER(s->button), box);
 
     /* add button to snapshot box */
-    gtk_box_pack_end(GTK_BOX(d->snapshots_box), d->snapshot[k].button, FALSE, FALSE, 0);
+    gtk_box_pack_end(GTK_BOX(d->snapshots_box), s->button, FALSE, FALSE, 0);
 
     /* prevent widget to show on external show all */
-    gtk_widget_set_no_show_all(d->snapshot[k].button, TRUE);
+    gtk_widget_set_no_show_all(s->button, TRUE);
   }
 
   /* add snapshot box and take snapshot button to widget ui*/
@@ -732,11 +792,13 @@ void gui_init(dt_lib_module_t *self)
                                   G_CALLBACK(_signal_profile_changed), self);
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_IMAGE_CHANGED,
                                   G_CALLBACK(_signal_image_changed), self);
+  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_IMAGE_REMOVED,
+                                  G_CALLBACK(_signal_image_removed), self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
 {
-  _clear_snapshots(self, -1);
+  _clear_snapshots(self);
 
   g_free(self->data);
   self->data = NULL;


### PR DESCRIPTION
Avoid a crash, if an image is removed from the DB it is not anymore reacheable and cannot be used a snapshot. To do that we introduce a new signal DT_SIGNAL_IMAGE_REMOVED. In snapshots we connect to it and then we remove all snapshots created for the corresponding image.

Fixes #15565.