### PR TITLE
simplify more dt_print conditionals

### DIFF
--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -281,7 +281,7 @@ void dt_color_picker_helper(const dt_iop_buffer_dsc_t *dsc,
                             const dt_iop_colorspace_type_t picker_cst,
                             const dt_iop_order_iccprofile_info_t *const profile)
 {
-  dt_times_t start_time = { 0 }, end_time = { 0 };
+  dt_times_t start_time = { 0 };
   dt_get_perf_times(&start_time);
 
   if(dsc->channels == 4u)
@@ -362,15 +362,11 @@ void dt_color_picker_helper(const dt_iop_buffer_dsc_t *dsc,
   else
     dt_unreachable_codepath();
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_get_times(&end_time);
-    dt_print(DT_DEBUG_ALWAYS,
-             "colorpicker stats reading %u channels (filters %u) cst %d -> %d "
-             "size %zu denoised %d took %.3f secs (%.3f CPU)\n",
-             dsc->channels, dsc->filters, image_cst, picker_cst, _box_size(box), denoise,
-             end_time.clock - start_time.clock, end_time.user - start_time.user);
-  }
+  dt_print(DT_DEBUG_PERF,
+           "colorpicker stats reading %u channels (filters %u) cst %d -> %d "
+           "size %zu denoised %d took %.3f secs (%.3f CPU)\n",
+           dsc->channels, dsc->filters, image_cst, picker_cst, _box_size(box), denoise,
+           dt_get_lap_time(&start_time.clock), dt_get_lap_utime(&start_time.user));
 }
 
 // clang-format off

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -939,62 +939,39 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
       }
       else if(argv[k][1] == 'd' && argc > k + 1)
       {
-        if(!strcmp(argv[k + 1], "common"))
-          darktable.unmuted |= DT_DEBUG_COMMON; // enable common processing options
-        else if(!strcmp(argv[k + 1], "all"))
-          darktable.unmuted |= DT_DEBUG_ALL; // enable all debug information except verbose
-        else if(!strcmp(argv[k + 1], "cache"))
-          darktable.unmuted |= DT_DEBUG_CACHE; // enable debugging for lib/film/cache module
-        else if(!strcmp(argv[k + 1], "control"))
-          darktable.unmuted |= DT_DEBUG_CONTROL; // enable debugging for scheduler module
-        else if(!strcmp(argv[k + 1], "dev"))
-          darktable.unmuted |= DT_DEBUG_DEV; // develop module
-        else if(!strcmp(argv[k + 1], "input"))
-          darktable.unmuted |= DT_DEBUG_INPUT; // input devices
-        else if(!strcmp(argv[k + 1], "camctl"))
-          darktable.unmuted |= DT_DEBUG_CAMCTL; // camera control module
-        else if(!strcmp(argv[k + 1], "perf"))
-          darktable.unmuted |= DT_DEBUG_PERF; // performance measurements
-        else if(!strcmp(argv[k + 1], "pwstorage"))
-          darktable.unmuted |= DT_DEBUG_PWSTORAGE; // pwstorage module
-        else if(!strcmp(argv[k + 1], "opencl"))
-          darktable.unmuted |= DT_DEBUG_OPENCL; // gpu accel via opencl
-        else if(!strcmp(argv[k + 1], "sql"))
-          darktable.unmuted |= DT_DEBUG_SQL; // SQLite3 queries
-        else if(!strcmp(argv[k + 1], "memory"))
-          darktable.unmuted |= DT_DEBUG_MEMORY; // some stats on mem usage now and then.
-        else if(!strcmp(argv[k + 1], "lighttable"))
-          darktable.unmuted |= DT_DEBUG_LIGHTTABLE; // lighttable related stuff.
-        else if(!strcmp(argv[k + 1], "nan"))
-          darktable.unmuted |= DT_DEBUG_NAN; // check for NANs when processing the pipe.
-        else if(!strcmp(argv[k + 1], "masks"))
-          darktable.unmuted |= DT_DEBUG_MASKS; // masks related stuff.
-        else if(!strcmp(argv[k + 1], "lua"))
-          darktable.unmuted |= DT_DEBUG_LUA; // lua errors are reported on console
-        else if(!strcmp(argv[k + 1], "print"))
-          darktable.unmuted |= DT_DEBUG_PRINT; // print errors are reported on console
-        else if(!strcmp(argv[k + 1], "camsupport"))
-          darktable.unmuted |= DT_DEBUG_CAMERA_SUPPORT; // camera support warnings are reported on console
-        else if(!strcmp(argv[k + 1], "ioporder"))
-          darktable.unmuted |= DT_DEBUG_IOPORDER; // iop order information are reported on console
-        else if(!strcmp(argv[k + 1], "imageio"))
-          darktable.unmuted |= DT_DEBUG_IMAGEIO; // image importing or exporting messages on console
-        else if(!strcmp(argv[k + 1], "undo"))
-          darktable.unmuted |= DT_DEBUG_UNDO; // undo/redo
-        else if(!strcmp(argv[k + 1], "signal"))
-          darktable.unmuted |= DT_DEBUG_SIGNAL; // signal information on console
-        else if(!strcmp(argv[k + 1], "params"))
-          darktable.unmuted |= DT_DEBUG_PARAMS; // iop module params checks on console
-        else if(!strcmp(argv[k + 1], "act_on"))
-          darktable.unmuted |= DT_DEBUG_ACT_ON;
-        else if(!strcmp(argv[k + 1], "tiling"))
-          darktable.unmuted |= DT_DEBUG_TILING;
-        else if(!strcmp(argv[k + 1], "verbose"))
-          darktable.unmuted |= DT_DEBUG_VERBOSE;
-        else if(!strcmp(argv[k + 1], "pipe"))
-          darktable.unmuted |= DT_DEBUG_PIPE;
-        else if(!strcmp(argv[k + 1], "expose"))
-          darktable.unmuted |= DT_DEBUG_EXPOSE;
+        char *darg = argv[k + 1];
+        dt_debug_thread_t dadd =
+          !strcmp(darg, "common") ? DT_DEBUG_COMMON : // enable common processing options
+          !strcmp(darg, "all") ? DT_DEBUG_ALL : // enable all debug information except verbose
+          !strcmp(darg, "cache") ? DT_DEBUG_CACHE : // enable debugging for lib/film/cache module
+          !strcmp(darg, "control") ? DT_DEBUG_CONTROL : // enable debugging for scheduler module
+          !strcmp(darg, "dev") ? DT_DEBUG_DEV : // develop module
+          !strcmp(darg, "input") ? DT_DEBUG_INPUT : // input devices
+          !strcmp(darg, "camctl") ? DT_DEBUG_CAMCTL : // camera control module
+          !strcmp(darg, "perf") ? DT_DEBUG_PERF : // performance measurements
+          !strcmp(darg, "pwstorage") ? DT_DEBUG_PWSTORAGE : // pwstorage module
+          !strcmp(darg, "opencl") ? DT_DEBUG_OPENCL : // gpu accel via opencl
+          !strcmp(darg, "sql") ? DT_DEBUG_SQL : // SQLite3 queries
+          !strcmp(darg, "memory") ? DT_DEBUG_MEMORY : // some stats on mem usage now and then.
+          !strcmp(darg, "lighttable") ? DT_DEBUG_LIGHTTABLE : // lighttable related stuff.
+          !strcmp(darg, "nan") ? DT_DEBUG_NAN : // check for NANs when processing the pipe.
+          !strcmp(darg, "masks") ? DT_DEBUG_MASKS : // masks related stuff.
+          !strcmp(darg, "lua") ? DT_DEBUG_LUA : // lua errors are reported on console
+          !strcmp(darg, "print") ? DT_DEBUG_PRINT : // print errors are reported on console
+          !strcmp(darg, "camsupport") ? DT_DEBUG_CAMERA_SUPPORT : // camera support warnings are reported on console
+          !strcmp(darg, "ioporder") ? DT_DEBUG_IOPORDER : // iop order information are reported on console
+          !strcmp(darg, "imageio") ? DT_DEBUG_IMAGEIO : // image importing or exporting messages on console
+          !strcmp(darg, "undo") ? DT_DEBUG_UNDO : // undo/redo
+          !strcmp(darg, "signal") ? DT_DEBUG_SIGNAL : // signal information on console
+          !strcmp(darg, "params") ? DT_DEBUG_PARAMS : // iop module params checks on console
+          !strcmp(darg, "act_on") ? DT_DEBUG_ACT_ON :
+          !strcmp(darg, "tiling") ? DT_DEBUG_TILING :
+          !strcmp(darg, "verbose") ? DT_DEBUG_VERBOSE :
+          !strcmp(darg, "pipe") ? DT_DEBUG_PIPE :
+          !strcmp(darg, "expose") ? DT_DEBUG_EXPOSE :
+          0;
+        if(dadd)
+          darktable.unmuted |= dadd;
         else
           return usage(argv[0]);
         k++;

--- a/src/common/heal.c
+++ b/src/common/heal.c
@@ -387,7 +387,7 @@ void dt_heal(const float *const src_buffer, float *dest_buffer, const float *con
 {
   if(ch != 4)
   {
-    dt_print(DT_DEBUG_ALWAYS,"dt_heal: full-color image required\n");
+    dt_print(DT_DEBUG_ALWAYS, "dt_heal: full-color image required\n");
     return;
   }
   const size_t subwidth = 4 * ((width+1)/2);  // round up to be able to handle odd widths

--- a/src/common/histogram.c
+++ b/src/common/histogram.c
@@ -215,7 +215,7 @@ void dt_histogram_helper(dt_dev_histogram_collection_params_t *histogram_params,
                          const gboolean compensate_middle_grey,
                          const dt_iop_order_iccprofile_info_t *const profile_info)
 {
-  dt_times_t start_time = { 0 }, end_time = { 0 };
+  dt_times_t start_time = { 0 };
   dt_get_perf_times(&start_time);
 
   // all use 256 bins excepting:
@@ -291,17 +291,13 @@ void dt_histogram_helper(dt_dev_histogram_collection_params_t *histogram_params,
     for_each_channel(ch,aligned(m:16))
       histogram_max[ch] = m[ch];
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_get_times(&end_time);
-    dt_print(DT_DEBUG_ALWAYS,
-             "histogram calculation %u bins %d -> %d"
-             " compensate %d %u channels %u pixels took %.3f secs (%.3f CPU)\n",
-             histogram_params->bins_count, cst, cst_to,
-             compensate_middle_grey && profile_info, histogram_stats->ch,
-             histogram_stats->pixels,
-             end_time.clock - start_time.clock, end_time.user - start_time.user);
-  }
+  dt_print(DT_DEBUG_PERF,
+            "histogram calculation %u bins %d -> %d"
+            " compensate %d %u channels %u pixels took %.3f secs (%.3f CPU)\n",
+            histogram_params->bins_count, cst, cst_to,
+            compensate_middle_grey && profile_info, histogram_stats->ch,
+            histogram_stats->pixels,
+            dt_get_lap_time(&start_time.clock), dt_get_lap_utime(&start_time.user));
 }
 
 // clang-format off

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -581,22 +581,18 @@ static gboolean _history_copy_and_paste_on_image_merge(const dt_imgid_t imgid,
   // This prepends the default modules and converts just in case it's an empty history
   dt_dev_read_history_ext(dev_dest, dest_imgid, TRUE, -1);
 
-  if(darktable.unmuted & DT_DEBUG_IOPORDER)
-    dt_ioppr_check_iop_order(dev_src, imgid,
-                             "_history_copy_and_paste_on_image_merge ");
-  if(darktable.unmuted & DT_DEBUG_IOPORDER)
-    dt_ioppr_check_iop_order(dev_dest, dest_imgid,
-                             "_history_copy_and_paste_on_image_merge ");
+  dt_ioppr_check_iop_order(dev_src, imgid,
+                           "_history_copy_and_paste_on_image_merge ");
+  dt_ioppr_check_iop_order(dev_dest, dest_imgid,
+                           "_history_copy_and_paste_on_image_merge ");
 
   dt_dev_pop_history_items_ext(dev_src, dev_src->history_end);
   dt_dev_pop_history_items_ext(dev_dest, dev_dest->history_end);
 
-  if(darktable.unmuted & DT_DEBUG_IOPORDER)
-    dt_ioppr_check_iop_order(dev_src, imgid,
-                             "_history_copy_and_paste_on_image_merge 1");
-  if(darktable.unmuted & DT_DEBUG_IOPORDER)
-    dt_ioppr_check_iop_order(dev_dest, dest_imgid,
-                             "_history_copy_and_paste_on_image_merge 1");
+  dt_ioppr_check_iop_order(dev_src, imgid,
+                           "_history_copy_and_paste_on_image_merge 1");
+  dt_ioppr_check_iop_order(dev_dest, dest_imgid,
+                           "_history_copy_and_paste_on_image_merge 1");
 
   GList *mod_list = NULL;
   GList *autoinit_list = NULL;
@@ -677,8 +673,7 @@ static gboolean _history_copy_and_paste_on_image_merge(const dt_imgid_t imgid,
   if(!copy_iop_order)
     dt_ioppr_update_for_modules(dev_dest, mod_list, FALSE);
 
-  if(darktable.unmuted & DT_DEBUG_IOPORDER)
-    dt_ioppr_check_iop_order(dev_dest, dest_imgid,
+  dt_ioppr_check_iop_order(dev_dest, dest_imgid,
                            "_history_copy_and_paste_on_image_merge 2");
 
   // write history and forms to db

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -2180,9 +2180,9 @@ void dt_ioppr_insert_module_instance(struct dt_develop_t *dev,
   dev->iop_order_list = g_list_insert_before(dev->iop_order_list, place, entry);
 }
 
-gboolean dt_ioppr_check_iop_order(dt_develop_t *dev,
-                                  const dt_imgid_t imgid,
-                                  const char *msg)
+gboolean dt_ioppr_check_iop_order_ext(dt_develop_t *dev,
+                                      const dt_imgid_t imgid,
+                                      const char *msg)
 {
   gboolean iop_order_ok = TRUE;
 

--- a/src/common/iop_order.h
+++ b/src/common/iop_order.h
@@ -288,9 +288,12 @@ gboolean dt_ioppr_move_iop_after(struct dt_develop_t *dev,
                                  struct dt_iop_module_t *module_prev);
 
 // for debug only
-gboolean dt_ioppr_check_iop_order(struct dt_develop_t *dev,
-                                  const dt_imgid_t imgid,
-                                  const char *msg);
+#define dt_ioppr_check_iop_order(...) \
+  dt_debug_if(DT_DEBUG_IOPORDER, dt_ioppr_check_iop_order_ext, __VA_ARGS__)
+
+gboolean dt_ioppr_check_iop_order_ext(struct dt_develop_t *dev,
+                                      const dt_imgid_t imgid,
+                                      const char *msg);
 void dt_ioppr_print_module_iop_order(GList *iop_list,
                                      const char *msg);
 void dt_ioppr_print_history_iop_order(GList *history_list,

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -1240,7 +1240,7 @@ void dt_ioppr_transform_image_colorspace
     return;
   }
 
-  dt_times_t start_time = { 0 }, end_time = { 0 };
+  dt_times_t start_time = { 0 };
   dt_get_perf_times(&start_time);
 
   // matrix should never be invalid, this is only to test it against lcms2!
@@ -1250,32 +1250,24 @@ void dt_ioppr_transform_image_colorspace
     _transform_matrix(self, image_in, image_out, width, height,
                       cst_from, cst_to, converted_cst, profile_info);
 
-    if(darktable.unmuted & DT_DEBUG_PERF)
-    {
-      dt_get_times(&end_time);
-      dt_print(DT_DEBUG_ALWAYS,
-               "[dt_ioppr_transform_image_colorspace] %s-->%s took %.3f secs (%.3f CPU) [%s%s]\n",
-               dt_iop_colorspace_to_name(cst_from), dt_iop_colorspace_to_name(cst_to),
-               end_time.clock - start_time.clock,
-               end_time.user - start_time.user,
-               self->op, dt_iop_get_instance_id(self));
-    }
+    dt_print(DT_DEBUG_PERF,
+             "[dt_ioppr_transform_image_colorspace] %s-->%s took %.3f secs (%.3f CPU) [%s%s]\n",
+             dt_iop_colorspace_to_name(cst_from), dt_iop_colorspace_to_name(cst_to),
+             dt_get_lap_time(&start_time.clock),
+             dt_get_lap_utime(&start_time.user),
+             self->op, dt_iop_get_instance_id(self));
   }
   else
   {
     _transform_lcms2(self, image_in, image_out, width, height,
                      cst_from, cst_to, converted_cst, profile_info);
 
-    if(darktable.unmuted & DT_DEBUG_PERF)
-    {
-      dt_get_times(&end_time);
-      dt_print(DT_DEBUG_ALWAYS,
-               "[dt_ioppr_transform_image_colorspace] %s-->%s took %.3f secs (%.3f lcms2) [%s%s]\n",
-               dt_iop_colorspace_to_name(cst_from), dt_iop_colorspace_to_name(cst_to),
-               end_time.clock - start_time.clock,
-               end_time.user - start_time.user,
-               self->op, dt_iop_get_instance_id(self));
-    }
+    dt_print(DT_DEBUG_PERF,
+             "[dt_ioppr_transform_image_colorspace] %s-->%s took %.3f secs (%.3f lcms2) [%s%s]\n",
+             dt_iop_colorspace_to_name(cst_from), dt_iop_colorspace_to_name(cst_to),
+             dt_get_lap_time(&start_time.clock),
+             dt_get_lap_utime(&start_time.user),
+             self->op, dt_iop_get_instance_id(self));
   }
 
   if(*converted_cst == cst_from)
@@ -1314,7 +1306,7 @@ void dt_ioppr_transform_image_colorspace_rgb
     return;
   }
 
-  dt_times_t start_time = { 0 }, end_time = { 0 };
+  dt_times_t start_time = { 0 };
   dt_get_perf_times(&start_time);
 
   if(dt_is_valid_colormatrix(profile_info_from->matrix_in[0][0])
@@ -1324,30 +1316,22 @@ void dt_ioppr_transform_image_colorspace_rgb
   {
     _transform_matrix_rgb(image_in, image_out, width, height, profile_info_from, profile_info_to);
 
-    if(darktable.unmuted & DT_DEBUG_PERF)
-    {
-      dt_get_times(&end_time);
-      dt_print(DT_DEBUG_ALWAYS,
-               "[dt_ioppr_transform_image_colorspace_rgb] RGB-->RGB took %.3f secs (%.3f CPU) [%s]\n",
-               end_time.clock - start_time.clock,
-               end_time.user - start_time.user,
-               (message) ? message : "");
-    }
+    dt_print(DT_DEBUG_PERF,
+             "[dt_ioppr_transform_image_colorspace_rgb] RGB-->RGB took %.3f secs (%.3f CPU) [%s]\n",
+             dt_get_lap_time(&start_time.clock),
+             dt_get_lap_utime(&start_time.user),
+             (message) ? message : "");
   }
   else
   {
     _transform_lcms2_rgb(image_in, image_out, width, height, profile_info_from, profile_info_to);
 
-    if(darktable.unmuted & DT_DEBUG_PERF)
-    {
-      dt_get_times(&end_time);
-      dt_print(DT_DEBUG_ALWAYS,
-               "[dt_ioppr_transform_image_colorspace_rgb] RGB-->RGB"
-               " took %.3f secs (%.3f lcms2) [%s]\n",
-               end_time.clock - start_time.clock,
-               end_time.user - start_time.user,
-               (message) ? message : "");
-    }
+    dt_print(DT_DEBUG_PERF,
+             "[dt_ioppr_transform_image_colorspace_rgb] RGB-->RGB"
+             " took %.3f secs (%.3f lcms2) [%s]\n",
+             dt_get_lap_time(&start_time.clock),
+             dt_get_lap_utime(&start_time.user),
+             (message) ? message : "");
   }
 }
 
@@ -1539,7 +1523,7 @@ gboolean dt_ioppr_transform_image_colorspace_cl
   if(dt_is_valid_colormatrix(profile_info->matrix_in[0][0])
      && dt_is_valid_colormatrix(profile_info->matrix_out[0][0]))
   {
-    dt_times_t start_time = { 0 }, end_time = { 0 };
+    dt_times_t start_time = { 0 };
     dt_get_perf_times(&start_time);
 
     size_t origin[] = { 0, 0, 0 };
@@ -1613,16 +1597,12 @@ gboolean dt_ioppr_transform_image_colorspace_cl
 
     *converted_cst = cst_to;
 
-    if(darktable.unmuted & DT_DEBUG_PERF)
-    {
-      dt_get_times(&end_time);
-      dt_print(DT_DEBUG_ALWAYS,
-               "[dt_ioppr_transform_image_colorspace_cl] %s-->%s took %.3f secs (%.3f GPU) [%s%s]\n",
-               dt_iop_colorspace_to_name(cst_from), dt_iop_colorspace_to_name(cst_to),
-               end_time.clock - start_time.clock,
-               end_time.user - start_time.user,
-               self->op, dt_iop_get_instance_id(self));
-    }
+    dt_print(DT_DEBUG_PERF,
+             "[dt_ioppr_transform_image_colorspace_cl] %s-->%s took %.3f secs (%.3f GPU) [%s%s]\n",
+             dt_iop_colorspace_to_name(cst_from), dt_iop_colorspace_to_name(cst_to),
+             dt_get_lap_time(&start_time.clock),
+             dt_get_lap_utime(&start_time.user),
+             self->op, dt_iop_get_instance_id(self));
   }
   else
   {
@@ -1728,7 +1708,7 @@ gboolean dt_ioppr_transform_image_colorspace_rgb_cl
      && dt_is_valid_colormatrix(profile_info_to->matrix_in[0][0])
      && dt_is_valid_colormatrix(profile_info_to->matrix_out[0][0]))
   {
-    dt_times_t start_time = { 0 }, end_time = { 0 };
+    dt_times_t start_time = { 0 };
     dt_get_perf_times(&start_time);
 
     size_t origin[] = { 0, 0, 0 };
@@ -1812,15 +1792,11 @@ gboolean dt_ioppr_transform_image_colorspace_rgb_cl
     if(err != CL_SUCCESS)
       goto cleanup;
 
-    if(darktable.unmuted & DT_DEBUG_PERF)
-    {
-      dt_get_times(&end_time);
-      dt_print(DT_DEBUG_ALWAYS,
-               "image colorspace transform RGB-->RGB CL took %.3f secs (%.3f GPU) [%s]\n",
-               end_time.clock - start_time.clock,
-               end_time.user - start_time.user,
-               (message) ? message : "");
-    }
+    dt_print(DT_DEBUG_PERF,
+             "image colorspace transform RGB-->RGB CL took %.3f secs (%.3f GPU) [%s]\n",
+             dt_get_lap_time(&start_time.clock),
+             dt_get_lap_utime(&start_time.user),
+             (message) ? message : "");
   }
   else
   {

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -959,13 +959,11 @@ void _styles_apply_to_image_ext(const char *name,
 
     dt_dev_read_history_ext(dev_dest, newimgid, TRUE, -1);
 
-    if(darktable.unmuted & DT_DEBUG_IOPORDER)
-      dt_ioppr_check_iop_order(dev_dest, newimgid, "dt_styles_apply_to_image ");
+    dt_ioppr_check_iop_order(dev_dest, newimgid, "dt_styles_apply_to_image ");
 
     dt_dev_pop_history_items_ext(dev_dest, dev_dest->history_end);
 
-    if(darktable.unmuted & DT_DEBUG_IOPORDER)
-      dt_ioppr_check_iop_order(dev_dest, newimgid, "dt_styles_apply_to_image 1");
+    dt_ioppr_check_iop_order(dev_dest, newimgid, "dt_styles_apply_to_image 1");
 
     dt_print(DT_DEBUG_IOPORDER,
              "[styles_apply_to_image_ext] Apply style on image `%s' id %i, history size %i",
@@ -1028,8 +1026,7 @@ void _styles_apply_to_image_ext(const char *name,
 
     g_list_free_full(si_list, dt_style_item_free);
 
-    if(darktable.unmuted & DT_DEBUG_IOPORDER)
-      dt_ioppr_check_iop_order(dev_dest, newimgid, "dt_styles_apply_to_image 2");
+    dt_ioppr_check_iop_order(dev_dest, newimgid, "dt_styles_apply_to_image 2");
 
     dt_undo_lt_history_t *hist = NULL;
     if(undo)

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -297,7 +297,7 @@ void dt_dev_process_image_job(dt_develop_t *dev,
   pipe->status = DT_DEV_PIXELPIPE_RUNNING;
 
   dt_times_t start;
-  dt_get_times(&start);
+  dt_get_perf_times(&start);
 
   dt_mipmap_buffer_t buf;
   dt_mipmap_cache_get(darktable.mipmap_cache,
@@ -490,7 +490,7 @@ static inline void _dt_dev_load_raw(dt_develop_t *dev,
   // first load the raw, to make sure dt_image_t will contain all and correct data.
   dt_mipmap_buffer_t buf;
   dt_times_t start;
-  dt_get_times(&start);
+  dt_get_perf_times(&start);
   dt_mipmap_cache_get(darktable.mipmap_cache, &buf, imgid, DT_MIPMAP_FULL,
                       DT_MIPMAP_BLOCKING, 'r');
   dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
@@ -1192,8 +1192,7 @@ void dt_dev_reload_history_items(dt_develop_t *dev)
 
 void dt_dev_pop_history_items_ext(dt_develop_t *dev, const int32_t cnt)
 {
-  if(darktable.unmuted & DT_DEBUG_IOPORDER)
-    dt_ioppr_check_iop_order(dev, 0, "dt_dev_pop_history_items_ext begin");
+  dt_ioppr_check_iop_order(dev, 0, "dt_dev_pop_history_items_ext begin");
 
   const int end_prev = dev->history_end;
   dev->history_end = cnt;
@@ -1240,8 +1239,7 @@ void dt_dev_pop_history_items_ext(dt_develop_t *dev, const int32_t cnt)
 
   dt_ioppr_check_duplicate_iop_order(&dev->iop, dev->history);
 
-  if(darktable.unmuted & DT_DEBUG_IOPORDER)
-    dt_ioppr_check_iop_order(dev, 0, "dt_dev_pop_history_items_ext end");
+  dt_ioppr_check_iop_order(dev, 0, "dt_dev_pop_history_items_ext end");
 
   // check if masks have changed
   gboolean masks_changed = FALSE;
@@ -2265,8 +2263,7 @@ void dt_dev_read_history_ext(dt_develop_t *dev,
     sqlite3_finalize(stmt);
   }
 
-  if(darktable.unmuted & DT_DEBUG_IOPORDER)
-    dt_ioppr_check_iop_order(dev, imgid, "dt_dev_read_history_no_image end");
+  dt_ioppr_check_iop_order(dev, imgid, "dt_dev_read_history_no_image end");
 
   dt_masks_read_masks_history(dev, imgid);
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -664,8 +664,7 @@ dt_iop_module_t *dt_iop_gui_get_next_visible_module(dt_iop_module_t *module)
 
 static void _gui_movedown_callback(GtkButton *button, dt_iop_module_t *module)
 {
-  if(darktable.unmuted & DT_DEBUG_IOPORDER)
-    dt_ioppr_check_iop_order(module->dev, 0, "dt_iop_gui_movedown_callback begin");
+  dt_ioppr_check_iop_order(module->dev, 0, "dt_iop_gui_movedown_callback begin");
 
   // we need to place this module right before the previous
   dt_iop_module_t *prev = dt_iop_gui_get_previous_visible_module(module);
@@ -688,8 +687,7 @@ static void _gui_movedown_callback(GtkButton *button, dt_iop_module_t *module)
 
   dt_dev_add_history_item(prev->dev, module, TRUE);
 
-  if(darktable.unmuted & DT_DEBUG_IOPORDER)
-    dt_ioppr_check_iop_order(module->dev, 0, "dt_iop_gui_movedown_callback end");
+  dt_ioppr_check_iop_order(module->dev, 0, "dt_iop_gui_movedown_callback end");
 
   // rebuild the accelerators
   dt_iop_connect_accels_multi(module->so);
@@ -701,8 +699,7 @@ static void _gui_movedown_callback(GtkButton *button, dt_iop_module_t *module)
 
 static void _gui_moveup_callback(GtkButton *button, dt_iop_module_t *module)
 {
-  if(darktable.unmuted & DT_DEBUG_IOPORDER)
-    dt_ioppr_check_iop_order(module->dev, 0, "dt_iop_gui_moveup_callback begin");
+  dt_ioppr_check_iop_order(module->dev, 0, "dt_iop_gui_moveup_callback begin");
 
   // we need to place this module right after the next one
   dt_iop_module_t *next = dt_iop_gui_get_next_visible_module(module);
@@ -726,8 +723,7 @@ static void _gui_moveup_callback(GtkButton *button, dt_iop_module_t *module)
 
   dt_dev_add_history_item(next->dev, module, TRUE);
 
-  if(darktable.unmuted & DT_DEBUG_IOPORDER)
-    dt_ioppr_check_iop_order(module->dev, 0, "dt_iop_gui_moveup_callback end");
+  dt_ioppr_check_iop_order(module->dev, 0, "dt_iop_gui_moveup_callback end");
 
   // rebuild the accelerators
   dt_iop_connect_accels_multi(module->so);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -789,12 +789,9 @@ static int _brush_get_pts_border(dt_develop_t *dev,
   int cw = 1;
   int start_stamp = 0;
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] brush_points init took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] brush_points init took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
 
   // we render all segments first upwards, then downwards
   for(int n = 0; n < 2 * nb; n++)
@@ -1044,13 +1041,9 @@ static int _brush_get_pts_border(dt_develop_t *dev,
   // printf("points %d, border %d, playload %d\n", *points_count, border ? *border_count : -1, payload ?
   // *payload_count : -1);
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] brush_points point recurs %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] brush_points point recurs %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
 
   // and we transform them with all distorted modules
   if(source && transf_direction == DT_DEV_TRANSFORM_DIR_ALL)
@@ -1093,10 +1086,9 @@ static int _brush_get_pts_border(dt_develop_t *dev,
         goto fail;
     }
 
-    if(darktable.unmuted & DT_DEBUG_PERF)
-      dt_print(DT_DEBUG_MASKS,
-               "[masks %s] path_points end took %0.04f sec\n",
-               form->name, dt_get_wtime() - start2);
+    dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+             "[masks %s] path_points end took %0.04f sec\n",
+             form->name, dt_get_lap_time(&start2));
 
     return 1;
   }
@@ -1106,10 +1098,9 @@ static int _brush_get_pts_border(dt_develop_t *dev,
     if(!border || dt_dev_distort_transform_plus(dev, pipe, iop_order,
                                                 transf_direction, *border, *border_count))
     {
-      if(darktable.unmuted & DT_DEBUG_PERF)
-        dt_print(DT_DEBUG_MASKS,
-                 "[masks %s] brush_points transform took %0.04f sec\n", form->name,
-                 dt_get_wtime() - start2);
+      dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+               "[masks %s] brush_points transform took %0.04f sec\n", form->name,
+               dt_get_lap_time(&start2));
       return 1;
     }
   }
@@ -2985,21 +2976,16 @@ static int _brush_get_mask(const dt_iop_module_t *const module,
     return 0;
   }
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] brush points took %0.04f sec\n",
-             form->name, dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] brush points took %0.04f sec\n",
+           form->name, dt_get_lap_time(&start2));
 
   const guint nb_corner = g_list_length(form->points);
   _brush_bounding_box(points, border, nb_corner, points_count, width, height, posx, posy);
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] brush_fill min max took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] brush_fill min max took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
 
   // we allocate the buffer
   const size_t bufsize = (size_t)(*width) * (*height);
@@ -3032,9 +3018,9 @@ static int _brush_get_mask(const dt_iop_module_t *const module,
   dt_free_align(border);
   dt_free_align(payload);
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-    dt_print(DT_DEBUG_MASKS, "[masks %s] brush fill buffer took %0.04f sec\n", form->name,
-             dt_get_wtime() - start);
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] brush fill buffer took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start));
 
   return 1;
 }
@@ -3124,13 +3110,9 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module,
     return 0;
   }
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] brush points took %0.04f sec\n",
-             form->name, dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] brush points took %0.04f sec\n",
+           form->name, dt_get_lap_time(&start2));
 
   const guint nb_corner = g_list_length(form->points);
 
@@ -3156,13 +3138,9 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module,
   _brush_bounding_box_raw(points, border, nb_corner,
                           points_count, &xmin, &xmax, &ymin, &ymax);
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] brush_fill min max took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] brush_fill min max took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
 
   // check if the path completely lies outside of roi -> we're done/mask remains empty
   if(xmax < 0 || ymax < 0 || xmin >= width || ymin >= height)
@@ -3199,13 +3177,12 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module,
   dt_free_align(border);
   dt_free_align(payload);
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] brush set falloff took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    dt_print(DT_DEBUG_MASKS, "[masks %s] brush fill buffer took %0.04f sec\n", form->name,
-             dt_get_wtime() - start);
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] brush set falloff took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] brush fill buffer took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start));
 
   return 1;
 }

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -1105,13 +1105,9 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module,
   // we get the area
   if(!_circle_get_area(module, piece, form, width, height, posx, posy)) return 0;
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] circle area took %0.04f sec\n",
-             form->name, dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] circle area took %0.04f sec\n",
+           form->name, dt_get_lap_time(&start2));
 
   // we get the circle values
   dt_masks_point_circle_t *const restrict circle =
@@ -1144,13 +1140,9 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module,
       p[2*j + 1] = y;
     }
   }
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] circle draw took %0.04f sec\n", form->name, dt_get_wtime() - start2);
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] circle draw took %0.04f sec\n", form->name, dt_get_lap_time(&start2));
 
-    start2 = dt_get_wtime();
-  }
   // we back transform all this points
   if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, module->iop_order,
                                         DT_DEV_TRANSFORM_DIR_BACK_INCL,
@@ -1160,13 +1152,9 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module,
     return 0;
   }
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] circle transform took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] circle transform took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
 
   // we allocate the buffer
   *buffer = dt_alloc_align_float((size_t)w * h);
@@ -1207,10 +1195,9 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module,
 
   dt_free_align(points);
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] circle fill took %0.04f sec\n",
-             form->name, dt_get_wtime() - start2);
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] circle fill took %0.04f sec\n",
+           form->name, dt_get_lap_time(&start2));
 
   return 1;
 }
@@ -1254,13 +1241,9 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
   // initialize output buffer with zero
   memset(buffer, 0, sizeof(float) * w * h);
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] circle init took %0.04f sec\n",
-             form->name, dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] circle init took %0.04f sec\n",
+           form->name, dt_get_lap_time(&start2));
 
   // we look at the outer circle of the shape - no effects outside of
   // this circle; we need many points as we do not know how the circle
@@ -1315,13 +1298,9 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
     return 0;
   }
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] circle outline took %0.04f sec\n",
-             form->name, dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] circle outline took %0.04f sec\n",
+           form->name, dt_get_lap_time(&start2));
 
   // we get the min/max values ...
   float xmin = FLT_MAX, ymin = FLT_MAX, xmax = FLT_MIN, ymax = FLT_MIN;
@@ -1357,13 +1336,9 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
 
   dt_free_align(circ);
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] circle bounding box took %0.04f sec\n",
-             form->name, dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] circle bounding box took %0.04f sec\n",
+           form->name, dt_get_lap_time(&start2));
 
   // check if there is anything to do at all; only if width and height
   // of bounding box is 2 or greater the shape lies inside of roi and
@@ -1393,12 +1368,8 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
       points[index * 2 + 1] = (grid * j + py) * iscale;
     }
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] circle grid took %0.04f sec\n", form->name, dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] circle grid took %0.04f sec\n", form->name, dt_get_lap_time(&start2));
 
   // we back transform all these points to the input image coordinates
   if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, module->iop_order,
@@ -1409,13 +1380,9 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
     return 0;
   }
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] circle transform took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] circle transform took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
 
   // we calculate the mask values at the transformed points;
   // for results: re-use the points array
@@ -1444,13 +1411,9 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
       points[2*index] = f * f;
     }
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] circle draw took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] circle draw took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
 
   // we fill the pre-initialized output buffer by interpolation;
   // we only need to take the contents of our bounding box into account
@@ -1485,15 +1448,12 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
 
   dt_free_align(points);
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] circle fill took %0.04f sec\n",
-             form->name, dt_get_wtime() - start2);
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] circle total render took %0.04f sec\n", form->name,
-             dt_get_wtime() - start1);
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] circle fill took %0.04f sec\n",
+           form->name, dt_get_lap_time(&start2));
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] circle total render took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start1));
 
   return 1;
 }

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1691,13 +1691,9 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module,
   // we get the area
   if(!_ellipse_get_area(module, piece, form, width, height, posx, posy)) return 0;
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] ellipse area took %0.04f sec\n",
-             form->name, dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] ellipse area took %0.04f sec\n",
+           form->name, dt_get_lap_time(&start2));
 
   // we get the ellipse values
   dt_masks_point_ellipse_t *ellipse = (dt_masks_point_ellipse_t *)((form->points)->data);
@@ -1715,13 +1711,9 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module,
       points[(i * w + j) * 2 + 1] = (i + (*posy));
     }
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] ellipse draw took %0.04f sec\n",
-             form->name, dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] ellipse draw took %0.04f sec\n",
+           form->name, dt_get_lap_time(&start2));
 
   // we back transform all this points
   if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, module->iop_order,
@@ -1732,13 +1724,9 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module,
     return 0;
   }
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] ellipse transform took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] ellipse transform took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
 
   // we allocate the buffer
   *buffer = dt_alloc_align_float((size_t)w * h);
@@ -1786,8 +1774,9 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module,
 
   dt_free_align(points);
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-    dt_print(DT_DEBUG_MASKS, "[masks %s] ellipse fill took %0.04f sec\n", form->name, dt_get_wtime() - start2);
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] ellipse fill took %0.04f sec\n", 
+           form->name, dt_get_lap_time(&start2));
 
   return 1;
 }
@@ -1836,13 +1825,9 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
   const int gw = (w + grid - 1) / grid + 1;  // grid dimension of total roi
   const int gh = (h + grid - 1) / grid + 1;  // grid dimension of total roi
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] ellipse init took %0.04f sec\n",
-             form->name, dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] ellipse init took %0.04f sec\n",
+           form->name, dt_get_lap_time(&start2));
 
   // we look at the outer line of the shape - no effects outside of
   // this ellipse; we need many points as we do not know how the
@@ -1873,13 +1858,9 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
     ell[2 * n + 1] = center[1] + ta * sina * cosp + tb * cosa * sinp;
   }
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] ellipse outline took %0.04f sec\n",
-             form->name, dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] ellipse outline took %0.04f sec\n",
+           form->name, dt_get_lap_time(&start2));
 
   // we transform the outline from input image coordinates to current position in pixelpipe
   if(!dt_dev_distort_transform_plus(module->dev, piece->pipe, module->iop_order,
@@ -1890,13 +1871,9 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
     return 0;
   }
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] ellipse outline transform took %0.04f sec\n",
-             form->name, dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] ellipse outline transform took %0.04f sec\n",
+           form->name, dt_get_lap_time(&start2));
 
   // we get the min/max values ...
   float xmin = FLT_MAX, ymin = FLT_MAX, xmax = FLT_MIN, ymax = FLT_MIN;
@@ -1932,13 +1909,9 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
 
   dt_free_align(ell);
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] ellipse bounding box took %0.04f sec\n",
-             form->name, dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] ellipse bounding box took %0.04f sec\n",
+           form->name, dt_get_lap_time(&start2));
 
   // check if there is anything to do at all; only if width and height
   // of bounding box is 2 or greater the shape lies inside of roi and
@@ -1967,13 +1940,9 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
       points[index * 2 + 1] = (grid * j + py) * iscale;
     }
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] ellipse grid took %0.04f sec\n",
-             form->name, dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] ellipse grid took %0.04f sec\n",
+           form->name, dt_get_lap_time(&start2));
 
   // we back transform all these points to the input image coordinates
   if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, module->iop_order,
@@ -1984,25 +1953,18 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
     return 0;
   }
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] ellipse transform took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] ellipse transform took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
 
   // we calculate the mask values at the transformed points; re-use
   // the points array for results; this requires out_scale==1 to
   // double the offsets at which they are stored
   _fill_mask((size_t)(bbh)*bbw, points, points, center, a, b, ta, tb, alpha, 1);
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] ellipse draw took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] ellipse draw took %0.04f sec\n", form->name,
+           dt_get_wtime() - start2);
 
   // we fill the pre-initialized output buffer by interpolation;
   // we only need to take the contents of our bounding box into account
@@ -2037,15 +1999,13 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
 
   dt_free_align(points);
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] ellipse fill took %0.04f sec\n",
-             form->name, dt_get_wtime() - start2);
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] ellipse total render took %0.04f sec\n", form->name,
-             dt_get_wtime() - start1);
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] ellipse fill took %0.04f sec\n",
+           form->name, dt_get_wtime() - start2);
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] ellipse total render took %0.04f sec\n", form->name,
+           dt_get_wtime() - start1);
+
   return 1;
 }
 

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -1151,13 +1151,9 @@ static int _gradient_get_mask(const dt_iop_module_t *const module,
   // we get the area
   if(!_gradient_get_area(module, piece, form, width, height, posx, posy)) return 0;
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] gradient area took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] gradient area took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
 
   // we get the gradient values
   dt_masks_point_gradient_t *gradient =
@@ -1192,13 +1188,9 @@ static int _gradient_get_mask(const dt_iop_module_t *const module,
       points[(j * gw + i) * 2 + 1] = (grid * j + py);
     }
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] gradient draw took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] gradient draw took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
 
   // we backtransform all these points
   if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe,
@@ -1210,13 +1202,9 @@ static int _gradient_get_mask(const dt_iop_module_t *const module,
     return 0;
   }
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] gradient transform took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] gradient transform took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
 
   // we calculate the mask at grid points and recycle point buffer to store results
   const float wd = piece->pipe->iwidth;
@@ -1333,9 +1321,9 @@ static int _gradient_get_mask(const dt_iop_module_t *const module,
 
   dt_free_align(points);
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-    dt_print(DT_DEBUG_MASKS, "[masks %s] gradient fill took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] gradient fill took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
 
   return 1;
 }
@@ -1385,13 +1373,9 @@ static int _gradient_get_mask_roi(const dt_iop_module_t *const module,
       points[index * 2 + 1] = (grid * j + py) * iscale;
     }
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] gradient draw took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] gradient draw took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
 
   // we backtransform all these points
   if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe,
@@ -1403,13 +1387,9 @@ static int _gradient_get_mask_roi(const dt_iop_module_t *const module,
     return 0;
   }
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] gradient transform took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] gradient transform took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
 
   // we calculate the mask at grid points and recycle point buffer to store results
   const float wd = piece->pipe->iwidth;
@@ -1521,9 +1501,9 @@ static int _gradient_get_mask_roi(const dt_iop_module_t *const module,
 
   dt_free_align(points);
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-    dt_print(DT_DEBUG_MASKS, "[masks %s] gradient fill took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] gradient fill took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
 
   return 1;
 }

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -330,10 +330,9 @@ static int _group_get_mask(const dt_iop_module_t *const module,
       {
         const double start = dt_get_wtime();
         _inverse_mask(module, piece, sel, &bufs[pos], &w[pos], &h[pos], &px[pos], &py[pos]);
-        if(darktable.unmuted & DT_DEBUG_PERF)
-          dt_print(DT_DEBUG_MASKS,
-                   "[masks %s] inverse took %0.04f sec\n",
-                   sel->name, dt_get_wtime() - start);
+        dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+                 "[masks %s] inverse took %0.04f sec\n",
+                 sel->name, dt_get_wtime() - start);
       }
       op[pos] = fpt->opacity;
       states[pos] = fpt->state;
@@ -444,10 +443,9 @@ static int _group_get_mask(const dt_iop_module_t *const module,
       }
     }
 
-    if(darktable.unmuted & DT_DEBUG_PERF)
-      dt_print(DT_DEBUG_MASKS,
-               "[masks %d] combine took %0.04f sec\n",
-               i, dt_get_wtime() - start);
+    dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+             "[masks %d] combine took %0.04f sec\n",
+             i, dt_get_wtime() - start);
   }
 
   free(op);
@@ -799,11 +797,9 @@ static int _group_get_mask_roi(const dt_iop_module_t *const restrict module,
           }
         }
 
-        if(darktable.unmuted & DT_DEBUG_PERF)
-          dt_print(DT_DEBUG_MASKS,
-                   "[masks %d] combine took %0.04f sec\n",
-                   nb_ok, dt_get_wtime() - start);
-        start = dt_get_wtime();
+        dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+                 "[masks %d] combine took %0.04f sec\n",
+                 nb_ok, dt_get_lap_time(&start));
 
         nb_ok++;
       }
@@ -838,10 +834,9 @@ int dt_masks_group_render_roi(dt_iop_module_t *module,
 
   const int ok = dt_masks_get_mask_roi(module, piece, form, roi, buffer);
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-    dt_print(DT_DEBUG_MASKS,
-             "[masks] render all masks took %0.04f sec\n",
-             dt_get_wtime() - start);
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks] render all masks took %0.04f sec\n",
+           dt_get_wtime() - start);
   return ok;
 }
 

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -720,12 +720,9 @@ static int _path_get_pts_border(dt_develop_t *dev,
   int cw = _path_is_clockwise(form);
   if(cw == 0) cw = -1;
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] path_points init took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] path_points init took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
 
   // we render all segments
   const GList *form_points = form->points;
@@ -847,13 +844,9 @@ static int _path_get_pts_border(dt_develop_t *dev,
     dt_masks_dynbuf_free(dborder);
   }
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS, "[masks %s] path_points point recurs %0.04f sec\n",
-             form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] path_points point recurs %0.04f sec\n",
+           form->name, dt_get_lap_time(&start2));
 
   // we don't want the border to self-intersect
   int inter_count = 0;
@@ -861,13 +854,9 @@ static int _path_get_pts_border(dt_develop_t *dev,
   {
     inter_count = _path_find_self_intersection(intersections, nb, *border, *border_count);
 
-    if(darktable.unmuted & DT_DEBUG_PERF)
-    {
-      dt_print(DT_DEBUG_MASKS,
-               "[masks %s] path_points self-intersect took %0.04f sec\n", form->name,
-               dt_get_wtime() - start2);
-      start2 = dt_get_wtime();
-    }
+    dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+             "[masks %s] path_points self-intersect took %0.04f sec\n", form->name,
+             dt_get_lap_time(&start2));
   }
 
   // and we transform them with all distorted modules
@@ -908,9 +897,9 @@ static int _path_get_pts_border(dt_develop_t *dev,
         goto fail;
     }
 
-    if(darktable.unmuted & DT_DEBUG_PERF)
-      dt_print(DT_DEBUG_MASKS, "[masks %s] path_points end took %0.04f sec\n",
-               form->name, dt_get_wtime() - start2);
+    dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+             "[masks %s] path_points end took %0.04f sec\n",
+             form->name, dt_get_lap_time(&start2));
 
     dt_masks_dynbuf_free(intersections);
     dt_free_align(border_init);
@@ -923,13 +912,9 @@ static int _path_get_pts_border(dt_develop_t *dev,
        || dt_dev_distort_transform_plus(dev, pipe, iop_order,
                                         transf_direction, *border, *border_count))
     {
-      if(darktable.unmuted & DT_DEBUG_PERF)
-      {
-        dt_print(DT_DEBUG_MASKS,
-                 "[masks %s] path_points transform took %0.04f sec\n", form->name,
-                 dt_get_wtime() - start2);
-        start2 = dt_get_wtime();
-      }
+      dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+               "[masks %s] path_points transform took %0.04f sec\n", form->name,
+               dt_get_lap_time(&start2));
 
       if(border)
       {
@@ -965,10 +950,9 @@ static int _path_get_pts_border(dt_develop_t *dev,
         }
       }
 
-      if(darktable.unmuted & DT_DEBUG_PERF)
-        dt_print(DT_DEBUG_MASKS,
-                 "[masks %s] path_points end took %0.04f sec\n", form->name,
-                 dt_get_wtime() - start2);
+      dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+               "[masks %s] path_points end took %0.04f sec\n", form->name,
+               dt_get_lap_time(&start2));
 
       dt_masks_dynbuf_free(intersections);
       dt_free_align(border_init);
@@ -2591,13 +2575,10 @@ static int _path_get_mask(const dt_iop_module_t *const module,
     return 0;
   }
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] path points took %0.04f sec\n",
-             form->name, dt_get_wtime() - start);
-    start = start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] path points took %0.04f sec\n",
+           form->name, dt_get_lap_time(&start));
+  start2 = start;
 
   // now we want to find the area, so we search min/max points
   const guint nb_corner = g_list_length(form->points);
@@ -2607,13 +2588,9 @@ static int _path_get_mask(const dt_iop_module_t *const module,
   const int hb = *height;
   const int wb = *width;
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] path_fill min max took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] path_fill min max took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
 
   // we allocate the buffer
   const size_t bufsize = (size_t)(*width) * (*height);
@@ -2733,13 +2710,9 @@ static int _path_get_mask(const dt_iop_module_t *const module,
       if(ii != i) break;
     }
   }
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] path_fill draw path took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] path_fill draw path took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
 
 #ifdef _OPENMP
 #pragma omp parallel for \
@@ -2757,13 +2730,9 @@ static int _path_get_mask(const dt_iop_module_t *const module,
     }
   }
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] path_fill fill plain took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] path_fill fill plain took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
 
   // now we fill the falloff
   int p0[2] = { 0 }, p1[2] = { 0 };
@@ -2805,18 +2774,16 @@ static int _path_get_mask(const dt_iop_module_t *const module,
     }
   }
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] path_fill fill falloff took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] path_fill fill falloff took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
 
   dt_free_align(points);
   dt_free_align(border);
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] path fill buffer took %0.04f sec\n", form->name,
-             dt_get_wtime() - start);
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] path fill buffer took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start));
 
   return 1;
 }
@@ -3057,13 +3024,10 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
     return 0;
   }
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] path points took %0.04f sec\n",
-             form->name, dt_get_wtime() - start);
-    start = start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] path points took %0.04f sec\n",
+           form->name, dt_get_lap_time(&start));
+  start2 = start;
 
   const guint nb_corner = g_list_length(form->points);
 
@@ -3161,21 +3125,13 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
   _path_bounding_box_raw(points, border, nb_corner, points_count, border_count,
                          &xmin, &xmax, &ymin, &ymax);
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] path_fill min max took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] path_fill min max took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-  {
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] path_fill clear mask took %0.04f sec\n", form->name,
-             dt_get_wtime() - start2);
-    start2 = dt_get_wtime();
-  }
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] path_fill clear mask took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start2));
 
   // deal with path if it does not lie outside of roi
   if(path_in_roi)
@@ -3203,13 +3159,9 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
                                                height);
     path_encircles_roi = path_encircles_roi || !crop_success;
 
-    if(darktable.unmuted & DT_DEBUG_PERF)
-    {
-      dt_print(DT_DEBUG_MASKS,
-               "[masks %s] path_fill crop to roi took %0.04f sec\n", form->name,
-               dt_get_wtime() - start2);
-      start2 = dt_get_wtime();
-    }
+    dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+             "[masks %s] path_fill crop to roi took %0.04f sec\n", form->name,
+             dt_get_lap_time(&start2));
 
     if(path_encircles_roi)
     {
@@ -3264,13 +3216,9 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
         }
       }
 
-      if(darktable.unmuted & DT_DEBUG_PERF)
-      {
-        dt_print(DT_DEBUG_MASKS,
-                 "[masks %s] path_fill draw path took %0.04f sec\n", form->name,
-                 dt_get_wtime() - start2);
-        start2 = dt_get_wtime();
-      }
+      dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+               "[masks %s] path_fill draw path took %0.04f sec\n", form->name,
+               dt_get_lap_time(&start2));
 
       // we fill the inside plain
       // we don't need to deal with parts of shape outside of roi
@@ -3300,13 +3248,9 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
         }
       }
 
-      if(darktable.unmuted & DT_DEBUG_PERF)
-      {
-        dt_print(DT_DEBUG_MASKS,
-                 "[masks %s] path_fill fill plain took %0.04f sec\n", form->name,
-                 dt_get_wtime() - start2);
-        start2 = dt_get_wtime();
-      }
+      dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+               "[masks %s] path_fill fill plain took %0.04f sec\n", form->name,
+               dt_get_lap_time(&start2));
     }
     dt_free_align(cpoints);
   }
@@ -3388,21 +3332,17 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
 
     dt_free_align(dpoints);
 
-    if(darktable.unmuted & DT_DEBUG_PERF)
-    {
-      dt_print(DT_DEBUG_MASKS,
-               "[masks %s] path_fill fill falloff took %0.04f sec\n", form->name,
-               dt_get_wtime() - start2);
-    }
+    dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+             "[masks %s] path_fill fill falloff took %0.04f sec\n", form->name,
+             dt_get_lap_time(&start2));
   }
 
   dt_free_align(points);
   dt_free_align(border);
 
-  if(darktable.unmuted & DT_DEBUG_PERF)
-    dt_print(DT_DEBUG_MASKS,
-             "[masks %s] path fill buffer took %0.04f sec\n", form->name,
-             dt_get_wtime() - start);
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           "[masks %s] path fill buffer took %0.04f sec\n", form->name,
+           dt_get_lap_time(&start));
 
   return 1;
 }

--- a/src/lua/call.c
+++ b/src/lua/call.c
@@ -30,10 +30,7 @@
 int dt_lua_check_print_error(lua_State* L, int result)
 {
   if(result == LUA_OK) return result;
-  if(darktable.unmuted & DT_DEBUG_LUA)
-  {
-    dt_print(DT_DEBUG_LUA, "LUA ERROR : %s\n", lua_tostring(L, -1));
-  }
+  dt_print(DT_DEBUG_LUA, "LUA ERROR : %s\n", lua_tostring(L, -1));
   lua_pop(L,1); // remove the error message, it has been handled
   return result;
 }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2813,8 +2813,7 @@ static void _on_drag_data_received(GtkWidget *widget,
 
     dt_dev_add_history_item(module_src->dev, module_src, TRUE);
 
-    if(darktable.unmuted & DT_DEBUG_IOPORDER)
-      dt_ioppr_check_iop_order(module_src->dev, 0, "_on_drag_data_received end");
+    dt_ioppr_check_iop_order(module_src->dev, 0, "_on_drag_data_received end");
 
     // rebuild the accelerators
     dt_iop_connect_accels_multi(module_src->so);

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -429,9 +429,9 @@ void expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t
   // we have started the first expose
   lib->already_started = TRUE;
 
-  const double end = dt_get_wtime();
-  if(darktable.unmuted & DT_DEBUG_PERF)
-    dt_print(DT_DEBUG_LIGHTTABLE, "[lighttable] expose took %0.04f sec\n", end - start);
+  dt_print(DT_DEBUG_LIGHTTABLE | DT_DEBUG_PERF, 
+           "[lighttable] expose took %0.04f sec\n", 
+           dt_get_wtime() - start);
 }
 
 void enter(dt_view_t *self)

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -1359,7 +1359,7 @@ static void _view_map_changed_callback_delayed(gpointer user_data)
                                   * epsilon_factor * 0.01 * 0.000001 / R);
 
       dt_times_t start;
-      dt_get_times(&start);
+      dt_get_perf_times(&start);
       _dbscan(p, img_count, epsilon, min_images);
       dt_show_times(&start, "[map] dbscan calculation");
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -885,21 +885,16 @@ dt_view_surface_value_t dt_view_image_get_surface(const dt_imgid_t imgid,
   if(rgbbuf) free(rgbbuf);
 
   // logs
-  if((darktable.unmuted & (DT_DEBUG_LIGHTTABLE | DT_DEBUG_PERF)) ==
-     (DT_DEBUG_LIGHTTABLE | DT_DEBUG_PERF))
-  {
+  if(darktable.unmuted & DT_DEBUG_PERF)
     dt_print(DT_DEBUG_LIGHTTABLE | DT_DEBUG_PERF,
              "[dt_view_image_get_surface]  id %i, dots %ix%i, mip %ix%i,"
              " surf %ix%i created in %0.04f sec\n",
              imgid, width, height, buf_wd, buf_ht,
              img_width, img_height, dt_get_wtime() - tt);
-  }
-  else if(darktable.unmuted & DT_DEBUG_LIGHTTABLE)
-  {
+  else
     dt_print(DT_DEBUG_LIGHTTABLE,
              "[dt_view_image_get_surface]  id %i, dots %ix%i, mip %ix%i, surf %ix%i\n",
              imgid, width, height, buf_wd, buf_ht, img_width, img_height);
-  }
 
   // we consider skull as ok as the image hasn't to be reload
   return ret;


### PR DESCRIPTION
Building on #15557 simplify many dt_print calls preceded by an `if(darktable.unmuted & XXX)`.

Especially `DT_DEBUG_PERF` which now behaves like `DT_DEBUG_VERBOSE` when specified together with other "threads"; it will only print if _both_ are requested at the command line.

But `DT_DEBUG_PERF` is different from how `DT_DEBUG_VERBOSE` used to behave in that it can be specified as the single "thread" too, so that `-d perf` will show it.
`DT_DEBUG_VERBOSE` has been changed to behave in the same way (effectively `dt_print(DT_DEBUG_VERBOSE,` would be the verbose equivalent of `DT_DEBUG_ALWAYS`).

Also introduce `dt_get_lap_time` and `dt_get_lap_utime` to allow resetting the start time from within `dt_debug` arguments, i.e. only when needed (which was one reason if(perf) was often used).

Made `dt_ioppr_check_iop_order` conditional too (providing one more use case example of `dt_debug_if` although in this case the pre-call inline check was imho a little overkill since it never gets / can be called with a heavy argument list.
