### PR TITLE
wb_presets: add Sony ILCE-7CM2

### DIFF
--- a/data/wb_presets.json
+++ b/data/wb_presets.json
@@ -152075,6 +152075,2657 @@
           ]
         },
         {
+          "model": "ILCE-7CM2",
+          "presets": [
+            {
+              "name": "Daylight",
+              "tuning": -14,
+              "channels": [
+                1.955078125,
+                1,
+                2.0791015625,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": -13,
+              "channels": [
+                1.984375,
+                1,
+                2.0419921875,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": -12,
+              "channels": [
+                2.0146484375,
+                1,
+                2.005859375,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": -11,
+              "channels": [
+                2.044921875,
+                1,
+                1.96875,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": -10,
+              "channels": [
+                2.076171875,
+                1,
+                1.9345703125,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": -9,
+              "channels": [
+                2.107421875,
+                1,
+                1.900390625,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": -8,
+              "channels": [
+                2.1396484375,
+                1,
+                1.8662109375,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": -7,
+              "channels": [
+                2.1728515625,
+                1,
+                1.8330078125,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": -6,
+              "channels": [
+                2.205078125,
+                1,
+                1.80078125,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": -5,
+              "channels": [
+                2.2392578125,
+                1,
+                1.7685546875,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": -4,
+              "channels": [
+                2.2734375,
+                1,
+                1.73828125,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": -3,
+              "channels": [
+                2.30859375,
+                1,
+                1.70703125,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": -2,
+              "channels": [
+                2.3447265625,
+                1,
+                1.677734375,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": -1,
+              "channels": [
+                2.380859375,
+                1,
+                1.6484375,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "channels": [
+                2.41796875,
+                1,
+                1.619140625,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": 1,
+              "channels": [
+                2.4560546875,
+                1,
+                1.5908203125,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": 2,
+              "channels": [
+                2.494140625,
+                1,
+                1.5634765625,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": 3,
+              "channels": [
+                2.5341796875,
+                1,
+                1.5361328125,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": 4,
+              "channels": [
+                2.5732421875,
+                1,
+                1.509765625,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": 5,
+              "channels": [
+                2.615234375,
+                1,
+                1.4833984375,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": 6,
+              "channels": [
+                2.65625,
+                1,
+                1.45703125,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": 7,
+              "channels": [
+                2.6982421875,
+                1,
+                1.4326171875,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": 8,
+              "channels": [
+                2.740234375,
+                1,
+                1.4072265625,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": 9,
+              "channels": [
+                2.78515625,
+                1,
+                1.3828125,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": 10,
+              "channels": [
+                2.830078125,
+                1,
+                1.359375,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": 11,
+              "channels": [
+                2.875,
+                1,
+                1.3359375,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": 12,
+              "channels": [
+                2.921875,
+                1,
+                1.3134765625,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": 13,
+              "channels": [
+                2.96875,
+                1,
+                1.2900390625,
+                0
+              ]
+            },
+            {
+              "name": "Daylight",
+              "tuning": 14,
+              "channels": [
+                3.0185546875,
+                1,
+                1.2685546875,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": -14,
+              "channels": [
+                2.2783203125,
+                1,
+                1.6796875,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": -13,
+              "channels": [
+                2.314453125,
+                1,
+                1.650390625,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": -12,
+              "channels": [
+                2.349609375,
+                1,
+                1.62109375,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": -11,
+              "channels": [
+                2.38671875,
+                1,
+                1.5927734375,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": -10,
+              "channels": [
+                2.4248046875,
+                1,
+                1.564453125,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": -9,
+              "channels": [
+                2.462890625,
+                1,
+                1.537109375,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": -8,
+              "channels": [
+                2.5009765625,
+                1,
+                1.5107421875,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": -7,
+              "channels": [
+                2.541015625,
+                1,
+                1.484375,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": -6,
+              "channels": [
+                2.58203125,
+                1,
+                1.4580078125,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": -5,
+              "channels": [
+                2.623046875,
+                1,
+                1.4326171875,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": -4,
+              "channels": [
+                2.6650390625,
+                1,
+                1.408203125,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": -3,
+              "channels": [
+                2.70703125,
+                1,
+                1.3837890625,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": -2,
+              "channels": [
+                2.7509765625,
+                1,
+                1.359375,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": -1,
+              "channels": [
+                2.7958984375,
+                1,
+                1.3359375,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "channels": [
+                2.83984375,
+                1,
+                1.3125,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": 1,
+              "channels": [
+                2.88671875,
+                1,
+                1.2900390625,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": 2,
+              "channels": [
+                2.9345703125,
+                1,
+                1.267578125,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": 3,
+              "channels": [
+                2.982421875,
+                1,
+                1.24609375,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": 4,
+              "channels": [
+                3.0322265625,
+                1,
+                1.224609375,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": 5,
+              "channels": [
+                3.08203125,
+                1,
+                1.203125,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": 6,
+              "channels": [
+                3.1328125,
+                1,
+                1.1826171875,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": 7,
+              "channels": [
+                3.185546875,
+                1,
+                1.162109375,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": 8,
+              "channels": [
+                3.23828125,
+                1,
+                1.142578125,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": 9,
+              "channels": [
+                3.29296875,
+                1,
+                1.123046875,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": 10,
+              "channels": [
+                3.34765625,
+                1,
+                1.103515625,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": 11,
+              "channels": [
+                3.4033203125,
+                1,
+                1.0849609375,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": 12,
+              "channels": [
+                3.4619140625,
+                1,
+                1.06640625,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": 13,
+              "channels": [
+                3.521484375,
+                1,
+                1.0478515625,
+                0
+              ]
+            },
+            {
+              "name": "Shade",
+              "tuning": 14,
+              "channels": [
+                3.580078125,
+                1,
+                1.0302734375,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": -14,
+              "channels": [
+                2.10546875,
+                1,
+                1.9013671875,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": -13,
+              "channels": [
+                2.1376953125,
+                1,
+                1.8681640625,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": -12,
+              "channels": [
+                2.1708984375,
+                1,
+                1.8349609375,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": -11,
+              "channels": [
+                2.2041015625,
+                1,
+                1.802734375,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": -10,
+              "channels": [
+                2.2373046875,
+                1,
+                1.7705078125,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": -9,
+              "channels": [
+                2.271484375,
+                1,
+                1.7392578125,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": -8,
+              "channels": [
+                2.306640625,
+                1,
+                1.708984375,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": -7,
+              "channels": [
+                2.3427734375,
+                1,
+                1.6787109375,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": -6,
+              "channels": [
+                2.37890625,
+                1,
+                1.6494140625,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": -5,
+              "channels": [
+                2.4169921875,
+                1,
+                1.6201171875,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": -4,
+              "channels": [
+                2.4541015625,
+                1,
+                1.591796875,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": -3,
+              "channels": [
+                2.4931640625,
+                1,
+                1.564453125,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": -2,
+              "channels": [
+                2.53125,
+                1,
+                1.537109375,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": -1,
+              "channels": [
+                2.5712890625,
+                1,
+                1.5107421875,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "channels": [
+                2.6123046875,
+                1,
+                1.484375,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": 1,
+              "channels": [
+                2.6533203125,
+                1,
+                1.458984375,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": 2,
+              "channels": [
+                2.6962890625,
+                1,
+                1.43359375,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": 3,
+              "channels": [
+                2.7392578125,
+                1,
+                1.4091796875,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": 4,
+              "channels": [
+                2.783203125,
+                1,
+                1.384765625,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": 5,
+              "channels": [
+                2.828125,
+                1,
+                1.3603515625,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": 6,
+              "channels": [
+                2.873046875,
+                1,
+                1.3369140625,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": 7,
+              "channels": [
+                2.919921875,
+                1,
+                1.314453125,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": 8,
+              "channels": [
+                2.966796875,
+                1,
+                1.2919921875,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": 9,
+              "channels": [
+                3.0146484375,
+                1,
+                1.26953125,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": 10,
+              "channels": [
+                3.064453125,
+                1,
+                1.248046875,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": 11,
+              "channels": [
+                3.115234375,
+                1,
+                1.2265625,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": 12,
+              "channels": [
+                3.1669921875,
+                1,
+                1.2060546875,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": 13,
+              "channels": [
+                3.21875,
+                1,
+                1.1845703125,
+                0
+              ]
+            },
+            {
+              "name": "Cloudy",
+              "tuning": 14,
+              "channels": [
+                3.271484375,
+                1,
+                1.1650390625,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": -14,
+              "channels": [
+                1.224609375,
+                1,
+                3.8330078125,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": -13,
+              "channels": [
+                1.2421875,
+                1,
+                3.7578125,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": -12,
+              "channels": [
+                1.2587890625,
+                1,
+                3.68359375,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": -11,
+              "channels": [
+                1.27734375,
+                1,
+                3.6123046875,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": -10,
+              "channels": [
+                1.294921875,
+                1,
+                3.5419921875,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": -9,
+              "channels": [
+                1.3134765625,
+                1,
+                3.474609375,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": -8,
+              "channels": [
+                1.33203125,
+                1,
+                3.4072265625,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": -7,
+              "channels": [
+                1.3515625,
+                1,
+                3.3427734375,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": -6,
+              "channels": [
+                1.37109375,
+                1,
+                3.2763671875,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": -5,
+              "channels": [
+                1.3896484375,
+                1,
+                3.216796875,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": -4,
+              "channels": [
+                1.41015625,
+                1,
+                3.154296875,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": -3,
+              "channels": [
+                1.4296875,
+                1,
+                3.0947265625,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": -2,
+              "channels": [
+                1.451171875,
+                1,
+                3.0361328125,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": -1,
+              "channels": [
+                1.4716796875,
+                1,
+                2.978515625,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "channels": [
+                1.4931640625,
+                1,
+                2.923828125,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": 1,
+              "channels": [
+                1.5146484375,
+                1,
+                2.869140625,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": 2,
+              "channels": [
+                1.537109375,
+                1,
+                2.814453125,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": 3,
+              "channels": [
+                1.55859375,
+                1,
+                2.7626953125,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": 4,
+              "channels": [
+                1.5810546875,
+                1,
+                2.7119140625,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": 5,
+              "channels": [
+                1.6044921875,
+                1,
+                2.66015625,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": 6,
+              "channels": [
+                1.6279296875,
+                1,
+                2.6123046875,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": 7,
+              "channels": [
+                1.65234375,
+                1,
+                2.5634765625,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": 8,
+              "channels": [
+                1.6767578125,
+                1,
+                2.5166015625,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": 9,
+              "channels": [
+                1.7001953125,
+                1,
+                2.470703125,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": 10,
+              "channels": [
+                1.7265625,
+                1,
+                2.4248046875,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": 11,
+              "channels": [
+                1.751953125,
+                1,
+                2.380859375,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": 12,
+              "channels": [
+                1.77734375,
+                1,
+                2.3369140625,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": 13,
+              "channels": [
+                1.8037109375,
+                1,
+                2.294921875,
+                0
+              ]
+            },
+            {
+              "name": "Tungsten",
+              "tuning": 14,
+              "channels": [
+                1.830078125,
+                1,
+                2.25390625,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": -14,
+              "channels": [
+                1.451171875,
+                1,
+                3.5869140625,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": -13,
+              "channels": [
+                1.470703125,
+                1,
+                3.521484375,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": -12,
+              "channels": [
+                1.4912109375,
+                1,
+                3.4560546875,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": -11,
+              "channels": [
+                1.5107421875,
+                1,
+                3.3935546875,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": -10,
+              "channels": [
+                1.5322265625,
+                1,
+                3.3310546875,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": -9,
+              "channels": [
+                1.5537109375,
+                1,
+                3.2705078125,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": -8,
+              "channels": [
+                1.5751953125,
+                1,
+                3.2099609375,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": -7,
+              "channels": [
+                1.5966796875,
+                1,
+                3.15234375,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": -6,
+              "channels": [
+                1.619140625,
+                1,
+                3.095703125,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": -5,
+              "channels": [
+                1.6416015625,
+                1,
+                3.0400390625,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": -4,
+              "channels": [
+                1.6640625,
+                1,
+                2.984375,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": -3,
+              "channels": [
+                1.6884765625,
+                1,
+                2.9306640625,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": -2,
+              "channels": [
+                1.7109375,
+                1,
+                2.880859375,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": -1,
+              "channels": [
+                1.7353515625,
+                1,
+                2.8291015625,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "channels": [
+                1.759765625,
+                1,
+                2.7783203125,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": 1,
+              "channels": [
+                1.78515625,
+                1,
+                2.728515625,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": 2,
+              "channels": [
+                1.8095703125,
+                1,
+                2.6806640625,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": 3,
+              "channels": [
+                1.8359375,
+                1,
+                2.6328125,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": 4,
+              "channels": [
+                1.8623046875,
+                1,
+                2.5869140625,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": 5,
+              "channels": [
+                1.8876953125,
+                1,
+                2.541015625,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": 6,
+              "channels": [
+                1.9150390625,
+                1,
+                2.4970703125,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": 7,
+              "channels": [
+                1.9423828125,
+                1,
+                2.453125,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": 8,
+              "channels": [
+                1.970703125,
+                1,
+                2.41015625,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": 9,
+              "channels": [
+                1.9990234375,
+                1,
+                2.3681640625,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": 10,
+              "channels": [
+                2.02734375,
+                1,
+                2.326171875,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": 11,
+              "channels": [
+                2.056640625,
+                1,
+                2.287109375,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": 12,
+              "channels": [
+                2.0869140625,
+                1,
+                2.2470703125,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": 13,
+              "channels": [
+                2.1171875,
+                1,
+                2.208984375,
+                0
+              ]
+            },
+            {
+              "name": "Warm White Fluorescent",
+              "tuning": 14,
+              "channels": [
+                2.1474609375,
+                1,
+                2.169921875,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": -14,
+              "channels": [
+                1.85546875,
+                1,
+                2.84375,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": -13,
+              "channels": [
+                1.8818359375,
+                1,
+                2.7939453125,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": -12,
+              "channels": [
+                1.908203125,
+                1,
+                2.74609375,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": -11,
+              "channels": [
+                1.9345703125,
+                1,
+                2.6982421875,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": -10,
+              "channels": [
+                1.9619140625,
+                1,
+                2.65234375,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": -9,
+              "channels": [
+                1.9892578125,
+                1,
+                2.6064453125,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": -8,
+              "channels": [
+                2.0166015625,
+                1,
+                2.5615234375,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": -7,
+              "channels": [
+                2.0439453125,
+                1,
+                2.5185546875,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": -6,
+              "channels": [
+                2.0732421875,
+                1,
+                2.474609375,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": -5,
+              "channels": [
+                2.1025390625,
+                1,
+                2.4326171875,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": -4,
+              "channels": [
+                2.1318359375,
+                1,
+                2.3916015625,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": -3,
+              "channels": [
+                2.1630859375,
+                1,
+                2.3515625,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": -2,
+              "channels": [
+                2.193359375,
+                1,
+                2.3115234375,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": -1,
+              "channels": [
+                2.224609375,
+                1,
+                2.2734375,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "channels": [
+                2.255859375,
+                1,
+                2.234375,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": 1,
+              "channels": [
+                2.2880859375,
+                1,
+                2.197265625,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": 2,
+              "channels": [
+                2.3212890625,
+                1,
+                2.16015625,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": 3,
+              "channels": [
+                2.3544921875,
+                1,
+                2.1240234375,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": 4,
+              "channels": [
+                2.388671875,
+                1,
+                2.0888671875,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": 5,
+              "channels": [
+                2.4228515625,
+                1,
+                2.0537109375,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": 6,
+              "channels": [
+                2.458984375,
+                1,
+                2.01953125,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": 7,
+              "channels": [
+                2.494140625,
+                1,
+                1.986328125,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": 8,
+              "channels": [
+                2.5302734375,
+                1,
+                1.953125,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": 9,
+              "channels": [
+                2.5673828125,
+                1,
+                1.9208984375,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": 10,
+              "channels": [
+                2.6044921875,
+                1,
+                1.8896484375,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": 11,
+              "channels": [
+                2.6435546875,
+                1,
+                1.8583984375,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": 12,
+              "channels": [
+                2.6826171875,
+                1,
+                1.828125,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": 13,
+              "channels": [
+                2.7216796875,
+                1,
+                1.7978515625,
+                0
+              ]
+            },
+            {
+              "name": "Cool White Fluorescent",
+              "tuning": 14,
+              "channels": [
+                2.76171875,
+                1,
+                1.7685546875,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": -14,
+              "channels": [
+                1.9501953125,
+                1,
+                2.10546875,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": -13,
+              "channels": [
+                1.9794921875,
+                1,
+                2.0673828125,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": -12,
+              "channels": [
+                2.009765625,
+                1,
+                2.0302734375,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": -11,
+              "channels": [
+                2.0390625,
+                1,
+                1.9951171875,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": -10,
+              "channels": [
+                2.0703125,
+                1,
+                1.958984375,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": -9,
+              "channels": [
+                2.1025390625,
+                1,
+                1.923828125,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": -8,
+              "channels": [
+                2.1337890625,
+                1,
+                1.8896484375,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": -7,
+              "channels": [
+                2.1669921875,
+                1,
+                1.8564453125,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": -6,
+              "channels": [
+                2.19921875,
+                1,
+                1.8232421875,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": -5,
+              "channels": [
+                2.232421875,
+                1,
+                1.7919921875,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": -4,
+              "channels": [
+                2.267578125,
+                1,
+                1.759765625,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": -3,
+              "channels": [
+                2.3017578125,
+                1,
+                1.7294921875,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": -2,
+              "channels": [
+                2.337890625,
+                1,
+                1.69921875,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": -1,
+              "channels": [
+                2.3740234375,
+                1,
+                1.669921875,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "channels": [
+                2.4111328125,
+                1,
+                1.640625,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": 1,
+              "channels": [
+                2.4482421875,
+                1,
+                1.611328125,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": 2,
+              "channels": [
+                2.486328125,
+                1,
+                1.583984375,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": 3,
+              "channels": [
+                2.525390625,
+                1,
+                1.5556640625,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": 4,
+              "channels": [
+                2.564453125,
+                1,
+                1.529296875,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": 5,
+              "channels": [
+                2.60546875,
+                1,
+                1.5029296875,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": 6,
+              "channels": [
+                2.646484375,
+                1,
+                1.4765625,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": 7,
+              "channels": [
+                2.6884765625,
+                1,
+                1.451171875,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": 8,
+              "channels": [
+                2.7314453125,
+                1,
+                1.42578125,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": 9,
+              "channels": [
+                2.775390625,
+                1,
+                1.4013671875,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": 10,
+              "channels": [
+                2.8193359375,
+                1,
+                1.3779296875,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": 11,
+              "channels": [
+                2.8642578125,
+                1,
+                1.353515625,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": 12,
+              "channels": [
+                2.9111328125,
+                1,
+                1.330078125,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": 13,
+              "channels": [
+                2.9580078125,
+                1,
+                1.3076171875,
+                0
+              ]
+            },
+            {
+              "name": "Day White Fluorescent",
+              "tuning": 14,
+              "channels": [
+                3.005859375,
+                1,
+                1.28515625,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": -14,
+              "channels": [
+                2.16015625,
+                1,
+                1.9541015625,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": -13,
+              "channels": [
+                2.1923828125,
+                1,
+                1.9189453125,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": -12,
+              "channels": [
+                2.224609375,
+                1,
+                1.88671875,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": -11,
+              "channels": [
+                2.2587890625,
+                1,
+                1.853515625,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": -10,
+              "channels": [
+                2.29296875,
+                1,
+                1.8212890625,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": -9,
+              "channels": [
+                2.328125,
+                1,
+                1.7890625,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": -8,
+              "channels": [
+                2.36328125,
+                1,
+                1.7587890625,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": -7,
+              "channels": [
+                2.3994140625,
+                1,
+                1.7275390625,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": -6,
+              "channels": [
+                2.4365234375,
+                1,
+                1.6982421875,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": -5,
+              "channels": [
+                2.4736328125,
+                1,
+                1.6689453125,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": -4,
+              "channels": [
+                2.51171875,
+                1,
+                1.6396484375,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": -3,
+              "channels": [
+                2.55078125,
+                1,
+                1.6123046875,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": -2,
+              "channels": [
+                2.58984375,
+                1,
+                1.5849609375,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": -1,
+              "channels": [
+                2.630859375,
+                1,
+                1.5576171875,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "channels": [
+                2.671875,
+                1,
+                1.5302734375,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": 1,
+              "channels": [
+                2.7138671875,
+                1,
+                1.5048828125,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": 2,
+              "channels": [
+                2.7568359375,
+                1,
+                1.478515625,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": 3,
+              "channels": [
+                2.7998046875,
+                1,
+                1.453125,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": 4,
+              "channels": [
+                2.8447265625,
+                1,
+                1.4287109375,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": 5,
+              "channels": [
+                2.888671875,
+                1,
+                1.404296875,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": 6,
+              "channels": [
+                2.935546875,
+                1,
+                1.380859375,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": 7,
+              "channels": [
+                2.982421875,
+                1,
+                1.357421875,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": 8,
+              "channels": [
+                3.029296875,
+                1,
+                1.3349609375,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": 9,
+              "channels": [
+                3.078125,
+                1,
+                1.3115234375,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": 10,
+              "channels": [
+                3.12890625,
+                1,
+                1.2900390625,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": 11,
+              "channels": [
+                3.1787109375,
+                1,
+                1.2685546875,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": 12,
+              "channels": [
+                3.2314453125,
+                1,
+                1.2470703125,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": 13,
+              "channels": [
+                3.283203125,
+                1,
+                1.2255859375,
+                0
+              ]
+            },
+            {
+              "name": "Daylight Fluorescent",
+              "tuning": 14,
+              "channels": [
+                3.3369140625,
+                1,
+                1.205078125,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": -14,
+              "channels": [
+                2.1474609375,
+                1,
+                1.84765625,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": -13,
+              "channels": [
+                2.1806640625,
+                1,
+                1.814453125,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": -12,
+              "channels": [
+                2.2138671875,
+                1,
+                1.7822265625,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": -11,
+              "channels": [
+                2.248046875,
+                1,
+                1.7509765625,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": -10,
+              "channels": [
+                2.283203125,
+                1,
+                1.720703125,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": -9,
+              "channels": [
+                2.318359375,
+                1,
+                1.689453125,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": -8,
+              "channels": [
+                2.3544921875,
+                1,
+                1.66015625,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": -7,
+              "channels": [
+                2.3916015625,
+                1,
+                1.630859375,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": -6,
+              "channels": [
+                2.427734375,
+                1,
+                1.6025390625,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": -5,
+              "channels": [
+                2.4658203125,
+                1,
+                1.5751953125,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": -4,
+              "channels": [
+                2.5048828125,
+                1,
+                1.5478515625,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": -3,
+              "channels": [
+                2.5439453125,
+                1,
+                1.5205078125,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": -2,
+              "channels": [
+                2.583984375,
+                1,
+                1.494140625,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": -1,
+              "channels": [
+                2.6259765625,
+                1,
+                1.4677734375,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "channels": [
+                2.6669921875,
+                1,
+                1.4423828125,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": 1,
+              "channels": [
+                2.7099609375,
+                1,
+                1.41796875,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": 2,
+              "channels": [
+                2.75390625,
+                1,
+                1.392578125,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": 3,
+              "channels": [
+                2.796875,
+                1,
+                1.369140625,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": 4,
+              "channels": [
+                2.8427734375,
+                1,
+                1.345703125,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": 5,
+              "channels": [
+                2.888671875,
+                1,
+                1.322265625,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": 6,
+              "channels": [
+                2.935546875,
+                1,
+                1.2998046875,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": 7,
+              "channels": [
+                2.9833984375,
+                1,
+                1.27734375,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": 8,
+              "channels": [
+                3.0322265625,
+                1,
+                1.2548828125,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": 9,
+              "channels": [
+                3.08203125,
+                1,
+                1.234375,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": 10,
+              "channels": [
+                3.1328125,
+                1,
+                1.212890625,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": 11,
+              "channels": [
+                3.18359375,
+                1,
+                1.1923828125,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": 12,
+              "channels": [
+                3.236328125,
+                1,
+                1.171875,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": 13,
+              "channels": [
+                3.291015625,
+                1,
+                1.1513671875,
+                0
+              ]
+            },
+            {
+              "name": "Flash",
+              "tuning": 14,
+              "channels": [
+                3.3466796875,
+                1,
+                1.1318359375,
+                0
+              ]
+            },
+            {
+              "name": "2500K",
+              "channels": [
+                1.3681640625,
+                1,
+                3.263671875,
+                0
+              ]
+            },
+            {
+              "name": "3200K",
+              "channels": [
+                1.724609375,
+                1,
+                2.4140625,
+                0
+              ]
+            },
+            {
+              "name": "4500K",
+              "channels": [
+                2.1982421875,
+                1,
+                1.7783203125,
+                0
+              ]
+            },
+            {
+              "name": "6000K",
+              "channels": [
+                2.564453125,
+                1,
+                1.4853515625,
+                0
+              ]
+            },
+            {
+              "name": "8500K",
+              "channels": [
+                2.92578125,
+                1,
+                1.2568359375,
+                0
+              ]
+            }
+          ]
+        },
+        {
           "model": "ILCE-7R",
           "presets": [
             {


### PR DESCRIPTION
Here's the Sony 7Cii white balance presets, acquired as described on [the wiki page](https://github.com/darktable-org/darktable/wiki/White-balance-presets) using the finetuned (properly) instructions. I didn't do the underwater preset because it is labelled as "Underwater Auto" on this camera, so I assume there's something extra going on there.

Also I got the error `Warning: Unknown Sony Fluorescent WB Preset!` a bunch of times from the script, but I'm not sure which preset was causing this, as they all seem to have made it into the output.