### PR TITLE
[CI/CD] Unblock the use of Clang 12 for AppImage

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -123,6 +123,9 @@ jobs:
           sudo lensfun-update-data
       - name: Build and Install
         run: |
+          # Only Clang 12 is available on Ubuntu 20.04. We can lower the Clang version requirement to use Clang 12,
+          # since at the moment it is only a policy enforcement, and not a real requirement of the current source code.
+          sed -i 's/COMPILER_VERSION VERSION_LESS 14/COMPILER_VERSION VERSION_LESS 12/' cmake/compiler-versions.cmake src/external/rawspeed/cmake/compiler-versions.cmake
           bash tools/appimage-build-script.sh
       - name: Check if it runs
         run: |


### PR DESCRIPTION
I'm using Ubuntu 20.04 to build nightly AppImages. The purpose of using such an old version of Ubuntu was to make AppImage compatible with distribution releases that use glibc 2.31 and later.

Unfortunately, today's commits raised the Clang version requirements and now the minimum version is 14. Only Clang 12 is available on Ubuntu 20.04.

So this PR uses sed-magic to cancel the increase in the requirement for the compiler version, since at the moment it is only an enforcement of an arbitrarily set policy, and not a real requirement of the current source code.