### PR TITLE
refactor iop module skipping code

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -3129,9 +3129,7 @@ int dt_dev_distort_transform_locked(dt_develop_t *dev,
                && module->iop_order <= iop_order)
            || (transf_direction == DT_DEV_TRANSFORM_DIR_BACK_EXCL
                && module->iop_order < iop_order))
-       && !(dev->gui_module
-            && dev->gui_module != module
-            && (dev->gui_module->operation_tags_filter() & module->operation_tags())
+       && !(dt_iop_module_is_skipped(dev, module)
             && (pipe->type & DT_DEV_PIXELPIPE_BASIC)))
     {
       module->distort_transform(module, piece, points, points_count);
@@ -3187,10 +3185,8 @@ int dt_dev_distort_backtransform_locked(dt_develop_t *dev,
                && module->iop_order <= iop_order)
            || (transf_direction == DT_DEV_TRANSFORM_DIR_BACK_EXCL
                && module->iop_order < iop_order))
-       && !(dev->gui_module
-            && dev->gui_module != module
-            && (dev->gui_module->operation_tags_filter() & module->operation_tags())
-            && (pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW))))
+       && !(dt_iop_module_is_skipped(dev, module)
+            && (pipe->type & DT_DEV_PIXELPIPE_BASIC)))
     {
       module->distort_backtransform(module, piece, points, points_count);
     }

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -3627,6 +3627,14 @@ void dt_iop_gui_changed(dt_action_t *action, GtkWidget *widget, gpointer data)
   dt_dev_add_history_item_target(darktable.develop, module, TRUE, widget);
 }
 
+gboolean dt_iop_module_is_skipped(const struct dt_develop_t *dev,
+                                  const struct dt_iop_module_t *module)
+{
+  return dev->gui_module
+      && dev->gui_module != module
+      && (dev->gui_module->operation_tags_filter() & module->operation_tags());
+}
+
 enum
 {
   // Multi-instance

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -576,6 +576,8 @@ void dt_iop_gui_rename_module(dt_iop_module_t *module);
 
 void dt_iop_gui_changed(dt_action_t *action, GtkWidget *widget, gpointer data);
 
+gboolean dt_iop_module_is_skipped(const struct dt_develop_t *dev, const struct dt_iop_module_t *module);
+
 // copy the RGB channels of a pixel using nontemporal stores if
 // possible; includes the 'alpha' channel as well if faster due to
 // vectorization, but subsequent code should ignore the value of the

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -136,11 +136,8 @@ static uint64_t _dev_pixelpipe_cache_basichash(
     dt_develop_t *dev = piece->module->dev;
 
     // don't take skipped modules into account
-    const gboolean skipped =
-      dev->gui_module
-      && dev->gui_module != piece->module
-      && (dev->gui_module->operation_tags_filter() & piece->module->operation_tags())
-      && (pipe->type & (DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW));
+    const gboolean skipped = dt_iop_module_is_skipped(dev, piece->module)
+      && (pipe->type & DT_DEV_PIXELPIPE_BASIC);
 
     if(!skipped)
     {

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1331,10 +1331,8 @@ static inline gboolean _skip_piece_on_tags(const dt_dev_pixelpipe_iop_t *piece)
   if(!piece->enabled)
     return TRUE;
 
-  return piece->module->dev->gui_module
-      && piece->module->dev->gui_module != piece->module
-      && (piece->module->dev->gui_module->operation_tags_filter() & piece->module->operation_tags())
-      && (piece->pipe->type & DT_DEV_PIXELPIPE_BASIC);
+  return dt_iop_module_is_skipped(piece->module->dev, piece->module)
+          && (piece->pipe->type & DT_DEV_PIXELPIPE_BASIC);
 }
 
 // recursive helper for process, returns TRUE in case of unfinished work or error

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4138,10 +4138,10 @@ static int call_distort_transform(dt_develop_t *dev,
   dt_dev_pixelpipe_iop_t *piece =
     dt_dev_distort_get_iop_pipe(self->dev, self->dev->preview_pipe, self);
   if(!piece) return ret;
-  if(piece->module == self && /*piece->enabled && */  //see note below
-     !(dev->gui_module
-        && (dev->gui_module->operation_tags_filter() & piece->module->operation_tags())
-        && (pipe->type & DT_DEV_PIXELPIPE_BASIC)))
+  if(piece->module == self
+      // && *piece->enabled see note below
+      && !(dt_iop_module_is_skipped(dev, piece->module)
+            && (pipe->type & DT_DEV_PIXELPIPE_BASIC)))
   {
     ret = piece->module->distort_transform(piece->module, piece, points, points_count);
   }


### PR DESCRIPTION
introduce
gboolean dt_iop_module_is_skipped(const struct dt_develop_t *dev, const struct dt_iop_module_t *module);

and make use of it for maintenance