### PR TITLE
Fix dt_view_get_view_context()

### DIFF
--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1813,12 +1813,13 @@ dt_view_context_t dt_view_get_view_context(void)
 
   dt_view_context_t ctx = 0;
   ADD_TO_CONTEXT(closeup);
-  ADD_TO_CONTEXT(zoom_scale * flt_prec);
-  ADD_TO_CONTEXT(zoom_x * flt_prec);
-  ADD_TO_CONTEXT(zoom_y * flt_prec);
+  ADD_TO_CONTEXT((int)(zoom_scale * flt_prec));
+  ADD_TO_CONTEXT((int)(zoom_x * flt_prec));
+  ADD_TO_CONTEXT((int)(zoom_y * flt_prec));
   ADD_TO_CONTEXT(iso_12646);
   ADD_TO_CONTEXT(focus_peaking);
 
+  // dt_print(DT_DEBUG_EXPOSE, "dt_view_get_view_context ctx==%" PRIx64 " scale=%f\n", ctx, zoom_scale);
   return ctx;
 }
 


### PR DESCRIPTION
we pass the int-casted data to the macro

To reproduce the issue:
- for observation use: `-d pipe -d expose`
- open image with fresh history
- do a snapshot and activate visualizing
- zoom in (done here via mouse shortcut)
- you will see constantly repeated patterns like here

```
    86.5457 dt_view_paint_surface      [preview]                               size 1132x1072. processed 6744x4500. buf 1132x830 scale=0.185. surface 891x1335. zoom x=3574.233 y=2291.664 scale=0.933
    86.5457 dt_view_paint_surface      [full]                                  size 1132x1072. processed 6744x4500. buf 1132x830 scale=0.185. surface 1132x830. zoom x=3574.233 y=2291.664 scale=0.933
    86.5825 dt_view_paint_surface      [preview]                               size 1132x1072. processed 6744x4500. buf 1132x830 scale=0.185. surface 891x1335. zoom x=3574.233 y=2291.664 scale=0.933
    86.5825 dt_view_paint_surface      [full]                                  size 1132x1072. processed 6744x4500. buf 1132x830 scale=0.185. surface 1132x830. zoom x=3574.233 y=2291.664 scale=0.933
    86.6371 dt_view_paint_surface      [preview]                               size 1132x1072. processed 6744x4500. buf 1132x830 scale=0.185. surface 891x1335. zoom x=3574.233 y=2291.664 scale=0.933
    86.6371 dt_view_paint_surface      [full]                                  size 1132x1072. processed 6744x4500. buf 1132x830 scale=0.185. surface 1132x830. zoom x=3574.233 y=2291.664 scale=0.933
    86.6976 dt_view_paint_surface      [preview]                               size 1132x1072. processed 6744x4500. buf 1132x830 scale=0.185. surface 891x1335. zoom x=3574.233 y=2291.664 scale=0.933
    86.6976 dt_view_paint_surface      [full]                                  size 1132x1072. processed 6744x4500. buf 1132x830 scale=0.185. surface 1132x830. zoom x=3574.233 y=2291.664 scale=0.933
    86.7993 dt_dev_pixelpipe_synch_all [full/dev]                              defaults 0.0344s, history 0.0082s
    86.7994 pixelpipe_cache_checkmem   [full/dev]                              64 lines (important=0, used=0). Freed 0MB. Using using 0MB, limit=1002MB
    86.7994 pixelpipe starting CL      [full/dev]                              (  69/   0) 1132x 830 scale=0.1846 --> (  69/   0) 1132x 830 scale=0.1846 device=0 (nvidiacudaquadrortx4000)
    86.7999 modify roi IN              [full/dev]       lens                   (  68/   0) 1132x 829 scale=0.1846 --> (  69/   0) 1132x 830 scale=0.1846 
    86.7999 modify roi IN              [full/dev]       demosaic               ( 368/   0) 6130x4489 scale=1.0000 --> (  68/   0) 1132x 829 scale=0.1846 
    86.7999 modify roi IN              [full/dev]       highlights             (   0/   0) 6744x4500 scale=1.0000 --> ( 368/   0) 6130x4489 scale=1.0000 
    86.8000 modify roi IN              [full/dev]       rawprepare             (   0/   0) 6880x4544 scale=1.0000 --> (   0/   0) 6744x4500 scale=1.0000 
    86.8000 pixelpipe data: full       [full/dev]                              (   0/   0) 6880x4544 scale=1.0000 --> (   0/   0) 6880x4544 scale=1.0000 
```

The reason is the viewport hash being not "stable"