### PR TITLE
make distort functions return a gboolean

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -3083,16 +3083,17 @@ gchar *dt_history_item_get_name(const struct dt_iop_module_t *module)
   return label;
 }
 
-int dt_dev_distort_transform(dt_develop_t *dev,
-                             float *points,
-                             const size_t points_count)
+gboolean dt_dev_distort_transform(dt_develop_t *dev,
+                                  float *points,
+                                  const size_t points_count)
 {
   return dt_dev_distort_transform_plus
     (dev, dev->preview_pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
 }
-int dt_dev_distort_backtransform(dt_develop_t *dev,
-                                 float *points,
-                                 const size_t points_count)
+
+gboolean dt_dev_distort_backtransform(dt_develop_t *dev,
+                                      float *points,
+                                      const size_t points_count)
 {
   return dt_dev_distort_backtransform_plus
     (dev, dev->preview_pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
@@ -3101,12 +3102,12 @@ int dt_dev_distort_backtransform(dt_develop_t *dev,
 // only call directly or indirectly from
 // dt_dev_distort_transform_plus, so that it runs with the history
 // locked
-int dt_dev_distort_transform_locked(dt_develop_t *dev,
-                                    dt_dev_pixelpipe_t *pipe,
-                                    const double iop_order,
-                                    const int transf_direction,
-                                    float *points,
-                                    const size_t points_count)
+gboolean dt_dev_distort_transform_locked(dt_develop_t *dev,
+                                         dt_dev_pixelpipe_t *pipe,
+                                         const double iop_order,
+                                         const int transf_direction,
+                                         float *points,
+                                         const size_t points_count)
 {
   GList *modules = pipe->iop;
   GList *pieces = pipe->nodes;
@@ -3114,7 +3115,7 @@ int dt_dev_distort_transform_locked(dt_develop_t *dev,
   {
     if(!pieces)
     {
-      return 0;
+      return FALSE;
     }
     dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
     dt_dev_pixelpipe_iop_t *piece = (dt_dev_pixelpipe_iop_t *)(pieces->data);
@@ -3137,32 +3138,32 @@ int dt_dev_distort_transform_locked(dt_develop_t *dev,
     modules = g_list_next(modules);
     pieces = g_list_next(pieces);
   }
-  return 1;
+  return TRUE;
 }
 
-int dt_dev_distort_transform_plus(dt_develop_t *dev,
-                                  dt_dev_pixelpipe_t *pipe,
-                                  const double iop_order,
-                                  const int transf_direction,
-                                  float *points,
-                                  const size_t points_count)
+gboolean dt_dev_distort_transform_plus(dt_develop_t *dev,
+                                       dt_dev_pixelpipe_t *pipe,
+                                       const double iop_order,
+                                       const int transf_direction,
+                                       float *points,
+                                       const size_t points_count)
 {
   dt_pthread_mutex_lock(&dev->history_mutex);
   dt_dev_distort_transform_locked(dev, pipe, iop_order, transf_direction,
                                   points, points_count);
   dt_pthread_mutex_unlock(&dev->history_mutex);
-  return 1;
+  return TRUE;
 }
 
 // only call directly or indirectly from
 // dt_dev_distort_transform_plus, so that it runs with the history
 // locked
-int dt_dev_distort_backtransform_locked(dt_develop_t *dev,
-                                        dt_dev_pixelpipe_t *pipe,
-                                        const double iop_order,
-                                        const int transf_direction,
-                                        float *points,
-                                        const size_t points_count)
+gboolean dt_dev_distort_backtransform_locked(dt_develop_t *dev,
+                                             dt_dev_pixelpipe_t *pipe,
+                                             const double iop_order,
+                                             const int transf_direction,
+                                             float *points,
+                                             const size_t points_count)
 {
   GList *modules = g_list_last(pipe->iop);
   GList *pieces = g_list_last(pipe->nodes);
@@ -3170,7 +3171,7 @@ int dt_dev_distort_backtransform_locked(dt_develop_t *dev,
   {
     if(!pieces)
     {
-      return 0;
+      return FALSE;
     }
     dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
     dt_dev_pixelpipe_iop_t *piece = (dt_dev_pixelpipe_iop_t *)(pieces->data);
@@ -3193,18 +3194,18 @@ int dt_dev_distort_backtransform_locked(dt_develop_t *dev,
     modules = g_list_previous(modules);
     pieces = g_list_previous(pieces);
   }
-  return 1;
+  return TRUE;
 }
 
-int dt_dev_distort_backtransform_plus(dt_develop_t *dev,
-                                      dt_dev_pixelpipe_t *pipe,
-                                      const double iop_order,
-                                      const int transf_direction,
-                                      float *points,
-                                      const size_t points_count)
+gboolean dt_dev_distort_backtransform_plus(dt_develop_t *dev,
+                                           dt_dev_pixelpipe_t *pipe,
+                                           const double iop_order,
+                                           const int transf_direction,
+                                           float *points,
+                                           const size_t points_count)
 {
   dt_pthread_mutex_lock(&dev->history_mutex);
-  const int success = dt_dev_distort_backtransform_locked
+  const gboolean success = dt_dev_distort_backtransform_locked
     (dev, pipe, iop_order,
      transf_direction, points, points_count);
   dt_pthread_mutex_unlock(&dev->history_mutex);
@@ -3270,12 +3271,12 @@ uint64_t dt_dev_hash_plus(dt_develop_t *dev,
   return hash;
 }
 
-int dt_dev_wait_hash(dt_develop_t *dev,
-                     struct dt_dev_pixelpipe_t *pipe,
-                     const double iop_order,
-                     const int transf_direction,
-                     dt_pthread_mutex_t *lock,
-                     const volatile uint64_t *const hash)
+gboolean dt_dev_wait_hash(dt_develop_t *dev,
+                          struct dt_dev_pixelpipe_t *pipe,
+                          const double iop_order,
+                          const int transf_direction,
+                          dt_pthread_mutex_t *lock,
+                          const volatile uint64_t *const hash)
 {
   const int usec = 5000;
   int nloop;
@@ -3316,12 +3317,12 @@ int dt_dev_wait_hash(dt_develop_t *dev,
   return FALSE;
 }
 
-int dt_dev_sync_pixelpipe_hash(dt_develop_t *dev,
-                               struct dt_dev_pixelpipe_t *pipe,
-                               const double iop_order,
-                               const int transf_direction,
-                               dt_pthread_mutex_t *lock,
-                               const volatile uint64_t *const hash)
+gboolean dt_dev_sync_pixelpipe_hash(dt_develop_t *dev,
+                                    struct dt_dev_pixelpipe_t *pipe,
+                                    const double iop_order,
+                                    const int transf_direction,
+                                    dt_pthread_mutex_t *lock,
+                                    const volatile uint64_t *const hash)
 {
   // first wait for matching hash values
   if(dt_dev_wait_hash(dev, pipe, iop_order, transf_direction, lock, hash))
@@ -3383,12 +3384,13 @@ uint64_t dt_dev_hash_distort_plus(dt_develop_t *dev,
   return hash;
 }
 
-int dt_dev_wait_hash_distort(dt_develop_t *dev,
-                             struct dt_dev_pixelpipe_t *pipe,
-                             const double iop_order,
-                             const int transf_direction,
-                             dt_pthread_mutex_t *lock,
-                             const volatile uint64_t *const hash)
+/*
+gboolean dt_dev_wait_hash_distort(dt_develop_t *dev,
+                                  struct dt_dev_pixelpipe_t *pipe,
+                                  const double iop_order,
+                                  const int transf_direction,
+                                  dt_pthread_mutex_t *lock,
+                                  const volatile uint64_t *const hash)
 {
   const int usec = 5000;
   int nloop = 0;
@@ -3429,12 +3431,12 @@ int dt_dev_wait_hash_distort(dt_develop_t *dev,
   return FALSE;
 }
 
-int dt_dev_sync_pixelpipe_hash_distort(dt_develop_t *dev,
-                                       struct dt_dev_pixelpipe_t *pipe,
-                                       const double iop_order,
-                                       const int transf_direction,
-                                       dt_pthread_mutex_t *lock,
-                                       const volatile uint64_t *const hash)
+gboolean dt_dev_sync_pixelpipe_hash_distort(dt_develop_t *dev,
+                                            struct dt_dev_pixelpipe_t *pipe,
+                                            const double iop_order,
+                                            const int transf_direction,
+                                            dt_pthread_mutex_t *lock,
+                                            const volatile uint64_t *const hash)
 {
   // first wait for matching hash values
   if(dt_dev_wait_hash_distort(dev, pipe, iop_order, transf_direction, lock, hash))
@@ -3452,7 +3454,7 @@ int dt_dev_sync_pixelpipe_hash_distort(dt_develop_t *dev,
   // no way to get pixelpipes in sync
   return FALSE;
 }
-
+*/
 // set the module list order
 void dt_dev_reorder_gui_module_list(dt_develop_t *dev)
 {

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -528,15 +528,15 @@ gchar *dt_history_item_get_name(const struct dt_iop_module_t *module);
  * distort functions
  */
 /** apply all transforms to the specified points (in preview pipe space) */
-int dt_dev_distort_transform(dt_develop_t *dev,
+gboolean dt_dev_distort_transform(dt_develop_t *dev,
                              float *points,
                              const size_t points_count);
 /** reverse apply all transforms to the specified points (in preview pipe space) */
-int dt_dev_distort_backtransform(dt_develop_t *dev,
+gboolean dt_dev_distort_backtransform(dt_develop_t *dev,
                                  float *points,
                                  const size_t points_count);
 /** same fct, but we can specify iop with priority between pmin and pmax */
-int dt_dev_distort_transform_plus(dt_develop_t *dev,
+gboolean dt_dev_distort_transform_plus(dt_develop_t *dev,
                                   struct dt_dev_pixelpipe_t *pipe,
                                   const double iop_order,
                                   const int transf_direction,
@@ -544,7 +544,7 @@ int dt_dev_distort_transform_plus(dt_develop_t *dev,
                                   const size_t points_count);
 /** same fct, but can only be called from a distort_transform function
  * called by dt_dev_distort_transform_plus */
-int dt_dev_distort_transform_locked(dt_develop_t *dev,
+gboolean dt_dev_distort_transform_locked(dt_develop_t *dev,
                                     struct dt_dev_pixelpipe_t *pipe,
                                     const double iop_order,
                                     const int transf_direction,
@@ -552,7 +552,7 @@ int dt_dev_distort_transform_locked(dt_develop_t *dev,
                                     const size_t points_count);
 /** same fct as dt_dev_distort_backtransform, but we can specify iop
  * with priority between pmin and pmax */
-int dt_dev_distort_backtransform_plus(dt_develop_t *dev,
+gboolean dt_dev_distort_backtransform_plus(dt_develop_t *dev,
                                       struct dt_dev_pixelpipe_t *pipe,
                                       const double iop_order,
                                       const int transf_direction,
@@ -560,7 +560,7 @@ int dt_dev_distort_backtransform_plus(dt_develop_t *dev,
                                       const size_t points_count);
 /** same fct, but can only be called from a distort_backtransform
  * function called by dt_dev_distort_backtransform_plus */
-int dt_dev_distort_backtransform_locked(dt_develop_t *dev,
+gboolean dt_dev_distort_backtransform_locked(dt_develop_t *dev,
                                         struct dt_dev_pixelpipe_t *pipe,
                                         const double iop_order,
                                         const int transf_direction,
@@ -583,7 +583,7 @@ uint64_t dt_dev_hash_plus(dt_develop_t *dev,
                           const int transf_direction);
 /** wait until hash value found in hash matches hash value defined by
  * dev/pipe/pmin/pmax with timeout */
-int dt_dev_wait_hash(dt_develop_t *dev,
+gboolean dt_dev_wait_hash(dt_develop_t *dev,
                      struct dt_dev_pixelpipe_t *pipe,
                      const double iop_order,
                      const int transf_direction,
@@ -591,7 +591,7 @@ int dt_dev_wait_hash(dt_develop_t *dev,
                      const volatile uint64_t *const hash);
 /** synchronize pixelpipe by means hash values by waiting with timeout
  * and potential reprocessing */
-int dt_dev_sync_pixelpipe_hash(dt_develop_t *dev,
+gboolean dt_dev_sync_pixelpipe_hash(dt_develop_t *dev,
                                struct dt_dev_pixelpipe_t *pipe,
                                const double iop_order,
                                const int transf_direction,
@@ -604,21 +604,22 @@ uint64_t dt_dev_hash_distort_plus(dt_develop_t *dev,
                                   struct dt_dev_pixelpipe_t *pipe,
                                   const double iop_order,
                                   const int transf_direction);
-/** same as dt_dev_wait_hash but only for distorting modules */
-int dt_dev_wait_hash_distort(dt_develop_t *dev,
+/** same as dt_dev_wait_hash but only for distorting modules
+gboolean dt_dev_wait_hash_distort(dt_develop_t *dev,
                              struct dt_dev_pixelpipe_t *pipe,
                              const double iop_order,
                              const int transf_direction,
                              dt_pthread_mutex_t *lock,
                              const volatile uint64_t *const hash);
-/** same as dt_dev_sync_pixelpipe_hash but only for distorting modules */
-int dt_dev_sync_pixelpipe_hash_distort (dt_develop_t *dev,
+*/
+/** same as dt_dev_sync_pixelpipe_hash but only for distorting modules
+gboolean dt_dev_sync_pixelpipe_hash_distort (dt_develop_t *dev,
                                         struct dt_dev_pixelpipe_t *pipe,
                                         const double iop_order,
                                         const int transf_direction,
                                         dt_pthread_mutex_t *lock,
                                         const volatile uint64_t *const hash);
-
+*/
 /*
  *   history undo support helpers for darkroom
  */

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -186,19 +186,19 @@ static void default_cleanup(dt_iop_module_t *module)
 }
 
 
-static int default_distort_transform(dt_iop_module_t *self,
-                                     dt_dev_pixelpipe_iop_t *piece,
-                                     float *points,
-                                     size_t points_count)
+static gboolean default_distort_transform(dt_iop_module_t *self,
+                                          dt_dev_pixelpipe_iop_t *piece,
+                                          float *points,
+                                          size_t points_count)
 {
-  return 1;
+  return TRUE;
 }
-static int default_distort_backtransform(dt_iop_module_t *self,
-                                         dt_dev_pixelpipe_iop_t *piece,
-                                         float *points,
-                                         size_t points_count)
+static gboolean default_distort_backtransform(dt_iop_module_t *self,
+                                              dt_dev_pixelpipe_iop_t *piece,
+                                              float *points,
+                                              size_t points_count)
 {
-  return 1;
+  return TRUE;
 }
 
 static void default_process(struct dt_iop_module_t *self,

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -1015,15 +1015,15 @@ static inline int isneutral(const dt_iop_ashift_data_t *data)
 }
 
 
-int distort_transform(dt_iop_module_t *self,
-                      dt_dev_pixelpipe_iop_t *piece,
-                      float *const restrict points,
-                      const size_t points_count)
+gboolean distort_transform(dt_iop_module_t *self,
+                           dt_dev_pixelpipe_iop_t *piece,
+                           float *const restrict points,
+                           const size_t points_count)
 {
   const dt_iop_ashift_data_t *const data = (dt_iop_ashift_data_t *)piece->data;
 
   // nothing to be done if parameters are set to neutral values
-  if(isneutral(data)) return 1;
+  if(isneutral(data)) return TRUE;
 
   float DT_ALIGNED_ARRAY homograph[3][3];
   _homography((float *)homograph, data->rotation, data->lensshift_v, data->lensshift_h,
@@ -1051,19 +1051,19 @@ int distort_transform(dt_iop_module_t *self,
     points[i + 1] = po[1] / po[2] - cy;
   }
 
-  return 1;
+  return TRUE;
 }
 
 
-int distort_backtransform(dt_iop_module_t *self,
-                          dt_dev_pixelpipe_iop_t *piece,
-                          float *points,
-                          const size_t points_count)
+gboolean distort_backtransform(dt_iop_module_t *self,
+                               dt_dev_pixelpipe_iop_t *piece,
+                               float *points,
+                               const size_t points_count)
 {
   const dt_iop_ashift_data_t *const data = (dt_iop_ashift_data_t *)piece->data;
 
   // nothing to be done if parameters are set to neutral values
-  if(isneutral(data)) return 1;
+  if(isneutral(data)) return TRUE;
 
   float DT_ALIGNED_ARRAY ihomograph[3][3];
   _homography((float *)ihomograph, data->rotation, data->lensshift_v, data->lensshift_h,
@@ -1091,7 +1091,7 @@ int distort_backtransform(dt_iop_module_t *self,
     points[i + 1] = po[1] / po[2];
   }
 
-  return 1;
+  return TRUE;
 }
 
 void distort_mask(struct dt_iop_module_t *self,

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -349,10 +349,10 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
   return IOP_CS_RGB;
 }
 
-int distort_transform(dt_iop_module_t *self,
-                      dt_dev_pixelpipe_iop_t *piece,
-                      float *const restrict points,
-                      size_t points_count)
+gboolean distort_transform(dt_iop_module_t *self,
+                           dt_dev_pixelpipe_iop_t *piece,
+                           float *const restrict points,
+                           size_t points_count)
 {
   dt_iop_borders_data_t *d = (dt_iop_borders_data_t *)piece->data;
 
@@ -362,7 +362,7 @@ int distort_transform(dt_iop_module_t *self,
   const int border_size_l = border_tot_width * d->pos_h;
 
   // nothing to be done if parameters are set to neutral values (no top/left border)
-  if(border_size_l == 0 && border_size_t == 0) return 1;
+  if(border_size_l == 0 && border_size_t == 0) return TRUE;
 
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) \
@@ -375,12 +375,13 @@ int distort_transform(dt_iop_module_t *self,
     points[i + 1] += border_size_t;
   }
 
-  return 1;
+  return TRUE;
 }
-int distort_backtransform(dt_iop_module_t *self,
-                          dt_dev_pixelpipe_iop_t *piece,
-                          float *const restrict points,
-                          size_t points_count)
+
+gboolean distort_backtransform(dt_iop_module_t *self,
+                               dt_dev_pixelpipe_iop_t *piece,
+                               float *const restrict points,
+                               size_t points_count)
 {
   dt_iop_borders_data_t *d = (dt_iop_borders_data_t *)piece->data;
 
@@ -390,7 +391,7 @@ int distort_backtransform(dt_iop_module_t *self,
   const int border_size_l = border_tot_width * d->pos_h;
 
   // nothing to be done if parameters are set to neutral values (no top/left border)
-  if(border_size_l == 0 && border_size_t == 0) return 1;
+  if(border_size_l == 0 && border_size_t == 0) return TRUE;
 
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) \
@@ -403,7 +404,7 @@ int distort_backtransform(dt_iop_module_t *self,
     points[i + 1] -= border_size_t;
   }
 
-  return 1;
+  return TRUE;
 }
 
 void distort_mask(struct dt_iop_module_t *self,

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -495,7 +495,10 @@ static inline void transform(float *x, float *o, const float *m, const float t_h
   o[0] *= (1.0f + o[1] * t_v);
 }
 
-int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *const restrict points, size_t points_count)
+gboolean distort_transform(dt_iop_module_t *self,
+                           dt_dev_pixelpipe_iop_t *piece,
+                           float *const restrict points,
+                           size_t points_count)
 {
   // as dt_iop_roi_t contain int values and not floats, we can have some rounding errors
   // as a workaround, we use a factor for preview pipes
@@ -562,10 +565,12 @@ int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, floa
     self->modify_roi_out(self, piece, &roi_out, &roi_in);
   }
 
-  return 1;
+  return TRUE;
 }
-int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *const restrict points,
-                          size_t points_count)
+gboolean distort_backtransform(dt_iop_module_t *self,
+                               dt_dev_pixelpipe_iop_t *piece,
+                               float *const restrict points,
+                               size_t points_count)
 {
   // as dt_iop_roi_t contain int values and not floats, we can have some rounding errors
   // as a workaround, we use a factor for preview pipes
@@ -632,11 +637,15 @@ int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, 
     self->modify_roi_out(self, piece, &roi_out, &roi_in);
   }
 
-  return 1;
+  return TRUE;
 }
 
-void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const float *const in,
-                  float *const out, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+void distort_mask(struct dt_iop_module_t *self,
+                  struct dt_dev_pixelpipe_iop_t *piece,
+                  const float *const in,
+                  float *const out,
+                  const dt_iop_roi_t *const roi_in,
+                  const dt_iop_roi_t *const roi_out)
 {
   dt_iop_clipping_data_t *d = (dt_iop_clipping_data_t *)piece->data;
 

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -271,10 +271,10 @@ static int _set_max_clip(struct dt_iop_module_t *self)
   return 1;
 }
 
-int distort_transform(dt_iop_module_t *self,
-                      dt_dev_pixelpipe_iop_t *piece,
-                      float *const restrict points,
-                      size_t points_count)
+gboolean distort_transform(dt_iop_module_t *self,
+                           dt_dev_pixelpipe_iop_t *piece,
+                           float *const restrict points,
+                           size_t points_count)
 {
   dt_iop_crop_data_t *d = (dt_iop_crop_data_t *)piece->data;
 
@@ -282,7 +282,7 @@ int distort_transform(dt_iop_module_t *self,
   const float crop_left = piece->buf_in.width * d->cx;
 
   // nothing to be done if parameters are set to neutral values (no top/left border)
-  if(crop_top == 0 && crop_left == 0) return 1;
+  if(crop_top == 0 && crop_left == 0) return TRUE;
 
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) dt_omp_firstprivate(points, points_count, crop_left, crop_top)        \
@@ -294,13 +294,13 @@ int distort_transform(dt_iop_module_t *self,
     points[i + 1] -= crop_top;
   }
 
-  return 1;
+  return TRUE;
 }
 
-int distort_backtransform(dt_iop_module_t *self,
-                          dt_dev_pixelpipe_iop_t *piece,
-                          float *const restrict points,
-                          size_t points_count)
+gboolean distort_backtransform(dt_iop_module_t *self,
+                               dt_dev_pixelpipe_iop_t *piece,
+                               float *const restrict points,
+                               size_t points_count)
 {
   dt_iop_crop_data_t *d = (dt_iop_crop_data_t *)piece->data;
 
@@ -308,7 +308,7 @@ int distort_backtransform(dt_iop_module_t *self,
   const float crop_left = piece->buf_in.width * d->cx;
 
   // nothing to be done if parameters are set to neutral values (no top/left border)
-  if(crop_top == 0 && crop_left == 0) return 1;
+  if(crop_top == 0 && crop_left == 0) return TRUE;
 
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) dt_omp_firstprivate(points, points_count, crop_left, crop_top)        \
@@ -320,7 +320,7 @@ int distort_backtransform(dt_iop_module_t *self,
     points[i + 1] += crop_top;
   }
 
-  return 1;
+  return TRUE;
 }
 
 void distort_mask(struct dt_iop_module_t *self,

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -214,16 +214,15 @@ static void backtransform(const int32_t *x,
   }
 }
 
-int distort_transform(dt_iop_module_t *self,
-                      dt_dev_pixelpipe_iop_t *piece,
-                      float *const restrict points,
-                      const size_t points_count)
+gboolean distort_transform(dt_iop_module_t *self,
+                           dt_dev_pixelpipe_iop_t *piece,
+                           float *const restrict points,
+                           const size_t points_count)
 {
-  // if(!self->enabled) return 2;
   const dt_iop_flip_data_t *d = (dt_iop_flip_data_t *)piece->data;
 
   // nothing to be done if parameters are set to neutral values (no flip or swap)
-  if(d->orientation == 0) return 1;
+  if(d->orientation == 0) return TRUE;
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
@@ -251,19 +250,18 @@ int distort_transform(dt_iop_module_t *self,
     points[i + 1] = y;
   }
 
-  return 1;
+  return TRUE;
 }
 
-int distort_backtransform(dt_iop_module_t *self,
-                          dt_dev_pixelpipe_iop_t *piece,
-                          float *const restrict points,
-                          const size_t points_count)
+gboolean distort_backtransform(dt_iop_module_t *self,
+                               dt_dev_pixelpipe_iop_t *piece,
+                               float *const restrict points,
+                               const size_t points_count)
 {
-  // if(!self->enabled) return 2;
   const dt_iop_flip_data_t *d = (dt_iop_flip_data_t *)piece->data;
 
   // nothing to be done if parameters are set to neutral values (no flip or swap)
-  if(d->orientation == 0) return 1;
+  if(d->orientation == 0) return TRUE;
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
@@ -290,7 +288,7 @@ int distort_backtransform(dt_iop_module_t *self,
     points[i + 1] = y;
   }
 
-  return 1;
+  return TRUE;
 }
 
 void distort_mask(struct dt_iop_module_t *self,

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -268,12 +268,12 @@ DEFAULT(int, process_tiling_cl, struct dt_iop_module_t *self,
  * points is an array of float {x1,y1,x2,y2,...}
  * size is 2*points_count */
 /** points before the iop is applied => point after processed */
-DEFAULT(int, distort_transform, struct dt_iop_module_t *self,
+DEFAULT(gboolean, distort_transform, struct dt_iop_module_t *self,
                                 struct dt_dev_pixelpipe_iop_t *piece,
                                 float *points,
                                 size_t points_count);
 /** reverse points after the iop is applied => point before process */
-DEFAULT(int, distort_backtransform, struct dt_iop_module_t *self,
+DEFAULT(gboolean, distort_backtransform, struct dt_iop_module_t *self,
                                     struct dt_dev_pixelpipe_iop_t *piece,
                                     float *points,
                                     size_t points_count);

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1292,11 +1292,11 @@ void modify_roi_in(struct dt_iop_module_t *module,
   cairo_region_destroy(roi_in_region);
 }
 
-static int _distort_xtransform(dt_iop_module_t *self,
-                               dt_dev_pixelpipe_iop_t *piece,
-                               float *const restrict points,
-                               const size_t points_count,
-                               const gboolean inverted)
+static gboolean _distort_xtransform(dt_iop_module_t *self,
+                                    dt_dev_pixelpipe_iop_t *piece,
+                                    float *const restrict points,
+                                    const size_t points_count,
+                                    const gboolean inverted)
 {
   const float scale = piece->iscale;
 
@@ -1339,7 +1339,7 @@ static int _distort_xtransform(dt_iop_module_t *self,
     _build_global_distortion_map(self, piece, scale, TRUE, &roi_in,
                                  &extent, inverted, &map);
 
-    if(map == NULL) return 0;
+    if(map == NULL) return FALSE;
 
     const int map_size =  extent.width * extent.height;
     const int x_last = extent.x + extent.width;
@@ -1376,7 +1376,7 @@ static int _distort_xtransform(dt_iop_module_t *self,
     dt_free_align((void *) map);
   }
 
-  return 1;
+  return TRUE;
 }
 
 static void start_drag(dt_iop_liquify_gui_data_t *g,
@@ -1397,18 +1397,18 @@ static gboolean is_dragging(const dt_iop_liquify_gui_data_t *g)
   return g->dragging.elem != NULL;
 }
 
-int distort_transform(dt_iop_module_t *self,
-                      dt_dev_pixelpipe_iop_t *piece,
-                      float *const restrict points,
-                      const size_t points_count)
+gboolean distort_transform(dt_iop_module_t *self,
+                           dt_dev_pixelpipe_iop_t *piece,
+                           float *const restrict points,
+                           const size_t points_count)
 {
   return _distort_xtransform(self, piece, points, points_count, TRUE);
 }
 
-int distort_backtransform(dt_iop_module_t *self,
-                          dt_dev_pixelpipe_iop_t *piece,
-                          float *const restrict points,
-                          const size_t points_count)
+gboolean distort_backtransform(dt_iop_module_t *self,
+                               dt_dev_pixelpipe_iop_t *piece,
+                               float *const restrict points,
+                               const size_t points_count)
 {
   return _distort_xtransform(self, piece, points, points_count, FALSE);
 }

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -204,16 +204,15 @@ static int _compute_proper_crop(dt_dev_pixelpipe_iop_t *piece,
   return (int)roundf((float)value * scale);
 }
 
-int distort_transform(
-        dt_iop_module_t *self,
-        dt_dev_pixelpipe_iop_t *piece,
-        float *const restrict points,
-        size_t points_count)
+gboolean distort_transform(dt_iop_module_t *self,
+                           dt_dev_pixelpipe_iop_t *piece,
+                           float *const restrict points,
+                           size_t points_count)
 {
   dt_iop_rawprepare_data_t *d = (dt_iop_rawprepare_data_t *)piece->data;
 
   // nothing to be done if parameters are set to neutral values (no top/left crop)
-  if(d->left == 0 && d->top == 0) return 1;
+  if(d->left == 0 && d->top == 0) return TRUE;
 
   const float scale = piece->buf_in.scale / piece->iscale;
 
@@ -232,19 +231,18 @@ int distort_transform(
     points[i + 1] -= y;
   }
 
-  return 1;
+  return TRUE;
 }
 
-int distort_backtransform(
-        dt_iop_module_t *self,
-        dt_dev_pixelpipe_iop_t *piece,
-        float *const restrict points,
-        size_t points_count)
+gboolean distort_backtransform(dt_iop_module_t *self,
+                               dt_dev_pixelpipe_iop_t *piece,
+                               float *const restrict points,
+                               size_t points_count)
 {
   dt_iop_rawprepare_data_t *d = (dt_iop_rawprepare_data_t *)piece->data;
 
   // nothing to be done if parameters are set to neutral values (no top/left crop)
-  if(d->left == 0 && d->top == 0) return 1;
+  if(d->left == 0 && d->top == 0) return TRUE;
 
   const float scale = piece->buf_in.scale / piece->iscale;
 
@@ -263,7 +261,7 @@ int distort_backtransform(
     points[i + 1] += y;
   }
 
-  return 1;
+  return TRUE;
 }
 
 void distort_mask(

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -105,7 +105,9 @@ const char **description(struct dt_iop_module_t *self)
 #ifdef _OPENMP
 #pragma omp declare simd
 #endif
-static void transform(const dt_dev_pixelpipe_iop_t *const piece, const float scale, const float *const x,
+static void transform(const dt_dev_pixelpipe_iop_t *const piece,
+                      const float scale,
+                      const float *const x,
                       float *o)
 {
   dt_iop_rotatepixels_data_t *d = (dt_iop_rotatepixels_data_t *)piece->data;
@@ -119,7 +121,9 @@ static void transform(const dt_dev_pixelpipe_iop_t *const piece, const float sca
 #ifdef _OPENMP
 #pragma omp declare simd
 #endif
-static void backtransform(const dt_dev_pixelpipe_iop_t *const piece, const float scale, const float *const x,
+static void backtransform(const dt_dev_pixelpipe_iop_t *const piece,
+                          const float scale,
+                          const float *const x,
                           float *o)
 {
   dt_iop_rotatepixels_data_t *d = (dt_iop_rotatepixels_data_t *)piece->data;
@@ -131,7 +135,10 @@ static void backtransform(const dt_dev_pixelpipe_iop_t *const piece, const float
   o[1] += d->ry * scale;
 }
 
-int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *const restrict points, size_t points_count)
+gboolean distort_transform(dt_iop_module_t *self,
+                           dt_dev_pixelpipe_iop_t *piece,
+                           float *const restrict points,
+                           size_t points_count)
 {
   const float scale = piece->buf_in.scale / piece->iscale;
 
@@ -153,11 +160,13 @@ int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, floa
     points[i + 1] = po[1];
   }
 
-  return 1;
+  return TRUE;
 }
 
-int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *const restrict points,
-                          size_t points_count)
+gboolean distort_backtransform(dt_iop_module_t *self,
+                               dt_dev_pixelpipe_iop_t *piece,
+                               float *const restrict points,
+                               size_t points_count)
 {
   const float scale = piece->buf_in.scale / piece->iscale;
 
@@ -179,11 +188,15 @@ int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, 
     points[i + 1] = po[1];
   }
 
-  return 1;
+  return TRUE;
 }
 
-void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const float *const in,
-                  float *const out, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+void distort_mask(struct dt_iop_module_t *self,
+                  struct dt_dev_pixelpipe_iop_t *piece,
+                  const float *const in,
+                  float *const out,
+                  const dt_iop_roi_t *const roi_in,
+                  const dt_iop_roi_t *const roi_out)
 {
   // TODO
   memset(out, 0, sizeof(float) * roi_out->width * roi_out->height);

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -111,7 +111,10 @@ static void precalculate_scale(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
   self->modify_roi_in(self, piece, &roi_out, &roi_in);
 }
 
-int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *points, size_t points_count)
+gboolean distort_transform(dt_iop_module_t *self,
+                           dt_dev_pixelpipe_iop_t *piece,
+                           float *points,
+                           size_t points_count)
 {
   precalculate_scale(self, piece);
   dt_iop_scalepixels_data_t *d = piece->data;
@@ -122,11 +125,13 @@ int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, floa
     points[i+1] /= d->y_scale;
   }
 
-  return 1;
+  return TRUE;
 }
 
-int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *points,
-                          size_t points_count)
+gboolean distort_backtransform(dt_iop_module_t *self,
+                               dt_dev_pixelpipe_iop_t *piece,
+                               float *points,
+                               size_t points_count)
 {
   precalculate_scale(self, piece);
   dt_iop_scalepixels_data_t *d = piece->data;
@@ -137,7 +142,7 @@ int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, 
     points[i+1] *= d->y_scale;
   }
 
-  return 1;
+  return TRUE;
 }
 
 void distort_mask(

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -282,10 +282,10 @@ void tiling_callback(struct dt_iop_module_t *self,
 #if 0
 /** modify pixel coordinates according to the pixel shifts the module
  * applies (optional, per-pixel ops don't need) */
-int distort_transform(dt_iop_module_t *self,
-                      dt_dev_pixelpipe_iop_t *piece,
-                      float *points,
-                      const size_t points_count)
+gboolean distort_transform(dt_iop_module_t *self,
+                           dt_dev_pixelpipe_iop_t *piece,
+                           float *points,
+                           const size_t points_count)
 {
   const dt_iop_useless_params_t *d = (dt_iop_useless_params_t *)piece->data;
 
@@ -294,7 +294,7 @@ int distort_transform(dt_iop_module_t *self,
 
   // nothing to be done if parameters are set to neutral values (no pixel shifts)
   if(adjx == 0.0 && adjy == 0.0)
-    return 1;
+    return TRUE;
 
   // apply the coordinate adjustment to each provided point
   for(size_t i = 0; i < points_count * 2; i += 2)
@@ -303,16 +303,16 @@ int distort_transform(dt_iop_module_t *self,
     points[i + 1] -= adjy;
   }
 
-  return 1;  // return 1 on success, 0 if one or more points could not be transformed
+  return TRUE;  // return TRUE on success, FALSE if one or more points could not be transformed
 }
 #endif
 
 #if 0
 /** undo pixel shifts the module applies (optional, per-pixel ops don't need this) */
-int distort_backtransform(dt_iop_module_t *self,
-                          dt_dev_pixelpipe_iop_t *piece,
-                          float *points,
-                          const size_t points_count)
+gboolean distort_backtransform(dt_iop_module_t *self,
+                               dt_dev_pixelpipe_iop_t *piece,
+                               float *points,
+                               const size_t points_count)
 {
   const dt_iop_useless_params_t *d = (dt_iop_useless_params_t *)piece->data;
 
@@ -320,7 +320,7 @@ int distort_backtransform(dt_iop_module_t *self,
   const float adjy = 0.0;
 
   // nothing to be done if parameters are set to neutral values (no pixel shifts)
-  if(adjx == 0.0 && adjy == 0.0) return 1;
+  if(adjx == 0.0 && adjy == 0.0) return TRUE;
 
   // apply the inverse coordinate adjustment to each provided point
   for(size_t i = 0; i < points_count * 2; i += 2)
@@ -329,7 +329,7 @@ int distort_backtransform(dt_iop_module_t *self,
     points[i + 1] += adjy;
   }
 
-  return 1;  // return 1 on success, 0 if one or more points could not be back-transformed
+  return TRUE;  // return TRUE on success, FALSE if one or more points could not be back-transformed
 }
 #endif
 


### PR DESCRIPTION
all distort functions returned an int but in fact the tests using them and returned values were bools. So all redefined as gboolean ...()

While being here two functions dt_dev_wait_hash_distort() and dt_dev_sync_pixelpipe_hash_distort() were recognized as not being used in the dt codebase and thus have been commented (we might want to make use of them later)