### PR TITLE
add missing history lock when switching images

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -326,8 +326,10 @@ void dt_dev_process_image_job(dt_develop_t *dev,
   if(pipe->loading)
   {
     // init pixel pipeline
+    dt_pthread_mutex_lock(&dev->history_mutex);
     dt_dev_pixelpipe_cleanup_nodes(pipe);
     dt_dev_pixelpipe_create_nodes(pipe, dev);
+    dt_pthread_mutex_unlock(&dev->history_mutex);
     if(pipe == dev->full.pipe)
     {
       if(dev->image_force_reload) dt_dev_pixelpipe_cache_flush(pipe);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -925,10 +925,12 @@ static gboolean _dev_load_requested_image(gpointer user_data)
   // make sure no signals propagate here:
   ++darktable.gui->reset;
 
-  const guint nb_iop = g_list_length(dev->iop);
+  dt_pthread_mutex_lock(&dev->history_mutex);
   dt_dev_pixelpipe_cleanup_nodes(dev->full.pipe);
   dt_dev_pixelpipe_cleanup_nodes(dev->preview_pipe);
   dt_dev_pixelpipe_cleanup_nodes(dev->preview2.pipe);
+
+  const guint nb_iop = g_list_length(dev->iop);
   for(int i = nb_iop - 1; i >= 0; i--)
   {
     dt_iop_module_t *module = (dt_iop_module_t *)(g_list_nth_data(dev->iop, i));
@@ -985,6 +987,7 @@ static gboolean _dev_load_requested_image(gpointer user_data)
   dt_dev_pixelpipe_create_nodes(dev->preview_pipe, dev);
   if(dev->preview2.widget && GTK_IS_WIDGET(dev->preview2.widget))
     dt_dev_pixelpipe_create_nodes(dev->preview2.pipe, dev);
+  dt_pthread_mutex_unlock(&dev->history_mutex);
   dt_dev_read_history(dev);
 
   // we have to init all module instances other than "base" instance
@@ -3124,11 +3127,12 @@ void leave(dt_view_t *self)
 
   dev->gui_leaving = TRUE;
 
+  dt_pthread_mutex_lock(&dev->history_mutex);
+
   dt_dev_pixelpipe_cleanup_nodes(dev->full.pipe);
   dt_dev_pixelpipe_cleanup_nodes(dev->preview2.pipe);
   dt_dev_pixelpipe_cleanup_nodes(dev->preview_pipe);
 
-  dt_pthread_mutex_lock(&dev->history_mutex);
   while(dev->history)
   {
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(dev->history->data);


### PR DESCRIPTION
Hoping that this finally addresses the real issue and fixes https://github.com/darktable-org/darktable/issues/15533.

Reproducing that bug is hard here, but with these changes I haven't yet been able to at all.

@sss123next Sorry to make you do all the extra work, but I'm hopeful again this is it. Would you please test and let me know? Many thanks!