### PR TITLE
fix segfault on tiny RoI

### DIFF
--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -754,6 +754,7 @@ void process(struct dt_iop_module_t *self,
   for(size_t chunk = 0; chunk < nthreads; chunk++)
   {
     size_t start = chunksize * dt_get_thread_num();
+    if (start >= npixels) continue;  // handle case when chunksize is < 4*nthreads and last thread has no work
     size_t end = MIN(start + chunksize, npixels);
     switch(mode)
     {

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -525,6 +525,7 @@ static void _transform_lcms(const dt_iop_colorout_data_t *const d,
   for(size_t chunk = 0; chunk < nthreads; chunk++)
   {
     size_t start = chunksize * dt_get_thread_num();
+    if (start >= npixels) continue;  // handle case when chunksize is < 4*nthreads and last thread has no work
     size_t count = MIN(start + chunksize, npixels) - start;
     float *const outp = out + 4 * start;
 


### PR DESCRIPTION
We have code in several iops to split the image buffer into N chunks, one per thread, such that each chunk is 64-byte aligned (cache line). When the RoI is very small such that the computed chunk size is less than 4 times the number of threads, we can have a situation where the last thread has no work to do but reducing the chunk size by 4 pixels (one cacheline) would leave unprocessed pixels.  This commit fixes the segfault resulting from the last thread interpreting a negative number of pixels as a huge positive number and overrunning the image buffer.