### PR TITLE
Visualize mask in developer mode

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2463,6 +2463,13 @@
     <shortdescription>show loading screen between images</shortdescription>
     <longdescription>show gray loading screen when navigating between images in the darkroom\ndisable to just show a toast message</longdescription>
   </dtconfig>
+  <dtconfig>
+    <name>darkroom/ui/develop_mask</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>show mask in developer mode</shortdescription>
+    <longdescription>if switched on, the mask visualize button will show the 'pure mask' instead of mask and image content.</longdescription>
+  </dtconfig>
   <dtconfig prefs="processing" section="general">
     <name>plugins/lighttable/export/pixel_interpolator_warp</name>
     <type>

--- a/src/iop/gamma.c
+++ b/src/iop/gamma.c
@@ -305,15 +305,15 @@ static void _mask_display(const float *const restrict in,
 {
   // yellow, "unused" element aids vectorization
   const dt_aligned_pixel_t mask_color = { 1.0f, 1.0f, 0.0f };
-
+  const gboolean devel = dt_conf_get_bool("darkroom/ui/develop_mask");
   #ifdef _OPENMP
   #pragma omp parallel for simd default(none) schedule(static) \
     aligned(in, out: 64) aligned(mask_color: 16)                \
-    dt_omp_firstprivate(in, out, buffsize, alpha, mask_color)
+    dt_omp_firstprivate(in, out, buffsize, alpha, mask_color, devel)
   #endif
     for(size_t j = 0; j < buffsize; j+= 4)
     {
-      const float gray = 0.3f * in[j + 0] + 0.59f * in[j + 1] + 0.11f * in[j + 2];
+      const float gray = devel ? in[j + 3] : (0.3f * in[j + 0] + 0.59f * in[j + 1] + 0.11f * in[j + 2]);
       const dt_aligned_pixel_t pixel = { gray, gray, gray, gray };
       _write_pixel(pixel, out + j, mask_color, in[j + 3] * alpha);
     }


### PR DESCRIPTION
The way we visualize masks is good while developing the image in most cases, especially if debugging code or trying to understand why some masks "misbehave" we might want to see the masks without any distraction from image content.

Issues like #14215 make this "necessary"