### PR TITLE
fix modulegroups preset use after free

### DIFF
--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -3931,9 +3931,10 @@ void view_enter(dt_lib_module_t *self, dt_view_t *old_view, dt_view_t *new_view)
     dt_lib_modulegroups_t *d = (dt_lib_modulegroups_t *)self->data;
 
     // and we initialize the buttons too
-    const char *preset = dt_conf_get_string_const("plugins/darkroom/modulegroups_preset");
+    char *preset = dt_conf_get_string("plugins/darkroom/modulegroups_preset");
     if(!dt_lib_presets_apply(preset, self->plugin_name, self->version()))
       dt_lib_presets_apply(_(FALLBACK_PRESET_NAME), self->plugin_name, self->version());
+    g_free(preset);
 
     // and set the current group
     d->current = dt_conf_get_int("plugins/darkroom/groups");


### PR DESCRIPTION
You can't pass the result of `dt_conf_get_string_const` to a function that is going to update the requested configuration variable before using the string. Asan doesn't like it.

EDIT:
as an aside, switching to Debug build allows compiling with asan/ADDRESS_SANITIZER=1 without the error mentioned in https://github.com/darktable-org/darktable/pull/15593#issuecomment-1799259715
This PR then allows running without asan terminating. It kind of makes sense to run asan in debugger build. On the other hand some crashes/corruption might only happen in release build. What would be the pros and cons of _always_ (by default) enabling asan in debug build? @victoryforce what do you think? @sss123next any experience with that?