### PR TITLE
Some debug log improvements

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -428,6 +428,18 @@ static void _develop_blend_process_mask_tone_curve(float *const restrict mask,
   }
 }
 
+static const char *_develop_blend_colorspace_to_str(const dt_develop_blend_colorspace_t type)
+{
+  switch(type)
+  {
+    case DEVELOP_BLEND_CS_NONE:         return "BLEND_CS_NONE";
+    case DEVELOP_BLEND_CS_RAW:          return "BLEND_CS_RAW";
+    case DEVELOP_BLEND_CS_LAB:          return "BLEND_CS_LAB";
+    case DEVELOP_BLEND_CS_RGB_DISPLAY:  return "BLEND_CS_RGB_DISPLAY";
+    case DEVELOP_BLEND_CS_RGB_SCENE:    return "BLEND_CS_RGB_SCENE";
+    default:                            return "invalid BLEND_CS";
+  }
+}
 
 void dt_develop_blend_process(struct dt_iop_module_t *self,
                               struct dt_dev_pixelpipe_iop_t *piece,
@@ -612,10 +624,12 @@ void dt_develop_blend_process(struct dt_iop_module_t *self,
 
     dt_print_pipe(DT_DEBUG_PIPE,
        "blend with form on CPU",
-       piece->pipe, self, roi_in, roi_out, "%s%s%s\n",
+       piece->pipe, self, roi_in, roi_out, "%s, %s%s%s%s\n",
        dt_iop_colorspace_to_name(cst),
+       _develop_blend_colorspace_to_str(blend_csp),
        inverted ? ", inverted" : "",
-       form ? ( form_ok ? ", form available and rendered" : ", render problem on form") : ",no form");
+       rois_equal ? "" : ", roi differ",
+       form && form_ok ? ", form available and rendered" : ", no form");
 
     _refine_with_detail_mask(self, piece, mask, roi_in, roi_out, d->details);
 
@@ -1166,10 +1180,12 @@ gboolean dt_develop_blend_process_cl(struct dt_iop_module_t *self,
 
     dt_print_pipe(DT_DEBUG_PIPE,
        "blend with form CL",
-       piece->pipe, self, roi_in, roi_out, "%s%s%s\n",
+       piece->pipe, self, roi_in, roi_out, "%s, %s%s%s%s\n",
        dt_iop_colorspace_to_name(cst),
+       _develop_blend_colorspace_to_str(blend_csp),
        inverted ? ", inverted" : "",
-       form ? ( form_ok ? ", form available and rendered" : ", render problem on form") : ",no form");
+       rois_equal ? "" : ", roi differ",
+       form && form_ok ? ", form available and rendered" : ", no form");
 
     _refine_with_detail_mask_cl(self, piece, mask, roi_in, roi_out, d->details, devid);
 

--- a/src/iop/hlreconstruct/opposed.c
+++ b/src/iop/hlreconstruct/opposed.c
@@ -372,15 +372,16 @@ static float *_process_opposed(
         for_three_channels(c)
           img_oppchroma[c] = chrominance[c];
         img_opphash = opphash;
-
-        dt_print_pipe(DT_DEBUG_PIPE,
-          "opposed chroma cache CPU", piece->pipe, self, roi_in, roi_out,
-          " red: %8.6f (%.0f), green: %8.6f (%.0f), blue: %8.6f (%.0f) for hash=%" PRIx64 " %s\n",
-          chrominance[0], cnts[0], chrominance[1], cnts[1], chrominance[2], cnts[2],
-          _opposed_parhash(piece), anyclipped ? "" : "copymode");
-
         img_oppclipped = anyclipped;
       }
+
+      dt_print_pipe(DT_DEBUG_PIPE,
+          "opposed chroma CPU", piece->pipe, self, roi_in, roi_out,
+          "red: %3.4f, green: %3.4f, blue: %3.4f for hash=%" PRIx64 "%s%s\n",
+          chrominance[0], chrominance[1], chrominance[2],
+          _opposed_parhash(piece),
+          piece->pipe->type == DT_DEV_PIXELPIPE_FULL ? ", saved to cache" : "",
+          img_oppclipped ? "" : ", unclipped");
     }
     dt_free_align(mask);
   }
@@ -573,13 +574,15 @@ static cl_int process_opposed_cl(
       img_opphash = opphash;
 
       img_oppclipped = cnts[0] > 0.0f || cnts[1] > 0.0f || cnts[2] > 0.0f;
-
-      dt_print_pipe(DT_DEBUG_PIPE,
-          "opposed chroma cache CL", piece->pipe, self, roi_in, roi_out,
-          " red: %8.6f (%.0f), green: %8.6f (%.0f), blue: %8.6f (%.0f) for hash=%" PRIx64 " %s\n",
-          chrominance[0], cnts[0], chrominance[1], cnts[1], chrominance[2], cnts[2],
-          _opposed_parhash(piece), img_oppclipped ? "" : "copymode");
     }
+
+    dt_print_pipe(DT_DEBUG_PIPE,
+        "opposed chroma CL", piece->pipe, self, roi_in, roi_out,
+        "red: %3.4f, green: %3.4f, blue: %3.4f for hash=%" PRIx64 "%s%s\n",
+        chrominance[0], chrominance[1], chrominance[2],
+        _opposed_parhash(piece),
+        piece->pipe->type == DT_DEV_PIXELPIPE_FULL ? ", saved to cache" : "",
+        img_oppclipped ? "" : ", unclipped");
   }
 
   err = DT_OPENCL_SYSMEM_ALLOCATION;


### PR DESCRIPTION
1. With the new pixelpipe workflow make sure all chroma correction calculations are reported properly even if data are not saved.
2. more precise blending debug logs
- Also report blending colorspace
- fix issue with forms reported
- info about roi copy mode