### PR TITLE
don't place tooltip window if not moved

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -966,9 +966,10 @@ static void _tooltip_reposition(GtkWidget *widget,
                                                              window),
                            &workarea);
 
-  wx = CLAMP(wx, workarea.x, workarea.x + workarea.width - width);
+  gint nx = CLAMP(wx, workarea.x, workarea.x + workarea.width - width);
 
-  gdk_window_move(window, wx, wy);
+  if(nx != wx)
+    gdk_window_move(window, nx, wy);
 }
 
 gboolean dt_shortcut_tooltip_callback(GtkWidget *widget,

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -625,7 +625,7 @@ static void _set_mapping_mode_cursor(GtkWidget *widget)
   if(GTK_IS_EVENT_BOX(widget)) widget = gtk_bin_get_child(GTK_BIN(widget));
 
   if(widget && !strcmp(gtk_widget_get_name(widget), "module-header"))
-    cursor = gdk_cursor_new_for_display(display, GDK_BASED_ARROW_DOWN);
+    cursor = gdk_cursor_new_from_name(display, "context-menu");
   else if(dt_action_widget(darktable.control->mapping_widget)
           && darktable.develop)
   {
@@ -641,7 +641,7 @@ static void _set_mapping_mode_cursor(GtkWidget *widget)
     gdk_window_set_cursor(window, NULL); // work around bug where gtk seems to buffer surface cursors
   }
   else
-    cursor = gdk_cursor_new_for_display(display, GDK_DIAMOND_CROSS);
+    cursor = gdk_cursor_new_from_name(display, "not-allowed");
 
   gdk_window_set_cursor(window, cursor);
   g_object_unref(cursor);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3616,10 +3616,10 @@ GSList *mouse_actions(const dt_view_t *self)
  * DPI */
 #define DT_PIXEL_APPLY_DPI_2ND_WND(dev, value) ((value) * dev->preview2.dpi_factor)
 
-static void dt_second_window_change_cursor(dt_develop_t *dev, dt_cursor_t curs)
+static void dt_second_window_change_cursor(dt_develop_t *dev, const gchar *curs)
 {
   GtkWidget *widget = dev->second_wnd;
-  GdkCursor *cursor = gdk_cursor_new_for_display(gdk_display_get_default(), curs);
+  GdkCursor *cursor = gdk_cursor_new_from_name(gdk_display_get_default(), curs);
   gdk_window_set_cursor(gtk_widget_get_window(widget), cursor);
   g_object_unref(cursor);
 }
@@ -3627,7 +3627,7 @@ static void dt_second_window_change_cursor(dt_develop_t *dev, dt_cursor_t curs)
 static void second_window_leave(dt_develop_t *dev)
 {
   // reset any changes the selected plugin might have made.
-  dt_second_window_change_cursor(dev, GDK_LEFT_PTR);
+  dt_second_window_change_cursor(dev, "default");
 }
 
 static void _second_window_configure_ppd_dpi(dt_develop_t *dev)
@@ -3714,7 +3714,7 @@ static gboolean _second_window_button_pressed_callback(GtkWidget *w,
   {
     darktable.control->button_x = event->x;
     darktable.control->button_y = event->y;
-    dt_second_window_change_cursor(dev, GDK_HAND1);
+    dt_second_window_change_cursor(dev, "grabbing");
     return TRUE;
   }
   if(event->button == 2)
@@ -3729,7 +3729,7 @@ static gboolean _second_window_button_released_callback(GtkWidget *w,
                                                         GdkEventButton *event,
                                                         dt_develop_t *dev)
 {
-  if(event->button == 1) dt_second_window_change_cursor(dev, GDK_LEFT_PTR);
+  if(event->button == 1) dt_second_window_change_cursor(dev, "default");
 
   gtk_widget_queue_draw(w);
   return TRUE;


### PR DESCRIPTION
One fun change in wayland (besides the whole color management thing) is that it doesn't allow you position windows. In dt this impacts tooltips (which we are trying to stop from appearing off screen) and bauhaus popups (same, but also we move the dropdown window while scrolling or if the value is updated for some other reason, like calculation or shortcut).

It looks like there are partial workarounds, which may or may not be sufficient for us, but they would need extensive testing on all platforms, so that's not a high priority while we don't officially support wayland anyway.

However there's one annoying bug triggered by my tooltip positioning code. It requests the expected position of the tooltip (which wayland won't give it; it just say 0,0) and then corrects that and places the window explicitly. Except that last step overrides waylands default placement, so now it always ends up at 0,0 (top-left). 

This small "fix" _only_ explicitly places the tooltip if a correction has been made (if it otherwise would appear off-screen). Since under wayland we "never" are able to correct anything, we just let it do its own thing (which could mean placing off screen sometimes, but there's no way to fix that correctly at the moment, I think). Under x we should see the same behavior as before.