### PR TITLE
sigmoid custom primaries: enhancements and release note entry

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -51,6 +51,14 @@ changes (where available).
   primary colors around based on "hue" and "purity" parameters set by the
   user. The underlying pixel operation is the same as channel mixing.
 
+- _sigmoid_ now features a _primaries_ section which can be used to
+  handle difficult lighting (such as LEDs) gracefully and tune the overall
+  look of the resulting image, allowing for pleasing sunsets, skin tones etc.
+  The feature applies only to the per-channel mode. It is loosely based on
+  ideas from Troy Sobotka's [AgX](https://github.com/sobotka/AgX-S2O3)
+  and related work and discussions in the [Blender community](https://blenderartists.org/t/feedback-development-filmic-baby-step-to-a-v2/1361663). Preset "smooth",
+  utilizing the new feature, is added to provide a good starting point.
+
 ## Performance Improvements
 
 - Initialize OpenCL in the background. Especially under Windows this

--- a/data/kernels/sigmoid.cl
+++ b/data/kernels/sigmoid.cl
@@ -184,7 +184,8 @@ sigmoid_loglogistic_per_channel (read_only image2d_t in,
                                  const float contrast_power,
                                  const float skew_power,
                                  const float hue_preservation,
-                                 constant const float *const pipe_to_rendering,
+                                 constant const float *const pipe_to_base,
+                                 constant const float *const base_to_rendering,
                                  constant const float *const rendering_to_pipe)
 {
   const unsigned int x = get_global_id(0);
@@ -195,11 +196,13 @@ sigmoid_loglogistic_per_channel (read_only image2d_t in,
   float4 i = read_imagef(in, sampleri, (int2)(x, y));
   float alpha = i.w;
 
+  i = matrix_product_float4(i, pipe_to_base);
+
   // Force negative values to zero
   i = _desaturate_negative_values(i);
 
   // Convert to rendering primaries
-  i = matrix_product_float4(i, pipe_to_rendering);
+  i = matrix_product_float4(i, base_to_rendering);
   float pix_array[3] = {i.x, i.y, i.z};
 
   i = _generalized_loglogistic_sigmoid_vector(i, white_target, paper_exp, film_fog, contrast_power, skew_power);

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -47,8 +47,6 @@ typedef enum dt_iop_sigmoid_methods_type_t
 } dt_iop_sigmoid_methods_type_t;
 
 
-// NOTE: code relies on the order of the enum values and also on the fact that
-// they don't have gaps.
 typedef enum dt_iop_sigmoid_base_primaries_t
 {
   DT_SIGMOID_WORK_PROFILE = 0, // $DESCRIPTION: "work profile"
@@ -467,7 +465,7 @@ static void _calculate_adjusted_primaries(const dt_iop_sigmoid_data_t *const mod
   dt_colormatrix_mul(rendering_to_pipe, rendering_to_base, base_to_pipe);
 }
 
-static dt_colorspaces_color_profile_type_t _get_base_profile_type(dt_iop_sigmoid_base_primaries_t base_primaries)
+static dt_colorspaces_color_profile_type_t _get_base_profile_type(const dt_iop_sigmoid_base_primaries_t base_primaries)
 {
   if(base_primaries == DT_SIGMOID_SRGB)
     return DT_COLORSPACE_SRGB;
@@ -887,7 +885,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
   if(!w || w == g->color_processing_list)
   {
-    int is_per_channel = p->color_processing == DT_SIGMOID_METHOD_PER_CHANNEL;
+    const gboolean is_per_channel = p->color_processing == DT_SIGMOID_METHOD_PER_CHANNEL;
     gtk_widget_set_visible(g->hue_preservation_slider, is_per_channel);
     gtk_widget_set_visible(g->primaries_section.expander, is_per_channel);
   }

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -272,17 +272,23 @@ void init_presets(dt_iop_module_so_t *self)
                              DEVELOP_BLEND_CS_RGB_SCENE);
 
   const float DEG_TO_RAD = DT_M_PI_F / 180.f;
-  p.middle_grey_contrast = 1.4f;
-  p.contrast_skewness = 0.0f;
+
+  // smooth - a preset that utilizes the primaries feature
+  p.middle_grey_contrast = 1.5f;
+  // Allow a little bit more room for the highlights
+  p.contrast_skewness = -0.2f;
   p.color_processing = DT_SIGMOID_METHOD_PER_CHANNEL;
+  // Allow shifts of the chromaticity. This will work well for sunsets etc.
   p.hue_preservation = 0.0f;
-  p.red_inset = 0.15f;
-  p.green_inset = 0.15f;
+  p.red_inset = 0.1f;
+  p.green_inset = 0.1f;
   p.blue_inset = 0.15f;
-  p.red_rotation = 4.f * DEG_TO_RAD;
-  p.green_rotation = 1.5f * DEG_TO_RAD;
-  p.blue_rotation = -5.f * DEG_TO_RAD;
-  p.purity = 0.5f;
+  p.red_rotation = 2.f * DEG_TO_RAD;
+  p.green_rotation = -1.f * DEG_TO_RAD;
+  p.blue_rotation = -3.f * DEG_TO_RAD;
+  // Don't restore purity - try to avoid posterization.
+  p.purity = 0.f;
+  // Constant base primaries (not dependent on work profile) to maintain a consistent behavior
   p.base_primaries = DT_SIGMOID_REC2020;
   dt_gui_presets_add_generic(_("smooth"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 }

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -52,7 +52,8 @@ typedef enum dt_iop_sigmoid_base_primaries_t
   DT_SIGMOID_WORK_PROFILE = 0, // $DESCRIPTION: "work profile"
   DT_SIGMOID_REC2020 = 1, // $DESCRIPTION: "Rec2020"
   DT_SIGMOID_DISPLAY_P3 = 2, // $DESCRIPTION: "Display P3"
-  DT_SIGMOID_SRGB = 3, // $DESCRIPTION: "sRGB"
+  DT_SIGMOID_ADOBE_RGB = 3, // $DESCRIPTION: "Adobe RGB (compatible)"
+  DT_SIGMOID_SRGB = 4, // $DESCRIPTION: "sRGB"
 } dt_iop_sigmoid_base_primaries_t;
 
 
@@ -472,6 +473,9 @@ static dt_colorspaces_color_profile_type_t _get_base_profile_type(const dt_iop_s
 
   if(base_primaries == DT_SIGMOID_DISPLAY_P3)
     return DT_COLORSPACE_DISPLAY_P3;
+
+  if(base_primaries == DT_SIGMOID_ADOBE_RGB)
+    return DT_COLORSPACE_ADOBERGB;
 
   return DT_COLORSPACE_LIN_REC2020;
 }

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -34,7 +34,7 @@
 #include <gtk/gtk.h>
 #include <stdlib.h>
 
-DT_MODULE_INTROSPECTION(2, dt_iop_sigmoid_params_t)
+DT_MODULE_INTROSPECTION(3, dt_iop_sigmoid_params_t)
 
 
 #define MIDDLE_GREY 0.1845f
@@ -45,6 +45,17 @@ typedef enum dt_iop_sigmoid_methods_type_t
   DT_SIGMOID_METHOD_PER_CHANNEL = 0, // $DESCRIPTION: "per channel"
   DT_SIGMOID_METHOD_RGB_RATIO = 1,   // $DESCRIPTION: "RGB ratio"
 } dt_iop_sigmoid_methods_type_t;
+
+
+// NOTE: code relies on the order of the enum values and also on the fact that
+// they don't have gaps.
+typedef enum dt_iop_sigmoid_base_primaries_t
+{
+  DT_SIGMOID_WORK_PROFILE = 0, // $DESCRIPTION: "work profile"
+  DT_SIGMOID_REC2020 = 1, // $DESCRIPTION: "Rec2020"
+  DT_SIGMOID_DISPLAY_P3 = 2, // $DESCRIPTION: "Display P3"
+  DT_SIGMOID_SRGB = 3, // $DESCRIPTION: "sRGB"
+} dt_iop_sigmoid_base_primaries_t;
 
 
 typedef struct dt_iop_sigmoid_params_t
@@ -62,6 +73,7 @@ typedef struct dt_iop_sigmoid_params_t
   float blue_inset;       // $MIN:  0.0  $MAX: 0.99 $DEFAULT: 0.0 $DESCRIPTION: "blue attenuation"
   float blue_rotation;    // $MIN: -0.4  $MAX: 0.4  $DEFAULT: 0.0 $DESCRIPTION: "blue rotation"
   float purity;           // $MIN:  0.0  $MAX: 1.0  $DEFAULT: 0.0 $DESCRIPTION: "recover purity"
+  dt_iop_sigmoid_base_primaries_t base_primaries; // $DEFAULT: DT_SIGMOID_WORK_PROFILE $DESCRIPTION: "base primaries"
 } dt_iop_sigmoid_params_t;
 
 int legacy_params(dt_iop_module_t *self,
@@ -88,7 +100,10 @@ int legacy_params(dt_iop_module_t *self,
     float blue_inset;
     float blue_rotation;
     float purity;
-  } dt_iop_sigmoid_params_v2_t;
+
+    /* v3 params */
+    dt_iop_sigmoid_base_primaries_t base_primaries;
+  } dt_iop_sigmoid_params_v3_t;
 
   if(old_version == 1)
   {
@@ -103,12 +118,42 @@ int legacy_params(dt_iop_module_t *self,
     } dt_iop_sigmoid_params_v1_t;
 
     // Copy the common part of the params struct
-    dt_iop_sigmoid_params_v2_t *n = (dt_iop_sigmoid_params_v2_t *)calloc(1, sizeof(dt_iop_sigmoid_params_v2_t));
+    dt_iop_sigmoid_params_v3_t *n = (dt_iop_sigmoid_params_v3_t *)calloc(1, sizeof(dt_iop_sigmoid_params_v3_t));
     memcpy(n, old_params, sizeof(dt_iop_sigmoid_params_v1_t));
 
     *new_params = n;
-    *new_params_size = sizeof(dt_iop_sigmoid_params_v2_t);
-    *new_version = 2;
+    *new_params_size = sizeof(dt_iop_sigmoid_params_v3_t);
+    *new_version = 3;
+
+    return 0;
+  }
+  else if(old_version == 2)
+  {
+    typedef struct dt_iop_sigmoid_params_v2_t
+    {
+      float middle_grey_contrast;
+      float contrast_skewness;
+      float display_white_target;
+      float display_black_target;
+      dt_iop_sigmoid_methods_type_t color_processing;
+      float hue_preservation;
+
+      /* v2 params */
+      float red_inset;
+      float red_rotation;
+      float green_inset;
+      float green_rotation;
+      float blue_inset;
+      float blue_rotation;
+      float purity;
+    } dt_iop_sigmoid_params_v2_t;
+    // Copy the common part of the params struct
+    dt_iop_sigmoid_params_v3_t *n = (dt_iop_sigmoid_params_v3_t *)calloc(1, sizeof(dt_iop_sigmoid_params_v3_t));
+    memcpy(n, old_params, sizeof(dt_iop_sigmoid_params_v2_t));
+
+    *new_params = n;
+    *new_params_size = sizeof(dt_iop_sigmoid_params_v3_t);
+    *new_version = 3;
 
     return 0;
   }
@@ -129,6 +174,7 @@ typedef struct dt_iop_sigmoid_data_t
   float inset[3];
   float rotation[3];
   float purity;
+  dt_iop_sigmoid_base_primaries_t base_primaries;
 } dt_iop_sigmoid_data_t;
 
 typedef struct dt_iop_sigmoid_gui_data_t
@@ -237,6 +283,7 @@ void init_presets(dt_iop_module_so_t *self)
   p.green_rotation = 1.5f * DEG_TO_RAD;
   p.blue_rotation = -5.f * DEG_TO_RAD;
   p.purity = 0.5f;
+  p.base_primaries = DT_SIGMOID_REC2020;
   dt_gui_presets_add_generic(_("smooth"), self->op, self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 }
 
@@ -335,11 +382,14 @@ void commit_params(dt_iop_module_t *self,
   module_data->rotation[0] = params->red_rotation;
   module_data->rotation[1] = params->green_rotation;
   module_data->rotation[2] = params->blue_rotation;
+  module_data->base_primaries = params->base_primaries;
 }
 
 static void _calculate_adjusted_primaries(const dt_iop_sigmoid_data_t *const module_data,
                                           const dt_iop_order_iccprofile_info_t *const pipe_work_profile,
-                                          dt_colormatrix_t pipe_to_rendering,
+                                          const dt_iop_order_iccprofile_info_t *const base_profile,
+                                          dt_colormatrix_t pipe_to_base,
+                                          dt_colormatrix_t base_to_rendering,
                                           dt_colormatrix_t rendering_to_pipe)
 {
   // Make adjusted primaries for generating the inset matrix
@@ -355,27 +405,81 @@ static void _calculate_adjusted_primaries(const dt_iop_sigmoid_data_t *const mod
   // per-channel process desaturates them.
   // The primaries are also rotated to compensate for Abney etc.
   // and achieve a favourable shift towards yellow.
+
+  // First, calculate matrix to get from pipe work profile to "base primaries".
+  dt_colormatrix_t base_to_pipe;
+  if(pipe_work_profile != base_profile)
+  {
+    dt_colormatrix_mul(pipe_to_base, pipe_work_profile->matrix_in_transposed,
+                       base_profile->matrix_out_transposed);
+    mat3SSEinv(base_to_pipe, pipe_to_base);
+  }
+  else
+  {
+    // Special case: if pipe and base profile are the same, pipe_to_base is an identity matrix.
+    for(size_t i = 0; i < 4; i++)
+    {
+      for(size_t j = 0; j < 4; j++)
+      {
+        if(i == j && i < 3)
+        {
+          pipe_to_base[i][j] = 1.f;
+          base_to_pipe[i][j] = 1.f;
+        }
+        else
+        {
+          pipe_to_base[i][j] = 0.f;
+          base_to_pipe[i][j] = 0.f;
+        }
+      }
+    }
+  }
+
+  // Rotated, scaled primaries are calculated based on the "base profile"
   float custom_primaries[3][2];
   for(size_t i = 0; i < 3; i++)
-    dt_rotate_and_scale_primary(pipe_work_profile, 1.f - module_data->inset[i], module_data->rotation[i], i,
+    dt_rotate_and_scale_primary(base_profile, 1.f - module_data->inset[i], module_data->rotation[i], i,
                                 custom_primaries[i]);
 
   dt_colormatrix_t custom_to_XYZ;
-  dt_make_transposed_matrices_from_primaries_and_whitepoint(custom_primaries, pipe_work_profile->whitepoint,
+  dt_make_transposed_matrices_from_primaries_and_whitepoint(custom_primaries, base_profile->whitepoint,
                                                             custom_to_XYZ);
-  dt_colormatrix_mul(pipe_to_rendering, custom_to_XYZ, pipe_work_profile->matrix_out_transposed);
+  dt_colormatrix_mul(base_to_rendering, custom_to_XYZ, base_profile->matrix_out_transposed);
 
   for(size_t i = 0; i < 3; i++)
   {
     const float scaling = 1.f - module_data->purity * module_data->inset[i];
-    dt_rotate_and_scale_primary(pipe_work_profile, scaling, module_data->rotation[i], i, custom_primaries[i]);
+    dt_rotate_and_scale_primary(base_profile, scaling, module_data->rotation[i], i, custom_primaries[i]);
   }
 
-  dt_make_transposed_matrices_from_primaries_and_whitepoint(custom_primaries, pipe_work_profile->whitepoint,
+  dt_make_transposed_matrices_from_primaries_and_whitepoint(custom_primaries, base_profile->whitepoint,
                                                             custom_to_XYZ);
   dt_colormatrix_t tmp;
-  dt_colormatrix_mul(tmp, custom_to_XYZ, pipe_work_profile->matrix_out_transposed);
-  mat3SSEinv(rendering_to_pipe, tmp);
+  dt_colormatrix_mul(tmp, custom_to_XYZ, base_profile->matrix_out_transposed);
+  dt_colormatrix_t rendering_to_base;
+  mat3SSEinv(rendering_to_base, tmp);
+  dt_colormatrix_mul(rendering_to_pipe, rendering_to_base, base_to_pipe);
+}
+
+static dt_colorspaces_color_profile_type_t _get_base_profile_type(dt_iop_sigmoid_base_primaries_t base_primaries)
+{
+  if(base_primaries == DT_SIGMOID_SRGB)
+    return DT_COLORSPACE_SRGB;
+
+  if(base_primaries == DT_SIGMOID_DISPLAY_P3)
+    return DT_COLORSPACE_DISPLAY_P3;
+
+  return DT_COLORSPACE_LIN_REC2020;
+}
+
+static const dt_iop_order_iccprofile_info_t * _get_base_profile(struct dt_develop_t *dev,
+                                                                const dt_iop_order_iccprofile_info_t *pipe_work_profile,
+                                                                const dt_iop_sigmoid_base_primaries_t base_primaries)
+{
+  if(base_primaries == DT_SIGMOID_WORK_PROFILE)
+    return pipe_work_profile;
+
+  return dt_ioppr_add_profile_info_to_list(dev, _get_base_profile_type(base_primaries), "", DT_INTENT_RELATIVE_COLORIMETRIC);
 }
 
 #ifdef _OPENMP
@@ -593,7 +697,8 @@ static inline void _preserve_hue_and_energy(const dt_aligned_pixel_t pix_in,
   }
 }
 
-void process_loglogistic_per_channel(dt_dev_pixelpipe_iop_t *piece,
+void process_loglogistic_per_channel(struct dt_develop_t *dev,
+                                     dt_dev_pixelpipe_iop_t *piece,
                                      const void *const ivoid, void *const ovoid,
                                      const dt_iop_roi_t *const roi_in,
                                      const dt_iop_roi_t *const roi_out)
@@ -612,26 +717,30 @@ void process_loglogistic_per_channel(dt_dev_pixelpipe_iop_t *piece,
   const float hue_preservation = module_data->hue_preservation;
 
   const dt_iop_order_iccprofile_info_t *pipe_work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
-  dt_colormatrix_t pipe_to_rendering, rendering_to_pipe;
-  _calculate_adjusted_primaries(module_data, pipe_work_profile, pipe_to_rendering, rendering_to_pipe);
+  const dt_iop_order_iccprofile_info_t *base_profile = _get_base_profile(dev, pipe_work_profile, module_data->base_primaries);
+  dt_colormatrix_t pipe_to_base, base_to_rendering, rendering_to_pipe;
+  _calculate_adjusted_primaries(module_data, pipe_work_profile, base_profile, pipe_to_base, base_to_rendering, rendering_to_pipe);
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none)                                                                            \
     dt_omp_firstprivate(npixels, white_target, paper_exp, film_fog, contrast_power, skew_power, hue_preservation, \
-                            pipe_to_rendering, rendering_to_pipe) dt_omp_sharedconst(in, out) schedule(static)
+                        pipe_to_base, base_to_rendering, rendering_to_pipe) dt_omp_sharedconst(in, out) schedule(static)
 #endif
   for(size_t k = 0; k < 4 * npixels; k += 4)
   {
     const float *const restrict pix_in = in + k;
     float *const restrict pix_out = out + k;
-    dt_aligned_pixel_t pix_in_strict_positive;
+    dt_aligned_pixel_t pix_in_base, pix_in_strict_positive;
     dt_aligned_pixel_t per_channel;
 
+    // Convert to "base primaries"
+    dt_apply_transposed_color_matrix(pix_in, pipe_to_base, pix_in_base);
+
     // Force negative values to zero
-    _desaturate_negative_values(pix_in, pix_in_strict_positive);
+    _desaturate_negative_values(pix_in_base, pix_in_strict_positive);
 
     dt_aligned_pixel_t rendering_RGB;
-    dt_apply_transposed_color_matrix(pix_in_strict_positive, pipe_to_rendering, rendering_RGB);
+    dt_apply_transposed_color_matrix(pix_in_strict_positive, base_to_rendering, rendering_RGB);
 
     for_each_channel(c, aligned(rendering_RGB, per_channel))
     {
@@ -665,7 +774,7 @@ void process(struct dt_iop_module_t *self,
 
   if(module_data->color_processing == DT_SIGMOID_METHOD_PER_CHANNEL)
   {
-    process_loglogistic_per_channel(piece, ivoid, ovoid, roi_in, roi_out);
+    process_loglogistic_per_channel(self->dev, piece, ivoid, ovoid, roi_in, roi_out);
   }
   else // DT_SIGMOID_METHOD_RGB_RATIO
   {
@@ -696,16 +805,20 @@ int process_cl(struct dt_iop_module_t *self,
   const float skew_power = d->paper_power;
 
   const dt_iop_order_iccprofile_info_t *pipe_work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
-  dt_colormatrix_t pipe_to_rendering_transposed, rendering_to_pipe_transposed, pipe_to_rendering,
-      rendering_to_pipe;
-  _calculate_adjusted_primaries(d, pipe_work_profile, pipe_to_rendering_transposed, rendering_to_pipe_transposed);
-  transpose_3xSSE(pipe_to_rendering_transposed, pipe_to_rendering);
+  const dt_iop_order_iccprofile_info_t *base_profile = _get_base_profile(self->dev, pipe_work_profile, d->base_primaries);
+  dt_colormatrix_t pipe_to_base_transposed, base_to_rendering_transposed,
+      rendering_to_pipe_transposed, pipe_to_base, base_to_rendering, rendering_to_pipe;
+  _calculate_adjusted_primaries(d, pipe_work_profile, base_profile, pipe_to_base_transposed, base_to_rendering_transposed, rendering_to_pipe_transposed);
+  transpose_3xSSE(pipe_to_base_transposed, pipe_to_base);
+  transpose_3xSSE(base_to_rendering_transposed, base_to_rendering);
   transpose_3xSSE(rendering_to_pipe_transposed, rendering_to_pipe);
-  cl_mem dev_pipe_to_rendering
-      = dt_opencl_copy_host_to_device_constant(devid, sizeof(pipe_to_rendering), pipe_to_rendering);
+  cl_mem dev_pipe_to_base
+      = dt_opencl_copy_host_to_device_constant(devid, sizeof(pipe_to_base), pipe_to_base);
+  cl_mem dev_base_to_rendering
+      = dt_opencl_copy_host_to_device_constant(devid, sizeof(base_to_rendering), base_to_rendering);
   cl_mem dev_rendering_to_pipe
       = dt_opencl_copy_host_to_device_constant(devid, sizeof(rendering_to_pipe), rendering_to_pipe);
-  if(dev_pipe_to_rendering == NULL || dev_rendering_to_pipe == NULL)
+  if(dev_pipe_to_base == NULL || dev_base_to_rendering == NULL || dev_rendering_to_pipe == NULL)
   {
     dt_print(DT_DEBUG_OPENCL, "[opencl_sigmoid] couldn't allocate memory!\n");
     goto cleanup;
@@ -717,7 +830,7 @@ int process_cl(struct dt_iop_module_t *self,
     err = dt_opencl_enqueue_kernel_2d_args(
         devid, gd->kernel_sigmoid_loglogistic_per_channel, width, height, CLARG(dev_in), CLARG(dev_out),
         CLARG(width), CLARG(height), CLARG(white_target), CLARG(paper_exp), CLARG(film_fog), CLARG(contrast_power),
-        CLARG(skew_power), CLARG(hue_preservation), CLARG(dev_pipe_to_rendering), CLARG(dev_rendering_to_pipe));
+        CLARG(skew_power), CLARG(hue_preservation), CLARG(dev_pipe_to_base), CLARG(dev_base_to_rendering), CLARG(dev_rendering_to_pipe));
   }
   else
   {
@@ -730,7 +843,8 @@ int process_cl(struct dt_iop_module_t *self,
   }
 
 cleanup:
-  dt_opencl_release_mem_object(dev_pipe_to_rendering);
+  dt_opencl_release_mem_object(dev_pipe_to_base);
+  dt_opencl_release_mem_object(dev_base_to_rendering);
   dt_opencl_release_mem_object(dev_rendering_to_pipe);
   return err;
 }
@@ -812,6 +926,9 @@ void gui_init(dt_iop_module_t *self)
 
   self->widget = GTK_WIDGET(g->primaries_section.container);
   dt_iop_module_t *sect = DT_IOP_SECTION_FOR_PARAMS(self, N_("primaries"));
+
+  GtkWidget *base_primaries = dt_bauhaus_combobox_from_params(self, "base_primaries");
+  gtk_widget_set_tooltip_text(base_primaries, _("primaries to use as the base for below adjustments"));
 
 #define SETUP_COLOR_COMBO(color, r, g, b, inset_tooltip, rotation_tooltip)                                        \
   slider = dt_bauhaus_slider_from_params(sect, #color "_inset");                                                  \

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -886,7 +886,11 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   dt_iop_sigmoid_params_t *p = (dt_iop_sigmoid_params_t *)self->params;
 
   if(!w || w == g->color_processing_list)
-    gtk_widget_set_visible(g->hue_preservation_slider, p->color_processing == DT_SIGMOID_METHOD_PER_CHANNEL);
+  {
+    int is_per_channel = p->color_processing == DT_SIGMOID_METHOD_PER_CHANNEL;
+    gtk_widget_set_visible(g->hue_preservation_slider, is_per_channel);
+    gtk_widget_set_visible(g->primaries_section.expander, is_per_channel);
+  }
 }
 
 void gui_update(dt_iop_module_t *self)

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -55,11 +55,11 @@ typedef struct dt_iop_sigmoid_params_t
   float display_black_target; // $MIN: 0.0  $MAX: 15.0 $DEFAULT: 0.0152 $DESCRIPTION: "target black"
   dt_iop_sigmoid_methods_type_t color_processing; // $DEFAULT: DT_SIGMOID_METHOD_PER_CHANNEL $DESCRIPTION: "color processing"
   float hue_preservation; // $MIN: 0.0 $MAX: 100.0 $DEFAULT: 100.0 $DESCRIPTION: "preserve hue"
-  float red_inset;        // $MIN:  0.0  $MAX: 0.99 $DEFAULT: 0.0 $DESCRIPTION: "red inset"
+  float red_inset;        // $MIN:  0.0  $MAX: 0.99 $DEFAULT: 0.0 $DESCRIPTION: "red attenuation"
   float red_rotation;     // $MIN: -0.4  $MAX: 0.4  $DEFAULT: 0.0 $DESCRIPTION: "red rotation"
-  float green_inset;      // $MIN:  0.0  $MAX: 0.99 $DEFAULT: 0.0 $DESCRIPTION: "green inset"
+  float green_inset;      // $MIN:  0.0  $MAX: 0.99 $DEFAULT: 0.0 $DESCRIPTION: "green attenuation"
   float green_rotation;   // $MIN: -0.4  $MAX: 0.4  $DEFAULT: 0.0 $DESCRIPTION: "green rotation"
-  float blue_inset;       // $MIN:  0.0  $MAX: 0.99 $DEFAULT: 0.0 $DESCRIPTION: "blue inset"
+  float blue_inset;       // $MIN:  0.0  $MAX: 0.99 $DEFAULT: 0.0 $DESCRIPTION: "blue attenuation"
   float blue_rotation;    // $MIN: -0.4  $MAX: 0.4  $DEFAULT: 0.0 $DESCRIPTION: "blue rotation"
   float purity;           // $MIN:  0.0  $MAX: 1.0  $DEFAULT: 0.0 $DESCRIPTION: "recover purity"
 } dt_iop_sigmoid_params_t;
@@ -830,12 +830,12 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(slider, rotation_tooltip);
 
   const float desaturation = 0.2f;
-  SETUP_COLOR_COMBO(red, 1.f - desaturation, desaturation, desaturation, _("red primary inset"),
-                    _("red primary rotation"));
-  SETUP_COLOR_COMBO(green, desaturation, 1.f - desaturation, desaturation, _("green primary inset"),
-                    _("green primary rotation"));
-  SETUP_COLOR_COMBO(blue, desaturation, desaturation, 1.f - desaturation, _("blue primary inset"),
-                    _("blue primary rotation"));
+  SETUP_COLOR_COMBO(red, 1.f - desaturation, desaturation, desaturation, _("attenuate the purity of the red primary"),
+                    _("rotate the red primary"));
+  SETUP_COLOR_COMBO(green, desaturation, 1.f - desaturation, desaturation, _("attenuate the purity of the green primary"),
+                    _("rotate the green primary"));
+  SETUP_COLOR_COMBO(blue, desaturation, desaturation, 1.f - desaturation, _("attenuate the purity of the blue primary"),
+                    _("rotate the blue primary"));
 #undef SETUP_COLOR_COMBO
 
   slider = dt_bauhaus_slider_from_params(sect, "purity");


### PR DESCRIPTION
Final enhancements to the "primaries" feature of sigmoid before the release. Thanks to @MStraeten for suggestions of tooltip adjustments (hope these make more sense) and hiding the section when "RGB ratio" mode is selected.

@dterrahe would you mind looking at the way the section is hidden? I couldn't think of any other way.

Descriptions in commits. Decided to add the ability to select a custom base profile for the mapping operation to allow the construction of presets whose look doesn't change when user switches the working profile in the _input color module_. This is actually pretty important since I want the "smooth" preset to be robust so that there won't be any surprises if users have e.g. ProPhoto as their default work profile (the "smooth" preset was tuned with respect to Rec.2020).