### PR TITLE
Add a gettext context to the Export action button

### DIFF
--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -1395,7 +1395,7 @@ void gui_init(dt_lib_module_t *self)
 
   // Export button
   d->export_button = GTK_BUTTON(dt_action_button_new
-                                (self, N_("export"),
+                                (self, NC_("actionbutton", "export"),
                                  _export_button_clicked, d,
                                  _("export with current settings"),
                                  GDK_KEY_e, GDK_CONTROL_MASK));


### PR DESCRIPTION
Now we have one string for the name of the module "export" and for the button in the module that activates the export process itself. The name of the module is a noun (similar to the names of other modules), while the label on the action button is essentially a verb. Thanks to a property of the English language known as conversion, "export" as a noun and as a verb are spelled the same. This is not the case in many other languages, so this PR adds the ability to separate the label on the action button to allow for a different word translation.
