### PR TITLE
Bugfix: blend feathering

### DIFF
--- a/src/common/box_filters.c
+++ b/src/common/box_filters.c
@@ -1129,7 +1129,7 @@ void dt_box_mean_horizontal(float *const restrict buf,
 {
   if(ch == (4|BOXFILTER_KAHAN_SUM))
   {
-    float *const restrict scratch = user_scratch ? user_scratch : dt_alloc_align_float(4*width);
+    float *const restrict scratch = user_scratch ? user_scratch : dt_alloc_align_float(4 * dt_round_size(width, 16));
     if(scratch)
     {
       _blur_horizontal_4ch_Kahan(buf, width, radius, scratch);
@@ -1141,7 +1141,7 @@ void dt_box_mean_horizontal(float *const restrict buf,
   }
   else if(ch == (9|BOXFILTER_KAHAN_SUM))
   {
-    float *const restrict scratch = user_scratch ? user_scratch : dt_alloc_align_float(9*width);
+    float *const restrict scratch = user_scratch ? user_scratch : dt_alloc_align_float(9 * dt_round_size(width, 16));
     if(scratch)
     {
       _blur_horizontal_Nch_Kahan(9, buf, width, radius, scratch);


### PR DESCRIPTION
1. The cpu code of feathering was broken due to a) not properly aligned and b) not sufficiently sized internal buffers.
2. fix blurring feather combinations.


Reported issues leading to this work were #10090 and #14215 (thanks a lot for those reports and sort-of-insisting @kofa73 ) but in fact the issue could be reproduced on almost all images and feathered blending i tested if disabling OpenCL. The problem was often not easy to see so got unnoticed for some time, to check you might want to use the new "developer masking mode" as implemented in #15599 

Both issues should be "mostly fixed" by this PR, the xmp in #14215 uses the rgb chromatic aberration module, there seems to be a pending problem.

EDIT:
It was reported to happen with OpenCL too - this is
1) due to the large mem requirements so on smaller machines the OpenCL codepath for feathering did a fallback to cpu
2) with feathering on input we had a problem too

Fixes #14215