### PR TITLE
Remove unrequested debug printing in the Debug build

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2361,10 +2361,8 @@ static gboolean _dev_pixelpipe_process_rec(
   }
 
   // warn on NaN or infinity
-#ifndef _DEBUG
   if((darktable.unmuted & DT_DEBUG_NAN)
      && !dt_iop_module_is(module->so, "gamma"))
-#endif
   {
     if(dt_atomic_get_int(&pipe->shutdown))
       return TRUE;


### PR DESCRIPTION
We should print debug information only if the corresponding channel is requested.