### PR TITLE
switch vignetting module off when crop focused

### DIFF
--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -134,6 +134,11 @@ int default_group()
   return IOP_GROUP_EFFECT | IOP_GROUP_EFFECTS;
 }
 
+int operation_tags()
+{
+  return IOP_TAG_DECORATION;
+}
+
 dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
                                             dt_dev_pixelpipe_t *pipe,
                                             dt_dev_pixelpipe_iop_t *piece)


### PR DESCRIPTION
The vignetting module applies an effect relative to the current middle of the image. When the crop is temporarily disabled while the crop module (or retouch or liquify) is focused, the vignette is applied in a different location. It is probably better to temporarily switch it off instead.