### PR TITLE
Introduce dt_get_debug_wtime()

### DIFF
--- a/src/common/cache.c
+++ b/src/common/cache.c
@@ -107,7 +107,7 @@ dt_cache_entry_t *dt_cache_testget(dt_cache_t *cache, const uint32_t key, char m
 {
   gpointer orig_key, value;
   gboolean res;
-  double start = dt_get_wtime();
+  double start = dt_get_debug_wtime();
   dt_pthread_mutex_lock(&cache->lock);
   res = g_hash_table_lookup_extended(cache->hashtable,
                                      GINT_TO_POINTER(key),
@@ -130,7 +130,7 @@ dt_cache_entry_t *dt_cache_testget(dt_cache_t *cache, const uint32_t key, char m
     cache->lru = g_list_remove_link(cache->lru, entry->link);
     cache->lru = g_list_concat(cache->lru, entry->link);
     dt_pthread_mutex_unlock(&cache->lock);
-    double end = dt_get_wtime();
+    double end = dt_get_debug_wtime();
     if(end - start > 0.1)
       dt_print(DT_DEBUG_ALWAYS, "try+ wait time %.06fs mode %c \n", end - start, mode);
 
@@ -145,7 +145,7 @@ dt_cache_entry_t *dt_cache_testget(dt_cache_t *cache, const uint32_t key, char m
     return entry;
   }
   dt_pthread_mutex_unlock(&cache->lock);
-  double end = dt_get_wtime();
+  double end = dt_get_debug_wtime();
   if(end - start > 0.1)
     dt_print(DT_DEBUG_ALWAYS, "try- wait time %.06fs\n", end - start);
   return 0;
@@ -163,7 +163,7 @@ dt_cache_entry_t *dt_cache_get_with_caller(dt_cache_t *cache,
   gpointer orig_key, value;
   gboolean res;
   int result;
-  double start = dt_get_wtime();
+  double start = dt_get_debug_wtime();
 restart:
   dt_pthread_mutex_lock(&cache->lock);
   res = g_hash_table_lookup_extended(cache->hashtable,
@@ -261,7 +261,7 @@ restart:
   cache->lru = g_list_concat(cache->lru, entry->link);
 
   dt_pthread_mutex_unlock(&cache->lock);
-  double end = dt_get_wtime();
+  double end = dt_get_debug_wtime();
   if(end - start > 0.1)
     dt_print(DT_DEBUG_ALWAYS, "wait time %.06fs\n", end - start);
 

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -574,6 +574,11 @@ static inline double dt_get_wtime(void)
   return time.tv_sec - 1290608000 + (1.0 / 1000000.0) * time.tv_usec;
 }
 
+static inline double dt_get_debug_wtime(void)
+{
+  return darktable.unmuted ? dt_get_wtime() : 0.0;
+}
+
 static inline double dt_get_lap_time(double *time)
 {
   double prev = *time;

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -895,7 +895,6 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
     goto end;
   }
 
-  double tstart, tend, tdiff;
   dt_loc_get_user_cache_dir(dtcache, PATH_MAX * sizeof(char));
 
   int len = MIN(strlen(fullname),1024 * sizeof(char));;
@@ -991,7 +990,7 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
 
   // now load all darktable cl kernels.
   // TODO: compile as a job?
-  tstart = dt_get_wtime();
+  double tstart = dt_get_debug_wtime();
   FILE *f = g_fopen(filename, "rb");
   if(f)
   {
@@ -1066,10 +1065,8 @@ static gboolean _opencl_device_init(dt_opencl_t *cl,
     }
 
     fclose(f);
-    tend = dt_get_wtime();
-    tdiff = tend - tstart;
     dt_print_nts(DT_DEBUG_OPENCL,
-                 "   KERNEL LOADING TIME:       %2.4lf sec\n", tdiff);
+                 "   KERNEL LOADING TIME:       %2.4lf sec\n", dt_get_lap_time(&tstart));
   }
   else
   {

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -706,8 +706,7 @@ static int _brush_get_pts_border(dt_develop_t *dev,
                                  int *payload_count,
                                  const int source)
 {
-  double start2 = 0.0;
-  if(darktable.unmuted & DT_DEBUG_PERF) start2 = dt_get_wtime();
+  double start2 = dt_get_debug_wtime();
 
   const float wd = pipe->iwidth;
   const float ht = pipe->iheight;
@@ -789,7 +788,7 @@ static int _brush_get_pts_border(dt_develop_t *dev,
   int cw = 1;
   int start_stamp = 0;
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] brush_points init took %0.04f sec\n", form->name,
            dt_get_lap_time(&start2));
 
@@ -1086,7 +1085,7 @@ static int _brush_get_pts_border(dt_develop_t *dev,
         goto fail;
     }
 
-    dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+    dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
              "[masks %s] path_points end took %0.04f sec\n",
              form->name, dt_get_lap_time(&start2));
 
@@ -2958,9 +2957,8 @@ static int _brush_get_mask(const dt_iop_module_t *const module,
                            int *posy)
 {
   if(!module) return 0;
-  double start = 0.0;
-  double start2 = 0.0;
-  if(darktable.unmuted & DT_DEBUG_PERF) start = start2 = dt_get_wtime();
+  double start = dt_get_debug_wtime();
+  double start2 = start;
 
   // we get buffers for all points
   float *points = NULL, *border = NULL, *payload = NULL;
@@ -3084,9 +3082,8 @@ static int _brush_get_mask_roi(const dt_iop_module_t *const module,
                                float *buffer)
 {
   if(!module) return 0;
-  double start = 0.0;
-  double start2 = 0.0;
-  if(darktable.unmuted & DT_DEBUG_PERF) start = start2 = dt_get_wtime();
+  double start = dt_get_debug_wtime();
+  double start2 = start;
 
   const int px = roi->x;
   const int py = roi->y;

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -1099,8 +1099,7 @@ static int _circle_get_mask(const dt_iop_module_t *const restrict module,
                             int *posx,
                             int *posy)
 {
-  double start2 = 0.0;
-  if(darktable.unmuted & DT_DEBUG_PERF) start2 = dt_get_wtime();
+  double start2 = dt_get_debug_wtime();
 
   // we get the area
   if(!_circle_get_area(module, piece, form, width, height, posx, posy)) return 0;
@@ -1209,10 +1208,8 @@ static int _circle_get_mask_roi(const dt_iop_module_t *const restrict module,
                                 const dt_iop_roi_t *const roi,
                                 float *const restrict buffer)
 {
-  double start1 = 0.0;
+  double start1 = dt_get_debug_wtime();
   double start2 = start1;
-
-  if(darktable.unmuted & DT_DEBUG_PERF) start2 = start1 = dt_get_wtime();
 
   // we get the circle parameters
   dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)((form->points)->data);

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1685,8 +1685,7 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module,
                              int *posx,
                              int *posy)
 {
-  double start2 = 0.0;
-  if(darktable.unmuted & DT_DEBUG_PERF) start2 = dt_get_wtime();
+  double start2 = dt_get_debug_wtime();
 
   // we get the area
   if(!_ellipse_get_area(module, piece, form, width, height, posx, posy)) return 0;
@@ -1774,8 +1773,8 @@ static int _ellipse_get_mask(const dt_iop_module_t *const module,
 
   dt_free_align(points);
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
-           "[masks %s] ellipse fill took %0.04f sec\n", 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
+           "[masks %s] ellipse fill took %0.04f sec\n",
            form->name, dt_get_lap_time(&start2));
 
   return 1;
@@ -1787,9 +1786,8 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
                                  const dt_iop_roi_t *roi,
                                  float *buffer)
 {
-  double start1 = 0.0;
+  double start1 = dt_get_debug_wtime();
   double start2 = start1;
-  if(darktable.unmuted & DT_DEBUG_PERF) start2 = start1 = dt_get_wtime();
 
   // we get the ellipse parameters
   dt_masks_point_ellipse_t *ellipse = (dt_masks_point_ellipse_t *)((form->points)->data);
@@ -1825,7 +1823,7 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
   const int gw = (w + grid - 1) / grid + 1;  // grid dimension of total roi
   const int gh = (h + grid - 1) / grid + 1;  // grid dimension of total roi
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] ellipse init took %0.04f sec\n",
            form->name, dt_get_lap_time(&start2));
 
@@ -1858,7 +1856,7 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
     ell[2 * n + 1] = center[1] + ta * sina * cosp + tb * cosa * sinp;
   }
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] ellipse outline took %0.04f sec\n",
            form->name, dt_get_lap_time(&start2));
 
@@ -1871,7 +1869,7 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
     return 0;
   }
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] ellipse outline transform took %0.04f sec\n",
            form->name, dt_get_lap_time(&start2));
 
@@ -1909,7 +1907,7 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
 
   dt_free_align(ell);
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] ellipse bounding box took %0.04f sec\n",
            form->name, dt_get_lap_time(&start2));
 
@@ -1940,7 +1938,7 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
       points[index * 2 + 1] = (grid * j + py) * iscale;
     }
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] ellipse grid took %0.04f sec\n",
            form->name, dt_get_lap_time(&start2));
 
@@ -1953,7 +1951,7 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
     return 0;
   }
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] ellipse transform took %0.04f sec\n", form->name,
            dt_get_lap_time(&start2));
 
@@ -1962,7 +1960,7 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
   // double the offsets at which they are stored
   _fill_mask((size_t)(bbh)*bbw, points, points, center, a, b, ta, tb, alpha, 1);
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] ellipse draw took %0.04f sec\n", form->name,
            dt_get_wtime() - start2);
 
@@ -1999,12 +1997,12 @@ static int _ellipse_get_mask_roi(const dt_iop_module_t *const module,
 
   dt_free_align(points);
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] ellipse fill took %0.04f sec\n",
-           form->name, dt_get_wtime() - start2);
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+           form->name, dt_get_lap_time(&start2));
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] ellipse total render took %0.04f sec\n", form->name,
-           dt_get_wtime() - start1);
+           dt_get_lap_time(&start1));
 
   return 1;
 }

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -1146,12 +1146,11 @@ static int _gradient_get_mask(const dt_iop_module_t *const module,
                               int *posx,
                               int *posy)
 {
-  double start2 = 0.0;
-  if(darktable.unmuted & DT_DEBUG_PERF) start2 = dt_get_wtime();
+  double start2 = dt_get_debug_wtime();
   // we get the area
   if(!_gradient_get_area(module, piece, form, width, height, posx, posy)) return 0;
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] gradient area took %0.04f sec\n", form->name,
            dt_get_lap_time(&start2));
 
@@ -1188,7 +1187,7 @@ static int _gradient_get_mask(const dt_iop_module_t *const module,
       points[(j * gw + i) * 2 + 1] = (grid * j + py);
     }
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] gradient draw took %0.04f sec\n", form->name,
            dt_get_lap_time(&start2));
 
@@ -1202,7 +1201,7 @@ static int _gradient_get_mask(const dt_iop_module_t *const module,
     return 0;
   }
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] gradient transform took %0.04f sec\n", form->name,
            dt_get_lap_time(&start2));
 
@@ -1321,7 +1320,7 @@ static int _gradient_get_mask(const dt_iop_module_t *const module,
 
   dt_free_align(points);
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] gradient fill took %0.04f sec\n", form->name,
            dt_get_lap_time(&start2));
 
@@ -1335,8 +1334,8 @@ static int _gradient_get_mask_roi(const dt_iop_module_t *const module,
                                   const dt_iop_roi_t *roi,
                                   float *buffer)
 {
-  double start2 = 0.0;
-  if(darktable.unmuted & DT_DEBUG_PERF) start2 = dt_get_wtime();
+  double start2 = dt_get_debug_wtime();
+
   // we get the gradient values
   const dt_masks_point_gradient_t *gradient =
     (dt_masks_point_gradient_t *)(form->points->data);
@@ -1373,7 +1372,7 @@ static int _gradient_get_mask_roi(const dt_iop_module_t *const module,
       points[index * 2 + 1] = (grid * j + py) * iscale;
     }
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] gradient draw took %0.04f sec\n", form->name,
            dt_get_lap_time(&start2));
 
@@ -1387,7 +1386,7 @@ static int _gradient_get_mask_roi(const dt_iop_module_t *const module,
     return 0;
   }
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] gradient transform took %0.04f sec\n", form->name,
            dt_get_lap_time(&start2));
 
@@ -1501,7 +1500,7 @@ static int _gradient_get_mask_roi(const dt_iop_module_t *const module,
 
   dt_free_align(points);
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] gradient fill took %0.04f sec\n", form->name,
            dt_get_lap_time(&start2));
 

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -328,11 +328,11 @@ static int _group_get_mask(const dt_iop_module_t *const module,
                                   &w[pos], &h[pos], &px[pos], &py[pos]);
       if(fpt->state & DT_MASKS_STATE_INVERSE)
       {
-        const double start = dt_get_wtime();
+        double start = dt_get_wtime();
         _inverse_mask(module, piece, sel, &bufs[pos], &w[pos], &h[pos], &px[pos], &py[pos]);
-        dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+        dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
                  "[masks %s] inverse took %0.04f sec\n",
-                 sel->name, dt_get_wtime() - start);
+                 sel->name, dt_get_lap_time(&start));
       }
       op[pos] = fpt->opacity;
       states[pos] = fpt->state;
@@ -362,7 +362,7 @@ static int _group_get_mask(const dt_iop_module_t *const module,
   // and we copy each buffer inside, row by row
   for(int i = 0; i < nb; i++)
   {
-    const double start = dt_get_wtime();
+    double start = dt_get_debug_wtime();
     if(states[i] & (DT_MASKS_STATE_UNION | DT_MASKS_STATE_SUM))
     {
       for(int y = 0; y < h[i]; y++)
@@ -443,9 +443,9 @@ static int _group_get_mask(const dt_iop_module_t *const module,
       }
     }
 
-    dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+    dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
              "[masks %d] combine took %0.04f sec\n",
-             i, dt_get_wtime() - start);
+             i, dt_get_lap_time(&start));
   }
 
   free(op);
@@ -714,8 +714,8 @@ static int _group_get_mask_roi(const dt_iop_module_t *const restrict module,
                                const dt_iop_roi_t *const roi,
                                float *const restrict buffer)
 {
-  double start = dt_get_wtime();
   if(!form->points) return 0;
+  double start = dt_get_debug_wtime();
   int nb_ok = 0;
 
   const int width = roi->width;
@@ -797,7 +797,7 @@ static int _group_get_mask_roi(const dt_iop_module_t *const restrict module,
           }
         }
 
-        dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+        dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
                  "[masks %d] combine took %0.04f sec\n",
                  nb_ok, dt_get_lap_time(&start));
 
@@ -829,14 +829,14 @@ int dt_masks_group_render_roi(dt_iop_module_t *module,
                               const dt_iop_roi_t *roi,
                               float *buffer)
 {
-  const double start = dt_get_wtime();
   if(!form) return 0;
 
+  double start = dt_get_debug_wtime();
   const int ok = dt_masks_get_mask_roi(module, piece, form, roi, buffer);
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks] render all masks took %0.04f sec\n",
-           dt_get_wtime() - start);
+           dt_get_lap_time(&start));
   return ok;
 }
 

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -652,9 +652,7 @@ static int _path_get_pts_border(dt_develop_t *dev,
                                 int *border_count,
                                 const gboolean source)
 {
-  double start2 = 0.0;
-
-  if(darktable.unmuted & DT_DEBUG_PERF) start2 = dt_get_wtime();
+  double start2 = dt_get_debug_wtime();
 
   const float wd = pipe->iwidth, ht = pipe->iheight;
   const guint nb = g_list_length(form->points);
@@ -720,7 +718,7 @@ static int _path_get_pts_border(dt_develop_t *dev,
   int cw = _path_is_clockwise(form);
   if(cw == 0) cw = -1;
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] path_points init took %0.04f sec\n", form->name,
            dt_get_lap_time(&start2));
 
@@ -844,7 +842,7 @@ static int _path_get_pts_border(dt_develop_t *dev,
     dt_masks_dynbuf_free(dborder);
   }
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] path_points point recurs %0.04f sec\n",
            form->name, dt_get_lap_time(&start2));
 
@@ -854,7 +852,7 @@ static int _path_get_pts_border(dt_develop_t *dev,
   {
     inter_count = _path_find_self_intersection(intersections, nb, *border, *border_count);
 
-    dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+    dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
              "[masks %s] path_points self-intersect took %0.04f sec\n", form->name,
              dt_get_lap_time(&start2));
   }
@@ -897,7 +895,7 @@ static int _path_get_pts_border(dt_develop_t *dev,
         goto fail;
     }
 
-    dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+    dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
              "[masks %s] path_points end took %0.04f sec\n",
              form->name, dt_get_lap_time(&start2));
 
@@ -912,7 +910,7 @@ static int _path_get_pts_border(dt_develop_t *dev,
        || dt_dev_distort_transform_plus(dev, pipe, iop_order,
                                         transf_direction, *border, *border_count))
     {
-      dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+      dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
                "[masks %s] path_points transform took %0.04f sec\n", form->name,
                dt_get_lap_time(&start2));
 
@@ -950,7 +948,7 @@ static int _path_get_pts_border(dt_develop_t *dev,
         }
       }
 
-      dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+      dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
                "[masks %s] path_points end took %0.04f sec\n", form->name,
                dt_get_lap_time(&start2));
 
@@ -2557,10 +2555,8 @@ static int _path_get_mask(const dt_iop_module_t *const module,
                           int *posy)
 {
   if(!module) return 0;
-  double start = 0.0;
-  double start2 = 0.0;
-
-  if(darktable.unmuted & DT_DEBUG_PERF) start = dt_get_wtime();
+  double start = dt_get_debug_wtime();
+  double start2 = start;
 
   // we get buffers for all points
   float *points = NULL, *border = NULL;
@@ -2575,7 +2571,7 @@ static int _path_get_mask(const dt_iop_module_t *const module,
     return 0;
   }
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] path points took %0.04f sec\n",
            form->name, dt_get_lap_time(&start));
   start2 = start;
@@ -2588,7 +2584,7 @@ static int _path_get_mask(const dt_iop_module_t *const module,
   const int hb = *height;
   const int wb = *width;
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] path_fill min max took %0.04f sec\n", form->name,
            dt_get_lap_time(&start2));
 
@@ -2710,7 +2706,7 @@ static int _path_get_mask(const dt_iop_module_t *const module,
       if(ii != i) break;
     }
   }
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] path_fill draw path took %0.04f sec\n", form->name,
            dt_get_lap_time(&start2));
 
@@ -2730,7 +2726,7 @@ static int _path_get_mask(const dt_iop_module_t *const module,
     }
   }
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] path_fill fill plain took %0.04f sec\n", form->name,
            dt_get_lap_time(&start2));
 
@@ -2774,14 +2770,14 @@ static int _path_get_mask(const dt_iop_module_t *const module,
     }
   }
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] path_fill fill falloff took %0.04f sec\n", form->name,
            dt_get_lap_time(&start2));
 
   dt_free_align(points);
   dt_free_align(border);
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] path fill buffer took %0.04f sec\n", form->name,
            dt_get_lap_time(&start));
 
@@ -2992,9 +2988,8 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
                               float *buffer)
 {
   if(!module) return 0;
-  double start = 0.0;
+  double start = dt_get_debug_wtime();
   double start2 = 0.0;
-  if(darktable.unmuted & DT_DEBUG_PERF) start = dt_get_wtime();
 
   const int px = roi->x;
   const int py = roi->y;
@@ -3024,7 +3019,7 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
     return 0;
   }
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] path points took %0.04f sec\n",
            form->name, dt_get_lap_time(&start));
   start2 = start;
@@ -3125,11 +3120,11 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
   _path_bounding_box_raw(points, border, nb_corner, points_count, border_count,
                          &xmin, &xmax, &ymin, &ymax);
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] path_fill min max took %0.04f sec\n", form->name,
            dt_get_lap_time(&start2));
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] path_fill clear mask took %0.04f sec\n", form->name,
            dt_get_lap_time(&start2));
 
@@ -3159,7 +3154,7 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
                                                height);
     path_encircles_roi = path_encircles_roi || !crop_success;
 
-    dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+    dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
              "[masks %s] path_fill crop to roi took %0.04f sec\n", form->name,
              dt_get_lap_time(&start2));
 
@@ -3216,7 +3211,7 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
         }
       }
 
-      dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+      dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
                "[masks %s] path_fill draw path took %0.04f sec\n", form->name,
                dt_get_lap_time(&start2));
 
@@ -3248,7 +3243,7 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
         }
       }
 
-      dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+      dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
                "[masks %s] path_fill fill plain took %0.04f sec\n", form->name,
                dt_get_lap_time(&start2));
     }
@@ -3332,7 +3327,7 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
 
     dt_free_align(dpoints);
 
-    dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+    dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
              "[masks %s] path_fill fill falloff took %0.04f sec\n", form->name,
              dt_get_lap_time(&start2));
   }
@@ -3340,7 +3335,7 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
   dt_free_align(points);
   dt_free_align(border);
 
-  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF, 
+  dt_print(DT_DEBUG_MASKS | DT_DEBUG_PERF,
            "[masks %s] path fill buffer took %0.04f sec\n", form->name,
            dt_get_lap_time(&start));
 

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -522,10 +522,7 @@ void dt_dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe,
 void dt_dev_pixelpipe_synch_all(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
 {
   dt_pthread_mutex_lock(&pipe->busy_mutex);
-  double start = 0.0;
-  double defaults = 0.0;
-  if(darktable.unmuted & DT_DEBUG_PIPE)
-    start = dt_get_wtime();
+  double start = dt_get_debug_wtime();
 
   dev->cropping.exposer = NULL;
   dt_print_pipe(DT_DEBUG_PARAMS, "synch all modules with defaults",
@@ -543,8 +540,7 @@ void dt_dev_pixelpipe_synch_all(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
                          piece->module->default_blendop_params,
                          pipe, piece);
   }
-  if(darktable.unmuted & DT_DEBUG_PIPE)
-    defaults = dt_get_wtime();
+  double defaults = dt_get_debug_wtime();
 
   dt_print_pipe(DT_DEBUG_PARAMS, "synch all modules with history",
     pipe, NULL, NULL, NULL, "\n");

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1773,9 +1773,9 @@ void dt_culling_update_active_images_list(dt_culling_t *table)
 void dt_culling_full_redraw(dt_culling_t *table, const gboolean force)
 {
   if(!gtk_widget_get_visible(table->widget)) return;
-  const double start = dt_get_wtime();
   // first, we see if we need to do something
   if(!_compute_sizes(table, force)) return;
+  const double start = dt_get_debug_wtime();
 
   // we store first image zoom and pos for new ones
   float old_zx = 0.0;

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -2282,7 +2282,7 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table,
     // we update the scrollbars
     _thumbtable_update_scrollbars(table);
 
-    const double start = dt_get_wtime();
+    const double start = dt_get_debug_wtime();
     table->dragging = FALSE;
     sqlite3_stmt *stmt;
     dt_print(DT_DEBUG_LIGHTTABLE,

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -389,7 +389,7 @@ void expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t
 {
   dt_library_t *lib = (dt_library_t *)self->data;
 
-  const double start = dt_get_wtime();
+  const double start = dt_get_debug_wtime();
   const dt_lighttable_layout_t layout = dt_view_lighttable_get_layout(darktable.view_manager);
 
   // Let's show full preview if in that state...
@@ -429,8 +429,8 @@ void expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t
   // we have started the first expose
   lib->already_started = TRUE;
 
-  dt_print(DT_DEBUG_LIGHTTABLE | DT_DEBUG_PERF, 
-           "[lighttable] expose took %0.04f sec\n", 
+  dt_print(DT_DEBUG_LIGHTTABLE | DT_DEBUG_PERF,
+           "[lighttable] expose took %0.04f sec\n",
            dt_get_wtime() - start);
 }
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -711,10 +711,7 @@ dt_view_surface_value_t dt_view_image_get_surface(const dt_imgid_t imgid,
                                                   cairo_surface_t **surface,
                                                   const gboolean quality)
 {
-  double tt = 0;
-  if((darktable.unmuted & (DT_DEBUG_LIGHTTABLE | DT_DEBUG_PERF)) ==
-     (DT_DEBUG_LIGHTTABLE | DT_DEBUG_PERF))
-    tt = dt_get_wtime();
+  const double tt = dt_get_debug_wtime();
 
   dt_view_surface_value_t ret = DT_VIEW_SURFACE_KO;
   // if surface not null, clean it up


### PR DESCRIPTION
In many cases we require the dt_get_wtime() only for debug log output, the new inline function returns zero in case darktable.unmuted is zero.

Instead of doing some macro stuff as for dt_print() variants i took the simple solution as sufficient. 