### PR TITLE
fix openstreetmap location search string

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -3600,7 +3600,7 @@
   <dtconfig>
     <name>plugins/map/geotagging_search_url</name>
     <type>string</type>
-    <default>https://nominatim.openstreetmap.org/search/%s?format=xml&amp;limit=%d&amp;polygon_text=1</default>
+    <default>https://nominatim.openstreetmap.org/search?q=%s&amp;format=xml&amp;limit=%d&amp;polygon_text=1</default>
     <shortdescription>Geotagging search URL</shortdescription>
     <longdescription>this can be changed when the default OpenStreetMap search URL is broken</longdescription>
   </dtconfig>

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -351,7 +351,13 @@ static gboolean _lib_location_search(gpointer user_data)
   clear_search(lib);
 
   /* build the query url */
-  const char *search_url = dt_conf_get_string_const("plugins/map/geotagging_search_url");
+  const char *conf_name = "plugins/map/geotagging_search_url";
+  const char *search_url = dt_conf_get_string_const(conf_name);
+  if(!g_strcmp0(search_url, "https://nominatim.openstreetmap.org/search/%s?format=xml&limit=%d&polygon_text=1"))
+  {
+    dt_conf_set_string(conf_name, NULL); // reset to new default
+    search_url = dt_conf_get_string_const(conf_name);
+  }
   query = g_strdup_printf(search_url, text, LIMIT_RESULT);
   /* load url */
   curl = curl_easy_init();


### PR DESCRIPTION
fixes #15072

Using `dt_conf_set_string(conf_name, NULL);` to reset to default and then rereading, rather than `dt_confgen_get(conf_name DT_DEFAULT);` and writing that back, because otherwise would have to add two `g_free`s :-)
