### PR TITLE
switch off frames when in tone equalizer

### DIFF
--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -337,6 +337,12 @@ int flags()
   return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING;
 }
 
+int operation_tags_filter()
+{
+  // switch off borders
+  return IOP_TAG_DECORATION;
+}
+
 dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
                                             dt_dev_pixelpipe_t *pipe,
                                             dt_dev_pixelpipe_iop_t *piece)


### PR DESCRIPTION
If there is a border created using the framing module, the tone equalizer cursor gets confused when trying to pick luminosity from the image; it thinks the image still has its original width.

This is probably not the _correct_ fix; the coordinates could be corrected for whatever transformations happen after the module instead. But there are probably more issues that could be fixed here, so if I tried to address this minor issue I might get sucked into a rabid hole again.

And maybe this _is_ the correct fix, since leaving watermarks etc in place while making adjustments using the equalizer cursor does not work as one might expect.

What do you think @jenshannoschwalm ?