### PR TITLE
Guided filter OpenCL fixes

### DIFF
--- a/data/kernels/blendop.cl
+++ b/data/kernels/blendop.cl
@@ -942,7 +942,7 @@ blendop_RAW(__read_only image2d_t in_a, __read_only image2d_t in_b, __read_only 
 
   }
 
-  write_imagef(out, (int2)(x, y), (float4)(o, 0.0f, 0.0f, 0.0f));
+  write_imagef(out, (int2)(x, y), o);
 }
 
 

--- a/data/kernels/guided_filter.cl
+++ b/data/kernels/guided_filter.cl
@@ -1,6 +1,7 @@
 /*
     This file is part of darktable,
     copyright (c) 2019 Heiko Bauke
+    Copyright (C) 2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -18,33 +19,41 @@
 
 #include "common.h"
 
-kernel void guided_filter_split_rgb_image(const int width, const int height, read_only image2d_t in,
-                                          write_only image2d_t out_r, write_only image2d_t out_g,
-                                          write_only image2d_t out_b, const float guide_weight)
+kernel void guided_filter_split_rgb_image(const int width,
+                                          const int height,
+                                          read_only image2d_t guide,
+                                          write_only image2d_t out_r,
+                                          write_only image2d_t out_g,
+                                          write_only image2d_t out_b,
+                                          const float guide_weight)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
   if(x >= width || y >= height) return;
 
-  const float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
-  write_imagef(out_r, (int2)(x, y), (float4)(pixel.x * guide_weight, 0.0f, 0.0f, 0.0f));
-  write_imagef(out_g, (int2)(x, y), (float4)(pixel.y * guide_weight, 0.0f, 0.0f, 0.0f));
-  write_imagef(out_b, (int2)(x, y), (float4)(pixel.z * guide_weight, 0.0f, 0.0f, 0.0f));
+  const float4 weight = { guide_weight, guide_weight, guide_weight, 0.0f };
+  const float4 pixel = weight * read_imagef(guide, sampleri, (int2)(x, y));
+  write_imagef(out_r, (int2)(x, y), pixel.x);
+  write_imagef(out_g, (int2)(x, y), pixel.y);
+  write_imagef(out_b, (int2)(x, y), pixel.z);
 }
 
 
 // Kahan summation algorithm
-#define Kahan_sum(m, c, add)                                                                                      \
-  {                                                                                                               \
-    const float t1 = (add) - (c);                                                                                 \
-    const float t2 = (m) + t1;                                                                                    \
-    c = (t2 - m) - t1;                                                                                            \
-    m = t2;                                                                                                       \
+#define Kahan_sum(m, c, add)        \
+  {                                 \
+    const float t1 = (add) - (c);   \
+    const float t2 = (m) + t1;      \
+    c = (t2 - m) - t1;              \
+    m = t2;                         \
   }
 
 
-kernel void guided_filter_box_mean_x(const int width, const int height, read_only image2d_t in,
-                                     write_only image2d_t out, const int w)
+kernel void guided_filter_box_mean_x(const int width,
+                                     const int height,
+                                     read_only image2d_t in,
+                                     write_only image2d_t out,
+                                     const int w)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -55,25 +64,25 @@ kernel void guided_filter_box_mean_x(const int width, const int height, read_onl
   {
     for(int i = 0, i_end = w + 1; i < i_end; i++)
     {
-      Kahan_sum(m, c, read_imagef(in, sampleri, (int2)(i, y)).x);
+      Kahan_sum(m, c, read_imagef(in, samplerA, (int2)(i, y)).x);
       n_box += 1.f;
     }
     for(int i = 0, i_end = w; i < i_end; i++)
     {
-      write_imagef(out, (int2)(i, y), (float4)(m / n_box, 0.0f, 0.0f, 0.0f));
-      Kahan_sum(m, c, read_imagef(in, sampleri, (int2)(i + w + 1, y)).x);
+      write_imagef(out, (int2)(i, y), m / n_box);
+      Kahan_sum(m, c, read_imagef(in, samplerA, (int2)(i + w + 1, y)).x);
       n_box += 1.f;
     }
     for(int i = w, i_end = width - w - 1; i < i_end; i++)
     {
-      write_imagef(out, (int2)(i, y), (float4)(m / n_box, 0.0f, 0.0f, 0.0f));
-      Kahan_sum(m, c, read_imagef(in, sampleri, (int2)(i + w + 1, y)).x);
-      Kahan_sum(m, c, -read_imagef(in, sampleri, (int2)(i - w, y)).x);
+      write_imagef(out, (int2)(i, y), m / n_box);
+      Kahan_sum(m, c, read_imagef(in, samplerA, (int2)(i + w + 1, y)).x);
+      Kahan_sum(m, c, -read_imagef(in, samplerA, (int2)(i - w, y)).x);
     }
     for(int i = width - w - 1, i_end = width; i < i_end; i++)
     {
-      write_imagef(out, (int2)(i, y), (float4)(m / n_box, 0.0f, 0.0f, 0.0f));
-      Kahan_sum(m, c, -read_imagef(in, sampleri, (int2)(i - w, y)).x);
+      write_imagef(out, (int2)(i, y), m / n_box);
+      Kahan_sum(m, c, -read_imagef(in, samplerA, (int2)(i - w, y)).x);
       n_box -= 1.f;
     }
   }
@@ -81,20 +90,20 @@ kernel void guided_filter_box_mean_x(const int width, const int height, read_onl
   {
     for(int i = 0, i_end = min(w + 1, width); i < i_end; i++)
     {
-      Kahan_sum(m, c, read_imagef(in, sampleri, (int2)(i, y)).x);
+      Kahan_sum(m, c, read_imagef(in, samplerA, (int2)(i, y)).x);
       n_box += 1.f;
     }
     for(int i = 0; i < width; i++)
     {
-      write_imagef(out, (int2)(i, y), (float4)(m / n_box, 0.0f, 0.0f, 0.0f));
+      write_imagef(out, (int2)(i, y), m / n_box);
       if(i - w >= 0)
       {
-        Kahan_sum(m, c, -read_imagef(in, sampleri, (int2)(i - w, y)).x);
+        Kahan_sum(m, c, -read_imagef(in, samplerA, (int2)(i - w, y)).x);
         n_box -= 1.f;
       }
       if(i + w + 1 < width)
       {
-        Kahan_sum(m, c, read_imagef(in, sampleri, (int2)(i + w + 1, y)).x);
+        Kahan_sum(m, c, read_imagef(in, samplerA, (int2)(i + w + 1, y)).x);
         n_box += 1.f;
       }
     }
@@ -102,8 +111,11 @@ kernel void guided_filter_box_mean_x(const int width, const int height, read_onl
 }
 
 
-kernel void guided_filter_box_mean_y(const int width, const int height, read_only image2d_t in,
-                                     write_only image2d_t out, const int w)
+kernel void guided_filter_box_mean_y(const int width,
+                                     const int height,
+                                     read_only image2d_t in,
+                                     write_only image2d_t out,
+                                     const int w)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -114,25 +126,25 @@ kernel void guided_filter_box_mean_y(const int width, const int height, read_onl
   {
     for(int i = 0, i_end = w + 1; i < i_end; i++)
     {
-      Kahan_sum(m, c, read_imagef(in, sampleri, (int2)(x, i)).x);
+      Kahan_sum(m, c, read_imagef(in, samplerA, (int2)(x, i)).x);
       n_box += 1.f;
     }
     for(int i = 0, i_end = w; i < i_end; i++)
     {
-      write_imagef(out, (int2)(x, i), (float4)(m / n_box, 0.0f, 0.0f, 0.0f));
-      Kahan_sum(m, c, read_imagef(in, sampleri, (int2)(x, i + w + 1)).x);
+      write_imagef(out, (int2)(x, i), m / n_box);
+      Kahan_sum(m, c, read_imagef(in, samplerA, (int2)(x, i + w + 1)).x);
       n_box += 1.f;
     }
     for(int i = w, i_end = height - w - 1; i < i_end; i++)
     {
-      write_imagef(out, (int2)(x, i), (float4)(m / n_box, 0.0f, 0.0f, 0.0f));
-      Kahan_sum(m, c, read_imagef(in, sampleri, (int2)(x, i + w + 1)).x);
-      Kahan_sum(m, c, -read_imagef(in, sampleri, (int2)(x, i - w)).x);
+      write_imagef(out, (int2)(x, i), m / n_box);
+      Kahan_sum(m, c, read_imagef(in, samplerA, (int2)(x, i + w + 1)).x);
+      Kahan_sum(m, c, -read_imagef(in, samplerA, (int2)(x, i - w)).x);
     }
     for(int i = height - w - 1, i_end = height; i < i_end; i++)
     {
-      write_imagef(out, (int2)(x, i), (float4)(m / n_box, 0.0f, 0.0f, 0.0f));
-      Kahan_sum(m, c, -read_imagef(in, sampleri, (int2)(x, i - w)).x);
+      write_imagef(out, (int2)(x, i), m / n_box);
+      Kahan_sum(m, c, -read_imagef(in, samplerA, (int2)(x, i - w)).x);
       n_box -= 1.f;
     }
   }
@@ -140,20 +152,20 @@ kernel void guided_filter_box_mean_y(const int width, const int height, read_onl
   {
     for(int i = 0, i_end = min(w + 1, height); i < i_end; i++)
     {
-      Kahan_sum(m, c, read_imagef(in, sampleri, (int2)(x, i)).x);
+      Kahan_sum(m, c, read_imagef(in, samplerA, (int2)(x, i)).x);
       n_box += 1.f;
     }
     for(int i = 0; i < height; i++)
     {
-      write_imagef(out, (int2)(x, i), (float4)(m / n_box, 0.0f, 0.0f, 0.0f));
+      write_imagef(out, (int2)(x, i), m / n_box);
       if(i - w >= 0)
       {
-        Kahan_sum(m, c, -read_imagef(in, sampleri, (int2)(x, i - w)).x);
+        Kahan_sum(m, c, -read_imagef(in, samplerA, (int2)(x, i - w)).x);
         n_box -= 1.f;
       }
       if(i + w + 1 < height)
       {
-        Kahan_sum(m, c, read_imagef(in, sampleri, (int2)(x, i + w + 1)).x);
+        Kahan_sum(m, c, read_imagef(in, samplerA, (int2)(x, i + w + 1)).x);
         n_box += 1.f;
       }
     }
@@ -161,91 +173,114 @@ kernel void guided_filter_box_mean_y(const int width, const int height, read_onl
 }
 
 
-kernel void guided_filter_covariances(const int width, const int height, read_only image2d_t imgg,
-                                      read_only image2d_t img, write_only image2d_t cov_imgg_img_r,
-                                      write_only image2d_t cov_imgg_img_g, write_only image2d_t cov_imgg_img_b,
+kernel void guided_filter_covariances(const int width,
+                                      const int height,
+                                      read_only image2d_t guide,
+                                      read_only image2d_t img,
+                                      write_only image2d_t cov_imgg_img_r,
+                                      write_only image2d_t cov_imgg_img_g,
+                                      write_only image2d_t cov_imgg_img_b,
                                       const float guide_weight)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
   if(x >= width || y >= height) return;
 
-  float4 pixel = read_imagef(imgg, sampleri, (int2)(x, y));
-  pixel.x *= guide_weight;
-  pixel.y *= guide_weight;
-  pixel.z *= guide_weight;
-  const float img_ = read_imagef(img, sampleri, (int2)(x, y)).x;
-  write_imagef(cov_imgg_img_r, (int2)(x, y), (float4)(pixel.x * img_, 0.f, 0.f, 0.f));
-  write_imagef(cov_imgg_img_g, (int2)(x, y), (float4)(pixel.y * img_, 0.f, 0.f, 0.f));
-  write_imagef(cov_imgg_img_b, (int2)(x, y), (float4)(pixel.z * img_, 0.f, 0.f, 0.f));
+  const float4 weight = { guide_weight, guide_weight, guide_weight, 0.0f };
+  const float img_ = read_imagef(img, samplerA, (int2)(x, y)).x;
+  const float4 imgv = { img_, img_, img_, 0.0f };
+  const float4 pixel = imgv * weight * read_imagef(guide, sampleri, (int2)(x, y));
+  write_imagef(cov_imgg_img_r, (int2)(x, y), pixel.x);
+  write_imagef(cov_imgg_img_g, (int2)(x, y), pixel.y);
+  write_imagef(cov_imgg_img_b, (int2)(x, y), pixel.z);
 }
 
 
-kernel void guided_filter_variances(const int width, const int height, read_only image2d_t imgg,
-                                    write_only image2d_t var_imgg_rr, write_only image2d_t var_imgg_rg,
-                                    write_only image2d_t var_imgg_rb, write_only image2d_t var_imgg_gg,
-                                    write_only image2d_t var_imgg_gb, write_only image2d_t var_imgg_bb,
+kernel void guided_filter_variances(const int width,
+                                    const int height,
+                                    read_only image2d_t guide,
+                                    write_only image2d_t var_imgg_rr,
+                                    write_only image2d_t var_imgg_rg,
+                                    write_only image2d_t var_imgg_rb,
+                                    write_only image2d_t var_imgg_gg,
+                                    write_only image2d_t var_imgg_gb,
+                                    write_only image2d_t var_imgg_bb,
                                     const float guide_weight)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
   if(x >= width || y >= height) return;
 
-  float4 pixel = read_imagef(imgg, sampleri, (int2)(x, y));
-  pixel.x *= guide_weight;
-  pixel.y *= guide_weight;
-  pixel.z *= guide_weight;
-  write_imagef(var_imgg_rr, (int2)(x, y), (float4)(pixel.x * pixel.x, 0.f, 0.f, 0.f));
-  write_imagef(var_imgg_rg, (int2)(x, y), (float4)(pixel.x * pixel.y, 0.f, 0.f, 0.f));
-  write_imagef(var_imgg_rb, (int2)(x, y), (float4)(pixel.x * pixel.z, 0.f, 0.f, 0.f));
-  write_imagef(var_imgg_gg, (int2)(x, y), (float4)(pixel.y * pixel.y, 0.f, 0.f, 0.f));
-  write_imagef(var_imgg_gb, (int2)(x, y), (float4)(pixel.y * pixel.z, 0.f, 0.f, 0.f));
-  write_imagef(var_imgg_bb, (int2)(x, y), (float4)(pixel.z * pixel.z, 0.f, 0.f, 0.f));
+  const float4 weight = { guide_weight, guide_weight, guide_weight, 0.0f };
+  const float4 pixel = weight * read_imagef(guide, sampleri, (int2)(x, y));
+  write_imagef(var_imgg_rr, (int2)(x, y), pixel.x * pixel.x);
+  write_imagef(var_imgg_rg, (int2)(x, y), pixel.x * pixel.y);
+  write_imagef(var_imgg_rb, (int2)(x, y), pixel.x * pixel.z);
+  write_imagef(var_imgg_gg, (int2)(x, y), pixel.y * pixel.y);
+  write_imagef(var_imgg_gb, (int2)(x, y), pixel.y * pixel.z);
+  write_imagef(var_imgg_bb, (int2)(x, y), pixel.z * pixel.z);
 }
 
 
-kernel void guided_filter_update_covariance(const int width, const int height, read_only image2d_t in,
-                                            write_only image2d_t out, read_only image2d_t a, read_only image2d_t b,
+kernel void guided_filter_update_covariance(const int width,
+                                            const int height,
+                                            read_only image2d_t in,
+                                            write_only image2d_t out,
+                                            read_only image2d_t a,
+                                            read_only image2d_t b,
                                             const float eps)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
   if(x >= width || y >= height) return;
 
-  const float in_val = read_imagef(in, sampleri, (int2)(x, y)).x;
-  const float a_val = read_imagef(a, sampleri, (int2)(x, y)).x;
-  const float b_val = read_imagef(b, sampleri, (int2)(x, y)).x;
-  write_imagef(out, (int2)(x, y), (float4)(in_val - a_val * b_val + eps, 0.f, 0.f, 0.f));
+  const float i_val = read_imagef(in, samplerA, (int2)(x, y)).x;
+  const float a_val = read_imagef(a,  samplerA, (int2)(x, y)).x;
+  const float b_val = read_imagef(b,  samplerA, (int2)(x, y)).x;
+  write_imagef(out, (int2)(x, y), i_val - a_val * b_val + eps);
 }
 
 
-kernel void guided_filter_solve(const int width, const int height, read_only image2d_t img_mean,
-                                read_only image2d_t imgg_mean_r, read_only image2d_t imgg_mean_g,
-                                read_only image2d_t imgg_mean_b, read_only image2d_t cov_imgg_img_r,
-                                read_only image2d_t cov_imgg_img_g, read_only image2d_t cov_imgg_img_b,
-                                read_only image2d_t var_imgg_rr, read_only image2d_t var_imgg_rg,
-                                read_only image2d_t var_imgg_rb, read_only image2d_t var_imgg_gg,
-                                read_only image2d_t var_imgg_gb, read_only image2d_t var_imgg_bb,
-                                write_only image2d_t a_r, write_only image2d_t a_g, write_only image2d_t a_b,
+kernel void guided_filter_solve(const int width,
+                                const int height,
+                                read_only image2d_t img_mean,
+                                read_only image2d_t imgg_mean_r,
+                                read_only image2d_t imgg_mean_g,
+                                read_only image2d_t imgg_mean_b,
+                                read_only image2d_t cov_imgg_img_r,
+                                read_only image2d_t cov_imgg_img_g,
+                                read_only image2d_t cov_imgg_img_b,
+                                read_only image2d_t var_imgg_rr,
+                                read_only image2d_t var_imgg_rg,
+                                read_only image2d_t var_imgg_rb,
+                                read_only image2d_t var_imgg_gg,
+                                read_only image2d_t var_imgg_gb,
+                                read_only image2d_t var_imgg_bb,
+                                write_only image2d_t a_r,
+                                write_only image2d_t a_g,
+                                write_only image2d_t a_b,
                                 write_only image2d_t b)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
   if(x >= width || y >= height) return;
 
-  const float Sigma_0_0 = read_imagef(var_imgg_rr, sampleri, (int2)(x, y)).x;
-  const float Sigma_0_1 = read_imagef(var_imgg_rg, sampleri, (int2)(x, y)).x;
-  const float Sigma_0_2 = read_imagef(var_imgg_rb, sampleri, (int2)(x, y)).x;
-  const float Sigma_1_1 = read_imagef(var_imgg_gg, sampleri, (int2)(x, y)).x;
-  const float Sigma_1_2 = read_imagef(var_imgg_gb, sampleri, (int2)(x, y)).x;
-  const float Sigma_2_2 = read_imagef(var_imgg_bb, sampleri, (int2)(x, y)).x;
-  const float cov_imgg_img[3] = { read_imagef(cov_imgg_img_r, sampleri, (int2)(x, y)).x,
-                                  read_imagef(cov_imgg_img_g, sampleri, (int2)(x, y)).x,
-                                  read_imagef(cov_imgg_img_b, sampleri, (int2)(x, y)).x };
+  const float Sigma_0_0 = read_imagef(var_imgg_rr, samplerA, (int2)(x, y)).x;
+  const float Sigma_0_1 = read_imagef(var_imgg_rg, samplerA, (int2)(x, y)).x;
+  const float Sigma_0_2 = read_imagef(var_imgg_rb, samplerA, (int2)(x, y)).x;
+  const float Sigma_1_1 = read_imagef(var_imgg_gg, samplerA, (int2)(x, y)).x;
+  const float Sigma_1_2 = read_imagef(var_imgg_gb, samplerA, (int2)(x, y)).x;
+  const float Sigma_2_2 = read_imagef(var_imgg_bb, samplerA, (int2)(x, y)).x;
+  const float cov_imgg_img[3] = { read_imagef(cov_imgg_img_r, samplerA, (int2)(x, y)).x,
+                                  read_imagef(cov_imgg_img_g, samplerA, (int2)(x, y)).x,
+                                  read_imagef(cov_imgg_img_b, samplerA, (int2)(x, y)).x };
   const float det0 = Sigma_0_0 * (Sigma_1_1 * Sigma_2_2 - Sigma_1_2 * Sigma_1_2)
                      - Sigma_0_1 * (Sigma_0_1 * Sigma_2_2 - Sigma_0_2 * Sigma_1_2)
                      + Sigma_0_2 * (Sigma_0_1 * Sigma_1_2 - Sigma_0_2 * Sigma_1_1);
-  float a_r_, a_g_, a_b_;
+  float a_r_ = 0.0f;
+  float a_g_ = 0.0f;
+  float a_b_ = 0.0f;
+  float b_ = read_imagef(img_mean, samplerA, (int2)(x, y)).x;
   if(fabs(det0) > 4.f * FLT_EPSILON)
   {
     const float det1 = cov_imgg_img[0] * (Sigma_1_1 * Sigma_2_2 - Sigma_1_2 * Sigma_1_2)
@@ -260,44 +295,40 @@ kernel void guided_filter_solve(const int width, const int height, read_only ima
     a_r_ = det1 / det0;
     a_g_ = det2 / det0;
     a_b_ = det3 / det0;
+    b_ =  b_
+        - a_r_ * read_imagef(imgg_mean_r, samplerA, (int2)(x, y)).x
+        - a_g_ * read_imagef(imgg_mean_g, samplerA, (int2)(x, y)).x
+        - a_b_ * read_imagef(imgg_mean_b, samplerA, (int2)(x, y)).x;
   }
-  else
-  {
-    // linear system is singular
-    a_r_ = 0.f;
-    a_g_ = 0.f;
-    a_b_ = 0.f;
-  }
-  write_imagef(a_r, (int2)(x, y), (float4)(a_r_, 0.f, 0.f, 0.f));
-  write_imagef(a_g, (int2)(x, y), (float4)(a_g_, 0.f, 0.f, 0.f));
-  write_imagef(a_b, (int2)(x, y), (float4)(a_b_, 0.f, 0.f, 0.f));
-  write_imagef(b, (int2)(x, y),
-               (float4)(read_imagef(img_mean, sampleri, (int2)(x, y)).x
-                            - a_r_ * read_imagef(imgg_mean_r, sampleri, (int2)(x, y)).x
-                            - a_g_ * read_imagef(imgg_mean_g, sampleri, (int2)(x, y)).x
-                            - a_b_ * read_imagef(imgg_mean_b, sampleri, (int2)(x, y)).x,
-                        0.f, 0.f, 0.f));
+
+  write_imagef(a_r, (int2)(x, y), a_r_);
+  write_imagef(a_g, (int2)(x, y), a_g_);
+  write_imagef(a_b, (int2)(x, y), a_b_);
+  write_imagef(b,   (int2)(x, y), b_);
 }
 
 
-kernel void guided_filter_generate_result(const int width, const int height, read_only image2d_t imgg,
-                                          read_only image2d_t a_r, read_only image2d_t a_g,
-                                          read_only image2d_t a_b, read_only image2d_t b, write_only image2d_t res,
-                                          const float guide_weight, const float min_, const float max_)
+kernel void guided_filter_generate_result(const int width,
+                                          const int height,
+                                          read_only image2d_t guide,
+                                          read_only image2d_t a_r,
+                                          read_only image2d_t a_g,
+                                          read_only image2d_t a_b,
+                                          read_only image2d_t b,
+                                          write_only image2d_t res,
+                                          const float guide_weight,
+                                          const float minval,
+                                          const float maxval)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
   if(x >= width || y >= height) return;
 
-  const float4 imgg_ = read_imagef(imgg, sampleri, (int2)(x, y));
-  const float a_r_ = read_imagef(a_r, sampleri, (int2)(x, y)).x;
-  const float a_g_ = read_imagef(a_g, sampleri, (int2)(x, y)).x;
-  const float a_b_ = read_imagef(a_b, sampleri, (int2)(x, y)).x;
-  const float b_ = read_imagef(b, sampleri, (int2)(x, y)).x;
-  float res_ = imgg_.x * a_r_ + imgg_.y * a_g_ + imgg_.z * a_b_;
-  res_ *= guide_weight;
-  res_ += b_;
-  if(res_ < min_) res_ = min_;
-  if(res_ > max_) res_ = max_;
-  write_imagef(res, (int2)(x, y), (float4)(res_, 0.f, 0.f, 0.f));
+  const float4 pixel = read_imagef(guide, sampleri, (int2)(x, y));
+  const float a_r_ = pixel.x * read_imagef(a_r, samplerA, (int2)(x, y)).x;
+  const float a_g_ = pixel.y * read_imagef(a_g, samplerA, (int2)(x, y)).x;
+  const float a_b_ = pixel.z * read_imagef(a_b, samplerA, (int2)(x, y)).x;
+  const float b_ =   read_imagef(b,   samplerA, (int2)(x, y)).x;
+  const float res_ = guide_weight * (a_r_ + a_g_ + a_b_) + b_;
+  write_imagef(res, (int2)(x, y), fmin(maxval, fmax(minval, res_)));
 }

--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -289,8 +289,7 @@ dt_guided_filter_cl_global_t *dt_guided_filter_init_cl_global()
   g->kernel_guided_filter_split_rgb = dt_opencl_create_kernel(program, "guided_filter_split_rgb_image");
   g->kernel_guided_filter_box_mean_x = dt_opencl_create_kernel(program, "guided_filter_box_mean_x");
   g->kernel_guided_filter_box_mean_y = dt_opencl_create_kernel(program, "guided_filter_box_mean_y");
-  g->kernel_guided_filter_guided_filter_covariances
-      = dt_opencl_create_kernel(program, "guided_filter_covariances");
+  g->kernel_guided_filter_guided_filter_covariances = dt_opencl_create_kernel(program, "guided_filter_covariances");
   g->kernel_guided_filter_guided_filter_variances = dt_opencl_create_kernel(program, "guided_filter_variances");
   g->kernel_guided_filter_update_covariance = dt_opencl_create_kernel(program, "guided_filter_update_covariance");
   g->kernel_guided_filter_solve = dt_opencl_create_kernel(program, "guided_filter_solve");
@@ -614,7 +613,7 @@ void guided_filter_cl(int devid,
                       cl_mem guide,
                       cl_mem in,
                       cl_mem out,
-                      const int width,
+                      const int width,          // width & height are roi_out
                       const int height,
                       const int ch,
                       const int w,              // window size

--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -323,8 +323,10 @@ static int _cl_split_rgb(const int devid,
                           cl_mem imgg_b,
                           const float guide_weight)
 {
+  const int clwidth = ROUNDUPDWD(width, devid);
+  const int clheight = ROUNDUPDHT(height, devid);
   const int kernel = darktable.opencl->guided_filter->kernel_guided_filter_split_rgb;
-  return dt_opencl_enqueue_kernel_2d_args(devid, kernel, width, height,
+  return dt_opencl_enqueue_kernel_2d_args(devid, kernel, clwidth, clheight,
     CLARG(width), CLARG(height), CLARG(guide), CLARG(imgg_r), CLARG(imgg_g), CLARG(imgg_b), CLARG(guide_weight));
 }
 
@@ -337,15 +339,18 @@ static int _cl_box_mean(const int devid,
                         cl_mem out,
                         cl_mem temp)
 {
+  const int clwidth = ROUNDUPDWD(width, devid);
+  const int clheight = ROUNDUPDHT(height, devid);
+
   const int kernel_x = darktable.opencl->guided_filter->kernel_guided_filter_box_mean_x;
   dt_opencl_set_kernel_args(devid, kernel_x, 0, CLARG(width), CLARG(height), CLARG(in), CLARG(temp), CLARG(w));
-  const size_t sizes_x[] = { 1, ROUNDUPDHT(height, devid) };
+  const size_t sizes_x[] = { 1, clheight };
   const int err = dt_opencl_enqueue_kernel_2d(devid, kernel_x, sizes_x);
   if(err != CL_SUCCESS) return err;
 
   const int kernel_y = darktable.opencl->guided_filter->kernel_guided_filter_box_mean_y;
   dt_opencl_set_kernel_args(devid, kernel_y, 0, CLARG(width), CLARG(height), CLARG(temp), CLARG(out), CLARG(w));
-  const size_t sizes_y[] = { ROUNDUPDWD(width, devid), 1 };
+  const size_t sizes_y[] = { clwidth, 1 };
   return dt_opencl_enqueue_kernel_2d(devid, kernel_y, sizes_y);
 }
 
@@ -360,10 +365,15 @@ static int _cl_covariances(const int devid,
                           cl_mem cov_imgg_img_b,
                           const float guide_weight)
 {
+  const int clwidth = ROUNDUPDWD(width, devid);
+  const int clheight = ROUNDUPDHT(height, devid);
+
   const int kernel = darktable.opencl->guided_filter->kernel_guided_filter_guided_filter_covariances;
-  return dt_opencl_enqueue_kernel_2d_args(devid, kernel, width, height,
-    CLARG(width), CLARG(height), CLARG(guide), CLARG(in), CLARG(cov_imgg_img_r), CLARG(cov_imgg_img_g),
-    CLARG(cov_imgg_img_b), CLARG(guide_weight));
+  return dt_opencl_enqueue_kernel_2d_args(devid, kernel, clwidth, clheight,
+                                          CLARG(width), CLARG(height),
+                                          CLARG(guide), CLARG(in),
+                                          CLARG(cov_imgg_img_r), CLARG(cov_imgg_img_g), CLARG(cov_imgg_img_b),
+                                          CLARG(guide_weight));
 }
 
 
@@ -379,10 +389,15 @@ static int _cl_variances(const int devid,
                           cl_mem var_imgg_bb,
                           const float guide_weight)
 {
+  const int clwidth = ROUNDUPDWD(width, devid);
+  const int clheight = ROUNDUPDHT(height, devid);
   const int kernel = darktable.opencl->guided_filter->kernel_guided_filter_guided_filter_variances;
-  return dt_opencl_enqueue_kernel_2d_args(devid, kernel, width, height,
-    CLARG(width), CLARG(height), CLARG(guide), CLARG(var_imgg_rr), CLARG(var_imgg_rg), CLARG(var_imgg_rb),
-    CLARG(var_imgg_gg), CLARG(var_imgg_gb), CLARG(var_imgg_bb), CLARG(guide_weight));
+  return dt_opencl_enqueue_kernel_2d_args(devid, kernel, clwidth, clheight,
+                                          CLARG(width), CLARG(height),
+                                          CLARG(guide),
+                                          CLARG(var_imgg_rr), CLARG(var_imgg_rg), CLARG(var_imgg_rb),
+                                          CLARG(var_imgg_gg), CLARG(var_imgg_gb), CLARG(var_imgg_bb),
+                                          CLARG(guide_weight));
 }
 
 
@@ -395,9 +410,14 @@ static int _cl_update_covariance(const int devid,
                                   cl_mem b,
                                   float eps)
 {
+  const int clwidth = ROUNDUPDWD(width, devid);
+  const int clheight = ROUNDUPDHT(height, devid);
   const int kernel = darktable.opencl->guided_filter->kernel_guided_filter_update_covariance;
-  return dt_opencl_enqueue_kernel_2d_args(devid, kernel, width, height,
-    CLARG(width), CLARG(height), CLARG(in), CLARG(out), CLARG(a), CLARG(b), CLARG(eps));
+  return dt_opencl_enqueue_kernel_2d_args(devid, kernel, clwidth, clheight,
+                                          CLARG(width), CLARG(height),
+                                          CLARG(in), CLARG(out),
+                                          CLARG(a), CLARG(b),
+                                          CLARG(eps));
 }
 
 
@@ -422,12 +442,18 @@ static int _cl_solve(const int devid,
                       cl_mem a_b,
                       cl_mem b)
 {
+  const int clwidth = ROUNDUPDWD(width, devid);
+  const int clheight = ROUNDUPDHT(height, devid);
   const int kernel = darktable.opencl->guided_filter->kernel_guided_filter_solve;
-  return dt_opencl_enqueue_kernel_2d_args(devid, kernel, width, height,
-    CLARG(width), CLARG(height), CLARG(img_mean), CLARG(imgg_mean_r), CLARG(imgg_mean_g), CLARG(imgg_mean_b),
-    CLARG(cov_imgg_img_r), CLARG(cov_imgg_img_g), CLARG(cov_imgg_img_b), CLARG(var_imgg_rr), CLARG(var_imgg_rg),
-    CLARG(var_imgg_rb), CLARG(var_imgg_gg), CLARG(var_imgg_gb), CLARG(var_imgg_bb), CLARG(a_r), CLARG(a_g),
-    CLARG(a_b), CLARG(b));
+  return dt_opencl_enqueue_kernel_2d_args(devid, kernel, clwidth, clheight,
+                                          CLARG(width), CLARG(height),
+                                          CLARG(img_mean), CLARG(imgg_mean_r), CLARG(imgg_mean_g), CLARG(imgg_mean_b),
+                                          CLARG(cov_imgg_img_r), CLARG(cov_imgg_img_g), CLARG(cov_imgg_img_b),
+                                          CLARG(var_imgg_rr), CLARG(var_imgg_rg), CLARG(var_imgg_rb),
+                                          CLARG(var_imgg_gg), CLARG(var_imgg_gb),
+                                          CLARG(var_imgg_bb),
+                                          CLARG(a_r), CLARG(a_g),
+                                          CLARG(a_b), CLARG(b));
 }
 
 
@@ -444,10 +470,15 @@ static int _cl_generate_result(const int devid,
                                 const float min,
                                 const float max)
 {
+  const int clwidth = ROUNDUPDWD(width, devid);
+  const int clheight = ROUNDUPDHT(height, devid);
   const int kernel = darktable.opencl->guided_filter->kernel_guided_filter_generate_result;
-  return dt_opencl_enqueue_kernel_2d_args(devid, kernel, width, height,
-    CLARG(width), CLARG(height), CLARG(guide), CLARG(a_r), CLARG(a_g), CLARG(a_b), CLARG(b), CLARG(out),
-    CLARG(guide_weight), CLARG(min), CLARG(max));
+  return dt_opencl_enqueue_kernel_2d_args(devid, kernel, clwidth, clheight,
+                                          CLARG(width), CLARG(height),
+                                          CLARG(guide),
+                                          CLARG(a_r), CLARG(a_g), CLARG(a_b),
+                                          CLARG(b), CLARG(out),
+                                          CLARG(guide_weight), CLARG(min), CLARG(max));
 }
 
 
@@ -467,24 +498,27 @@ static int _guided_filter_cl_impl(int devid,
 {
   const float eps = sqrt_eps * sqrt_eps; // this is the regularization parameter of the original papers
 
-  cl_mem temp1 = dt_opencl_alloc_device(devid, width, height, sizeof(float));
-  cl_mem temp2 = dt_opencl_alloc_device(devid, width, height, sizeof(float));
-  cl_mem imgg_mean_r = dt_opencl_alloc_device(devid, width, height, sizeof(float));
-  cl_mem imgg_mean_g = dt_opencl_alloc_device(devid, width, height, sizeof(float));
-  cl_mem imgg_mean_b = dt_opencl_alloc_device(devid, width, height, sizeof(float));
-  cl_mem img_mean = dt_opencl_alloc_device(devid, width, height, sizeof(float));
-  cl_mem cov_imgg_img_r = dt_opencl_alloc_device(devid, width, height, sizeof(float));
-  cl_mem cov_imgg_img_g = dt_opencl_alloc_device(devid, width, height, sizeof(float));
-  cl_mem cov_imgg_img_b = dt_opencl_alloc_device(devid, width, height, sizeof(float));
-  cl_mem var_imgg_rr = dt_opencl_alloc_device(devid, width, height, sizeof(float));
-  cl_mem var_imgg_gg = dt_opencl_alloc_device(devid, width, height, sizeof(float));
-  cl_mem var_imgg_bb = dt_opencl_alloc_device(devid, width, height, sizeof(float));
-  cl_mem var_imgg_rg = dt_opencl_alloc_device(devid, width, height, sizeof(float));
-  cl_mem var_imgg_rb = dt_opencl_alloc_device(devid, width, height, sizeof(float));
-  cl_mem var_imgg_gb = dt_opencl_alloc_device(devid, width, height, sizeof(float));
-  cl_mem a_r = dt_opencl_alloc_device(devid, width, height, sizeof(float));
-  cl_mem a_g = dt_opencl_alloc_device(devid, width, height, sizeof(float));
-  cl_mem a_b = dt_opencl_alloc_device(devid, width, height, sizeof(float));
+  const int clwidth = ROUNDUPDWD(width, devid);
+  const int clheight = ROUNDUPDHT(height, devid);
+
+  cl_mem temp1 = dt_opencl_alloc_device(devid, clwidth, clheight, sizeof(float));
+  cl_mem temp2 = dt_opencl_alloc_device(devid, clwidth, clheight, sizeof(float));
+  cl_mem imgg_mean_r = dt_opencl_alloc_device(devid, clwidth, clheight, sizeof(float));
+  cl_mem imgg_mean_g = dt_opencl_alloc_device(devid, clwidth, clheight, sizeof(float));
+  cl_mem imgg_mean_b = dt_opencl_alloc_device(devid, clwidth, clheight, sizeof(float));
+  cl_mem img_mean = dt_opencl_alloc_device(devid, clwidth, clheight, sizeof(float));
+  cl_mem cov_imgg_img_r = dt_opencl_alloc_device(devid, clwidth, clheight, sizeof(float));
+  cl_mem cov_imgg_img_g = dt_opencl_alloc_device(devid, clwidth, clheight, sizeof(float));
+  cl_mem cov_imgg_img_b = dt_opencl_alloc_device(devid, clwidth, clheight, sizeof(float));
+  cl_mem var_imgg_rr = dt_opencl_alloc_device(devid, clwidth, clheight, sizeof(float));
+  cl_mem var_imgg_gg = dt_opencl_alloc_device(devid, clwidth, clheight, sizeof(float));
+  cl_mem var_imgg_bb = dt_opencl_alloc_device(devid, clwidth, clheight, sizeof(float));
+  cl_mem var_imgg_rg = dt_opencl_alloc_device(devid, clwidth, clheight, sizeof(float));
+  cl_mem var_imgg_rb = dt_opencl_alloc_device(devid, clwidth, clheight, sizeof(float));
+  cl_mem var_imgg_gb = dt_opencl_alloc_device(devid, clwidth, clheight, sizeof(float));
+  cl_mem a_r = dt_opencl_alloc_device(devid, clwidth, clheight, sizeof(float));
+  cl_mem a_g = dt_opencl_alloc_device(devid, clwidth, clheight, sizeof(float));
+  cl_mem a_b = dt_opencl_alloc_device(devid, clwidth, clheight, sizeof(float));
   cl_mem b = temp2;
 
   cl_int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;


### PR DESCRIPTION
1. Cleaned up filter kernels, using float4 simplifications, some perf improvements due to using samplerA if coordinates are known for sure
2. The big bug was the boxing kernels assumed aligned mask dimensions but they were not. So functioning was just good luck.


Fixes #15621