### PR TITLE
Bugfix: OpenCL issues with details mask & dual demosaic

### DIFF
--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -237,8 +237,6 @@ typedef struct dt_blendop_cl_global_t
   int kernel_calc_Y0_mask;
   int kernel_calc_scharr_mask;
   int kernel_write_scharr_mask;
-  int kernel_write_mask;
-  int kernel_read_mask;
   int kernel_calc_blend;
   int kernel_mask_blur;
 } dt_blendop_cl_global_t;


### PR DESCRIPTION
There have been some issues about details mask and dual demosaicing. There have been a few bugs in dt code that were very difficult to spot but a) might lead to read/write of too large data or b) having false/ even NaN data in the mask.



- always use buffers and not cl image for writing/reading and blending the scharr/details masks we might take data from cl struct as mask-data
- faster code in some parts
