### PR TITLE
don't show inactive picker under snapshot overlay

### DIFF
--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -293,7 +293,6 @@ typedef struct dt_develop_t
   {
     // set by dt_dev_pixelpipe_synch() if an enabled crop module is included in history
     struct dt_iop_module_t *exposer;
-    struct dt_iop_module_t *requester;
   } cropping;
 
   // for the overexposure indicator

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -3615,6 +3615,12 @@ gboolean dt_iop_have_required_input_format(const int req_ch,
   }
 }
 
+gboolean dt_iop_canvas_not_sensitive(const struct dt_develop_t *dev)
+{
+  return dt_iop_color_picker_is_visible(dev)
+         || darktable.lib->proxy.snapshots.enabled;
+}
+
 void dt_iop_gui_changed(dt_action_t *action, GtkWidget *widget, gpointer data)
 {
   if(!action || action->type != DT_ACTION_TYPE_IOP_INSTANCE) return;

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -569,7 +569,9 @@ gboolean dt_iop_have_required_input_format(const int required_ch,
                                            const dt_iop_roi_t *const roi_in,
                                            const dt_iop_roi_t *const roi_out);
 
-
+// should module ignore mouse actions on gui elements, like handles or shapes?
+// returns true while color picker or snapshots active; show other elements dimmed
+gboolean dt_iop_canvas_not_sensitive(const struct dt_develop_t *dev);
 
 /* bring up module rename dialog */
 void dt_iop_gui_rename_module(dt_iop_module_t *module);

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2453,7 +2453,7 @@ void dt_masks_draw_clone_source_pos(cairo_t *cr,
   dashed[1] /= zoom_scale;
 
   cairo_set_dash(cr, dashed, 0, 0);
-  const double lwidth = (dt_iop_color_picker_is_visible(darktable.develop) ? 0.5 : 1.0) / zoom_scale;
+  const double lwidth = (dt_iop_canvas_not_sensitive(darktable.develop) ? 0.5 : 1.0) / zoom_scale;
   cairo_set_line_width(cr, 3.0 * lwidth);
   cairo_set_source_rgba(cr, .3, .3, .3, .8);
 
@@ -2672,7 +2672,7 @@ void dt_masks_draw_anchor(cairo_t *cr,
                   anchor_size,
                   anchor_size);
   cairo_fill_preserve(cr);
-  const double lwidth = (dt_iop_color_picker_is_visible(darktable.develop) ? 0.5 : 1.0) / zoom_scale;
+  const double lwidth = (dt_iop_canvas_not_sensitive(darktable.develop) ? 0.5 : 1.0) / zoom_scale;
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(selected ? 2.0 : 1.0) * lwidth);
   dt_draw_set_color_overlay(cr, FALSE, 0.8);
   cairo_stroke(cr);
@@ -2691,7 +2691,7 @@ void dt_masks_draw_ctrl(cairo_t *cr,
   dt_draw_set_color_overlay(cr, TRUE, 0.8);
   cairo_fill_preserve(cr);
 
-  const double lwidth = (dt_iop_color_picker_is_visible(darktable.develop) ? 0.5 : 1.0) / zoom_scale;
+  const double lwidth = (dt_iop_canvas_not_sensitive(darktable.develop) ? 0.5 : 1.0) / zoom_scale;
   cairo_set_line_width(cr, lwidth);
   dt_draw_set_color_overlay(cr, FALSE, 0.8);
   cairo_stroke(cr);
@@ -2757,7 +2757,7 @@ void dt_masks_stroke_arrow(cairo_t *cr,
   double dashed[] = { 0, 0 };
   cairo_set_dash(cr, dashed, 0, 0);
 
-  const double lwidth = (dt_iop_color_picker_is_visible(darktable.develop) ? 0.5 : 1.0) / zoom_scale;
+  const double lwidth = (dt_iop_canvas_not_sensitive(darktable.develop) ? 0.5 : 1.0) / zoom_scale;
   if((gui->group_selected == group) && (gui->form_selected || gui->form_dragging))
     cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2.5) * lwidth);
   else
@@ -2822,7 +2822,7 @@ void dt_masks_line_stroke(cairo_t *cr,
   dt_draw_set_color_overlay(cr, FALSE, selected ? 0.8 : 0.5);
   cairo_set_dash(cr, dashed, border ? len : 0, 0);
 
-  const double lwidth = (dt_iop_color_picker_is_visible(darktable.develop) ? 0.5 : 1.0) / zoom_scale;
+  const double lwidth = (dt_iop_canvas_not_sensitive(darktable.develop) ? 0.5 : 1.0) / zoom_scale;
   const double line_width =
     ((border ? size_border : (source ? size_source : size_mask))
      * (selected ? factor_selected : 1.0)) * lwidth;

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -70,7 +70,7 @@ gboolean dt_iop_color_picker_is_visible(const dt_develop_t *dev)
 
   const gboolean primary_picker = proxy && !proxy->module;
 
-  return module_picker || primary_picker || darktable.lib->proxy.snapshots.enabled;
+  return module_picker || primary_picker;
 }
 
 static gboolean _record_point_area(dt_iop_color_picker_t *self)

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4209,7 +4209,7 @@ void gui_post_expose(dt_iop_module_t *self,
   dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
   dt_iop_ashift_params_t *p = (dt_iop_ashift_params_t *)self->params;
 
-  const gboolean dimmed = dt_iop_color_picker_is_visible(dev);
+  const gboolean dimmed = dt_iop_canvas_not_sensitive(dev);
   const double lwidth = (dimmed ? 0.5 : 1.0) / zoom_scale;
   const double fillc = dimmed ? 0.9 : 0.2;
 

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -2680,7 +2680,7 @@ void gui_post_expose(dt_iop_module_t *self,
     (dt_iop_channelmixer_rgb_gui_data_t *)self->gui_data;
   if(!g->is_profiling_started) return;
 
-  const gboolean showhandle = dt_iop_color_picker_is_visible(darktable.develop) == FALSE;
+  const gboolean showhandle = dt_iop_canvas_not_sensitive(darktable.develop) == FALSE;
   const double lwidth = (showhandle ? 1.0 : 0.5) / zoom_scale;
 
   cairo_set_line_width(cr, 2.0 * lwidth);

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -1337,15 +1337,13 @@ void gui_post_expose(dt_iop_module_t *self,
   dt_iop_crop_gui_data_t *g = (dt_iop_crop_gui_data_t *)self->gui_data;
 
   // is this expose enforced by another module in focus?
-  const gboolean external = dev->cropping.exposer
-                        &&  dev->cropping.requester
-                        && (dev->cropping.exposer != dev->cropping.requester);
+  const gboolean external = dev->gui_module != self;
   const gboolean dimmed = dt_iop_color_picker_is_visible(dev) || external;
 
   // we don't do anything if the image is not ready within crop module
   // and we don't have visualizing enforced by other modules
-  if((dev->full.pipe->changed & DT_DEV_PIPE_REMOVE 
-      || self->dev->preview_pipe->loading) 
+  if((dev->full.pipe->changed & DT_DEV_PIPE_REMOVE
+      || self->dev->preview_pipe->loading)
      && !external) return;
 
   _aspect_apply(self, GRAB_HORIZONTAL);

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -507,7 +507,7 @@ void gui_post_expose(dt_iop_module_t *self,
 
   const float xa = g->xa * wd, xb = g->xb * wd, ya = g->ya * ht, yb = g->yb * ht;
   // the lines
-  const double lwidth = (dt_iop_color_picker_is_visible(darktable.develop) ? 0.5 : 1.0) / zoom_scale;
+  const double lwidth = (dt_iop_canvas_not_sensitive(darktable.develop) ? 0.5 : 1.0) / zoom_scale;
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
   if(g->selected == 3 || g->dragging == 3)
     cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(5.0) * lwidth);
@@ -528,7 +528,7 @@ void gui_post_expose(dt_iop_module_t *self,
   cairo_line_to(cr, xb, yb);
   cairo_stroke(cr);
 
-  if(dt_iop_color_picker_is_visible(darktable.develop))
+  if(dt_iop_canvas_not_sensitive(darktable.develop))
     return;
   // the extremities
   float x1, y1, x2, y2;

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1723,7 +1723,7 @@ static void set_line_width(cairo_t *cr,
                            dt_liquify_ui_width_enum_t w)
 {
   const double width = get_ui_width(scale, w);
-  cairo_set_line_width(cr, width * (dt_iop_color_picker_is_visible(darktable.develop) ? 0.5 : 1.0));
+  cairo_set_line_width(cr, width * (dt_iop_canvas_not_sensitive(darktable.develop) ? 0.5 : 1.0));
 }
 
 static gboolean detect_drag(const dt_iop_liquify_gui_data_t *g,
@@ -1845,7 +1845,7 @@ static void _draw_paths(dt_iop_module_t *module,
 
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
 
-  const gboolean showhandle = dt_iop_color_picker_is_visible(darktable.develop) == FALSE;
+  const gboolean showhandle = dt_iop_canvas_not_sensitive(darktable.develop) == FALSE;
   // do not display any iterpolated items as slow when:
   //   - we are dragging (pan)
   //   - the button one is pressed
@@ -2772,7 +2772,6 @@ void gui_focus(struct dt_iop_module_t *self,
     dt_collection_hint_message(darktable.collection);
     btn_make_radio_callback(NULL, NULL, self);
   }
-  self->dev->cropping.requester = (in && !darktable.develop->full.pipe->loading) ? self : NULL;
 }
 
 static void sync_pipe(struct dt_iop_module_t *module,

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2208,7 +2208,6 @@ void cleanup_global(dt_iop_module_so_t *module)
 void gui_focus(struct dt_iop_module_t *self,
                const gboolean in)
 {
-  self->dev->cropping.requester = NULL;
   if(self->enabled
      && !darktable.develop->full.pipe->loading)
   {
@@ -2216,7 +2215,6 @@ void gui_focus(struct dt_iop_module_t *self,
 
     if(in)
     {
-      self->dev->cropping.requester = self;
       dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->blend_data;
       //only show shapes if shapes exist
       dt_masks_form_t *grp =

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -2017,7 +2017,7 @@ static void switch_cursors(struct dt_iop_module_t *self)
   // if we are editing masks or using colour-pickers, do not display controls
   if(!sanity_check(self)
      || in_mask_editing(self)
-     || dt_iop_color_picker_is_visible(self->dev))
+     || dt_iop_canvas_not_sensitive(self->dev))
   {
     // display default cursor
     GdkCursor *const cursor =

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -334,7 +334,7 @@ static void draw_overlay(cairo_t *cr, float x, float y, float fx, float fy, int 
   cairo_restore(cr);
   cairo_stroke(cr);
 
-  if(dt_iop_color_picker_is_visible(darktable.develop))
+  if(dt_iop_canvas_not_sensitive(darktable.develop))
     return;
   // the handles
   const float radius_sel = DT_PIXEL_APPLY_DPI(6.0) / zoom_scale;
@@ -443,7 +443,7 @@ void gui_post_expose(dt_iop_module_t *self,
   int grab = get_grab(pzx * wd - vignette_x, pzy * ht - vignette_y, vignette_w, -vignette_h, vignette_fx,
                       -vignette_fy, zoom_scale);
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  const double lwidth = (dt_iop_color_picker_is_visible(darktable.develop) ? 0.5 : 1.0) / zoom_scale;
+  const double lwidth = (dt_iop_canvas_not_sensitive(darktable.develop) ? 0.5 : 1.0) / zoom_scale;
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(3.0) * lwidth);
   dt_draw_set_color_overlay(cr, FALSE, 0.8);
   draw_overlay(cr, vignette_w, vignette_h, vignette_fx, vignette_fy, grab, zoom_scale);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -633,7 +633,8 @@ void expose(
   if(dev->gui_module && dev->gui_module != dev->proxy.rotate)
   {
     // the cropping.exposer->gui_post_expose needs special care
-    if(expose_full && dev->cropping.requester)
+    if(expose_full
+       && dev->gui_module->operation_tags_filter() & IOP_TAG_CROPPING)
     {
       dt_print_pipe(DT_DEBUG_EXPOSE,
         "expose cropper",


### PR DESCRIPTION
fixes #15626

Also fixes https://github.com/darktable-org/darktable/pull/15546#issuecomment-1793453837;
when the retouch module was _focused_ but not _enabled_, the crop module would not show an outline of the crop area (like it did if liquify was focused). You had to enabled and then un+refocus retouch to see the crop outline.

@jenshannoschwalm I don't think we only want to see the outline when the "requester" is enabled, but rather always when crop is temporarily disabled. So I've simplified the logic a little bit. Let me know if I overlooked something.