### PR TITLE
avoid recalc when scrollbar updated with current position

### DIFF
--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -62,7 +62,6 @@ typedef struct dt_gui_scrollbars_t
     GtkWidget *hscrollbar;
 
     gboolean visible;
-    gboolean dragging;
 } dt_gui_scrollbars_t;
 
 typedef enum dt_gui_color_t

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -676,16 +676,6 @@ void dt_view_set_scrollbar(dt_view_t *view,
                            const float vsize,
                            const float vwinsize)
 {
-  if(1e-5 > fabsf(view->hscroll_pos - hpos)
-          + fabsf(view->hscroll_lower - hlower)
-          + fabsf(view->hscroll_size - hsize)
-          + fabsf(view->hscroll_viewport_size - hwinsize)
-          + fabsf(view->vscroll_pos - vpos)
-          + fabsf(view->vscroll_lower - vlower)
-          + fabsf(view->vscroll_size - vsize)
-          + fabsf(view->vscroll_viewport_size - vwinsize))
-    return;
-
   view->vscroll_pos = vpos;
   view->vscroll_lower = vlower;
   view->vscroll_size = vsize;
@@ -701,8 +691,7 @@ void dt_view_set_scrollbar(dt_view_t *view,
   gtk_widget_queue_draw(widgets->bottom_border);
   gtk_widget_queue_draw(widgets->top_border);
 
-  if(!darktable.gui->scrollbars.dragging)
-    dt_ui_update_scrollbars(darktable.gui->ui);
+  dt_ui_update_scrollbars(darktable.gui->ui);
 }
 
 dt_view_surface_value_t dt_view_image_get_surface(const dt_imgid_t imgid,


### PR DESCRIPTION
fixes #15648

better fix than #15526

If the center image in the darkroom is updated with different coordinates, the scrollbars will also get updated and this would trigger another potential update of the image. If the coordinates had shifted a little because they are stored in RAW pixel terms and transformed back into cropped display pixels, then a loop could result. But really, there should be no need to redraw after just updating the scrollbars, so just disable that trigger while updating.

@cabuy are you able to compile this PR to test? @todd-prior too please? Thank you!