### PR TITLE
OpenCL guided filter (III)

### DIFF
--- a/data/kernels/guided_filter.cl
+++ b/data/kernels/guided_filter.cl
@@ -32,7 +32,7 @@ kernel void guided_filter_split_rgb_image(const int width,
   if(x >= width || y >= height) return;
 
   const float4 weight = { guide_weight, guide_weight, guide_weight, 0.0f };
-  const float4 pixel = weight * read_imagef(guide, sampleri, (int2)(x, y));
+  const float4 pixel = weight * fmin(100.0, fmax(0.0, read_imagef(guide, sampleri, (int2)(x, y))));
   write_imagef(out_r, (int2)(x, y), pixel.x);
   write_imagef(out_g, (int2)(x, y), pixel.y);
   write_imagef(out_b, (int2)(x, y), pixel.z);
@@ -186,7 +186,7 @@ kernel void guided_filter_covariances(const int width,
   const float4 weight = { guide_weight, guide_weight, guide_weight, 0.0f };
   const float img_ = read_imagef(img, samplerA, (int2)(x, y)).x;
   const float4 imgv = { img_, img_, img_, 0.0f };
-  const float4 pixel = imgv * weight * read_imagef(guide, sampleri, (int2)(x, y));
+  const float4 pixel = imgv * weight * fmin(100.0, fmax(0.0, read_imagef(guide, sampleri, (int2)(x, y))));
   write_imagef(cov_imgg_img_r, (int2)(x, y), pixel.x);
   write_imagef(cov_imgg_img_g, (int2)(x, y), pixel.y);
   write_imagef(cov_imgg_img_b, (int2)(x, y), pixel.z);
@@ -209,7 +209,7 @@ kernel void guided_filter_variances(const int width,
   if(x >= width || y >= height) return;
 
   const float4 weight = { guide_weight, guide_weight, guide_weight, 0.0f };
-  const float4 pixel = weight * read_imagef(guide, sampleri, (int2)(x, y));
+  const float4 pixel = weight * fmin(100.0, fmax(0.0, read_imagef(guide, sampleri, (int2)(x, y))));
   write_imagef(var_imgg_rr, (int2)(x, y), pixel.x * pixel.x);
   write_imagef(var_imgg_rg, (int2)(x, y), pixel.x * pixel.y);
   write_imagef(var_imgg_rb, (int2)(x, y), pixel.x * pixel.z);
@@ -321,7 +321,7 @@ kernel void guided_filter_generate_result(const int width,
   const int y = get_global_id(1);
   if(x >= width || y >= height) return;
 
-  const float4 pixel = read_imagef(guide, sampleri, (int2)(x, y));
+  const float4 pixel = fmin(100.0, fmax(0.0, read_imagef(guide, sampleri, (int2)(x, y))));
   const float a_r_ = pixel.x * read_imagef(a_r, samplerA, (int2)(x, y)).x;
   const float a_g_ = pixel.y * read_imagef(a_g, samplerA, (int2)(x, y)).x;
   const float a_b_ = pixel.z * read_imagef(a_b, samplerA, (int2)(x, y)).x;

--- a/data/kernels/guided_filter.cl
+++ b/data/kernels/guided_filter.cl
@@ -55,9 +55,8 @@ kernel void guided_filter_box_mean_x(const int width,
                                      write_only image2d_t out,
                                      const int w)
 {
-  const int x = get_global_id(0);
-  const int y = get_global_id(1);
-  if(x >= 1 || y >= height) return;
+  const int y = get_global_id(0);
+  if(y >= height) return;
 
   float m = 0.f, n_box = 0.f, c = 0.f;
   if(width > 2 * w)
@@ -118,8 +117,7 @@ kernel void guided_filter_box_mean_y(const int width,
                                      const int w)
 {
   const int x = get_global_id(0);
-  const int y = get_global_id(1);
-  if(x >= width || y >= 1) return;
+  if(x >= width) return;
 
   float m = 0.f, n_box = 0.f, c = 0.f;
   if(height > 2 * w)
@@ -171,7 +169,6 @@ kernel void guided_filter_box_mean_y(const int width,
     }
   }
 }
-
 
 kernel void guided_filter_covariances(const int width,
                                       const int height,
@@ -328,7 +325,7 @@ kernel void guided_filter_generate_result(const int width,
   const float a_r_ = pixel.x * read_imagef(a_r, samplerA, (int2)(x, y)).x;
   const float a_g_ = pixel.y * read_imagef(a_g, samplerA, (int2)(x, y)).x;
   const float a_b_ = pixel.z * read_imagef(a_b, samplerA, (int2)(x, y)).x;
-  const float b_ =   read_imagef(b,   samplerA, (int2)(x, y)).x;
-  const float res_ = guide_weight * (a_r_ + a_g_ + a_b_) + b_;
+  const float b_ =             read_imagef(b,   samplerA, (int2)(x, y)).x;
+  const float res_ = guide_weight * (a_r_ + a_g_ + a_b_)+ b_;
   write_imagef(res, (int2)(x, y), fmin(maxval, fmax(minval, res_)));
 }


### PR DESCRIPTION
Hopefully the last work on this ... related to a number of issues, see #15634 as a starting point ...

Two commits

1. some reverting of unnecessary aligning of cl kernel dimensions as that is done internally via `dt_opencl_enqueue_kernel_2d_args()`. Also the box filters now use `dt_opencl_enqueue_kernel_ndim_with_local()` to emphasize the dimension of one.
2. I took pretty long to mostly-understand but the problem with the mentioned image in the other pr is in CL arithmetics with the solver based on massive calculations before. (See commit message)

I suggest to use the "safety belt" as in the second commit but we could leave that out and accept some limitations with synthetic images combined with extreme settings.

