### PR TITLE
[macOS]: enable curve and noise tools for homebrew

### DIFF
--- a/packaging/macosx/2_build_hb_darktable_default.sh
+++ b/packaging/macosx/2_build_hb_darktable_default.sh
@@ -20,6 +20,8 @@ installDir="${buildDir}/macosx"
 options=" \
     -DUSE_GRAPHICSMAGICK=OFF \
     -DUSE_IMAGEMAGICK=ON \
+    -DBUILD_CURVE_TOOLS=ON \
+    -DBUILD_NOISE_TOOLS=ON \
 "
 
 # Check for previous attempt and clean


### PR DESCRIPTION
Enable the build of curvetool and noisetool for homebrew default build script.
