### PR TITLE
fix filmroll sort by folder descending

### DIFF
--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2120,7 +2120,10 @@ static void _list_view(dt_lib_collect_rule_t *dr)
           }
           else
           {
-            order_by = g_strdup("lower(folder) ASC");
+            if(sort_descending)
+              order_by = g_strdup("lower(folder) DESC");
+            else
+              order_by = g_strdup("lower(folder)");
           }
 
           // clang-format off


### PR DESCRIPTION
fixes #15669 

Setting sort order for filmroll to folder descending was not handled.

![image](https://github.com/darktable-org/darktable/assets/4083281/5f0bf50c-4a75-442a-8e1c-51b138e0586d)
