### PR TITLE
Add path suffix for opencl-c.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,7 +341,7 @@ if(TESTBUILD_OPENCL_PROGRAMS)
 
       find_path(CLANG_OPENCL_INCLUDE_DIR opencl-c.h
         HINTS ${LLVM_INSTALL_PREFIX}/lib/clang ${LLVM_INSTALL_PREFIX}/lib64/clang
-        PATH_SUFFIXES include ${LLVM_PACKAGE_VERSION}/include
+        PATH_SUFFIXES include ${LLVM_PACKAGE_VERSION}/include ${LLVM_VERSION_MAJOR}/include
         NO_DEFAULT_PATH
       )
 


### PR DESCRIPTION
I upgraded to Fedora 39 and had cmake error after the upgrade. The path in Fedora 39 is /usr/lib/clang/17/include. The build was failing to find the path. The LLVM_PACKAGE_VERSION is 17.0.1. The path suffix works if we add LLVM_VERSION_MAJOR (17). 

