### PR TITLE
Ensure overlaps for tiling

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -1555,7 +1555,7 @@ void tiling_callback_blendop(struct dt_iop_module_t *self,
     if(bldata->feathering_radius > 0.1f)
     {
       tiling->overhead += 3.5f; // we need all intermediate mask buffers
-      tiling->overlap += 2 * (int)(1.0f + bldata->feathering_radius);
+      tiling->overlap = 2 * (int)(1.0f + bldata->feathering_radius);
     }
   }
 }

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1610,7 +1610,8 @@ static gboolean _dev_pixelpipe_process_rec(
     tiling.factor_cl = fmax(tiling.factor_cl, tiling_blendop.factor);
     tiling.maxbuf = fmax(tiling.maxbuf, tiling_blendop.maxbuf);
     tiling.maxbuf_cl = fmax(tiling.maxbuf_cl, tiling_blendop.maxbuf);
-    tiling.overhead = fmax(tiling.overhead, tiling_blendop.overhead);
+    tiling.overhead = MAX(tiling.overhead, tiling_blendop.overhead);
+    tiling.overlap = MAX(tiling.overlap, tiling_blendop.overlap);
   }
 
   /* remark: we do not do tiling for blendop step, neither in opencl


### PR DESCRIPTION
Feathering in mask-blended modules requires some overlap according to radius, we must ensure this overlap in tiling mode, the module overlap calculation does not do that already.