### PR TITLE
Bugfix: blending OpenCL requirements

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1606,11 +1606,12 @@ static gboolean _dev_pixelpipe_process_rec(
     tiling_callback_blendop(module, piece, &roi_in, roi_out, &tiling_blendop);
 
     /* aggregate in structure tiling */
-    tiling.factor = fmax(tiling.factor, tiling_blendop.factor);
-    tiling.factor_cl = fmax(tiling.factor_cl, tiling_blendop.factor);
-    tiling.maxbuf = fmax(tiling.maxbuf, tiling_blendop.maxbuf);
-    tiling.maxbuf_cl = fmax(tiling.maxbuf_cl, tiling_blendop.maxbuf);
-    tiling.overhead = fmax(tiling.overhead, tiling_blendop.overhead);
+    tiling.factor = MAX(tiling.factor, tiling_blendop.factor);
+    tiling.factor_cl = MAX(tiling.factor_cl, tiling_blendop.factor);
+    tiling.maxbuf = MAX(tiling.maxbuf, tiling_blendop.maxbuf);
+    tiling.maxbuf_cl = MAX(tiling.maxbuf_cl, tiling_blendop.maxbuf);
+    tiling.overhead = MAX(tiling.overhead, tiling_blendop.overhead);
+    tiling.overlap = MAX(tiling.overlap, tiling_blendop.overlap);
   }
 
   /* remark: we do not do tiling for blendop step, neither in opencl


### PR DESCRIPTION
We have to calculate the factor needed in blending code as we would avoid any attempt to process the module on the CL device if we can't process the blending on full required data.

1. Fixes the wrong #15635 
2. As we don't have any "tiled blending mode" we check in the pixelpipe if **all included blending** can be done on the GPU. Thus we have to calculate the required memory with the maximum factor_cl of a) module processing & b) blend processing

Without this pr we only ensure a safe module CL processing but would run into trouble (possible cl crashes) if we use masks with feathering and those requirements are larger than available.  