### PR TITLE
[imageio] [DAM] Hardcode the crop factor for the handful of cameras for which we can't calculate it correctly

### DIFF
--- a/src/common/exif.h
+++ b/src/common/exif.h
@@ -53,6 +53,12 @@ typedef enum dt_dng_illuminant_t // from adobes dng_sdk
 	DT_LS_Other                = 255
 } dt_dng_illuminant_t;
 
+// stores hard-coded crop factors for models for which we can't calculate the correct value
+struct dt_model_cropfactor
+{
+  const char *model;
+  float cropfactor;
+};
 
 /** set the list of available tags from Exvi2 */
 void dt_exif_set_exiv2_taglist();


### PR DESCRIPTION
To verify:

- for [XF10](https://www.dpreview.com/products/fujifilm/compacts/fujifilm_xf10) and [FinePix S1](https://www.dpreview.com/products/fujifilm/compacts/fujifilm_s1): the resolution in the metadata is indicated relative to the pixel dimensions of the sensor, and not a preview, as in most Fujifilm cameras.
- for [FinePix SL1000](https://www.dpreview.com/products/fujifilm/compacts/fujifilm_sl1000): the same as above, plus the sensor measurements are in FujiIFD and exiv2 can't read them yet (so there can be no other option but to hardcode the correct crop factor).
- for [FinePix E550](https://www.dpreview.com/products/fujifilm/compacts/fuji_finepixe550z): the sensor size corresponds to a crop factor of 4.65 (4.7 rounded), but the calculation gives an incorrect value of 6.4. This camera has a [Super CCD HR](https://en.wikipedia.org/wiki/Super_CCD) type sensor with a diagonal pixel layout. It seems that the Fujifilm programmers made a mistake and put  in the metadata the resolution values that are not quite correct.
- FinePix HS10 HS11: The calculated value is a little inaccurate, so let's correct it if we already do it for other cameras.