### PR TITLE
tagging: sort tags case insensitive and unicode

### DIFF
--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -2681,6 +2681,8 @@ static gint _sort_tree_tag_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIter
 
   g_free(tag_a);
   g_free(tag_b);
+  g_free(tag_a_nc);
+  g_free(tag_b_nc);
   return sort;
 }
 
@@ -2715,6 +2717,8 @@ static gint _sort_tree_path_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIte
 
   g_free(tag_a);
   g_free(tag_b);
+  g_free(tag_a_nc);
+  g_free(tag_b_nc);
   return sort;
 }
 

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -2667,11 +2667,18 @@ static gint _sort_tree_tag_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIter
 {
   char *tag_a = NULL;
   char *tag_b = NULL;
+  char *tag_a_nc = NULL;
+  char *tag_b_nc = NULL;
   gtk_tree_model_get(model, a, DT_LIB_TAGGING_COL_TAG, &tag_a, -1);
   gtk_tree_model_get(model, b, DT_LIB_TAGGING_COL_TAG, &tag_b, -1);
   if(tag_a == NULL) tag_a = g_strdup("");
   if(tag_b == NULL) tag_b = g_strdup("");
-  const gboolean sort = g_strcmp0(tag_a, tag_b);
+
+  tag_a_nc = g_utf8_casefold(tag_a, -1);
+  tag_b_nc = g_utf8_casefold(tag_b, -1);
+
+  const gint sort = g_utf8_collate(tag_a_nc, tag_b_nc);
+
   g_free(tag_a);
   g_free(tag_b);
   return sort;
@@ -2681,6 +2688,8 @@ static gint _sort_tree_path_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIte
 {
   char *tag_a = NULL;
   char *tag_b = NULL;
+  char *tag_a_nc = NULL;
+  char *tag_b_nc = NULL;
   gtk_tree_model_get(model, a, DT_LIB_TAGGING_COL_PATH, &tag_a, -1);
   gtk_tree_model_get(model, b, DT_LIB_TAGGING_COL_PATH, &tag_b, -1);
   if(tag_a)
@@ -2699,7 +2708,11 @@ static gint _sort_tree_path_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIte
   else
     tag_b = g_strdup("");
 
-  const gboolean sort = g_strcmp0(tag_a, tag_b);
+  tag_a_nc = g_utf8_casefold(tag_a, -1);
+  tag_b_nc = g_utf8_casefold(tag_b, -1);
+
+  const gint sort = g_utf8_collate(tag_a_nc, tag_b_nc);
+
   g_free(tag_a);
   g_free(tag_b);
   return sort;

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -2663,26 +2663,29 @@ static gint _sort_tree_count_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIt
   return (count_b - count_a);
 }
 
+static inline gint _compare_utf8_no_case(const char *a, const char *b)
+{
+  char *a_nc = g_utf8_casefold(a, -1);
+  char *b_nc = g_utf8_casefold(b, -1);
+  const gint sort = g_utf8_collate(a_nc, b_nc);
+  g_free(a_nc);
+  g_free(b_nc);
+  return sort;
+}
+
 static gint _sort_tree_tag_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIter *b, dt_lib_module_t *self)
 {
   char *tag_a = NULL;
   char *tag_b = NULL;
-  char *tag_a_nc = NULL;
-  char *tag_b_nc = NULL;
   gtk_tree_model_get(model, a, DT_LIB_TAGGING_COL_TAG, &tag_a, -1);
   gtk_tree_model_get(model, b, DT_LIB_TAGGING_COL_TAG, &tag_b, -1);
   if(tag_a == NULL) tag_a = g_strdup("");
   if(tag_b == NULL) tag_b = g_strdup("");
 
-  tag_a_nc = g_utf8_casefold(tag_a, -1);
-  tag_b_nc = g_utf8_casefold(tag_b, -1);
-
-  const gint sort = g_utf8_collate(tag_a_nc, tag_b_nc);
+  const gint sort = _compare_utf8_no_case(tag_a, tag_b);
 
   g_free(tag_a);
   g_free(tag_b);
-  g_free(tag_a_nc);
-  g_free(tag_b_nc);
   return sort;
 }
 
@@ -2690,8 +2693,6 @@ static gint _sort_tree_path_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIte
 {
   char *tag_a = NULL;
   char *tag_b = NULL;
-  char *tag_a_nc = NULL;
-  char *tag_b_nc = NULL;
   gtk_tree_model_get(model, a, DT_LIB_TAGGING_COL_PATH, &tag_a, -1);
   gtk_tree_model_get(model, b, DT_LIB_TAGGING_COL_PATH, &tag_b, -1);
   if(tag_a)
@@ -2710,15 +2711,10 @@ static gint _sort_tree_path_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIte
   else
     tag_b = g_strdup("");
 
-  tag_a_nc = g_utf8_casefold(tag_a, -1);
-  tag_b_nc = g_utf8_casefold(tag_b, -1);
-
-  const gint sort = g_utf8_collate(tag_a_nc, tag_b_nc);
+  const gint sort = _compare_utf8_no_case(tag_a, tag_b);
 
   g_free(tag_a);
   g_free(tag_b);
-  g_free(tag_a_nc);
-  g_free(tag_b_nc);
   return sort;
 }
 


### PR DESCRIPTION
The tags in the tagging module and in the collections module are case-sensitive ASCII-sorted, meaning that lowercased tags are sorted at the end. Also unicode characters (i.e. german umlauts or diacritic characters) are not sorted naturally.

This PR implements a natural sort on tags.

Before:
<img width="227" alt="Bildschirmfoto 2023-11-20 um 19 01 13" src="https://github.com/darktable-org/darktable/assets/4083281/2f88a718-2518-4963-a134-bed09797b5e3">

After:
<img width="226" alt="Bildschirmfoto 2023-11-20 um 19 00 08" src="https://github.com/darktable-org/darktable/assets/4083281/5c7d54e9-2688-4504-90f8-60e5ea0fcb42">

This is the same for the collections module when collection type 'tagging' is selected.

Before:
<img width="324" alt="Bildschirmfoto 2023-11-20 um 19 02 47" src="https://github.com/darktable-org/darktable/assets/4083281/15eea1b5-fbc8-48d2-9e72-43d89d62e20f">

After:
<img width="272" alt="Bildschirmfoto 2023-11-20 um 19 40 38" src="https://github.com/darktable-org/darktable/assets/4083281/a7e4980b-651d-42f6-a963-d4b0d6fce3af">

implements #15665 
