### PR TITLE
Bugfix: Guided filter IV

### DIFF
--- a/src/common/box_filters.c
+++ b/src/common/box_filters.c
@@ -496,8 +496,8 @@ static void _blur_horizontal_Nch_Kahan(const size_t N,
   if(N > 16) return;
   if(N != 9) return;  // since we only use 9 channels at the moment, give the compiler a big hint
 
-  float DT_ALIGNED_ARRAY L[16] = { 0, 0, 0, 0 };
-  float DT_ALIGNED_ARRAY comp[16] = { 0, 0, 0, 0 };
+  float DT_ALIGNED_ARRAY L[16] =    { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
+  float DT_ALIGNED_ARRAY comp[16] = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
   size_t hits = 0;
   // add up the left half of the window
   for(size_t x = 0; x < MIN(radius,width) ; x++)
@@ -809,7 +809,7 @@ static void _blur_vertical_16wide(float *const restrict buf,
   size_t mask = 1;
   for(size_t r = (2*radius+1); r > 1 ; r >>= 1) mask = (mask << 1) | 1;
 
-  float DT_ALIGNED_ARRAY L[16] = { 0, 0, 0, 0 };
+  float DT_ALIGNED_ARRAY L[16] = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
   float hits = 0;
   // add up the left half of the window
   for(size_t y = 0; y < MIN(radius, height); y++)
@@ -870,9 +870,9 @@ static void _blur_vertical_16wide_Kahan(float *const restrict buf,
   size_t mask = 1;
   for(size_t r = (2*radius+1); r > 1 ; r >>= 1) mask = (mask << 1) | 1;
 
-  float DT_ALIGNED_ARRAY L[16] = { 0, 0, 0, 0 };
-  float DT_ALIGNED_ARRAY comp[16] = { 0, 0, 0, 0 };
-  float hits = 0;
+  float DT_ALIGNED_ARRAY L[16] =    { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
+  float DT_ALIGNED_ARRAY comp[16] = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
+  float hits = 0.0f;
   // add up the left half of the window
   for(size_t y = 0; y < MIN(radius, height); y++)
   {

--- a/src/common/guided_filter.h
+++ b/src/common/guided_filter.h
@@ -34,7 +34,7 @@ typedef struct gray_image
 // allocate space for 1-component image of size width x height
 static inline gray_image new_gray_image(int width, int height)
 {
-  return (gray_image){ dt_alloc_align(64, sizeof(float) * width * height), width, height };
+  return (gray_image){ dt_alloc_align_float((size_t)width * height), width, height };
 }
 
 
@@ -50,20 +50,6 @@ static inline void free_gray_image(gray_image *img_p)
 static inline void copy_gray_image(gray_image img1, gray_image img2)
 {
   memcpy(img2.data, img1.data, sizeof(float) * img1.width * img1.height);
-}
-
-
-// minimum of two integers
-static inline int min_i(int a, int b)
-{
-  return a < b ? a : b;
-}
-
-
-// maximum of two integers
-static inline int max_i(int a, int b)
-{
-  return a > b ? a : b;
 }
 
 void guided_filter(const float *guide, const float *in, float *out, int width, int height, int ch, int w,

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -132,7 +132,7 @@ static inline float interpolatef(const float a, const float b, const float c)
 
 // Kahan summation algorithm
 #ifdef _OPENMP
-#pragma omp declare simd aligned(c)
+#pragma omp declare simd
 #endif
 static inline float Kahan_sum(const float m, float *const __restrict__ c, const float add)
 {


### PR DESCRIPTION
Two reasons for really being sorry

1) Due to my insufficiency i forgot to remove a wrong check while pushing the last
   PR related to this subject, this effectively disabled the OpenCL path.
2) I couldn't really "fix" the issue - not as i thought

I spent some full days working on the guided filter investigating why the algorithm is "unstable" in certain situations.

a) In previous PR's checked all the boxing filters - i think there were a few minor problems - did that for another round but couldn't detect an issue in those functions,
b) tried very stupid&slow box filters col-by-col and row-by-row and using doubles,
c) enforced the CPU algo to work on full data instead of the tiling and made sure the tiling works as intended, the "artefacts stayed the same as we see on GPU
d) checked modules that possibly add some high frequency, high signal level content (ca correction, highlights) and could confirm that those modules sometimes are "critical"

and yes - there were some numerical differences we can also see while using OpenCL vs CPU code but - the principal "instability" of the algorithms in extreme conditions stayed the same leading to non-predictable results. BTW these "artefacts" are reproducable, exactly same settings lead to same "artefacts". 
(While investigating you might want to use the new developer masking mode)

I looked through the git file history and we had some early problems fixed by @rabauke, he introduced the kahan filters.

While reading the original paper it became obvious, we have to select proper eps and weights for the guided filter, they are not "per se defined by maths" but depend on content, input signal range, and mask vs guide signal levels.
By selecting a weight we must also select some proper eps. Instead of trying to explain what the parameters do, i attach the
original paper, surprisingly easy to read/understand :-)

The time @rabauke selected weight=100/eps=1 was well before the scene-referred time, we now have other signals or maybe such extreme situations as given by @kofa73 were simply not tested.

Investigating other weights and sigmas show, the algo gets very stable with pairs like
 - weight=100     sigma=3
 - weight=3       sigma=0.4
 - weight=20      sigma=1


I think we should probably rethink how we select those params, thus i implemented the two new functions - both more or less prototypes atm returning what we had - and i experimented with setting params there.

How to proceed? Not sure, options
1. do another pr for 4.6 just removing the don't-use-OpenCL bug and the non-aligned-access for
   a filter
2. take this pr as it has some additional code maintenance without adding new things
3. I tested the current behaviour against choosing weight=20/sigma=1, the algo is table with
   only very subtle differences and avoiding errors that could well happen with current settings.
4. We could possibly evaluate params a bit more and possibly do a blend-version-bump


