### PR TITLE
fix collection filter title label truncating

### DIFF
--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -1282,7 +1282,7 @@ static gboolean _widget_init(dt_lib_filtering_rule_t *rule, const dt_collection_
     g_object_set_data(G_OBJECT(rule->w_prop), "rule", rule);
     dt_bauhaus_combobox_set_from_value(rule->w_prop, prop);
     g_signal_connect(G_OBJECT(rule->w_prop), "value-changed", G_CALLBACK(_event_rule_change_type), self);
-    gtk_box_pack_start(GTK_BOX(hbox), rule->w_prop, TRUE, FALSE, 0);
+    gtk_box_pack_start(GTK_BOX(hbox), rule->w_prop, TRUE, TRUE, 0);
   }
   else if(newprop)
   {


### PR DESCRIPTION
fixes #15702

I noticed this on my Mac, but couldn't reproduce on Windows.

The titles in the collection filters are truncated even if there is plenty much free space:
<img width="326" alt="Bildschirmfoto 2023-11-22 um 14 07 36" src="https://github.com/darktable-org/darktable/assets/4083281/f3f15067-ad94-42c8-b6f2-178f976c71e5">

Reason: The combobox is allowed to expand but not filled.

With this PR it looks like this:
<img width="324" alt="Bildschirmfoto 2023-11-22 um 14 06 51" src="https://github.com/darktable-org/darktable/assets/4083281/299fd5cf-ad03-4020-9dd7-a7b97a8fcd96">

