### PR TITLE
[GUI] Fixes to Piwigo export tooltips

### DIFF
--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -1010,9 +1010,11 @@ void gui_init(dt_imageio_module_storage_t *self)
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   ui->user_entry = GTK_ENTRY
     (dt_action_entry_new
-     (DT_ACTION(self), N_("user"),
-      G_CALLBACK(_piwigo_entry_changed), ui,
-      _("the server name\ndefault protocol is https\nspecify http:// if non secure server"),
+     (DT_ACTION(self),
+      N_("user"),
+      G_CALLBACK(_piwigo_entry_changed),
+      ui,
+      NULL,
       last_account ? last_account->username : ""));
 
   gtk_widget_set_hexpand(GTK_WIDGET(ui->user_entry), TRUE);

--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -991,9 +991,13 @@ void gui_init(dt_imageio_module_storage_t *self)
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   ui->server_entry = GTK_ENTRY
     (dt_action_entry_new
-     (DT_ACTION(self), N_("server"),
-      G_CALLBACK(_piwigo_server_entry_changed), ui,
-      _("the server name\ndefault protocol is https\nspecify http:// if non secure server"),
+     (DT_ACTION(self),
+      N_("server"),
+      G_CALLBACK(_piwigo_server_entry_changed),
+      ui,
+      _("the server name\n"
+        "default protocol is https\n"
+        "specify insecure protocol http:// explicitly if that protocol is required"),
       last_account ? last_account->server : "piwigo.com"));
 
   gtk_widget_set_hexpand(GTK_WIDGET(ui->server_entry), TRUE);


### PR DESCRIPTION
English does not have a separate word `non`. When correcting, I reworded the idea more clearly, because the mention of server "insecurity" may sound intimidating to those who are not tech-savvy.

I also removed the tooltip from the username input field where it was due to a copy and paste error.

