### PR TITLE
Added a color finder tool

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ FILE(GLOB SOURCE_FILES
   "common/cache.c"
   "common/calculator.c"
   "common/collection.c"
+  "common/color_finder.c"
   "common/color_harmony.c"
   "common/color_picker.c"
   "common/color_vocabulary.c"

--- a/src/common/color_finder.c
+++ b/src/common/color_finder.c
@@ -1,0 +1,65 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2019-2021 darktable developers.
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "common/color_finder.h"
+#include "common/colorspaces_inline_conversions.h"
+#include "common/darktable.h"
+#include "common/dttypes.h"
+#include "develop/develop.h"
+#include "develop/imageop_math.h"
+#include "gui/gtk.h"
+#include <bits/stdint-uintn.h>
+#include <omp.h>
+
+
+#include <cairo.h>
+#include <stddef.h>
+#include <sys/param.h>
+
+void dt_color_finder(const uint8_t *const restrict in, uint8_t *const out, const int width, const int height,
+                     const int target_value, const float saturation_adjustment)
+{
+  const int ch = 4;
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none)                                                                       \
+    dt_omp_sharedconst(in, out, saturation_adjustment, target_value, height, width, ch) schedule(simd             \
+                                                                                                 : static)        \
+        aligned(in, out : 16)
+#endif
+  for(size_t i = 0; i < width * height * ch; i += ch)
+  {
+    // transform input image to HSV
+    dt_aligned_pixel_t rgb_in = { in[i], in[i + 1], in[i + 2] };
+    dt_aligned_pixel_t hsv_in;
+    dt_RGB_2_HSV(rgb_in, hsv_in);
+
+    // apply the operation and transform it back to RGB
+    dt_aligned_pixel_t hsv_out = { hsv_in[0], MIN(hsv_in[1] * saturation_adjustment, 1), target_value };
+    dt_aligned_pixel_t rgb_out;
+    dt_HSV_2_RGB(hsv_out, rgb_out);
+    rgb_out[3] = 255;
+
+    // set the data
+    for_four_channels(c) out[i + c] = rgb_out[c];
+  }
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/common/color_finder.h
+++ b/src/common/color_finder.h
@@ -1,0 +1,31 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2019-2021 darktable developers.
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "develop/develop.h"
+#include <cairo.h>
+#include <stdint.h>
+
+void dt_color_finder(const uint8_t *const restrict in, uint8_t *const out, const int width, const int height,
+                     const int target_value, const float saturation_adjustment);
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -128,6 +128,10 @@ void dt_dev_init(dt_develop_t *dev,
   dev->rawoverexposed.threshold =
     dt_conf_get_float("darkroom/ui/rawoverexposed/threshold");
 
+  dev->color_finder.enabled = FALSE;
+  dev->color_finder.value = dt_conf_get_int("darkroom/ui/color_finder/value");
+  dev->color_finder.saturation = dt_conf_get_float("darkroom/ui/color_finder/saturation");
+
   dev->overexposed.enabled = FALSE;
   dev->overexposed.mode = dt_conf_get_int("darkroom/ui/overexposed/mode");
   dev->overexposed.colorscheme = dt_conf_get_int("darkroom/ui/overexposed/colorscheme");
@@ -202,6 +206,9 @@ void dt_dev_cleanup(dt_develop_t *dev)
                   dev->rawoverexposed.colorscheme);
   dt_conf_set_float("darkroom/ui/rawoverexposed/threshold",
                     dev->rawoverexposed.threshold);
+
+  dt_conf_set_int("darkroom/ui/color_finder/value", dev->color_finder.value);
+  dt_conf_set_float("darkroom/ui/color_finder/saturation", dev->color_finder.saturation);
 
   dt_conf_set_int("darkroom/ui/overexposed/mode", dev->overexposed.mode);
   dt_conf_set_int("darkroom/ui/overexposed/colorscheme", dev->overexposed.colorscheme);

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -312,6 +312,16 @@ typedef struct dt_develop_t
   struct
   {
     GtkWidget *floating_window, *button;
+
+    gboolean enabled;
+    int value;
+    float saturation;
+  } color_finder;
+
+  // for the raw overexposure indicator
+  struct
+  {
+    GtkWidget *floating_window, *button;
     // yes, having gtk stuff in here is ugly. live with it.
 
     gboolean enabled;


### PR DESCRIPTION
Hi!

I have recently watched the fantastic video "Secrets of color-grading in photography" by Joanna Kustra (https://youtu.be/mC8ol2-V7Ck?feature=shared&t=3938) and noticed that around 1:05:38 she applies this neat trick to view only color without shades by luminosity blending the image with a neutral grey layer.
I reproduced this functionality in Darktable by adding a "color balance rgb" instance where the global saturation is set to 0 and the blend mode to divide. 

To make this a bit more convinient I have added this functionality in a more convinient way through the press of a button. The target value and saturation amplification are settable with a right-click context menu similar to other overlays.

**Why is this useful?**
Sometimes (for example during creative color-grading) I find some hues in the vectorscope strike my interest ("Where exactly is this shade of purple..?"). Instead of hunting around with the color picket to find those hues, with this addition they can be found with the press of a button. The elimination of shades and reduction of the image to saturation and hue makes this process very easy. 
It is also helpful when correcting color casts in shadows, defrinding, ..

Some comparison imges:

<img src="https://github.com/darktable-org/darktable/assets/151759884/250d58be-26a2-40a1-8399-c05406808b85" width="300"/>
<img src="https://github.com/darktable-org/darktable/assets/151759884/2d0f312a-a718-499f-881d-6dfdcfa5267a" width="300"/>

<img src="https://github.com/darktable-org/darktable/assets/151759884/ad9f8626-5dda-497b-acb7-c33939731bde" width="300"/>
<img src="https://github.com/darktable-org/darktable/assets/151759884/22e92f79-88c9-4432-bf68-54a2ac1ab62a" width="300"/>

<img src="https://github.com/darktable-org/darktable/assets/151759884/8f26f2bb-1a03-42fa-b2e4-2df5b31b7c47" width="300"/>
<img src="https://github.com/darktable-org/darktable/assets/151759884/043889c5-26c0-46c0-b998-783f24d75517" width="300"/>

