### PR TITLE
Fix bug with filename filter text fields not being re-filled after restart on Windows

### DIFF
--- a/src/libs/filters/filename.c
+++ b/src/libs/filters/filename.c
@@ -57,7 +57,7 @@ static void _filename_decode(const gchar *txt, gchar **name, gchar **ext)
   if(!txt || strlen(txt) == 0) return;
 
   // split the path to find filename and extension parts
-  gchar **elems = g_strsplit(txt, G_DIR_SEPARATOR_S, -1);
+  gchar **elems = g_strsplit(txt, "/", -1);
   const unsigned int size = g_strv_length(elems);
   if(size == 2)
   {


### PR DESCRIPTION
Resolves #15701.

The problem was an inconsistency that manifested itself only on Windows: in one place we serialized the filter parameters by separating them with the `/` character, while in another place `G_DIR_SEPARATOR_S` was used for decoding.