### PR TITLE
Fix feathering Part V - use modified feather weight and eps

### DIFF
--- a/src/common/math.h
+++ b/src/common/math.h
@@ -63,11 +63,6 @@
 // Nan-safe: NaN compares false and will result in mn
 #define CLAMPF(a, mn, mx) ((a) >= (mn) ? ((a) <= (mx) ? (a) : (mx)) : (mn))
 
-static inline float clamp_range_f(const float x, const float low, const float high)
-{
-  return x > high ? high : (x < low ? low : x);
-}
-
 //*****************
 // functions to check for non-finite values
 // with -ffinite-math-only, the compiler is free to elide checks based

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -209,8 +209,10 @@ typedef struct dt_develop_blend_params_t
   float brightness;
   /** details threshold */
   float details;
+  /** feathering parameters version */
+  uint32_t feather_version;
   /** some reserved fields for future use */
-  uint32_t reserved[3];
+  uint32_t reserved[2];
   /** blendif parameters */
   float blendif_parameters[4 * DEVELOP_BLENDIF_SIZE];
   float blendif_boost_factors[DEVELOP_BLENDIF_SIZE];


### PR DESCRIPTION
For stability of the feathered blending algorithm we use modified weight and eps parameters for the guided filter.

`feather_version` has been added to the blending params, it's is updated to the new version whenever we modify the feather radius or blur on-the-fly. This way we keep all old image edits safely but if the user works on the image and tries with new feather parameters is's safely updated.

While being here remove the `clamp_range_f()` function - only used within blend code - and make use of CLIP.

@kofa73 may i ask you for another round of testing? You can "safely" do this as there is no "version bump" leading to edits lost after going back to master. Please note that old edits will have the issue until the feathering values are changed. Works with opencl on/off.