### PR TITLE
Fix demosaicing mode for tiny roi_out sizes

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -619,6 +619,9 @@ void process(
   const int qual_flags = demosaic_qual_flags(piece, img, roi_out);
   int demosaicing_method = data->demosaicing_method;
 
+  if(roi_out->width < 16 || roi_out->height < 16)
+    demosaicing_method = (piece->pipe->dsc.filters == 9u) ? DT_IOP_DEMOSAIC_MARKEST3_VNG : DT_IOP_DEMOSAIC_VNG4;
+
   gboolean showmask = FALSE;
   if(self->dev->gui_attached && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
   {
@@ -779,6 +782,9 @@ int process_cl(
   dt_iop_demosaic_data_t *data = (dt_iop_demosaic_data_t *)piece->data;
 
   int demosaicing_method = data->demosaicing_method;
+
+  if(roi_out->width < 16 || roi_out->height < 16)
+    demosaicing_method = (piece->pipe->dsc.filters == 9u) ? DT_IOP_DEMOSAIC_MARKEST3_VNG : DT_IOP_DEMOSAIC_VNG4;
 
   gboolean showmask = FALSE;
   if(self->dev->gui_attached && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))


### PR DESCRIPTION
For roi_out sizes less than 16 in width or height most demosaicers run "wild". We don't have images with such parameters but by selecting some very strange lens distortions there might be such sizes.

As we don't care about much quality for those images we just fall back to VNG4 as that works safely under these circumstances and we avoid a crash.

Fixes #14995