### PR TITLE
[GUI] Fix tooltip text in 'unbreak input profile' module for better wording

### DIFF
--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -667,7 +667,7 @@ void gui_init(dt_iop_module_t *self)
 
   g->security_factor = dt_bauhaus_slider_from_params(self, "security_factor");
   dt_bauhaus_slider_set_format(g->security_factor, "%");
-  gtk_widget_set_tooltip_text(g->security_factor, _("enlarge or shrink the computed dynamic range\nthis is useful when noise perturbs the measurements"));
+  gtk_widget_set_tooltip_text(g->security_factor, _("increase or decrease the computed dynamic range\nthis is useful when noise distorts the measurement"));
 
   g->auto_button = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_combobox_new(self));
   dt_bauhaus_widget_set_label(g->auto_button, NULL, N_("auto tune levels"));


### PR DESCRIPTION
`distort` is more common (see Google Ngram) and therefore more familiar for most users than `perturb` (also, in this particular phrase, distort seems more natural, but that may be my subjective opinion). Another incorrect word usage catches the eye even more: `enlarge` and `shrink` mainly refer to spatial changes, they are not very suitable for indicating an increase or decrease of a numerical value (dynamic range).