### PR TITLE
deduplicate processed_maximum usage

### DIFF
--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -173,6 +173,22 @@ static inline int FC(const size_t row, const size_t col, const uint32_t filters)
 #define BLUE 2
 #define ALPHA 3
 
+static inline float dt_iop_get_processed_maximum(dt_dev_pixelpipe_iop_t *piece)
+{
+  return  fmaxf(1.0f,
+          fmaxf(piece->pipe->dsc.processed_maximum[0],
+          fmaxf(piece->pipe->dsc.processed_maximum[1],
+                piece->pipe->dsc.processed_maximum[2])));
+}
+
+static inline float dt_iop_get_processed_minimum(dt_dev_pixelpipe_iop_t *piece)
+{
+  return  fmaxf(1.0f,
+          fminf(piece->pipe->dsc.processed_maximum[0],
+          fminf(piece->pipe->dsc.processed_maximum[1],
+                piece->pipe->dsc.processed_maximum[2])));
+}
+
 /** Calculate the xtrans pattern color from the row and column **/
 static inline int FCxtrans(const int row, const int col, const dt_iop_roi_t *const roi,
                            const uint8_t (*const xtrans)[6])

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -289,11 +289,7 @@ void process(
     return;
   }
 
-  const float scaler = fmaxf(1.0f,
-                       fmaxf(piece->pipe->dsc.processed_maximum[0],
-                       fmaxf(piece->pipe->dsc.processed_maximum[1],
-                             piece->pipe->dsc.processed_maximum[2])));
-
+  const float scaler = dt_iop_get_processed_maximum(piece);
   dt_iop_image_scaled_copy(out, input, 1.0f / scaler, roi_in->width, roi_in->height, 1);
 
   if(run_fast) goto writeout;

--- a/src/iop/demosaicing/amaze.cc
+++ b/src/iop/demosaicing/amaze.cc
@@ -139,8 +139,7 @@ void amaze_demosaic(dt_dev_pixelpipe_iop_t *piece,
   int winh = roi_in->height;
 
   const int width = winw, height = winh;
-  const float clip_pt = fminf(piece->pipe->dsc.processed_maximum[0],
-                              fminf(piece->pipe->dsc.processed_maximum[1], piece->pipe->dsc.processed_maximum[2]));
+  const float clip_pt = dt_iop_get_processed_minimum(piece);
   const float clip_pt8 = 0.8f * clip_pt;
 
 // this allows to pass AMAZETS to the code. On some machines larger AMAZETS is faster
@@ -1238,7 +1237,7 @@ void amaze_demosaic(dt_dev_pixelpipe_iop_t *piece,
                                       + (hvwt[(indx + v1) >> 1]) * Dgrb[0][(indx + v1) >> 1])
                                          * temp,
                                0.0, 1.0);
- 
+
                 out[(row * roi_out->width + col) * 4 + 2]
                     = _clampnan(rgbgreen[indx]
                                    - ((hvwt[(indx - v1) >> 1]) * Dgrb[1][(indx - v1) >> 1]

--- a/src/iop/demosaicing/lmmse.c
+++ b/src/iop/demosaicing/lmmse.c
@@ -156,10 +156,7 @@ static void lmmse_demosaic(
   // refinement steps
   const int refine = (mode > 2) ? mode - 2 : 0;
 
-  const float scaler = fmaxf(1.0f,
-                             fmaxf(piece->pipe->dsc.processed_maximum[0],
-                                   fmaxf(piece->pipe->dsc.processed_maximum[1],
-                                         piece->pipe->dsc.processed_maximum[2])));
+  const float scaler = dt_iop_get_processed_maximum(piece);
   const float revscaler = 1.0f / scaler;
 
   const int num_vertical =   1 + (height - 2 * LMMSE_OVERLAP -1) / LMMSE_TILEVALID;

--- a/src/iop/demosaicing/rcd.c
+++ b/src/iop/demosaicing/rcd.c
@@ -301,7 +301,7 @@ static void rcd_demosaic(
 
   rcd_ppg_border(out, in, width, height, filters, RCD_MARGIN);
 
-  const float scaler = fmaxf(piece->pipe->dsc.processed_maximum[0], fmaxf(piece->pipe->dsc.processed_maximum[1], piece->pipe->dsc.processed_maximum[2]));
+  const float scaler = dt_iop_get_processed_maximum(piece);
   const float revscaler = 1.0f / scaler;
 
   const int num_vertical = 1 + (height - 2 * RCD_BORDER -1) / RCD_TILEVALID;
@@ -703,7 +703,7 @@ static int process_rcd_cl(
 
     {
       // populate data
-      const float scaler = 1.0f / fmaxf(piece->pipe->dsc.processed_maximum[0], fmaxf(piece->pipe->dsc.processed_maximum[1], piece->pipe->dsc.processed_maximum[2]));
+      const float scaler = 1.0f / dt_iop_get_processed_maximum(piece);
       err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_rcd_populate, width, height,
         CLARG(dev_in), CLARG(cfa), CLARG(rgb0), CLARG(rgb1), CLARG(rgb2), CLARG(width), CLARG(height),
         CLARG(piece->pipe->dsc.filters), CLARG(scaler));
@@ -765,8 +765,7 @@ static int process_rcd_cl(
         CLARG(VH_dir), CLARG(rgb0), CLARG(rgb1), CLARG(rgb2), CLARG(width), CLARG(height), CLARG(piece->pipe->dsc.filters));
       if(err != CL_SUCCESS) goto error;
     }
-    const float scaler = fmaxf(piece->pipe->dsc.processed_maximum[0], fmaxf(piece->pipe->dsc.processed_maximum[1], piece->pipe->dsc.processed_maximum[2]));
-
+    const float scaler = dt_iop_get_processed_maximum(piece);
     {
       // write output
       const int myborder = RCD_MARGIN;

--- a/src/iop/hlreconstruct/opposed.c
+++ b/src/iop/hlreconstruct/opposed.c
@@ -100,7 +100,7 @@ static void _process_linear_opposed(
         const gboolean quality)
 {
   dt_iop_highlights_data_t *d = (dt_iop_highlights_data_t *)piece->data;
-  const float clipval = 0.987f * d->clip;
+  const float clipval = highlights_clip_magics[DT_IOP_HIGHLIGHTS_OPPOSED] * d->clip;
   const dt_iop_buffer_dsc_t *dsc = &piece->pipe->dsc;
   const gboolean wbon = dsc->temperature.enabled;
   const dt_aligned_pixel_t icoeffs = { wbon ? dsc->temperature.coeffs[0] : 1.0f,
@@ -233,7 +233,7 @@ static float *_process_opposed(
   dt_iop_highlights_data_t *d = (dt_iop_highlights_data_t *)piece->data;
   const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
   const uint32_t filters = piece->pipe->dsc.filters;
-  const float clipval = 0.987f * d->clip;
+  const float clipval = highlights_clip_magics[DT_IOP_HIGHLIGHTS_OPPOSED] * d->clip;
   const dt_iop_buffer_dsc_t *dsc = &piece->pipe->dsc;
   const gboolean wbon = dsc->temperature.enabled;
   const dt_aligned_pixel_t icoeffs = { wbon ? dsc->temperature.coeffs[0] : 1.0f,
@@ -443,7 +443,7 @@ static cl_int process_opposed_cl(
 
   const int devid = piece->pipe->devid;
   const uint32_t filters = piece->pipe->dsc.filters;
-  const float clipval = 0.987f * d->clip;
+  const float clipval = highlights_clip_magics[DT_IOP_HIGHLIGHTS_OPPOSED] * d->clip;
   const dt_iop_buffer_dsc_t *dsc = &piece->pipe->dsc;
   const gboolean wbon = dsc->temperature.enabled;
   const dt_aligned_pixel_t icoeffs = { wbon ? dsc->temperature.coeffs[0] : 1.0f,


### PR DESCRIPTION
At some parts we look for the maximum or minimum dsc.processed_maximum over the color channels. Introduces get_processed_maximum() and get_processed_minimum() inline functions and make use of them.