### PR TITLE
preferences: use consistent wording for thumbnails

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1363,7 +1363,7 @@
       </enum>
     </type>
     <default>never</default>
-    <shortdescription>generate thumbs in background</shortdescription>
+    <shortdescription>generate thumbnails in background</shortdescription>
     <longdescription>if 'enable disk backend for thumbnail cache' is enabled thumbnails/mipmaps up to the selected size are generated while user is inactive in lighttable.</longdescription>
   </dtconfig>
   <dtconfig prefs="lighttable" section="thumbs">


### PR DESCRIPTION
Use the term "thumbnails" instead of "thumbs"