### PR TITLE
fix dt_print perf and verbose checks

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -412,10 +412,10 @@ void dt_cleanup();
   for performance reasons the debug log functions should only be called,
   and their arguments evaluated, if flags in thread match what is requested.
 */
-#define dt_debug_if(thread, func, ...)                           \
-  do{ if((thread) == DT_DEBUG_ALWAYS                             \
-         || (darktable.unmuted & (thread) &&                     \
-          !(~darktable.unmuted & (thread) & DT_DEBUG_RESTRICT))) \
+#define dt_debug_if(thread, func, ...)                            \
+  do{ if( ( (~DT_DEBUG_RESTRICT & (thread)) == DT_DEBUG_ALWAYS    \
+          || ~DT_DEBUG_RESTRICT & (thread) &  darktable.unmuted ) \
+         && !(DT_DEBUG_RESTRICT & (thread) & ~darktable.unmuted)) \
         func(__VA_ARGS__); } while(0)
 
 #define dt_print_pipe(thread, ...) dt_debug_if(thread, dt_print_pipe_ext, __VA_ARGS__)


### PR DESCRIPTION
As noted in #15720, #15572 introduced a regression when `-d perf` is specified on its own on the command line; it enables all `dt_print` statements, even those that require both `DT_DEBUG_PERF` _and_ some other flag.

This PR aims to remedy this.

I tested with the following batch file
```
build/bin/darktable 
build/bin/darktable -d all
build/bin/darktable -d common
build/bin/darktable -d verbose
build/bin/darktable -d opencl
build/bin/darktable -d opencl -d verbose
build/bin/darktable -d perf
build/bin/darktable -d opencl -d perf
build/bin/darktable -d opencl -d verbose -d perf
build/bin/darktable -d opencl -d sql -d perf
```
After adding `fprintf(stdout, "check debug flags %s\n", g_strjoinv(" ", argv));` as the first line in `src/main.c::main()` and
```
#define TEST_DEBUG(test) dt_print(test, #test "\n");
TEST_DEBUG(DT_DEBUG_ALWAYS);
TEST_DEBUG(DT_DEBUG_VERBOSE);
TEST_DEBUG(DT_DEBUG_PERF);
TEST_DEBUG(DT_DEBUG_OPENCL);
TEST_DEBUG(DT_DEBUG_SQL);
TEST_DEBUG(DT_DEBUG_OPENCL | DT_DEBUG_PERF);
TEST_DEBUG(DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE);
TEST_DEBUG(DT_DEBUG_OPENCL | DT_DEBUG_PERF | DT_DEBUG_VERBOSE);
TEST_DEBUG(DT_DEBUG_SQL | DT_DEBUG_PERF);
TEST_DEBUG(DT_DEBUG_SQL | DT_DEBUG_OPENCL);
exit(1);
```
in `darktable.c` before `if(darktable.unmuted)`

This generates:
```
check debug flags build/bin/darktable
     0.0020 DT_DEBUG_ALWAYS
check debug flags build/bin/darktable -d all
     0.0018 DT_DEBUG_ALWAYS
     0.0019 DT_DEBUG_PERF
     0.0019 DT_DEBUG_OPENCL
     0.0019 DT_DEBUG_SQL
     0.0019 DT_DEBUG_OPENCL | DT_DEBUG_PERF
     0.0019 DT_DEBUG_SQL | DT_DEBUG_PERF
     0.0019 DT_DEBUG_SQL | DT_DEBUG_OPENCL
check debug flags build/bin/darktable -d common
     0.0020 DT_DEBUG_ALWAYS
     0.0020 DT_DEBUG_OPENCL
     0.0020 DT_DEBUG_SQL | DT_DEBUG_OPENCL
check debug flags build/bin/darktable -d verbose
     0.0016 DT_DEBUG_ALWAYS
     0.0016 DT_DEBUG_VERBOSE
check debug flags build/bin/darktable -d opencl
     0.0025 DT_DEBUG_ALWAYS
     0.0025 DT_DEBUG_OPENCL
     0.0025 DT_DEBUG_SQL | DT_DEBUG_OPENCL
check debug flags build/bin/darktable -d opencl -d verbose
     0.0013 DT_DEBUG_ALWAYS
     0.0013 DT_DEBUG_VERBOSE
     0.0013 DT_DEBUG_OPENCL
     0.0013 DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE
     0.0013 DT_DEBUG_SQL | DT_DEBUG_OPENCL
check debug flags build/bin/darktable -d perf
     0.0015 DT_DEBUG_ALWAYS
     0.0015 DT_DEBUG_PERF
check debug flags build/bin/darktable -d opencl -d perf
     0.0013 DT_DEBUG_ALWAYS
     0.0013 DT_DEBUG_PERF
     0.0013 DT_DEBUG_OPENCL
     0.0013 DT_DEBUG_OPENCL | DT_DEBUG_PERF
     0.0013 DT_DEBUG_SQL | DT_DEBUG_OPENCL
check debug flags build/bin/darktable -d opencl -d verbose -d perf
     0.0013 DT_DEBUG_ALWAYS
     0.0014 DT_DEBUG_VERBOSE
     0.0014 DT_DEBUG_PERF
     0.0014 DT_DEBUG_OPENCL
     0.0014 DT_DEBUG_OPENCL | DT_DEBUG_PERF
     0.0014 DT_DEBUG_OPENCL | DT_DEBUG_VERBOSE
     0.0014 DT_DEBUG_OPENCL | DT_DEBUG_PERF | DT_DEBUG_VERBOSE
     0.0014 DT_DEBUG_SQL | DT_DEBUG_OPENCL
check debug flags build/bin/darktable -d opencl -d sql -d perf
     0.0014 DT_DEBUG_ALWAYS
     0.0014 DT_DEBUG_PERF
     0.0014 DT_DEBUG_OPENCL
     0.0014 DT_DEBUG_SQL
     0.0014 DT_DEBUG_OPENCL | DT_DEBUG_PERF
     0.0014 DT_DEBUG_SQL | DT_DEBUG_PERF
     0.0015 DT_DEBUG_SQL | DT_DEBUG_OPENCL
```
which looks correct to me.

Please double check and let me know if I overlooked a test case or otherwise committed thinkos again.