### PR TITLE
Enforce struct aligning in rgbcurve

### DIFF
--- a/src/common/curve_tools.h
+++ b/src/common/curve_tools.h
@@ -19,6 +19,8 @@
     Copyright 2004-2008 by Shawn Freeman, Udi Fuchs
 */
 
+#include <inttypes.h>
+
 #pragma once
 
 // Curve Types
@@ -55,7 +57,7 @@ typedef struct
 typedef struct
 {
   // Type for this curve
-  unsigned int m_spline_type;
+  uint32_t m_spline_type;
 
   // Box data
   float m_min_x;
@@ -64,7 +66,7 @@ typedef struct
   float m_max_y;
 
   // Number of anchor points
-  unsigned char m_numAnchors;
+  uint8_t m_numAnchors;
 
   // contains a list of anchors, 2 floats per each point, x-y format
   // max is 20 points
@@ -75,11 +77,11 @@ typedef struct
 typedef struct
 {
   // Number of samples to use for the curve.
-  unsigned int m_samplingRes;
-  unsigned int m_outputRes;
+  uint32_t m_samplingRes;
+  uint32_t m_outputRes;
 
   // Sampling array
-  unsigned short int *m_Samples; // jo: changed to short int to save memory
+  uint16_t *m_Samples; // jo: changed to short int to save memory
 
 } CurveSample;
 

--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -491,14 +491,13 @@ static inline float dt_draw_curve_calc_value(dt_draw_curve_t *c, const float x)
   return MIN(MAX(val, c->c.m_min_y), c->c.m_max_y);
 }
 
-static inline int dt_draw_curve_add_point(dt_draw_curve_t *c,
+static inline void dt_draw_curve_add_point(dt_draw_curve_t *c,
                                           const float x,
                                           const float y)
 {
   c->c.m_anchors[c->c.m_numAnchors].x = x;
   c->c.m_anchors[c->c.m_numAnchors].y = y;
   c->c.m_numAnchors++;
-  return 0;
 }
 
 // linear x linear y

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -35,7 +35,7 @@
 
 #define DT_GUI_CURVE_EDITOR_INSET DT_PIXEL_APPLY_DPI(1)
 #define DT_IOP_RGBCURVE_RES 256
-#define DT_IOP_RGBCURVE_MAXNODES 20
+#define DT_IOP_RGBCURVE_MAXNODES MAX_ANCHORS
 #define DT_IOP_RGBCURVE_MIN_X_DISTANCE 0.0025f
 // max iccprofile file name length
 // must be in synch with filename in dt_colorspaces_color_profile_t in colorspaces.h

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -271,18 +271,24 @@ void init_presets(dt_iop_module_so_t *self)
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_DISPLAY);
 }
 
-static float _curve_to_mouse(const float x, const float zoom_factor, const float offset)
+static float _curve_to_mouse(const float x,
+                            const float zoom_factor,
+                            const float offset)
 {
   return (x - offset) * zoom_factor;
 }
 
-static float _mouse_to_curve(const float x, const float zoom_factor, const float offset)
+static float _mouse_to_curve(const float x,
+                              const float zoom_factor,
+                              const float offset)
 {
   return (x / zoom_factor) + offset;
 }
 
-static void picker_scale(const float *const in, float *out, dt_iop_rgbcurve_params_t *p,
-                         const dt_iop_order_iccprofile_info_t *const work_profile)
+static void picker_scale(const float *const in,
+                          float *out,
+                          dt_iop_rgbcurve_params_t *p,
+                          const dt_iop_order_iccprofile_info_t *const work_profile)
 {
   switch(p->curve_autoscale)
   {
@@ -322,14 +328,16 @@ static void picker_scale(const float *const in, float *out, dt_iop_rgbcurve_para
   for(int c = 0; c < 3; c++) out[c] = CLIP(out[c]);
 }
 
-static void _rgbcurve_show_hide_controls(dt_iop_rgbcurve_params_t *p, dt_iop_rgbcurve_gui_data_t *g)
+static void _rgbcurve_show_hide_controls(dt_iop_rgbcurve_params_t *p,
+                                          dt_iop_rgbcurve_gui_data_t *g)
 {
   gtk_notebook_set_show_tabs(g->channel_tabs, p->curve_autoscale == DT_S_SCALE_MANUAL_RGB);
 
   gtk_widget_set_visible(g->cmb_preserve_colors, p->curve_autoscale == DT_S_SCALE_AUTOMATIC_RGB);
 }
 
-static gboolean _is_identity(dt_iop_rgbcurve_params_t *p, rgbcurve_channel_t channel)
+static gboolean _is_identity(dt_iop_rgbcurve_params_t *p,
+                              rgbcurve_channel_t channel)
 {
   for(int k=0; k<p->curve_num_nodes[channel]; k++)
     if(p->curve_nodes[channel][k].x != p->curve_nodes[channel][k].y) return FALSE;
@@ -415,7 +423,10 @@ static void interpolator_callback(GtkWidget *widget, dt_iop_module_t *self)
   gtk_widget_queue_draw(GTK_WIDGET(g->area));
 }
 
-static void tab_switch_callback(GtkNotebook *notebook, GtkWidget *page, guint page_num, gpointer user_data)
+static void tab_switch_callback(GtkNotebook *notebook,
+                                GtkWidget *page,
+                                guint page_num,
+                                gpointer user_data)
 {
   if(darktable.gui->reset) return;
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
@@ -426,7 +437,10 @@ static void tab_switch_callback(GtkNotebook *notebook, GtkWidget *page, guint pa
   gtk_widget_queue_draw(self->widget);
 }
 
-static inline int _add_node(dt_iop_rgbcurve_node_t *curve_nodes, int *nodes, float x, float y)
+static inline int _add_node(dt_iop_rgbcurve_node_t *curve_nodes,
+                            int *nodes,
+                            float x,
+                            float y)
 {
   int selected = -1;
   if(curve_nodes[0].x > x)
@@ -455,8 +469,11 @@ static inline int _add_node(dt_iop_rgbcurve_node_t *curve_nodes, int *nodes, flo
   return selected;
 }
 
-static inline int _add_node_from_picker(dt_iop_rgbcurve_params_t *p, const float *const in, const float increment,
-                                        const int ch, const dt_iop_order_iccprofile_info_t *const work_profile)
+static inline int _add_node_from_picker(dt_iop_rgbcurve_params_t *p,
+                                        const float *const in,
+                                        const float increment,
+                                        const int ch,
+                                        const dt_iop_order_iccprofile_info_t *const work_profile)
 {
   float x = 0.f;
   float y = 0.f;
@@ -484,7 +501,8 @@ static inline int _add_node_from_picker(dt_iop_rgbcurve_params_t *p, const float
   return _add_node(p->curve_nodes[ch], &p->curve_num_nodes[ch], x, y);
 }
 
-void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
+void color_picker_apply(dt_iop_module_t *self,
+                        GtkWidget *picker,
                         dt_dev_pixelpipe_t *pipe)
 {
   dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
@@ -532,7 +550,9 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
   dt_control_queue_redraw_widget(self->widget);
 }
 
-static gboolean _sanity_check(const float x, const int selected, const int nodes,
+static gboolean _sanity_check(const float x,
+                              const int selected,
+                              const int nodes,
                               const dt_iop_rgbcurve_node_t *curve)
 {
   gboolean point_valid = TRUE;
@@ -553,7 +573,11 @@ static gboolean _sanity_check(const float x, const int selected, const int nodes
   return point_valid;
 }
 
-static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, float dx, float dy, guint state)
+static gboolean _move_point_internal(dt_iop_module_t *self,
+                                      GtkWidget *widget,
+                                      float dx,
+                                      float dy,
+                                      guint state)
 {
   dt_iop_rgbcurve_params_t *p = (dt_iop_rgbcurve_params_t *)self->params;
   dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
@@ -583,7 +607,9 @@ static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, f
 
 #define RGBCURVE_DEFAULT_STEP (0.001f)
 
-static gboolean _area_scrolled_callback(GtkWidget *widget, GdkEventScroll *event, dt_iop_module_t *self)
+static gboolean _area_scrolled_callback(GtkWidget *widget,
+                                        GdkEventScroll *event,
+                                        dt_iop_module_t *self)
 {
   dt_iop_rgbcurve_params_t *p = (dt_iop_rgbcurve_params_t *)self->params;
   dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
@@ -635,7 +661,9 @@ static gboolean _area_scrolled_callback(GtkWidget *widget, GdkEventScroll *event
   return TRUE;
 }
 
-static gboolean _area_key_press_callback(GtkWidget *widget, GdkEventKey *event, dt_iop_module_t *self)
+static gboolean _area_key_press_callback(GtkWidget *widget,
+                                          GdkEventKey *event,
+                                          dt_iop_module_t *self)
 {
   dt_iop_rgbcurve_params_t *p = (dt_iop_rgbcurve_params_t *)self->params;
   dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
@@ -678,7 +706,9 @@ static gboolean _area_key_press_callback(GtkWidget *widget, GdkEventKey *event, 
 
 #undef RGBCURVE_DEFAULT_STEP
 
-static gboolean _area_leave_notify_callback(GtkWidget *widget, GdkEventCrossing *event, dt_iop_module_t *self)
+static gboolean _area_leave_notify_callback(GtkWidget *widget,
+                                            GdkEventCrossing *event,
+                                            dt_iop_module_t *self)
 {
   dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
   if(!(event->state & GDK_BUTTON1_MASK))
@@ -1061,7 +1091,9 @@ finally:
   return TRUE;
 }
 
-static gboolean _area_motion_notify_callback(GtkWidget *widget, GdkEventMotion *event, dt_iop_module_t *self)
+static gboolean _area_motion_notify_callback(GtkWidget *widget,
+                                              GdkEventMotion *event,
+                                              dt_iop_module_t *self)
 {
   dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
   dt_iop_rgbcurve_params_t *p = (dt_iop_rgbcurve_params_t *)self->params;
@@ -1474,7 +1506,9 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
   for(int k = 0; k < 0x10000; k++) d->table[DT_IOP_RGBCURVE_B][k] = k / 0x10000; // identity for b
 }
 
-void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+void cleanup_pipe(struct dt_iop_module_t *self,
+                  dt_dev_pixelpipe_t *pipe,
+                  dt_dev_pixelpipe_iop_t *piece)
 {
   // clean up everything again.
   dt_iop_rgbcurve_data_t *d = (dt_iop_rgbcurve_data_t *)(piece->data);
@@ -1518,7 +1552,8 @@ void cleanup_global(dt_iop_module_so_t *module)
 
 // this will be called from process*()
 // it must be executed only if profile info has changed
-static void _generate_curve_lut(dt_dev_pixelpipe_t *pipe, dt_iop_rgbcurve_data_t *d)
+static void _generate_curve_lut(dt_dev_pixelpipe_t *pipe,
+                                dt_iop_rgbcurve_data_t *d)
 {
   const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(pipe);
 
@@ -1583,8 +1618,10 @@ static void _generate_curve_lut(dt_dev_pixelpipe_t *pipe, dt_iop_rgbcurve_data_t
   }
 }
 
-void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
-                   dt_dev_pixelpipe_iop_t *piece)
+void commit_params(struct dt_iop_module_t *self,
+                    dt_iop_params_t *p1,
+                    dt_dev_pixelpipe_t *pipe,
+                    dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_rgbcurve_data_t *d = (dt_iop_rgbcurve_data_t *)(piece->data);
   dt_iop_rgbcurve_params_t *p = (dt_iop_rgbcurve_params_t *)p1;
@@ -1611,8 +1648,12 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 }
 
 #ifdef HAVE_OPENCL
-int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+int process_cl(struct dt_iop_module_t *self,
+                dt_dev_pixelpipe_iop_t *piece,
+                cl_mem dev_in,
+                cl_mem dev_out,
+                const dt_iop_roi_t *const roi_in,
+                const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
 
@@ -1683,8 +1724,12 @@ cleanup:
 }
 #endif
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
-             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+void process(struct dt_iop_module_t *self,
+              dt_dev_pixelpipe_iop_t *piece,
+              const void *const ivoid,
+              void *const ovoid,
+              const dt_iop_roi_t *const roi_in,
+              const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
 

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1556,7 +1556,7 @@ static void _generate_curve_lut(dt_dev_pixelpipe_t *pipe,
 {
   const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(pipe);
 
-  dt_iop_rgbcurve_node_t curve_nodes[3][DT_IOP_RGBCURVE_MAXNODES];
+  DT_ALIGNED_ARRAY dt_iop_rgbcurve_node_t curve_nodes[3][DT_IOP_RGBCURVE_MAXNODES];
 
   if(work_profile)
   {


### PR DESCRIPTION
As reported in #15358 we have the module crashing under certain circumstances, maybe related to compiler optimizing.

This pr
1. enforces the the (dt_iop_rgbcurve_data_t *) to be aligned-64
2. changes the order in typedef struct dt_iop_rgbcurve_data_t to make sure the float table[DT_IOP_RGBCURVE_MAX_CHANNELS][0x10000] is aligned for simd too.

Until now that table was aligned to 8 due to struct padding.

@robmate would you be able to check?