### PR TITLE
imageio_jxl: workaround for missing v0.7 version macros

### DIFF
--- a/src/imageio/format/jxl.c
+++ b/src/imageio/format/jxl.c
@@ -26,6 +26,7 @@
 
 #include <jxl/encode.h>
 #include <jxl/resizable_parallel_runner.h>
+#include <jxl/version.h> /* TODO: workaround for v0.7, remove when bumping requirement */
 
 DT_MODULE(1)
 


### PR DESCRIPTION
Addresses https://github.com/darktable-org/darktable/pull/15778#issuecomment-1831790650 for libjxl v0.7 quirk. @TurboGit 