### PR TITLE
[GUI] Rename spot mapping to area mapping as a spot is always small area by definition

### DIFF
--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -4539,7 +4539,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_gui_new_collapsible_section
     (&g->csspot,
      "plugins/darkroom/channelmixerrgb/expand_picker_mapping",
-     _("spot color mapping"),
+     _("area color mapping"),
      GTK_BOX(self->widget),
      DT_ACTION(self));
 
@@ -4552,7 +4552,7 @@ void gui_init(struct dt_iop_module_t *self)
        " surface over your series of images."));
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL
-    (g->spot_mode, self, N_("mapping"), N_("spot mode"),
+    (g->spot_mode, self, N_("mapping"), N_("area mode"),
      _("\"correction\" automatically adjust the illuminant\n"
        "such that the input color is mapped to the target.\n"
        "\"measure\" simply shows how an input color is mapped by the CAT\n"

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -1189,7 +1189,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_gui_new_collapsible_section
     (&g->cs,
      "plugins/darkroom/exposure/mapping",
-     _("spot exposure mapping"),
+     _("area exposure mapping"),
      GTK_BOX(self->widget),
      DT_ACTION(self));
 
@@ -1203,7 +1203,7 @@ void gui_init(struct dt_iop_module_t *self)
        "consistently-lit surface over your series of images."));
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL
-    (g->spot_mode, self, NULL, N_("spot mode"),
+    (g->spot_mode, self, NULL, N_("area mode"),
      _("\"correction\" automatically adjust exposure\n"
        "such that the input lightness is mapped to the target.\n"
        "\"measure\" simply shows how an input color is mapped by\n"


### PR DESCRIPTION
Initially, this was not my idea, I received this suggestion in a local chat  with dt users. But although I myself did not notice this issue at first, in the end I agreed that their proposal was reasonable and logical.

All photographers are familiar with the concept of spot metering. In this metering mode, the camera measures only a very small part of the scene (typically 1–5% of the viewfinder area). All other modes end up measuring a much larger part or the entire area of the scene.

That is, for photographers, the concept of spot is clearly associated with the concept of a very small area (this is also the dictionary definition of the word spot in the meaning of some area - it is always a very small area).

The "spot mapping" modes/sections in the exposure and color calibration modules are not limited in the size of the measurement area. These areas can be quite large even in real-world use cases. Therefore, the word spot here looks illogical and is not an accurate name for a potentially large area.

It is most logical to replace the word spot with the neutral "area".