### PR TITLE
fix presets GUI when called from preference dialog.

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -3091,6 +3091,23 @@ dt_iop_module_t *dt_iop_get_module(const char *op)
   return dt_iop_get_module_from_list(darktable.develop->iop, op);
 }
 
+dt_iop_module_so_t *dt_iop_get_module_so(const char *op)
+{
+  dt_iop_module_so_t *result = NULL;
+
+  for(GList *modules = darktable.iop; modules; modules = g_list_next(modules))
+  {
+    dt_iop_module_so_t *mod = (dt_iop_module_so_t *)modules->data;
+    if(dt_iop_module_is(mod, op))
+    {
+      result = mod;
+      break;
+    }
+  }
+
+  return result;
+}
+
 int dt_iop_get_module_flags(const char *op)
 {
   GList *modules = darktable.iop;

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -449,6 +449,7 @@ dt_iop_module_t *dt_iop_get_colorout_module(void);
 /* returns the iop-module found in list with the given name */
 dt_iop_module_t *dt_iop_get_module_from_list(GList *iop_list, const char *op);
 dt_iop_module_t *dt_iop_get_module(const char *op);
+dt_iop_module_so_t *dt_iop_get_module_so(const char *op);
 /** returns module with op + multi_priority or NULL if not found on the list,
     if multi_priority == -1 do not check for it */
 dt_iop_module_t *dt_iop_get_module_by_op_priority(GList *modules,

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -908,7 +908,7 @@ void dt_gui_presets_show_iop_edit_dialog(const char *name_in,
   g->iop = module;
   g->operation = g_strdup(module->op);
   g->op_version = module->version();
-  g->module_name = g_strdup(module->name());
+  g->module_name = g_strdup(module->op);
   g->callback = final_callback;
   g->data = data;
   g->parent = parent;

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -616,7 +616,11 @@ static void _presets_show_edit_dialog(dt_gui_presets_edit_dialog_t *g,
                               _("be very careful with this option. "
                                 "this might be the last time you see your preset."));
   gtk_box_pack_start(box, GTK_WIDGET(g->filter), FALSE, FALSE, 0);
-  if(!g->iop)
+
+  // check if module_name is an IOP module
+  const dt_iop_module_so_t *module = dt_iop_get_module_so(g->module_name);
+
+  if(!module)
   {
     // lib usually don't support auto-init / autoapply
     gtk_widget_set_no_show_all(GTK_WIDGET(g->autoinit), TRUE);
@@ -625,6 +629,13 @@ static void _presets_show_edit_dialog(dt_gui_presets_edit_dialog_t *g,
     // for libs, we don't want the filtering option as it's not implemented...
     gtk_widget_set_no_show_all(GTK_WIDGET(g->filter), TRUE);
   }
+  else
+  {
+    // without an IOP history we cannot support autoinit
+    gtk_widget_set_sensitive(GTK_WIDGET(g->autoinit), g->iop != NULL);
+    gtk_widget_set_sensitive(GTK_WIDGET(g->filter), TRUE);
+  }
+
   g_signal_connect(G_OBJECT(g->autoapply), "toggled",
                    G_CALLBACK(_check_buttons_activated), g);
   g_signal_connect(G_OBJECT(g->filter), "toggled",


### PR DESCRIPTION
presets: Fix presets GUI when called from preferences dialog.
    
We ensure that all lines are displayed but the auto-init selection
is disabled as it is impossible to use it without a proper history
module. It is available as before only from the darkroom presets menu.
    
Fixes #15761.
