### PR TITLE
crawler sync XMP: better layout of buttons (CSS tweak).

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -742,6 +742,12 @@ dialog .dialog-vbox
   margin: 0.42em;
 }
 
+dialog .text-button
+{
+  margin: 0.42em;
+  padding: 0.3em;
+}
+
 /* set top margin in bottom button bar to be the same as bottom margin applied above for main dialog window */
 dialog .dialog-action-box
 {
@@ -749,12 +755,14 @@ dialog .dialog-action-box
 }
 
 /* remove margin on the left for first left button only, then do the same for right margin for last right button only */
-dialog .dialog-action-box button:first-child
+dialog .dialog-action-box button:first-child,
+dialog .text-button:first-child
 {
   margin-left: 0;
 }
 
-dialog .dialog-action-box button:last-child
+dialog .dialog-action-box button:last-child,
+dialog .text-button:last-child
 {
   margin-right: 0;
 }


### PR DESCRIPTION
This is only a CSS tweak to get better button visibility in the updated XMP sidecars sync dialog.

From where all buttons are very close to each others:

![image](https://github.com/darktable-org/darktable/assets/467069/3afeccbf-230d-4140-8e7d-109aeb05e74f)

To:

![image](https://github.com/darktable-org/darktable/assets/467069/42d46c52-96e0-4951-9d2f-b3e22bbe4716)

This has been hitching me since some time now.