### PR TITLE
darkroom: increase distance between search icon and entry

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1510,7 +1510,7 @@ border-bottom: 0.07em solid alpha(@selected_bg_color, 0.75);
 
 .search image.left
 {
-  padding: 0 0.21em;
+  padding: 0 0.4em;
 }
 
 .search image:disabled


### PR DESCRIPTION
The search entry field currently seems a little too close to the icon for me. The following is the CSS tweak I'm using in my current working build and IMO looks better.

Before:

![Screenshot_2023-12-01_08-32-48](https://github.com/darktable-org/darktable/assets/9555491/e1e00c2c-08a4-4f35-8232-65873a6ebd74)

After:

![Screenshot_2023-12-01_08-33-43](https://github.com/darktable-org/darktable/assets/9555491/277e64d7-904f-4a95-bf87-a96e9f2f18bb)
