### PR TITLE
[GUI] Better placement and font style for the warning in manage module layout window

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1454,7 +1454,8 @@ border-bottom: 0.07em solid alpha(@selected_bg_color, 0.75);
 #import-presets,
 #modulegroups-ro
 {
-  font-style: italic;
+  margin-top: 1.0em;
+  font-weight: bold;
 }
 
 /* About window: set different background for credits view */


### PR DESCRIPTION
Currently, the warning text looks like it is glued to the table above (with no margin). Italics also look inappropriate (in general, italics in the UI should be used very carefully). This is a warning, so it should be in bold.