### PR TITLE
collection: Always sort ascending on version number.

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -820,7 +820,7 @@ gchar *dt_collection_get_sort_query(const dt_collection_t *collection)
   if(!filename) query = dt_util_dstrcat(query, ", filename%s",
                                         (first_order) ? " DESC" : "");
 
-  query = dt_util_dstrcat(query, ", version%s", (first_order) ? " DESC" : "");
+  query = dt_util_dstrcat(query, ", version ASC");
 
   return query;
 }


### PR DESCRIPTION
For all collection order we want to keep the duplicates in the order they have been created. That is, the original first then the first duplicate and the other dupliaces following.

Fixes #15826.