### PR TITLE
add 'Arial Unicode MS' font for glyphs

### DIFF
--- a/data/themes/darktable-elegant-darker.css
+++ b/data/themes/darktable-elegant-darker.css
@@ -72,7 +72,8 @@ box *
                "SF Pro Display Light", "SF Pro Display",  /* Mac OS X default */
                "Ubuntu Light", "Ubuntu", "IPAPGothic",    /* Ubuntu default */
                "Cantarell",                               /* Gnome default */
-                sans-serif;                                /* default default */
+               "Arial Unicode MS",                        /* Unicode glyphs */
+                sans-serif;                               /* default default */
 }
 
 .dt_section_label:not(#blending-box),
@@ -84,6 +85,7 @@ box *
                "SF Pro Display Medium", "SF Pro Display",
                "Ubuntu Medium", "Ubuntu", "IPAPGothic",
                "Cantarell",
+               "Arial Unicode MS",
                 sans-serif;
 }
 
@@ -95,7 +97,8 @@ box *
                "SF Pro Display", "SF Pro Display",
                "Ubuntu Condensed", "Ubuntu", "IPAPGothic",
                "Cantarell",
-               sans-serif;
+               "Arial Unicode MS",
+                sans-serif;
 }
 
 .active_menu_item *, /* needed for some Pango issues not rendering synthetic bold for all OS */
@@ -109,5 +112,6 @@ tooltip label,
                "SF Pro Text",
                "Ubuntu", "IPAPGothic",
                "Cantarell",
+               "Arial Unicode MS",
                 sans-serif;
 }

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -237,7 +237,7 @@ Why that? Just because it's a developer choice and most classes use underscore i
   background-image: none;
   color: @fg_color;
   font-size: 1em;   /* avoid changing this settings or you will made the UI quite awful (too big or too small) */
-  font-family: sans-serif;
+  font-family: sans-serif, "Arial Unicode MS";
   font-feature-settings: "tnum";
   font-weight: normal;
   box-shadow:none;
@@ -297,6 +297,7 @@ box,
 box *
 {
   background-color: transparent;
+  font-family: sans-serif, "Arial Unicode MS";
 }
 
 /*----------------------
@@ -353,7 +354,7 @@ textview,
   border: 1px solid @button_border; /* this too */
   border-radius: 0.21em;
   background-color: @button_bg;
-  font-family: sans-serif;
+  font-family: sans-serif, "Arial Unicode MS";
 }
 
 /* then set specific settings for all text zones and combo */
@@ -593,7 +594,7 @@ dialog .sidebar row:selected:hover label,
   color: @plugin_label_color;
   padding: 0 0.14em 0.14em 0.45em;
   font-weight: normal;
-  font-family: sans-serif;
+  font-family: sans-serif, "Arial Unicode MS";
   font-size: 1.1em;
 }
 
@@ -601,7 +602,7 @@ dialog .sidebar row:selected:hover label,
 #iop-module-name
 {
   font-weight: lighter;
-  font-family: sans-serif;
+  font-family: sans-serif, "Arial Unicode MS";
   font-size: 0.8em;
 }
 
@@ -625,7 +626,7 @@ dialog .sidebar row:selected:hover label,
 {
   padding: 0.14em 0;
   color: @section_label;
-  font-family: sans-serif;
+  font-family: sans-serif, "Arial Unicode MS";
   font-weight: 500;
 }
 
@@ -906,7 +907,7 @@ notebook tabs,
 #guides-line,
 #modules-tabs
 {
-  font-family: sans-serif;
+  font-family: sans-serif, "Arial Unicode MS";
 }
 
 #blending-tabs,


### PR DESCRIPTION
fixes #8981 

The unicode checkmark character "✔" is not displayed on macOS because the font "Arial Unicode MS" is not loaded:

<img width="627" alt="Bildschirmfoto 2023-12-05 um 07 40 11" src="https://github.com/darktable-org/darktable/assets/4083281/5a649039-c7ca-4ec9-962d-2c5880a4ca2e">

I have fixed this not only for the use in Treeviews but globally, in case the checkmark will be used anywhere else.

<img width="626" alt="Bildschirmfoto 2023-12-05 um 08 29 35" src="https://github.com/darktable-org/darktable/assets/4083281/8b1ca178-10c9-4bbb-967b-ad2454bbb152">

@Nilvus, @victoryforce:
I would have expected the global font definitions in `darktable.css`. What's the reason they have been put in `darktable-elegant-darker.css` ?