### PR TITLE
Fix some OpenCL error conditions

### DIFF
--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -1365,6 +1365,8 @@ int dt_interpolation_resample_cl(const struct dt_interpolation *itor,
   // store resampling plan to device memory hindex, vindex, hkernel,
   // vkernel: (v|h)maxtaps might be too small, so store a bit more
   // than needed
+  err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
+
   dev_hindex = dt_opencl_copy_host_to_device_constant
     (devid, sizeof(int) * width * (hmaxtaps + 1), hindex);
   if(dev_hindex == NULL) goto error;

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3751,6 +3751,7 @@ int process_cl(struct dt_iop_module_t *self,
   const float cx = roi_out->scale * fullwidth * d->cl;
   const float cy = roi_out->scale * fullheight * d->ct;
 
+  err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
   dev_homo = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 9, ihomograph);
   if(dev_homo == NULL) goto error;
 
@@ -3781,6 +3782,7 @@ int process_cl(struct dt_iop_module_t *self,
       ldkernel = gd->kernel_ashift_lanczos3;
       break;
     default:
+      err = DT_OPENCL_DEFAULT_ERROR;
       goto error;
   }
 

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -724,6 +724,7 @@ int process_cl_fusion(struct dt_iop_module_t *self,
 
   int num_levels = num_levels_max;
 
+  err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
   dev_tmp1 = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
   if(dev_tmp1 == NULL) goto error;
 

--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -328,6 +328,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     b = NULL; // make sure we don't clean it up twice
   }
 
+  err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
   dev_tmp = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
   if(dev_tmp == NULL) goto error;
 

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1100,7 +1100,10 @@ int process_cl(struct dt_iop_module_t *self,
   hue_rotation_matrix_cl = dt_opencl_copy_host_to_device_constant(devid, 4 * sizeof(float), hue_rotation_matrix);
 
   if(input_matrix_cl == NULL || output_matrix_cl == NULL || gamut_LUT_cl == NULL || hue_rotation_matrix_cl == NULL)
+  {
+    err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto error;
+  }
 
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_colorbalance_rgb, width, height,
     CLARG(dev_in), CLARG(dev_out),

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -651,6 +651,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
           = (data->target_var[i][1] > 0.0f) ? data->source_var[mapio[i]][1] / data->target_var[i][1] : 0.0f;
     }
 
+    err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
     if(dev_tmp == NULL) goto error;
 

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -298,6 +298,7 @@ int process_cl(struct dt_iop_module_t *self,
     b = NULL; // make sure we don't clean it up twice
   }
 
+  err = DT_OPENCL_SYSMEM_ALLOCATION;
   dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
   if(dev_tmp == NULL) goto error;
 

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -280,6 +280,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const int raw_width = buf.width;
   const int raw_height = buf.height;
 
+  err = DT_OPENCL_SYSMEM_ALLOCATION;
   dev_raw = dt_opencl_copy_host_to_device(devid, buf.buf, raw_width, raw_height, sizeof(uint16_t));
   if(dev_raw == NULL) goto error;
 
@@ -340,6 +341,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
       break;
   }
 
+  err = DT_OPENCL_SYSMEM_ALLOCATION;
   if(filters == 9u)
   {
     dev_xtrans

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -580,6 +580,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     b = NULL; // make sure we don't clean it up twice
   }
 
+  err = DT_OPENCL_SYSMEM_ALLOCATION;
   dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
   if(dev_tmp == NULL) goto error;
 


### PR DESCRIPTION
While testing for a successful data copy from host to CL device we might want to quit CL code with a returned valid error condition.

All fixes done in this commit tackle a situation where we might have a SUCCESS err code, this would result in an aborted cl code but the caller would not be told about this and we wouldn't do a fallback to cpu.

I checked while investigating #15821 and spotted some "issues". Although not very likely to happen because of small amount of mem transferred all are possible "stoppers" that could result in unexpected "didn't process" situations especially on small cards.
