### PR TITLE
macOS: fix shift-scrollwheel issues part 2

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -422,7 +422,7 @@ static gboolean _popup_scroll(GtkWidget *widget,
 {
   dt_bauhaus_widget_t *w = darktable.bauhaus->current;
   int delta_y = 0;
-  if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
+  if(dt_gui_get_scroll_unit_delta(event, &delta_y))
   {
     if(darktable.bauhaus->current->type == DT_BAUHAUS_COMBOBOX)
       _combobox_next_sensitive(w, delta_y, 0, w->data.combobox.mute_scrolling);
@@ -2909,7 +2909,7 @@ static gboolean _widget_scroll(GtkWidget *widget,
   gtk_widget_grab_focus(widget);
 
   int delta_y = 0;
-  if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
+  if(dt_gui_get_scroll_unit_delta(event, &delta_y))
   {
     if(delta_y == 0) return TRUE;
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2205,7 +2205,7 @@ static gboolean _presets_scroll_callback(GtkWidget *widget,
                                          dt_iop_module_t *module)
 {
   int delta_y = 0;
-  if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
+  if(dt_gui_get_scroll_unit_delta(event, &delta_y))
     dt_gui_presets_apply_adjacent_preset(module, delta_y);
 
   return TRUE;

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1580,7 +1580,7 @@ static gboolean area_scrolled(GtkWidget *widget,
   if(dt_gui_ignore_scroll(event)) return FALSE;
 
   int delta_y;
-  if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
+  if(dt_gui_get_scroll_unit_delta(event, &delta_y))
   {
     c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta_y), 0.25 / BANDS, 1.0);
     gtk_widget_queue_draw(widget);

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -451,7 +451,7 @@ static gboolean dt_iop_colorcorrection_scrolled(GtkWidget *widget, GdkEventScrol
   if(dt_gui_ignore_scroll(event)) return FALSE;
 
   int delta_y;
-  if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
+  if(dt_gui_get_scroll_unit_delta(event, &delta_y))
   {
      p->saturation = CLAMP(p->saturation - 0.1 * delta_y, -3.0, 3.0);
      dt_bauhaus_slider_set(g->slider, p->saturation);

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -1883,7 +1883,7 @@ static gboolean _area_scrolled_callback(GtkWidget *widget,
 
   if(darktable.develop->darkroom_skip_mouse_events)
   {
-    if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
+    if(dt_gui_get_scroll_unit_delta(event, &delta_y))
     {
       GtkAllocation allocation;
       gtk_widget_get_allocation(widget, &allocation);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3654,7 +3654,7 @@ static gboolean denoiseprofile_scrolled(GtkWidget *widget,
   if(dt_gui_ignore_scroll(event)) return FALSE;
 
   int delta_y;
-  if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
+  if(dt_gui_get_scroll_unit_delta(event, &delta_y))
   {
     c->mouse_radius = CLAMP(c->mouse_radius * (1.f + 0.1f * delta_y),
                             0.2f / DT_IOP_DENOISE_PROFILE_BANDS, 1.f);

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -986,7 +986,7 @@ static gboolean dt_iop_levels_scroll(GtkWidget *widget, GdkEventScroll *event, g
 
   const float interval = 0.002 * dt_accel_get_speed_multiplier(widget, event->state); // Distance moved for each scroll event
   int delta_y;
-  if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
+  if(dt_gui_get_scroll_unit_delta(event, &delta_y))
   {
     float new_position = p->levels[c->handle_move] - interval * delta_y;
     dt_iop_levels_move_handle(self, c->handle_move, new_position, p->levels, c->drag_start_percentage);

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -788,7 +788,7 @@ static gboolean lowlight_scrolled(GtkWidget *widget, GdkEventScroll *event, gpoi
   if(dt_gui_ignore_scroll(event)) return FALSE;
 
   int delta_y;
-  if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
+  if(dt_gui_get_scroll_unit_delta(event, &delta_y))
   {
     c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta_y), 0.2 / DT_IOP_LOWLIGHT_BANDS, 1.0);
     gtk_widget_queue_draw(widget);

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -544,7 +544,7 @@ static gboolean dt_iop_monochrome_scrolled(GtkWidget *widget, GdkEventScroll *ev
   dt_iop_color_picker_reset(self, TRUE);
 
   int delta_y;
-  if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
+  if(dt_gui_get_scroll_unit_delta(event, &delta_y))
   {
     const float old_size = p->size;
     p->size = CLAMP(p->size + delta_y * 0.1, 0.5f, 3.0f);

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -879,7 +879,7 @@ static gboolean rawdenoise_scrolled(GtkWidget *widget, GdkEventScroll *event, gp
   if(dt_gui_ignore_scroll(event)) return FALSE;
 
   int delta_y;
-  if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
+  if(dt_gui_get_scroll_unit_delta(event, &delta_y))
   {
     c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta_y), 0.2 / DT_IOP_RAWDENOISE_BANDS, 1.0);
     gtk_widget_queue_draw(widget);

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1319,7 +1319,7 @@ static gboolean rt_wdbar_scrolled(GtkWidget *widget,
   dt_iop_request_focus(self);
 
   int delta_y;
-  if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
+  if(dt_gui_get_scroll_unit_delta(event, &delta_y))
   {
     if(g->lower_margin) // bottom slider
       rt_num_scales_update(p->num_scales - delta_y, self);

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -675,7 +675,7 @@ static gboolean _area_scroll_callback(GtkWidget *widget,
   const float interval = 0.002 * dt_accel_get_speed_multiplier(widget, event->state);
   // Distance moved for each scroll event
   int delta_y;
-  if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
+  if(dt_gui_get_scroll_unit_delta(event, &delta_y))
   {
     const float new_position = p->levels[c->channel][c->handle_move] - interval * delta_y;
     _rgblevels_move_handle(self, c->handle_move, new_position, p->levels[c->channel], c->drag_start_percentage);

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -682,7 +682,7 @@ static gboolean dt_iop_zonesystem_bar_scrolled(GtkWidget *widget, GdkEventScroll
   if(dt_gui_ignore_scroll(event)) return FALSE;
 
   int delta_y;
-  if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
+  if(dt_gui_get_scroll_unit_delta(event, &delta_y))
   {
     p->size = CLAMP(p->size - delta_y, 4, MAX_ZONE_SYSTEM_SIZE);
     p->zone[cs] = -1;

--- a/src/libs/tools/timeline.c
+++ b/src/libs/tools/timeline.c
@@ -1322,7 +1322,7 @@ static gboolean _lib_timeline_scroll_callback(GtkWidget *w, GdkEventScroll *e, g
   {
     int z = strip->zoom;
     int delta_y = 0;
-    if(dt_gui_get_scroll_unit_deltas(e, NULL, &delta_y))
+    if(dt_gui_get_scroll_unit_delta(e, &delta_y))
     {
       if(delta_y < 0)
       {

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3696,7 +3696,7 @@ static gboolean _second_window_scrolled_callback(GtkWidget *widget,
                                                  dt_develop_t *dev)
 {
   int delta_y;
-  if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
+  if(dt_gui_get_scroll_unit_delta(event, &delta_y))
   {
     const gboolean constrained = !dt_modifier_is(event->state, GDK_CONTROL_MASK);
     dt_dev_zoom_move(&dev->preview2, DT_ZOOM_SCROLL, 0.0f, delta_y < 0,


### PR DESCRIPTION
fixes #15838 

In addition to PR #15400 I have now changed all occurrences of `dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y);` (where only `delta_y` is involved) to the safer function `dt_gui_get_scroll_unit_delta(event, &delta_y);`

On macOS (and probably other platforms as well), Shift+Scroll is trapped as a horizontal scroll, which doesn't make sense.
