### PR TITLE
[CI/CD] Downgrade GCC 13 to GCC 12 in AppImage build action

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler:
-          - { compiler: GNU13,  CC: gcc-13,   CXX: g++-13,     packages: gcc-13 g++-13 }
+          - { compiler: GNU12, CC: gcc-12, CXX: g++-12, packages: gcc-12 g++-12 }
         branch:
           - { code: master, label: gitmaster }
     env:


### PR DESCRIPTION
GCC 13 is not available in Ubuntu 22.04, this version of the compiler has been added to the action runner OS image by GitHub.

As a result, compiling with this version introduces a dependency on versioned C++ standard library symbols into the compiled program, which are not present in the Ubuntu 22.04 release. This makes it impossible to run the generated AppImage on this OS release. The problem does not occur only in those distribution releases that contain GCC 13 as the main system compiler.

This PR fixes the problem by switching to GCC 12.
