### PR TITLE
CMake: do not tweak find library suffixes for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,6 @@ include(compiler-versions)
 
 if(WIN32)
   message("-- Win32 build detected, setting default features")
-  set(CMAKE_FIND_LIBRARY_SUFFIXES .dll ${CMAKE_FIND_LIBRARY_SUFFIXES})
   set(USE_COLORD OFF)
   set(USE_KWALLET OFF)
   set(BUILD_CMSTEST OFF)


### PR DESCRIPTION
This tweak should not be necessary AFAIK. Was it there to address a specific library? @phrrk @Mark-64 @peterbud 

It now actually breaks the Windows MSYS2 build since the recent [CMake 3.28 ](https://www.kitware.com/cmake-3-28-0-available-for-download/) update which (again) changed this behaviour:
```
* The "find_library()", "find_path()", and "find_file()" commands no
longer search in installation prefixes derived from the "PATH"
environment variable.  This behavior was added in CMake 3.3 to
support MSYS and MinGW ("MSYSTEM") development environments on
Windows, but it can search undesired prefixes that happen to be in
the "PATH" for unrelated reasons.  Users who keep some
"<prefix>/bin" directories in the "PATH" just for their tools do not
necessarily want any corresponding "<prefix>/lib" or
"<prefix>/include" directories searched. The behavior was reverted
for non-Windows platforms by CMake 3.6. Now it has been reverted on
Windows platforms too.

One may set the "CMAKE_PREFIX_PATH" environment variable with a
semicolon-separated list of prefixes that are to be searched.

* When using MinGW tools in a "MSYSTEM" environment on Windows, the
"$MSYSTEM_PREFIX/local" and "$MSYSTEM_PREFIX" prefixes are now added
to "CMAKE_SYSTEM_PREFIX_PATH".
``` 
With .dll in the search suffixes, it now prioritizes system DLLs in C:\Windows\System32 instead of desired MSYS2 .dll.a import stub libs. The linker of course fails if you try to link to a .dll instead of the import .dll.a or .lib stub.