### PR TITLE
macOS: Fix wrong DPI value detected by gtk/gdk

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1391,6 +1391,35 @@ double dt_get_system_gui_ppd(GtkWidget *widget)
   return res;
 }
 
+double dt_get_screen_resolution(GtkWidget *widget)
+{
+  // get the screen resolution
+  float screen_dpi = dt_conf_get_float("screen_dpi_overwrite");
+  if(screen_dpi > 0.0)
+  {
+    gdk_screen_set_resolution(gtk_widget_get_screen(widget), screen_dpi);
+    dt_print(DT_DEBUG_CONTROL,
+             "[screen resolution] setting the screen resolution to %f dpi as specified in "
+             "the configuration file\n",
+             screen_dpi);
+  }
+  else
+  {
+    screen_dpi = gdk_screen_get_resolution(gtk_widget_get_screen(widget));
+    if(screen_dpi < 0.0) 
+    {
+      screen_dpi = 96.0;
+      gdk_screen_set_resolution(gtk_widget_get_screen(widget), 96.0);
+      dt_print(DT_DEBUG_CONTROL,
+               "[screen resolution] setting the screen resolution to the default 96 dpi\n");
+    }
+    else
+      dt_print(DT_DEBUG_CONTROL,
+               "[screen resolution] setting the screen resolution to %f dpi\n", screen_dpi);
+  }
+  return screen_dpi;
+}
+
 void dt_configure_ppd_dpi(dt_gui_gtk_t *gui)
 {
   GtkWidget *widget = gui->ui->main_window;
@@ -1402,31 +1431,9 @@ void dt_configure_ppd_dpi(dt_gui_gtk_t *gui)
       gui->ppd_thb *= DT_GUI_THUMBSIZE_REDUCE;
       gui->filter_image = CAIRO_FILTER_FAST;
   }
-  // get the screen resolution
-  const float screen_dpi_overwrite = dt_conf_get_float("screen_dpi_overwrite");
-  if(screen_dpi_overwrite > 0.0)
-  {
-    gui->dpi = screen_dpi_overwrite;
-    gdk_screen_set_resolution(gtk_widget_get_screen(widget), screen_dpi_overwrite);
-    dt_print(DT_DEBUG_CONTROL,
-             "[screen resolution] setting the screen resolution to %f dpi as specified in "
-             "the configuration file\n",
-             screen_dpi_overwrite);
-  }
-  else
-  {
-    gui->dpi = gdk_screen_get_resolution(gtk_widget_get_screen(widget));
-    if(gui->dpi < 0.0)
-    {
-      gui->dpi = 96.0;
-      gdk_screen_set_resolution(gtk_widget_get_screen(widget), 96.0);
-      dt_print(DT_DEBUG_CONTROL,
-               "[screen resolution] setting the screen resolution to the default 96 dpi\n");
-    }
-    else
-      dt_print(DT_DEBUG_CONTROL,
-               "[screen resolution] setting the screen resolution to %f dpi\n", gui->dpi);
-  }
+
+   gui->dpi = dt_get_screen_resolution(widget);
+
 #ifdef GDK_WINDOWING_QUARTZ
   gui->dpi_factor
       = gui->dpi / 72; // macOS has a fixed DPI of 72

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1417,8 +1417,11 @@ void dt_configure_ppd_dpi(dt_gui_gtk_t *gui)
   {
 #ifdef GDK_WINDOWING_QUARTZ
     dt_osx_autoset_dpi(widget);
-#endif
+    // gtk/gdk gives wrong results for DPI on Macs
+    gui->dpi = 96.0;
+#else
     gui->dpi = gdk_screen_get_resolution(gtk_widget_get_screen(widget));
+#endif
     if(gui->dpi < 0.0)
     {
       gui->dpi = 96.0;

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1427,12 +1427,8 @@ void dt_configure_ppd_dpi(dt_gui_gtk_t *gui)
       dt_print(DT_DEBUG_CONTROL,
                "[screen resolution] setting the screen resolution to %f dpi\n", gui->dpi);
   }
-  #ifdef GDK_WINDOWING_QUARTZ
-    gui->dpi_factor = 1.0;
-  #else
     gui->dpi_factor
         = gui->dpi / 96; // according to man xrandr and the docs of gdk_screen_set_resolution 96 is the default
-  #endif
 }
 
 static gboolean _focus_in_out_event(GtkWidget *widget, GdkEvent *event, gpointer user_data)

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1427,8 +1427,8 @@ void dt_configure_ppd_dpi(dt_gui_gtk_t *gui)
       dt_print(DT_DEBUG_CONTROL,
                "[screen resolution] setting the screen resolution to %f dpi\n", gui->dpi);
   }
-    gui->dpi_factor
-        = gui->dpi / 96; // according to man xrandr and the docs of gdk_screen_set_resolution 96 is the default
+  gui->dpi_factor
+      = gui->dpi / 96; // according to man xrandr and the docs of gdk_screen_set_resolution 96 is the default
 }
 
 static gboolean _focus_in_out_event(GtkWidget *widget, GdkEvent *event, gpointer user_data)

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1416,7 +1416,6 @@ void dt_configure_ppd_dpi(dt_gui_gtk_t *gui)
   else
   {
 #ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_autoset_dpi(widget);
     // gtk/gdk gives wrong results for DPI on Macs
     gui->dpi = 96.0;
 #else

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1415,12 +1415,7 @@ void dt_configure_ppd_dpi(dt_gui_gtk_t *gui)
   }
   else
   {
-#ifdef GDK_WINDOWING_QUARTZ
-    // gtk/gdk gives wrong results for DPI on Macs
-    gui->dpi = 96.0;
-#else
     gui->dpi = gdk_screen_get_resolution(gtk_widget_get_screen(widget));
-#endif
     if(gui->dpi < 0.0)
     {
       gui->dpi = 96.0;
@@ -1432,8 +1427,12 @@ void dt_configure_ppd_dpi(dt_gui_gtk_t *gui)
       dt_print(DT_DEBUG_CONTROL,
                "[screen resolution] setting the screen resolution to %f dpi\n", gui->dpi);
   }
-  gui->dpi_factor
-      = gui->dpi / 96; // according to man xrandr and the docs of gdk_screen_set_resolution 96 is the default
+  #ifdef GDK_WINDOWING_QUARTZ
+    gui->dpi_factor = 1.0;
+  #else
+    gui->dpi_factor
+        = gui->dpi / 96; // according to man xrandr and the docs of gdk_screen_set_resolution 96 is the default
+  #endif
 }
 
 static gboolean _focus_in_out_event(GtkWidget *widget, GdkEvent *event, gpointer user_data)

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1427,8 +1427,13 @@ void dt_configure_ppd_dpi(dt_gui_gtk_t *gui)
       dt_print(DT_DEBUG_CONTROL,
                "[screen resolution] setting the screen resolution to %f dpi\n", gui->dpi);
   }
+#ifdef GDK_WINDOWING_QUARTZ
+  gui->dpi_factor
+      = gui->dpi / 72; // macOS has a fixed DPI of 72
+#else
   gui->dpi_factor
       = gui->dpi / 96; // according to man xrandr and the docs of gdk_screen_set_resolution 96 is the default
+#endif
 }
 
 static gboolean _focus_in_out_event(GtkWidget *widget, GdkEvent *event, gpointer user_data)

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -30,11 +30,11 @@ extern "C" {
 
 #define DT_GUI_IOP_MODULE_CONTROL_SPACING 0
 
-#define DT_GUI_THUMBSIZE_REDUCE 0.7f
+#define DT_GUI_THUMBSIZE_REDUCE 0.7f 
 
 /* helper macro that applies the DPI transformation to fixed pixel values. input should be defaulting to 96
  * DPI */
-#define DT_PIXEL_APPLY_DPI(value) ((value) * darktable.gui->dpi_factor)
+#define DT_PIXEL_APPLY_DPI(value) ((value) * ((darktable.gui->dpi_factor < 1.0)? 1.0 : darktable.gui->dpi_factor))
 
 #define DT_RESIZE_HANDLE_SIZE DT_PIXEL_APPLY_DPI(5)
 

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -210,6 +210,7 @@ int dt_gui_gtk_write_config();
 void dt_gui_gtk_set_source_rgb(cairo_t *cr, dt_gui_color_t);
 void dt_gui_gtk_set_source_rgba(cairo_t *cr, dt_gui_color_t, float opacity_coef);
 double dt_get_system_gui_ppd(GtkWidget *widget);
+double dt_get_screen_resolution(GtkWidget *widget);
 
 /* Check sidebar_scroll_default and modifier keys to determine if scroll event
  * should be processed by control or by panel. If default is panel scroll but

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -34,7 +34,7 @@ extern "C" {
 
 /* helper macro that applies the DPI transformation to fixed pixel values. input should be defaulting to 96
  * DPI */
-#define DT_PIXEL_APPLY_DPI(value) ((value) * ((darktable.gui->dpi_factor < 1.0)? 1.0 : darktable.gui->dpi_factor))
+#define DT_PIXEL_APPLY_DPI(value) ((value) * darktable.gui->dpi_factor)
 
 #define DT_RESIZE_HANDLE_SIZE DT_PIXEL_APPLY_DPI(5)
 

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -30,7 +30,7 @@ extern "C" {
 
 #define DT_GUI_IOP_MODULE_CONTROL_SPACING 0
 
-#define DT_GUI_THUMBSIZE_REDUCE 0.7f 
+#define DT_GUI_THUMBSIZE_REDUCE 0.7f
 
 /* helper macro that applies the DPI transformation to fixed pixel values. input should be defaulting to 96
  * DPI */

--- a/src/osx/osx.h
+++ b/src/osx/osx.h
@@ -24,7 +24,6 @@
 extern "C" {
 #endif
 
-void dt_osx_autoset_dpi(GtkWidget *widget);
 float dt_osx_get_ppd();
 void dt_osx_disallow_fullscreen(GtkWidget *widget);
 gboolean dt_osx_file_trash(const char *filename, GError **error);

--- a/src/osx/osx.mm
+++ b/src/osx/osx.mm
@@ -39,24 +39,6 @@
 #include "osx.h"
 #include "libintl.h"
 
-void dt_osx_autoset_dpi(GtkWidget *widget)
-{
-#if 0
-  GdkScreen *screen = gtk_widget_get_screen(widget);
-  if(!screen)
-    screen = gdk_screen_get_default();
-  if(!screen)
-    return;
-
-  CGDirectDisplayID id = CGMainDisplayID();
-  CGSize size_in_mm = CGDisplayScreenSize(id);
-  int width = CGDisplayPixelsWide(id);
-  int height = CGDisplayPixelsHigh(id);
-  gdk_screen_set_resolution(screen,
-      25.4 * sqrt(width * width + height * height)
-           / sqrt(size_in_mm.width * size_in_mm.width + size_in_mm.height * size_in_mm.height));
-#endif
-}
 
 float dt_osx_get_ppd()
 {

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3650,9 +3650,6 @@ static void _second_window_configure_ppd_dpi(dt_develop_t *dev)
   }
   else
   {
-#ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_autoset_dpi(widget);
-#endif
     dev->preview2.dpi = gdk_screen_get_resolution(gtk_widget_get_screen(widget));
     if(dev->preview2.dpi < 0.0)
     {

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3636,35 +3636,15 @@ static void _second_window_configure_ppd_dpi(dt_develop_t *dev)
   GtkWidget *widget = dev->second_wnd;
 
   dev->preview2.ppd = dt_get_system_gui_ppd(widget);
+  dev->preview2.dpi = dt_get_screen_resolution(widget);
 
-  // get the screen resolution
-  float screen_dpi_overwrite = dt_conf_get_float("screen_dpi_overwrite");
-  if(screen_dpi_overwrite > 0.0)
-  {
-    dev->preview2.dpi = screen_dpi_overwrite;
-    gdk_screen_set_resolution(gtk_widget_get_screen(widget), screen_dpi_overwrite);
-    dt_print(DT_DEBUG_CONTROL,
-             "[screen resolution] setting the screen resolution to %f dpi as specified in "
-             "the configuration file\n",
-             screen_dpi_overwrite);
-  }
-  else
-  {
-    dev->preview2.dpi = gdk_screen_get_resolution(gtk_widget_get_screen(widget));
-    if(dev->preview2.dpi < 0.0)
-    {
-      dev->preview2.dpi = 96.0;
-      gdk_screen_set_resolution(gtk_widget_get_screen(widget), 96.0);
-      dt_print(DT_DEBUG_CONTROL,
-               "[screen resolution] setting the screen resolution to the default 96 dpi\n");
-    }
-    else
-      dt_print(DT_DEBUG_CONTROL,
-               "[screen resolution] setting the screen resolution to %f dpi\n",
-               dev->preview2.dpi);
-  }
+#ifdef GDK_WINDOWING_QUARTZ
+  dev->preview2.dpi_factor
+      = dev->preview2.dpi / 72; // macOS has a fixed DPI of 72
+#else
   dev->preview2.dpi_factor
       = dev->preview2.dpi / 96; // according to man xrandr and the docs of gdk_screen_set_resolution 96 is the default
+#endif
 }
 
 static gboolean _second_window_draw_callback(GtkWidget *widget,


### PR DESCRIPTION
What really annoys me from my beginning of using darktable was some extremely small GUI elements on my Mac.

After doing some research I found out that the DPI screen resolution of a Mac screen is reported by `gdk_screen_get_resolution()` as 72 DPI (96 is assumed to be the default), leading to a `darktable.gui->dpi_factor` value of 0.75

That means that those GUI elements are actually shrinked, making it very hard for some of them to be used.


Some examples:

The panels of the main window can be collapsed/expanded by clicking in the border areas. The border size is set to be 10 pixels with respect to the dpi_factor, now resulting in only 7 pixels. The clickable area is even smaller, making it nearly impossible to hit that few pixels with the mouse. So I always used the shortcuts to expand/collapse.

before:
<img width="1792" alt="Bildschirmfoto 2023-12-08 um 17 37 59" src="https://github.com/darktable-org/darktable/assets/4083281/b21dcf1b-c084-449e-95a7-cbd1e4e14025">

after:
<img width="1792" alt="Bildschirmfoto 2023-12-08 um 17 44 06" src="https://github.com/darktable-org/darktable/assets/4083281/a6325ecc-279f-4efa-9720-984b5677a205">


The color indicators in the vectorscope are tiny.

before:
<img width="261" alt="Bildschirmfoto 2023-12-08 um 17 39 00" src="https://github.com/darktable-org/darktable/assets/4083281/b31d7352-1e1f-4658-b374-cf2d25a62704">

after:
<img width="265" alt="Bildschirmfoto 2023-12-08 um 17 44 26" src="https://github.com/darktable-org/darktable/assets/4083281/e6101706-2b59-48d1-866f-89baf3beac04">

The handles of drawn masks are tiny also.

before:
<img width="653" alt="Bildschirmfoto 2023-12-08 um 17 39 49" src="https://github.com/darktable-org/darktable/assets/4083281/6db16a08-6014-4d3d-a017-fdb43a6dabe8">

after:
<img width="644" alt="Bildschirmfoto 2023-12-08 um 17 44 53" src="https://github.com/darktable-org/darktable/assets/4083281/ad2d540b-c8f2-440f-be9e-4f5d73c7b0ab">


It makes the usability MUCH better on my Mac.






