### PR TITLE
Enforce tone-equalizer pipe-cache data

### DIFF
--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -638,7 +638,7 @@ static void invalidate_luminance_cache(dt_iop_module_t *const self)
   g->thumb_preview_hash = 0;
   g->ui_preview_hash = 0;
   dt_iop_gui_leave_critical_section(self);
-  dt_iop_refresh_preview(self);
+  dt_iop_refresh_all(self);
 }
 
 // gaussian-ish kernel - sum is == 1.0f so we don't care much about actual coeffs


### PR DESCRIPTION
If we call `invalidate_luminance_cache` we want refreshed data not only for the preview but also for the main and preview2 pixelpipes.

Fixes #15743 

As suspected we want to invalidate pixelpipe cache data for this module (and later) and refresh the views. 