### PR TITLE
RFC: Full image processing in darkroom

### DIFF
--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -326,6 +326,12 @@ typedef struct dt_develop_t
     GtkWidget *button; // yes, ugliness is the norm. what did you expect ?
   } iso_12646;
 
+  // late scaling down from full roi
+  struct
+  {
+    GtkWidget *button;
+  } late_scaling;
+
   // the display profile related things (softproof, gamut check, profiles ...)
   struct
   {

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1432,6 +1432,14 @@ static void _iso_12646_quickbutton_clicked(GtkWidget *w, gpointer user_data)
   dt_dev_configure(&dev->full);
 }
 
+static void _latescaling_quickbutton_clicked(GtkWidget *w, gpointer user_data)
+{
+  dt_develop_t *dev = (dt_develop_t *)user_data;
+  if(!dev->gui_attached) return;
+
+  dt_dev_reprocess_center(dev);
+}
+
 /* overlay color */
 static void _guides_quickbutton_clicked(GtkWidget *widget, gpointer user_data)
 {
@@ -2198,6 +2206,14 @@ void gui_init(dt_view_t *self)
                               _("toggle ISO 12646 color assessment conditions"));
   g_signal_connect(G_OBJECT(dev->iso_12646.button), "clicked", G_CALLBACK(_iso_12646_quickbutton_clicked), dev);
   dt_view_manager_module_toolbox_add(darktable.view_manager, dev->iso_12646.button, DT_VIEW_DARKROOM);
+
+  /* Enable late-scaling button */
+  dev->late_scaling.button = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_fullpreview, 0, NULL);
+  ac = dt_action_define(sa, NULL, N_("export view scaling"), dev->late_scaling.button, &dt_action_def_toggle);
+  gtk_widget_set_tooltip_text(dev->late_scaling.button,
+                              _("toggle export view scaling, if 'on' darktable processes image data as it does while exporting"));
+  g_signal_connect(G_OBJECT(dev->late_scaling.button), "clicked", G_CALLBACK(_latescaling_quickbutton_clicked), dev);
+  dt_view_manager_module_toolbox_add(darktable.view_manager, dev->late_scaling.button, DT_VIEW_DARKROOM);
 
   GtkWidget *colorscheme, *mode;
 


### PR DESCRIPTION
Several times we had short discussions about "image in darkroom" does not exactly look like after exporting or at 100%, often this is due to module-internal algorithms. Thus there was a wish to make darktable do the pixelpipe processing on full image data while being in darkroom mode instead of the region-of-interest (ROI), "only calculate what you see on the main canvas".

This PR implements this feature, in darkroom there is one additional toggle-button at the bottom
![Bildschirmfoto vom 2023-12-10 14-38-30](https://github.com/darktable-org/darktable/assets/50982232/61bff33c-d543-4808-bb3c-1208ffa8cf9f) - here it is switched on and thus we will process full data.

How does it work? In short - only the `colorout` module has been modified. I chose colorout a) as it's very late in the pipe and we would want the scaling done in lin colorspace (EDIT2 not in the initial pr but implemented later) and b) wanted to avoid some extra stuff in the pipe and c) we might re-use this scaler otherwise.

If the button is "on" - in colorout
1. the roi_in is expanded to full image data
2. we add a scale&crop step to process() while writing to output (this is basically the same as we do for raw files in the demosaicer).

First user experience: As we know, this means heavy processing - as while exporting. Yet - on my Intel® Xeon® E-2288G (like a i9-9900) plus 8GB nvidia card (Quadro RTX 4000) - doing my usual 50Mpix images it's fully usable (leaving out the heavy stuff with "intensive" D&S or complex masking). Also - once you have the image processed - the system is very fast while dragging around as we only re-process colorout including the scaler plus gamma instead of possibly the whole pipe as the roi changed.

Please give it a try and feedback if you think it's worthwhile. Or/and feedback on the how-it's-done.

  
