### PR TITLE
Fix avoid colorshift for raw CA correction

### DIFF
--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -266,7 +266,9 @@ void process(
 
   dt_iop_cacorrect_data_t *d = (dt_iop_cacorrect_data_t *)piece->data;
 
-  const gboolean avoidshift = d->avoidshift;
+  // the colorshift avoiding requires non-downscaled data for sure so we
+  // don't do this for preview
+  const gboolean avoidshift = d->avoidshift && !(piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW);
   const int iterations = d->iterations;
 
   // Because we can't break parallel processing, we need a switch do handle the errors


### PR DESCRIPTION
The "avoid colorshift" algorithm in raw chromatic aberration correction certainly requires non-downscaled raw data to work correctly.

This is one of the cases where we simply can't garantee preview to be almost equal to main canvas. But for previews the added correction in not predictable so it's better to avoid than trusting correction to be correct.

Fixes #15869