### PR TITLE
Update generate-translation.sh with BCP47 names

### DIFF
--- a/tools/release/generate-translation.sh
+++ b/tools/release/generate-translation.sh
@@ -50,14 +50,14 @@ declare -A LANG_NAME=( [af]=Afrikaans
                        [sk]=Slovak
                        [sl]=Slovenian
                        [sq]=Albanian
-                       [sr@latin]="Serbian Latin"
-                       [sr]="Serbian Cyrilic"
+                       [sr@latin]="Serbian (Latin)"
+                       [sr]="Serbian (Cyrilic)"
                        [sv]=Swedish
                        [th]=Thai
                        [tr]=Turkish
                        [uk]=Ukrainian
-                       [zh_CN]="Chinese - (simplified)"
-                       [zh_TW]="Chinese - (traditional)" )
+                       [zh_CN]="Chinese (Simplified)"
+                       [zh_TW]="Chinese (Traditional)" )
 
 
 


### PR DESCRIPTION
See e.g. https://icu4c-demos.unicode.org/icu-bin/locexp and https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c

I guess it should also be backported to 4.6.x branch for future point releases...