### PR TITLE
Avoid roi_in over-expanding

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -448,28 +448,25 @@ void modify_roi_in(
     const int dy = roi_in->y % aligner;
 
 /*
-    // This code is correctly working on CPU, OpenCL artefacts needs a FIXME
+    // This implements snapping to closest position, meant for optimized xtrans position
+    // but with problems at extreme zoom levels
     const int shift_x = (dx > aligner / 2) ? aligner - dx : -dx;
     const int shift_y = (dy > aligner / 2) ? aligner - dy : -dy;
 
-    roi_in->x = MAX(0, roi_in->x + shift_x);
-    roi_in->y = MAX(0, roi_in->y + shift_y);
-
-    // if we shift to the right/bottom we also need to expand the roi
-    roi_in->width += MAX(0, shift_x);
-    roi_in->height += MAX(0, shift_y);
+    roi_in->x += shift_x;
+    roi_in->y += shift_y;
 */
 
-    roi_in->x = MAX(0, roi_in->x - dx);
-    roi_in->y = MAX(0, roi_in->y - dy);
+    // currently we always snap to left & upper
+    roi_in->x -= dx;
+    roi_in->y -= dy;
   }
 
-  // clamp numeric inaccuracies to full buffer, to avoid scaling/copying in pixelpipe:
-  if(abs(piece->pipe->image.width - roi_in->width) < MAX(ceilf(1.0f / roi_out->scale), 10))
-    roi_in->width = piece->pipe->image.width;
-
-  if(abs(piece->pipe->image.height - roi_in->height) < MAX(ceilf(1.0f / roi_out->scale), 10))
-    roi_in->height = piece->pipe->image.height;
+  // clamp to full buffer fixing numeric inaccuracies
+  roi_in->x = MAX(0, roi_in->x);
+  roi_in->y = MAX(0, roi_in->y);
+  roi_in->width = MIN(roi_in->width, piece->buf_in.width);
+  roi_in->height = MIN(roi_in->height, piece->buf_in.height);
 }
 
 void tiling_callback(

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -75,8 +75,12 @@ void modify_roi_in(dt_iop_module_t *self,
   roi_in->width  = (roi_out->width  - .5f)/roi_out->scale;
   roi_in->height = (roi_out->height - .5f)/roi_out->scale;
 */
-  roi_in->width  = ceilf(roi_out->width / roi_out->scale);
-  roi_in->height = ceilf(roi_out->height / roi_out->scale);
+
+  // always avoid
+  // - expanding roi_in dimensions to more than what is provided
+  // - processing micro-sizes
+  roi_in->width  = MAX(16, MIN(ceilf(roi_out->width / roi_out->scale), piece->buf_in.width));
+  roi_in->height = MAX(16, MIN(ceilf(roi_out->height / roi_out->scale), piece->buf_in.height));
   roi_in->scale = 1.0f;
 }
 


### PR DESCRIPTION
Due to imprecisions or ceil functions we might set roi_in size to be larger than what we provide via piece->buf_in.width/height.
Relevant for modules that do scaling in the pipe like demosaic or finalscale.

Fixes #15876

We might want to do all these "safety checks" not in the module's code but in pixelpipe while we do all the modify roi_in calls, as this PR is meant for 4.6 and 4.8 branch just this fix.

While being here it doesn't hurt to fix some comments too. 