### PR TITLE
Optional full image processing in darkroom

### DIFF
--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -326,6 +326,12 @@ typedef struct dt_develop_t
     GtkWidget *button; // yes, ugliness is the norm. what did you expect ?
   } iso_12646;
 
+  // late scaling down from full roi
+  struct
+  {
+    GtkWidget *button;
+  } late_scaling;
+
   // the display profile related things (softproof, gamut check, profiles ...)
   struct
   {

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2133,12 +2133,12 @@ static gboolean _dev_pixelpipe_process_rec(
         */
         important_cl =
            (pipe->mask_display == DT_DEV_PIXELPIPE_DISPLAY_NONE)
-           && ((pipe->type == DT_DEV_PIXELPIPE_FULL) // ignored in fast mode
-              || (pipe->type == DT_DEV_PIXELPIPE_PREVIEW))
+           && pipe->type & DT_DEV_PIXELPIPE_BASIC
            && dev->gui_attached
            && ((module == dt_dev_gui_module())
                 || darktable.develop->history_last_module == module
-                || dt_iop_module_is(module->so, "colorout"));
+                || dt_iop_module_is(module->so, "colorout")
+                || dt_iop_module_is(module->so, "finalscale"));
 
         if(important_cl)
         {

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1432,6 +1432,14 @@ static void _iso_12646_quickbutton_clicked(GtkWidget *w, gpointer user_data)
   dt_dev_configure(&dev->full);
 }
 
+static void _latescaling_quickbutton_clicked(GtkWidget *w, gpointer user_data)
+{
+  dt_develop_t *dev = (dt_develop_t *)user_data;
+  if(!dev->gui_attached) return;
+
+  dt_dev_reprocess_center(dev);
+}
+
 /* overlay color */
 static void _guides_quickbutton_clicked(GtkWidget *widget, gpointer user_data)
 {
@@ -2198,6 +2206,14 @@ void gui_init(dt_view_t *self)
                               _("toggle ISO 12646 color assessment conditions"));
   g_signal_connect(G_OBJECT(dev->iso_12646.button), "clicked", G_CALLBACK(_iso_12646_quickbutton_clicked), dev);
   dt_view_manager_module_toolbox_add(darktable.view_manager, dev->iso_12646.button, DT_VIEW_DARKROOM);
+
+  /* Enable late-scaling button */
+  dev->late_scaling.button = dtgtk_togglebutton_new(dtgtk_cairo_paint_lt_mode_fullpreview, 0, NULL);
+  ac = dt_action_define(sa, NULL, N_("export view scaling"), dev->late_scaling.button, &dt_action_def_toggle);
+  gtk_widget_set_tooltip_text(dev->late_scaling.button,
+                              _("toggle export view scaling, if 'on' darktable processes image data as it does while exporting"));
+  g_signal_connect(G_OBJECT(dev->late_scaling.button), "clicked", G_CALLBACK(_latescaling_quickbutton_clicked), dev);
+  dt_view_manager_module_toolbox_add(darktable.view_manager, dev->late_scaling.button, DT_VIEW_DARKROOM);
 
   GtkWidget *colorscheme, *mode;
 


### PR DESCRIPTION
Adds another darktable-lower button, if active the canvas and second window pixelpipes will be processing the full image data as we do while exporting in high-quality mode.

The `finalscale` module has been modified, it now does roi aware crop&scale instead of pure scaling and is also enabled if the mentioned toogle-button is ON for main canvas and second window.

If we use darkroom full-image expanded roi using opencl we want to make sure the cldata are written to the cache so we can move canvas window around without any significant reprocessing.

_________________________________________

This PR is a safe & simplified modification after a lot of testing in #15851. Instead of suggested - by me - late and linear-space scaling in colorout  -- here in this PR we scale exactly as we do while high-quality exporting as a safe option until we might agree on other ways discussed in #13682.

Fixes #15890 #15092 
