### PR TITLE
po/import job asynchronous

### DIFF
--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -320,7 +320,8 @@ gchar *dt_conf_get_path(const char *name)
   const char *path = _conf_get_var(name);
   const dt_confgen_value_t *item = g_hash_table_lookup(darktable.conf->x_confgen, name);
 
-  if(item
+  if(path[0]
+     && item
      && item->type == DT_PATH
      && !g_file_test(path, G_FILE_TEST_IS_DIR | G_FILE_TEST_IS_SYMLINK))
   {

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -945,6 +945,8 @@ static void _import_set_file_list_start(const gchar *folder,
   d->to_be_visited = NULL;
   d->is_importing = TRUE;
 
+  _import_active(self, FALSE, 0);
+
   _import_set_file_list(folder, self);
 }
 
@@ -2118,7 +2120,6 @@ static void _import_from_dialog_new(dt_lib_module_t* self)
   }
   else
   {
-    _import_active(self, FALSE, 0);
     gtk_widget_show_all(d->from.dialog);
   }
 

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -552,7 +552,11 @@ static void _thumb_set_in_listview(GtkTreeModel *model,
 {
   dt_lib_import_t *d = (dt_lib_import_t *)self->data;
   gchar *filename;
-  gtk_tree_model_get(model, iter, DT_IMPORT_FILENAME, &filename, -1);
+  gchar *fullname;
+  gtk_tree_model_get(model, iter,
+                     DT_IMPORT_UI_FILENAME, &filename,
+                     DT_IMPORT_FILENAME, &fullname,
+                     -1);
   GdkPixbuf *pixbuf = NULL;
 #ifdef HAVE_GPHOTO2
   if(d->import_case == DT_IMPORT_CAMERA)
@@ -562,16 +566,17 @@ static void _thumb_set_in_listview(GtkTreeModel *model,
   else
 #endif
   {
-    const char *folder = dt_conf_get_string_const("ui_last/import_last_directory");
-    char *fullname = g_build_filename(folder, filename, NULL);
     pixbuf = thumb_sel ? _import_get_thumbnail(fullname) : d->from.eye;
     g_free(fullname);
   }
   gtk_list_store_set(d->from.store, iter, DT_IMPORT_SEL_THUMB, thumb_sel,
                                           DT_IMPORT_THUMB, pixbuf, -1);
 
-  if(pixbuf) g_object_ref(pixbuf);
+  if(pixbuf)
+    g_object_ref(pixbuf);
+
   g_free(filename);
+  g_free(fullname);
 }
 
 static gboolean _files_button_press(GtkWidget *view,
@@ -804,7 +809,7 @@ static void _add_file_callback(GObject *direnum,
           gtk_list_store_set(d->from.store, &iter,
                              DT_IMPORT_UI_EXISTS, already_imported ? "✔" : " ",
                              DT_IMPORT_UI_FILENAME, &uifullname[offset],
-                             DT_IMPORT_FILENAME, &fullname[offset],
+                             DT_IMPORT_FILENAME, fullname,
                              DT_IMPORT_UI_DATETIME, dt_txt,
                              DT_IMPORT_DATETIME, datetime,
                              DT_IMPORT_THUMB, d->from.eye,

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -663,9 +663,12 @@ static void _all_thumb_toggled(GtkTreeViewColumn *column,
     d->from.event = 0;
     GtkTreeModel *model = GTK_TREE_MODEL(d->from.store);
     GtkTreeIter iter;
-    for(gboolean valid = gtk_tree_model_get_iter_first(model, &iter); valid;
+    for(gboolean valid = gtk_tree_model_get_iter_first(model, &iter);
+        valid;
         valid = gtk_tree_model_iter_next(model, &iter))
+    {
       _thumb_set_in_listview(model, &iter, FALSE, self);
+    }
   }
   else if(!d->from.event)
   {
@@ -838,13 +841,13 @@ static void _add_file_callback(GObject *direnum,
           }
 
           // if folder is root, consider one folder separator less
-          const int offset = (g_path_skip_root(folder)[0]
+          const int offset = g_path_skip_root(folder)[0]
 #ifdef WIN32
           // .. but for Windows UNC there will be a folder separator anyway
                         || dt_util_path_is_UNC(folder)
 #endif
                         ? strlen(folder) + 1
-                        : strlen(folder));
+                        : strlen(folder);
 
           GtkTreeIter iter;
           gtk_list_store_append(d->from.store, &iter);

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -706,6 +706,9 @@ static void _import_cancel(dt_lib_module_t *self)
   dt_lib_import_t *d = (dt_lib_import_t *)self->data;
   if(d->cancel_iter)
     g_cancellable_cancel(d->cancel_iter);
+
+  d->from.nb = 0;
+  _update_images_number(self, 0);
 }
 
 static void _import_active(dt_lib_module_t *self,
@@ -1264,6 +1267,7 @@ static gboolean _places_button_press(GtkWidget *view,
       gtk_tree_selection_select_path(place_selection, path);
       dt_conf_set_string("ui_last/import_last_place", folder_path);
       dt_conf_set_string("ui_last/import_last_directory", "");
+      _import_cancel(self);
       _update_folders_list(self);
       _update_files_list(self);
     }


### PR DESCRIPTION
Main commit is:

    Rework import-inplace to use an asynchronous iterator.
    
    This ensure that the UI don't get frozen while filling the
    set of files found. This is especially important when recursive
    is set and the user do select $HOME for example (or any other
    root directory containing a huge number of files/directories).
    
    Motivated by #15861.

While working on this a fix:

    Fix thumb display on the import dialog for subdirectories.
    
    Found while working on #15861.
