### PR TITLE
CMake: use "required" when looking for external programs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,25 +276,14 @@ include(windows-macros)
 
 # we need some external programs for building darktable
 message(STATUS "Looking for external programs")
-set(EXTERNAL_PROGRAMS_FOUND 1)
 
 # we need perl for introspection
-find_program(perl_BIN perl)
-if(${perl_BIN} STREQUAL "perl_BIN-NOTFOUND")
-  message(STATUS "Missing perl")
-  set(EXTERNAL_PROGRAMS_FOUND 0)
-else(${perl_BIN} STREQUAL "perl_BIN-NOTFOUND")
-  message(STATUS "Found perl")
-endif(${perl_BIN} STREQUAL "perl_BIN-NOTFOUND")
+find_program(perl_BIN perl REQUIRED)
+message(STATUS "Found perl")
 
 # we need intltool-merge for org.darktable.darktable.desktop
-find_program(intltool_merge_BIN intltool-merge)
-if(${intltool_merge_BIN} STREQUAL "intltool_merge_BIN-NOTFOUND")
-  message(STATUS "Missing intltool-merge")
-  set(EXTERNAL_PROGRAMS_FOUND 0)
-else(${intltool_merge_BIN} STREQUAL "intltool_merge_BIN-NOTFOUND")
-  message(STATUS "Found intltool-merge")
-endif(${intltool_merge_BIN} STREQUAL "intltool_merge_BIN-NOTFOUND")
+find_program(intltool_merge_BIN intltool-merge REQUIRED)
+message(STATUS "Found intltool-merge")
 
 # we need desktop-file-validate to check org.darktable.darktable.desktop
 find_program(desktop_file_validate_BIN desktop-file-validate)
@@ -383,11 +372,10 @@ if(${Xsltproc_BIN} STREQUAL "Xsltproc_BIN-NOTFOUND")
   message(STATUS "Missing xsltproc")
   find_program(Saxon_BIN saxon-xslt)
   if(${Saxon_BIN} STREQUAL "Saxon_BIN-NOTFOUND")
-    message(STATUS "Missing Saxon-XSLT")
-    message(STATUS "No XSLT interpreter found")
-    set(EXTERNAL_PROGRAMS_FOUND 0)
+    message(STATUS "Missing saxon-xslt")
+    message(FATAL_ERROR "No XSLT interpreter found")
   else(${Saxon_BIN} STREQUAL "Saxon_BIN-NOTFOUND")
-    message(STATUS "Found Saxon-XSLT")
+    message(STATUS "Found saxon-xslt")
   endif(${Saxon_BIN} STREQUAL "Saxon_BIN-NOTFOUND")
 else(${Xsltproc_BIN} STREQUAL "Xsltproc_BIN-NOTFOUND")
   message(STATUS "Found xsltproc")
@@ -414,11 +402,7 @@ else()
 endif()
 
 # done with looking for programs
-if(NOT EXTERNAL_PROGRAMS_FOUND)
-  message(FATAL_ERROR "Some external programs couldn't be found")
-else(NOT EXTERNAL_PROGRAMS_FOUND)
-  message(STATUS "All external programs found")
-endif(NOT EXTERNAL_PROGRAMS_FOUND)
+message(STATUS "All external programs found")
 
 # The path can be modified by setting CMAKE_INSTALL_LOCALEDIR
 if(USE_NLS)


### PR DESCRIPTION
Stops executing immediately for more useful feedback.

From e.g. https://www.mail-archive.com/darktable-user@lists.darktable.org/msg13111.html it is not clear whether execution stopped because of missing intltool-merge or missing jsonschema...