### PR TITLE
Remove thumbnail background animation for last active image

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1907,22 +1907,6 @@ Details :
   border: 1px solid @lighttable_bg_color;
 }
 
-/* Last active images animation */
-@keyframes lastactive
-{
-  0% {border-color: @lighttable_bg_color; border-width : 0.14em;}
-  50% {border-color: @thumbnail_bg50_color; border-width : 0.28em;}
-  100% {border-color: @lighttable_bg_color; border-width : 0.14em;}
-}
-
-.dt_last_active #thumb-back
-{
-  animation-name: lastactive;
-  animation-duration: 4s;
-  animation-timing-function: linear;
-  animation-iteration-count: 3;
-}
-
 /* set selected image and/or focus one */
 #thumb-main:active #thumb-back,
 #thumb-main:selected #thumb-back


### PR DESCRIPTION
As we can see from the discussion in #15720, no one is advocating keeping this animation. The biggest argument for removing animation is its practical invisibility ("eye candy almost invisible is no candy"). Also, in my workflow, when returning to the lighttable, the last active image is also selected (I've never had a case where it wasn't). So there is no point in the additional animation of the selected thumbnail, even if the user notices it.