### PR TITLE
Update generate-translation.sh

### DIFF
--- a/tools/release/generate-translation.sh
+++ b/tools/release/generate-translation.sh
@@ -51,7 +51,7 @@ declare -A LANG_NAME=( [af]=Afrikaans
                        [sl]=Slovenian
                        [sq]=Albanian
                        [sr@latin]="Serbian (Latin)"
-                       [sr]="Serbian (Cyrilic)"
+                       [sr]="Serbian (Cyrillic)"
                        [sv]=Swedish
                        [th]=Thai
                        [tr]=Turkish


### PR DESCRIPTION
No real need to backport to 4.6.x branch, there is no translation there.