### PR TITLE
Deduplicate hashing code

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -653,7 +653,8 @@ static inline int dt_get_thread_num()
 }
 
 #define DT_INITHASH 5381
-static inline uint64_t dt_hash(uint64_t hash, const void *data, const size_t size)
+typedef uint64_t dt_hash_t;
+static inline dt_hash_t dt_hash(dt_hash_t hash, const void *data, const size_t size)
 {
   const uint8_t* str = (uint8_t*)data;
   // Scramble bits in str to create an (hopefully) unique hash representing the state of str

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -652,6 +652,19 @@ static inline int dt_get_thread_num()
 #endif
 }
 
+#define DT_INITHASH 5381
+static inline uint64_t dt_hash(uint64_t hash, const void *data, const size_t size)
+{
+  const uint8_t* str = (uint8_t*)data;
+  // Scramble bits in str to create an (hopefully) unique hash representing the state of str
+  // Dan Bernstein algo v2 http://www.cse.yorku.ca/~oz/hash.html
+  // hash should be inited to DT_INITHASH if first run, or from a previous hash computed with this function.
+  for(size_t i = 0; i < size; i++)
+    hash = ((hash << 5) + hash) ^ str[i];
+
+  return hash;
+}
+
 // Allocate a buffer for 'n' objects each of size 'objsize' bytes for
 // each of the program's threads.  Ensures that there is no false
 // sharing among threads by aligning and rounding up the allocation to

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -3262,7 +3262,7 @@ uint64_t dt_dev_hash_plus(dt_develop_t *dev,
                           const double iop_order,
                           const dt_dev_transform_direction_t transf_direction)
 {
-  uint64_t hash = 5381;
+  uint64_t hash = DT_INITHASH;
   dt_pthread_mutex_lock(&dev->history_mutex);
   GList *modules = g_list_last(pipe->iop);
   GList *pieces = g_list_last(pipe->nodes);
@@ -3285,7 +3285,7 @@ uint64_t dt_dev_hash_plus(dt_develop_t *dev,
                           || (transf_direction == DT_DEV_TRANSFORM_DIR_BACK_EXCL
                               && module->iop_order < iop_order)))
     {
-      hash = ((hash << 5) + hash) ^ piece->hash;
+      hash = dt_hash(hash, &piece->hash, sizeof(uint64_t));
     }
     modules = g_list_previous(modules);
     pieces = g_list_previous(pieces);
@@ -3374,7 +3374,7 @@ uint64_t dt_dev_hash_distort_plus(dt_develop_t *dev,
                                   const double iop_order,
                                   const dt_dev_transform_direction_t transf_direction)
 {
-  uint64_t hash = 5381;
+  uint64_t hash = DT_INITHASH;
   dt_pthread_mutex_lock(&dev->history_mutex);
   GList *modules = g_list_last(pipe->iop);
   GList *pieces = g_list_last(pipe->nodes);
@@ -3398,7 +3398,7 @@ uint64_t dt_dev_hash_distort_plus(dt_develop_t *dev,
            || (transf_direction == DT_DEV_TRANSFORM_DIR_BACK_EXCL
                && module->iop_order < iop_order)))
     {
-      hash = ((hash << 5) + hash) ^ piece->hash;
+      hash = dt_hash(hash, &piece->hash, sizeof(uint64_t));
     }
     modules = g_list_previous(modules);
     pieces = g_list_previous(pieces);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -3252,17 +3252,17 @@ dt_dev_pixelpipe_iop_t *dt_dev_distort_get_iop_pipe(dt_develop_t *dev,
   return NULL;
 }
 
-uint64_t dt_dev_hash(dt_develop_t *dev)
+dt_hash_t dt_dev_hash(dt_develop_t *dev)
 {
   return dt_dev_hash_plus(dev, dev->preview_pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL);
 }
 
-uint64_t dt_dev_hash_plus(dt_develop_t *dev,
+dt_hash_t dt_dev_hash_plus(dt_develop_t *dev,
                           struct dt_dev_pixelpipe_t *pipe,
                           const double iop_order,
                           const dt_dev_transform_direction_t transf_direction)
 {
-  uint64_t hash = DT_INITHASH;
+  dt_hash_t hash = DT_INITHASH;
   dt_pthread_mutex_lock(&dev->history_mutex);
   GList *modules = g_list_last(pipe->iop);
   GList *pieces = g_list_last(pipe->nodes);
@@ -3285,7 +3285,7 @@ uint64_t dt_dev_hash_plus(dt_develop_t *dev,
                           || (transf_direction == DT_DEV_TRANSFORM_DIR_BACK_EXCL
                               && module->iop_order < iop_order)))
     {
-      hash = dt_hash(hash, &piece->hash, sizeof(uint64_t));
+      hash = dt_hash(hash, &piece->hash, sizeof(piece->hash));
     }
     modules = g_list_previous(modules);
     pieces = g_list_previous(pieces);
@@ -3299,7 +3299,7 @@ gboolean dt_dev_wait_hash(dt_develop_t *dev,
                           const double iop_order,
                           const dt_dev_transform_direction_t transf_direction,
                           dt_pthread_mutex_t *lock,
-                          const volatile uint64_t *const hash)
+                          const volatile dt_hash_t *const hash)
 {
   const int usec = 5000;
   int nloop;
@@ -3320,7 +3320,7 @@ gboolean dt_dev_wait_hash(dt_develop_t *dev,
     if(dt_atomic_get_int(&pipe->shutdown))
       return TRUE;  // stop waiting if pipe shuts down
 
-    uint64_t probehash;
+    dt_hash_t probehash;
 
     if(lock)
     {
@@ -3345,7 +3345,7 @@ gboolean dt_dev_sync_pixelpipe_hash(dt_develop_t *dev,
                                     const double iop_order,
                                     const dt_dev_transform_direction_t transf_direction,
                                     dt_pthread_mutex_t *lock,
-                                    const volatile uint64_t *const hash)
+                                    const volatile dt_hash_t *const hash)
 {
   // first wait for matching hash values
   if(dt_dev_wait_hash(dev, pipe, iop_order, transf_direction, lock, hash))
@@ -3364,17 +3364,17 @@ gboolean dt_dev_sync_pixelpipe_hash(dt_develop_t *dev,
   return FALSE;
 }
 
-uint64_t dt_dev_hash_distort(dt_develop_t *dev)
+dt_hash_t dt_dev_hash_distort(dt_develop_t *dev)
 {
   return dt_dev_hash_distort_plus(dev, dev->preview_pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL);
 }
 
-uint64_t dt_dev_hash_distort_plus(dt_develop_t *dev,
+dt_hash_t dt_dev_hash_distort_plus(dt_develop_t *dev,
                                   struct dt_dev_pixelpipe_t *pipe,
                                   const double iop_order,
                                   const dt_dev_transform_direction_t transf_direction)
 {
-  uint64_t hash = DT_INITHASH;
+  dt_hash_t hash = DT_INITHASH;
   dt_pthread_mutex_lock(&dev->history_mutex);
   GList *modules = g_list_last(pipe->iop);
   GList *pieces = g_list_last(pipe->nodes);
@@ -3398,7 +3398,7 @@ uint64_t dt_dev_hash_distort_plus(dt_develop_t *dev,
            || (transf_direction == DT_DEV_TRANSFORM_DIR_BACK_EXCL
                && module->iop_order < iop_order)))
     {
-      hash = dt_hash(hash, &piece->hash, sizeof(uint64_t));
+      hash = dt_hash(hash, &piece->hash, sizeof(piece->hash));
     }
     modules = g_list_previous(modules);
     pieces = g_list_previous(pieces);

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -580,9 +580,9 @@ struct dt_dev_pixelpipe_iop_t *dt_dev_distort_get_iop_pipe(dt_develop_t *dev,
  * hash functions
  */
 /** generate hash value out of all module settings of pixelpipe */
-uint64_t dt_dev_hash(dt_develop_t *dev);
+dt_hash_t dt_dev_hash(dt_develop_t *dev);
 /** same function, but we can specify iop with priority between pmin and pmax */
-uint64_t dt_dev_hash_plus(dt_develop_t *dev,
+dt_hash_t dt_dev_hash_plus(dt_develop_t *dev,
                           struct dt_dev_pixelpipe_t *pipe,
                           const double iop_order,
                           const dt_dev_transform_direction_t transf_direction);
@@ -593,7 +593,7 @@ gboolean dt_dev_wait_hash(dt_develop_t *dev,
                      const double iop_order,
                      const dt_dev_transform_direction_t transf_direction,
                      dt_pthread_mutex_t *lock,
-                     const volatile uint64_t *const hash);
+                     const volatile dt_hash_t *const hash);
 /** synchronize pixelpipe by means hash values by waiting with timeout
  * and potential reprocessing */
 gboolean dt_dev_sync_pixelpipe_hash(dt_develop_t *dev,
@@ -601,11 +601,11 @@ gboolean dt_dev_sync_pixelpipe_hash(dt_develop_t *dev,
                                const double iop_order,
                                const dt_dev_transform_direction_t transf_direction,
                                dt_pthread_mutex_t *lock,
-                               const volatile uint64_t *const hash);
+                               const volatile dt_hash_t *const hash);
 /** generate hash value out of module settings of all distorting modules of pixelpipe */
-uint64_t dt_dev_hash_distort(dt_develop_t *dev);
+dt_hash_t dt_dev_hash_distort(dt_develop_t *dev);
 /** same function, but we can specify iop with priority between pmin and pmax */
-uint64_t dt_dev_hash_distort_plus(dt_develop_t *dev,
+dt_hash_t dt_dev_hash_distort_plus(dt_develop_t *dev,
                                   struct dt_dev_pixelpipe_t *pipe,
                                   const double iop_order,
                                   const dt_dev_transform_direction_t transf_direction);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2084,9 +2084,7 @@ void dt_iop_commit_params(dt_iop_module_t *module,
     /* and we add masks */
     dt_masks_group_get_hash_buffer(grp, str + pos);
 
-    uint64_t hash = 5381;
-    for(int i = 0; i < length; i++) hash = ((hash << 5) + hash) ^ str[i];
-    piece->hash = hash;
+    piece->hash = dt_hash(DT_INITHASH, str, length);
 
     free(str);
   }

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -396,7 +396,7 @@ typedef struct dt_masks_form_gui_t
 
   // ids
   dt_mask_id_t formid;
-  uint64_t pipe_hash;
+  dt_hash_t pipe_hash;
 } dt_masks_form_gui_t;
 
 /** special value to indicate an invalid or uninitialized coordinate */

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -46,8 +46,8 @@ gboolean dt_dev_pixelpipe_cache_init(
   cache->data = (void **) calloc(entries, csize);
   cache->size = (size_t *)((void *)cache->data + entries * sizeof(void *));
   cache->dsc = (dt_iop_buffer_dsc_t *)((void *)cache->size + entries * sizeof(size_t));
-  cache->hash = (uint64_t *)((void *)cache->dsc + entries * sizeof(dt_iop_buffer_dsc_t));
-  cache->used = (int32_t *)((void *)cache->hash + entries * sizeof(uint64_t));
+  cache->hash = (dt_hash_t *)((void *)cache->dsc + entries * sizeof(dt_iop_buffer_dsc_t));
+  cache->used = (int32_t *)((void *)cache->hash + entries * sizeof(dt_hash_t));
   cache->ioporder = (int32_t *)((void *)cache->used + entries * sizeof(int32_t));
 
   for(int k = 0; k < entries; k++)
@@ -103,7 +103,7 @@ void dt_dev_pixelpipe_cache_cleanup(struct dt_dev_pixelpipe_t *pipe)
   cache->data = NULL;
 }
 
-static uint64_t _dev_pixelpipe_cache_basichash(
+static dt_hash_t _dev_pixelpipe_cache_basichash(
            const dt_imgid_t imgid,
            struct dt_dev_pixelpipe_t *pipe,
            const int position)
@@ -120,7 +120,7 @@ static uint64_t _dev_pixelpipe_cache_basichash(
   const uint32_t hashing_pipemode[3] = {(uint32_t)imgid,
                                         (uint32_t)pipe->type,
                                         (uint32_t)pipe->want_detail_mask };
-  uint64_t hash = dt_hash(DT_INITHASH, &hashing_pipemode, sizeof(hashing_pipemode));
+  dt_hash_t hash = dt_hash(DT_INITHASH, &hashing_pipemode, sizeof(hashing_pipemode));
 
   // go through all modules up to position and compute a hash using the operation and params.
   GList *pieces = pipe->nodes;
@@ -135,7 +135,7 @@ static uint64_t _dev_pixelpipe_cache_basichash(
 
     if(!skipped)
     {
-      hash = dt_hash(hash, &piece->hash, sizeof(uint64_t));
+      hash = dt_hash(hash, &piece->hash, sizeof(piece->hash));
       if(piece->module->request_color_pick != DT_REQUEST_COLORPICK_OFF)
       {
         if(darktable.lib->proxy.colorpicker.primary_sample->size == DT_LIB_COLORPICKER_SIZE_BOX)
@@ -153,22 +153,22 @@ static uint64_t _dev_pixelpipe_cache_basichash(
   return hash;
 }
 
-uint64_t dt_dev_pixelpipe_cache_hash(
+dt_hash_t dt_dev_pixelpipe_cache_hash(
            const dt_imgid_t imgid,
            const dt_iop_roi_t *roi,
            struct dt_dev_pixelpipe_t *pipe,
            const int position)
 {
-  uint64_t hash = _dev_pixelpipe_cache_basichash(imgid, pipe, position);
+  dt_hash_t hash = _dev_pixelpipe_cache_basichash(imgid, pipe, position);
   // also include roi data
   // FIXME include full roi data in cachelines
   hash = dt_hash(hash, roi, sizeof(dt_iop_roi_t));
-  return dt_hash(hash, &pipe->scharr.hash, sizeof(uint64_t));
+  return dt_hash(hash, &pipe->scharr.hash, sizeof(pipe->scharr.hash));
 }
 
 gboolean dt_dev_pixelpipe_cache_available(
            dt_dev_pixelpipe_t *pipe,
-           const uint64_t hash,
+           const dt_hash_t hash,
            const size_t size)
 {
   if(pipe->mask_display
@@ -245,7 +245,7 @@ static int _get_cacheline(struct dt_dev_pixelpipe_t *pipe)
 static gboolean _get_by_hash(
           struct dt_dev_pixelpipe_t *pipe,
           struct dt_iop_module_t *module,
-          const uint64_t hash,
+          const dt_hash_t hash,
           const size_t size,
           void **data,
           dt_iop_buffer_dsc_t **dsc)
@@ -286,7 +286,7 @@ static gboolean _get_by_hash(
 
 gboolean dt_dev_pixelpipe_cache_get(
            struct dt_dev_pixelpipe_t *pipe,
-           const uint64_t hash,
+           const dt_hash_t hash,
            const size_t size,
            void **data,
            dt_iop_buffer_dsc_t **dsc,

--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -38,7 +38,7 @@ typedef struct dt_dev_pixelpipe_cache_t
   void **data;
   size_t *size;
   struct dt_iop_buffer_dsc_t *dsc;
-  uint64_t *hash;
+  dt_hash_t *hash;
   int32_t *used;
   int32_t *ioporder;
   uint64_t calls;
@@ -66,7 +66,7 @@ gboolean dt_dev_pixelpipe_cache_init(struct dt_dev_pixelpipe_t *pipe, const int 
 void dt_dev_pixelpipe_cache_cleanup(struct dt_dev_pixelpipe_t *pipe);
 
 /** creates a hopefully unique hash from the complete module stack up to the module-th, including current viewport. */
-uint64_t dt_dev_pixelpipe_cache_hash(const dt_imgid_t imgid, const struct dt_iop_roi_t *roi,
+dt_hash_t dt_dev_pixelpipe_cache_hash(const dt_imgid_t imgid, const struct dt_iop_roi_t *roi,
                                      struct dt_dev_pixelpipe_t *pipe, const int position);
 
 /** returns a float data buffer in 'data' for the given hash from the cache, dsc is updated too.
@@ -74,11 +74,11 @@ uint64_t dt_dev_pixelpipe_cache_hash(const dt_imgid_t imgid, const struct dt_iop
   The size of the buffer in 'data' will be at least of size bytes.
   Returned flag is TRUE for a new buffer
 */
-gboolean dt_dev_pixelpipe_cache_get(struct dt_dev_pixelpipe_t *pipe, const uint64_t hash,
+gboolean dt_dev_pixelpipe_cache_get(struct dt_dev_pixelpipe_t *pipe, const dt_hash_t hash,
                                const size_t size, void **data, struct dt_iop_buffer_dsc_t **dsc, struct dt_iop_module_t *module, const gboolean important);
 
 /** test availability of a cache line without destroying another, if it is not found. */
-gboolean dt_dev_pixelpipe_cache_available(struct dt_dev_pixelpipe_t *pipe, const uint64_t hash, const size_t size);
+gboolean dt_dev_pixelpipe_cache_available(struct dt_dev_pixelpipe_t *pipe, const dt_hash_t hash, const size_t size);
 
 /** invalidates all cachelines. */
 void dt_dev_pixelpipe_cache_flush(const struct dt_dev_pixelpipe_t *pipe);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2997,11 +2997,7 @@ gboolean dt_dev_write_scharr_mask(dt_dev_pixelpipe_iop_t *piece,
   if(dt_masks_calc_scharr_mask(&p->scharr, rgb, wb))
     goto error;
 
-  uint64_t hash = 5381;
-  const char *str = (const char *)&p->scharr.roi;
-  for(size_t i = 0; i < sizeof(dt_iop_roi_t); i++)
-    hash = ((hash << 5) + hash) ^ str[i];
-  p->scharr.hash = hash;
+  p->scharr.hash = dt_hash(DT_INITHASH, &p->scharr.roi, sizeof(dt_iop_roi_t));
 
   dt_print_pipe(DT_DEBUG_PIPE, "write scharr mask CPU", p, NULL, roi_in, NULL, "\n");
   if(darktable.dump_pfm_module && (piece->pipe->type & DT_DEV_PIXELPIPE_EXPORT))
@@ -3066,11 +3062,7 @@ gboolean dt_dev_write_scharr_mask_cl(dt_dev_pixelpipe_iop_t *piece,
   p->scharr.data = mask;
   memcpy(&p->scharr.roi, roi_in, sizeof(dt_iop_roi_t));
 
-  uint64_t hash = 5381;
-  const char *str = (const char *)&p->scharr.roi;
-  for(size_t i = 0; i < sizeof(dt_iop_roi_t); i++)
-    hash = ((hash << 5) + hash) ^ str[i];
-  p->scharr.hash = hash;
+  p->scharr.hash = dt_hash(DT_INITHASH, &p->scharr.roi, sizeof(dt_iop_roi_t));
 
   dt_print_pipe(DT_DEBUG_PIPE, "write scharr mask CL", p, NULL, roi_in, NULL, "\n");
   if(darktable.dump_pfm_module && (piece->pipe->type & DT_DEV_PIXELPIPE_EXPORT))

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1385,7 +1385,7 @@ static gboolean _dev_pixelpipe_process_rec(
   if(dt_atomic_get_int(&pipe->shutdown))
     return TRUE;
 
-  uint64_t hash = dt_dev_pixelpipe_cache_hash(pipe->image.id, roi_out, pipe, pos);
+  dt_hash_t hash = dt_dev_pixelpipe_cache_hash(pipe->image.id, roi_out, pipe, pos);
 
   // we do not want data from the preview pixelpipe cache
   // for gamma so we can compute the final scope

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -57,7 +57,7 @@ typedef struct dt_dev_pixelpipe_iop_t
 
   float iscale;        // input actually just downscaled buffer? iscale*iwidth = actual width
   int iwidth, iheight; // width and height of input buffer
-  uint64_t hash;       // hash of params and enabled.
+  dt_hash_t hash;       // hash of params and enabled.
   int bpc;             // bits per channel, 32 means float
   int colors;          // how many colors per pixel
   dt_iop_roi_t buf_in,
@@ -93,7 +93,7 @@ typedef enum dt_dev_pixelpipe_status_t
 typedef struct dt_dev_detail_mask_t
 {
   dt_iop_roi_t roi;
-  uint64_t hash;
+  dt_hash_t hash;
   float *data;
 } dt_dev_detail_mask_t;
 
@@ -144,7 +144,7 @@ typedef struct dt_dev_pixelpipe_t
   int backbuf_width, backbuf_height;
   float backbuf_scale;
   float backbuf_zoom_x, backbuf_zoom_y;
-  uint64_t backbuf_hash;
+  dt_hash_t backbuf_hash;
   dt_pthread_mutex_t mutex, backbuf_mutex, busy_mutex;
   int final_width, final_height;
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -408,9 +408,9 @@ typedef struct dt_iop_ashift_gui_data_t
   int buf_x_off;
   int buf_y_off;
   float buf_scale;
-  uint64_t lines_hash;
-  uint64_t grid_hash;
-  uint64_t buf_hash;
+  dt_hash_t lines_hash;
+  dt_hash_t grid_hash;
+  dt_hash_t buf_hash;
   dt_iop_ashift_fitaxis_t lastfit;
   float lastx;
   float lasty;
@@ -3546,7 +3546,7 @@ void process(struct dt_iop_module_t *self,
       ? 1 : 0;
 
     // did modules prior to this one in pixelpipe have changed? -> check via hash value
-    const uint64_t hash = dt_dev_hash_plus(self->dev, self->dev->preview_pipe,
+    const dt_hash_t hash = dt_dev_hash_plus(self->dev, self->dev->preview_pipe,
                                            self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL);
 
     dt_iop_gui_enter_critical_section(self);
@@ -3697,7 +3697,7 @@ int process_cl(struct dt_iop_module_t *self,
       fabs(fmod(alpha + M_PI, M_PI) - M_PI / 2.0f) < M_PI / 4.0f ? 1 : 0;
 
     // do modules coming before this one in pixelpipe have changed? -> check via hash value
-    const uint64_t hash = dt_dev_hash_plus(self->dev, self->dev->preview_pipe,
+    const dt_hash_t hash = dt_dev_hash_plus(self->dev, self->dev->preview_pipe,
                                            self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_EXCL);
 
     dt_iop_gui_enter_critical_section(self);
@@ -3912,10 +3912,10 @@ static void _get_bounded_inside(const float *points,
 }
 
 // generate hash value for lines taking into account only the end point coordinates
-static uint64_t _get_lines_hash(const dt_iop_ashift_line_t *lines,
+static dt_hash_t _get_lines_hash(const dt_iop_ashift_line_t *lines,
                                 const int lines_count)
 {
-  uint64_t hash = DT_INITHASH;
+  dt_hash_t hash = DT_INITHASH;
   for(int n = 0; n < lines_count; n++)
   {
     const dt_boundingbox_t v = { lines[n].p1[0],
@@ -3927,7 +3927,8 @@ static uint64_t _get_lines_hash(const dt_iop_ashift_line_t *lines,
         uint32_t u;
     } x;
 
-    for(size_t i = 0; i < 4; i++) {
+    for(size_t i = 0; i < 4; i++)
+    {
       x.f = v[i];
       hash = dt_hash(hash, &x.u, sizeof(uint32_t));
     }
@@ -4426,9 +4427,9 @@ void gui_post_expose(dt_iop_module_t *self,
 
   // get hash value that changes if distortions from here to the end
   // of the pixelpipe changed
-  const uint64_t hash = dt_dev_hash_distort(dev);
+  const dt_hash_t hash = dt_dev_hash_distort(dev);
   // get hash value that changes if coordinates of lines have changed
-  const uint64_t lines_hash = _get_lines_hash(g->lines, g->lines_count);
+  const dt_hash_t lines_hash = _get_lines_hash(g->lines, g->lines_count);
 
   // points data are missing or outdated, or distortion has changed?
   if(g->points == NULL || g->points_idx == NULL || hash != g->grid_hash

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3915,7 +3915,7 @@ static void _get_bounded_inside(const float *points,
 static uint64_t _get_lines_hash(const dt_iop_ashift_line_t *lines,
                                 const int lines_count)
 {
-  uint64_t hash = 5381;
+  uint64_t hash = DT_INITHASH;
   for(int n = 0; n < lines_count; n++)
   {
     const dt_boundingbox_t v = { lines[n].p1[0],
@@ -3929,7 +3929,7 @@ static uint64_t _get_lines_hash(const dt_iop_ashift_line_t *lines,
 
     for(size_t i = 0; i < 4; i++) {
       x.f = v[i];
-      hash = ((hash << 5) + hash) ^ x.u;
+      hash = dt_hash(hash, &x.u, sizeof(uint32_t));
     }
   }
   return hash;

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -282,7 +282,7 @@ typedef struct dt_iop_clipping_gui_data_t
   float prev_clip_x, prev_clip_y, prev_clip_w, prev_clip_h;
   /* maximum clip box */
   float clip_max_x, clip_max_y, clip_max_w, clip_max_h;
-  uint64_t clip_max_pipe_hash;
+  dt_hash_t clip_max_pipe_hash;
 
  int k_selected, k_show, k_selected_segment;
   gboolean k_drag;

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -88,7 +88,7 @@ typedef struct dt_iop_colorreconstruct_gui_data_t
   GtkWidget *precedence;
   GtkWidget *hue;
   dt_iop_colorreconstruct_bilateral_frozen_t *can;
-  uint64_t hash;
+  dt_hash_t hash;
 } dt_iop_colorreconstruct_gui_data_t;
 
 typedef struct dt_iop_colorreconstruct_data_t
@@ -670,7 +670,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   // here is where we generate the canned bilateral grid of the preview pipe for later use
   if(self->dev->gui_attached && g && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
   {
-    uint64_t hash = dt_dev_hash_plus(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL);
+    dt_hash_t hash = dt_dev_hash_plus(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL);
     dt_iop_gui_enter_critical_section(self);
     dt_iop_colorreconstruct_bilateral_dump(g->can);
     g->can = dt_iop_colorreconstruct_bilateral_freeze(b);
@@ -1078,7 +1078,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   if(self->dev->gui_attached && g && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
   {
-    uint64_t hash = dt_dev_hash_plus(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL);
+    dt_hash_t hash = dt_dev_hash_plus(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL);
     dt_iop_gui_enter_critical_section(self);
     dt_iop_colorreconstruct_bilateral_dump(g->can);
     g->can = dt_iop_colorreconstruct_bilateral_freeze_cl(b);

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -101,7 +101,7 @@ typedef struct dt_iop_crop_gui_data_t
   float prev_clip_x, prev_clip_y, prev_clip_w, prev_clip_h;
   /* maximum clip box */
   float clip_max_x, clip_max_y, clip_max_w, clip_max_h;
-  uint64_t clip_max_pipe_hash;
+  dt_hash_t clip_max_pipe_hash;
 
   int cropping;
   gboolean shift_hold;

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -82,7 +82,7 @@ typedef struct dt_iop_global_tonemap_gui_data_t
   } drago;
   GtkWidget *detail;
   float lwmax;
-  uint64_t hash;
+  dt_hash_t hash;
 } dt_iop_global_tonemap_gui_data_t;
 
 typedef struct dt_iop_global_tonemap_global_data_t
@@ -216,7 +216,7 @@ static inline void process_drago(struct dt_iop_module_t *self, dt_dev_pixelpipe_
   if(self->dev->gui_attached && g && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
   {
     dt_iop_gui_enter_critical_section(self);
-    const uint64_t hash = g->hash;
+    const dt_hash_t hash = g->hash;
     dt_iop_gui_leave_critical_section(self);
 
     // note that the case 'hash == 0' on first invocation in a session implies that g->lwmax
@@ -254,7 +254,7 @@ static inline void process_drago(struct dt_iop_module_t *self, dt_dev_pixelpipe_
   // PREVIEW pixelpipe stores lwmax
   if(self->dev->gui_attached && g && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
   {
-    uint64_t hash = dt_dev_hash_plus(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL);
+    dt_hash_t hash = dt_dev_hash_plus(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL);
     dt_iop_gui_enter_critical_section(self);
     g->lwmax = lwmax;
     g->hash = hash;
@@ -390,7 +390,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     if(self->dev->gui_attached && g && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
     {
       dt_iop_gui_enter_critical_section(self);
-      const uint64_t hash = g->hash;
+      const dt_hash_t hash = g->hash;
       dt_iop_gui_leave_critical_section(self);
       if(hash != 0 && !dt_dev_sync_pixelpipe_hash(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, &self->gui_lock, &g->hash))
         dt_control_log(_("inconsistent output"));
@@ -489,7 +489,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
     if(self->dev->gui_attached && g && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
     {
-      uint64_t hash = dt_dev_hash_plus(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL);
+      dt_hash_t hash = dt_dev_hash_plus(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL);
       dt_iop_gui_enter_critical_section(self);
       g->lwmax = lwmax;
       g->hash = hash;

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -81,7 +81,7 @@ typedef struct dt_iop_hazeremoval_gui_data_t
   GtkWidget *distance;
   rgb_pixel A0;
   float distance_max;
-  uint64_t hash;
+  dt_hash_t hash;
 } dt_iop_hazeremoval_gui_data_t;
 
 typedef struct dt_iop_hazeremoval_global_data_t
@@ -527,7 +527,7 @@ void process(struct dt_iop_module_t *self,
   if(self->dev->gui_attached && g && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
   {
     dt_iop_gui_enter_critical_section(self);
-    const uint64_t hash = g->hash;
+    const dt_hash_t hash = g->hash;
     dt_iop_gui_leave_critical_section(self);
     // Note that the case 'hash == 0' on first invocation in a session
     // implies that g->distance_max is NAN, which initiates special
@@ -552,7 +552,7 @@ void process(struct dt_iop_module_t *self,
   // PREVIEW pixelpipe stores values.
   if(self->dev->gui_attached && g && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
   {
-    uint64_t hash = dt_dev_hash_plus(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL);
+    dt_hash_t hash = dt_dev_hash_plus(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL);
     dt_iop_gui_enter_critical_section(self);
     g->A0[0] = A0[0];
     g->A0[1] = A0[1];
@@ -762,7 +762,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   if(self->dev->gui_attached && g && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
   {
     dt_iop_gui_enter_critical_section(self);
-    const uint64_t hash = g->hash;
+    const dt_hash_t hash = g->hash;
     dt_iop_gui_leave_critical_section(self);
     // Note that the case 'hash == 0' on first invocation in a session
     // implies that g->distance_max is NAN, which initiates special
@@ -788,7 +788,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   // PREVIEW pixelpipe stores values.
   if(self->dev->gui_attached && g && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
   {
-    uint64_t hash = dt_dev_hash_plus(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL);
+    dt_hash_t hash = dt_dev_hash_plus(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL);
     dt_iop_gui_enter_critical_section(self);
     g->A0[0] = A0[0];
     g->A0[1] = A0[1];

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -320,7 +320,7 @@ int legacy_params(dt_iop_module_t *self,
 
 static dt_aligned_pixel_t img_oppchroma;
 static gboolean img_oppclipped = TRUE;
-static uint64_t img_opphash = ULLONG_MAX;
+static dt_hash_t img_opphash = ULLONG_MAX;
 
 #include "hlreconstruct/segmentation.c"
 #include "hlreconstruct/segbased.c"

--- a/src/iop/hlreconstruct/opposed.c
+++ b/src/iop/hlreconstruct/opposed.c
@@ -43,33 +43,15 @@ static uint64_t _opposed_parhash(dt_dev_pixelpipe_iop_t *piece)
   dt_iop_buffer_dsc_t *dsc = &piece->pipe->dsc;
   dt_iop_highlights_data_t *d = (dt_iop_highlights_data_t *)piece->data;
 
-  // bernstein hash (djb2)
-  uint64_t hash = 5381;
-
-  char *pstr = (char *) &dsc->rawprepare;
-  for(size_t ip = 0; ip < sizeof(dsc->rawprepare); ip++)
-    hash = ((hash << 5) + hash) ^ pstr[ip];
-
-  pstr = (char *) &dsc->temperature;
-  for(size_t ip = 0; ip < sizeof(dsc->temperature); ip++)
-    hash = ((hash << 5) + hash) ^ pstr[ip];
-
-  pstr = (char *) &d->clip;
-  for(size_t ip = 0; ip < sizeof(d->clip); ip++)
-    hash = ((hash << 5) + hash) ^ pstr[ip];
-
-  return hash;
+  uint64_t hash = dt_hash(DT_INITHASH, &dsc->rawprepare, sizeof(dsc->rawprepare));
+  hash = dt_hash(hash, &dsc->temperature, sizeof(dsc->temperature));
+  return dt_hash(hash, &d->clip, sizeof(d->clip));
 }
 
 static uint64_t _opposed_hash(dt_dev_pixelpipe_iop_t *piece)
 {
   uint64_t hash = _opposed_parhash(piece);
-
-  char *pstr = (char *) &piece->pipe->image.id;
-  for(size_t ip = 0; ip < sizeof(piece->pipe->image.id); ip++)
-    hash = ((hash << 5) + hash) ^ pstr[ip];
-
-  return hash;
+  return dt_hash(hash, &piece->pipe->image.id, sizeof(piece->pipe->image.id));
 }
 
 static inline float _calc_linear_refavg(const float *in, const int color)

--- a/src/iop/hlreconstruct/opposed.c
+++ b/src/iop/hlreconstruct/opposed.c
@@ -38,19 +38,19 @@
    Again the algorithm has been developed in collaboration by @garagecoder and @Iain from gmic team and @jenshannoschwalm from dt.
 */
 
-static uint64_t _opposed_parhash(dt_dev_pixelpipe_iop_t *piece)
+static dt_hash_t _opposed_parhash(dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_buffer_dsc_t *dsc = &piece->pipe->dsc;
   dt_iop_highlights_data_t *d = (dt_iop_highlights_data_t *)piece->data;
 
-  uint64_t hash = dt_hash(DT_INITHASH, &dsc->rawprepare, sizeof(dsc->rawprepare));
+  dt_hash_t hash = dt_hash(DT_INITHASH, &dsc->rawprepare, sizeof(dsc->rawprepare));
   hash = dt_hash(hash, &dsc->temperature, sizeof(dsc->temperature));
   return dt_hash(hash, &d->clip, sizeof(d->clip));
 }
 
-static uint64_t _opposed_hash(dt_dev_pixelpipe_iop_t *piece)
+static dt_hash_t _opposed_hash(dt_dev_pixelpipe_iop_t *piece)
 {
-  uint64_t hash = _opposed_parhash(piece);
+  dt_hash_t hash = _opposed_parhash(piece);
   return dt_hash(hash, &piece->pipe->image.id, sizeof(piece->pipe->image.id));
 }
 
@@ -245,7 +245,7 @@ static float *_process_opposed(
   const size_t mheight = roi_in->height / 3;
   const size_t msize = dt_round_size((size_t) (mwidth+1) * (mheight+1), 16);
 
-  const uint64_t opphash = _opposed_hash(piece);
+  const dt_hash_t opphash = _opposed_hash(piece);
   dt_aligned_pixel_t chrominance = {0.0f, 0.0f, 0.0f, 0.0f};
 
   if(opphash == img_opphash)
@@ -469,7 +469,7 @@ static cl_int process_opposed_cl(
   const int mheight = roi_in->height / 3;
   const int msize = dt_round_size((size_t) (mwidth+1) * (mheight+1), 16);
 
-  const uint64_t opphash = _opposed_hash(piece);
+  const dt_hash_t opphash = _opposed_hash(piece);
   const int fastcopymode = (opphash == img_opphash) && !img_oppclipped;
 
   if(!fastcopymode)

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -242,7 +242,7 @@ typedef struct dt_iop_lens_data_t
   float v_steepness;
   float reserved[2];
   float vigspline[VIGSPLINES];
-  uint32_t vighash;
+  dt_hash_t vighash;
 } dt_iop_lens_data_t;
 
 
@@ -1962,7 +1962,7 @@ static void _commit_params_lf(struct dt_iop_module_t *self,
 
 static void _init_vignette_spline(dt_iop_lens_data_t *d)
 {
-  uint64_t vhash = dt_hash(DT_INITHASH, &d->v_radius, 2 * sizeof(float));
+  dt_hash_t vhash = dt_hash(DT_INITHASH, &d->v_radius, 2 * sizeof(float));
   if(d->vighash == vhash) return;
   d->vighash = vhash;
 

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1960,21 +1960,9 @@ static void _commit_params_lf(struct dt_iop_module_t *self,
   #pragma GCC optimize ("fast-math", "fp-contract=fast", "finite-math-only", "no-math-errno")
 #endif
 
-/* manually controlled vignette using a linear spline */
-static uint64_t _get_vignette_hash(dt_iop_lens_data_t *d)
-{
-  uint64_t hash = 5381;
-  char *pstr = (char *)(&d->v_radius);
-  // radius & steepness are the parameters used for the spline so represented in the cache
-  for(size_t ip = 0; ip < 2 * sizeof(float); ip++)
-    hash = ((hash << 5) + hash) ^ pstr[ip];
-
-  return hash;
-}
-
 static void _init_vignette_spline(dt_iop_lens_data_t *d)
 {
-  uint64_t vhash = _get_vignette_hash(d);
+  uint64_t vhash = dt_hash(DT_INITHASH, &d->v_radius, 2 * sizeof(float));
   if(d->vighash == vhash) return;
   d->vighash = vhash;
 

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -88,7 +88,7 @@ typedef struct dt_iop_levels_gui_data_t
   GtkWidget *percentile_grey;
   GtkWidget *percentile_white;
   float auto_levels[3];
-  uint64_t hash;
+  dt_hash_t hash;
   GtkWidget *blackpick, *greypick, *whitepick;
 } dt_iop_levels_gui_data_t;
 
@@ -347,7 +347,7 @@ static void commit_params_late(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
     if(g && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL))
     {
       dt_iop_gui_enter_critical_section(self);
-      const uint64_t hash = g->hash;
+      const dt_hash_t hash = g->hash;
       dt_iop_gui_leave_critical_section(self);
 
       // note that the case 'hash == 0' on first invocation in a session implies that d->levels[]
@@ -376,7 +376,7 @@ static void commit_params_late(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
 
     if(g && (piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW) && d->mode == LEVELS_MODE_AUTOMATIC)
     {
-      uint64_t hash = dt_dev_hash_plus(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL);
+      dt_hash_t hash = dt_dev_hash_plus(self->dev, piece->pipe, self->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL);
       dt_iop_gui_enter_critical_section(self);
       g->auto_levels[0] = d->levels[0];
       g->auto_levels[1] = d->levels[1];

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -232,8 +232,8 @@ typedef struct dt_iop_toneequalizer_gui_data_t
   int pipe_order;
 
   // 6 uint64 to pack - contiguous-ish memory
-  uint64_t ui_preview_hash;
-  uint64_t thumb_preview_hash;
+  dt_hash_t ui_preview_hash;
+  dt_hash_t thumb_preview_hash;
   size_t full_preview_buf_width, full_preview_buf_height;
   size_t thumb_preview_buf_width, thumb_preview_buf_height;
 
@@ -613,8 +613,8 @@ static gboolean in_mask_editing(dt_iop_module_t *self)
   return dev->form_gui && dev->form_visible;
 }
 
-static void hash_set_get(const uint64_t *hash_in,
-                         uint64_t *hash_out,
+static void hash_set_get(const dt_hash_t *hash_in,
+                         dt_hash_t *hash_out,
                          dt_pthread_mutex_t *lock)
 {
   // Set or get a hash in a struct the thread-safe way
@@ -1036,7 +1036,7 @@ void toneeq_process(struct dt_iop_module_t *self,
 
   // Get the hash of the upstream pipe to track changes
   const int position = self->iop_order;
-  const uint64_t hash = dt_dev_pixelpipe_cache_hash(piece->pipe->image.id,
+  const dt_hash_t hash = dt_dev_pixelpipe_cache_hash(piece->pipe->image.id,
                                                     roi_out, piece->pipe, position);
 
   // Sanity checks
@@ -1128,7 +1128,7 @@ void toneeq_process(struct dt_iop_module_t *self,
 
     if(piece->pipe->type & DT_DEV_PIXELPIPE_FULL)
     {
-      uint64_t saved_hash;
+      dt_hash_t saved_hash;
       hash_set_get(&g->ui_preview_hash, &saved_hash, &self->gui_lock);
 
       dt_iop_gui_enter_critical_section(self);
@@ -1144,7 +1144,7 @@ void toneeq_process(struct dt_iop_module_t *self,
     }
     else if(piece->pipe->type & DT_DEV_PIXELPIPE_PREVIEW)
     {
-      uint64_t saved_hash;
+      dt_hash_t saved_hash;
       hash_set_get(&g->thumb_preview_hash, &saved_hash, &self->gui_lock);
 
       dt_iop_gui_enter_critical_section(self);

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1794,8 +1794,6 @@ cairo_surface_t *dt_view_create_surface(uint8_t *buffer,
     (buffer, CAIRO_FORMAT_RGB24, processed_width, processed_height, stride);
 }
 
-#define ADD_TO_CONTEXT(v) ctx = ((ctx << 5) + ctx) ^ (dt_view_context_t)(v);
-
 dt_view_context_t dt_view_get_view_context(void)
 {
   dt_develop_t *dev = darktable.develop;
@@ -1804,20 +1802,17 @@ dt_view_context_t dt_view_get_view_context(void)
   float zoom_x, zoom_y;
   dt_dev_get_viewport_params(&dev->full, &zoom, &closeup, &zoom_x, &zoom_y);
   const float zoom_scale = dt_dev_get_zoom_scale(&dev->full, zoom, 1<<closeup, 1);
-  const gboolean iso_12646 = dev->full.iso_12646;
-  const gboolean focus_peaking = darktable.gui->show_focus_peaking;
+
+  // calculate a hash on view parameters. Use flt_prec here to avoid different hashes
+  // for irrelevant variations for the zooms.
   const float flt_prec = 1.e6;
-
-  dt_view_context_t ctx = 0;
-  ADD_TO_CONTEXT(closeup);
-  ADD_TO_CONTEXT((int)(zoom_scale * flt_prec));
-  ADD_TO_CONTEXT((int)(zoom_x * flt_prec));
-  ADD_TO_CONTEXT((int)(zoom_y * flt_prec));
-  ADD_TO_CONTEXT(iso_12646);
-  ADD_TO_CONTEXT(focus_peaking);
-
-  // dt_print(DT_DEBUG_EXPOSE, "dt_view_get_view_context ctx==%" PRIx64 " scale=%f\n", ctx, zoom_scale);
-  return ctx;
+  const uint32_t test[6] = {(uint32_t)dev->full.iso_12646,
+                            (uint32_t)darktable.gui->show_focus_peaking,
+                            (uint32_t)closeup,
+                            (uint32_t)(zoom_scale * flt_prec),
+                            (uint32_t)(zoom_x * flt_prec),
+                            (uint32_t)(zoom_y * flt_prec)};
+  return (dt_view_context_t)dt_hash(DT_INITHASH, &test, sizeof(test));
 }
 
 gboolean dt_view_check_view_context(dt_view_context_t *ctx)

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -647,7 +647,7 @@ void dt_view_paint_surface(cairo_t *cr,
                            float buf_zoom_x,
                            float buf_zoom_y);
 
-typedef uint64_t dt_view_context_t;
+typedef dt_hash_t dt_view_context_t;
 
 dt_view_context_t dt_view_get_view_context(void);
 


### PR DESCRIPTION
Inspired by some ansel code introducing dt_hash(), modified code with const and pointer type casting.

Use new inline function all over the code for code deduplication and readability. In two places the hash calculation was not of best quality.