### PR TITLE
Fix memory leaks in imageio_qui

### DIFF
--- a/src/imageio/imageio_qoi.c
+++ b/src/imageio/imageio_qoi.c
@@ -59,8 +59,13 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
     // if we can't read even first 4 bytes, it's more like file disappeared
     return DT_IMAGEIO_FILE_NOT_FOUND;
   }
+
   if(memcmp(read_buffer, "qoif", 4) != 0)
   {
+    fclose(f);
+    g_free(read_buffer);
+    dt_print(DT_DEBUG_ALWAYS,
+             "[qoi_open] no proper file header in %s\n", filename);
     return DT_IMAGEIO_LOAD_FAILED;
   }
 
@@ -130,6 +135,7 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
   img->loader = LOADER_QOI;
 
   QOI_FREE(int_RGBA_buf);
+  g_free(read_buffer);
 
   return DT_IMAGEIO_OK;
 }


### PR DESCRIPTION
- close file if invalid header
- free mem if a) invalid header and b) after decoding and everything is fine.

Found this while investigating reports about mem-usage that could be the result of leaks.

As i haven't used such files at all - don't even know what exactly they are - a review also by @victoryforce  is requested. 