### PR TITLE
macOS: Add libraw package for homebrew build

### DIFF
--- a/packaging/macosx/1_install_hb_dependencies.sh
+++ b/packaging/macosx/1_install_hb_dependencies.sh
@@ -47,6 +47,7 @@ hbDependencies="adwaita-icon-theme \
     libavif \
     libheif \
     libomp \
+    libraw \
     librsvg \
     libsecret \
     little-cms2 \


### PR DESCRIPTION
For people who want to build with `-DDONT_USE_INTERNAL_LIBRAW`

For CI and nightly builds this is already included.