### PR TITLE
Simplify interpolation api

### DIFF
--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -73,16 +73,6 @@ static void _show_2_times(const dt_times_t *start,
   }
 }
 
-#if DEBUG_PRINT_VERBOSE
-#define debug_extra(...)               \
-  do                                   \
-  {                                    \
-    fprintf(stderr, __VA_ARGS__);      \
-  } while(0)
-#else
-#define debug_extra(...)
-#endif
-
 /* --------------------------------------------------------------------------
  * Generic helpers
  * ------------------------------------------------------------------------*/
@@ -1109,8 +1099,6 @@ static void _interpolation_resample_plain(const struct dt_interpolation *itor,
     // Process each output column
     for(size_t ox = 0; ox < width; ox++)
     {
-      debug_extra("output %p [% 4d % 4d]\n", out, ox, oy);
-
       // This will hold the resulting pixel
       dt_aligned_pixel_t vs = { 0.0f, 0.0f, 0.0f, 0.0f };
 
@@ -1456,10 +1444,8 @@ int dt_interpolation_resample_roi_cl(const struct dt_interpolation *itor,
 static void _interpolation_resample_1c_plain(const struct dt_interpolation *itor,
                                              float *out,
                                              const dt_iop_roi_t *const roi_out,
-                                             const int32_t out_stride,
                                              const float *const in,
-                                             const dt_iop_roi_t *const roi_in,
-                                             const int32_t in_stride)
+                                             const dt_iop_roi_t *const roi_in)
 {
   int *hindex = NULL;
   int *hlength = NULL;
@@ -1474,6 +1460,9 @@ static void _interpolation_resample_1c_plain(const struct dt_interpolation *itor
   dt_times_t start = { 0 }, mid = { 0 };
   dt_get_perf_times(&start);
 
+  const size_t out_stride = roi_out->width * sizeof(float);
+  const size_t in_stride = roi_in->width * sizeof(float);
+
   // Fast code path for 1:1 copy, only cropping area can change
   if(roi_out->scale == 1.f)
   {
@@ -1485,8 +1474,8 @@ static void _interpolation_resample_1c_plain(const struct dt_interpolation *itor
 #endif
     for(int y = 0; y < roi_out->height; y++)
     {
-      float *i = (float *)((char *)in + (size_t)in_stride * (y + roi_out->y) + x0);
-      float *o = (float *)((char *)out + (size_t)out_stride * y);
+      float *i = (float *)((char *)in + in_stride * (y + roi_out->y) + x0);
+      float *o = (float *)((char *)out + out_stride * y);
       memcpy(o, i, out_stride);
     }
     dt_show_times_f(&start, "[resample_1c_plain]", "1:1 copy/crop of %dx%d pixels",
@@ -1534,8 +1523,6 @@ static void _interpolation_resample_1c_plain(const struct dt_interpolation *itor
     // Process each output column
     for(int ox = 0; ox < roi_out->width; ox++)
     {
-      debug_extra("output %p [% 4d % 4d]\n", out, ox, oy);
-
       // This will hold the resulting pixel
       float vs = 0.0f;
 
@@ -1545,7 +1532,7 @@ static void _interpolation_resample_1c_plain(const struct dt_interpolation *itor
       for(int iy = 0; iy < vl; iy++)
       {
         // This is our input line
-        const float *i = (float *)((char *)in + (size_t)in_stride * vindex[viidx++]);
+        const float *i = (float *)((char *)in + in_stride * vindex[viidx++]);
 
         float vhs = 0.0f;
 
@@ -1596,13 +1583,10 @@ static void _interpolation_resample_1c_plain(const struct dt_interpolation *itor
 void dt_interpolation_resample_1c(const struct dt_interpolation *itor,
                                   float *out,
                                   const dt_iop_roi_t *const roi_out,
-                                  const int32_t out_stride,
                                   const float *const in,
-                                  const dt_iop_roi_t *const roi_in,
-                                  const int32_t in_stride)
+                                  const dt_iop_roi_t *const roi_in)
 {
-  return _interpolation_resample_1c_plain(itor, out, roi_out, out_stride,
-                                          in, roi_in, in_stride);
+  return _interpolation_resample_1c_plain(itor, out, roi_out, in, roi_in);
 }
 
 /** Applies resampling (re-scaling) on a specific region-of-interest of an image. The input
@@ -1612,10 +1596,8 @@ void dt_interpolation_resample_1c(const struct dt_interpolation *itor,
 void dt_interpolation_resample_roi_1c(const struct dt_interpolation *itor,
                                       float *out,
                                       const dt_iop_roi_t *const roi_out,
-                                      const int32_t out_stride,
                                       const float *const in,
-                                      const dt_iop_roi_t *const roi_in,
-                                      const int32_t in_stride)
+                                      const dt_iop_roi_t *const roi_in)
 {
   dt_iop_roi_t oroi = *roi_out;
   oroi.x = oroi.y = 0;
@@ -1623,7 +1605,7 @@ void dt_interpolation_resample_roi_1c(const struct dt_interpolation *itor,
   dt_iop_roi_t iroi = *roi_in;
   iroi.x = iroi.y = 0;
 
-  dt_interpolation_resample_1c(itor, out, &oroi, out_stride, in, &iroi, in_stride);
+  dt_interpolation_resample_1c(itor, out, &oroi, in, &iroi);
 }
 
 // clang-format off

--- a/src/common/interpolation.h
+++ b/src/common/interpolation.h
@@ -131,14 +131,12 @@ const struct dt_interpolation *dt_interpolation_new(enum dt_interpolation_type t
  * @param in_stride [in] Input line stride in <strong>bytes</strong>
  */
 void dt_interpolation_resample(const struct dt_interpolation *itor, float *out,
-                               const dt_iop_roi_t *const roi_out, const int32_t out_stride,
-                               const float *const in, const dt_iop_roi_t *const roi_in,
-                               const int32_t in_stride);
+                               const dt_iop_roi_t *const roi_out,
+                               const float *const in, const dt_iop_roi_t *const roi_in);
 
 void dt_interpolation_resample_roi(const struct dt_interpolation *itor, float *out,
-                                   const dt_iop_roi_t *const roi_out, const int32_t out_stride,
-                                   const float *const in, const dt_iop_roi_t *const roi_in,
-                                   const int32_t in_stride);
+                                   const dt_iop_roi_t *const roi_out,
+                                   const float *const in, const dt_iop_roi_t *const roi_in);
 
 #ifdef HAVE_OPENCL
 typedef struct dt_interpolation_cl_global_t

--- a/src/common/interpolation.h
+++ b/src/common/interpolation.h
@@ -182,16 +182,13 @@ int dt_interpolation_resample_roi_cl(const struct dt_interpolation *itor, int de
                                      const dt_iop_roi_t *const roi_in);
 #endif
 
-// same as above for single channel images (i.e., masks). no SSE or CPU code paths for now
-void dt_interpolation_resample_1c(const struct dt_interpolation *itor, float *out,
-                                  const dt_iop_roi_t *const roi_out, const int32_t out_stride,
-                                  const float *const in, const dt_iop_roi_t *const roi_in,
-                                  const int32_t in_stride);
+void dt_interpolation_resample_1c(const struct dt_interpolation *itor,
+                                  float *out, const dt_iop_roi_t *const roi_out,
+                                  const float *const in, const dt_iop_roi_t *const roi_in);
 
-void dt_interpolation_resample_roi_1c(const struct dt_interpolation *itor, float *out,
-                                      const dt_iop_roi_t *const roi_out, const int32_t out_stride,
-                                      const float *const in, const dt_iop_roi_t *const roi_in,
-                                      const int32_t in_stride);
+void dt_interpolation_resample_roi_1c(const struct dt_interpolation *itor,
+                                      float *out, const dt_iop_roi_t *const roi_out,
+                                      const float *const in, const dt_iop_roi_t *const roi_in);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1105,7 +1105,7 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
     // downsample
     dt_print_pipe(DT_DEBUG_PIPE,
                   "mipmap clip and zoom", NULL, NULL, &roi_in, &roi_out, "\n");
-    dt_iop_clip_and_zoom(out, (const float *)buf.buf, &roi_out, &roi_in, roi_out.width, roi_in.width);
+    dt_iop_clip_and_zoom(out, (const float *)buf.buf, &roi_out, &roi_in);
   }
 
   dt_mipmap_cache_release(darktable.mipmap_cache, &buf);

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -153,28 +153,24 @@ void dt_iop_clip_and_zoom_8(const uint8_t *i,
 void dt_iop_clip_and_zoom(float *out,
                           const float *const in,
                           const dt_iop_roi_t *const roi_out,
-                          const dt_iop_roi_t *const roi_in,
-                          const int32_t out_stride,
-                          const int32_t in_stride)
+                          const dt_iop_roi_t *const roi_in)
 {
   const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
-  dt_interpolation_resample(itor, out, roi_out, out_stride * 4 * sizeof(float), in, roi_in,
-                            in_stride * 4 * sizeof(float));
+  dt_interpolation_resample(itor, out, roi_out, roi_out->width * 4 * sizeof(float), in, roi_in,
+                            roi_in->width * 4 * sizeof(float));
 }
 
 // apply clip and zoom on the image region supplied in the input buffer.
-// roi_in and roi_out describe which part of the full image this relates to.
+// roi_in and roi_out describe which part of the full image this relates to but shifts are ignored.
 void dt_iop_clip_and_zoom_roi(float *out,
                               const float *const in,
                               const dt_iop_roi_t *const roi_out,
-                              const dt_iop_roi_t *const roi_in,
-                              const int32_t out_stride,
-                              const int32_t in_stride)
+                              const dt_iop_roi_t *const roi_in)
 {
   const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
-  dt_interpolation_resample_roi(itor, out, roi_out,
-                                out_stride * 4 * sizeof(float), in, roi_in,
-                                in_stride * 4 * sizeof(float));
+  dt_interpolation_resample_roi(itor,
+                                out, roi_out, roi_out->width * 4 * sizeof(float),
+                                in, roi_in, roi_in->width * 4 * sizeof(float));
 }
 
 #ifdef HAVE_OPENCL
@@ -191,7 +187,7 @@ int dt_iop_clip_and_zoom_cl(int devid,
 }
 
 // apply clip and zoom on the image region supplied in the input buffer.
-// roi_in and roi_out describe which part of the full image this relates to.
+// roi_in and roi_out describe which part of the full image this relates to but shifts are ignored.
 int dt_iop_clip_and_zoom_roi_cl(int devid,
                                 cl_mem dev_out,
                                 cl_mem dev_in,
@@ -213,7 +209,7 @@ int dt_iop_clip_and_zoom_roi_cl(int devid,
             (devid, in, dev_in, roi_in->width, roi_in->height, 4 * sizeof(float));
       if(err == CL_SUCCESS)
       {
-        dt_iop_clip_and_zoom_roi(out, in, roi_out, roi_in, 0, 0);
+        dt_iop_clip_and_zoom_roi(out, in, roi_out, roi_in);
         err = dt_opencl_write_host_to_device
               (devid, out, dev_out, roi_out->width, roi_out->height, 4 * sizeof(float));
       }

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -156,8 +156,7 @@ void dt_iop_clip_and_zoom(float *out,
                           const dt_iop_roi_t *const roi_in)
 {
   const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
-  dt_interpolation_resample(itor, out, roi_out, roi_out->width * 4 * sizeof(float), in, roi_in,
-                            roi_in->width * 4 * sizeof(float));
+  dt_interpolation_resample(itor, out, roi_out, in, roi_in);
 }
 
 // apply clip and zoom on the image region supplied in the input buffer.
@@ -168,9 +167,7 @@ void dt_iop_clip_and_zoom_roi(float *out,
                               const dt_iop_roi_t *const roi_in)
 {
   const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
-  dt_interpolation_resample_roi(itor,
-                                out, roi_out, roi_out->width * 4 * sizeof(float),
-                                in, roi_in, roi_in->width * 4 * sizeof(float));
+  dt_interpolation_resample_roi(itor, out, roi_out, in, roi_in);
 }
 
 #ifdef HAVE_OPENCL

--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -38,13 +38,11 @@ void dt_iop_flip_and_zoom_8(const uint8_t *in, int32_t iw, int32_t ih, uint8_t *
 
 /** for homebrew pixel pipe: zoom pixel array. */
 void dt_iop_clip_and_zoom(float *out, const float *const in, const struct dt_iop_roi_t *const roi_out,
-                          const struct dt_iop_roi_t *const roi_in, const int32_t out_stride,
-                          const int32_t in_stride);
+                          const struct dt_iop_roi_t *const roi_in);
 
 /** zoom pixel array for roi buffers. */
 void dt_iop_clip_and_zoom_roi(float *out, const float *const in, const struct dt_iop_roi_t *const roi_out,
-                              const struct dt_iop_roi_t *const roi_in, const int32_t out_stride,
-                              const int32_t in_stride);
+                              const struct dt_iop_roi_t *const roi_in);
 #ifdef HAVE_OPENCL
 int dt_iop_clip_and_zoom_cl(int devid, cl_mem dev_out, cl_mem dev_in,
                             const struct dt_iop_roi_t *const roi_out,

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1484,8 +1484,7 @@ static gboolean _dev_pixelpipe_process_rec(
         roi_in.scale = 1.0f;
         dt_print_pipe(DT_DEBUG_PIPE,
           "pixelpipe data: clip&zoom", pipe, module, &roi_in, roi_out, "\n");
-        dt_iop_clip_and_zoom(*output, pipe->input, roi_out, &roi_in,
-                             roi_out->width, pipe->iwidth);
+        dt_iop_clip_and_zoom(*output, pipe->input, roi_out, &roi_in);
       }
     }
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -403,8 +403,7 @@ void distort_mask(
         const dt_iop_roi_t *const roi_out)
 {
   const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
-  dt_interpolation_resample_roi_1c(itor, out, roi_out, roi_out->width * sizeof(float), in, roi_in,
-                                   roi_in->width * sizeof(float));
+  dt_interpolation_resample_roi_1c(itor, out, roi_out, in, roi_in);
 }
 
 void modify_roi_out(
@@ -737,7 +736,7 @@ void process(
     {
       roi = *roi_out;
       dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi", piece->pipe, self, roi_in, roi_out, "\n");
-      dt_iop_clip_and_zoom_roi((float *)o, tmp, &roi, &roo, roi.width, roo.width);
+      dt_iop_clip_and_zoom_roi((float *)o, tmp, &roi, &roo);
       dt_free_align(tmp);
     }
   }


### PR DESCRIPTION
As we know about strides if we have the rois we don't have to pass them all along for cpu code, less code burden/parameters plus they are basically the same as the OpenCL code.

Make finalscale use dt_iop_clip_and_zoom() and it's CL variant.

While checking this two bugs were fixed
1. distort_mask in finalscale now must use dt_interpolation_resample_1c()
2. the fallback in dt_iop_clip_and_zoom_roi_cl() got strides of zero.
3. Remove extremely verbose and not helping logs