### PR TITLE
Fix dt_iop_clip_and_zoom_roi_cl() fallback

### DIFF
--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -213,7 +213,7 @@ int dt_iop_clip_and_zoom_roi_cl(int devid,
             (devid, in, dev_in, roi_in->width, roi_in->height, 4 * sizeof(float));
       if(err == CL_SUCCESS)
       {
-        dt_iop_clip_and_zoom_roi(out, in, roi_out, roi_in, 0, 0);
+        dt_iop_clip_and_zoom_roi(out, in, roi_out, roi_in, roi_out->width, roi_in->width);
         err = dt_opencl_write_host_to_device
               (devid, out, dev_out, roi_out->width, roi_out->height, 4 * sizeof(float));
       }


### PR DESCRIPTION
In case of the OpenCL code returned CL_INVALID_WORK_GROUP_SIZE we do a fallback to CPU code. That code didn't get proper strides thus resulting in undefined data.

@TurboGit fix for 4.6 branch. Stumbled across this while on #15958