### PR TITLE
styles: Fix wrong SQL index for multi_name.

### DIFF
--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -1284,9 +1284,9 @@ GList *dt_styles_get_item_list(const char *name,
       }
       item->name = g_strdup(iname);
       item->operation = g_strdup((char *)sqlite3_column_text(stmt, 3));
-      item->multi_name = g_strdup((char *)sqlite3_column_text(stmt, 7));
+      item->multi_name = g_strdup(multi_name);
       item->multi_name_hand_edited = multi_name_hand_edited;
-      item->iop_order = sqlite3_column_double(stmt, 8);
+      item->iop_order = 0;
       result = g_list_prepend(result, item);
     }
     sqlite3_finalize(stmt);


### PR DESCRIPTION
Remove iop_order as not part of a style item, initialize to 0 it will be set later when applied to an history.

Found while looking at #15936. This is not a fix for this issue, just a display issue when flying over a style in the style lib module where the multi_name was display was broken. May be applied to 4.6.1.