### PR TITLE
Various OpenCL related fixes

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -3428,7 +3428,7 @@ void dt_opencl_memory_statistics(int devid, const cl_mem mem, const dt_opencl_me
 
 /* amount of graphics memory declared as available depends on max_global_mem and
    "resourcelevel". We garantee
-   - a headroom of 400MB in all cases not using tuned cl
+   - a headroom of DT_OPENCL_DEFAULT_HEADROOM MB in all cases not using tuned cl
    - 256MB to simulate a minimum system
    - 2GB to simalate a reference system
 
@@ -3477,7 +3477,7 @@ void dt_opencl_check_tuning(const int devid)
       : DT_OPENCL_DEFAULT_HEADROOM;
 
     const int reserved_mb =
-      MAX(1, headroom) + (cl->dev[devid].clmem_error ? 400 : 0);
+      MAX(1, headroom) + (cl->dev[devid].clmem_error ? DT_OPENCL_DEFAULT_HEADROOM : 0);
     const int global_mb = cl->dev[devid].max_global_mem / 1024lu / 1024lu;
     cl->dev[devid].used_available = (size_t)
       (MAX(0, global_mb - reserved_mb)) * 1024ul * 1024ul;
@@ -3485,7 +3485,7 @@ void dt_opencl_check_tuning(const int devid)
   else
   {
     // calculate data from fractions
-    const size_t disposable = allmem - 400ul * 1024ul * 1024ul;
+    const size_t disposable = allmem - DT_OPENCL_DEFAULT_HEADROOM * 1024ul * 1024ul;
     const int fraction = MIN(1024lu, MAX(0, res->fractions[res->group + 3]));
     cl->dev[devid].used_available =
       MAX(256ul * 1024ul * 1024ul, disposable / 1024ul * fraction);

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -825,7 +825,7 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self,
   cl_mem tmp = NULL;
   cl_mem blur = NULL;
   cl_mem out = NULL;
-  cl_int err = DT_OPENCL_DEFAULT_ERROR;
+  cl_int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
 
   dt_dev_pixelpipe_t *p = piece->pipe;
   if(p->scharr.data == NULL)
@@ -872,7 +872,7 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self,
   }
   else
   {
-    err = DT_OPENCL_DEFAULT_ERROR;
+    err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
     goto error;
   }
 
@@ -883,7 +883,7 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self,
   float *warp_mask = dt_dev_distort_detail_mask(p, lum, self);
   if(warp_mask == NULL)
   {
-    err = DT_OPENCL_DEFAULT_ERROR;
+    err = DT_OPENCL_PROCESS_CL;
     goto error;
   }
   dt_free_align(lum);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -3004,10 +3004,10 @@ gboolean dt_dev_write_scharr_mask(dt_dev_pixelpipe_iop_t *piece,
 }
 
 #ifdef HAVE_OPENCL
-gboolean dt_dev_write_scharr_mask_cl(dt_dev_pixelpipe_iop_t *piece,
-                                        cl_mem in,
-                                        const dt_iop_roi_t *const roi_in,
-                                        const gboolean rawmode)
+int dt_dev_write_scharr_mask_cl(dt_dev_pixelpipe_iop_t *piece,
+                                cl_mem in,
+                                const dt_iop_roi_t *const roi_in,
+                                const gboolean rawmode)
 {
   dt_dev_pixelpipe_t *p = piece->pipe;
   dt_dev_clear_scharr_mask(p);
@@ -3022,7 +3022,7 @@ gboolean dt_dev_write_scharr_mask_cl(dt_dev_pixelpipe_iop_t *piece,
   cl_mem tmp = NULL;
   float *mask = NULL;
 
-  cl_int err = CL_SUCCESS;
+  cl_int err = DT_OPENCL_SYSMEM_ALLOCATION;
   mask = dt_alloc_align_float((size_t)width * height);
   out = dt_opencl_alloc_device_buffer(devid, sizeof(float) * width * height);
   tmp = dt_opencl_alloc_device_buffer(devid, sizeof(float) * width * height);

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -302,14 +302,14 @@ float *dt_dev_get_raster_mask(const struct dt_dev_pixelpipe_iop_t *piece,
 void dt_dev_clear_scharr_mask(dt_dev_pixelpipe_t *pipe);
 
 gboolean dt_dev_write_scharr_mask(dt_dev_pixelpipe_iop_t *piece,
-                                     float *const rgb,
-                                     const dt_iop_roi_t *const roi_in,
-                                     const gboolean mode);
+                                  float *const rgb,
+                                  const dt_iop_roi_t *const roi_in,
+                                  const gboolean mode);
 #ifdef HAVE_OPENCL
-gboolean dt_dev_write_scharr_mask_cl(dt_dev_pixelpipe_iop_t *piece,
-                                        cl_mem in,
-                                        const dt_iop_roi_t *const roi_in,
-                                        const gboolean mode);
+int dt_dev_write_scharr_mask_cl(dt_dev_pixelpipe_iop_t *piece,
+                                cl_mem in,
+                                const dt_iop_roi_t *const roi_in,
+                                const gboolean mode);
 #endif
 
 /* specialized version of dt_print for pixelpipe debugging */

--- a/src/iop/demosaicing/basics.c
+++ b/src/iop/demosaicing/basics.c
@@ -662,7 +662,8 @@ static int process_default_cl(
     }
 
     if(piece->pipe->want_detail_mask)
-      dt_dev_write_scharr_mask_cl(piece, dev_aux, roi_in, TRUE);
+      err = dt_dev_write_scharr_mask_cl(piece, dev_aux, roi_in, TRUE);
+    if(err != CL_SUCCESS) goto error;
 
     if(scaled)
     {

--- a/src/iop/demosaicing/rcd.c
+++ b/src/iop/demosaicing/rcd.c
@@ -787,7 +787,8 @@ static int process_rcd_cl(
     dev_green_eq = cfa = rgb0 = rgb1 = rgb2 = VH_dir = PQ_dir = VP_diff = HQ_diff = NULL;
 
     if(piece->pipe->want_detail_mask)
-      dt_dev_write_scharr_mask_cl(piece, dev_aux, roi_in, TRUE);
+      err = dt_dev_write_scharr_mask_cl(piece, dev_aux, roi_in, TRUE);
+    if(err != CL_SUCCESS) goto error;
 
     if(scaled)
     {

--- a/src/iop/demosaicing/xtrans.c
+++ b/src/iop/demosaicing/xtrans.c
@@ -2219,7 +2219,8 @@ static int process_markesteijn_cl(
     }
 
     if(piece->pipe->want_detail_mask)
-      dt_dev_write_scharr_mask_cl(piece, dev_tmp, roi_in, TRUE);
+      err = dt_dev_write_scharr_mask_cl(piece, dev_tmp, roi_in, TRUE);
+    if(err != CL_SUCCESS) goto error;
 
     if(scaled)
     {

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -514,7 +514,7 @@ int process_cl(
   cl_mem dev_sub = NULL;
   cl_mem dev_div = NULL;
   cl_mem dev_gainmap[4] = {NULL};
-  cl_int err = DT_OPENCL_DEFAULT_ERROR;
+  cl_int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
 
   int kernel = -1;
   gboolean gainmap_args = FALSE;
@@ -574,8 +574,9 @@ int process_cl(
     const float rel_to_map[2] = { 1.0f / d->gainmaps[0]->map_spacing_h, 1.0f / d->gainmaps[0]->map_spacing_v };
     const float map_origin[2] = { d->gainmaps[0]->map_origin_h, d->gainmaps[0]->map_origin_v };
 
-    for(int i = 0; i < 4; i++)
+     for(int i = 0; i < 4; i++)
     {
+      err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
       dev_gainmap[i] = dt_opencl_alloc_device(devid, map_size[0], map_size[1], sizeof(float));
       if(dev_gainmap[i] == NULL) goto finish;
       err = dt_opencl_write_host_to_device(devid, d->gainmaps[i]->map_gain, dev_gainmap[i],


### PR DESCRIPTION
1. gainmaps code in rawprepare could a) possibly run into undefined states with intermediate cl buffers so releasing mem would point to nirvana b) return wronfully CL_SUCCESS
2. dt_dev_write_scharr_mask_cl() returns the error code instead of a bool
3. At various places in the demosaicer we would not report back a missing details mask
4. the vng code could possibly and wrongfully either return success or an error if everything was fine.
5. EDIT: second commit enforces a 600MB headroom while selecting one of the resource levels (as current OS mostly require)

@TurboGit stumbled across this - unfortunately after 4.6 - while reading the log reported in #15956. Sure it's more than a one-liner yet i think for 4.6 and 4.8

