### PR TITLE
tagging: implement natural sort

### DIFF
--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1240,14 +1240,14 @@ static char *tag_collate_key(char *tag)
   const size_t len = strlen(tag);
   char *result = g_malloc(len + 2);
   if(!g_strcmp0(tag, _("not tagged")))
-    *result = '\1';
+    *result = ' ';  // 1
   else if(g_str_has_prefix(tag, "darktable|"))
-    *result = '\2';
+    *result = '!';  // 2
   else
-    *result = '\3';
+    *result = '"';  // 3
   memcpy(result + 1, tag, len + 1);
   for(char *iter = result + 1; *iter; iter++)
-    if(*iter == '|') *iter = '\1';
+    if(*iter == '|') *iter = ' ';
   return result;
 }
 

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1230,13 +1230,7 @@ static gint _sort_folder_tag(gconstpointer a, gconstpointer b)
   const name_key_tuple_t *tuple_a = (const name_key_tuple_t *)a;
   const name_key_tuple_t *tuple_b = (const name_key_tuple_t *)b;
 
-  if (tuple_a->status != -1)
-    // collection type: folders
-    // In this case the collate_key is filled by g_utf8_collate_key_for_filename()
-    // which cannot be compared by g_utf8_collate() so we use g_strcmp0() here
-    return g_strcmp0(tuple_a->collate_key, tuple_b->collate_key);
-  else
-    return g_utf8_collate(tuple_a->collate_key, tuple_b->collate_key);
+  return g_strcmp0(tuple_a->collate_key, tuple_b->collate_key);
 }
 
 // create a key such that  _("not tagged") & "darktable|" are coming first,
@@ -1551,7 +1545,11 @@ static void _tree_view(dt_lib_collect_rule_t *dr)
         g_free(name_folded);
       }
       else
-        collate_key = tag_collate_key(name);
+      {
+        char *tck = tag_collate_key(name);
+        collate_key = g_utf8_collate_key_for_filename(tck, -1);
+        g_free(tck);
+      }
 
       name_key_tuple_t *tuple = (name_key_tuple_t *)malloc(sizeof(name_key_tuple_t));
       tuple->name = name;

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -2666,10 +2666,17 @@ static gint _sort_tree_count_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIt
 static inline gint _compare_utf8_no_case(const char *a, const char *b)
 {
   char *a_nc = g_utf8_casefold(a, -1);
-  char *b_nc = g_utf8_casefold(b, -1);
-  const gint sort = g_utf8_collate(a_nc, b_nc);
+  char *a_nc_nat = g_utf8_collate_key_for_filename(a_nc, -1);
   g_free(a_nc);
+
+  char *b_nc = g_utf8_casefold(b, -1);
+  char *b_nc_nat = g_utf8_collate_key_for_filename(b_nc, -1);
   g_free(b_nc);
+
+  const gint sort = g_strcmp0(a_nc_nat, b_nc_nat);
+
+  g_free(a_nc_nat);
+  g_free(b_nc_nat);
   return sort;
 }
 


### PR DESCRIPTION
With PR #15696 we got case-insensitve and unicode sorting of tags.

This does not implement a natural sort if tags contain numbers (thanks for the hint @EC1000).
So a tag named "z2" comes after "z10" which is not natural.

Tagging module before:
![image](https://github.com/darktable-org/darktable/assets/4083281/c46304f3-5825-4858-bf3f-0c826f169690)

Tagging module after:
![image](https://github.com/darktable-org/darktable/assets/4083281/af56f308-e8f1-4edd-b448-263f3383586e)

Collection module before:
![image](https://github.com/darktable-org/darktable/assets/4083281/70288ebf-d04a-471f-bc13-82ca9f9d0f65)

Collection module after:
![image](https://github.com/darktable-org/darktable/assets/4083281/a4139853-2c87-4ca2-9fcf-7138cde19958)

We already have a release notes entry mentioning "natural" sort order, so now it fits better.