### PR TITLE
Bugfix: guides exposing

### DIFF
--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4337,6 +4337,8 @@ void gui_post_expose(dt_iop_module_t *self,
 
     cairo_restore(cr);
   }
+  else
+    dt_guides_draw(cr, 0.0f, 0.0f, wd, ht, zoom_scale);
 
   // we draw the straightening line
   if(g->straightening)

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3901,20 +3901,11 @@ static dt_hash_t _get_lines_hash(const dt_iop_ashift_line_t *lines,
   dt_hash_t hash = DT_INITHASH;
   for(int n = 0; n < lines_count; n++)
   {
-    const dt_boundingbox_t v = { lines[n].p1[0],
-                                 lines[n].p1[1],
-                                 lines[n].p2[0],
-                                 lines[n].p2[1] };
-    union {
-        float f;
-        uint32_t u;
-    } x;
-
-    for(size_t i = 0; i < 4; i++)
-    {
-      x.f = v[i];
-      hash = dt_hash(hash, &x.u, sizeof(uint32_t));
-    }
+    const uint32_t v[4] = { (uint32_t)lines[n].p1[0],
+                            (uint32_t)lines[n].p1[1],
+                            (uint32_t)lines[n].p2[0],
+                            (uint32_t)lines[n].p2[1] };
+    hash = dt_hash(hash, &v, sizeof(v));
   }
   return hash;
 }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -590,8 +590,10 @@ void expose(
                            darktable.lib->proxy.colorpicker.live_samples, FALSE);
   }
 
-  // draw guide lines if needed
-  if(!dev->gui_module || !(dev->gui_module->flags() & IOP_FLAGS_GUIDES_SPECIAL_DRAW))
+  const gboolean special_draw = dev->gui_module
+                             && dev->gui_module->flags() & IOP_FLAGS_GUIDES_SPECIAL_DRAW;
+  // draw guide lines if there is no active gui_module doing it via post_expose
+  if(!special_draw)
     dt_guides_draw(cri, 0.0f, 0.0f, wd, ht, zoom_scale);
 
   // draw colorpicker for in focus module or execute module callback hook


### PR DESCRIPTION
The global guide drawing via darkroom expose has to check for an active gui_module with `IOP_FLAGS_GUIDES_SPECIAL_DRAW`, in such a case it should not do that globally but rely on the module's exposure hook.

While being here simplified the ashift hash calculation.

Fixes #15984

@TurboGit might be worth to concider the second commit for 4.6.1 too