### PR TITLE
maintenance: improved alignment to cache lines

### DIFF
--- a/src/common/cache.c
+++ b/src/common/cache.c
@@ -241,7 +241,7 @@ restart:
   if(cache->allocate)
     cache->allocate(cache->allocate_data, entry);
   else
-    entry->data = dt_alloc_align(64, entry->data_size);
+    entry->data = dt_alloc_aligned(entry->data_size);
 
   assert(entry->data_size);
   ASAN_POISON_MEMORY_REGION(entry->data, entry->data_size);

--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -344,7 +344,7 @@ static void _camera_process_job(const dt_camctl_t *c, const dt_camera_t *camera,
           // dt_colorspaces_color_profile_type_t color_space = dt_imageio_jpeg_read_color_space(&jpg);
           //if(color_space == DT_COLORSPACE_DISPLAY)
           //  color_space = DT_COLORSPACE_SRGB;            // no embedded colorspace, assume is sRGB
-          uint8_t *const buffer = (uint8_t *)dt_alloc_aligned(sizeof(uint8_t) * 4 * jpg.width * jpg.height);
+          uint8_t *const buffer = (uint8_t *)dt_alloc_align_uint8(4 * jpg.width * jpg.height);
           if(!buffer)
           {
             dt_print(DT_DEBUG_CAMCTL, "[camera_control] live view could not allocate image buffer\n");

--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -344,7 +344,7 @@ static void _camera_process_job(const dt_camctl_t *c, const dt_camera_t *camera,
           // dt_colorspaces_color_profile_type_t color_space = dt_imageio_jpeg_read_color_space(&jpg);
           //if(color_space == DT_COLORSPACE_DISPLAY)
           //  color_space = DT_COLORSPACE_SRGB;            // no embedded colorspace, assume is sRGB
-          uint8_t *const buffer = (uint8_t *)dt_alloc_align(64, sizeof(uint8_t) * 4 * jpg.width * jpg.height);
+          uint8_t *const buffer = (uint8_t *)dt_alloc_aligned(sizeof(uint8_t) * 4 * jpg.width * jpg.height);
           if(!buffer)
           {
             dt_print(DT_DEBUG_CAMCTL, "[camera_control] live view could not allocate image buffer\n");

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1919,8 +1919,9 @@ void dt_print_nts_ext(const char *msg, ...)
   fflush(stdout);
 }
 
-void *dt_alloc_align(const size_t alignment, const size_t size)
+void *dt_alloc_aligned(const size_t size)
 {
+  const size_t alignment = DT_CACHELINE_BYTES;
   const size_t aligned_size = dt_round_size(size, alignment);
 #if defined(__FreeBSD_version) && __FreeBSD_version < 700013
   return malloc(aligned_size);

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -480,6 +480,11 @@ static inline float *dt_alloc_align_float(const size_t nfloats)
   return (float*)__builtin_assume_aligned(dt_alloc_aligned(nfloats * sizeof(float)),
                                           DT_CACHELINE_BYTES);
 }
+static inline double *dt_alloc_align_double(const size_t ndoubles)
+{
+  return (double*)__builtin_assume_aligned(dt_alloc_aligned(ndoubles * sizeof(double)),
+                                           DT_CACHELINE_BYTES);
+}
 static inline float *dt_calloc_align_float(const size_t nfloats)
 {
   float *const buf = (float*)dt_alloc_align_float(nfloats);

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -467,6 +467,16 @@ static inline void* dt_calloc_aligned(const size_t size)
   if(buf) memset(buf, 0, size);
   return buf;
 }
+#define dt_calloc1_align_type(TYPE) \
+  ((TYPE*)__builtin_assume_aligned(dt_calloc_aligned(sizeof(TYPE)), DT_CACHELINE_BYTES))
+static inline int* dt_calloc_align_int(const size_t n_ints)
+{
+  return (int*)__builtin_assume_aligned(dt_calloc_aligned(n_ints * sizeof(int)), DT_CACHELINE_BYTES);
+}
+
+#define dt_alloc1_align_type(TYPE) \
+  ((TYPE*)__builtin_assume_aligned(dt_alloc_aligned(sizeof(TYPE)), DT_CACHELINE_BYTES))
+
 static inline int *dt_alloc_align_int(const size_t n_ints)
 {
   return (int*)__builtin_assume_aligned(dt_alloc_aligned(n_ints * sizeof(int)), DT_CACHELINE_BYTES);

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -469,6 +469,8 @@ static inline void* dt_calloc_aligned(const size_t size)
 }
 #define dt_calloc1_align_type(TYPE) \
   ((TYPE*)__builtin_assume_aligned(dt_calloc_aligned(sizeof(TYPE)), DT_CACHELINE_BYTES))
+#define dt_calloc_align_type(TYPE, count) \
+  ((TYPE*)__builtin_assume_aligned(dt_calloc_aligned(count * sizeof(TYPE)), DT_CACHELINE_BYTES))
 static inline int* dt_calloc_align_int(const size_t n_ints)
 {
   return (int*)__builtin_assume_aligned(dt_calloc_aligned(n_ints * sizeof(int)), DT_CACHELINE_BYTES);
@@ -476,6 +478,9 @@ static inline int* dt_calloc_align_int(const size_t n_ints)
 
 #define dt_alloc1_align_type(TYPE) \
   ((TYPE*)__builtin_assume_aligned(dt_alloc_aligned(sizeof(TYPE)), DT_CACHELINE_BYTES))
+
+#define dt_alloc_align_type(TYPE, count) \
+  ((TYPE*)__builtin_assume_aligned(dt_alloc_aligned(count * sizeof(TYPE)), DT_CACHELINE_BYTES))
 
 static inline int *dt_alloc_align_int(const size_t n_ints)
 {

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -471,6 +471,10 @@ static inline int *dt_alloc_align_int(const size_t n_ints)
 {
   return (int*)__builtin_assume_aligned(dt_alloc_aligned(n_ints * sizeof(int)), DT_CACHELINE_BYTES);
 }
+static inline uint8_t *dt_alloc_align_uint8(const size_t n_ints)
+{
+  return (uint8_t*)__builtin_assume_aligned(dt_alloc_aligned(n_ints * sizeof(uint8_t)), DT_CACHELINE_BYTES);
+}
 static inline float *dt_alloc_align_float(const size_t nfloats)
 {
   return (float*)__builtin_assume_aligned(dt_alloc_aligned(nfloats * sizeof(float)),

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -459,17 +459,17 @@ void dt_dump_pipe_pfm(const char *mod,
                       const gboolean input,
                       const char *pipe);
 
-void *dt_alloc_align(const size_t alignment, const size_t size);
+void *dt_alloc_aligned(const size_t size);
 
-static inline void* dt_calloc_align(const size_t alignment, const size_t size)
+static inline void* dt_calloc_aligned(const size_t size)
 {
-  void *buf = dt_alloc_align(alignment, size);
+  void *buf = dt_alloc_aligned(size);
   if(buf) memset(buf, 0, size);
   return buf;
 }
 static inline float *dt_alloc_align_float(const size_t nfloats)
 {
-  return (float*)__builtin_assume_aligned(dt_alloc_align(DT_CACHELINE_BYTES, nfloats * sizeof(float)),
+  return (float*)__builtin_assume_aligned(dt_alloc_aligned(nfloats * sizeof(float)),
                                           DT_CACHELINE_BYTES);
 }
 static inline float *dt_calloc_align_float(const size_t nfloats)
@@ -682,7 +682,7 @@ static inline void *dt_alloc_perthread(const size_t n,
   const size_t cache_lines = (alloc_size+DT_CACHELINE_BYTES-1)/DT_CACHELINE_BYTES;
   *padded_size = DT_CACHELINE_BYTES * cache_lines / objsize;
   const size_t total_bytes = DT_CACHELINE_BYTES * cache_lines * dt_get_num_threads();
-  return __builtin_assume_aligned(dt_alloc_align(DT_CACHELINE_BYTES, total_bytes), DT_CACHELINE_BYTES);
+  return __builtin_assume_aligned(dt_alloc_aligned(total_bytes), DT_CACHELINE_BYTES);
 }
 static inline void *dt_calloc_perthread(const size_t n,
                                         const size_t objsize,

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -467,6 +467,10 @@ static inline void* dt_calloc_aligned(const size_t size)
   if(buf) memset(buf, 0, size);
   return buf;
 }
+static inline int *dt_alloc_align_int(const size_t n_ints)
+{
+  return (int*)__builtin_assume_aligned(dt_alloc_aligned(n_ints * sizeof(int)), DT_CACHELINE_BYTES);
+}
 static inline float *dt_alloc_align_float(const size_t nfloats)
 {
   return (float*)__builtin_assume_aligned(dt_alloc_aligned(nfloats * sizeof(float)),

--- a/src/common/distance_transform.c
+++ b/src/common/distance_transform.c
@@ -126,7 +126,7 @@ float dt_image_distance_transform(float *const src,
     float *f = dt_alloc_align_float(maxdim);
     float *z = dt_alloc_align_float(maxdim + 1);
     float *d = dt_alloc_align_float(maxdim);
-    int *v = dt_alloc_aligned(maxdim * sizeof (int));
+    int *v = dt_alloc_align_int(maxdim);
 
     // transform along columns
 #ifdef _OPENMP

--- a/src/common/distance_transform.c
+++ b/src/common/distance_transform.c
@@ -126,7 +126,7 @@ float dt_image_distance_transform(float *const src,
     float *f = dt_alloc_align_float(maxdim);
     float *z = dt_alloc_align_float(maxdim + 1);
     float *d = dt_alloc_align_float(maxdim);
-    int *v = dt_alloc_align(64, maxdim * sizeof (int));
+    int *v = dt_alloc_aligned(maxdim * sizeof (int));
 
     // transform along columns
 #ifdef _OPENMP

--- a/src/common/dttypes.h
+++ b/src/common/dttypes.h
@@ -65,6 +65,16 @@ typedef float DT_ALIGNED_ARRAY dt_colormatrix_t[4][4];
 #define DT_PIXEL_SIMD_CHANNELS 4
 #endif
 
+// A function to compute how many pixels each thread should process in a parallelized for loop.
+// For very small RoIs on a CPU with lots of threads, the last one or two hardware threads can end
+// up without any work, so there needs to be a check whether the starting offset exceeds the total
+// number of pixels to be processed.
+static inline size_t dt_cacheline_chunks(const size_t npixels, const size_t nthreads)
+{
+  return DT_CACHELINE_PIXELS * ((((npixels + nthreads - 1) / nthreads) + (DT_CACHELINE_PIXELS-1))
+                                / DT_CACHELINE_PIXELS);
+}
+
 // A macro which gives us a configurable shorthand to produce the optimal performance when processing all of the
 // channels in a pixel.  Its first argument is the name of the variable to be used inside the 'for' loop it creates,
 // while the optional second argument is a set of OpenMP directives, typically specifying variable alignment.

--- a/src/common/dttypes.h
+++ b/src/common/dttypes.h
@@ -32,6 +32,18 @@
 #define DT_RESTRICT restrict
 #endif
 
+// Configure the size of a CPU cacheline in bytes, floats, and pixels.  On most current architectures,
+// a cacheline contains 64 bytes, but Apple Silicon (M-series processors) uses 128-byte cache lines.
+#if defined(__APPLE__) && defined(__aarch64__)
+#define DT_CACHELINE_BYTES 128
+#define DT_CACHELINE_FLOATS 32
+#define DT_CACHELINE_PIXELS 8
+#else
+#define DT_CACHELINE_BYTES 64
+#define DT_CACHELINE_FLOATS 16
+#define DT_CACHELINE_PIXELS 4
+#endif /* __APPLE__ && __aarch64__ */
+
 // Helper to force heap vectors to be aligned on 64 byte blocks to enable AVX2
 // If this is applied to a struct member and the struct is allocated on the heap, then it must be allocated
 // on a 64 byte boundary to avoid crashes or undefined behavior because of unaligned memory access.

--- a/src/common/focus_peaking.h
+++ b/src/common/focus_peaking.h
@@ -87,7 +87,7 @@ static inline void dt_focuspeaking(cairo_t *cr, const int buf_width, const int b
                                    uint8_t *const restrict image)
 {
   float *const restrict luma = dt_alloc_align_float((size_t)buf_width * buf_height);
-  uint8_t *const restrict focus_peaking = dt_alloc_aligned(sizeof(uint8_t) * buf_width * buf_height * 4);
+  uint8_t *const restrict focus_peaking = dt_alloc_align_uint8(buf_width * buf_height * 4);
 
   const size_t npixels = (size_t)buf_height * buf_width;
   // Create a luma buffer as the euclidian norm of RGB channels

--- a/src/common/focus_peaking.h
+++ b/src/common/focus_peaking.h
@@ -1,6 +1,7 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2019-2021 darktable developers.
+    Copyright (C) 2019-2023 darktable developers.
+
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
@@ -86,7 +87,7 @@ static inline void dt_focuspeaking(cairo_t *cr, const int buf_width, const int b
                                    uint8_t *const restrict image)
 {
   float *const restrict luma = dt_alloc_align_float((size_t)buf_width * buf_height);
-  uint8_t *const restrict focus_peaking = dt_alloc_align(64, sizeof(uint8_t) * buf_width * buf_height * 4);
+  uint8_t *const restrict focus_peaking = dt_alloc_aligned(sizeof(uint8_t) * buf_width * buf_height * 4);
 
   const size_t npixels = (size_t)buf_height * buf_width;
   // Create a luma buffer as the euclidian norm of RGB channels

--- a/src/common/heal.c
+++ b/src/common/heal.c
@@ -327,8 +327,8 @@ static void _heal_laplace_loop(float *const restrict red_pixels, float *const re
   // a handful of runs in each row of pixels.
   // Note that using `unsigned` instead of size_t, the stamp is limited to ~8 gigapixels (the main image can be larger)
   const size_t subwidth = (width+1)/2;  // round up to be able to handle odd widths
-  unsigned *const restrict red_runs = dt_alloc_aligned(sizeof(unsigned) * subwidth * (height + 2));
-  unsigned *const restrict black_runs = dt_alloc_aligned(sizeof(unsigned) * subwidth * (height + 2));
+  unsigned *const restrict red_runs = dt_alloc_align_type(unsigned, subwidth * (height + 2));
+  unsigned *const restrict black_runs = dt_alloc_align_type(unsigned, subwidth * (height + 2));
   if(!red_runs || !black_runs)
   {
     dt_print(DT_DEBUG_ALWAYS, "_heal_laplace_loop: error allocating memory for healing\n");

--- a/src/common/heal.c
+++ b/src/common/heal.c
@@ -327,8 +327,8 @@ static void _heal_laplace_loop(float *const restrict red_pixels, float *const re
   // a handful of runs in each row of pixels.
   // Note that using `unsigned` instead of size_t, the stamp is limited to ~8 gigapixels (the main image can be larger)
   const size_t subwidth = (width+1)/2;  // round up to be able to handle odd widths
-  unsigned *const restrict red_runs = dt_alloc_align(64, sizeof(unsigned) * subwidth * (height + 2));
-  unsigned *const restrict black_runs = dt_alloc_align(64, sizeof(unsigned) * subwidth * (height + 2));
+  unsigned *const restrict red_runs = dt_alloc_aligned(sizeof(unsigned) * subwidth * (height + 2));
+  unsigned *const restrict black_runs = dt_alloc_aligned(sizeof(unsigned) * subwidth * (height + 2));
   if(!red_runs || !black_runs)
   {
     dt_print(DT_DEBUG_ALWAYS, "_heal_laplace_loop: error allocating memory for healing\n");

--- a/src/common/histogram.c
+++ b/src/common/histogram.c
@@ -176,7 +176,7 @@ void _hist_worker(dt_dev_histogram_collection_params_t *const histogram_params,
   {
     if(*histogram)
       dt_free_align(*histogram);
-    *histogram = dt_alloc_align(64, buf_size);
+    *histogram = dt_alloc_aligned(buf_size);
     if(!*histogram) return;
     histogram_stats->buf_size = buf_size;
   }

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -876,7 +876,7 @@ static gboolean _prepare_resampling_plan(const struct dt_interpolation *itor,
   const size_t metareq = dt_round_size(pmeta ? 4 * sizeof(int) * out : 0, SSE_ALIGNMENT);
 
   const size_t totalreq = kernelreq + lengthreq + indexreq + scratchreq + metareq;
-  void *blob = dt_alloc_align(SSE_ALIGNMENT, totalreq);
+  void *blob = dt_alloc_aligned(totalreq);
   if(!blob) return TRUE;
 
   int *lengths = (int *)blob;

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -870,7 +870,7 @@ dt_ioppr_add_profile_info_to_list(struct dt_develop_t *dev,
     dt_ioppr_get_profile_info_from_list(dev, profile_type, profile_filename);
   if(profile_info == NULL)
   {
-    profile_info = dt_alloc_align(64, sizeof(dt_iop_order_iccprofile_info_t));
+    profile_info = dt_alloc_aligned(sizeof(dt_iop_order_iccprofile_info_t));
     dt_ioppr_init_profile_info(profile_info, 0);
     const gboolean err =
       _ioppr_generate_profile_info(profile_info, profile_type, profile_filename, intent);

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -870,7 +870,7 @@ dt_ioppr_add_profile_info_to_list(struct dt_develop_t *dev,
     dt_ioppr_get_profile_info_from_list(dev, profile_type, profile_filename);
   if(profile_info == NULL)
   {
-    profile_info = dt_alloc_aligned(sizeof(dt_iop_order_iccprofile_info_t));
+    profile_info = dt_alloc1_align_type(dt_iop_order_iccprofile_info_t);
     dt_ioppr_init_profile_info(profile_info, 0);
     const gboolean err =
       _ioppr_generate_profile_info(profile_info, profile_type, profile_filename, intent);

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -253,7 +253,7 @@ void *dt_mipmap_cache_alloc(dt_mipmap_buffer_t *buf, const dt_image_t *img)
 
     entry->data_size = 0;
 
-    entry->data = dt_alloc_align(64, buffer_size);
+    entry->data = dt_alloc_aligned(buffer_size);
 
     if(!entry->data)
     {
@@ -321,7 +321,7 @@ void dt_mipmap_cache_allocate_dynamic(void *data, dt_cache_entry_t *entry)
       entry->data_size = sizeof(*dsc) + sizeof(float) * 4 * 64;
     }
 
-    entry->data = dt_alloc_align(64, entry->data_size);
+    entry->data = dt_alloc_aligned(entry->data_size);
 
     // dt_print(DT_DEBUG_ALWAYS, "[mipmap cache] alloc dynamic for key %u %p\n", key, *buf);
     if(!(entry->data))
@@ -369,7 +369,7 @@ void dt_mipmap_cache_allocate_dynamic(void *data, dt_cache_entry_t *entry)
         fseek(f, 0, SEEK_END);
         const long len = ftell(f);
         if(len <= 0) goto read_error; // coverity madness
-        blob = (uint8_t *)dt_alloc_align(64, len);
+        blob = (uint8_t *)dt_alloc_aligned(len);
         if(!blob) goto read_error;
         fseek(f, 0, SEEK_SET);
         const int rd = fread(blob, sizeof(uint8_t), len, f);

--- a/src/common/nlmeans_core.c
+++ b/src/common/nlmeans_core.c
@@ -109,7 +109,7 @@ static struct patch_t* define_patches(
     n_patches = (n_patches + 1) / 2;
   *num_patches = n_patches ;
   // allocate a cacheline-aligned buffer
-  struct patch_t* patches = dt_alloc_aligned(sizeof(struct patch_t) * n_patches);
+  struct patch_t* patches = dt_alloc_align_type(struct patch_t, n_patches);
   // set up the patch offsets
   int patch_num = 0;
   int shift = 0;

--- a/src/common/nlmeans_core.c
+++ b/src/common/nlmeans_core.c
@@ -109,7 +109,7 @@ static struct patch_t* define_patches(
     n_patches = (n_patches + 1) / 2;
   *num_patches = n_patches ;
   // allocate a cacheline-aligned buffer
-  struct patch_t* patches = dt_alloc_align(64, sizeof(struct patch_t) * n_patches);
+  struct patch_t* patches = dt_alloc_aligned(sizeof(struct patch_t) * n_patches);
   // set up the patch offsets
   int patch_num = 0;
   int shift = 0;

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -3386,7 +3386,7 @@ void dt_opencl_dump_pipe_pfm(const char* mod,
   const int width = dt_opencl_get_image_width(img);
   const int height = dt_opencl_get_image_height(img);
   const int element_size = dt_opencl_get_image_element_size(img);
-  float *data = dt_alloc_align(64, (size_t)width * height * element_size);
+  float *data = dt_alloc_aligned((size_t)width * height * element_size);
   if(data)
   {
     const cl_int err =

--- a/src/common/tea.h
+++ b/src/common/tea.h
@@ -23,10 +23,10 @@
 // cache line will be running in lock-step as the cache line bounces back and forth between them, effectively
 // cutting throughput by a factor equal to the number of threads sharing a cache line (8 with a 64-byte cache
 // line and 32-bit ints)
-#define TEA_STATE_SIZE (MAX(64, 2*sizeof(unsigned int)))
+#define TEA_STATE_SIZE (MAX(DT_CACHELINE_BYTES, 2*sizeof(unsigned int)))
 static inline unsigned int* alloc_tea_states(size_t numthreads)
 {
-  unsigned int* states = dt_alloc_align(64, numthreads * TEA_STATE_SIZE);
+  unsigned int* states = dt_alloc_aligned(numthreads * TEA_STATE_SIZE);
   if (states) memset(states, 0, numthreads * TEA_STATE_SIZE);
   return states;
 }

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -3490,7 +3490,7 @@ void dt_dev_image(const dt_imgid_t imgid,
 
   const uint32_t bufsize =
     sizeof(uint32_t) * pipe->backbuf_width * pipe->backbuf_height;
-  *buf = dt_alloc_align(64, bufsize);
+  *buf = dt_alloc_aligned(bufsize);
   memcpy(*buf, pipe->backbuf, bufsize);
 
   if(buf_width) *buf_width = pipe->backbuf_width;

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -549,7 +549,7 @@ const char *dt_iop_colorspace_to_name(const dt_iop_colorspace_type_t type);
 static inline dt_iop_gui_data_t *_iop_gui_alloc(dt_iop_module_t *module, const size_t size)
 {
   // Align so that DT_ALIGNED_ARRAY may be used within gui_data struct
-  module->gui_data = (dt_iop_gui_data_t*)dt_calloc_align(64, size);
+  module->gui_data = (dt_iop_gui_data_t*)dt_calloc_aligned(size);
   dt_pthread_mutex_init(&module->gui_lock, NULL);
   return module->gui_data;
 }

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -516,7 +516,7 @@ static int _path_find_self_intersection(dt_masks_dynbuf_t *inter,
   const size_t ss = (size_t)hb * wb;
   if(ss < 10 || hb < 0 || wb < 0) return 0;
 
-  int *binter = dt_alloc_align(64, sizeof(int) * ss);
+  int *binter = dt_alloc_aligned(sizeof(int) * ss);
   if(binter == NULL) return 0;
   memset(binter, 0, sizeof(int) * ss);
 
@@ -3253,7 +3253,7 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
   // deal with feather if it does not lie outside of roi
   if(!path_encircles_roi)
   {
-    int *dpoints = dt_alloc_align(64, sizeof(int) * 4 * border_count);
+    int *dpoints = dt_alloc_aligned(sizeof(int) * 4 * border_count);
     if(dpoints == NULL)
     {
       dt_free_align(points);

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -516,7 +516,7 @@ static int _path_find_self_intersection(dt_masks_dynbuf_t *inter,
   const size_t ss = (size_t)hb * wb;
   if(ss < 10 || hb < 0 || wb < 0) return 0;
 
-  int *binter = dt_alloc_aligned(sizeof(int) * ss);
+  int *binter = dt_alloc_align_int(ss);
   if(binter == NULL) return 0;
   memset(binter, 0, sizeof(int) * ss);
 
@@ -3253,7 +3253,7 @@ static int _path_get_mask_roi(const dt_iop_module_t *const module,
   // deal with feather if it does not lie outside of roi
   if(!path_encircles_roi)
   {
-    int *dpoints = dt_alloc_aligned(sizeof(int) * 4 * border_count);
+    int *dpoints = dt_alloc_align_int(4 * border_count);
     if(dpoints == NULL)
     {
       dt_free_align(points);

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -61,7 +61,7 @@ gboolean dt_dev_pixelpipe_cache_init(
   for(int k = 0; k < entries; k++)
   {
     cache->size[k] = size;
-    cache->data[k] = (void *)dt_alloc_align(64, size);
+    cache->data[k] = (void *)dt_alloc_aligned(size);
     if(!cache->data[k])
       goto alloc_memory_fail;
 
@@ -324,7 +324,7 @@ gboolean dt_dev_pixelpipe_cache_get(
   {
     dt_free_align(cache->data[cline]);
     cache->allmem -= cache->size[cline];
-    cache->data[cline] = (void *)dt_alloc_align(64, size);
+    cache->data[cline] = (void *)dt_alloc_aligned(size);
     if(cache->data[cline])
     {
       cache->size[cline] = size;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -948,7 +948,7 @@ static void _pixelpipe_picker_cl(const int devid,
   if(buffer && bufsize >= size * bpp)
     pixel = buffer;
   else
-    pixel = tmpbuf = dt_alloc_align(64, size * bpp);
+    pixel = tmpbuf = dt_alloc_aligned(size * bpp);
 
   if(pixel == NULL) return;
 

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -698,7 +698,7 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self, struct dt_
            dt_dev_pixelpipe_type_to_str(piece->pipe->type), tiles_x, tiles_y, width, height, overlap);
 
   /* reserve input and output buffers for tiles */
-  input = dt_alloc_align(64, (size_t)width * height * in_bpp);
+  input = dt_alloc_aligned((size_t)width * height * in_bpp);
   if(input == NULL)
   {
     dt_print(DT_DEBUG_TILING,
@@ -706,7 +706,7 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self, struct dt_
              dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
     goto error;
   }
-  output = dt_alloc_align(64, (size_t)width * height * out_bpp);
+  output = dt_alloc_aligned((size_t)width * height * out_bpp);
   if(output == NULL)
   {
     dt_print(DT_DEBUG_TILING,
@@ -1096,7 +1096,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
                iroi_full.width, iroi_full.height, iroi_full.x, iroi_full.y);
 
       /* prepare input tile buffer */
-      input = dt_alloc_align(64, (size_t)iroi_full.width * iroi_full.height * in_bpp);
+      input = dt_alloc_aligned((size_t)iroi_full.width * iroi_full.height * in_bpp);
       if(input == NULL)
       {
         dt_print(DT_DEBUG_TILING,
@@ -1104,7 +1104,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
                  dt_dev_pixelpipe_type_to_str(piece->pipe->type), self->op, dt_iop_get_instance_id(self));
         goto error;
       }
-      output = dt_alloc_align(64, (size_t)oroi_full.width * oroi_full.height * out_bpp);
+      output = dt_alloc_aligned((size_t)oroi_full.width * oroi_full.height * out_bpp);
       if(output == NULL)
       {
         dt_print(DT_DEBUG_TILING,

--- a/src/imageio/format/exr.cc
+++ b/src/imageio/format/exr.cc
@@ -248,7 +248,7 @@ icc_end:
     const size_t width = exr->global.width;
     const size_t height = exr->global.height;
     stride = 3 * sizeof(unsigned short);
-    out_image = dt_alloc_align(64, stride * width * height);
+    out_image = dt_alloc_aligned(stride * width * height);
     if(out_image == NULL)
     {
       dt_print(DT_DEBUG_ALWAYS, "[exr export] error allocating image conversion buffer\n");
@@ -329,7 +329,7 @@ icc_end:
           const size_t width = exr->global.width;
           const size_t height = exr->global.height;
           stride = sizeof(unsigned short);
-          void *out_mask = dt_alloc_align(64, stride * width * height);
+          void *out_mask = dt_alloc_aligned(stride * width * height);
           if(out_mask == NULL)
           {
             dt_print(DT_DEBUG_ALWAYS, "[exr export] error allocating mask conversion buffer\n");

--- a/src/imageio/format/jpeg.c
+++ b/src/imageio/format/jpeg.c
@@ -272,7 +272,7 @@ int write_image(dt_imageio_module_data_t *jpg_tmp,
     }
   }
 
-  uint8_t *row = dt_alloc_aligned(sizeof(uint8_t) * 3 * jpg->global.width);
+  uint8_t *row = dt_alloc_align_uint8(3 * jpg->global.width);
   const uint8_t *buf;
   while(jpg->cinfo.next_scanline < jpg->cinfo.image_height)
   {

--- a/src/imageio/format/jpeg.c
+++ b/src/imageio/format/jpeg.c
@@ -272,7 +272,7 @@ int write_image(dt_imageio_module_data_t *jpg_tmp,
     }
   }
 
-  uint8_t *row = dt_alloc_align(64, sizeof(uint8_t) * 3 * jpg->global.width);
+  uint8_t *row = dt_alloc_aligned(sizeof(uint8_t) * 3 * jpg->global.width);
   const uint8_t *buf;
   while(jpg->cinfo.next_scanline < jpg->cinfo.image_height)
   {
@@ -332,7 +332,7 @@ int read_image(dt_imageio_module_data_t *jpg_tmp,
   }
   (void)jpeg_start_decompress(&(jpg->dinfo));
   JSAMPROW row_pointer[1];
-  row_pointer[0] = (uint8_t *)dt_alloc_align(64, (size_t)jpg->dinfo.output_width * jpg->dinfo.num_components);
+  row_pointer[0] = (uint8_t *)dt_alloc_aligned((size_t)jpg->dinfo.output_width * jpg->dinfo.num_components);
   uint8_t *tmp = out;
   while(jpg->dinfo.output_scanline < jpg->dinfo.image_height)
   {

--- a/src/imageio/format/pdf.c
+++ b/src/imageio/format/pdf.c
@@ -310,7 +310,7 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
   {
     if(d->params.bpp == 8)
     {
-      image_data = dt_alloc_align(64, (size_t)3 * data->width * data->height);
+      image_data = dt_alloc_aligned((size_t)3 * data->width * data->height);
       const uint8_t *in_ptr = (const uint8_t *)in;
       uint8_t *out_ptr = (uint8_t *)image_data;
       for(int y = 0; y < data->height; y++)
@@ -321,7 +321,7 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
     }
     else
     {
-      image_data = dt_alloc_align(64, sizeof(uint16_t) * 3 * data->width * data->height);
+      image_data = dt_alloc_aligned(sizeof(uint16_t) * 3 * data->width * data->height);
       const uint16_t *in_ptr = (const uint16_t *)in;
       uint16_t *out_ptr = (uint16_t *)image_data;
       for(int y = 0; y < data->height; y++)

--- a/src/imageio/format/pdf.c
+++ b/src/imageio/format/pdf.c
@@ -321,7 +321,7 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
     }
     else
     {
-      image_data = dt_alloc_aligned(sizeof(uint16_t) * 3 * data->width * data->height);
+      image_data = dt_alloc_align_type(uint16_t, 3 * data->width * data->height);
       const uint16_t *in_ptr = (const uint16_t *)in;
       uint16_t *out_ptr = (uint16_t *)image_data;
       for(int y = 0; y < data->height; y++)

--- a/src/imageio/format/png.c
+++ b/src/imageio/format/png.c
@@ -290,7 +290,7 @@ int write_image(dt_imageio_module_data_t *p_tmp, const char *filename, const voi
    */
   png_set_filler(png_ptr, 0, PNG_FILLER_AFTER);
 
-  png_bytep *row_pointers = dt_alloc_aligned(sizeof(png_bytep) * height);
+  png_bytep *row_pointers = dt_alloc_align_type(png_bytep, height);
 
   if(p->bpp > 8)
   {

--- a/src/imageio/format/png.c
+++ b/src/imageio/format/png.c
@@ -290,7 +290,7 @@ int write_image(dt_imageio_module_data_t *p_tmp, const char *filename, const voi
    */
   png_set_filler(png_ptr, 0, PNG_FILLER_AFTER);
 
-  png_bytep *row_pointers = dt_alloc_align(64, sizeof(png_bytep) * height);
+  png_bytep *row_pointers = dt_alloc_aligned(sizeof(png_bytep) * height);
 
   if(p->bpp > 8)
   {

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -170,7 +170,7 @@ int dt_imageio_large_thumbnail(const char *filename,
     if(dt_imageio_jpeg_decompress_header(buf, bufsize, &jpg))
       goto error;
 
-    *buffer = (uint8_t *)dt_alloc_align(64, sizeof(uint8_t) * 4 * jpg.width * jpg.height);
+    *buffer = (uint8_t *)dt_alloc_aligned(sizeof(uint8_t) * 4 * jpg.width * jpg.height);
     if(!*buffer) goto error;
 
     *width = jpg.width;
@@ -215,8 +215,7 @@ int dt_imageio_large_thumbnail(const char *filename,
                                        // embedded thumbnails are
                                        // always srgb
 
-    *buffer = (uint8_t *)dt_alloc_align(64,
-                                        sizeof(uint8_t) * 4 * image->columns * image->rows);
+    *buffer = (uint8_t *)dt_alloc_aligned(sizeof(uint8_t) * 4 * image->columns * image->rows);
     if(!*buffer) goto error_gm;
 
     for(uint32_t row = 0; row < image->rows; row++)
@@ -1475,7 +1474,7 @@ cairo_surface_t *dt_imageio_preview(const dt_imgid_t imgid,
   dat.head.height = height;
   dat.head.style_append = TRUE;
   dat.bpp = 8;
-  dat.buf = (uint8_t *)dt_alloc_align(64, sizeof(uint32_t) * width * height);
+  dat.buf = (uint8_t *)dt_alloc_aligned(sizeof(uint32_t) * width * height);
 
   g_strlcpy(dat.head.style, style_name, sizeof(dat.head.style));
 

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -170,7 +170,7 @@ int dt_imageio_large_thumbnail(const char *filename,
     if(dt_imageio_jpeg_decompress_header(buf, bufsize, &jpg))
       goto error;
 
-    *buffer = (uint8_t *)dt_alloc_aligned(sizeof(uint8_t) * 4 * jpg.width * jpg.height);
+    *buffer = dt_alloc_align_uint8(4 * jpg.width * jpg.height);
     if(!*buffer) goto error;
 
     *width = jpg.width;
@@ -215,7 +215,7 @@ int dt_imageio_large_thumbnail(const char *filename,
                                        // embedded thumbnails are
                                        // always srgb
 
-    *buffer = (uint8_t *)dt_alloc_aligned(sizeof(uint8_t) * 4 * image->columns * image->rows);
+    *buffer = dt_alloc_align_uint8(4 * image->columns * image->rows);
     if(!*buffer) goto error_gm;
 
     for(uint32_t row = 0; row < image->rows; row++)

--- a/src/imageio/imageio_jpeg.c
+++ b/src/imageio/imageio_jpeg.c
@@ -291,7 +291,7 @@ int dt_imageio_jpeg_compress(const uint8_t *in,
   if(quality > 90) jpg.cinfo.comp_info[0].v_samp_factor = 1;
   if(quality > 92) jpg.cinfo.comp_info[0].h_samp_factor = 1;
   jpeg_start_compress(&(jpg.cinfo), TRUE);
-  uint8_t *row = dt_alloc_aligned(sizeof(uint8_t) * 3 * width);
+  uint8_t *row = dt_alloc_align_uint8(3 * width);
   const uint8_t *buf;
   while(jpg.cinfo.next_scanline < jpg.cinfo.image_height)
   {
@@ -548,7 +548,7 @@ int dt_imageio_jpeg_write_with_icc_profile(const char *filename,
 
   if(exif && exif_len > 0 && exif_len < 65534) jpeg_write_marker(&(jpg.cinfo), JPEG_APP0 + 1, exif, exif_len);
 
-  uint8_t *row = dt_alloc_aligned(sizeof(uint8_t) * 3 * width);
+  uint8_t *row = dt_alloc_align_uint8(3 * width);
   const uint8_t *buf;
   while(jpg.cinfo.next_scanline < jpg.cinfo.image_height)
   {
@@ -778,7 +778,7 @@ dt_imageio_retval_t dt_imageio_open_jpeg(dt_image_t *img,
   img->width = jpg.width;
   img->height = jpg.height;
 
-  uint8_t *tmp = (uint8_t *)dt_alloc_aligned(sizeof(uint8_t) * 4 * jpg.width * jpg.height);
+  uint8_t *tmp = dt_alloc_align_uint8(4 * jpg.width * jpg.height);
   if(dt_imageio_jpeg_read(&jpg, tmp))
   {
     dt_free_align(tmp);

--- a/src/imageio/imageio_jpeg.c
+++ b/src/imageio/imageio_jpeg.c
@@ -539,7 +539,7 @@ int dt_imageio_jpeg_write_with_icc_profile(const char *filename,
     cmsSaveProfileToMem(out_profile, 0, &len);
     if(len > 0)
     {
-      unsigned char *buf = dt_alloc_aligned(sizeof(unsigned char) * len);
+      unsigned char *buf = dt_alloc_align_type(unsigned char, len);
       cmsSaveProfileToMem(out_profile, buf, &len);
       write_icc_profile(&(jpg.cinfo), buf, len);
       dt_free_align(buf);

--- a/src/imageio/imageio_jpeg.c
+++ b/src/imageio/imageio_jpeg.c
@@ -172,7 +172,7 @@ static int decompress_jsc(dt_imageio_jpeg_t *jpg, uint8_t *out)
 static int decompress_plain(dt_imageio_jpeg_t *jpg, uint8_t *out)
 {
   JSAMPROW row_pointer[1];
-  row_pointer[0] = (uint8_t *)dt_alloc_align(64, (size_t)jpg->dinfo.output_width * jpg->dinfo.num_components);
+  row_pointer[0] = (uint8_t *)dt_alloc_aligned((size_t)jpg->dinfo.output_width * jpg->dinfo.num_components);
   uint8_t *tmp = out;
   while(jpg->dinfo.output_scanline < jpg->dinfo.image_height)
   {
@@ -291,7 +291,7 @@ int dt_imageio_jpeg_compress(const uint8_t *in,
   if(quality > 90) jpg.cinfo.comp_info[0].v_samp_factor = 1;
   if(quality > 92) jpg.cinfo.comp_info[0].h_samp_factor = 1;
   jpeg_start_compress(&(jpg.cinfo), TRUE);
-  uint8_t *row = dt_alloc_align(64, sizeof(uint8_t) * 3 * width);
+  uint8_t *row = dt_alloc_aligned(sizeof(uint8_t) * 3 * width);
   const uint8_t *buf;
   while(jpg.cinfo.next_scanline < jpg.cinfo.image_height)
   {
@@ -539,7 +539,7 @@ int dt_imageio_jpeg_write_with_icc_profile(const char *filename,
     cmsSaveProfileToMem(out_profile, 0, &len);
     if(len > 0)
     {
-      unsigned char *buf = dt_alloc_align(64, sizeof(unsigned char) * len);
+      unsigned char *buf = dt_alloc_aligned(sizeof(unsigned char) * len);
       cmsSaveProfileToMem(out_profile, buf, &len);
       write_icc_profile(&(jpg.cinfo), buf, len);
       dt_free_align(buf);
@@ -548,7 +548,7 @@ int dt_imageio_jpeg_write_with_icc_profile(const char *filename,
 
   if(exif && exif_len > 0 && exif_len < 65534) jpeg_write_marker(&(jpg.cinfo), JPEG_APP0 + 1, exif, exif_len);
 
-  uint8_t *row = dt_alloc_align(64, sizeof(uint8_t) * 3 * width);
+  uint8_t *row = dt_alloc_aligned(sizeof(uint8_t) * 3 * width);
   const uint8_t *buf;
   while(jpg.cinfo.next_scanline < jpg.cinfo.image_height)
   {
@@ -628,7 +628,7 @@ static int read_jsc(dt_imageio_jpeg_t *jpg, uint8_t *out)
 static int read_plain(dt_imageio_jpeg_t *jpg, uint8_t *out)
 {
   JSAMPROW row_pointer[1];
-  row_pointer[0] = (uint8_t *)dt_alloc_align(64, (size_t)jpg->dinfo.output_width * jpg->dinfo.num_components);
+  row_pointer[0] = (uint8_t *)dt_alloc_aligned((size_t)jpg->dinfo.output_width * jpg->dinfo.num_components);
   uint8_t *tmp = out;
   while(jpg->dinfo.output_scanline < jpg->dinfo.image_height)
   {
@@ -778,7 +778,7 @@ dt_imageio_retval_t dt_imageio_open_jpeg(dt_image_t *img,
   img->width = jpg.width;
   img->height = jpg.height;
 
-  uint8_t *tmp = (uint8_t *)dt_alloc_align(64, sizeof(uint8_t) * 4 * jpg.width * jpg.height);
+  uint8_t *tmp = (uint8_t *)dt_alloc_aligned(sizeof(uint8_t) * 4 * jpg.width * jpg.height);
   if(dt_imageio_jpeg_read(&jpg, tmp))
   {
     dt_free_align(tmp);

--- a/src/imageio/imageio_png.c
+++ b/src/imageio/imageio_png.c
@@ -182,7 +182,7 @@ dt_imageio_retval_t dt_imageio_open_png(dt_image_t *img, const char *filename, d
     return DT_IMAGEIO_CACHE_FULL;
   }
 
-  buf = dt_alloc_align(64, (size_t)image.height * png_get_rowbytes(image.png_ptr, image.info_ptr));
+  buf = dt_alloc_aligned((size_t)image.height * png_get_rowbytes(image.png_ptr, image.info_ptr));
 
   if(!buf)
   {

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -783,7 +783,7 @@ static void _get_auto_exp_histogram(const float *const img, const int width, con
   uint32_t *histogram = NULL;
   const float mul = hist_size;
 
-  histogram = dt_alloc_align(64, sizeof(uint32_t) * hist_size);
+  histogram = dt_alloc_aligned(sizeof(uint32_t) * hist_size);
   if(histogram == NULL) goto cleanup;
 
   memset(histogram, 0, sizeof(uint32_t) * hist_size);

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -783,7 +783,7 @@ static void _get_auto_exp_histogram(const float *const img, const int width, con
   uint32_t *histogram = NULL;
   const float mul = hist_size;
 
-  histogram = dt_alloc_aligned(sizeof(uint32_t) * hist_size);
+  histogram = dt_alloc_align_type(uint32_t, hist_size);
   if(histogram == NULL) goto cleanup;
 
   memset(histogram, 0, sizeof(uint32_t) * hist_size);

--- a/src/iop/blurs.c
+++ b/src/iop/blurs.c
@@ -765,7 +765,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
 
   if(!g->img_cached)
   {
-    g->img = dt_alloc_aligned(sizeof(unsigned char) * 4 * allocation.width * allocation.width);
+    g->img = dt_alloc_align_type(unsigned char, 4 * allocation.width * allocation.width);
     g->img_width = allocation.width;
     g->img_cached = TRUE;
     build_gui_kernel(g->img, g->img_width, g->img_width, p);

--- a/src/iop/blurs.c
+++ b/src/iop/blurs.c
@@ -765,7 +765,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
 
   if(!g->img_cached)
   {
-    g->img = dt_alloc_align(64, sizeof(unsigned char) * 4 * allocation.width * allocation.width);
+    g->img = dt_alloc_aligned(sizeof(unsigned char) * 4 * allocation.width * allocation.width);
     g->img_width = allocation.width;
     g->img_cached = TRUE;
     build_gui_kernel(g->img, g->img_width, g->img_width, p);

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -1801,10 +1801,8 @@ static void _extract_color_checker(const float *const restrict in,
                           &post_wb_delta_E, &post_wb_max_delta_E);
 
   /* Compute the matrix of mix */
-  double *const restrict Y =
-    dt_alloc_align(64, g->checker->patches * 3 * sizeof(double));
-  double *const restrict A =
-    dt_alloc_align(64, g->checker->patches * 3 * 9 * sizeof(double));
+  double *const restrict Y = dt_alloc_aligned(g->checker->patches * 3 * sizeof(double));
+  double *const restrict A = dt_alloc_aligned(g->checker->patches * 3 * 9 * sizeof(double));
 
   for(size_t k = 0; k < g->checker->patches; k++)
   {
@@ -3768,7 +3766,7 @@ void init_pipe(struct dt_iop_module_t *self,
                dt_dev_pixelpipe_t *pipe,
                dt_dev_pixelpipe_iop_t *piece)
 {
-  piece->data = dt_calloc_align(64, sizeof(dt_iop_channelmixer_rbg_data_t));
+  piece->data = dt_calloc_aligned(sizeof(dt_iop_channelmixer_rbg_data_t));
 }
 
 void cleanup_pipe(struct dt_iop_module_t *self,

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -1801,8 +1801,8 @@ static void _extract_color_checker(const float *const restrict in,
                           &post_wb_delta_E, &post_wb_max_delta_E);
 
   /* Compute the matrix of mix */
-  double *const restrict Y = dt_alloc_aligned(g->checker->patches * 3 * sizeof(double));
-  double *const restrict A = dt_alloc_aligned(g->checker->patches * 3 * 9 * sizeof(double));
+  double *const restrict Y = dt_alloc_align_double(g->checker->patches * 3);
+  double *const restrict A = dt_alloc_align_double(g->checker->patches * 3 * 9);
 
   for(size_t k = 0; k < g->checker->patches; k++)
   {

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -3766,7 +3766,7 @@ void init_pipe(struct dt_iop_module_t *self,
                dt_dev_pixelpipe_t *pipe,
                dt_dev_pixelpipe_iop_t *piece)
 {
-  piece->data = dt_calloc_aligned(sizeof(dt_iop_channelmixer_rbg_data_t));
+  piece->data = dt_calloc1_align_type(dt_iop_channelmixer_rbg_data_t);
 }
 
 void cleanup_pipe(struct dt_iop_module_t *self,

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -740,54 +740,37 @@ void process(struct dt_iop_module_t *self,
       1.0f };
 
   const int mode = d->mode;
-#ifdef _OPENMP
   // figure out the number of pixels each thread needs to process,
   // rounded up to a multiple of the CPU's cache line size
   const size_t nthreads = dt_get_num_threads();
   const size_t chunksize = dt_cacheline_chunks(npixels, nthreads);
+#ifdef _OPENMP
 #pragma omp parallel for simd default(none)                             \
-  dt_omp_firstprivate(in, out, mode, npixels, nthreads, chunksize, \
+  dt_omp_firstprivate(in, out, mode, npixels, chunksize,                \
                       grey, saturation, saturation_out, lift, lift_sop, \
-                      gamma, gamma_inv_lgg, gamma_sop, gain, \
+                      gamma, gamma_inv_lgg, gamma_sop, gain,            \
                       gamma_inv_legacy, contrast, contrast_power)       \
   schedule(static)
-  for(size_t chunk = 0; chunk < nthreads; chunk++)
+#endif
+  for(size_t chunkstart = 0; chunkstart < npixels; chunkstart += chunksize)
   {
-    size_t start = chunksize * dt_get_thread_num();
-    if (start >= npixels) continue;  // when npixels is small enough, rounding can leave last thread w/o wok
-    size_t end = MIN(start + chunksize, npixels);
+    size_t end = MIN(chunkstart + chunksize, npixels);
     switch(mode)
     {
       case LEGACY:
-        _process_legacy(in + 4*start, out + 4*start, end-start, lift, gamma_inv_legacy, gain);
+        _process_legacy(in + 4*chunkstart, out + 4*chunkstart, end-chunkstart, lift, gamma_inv_legacy, gain);
         break;
       case LIFT_GAMMA_GAIN:
-        _process_lgg(in + 4*start, out + 4*start, end-start, lift, gamma_inv_lgg, gain,
+        _process_lgg(in + 4*chunkstart, out + 4*chunkstart, end-chunkstart, lift, gamma_inv_lgg, gain,
                      grey, saturation, saturation_out, contrast_power);
         break;
       case SLOPE_OFFSET_POWER:
-        _process_sop(in + 4*start, out + 4*start, end-start,
+        _process_sop(in + 4*chunkstart, out + 4*chunkstart, end-chunkstart,
                      lift_sop, gamma_sop, gain, grey, saturation,
                      saturation_out, contrast, contrast_power);
         break;
     }
   }
-#else
-  switch(mode)
-  {
-    case LEGACY:
-      _process_legacy(in, out, npixels, lift, gamma_inv_legacy, gain);
-      break;
-    case LIFT_GAMMA_GAIN:
-      _process_lgg(in, out, npixels, lift, gamma_inv_lgg, gain,
-                   grey, saturation, saturation_out, contrast_power);
-      break;
-    case SLOPE_OFFSET_POWER:
-      _process_sop(in, out, npixels, lift_sop, gamma_sop, gain, grey, saturation,
-                   saturation_out, contrast, contrast_power);
-      break;
-  }
-#endif
   dt_omploop_sfence();
 }
 

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1401,7 +1401,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  piece->data = dt_calloc_aligned(sizeof(dt_iop_colorbalancergb_data_t));
+  piece->data = dt_calloc1_align_type(dt_iop_colorbalancergb_data_t);
   dt_iop_colorbalancergb_data_t *d = (dt_iop_colorbalancergb_data_t *)(piece->data);
   d->gamut_LUT = dt_alloc_align_float(LUT_ELEM);
   d->lut_inited = FALSE;

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1401,7 +1401,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  piece->data = dt_calloc_align(64, sizeof(dt_iop_colorbalancergb_data_t));
+  piece->data = dt_calloc_aligned(sizeof(dt_iop_colorbalancergb_data_t));
   dt_iop_colorbalancergb_data_t *d = (dt_iop_colorbalancergb_data_t *)(piece->data);
   d->gamut_LUT = dt_alloc_align_float(LUT_ELEM);
   d->lut_inited = FALSE;

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -437,8 +437,7 @@ void process(struct dt_iop_module_t *self,
   // convert patch data from struct of arrays to array of structs so
   // we can vectorize operations
   const int num_patches = data->num_patches;
-  dt_aligned_pixel_t *sources =
-    dt_alloc_align(64, sizeof(dt_aligned_pixel_t) * num_patches);
+  dt_aligned_pixel_t *sources = dt_alloc_aligned(sizeof(dt_aligned_pixel_t) * num_patches);
   for(int i = 0; i < num_patches; i++)
   {
     sources[i][0] = data->source_Lab[3 * i];
@@ -446,8 +445,7 @@ void process(struct dt_iop_module_t *self,
     sources[i][2] = data->source_Lab[3 * i + 2];
     sources[i][3] = 0.0f;
   }
-  dt_aligned_pixel_t *patches =
-    dt_alloc_align(64, sizeof(dt_aligned_pixel_t) * (num_patches + 1));
+  dt_aligned_pixel_t *patches = dt_alloc_aligned(sizeof(dt_aligned_pixel_t) * (num_patches + 1));
   for(int i = 0; i <= num_patches; i++)
   {
     patches[i][0] = data->coeff_L[i];

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -437,7 +437,7 @@ void process(struct dt_iop_module_t *self,
   // convert patch data from struct of arrays to array of structs so
   // we can vectorize operations
   const int num_patches = data->num_patches;
-  dt_aligned_pixel_t *sources = dt_alloc_aligned(sizeof(dt_aligned_pixel_t) * num_patches);
+  dt_aligned_pixel_t *sources = dt_alloc_align_type(dt_aligned_pixel_t, num_patches);
   for(int i = 0; i < num_patches; i++)
   {
     sources[i][0] = data->source_Lab[3 * i];
@@ -445,7 +445,7 @@ void process(struct dt_iop_module_t *self,
     sources[i][2] = data->source_Lab[3 * i + 2];
     sources[i][3] = 0.0f;
   }
-  dt_aligned_pixel_t *patches = dt_alloc_aligned(sizeof(dt_aligned_pixel_t) * (num_patches + 1));
+  dt_aligned_pixel_t *patches = dt_alloc_align_type(dt_aligned_pixel_t, (num_patches + 1));
   for(int i = 0; i <= num_patches; i++)
   {
     patches[i][0] = data->coeff_L[i];

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -515,17 +515,22 @@ static void _transform_lcms(const dt_iop_colorout_data_t *const d,
                             const size_t npixels)
 {
   const int gamutcheck = (d->mode == DT_PROFILE_GAMUTCHECK);
-  // figure out the number of pixels each thread needs to process
-  // round up to a multiple of 4 pixels so that each chunk starts aligned(64)
+#ifdef _OPENMP
+  // figure out the number of pixels each thread needs to process,
+  // rounded up to a multiple of the CPU's cache line size
   const size_t nthreads = dt_get_num_threads();
-  const size_t chunksize = 4 * ((((npixels + nthreads - 1) / nthreads) + 3) / 4);
+  const size_t chunksize = dt_cacheline_chunks(npixels, nthreads);
 #pragma omp parallel for default(none)                                  \
     dt_omp_firstprivate(in, out, npixels, chunksize, nthreads, d, gamutcheck) \
     schedule(static)
+#else
+  const size_t nthreads = 1;
+  const size_t chunksize = npixels;
+#endif
   for(size_t chunk = 0; chunk < nthreads; chunk++)
   {
     size_t start = chunksize * dt_get_thread_num();
-    if (start >= npixels) continue;  // handle case when chunksize is < 4*nthreads and last thread has no work
+    if (start >= npixels) continue;  // when npixels is small enough, rounding can leave last thread w/o wok
     size_t count = MIN(start + chunksize, npixels) - start;
     float *const outp = out + 4 * start;
 

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -515,26 +515,21 @@ static void _transform_lcms(const dt_iop_colorout_data_t *const d,
                             const size_t npixels)
 {
   const int gamutcheck = (d->mode == DT_PROFILE_GAMUTCHECK);
-#ifdef _OPENMP
   // figure out the number of pixels each thread needs to process,
   // rounded up to a multiple of the CPU's cache line size
   const size_t nthreads = dt_get_num_threads();
   const size_t chunksize = dt_cacheline_chunks(npixels, nthreads);
+#ifdef _OPENMP
 #pragma omp parallel for default(none)                                  \
-    dt_omp_firstprivate(in, out, npixels, chunksize, nthreads, d, gamutcheck) \
+    dt_omp_firstprivate(in, out, npixels, chunksize, d, gamutcheck) \
     schedule(static)
-#else
-  const size_t nthreads = 1;
-  const size_t chunksize = npixels;
 #endif
-  for(size_t chunk = 0; chunk < nthreads; chunk++)
+  for(size_t chunkstart = 0; chunkstart < npixels; chunkstart += chunksize)
   {
-    size_t start = chunksize * dt_get_thread_num();
-    if (start >= npixels) continue;  // when npixels is small enough, rounding can leave last thread w/o wok
-    size_t count = MIN(start + chunksize, npixels) - start;
-    float *const outp = out + 4 * start;
+    size_t count = MIN(chunkstart + chunksize, npixels) - chunkstart;
+    float *const outp = out + 4 * chunkstart;
 
-    cmsDoTransform(d->xform, in + 4*start, outp, count);
+    cmsDoTransform(d->xform, in + 4*chunkstart, outp, count);
 
     if(gamutcheck)
     {

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -288,7 +288,7 @@ static dt_iop_colorreconstruct_bilateral_t *dt_iop_colorreconstruct_bilateral_in
   b->scale = iscale / roi->scale;
   b->sigma_s = MAX(roi->height / (b->size_y - 1.0f), roi->width / (b->size_x - 1.0f));
   b->sigma_r = 100.0f / (b->size_z - 1.0f);
-  b->buf = dt_alloc_aligned(sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
+  b->buf = dt_alloc_align_type(dt_iop_colorreconstruct_Lab_t, b->size_x * b->size_y * b->size_z);
   if(!b->buf)
   {
     dt_print(DT_DEBUG_ALWAYS, "[color reconstruction] not able to allocate buffer (b)\n");
@@ -326,7 +326,7 @@ static dt_iop_colorreconstruct_bilateral_frozen_t *dt_iop_colorreconstruct_bilat
   bf->scale = b->scale;
   bf->sigma_s = b->sigma_s;
   bf->sigma_r = b->sigma_r;
-  bf->buf = dt_alloc_aligned(sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
+  bf->buf = dt_alloc_align_type(dt_iop_colorreconstruct_Lab_t, b->size_x * b->size_y * b->size_z);
   if(bf->buf && b->buf)
   {
     memcpy(bf->buf, b->buf, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
@@ -362,7 +362,7 @@ static dt_iop_colorreconstruct_bilateral_t *dt_iop_colorreconstruct_bilateral_th
   b->scale = bf->scale;
   b->sigma_s = bf->sigma_s;
   b->sigma_r = bf->sigma_r;
-  b->buf = dt_alloc_aligned(sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
+  b->buf = dt_alloc_align_type(dt_iop_colorreconstruct_Lab_t, b->size_x * b->size_y * b->size_z);
   if(b->buf && bf->buf)
   {
     memcpy(b->buf, bf->buf, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
@@ -830,7 +830,7 @@ static dt_iop_colorreconstruct_bilateral_frozen_t *dt_iop_colorreconstruct_bilat
   bf->scale = b->scale;
   bf->sigma_s = b->sigma_s;
   bf->sigma_r = b->sigma_r;
-  bf->buf = dt_alloc_aligned(sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
+  bf->buf = dt_alloc_align_type(dt_iop_colorreconstruct_Lab_t, b->size_x * b->size_y * b->size_z);
   if(bf->buf && b->dev_grid)
   {
     // read bilateral grid from device memory to host buffer (blocking)

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -288,7 +288,7 @@ static dt_iop_colorreconstruct_bilateral_t *dt_iop_colorreconstruct_bilateral_in
   b->scale = iscale / roi->scale;
   b->sigma_s = MAX(roi->height / (b->size_y - 1.0f), roi->width / (b->size_x - 1.0f));
   b->sigma_r = 100.0f / (b->size_z - 1.0f);
-  b->buf = dt_alloc_align(64, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
+  b->buf = dt_alloc_aligned(sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
   if(!b->buf)
   {
     dt_print(DT_DEBUG_ALWAYS, "[color reconstruction] not able to allocate buffer (b)\n");
@@ -326,7 +326,7 @@ static dt_iop_colorreconstruct_bilateral_frozen_t *dt_iop_colorreconstruct_bilat
   bf->scale = b->scale;
   bf->sigma_s = b->sigma_s;
   bf->sigma_r = b->sigma_r;
-  bf->buf = dt_alloc_align(64, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
+  bf->buf = dt_alloc_aligned(sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
   if(bf->buf && b->buf)
   {
     memcpy(bf->buf, b->buf, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
@@ -362,7 +362,7 @@ static dt_iop_colorreconstruct_bilateral_t *dt_iop_colorreconstruct_bilateral_th
   b->scale = bf->scale;
   b->sigma_s = bf->sigma_s;
   b->sigma_r = bf->sigma_r;
-  b->buf = dt_alloc_align(64, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
+  b->buf = dt_alloc_aligned(sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
   if(b->buf && bf->buf)
   {
     memcpy(b->buf, bf->buf, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
@@ -830,7 +830,7 @@ static dt_iop_colorreconstruct_bilateral_frozen_t *dt_iop_colorreconstruct_bilat
   bf->scale = b->scale;
   bf->sigma_s = b->sigma_s;
   bf->sigma_r = b->sigma_r;
-  bf->buf = dt_alloc_align(64, sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
+  bf->buf = dt_alloc_aligned(sizeof(dt_iop_colorreconstruct_Lab_t) * b->size_x * b->size_y * b->size_z);
   if(bf->buf && b->dev_grid)
   {
     // read bilateral grid from device memory to host buffer (blocking)

--- a/src/iop/demosaicing/vng.c
+++ b/src/iop/demosaicing/vng.c
@@ -203,8 +203,7 @@ static void vng_interpolate(
   // if only linear interpolation is requested we can stop it here
   if(only_vng_linear) return;
 
-  char *buffer
-      = (char *)dt_alloc_align(64, sizeof(**brow) * width * 3 + sizeof(*ip) * prow * pcol * 320);
+  char *buffer = (char *)dt_alloc_aligned(sizeof(**brow) * width * 3 + sizeof(*ip) * prow * pcol * 320);
   if(!buffer)
   {
     dt_print(DT_DEBUG_ALWAYS, "[demosaic] not able to allocate VNG buffer\n");

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1368,7 +1368,7 @@ void process(dt_iop_module_t *self,
     return;
   }
 
-  uint8_t *const restrict mask = dt_alloc_aligned(sizeof(uint8_t) * width * height);
+  uint8_t *const restrict mask = dt_alloc_align_uint8(width * height);
 
   float *restrict in = DT_IS_ALIGNED((float *const restrict)ivoid);
   float *const restrict out = DT_IS_ALIGNED((float *const restrict)ovoid);

--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -1,6 +1,6 @@
 /*
    This file is part of darktable,
-   Copyright (C) 2021-23 darktable developers.
+   Copyright (C) 2021-2023 darktable developers.
 
    darktable is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -1368,7 +1368,7 @@ void process(dt_iop_module_t *self,
     return;
   }
 
-  uint8_t *const restrict mask = dt_alloc_align(64, sizeof(uint8_t) * width * height);
+  uint8_t *const restrict mask = dt_alloc_aligned(sizeof(uint8_t) * width * height);
 
   float *restrict in = DT_IS_ALIGNED((float *const restrict)ivoid);
   float *const restrict out = DT_IS_ALIGNED((float *const restrict)ovoid);

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -3237,7 +3237,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  piece->data = dt_calloc_align(64, sizeof(dt_iop_filmicrgb_data_t));
+  piece->data = dt_calloc_aligned(sizeof(dt_iop_filmicrgb_data_t));
 }
 
 void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -3237,7 +3237,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  piece->data = dt_calloc_aligned(sizeof(dt_iop_filmicrgb_data_t));
+  piece->data = dt_calloc1_align_type(dt_iop_filmicrgb_data_t);
 }
 
 void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/gaussian_elimination.h
+++ b/src/iop/gaussian_elimination.h
@@ -159,8 +159,8 @@ static inline int pseudo_solve_gaussian(double *const restrict A,
     return 0;
   }
 
-  double *const restrict A_square = dt_alloc_align(64, n * n * sizeof(double));
-  double *const restrict y_square = dt_alloc_align(64, n * sizeof(double));
+  double *const restrict A_square = dt_alloc_aligned(n * n * sizeof(double));
+  double *const restrict y_square = dt_alloc_aligned(n * sizeof(double));
 
   #ifdef _OPENMP
   #pragma omp parallel sections

--- a/src/iop/gaussian_elimination.h
+++ b/src/iop/gaussian_elimination.h
@@ -159,8 +159,8 @@ static inline int pseudo_solve_gaussian(double *const restrict A,
     return 0;
   }
 
-  double *const restrict A_square = dt_alloc_aligned(n * n * sizeof(double));
-  double *const restrict y_square = dt_alloc_aligned(n * sizeof(double));
+  double *const restrict A_square = dt_alloc_align_double(n * n);
+  double *const restrict y_square = dt_alloc_align_double(n);
 
   #ifdef _OPENMP
   #pragma omp parallel sections

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -611,7 +611,7 @@ static float ambient_light_cl(struct dt_iop_module_t *self, int devid, cl_mem im
   const int width = dt_opencl_get_image_width(img);
   const int height = dt_opencl_get_image_height(img);
   const int element_size = dt_opencl_get_image_element_size(img);
-  float *in = dt_alloc_align(64, (size_t)width * height * element_size);
+  float *in = dt_alloc_aligned((size_t)width * height * element_size);
   int err = dt_opencl_read_host_from_device(devid, in, img, width, height, element_size);
   if(err != CL_SUCCESS) goto error;
   const const_rgb_image img_in = (const_rgb_image){ in, width, height, element_size / sizeof(float) };

--- a/src/iop/hlreconstruct/opposed.c
+++ b/src/iop/hlreconstruct/opposed.c
@@ -118,7 +118,7 @@ static void _process_linear_opposed(
 
   dt_aligned_pixel_t chrominance = {0.0f, 0.0f, 0.0f, 0.0f};
 
-  char *mask = (quality) ? dt_calloc_align(64, 6 * msize * sizeof(char)) : NULL;
+  char *mask = (quality) ? dt_calloc_aligned(6 * msize * sizeof(char)) : NULL;
   if(mask)
   {
     gboolean anyclipped = FALSE;
@@ -260,7 +260,7 @@ static float *_process_opposed(
   }
   else
   {
-    char *mask = (quality) ? dt_calloc_align(64, 6 * msize * sizeof(char)) : NULL;
+    char *mask = (quality) ? dt_calloc_aligned(6 * msize * sizeof(char)) : NULL;
     if(mask)
     {
       gboolean anyclipped = FALSE;

--- a/src/iop/hlreconstruct/opposed.c
+++ b/src/iop/hlreconstruct/opposed.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2022-23 darktable developers.
+    Copyright (C) 2022-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -118,7 +118,7 @@ static void _process_linear_opposed(
 
   dt_aligned_pixel_t chrominance = {0.0f, 0.0f, 0.0f, 0.0f};
 
-  char *mask = (quality) ? dt_calloc_aligned(6 * msize * sizeof(char)) : NULL;
+  char *mask = (quality) ? dt_calloc_align_type(char, 6 * msize) : NULL;
   if(mask)
   {
     gboolean anyclipped = FALSE;
@@ -260,7 +260,7 @@ static float *_process_opposed(
   }
   else
   {
-    char *mask = (quality) ? dt_calloc_aligned(6 * msize * sizeof(char)) : NULL;
+    char *mask = (quality) ? dt_calloc_align_type(char, 6 * msize) : NULL;
     if(mask)
     {
       gboolean anyclipped = FALSE;

--- a/src/iop/hlreconstruct/segmentation.c
+++ b/src/iop/hlreconstruct/segmentation.c
@@ -637,11 +637,11 @@ gboolean dt_segmentation_init_struct(dt_iop_segmentation_t *seg,
 
   seg->data =   dt_calloc_aligned(bsize);
   seg->tmp =    dt_alloc_aligned(bsize);
-  seg->size =   dt_alloc_aligned(slots * sizeof(int));
-  seg->xmin =   dt_alloc_aligned(slots * sizeof(int));
-  seg->xmax =   dt_alloc_aligned(slots * sizeof(int));
-  seg->ymin =   dt_alloc_aligned(slots * sizeof(int));
-  seg->ymax =   dt_alloc_aligned(slots * sizeof(int));
+  seg->size =   dt_alloc_align_int(slots);
+  seg->xmin =   dt_alloc_align_int(slots);
+  seg->xmax =   dt_alloc_align_int(slots);
+  seg->ymin =   dt_alloc_align_int(slots);
+  seg->ymax =   dt_alloc_align_int(slots);
   seg->val1 =   dt_alloc_align_float(slots);
   seg->val2 =   dt_alloc_align_float(slots);
 

--- a/src/iop/hlreconstruct/segmentation.c
+++ b/src/iop/hlreconstruct/segmentation.c
@@ -559,7 +559,7 @@ void dt_segmentize_plane(dt_iop_segmentation_t *seg)
   const int width = seg->width;
   const int height = seg->height;
   stack.size = (size_t)width * height / 32;
-  stack.el = dt_alloc_align(64, stack.size * sizeof(dt_pos_t));
+  stack.el = dt_alloc_aligned(stack.size * sizeof(dt_pos_t));
   if(!stack.el)
   {
     dt_print(DT_DEBUG_ALWAYS, "[segmentize_plane] can't allocate segmentation stack\n");
@@ -635,13 +635,13 @@ gboolean dt_segmentation_init_struct(dt_iop_segmentation_t *seg,
   const int slots = MAX(256, MIN(islots, DT_SEG_ID_MASK - 2));
   const size_t bsize = (size_t) width * height * sizeof(uint32_t);
 
-  seg->data =   dt_calloc_align(64, bsize);
-  seg->tmp =    dt_alloc_align(64, bsize);
-  seg->size =   dt_alloc_align(64, slots * sizeof(int));
-  seg->xmin =   dt_alloc_align(64, slots * sizeof(int));
-  seg->xmax =   dt_alloc_align(64, slots * sizeof(int));
-  seg->ymin =   dt_alloc_align(64, slots * sizeof(int));
-  seg->ymax =   dt_alloc_align(64, slots * sizeof(int));
+  seg->data =   dt_calloc_aligned(bsize);
+  seg->tmp =    dt_alloc_aligned(bsize);
+  seg->size =   dt_alloc_aligned(slots * sizeof(int));
+  seg->xmin =   dt_alloc_aligned(slots * sizeof(int));
+  seg->xmax =   dt_alloc_aligned(slots * sizeof(int));
+  seg->ymin =   dt_alloc_aligned(slots * sizeof(int));
+  seg->ymax =   dt_alloc_aligned(slots * sizeof(int));
   seg->val1 =   dt_alloc_align_float(slots);
   seg->val2 =   dt_alloc_align_float(slots);
 

--- a/src/iop/hlreconstruct/segmentation.c
+++ b/src/iop/hlreconstruct/segmentation.c
@@ -559,7 +559,7 @@ void dt_segmentize_plane(dt_iop_segmentation_t *seg)
   const int width = seg->width;
   const int height = seg->height;
   stack.size = (size_t)width * height / 32;
-  stack.el = dt_alloc_aligned(stack.size * sizeof(dt_pos_t));
+  stack.el = dt_alloc_align_type(dt_pos_t, stack.size);
   if(!stack.el)
   {
     dt_print(DT_DEBUG_ALWAYS, "[segmentize_plane] can't allocate segmentation stack\n");

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1187,7 +1187,7 @@ static void _process_lf(dt_iop_module_t *self,
   {
     // acquire temp memory for image buffer
     const size_t bufsize = (size_t)roi_in->width * roi_in->height * ch * sizeof(float);
-    void *buf = dt_alloc_align(64, bufsize);
+    void *buf = dt_alloc_aligned(bufsize);
     memcpy(buf, ivoid, bufsize);
 
     if(modflags & LF_MODIFY_VIGNETTING)
@@ -1360,7 +1360,7 @@ static int _process_cl_lf(struct dt_iop_module_t *self,
       return DT_OPENCL_PROCESS_CL;
   }
 
-  tmpbuf = (float *)dt_alloc_align(64, tmpbuflen);
+  tmpbuf = (float *)dt_alloc_aligned(tmpbuflen);
   if(tmpbuf == NULL) goto error;
 
   dev_tmp = (cl_mem)dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
@@ -1739,7 +1739,7 @@ static void _modify_roi_in_lf(struct dt_iop_module_t *self,
     float xm = FLT_MAX, xM = -FLT_MAX, ym = FLT_MAX, yM = -FLT_MAX;
     const size_t nbpoints = 2 * awidth + 2 * aheight;
 
-    float *const buf = (float *)dt_alloc_align(64, sizeof(float) * nbpoints * 2 * 3);
+    float *const buf = (float *)dt_alloc_align_float(nbpoints * 2 * 3);
 
 #ifdef _OPENMP
 #pragma omp parallel default(none) \

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -861,7 +861,7 @@ static float *build_lookup_table(const int distance,
                                  const float control1,
                                  const float control2)
 {
-  float complex *clookup = dt_alloc_align(64, sizeof(float complex) * (distance + 2));
+  float complex *clookup = dt_alloc_aligned(sizeof(float complex) * (distance + 2));
   float *lookup = dt_alloc_align_float((size_t)(distance + 2));
   if (!clookup || !lookup)
   {
@@ -1136,7 +1136,7 @@ static float complex *create_global_distortion_map(const cairo_rectangle_int_t *
   }
 
   // allocate distortion map big enough to contain all paths
-  float complex *map = dt_alloc_align(64, sizeof(float complex) * mapsize);
+  float complex *map = dt_alloc_aligned(sizeof(float complex) * mapsize);
   memset(map, 0, sizeof(float complex) * mapsize);
 
   // build map
@@ -1148,7 +1148,7 @@ static float complex *create_global_distortion_map(const cairo_rectangle_int_t *
 
   if(inverted)
   {
-    float complex * const imap = dt_alloc_align(64, sizeof(float complex) * mapsize);
+    float complex * const imap = dt_alloc_aligned(sizeof(float complex) * mapsize);
     memset(imap, 0, sizeof(float complex) * mapsize);
 
     // copy map into imap(inverted map).

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -861,7 +861,7 @@ static float *build_lookup_table(const int distance,
                                  const float control1,
                                  const float control2)
 {
-  float complex *clookup = dt_alloc_aligned(sizeof(float complex) * (distance + 2));
+  float complex *clookup = dt_alloc_align_type(float complex, (distance + 2));
   float *lookup = dt_alloc_align_float((size_t)(distance + 2));
   if (!clookup || !lookup)
   {
@@ -1136,7 +1136,7 @@ static float complex *create_global_distortion_map(const cairo_rectangle_int_t *
   }
 
   // allocate distortion map big enough to contain all paths
-  float complex *map = dt_alloc_aligned(sizeof(float complex) * mapsize);
+  float complex *map = dt_alloc_align_type(float complex, mapsize);
   memset(map, 0, sizeof(float complex) * mapsize);
 
   // build map
@@ -1148,7 +1148,7 @@ static float complex *create_global_distortion_map(const cairo_rectangle_int_t *
 
   if(inverted)
   {
-    float complex * const imap = dt_alloc_aligned(sizeof(float complex) * mapsize);
+    float complex * const imap = dt_alloc_align_type(float complex, mapsize);
     memset(imap, 0, sizeof(float complex) * mapsize);
 
     // copy map into imap(inverted map).

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -561,7 +561,7 @@ uint16_t calculate_clut_haldclut(dt_iop_lut3d_params_t *const p, const char *con
   const size_t buf_size = (size_t)png.height * png_get_rowbytes(png.png_ptr, png.info_ptr);
   dt_print(DT_DEBUG_DEV, "[lut3d] allocating %zu bytes for png file\n", buf_size);
   uint8_t *buf = NULL;
-  buf = dt_alloc_align(16, buf_size);
+  buf = dt_alloc_aligned(buf_size);
   if(!buf)
   {
     dt_print(DT_DEBUG_ALWAYS, "[lut3d] error allocating buffer for png LUT\n");

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -1,6 +1,6 @@
 /*
    This file is part of darktable,
-   Copyright (C) 2016-2021 darktable developers.
+   Copyright (C) 2016-2023 darktable developers.
 
    darktable is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -286,7 +286,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   const size_t coordbufsize = (size_t)height * width * 2 * sizeof(float);
 
-  coordbuf = dt_alloc_align(64, coordbufsize);
+  coordbuf = dt_alloc_aligned(coordbufsize);
   if(coordbuf == NULL) goto error;
 
 #ifdef _OPENMP

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1625,8 +1625,7 @@ void init_pipe(struct dt_iop_module_t *self,
                dt_dev_pixelpipe_iop_t *piece)
 {
   // create part of the pixelpipe
-  dt_iop_rgbcurve_data_t *d =
-    (dt_iop_rgbcurve_data_t *)dt_alloc_align(64, sizeof(dt_iop_rgbcurve_data_t));
+  dt_iop_rgbcurve_data_t *d = (dt_iop_rgbcurve_data_t *)dt_alloc_aligned(sizeof(dt_iop_rgbcurve_data_t));
   const dt_iop_rgbcurve_params_t *const default_params =
     (dt_iop_rgbcurve_params_t *)self->default_params;
   piece->data = (void *)d;
@@ -1681,7 +1680,7 @@ void init_global(dt_iop_module_so_t *module)
 {
   const int program = 25; // rgbcurve.cl, from programs.conf
   dt_iop_rgbcurve_global_data_t *gd =
-    (dt_iop_rgbcurve_global_data_t *)dt_alloc_align(64, sizeof(dt_iop_rgbcurve_global_data_t));
+    (dt_iop_rgbcurve_global_data_t *)dt_alloc_aligned(sizeof(dt_iop_rgbcurve_global_data_t));
   module->data = gd;
 
   gd->kernel_rgbcurve = dt_opencl_create_kernel(program, "rgbcurve");

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1625,7 +1625,7 @@ void init_pipe(struct dt_iop_module_t *self,
                dt_dev_pixelpipe_iop_t *piece)
 {
   // create part of the pixelpipe
-  dt_iop_rgbcurve_data_t *d = (dt_iop_rgbcurve_data_t *)dt_alloc_aligned(sizeof(dt_iop_rgbcurve_data_t));
+  dt_iop_rgbcurve_data_t *d = dt_alloc1_align_type(dt_iop_rgbcurve_data_t);
   const dt_iop_rgbcurve_params_t *const default_params =
     (dt_iop_rgbcurve_params_t *)self->default_params;
   piece->data = (void *)d;
@@ -1679,8 +1679,7 @@ void init(dt_iop_module_t *module)
 void init_global(dt_iop_module_so_t *module)
 {
   const int program = 25; // rgbcurve.cl, from programs.conf
-  dt_iop_rgbcurve_global_data_t *gd =
-    (dt_iop_rgbcurve_global_data_t *)dt_alloc_aligned(sizeof(dt_iop_rgbcurve_global_data_t));
+  dt_iop_rgbcurve_global_data_t *gd =dt_alloc1_align_type(dt_iop_rgbcurve_global_data_t);
   module->data = gd;
 
   gd->kernel_rgbcurve = dt_opencl_create_kernel(program, "rgbcurve");

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1693,7 +1693,7 @@ void init_pipe(struct dt_iop_module_t *self,
                dt_dev_pixelpipe_t *pipe,
                dt_dev_pixelpipe_iop_t *piece)
 {
-  piece->data = dt_calloc_aligned(sizeof(dt_iop_toneequalizer_data_t));
+  piece->data = dt_calloc1_align_type(dt_iop_toneequalizer_data_t);
 }
 
 

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1693,7 +1693,7 @@ void init_pipe(struct dt_iop_module_t *self,
                dt_dev_pixelpipe_t *pipe,
                dt_dev_pixelpipe_iop_t *piece)
 {
-  piece->data = dt_calloc_align(64, sizeof(dt_iop_toneequalizer_data_t));
+  piece->data = dt_calloc_aligned(sizeof(dt_iop_toneequalizer_data_t));
 }
 
 

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -2567,7 +2567,7 @@ void gui_init(dt_lib_module_t *self)
     d->waveform_max_bins
     * cairo_format_stride_for_width(CAIRO_FORMAT_A8, d->waveform_tones);
   for(int ch=0; ch<3; ch++)
-    d->waveform_img[ch] = dt_alloc_aligned(sizeof(uint8_t) * MAX(bytes_hori, bytes_vert));
+    d->waveform_img[ch] = dt_alloc_align_uint8(MAX(bytes_hori, bytes_vert));
 
   // FIXME: what is the appropriate resolution for this: balance
   // memory use, processing speed, helpful resolution
@@ -2575,11 +2575,11 @@ void gui_init(dt_lib_module_t *self)
   // FIXME: make this and waveform params #DEFINEd or const above,
   // rather than set here?
   d->vectorscope_diameter_px = 384;
-  d->vectorscope_graph = dt_alloc_aligned(sizeof(uint8_t) * d->vectorscope_diameter_px *
+  d->vectorscope_graph = dt_alloc_align_uint8(d->vectorscope_diameter_px *
      cairo_format_stride_for_width(CAIRO_FORMAT_A8, d->vectorscope_diameter_px));
   d->vectorscope_bkgd =
-    dt_alloc_aligned(sizeof(uint8_t) * 4U * d->vectorscope_diameter_px *
-                     cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, d->vectorscope_diameter_px));
+    dt_alloc_align_uint8(4U * d->vectorscope_diameter_px *
+                         cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, d->vectorscope_diameter_px));
   d->hue_ring_prof = NULL;
   d->hue_ring_scale = DT_LIB_HISTOGRAM_SCALE_N;
   d->hue_ring_colorspace = DT_LIB_HISTOGRAM_VECTORSCOPE_N;

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -788,9 +788,7 @@ static void _lib_histogram_process_vectorscope
   // histogram profile PCS (always D50)?
   //
   // FIXME: pre-allocate? -- use the same buffer as for waveform?
-  dt_atomic_int *const restrict binned =
-    __builtin_assume_aligned(dt_alloc_aligned(sizeof(int) * diam_px * diam_px), DT_CACHELINE_BYTES);
-  memset(binned, 0, sizeof(int) * diam_px * diam_px);
+  dt_atomic_int *const restrict binned = (dt_atomic_int*)dt_calloc_align_int(diam_px * diam_px);
   // FIXME: move verbosed interleaved comments into a method note at
   // the start, as the code itself is succinct and clear
   //
@@ -2486,8 +2484,7 @@ void view_leave(struct dt_lib_module_t *self,
 void gui_init(dt_lib_module_t *self)
 {
   /* initialize ui widgets */
-  dt_lib_histogram_t *d =
-    (dt_lib_histogram_t *)dt_calloc_aligned(sizeof(dt_lib_histogram_t));
+  dt_lib_histogram_t *d = dt_calloc1_align_type(dt_lib_histogram_t);
   self->data = (void *)d;
 
   dt_pthread_mutex_init(&d->lock, NULL);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -2521,7 +2521,7 @@ void gui_init(dt_lib_module_t *self)
   int a = dt_conf_get_int("plugins/darkroom/histogram/vectorscope/angle");
   d->vectorscope_angle = a * M_PI / 180.0;
 
-  d->histogram = (uint32_t *)dt_alloc_aligned(4 * HISTOGRAM_BINS * sizeof(uint32_t));
+  d->histogram = dt_alloc_align_type(uint32_t, 4 * HISTOGRAM_BINS);
   memset(d->histogram, 0, 4 * HISTOGRAM_BINS * sizeof(uint32_t));
   d->histogram_max = 0;
 

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -788,7 +788,8 @@ static void _lib_histogram_process_vectorscope
   // histogram profile PCS (always D50)?
   //
   // FIXME: pre-allocate? -- use the same buffer as for waveform?
-  dt_atomic_int *const restrict binned = __builtin_assume_aligned(dt_alloc_align(64, sizeof(int) * diam_px * diam_px), 64);
+  dt_atomic_int *const restrict binned =
+    __builtin_assume_aligned(dt_alloc_aligned(sizeof(int) * diam_px * diam_px), DT_CACHELINE_BYTES);
   memset(binned, 0, sizeof(int) * diam_px * diam_px);
   // FIXME: move verbosed interleaved comments into a method note at
   // the start, as the code itself is succinct and clear
@@ -2486,7 +2487,7 @@ void gui_init(dt_lib_module_t *self)
 {
   /* initialize ui widgets */
   dt_lib_histogram_t *d =
-    (dt_lib_histogram_t *)dt_calloc_align(64, sizeof(dt_lib_histogram_t));
+    (dt_lib_histogram_t *)dt_calloc_aligned(sizeof(dt_lib_histogram_t));
   self->data = (void *)d;
 
   dt_pthread_mutex_init(&d->lock, NULL);
@@ -2523,7 +2524,7 @@ void gui_init(dt_lib_module_t *self)
   int a = dt_conf_get_int("plugins/darkroom/histogram/vectorscope/angle");
   d->vectorscope_angle = a * M_PI / 180.0;
 
-  d->histogram = (uint32_t *)dt_alloc_align(64, 4 * HISTOGRAM_BINS * sizeof(uint32_t));
+  d->histogram = (uint32_t *)dt_alloc_aligned(4 * HISTOGRAM_BINS * sizeof(uint32_t));
   memset(d->histogram, 0, 4 * HISTOGRAM_BINS * sizeof(uint32_t));
   d->histogram_max = 0;
 
@@ -2566,7 +2567,7 @@ void gui_init(dt_lib_module_t *self)
     d->waveform_max_bins
     * cairo_format_stride_for_width(CAIRO_FORMAT_A8, d->waveform_tones);
   for(int ch=0; ch<3; ch++)
-    d->waveform_img[ch] = dt_alloc_align(64, sizeof(uint8_t) * MAX(bytes_hori, bytes_vert));
+    d->waveform_img[ch] = dt_alloc_aligned(sizeof(uint8_t) * MAX(bytes_hori, bytes_vert));
 
   // FIXME: what is the appropriate resolution for this: balance
   // memory use, processing speed, helpful resolution
@@ -2574,13 +2575,11 @@ void gui_init(dt_lib_module_t *self)
   // FIXME: make this and waveform params #DEFINEd or const above,
   // rather than set here?
   d->vectorscope_diameter_px = 384;
-  d->vectorscope_graph = dt_alloc_align
-    (64, sizeof(uint8_t) * d->vectorscope_diameter_px *
+  d->vectorscope_graph = dt_alloc_aligned(sizeof(uint8_t) * d->vectorscope_diameter_px *
      cairo_format_stride_for_width(CAIRO_FORMAT_A8, d->vectorscope_diameter_px));
   d->vectorscope_bkgd =
-    dt_alloc_align(64, sizeof(uint8_t) * 4U * d->vectorscope_diameter_px *
-                   cairo_format_stride_for_width
-                     (CAIRO_FORMAT_RGB24, d->vectorscope_diameter_px));
+    dt_alloc_aligned(sizeof(uint8_t) * 4U * d->vectorscope_diameter_px *
+                     cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, d->vectorscope_diameter_px));
   d->hue_ring_prof = NULL;
   d->hue_ring_scale = DT_LIB_HISTOGRAM_SCALE_N;
   d->hue_ring_colorspace = DT_LIB_HISTOGRAM_VECTORSCOPE_N;

--- a/src/tests/cache.c
+++ b/src/tests/cache.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2020 darktable developers.
+    Copyright (C) 2011-2023 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -18,8 +18,8 @@
 
 
 #define DT_UNIT_TEST
-// define dt alloc, so we don't need to include the rest of dt:
-#define dt_alloc_align(A, B) malloc(B)
+// define dt alloc_aligned, so we don't need to include the rest of dt:
+#define dt_alloc_aligned(A, B) malloc(B)
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 // unit test for the concurrent hopscotch hashmap and the LRU cache built on top of it.

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -233,7 +233,7 @@ static void _expose_tethered_mode(dt_view_t *self, cairo_t *cr, int32_t width, i
       const uint8_t *const p_buf = cam->live_view_buffer;
 
       // draw live view image
-      uint8_t *const tmp_i = dt_alloc_aligned(sizeof(uint8_t) * pw * ph * 4);
+      uint8_t *const tmp_i = dt_alloc_align_uint8(pw * ph * 4);
       if(tmp_i)
       {
         const int stride = cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, pw);

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -233,7 +233,7 @@ static void _expose_tethered_mode(dt_view_t *self, cairo_t *cr, int32_t width, i
       const uint8_t *const p_buf = cam->live_view_buffer;
 
       // draw live view image
-      uint8_t *const tmp_i = dt_alloc_align(64, sizeof(uint8_t) * pw * ph * 4);
+      uint8_t *const tmp_i = dt_alloc_aligned(sizeof(uint8_t) * pw * ph * 4);
       if(tmp_i)
       {
         const int stride = cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, pw);


### PR DESCRIPTION
Yesterday's #15987 inspired me to implement something that's been in the back of my mind for a while now - take into account that Apple Silicon has 128-byte cache lines instead of the usual 64-byte lines, and do a bit of cleanup on the aligned allocation functions.
