### PR TITLE
thumbtable: Ensure we at least keep one thumb visible.

### DIFF
--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -903,7 +903,9 @@ static void _zoomable_zoom(dt_thumbtable_t *table,
     // we compute new position taking anchor image as reference
     th->x = anchor_posx - (anchor_x - posx) * new_size;
     th->y = anchor_posy - (anchor_y - posy) * new_size;
-    if(th->y + table->thumb_size <= 0 || th->y > table->view_height)
+    if(table->list->next
+       && (th->y + table->thumb_size <= 0
+           || th->y > table->view_height))
     {
       th_invalid = g_list_prepend(th_invalid, th);
       GList *ll = l;


### PR DESCRIPTION
Avoid crash reported in #15991.


This fixes the crash but I'm not sure it is the best fix. @AlicVB can you have a look? The thing that I don't like is that the thumbs may not start on first column / first row when zooming in again.

![image](https://github.com/darktable-org/darktable/assets/467069/8e0a5daa-3aff-46fa-9943-adf6a4a4f1cd)
