### PR TITLE
[macOS] handle rpath dependencies in package build

### DIFF
--- a/packaging/macosx/3_make_hb_darktable_package.sh
+++ b/packaging/macosx/3_make_hb_darktable_package.sh
@@ -37,6 +37,7 @@ function install_dependencies {
 
     # Handle library relative paths
     oToolLDependencies=$(echo "$oToolLDependencies" | sed "s#@loader_path#${absolutePath}#")
+    oToolLDependencies=$(echo "$oToolLDependencies" | sed "s#@rpath#${absolutePath}#")
 
     # Filter for homebrew dependencies
     if [[ "$oToolLDependencies" == *"$homebrewHome"* ]]; then


### PR DESCRIPTION
fixes #15996 

With jpeg-xl updated to 0.9.0 the handling of `@rpath` dependencies need to be changed for macOS package building.
