### PR TITLE
Fix details mask on low opencl memory

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -840,7 +840,7 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self,
 
   dt_print_pipe(DT_DEBUG_PIPE,
        "refine_detail_mask on GPU",
-       piece->pipe, self, roi_in, roi_out, "\n");
+       piece->pipe, self, roi_in, roi_out, "scharr %ix%i\n", iwidth, iheight);
 
   lum = dt_alloc_align_float((size_t)iwidth * iheight);
   out = dt_opencl_alloc_device_buffer(devid, sizeof(float) * iwidth * iheight);
@@ -878,6 +878,8 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self,
 
   dt_opencl_release_mem_object(blur);
   dt_opencl_release_mem_object(out);
+  out = NULL;
+  blur = NULL;
 
   // here we have the slightly blurred full detail mask available
   float *warp_mask = dt_dev_distort_detail_mask(p, lum, self);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2971,6 +2971,8 @@ gboolean dt_dev_write_scharr_mask(dt_dev_pixelpipe_iop_t *piece,
 {
   dt_dev_pixelpipe_t *p = piece->pipe;
   dt_dev_clear_scharr_mask(p);
+  if(piece->pipe->tiling)
+    goto error;
 
   const int width = roi_in->width;
   const int height = roi_in->height;
@@ -3011,6 +3013,9 @@ int dt_dev_write_scharr_mask_cl(dt_dev_pixelpipe_iop_t *piece,
 {
   dt_dev_pixelpipe_t *p = piece->pipe;
   dt_dev_clear_scharr_mask(p);
+
+  if(piece->pipe->tiling)
+    return DT_OPENCL_PROCESS_CL;
 
   const int width = roi_in->width;
   const int height = roi_in->height;

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1107,7 +1107,8 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
   // The details mask calculation required for dual demosaicing does not allow tiling.
   if((d->green_eq == DT_IOP_GREEN_EQ_FULL
       || d->green_eq == DT_IOP_GREEN_EQ_BOTH)
-      || (use_method & DT_DEMOSAIC_DUAL))
+      || use_method & DT_DEMOSAIC_DUAL
+      || piece->pipe->want_detail_mask)
   {
     piece->process_tiling_ready = FALSE;
   }


### PR DESCRIPTION
Due to the design of the details threshold mask we precalculate the scharr mask in demosaic module but we do **not** support doing that in tiling mode.

In #15999 and related reports in pixls and on github we ran into problems because of tiling the generated scharr mask did not cover the full roi of demosaic but just a tile of it, this lead to crashes.

Due to the way we commit parameters while preparing the pipeline we have to make sure about no tiling while committing params and also make sure in process and the cl variant.

Fixes #15999

For 4.6 and 4.8