### PR TITLE
Pixelpipe work III

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -164,6 +164,9 @@ typedef int32_t dt_imgid_t;
   INVALID_MASKID is used while testing in mask manager
 */
 
+#define DT_DEVICE_CPU -1
+#define DT_DEVICE_NONE -2
+
 typedef int32_t dt_mask_id_t;
 #define INVALID_MASKID (-1)
 #define NO_MASKID (0)

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -171,8 +171,8 @@ typedef int32_t dt_mask_id_t;
 // testing for a valid form
 #define dt_is_valid_maskid(n) ((n) > NO_MASKID)
 
-/* Helper to force stack vectors to be aligned on 64-byte blocks to enable AVX2 */
-#define DT_IS_ALIGNED(x) __builtin_assume_aligned(x, 64)
+/* Helper to force stack vectors to be aligned on DT_CACHELINE_BYTES blocks to enable AVX2 */
+#define DT_IS_ALIGNED(x) __builtin_assume_aligned(x, DT_CACHELINE_BYTES)
 
 #define DT_MODULE_VERSION 25 // version of dt's module interface
 

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -1025,7 +1025,7 @@ static void _interpolation_resample_plain(const struct dt_interpolation *itor,
   const int32_t out_stride_floats = roi_out->width * 4;
 
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
-                "resample_plain", NULL, NULL, roi_in, roi_out, "%s\n",itor->name);
+                "resample_plain", NULL, NULL, DT_DEVICE_CPU, roi_in, roi_out, "%s\n",itor->name);
   dt_times_t start = { 0 }, mid = { 0 };
   dt_get_perf_times(&start);
 
@@ -1256,7 +1256,7 @@ int dt_interpolation_resample_cl(const struct dt_interpolation *itor,
   cl_mem dev_vmeta = NULL;
 
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
-                "resample_cl", NULL, NULL, roi_in, roi_out, "%s\n", itor->name);
+                "resample", NULL, NULL, devid, roi_in, roi_out, "%s\n", itor->name);
   dt_times_t start = { 0 }, mid = { 0 };
   dt_get_perf_times(&start);
 
@@ -1393,7 +1393,7 @@ error:
   if(err == CL_SUCCESS)
     _show_2_times(&start, &mid, "resample_cl");
   else if(err != CL_INVALID_WORK_GROUP_SIZE)
-    dt_print_pipe(DT_DEBUG_OPENCL, "interpolation_resample_cl", NULL, NULL, roi_in, roi_out,
+    dt_print_pipe(DT_DEBUG_OPENCL, "interpolation_resample", NULL, NULL, devid, roi_in, roi_out,
       "Error: %s\n", cl_errstr(err));
 
   dt_opencl_release_mem_object(dev_hindex);
@@ -1446,7 +1446,7 @@ static void _interpolation_resample_1c_plain(const struct dt_interpolation *itor
   int *vmeta = NULL;
 
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE,
-                "resample_1c_plain", NULL, NULL, roi_in, roi_out, "%s\n", itor->name);
+      "resample_1c_plain", NULL, NULL, DT_DEVICE_CPU, roi_in, roi_out, "%s\n", itor->name);
   dt_times_t start = { 0 }, mid = { 0 };
   dt_get_perf_times(&start);
 

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -44,9 +44,6 @@ enum border_mode
  * unnecessary modes in interpolation codepath */
 #define INTERPOLATION_BORDER_MODE BORDER_MIRROR
 
-// Defines minimum alignment requirement for critical SIMD code
-#define SSE_ALIGNMENT 64
-
 // Defines the maximum kernel half length
 // !! Make sure to sync this with the filter array !!
 #define MAX_HALF_FILTER_WIDTH 3
@@ -868,12 +865,12 @@ static gboolean _prepare_resampling_plan(const struct dt_interpolation *itor,
   int nlengths = out;
   const int nindex = maxtapsapixel * out;
   const int nkernel = maxtapsapixel * out;
-  const size_t lengthreq = dt_round_size(nlengths * sizeof(int), SSE_ALIGNMENT);
-  const size_t indexreq = dt_round_size(nindex * sizeof(int), SSE_ALIGNMENT);
-  const size_t kernelreq = dt_round_size(nkernel * sizeof(float), SSE_ALIGNMENT);
-  const size_t scratchreq = dt_round_size(maxtapsapixel * sizeof(float) + 4 * sizeof(float), SSE_ALIGNMENT);
+  const size_t lengthreq = dt_round_size(nlengths * sizeof(int), DT_CACHELINE_BYTES);
+  const size_t indexreq = dt_round_size(nindex * sizeof(int), DT_CACHELINE_BYTES);
+  const size_t kernelreq = dt_round_size(nkernel * sizeof(float), DT_CACHELINE_BYTES);
+  const size_t scratchreq = dt_round_size(maxtapsapixel * sizeof(float) + 4 * sizeof(float), DT_CACHELINE_BYTES);
   // NB: because sse versions compute four taps a time
-  const size_t metareq = dt_round_size(pmeta ? 4 * sizeof(int) * out : 0, SSE_ALIGNMENT);
+  const size_t metareq = dt_round_size(pmeta ? 4 * sizeof(int) * out : 0, DT_CACHELINE_BYTES);
 
   const size_t totalreq = kernelreq + lengthreq + indexreq + scratchreq + metareq;
   void *blob = dt_alloc_aligned(totalreq);

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1104,7 +1104,7 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
   {
     // downsample
     dt_print_pipe(DT_DEBUG_PIPE,
-                  "mipmap clip and zoom", NULL, NULL, &roi_in, &roi_out, "\n");
+      "mipmap clip and zoom", NULL, NULL, DT_DEVICE_CPU, &roi_in, &roi_out, "\n");
     dt_iop_clip_and_zoom(out, (const float *)buf.buf, &roi_out, &roi_in);
   }
 

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -831,7 +831,7 @@ static void _refine_with_detail_mask_cl(struct dt_iop_module_t *self,
   if(p->scharr.data == NULL)
   {
     dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_OPENCL,
-       "refine_detail_mask",
+       "refine detail mask",
        piece->pipe, self, piece->pipe->devid, roi_in, roi_out, "no detail data available\n");
     return;
   }

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1876,7 +1876,7 @@ dt_iop_module_t *dt_iop_commit_blend_params(dt_iop_module_t *module,
         module->raster_mask.sink.id = blendop_params->raster_mask_id;
         dt_print_pipe(DT_DEBUG_PIPE,
                       "commit_blend_params",
-                      NULL, module, NULL, NULL, "raster mask from '%s%s' %s\n",
+                      NULL, module, DT_DEVICE_NONE, NULL, NULL, "raster mask from '%s%s' %s\n",
                       candidate->op, dt_iop_get_instance_id(candidate),
                       new ? "new" : "existing");
 
@@ -1894,7 +1894,7 @@ dt_iop_module_t *dt_iop_commit_blend_params(dt_iop_module_t *module,
   {
     dt_print_pipe(DT_DEBUG_PIPE,
                   "commit_blend_params",
-                  NULL, module, NULL, NULL, "clear raster mask source '%s%s'\n",
+                  NULL, module, DT_DEVICE_NONE, NULL, NULL, "clear raster mask source '%s%s'\n",
                   sink_source->op, dt_iop_get_instance_id(sink_source));
     g_hash_table_remove(module->raster_mask.sink.source->raster_mask.source.users, module);
   }

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -213,10 +213,10 @@ int dt_iop_clip_and_zoom_roi_cl(int devid,
 
     }
     if(err == CL_SUCCESS)
-      dt_print_pipe(DT_DEBUG_OPENCL, "clip_and_zoom_roi_cl", NULL, NULL, roi_in, roi_out,
+      dt_print_pipe(DT_DEBUG_OPENCL, "clip and zoom roi", NULL, NULL, devid, roi_in, roi_out,
           "did fast cpu fallback\n");
     else
-      dt_print_pipe(DT_DEBUG_OPENCL, "clip_and_zoom_roi_cl", NULL, NULL, roi_in, roi_out,
+      dt_print_pipe(DT_DEBUG_OPENCL, "clip and zoom roi", NULL, NULL, devid, roi_in, roi_out,
           "fast cpu fallback failing: %s\n", cl_errstr(err));
 
     dt_free_align(in);

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -347,7 +347,7 @@ gboolean dt_dev_pixelpipe_cache_get(
   cache->hash[cline]      = masking ? INVALID_CACHEHASH : hash;
 
   const dt_iop_buffer_dsc_t *cdsc = *dsc;
-  dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "pixelpipe_cache_get",
+  dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "pipe cache get",
     pipe, module, DT_DEVICE_NONE, NULL, NULL,
     "%s %sline%3i(%2i) at %p. hash=%" PRIx64 "%s\n",
      dt_iop_colorspace_to_name(cdsc->cst),
@@ -459,7 +459,7 @@ void dt_dev_pixelpipe_cache_checkmem(struct dt_dev_pixelpipe_t *pipe)
   }
 
   _cline_stats(cache);
-  dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe_cache_checkmem", pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
+  dt_print_pipe(DT_DEBUG_PIPE, "pipe cache check", pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
     "%i lines (important=%i, used=%i). Freed %iMB. Using using %iMB, limit=%iMB\n",
     cache->entries, cache->limportant, cache->lused,
     _to_mb(freed), _to_mb(cache->allmem), _to_mb(cache->memlimit));

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -263,7 +263,8 @@ static gboolean _get_by_hash(
            Anyway this has to be accepted as a dt bug so we always report
         */
         cache->hash[k] = INVALID_CACHEHASH;
-        dt_print_pipe(DT_DEBUG_ALWAYS, "CACHELINE_SIZE ERROR", pipe, module, NULL, NULL, "\n");
+        dt_print_pipe(DT_DEBUG_ALWAYS, "CACHELINE_SIZE ERROR",
+          pipe, module, DT_DEVICE_NONE, NULL, NULL, "\n");
       }
       else if(pipe->mask_display || pipe->nocache)
       {
@@ -305,7 +306,7 @@ gboolean dt_dev_pixelpipe_cache_get(
   {
     const dt_iop_buffer_dsc_t *cdsc = *dsc;
     dt_print_pipe(DT_DEBUG_PIPE, "cache HIT",
-          pipe, module, NULL, NULL,
+          pipe, module, DT_DEVICE_NONE, NULL, NULL,
           "%s, hash=%" PRIx64 "\n",
           dt_iop_colorspace_to_name(cdsc->cst), hash);
     return FALSE;
@@ -347,7 +348,7 @@ gboolean dt_dev_pixelpipe_cache_get(
 
   const dt_iop_buffer_dsc_t *cdsc = *dsc;
   dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "pixelpipe_cache_get",
-    pipe, module, NULL, NULL,
+    pipe, module, DT_DEVICE_NONE, NULL, NULL,
     "%s %sline%3i(%2i) at %p. hash=%" PRIx64 "%s\n",
      dt_iop_colorspace_to_name(cdsc->cst),
      important ? "important " : "",
@@ -458,7 +459,7 @@ void dt_dev_pixelpipe_cache_checkmem(struct dt_dev_pixelpipe_t *pipe)
   }
 
   _cline_stats(cache);
-  dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe_cache_checkmem", pipe, NULL, NULL, NULL,
+  dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe_cache_checkmem", pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
     "%i lines (important=%i, used=%i). Freed %iMB. Using using %iMB, limit=%iMB\n",
     cache->entries, cache->limportant, cache->lused,
     _to_mb(freed), _to_mb(cache->allmem), _to_mb(cache->memlimit));
@@ -469,7 +470,7 @@ void dt_dev_pixelpipe_cache_report(struct dt_dev_pixelpipe_t *pipe)
   dt_dev_pixelpipe_cache_t *cache = &(pipe->cache);
 
   _cline_stats(cache);
-  dt_print_pipe(DT_DEBUG_PIPE, "cache report", pipe, NULL, NULL, NULL,
+  dt_print_pipe(DT_DEBUG_PIPE, "cache report", pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
     "%i lines (important=%i, used=%i, invalid=%i). Using %iMB, limit=%iMB. Hits/run=%.2f. Hits/test=%.3f\n",
     cache->entries, cache->limportant, cache->lused, cache->linvalid,
     _to_mb(cache->allmem), _to_mb(cache->memlimit),

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -143,7 +143,7 @@ void dt_print_pipe_ext(const char *title,
   vsnprintf(vbuf, sizeof(vbuf), msg, ap);
   va_end(ap);
 
-  dt_print_ext("%-26s %-3s %-16s %-22s %s%s%s%s",
+  dt_print_ext("%-25s %-3s %-16s %-22s %s%s%s%s",
                vtit, dev, pname, vmod, roi, roo, masking, vbuf);
 }
 
@@ -504,14 +504,14 @@ void dt_dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe,
                " history copy&paste"),
              NULL);
 
-        dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe synch problem",
+        dt_print_pipe(DT_DEBUG_PIPE, "pipe synch problem",
           pipe, piece->module, DT_DEVICE_NONE, NULL, NULL,
           "piece enabling mismatch for image %i, piece hash=%" PRIx64 ", \n",
           imgid, piece->hash);
       }
       dt_iop_commit_params(hist->module, hist->params, hist->blend_params, pipe, piece);
 
-      dt_print_pipe(DT_DEBUG_PARAMS, "committed params",
+      dt_print_pipe(DT_DEBUG_PARAMS, "commit params",
           pipe, piece->module, DT_DEVICE_NONE, NULL, NULL,
           "piece hash=%" PRIx64 ", \n", piece->hash);
 
@@ -532,7 +532,7 @@ void dt_dev_pixelpipe_synch_all(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
   double start = dt_get_debug_wtime();
 
   dev->cropping.exposer = NULL;
-  dt_print_pipe(DT_DEBUG_PARAMS, "synch all modules with defaults",
+  dt_print_pipe(DT_DEBUG_PARAMS, "synch all module defaults",
     pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "\n");
 
   // call reset_params on all pieces first. This is mandatory to init
@@ -549,7 +549,7 @@ void dt_dev_pixelpipe_synch_all(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
   }
   double defaults = dt_get_debug_wtime();
 
-  dt_print_pipe(DT_DEBUG_PARAMS, "synch all modules with history",
+  dt_print_pipe(DT_DEBUG_PARAMS, "synch all module history",
     pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "\n");
 
   // go through all history items and adjust params
@@ -560,7 +560,7 @@ void dt_dev_pixelpipe_synch_all(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
     history = g_list_next(history);
   }
   dt_print_pipe(DT_DEBUG_PIPE,
-           "dt_dev_pixelpipe_synch_all",
+           "synch all modules done",
            pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
            "defaults %.4fs, history %.4fs\n",
            defaults - start, dt_get_wtime() - defaults);
@@ -590,7 +590,7 @@ void dt_dev_pixelpipe_change(dt_dev_pixelpipe_t *pipe, struct dt_develop_t *dev)
 {
   dt_pthread_mutex_lock(&dev->history_mutex);
 
-  dt_print_pipe(DT_DEBUG_PARAMS, "pipeline state changing",
+  dt_print_pipe(DT_DEBUG_PARAMS, "pipe state changing",
       pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "flag = %d\n", pipe->changed);
   // case DT_DEV_PIPE_UNCHANGED: case DT_DEV_PIPE_ZOOMED:
   if(pipe->changed & DT_DEV_PIPE_TOP_CHANGED)
@@ -1210,7 +1210,7 @@ static gboolean _pixelpipe_process_on_CPU(
   else
   {
     dt_print_pipe(DT_DEBUG_PIPE,
-       "pixelpipe process",
+       "pipe process",
        piece->pipe, module, DT_DEVICE_CPU, roi_in, roi_out, "%s%s%s%s\n",
        dt_iop_colorspace_to_name(cst_to),
        cst_to != cst_out ? " -> " : "",
@@ -1418,7 +1418,7 @@ static gboolean _dev_pixelpipe_process_rec(
       return TRUE;
 
     dt_print_pipe(DT_DEBUG_PIPE,
-        "pixelpipe data: from cache", pipe, module, DT_DEVICE_NONE, &roi_in, NULL, "\n");
+        "pipe data: from cache", pipe, module, DT_DEVICE_NONE, &roi_in, NULL, "\n");
     // we're done! as colorpicker/scopes only work on gamma iop
     // input -- which is unavailable via cache -- there's no need to
     // run these
@@ -1451,7 +1451,7 @@ static gboolean _dev_pixelpipe_process_rec(
     {
       *output = pipe->input;
       dt_print_pipe(DT_DEBUG_PIPE,
-          "pixelpipe data: full", pipe, module, DT_DEVICE_NONE, &roi_in, roi_out, "\n");
+          "pipe data: full", pipe, module, DT_DEVICE_NONE, &roi_in, roi_out, "\n");
     }
     else if(dt_dev_pixelpipe_cache_get(pipe, hash, bufsize,
                                        output, out_format, NULL, FALSE))
@@ -1491,7 +1491,7 @@ static gboolean _dev_pixelpipe_process_rec(
         roi_in.scale = 1.0f;
         const gboolean valid_bpp = (bpp == 4 * sizeof(float));
         dt_print_pipe(DT_DEBUG_PIPE,
-          "pixelpipe data: clip&zoom", pipe, module, DT_DEVICE_CPU, &roi_in, roi_out, "%s\n",
+          "pipe data: clip&zoom", pipe, module, DT_DEVICE_CPU, &roi_in, roi_out, "%s\n",
           valid_bpp ? "" : "requires 4 floats data");
         if(valid_bpp)
           dt_iop_clip_and_zoom(*output, pipe->input, roi_out, &roi_in);
@@ -1577,7 +1577,7 @@ static gboolean _dev_pixelpipe_process_rec(
      && !memcmp(&roi_in, roi_out, sizeof(struct dt_iop_roi_t)))
   {
     dt_print_pipe(DT_DEBUG_PIPE,
-                    "pixelpipe bypass", pipe, module, DT_DEVICE_NONE, &roi_in, roi_out, "\n");
+                    "pipe bypass", pipe, module, DT_DEVICE_NONE, &roi_in, roi_out, "\n");
     // since we're not actually running the module, the output format
     // is the same as the input format
     **out_format = pipe->dsc = piece->dsc_out = piece->dsc_in;
@@ -1726,7 +1726,7 @@ static gboolean _dev_pixelpipe_process_rec(
                                               roi_in.width, roi_in.height, in_bpp) != CL_SUCCESS)
             {
               dt_print_pipe(DT_DEBUG_OPENCL,
-                "pixelpipe process", pipe, module, pipe->devid, &roi_in, roi_out, "%s\n",
+                "pipe process", pipe, module, pipe->devid, &roi_in, roi_out, "%s\n",
                   "couldn't copy image to OpenCL device");
               success_opencl = FALSE;
             }
@@ -1813,7 +1813,7 @@ static gboolean _dev_pixelpipe_process_rec(
         if(success_opencl)
         {
           dt_print_pipe(DT_DEBUG_PIPE,
-                        "pixelpipe process",
+                        "pipe process",
                         piece->pipe, module, pipe->devid, &roi_in, roi_out, "%s%s%s\n",
                         dt_iop_colorspace_to_name(cst_to),
                         cst_to != cst_out ? " -> " : "",
@@ -1972,7 +1972,7 @@ static gboolean _dev_pixelpipe_process_rec(
                                                            in_bpp) != CL_SUCCESS)
           {
             dt_print_pipe(DT_DEBUG_OPENCL,
-              "pixelpipe process", pipe, module, pipe->devid, &roi_in, roi_out, "%s\n",
+              "pipe process", pipe, module, pipe->devid, &roi_in, roi_out, "%s\n",
                 "couldn't copy data back to host memory (A)");
             dt_opencl_release_mem_object(cl_mem_input);
             pipe->opencl_error = TRUE;
@@ -2150,7 +2150,7 @@ static gboolean _dev_pixelpipe_process_rec(
             {
               important_cl = FALSE;
               dt_print_pipe(DT_DEBUG_OPENCL,
-                "pixelpipe process", pipe, module, pipe->devid, &roi_in, roi_out, "%s\n",
+                "pipe process", pipe, module, pipe->devid, &roi_in, roi_out, "%s\n",
                   "couldn't copy important data back to host memory (B)");
               /* late opencl error, not likely to happen here */
               /* that's all we do here, we later make sure to invalidate cache line */
@@ -2188,7 +2188,7 @@ static gboolean _dev_pixelpipe_process_rec(
       {
         /* Bad luck, opencl failed. Let's clean up and fall back to cpu module */
         dt_print_pipe(DT_DEBUG_OPENCL,
-           "pixelpipe aborts", pipe, module, pipe->devid, &roi_in, roi_out, "%s\n",
+           "pipe aborts", pipe, module, pipe->devid, &roi_in, roi_out, "%s\n",
                 "couldn't run module on GPU, falling back to CPU");
 
         /* we might need to free unused output buffer */
@@ -2243,7 +2243,7 @@ static gboolean _dev_pixelpipe_process_rec(
                                          in_bpp) != CL_SUCCESS)
         {
           dt_print_pipe(DT_DEBUG_OPENCL,
-            "pixelpipe process", pipe, module, pipe->devid, &roi_in, roi_out, "%s\n",
+            "pipe process", pipe, module, pipe->devid, &roi_in, roi_out, "%s\n",
               "couldn't copy data back to host memory (D)");
           dt_opencl_release_mem_object(cl_mem_input);
           pipe->opencl_error = TRUE;
@@ -2645,11 +2645,13 @@ restart:
 
 #ifdef HAVE_OPENCL
   if(pipe->devid >= 0)
-    dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe starting", pipe, NULL, pipe->devid, &roi, &roi, "%s\n",
+    dt_print_pipe(DT_DEBUG_PIPE, "pipe starting", pipe, NULL, pipe->devid, &roi, &roi, "ID %i, %s\n",
+      pipe->image.id,
       darktable.opencl->dev[pipe->devid].cname);
   else
 #endif
-    dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe starting", pipe, NULL, pipe->devid, &roi, &roi, "\n");
+    dt_print_pipe(DT_DEBUG_PIPE, "pipe starting", pipe, NULL, pipe->devid, &roi, &roi, "ID %i\n",
+      pipe->image.id);
 
   // run pixelpipe recursively and get error status
   const gboolean err = _dev_pixelpipe_process_rec_and_backcopy(pipe, dev, &buf,
@@ -2701,7 +2703,7 @@ restart:
     dt_dev_pixelpipe_change(pipe, dev);
 
     dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_OPENCL,
-      "pixelpipe restarting on CPU", pipe, NULL, old_devid, &roi, &roi, "\n");
+      "pipe restarting on CPU", pipe, NULL, old_devid, &roi, &roi, "\n");
 
     goto restart; // try again (this time without opencl)
   }
@@ -2755,7 +2757,7 @@ restart:
 
   dt_dev_pixelpipe_cache_report(pipe);
 
-  dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe finished", pipe, NULL, old_devid, &roi, &roi, "\n\n");
+  dt_print_pipe(DT_DEBUG_PIPE, "pipe finished", pipe, NULL, old_devid, &roi, &roi, "\n\n");
 
   pipe->processing = FALSE;
   return FALSE;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -93,12 +93,14 @@ const char *dt_dev_pixelpipe_type_to_str(const int pipe_type)
 void dt_print_pipe_ext(const char *title,
                        const dt_dev_pixelpipe_t *pipe,
                        const struct dt_iop_module_t *module,
+                       const int device,
                        const dt_iop_roi_t *roi_in,
                        const dt_iop_roi_t *roi_out,
                        const char *msg, ...)
 {
   char vtit[128];
   char vmod[128];
+  char dev[32] = { 0 };
   char vbuf[1024] = { 0 };
   char roi[128] = { 0 };
   char roo[128] = { 0 };
@@ -110,6 +112,11 @@ void dt_print_pipe_ext(const char *title,
   snprintf(vmod, sizeof(vmod), "%s%s",
     module ? module->op : "",
     module ? dt_iop_get_instance_id(module) : "");
+
+  if(device == DT_DEVICE_CPU)
+    snprintf(dev, sizeof(dev), "CPU");
+  else if(device > DT_DEVICE_CPU)
+    snprintf(dev, sizeof(dev), "CL%i", device);
 
   if(roi_in)
     snprintf(roi, sizeof(roi),
@@ -136,8 +143,8 @@ void dt_print_pipe_ext(const char *title,
   vsnprintf(vbuf, sizeof(vbuf), msg, ap);
   va_end(ap);
 
-  dt_print_ext("%-26s %-16s %-22s %s%s%s%s",
-               vtit, pname, vmod, roi, roo, masking, vbuf);
+  dt_print_ext("%-26s %-3s %-16s %-22s %s%s%s%s",
+               vtit, dev, pname, vmod, roi, roo, masking, vbuf);
 }
 
 gboolean dt_dev_pixelpipe_init_export(dt_dev_pixelpipe_t *pipe,
@@ -207,7 +214,7 @@ gboolean dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe,
                                       const int32_t entries,
                                       const size_t memlimit)
 {
-  pipe->devid = -1;
+  pipe->devid = DT_DEVICE_CPU;
   pipe->loading = FALSE;
   pipe->input_changed = FALSE;
   pipe->changed = DT_DEV_PIPE_UNCHANGED;
@@ -498,14 +505,14 @@ void dt_dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe,
              NULL);
 
         dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe synch problem",
-          pipe, piece->module, NULL, NULL,
+          pipe, piece->module, DT_DEVICE_NONE, NULL, NULL,
           "piece enabling mismatch for image %i, piece hash=%" PRIx64 ", \n",
           imgid, piece->hash);
       }
       dt_iop_commit_params(hist->module, hist->params, hist->blend_params, pipe, piece);
 
       dt_print_pipe(DT_DEBUG_PARAMS, "committed params",
-          pipe, piece->module, NULL, NULL,
+          pipe, piece->module, DT_DEVICE_NONE, NULL, NULL,
           "piece hash=%" PRIx64 ", \n", piece->hash);
 
       if(piece->blendop_data)
@@ -526,7 +533,7 @@ void dt_dev_pixelpipe_synch_all(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
 
   dev->cropping.exposer = NULL;
   dt_print_pipe(DT_DEBUG_PARAMS, "synch all modules with defaults",
-    pipe, NULL, NULL, NULL, "\n");
+    pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "\n");
 
   // call reset_params on all pieces first. This is mandatory to init
   // utility modules that don't have an history stack
@@ -543,7 +550,7 @@ void dt_dev_pixelpipe_synch_all(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
   double defaults = dt_get_debug_wtime();
 
   dt_print_pipe(DT_DEBUG_PARAMS, "synch all modules with history",
-    pipe, NULL, NULL, NULL, "\n");
+    pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "\n");
 
   // go through all history items and adjust params
   GList *history = dev->history;
@@ -554,7 +561,7 @@ void dt_dev_pixelpipe_synch_all(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
   }
   dt_print_pipe(DT_DEBUG_PIPE,
            "dt_dev_pixelpipe_synch_all",
-           pipe, NULL, NULL, NULL,
+           pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
            "defaults %.4fs, history %.4fs\n",
            defaults - start, dt_get_wtime() - defaults);
   dt_pthread_mutex_unlock(&pipe->busy_mutex);
@@ -568,13 +575,13 @@ void dt_dev_pixelpipe_synch_top(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
   {
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)history->data;
     dt_print_pipe(DT_DEBUG_PARAMS, "synch top history module",
-      pipe, hist->module, NULL, NULL, "\n");
+      pipe, hist->module, DT_DEVICE_NONE, NULL, NULL, "\n");
     dt_dev_pixelpipe_synch(pipe, dev, history);
   }
   else
   {
     dt_print_pipe(DT_DEBUG_PARAMS, "synch top history module missing!",
-      pipe, NULL, NULL, NULL, "\n");
+      pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "\n");
   }
   dt_pthread_mutex_unlock(&pipe->busy_mutex);
 }
@@ -584,7 +591,7 @@ void dt_dev_pixelpipe_change(dt_dev_pixelpipe_t *pipe, struct dt_develop_t *dev)
   dt_pthread_mutex_lock(&dev->history_mutex);
 
   dt_print_pipe(DT_DEBUG_PARAMS, "pipeline state changing",
-      pipe, NULL, NULL, NULL, "flag = %d\n", pipe->changed);
+      pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "flag = %d\n", pipe->changed);
   // case DT_DEV_PIPE_UNCHANGED: case DT_DEV_PIPE_ZOOMED:
   if(pipe->changed & DT_DEV_PIPE_TOP_CHANGED)
   {
@@ -1153,8 +1160,8 @@ static gboolean _pixelpipe_process_on_CPU(
 
   if(cst_from != cst_to)
     dt_print_pipe(DT_DEBUG_PIPE,
-           "transform colorspace CPU",
-           piece->pipe, module, roi_in, NULL, " %s -> %s\n",
+           "transform colorspace",
+           piece->pipe, module, DT_DEVICE_CPU, roi_in, NULL, " %s -> %s\n",
            dt_iop_colorspace_to_name(cst_from),
            dt_iop_colorspace_to_name(cst_to));
 
@@ -1193,7 +1200,7 @@ static gboolean _pixelpipe_process_on_CPU(
   if(!fitting && piece->process_tiling_ready)
   {
     dt_print_pipe(DT_DEBUG_PIPE,
-                  "process TILE", piece->pipe, module, roi_in, roi_out, "\n");
+                  "process TILE", piece->pipe, module, DT_DEVICE_CPU, roi_in, roi_out, "\n");
     module->process_tiling(module, piece, input, *output, roi_in, roi_out, in_bpp);
 
     *pixelpipe_flow |= (PIXELPIPE_FLOW_PROCESSED_ON_CPU
@@ -1203,8 +1210,8 @@ static gboolean _pixelpipe_process_on_CPU(
   else
   {
     dt_print_pipe(DT_DEBUG_PIPE,
-       "pixelpipe process CPU",
-       piece->pipe, module, roi_in, roi_out, "%s%s%s%s\n",
+       "pixelpipe process",
+       piece->pipe, module, DT_DEVICE_CPU, roi_in, roi_out, "%s%s%s%s\n",
        dt_iop_colorspace_to_name(cst_to),
        cst_to != cst_out ? " -> " : "",
        cst_to != cst_out ? dt_iop_colorspace_to_name(cst_out) : "",
@@ -1411,7 +1418,7 @@ static gboolean _dev_pixelpipe_process_rec(
       return TRUE;
 
     dt_print_pipe(DT_DEBUG_PIPE,
-                  "pixelpipe data: from cache", pipe, module, &roi_in, NULL, "\n");
+        "pixelpipe data: from cache", pipe, module, DT_DEVICE_NONE, &roi_in, NULL, "\n");
     // we're done! as colorpicker/scopes only work on gamma iop
     // input -- which is unavailable via cache -- there's no need to
     // run these
@@ -1444,7 +1451,7 @@ static gboolean _dev_pixelpipe_process_rec(
     {
       *output = pipe->input;
       dt_print_pipe(DT_DEBUG_PIPE,
-                    "pixelpipe data: full", pipe, module, &roi_in, roi_out, "\n");
+          "pixelpipe data: full", pipe, module, DT_DEVICE_NONE, &roi_in, roi_out, "\n");
     }
     else if(dt_dev_pixelpipe_cache_get(pipe, hash, bufsize,
                                        output, out_format, NULL, FALSE))
@@ -1460,7 +1467,7 @@ static gboolean _dev_pixelpipe_process_rec(
         const int cp_height = MIN(roi_out->height, pipe->iheight - in_y);
         dt_print_pipe(DT_DEBUG_PIPE,
           (cp_width > 0) ? "pixelpipe data: 1:1 copied" : "pixelpipe data: 1:1 none",
-          pipe, module, &roi_in, roi_out, "bpp=%lu\n", bpp);
+          pipe, module, DT_DEVICE_NONE, &roi_in, roi_out, "bpp=%lu\n", bpp);
         if(cp_width > 0)
         {
 #ifdef _OPENMP
@@ -1484,7 +1491,7 @@ static gboolean _dev_pixelpipe_process_rec(
         roi_in.scale = 1.0f;
         const gboolean valid_bpp = (bpp == 4 * sizeof(float));
         dt_print_pipe(DT_DEBUG_PIPE,
-          "pixelpipe data: clip&zoom", pipe, module, &roi_in, roi_out, "%s\n",
+          "pixelpipe data: clip&zoom", pipe, module, DT_DEVICE_CPU, &roi_in, roi_out, "%s\n",
           valid_bpp ? "" : "requires 4 floats data");
         if(valid_bpp)
           dt_iop_clip_and_zoom(*output, pipe->input, roi_out, &roi_in);
@@ -1508,7 +1515,7 @@ static gboolean _dev_pixelpipe_process_rec(
   module->modify_roi_in(module, piece, roi_out, &roi_in);
   if((darktable.unmuted & DT_DEBUG_PIPE) && memcmp(roi_out, &roi_in, sizeof(dt_iop_roi_t)))
     dt_print_pipe(DT_DEBUG_PIPE,
-                  "modify roi IN", piece->pipe, module, &roi_in, roi_out, "\n");
+                  "modify roi IN", piece->pipe, module, DT_DEVICE_NONE, &roi_in, roi_out, "\n");
   // recurse to get actual data of input buffer
 
   dt_iop_buffer_dsc_t _input_format = { 0 };
@@ -1570,7 +1577,7 @@ static gboolean _dev_pixelpipe_process_rec(
      && !memcmp(&roi_in, roi_out, sizeof(struct dt_iop_roi_t)))
   {
     dt_print_pipe(DT_DEBUG_PIPE,
-                    "pixelpipe bypass", pipe, module, &roi_in, roi_out, "\n");
+                    "pixelpipe bypass", pipe, module, DT_DEVICE_NONE, &roi_in, roi_out, "\n");
     // since we're not actually running the module, the output format
     // is the same as the input format
     **out_format = pipe->dsc = piece->dsc_out = piece->dsc_in;
@@ -1719,7 +1726,7 @@ static gboolean _dev_pixelpipe_process_rec(
                                               roi_in.width, roi_in.height, in_bpp) != CL_SUCCESS)
             {
               dt_print_pipe(DT_DEBUG_OPENCL,
-                "pixelpipe process CL", pipe, module, &roi_in, roi_out, "%s\n",
+                "pixelpipe process", pipe, module, pipe->devid, &roi_in, roi_out, "%s\n",
                   "couldn't copy image to OpenCL device");
               success_opencl = FALSE;
             }
@@ -1752,7 +1759,7 @@ static gboolean _dev_pixelpipe_process_rec(
         {
           if(cst_from != cst_to)
             dt_print_pipe(DT_DEBUG_PIPE,
-               "transform colorspace CL", piece->pipe, module, &roi_in, NULL, " %s -> %s\n",
+               "transform colorspace", piece->pipe, module, pipe->devid, &roi_in, NULL, " %s -> %s\n",
                dt_iop_colorspace_to_name(cst_from),
                dt_iop_colorspace_to_name(cst_to));
           success_opencl = dt_ioppr_transform_image_colorspace_cl
@@ -1806,8 +1813,8 @@ static gboolean _dev_pixelpipe_process_rec(
         if(success_opencl)
         {
           dt_print_pipe(DT_DEBUG_PIPE,
-                        "pixelpipe process CL",
-                        piece->pipe, module, &roi_in, roi_out, "%s%s%s\n",
+                        "pixelpipe process",
+                        piece->pipe, module, pipe->devid, &roi_in, roi_out, "%s%s%s\n",
                         dt_iop_colorspace_to_name(cst_to),
                         cst_to != cst_out ? " -> " : "",
                         cst_to != cst_out ? dt_iop_colorspace_to_name(cst_out) : "");
@@ -1864,7 +1871,7 @@ static gboolean _dev_pixelpipe_process_rec(
 
           if(!success_opencl)
             dt_print_pipe(DT_DEBUG_OPENCL,
-              "Error: process_CL", piece->pipe, module, &roi_in, roi_out,
+              "Error: process", piece->pipe, module, pipe->devid, &roi_in, roi_out,
               "device=%i (%s), %s\n",
               pipe->devid, darktable.opencl->dev[pipe->devid].cname, cl_errstr(err));
 
@@ -1965,7 +1972,7 @@ static gboolean _dev_pixelpipe_process_rec(
                                                            in_bpp) != CL_SUCCESS)
           {
             dt_print_pipe(DT_DEBUG_OPENCL,
-              "pixelpipe process CL", pipe, module, &roi_in, roi_out, "%s\n",
+              "pixelpipe process", pipe, module, pipe->devid, &roi_in, roi_out, "%s\n",
                 "couldn't copy data back to host memory (A)");
             dt_opencl_release_mem_object(cl_mem_input);
             pipe->opencl_error = TRUE;
@@ -2016,7 +2023,7 @@ static gboolean _dev_pixelpipe_process_rec(
 
           if(!success_opencl)
             dt_print_pipe(DT_DEBUG_OPENCL,
-              "Error: process_tiling_CL", piece->pipe, module, &roi_in, roi_out,
+              "Error: process_tiling", piece->pipe, module, pipe->devid, &roi_in, roi_out,
               "device=%i (%s), %s\n",
               pipe->devid, darktable.opencl->dev[pipe->devid].cname, cl_errstr(err));
 
@@ -2143,7 +2150,7 @@ static gboolean _dev_pixelpipe_process_rec(
             {
               important_cl = FALSE;
               dt_print_pipe(DT_DEBUG_OPENCL,
-                "pixelpipe process CL", pipe, module, &roi_in, roi_out, "%s\n",
+                "pixelpipe process", pipe, module, pipe->devid, &roi_in, roi_out, "%s\n",
                   "couldn't copy important data back to host memory (B)");
               /* late opencl error, not likely to happen here */
               /* that's all we do here, we later make sure to invalidate cache line */
@@ -2151,7 +2158,7 @@ static gboolean _dev_pixelpipe_process_rec(
             else
             {
               dt_print_pipe(DT_DEBUG_PIPE,
-                "copy CL data to host", pipe, module, &roi_in, NULL, "\n");
+                "copy CL data to host", pipe, module, pipe->devid, &roi_in, NULL, "\n");
               /* success: cache line is valid now, so we will not need
                  to invalidate it later */
               valid_input_on_gpu_only = FALSE;
@@ -2181,7 +2188,7 @@ static gboolean _dev_pixelpipe_process_rec(
       {
         /* Bad luck, opencl failed. Let's clean up and fall back to cpu module */
         dt_print_pipe(DT_DEBUG_OPENCL,
-           "pixelpipe aborts CL", pipe, module, &roi_in, roi_out, "%s\n",
+           "pixelpipe aborts", pipe, module, pipe->devid, &roi_in, roi_out, "%s\n",
                 "couldn't run module on GPU, falling back to CPU");
 
         /* we might need to free unused output buffer */
@@ -2199,7 +2206,7 @@ static gboolean _dev_pixelpipe_process_rec(
                                            in_bpp) != CL_SUCCESS)
           {
             dt_print_pipe(DT_DEBUG_OPENCL,
-              "pixelpipe process CL", pipe, module, &roi_in, roi_out, "%s\n",
+              "pixelpipe process", pipe, module, pipe->devid, &roi_in, roi_out, "%s\n",
                 "couldn't copy data back to host memory (C)");
             dt_opencl_release_mem_object(cl_mem_input);
             pipe->opencl_error = TRUE;
@@ -2236,7 +2243,7 @@ static gboolean _dev_pixelpipe_process_rec(
                                          in_bpp) != CL_SUCCESS)
         {
           dt_print_pipe(DT_DEBUG_OPENCL,
-            "pixelpipe process CL", pipe, module, &roi_in, roi_out, "%s\n",
+            "pixelpipe process", pipe, module, pipe->devid, &roi_in, roi_out, "%s\n",
               "couldn't copy data back to host memory (D)");
           dt_opencl_release_mem_object(cl_mem_input);
           pipe->opencl_error = TRUE;
@@ -2324,7 +2331,7 @@ static gboolean _dev_pixelpipe_process_rec(
         && (has_focus || darktable.develop->history_last_module == module || important_cl))
     {
       dt_print_pipe(DT_DEBUG_PIPE,
-        "importance hints", pipe, module, &roi_in, NULL, " %s%s%s\n",
+        "importance hints", pipe, module, pipe->devid, &roi_in, NULL, " %s%s%s\n",
         darktable.develop->history_last_module == module ? "input_hint " : "",
         has_focus ? "focus " : "",
         important_cl ? "cldata" : "");
@@ -2338,7 +2345,7 @@ static gboolean _dev_pixelpipe_process_rec(
        && (pipe->type & DT_DEV_PIXELPIPE_BASIC)
        && (module->request_histogram & DT_REQUEST_EXPANDED))
     {
-      dt_print_pipe(DT_DEBUG_PIPE, "internal histogram", pipe, module, &roi_in, roi_out, "\n");
+      dt_print_pipe(DT_DEBUG_PIPE, "internal histogram", pipe, module, DT_DEVICE_NONE, &roi_in, roi_out, "\n");
       pipe->nocache = TRUE;
       dt_dev_pixelpipe_invalidate_cacheline(pipe, *output);
     }
@@ -2593,7 +2600,7 @@ gboolean dt_dev_pixelpipe_process(
   pipe->runs++;
   pipe->opencl_enabled = dt_opencl_running();
   pipe->devid = (pipe->opencl_enabled) ? dt_opencl_lock_device(pipe->type)
-                                       : -1; // try to get/lock opencl resource
+                                       : DT_DEVICE_CPU; // try to get/lock opencl resource
 
   dt_dev_pixelpipe_cache_checkmem(pipe);
 
@@ -2638,18 +2645,17 @@ restart:
 
 #ifdef HAVE_OPENCL
   if(pipe->devid >= 0)
-    dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe starting CL", pipe, NULL, &roi, &roi, "device=%i (%s)\n",
-      pipe->devid, darktable.opencl->dev[pipe->devid].cname);
+    dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe starting", pipe, NULL, pipe->devid, &roi, &roi, "%s\n",
+      darktable.opencl->dev[pipe->devid].cname);
   else
 #endif
-    dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe starting on CPU", pipe, NULL, &roi, &roi, "\n");
+    dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe starting", pipe, NULL, pipe->devid, &roi, &roi, "\n");
 
   // run pixelpipe recursively and get error status
   const gboolean err = _dev_pixelpipe_process_rec_and_backcopy(pipe, dev, &buf,
                                                                &cl_mem_out, &out_format,
                                                                &roi,
                                                                modules, pieces, pos);
-
   // get status summary of opencl queue by checking the eventlist
   const gboolean oclerr = (pipe->devid >= 0)
                           ? (dt_opencl_events_flush(pipe->devid, TRUE) != 0)
@@ -2659,7 +2665,7 @@ restart:
   // remark: opencl errors can come in two ways:
   // processed pipe->opencl_error checked via 'err'
   // OpenCL events so oclerr is TRUE
-
+  const int old_devid = pipe->devid;
   if(oclerr || (err && pipe->opencl_error))
   {
     // Well, there were errors -> we might need to free an invalid opencl memory object
@@ -2668,7 +2674,7 @@ restart:
     dt_pthread_mutex_lock(&pipe->busy_mutex);
     pipe->opencl_enabled = FALSE; // disable opencl for this pipe
     pipe->opencl_error = FALSE;   // reset error status
-    pipe->devid = -1;
+    pipe->devid = DT_DEVICE_CPU;
     dt_pthread_mutex_unlock(&pipe->busy_mutex);
 
     darktable.opencl->error_count++; // increase error count
@@ -2695,7 +2701,7 @@ restart:
     dt_dev_pixelpipe_change(pipe, dev);
 
     dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_OPENCL,
-      "pixelpipe restarting on CPU", pipe, NULL, &roi, &roi, "\n");
+      "pixelpipe restarting on CPU", pipe, NULL, old_devid, &roi, &roi, "\n");
 
     goto restart; // try again (this time without opencl)
   }
@@ -2709,7 +2715,7 @@ restart:
   if(pipe->devid >= 0)
   {
     dt_opencl_unlock_device(pipe->devid);
-    pipe->devid = -1;
+    pipe->devid = DT_DEVICE_CPU;
   }
   // ... and in case of other errors ...
   if(err)
@@ -2749,7 +2755,7 @@ restart:
 
   dt_dev_pixelpipe_cache_report(pipe);
 
-  dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe finished", pipe, NULL, &roi, &roi, "\n\n");
+  dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe finished", pipe, NULL, old_devid, &roi, &roi, "\n\n");
 
   pipe->processing = FALSE;
   return FALSE;
@@ -2780,7 +2786,7 @@ void dt_dev_pixelpipe_get_dimensions(dt_dev_pixelpipe_t *pipe,
       module->modify_roi_out(module, piece, &roi_out, &roi_in);
       if((darktable.unmuted & DT_DEBUG_PIPE) && memcmp(&roi_out, &roi_in, sizeof(dt_iop_roi_t)))
       dt_print_pipe(DT_DEBUG_PIPE,
-                  "modify roi OUT", piece->pipe, module, &roi_in, &roi_out, "\n");
+                  "modify roi OUT", piece->pipe, module, DT_DEVICE_NONE, &roi_in, &roi_out, "\n");
     }
     else
     {
@@ -2865,7 +2871,7 @@ float *dt_dev_get_raster_mask(const struct dt_dev_pixelpipe_iop_t *piece,
     if(!source_enabled)
     {
       dt_print_pipe(DT_DEBUG_PIPE,
-         "no raster found", piece->pipe, piece->module, NULL, NULL,
+         "no raster found", piece->pipe, piece->module, DT_DEVICE_NONE, NULL, NULL,
          "source module `%s%s' is disabled\n",
          raster_mask_source->op, dt_iop_get_instance_id(raster_mask_source));
       return NULL;
@@ -2877,7 +2883,7 @@ float *dt_dev_get_raster_mask(const struct dt_dev_pixelpipe_iop_t *piece,
       if(!raster_mask)
       {
         dt_print_pipe(DT_DEBUG_PIPE,
-          "no raster mask found", piece->pipe, piece->module, NULL, NULL,
+          "no raster mask found", piece->pipe, piece->module, DT_DEVICE_NONE, NULL, NULL,
           "raster mask seems to be lost in module `%s%s'\n",
           raster_mask_source->op, dt_iop_get_instance_id(raster_mask_source));
         return NULL;
@@ -2920,7 +2926,7 @@ float *dt_dev_get_raster_mask(const struct dt_dev_pixelpipe_iop_t *piece,
               {
                 dt_print_pipe(DT_DEBUG_ALWAYS,
                       "no distort raster mask",
-                      piece->pipe, it_piece->module,
+                      piece->pipe, it_piece->module, DT_DEVICE_NONE,
                       &it_piece->processed_roi_in, &it_piece->processed_roi_out,
                       "skipped transforming mask due to lack of memory\n");
                 return NULL;
@@ -2934,7 +2940,7 @@ float *dt_dev_get_raster_mask(const struct dt_dev_pixelpipe_iop_t *piece,
             {
               dt_print_pipe(DT_DEBUG_ALWAYS,
                       "distort raster mask",
-                      piece->pipe, it_piece->module,
+                      piece->pipe, it_piece->module, DT_DEVICE_NONE,
                       &it_piece->processed_roi_in, &it_piece->processed_roi_out,
                       "misses distort_mask() function\n");
               return NULL;
@@ -2950,7 +2956,7 @@ float *dt_dev_get_raster_mask(const struct dt_dev_pixelpipe_iop_t *piece,
   }
 
   dt_print_pipe(DT_DEBUG_PIPE,
-                "got raster mask", piece->pipe, target_module, NULL, NULL,
+                "got raster mask", piece->pipe, target_module, DT_DEVICE_NONE, NULL, NULL,
                 "from module `%s%s' %s\n",
                 raster_mask_source->op, dt_iop_get_instance_id(raster_mask_source),
                 *free_mask ? "distorted" : "");
@@ -2991,7 +2997,7 @@ gboolean dt_dev_write_scharr_mask(dt_dev_pixelpipe_iop_t *piece,
 
   p->scharr.hash = dt_hash(DT_INITHASH, &p->scharr.roi, sizeof(dt_iop_roi_t));
 
-  dt_print_pipe(DT_DEBUG_PIPE, "write scharr mask CPU", p, NULL, roi_in, NULL, "\n");
+  dt_print_pipe(DT_DEBUG_PIPE, "write scharr mask", p, NULL, DT_DEVICE_CPU, roi_in, NULL, "\n");
   if(darktable.dump_pfm_module && (piece->pipe->type & DT_DEV_PIXELPIPE_EXPORT))
     dt_dump_pfm("scharr_cpu", mask, width, height, sizeof(float), "detail");
 
@@ -2999,7 +3005,7 @@ gboolean dt_dev_write_scharr_mask(dt_dev_pixelpipe_iop_t *piece,
 
   error:
   dt_print_pipe(DT_DEBUG_ALWAYS,
-           "write scharr mask CPU", p, NULL, roi_in, NULL,
+           "write scharr mask", p, NULL, DT_DEVICE_CPU, roi_in, NULL,
            "couldn't write detail mask\n");
   dt_dev_clear_scharr_mask(p);
   return TRUE;
@@ -3059,7 +3065,7 @@ int dt_dev_write_scharr_mask_cl(dt_dev_pixelpipe_iop_t *piece,
 
   p->scharr.hash = dt_hash(DT_INITHASH, &p->scharr.roi, sizeof(dt_iop_roi_t));
 
-  dt_print_pipe(DT_DEBUG_PIPE, "write scharr mask CL", p, NULL, roi_in, NULL, "\n");
+  dt_print_pipe(DT_DEBUG_PIPE, "write scharr mask", p, NULL, piece->pipe->devid, roi_in, NULL, "\n");
   if(darktable.dump_pfm_module && (piece->pipe->type & DT_DEV_PIXELPIPE_EXPORT))
     dt_dump_pfm("scharr_cl", mask, width, height, sizeof(float), "detail");
 
@@ -3067,7 +3073,7 @@ int dt_dev_write_scharr_mask_cl(dt_dev_pixelpipe_iop_t *piece,
   if(err != CL_SUCCESS)
   {
     dt_print_pipe(DT_DEBUG_ALWAYS,
-           "write scharr mask CL", p, NULL, roi_in, NULL,
+           "write scharr mask", p, NULL, piece->pipe->devid, roi_in, NULL,
            "couldn't write scharr mask: %s\n", cl_errstr(err));
     dt_dev_clear_scharr_mask(p);
   }
@@ -3108,7 +3114,7 @@ float *dt_dev_distort_detail_mask(dt_dev_pixelpipe_t *pipe,
   if(!valid) return NULL;
 
   dt_print_pipe(DT_DEBUG_MASKS,
-           "distort detail mask", pipe, target_module, &pipe->scharr.roi, NULL, "\n");
+           "distort detail mask", pipe, target_module, pipe->devid, &pipe->scharr.roi, NULL, "\n");
 
   float *resmask = src;
   float *inmask  = src;
@@ -3128,7 +3134,7 @@ float *dt_dev_distort_detail_mask(dt_dev_pixelpipe_t *pipe,
           float *tmp = dt_alloc_align_float((size_t)it_piece->processed_roi_out.width
                                             * it_piece->processed_roi_out.height);
           dt_print_pipe(DT_DEBUG_MASKS | DT_DEBUG_VERBOSE,
-             "distort detail mask", pipe, it_piece->module, &it_piece->processed_roi_in, &it_piece->processed_roi_out, "\n");
+             "distort detail mask", pipe, it_piece->module, pipe->devid, &it_piece->processed_roi_in, &it_piece->processed_roi_out, "\n");
 
           it_piece->module->distort_mask(it_piece->module, it_piece, inmask, tmp,
                                        &it_piece->processed_roi_in,
@@ -3144,7 +3150,7 @@ float *dt_dev_distort_detail_mask(dt_dev_pixelpipe_t *pipe,
                     || it_piece->processed_roi_in.y != it_piece->processed_roi_out.y))
               dt_print_pipe(DT_DEBUG_ALWAYS,
                       "distort details mask",
-                      pipe, it_piece->module,
+                      pipe, it_piece->module, pipe->devid,
                       &it_piece->processed_roi_in, &it_piece->processed_roi_out,
                       "misses distort_mask()\n");
 

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1133,8 +1133,8 @@ static gboolean _pixelpipe_process_on_CPU(
   if(dt_atomic_get_int(&pipe->shutdown))
     return TRUE;
 
-  // the data buffers must always have a 64 alignment
-  if((((uintptr_t)input) & 63) || (((uintptr_t)*output) & 63))
+  // the data buffers must always have an alignment to DT_CACHELINE_BYTES
+  if((((uintptr_t)input) & (DT_CACHELINE_BYTES - 1)) || (((uintptr_t)*output) & (DT_CACHELINE_BYTES - 1)))
     dt_print(DT_DEBUG_ALWAYS,
              "[pixelpipe_process CPU] buffer aligment problem: IN=%p OUT=%p\n",
              input, *output);

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -316,10 +316,11 @@ int dt_dev_write_scharr_mask_cl(dt_dev_pixelpipe_iop_t *piece,
 void dt_print_pipe_ext(const char *title,
                        const dt_dev_pixelpipe_t *pipe,
                        const struct dt_iop_module_t *mod,
+                       const int device,
                        const dt_iop_roi_t *roi_in,
                        const dt_iop_roi_t *roi_out,
                        const char *msg, ...)
-  __attribute__((format(printf, 6, 7)));
+  __attribute__((format(printf, 7, 8)));
 
 // helper function writing the pipe-processed ctmask data to dest
 float *dt_dev_distort_detail_mask(dt_dev_pixelpipe_t *pipe,

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -2036,7 +2036,7 @@ static void _set_trouble_messages(struct dt_iop_module_t *self)
     && !dt_image_is_monochrome(&dev->image_storage);
 
   dt_print_pipe(DT_DEBUG_PARAMS, "chroma trouble data",
-      NULL, self, NULL, NULL,
+      NULL, self, DT_DEVICE_NONE, NULL, NULL,
       "D65=%s.  NOW %.3f %.3f %.3f, D65 %.3f %.3f %.3f, AS-SHOT %.3f %.3f %.3f\n",
     dt_dev_is_D65_chroma(dev) ? "YES" : "NO",
     chr->wb_coeffs[0], chr->wb_coeffs[1], chr->wb_coeffs[2],

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -659,7 +659,7 @@ int process_cl(struct dt_iop_module_t *self,
   cl_mem dev_g = NULL, dev_b = NULL, dev_coeffs = NULL;
 
   dt_print_pipe(DT_DEBUG_PARAMS,
-    "matrix conversion on GPU", piece->pipe, self,
+    "matrix conversion", piece->pipe, self, piece->pipe->devid,
                     roi_in, roi_out, "`%s'\n", dt_colorspaces_get_name(d->type, NULL));
   int kernel;
   float cmat[9], lmat[9];
@@ -1185,7 +1185,7 @@ void process(struct dt_iop_module_t *self,
     d->blue_mapping && dt_image_is_matrix_correction_supported(&piece->pipe->image);
 
   dt_print_pipe(DT_DEBUG_PARAMS,
-    "matrix conversion on CPU", piece->pipe, self,
+    "matrix conversion", piece->pipe, self, piece->pipe->devid,
                     roi_in, roi_out, "`%s'\n", dt_colorspaces_get_name(d->type, NULL));
 
   if(d->type == DT_COLORSPACE_LAB)

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -735,7 +735,8 @@ void process(
     if(scaled)
     {
       roi = *roi_out;
-      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi", piece->pipe, self, roi_in, roi_out, "\n");
+      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi",
+        piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out, "\n");
       dt_iop_clip_and_zoom_roi((float *)o, tmp, &roi, &roo);
       dt_free_align(tmp);
     }

--- a/src/iop/demosaicing/basics.c
+++ b/src/iop/demosaicing/basics.c
@@ -667,7 +667,7 @@ static int process_default_cl(
 
     if(scaled)
     {
-      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self, roi_in, roi_out, "\n");
+      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi", piece->pipe, self, piece->pipe->devid, roi_in, roi_out, "\n");
       // scale aux buffer to output buffer
       err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
     }

--- a/src/iop/demosaicing/rcd.c
+++ b/src/iop/demosaicing/rcd.c
@@ -792,7 +792,8 @@ static int process_rcd_cl(
 
     if(scaled)
     {
-      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self, roi_in, roi_out, "\n");
+      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi",
+        piece->pipe, self, piece->pipe->devid, roi_in, roi_out, "\n");
       // scale aux buffer to output buffer
       err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
     }

--- a/src/iop/demosaicing/vng.c
+++ b/src/iop/demosaicing/vng.c
@@ -644,7 +644,8 @@ static int process_vng_cl(
 
     if(scaled)
     {
-      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self, roi_in, roi_out, "\n");
+      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi",
+        piece->pipe, self, piece->pipe->devid, roi_in, roi_out, "\n");
       // scale temp buffer to output buffer
       err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_aux, roi_out, roi_in);
       if(err != CL_SUCCESS) goto finish;

--- a/src/iop/demosaicing/xtrans.c
+++ b/src/iop/demosaicing/xtrans.c
@@ -2224,7 +2224,8 @@ static int process_markesteijn_cl(
 
     if(scaled)
     {
-      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi_cl", piece->pipe, self, roi_in, roi_out, "\n");
+      dt_print_pipe(DT_DEBUG_PIPE, "clip_and_zoom_roi",
+        piece->pipe, self, piece->pipe->devid, roi_in, roi_out, "\n");
       // scale temp buffer to output buffer
       err = dt_iop_clip_and_zoom_roi_cl(devid, dev_out, dev_tmp, roi_out, roi_in);
       if(err != CL_SUCCESS) goto error;

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -138,8 +138,8 @@ int process_cl(struct dt_iop_module_t *self,
   const int devid = piece->pipe->devid;
 
   dt_print_pipe(DT_DEBUG_IMAGEIO,
-                "clip_and_zoom_roi CL",
-                piece->pipe, self, roi_in, roi_out, "device=%i\n", devid);
+                "clip_and_zoom_roi",
+                piece->pipe, self, piece->pipe->devid, roi_in, roi_out, "device=%i\n", devid);
   return dt_iop_clip_and_zoom_cl(devid, dev_out, dev_in, roi_out, roi_in);
 }
 #endif
@@ -152,7 +152,7 @@ void process(dt_iop_module_t *self,
              const dt_iop_roi_t *const roi_out)
 {
   dt_print_pipe(DT_DEBUG_IMAGEIO,
-                "clip_and_zoom_roi", piece->pipe, self, roi_in, roi_out, "\n");
+                "clip_and_zoom_roi", piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out, "\n");
 
   dt_iop_clip_and_zoom((float *)ovoid, (float *)ivoid, roi_out, roi_in);
 }

--- a/src/iop/hlreconstruct/opposed.c
+++ b/src/iop/hlreconstruct/opposed.c
@@ -358,7 +358,7 @@ static float *_process_opposed(
       }
 
       dt_print_pipe(DT_DEBUG_PIPE,
-          "opposed chroma CPU", piece->pipe, self, roi_in, roi_out,
+          "opposed chroma", piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out,
           "red: %3.4f, green: %3.4f, blue: %3.4f for hash=%" PRIx64 "%s%s\n",
           chrominance[0], chrominance[1], chrominance[2],
           _opposed_parhash(piece),
@@ -559,7 +559,7 @@ static cl_int process_opposed_cl(
     }
 
     dt_print_pipe(DT_DEBUG_PIPE,
-        "opposed chroma CL", piece->pipe, self, roi_in, roi_out,
+        "opposed chroma", piece->pipe, self, piece->pipe->devid, roi_in, roi_out,
         "red: %3.4f, green: %3.4f, blue: %3.4f for hash=%" PRIx64 "%s%s\n",
         chrominance[0], chrominance[1], chrominance[2],
         _opposed_parhash(piece),

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -584,7 +584,7 @@ void expose(
   {
     dt_print_pipe(DT_DEBUG_EXPOSE,
         "expose livesamples FALSE",
-         port->pipe, NULL, NULL, NULL, "%dx%d, px=%d py=%d\n",
+         port->pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "%dx%d, px=%d py=%d\n",
          width, height, pointerx, pointery);
     _darkroom_pickers_draw(self, cri, wd, ht, zoom_scale,
                            darktable.lib->proxy.colorpicker.live_samples, FALSE);
@@ -605,7 +605,7 @@ void expose(
   {
     dt_print_pipe(DT_DEBUG_EXPOSE,
         "expose livesample TRUE",
-         port->pipe, NULL, NULL, NULL, "%dx%d, px=%d py=%d\n",
+         port->pipe, NULL, DT_DEVICE_NONE, NULL, NULL, "%dx%d, px=%d py=%d\n",
          width, height, pointerx, pointery);
     GSList samples = { .data = darktable.lib->proxy.colorpicker.primary_sample,
                        .next = NULL };
@@ -626,7 +626,7 @@ void expose(
   {
     dt_print_pipe(DT_DEBUG_EXPOSE,
         "expose masks",
-         port->pipe, dev->gui_module, NULL, NULL, "%dx%d, px=%d py=%d\n",
+         port->pipe, dev->gui_module, DT_DEVICE_NONE, NULL, NULL, "%dx%d, px=%d py=%d\n",
          width, height, pointerx, pointery);
     dt_masks_events_post_expose(dev->gui_module, cri, width, height, pzx, pzy, zoom_scale);
   }
@@ -640,7 +640,7 @@ void expose(
     {
       dt_print_pipe(DT_DEBUG_EXPOSE,
         "expose cropper",
-         port->pipe, dev->cropping.exposer, NULL, NULL, "%dx%d, px=%d py=%d\n",
+         port->pipe, dev->cropping.exposer, DT_DEVICE_NONE, NULL, NULL, "%dx%d, px=%d py=%d\n",
          width, height, pointerx, pointery);
       _module_gui_post_expose(dev->cropping.exposer, cri, wd, ht, pzx, pzy, zoom_scale);
     }
@@ -650,7 +650,7 @@ void expose(
     {
       dt_print_pipe(DT_DEBUG_EXPOSE,
         "expose module",
-         port->pipe, dev->gui_module, NULL, NULL, "%dx%d, px=%d py=%d\n",
+         port->pipe, dev->gui_module, DT_DEVICE_NONE, NULL, NULL, "%dx%d, px=%d py=%d\n",
          width, height, pointerx, pointery);
       _module_gui_post_expose(dev->gui_module, cri, wd, ht, pzx, pzy, zoom_scale);
     }
@@ -670,7 +670,7 @@ void expose(
     gchar *label = darktable.color_profiles->mode == DT_PROFILE_GAMUTCHECK ? _("gamut check") : _("soft proof");
     dt_print_pipe(DT_DEBUG_EXPOSE,
         "expose profile",
-         port->pipe, NULL, NULL, NULL, "%dx%d, px=%d py=%d. proof: %s\n",
+         port->pipe, NULL, port->pipe->devid, NULL, NULL, "%dx%d, px=%d py=%d. proof: %s\n",
          width, height, pointerx, pointery, label);
 
     cairo_set_source_rgba(cri, 0.5, 0.5, 0.5, 0.5);

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1672,7 +1672,7 @@ void dt_view_paint_surface(cairo_t *cr,
 
   dt_print_pipe(DT_DEBUG_EXPOSE,
       "dt_view_paint_surface",
-        port->pipe, NULL, NULL, NULL,
+        port->pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
         "viewport zoom_scale %6.3f backbuf_scale %6.3f "
         "(x=%6.2f y=%6.2f) -> (x=%+.3f y=%+.3f)\n",
         zoom_scale, backbuf_scale,
@@ -1737,7 +1737,7 @@ void dt_view_paint_surface(cairo_t *cr,
 
     dt_print_pipe(DT_DEBUG_EXPOSE,
         "dt_view_paint_surface",
-         dev->preview_pipe, NULL, NULL, NULL,
+         dev->preview_pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
          "size %4lux%-4lu processed %4.0fx%-4.0f "
          "buf %4dx%-4d scale=%.3f "
          "zoom (x=%6.2f y=%6.2f) -> offset (x=%+.3f y=%+.3f)\n",
@@ -1755,7 +1755,7 @@ void dt_view_paint_surface(cairo_t *cr,
   {
     dt_print_pipe(DT_DEBUG_EXPOSE,
         "dt_view_paint_surface",
-         port->pipe, NULL, NULL, NULL,
+         port->pipe, NULL, DT_DEVICE_NONE, NULL, NULL,
          "size %4lux%-4lu processed %4dx%-4d "
          "buf %4dx%-4d scale=%.3f "
          "zoom (x=%6.2f y=%6.2f) -> offset (x=%+.3f y=%+.3f)\n",


### PR DESCRIPTION
1. Make more use of DT_CACHELINE_BYTES
- DT_IS_ALIGNED() macro
- while checking for data buffers while processing a module
- in interpolation

2. Improved debugging log for multiple CL devices

As multiple potent OpenCL devices - possibly from different vendors - become more common
for darktable users it sometimes became difficult to read the logs written by -d pipe
as the most valuable source of information what has been wrong while procssing.

The pipe->devid information can't be used because of these reasons
- we want to better trace fallbacks
- sometimes the info is not relevant at all
- we might process CPU code - and want to know about it - even in OpenCL pipes.

Thus the dt_print_pipe() api has slightly changed, the devid has been added.
Two #defines have been added in darktable.h
DT_DEVICE_CPU
DT_DEVICE_NONE used for "no device information wanted"

The output of the device is the third tab, either CPU or CLx where x is the device id.