### PR TITLE
Culling : ensure to keep zoom value between images

### DIFF
--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1300,13 +1300,15 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table,
       // something > 0 to trigger draw events
       int nw = 40;
       int nh = 40;
-      if(table->mode == DT_CULLING_MODE_PREVIEW)
+      if(table->mode == DT_CULLING_MODE_PREVIEW ||
+         (table->mode == DT_CULLING_MODE_CULLING && table->thumbs_count == 1))
       {
         nw = table->view_width;
         nh = table->view_height;
       }
       else if(table->list)
       {
+
         dt_thumbnail_t *th_model = (dt_thumbnail_t *)(table->list)->data;
         nw = th_model->width;
         nh = th_model->height;

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -711,7 +711,6 @@ static gboolean _event_image_draw(GtkWidget *widget,
       {
         const float zoom100 = dt_thumbnail_get_zoom100(thumb);
         // Any zoom100 > 1 is ensured to be correct
-
         if(thumb->zoom > 1.0f && zoom100 > 1.0f)
           thumb->zoom = MIN(thumb->zoom, zoom100);
 
@@ -2299,15 +2298,8 @@ float dt_thumbnail_get_zoom100(dt_thumbnail_t *thumb)
       (float)(thumb->height - thumb->img_margin->top - thumb->img_margin->bottom);
     const float used_w =
       (float)(thumb->width - thumb->img_margin->left - thumb->img_margin->right);
-    const float zoom100 = fmaxf((float)w / used_w, (float)h / used_h);
 
-    /* the thumb->zoom_100 value is kept for the thumbs lifetime so
-       we have to make sure this is only done if valid even in cornercases.
-       If not safe we won't keep it.
-    */
-    const gboolean safe = zoom100 >= 1.0f && thumb->img_width > 0;
-    if(safe)
-      thumb->zoom_100 = MAX(zoom100, 1.0f);
+    thumb->zoom_100 = MAX(1.0f, fmaxf((float)w / used_w, (float)h / used_h));
   }
 
   return MAX(1.0f, thumb->zoom_100);


### PR DESCRIPTION
this fixes #15966 

This fix a regression due to PR #15810 . In fact the issue mentioned there is due to the fact that in culling with only 1 image, we have an empty `table->list` on each image change, thus we don't have valid size value on first load.
Instead of resetting the zoom value to 1.0 each time, we use the same code path as for full preview.

@jenshannoschwalm : you may want to have a look, as I've in fact reverted a part of your code here...