### PR TITLE
Correct warping usage

### DIFF
--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -590,7 +590,7 @@ float dt_interpolation_compute_sample(const struct dt_interpolation *itor,
     // invalid coordinate
     r = 0.0f;
   }
-  return r;
+  return fmaxf(0.0f, r);
 }
 
 /* --------------------------------------------------------------------------
@@ -702,7 +702,7 @@ void dt_interpolation_compute_pixel4c(const struct dt_interpolation *itor,
     }
 
     for_each_channel(c,aligned(out))
-      out[c] = oonorm * pixel[c];
+      out[c] = fmaxf(0.0f, oonorm * pixel[c]);
   }
   else
   {

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -155,7 +155,7 @@ void dt_iop_clip_and_zoom(float *out,
                           const dt_iop_roi_t *const roi_out,
                           const dt_iop_roi_t *const roi_in)
 {
-  const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
   dt_interpolation_resample(itor, out, roi_out, in, roi_in);
 }
 
@@ -179,7 +179,7 @@ int dt_iop_clip_and_zoom_cl(int devid,
                             const dt_iop_roi_t *const roi_out,
                             const dt_iop_roi_t *const roi_in)
 {
-  const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
   return dt_interpolation_resample_cl(itor, devid, dev_out, roi_out, dev_in, roi_in);
 }
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -402,7 +402,7 @@ void distort_mask(
         const dt_iop_roi_t *const roi_in,
         const dt_iop_roi_t *const roi_out)
 {
-  const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
   dt_interpolation_resample_roi_1c(itor, out, roi_out, in, roi_in);
 }
 


### PR DESCRIPTION
1. the distort of the mask in demosaicer should use the user specified warp interpolator.
2. Make sure the single pixel warp interpolators don't return NaN, it's safe to avoid values < 0.
3. As specified in the doc and tooltips we should use the warp interpolator for finalscale.

@TurboGit please note we might see some subtle differences.
