### PR TITLE
Masks distort should use warp interpolator in demosaic

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -402,7 +402,7 @@ void distort_mask(
         const dt_iop_roi_t *const roi_in,
         const dt_iop_roi_t *const roi_out)
 {
-  const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
+  const struct dt_interpolation *itor = dt_interpolation_new(DT_INTERPOLATION_USERPREF_WARP);
   dt_interpolation_resample_roi_1c(itor, out, roi_out, in, roi_in);
 }
 


### PR DESCRIPTION
For raw files we normaly scale down in demosaicer for output roi. We also have to do the same with masks possibly being there already. That should be done with the user defined warp interpolator for less artifacts.

Safe part of closed #16013