### PR TITLE
Strictly avoid NaNs in lens module output

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -1968,7 +1968,7 @@ lens_distort_bilinear (read_only image2d_t in, write_only image2d_t out, const i
   ry = (ry <= iheight - 1) ? ry : iheight - 1;
   pixel.z = read_imagef(in, samplerf, (float2)(rx, ry)).z;
 
-  pixel = all(isfinite(pixel.xyz)) ? pixel : (float4)0.0f;
+  pixel = all(isfinite(pixel.xyz)) ? fmax(0.0f, pixel) : (float4)0.0f;
 
   write_imagef (out, (int2)(x, y), pixel);
 }
@@ -2112,7 +2112,7 @@ lens_distort_bicubic (read_only image2d_t in,
   }
   pixel.z = sum/weight;
 
-  pixel = all(isfinite(pixel.xyz)) ? pixel : (float4)0.0f;
+  pixel = all(isfinite(pixel.xyz)) ? fmax(0.0f, pixel) : (float4)0.0f;
 
   write_imagef (out, (int2)(x, y), pixel);
 }
@@ -2257,7 +2257,7 @@ lens_distort_lanczos2 (read_only image2d_t in,
   }
   pixel.z = sum/weight;
 
-  pixel = all(isfinite(pixel.xyz)) ? pixel : (float4)0.0f;
+  pixel = all(isfinite(pixel.xyz)) ? fmax(0.0f, pixel) : (float4)0.0f;
 
   write_imagef (out, (int2)(x, y), pixel);
 }
@@ -2394,7 +2394,7 @@ lens_distort_lanczos3 (read_only image2d_t in, write_only image2d_t out, const i
   }
   pixel.z = sum/weight;
 
-  pixel = all(isfinite(pixel.xyz)) ? pixel : (float4)0.0f;
+  pixel = all(isfinite(pixel.xyz)) ? fmax(0.0f, pixel) : (float4)0.0f;
 
   write_imagef (out, (int2)(x, y), pixel);
 }
@@ -3059,8 +3059,8 @@ kernel void md_lens_correction(read_only image2d_t in,
       _interpolate_linear_spline(knots_dist, &cor_rgb[plane * MAXKNOTS], knots, radius);
     const float xs = dr*cx + w2 - roix;
     const float ys = dr*cy + h2 - roiy;
-    output[c] = interpolation_compute_sample(in, itor_mode, itor_width,
-                                             xs, ys, iwidth, iheight, c);
+    output[c] = fmax(0.0f, interpolation_compute_sample(in, itor_mode, itor_width,
+                                             xs, ys, iwidth, iheight, c));
   }
 
   float4 pixel = {output[0], output[1], output[2], output[3]};

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -545,7 +545,7 @@ float dt_interpolation_compute_sample(const struct dt_interpolation *itor,
       s += kernelv[i] * h;
       in += linestride;
     }
-    r = s / (normh * normv);
+    r = fmaxf(0.0f, s / (normh * normv));
   }
   else if(ix >= 0 && iy >= 0 && ix < width && iy < height)
   {
@@ -583,7 +583,7 @@ float dt_interpolation_compute_sample(const struct dt_interpolation *itor,
       s += kernelv[i] * h;
     }
 
-    r = s / (normh * normv);
+    r = fmaxf(0.0f, s / (normh * normv));
   }
   else
   {
@@ -658,7 +658,7 @@ void dt_interpolation_compute_pixel4c(const struct dt_interpolation *itor,
     }
 
     for_each_channel(c,aligned(out))
-      out[c] = oonorm * pixel[c];
+      out[c] = fmaxf(0.0f, oonorm * pixel[c]);
   }
   else if(ix >= 0 && iy >= 0 && ix < width && iy < height)
   {
@@ -702,7 +702,7 @@ void dt_interpolation_compute_pixel4c(const struct dt_interpolation *itor,
     }
 
     for_each_channel(c,aligned(out))
-      out[c] = oonorm * pixel[c];
+      out[c] = fmaxf(0.0f, oonorm * pixel[c]);
   }
   else
   {


### PR DESCRIPTION
Due to some - not understood - reason the single pixel interpolators `dt_interpolation_compute_sample()` and `dt_interpolation_compute_pixel4c()` could return NaNs as result.

These interpolators are used in lens, ashift, clipping, rotatepixels, scalepixels and liquify and can possibly introduce artifacts, the effect is strongly depending on **how** these data are used further up the pipe.
This is also true for OpenCL codepath, especially AMD drivers don't like these NaNs at all!

One example is the color equalizer module currently under development where we feed those data in a box filter used for guiding leading to crazy results.

I came across this issue while working on #15926, the problem fixed here was the main culprit for guiding strongly misbehaving leading to large black boxes. More work from that following ...

@TurboGit my integration tests don't work reliably on my machine so could you check and report back? I think this should also be concidered for 4.6.1

@ralfbrown no MAX() but fmaxf() here :-) 
