### PR TITLE
Update boxing filters for 4.8

### DIFF
--- a/src/common/box_filters.c
+++ b/src/common/box_filters.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2023 darktable developers.
+    Copyright (C) 2009-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -224,7 +224,7 @@ static void _sub_4wide_Kahan(float *const restrict accum,
   }
 }
 
-static void store_scaled_4wide(float *const restrict out,
+static void _store_scaled_4wide(float *const restrict out,
                                const dt_aligned_pixel_t in,
                                const float scale)
 {
@@ -308,7 +308,7 @@ static void _store_16wide(float *const restrict out,
     out[c] = in[c];
 }
 
-static void store_scaled_16wide(float *const restrict out,
+static void _store_scaled_16wide(float *const restrict out,
     const float *const restrict in,
     const float scale)
 {
@@ -405,13 +405,13 @@ static void _blur_horizontal_4ch(float *const restrict buf,
       const int np = x + radius;
       hits++;
       _load_add_4wide(scratch + 4*np, L, bufp + 4*np);
-      store_scaled_4wide(bufp + 4*x, L, hits);
+      _store_scaled_4wide(bufp + 4*x, L, hits);
     }
     // if radius > width/2, we have pixels for which we can neither add new values (x+radius >= width) nor
     //  remove old values (x-radius < 0)
     for(; x <= radius && x < width; x++)
     {
-      store_scaled_4wide(bufp + 4*x, L, hits);
+      _store_scaled_4wide(bufp + 4*x, L, hits);
     }
     // process the blur for the bulk of the scan line
     for(; x + radius < width; x++)
@@ -422,7 +422,7 @@ static void _blur_horizontal_4ch(float *const restrict buf,
       const int np = x + radius;
       _sub_4wide(L, scratch + 4*op);
       _load_add_4wide(scratch + 4*np, L, bufp + 4*np);
-      store_scaled_4wide(bufp + 4*x, L, hits);
+      _store_scaled_4wide(bufp + 4*x, L, hits);
     }
     // process the right end where we have no more values to add to the running sum
     for(; x < width; x++)
@@ -430,7 +430,7 @@ static void _blur_horizontal_4ch(float *const restrict buf,
       const int op = x - radius - 1;
       hits--;
       _sub_4wide(L, scratch + 4*op);
-      store_scaled_4wide(bufp + 4*x, L, hits);
+      _store_scaled_4wide(bufp + 4*x, L, hits);
     }
   }
   return;
@@ -458,13 +458,13 @@ static void _blur_horizontal_4ch_Kahan(float *const restrict buf,
     const int np = x + radius;
     hits++;
     _load_add_4wide_Kahan(scratch + 4*np, L, buf + 4*np, comp);
-    store_scaled_4wide(buf + 4*x, L, hits);
+    _store_scaled_4wide(buf + 4*x, L, hits);
   }
   // if radius > width/2, we have pixels for which we can neither add new values (x+radius >= width) nor
   //  remove old values (x-radius < 0)
   for(; x <= radius && x < width; x++)
   {
-    store_scaled_4wide(buf + 4*x, L, hits);
+    _store_scaled_4wide(buf + 4*x, L, hits);
   }
   // process the blur for the bulk of the scan line
   for(; x + radius < width; x++)
@@ -473,7 +473,7 @@ static void _blur_horizontal_4ch_Kahan(float *const restrict buf,
     const int np = x + radius;
     _sub_4wide_Kahan(L, scratch + 4*op, comp);
     _load_add_4wide_Kahan(scratch + 4*np, L, buf + 4*np, comp);
-    store_scaled_4wide(buf + 4*x, L, hits);
+    _store_scaled_4wide(buf + 4*x, L, hits);
   }
   // process the right end where we have no more values to add to the running sum
   for(; x < width; x++)
@@ -481,7 +481,7 @@ static void _blur_horizontal_4ch_Kahan(float *const restrict buf,
     const int op = x - radius - 1;
     hits--;
     _sub_4wide_Kahan(L, scratch + 4*op, comp);
-    store_scaled_4wide(buf + 4*x, L, hits);
+    _store_scaled_4wide(buf + 4*x, L, hits);
   }
   return;
 }
@@ -706,13 +706,13 @@ static void _blur_vertical_4wide(float *const restrict buf,
     const int np = y + radius;
     hits++;
     _load_add_4wide(scratch + 4*(np&mask), L, buf + np*width);
-    store_scaled_4wide(buf + y*width, L, hits);
+    _store_scaled_4wide(buf + y*width, L, hits);
   }
   // if radius > height/2, we have pixels for which we can neither add new values (y+radius >= height) nor
   //  remove old values (y-radius < 0)
   for(; y <= radius && y < height; y++)
   {
-    store_scaled_4wide(buf + y*width, L, hits);
+    _store_scaled_4wide(buf + y*width, L, hits);
   }
   // process the blur for the bulk of the column
   for( ; y + radius < height; y++)
@@ -721,7 +721,7 @@ static void _blur_vertical_4wide(float *const restrict buf,
     const int op = y - radius - 1;
     _sub_4wide(L, scratch + 4*(op&mask));
     _load_add_4wide(scratch + 4*(np&mask), L, buf + np*width);
-    store_scaled_4wide(buf + y*width, L, hits);
+    _store_scaled_4wide(buf + y*width, L, hits);
   }
   // process the blur for the end of the scan line, where we don't have any more values to add to the mean
   for( ; y < height; y++)
@@ -729,7 +729,7 @@ static void _blur_vertical_4wide(float *const restrict buf,
     const int op = y - radius - 1;
     hits--;
     _sub_4wide(L, scratch + 4*(op&mask));
-    store_scaled_4wide(buf + y*width, L, hits);
+    _store_scaled_4wide(buf + y*width, L, hits);
   }
   return;
 }
@@ -766,13 +766,13 @@ static void _blur_vertical_4wide_Kahan(float *const restrict buf,
     const int np = y + radius;
     hits++;
     _load_add_4wide_Kahan(scratch + 4*(np&mask), L, buf + np*width, comp);
-    store_scaled_4wide(buf + y*width, L, hits);
+    _store_scaled_4wide(buf + y*width, L, hits);
   }
   // if radius > height/2, we have pixels for which we can neither add new values (y+radius >= height) nor
   //  remove old values (y-radius < 0)
   for(; y <= radius && y < height; y++)
   {
-    store_scaled_4wide(buf + y*width, L, hits);
+    _store_scaled_4wide(buf + y*width, L, hits);
   }
   // process the blur for the bulk of the scan line
   for( ; y + radius < height; y++)
@@ -781,7 +781,7 @@ static void _blur_vertical_4wide_Kahan(float *const restrict buf,
     const int op = y - radius - 1;
     _sub_4wide_Kahan(L, scratch + 4*(op&mask), comp);
     _load_add_4wide_Kahan(scratch + 4*(np&mask), L, buf + np*width, comp);
-    store_scaled_4wide(buf + y*width, L, hits);
+    _store_scaled_4wide(buf + y*width, L, hits);
   }
   // process the blur for the end of the scan line, where we don't have any more values to add to the mean
   for( ; y < height; y++)
@@ -789,7 +789,7 @@ static void _blur_vertical_4wide_Kahan(float *const restrict buf,
     const int op = y - radius - 1;
     hits--;
     _sub_4wide_Kahan(L, scratch + 4*(op&mask), comp);
-    store_scaled_4wide(buf + y*width, L, hits);
+    _store_scaled_4wide(buf + y*width, L, hits);
   }
   return;
 }
@@ -825,13 +825,13 @@ static void _blur_vertical_16wide(float *const restrict buf,
     const int np = y + radius;
     hits++;
     _load_add_16wide(scratch + 16 * (np&mask), L, buf + np*width);
-    store_scaled_16wide(buf + y*width, L, hits);
+    _store_scaled_16wide(buf + y*width, L, hits);
   }
   // if radius > height/2, we have pixels for which we can neither add new values (y+radius >= height) nor
   //  remove old values (y-radius < 0)
   for(; y <= radius && y < height; y++)
   {
-    store_scaled_16wide(buf + y*width, L, hits);
+    _store_scaled_16wide(buf + y*width, L, hits);
   }
   // process the blur for the bulk of the column
   for( ; y + radius < height; y++)
@@ -841,7 +841,7 @@ static void _blur_vertical_16wide(float *const restrict buf,
     _sub_16wide(L, scratch + 16*(op&mask));
     _load_add_16wide(scratch + 16*(np&mask), L, buf + np*width);
     // update the means
-    store_scaled_16wide(buf + y*width, L, hits);
+    _store_scaled_16wide(buf + y*width, L, hits);
   }
   // process the blur for the end of the scan line, where we don't have any more values to add to the mean
   for( ; y < height; y++)
@@ -850,7 +850,7 @@ static void _blur_vertical_16wide(float *const restrict buf,
     hits--;
     _sub_16wide(L, scratch + 16*(op&mask));
     // update the means
-    store_scaled_16wide(buf + y*width, L, hits);
+    _store_scaled_16wide(buf + y*width, L, hits);
   }
   return;
 }
@@ -887,13 +887,13 @@ static void _blur_vertical_16wide_Kahan(float *const restrict buf,
     const int np = y + radius;
     hits++;
     _load_add_16wide_Kahan(scratch + 16 * (np&mask), L, buf + np*width, comp);
-    store_scaled_16wide(buf + y*width, L, hits);
+    _store_scaled_16wide(buf + y*width, L, hits);
   }
   // if radius > height/2, we have pixels for which we can neither add new values (y+radius >= height) nor
   //  remove old values (y-radius < 0)
   for(; y <= radius && y < height; y++)
   {
-    store_scaled_16wide(buf + y*width, L, hits);
+    _store_scaled_16wide(buf + y*width, L, hits);
   }
   // process the blur for the bulk of the column
   for( ; y + radius < height; y++)
@@ -903,7 +903,7 @@ static void _blur_vertical_16wide_Kahan(float *const restrict buf,
     _sub_16wide_Kahan(L, scratch + 16*(op&mask), comp);
     _load_add_16wide_Kahan(scratch + 16*(np&mask), L, buf + np*width, comp);
     // update the means
-    store_scaled_16wide(buf + y*width, L, hits);
+    _store_scaled_16wide(buf + y*width, L, hits);
   }
   // process the blur for the end of the scan line, where we don't have any more values to add to the mean
   for( ; y < height; y++)
@@ -912,7 +912,7 @@ static void _blur_vertical_16wide_Kahan(float *const restrict buf,
     hits--;
     _sub_16wide_Kahan(L, scratch + 16*(op&mask), comp);
     // update the means
-    store_scaled_16wide(buf + y*width, L, hits);
+    _store_scaled_16wide(buf + y*width, L, hits);
   }
   return;
 }
@@ -959,11 +959,11 @@ static size_t _compute_effective_height(const size_t height, const size_t radius
   return eff_height;
 }
 
-static void dt_box_mean_1ch(float *const buf,
-                            const size_t height,
-                            const size_t width,
-                            const size_t radius,
-                            const unsigned iterations)
+static void _box_mean_1ch(float *const buf,
+                          const size_t height,
+                          const size_t width,
+                          const size_t radius,
+                          const uint32_t iterations)
 {
   // scratch space needed per thread:
   //   width floats to store one row during horizontal pass
@@ -972,8 +972,9 @@ static void dt_box_mean_1ch(float *const buf,
   const size_t size = MAX(width,16*eff_height);
   size_t padded_size;
   float *const restrict scanlines = dt_alloc_perthread_float(size, &padded_size);
+  if(scanlines == NULL) return;
 
-  for(unsigned iteration = 0; iteration < iterations; iteration++)
+  for(uint32_t iteration = 0; iteration < iterations; iteration++)
   {
     _blur_horizontal_1ch(buf, height, width, radius, scanlines, padded_size);
     _blur_vertical_1ch(buf, height, width, radius, scanlines, padded_size);
@@ -982,11 +983,11 @@ static void dt_box_mean_1ch(float *const buf,
   dt_free_align(scanlines);
 }
 
-static void dt_box_mean_4ch(float *const buf,
-                            const int height,
-                            const int width,
-                            const int radius,
-                            const unsigned iterations)
+static void _box_mean_4ch(float *const buf,
+                          const size_t height,
+                          const size_t width,
+                          const size_t radius,
+                          const uint32_t iterations)
 {
   // scratch space needed per thread:
   //   4*width floats to store one row during horizontal pass
@@ -995,8 +996,9 @@ static void dt_box_mean_4ch(float *const buf,
   const size_t size = MAX(4*width,16*eff_height);
   size_t padded_size;
   float *const restrict scanlines = dt_alloc_perthread_float(size, &padded_size);
+  if(scanlines == NULL) return;
 
-  for(unsigned iteration = 0; iteration < iterations; iteration++)
+  for(uint32_t iteration = 0; iteration < iterations; iteration++)
   {
     _blur_horizontal_4ch(buf, height, width, radius, scanlines, padded_size);
     // we need to multiply width by 4 to get the correct stride for the vertical blur
@@ -1006,14 +1008,16 @@ static void dt_box_mean_4ch(float *const buf,
   dt_free_align(scanlines);
 }
 
-static void box_mean_vert_1ch_Kahan(float *const buf,
-    const int height,
+static void _box_mean_vert_1ch_Kahan(float *const buf,
+    const size_t height,
     const size_t width,
     const size_t radius)
 {
   const size_t eff_height = _compute_effective_height(height,radius);
+  const size_t size = MAX(16*width,16*eff_height);
   size_t padded_size;
-  float *const restrict scratch_buf = dt_alloc_perthread_float(16*eff_height,&padded_size);
+  float *const restrict scratch_buf = dt_alloc_perthread_float(size,&padded_size);
+  if(scratch_buf == NULL) return;
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
@@ -1031,7 +1035,7 @@ static void box_mean_vert_1ch_Kahan(float *const buf,
     {
       // handle the 1..15 remaining columns
       size_t col_ = col;
-      for( ; col_ < (width & ~3); col_ += 4)
+      for( ; col_ + 4 <= width; col_ += 4)
         _blur_vertical_4wide_Kahan(buf + col_, height, width, radius, scratch);
       for( ; col_ < width; col_++)
         _blur_vertical_1wide_Kahan(buf + col_, height, width, radius, scratch);
@@ -1041,17 +1045,20 @@ static void box_mean_vert_1ch_Kahan(float *const buf,
   dt_free_align(scratch_buf);
 }
 
-static void dt_box_mean_4ch_Kahan(float *const buf,
+static void _box_mean_4ch_Kahan(float *const buf,
     const size_t height,
     const size_t width,
-    const int radius,
-    const unsigned iterations)
+    const size_t radius,
+    const uint32_t iterations)
 {
+  const size_t eff_height = _compute_effective_height(height,radius);
+  const size_t size = MAX(4*width,16*eff_height);
+  size_t padded_size;
+  float *const restrict scanlines = dt_alloc_perthread_float(size,&padded_size);
+  if(scanlines == NULL) return;
 
-  for(unsigned iteration = 0; iteration < iterations; iteration++)
+  for(uint32_t iteration = 0; iteration < iterations; iteration++)
   {
-    size_t padded_size;
-    float *const restrict scanlines = dt_alloc_perthread_float(4*width,&padded_size);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(width, height, radius, padded_size, buf, scanlines) \
@@ -1063,18 +1070,46 @@ static void dt_box_mean_4ch_Kahan(float *const buf,
       _blur_horizontal_4ch_Kahan(buf + row * 4 * width, width, radius, scratch);
     }
 
-    dt_free_align(scanlines);
-
-    box_mean_vert_1ch_Kahan(buf, height, 4*width, radius);
+    _box_mean_vert_1ch_Kahan(buf, height, 4*width, radius);
   }
-
+  dt_free_align(scanlines);
 }
 
-static inline void box_mean_2ch(float *const restrict in,
+static void _box_mean_2ch_Kahan(float *const buf,
     const size_t height,
     const size_t width,
-    const int radius,
-    const unsigned iterations)
+    const size_t radius,
+    const uint32_t iterations)
+{
+  const size_t eff_height = _compute_effective_height(height,radius);
+  const size_t size = MAX(4*width,16*eff_height);
+  size_t padded_size;
+  float *const restrict scanlines = dt_alloc_perthread_float(size,&padded_size);
+  if(scanlines == NULL) return;
+
+  for(uint32_t iteration = 0; iteration < iterations; iteration++)
+  {
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(width, height, radius, padded_size, buf, scanlines) \
+  schedule(static)
+#endif
+    for(size_t row = 0; row < height; row++)
+    {
+      float *const restrict scratch = dt_get_perthread(scanlines,padded_size);
+
+      _blur_horizontal_Nch_Kahan(2, buf + row * 2 * width, width, radius, scratch);
+    }
+    _box_mean_vert_1ch_Kahan(buf, height, 2*width, radius);
+  }
+  dt_free_align(scanlines);
+}
+
+static void _box_mean_2ch(float *const restrict in,
+    const size_t height,
+    const size_t width,
+    const size_t radius,
+    const uint32_t iterations)
 {
   // Compute in-place a box average (filter) on a multi-channel image over a window of size 2*radius + 1
   // We make use of the separable nature of the filter kernel to speed-up the computation
@@ -1086,7 +1121,7 @@ static inline void box_mean_2ch(float *const restrict in,
   float *const restrict temp = dt_alloc_perthread_float(Ndim, &padded_size);
   if(temp == NULL) return;
 
-  for(unsigned iteration = 0; iteration < iterations; iteration++)
+  for(uint32_t iteration = 0; iteration < iterations; iteration++)
   {
     _blur_horizontal_2ch(in, height, width, radius, temp, padded_size);
     _blur_vertical_1ch(in, height, 2*width, radius, temp, padded_size);
@@ -1097,25 +1132,29 @@ static inline void box_mean_2ch(float *const restrict in,
 void dt_box_mean(float *const buf,
                  const size_t height,
                  const size_t width,
-                 const int ch,
-                 const int radius,
-                 const unsigned iterations)
+                 const uint32_t ch,
+                 const size_t radius,
+                 const uint32_t iterations)
 {
   if(ch == 1)
   {
-    dt_box_mean_1ch(buf,height,width,radius,iterations);
+    _box_mean_1ch(buf,height,width,radius,iterations);
   }
   else if(ch == 4)
   {
-    dt_box_mean_4ch(buf,height,width,radius,iterations);
+    _box_mean_4ch(buf,height,width,radius,iterations);
   }
   else if(ch == (4|BOXFILTER_KAHAN_SUM))
   {
-    dt_box_mean_4ch_Kahan(buf,height,width,radius,iterations);
+    _box_mean_4ch_Kahan(buf,height,width,radius,iterations);
   }
   else if(ch == 2) // used by fast_guided_filter.h
   {
-    box_mean_2ch(buf,height,width,radius,iterations);
+    _box_mean_2ch(buf,height,width,radius,iterations);
+  }
+  else if(ch == (2|BOXFILTER_KAHAN_SUM))
+  {
+    _box_mean_2ch_Kahan(buf,height,width,radius,iterations);
   }
   else
     dt_unreachable_codepath();
@@ -1123,8 +1162,8 @@ void dt_box_mean(float *const buf,
 
 void dt_box_mean_horizontal(float *const restrict buf,
     const size_t width,
-    const int ch,
-    const int radius,
+    const uint32_t ch,
+    const size_t radius,
     float *const restrict user_scratch)
 {
   if(ch == (4|BOXFILTER_KAHAN_SUM))
@@ -1158,19 +1197,19 @@ void dt_box_mean_horizontal(float *const restrict buf,
 void dt_box_mean_vertical(float *const buf,
     const size_t height,
     const size_t width,
-    const int ch,
-    const int radius)
+    const uint32_t ch,
+    const size_t radius)
 {
   if((ch & BOXFILTER_KAHAN_SUM) && (ch & ~BOXFILTER_KAHAN_SUM) <= 16)
   {
     size_t channels = ch & ~BOXFILTER_KAHAN_SUM;
-    box_mean_vert_1ch_Kahan(buf, height, channels*width, radius);
+    _box_mean_vert_1ch_Kahan(buf, height, channels*width, radius);
   }
   else
     dt_unreachable_codepath();
 }
 
-static inline float window_max(const float *x, int n)
+static inline float _window_max(const float *x, int n)
 {
   float m = -(FLT_MAX);
 #ifdef _OPENMP
@@ -1189,7 +1228,7 @@ static inline void box_max_1d(const int N,
                               const size_t stride_y,
                               const int w)
 {
-  float m = window_max(x, MIN(w + 1, N));
+  float m = _window_max(x, MIN(w + 1, N));
   for(int i = 0; i < N; i++)
   {
     // store maximum of current window at center position
@@ -1199,7 +1238,7 @@ static inline void box_max_1d(const int N,
     if(i - w >= 0 && x[i - w] == m)
     {
       const int start = i - w + 1;
-      m = window_max(x + start, MIN(i + w + 2, N) - start);
+      m = _window_max(x + start, MIN(i + w + 2, N) - start);
     }
     // if the window has not yet exceeded the end of the row/column, update the maximum value
     if(i + w + 1 < N)
@@ -1207,7 +1246,7 @@ static inline void box_max_1d(const int N,
   }
 }
 
-static void set_16wide(float *const restrict out, const float value)
+static void _set_16wide(float *const restrict out, const float value)
 {
 #ifdef _OPENMP
 #pragma omp simd aligned(out : 64)
@@ -1216,7 +1255,7 @@ static void set_16wide(float *const restrict out, const float value)
     out[c] = value;
 }
 
-static inline void update_max_16wide(float m[16],
+static inline void _update_max_16wide(float m[16],
     const float *const restrict base)
 {
 #ifdef _OPENMP
@@ -1246,7 +1285,7 @@ static inline void _load_update_max_16wide(float *const restrict out,
 // calculate the one-dimensional moving maximum on four adjacent columns over a window of size 2*w+1
 // input/output array 'buf' has stride 'stride' and we will write 16 consecutive elements every stride elements
 // (thus processing a cache line at a time)
-static inline void box_max_vert_16wide(const int N,
+static inline void _box_max_vert_16wide(const int N,
     float *const restrict scratch,
     float *const restrict buf,
     const int stride,
@@ -1271,10 +1310,10 @@ static inline void box_max_vert_16wide(const int N,
     // rescan the window to determine the new maximum
     if(i >= w)
     {
-      set_16wide(m, -(FLT_MAX));  // reset max values to lowest possible
+      _set_16wide(m, -(FLT_MAX));  // reset max values to lowest possible
       for(int j = i - w + 1; j < MIN(i + w + 1, N); j++)
       {
-        update_max_16wide(m,scratch + 16*(j&mask));
+        _update_max_16wide(m,scratch + 16*(j&mask));
       }
     }
     // if the window has not yet exceeded the end of the row/column, update the maximum value
@@ -1288,7 +1327,7 @@ static inline void box_max_vert_16wide(const int N,
 
 // calculate the two-dimensional moving maximum over a box of size (2*w+1) x (2*w+1)
 // does the calculation in-place if input and output images are identical
-static void box_max_1ch(float *const buf,
+static void _box_max_1ch(float *const buf,
                         const size_t height,
                         const size_t width,
                         const unsigned w)
@@ -1297,6 +1336,7 @@ static void box_max_1ch(float *const buf,
   const size_t scratch_size = MAX(width,MAX(height,16*eff_height));
   size_t allocsize;
   float *const restrict scratch_buffers = dt_alloc_perthread_float(scratch_size,&allocsize);
+  if(scratch_buffers == NULL) return;
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(w, width, height, buf, allocsize, scratch_buffers) \
@@ -1316,7 +1356,7 @@ static void box_max_1ch(float *const buf,
   for(int col = 0; col < (width & ~15); col += 16)
   {
     float *const restrict scratch = dt_get_perthread(scratch_buffers,allocsize);
-    box_max_vert_16wide(height, scratch, buf + col, width, w, eff_height-1);
+    _box_max_vert_16wide(height, scratch, buf + col, width, w, eff_height-1);
   }
   // handle the leftover 0..15 columns
   for(size_t col = width & ~15 ; col < width; col++)
@@ -1334,17 +1374,17 @@ static void box_max_1ch(float *const buf,
 void dt_box_max(float *const buf,
                 const size_t height,
                 const size_t width,
-                const int ch,
-                const int radius)
+                const uint32_t ch,
+                const size_t radius)
 {
   if(ch == 1)
-    box_max_1ch(buf, height, width, radius);
+    _box_max_1ch(buf, height, width, radius);
   else
   //TODO: 4ch version if needed
     dt_unreachable_codepath();
 }
 
-static inline float window_min(const float *x, int n)
+static inline float _window_min(const float *x, int n)
 {
   float m = FLT_MAX;
 #ifdef _OPENMP
@@ -1357,16 +1397,16 @@ static inline float window_min(const float *x, int n)
 
 // calculate the one-dimensional moving minimum over a window of size 2*w+1
 // input array x has stride 1, output array y has stride stride_y
-static inline void box_min_1d(int N, const float *x, float *y, size_t stride_y, int w)
+static inline void _box_min_1d(int N, const float *x, float *y, size_t stride_y, int w)
 {
-  float m = window_min(x, MIN(w + 1, N));
+  float m = _window_min(x, MIN(w + 1, N));
   for(int i = 0; i < N; i++)
   {
     y[i * stride_y] = m;
     if(i - w >= 0 && x[i - w] == m)
     {
       const int start = (i - w + 1);
-      m = window_min(x + start, MIN((i + w + 2), N) - start);
+      m = _window_min(x + start, MIN((i + w + 2), N) - start);
     }
     // if the window has not yet exceeded the end of the row/column, update the minimum value
     if(i + w + 1 < N)
@@ -1374,7 +1414,7 @@ static inline void box_min_1d(int N, const float *x, float *y, size_t stride_y, 
   }
 }
 
-static inline void update_min_16wide(float m[16], const float *const restrict base)
+static inline void _update_min_16wide(float m[16], const float *const restrict base)
 {
 #ifdef _OPENMP
 #pragma omp simd aligned(m, base : 64)
@@ -1403,7 +1443,7 @@ static inline void _load_update_min_16wide(float *const restrict out,
 // calculate the one-dimensional moving minimum on four adjacent columns over a window of size 2*w+1
 // input/output array 'buf' has stride 'stride' and we will write 16 consecutive elements every stride elements
 // (thus processing a cache line at a time)
-static inline void box_min_vert_16wide(const int N,
+static inline void _box_min_vert_16wide(const int N,
     float *const restrict scratch,
     float *const restrict buf,
     const int stride,
@@ -1428,10 +1468,10 @@ static inline void box_min_vert_16wide(const int N,
     // rescan the window to determine the new minimum
     if(i >= w)
     {
-      set_16wide(m, FLT_MAX);  // reset min values to the highest possible
+      _set_16wide(m, FLT_MAX);  // reset min values to the highest possible
       for(int j = i - w + 1; j < MIN(i + w + 1, N); j++)
       {
-        update_min_16wide(m,scratch + 16*(j&mask));
+        _update_min_16wide(m,scratch + 16*(j&mask));
       }
     }
     // if the window has not yet exceeded the end of the row/column, update the minimum value
@@ -1446,7 +1486,7 @@ static inline void box_min_vert_16wide(const int N,
 
 // calculate the two-dimensional moving minimum over a box of size (2*w+1) x (2*w+1)
 // does the calculation in-place if input and output images are identical
-static void box_min_1ch(float *const buf,
+static void _box_min_1ch(float *const buf,
                         const size_t height,
                         const size_t width,
                         const int w)
@@ -1455,6 +1495,8 @@ static void box_min_1ch(float *const buf,
   const size_t scratch_size = MAX(width,MAX(height,16*eff_height));
   size_t allocsize;
   float *const restrict scratch_buffers = dt_alloc_perthread_float(scratch_size,&allocsize);
+  if(scratch_buffers == NULL) return;
+
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(w, width, height, buf, allocsize, scratch_buffers) \
@@ -1464,7 +1506,7 @@ static void box_min_1ch(float *const buf,
   {
     float *const restrict scratch = dt_get_perthread(scratch_buffers,allocsize);
     memcpy(scratch, buf + row * width, sizeof(float) * width);
-    box_min_1d(width, scratch, buf + row * width, 1, w);
+    _box_min_1d(width, scratch, buf + row * width, 1, w);
   }
 #ifdef _OPENMP
 #pragma omp parallel for default(none)           \
@@ -1474,7 +1516,7 @@ static void box_min_1ch(float *const buf,
   for(size_t col = 0; col < (width & ~15); col += 16)
   {
     float *const restrict scratch = dt_get_perthread(scratch_buffers,allocsize);
-    box_min_vert_16wide(height, scratch, buf + col, width, w, eff_height-1);
+    _box_min_vert_16wide(height, scratch, buf + col, width, w, eff_height-1);
   }
   // handle the leftover 0..15 columns
   for(size_t col = width & ~15 ; col < width; col++)
@@ -1482,7 +1524,7 @@ static void box_min_1ch(float *const buf,
     float *const restrict scratch = scratch_buffers;
     for(size_t row = 0; row < height; row++)
       scratch[row] = buf[row * width + col];
-    box_min_1d(height, scratch, buf + col, width, w);
+    _box_min_1d(height, scratch, buf + col, width, w);
   }
 
   dt_free_align(scratch_buffers);
@@ -1491,11 +1533,11 @@ static void box_min_1ch(float *const buf,
 void dt_box_min(float *const buf,
                 const size_t height,
                 const size_t width,
-                const int ch,
-                const int radius)
+                const uint32_t ch,
+                const size_t radius)
 {
   if(ch == 1)
-    box_min_1ch(buf, height, width, radius);
+    _box_min_1ch(buf, height, width, radius);
   else
   //TODO: 4ch version if needed
     dt_unreachable_codepath();

--- a/src/common/box_filters.h
+++ b/src/common/box_filters.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2021 darktable developers.
+    Copyright (C) 2009-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <stdlib.h>
+#include <inttypes.h>
 
 // default number of iterations to run for dt_box_mean
 #define BOX_ITERATIONS 8
@@ -28,17 +29,17 @@
 #define BOXFILTER_KAHAN_SUM 0x1000000
 
 // ch = number of channels per pixel.  Supported values: 1, 2, 4, and 4|Kahan
-void dt_box_mean(float *const buf, const size_t height, const size_t width, const int ch,
-                 const int radius, const unsigned interations);
+void dt_box_mean(float *const buf, const size_t height, const size_t width, const uint32_t ch,
+                 const size_t radius, const uint32_t interations);
 // run a single iteration horizonally over a single row.  Supported values for ch: 4|Kahan
 // 'scratch' must point at a buffer large enough to hold ch*width floats, or be NULL
-void dt_box_mean_horizontal(float *const restrict buf, const size_t width, const int ch, const int radius,
+void dt_box_mean_horizontal(float *const restrict buf, const size_t width, const uint32_t ch, const size_t radius,
                             float *const restrict scratch);
 // run a single iteration vertically over the entire image.  Supported values for ch: 4|Kahan
-void dt_box_mean_vertical(float *const buf, const size_t height, const size_t width, const int ch, const int radius);
+void dt_box_mean_vertical(float *const buf, const size_t height, const size_t width, const uint32_t ch, const size_t radius);
 
-void dt_box_min(float *const buf, const size_t height, const size_t width, const int ch, const int radius);
-void dt_box_max(float *const buf, const size_t height, const size_t width, const int ch, const int radius);
+void dt_box_min(float *const buf, const size_t height, const size_t width, const uint32_t ch, const size_t radius);
+void dt_box_max(float *const buf, const size_t height, const size_t width, const uint32_t ch, const size_t radius);
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py


### PR DESCRIPTION
1. implement the 2float box_mean kahan variant
2. performance gain for _box_mean_4ch_Kahan by allocation scratch buff outside iteration loop
3. dt_box_mean also supports the new variant
4. Test for allocated scratch buffers to avoid crashes
5. all static functions get a leading underscore
6. use size_t / uint32_t where appropriate

Also required for stable working in #15926, the guiding filters is far better working by using the kahan variants for the box filters.