### PR TITLE
RFC: Remove 'unrestricted' resource setting from UI preferences

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -217,12 +217,11 @@
         <option>small</option>
         <option>default</option>
         <option>large</option>
-        <option>unrestricted</option>
       </enum>
     </type>
     <default>default</default>
     <shortdescription>darktable resources</shortdescription>
-    <longdescription>defines how much darktable may take from your system resources:\n - 'default': darktable takes ~50% of your systems resources and gives darktable enough to be still performant.\n - 'small': should be used if you are simultaneously running applications taking large parts of your systems memory or OpenCL/GL applications like games or Hugin.\n - 'large': is the best option if you are mainly using darktable and want it to take most of your systems resources for performance.\n - 'unrestricted': should only be used for developing extremely large images as darktable will take all of your systems resources\n   and thus might lead to swapping and unexpected performance drops.\n   use with caution and not recommended for general use!</longdescription>
+    <longdescription>defines how much darktable may take from your system resources:\n - 'default': darktable takes ~50% of your systems resources and gives darktable enough to be still performant.\n - 'small': should be used if you are simultaneously running applications taking large parts of your systems memory or OpenCL/GL applications like games or Hugin.\n - 'large': is the best option if you are mainly using darktable and want it to take most of your systems resources for performance.</longdescription>
   </dtconfig>
   <dtconfig prefs="processing" section="cpugpu">
     <name>ui/performance</name>


### PR DESCRIPTION
We have had quite a number of issues by users setting the resources preference to "unrestricted" despite clear warnings in tooltips and the manual - whatever the reason is to do so.

In some situations this might be useful though but clearly for the experienced user understanding darktable internals, system mem management and possibly OpenCL driver/device specific stuff.

So:
1. remove that option from UI preferences
2. keep it available to be set via the resource file