### PR TITLE
Fix locale for aperture filter

### DIFF
--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -99,7 +99,7 @@ guint dt_util_str_occurence(const gchar *haystack, const gchar *needle)
 
 gchar *dt_util_float_to_str(const gchar *format, const double value)
 {
-#if defined(_MSC_VER)
+#if defined(WIN32)
   _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
   setlocale (LC_NUMERIC, "C");
 #else
@@ -110,7 +110,7 @@ gchar *dt_util_float_to_str(const gchar *format, const double value)
 
   gchar *txt = g_strdup_printf(format, value);
   
-#if defined(_MSC_VER)
+#if defined(WIN32)
   _configthreadlocale(_DISABLE_PER_THREAD_LOCALE);
 #else
   uselocale(locale);

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -97,6 +97,28 @@ guint dt_util_str_occurence(const gchar *haystack, const gchar *needle)
   return o;
 }
 
+gchar *dt_util_float_to_str(const gchar *format, const double value)
+{
+#if defined(_MSC_VER)
+  _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
+  setlocale (LC_NUMERIC, "C");
+#else
+  locale_t locale = uselocale((locale_t) 0);
+  locale_t nlocale = newlocale(LC_NUMERIC_MASK, "C", (locale_t) 0);
+  uselocale(nlocale);
+#endif
+
+  gchar *txt = g_strdup_printf(format, value);
+  
+#if defined(_MSC_VER)
+  _configthreadlocale(_DISABLE_PER_THREAD_LOCALE);
+#else
+  uselocale(locale);
+  freelocale(nlocale);
+#endif
+  return txt;
+}
+
 gchar *dt_util_str_replace(const gchar *string, const gchar *pattern, const gchar *substitute)
 {
   const gint occurrences = dt_util_str_occurence(string, pattern);

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -103,9 +103,8 @@ gchar *dt_util_float_to_str(const gchar *format, const double value)
   _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
   setlocale (LC_NUMERIC, "C");
 #else
-  locale_t locale = uselocale((locale_t) 0);
   locale_t nlocale = newlocale(LC_NUMERIC_MASK, "C", (locale_t) 0);
-  uselocale(nlocale);
+  locale_t locale = uselocale(nlocale);
 #endif
 
   gchar *txt = g_strdup_printf(format, value);

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -33,6 +33,8 @@ gchar *dt_util_dstrcat(gchar *str, const gchar *format, ...) __attribute__((form
 gchar *dt_util_str_replace(const gchar *string, const gchar *pattern, const gchar *substitute);
 /** count the number of occurrences of needle in haystack */
 guint dt_util_str_occurence(const gchar *haystack, const gchar *needle);
+/** format a floating point number string with dot separator locale independent */
+gchar *dt_util_float_to_str(const gchar *format, const double value);
 /** generate a string from the elements of the list, separated by separator. the result has to be freed. */
 gchar *dt_util_glist_to_str(const gchar *separator, GList *items);
 /** generate a GList from the elements of a string, separated by separator. the result has to be freed. */

--- a/src/libs/filters/aperture.c
+++ b/src/libs/filters/aperture.c
@@ -67,7 +67,19 @@ static gboolean _aperture_update(dt_lib_filtering_rule_t *rule)
 
 static gchar *_aperture_print_func(const double value, const gboolean detailled)
 {
-  return g_strdup_printf("%s%.1lf", detailled ? "f/" : "", value);
+  if (detailled)
+  {
+    return g_strdup_printf("%s%.1lf", detailled ? "f/" : "", value);
+  }
+  else
+  {
+    gchar *locale = g_strdup(setlocale(LC_ALL, NULL));
+    setlocale(LC_NUMERIC, "C");
+    gchar *txt = g_strdup_printf("%.1lf", value);
+    setlocale(LC_NUMERIC, locale);
+    g_free(locale);
+    return txt;
+  }
 }
 
 static void _aperture_widget_init(dt_lib_filtering_rule_t *rule, const dt_collection_properties_t prop,

--- a/src/libs/filters/aperture.c
+++ b/src/libs/filters/aperture.c
@@ -69,7 +69,7 @@ static gchar *_aperture_print_func(const double value, const gboolean detailled)
 {
   if(detailled)
   {
-    return g_strdup_printf("%s%.1lf", detailled ? "f/" : "", value);
+    return g_strdup_printf("f/%.1lf", value);
   }
   else
   {

--- a/src/libs/filters/aperture.c
+++ b/src/libs/filters/aperture.c
@@ -20,6 +20,7 @@
   This file contains the necessary routines to implement a filter for the filtering module
 */
 
+#include "common/utility.h"
 
 static gboolean _aperture_update(dt_lib_filtering_rule_t *rule)
 {
@@ -73,12 +74,7 @@ static gchar *_aperture_print_func(const double value, const gboolean detailled)
   }
   else
   {
-    gchar *locale = g_strdup(setlocale(LC_ALL, NULL));
-    setlocale(LC_NUMERIC, "C");
-    gchar *txt = g_strdup_printf("%.1lf", value);
-    setlocale(LC_NUMERIC, locale);
-    g_free(locale);
-    return txt;
+    return dt_util_float_to_str("%.1f", value);
   }
 }
 

--- a/src/libs/filters/aperture.c
+++ b/src/libs/filters/aperture.c
@@ -67,7 +67,7 @@ static gboolean _aperture_update(dt_lib_filtering_rule_t *rule)
 
 static gchar *_aperture_print_func(const double value, const gboolean detailled)
 {
-  if (detailled)
+  if(detailled)
   {
     return g_strdup_printf("%s%.1lf", detailled ? "f/" : "", value);
   }

--- a/src/libs/filters/exposure.c
+++ b/src/libs/filters/exposure.c
@@ -20,6 +20,7 @@
   This file contains the necessary routines to implement a filter for the filtering module
 */
 
+#include "common/utility.h"
 
 static gboolean _exposure_update(dt_lib_filtering_rule_t *rule)
 {
@@ -84,12 +85,7 @@ static gchar *_exposure_print_func(const double value, const gboolean detailled)
   }
   else
   {
-    gchar *locale = g_strdup(setlocale(LC_ALL, NULL));
-    setlocale(LC_NUMERIC, "C");
-    gchar *txt = g_strdup_printf("%.6lf", value);
-    setlocale(LC_NUMERIC, locale);
-    g_free(locale);
-    return txt;
+    return dt_util_float_to_str("%.6lf", value);
   }
 }
 

--- a/src/libs/filters/iso.c
+++ b/src/libs/filters/iso.c
@@ -20,6 +20,7 @@
   This file contains the necessary routines to implement a filter for the filtering module
 */
 
+#include "common/utility.h"
 
 static gboolean _iso_update(dt_lib_filtering_rule_t *rule)
 {
@@ -91,12 +92,7 @@ static gchar *_iso_print_func(const double value, const gboolean detailled)
   }
   else
   {
-    gchar *locale = g_strdup(setlocale(LC_ALL, NULL));
-    setlocale(LC_NUMERIC, "C");
-    gchar *txt = g_strdup_printf("%.0lf", value);
-    setlocale(LC_NUMERIC, locale);
-    g_free(locale);
-    return txt;
+    return dt_util_float_to_str("%.0lf", value);
   }
 }
 

--- a/src/libs/filters/ratio.c
+++ b/src/libs/filters/ratio.c
@@ -20,6 +20,8 @@
   This file contains the necessary routines to implement a filter for the filtering module
 */
 
+#include "common/utility.h"
+
 static gboolean _ratio_update(dt_lib_filtering_rule_t *rule)
 {
   if(!rule->w_specific) return FALSE;
@@ -110,11 +112,7 @@ static double _ratio_value_from_band_func(const double value)
 
 static gchar *_ratio_print_func(const double value, const gboolean detailled)
 {
-  gchar *locale = g_strdup(setlocale(LC_ALL, NULL));
-  setlocale(LC_NUMERIC, "C");
-  gchar *txt = g_strdup_printf("%.2lf", value);
-  setlocale(LC_NUMERIC, locale);
-  g_free(locale);
+  gchar *txt = dt_util_float_to_str("%.2lf", value);
 
   if(detailled)
   {


### PR DESCRIPTION
fixes #16031 

The locale needs to be switched for the aperture values, similar to the exposure filter.
