### PR TITLE
Remove unused code that might trigger compiler warning

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2023 darktable developers.
+    Copyright (C) 2010-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -1194,10 +1194,6 @@ static int32_t dt_control_delete_images_job_run(dt_job_t *job)
     gboolean from_cache = FALSE;
     dt_image_full_path(imgid, filename, sizeof(filename), &from_cache);
 
-#ifdef _WIN32
-    char *dirname = g_path_get_dirname(filename);
-#endif
-
     int duplicates = 0;
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
     if(sqlite3_step(stmt) == SQLITE_ROW)
@@ -1268,9 +1264,6 @@ static int32_t dt_control_delete_images_job_run(dt_job_t *job)
     }
 
 delete_next_file:
-#ifdef _WIN32
-    g_free(dirname);
-#endif
     t = g_list_next(t);
     fraction += 1.0 / total;
     dt_control_job_set_progress(job, fraction);


### PR DESCRIPTION
When building under Windows with -DCMAKE_BUILD_TYPE=Release, we get the following warning that makes the build fail:

```
[225/737] Building C object bin/CMakeFiles/lib_darktable.dir/control/jobs/control_jobs.c.obj
FAILED: bin/CMakeFiles/lib_darktable.dir/control/jobs/control_jobs.c.obj
C:\msys64\ucrt64\bin\cc.exe -DAVIF_DLL -DGDK_DISABLE_DEPRECATED -DGDK_VERSION_MIN_REQUIRED=GDK_VERSION_3_24 -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_MIN_REQUIRED -DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_56 -DGTK_DISABLE_DEPRECATED -DGTK_DISABLE_SINGLE_INCLUDES -DHAVE_BUILTIN_CPU_SUPPORTS -DHAVE_CONFIG_H -DHAVE_GAME -DHAVE_GMIC -DHAVE_GPHOTO2 -DHAVE_GRAPHICSMAGICK -DHAVE_ICU -DHAVE_IMATH -DHAVE_ISO_CODES -DHAVE_LIBAVIF=1 -DHAVE_LIBEXIV2_WITH_ISOBMFF=1 -DHAVE_LIBHEIF=1 -DHAVE_LIBJXL -DHAVE_LIBRAW=1 -DHAVE_LIBSECRET -DHAVE_LIBSHARPYUV=1 -DHAVE_MAP -DHAVE_OPENCL -DHAVE_OPENEXR -DHAVE_OPENJPEG -DHAVE_OSMGPSMAP_110_OR_NEWER -DHAVE_OSMGPSMAP_NEWER_THAN_110 -DHAVE_SQLITE_324_OR_NEWER -DHAVE_VISIBILITY -DHAVE_WEBP -DIMATH_DLL -DLIBHEIF_EXPORTS -DNATIVE_ARCH -DOPENEXR_DLL -DSQLITE_CORE -DSQLITE_ENABLE_ICU -D_POSIX_THREAD_SAFE_FUNCTIONS -D_USE_MATH_DEFINES -D__USE_MINGW_ANSI_STDIO=1 -Dlib_darktable_EXPORTS -IC:/msys64/home/Victor/darktable/build/bin -IC:/msys64/home/Victor/darktable/src -IC:/msys64/home/Victor/darktable/src/external/whereami/src -isystem C:/msys64/home/Victor/darktable/src/external -isystem C:/msys64/home/Victor/darktable/src/external/OpenCL -isystem C:/msys64/ucrt64/include/glib-2.0 -isystem C:/msys64/ucrt64/lib/glib-2.0/include -isystem C:/msys64/ucrt64/include/gtk-3.0 -isystem C:/msys64/ucrt64/include/pango-1.0 -isystem C:/msys64/ucrt64/include/cairo -isystem C:/msys64/ucrt64/include/harfbuzz -isystem C:/msys64/ucrt64/include/freetype2 -isystem C:/msys64/ucrt64/include/gdk-pixbuf-2.0 -isystem C:/msys64/ucrt64/include/atk-1.0 -isystem C:/msys64/ucrt64/include/pixman-1 -isystem C:/msys64/ucrt64/include/libpng16 -isystem C:/msys64/ucrt64/include/webp -isystem C:/msys64/ucrt64/include/fribidi -isystem C:/msys64/ucrt64/include/libxml2 -isystem C:/msys64/ucrt64/include/lensfun -isystem C:/msys64/ucrt64/include/librsvg-2.0 -isystem C:/msys64/ucrt64/include/json-glib-1.0 -isystem C:/msys64/ucrt64/include/openjpeg-2.5 -isystem C:/msys64/ucrt64/include/libsecret-1 -isystem C:/msys64/ucrt64/include/GraphicsMagick -isystem C:/msys64/ucrt64/include/osmgpsmap-1.0 -isystem C:/msys64/ucrt64/include/libsoup-2.4 -isystem C:/msys64/ucrt64/include/Imath -isystem C:/msys64/ucrt64/include/OpenEXR -Wall -Wno-format -Wshadow -Wtype-limits -Wvla -Wold-style-declaration -Wmaybe-uninitialized -Wno-unknown-pragmas -Wno-error=varargs -Wno-format-truncation -Wno-error=address-of-packed-member -fopenmp -march=native -msse2 -g -mfpmath=sse -O3 -DNDEBUG -O3 -ffast-math -fno-finite-math-only -fexpensive-optimizations -std=c99   -DUNICODE -D_UNICODE -Werror -Wfatal-errors -MD -MT bin/CMakeFiles/lib_darktable.dir/control/jobs/control_jobs.c.obj -MF bin\CMakeFiles\lib_darktable.dir\control\jobs\control_jobs.c.obj.d -o bin/CMakeFiles/lib_darktable.dir/control/jobs/control_jobs.c.obj -c C:/msys64/home/Victor/darktable/src/control/jobs/control_jobs.c
C:/msys64/home/Victor/darktable/src/control/jobs/control_jobs.c: In function 'dt_control_delete_images_job_run':
C:/msys64/home/Victor/darktable/src/control/jobs/control_jobs.c:1272:5: error: 'dirname' may be used uninitialized [-Werror=maybe-uninitialized]
 1272 |     g_free(dirname);
      |     ^~~~~~~~~~~~~~~
compilation terminated due to -Wfatal-errors.
cc1.exe: all warnings being treated as errors
```

This warning does not appear when building with -DCMAKE_BUILD_TYPE=Debug, so this problem was not caught in CI, where the Debug build type was used for faster compilation.

So, by the way, the next PR will replace the build type in CI for Windows, as Release is more important to us and we can also expect that a higher level of optimization uses more checks, so there is a higher chance of failure from triggering a compiler warning.

The code that triggers the warning here is not actually used in any way. At one point in the function, a pointer variable is assigned the address of the allocated memory filled with a string, and later that area is freed. But there is no use of this variable. It looks like it was a copy-paste from another function.

@TurboGit Since Windows nightly is built with a Release type, the last nightly build failed because of this. It would be nice to have this fix before the next nightly.
