### PR TITLE
[GUI] Rename the module so that there is no verb in the name

### DIFF
--- a/src/iop/enlargecanvas.c
+++ b/src/iop/enlargecanvas.c
@@ -72,7 +72,7 @@ typedef struct dt_iop_enlargecanvas_gui_data_t
 
 const char *name()
 {
-  return _("enlarge canvas");
+  return _("canvas enlargement");
 }
 
 const char** description(struct dt_iop_module_t *self)


### PR DESCRIPTION
We do not have modules with a verb in their name. The only module that violated this naming convention was renamed in PR #15788.