### PR TITLE
Bump libavif requirement to 0.9.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Optional dependencies (minimum version):
 * Lua 5.4 *(for plugins and extension scripting)*
 * libgphoto2 2.5 *(for camera tethering)*
 * Imath 3.1.0 *(for 16-bit "half" float TIFF export and faster import)*
-* libavif 0.9.2 *(for AVIF import & export)*
+* libavif 0.9.3 *(for AVIF import & export)*
 * libheif 1.13.0 *(for HEIF/HEIC/HIF import; also for AVIF import if no libavif)*
 * libjxl 0.7.0 *(for JPEG XL import & export)*
 * WebP 0.3.0 *(for WebP import & export)*

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -98,7 +98,7 @@ changes (where available).
 
 ### Optional
 
-- Bump libavif to 0.9.2
+- Bump libavif to 0.9.3
 
 ## RawSpeed changes
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -364,7 +364,7 @@ if(USE_AVIF)
   # no version check in config mode because of major only match policy
   find_package(libavif CONFIG)
   if(TARGET avif)
-    if(libavif_VERSION VERSION_GREATER_EQUAL 0.9.2)
+    if(libavif_VERSION VERSION_GREATER_EQUAL 0.9.3)
       list(APPEND LIBS avif)
       add_definitions(-DHAVE_LIBAVIF=1)
       list(APPEND SOURCES "imageio/imageio_avif.c")


### PR DESCRIPTION
0.9.2 release was actually [misreporting](https://github.com/flathub/org.darktable.Darktable/issues/118#issuecomment-1880579185) itself and was short-lived... Debian 11 and Ubuntu 22.04 ship 0.9.3 anyway.

Could potentially clarify for 4.6.x branch as well...