### PR TITLE
Avoid crash when starting with a locked database on Windows

### DIFF
--- a/src/common/database.c
+++ b/src/common/database.c
@@ -3364,7 +3364,7 @@ void dt_database_show_error(const dt_database_t *db)
     char lck_pathname[1024];
     snprintf(lck_pathname, sizeof(lck_pathname), "%s.lock", db->error_dbfilename);
     char *lck_dirname = g_strdup(lck_pathname);
-    char *last_dirsep_position = g_strrstr(lck_dirname, "/");
+    char *last_dirsep_position = g_strrstr(lck_dirname, G_DIR_SEPARATOR_S);
     if(last_dirsep_position)
       *last_dirsep_position = '\0';  // make lck_dirname contain only the directory name
 

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -3364,7 +3364,10 @@ void dt_database_show_error(const dt_database_t *db)
     char lck_pathname[1024];
     snprintf(lck_pathname, sizeof(lck_pathname), "%s.lock", db->error_dbfilename);
     char *lck_dirname = g_strdup(lck_pathname);
-    *g_strrstr(lck_dirname, "/") = '\0';
+    char *last_dirsep_position = g_strrstr(lck_dirname, "/");
+    if(last_dirsep_position)
+      *last_dirsep_position = '\0';  // make lck_dirname contain only the directory name
+
     // clang-format off
     char *label_text = g_markup_printf_escaped(
         _("\n"


### PR DESCRIPTION
Fixes #16023.

The existing code was very unsafe and did not check if it would write to a NULL address. Also, the search for the directory separator in the string did not take into account that the separator is different on Windows.