### PR TITLE
Fix XYZ_to_xyY and dt_xyY_to_XYZ conversions

### DIFF
--- a/data/kernels/colorspace.h
+++ b/data/kernels/colorspace.h
@@ -624,20 +624,35 @@ static inline float4 dt_uvY_to_xyY(const float4 uvY)
 
 static inline float4 dt_XYZ_to_xyY(const float4 XYZ)
 {
+  // see cpu implementation for details
   float4 xyY;
   const float sum = XYZ.x + XYZ.y + XYZ.z;
-  xyY.xy = XYZ.xy / sum;
+  if(XYZ.x == 0.0f && XYZ.y == 0.0f && XYZ.z == 0.0f)
+  {
+    xyY.x = 2.0f / 4.5f;
+    xyY.y = 1.0f / 4.5f;
+  }
+  else
+  {
+    xyY.xy = XYZ.xy / sum;
+  }
+
   xyY.z = XYZ.y;
   xyY.w = XYZ.w;
+
   return xyY;
 }
 
 static inline float4 dt_xyY_to_XYZ(const float4 xyY)
 {
-  float4 XYZ;
-  XYZ.x = xyY.z * xyY.x / xyY.y;
-  XYZ.y = xyY.z;
-  XYZ.z = xyY.z * (1.f - xyY.x - xyY.y) / xyY.y;
+  // see cpu implementation for details
+  float4 XYZ = 0.0f;
+  if(xyY.y != 0.0f)
+  {
+    XYZ.x = xyY.z * xyY.x / xyY.y;
+    XYZ.y = xyY.z;
+    XYZ.z = xyY.z * (1.f - xyY.x - xyY.y) / xyY.y;
+  }
   XYZ.w = xyY.w;
   return XYZ;
 }


### PR DESCRIPTION
The functions `dt_XYZ_to_xyY` and `dt_xyY_to_XYZ` can return NaNs both on opencl and cpu code path as we might divide by zero.

Both functions now check for such an error condition - black pixels - and calculate otherwise as suggested by bruce lindbloom at http://brucelindbloom.com

Found this while investigating issues like black boxes or leaking blues in #15926

These might explain some problems also in colorbalancergb or difficulties with some OpenCL drivers that dislike NaNs. I would suggest this also for 4.6.1
