### PR TITLE
[CI] Use Release build on all platforms plus one Debug build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,7 +288,7 @@ jobs:
           - { os: macos-12,    xcode: 14.2,   deployment: 12.5 } # LLVM14
         compiler:
           - { compiler: XCode,   CC: cc, CXX: c++ }
-        btype: [ Debug ]
+        btype: [ Release ]
         target:
           - skiptest
         generator:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,13 @@ jobs:
         generator:
           #- Unix Makefiles
           - Ninja
+        include:
+          # We want one run in CI to be Debug to make sure the Debug build isn't broken
+          - os: { label: ubuntu-latest, code: latest }
+            btype: Debug
+            compiler: { compiler: GNU13,  CC: gcc-13,   CXX: g++-13,     packages: gcc-13 g++-13 }
+            target: skiptest
+            generator: Ninja
     env:
       CC: ${{ matrix.compiler.CC }}
       CXX: ${{ matrix.compiler.CXX }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
       fail-fast: true
       matrix:
         btype:
-          - Debug
+          - Release
         msystem:
           #- CLANG64
           - UCRT64


### PR DESCRIPTION
As described in #16054, in a Release build compilers can issue warnings that are not present in a Debug build. So to ensure build success on all platforms (since there is platform-specific code), we switch the build tasks to Release.

But, as suggested by @ralfbrown, we keep one Debug build in the CI just to make sure the Debug build is not broken.

