### PR TITLE
iop_order: Move overlay before liquify & retouch.

### DIFF
--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -196,6 +196,7 @@ const dt_iop_order_entry_t v30_order[] = {
   { {15.0f }, "ashift", 0},
   { {16.0f }, "flip", 0},
   { {16.5f }, "enlargecanvas", 0},
+  { {16.7f }, "overlay", 0},
   { {17.0f }, "clipping", 0},
   { {18.0f }, "liquify", 0},
   { {19.0f }, "spots", 0},
@@ -207,7 +208,6 @@ const dt_iop_order_entry_t v30_order[] = {
                                      // roi_in
   { {24.5f }, "crop", 0},            // should go after all modules
                                      // that may need a wider roi_in
-  { {24.7f }, "overlay", 0},
   { {25.0f }, "graduatednd", 0},
   { {26.0f }, "profile_gamma", 0},
   { {27.0f }, "equalizer", 0},
@@ -313,6 +313,7 @@ const dt_iop_order_entry_t v30_jpg_order[] = {
   { { 28.0f }, "ashift", 0},
   { { 28.0f }, "flip", 0},
   { { 28.0f }, "enlargecanvas", 0},
+  { { 28.0f }, "overlay", 0},
   { { 28.0f }, "clipping", 0},
   { { 28.0f }, "liquify", 0},
   { { 28.0f }, "spots", 0},
@@ -323,7 +324,6 @@ const dt_iop_order_entry_t v30_jpg_order[] = {
   { { 28.0f }, "toneequal", 0},       // last module that need enlarged roi_in
   { { 28.0f }, "crop", 0},            // should go after all modules
                                       // that may need a wider roi_in
-  { { 28.0f }, "overlay", 0},
   { { 28.0f }, "graduatednd", 0},
   { { 28.0f }, "profile_gamma", 0},
   { { 28.0f }, "equalizer", 0},
@@ -922,7 +922,7 @@ GList *dt_ioppr_get_iop_order_list(const dt_imgid_t imgid,
           _insert_before(iop_order_list, "ashift", "cacorrectrgb");
           _insert_before(iop_order_list, "graduatednd", "crop");
           _insert_before(iop_order_list, "flip", "enlargecanvas");
-          _insert_before(iop_order_list, "crop", "overlay");
+          _insert_before(iop_order_list, "enlargecanvas", "overlay");
           _insert_before(iop_order_list, "colorbalance", "diffuse");
           _insert_before(iop_order_list, "nlmeans", "blurs");
           _insert_before(iop_order_list, "filmicrgb", "sigmoid");


### PR DESCRIPTION
For some reasons the overly iop-order was moved while I worked on this PR making it impossible to use Retouch or Liquify as I demonstrated in PR #15465.