### PR TITLE
Ensure safe RGB data while processing colorbalancergb

### DIFF
--- a/data/kernels/extended.cl
+++ b/data/kernels/extended.cl
@@ -980,6 +980,7 @@ colorbalancergb (read_only image2d_t in, write_only image2d_t out,
   }
   else
   {
+    XYZ_D65 = fmax(0.0f, XYZ_D65);
     float4 xyY = dt_XYZ_to_xyY(XYZ_D65);
     float4 JCH = xyY_to_dt_UCS_JCH(xyY, L_white);
     float4 HCB = dt_UCS_JCH_to_HCB(JCH);
@@ -991,8 +992,8 @@ colorbalancergb (read_only image2d_t in, write_only image2d_t out,
     // This would be the full matrice of direct rotation if we didn't need only its last row
     //const float M_rot_dir[2][2] = { { cos_T, -sin_T }, {  sin_T, cos_T } };
 
-    float P = HCB.y;
-    float W = sin_T * HCB.y + cos_T * HCB.z;
+    const float P = fmax(FLT_MIN, HCB.y);
+    const float W = sin_T * HCB.y + cos_T * HCB.z;
 
     float a = fmax(1.f + saturation_global + dot(opacities, saturation), 0.f);
     const float b = fmax(1.f + brilliance_global + dot(opacities, brilliance), 0.f);

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -911,6 +911,7 @@ void process(struct dt_iop_module_t *self,
     else
     {
       dt_aligned_pixel_t xyY, JCH, HCB;
+      dt_vector_clipneg(XYZ_D65);
       dt_XYZ_to_xyY(XYZ_D65, xyY);
       xyY_to_dt_UCS_JCH(xyY, L_white, JCH);
       dt_UCS_JCH_to_HCB(JCH, HCB);
@@ -922,8 +923,8 @@ void process(struct dt_iop_module_t *self,
       // This would be the full matrice of direct rotation if we didn't need only its last row
       //const float DT_ALIGNED_PIXEL M_rot_dir[2][2] = { { cos_T, -sin_T }, {  sin_T, cos_T } };
 
-      float P = HCB[1];
-      float W = sin_T * HCB[1] + cos_T * HCB[2];
+      const float P = MAX(FLT_MIN, HCB[1]); // as HCB[1] is at least zero we don't fiddle with sign
+      const float W = sin_T * HCB[1] + cos_T * HCB[2];
 
       float a = MAX(1.f + d->saturation_global + scalar_product(opacities, saturation), 0.f);
       const float b = MAX(1.f + d->brilliance_global + scalar_product(opacities, brilliance), 0.f);


### PR DESCRIPTION
As reported in #16071 (comments) we can have some visible artefacts in very dark areas.

These are due to negative pixel rgb data in the still linear part of processing. Make sure we don't process those by ensure at least 0 per channel. Both CPU and OpenCL paths have the same issue.

I think this is correct and also safe, @flannelhead @ralfbrown would appreciate your comments on this.