### PR TITLE
Use D65_xy as fallback in dt_XYZ_to_xyY

### DIFF
--- a/data/kernels/colorspace.h
+++ b/data/kernels/colorspace.h
@@ -624,13 +624,13 @@ static inline float4 dt_uvY_to_xyY(const float4 uvY)
 
 static inline float4 dt_XYZ_to_xyY(const float4 XYZ)
 {
-  // see cpu implementation for details
+  // see cpu implementation for details, use D65_xy as fallback
   float4 xyY;
   const float sum = XYZ.x + XYZ.y + XYZ.z;
   if(XYZ.x == 0.0f && XYZ.y == 0.0f && XYZ.z == 0.0f)
   {
-    xyY.x = 2.0f / 4.5f;
-    xyY.y = 1.0f / 4.5f;
+    xyY.x = 0.312700492f;
+    xyY.y = 0.329000939f;
   }
   else
   {

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -46,9 +46,6 @@
 
 static const cmsCIEXYZ d65 = {0.95045471, 1.00000000, 1.08905029};
 
-//D65 (sRGB, AdobeRGB, Rec2020)
-static const cmsCIExyY D65xyY = {0.312700492, 0.329000939, 1.0};
-
 //D60
 //static const cmsCIExyY d60 = {0.32168, 0.33767, 1.0};
 

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -27,6 +27,9 @@
   #define TYPE_XYZA_FLT (FLOAT_SH(1)|COLORSPACE_SH(PT_XYZ)|EXTRA_SH(1)|CHANNELS_SH(3)|BYTES_SH(4))
 #endif
 
+//D65 (sRGB, AdobeRGB, Rec2020)
+static const cmsCIExyY D65xyY = {0.312700492, 0.329000939, 1.0};
+
 /** colorspace enums, must be in synch with dt_iop_colorspace_type_t
  * in color_conversion.cl */
 typedef enum dt_iop_colorspace_type_t

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -19,7 +19,7 @@
 #pragma once
 
 #include "common/math.h" // also loads darkable.h, sse.h, <xmmintrin.h>
-
+#include "common/colorspaces.h"
 
 #ifdef __SSE2__
 static inline __m128 lab_f_inv_m(const __m128 x)
@@ -279,13 +279,12 @@ static inline void dt_XYZ_to_xyY(const dt_aligned_pixel_t XYZ, dt_aligned_pixel_
   const gboolean black = XYZ[0] == 0.0f && XYZ[1] == 0.0f && XYZ[2] == 0.0f;
   /* the calculation for black would fail with NaNs as result.
      According to http://www.brucelindbloom.com/index.html?Eqn_XYZ_to_xyY.html
-     we would want the chromaticity coordinates of the reference white.
-     As this is a costly operation requiring dev->white-balance data we use a rough guess
-     of 2.0, 1.0, 1.5
+     we would want the pipes chromaticity coordinates of the reference white.
+     The best guess as a fallback is from D65_xyY so
   */
   const float sum = XYZ[0] + XYZ[1] + XYZ[2];
-  xyY[0] = black ? 2.0f / 4.5f : XYZ[0] / sum;
-  xyY[1] = black ? 1.0f / 4.5f : XYZ[1] / sum;
+  xyY[0] = black ? D65xyY.x : XYZ[0] / sum;
+  xyY[1] = black ? D65xyY.y : XYZ[1] / sum;
   xyY[2] = XYZ[1];
 }
 


### PR DESCRIPTION
The best guess we have as a fallback for all-black is D65_xy instead of some RGB_xy default.

Improved results for "complete blacks" in color equalizer module visible, we should use these in any case instead of "RGB_xy" as a fallback as we are most likely in D65. 

Should be for 4.6 too