### PR TITLE
[map]: fix double click on map osd circle

### DIFF
--- a/src/views/map.c
+++ b/src/views/map.c
@@ -1898,8 +1898,13 @@ static gboolean _view_map_button_press_callback(GtkWidget *w, GdkEventButton *e,
     const gint osd_y = g_value_get_int(&value);
     g_object_get_property((GObject*) lib->osd, "dpad-radius", &value);
     const gint dpad_radius = g_value_get_int(&value);
+    g_object_get_property((GObject*) lib->osd, "show-zoom", &value);
+    // g_value_get_boolean returns FALSE although the value is 1! Bug?
+    const gint show_zoom = g_value_get_int(&value);  
+    const gint zoom_height = show_zoom? 40:0;
 
-    if(e->x >= osd_x && e->x <= osd_x+2*dpad_radius && e->y >= osd_y && e->y <= osd_y+2*dpad_radius)
+    if(e->x >= osd_x && e->x <= osd_x+2*dpad_radius && 
+       e->y >= osd_y && e->y <= osd_y+2*dpad_radius+zoom_height)
     {
       return FALSE;
     }

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -1884,6 +1884,27 @@ static gboolean _view_map_button_press_callback(GtkWidget *w, GdkEventButton *e,
     g_list_free(lib->selected_images);
     lib->selected_images = NULL;
   }
+
+  if(lib->osd)
+  {
+    // check if the OSD circle was clicked
+    GValue value = {
+      0,
+    };
+
+    g_object_get_property((GObject*) lib->osd, "osd-x", &value);
+    const gint osd_x = g_value_get_int(&value);
+    g_object_get_property((GObject*) lib->osd, "osd-y", &value);
+    const gint osd_y = g_value_get_int(&value);
+    g_object_get_property((GObject*) lib->osd, "dpad-radius", &value);
+    const gint dpad_radius = g_value_get_int(&value);
+
+    if(e->x >= osd_x && e->x <= osd_x+2*dpad_radius && e->y >= osd_y && e->y <= osd_y+2*dpad_radius)
+    {
+      return FALSE;
+    }
+  }
+
   if(e->button == 1)
   {
     // check if the click was in a location form - crtl gives priority to images


### PR DESCRIPTION
fixes #16062 

The OSD circle on the map view should handle the click/doubleclick without further interaction.
