### PR TITLE
Fixes for gamut_lut in colorbalance rgb

### DIFF
--- a/data/kernels/colorspace.h
+++ b/data/kernels/colorspace.h
@@ -840,7 +840,7 @@ static inline float4 xyY_to_dt_UCS_JCH(const float4 xyY, const float L_white)
   xyY_to_dt_UCS_UV(xyY, UV_star_prime);
 
   // Y upper limit is calculated from the L star upper limit.
-  const float DT_UCS_Y_UPPER_LIMIT = 13237757000.f;
+  const float DT_UCS_Y_UPPER_LIMIT = 1e8f;
   const float L_star = Y_to_dt_UCS_L_star(clamp(xyY.z, 0.f, DT_UCS_Y_UPPER_LIMIT));
   const float M2 = UV_star_prime[0] * UV_star_prime[0] + UV_star_prime[1] * UV_star_prime[1]; // square of colorfulness M
 
@@ -867,7 +867,10 @@ static inline float4 dt_UCS_JCH_to_xyY(const float4 JCH, const float L_white)
   // should be L_star = powf(JCH[0], 1.f / cz) * L_white but we treat only the case where cz = 1
   // L_star upper limit is 2.098883786377 truncated to 32-bit float and last decimal removed.
   // By clipping L_star to this limit, we ensure dt_UCS_L_star_to_Y() doesn't divide by zero.
-  const float DT_UCS_L_STAR_UPPER_LIMIT = 2.098883f;
+  // Instead of using above theoretical values we use some modified versions
+  // that not avoid div-by-zero but div-by-close-to-zero
+  // this leads to more stability for extremely bright parts as we avoid single float precision overflows
+  const float DT_UCS_L_STAR_UPPER_LIMIT = 2.09885f;
   const float L_star = clamp(JCH.x * L_white, 0.f, DT_UCS_L_STAR_UPPER_LIMIT);
   const float M = L_star != 0.f
     ? native_powr(JCH.y * L_white / (15.932993652962535f * native_powr(L_star, 0.6523997524738018f)), 0.8322850678616855f)

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -1362,9 +1362,15 @@ static inline float dt_UCS_L_star_to_Y(const float L_star)
 
 // L_star upper limit is 2.098883786377 truncated to 32-bit float and last decimal removed.
 // By clipping L_star to this limit, we ensure dt_UCS_L_star_to_Y() doesn't divide by zero.
-static const float DT_UCS_L_STAR_UPPER_LIMIT = 2.098883f;
+// static const float DT_UCS_L_STAR_UPPER_LIMIT = 2.098883f;
 // Y upper limit is calculated from the above L star upper limit.
-static const float DT_UCS_Y_UPPER_LIMIT = 13237757000.f;
+// static const float DT_UCS_Y_UPPER_LIMIT = 13237757000.f;
+
+// Instead of using above theoretical values we use some modified versions
+// that not avoid div-by-zero but div-by-close-to-zero
+// this leads to more stability for extremely bright parts as we avoid single float precision overflows
+static const float DT_UCS_L_STAR_UPPER_LIMIT = 2.09885f;
+static const float DT_UCS_Y_UPPER_LIMIT = 1e8f;
 
 
 #ifdef _OPENMP


### PR DESCRIPTION
1. remove chroma_LUT as it is not used at all
2. use public D65xyY for initializing instead of specific declaration
3. ensure complete initializing of gamut_lut in UCS mode
4. always smooth gamut_lut
5. use proper reduction for max while in OpenMP