### PR TITLE
Make natural tag sorting configurable

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -319,6 +319,13 @@
     <shortdescription>omit hierarchy in simple tag lists</shortdescription>
     <longdescription>when creating an XMP sidecar file the hierarchical tags are also added as a simple list\nof non-hierarchical ones to make them visible to some other programs.\nwhen this option is checked darktable will only include their last part\nand ignore the rest. so 'foo|bar|baz' will only add 'baz'.</longdescription>
   </dtconfig>
+  <dtconfig prefs="misc" section="tags">
+    <name>tags_natural_sort</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>sort tags in natural order</shortdescription>
+    <longdescription>sort tags case-insensitive and in 'natural' order in the collection and tagging modules.\nso 'tag_2' will come before 'tag_10'</longdescription>
+  </dtconfig>
   <dtconfig dialog="collect">
     <name>plugins/lighttable/tagging/no_uncategorized</name>
     <type>bool</type>

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1235,7 +1235,7 @@ static gint _sort_folder_tag(gconstpointer a, gconstpointer b)
 
 // create a key such that  _("not tagged") & "darktable|" are coming first,
 // and the rest is ordered such that sub tags are coming directly behind their parent
-static char *tag_collate_key(char *tag)
+static char* _tag_collate_key(char *tag)
 {
   const size_t len = strlen(tag);
   char *result = g_malloc(len + 2);
@@ -1514,6 +1514,7 @@ static void _tree_view(dt_lib_collect_rule_t *dr)
     // because it knows nothing about path separators.
     GList *sorted_names = NULL;
     guint index = 0;
+    const gboolean tags_natural_sort = dt_conf_get_bool("tags_natural_sort");
     while(sqlite3_step(stmt) == SQLITE_ROW)
     {
       char *name;
@@ -1544,9 +1545,16 @@ static void _tree_view(dt_lib_collect_rule_t *dr)
       }
       else
       {
-        char *tck = tag_collate_key(name);
-        collate_key = g_utf8_collate_key_for_filename(tck, -1);
-        g_free(tck);
+        if(tags_natural_sort)
+        {
+          char *tck = _tag_collate_key(name);
+          collate_key = g_utf8_collate_key_for_filename(tck, -1);
+          g_free(tck);
+        }
+        else
+        {
+          collate_key = _tag_collate_key(name);
+        }
       }
 
       name_key_tuple_t *tuple = (name_key_tuple_t *)malloc(sizeof(name_key_tuple_t));


### PR DESCRIPTION
fixes #16081 

It seems that not everyone is comfortable with the natural tag sorting (#15983) so I now made it configurable in the preferences:

<img width="667" alt="Bildschirmfoto 2024-01-13 um 11 21 02" src="https://github.com/darktable-org/darktable/assets/4083281/48fc223f-c61f-44cd-b2fd-59e2d02a138a">
