### PR TITLE
Make use of public illuminant whitepoints

### DIFF
--- a/data/kernels/colorspace.h
+++ b/data/kernels/colorspace.h
@@ -629,8 +629,8 @@ static inline float4 dt_XYZ_to_xyY(const float4 XYZ)
   const float sum = XYZ.x + XYZ.y + XYZ.z;
   if(XYZ.x == 0.0f && XYZ.y == 0.0f && XYZ.z == 0.0f)
   {
-    xyY.x = 0.312700492f;
-    xyY.y = 0.329000939f;
+    xyY.x = (float)0.31271;
+    xyY.y = (float)0.32902;
   }
   else
   {

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -27,11 +27,12 @@
   #define TYPE_XYZA_FLT (FLOAT_SH(1)|COLORSPACE_SH(PT_XYZ)|EXTRA_SH(1)|CHANNELS_SH(3)|BYTES_SH(4))
 #endif
 
+// CIE 1931 2° as used in dt
 //D50 (ProPhoto RGB)
-static const cmsCIExyY D50xyY = {0.3457, 0.3585, 1.0};
+static const cmsCIExyY D50xyY = {0.34567, 0.35850, 1.0};
 
 //D65 (sRGB, AdobeRGB, Rec2020)
-static const cmsCIExyY D65xyY = {0.312700492, 0.329000939, 1.0};
+static const cmsCIExyY D65xyY = {0.31271, 0.32902, 1.0};
 
 /** colorspace enums, must be in synch with dt_iop_colorspace_type_t
  * in color_conversion.cl */

--- a/src/common/illuminants.h
+++ b/src/common/illuminants.h
@@ -257,8 +257,8 @@ static inline int illuminant_to_xy(const dt_illuminant_t illuminant, // primary 
     case DT_ILLUMINANT_PIPE:
     {
       // darktable default pipeline D50
-      x = 0.34567f;
-      y = 0.35850f;
+      x = D50xyY.x;
+      y = D50xyY.y;
       break;
     }
     case DT_ILLUMINANT_E:

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -1032,7 +1032,7 @@ static inline void _auto_detect_WB(const float *const restrict in,
    // Convert RGB to xy
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(width, height, ch, in, temp, RGB_to_XYZ) \
+  dt_omp_firstprivate(width, height, ch, in, temp, RGB_to_XYZ, D50xyY) \
   collapse(2) schedule(simd:static)
 #endif
   for(size_t i = 0; i < height; i++)
@@ -1056,7 +1056,7 @@ static inline void _auto_detect_WB(const float *const restrict in,
       XYZ[1] /= sum;   // y
 
       // Shift the chromaticity plane so the D50 point (target) becomes the origin
-      const float D50[2] = { 0.34567f, 0.35850f };
+      const float D50[2] = { D50xyY.x, D50xyY.y };
       const float norm = dt_fast_hypotf(D50[0], D50[1]);
 
       temp[index    ] = (XYZ[0] - D50[0]) / norm;
@@ -1182,7 +1182,7 @@ static inline void _auto_detect_WB(const float *const restrict in,
       }
   }
 
-  const float D50[2] = { 0.34567f, 0.35850 };
+  const float D50[2] = { D50xyY.x, D50xyY.y };
   const float norm_D50 = dt_fast_hypotf(D50[0], D50[1]);
 
   for(size_t c = 0; c < 2; c++)
@@ -1706,7 +1706,7 @@ static void _extract_color_checker(const float *const restrict in,
 
   // compute reference illuminant
   dt_aligned_pixel_t D50_XYZ;
-  illuminant_xy_to_XYZ(0.34567f, 0.35850f, D50_XYZ);
+  illuminant_xy_to_XYZ(D50xyY.x, D50xyY.y, D50_XYZ);
 
   // normalize luminances - note : illuminant is normalized by definition
   const float Y_test = XYZ_grey_test[1];

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -291,7 +291,7 @@ static double spd_blackbody(unsigned long int wavelength, double TempK)
  */
 static double spd_daylight(unsigned long int wavelength, double TempK)
 {
-  cmsCIExyY WhitePoint = { 0.3127, 0.3290, 1.0 };
+  cmsCIExyY WhitePoint = { D65xyY.x, D65xyY.y, 1.0 };
 
   /*
    * Bruce Lindbloom, "TempK to xy"


### PR DESCRIPTION
At several places we make use of `cmsCIExyY D50xyY` and `cmsCIExyY D65xyY` constants, sometimes even with slightly differing values possibly leading to wrong hue shifts.

Looked up the references from https://en.wikipedia.org/wiki/Standard_illuminant#cite_note-27

Make use of the public data all over ...