### PR TITLE
Lua widget enhancements

### DIFF
--- a/src/lua/configuration.h
+++ b/src/lua/configuration.h
@@ -39,10 +39,11 @@
 // 4.2.0 was 9.0.0 (view toolbox functions and snapshot filename removed)
 // 4.4.0 was 9.1.0 (added mimic and dt_lua_image_t changes)
 // 4.6.0 was 9.2.0 (added change_timestamp to dt_image_t)
+// 4.8.0 was 9.3.0 (added button and box widget enhancements)
 /* incompatible API change */
 #define LUA_API_VERSION_MAJOR 9
 /* backward compatible API change */
-#define LUA_API_VERSION_MINOR 2
+#define LUA_API_VERSION_MINOR 3
 /* bugfixes that should not change anything to the API */
 #define LUA_API_VERSION_PATCH 0
 /* suffix for unstable version */

--- a/src/lua/types.c
+++ b/src/lua/types.c
@@ -986,6 +986,12 @@ int dt_lua_init_early_types(lua_State *L)
   luaA_enum_value_name(L, dt_lua_align_t, GTK_ALIGN_CENTER, "center");
   luaA_enum_value_name(L, dt_lua_align_t, GTK_ALIGN_BASELINE, "baseline");
 
+  luaA_enum(L, dt_lua_position_type_t);
+  luaA_enum_value_name(L, dt_lua_position_type_t, GTK_POS_LEFT, "left");
+  luaA_enum_value_name(L, dt_lua_position_type_t, GTK_POS_RIGHT, "right");
+  luaA_enum_value_name(L, dt_lua_position_type_t, GTK_POS_TOP, "top");
+  luaA_enum_value_name(L, dt_lua_position_type_t, GTK_POS_BOTTOM, "bottom");
+
   luaA_enum(L, dt_lua_ellipsize_mode_t);
   luaA_enum_value_name(L, dt_lua_ellipsize_mode_t, PANGO_ELLIPSIZE_NONE, "none");
   luaA_enum_value_name(L, dt_lua_ellipsize_mode_t, PANGO_ELLIPSIZE_START, "start");

--- a/src/lua/types.h
+++ b/src/lua/types.h
@@ -46,6 +46,7 @@ typedef double progress_double; // a double in [0.0,1.0] any value out of bound 
 // Types added to the lua type system and usable externally
 typedef GtkOrientation dt_lua_orientation_t;
 typedef GtkAlign dt_lua_align_t;
+typedef GtkPositionType dt_lua_position_type_t;
 typedef PangoEllipsizeMode dt_lua_ellipsize_mode_t;
 
 

--- a/src/lua/widget/box.c
+++ b/src/lua/widget/box.c
@@ -82,7 +82,7 @@ void _set_packing_info(lua_box box, gboolean expand, gboolean fill, guint paddin
   g_list_free(children);
 }
 
-static int packing_expand_member(lua_State *L)
+static int expand_member(lua_State *L)
 {
   lua_box box;
   luaA_to(L, lua_box, &box, 1);
@@ -100,7 +100,7 @@ static int packing_expand_member(lua_State *L)
   return 1;
 }
 
-static int packing_fill_member(lua_State *L)
+static int fill_member(lua_State *L)
 {
   lua_box box;
   luaA_to(L, lua_box, &box, 1);
@@ -118,7 +118,7 @@ static int packing_fill_member(lua_State *L)
   return 1;
 }
 
-static int packing_padding_member(lua_State *L)
+static int padding_member(lua_State *L)
 {
   lua_box box;
   luaA_to(L, lua_box, &box, 1);
@@ -143,15 +143,15 @@ int dt_lua_init_widget_box(lua_State* L)
   lua_pushcfunction(L, orientation_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_register(L, lua_box, "orientation");
-  lua_pushcfunction(L, packing_expand_member);
+  lua_pushcfunction(L, expand_member);
   dt_lua_gtk_wrap(L);
-  dt_lua_type_register(L, lua_box, "packing_expand");
-  lua_pushcfunction(L, packing_fill_member);
+  dt_lua_type_register(L, lua_box, "expand");
+  lua_pushcfunction(L, fill_member);
   dt_lua_gtk_wrap(L);
-  dt_lua_type_register(L, lua_box, "packing_fill");
-  lua_pushcfunction(L, packing_padding_member);
+  dt_lua_type_register(L, lua_box, "fill");
+  lua_pushcfunction(L, padding_member);
   dt_lua_gtk_wrap(L);
-  dt_lua_type_register(L, lua_box, "packing_padding");
+  dt_lua_type_register(L, lua_box, "padding");
   return 0;
 }
 // clang-format off

--- a/src/lua/widget/box.c
+++ b/src/lua/widget/box.c
@@ -32,19 +32,19 @@ static dt_lua_widget_type_t box_type = {
 static void box_init(lua_State* L)
 {
   lua_box box;
-  luaA_to(L,lua_box,&box,-1);
-  gtk_orientable_set_orientation(GTK_ORIENTABLE(box->widget),GTK_ORIENTATION_VERTICAL);
+  luaA_to(L, lua_box, &box, -1);
+  gtk_orientable_set_orientation(GTK_ORIENTABLE(box->widget), GTK_ORIENTATION_VERTICAL);
 }
 
 
 static int orientation_member(lua_State *L)
 {
   lua_box box;
-  luaA_to(L,lua_box,&box,1);
+  luaA_to(L, lua_box, &box, 1);
   dt_lua_orientation_t orientation;
   if(lua_gettop(L) > 2) {
-    luaA_to(L,dt_lua_orientation_t,&orientation,3);
-    gtk_orientable_set_orientation(GTK_ORIENTABLE(box->widget),orientation);
+    luaA_to(L, dt_lua_orientation_t, &orientation, 3);
+    gtk_orientable_set_orientation(GTK_ORIENTABLE(box->widget), orientation);
     if(gtk_orientable_get_orientation(GTK_ORIENTABLE(box->widget)) == GTK_ORIENTATION_HORIZONTAL)
     {
       GList *children = gtk_container_get_children(GTK_CONTAINER(box->widget));
@@ -57,7 +57,7 @@ static int orientation_member(lua_State *L)
     return 0;
   }
   orientation = gtk_orientable_get_orientation(GTK_ORIENTABLE(box->widget));
-  luaA_push(L,dt_lua_orientation_t,&orientation);
+  luaA_push(L, dt_lua_orientation_t, &orientation);
   return 1;
 }
 
@@ -132,24 +132,24 @@ static int packing_padding_member(lua_State *L)
       _set_packing_info(box, old_expand, old_fill, padding);
     return 0;
   }
-  lua_pushboolean(L, old_padding);
+  lua_pushinteger(L, old_padding);
   return 1;
 }
 
 int dt_lua_init_widget_box(lua_State* L)
 {
-  dt_lua_init_widget_type(L,&box_type,lua_box,GTK_TYPE_BOX);
+  dt_lua_init_widget_type(L, &box_type, lua_box, GTK_TYPE_BOX);
 
-  lua_pushcfunction(L,orientation_member);
+  lua_pushcfunction(L, orientation_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_register(L, lua_box, "orientation");
-  lua_pushcfunction(L,packing_expand_member);
+  lua_pushcfunction(L, packing_expand_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_register(L, lua_box, "packing_expand");
-  lua_pushcfunction(L,packing_fill_member);
+  lua_pushcfunction(L, packing_fill_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_register(L, lua_box, "packing_fill");
-  lua_pushcfunction(L,packing_padding_member);
+  lua_pushcfunction(L, packing_padding_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_register(L, lua_box, "packing_padding");
   return 0;

--- a/src/lua/widget/button.c
+++ b/src/lua/widget/button.c
@@ -139,11 +139,28 @@ static int image_member(lua_State *L)
     const char * imagefile = luaL_checkstring(L, 3);
     image = gtk_image_new_from_file (imagefile);
     gtk_button_set_image(GTK_BUTTON(button->widget), image);
-    gtk_button_set_image_position(GTK_BUTTON(button->widget), GTK_POS_LEFT);
-    gtk_button_set_always_show_image(GTK_BUTTON(button->widget), true);
+    gtk_button_set_always_show_image(GTK_BUTTON(button->widget), TRUE);
     return 0;
   }
   return 0;
+}
+
+static int image_align_member(lua_State *L)
+{
+  lua_button button;
+  luaA_to(L, lua_button, &button, 1);
+  dt_lua_align_t image_align;
+  if(lua_gettop(L) > 2)
+  {
+    luaA_to(L, dt_lua_align_t, &image_align, 3);
+    // check for image before trying to ellipsize it
+    if(gtk_button_get_image(GTK_BUTTON(button->widget)))
+      gtk_button_set_image_position(GTK_BUTTON(button->widget), image_align);
+    return 0;
+  }
+  image_align = gtk_button_get_image_position(GTK_BUTTON(button->widget));
+  luaA_push(L, dt_lua_align_t, &image_align);
+  return 1;
 }
 
 static int tostring_member(lua_State *L)
@@ -170,6 +187,9 @@ int dt_lua_init_widget_button(lua_State* L)
   lua_pushcfunction(L, image_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_register(L, lua_button, "image");
+  lua_pushcfunction(L, image_align_member);
+  dt_lua_gtk_wrap(L);
+  dt_lua_type_register(L, lua_button, "image_align");
   lua_pushcfunction(L, ellipsize_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_register(L, lua_button, "ellipsize");

--- a/src/lua/widget/button.c
+++ b/src/lua/widget/button.c
@@ -19,8 +19,8 @@
 #include "lua/widget/common.h"
 
 /*
-  we can't guarantee the order of label and ellipsize calls so
-  sometimes we have to store the ellipsize mode until the
+  we can't guarantee the order of label and ellipsize|halign calls so
+  sometimes we have to store the ellipsize|hali mode until the
   label is created.
 */
 struct dt_lua_ellipsize_mode_info
@@ -121,6 +121,11 @@ static int label_member(lua_State *L)
     {
       gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button->widget))), ellipsize_store.mode);
       ellipsize_store.used = FALSE;
+    }
+    if(halign_store.used)
+    {
+      gtk_widget_set_halign(GTK_WIDGET(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button->widget)))), halign_store.halign);
+      halign_store.used = FALSE;
     }
     return 0;
   }

--- a/src/lua/widget/button.c
+++ b/src/lua/widget/button.c
@@ -57,9 +57,9 @@ static dt_lua_widget_type_t button_type =
 static void clicked_callback(GtkButton *widget, gpointer user_data)
 {
   dt_lua_async_call_alien(dt_lua_widget_trigger_callback,
-      0,NULL,NULL,
-      LUA_ASYNC_TYPENAME,"lua_widget",user_data,
-      LUA_ASYNC_TYPENAME,"const char*","clicked",
+      0, NULL, NULL,
+      LUA_ASYNC_TYPENAME, "lua_widget", user_data,
+      LUA_ASYNC_TYPENAME, "const char*", "clicked",
       LUA_ASYNC_DONE);
 }
 
@@ -112,11 +112,11 @@ static int halign_member(lua_State *L)
 static int label_member(lua_State *L)
 {
   lua_button button;
-  luaA_to(L,lua_button,&button,1);
+  luaA_to(L, lua_button, &button, 1);
   if(lua_gettop(L) > 2)
   {
-    const char * label = luaL_checkstring(L,3);
-    gtk_button_set_label(GTK_BUTTON(button->widget),label);
+    const char * label = luaL_checkstring(L, 3);
+    gtk_button_set_label(GTK_BUTTON(button->widget), label);
     if(ellipsize_store.used)
     {
       gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button->widget))), ellipsize_store.mode);
@@ -124,7 +124,7 @@ static int label_member(lua_State *L)
     }
     return 0;
   }
-  lua_pushstring(L,gtk_button_get_label(GTK_BUTTON(button->widget)));
+  lua_pushstring(L, gtk_button_get_label(GTK_BUTTON(button->widget)));
   return 1;
 }
 
@@ -133,14 +133,14 @@ static int image_member(lua_State *L)
   lua_button button;
   GtkWidget *image;
 
-  luaA_to(L,lua_button,&button,1);
+  luaA_to(L, lua_button, &button, 1);
   if(lua_gettop(L) > 2)
   {
-    const char * imagefile = luaL_checkstring(L,3);
+    const char * imagefile = luaL_checkstring(L, 3);
     image = gtk_image_new_from_file (imagefile);
-    gtk_button_set_image(GTK_BUTTON(button->widget),image);
-    gtk_button_set_image_position(GTK_BUTTON(button->widget),GTK_POS_LEFT);
-    gtk_button_set_always_show_image(GTK_BUTTON(button->widget),true);
+    gtk_button_set_image(GTK_BUTTON(button->widget), image);
+    gtk_button_set_image_position(GTK_BUTTON(button->widget), GTK_POS_LEFT);
+    gtk_button_set_always_show_image(GTK_BUTTON(button->widget), true);
     return 0;
   }
   return 0;
@@ -159,24 +159,24 @@ static int tostring_member(lua_State *L)
 
 int dt_lua_init_widget_button(lua_State* L)
 {
-  dt_lua_init_widget_type(L,&button_type,lua_button,GTK_TYPE_BUTTON);
+  dt_lua_init_widget_type(L, &button_type, lua_button, GTK_TYPE_BUTTON);
 
   lua_pushcfunction(L, tostring_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_setmetafield(L, lua_button, "__tostring");
-  lua_pushcfunction(L,label_member);
+  lua_pushcfunction(L, label_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_register(L, lua_button, "label");
-  lua_pushcfunction(L,image_member);
+  lua_pushcfunction(L, image_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_register(L, lua_button, "image");
-  lua_pushcfunction(L,ellipsize_member);
+  lua_pushcfunction(L, ellipsize_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_register(L, lua_button, "ellipsize");
-  lua_pushcfunction(L,halign_member);
+  lua_pushcfunction(L, halign_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_register(L, lua_button, "halign");
-  dt_lua_widget_register_gtk_callback(L,lua_button,"clicked","clicked_callback",G_CALLBACK(clicked_callback));
+  dt_lua_widget_register_gtk_callback(L, lua_button, "clicked", "clicked_callback", G_CALLBACK(clicked_callback));
 
   return 0;
 }

--- a/src/lua/widget/button.c
+++ b/src/lua/widget/button.c
@@ -128,6 +128,24 @@ static int label_member(lua_State *L)
   return 1;
 }
 
+static int image_member(lua_State *L)
+{
+  lua_button button;
+  GtkWidget *image;
+
+  luaA_to(L,lua_button,&button,1);
+  if(lua_gettop(L) > 2)
+  {
+    const char * imagefile = luaL_checkstring(L,3);
+    image = gtk_image_new_from_file (imagefile);
+    gtk_button_set_image(GTK_BUTTON(button->widget),image);
+    gtk_button_set_image_position(GTK_BUTTON(button->widget),GTK_POS_LEFT);
+    gtk_button_set_always_show_image(GTK_BUTTON(button->widget),true);
+    return 0;
+  }
+  return 0;
+}
+
 static int tostring_member(lua_State *L)
 {
   lua_button widget;
@@ -149,6 +167,9 @@ int dt_lua_init_widget_button(lua_State* L)
   lua_pushcfunction(L,label_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_register(L, lua_button, "label");
+  lua_pushcfunction(L,image_member);
+  dt_lua_gtk_wrap(L);
+  dt_lua_type_register(L, lua_button, "image");
   lua_pushcfunction(L,ellipsize_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_register(L, lua_button, "ellipsize");

--- a/src/lua/widget/label.c
+++ b/src/lua/widget/label.c
@@ -30,26 +30,26 @@ static dt_lua_widget_type_t label_type = {
 static int label_member(lua_State *L)
 {
   lua_label label;
-  luaA_to(L,lua_label,&label,1);
+  luaA_to(L, lua_label, &label, 1);
   if(lua_gettop(L) > 2) {
-    const char * text = luaL_checkstring(L,3);
-    gtk_label_set_text(GTK_LABEL(label->widget),text);
+    const char * text = luaL_checkstring(L, 3);
+    gtk_label_set_text(GTK_LABEL(label->widget), text);
     return 0;
   }
-  lua_pushstring(L,gtk_label_get_text(GTK_LABEL(label->widget)));
+  lua_pushstring(L, gtk_label_get_text(GTK_LABEL(label->widget)));
   return 1;
 }
 
 static int selectable_member(lua_State *L)
 {
   lua_label label;
-  luaA_to(L,lua_label,&label,1);
+  luaA_to(L, lua_label, &label, 1);
   if(lua_gettop(L) > 2) {
-    gboolean selectable = lua_toboolean(L,3);
-    gtk_label_set_selectable(GTK_LABEL(label->widget),selectable);
+    gboolean selectable = lua_toboolean(L, 3);
+    gtk_label_set_selectable(GTK_LABEL(label->widget), selectable);
     return 0;
   }
-  lua_pushboolean(L,gtk_label_get_selectable(GTK_LABEL(label->widget)));
+  lua_pushboolean(L, gtk_label_get_selectable(GTK_LABEL(label->widget)));
   return 1;
 }
 
@@ -96,21 +96,21 @@ static int tostring_member(lua_State *L)
 
 int dt_lua_init_widget_label(lua_State* L)
 {
-  dt_lua_init_widget_type(L,&label_type,lua_label,GTK_TYPE_LABEL);
+  dt_lua_init_widget_type(L, &label_type, lua_label, GTK_TYPE_LABEL);
 
   lua_pushcfunction(L, tostring_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_setmetafield(L, lua_label, "__tostring");
-  lua_pushcfunction(L,label_member);
+  lua_pushcfunction(L, label_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_register(L, lua_label, "label");
-  lua_pushcfunction(L,selectable_member);
+  lua_pushcfunction(L, selectable_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_register(L, lua_label, "selectable");
   lua_pushcfunction(L, halign_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_register(L, lua_label, "halign");
-  lua_pushcfunction(L,ellipsize_member);
+  lua_pushcfunction(L, ellipsize_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_register(L, lua_label, "ellipsize");
   return 0;


### PR DESCRIPTION
Added more capabilities to:

Lua button widget
* added halign member to horizontally position the label
* added image member to use an image as the button label
* added image_align to horizontally position the image

Lua box widget
* added expand member to control cells being expanded to fill the with of the box
* added fill member to control if the widgets fill the cell
* added padding member to control padding size of the cells

With the enhancements we can create buttons like:

![example_buttons](https://github.com/darktable-org/darktable/assets/1634891/32a04e29-d4ad-43b4-b693-cb052115ff02)

To test I've included the button_example.lua, the power button icon, and the user.css file.  The power button needs to go in the lua/Data directory (you need to create it).

[user.css.txt](https://github.com/darktable-org/darktable/files/13944210/user.css.txt)
![path2](https://github.com/darktable-org/darktable/assets/1634891/c5cdd78c-5998-4886-95bb-7dafe0c93c40)
[button_example.zip](https://github.com/darktable-org/darktable/files/13944211/button_example.zip)

Needed to complete https://github.com/darktable-org/lua-scripts/issues/438