### PR TITLE
overlay: Avoid cross references between image and overlay.

### DIFF
--- a/src/common/overlay.c
+++ b/src/common/overlay.c
@@ -125,3 +125,27 @@ GList *dt_overlay_get_used_in_imgs(const dt_imgid_t overlay_id,
 
   return res;
 }
+
+gboolean dt_overlay_used_by(const dt_imgid_t imgid, const dt_imgid_t overlay_id)
+{
+  sqlite3_stmt *stmt;
+
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "SELECT 1"
+                              " FROM overlay"
+                              " WHERE imgid = ?1"
+                              "   AND overlay_id = ?2",
+                              -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, overlay_id);
+
+  gboolean result = FALSE;
+
+  if(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    result = TRUE;
+  }
+  sqlite3_finalize(stmt);
+
+  return result;
+}

--- a/src/common/overlay.h
+++ b/src/common/overlay.h
@@ -55,6 +55,9 @@ GList *dt_overlay_get_imgs(const dt_imgid_t imgid);
 GList *dt_overlay_get_used_in_imgs(const dt_imgid_t overlay_id,
                                    const gboolean except_self);
 
+/* Return TRUE is overlay_id is used by imgid */
+gboolean dt_overlay_used_by(const dt_imgid_t imgid, const dt_imgid_t overlay_id);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif /* __cplusplus */


### PR DESCRIPTION
This just makes dt freeze!