### PR TITLE
Increase verbosity for OpenCL platform detection safety check errors

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -1249,6 +1249,7 @@ void dt_opencl_init(
     {
       dt_print(DT_DEBUG_OPENCL,
                "[opencl_init] detected wrong OpenCL platforms setup: multiple drivers for some platform\n");
+      logerror = _("found mutiple installed drivers for some platform(s)");
       num_platforms = 0;
       goto finally;
     }

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -1235,7 +1235,12 @@ void dt_opencl_init(
       for(int k = 0; k < n; k++)
       {
         if(!strcmp(platforms + n * DT_OPENCL_CBUFFSIZE, platforms + k * DT_OPENCL_CBUFFSIZE))
+        {
           multiple = TRUE;
+          dt_print(DT_DEBUG_OPENCL,
+                   "[opencl_init] found multiple drivers for the platform '%s'\n",
+                   platforms + k * DT_OPENCL_CBUFFSIZE);
+        }
       }
     }
     free(platforms);


### PR DESCRIPTION
These changes will allow users to get information about what specific OpenCL setup problem they are having, allowing them to fix it themselves without looking for help in the forums or the darktable bugtracker (like in #16028):

- To be precise, we distinguish between failure when clGetPlatformInfo reports an invalid platform and when we find multiple drivers for the same platform. It seems to me that the first case should not happen in practice, but still.

- Then we report a more precise reason for the failure in the log.

- Also, if these are duplicate drivers for a platform, we report the platform name in the log.

- A corresponding warning message is also displayed in the GUI.

@jenshannoschwalm please can you review?
