### PR TITLE
[maintenance] Remove unused define in darkroom.c

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -53,6 +53,7 @@
 #include "libs/modulegroups.h"
 #include "views/view.h"
 #include "views/view_api.h"
+
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
@@ -70,10 +71,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-
-#ifndef G_SOURCE_FUNC // Defined for glib >= 2.58
-#define G_SOURCE_FUNC(f) ((GSourceFunc) (void (*)(void)) (f))
-#endif
 
 DT_MODULE(1)
 


### PR DESCRIPTION
It is no longer needed as the code that used it was removed in 401dc7f.
