### PR TITLE
Remove unnecessary function calls

### DIFF
--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -2669,7 +2669,7 @@ static inline gint _compare_utf8_no_case(const char *a, const char *b)
   char *b_nc_nat = g_utf8_collate_key_for_filename(b, -1);
 
   const gint sort = g_strcmp0(a_nc_nat, b_nc_nat);
-  
+
   g_free(a_nc_nat);
   g_free(b_nc_nat);
   return sort;

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -2665,16 +2665,11 @@ static gint _sort_tree_count_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIt
 
 static inline gint _compare_utf8_no_case(const char *a, const char *b)
 {
-  char *a_nc = g_utf8_casefold(a, -1);
-  char *a_nc_nat = g_utf8_collate_key_for_filename(a_nc, -1);
-  g_free(a_nc);
-
-  char *b_nc = g_utf8_casefold(b, -1);
-  char *b_nc_nat = g_utf8_collate_key_for_filename(b_nc, -1);
-  g_free(b_nc);
+  char *a_nc_nat = g_utf8_collate_key_for_filename(a, -1);
+  char *b_nc_nat = g_utf8_collate_key_for_filename(b, -1);
 
   const gint sort = g_strcmp0(a_nc_nat, b_nc_nat);
-
+  
   g_free(a_nc_nat);
   g_free(b_nc_nat);
   return sort;


### PR DESCRIPTION
As it turned out `g_utf8_collate_key_for_filename()` always works case-insensitive so there is no need to call `g_utf8_casefold()` before.
