### PR TITLE
Some color maths improving

### DIFF
--- a/data/kernels/colorspace.h
+++ b/data/kernels/colorspace.h
@@ -622,19 +622,20 @@ static inline float4 dt_uvY_to_xyY(const float4 uvY)
   return xyY;
 }
 
-static inline float4 dt_XYZ_to_xyY(const float4 XYZ)
+static inline float4 dt_D65_XYZ_to_xyY(const float4 sXYZ)
 {
   // see cpu implementation for details, use D65_xy as fallback
+  float4 XYZ = fmax(0.0f, sXYZ);
   float4 xyY;
   const float sum = XYZ.x + XYZ.y + XYZ.z;
-  if(XYZ.x == 0.0f && XYZ.y == 0.0f && XYZ.z == 0.0f)
+  if(sum > 0.0f)
   {
-    xyY.x = (float)0.31271;
-    xyY.y = (float)0.32902;
+    xyY.xy = XYZ.xy / sum;
   }
   else
   {
-    xyY.xy = XYZ.xy / sum;
+    xyY.x = (float)0.31271;
+    xyY.y = (float)0.32902;
   }
 
   xyY.z = XYZ.y;

--- a/data/kernels/extended.cl
+++ b/data/kernels/extended.cl
@@ -980,8 +980,7 @@ colorbalancergb (read_only image2d_t in, write_only image2d_t out,
   }
   else
   {
-    XYZ_D65 = fmax(0.0f, XYZ_D65);
-    float4 xyY = dt_XYZ_to_xyY(XYZ_D65);
+    float4 xyY = dt_D65_XYZ_to_xyY(XYZ_D65);
     float4 JCH = xyY_to_dt_UCS_JCH(xyY, L_white);
     float4 HCB = dt_UCS_JCH_to_HCB(JCH);
 

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2023 darktable developers.
+    Copyright (C) 2010-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -2559,7 +2559,7 @@ void cmsCIEXYZ_to_xy(const cmsCIEXYZ *const cmsXYZ, float xy[2])
 {
   dt_aligned_pixel_t XYZ = { cmsXYZ->X, cmsXYZ->Y, cmsXYZ->Z, 0.f };
   dt_aligned_pixel_t xyY;
-  dt_XYZ_to_xyY(XYZ, xyY);
+  dt_D50_XYZ_to_xyY(XYZ, xyY);
   xy[0] = xyY[0];
   xy[1] = xyY[1];
 }

--- a/src/common/darktable_ucs_22_helpers.h
+++ b/src/common/darktable_ucs_22_helpers.h
@@ -45,9 +45,9 @@ static inline void dt_UCS_22_build_gamut_LUT(dt_colormatrix_t input_matrix, floa
   dot_product(RGB_blue, input_matrix, XYZ_blue);
 
   dt_aligned_pixel_t xyY_red, xyY_green, xyY_blue;
-  dt_XYZ_to_xyY(XYZ_red, xyY_red);
-  dt_XYZ_to_xyY(XYZ_green, xyY_green);
-  dt_XYZ_to_xyY(XYZ_blue, xyY_blue);
+  dt_D65_XYZ_to_xyY(XYZ_red, xyY_red);
+  dt_D65_XYZ_to_xyY(XYZ_green, xyY_green);
+  dt_D65_XYZ_to_xyY(XYZ_blue, xyY_blue);
 
   // Get the "hue" angles of the primaries in xy compared to D65
   const float h_red   = atan2f(xyY_red[1] - D65_xyY[1], xyY_red[0] - D65_xyY[0]);

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -1,6 +1,6 @@
 /*
   This file is part of darktable,
-  Copyright (C) 2010-2023 darktable developers.
+  Copyright (C) 2010-2024 darktable developers.
 
   darktable is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -1731,9 +1731,14 @@ static void _extract_color_checker(const float *const restrict in,
   // convert back the illuminant to XYZ then xyY
   dt_aligned_pixel_t illuminant_XYZ, illuminant_xyY = { .0f };
   convert_any_LMS_to_XYZ(illuminant, illuminant_XYZ, kind);
+  dt_vector_clipneg(illuminant_XYZ);
   const float Y_illu = illuminant_XYZ[1];
-  for(size_t c = 0; c < 3; c++) illuminant_XYZ[c] /= Y_illu;
-  dt_XYZ_to_xyY(illuminant_XYZ, illuminant_xyY);
+  for(size_t c = 0; c < 3; c++)
+  {
+    if(Y_illu > 0.0f)
+      illuminant_XYZ[c] /= Y_illu;
+  }
+  dt_D50_XYZ_to_xyY(illuminant_XYZ, illuminant_xyY);
 
   // save the illuminant in GUI struct for commit
   g->xy[0] = illuminant_xyY[0];

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2020-2023 darktable developers.
+    Copyright (C) 2020-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -910,8 +910,7 @@ void process(struct dt_iop_module_t *self,
     else
     {
       dt_aligned_pixel_t xyY, JCH, HCB;
-      dt_vector_clipneg(XYZ_D65);
-      dt_XYZ_to_xyY(XYZ_D65, xyY);
+      dt_D65_XYZ_to_xyY(XYZ_D65, xyY);
       xyY_to_dt_UCS_JCH(xyY, L_white, JCH);
       dt_UCS_JCH_to_HCB(JCH, HCB);
 
@@ -1316,9 +1315,9 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
       dot_product(RGB_blue, input_matrix, XYZ_blue);
 
       dt_aligned_pixel_t xyY_red, xyY_green, xyY_blue;
-      dt_XYZ_to_xyY(XYZ_red, xyY_red);
-      dt_XYZ_to_xyY(XYZ_green, xyY_green);
-      dt_XYZ_to_xyY(XYZ_blue, xyY_blue);
+      dt_D65_XYZ_to_xyY(XYZ_red, xyY_red);
+      dt_D65_XYZ_to_xyY(XYZ_green, xyY_green);
+      dt_D65_XYZ_to_xyY(XYZ_blue, xyY_blue);
 
       // Get the "hue" angles of the primaries in xy compared to D65
       const float h_red   = atan2f(xyY_red[1] - D65_xyY[1], xyY_red[0] - D65_xyY[0]);

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -761,7 +761,7 @@ void process(struct dt_iop_module_t *self,
     dot_product(pix_in, input_matrix, XYZ_D65);
     // Convert to dt UCS 22 UV and store UV
     dt_aligned_pixel_t xyY = { 0.f };
-    dt_XYZ_to_xyY(XYZ_D65, xyY);
+    dt_D65_XYZ_to_xyY(XYZ_D65, xyY);
 
     xyY_to_dt_UCS_UV(xyY, uv);
     L[k] = Y_to_dt_UCS_L_star(xyY[2]);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -505,7 +505,7 @@ static void _lib_histogram_vectorscope_bkgd
                                      vs_prof->lutsize,
                                      vs_prof->nonlinearlut);
           dt_aligned_pixel_t xyY;
-          dt_XYZ_to_xyY(XYZ_D50, xyY);
+          dt_D50_XYZ_to_xyY(XYZ_D50, xyY);
           dt_xyY_to_Luv(xyY, chromaticity);
           dt_XYZ_to_Rec709_D50(XYZ_D50, rgb_display);
           break;
@@ -687,7 +687,7 @@ static void _get_chromaticity(const dt_aligned_pixel_t RGB,
       // how does the result change if we adapt to D65 then convert to
       // L*u*v* with a D65 whitepoint?
       dt_aligned_pixel_t xyY_D50;
-      dt_XYZ_to_xyY(XYZ_D50, xyY_D50);
+      dt_D50_XYZ_to_xyY(XYZ_D50, xyY_D50);
       // using D50 correct u*v* (not u'v') to be relative to the
       // whitepoint (important for vectorscope) and as u*v* is more
       // evenly spaced


### PR DESCRIPTION
- Whenever we call a XYZ_to_xyY conversion we make sure the XYZ triplet is non-negative. This avoids extra dt_vector_clipneg calls
- For black - XYZ are all zero - we have to do a fallback to "current whitepoint", in current darktable code this is either D50 or D60 so we have two inline variants to avoid always passing the current white points.

While working on color equalizer i observed -0.0 fed into the pipe leading to negative L_Star values and later NaNs which are simply wrong and may lead to strong artifacts in the blurring/guiding phase.

@flannelhead could you check this for correctness please?

@TurboGit could you test the color equalizer output? For me this seems to be significantly more stable. Can you confirm?
 