### PR TITLE
darkroom.c: Ensure the rotate perspective line is drawn.

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -622,43 +622,48 @@ void expose(
     dt_masks_events_post_expose(dev->gui_module, cri, width, height, pzx, pzy, zoom_scale);
   }
 
-  gboolean guides = FALSE;
-  // true if anything could be exposed
-  if(dev->gui_module && dev->gui_module != dev->proxy.rotate)
-  {
-    // the cropping.exposer->gui_post_expose needs special care
-    if(expose_full
-       && dev->gui_module->operation_tags_filter() & IOP_TAG_CROPPING)
-    {
-      dt_print_pipe(DT_DEBUG_EXPOSE,
-        "expose cropper",
-         port->pipe, dev->cropping.exposer, DT_DEVICE_NONE, NULL, NULL, "%dx%d, px=%d py=%d\n",
-         width, height, pointerx, pointery);
-      _module_gui_post_expose(dev->cropping.exposer, cri, wd, ht, pzx, pzy, zoom_scale);
-      guides = TRUE;
-    }
-
-    // gui active module
-    if(dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS)
-    {
-      dt_print_pipe(DT_DEBUG_EXPOSE,
-        "expose module",
-         port->pipe, dev->gui_module, DT_DEVICE_NONE, NULL, NULL, "%dx%d, px=%d py=%d\n",
-         width, height, pointerx, pointery);
-      _module_gui_post_expose(dev->gui_module, cri, wd, ht, pzx, pzy, zoom_scale);
-      guides = TRUE;
-    }
-  }
-
-  if(!guides && dev->proxy.rotate)
+  // if dragging the rotation line, do it and nothing else
+  if(darktable.control->button_down_which == 3 && dev->proxy.rotate)
   {
     // reminder, we want this to be exposed always for guidings
     _module_gui_post_expose(dev->proxy.rotate, cri, wd, ht, pzx, pzy, zoom_scale);
-    guides = TRUE;
   }
+  else
+  {
+    gboolean guides = FALSE;
+    // true if anything could be exposed
+    if(dev->gui_module && dev->gui_module != dev->proxy.rotate)
+    {
+      // the cropping.exposer->gui_post_expose needs special care
+      if(expose_full
+         && dev->gui_module->operation_tags_filter() & IOP_TAG_CROPPING)
+      {
+        dt_print_pipe(DT_DEBUG_EXPOSE,
+                      "expose cropper",
+                      port->pipe, dev->cropping.exposer,
+                      DT_DEVICE_NONE, NULL, NULL, "%dx%d, px=%d py=%d\n",
+                      width, height, pointerx, pointery);
+        _module_gui_post_expose(dev->cropping.exposer, cri, wd, ht, pzx, pzy, zoom_scale);
+        guides = TRUE;
+      }
 
-  if(!guides)
-    dt_guides_draw(cri, 0.0f, 0.0f, wd, ht, zoom_scale);
+      // gui active module
+      if(dt_dev_modulegroups_get_activated(darktable.develop) != DT_MODULEGROUP_BASICS)
+      {
+        dt_print_pipe(DT_DEBUG_EXPOSE,
+                      "expose module",
+                      port->pipe, dev->gui_module,
+                      DT_DEVICE_NONE, NULL, NULL,
+                      "%dx%d, px=%d py=%d\n",
+                      width, height, pointerx, pointery);
+        _module_gui_post_expose(dev->gui_module, cri, wd, ht, pzx, pzy, zoom_scale);
+        guides = TRUE;
+      }
+    }
+
+    if(!guides)
+      dt_guides_draw(cri, 0.0f, 0.0f, wd, ht, zoom_scale);
+  }
 
   cairo_restore(cri);
 


### PR DESCRIPTION
Force drawing of rotation line if the 3rd mouse button is down.

Fixes #16150.