### PR TITLE
Use gp_camera_get_single_config where possible

### DIFF
--- a/src/common/camera_control.h
+++ b/src/common/camera_control.h
@@ -47,7 +47,6 @@ typedef struct dt_camera_t
   /** Registered timeout func */
   CameraTimeoutFunc timeout;
 
-  gboolean config_changed;
   dt_pthread_mutex_t config_lock;
   /** This camera/device can import images. */
   gboolean can_import;


### PR DESCRIPTION
`gp_camera_get_config` can be slow on cameras such as the Z6ii, where it takes a few seconds and locks up the live view and controls, making tethering all but unusable.
Fetching and setting config values individually speeds this up significantly, though unfortunately determining the property to update requires parsing the event string. I don't know if there's a better API for fetching the details of the changed config value, but I couldn't find one.

Tested on a Nikon Z6ii (and a D3200, though that was much faster to start with, probably since gphoto2 reports ~8x as many settings on the Z6ii).