### PR TITLE
[CI/CD] Remove cmocka from all build environments

### DIFF
--- a/.ci/Brewfile
+++ b/.ci/Brewfile
@@ -1,5 +1,5 @@
 #    This file is part of darktable.
-#    Copyright (C) 2016-2023 darktable developers.
+#    Copyright (C) 2016-2024 darktable developers.
 #
 #    darktable is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -51,7 +51,6 @@ brew 'osm-gps-map'
 brew 'portmidi'
 brew 'pugixml'
 brew 'sdl2'
-brew 'cmocka'
 brew 'curl'
 brew 'perl'
 brew 'webp'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,6 @@ jobs:
             libcairo2-dev \
             libcolord-dev \
             libcolord-gtk-dev \
-            libcmocka-dev \
             libcups2-dev \
             libcurl4-gnutls-dev \
             libexiv2-dev \
@@ -214,7 +213,6 @@ jobs:
           pacboy: >-
             cc:p
             cmake:p
-            cmocka:p
             libxslt:p
             ninja:p
             nsis:p

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,7 +55,6 @@ jobs:
             libcairo2-dev \
             libcolord-dev \
             libcolord-gtk-dev \
-            libcmocka-dev \
             libcups2-dev \
             libcurl4-gnutls-dev \
             libimage-exiftool-perl \


### PR DESCRIPTION
We don't need this, since we don't run long-abandoned (and with extremely low coverage) unit tests during the build process.