### PR TITLE
Color equalizer improvements

### DIFF
--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -782,6 +782,8 @@ void process(struct dt_iop_module_t *self,
   if(d->use_filter)
     _prefilter_chromaticity(UV, saturations, roi_out, d->chroma_size, d->chroma_feathering);
 
+  _mean_gaussian(saturations, roi_out->width, roi_out->height, 1, 4.0f);
+
   // STEP 3 : carry-on with conversion from LUV to HSB
 
 #ifdef _OPENMP


### PR DESCRIPTION
Corrected weighing for brightness control allowing also darker areas to be controlled.

The equalizer guiding has strong problems at transitions from chromatic to achromatic areas.
- Color bleeding into achromatic areas
- bright halos if some color has increased brightness
- color shifts and chroma noise in achromatic areas

This is corrected by checking for achromatics when writing output in the guiding filter, for
- correcting UV
- correcting brightness and saturation

This gets somewhat deeper into the guiding code btw ...

Fixes #16154
replaces #16158