### PR TITLE
Fix thumbtable scrolling sometimes not working

### DIFF
--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1047,7 +1047,12 @@ static gboolean _event_scroll_compressed(gpointer user_data)
 {
   if (!user_data) return FALSE;
   dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
-  if (table->scroll_value == 0) return FALSE;
+  if (table->scroll_value == 0)
+  {
+    table->scroll_timeout_id = 0;
+    return FALSE;
+  }
+
   float delta = table->scroll_value;
 
   // starting from here, all further scroll event will count for the next round


### PR DESCRIPTION
fixes #15981 

If `_event_scroll_compressed()` is called and the scroll_value is 0, the `scroll_timeout_id` is not reset. Then the scrolling does not work anymore because the function never gets called again.

See also the discussion on [pixls.us](https://discuss.pixls.us/t/darktable-4-6-mac-lighttable-scrolling-stops-responding/41176/8)
