### PR TITLE
Diffuse and sharpen: add local contrast fine 

### DIFF
--- a/src/iop/diffuse.c
+++ b/src/iop/diffuse.c
@@ -600,6 +600,31 @@ void init_presets(dt_iop_module_so_t *self)
                              sizeof(dt_iop_diffuse_params_t), 1,
                              DEVELOP_BLEND_CS_RGB_SCENE);
 
+  dt_gui_presets_add_generic(_("local contrast fine"), self->op, self->version(),
+                             &(dt_iop_diffuse_params_t)
+                               { .iterations = 5,
+                                 .radius_center = 0,
+                                 .radius = 170,
+
+                                 .first = -0.1f,
+                                 .second = 0.f,
+                                 .third = 0.f,
+                                 .fourth = -0.1f,
+
+                                 .anisotropy_first = 10.f,
+                                 .anisotropy_second = 0.f,
+                                 .anisotropy_third = 0.f,
+                                 .anisotropy_fourth = 10.f,
+
+                                 .sharpness = 0.0f,
+                                 .regularization = 1.f,
+                                 .variance_threshold = 0.f,
+
+                                 .threshold = 0.0f
+                               },
+                             sizeof(dt_iop_diffuse_params_t), 1,
+                             DEVELOP_BLEND_CS_RGB_SCENE);
+
   dt_gui_presets_add_generic(_("inpaint highlights"), self->op, self->version(),
                              &(dt_iop_diffuse_params_t)
                                { .iterations = 32,


### PR DESCRIPTION
Hello all,

Back then with the display-referred workflow, I tended to use the local contrast module quite often when mapping scenes with high dynamic range.
Although the diffuse and sharpen module comes with a preset do increase the local contrast, it often yielded inferior results in my use cases because it emphasizes lower frequencies and also tends to crush large, dark areas to black.

This new preset is the base I currently use for increasing local contrast. 
It focuses more on the enhancement of fine to medium structures, and hence resembles (at least in my perception) something like "clarity" more closely than the standard preset. 
Due to the accentuation of finer textures, I called this "local contrast fine".
The strength can be adjusted easily by the diffusion strengths of scales 1 and 4 and also via the number of iterations.

Comparison (order: without local contrast, with new preset, with normal local contrast preset).
The difference is probably hard to spot side-by-side. Notice the emphasis of the texture in the bottom left area.
![DSCF2035_raw)](https://github.com/darktable-org/darktable/assets/1688125/1934bd77-af22-419c-b230-feeab3d1500e)
![DSCF2035_lc)](https://github.com/darktable-org/darktable/assets/1688125/c521284f-7da0-41fd-babb-a4cf7f60daef)
![DSCF2035_lc_default)](https://github.com/darktable-org/darktable/assets/1688125/6407515c-3fa4-4c73-9e17-9ecb4173652f)
