### PR TITLE
[GUI] Change label on the dialog close button

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2023 darktable developers.
+    Copyright (C) 2009-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -1630,7 +1631,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
       not_again = dt_gui_show_standalone_yes_no_dialog
         (_("configuration information"),
          config_info,
-         _("_show this information again"), _("_understood"));
+         _("_show this information again"), _("_dismiss"));
 
     if(not_again || (last_configure_version == 0))
       dt_conf_set_int("performance_configuration_version_completed",


### PR DESCRIPTION
I agree with @elstoc's opinion expressed [here](https://discuss.pixls.us/t/darktable-4-6-0-released/41045/130). `dismiss` is a more commonly used action label in such cases.