### PR TITLE
[GUI] Make original string multi-line and extra narrow for safe translations

### DIFF
--- a/src/iop/overlay.c
+++ b/src/iop/overlay.c
@@ -753,7 +753,7 @@ static void _draw_thumb(GtkWidget *area,
     pango_font_description_set_absolute_size(desc, DT_PIXEL_APPLY_DPI(12) * PANGO_SCALE);
     PangoLayout *layout = pango_cairo_create_layout(crf);
     pango_layout_set_font_description(layout, desc);
-    pango_layout_set_text(layout, _("drop image here"), -1);
+    pango_layout_set_text(layout, _("drop\nimage\nhere"), -1);
 
     PangoRectangle ink;
     pango_layout_get_pixel_extents(layout, &ink, NULL);


### PR DESCRIPTION
In the overlay module there is a target to drag and drop an image to use as an overlay, this area says `drop image here`. The fact is that the translation of this string will be truncated on both sides if it is longer than the original text (and because the English words in this text are very short, I think that _most_ translations will be longer and truncated).

In this case we are placing the text in a drawing area of a fixed size, this is not a widget that can adapt its size according to the length of the contained text.

The easiest way to solve the problem is to split the original text into several lines. This should prompt translators to think that the same should be done in translation. Without this, to be honest, I don't believe that translators will check their translations in the program interface and notice the need to split the translated string.