### PR TITLE
Film maintenance

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -85,7 +85,7 @@ fprintf(stderr, "darktable %s\n"
 
                 "   --height <max height> default: 0 = full resolution\n"
                 "   --width <max width> default: 0 = full resolution\n"
-                
+
                 "   --hq <0|1|false|true> default: true\n"
                 "   --upscale <0|1|false|true>, default: false\n"
                 "   --style <style name>\n"
@@ -101,7 +101,7 @@ fprintf(stderr, "darktable %s\n"
                 "                     use --help icc-intent for list of supported intents\n"
                 "   --verbose\n"
                 "   -h, --help [option]\n"
-                "   -v, --version\n", 
+                "   -v, --version\n",
                 darktable_package_version,
                 darktable_last_commit_year);
 
@@ -246,10 +246,10 @@ int main(int argc, char *arg[])
         exit(1);
       }
       else if(!strcmp(arg[k], "--version") || !strcmp(arg[k], "-v"))
-      {     
+      {
           printf("darktable %s\nCopyright (C) 2012-%s Johannes Hanika and other contributors.\n\n",darktable_package_version, darktable_last_commit_year);
           printf("See %s for detailed documentation.\n", PACKAGE_DOCS);
-          printf("See %s to report bugs.\n",PACKAGE_BUGREPORT);              
+          printf("See %s to report bugs.\n",PACKAGE_BUGREPORT);
           exit(0);
       }
       else if(!strcmp(arg[k], "--width") && argc > k + 1)
@@ -548,7 +548,7 @@ int main(int argc, char *arg[])
 
     if(g_file_test(input, G_FILE_TEST_IS_DIR))
     {
-      const int filmid = dt_film_import(input);
+      const dt_filmid_t filmid = dt_film_import(input);
       if(!filmid)
       {
         // one of inputs was a failure, no prob
@@ -561,13 +561,13 @@ int main(int argc, char *arg[])
     else
     {
       dt_film_t film;
-      int filmid = 0;
+      dt_filmid_t filmid = NO_FILMID;
 
       gchar *directory = g_path_get_dirname(input);
       filmid = dt_film_new(&film, directory);
-      const int32_t id = dt_image_import(filmid, input, TRUE, TRUE);
+      const dt_imgid_t id = dt_image_import(filmid, input, TRUE, TRUE);
       g_free(directory);
-      if(!id)
+      if(!dt_is_valid_imgid(id))
       {
         fprintf(stderr, _("error: can't open file %s"), input);
         fprintf(stderr, "\n");

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -362,28 +362,28 @@ gboolean dt_supported_image(const gchar *filename)
   return supported;
 }
 
-int dt_load_from_string(const gchar *input,
+dt_imgid_t dt_load_from_string(const gchar *input,
                         const gboolean open_image_in_dr,
                         gboolean *single_image)
 {
-  int32_t id = 0;
-  if(input == NULL || input[0] == '\0') return 0;
+  dt_imgid_t id = NO_IMGID;
+  if(input == NULL || input[0] == '\0') return NO_IMGID;
 
   char *filename = dt_util_normalize_path(input);
 
   if(filename == NULL)
   {
     dt_control_log(_("found strange path `%s'"), input);
-    return 0;
+    return NO_IMGID;
   }
 
   if(g_file_test(filename, G_FILE_TEST_IS_DIR))
   {
     // import a directory into a film roll
-    id = dt_film_import(filename);
-    if(id)
+    const dt_filmid_t filmid = dt_film_import(filename);
+    if(dt_is_valid_filmid(filmid))
     {
-      dt_film_open(id);
+      dt_film_open(filmid);
       dt_ctl_switch_mode_to("lighttable");
     }
     else
@@ -397,10 +397,10 @@ int dt_load_from_string(const gchar *input,
     // import a single image
     gchar *directory = g_path_get_dirname((const gchar *)filename);
     dt_film_t film;
-    const int filmid = dt_film_new(&film, directory);
+    const dt_filmid_t filmid = dt_film_new(&film, directory);
     id = dt_image_import(filmid, filename, TRUE, TRUE);
     g_free(directory);
-    if(id)
+    if(dt_is_valid_imgid(id))
     {
       dt_film_open(filmid);
       // make sure buffers are loaded (load full for testing)
@@ -411,7 +411,7 @@ int dt_load_from_string(const gchar *input,
       dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
       if(!loaded)
       {
-        id = 0;
+        id = NO_IMGID;
         dt_control_log(_("file `%s' has unknown format!"), filename);
       }
       else

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2023 darktable developers.
+    Copyright (C) 2009-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -154,9 +154,11 @@ extern "C" {
 #endif
 
 typedef int32_t dt_imgid_t;
+typedef int32_t dt_filmid_t;
 #define NO_IMGID (0)
+#define NO_FILMID (0)
 #define dt_is_valid_imgid(n) ((n) > NO_IMGID)
-
+#define dt_is_valid_filmid(n) ((n) > NO_FILMID)
 /*
   A dt_mask_id_t can be
   0  -> a formless mask
@@ -827,7 +829,7 @@ void dt_configure_runtime_performance(const int version, char *config_info);
 // helper function which loads whatever image_to_load points to:
 // single image files or whole directories it tells you if it was a
 // single image or a directory in single_image (when it's not NULL)
-int dt_load_from_string(const gchar *image_to_load,
+dt_imgid_t dt_load_from_string(const gchar *image_to_load,
                         const gboolean open_image_in_dr,
                         gboolean *single_image);
 

--- a/src/common/film.h
+++ b/src/common/film.h
@@ -31,7 +31,7 @@
  */
 typedef struct dt_film_t
 {
-  int32_t id;
+  dt_filmid_t id;
   char dirname[512];
   dt_pthread_mutex_t images_mutex;
   GDir *dir;
@@ -42,29 +42,27 @@ typedef struct dt_film_t
 void dt_film_init(dt_film_t *film);
 void dt_film_cleanup(dt_film_t *film);
 /** open film with given id. */
-int dt_film_open(const int32_t id);
-/** open film with given id. */
-int dt_film_open2(dt_film_t *film);
+gboolean dt_film_open(const dt_filmid_t id);
 
 /** open num-th most recently used film. */
-int dt_film_open_recent(const int32_t num);
+// gboolean dt_film_open_recent(const int32_t num);
 /** import new film and all images in this directory as a background task(non-recursive, existing films/images
  * are respected). */
-int dt_film_import(const char *dirname);
+dt_filmid_t dt_film_import(const char *dirname);
 /** constructs the lighttable/query setting for this film, respecting stars and filters. */
-void dt_film_set_query(const int32_t id);
+void dt_film_set_query(const dt_filmid_t id);
 /** get id associated with filmroll */
-int32_t dt_film_get_id(const char *folder);
+dt_filmid_t dt_film_get_id(const char *folder);
 /** removes this film and all its images from db. */
-void dt_film_remove(const int id);
+void dt_film_remove(const dt_filmid_t id);
 /** checks if film is empty */
-gboolean dt_film_is_empty(const int id);
+gboolean dt_film_is_empty(const dt_filmid_t id);
 /** Creating a new filmroll */
-int dt_film_new(dt_film_t *film, const char *directory);
+dt_filmid_t dt_film_new(dt_film_t *film, const char *directory);
 /** removes all empty film rolls. */
 void dt_film_remove_empty();
 /** gets all image ids in film. the returned GList has to be freed with g_list_free(). */
-GList *dt_film_get_image_ids(const int filmid);
+GList *dt_film_get_image_ids(const dt_filmid_t filmid);
 // initialize film folder status
 void dt_film_set_folder_status();
 // clang-format off

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -2035,7 +2035,7 @@ dt_imgid_t dt_image_get_id(const uint32_t film_id, const gchar *filename)
   return id;
 }
 
-dt_imgid_t dt_image_import(const int32_t film_id,
+dt_imgid_t dt_image_import(const dt_filmid_t film_id,
                            const char *filename,
                            const gboolean override_ignore_nonraws,
                            const gboolean raise_signals)
@@ -2044,7 +2044,7 @@ dt_imgid_t dt_image_import(const int32_t film_id,
                                 TRUE, raise_signals);
 }
 
-dt_imgid_t dt_image_import_lua(const int32_t film_id,
+dt_imgid_t dt_image_import_lua(const dt_filmid_t film_id,
                                const char *filename,
                                const gboolean override_ignore_nonraws)
 {

--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -79,8 +79,8 @@ static gboolean _import_session_initialize_filmroll(dt_import_session_t *self, c
   }
   /* open one or initialize a filmroll for the session */
   self->film = (dt_film_t *)g_malloc0(sizeof(dt_film_t));
-  const int32_t film_id = dt_film_new(self->film, path);
-  if(film_id == 0)
+  const dt_filmid_t film_id = dt_film_new(self->film, path);
+  if(!dt_is_valid_filmid(film_id))
   {
     dt_print(DT_DEBUG_ALWAYS, "[import_session] Failed to initialize film roll.\n");
     _import_session_cleanup_filmroll(self);

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -147,10 +147,10 @@ static int32_t _generic_dt_control_fileop_images_job_run
 
   // create new film roll for the destination directory
   dt_film_t new_film;
-  const int32_t film_id = dt_film_new(&new_film, newdir);
+  const dt_filmid_t film_id = dt_film_new(&new_film, newdir);
   g_free(newdir);
 
-  if(film_id <= 0)
+  if(!dt_is_valid_filmid(film_id))
   {
     dt_control_log(_("failed to create film roll for destination directory,"
                      " aborting move.."));
@@ -610,7 +610,7 @@ static int32_t dt_control_merge_hdr_job_run(dt_job_t *job)
   // import new image
   gchar *directory = g_path_get_dirname((const gchar *)pathname);
   dt_film_t film;
-  const int filmid = dt_film_new(&film, directory);
+  const dt_filmid_t filmid = dt_film_new(&film, directory);
   const dt_imgid_t imageid = dt_image_import(filmid, pathname, TRUE, TRUE);
   g_free(directory);
 
@@ -2397,9 +2397,9 @@ static int _control_import_image_insitu(const char *filename,
   dt_conf_set_int("ui_last/import_last_image", -1);
   char *dirname = dt_util_path_get_dirname(filename);
   dt_film_t film;
-  const int filmid = dt_film_new(&film, dirname);
+  const dt_filmid_t filmid = dt_film_new(&film, dirname);
   const dt_imgid_t imgid = dt_image_import(filmid, filename, FALSE, FALSE);
-  if(!imgid) dt_control_log(_("error loading file `%s'"), filename);
+  if(!dt_is_valid_imgid(imgid)) dt_control_log(_("error loading file `%s'"), filename);
   else
   {
     *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(imgid));

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -872,7 +872,7 @@ static gboolean _osx_openfile_callback(GtkOSXApplication *OSXapp, gchar *path, g
 static gboolean _osx_openfile_callback(GtkosxApplication *OSXapp, gchar *path, gpointer user_data)
 #endif
 {
-  return dt_load_from_string(path, TRUE, NULL) > 0;
+  return dt_is_valid_imgid(dt_load_from_string(path, TRUE, NULL));
 }
 #endif
 
@@ -1406,7 +1406,7 @@ double dt_get_screen_resolution(GtkWidget *widget)
   else
   {
     screen_dpi = gdk_screen_get_resolution(gtk_widget_get_screen(widget));
-    if(screen_dpi < 0.0) 
+    if(screen_dpi < 0.0)
     {
       screen_dpi = 96.0;
       gdk_screen_set_resolution(gtk_widget_get_screen(widget), 96.0);

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -817,7 +817,7 @@ static void _add_file_callback(GObject *direnum,
       ? strlen(folder) + 1
       : strlen(folder);
 
-    const int32_t filmroll_id = dt_film_get_id(folder);
+    const dt_filmid_t filmroll_id = dt_film_get_id(folder);
     for(GList *node = file_list;
         node;
         node = node->next)

--- a/src/lua/database.c
+++ b/src/lua/database.c
@@ -108,7 +108,7 @@ int dt_lua_copy_image(lua_State *L)
 static int import_images(lua_State *L)
 {
   char *full_name = g_realpath(luaL_checkstring(L, -1));
-  int result;
+  dt_filmid_t result;
 
   if(!full_name || !g_file_test(full_name, G_FILE_TEST_EXISTS))
   {
@@ -118,7 +118,7 @@ static int import_images(lua_State *L)
   else if(g_file_test(full_name, G_FILE_TEST_IS_DIR))
   {
     result = dt_film_import(full_name);
-    if(result == 0)
+    if(!dt_is_valid_filmid(result))
     {
       g_free(full_name);
       return luaL_error(L, "error while importing");
@@ -141,7 +141,7 @@ static int import_images(lua_State *L)
     }
     result = dt_film_new(&new_film, final_path);
     g_free(final_path);
-    if(result == 0)
+    if(!dt_is_valid_filmid(result))
     {
       if(dt_film_is_empty(new_film.id)) dt_film_remove(new_film.id);
       dt_film_cleanup(&new_film);
@@ -152,7 +152,7 @@ static int import_images(lua_State *L)
     result = dt_image_import_lua(new_film.id, full_name, TRUE);
     if(dt_film_is_empty(new_film.id)) dt_film_remove(new_film.id);
     dt_film_cleanup(&new_film);
-    if(result == 0)
+    if(!dt_is_valid_filmid(result))
     {
       g_free(full_name);
       return luaL_error(L, "error while importing");

--- a/src/lua/film.c
+++ b/src/lua/film.c
@@ -196,9 +196,9 @@ static int films_new(lua_State *L)
 
   dt_film_t my_film;
   dt_film_init(&my_film);
-  int film_id = dt_film_new(&my_film, final_path);
+  dt_filmid_t film_id = dt_film_new(&my_film, final_path);
   g_free(final_path);
-  if(film_id)
+  if(dt_is_valid_filmid(film_id))
   {
     luaA_push(L, dt_lua_film_t, &film_id);
     return 1;


### PR DESCRIPTION
Handling film id's is done via simple int and int32_t, tests use '== 0' or '<= 0' for non-valid film id.
Added - as we have for image id - and make use of these all over.

```
typedef int32_t dt_filmid_t;
#define NO_FILMID (0)
dt_is_valid_filmid()
```
Removed unused function dt_film_open2()
Commented unused function dt_film_open_recent(), not removed as we might make use of it