### PR TITLE
[GUI] Change fallback theme to match default theme

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2829,8 +2829,9 @@ void dt_gui_load_theme(const char *theme)
     {
       // fallback to default theme
       g_free(path);
-      path = g_build_filename(datadir, "themes", "darktable.css", NULL);
-      dt_conf_set_string("ui_last/theme", "darktable");
+      // NOTE: When changing the default theme, don't forget to change it here!
+      path = g_build_filename(datadir, "themes", "darktable-elegant-grey.css", NULL);
+      dt_conf_set_string("ui_last/theme", "darktable-elegant-grey");
     }
     else
       dt_conf_set_string("ui_last/theme", theme);


### PR DESCRIPTION
This code works only in a very specific situation, so in practice it affects not too many users. On the other hand, the change is safe, so should be fine for 4.6.1.