### PR TITLE
[GUI] Add nl to the list of languages in which online help is available

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2731,7 +2731,7 @@ void dt_gui_show_help(GtkWidget *widget)
       // array of languages the usermanual supports.
       // NULL MUST remain the last element of the array
       const char *supported_languages[] =
-        { "en", "fr", "de", "eo", "es", "gl", "it", "pl", "pt-br", "uk", NULL };
+        { "en", "fr", "de", "eo", "es", "gl", "it", "nl", "pl", "pt-br", "uk", NULL };
       int lang_index = 0;
       gboolean is_language_supported = FALSE;
 


### PR DESCRIPTION
The Dutch online help [is 100% translated](https://weblate.pixls.us/projects/darktable/dtdocs/nl/). The change is safe, so should be fine for 4.6.1.