### PR TITLE
Update darktable GIMP API

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1171,7 +1171,6 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
           if(!darktable.gimp.error)
           {
             dbfilename_from_command = ":memory:";
-            dt_gimp_init_settings();
           }
         }
       }

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -921,6 +921,11 @@ static inline gboolean dt_check_gimpmode(const char *mode)
   return darktable.gimp.mode ? strcmp(darktable.gimp.mode, mode) == 0 : FALSE;
 }
 
+static inline gboolean dt_check_gimpmode_ok(const char *mode)
+{
+  return darktable.gimp.mode ? !darktable.gimp.error && strcmp(darktable.gimp.mode, mode) == 0 : FALSE;
+}
+
 #ifdef __cplusplus
 } // extern "C"
 #endif /* __cplusplus */

--- a/src/common/gimp.c
+++ b/src/common/gimp.c
@@ -21,12 +21,6 @@
 #include "control/control.h"
 #include <glib.h>
 
-void dt_gimp_init_settings(void)
-{
-  darktable.unmuted_signal_dbg_acts = 0;
-  darktable.unmuted = 0;
-}
-
 gboolean dt_export_gimp_file(const dt_imgid_t id)
 {
   const gboolean thumb = dt_check_gimpmode("thumb");
@@ -69,13 +63,14 @@ gboolean dt_export_gimp_file(const dt_imgid_t id)
                   NULL,  // icc_filename
                   DT_INTENT_PERCEPTUAL, // for xcf it's irrelevant, for jpeg we want it
                   NULL);  // &metadata
-  fprintf(stdout, "\n%s%s\n", path, thumb ? ".jpg" : ".xcf");
+  fprintf(stdout, "<<<gimp\n%s%s\n", path, thumb ? ".jpg" : ".xcf");
   if(thumb)
   {
     dt_image_t *image = dt_image_cache_get(darktable.image_cache, id, 'r');
     fprintf(stdout, "%i %i\n", image->width, image->height);
     dt_image_cache_read_release(darktable.image_cache, image);
   }
+  fprintf(stdout, "gimp>>>\n");
   return TRUE;
 }
 

--- a/src/common/gimp.h
+++ b/src/common/gimp.h
@@ -18,7 +18,6 @@
 
 #define DT_GIMP_VERSION 1
 
-void dt_gimp_init_settings(void);
 gboolean dt_export_gimp_file(const dt_imgid_t id);
 
 dt_imgid_t dt_gimp_load_darkroom(const char *file);

--- a/src/main.c
+++ b/src/main.c
@@ -96,20 +96,17 @@ int main(int argc, char *argv[])
 
   if(dt_init(argc, argv, TRUE, TRUE, NULL)) exit(1);
 
-  if(dt_check_gimpmode("version"))
-  {
-    fprintf(stdout, "\n%d\n", DT_GIMP_VERSION);
-    exit(0);
-  }
+  if(dt_check_gimpmode_ok("version"))
+    fprintf(stdout, "\n<<<gimp\n%d\ngimp>>>\n", DT_GIMP_VERSION);
 
-  if(dt_check_gimpmode("file") && !darktable.gimp.error)
+  if(dt_check_gimpmode_ok("file"))
   {
     const dt_imgid_t id = dt_gimp_load_darkroom(darktable.gimp.path);
     if(!dt_is_valid_imgid(id))
       darktable.gimp.error = TRUE;
   }
 
-  if(dt_check_gimpmode("thumb") && !darktable.gimp.error)
+  if(dt_check_gimpmode_ok("thumb"))
   {
     const dt_imgid_t id = dt_gimp_load_image(darktable.gimp.path);
     if(dt_is_valid_imgid(id))
@@ -121,33 +118,19 @@ int main(int argc, char *argv[])
       darktable.gimp.error = TRUE;
   }
 
-  if(darktable.gimp.error)
+  if(!darktable.gimp.mode || dt_check_gimpmode_ok("file"))
+    dt_gui_gtk_run(darktable.gui);
+
+  if(dt_check_gimpmode_ok("file"))
   {
-    fprintf(stdout, "\nerror\n");
-    exit(1);
+    if(!dt_export_gimp_file(darktable.gimp.imgid))
+      darktable.gimp.error = TRUE;
   }
 
-  if(dt_check_gimpmode("thumb")) exit(darktable.gimp.error ? 1 : 0);
-
-  dt_gui_gtk_run(darktable.gui);
-
-  if(dt_check_gimpmode("file") && !darktable.gimp.error)
-  {
-    const dt_imgid_t id = darktable.gimp.imgid;
-    if(!darktable.gimp.error && dt_is_valid_imgid(id))
-    {
-      if(!dt_export_gimp_file(id))
-        darktable.gimp.error = TRUE;
-    }
-  }
   dt_cleanup();
 
-  if(darktable.gimp.error)
-  {
-    fprintf(stdout, "\nerror\n");
-    exit(1);
-  }
-
+  if(darktable.gimp.mode && darktable.gimp.error)
+    fprintf(stdout, "\n<<<gimp\nerror\ngimp>>>\n");
 
 #ifdef _WIN32
   if(redirect_output)
@@ -159,7 +142,8 @@ int main(int argc, char *argv[])
   }
 #endif
 
-  exit(0);
+  const int exitcode = darktable.gimp.mode ? (darktable.gimp.error ? 1 : 0) : 0;
+  exit(exitcode);
 }
 
 // clang-format off


### PR DESCRIPTION
Topic: Encapsulate gimp results in output files.

As we might want to make use of our debug log system or other libraries called by darktable can write text in an uncontrolled manner we want to encapsulate the gimp-relevant results for reliable use.

So redefine the new API as:

*************************************************************************************** 
The GIMP support CLI API

Added --gimp <mode> option to the cli interface. <mode> is always a string, can be "version" "file" "thumb"

Whenever we call 'darktable --gimp' the results are written to 'stdout'. All requested results are in a block encapsulated by

a start line `\n<<<gimp\n` and
a final line `\ngimp>>>`

for defined interpretation.

(This allows darktable to use the debug logs and avoids problems with libraries writing to output in an uncontrolled manner.)

In case of an error the <res> is 'error'

The exitcode of darktable while using any --gimp option reflects the error status.

version            Returns the current API version (for initial commit will be 1)
file <path>        Starts darktable in darkroom mode using image defined by <path>.
                   When closing the darkroom window the file is exported as an
                   xcf file to a temporary location.
                   The full path of the exported file is returned as <res>
thumb <path> <dim> Write a thumbnail jpg file to a temporary location.
                   <path> is the image file
                   <dim> (in pixels) is used for the greater of width/height and ratio is kept.
                   The returned <res> has the following format:
                   * The full path of the exported file on the first line
                   * The width and height as space-separated integers on the second line.
                     These dimensions are informational and may not be accurate.
                     For raw files this is sensor size containing valid data.