### PR TITLE
[CI] Fix for ImageMagick support in CI build on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,7 @@ jobs:
           - skiptest
         generator:
           - Ninja
-        eco: [-DDONT_USE_INTERNAL_LIBRAW=ON]
+        eco: [-DDONT_USE_INTERNAL_LIBRAW=ON -DUSE_GRAPHICSMAGICK=OFF -DUSE_IMAGEMAGICK=ON]
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.build.xcode }}.app/Contents/Developer
       CC: ${{ matrix.compiler.CC }}


### PR DESCRIPTION
Due to a number of issues with GraphicsMagick, the macOS nightly build has been switched to ImageMagick. But this was not done for CI, and neither GraphicsMagick nor ImageMagick was used in macOS CI builds before this PR.
