### PR TITLE
Remove unused introspection comments in the overlay module

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2023 darktable developers.
+    Copyright (C) 2009-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/iop/overlay.c
+++ b/src/iop/overlay.c
@@ -92,11 +92,11 @@ typedef struct dt_iop_overlay_params_t
   dt_iop_overlay_base_scale_t scale_base; // $DEFAULT: DT_SCALE_MAINMENU_IMAGE $DESCRIPTION: "scale on"
   dt_iop_overlay_img_scale_t scale_img; // $DEFAULT: DT_SCALE_IMG_LARGER $DESCRIPTION: "scale marker to"
   dt_iop_overlay_svg_scale_t scale_svg; // $DEFAULT: DT_SCALE_SVG_WIDTH $DESCRIPTION: "scale marker reference"
-  dt_imgid_t imgid; // $DEFAULT: NO_IMGID $DESCRIPTION: "overlay image id"
-  char filename[1024]; // $DEFAULT: 0 $DESCRIPTION: "full overlay's filename"
-  size_t buf_width; // $DEFAULT: 0 $DESCRIPTION: "no image"
-  size_t buf_height; // $DEFAULT: 0 $DESCRIPTION: "no image"
-  int64_t hash; // $DEFAULT: 0 $DESCRIPTION: "NULL pointer"
+  dt_imgid_t imgid; // overlay image id
+  char filename[1024]; // full overlay's filename
+  size_t buf_width;
+  size_t buf_height;
+  int64_t hash;
 } dt_iop_overlay_params_t;
 
 typedef struct dt_iop_overlay_data_t


### PR DESCRIPTION
It appears that introspection for these parameters is not used in the code. Therefore, the only consequence of having such comments is the creation of unused .pot msgids.

@TurboGit maybe I missed something?
