### PR TITLE
Require restart on pwstorage backend change

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2846,7 +2846,7 @@
     <shortdescription>XCF bit depth (bpp)</shortdescription>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="security" section="other">
+  <dtconfig prefs="security" section="other" restart="true">
     <name>plugins/pwstorage/pwstorage_backend</name>
     <type>
       <enum>

--- a/src/common/pwstorage/pwstorage.c
+++ b/src/common/pwstorage/pwstorage.c
@@ -109,7 +109,7 @@ const dt_pwstorage_t *dt_pwstorage_new()
       pwstorage->pw_storage_backend = PW_STORAGE_BACKEND_NONE;
       pwstorage->backend_context = NULL;
       dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_new] no storage backend. not storing username/password. "
-                                   "please change in preferences, core tab.\n");
+                                   "please change in preferences, security tab.\n");
       break;
     case PW_STORAGE_BACKEND_LIBSECRET:
 #ifdef HAVE_LIBSECRET


### PR DESCRIPTION
Since the pwstorage backend is only initialized at darktable start, a change of the backend in the preferences requires a restart.
