### PR TITLE
[GUI] Limit width of style preview tooltips

### DIFF
--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -959,21 +959,30 @@ GtkWidget *dt_gui_style_content_dialog(char *name, const dt_imgid_t imgid)
 
   GtkWidget *label = NULL;
 
-  // name
+// Currently, some module names listed in the style tooltip are wider than the
+// style thumbnail, so the actual width of the tooltip can sometimes "breathe".
+// Given this, the width we specify here can also make the tooltip a little wider.
+#define STYLE_TOOLTIP_MAX_WIDTH 30
+
+  // Style name
   gchar *esc_name = g_markup_printf_escaped("<b>%s</b>", name);
   label = gtk_label_new(NULL);
   gtk_label_set_markup(GTK_LABEL(label), esc_name);
+  gtk_label_set_max_width_chars(GTK_LABEL(label), STYLE_TOOLTIP_MAX_WIDTH);
+  gtk_label_set_line_wrap(GTK_LABEL(label), TRUE);
   gtk_box_pack_start(GTK_BOX(ht), label, FALSE, FALSE, 0);
   g_free(esc_name);
 
-  // description
+  // Style description, it can be empty
   char *des = dt_styles_get_description(name);
 
-  if(strlen(des)>0)
+  if(strlen(des) > 0)
   {
     gchar *esc_des = g_markup_printf_escaped("<b>%s</b>", des);
     label = gtk_label_new(NULL);
     gtk_label_set_markup(GTK_LABEL(label), esc_des);
+    gtk_label_set_max_width_chars(GTK_LABEL(label), STYLE_TOOLTIP_MAX_WIDTH);
+    gtk_label_set_line_wrap(GTK_LABEL(label), TRUE);
     gtk_box_pack_start(GTK_BOX(ht), label, FALSE, FALSE, 0);
     g_free(esc_des);
   }

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -978,6 +978,10 @@ GtkWidget *dt_gui_style_content_dialog(char *name, const dt_imgid_t imgid)
 
   if(strlen(des) > 0)
   {
+    // If the name and/or description are long and become multi-line, it will look
+    // hard to understand what is what, so we add a horizontal separator between them.
+    gtk_box_pack_start(GTK_BOX(ht), gtk_separator_new(GTK_ORIENTATION_HORIZONTAL), TRUE, TRUE, 0);
+
     gchar *esc_des = g_markup_printf_escaped("<b>%s</b>", des);
     label = gtk_label_new(NULL);
     gtk_label_set_markup(GTK_LABEL(label), esc_des);


### PR DESCRIPTION
I recently stumbled across [this article](https://librearts.org/2022/12/darktable-4-2/) and saw there criticism of the new style preview functionality. I began to look for relevant issues, but, to my great surprise, I did not find any. I don't really understand the motivation to report certain flaws on some site and not to report them to the projects in which you participated.

Anyway, this PR fixes the problem with unlimited tooltip expansion due to the length of the style's name or description string.

To test this PR on real examples of styles, you can import t3mujinpack styles, or take such styles as Oly_* or Architecture* from dtstyle.net. Or create your own style with a fairly long name and description.

P.S. Regarding the sluggishness, Alexandre seems to have confused the delay in displaying the tooltip with the slowness of the preview build. On my 7-year-old laptop, previews are shown almost instantly.