### PR TITLE
Use apt instead of apt-get in scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,12 +89,12 @@ jobs:
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo add-apt-repository -y universe
           sudo add-apt-repository -y multiverse
-          sudo apt-get update
-          sudo eatmydata apt-get -y install \
+          sudo apt update
+          sudo eatmydata apt -qq install \
             ${{ matrix.compiler.packages }}
       - name: Install Base Dependencies
         run: |
-          sudo eatmydata apt-get -y install \
+          sudo eatmydata apt -qq install \
             build-essential \
             appstream-util \
             desktop-file-utils \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,12 +38,12 @@ jobs:
         run: |
           # Remove azure mirror because it is unreliable and sometimes unpredictably leads to failed CI
           sudo sed -i 's/azure\.//' /etc/apt/sources.list
-          sudo apt-get update
-          sudo apt-get -y install \
+          sudo apt update
+          sudo eatmydata apt -qq install \
             ${{ matrix.compiler.packages }}
       - name: Install Base Dependencies
         run: |
-          sudo apt-get -y install \
+          sudo eatmydata apt -qq install \
             build-essential \
             appstream-util \
             desktop-file-utils \

--- a/README.md
+++ b/README.md
@@ -211,8 +211,8 @@ sudo zypper si -d darktable
 sed -e '/^#\sdeb-src /s/^# *//;t;d' "/etc/apt/sources.list" \
   | sudo tee /etc/apt/sources.list.d/darktable-sources-tmp.list > /dev/null \
   && (
-    sudo apt-get update
-    sudo apt-get build-dep darktable
+    sudo apt update
+    sudo apt build-dep darktable
   )
 sudo rm /etc/apt/sources.list.d/darktable-sources-tmp.list
 ```
@@ -220,7 +220,7 @@ sudo rm /etc/apt/sources.list.d/darktable-sources-tmp.list
 #### Debian
 
 ```bash
-sudo apt-get build-dep darktable
+sudo apt build-dep darktable
 ```
 
 #### Install missing dependencies


### PR DESCRIPTION
Meh, still says "WARNING: apt does not have a stable CLI interface. Use with caution in scripts".