### PR TITLE
Fix translatable string

### DIFF
--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -323,7 +323,7 @@ static float _action_process_preview(gpointer target, dt_action_element_t elemen
 
 const dt_action_element_def_t _action_elements_preview[]
   = { { "normal", dt_action_effect_hold },
-      { "focus detection", dt_action_effect_hold },
+      { N_("focus detection"), dt_action_effect_hold },
       { NULL } };
 
 const dt_action_def_t _action_def_preview


### PR DESCRIPTION
Possibly missed string translatable for full preview layout tooltip in light table.