### PR TITLE
[imageio] Modify the libraw loader so that it can work as a fallback loader

### DIFF
--- a/src/imageio/imageio_libraw.c
+++ b/src/imageio/imageio_libraw.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2021-2023 darktable developers.
+    Copyright (C) 2021-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -259,6 +259,8 @@ const model_map_t modelMap[] = {
 
 /* LibRaw is expected to read only new Canon CR3 files */
 
+// Let's deactivate self-restriction in order to be able to act as a fallback loader:
+#if 0
 static gboolean _supported_image(const gchar *filename)
 {
   // At the moment of writing this code CR3 files are not supported by RawSpeed,
@@ -290,6 +292,7 @@ static gboolean _supported_image(const gchar *filename)
   g_free(extensions_whitelist);
   return FALSE;
 }
+#endif
 
 void _check_libraw_missing_support(const struct dt_image_t *img)
 {
@@ -339,7 +342,10 @@ dt_imageio_retval_t dt_imageio_open_libraw(dt_image_t *img,
 {
   int err = DT_IMAGEIO_LOAD_FAILED;
   int libraw_err = LIBRAW_SUCCESS;
-  if(!_supported_image(filename)) return DT_IMAGEIO_LOAD_FAILED;
+
+  // Let's deactivate self-restriction in order to be able to act as a fallback loader:
+  // if(!_supported_image(filename)) return DT_IMAGEIO_LOAD_FAILED;
+
   if(!img->exif_inited) (void)dt_exif_read(img, filename);
 
   libraw_data_t *raw = libraw_init(0);


### PR DESCRIPTION
The libraw loader was originally added to handle only the `cr3` format, which is not supported by rawspeed. But there are cases where rawspeed failed to handle certain files of supported formats, while libraw loaded them successfully. So, an option was added to allow the rawspeed loader to ignore the processing of certain formats and offload them to the libraw loader. However, all this time we restricted the libraw loader from trying to process files that rawspeed previously worked with. This PR improves the user experience by giving libraw a chance (by removing the self-restriction) to better handle a file on which rawspeed failed.

For testing, you can use the files from #14848. They were not opened in darktable by the rawspeed loader, but they are opened with this PR because libraw works as a fallback and opens them successfully.

