### PR TITLE
RFC: Two possibly auto-applied presets for channelmixer rgb

### DIFF
--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -403,7 +403,7 @@ void init_presets(dt_iop_module_so_t *self)
        1, DEVELOP_BLEND_CS_RGB_SCENE);
 
     dt_gui_presets_update_format(_("scene-referred default"), self->op,
-                                 self->version(), FOR_MATRIX);
+                                 self->version(), FOR_MATRIX | FOR_NOT_MONO);
 
     dt_gui_presets_update_autoapply(_("scene-referred default"),
                                     self->op, self->version(), TRUE);
@@ -536,6 +536,12 @@ void init_presets(dt_iop_module_so_t *self)
 
   dt_gui_presets_add_generic(_("B&W: Fuji Acros 100"), self->op,
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
+
+  dt_gui_presets_update_format(_("B&W: Fuji Acros 100"), self->op,
+                              self->version(), FOR_RAW | FOR_NOT_COLOR);
+
+  dt_gui_presets_update_autoapply(_("B&W: Fuji Acros 100"),
+                                    self->op, self->version(), TRUE);
 
   // Kodak ?
   // can't find spectral sensitivity curves and the illuminant under which they are produced,


### PR DESCRIPTION
When using the scene-referred workflows we auto-apply the "scene-referred default" preset for all `FOR_MATRIX` images.

This PR introduces two auto-applied presets depending on the image being detected/set as BW as it can be done via

a) preference setting while importing
b) set to monochrome or
c) by demosaicer on debayered cameras.

After this pr
- color images get the old preset
- bw images auto apply the 'Fuji Acros 100' emulation

Would this be right to offer this as default or do we want the user to define the presets?