### PR TITLE
Improved history autosaving

### DIFF
--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -171,6 +171,7 @@ typedef struct dt_develop_t
   gboolean focus_hash;   // determines whether to start a new history item or to merge down.
   gboolean history_updating, image_force_reload, first_load;
   gboolean autosaving;
+  double autosave_time;
   int32_t image_invalid_cnt;
   uint32_t timestamp;
   uint32_t preview_average_delay;

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -137,7 +137,6 @@ void init(dt_view_t *self)
   lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
   dt_lua_event_add(L, "darkroom-image-loaded");
 #endif
-  dev->autosaving = TRUE;
 }
 
 uint32_t view(const dt_view_t *self)
@@ -734,6 +733,10 @@ gboolean try_enter(dt_view_t *self)
   darktable.develop->image_storage.id = imgid;
 
   dt_dev_reset_chroma(darktable.develop);
+
+  // possible enable autosaving due to conf setting but wait for some seconds for first save
+  darktable.develop->autosaving = (double)dt_conf_get_int("autosave_interval") > 1.0;
+  darktable.develop->autosave_time = dt_get_wtime() + 10.0;
   return FALSE;
 }
 
@@ -833,6 +836,10 @@ static void _dev_change_image(dt_develop_t *dev, const dt_imgid_t imgid)
   dt_dev_write_history(dev);
 
   dev->requested_id = imgid;
+
+  // possible enable autosaving due to conf setting but wait for some seconds for first save
+  darktable.develop->autosaving = (double)dt_conf_get_int("autosave_interval") > 1.0;
+  darktable.develop->autosave_time = dt_get_wtime() + 10.0;
 
   g_idle_add(_dev_load_requested_image, dev);
 }


### PR DESCRIPTION
As either a very large history or a slow drive (like on a network) can be the reason for very slow writing of history to db and the xmp to disk we want to disable the autosave feature in such cases.

Due to the described reasons this should be checked on a 'per image basis'.

This commit
1. keeps track of last saving time in dev struct
2. re-enables autosaving after an image change or darkroom restarting
3. disables only on per image