### PR TITLE
history: Ensure we copy items based on their multi-priority.

### DIFF
--- a/src/common/history.h
+++ b/src/common/history.h
@@ -140,6 +140,7 @@ char *dt_history_get_name_label(const char *name,
 /** get list of history items for image */
 GList *dt_history_get_items(const dt_imgid_t imgid,
                             const gboolean enabled,
+                            const gboolean multi_priority_order,
                             const gboolean markup);
 
 /** get list of history items for image as a nice string */

--- a/src/gui/hist_dialog.c
+++ b/src/gui/hist_dialog.c
@@ -311,7 +311,7 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
     dt_draw_paint_to_pixbuf(GTK_WIDGET(dialog), 10, 0, dtgtk_cairo_paint_showmask);
 
   /* fill list with history items */
-  GList *items = dt_history_get_items(imgid, FALSE, TRUE);
+  GList *items = dt_history_get_items(imgid, FALSE, TRUE, TRUE);
   if(items)
   {
     GtkTreeIter iter;

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -821,7 +821,7 @@ static void _gui_styles_dialog_run(gboolean edit,
                        -1);
     g_free(label);
 
-    GList *items = dt_history_get_items(imgid, FALSE, TRUE);
+    GList *items = dt_history_get_items(imgid, FALSE, TRUE, TRUE);
     if(items)
     {
       for(const GList *items_iter = items; items_iter; items_iter = g_list_next(items_iter))


### PR DESCRIPTION
That is, we want to insert new items from lowest multi-priority to highest. This is to ensure we keep the proper order into the destination.

Fixes #16372.