### PR TITLE
increase gmz LUT selection box max height (200 -> 350), scroll wheel behavior

### DIFF
--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -1343,7 +1343,7 @@ static void show_hide_controls(dt_iop_module_t *self)
   if((nb_luts > 1) || ((nb_luts > 0) &&
        g_str_has_prefix(dt_bauhaus_combobox_get_text(g->filepath), invalid_filepath_prefix)))
   {
-    int nb_pixels = (20*(nb_luts+1) > 200) ? 200 : 20*(nb_luts);
+    int nb_pixels = (20*(nb_luts+1) > 350) ? 350 : 20*(nb_luts);
     if(nb_luts > 100)
       gtk_widget_set_visible(g->lutentry, TRUE);
     else
@@ -1454,30 +1454,6 @@ static void lutname_callback(GtkTreeSelection *selection, dt_iop_module_t *self)
     }
     g_free(lutname);
   }
-}
-
-static gboolean mouse_scroll(GtkWidget *view, GdkEventScroll *event, dt_lib_module_t *self)
-{
-  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(view));
-  GtkTreeIter iter;
-  GtkTreeModel *model = gtk_tree_view_get_model((GtkTreeView *)view);
-  if(gtk_tree_selection_get_selected(selection, &model, &iter))
-  {
-    gboolean next = FALSE;
-    if(event->delta_y > 0)
-      next = gtk_tree_model_iter_next(model, &iter);
-    else
-      next = gtk_tree_model_iter_previous(model, &iter);
-    if(next)
-    {
-      gtk_tree_selection_select_iter(selection, &iter);
-      GtkTreePath *path = gtk_tree_model_get_path(model, &iter);
-      gtk_tree_view_set_cursor((GtkTreeView *)view, path, NULL, FALSE);
-      gtk_tree_path_free(path);
-      return TRUE;
-    }
-  }
-  return FALSE;
 }
 #endif // HAVE_GMIC
 
@@ -1738,7 +1714,6 @@ void gui_init(dt_iop_module_t *self)
   GtkTreeSelection *selection = gtk_tree_view_get_selection(view);
   gtk_tree_selection_set_mode(selection, GTK_SELECTION_SINGLE);
   g->lutname_handler_id = g_signal_connect(G_OBJECT(selection), "changed", G_CALLBACK(lutname_callback), self);
-  g_signal_connect(G_OBJECT(view), "scroll-event", G_CALLBACK(mouse_scroll), (gpointer)self);
   gtk_box_pack_start((GtkBox *)self->widget, sw , TRUE, TRUE, 0);
 #endif // HAVE_GMIC
 


### PR DESCRIPTION
…now works to scroll

### Overview
Currently, the LUT 3D iop gui has a specific UI for use with compressed LUTs (.gmz files). Once a .gmz file is selected, a list box is rendered, populated with all the LUT available from the selected .gmz file. This list box is currently rather short in height, making it difficult to view the list of available LUTs. The popular gmic ships gmic_clutz.gmz with hundreds (over a thousand?) contained LUTs - finding a specific one in a small box is difficult if the name isn't precisely known to use text search. 

![image](https://github.com/darktable-org/darktable/assets/69985420/a9e605c3-ba07-4223-a920-db324a263508)

When browsing through the LUT list, a user will intuitively begin to scroll through with the mouse wheel. Instead of scrolling the list as expected, darktable will currently interpret the scroll input to cycle through the available LUTs, applying them as the user scrolls. Because the scroll wheel is not a particular precise input mechanism - a single flick of the wheel can create an unpredictable number of events - the user ends up changing the applied LUT. This is not intuitive. Nor is it a responsive operation - changing the LUT can and frequently will cause the UI to lag with every scroll as LUTs are decompressed and applied. There's no convenient way to scroll through the list without grabbing the scroll bar and going on a hunt.

### Changed
- The max height for the LUT select box is increased from 200 to 350 px (subject to dpi scaling as usual). 

![image](https://github.com/darktable-org/darktable/assets/69985420/38aee388-271e-4fa4-89b8-d23ac0f8a1d3)

- Special behavior to iterate through LUTs on scroll behavior is removed. Users can still use the keyboard up/down arrow to iterate through LUTs, but the mouse scroll wheel will now move through the list without changing the selected LUT. The UI is both more intuitive to use and faster to respond.

### Potential future improvements
- Adjustable LUT selection list height, similar to equalizer UI
- Maybe use the existing scroll behavior with a modifier key? Open to input on this, not sure it's worth supporting LUT iteration by mouse wheel.