### PR TITLE
[CI] Use GCC 13 in Linux CI as the latest GCC release at the moment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         distro:
           - "debian:trixie-slim"
         compiler:
-          - { compiler: GNU12,  CC: gcc-12,   CXX: g++-12,     packages: gcc-12 g++-12 }
+          - { compiler: GNU13,  CC: gcc-13,   CXX: g++-13,     packages: gcc-13 g++-13 }
           - { compiler: LLVM15, CC: clang-15, CXX: clang++-15, packages: clang-15 libomp-15-dev llvm-15-dev libc++-15-dev libc++abi1-15 lld-15 clang-tools-15 mlir-15-tools libmlir-15-dev}
         btype:
           - Release
@@ -66,7 +66,7 @@ jobs:
           # We want one run in CI to be Debug to make sure the Debug build isn't broken
           - distro: "debian:trixie-slim"
             btype: Debug
-            compiler: { compiler: GNU12,  CC: gcc-12,   CXX: g++-12,     packages: gcc-12 g++-12 }
+            compiler: { compiler: GNU13, CC: gcc-13, CXX: g++-13, packages: gcc-13 g++-13 }
             target: skiptest
             generator: Ninja
     env:


### PR DESCRIPTION
We need to use the latest GCC release in CI (currently GCC 13). It doesn't make sense to use GCC 12 here because we already use GCC 12 for the AppImage nightly build. This PR is returning to the way it was before, it's part of the damage control after "summer dependency bumps".
