### PR TITLE
Bugfix CAcorrect for clang / gcc

### DIFF
--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2023 darktable developers.
+    Copyright (C) 2010-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -281,13 +281,13 @@ void process(
   float *RawDataTmp = NULL;
   float *Gtmp = NULL;
 
-  const size_t width = roi_in->width;
-  const size_t height = roi_in->height;
-  const size_t ibsize = dt_round_size(width, DT_CACHELINE_FLOATS) * (height + 2);
+  const int width = roi_in->width;
+  const int height = roi_in->height;
+  const size_t ibsize = dt_round_size(width, DT_CACHELINE_FLOATS) * (size_t)(height + 2);
 
-  const size_t h_width = (width + 1) / 2;
-  const size_t h_height = (height + 1) / 2;
-  const size_t h_bsize = dt_round_size(h_width, DT_CACHELINE_FLOATS) * (h_height + 2);
+  const int h_width = (width + 1) / 2;
+  const int h_height = (height + 1) / 2;
+  const size_t h_bsize = dt_round_size(h_width, DT_CACHELINE_FLOATS) * (size_t)(h_height + 2);
 
   float *out = dt_alloc_align_float(ibsize);
   if(!out)
@@ -377,68 +377,67 @@ void process(
   const float eps = 1e-5f;
   const float eps2 = 1e-10f; // tolerance to avoid dividing by zero
 
-  for(size_t it = 0; it < iterations && processpasstwo; it++)
+  for(int it = 0; it < iterations && processpasstwo; it++)
   {
     // A reminder, be very careful if you try to optimize the parallel processing loop
     // for not breaking multipass mode and clang/gcc differences.
     // See darktable file history and related problems before doing so.
-#if defined(_OPENMP)
+#ifdef _OPENMP
 #pragma omp parallel
 #endif
-   {
-    // direction of the CA shift in a tile
-    int GRBdir[2][3];
-
-    int shifthfloor[3];
-    int shiftvfloor[3];
-    int shifthceil[3];
-    int shiftvceil[3];
-
-    // local quadratic fit to shift data within a tile
-    float coeff[2][3][2];
-    // measured CA shift parameters for a tile
-    float CAshift[2][2];
-    // polynomial fit coefficients
-    // residual CA shift amount within a plaquette
-    float shifthfrac[3];
-    float shiftvfrac[3];
-    // per thread data for evaluation of block CA shift variance
-    float blockavethr[2][2] = { { 0, 0 }, { 0, 0 } };
-    float blocksqavethr[2][2] = { { 0, 0 }, { 0, 0 } };
-    float blockdenomthr[2][2] = { { 0, 0 }, { 0, 0 } };
-
-    // assign working space
-    // allocate all buffers in one bunch but make sure they are all aligned-64 by proper tilesize ts
-    const size_t tilebuf_size = ts * ts;
-    const size_t tilebuf_half_size = ts * tsh;
-
-    const size_t buffersize = 3 * tilebuf_size + 6 * tilebuf_half_size;
-    float *data = dt_alloc_align_float(buffersize);
-
-    // rgb data in a tile
-    float *rgb[3];
-    rgb[0] = (float(*))data;
-    rgb[1] = (float(*))(data + tilebuf_size);
-    rgb[2] = (float(*))(data + 2 * tilebuf_size);
-
-    // high pass filter for R/B in vertical direction
-    float *rbhpfh = data + 3 * tilebuf_size;
-    // high pass filter for R/B in horizontal direction
-    float *rbhpfv = data + 3 * tilebuf_size + 1 * tilebuf_half_size;
-    // low pass filter for R/B in horizontal direction
-    float *rblpfh = data + 3 * tilebuf_size + 2 * tilebuf_half_size;
-    // low pass filter for R/B in vertical direction
-    float *rblpfv = data + 3 * tilebuf_size + 3 * tilebuf_half_size;
-    // low pass filter for colour differences in horizontal direction
-    float *grblpfh = data + 3 * tilebuf_size + 4 * tilebuf_half_size;
-    // low pass filter for colour differences in vertical direction
-    float *grblpfv = data + 3 * tilebuf_size + 5 * tilebuf_half_size;
-    // colour differences
-    float *grbdiff = rbhpfh; // there is no overlap in buffer usage => share
-    // green interpolated to optical sample points for R/B
-    float *gshift = rbhpfv; // there is no overlap in buffer usage => share
-
     {
+      // direction of the CA shift in a tile
+      int GRBdir[2][3];
+
+      int shifthfloor[3];
+      int shiftvfloor[3];
+      int shifthceil[3];
+      int shiftvceil[3];
+
+      // local quadratic fit to shift data within a tile
+      float coeff[2][3][2];
+      // measured CA shift parameters for a tile
+      float CAshift[2][2];
+      // polynomial fit coefficients
+      // residual CA shift amount within a plaquette
+      float shifthfrac[3];
+      float shiftvfrac[3];
+      // per thread data for evaluation of block CA shift variance
+      float blockavethr[2][2] = { { 0, 0 }, { 0, 0 } };
+      float blocksqavethr[2][2] = { { 0, 0 }, { 0, 0 } };
+      float blockdenomthr[2][2] = { { 0, 0 }, { 0, 0 } };
+
+      // assign working space
+      // allocate all buffers in one bunch but make sure they are all aligned-64 by proper tilesize ts
+      const int tilebuf_size = ts * ts;
+      const int tilebuf_half_size = ts * tsh;
+
+      const size_t buffersize = 3 * (size_t)tilebuf_size + 6 * tilebuf_half_size;
+      float *data = dt_alloc_align_float(buffersize);
+
+      // rgb data in a tile
+      float *rgb[3];
+      rgb[0] = (float(*))data;
+      rgb[1] = (float(*))(data + tilebuf_size);
+      rgb[2] = (float(*))(data + 2 * tilebuf_size);
+
+      // high pass filter for R/B in vertical direction
+      float *rbhpfh = data + 3 * tilebuf_size;
+      // high pass filter for R/B in horizontal direction
+      float *rbhpfv = data + 3 * tilebuf_size + 1 * tilebuf_half_size;
+      // low pass filter for R/B in horizontal direction
+      float *rblpfh = data + 3 * tilebuf_size + 2 * tilebuf_half_size;
+      // low pass filter for R/B in vertical direction
+      float *rblpfv = data + 3 * tilebuf_size + 3 * tilebuf_half_size;
+      // low pass filter for colour differences in horizontal direction
+      float *grblpfh = data + 3 * tilebuf_size + 4 * tilebuf_half_size;
+      // low pass filter for colour differences in vertical direction
+      float *grblpfv = data + 3 * tilebuf_size + 5 * tilebuf_half_size;
+      // colour differences
+      float *grbdiff = rbhpfh; // there is no overlap in buffer usage => share
+      // green interpolated to optical sample points for R/B
+      float *gshift = rbhpfv; // there is no overlap in buffer usage => share
+
 // Main algorithm: Tile loop calculating correction parameters per tile
 #ifdef _OPENMP
 #pragma omp for collapse(2) schedule(static) nowait
@@ -454,31 +453,29 @@ void process(
           const int right = MIN(left + ts, width + border);
           const int rr1 = bottom - top;
           const int cc1 = right - left;
-          const size_t rrmin = top < 0 ? border : 0;
-          const size_t rrmax = bottom > height ? height - top : rr1;
-          const size_t ccmin = left < 0 ? border : 0;
-          const size_t ccmax = right > width ? width - left : cc1;
+          const int rrmin = top < 0 ? border : 0;
+          const int rrmax = bottom > height ? height - top : rr1;
+          const int ccmin = left < 0 ? border : 0;
+          const int ccmax = right > width ? width - left : cc1;
 
           // rgb from input CFA data
           // rgb values should be floating point numbers between 0 and 1
           // after white balance multipliers are applied
 
-          for(size_t rr = rrmin; rr < rrmax; rr++)
+          for(int rr = rrmin; rr < rrmax; rr++)
           {
-            size_t row = rr + top;
-            size_t c = FC(rr, ccmin, filters);
-            const size_t c_diff = c ^ FC(rr, ccmin+1, filters);
-            for(size_t cc = ccmin; cc < ccmax; cc++)
+            int row = rr + top;
+            int c = FC(rr, ccmin, filters);
+            const int c_diff = c ^ FC(rr, ccmin+1, filters);
+            for(int cc = ccmin; cc < ccmax; cc++)
             {
-              const size_t col = cc + left;
-              const size_t indx = row * width + col;
-              const size_t indx1 = rr * ts + cc;
+              const int col = cc + left;
+              const size_t indx = (size_t)row * width + col;
+              const size_t indx1 = (size_t)rr * ts + cc;
               rgb[c][indx1] = in[indx];
               c ^= c_diff;
             }
           }
-
-          // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
           // fill borders
           if(rrmin > 0)
           {
@@ -487,9 +484,8 @@ void process(
               {
                 const int c = FC(rr, cc, filters);
                 rgb[c][rr * ts + cc] = rgb[c][(border2 - rr) * ts + cc];
-              }
+             }
           }
-
           if(rrmax < rr1)
           {
             for(int rr = 0; rr < MIN(border, rr1 - rrmax); rr++)
@@ -499,7 +495,6 @@ void process(
                 rgb[c][(rrmax + rr) * ts + cc] = in[(height - rr - 2) * width + left + cc];
               }
           }
-
           if(ccmin > 0)
           {
             for(int rr = rrmin; rr < rrmax; rr++)
@@ -509,7 +504,6 @@ void process(
                 rgb[c][rr * ts + cc] = rgb[c][rr * ts + border2 - cc];
               }
           }
-
           if(ccmax < cc1)
           {
             for(int rr = rrmin; rr < rrmax; rr++)
@@ -519,7 +513,6 @@ void process(
                 rgb[c][rr * ts + ccmax + cc] = in[(top + rr) * width + (width - cc - 2)];
               }
           }
-
           // also, fill the image corners
           if(rrmin > 0 && ccmin > 0)
           {
@@ -530,7 +523,6 @@ void process(
                 rgb[c][(rr)*ts + cc] = in[(border2 - rr) * width + border2 - cc];
               }
           }
-
           if(rrmax < rr1 && ccmax < cc1)
           {
             for(int rr = 0; rr < MIN(border, rr1 - rrmax); rr++)
@@ -540,7 +532,6 @@ void process(
                 rgb[c][(rrmax + rr) * ts + ccmax + cc] = in[(height - rr - 2) * width + (width - cc - 2)];
               }
           }
-
           if(rrmin > 0 && ccmax < cc1)
           {
             for(int rr = 0; rr < border; rr++)
@@ -550,7 +541,6 @@ void process(
                 rgb[c][(rr)*ts + ccmax + cc] = in[(border2 - rr) * width + (width - cc - 2)];
               }
           }
-
           if(rrmax < rr1 && ccmin > 0)
           {
             for(int rr = 0; rr < MIN(border, rr1 - rrmax); rr++)
@@ -560,61 +550,55 @@ void process(
                 rgb[c][(rrmax + rr) * ts + cc] = in[(height - rr - 2) * width + (border2 - cc)];
               }
           }
-
-// end of border fill
-// %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-// end of initialization
-
-          for(int rr = 3; rr < rr1 - 3; rr++)
+          // end of border fill
+          // end of initialization
+            for(int rr = 3; rr < rr1 - 3; rr++)
           {
             int row = rr + top;
-            for(int cc = 3 + (FC(rr, 3, filters) & 1), indx = rr * ts + cc, c = FC(rr, cc, filters); cc < cc1 - 3; cc += 2, indx += 2)
+            for(int cc = 3 + (FC(rr, 3, filters) & 1), indx = rr * ts + cc, c = FC(rr, cc, filters);
+                  cc < cc1 - 3;
+                  cc += 2, indx += 2)
             {
               // compute directional weights using image gradients
-              const float wtu = 1.f / sqrf(eps + fabsf(rgb[1][indx + v1] - rgb[1][indx - v1])
-                                    + fabsf(rgb[c][indx] - rgb[c][indx - v2])
-                                    + fabsf(rgb[1][indx - v1] - rgb[1][indx - v3]));
-              const float wtd = 1.f / sqrf(eps + fabsf(rgb[1][indx - v1] - rgb[1][indx + v1])
-                                    + fabsf(rgb[c][indx] - rgb[c][indx + v2])
-                                    + fabsf(rgb[1][indx + v1] - rgb[1][indx + v3]));
-              const float wtl = 1.f / sqrf(eps + fabsf(rgb[1][indx + 1] - rgb[1][indx - 1])
-                                    + fabsf(rgb[c][indx] - rgb[c][indx - 2])
-                                    + fabsf(rgb[1][indx - 1] - rgb[1][indx - 3]));
-              const float wtr = 1.f / sqrf(eps + fabsf(rgb[1][indx - 1] - rgb[1][indx + 1])
-                                    + fabsf(rgb[c][indx] - rgb[c][indx + 2])
-                                    + fabsf(rgb[1][indx + 1] - rgb[1][indx + 3]));
-
-              // store in rgb array the interpolated G value at R/B grid points using directional weighted
-              // average
-              rgb[1][indx] = (wtu * rgb[1][indx - v1] + wtd * rgb[1][indx + v1] + wtl * rgb[1][indx - 1]
-                              + wtr * rgb[1][indx + 1])
-                             / (wtu + wtd + wtl + wtr);
+              const float wtu = 1.f / sqrf(eps+ fabsf(rgb[1][indx + v1] - rgb[1][indx - v1])
+                                              + fabsf(rgb[c][indx]      - rgb[c][indx - v2])
+                                              + fabsf(rgb[1][indx - v1] - rgb[1][indx - v3]));
+              const float wtd = 1.f / sqrf(eps+ fabsf(rgb[1][indx - v1] - rgb[1][indx + v1])
+                                              + fabsf(rgb[c][indx]      - rgb[c][indx + v2])
+                                              + fabsf(rgb[1][indx + v1] - rgb[1][indx + v3]));
+              const float wtl = 1.f / sqrf(eps+ fabsf(rgb[1][indx + 1]  - rgb[1][indx - 1])
+                                              + fabsf(rgb[c][indx]      - rgb[c][indx - 2])
+                                              + fabsf(rgb[1][indx - 1]  - rgb[1][indx - 3]));
+              const float wtr = 1.f / sqrf(eps+ fabsf(rgb[1][indx - 1]  - rgb[1][indx + 1])
+                                              + fabsf(rgb[c][indx]      - rgb[c][indx + 2])
+                                              + fabsf(rgb[1][indx + 1]  - rgb[1][indx + 3]));
+              // store in rgb array the interpolated G value at R/B grid points using directional weighted average
+              rgb[1][indx] = (wtu * rgb[1][indx - v1] + wtd * rgb[1][indx + v1] + wtl * rgb[1][indx - 1] + wtr * rgb[1][indx + 1])
+                              / (wtu + wtd + wtl + wtr);
             }
-
             if(row > -1 && row < height)
             {
               for(int col = MAX(left + 3, 0), indx = rr * ts + 3 - (left < 0 ? (left + 3) : 0);
-                  col < MIN(cc1 + left - 3, width); col++, indx++)
+                    col < MIN(cc1 + left - 3, width);
+                    col++, indx++)
               {
                 Gtmp[row * width + col] = rgb[1][indx];
               }
             }
           }
-
           for(int rr = borderh; rr < rr1 - borderh; rr++)
           {
-            for(int cc = borderh + (FC(rr, 2, filters) & 1), indx = rr * ts + cc, c = FC(rr, cc, filters); cc < cc1 - borderh; cc += 2, indx += 2)
+            for(int cc = borderh + (FC(rr, 2, filters) & 1), indx = rr * ts + cc, c = FC(rr, cc, filters);
+                  cc < cc1 - borderh;
+                  cc += 2, indx += 2)
             {
-              rbhpfv[indx >> 1] = fabsf(
-                    fabsf((rgb[1][indx] - rgb[c][indx]) - (rgb[1][indx + v4] - rgb[c][indx + v4]))
-                  + fabsf((rgb[1][indx - v4] - rgb[c][indx - v4]) - (rgb[1][indx] - rgb[c][indx]))
-                  - fabsf((rgb[1][indx - v4] - rgb[c][indx - v4]) - (rgb[1][indx + v4] - rgb[c][indx + v4])));
-              rbhpfh[indx >> 1] = fabsf(
-                  fabsf((rgb[1][indx] - rgb[c][indx]) - (rgb[1][indx + 4] - rgb[c][indx + 4]))
-                  + fabsf((rgb[1][indx - 4] - rgb[c][indx - 4]) - (rgb[1][indx] - rgb[c][indx]))
-                  - fabsf((rgb[1][indx - 4] - rgb[c][indx - 4]) - (rgb[1][indx + 4] - rgb[c][indx + 4])));
-
-              // low and high pass 1D filters of G in vertical/horizontal directions
+              rbhpfv[indx >> 1] = fabsf(fabsf((rgb[1][indx] - rgb[c][indx])           - (rgb[1][indx + v4] - rgb[c][indx + v4]))
+                                      + fabsf((rgb[1][indx - v4] - rgb[c][indx - v4]) - (rgb[1][indx] - rgb[c][indx]))
+                                      - fabsf((rgb[1][indx - v4] - rgb[c][indx - v4]) - (rgb[1][indx + v4] - rgb[c][indx + v4])));
+              rbhpfh[indx >> 1] = fabsf(fabsf((rgb[1][indx] - rgb[c][indx])           - (rgb[1][indx + 4] - rgb[c][indx + 4]))
+                                      + fabsf((rgb[1][indx - 4] - rgb[c][indx - 4])   - (rgb[1][indx] - rgb[c][indx]))
+                                      - fabsf((rgb[1][indx - 4] - rgb[c][indx - 4])   - (rgb[1][indx + 4] - rgb[c][indx + 4])));
+                // low and high pass 1D filters of G in vertical/horizontal directions
               const float glpfv = 0.25f * (2.f * rgb[1][indx] + rgb[1][indx + v2] + rgb[1][indx - v2]);
               const float glpfh = 0.25f * (2.f * rgb[1][indx] + rgb[1][indx + 2] + rgb[1][indx - 2]);
               rblpfv[indx >> 1] = eps + fabsf(glpfv - 0.25f * (2.f * rgb[c][indx] + rgb[c][indx + v2] + rgb[c][indx - v2]));
@@ -623,15 +607,12 @@ void process(
               grblpfh[indx >> 1] = glpfh + 0.25f * (2.f * rgb[c][indx] + rgb[c][indx + 2] + rgb[c][indx - 2]);
             }
           }
-
           for(int dir = 0; dir < 2; dir++)
           {
             for(int k = 0; k < 3; k++)
             {
               for(int c = 0; c < 2; c++)
-              {
                 coeff[dir][k][c] = 0;
-              }
             }
           }
 
@@ -639,47 +620,31 @@ void process(
           // averaged over the tile; evaluate for up/down and left/right away from R/B grid point
           for(int rr = border; rr < rr1 - border; rr++)
           {
-            for(int cc = border + (FC(rr, 2, filters) & 1), indx = rr * ts + cc, c = FC(rr, cc, filters); cc < cc1 - border; cc += 2, indx += 2)
+            for(int cc = border + (FC(rr, 2, filters) & 1), indx = rr * ts + cc, c = FC(rr, cc, filters);
+                  cc < cc1 - border;
+                  cc += 2, indx += 2)
             {
-
               // in linear interpolation, colour differences are a quadratic function of interpolation
-              // position;
-              // solve for the interpolation position that minimizes colour difference variance over the tile
-
-              // vertical
+              // position; solve for the interpolation position that minimizes colour difference variance over the tile
+                // vertical
               float gdiff = 0.3125f * (rgb[1][indx + ts] - rgb[1][indx - ts])
-                         + 0.09375f * (rgb[1][indx + ts + 1] - rgb[1][indx - ts + 1]
-                                     + rgb[1][indx + ts - 1] - rgb[1][indx - ts - 1]);
+                         + 0.09375f * (rgb[1][indx + ts + 1] - rgb[1][indx - ts + 1] + rgb[1][indx + ts - 1] - rgb[1][indx - ts - 1]);
               float deltgrb = (rgb[c][indx] - rgb[1][indx]);
-
-              float gradwt = fabsf(0.25f *  rbhpfv[indx >> 1]
-                                + 0.125f * (rbhpfv[(indx >> 1) + 1]
-                                +           rbhpfv[(indx >> 1) - 1]))
+              float gradwt = fabsf(0.25f *  rbhpfv[indx >> 1] + 0.125f * (rbhpfv[(indx >> 1) + 1] + rbhpfv[(indx >> 1) - 1]))
                              * (grblpfv[(indx >> 1) - v1] + grblpfv[(indx >> 1) + v1])
-                             / (eps + 0.1f * (grblpfv[(indx >> 1) - v1]
-                                            + grblpfv[(indx >> 1) + v1])
-                                            + rblpfv[(indx >> 1) - v1] + rblpfv[(indx >> 1) + v1]);
-
+                             / (eps + 0.1f * (grblpfv[(indx >> 1) - v1] + grblpfv[(indx >> 1) + v1]) + rblpfv[(indx >> 1) - v1] + rblpfv[(indx >> 1) + v1]);
               coeff[0][0][c >> 1] += gradwt * deltgrb * deltgrb;
               coeff[0][1][c >> 1] += gradwt * gdiff * deltgrb;
               coeff[0][2][c >> 1] += gradwt * gdiff * gdiff;
-
-              // horizontal
+                // horizontal
               gdiff = 0.3125f * (rgb[1][indx + 1] - rgb[1][indx - 1])
-                   + 0.09375f * (rgb[1][indx + 1 + ts] - rgb[1][indx - 1 + ts] + rgb[1][indx + 1 - ts]
-                               - rgb[1][indx - 1 - ts]);
-
-              gradwt = fabsf(0.25f * rbhpfh[indx >> 1]
-                          + 0.125f * (rbhpfh[(indx >> 1) + v1]
-                                    + rbhpfh[(indx >> 1) - v1]))
+                   + 0.09375f * (rgb[1][indx + 1 + ts] - rgb[1][indx - 1 + ts] + rgb[1][indx + 1 - ts] - rgb[1][indx - 1 - ts]);
+              gradwt = fabsf(0.25f * rbhpfh[indx >> 1] + 0.125f * (rbhpfh[(indx >> 1) + v1] + rbhpfh[(indx >> 1) - v1]))
                        * (grblpfh[(indx >> 1) - 1] + grblpfh[(indx >> 1) + 1])
-                       / (eps + 0.1f * (grblpfh[(indx >> 1) - 1] + grblpfh[(indx >> 1) + 1])
-                          + rblpfh[(indx >> 1) - 1] + rblpfh[(indx >> 1) + 1]);
-
+                       / (eps + 0.1f * (grblpfh[(indx >> 1) - 1] + grblpfh[(indx >> 1) + 1]) + rblpfh[(indx >> 1) - 1] + rblpfh[(indx >> 1) + 1]);
               coeff[1][0][c >> 1] += gradwt * deltgrb * deltgrb;
               coeff[1][1][c >> 1] += gradwt * gdiff * deltgrb;
               coeff[1][2][c >> 1] += gradwt * gdiff * gdiff;
-
               //  In Mathematica,
               //  f[x_]=Expand[Total[Flatten[
               //  ((1-x) RotateLeft[Gint,shift1]+x
@@ -692,7 +657,6 @@ void process(
           {
             for(int dir = 0; dir < 2; dir++)
             { // vert/hor
-
               // CAshift[dir][c] are the locations
               // that minimize colour difference variances;
               // This is the approximate _optical_ location of the R/B pixels
@@ -706,10 +670,8 @@ void process(
                 CAshift[dir][c] = 17.0f;
                 blockwt[vblock * horiz_tiles + hblock] = 0;
               }
-
               // data structure = CAshift[vert/hor][colour]
               // dir : 0=vert, 1=hor
-
               // offset gives NW corner of square containing the min; dir : 0=vert, 1=hor
               if(fabsf(CAshift[dir][c]) < 2.0f)
               {
@@ -719,12 +681,12 @@ void process(
               }
               // evaluate the shifts to the location that minimizes CA within the tile
               blockshifts[vblock * horiz_tiles + hblock][c][dir] = CAshift[dir][c]; // vert/hor CA shift for R/B
-
             } // vert/hor
           }   // colour
         }
       }
-// end of diagnostic pass
+      // end of diagnostic pass per tile
+
 #ifdef _OPENMP
 #pragma omp critical(cadetectpass2)
 #endif
@@ -737,6 +699,7 @@ void process(
             blockave[dir][c] += blockavethr[dir][c];
           }
       }
+
 #ifdef _OPENMP
 #pragma omp barrier
 #endif
@@ -750,9 +713,7 @@ void process(
           for(int c = 0; c < 2; c++)
           {
             if(blockdenom[dir][c])
-            {
               blockvar[dir][c] = blocksqave[dir][c] / blockdenom[dir][c] - sqrf(blockave[dir][c] / blockdenom[dir][c]);
-            }
             else
             {
               processpasstwo = FALSE;
@@ -761,7 +722,6 @@ void process(
             }
           }
         }
-
         // now prepare for CA correction pass
         // first, fill border blocks of blockshift array
         if(processpasstwo)
@@ -777,7 +737,6 @@ void process(
               }
             }
           }
-
           for(int hblock = 0; hblock < horiz_tiles; hblock++)
           { // top and bottom sides
             for(int c = 0; c < 2; c++)
@@ -789,22 +748,16 @@ void process(
               }
             }
           }
-
           // end of filling border pixels of blockshift array
-
           // initialize fit arrays
           double polymat[2][2][256];
           double shiftmat[2][2][16];
 
           for(int i = 0; i < 256; i++)
-          {
             polymat[0][0][i] = polymat[0][1][i] = polymat[1][0][i] = polymat[1][1][i] = 0;
-          }
 
           for(int i = 0; i < 16; i++)
-          {
             shiftmat[0][0][i] = shiftmat[0][1][i] = shiftmat[1][0][i] = shiftmat[1][1][i] = 0;
-          }
 
           int numblox[2] = { 0, 0 };
 
@@ -819,28 +772,22 @@ void process(
                 for(int dir = 0; dir < 2; dir++)
                 {
                   const float p[9]  __attribute__((aligned(16))) =
-                  { blockshifts[(vblock - 1) * horiz_tiles + hblock - 1][c][dir],
-                    blockshifts[(vblock - 1) * horiz_tiles + hblock    ][c][dir],
-                    blockshifts[(vblock - 1) * horiz_tiles + hblock + 1][c][dir],
-                    blockshifts[(vblock)     * horiz_tiles + hblock - 1][c][dir],
-                    blockshifts[(vblock)     * horiz_tiles + hblock    ][c][dir],
-                    blockshifts[(vblock)     * horiz_tiles + hblock + 1][c][dir],
-                    blockshifts[(vblock + 1) * horiz_tiles + hblock - 1][c][dir],
-                    blockshifts[(vblock + 1) * horiz_tiles + hblock    ][c][dir],
-                    blockshifts[(vblock + 1) * horiz_tiles + hblock + 1][c][dir] };
+                        { blockshifts[(vblock - 1) * horiz_tiles + hblock - 1][c][dir],
+                          blockshifts[(vblock - 1) * horiz_tiles + hblock    ][c][dir],
+                          blockshifts[(vblock - 1) * horiz_tiles + hblock + 1][c][dir],
+                          blockshifts[(vblock)     * horiz_tiles + hblock - 1][c][dir],
+                          blockshifts[(vblock)     * horiz_tiles + hblock    ][c][dir],
+                          blockshifts[(vblock)     * horiz_tiles + hblock + 1][c][dir],
+                          blockshifts[(vblock + 1) * horiz_tiles + hblock - 1][c][dir],
+                          blockshifts[(vblock + 1) * horiz_tiles + hblock    ][c][dir],
+                          blockshifts[(vblock + 1) * horiz_tiles + hblock + 1][c][dir] };
                   bstemp[dir] = median9f(p);
                 }
-
-                // now prepare coefficient matrix; use only data points within caautostrength/2 std devs of
-                // zero
-                if(sqrf(bstemp[0]) > caautostrength * blockvar[0][c]
-                   || sqrf(bstemp[1]) > caautostrength * blockvar[1][c])
-                {
+                  // now prepare coefficient matrix; use only data points within caautostrength/2 std devs of zero
+                if(sqrf(bstemp[0]) > caautostrength * blockvar[0][c] || sqrf(bstemp[1]) > caautostrength * blockvar[1][c])
                   continue;
-                }
 
                 numblox[c]++;
-
                 double powVblockInit = 1.0;
                 for(int i = 0; i < polyord; i++)
                 {
@@ -873,7 +820,6 @@ void process(
           }
 
           numblox[1] = MIN(numblox[0], numblox[1]);
-
           // if too few data points, restrict the order of the fit to linear
           if(numblox[1] < 32)
           {
@@ -896,319 +842,289 @@ void process(
                 if(!_LinEqSolve(numpar, polymat[c][dir], shiftmat[c][dir], fitparams[c][dir]))
                 {
                   dt_print(DT_DEBUG_PIPE,
-                           "[cacorrect] can't solve linear equations for colour %d direction %d", c, dir);
+                         "[cacorrect] can't solve linear equations for colour %d direction %d", c, dir);
                   processpasstwo = FALSE;
                 }
               }
           }
         }
-
         // fitparams[polyord*i+j] gives the coefficients of (vblock^i hblock^j) in a polynomial fit for i,j<=4
       }
       // end of initialization for CA correction pass
       // only executed if cared and cablue are zero
-    }
 
-    // Main algorithm: Tile loop
-    if(processpasstwo)
-    {
+      // Main algorithm: Tile loop
+      if(processpasstwo)
+      {
 #ifdef _OPENMP
 #pragma omp for schedule(static) collapse(2) nowait
 #endif
-
-      for(int top = -border; top < height; top += ts - border2)
-      {
-        for(int left = -border; left < width; left += ts - border2)
+        for(int top = -border; top < height; top += ts - border2)
         {
-          memset(data, 0, buffersize * sizeof(float));
-          float lblockshifts[2][2];
-          const int vblock = ((top + border) / (ts - border2)) + 1;
-          const int hblock = ((left + border) / (ts - border2)) + 1;
-          const int bottom = MIN(top + ts, height + border);
-          const int right = MIN(left + ts, width + border);
-          const int rr1 = bottom - top;
-          const int cc1 = right - left;
-
-          const int rrmin = top < 0 ? border : 0;
-          const int rrmax = bottom > height ? height - top : rr1;
-          const int ccmin = left < 0 ? border : 0;
-          const int ccmax = right > width ? width - left : cc1;
-
-          // rgb from input CFA data
-          // rgb values should be floating point number between 0 and 1
-          // after white balance multipliers are applied
-
-          for(size_t rr = rrmin; rr < rrmax; rr++)
+          for(int left = -border; left < width; left += ts - border2)
           {
-            size_t row = rr + top;
-            size_t c = FC(rr, ccmin, filters);
-            const size_t c_diff = c ^ FC(rr, ccmin+1, filters);
-            for(size_t cc = ccmin; cc < ccmax; cc++)
+            memset(data, 0, buffersize * sizeof(float));
+            float lblockshifts[2][2];
+            const int vblock = ((top + border) / (ts - border2)) + 1;
+            const int hblock = ((left + border) / (ts - border2)) + 1;
+            const int bottom = MIN(top + ts, height + border);
+            const int right = MIN(left + ts, width + border);
+            const int rr1 = bottom - top;
+            const int cc1 = right - left;
+
+            const int rrmin = top < 0 ? border : 0;
+            const int rrmax = bottom > height ? height - top : rr1;
+            const int ccmin = left < 0 ? border : 0;
+            const int ccmax = right > width ? width - left : cc1;
+
+            // rgb from input CFA data
+            // rgb values should be floating point number between 0 and 1
+            // after white balance multipliers are applied
+
+            for(int rr = rrmin; rr < rrmax; rr++)
             {
-              const size_t col = cc + left;
-              const size_t indx = row * width + col;
-              const size_t indx1 = rr * ts + cc;
-              rgb[c][indx1] = in[indx];
-
-              if((c & 1) == 0)
-              {
-                rgb[1][indx1] = Gtmp[indx];
-              }
-              c ^= c_diff;
-            }
-          }
-
-          // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-          // fill borders
-          if(rrmin > 0)
-          {
-            for(int rr = 0; rr < border; rr++)
+              int row = rr + top;
+              int c = FC(rr, ccmin, filters);
+              const int c_diff = c ^ FC(rr, ccmin+1, filters);
               for(int cc = ccmin; cc < ccmax; cc++)
               {
-                const int c = FC(rr, cc, filters);
-                rgb[c][rr * ts + cc] = rgb[c][(border2 - rr) * ts + cc];
-                rgb[1][rr * ts + cc] = rgb[1][(border2 - rr) * ts + cc];
-              }
-          }
+                const int col = cc + left;
+                const size_t indx = (size_t)row * width + col;
+                const size_t indx1 = (size_t)rr * ts + cc;
+                rgb[c][indx1] = in[indx];
 
-          if(rrmax < rr1)
-          {
-            for(int rr = 0; rr < MIN(border, rr1 - rrmax); rr++)
-              for(int cc = ccmin; cc < ccmax; cc++)
-              {
-                const int c = FC(rr, cc, filters);
-                rgb[c][(rrmax + rr) * ts + cc] = in[(height - rr - 2) * width + left + cc];
-                rgb[1][(rrmax + rr) * ts + cc] = Gtmp[(height - rr - 2) * width + left + cc];
+                if((c & 1) == 0)
+                  rgb[1][indx1] = Gtmp[indx];
+                c ^= c_diff;
               }
-          }
-
-          if(ccmin > 0)
-          {
-            for(int rr = rrmin; rr < rrmax; rr++)
-              for(int cc = 0; cc < border; cc++)
-              {
-                const int c = FC(rr, cc, filters);
-                rgb[c][rr * ts + cc] = rgb[c][rr * ts + border2 - cc];
-                rgb[1][rr * ts + cc] = rgb[1][rr * ts + border2 - cc];
-              }
-          }
-
-          if(ccmax < cc1)
-          {
-            for(int rr = rrmin; rr < rrmax; rr++)
-              for(int cc = 0; cc < MIN(border, cc1 - ccmax); cc++)
-              {
-                const int c = FC(rr, cc, filters);
-                rgb[c][rr * ts + ccmax + cc] = in[(top + rr) * width + (width - cc - 2)];
-                rgb[1][rr * ts + ccmax + cc] = Gtmp[(top + rr) * width + (width - cc - 2)];
-              }
-          }
-
-          // also, fill the image corners
-          if(rrmin > 0 && ccmin > 0)
-          {
-            for(int rr = 0; rr < border; rr++)
-              for(int cc = 0; cc < border; cc++)
-              {
-                const int c = FC(rr, cc, filters);
-                rgb[c][(rr)*ts + cc] = in[(border2 - rr) * width + border2 - cc];
-                rgb[1][(rr)*ts + cc] = Gtmp[(border2 - rr) * width + border2 - cc];
-              }
-          }
-
-          if(rrmax < rr1 && ccmax < cc1)
-          {
-            for(int rr = 0; rr < MIN(border, rr1 - rrmax); rr++)
-              for(int cc = 0; cc < MIN(border, cc1 - ccmax); cc++)
-              {
-                const int c = FC(rr, cc, filters);
-                rgb[c][(rrmax + rr) * ts + ccmax + cc] = in[(height - rr - 2) * width + (width - cc - 2)];
-                rgb[1][(rrmax + rr) * ts + ccmax + cc] = Gtmp[(height - rr - 2) * width + (width - cc - 2)];
-              }
-          }
-
-          if(rrmin > 0 && ccmax < cc1)
-          {
-            for(int rr = 0; rr < border; rr++)
-              for(int cc = 0; cc < MIN(border, cc1 - ccmax); cc++)
-              {
-                const int c = FC(rr, cc, filters);
-                rgb[c][(rr)*ts + ccmax + cc] = in[(border2 - rr) * width + (width - cc - 2)];
-                rgb[1][(rr)*ts + ccmax + cc] = Gtmp[(border2 - rr) * width + (width - cc - 2)];
-              }
-          }
-
-          if(rrmax < rr1 && ccmin > 0)
-          {
-            for(int rr = 0; rr < MIN(border, rr1 - rrmax); rr++)
-              for(int cc = 0; cc < border; cc++)
-              {
-                const int c = FC(rr, cc, filters);
-                rgb[c][(rrmax + rr) * ts + cc] = in[(height - rr - 2) * width + (border2 - cc)];
-                rgb[1][(rrmax + rr) * ts + cc] = Gtmp[(height - rr - 2) * width + (border2 - cc)];
-              }
-          }
-
-          // end of border fill
-          {
-            // CA auto correction; use CA diagnostic pass to set shift parameters
-            lblockshifts[0][0] = lblockshifts[0][1] = 0;
-            lblockshifts[1][0] = lblockshifts[1][1] = 0;
-            float powVblock = 1.0f;
-            for(int i = 0; i < polyord; i++)
-            {
-              float powHblock = powVblock;
-              for(int j = 0; j < polyord; j++)
-              {
-                // printf("i= %d j= %d polycoeff= %f \n",i,j,fitparams[0][0][polyord*i+j]);
-                lblockshifts[0][0] += powHblock * fitparams[0][0][polyord * i + j];
-                lblockshifts[0][1] += powHblock * fitparams[0][1][polyord * i + j];
-                lblockshifts[1][0] += powHblock * fitparams[1][0][polyord * i + j];
-                lblockshifts[1][1] += powHblock * fitparams[1][1][polyord * i + j];
-                powHblock *= hblock;
-              }
-              powVblock *= vblock;
             }
-            const float bslim = 3.99f; // max allowed CA shift
-            lblockshifts[0][0] = CLAMPF(lblockshifts[0][0], -bslim, bslim);
-            lblockshifts[0][1] = CLAMPF(lblockshifts[0][1], -bslim, bslim);
-            lblockshifts[1][0] = CLAMPF(lblockshifts[1][0], -bslim, bslim);
-            lblockshifts[1][1] = CLAMPF(lblockshifts[1][1], -bslim, bslim);
-          } // end of setting CA shift parameters
 
-
-          for(int c = 0; c < 3; c += 2)
-          {
-
-            // some parameters for the bilinear interpolation
-            shiftvfloor[c] = floorf(lblockshifts[c >> 1][0]);
-            shiftvceil[c] = ceilf(lblockshifts[c >> 1][0]);
-            if(lblockshifts[c>>1][0] < 0.f)
+            // fill borders
+            if(rrmin > 0)
             {
-              const int tmp = shiftvfloor[c];
-              shiftvfloor[c] = shiftvceil[c];
-              shiftvceil[c] = tmp;
-            }
-            shiftvfrac[c] = fabsf(lblockshifts[c>>1][0] - shiftvfloor[c]);
-
-            shifthfloor[c] = floorf(lblockshifts[c >> 1][1]);
-            shifthceil[c] = ceilf(lblockshifts[c >> 1][1]);
-            if(lblockshifts[c>>1][1] < 0.f)
-            {
-              const int tmp = shifthfloor[c];
-              shifthfloor[c] = shifthceil[c];
-              shifthceil[c] = tmp;
-            }
-            shifthfrac[c] = fabsf(lblockshifts[c>>1][1] - shifthfloor[c]);
-
-            GRBdir[0][c] = lblockshifts[c >> 1][0] > 0 ? 2 : -2;
-            GRBdir[1][c] = lblockshifts[c >> 1][1] > 0 ? 2 : -2;
-          }
-
-
-          for(int rr = borderh; rr < rr1 - borderh; rr++)
-          {
-            for(int cc = borderh + (FC(rr, 2, filters) & 1), c = FC(rr, cc, filters); cc < cc1 - borderh; cc += 2)
-            {
-              // perform CA correction using colour ratios or colour differences
-              const float Ginthfloor = interpolatef(shifthfrac[c],
-                                                    rgb[1][(rr + shiftvfloor[c]) * ts + cc + shifthceil[c]],
-                                                    rgb[1][(rr + shiftvfloor[c]) * ts + cc + shifthfloor[c]]);
-              const float Ginthceil = interpolatef(shifthfrac[c],
-                                                    rgb[1][(rr + shiftvceil[c]) * ts + cc + shifthceil[c]],
-                                                    rgb[1][(rr + shiftvceil[c]) * ts + cc + shifthfloor[c]]);
-              // Gint is bilinear interpolation of G at CA shift point
-              const float Gint = interpolatef(shiftvfrac[c], Ginthceil, Ginthfloor);
-
-              // determine R/B at grid points using colour differences at shift point plus interpolated G
-              // value at grid point
-              // but first we need to interpolate G-R/G-B to grid points...
-              grbdiff[(rr*ts + cc) >> 1] = Gint - rgb[c][rr*ts + cc];
-              gshift[(rr*ts + cc) >> 1] = Gint;
-            }
-          }
-
-          shifthfrac[0] /= 2.f;
-          shifthfrac[2] /= 2.f;
-          shiftvfrac[0] /= 2.f;
-          shiftvfrac[2] /= 2.f;
-
-          // this loop does not deserve vectorization in mainly because the most expensive part with the
-          // divisions does not happen often (less than 1/10 in my tests)
-          for(int rr = border; rr < rr1 - border; rr++)
-          {
-            for(int cc = border + (FC(rr, 2, filters) & 1), c = FC(rr, cc, filters), indx = rr * ts + cc;
-                cc < cc1 - border; cc += 2, indx += 2)
-            {
-
-              const float grbdiffold = rgb[1][indx] - rgb[c][indx];
-
-              // interpolate colour difference from optical R/B locations to grid locations
-              const float grbdiffinthfloor = interpolatef(shifthfrac[c],
-                                                          grbdiff[(indx - GRBdir[1][c]) >> 1],
-                                                          grbdiff[indx >> 1]);
-              const float grbdiffinthceil  = interpolatef(shifthfrac[c],
-                                                          grbdiff[((rr - GRBdir[0][c]) * ts + cc - GRBdir[1][c]) >> 1],
-                                                          grbdiff[((rr - GRBdir[0][c]) * ts + cc) >> 1]);
-              // grbdiffint is bilinear interpolation of G-R/G-B at grid point
-              float grbdiffint = interpolatef(shiftvfrac[c], grbdiffinthceil, grbdiffinthfloor);
-
-              // now determine R/B at grid points using interpolated colour differences and interpolated G
-              // value at grid point
-              const float RBint = rgb[1][indx] - grbdiffint;
-
-              if(fabsf(RBint - rgb[c][indx]) < 0.25f * (RBint + rgb[c][indx]))
-              {
-                if(fabsf(grbdiffold) > fabsf(grbdiffint))
+              for(int rr = 0; rr < border; rr++)
+                for(int cc = ccmin; cc < ccmax; cc++)
                 {
-                  rgb[c][indx] = RBint;
+                  const int c = FC(rr, cc, filters);
+                  rgb[c][rr * ts + cc] = rgb[c][(border2 - rr) * ts + cc];
+                  rgb[1][rr * ts + cc] = rgb[1][(border2 - rr) * ts + cc];
                 }
-              }
-              else
+            }
+            if(rrmax < rr1)
+            {
+              for(int rr = 0; rr < MIN(border, rr1 - rrmax); rr++)
+                for(int cc = ccmin; cc < ccmax; cc++)
+                {
+                  const int c = FC(rr, cc, filters);
+                  rgb[c][(rrmax + rr) * ts + cc] = in[(height - rr - 2) * width + left + cc];
+                  rgb[1][(rrmax + rr) * ts + cc] = Gtmp[(height - rr - 2) * width + left + cc];
+                }
+            }
+            if(ccmin > 0)
+            {
+              for(int rr = rrmin; rr < rrmax; rr++)
+                for(int cc = 0; cc < border; cc++)
+                {
+                  const int c = FC(rr, cc, filters);
+                  rgb[c][rr * ts + cc] = rgb[c][rr * ts + border2 - cc];
+                  rgb[1][rr * ts + cc] = rgb[1][rr * ts + border2 - cc];
+                }
+            }
+            if(ccmax < cc1)
+            {
+              for(int rr = rrmin; rr < rrmax; rr++)
+                for(int cc = 0; cc < MIN(border, cc1 - ccmax); cc++)
+                {
+                  const int c = FC(rr, cc, filters);
+                  rgb[c][rr * ts + ccmax + cc] = in[(top + rr) * width + (width - cc - 2)];
+                  rgb[1][rr * ts + ccmax + cc] = Gtmp[(top + rr) * width + (width - cc - 2)];
+                }
+            }
+            // also, fill the image corners
+            if(rrmin > 0 && ccmin > 0)
+            {
+              for(int rr = 0; rr < border; rr++)
+                for(int cc = 0; cc < border; cc++)
+                {
+                  const int c = FC(rr, cc, filters);
+                  rgb[c][(rr)*ts + cc] = in[(border2 - rr) * width + border2 - cc];
+                  rgb[1][(rr)*ts + cc] = Gtmp[(border2 - rr) * width + border2 - cc];
+                }
+            }
+            if(rrmax < rr1 && ccmax < cc1)
+            {
+              for(int rr = 0; rr < MIN(border, rr1 - rrmax); rr++)
+                for(int cc = 0; cc < MIN(border, cc1 - ccmax); cc++)
+                {
+                  const int c = FC(rr, cc, filters);
+                  rgb[c][(rrmax + rr) * ts + ccmax + cc] = in[(height - rr - 2) * width + (width - cc - 2)];
+                  rgb[1][(rrmax + rr) * ts + ccmax + cc] = Gtmp[(height - rr - 2) * width + (width - cc - 2)];
+                }
+            }
+            if(rrmin > 0 && ccmax < cc1)
+            {
+              for(int rr = 0; rr < border; rr++)
+                for(int cc = 0; cc < MIN(border, cc1 - ccmax); cc++)
+                {
+                  const int c = FC(rr, cc, filters);
+                  rgb[c][(rr)*ts + ccmax + cc] = in[(border2 - rr) * width + (width - cc - 2)];
+                  rgb[1][(rr)*ts + ccmax + cc] = Gtmp[(border2 - rr) * width + (width - cc - 2)];
+                }
+            }
+           if(rrmax < rr1 && ccmin > 0)
+            {
+              for(int rr = 0; rr < MIN(border, rr1 - rrmax); rr++)
+                for(int cc = 0; cc < border; cc++)
+                {
+                  const int c = FC(rr, cc, filters);
+                  rgb[c][(rrmax + rr) * ts + cc] = in[(height - rr - 2) * width + (border2 - cc)];
+                  rgb[1][(rrmax + rr) * ts + cc] = Gtmp[(height - rr - 2) * width + (border2 - cc)];
+                }
+            }
+            // end of border fill
+            {
+              // CA auto correction; use CA diagnostic pass to set shift parameters
+              lblockshifts[0][0] = lblockshifts[0][1] = 0;
+              lblockshifts[1][0] = lblockshifts[1][1] = 0;
+              float powVblock = 1.0f;
+              for(int i = 0; i < polyord; i++)
               {
+                float powHblock = powVblock;
+                for(int j = 0; j < polyord; j++)
+                {
+                  // printf("i= %d j= %d polycoeff= %f \n",i,j,fitparams[0][0][polyord*i+j]);
+                  lblockshifts[0][0] += powHblock * fitparams[0][0][polyord * i + j];
+                  lblockshifts[0][1] += powHblock * fitparams[0][1][polyord * i + j];
+                  lblockshifts[1][0] += powHblock * fitparams[1][0][polyord * i + j];
+                  lblockshifts[1][1] += powHblock * fitparams[1][1][polyord * i + j];
+                  powHblock *= hblock;
+                }
+                powVblock *= vblock;
+              }
+              const float bslim = 3.99f; // max allowed CA shift
+              lblockshifts[0][0] = CLAMPF(lblockshifts[0][0], -bslim, bslim);
+              lblockshifts[0][1] = CLAMPF(lblockshifts[0][1], -bslim, bslim);
+              lblockshifts[1][0] = CLAMPF(lblockshifts[1][0], -bslim, bslim);
+              lblockshifts[1][1] = CLAMPF(lblockshifts[1][1], -bslim, bslim);
+            } // end of setting CA shift parameters
 
-                // gradient weights using difference from G at CA shift points and G at grid points
-                const float p0 = 1.0f / (eps + fabsf(rgb[1][indx] - gshift[indx >> 1]));
-                const float p1 = 1.0f / (eps + fabsf(rgb[1][indx] - gshift[(indx - GRBdir[1][c]) >> 1]));
-                const float p2 = 1.0f / (eps + fabsf(rgb[1][indx] - gshift[((rr - GRBdir[0][c]) * ts + cc) >> 1]));
-                const float p3 = 1.0f / (eps + fabsf(rgb[1][indx] - gshift[((rr - GRBdir[0][c]) * ts + cc - GRBdir[1][c]) >> 1]));
+            for(int c = 0; c < 3; c += 2)
+            {
+              // some parameters for the bilinear interpolation
+              shiftvfloor[c] = floorf(lblockshifts[c >> 1][0]);
+              shiftvceil[c] = ceilf(lblockshifts[c >> 1][0]);
+              if(lblockshifts[c>>1][0] < 0.f)
+              {
+                const int tmp = shiftvfloor[c];
+                shiftvfloor[c] = shiftvceil[c];
+                shiftvceil[c] = tmp;
+              }
+              shiftvfrac[c] = fabsf(lblockshifts[c>>1][0] - shiftvfloor[c]);
+              shifthfloor[c] = floorf(lblockshifts[c >> 1][1]);
+              shifthceil[c] = ceilf(lblockshifts[c >> 1][1]);
+              if(lblockshifts[c>>1][1] < 0.f)
+              {
+                const int tmp = shifthfloor[c];
+                shifthfloor[c] = shifthceil[c];
+                shifthceil[c] = tmp;
+              }
+              shifthfrac[c] = fabsf(lblockshifts[c>>1][1] - shifthfloor[c]);
 
-                grbdiffint = (  p0 * grbdiff[indx >> 1]
+              GRBdir[0][c] = lblockshifts[c >> 1][0] > 0 ? 2 : -2;
+              GRBdir[1][c] = lblockshifts[c >> 1][1] > 0 ? 2 : -2;
+            }
+
+
+            for(int rr = borderh; rr < rr1 - borderh; rr++)
+            {
+              for(int cc = borderh + (FC(rr, 2, filters) & 1), c = FC(rr, cc, filters); cc < cc1 - borderh; cc += 2)
+              {
+                // perform CA correction using colour ratios or colour differences
+                const float Ginthfloor = interpolatef(shifthfrac[c],
+                                                      rgb[1][(rr + shiftvfloor[c]) * ts + cc + shifthceil[c]],
+                                                      rgb[1][(rr + shiftvfloor[c]) * ts + cc + shifthfloor[c]]);
+                const float Ginthceil = interpolatef(shifthfrac[c],
+                                                      rgb[1][(rr + shiftvceil[c]) * ts + cc + shifthceil[c]],
+                                                      rgb[1][(rr + shiftvceil[c]) * ts + cc + shifthfloor[c]]);
+                // Gint is bilinear interpolation of G at CA shift point
+                const float Gint = interpolatef(shiftvfrac[c], Ginthceil, Ginthfloor);
+
+                // determine R/B at grid points using colour differences at shift point plus interpolated G value at grid point
+                // but first we need to interpolate G-R/G-B to grid points...
+                grbdiff[(rr*ts + cc) >> 1] = Gint - rgb[c][rr*ts + cc];
+                gshift[(rr*ts + cc) >> 1] = Gint;
+              }
+            }
+
+            shifthfrac[0] /= 2.f;
+            shifthfrac[2] /= 2.f;
+            shiftvfrac[0] /= 2.f;
+            shiftvfrac[2] /= 2.f;
+
+            // this loop does not deserve vectorization in mainly because the most expensive part with the
+            // divisions does not happen often (less than 1/10 in my tests)
+            for(int rr = border; rr < rr1 - border; rr++)
+            {
+              for(int cc = border + (FC(rr, 2, filters) & 1), c = FC(rr, cc, filters), indx = rr * ts + cc;
+                      cc < cc1 - border;
+                      cc += 2, indx += 2)
+              {
+                const float grbdiffold = rgb[1][indx] - rgb[c][indx];
+                // interpolate colour difference from optical R/B locations to grid locations
+                const float grbdiffinthfloor = interpolatef(shifthfrac[c],
+                                                            grbdiff[(indx - GRBdir[1][c]) >> 1],
+                                                            grbdiff[indx >> 1]);
+                const float grbdiffinthceil  = interpolatef(shifthfrac[c],
+                                                            grbdiff[((rr - GRBdir[0][c]) * ts + cc - GRBdir[1][c]) >> 1],
+                                                            grbdiff[((rr - GRBdir[0][c]) * ts + cc) >> 1]);
+                // grbdiffint is bilinear interpolation of G-R/G-B at grid point
+                float grbdiffint = interpolatef(shiftvfrac[c], grbdiffinthceil, grbdiffinthfloor);
+
+                // now determine R/B at grid points using interpolated colour differences and interpolated G value at grid point
+                const float RBint = rgb[1][indx] - grbdiffint;
+                if(fabsf(RBint - rgb[c][indx]) < 0.25f * (RBint + rgb[c][indx]))
+                {
+                  if(fabsf(grbdiffold) > fabsf(grbdiffint))
+                    rgb[c][indx] = RBint;
+                }
+                else
+                {
+                  // gradient weights using difference from G at CA shift points and G at grid points
+                  const float p0 = 1.0f / (eps + fabsf(rgb[1][indx] - gshift[indx >> 1]));
+                  const float p1 = 1.0f / (eps + fabsf(rgb[1][indx] - gshift[(indx - GRBdir[1][c]) >> 1]));
+                  const float p2 = 1.0f / (eps + fabsf(rgb[1][indx] - gshift[((rr - GRBdir[0][c]) * ts + cc) >> 1]));
+                  const float p3 = 1.0f / (eps + fabsf(rgb[1][indx] - gshift[((rr - GRBdir[0][c]) * ts + cc - GRBdir[1][c]) >> 1]));
+
+                  grbdiffint = (p0 * grbdiff[indx >> 1]
                               + p1 * grbdiff[(indx - GRBdir[1][c]) >> 1]
                               + p2 * grbdiff[((rr - GRBdir[0][c]) * ts + cc) >> 1]
                               + p3 * grbdiff[((rr - GRBdir[0][c]) * ts + cc - GRBdir[1][c]) >> 1])
                              / (p0 + p1 + p2 + p3);
 
-                // now determine R/B at grid points using interpolated colour differences and interpolated G
-                // value at grid point
-                if(fabsf(grbdiffold) > fabsf(grbdiffint))
-                {
-                  rgb[c][indx] = rgb[1][indx] - grbdiffint;
+                  // now determine R/B at grid points using interpolated colour differences and interpolated G
+                  // value at grid point
+                  if(fabsf(grbdiffold) > fabsf(grbdiffint))
+                    rgb[c][indx] = rgb[1][indx] - grbdiffint;
                 }
-              }
 
-              // if colour difference interpolation overshot the correction, just desaturate
-              if(grbdiffold * grbdiffint < 0)
-              {
-                rgb[c][indx] = rgb[1][indx] - 0.5f * (grbdiffold + grbdiffint);
+                // if colour difference interpolation overshot the correction, just desaturate
+                if(grbdiffold * grbdiffint < 0)
+                  rgb[c][indx] = rgb[1][indx] - 0.5f * (grbdiffold + grbdiffint);
               }
             }
-          }
-          // copy CA corrected results to temporary image matrix
-          for(int rr = border; rr < rr1 - border; rr++)
-          {
-            const int c = FC(rr + top, left + border + (FC(rr + top, 2, filters) & 1), filters);
-
-            for(int row = rr + top, cc = border + (FC(rr, 2, filters) & 1),
-                    indx = (row * width + cc + left) >> 1;
-                cc < cc1 - border; cc += 2, indx++)
+            // copy CA corrected results to temporary image matrix
+            for(int rr = border; rr < rr1 - border; rr++)
             {
-              //               int col = cc + left;
-              RawDataTmp[indx] = rgb[c][(rr)*ts + cc];
+              const int c = FC(rr + top, left + border + (FC(rr + top, 2, filters) & 1), filters);
+              for(int row = rr + top, cc = border + (FC(rr, 2, filters) & 1), indx = (row * width + cc + left) >> 1;
+                    cc < cc1 - border; cc += 2, indx++)
+              {
+                RawDataTmp[indx] = rgb[c][(rr)*ts + cc];
+              }
             }
           }
         }
-      }
+
 #ifdef _OPENMP
 #pragma omp barrier
 #endif
@@ -1216,15 +1132,14 @@ void process(
 #ifdef _OPENMP
 #pragma omp for
 #endif
-      for(int row = 0; row < height; row++)
-        for(int col = 0 + (FC(row, 0, filters) & 1), indx = (row * width + col) >> 1; col < width;
-            col += 2, indx++)
-        {
-          out[row * width + col] = RawDataTmp[indx];
-        }
+        for(int row = 0; row < height; row++)
+          for(int col = 0 + (FC(row, 0, filters) & 1), indx = (row * width + col) >> 1; col < width; col += 2, indx++)
+          {
+            out[row * width + col] = RawDataTmp[indx];
+          }
+      }
+      dt_free_align(data);
     }
-    dt_free_align(data);
-   }
   }
 
   if(avoidshift && processpasstwo)
@@ -1235,15 +1150,15 @@ void process(
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-    for(size_t row = 0; row < height; row++)
+    for(int row = 0; row < height; row++)
     {
-      const size_t firstCol = FC(row, 0, filters) & 1;
+      const int firstCol = FC(row, 0, filters) & 1;
       const int color    = FC(row, firstCol, filters);
       float *nongreen    = (color == 0) ? redfactor : bluefactor;
-      for(size_t col = firstCol; col < width; col += 2)
+      for(int col = firstCol; col < width; col += 2)
       {
-        const size_t index = row * width + col;
-        const size_t oindex = row * h_width + col / 2;
+        const size_t index = (size_t)row * width + col;
+        const size_t oindex = (size_t)row * h_width + col / 2;
         nongreen[(row / 2) * h_width + col / 2] = CLAMPF(oldraw[oindex] / in[index], 0.5f, 2.0f);
       }
     }
@@ -1288,7 +1203,7 @@ void process(
 #endif
       for(size_t row = 2; row < height - 2; row++)
       {
-        const size_t firstCol = FC(row, 0, filters) & 1;
+        const int firstCol = FC(row, 0, filters) & 1;
         const int color = FC(row, firstCol, filters);
         float *nongreen = (color == 0) ? redfactor : bluefactor;
         for(size_t col = firstCol; col < width - 2; col += 2)


### PR DESCRIPTION
As this has been another complete round of source review there was some more formatting for maintenance/readability of this pretty hard-to-read code.

The main problem with current code was use of size_t where not appropriate as we use it with signed int data at some parts. For some reasons this works different on gcc vs clang so it got unnoticed. BTW this problem also affected gcc compiled code, just in a different way. 1) Some tiles had incorrect correction and 2) we read to out-of-bounds (something i did't fully understand and mitigated by reserved some extra memory in the buffers.

@MStraeten @pieterverberne @zisoft can you confirm the fix? Obviously i can't test on OSX, just tried on fedora using clang which was broken as described and now works perfectly. 

Fixes #16362 