### PR TITLE
Remove unused cl kernel parameters in demosaicers

### DIFF
--- a/data/kernels/demosaic_vng.cl
+++ b/data/kernels/demosaic_vng.cl
@@ -151,7 +151,7 @@ vng_lin_interpolate(read_only image2d_t in, write_only image2d_t out, const int 
 
 kernel void
 vng_interpolate(read_only image2d_t in, write_only image2d_t out, const int width, const int height,
-                const int rin_x, const int rin_y, const unsigned int filters, const float4 processed_maximum,
+                const int rin_x, const int rin_y, const unsigned int filters,
                 global const unsigned char (*const xtrans)[6], global const int (*const ips),
                 global const int (*const code)[16], local float *buffer)
 {
@@ -212,12 +212,12 @@ vng_interpolate(read_only image2d_t in, write_only image2d_t out, const int widt
     const int x0 = (short)(offset0 & 0xffffu);
     const int y0 = (short)(offset0 >> 16);
     const int idx0 = 4 * mad24(y0, stride, x0);
-  
+
     const int offset1 = ip[1];
     const int x1 = (short)(offset1 & 0xffffu);
     const int y1 = (short)(offset1 >> 16);
     const int idx1 = 4 * mad24(y1, stride, x1);
-  
+
     const int weight = (short)(ip[2] & 0xffffu);
     const int color = (short)(ip[2] >> 16);
 
@@ -343,7 +343,7 @@ clip_and_zoom_demosaic_third_size_xtrans(read_only image2d_t in, write_only imag
   const int py = clamp((int)round((y - 0.5f) * px_footprint), 0, rin_ht - 3);
 
   const int xmax = min(rin_wd - 3, px + 3 * samples);
-  const int ymax = min(rin_ht - 3, py + 3 * samples);  
+  const int ymax = min(rin_ht - 3, py + 3 * samples);
 
   for(int yy = py; yy <= ymax; yy += 3)
     for(int xx = px; xx <= xmax; xx += 3)

--- a/src/iop/demosaicing/vng.c
+++ b/src/iop/demosaicing/vng.c
@@ -365,10 +365,6 @@ static int process_vng_cl(
   const int pcol = (filters4 == 9u) ? 6 : 2;
   const int devid = piece->pipe->devid;
 
-  const float processed_maximum[4]
-      = { piece->pipe->dsc.processed_maximum[0], piece->pipe->dsc.processed_maximum[1],
-          piece->pipe->dsc.processed_maximum[2], 1.0f };
-
   const int qual_flags = demosaic_qual_flags(piece, img, roi_out);
 
   int *ips = NULL;
@@ -609,7 +605,7 @@ static int process_vng_cl(
       size_t sizes[3] = { ROUNDUP(width, locopt.sizex), ROUNDUP(height, locopt.sizey), 1 };
       size_t local[3] = { locopt.sizex, locopt.sizey, 1 };
       dt_opencl_set_kernel_args(devid, gd->kernel_vng_interpolate, 0, CLARG(dev_tmp), CLARG(dev_aux),
-        CLARG(width), CLARG(height), CLARG(roi_in->x), CLARG(roi_in->y), CLARG(filters4), CLARRAY(4, processed_maximum),
+        CLARG(width), CLARG(height), CLARG(roi_in->x), CLARG(roi_in->y), CLARG(filters4),
         CLARG(dev_xtrans), CLARG(dev_ips), CLARG(dev_code), CLLOCAL(sizeof(float) * 4 * (locopt.sizex + 4) * (locopt.sizey + 4)));
       err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_vng_interpolate, sizes, local);
       if(err != CL_SUCCESS) goto finish;

--- a/src/iop/demosaicing/xtrans.c
+++ b/src/iop/demosaicing/xtrans.c
@@ -1662,10 +1662,6 @@ static int process_markesteijn_cl(
   const int devid = piece->pipe->devid;
   const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
 
-  const float processed_maximum[4]
-      = { piece->pipe->dsc.processed_maximum[0], piece->pipe->dsc.processed_maximum[1],
-          piece->pipe->dsc.processed_maximum[2], 1.0f };
-
   const int qual_flags = demosaic_qual_flags(piece, &self->dev->image_storage, roi_out);
 
   cl_mem dev_tmp = NULL;
@@ -2117,7 +2113,7 @@ static int process_markesteijn_cl(
 
     // process the final image
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_markesteijn_final, width, height,
-        CLARG(dev_tmptmp), CLARG(dev_tmp), CLARG(width), CLARG(height), CLARG(pad_tile), CLARRAY(4, processed_maximum));
+        CLARG(dev_tmptmp), CLARG(dev_tmp), CLARG(width), CLARG(height), CLARG(pad_tile));
     if(err != CL_SUCCESS) goto error;
 
     // now it's time to get rid of most of the temporary buffers (except of dev_tmp and dev_xtrans)


### PR DESCRIPTION
In both - VNG and markesteijn - demosaicers the processed_maximum data are neither used nor required so let's not pass them to the CL kernels.

Spotted in #16383 discussion