### PR TITLE
[GUI] Some fixes in CE tooltips

### DIFF
--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -2518,9 +2518,9 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_widget_set_tooltip_text(g->threshold,
                               _("set saturation threshold for the guided filter.\n"
-                                " - decrease to allow changes in areas with low chromacity\n"
-                                " - increase to restrict changes to higher chromacities.\n"
-                                "   increases contrast and avoids brightness changes in low chromacity areas."));
+                                " - decrease to allow changes in areas with low chromaticity\n"
+                                " - increase to restrict changes to higher chromaticities\n"
+                                "   increases contrast and avoids brightness changes in low chromaticity areas"));
 
   g->contrast = dt_bauhaus_slider_from_params(self, "contrast");
   dt_bauhaus_slider_set_digits(g->contrast, 3);

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -2527,7 +2527,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->contrast,
                               _("set saturation contrast for the guided filter.\n"
                                 " - increase to favour sharp transitions between saturations leading to higher contrast\n"
-                                " - decrease for smoother transitions."));
+                                " - decrease for smoother transitions"));
 
   g->param_size = dt_bauhaus_slider_from_params(self, "param_size");
   dt_bauhaus_slider_set_digits(g->param_size, 1);


### PR DESCRIPTION
The term is spelled `chromaticity`, not `chromacity`. This is obviously a typo and the correction needs no explanation. As for removing one punctuation point in another tooltip, it's worth giving a rationale.

Now, when darktable tooltips have phrases that are formatted as list items (lines with dashes at the beginning), we use one of two styles. In one of them, a punctuation mark (comma) is placed at the end of each line (list element) and the entire text ends with a period. In another style, no punctuation mark is placed at the end of such lines. We can discuss whether to make one style mandatory, but in this case, no style was followed. If we do not put punctuation in one of the list items, then we do not need to put a period in the last item.
