### PR TITLE
Fix empty folders on import

### DIFF
--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -209,9 +209,6 @@ void dt_import_session_set_name(struct dt_import_session_t *self, const char *na
   g_free((void *)self->vp->jobcode);
 
   self->vp->jobcode = g_strdup(name);
-
-  /* setup new filmroll if path has changed */
-  dt_import_session_path(self, FALSE);
 }
 
 


### PR DESCRIPTION
fixes #16411
fixes #15979 

When the users sets a subdirectory naming pattern with variables, a filmroll/path is created. At import session start most of these variables are empty, leading to empty zombie folders.
