### PR TITLE
Fix UI not updating when thumbtable image is rejected

### DIFF
--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -215,8 +215,6 @@ static void _image_get_infos(dt_thumbnail_t *thumb)
 {
   if(!dt_is_valid_imgid(thumb->imgid))
     return;
-  if(thumb->over == DT_THUMBNAIL_OVERLAYS_NONE)
-    return;
 
   // we only get here infos that might change, others(exif, ...) are
   // cached on widget creation


### PR DESCRIPTION
Fixes the following bug:
Steps to reproduce:
    - Enter darkroom view
    - Scale bottom panel UI small enough that rating overlay does not display on
      thumbnail mouseover
    - Hover over an image, and press R.
    - Observe that the image does not appear to be rejected until we
      enter another view where the rating overlay is displayed.

Previously, _image_get_infos short-circuited when a thumbnail did not have an overlay. When using keyboard shortcuts, there are situations where we still need to call _image_get_infos to appropriately update the UI.