### PR TITLE
Fix mask visualizing refreshing

### DIFF
--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -255,6 +255,7 @@ void dt_masks_gui_form_test_create(dt_masks_form_t *form,
   {
     if(gui->pipe_hash != darktable.develop->preview_pipe->backbuf_hash)
     {
+      dt_print(DT_DEBUG_EXPOSE, "[dt_masks_gui_form_test_create] refreshes mask visualizer\n");
       gui->pipe_hash = 0;
       gui->formid = NO_MASKID;
       g_list_free_full(gui->points, dt_masks_form_gui_points_free);
@@ -1255,6 +1256,7 @@ int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module,
   return ret;
 }
 
+// visualize mask from viewport
 void dt_masks_events_post_expose(struct dt_iop_module_t *module,
                                  cairo_t *cr,
                                  const int32_t width,

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2774,7 +2774,7 @@ restart:
 
   // terminate
   dt_pthread_mutex_lock(&pipe->backbuf_mutex);
-  pipe->backbuf_hash = dt_dev_pixelpipe_cache_hash(pipe->image.id, &roi, pipe, 0);
+  pipe->backbuf_hash = dt_dev_pixelpipe_cache_hash(pipe->image.id, &roi, pipe, pos);
 
   //FIXME lock/release cache line instead of copying
   if(pipe->type & DT_DEV_PIXELPIPE_SCREEN)


### PR DESCRIPTION
A summary how mask visualizing works:
1. In view->darkroom we visualize any desired masks via dt_masks_events_post_expose()
2. There dt_masks_gui_form_test_create() possibly updates the form via dt_masks_gui_form_create()
3. To avoid this costly operations in most cases we keep a hash in gui and compare it with a hash generated at pixelpipe run for the backbuf (darktable.develop->preview_pipe->backbuf_hash).
4. Until now the backbuf hash didn't include data from the processed pieces so all above steps didn't work correctly if any module operation changed.
5. So we calculate the backbuf hash including piece data. We could possibly optimize this by a special hash only taking account of relevant data but as the whole thing only happens while visualizing any masks the penalty seems to be neglectable.

Fixes #10151 

In fact it's not only about lens & gradients, all distorting/morphing/rotation modules and all  drawn masks were affected.