### PR TITLE
Fix wildcard search on collections and filters

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1255,7 +1255,7 @@ static gchar **_strsplit_quotes(const gchar *string,
   g_return_val_if_fail(delimiter != NULL, NULL);
   g_return_val_if_fail(delimiter[0] != '\0', NULL);
 
-  if (max_tokens < 1)
+  if(max_tokens < 1)
   {
     max_tokens = G_MAXINT;
     string_list = g_ptr_array_new();
@@ -2604,6 +2604,21 @@ void dt_collection_update_query(const dt_collection_t *collection,
     gchar *text = dt_conf_get_string(confname);
     snprintf(confname, sizeof(confname), "plugins/lighttable/collect/mode%1d", i);
     const int mode = dt_conf_get_int(confname);
+
+    if(*text
+       && g_strcmp0(text, _("unnamed")) != 0
+       && (property == DT_COLLECTION_PROP_CAMERA
+       || property == DT_COLLECTION_PROP_LENS
+       || property == DT_COLLECTION_PROP_WHITEBALANCE
+       || property == DT_COLLECTION_PROP_FLASH
+       || property == DT_COLLECTION_PROP_EXPOSURE_PROGRAM
+       || property == DT_COLLECTION_PROP_METERING_MODE))
+    {
+      gchar *text_quoted = g_strdup_printf("\"%s\"", text);
+      g_free(text);
+      text = g_strdup(text_quoted);
+      g_free(text_quoted);
+    }
 
     _get_query_part(property, text, mode, FALSE, &nb, &query_parts[i]);
 


### PR DESCRIPTION
fixes #16034
fixes #16336 

This PR fixes two issues which have basically the same root cause:

__Collection filters__
When adding an entry for a collection filter from the list (right click) it is added with surrounded double quotes `"` to the filter so it should be handled by the query without wildcards (exact match). However, if the string contains a `,` this breaks the string handling because the string gets split at that comma and is then handled as two separate wildcard based search querys. Example: Camera name is `CASIO COMPUTER CO., LTD. EX-Z40` (with a `,` in the middle).

To prevent this I have implemented the function `_str_split_quotes()` which takes care for strings which are enclosed in double quotes.

__Collections__
If there are camera names where the shorter name is a full submatch of the longer name (like `iPhone 4` and `iPhone 4S`) and the shorter name is selected, the lighttable shows all images from both cameras because a wildcard based search is performed.

This is now fixed by enclosing the collection name in double quotes.

Both topics are valid for
- cameras
- lenses
- white balance
- flash
- exposure program
- metering mode
