### PR TITLE
Lua API - Add duplicate_image_with_history

### DIFF
--- a/src/lua/database.c
+++ b/src/lua/database.c
@@ -42,6 +42,25 @@ int dt_lua_duplicate_image(lua_State *L)
   return 1;
 }
 
+int dt_lua_duplicate_image_with_history(lua_State *L)
+{
+  dt_imgid_t imgid;
+  dt_imgid_t newid;
+  luaA_to(L, dt_lua_image_t, &imgid, -1);
+  newid = dt_image_duplicate(imgid);
+  if(!dt_is_valid_imgid(newid))
+  {
+    luaA_push(L, dt_lua_image_t, &imgid);
+    return 1;
+  }
+  else
+  {
+    dt_history_copy_and_paste_on_image(imgid, newid, FALSE, NULL, TRUE, TRUE);
+    luaA_push(L, dt_lua_image_t, &newid);
+    return 1;
+  }
+}
+
 int dt_lua_delete_image(lua_State *L)
 {
   dt_imgid_t imgid;

--- a/src/lua/database.h
+++ b/src/lua/database.h
@@ -22,6 +22,7 @@
 
 
 int dt_lua_duplicate_image(lua_State *L);
+int dt_lua_duplicate_image_with_history(lua_State *L);
 int dt_lua_delete_image(lua_State *L);
 int dt_lua_move_image(lua_State *L);
 int dt_lua_copy_image(lua_State *L);

--- a/src/lua/image.c
+++ b/src/lua/image.c
@@ -615,6 +615,9 @@ int dt_lua_init_image(lua_State *L)
   lua_pushcfunction(L, dt_lua_duplicate_image);
   lua_pushcclosure(L, dt_lua_type_member_common, 1);
   dt_lua_type_register_const(L, dt_lua_image_t, "duplicate");
+  lua_pushcfunction(L, dt_lua_duplicate_image_with_history);
+  lua_pushcclosure(L, dt_lua_type_member_common, 1);
+  dt_lua_type_register_const(L, dt_lua_image_t, "duplicate_with_history");
   lua_pushcfunction(L, dt_lua_delete_image);
   lua_pushcclosure(L, dt_lua_type_member_common, 1);
   dt_lua_type_register_const(L, dt_lua_image_t, "delete");


### PR DESCRIPTION
The Lua API already includes a function to duplicate an image, but the duplicated image is a copy of the original without any processing applied.

This PR adds a duplicate_image_with_history function to provide a duplicate of the processed image.

Use case: I wanted to duplicate 1 or more processed images, then apply a square crop to them before posting to instagram.  I wanted to do it with a Lua script because it would be way faster and save lots of mouse clicks.  