### PR TITLE
Refactor raw image buff size

### DIFF
--- a/src/common/image.h
+++ b/src/common/image.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2023 darktable developers.
+    Copyright (C) 2009-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -485,6 +485,17 @@ gboolean dt_image_set_history_end(const dt_imgid_t imgid,
                                   const int history_end);
 /** get the ratio of cropped raw sensor data */
 float dt_image_get_sensor_ratio(const dt_image_t *img);
+
+/** get dimensions of image after cropping in rawprepare */
+static inline int dt_image_raw_width(const dt_image_t *img)
+{
+  return img->width - img->crop_x - img->crop_right;
+}
+static inline int dt_image_raw_height(const dt_image_t *img)
+{
+  return img->height - img->crop_y - img->crop_bottom;
+}
+
 /** returns the orientation bits of the image from exif. */
 static inline dt_image_orientation_t dt_image_orientation(const dt_image_t *img)
 {

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -611,8 +611,8 @@ static void dt_masks_legacy_params_v2_to_v3_transform(const dt_image_t *img,
 
   const float cx = (float)img->crop_x, cy = (float)img->crop_y;
 
-  const float cw = (float)(img->width - img->crop_x - img->crop_right);
-  const float ch = (float)(img->height - img->crop_y - img->crop_bottom);
+  const float cw = dt_image_raw_width(img);
+  const float ch = dt_image_raw_height(img);
 
   /*
    * masks coordinates are normalized, so we need to:
@@ -631,8 +631,8 @@ static void dt_masks_legacy_params_v2_to_v3_transform_only_rescale
 {
   const float w = (float)img->width, h = (float)img->height;
 
-  const float cw = (float)(img->width - img->crop_x - img->crop_right);
-  const float ch = (float)(img->height - img->crop_y - img->crop_bottom);
+  const float cw = dt_image_raw_width(img);
+  const float ch = dt_image_raw_height(img);
 
   /*
    * masks coordinates are normalized, so we need to:

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1379,8 +1379,8 @@ dt_imageio_retval_t dt_imageio_open(dt_image_t *img,
   if((ret == DT_IMAGEIO_OK) && (was_bw != dt_image_monochrome_flags(img)))
     dt_imageio_update_monochrome_workflow_tag(img->id, dt_image_monochrome_flags(img));
 
-  img->p_width = img->width - img->crop_x - img->crop_right;
-  img->p_height = img->height - img->crop_y - img->crop_bottom;
+  img->p_width = dt_image_raw_width(img);
+  img->p_height = dt_image_raw_height(img);
 
   return ret;
 }

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1016,10 +1016,8 @@ static float _get_autoscale_lf(dt_iop_module_t *self,
     if(lenslist)
     {
       const dt_image_t *img = &(self->dev->image_storage);
-
-      // FIXME: get those from rawprepare IOP somehow !!!
-      const int iwd = img->width - img->crop_x - img->crop_right,
-                iht = img->height - img->crop_y - img->crop_bottom;
+      const int iwd = dt_image_raw_width(img);
+      const int iht = dt_image_raw_height(img);
 
       // create dummy modifier
       const dt_iop_lens_data_t d =
@@ -2528,10 +2526,8 @@ static int _init_coeffs_md_v2(const dt_image_t *img,
   // TODO(sgotti) Theoretically, since the distortion function should always be
   // monotonic and the center is always the center of the image, we should only
   // look at the the shorter image radius and 1 ignoring intermediate values
-
-  // FIXME: get those from rawprepare IOP somehow !!!
-  const float iwd2 = 0.5f *(img->width - img->crop_x - img->crop_right),
-              iht2 = 0.5f *(img->height - img->crop_y - img->crop_bottom);
+  const float iwd2 = 0.5f * dt_image_raw_width(img);
+  const float iht2 = 0.5f * dt_image_raw_height(img);
 
   const float r = sqrtf(iwd2 * iwd2 + iht2 * iht2);
   const float sr = fminf(iwd2, iht2);


### PR DESCRIPTION
We need image dimensions corrected in rawprepare at several places, this commit adds two inline functions
`  int dt_image_raw_width(const dt_image_t *img)`
`  int dt_image_raw_height(const dt_image_t *img)`
to image.h and make dt use them where possible.