### PR TITLE
Fix string comparison for unknown lenses

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1611,11 +1611,10 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
         img->exif_lens[i] = g_ascii_tolower(img->exif_lens[i]);
     }
 
-    // finally the lens has only numbers and parentheses, let's try to use
-    // Exif.Photo.LensModel if defined.
-
+    // finally we check if an "Unknwon Lens (xxx)" was returned by using
+    // a regular expression search.
     std::string lens(img->exif_lens);
-    if(std::string::npos == lens.find_first_not_of(" (1234567890)")
+    if(std::regex_search(lens, std::regex("\\(\\d+\\)$"))
        && FIND_EXIF_TAG("Exif.Photo.LensModel"))
     {
       _strlcpy_to_utf8(img->exif_lens, sizeof(img->exif_lens), pos, exifData);


### PR DESCRIPTION
For lens detection we use the tag `Exif.Photo.LensModel` as the last attempt. For this we check if the lens name only contains parantheses and digits but this always fails because Exiv2 returns not only `(xxx)` but `Unknown Lens (xxx)`.

This is now improved by using a regex search to check if the string ends with `(xxx)`.

fixes #14882