### PR TITLE
fix import from camera not working

### DIFF
--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -177,11 +177,6 @@ void dt_import_session_destroy(struct dt_import_session_t *self)
   g_free(self);
 }
 
-gboolean dt_import_session_ready(struct dt_import_session_t *self)
-{
-  return (self->film && self->film->id);
-}
-
 void dt_import_session_ref(struct dt_import_session_t *self)
 {
   self->ref++;

--- a/src/common/import_session.h
+++ b/src/common/import_session.h
@@ -23,9 +23,6 @@ struct dt_import_session_t;
 struct dt_import_session_t *dt_import_session_new();
 void dt_import_session_destroy(struct dt_import_session_t *self);
 
-/** \brief Verify that we use current film and import images into it */
-gboolean dt_import_session_ready(struct dt_import_session_t *self);
-
 /** \brief add reference to specified import session */
 void dt_import_session_ref(struct dt_import_session_t *self);
 /** \brief remove reference to specified import session */

--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -330,12 +330,6 @@ static int32_t dt_camera_import_job_run(dt_job_t *job)
   dt_camera_import_t *params = dt_control_job_get_params(job);
   dt_control_log(_("starting to import images from camera"));
 
-  if(!dt_import_session_ready(params->shared.session))
-  {
-    dt_control_log(_("failed to import images from camera."));
-    return 1;
-  }
-
   guint total = g_list_length(params->images);
   char message[512] = { 0 };
   snprintf(message, sizeof(message),


### PR DESCRIPTION
Similar to #16484 it does not make sense to create a filmroll/path at import session start because each imported image can be stored in a different folder according to the import subdirectory naming pattern.

The filmroll/path is created by the listener for each image.

fixes #16552