### PR TITLE
[CI/nightly]: bump xcode for macos-14 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,7 +335,7 @@ jobs:
       matrix:
         build:
           - { os: macos-13,    xcode: 15.2,   deployment: 13.5 } # LLVM16, x86_64
-          - { os: macos-14,    xcode: 15.2,   deployment: 14.0 } # LLVM16, arm64
+          - { os: macos-14,    xcode: 15.3,   deployment: 14.0 } # LLVM16, arm64
         compiler:
           - { compiler: XCode,   CC: cc, CXX: c++ }
         btype: [ Release ]

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -288,7 +288,7 @@ jobs:
       matrix:
         build:
           - { os: macos-13, xcode: 15.2, deployment: 13.5 } # LLVM16, x86_64
-          - { os: macos-14, xcode: 15.2, deployment: 14.0 } # LLVM16, arm64
+          - { os: macos-14, xcode: 15.3, deployment: 14.0 } # LLVM16, arm64
         compiler:
           - { compiler: XCode,   CC: cc, CXX: c++ }
         btype: [ Release ]


### PR DESCRIPTION
Github runner `macos-14` now contains Xcode 15.3