### PR TITLE
[GUI] Fix the poorly worded tooltip for the mask display toggle

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1311,7 +1311,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_widget_set_quad_toggle(g->dual_thrs, TRUE);
   dt_bauhaus_widget_set_quad_active(g->dual_thrs, FALSE);
   g_signal_connect(G_OBJECT(g->dual_thrs), "quad-pressed", G_CALLBACK(_visualize_callback), self);
-  dt_bauhaus_widget_set_quad_tooltip(g->dual_thrs, _("toggle to visualize the mask"));
+  dt_bauhaus_widget_set_quad_tooltip(g->dual_thrs, _("toggle mask visualization"));
 
   g->lmmse_refine = dt_bauhaus_combobox_from_params(self, "lmmse_refine");
   gtk_widget_set_tooltip_text(g->lmmse_refine, _("LMMSE refinement steps. the median steps average the output,\nrefine adds some recalculation of red & blue channels"));


### PR DESCRIPTION
It is incorrect to describe the toggle button with the phrase "toggle to visualize the mask".

This wording states that the toggle only visualizes the mask. But this is not so, because the toggle turns the feature on and off with successive clicks/presses.