### PR TITLE
Color picker cst fix

### DIFF
--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -35,7 +35,8 @@ static inline size_t _box_size(const int *const box)
 static inline void _update_stats_by_ch(dt_aligned_pixel_t acc,
                                        dt_aligned_pixel_t low,
                                        dt_aligned_pixel_t high,
-                                       const int ch, const float pick)
+                                       const int ch,
+                                       const float pick)
 {
   acc[ch] += pick;
   low[ch] = MIN(low[ch], pick);
@@ -55,7 +56,8 @@ static inline void _update_stats_4ch(dt_aligned_pixel_t acc,
 #ifdef _OPENMP
 #pragma omp declare simd aligned(rgb, JzCzhz: 16) uniform(profile)
 #endif
-static inline void rgb_to_JzCzhz(const dt_aligned_pixel_t rgb, dt_aligned_pixel_t JzCzhz,
+static inline void rgb_to_JzCzhz(const dt_aligned_pixel_t rgb,
+                                 dt_aligned_pixel_t JzCzhz,
                                  const dt_iop_order_iccprofile_info_t *const profile)
 {
   dt_aligned_pixel_t XYZ_D65 = { 0.0f, 0.0f, 0.0f };
@@ -81,7 +83,8 @@ static inline void rgb_to_JzCzhz(const dt_aligned_pixel_t rgb, dt_aligned_pixel_
 typedef void((*picker_worker_4ch)(dt_aligned_pixel_t acc,
                                   dt_aligned_pixel_t low,
                                   dt_aligned_pixel_t high,
-                                  const float *const pixels, const size_t width,
+                                  const float *const pixels,
+                                  const size_t width,
                                   const void *const data));
 typedef void((*picker_worker_1ch)(dt_aligned_pixel_t acc,
                                   dt_aligned_pixel_t low,
@@ -96,7 +99,8 @@ typedef void((*picker_worker_1ch)(dt_aligned_pixel_t acc,
 static inline void _color_picker_rgb_or_lab(dt_aligned_pixel_t acc,
                                             dt_aligned_pixel_t low,
                                             dt_aligned_pixel_t high,
-                                            const float *const pixels, const size_t width,
+                                            const float *const pixels,
+                                            const size_t width,
                                             const void *const data)
 {
   for(size_t i = 0; i < width; i += 4)
@@ -107,7 +111,8 @@ static inline void _color_picker_rgb_or_lab(dt_aligned_pixel_t acc,
 static inline void _color_picker_lch(dt_aligned_pixel_t acc,
                                      dt_aligned_pixel_t low,
                                      dt_aligned_pixel_t high,
-                                     const float *const pixels, const size_t width,
+                                     const float *const pixels,
+                                     const size_t width,
                                      const void *const data)
 {
   for(size_t i = 0; i < width; i += 4)
@@ -124,7 +129,8 @@ static inline void _color_picker_lch(dt_aligned_pixel_t acc,
 static inline void _color_picker_hsl(dt_aligned_pixel_t acc,
                                      dt_aligned_pixel_t low,
                                      dt_aligned_pixel_t high,
-                                     const float *const pixels, const size_t width,
+                                     const float *const pixels,
+                                     const size_t width,
                                      const void *const data)
 {
   for(size_t i = 0; i < width; i += 4)
@@ -141,7 +147,8 @@ static inline void _color_picker_hsl(dt_aligned_pixel_t acc,
 static inline void _color_picker_jzczhz(dt_aligned_pixel_t acc,
                                         dt_aligned_pixel_t low,
                                         dt_aligned_pixel_t high,
-                                        const float *const pixels, const size_t width,
+                                        const float *const pixels,
+                                        const size_t width,
                                         const void *const data)
 {
   const dt_iop_order_iccprofile_info_t *const profile = data;
@@ -195,7 +202,8 @@ static inline void _color_picker_xtrans(dt_aligned_pixel_t acc,
 }
 
 static void _color_picker_work_4ch(const float *const pixel,
-                                   const dt_iop_roi_t *const roi, const int *const box,
+                                   const dt_iop_roi_t *const roi,
+                                   const int *const box,
                                    lib_colorpicker_stats pick,
                                    const void *const data,
                                    const picker_worker_4ch worker,
@@ -236,7 +244,8 @@ static void _color_picker_work_4ch(const float *const pixel,
 }
 
 static void _color_picker_work_1ch(const float *const pixel,
-                                   const dt_iop_roi_t *const roi, const int *const box,
+                                   const dt_iop_roi_t *const roi,
+                                   const int *const box,
                                    lib_colorpicker_stats pick,
                                    const void *const data,
                                    const picker_worker_1ch worker,

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -323,8 +323,7 @@ enum _channel_indexes
 
 static void _blendop_blendif_update_tab(dt_iop_module_t *module, const int tab);
 
-static inline dt_iop_colorspace_type_t
-_blendif_colorpicker_cst(dt_iop_gui_blend_data_t *data)
+static inline dt_iop_colorspace_type_t _blendif_colorpicker_cst(dt_iop_gui_blend_data_t *data)
 {
   dt_iop_colorspace_type_t cst = dt_iop_color_picker_get_active_cst(data->module);
   if(cst == IOP_CS_NONE)
@@ -433,7 +432,8 @@ static void _blendif_scale(dt_iop_gui_blend_data_t *data,
 }
 
 static void _blendif_cook(const dt_iop_colorspace_type_t cst,
-                          const float *in, float *out,
+                          const float *in,
+                          float *out,
                           const dt_iop_order_iccprofile_info_t *const work_profile)
 {
   out[0] = out[1] = out[2] = out[3] = out[4] = out[5] = out[6] = out[7] = -1.0f;
@@ -500,7 +500,8 @@ static inline int _blendif_print_digits_ab(float value)
 
 static void _blendif_scale_print_ab(const float value,
                                     const float boost_factor,
-                                    char *string, int n)
+                                    char *string,
+                                    int n)
 {
   const float scaled = (value * 256.0f - 128.0f) * boost_factor;
   snprintf(string, n, "%-5.*f", _blendif_print_digits_ab(scaled), scaled);
@@ -1049,8 +1050,7 @@ static void _blendop_blendif_disp_alternative_reset(GtkWidget *widget,
 }
 
 
-static dt_iop_colorspace_type_t
-_blendop_blendif_get_picker_colorspace(dt_iop_gui_blend_data_t *bd)
+static dt_iop_colorspace_type_t _blendop_blendif_get_picker_colorspace(dt_iop_gui_blend_data_t *bd)
 {
   dt_iop_colorspace_type_t picker_cst = IOP_CS_NONE;
 
@@ -1266,7 +1266,7 @@ static void _blendop_blendif_tab_switch(GtkNotebook *notebook,
      || !data->blendif_inited)
     return;
 
-  const int cst_old = _blendop_blendif_get_picker_colorspace(data);
+  const dt_iop_colorspace_type_t cst_old = _blendop_blendif_get_picker_colorspace(data);
   dt_iop_color_picker_reset(data->module, FALSE);
 
   data->tab = page_num;
@@ -1945,7 +1945,7 @@ static gboolean _blendif_change_blend_colorspace(dt_iop_module_t *module,
     }
 
     dt_iop_gui_blend_data_t *bd = module->blend_data;
-    const int cst_old = _blendop_blendif_get_picker_colorspace(bd);
+    const dt_iop_colorspace_type_t cst_old = _blendop_blendif_get_picker_colorspace(bd);
     dt_dev_add_new_history_item(darktable.develop, module, FALSE);
     dt_iop_gui_update(module);
 

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -171,6 +171,7 @@ static void _init_picker(dt_iop_color_picker_t *picker,
                               : IOP_CS_NONE;
   picker->colorpick  = button;
   picker->changed    = FALSE;
+  picker->fixed_cst  = FALSE;
 
   // default values
   picker->pick_box[0] = picker->pick_box[1] = 0.0f;
@@ -303,7 +304,7 @@ void dt_iop_color_picker_set_cst(dt_iop_module_t *module,
   dt_iop_color_picker_t *const picker = darktable.lib->proxy.colorpicker.picker_proxy;
   // this is a bit hacky, because the code was built for when a module
   // "owned" an active pcicker
-  if(picker && picker->module == module && picker->picker_cst != picker_cst)
+  if(picker && picker->module == module && picker->picker_cst != picker_cst && !picker->fixed_cst)
   {
     picker->picker_cst = picker_cst;
     // force applying next picker data
@@ -430,7 +431,10 @@ static GtkWidget *_color_picker_new(dt_iop_module_t *module,
     dt_gui_add_class(button, "dt_transparent_background");
     _init_picker(color_picker, module, flags, button);
     if(init_cst)
+    {
       color_picker->picker_cst = cst;
+      color_picker->fixed_cst = TRUE;
+    }
     g_signal_connect_data(G_OBJECT(button), "button-press-event",
                           G_CALLBACK(_color_picker_callback_button_press),
                           color_picker, (GClosureNotify)g_free, 0);
@@ -445,7 +449,10 @@ static GtkWidget *_color_picker_new(dt_iop_module_t *module,
     dt_bauhaus_widget_set_quad_tooltip(w, _("pick color from image"));
     _init_picker(color_picker, module, flags, w);
     if(init_cst)
+    {
       color_picker->picker_cst = cst;
+      color_picker->fixed_cst = TRUE;
+    }
     g_signal_connect_data(G_OBJECT(w), "quad-pressed",
                           G_CALLBACK(_color_picker_callback),
                           color_picker, (GClosureNotify)g_free, 0);

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -53,6 +53,10 @@ typedef struct dt_iop_color_picker_t
    * IOP_CS_HSL: for RGB modules
    */
   dt_iop_colorspace_type_t picker_cst;
+  /* if we define via dt_color_picker_new_with_cst() we don't want the picker callbacks
+     to modify it's picker_cst
+  */
+  gboolean fixed_cst;
   /** used to avoid recursion when a parameter is modified in the apply() */
   GtkWidget *colorpick;
   // positions are associated with the current picker widget: will set

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -2062,12 +2062,6 @@ static void _picker_callback(GtkWidget *quad, gpointer user_data)
 
   g->picking = dt_bauhaus_widget_get_quad_active(quad);
 
-  /* FIXME: For some (not understood) reason after applying a preset the picker cst will be RGB.
-     This is ceratinly a hack
-  */
-  if(g->picking)
-    dt_iop_color_picker_set_cst(self, IOP_CS_HSL);
-
   gtk_widget_queue_draw(GTK_WIDGET(g->area));
 }
 


### PR DESCRIPTION
Make sure the picker_cst is not changed at runtime via dt_iop_color_picker_set_cst() by adding a gboolean `fixed_cst` to the picker struct as we can't know otherwise if a picker was initialized as above. (This happened in the callbacks)

Removed the "fixing hack" in color equalizer module

Some formatting and minor code maintenance otherwise.