### PR TITLE
[pwstorage] implement windows credentials backend

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2855,11 +2855,12 @@
         <option capability="libsecret">libsecret</option>
         <option capability="kwallet">kwallet</option>
         <option capability="apple_keychain">apple_keychain</option>
+        <option capability="windows_credentials">windows_credentials</option>
       </enum>
     </type>
     <default>auto</default>
     <shortdescription>password storage backend to use</shortdescription>
-    <longdescription>the storage backend for password storage: auto, none, libsecret, kwallet, apple_keychain</longdescription>
+    <longdescription>the storage backend for password storage: auto, none, libsecret, kwallet, apple_keychain, windows_credentials</longdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/export/icctype</name>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -198,6 +198,9 @@ if(WIN32)
   list(APPEND SOURCE_FILES "win/scandir.c")
   list(APPEND HEADER_FILES "win/scandir.h")
 
+  list(APPEND SOURCE_FILES "common/pwstorage/backend_windows_credentials.c")
+  list(APPEND HEADER_FILES "common/pwstorage/backend_windows_credentials.h")
+
   # Use mingw's sprintf instead of windows's
   ADD_DEFINITIONS( -D__USE_MINGW_ANSI_STDIO=1 )
 
@@ -522,6 +525,10 @@ endif(USE_KWALLET)
 if(APPLE)
   add_definitions("-DHAVE_APPLE_KEYCHAIN")
 endif(APPLE)
+
+if(WIN32)
+  add_definitions("-DHAVE_WINDOWS_CREDENTIALS")
+endif(WIN32)
 
 if(USE_MAC_INTEGRATION)
   find_package(MacIntegration)

--- a/src/common/pwstorage/backend_windows_credentials.c
+++ b/src/common/pwstorage/backend_windows_credentials.c
@@ -1,0 +1,157 @@
+// This file is part of darktable
+// Copyright (C) 2024 darktable developers.
+
+// darktable is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// darktable is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "backend_windows_credentials.h"
+#include "common/darktable.h"
+
+#include <json-glib/json-glib.h>
+
+#include <wincred.h>
+
+const backend_windows_credentials_context_t *dt_pwstorage_windows_credentials_new()
+{
+  // no context needed for windows credentials manager
+  return NULL;
+}
+
+void dt_pwstorage_windows_credentials_destroy(const backend_windows_credentials_context_t *context)
+{
+  // nothing to do here
+}
+
+gboolean dt_pwstorage_windows_credentials_set(const backend_windows_credentials_context_t *context,
+                                              const gchar *slot,
+                                              GHashTable *table)
+{
+  gboolean result = TRUE;
+  GHashTableIter iter;
+  g_hash_table_iter_init(&iter, table);
+  gpointer key, value;
+
+  while(g_hash_table_iter_next(&iter, &key, &value))
+  {
+    dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_windows_credentials_set] storing (%s, %s)\n", (gchar *) key, (gchar *) value);
+
+    gchar *target_name = g_strconcat("darktable - ", slot, NULL);
+
+    // Parse server, username and password from JSON value
+    // {"server":"www.example.com","username":"myuser","password":"mypassword"}
+    JsonParser *json_parser = json_parser_new();
+
+    if(json_parser_load_from_data(json_parser, value, -1, NULL) == FALSE)
+    {
+      dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_windows_credentials_set] unable to parse JSON from value (%s)\n", (gchar *) value);
+      g_object_unref(json_parser);
+      g_free(target_name);
+      return FALSE;
+    }
+
+    // Read JSON
+    JsonNode *json_root = json_parser_get_root(json_parser);
+    JsonReader *json_reader = json_reader_new(json_root);
+
+    GHashTable *v_attributes = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+
+    // Save each element as a key/value pair
+    gint n_attributes = json_reader_count_members(json_reader);
+    for(gint i = 0; i < n_attributes; i++)
+    {
+      if(json_reader_read_element(json_reader, i) == FALSE)
+      {
+        continue;
+      }
+
+      const gchar *k = json_reader_get_member_name(json_reader);
+      const gchar *v = json_reader_get_string_value(json_reader);
+
+      g_hash_table_insert(v_attributes, g_strdup(k), g_strdup(v));
+
+      json_reader_end_element(json_reader);
+    }
+
+    g_object_unref(json_reader);
+    g_object_unref(json_parser);
+
+    gchar *server = g_strdup((gchar *) g_hash_table_lookup(v_attributes, "server"));
+    gchar *username = g_strdup((gchar *) g_hash_table_lookup(v_attributes, "username"));
+    gchar *password = g_strdup((gchar *) g_hash_table_lookup(v_attributes, "password"));
+
+    // delete existing entry
+    CredDeleteW((LPWSTR) target_name, CRED_TYPE_GENERIC, 0);
+
+    // create new entry
+    DWORD cbCreds = 1 + strlen(password);
+
+    CREDENTIALW cred = { 0 };
+    cred.Type = CRED_TYPE_GENERIC;
+    cred.TargetName = (LPWSTR) target_name;
+    cred.CredentialBlobSize = cbCreds;
+    cred.CredentialBlob = (LPBYTE) password;
+    cred.Persist = CRED_PERSIST_LOCAL_MACHINE;
+    cred.Comment = (LPWSTR) server;
+    cred.UserName = (LPWSTR) username;
+
+    result = CredWriteW (&cred, 0);
+
+    g_free(server);
+    g_free(username);
+    g_free(password);
+    g_free(target_name);
+  }
+
+  return result;
+}
+
+GHashTable *dt_pwstorage_windows_credentials_get(const backend_windows_credentials_context_t *context, const gchar *slot)
+{
+  GHashTable *table = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+
+  gchar *target_name = g_strconcat("darktable - ", slot, NULL);
+
+  PCREDENTIALW pcred;
+  gboolean ok = CredReadW((LPWSTR) target_name, CRED_TYPE_GENERIC, 0, &pcred);
+
+  if(ok)
+  {
+    // build JSON
+    JsonBuilder *json_builder = json_builder_new();
+    json_builder_begin_object(json_builder);
+    json_builder_set_member_name(json_builder, "server");
+    json_builder_add_string_value(json_builder, (gchar*) pcred->Comment);
+    json_builder_set_member_name(json_builder, "username");
+    json_builder_add_string_value(json_builder, (gchar*) pcred->UserName);
+    json_builder_set_member_name(json_builder, "password");
+    json_builder_add_string_value(json_builder, (char*) pcred->CredentialBlob);
+    json_builder_end_object(json_builder);
+
+    // generate JSON
+    JsonGenerator *json_generator = json_generator_new();
+    json_generator_set_root(json_generator, json_builder_get_root(json_builder));
+    gchar *json_data = json_generator_to_data(json_generator, 0);
+
+    g_object_unref(json_generator);
+    g_object_unref(json_builder);
+
+    dt_print(DT_DEBUG_PWSTORAGE, "[pwstorage_windows_credentials_get] reading (%s, %s)\n", (gchar*) pcred->Comment, json_data);
+
+    g_hash_table_insert(table, g_strdup((gchar*) pcred->Comment), g_strdup(json_data));
+  }
+
+  CredFree (pcred);
+  g_free(target_name);
+
+  return table;
+}

--- a/src/common/pwstorage/backend_windows_credentials.h
+++ b/src/common/pwstorage/backend_windows_credentials.h
@@ -1,5 +1,5 @@
 // This file is part of darktable
-// Copyright (c) 2010-2016 Tobias Ellinghaus <me@houz.org>.
+// Copyright (C) 2024 darktable developers.
 
 // darktable is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -16,36 +16,31 @@
 
 #pragma once
 
-#include "common/darktable.h"
+#include <glib.h>
 
-typedef enum pw_storage_backend_t
+/** windows credentials backend context */
+typedef struct backend_windows_credentials_context_t
 {
-  PW_STORAGE_BACKEND_NONE = 0,
-  PW_STORAGE_BACKEND_KWALLET,
-  PW_STORAGE_BACKEND_LIBSECRET,
-  PW_STORAGE_BACKEND_APPLE_KEYCHAIN,
-  PW_STORAGE_BACKEND_WINDOWS_CREDENTIALS
-} pw_storage_backend_t;
+} backend_windows_credentials_context_t;
 
-/** pwstorage context */
-typedef struct dt_pwstorage_t
-{
-  pw_storage_backend_t pw_storage_backend;
-  void *backend_context;
-} dt_pwstorage_t;
 
-/** Initializes a new pwstorage context. */
-const dt_pwstorage_t *dt_pwstorage_new();
-/** Cleanup and destroy pwstorage context. \remarks After this point pointer at pwstorage is invalid. */
-void dt_pwstorage_destroy(const dt_pwstorage_t *pwstorage);
+/** Initializes a new windows credentials backend context. */
+const backend_windows_credentials_context_t *dt_pwstorage_windows_credentials_new();
+
+/** Cleanup and destroy windows credentials backend context. */
+void dt_pwstorage_windows_credentials_destroy(const backend_windows_credentials_context_t *context);
+
 /** Store (key,value) pairs. */
-gboolean dt_pwstorage_set(const gchar *slot, GHashTable *table);
+gboolean dt_pwstorage_windows_credentials_set(const backend_windows_credentials_context_t *context,
+                                              const gchar *slot,
+                                              GHashTable *table);
+
 /** Load (key,value) pairs. */
-GHashTable *dt_pwstorage_get(const gchar *slot);
+GHashTable *dt_pwstorage_windows_credentials_get(const backend_windows_credentials_context_t *context,
+                                                 const gchar *slot);
 
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-


### PR DESCRIPTION
Use the Windows built-in credentials manager for pwstorage.

fixes #16518

![image](https://github.com/darktable-org/darktable/assets/4083281/7455b43a-86cb-45e1-af3d-2016431aaca2)
