### PR TITLE
Add sraw support to BLEND_CS_RAW

### DIFF
--- a/data/kernels/blendop.cl
+++ b/data/kernels/blendop.cl
@@ -945,6 +945,153 @@ blendop_RAW(__read_only image2d_t in_a, __read_only image2d_t in_b, __read_only 
   write_imagef(out, (int2)(x, y), o);
 }
 
+__kernel void
+blendop_RAW4(__read_only image2d_t in_a, __read_only image2d_t in_b, __read_only image2d_t mask, __write_only image2d_t out, const int width, const int height,
+            const int blend_mode, const float blend_parameter, const int2 offs, const int mask_display)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  if(x >= width || y >= height) return;
+
+  float4 a, b, o;
+
+  if((blend_mode & DEVELOP_BLEND_REVERSE) == DEVELOP_BLEND_REVERSE)
+  {
+    b = read_imagef(in_a, sampleri, (int2)(x, y) + offs);
+    a = read_imagef(in_b, sampleri, (int2)(x, y));
+  }
+  else
+  {
+    a = read_imagef(in_a, sampleri, (int2)(x, y) + offs);
+    b = read_imagef(in_b, sampleri, (int2)(x, y));
+  }
+
+  float4 opacity = read_imagef(mask, sampleri, (int2)(x, y)).x;
+
+  const float4 min = 0.0f;
+  const float4 max = 1.0f;
+  const float4 lmin = 0.0f;
+  const float4 lmax = 1.0f;        /* max + fabs(min) */
+  const float4 halfmax = 0.5f;     /* lmax / 2.0f */
+  const float4 doublemax = 2.0f;   /* lmax * 2.0f */
+  const float4 opacity2 = opacity*opacity;
+
+  float4 la = clamp(a + fabs(min), lmin, lmax);
+  float4 lb = clamp(b + fabs(min), lmin, lmax);
+
+
+  /* select the blend operator */
+  switch(blend_mode & DEVELOP_BLEND_MODE_MASK)
+  {
+    case DEVELOP_BLEND_LIGHTEN:
+      o = clamp(a * (1.0f - opacity) + fmax(a, b) * opacity, min, max);
+      break;
+
+    case DEVELOP_BLEND_DARKEN:
+      o = clamp(a * (1.0f - opacity) + fmin(a, b) * opacity, min, max);
+      break;
+
+    case DEVELOP_BLEND_MULTIPLY:
+      o = clamp(a * (1.0f - opacity) + a * b * opacity, min, max);
+      break;
+
+    case DEVELOP_BLEND_AVERAGE:
+      o = clamp(a * (1.0f - opacity) + (a + b)/2.0f * opacity, min, max);
+      break;
+
+    case DEVELOP_BLEND_ADD:
+      o =  clamp(a * (1.0f - opacity) +  (a + b) * opacity, min, max);
+      break;
+
+    case DEVELOP_BLEND_SUBTRACT:
+      o =  clamp(a * (1.0f - opacity) +  (b + a - fabs(min + max)) * opacity, min, max);
+      break;
+
+    case DEVELOP_BLEND_DIFFERENCE:
+    case DEVELOP_BLEND_DIFFERENCE2:
+      o = clamp(la * (1.0f - opacity) + fabs(la - lb) * opacity, lmin, lmax) - fabs(min);
+      break;
+
+    case DEVELOP_BLEND_SCREEN:
+      o = clamp(la * (1.0f - opacity) + (lmax - (lmax - la) * (lmax - lb)) * opacity, lmin, lmax) - fabs(min);
+      break;
+
+    case DEVELOP_BLEND_OVERLAY:
+      o = clamp(la * (1.0f - opacity2) + (la > halfmax ? lmax - (lmax - doublemax * (la - halfmax)) * (lmax-lb) : doublemax * la * lb) * opacity2, lmin, lmax) - fabs(min);
+      break;
+
+    case DEVELOP_BLEND_SOFTLIGHT:
+      o = clamp(la * (1.0f - opacity2) + (lb > halfmax ? lmax - (lmax - la)  * (lmax - (lb - halfmax)) : la * (lb + halfmax)) * opacity2, lmin, lmax) - fabs(min);
+      break;
+
+    case DEVELOP_BLEND_HARDLIGHT:
+      o = clamp(la * (1.0f - opacity2) + (lb > halfmax ? lmax - (lmax - doublemax * (la - halfmax)) * (lmax-lb) : doublemax * la * lb) * opacity2, lmin, lmax) - fabs(min);
+      break;
+
+    case DEVELOP_BLEND_VIVIDLIGHT:
+      o = clamp(la * (1.0f - opacity2) + (lb > halfmax ? la / (lb >= lmax ? lmax : (doublemax * (lmax - lb))) : (lb <= lmin ? lmin : lmax - (lmax - la)/(doublemax * lb))) * opacity2, lmin, lmax) - fabs(min);
+      break;
+
+    case DEVELOP_BLEND_LINEARLIGHT:
+      o = clamp(la * (1.0f - opacity2) + (la + doublemax * lb - lmax) * opacity2, lmin, lmax) - fabs(min);
+      break;
+
+    case DEVELOP_BLEND_PINLIGHT:
+      o = clamp(la * (1.0f - opacity2) + (lb > halfmax ? fmax(la, doublemax * (lb - halfmax)) : fmin(la, doublemax * lb)) * opacity2, lmin, lmax) - fabs(min);
+      break;
+
+    case DEVELOP_BLEND_LIGHTNESS:
+      o = clamp(a, min, max);   // Noop for Raw
+      break;
+
+    case DEVELOP_BLEND_CHROMA:
+      o = clamp(a, min, max);   // Noop for Raw
+      break;
+
+    case DEVELOP_BLEND_HUE:
+      o = clamp(a, min, max);   // Noop for Raw
+      break;
+
+    case DEVELOP_BLEND_COLOR:
+      o = clamp(a, min, max);   // Noop for Raw
+      break;
+
+    case DEVELOP_BLEND_COLORADJUST:
+      o = clamp(a, min, max);   // Noop for Raw
+      break;
+
+    case DEVELOP_BLEND_BOUNDED:
+      o =  clamp((a * (1.0f - opacity)) + (b * opacity), min, max);
+      break;
+
+    case DEVELOP_BLEND_LAB_LIGHTNESS:
+    case DEVELOP_BLEND_LAB_COLOR:
+    case DEVELOP_BLEND_LAB_L:
+    case DEVELOP_BLEND_LAB_A:
+    case DEVELOP_BLEND_LAB_B:
+      o = a;                            // Noop for Raw (without clamping)
+      break;
+
+    case DEVELOP_BLEND_HSV_LIGHTNESS:
+    case DEVELOP_BLEND_HSV_COLOR:
+    case DEVELOP_BLEND_RGB_R:
+    case DEVELOP_BLEND_RGB_G:
+    case DEVELOP_BLEND_RGB_B:
+      o = a;                            // Noop for Raw (without clamping)
+      break;
+
+    /* fallback to normal blend */
+    case DEVELOP_BLEND_NORMAL2:
+    default:
+      o =  (a * (1.0f - opacity)) + (b * opacity);
+      break;
+
+  }
+
+  write_imagef(out, (int2)(x, y), o);
+}
+
 
 __kernel void
 blendop_rgb_hsl(__read_only image2d_t in_a, __read_only image2d_t in_b, __read_only image2d_t mask, __write_only image2d_t out, const int width, const int height,

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -1064,7 +1064,8 @@ gboolean dt_develop_blend_process_cl(struct dt_iop_module_t *self,
   switch(blend_csp)
   {
     case DEVELOP_BLEND_CS_RAW:
-      kernel = darktable.opencl->blendop->kernel_blendop_RAW;
+      kernel = ch == 1  ? darktable.opencl->blendop->kernel_blendop_RAW
+                        : darktable.opencl->blendop->kernel_blendop_RAW4;
       kernel_mask = darktable.opencl->blendop->kernel_blendop_mask_RAW;
       break;
 
@@ -1584,6 +1585,8 @@ dt_blendop_cl_global_t *dt_develop_blend_init_cl_global(void)
     dt_opencl_create_kernel(program, "blendop_Lab");
   b->kernel_blendop_RAW =
     dt_opencl_create_kernel(program, "blendop_RAW");
+  b->kernel_blendop_RAW4 =
+    dt_opencl_create_kernel(program, "blendop_RAW4");
   b->kernel_blendop_rgb_hsl =
     dt_opencl_create_kernel(program, "blendop_rgb_hsl");
   b->kernel_blendop_rgb_jzczhz =
@@ -1627,6 +1630,7 @@ void dt_develop_blend_free_cl_global(dt_blendop_cl_global_t *b)
   dt_opencl_free_kernel(b->kernel_blendop_mask_rgb_jzczhz);
   dt_opencl_free_kernel(b->kernel_blendop_Lab);
   dt_opencl_free_kernel(b->kernel_blendop_RAW);
+  dt_opencl_free_kernel(b->kernel_blendop_RAW4);
   dt_opencl_free_kernel(b->kernel_blendop_rgb_hsl);
   dt_opencl_free_kernel(b->kernel_blendop_rgb_jzczhz);
   dt_opencl_free_kernel(b->kernel_blendop_mask_tone_curve);

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -231,6 +231,7 @@ typedef struct dt_blendop_cl_global_t
   int kernel_blendop_mask_rgb_jzczhz;
   int kernel_blendop_Lab;
   int kernel_blendop_RAW;
+  int kernel_blendop_RAW4;
   int kernel_blendop_rgb_hsl;
   int kernel_blendop_rgb_jzczhz;
   int kernel_blendop_mask_tone_curve;


### PR DESCRIPTION
Modules in the early stage of the pipe might be running as IOP_CS_RAW. But we might have sraw or raw files doing so thus we can have 4 or just 1 channel.

Introduces an OpenCL kernel function as that was missing and let dt_develop_blend_process_cl() use the appropriate one.

To reproduce:
1. use a sraw file
2. select clip as highlights algorithm
3. add a mask there and the image will go grey.