### PR TITLE
Avoid crash on corrupted PNG files with an incorrect header

### DIFF
--- a/src/imageio/imageio_png.c
+++ b/src/imageio/imageio_png.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2023 darktable developers.
+    Copyright (C) 2009-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -267,7 +267,7 @@ int dt_imageio_png_read_profile(const char *filename, uint8_t **out, dt_colorspa
 
   if(!(filename && *filename)) return 0;
 
-  if(read_header(filename, &image) != 0) return DT_IMAGEIO_LOAD_FAILED;
+  if(read_header(filename, &image) != 0) return 0;
 
   /* TODO: also add check for known cICP chunk read support once added to libpng */
 #ifdef PNG_STORE_UNKNOWN_CHUNKS_SUPPORTED


### PR DESCRIPTION
Returning an error code from dt_imageio_png_read_profile  is simply wrong because we should be returning the size of the profile (so 0 when the profile cannot be retrieved).