### PR TITLE
Change grayscale tiff export toast warning to dtprint

### DIFF
--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2023 darktable developers.
+    Copyright (C) 2010-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -240,7 +240,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
   }
 
   if(d->shortfile && layers == 3)
-    dt_control_log(_("not a B&W image, will not export as grayscale"));
+    dt_print(DT_DEBUG_IMAGEIO, "[tiff export] '%s' is not a B&W image, not exporting as grayscale\n", filename);
 
   TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, layers);
   TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, (uint16_t)d->bpp);


### PR DESCRIPTION
The toast message simply did not work due to the fact that `&` in the text was interpreted as the beginning of the markup entity and this led to a parsing error. Even after fixing this, we will not see this message when exporting a single image (or for the last image if multiple images are exported), as it is immediately overwritten by the following text, the export statistics.

Also, this warning is not serious enough to issue in the program interface, so I moved it to the debug print.