### PR TITLE
Use modern cl interface kernel calling

### DIFF
--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2023 darktable developers.
+    Copyright (C) 2011-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -619,15 +619,13 @@ int process_cl(struct dt_iop_module_t *self,
 
   const int width = roi_out->width;
   const int height = roi_out->height;
-  size_t sizes[2] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid) };
 
   // ----- Filling border
   const float col[4] = { d->color[0], d->color[1], d->color[2], 1.0f };
   const int zero = 0;
-  dt_opencl_set_kernel_args(devid, gd->kernel_borders_fill,
-                            0, CLARG(dev_out), CLARG(zero), CLARG(zero),
+  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_borders_fill, width, height,
+                            CLARG(dev_out), CLARG(zero), CLARG(zero),
                             CLARG(width), CLARG(height), CLARG(col));
-  err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_borders_fill, sizes);
   if(err != CL_SUCCESS) goto error;
 
   if(binfo.frame_size != 0)
@@ -641,20 +639,18 @@ int process_cl(struct dt_iop_module_t *self,
     const int roi_frame_out_width  = binfo.frame_br_out_x - binfo.frame_tl_out_x;
     const int roi_frame_out_height = binfo.frame_br_out_y - binfo.frame_tl_out_y;
 
-    dt_opencl_set_kernel_args(devid, gd->kernel_borders_fill, 0,
+    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_borders_fill, width, height,
                               CLARG(dev_out),
                               CLARG(binfo.frame_tl_out_x), CLARG(binfo.frame_tl_out_y),
                               CLARG(roi_frame_out_width), CLARG(roi_frame_out_height),
                               CLARG(col_frame));
-    err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_borders_fill, sizes);
     if(err != CL_SUCCESS) goto error;
 
-    dt_opencl_set_kernel_args(devid, gd->kernel_borders_fill, 0,
+    err = dt_opencl_set_kernel_args(devid, gd->kernel_borders_fill, width, height,
                               CLARG(dev_out),
                               CLARG(binfo.frame_tl_in_x), CLARG(binfo.frame_tl_in_y),
                               CLARG(roi_frame_in_width), CLARG(roi_frame_in_height),
                               CLARG(col));
-    err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_borders_fill, sizes);
     if(err != CL_SUCCESS) goto error;
   }
 

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -2328,7 +2328,7 @@ int process_cl(struct dt_iop_module_t *self,
     }
   }
 
-  cl_int err = DT_OPENCL_DEFAULT_ERROR;
+  cl_int err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
 
   if(piece->colors != 4)
   {
@@ -2339,8 +2339,6 @@ int process_cl(struct dt_iop_module_t *self,
   const int devid = piece->pipe->devid;
   const int width = roi_in->width;
   const int height = roi_in->height;
-
-  size_t sizes[] = { ROUNDUPDWD(width, devid), ROUNDUPDHT(height, devid), 1 };
 
   cl_mem input_matrix_cl = dt_opencl_copy_host_to_device_constant
     (devid, 12 * sizeof(float), (float*)work_profile->matrix_in);
@@ -2385,16 +2383,14 @@ int process_cl(struct dt_iop_module_t *self,
     }
   }
 
-  dt_opencl_set_kernel_args
-    (devid, kernel, 0, CLARG(dev_in), CLARG(dev_out),
-     CLARG(width), CLARG(height),
-     CLARG(input_matrix_cl), CLARG(output_matrix_cl),
-     CLARG(MIX_cl), CLARG(d->illuminant), CLARG(d->saturation),
-     CLARG(d->lightness), CLARG(d->grey),
-     CLARG(d->p), CLARG(d->gamut), CLARG(d->clip), CLARG(d->apply_grey),
-     CLARG(d->version));
-
-  err = dt_opencl_enqueue_kernel_2d(devid, kernel, sizes);
+  err = dt_opencl_enqueue_kernel_2d_args(devid, kernel, width, height,
+          CLARG(dev_in), CLARG(dev_out),
+          CLARG(width), CLARG(height),
+          CLARG(input_matrix_cl), CLARG(output_matrix_cl),
+          CLARG(MIX_cl), CLARG(d->illuminant), CLARG(d->saturation),
+          CLARG(d->lightness), CLARG(d->grey),
+          CLARG(d->p), CLARG(d->gamut), CLARG(d->clip), CLARG(d->apply_grey),
+          CLARG(d->version));
 
 error:
   dt_opencl_release_mem_object(input_matrix_cl);

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -229,13 +229,9 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dev_m = dt_opencl_copy_host_to_device_constant(devid, mat_size, mat);
   if(dev_m == NULL) goto error;
 
-  /* overexpose image */
-  sizes[0] = ROUNDUPDWD(width, devid);
-  sizes[1] = ROUNDUPDHT(height, devid);
-  sizes[2] = 1;
-  dt_opencl_set_kernel_args(devid, gd->kernel_soften_overexposed, 0, CLARG(dev_in), CLARG(dev_tmp),
+  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_soften_overexposed, width, height,
+    CLARG(dev_in), CLARG(dev_tmp),
     CLARG(width), CLARG(height), CLARG(saturation), CLARG(brightness));
-  err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_soften_overexposed, sizes);
   if(err != CL_SUCCESS) goto error;
 
   if(rad != 0)
@@ -266,13 +262,9 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     if(err != CL_SUCCESS) goto error;
   }
 
-  /* mixing tmp and in -> out */
-  sizes[0] = ROUNDUPDWD(width, devid);
-  sizes[1] = ROUNDUPDHT(height, devid);
-  sizes[2] = 1;
-  dt_opencl_set_kernel_args(devid, gd->kernel_soften_mix, 0, CLARG(dev_in), CLARG(dev_tmp), CLARG(dev_out),
+  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_soften_mix, width, height,
+    CLARG(dev_in), CLARG(dev_tmp), CLARG(dev_out),
     CLARG(width), CLARG(height), CLARG(amount));
-  err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_soften_mix, sizes);
 
 error:
   dt_opencl_release_mem_object(dev_m);


### PR DESCRIPTION
Make use of `dt_opencl_enqueue_kernel_2d_args()` instead of `dt_opencl_set_kernel_args()` followed by `dt_opencl_enqueue_kernel_2d()` where possible.