### PR TITLE
Color equalizer tooltips and UI naming

### DIFF
--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -2481,7 +2481,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   self->widget = box;
   g->hue_shift = dt_color_picker_new_with_cst(self, DT_COLOR_PICKER_POINT_AREA | DT_COLOR_PICKER_DENOISE,
-                 dt_bauhaus_slider_from_params(self, "hue_shift"), IOP_CS_HSL);
+                 dt_bauhaus_slider_from_params(self, "hue_shift"), IOP_CS_JZCZHZ);
   dt_bauhaus_slider_set_format(g->hue_shift, "°");
   dt_bauhaus_slider_set_digits(g->hue_shift, 0);
   gtk_widget_set_tooltip_text(g->hue_shift,


### PR DESCRIPTION
Some UI modifications

1. "analysis radius" has been renamed to "hue analysis radius", the slightly longer text shouldn't hurt and makes it more understandable.
2. Some tooltips explicitely remind about effect only for the guided filter.
3. At least as long (or if) we have the guided filter as an on/off option we might want to make the group of controls unselectable that are only effective if the guided filter is in use.

Second commit fixes the hue picker colorspace regression in https://github.com/darktable-org/darktable/commit/34ee36574895a1c4ef03fd82b70c86abc47f0928 