### PR TITLE
Revert incorrect CI code checkout change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,15 +192,10 @@ jobs:
             python3-jsonschema \
             xsltproc \
             zlib1g-dev;
-      - name: Checkout darktable master branch
-        run: |
-          # For speed (and saving traffic), we make a shallow clone with a history truncated to 1 commit
-          git clone --depth 1 https://github.com/darktable-org/darktable src
-          cd src
-          git submodule init
-          git config submodule.src/tests/integration.update none
-          git submodule update
-          cd -
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          path: src
       - name: Build and Install
         run: |
           cmake -E make_directory "${BUILD_DIR}";
@@ -305,15 +300,10 @@ jobs:
           update: false
       - run: git config --global core.autocrlf input
         shell: bash
-      - name: Checkout darktable master branch
-        run: |
-          # For speed (and saving traffic), we make a shallow clone with a history truncated to 1 commit
-          git clone --depth 1 https://github.com/darktable-org/darktable src
-          pushd src
-          git submodule init
-          git config submodule.src/tests/integration.update none
-          git submodule update
-          popd
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          path: src
       - name: Build and Install
         run: |
           cmake -E make_directory "${BUILD_DIR}"
@@ -364,15 +354,10 @@ jobs:
       GENERATOR: ${{ matrix.generator }}
       TARGET: ${{ matrix.target }}
     steps:
-      - name: Checkout darktable master branch
-        run: |
-          # For speed (and saving traffic), we make a shallow clone with a history truncated to 1 commit
-          git clone --depth 1 https://github.com/darktable-org/darktable src
-          pushd src
-          git submodule init
-          git config submodule.src/tests/integration.update none
-          git submodule update
-          popd
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          path: src
       - name: Install Base Dependencies
         run: |
           brew update > /dev/null || true


### PR DESCRIPTION
This reverts obviously incorrect commit 6cd6dc5bd08d7b1fc4a880b629896e24e78bd644. The same cloning code was copied from the nightly action (where it was correct) without enough thought, to say the least. 😕