### PR TITLE
[README.md] Nightly packages are no longer x86_64 only

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ You can check for them by running darktable with the `--version` command line op
 
 The development snapshot reflects the current state of the master branch. It is intended for testing and is generally not safe. See the notes [below](#get-the-source) for warnings and precautions about using the master branch.
 
-* [Install native packages and repositories for Linux](https://software.opensuse.org/download.html?project=graphics:darktable:master&package=darktable) (one snapshot per day).
-* [Binary packages are provided for Linux (AppImage), macOS and Windows on a nightly basis](https://github.com/darktable-org/darktable/releases/tag/nightly) (x86_64 only).
+* [Install native packages and repositories for Linux](https://software.opensuse.org/download.html?project=graphics:darktable:master&package=darktable) (one snapshot per day)
+* [Binary packages are provided for Linux (AppImage), macOS and Windows on a nightly basis](https://github.com/darktable-org/darktable/releases/tag/nightly)
 
 Updating from older versions
 ----------------------------

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You can check for them by running darktable with the `--version` command line op
 
 The development snapshot reflects the current state of the master branch. It is intended for testing and is generally not safe. See the notes [below](#get-the-source) for warnings and precautions about using the master branch.
 
-* [Install native packages and repositories for Linux](https://software.opensuse.org/download.html?project=graphics:darktable:master&package=darktable) (one snapshot per day)
+* [Install native packages directly or add third party repository for some Linux distros](https://software.opensuse.org/download.html?project=graphics:darktable:master&package=darktable) (one snapshot per day)
 * [Binary packages are provided for Linux (AppImage), macOS and Windows on a nightly basis](https://github.com/darktable-org/darktable/releases/tag/nightly)
 
 Updating from older versions


### PR DESCRIPTION
We build nightly for Apple Silicon as well. Also improved the wording of link to OBS packages and repositories.