### PR TITLE
add 'clarity' search alias to local contrast module

### DIFF
--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -77,6 +77,11 @@ const char *name()
   return _("local contrast");
 }
 
+const char *aliases()
+{
+  return _("clarity");
+}
+
 const char **description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description(self, _("manipulate local and global contrast separately"),


### PR DESCRIPTION
Since users of other software may be more familiar with that term. LR-sidecar import converts the clarity setting to the local contrast module's "details" slider as well.