### PR TITLE
RFC: Add more widgets to QAP by default

### DIFF
--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1482,6 +1482,8 @@ static void _preset_from_string(dt_lib_module_t *self, gchar *txt, gboolean edit
       AM("filmicrgb/white relative exposure");                                                                    \
       AM("filmicrgb/black relative exposure");                                                                    \
       AM("filmicrgb/contrast");                                                                                   \
+      AM("sigmoid/contrast");											  \
+      AM("sigmoid/skew");											  \
       AM("channelmixerrgb/temperature");                                                                          \
       AM("channelmixerrgb/chroma");                                                                               \
       AM("channelmixerrgb/hue");                                                                                  \

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1487,6 +1487,9 @@ static void _preset_from_string(dt_lib_module_t *self, gchar *txt, gboolean edit
       AM("channelmixerrgb/temperature");                                                                          \
       AM("channelmixerrgb/chroma");                                                                               \
       AM("channelmixerrgb/hue");                                                                                  \
+      AM("channelmixerrgb/illuminant");                                                                           \
+      AM("channelmixerrgb/F source");                                                                             \
+      AM("channelmixerrgb/LED source");                                                                           \
     }                                                                                                             \
     else                                                                                                          \
     {                                                                                                             \

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1504,7 +1504,7 @@ static void _preset_from_string(dt_lib_module_t *self, gchar *txt, gboolean edit
     AM("ashift/rotation");                                                                                        \
     AM("denoiseprofile");                                                                                         \
     AM("lens");                                                                                                   \
-    AM("bilat");                                                                                                  \
+    AM("bilat/detail");                                                                                           \
   }
 
 // start module group

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1493,6 +1493,9 @@ static void _preset_from_string(dt_lib_module_t *self, gchar *txt, gboolean edit
       AM("temperature/temperature");                                                                              \
       AM("temperature/tint");                                                                                     \
     }                                                                                                             \
+    AM("colorequal/page");	                                             					  \
+    AM("colorequal/graph");                                                 					  \
+    AM("colorequal/node placement");                                           					  \
     AM("exposure/exposure");                                                                                      \
     if(!is_scene_referred) AM("colorbalancergb/contrast"); /* contrast is already in filmic */                    \
     AM("colorbalancergb/global chroma");                                                                          \

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2022 darktable developers.
+    Copyright (C) 2011-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1505,7 +1505,7 @@ static void _preset_from_string(dt_lib_module_t *self, gchar *txt, gboolean edit
     AM("colorbalancergb/global vibrance");                                                                        \
     AM("colorbalancergb/global saturation");                                                                      \
     AM("ashift/rotation");                                                                                        \
-    AM("denoiseprofile");                                                                                         \
+    AM("denoiseprofile/strength");                                                                                \
     AM("lens");                                                                                                   \
     AM("bilat/detail");                                                                                           \
   }

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -1506,6 +1506,9 @@ static void _preset_from_string(dt_lib_module_t *self, gchar *txt, gboolean edit
     AM("colorbalancergb/global saturation");                                                                      \
     AM("ashift/rotation");                                                                                        \
     AM("denoiseprofile/strength");                                                                                \
+    AM("toneequal/graph");                                    						  	  \
+    AM("toneequal/mask exposure compensation");                       						  \
+    AM("toneequal/mask contrast compensation");                       						  \
     AM("lens");                                                                                                   \
     AM("bilat/detail");                                                                                           \
   }


### PR DESCRIPTION
And before everyone jumps on me for making the panel require scrolling, I'm aware of that but think it's warranted to get all of the main editing functions that new users might end up using into one place.  It's probably also better to err a little on the side of adding too many (e.g. having both Filmic and Sigmoid by default) since it's easier to remove widgets than to add them -- plus most users of **any** software never change defaults.  The scrolling issue could be mitigated by switching the default preference to scrolling the panel instead of adjusting sliders; in that case we should consider adding a hint about using Alt-Scroll to the slider tooltips.

I've separated the additions into a bunch of small commits to permit easy cherrypicking.  If all of them are included, we get full color and tonal control (including global and local contrast) as well as denoising control right from the panel.

Two other things I would like to add: binding the Escape key to activating the QAP (to return there after linking out to a full module), and adding the preset menu for each module next to the link button.  I haven't figured out how to do the former in code yet, though it works quite well when done manually in the UI via the mapping function (changing the action from the default "toggle" to "on").  I haven't had a chance to look into the latter yet.

A dedicated return to the exact position in the QAP from which one jumped to a full module would be better (though more work) than a shortcut to activate the QAP, since the latter action always leaves you at the top instead of preserving the scroll position.
