### PR TITLE
link module preset menus in quick access panel

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2188,7 +2188,7 @@ static void _gui_reset_callback(GtkButton *button,
   dt_iop_connect_accels_multi(module->so);
 }
 
-static void _presets_popup_callback(GtkButton *button, dt_iop_module_t *module)
+void dt_presets_popup_callback(GtkButton *button, dt_iop_module_t *module)
 {
   const gboolean disabled = !module->default_enabled && module->hide_enable_button;
   if(disabled) return;
@@ -2406,7 +2406,7 @@ static gboolean _iop_plugin_body_button_press(GtkWidget *w,
   }
   else if(e->button == 3)
   {
-    _presets_popup_callback(NULL, module);
+    dt_presets_popup_callback(NULL, module);
 
     return TRUE;
   }
@@ -2454,7 +2454,7 @@ static gboolean _iop_plugin_header_button_press(GtkWidget *w,
   }
   else if(e->button == 3)
   {
-    _presets_popup_callback(NULL, module);
+    dt_presets_popup_callback(NULL, module);
 
     return TRUE;
   }
@@ -2945,7 +2945,7 @@ void dt_iop_gui_set_expander(dt_iop_module_t *module)
     gtk_widget_set_tooltip_text(GTK_WIDGET(hw[IOP_MODULE_PRESETS]),
                                 _("presets\nright-click to apply on new instance"));
   g_signal_connect(G_OBJECT(hw[IOP_MODULE_PRESETS]), "clicked",
-                   G_CALLBACK(_presets_popup_callback), module);
+                   G_CALLBACK(dt_presets_popup_callback), module);
   g_signal_connect(G_OBJECT(hw[IOP_MODULE_PRESETS]), "enter-notify-event",
                    G_CALLBACK(_header_enter_notify_callback),
                    GINT_TO_POINTER(DT_ACTION_ELEMENT_PRESETS));
@@ -3740,7 +3740,8 @@ static float _action_process(gpointer target,
       switch(effect)
       {
       case DT_ACTION_EFFECT_ACTIVATE:
-        if(module->presets_button) _presets_popup_callback(NULL, module);
+        if(module->presets_button)
+          dt_presets_popup_callback(NULL, module);
         break;
       case DT_ACTION_EFFECT_NEXT:
         move_size *= -1;

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -35,6 +35,9 @@
 #include "osx/osx.h"
 #endif
 
+extern void dt_presets_popup_callback(GtkButton *button,
+                                      dt_iop_module_t *module);
+
 DT_MODULE(1)
 
 // the T_ macros are for the translation engine to take them into account
@@ -413,6 +416,13 @@ static gboolean _basics_goto_module(GtkWidget *w, GdkEventButton *e, gpointer us
   return TRUE;
 }
 
+static gboolean _basics_apply_preset(GtkWidget *w, GdkEventButton *e, gpointer user_data)
+{
+  dt_iop_module_t *module = (dt_iop_module_t *)(user_data);
+  dt_presets_popup_callback(NULL,module);
+  return TRUE;
+}
+
 static void _basics_on_off_callback(GtkWidget *btn, dt_lib_modulegroups_basic_item_t *item)
 {
   // we switch the "real" button accordingly
@@ -626,6 +636,14 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
     gtk_box_pack_start(GTK_BOX(hbox_basic), d->mod_vbox_basic, TRUE, TRUE, 0);
     gtk_widget_show_all(hbox_basic);
 
+    // we create a button to open the presets menu
+    GtkWidget *pbt = dtgtk_button_new(dtgtk_cairo_paint_presets, 0, NULL);
+    gtk_widget_show(pbt);
+    gtk_widget_set_tooltip_text(pbt, "presets");
+    gtk_widget_set_name(pbt, "quick-presets");
+    gtk_widget_set_valign(pbt, GTK_ALIGN_CENTER);
+    g_signal_connect(G_OBJECT(pbt), "button-press-event", G_CALLBACK(_basics_apply_preset), item->module);
+
     // we create the link to the full iop
     GtkWidget *wbt = dtgtk_button_new(dtgtk_cairo_paint_link, 0, NULL);
     gtk_widget_show(wbt);
@@ -655,11 +673,13 @@ static void _basics_add_widget(dt_lib_module_t *self, dt_lib_modulegroups_basic_
       gtk_box_pack_start(GTK_BOX(header_box), sect, TRUE, TRUE, 0);
 
       gtk_box_pack_end(GTK_BOX(header_box), wbt, FALSE, FALSE, 0);
+      gtk_box_pack_end(GTK_BOX(header_box), pbt, FALSE, FALSE, 0);
     }
     else
     {
-      // if there is no section label, we add the link to the module hbox
+      // if there is no section label, we add the presets menu and link to the module hbox
       gtk_box_pack_end(GTK_BOX(hbox_basic), wbt, FALSE, FALSE, 0);
+      gtk_box_pack_end(GTK_BOX(hbox_basic), pbt, FALSE, FALSE, 0);
 
       // if there is no label, we handle separately in css the first module header
       if(item_pos == FIRST_MODULE) gtk_widget_set_name(header_box, "basics-header-box-first");


### PR DESCRIPTION
Adds the hamburger menu just to the left of the link-to-module icon, allowing presets to applied without first opening the full  module.
Companion to #16656.
