### PR TITLE
Highlights masking fixes

### DIFF
--- a/data/kernels/blendop.cl
+++ b/data/kernels/blendop.cl
@@ -1489,17 +1489,17 @@ __kernel void blendop_highlights_mask
   if(ch == 1)
   {
     const float a = fmax(MININ, read_imagef(in, sampleri, (int2)(icol, irow)).x);
-    const float b = read_imagef(out, sampleri, (int2)(x, y)).x;
-    r = b / a;
+    const float b = read_imagef(out, sampleri, (int2)(x, y)).x / a;
+    r = 10.0f * (b - 1.0f);
   }
   else
   {
     const float4 a = fmax(MININ, read_imagef(in, sampleri, (int2)(icol, irow)));
     const float4 b = read_imagef(out, sampleri, (int2)(x, y)) / a;
-    r = fmax(b.w, fmax(b.x, b.y));
+    r = 10.0f * (fmax(b.w, fmax(b.x, b.y)) - 1.0f);
   }
 
-  write_imagef(mask_out, (int2)(x, y), m * clamp(r * r - 1.0f, 0.0f, 1.0f));
+  write_imagef(mask_out, (int2)(x, y), m * clamp(r*r, 0.0f, 2.0f));
 }
 #undef MININ
 

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -484,7 +484,7 @@ static void _write_highlights_raster(const gboolean israw,
                               : MAX(output[4*ox+0] / MAX(MININ, input[4*ix+0]),
                                 MAX(output[4*ox+1] / MAX(MININ, input[4*ix+1]),
                                     output[4*ox+2] / MAX(MININ, input[4*ix+2])));
-        mask[ox] *= CLIP(sqrf(r) - 1.0f);
+        mask[ox] *= CLAMP(sqrf(10.0f * (r - 1.0f)), 0.0f, 2.0f);
       }
     }
   }


### PR DESCRIPTION
1. The generated HLR raster mask has been changed slightly after a lot of more testing for usability. Better response at the transition unclipped->clipped and a bit more "intense".
2. If we generate the raster mask we have increased cl memory requirements because of gaussian blur