### PR TITLE
Allow taking edges of colorpicker

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -251,7 +251,7 @@ static int usage(const char *argv0)
          "    act_on, cache, camctl, camsupport, control, dev, expose,\n"
          "    imageio, input, ioporder, lighttable, lua, masks, memory,\n"
          "    nan, opencl, params, perf, pipe, print, pwstorage, signal,\n"
-         "    sql, tiling, undo\n"
+         "    sql, tiling, picker, undo\n"
          "\n"
          "    all     -> to debug all signals\n"
          "    common  -> to debug dev, imageio, masks, opencl, params, pipe\n"
@@ -971,6 +971,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
           !strcmp(darg, "verbose") ? DT_DEBUG_VERBOSE :
           !strcmp(darg, "pipe") ? DT_DEBUG_PIPE :
           !strcmp(darg, "expose") ? DT_DEBUG_EXPOSE :
+          !strcmp(darg, "picker") ? DT_DEBUG_PICKER :
           0;
         if(dadd)
           darktable.unmuted |= dadd;

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -302,6 +302,7 @@ typedef enum dt_debug_thread_t
   DT_DEBUG_VERBOSE        = 1 << 24,
   DT_DEBUG_PIPE           = 1 << 25,
   DT_DEBUG_EXPOSE         = 1 << 26,
+  DT_DEBUG_PICKER         = 1 << 27,
   DT_DEBUG_ALL            = 0xffffffff & ~DT_DEBUG_VERBOSE,
   DT_DEBUG_COMMON         = DT_DEBUG_OPENCL | DT_DEBUG_DEV | DT_DEBUG_MASKS | DT_DEBUG_PARAMS | DT_DEBUG_IMAGEIO | DT_DEBUG_PIPE,
   DT_DEBUG_RESTRICT       = DT_DEBUG_VERBOSE | DT_DEBUG_PERF,

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -801,7 +801,7 @@ static void _pixelpipe_picker(dt_iop_module_t *module,
     const dt_iop_order_iccprofile_info_t *const profile =
       dt_ioppr_get_pipe_current_profile_info(module, piece->pipe);
 
-    dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe picker",
+    dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_PICKER, "pixelpipe picker",
       piece->pipe, module, DT_DEVICE_CPU, roi, NULL, " %s -> %s, %sbox %i/%i -- %i/%i\n",
       dt_iop_colorspace_to_name(image_cst),
       dt_iop_colorspace_to_name(dt_iop_color_picker_get_active_cst(module)),
@@ -887,6 +887,13 @@ static void _pixelpipe_picker_cl(const int devid,
 
   if(err != CL_SUCCESS) goto error;
 
+  dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_PICKER, "pixelpipe picker CL",
+    piece->pipe, module, devid, roi, NULL, " %s -> %s, %sbox %i/%i -- %i/%i\n",
+    dt_iop_colorspace_to_name(image_cst),
+    dt_iop_colorspace_to_name(dt_iop_color_picker_get_active_cst(module)),
+    darktable.lib->proxy.colorpicker.primary_sample->denoise ? "denoised " : "",
+    box[0], box[1], box[2], box[3]);
+
   dt_iop_roi_t roi_copy = (dt_iop_roi_t)
     {.x      = roi->x + box[0],
      .y      = roi->y + box[1],
@@ -902,13 +909,6 @@ static void _pixelpipe_picker_cl(const int devid,
 
   const dt_iop_order_iccprofile_info_t *const profile =
     dt_ioppr_get_pipe_current_profile_info(module, piece->pipe);
-
-  dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe picker",
-    piece->pipe, module, devid, roi, NULL, " %s -> %s, %sbox %i/%i -- %i/%i\n",
-    dt_iop_colorspace_to_name(image_cst),
-    dt_iop_colorspace_to_name(dt_iop_color_picker_get_active_cst(module)),
-    darktable.lib->proxy.colorpicker.primary_sample->denoise ? "denoised " : "",
-    box[0], box[1], box[2], box[3]);
 
   dt_color_picker_helper(dsc, pixel, &roi_copy, box,
                          darktable.lib->proxy.colorpicker.primary_sample->denoise,
@@ -960,7 +960,7 @@ static void _pixelpipe_pick_samples(dt_develop_t *dev,
        !dt_color_picker_box(module, roi_in, sample, PIXELPIPE_PICKER_INPUT, box))
     {
       // pixel input is in display profile, hence the sample output will be as well
-      dt_print_pipe(DT_DEBUG_PIPE, "pixelpipe pick samples",
+      dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_PICKER, "pixelpipe pick samples",
         NULL, module, DT_DEVICE_NONE, roi_in, NULL, " %sbox %i/%i -- %i/%i\n",
         darktable.lib->proxy.colorpicker.primary_sample->denoise ? "denoised " : "",
         box[0], box[1], box[2], box[3]);

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -151,14 +151,15 @@ static void _backtransform_box(const int num,
                             box ? htp * in[3] : 0.0f };
   dt_dev_distort_backtransform(dev, fbox, num);
 
-  out[0] = fbox[0] / wd;
-  out[1] = fbox[1] / ht;
+  out[0] = CLIP(fbox[0] / wd);
+  out[1] = CLIP(fbox[1] / ht);
   if(box)
   {
-    out[2] = fbox[2] / wd;
-    out[3] = fbox[3] / ht;
+    out[2] = CLIP(fbox[2] / wd);
+    out[3] = CLIP(fbox[3] / ht);
   }
 }
+
 static void _init_picker(dt_iop_color_picker_t *picker,
                          dt_iop_module_t *module,
                          const dt_iop_color_picker_flags_t flags,
@@ -227,9 +228,8 @@ static gboolean _color_picker_callback_button_press(GtkWidget *button,
       if(   self->pick_box[0] == 0.0f && self->pick_box[1] == 0.0f
          && self->pick_box[2] == 1.0f && self->pick_box[3] == 1.0f)
       {
-        dt_boundingbox_t area = { 0.01f, 0.01f, 0.99f, 0.99f };
-        _backtransform_box(2, area, self->pick_box);
-
+        dt_boundingbox_t reset = { 0.02f, 0.02f, 0.98f, 0.98f };
+        _backtransform_box(2, reset, self->pick_box);
       }
       dt_lib_colorpicker_set_box_area(darktable.lib, self->pick_box);
     }

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -345,7 +345,7 @@ static void _iop_color_picker_pickerdata_ready_callback(gpointer instance,
     {
       if(module->color_picker_apply)
       {
-        dt_print_pipe(DT_DEBUG_PIPE, "color picker apply",
+        dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_PICKER, "color picker apply",
           pipe, module, DT_DEVICE_NONE, NULL, NULL,
           "%s%s.%s%s. point=%.3f - %.3f. area=%.3f - %.3f / %.3f - %.3f\n",
           picker->flags & DT_COLOR_PICKER_POINT ? " point" : "",
@@ -376,7 +376,7 @@ static void _color_picker_proxy_preview_pipe_callback(gpointer instance,
   dt_lib_module_t *module = darktable.lib->proxy.colorpicker.module;
   if(module)
   {
-    dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_VERBOSE, "picker update callback",
+    dt_print_pipe(DT_DEBUG_PIPE | DT_DEBUG_PICKER | DT_DEBUG_VERBOSE, "picker update callback",
       NULL, NULL, DT_DEVICE_NONE, NULL, NULL, "\n");
 
     // pixelpipe may have run because sample area changed or an iop,

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3451,41 +3451,33 @@ int button_pressed(dt_view_t *self,
     dt_boundingbox_t pbox = { zoom_x, zoom_y };
     dt_boundingbox_t zb;
     dt_color_picker_backtransform_box(dev, 1, pbox, zb);
-    const float zx = zb[0];
-    const float zy = zb[1];
 
     if(which == 1)
     {
-      // The default box will be a square with 1% of the image width
-      const float delta_x = 0.01f;
-      const float delta_y = delta_x * (float)dev->full.pipe->processed_width / (float)dev->full.pipe->processed_height;
-
       // FIXME: here and in mouse move use to dt_lib_colorpicker_set_{box_area,point} interface?
       // -- would require a different hack for figuring out base of the drag
       // hack: for box pickers, these represent the "base" point being dragged
-      sample->point[0] = zx;
-      sample->point[1] = zy;
+      sample->point[0] = zb[0];
+      sample->point[1] = zb[1];
 
       if(sample->size == DT_LIB_COLORPICKER_SIZE_BOX)
       {
-        // this is slightly more than as drawn, to give room for slop
-        const float handle_px = 2.0f;
-        float hx = handle_px / (procw * zoom_scale);
-        float hy = handle_px / (proch * zoom_scale);
+        const float eps = 0.05f / MAX(0.1f, zoom_scale);
+
         gboolean on_corner_prev_box = TRUE;
         // initialized to calm gcc-11
         float opposite_x = 0.f, opposite_y = 0.f;
 
-        if(fabsf(zx - sample->box[0]) <= hx)
+        if(feqf(zb[0], sample->box[0], eps))
           opposite_x = sample->box[2];
-        else if(fabsf(zx - sample->box[2]) <= hx)
+        else if(feqf(zb[0], sample->box[2], eps))
           opposite_x = sample->box[0];
         else
           on_corner_prev_box = FALSE;
 
-        if(fabsf(zy - sample->box[1]) <= hy)
+        if(feqf(zb[1], sample->box[1], eps))
           opposite_y = sample->box[3];
-        else if(fabsf(zy - sample->box[3]) <= hy)
+        else if(feqf(zb[1], sample->box[3], eps))
           opposite_y = sample->box[1];
         else
           on_corner_prev_box = FALSE;
@@ -3497,11 +3489,10 @@ int button_pressed(dt_view_t *self,
         }
         else
         {
-          dt_boundingbox_t fbox = { MAX(0.0, zoom_x - delta_x),
-                                    MAX(0.0, zoom_y - delta_y),
-                                    MIN(1.0, zoom_x + delta_x),
-                                    MIN(1.0, zoom_y + delta_y) };
-         dt_color_picker_backtransform_box(dev, 2, fbox, sample->box);
+          const float dx = 0.02f;
+          const float dy = dx * (float)dev->full.pipe->processed_width / (float)dev->full.pipe->processed_height;
+          const dt_boundingbox_t fbox = { zoom_x - dx, zoom_y - dy, zoom_x + dx, zoom_y + dy };
+          dt_color_picker_backtransform_box(dev, 2, fbox, sample->box);
         }
         dt_control_change_cursor(GDK_FLEUR);
       }
@@ -3524,8 +3515,8 @@ int button_pressed(dt_view_t *self,
           if(live_sample->size == DT_LIB_COLORPICKER_SIZE_BOX
              && (picker->flags & DT_COLOR_PICKER_AREA))
           {
-            if(zx < live_sample->box[0] || zx > live_sample->box[2]
-               || zy < live_sample->box[1] || zy > live_sample->box[3])
+            if(zb[0] < live_sample->box[0] || zb[0] > live_sample->box[2]
+               || zb[1] < live_sample->box[1] || zb[1] > live_sample->box[3])
               continue;
             dt_lib_colorpicker_set_box_area(darktable.lib, live_sample->box);
           }
@@ -3536,7 +3527,7 @@ int button_pressed(dt_view_t *self,
             float slop_px = MAX(26.0f, roundf(3.0f * zoom_scale));
             const float slop_x = slop_px / (procw * zoom_scale);
             const float slop_y = slop_px / (proch * zoom_scale);
-            if(fabsf(zx - live_sample->point[0]) > slop_x || fabsf(zy - live_sample->point[1]) > slop_y)
+            if(!feqf(zb[0], live_sample->point[0], slop_x) || !feqf(zb[1], live_sample->point[1], slop_y))
               continue;
             dt_lib_colorpicker_set_point(darktable.lib, live_sample->point);
           }
@@ -3551,7 +3542,7 @@ int button_pressed(dt_view_t *self,
       {
         // default is hardcoded this way
         // FIXME: color_pixer_proxy should have an dt_iop_color_picker_clear_area() function for this
-        dt_boundingbox_t reset = { 0.01f, 0.01f, 0.99f, 0.99f };
+        dt_boundingbox_t reset = { 0.02f, 0.02f, 0.98f, 0.98f };
         dt_boundingbox_t box;
         dt_color_picker_backtransform_box(dev, 2, reset, box);
         dt_lib_colorpicker_set_box_area(darktable.lib, box);


### PR DESCRIPTION
1. Allow again to take edges of the visible area colorpicker. Taking distortions into account.
2. Add a `DT_DEBUG_PICKER` option for better picker debugging, `-d picker` as the cli switch.

Fixes #16661