### PR TITLE
__builtin_assume_aligned helper work

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -179,6 +179,9 @@ typedef int32_t dt_mask_id_t;
 /* Helper to force stack vectors to be aligned on DT_CACHELINE_BYTES blocks to enable AVX2 */
 #define DT_IS_ALIGNED(x) __builtin_assume_aligned(x, DT_CACHELINE_BYTES)
 
+/* Helper for 4-float pixel vectors */
+#define DT_IS_ALIGNED_PIXEL(x) __builtin_assume_aligned(x, 16)
+
 #define DT_MODULE_VERSION 25 // version of dt's module interface
 
 // version of current performance configuration version

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -477,7 +477,7 @@ static inline void _transform_rgb_to_lab_matrix
 #endif
     for(size_t y = 0; y < stride; y += ch)
     {
-      float *const restrict in = __builtin_assume_aligned(image_out + y, 16);
+      float *const restrict in = DT_IS_ALIGNED_PIXEL(image_out + y);
       dt_aligned_pixel_t xyz; // inited in _ioppr_linear_rgb_matrix_to_xyz()
       dt_apply_transposed_color_matrix(in, *matrix_ptr, xyz);
       dt_XYZ_to_Lab(xyz, in);
@@ -492,8 +492,8 @@ static inline void _transform_rgb_to_lab_matrix
 #endif
     for(size_t y = 0; y < stride; y += ch)
     {
-      const float *const restrict in = __builtin_assume_aligned(image_in + y, 16);
-      float *const restrict out = __builtin_assume_aligned(image_out + y, 16);
+      const float *const restrict in = DT_IS_ALIGNED_PIXEL(image_in + y);
+      float *const restrict out = DT_IS_ALIGNED_PIXEL(image_out + y);
 
       dt_aligned_pixel_t xyz; // inited in _ioppr_linear_rgb_matrix_to_xyz()
       dt_apply_transposed_color_matrix(in, *matrix_ptr, xyz);
@@ -521,8 +521,8 @@ static inline void _transform_lab_to_rgb_matrix
 #endif
   for(size_t y = 0; y < stride; y += ch)
   {
-    const float *const restrict in = __builtin_assume_aligned(image_in + y, 16);
-    float *const restrict out = __builtin_assume_aligned(image_out + y, 16);
+    const float *const restrict in = DT_IS_ALIGNED_PIXEL(image_in + y);
+    float *const restrict out = DT_IS_ALIGNED_PIXEL(image_out + y);
 
     dt_aligned_pixel_t xyz;
     const float alpha = in[3];
@@ -583,8 +583,8 @@ static inline void _transform_matrix_rgb
 #endif
     for(size_t y = 0; y < stride; y += 4)
     {
-      const float *const restrict in = __builtin_assume_aligned(image_in + y, 16);
-      float *const restrict out = __builtin_assume_aligned(image_out + y, 16);
+      const float *const restrict in = DT_IS_ALIGNED_PIXEL(image_in + y);
+      float *const restrict out = DT_IS_ALIGNED_PIXEL(image_out + y);
       dt_aligned_pixel_t rgb;
 
       // linearize if non-linear input
@@ -640,8 +640,8 @@ static inline void _transform_matrix_rgb
 #endif
     for(size_t y = 0; y < stride; y += 4)
     {
-      const float *const restrict in = __builtin_assume_aligned(image_in + y, 16);
-      float *const restrict out = __builtin_assume_aligned(image_out + y, 16);
+      const float *const restrict in = DT_IS_ALIGNED_PIXEL(image_in + y);
+      float *const restrict out = DT_IS_ALIGNED_PIXEL(image_out + y);
 
       dt_apply_transposed_color_matrix(in, matrix, out);
     }

--- a/src/iop/blurs.c
+++ b/src/iop/blurs.c
@@ -574,8 +574,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
   if(!dt_iop_have_required_input_format(4, self, piece->colors, ivoid, ovoid, roi_in, roi_out))
     return;
 
-  const float *const restrict in = __builtin_assume_aligned(ivoid, 64);
-  float *const restrict out = __builtin_assume_aligned(ovoid, 64);
+  const float *const restrict in = DT_IS_ALIGNED(ivoid);
+  float *const restrict out = DT_IS_ALIGNED(ovoid);
 
   // Init the blur kernel
   const int radius = MAX(roundf(p->radius / scale), 2);

--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -121,7 +121,7 @@ static inline void make_noise(float *const output, const float noise, const size
       xoshiro128plus(state);
 
       const size_t index = (i * width + j) * 4;
-      float *const restrict pix_out = __builtin_assume_aligned(output + index, 16);
+      float *const restrict pix_out = DT_IS_ALIGNED_PIXEL(output + index);
       const float norm = pix_out[1];
 
       // create statistical noise
@@ -218,7 +218,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         dt_aligned_pixel_t RGB = { 0.f };
         for(size_t k = 0; k < 5; k++)
         {
-          const float *const restrict pix_in = __builtin_assume_aligned(input + (width * box[k].y + box[k].x) * 4, 16);
+          const float *const restrict pix_in = DT_IS_ALIGNED_PIXEL(input + (width * box[k].y + box[k].x) * 4);
           for_four_channels(c)
             RGB[c] += pix_in[c] / 5.f;
         }
@@ -227,7 +227,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         for(size_t jj = tl.y; jj < br.y; jj++)
           for(size_t ii = tl.x; ii < br.x; ii++)
           {
-            float *const restrict pix_out = __builtin_assume_aligned(output + (jj * width + ii) * 4, 16);
+            float *const restrict pix_out = DT_IS_ALIGNED_PIXEL(output + (jj * width + ii) * 4);
             for_four_channels(c)
               pix_out[c] = RGB[c];
           }

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -679,18 +679,18 @@ void process(struct dt_iop_module_t *self,
   dt_colormatrix_t output_matrix_trans;
   dt_colormatrix_transpose(output_matrix_trans, output_matrix);
 
-  const float *const restrict in = __builtin_assume_aligned(((const float *const restrict)ivoid), 64);
-  float *const restrict out = __builtin_assume_aligned(((float *const restrict)ovoid), 64);
-  const float *const restrict gamut_LUT = __builtin_assume_aligned(((const float *const restrict)d->gamut_LUT), 64);
+  const float *const restrict in = DT_IS_ALIGNED(((const float *const restrict)ivoid));
+  float *const restrict out = DT_IS_ALIGNED(((float *const restrict)ovoid));
+  const float *const restrict gamut_LUT = DT_IS_ALIGNED(((const float *const restrict)d->gamut_LUT));
 
-  const float *const restrict global = __builtin_assume_aligned((const float *const restrict)d->global, 16);
-  const float *const restrict highlights = __builtin_assume_aligned((const float *const restrict)d->highlights, 16);
-  const float *const restrict shadows = __builtin_assume_aligned((const float *const restrict)d->shadows, 16);
-  const float *const restrict midtones = __builtin_assume_aligned((const float *const restrict)d->midtones, 16);
+  const float *const restrict global = DT_IS_ALIGNED_PIXEL((const float *const restrict)d->global);
+  const float *const restrict highlights = DT_IS_ALIGNED_PIXEL((const float *const restrict)d->highlights);
+  const float *const restrict shadows = DT_IS_ALIGNED_PIXEL((const float *const restrict)d->shadows);
+  const float *const restrict midtones = DT_IS_ALIGNED_PIXEL((const float *const restrict)d->midtones);
 
-  const float *const restrict chroma = __builtin_assume_aligned((const float *const restrict)d->chroma, 16);
-  const float *const restrict saturation = __builtin_assume_aligned((const float *const restrict)d->saturation, 16);
-  const float *const restrict brilliance = __builtin_assume_aligned((const float *const restrict)d->brilliance, 16);
+  const float *const restrict chroma = DT_IS_ALIGNED_PIXEL((const float *const restrict)d->chroma);
+  const float *const restrict saturation = DT_IS_ALIGNED_PIXEL((const float *const restrict)d->saturation);
+  const float *const restrict brilliance = DT_IS_ALIGNED_PIXEL((const float *const restrict)d->brilliance);
 
   const gint mask_display
       = ((piece->pipe->type & DT_DEV_PIXELPIPE_FULL) && self->dev->gui_attached
@@ -2124,8 +2124,8 @@ void gui_init(dt_iop_module_t *self)
 
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(C_("section", "luminance ranges")), FALSE, FALSE, 0);
 
-  g->area = GTK_DRAWING_AREA(dt_ui_resize_wrap(NULL, 
-                                               0, 
+  g->area = GTK_DRAWING_AREA(dt_ui_resize_wrap(NULL,
+                                               0,
                                                "plugins/darkroom/colorbalancergb/graphheight"));
   g_object_set_data(G_OBJECT(g->area), "iop-instance", self);
   dt_action_define_iop(self, NULL, N_("graph"), GTK_WIDGET(g->area), NULL);

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -882,7 +882,7 @@ void process(struct dt_iop_module_t *self,
 #endif
   for(size_t k = 0; k < npixels; k++)
   {
-    const float *const restrict pix_in = __builtin_assume_aligned(in + k * 4, 16);
+    const float *const restrict pix_in = DT_IS_ALIGNED_PIXEL(in + k * 4);
     float *const restrict uv = UV + k * 2;
 
     // Convert to XYZ D65
@@ -923,8 +923,8 @@ void process(struct dt_iop_module_t *self,
     {
       const size_t k = (size_t)row * owidth + col;
 
-      const float *const restrict pix_in = __builtin_assume_aligned(in + k * 4, 16);
-      float *const restrict pix_out = __builtin_assume_aligned(out + k * 4, 16);
+      const float *const restrict pix_in = DT_IS_ALIGNED_PIXEL(in + k * 4);
+      float *const restrict pix_out = DT_IS_ALIGNED_PIXEL(out + k * 4);
       float *const restrict corrections_out = corrections + k * 2;
 
       float *const restrict uv = UV + k * 2;
@@ -986,7 +986,7 @@ void process(struct dt_iop_module_t *self,
     for(size_t k = 0; k < npixels; k++)
     {
       const float *const restrict corrections_out = corrections + k * 2;
-      float *const restrict pix_out = __builtin_assume_aligned(out + k * 4, 16);
+      float *const restrict pix_out = DT_IS_ALIGNED_PIXEL(out + k * 4);
 
       // Apply the corrections
       pix_out[0] += corrections_out[0]; // WARNING: hue is an offset
@@ -1016,7 +1016,7 @@ void process(struct dt_iop_module_t *self,
 #endif
     for(size_t k = 0; k < npixels; k++)
     {
-      float *const restrict pix_out = __builtin_assume_aligned(out + k * 4, 16);
+      float *const restrict pix_out = DT_IS_ALIGNED_PIXEL(out + k * 4);
       const float *const restrict corrections_out = corrections + k * 2;
 
       const float val = pix_out[2] * B_norm;
@@ -2457,7 +2457,7 @@ void gui_init(struct dt_iop_module_t *self)
     (dt_ui_resize_wrap(NULL,
                        0,
                        "plugins/darkroom/colorequal/graphheight"));
-                       
+
   g_object_set_data(G_OBJECT(g->area), "iop-instance", self);
   dt_action_define_iop(self, NULL, N_("graph"), GTK_WIDGET(g->area), &_action_def_coloreq);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->area), _("double-click to reset the curve\nmiddle click to toggle sliders visibility\nalt+scroll to change page"));

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1142,7 +1142,7 @@ inline static void inpaint_noise(const float *const in, const float *const mask,
       const size_t idx = i * width + j;
       const size_t index = idx * 4;
       const float weight = mask[idx];
-      const float *const restrict pix_in = __builtin_assume_aligned(in + index, 16);
+      const float *const restrict pix_in = DT_IS_ALIGNED_PIXEL(in + index);
       dt_aligned_pixel_t noise = { 0.f };
       dt_aligned_pixel_t sigma = { 0.f };
       const int DT_ALIGNED_ARRAY flip[4] = { TRUE, FALSE, TRUE, FALSE };
@@ -1179,9 +1179,9 @@ inline static void wavelets_reconstruct_RGB(const float *const restrict HF, cons
     const float alpha = mask[k / 4];
 
     // cache RGB wavelets scales just to be sure the compiler doesn't reload them
-    const float *const restrict HF_c = __builtin_assume_aligned(HF + k, 16);
-    const float *const restrict LF_c = __builtin_assume_aligned(LF + k, 16);
-    const float *const restrict TT_c = __builtin_assume_aligned(texture + k, 16);
+    const float *const restrict HF_c = DT_IS_ALIGNED_PIXEL(HF + k);
+    const float *const restrict LF_c = DT_IS_ALIGNED_PIXEL(LF + k);
+    const float *const restrict TT_c = DT_IS_ALIGNED_PIXEL(texture + k);
 
     // synthesize the max of all RGB channels texture as a flat texture term for the whole pixel
     // this is useful if only 1 or 2 channels are clipped, so we transfer the valid/sharpest texture on the other
@@ -1257,9 +1257,9 @@ static inline void wavelets_reconstruct_ratios(const float *const restrict HF,
     const float alpha = mask[k / 4];
 
     // cache RGB wavelets scales just to be sure the compiler doesn't reload them
-    const float *const restrict HF_c = __builtin_assume_aligned(HF + k, 16);
-    const float *const restrict LF_c = __builtin_assume_aligned(LF + k, 16);
-    const float *const restrict TT_c = __builtin_assume_aligned(texture + k, 16);
+    const float *const restrict HF_c = DT_IS_ALIGNED_PIXEL(HF + k);
+    const float *const restrict LF_c = DT_IS_ALIGNED_PIXEL(LF + k);
+    const float *const restrict TT_c = DT_IS_ALIGNED_PIXEL(texture + k);
 
     // synthesize the max of all RGB channels texture as a flat texture term for the whole pixel
     // this is useful if only 1 or 2 channels are clipped, so we transfer the valid/sharpest texture on the other

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -350,9 +350,9 @@ void process(struct dt_iop_module_t *const self, dt_dev_pixelpipe_iop_t *const p
     soft_clip_comp[c] = d->soft_clip_comp;
   }
   // Unpack vectors one by one with extra pragmas to be sure the compiler understands they can be vectorized
-  const float *const restrict Dmin = __builtin_assume_aligned(d->Dmin, 16);
-  const float *const restrict wb_high = __builtin_assume_aligned(d->wb_high, 16);
-  const float *const restrict offset = __builtin_assume_aligned(d->offset, 16);
+  const float *const restrict Dmin = DT_IS_ALIGNED_PIXEL(d->Dmin);
+  const float *const restrict wb_high = DT_IS_ALIGNED_PIXEL(d->wb_high);
+  const float *const restrict offset = DT_IS_ALIGNED_PIXEL(d->offset);
 
 #ifdef _OPENMP
   #pragma omp parallel for default(none) \

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -131,8 +131,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const float *const upper_color = dt_iop_overexposed_colors[colorscheme][0];
   const float *const lower_color = dt_iop_overexposed_colors[colorscheme][1];
 
-  const float *const restrict in = __builtin_assume_aligned((const float *const restrict)ivoid, 64);
-  float *const restrict out = __builtin_assume_aligned((float *const restrict)ovoid, 64);
+  const float *const restrict in = DT_IS_ALIGNED((const float *const restrict)ivoid);
+  float *const restrict out = DT_IS_ALIGNED((float *const restrict)ovoid);
 
   const dt_iop_order_iccprofile_info_t *const current_profile = dt_ioppr_get_pipe_current_profile_info(self, piece->pipe);
   const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_histogram_profile_info(dev);


### PR DESCRIPTION
Introduced a DT_IS_ALIGNED_PIXEL macro for `__builtin_assume_aligned(x, 16)` and make the code using it.

Replaced some __builtin_assume_aligned(x, 64) with the appropriate macro.