### PR TITLE
performance: list-length check optimizations

### DIFF
--- a/src/common/act_on.c
+++ b/src/common/act_on.c
@@ -82,6 +82,16 @@ static void _insert_in_list(GList **list,
   }
 }
 
+static gboolean _slist_length_equal(GSList *l1, GSList *l2)
+{
+  while (l1 && l2)
+  {
+    l1 = g_slist_next(l1);
+    l2 = g_slist_next(l2);
+  }
+  return !l1 && !l2;
+}
+
 // test if the cache is still valid
 static gboolean _test_cache(dt_act_on_cache_t *cache)
 {
@@ -90,7 +100,7 @@ static gboolean _test_cache(dt_act_on_cache_t *cache)
   if(cache->ok
      && cache->image_over == mouseover
      && cache->inside_table == dt_ui_thumbtable(darktable.gui->ui)->mouse_inside
-     && g_slist_length(cache->active_imgs) == g_slist_length(darktable.view_manager->active_images))
+     && _slist_length_equal(cache->active_imgs, darktable.view_manager->active_images))
   {
     // we test active images if mouse outside table
     gboolean ok = TRUE;

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1996,7 +1996,7 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
           g_free(name); // free the original filename
         }
 
-        if(g_list_length(list) > 0) subquery = dt_util_glist_to_str(" OR ", list);
+        if(list) subquery = dt_util_glist_to_str(" OR ", list);
         g_list_free_full(list, g_free); // free the SQL clauses as well as the list
       }
       if(g_strv_length(elems) > 1)
@@ -2031,7 +2031,7 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
           g_free(name); // free the original filename
         }
 
-        if(g_list_length(list) > 0)
+        if(list)
         {
           if(subquery)
           {

--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2022 darktable developers.
+    Copyright (C) 2022-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -1420,7 +1420,7 @@ static gboolean _event_band_draw(GtkWidget *widget, cairo_t *cr, gpointer user_d
   }
 
   // draw the icons
-  if(g_list_length(range->icons) > 0)
+  if(range->icons)
   {
     // we do a first pass to determine the max icon width
     int last = 0;

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -130,6 +130,16 @@ static void _fill_text_view(const uint32_t i,
 
 static void _write_metadata(dt_lib_module_t *self);
 
+static gboolean _list_length_equal(GList *l1, GList *l2)
+{
+  while (l1 && l2)
+  {
+    l1 = g_list_next(l1);
+    l2 = g_list_next(l2);
+  }
+  return !l1 && !l2;
+}
+
 void gui_update(dt_lib_module_t *self)
 {
   dt_lib_metadata_t *d = (dt_lib_metadata_t *)self->data;
@@ -138,7 +148,7 @@ void gui_update(dt_lib_module_t *self)
 
   // first we want to make sure the list of images to act on has changed
   // this is not the case if mouse hover change but still stay in selection for ex.
-  if(imgs && d->last_act_on && g_list_length(imgs) == g_list_length(d->last_act_on))
+  if(imgs && d->last_act_on && _list_length_equal(imgs, d->last_act_on))
   {
     gboolean changed = FALSE;
     GList *l = d->last_act_on;

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -3337,7 +3337,7 @@ static void _manage_editor_basics_toggle(GtkWidget *button, dt_lib_module_t *sel
   if(d->editor_reset) return;
   const gboolean state = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
   // we don't allow that to be false if there's no group or search
-  if(!state && g_list_length(d->edit_groups) == 0 && !d->edit_show_search)
+  if(!state && !d->edit_groups && !d->edit_show_search)
   {
     d->editor_reset = TRUE;
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
@@ -3353,7 +3353,7 @@ static void _manage_editor_search_toggle(GtkWidget *button, dt_lib_module_t *sel
   if(d->editor_reset) return;
   const gboolean state = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
   // we don't allow that to be false if there's no group or quick access
-  if(!state && g_list_length(d->edit_groups) == 0 && !d->edit_basics_show)
+  if(!state && !d->edit_groups && !d->edit_basics_show)
   {
     d->editor_reset = TRUE;
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -682,7 +682,7 @@ static void _import_clicked(GtkWidget *w, gpointer user_data)
             gtk_widget_show_all(dialog_overwrite_import);
 
             // disable check button and skip button when dealing with one style
-            if(g_slist_length(filenames) == 1)
+            if(g_list_is_singleton(filenames))
             {
               gtk_widget_set_sensitive(overwrite_dialog_check_button, FALSE);
               gtk_dialog_set_response_sensitive(GTK_DIALOG(dialog_overwrite_import), GTK_RESPONSE_NONE, FALSE);


### PR DESCRIPTION
Use NULL check instead of calling list_length function when checking for empty lists.  Added utility functions to check whether two GList or GSList are of identical length.

[Just noticed that I had never pushed this commit from back in October....]
