### PR TITLE
enable $(NL) in watermark text

### DIFF
--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -442,7 +442,12 @@ static char *_get_base_value(dt_variables_params_t *params, char **variable)
   else if(_has_prefix(variable, "EXIF.ISO") || _has_prefix(variable, "EXIF_ISO"))
     result = g_strdup_printf("%d", params->data->exif_iso);
   else if(_has_prefix(variable, "NL") && g_strcmp0(params->jobcode, "infos") == 0)
-    result = g_strdup_printf("\n");
+  {
+    if (params->use_html_newline)
+      result = g_strdup_printf("&#13;");
+    else
+      result = g_strdup_printf("\n");
+  }
   else if(_has_prefix(variable, "EXIF.EXPOSURE.BIAS")
           || _has_prefix(variable, "EXIF_EXPOSURE_BIAS"))
   {
@@ -1300,6 +1305,7 @@ char *dt_variables_expand(dt_variables_params_t *params,
 
   _cleanup_expansion(params);
 
+  fprintf(stderr,"varexp: %s\n",result);
   return result;
 }
 

--- a/src/common/variables.h
+++ b/src/common/variables.h
@@ -44,6 +44,9 @@ typedef struct dt_variables_params_t
   /** do we need to escape variables text for markup ? */
   gboolean escape_markup;
 
+  /** do we need to use an HTML entity for new lines instead of a newline character? */
+  gboolean use_html_newline;
+
   /** img cache already controlled */
   void *img;
 

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -560,6 +560,7 @@ static gchar *_watermark_get_svgdoc(dt_iop_module_t *self, dt_iop_watermark_data
     dt_image_full_path(image->id, image_path, sizeof(image_path), &from_cache);
     params->filename = image_path;
     params->jobcode = "infos";
+    params->use_html_newline = TRUE;
     params->sequence = 0;
     params->imgid = image->id;
     dt_variables_set_tags_flags(params, flags);


### PR DESCRIPTION
This permits multiline text in the 'simple-text', 'simple-text-shadow', and 'fixed-size-text' standard watermarks.