### PR TITLE
Remove checking for exiftool at build time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,15 +392,6 @@ if(USE_XMLLINT)
   endif(${Xmllint_BIN} STREQUAL "Xmllint_BIN-NOTFOUND")
 endif(USE_XMLLINT)
 
-find_program(exiftool_BIN exiftool)
-if(${exiftool_BIN} STREQUAL "exiftool_BIN-NOTFOUND")
-  message(STATUS "Missing exiftool")
-  set(HAVE_EXIFTOOL 0)
-else()
-  message(STATUS "Found exiftool")
-  set(HAVE_EXIFTOOL 1)
-endif()
-
 # done with looking for programs
 message(STATUS "All external programs found")
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -5,14 +5,10 @@ if (BUILD_NOISE_TOOLS)
   add_subdirectory(noise)
 endif()
 
-set(TOOLS common.sh purge_from_cache.sh purge_non_existing_images.sh purge_unused_tags.sh)
+set(TOOLS common.sh extract_wb_from_images.sh purge_from_cache.sh purge_non_existing_images.sh purge_unused_tags.sh)
 set(TOOLSWIN purge_nonexistent_images.bat)
 
 if ((NOT WIN32) OR BUILD_MSYS2_INSTALL)
-
-  if(HAVE_EXIFTOOL)
-    set(TOOLS ${TOOLS} extract_wb_from_images.sh)
-  endif()
 
   install(PROGRAMS ${TOOLS} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/darktable/tools)
 

--- a/tools/extract_wb_from_images.sh
+++ b/tools/extract_wb_from_images.sh
@@ -6,6 +6,13 @@
 
 commandline="$0 $*"
 
+# check for exiftool
+_etpath="$(which exiftool)"
+if [ ! -f "$_etpath" -o ! -x "$_etpath" ] ; then
+    echo "error: 'exiftool' not found, please ensure it is installed and added to path."
+    exit 1
+fi
+
 # handle command line arguments
 option="$1"
 if [ "${option}" = "-h" ] || [ "${option}" = "--help" ]; then


### PR DESCRIPTION
It's not actually used for anything during the build.

The script is useful and should always be installed, exiftool could always be added later.