### PR TITLE
[imageio] WebP loader improvements

### DIFF
--- a/src/imageio/imageio_webp.c
+++ b/src/imageio/imageio_webp.c
@@ -64,6 +64,15 @@ dt_imageio_retval_t dt_imageio_open_webp(dt_image_t *img, const char *filename, 
   // so the number of pixels will never overflow int
   const int npixels = width * height;
 
+  uint8_t *int_RGBA_buf = dt_alloc_align_uint8(npixels * 4);
+  int_RGBA_buf = WebPDecodeRGBAInto(read_buffer, filesize, int_RGBA_buf, npixels * 4, width * 4);
+  if(!int_RGBA_buf)
+  {
+    g_free(read_buffer);
+    dt_print(DT_DEBUG_ALWAYS,"[webp_open] failed to decode file: %s\n", filename);
+    return DT_IMAGEIO_LOAD_FAILED;
+  }
+
   img->width = width;
   img->height = height;
   img->buf_dsc.channels = 4;
@@ -73,17 +82,9 @@ dt_imageio_retval_t dt_imageio_open_webp(dt_image_t *img, const char *filename, 
   if(!mipbuf)
   {
     g_free(read_buffer);
+    dt_free_align(int_RGBA_buf);
     dt_print(DT_DEBUG_ALWAYS, "[webp_open] could not alloc full buffer for image: %s\n", img->filename);
     return DT_IMAGEIO_CACHE_FULL;
-  }
-
-  uint8_t *int_RGBA_buf = dt_alloc_align_uint8(npixels * 4);
-  int_RGBA_buf = WebPDecodeRGBAInto(read_buffer, filesize, int_RGBA_buf, npixels * 4, width * 4);
-  if(!int_RGBA_buf)
-  {
-    g_free(read_buffer);
-    dt_print(DT_DEBUG_ALWAYS,"[webp_open] failed to decode file: %s\n", filename);
-    return DT_IMAGEIO_LOAD_FAILED;
   }
 
 #ifdef _OPENMP

--- a/src/imageio/imageio_webp.c
+++ b/src/imageio/imageio_webp.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2022-2023 darktable developers.
+    Copyright (C) 2022-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,8 +15,6 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
-
-#include <inttypes.h>
 
 #include <webp/decode.h>
 #include <webp/mux.h>


### PR DESCRIPTION
The improvements are as follows:
- Removed unused #include
- Call dt_mipmap_cache_alloc only after successful file decoding
- The conversion of decoded data into the format expected by darktable is accelerated due to use of SIMD and nontemporal writes

It should be noted, however, that the speedup will be imperceptible relative to code without vectorization, as the difference is within a few microseconds even for quite large files.
