### PR TITLE
Display OpenCL memory usage with a warning when it exceeds available in debug logs and a bug fix

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -3428,10 +3428,18 @@ void dt_opencl_memory_statistics(int devid,
         darktable.opencl->dev[devid].memory_in_use);
 
   if(darktable.unmuted & DT_DEBUG_MEMORY)
-    dt_print(DT_DEBUG_OPENCL,
-             "[opencl memory] device %d: %zu bytes (%.1f MB) in use\n",
+  {
+      dt_print(DT_DEBUG_OPENCL,
+             "[opencl memory] device %d: %zu bytes (%.1f MB) in use, %.1f MB available GPU memory, %.1f MB global GPU mem size\n",
              devid, darktable.opencl->dev[devid].memory_in_use,
-             (float)darktable.opencl->dev[devid].memory_in_use/(1024*1024));
+             (float)darktable.opencl->dev[devid].memory_in_use/(1024*1024),
+             (float)darktable.opencl->dev[devid].used_available/(1024*1024),
+             (float)darktable.opencl->dev[devid].max_global_mem/(1024*1024));
+      if (darktable.opencl->dev[devid].memory_in_use > darktable.opencl->dev[devid].used_available)
+      dt_print(DT_DEBUG_OPENCL,
+              "[opencl memory] Warning, device %d used more GPU memory than available\n",
+              devid);
+  }
 }
 
 /* amount of graphics memory declared as available depends on max_global_mem and

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -3501,7 +3501,8 @@ void dt_opencl_check_tuning(const int devid)
   else
   {
     // calculate data from fractions
-    const size_t disposable = allmem - DT_OPENCL_DEFAULT_HEADROOM * 1024ul * 1024ul;
+    const size_t default_headroom = DT_OPENCL_DEFAULT_HEADROOM * 1024ul * 1024ul;
+    const size_t disposable = allmem > default_headroom ? allmem - default_headroom : 0;
     const int fraction = MIN(1024lu, MAX(0, res->fractions[res->group + 3]));
     cl->dev[devid].used_available =
       MAX(256ul * 1024ul * 1024ul, disposable / 1024ul * fraction);


### PR DESCRIPTION
To aid in investigation of this issue: https://github.com/darktable-org/darktable/issues/16641 I updated the debug memory information to record the available memory and global memory per GPU device. The debug will also display a warning when this happen.

Using the debug information I discovered a bug in the available memory calculation when the global memory is smaller than the headroom. The second commit is a bug fix.

There is still a bug that we are using more opencl memory (2x to 4x) than available when during tiling. The changes in this PR should aid in discovering the root cause.