### PR TITLE
[imageio] RGBE loader code improvements

### DIFF
--- a/src/imageio/imageio_rgbe.c
+++ b/src/imageio/imageio_rgbe.c
@@ -461,7 +461,8 @@ dt_imageio_retval_t dt_imageio_open_rgbe(dt_image_t *img,
   if(!buf)
     goto error_cache_full;
 
-  rgbe_buf = dt_alloc_align_float((size_t) img->width * img->height * 4);
+  // The decoder writes three RGB channels to rgbe_buf, so size = number of pixels * 3
+  rgbe_buf = dt_alloc_align_float((size_t) img->width * img->height * 3);
   if(!rgbe_buf)
     goto rgbe_failed;
 

--- a/src/imageio/imageio_rgbe.c
+++ b/src/imageio/imageio_rgbe.c
@@ -450,7 +450,6 @@ dt_imageio_retval_t dt_imageio_open_rgbe(dt_image_t *img,
   if(!f)
     return DT_IMAGEIO_LOAD_FAILED;
 
-  float *rgbe_buf = NULL;
   rgbe_header_info info;
   if(RGBE_ReadHeader(f, &img->width, &img->height, &info) != RGBE_RETURN_SUCCESS)
     goto rgbe_failed;
@@ -462,12 +461,15 @@ dt_imageio_retval_t dt_imageio_open_rgbe(dt_image_t *img,
     goto error_cache_full;
 
   // The decoder writes three RGB channels to rgbe_buf, so size = number of pixels * 3
-  rgbe_buf = dt_alloc_align_float((size_t) img->width * img->height * 3);
+  float *rgbe_buf = dt_alloc_align_float((size_t) img->width * img->height * 3);
   if(!rgbe_buf)
     goto rgbe_failed;
 
   if(RGBE_ReadPixels_RLE(f, rgbe_buf, img->width, img->height) != RGBE_RETURN_SUCCESS)
+  {
+    dt_free_align(rgbe_buf);
     goto rgbe_failed;
+  }
 
   fclose(f);
 
@@ -518,7 +520,6 @@ dt_imageio_retval_t dt_imageio_open_rgbe(dt_image_t *img,
 
 rgbe_failed:
   fclose(f);
-  dt_free_align(rgbe_buf);
   return DT_IMAGEIO_LOAD_FAILED;
 
 error_cache_full:


### PR DESCRIPTION
The improvements are as follows:

- Reduce RGBE decoding buffer size, it was bigger than needed
- Call `dt_mipmap_cache_alloc` only after successful file decoding

Also, memory for `rgbe_buf` has not yet been allocated in two places of the code at the time of `goto rgbe_failed`, where this memory was freed. This takes advantage of the fact that freeing a NULL address is valid and does nothing. But this is not a very reliable programming style. Therefore, I remove memory freeing from the goto point, it will be done directly in the place where it is needed.

After that, the early initialization `float *rgbe_buf = NULL;` was also unnecessary.