### PR TITLE
[GUI] One of the actions on the image in the censorize module is pixelization, not pixellation

### DIFF
--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -1,6 +1,6 @@
 /*
   This file is part of darktable,
-  Copyright (C) 2020-2023 darktable developers.
+  Copyright (C) 2020-2024 darktable developers.
 
   darktable is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -48,7 +48,7 @@ DT_MODULE_INTROSPECTION(1, dt_iop_censorize_params_t)
 typedef struct dt_iop_censorize_params_t
 {
   float radius_1;              // $MIN: 0.0 $MAX: 500.0 $DEFAULT: 0.0  $DESCRIPTION: "input blur radius"
-  float pixelate;              // $MIN: 0.0 $MAX: 500.0 $DEFAULT: 0.0 $DESCRIPTION: "pixellation radius"
+  float pixelate;              // $MIN: 0.0 $MAX: 500.0 $DEFAULT: 0.0 $DESCRIPTION: "pixelization radius"
   float radius_2;              // $MIN: 0.0 $MAX: 500.0 $DEFAULT: 0.0  $DESCRIPTION: "output blur radius"
   float noise;                 // $MIN: 0.0 $MAX: 1.0   $DEFAULT: 0.0   $DESCRIPTION: "noise level"
 } dt_iop_censorize_params_t;
@@ -410,9 +410,9 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->noise = dt_bauhaus_slider_from_params(self, N_("noise"));
 
-  gtk_widget_set_tooltip_text(g->radius_1, _("radius of gaussian blur before pixellation"));
-  gtk_widget_set_tooltip_text(g->radius_2, _("radius of gaussian blur after pixellation"));
-  gtk_widget_set_tooltip_text(g->pixelate, _("radius of the intermediate pixellation"));
+  gtk_widget_set_tooltip_text(g->radius_1, _("radius of gaussian blur before pixelization"));
+  gtk_widget_set_tooltip_text(g->radius_2, _("radius of gaussian blur after pixelization"));
+  gtk_widget_set_tooltip_text(g->pixelate, _("radius of the intermediate pixelization"));
   gtk_widget_set_tooltip_text(g->noise, _("amount of noise to add at the end"));
 }
 
@@ -421,4 +421,3 @@ void gui_init(struct dt_iop_module_t *self)
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-


### PR DESCRIPTION

See, for example, https://cloudinary.com/glossary/pixelization:


"`Pixelization` ... refers to the intentional process of reducing the resolution of an image by replacing groups of pixels with larger, uniform squares or rectangles. This technique is commonly used for privacy protection, censorship, or creative purposes...

On the other hand, `pixelation` can refer to the unintended, visible pixels in an image that occur due to low resolution, excessive compression, or scaling up a small image beyond its original dimensions."
