### PR TITLE
enable macOS CMD-key for image selection

### DIFF
--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -968,7 +968,8 @@ static gboolean _event_main_release(GtkWidget *widget,
       dt_selection_select_single(darktable.selection, thumb->imgid);
     else if(dt_modifier_is(event->state, GDK_MOD1_MASK))
       dt_selection_select_single(darktable.selection, thumb->imgid);
-    else if(dt_modifier_is(event->state, GDK_CONTROL_MASK))
+    else if(dt_modifier_is(event->state, GDK_CONTROL_MASK)
+            || dt_modifier_is(event->state, GDK_MOD2_MASK))
       dt_selection_toggle(darktable.selection, thumb->imgid);
     else if(dt_modifier_is(event->state, GDK_SHIFT_MASK))
       dt_selection_select_range(darktable.selection, thumb->imgid);


### PR DESCRIPTION
On macOS it is common to use the CMD-key to select multiple items. This PR allows to use both CTRL as well as CMD.

fixes #16739