### PR TITLE
rename 'alt' key to 'option' on macos

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -111,7 +111,11 @@ const struct _modifier_name
 } modifier_string[]
   = { { GDK_SHIFT_MASK  , N_("shift") },
       { GDK_CONTROL_MASK, N_("ctrl" ) },
+#ifdef __APPLE__
+      { GDK_MOD1_MASK   , N_("option") },
+#else
       { GDK_MOD1_MASK   , N_("alt"  ) },
+#endif
       { GDK_MOD2_MASK   , N_("cmd"  ) },
       { GDK_MOD5_MASK   , N_("altgr") },
       { 0, NULL } };

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1358,7 +1358,11 @@ static gchar *_mouse_action_get_string(dt_mouse_action_t *ma)
   if(ma->mods & GDK_CONTROL_MASK)
     atxt = dt_util_dstrcat(atxt, "%s+", _("ctrl"));
   if(ma->mods & GDK_MOD1_MASK   )
+#ifdef __APPLE__
+    atxt = dt_util_dstrcat(atxt, "%s+", _("option"));
+#else
     atxt = dt_util_dstrcat(atxt, "%s+", _("alt"));
+#endif
 
   switch(ma->action)
   {


### PR DESCRIPTION
On macOS the `alt` key is named `option`.

fixes #16766