### PR TITLE
Again a round of clang related OMP fixes

### DIFF
--- a/src/common/eigf.h
+++ b/src/common/eigf.h
@@ -84,7 +84,7 @@ static inline void eigf_variance_analysis(const float *const restrict guide, // 
   float maxg2 = 0.0f;
   float minmg = 10000000.0f;
   float maxmg = 0.0f;
-  DT_OMP_FOR_SIMD(reduction(max:maxg, maxm, maxg2, maxmg) reduction(min:ming, minm, ming2, minmg))
+  DT_OMP_FOR(reduction(max:maxg, maxm, maxg2, maxmg) reduction(min:ming, minm, ming2, minmg))
   for(size_t k = 0; k < Ndim; k++)
   {
     const float pixelg = guide[k];
@@ -137,7 +137,7 @@ static inline void eigf_variance_analysis_no_mask(const float *const restrict gu
   float maxg = 0.0f;
   float ming2 = 10000000.0f;
   float maxg2 = 0.0f;
-  DT_OMP_FOR_SIMD(reduction(max:maxg, maxg2) reduction(min:ming, ming2))
+  DT_OMP_FOR(reduction(max:maxg, maxg2) reduction(min:ming, ming2))
   for(size_t k = 0; k < Ndim; k++)
   {
     const float pixelg = guide[k];
@@ -205,7 +205,7 @@ void eigf_blending_no_mask(float *const restrict image,
                   const dt_iop_guided_filter_blending_t filter,
                   const float feathering)
 {
-  DT_OMP_FOR_SIMD(aligned(image, av:64))
+  DT_OMP_FOR()
   for(size_t k = 0; k < Ndim; k++)
   {
     const float avg_g = av[k * 2];
@@ -295,11 +295,11 @@ static inline void fast_eigf_surface_blur(float *const restrict image,
   }
 
 clean:
-  if(av) dt_free_align(av);
-  if(ds_av) dt_free_align(ds_av);
-  if(ds_mask) dt_free_align(ds_mask);
-  if(ds_image) dt_free_align(ds_image);
-  if(mask) dt_free_align(mask);
+  dt_free_align(av);
+  dt_free_align(ds_av);
+  dt_free_align(ds_mask);
+  dt_free_align(ds_image);
+  dt_free_align(mask);
 }
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py

--- a/src/common/fast_guided_filter.h
+++ b/src/common/fast_guided_filter.h
@@ -100,7 +100,7 @@ static inline void interpolate_bilinear(const float *const restrict in,
                                         const size_t ch)
 {
   // Fast vectorized bilinear interpolation on ch channels
-  DT_OMP_FOR_SIMD(collapse(2))
+  DT_OMP_FOR(collapse(2))
   for(size_t i = 0; i < height_out; i++)
   {
     for(size_t j = 0; j < width_out; j++)

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1096,7 +1096,7 @@ inline static void inpaint_noise(const float *const in, const float *const mask,
   // this creates "particules" in highlights, that will help the implicit partial derivative equation
   // solver used in wavelets reconstruction to generate texture
 
-  DT_OMP_FOR_SIMD(collapse(2))
+  DT_OMP_FOR(collapse(2))
   for(size_t i = 0; i < height; i++)
     for(size_t j = 0; j < width; j++)
     {
@@ -1417,7 +1417,7 @@ static inline void filmic_split_v1(const float *const restrict in,
   const dt_aligned_pixel_t output_power
     = { data->output_power, data->output_power, data->output_power, data->output_power };
 
-  DT_OMP_FOR_SIMD()
+  DT_OMP_FOR()
   for(size_t k = 0; k < height * width * 4; k += 4)
   {
     const float *const restrict pix_in = in + k;
@@ -1505,7 +1505,7 @@ static inline void filmic_chroma_v1(const float *const restrict in, float *const
                                     const dt_iop_filmic_rgb_spline_t spline, const int variant, const size_t width,
                                     const size_t height)
 {
-  DT_OMP_FOR_SIMD()
+  DT_OMP_FOR()
   for(size_t k = 0; k < height * width * 4; k += 4)
   {
     const float *const restrict pix_in = in + k;
@@ -1565,7 +1565,7 @@ static inline void filmic_chroma_v2_v3(const float *const restrict in,
                                        const size_t height,
                                        const dt_iop_filmicrgb_colorscience_type_t colorscience_version)
 {
-  DT_OMP_FOR_SIMD()
+  DT_OMP_FOR()
   for(size_t k = 0; k < 4 * height * width; k += 4)
   {
     const float *const restrict pix_in = in + k;
@@ -1883,7 +1883,7 @@ static inline void filmic_chroma_v4(const float *const restrict in,
   const float norm_min = exp_tonemapping_v2(0.f, data->grey_source, data->black_source, data->dynamic_range);
   const float norm_max = exp_tonemapping_v2(1.f, data->grey_source, data->black_source, data->dynamic_range);
 
-  DT_OMP_FOR_SIMD()
+  DT_OMP_FOR()
   for(size_t k = 0; k < 4 * height * width; k += 4)
   {
     const float *const restrict pix_in = in + k;
@@ -1934,7 +1934,7 @@ static inline void filmic_split_v4(const float *const restrict in,
                                  export_input_matrix_trans, export_output_matrix, export_output_matrix_trans,
                                  work_profile, export_profile);
 
-  DT_OMP_FOR_SIMD()
+  DT_OMP_FOR()
   for(size_t k = 0; k < 4 * height * width; k += 4)
   {
     const float *const restrict pix_in = in + k;
@@ -1986,7 +1986,7 @@ static inline void filmic_v5(const float *const restrict in, float *const restri
   const float norm_min = exp_tonemapping_v2(0.f, data->grey_source, data->black_source, data->dynamic_range);
   const float norm_max = exp_tonemapping_v2(1.f, data->grey_source, data->black_source, data->dynamic_range);
 
-  DT_OMP_FOR_SIMD()
+  DT_OMP_FOR()
   for(size_t k = 0; k < height * width * 4; k += 4)
   {
     const float *const restrict pix_in = in + k;


### PR DESCRIPTION
clang compiler gives more warnings about incorrect vectorising due to omp simd code.

1. Checked all warnings and fixed.
2. the bilateral code is highly suspicious anyway
3. some superfluos check removed

Inspired to check from #16781