### PR TITLE
darktable.css - added css to manage script_manager power button and label

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2319,3 +2319,17 @@ Details :
 {
   margin: 0.07em 0.28em;
 }
+
+/* script_manager power button */
+button#pb_off 
+{ 
+  opacity: 0.5; 
+}
+button#pb_on 
+{ 
+  opacity: 1.0; 
+}
+label#pb_label 
+{ 
+  padding-left: .5em; 
+}


### PR DESCRIPTION
Partial fix for https://github.com/darktable-org/lua-scripts/issues/438