### PR TITLE
CI refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
           - skiptest
         generator:
           - Ninja
+        eco: [-DDONT_USE_INTERNAL_LIBRAW=ON]
         include:
           # We want one run in CI to be Debug to make sure the Debug build isn't broken
           - distro: "debian:trixie-slim"
@@ -69,6 +70,7 @@ jobs:
             compiler: { compiler: GNU13, CC: gcc-13, CXX: g++-13, packages: gcc-13 g++-13 }
             target: skiptest
             generator: Ninja
+            eco: -DDONT_USE_INTERNAL_LIBRAW=OFF
     env:
       DISTRO: ${{ matrix.distro }}
       CC: ${{ matrix.compiler.CC }}
@@ -76,7 +78,7 @@ jobs:
       SRC_DIR: ${{ github.workspace }}/src
       BUILD_DIR: ${{ github.workspace }}/build
       INSTALL_PREFIX: ${{ github.workspace }}/install
-      ECO: -DTEMPORAIRLY_ALLOW_OLD_TOOCHAIN=OFF
+      ECO: ${{ matrix.eco }}
       CMAKE_BUILD_TYPE: ${{ matrix.btype }}
       GENERATOR: ${{ matrix.generator }}
       TARGET: ${{ matrix.target }}
@@ -176,6 +178,7 @@ jobs:
             libpng-dev \
             libportmidi-dev \
             libpugixml-dev \
+            libraw-dev \
             librsvg2-dev \
             libsaxon-java \
             libsdl2-dev \
@@ -332,7 +335,7 @@ jobs:
       matrix:
         build:
           - { os: macos-13,    xcode: 15.2,   deployment: 13.5 } # LLVM16, x86_64
-          - { os: macos-14,    xcode: 15.3,   deployment: 14.0 } # LLVM16, arm64
+          - { os: macos-14,    xcode: 15.4,   deployment: 14.0 } # LLVM16, arm64
         compiler:
           - { compiler: XCode,   CC: cc, CXX: c++ }
         btype: [ Release ]

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -110,13 +110,11 @@ jobs:
             libxfixes-dev;
       - name: Build and install a more recent version of exiv2
         run: |
-          git clone --branch v0.28.1 --depth 1 https://github.com/Exiv2/exiv2 src-exiv2
+          git clone --branch v0.28.2 --depth 1 https://github.com/Exiv2/exiv2 src-exiv2
           cd src-exiv2
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_SHARED_LIBS=ON \
-            -DEXIV2_ENABLE_BMFF=ON \
-            -DEXIV2_ENABLE_XMP=ON \
             -DEXIV2_ENABLE_VIDEO=OFF \
             -DCMAKE_INSTALL_PREFIX=/usr
           cmake --build build
@@ -288,7 +286,7 @@ jobs:
       matrix:
         build:
           - { os: macos-13, xcode: 15.2, deployment: 13.5 } # LLVM16, x86_64
-          - { os: macos-14, xcode: 15.3, deployment: 14.0 } # LLVM16, arm64
+          - { os: macos-14, xcode: 15.4, deployment: 14.0 } # LLVM16, arm64
         compiler:
           - { compiler: XCode,   CC: cc, CXX: c++ }
         btype: [ Release ]


### PR DESCRIPTION
- Xcode 15.4
- Debian testing ships the min required LibRaw, so use it to skip compiling bundled copy for CI only
- Bump exiv2 to latest tag for nightly AppImage, remove default options