### PR TITLE
Don't use FOR SIMD in color equalizer

### DIFF
--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -430,7 +430,7 @@ void _prefilter_chromaticity(float *const restrict UV,
   // and subtract avg(x) * avg(y) later
   float *const restrict covariance = dt_alloc_align_float(ds_pixels * 4);
 
-  DT_OMP_FOR_SIMD(aligned(ds_UV, covariance: 64))
+  DT_OMP_FOR()
   for(size_t k = 0; k < ds_pixels; k++)
   {
     // corr(U, U)
@@ -453,7 +453,7 @@ void _prefilter_chromaticity(float *const restrict UV,
 
   // Finish the UV covariance matrix computation by subtracting avg(x) * avg(y)
   // to avg(x * y) already computed
-  DT_OMP_FOR_SIMD(aligned(ds_UV, covariance: 64))
+  DT_OMP_FOR()
   for(size_t k = 0; k < ds_pixels; k++)
   {
     // covar(U, U) = var(U)
@@ -469,7 +469,7 @@ void _prefilter_chromaticity(float *const restrict UV,
   float *const restrict a = dt_alloc_align_float(4 * ds_pixels);
   float *const restrict b = dt_alloc_align_float(2 * ds_pixels);
 
-  DT_OMP_FOR_SIMD(aligned(ds_UV, covariance, a, b: 64))
+  DT_OMP_FOR()
   for(size_t k = 0; k < ds_pixels; k++)
   {
     // Extract the 2×2 covariance matrix sigma = cov(U, V) at current pixel
@@ -536,7 +536,7 @@ void _prefilter_chromaticity(float *const restrict UV,
   }
 
   // Apply the guided filter
-  DT_OMP_FOR_SIMD(aligned(a_full, b_full, saturation, UV: 64))
+  DT_OMP_FOR()
   for(size_t k = 0; k < pixels; k++)
   {
     // For each correction factor, we re-express it as a[0] * U + a[1] * V + b
@@ -610,7 +610,7 @@ void _guide_with_chromaticity(float *const restrict UV,
   // and subtract avg(x) * avg(y) later
   float *const restrict covariance = dt_alloc_align_float(ds_pixels * 4);
 
-  DT_OMP_FOR_SIMD(aligned(ds_UV, covariance: 64))
+  DT_OMP_FOR()
   for(size_t k = 0; k < ds_pixels; k++)
   {
     // corr(U, U)
@@ -624,7 +624,7 @@ void _guide_with_chromaticity(float *const restrict UV,
   // Get the correlations between corrections and UV
   float *const restrict correlations = dt_alloc_align_float(ds_pixels * 4);
 
-  DT_OMP_FOR_SIMD(aligned(ds_UV, ds_corrections, ds_b_corrections, correlations: 64))
+  DT_OMP_FOR()
   for(size_t k = 0; k < ds_pixels; k++)
   {
     // corr(sat, U)
@@ -652,7 +652,7 @@ void _guide_with_chromaticity(float *const restrict UV,
 
   // Finish the UV covariance matrix computation by subtracting avg(x) * avg(y)
   // to avg(x * y) already computed
-  DT_OMP_FOR_SIMD(aligned(ds_UV, covariance: 64))
+  DT_OMP_FOR()
   for(size_t k = 0; k < ds_pixels; k++)
   {
     // covar(U, U) = var(U)
@@ -665,7 +665,7 @@ void _guide_with_chromaticity(float *const restrict UV,
   }
 
   // Finish the guide * guided correlation computation
-  DT_OMP_FOR_SIMD(aligned(ds_UV, ds_corrections, correlations: 64))
+  DT_OMP_FOR()
   for(size_t k = 0; k < ds_pixels; k++)
   {
     correlations[4 * k + 0] -= ds_UV[2 * k + 0] * ds_corrections[2 * k + 1];
@@ -679,7 +679,7 @@ void _guide_with_chromaticity(float *const restrict UV,
   float *const restrict a = dt_alloc_align_float(4 * ds_pixels);
   float *const restrict b = dt_alloc_align_float(2 * ds_pixels);
 
-  DT_OMP_FOR_SIMD(aligned(ds_UV, covariance, correlations, ds_corrections, ds_b_corrections, a, b: 64))
+  DT_OMP_FOR()
   for(size_t k = 0; k < ds_pixels; k++)
   {
     // Extract the 2×2 covariance matrix sigma = cov(U, V) at current pixel
@@ -754,7 +754,7 @@ void _guide_with_chromaticity(float *const restrict UV,
   }
 
   // Apply the guided filter
-  DT_OMP_FOR_SIMD(aligned(a_full, b_full, corrections, saturation, gradients, UV: 64))
+  DT_OMP_FOR()
   for(size_t k = 0; k < pixels; k++)
   {
     // For each correction factor, we re-express it as a[0] * U + a[1] * V + b


### PR DESCRIPTION
Uses the FOR variant for safety.
Measured performance to check if it's worth to check compiler code in detail, no penalty that's measurable here.

Hopefully fixes #16781