### PR TITLE
set IPTC character set on export

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1561,6 +1561,16 @@ static int32_t dt_control_export_job_run(dt_job_t *job)
   dt_tag_new("darktable|changed", &tagid);
   dt_tag_new("darktable|exported", &etagid);
 
+  const char iptc_envelope_characterset[] = "Iptc.Envelope.CharacterSet";
+  if(!g_strstr_len(settings->metadata_export, -1, iptc_envelope_characterset))
+  {
+    // IPTC character encoding not set by user, so we set the default utf8 here
+    settings->metadata_export = dt_util_dstrcat(settings->metadata_export,
+                                                "\1%s\1%s", 
+                                                iptc_envelope_characterset,
+                                                "\x1b%G");  // ESC % G
+  }
+
   dt_export_metadata_t metadata;
   metadata.flags = 0;
   metadata.list = dt_util_str_to_glist("\1", settings->metadata_export);


### PR DESCRIPTION
darktable exports IPTC data in utf8 character set, but the encoding is not specified. This can lead to misinterpretations by various other applications.

This can be done by setting `Iptc.Envelope.CharacterSet` in the export preferences but it needs to be set to a 3 byte escape sequence `ESC % G`. This is not user friendly because

- not obvious how to set this and what value is needed
- it is not simply possible to enter an Esc sequence with the keyboard.

This PR sets the default value for utf8 on export if not set by the user.

fixes #16797