### PR TITLE
RFC: [ColorCalib] update label to reflect whether color mapping is active

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -4120,6 +4120,7 @@ void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
   GtkWidget *destdisp_head = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_BAUHAUS_SPACE);
   GtkWidget *header_evb = gtk_event_box_new();
   GtkWidget *destdisp = dt_ui_section_label_new(label);
+  cs->label = destdisp;
   dt_gui_add_class(destdisp_head, "dt_section_expander");
   gtk_container_add(GTK_CONTAINER(header_evb), destdisp);
 
@@ -4147,6 +4148,16 @@ void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
 
   g_signal_connect(G_OBJECT(header_evb), "button-press-event",
                    G_CALLBACK(_collapse_expander_click), cs);
+}
+
+void dt_gui_collapsible_section_set_label(dt_gui_collapsible_section_t *cs,
+                                          const char *label)
+{
+  if (!cs || !cs->label || !label)
+    return;
+  gtk_label_set_text(GTK_LABEL(cs->label), label);
+//  dt_control_queue_redraw_widget(cs->label);
+  dt_control_queue_redraw();
 }
 
 gboolean dt_gui_long_click(const int second,

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2022 darktable developers.
+    Copyright (C) 2009-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -155,6 +155,7 @@ typedef struct _gui_collapsible_section_t
   gchar *confname;      // configuration name for the toggle status
   GtkWidget *toggle;    // toggle button
   GtkWidget *expander;  // the expanded
+  GtkWidget *label;	// the label containing the section's title text
   GtkBox *container;    // the container for all widgets into the section
   struct dt_action_t *module; // the lib or iop module that contains this section
 } dt_gui_collapsible_section_t;
@@ -514,6 +515,9 @@ void dt_gui_new_collapsible_section(dt_gui_collapsible_section_t *cs,
                                     const char *label,
                                     GtkBox *parent,
                                     struct dt_action_t *module);
+// update the collapsible section's label text
+void dt_gui_collapsible_section_set_label(dt_gui_collapsible_section_t *cs,
+                                          const char *label);
 // routine to be called from gui_update
 void dt_gui_update_collapsible_section(dt_gui_collapsible_section_t *cs);
 

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -594,6 +594,18 @@ void init_presets(dt_iop_module_so_t *self)
                              self->version(), &p, sizeof(p), 1, DEVELOP_BLEND_CS_RGB_SCENE);
 }
 
+static gboolean _area_mapping_active(const dt_iop_channelmixer_rgb_gui_data_t *g)
+{
+  return g && g->spot_mode && dt_bauhaus_combobox_get(g->spot_mode) != DT_SPOT_MODE_MEASURE &&
+    ((g->lightness_spot && dt_bauhaus_slider_get_val(g->lightness_spot) != 50.0f) ||
+     (g->hue_spot && dt_bauhaus_slider_get_val(g->hue_spot) != 0.0f) ||
+     (g->chroma_spot && dt_bauhaus_slider_get_val(g->chroma_spot) != 0.0f));
+}
+
+static const char *_area_mapping_section_text(const dt_iop_channelmixer_rgb_gui_data_t *g)
+{
+  return _area_mapping_active(g) ? _("area color mapping (active)") : _("area color mapping");
+}
 
 static gboolean _get_white_balance_coeff(struct dt_iop_module_t *self,
                                          dt_aligned_pixel_t custom_wb)
@@ -3835,6 +3847,7 @@ void gui_update(struct dt_iop_module_t *self)
   g->is_profiling_started = FALSE;
 
   dt_gui_hide_collapsible_section(&g->cs);
+  dt_gui_collapsible_section_set_label(&g->csspot, _area_mapping_section_text(g));
   dt_gui_update_collapsible_section(&g->csspot);
 
   g->spot_RGB[0] = 0.f;
@@ -4522,7 +4535,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_gui_new_collapsible_section
     (&g->csspot,
      "plugins/darkroom/channelmixerrgb/expand_picker_mapping",
-     _("area color mapping"),
+     _area_mapping_section_text(g),
      GTK_BOX(self->widget),
      DT_ACTION(self));
 
@@ -4630,6 +4643,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(hhbox), GTK_WIDGET(vvbox), TRUE, TRUE, DT_BAUHAUS_SPACE);
 
   gtk_box_pack_start(GTK_BOX(g->csspot.container), GTK_WIDGET(hhbox), FALSE, FALSE, 0);
+  dt_gui_collapsible_section_set_label(&g->csspot, _area_mapping_section_text(g));
 
   GtkWidget *first, *second, *third;
 #define NOTEBOOK_PAGE(var, short, label, tooltip, section, swap, soft_range, sr_min, sr_max) \


### PR DESCRIPTION
This PR is in response to the repeated occurrences where someone unknowingly had color mapping activated and some recent suggestions on pixls.us.  The label on the collapsible section for the color mapping controls now shows whether color mapping is active.

I'll need some help from someone familiar with Gtk - I have the label being set to either "area color mapping" or "area color mapping (active)", but it only gets set on opening the image in darkroom (either from lighttable or by switching between images in darkroom).  The label doesn't get updated when  the parameters change and switch the "active" state.
