### PR TITLE
change enlarge canvas module description

### DIFF
--- a/src/iop/enlargecanvas.c
+++ b/src/iop/enlargecanvas.c
@@ -79,7 +79,7 @@ const char** description(struct dt_iop_module_t *self)
 {
   return dt_iop_set_description
     (self,
-     _("enlarge canvas"),
+     _("add empty space to the left, top, right or bottom"),
      _("corrective and creative"),
      _("linear, RGB, scene-referred"),
      _("linear, RGB"),


### PR DESCRIPTION
#16816 made the module name the same with module description. That caused a problem for zh_TW translation. I just added some description texts.