### PR TITLE
Remove unused gettext calls in `censorize` module

### DIFF
--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -394,13 +394,13 @@ void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_censorize_gui_data_t *g = IOP_GUI_ALLOC(censorize);
 
-  g->radius_1 = dt_bauhaus_slider_from_params(self, N_("radius_1"));
+  g->radius_1 = dt_bauhaus_slider_from_params(self, "radius_1");
 
-  g->pixelate = dt_bauhaus_slider_from_params(self, N_("pixelate"));
+  g->pixelate = dt_bauhaus_slider_from_params(self, "pixelate");
 
-  g->radius_2 = dt_bauhaus_slider_from_params(self, N_("radius_2"));
+  g->radius_2 = dt_bauhaus_slider_from_params(self, "radius_2");
 
-  g->noise = dt_bauhaus_slider_from_params(self, N_("noise"));
+  g->noise = dt_bauhaus_slider_from_params(self, "noise");
 
   gtk_widget_set_tooltip_text(g->radius_1, _("radius of gaussian blur before pixelization"));
   gtk_widget_set_tooltip_text(g->radius_2, _("radius of gaussian blur after pixelization"));


### PR DESCRIPTION
This will remove unnecessary elements in the .pot file. Widget labels are specified in introspection and are automatically used and added to strings for translation. What we added here through `N_()` is not used anywhere.