### PR TITLE
Fix pixelpipe extensive work while exporting

### DIFF
--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1003,12 +1003,12 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
            pipe.processed_width, pipe.processed_height,
            processed_width, processed_height, scale, max_scale,
            upscale ? "yes" : "no",
-           high_quality_processing ? "yes" : "no");
+           high_quality_processing || scale > 1.0f ? "yes" : "no");
 
   const int bpp = format->bpp(format_params);
 
   dt_get_perf_times(&start);
-  if(high_quality_processing)
+  if(high_quality_processing || scale > 1.0f)
   {
     /*
      * if high quality processing was requested, downsampling will be done


### PR DESCRIPTION
This is how it should be done depending on "high-quality" (HQ) and "upscale" UP

HQ=OFF  UP=OFF
  the final size is achieved by down-scaling in demosaic, we never upscale. (was good)
HQ=ON   UP=OFF
  the pixelpipe processes all avaible data, the output size is achieved in the finalscale
  module and is never upscaled (was good)
HQ=ON   UP=ON
  the pixelpipe processes all available data, the output size is achieved in the finalscale
  module and may be increased by upscaling (was good)

HQ=OFF  UP=ON
  as uscaling is allowed this should behave exactly as HQ=ON/UP=ON
  Until now we **upscaled** in the demosaicer to full output size leading to excessive cpu/gpu load
  possibly with heavy tiling achieving nothing or even likely reducing quality.
