### PR TITLE
[GUI] We don't have a favorites menu

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1462,7 +1462,7 @@
     <type>bool</type>
     <default>false</default>
     <shortdescription>hide built-in presets for processing modules</shortdescription>
-    <longdescription>hides built-in presets of processing modules in both presets and favourites menu.</longdescription>
+    <longdescription>hide built-in presets of processing modules in presets menu.</longdescription>
   </dtconfig>
     <dtconfig prefs="darkroom" section="modules">
     <name>plugins/darkroom/show_guides_in_ui</name>
@@ -1476,7 +1476,7 @@
     <type>bool</type>
     <default>false</default>
     <shortdescription>hide built-in presets for utility modules</shortdescription>
-    <longdescription>hides built-in presets of utility modules in presets menu.</longdescription>
+    <longdescription>hide built-in presets of utility modules in presets menu.</longdescription>
   </dtconfig>
   <dtconfig prefs="import" section="session">
     <name>session/base_directory_pattern</name>


### PR DESCRIPTION
Well, not only that. If you look at the code, you can conclude that this term (favorites menu) was used internally for what is labeled "quick access to presets" in the GUI. But the fact is that the setting, the tooltip to which I am correcting, does NOT affect the display of built-in presets in the "quick access to presets" menu. That is, the tooltip was factually inaccurate, so the PR removes that part instead of referring to the widget by the correct label.