### PR TITLE
Change the default for mouse scrolling over panels

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2218,7 +2218,7 @@
   <dtconfig prefs="misc" section="interface">
     <name>darkroom/ui/sidebar_scroll_default</name>
     <type>bool</type>
-    <default>false</default>
+    <default>true</default>
     <shortdescription>mouse wheel scrolls modules side panel by default</shortdescription>
     <longdescription>when enabled, use mouse wheel to scroll modules side panel.  use ctrl+alt to use mouse wheel for data entry.  when disabled, this behavior is reversed</longdescription>
   </dtconfig>


### PR DESCRIPTION
If you have to name one feature that annoys users in darktable the most, it's most likely the default change of widget values when scrolling with the mouse over the panels.

I hear complaints about this in feedback from members of the local photo community, I read them in comments on YouTube and various forums. I haven't seen any user feedback that they like the current default.

In addition, user troubleshooting sometimes boils down to an incorrect parameter in a module that the user _claims he did not intentionally change_. This is not an uncommon situation in my experience when I have helped solve a user problem. Obviously, in such cases, the reason was a change in the value of the widget by scrolling the mouse, which the user simply did not notice.