### PR TITLE
Downgrading the Pango library is no longer safe

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -230,10 +230,6 @@ jobs:
         run: |
           # It's a temporary fix, to be removed when the issue will be resolved
           pacman -U --noconfirm https://repo.msys2.org/mingw/ucrt64/mingw-w64-ucrt-x86_64-exiv2-0.27.7-1-any.pkg.tar.zst
-      - name: Install the latest still safe to display cyrillic texts version of pango
-        run: |
-          # It's a temporary fix, to be removed when the issue #13084 will be resolved
-          pacman -U --noconfirm https://repo.msys2.org/mingw/ucrt64/mingw-w64-ucrt-x86_64-pango-1.50.11-1-any.pkg.tar.zst
       - name: Cancel workflow if job fails
         if: ${{ failure() }}
         uses: andymckay/cancel-action@0.4


### PR DESCRIPTION
Resolves #16896.

We've done this before and it (even at the beginning of the year) was a working, albeit temporary, way to get rid of the Cyrillic GUI problems. But it turned out that the pinned older version of Pango and recent versions of some other libraries no longer play well together, which leads to crashes with a characteristic symptom, written in the log messages:
```
GLib-GObject:ERROR:../glib-2.80.0/gobject/gobject.c:299:weak_ref_data_ref: assertion failed: (wrdata)
Bail out! GLib-GObject:ERROR:../glib-2.80.0/gobject/gobject.c:299:weak_ref_data_ref: assertion failed: (wrdata)
```