### PR TITLE
Make aware of invalid IOP ORDER

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -103,6 +103,9 @@ void dt_print_pipe_ext(const char *title,
 
   snprintf(vtit, sizeof(vtit), "%s", title);
 
+  if(module && module->iop_order == INT_MAX)
+    snprintf(vtit, sizeof(vtit), "%s", "INVALID IOP ORDER");
+
   snprintf(vmod, sizeof(vmod), "%s%s",
     module ? module->op : "",
     module ? dt_iop_get_instance_id(module) : "");


### PR DESCRIPTION
Because of wrongfully done UNDO/REDO on module duplicates we can have invalid IOP orders for processed modules but will not see them as made hidden.

The logs will tell about this

