### PR TITLE
Fixing chroma trouble warnings

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1098,10 +1098,6 @@ static void _gui_off_callback(GtkToggleButton *togglebutton, dt_iop_module_t *mo
     {
       module->enabled = FALSE;
 
-      //  if current module is set as the CAT instance, remove that setting
-      if(module->dev->chroma.adaptation == module)
-        module->dev->chroma.adaptation = NULL;
-
       dt_dev_add_history_item(module->dev, module, FALSE);
 
       if(!basics && dt_conf_get_bool("darkroom/ui/activate_expand") && module->expanded)


### PR DESCRIPTION
This is all about the warnings given in temperature & color calibration modules

1. Make sure the CAT is not made invalid while toggling a module on/off. Cat being active will be checked while looking for one of the error conditions
2. The temperature is registerd while commiting params, this avoids check at runtime which might not be done while processing du to cache line use
3. coeffs being 1 - as in an image provided by @RawConvert - should not be taken as a problem
4. There was one subtle issue with `DT_IOP_TEMP_USER` not being set correctly if no preset was found

Otherwise - no color math changes.