### PR TITLE
Migration of button-pressed and button-released to new GtkGesture API.

### DIFF
--- a/src/dtgtk/button.c
+++ b/src/dtgtk/button.c
@@ -147,6 +147,29 @@ void dtgtk_button_set_active(GtkDarktableButton *button, gboolean active)
     button->icon_flags &= ~CPF_ACTIVE;
 }
 
+GtkGesture *dtgtk_button_default_handler_new(
+    GtkWidget *widget,
+    guint button,
+    GCallback func_press,
+    GCallback func_release,
+    gpointer data)
+{
+  GtkGesture *gesture = gtk_gesture_multi_press_new(widget);
+  gtk_gesture_single_set_button(GTK_GESTURE_SINGLE(gesture), button);
+
+  if (func_press != NULL)
+  {
+    g_signal_connect(G_OBJECT(gesture), "pressed", func_press, data);
+  }
+
+  if (func_release != NULL)
+  {
+    g_signal_connect(G_OBJECT(gesture), "released", func_release, data);
+  }
+
+  return gesture;
+}
+
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/dtgtk/button.h
+++ b/src/dtgtk/button.h
@@ -48,6 +48,22 @@ void dtgtk_button_set_paint(GtkDarktableButton *button, DTGTKCairoPaintIconFunc 
 /** set the active state of the button icon */
 void dtgtk_button_set_active(GtkDarktableButton *button, gboolean active);
 
+/**
+ * Create default handler for primary button.
+ * @param widget widget to create the gesture object for
+ * @param button type of button
+ * @param func_press gets called when button will be pressed
+ * @param func_release gets called when button will be released
+ * @param data user data send to function
+ * @return new gesture object; receiver is responsible for deletion
+ */
+GtkGesture *dtgtk_button_default_handler_new(
+    GtkWidget *widget,
+    guint button,
+    GCallback func_press,
+    GCallback func_release,
+    gpointer data);
+
 G_END_DECLS
 
 // clang-format off

--- a/src/dtgtk/thumbtable.h
+++ b/src/dtgtk/thumbtable.h
@@ -104,6 +104,10 @@ typedef struct dt_thumbtable_t
   // scroll timeout values
   guint scroll_timeout_id;
   float scroll_value;
+
+  // different controller for event processing
+  GtkGesture *gesture_button_primary;
+
 } dt_thumbtable_t;
 
 dt_thumbtable_t *dt_thumbtable_new();


### PR DESCRIPTION
**This pr is connected to #15923, which has been closed and reopened here on a new branch.**

Hello to everyone,

this pr will migrate the first button-pressed and button-release to the new GtkGesture API. Please test if everything is working as before. I do not find any problem but I also might have missed something.

I will wait with all further migration to this event context, until this pr has been reviewed. This is because I want to be sure, that the way I implemented it is your preferred way and I don't need to do things twice. :-)

Just to let all of you know: I am coming from the cpp perspective. This might break some things in code structure in the way I prefer to implement it.

Looking forward to your reply.
Thanks in advance

Greetings
