### PR TITLE
CMake: switch to curl imported target

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Required dependencies (minimum version):
 * GTK 3.24.15
 * GLib 2.56
 * SQLite 3.15 *(but 3.24 or newer strongly recommended)*
+* libcurl 7.56
 * Exiv2 0.27.2 *(but at least 0.27.4 built with ISO BMFF support needed for Canon CR3 raw import)*
 * pugixml 1.5
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -242,6 +242,7 @@ changes (where available).
 - Minimum libpng version 1.5.x is now required
 - Bump Exiv2 requirement to 0.27.2
 - Minimum pugixml version 1.5 is now required
+- Minimum libcurl version 7.56 is now required
 
 ### Optional
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -435,7 +435,7 @@ include_directories(SYSTEM ${Sqlite3_INCLUDE_DIR})
 list(APPEND LIBS ${Sqlite3_LIBRARIES})
 add_definitions(${Sqlite3_DEFINITIONS})
 
-foreach(lib ${OUR_LIBS} GIO GThread GModule PangoCairo Rsvg2 LibXml2 CURL PNG JPEG TIFF LCMS2 JsonGlib)
+foreach(lib ${OUR_LIBS} GIO GThread GModule PangoCairo Rsvg2 LibXml2 PNG JPEG TIFF LCMS2 JsonGlib)
   find_package(${lib} REQUIRED)
   include_directories(SYSTEM ${${lib}_INCLUDE_DIRS})
   list(APPEND LIBS ${${lib}_LIBRARIES})
@@ -445,6 +445,10 @@ endforeach(lib)
 if(PNG_VERSION_STRING VERSION_LESS 1.5)
   message(FATAL_ERROR "libpng version 1.5 or newer is required")
 endif()
+
+# Use imported target for curl
+find_package(CURL 7.56 REQUIRED)
+list(APPEND LIBS CURL::libcurl)
 
 # Require exiv2 >= 0.27.2 to make sure everything we need is available
 find_package(Exiv2 0.27.2 REQUIRED)

--- a/src/imageio/storage/CMakeLists.txt
+++ b/src/imageio/storage/CMakeLists.txt
@@ -5,15 +5,7 @@ include(manage-symbol-visibility)
 add_definitions(-include common/module_api.h)
 add_definitions(-include imageio/storage/imageio_storage_api.h)
 
-set(MODULES disk email gallery latex)
-
-find_package(CURL 7.56)
-if(CURL_FOUND)
-  message(STATUS "Found recent CURL version to build piwigo.")
-  list(APPEND MODULES piwigo)
-else(CURL_FOUND)
-  message(STATUS "Cannot found recent CURL version (>= 7.56) to build piwigo.")
-endif(CURL_FOUND)
+set(MODULES disk email gallery latex piwigo)
 
 foreach(module ${MODULES})
 	add_library(${module} MODULE "${module}.c")


### PR DESCRIPTION
This works around https://discuss.pixls.us/t/problem-building-darktable-master-on-windows-11-using-msys-mingw64/43829

Likely to also hit other platforms with future curl package updates.

Also simplified piwigo building, as libcurl was already REQUIRED anyway.