### PR TITLE
Fix internal histograms in tone equalizer

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -753,7 +753,7 @@ static void _histogram_collect_cl(const int devid,
                                                    sizeof(float) * 4);
   if(err != CL_SUCCESS)
   {
-    if(tmpbuf) dt_free_align(tmpbuf);
+    dt_free_align(tmpbuf);
     return;
   }
 
@@ -785,7 +785,7 @@ static void _histogram_collect_cl(const int devid,
                       piece->module->histogram_middle_grey,
                       dt_ioppr_get_pipe_work_profile_info(piece->pipe));
 
-  if(tmpbuf) dt_free_align(tmpbuf);
+  dt_free_align(tmpbuf);
 }
 #endif
 
@@ -1042,7 +1042,7 @@ static void _collect_histogram_on_CPU(dt_dev_pixelpipe_t *pipe,
                                       dt_dev_pixelpipe_iop_t *piece,
                                       dt_pixelpipe_flow_t *pixelpipe_flow)
 {
-  // histogram collection for module
+  // histogram collect for iop_module
   if((dev->gui_attached || !(piece->request_histogram & DT_REQUEST_ONLY_IN_GUI))
      && (piece->request_histogram & DT_REQUEST_ON))
   {
@@ -1741,7 +1741,7 @@ static gboolean _dev_pixelpipe_process_rec(
 
           if(piece->histogram
              && (module->request_histogram & DT_REQUEST_ON)
-             && (pipe->type & DT_DEV_PIXELPIPE_PREVIEW) == DT_DEV_PIXELPIPE_PREVIEW)
+             && (pipe->type & DT_DEV_PIXELPIPE_PREVIEW))
           {
             const size_t buf_size =
               sizeof(uint32_t) * 4 * piece->histogram_stats.bins_count;

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1142,6 +1142,7 @@ void toneeq_process(struct dt_iop_module_t *self,
         compute_luminance_mask(in, luminance, width, height, d);
         g->luminance_valid = TRUE;
         dt_iop_gui_leave_critical_section(self);
+        dt_dev_pixelpipe_cache_invalidate_later(piece->pipe, self->iop_order);
       }
     }
     else // make it dummy-proof


### PR DESCRIPTION
A recalculation of histogram data for the preview pipe in that module should also simply invalidate cachelines for modules later in the pipe to enforce redrawing the histogram.

Fixes #16940 

While checking this did some minimal code cleanup for histograms in pixelpipe code.

@TurboGit the one-liner second commit at least might still be a bugfix for 4.8