### PR TITLE
Leave note about inconsistent output in haze removal

### DIFF
--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -564,6 +564,12 @@ void process(struct dt_iop_module_t *self,
     distance_max = g->distance_max;
     dt_iop_gui_leave_critical_section(self);
   }
+
+  // FIXME in pipe->type |= DT_DEV_PIXELPIPE_IMAGE mode we currently can't receive data from preview
+  // so we at least leave a note to the user
+  if(piece->pipe->type & DT_DEV_PIXELPIPE_IMAGE)
+    dt_control_log(_("inconsistent output"));
+
   // In all other cases we calculate distance_max and A0 here.
   if(dt_isnan(distance_max))
     distance_max = _ambient_light(img_in, w1, &A0, compatibility_mode);
@@ -842,6 +848,12 @@ int process_cl(struct dt_iop_module_t *self,
     distance_max = g->distance_max;
     dt_iop_gui_leave_critical_section(self);
   }
+
+  // FIXME in pipe->type |= DT_DEV_PIXELPIPE_IMAGE mode we currently can't receive data from preview
+  // so we at least leave a note to the user
+  if(piece->pipe->type & DT_DEV_PIXELPIPE_IMAGE)
+    dt_control_log(_("inconsistent output"));
+
   // In all other cases we calculate distance_max and A0 here.
   if(dt_isnan(distance_max))
     distance_max = _ambient_light_cl(self, devid, img_in, w1, &A0, compatibility_mode);


### PR DESCRIPTION
haze removal requires either full image roi or data from a run of the preview pipe for stable output data. Unfortunately this is currently not possible for the `DT_DEV_PIXELPIPE_IMAGE` pipe we use for snapshots.

Until this is properly sorted out we at least give a hint for the user.

Related to #16925

@TurboGit i also checked "chromatic aberrations" and "denoise profiled" for anything suspicious about full pipe processing but couldn't spot anything where output might be depending on full pipe in `DT_DEV_PIXELPIPE_IMAGE` mode or not (as long as the ROIs for both full pipes are the same and that seems to be the case from my logs.)

I am not sure how (or even if) we can fix such problems as in haze removal. Other modules with identical problems are `colorreconstruction`,  `globaltonemap` and `levels`, all are using the problematic `dt_dev_sync_pixelpipe_hash()`.

As we use an already translated string, would this still be possible for 4.8 (not sure how that translation thing works :-) ? If so i would prepare a "temporary fix" also for the others ... 