### PR TITLE
CMake: don't look for LibXml2 twice

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -435,7 +435,7 @@ include_directories(SYSTEM ${Sqlite3_INCLUDE_DIR})
 list(APPEND LIBS ${Sqlite3_LIBRARIES})
 add_definitions(${Sqlite3_DEFINITIONS})
 
-foreach(lib ${OUR_LIBS} GIO GThread GModule PangoCairo Rsvg2 LibXml2 PNG JPEG TIFF LCMS2 JsonGlib)
+foreach(lib ${OUR_LIBS} GIO GThread GModule PangoCairo Rsvg2 PNG JPEG TIFF LCMS2 JsonGlib)
   find_package(${lib} REQUIRED)
   include_directories(SYSTEM ${${lib}_INCLUDE_DIRS})
   list(APPEND LIBS ${${lib}_LIBRARIES})


### PR DESCRIPTION
Already required earlier: https://github.com/darktable-org/darktable/blob/2347e678b3990e89b817703aa1b86813ae27087f/src/CMakeLists.txt#L301