### PR TITLE
[CI] Speed up CI builds by skipping integration submodule cloning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,7 @@ jobs:
         with:
           submodules: false
           path: src
+          fetch-depth: 1
       - name: Get only those submodules that are needed for build
         run: |
           cd src
@@ -314,6 +315,7 @@ jobs:
         with:
           submodules: false
           path: src
+          fetch-depth: 1
       - name: Get only those submodules that are needed for build
         run: |
           cd src
@@ -375,6 +377,7 @@ jobs:
         with:
           submodules: false
           path: src
+          fetch-depth: 1
       - name: Get only those submodules that are needed for build
         run: |
           cd src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,8 +197,15 @@ jobs:
             zlib1g-dev;
       - uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: false
           path: src
+      - name: Get only those submodules that are needed for build
+        run: |
+          cd src
+          git submodule init
+          git config submodule.src/tests/integration.update none
+          git submodule update
+          cd -
       - name: Build and Install
         run: |
           cmake -E make_directory "${BUILD_DIR}";
@@ -305,8 +312,15 @@ jobs:
         shell: bash
       - uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: false
           path: src
+      - name: Get only those submodules that are needed for build
+        run: |
+          cd src
+          git submodule init
+          git config submodule.src/tests/integration.update none
+          git submodule update
+          cd -
       - name: Build and Install
         run: |
           cmake -E make_directory "${BUILD_DIR}"
@@ -359,8 +373,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: false
           path: src
+      - name: Get only those submodules that are needed for build
+        run: |
+          cd src
+          git submodule init
+          git config submodule.src/tests/integration.update none
+          git submodule update
+          cd -
       - name: Install Base Dependencies
         run: |
           brew update > /dev/null || true


### PR DESCRIPTION
Done right this time. The previous attempt was in #16583. However, the previous time due to an inexplicable mental lapse, the clone code was copied from nightly which cloned the master HEAD, but when run for the pull request it's incorrect.

Now I use the same `actions/checkout` which does the right thing, but I ask it not to clone the submodules, but do it manually as a next step, skipping the integration.

I would like to repeat the rationale of this change: integration submodule checkout time takes up to 70-75% of the total checkout time and skipping this can save up to 1 or even 2 minutes in typical CI action runs.