### PR TITLE
[GUI] Fix Cyrillic rendering in some themes by removing `Segoe UI Light`

### DIFF
--- a/data/themes/darktable-elegant-darker.css
+++ b/data/themes/darktable-elegant-darker.css
@@ -68,7 +68,7 @@ box,
 box *
 {
   font-family: "Roboto Light", "Roboto",                  /* best case scenario */
-               "Segoe UI Light", "Segoe UI",              /* Windows 10 default */
+               "Segoe UI",                                /* Windows 10 default */
                "SF Pro Display Light", "SF Pro Display",  /* Mac OS X default */
                "Ubuntu Light", "Ubuntu", "IPAPGothic",    /* Ubuntu default */
                "Cantarell",                               /* Gnome default */


### PR DESCRIPTION
Resolves #13084.

There are themes that do not use `Segoe UI Light`, so using this font in the theme is definitely not necessary for correct rendering. But I want to ask everyone to test this change as much as possible now, because merging it into 4.8 would allow to abandon the need for an outdated package base for building darktable on Windows.