### PR TITLE
Safe module_filter_out handling

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -423,15 +423,6 @@ restart:
 
   dt_get_times(&start);
 
-  // disable some modules if needed
-  for(GList *m = dev->module_filter_out;
-      m;
-      m = g_list_next(m))
-  {
-    char *mod = (char *)(m->data);
-    dt_dev_pixelpipe_module_enabled(port->pipe, mod, FALSE);
-  }
-
   if(dt_dev_pixelpipe_process(pipe, dev, x, y, wd, ht, scale, devid))
   {
     // interrupted because image changed?

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -516,6 +516,22 @@ void dt_dev_pixelpipe_synch(dt_dev_pixelpipe_t *pipe,
           "enabled module with iop_order of INT_MAX is disabled\n");
       }
 
+      // disable pieces if included in list
+      if(piece->enabled && dev->module_filter_out)
+      {
+        for(GList *m = dev->module_filter_out; m; m = g_list_next(m))
+        {
+          char *mod = (char *)(m->data);
+          if(dt_iop_module_is(piece->module->so, mod))
+          {
+            piece->enabled = FALSE;
+            dt_print_pipe(DT_DEBUG_PARAMS | DT_DEBUG_PIPE, "dt_dev_pixelpipe_synch",
+              pipe, piece->module, DT_DEVICE_NONE, NULL, NULL,
+              "module is disabled because it's included in module_filter_out\n");
+          }
+        }
+      }
+
       dt_iop_commit_params(hist->module, hist->params, hist->blend_params, pipe, piece);
 
       dt_print_pipe(DT_DEBUG_PARAMS, "dt_dev_pixelpipe_synch",
@@ -2494,21 +2510,6 @@ void dt_dev_pixelpipe_disable_before(dt_dev_pixelpipe_t *pipe, const char *op)
     nodes = g_list_next(nodes);
     if(!nodes) break;
     piece = (dt_dev_pixelpipe_iop_t *)nodes->data;
-  }
-}
-
-void dt_dev_pixelpipe_module_enabled(dt_dev_pixelpipe_t *pipe, const char *op, const gboolean enable)
-{
-  for(GList *nodes = pipe->nodes;
-      nodes;
-      nodes = g_list_next(nodes))
-  {
-    dt_dev_pixelpipe_iop_t *piece = (dt_dev_pixelpipe_iop_t *)nodes->data;
-    if(dt_iop_module_is(piece->module->so, op))
-    {
-      piece->enabled = enable;
-      break;
-    }
   }
 }
 

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -292,8 +292,6 @@ gboolean dt_dev_pixelpipe_process_no_gamma(dt_dev_pixelpipe_t *pipe,
 void dt_dev_pixelpipe_disable_after(dt_dev_pixelpipe_t *pipe, const char *op);
 // disable given op and all that comes before it in the pipe:
 void dt_dev_pixelpipe_disable_before(dt_dev_pixelpipe_t *pipe, const char *op);
-// disable given op only:
-void dt_dev_pixelpipe_module_enabled(dt_dev_pixelpipe_t *pipe, const char *op, const gboolean enable);
 
 // helper function to pass a raster mask through a (so far) processed pipe
 float *dt_dev_get_raster_mask(struct dt_dev_pixelpipe_iop_t *piece,

--- a/src/iop/overlay.c
+++ b/src/iop/overlay.c
@@ -226,6 +226,21 @@ static GList *_get_disabled_modules(const dt_iop_module_t *self,
     }
   }
 
+  if(darktable.unmuted & (DT_DEBUG_PARAMS | DT_DEBUG_PIPE))
+  {
+    char *buf = g_malloc0(PATH_MAX);
+    for(GList *m = result; m; m = g_list_next(m))
+    {
+      char *mod = (char *)(m->data);
+      g_strlcat(buf, mod, PATH_MAX);
+      g_strlcat(buf, " ", PATH_MAX);
+    }
+    dt_print_pipe(DT_DEBUG_PARAMS | DT_DEBUG_PIPE, "module_filter_out",
+          NULL, self, DT_DEVICE_NONE, NULL, NULL,
+          "%s\n", buf);
+    g_free(buf);
+  }
+
   return result;
 }
 


### PR DESCRIPTION
As modules being disabled via the dev->module_filter_out list should not
 - process code
 - modify roi_in or roi_out

we handle modules in the list while syncing the pipe nodes the same way as it is done for other "enforcements".

1. performance penalty only for pipes that use the module_filter_out list
2. modules that get disabled by this mechanism report that in the log
3. the overlay module reports the list for conveniance