### PR TITLE
Update RELEASE_NOTES.md regarding macOS version

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -236,8 +236,8 @@ changes (where available).
 - Starting with release 4.4 a new support policy regarding macOS
   versions has been put in place – darktable releases will now only
   support those macOS versions that are also supported by Apple.
-  Release 4.6 therefore drops support for macOS versions older than
-  12.5.
+  Release 4.8 therefore drops support for macOS versions older than
+  13.5.
 
 ## Changed Dependencies
 


### PR DESCRIPTION
Dt 4.8 drops support for macOS <13.5