### PR TITLE
Removing text that is no longer relevant from release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -226,13 +226,6 @@ changes (where available).
   metadata fields unless the user selects all of the checkboxes in the
   export module's preference options.
 
-- In order to support the correct display of numbers in darktable, the
-  minimum supported GTK version has had to be increased to
-  3.24.15. For people who need to build darktable with an older
-  version, this can be achieved by removing line 241 of the
-  `darktable.css` file on your system. See
-  https://github.com/darktable-org/darktable/issues/13166.
-
 - Release 4.8 drops support for macOS versions older than 13.5.
 
 ## Changed Dependencies


### PR DESCRIPTION
There are simply no users who could compile darktable with a version of GTK3 older than 3.24.15. If they have such an old release of a distro with such an old version of GTK3, the versions of other packages (starting with GCC) will not allow darktable to be compiled.