### PR TITLE
Bézier handles for path masks

### DIFF
--- a/po/darktable.pot
+++ b/po/darktable.pot
@@ -8965,7 +8965,7 @@ msgstr ""
 
 #: ../src/develop/masks/path.c:3360
 msgid ""
-"<b>node curvature</b>: drag\n"
+"<b>node curvature</b>: drag, <b>move single handle</b>: shift+drag\n"
 "<b>reset curvature</b>: right-click"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -9572,10 +9572,11 @@ msgstr ""
 
 #: ../src/develop/masks/path.c:3360
 msgid ""
-"<b>node curvature</b>: drag\n"
+"<b>node curvature</b>: drag, <b>move single handle</b>: shift+drag\n"
 "<b>reset curvature</b>: right-click"
 msgstr ""
-"<b>Knoten Krümmung</b>: ziehen\n"
+"<b>Knoten Krümmung</b>: Ziehen, <b>Einzelnen Kontrollpunkt bewegen</b>: "
+"Shift+Ziehen,\n"
 "<b>Krümmung zurücksetzen</b>: Rechtsklick"
 
 #: ../src/develop/masks/path.c:3365

--- a/po/en@truecase.po
+++ b/po/en@truecase.po
@@ -9421,12 +9421,12 @@ msgstr ""
 "<b>Move node</b>: drag, <b>Remove node</b>: right-click\n"
 "<b>Switch smooth/sharp mode</b>: Ctrl+click"
 
-#: ../src/develop/masks/path.c:3360
+#: ../src/develop/masks/path.c:3360#: ../src/develop/masks/path.c:3360
 msgid ""
-"<b>node curvature</b>: drag\n"
+"<b>node curvature</b>: drag, <b>move single handle</b>: shift+drag\n"
 "<b>reset curvature</b>: right-click"
 msgstr ""
-"<b>Node curvature</b>: drag\n"
+"<b>Node Curvature</b>: drag, <b>Move single handle</b>: shift+drag\n"
 "<b>Reset curvature</b>: right-click"
 
 #: ../src/develop/masks/path.c:3365

--- a/po/fr.po
+++ b/po/fr.po
@@ -9575,10 +9575,11 @@ msgstr ""
 
 #: ../src/develop/masks/path.c:3360
 msgid ""
-"<b>node curvature</b>: drag\n"
+"<b>node curvature</b>: drag, <b>move single handle</b>: shift+drag\n"
 "<b>reset curvature</b>: right-click"
 msgstr ""
-"<b>Courbe du nœud</b> : déplacer\n"
+"<b>Courbe du nœud</b> : glisser, <b>Déplacer un seul point de contrôle</b> : "
+"Maj+glisser\n"
 "<b>Réinitialiser la courbe</b> : clic droit"
 
 #: ../src/develop/masks/path.c:3365

--- a/po/it.po
+++ b/po/it.po
@@ -9652,10 +9652,11 @@ msgstr ""
 
 #: ../src/develop/masks/path.c:3360
 msgid ""
-"<b>node curvature</b>: drag\n"
+"<b>node curvature</b>: drag, <b>move single handle</b>: shift+drag\n"
 "<b>reset curvature</b>: right-click"
 msgstr ""
-"<b>nodo curvatura</b>: trascina\n"
+"<b>nodo curvatura</b>: trascina, <b>muovere punto di controllo singolo</b>: "
+"maiusc+trascina\n"
 "<b>azzera curvatura</b>: clic pulsante destro"
 
 #: ../src/develop/masks/path.c:3365

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -120,6 +120,14 @@ typedef enum dt_masks_source_pos_type_t
   DT_MASKS_SOURCE_POS_ABSOLUTE = 2
 } dt_masks_source_pos_type_t;
 
+typedef enum dt_masks_path_ctrl_t
+{
+  DT_MASKS_PATH_CRTL_NONE = -1,
+  DT_MASKS_PATH_CTRL1 = 1,
+  DT_MASKS_PATH_CTRL2 = 2
+
+} dt_masks_path_ctrl_t;
+
 /** structure used to store 1 point for a circle */
 typedef struct dt_masks_point_circle_t
 {
@@ -367,6 +375,7 @@ typedef struct dt_masks_form_gui_t
   int point_selected;
   int point_edited;
   int feather_selected;
+  dt_masks_path_ctrl_t feather_bezier_ctrl; // For paths, feather is used to control the bezier curve. This selects a control point.
   int seg_selected;
   int point_border_selected;
   int source_pos_type;
@@ -378,6 +387,7 @@ typedef struct dt_masks_form_gui_t
   gboolean gradient_toggling;
   int point_dragging;
   int feather_dragging;
+  gboolean feather_bezier_single;  // User shift-drags to move a single control point.
   int seg_dragging;
   int point_border_dragging;
 

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -32,8 +32,8 @@ static void _path_bounding_box_raw(const float *const points, const float *borde
                                    const int num_points, const int num_borders, float *x_min, float *x_max,
                                    float *y_min, float *y_max);
 
-static void _update_bezier_ctrl_points(dt_masks_point_path_t *point, float iwidth, float iheight, dt_masks_path_ctrl_t ctrl_select,
-                               float pts[2], bool ctrl_single);
+static void _update_bezier_ctrl_points(dt_masks_point_path_t *point, float iwidth, float iheight,
+                               float pts[2], dt_masks_path_ctrl_t ctrl_select, bool ctrl_single);
 
 static void _path_bounding_box(const float *const points,
                                const float *border,
@@ -119,8 +119,8 @@ static void _path_border_get_XY(const float p0x,
   *yb = (*yc) - rad * dx * l;
 }
 
-void _update_bezier_ctrl_points(dt_masks_point_path_t *point, float iwidth, float iheight, dt_masks_path_ctrl_t ctrl_select,
-                        float new_ctrl[2], bool ctrl_single)
+void _update_bezier_ctrl_points(dt_masks_point_path_t *point, float iwidth, float iheight,
+                        float new_ctrl[2], dt_masks_path_ctrl_t ctrl_select, bool ctrl_single)
 {
   float icorner[2] = { point->corner[0] * iwidth, point->corner[1] * iheight };
   if(ctrl_select == DT_MASKS_PATH_CTRL1)
@@ -1795,9 +1795,8 @@ static int _path_events_button_released(struct dt_iop_module_t *module,
     float pts[2] = { pzx * wd, pzy * ht };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
-    _update_bezier_ctrl_points(point, iwidth, iheight, gui->feather_bezier_ctrl, pts, gui->feather_bezier_single);
+    _update_bezier_ctrl_points(point, iwidth, iheight, pts, gui->feather_bezier_ctrl, gui->feather_bezier_single);
     gui->feather_bezier_single = FALSE;
-
     point->state = DT_MASKS_POINT_STATE_USER;
 
     _path_init_ctrl_points(form);
@@ -1947,7 +1946,8 @@ static int _path_events_mouse_moved(struct dt_iop_module_t *module,
         = (dt_masks_point_path_t *)g_list_nth_data(form->points, gui->feather_dragging);
 
     // TODO: No access to the current state of the shift key in mouse_moved?
-    _update_bezier_ctrl_points(point, iwidth, iheight, gui->feather_bezier_ctrl, pts, gui->feather_bezier_single);
+    _update_bezier_ctrl_points(point, iwidth, iheight, pts, gui->feather_bezier_ctrl, gui->feather_bezier_single);
+    point->state = DT_MASKS_POINT_STATE_USER;
 
     _path_init_ctrl_points(form);
     // we recreate the form points


### PR DESCRIPTION
Changing the UI for editing path masks. This is discussed in #14236 .

- The single control point for curvature has been removed.
- Instead the actual Bézier control points are used for this now. By default they move symmetrically, preserving the old behaviour.
- Shift-Dragging allows to move control points independently, for more freedom in shaping the mask.

Issues/possible areas of improvement:

1. Exposing the possibility of moving handles separately may break assumptions of the code that calculates the Bézier outline and the final mask, especially with regards to feathering. However in tests this seems to work mostly OK (except for 2). There is the possibility of creating wonky masks by using extreme inputs (i.e. loops, cases where the border control point is not on the border but inside the shape), but this has been possible before as well.
2. In rare situations the border outline incorrectly renders a full circle around a node.
3. Nodes move slightly when being selected (just click, no drag). This was the same before, not sure if it is intended.
4. It would be nicer, if the user could press and release shift while dragging and therefore change between symmetry modes on the fly. This is not possible because the state of the shift key is not available in _path_events_mouse_moved.

Includes an updated tooltip in English, German, Italian and French.

(I tried the clang-format tool from the contributing guidelines, but this tool wants to change lots of code that I did not touch. These commits only contain my actual changes.)