### PR TITLE
Removing max height of histogram

### DIFF
--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -461,6 +461,9 @@ guint dt_gui_translated_key_state(GdkEventKey *event);
 // return modifier keys currently pressed, independent of any key event
 GdkModifierType dt_key_modifier_state();
 
+// check if the given config_str is asking for height or aspect ratio configuration
+gboolean _config_uses_height(const char *config_str);
+
 GtkWidget *dt_ui_resize_wrap(GtkWidget *w,
                              const gint min_size,
                              char *config_str);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -2605,7 +2605,7 @@ void gui_init(dt_lib_module_t *self)
   // shows the scope, scale, and has draggable areas
   d->scope_draw = dt_ui_resize_wrap(NULL,
                                     0,
-                                    "plugins/darkroom/histogram/graphheight");
+                                    "plugins/darkroom/histogram/aspect_percent");
   ac = dt_action_define(dark, NULL, N_("hide histogram"), d->scope_draw, NULL);
   dt_action_register(ac, NULL, _lib_histogram_collapse_callback,
                      GDK_KEY_H, GDK_CONTROL_MASK | GDK_SHIFT_MASK);


### PR DESCRIPTION
When implementing height limits on modules, the histogram container was also limited. This is not desirable, though, since screens with high resolution make the histogram small and hard to read, particularly when using the scope. This commit fixes this by doing two things:

1) Making functions auto-detect whether they should use height or
   aspect ratio to manage the container size by checking whether
   the passed "config_str" variable refers to height or aspect ratio
   -- Note: this is actually safer anyway, since it was perfectly
            possible before to pass an AR request to a height function

2) Changing the histogram back to using aspect ratio instead of height