### PR TITLE
[GUI] Add forgotten gettext call to dt_gui_preferences_enum

### DIFF
--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -1259,7 +1259,8 @@ GtkWidget *dt_gui_preferences_enum(dt_action_t *action, const char *key)
   dt_bauhaus_combobox_alignment_t align = action ? DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT
                                                  : DT_BAUHAUS_COMBOBOX_ALIGN_LEFT;
   dt_bauhaus_combobox_set_selected_text_align(w, align);
-  if(action) gtk_widget_set_tooltip_text(w, dt_confgen_get_tooltip(key));
+  if(action)
+    gtk_widget_set_tooltip_text(w, _(dt_confgen_get_tooltip(key)));
 
   const char *values = dt_confgen_get(key, DT_VALUES);
   const char *defstr = dt_confgen_get(key, DT_DEFAULT);


### PR DESCRIPTION
This will show in the UI those translations that have already been made because they got into the .pot file from darktableconfig.xml, but were not displayed before because of a forgotten gettext call.

Since this PR does not require additional work by translators, it can definitely be added to 4.8.1.