### PR TITLE
[README.md] Streamline wording for 32/64-bit platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ Requirements
 
 ### Supported platforms
 
-* Linux (64-bit)
-* FreeBSD (64-bit)
-* Windows (64-bit), 8.1 w/ [UCRT](https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c) and later
+* Linux
+* FreeBSD
+* Windows 8.1 with [UCRT](https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c) and later
 * macOS 13.5 and later
 
 *Big-endian platforms are not supported.*


### PR DESCRIPTION
It does not make sense to specify additionally about the 64-bit nature of some supported platforms. A general statement below is enough: *32-bit platforms are not officially supported - they might or might not work.*