### PR TITLE
preferences: add NULL check

### DIFF
--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -1248,9 +1248,12 @@ static void
 _gui_preferences_enum_callback(GtkWidget *widget, gpointer data)
 {
   const gchar *index = dt_bauhaus_combobox_get_data(widget);
-  gchar *s = g_strndup(index, strchr(index, ']') - index);
-  dt_conf_set_string(data, s);
-  g_free(s);
+  if(index)
+  {
+    gchar *s = g_strndup(index, strchr(index, ']') - index);
+    dt_conf_set_string(data, s);
+    g_free(s);
+  }
 }
 
 GtkWidget *dt_gui_preferences_enum(dt_action_t *action, const char *key)


### PR DESCRIPTION
Fix the crash reported in #17065 by verifying that the data for the combobox is not NULL before attempting to use it.