### PR TITLE
update tooltip on 'refresh EXIF' button

### DIFF
--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2023 darktable developers.
+    Copyright (C) 2010-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -675,7 +675,9 @@ void gui_init(dt_lib_module_t *self)
 
   d->refresh_button = dt_action_button_new
     (self, N_("refresh EXIF"), button_clicked, GINT_TO_POINTER(14),
-     _("update image information to match changes to file"), 0, 0);
+     _("update all image information to match changes to file\n"
+       "warning: resets star ratings unless you select\n"
+       "'ignore exif rating' in the 'import' module\n"), 0, 0);
   gtk_grid_attach(grid, d->refresh_button, 0, line++, 6, 1);
 
   d->set_monochrome_button = dt_action_button_new


### PR DESCRIPTION
Tell users that star ratings will be overwritten unless they make a change in the import module.

Resolves #17056.
