### PR TITLE
Fix crashing monochrome -d pipe runs

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1124,7 +1124,7 @@ static gboolean _pixelpipe_process_on_CPU(
            piece->pipe, module, DT_DEVICE_CPU, roi_in, NULL, " %s -> %s `%s'\n",
            dt_iop_colorspace_to_name(cst_from),
            dt_iop_colorspace_to_name(cst_to),
-           dt_colorspaces_get_name(work_profile->type, work_profile->filename));
+           work_profile ? dt_colorspaces_get_name(work_profile->type, work_profile->filename) : "no work profile");
 
   // transform to module input colorspace
   dt_ioppr_transform_image_colorspace
@@ -1736,7 +1736,7 @@ static gboolean _dev_pixelpipe_process_rec(
                "transform colorspace", piece->pipe, module, pipe->devid, &roi_in, NULL, " %s -> %s `%s'\n",
                dt_iop_colorspace_to_name(cst_from),
                dt_iop_colorspace_to_name(cst_to),
-               dt_colorspaces_get_name(work_profile->type, work_profile->filename));
+               work_profile ? dt_colorspaces_get_name(work_profile->type, work_profile->filename) : "no work profile");
           success_opencl = dt_ioppr_transform_image_colorspace_cl
             (module, piece->pipe->devid,
              cl_mem_input, cl_mem_input,


### PR DESCRIPTION
While using monochromes we don't have a defined work profile while we transform the colorspace so we have to check that while reporting in the log instead of access to NULL.