### PR TITLE
Fixed null pointer dereference issue.

### DIFF
--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -2032,17 +2032,17 @@ void dt_colorspaces_set_display_profile
   int profile_changed = 0;
   if(profile_type == DT_COLORSPACE_DISPLAY2)
   {
-    profile_changed
-        = buffer_size > 0
-      && (darktable.color_profiles->xprofile_size2 != buffer_size
-          || memcmp(darktable.color_profiles->xprofile_data2, buffer, buffer_size) != 0);
+      profile_changed
+          = buffer_size > 0
+        && (darktable.color_profiles->xprofile_size2 != buffer_size
+            || (buffer != NULL && memcmp(darktable.color_profiles->xprofile_data2, buffer, buffer_size) != 0));
   }
   else
   {
-    profile_changed
-        = buffer_size > 0
-      && (darktable.color_profiles->xprofile_size != buffer_size
-          || memcmp(darktable.color_profiles->xprofile_data, buffer, buffer_size) != 0);
+      profile_changed
+          = buffer_size > 0
+        && (darktable.color_profiles->xprofile_size != buffer_size
+            || (buffer != NULL && memcmp(darktable.color_profiles->xprofile_data, buffer, buffer_size) != 0));
   }
   if(profile_changed)
   {


### PR DESCRIPTION
There was a null pointer dereference issue in `common/colorspaces.c`.

```
common/colorspaces.c:2038:63: error: Null pointer dereference: buffer [nullPointer]
          || memcmp(darktable.color_profiles->xprofile_data2, buffer, buffer_size) != 0);
                                                              ^
```

I modified it to this to prevent this error:

```c
if(profile_type == DT_COLORSPACE_DISPLAY2)
  {
      profile_changed
          = buffer_size > 0
        && (darktable.color_profiles->xprofile_size2 != buffer_size
            || (buffer != NULL && memcmp(darktable.color_profiles->xprofile_data2, buffer, buffer_size) != 0));
  }
  else
  {
      profile_changed
          = buffer_size > 0
        && (darktable.color_profiles->xprofile_size != buffer_size
            || (buffer != NULL && memcmp(darktable.color_profiles->xprofile_data, buffer, buffer_size) != 0));
  }
 ```
 
 In this version, `memcmp` is only called if `buffer` is not `NULL`.