### PR TITLE
Avoid colorspace conversions

### DIFF
--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -163,7 +163,7 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
                                             dt_dev_pixelpipe_t *pipe,
                                             dt_dev_pixelpipe_iop_t *piece)
 {
-  return IOP_CS_RGB;
+  return (pipe && pipe->dsc.cst == IOP_CS_LAB) ? IOP_CS_LAB : IOP_CS_RGB;
 }
 
 static int _gui_has_focus(struct dt_iop_module_t *self)

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -100,7 +100,7 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
                                             dt_dev_pixelpipe_t *pipe,
                                             dt_dev_pixelpipe_iop_t *piece)
 {
-  return IOP_CS_RGB;
+  return (pipe && pipe->dsc.cst == IOP_CS_LAB) ? IOP_CS_LAB : IOP_CS_RGB;
 }
 
 const char **description(struct dt_iop_module_t *self)

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -198,7 +198,7 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
 {
   // This module might possible work in RAW or RGB (e.g. for TIFF files) color space
   // depending on the input but will not change it.
-  return (piece && piece->dsc_in.cst != IOP_CS_RAW) ? IOP_CS_RGB : IOP_CS_RAW;
+  return (pipe && pipe->dsc.cst == IOP_CS_RGB) ? IOP_CS_RGB : IOP_CS_RAW;
 }
 
 int legacy_params(dt_iop_module_t *self,


### PR DESCRIPTION
This fixes:

1. if there was no colorspace transformations because of "nothing to do" we might still have to copy the buffer if output differs from input.
2. Some modules can avoid pre colorspace transformation as they simply don't care about colorspace. This avoids transformation in certain cases.