### PR TITLE
[README.md] Add more platforms on which darktable is known to be available

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Requirements
 
 * Linux
 * FreeBSD
+* NetBSD
+* OpenBSD
 * Windows 8.1 with [UCRT](https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c) and later
 * macOS 13.5 and later
 


### PR DESCRIPTION
darktable is available (and has more or less fresh versions) also on [NetBSD](http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/graphics/darktable/) and [OpenBSD](https://github.com/openbsd/ports/tree/master/graphics/darktable).