### PR TITLE
Use Windows Terminal to display DT stdout/stderr

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -280,16 +280,18 @@ static int usage(const char *argv0)
 #endif
          "\n"
          "    If -d signal or -d all is specified, specify the signal action\n"
-         "    to debug using this option.\n");
+         "    to debug using this option.\n"
+         "\n");
 #ifdef _WIN32
-  printf("\n\n");
-  printf("Debug log and output will be written to this file:\n");
+  printf("\n");
+  printf("Debug log and output will be written to this file (unless running in \n"
+         "Windows Terminal):\n\n");
   printf("    %s\n", logfile);
 #else
-  printf("\n");
 #endif
 
-  printf("See %s for more detailed documentation.\n"
+  printf("\n"
+         "See %s for more detailed documentation.\n"
          "See %s to report bugs.\n",
          PACKAGE_DOCS,
          PACKAGE_BUGREPORT);

--- a/src/main.c
+++ b/src/main.c
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
 #endif
 #ifdef _WIN32
   // on Windows we have a hard time showing stuff printed to stdout/stderr to the user.
-  // because of that we write it to a log file.
+  // because of that we write it to a log file (unless Windows Terminal is used)
   char datetime[DT_DATETIME_EXIF_LENGTH];
   dt_datetime_now_to_exif(datetime);
 
@@ -48,14 +48,33 @@ int main(int argc, char *argv[])
   int err_type = GetFileType(GetStdHandle(STD_ERROR_HANDLE));
   gboolean redirect_output = ((out_type != FILE_TYPE_DISK && out_type != FILE_TYPE_PIPE) &&
                               (err_type != FILE_TYPE_DISK && err_type != FILE_TYPE_PIPE));
+  const gboolean running_in_wt = (getenv("WT_SESSION") != NULL);
 
-  for(int k = 1; k < argc; k++)
+  if (running_in_wt)
   {
-    // For simple arguments do not redirect stdout
-    if(!strcmp(argv[k], "--help") || !strcmp(argv[k], "-h") || !strcmp(argv[k], "/?") || !strcmp(argv[k], "--version"))
+    // Let's assume that Windows Terminal is good enough to display debug output, and perhaps that
+    // the user runs DT from a terminal because they actually expect to see something being printed out.
+    // Windows Terminal is available on Windows 11 by default.
+    redirect_output = FALSE;
+  }
+  else
+  {
+    for(int k = 1; k < argc; k++)
     {
-      redirect_output = FALSE;
-      break;
+      // For simple arguments do not redirect stdout
+      if(!strcmp(argv[k], "--help") || !strcmp(argv[k], "-h") || !strcmp(argv[k], "/?") || !strcmp(argv[k], "--version"))
+      {
+        redirect_output = FALSE;
+        break;
+      }
+      if (strcmp(argv[k], "-d") || strcmp(argv[k], "--debug"))
+      {
+        if (running_in_wt)
+        {
+          redirect_output = FALSE;
+          break;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Currently on Windows, DT redirects all output to

    %LOCALAPPDATA%\Microsoft\Windows\INetCache\darktable\darktable-log.txt

I suggest to override this behavior for Windows Terminal which is the default terminal app since Windows 11, assuming that the user runs DT in a terminal for debugging reasons.

It is however still perfectly possible to redirect DT output using the standard redirection operator:

    darktable\bin\darktable.exe -d lua > darktable.log 2>&1