### PR TITLE
highlights and demosaic fixes

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -483,6 +483,7 @@ kernel void highlights_chroma(
   float sum[3] = {0.0f, 0.0f, 0.0f};
   float cnt[3] = {0.0f, 0.0f, 0.0f};
 
+  float clipped = 0.0f;
   for(int col = 3; col < width-3; col++)
   {
     const int idx = mad24(row, width, col);
@@ -495,16 +496,18 @@ kernel void highlights_chroma(
       sum[color] += inval - ref;
       cnt[color] += 1.0f;
     }
+    if(mask[px]) clipped += 1.0f;
   }
 
   for(int c = 0; c < 3; c++)
   {
     if(cnt[c] > 0.0f)
     {
-      accu[row*6 + 2*c] = sum[c];
-      accu[row*6 + 2*c +1] = cnt[c];
+      accu[row*8 + 2*c] = sum[c];
+      accu[row*8 + 2*c +1] = cnt[c];
     }
   }
+  accu[row*8 + 6] = clipped;
 }
 
 kernel void highlights_opposed(

--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -331,17 +331,17 @@ static float _calc_refavg(
   float sum[3] =  { 0.0f, 0.0f, 0.0f };
   float cnt[3]  = { 0.0f, 0.0f, 0.0f };
 
-  const int dymin = (row > 0) ? -1 : 0;
-  const int dxmin = (col > 0) ? -1 : 0;
-  const int dymax = (row < maxrow -1) ? 2 : 1;
-  const int dxmax = (col < maxcol -1) ? 2 : 1;
+  const int dymin = max(0, row - 1);
+  const int dxmin = max(0, col - 1);
+  const int dymax = min(maxrow - 1, row + 2);
+  const int dxmax = min(maxcol - 1, col + 2);
 
   for(int dy = dymin; dy < dymax; dy++)
   {
     for(int dx = dxmin; dx < dxmax; dx++)
     {
-      const float val = fmax(0.0f, read_imagef(in, samplerA, (int2)(col+dx, row+dy)).x);
-      const int c = (filters == 9u) ? FCxtrans(row + dy, col + dx, xtrans) : FC(row + dy, col + dx, filters);
+      const float val = fmax(0.0f, read_imagef(in, samplerA, (int2)(dx, dy)).x);
+      const int c = (filters == 9u) ? FCxtrans(dy, dx, xtrans) : FC(dy, dx, filters);
       sum[c] += val;
       cnt[c] += 1.0f;
     }

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -425,10 +425,10 @@ void modify_roi_in(
 {
   *roi_in = *roi_out;
   // need 1:1, demosaic and then sub-sample. or directly sample half-size
-  roi_in->x /= roi_out->scale;
-  roi_in->y /= roi_out->scale;
-  roi_in->width /= roi_out->scale;
-  roi_in->height /= roi_out->scale;
+  roi_in->x = floorf(roi_in->x / roi_out->scale);
+  roi_in->y = floorf(roi_in->y / roi_out->scale);
+  roi_in->width = ceilf(roi_in->width / roi_out->scale);
+  roi_in->height = ceilf(roi_in->height / roi_out->scale);
   roi_in->scale = 1.0f;
 
   dt_iop_demosaic_data_t *data = (dt_iop_demosaic_data_t *)piece->data;

--- a/src/iop/hlreconstruct/opposed.c
+++ b/src/iop/hlreconstruct/opposed.c
@@ -335,7 +335,7 @@ static float *_process_opposed(
 
       dt_print_pipe(DT_DEBUG_PIPE,
           "opposed chroma", piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out,
-          "red: %3.4f, green: %3.4f, blue: %3.4f for hash=%" PRIx64 "%s%s\n",
+          "red=%3.4f green=%3.4f blue=%3.4f hash=%" PRIx64 "%s%s\n",
           chrominance[0], chrominance[1], chrominance[2],
           _opposed_parhash(piece),
           piece->pipe->type == DT_DEV_PIXELPIPE_FULL ? ", saved to cache" : "",
@@ -438,9 +438,6 @@ static cl_int process_opposed_cl(
   float *claccu = NULL;
 
   const size_t iheight = ROUNDUPDHT(roi_in->height, devid);
-  const size_t owidth = ROUNDUPDWD(roi_out->width, devid);
-  const size_t oheight = ROUNDUPDHT(roi_out->height, devid);
-
   const int mwidth  = roi_in->width / 3;
   const int mheight = roi_in->height / 3;
   const int msize = dt_round_size((size_t) (mwidth+1) * (mheight+1), 16);
@@ -490,11 +487,11 @@ static cl_int process_opposed_cl(
     if(err != CL_SUCCESS) goto error;
 
     err = DT_OPENCL_SYSMEM_ALLOCATION;
-    const size_t accusize = sizeof(float) * 6 * iheight;
+    const size_t accusize = sizeof(float) * 8 * iheight;
     dev_accu = dt_opencl_alloc_device_buffer(devid, accusize);
     if(dev_accu == NULL) goto error;
 
-    claccu = dt_calloc_align_float(6 * iheight);
+    claccu = dt_calloc_align_float(8 * iheight);
     if(claccu == NULL) goto error;
 
     err = dt_opencl_write_buffer_to_device(devid, claccu, dev_accu, 0, accusize, TRUE);
@@ -517,12 +514,14 @@ static cl_int process_opposed_cl(
     // collect row data and accumulate
     dt_aligned_pixel_t sums = { 0.0f, 0.0f, 0.0f};
     dt_aligned_pixel_t cnts = { 0.0f, 0.0f, 0.0f};
+    float clipped = 0.0f;
     for(int row = 3; row < roi_in->height - 3; row++)
     {
       for_three_channels(c)
       {
-        sums[c] += claccu[6*row + 2*c];
-        cnts[c] += claccu[6*row + 2*c +1];
+        sums[c] += claccu[8*row + 2*c];
+        cnts[c] += claccu[8*row + 2*c +1];
+        clipped += claccu[8*row + 6];
       }
     }
     for_three_channels(c)
@@ -533,13 +532,12 @@ static cl_int process_opposed_cl(
       for_three_channels(c)
         img_oppchroma[c] = chrominance[c];
       img_opphash = opphash;
-
-      img_oppclipped = cnts[0] > 0.0f || cnts[1] > 0.0f || cnts[2] > 0.0f;
+      img_oppclipped = clipped > 0.0f;
     }
 
     dt_print_pipe(DT_DEBUG_PIPE,
         "opposed chroma", piece->pipe, self, piece->pipe->devid, roi_in, roi_out,
-        "red: %3.4f, green: %3.4f, blue: %3.4f for hash=%" PRIx64 "%s%s\n",
+        "red=%3.4f green=%3.4f, blue=%3.4f hash=%" PRIx64 "%s%s\n",
         chrominance[0], chrominance[1], chrominance[2],
         _opposed_parhash(piece),
         piece->pipe->type == DT_DEV_PIXELPIPE_FULL ? ", saved to cache" : "",
@@ -550,7 +548,7 @@ static cl_int process_opposed_cl(
   dev_chrominance = dt_opencl_copy_host_to_device_constant(devid, 4 * sizeof(float), chrominance);
   if(dev_chrominance == NULL) goto error;
 
-  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_highlights_opposed, owidth, oheight,
+  err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_highlights_opposed, roi_out->width, roi_out->height,
           CLARG(dev_in), CLARG(dev_out),
           CLARG(roi_out->width), CLARG(roi_out->height),
           CLARG(roi_in->width), CLARG(roi_in->height),

--- a/src/iop/hlreconstruct/opposed.c
+++ b/src/iop/hlreconstruct/opposed.c
@@ -316,7 +316,7 @@ static float *_process_opposed(
             if((inval < clips[color]) && (inval > lo_clips[color])
                && (mask[(color+3) * msize + _raw_to_cmap(mwidth, row, col)]))
             {
-              sums[color] += inval - _calc_refavg(&input[idx], xtrans, filters, row, col, roi_in, correction, TRUE);
+              sums[color] += inval - _calc_refavg(input, xtrans, filters, row, col, roi_in, correction, TRUE);
               cnts[color] += 1.0f;
             }
           }
@@ -357,7 +357,7 @@ static float *_process_opposed(
         const float inval = MAX(0.0f, input[idx]);
         if(inval >= clips[color])
         {
-          const float ref = _calc_refavg(&input[idx], xtrans, filters, row, col, roi_in, correction, TRUE);
+          const float ref = _calc_refavg(input, xtrans, filters, row, col, roi_in, correction, TRUE);
           tmpout[idx] = MAX(inval, ref + chrominance[color]);
         }
         else
@@ -386,7 +386,7 @@ static float *_process_opposed(
           oval = MAX(0.0f, input[ix]);
           if(oval >= clips[color])
           {
-            const float ref = _calc_refavg(&input[ix], xtrans, filters, irow, icol, roi_in, correction, TRUE);
+            const float ref = _calc_refavg(input, xtrans, filters, irow, icol, roi_in, correction, TRUE);
             oval = MAX(oval, ref + chrominance[color]);
           }
         }

--- a/src/iop/hlreconstruct/segbased.c
+++ b/src/iop/hlreconstruct/segbased.c
@@ -198,17 +198,17 @@ static inline float _calc_refavg(const float *in,
   dt_aligned_pixel_t mean = { 0.0f, 0.0f, 0.0f, 0.0f };
   dt_aligned_pixel_t cnt = { 0.0f, 0.0f, 0.0f, 0.0f };
 
-  const int dymin = (row > 0) ? -1 : 0;
-  const int dxmin = (col > 0) ? -1 : 0;
-  const int dymax = (row < roi->height -1) ? 2 : 1;
-  const int dxmax = (col < roi->width -1) ? 2 : 1;
+  const int dymin = MAX(0, row - 1);
+  const int dxmin = MAX(0, col - 1);
+  const int dymax = MIN(roi->height - 1, row +2);
+  const int dxmax = MIN(roi->width - 1, col + 2);
 
   for(int dy = dymin; dy < dymax; dy++)
   {
     for(int dx = dxmin; dx < dxmax; dx++)
     {
       const float val = fmaxf(0.0f, in[(size_t)dy * roi->width + dx]);
-      const int c = (filters == 9u) ? FCxtrans(row + dy, col + dx, roi, xtrans) : FC(row + dy, col + dx, filters);
+      const int c = (filters == 9u) ? FCxtrans(dy, dx, roi, xtrans) : FC(dy, dx, filters);
       mean[c] += val;
       cnt[c] += 1.0f;
     }
@@ -580,7 +580,7 @@ static void _process_segmentation(dt_dev_pixelpipe_iop_t *piece,
           if(candidate != 0.0f)
           {
             const float cand_reference = isegments[color].val2[pid];
-            const float refavg_here = _calc_refavg(&input[idx], xtrans, filters, row, col, roi_in, correction, FALSE);
+            const float refavg_here = _calc_refavg(input, xtrans, filters, row, col, roi_in, correction, FALSE);
             const float oval = powf(refavg_here + candidate - cand_reference, HL_POWERF);
             tmpout[idx] = plane[color][o] = fmaxf(inval, oval);
           }


### PR DESCRIPTION
1. Fix demosaic modify_roi_in: We should try to keep roi_in width&height as requested by avoiding rounding errors.
2. Fix calc_refavg() at right and bottom borders:
 Restrict tested locations to valid positions being strictly inside the given roi width & height. In OpenCL we could have tested via `sampleri` but that would not allow us to ensure a correctly tested color plane.
No performance penalty while doing so.

Stumbled across this while checking #16986, see the relevant part of the log
```
    22.3700 modify roi OUT                [full]           flip                   (   0/   0) 6048x4024 scale=1.0000 --> (   0/   0) 4024x6048 scale=1.0000 ID=1
    22.3701 pipe cache check              [full]                                  64 lines (important=0, used=0). Freed 0MB. Using using 0MB, limit=995MB
    22.3701 pipe starting             CL0 [full]                                  (   0/   0)  718x1079 scale=0.1784 --> (   0/   0)  718x1079 scale=0.1784 ID=1, amdacceleratedparallelprocessinggfx90cxnack
    22.3701 [dt_opencl_check_tuning] use 21358MB (headroom=OFF, pinning=OFF) on device `AMD Accelerated Parallel Processing gfx90c:xnack-' id=0
    22.3702 modify roi IN                 [full]           flip                   (   0/   0) 1079x 718 scale=0.1784 --> (   0/   0)  718x1079 scale=0.1784 ID=1
    22.3702 modify roi IN                 [full]           demosaic               (   0/   0) 6047x4024 scale=1.0000 --> (   0/   0) 1079x 718 scale=0.1784 ID=1
    22.3702 modify roi IN                 [full]           highlights             (   0/   0) 6048x4024 scale=1.0000 --> (   0/   0) 6047x4024 scale=1.0000 ID=1
    22.3702 pipe data: full               [full]                                  (   0/   0) 6048x4024 scale=1.0000 --> (   0/   0) 6048x4024 scale=1.0000
    22.3921 process                   CL0 [full]           rawprepare             (   0/   0) 6048x4024 scale=1.0000 --> (   0/   0) 6048x4024 scale=1.0000   1 IOP_CS_RAW
    22.4127 process                   CL0 [full]           temperature            (   0/   0) 6048x4024 scale=1.0000 --> (   0/   0) 6048x4024 scale=1.0000   3 IOP_CS_RAW
    22.4295 process                   CL0 [full]           highlights             (   0/   0) 6048x4024 scale=1.0000 --> (   0/   0) 6047x4024 scale=1.0000   4 IOP_CS_RAW
    22.4501 opposed chroma            CL0 [full]           highlights             (   0/   0) 6048x4024 scale=1.0000 --> (   0/   0) 6047x4024 scale=1.0000 red: 0.0000, green: 0.0000, blue: 0.0000 for hash=2e8f5d919320142, saved to cache, unclipped

```

Not sure if this really fixes the problem but we could run into such border issues.

Latest commit also fixes the OpenCL check for any-photosite-clipped.

Fixes #17189