### PR TITLE
implement callback for GtkDarktableResetLabel

### DIFF
--- a/src/dtgtk/resetlabel.c
+++ b/src/dtgtk/resetlabel.c
@@ -36,19 +36,26 @@ static gboolean _reset_label_callback(GtkDarktableResetLabel *label, GdkEventBut
            ((char *)label->module->default_params) + label->offset, label->size);
     if(label->module->gui_update) label->module->gui_update(label->module);
     dt_dev_add_history_item(darktable.develop, label->module, FALSE);
+
+    if(label->reset_callback)
+    {
+      ((void (*)(GtkDarktableResetLabel *, gpointer))label->reset_callback)(label, label->module);
+    }
+
     return TRUE;
   }
   return FALSE;
 }
 
 // public functions
-GtkWidget *dtgtk_reset_label_new(const gchar *text, dt_iop_module_t *module, void *param, int param_size)
+GtkWidget *dtgtk_reset_label_new(const gchar *text, dt_iop_module_t *module, void *param, int param_size, GCallback reset_callback)
 {
   GtkDarktableResetLabel *label;
   label = g_object_new(dtgtk_reset_label_get_type(), NULL);
   label->module = module;
   label->offset = param - (void *)module->params;
   label->size = param_size;
+  label->reset_callback = reset_callback;
 
   label->lb = GTK_LABEL(gtk_label_new(text));
   gtk_widget_set_halign(GTK_WIDGET(label->lb), GTK_ALIGN_START);

--- a/src/dtgtk/resetlabel.h
+++ b/src/dtgtk/resetlabel.h
@@ -31,12 +31,13 @@ struct _GtkDarktableResetLabel
   GtkEventBox widget;
   GtkLabel *lb;
   dt_iop_module_t *module;
-  int offset; // offset in params to reset
-  int size;   // size of param to reset
+  int offset;                // offset in params to reset
+  int size;                  // size of param to reset
+  GCallback reset_callback;  // pointer to callback function
 };
 
 /** instantiate a new darktable reset label for the given module and param. */
-GtkWidget *dtgtk_reset_label_new(const gchar *label, dt_iop_module_t *module, void *param, int param_size);
+GtkWidget *dtgtk_reset_label_new(const gchar *label, dt_iop_module_t *module, void *param, int param_size, GCallback reset_callback);
 /** Sets the text within the GtkResetLabel widget. It overwrites any text that was there before. */
 void dtgtk_reset_label_set_text(GtkDarktableResetLabel *label, const gchar *str);
 

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -772,8 +772,8 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void aspect_changed(GtkWidget *combo,
-                           dt_iop_module_t *self)
+static void _aspect_changed(GtkWidget *combo,
+                            dt_iop_module_t *self)
 {
   dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
@@ -789,8 +789,8 @@ static void aspect_changed(GtkWidget *combo,
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void position_h_changed(GtkWidget *combo,
-                               dt_iop_module_t *self)
+static void _position_h_changed(GtkWidget *combo,
+                                dt_iop_module_t *self)
 {
   dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
@@ -806,8 +806,8 @@ static void position_h_changed(GtkWidget *combo,
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void position_v_changed(GtkWidget *combo,
-                               dt_iop_module_t *self)
+static void _position_v_changed(GtkWidget *combo,
+                                dt_iop_module_t *self)
 {
   dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
@@ -860,7 +860,7 @@ void gui_changed(dt_iop_module_t *self,
   }
 }
 
-static void colorpick_color_set(GtkColorButton *widget,
+static void _colorpick_color_set(GtkColorButton *widget,
                                 dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return;
@@ -878,9 +878,28 @@ static void colorpick_color_set(GtkColorButton *widget,
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
+static void _reset_border_color(GtkDarktableResetLabel label, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
+  dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
+  dt_iop_borders_params_t *dp = (dt_iop_borders_params_t *)self->default_params;
 
-static void frame_colorpick_color_set(GtkColorButton *widget,
-                                      dt_iop_module_t *self)
+  GdkRGBA c = (GdkRGBA){.red = dp->color[0],
+                        .green = dp->color[1],
+                        .blue = dp->color[2],
+                        .alpha = 1.0 };
+
+  gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(g->colorpick), &c);
+
+  p->color[0] = dp->color[0];
+  p->color[1] = dp->color[1];
+  p->color[2] = dp->color[2];
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void _frame_colorpick_color_set(GtkColorButton *widget, dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return;
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
@@ -896,6 +915,28 @@ static void frame_colorpick_color_set(GtkColorButton *widget,
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
+
+static void _reset_frame_color(GtkDarktableResetLabel label, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
+  dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
+  dt_iop_borders_params_t *dp = (dt_iop_borders_params_t *)self->default_params;
+
+  GdkRGBA c = (GdkRGBA){.red = dp->frame_color[0],
+                        .green = dp->frame_color[1],
+                        .blue = dp->frame_color[2],
+                        .alpha = 1.0 };
+
+  gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(g->frame_colorpick), &c);
+
+  p->frame_color[0] = dp->frame_color[0];
+  p->frame_color[1] = dp->frame_color[1];
+  p->frame_color[2] = dp->frame_color[2];
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
 
 void gui_update(struct dt_iop_module_t *self)
 {
@@ -925,7 +966,8 @@ void gui_update(struct dt_iop_module_t *self)
 void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_borders_gui_data_t *g = IOP_GUI_ALLOC(borders);
-  dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->default_params;
+  dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
+  dt_iop_borders_params_t *dp = (dt_iop_borders_params_t *)self->default_params;
 
   g->basis = dt_bauhaus_combobox_from_params(self, "basis");
   gtk_widget_set_tooltip_text(g->basis,
@@ -940,7 +982,7 @@ void gui_init(struct dt_iop_module_t *self)
   DT_BAUHAUS_COMBOBOX_NEW_FULL(g->aspect, self, NULL, N_("aspect"),
                                _("select the aspect ratio\n"
                                  "(right click on slider below to type your own w:h)"),
-                               0, aspect_changed, self,
+                               0, _aspect_changed, self,
                                N_("image"),
                                N_("3:1"),
                                N_("95:33"),
@@ -975,7 +1017,7 @@ void gui_init(struct dt_iop_module_t *self)
   DT_BAUHAUS_COMBOBOX_NEW_FULL(g->pos_h, self, NULL, N_("horizontal position"),
                                _("select the horizontal position ratio relative to top\n"
                                  "(right click on slider below to type your own x:w)"),
-                               0, position_h_changed, self,
+                               0, _position_h_changed, self,
                                N_("center"), N_("1/3"), N_("3/8"),
                                N_("5/8"), N_("2/3"), N_("custom..."));
   gtk_box_pack_start(GTK_BOX(self->widget), g->pos_h, TRUE, TRUE, 0);
@@ -986,7 +1028,7 @@ void gui_init(struct dt_iop_module_t *self)
   DT_BAUHAUS_COMBOBOX_NEW_FULL(g->pos_v, self, NULL, N_("vertical position"),
                                _("select the vertical position ratio relative to left\n"
                                  "(right click on slider below to type your own y:h)"),
-                               0, position_v_changed, self,
+                               0, _position_v_changed, self,
                                N_("center"), N_("1/3"), N_("3/8"),
                                N_("5/8"), N_("2/3"), N_("custom..."));
   gtk_box_pack_start(GTK_BOX(self->widget), g->pos_v, TRUE, TRUE, 0);
@@ -1006,21 +1048,26 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->frame_offset,
                               _("offset of the frame line beginning on picture side"));
 
-  GdkRGBA color = (GdkRGBA){.red   = p->color[0],
-                            .green = p->color[1],
-                            .blue  = p->color[2],
+  GdkRGBA color = (GdkRGBA){.red   = dp->color[0],
+                            .green = dp->color[1],
+                            .blue  = dp->color[2],
                             .alpha = 1.0 };
+
+  GdkRGBA frame_color = (GdkRGBA){.red = dp->frame_color[0],
+                                  .green = dp->frame_color[1],
+                                  .blue = dp->frame_color[2],
+                                  .alpha = 1.0 };
 
   GtkWidget *label, *box;
 
   box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  label = dtgtk_reset_label_new(_("border color"), self, &p->color, 3 * sizeof(float), NULL);
+  label = dtgtk_reset_label_new(_("border color"), self, &p->color, 3 * sizeof(float), G_CALLBACK(_reset_border_color));
   gtk_box_pack_start(GTK_BOX(box), label, TRUE, TRUE, 0);
   g->colorpick = gtk_color_button_new_with_rgba(&color);
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->colorpick), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->colorpick), _("select border color"));
   g_signal_connect(G_OBJECT(g->colorpick), "color-set",
-                   G_CALLBACK(colorpick_color_set), self);
+                   G_CALLBACK(_colorpick_color_set), self);
   gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(g->colorpick), FALSE, TRUE, 0);
   g->border_picker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, box);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->border_picker),
@@ -1030,14 +1077,14 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), box, TRUE, TRUE, 0);
 
   box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  label = dtgtk_reset_label_new(_("frame line color"), self, &p->color, 3 * sizeof(float), NULL);
+  label = dtgtk_reset_label_new(_("frame line color"), self, &p->frame_color, 3 * sizeof(float), G_CALLBACK(_reset_frame_color));
   gtk_box_pack_start(GTK_BOX(box), label, TRUE, TRUE, 0);
-  g->frame_colorpick = gtk_color_button_new_with_rgba(&color);
+  g->frame_colorpick = gtk_color_button_new_with_rgba(&frame_color);
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->frame_colorpick), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->frame_colorpick),
                              _("select frame line color"));
   g_signal_connect(G_OBJECT(g->frame_colorpick), "color-set",
-                   G_CALLBACK(frame_colorpick_color_set), self);
+                   G_CALLBACK(_frame_colorpick_color_set), self);
   gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(g->frame_colorpick), FALSE, TRUE, 0);
   g->frame_picker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, box);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->frame_picker),

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -1014,7 +1014,7 @@ void gui_init(struct dt_iop_module_t *self)
   GtkWidget *label, *box;
 
   box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  label = dtgtk_reset_label_new(_("border color"), self, &p->color, 3 * sizeof(float));
+  label = dtgtk_reset_label_new(_("border color"), self, &p->color, 3 * sizeof(float), NULL);
   gtk_box_pack_start(GTK_BOX(box), label, TRUE, TRUE, 0);
   g->colorpick = gtk_color_button_new_with_rgba(&color);
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->colorpick), FALSE);
@@ -1030,7 +1030,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), box, TRUE, TRUE, 0);
 
   box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  label = dtgtk_reset_label_new(_("frame line color"), self, &p->color, 3 * sizeof(float));
+  label = dtgtk_reset_label_new(_("frame line color"), self, &p->color, 3 * sizeof(float), NULL);
   gtk_box_pack_start(GTK_BOX(box), label, TRUE, TRUE, 0);
   g->frame_colorpick = gtk_color_button_new_with_rgba(&color);
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->frame_colorpick), FALSE);

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -323,9 +323,9 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->vbox1), FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->vbox2), TRUE, TRUE, 0);
 
-  g->label1 = dtgtk_reset_label_new(_("radius"), self, &p->radius, sizeof(float));
+  g->label1 = dtgtk_reset_label_new(_("radius"), self, &p->radius, sizeof(float), NULL);
   gtk_box_pack_start(GTK_BOX(g->vbox1), g->label1, TRUE, TRUE, 0);
-  g->label2 = dtgtk_reset_label_new(_("amount"), self, &p->slope, sizeof(float));
+  g->label2 = dtgtk_reset_label_new(_("amount"), self, &p->slope, sizeof(float), NULL);
   gtk_box_pack_start(GTK_BOX(g->vbox1), g->label2, TRUE, TRUE, 0);
 
   g->scale1 = dt_bauhaus_slider_new_with_range(NULL, 0.0, 256.0, 0, p->radius, 0);

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -597,7 +597,7 @@ void gui_init(struct dt_iop_module_t *self)
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
   GtkWidget *label = dtgtk_reset_label_new(_("transform"),
-                                           self, &p->orientation, sizeof(int32_t));
+                                           self, &p->orientation, sizeof(int32_t), NULL);
   gtk_box_pack_start(GTK_BOX(self->widget), label, TRUE, TRUE, 0);
 
   dt_iop_button_new(self, N_("rotate 90 degrees CCW"),

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -492,7 +492,7 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_invert_params_t *p = (dt_iop_invert_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  g->label = DTGTK_RESET_LABEL(dtgtk_reset_label_new("", self, &p->color, sizeof(float) * 4));
+  g->label = DTGTK_RESET_LABEL(dtgtk_reset_label_new("", self, &p->color, sizeof(float) * 4, NULL));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->label), TRUE, TRUE, 0);
 
   g->pickerbuttons = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));

--- a/src/iop/overlay.c
+++ b/src/iop/overlay.c
@@ -1138,7 +1138,7 @@ void gui_init(struct dt_iop_module_t *self)
   // Create the 3x3 gtk table toggle button table...
   GtkWidget *bat = gtk_grid_new();
   GtkWidget *label = dtgtk_reset_label_new(_("alignment"),
-                                           self, &p->alignment, sizeof(p->alignment));
+                                           self, &p->alignment, sizeof(p->alignment), NULL);
   gtk_grid_attach(GTK_GRID(bat), label, 0, 0, 1, 3);
   gtk_widget_set_hexpand(label, TRUE);
   gtk_grid_set_row_spacing(GTK_GRID(bat), DT_PIXEL_APPLY_DPI(3));

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1001,7 +1001,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
 }
 
-static void watermark_callback(GtkWidget *tb, gpointer user_data)
+static void _watermark_callback(GtkWidget *tb, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_watermark_gui_data_t *g = (dt_iop_watermark_gui_data_t *)self->gui_data;
@@ -1042,7 +1042,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker,
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void load_watermarks(const char *basedir, dt_iop_watermark_gui_data_t *g)
+static void _load_watermarks(const char *basedir, dt_iop_watermark_gui_data_t *g)
 {
   GList *files = NULL;
   char *watermarks_dir = g_build_filename(basedir, "watermarks", NULL);
@@ -1081,12 +1081,12 @@ static void load_watermarks(const char *basedir, dt_iop_watermark_gui_data_t *g)
   g_free(watermarks_dir);
 }
 
-static void refresh_watermarks(dt_iop_module_t *self)
+static void _refresh_watermarks(dt_iop_module_t *self)
 {
   dt_iop_watermark_gui_data_t *g = (dt_iop_watermark_gui_data_t *)self->gui_data;
   dt_iop_watermark_params_t *p = (dt_iop_watermark_params_t *)self->params;
 
-  g_signal_handlers_block_by_func(g->watermarks, watermark_callback, self);
+  g_signal_handlers_block_by_func(g->watermarks, _watermark_callback, self);
 
   // Clear combobox...
   dt_bauhaus_combobox_clear(g->watermarks);
@@ -1099,21 +1099,21 @@ static void refresh_watermarks(dt_iop_module_t *self)
   dt_loc_get_datadir(datadir, sizeof(datadir));
   dt_loc_get_user_config_dir(configdir, sizeof(configdir));
 
-  load_watermarks(datadir, g);
-  load_watermarks(configdir, g);
+  _load_watermarks(datadir, g);
+  _load_watermarks(configdir, g);
 
   _combo_box_set_active_text(g, p->filename);
 
-  g_signal_handlers_unblock_by_func(g->watermarks, watermark_callback, self);
+  g_signal_handlers_unblock_by_func(g->watermarks, _watermark_callback, self);
 }
 
-static void refresh_callback(GtkWidget *tb, gpointer user_data)
+static void _refresh_callback(GtkWidget *tb, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  refresh_watermarks(self);
+  _refresh_watermarks(self);
 }
 
-static void alignment_callback(GtkWidget *tb, gpointer user_data)
+static void _alignment_callback(GtkWidget *tb, gpointer user_data)
 {
   int index = -1;
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
@@ -1126,7 +1126,7 @@ static void alignment_callback(GtkWidget *tb, gpointer user_data)
   for(int i = 0; i < 9; i++)
   {
     /* block signal handler */
-    g_signal_handlers_block_by_func(g->align[i], alignment_callback, user_data);
+    g_signal_handlers_block_by_func(g->align[i], _alignment_callback, user_data);
 
     if(GTK_WIDGET(g->align[i]) == tb)
     {
@@ -1137,13 +1137,39 @@ static void alignment_callback(GtkWidget *tb, gpointer user_data)
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->align[i]), FALSE);
 
     /* unblock signal handler */
-    g_signal_handlers_unblock_by_func(g->align[i], alignment_callback, user_data);
+    g_signal_handlers_unblock_by_func(g->align[i], _alignment_callback, user_data);
   }
   p->alignment = index;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void text_callback(GtkWidget *entry, gpointer user_data)
+static void _reset_alignment_callback(GtkDarktableResetLabel *label, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  dt_iop_watermark_gui_data_t *g = (dt_iop_watermark_gui_data_t *)self->gui_data;
+
+  if(darktable.gui->reset) return;
+  dt_iop_watermark_params_t *p = (dt_iop_watermark_params_t *)self->params;
+  dt_iop_watermark_params_t *dp = (dt_iop_watermark_params_t *)self->default_params;
+
+  for(int i = 0; i < 9; i++)
+  {
+    /* block signal handler */
+    g_signal_handlers_block_by_func(g->align[i], _alignment_callback, user_data);
+
+    if(i == dp->alignment)
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->align[i]), TRUE);
+    else
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->align[i]), FALSE);
+
+    /* unblock signal handler */
+    g_signal_handlers_unblock_by_func(g->align[i], _alignment_callback, user_data);
+  }
+  p->alignment = dp->alignment;
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void _text_callback(GtkWidget *entry, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(darktable.gui->reset) return;
@@ -1153,7 +1179,7 @@ static void text_callback(GtkWidget *entry, gpointer user_data)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void colorpick_color_set(GtkColorButton *widget, gpointer user_data)
+static void _colorpick_color_set(GtkColorButton *widget, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(darktable.gui->reset) return;
@@ -1171,7 +1197,7 @@ static void colorpick_color_set(GtkColorButton *widget, gpointer user_data)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void fontsel_callback(GtkWidget *button, gpointer user_data)
+static void _fontsel_callback(GtkWidget *button, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(darktable.gui->reset) return;
@@ -1314,7 +1340,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   // Simple text
   label = dt_ui_label_new(_("text"));
-  g->text = dt_action_entry_new(DT_ACTION(self), N_("text"), G_CALLBACK(text_callback), self,
+  g->text = dt_action_entry_new(DT_ACTION(self), N_("text"), G_CALLBACK(_text_callback), self,
                                 _("text string, tag:\n$(WATERMARK_TEXT)"),
                                 dt_conf_get_string_const("plugins/darkroom/watermark/text"));
   gtk_entry_set_placeholder_text(GTK_ENTRY(g->text), _("content"));
@@ -1389,7 +1415,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   // Create the 3x3 gtk table toggle button table...
   GtkWidget *bat = gtk_grid_new();
-  label = dtgtk_reset_label_new(_("alignment"), self, &p->alignment, sizeof(p->alignment), NULL);
+  label = dtgtk_reset_label_new(_("alignment"), self, &p->alignment, sizeof(p->alignment), G_CALLBACK(_reset_alignment_callback));
   gtk_grid_attach(GTK_GRID(bat), label, 0, 0, 1, 3);
   gtk_widget_set_hexpand(label, TRUE);
   gtk_grid_set_row_spacing(GTK_GRID(bat), DT_PIXEL_APPLY_DPI(3));
@@ -1398,7 +1424,7 @@ void gui_init(struct dt_iop_module_t *self)
   {
     g->align[i] = dtgtk_togglebutton_new(dtgtk_cairo_paint_alignment, (CPF_SPECIAL_FLAG << i), NULL);
     gtk_grid_attach(GTK_GRID(bat), GTK_WIDGET(g->align[i]), 1 + i%3, i/3, 1, 1);
-    g_signal_connect(G_OBJECT(g->align[i]), "toggled", G_CALLBACK(alignment_callback), self);
+    g_signal_connect(G_OBJECT(g->align[i]), "toggled", G_CALLBACK(_alignment_callback), self);
   }
 
   gtk_box_pack_start(GTK_BOX(self->widget), bat, FALSE, FALSE, 0);
@@ -1414,12 +1440,12 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->scale, _("the scale of the watermark"));
   gtk_widget_set_tooltip_text(g->rotate, _("the rotation of the watermark"));
 
-  refresh_watermarks(self);
+  _refresh_watermarks(self);
 
-  g_signal_connect(G_OBJECT(g->watermarks), "value-changed", G_CALLBACK(watermark_callback), self);
-  g_signal_connect(G_OBJECT(g->refresh), "clicked", G_CALLBACK(refresh_callback), self);
-  g_signal_connect(G_OBJECT(g->colorpick), "color-set", G_CALLBACK(colorpick_color_set), self);
-  g_signal_connect(G_OBJECT(g->fontsel), "font-set", G_CALLBACK(fontsel_callback), self);
+  g_signal_connect(G_OBJECT(g->watermarks), "value-changed", G_CALLBACK(_watermark_callback), self);
+  g_signal_connect(G_OBJECT(g->refresh), "clicked", G_CALLBACK(_refresh_callback), self);
+  g_signal_connect(G_OBJECT(g->colorpick), "color-set", G_CALLBACK(_colorpick_color_set), self);
+  g_signal_connect(G_OBJECT(g->fontsel), "font-set", G_CALLBACK(_fontsel_callback), self);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1300,7 +1300,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_loc_get_datadir(datadir, sizeof(datadir));
   dt_loc_get_user_config_dir(configdir, sizeof(configdir));
 
-  GtkWidget *label = dtgtk_reset_label_new(_("marker"), self, &p->filename, sizeof(p->filename));
+  GtkWidget *label = dtgtk_reset_label_new(_("marker"), self, &p->filename, sizeof(p->filename), NULL);
   g->watermarks = dt_bauhaus_combobox_new(self);
   gtk_widget_set_hexpand(GTK_WIDGET(g->watermarks), TRUE);
   char *tooltip = g_strdup_printf(_("SVG watermarks in %s/watermarks or %s/watermarks"), configdir, datadir);
@@ -1322,7 +1322,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_grid_attach_next_to(grid, g->text, label, GTK_POS_RIGHT, 2, 1);
 
   // Text font
-  label = dtgtk_reset_label_new(_("font"), self, &p->font, sizeof(p->font));
+  label = dtgtk_reset_label_new(_("font"), self, &p->font, sizeof(p->font), NULL);
   const char *str = dt_conf_get_string_const("plugins/darkroom/watermark/font");
   g->fontsel = gtk_font_button_new_with_font(str==NULL?"DejaVu Sans 10":str);
   GtkWidget *child = dt_gui_container_first_child(GTK_CONTAINER(gtk_bin_get_child(GTK_BIN(g->fontsel))));
@@ -1340,7 +1340,7 @@ void gui_init(struct dt_iop_module_t *self)
   float blue = dt_conf_get_float("plugins/darkroom/watermark/color_blue");
   GdkRGBA color = (GdkRGBA){.red = red, .green = green, .blue = blue, .alpha = 1.0 };
 
-  label = dtgtk_reset_label_new(_("color"), self, &p->color, 3 * sizeof(float));
+  label = dtgtk_reset_label_new(_("color"), self, &p->color, 3 * sizeof(float), NULL);
   g->colorpick = gtk_color_button_new_with_rgba(&color);
   gtk_widget_set_tooltip_text(g->colorpick, _("watermark color, tag:\n$(WATERMARK_COLOR)"));
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->colorpick), FALSE);
@@ -1389,7 +1389,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   // Create the 3x3 gtk table toggle button table...
   GtkWidget *bat = gtk_grid_new();
-  label = dtgtk_reset_label_new(_("alignment"), self, &p->alignment, sizeof(p->alignment));
+  label = dtgtk_reset_label_new(_("alignment"), self, &p->alignment, sizeof(p->alignment), NULL);
   gtk_grid_attach(GTK_GRID(bat), label, 0, 0, 1, 3);
   gtk_widget_set_hexpand(label, TRUE);
   gtk_grid_set_row_spacing(GTK_GRID(bat), DT_PIXEL_APPLY_DPI(3));


### PR DESCRIPTION
fixes #17157 

The problem here is that `_reset_label_callback()` resets the module parameters to its default values, but the according GUI element needs to be reset as well. So I have implemented a callback function for the GtkDarktableResetLabel to accomplish this.

The commits are per module for easier reverts if something went wrong.
