### PR TITLE
Added Bézier handles to path masks, so the control points can be moved independently

### DIFF
--- a/po/darktable.pot
+++ b/po/darktable.pot
@@ -8965,7 +8965,7 @@ msgstr ""
 
 #: ../src/develop/masks/path.c:3360
 msgid ""
-"<b>node curvature</b>: drag\n"
+"<b>node curvature</b>: drag, <b>move single handle</b>: shift+drag\n"
 "<b>reset curvature</b>: right-click"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -9572,10 +9572,11 @@ msgstr ""
 
 #: ../src/develop/masks/path.c:3360
 msgid ""
-"<b>node curvature</b>: drag\n"
+"<b>node curvature</b>: drag, <b>move single handle</b>: shift+drag\n"
 "<b>reset curvature</b>: right-click"
 msgstr ""
-"<b>Knoten Krümmung</b>: ziehen\n"
+"<b>Knoten Krümmung</b>: Ziehen, <b>Einzelnen Kontrollpunkt bewegen</b>: "
+"Shift+Ziehen,\n"
 "<b>Krümmung zurücksetzen</b>: Rechtsklick"
 
 #: ../src/develop/masks/path.c:3365

--- a/po/en@truecase.po
+++ b/po/en@truecase.po
@@ -9421,12 +9421,12 @@ msgstr ""
 "<b>Move node</b>: drag, <b>Remove node</b>: right-click\n"
 "<b>Switch smooth/sharp mode</b>: Ctrl+click"
 
-#: ../src/develop/masks/path.c:3360
+#: ../src/develop/masks/path.c:3360#: ../src/develop/masks/path.c:3360
 msgid ""
-"<b>node curvature</b>: drag\n"
+"<b>node curvature</b>: drag, <b>move single handle</b>: shift+drag\n"
 "<b>reset curvature</b>: right-click"
 msgstr ""
-"<b>Node curvature</b>: drag\n"
+"<b>Node Curvature</b>: drag, <b>Move single handle</b>: shift+drag\n"
 "<b>Reset curvature</b>: right-click"
 
 #: ../src/develop/masks/path.c:3365

--- a/po/fr.po
+++ b/po/fr.po
@@ -9575,10 +9575,11 @@ msgstr ""
 
 #: ../src/develop/masks/path.c:3360
 msgid ""
-"<b>node curvature</b>: drag\n"
+"<b>node curvature</b>: drag, <b>move single handle</b>: shift+drag\n"
 "<b>reset curvature</b>: right-click"
 msgstr ""
-"<b>Courbe du nœud</b> : déplacer\n"
+"<b>Courbe du nœud</b> : glisser, <b>Déplacer un seul point de contrôle</b> : "
+"Maj+glisser\n"
 "<b>Réinitialiser la courbe</b> : clic droit"
 
 #: ../src/develop/masks/path.c:3365

--- a/po/it.po
+++ b/po/it.po
@@ -9652,10 +9652,11 @@ msgstr ""
 
 #: ../src/develop/masks/path.c:3360
 msgid ""
-"<b>node curvature</b>: drag\n"
+"<b>node curvature</b>: drag, <b>move single handle</b>: shift+drag\n"
 "<b>reset curvature</b>: right-click"
 msgstr ""
-"<b>nodo curvatura</b>: trascina\n"
+"<b>nodo curvatura</b>: trascina, <b>muovere punto di controllo singolo</b>: "
+"maiusc+trascina\n"
 "<b>azzera curvatura</b>: clic pulsante destro"
 
 #: ../src/develop/masks/path.c:3365

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -120,6 +120,15 @@ typedef enum dt_masks_source_pos_type_t
   DT_MASKS_SOURCE_POS_ABSOLUTE = 2
 } dt_masks_source_pos_type_t;
 
+/* selected Bézier control point for path*/
+typedef enum dt_masks_path_ctrl_t
+{
+  DT_MASKS_PATH_CRTL_NONE = -1,
+  DT_MASKS_PATH_CTRL1 = 1,
+  DT_MASKS_PATH_CTRL2 = 2
+
+} dt_masks_path_ctrl_t;
+
 /** structure used to store 1 point for a circle */
 typedef struct dt_masks_point_circle_t
 {
@@ -367,6 +376,7 @@ typedef struct dt_masks_form_gui_t
   int point_selected;
   int point_edited;
   int feather_selected;
+  dt_masks_path_ctrl_t bezier_ctrl; // For paths, this selects a Bézier control point.
   int seg_selected;
   int point_border_selected;
   int source_pos_type;
@@ -378,6 +388,7 @@ typedef struct dt_masks_form_gui_t
   gboolean gradient_toggling;
   int point_dragging;
   int feather_dragging;
+  gboolean bezier_single;  // User drags a single control point.  
   int seg_dragging;
   int point_border_dragging;
 
@@ -828,6 +839,15 @@ float dt_masks_dynbuf_get(dt_masks_dynbuf_t *a, const int offset)
 }
 
 static inline
+float dt_masks_dynbuf_get_absolute(dt_masks_dynbuf_t *a, const int position)
+{
+  assert(a != NULL);
+  assert(position >= 0);
+  assert((long)a->pos > position);
+  return (a->buffer[position]);
+}
+
+static inline
 void dt_masks_dynbuf_set(dt_masks_dynbuf_t *a, const int offset, const float value)
 {
   assert(a != NULL);
@@ -835,6 +855,15 @@ void dt_masks_dynbuf_set(dt_masks_dynbuf_t *a, const int offset, const float val
   assert(offset < 0);
   assert((long)a->pos + offset >= 0);
   a->buffer[a->pos + offset] = value;
+}
+
+static inline
+void dt_masks_dynbuf_set_absolute(dt_masks_dynbuf_t *a, const int position, const float value)
+{
+  assert(a != NULL);
+  assert(position >= 0);
+  assert((long)a->pos > position);
+  a->buffer[position] = value;
 }
 
 static inline


### PR DESCRIPTION
Patch for issue #14236 .
Replaces my previous PR #17044 .

Includes changes to the way the feathering border is drawn for paths. The border could already be bugged in rare cases before. With the added freedom of moving the control points individually, broken feathering borders were much too easy to produce.

Includes one changed UI tooltip in English, German, French, Italian.