### PR TITLE
enhance tooltips for utility modules

### DIFF
--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2015-2023 darktable developers.
+    Copyright (C) 2015-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -58,6 +58,12 @@ typedef struct dt_lib_duplicate_t
 const char *name(dt_lib_module_t *self)
 {
   return _("duplicate manager");
+}
+
+const char *description(dt_lib_module_t *self)
+{
+  return _("create/rename/remove multiple\n"
+           "edits of the current image");
 }
 
 dt_view_type_flags_t views(dt_lib_module_t *self)

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2023 darktable developers.
+    Copyright (C) 2011-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -90,6 +90,13 @@ static void _lib_history_module_remove_callback(gpointer instance,
 const char *name(dt_lib_module_t *self)
 {
   return _("history");
+}
+
+const char *description(dt_lib_module_t *self)
+{
+  return _("display the sequence of edit actions\n"
+           "and allow temporarily returning to\n"
+           "an earlier state of the edit");
 }
 
 dt_view_type_flags_t views(dt_lib_module_t *self)

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2023 darktable developers.
+    Copyright (C) 2009-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -1104,7 +1104,10 @@ GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module)
   gtk_container_add(GTK_CONTAINER(label_evb), label);
   gchar *mname = g_markup_escape_text(module->name(module), -1);
   gtk_label_set_markup(GTK_LABEL(label), mname);
-  gtk_widget_set_tooltip_text(label_evb, mname);
+  if(module->description)
+    gtk_widget_set_tooltip_text(label_evb, module->description(module));
+  else
+    gtk_widget_set_tooltip_text(label_evb, mname);
   g_free(mname);
   gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
   g_object_set(G_OBJECT(label), "halign", GTK_ALIGN_START, "xalign", 0.0, (gchar *)0);

--- a/src/libs/lib_api.h
+++ b/src/libs/lib_api.h
@@ -55,6 +55,8 @@ DEFAULT(gboolean, expandable, struct dt_lib_module_t *self);
 /** constructor */
 OPTIONAL(void, init, struct dt_lib_module_t *self);
 /** callback methods for gui. */
+/** get a description string to be used as tooltip on the module header */
+OPTIONAL(const char*, description, struct dt_lib_module_t *self);
 /** construct widget. */
 REQUIRED(void, gui_init, struct dt_lib_module_t *self);
 /** destroy widget. */

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -98,6 +98,13 @@ const char *name(dt_lib_module_t *self)
   return _("snapshots");
 }
 
+const char *description(dt_lib_module_t *self)
+{
+  return _("remember a specific edit state and\n"
+           "allow comparing it against another\n"
+           "or returning to that version");
+}
+
 dt_view_type_flags_t views(dt_lib_module_t *self)
 {
   return DT_VIEW_DARKROOM;


### PR DESCRIPTION
Currently, the tooltips shown when hovering the header of a utility module simply show the module's name, which isn't very useful since one is already hovering over the name....  This commit adds the ability for a module to specify the tooltip in a description() function just like processing modules can, and adds new tooltips for the snapshots, history, and duplicate manager modules in the darkroom view.