### PR TITLE
[imageio] Correctly flag high bit depth PNG

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -142,7 +142,7 @@ gboolean dt_image_is_ldr(const dt_image_t *img)
 {
   const char *c = img->filename + strlen(img->filename);
   while(*c != '.' && c > img->filename) c--;
-  if((img->flags & DT_IMAGE_LDR) || !strcasecmp(c, ".jpg") || !strcasecmp(c, ".png")
+  if((img->flags & DT_IMAGE_LDR) || !strcasecmp(c, ".jpg") || !strcasecmp(c, ".webp")
      || !strcasecmp(c, ".ppm"))
     return TRUE;
   else

--- a/src/imageio/imageio_png.c
+++ b/src/imageio/imageio_png.c
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include <assert.h>
 #include <inttypes.h>
 #include <memory.h>
@@ -203,6 +204,9 @@ dt_imageio_retval_t dt_imageio_open_png(dt_image_t *img, const char *filename, d
 
   if(bpp < 16)
   {
+    img->flags &= ~DT_IMAGE_HDR;
+    img->flags |= DT_IMAGE_LDR;
+
     const float normalizer = 1.0f / 255.0f;
 
     DT_OMP_FOR()
@@ -215,6 +219,9 @@ dt_imageio_retval_t dt_imageio_open_png(dt_image_t *img, const char *filename, d
   }
   else
   {
+    img->flags &= ~DT_IMAGE_LDR;
+    img->flags |= DT_IMAGE_HDR;
+
     const float normalizer = 1.0f / 65535.0f;
 
     DT_OMP_FOR()
@@ -232,8 +239,6 @@ dt_imageio_retval_t dt_imageio_open_png(dt_image_t *img, const char *filename, d
   img->buf_dsc.filters = 0u;
   img->flags &= ~DT_IMAGE_RAW;
   img->flags &= ~DT_IMAGE_S_RAW;
-  img->flags &= ~DT_IMAGE_HDR;
-  img->flags |= DT_IMAGE_LDR;
   img->loader = LOADER_PNG;
 
   return DT_IMAGEIO_OK;


### PR DESCRIPTION
Although 8-bit PNG files are most common, the PNG format can contain data with a high bit depth (16 bits per channel). Our PNG loader even handles both options. But for some reason, regardless of the bit depth of the data in the image, the LDR flag was always set in the loader.

I am even more surprised that, although I worked a lot with loaders and more than once turned my attention to their source code, I noticed it only now. 🤷‍♂️

Also removed check for .png extension from dt_image_is_ldr (added .webp there instead, since that format is always LDR).
