### PR TITLE
add busy cursor to lengthy operations

### DIFF
--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2022 darktable developers.
+    Copyright (C) 2009-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -523,6 +523,11 @@ void dt_gui_hide_collapsible_section(dt_gui_collapsible_section_t *cs);
 // is delay between first and second click/press longer than double-click time?
 gboolean dt_gui_long_click(const int second,
                            const int first);
+
+// control whether the mouse pointer displays as a "busy" cursor, e.g. watch or timer
+// the calls may be nested, but must be matched
+void dt_gui_cursor_set_busy();
+void dt_gui_cursor_clear_busy();
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -277,8 +277,9 @@ static void _write_metadata(dt_lib_module_t *self)
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
     _metadata_set_list(i, &key_value, d);
 
-  if(key_value)
+  if(key_value && d->last_act_on)
   {
+    dt_gui_cursor_set_busy();
     dt_metadata_set_list(d->last_act_on, key_value, TRUE);
 
     for(GList *l = key_value; l; l = l->next->next) g_free(l->next->data);
@@ -290,6 +291,7 @@ static void _write_metadata(dt_lib_module_t *self)
                                   DT_SIGNAL_METADATA_CHANGED, DT_METADATA_SIGNAL_NEW_VALUE);
 
     dt_image_synch_xmps(d->last_act_on);
+    dt_gui_cursor_clear_busy();
   }
 
   g_list_free(d->last_act_on);

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2023 darktable developers.
+    Copyright (C) 2010-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -1071,6 +1071,7 @@ static void _attach_selected_tag(dt_lib_module_t *self, dt_lib_tagging_t *d)
   if(tagid <= 0) return;
 
   // attach tag on images to act on
+  dt_gui_cursor_set_busy();
   if(dt_tag_attach(tagid, -1, TRUE, TRUE))
   {
     /** record last tag used */
@@ -1105,6 +1106,7 @@ static void _attach_selected_tag(dt_lib_module_t *self, dt_lib_tagging_t *d)
     _raise_signal_tag_changed(self);
     dt_image_synch_xmp(-1);
   }
+  dt_gui_cursor_clear_busy();
 }
 
 static void _detach_selected_tag(GtkTreeView *view, dt_lib_module_t *self)
@@ -1124,6 +1126,7 @@ static void _detach_selected_tag(GtkTreeView *view, dt_lib_module_t *self)
   GList *affected_images = dt_tag_get_images_from_list(imgs, tagid);
   if(affected_images)
   {
+    dt_gui_cursor_set_busy();
     GtkTreePath *path = gtk_tree_model_get_path(model, &iter);
     gint *indices = gtk_tree_path_get_indices(path);
     const int index = indices[0];
@@ -1170,6 +1173,7 @@ static void _detach_selected_tag(GtkTreeView *view, dt_lib_module_t *self)
       dt_image_synch_xmps(affected_images);
     }
     g_list_free(affected_images);
+    dt_gui_cursor_clear_busy();
   }
   g_list_free(imgs);
 }


### PR DESCRIPTION
Bulk tagging (attach/detach) and metadata edits will now show a busy cursor while they are in progress.  Partially addresses #8909 by letting the user know that darktable is busy, though a full resolution will require moving the sidecar writes into a background job to dramatically reduce the busy time.
