### PR TITLE
[imageio] Exit AVIF loader early if the file extension is not .avif

### DIFF
--- a/src/imageio/imageio_avif.c
+++ b/src/imageio/imageio_avif.c
@@ -1,22 +1,21 @@
 /*
- * This file is part of darktable,
- * Copyright (C) 2019-2024 darktable developers.
- *
- *  darktable is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  darktable is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with darktable.  If not, see <http://www.gnu.org/licenses/>.
- */
+    This file is part of darktable,
+    Copyright (C) 2019-2024 darktable developers.
 
-#include "common/image.h"
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 #include <avif/avif.h>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -28,6 +27,7 @@
 #include <strings.h>
 
 #include "control/control.h"
+#include "common/image.h"
 #include "common/exif.h"
 #include "control/conf.h"
 #include "develop/develop.h"
@@ -38,6 +38,11 @@ dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
                                          const char *filename,
                                          dt_mipmap_buffer_t *mbuf)
 {
+  // We shouldn't expect AVIF images in files with an extension other than .avif
+  char *ext = g_strrstr(filename, ".");
+  if(ext && g_ascii_strcasecmp(ext, ".avif"))
+    return DT_IMAGEIO_LOAD_FAILED;
+
   dt_imageio_retval_t ret;
   avifImage *avif_image = avifImageCreateEmpty();
   avifDecoder *decoder = avifDecoderCreate();

--- a/src/imageio/imageio_avif.c
+++ b/src/imageio/imageio_avif.c
@@ -62,11 +62,7 @@ dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
   result = avifDecoderReadFile(decoder, avif_image, filename);
   if(result != AVIF_RESULT_OK)
   {
-    if(result != AVIF_RESULT_INVALID_FTYP)
-    {
-      /* print debug info only if genuine AVIF */
-      dt_print(DT_DEBUG_IMAGEIO, "[avif_open] failed to parse `%s': %s\n", filename, avifResultToString(result));
-    }
+    dt_print(DT_DEBUG_IMAGEIO, "[avif_open] failed to parse `%s': %s\n", filename, avifResultToString(result));
     ret = DT_IMAGEIO_LOAD_FAILED;
     goto out;
   }


### PR DESCRIPTION
This allows us to avoid cluttering the log with debug messages about decoding failures if the loader was called for a different format image.