### PR TITLE
move most sidecar writes into a background job

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,6 +94,7 @@ FILE(GLOB SOURCE_FILES
   "control/jobs/develop_jobs.c"
   "control/jobs/film_jobs.c"
   "control/jobs/image_jobs.c"
+  "control/jobs/sidecar_jobs.c"
   "control/progress.c"
   "control/signal.c"
   "develop/blend.c"

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -61,6 +61,7 @@
 #include "control/crawler.h"
 #include "control/jobs/control_jobs.h"
 #include "control/jobs/film_jobs.h"
+#include "control/jobs/sidecar_jobs.h"
 #include "control/signal.h"
 #include "develop/blend.h"
 #include "develop/imageop.h"
@@ -1687,6 +1688,9 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 #ifdef USE_LUA
   dt_lua_init(darktable.lua_state.state, lua_command);
 #endif
+
+  // fire up a background job to perform sidecar writes
+  dt_control_sidecar_synch_start();
 
   if(init_gui)
   {

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1437,7 +1437,7 @@ int dt_history_compress_on_list(const GList *imgs)
       // update history end
       dt_image_set_history_end(imgid, done);
 
-      dt_image_write_sidecar_file(imgid);
+      dt_image_synch_xmp(imgid);
     }
     if(test == 0) // no compression as history_end is right in the middle of history
       uncompressed++;

--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -397,7 +397,7 @@ void dt_image_cache_write_release_info(dt_image_cache_t *cache,
 
   if(mode == DT_IMAGE_CACHE_SAFE)
   {
-    dt_image_write_sidecar_file(img->id);
+    dt_image_synch_xmp(img->id);
     if(info)
     {
       const double spent = dt_get_debug_wtime() - start;

--- a/src/control/jobs/sidecar_jobs.c
+++ b/src/control/jobs/sidecar_jobs.c
@@ -1,0 +1,171 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2024 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "control/jobs/sidecar_jobs.h"
+
+static GSList *pending_images = NULL;
+static gboolean background_running = FALSE;
+
+#ifndef _OPENMP
+#include "common/dtpthread.h"
+static gboolean lock_initialized = FALSE;
+static dt_pthread_mutex_t pending_mutex;
+
+static void _lock_pending_queue()
+{
+  if(!lock_initialized)
+  {
+    dt_pthread_mutex_init(&pending_mutex, NULL);
+    lock_initialized = TRUE;
+  }
+  dt_pthread_mutex_lock(&pending_mutex);
+}
+
+static void _unlock_pending_queue()
+{
+  if(lock_initialized)
+  {
+    dt_pthread_mutex_unlock(&pending_mutex);
+  }
+}
+#endif /* !_OPENMP */
+
+static int32_t _control_write_sidecars_job_run(dt_job_t *job)
+{
+  GSList *imgs = NULL;
+  GHashTable *enqueued = g_hash_table_new(g_direct_hash, g_direct_equal);
+
+  // keep going until explicitly cancelled or darktable shuts down AND all writes have finished
+  while(imgs || (dt_control_running() && dt_control_job_get_state(job) != DT_JOB_STATE_CANCELLED))
+  {
+    // grab any pending images and add them to the list of images to be synchronized
+    GSList *new_imgs;
+#ifdef _OPENMP
+#pragma omp atomic capture
+    { new_imgs = pending_images; pending_images = NULL ; }
+#else
+    // don't have atomics, so use locks instead
+    _lock_pending_queue();
+    new_imgs = pending_images;
+    pending_images = NULL;
+    _unlock_pending_queue();
+#endif
+    if(new_imgs)
+    {
+      // add the new images to the queue being processed if they are not already on the queue
+      GSList *to_add = NULL;
+      for(GSList *imglist = new_imgs; imglist; imglist = g_slist_next(imglist))
+      {
+        if(!g_hash_table_contains(enqueued,GINT_TO_POINTER(imglist->data)))
+        {
+          to_add = g_slist_prepend(to_add, imglist->data);
+          g_hash_table_insert(enqueued, GINT_TO_POINTER(imglist->data), GINT_TO_POINTER(imglist->data));
+        }
+      }
+      imgs = g_slist_concat(imgs, to_add);
+      g_slist_free(new_imgs);
+    }
+    if (imgs)
+    {
+      // synchronize the first image on the queue
+      dt_imgid_t imgid = GPOINTER_TO_INT(imgs->data);
+      dt_image_write_sidecar_file(imgid);
+      // remove the head of the image queue
+      g_hash_table_remove(enqueued, GINT_TO_POINTER(imgid));
+      imgs = g_slist_delete_link(imgs, imgs);
+    }
+    else
+    {
+      // we currently have nothing to do, so wait 1/2 second before checking again
+      g_usleep(500000);
+    }
+  }
+  g_hash_table_destroy(enqueued);
+  return 0;
+}
+
+void dt_sidecar_synch_enqueue(dt_imgid_t imgid)
+{
+  if(background_running)
+  {
+    GSList *img = g_slist_prepend(NULL,GINT_TO_POINTER(imgid));
+#ifdef _OPENMP
+#pragma omp atomic capture
+    { img->next = pending_images; pending_images = img; }
+#else
+    // don't have atomics, so use locks instead
+    _lock_pending_queue();
+    img->next = pending_images;
+    pending_images = img;
+    _unlock_pending_queue();
+#endif
+  }
+  else
+  {
+    // synchronize the sidecar immediately instead of queueing it for background write
+    dt_image_write_sidecar_file(imgid);
+  }
+}
+
+void dt_sidecar_synch_enqueue_list(const GList *imgs)
+{
+  if(!imgs)
+    return;
+  if(!background_running)
+  {
+    // synchronize the sidecars immediately instead of queueing them for background write
+    for(const GList *ilist = imgs; ilist; ilist = g_list_next(ilist))
+    {
+      dt_image_write_sidecar_file(GPOINTER_TO_INT(ilist->data));
+    }
+    return;
+  }
+  GSList *new_imgs = NULL;
+  for(const GList *ilist = imgs; ilist; ilist = g_list_next(ilist))
+  {
+    new_imgs = g_slist_prepend(new_imgs,ilist->data);
+  }
+  GSList *last = g_slist_last(new_imgs);
+#ifdef _OPENMP
+#pragma omp atomic capture
+  { last->next = pending_images; pending_images = new_imgs; }
+#else
+  // don't have atomics, so use locks instead
+  _lock_pending_queue();
+  last->next = pending_images;
+  pending_images = new_imgs;
+  _unlock_pending_queue();
+#endif
+}
+
+void dt_control_sidecar_synch_start()
+{
+  dt_job_t *job = dt_control_job_create(_control_write_sidecars_job_run, "%s", N_("synchronize sidecars"));
+  if(!job)
+  {
+    return;
+  }
+  dt_control_add_job(darktable.control, DT_JOB_QUEUE_SYSTEM_FG, job);
+  background_running = TRUE;
+}
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/control/jobs/sidecar_jobs.h
+++ b/src/control/jobs/sidecar_jobs.h
@@ -1,0 +1,33 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2024 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "control/control.h"
+#include "imageio/imageio_module.h"
+
+void dt_sidecar_synch_enqueue(dt_imgid_t imgid);
+void dt_sidecar_synch_enqueue_list(const GList *imgs);
+void dt_control_sidecar_synch_start();
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on
+

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -719,7 +719,7 @@ static void _dev_auto_save(dt_develop_t *dev)
   if(saving)
   {
     dt_dev_write_history(dev);
-    dt_image_write_sidecar_file(imgid);
+    dt_image_synch_xmp(imgid);
     const double after = dt_get_wtime();
     dev->autosave_time = after;
     // if writing to database and the xmp took too long we disable


### PR DESCRIPTION
Yields a dramatic improvement in responsiveness for bulk operations - applying a color label to 5000+ images now leaves the UI unresponsive for only about a second.
