### PR TITLE
Remove outdated information about ubuntu packaging

### DIFF
--- a/packaging/ubuntu/README
+++ b/packaging/ubuntu/README
@@ -1,8 +1,3 @@
 Please refer to documentation on the darktable website
 
-https://www.darktable.org/install/#ubuntu
-
-And the .debian.tar.gz files available from the darktable PPAs:
-
-https://launchpad.net/~pmjdebruijn/+archive/darktable-release/+packages
-https://launchpad.net/~pmjdebruijn/+archive/darktable-unstable/+packages
+https://www.darktable.org/install


### PR DESCRIPTION
Both ubuntu PPAs contain darktable packages which are more than 4 years outdated. Currently the OBS server is used to ship packaged versions of darktable for all common distros, so this one should be preferred.