### PR TITLE
add detailed tooltips to headers of lighttable utility modules

### DIFF
--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -164,6 +164,12 @@ const char *name(dt_lib_module_t *self)
   return _("collections");
 }
 
+const char *description(dt_lib_module_t *self)
+{
+  return _("define search criteria for images\n"
+           "to be displayed or edited");
+}
+
 void *legacy_params(struct dt_lib_module_t *self,
                     const void *const old_params,
                     const size_t old_params_size,

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2023 darktable developers.
+    Copyright (C) 2009-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -59,6 +59,13 @@ typedef struct dt_lib_copy_history_t
 const char *name(dt_lib_module_t *self)
 {
   return _("history stack");
+}
+
+const char *description(dt_lib_module_t *self)
+{
+  return _("perform actions on the history\n"
+           "stacks (edit histories) of the\n"
+           "currently selected images");
 }
 
 dt_view_type_flags_t views(dt_lib_module_t *self)

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2023 darktable developers.
+    Copyright (C) 2009-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -158,6 +158,13 @@ static inline float pixels2print(dt_lib_export_t *self,
 const char *name(dt_lib_module_t *self)
 {
   return _("export");
+}
+
+const char *description(dt_lib_module_t *self)
+{
+  return _("create new files for the\n"
+           "currently selected images\n"
+           "which apply your edits");
 }
 
 dt_view_type_flags_t views(dt_lib_module_t *self)

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -271,6 +271,13 @@ const char *name(dt_lib_module_t *self)
   return _("collection filters");
 }
 
+const char *description(dt_lib_module_t *self)
+{
+  return _("refine the set of images to display or edit\n"
+           "filters can be pinned to the top toolbar, where\n"
+           "they will also be visible in the darkroom");
+}
+
 void init_presets(dt_lib_module_t *self)
 {
   dt_lib_filtering_params_t params;

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2022 darktable developers.
+    Copyright (C) 2012-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -139,6 +139,12 @@ static void free_tz_tuple(gpointer data)
 const char *name(dt_lib_module_t *self)
 {
   return _("geotagging");
+}
+
+const char *description(dt_lib_module_t *self)
+{
+  return _("set geolocation information for\n"
+           "the currently selected images");
 }
 
 dt_view_type_flags_t views(dt_lib_module_t *self)

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2013-2023 darktable developers.
+    Copyright (C) 2013-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -61,6 +61,12 @@ typedef struct dt_lib_masks_t
 const char *name(dt_lib_module_t *self)
 {
   return _("mask manager");
+}
+
+const char *description(dt_lib_module_t *self)
+{
+  return _("manipulate the drawn shapes used\n"
+           "for masks on the processing modules");
 }
 
 dt_view_type_flags_t views(dt_lib_module_t *self)

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -60,6 +60,12 @@ const char *name(dt_lib_module_t *self)
   return _("metadata editor");
 }
 
+const char *description(dt_lib_module_t *self)
+{
+  return _("modify text metadata fields of\n"
+           "the currently selected images");
+}
+
 dt_view_type_flags_t views(dt_lib_module_t *self)
 {
   return DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING;

--- a/src/libs/recentcollect.c
+++ b/src/libs/recentcollect.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2021 darktable developers.
+    Copyright (C) 2011-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -66,6 +66,12 @@ typedef struct dt_lib_recentcollect_t
 const char *name(dt_lib_module_t *self)
 {
   return _("recently used collections");
+}
+
+const char *description(dt_lib_module_t *self)
+{
+  return _("select among the most recent search\n"
+           "criteria set in the collections module");
 }
 
 dt_view_type_flags_t views(dt_lib_module_t *self)

--- a/src/libs/select.c
+++ b/src/libs/select.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2023 darktable developers.
+    Copyright (C) 2010-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -38,6 +38,12 @@ DT_MODULE(1)
 const char *name(dt_lib_module_t *self)
 {
   return _("selection");
+}
+
+const char *description(dt_lib_module_t *self)
+{
+  return _("modify which of the displayed\n"
+           "images are selected");
 }
 
 dt_view_type_flags_t views(dt_lib_module_t *self)

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2023 darktable developers.
+    Copyright (C) 2010-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -107,6 +107,12 @@ static void _save_last_tag_used(const char *tags, dt_lib_tagging_t *d);
 const char *name(dt_lib_module_t *self)
 {
   return _("tagging");
+}
+
+const char *description(dt_lib_module_t *self)
+{
+  return _("add or remove keywords for\n"
+           "the currently selected images");
 }
 
 dt_view_type_flags_t views(dt_lib_module_t *self)


### PR DESCRIPTION
Followup to #17213.

I'm open to suggestions on the wording of the new tooltips.
