### PR TITLE
Busy cursor fixes

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -2020,6 +2020,7 @@ gboolean dt_history_delete_on_list(const GList *list,
   if(!list)  // do we have any images on which to operate?
     return FALSE;
 
+  dt_gui_cursor_set_busy();
   if(undo) dt_undo_start_group(darktable.undo, DT_UNDO_LT_HISTORY);
 
   for(GList *l = (GList *)list; l; l = g_list_next(l))
@@ -2048,6 +2049,7 @@ gboolean dt_history_delete_on_list(const GList *list,
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
 
   if(undo) dt_undo_end_group(darktable.undo);
+  dt_gui_cursor_clear_busy();
   return TRUE;
 }
 

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2023 darktable developers.
+    Copyright (C) 2010-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -639,6 +639,7 @@ gboolean dt_styles_create_from_image(const char *name,
 
 void dt_styles_apply_to_list(const char *name, const GList *list, gboolean duplicate)
 {
+  dt_gui_cursor_set_busy();
   gboolean selected = FALSE;
 
   /* write current history changes so nothing gets lost,
@@ -693,12 +694,14 @@ void dt_styles_apply_to_list(const char *name, const GList *list, gboolean dupli
   {
     dt_control_log(_("style %s successfully applied!"), name);
   }
+  dt_gui_cursor_clear_busy();
 }
 
 void dt_multiple_styles_apply_to_list(GList *styles,
                                       const GList *list,
                                       const gboolean duplicate)
 {
+  dt_gui_cursor_set_busy();
   /* write current history changes so nothing gets lost,
      do that only in the darkroom as there is nothing to be saved
      when in the lighttable (and it would write over current history stack) */
@@ -744,6 +747,7 @@ void dt_multiple_styles_apply_to_list(GList *styles,
   const guint styles_cnt = g_list_length(styles);
   dt_control_log(ngettext("style successfully applied!",
                           "styles successfully applied!", styles_cnt));
+  dt_gui_cursor_clear_busy();
 }
 
 void dt_styles_create_from_list(const GList *list)

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2021 darktable developers.
+    Copyright (C) 2010-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -424,7 +424,6 @@ static gboolean _tag_execute(const GList *tags,
                              const gboolean undo_on,
                              const gint action)
 {
-  dt_gui_cursor_set_busy();
   gboolean res = FALSE;
   for(const GList *images = imgs; images; images = g_list_next(images))
   {
@@ -464,7 +463,6 @@ static gboolean _tag_execute(const GList *tags,
     else
       _undo_tags_free(undotags);
   }
-  dt_gui_cursor_clear_busy();
   return res;
 }
 
@@ -473,6 +471,7 @@ gboolean dt_tag_attach_images(const guint tagid,
                               const gboolean undo_on)
 {
   if(g_list_is_empty(img)) return FALSE;
+  dt_gui_cursor_set_busy();
   GList *undo = NULL;
   GList *tags = NULL;
 
@@ -490,6 +489,7 @@ gboolean dt_tag_attach_images(const guint tagid,
     dt_undo_end_group(darktable.undo);
   }
 
+  dt_gui_cursor_clear_busy();
   return res;
 }
 
@@ -523,6 +523,7 @@ gboolean dt_tag_set_tags(const GList *tags,
 {
   if(!g_list_is_empty(img))
   {
+    dt_gui_cursor_set_busy();
     GList *undo = NULL;
     if(undo_on)
       dt_undo_start_group(darktable.undo, DT_UNDO_TAGS);
@@ -536,6 +537,7 @@ gboolean dt_tag_set_tags(const GList *tags,
                      _pop_undo, _tags_undo_data_free);
       dt_undo_end_group(darktable.undo);
     }
+    dt_gui_cursor_clear_busy();
     return res;
   }
   return FALSE;

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2023 darktable developers.
+    Copyright (C) 2009-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -242,13 +242,19 @@ static void discard_button_clicked(GtkWidget *widget, gpointer user_data)
   if(!imgs) return;
 
   const int number = g_list_length((GList *)imgs);
-
-  if(!dt_conf_get_bool("ask_before_discard")
+  const gboolean ask = dt_conf_get_bool("ask_before_discard");
+  if(!ask
      || dt_gui_show_yes_no_dialog(_("delete images' history?"),
           ngettext("do you really want to clear history of %d selected image?",
                    "do you really want to clear history of %d selected images?", number),
                                   number))
   {
+    if(ask && number > 10)
+    {
+      // ensure that the dialog window gets hidden on click
+      dt_control_queue_redraw_center();
+      dt_gui_process_events();
+    }
     dt_history_delete_on_list(imgs, TRUE);
     dt_collection_update_query(darktable.collection,
                                DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,


### PR DESCRIPTION
Fix flickering busy cursor while bulk-applying a style or tag, discarding history, and during background writes of sidecars.  Also ensure that the "really discard?" dialog is hidden immediately on clicking Yes, rather than after all the histories have been discarded.
