### PR TITLE
Fix performance regression for thumbs redraw event

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -868,23 +868,30 @@ void dt_image_update_final_size(const dt_imgid_t imgid)
       DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_IMAGE_CHANGED);
     }
   }
+  dt_print(DT_DEBUG_PIPE, "[dt_image_update_final_size] for ID=%i, updated to %ix%i\n", imgid, ww, hh);
 }
 
 gboolean dt_image_get_final_size(const dt_imgid_t imgid, int *width, int *height)
 {
+  if(!dt_is_valid_imgid(imgid))
+    return FALSE;
+
   // get the img strcut
   dt_image_t *imgtmp = dt_image_cache_get(darktable.image_cache, imgid, 'r');
   dt_image_t img = *imgtmp;
   dt_image_cache_read_release(darktable.image_cache, imgtmp);
+
   // if we already have computed them
   if(img.final_height > 0 && img.final_width > 0)
   {
     *width = img.final_width;
     *height = img.final_height;
-    return 0;
+    dt_print(DT_DEBUG_PIPE, "[dt_image_get_final_size] for ID=%i from cache %ix%i\n", imgid, *width, *height);
+    return FALSE;
   }
 
-  // and now we can do the pipe stuff to get final image size
+  // we have to do the costly pipe run to get the final image size
+  dt_print(DT_DEBUG_PIPE, "[dt_image_get_final_size] calculate it for ID=%i\n", imgid);
   dt_develop_t dev;
   dt_dev_init(&dev, FALSE);
   dt_dev_load_image(&dev, imgid);

--- a/src/common/mipmap_cache.h
+++ b/src/common/mipmap_cache.h
@@ -155,7 +155,7 @@ dt_colorspaces_color_profile_type_t dt_mipmap_cache_get_colorspace();
 
 // copy over thumbnails. used by file operation that copies raw files, to speed up thumbnail generation.
 // only copies over the jpg backend on disk, doesn't directly affect the in-memory cache.
-void dt_mipmap_cache_copy_thumbnails(const dt_mipmap_cache_t *cache, const uint32_t dst_imgid, const uint32_t src_imgid);
+void dt_mipmap_cache_copy_thumbnails(const dt_mipmap_cache_t *cache, const dt_imgid_t dst_imgid, const dt_imgid_t src_imgid);
 
 // return the mipmap corresponding to text value saved in prefs
 dt_mipmap_size_t dt_mipmap_cache_get_min_mip_from_pref(const char *value);

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1765,7 +1765,7 @@ void dt_culling_update_active_images_list(dt_culling_t *table)
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_ACTIVE_IMAGES_CHANGE);
 }
 
-// recreate the list of thumb if needed and recomputes sizes and positions if needed
+// recreate the list of thumbs if needed and recomputes sizes and positions if needed
 void dt_culling_full_redraw(dt_culling_t *table, const gboolean force)
 {
   if(!gtk_widget_get_visible(table->widget) && !force) return;
@@ -1877,7 +1877,7 @@ void dt_culling_full_redraw(dt_culling_t *table, const gboolean force)
     }
   }
 
-  dt_print(DT_DEBUG_LIGHTTABLE, "done in %0.04f sec\n", dt_get_wtime() - start);
+  dt_print(DT_DEBUG_LIGHTTABLE | DT_DEBUG_PERF, "[dt_culling_full_redraw] done in %0.04f sec\n", dt_get_wtime() - start);
 
   if(darktable.unmuted & DT_DEBUG_CACHE) dt_mipmap_cache_print(darktable.mipmap_cache);
 }

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -711,11 +711,12 @@ static gboolean _event_image_draw(GtkWidget *widget,
       cairo_surface_t *img_surf = NULL;
       if(thumb->zoomable)
       {
-        const float zoom100 = dt_thumbnail_get_zoom100(thumb);
-        // Any zoom100 > 1 is ensured to be correct
-        if(thumb->zoom > 1.0f && zoom100 > 1.0f)
-          thumb->zoom = MIN(thumb->zoom, zoom100);
-
+        if(thumb->zoom > 1.0f)
+        {
+          const float zoom100 = dt_thumbnail_get_zoom100(thumb);
+          if(zoom100 > 1.0f)
+            thumb->zoom = MIN(thumb->zoom, zoom100);
+        }
         res = dt_view_image_get_surface(thumb->imgid,
                                         image_w * thumb->zoom,
                                         image_h * thumb->zoom,

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -741,7 +741,7 @@ dt_view_surface_value_t dt_view_image_get_surface(const dt_imgid_t imgid,
       "dt_view_image_get_surface  id %i, dots %ix%i -> mip %ix%i, found %ix%i\n",
       imgid, mipwidth, mipheight, cache->max_width[mip], cache->max_height[mip], buf_wd, buf_ht);
 
-  // if we don't get buffer, no image is awailable at the moment
+  // no image is available at the moment as we didn't get buffer data
   if(!buf.buf)
   {
     dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
@@ -892,11 +892,15 @@ dt_view_surface_value_t dt_view_image_get_surface(const dt_imgid_t imgid,
     dt_print(DT_DEBUG_LIGHTTABLE | DT_DEBUG_PERF,
              "got surface  %ix%i created in %0.04f sec\n",
              img_width, img_height, dt_get_wtime() - tt);
-  else
-    dt_print(DT_DEBUG_LIGHTTABLE,
-             "got surface  %ix%i\n", img_width, img_height);
 
   // we consider skull as ok as the image hasn't to be reload
+  if(ret != DT_VIEW_SURFACE_OK)
+    dt_print(DT_DEBUG_LIGHTTABLE,
+      "dt_view_image_get_surface  ID=%i with surface problem %s%s%s\n",
+      imgid,
+      tmp_surface ? "" : "no tmp_surface, ",
+      ret == DT_VIEW_SURFACE_SMALLER ? "DT_VIEW_SURFACE_SMALLER" : "",
+      ret == DT_VIEW_SURFACE_KO ? "DT_VIEW_SURFACE_KO" : "");
   return ret;
 }
 


### PR DESCRIPTION
While correcting thumb->zoom in the thumbs image_draw event we must call `dt_thumbnail_get_zoom100()`
only if definitely required to avoid calling `dt_image_get_final_size()` as that is very costly by reading
the image file and a pixelpipe run to get it's output dimension.

Fixes #17243 

Big thanks to @wpferguson for discussing and bisecting and @vancouverbluesea for insisting on "there is a problem" !

Also included some work while investigating

Release note: Fixing a performance regression for redrawing mipmaps