### PR TITLE
fix first several toasts appearing empty

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2686,8 +2686,10 @@ static void _ui_toast_redraw_callback(gpointer instance,
   dt_pthread_mutex_lock(&darktable.control->toast_mutex);
   if(darktable.control->toast_ack != darktable.control->toast_pos)
   {
-    const uint32_t first_message = MAX(darktable.control->toast_ack,
-                                       darktable.control->toast_pos - DT_CTL_TOAST_SIZE + 1);
+    const uint32_t window_start = (darktable.control->toast_pos < DT_CTL_TOAST_SIZE
+                                   ? 0
+                                   : darktable.control->toast_pos - DT_CTL_TOAST_SIZE + 1);
+    const uint32_t first_message = MAX(darktable.control->toast_ack, window_start);
     gchar *message = g_malloc(ALLMESSSIZE);
     if(message)
     {


### PR DESCRIPTION
Until there have been enough toasts to have cycled through the buffer at least once, toasts were appearing blank due to an empty string being generated for them.  The cause is an integer underflow which wraps to a very large value due to use of an unsigned variable, which then causes none of the strings in the toast buffer to be included in the actual on-screen display.

The relevant code was last changed by commit 0d174b544d1.