### PR TITLE
[imageio] Reduce verbosity of libraw loader

### DIFF
--- a/src/imageio/imageio_libraw.c
+++ b/src/imageio/imageio_libraw.c
@@ -295,8 +295,8 @@ static gboolean _supported_image(const gchar *filename)
   else
     extensions_whitelist = g_strdup(always_by_libraw);
 
-  dt_print(DT_DEBUG_ALWAYS,
-           "[libraw_open] extensions whitelist: `%s'\n", extensions_whitelist);
+  dt_print(DT_DEBUG_IMAGEIO,
+           "[libraw_open] extensions whitelist: '%s'\n", extensions_whitelist);
 
   gchar *ext_lowercased = g_ascii_strdown(ext, -1);
   if(g_strstr_len(extensions_whitelist, -1, ext_lowercased))


### PR DESCRIPTION
There is no need to always print an informational message.