### PR TITLE
move busy cursor calls out of dt_tag_set_tags

### DIFF
--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -520,7 +520,6 @@ gboolean dt_tag_set_tags(const GList *tags,
 {
   if(!g_list_is_empty(img))
   {
-    dt_gui_cursor_set_busy();
     GList *undo = NULL;
     if(undo_on)
       dt_undo_start_group(darktable.undo, DT_UNDO_TAGS);
@@ -534,7 +533,6 @@ gboolean dt_tag_set_tags(const GList *tags,
                      _pop_undo, _tags_undo_data_free);
       dt_undo_end_group(darktable.undo);
     }
-    dt_gui_cursor_clear_busy();
     return res;
   }
   return FALSE;

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -333,6 +333,9 @@ static void _execute_metadata(dt_lib_module_t *self, const int action)
   GList *imgs = dt_act_on_get_images(FALSE, TRUE, FALSE);
   if(imgs)
   {
+    gboolean show_busy = !g_list_shorter_than(imgs,10);
+    if(show_busy)
+      dt_gui_cursor_set_busy();
     // for all the above actions, we don't use the grpu_on tag, as
     // grouped images have already been added to image list
     const dt_undo_type_t undo_type =
@@ -395,6 +398,8 @@ static void _execute_metadata(dt_lib_module_t *self, const int action)
     {
       g_list_free(imgs);
     }
+    if(show_busy)
+      dt_gui_cursor_clear_busy();
   }
 }
 


### PR DESCRIPTION
Followup to #17290.
