### PR TITLE
Add inter script communication to Lua API

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -746,6 +746,7 @@ if(USE_LUA)
       "lua/styles.c"
       "lua/tags.c"
       "lua/types.c"
+      "lua/util.c"
       "lua/view.c"
       "lua/widget/box.c"
       "lua/widget/button.c"

--- a/src/lua/configuration.h
+++ b/src/lua/configuration.h
@@ -40,10 +40,11 @@
 // 4.4.0 was 9.1.0 (added mimic and dt_lua_image_t changes)
 // 4.6.0 was 9.2.0 (added change_timestamp to dt_image_t)
 // 4.8.0 was 9.3.0 (added button and box widget enhancements)
+// 5.0.0 was 9.4.0 (added group events and uuid)
 /* incompatible API change */
 #define LUA_API_VERSION_MAJOR 9
 /* backward compatible API change */
-#define LUA_API_VERSION_MINOR 3
+#define LUA_API_VERSION_MINOR 4
 /* bugfixes that should not change anything to the API */
 #define LUA_API_VERSION_PATCH 0
 /* suffix for unstable version */

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -43,6 +43,7 @@
 #include "lua/styles.h"
 #include "lua/tags.h"
 #include "lua/types.h"
+#include "lua/util.h"
 #include "lua/view.h"
 #include "lua/widget/widget.h"
 
@@ -138,7 +139,7 @@ static lua_CFunction init_funcs[]
         dt_lua_init_luastorages,   dt_lua_init_tags,        dt_lua_init_film,     dt_lua_init_call,
         dt_lua_init_view,          dt_lua_init_events,      dt_lua_init_init,     dt_lua_init_widget,
         dt_lua_init_lualib,        dt_lua_init_gettext,     dt_lua_init_guides,   dt_lua_init_cairo,
-        dt_lua_init_password,      NULL };
+        dt_lua_init_password,      dt_lua_init_util,        NULL };
 
 
 void dt_lua_init(lua_State *L, const char *lua_command)

--- a/src/lua/util.c
+++ b/src/lua/util.c
@@ -1,0 +1,66 @@
+/*
+   This file is part of darktable,
+   Copyright (C) 2013-2020 darktable developers.
+
+   darktable is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   darktable is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "lua/preferences.h"
+#include "lua/call.h"
+#include "lua/events.h"
+#include <glib.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int message(lua_State *L)
+{
+  const char *sender = luaL_checkstring(L, 1);
+  const char *receiver = luaL_checkstring(L, 2);
+  const char *message = luaL_checkstring(L, 3);
+
+  dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
+      0, NULL, NULL,
+      LUA_ASYNC_TYPENAME, "const char*", "inter-script-communication",
+      LUA_ASYNC_TYPENAME, "const char*", sender,
+      LUA_ASYNC_TYPENAME, "const char*", receiver,
+      LUA_ASYNC_TYPENAME, "const char*", message,
+      LUA_ASYNC_DONE);
+
+  return 0;
+}
+
+
+int dt_lua_init_util(lua_State *L)
+{
+  dt_lua_push_darktable_lib(L);
+  dt_lua_goto_subtable(L, "util");
+
+  lua_pushcfunction(L, message);
+  lua_setfield(L, -2, "message");
+
+  lua_pop(L, 1);
+
+
+  lua_pushcfunction(L, dt_lua_event_multiinstance_register);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
+  lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
+  dt_lua_event_add(L, "inter-script-communication");
+
+  return 0;
+}
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on
+

--- a/src/lua/util.h
+++ b/src/lua/util.h
@@ -1,0 +1,28 @@
+/*
+   This file is part of darktable,
+   Copyright (C) 2013-2020 darktable developers.
+
+   darktable is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   darktable is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+int dt_lua_init_util(lua_State *L);
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on
+


### PR DESCRIPTION
Added a new event, `inter-script-communication`

Bumped API to 9.4.0

Added a new utili module to the API for functions that don't fall into a specific category.

Added darktable.lua.message function for sending messages between scripts.

To test unzip the included test scripts zip file.  Start darktable with the -d lua flag.  Start both scripts.  Assign a keyboard shortcut to `send isc message`.  Press the shortcut key and observe the messages in the console output.

Fixes #17295.

Partial fix for #17296.

[test_isc.zip](https://github.com/user-attachments/files/16565576/test_isc.zip)
