### PR TITLE
add Calibrite alias for X-Rite ColorChecker

### DIFF
--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -4754,7 +4754,7 @@ void gui_init(struct dt_iop_module_t *self)
      _("choose the vendor and the type of your chart"),
      0, _checker_changed_callback, self,
      N_("Xrite ColorChecker 24 pre-2014"),
-     N_("Xrite ColorChecker 24 post-2014"),
+     N_("Xrite/Calibrite ColorChecker 24 post-2014"),
      N_("Datacolor SpyderCheckr 24 pre-2018"),
      N_("Datacolor SpyderCheckr 24 post-2018"),
      N_("Datacolor SpyderCheckr 48 pre-2018"),


### PR DESCRIPTION
Hopefully reduces future user requests such as https://discuss.pixls.us/t/2024-08-07-darktable-support-for-calibrite-colorchecker-classic/45104.
