### PR TITLE
show busy cursor during undo operations

### DIFF
--- a/src/common/undo.c
+++ b/src/common/undo.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2017-2023 darktable developers.
+    Copyright (C) 2017-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -294,12 +294,18 @@ static void _undo_do_undo_redo(dt_undo_t *self,
 
 void dt_undo_do_redo(dt_undo_t *self, const uint32_t filter)
 {
+  dt_gui_cursor_set_busy();
+  dt_gui_process_events();
   _undo_do_undo_redo(self, filter, DT_ACTION_REDO);
+  dt_gui_cursor_clear_busy();
 }
 
 void dt_undo_do_undo(dt_undo_t *self, const uint32_t filter)
 {
+  dt_gui_cursor_set_busy();
+  dt_gui_process_events();
   _undo_do_undo_redo(self, filter, DT_ACTION_UNDO);
+  dt_gui_cursor_clear_busy();
 }
 
 static void _undo_clear_list(GList **list, const uint32_t filter)


### PR DESCRIPTION
Since undoing a bulk operation takes at least as long as the original operation, turn on the busy cursor during undo so that the user knows darktable is still processing the undo.