### PR TITLE
Don't run GitHub actions in forks

### DIFF
--- a/.github/workflows/check-po.yml
+++ b/.github/workflows/check-po.yml
@@ -20,6 +20,7 @@ permissions:
 
 jobs:
   po-check:
+    if: github.repository == 'darktable-org/darktable' || github.event_name == 'workflow_dispatch'
     name: Check the PO files for correctness
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ permissions:
 jobs:
 
   Linux:
+    if: github.repository == 'darktable-org/darktable' || github.event_name == 'workflow_dispatch'
     name: Linux.${{ matrix.distro }}.${{ matrix.compiler.compiler }}.${{ matrix.btype }}
     runs-on: ubuntu-latest
     container:
@@ -232,6 +233,7 @@ jobs:
           ./run.sh --no-opencl --no-deltae --fast-fail
 
   Windows:
+    if: github.repository == 'darktable-org/darktable' || github.event_name == 'workflow_dispatch'
     name: Windows.${{ matrix.msystem }}.${{ matrix.btype }}
     runs-on: windows-latest
     strategy:
@@ -344,6 +346,7 @@ jobs:
                  --conf plugins/lighttable/export/iccintent=0
 
   macOS:
+    if: github.repository == 'darktable-org/darktable' || github.event_name == 'workflow_dispatch'
     name: macOS.${{ matrix.build.os }}.${{ matrix.compiler.compiler }}.${{ matrix.build.xcode }}.${{ matrix.btype }}
     runs-on: ${{ matrix.build.os }}
     strategy:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   stale:
+    if: github.repository == 'darktable-org/darktable' || github.event_name == 'workflow_dispatch'
 
     permissions:
       issues: write  # for actions/stale to close stale issues


### PR DESCRIPTION
If in the actions we do not set the restriction to run only in the original darktable repository, then they will also be triggered and run in forks, which is completely unnecessary and actually wastes energy without any benefit.