### PR TITLE
fix sql text handling

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -3164,19 +3164,17 @@ void dt_image_check_camera_missing_sample(const struct dt_image_t *img)
   }
 }
 
-static int32_t _image_get_set_name_id(const char *table,
-                                      const char *name)
+static int32_t _image_get_set_name_id(const char *table, const char *name)
 {
   sqlite3_stmt *stmt;
 
   char *query = g_strdup_printf("SELECT id"
                                 "  FROM main.%s"
-                                "  WHERE LOWER(name) = LOWER('%s')",
-                                table,
-                                name);
+                                "  WHERE LOWER(name) = LOWER(?1)",
+                                table);
 
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              query, -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, name, -1, SQLITE_TRANSIENT);
 
   int32_t id = -1;
 
@@ -3189,12 +3187,12 @@ static int32_t _image_get_set_name_id(const char *table,
     g_free(query);
     query = g_strdup_printf("INSERT"
                             "  INTO main.%s (name)"
-                            "  VALUES ('%s')",
-                            table,
-                            name);
+                            "  VALUES (?1)",
+                            table);
 
-    DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db),
-                          query, NULL, NULL, NULL);
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
+    DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, name, -1, SQLITE_TRANSIENT);
+    sqlite3_step(stmt);
     id = dt_database_last_insert_rowid(darktable.db);
   }
 


### PR DESCRIPTION
The text used for search and insert must be passed as a parameter to the sql for proper handling.

fixes #17254