### PR TITLE
improve handling of unsupported images

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -454,7 +454,10 @@ dt_imgid_t dt_load_from_string(const gchar *input,
       if(!loaded)
       {
         id = NO_IMGID;
-        dt_control_log(_("file `%s' has unknown format!"), filename);
+        if(buf.loader_status == DT_IMAGEIO_UNSUPPORTED_FORMAT || buf.loader_status == DT_IMAGEIO_UNSUPPORTED_FEATURE)
+          dt_control_log(_("file `%s' has unsupported format!"), filename);
+        else
+          dt_control_log(_("file `%s' has unknown format!"), filename);
       }
       else
       {

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -2149,6 +2149,7 @@ void dt_image_init(dt_image_t *img)
       dt_mark_colormatrix_invalid(&img->adobe_XYZ_to_CAM[k][i]);
 
   img->job_flags = DT_IMAGE_JOB_NONE;
+  img->load_status = DT_IMAGEIO_OK;
 }
 
 void dt_image_refresh_makermodel(dt_image_t *img)

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -38,8 +38,12 @@ typedef enum dt_imageio_retval_t
 {
   DT_IMAGEIO_OK = 0,         // all good :)
   DT_IMAGEIO_FILE_NOT_FOUND, // file has been lost
-  DT_IMAGEIO_LOAD_FAILED,    // file either corrupted or in a format
-                             // not supported by the current loader.
+  DT_IMAGEIO_LOAD_FAILED,    // file either corrupted or in a format not supported by the current loader,
+                             // and a more detailed error from among those below is not available.
+  DT_IMAGEIO_UNSUPPORTED_FORMAT,  // the file type is not supported; may be one which is a build-time option
+  DT_IMAGEIO_UNSUPPORTED_FEATURE, // the file uses an unsupported feature such as compression type
+  DT_IMAGEIO_FILE_CORRUPTED,      // invalid data was detected while parsing the file
+  DT_IMAGEIO_IOERROR,             // a read error occurred while loading the file
   DT_IMAGEIO_CACHE_FULL      // buffer allocation for image data failed
 } dt_imageio_retval_t;
 

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -351,6 +351,9 @@ typedef struct dt_image_t
   struct dt_cache_entry_t *cache_entry;
 
   dt_image_job_flag_t job_flags;
+
+  /* result of attempting to load the image, needed to be able to report why the image can't be displayed */
+  dt_imageio_retval_t load_status;
 } dt_image_t;
 
 // should be in datetime.h, workaround to solve cross references

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -41,6 +41,7 @@ typedef enum dt_imageio_retval_t
   DT_IMAGEIO_LOAD_FAILED,    // file either corrupted or in a format not supported by the current loader,
                              // and a more detailed error from among those below is not available.
   DT_IMAGEIO_UNSUPPORTED_FORMAT,  // the file type is not supported; may be one which is a build-time option
+  DT_IMAGEIO_UNSUPPORTED_CAMERA,  // the file type is supported, but the camera model is not
   DT_IMAGEIO_UNSUPPORTED_FEATURE, // the file uses an unsupported feature such as compression type
   DT_IMAGEIO_FILE_CORRUPTED,      // invalid data was detected while parsing the file
   DT_IMAGEIO_IOERROR,             // a read error occurred while loading the file

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -57,7 +57,7 @@
 // the number of pixels in the largest static image is the smallest number of pixels we
 // can allocate for the mipmap buffer, since that gets filled in after we attempt to read
 // from the image file on disk
-#define MIN_IMG_PIXELS  210
+#define MIN_IMG_PIXELS  540
 
 typedef enum dt_mipmap_buffer_dsc_flags
 {
@@ -116,28 +116,40 @@ static inline void _dead_image_8(dt_mipmap_buffer_t *buf)
 {
   if(!buf->buf) return;
   struct dt_mipmap_buffer_dsc *dsc = (struct dt_mipmap_buffer_dsc *)buf->buf - 1;
-  dsc->width = 14; dsc->height = 15;
+  dsc->width = 20; dsc->height = 27;
   dsc->iscale = 1.0f;
   buf->color_space = dsc->color_space = DT_COLORSPACE_DISPLAY;
   assert(dsc->size > 210 * sizeof(uint32_t));
   const uint32_t XX = 0xffffffffu;
   const uint32_t __ = 0u;
   static const uint32_t image[]
-      = { __,__,__,__,__,__,__,__,__,__,__,__,__,__,
-          __,__,__,__,XX,XX,XX,XX,XX,XX,__,__,__,__,
-          __,__,__,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,
-          __,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,
-          __,XX,XX,XX,__,__,XX,XX,__,__,XX,XX,XX,__,
-          __,XX,XX,XX,__,__,XX,XX,__,__,XX,XX,XX,__,
-          __,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,
-          __,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,
-          __,__,__,XX,XX,__,XX,__,__,XX,XX,__,__,__,
-          __,__,__,XX,XX,__,__,__,__,XX,XX,__,__,__,
-          __,__,__,__,__,__,__,__,__,__,__,__,__,__,
-          __,__,__,XX,__,XX,__,__,XX,__,XX,__,__,__,
-          __,__,__,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,
-          __,__,__,__,XX,XX,XX,XX,XX,XX,__,__,__,__,
-          __,__,__,__,__,__,__,__,__,__,__,__,__,__ };
+      = { __,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,XX,XX,XX,XX,XX,XX,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,__,__,
+          __,__,__,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,__,
+          __,__,__,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,__,
+          __,__,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,
+          __,__,__,__,XX,XX,XX,__,XX,XX,XX,XX,__,XX,XX,XX,__,__,__,__,
+          __,__,__,XX,XX,XX,__,__,__,XX,XX,__,__,__,XX,XX,XX,__,__,__,
+          __,__,__,XX,XX,XX,__,__,__,XX,XX,__,__,__,XX,XX,XX,__,__,__,
+          __,__,XX,XX,XX,__,__,__,__,XX,XX,__,__,__,__,XX,XX,XX,__,__,
+          __,__,XX,XX,XX,__,__,__,__,XX,XX,__,__,__,__,XX,XX,XX,__,__,
+          __,XX,XX,XX,XX,XX,__,__,__,XX,XX,__,__,__,XX,XX,XX,XX,XX,__,
+          __,XX,XX,XX,XX,XX,__,__,XX,XX,XX,XX,__,__,XX,XX,XX,XX,XX,__,
+          __,XX,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,XX,__,
+          __,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,
+          __,__,XX,XX,XX,XX,XX,XX,XX,__,__,XX,XX,XX,XX,XX,XX,XX,__,__,
+          __,__,XX,XX,XX,XX,XX,XX,XX,__,__,XX,XX,XX,XX,XX,XX,XX,__,__,
+          __,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,
+          __,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,
+          __,__,__,XX,XX,__,XX,__,XX,__,XX,__,XX,__,XX,XX,__,__,__,__,
+          __,__,__,XX,XX,__,__,__,__,__,__,__,__,__,XX,XX,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,
+          __,__,__,__,XX,__,__,XX,__,XX,__,XX,__,__,XX,__,__,__,__,__,
+          __,__,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,__,
+          __,__,__,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,__,__,
+          __,__,__,__,__,__,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__ };
   memcpy(buf->buf, image, sizeof(image));
 }
 
@@ -145,7 +157,7 @@ static inline void _dead_image_f(dt_mipmap_buffer_t *buf)
 {
   if(!buf->buf) return;
   struct dt_mipmap_buffer_dsc *dsc = (struct dt_mipmap_buffer_dsc *)buf->buf - 1;
-  dsc->width = 14; dsc->height = 15;
+  dsc->width = 20; dsc->height = 27;
   dsc->iscale = 1.0f;
   buf->color_space = dsc->color_space = DT_COLORSPACE_DISPLAY;
   assert(dsc->size > 210 * 4 * sizeof(float));
@@ -153,21 +165,33 @@ static inline void _dead_image_f(dt_mipmap_buffer_t *buf)
 #define XX 1.0f, 1.0f, 1.0f, 1.0f
 #define __ 0.0f, 0.0f, 0.0f, 0.0f
   static const float image[]
-      = { __,__,__,__,__,__,__,__,__,__,__,__,__,__,
-          __,__,__,__,XX,XX,XX,XX,XX,XX,__,__,__,__,
-          __,__,__,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,
-          __,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,
-          __,XX,XX,XX,__,__,XX,XX,__,__,XX,XX,XX,__,
-          __,XX,XX,XX,__,__,XX,XX,__,__,XX,XX,XX,__,
-          __,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,
-          __,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,
-          __,__,__,XX,XX,__,XX,__,__,XX,XX,__,__,__,
-          __,__,__,XX,XX,__,__,__,__,XX,XX,__,__,__,
-          __,__,__,__,__,__,__,__,__,__,__,__,__,__,
-          __,__,__,XX,__,XX,__,__,XX,__,XX,__,__,__,
-          __,__,__,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,
-          __,__,__,__,XX,XX,XX,XX,XX,XX,__,__,__,__,
-          __,__,__,__,__,__,__,__,__,__,__,__,__,__ };
+      = { __,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,XX,XX,XX,XX,XX,XX,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,__,__,
+          __,__,__,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,__,
+          __,__,__,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,__,
+          __,__,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,
+          __,__,__,__,XX,XX,XX,__,XX,XX,XX,XX,__,XX,XX,XX,__,__,__,__,
+          __,__,__,XX,XX,XX,__,__,__,XX,XX,__,__,__,XX,XX,XX,__,__,__,
+          __,__,__,XX,XX,XX,__,__,__,XX,XX,__,__,__,XX,XX,XX,__,__,__,
+          __,__,XX,XX,XX,__,__,__,__,XX,XX,__,__,__,__,XX,XX,XX,__,__,
+          __,__,XX,XX,XX,__,__,__,__,XX,XX,__,__,__,__,XX,XX,XX,__,__,
+          __,XX,XX,XX,XX,XX,__,__,__,XX,XX,__,__,__,XX,XX,XX,XX,XX,__,
+          __,XX,XX,XX,XX,XX,__,__,XX,XX,XX,XX,__,__,XX,XX,XX,XX,XX,__,
+          __,XX,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,XX,__,
+          __,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,
+          __,__,XX,XX,XX,XX,XX,XX,XX,__,__,XX,XX,XX,XX,XX,XX,XX,__,__,
+          __,__,XX,XX,XX,XX,XX,XX,XX,__,__,XX,XX,XX,XX,XX,XX,XX,__,__,
+          __,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,
+          __,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,
+          __,__,__,XX,XX,__,XX,__,XX,__,XX,__,XX,__,XX,XX,__,__,__,__,
+          __,__,__,XX,XX,__,__,__,__,__,__,__,__,__,XX,XX,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,
+          __,__,__,__,XX,__,__,XX,__,XX,__,XX,__,__,XX,__,__,__,__,__,
+          __,__,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,__,
+          __,__,__,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,__,__,
+          __,__,__,__,__,__,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__ };
 #undef XX
 #undef __
   memcpy(buf->buf, image, sizeof(image));
@@ -177,26 +201,38 @@ static inline void unsupp_image_8(dt_mipmap_buffer_t *buf)
 {
   if(!buf->buf) return;
   struct dt_mipmap_buffer_dsc *dsc = (struct dt_mipmap_buffer_dsc *)buf->buf - 1;
-  dsc->width = 9; dsc->height = 13;
+  dsc->width = 17; dsc->height = 25;
   dsc->iscale = 1.0f;
   buf->color_space = dsc->color_space = DT_COLORSPACE_DISPLAY;
-  assert(dsc->size > dsc->width * dsc->height * sizeof(uint32_t));
+  assert(dsc->size >= dsc->width * dsc->height * sizeof(uint32_t));
   const uint32_t XX = 0xffffffffu;
   const uint32_t __ = 0u;
   static const uint32_t image[]
-      = { __,__,__,__,__,__,__,__,__,
-          __,__,__,XX,XX,XX,__,__,__,
-          __,__,XX,__,__,__,XX,__,__,
-          __,XX,__,__,__,__,__,XX,__,
-          __,XX,__,__,__,__,__,XX,__,
-          __,__,__,__,__,__,XX,__,__,
-          __,__,__,__,__,XX,__,__,__,
-          __,__,__,__,XX,__,__,__,__,
-          __,__,__,__,XX,__,__,__,__,
-          __,__,__,__,XX,__,__,__,__,
-          __,__,__,__,__,__,__,__,__,
-          __,__,__,__,XX,__,__,__,__,
-          __,__,__,__,__,__,__,__,__ };
+      = { __,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,XX,XX,XX,XX,__,__,__,__,__,__,
+          __,__,__,__,__,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,
+          __,__,__,__,XX,XX,XX,__,__,__,__,XX,XX,XX,__,__,__,
+          __,__,__,XX,XX,__,__,__,__,__,__,__,__,XX,XX,__,__,
+          __,__,XX,XX,__,__,__,__,__,__,__,__,__,XX,XX,__,__,
+          __,__,XX,XX,__,__,__,__,__,__,__,__,__,__,XX,XX,__,
+          __,XX,XX,__,__,__,__,__,__,__,__,__,__,__,XX,XX,__,
+          __,XX,XX,__,__,__,__,__,__,__,__,__,__,__,XX,XX,__,
+          __,XX,XX,__,__,__,__,__,__,__,__,__,__,__,XX,XX,__,
+          __,__,__,__,__,__,__,__,__,__,__,__,__,XX,XX,__,__,
+          __,__,__,__,__,__,__,__,__,__,__,__,__,XX,XX,__,__,
+          __,__,__,__,__,__,__,__,__,__,__,__,XX,XX,__,__,__,
+          __,__,__,__,__,__,__,__,__,__,__,XX,XX,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,__,XX,XX,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,XX,XX,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,XX,XX,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,XX,XX,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,XX,XX,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,XX,XX,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,XX,XX,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,XX,XX,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,XX,XX,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__ };
   memcpy(buf->buf, image, sizeof(image));
 }
 
@@ -204,7 +240,7 @@ static inline void unsupp_image_f(dt_mipmap_buffer_t *buf)
 {
   if(!buf->buf) return;
   struct dt_mipmap_buffer_dsc *dsc = (struct dt_mipmap_buffer_dsc *)buf->buf - 1;
-  dsc->width = 9; dsc->height = 13;
+  dsc->width = 17; dsc->height = 25;
   dsc->iscale = 1.0f;
   buf->color_space = dsc->color_space = DT_COLORSPACE_DISPLAY;
   assert(dsc->size > dsc->width * dsc->height * 4 * sizeof(float));
@@ -212,19 +248,31 @@ static inline void unsupp_image_f(dt_mipmap_buffer_t *buf)
 #define XX 1.0f, 1.0f, 1.0f, 1.0f
 #define __ 0.0f, 0.0f, 0.0f, 0.0f
   static const float image[]
-      = { __,__,__,__,__,__,__,__,__,
-          __,__,__,XX,XX,XX,__,__,__,
-          __,__,XX,__,__,__,XX,__,__,
-          __,XX,__,__,__,__,__,XX,__,
-          __,XX,__,__,__,__,__,XX,__,
-          __,__,__,__,__,__,XX,__,__,
-          __,__,__,__,__,XX,__,__,__,
-          __,__,__,__,XX,__,__,__,__,
-          __,__,__,__,XX,__,__,__,__,
-          __,__,__,__,XX,__,__,__,__,
-          __,__,__,__,__,__,__,__,__,
-          __,__,__,__,XX,__,__,__,__,
-          __,__,__,__,__,__,__,__,__ };
+      = { __,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,XX,XX,XX,XX,__,__,__,__,__,__,
+          __,__,__,__,__,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,
+          __,__,__,__,XX,XX,XX,__,__,__,__,XX,XX,XX,__,__,__,
+          __,__,__,XX,XX,__,__,__,__,__,__,__,__,XX,XX,__,__,
+          __,__,XX,XX,__,__,__,__,__,__,__,__,__,XX,XX,__,__,
+          __,__,XX,XX,__,__,__,__,__,__,__,__,__,__,XX,XX,__,
+          __,XX,XX,__,__,__,__,__,__,__,__,__,__,__,XX,XX,__,
+          __,XX,XX,__,__,__,__,__,__,__,__,__,__,__,XX,XX,__,
+          __,XX,XX,__,__,__,__,__,__,__,__,__,__,__,XX,XX,__,
+          __,__,__,__,__,__,__,__,__,__,__,__,__,XX,XX,__,__,
+          __,__,__,__,__,__,__,__,__,__,__,__,__,XX,XX,__,__,
+          __,__,__,__,__,__,__,__,__,__,__,__,XX,XX,__,__,__,
+          __,__,__,__,__,__,__,__,__,__,__,XX,XX,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,__,XX,XX,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,XX,XX,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,XX,XX,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,XX,XX,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,XX,XX,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,XX,XX,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,XX,XX,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,XX,XX,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,XX,XX,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__ };
 #undef XX
 #undef __
   memcpy(buf->buf, image, sizeof(image));
@@ -234,26 +282,36 @@ static inline void error_image_8(dt_mipmap_buffer_t *buf)
 {
   if(!buf->buf) return;
   struct dt_mipmap_buffer_dsc *dsc = (struct dt_mipmap_buffer_dsc *)buf->buf - 1;
-  dsc->width = dsc->height = 13;
+  dsc->width = dsc->height = 23;
   dsc->iscale = 1.0f;
   buf->color_space = dsc->color_space = DT_COLORSPACE_DISPLAY;
-  assert(dsc->size > dsc->width * dsc->height * sizeof(uint32_t));
+  assert(dsc->size >= dsc->width * dsc->height * sizeof(uint32_t));
   const uint32_t XX = 0xffffffffu;
   const uint32_t __ = 0u;
   static const uint32_t image[]
-      = { __,__,__,__,__,__,__,__,__,__,__,__,__,
-          __,__,__,__,__,__,XX,__,__,__,__,__,__,
-          __,__,__,__,__,XX,XX,XX,__,__,__,__,__,
-          __,__,__,__,__,XX,__,XX,__,__,__,__,__,
-          __,__,__,__,XX,XX,__,XX,XX,__,__,__,__,
-          __,__,__,__,XX,XX,__,XX,XX,__,__,__,__,
-          __,__,__,XX,XX,XX,__,XX,XX,XX,__,__,__,
-          __,__,__,XX,XX,XX,__,XX,XX,XX,__,__,__,
-          __,__,XX,XX,XX,XX,__,XX,XX,XX,XX,__,__,
-          __,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,
-          __,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,__,
-          __,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,
-          __,__,__,__,__,__,__,__,__,__,__,__,__ };
+      = { __,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,__,__,XX,__,__,__,__,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,__,XX,XX,XX,__,__,__,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,__,XX,__,XX,__,__,__,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,XX,XX,__,XX,XX,__,__,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,XX,XX,__,XX,XX,__,__,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,XX,XX,__,__,__,XX,XX,__,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,XX,XX,__,__,__,XX,XX,__,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,XX,XX,XX,__,__,__,XX,XX,XX,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,XX,XX,XX,__,__,__,XX,XX,XX,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,XX,XX,XX,XX,__,__,__,XX,XX,XX,XX,__,__,__,__,__,__,
+          __,__,__,__,__,__,XX,XX,XX,XX,__,__,__,XX,XX,XX,XX,__,__,__,__,__,__,
+          __,__,__,__,__,XX,XX,XX,XX,XX,__,__,__,XX,XX,XX,XX,XX,__,__,__,__,__,
+          __,__,__,__,__,XX,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,XX,__,__,__,__,__,
+          __,__,__,__,XX,XX,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,
+          __,__,__,__,XX,XX,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,
+          __,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,
+          __,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,
+          __,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,
+          __,__,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,XX,XX,XX,XX,XX,XX,XX,XX,__,__,
+          __,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,
+          __,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,
+          __,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__ };
   memcpy(buf->buf, image, sizeof(image));
 }
 
@@ -262,27 +320,37 @@ void error_image_f(dt_mipmap_buffer_t *buf)
 {
   if(!buf->buf) return;
   struct dt_mipmap_buffer_dsc *dsc = (struct dt_mipmap_buffer_dsc *)buf->buf - 1;
-  dsc->width = dsc->height = 13;
+  dsc->width = dsc->height = 23;
   dsc->iscale = 1.0f;
   buf->color_space = dsc->color_space = DT_COLORSPACE_DISPLAY;
-  assert(dsc->size > dsc->width * dsc->height * 4 * sizeof(float));
+  assert(dsc->size >= dsc->width * dsc->height * 4 * sizeof(float));
 
 #define XX 1.0f, 1.0f, 1.0f, 1.0f
 #define __ 0.0f, 0.0f, 0.0f, 0.0f
   static const float image[]
-      = { __,__,__,__,__,__,__,__,__,__,__,__,__,
-          __,__,__,__,__,__,XX,__,__,__,__,__,__,
-          __,__,__,__,__,XX,XX,XX,__,__,__,__,__,
-          __,__,__,__,__,XX,__,XX,__,__,__,__,__,
-          __,__,__,__,XX,XX,__,XX,XX,__,__,__,__,
-          __,__,__,__,XX,XX,__,XX,XX,__,__,__,__,
-          __,__,__,XX,XX,XX,__,XX,XX,XX,__,__,__,
-          __,__,__,XX,XX,XX,__,XX,XX,XX,__,__,__,
-          __,__,XX,XX,XX,XX,__,XX,XX,XX,XX,__,__,
-          __,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,
-          __,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,__,
-          __,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,
-          __,__,__,__,__,__,__,__,__,__,__,__,__ };
+      = { __,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,__,__,XX,__,__,__,__,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,__,XX,XX,XX,__,__,__,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,__,XX,__,XX,__,__,__,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,XX,XX,__,XX,XX,__,__,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,__,XX,XX,__,XX,XX,__,__,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,XX,XX,__,__,__,XX,XX,__,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,__,XX,XX,__,__,__,XX,XX,__,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,XX,XX,XX,__,__,__,XX,XX,XX,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,__,XX,XX,XX,__,__,__,XX,XX,XX,__,__,__,__,__,__,__,
+          __,__,__,__,__,__,XX,XX,XX,XX,__,__,__,XX,XX,XX,XX,__,__,__,__,__,__,
+          __,__,__,__,__,__,XX,XX,XX,XX,__,__,__,XX,XX,XX,XX,__,__,__,__,__,__,
+          __,__,__,__,__,XX,XX,XX,XX,XX,__,__,__,XX,XX,XX,XX,XX,__,__,__,__,__,
+          __,__,__,__,__,XX,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,XX,__,__,__,__,__,
+          __,__,__,__,XX,XX,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,
+          __,__,__,__,XX,XX,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,XX,XX,__,__,__,__,
+          __,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,
+          __,__,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,
+          __,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,__,
+          __,__,XX,XX,XX,XX,XX,XX,XX,XX,__,__,__,XX,XX,XX,XX,XX,XX,XX,XX,__,__,
+          __,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,
+          __,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,XX,__,
+          __,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__,__ };
 #undef XX
 #undef __
   memcpy(buf->buf, image, sizeof(image));
@@ -673,7 +741,7 @@ void dt_mipmap_cache_init(dt_mipmap_cache_t *cache)
   _mipmap_cache_get_filename(cache->cachedir, sizeof(cache->cachedir));
   // make sure static memory is initialized
   struct dt_mipmap_buffer_dsc *dsc = (struct dt_mipmap_buffer_dsc *)_mipmap_cache_static_dead_image;
-  dead_image_f((dt_mipmap_buffer_t *)(dsc + 1));
+  _dead_image_f((dt_mipmap_buffer_t *)(dsc + 1));
 
   // adjust numbers to be large enough to hold what mem limit suggests.
   // we want at least 100MB, and consider 8G just still reasonable.
@@ -937,9 +1005,9 @@ void dt_mipmap_cache_get_with_caller(
           {
             buf->buf = (uint8_t*)(dsc+1); // point at pre-allocated space for static image
             if(mip < DT_MIPMAP_F)
-              dead_image_8(buf);
+              _dead_image_8(buf);
             else
-              dead_image_f(buf);
+              _dead_image_f(buf);
           }
         }
         else if(ret == DT_IMAGEIO_UNSUPPORTED_FORMAT || ret == DT_IMAGEIO_UNSUPPORTED_FEATURE)

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1350,7 +1350,14 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf,
 
   if(!buf.buf)
   {
-    dt_control_log(_("image `%s' is not available!"), image->filename);
+    fprintf(stderr,"load_status = %d\n",(int)image->load_status);
+    if(image->load_status == DT_IMAGEIO_FILE_NOT_FOUND)
+      dt_control_log(_("image `%s' is not available!"), image->filename);
+    else if(image->load_status == DT_IMAGEIO_LOAD_FAILED || image->load_status == DT_IMAGEIO_IOERROR ||
+            image->load_status == DT_IMAGEIO_CACHE_FULL)
+      dt_control_log(_("unable to load image `%s'!"), image->filename);
+    else
+      dt_control_log(_("image '%s' not supported"), image->filename);
     dt_image_cache_read_release(darktable.image_cache, image);
     *width = *height = 0;
     *iscale = 0.0f;

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1106,6 +1106,7 @@ void dt_mipmap_cache_get_with_caller(
           _dead_image_8(buf);
           break;
         case DT_IMAGEIO_UNSUPPORTED_FORMAT:
+        case DT_IMAGEIO_UNSUPPORTED_CAMERA:
         case DT_IMAGEIO_UNSUPPORTED_FEATURE:
           unsupp_image_8(buf);
           break;
@@ -1125,6 +1126,7 @@ void dt_mipmap_cache_get_with_caller(
           _dead_image_f(buf);
           break;
         case DT_IMAGEIO_UNSUPPORTED_FORMAT:
+        case DT_IMAGEIO_UNSUPPORTED_CAMERA:
         case DT_IMAGEIO_UNSUPPORTED_FEATURE:
           unsupp_image_f(buf);
           break;

--- a/src/common/mipmap_cache.h
+++ b/src/common/mipmap_cache.h
@@ -70,6 +70,7 @@ typedef struct dt_mipmap_buffer_t
   float iscale;
   uint8_t *buf;
   dt_colorspaces_color_profile_type_t color_space;
+  dt_imageio_retval_t loader_status;
   dt_cache_entry_t *cache_entry;
 } dt_mipmap_buffer_t;
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -327,6 +327,7 @@ void dt_dev_process_image_job(dt_develop_t *dev,
                       port ? DT_MIPMAP_FULL     : DT_MIPMAP_F,
                       port ? DT_MIPMAP_BLOCKING : DT_MIPMAP_BEST_EFFORT,
                       'r');
+  dev->image_load_error = buf.loader_status;
 
   dt_show_times(&start, "[dt_dev_process_image_job] loading image.");
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -327,7 +327,7 @@ void dt_dev_process_image_job(dt_develop_t *dev,
                       port ? DT_MIPMAP_FULL     : DT_MIPMAP_F,
                       port ? DT_MIPMAP_BLOCKING : DT_MIPMAP_BEST_EFFORT,
                       'r');
-  dev->image_load_error = buf.loader_status;
+  dev->image_storage.load_status = buf.loader_status;
 
   dt_show_times(&start, "[dt_dev_process_image_job] loading image.");
 
@@ -526,7 +526,8 @@ static inline void _dt_dev_load_raw(dt_develop_t *dev,
   dev->image_storage = *image;
   dt_image_cache_read_release(darktable.image_cache, image);
 
-  dev->requested_id = dev->image_storage.id;
+//  dev->requested_id = (dev->image_storage.load_status == DT_IMAGEIO_OK) ? dev->image_storage.id : 0; 
+  dev->requested_id = dev->image_storage.id; 
 }
 
 void dt_dev_reload_image(dt_develop_t *dev,

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -173,7 +173,6 @@ typedef struct dt_develop_t
   gboolean autosaving;
   double autosave_time;
   int32_t image_invalid_cnt;
-  dt_imageio_retval_t image_load_error;
   uint32_t timestamp;
   uint32_t preview_average_delay;
   struct dt_iop_module_t *gui_module; // this module claims gui expose/event callbacks.

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -173,6 +173,7 @@ typedef struct dt_develop_t
   gboolean autosaving;
   double autosave_time;
   int32_t image_invalid_cnt;
+  dt_imageio_retval_t image_load_error;
   uint32_t timestamp;
   uint32_t preview_average_delay;
   struct dt_iop_module_t *gui_module; // this module claims gui expose/event callbacks.

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2019-2023 darktable developers.
+    Copyright (C) 2019-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -681,11 +681,11 @@ static gboolean _event_image_draw(GtkWidget *widget,
         cairo_scale(cr2, scale, scale);
 
         cairo_set_source_surface(cr2, tmp_surface, 0, 0);
-        // set filter no nearest: in skull mode, we want to see big
+        // set filter to nearest: in skull/error mode, we want to see big
         // pixels.  in 1 iir mode for the right mip, we want to see
         // exactly what the pipe gave us, 1:1 pixel for pixel.  in
         // between, filtering just makes stuff go unsharp.
-        if((buf_width <= 8 && buf_height <= 8) || fabsf(scale - 1.0f) < 0.01f)
+        if((buf_width <= 16 && buf_height <= 16) || fabsf(scale - 1.0f) < 0.01f)
           cairo_pattern_set_filter(cairo_get_source(cr2), CAIRO_FILTER_NEAREST);
         else
           cairo_pattern_set_filter(cairo_get_source(cr2), darktable.gui->filter_image);

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -685,7 +685,7 @@ static gboolean _event_image_draw(GtkWidget *widget,
         // pixels.  in 1 iir mode for the right mip, we want to see
         // exactly what the pipe gave us, 1:1 pixel for pixel.  in
         // between, filtering just makes stuff go unsharp.
-        if((buf_width <= 16 && buf_height <= 16) || fabsf(scale - 1.0f) < 0.01f)
+        if((buf_width <= 30 && buf_height <= 30) || fabsf(scale - 1.0f) < 0.01f)
           cairo_pattern_set_filter(cairo_get_source(cr2), CAIRO_FILTER_NEAREST);
         else
           cairo_pattern_set_filter(cairo_get_source(cr2), darktable.gui->filter_image);

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -790,9 +790,15 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
   if(!buf.buf || !buf.width || !buf.height)
   {
     dt_print(DT_DEBUG_ALWAYS,
-             "[dt_imageio_export_with_flags] mipmap allocation for `%s' failed\n",
-             filename);
-    dt_control_log(_("image `%s' is not available!"), img->filename);
+             "[dt_imageio_export_with_flags] mipmap allocation for `%s' failed (status %d)\n",
+             filename,img->load_status);
+    if(img->load_status == DT_IMAGEIO_FILE_NOT_FOUND)
+      dt_control_log(_("image `%s' is not available!"), img->filename);
+    else if(img->load_status == DT_IMAGEIO_LOAD_FAILED || img->load_status == DT_IMAGEIO_IOERROR ||
+            img->load_status == DT_IMAGEIO_CACHE_FULL)
+      dt_control_log(_("unable to load image `%s'!"), img->filename);
+    else
+      dt_control_log(_("image '%s' not supported"), img->filename);
     goto error_early;
   }
 

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1308,7 +1308,7 @@ dt_imageio_retval_t dt_imageio_open(dt_image_t *img,
   /* first of all, check if file exists, don't bother to test loading
    * if not exists */
   if(!g_file_test(filename, G_FILE_TEST_IS_REGULAR))
-    return !DT_IMAGEIO_OK;
+    return DT_IMAGEIO_FILE_NOT_FOUND;
 
   const int32_t was_hdr = (img->flags & DT_IMAGE_HDR);
   const int32_t was_bw = dt_image_monochrome_flags(img);

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1344,16 +1344,20 @@ dt_imageio_retval_t dt_imageio_open(dt_image_t *img,
     ret = dt_imageio_open_rawspeed(img, filename, buf);
   }
 
-  /* fallback that tries to open file via LibRaw to support Canon CR3 */
-  if(ret != DT_IMAGEIO_OK && ret != DT_IMAGEIO_CACHE_FULL)
-    ret = dt_imageio_open_libraw(img, filename, buf);
+  // if rawspeed tried but failed to load a known filetype, skip the attempts to try other loaders
+  if(ret != DT_IMAGEIO_UNSUPPORTED_FEATURE && ret != DT_IMAGEIO_FILE_CORRUPTED && ret != DT_IMAGEIO_IOERROR)
+  {
+    /* fallback that tries to open file via LibRaw to support Canon CR3 */
+    if(ret != DT_IMAGEIO_OK && ret != DT_IMAGEIO_CACHE_FULL)
+      ret = dt_imageio_open_libraw(img, filename, buf);
 
-  if(ret != DT_IMAGEIO_OK && ret != DT_IMAGEIO_CACHE_FULL)
-    ret = dt_imageio_open_qoi(img, filename, buf);
+    if(ret != DT_IMAGEIO_OK && ret != DT_IMAGEIO_CACHE_FULL)
+      ret = dt_imageio_open_qoi(img, filename, buf);
 
-  /* fallback that tries to open file via GraphicsMagick */
-  if(ret != DT_IMAGEIO_OK && ret != DT_IMAGEIO_CACHE_FULL)
-    ret = dt_imageio_open_exotic(img, filename, buf);
+    /* fallback that tries to open file via GraphicsMagick */
+    if(ret != DT_IMAGEIO_OK && ret != DT_IMAGEIO_CACHE_FULL)
+      ret = dt_imageio_open_exotic(img, filename, buf);
+  }
 
   if((ret == DT_IMAGEIO_OK) && !was_hdr && (img->flags & DT_IMAGE_HDR))
     dt_imageio_set_hdr_tag(img);

--- a/src/imageio/imageio_avif.c
+++ b/src/imageio/imageio_avif.c
@@ -41,7 +41,7 @@ dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
   // We shouldn't expect AVIF images in files with an extension other than .avif
   char *ext = g_strrstr(filename, ".");
   if(ext && g_ascii_strcasecmp(ext, ".avif"))
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_UNSUPPORTED_FORMAT;
 
   dt_imageio_retval_t ret;
   avifImage *avif_image = avifImageCreateEmpty();
@@ -63,7 +63,7 @@ dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
   if(result != AVIF_RESULT_OK)
   {
     dt_print(DT_DEBUG_IMAGEIO, "[avif_open] failed to parse `%s': %s\n", filename, avifResultToString(result));
-    ret = DT_IMAGEIO_LOAD_FAILED;
+    ret = DT_IMAGEIO_FILE_CORRUPTED;
     goto out;
   }
 

--- a/src/imageio/imageio_exr.cc
+++ b/src/imageio/imageio_exr.cc
@@ -64,7 +64,7 @@ dt_imageio_retval_t dt_imageio_open_exr(dt_image_t *img,
 
   /* verify openexr image */
   if(!Imf::isOpenExrFile((const char *)filename, isTiled))
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_UNSUPPORTED_FORMAT;
 
   /* open exr file */
   try
@@ -106,7 +106,7 @@ dt_imageio_retval_t dt_imageio_open_exr(dt_image_t *img,
     dt_print(DT_DEBUG_ALWAYS,
              "[exr_open] error: only images with RGB(A) channels are supported,"
              " skipping `%s'\n", img->filename);
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_UNSUPPORTED_FEATURE;
   }
 
   if(!img->exif_inited)

--- a/src/imageio/imageio_heif.c
+++ b/src/imageio/imageio_heif.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2021-2023 darktable developers.
+    Copyright (C) 2021-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -62,6 +62,7 @@ dt_imageio_retval_t dt_imageio_open_heif(dt_image_t *img,
   err = heif_context_read_from_file(ctx, filename, NULL);
   if(err.code != heif_error_Ok)
   {
+    ret = DT_IMAGEIO_LOAD_FAILED;
     if(err.code == heif_error_Unsupported_feature && err.subcode == heif_suberror_Unsupported_codec)
     {
       /* we want to feedback this to the user, so output to stderr */
@@ -69,13 +70,14 @@ dt_imageio_retval_t dt_imageio_open_heif(dt_image_t *img,
                "[imageio_heif] Unsupported codec for `%s'. "
                "Check if your libheif is built with HEVC and/or AV1 decoding support.\n",
                filename);
+      ret = DT_IMAGEIO_UNSUPPORTED_FEATURE;
     }
     else if(err.code != heif_error_Unsupported_filetype && err.subcode != heif_suberror_No_ftyp_box)
     {
       /* print debug info only if genuine HEIF */
       dt_print(DT_DEBUG_IMAGEIO, "Failed to read HEIF file [%s]: %s\n", filename, err.message);
+      ret = DT_IMAGEIO_UNSUPPORTED_FORMAT;
     }
-    ret = DT_IMAGEIO_LOAD_FAILED;
     goto out;
   }
 
@@ -86,7 +88,7 @@ dt_imageio_retval_t dt_imageio_open_heif(dt_image_t *img,
     dt_print(DT_DEBUG_IMAGEIO,
              "No images found in HEIF file [%s]\n",
              filename);
-    ret = DT_IMAGEIO_LOAD_FAILED;
+    ret = DT_IMAGEIO_FILE_CORRUPTED;
     goto out;
   }
 
@@ -97,7 +99,7 @@ dt_imageio_retval_t dt_imageio_open_heif(dt_image_t *img,
     dt_print(DT_DEBUG_IMAGEIO,
              "Failed to read primary image from HEIF file [%s]\n",
              filename);
-    ret = DT_IMAGEIO_LOAD_FAILED;
+    ret = DT_IMAGEIO_UNSUPPORTED_FEATURE;
     goto out;
   }
 
@@ -169,7 +171,7 @@ dt_imageio_retval_t dt_imageio_open_heif(dt_image_t *img,
     dt_print(DT_DEBUG_IMAGEIO,
              "Failed to decode HEIF file [%s]\n",
              filename);
-    ret = DT_IMAGEIO_LOAD_FAILED;
+    ret = DT_IMAGEIO_FILE_CORRUPTED;
     goto out;
   }
 

--- a/src/imageio/imageio_jpeg.c
+++ b/src/imageio/imageio_jpeg.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2023 darktable developers.
+    Copyright (C) 2009-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -768,13 +768,14 @@ dt_imageio_retval_t dt_imageio_open_jpeg(dt_image_t *img,
 
   if(memcmp(first3bytes, jpeg_magicbytes, 3) != 0)
   {
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_UNSUPPORTED_FORMAT;
   }
 
   if(!img->exif_inited) (void)dt_exif_read(img, filename);
 
   dt_imageio_jpeg_t jpg;
-  if(dt_imageio_jpeg_read_header(filename, &jpg)) return DT_IMAGEIO_LOAD_FAILED;
+  if(dt_imageio_jpeg_read_header(filename, &jpg))
+    return DT_IMAGEIO_FILE_CORRUPTED;
   img->width = jpg.width;
   img->height = jpg.height;
 
@@ -782,7 +783,7 @@ dt_imageio_retval_t dt_imageio_open_jpeg(dt_image_t *img,
   if(dt_imageio_jpeg_read(&jpg, tmp))
   {
     dt_free_align(tmp);
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_FILE_CORRUPTED;
   }
 
   img->buf_dsc.channels = 4;

--- a/src/imageio/imageio_jpegxl.c
+++ b/src/imageio/imageio_jpegxl.c
@@ -66,7 +66,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
              filename);
     free(read_buffer);
     fclose(inputfile);
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_IOERROR;
   }
   fclose(inputfile);
 
@@ -76,7 +76,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
   {
     // It's normal if this function is called for a non-jxl file, so we should fail silently.
     free(read_buffer);
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_UNSUPPORTED_FORMAT;
   }
 
   const JxlPixelFormat pixel_format =
@@ -149,7 +149,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
       JxlResizableParallelRunnerDestroy(runner);
       JxlDecoderDestroy(decoder);
       free(read_buffer);
-      return DT_IMAGEIO_LOAD_FAILED;
+      return DT_IMAGEIO_FILE_CORRUPTED;
     }
 
     if(status == JXL_DEC_NEED_MORE_INPUT)
@@ -158,7 +158,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
       JxlResizableParallelRunnerDestroy(runner);
       JxlDecoderDestroy(decoder);
       free(read_buffer);
-      return DT_IMAGEIO_LOAD_FAILED;
+      return DT_IMAGEIO_FILE_CORRUPTED;
     }
 
     if(status == JXL_DEC_BASIC_INFO)
@@ -169,7 +169,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
         JxlResizableParallelRunnerDestroy(runner);
         JxlDecoderDestroy(decoder);
         free(read_buffer);
-        return DT_IMAGEIO_LOAD_FAILED;
+        return DT_IMAGEIO_FILE_CORRUPTED;
       }
 
       // Unlikely to happen, but let there be a sanity check
@@ -179,7 +179,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
         JxlResizableParallelRunnerDestroy(runner);
         JxlDecoderDestroy(decoder);
         free(read_buffer);
-        return DT_IMAGEIO_LOAD_FAILED;
+        return DT_IMAGEIO_FILE_CORRUPTED;
       }
 
 
@@ -261,7 +261,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
         JxlResizableParallelRunnerDestroy(runner);
         JxlDecoderDestroy(decoder);
         free(read_buffer);
-        return DT_IMAGEIO_LOAD_FAILED;
+        return DT_IMAGEIO_UNSUPPORTED_FEATURE;
       }
     continue;    // go to next iteration to process rest of the input
     }

--- a/src/imageio/imageio_libraw.c
+++ b/src/imageio/imageio_libraw.c
@@ -386,10 +386,7 @@ dt_imageio_retval_t dt_imageio_open_libraw(dt_image_t *img,
 
   libraw_err = libraw_unpack(raw);
   if(libraw_err != LIBRAW_SUCCESS)
-  {
-    err = DT_IMAGEIO_UNSUPPORTED_FORMAT;
     goto error;
-  }
 
   // Bad method to detect if camera is fully supported by LibRaw,
   // but seems to be the best available. LibRaw crx decoder can actually
@@ -410,7 +407,10 @@ dt_imageio_retval_t dt_imageio_open_libraw(dt_image_t *img,
   // table for Canon CR3s only.
   gchar *ext = g_strrstr(filename, ".");
   if(!ext)
+  {
+    err = DT_IMAGEIO_LOAD_FAILED;
     goto error;
+  }
   ext++;
   if(!g_ascii_strncasecmp("cr3", ext, 3))
     _check_libraw_missing_support(img);
@@ -528,9 +528,29 @@ dt_imageio_retval_t dt_imageio_open_libraw(dt_image_t *img,
 
 error:
   if(libraw_err != LIBRAW_SUCCESS)
+  {
     dt_print(DT_DEBUG_ALWAYS,
              "[libraw_open] `%s': %s\n",
              img->filename, libraw_strerror(libraw_err));
+    switch(libraw_err)
+    {
+    case LIBRAW_FILE_UNSUPPORTED:
+      err = DT_IMAGEIO_UNSUPPORTED_FORMAT;
+      break;
+    case LIBRAW_NOT_IMPLEMENTED:
+      err = DT_IMAGEIO_UNSUPPORTED_FEATURE;
+      break;
+    case LIBRAW_DATA_ERROR:
+      err = DT_IMAGEIO_FILE_CORRUPTED;
+      break;
+    case LIBRAW_IO_ERROR:
+      err = DT_IMAGEIO_IOERROR;
+      break;
+    default:
+      err = DT_IMAGEIO_LOAD_FAILED;
+      break;
+    }
+  }
   libraw_close(raw);
   return err;
 }

--- a/src/imageio/imageio_libraw.c
+++ b/src/imageio/imageio_libraw.c
@@ -386,7 +386,10 @@ dt_imageio_retval_t dt_imageio_open_libraw(dt_image_t *img,
 
   libraw_err = libraw_unpack(raw);
   if(libraw_err != LIBRAW_SUCCESS)
+  {
+    err = DT_IMAGEIO_UNSUPPORTED_FORMAT;
     goto error;
+  }
 
   // Bad method to detect if camera is fully supported by LibRaw,
   // but seems to be the best available. LibRaw crx decoder can actually
@@ -398,6 +401,7 @@ dt_imageio_retval_t dt_imageio_open_libraw(dt_image_t *img,
   {
     dt_print(DT_DEBUG_ALWAYS,
              "[libraw_open] detected unsupported image `%s'\n", img->filename);
+    err = DT_IMAGEIO_UNSUPPORTED_FEATURE;
     goto error;
   }
 

--- a/src/imageio/imageio_pfm.c
+++ b/src/imageio/imageio_pfm.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2023 darktable developers.
+    Copyright (C) 2009-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -41,7 +41,7 @@ dt_imageio_retval_t dt_imageio_open_pfm(dt_image_t *img, const char *filename, d
   if(strcasecmp(ext, ".pfm")) return DT_IMAGEIO_LOAD_FAILED;
 
   FILE *f = g_fopen(filename, "rb");
-  if(!f) return DT_IMAGEIO_LOAD_FAILED;
+  if(!f) return DT_IMAGEIO_FILE_NOT_FOUND;
 
   int ret = 0;
   int cols = 3;
@@ -128,7 +128,7 @@ dt_imageio_retval_t dt_imageio_open_pfm(dt_image_t *img, const char *filename, d
 
 error_corrupt:
   fclose(f);
-  return DT_IMAGEIO_LOAD_FAILED;
+  return DT_IMAGEIO_FILE_CORRUPTED;
 error_cache_full:
   fclose(f);
   return DT_IMAGEIO_CACHE_FULL;

--- a/src/imageio/imageio_png.c
+++ b/src/imageio/imageio_png.c
@@ -155,7 +155,8 @@ dt_imageio_retval_t dt_imageio_open_png(dt_image_t *img, const char *filename, d
 {
   const char *ext = filename + strlen(filename);
   while(*ext != '.' && ext > filename) ext--;
-  if(strncmp(ext, ".png", 4) && strncmp(ext, ".PNG", 4)) return DT_IMAGEIO_LOAD_FAILED;
+  if(strncmp(ext, ".png", 4) && strncmp(ext, ".PNG", 4))
+    return DT_IMAGEIO_UNSUPPORTED_FORMAT;
   if(!img->exif_inited) (void)dt_exif_read(img, filename);
 
   dt_imageio_png_t image;
@@ -165,7 +166,7 @@ dt_imageio_retval_t dt_imageio_open_png(dt_image_t *img, const char *filename, d
 
 
   if(!dt_imageio_png_read_header(filename, &image))
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_UNSUPPORTED_FORMAT;
 
   width = img->width = image.width;
   height = img->height = image.height;
@@ -197,7 +198,7 @@ dt_imageio_retval_t dt_imageio_open_png(dt_image_t *img, const char *filename, d
   {
     dt_free_align(buf);
     dt_print(DT_DEBUG_ALWAYS, "[png_open] could not read image `%s'\n", img->filename);
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_FILE_CORRUPTED;
   }
 
   const size_t npixels = (size_t)width * height;

--- a/src/imageio/imageio_pnm.c
+++ b/src/imageio/imageio_pnm.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2018-2023 darktable developers.
+    Copyright (C) 2018-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -47,7 +47,7 @@ static dt_imageio_retval_t _read_pbm(dt_image_t *img, FILE*f, float *buf)
   {
     if(fread(line, sizeof(uint8_t), (size_t)bytes_needed, f) != bytes_needed)
     {
-      result = DT_IMAGEIO_LOAD_FAILED;
+      result = DT_IMAGEIO_IOERROR;
       break;
     }
     for(size_t x = 0; x < bytes_needed; x++)
@@ -81,7 +81,7 @@ static dt_imageio_retval_t _read_pgm(dt_image_t *img, FILE*f, float *buf)
     max = atoi(maxvalue_string);
   else
     return DT_IMAGEIO_LOAD_FAILED;
-  if(max == 0 || max > 65535) return DT_IMAGEIO_LOAD_FAILED;
+  if(max == 0 || max > 65535) return DT_IMAGEIO_FILE_CORRUPTED;
 
   if(max <= 255)
   {
@@ -92,7 +92,7 @@ static dt_imageio_retval_t _read_pgm(dt_image_t *img, FILE*f, float *buf)
     {
       if(fread(line, sizeof(uint8_t), (size_t)img->width, f) != img->width)
       {
-        result = DT_IMAGEIO_LOAD_FAILED;
+        result = DT_IMAGEIO_FILE_CORRUPTED;
         break;
       }
       for(size_t x = 0; x < img->width; x++)
@@ -114,7 +114,7 @@ static dt_imageio_retval_t _read_pgm(dt_image_t *img, FILE*f, float *buf)
     {
       if(fread(line, sizeof(uint16_t), (size_t)img->width, f) != img->width)
       {
-        result = DT_IMAGEIO_LOAD_FAILED;
+        result = DT_IMAGEIO_FILE_CORRUPTED;
         break;
       }
       for(size_t x = 0; x < img->width; x++)
@@ -146,7 +146,7 @@ static dt_imageio_retval_t _read_ppm(dt_image_t *img, FILE*f, float *buf)
     max = atoi(maxvalue_string);
   else
     return DT_IMAGEIO_LOAD_FAILED;
-  if(max == 0 || max > 65535) return DT_IMAGEIO_LOAD_FAILED;
+  if(max == 0 || max > 65535) return DT_IMAGEIO_FILE_CORRUPTED;
 
   if(max <= 255)
   {
@@ -181,7 +181,7 @@ static dt_imageio_retval_t _read_ppm(dt_image_t *img, FILE*f, float *buf)
     {
       if(fread(line, 3 * sizeof(uint16_t), (size_t)img->width, f) != img->width)
       {
-        result = DT_IMAGEIO_LOAD_FAILED;
+        result = DT_IMAGEIO_FILE_CORRUPTED;
         break;
       }
       for(size_t x = 0; x < img->width; x++)
@@ -209,9 +209,9 @@ dt_imageio_retval_t dt_imageio_open_pnm(dt_image_t *img, const char *filename, d
   const char *ext = filename + strlen(filename);
   while(*ext != '.' && ext > filename) ext--;
   if(strcasecmp(ext, ".pbm") && strcasecmp(ext, ".pgm") && strcasecmp(ext, ".pnm") && strcasecmp(ext, ".ppm"))
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_UNSUPPORTED_FORMAT;
   FILE *f = g_fopen(filename, "rb");
-  if(!f) return DT_IMAGEIO_LOAD_FAILED;
+  if(!f) return DT_IMAGEIO_FILE_NOT_FOUND;
   int ret = 0;
   dt_imageio_retval_t result = DT_IMAGEIO_LOAD_FAILED;
 

--- a/src/imageio/imageio_qoi.c
+++ b/src/imageio/imageio_qoi.c
@@ -38,13 +38,13 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
   // We shouldn't expect QOI images in files with an extension other than .qoi
   char *ext = g_strrstr(filename, ".");
   if(ext && g_ascii_strcasecmp(ext, ".qoi"))
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_UNSUPPORTED_FORMAT;
 
   FILE *f = g_fopen(filename, "rb");
   if(!f)
   {
     dt_print(DT_DEBUG_ALWAYS,"[qoi_open] cannot open file for read: %s\n", filename);
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_FILE_NOT_FOUND;
   }
 
   fseek(f, 0, SEEK_END);
@@ -62,7 +62,7 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
     g_free(read_buffer);
     dt_print(DT_DEBUG_ALWAYS, "[qoi_open] failed to read from %s\n", filename);
     // if we can't read even first 4 bytes, it's more like file disappeared
-    return DT_IMAGEIO_FILE_NOT_FOUND;
+    return DT_IMAGEIO_FILE_CORRUPTED;
   }
 
   if(memcmp(read_buffer, "qoif", 4) != 0)
@@ -71,7 +71,7 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
     g_free(read_buffer);
     dt_print(DT_DEBUG_ALWAYS,
              "[qoi_open] no proper file header in %s\n", filename);
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_UNSUPPORTED_FORMAT;
   }
 
   if(fread(read_buffer+4, 1, filesize-4, f) != filesize-4)
@@ -81,7 +81,7 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
     dt_print(DT_DEBUG_ALWAYS,
              "[qoi_open] failed to read %zu bytes from %s\n",
              filesize, filename);
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_IOERROR;
   }
   fclose(f);
 
@@ -92,7 +92,7 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
   {
     g_free(read_buffer);
     dt_print(DT_DEBUG_ALWAYS,"[qoi_open] failed to decode file: %s\n", filename);
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_FILE_CORRUPTED;
   }
 
   img->width = desc.width;

--- a/src/imageio/imageio_rawspeed.cc
+++ b/src/imageio/imageio_rawspeed.cc
@@ -21,6 +21,10 @@
 #endif
 
 #include "RawSpeed-API.h"
+#include "io/FileIOException.h"
+#include "metadata/CameraMetadataException.h"
+#include "parsers/RawParserException.h"
+#include "parsers/FiffParserException.h"
 
 #define TYPE_FLOAT32 RawImageType::F32
 #define TYPE_USHORT16 RawImageType::UINT16
@@ -406,6 +410,26 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img,
 
     if(cam && cam->supportStatus == Camera::SupportStatus::SupportedNoSamples)
       img->camera_missing_sample = TRUE;
+  }
+  catch(const rawspeed::IOException &exc)
+  {
+    dt_print(DT_DEBUG_ALWAYS, "[rawspeed] (%s) I/O error: %s\n", img->filename, exc.what());
+    return DT_IMAGEIO_IOERROR;
+  }
+  catch(const rawspeed::FileIOException &exc)
+  {
+    dt_print(DT_DEBUG_ALWAYS, "[rawspeed] (%s) File I/O error: %s\n", img->filename, exc.what());
+    return DT_IMAGEIO_IOERROR;
+  }
+  catch(const rawspeed::RawParserException &exc)
+  {
+    dt_print(DT_DEBUG_ALWAYS, "[rawspeed] (%s) CIFF/FIFF error: %s\n", img->filename, exc.what());
+    return DT_IMAGEIO_UNSUPPORTED_FORMAT;
+  }
+  catch(const rawspeed::CameraMetadataException &exc)
+  {
+    dt_print(DT_DEBUG_ALWAYS, "[rawspeed] (%s) metadata error: %s\n", img->filename, exc.what());
+    return DT_IMAGEIO_UNSUPPORTED_FEATURE;
   }
   catch(const std::exception &exc)
   {

--- a/src/imageio/imageio_rawspeed.cc
+++ b/src/imageio/imageio_rawspeed.cc
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2023 darktable developers.
+    Copyright (C) 2010-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -162,7 +162,7 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img,
                                              dt_mipmap_buffer_t *mbuf)
 {
   if(_ignore_image(filename))
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_UNSUPPORTED_FORMAT;
 
   if(!img->exif_inited)
     (void)dt_exif_read(img, filename);
@@ -182,7 +182,7 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img,
     RawParser t(storageBuf);
     std::unique_ptr<RawDecoder> d = t.getDecoder(meta);
 
-    if(!d.get()) return DT_IMAGEIO_LOAD_FAILED;
+    if(!d.get()) return DT_IMAGEIO_UNSUPPORTED_FORMAT;
 
     d->failOnUnknown = true;
     d->checkSupport(meta);
@@ -305,16 +305,16 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img,
     }
 
     if((r->getDataType() != TYPE_USHORT16) && (r->getDataType() != TYPE_FLOAT32))
-      return DT_IMAGEIO_LOAD_FAILED;
+      return DT_IMAGEIO_UNSUPPORTED_FEATURE;
 
     if((r->getBpp() != sizeof(uint16_t)) && (r->getBpp() != sizeof(float)))
-      return DT_IMAGEIO_LOAD_FAILED;
+      return DT_IMAGEIO_UNSUPPORTED_FEATURE;
 
     if((r->getDataType() == TYPE_USHORT16) && (r->getBpp() != sizeof(uint16_t)))
-      return DT_IMAGEIO_LOAD_FAILED;
+      return DT_IMAGEIO_UNSUPPORTED_FEATURE;
 
     if((r->getDataType() == TYPE_FLOAT32) && (r->getBpp() != sizeof(float)))
-      return DT_IMAGEIO_LOAD_FAILED;
+      return DT_IMAGEIO_UNSUPPORTED_FEATURE;
 
     const float cpp = r->getCpp();
     if(cpp != 1) return DT_IMAGEIO_LOAD_FAILED;
@@ -330,7 +330,7 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img,
         img->buf_dsc.datatype = TYPE_FLOAT;
         break;
       default:
-        return DT_IMAGEIO_LOAD_FAILED;
+        return DT_IMAGEIO_UNSUPPORTED_FEATURE;
     }
 
     // as the X-Trans filters comments later on states, these are for
@@ -413,12 +413,12 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img,
 
     /* if an exception is raised lets not retry or handle the
      specific ones, consider the file as corrupted */
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_FILE_CORRUPTED;
   }
   catch(...)
   {
     dt_print(DT_DEBUG_ALWAYS, "[rawspeed] unhandled exception in imageio_rawspeed\n");
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_FILE_CORRUPTED;
   }
 
   img->buf_dsc.cst = IOP_CS_RAW;
@@ -441,11 +441,11 @@ dt_imageio_retval_t dt_imageio_open_rawspeed_sraw(dt_image_t *img,
   img->buf_dsc.datatype = TYPE_FLOAT;
 
   if(r->getDataType() != TYPE_USHORT16 && r->getDataType() != TYPE_FLOAT32)
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_UNSUPPORTED_FEATURE;
 
   const uint32_t cpp = r->getCpp();
   if(cpp != 1 && cpp != 3 && cpp != 4)
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_FILE_CORRUPTED;
 
   // if buf is NULL, we quit the fct here
   if(!mbuf)

--- a/src/imageio/imageio_rgbe.c
+++ b/src/imageio/imageio_rgbe.c
@@ -444,11 +444,11 @@ dt_imageio_retval_t dt_imageio_open_rgbe(dt_image_t *img,
   if(!ext)
     return DT_IMAGEIO_LOAD_FAILED;
   if(g_ascii_strcasecmp(ext, ".hdr") != 0)
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_UNSUPPORTED_FORMAT;
 
   FILE *f = g_fopen(filename, "rb");
   if(!f)
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_FILE_NOT_FOUND;
 
   rgbe_header_info info;
   if(RGBE_ReadHeader(f, &img->width, &img->height, &info) != RGBE_RETURN_SUCCESS)
@@ -471,7 +471,7 @@ dt_imageio_retval_t dt_imageio_open_rgbe(dt_image_t *img,
   if(RGBE_ReadPixels_RLE(f, rgbe_buf, img->width, img->height) != RGBE_RETURN_SUCCESS)
   {
     dt_free_align(rgbe_buf);
-    goto rgbe_failed;
+    goto rgbe_corrupt;
   }
 
   fclose(f);
@@ -519,6 +519,10 @@ dt_imageio_retval_t dt_imageio_open_rgbe(dt_image_t *img,
 rgbe_failed:
   fclose(f);
   return DT_IMAGEIO_LOAD_FAILED;
+
+rgbe_corrupt:
+  fclose(f);
+  return DT_IMAGEIO_FILE_CORRUPTED;
 
 error_cache_full:
   fclose(f);

--- a/src/imageio/imageio_tiff.c
+++ b/src/imageio/imageio_tiff.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2010-2023 darktable developers.
+    Copyright (C) 2010-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -358,7 +358,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
   while(*ext != '.' && ext > filename) ext--;
   if(strncmp(ext, ".tif", 4) && strncmp(ext, ".TIF", 4) && strncmp(ext, ".tiff", 5)
      && strncmp(ext, ".TIFF", 5))
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_UNSUPPORTED_FORMAT;
   if(!img->exif_inited) (void)dt_exif_read(img, filename);
 
   tiff_t t;
@@ -391,13 +391,13 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
   {
     dt_print(DT_DEBUG_ALWAYS, "[tiff_open] error: CMYK (or multiink) TIFFs are not supported.\n");
     TIFFClose(t.tiff);
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_UNSUPPORTED_FEATURE;
   }
 
   if(TIFFRasterScanlineSize(t.tiff) != TIFFScanlineSize(t.tiff))
   {
     TIFFClose(t.tiff);
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_FILE_CORRUPTED;
   }
 
   t.scanlinesize = TIFFScanlineSize(t.tiff);
@@ -408,14 +408,14 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
   if(t.bpp != 8 && t.bpp != 16 && t.bpp != 32)
   {
     TIFFClose(t.tiff);
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_UNSUPPORTED_FEATURE;
   }
 
   /* we only support 1, 3 or 4 samples per pixel */
   if(t.spp != 1 && t.spp != 3 && t.spp != 4)
   {
     TIFFClose(t.tiff);
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_UNSUPPORTED_FEATURE;
   }
 
   /* don't depend on planar config if spp == 1 */
@@ -423,7 +423,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
   {
     dt_print(DT_DEBUG_ALWAYS, "[tiff_open] error: PlanarConfiguration other than chunky is not supported.\n");
     TIFFClose(t.tiff);
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_UNSUPPORTED_FEATURE;
   }
 
   /* initialize cached image buffer */
@@ -464,6 +464,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
   }
 
   int ok = 1;
+  dt_imageio_retval_t ret = DT_IMAGEIO_LOAD_FAILED;
 
   if((photometric == PHOTOMETRIC_CIELAB || photometric == PHOTOMETRIC_ICCLAB) && t.bpp == 8 && t.sampleformat == SAMPLEFORMAT_UINT)
     ok = _read_chunky_8_Lab(&t, photometric);
@@ -481,6 +482,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
   {
     dt_print(DT_DEBUG_ALWAYS, "[tiff_open] error: not a supported tiff image format.\n");
     ok = 0;
+    ret = DT_IMAGEIO_UNSUPPORTED_FEATURE;
   }
 
   _TIFFfree(t.buf);
@@ -494,7 +496,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
     return DT_IMAGEIO_OK;
   }
   else
-    return DT_IMAGEIO_LOAD_FAILED;
+    return ret;
 }
 
 int dt_imageio_tiff_read_profile(const char *filename, uint8_t **out)

--- a/src/imageio/imageio_webp.c
+++ b/src/imageio/imageio_webp.c
@@ -29,7 +29,7 @@ dt_imageio_retval_t dt_imageio_open_webp(dt_image_t *img, const char *filename, 
   if(!f)
   {
     dt_print(DT_DEBUG_ALWAYS,"[webp_open] cannot open file for read: %s\n", filename);
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_FILE_NOT_FOUND;
   }
 
   fseek(f, 0, SEEK_END);
@@ -43,7 +43,7 @@ dt_imageio_retval_t dt_imageio_open_webp(dt_image_t *img, const char *filename, 
     fclose(f);
     g_free(read_buffer);
     dt_print(DT_DEBUG_ALWAYS,"[webp_open] failed to read %zu bytes from %s\n", filesize, filename);
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_IOERROR;
   }
   fclose(f);
 

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -210,6 +210,10 @@ static gboolean _ignore_missing_wb(dt_image_t *img)
   if(g_str_has_suffix(img->filename,"-hdr.dng"))
     return TRUE;
 
+  // If we failed to read the image correctly, don't complain about WB
+  if(img->load_status != DT_IMAGEIO_OK && img->load_status != DT_IMAGEIO_CACHE_FULL)
+    return TRUE;
+
   static const char *const ignored_cameras[] = {
     "Canon PowerShot A610",
     "Canon PowerShot S3 IS",

--- a/src/libs/live_view.c
+++ b/src/libs/live_view.c
@@ -529,7 +529,7 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cr, int32_t width, int32_t 
       // in skull/error mode, we want to see big pixels.
       // in 1 iir mode for the right mip, we want to see exactly what the pipe gave us, 1:1 pixel for pixel.
       // in between, filtering just makes stuff go unsharp.
-      if((buf.width <= 16 && buf.height <= 16) || fabsf(scale - 1.0f) < 0.01f)
+      if((buf.width <= 30 && buf.height <= 30) || fabsf(scale - 1.0f) < 0.01f)
         cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_NEAREST);
       cairo_rectangle(cr, 0, 0, buf.width, buf.height);
       const int overlay_modes_index = dt_bauhaus_combobox_get(lib->overlay_mode);

--- a/src/libs/live_view.c
+++ b/src/libs/live_view.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2023 darktable developers.
+    Copyright (C) 2012-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -526,10 +526,10 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cr, int32_t width, int32_t 
 
       cairo_set_source_surface(cr, surface, 0, 0);
       // set filter no nearest:
-      // in skull mode, we want to see big pixels.
+      // in skull/error mode, we want to see big pixels.
       // in 1 iir mode for the right mip, we want to see exactly what the pipe gave us, 1:1 pixel for pixel.
       // in between, filtering just makes stuff go unsharp.
-      if((buf.width <= 8 && buf.height <= 8) || fabsf(scale - 1.0f) < 0.01f)
+      if((buf.width <= 16 && buf.height <= 16) || fabsf(scale - 1.0f) < 0.01f)
         cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_NEAREST);
       cairo_rectangle(cr, 0, 0, buf.width, buf.height);
       const int overlay_modes_index = dt_bauhaus_combobox_get(lib->overlay_mode);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -531,6 +531,11 @@ void expose(
           _("file `%s' is not in any recognized format, switching to lighttable now."),
           dev->image_storage.filename);
         break;
+      case DT_IMAGEIO_UNSUPPORTED_CAMERA:
+        load_txt = g_strdup_printf(
+          _("file `%s' is from an unsupported camera model, switching to lighttable now."),
+          dev->image_storage.filename);
+        break;
       case DT_IMAGEIO_UNSUPPORTED_FEATURE:
         load_txt = g_strdup_printf(
           _("file `%s' uses an unsupported feature, switching to lighttable now.\n\n"
@@ -802,6 +807,9 @@ gboolean try_enter(dt_view_t *self)
       break;
     case DT_IMAGEIO_UNSUPPORTED_FORMAT:
       reason = _("unsupported file format");
+      break;
+    case DT_IMAGEIO_UNSUPPORTED_CAMERA:
+      reason = _("unsupported camera model");
       break;
     case DT_IMAGEIO_UNSUPPORTED_FEATURE:
       reason = _("unsupported feature in file");

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -504,17 +504,57 @@ void expose(
   {
     gchar *load_txt;
     float fontsize;
-
+    dt_image_t *img = dt_image_cache_get(darktable.image_cache, dev->image_storage.id, 'r');;
+    dt_imageio_retval_t status = img->load_status;
+    dt_image_cache_read_release(darktable.image_cache, img);
+    
     if(dev->image_invalid_cnt)
     {
       fontsize = DT_PIXEL_APPLY_DPI(16);
-      load_txt = g_strdup_printf(
+      switch(status)
+      {
+      case DT_IMAGEIO_FILE_NOT_FOUND:
+        load_txt = g_strdup_printf(
+          _("file `%s' is not available, switching to lighttable now.\n\n"
+            "if stored on an external drive, ensure that the drive is connected and files\n"
+            "can be accessed in the same locations as when you imported this image."),
+          dev->image_storage.filename);
+        break;
+      case DT_IMAGEIO_FILE_CORRUPTED:
+        load_txt = g_strdup_printf(
+          _("file `%s' appears corrupt, switching to lighttable now.\n\n"
+            "please check that it was correctly and completely copied from the camera."),
+          dev->image_storage.filename);
+        break;
+      case DT_IMAGEIO_UNSUPPORTED_FORMAT:
+        load_txt = g_strdup_printf(
+          _("file `%s' is not in any recognized format, switching to lighttable now."),
+          dev->image_storage.filename);
+        break;
+      case DT_IMAGEIO_UNSUPPORTED_FEATURE:
+        load_txt = g_strdup_printf(
+          _("file `%s' uses an unsupported feature, switching to lighttable now.\n\n"
+            "please check that the image format and compression mode you selected in your\n"
+            "camera's menus is supported (see https://www.darktable.org/resources/camera-support/\n"
+            "and the release notes for this version of darktable)"),
+          dev->image_storage.filename);
+        break;
+      case DT_IMAGEIO_IOERROR:
+        load_txt = g_strdup_printf(
+          _("error while reading file `%s', switching to lighttable now.\n\n"
+            "please check that the file has not been truncated."),
+          dev->image_storage.filename);
+        break;
+      default:
+        load_txt = g_strdup_printf(
           _("darktable could not load `%s', switching to lighttable now.\n\n"
             "please check that the camera model that produced the image is supported in darktable\n"
             "(list of supported cameras is at https://www.darktable.org/resources/camera-support/).\n"
             "if you are sure that the camera model is supported, please consider opening an issue\n"
             "at https://github.com/darktable-org/darktable"),
           dev->image_storage.filename);
+        break;
+      }
       if(dev->image_invalid_cnt > 400)
       {
         dev->image_invalid_cnt = 0;
@@ -738,6 +778,38 @@ gboolean try_enter(dt_view_t *self)
   if(!g_file_test(imgfilename, G_FILE_TEST_IS_REGULAR))
   {
     dt_control_log(_("image `%s' is currently unavailable"), img->filename);
+    dt_image_cache_read_release(darktable.image_cache, img);
+    return TRUE;
+  }
+  else if(img->load_status != DT_IMAGEIO_OK)
+  {
+    const char *reason;
+    switch(img->load_status)
+    {
+    case DT_IMAGEIO_FILE_NOT_FOUND:
+      reason = _("file not found");
+      break;
+    case DT_IMAGEIO_LOAD_FAILED:
+    default:
+      reason = _("unspecified failure");
+      break;
+    case DT_IMAGEIO_UNSUPPORTED_FORMAT:
+      reason = _("unsupported file format");
+      break;
+    case DT_IMAGEIO_UNSUPPORTED_FEATURE:
+      reason = _("unsupported feature in file");
+      break;
+    case DT_IMAGEIO_FILE_CORRUPTED:
+      reason = _("file appears corrupt");
+      break;
+    case DT_IMAGEIO_IOERROR:
+      reason = _("I/O error");
+      break;
+    case DT_IMAGEIO_CACHE_FULL:
+      reason = _("cache full");
+      break;
+    }
+    dt_control_log(_("image `%s' could not be loaded\n%s"), img->filename, reason);
     dt_image_cache_read_release(darktable.image_cache, img);
     return TRUE;
   }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -555,12 +555,19 @@ void expose(
           dev->image_storage.filename);
         break;
       }
-      if(dev->image_invalid_cnt > 400)
+      // if we already saw an error, retry a FEW more times with a bit of delay in between
+      // it would be better if we could just put the delay after the first occurrence, but that
+      // resulted in the error message not showing
+      if(dev->image_invalid_cnt > 1)
       {
-        dev->image_invalid_cnt = 0;
-        dt_view_manager_switch(darktable.view_manager, "lighttable");
-        g_free(load_txt);
-        return;
+        g_usleep(1000000); // one second
+        if(dev->image_invalid_cnt > 8)
+        {
+          dev->image_invalid_cnt = 0;
+          dt_view_manager_switch(darktable.view_manager, "lighttable");
+          g_free(load_txt);
+          return;
+        }
       }
     }
     else

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -839,11 +839,11 @@ dt_view_surface_value_t dt_view_image_get_surface(const dt_imgid_t imgid,
     cairo_scale(cr, scale, scale);
 
     cairo_set_source_surface(cr, tmp_surface, 0, 0);
-    // set filter no nearest: in skull mode, we want to see big
+    // set filter no nearest: in skull/error mode, we want to see big
     // pixels.  in 1 iir mode for the right mip, we want to see
     // exactly what the pipe gave us, 1:1 pixel for pixel.  in
     // between, filtering just makes stuff go unsharp.
-    if((buf_wd <= 8 && buf_ht <= 8)
+    if((buf_wd <= 16 && buf_ht <= 16)
        || fabsf(scale - 1.0f) < 0.01f)
       cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_NEAREST);
     else if(mip != buf.size)
@@ -877,7 +877,7 @@ dt_view_surface_value_t dt_view_image_get_surface(const dt_imgid_t imgid,
   }
 
   // we consider skull as ok as the image hasn't to be reload
-  if(buf_wd <= 8 && buf_ht <= 8)
+  if(buf_wd <= 16 && buf_ht <= 16)
     ret = DT_VIEW_SURFACE_OK;
   else if(mip != buf.size)
     ret = DT_VIEW_SURFACE_SMALLER;

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -843,7 +843,7 @@ dt_view_surface_value_t dt_view_image_get_surface(const dt_imgid_t imgid,
     // pixels.  in 1 iir mode for the right mip, we want to see
     // exactly what the pipe gave us, 1:1 pixel for pixel.  in
     // between, filtering just makes stuff go unsharp.
-    if((buf_wd <= 16 && buf_ht <= 16)
+    if((buf_wd <= 30 && buf_ht <= 30)
        || fabsf(scale - 1.0f) < 0.01f)
       cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_NEAREST);
     else if(mip != buf.size)
@@ -876,8 +876,8 @@ dt_view_surface_value_t dt_view_image_get_surface(const dt_imgid_t imgid,
     cairo_destroy(cr);
   }
 
-  // we consider skull as ok as the image hasn't to be reload
-  if(buf_wd <= 16 && buf_ht <= 16)
+  // we consider skull/error as ok as the image hasn't to be reload
+  if(buf_wd <= 30 && buf_ht <= 30)
     ret = DT_VIEW_SURFACE_OK;
   else if(mip != buf.size)
     ret = DT_VIEW_SURFACE_SMALLER;


### PR DESCRIPTION
Add more internal failure codes and make error messages to the user more specific based on those additional codes.  Also suppress the "failed to read whitebalance" error when an image could not be fully loaded (e.g. due to unsupported camera model).

There are now three different icons for images which can't be edited by the user - the skull for missing/unreadable image files, a warning triangle for corrupted files or when an I/O error occurred, and a question mark for unsupported files (camera model, compression mode, etc.).  As you can tell from the icons, I'm not an artist, so improved renditions are not just welcome, they are requested.

Right now, the question mark will never show for two reasons - rawspeed uses the exact same exception type for both unsupported and corrupt files, and imageio_open() blindly tries every possible loader until one succeeds, so a later loader will replace the error code from the loader which could actually handle the file type with its own error.

A PR to address the second of these is coming.
