### PR TITLE
Remove unused introspection comment on the variable

### DIFF
--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -116,7 +116,7 @@ typedef struct dt_iop_retouch_params_t
   dt_iop_retouch_fill_modes_t fill_mode; // $DEFAULT: DT_IOP_RETOUCH_FILL_ERASE $DESCRIPTION: "fill mode" mode for fill algorithm, erase or fill with color
   float fill_color[3];   // $DEFAULT: 0.0 color for fill algorithm
   float fill_brightness; // $MIN: -1.0 $MAX: 1.0 $DESCRIPTION: "brightness" value to be added to the color
-  int max_heal_iter;     // $DEFAULT: 2000 $DESCRIPTION: "max_iter" number of iterations for heal algorithm
+  int max_heal_iter;     // number of iterations for heal algorithm
 } dt_iop_retouch_params_t;
 
 typedef struct dt_iop_retouch_gui_data_t
@@ -260,7 +260,7 @@ int legacy_params(dt_iop_module_t *self,
     dt_iop_retouch_fill_modes_t fill_mode; // $DEFAULT: DT_IOP_RETOUCH_FILL_ERASE $DESCRIPTION: "fill mode" mode for fill algorithm, erase or fill with color
     float fill_color[3];   // $DEFAULT: 0.0 color for fill algorithm
     float fill_brightness; // $MIN: -1.0 $MAX: 1.0 $DESCRIPTION: "brightness" value to be added to the color
-    int max_heal_iter;     // $DEFAULT: 2000 $DESCRIPTION: "max_iter" number of iterations for heal algorithm
+    int max_heal_iter;     // number of iterations for heal algorithm
   } dt_iop_retouch_params_v3_t;
 
   if(old_version == 1)


### PR DESCRIPTION
This PR removes the unused introspection comment on the variable, because it is used as a regular variable, and not in functions that work with the introspection system (`*_from_params`). Functionally, it will not bring noticeable benefit (at most, throwing out an unnecessary string from the POT file). It is more about improving the quality, correctness and readability of the source code.