### PR TITLE
Fix report of darktable command line

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -894,7 +894,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   GSList *config_override = NULL;
 
   // keep a copy of argv array for possibly reporting later
-  gchar **myoptions = argc > 1 ? g_strdupv(argv) : NULL;
+  gchar **myoptions = init_gui && argc > 1 ? g_strdupv(argv) : NULL;
 
   for(int k = 1; k < argc; k++)
   {


### PR DESCRIPTION
Due to handling of argc/argv in callers of dt_init() we can only use g_strdupv() if called from main darktable; check this via init_gui for safety.

Fixes #17365