### PR TITLE
Some OpenCL simplifications

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -963,15 +963,13 @@ box_blur_5x5(read_only image2d_t in,
   write_imagef(out, (int2)(x, y), acc);
 }
 
-
-kernel void
-interpolate_bilinear(read_only image2d_t in,
-                     const int width_in,
-                     const int height_in,
-                     write_only image2d_t out,
-                     const int width_out,
-                     const int height_out,
-                     const int ch) // works with 1-4 channels
+// works correctly with 1-4 channel float images 
+kernel void interpolate_bilinear(read_only image2d_t in,
+                                const int width_in,
+                                const int height_in,
+                                write_only image2d_t out,
+                                const int width_out,
+                                const int height_out)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -70,7 +70,7 @@ G_BEGIN_DECLS
 // version for current darktable cl kernels
 // this is reflected in the kernel directory and allows to
 // enforce a new kernel compilation cycle
-#define DT_OPENCL_KERNELS 4
+#define DT_OPENCL_KERNELS 5
 
 typedef enum dt_opencl_memory_t
 {

--- a/src/iop/censorize.c
+++ b/src/iop/censorize.c
@@ -348,7 +348,7 @@ int process_cl(struct dt_iop_module_t *self,
   }
 
   err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-  dev_tmp = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
+  dev_tmp = dt_opencl_duplicate_image(devid, dev_out);
   if(dev_tmp == NULL) goto error;
 
   dev_cm = dt_opencl_copy_host_to_device(devid, d->ctable, 256, 256, sizeof(float));
@@ -362,11 +362,6 @@ int process_cl(struct dt_iop_module_t *self,
 
   dev_lcoeffs = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3, d->lunbounded_coeffs);
   if(dev_lcoeffs == NULL) goto error;
-
-  size_t origin[] = { 0, 0, 0 };
-  size_t region[] = { width, height, 1 };
-  err = dt_opencl_enqueue_copy_image(devid, dev_out, dev_tmp, origin, origin, region);
-  if(err != CL_SUCCESS) goto error;
 
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_lowpass_mix, width, height,
     CLARG(dev_tmp), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(saturation), CLARG(dev_cm),

--- a/src/iop/colorequal.c
+++ b/src/iop/colorequal.c
@@ -1269,9 +1269,8 @@ static int _prefilter_chromaticity_cl(const int devid,
     ds_UV = dt_opencl_alloc_device(devid, ds_width, ds_height, 2 * sizeof(float));
     if(ds_UV == NULL) return err;
 
-    const int ch = 2;
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_interpolate_bilinear, ds_width, ds_height,
-          CLARG(UV), CLARG(width), CLARG(height), CLARG(ds_UV), CLARG(ds_width), CLARG(ds_height), CLARG(ch));
+          CLARG(UV), CLARG(width), CLARG(height), CLARG(ds_UV), CLARG(ds_width), CLARG(ds_height));
     if(err != CL_SUCCESS) goto error;
   }
 
@@ -1330,14 +1329,12 @@ static int _prefilter_chromaticity_cl(const int devid,
     b_full = dt_opencl_alloc_device(devid, width, height, 2 * sizeof(float));
     if(a_full == NULL || b_full == NULL) goto error;
 
-    int ch = 4;
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_interpolate_bilinear, width, height,
-          CLARG(a), CLARG(ds_width), CLARG(ds_height), CLARG(a_full), CLARG(width), CLARG(height), CLARG(ch));
+          CLARG(a), CLARG(ds_width), CLARG(ds_height), CLARG(a_full), CLARG(width), CLARG(height));
     if(err != CL_SUCCESS) goto error;
 
-    ch = 2;
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_interpolate_bilinear, width, height,
-          CLARG(b), CLARG(ds_width), CLARG(ds_height), CLARG(b_full), CLARG(width), CLARG(height), CLARG(ch));
+          CLARG(b), CLARG(ds_width), CLARG(ds_height), CLARG(b_full), CLARG(width), CLARG(height));
     if(err != CL_SUCCESS) goto error;
 
     dt_opencl_release_mem_object(a);
@@ -1412,18 +1409,16 @@ static int _guide_with_chromaticity_cl(const int devid,
     ds_b_corrections = dt_opencl_alloc_device(devid, ds_width, ds_height, sizeof(float));
     if(ds_UV == NULL || ds_corrections == NULL || ds_b_corrections == NULL) goto error;
 
-    int ch = 2;
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_interpolate_bilinear, ds_width, ds_height,
-          CLARG(UV), CLARG(width), CLARG(height), CLARG(ds_UV), CLARG(ds_width), CLARG(ds_height), CLARG(ch));
+          CLARG(UV), CLARG(width), CLARG(height), CLARG(ds_UV), CLARG(ds_width), CLARG(ds_height));
     if(err != CL_SUCCESS) goto error;
 
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_interpolate_bilinear, ds_width, ds_height,
-          CLARG(corrections), CLARG(width), CLARG(height), CLARG(ds_corrections), CLARG(ds_width), CLARG(ds_height), CLARG(ch));
+          CLARG(corrections), CLARG(width), CLARG(height), CLARG(ds_corrections), CLARG(ds_width), CLARG(ds_height));
     if(err != CL_SUCCESS) goto error;
 
-    ch = 1;
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_interpolate_bilinear, ds_width, ds_height,
-          CLARG(b_corrections), CLARG(width), CLARG(height), CLARG(ds_b_corrections), CLARG(ds_width), CLARG(ds_height), CLARG(ch));
+          CLARG(b_corrections), CLARG(width), CLARG(height), CLARG(ds_b_corrections), CLARG(ds_width), CLARG(ds_height));
     if(err != CL_SUCCESS) goto error;
   }
 
@@ -1506,14 +1501,12 @@ static int _guide_with_chromaticity_cl(const int devid,
     b_full = dt_opencl_alloc_device(devid, width, height, 2 * sizeof(float));
     if(a_full == NULL || b_full == NULL) goto error;
 
-    int ch = 4;
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_interpolate_bilinear, width, height,
-          CLARG(a), CLARG(ds_width), CLARG(ds_height), CLARG(a_full), CLARG(width), CLARG(height), CLARG(ch));
+          CLARG(a), CLARG(ds_width), CLARG(ds_height), CLARG(a_full), CLARG(width), CLARG(height));
     if(err != CL_SUCCESS) goto error;
 
-    ch = 2;
     err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_interpolate_bilinear, width, height,
-          CLARG(b), CLARG(ds_width), CLARG(ds_height), CLARG(b_full), CLARG(width), CLARG(height), CLARG(ch));
+          CLARG(b), CLARG(ds_width), CLARG(ds_height), CLARG(b_full), CLARG(width), CLARG(height));
     if(err != CL_SUCCESS) goto error;
   }
 

--- a/src/iop/hlreconstruct/laplacian.c
+++ b/src/iop/hlreconstruct/laplacian.c
@@ -845,17 +845,14 @@ static cl_int process_laplacian_bayer_cl(struct dt_iop_module_t *self,
   if(err != CL_SUCCESS) goto error;
 
   // Downsample
-  const int ch = 4;
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_interpolate_bilinear, ds_width, ds_height,
     CLARG(clipping_mask), CLARG(width), CLARG(height),
-    CLARG(ds_clipping_mask), CLARG(ds_width), CLARG(ds_height),
-    CLARG(ch));
+    CLARG(ds_clipping_mask), CLARG(ds_width), CLARG(ds_height));
   if(err != CL_SUCCESS) goto error;
 
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_interpolate_bilinear, ds_width, ds_height,
     CLARG(interpolated), CLARG(width), CLARG(height),
-    CLARG(ds_interpolated), CLARG(ds_width), CLARG(ds_height),
-    CLARG(ch));
+    CLARG(ds_interpolated), CLARG(ds_width), CLARG(ds_height));
 
   if(err != CL_SUCCESS) goto error;
 
@@ -874,8 +871,7 @@ static cl_int process_laplacian_bayer_cl(struct dt_iop_module_t *self,
   // Upsample
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_interpolate_bilinear, width, height,
     CLARG(ds_interpolated), CLARG(ds_width), CLARG(ds_height),
-    CLARG(interpolated), CLARG(width), CLARG(height),
-    CLARG(ch));
+    CLARG(interpolated), CLARG(width), CLARG(height));
   if(err != CL_SUCCESS) goto error;
 
   // Remosaic

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -299,7 +299,7 @@ int process_cl(struct dt_iop_module_t *self,
   }
 
   err = DT_OPENCL_SYSMEM_ALLOCATION;
-  dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
+  dev_tmp = dt_opencl_duplicate_image(devid, dev_out);
   if(dev_tmp == NULL) goto error;
 
   dev_cm = dt_opencl_copy_host_to_device(devid, d->ctable, 256, 256, sizeof(float));
@@ -313,11 +313,6 @@ int process_cl(struct dt_iop_module_t *self,
 
   dev_lcoeffs = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3, d->lunbounded_coeffs);
   if(dev_lcoeffs == NULL) goto error;
-
-  size_t origin[] = { 0, 0, 0 };
-  size_t region[] = { width, height, 1 };
-  err = dt_opencl_enqueue_copy_image(devid, dev_out, dev_tmp, origin, origin, region);
-  if(err != CL_SUCCESS) goto error;
 
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_lowpass_mix, width, height,
     CLARG(dev_tmp), CLARG(dev_out), CLARG(width), CLARG(height), CLARG(saturation), CLARG(dev_cm),

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -571,13 +571,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   }
 
   err = DT_OPENCL_SYSMEM_ALLOCATION;
-  dev_tmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
+  dev_tmp = dt_opencl_duplicate_image(devid, dev_out);
   if(dev_tmp == NULL) goto error;
-
-  size_t origin[] = { 0, 0, 0 };
-  size_t region[] = { width, height, 1 };
-  err = dt_opencl_enqueue_copy_image(devid, dev_out, dev_tmp, origin, origin, region);
-  if(err != CL_SUCCESS) goto error;
 
   // final mixing step
   err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_shadows_highlights_mix, width, height,


### PR DESCRIPTION
1. kernel interpolate_bilinear does not require ch as a parameeter as it works fine with 1-4 channels. callers can be simplified.

2. make some more use of dt_opencl_duplicate_image()