### PR TITLE
Support for darkroom visibility of utility modules toggle

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1966,6 +1966,13 @@
     <longdescription/>
   </dtconfig>
   <dtconfig>
+    <name>plugins/lighttable/metadata/hideindarkroom</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>controls visibility of metadata editor in darkroom mode</shortdescription>
+    <longdescription>metadata editor can be presented in darkroom mode if this toggle allow that</longdescription>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/lighttable/metadata/creator_text_height</name>
     <type>int</type>
     <default>1</default>

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -580,6 +580,15 @@ static void dt_lib_presets_popup_menu_show(dt_lib_module_info_t *minfo)
     }
     minfo->module->set_preferences(GTK_MENU_SHELL(menu), minfo->module);
   }
+
+  if(minfo->module->module_visibility_in_darkroom)
+  {
+    if(cnt>0)
+    {
+      gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
+    }
+    minfo->module->module_visibility_in_darkroom(GTK_MENU_SHELL(menu), minfo->module);
+  }
 }
 
 gint dt_lib_sort_plugins(gconstpointer a, gconstpointer b)

--- a/src/libs/lib_api.h
+++ b/src/libs/lib_api.h
@@ -97,6 +97,7 @@ OPTIONAL(int, set_params, struct dt_lib_module_t *self, const void *params, int 
 OPTIONAL(void, init_presets, struct dt_lib_module_t *self);
 OPTIONAL(void, manage_presets, struct dt_lib_module_t *self);
 OPTIONAL(void, set_preferences, void *menu, struct dt_lib_module_t *self);
+OPTIONAL(void, module_visibility_in_darkroom, void *menu, struct dt_lib_module_t *self);
 /** check if the module can autoapply presets. Default is FALSE */
 DEFAULT(gboolean, preset_autoapply, struct dt_lib_module_t *self);
 

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -68,12 +68,18 @@ const char *description(dt_lib_module_t *self)
 
 dt_view_type_flags_t views(dt_lib_module_t *self)
 {
-  return DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING;
+  if(dt_conf_get_bool("plugins/lighttable/metadata/hideindarkroom"))
+    return DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING;
+  else
+    return DT_VIEW_LIGHTTABLE | DT_VIEW_DARKROOM | DT_VIEW_TETHERING;
 }
 
 uint32_t container(dt_lib_module_t *self)
 {
-  return DT_UI_CONTAINER_PANEL_RIGHT_CENTER;
+  if(dt_view_get_current() == DT_VIEW_DARKROOM)
+    return DT_UI_CONTAINER_PANEL_LEFT_CENTER;
+  else
+    return DT_UI_CONTAINER_PANEL_RIGHT_CENTER;
 }
 
 static gboolean _is_leave_unchanged(GtkTextView *textview)

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -631,6 +631,25 @@ void set_preferences(void *menu, dt_lib_module_t *self)
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
 }
 
+static void _menuitem_hideindarkroom(GtkMenuItem *menuitem,
+                                     dt_lib_module_t *self)
+{
+  // Activation of check menu item should toggle active state
+  gboolean hide_in_darkroom = gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(menuitem));
+  dt_print(DT_DEBUG_ALWAYS, "entered 'activate' callback for 'hide in darkroom' menu item: active state = %d\n", hide_in_darkroom);
+  dt_conf_set_bool("plugins/lighttable/metadata/hideindarkroom", hide_in_darkroom);
+  gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(menuitem), hide_in_darkroom);
+}
+
+void module_visibility_in_darkroom(void *menu, dt_lib_module_t *self)
+{
+  GtkWidget *mi = gtk_check_menu_item_new_with_label(_("hide in darkroom"));
+  gboolean hide_in_darkroom = dt_conf_get_bool("plugins/lighttable/metadata/hideindarkroom");
+  gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mi), hide_in_darkroom);
+  g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_menuitem_hideindarkroom), self);
+  gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
+}
+
 static void _menu_line_activated(GtkMenuItem *menuitem, GtkTextView *textview)
 {
   GtkTextBuffer *buffer = gtk_text_view_get_buffer(textview);

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -639,6 +639,13 @@ static void _menuitem_hideindarkroom(GtkMenuItem *menuitem,
   dt_print(DT_DEBUG_ALWAYS, "entered 'activate' callback for 'hide in darkroom' menu item: active state = %d\n", hide_in_darkroom);
   dt_conf_set_bool("plugins/lighttable/metadata/hideindarkroom", hide_in_darkroom);
   gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(menuitem), hide_in_darkroom);
+  if(dt_view_get_current() == DT_VIEW_DARKROOM)
+  {
+    if(hide_in_darkroom)
+      dt_control_log("this module will NOT be shown on subsequent entering the darkroom mode");
+    else
+      dt_control_log("this module WILL be shown on subsequent entering the darkroom mode");
+  }
 }
 
 void module_visibility_in_darkroom(void *menu, dt_lib_module_t *self)

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -631,20 +631,23 @@ void set_preferences(void *menu, dt_lib_module_t *self)
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
 }
 
-static void _menuitem_hideindarkroom(GtkMenuItem *menuitem,
-                                     dt_lib_module_t *self)
+static void _menuitem_hideindarkroom_callback(GtkMenuItem *menuitem,
+                                              dt_lib_module_t *self)
 {
-  // Activation of check menu item should toggle active state
+  // Activation of check menu item toggles active state, we have to
+  // save and reflect it in GUI new state.
   gboolean hide_in_darkroom = gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(menuitem));
-  dt_print(DT_DEBUG_ALWAYS, "entered 'activate' callback for 'hide in darkroom' menu item: active state = %d\n", hide_in_darkroom);
   dt_conf_set_bool("plugins/lighttable/metadata/hideindarkroom", hide_in_darkroom);
   gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(menuitem), hide_in_darkroom);
+
+  // In darkroom view we will not remove the module immediately, so we notify
+  // the user about the action using a notification pill.
   if(dt_view_get_current() == DT_VIEW_DARKROOM)
   {
     if(hide_in_darkroom)
-      dt_control_log("this module will NOT be shown on subsequent entering the darkroom mode");
+      dt_control_log(_("this module will NOT be shown on subsequent entering the darkroom mode"));
     else
-      dt_control_log("this module WILL be shown on subsequent entering the darkroom mode");
+      dt_control_log(_("this module WILL be shown on subsequent entering the darkroom mode"));
   }
 }
 
@@ -653,7 +656,7 @@ void module_visibility_in_darkroom(void *menu, dt_lib_module_t *self)
   GtkWidget *mi = gtk_check_menu_item_new_with_label(_("hide in darkroom"));
   gboolean hide_in_darkroom = dt_conf_get_bool("plugins/lighttable/metadata/hideindarkroom");
   gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(mi), hide_in_darkroom);
-  g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_menuitem_hideindarkroom), self);
+  g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(_menuitem_hideindarkroom_callback), self);
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
 }
 


### PR DESCRIPTION
This PR supersedes #17263.

Yet to be discussed the toggle label ("hide in darkroom", "show in darkroom", or maybe one or the other depending on the default) and which of the utility modules we want to show by default.

