### PR TITLE
enable error handling for gpx file parser

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -112,6 +112,7 @@ src/common/eigf.h
 src/common/exif.cc
 src/common/fast_guided_filter.h
 src/common/film.c
+src/common/gpx.c
 src/common/history.c
 src/common/image.c
 src/common/image.h

--- a/src/common/gpx.c
+++ b/src/common/gpx.c
@@ -256,7 +256,7 @@ static void _gpx_parse_error(GError **error)
     g_set_error(error,
                 G_MARKUP_ERROR,
                 G_MARKUP_ERROR_PARSE,
-                _("failed to parse gpx file. see log for more info."));
+               _("failed to parse GPX file"));
 }
 
 /*

--- a/src/common/gpx.c
+++ b/src/common/gpx.c
@@ -460,11 +460,15 @@ void _gpx_parser_text(GMarkupParseContext *context, const gchar *text, gsize tex
 
 GList *dt_gpx_get_trkseg(struct dt_gpx_t *gpx)
 {
-  return gpx->trksegs;
+  return (gpx != NULL)? gpx->trksegs
+                      : NULL;
 }
 
 GList *dt_gpx_get_trkpts(struct dt_gpx_t *gpx, const guint segid)
 {
+  if(gpx == NULL)
+    return NULL;
+    
   GList *pts = NULL;
   GList *ts = g_list_nth(gpx->trksegs, segid);
   if(!ts) return pts;

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -875,7 +875,11 @@ static void _preview_gpx_file(GtkWidget *widget, dt_lib_module_t *self)
   _set_up_label(nb, GTK_ALIGN_CENTER, grid, 4, line, PANGO_ELLIPSIZE_NONE);
   g_free(nb);
 
-  dt_gpx_destroy(gpx);
+  if(gpx)
+  {
+    dt_gpx_destroy(gpx);
+    gpx = NULL;
+  }
 
   gtk_container_add(GTK_CONTAINER(w), grid);
 


### PR DESCRIPTION
If any error occurs during gpx parsing, dt prints something to the log and then crashes because no error handling is implemented.
