### PR TITLE
[export] use hierarchical menus for style selection

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -129,6 +129,7 @@ FILE(GLOB SOURCE_FILES
   "dtgtk/range.c"
   "dtgtk/resetlabel.c"
   "dtgtk/sidepanel.c"
+  "dtgtk/stylemenu.c"
   "dtgtk/thumbnail.c"
   "dtgtk/thumbnail_btn.c"
   "dtgtk/thumbtable.c"

--- a/src/dtgtk/stylemenu.c
+++ b/src/dtgtk/stylemenu.c
@@ -1,0 +1,149 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2024 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "common/act_on.h"
+#include "common/styles.h"
+#include "common/utility.h"
+#include "dtgtk/stylemenu.h"
+#include "gui/accelerators.h"
+#include "gui/styles.h"
+
+static gboolean _styles_tooltip_callback(GtkWidget* self,
+                                         const gint x,
+                                         const gint y,
+                                         const gboolean keyboard_mode,
+                                         GtkTooltip* tooltip,
+                                         gpointer user_data)
+{
+  gchar *name = (char *)user_data;
+  dt_develop_t *dev = darktable.develop;
+  // get the center-view image in darkroom view, or the active act-on image otherwise
+  const dt_imgid_t imgid = (dev && dt_is_valid_imgid(dev->image_storage.id))
+    ? dev->image_storage.id : dt_act_on_get_main_image();
+
+  if(!dt_is_valid_imgid(imgid))
+    return FALSE;
+
+  // write history to ensure the preview will be done with latest
+  // development history.
+  if(dev)
+    dt_dev_write_history(dev);
+
+  GtkWidget *ht = dt_gui_style_content_dialog(name, imgid);
+
+  g_object_set_data_full(G_OBJECT(self), "dt-preset-name", g_strdup(name), g_free);
+
+  return dt_shortcut_tooltip_callback(self, x, y, keyboard_mode, tooltip, ht);
+}
+
+static void _build_style_submenus(GtkMenuShell *menu,
+                                  const gchar *style_name,
+                                  gchar **splits,
+                                  const int index,
+                                  dtgtk_menuitem_activate_callback_fn *activate_callback,
+                                  dtgtk_menuitem_button_callback_fn *button_callback)
+{
+  // localize the name of the current level in the hierarchy
+  const char *split0 = dt_util_localize_string(splits[index]);
+  GtkMenuItem *mi = GTK_MENU_ITEM(gtk_menu_item_new_with_label(split0[0] ? split0 : _("none")));
+
+  // check if we already have an item or sub-menu with this name
+  GtkMenu *sm = NULL;
+  GList *children = gtk_container_get_children(GTK_CONTAINER(menu));
+  for(const GList *child = children; child; child = g_list_next(child))
+  {
+    GtkMenuItem *smi = (GtkMenuItem *)child->data;
+    if(g_strcmp0(split0,gtk_menu_item_get_label(smi)) == 0)
+    {
+      sm = (GtkMenu *)gtk_menu_item_get_submenu(smi);
+      break;
+    }
+  }
+  g_list_free(children);
+
+  if(!splits[index+1])
+  {
+    // we've reached the bottom level, so build a final menu item with preview popup
+    // need a tooltip for the signal below to be raised
+    gtk_menu_shell_append(menu, GTK_WIDGET(mi));
+    if(style_name && style_name[0]) // don't add tooltip for "none" style
+    {
+      gtk_widget_set_has_tooltip(GTK_WIDGET(mi), TRUE);
+      g_signal_connect_data(mi, "query-tooltip",
+                            G_CALLBACK(_styles_tooltip_callback),
+                            g_strdup(style_name), (GClosureNotify)g_free, 0);
+    }
+    else
+      gtk_widget_set_has_tooltip(GTK_WIDGET(mi), FALSE);
+  }
+  else
+  {
+    if (!sm)
+    {
+      // we need a sub-menu, but it doesn't exist yet
+      sm = (GtkMenu*)gtk_menu_new();
+      gtk_menu_item_set_submenu(mi, GTK_WIDGET(sm));
+      gtk_menu_shell_append(menu, GTK_WIDGET(mi));
+    }
+    _build_style_submenus(GTK_MENU_SHELL(sm), style_name, splits, index+1,
+                          activate_callback, button_callback);
+  }
+
+  if(activate_callback)
+    g_signal_connect_data(G_OBJECT(mi), "activate",
+                          G_CALLBACK(activate_callback),
+                          g_strdup(style_name), (GClosureNotify)g_free, 0);
+
+  if(button_callback)
+    g_signal_connect_data(G_OBJECT(mi), "button-press-event",
+                          G_CALLBACK(button_callback),
+                          g_strdup(style_name), (GClosureNotify)g_free, 0);
+
+  gtk_widget_show(GTK_WIDGET(mi));
+}
+
+
+GtkMenuShell *dtgtk_build_style_menu_hierarchy(gboolean allow_none,
+                                               dtgtk_menuitem_activate_callback_fn *activate_callback,
+                                               dtgtk_menuitem_button_callback_fn *button_callback)
+{
+  GtkMenuShell *menu = NULL;
+
+  GList *styles = dt_styles_get_list("");
+  if(styles || allow_none)
+  {
+    menu = GTK_MENU_SHELL(gtk_menu_new());
+    if(allow_none)
+    {
+      const char *none = "";
+      gchar *split[] = { (gchar*)none, 0 };
+      _build_style_submenus(menu, none, split, 0, activate_callback, button_callback);
+    }
+    for(const GList *st_iter = styles; st_iter; st_iter = g_list_next(st_iter))
+    {
+      dt_style_t *style = (dt_style_t *)st_iter->data;
+
+      gchar **split = g_strsplit(style->name, "|", 0);
+      _build_style_submenus(menu, style->name, split, 0, activate_callback, button_callback);
+      g_strfreev(split);
+    }
+    g_list_free_full(styles, dt_style_free);
+  }
+  return menu;
+}
+

--- a/src/dtgtk/stylemenu.h
+++ b/src/dtgtk/stylemenu.h
@@ -20,12 +20,21 @@
 
 G_BEGIN_DECLS
 
-typedef void dtgtk_menuitem_activate_callback_fn(GtkMenuItem *menuitem, gchar *name);
-typedef gboolean dtgtk_menuitem_button_callback_fn(GtkMenuItem *, GdkEventButton *event, gchar *name);
+typedef struct {
+  gchar *name;
+  gpointer user_data;
+} dt_stylemenu_data_t;
+
+typedef void dtgtk_menuitem_activate_callback_fn(GtkMenuItem *menuitem,
+                                                 const dt_stylemenu_data_t *menu_data);
+typedef gboolean dtgtk_menuitem_button_callback_fn(GtkMenuItem *,
+                                                   GdkEventButton *event,
+                                                   const dt_stylemenu_data_t *menu_data);
 
 GtkMenuShell *dtgtk_build_style_menu_hierarchy(gboolean allow_none,
                                                dtgtk_menuitem_activate_callback_fn *activate_callback,
-                                               dtgtk_menuitem_button_callback_fn *button_callback);
+                                               dtgtk_menuitem_button_callback_fn *button_callback,
+                                               gpointer user_data);
 
 G_END_DECLS
 

--- a/src/dtgtk/stylemenu.h
+++ b/src/dtgtk/stylemenu.h
@@ -1,0 +1,36 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2024 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <gtk/gtk.h>
+
+G_BEGIN_DECLS
+
+typedef void dtgtk_menuitem_activate_callback_fn(GtkMenuItem *menuitem, gchar *name);
+typedef gboolean dtgtk_menuitem_button_callback_fn(GtkMenuItem *, GdkEventButton *event, gchar *name);
+
+GtkMenuShell *dtgtk_build_style_menu_hierarchy(gboolean allow_none,
+                                               dtgtk_menuitem_activate_callback_fn *activate_callback,
+                                               dtgtk_menuitem_button_callback_fn *button_callback);
+
+G_END_DECLS
+
+// clang-format off
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// clang-format on

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1351,20 +1351,21 @@ static void _darkroom_ui_favorite_presets_popupmenu(GtkWidget *w, gpointer user_
     dt_control_log(_("no user-defined presets for favorite modules were found"));
 }
 
-static void _darkroom_ui_apply_style_activate_callback(GtkMenuItem *menuitem, gchar *name)
+static void _darkroom_ui_apply_style_activate_callback(GtkMenuItem *menuitem,
+                                                       const dt_stylemenu_data_t *menu_data)
 {
   if(gtk_get_current_event()->type == GDK_KEY_PRESS)
-    dt_styles_apply_to_dev(name, darktable.develop->image_storage.id);
+    dt_styles_apply_to_dev(menu_data->name, darktable.develop->image_storage.id);
 }
 
 static gboolean _darkroom_ui_apply_style_button_callback(GtkMenuItem *menuitem,
                                                          GdkEventButton *event,
-                                                         gchar *name)
+                                                         const dt_stylemenu_data_t *menu_data)
 {
   if(event->button == 1)
-    dt_styles_apply_to_dev(name, darktable.develop->image_storage.id);
+    dt_styles_apply_to_dev(menu_data->name, darktable.develop->image_storage.id);
   else
-    dt_shortcut_copy_lua(NULL, name);
+    dt_shortcut_copy_lua(NULL, menu_data->name);
 
   return FALSE;
 }
@@ -1374,7 +1375,8 @@ static void _darkroom_ui_apply_style_popupmenu(GtkWidget *w, gpointer user_data)
   /* if we got any styles, lets popup menu for selection */
   GtkMenuShell *menu = dtgtk_build_style_menu_hierarchy(FALSE,
                                                         _darkroom_ui_apply_style_activate_callback,
-                                                        _darkroom_ui_apply_style_button_callback);
+                                                        _darkroom_ui_apply_style_button_callback,
+                                                        user_data);
   if(menu)
   {
     dt_gui_menu_popup(GTK_MENU(menu), w, GDK_GRAVITY_SOUTH_WEST, GDK_GRAVITY_NORTH_WEST);


### PR DESCRIPTION
Followup to #17073, resolves the export-module usability problem noted by Pascal in https://github.com/darktable-org/darktable/pull/17073#issuecomment-2321920819

Replace the export module's styles combobox with a hierarchy of popup menus, as used in the Quick Apply button in darkroom view.  This avoids the hundreds-long listing of style names and as a bonus gives a style preview when in darkroom view or we have at least one image to act on in lighttable view.

Future enhancements:
1. respect the append/replace mode; right now the style preview always uses append
2. when there is no image to act on, still show the modules in the style rather than disabling the tooltip entirely

