### PR TITLE
Fix OpenCL RGB_2_HSL

### DIFF
--- a/data/kernels/colorspace.h
+++ b/data/kernels/colorspace.h
@@ -168,7 +168,8 @@ static inline float4 prophotorgb_to_Lab(float4 rgb)
 
 static inline float4 RGB_2_HSL(const float4 RGB)
 {
-  float H, S, L;
+  float H = 0.0f;
+  float S = 0.0f;
 
   // assumes that each channel is scaled to [0; 1]
   const float R = RGB.x;
@@ -179,14 +180,9 @@ static inline float4 RGB_2_HSL(const float4 RGB)
   const float var_Max = fmax(R, fmax(G, B));
   const float del_Max = var_Max - var_Min;
 
-  L = (var_Max + var_Min) / 2.0f;
+  const float L = (var_Max + var_Min) / 2.0f;
 
-  if (del_Max < 1e-6f)
-  {
-    H = 0.0f;
-    S = 0.0f;
-  }
-  else
+  if(fabs(del_Max) > 1e-6f && fabs(del_Max) > 1e-6)
   {
     if (L < 0.5f) S = del_Max / (var_Max + var_Min);
     else          S = del_Max / (2.0f - var_Max - var_Min);

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -671,7 +671,8 @@ static inline void dt_RGB_2_HSL(const dt_aligned_pixel_t RGB, dt_aligned_pixel_t
   const float delta = max - min;
 
   const float L = (max + min) / 2.0f;
-  float H, S;
+  float H = 0.0f;
+  float S = 0.0f;
 
   if(fabsf(max) > 1e-6f && fabsf(delta) > 1e-6f)
   {
@@ -680,11 +681,6 @@ static inline void dt_RGB_2_HSL(const dt_aligned_pixel_t RGB, dt_aligned_pixel_t
     else
       S = delta / (2.0f - max - min);
     H = _dt_RGB_2_Hue(RGB, max, delta);
-  }
-  else
-  {
-    H = 0.0f;
-    S = 0.0f;
   }
 
   HSL[0] = H;
@@ -1256,7 +1252,7 @@ static inline void dt_YCbCr_to_RGB(const dt_aligned_pixel_t yuv, dt_aligned_pixe
 // Instead of using above theoretical values we use some modified versions
 // that not avoid div-by-zero but div-by-close-to-zero
 // this leads to more stability for extremely bright parts as we avoid single float precision overflows
-#define DT_UCS_L_STAR_RANGE 2.098883786377f 
+#define DT_UCS_L_STAR_RANGE 2.098883786377f
 #define DT_UCS_L_STAR_UPPER_LIMIT 2.09885f
 #define DT_UCS_Y_UPPER_LIMIT 1e8f
 


### PR DESCRIPTION
Make RGB_2_HSL inlines behaving identical for OpenCL and CPU code