### PR TITLE
Fix M_PI related peculiars

### DIFF
--- a/data/kernels/common.h
+++ b/data/kernels/common.h
@@ -29,7 +29,7 @@ constant sampler_t samplerA = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_NONE    
 
 
 #ifndef M_PI_F
-#define M_PI_F           3.14159265358979323846  // should be defined by the OpenCL compiler acc. to standard
+#define M_PI_F           3.14159265358979323846f  // should be defined by the OpenCL compiler acc. to standard
 #endif
 
 #define RED 0

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -775,9 +775,9 @@ static inline void dt_Lab_2_LCH(const dt_aligned_pixel_t Lab, dt_aligned_pixel_t
   float var_H = atan2f(Lab[2], Lab[1]);
 
   if(var_H > 0.0f)
-    var_H = var_H / (2.0f * DT_M_PI_F);
+    var_H = var_H / (2.0f * M_PI_F);
   else
-    var_H = 1.0f - fabsf(var_H) / (2.0f * DT_M_PI_F);
+    var_H = 1.0f - fabsf(var_H) / (2.0f * M_PI_F);
 
   LCH[0] = Lab[0];
   LCH[1] = hypotf(Lab[1], Lab[2]);
@@ -789,8 +789,8 @@ DT_OMP_DECLARE_SIMD()
 static inline void dt_LCH_2_Lab(const dt_aligned_pixel_t LCH, dt_aligned_pixel_t Lab)
 {
   Lab[0] = LCH[0];
-  Lab[1] = cosf(2.0f * DT_M_PI_F * LCH[2]) * LCH[1];
-  Lab[2] = sinf(2.0f * DT_M_PI_F * LCH[2]) * LCH[1];
+  Lab[1] = cosf(2.0f * M_PI_F * LCH[2]) * LCH[1];
+  Lab[2] = sinf(2.0f * M_PI_F * LCH[2]) * LCH[1];
 }
 
 static inline float dt_camera_rgb_luminance(const dt_aligned_pixel_t rgb)
@@ -884,7 +884,7 @@ static inline void dt_XYZ_2_JzAzBz(const dt_aligned_pixel_t XYZ_D65, dt_aligned_
 DT_OMP_DECLARE_SIMD(aligned(JzAzBz, JzCzhz: 16))
 static inline void dt_JzAzBz_2_JzCzhz(const dt_aligned_pixel_t JzAzBz, dt_aligned_pixel_t JzCzhz)
 {
-  float var_H = atan2f(JzAzBz[2], JzAzBz[1]) / (2.0f * DT_M_PI_F);
+  float var_H = atan2f(JzAzBz[2], JzAzBz[1]) / (2.0f * M_PI_F);
   JzCzhz[0] = JzAzBz[0];
   JzCzhz[1] = hypotf(JzAzBz[1], JzAzBz[2]);
   JzCzhz[2] = var_H >= 0.0f ? var_H : 1.0f + var_H;
@@ -894,8 +894,8 @@ DT_OMP_DECLARE_SIMD(aligned(JzCzhz, JzAzBz: 16))
 static inline void dt_JzCzhz_2_JzAzBz(const dt_aligned_pixel_t JzCzhz, dt_aligned_pixel_t JzAzBz)
 {
   JzAzBz[0] = JzCzhz[0];
-  JzAzBz[1] = cosf(2.0f * DT_M_PI_F * JzCzhz[2]) * JzCzhz[1];
-  JzAzBz[2] = sinf(2.0f * DT_M_PI_F * JzCzhz[2]) * JzCzhz[1];
+  JzAzBz[1] = cosf(2.0f * M_PI_F * JzCzhz[2]) * JzCzhz[1];
+  JzAzBz[2] = sinf(2.0f * M_PI_F * JzCzhz[2]) * JzCzhz[1];
 }
 
 DT_OMP_DECLARE_SIMD(aligned(JzAzBz, XYZ_D65: 16))

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -42,12 +42,8 @@
 #define M_PI   3.14159265358979323846
 #endif /* !M_PI */
 #ifndef M_PI_F
-#define M_PI_F  3.14159265358979324f
+#define M_PI_F 3.14159265358979323846f
 #endif /* !M_PI_F */
-
-
-#define DT_M_PI_F (3.14159265358979324f)
-#define DT_M_PI (3.14159265358979324)
 
 #define DT_M_LN2f (0.6931471805599453f)
 

--- a/src/develop/blends/blendif_rgb_hsl.c
+++ b/src/develop/blends/blendif_rgb_hsl.c
@@ -892,16 +892,16 @@ _BLEND_FUNC _blend_HSV_color(const float *const a,
     dt_RGB_2_HSV(b + j, tb);
 
     // convert from polar to cartesian coordinates
-    const float xa = ta[1] * cosf(2.0f * DT_M_PI_F * ta[0]);
-    const float ya = ta[1] * sinf(2.0f * DT_M_PI_F * ta[0]);
-    const float xb = tb[1] * cosf(2.0f * DT_M_PI_F * tb[0]);
-    const float yb = tb[1] * sinf(2.0f * DT_M_PI_F * tb[0]);
+    const float xa = ta[1] * cosf(2.0f * M_PI_F * ta[0]);
+    const float ya = ta[1] * sinf(2.0f * M_PI_F * ta[0]);
+    const float xb = tb[1] * cosf(2.0f * M_PI_F * tb[0]);
+    const float yb = tb[1] * sinf(2.0f * M_PI_F * tb[0]);
 
     // blend color vectors of input and output
     const float xc = xa * (1.0f - local_opacity) + xb * local_opacity;
     const float yc = ya * (1.0f - local_opacity) + yb * local_opacity;
 
-    tb[0] = atan2f(yc, xc) / (2.0f * DT_M_PI_F);
+    tb[0] = atan2f(yc, xc) / (2.0f * M_PI_F);
     if(tb[0] < 0.0f) tb[0] += 1.0f;
     tb[1] = sqrtf(xc * xc + yc * yc);
 

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2381,7 +2381,7 @@ float dt_masks_change_rotation(const gboolean up,
                                const gboolean is_degree)
 {
   const float step = 40.f;
-  const float incr = is_degree ? 360.f / step : 2.0f * DT_M_PI_F / step;
+  const float incr = is_degree ? 360.f / step : 2.0f * M_PI_F / step;
   const float max  = is_degree ? 360.0        : M_PI_F;
   const float v =
     up

--- a/src/iop/colorbalancergb.c
+++ b/src/iop/colorbalancergb.c
@@ -801,7 +801,7 @@ void process(struct dt_iop_module_t *self,
                                 d->saturation_global + scalar_product(opacities, saturation) }; // move in O direction
 
       SO[0] = JC[0] * M_rot_dir[0][0] + JC[1] * M_rot_dir[0][1];
-      SO[1] = SO[0] * MIN(MAX(T * boosts[1], -T), DT_M_PI_F / 2.f - T);
+      SO[1] = SO[0] * MIN(MAX(T * boosts[1], -T), M_PI_F / 2.f - T);
       SO[0] = MAX(SO[0] * boosts[0], 0.f);
 
       // Project back to JCh, that is rotate back of -T angle

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -545,7 +545,7 @@ void process_v3(struct dt_iop_module_t *self,
     float *in = (float *)ivoid + ch * k;
     float *out = (float *)ovoid + ch * k;
     const float a = in[1], b = in[2];
-    const float h = fmodf(atan2f(b, a) + 2.0f * DT_M_PI_F, 2.0f * DT_M_PI_F) / (2.0f * DT_M_PI_F);
+    const float h = fmodf(atan2f(b, a) + 2.0f * M_PI_F, 2.0f * M_PI_F) / (2.0f * M_PI_F);
     const float C = sqrtf(b * b + a * a);
     float select = 0.0f;
     float blend = 0.0f;
@@ -570,8 +570,8 @@ void process_v3(struct dt_iop_module_t *self,
     const float Cm = 2.0f * lookup(d->lut[1], select);
     const float L = in[0] * powf(2.0f, 4.0f * Lm);
     out[0] = L;
-    out[1] = cosf(2.0f * DT_M_PI_F * (h + hm)) * Cm * C;
-    out[2] = sinf(2.0f * DT_M_PI_F * (h + hm)) * Cm * C;
+    out[1] = cosf(2.0f * M_PI_F * (h + hm)) * Cm * C;
+    out[2] = sinf(2.0f * M_PI_F * (h + hm)) * Cm * C;
     out[3] = in[3];
   }
 }
@@ -1526,7 +1526,7 @@ static gboolean _area_draw_callback(GtkWidget *widget,
     const float x = c->mouse_x, y = _curve_to_mouse(c->draw_ys[ch][k],
                                                     c->zoom_factor, c->offset_y);
 
-    cairo_arc(cr, x * width, -height * y, c->mouse_radius * width, 0, 2. * DT_M_PI);
+    cairo_arc(cr, x * width, -height * y, c->mouse_radius * width, 0, 2. * M_PI);
     cairo_stroke(cr);
   }
   else
@@ -2675,8 +2675,8 @@ void gui_init(struct dt_iop_module_t *self)
                        c->colorpicker_set_values, &dt_action_def_toggle);
 
   // the nice graph
-  c->area = GTK_DRAWING_AREA(dt_ui_resize_wrap(NULL, 
-                                               0, 
+  c->area = GTK_DRAWING_AREA(dt_ui_resize_wrap(NULL,
+                                               0,
                                                "plugins/darkroom/colorzones/graphheight"));
 
   gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(c->area), TRUE, TRUE, 0);

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -336,7 +336,7 @@ dt_iop_colorspace_type_t default_colorspace(dt_iop_module_t *self,
 static inline float get_rot(const dt_liquify_warp_type_enum_t warp_type)
 {
   if(warp_type == DT_LIQUIFY_WARP_TYPE_RADIAL_SHRINK)
-    return DT_M_PI_F;
+    return M_PI_F;
   else
     return 0.0f;
 }
@@ -1434,8 +1434,8 @@ static inline float lanczos(const float a, const float x)
   if(fabsf(x) >= a) return 0.0f;
   if(fabsf(x) < FLT_EPSILON) return 1.0f;
 
-  return (a * sinf(DT_M_PI_F * x) * sinf(DT_M_PI_F * x / a))
-    / (DT_M_PI_F * DT_M_PI_F * x * x);
+  return (a * sinf(M_PI_F * x) * sinf(M_PI_F * x / a))
+    / (M_PI_F * M_PI_F * x * x);
 }
 
 // compute bicubic kernel. See:
@@ -1660,7 +1660,7 @@ static void draw_circle(cairo_t *cr,
   const double x = creal(pt), y = cimag(pt);
   cairo_save(cr);
   cairo_new_sub_path(cr);
-  cairo_arc(cr, x, y, diameter / 2.0, 0, 2 * DT_M_PI);
+  cairo_arc(cr, x, y, diameter / 2.0, 0, 2 * M_PI);
   cairo_restore(cr);
 }
 
@@ -1949,10 +1949,10 @@ static void _draw_paths(dt_iop_module_t *module,
           switch(data->header.node_type)
           {
              case DT_LIQUIFY_NODE_TYPE_CUSP:
-               draw_triangle(cr, point - w / 2.0 * I, -DT_M_PI / 2.0, w);
+               draw_triangle(cr, point - w / 2.0 * I, -M_PI / 2.0, w);
                break;
              case DT_LIQUIFY_NODE_TYPE_SMOOTH:
-               draw_rectangle(cr, point, DT_M_PI / 4.0, w);
+               draw_rectangle(cr, point, M_PI / 4.0, w);
                break;
              case DT_LIQUIFY_NODE_TYPE_SYMMETRICAL:
                draw_rectangle(cr, point, 0, w);
@@ -3713,7 +3713,7 @@ static void _liquify_cairo_paint_point_tool(cairo_t *cr,
 {
   PREAMBLE;
   cairo_new_sub_path(cr);
-  cairo_arc(cr, 0.5, 0.5, 0.2, 0.0, 2 * DT_M_PI);
+  cairo_arc(cr, 0.5, 0.5, 0.2, 0.0, 2 * M_PI);
   cairo_fill(cr);
   POSTAMBLE;
 }

--- a/src/iop/primaries.c
+++ b/src/iop/primaries.c
@@ -41,7 +41,7 @@
 
 DT_MODULE_INTROSPECTION(1, dt_iop_primaries_params_t)
 
-static const float RAD_TO_DEG = 180.f / DT_M_PI_F;
+static const float RAD_TO_DEG = 180.f / M_PI_F;
 
 typedef struct dt_iop_primaries_params_t
 {

--- a/src/iop/sigmoid.c
+++ b/src/iop/sigmoid.c
@@ -276,7 +276,7 @@ void init_presets(dt_iop_module_so_t *self)
                              self->version(), &p, sizeof(p), 1,
                              DEVELOP_BLEND_CS_RGB_SCENE);
 
-  const float DEG_TO_RAD = DT_M_PI_F / 180.f;
+  const float DEG_TO_RAD = M_PI_F / 180.f;
 
   // smooth - a preset that utilizes the primaries feature
   p.middle_grey_contrast = 1.5f;
@@ -951,7 +951,7 @@ void gui_init(dt_iop_module_t *self)
   slider = dt_bauhaus_slider_from_params(sect, #color "_rotation");                                               \
   dt_bauhaus_slider_set_format(slider, "°");                                                                      \
   dt_bauhaus_slider_set_digits(slider, 1);                                                                        \
-  dt_bauhaus_slider_set_factor(slider, 180.f / DT_M_PI_F);                                                        \
+  dt_bauhaus_slider_set_factor(slider, 180.f / M_PI_F);                                                        \
   dt_bauhaus_slider_set_stop(slider, 0.f, r, g, b);                                                               \
   gtk_widget_set_tooltip_text(slider, rotation_tooltip);
 


### PR DESCRIPTION
1. It doesn't make sense to define two different values for (double)PI so let's get rid of the DT_M_PI DT_M_PI_F variants
2. For M_PI_F we can either use the value of M_PI with f at the end or the shorter form 3.141592654f with a binary-identical value