### PR TITLE
Introduce DT_OPENCL_PERFORMANCE compile time option

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -348,11 +348,11 @@ static float _calc_refavg(
   }
 
   for(int c = 0; c < 3; c++)
-    mean[c] = (cnt[c] > 0.0f) ? native_powr((correction[c] * sum[c]) / cnt[c], 0.33333333333f) : 0.0f;
+    mean[c] = (cnt[c] > 0.0f) ? dtcl_pow((correction[c] * sum[c]) / cnt[c], 0.33333333333f) : 0.0f;
 
   const float croot_refavg[3] = { 0.5f * (mean[1] + mean[2]), 0.5f * (mean[0] + mean[2]), 0.5f * (mean[0] + mean[1])};
   const int color = (filters == 9u) ? FCxtrans(row, col, xtrans) : FC(row, col, filters);
-  return native_powr(croot_refavg[color], 3.0f);
+  return dtcl_pow(croot_refavg[color], 3.0f);
 }
 
 kernel void highlights_initmask(
@@ -906,7 +906,7 @@ interpolate_and_mask(read_only image2d_t input,
     }
   }
 
-  float4 RGB = {R, G, B, native_sqrt(R * R + G * G + B * B) };
+  float4 RGB = {R, G, B, dtcl_sqrt(R * R + G * G + B * B) };
   float4 clipped = { R_clipped, G_clipped, B_clipped, (R_clipped || G_clipped || B_clipped) };
   const float4 WB4 = { wb[0], wb[1], wb[2], wb[3] };
   write_imagef(interpolated, (int2)(j, i), RGB / WB4);
@@ -963,7 +963,7 @@ box_blur_5x5(read_only image2d_t in,
   write_imagef(out, (int2)(x, y), acc);
 }
 
-// works correctly with 1-4 channel float images 
+// works correctly with 1-4 channel float images
 kernel void interpolate_bilinear(read_only image2d_t in,
                                 const int width_in,
                                 const int height_in,
@@ -1338,7 +1338,7 @@ lookup_unbounded_twosided(read_only image2d_t lut, const float x, constant float
       // two-sided extrapolation (with inverted x-axis for left side)
       const float xx = (x >= ar) ? x : 1.0f - x;
       constant float *aa = (x >= ar) ? a : a + 3;
-      return aa[1] * native_powr(xx*aa[0], aa[2]);
+      return aa[1] * dtcl_pow(xx*aa[0], aa[2]);
     }
   }
   else return x;
@@ -1362,7 +1362,7 @@ lerp_lookup_unbounded0(read_only image2d_t lut, const float x, global const floa
       const float l2 = read_imagef(lut, sampleri, p2).x;
       return l1 * (1.0f - f) + l2 * f;
     }
-    else return a[1] * native_powr(x*a[0], a[2]);
+    else return a[1] * dtcl_pow(x*a[0], a[2]);
   }
   else return x;
 }
@@ -3384,7 +3384,7 @@ colorzones (read_only image2d_t in,
   }
   select = clamp(select, 0.f, 1.f);
 
-  LCh.x *= native_powr(2.0f, 4.0f * (lookup(table_L, select) - .5f));
+  LCh.x *= dtcl_pow(2.0f, 4.0f * (lookup(table_L, select) - .5f));
   LCh.y *= 2.f * lookup(table_C, select);
   LCh.z += lookup(table_h, select) - .5f;
 
@@ -3499,7 +3499,7 @@ overexposed (read_only image2d_t in,
     {
       float4 saturation = { 0.f, 0.f, 0.f, 0.f};
       saturation = pixel_tmp - (float4)luminance;
-      saturation = native_sqrt(saturation * saturation / ((float4)(luminance * luminance) + pixel_tmp * pixel_tmp));
+      saturation = dtcl_sqrt(saturation * saturation / ((float4)(luminance * luminance) + pixel_tmp * pixel_tmp));
 
       if(saturation.x > upper || saturation.y > upper || saturation.z > upper ||
          pixel_tmp.x >= upper || pixel_tmp.y >= upper || pixel_tmp.z >= upper)
@@ -3527,7 +3527,7 @@ overexposed (read_only image2d_t in,
     {
       float4 saturation = { 0.f, 0.f, 0.f, 0.f};
       saturation = pixel_tmp - (float4)luminance;
-      saturation = native_sqrt(saturation * saturation / ((float4)(luminance * luminance) + pixel_tmp * pixel_tmp));
+      saturation = dtcl_sqrt(saturation * saturation / ((float4)(luminance * luminance) + pixel_tmp * pixel_tmp));
 
       if(saturation.x > upper || saturation.y > upper || saturation.z > upper ||
          pixel_tmp.x >= upper || pixel_tmp.y >= upper || pixel_tmp.z >= upper)

--- a/data/kernels/basicadj.cl
+++ b/data/kernels/basicadj.cl
@@ -21,7 +21,7 @@
 
 float get_gamma(const float x, const float gamma)
 {
-  return native_powr(x, gamma);
+  return dtcl_pow(x, gamma);
 }
 
 float get_lut_gamma(const float x, const float gamma, read_only image2d_t lut)
@@ -40,7 +40,7 @@ float get_lut_gamma(const float x, const float gamma, read_only image2d_t lut)
 
 float get_contrast(const float x, const float contrast, const float middle_grey, const float inv_middle_grey)
 {
-  return native_powr(x * inv_middle_grey, contrast) * middle_grey;
+  return dtcl_pow(x * inv_middle_grey, contrast) * middle_grey;
 }
 
 float get_lut_contrast(const float x, const float contrast, const float middle_grey, const float inv_middle_grey, read_only image2d_t lut)
@@ -144,7 +144,7 @@ basicadj(read_only image2d_t in, write_only image2d_t out, const int width, cons
     const float lum = dt_rgb_norm(pixel, preserve_colors, use_work_profile, profile_info, lut);
     if(lum > 0.f)
     {
-      const float contrast_lum = native_powr(lum / middle_grey, contrast) * middle_grey;
+      const float contrast_lum = dtcl_pow(lum / middle_grey, contrast) * middle_grey;
       ratio = contrast_lum / lum;
     }
 
@@ -156,7 +156,7 @@ basicadj(read_only image2d_t in, write_only image2d_t out, const int width, cons
   {
     const float average = (pixel.x + pixel.y + pixel.z) / 3;
     const float delta = fast_length(pixel - average);
-    const float P = vibrance * (1 - native_powr(delta, fabs(vibrance)));
+    const float P = vibrance * (1 - dtcl_pow(delta, fabs(vibrance)));
     pixel = average + (saturation + P) * (pixel - average);
   }
 

--- a/data/kernels/channelmixer.cl
+++ b/data/kernels/channelmixer.cl
@@ -50,7 +50,7 @@ static inline float sqf(const float x)
 
 static inline float euclidean_norm(const float4 input)
 {
-  return fmax(native_sqrt(sqf(input.x) + sqf(input.y) + sqf(input.z)), NORM_MIN);
+  return fmax(dtcl_sqrt(sqf(input.x) + sqf(input.y) + sqf(input.z)), NORM_MIN);
 }
 
 static inline float4 gamut_mapping(const float4 input, const float compression, const int clip)
@@ -74,7 +74,7 @@ static inline float4 gamut_mapping(const float4 input, const float compression, 
   const float Delta = Y * (sqf(delta.x) + sqf(delta.y));
 
   // Compress chromaticity (move toward white point)
-  const float correction = (compression == 0.0f) ? 0.f : native_powr(Delta, compression);
+  const float correction = (compression == 0.0f) ? 0.f : dtcl_pow(Delta, compression);
 
   // Ensure the correction does not bring our uyY vector the other side of D50
   // that would switch to the opposite color, so we clip at D50

--- a/data/kernels/color_conversion.h
+++ b/data/kernels/color_conversion.h
@@ -62,7 +62,7 @@ static inline float lerp_lookup_unbounded(const float x, read_only image2d_t lut
       const float l2 = read_imagef(lut, sampleri, p2).x;
       return l1 * (1.0f - f) + l2 * f;
     }
-    else return unbounded_coeffs[1] * native_powr(x*unbounded_coeffs[0], unbounded_coeffs[2]);
+    else return unbounded_coeffs[1] * dtcl_pow(x*unbounded_coeffs[0], unbounded_coeffs[2]);
   }
   else return x;
 }
@@ -86,7 +86,7 @@ static inline float lookup_unbounded(read_only image2d_t lut, const float x, con
       const int2 p = (int2)((xi & 0xff), (xi >> 8));
       return read_imagef(lut, sampleri, p).x;
     }
-    else return a[1] * native_powr(x*a[0], a[2]);
+    else return a[1] * dtcl_pow(x*a[0], a[2]);
   }
   else return x;
 }

--- a/data/kernels/colorequal.cl
+++ b/data/kernels/colorequal.cl
@@ -74,7 +74,7 @@ static inline float4 gamut_map_HSB(const float4 HSB, global float *gamut_LUT, co
 {
   const float4 JCH = dt_UCS_HSB_to_JCH(HSB);
   const float max_colorfulness = lookup_gamut(gamut_LUT, JCH.z);
-  const float max_chroma = 15.932993652962535f * native_powr(JCH.x * L_white, 0.6523997524738018f) * native_powr(max_colorfulness, 0.6007557017508491f) / L_white;
+  const float max_chroma = 15.932993652962535f * dtcl_pow(JCH.x * L_white, 0.6523997524738018f) * dtcl_pow(max_colorfulness, 0.6007557017508491f) / L_white;
   const float4 JCH_gamut_boundary = { JCH.x, max_chroma, JCH.z, 0.0f };
   const float4 HSB_gamut_boundary = dt_UCS_JCH_to_HSB(JCH_gamut_boundary);
 
@@ -401,7 +401,7 @@ __kernel void write_visual(__write_only image2d_t out,
   const float b_correction = read_imagef(b_corrections, samplerA, (int2)(col, row)).x;
 
   const float sat = read_imagef(saturation, samplerA, (int2)(col, row)).x;
-  const float val = native_sqrt(fmax(0.0f, B * white));
+  const float val = dtcl_sqrt(fmax(0.0f, B * white));
   float corr = 0.0f;
   switch(mode)
   {

--- a/data/kernels/colorspace.h
+++ b/data/kernels/colorspace.h
@@ -79,7 +79,7 @@ static inline float4 lab_f(float4 x)
 {
   const float4 epsilon = 216.0f / 24389.0f;
   const float4 kappa = 24389.0f / 27.0f;
-  return (x > epsilon) ? native_powr(x, (float4)(1.0f/3.0f)) : (kappa * x + (float4)16.0f) / ((float4)116.0f);
+  return (x > epsilon) ? dtcl_pow(x, (float4)(1.0f/3.0f)) : (kappa * x + (float4)16.0f) / ((float4)116.0f);
 }
 
 
@@ -381,8 +381,8 @@ static inline float4 XYZ_to_JzAzBz(float4 XYZ_D65)
   temp2.z = dot(M[2], temp1);
   temp2.w = 0.f;
   // LMS -> L'M'S'
-  temp2 = native_powr(fmax(temp2 / 10000.f, 0.0f), 0.159301758f);
-  temp2 = native_powr((0.8359375f + 18.8515625f * temp2) / (1.0f + 18.6875f * temp2), 134.034375f);
+  temp2 = dtcl_pow(fmax(temp2 / 10000.f, 0.0f), 0.159301758f);
+  temp2 = dtcl_pow((0.8359375f + 18.8515625f * temp2) / (1.0f + 18.6875f * temp2), 134.034375f);
   // L'M'S' -> Izazbz
   temp1.x = dot(A[0], temp2);
   temp1.y = dot(A[1], temp2);
@@ -422,8 +422,8 @@ static inline float4 JzAzBz_2_XYZ(const float4 JzAzBz)
   LMS.z = dot(AI[2], IzAzBz);
   LMS.w = 0.f;
   // L'M'S' -> LMS
-  LMS = native_powr(fmax(LMS, 0.0f), p_inv);
-  LMS = 10000.f * native_powr(fmax((c1 - LMS) / (c3 * LMS - c2), 0.0f), n_inv);
+  LMS = dtcl_pow(fmax(LMS, 0.0f), p_inv);
+  LMS = 10000.f * dtcl_pow(fmax((c1 - LMS) / (c3 * LMS - c2), 0.0f), n_inv);
   // LMS -> X'Y'Z
   XYZ.x = dot(MI[0], LMS);
   XYZ.y = dot(MI[1], LMS);
@@ -444,7 +444,7 @@ static inline float4 JzAzBz_to_JzCzhz(float4 JzAzBz)
   const float h = atan2(JzAzBz.z, JzAzBz.y) / (2.0f * M_PI_F);
   float4 JzCzhz;
   JzCzhz.x = JzAzBz.x;
-  JzCzhz.y = native_sqrt(JzAzBz.y * JzAzBz.y + JzAzBz.z * JzAzBz.z);
+  JzCzhz.y = dtcl_sqrt(JzAzBz.y * JzAzBz.y + JzAzBz.z * JzAzBz.z);
   JzCzhz.z = (h >= 0.0f) ? h : 1.0f + h;
   JzCzhz.w = JzAzBz.w;
   return JzCzhz;
@@ -717,7 +717,7 @@ static inline void bradford_adapt_D50(float4 *lms_in,
     float4 temp = *lms_in / origin_illuminant;
 
     // use linear Bradford if B is negative
-    temp.z = (temp.z > 0.f) ? native_powr(temp.z, p) : temp.z;
+    temp.z = (temp.z > 0.f) ? dtcl_pow(temp.z, p) : temp.z;
 
     *lms_in = D50 * temp;
   }
@@ -797,13 +797,13 @@ static inline float4 gamut_check_Yrg(float4 Ych)
 
 static inline float Y_to_dt_UCS_L_star(const float Y)
 {
-  const float Y_hat = native_powr(Y, 0.631651345306265f);
+  const float Y_hat = dtcl_pow(Y, 0.631651345306265f);
   return DT_UCS_L_STAR_RANGE * Y_hat / (Y_hat + 1.12426773749357f);
 }
 
 static inline float dt_UCS_L_star_to_Y(const float L_star)
 {
-  return native_powr((1.12426773749357f * L_star / (DT_UCS_L_STAR_RANGE - L_star)), 1.5831518565279648f);
+  return dtcl_pow((1.12426773749357f * L_star / (DT_UCS_L_STAR_RANGE - L_star)), 1.5831518565279648f);
 }
 
 static inline float2 xyY_to_dt_UCS_UV(const float4 xyY)
@@ -846,7 +846,7 @@ static inline float4 xyY_to_dt_UCS_JCH(const float4 xyY, const float L_white)
 
   // should be JCH[0] = powf(L_star / L_white), cz) but we treat only the case where cz = 1
   const float4 JCH = {  L_star / L_white,
-                        15.932993652962535f * native_powr(L_star, 0.6523997524738018f) * native_powr(M2, 0.6007557017508491f) / L_white,
+                        15.932993652962535f * dtcl_pow(L_star, 0.6523997524738018f) * dtcl_pow(M2, 0.6007557017508491f) / L_white,
                         atan2(UV_star_prime.y, UV_star_prime.x),
                         0.0f };
   return JCH;
@@ -871,11 +871,11 @@ static inline float4 dt_UCS_JCH_to_xyY(const float4 JCH, const float L_white)
   // this leads to more stability for extremely bright parts as we avoid single float precision overflows
   const float L_star = clamp(JCH.x * L_white, 0.f, DT_UCS_L_STAR_UPPER_LIMIT);
   const float M = L_star != 0.f
-    ? native_powr(JCH.y * L_white / (15.932993652962535f * native_powr(L_star, 0.6523997524738018f)), 0.8322850678616855f)
+    ? dtcl_pow(JCH.y * L_white / (15.932993652962535f * dtcl_pow(L_star, 0.6523997524738018f)), 0.8322850678616855f)
     : 0.f;
 
-  const float U_star_prime = M * native_cos(JCH.z);
-  const float V_star_prime = M * native_sin(JCH.z);
+  const float U_star_prime = M * dtcl_cos(JCH.z);
+  const float V_star_prime = M * dtcl_sin(JCH.z);
 
   // The following is equivalent to a 2D matrix product
   const float2 UV_star = { -5.037522385190711f * U_star_prime - 2.504856328185843f * V_star_prime,
@@ -901,7 +901,7 @@ static inline float4 dt_UCS_JCH_to_xyY(const float4 JCH, const float L_white)
 static inline float4 dt_UCS_JCH_to_HSB(const float4 JCH)
 {
   float4 HSB;
-  HSB.z = JCH.x * (native_powr(JCH.y, 1.33654221029386f) + 1.f);
+  HSB.z = JCH.x * (dtcl_pow(JCH.y, 1.33654221029386f) + 1.f);
   HSB.y = (HSB.z > 0.f) ? JCH.y / HSB.z : 0.f;
   HSB.x = JCH.z;
   return HSB;
@@ -913,7 +913,7 @@ static inline float4 dt_UCS_HSB_to_JCH(const float4 HSB)
   float4 JCH;
   JCH.z = HSB.x;
   JCH.y = HSB.y * HSB.z;
-  JCH.x = HSB.z / (native_powr(JCH.y, 1.33654221029386f) + 1.f);
+  JCH.x = HSB.z / (dtcl_pow(JCH.y, 1.33654221029386f) + 1.f);
   return JCH;
 }
 
@@ -921,7 +921,7 @@ static inline float4 dt_UCS_HSB_to_JCH(const float4 HSB)
 static inline float4 dt_UCS_JCH_to_HCB(const float4 JCH)
 {
   float4 HCB;
-  HCB.z = JCH.x * (native_powr(JCH.y, 1.33654221029386f) + 1.f);
+  HCB.z = JCH.x * (dtcl_pow(JCH.y, 1.33654221029386f) + 1.f);
   HCB.y = JCH.y;
   HCB.x = JCH.z;
   return HCB;
@@ -933,7 +933,7 @@ static inline float4 dt_UCS_HCB_to_JCH(const float4 HCB)
   float4 JCH;
   JCH.z = HCB.x;
   JCH.y = HCB.y;
-  JCH.x = HCB.z / (native_powr(HCB.y, 1.33654221029386f) + 1.f);
+  JCH.x = HCB.z / (dtcl_pow(HCB.y, 1.33654221029386f) + 1.f);
   return JCH;
 }
 
@@ -949,7 +949,7 @@ static inline float4 dt_UCS_LUV_to_JCH(const float L_star, const float L_white, 
 {
   const float M2 = UV_star_prime.x * UV_star_prime.x + UV_star_prime.y * UV_star_prime.y; // square of colorfulness M
   const float4 JCH = {  L_star / L_white,
-                        15.932993652962535f * native_powr(L_star, 0.6523997524738018f) * native_powr(M2, 0.6007557017508491f) / L_white,
+                        15.932993652962535f * dtcl_pow(L_star, 0.6523997524738018f) * dtcl_pow(M2, 0.6007557017508491f) / L_white,
                         atan2(UV_star_prime.y, UV_star_prime.x),
                         0.0f };
   return JCH;
@@ -960,7 +960,7 @@ static inline float soft_clip(const float x, const float soft_threshold, const f
   // use an exponential soft clipping above soft_threshold
   // hard threshold must be > soft threshold
   const float norm = hard_threshold - soft_threshold;
-  return (x > soft_threshold) ? soft_threshold + (1.f - native_exp(-(x - soft_threshold) / norm)) * norm : x;
+  return (x > soft_threshold) ? soft_threshold + (1.f - dtcl_exp(-(x - soft_threshold) / norm)) * norm : x;
 }
 
 

--- a/data/kernels/common.h
+++ b/data/kernels/common.h
@@ -37,6 +37,25 @@ constant sampler_t samplerA = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_NONE    
 #define BLUE 2
 #define ALPHA 3
 
+#define DT_OPENCL_PERFORMANCE
+
+#ifdef DT_OPENCL_PERFORMANCE
+  #define dtcl_sin(A) native_sin(A)
+  #define dtcl_cos(A) native_cos(A)
+  #define dtcl_sqrt(A) native_sqrt(A)
+  #define dtcl_pow(A,B) native_powr(A,B)
+  #define dtcl_exp(A) native_exp(A)
+  // Allow the compiler to convert a * b + c to fused multiply-add to use hardware acceleration
+  // on compatible platforms
+  #pragma OPENCL FP_CONTRACT ON
+#else
+  #define dtcl_sin(A) sin(A)
+  #define dtcl_cos(A) cos(A)
+  #define dtcl_sqrt(A) sqrt(A)
+  #define dtcl_pow(A,B) pow(A,B)
+  #define dtcl_exp(A) exp(A)
+  #pragma OPENCL FP_CONTRACT OFF
+#endif
 
 static inline int
 FC(const int row, const int col, const unsigned int filters)
@@ -55,7 +74,7 @@ FCxtrans(const int row, const int col, global const unsigned char (*const xtrans
 static inline float
 dt_fast_hypot(const float x, const float y)
 {
-  return native_sqrt(x * x + y * y);
+  return dtcl_sqrt(x * x + y * y);
 }
 
 /* we use this exp approximation to maintain full identity with cpu path */
@@ -77,7 +96,3 @@ dt_fast_expf(const float x)
   u.k = k0 > 0 ? k0 : 0;
   return u.f;
 }
-
-// Allow the compiler to convert a * b + c to fused multiply-add to use hardware acceleration
-// on compatible platforms
-#pragma OPENCL FP_CONTRACT ON

--- a/data/kernels/demosaic_rcd.cl
+++ b/data/kernels/demosaic_rcd.cl
@@ -309,7 +309,7 @@ __kernel void calc_Y0_mask(global float *mask, __read_only image2d_t in, const i
   const float val = fmax(pt.x / red, 0.0f)
                   + fmax(pt.y / green, 0.0f)
                   + fmax(pt.z / blue, 0.0f);
-  mask[idx] = native_sqrt(val / 3.0f);
+  mask[idx] = dtcl_sqrt(val / 3.0f);
 }
 
 __kernel void calc_scharr_mask(global float *in, global float *out, const int w, const int height)
@@ -330,7 +330,7 @@ __kernel void calc_scharr_mask(global float *in, global float *out, const int w,
                 + 162.0f / 255.0f * (in[idx-1]   - in[idx+1]);
   const float gy = 47.0f / 255.0f * (in[idx-w-1] - in[idx+w-1] + in[idx-w+1] - in[idx+w+1])
                 + 162.0f / 255.0f * (in[idx-w]   - in[idx+w]);
-  const float gradient_magnitude = native_sqrt(sqrf(gx) + sqrf(gy));
+  const float gradient_magnitude = dtcl_sqrt(sqrf(gx) + sqrf(gy));
   out[oidx] = clamp(gradient_magnitude / 16.0f, 0.0f, 1.0f);
 }
 

--- a/data/kernels/denoiseprofile.cl
+++ b/data/kernels/denoiseprofile.cl
@@ -77,7 +77,7 @@ denoiseprofile_precondition_v2(read_only image2d_t in, write_only image2d_t out,
   float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
   const float alpha = pixel.w;
 
-  float4 t = fmax(2.0f * native_powr(fmax((float4)0.0f, pixel / wb + b), 1.0f - p / 2.0f) / ((-p + 2.0f) * sqrt(a)), 0.f);
+  float4 t = fmax(2.0f * dtcl_pow(fmax((float4)0.0f, pixel / wb + b), 1.0f - p / 2.0f) / ((-p + 2.0f) * sqrt(a)), 0.f);
 
   t.w = alpha;
 
@@ -96,7 +96,7 @@ denoiseprofile_precondition_Y0U0V0(read_only image2d_t in, write_only image2d_t 
   float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
   const float alpha = pixel.w;
 
-  const float4 t = fmax(2.0f * native_powr(fmax((float4)0.0f, pixel + b), 1.0f - p / 2.0f) / ((-p + 2.0f) * sqrt(a)), 0.f);
+  const float4 t = fmax(2.0f * dtcl_pow(fmax((float4)0.0f, pixel + b), 1.0f - p / 2.0f) / ((-p + 2.0f) * sqrt(a)), 0.f);
 
   float4 outpx = (float4)0.0f;
   outpx.x += toY0U0V0[0] * t.x;
@@ -357,7 +357,7 @@ denoiseprofile_finish_v2(read_only image2d_t in, global float4* U2, write_only i
   float4 delta = px * px + (float4)bias;
   float4 denominator = 4.0f / (sqrt(a) * (2.0f - p));
   float4 z1 = (px + sqrt(fmax((float4)0.0f, delta))) / denominator;
-  px = fmax(native_powr(z1, 1.0f / (1.0f - p / 2.0f)) - b, 0.f);
+  px = fmax(dtcl_pow(z1, 1.0f / (1.0f - p / 2.0f)) - b, 0.f);
   px = px * wb;
   px.w = alpha;
 
@@ -406,7 +406,7 @@ denoiseprofile_backtransform_v2(read_only image2d_t in, write_only image2d_t out
   const float4 delta = px * px + (float4)bias;
   const float4 denominator = 4.0f / (sqrt(a) * (2.0f - p));
   const float4 z1 = (px + sqrt(fmax((float4)0.0f, delta))) / denominator;
-  px = fmax(native_powr(z1, 1.0f / (1.0f - p / 2.0f)) - b, 0.f);
+  px = fmax(dtcl_pow(z1, 1.0f / (1.0f - p / 2.0f)) - b, 0.f);
   px = px * wb;
   px.w = alpha;
 
@@ -441,7 +441,7 @@ denoiseprofile_backtransform_Y0U0V0(read_only image2d_t in, write_only image2d_t
   const float4 delta = px * px + (float4)bias * wb;
   const float4 denominator = 4.0f / (sqrt(a) * (2.0f - p));
   const float4 z1 = (px + sqrt(fmax((float4)0.0f, delta))) / denominator;
-  px = fmax(native_powr(z1, 1.0f / (1.0f - p / 2.0f)) - b, 0.f);
+  px = fmax(dtcl_pow(z1, 1.0f / (1.0f - p / 2.0f)) - b, 0.f);
   px.w = alpha;
 
   write_imagef (out, (int2)(x, y), px);

--- a/data/kernels/diffuse.cl
+++ b/data/kernels/diffuse.cl
@@ -218,7 +218,7 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
     find_gradient(neighbour_pixel_LF, gradient);
     find_gradient(neighbour_pixel_HF, laplacian);
 
-    const float4 magnitude_grad = native_sqrt(sqf(gradient[0]) + sqf(gradient[1]));
+    const float4 magnitude_grad = dtcl_sqrt(sqf(gradient[0]) + sqf(gradient[1]));
     // Compute cos(arg(grad)) = dx / hypot - force arg(grad) = 0 if hypot == 0
     gradient[0] = (magnitude_grad != 0.f) ? gradient[0] / magnitude_grad
                                           : 1.f; // cos(0)
@@ -227,7 +227,7 @@ diffuse_pde(read_only image2d_t HF, read_only image2d_t LF,
                                           : 0.f; // sin(0)
     // Warning : now gradient[2] = { cos(arg(grad)) , sin(arg(grad)) }
 
-    const float4 magnitude_lapl = native_sqrt(sqf(laplacian[0]) + sqf(laplacian[1]));
+    const float4 magnitude_lapl = dtcl_sqrt(sqf(laplacian[0]) + sqf(laplacian[1]));
     // Compute cos(arg(lapl)) = dx / hypot - force arg(lapl) = 0 if hypot == 0
     laplacian[0] = (magnitude_lapl != 0.f) ? laplacian[0] / magnitude_lapl
                                            : 1.f; // cos(0)

--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -141,7 +141,7 @@ filmic (read_only image2d_t in, write_only image2d_t out, int width, int height,
 
   // Apply the transfer function of the display
   const float4 power4 = power;
-  o = native_powr(o, power4);
+  o = dtcl_pow(o, power4);
 
   i.xyz = prophotorgb_to_Lab(o).xyz;
 
@@ -163,7 +163,7 @@ static inline float pixel_rgb_norm_euclidean(const float4 pixel)
 {
   const float4 RGB = pixel;
   const float4 RGB_square = RGB * RGB;
-  return native_sqrt(RGB_square.x + RGB_square.y + RGB_square.z);
+  return dtcl_sqrt(RGB_square.x + RGB_square.y + RGB_square.z);
 }
 
 static inline float get_pixel_norm(const float4 pixel, const dt_iop_filmicrgb_methods_type_t variant,
@@ -213,7 +213,7 @@ static inline float filmic_desaturate_v2(const float x, const float sigma_toe, c
 {
   const float radius_toe = x;
   const float radius_shoulder = 1.0f - x;
-  const float sat2 = 0.5f / native_sqrt(saturation);
+  const float sat2 = 0.5f / dtcl_sqrt(saturation);
   const float key_toe = native_exp(-radius_toe * radius_toe / sigma_toe * sat2);
   const float key_shoulder = native_exp(-radius_shoulder * radius_shoulder / sigma_shoulder * sat2);
 
@@ -588,7 +588,7 @@ static inline float4 filmic_chroma_v4(const float4 i,
 
   // Filmic S curve on the max RGB
   // Apply the transfer function of the display
-  norm = native_powr(clamp(filmic_spline(norm, M1, M2, M3, M4, M5, latitude_min, latitude_max, type),
+  norm = dtcl_pow(clamp(filmic_spline(norm, M1, M2, M3, M4, M5, latitude_min, latitude_max, type),
                            display_black,
                            display_white), output_power);
 
@@ -636,7 +636,7 @@ static inline float4 filmic_split_v4(const float4 i,
   // Clamp to [0, display_white]: we don't want to clamp individual channels to display_black
   // as that would limit the max available saturation. Luminance is clipped to display_black later.
   // Apply output power function afterwards.
-  o = native_powr(clamp(o, (float4)0.f, (float4)display_white), output_power);
+  o = dtcl_pow(clamp(o, (float4)0.f, (float4)display_white), output_power);
 
   // Save Ych in Kirk/Filmlight Yrg
   float4 Ych_original = pipe_RGB_to_Ych(i, matrix_in);
@@ -681,7 +681,7 @@ static inline float4 filmic_chroma_v5(const float4 i,
 
   // Filmic S curve on the max RGB
   // Apply the transfer function of the display
-  norm = native_powr(clamp(filmic_spline(norm, M1, M2, M3, M4, M5, latitude_min, latitude_max, type),
+  norm = dtcl_pow(clamp(filmic_spline(norm, M1, M2, M3, M4, M5, latitude_min, latitude_max, type),
                            display_black,
                            display_white), output_power);
 
@@ -703,7 +703,7 @@ static inline float4 filmic_chroma_v5(const float4 i,
   // Clamp to [0, display_white]: we don't want to clamp individual channels to display_black
   // as that would limit the max available saturation. Luminance is clipped to display_black later.
   // Apply output power function afterwards.
-  naive_rgb = native_powr(clamp(naive_rgb, (float4)0.f, (float4)display_white), output_power);
+  naive_rgb = dtcl_pow(clamp(naive_rgb, (float4)0.f, (float4)display_white), output_power);
 
   // Mix max RGB with naive RGB
   float4 o = (0.5f - saturation) * naive_rgb + (0.5f + saturation) * max_rgb;
@@ -753,7 +753,7 @@ static inline float4 filmic_split_v1(const float4 i,
   o.z = filmic_spline(o.z, M1, M2, M3, M4, M5, latitude_min, latitude_max, type);
 
   // Output power
-  o = native_powr(clamp(o, (float4)0.0f, (float4)1.0f), output_power);
+  o = dtcl_pow(clamp(o, (float4)0.0f, (float4)1.0f), output_power);
 
   return o;
 }
@@ -790,7 +790,7 @@ static inline float4 filmic_split_v2_v3(const float4 i,
   o.z = filmic_spline(o.z, M1, M2, M3, M4, M5, latitude_min, latitude_max, type);
 
   // Output power
-  o = native_powr(clamp(o, (float4)0.0f, (float4)1.0f), output_power);
+  o = dtcl_pow(clamp(o, (float4)0.0f, (float4)1.0f), output_power);
 
   return o;
 }
@@ -899,7 +899,7 @@ static inline float4 filmic_chroma_v1(const float4 i,
 
   // Filmic S curve on the max RGB
   // Apply the transfer function of the display
-  norm = native_powr(clamp(filmic_spline(norm, M1, M2, M3, M4, M5, latitude_min, latitude_max, type), 0.0f, 1.0f), output_power);
+  norm = dtcl_pow(clamp(filmic_spline(norm, M1, M2, M3, M4, M5, latitude_min, latitude_max, type), 0.0f, 1.0f), output_power);
 
   return o * norm;
 }
@@ -933,7 +933,7 @@ static inline float4 filmic_chroma_v2_v3(const float4 i,
 
   // Filmic S curve on the max RGB
   // Apply the transfer function of the display
-  norm = native_powr(clamp(filmic_spline(norm, M1, M2, M3, M4, M5, latitude_min, latitude_max, type), 0.0f, 1.0f), output_power);
+  norm = dtcl_pow(clamp(filmic_spline(norm, M1, M2, M3, M4, M5, latitude_min, latitude_max, type), 0.0f, 1.0f), output_power);
 
   // Re-apply ratios with saturation change
   ratios = fmax(ratios + ((float4)1.0f - ratios) * ((float4)1.0f - desaturation), (float4)0.f);
@@ -1048,7 +1048,7 @@ filmic_mask_clipped_pixels(read_only image2d_t in, write_only image2d_t out,
   float4 i = read_imagef(in, sampleri, (int2)(x, y));
   const float4 i2 = i * i;
 
-  const float pix_max = fmax(native_sqrt(i2.x + i2.y + i2.z), 0.f);
+  const float pix_max = fmax(dtcl_sqrt(i2.x + i2.y + i2.z), 0.f);
   const float argument = -pix_max * normalize + feathering;
   const float weight = clamp(1.0f / ( 1.0f + native_exp2(argument)), 0.f, 1.f);
 

--- a/data/kernels/gaussian.cl
+++ b/data/kernels/gaussian.cl
@@ -297,7 +297,7 @@ lookup_unbounded(read_only image2d_t lut, const float x, global float *a)
       const int2 p = (int2)((xi & 0xff), (xi >> 8));
       return read_imagef(lut, sampleri, p).x;
     }
-    else return a[1] * native_powr(x*a[0], a[2]);
+    else return a[1] * dtcl_pow(x*a[0], a[2]);
   }
   else return x;
 }

--- a/data/kernels/negadoctor.cl
+++ b/data/kernels/negadoctor.cl
@@ -40,7 +40,7 @@ negadoctor (read_only image2d_t in, write_only image2d_t out, int width, int hei
 
   // Print density on paper : ((1 - 10^corrected_de + black) * exposure)^gamma rewritten for FMA
   o = -((float4)exposure * native_exp10(o) + (float4)black);
-  o = native_powr(fmax(o, (float4)0.0f), gamma); // note : this is always > 0
+  o = dtcl_pow(fmax(o, (float4)0.0f), gamma); // note : this is always > 0
 
   // Compress highlights and clip negatives. from https://lists.gnu.org/archive/html/openexr-devel/2005-03/msg00009.html
   o = (o > (float4)soft_clip) ? soft_clip + ((float4)1.0f - native_exp(-(o - (float4)soft_clip) / (float4)soft_clip_comp)) * (float4)soft_clip_comp

--- a/data/kernels/rgb_norms.h
+++ b/data/kernels/rgb_norms.h
@@ -49,7 +49,7 @@ dt_rgb_norm(const float4 in, const int norm, const int work_profile,
   }
   else if (norm == DT_RGB_NORM_NORM)
   {
-    return native_powr(in.x * in.x + in.y * in.y + in.z * in.z, 0.5f);
+    return dtcl_pow(in.x * in.x + in.y * in.y + in.z * in.z, 0.5f);
   }
   else if (norm == DT_RGB_NORM_POWER)
   {

--- a/data/kernels/rgblevels.cl
+++ b/data/kernels/rgblevels.cl
@@ -31,7 +31,7 @@ float rgblevels_1c(const float pixel, global const float *levels, const float in
   else if(pixel >= levels[2])
   {
     const float percentage = (pixel - levels[0]) / (levels[2] - levels[0]);
-    level = native_powr(percentage, inv_gamma);
+    level = dtcl_pow(percentage, inv_gamma);
   }
   else
   {


### PR DESCRIPTION
When this is defined we use the native OpenCL function variants for sin, cos, sqrt, exp and pow. Also set OPENCL FP_CONTRACT ON.

Otherwise use the IEEE standard functions

To be used for debugging OpenCL vs CPU precision problems.