### PR TITLE
fix regressions from #17425

### DIFF
--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -61,9 +61,8 @@ gboolean dt_lib_is_visible_in_view(dt_lib_module_t *module,
     return FALSE;
   }
 
-  const dt_view_t *cv = view ?: dt_view_manager_get_current_view(darktable.view_manager);
-  gboolean ret = module->views(module) & cv->view(cv);
-  gchar *key = _get_lib_view_path(module, cv, "_visible");
+  gboolean ret = module->views(module) & view->view(view);
+  gchar *key = _get_lib_view_path(module, view, "_visible");
   if(key && dt_conf_key_exists(key))
     ret = dt_conf_get_bool(key);
   g_free(key);
@@ -1423,8 +1422,8 @@ static gchar *_get_lib_view_path(const dt_lib_module_t *module,
                                  const dt_view_t *cv,
                                  char *suffix)
 {
-  if(!darktable.view_manager) return NULL;
-  if(!cv) cv = dt_view_manager_get_current_view(darktable.view_manager);
+  if(!cv && darktable.view_manager)
+    cv = dt_view_manager_get_current_view(darktable.view_manager);
   if(!cv) return NULL;
   // in lighttable, we store panels states per layout
   char lay[32] = "";
@@ -1448,7 +1447,7 @@ static gchar *_get_lib_view_path(const dt_lib_module_t *module,
 
 gboolean dt_lib_is_visible(dt_lib_module_t *module)
 {
-  return dt_lib_is_visible_in_view(module, NULL);
+  return dt_lib_is_visible_in_view(module, dt_view_manager_get_current_view(darktable.view_manager));
 }
 
 void dt_lib_set_visible(dt_lib_module_t *module,

--- a/src/lua/lualib.c
+++ b/src/lua/lualib.c
@@ -111,13 +111,8 @@ int position_wrapper(const struct dt_lib_module_t *self)
   const dt_view_t *cur_view = dt_view_manager_get_current_view(darktable.view_manager);
   lua_lib_data_t *gui_data = self->data;
   position_description_t *position_description = get_position_description(gui_data, cur_view);
-  if(position_description) return position_description->position;
-  printf("ERROR in lualib, couldn't find a position for `%s', this should never happen\n", gui_data->name);
-  /*
-     No position found. This can happen if we are called while current view is not one
-     of our views. just return 0
-     */
-  return 0;
+  // If current view is not one of our views, just return 0
+  return position_description ? position_description->position : 0;
 }
 
 static int async_lib_call(lua_State * L)

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2878,6 +2878,7 @@ void leave(dt_view_t *self)
   }
 
   GtkWidget *box = GTK_WIDGET(dt_ui_get_container(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER));
+  gtk_container_foreach(GTK_CONTAINER(box), (GtkCallback)gtk_widget_destroy, NULL);
   GtkScrolledWindow *sw = GTK_SCROLLED_WINDOW(gtk_widget_get_ancestor(box, GTK_TYPE_SCROLLED_WINDOW));
   if(sw) gtk_scrolled_window_set_propagate_natural_width(sw, TRUE);
 


### PR DESCRIPTION
- Allow showing navigation/histogram in darkroom when entered with them hidden
- remove warnings "ERROR in lualib, couldn't find a position"
- fix drag&drop for iop reordering (please test!)
- fix crash when dropping a lib (from left panel) on iop (in right panel)
- make sure all iop guis are destroyed when leaving the darkroom (I have a suspicion that they were leaked before, but haven't verified).