### PR TITLE
bugfix: avoid DR crash by making history pastes on up to 3 images synchronous

### DIFF
--- a/src/control/jobs.c
+++ b/src/control/jobs.c
@@ -403,13 +403,13 @@ gboolean dt_control_add_job(dt_control_t *control,
                             dt_job_queue_t queue_id,
                             _dt_job_t *job)
 {
-  if(((unsigned int)queue_id) >= DT_JOB_QUEUE_MAX || !job)
+  if((((unsigned int)queue_id) >= DT_JOB_QUEUE_MAX && queue_id != DT_JOB_QUEUE_SYNCHRONOUS) || !job)
   {
     dt_control_job_dispose(job);
     return TRUE;
   }
 
-  if(!control->running)
+  if(!control->running || queue_id == DT_JOB_QUEUE_SYNCHRONOUS)
   {
     // whatever we are adding here won't be scheduled as the system isn't running. execute it synchronous instead.
     dt_pthread_mutex_lock(&job->wait_mutex); // is that even needed?

--- a/src/control/jobs.h
+++ b/src/control/jobs.h
@@ -48,7 +48,8 @@ typedef enum dt_job_queue_t
   DT_JOB_QUEUE_USER_BG = 2,     // imports, ...
   DT_JOB_QUEUE_USER_EXPORT = 3, // exports. only one of these jobs will ever be scheduled at a time
   DT_JOB_QUEUE_SYSTEM_BG = 4,   // some lua stuff that may not be pushed out of the queue, ...
-  DT_JOB_QUEUE_MAX = 5
+  DT_JOB_QUEUE_MAX = 5,
+  DT_JOB_QUEUE_SYNCHRONOUS = 1000 // don't queue, run immeidately and don't return until done
 } dt_job_queue_t;
 
 typedef struct _dt_job_t dt_job_t;

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -2186,7 +2186,8 @@ void dt_control_paste_history(GList *imgs)
     g_list_free(imgs);
     return;
   }
-  dt_control_add_job(darktable.control, DT_JOB_QUEUE_USER_FG, 
+  dt_job_queue_t queue = g_list_shorter_than(imgs,4) ? DT_JOB_QUEUE_SYNCHRONOUS : DT_JOB_QUEUE_USER_FG;
+  dt_control_add_job(darktable.control, queue,
                      dt_control_generic_images_job_create(&_control_paste_history_job_run,
                                                           N_("paste history"), 0,
                                                           imgs, PROGRESS_BLOCKING, FALSE));
@@ -2207,7 +2208,8 @@ void dt_control_paste_parts_history(GList *imgs)
 
   if(res == GTK_RESPONSE_OK)
   {
-    dt_control_add_job(darktable.control, DT_JOB_QUEUE_USER_FG,
+    dt_job_queue_t queue = g_list_shorter_than(imgs,4) ? DT_JOB_QUEUE_SYNCHRONOUS : DT_JOB_QUEUE_USER_FG;
+    dt_control_add_job(darktable.control, queue,
                        dt_control_generic_images_job_create(&_control_paste_history_job_run,
                                                             N_("paste history"), 0,
                                                             imgs, PROGRESS_BLOCKING, FALSE));


### PR DESCRIPTION
Fixes #17452.  (Or at least works around whatever race condition is corrupting things.)

