### PR TITLE
in darkroom don't allow dragging libs to right or iops to left

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2222,6 +2222,8 @@ static gboolean _on_drag_motion_drop(GtkWidget *widget, GdkDragContext *dc, gint
     if(gtk_widget_get_visible(GTK_WIDGET(m->data))) last = m->data;
   if(last)
     g_signal_emit_by_name(last, "drag-motion", dc, drop ? -1 : x, y, time, &ret);
+  else if(dt_view_get_current() == DT_VIEW_DARKROOM)
+    gdk_drag_status(dc, 0, time); // don't allow dropping in empty panel on other side
   else if(drop)
   {
     // drop in empty panel; dragged expander handles its own move; pass destination panel in dc

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -1320,7 +1320,8 @@ GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module)
 void dt_lib_gui_set_label(dt_lib_module_t *module,
                           const char *label)
 {
-  gtk_label_set_text(GTK_LABEL(module->label), label);
+  if(module->expander)
+    gtk_label_set_text(GTK_LABEL(module->label), label);
 }
 
 static void _preferences_changed(gpointer instance, gpointer self)


### PR DESCRIPTION
When a lib's header is dragged into an empty panel, it is responsible for moving itself there. It would happily put itself in the right panel in the darkroom if it is empty (for example because the search box has nonsense in it), but then crash on switching to lighttable. Similarly, when an iop is dragged into an empty panel it cannot be the right one (because that's where you're dragging it from, so it isn't empty), so it is the left one and the drop must be blocked. Before this fix, the cursor would indicate that a drop is allowed and actually dropping an iop on the left side would generate a bunch of Gtk-CRITICALS.

Also, since it is now possible to hide the iop-order module (bottom right), first check that there actually is an expander before trying to set its second label.