### PR TITLE
[GUI] Correct wording (use future instead of present tense)

### DIFF
--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -275,7 +275,7 @@ static void _reset_panels_clicked(GtkButton *button, gpointer user_data)
 {
   if(!dt_gui_show_yes_no_dialog(_("reset panels in all views"),
                                 _("are you sure?\n\n"
-                                  "you cannot restore your current panel layout and module selection.")))
+                                  "you will not be able to restore your current panel layout and module selection.")))
     return;
 
   g_hash_table_foreach_remove(darktable.conf->table, _remove_panel_config, NULL);


### PR DESCRIPTION
We warn the user about the impossibility of undoing the panel reset. Therefore, we have to use the future tense (we are talking about the situation after the reset, this is the future). The use of the present tense here is not correct and may confuse the user.