### PR TITLE
Place logdir under user's `Documents` folder on Windows

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -44,7 +44,8 @@ int main(int argc, char *argv[])
   char datetime[DT_DATETIME_EXIF_LENGTH];
   dt_datetime_now_to_exif(datetime);
 
-  // make sure to not redirect output when the output is already being redirected, either to a file or a pipe.
+  // Make sure to not redirect output when the output is already
+  // being redirected, either to a file or a pipe.
   int out_type = GetFileType(GetStdHandle(STD_OUTPUT_HANDLE));
   int err_type = GetFileType(GetStdHandle(STD_ERROR_HANDLE));
   gboolean redirect_output = ((out_type != FILE_TYPE_DISK && out_type != FILE_TYPE_PIPE) &&
@@ -53,7 +54,10 @@ int main(int argc, char *argv[])
   for(int k = 1; k < argc; k++)
   {
     // For simple arguments do not redirect stdout
-    if(!strcmp(argv[k], "--help") || !strcmp(argv[k], "-h") || !strcmp(argv[k], "/?") || !strcmp(argv[k], "--version"))
+    if(!strcmp(argv[k], "--help") ||
+       !strcmp(argv[k], "-h") ||
+       !strcmp(argv[k], "/?") ||
+       !strcmp(argv[k], "--version"))
     {
       redirect_output = FALSE;
       break;
@@ -70,17 +74,21 @@ int main(int argc, char *argv[])
     g_freopen(logfile, "a", stdout);
     dup2(fileno(stdout), fileno(stderr));
 
-    // We don't need the console window anymore, free it
-    // This ensures that only darktable's main window will be visible
+    // We don't need the console window anymore, free it.
+    // This ensures that only darktable's main window will be visible.
     FreeConsole();
 
     g_free(logdir);
     g_free(logfile);
 
-    // don't buffer stdout/stderr. we have basically two options: unbuffered or line buffered.
-    // unbuffered keeps the order in which things are printed but concurrent threads printing can lead to intermangled output. ugly.
-    // line buffered should keep lines together but in my tests the order of things no longer matches. ugly and potentially confusing.
-    // thus we are doing the thing that is just ugly (in rare cases) but at least not confusing.
+    // Don't buffer stdout/stderr. We have basically two options:
+    // unbuffered or line buffered.
+    // Unbuffered keeps the order in which things are printed but concurrent
+    // threads printing can lead to intermangled output. Ugly.
+    // Line buffered should keep lines together but the order of things
+    // no longer matches. Ugly and potentially confusing.
+    // Thus we are doing the thing that is just ugly (in rare cases)
+    // but at least not confusing.
     setvbuf(stdout, NULL, _IONBF, 0);
     setvbuf(stderr, NULL, _IONBF, 0);
 
@@ -90,7 +98,8 @@ int main(int argc, char *argv[])
     printf("\n");
   }
 
-  // make sure GTK client side decoration is disabled, otherwise windows resizing issues can be observed
+  // Make sure GTK client side decoration is disabled,
+  // otherwise windows resizing issues can be observed.
   g_setenv("GTK_CSD", "0", TRUE);
 #endif
 
@@ -151,4 +160,3 @@ int main(int argc, char *argv[])
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2009-2020 darktable developers.
+    Copyright (C) 2009-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "common/darktable.h"
 #include "common/image.h"
 #include "develop/develop.h"
@@ -61,8 +62,7 @@ int main(int argc, char *argv[])
 
   if(redirect_output)
   {
-    // something like C:\Users\username\AppData\Local\Microsoft\Windows\Temporary Internet Files\darktable\darktable-log.txt
-    char *logdir = g_build_filename(g_get_user_cache_dir(), "darktable", NULL);
+    char *logdir = g_build_filename(g_get_home_dir(), "Documents", "Darktable", NULL);
     char *logfile = g_build_filename(logdir, "darktable-log.txt", NULL);
 
     g_mkdir_with_parents(logdir, 0700);


### PR DESCRIPTION
Rationale of this change is in https://github.com/darktable-org/darktable/pull/17141#issuecomment-2278720889.

I copy the relevant text to the following paragraphs.

**Existing problems:**

- The log is somewhere deep in the tree of the apps working directories (AppData), where the user never looks, so it is impossible to come across it without knowing the exact location
- The log file is located under a directory that is hidden, so with the default system settings, it cannot be accessed by navigating in File Explorer. It is necessary to either teach the user to change the Windows setting to "show hidden files", or explain that the path they were told must be entered in the address field.

**The following is proposed as a solution:**

- Placing the log in a more visible and easily accessible location, for example under the Documents directory.

This PR implements the proposed solution.

I was considering putting the logging directory one level up, ie in `%USERPROFILE%` instead of `%USERPROFILE%\Documents`.
However, I don't think it will be any better. Standard user profile folders (such as `Desktop`, `Documents`, `Pictures` etc) are directly accessible in File Explorer, while going to `%USERPROFILE%` requires more clicks.

Also, for example, Adobe creates a folder of the same name in Documents. DxO PhotoLab also places folder for log files there.

Regarding folder name capitalization. We already have default import session base directory as `$(PICTURES_FOLDER)/Darktable`. So the folder for log files is also named `Darktable` with capital first letter for consistency.
