### PR TITLE
[maintenance] Remove unused functions from win/rlimit.c

### DIFF
--- a/src/win/rlimit.c
+++ b/src/win/rlimit.c
@@ -102,49 +102,6 @@ int setrlimit(int resource, const struct rlimit *rlp)
   return 0;  // success
 }
 
-// Wrap the real fwrite() with this rfwrite() function, which is
-// resource limit aware.
-//
-size_t rfwrite(const void *buffer, size_t size, size_t count, FILE *stream)
-{
-  // Convert the count to a large integer (64 bit integer)
-  const __int64 liByteCount = (__int64)count;
-
-  // Get the current file position
-  const __int64 liPosition = (__int64)ftell(stream);
-
-  // Check to make sure the write will not exceed the RLIMIT_FSIZE limit.
-  if(liPosition + liByteCount > rlimits[RLIMIT_FSIZE].rlim_cur)
-  {
-    // Report an error
-    return 0;
-  }
-  // Do the actual write the user requested
-  return fwrite(buffer, size, count, stream);
-}
-
-// Wrap the real _write() function with the _rwrite() function
-// which is resource aware.
-//
-int _rwrite(int handle, const void *buffer, unsigned int count)
-{
-  // Convert the count to a large integer
-  const int64_t liByteCount = (__int64)count;
-
-  // Get the Current file position
-  const int64_t liPosition = (__int64)_tell(handle);
-
-  // Check to make sure the write will not exceed the RLIMIT_FSIZE limit
-  if(liPosition + liByteCount > rlimits[RLIMIT_FSIZE].rlim_cur)
-  {
-    // Report an error
-    return 0;
-  }
-
-  // Do the actual write the user requested
-  return _write(handle, buffer, count);
-}
-
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/win/rlimit.h
+++ b/src/win/rlimit.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2017-2020 darktable developers.
+    Copyright (C) 2017-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -51,12 +51,8 @@ typedef struct rlimit rlimit_t;
 int getrlimit(int resource, struct rlimit *);
 int setrlimit(int resource, const struct rlimit *);
 
-size_t rfwrite(const void *buffer, size_t size, size_t count, FILE *stream);
-int _rwrite(int handle, const void *buffer, unsigned int count);
-
 // clang-format off
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.py
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
 // clang-format on
-

--- a/src/win/rlimit.h
+++ b/src/win/rlimit.h
@@ -20,34 +20,25 @@
 
 #include <stdio.h>
 
-#define RLIMIT_CPU 0    /* limit on CPU time per process */
-#define RLIMIT_FSIZE 1  /* limit on file size */
-#define RLIMIT_DATA 2   /* limit on data segment size */
-#define RLIMIT_STACK 3  /* limit on process stack size */
-#define RLIMIT_CORE 4   /* limit on size of core dump file */
-#define RLIMIT_NOFILE 5 /* limit on number of open files */
-#define RLIMIT_AS 6     /* limit on process total address space size */
+#define RLIMIT_CPU 0         // limit on CPU time per process
+#define RLIMIT_FSIZE 1       // limit on file size
+#define RLIMIT_DATA 2        // limit on data segment size
+#define RLIMIT_STACK 3       // limit on process stack size
+#define RLIMIT_CORE 4        // limit on size of core dump file
+#define RLIMIT_NOFILE 5      // limit on number of open files
+#define RLIMIT_AS 6          // limit on process total address space size
 #define RLIMIT_VMEM RLIMIT_AS
 #define RLIM_NLIMITS 7
 #define RLIM_INFINITY (~0UL)
 
-/*
- * process resource limits definitions
- */
-
 struct rlimit
 {
-  //        LARGE_INTEGER  rlim_cur;
-  //        LARGE_INTEGER  rlim_max;
-  __int64 rlim_cur;
-  __int64 rlim_max;
+  __int64 rlim_cur;  // current (soft) limit
+  __int64 rlim_max;  // maximum value for rlim_cur (hard limit)
 };
 
 typedef struct rlimit rlimit_t;
 
-/*
- * Prototypes
- */
 int getrlimit(int resource, struct rlimit *);
 int setrlimit(int resource, const struct rlimit *);
 


### PR DESCRIPTION
As it turned out, the win/rlimit.c code was copied from a sample implementation on Microsoft Learn site. The removed functions were there, but they are not used in any way in the darktable code.

As for the type of the rlimit structure members, in most implementations they are unsigned (which is logical, because negative limit values ​​are meaningless). However, changing the signed type from the Microsoft code will not bring us any practical improvement, so I left it as is.