### PR TITLE
[CI/CD] Remove `azure` mirror avoidance

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,8 +36,6 @@ jobs:
     steps:
       - name: Install compiler ${{ matrix.compiler.compiler }}
         run: |
-          # Remove azure mirror because it is unreliable and sometimes unpredictably leads to failed CI
-          sudo sed -i 's/azure\.//' /etc/apt/sources.list
           sudo apt-get update
           sudo apt-get -y install \
             ${{ matrix.compiler.packages }}


### PR DESCRIPTION
Ubuntu azure mirror removal has not worked for some time now, as the apt configuration in the runner image has now changed and this mirror is now listed in `/etc/apt/apt-mirrors.txt` instead of `/etc/apt/sources.list`. As a result, we actually worked with the azure mirror. So far azure doesn't fail, so I'll just remove this hack for now (I can quickly fix it and bring it back if needed).