### PR TITLE
Color equalizer OpenCL bugfixes

### DIFF
--- a/data/kernels/channelmixer.cl
+++ b/data/kernels/channelmixer.cl
@@ -41,7 +41,6 @@ typedef enum dt_adaptation_t
 #define INVERSE_SQRT_3 0.5773502691896258f
 #define TRUE 1
 #define FALSE 0
-#define NORM_MIN 1e-6f
 
 static inline float sqf(const float x)
 {

--- a/data/kernels/colorspace.h
+++ b/data/kernels/colorspace.h
@@ -804,9 +804,9 @@ static inline float dt_UCS_L_star_to_Y(const float L_star)
 
 static inline float2 xyY_to_dt_UCS_UV(const float4 xyY)
 {
-  float4 x_factors = { -0.783941002840055f,  0.745273540913283f, 0.318707282433486f, 0.f };
-  float4 y_factors = {  0.277512987809202f, -0.205375866083878f, 2.16743692732158f,  0.f };
-  float4 offsets   = {  0.153836578598858f, -0.165478376301988f, 0.291320554395942f, 0.f };
+  const float4 x_factors = { -0.783941002840055f,  0.745273540913283f, 0.318707282433486f, 0.f };
+  const float4 y_factors = {  0.277512987809202f, -0.205375866083878f, 2.16743692732158f,  0.f };
+  const float4 offsets   = {  0.153836578598858f, -0.165478376301988f, 0.291320554395942f, 0.f };
 
   float4 UVD = x_factors * xyY.x + y_factors * xyY.y + offsets;
   const float div = (UVD.z >= 0.0f) ? fmax(FLT_MIN, UVD.z) : fmin(-FLT_MIN, UVD.z);
@@ -817,10 +817,8 @@ static inline float2 xyY_to_dt_UCS_UV(const float4 xyY)
   const float2 UV_star =     { factors.x * UVD.x / (fabs(UVD.x) + half_values.x),
                                factors.y * UVD.y / (fabs(UVD.y) + half_values.y) };
   // The following is equivalent to a 2D matrix product
-
-  const float2 UV_star_prime =  { -1.124983854323892f * UV_star.x - 0.980483721769325f * UV_star.y,
-                                   1.86323315098672f  * UV_star.x + 1.971853092390862f * UV_star.y };
-  return UV_star_prime;
+  return (float2)( -1.124983854323892f * UV_star.x - 0.980483721769325f * UV_star.y,
+                    1.86323315098672f  * UV_star.x + 1.971853092390862f * UV_star.y);
 }
 
 static inline float4 xyY_to_dt_UCS_JCH(const float4 xyY, const float L_white)
@@ -841,11 +839,10 @@ static inline float4 xyY_to_dt_UCS_JCH(const float4 xyY, const float L_white)
   const float M2 = UV_star_prime.x * UV_star_prime.x + UV_star_prime.y * UV_star_prime.y; // square of colorfulness M
 
   // should be JCH[0] = powf(L_star / L_white), cz) but we treat only the case where cz = 1
-  const float4 JCH = {  L_star / L_white,
-                        15.932993652962535f * dtcl_pow(L_star, 0.6523997524738018f) * dtcl_pow(M2, 0.6007557017508491f) / L_white,
-                        atan2(UV_star_prime.y, UV_star_prime.x),
-                        0.0f };
-  return JCH;
+  return (float4)(L_star / L_white,
+                  15.932993652962535f * dtcl_pow(L_star, 0.6523997524738018f) * dtcl_pow(M2, 0.6007557017508491f) / L_white,
+                  atan2(UV_star_prime.y, UV_star_prime.x),
+                  0.0f);
 }
 
 static inline float4 dt_UCS_JCH_to_xyY(const float4 JCH, const float L_white)
@@ -889,8 +886,7 @@ static inline float4 dt_UCS_JCH_to_xyY(const float4 JCH, const float L_white)
   const float4 xyD = U_factors * UV.x + V_factors * UV.y + offsets;
 
   const float div = (xyD.z >= 0.0f) ? fmax(FLT_MIN, xyD.z) : fmin(-FLT_MIN, xyD.z);
-  const float4 xyY = { xyD.x / div, xyD.y / div, dt_UCS_L_star_to_Y(L_star), 0.0f };
-  return xyY;
+  return (float4)( xyD.x / div, xyD.y / div, dt_UCS_L_star_to_Y(L_star), 0.0f);
 }
 
 
@@ -937,19 +933,17 @@ static inline float4 dt_UCS_HSB_to_XYZ(const float4 HSB, const float L_w)
 {
   const float4 JCH = dt_UCS_HSB_to_JCH(HSB);
   const float4 xyY = dt_UCS_JCH_to_xyY(JCH, L_w);
-  const float4 XYZ = dt_xyY_to_XYZ(xyY);
-  return XYZ;
+  return dt_xyY_to_XYZ(xyY);
 }
 
 static inline float4 dt_UCS_LUV_to_JCH(const float L_star, const float L_white, const float2 UV_star_prime)
 {
   const float M2 = UV_star_prime.x * UV_star_prime.x + UV_star_prime.y * UV_star_prime.y; // square of colorfulness M
-  const float4 JCH = {  L_star / L_white,
-                        15.932993652962535f * dtcl_pow(L_star, 0.6523997524738018f) * dtcl_pow(M2, 0.6007557017508491f) / L_white,
-                        atan2(UV_star_prime.y, UV_star_prime.x),
-                        0.0f };
-  return JCH;
- }
+  return (float4)(L_star / L_white,
+                  15.932993652962535f * dtcl_pow(L_star, 0.6523997524738018f) * dtcl_pow(M2, 0.6007557017508491f) / L_white,
+                  atan2(UV_star_prime.y, UV_star_prime.x),
+                  0.0f);
+}
 
 static inline float soft_clip(const float x, const float soft_threshold, const float hard_threshold)
 {

--- a/data/kernels/common.h
+++ b/data/kernels/common.h
@@ -17,6 +17,8 @@
 */
 
 #pragma once
+#define NORM_MIN 1.52587890625e-05f // norm can't be < to 2^(-16)
+
 
 constant sampler_t sampleri =  CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
 

--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -291,9 +291,6 @@ static inline float filmic_spline(const float x,
   return result;
 }
 
-#define NORM_MIN 1.52587890625e-05f // norm can't be < to 2^(-16)
-
-
 static inline float log_tonemapping_v1(const float x,
                                        const float grey, const float black,
                                        const float dynamic_range)


### PR DESCRIPTION
**Color equalizer OpenCL bugfixes, checks and maintenance**

1. The OpenCL path for _guide_with_chromaticity_cl() was broken due to missing checks for kernel
   error conditions so the error was not reported back.
2. We passed size_t arguments to the kernel instead of int
3. A subtle error in scharr operator has been fixed
4. More allocation errors are correctly checked now
5. errors in the guiding filter subroutines are reported back and checked
6. Some code maintenance for reduced register pressure

Fixes #17448

**Subtle corrections for NORM_MIN**

This is used all over and should be the same for OpenCL and CPU code for all modules.
It's now OpenCL-public via kernels/common.h
