### PR TITLE
Lighttable default overlay text and darkroom information line improvements

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1355,7 +1355,7 @@
   <dtconfig prefs="lighttable" section="thumbs">
     <name>plugins/lighttable/extended_pattern</name>
     <type>longstring</type>
-    <default>$(FILE_NAME).$(FILE_EXTENSION)$(NL)$(EXIF_EXPOSURE) • f/$(EXIF_APERTURE) • $(EXIF_FOCAL_LENGTH)mm • $(EXIF_ISO) ISO $(SIDECAR_TXT)</default>
+    <default>$(EXIF.MODEL) $(EXIF.LENS)$(NL)$(FILE_NAME).$(FILE_EXTENSION) • &lt;b&gt;$(EXIF_EXPOSURE)&lt;/b&gt;s f/&lt;b&gt;$(EXIF_APERTURE)&lt;/b&gt; &lt;b&gt;$(EXIF_FOCAL_LENGTH)&lt;/b&gt;mm ISO&lt;b&gt;$(EXIF_ISO)&lt;/b&gt; $(SIDECAR_TXT)</default>
     <shortdescription>pattern for the thumbnail extended overlay text</shortdescription>
     <longdescription>see manual to know all the tags you can use.</longdescription>
   </dtconfig>
@@ -1424,7 +1424,7 @@
   <dtconfig prefs="darkroom" section="general">
     <name>plugins/darkroom/image_infos_pattern</name>
     <type>longstring</type>
-    <default>$(EXIF_EXPOSURE) • f/$(EXIF_APERTURE) • $(EXIF_FOCAL_LENGTH) mm • $(EXIF_ISO) ISO</default>
+    <default>$(EXIF.MAKER) &lt;b&gt;$(EXIF.MODEL) $(EXIF.LENS)&lt;/b&gt; • $(FILE_NAME).$(FILE_EXTENSION) • &lt;b&gt;$(EXIF_EXPOSURE)&lt;/b&gt;s &lt;b&gt;$(EXIF_FOCAL_LENGTH)&lt;/b&gt;mm f/&lt;b&gt;$(EXIF_APERTURE)&lt;/b&gt; ISO&lt;b&gt;$(EXIF_ISO)&lt;/b&gt;</default>
     <shortdescription>pattern for the image information line</shortdescription>
     <longdescription>see manual for a list of the tags you can use.</longdescription>
   </dtconfig>


### PR DESCRIPTION
The default lighttable extended overlay texts and darkroom information lines show only the basic exposure parameters and file name, but there is typically room for some more text. This pull request adds some more information and formats the information that is there a bit more nicely.

In particular, it adds information about the camera and lens used, and uses a bold font for the exposure parameters. It also adds a unit to the shutter speed, to make it more easily distinguishable from the other values. And it removes the center dot between the exposure parameters to save space. Thanks to the bold font, there is enough structure to the text to remain legible.

| Original | Improved |
| -------- | -------- |
| <img width="296" alt="Screenshot 2024-09-22 at 10 35 49" src="https://github.com/user-attachments/assets/096babd7-e83b-4202-a729-6d50cdb13b56"> | <img width="294" alt="Screenshot 2024-09-22 at 10 22 49" src="https://github.com/user-attachments/assets/373567a8-f5f2-4b28-a766-fa087e7d1f9c"> |
| <img width="212" alt="Screenshot 2024-09-22 at 10 26 54" src="https://github.com/user-attachments/assets/054f98d7-a483-4ec5-8e43-0f6ebd4885c9"> | <img width="561" alt="Screenshot 2024-09-22 at 10 22 59" src="https://github.com/user-attachments/assets/4719df91-5362-4e31-908a-9b6949f878cf"> |

(no idea why the left thumbnail is smaller than the right. The images are the same size.)