### PR TITLE
Fix uninitialized data and memory leaks

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1545,12 +1545,6 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   // init darktable tags table
   dt_set_darktable_tags();
 
-  // import default styles from shared directory
-  gchar *styledir = g_build_filename(sharedir, "darktable/styles", NULL);
-  if(styledir)
-    dt_import_default_styles(styledir);
-  g_free(styledir);
-
   // Initialize the signal system
   darktable.signals = dt_control_signal_init();
 
@@ -1575,6 +1569,12 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     dt_pthread_mutex_init(&darktable.control->run_mutex, NULL);
     dt_pthread_mutex_init(&darktable.control->log_mutex, NULL);
   }
+
+  // import default styles from shared directory
+  gchar *styledir = g_build_filename(sharedir, "darktable/styles", NULL);
+  if(styledir)
+    dt_import_default_styles(styledir);
+  g_free(styledir);
 
   // we initialize grouping early because it's needed for collection init
   // idem for folder reachability

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -2108,6 +2108,7 @@ void dt_image_init(dt_image_t *img)
   memset(img->exif_flash, 0, sizeof(img->exif_flash));
   memset(img->exif_exposure_program, 0, sizeof(img->exif_exposure_program));
   memset(img->exif_metering_mode, 0, sizeof(img->exif_metering_mode));
+  memset(&img->exif_datetime_taken, 0, sizeof(img->exif_datetime_taken));
   memset(img->camera_maker, 0, sizeof(img->camera_maker));
   memset(img->camera_model, 0, sizeof(img->camera_model));
   memset(img->camera_alias, 0, sizeof(img->camera_alias));

--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -33,7 +33,7 @@ static void _image_cache_allocate(void *data,
 {
   entry->cost = sizeof(dt_image_t);
 
-  dt_image_t *img = (dt_image_t *)g_malloc(sizeof(dt_image_t));
+  dt_image_t *img = (dt_image_t *)g_malloc0(sizeof(dt_image_t));
   dt_image_init(img);
   entry->data = img;
   // load stuff from db and store in cache:

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -868,6 +868,11 @@ GList *dt_ioppr_get_iop_order_list_version(const dt_iop_order_t version)
   return iop_order_list;
 }
 
+void dt_ioppr_iop_order_list_free(GList *iop_order_list)
+{
+  g_list_free_full(iop_order_list, free);
+}
+
 gboolean dt_ioppr_has_iop_order_list(const dt_imgid_t imgid)
 {
   gboolean result = FALSE;
@@ -2400,7 +2405,9 @@ char *dt_ioppr_serialize_text_iop_order_list(GList *iop_order_list)
     gchar buf[64];
     snprintf(buf, sizeof(buf), "%s,%d%s",
              entry->operation, entry->instance, (l == last) ? "" : ",");
-    text = g_strconcat(text, buf, NULL);
+    gchar *prev_text = text;
+    text = g_strconcat(prev_text, buf, NULL);
+    g_free(prev_text);
   }
 
   return text;

--- a/src/common/iop_order.h
+++ b/src/common/iop_order.h
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2018-2023 darktable developers.
+    Copyright (C) 2018-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by
@@ -179,6 +179,10 @@ GList *dt_ioppr_get_iop_order_list(const dt_imgid_t imgid,
 /** return the iop-order list for the given version, this is used to
  * get the built-in lists */
 GList *dt_ioppr_get_iop_order_list_version(dt_iop_order_t version);
+
+/** free iop-order list returned by above functions */
+void dt_ioppr_iop_order_list_free(GList *iop_order_list);
+
 /** returns the dt_iop_order_entry_t of iop_order_list with operation = op_name */
 dt_iop_order_entry_t *dt_ioppr_get_iop_order_entry(GList *iop_order_list,
                                                    const char *op_name,

--- a/src/common/wb_presets.c
+++ b/src/common/wb_presets.c
@@ -1,4 +1,22 @@
 /*
+    This file is part of darktable,
+    Copyright (C) 2013-2024 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
  * UFRaw - Unidentified Flying Raw converter for digital camera images
  *
  * wb_presets.c - White balance preset values for various cameras
@@ -284,6 +302,7 @@ void dt_wb_presets_init(const char *alternative)
            wb_presets_count);
 
 end:
+  if(parser) g_object_unref(parser);
   if(reader) g_object_unref(reader);
   if(!valid) exit(1);
   return;

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1437,7 +1437,7 @@ static void process_wavelets(struct dt_iop_module_t *self,
   float *restrict precond = NULL;
   float *restrict tmp = NULL;
 
-  if(!dt_iop_alloc_image_buffers(self, roi_in, roi_out, 4, &precond, 4, &tmp, 4, &buf, 0))
+  if(!dt_iop_alloc_image_buffers(self, roi_in, roi_out, 4, &precond, 4, &tmp, 4, &buf, 0, NULL))
   {
     dt_iop_copy_image_roi(out, in, piece->colors, roi_in, roi_out);
     return;

--- a/src/libs/ioporder.c
+++ b/src/libs/ioporder.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2019-2023 darktable developers.
+    Copyright (C) 2019-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -196,12 +196,15 @@ void init_presets(dt_lib_module_t *self)
                      (const char *)params, (int32_t)size, TRUE,
                      is_display_referred ? FOR_RAW | FOR_LDR : 0);
   free(params);
+  dt_ioppr_iop_order_list_free(list);
 
   list = dt_ioppr_get_iop_order_list_version(DT_IOP_ORDER_V30);
   params = dt_ioppr_serialize_iop_order_list(list, &size);
   dt_lib_presets_add(_("v3.0 for RAW input (default)"), self->plugin_name, self->version(),
                      (const char *)params, (int32_t)size, TRUE,
                      is_display_referred ? 0 : FOR_RAW | FOR_MATRIX);
+  free(params);
+  dt_ioppr_iop_order_list_free(list);
 
   list = dt_ioppr_get_iop_order_list_version(DT_IOP_ORDER_V30_JPG);
   params = dt_ioppr_serialize_iop_order_list(list, &size);
@@ -209,6 +212,7 @@ void init_presets(dt_lib_module_t *self)
                      (const char *)params, (int32_t)size, TRUE,
                      is_display_referred ? 0 : FOR_LDR | FOR_NOT_MONO);
   free(params);
+  dt_ioppr_iop_order_list_free(list);
 }
 
 int set_params(dt_lib_module_t *self, const void *params, int size)


### PR DESCRIPTION
The first commit fixes the crash reported by zisoft https://github.com/darktable-org/darktable/issues/17377#issuecomment-2366142572  It doesn't fix my need to reset the collection filters module to actually see the images imported on first run with a fresh config directory.

The other commits fix stuff I found while running Valgrind to try to fix the above two items from #17377.
