### PR TITLE
Corrected docs for dt_imageio_module_format_t.write_image.

### DIFF
--- a/tools/lua_doc/content.lua
+++ b/tools/lua_doc/content.lua
@@ -668,7 +668,7 @@ darktable.debug.type:set_text([[Similar to the system function type() but it wil
 	types.dt_imageio_module_format_t.write_image:add_parameter("image",types.dt_lua_image_t,[[The image object to export.]])
 	types.dt_imageio_module_format_t.write_image:add_parameter("filename","string",[[The filename to export to.]])
 	types.dt_imageio_module_format_t.write_image:add_parameter("allow_upscale","boolean",[[Set to true to allow upscaling of the image.]]):set_attribute("optional",true)
-	types.dt_imageio_module_format_t.write_image:add_return("boolean",[[Returns true on success.]])
+	types.dt_imageio_module_format_t.write_image:add_return("boolean",[[Returns false on success.]])
 
 	types.dt_imageio_module_format_data_png:set_text([[Type object describing parameters to export to png.]])
 	types.dt_imageio_module_format_data_png.bpp:set_text([[The bpp parameter to use when exporting.]])


### PR DESCRIPTION
`write_image` returns TRUE on error, and FALSE on success.

https://github.com/darktable-org/darktable/blob/a9a96278d095a68792ed86832ff2a39c21f9c591/src/lua/format.c#L167-L170

https://github.com/darktable-org/darktable/blob/a9a96278d095a68792ed86832ff2a39c21f9c591/src/imageio/imageio.c#L1244-L1256
