### PR TITLE
fix dt_imageio_export_with_flags return values

### DIFF
--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1243,7 +1243,7 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
 
   if(!thumbnail_export)
     dt_set_backthumb_time(5.0);
-  return FALSE; // success
+  return TRUE; // success
 
 error:
   dt_dev_pixelpipe_cleanup(&pipe);
@@ -1253,7 +1253,7 @@ error_early:
 
   if(!thumbnail_export)
     dt_set_backthumb_time(5.0);
-  return TRUE;
+  return FALSE;
 }
 
 

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -468,10 +468,10 @@ try_again:
   if(fail) return 1;
 
   /* export image to file */
-  if(dt_imageio_export(imgid, filename, format, fdata, high_quality,
+  if(!dt_imageio_export(imgid, filename, format, fdata, high_quality,
                        upscale, TRUE, export_masks, icc_type,
                        icc_filename, icc_intent, self, sdata,
-                       num, total, metadata) != 0)
+                       num, total, metadata))
   {
     dt_print(DT_DEBUG_ALWAYS,
              "[imageio_storage_disk] could not export to file: `%s'!\n",

--- a/src/imageio/storage/email.c
+++ b/src/imageio/storage/email.c
@@ -176,9 +176,9 @@ int store(dt_imageio_module_storage_t *self,
 
   attachment->file = g_build_filename(tmpdir, dirname, (char *)NULL);
 
-  if(dt_imageio_export(imgid, attachment->file, format, fdata, high_quality,
+  if(!dt_imageio_export(imgid, attachment->file, format, fdata, high_quality,
                        upscale, TRUE, export_masks, icc_type,
-                       icc_filename, icc_intent, self, sdata, num, total, metadata) != 0)
+                       icc_filename, icc_intent, self, sdata, num, total, metadata))
   {
     dt_print(DT_DEBUG_ALWAYS,
              "[imageio_storage_email] could not export to file: `%s'!\n",

--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -399,9 +399,9 @@ int store(dt_imageio_module_storage_t *self,
 
   // export image to file. need this to be able to access meaningful
   // fdata->width and height below.
-  if(dt_imageio_export(imgid, filename, format, fdata, high_quality,
+  if(!dt_imageio_export(imgid, filename, format, fdata, high_quality,
                        upscale, TRUE, export_masks, icc_type,
-                       icc_filename, icc_intent, self, sdata, num, total, metadata) != 0)
+                       icc_filename, icc_intent, self, sdata, num, total, metadata))
   {
     dt_print(DT_DEBUG_ALWAYS,
              "[imageio_storage_gallery] could not export to file: `%s'!\n", filename);
@@ -440,9 +440,9 @@ int store(dt_imageio_module_storage_t *self,
   if(c <= filename || *c == '/') c = filename + strlen(filename);
   ext = format->extension(fdata);
   sprintf(c, "-thumb.%s", ext);
-  if(dt_imageio_export(imgid, filename, format, fdata, FALSE, TRUE, FALSE,
+  if(!dt_imageio_export(imgid, filename, format, fdata, FALSE, TRUE, FALSE,
                        export_masks, icc_type, icc_filename,
-                       icc_intent, self, sdata, num, total, NULL) != 0)
+                       icc_intent, self, sdata, num, total, NULL))
   {
     dt_print(DT_DEBUG_ALWAYS,
              "[imageio_storage_gallery] could not export to file: `%s'!\n", filename);

--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -1348,9 +1348,9 @@ int store(dt_imageio_module_storage_t *self,
 
   dt_image_cache_read_release(darktable.image_cache, img);
 
-  if(dt_imageio_export(imgid, fname, format, fdata, high_quality, upscale,
+  if(!dt_imageio_export(imgid, fname, format, fdata, high_quality, upscale,
                        TRUE, export_masks, icc_type, icc_filename,
-                       icc_intent, self, sdata, num, total, metadata) != 0)
+                       icc_intent, self, sdata, num, total, metadata))
   {
     dt_print(DT_DEBUG_ALWAYS,
              "[imageio_storage_piwigo] could not export to file: `%s'!\n",

--- a/src/lua/luastorage.c
+++ b/src/lua/luastorage.c
@@ -111,8 +111,8 @@ static int store_wrapper(struct dt_imageio_module_storage_t *self,
 
   gchar *complete_name = g_build_filename(tmpdir, filename, (char *)NULL);
 
-  if(dt_imageio_export(imgid, complete_name, format, fdata, high_quality, upscale, TRUE, export_masks,
-                       icc_type, icc_filename, icc_intent, self, self_data, num, total, metadata) != 0)
+  if(!dt_imageio_export(imgid, complete_name, format, fdata, high_quality, upscale, TRUE, export_masks,
+                       icc_type, icc_filename, icc_intent, self, self_data, num, total, metadata))
   {
     dt_print(DT_DEBUG_ALWAYS,
              "[lua] %s: could not export to file `%s'!\n", self->name(self), complete_name);


### PR DESCRIPTION
Fixed dt_imageio_export_with_flags to return TRUE for success and FALSE for failure.  Since dt_imageio_export calls dt_imageio_export_with_flags and returns the return value, dt_imageio_export now has sane return values too.

Updated all the callers(that tested the return value)  of dt_imageio_export to actually use the boolean return values for testing rather than comparing to 0.

Fixes #17528.

Negates #17524.