### PR TITLE
[CI] GitHub messed up its debian-trixie container, we have to switch to debain-unstable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         eco: [-DDONT_USE_INTERNAL_LIBRAW=ON]
         include:
           # We want one run in CI to be Debug to make sure the Debug build isn't broken
-          - distro: "debian:trixie-slim"
+          - distro: "debian:unstable-slim"
             btype: Debug
             compiler: { compiler: GNU13, CC: gcc-13, CXX: g++-13, packages: gcc-13 g++-13 }
             target: skiptest


### PR DESCRIPTION
Out of the blue,  the error `E: Unable to locate package libgmic-dev` appeared in the `debian:trixie-slim `container. `debian-unstable-slim` is fine.