### PR TITLE
Rework deletion of custom places in import dialog

### DIFF
--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2011-2023 darktable developers.
+    Copyright (C) 2011-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -1331,14 +1331,6 @@ static gboolean _places_button_press(GtkWidget *view,
       _update_folders_list(self);
       _update_files_list(self);
     }
-    // right-click: delete / hide place (if not selected)
-    else if(button_pressed == 3)
-    {
-      if(g_strcmp0(folder_path, dt_conf_get_string_const("ui_last/import_last_place")))
-        _remove_place(folder_path, iter, self);
-      else
-        dt_toast_log(_("you can't delete the selected place"));
-    }
 
     g_free(folder_name);
     g_free(folder_path);
@@ -1477,7 +1469,7 @@ static void _set_places_list(GtkWidget *places_paned,
   GtkWidget *places_reset = dtgtk_button_new(dtgtk_cairo_paint_reset, 0, NULL);
   gtk_widget_set_tooltip_text
     (places_reset,
-     _("restore all default places you have removed by right-click"));
+     _("restore all default places you have removed"));
   g_signal_connect(places_reset, "clicked", G_CALLBACK(_places_reset_callback), self);
   gtk_box_pack_end(GTK_BOX(places_header), places_reset, FALSE, FALSE, 0);
 
@@ -1491,7 +1483,7 @@ static void _set_places_list(GtkWidget *places_paned,
   GtkWidget *places_add = dtgtk_button_new(dtgtk_cairo_paint_plus_simple, 0, NULL);
   gtk_widget_set_tooltip_text
     (places_add,
-     _("add a custom place\n\nright-click on a place to remove it"));
+     _("add a custom place"));
   g_signal_connect(places_add, "clicked", G_CALLBACK(_lib_import_select_folder), self);
   gtk_box_pack_end(GTK_BOX(places_header), places_add, FALSE, FALSE, 0);
 
@@ -1706,6 +1698,9 @@ static void _update_places_list(dt_lib_module_t* self)
   if(places)
     g_free(places->data);
   g_list_free(places);
+
+  _update_folders_list(self);
+  _update_files_list(self);
 }
 
 static void _update_folders_list(dt_lib_module_t* self)

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -167,6 +167,7 @@ typedef struct dt_lib_import_t
   GtkListStore *placesModel;
   GtkWidget *placesView;
   GtkTreeSelection *placesSelection;
+  GtkWidget *remove_place_button;
   GtkWidget *select_all;
   GtkWidget *select_new;
   GtkWidget *select_none;
@@ -1480,12 +1481,12 @@ static void _set_places_list(GtkWidget *places_paned,
   g_signal_connect(places_reset, "clicked", G_CALLBACK(_places_reset_callback), self);
   gtk_box_pack_end(GTK_BOX(places_header), places_reset, FALSE, FALSE, 0);
 
-  GtkWidget *places_remove = dtgtk_button_new(dtgtk_cairo_paint_minus_simple, 0, NULL);
+  d->remove_place_button = dtgtk_button_new(dtgtk_cairo_paint_minus_simple, 0, NULL);
   gtk_widget_set_tooltip_text
-    (places_remove,
+    (d->remove_place_button,
      _("remove the selected custom place"));
-  g_signal_connect(places_remove, "clicked", G_CALLBACK(_remove_selected_place), self);
-  gtk_box_pack_end(GTK_BOX(places_header), places_remove, FALSE, FALSE, 0);
+  g_signal_connect(d->remove_place_button, "clicked", G_CALLBACK(_remove_selected_place), self);
+  gtk_box_pack_end(GTK_BOX(places_header), d->remove_place_button, FALSE, FALSE, 0);
 
   GtkWidget *places_add = dtgtk_button_new(dtgtk_cairo_paint_plus_simple, 0, NULL);
   gtk_widget_set_tooltip_text
@@ -1719,6 +1720,7 @@ static void _update_folders_list(dt_lib_module_t* self)
   gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(model),
                                        GTK_TREE_SORTABLE_UNSORTED_SORT_COLUMN_ID,
                                        GTK_SORT_ASCENDING);
+  gtk_widget_set_sensitive(d->remove_place_button, last_place[0]);
   _get_folders_list(GTK_TREE_STORE(model), NULL, last_place, folder);
   gtk_tree_sortable_set_sort_column_id
     (GTK_TREE_SORTABLE(model), DT_FOLDER_PATH,


### PR DESCRIPTION
fixes #16525

The current step to delete a custom place in the import dialog is to right-click on a place. It will then be deleted without any further confirmation. However, if the place is currently selected it is not possible to delete, a toast indicates "you can’t delete the selected place". 

This is counter-intuitive for users used to first select an item to delete and then process the deletion.

This PR adds a remove button next to the add button in the top bar of the import dialog.
Select the place to delete and hit the button.

The right-click action to delete is removed.

![Bildschirmfoto 2024-09-27 um 15 52 31](https://github.com/user-attachments/assets/8082ea20-b116-46b6-979e-2ae70af969c6)
