### PR TITLE
Better name for the field for the final collection.

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1489,16 +1489,16 @@
     <name>session/base_directory_pattern</name>
     <type>string</type>
     <default>$(PICTURES_FOLDER)/Darktable</default>
-    <shortdescription>base directory naming pattern</shortdescription>
-    <longdescription>part of full import path for an import session</longdescription>
+    <shortdescription>base filmroll's directory</shortdescription>
+    <longdescription>directory where new imported filmrolls are created</longdescription>
   </dtconfig>
 
   <dtconfig prefs="import" section="session">
     <name>session/sub_directory_pattern</name>
     <type>string</type>
     <default>$(YEAR)$(MONTH)$(DAY)_$(JOBCODE)</default>
-    <shortdescription>sub directory naming pattern</shortdescription>
-    <longdescription>part of full import path for an import session</longdescription>
+    <shortdescription>filmroll name</shortdescription>
+    <longdescription>name of the imported filmroll</longdescription>
   </dtconfig>
 
   <dtconfig prefs="import" section="session">


### PR DESCRIPTION
In the naming rule of the copy & import dialog we have:

![image](https://github.com/user-attachments/assets/cb6dcdea-e880-4c39-a4ae-03cf8b9d7f85)

But the value for "sub directory naming pattern" is actually the name of the final collection. So I'm proposing to change the label:

base directory naming pattern -> **base collection's directory**
sub directory naming pattern -> **collection name**

![image](https://github.com/user-attachments/assets/0eeb908d-8e83-424b-97ff-d6cf4b10f339)

This seems more user friendly avoiding "pattern" and simplifying the strings.

 