### PR TITLE
Color equalizer maintenance

### DIFF
--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -328,23 +328,14 @@ static int _cl_box_mean(const int devid,
                         cl_mem out,
                         cl_mem temp)
 {
-  const int kernel_x = darktable.opencl->guided_filter->kernel_guided_filter_box_mean_x;
-  const int kernel_y = darktable.opencl->guided_filter->kernel_guided_filter_box_mean_y;
-
-  const size_t sizes_x[] = { ROUNDUPDHT(height, devid), 1, 1 };
-  const size_t sizes_y[] = { ROUNDUPDWD(width, devid), 1, 1 };
-
-  dt_opencl_set_kernel_args(devid, kernel_x, 0,
+  const cl_int err = dt_opencl_enqueue_kernel_1d_args(devid, darktable.opencl->guided_filter->kernel_guided_filter_box_mean_x, height,
                               CLARG(width), CLARG(height),
                               CLARG(in), CLARG(temp), CLARG(w));
-
-  const cl_int err = dt_opencl_enqueue_kernel_ndim_with_local(devid, kernel_x, sizes_x, NULL, 1);
   if(err != CL_SUCCESS) return err;
 
-  dt_opencl_set_kernel_args(devid, kernel_y, 0,
+  return dt_opencl_enqueue_kernel_1d_args(devid, darktable.opencl->guided_filter->kernel_guided_filter_box_mean_y, width,
                               CLARG(width), CLARG(height),
                               CLARG(temp), CLARG(out), CLARG(w));
-  return dt_opencl_enqueue_kernel_ndim_with_local(devid, kernel_y, sizes_y, NULL, 1);
 }
 
 

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -2754,6 +2754,27 @@ int dt_opencl_enqueue_kernel_2d_args_internal(const int dev,
   return dt_opencl_enqueue_kernel_2d_with_local(dev, kernel, sizes, NULL);
 }
 
+int dt_opencl_enqueue_kernel_1d_args_internal(const int dev,
+                                              const int kernel,
+                                              const size_t x,
+                                              ...)
+{
+  va_list ap;
+  va_start(ap, x);
+  const cl_int err = _opencl_set_kernel_args(dev, kernel, 0, ap);
+  va_end(ap);
+  if(err != CL_SUCCESS)
+  {
+    dt_print(DT_DEBUG_OPENCL,
+             "[dt_opencl_enqueue_kernel_1d_args_internal] kernel `%s' (%i) on device %d: %s\n",
+              darktable.opencl->name_saved[kernel], kernel, dev, cl_errstr(err));
+    return err;
+  }
+  const size_t sizes[] = { ROUNDUPDWD(x, dev), 1, 1 };
+
+  return dt_opencl_enqueue_kernel_ndim_with_local(dev, kernel, sizes, NULL, 1);
+}
+
 int dt_opencl_copy_device_to_host(const int devid,
                                   void *host,
                                   void *device,

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -380,10 +380,17 @@ int dt_opencl_enqueue_kernel_2d_with_local(const int dev,
 /** call kernel with arguments! */
 #define dt_opencl_enqueue_kernel_2d_args(dev, kernel, w, h, ...) \
     dt_opencl_enqueue_kernel_2d_args_internal(dev, kernel, w, h, __VA_ARGS__, CLWRAP(SIZE_MAX, NULL))
+
+#define dt_opencl_enqueue_kernel_1d_args(dev, kernel, x, ...) \
+    dt_opencl_enqueue_kernel_1d_args_internal(dev, kernel, x, __VA_ARGS__, CLWRAP(SIZE_MAX, NULL))
+
 int dt_opencl_enqueue_kernel_2d_args_internal(const int dev,
                                               const int kernel,
                                               const size_t w,
                                               const size_t h, ...);
+int dt_opencl_enqueue_kernel_1d_args_internal(const int dev,
+                                              const int kernel,
+                                              const size_t x, ...);
 
 /** launch kernel with specified dimension and defined local size! */
 int dt_opencl_enqueue_kernel_ndim_with_local(const int dev,

--- a/src/iop/hlreconstruct/opposed.c
+++ b/src/iop/hlreconstruct/opposed.c
@@ -335,10 +335,10 @@ static float *_process_opposed(
 
       dt_print_pipe(DT_DEBUG_PIPE,
           "opposed chroma", piece->pipe, self, DT_DEVICE_CPU, roi_in, roi_out,
-          "red=%3.4f green=%3.4f blue=%3.4f hash=%" PRIx64 "%s%s\n",
+          "RGB %3.4f %3.4f %3.4f hash=%" PRIx64 "%s%s\n",
           chrominance[0], chrominance[1], chrominance[2],
           _opposed_parhash(piece),
-          piece->pipe->type == DT_DEV_PIXELPIPE_FULL ? ", saved to cache" : "",
+          piece->pipe->type == DT_DEV_PIXELPIPE_FULL ? ", saved" : "",
           img_oppclipped ? "" : ", unclipped");
     }
     dt_free_align(mask);
@@ -497,15 +497,12 @@ static cl_int process_opposed_cl(
     err = dt_opencl_write_buffer_to_device(devid, claccu, dev_accu, 0, accusize, TRUE);
     if(err != CL_SUCCESS) goto error;
 
-    size_t sizes[] = { iheight, 1, 1 };
-
-    dt_opencl_set_kernel_args(devid, gd->kernel_highlights_chroma, 0,
+    err = dt_opencl_enqueue_kernel_1d_args(devid, gd->kernel_highlights_chroma, iheight,
             CLARG(dev_in), CLARG(dev_outmask), CLARG(dev_accu),
             CLARG(roi_in->width), CLARG(roi_in->height),
             CLARG(msize), CLARG(mwidth),
             CLARG(filters), CLARG(dev_xtrans), CLARG(dev_clips), CLARG(dev_correction));
 
-    err = dt_opencl_enqueue_kernel_ndim_with_local(devid, gd->kernel_highlights_chroma, sizes, NULL, 1);
     if(err != CL_SUCCESS) goto error;
 
     err = dt_opencl_read_buffer_from_device(devid, claccu, dev_accu, 0, accusize, TRUE);
@@ -537,10 +534,10 @@ static cl_int process_opposed_cl(
 
     dt_print_pipe(DT_DEBUG_PIPE,
         "opposed chroma", piece->pipe, self, piece->pipe->devid, roi_in, roi_out,
-        "red=%3.4f green=%3.4f, blue=%3.4f hash=%" PRIx64 "%s%s\n",
+        "RGB %3.4f %3.4f %3.4f hash=%" PRIx64 "%s%s\n",
         chrominance[0], chrominance[1], chrominance[2],
         _opposed_parhash(piece),
-        piece->pipe->type == DT_DEV_PIXELPIPE_FULL ? ", saved to cache" : "",
+        piece->pipe->type == DT_DEV_PIXELPIPE_FULL ? ", saved" : "",
         img_oppclipped ? "" : ", unclipped");
   }
 


### PR DESCRIPTION
**Introduce dt_opencl_enqueue_kernel_1d_args()**
Simplify calling OpenCL kernels with one dimension as we have for 2d.

**Make use of dt_opencl_enqueue_kernel_1d_args()**
Making use of the new macro for less code burden.
Also reduce logging line length for better text reading.

**Color equalizer maintenance**

1. Fix passing alpha channel in OpenCL path
2. Deduplicate parameter initializing in process & process_cl
3. Avoid recalculation of satweight data if no parameters have changed
4. OpenCL code uses dt_opencl_enqueue_kernel_1d_args() for drawing the weighing function
5. More data for halo suppression are shown with the brightness mask
6. Some tiling factor correction
7. Slightly reduce saturations dependency on roi->scale.
   Makes sure there are almost no visible differences in zoomed-out darkroom between HQ mode
   toggled on or not.
   Also reduces subtle artifacts while non-HQ exporting with strong downscaling.
8. Some renaming for better readability of code.