### PR TITLE
fix URLs don't open on macOS

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1081,10 +1081,13 @@ static const char* _get_axis_name(const int pos)
 
 void dt_open_url(const char* url)
 {
+#ifdef __APPLE__
+  dt_osx_open_url(url);
+#else
   GError *error = NULL;
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
 
-// TODO: call the web browser directly so that file:// style base for local installs works
+  // TODO: call the web browser directly so that file:// style base for local installs works
   const gboolean uri_success = gtk_show_uri_on_window(GTK_WINDOW(win),
                                                       url,
                                                       gtk_get_current_event_time(),
@@ -1103,6 +1106,7 @@ void dt_open_url(const char* url)
       g_error_free(error);
     }
   }
+#endif
 }
 
 #ifdef MAC_INTEGRATION

--- a/src/osx/osx.h
+++ b/src/osx/osx.h
@@ -30,6 +30,7 @@ gboolean dt_osx_file_trash(const char *filename, GError **error);
 char* dt_osx_get_bundle_res_path();
 void dt_osx_prepare_environment();
 void dt_osx_focus_window();
+void dt_osx_open_url(const char *url);
 
 #ifdef __cplusplus
 }

--- a/src/osx/osx.mm
+++ b/src/osx/osx.mm
@@ -284,6 +284,11 @@ void dt_osx_focus_window()
   [NSApp activateIgnoringOtherApps:YES];
 }
 
+void dt_osx_open_url(const char *url)
+{
+  [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@(url)]];
+}
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;


### PR DESCRIPTION
On macOS 15 (probably 14 already as well?) URLs cannot be opened anymore with `gtk_show_uri_on_window()` so all help links do not work.

Now URLs on Macs are opened using a dedicated macOS function to get them working again.

