### PR TITLE
Rework copy/paste parts.

### DIFF
--- a/src/gui/hist_dialog.c
+++ b/src/gui/hist_dialog.c
@@ -325,12 +325,10 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
 
       if(!(flags & IOP_FLAGS_HIDDEN))
       {
-        const gboolean is_safe = !dt_history_module_skip_copy(flags);
-
         gtk_list_store_append(GTK_LIST_STORE(liststore), &iter);
         gtk_list_store_set
           (GTK_LIST_STORE(liststore), &iter,
-           DT_HIST_ITEMS_COL_ENABLED, iscopy ? is_safe : _gui_is_set(d->selops, item->num),
+           DT_HIST_ITEMS_COL_ENABLED, iscopy ? FALSE : _gui_is_set(d->selops, item->num),
            DT_HIST_ITEMS_COL_AUTOINIT, FALSE,
            DT_HIST_ITEMS_COL_ISACTIVE, item->enabled ? is_active_pb : is_inactive_pb,
            DT_HIST_ITEMS_COL_NAME, item->name,
@@ -349,7 +347,7 @@ int dt_gui_hist_dialog_new(dt_history_copy_item_t *d,
                                     dt_iop_order_string(order));
       gtk_list_store_append(GTK_LIST_STORE(liststore), &iter);
       gtk_list_store_set(GTK_LIST_STORE(liststore), &iter,
-                         DT_HIST_ITEMS_COL_ENABLED, TRUE,
+                         DT_HIST_ITEMS_COL_ENABLED, d->copy_iop_order,
                          DT_HIST_ITEMS_COL_ISACTIVE, is_active_pb,
                          DT_HIST_ITEMS_COL_NAME, label,
                          DT_HIST_ITEMS_COL_NUM, -1,


### PR DESCRIPTION
The copy part now select no IOP by default (all safe IOP where selected). The paste part select by default (as before) all the items that have been copied.

Fixes #17228.