### PR TITLE
fix gtk warnings from #17425

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -214,8 +214,9 @@ static float _action_process_toggle(gpointer target,
 {
   float value = gtk_toggle_button_get_active(target);
 
-  if(DT_PERFORM_ACTION(move_size) &&
-     !((effect == DT_ACTION_EFFECT_ON
+  if(DT_PERFORM_ACTION(move_size)
+     && gtk_widget_get_ancestor(target, GTK_TYPE_WINDOW)
+     && !((effect == DT_ACTION_EFFECT_ON
         || effect == DT_ACTION_EFFECT_ON_CTRL
         || effect == DT_ACTION_EFFECT_ON_RIGHT) && value)
      && (effect != DT_ACTION_EFFECT_OFF
@@ -257,12 +258,14 @@ static float _action_process_button(gpointer target,
                                     dt_action_effect_t effect,
                                     float move_size)
 {
-  if(!gtk_widget_get_realized(target)) gtk_widget_realize(target);
-
   dt_lib_gui_update(g_object_get_data(G_OBJECT(target), "module"));
 
-  if(DT_PERFORM_ACTION(move_size) && gtk_widget_is_sensitive(target))
+  if(DT_PERFORM_ACTION(move_size)
+     && gtk_widget_is_sensitive(target)
+     && gtk_widget_get_ancestor(target, GTK_TYPE_WINDOW))
   {
+    if(!gtk_widget_get_realized(target)) gtk_widget_realize(target);
+
     if(effect != DT_ACTION_EFFECT_ACTIVATE
       || !g_signal_handler_find(target, G_SIGNAL_MATCH_ID,
                                 g_signal_lookup("clicked", gtk_button_get_type()),

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -695,7 +695,6 @@ void gui_init(dt_lib_module_t *self)
     gtk_grid_attach(grid, labelev, 0, i, 1, 1);
 
     GtkWidget *textview = gtk_text_view_new();
-    gtk_drag_dest_unset(textview);
     dt_action_define(DT_ACTION(self), NULL, name, textview, &dt_action_def_entry);
     gtk_widget_set_tooltip_text(textview,
               _("metadata text"


### PR DESCRIPTION
When reordering a lib by dragging it, a dropzone is shown above or below the module currently hovered over. If the module contains widgets that also accept drags, like entries, textviews, and some treeviews, those widgets try to process the hover and sometimes don't correctly indicate that they don't accept the module type and that the parent widget should process the hover. In that case, the hoverzone gets hidden when it shouldn't. This can lead to flickering, especially when passing over the 6 text widgets in the metadata editor. #17425 "fixed" this by removing the marking of the textviews as a drop target. But when the textview gets destroyed when dt is closed, the associated textbuffer is updated one last time, leading to a redefinition of the accepted drop target types, which was now invalid because the widget is no longer a drop zone. This PR reinstates the flickering to get rid of the error message on close, since there doesn't seem to be another workaround. Fixes #17476

Also checks first if a module is "visible" (i.e. not completely removed using new functionality in #17425, rather than just collapsed) before trying to realize a widget via a shortcut. Shortcuts to removed modules will still not work. Fixes #17530