### PR TITLE
[maint] imageio memory allocation checks

### DIFF
--- a/src/imageio/imageio_avif.c
+++ b/src/imageio/imageio_avif.c
@@ -218,8 +218,11 @@ dt_imageio_retval_t dt_imageio_open_avif(dt_image_t *img,
   if(icc->size && icc->data)
   {
     img->profile = (uint8_t *)g_malloc0(icc->size);
-    memcpy(img->profile, icc->data, icc->size);
-    img->profile_size = icc->size;
+    if(img->profile)
+    {
+      memcpy(img->profile, icc->data, icc->size);
+      img->profile_size = icc->size;
+    }
   }
 
   img->loader = LOADER_AVIF;
@@ -263,8 +266,11 @@ int dt_imageio_avif_read_profile(const char *filename, uint8_t **out, dt_colorsp
   if(icc->size && icc->data)
   {
     *out = (uint8_t *)g_malloc0(icc->size);
-    memcpy(*out, icc->data, icc->size);
-    size = icc->size;
+    if(*out)
+    {
+      memcpy(*out, icc->data, icc->size);
+      size = icc->size;
+    }
   }
   else
   {

--- a/src/imageio/imageio_gm.c
+++ b/src/imageio/imageio_gm.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2023 darktable developers.
+    Copyright (C) 2012-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -127,7 +127,8 @@ dt_imageio_retval_t dt_imageio_open_gm(dt_image_t *img, const char *filename, dt
   {
     img->profile_size = profile_length;
     img->profile = (uint8_t *)g_malloc0(profile_length);
-    memcpy(img->profile, profile_data, profile_length);
+    if(img->profile)
+      memcpy(img->profile, profile_data, profile_length);
   }
 
   if(image) DestroyImage(image);

--- a/src/imageio/imageio_im.c
+++ b/src/imageio/imageio_im.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2020-2023 darktable developers.
+    Copyright (C) 2020-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -126,7 +126,10 @@ dt_imageio_retval_t dt_imageio_open_im(dt_image_t *img, const char *filename, dt
   {
     img->profile_size = profile_length;
     img->profile = (uint8_t *)g_malloc0(profile_length);
-    memcpy(img->profile, profile_data, profile_length);
+    if(img->profile)
+    {
+      memcpy(img->profile, profile_data, profile_length);
+    }
     MagickRelinquishMemory(profile_data);
   }
 

--- a/src/imageio/imageio_jpegxl.c
+++ b/src/imageio/imageio_jpegxl.c
@@ -49,7 +49,7 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
     dt_print(DT_DEBUG_ALWAYS,
              "[jpegxl_open] ERROR: cannot open file for read: '%s'\n",
              filename);
-    return DT_IMAGEIO_LOAD_FAILED;
+    return DT_IMAGEIO_FILE_NOT_FOUND;
   }
 
   fseek(inputfile, 0, SEEK_END);
@@ -57,7 +57,11 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
   fseek(inputfile, 0, SEEK_SET);
 
   void* read_buffer = malloc(inputFileSize);
-
+  if(!read_buffer)
+  {
+    fclose(inputfile);
+    return DT_IMAGEIO_LOAD_FAILED;
+  }
   if(fread(read_buffer, 1, inputFileSize, inputfile) != inputFileSize)
   {
     dt_print(DT_DEBUG_ALWAYS,
@@ -240,7 +244,8 @@ dt_imageio_retval_t dt_imageio_open_jpegxl(dt_image_t *img,
         {
           img->profile_size = icc_size;
           img->profile = (uint8_t *)g_malloc0(icc_size);
-          JxlDecoderGetColorAsICCProfile(decoder,
+          if(img->profile)
+            JxlDecoderGetColorAsICCProfile(decoder,
 #if JPEGXL_NUMERIC_VERSION < JPEGXL_COMPUTE_NUMERIC_VERSION(0, 9, 0)
                                          &pixel_format,
 #endif

--- a/src/imageio/imageio_png.c
+++ b/src/imageio/imageio_png.c
@@ -130,6 +130,12 @@ gboolean dt_imageio_png_read_image(dt_imageio_png_t *png, void *out)
   }
 
   png_bytep *row_pointers = malloc(sizeof(png_bytep) * png->height);
+  if(!row_pointers)
+  {
+    fclose(png->f);
+    png_destroy_read_struct(&png->png_ptr, &png->info_ptr, NULL);
+    return FALSE;
+  }
 
   png_bytep row_pointer = (png_bytep)out;
   const size_t rowbytes = png_get_rowbytes(png->png_ptr, png->info_ptr);
@@ -290,7 +296,8 @@ int dt_imageio_png_read_profile(const char *filename, uint8_t **out, dt_colorspa
      && png_get_iCCP(image.png_ptr, image.info_ptr, &name, NULL, &profile, &proflen) != 0)
   {
     *out = (uint8_t *)g_malloc(proflen);
-    memcpy(*out, profile, proflen);
+    if(*out)
+      memcpy(*out, profile, proflen);
   }
 #endif
 

--- a/src/imageio/imageio_pnm.c
+++ b/src/imageio/imageio_pnm.c
@@ -41,6 +41,8 @@ static dt_imageio_retval_t _read_pbm(dt_image_t *img, FILE*f, float *buf)
 
   int bytes_needed = (img->width + 7) / 8;
   uint8_t *line = calloc(bytes_needed, sizeof(uint8_t));
+  if(!line)
+    return DT_IMAGEIO_LOAD_FAILED;
 
   float *buf_iter = buf;
   for(size_t y = 0; y < img->height; y++)
@@ -88,7 +90,7 @@ static dt_imageio_retval_t _read_pgm(dt_image_t *img, FILE*f, float *buf)
     uint8_t *line = calloc(img->width, sizeof(uint8_t));
 
     float *buf_iter = buf;
-    for(size_t y = 0; y < img->height; y++)
+    for(size_t y = 0; line && y < img->height; y++)
     {
       if(fread(line, sizeof(uint8_t), (size_t)img->width, f) != img->width)
       {
@@ -110,7 +112,7 @@ static dt_imageio_retval_t _read_pgm(dt_image_t *img, FILE*f, float *buf)
     uint16_t *line = calloc(img->width, sizeof(uint16_t));
 
     float *buf_iter = buf;
-    for(size_t y = 0; y < img->height; y++)
+    for(size_t y = 0; line && y < img->height; y++)
     {
       if(fread(line, sizeof(uint16_t), (size_t)img->width, f) != img->width)
       {
@@ -153,7 +155,7 @@ static dt_imageio_retval_t _read_ppm(dt_image_t *img, FILE*f, float *buf)
     uint8_t *line = calloc((size_t)3 * img->width, sizeof(uint8_t));
 
     float *buf_iter = buf;
-    for(size_t y = 0; y < img->height; y++)
+    for(size_t y = 0; line && y < img->height; y++)
     {
       if(fread(line, 3 * sizeof(uint8_t), (size_t)img->width, f) != img->width)
       {
@@ -177,7 +179,7 @@ static dt_imageio_retval_t _read_ppm(dt_image_t *img, FILE*f, float *buf)
     uint16_t *line = calloc((size_t)3 * img->width, sizeof(uint16_t));
 
     float *buf_iter = buf;
-    for(size_t y = 0; y < img->height; y++)
+    for(size_t y = 0; line && y < img->height; y++)
     {
       if(fread(line, 3 * sizeof(uint16_t), (size_t)img->width, f) != img->width)
       {

--- a/src/imageio/imageio_qoi.c
+++ b/src/imageio/imageio_qoi.c
@@ -52,6 +52,12 @@ dt_imageio_retval_t dt_imageio_open_qoi(dt_image_t *img,
   fseek(f, 0, SEEK_SET);
 
   void *read_buffer = g_malloc(filesize);
+  if(!read_buffer)
+  {
+    fclose(f);
+    dt_print(DT_DEBUG_ALWAYS, "[qoi_open] failed to allocate buffer for %s\n", filename);
+    return DT_IMAGEIO_LOAD_FAILED;
+  }
 
   // Let's check whether the entire content of the file should be read into the buffer.
   // If we see that it's a non-QOI file, we'll save time by avoiding unnecessary reading

--- a/src/imageio/imageio_tiff.c
+++ b/src/imageio/imageio_tiff.c
@@ -528,7 +528,8 @@ int dt_imageio_tiff_read_profile(const char *filename, uint8_t **out)
     if(profile_len > 0)
     {
       *out = (uint8_t *)g_malloc(profile_len);
-      cmsSaveProfileToMem(profile, *out, &profile_len);
+      if(*out)
+        cmsSaveProfileToMem(profile, *out, &profile_len);
     }
   }
   else if(TIFFGetField(tiff, TIFFTAG_ICCPROFILE, &profile_len, &profile))
@@ -536,7 +537,8 @@ int dt_imageio_tiff_read_profile(const char *filename, uint8_t **out)
     if(profile_len > 0)
     {
       *out = (uint8_t *)g_malloc(profile_len);
-      memcpy(*out, profile, profile_len);
+      if(*out)
+        memcpy(*out, profile, profile_len);
     }
   }
   else


### PR DESCRIPTION
Add null checks on return values for memory allocation calls in the image loaders to avoid potential crashes.
