### PR TITLE
Fix compilation without OpenEXR

### DIFF
--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -179,6 +179,10 @@ static dt_imageio_retval_t _unsupported_type(dt_image_t *img,
 #define dt_imageio_open_im _unsupported_type
 #endif
 
+#ifndef HAVE_OPENEXR
+#define dt_imageio_open_exr _unsupported_type
+#endif
+
 typedef struct {
   dt_filetype_t filetype;
   gboolean      hdr;


### PR DESCRIPTION
Commit e38d2c8db4f457a0e45624d646244446352de609 introduced surrogate loader functions for file types whose libraries are not available. It was missing a surrogate for OpenEXR resulting in compilation fail if the library was not enabled:
```
src/imageio/imageio.c:242:38: error: ‘dt_imageio_open_exr’ undeclared here (not in a function); did you mean ‘dt_imageio_open_ldr’?
  242 |   { DT_FILETYPE_OPENEXR, TRUE, 0, 4, dt_imageio_open_exr,
      |                                      ^~~~~~~~~~~~~~~~~~~
      |                                      dt_imageio_open_ldr
```
This commit adds the missing surrogate. I didn't thoroughly check if other surrogates are missing as well, but a glance at includes and their ifdefs suggests all others are already present.