### PR TITLE
Further simplify Windows build instructions

### DIFF
--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -25,7 +25,7 @@ are as follows:
     pacman -S --needed mingw-w64-ucrt-x86_64-nsis
     ```
 
-* Switch to the UCRT64 terminal and update your lensfun database:
+* Switch to the UCRT64 terminal and update your Lensfun database:
     ```bash
     lensfun-update-data
     ```

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -15,25 +15,14 @@ are as follows:
     pacman -S --needed mingw-w64-ucrt-x86_64-{cc,cmake,gcc-libs,ninja,omp}
     ```
 
-* Install required libraries and dependencies for darktable:
+* Install required and recommended dependencies for darktable:
     ```bash
-    pacman -S --needed mingw-w64-ucrt-x86_64-{libxslt,python-jsonschema,curl,drmingw,exiv2,gettext,gmic,graphicsmagick,gtk3,icu,imath,iso-codes,lcms2,lensfun,libavif,libgphoto2,libheif,libjpeg-turbo,libjxl,libpng,libraw,librsvg,libsecret,libtiff,libwebp,libxml2,lua,openexr,openjpeg2,osm-gps-map,pugixml,sqlite3,webp-pixbuf-loader,zlib}
+    pacman -S --needed mingw-w64-ucrt-x86_64-{libxslt,python-jsonschema,curl,drmingw,exiv2,gettext,gmic,graphicsmagick,gtk3,icu,imath,iso-codes,lcms2,lensfun,libavif,libgphoto2,libheif,libjpeg-turbo,libjxl,libpng,libraw,librsvg,libsecret,libtiff,libwebp,libxml2,lua,openexr,openjpeg2,osm-gps-map,portmidi,pugixml,SDL2,sqlite3,webp-pixbuf-loader,zlib}
     ```
 
 * Install the optional tool for building an installer image (currently x64 only):
     ```bash
     pacman -S --needed mingw-w64-ucrt-x86_64-nsis
-    ```
-
-* Install optional libraries and dependencies:
-
-    for cLUT
-    ```bash
-    pacman -S --needed mingw-w64-ucrt-x86_64-gmic
-    ```
-    for NG input with midi or gamepad devices
-    ```bash
-    pacman -S --needed mingw-w64-ucrt-x86_64-{portmidi,SDL2}
     ```
 
 * Switch to the UCRT64 terminal and update your lensfun database:


### PR DESCRIPTION
In fact, the main dependency list contains not only required packages, some of them are optional. It makes no sense that the portmidi and SDL2 packages, as optional as some of the other packages in the main list, are listed separately.