### PR TITLE
reorder enums for collection type

### DIFF
--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -110,11 +110,6 @@ typedef enum dt_collection_properties_t
   DT_COLLECTION_PROP_TEXTSEARCH,
   DT_COLLECTION_PROP_RATING,
 
-  DT_COLLECTION_PROP_LAST,
-
-  DT_COLLECTION_PROP_UNDEF,
-  DT_COLLECTION_PROP_SORT,
-
   DT_COLLECTION_PROP_WHITEBALANCE,
   DT_COLLECTION_PROP_FLASH,
   DT_COLLECTION_PROP_EXPOSURE_PROGRAM,
@@ -122,7 +117,15 @@ typedef enum dt_collection_properties_t
 
   DT_COLLECTION_PROP_GROUP_ID,
 
-  DT_COLLECTION_PROP_EXPOSURE_BIAS
+  DT_COLLECTION_PROP_EXPOSURE_BIAS,
+
+  // all new collection types need to be added before DT_COLLECTION_PROP_LAST,
+  // which separates actual collection types from special flag values
+  DT_COLLECTION_PROP_LAST,
+
+  DT_COLLECTION_PROP_UNDEF,
+  DT_COLLECTION_PROP_SORT
+
 } dt_collection_properties_t;
 
 typedef enum dt_collection_change_t


### PR DESCRIPTION
Ensure that all actual collection types come before DT_COLLECTION_PROP_LAST, which is a flag value, so that their names are properly displayed.  This has the side effect of breaking any presets created for the collections module since the affected types were added to master.

Fixes #17595.
