### PR TITLE
Fix memory requirement calculation

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -3612,7 +3612,7 @@ cl_ulong dt_opencl_get_device_memalloc(const int devid)
 gboolean dt_opencl_image_fits_device(const int devid,
                                      const size_t width,
                                      const size_t height,
-                                     const unsigned bpp,
+                                     const uint32_t bpp,
                                      const float factor,
                                      const size_t overhead)
 {

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -605,7 +605,7 @@ void dt_opencl_memory_statistics(int devid,
 gboolean dt_opencl_image_fits_device(const int devid,
                                      const size_t width,
                                      const size_t height,
-                                     const unsigned bpp,
+                                     const uint32_t bpp,
                                      const float factor,
                                      const size_t overhead);
 /** get available memory for the device */

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -1635,10 +1635,16 @@ void tiling_callback_blendop(struct dt_iop_module_t *self,
   if(bldata)
   {
     if(bldata->details != 0.0f)
-      tiling->factor = 0.75f; // details mask requires 3 additional quarter buffers
+    {
+      // details mask requires 2 additional quarter buffers of details data size
+      // so normalize to roi_size
+      dt_dev_detail_mask_t *details = &piece->pipe->scharr;
+      if(details->data)
+        tiling->factor = 0.5f * (float)(details->roi.width * details->roi.height) / (roi_in->width * roi_in->height);
+     }
 
     if(bldata->feathering_radius > 0.1f)
-      tiling->factor = 3.75f; // we need all intermediate guided filter mask buffers
+      tiling->factor = MAX(tiling->factor, 4.5f); // we need all intermediate guided filter mask buffers
   }
   tiling->factor += 3.5f; // in + out + (guide, tmp) + two quarter buffers for the mask
 }


### PR DESCRIPTION
1. Make sure in & output cl buffers are taken into account even if input is existing
2. Fix requirements for guided masking filter
3. Fix requirements for details mask. (requirements must be based on details->roi)
4. The log gets information about required memory via -d pipe

Inspired by #17569

Checked this also on my intel 630 notebook without issues. Checked the blur OpenCL code and couldn't spot anything suspicious yet, also not for the blend guided filter exept the wrong requirements calculations. 