### PR TITLE
imageio_avif: expose encoding speed control

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2820,6 +2820,13 @@
     <longdescription/>
   </dtconfig>
   <dtconfig>
+    <name>plugins/imageio/format/avif/speed</name>
+    <type min="0" max="10">int</type>
+    <default>6</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/imageio/format/xcf/bpp</name>
     <type>
       <enum>

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -41,7 +41,7 @@
 #define AVIF_MAX_TILE_SIZE 3072
 #define AVIF_DEFAULT_TILE_SIZE AVIF_MIN_TILE_SIZE * 2
 
-DT_MODULE(1)
+DT_MODULE(2)
 
 enum avif_compression_type_e
 {
@@ -69,6 +69,7 @@ typedef struct dt_imageio_avif_t
   uint32_t compression_type;
   uint32_t quality;
   uint32_t tiling;
+  uint32_t speed;
 } dt_imageio_avif_t;
 
 typedef struct dt_imageio_avif_gui_t
@@ -78,6 +79,7 @@ typedef struct dt_imageio_avif_gui_t
   GtkWidget *compression_type;
   GtkWidget *quality;
   GtkWidget *tiling;
+  GtkWidget *speed;
 } dt_imageio_avif_gui_t;
 
 static const struct
@@ -210,6 +212,13 @@ void init(dt_imageio_module_format_t *self)
                                 self,
                                 dt_imageio_avif_t,
                                 quality,
+                                int);
+
+  /* speed */
+  dt_lua_register_module_member(darktable.lua_state.state,
+                                self,
+                                dt_imageio_avif_t,
+                                speed,
                                 int);
 #endif
 }
@@ -530,9 +539,6 @@ int write_image(struct dt_imageio_module_data_t *data,
   switch(d->compression_type)
   {
     case AVIF_COMP_LOSSLESS:
-      /* It isn't recommend to use the extremities */
-      encoder->speed = AVIF_SPEED_SLOWEST + 1;
-
 #if AVIF_VERSION >= 1000000
       encoder->quality = AVIF_QUALITY_LOSSLESS;
 #else
@@ -542,8 +548,6 @@ int write_image(struct dt_imageio_module_data_t *data,
       break;
 
     case AVIF_COMP_LOSSY:
-      encoder->speed = AVIF_SPEED_DEFAULT;
-
 #if AVIF_VERSION >= 1000000
       encoder->quality = d->quality;
 #else
@@ -553,6 +557,8 @@ int write_image(struct dt_imageio_module_data_t *data,
 #endif
       break;
   }
+
+  encoder->speed = d->speed;
 
   /*
    * Tiling reduces the image quality but it has a negligible impact on
@@ -601,13 +607,14 @@ int write_image(struct dt_imageio_module_data_t *data,
 
   dt_print(DT_DEBUG_IMAGEIO,
            "[avif quality: %u => maxQuantizer: %u, minQuantizer: %u, "
-           "tileColsLog2: %u, tileRowsLog2: %u, threads: %u]\n",
+           "tileColsLog2: %u, tileRowsLog2: %u, threads: %u, speed: %u]\n",
            d->quality,
            encoder->maxQuantizer,
            encoder->minQuantizer,
            encoder->tileColsLog2,
            encoder->tileRowsLog2,
-           encoder->maxThreads);
+           encoder->maxThreads,
+           encoder->speed);
 
   avifRWData output = AVIF_DATA_EMPTY;
 
@@ -675,6 +682,61 @@ size_t params_size(dt_imageio_module_format_t *self)
   return sizeof(dt_imageio_avif_t);
 }
 
+void *legacy_params(dt_imageio_module_format_t *self,
+                    const void *const old_params,
+                    const size_t old_params_size,
+                    const int old_version,
+                    int *new_version,
+                    size_t *new_size)
+{
+  typedef struct dt_imageio_avif_v1_t
+  {
+    dt_imageio_module_data_t global;
+    uint32_t bit_depth;
+    uint32_t color_mode;
+    uint32_t compression_type;
+    uint32_t quality;
+    uint32_t tiling;
+  } dt_imageio_avif_v1_t;
+
+  // incremental update supported:
+  typedef struct dt_imageio_avif_v2_t
+  {
+    dt_imageio_module_data_t global;
+    uint32_t bit_depth;
+    uint32_t color_mode;
+    uint32_t compression_type;
+    uint32_t quality;
+    uint32_t tiling;
+    uint32_t speed;
+  } dt_imageio_avif_v2_t;
+
+  if(old_version == 1)
+  {
+    // let's update from 1 to 2
+    const dt_imageio_avif_v1_t *o = (dt_imageio_avif_v1_t *)old_params;
+    dt_imageio_avif_v2_t *n = (dt_imageio_avif_v2_t *)malloc(sizeof(dt_imageio_avif_v2_t));
+
+    n->global.max_width = o->global.max_width;
+    n->global.max_height = o->global.max_height;
+    n->global.width = o->global.width;
+    n->global.height = o->global.height;
+    g_strlcpy(n->global.style, o->global.style, sizeof(o->global.style));
+    n->global.style_append = o->global.style_append;
+    n->bit_depth = o->bit_depth;
+    n->color_mode = o->color_mode;
+    n->compression_type = o->compression_type;
+    n->quality = o->quality;
+    n->tiling = o->tiling;
+    n->speed = 6;
+
+    *new_size = sizeof(dt_imageio_avif_v2_t);
+    *new_version = 2;
+    return n;
+  }
+  return NULL;
+}
+
 void *get_params(dt_imageio_module_format_t *self)
 {
   dt_imageio_avif_t *d = (dt_imageio_avif_t *)calloc(1, sizeof(dt_imageio_avif_t));
@@ -701,6 +763,8 @@ void *get_params(dt_imageio_module_format_t *self)
       break;
   }
 
+  d->speed = dt_conf_get_int("plugins/imageio/format/avif/speed");
+
   d->tiling = !dt_conf_get_bool("plugins/imageio/format/avif/tiling");
 
   return d;
@@ -720,6 +784,7 @@ int set_params(dt_imageio_module_format_t *self,
   dt_bauhaus_combobox_set(g->tiling, d->tiling);
   dt_bauhaus_combobox_set(g->compression_type, d->compression_type);
   dt_bauhaus_slider_set(g->quality, d->quality);
+  dt_bauhaus_slider_set(g->speed, d->speed);
 
   return 0;
 }
@@ -817,6 +882,12 @@ static void quality_changed(GtkWidget *slider, gpointer user_data)
   dt_conf_set_int("plugins/imageio/format/avif/quality", quality);
 }
 
+static void speed_changed(GtkWidget *slider, gpointer user_data)
+{
+  const uint32_t speed = (int)dt_bauhaus_slider_get(slider);
+  dt_conf_set_int("plugins/imageio/format/avif/speed", speed);
+}
+
 void gui_init(dt_imageio_module_format_t *self)
 {
   dt_imageio_avif_gui_t *gui =
@@ -826,6 +897,7 @@ void gui_init(dt_imageio_module_format_t *self)
   const enum avif_tiling_e tiling = !dt_conf_get_bool("plugins/imageio/format/avif/tiling");
   const enum avif_compression_type_e compression_type = dt_conf_get_int("plugins/imageio/format/avif/compression_type");
   const uint32_t quality = dt_conf_get_int("plugins/imageio/format/avif/quality");
+  const uint32_t speed = dt_conf_get_int("plugins/imageio/format/avif/speed");
 
   self->gui_data = (void *)gui;
 
@@ -930,6 +1002,24 @@ void gui_init(dt_imageio_module_format_t *self)
   gtk_widget_set_visible(gui->quality, compression_type != AVIF_COMP_LOSSLESS);
   gtk_widget_set_no_show_all(gui->quality, TRUE);
 
+  /*
+   * Speed slider
+   */
+  gui->speed = dt_bauhaus_slider_new_with_range((dt_iop_module_t*)self,
+                                                  dt_confgen_get_int("plugins/imageio/format/avif/speed", DT_MIN), /* min */
+                                                  dt_confgen_get_int("plugins/imageio/format/avif/speed", DT_MAX), /* max */
+                                                  1, /* step */
+                                                  dt_confgen_get_int("plugins/imageio/format/avif/speed", DT_DEFAULT), /* default */
+                                                  0); /* digits */
+  dt_bauhaus_widget_set_label(gui->speed,  NULL, N_("encoding speed"));
+
+  gtk_widget_set_tooltip_text(gui->speed,
+          _("trades off quality and file size for quicker encoding time"));
+
+  dt_bauhaus_slider_set(gui->speed, speed);
+
+  gtk_box_pack_start(GTK_BOX(self->widget), gui->speed, TRUE, TRUE, 0);
+
   g_signal_connect(G_OBJECT(gui->bit_depth),
                    "value-changed",
                    G_CALLBACK(bit_depth_changed),
@@ -941,6 +1031,10 @@ void gui_init(dt_imageio_module_format_t *self)
   g_signal_connect(G_OBJECT(gui->quality),
                    "value-changed",
                    G_CALLBACK(quality_changed),
+                   NULL);
+  g_signal_connect(G_OBJECT(gui->speed),
+                   "value-changed",
+                   G_CALLBACK(speed_changed),
                    NULL);
 }
 
@@ -958,6 +1052,7 @@ void gui_reset(dt_imageio_module_format_t *self)
   const enum avif_tiling_e tiling = !dt_confgen_get_bool("plugins/imageio/format/avif/tiling", DT_DEFAULT);
   const enum avif_compression_type_e compression_type = dt_confgen_get_int("plugins/imageio/format/avif/compression_type", DT_DEFAULT);
   const uint32_t quality = dt_confgen_get_int("plugins/imageio/format/avif/quality", DT_DEFAULT);
+  const uint32_t speed = dt_confgen_get_int("plugins/imageio/format/avif/speed", DT_DEFAULT);
 
   size_t idx = 0;
   for(size_t i = 0; avif_bit_depth[i].name != NULL; ++i)
@@ -973,6 +1068,7 @@ void gui_reset(dt_imageio_module_format_t *self)
   dt_bauhaus_combobox_set(gui->tiling, tiling);
   dt_bauhaus_combobox_set(gui->compression_type, compression_type);
   dt_bauhaus_slider_set(gui->quality, quality);
+  dt_bauhaus_slider_set(gui->speed, speed);
 }
 
 // clang-format off


### PR DESCRIPTION
Resolves #17538

Relnotes: "Expose encoding speed control for AVIF export: trades off export time for file size and quality"