### PR TITLE
Disable libjxl lossless mode for float16

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -212,6 +212,8 @@ changes (where available).
 - Exporting to floating-point JPEG XL with a quality of 100 will try
   to do it as losslessly as possible. That is now consistent with the
   behavior of integral JPEG XL formats.
+  Note: Due to an upstream issue, exporting in 16-bit float at quality 100
+  is not currently mathematically lossless.
 
 - Improved visibility of shortcuts that can be changed by users by
   using bold text.

--- a/src/imageio/format/jxl.c
+++ b/src/imageio/format/jxl.c
@@ -176,7 +176,10 @@ int write_image(struct dt_imageio_module_data_t *data,
     // Must preserve original profile for lossless mode
     basic_info.uses_original_profile = JXL_TRUE;
     LIBJXL_ASSERT(JxlEncoderSetFrameDistance(frame_settings, 0.0f));
-    LIBJXL_ASSERT(JxlEncoderSetFrameLossless(frame_settings, JXL_TRUE));
+
+    // Do not enable libjxl lossless mode for float16, see #17487
+    if (!(params->bpp == 16 && params->pixel_type))
+      LIBJXL_ASSERT(JxlEncoderSetFrameLossless(frame_settings, JXL_TRUE));
   }
   else
   {


### PR DESCRIPTION
Closes #17487.

As discussed in the issue, libjxl lossless encoding of float16 is actually broken.
This patch disables the real lossless mode of libjxl, while still asking for a distance of 0 (basically lossless).

It didn't feel useful to mention this in tooltip of the quality slider.