### PR TITLE
Czech language translation fixes

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -320,7 +320,7 @@ msgstr "5K"
 #: ../build/bin/conf_gen.h:1359
 msgctxt "preferences"
 msgid "off"
-msgstr "vyp"
+msgstr "vyp."
 
 #: ../build/bin/conf_gen.h:1360
 msgctxt "preferences"

--- a/po/cs.po
+++ b/po/cs.po
@@ -182,7 +182,7 @@ msgstr "vybrat pouze obrázky, které ještě nebyly importovány"
 
 #: ../build/bin/conf_gen.h:984
 msgid "ignore non-raw images"
-msgstr "ignorovat ne-RAW obrázky"
+msgstr "ignorovat ne-raw obrázky"
 
 #: ../build/bin/conf_gen.h:985
 msgid ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -20182,7 +20182,7 @@ msgstr "prahová hodnota pro aktivaci doostření"
 
 #: ../src/iop/sigmoid.c:195
 msgid "sigmoid"
-msgstr "sigmatu"
+msgstr "sigmoida"
 
 #: ../src/iop/sigmoid.c:200
 msgid "tone mapping|view transform|display transform"

--- a/po/cs.po
+++ b/po/cs.po
@@ -202,7 +202,7 @@ msgstr "použít některá metadata na všechny nově importované obrázky."
 
 #: ../build/bin/conf_gen.h:998
 msgid "recursive directory"
-msgstr "procházet složku rekursivně"
+msgstr "procházet složku rekurzivně"
 
 #: ../build/bin/conf_gen.h:999
 msgid "recursive directory traversal when importing filmrolls"


### PR DESCRIPTION
`cs.po` appears to be mainly a product of machine translation, resulting into misinterpretations, terminology inconsistencies, and some hilarious translations in general. Some translations are missing, too.

Given the size of the file, this task will take some time to complete, so for now I'm marking it as a draft. I'll be adding commits as I continue using DT and getting acknowledged with its Czech version.