### PR TITLE
Signal and thumbtable code maintenance

### DIFF
--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -1052,7 +1052,7 @@ static gboolean dt_camctl_update_cameras(const dt_camctl_t *c)
   // one global camctl.  if there would ever be more it would be easy
   // to pass c with the signal.
   if(changed_camera)
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CAMERA_DETECTED);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CAMERA_DETECTED);
 
   return changed_camera;
 }

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -95,34 +95,21 @@ const dt_collection_t *dt_collection_new(const dt_collection_t *clone)
   /* connect to all the signals that might indicate that the count of
      images matching the collection changed
    */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_TAG_CHANGED,
-                            G_CALLBACK(_dt_collection_recount_callback_tag), collection);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED,
-                            G_CALLBACK(_dt_collection_recount_callback_filmroll), collection);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_FILMROLLS_REMOVED,
-                            G_CALLBACK(_dt_collection_recount_callback_filmroll), collection);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_TAG_CHANGED, _dt_collection_recount_callback_tag, collection);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_FILMROLLS_CHANGED, _dt_collection_recount_callback_filmroll, collection);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_FILMROLLS_REMOVED, _dt_collection_recount_callback_filmroll, collection);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_IMAGE_IMPORT,
-                            G_CALLBACK(_dt_collection_recount_callback_2), collection);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_FILMROLLS_IMPORTED,
-                            G_CALLBACK(_dt_collection_filmroll_imported_callback), collection);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_IMAGE_IMPORT, _dt_collection_recount_callback_2, collection);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_FILMROLLS_IMPORTED, _dt_collection_filmroll_imported_callback, collection);
   return collection;
 }
 
 void dt_collection_free(const dt_collection_t *collection)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_dt_collection_recount_callback_tag),
-                               (gpointer)collection);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_dt_collection_recount_callback_filmroll),
-                               (gpointer)collection);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_dt_collection_recount_callback_2),
-                               (gpointer)collection);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_dt_collection_filmroll_imported_callback),
-                               (gpointer)collection);
+  DT_CONTROL_SIGNAL_DISCONNECT(_dt_collection_recount_callback_tag, (gpointer)collection);
+  DT_CONTROL_SIGNAL_DISCONNECT(_dt_collection_recount_callback_filmroll, (gpointer)collection);
+  DT_CONTROL_SIGNAL_DISCONNECT(_dt_collection_recount_callback_2, (gpointer)collection);
+  DT_CONTROL_SIGNAL_DISCONNECT(_dt_collection_filmroll_imported_callback, (gpointer)collection);
 
   g_free(collection->query);
   g_free(collection->query_no_group);
@@ -2709,7 +2696,7 @@ void dt_collection_update_query(const dt_collection_t *collection,
     // if we have remove something from selection, we need to raise a signal
     if(sqlite3_changes(dt_database_get(darktable.db)) > 0)
     {
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_SELECTION_CHANGED);
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_SELECTION_CHANGED);
     }
 
     /* free allocated strings */
@@ -2720,10 +2707,9 @@ void dt_collection_update_query(const dt_collection_t *collection,
   if(!collection->clone)
   {
     dt_collection_memory_update();
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                  DT_SIGNAL_COLLECTION_CHANGED,
-                                  query_change, changed_property,
-                                  list, next);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_COLLECTION_CHANGED,
+                            query_change, changed_property,
+                            list, next);
   }
 }
 
@@ -2850,9 +2836,8 @@ static void _collection_recount_callback(gpointer instance,
   if(!collection->clone)
   {
     if(old_count != collection->count_no_group) dt_collection_hint_message(collection);
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                  DT_SIGNAL_COLLECTION_CHANGED, DT_COLLECTION_CHANGE_RELOAD,
-                                  DT_COLLECTION_PROP_UNDEF, (GList *)NULL, -1);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_COLLECTION_CHANGED, DT_COLLECTION_CHANGE_RELOAD,
+                            DT_COLLECTION_PROP_UNDEF, (GList *)NULL, -1);
   }
 }
 

--- a/src/common/colorlabels.c
+++ b/src/common/colorlabels.c
@@ -252,7 +252,7 @@ void dt_colorlabels_set_labels(const GList *img,
       dt_undo_end_group(darktable.undo);
     }
     dt_collection_hint_message(darktable.collection);
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
   }
 }
 

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -1872,8 +1872,7 @@ static void dt_colorspaces_get_display_profile_colord_callback(GObject *source,
 
   pthread_rwlock_unlock(&darktable.color_profiles->xprofile_lock);
 
-  if(profile_changed) DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                                    DT_SIGNAL_CONTROL_PROFILE_CHANGED);
+  if(profile_changed) DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_PROFILE_CHANGED);
 }
 #endif
 
@@ -2066,8 +2065,7 @@ void dt_colorspaces_set_display_profile
     g_free(buffer);
   }
   pthread_rwlock_unlock(&darktable.color_profiles->xprofile_lock);
-  if(profile_changed) DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                                    DT_SIGNAL_CONTROL_PROFILE_CHANGED);
+  if(profile_changed) DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_PROFILE_CHANGED);
   g_free(profile_source);
 }
 

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -749,7 +749,7 @@ static bool _exif_decode_iptc_data(dt_image_t *img,
         g_free(tag);
         ++pos;
       }
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
     }
     if(FIND_IPTC_TAG("Iptc.Application2.Caption"))
     {

--- a/src/common/film.c
+++ b/src/common/film.c
@@ -425,8 +425,7 @@ void dt_film_remove_empty()
     }
   }
   sqlite3_finalize(stmt);
-  if(raise_signal) DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                                 DT_SIGNAL_FILMROLLS_REMOVED);
+  if(raise_signal) DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_FILMROLLS_REMOVED);
 
   // dispatch asking for deletion (and subsequent deletion) to the gui thread
   if(empty_dirs)
@@ -503,7 +502,7 @@ void dt_film_remove(const dt_filmid_t id)
   sqlite3_finalize(stmt);
   // dt_control_update_recent_films();
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_FILMROLLS_CHANGED);
 }
 
 GList *dt_film_get_image_ids(const dt_filmid_t filmid)

--- a/src/common/grouping.c
+++ b/src/common/grouping.c
@@ -38,7 +38,7 @@ void dt_grouping_add_to_group(const dt_imgid_t group_id,
                                     DT_IMAGE_CACHE_SAFE, "dt_grouping_add_to_group");
   GList *imgs = NULL;
   imgs = g_list_prepend(imgs, GINT_TO_POINTER(image_id));
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGE_INFO_CHANGED, imgs);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_IMAGE_INFO_CHANGED, imgs);
 }
 
 /** remove an image from a group */
@@ -105,7 +105,7 @@ dt_imgid_t dt_grouping_remove_from_group(const dt_imgid_t image_id)
     // refresh also the group leader which may be alone now
     imgs = g_list_prepend(imgs, GINT_TO_POINTER(img_group_id));
   }
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGE_INFO_CHANGED, imgs);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_IMAGE_INFO_CHANGED, imgs);
 
   return new_group_id;
 }
@@ -134,7 +134,7 @@ dt_imgid_t dt_grouping_change_representative(const dt_imgid_t image_id)
     imgs = g_list_prepend(imgs, GINT_TO_POINTER(other_id));
   }
   sqlite3_finalize(stmt);
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGE_INFO_CHANGED, imgs);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_IMAGE_INFO_CHANGED, imgs);
 
   return image_id;
 }

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -135,14 +135,13 @@ void dt_history_delete_on_image_ext(const dt_imgid_t imgid,
   dt_tag_detach_by_string("darktable|style|%", imgid, FALSE, FALSE);
   dt_tag_detach_by_string("darktable|changed", imgid, FALSE, FALSE);
   /* signal that the tags may have changed */
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
 
   /* unset change timestamp */
   dt_image_cache_unset_change_timestamp(darktable.image_cache, imgid);
 
   // signal that the mipmap need to be updated
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, imgid);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, imgid);
 
   dt_unlock_image(imgid);
 
@@ -165,7 +164,7 @@ void dt_history_delete_on_image_ext(const dt_imgid_t imgid,
 void dt_history_delete_on_image(const dt_imgid_t imgid)
 {
   dt_history_delete_on_image_ext(imgid, TRUE, TRUE);
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
 }
 
 gboolean dt_history_load_and_apply(const dt_imgid_t imgid,
@@ -211,7 +210,7 @@ gboolean dt_history_load_and_apply(const dt_imgid_t imgid,
   }
   dt_unlock_image(imgid);
   // signal that the mipmap need to be updated
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, imgid);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, imgid);
   return FALSE;
 }
 
@@ -1005,8 +1004,7 @@ gboolean dt_history_copy_and_paste_on_image(const dt_imgid_t imgid,
     dt_image_synch_xmp(dest_imgid);
 
   // signal that the mipmap need to be updated
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, dest_imgid);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, dest_imgid);
 
   dt_unlock_image_pair(imgid, dest_imgid);
 
@@ -1318,8 +1316,7 @@ void dt_history_compress_on_image(const dt_imgid_t imgid)
 
   dt_database_release_transaction(darktable.db);
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, imgid);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, imgid);
 }
 
 /* Please note: dt_history_truncate_on_image
@@ -1374,8 +1371,7 @@ void dt_history_truncate_on_image(const dt_imgid_t imgid,
 
   dt_database_release_transaction(darktable.db);
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, imgid);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, imgid);
 }
 
 gboolean dt_history_compress(const dt_imgid_t imgid)

--- a/src/common/history_snapshot.c
+++ b/src/common/history_snapshot.c
@@ -167,7 +167,7 @@ static void _history_snapshot_restore(const dt_imgid_t imgid,
   dt_database_start_transaction(darktable.db);
 
   dt_history_delete_on_image_ext(imgid, FALSE, FALSE);
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
 
   // if no history end it means the image history was discarded,
   // nothing more to restore

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -660,9 +660,8 @@ static void _pop_undo(gpointer user_data,
                      : ngettext("geo-location re-applied to %d image",
                                 "geo-location re-applied to %d images", i),
                      i);
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                  DT_SIGNAL_GEOTAG_CHANGED, g_list_copy(*imgs), 0);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_GEOTAG_CHANGED, g_list_copy(*imgs), 0);
   }
   else if(type == DT_UNDO_DATETIME)
   {
@@ -685,9 +684,8 @@ static void _pop_undo(gpointer user_data,
                      : ngettext("date/time re-applied to %d image",
                                 "date/time re-applied to %d images", i),
                      i);
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                  DT_SIGNAL_IMAGE_INFO_CHANGED, g_list_copy(*imgs));
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_IMAGE_INFO_CHANGED, g_list_copy(*imgs));
   }
   else if(type == DT_UNDO_DUPLICATE)
   {
@@ -771,7 +769,7 @@ void dt_image_set_locations(const GList *imgs,
       dt_undo_end_group(darktable.undo);
     }
 
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
   }
 }
 
@@ -833,7 +831,7 @@ void dt_image_set_images_locations(const GList *imgs,
                    undo, _pop_undo, _geotag_undo_data_free);
     dt_undo_end_group(darktable.undo);
   }
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
 }
 
 void dt_image_update_final_size(const dt_imgid_t imgid)
@@ -863,8 +861,8 @@ void dt_image_update_final_size(const dt_imgid_t imgid)
       imgtmp->final_width = ww;
       imgtmp->final_height = hh;
       dt_image_cache_write_release(darktable.image_cache, imgtmp, DT_IMAGE_CACHE_RELAXED);
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_METADATA_UPDATE);
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_IMAGE_CHANGED);
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_METADATA_UPDATE);
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_IMAGE_CHANGED);
     }
   }
   dt_print(DT_DEBUG_PIPE, "[dt_image_update_final_size] for ID=%i, updated to %ix%i\n", imgid, ww, hh);
@@ -1458,7 +1456,7 @@ static dt_imgid_t _image_duplicate_with_version(const dt_imgid_t imgid,
     // make sure that the duplicate doesn't have some magic darktable| tags
     if(dt_tag_detach_by_string("darktable|changed", newid, FALSE, FALSE)
        || dt_tag_detach_by_string("darktable|exported", newid, FALSE, FALSE))
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
 
     /* unset change timestamp */
     dt_image_cache_unset_change_timestamp(darktable.image_cache, newid);
@@ -1515,7 +1513,7 @@ void dt_image_remove(const dt_imgid_t imgid)
   // also clear all thumbnails in mipmap_cache.
   dt_mipmap_cache_remove(darktable.mipmap_cache, imgid);
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGE_REMOVED, imgid, 0);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_IMAGE_REMOVED, imgid, 0);
 }
 
 gboolean dt_image_altered(const dt_imgid_t imgid)
@@ -1780,7 +1778,7 @@ static dt_imgid_t _image_import_internal(const dt_filmid_t film_id,
     if(raise_signals)
     {
       GList *imgs = g_list_prepend(NULL, GINT_TO_POINTER(id));
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED, imgs, 0);
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_GEOTAG_CHANGED, imgs, 0);
     }
     return id;
   }
@@ -1999,9 +1997,9 @@ static dt_imgid_t _image_import_internal(const dt_filmid_t film_id,
 
   if(raise_signals)
   {
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGE_IMPORT, id);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_IMAGE_IMPORT, id);
     GList *imgs = g_list_prepend(NULL, GINT_TO_POINTER(id));
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED, imgs, 0);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_GEOTAG_CHANGED, imgs, 0);
   }
 
   // the following line would look logical with new_tags_set being the

--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -192,7 +192,7 @@ void dt_import_session_import(struct dt_import_session_t *self)
   const dt_imgid_t imgid = dt_image_import(self->film->id, self->current_filename, TRUE, TRUE);
   if(dt_is_valid_imgid(imgid))
   {
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, imgid);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, imgid);
     dt_control_queue_redraw();
   }
 }

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -331,7 +331,7 @@ static void _pop_undo(gpointer user_data,
       *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(undometadata->imgid));
     }
 
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
   }
 }
 

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -813,7 +813,7 @@ void dt_mipmap_cache_print(dt_mipmap_cache_t *cache)
 
 static gboolean _raise_signal_mipmap_updated(gpointer user_data)
 {
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, GPOINTER_TO_INT(user_data));
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, GPOINTER_TO_INT(user_data));
   return FALSE; // only call once
 }
 

--- a/src/common/selection.c
+++ b/src/common/selection.c
@@ -45,7 +45,7 @@ static void _selection_raise_signal()
   dt_act_on_reset_cache(TRUE);
   dt_act_on_reset_cache(FALSE);
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_SELECTION_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_SELECTION_CHANGED);
 }
 
 /* updates the internal collection of an selection */
@@ -147,8 +147,7 @@ const dt_selection_t *dt_selection_new()
   //TODO: check whether this is actually necessary, since
   //  dt_collection_update_query calls dt_collection_update before
   //  raising the signal
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
-                            G_CALLBACK(_selection_update_collection), (gpointer)s);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_COLLECTION_CHANGED, _selection_update_collection, s);
 
   return s;
 }

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -467,7 +467,7 @@ void dt_styles_update(const char *name,
 
   dt_gui_style_content_dialog("", -1);
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_STYLE_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_STYLE_CHANGED);
 
   g_free(desc);
 }
@@ -553,7 +553,7 @@ void dt_styles_create_from_style(const char *name,
     dt_styles_save_to_file(newname, NULL, FALSE);
 
     dt_control_log(_("style named '%s' successfully created"), newname);
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_STYLE_CHANGED);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_STYLE_CHANGED);
   }
 }
 
@@ -638,7 +638,7 @@ gboolean dt_styles_create_from_image(const char *name,
     /* backup style to disk */
     dt_styles_save_to_file(name, NULL, FALSE);
 
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_STYLE_CHANGED);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_STYLE_CHANGED);
     return TRUE;
   }
   return FALSE;
@@ -988,8 +988,7 @@ void _styles_apply_to_image_ext(const char *name,
     dt_image_synch_xmp(newimgid);
 
     /* redraw center view to update visible mipmaps */
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                  DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, newimgid);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, newimgid);
   }
 }
 
@@ -1015,7 +1014,7 @@ void dt_styles_apply_to_dev(const char *name, const dt_imgid_t imgid)
   _styles_apply_to_image_ext(name, FALSE, FALSE, imgid, FALSE);
   dt_dev_reload_image(darktable.develop, imgid);
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
 
   /* record current history state : after change (needed for undo) */
   dt_dev_undo_end_record(darktable.develop);
@@ -1053,7 +1052,7 @@ void dt_styles_delete_by_name_adv(const char *name, const gboolean raise)
     dt_action_rename(old, NULL);
 
     if(raise)
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_STYLE_CHANGED);
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_STYLE_CHANGED);
   }
 }
 
@@ -1653,7 +1652,7 @@ void dt_styles_import_from_file(const char *style_path)
   dt_styles_style_data_free(style, TRUE);
   fclose(style_file);
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_STYLE_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_STYLE_CHANGED);
 }
 
 gchar *dt_styles_get_description(const char *name)

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -143,7 +143,7 @@ static void _pop_undo(gpointer user_data,
       *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(undotags->imgid));
     }
 
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
   }
 }
 
@@ -220,7 +220,7 @@ gboolean dt_tag_new_from_gui(const char *name,
   const gboolean ret = dt_tag_new(name, tagid);
   /* if everything went fine, raise signal of tags change to refresh
    * keywords module in GUI */
-  if(ret) DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+  if(ret) DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
   return ret;
 }
 
@@ -1770,7 +1770,7 @@ ssize_t dt_tag_import(const char *filename)
   g_list_free_full(hierarchy, g_free);
   fclose(fd);
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
 
   return count;
 }

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -741,27 +741,27 @@ void dt_control_toast_busy_leave()
 
 void dt_control_queue_redraw()
 {
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_REDRAW_ALL);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_REDRAW_ALL);
 }
 
 void dt_control_queue_redraw_center()
 {
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_REDRAW_CENTER);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_REDRAW_CENTER);
 }
 
 void dt_control_navigation_redraw()
 {
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_NAVIGATION_REDRAW);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_NAVIGATION_REDRAW);
 }
 
 void dt_control_log_redraw()
 {
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_LOG_REDRAW);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_LOG_REDRAW);
 }
 
 void dt_control_toast_redraw()
 {
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_TOAST_REDRAW);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_TOAST_REDRAW);
 }
 
 static int _widget_queue_draw(void *widget)
@@ -908,7 +908,7 @@ void dt_control_set_mouse_over_id(const dt_imgid_t imgid)
   {
     darktable.control->mouse_over_id = imgid;
     dt_pthread_mutex_unlock(&(darktable.control->global_mutex));
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
   }
   else
     dt_pthread_mutex_unlock(&(darktable.control->global_mutex));

--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -288,9 +288,9 @@ void _camera_import_image_downloaded(const dt_camera_t *camera,
   {
     // only redraw at the end, to not spam the cpu with exposure events
     dt_control_queue_redraw_center();
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
 
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_IMPORTED,
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_FILMROLLS_IMPORTED,
                             dt_import_session_film_id(t->shared.session));
   }
   t->import_count++;

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -222,7 +222,7 @@ static int32_t _generic_dt_control_fileop_images_job_run
     dt_collection_deserialize(collect, FALSE);
   }
   dt_film_remove_empty();
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_FILMROLLS_CHANGED);
   dt_collection_update_query(darktable.collection,
                              DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
                              g_list_copy(params->index));
@@ -692,7 +692,7 @@ static int32_t dt_control_merge_hdr_job_run(dt_job_t *job)
   dt_collection_update_query(darktable.collection,
                              DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
                              g_list_prepend(NULL, GINT_TO_POINTER(imageid)));
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_FILMROLLS_CHANGED);
   dt_control_queue_redraw_center();
 
 end:
@@ -741,7 +741,7 @@ static int32_t dt_control_duplicate_images_job_run(dt_job_t *job)
 
   dt_undo_end_group(darktable.undo);
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_FILMROLLS_CHANGED);
   dt_control_queue_redraw_center();
   return 0;
 }
@@ -985,7 +985,7 @@ static int32_t dt_control_remove_images_job_run(dt_job_t *job)
   dt_collection_update_query(darktable.collection,
                              DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
                              g_list_copy(params->index));
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_FILMROLLS_CHANGED);
   dt_control_queue_redraw_center();
 
   return 0;
@@ -1359,7 +1359,7 @@ delete_next_file:
   dt_collection_update_query(darktable.collection,
                              DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
                              g_list_copy(params->index));
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_FILMROLLS_CHANGED);
   dt_control_queue_redraw_center();
   return 0;
 }
@@ -1433,7 +1433,7 @@ static int32_t dt_control_gpx_apply_job_run(dt_job_t *job)
   g_time_zone_unref(tz_camera);
   dt_gpx_destroy(gpx);
   g_array_unref(gloc);
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED, imgs, 0);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_GEOTAG_CHANGED, imgs, 0);
   return 0;
 
 bail_out:
@@ -1507,8 +1507,8 @@ static int32_t dt_control_local_copy_images_job_run(dt_job_t *job)
   dt_collection_update_query(darktable.collection,
                              DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_LOCAL_COPY,
                              g_list_copy(params->index));
-  if(tag_change) DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED);
+  if(tag_change) DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_FILMROLLS_CHANGED);
   dt_control_queue_redraw_center();
   return 0;
 }
@@ -1550,7 +1550,7 @@ static int32_t dt_control_refresh_exif_run(dt_job_t *job)
                  "[dt_control_refresh_exif_run] couldn't dt_image_cache_get for imgid %i\n",
                  imgid);
 
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_IMAGE_CHANGED);
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_IMAGE_CHANGED);
     }
     else
       dt_print(DT_DEBUG_ALWAYS,"[dt_control_refresh_exif_run] illegal imgid %i\n", imgid);
@@ -1563,8 +1563,8 @@ static int32_t dt_control_refresh_exif_run(dt_job_t *job)
                              DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
                              g_list_copy(params->index));
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGE_INFO_CHANGED, imgs);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_IMAGE_INFO_CHANGED, imgs);
   dt_control_queue_redraw_center();
   return 0;
 }
@@ -1707,7 +1707,7 @@ static int32_t _control_discard_history_job_run(dt_job_t *job)
     _update_progress(job, fraction, &prev_time);
   }
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
   dt_undo_end_group(darktable.undo);
   dt_collection_update_query(darktable.collection,
                              DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
@@ -1769,7 +1769,7 @@ static int32_t _control_apply_styles_job_run(dt_job_t *job)
     _update_progress(job, fraction, &prev_time);
   }
   dt_undo_end_group(darktable.undo);
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
 
   g_list_free(imgs);
   g_list_free_full(styles, g_free);
@@ -1936,7 +1936,7 @@ end:
   // notify the user via the window manager
   dt_ui_notify_user();
 
-  if(tag_change) DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+  if(tag_change) DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
   return 0;
 }
 
@@ -2588,8 +2588,8 @@ static int32_t dt_control_datetime_job_run(dt_job_t *job)
     ? N_("added time offset to %d images")
     : N_("set date/time of %d images");
   dt_control_log(ngettext(mes21, mes22, cntr), cntr);
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGE_INFO_CHANGED, imgs);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_IMAGE_INFO_CHANGED, imgs);
   return 0;
 }
 
@@ -2938,9 +2938,9 @@ static int32_t _control_import_job_run(dt_job_t *job)
 
   dt_control_log(ngettext("imported %d image", "imported %d images", cntr), cntr);
   dt_control_queue_redraw_center();
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED, imgs, 0);
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_IMPORTED, filmid);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_GEOTAG_CHANGED, imgs, 0);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_FILMROLLS_IMPORTED, filmid);
   if(data->wait)
     *data->wait = FALSE;  // resume caller
   return 0;

--- a/src/control/jobs/film_jobs.c
+++ b/src/control/jobs/film_jobs.c
@@ -364,12 +364,12 @@ static void _film_import1(dt_job_t *job, dt_film_t *film, GList *images)
 
   // only redraw at the end, to not spam the cpu with exposure events
   dt_control_queue_redraw_center();
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_IMPORTED, film ? film->id : cfr->id);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_FILMROLLS_IMPORTED, film ? film->id : cfr->id);
 
   //QUESTION: should this come after _apply_filmroll_gpx, since that can change geotags again?
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED, all_imgs, 0);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_GEOTAG_CHANGED, all_imgs, 0);
 
   _apply_filmroll_gpx(cfr);
 

--- a/src/control/jobs/image_jobs.c
+++ b/src/control/jobs/image_jobs.c
@@ -79,7 +79,7 @@ static int32_t dt_image_import_job_run(dt_job_t *job)
   const int id = dt_image_import(params->film_id, params->filename, TRUE, TRUE);
   if(id)
   {
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, id);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, id);
     dt_control_queue_redraw();
   }
 

--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -96,119 +96,119 @@ static void _image_geotag_destroy_callback(gpointer instance, gpointer imgs, con
 
 static dt_signal_description _signal_description[DT_SIGNAL_COUNT] = {
   /* Global signals */
-  { "dt-global-mouse-over-image-change", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE
-  { "dt-global-active-images-change", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_ACTIVE_IMAGES_CHANGE
+  [DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE] = { "dt-global-mouse-over-image-change",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
+  [DT_SIGNAL_ACTIVE_IMAGES_CHANGE] = { "dt-global-active-images-change",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
 
-  { "dt-control-redraw-all", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_CONTROL_REDRAW_ALL
-  { "dt-control-redraw-center", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_CONTROL_REDRAW_CENTER
+  [DT_SIGNAL_CONTROL_REDRAW_ALL] = { "dt-control-redraw-all",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
+  [DT_SIGNAL_CONTROL_REDRAW_CENTER] = { "dt-control-redraw-center",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
 
-  { "dt-viewmanager-view-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 2, pointer_2arg, NULL,
-    FALSE }, // DT_SIGNAL_VIEWMANAGER_VIEW_CHANGED
-  { "dt-viewmanager-view-cannot-change", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 2, pointer_2arg,
-    NULL, FALSE }, // DT_SIGNAL_VIEWMANAGER_VIEW_CANNOT_CHANGE
-  { "dt-viewmanager-thumbtable-activate", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__UINT, 1, uint_arg,
-    NULL, FALSE }, // DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE
-
-  { "dt-collection-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 4, collection_args,
-    G_CALLBACK(_collection_changed_destroy_callback), FALSE }, // DT_SIGNAL_COLLECTION_CHANGED
-  { "dt-selection-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_SELECTION_CHANGED
-  { "dt-tag-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_TAG_CHANGED
-  { "dt-geotag-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 2, geotag_arg,
-    G_CALLBACK(_image_geotag_destroy_callback), FALSE }, // DT_SIGNAL_GEOTAG_CHANGED
-  { "dt-metadata-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__UINT, 1, uint_arg, NULL,
-    FALSE }, // DT_SIGNAL_METADATA_CHANGED
-  { "dt-image-info-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 1, pointer_arg,
-    G_CALLBACK(_image_info_changed_destroy_callback), FALSE }, // DT_SIGNAL_IMAGE_INFO_CHANGED
-  { "dt-style-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_STYLE_CHANGED
-  { "dt-images-order-change", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 1, pointer_arg, NULL,
-    FALSE }, // DT_SIGNAL_IMAGES_ORDER_CHANGE
-  { "dt-filmrolls-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_FILMROLLS_CHANGED
-  { "dt-filmrolls-imported", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__UINT, 1, uint_arg, NULL,
-    FALSE }, // DT_SIGNAL_FILMROLLS_IMPORTED
-  { "dt-filmrolls-removed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_FILMROLLS_REMOVED
-  { "dt-presets-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 1, pointer_arg,
-    G_CALLBACK(_presets_changed_destroy_callback), FALSE }, // DT_SIGNAL_PRESETS_CHANGED
+  [DT_SIGNAL_VIEWMANAGER_VIEW_CHANGED] = { "dt-viewmanager-view-changed",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 2, pointer_2arg, NULL, FALSE },
+  [DT_SIGNAL_VIEWMANAGER_VIEW_CANNOT_CHANGE] = { "dt-viewmanager-view-cannot-change",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 2, pointer_2arg, NULL, FALSE },
+  [DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE] = { "dt-viewmanager-thumbtable-activate",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__UINT, 1, uint_arg, NULL,  FALSE },
+  [DT_SIGNAL_COLLECTION_CHANGED] = { "dt-collection-changed",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 4, collection_args,
+    G_CALLBACK(_collection_changed_destroy_callback), FALSE },
+  [DT_SIGNAL_SELECTION_CHANGED] = { "dt-selection-changed",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
+  [DT_SIGNAL_TAG_CHANGED] = { "dt-tag-changed",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
+  [DT_SIGNAL_GEOTAG_CHANGED] = { "dt-geotag-changed",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 2, geotag_arg,
+    G_CALLBACK(_image_geotag_destroy_callback), FALSE },
+  [DT_SIGNAL_METADATA_CHANGED] = { "dt-metadata-changed",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__UINT, 1, uint_arg, NULL, FALSE },
+  [DT_SIGNAL_IMAGE_INFO_CHANGED] = { "dt-image-info-changed",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 1, pointer_arg,
+    G_CALLBACK(_image_info_changed_destroy_callback), FALSE },
+  [DT_SIGNAL_STYLE_CHANGED] = { "dt-style-changed",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
+  [DT_SIGNAL_IMAGES_ORDER_CHANGE] = { "dt-images-order-change",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 1, pointer_arg, NULL, FALSE },
+  [DT_SIGNAL_FILMROLLS_CHANGED] = { "dt-filmrolls-changed",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
+  [DT_SIGNAL_FILMROLLS_IMPORTED] = { "dt-filmrolls-imported",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__UINT, 1, uint_arg, NULL, FALSE },
+  [DT_SIGNAL_FILMROLLS_REMOVED] = { "dt-filmrolls-removed",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
+  [DT_SIGNAL_PRESETS_CHANGED] = { "dt-presets-changed",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 1, pointer_arg,
+    G_CALLBACK(_presets_changed_destroy_callback), FALSE },
 
   /* Develop related signals */
-  { "dt-develop-initialized", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_DEVELOP_INITIALIZED
-  { "dt-develop-mipmap-updated", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__UINT, 1, uint_arg, NULL,
-    FALSE }, // DT_SIGNAL_DEVELOP_MIPMAP_UPDATED
-  { "dt-develop-preview-pipe-finished", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED
-  { "dt-develop-preview2-pipe-finished", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_DEVELOP_PREVIEW2_PIPE_FINISHED
-  { "dt-develop-ui-pipe-finished", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED
-  { "dt-develop-history-will-change", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_DEVELOP_HISTORY_WILL_CHANGE
-  { "dt-develop-history-change", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_DEVELOP_HISTORY_CHANGE
-  { "dt-develop-history-invalidated", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_DEVELOP_HISTORY_INVALIDATED
-  { "dt-develop-module-remove", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 1, pointer_arg, NULL,
-    TRUE }, // DT_SIGNAL_MODULE_REMOVE
-  { "dt-develop-module-moved", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_DEVELOP_MODULE_MOVED
-  { "dt-develop-image-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_DEVELOP_IMAGE_CHANGE
-  { "dt-develop-distort", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_DEVELOP_DISTORT
+  [DT_SIGNAL_DEVELOP_INITIALIZE] = { "dt-develop-initialized",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
+  [DT_SIGNAL_DEVELOP_MIPMAP_UPDATED] = { "dt-develop-mipmap-updated",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__UINT, 1, uint_arg, NULL, FALSE },
+  [DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED] = { "dt-develop-preview-pipe-finished",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
+  [DT_SIGNAL_DEVELOP_PREVIEW2_PIPE_FINISHED] = { "dt-develop-preview2-pipe-finished",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
+  [DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED] = { "dt-develop-ui-pipe-finished",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
+  [DT_SIGNAL_DEVELOP_HISTORY_WILL_CHANGE] = { "dt-develop-history-will-change",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
+  [DT_SIGNAL_DEVELOP_HISTORY_CHANGE] = { "dt-develop-history-change",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
+  [DT_SIGNAL_DEVELOP_HISTORY_INVALIDATED] = { "dt-develop-history-invalidated",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
+  [DT_SIGNAL_DEVELOP_MODULE_REMOVE] = { "dt-develop-module-remove",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 1, pointer_arg, NULL, TRUE },
+  [DT_SIGNAL_DEVELOP_MODULE_MOVED] = { "dt-develop-module-moved",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
+  [DT_SIGNAL_DEVELOP_IMAGE_CHANGED] = { "dt-develop-image-changed",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
+  [DT_SIGNAL_DEVELOP_DISTORT] = { "dt-develop-distort",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
 
-  { "dt-image-removed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__UINT, 1, uint_arg, NULL,
-    FALSE }, // DT_SIGNAL_IMAGE_REMOVED
-  { "dt-control-profile-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_CONTROL_PROFILE_CHANGED
-  { "dt-control-profile-user-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__UINT, 1, uint_arg, NULL,
-    FALSE }, // DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED
-  { "dt-image-import", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__UINT, 1, uint_arg, NULL,
-    FALSE }, // DT_SIGNAL_IMAGE_IMPORT
-  { "dt-image-export-tmpfile", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 6, image_export_arg, NULL,
-    TRUE }, // DT_SIGNAL_IMAGE_EXPORT_TMPFILE
-  { "dt-imageio-storage-change", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_IMAGEIO_STORAGE_CHANGE
+  [DT_SIGNAL_IMAGE_REMOVED] = { "dt-image-removed",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__UINT, 1, uint_arg, NULL, FALSE },
+  [DT_SIGNAL_CONTROL_PROFILE_CHANGED] = { "dt-control-profile-changed",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
+  [DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED] = { "dt-control-profile-user-changed",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__UINT, 1, uint_arg, NULL, FALSE },
+  [DT_SIGNAL_IMAGE_IMPORT] = { "dt-image-import",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__UINT, 1, uint_arg, NULL, FALSE },
+  [DT_SIGNAL_IMAGE_EXPORT_TMPFILE] = { "dt-image-export-tmpfile",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 6, image_export_arg, NULL, TRUE },
+  [DT_SIGNAL_IMAGEIO_STORAGE_CHANGE] = { "dt-imageio-storage-change",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
 
+  [DT_SIGNAL_PREFERENCES_CHANGE] = { "dt-preferences-changed",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
 
-  { "dt-preferences-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_PREFERENCES_CHANGE
+  [DT_SIGNAL_CAMERA_DETECTED] = { "dt-camera-detected",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
 
+  [DT_SIGNAL_CONTROL_NAVIGATION_REDRAW] = { "dt-control-navigation-redraw",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
 
-  { "dt-camera-detected", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_CAMERA_DETECTED,
+  [DT_SIGNAL_CONTROL_LOG_REDRAW] = { "dt-control-log-redraw",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
 
-  { "dt-control-navigation-redraw", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_CONTROL_NAVIGATION_REDRAW
+  [DT_SIGNAL_CONTROL_TOAST_REDRAW] = { "dt-control-toast-redraw",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
 
-  { "dt-control-log-redraw", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_CONTROL_LOG_REDRAW
+  [DT_SIGNAL_CONTROL_PICKERDATA_READY] = { "dt-control-pickerdata-ready",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 2, pointer_2arg, NULL, FALSE },
 
-  { "dt-control-toast-redraw", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_CONTROL_TOAST_REDRAW
+  [DT_SIGNAL_METADATA_UPDATE] = { "dt-metadata-update",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
 
-  { "dt-control-pickerdata-ready", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 2, pointer_2arg, NULL,
-    FALSE }, // DT_SIGNAL_CONTROL_PICKERDATA_REAEDY
+  [DT_SIGNAL_TROUBLE_MESSAGE] = { "dt-trouble-message",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 3, pointer_trouble, NULL, FALSE },
 
-  { "dt-metadata-update", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_METADATA_UPDATE
+  [DT_SIGNAL_LOCATION_CHANGED] = { "dt-location-changed",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 1, pointer_arg, NULL, TRUE },
 
-  { "dt-trouble-message", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 3, pointer_trouble, NULL,
-    FALSE }, // DT_SIGNAL_TROUBLE_MESSAGE
-
-  { "dt-location-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 1, pointer_arg, NULL,
-    TRUE }, // DT_SIGNAL_LOCATION_CHANGED
-
- { "dt-imageio-storage-export-enable", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
-    FALSE }, // DT_SIGNAL_IMAGEIO_STORAGE_EXPORT_ENABLE
-
+  [DT_SIGNAL_IMAGEIO_STORAGE_EXPORT_ENABLE] = { "dt-imageio-storage-export-enable",
+    NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL, FALSE },
 };
 
 static GType _signal_type;

--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -307,35 +307,35 @@ void dt_control_signal_block_by_func(const struct dt_control_signal_t *ctlsig, G
 /* unblocks a callback */
 void dt_control_signal_unblock_by_func(const struct dt_control_signal_t *ctlsig, GCallback cb, gpointer user_data);
 
-#define DT_CONTROL_SIGNAL_RAISE(signal, ...)                                                                                     \
-  do                                                                                                                             \
-  {                                                                                                                              \
-    if((darktable.unmuted_signal_dbg_acts & DT_DEBUG_SIGNAL_ACT_RAISE) && darktable.unmuted_signal_dbg[signal])                  \
-    {                                                                                                                            \
-      dt_print(DT_DEBUG_SIGNAL, "[signal] %s:%d, function %s(): raise signal %s\n", __FILE__, __LINE__, __FUNCTION__, #signal);  \
-    }                                                                                                                            \
-    dt_control_signal_raise(darktable.signals, signal, ##__VA_ARGS__);                                                           \
+#define DT_CONTROL_SIGNAL_RAISE(signal, ...)                                                                               \
+  do                                                                                                                       \
+  {                                                                                                                        \
+    if((darktable.unmuted_signal_dbg_acts & DT_DEBUG_SIGNAL_ACT_RAISE) && darktable.unmuted_signal_dbg[signal])            \
+    {                                                                                                                      \
+      dt_print(DT_DEBUG_SIGNAL, "[signal] raise %s; %s:%d, function %s()\n", #signal, __FILE__, __LINE__, __FUNCTION__);   \
+    }                                                                                                                      \
+    dt_control_signal_raise(darktable.signals, signal, ##__VA_ARGS__);                                                     \
   } while (0)
 
-#define DT_CONTROL_SIGNAL_CONNECT(signal, cb, user_data)                                                                         \
-  do                                                                                                                             \
-  {                                                                                                                              \
-    if((darktable.unmuted_signal_dbg_acts & DT_DEBUG_SIGNAL_ACT_CONNECT) && darktable.unmuted_signal_dbg[signal])                \
-    {                                                                                                                            \
-      dt_print(DT_DEBUG_SIGNAL, "[signal] %s:%d, function: %s() connect handler %s to signal %s\n", __FILE__, __LINE__,          \
-               __FUNCTION__, #cb, #signal);                                                                                      \
-    }                                                                                                                            \
-    dt_control_signal_connect(darktable.signals, signal, G_CALLBACK(cb), user_data);                                             \
+#define DT_CONTROL_SIGNAL_CONNECT(signal, cb, user_data)                                                                   \
+  do                                                                                                                       \
+  {                                                                                                                        \
+    if((darktable.unmuted_signal_dbg_acts & DT_DEBUG_SIGNAL_ACT_CONNECT) && darktable.unmuted_signal_dbg[signal])          \
+    {                                                                                                                      \
+      dt_print(DT_DEBUG_SIGNAL, "[signal] connect    %s to %s; %s:%d, function: %s()\n", #cb, #signal,                        \
+                                __FILE__, __LINE__, __FUNCTION__);                                                         \
+    }                                                                                                                      \
+    dt_control_signal_connect(darktable.signals, signal, G_CALLBACK(cb), user_data);                                       \
   } while (0)
 
-#define DT_CONTROL_SIGNAL_DISCONNECT(cb, user_data)                                                                              \
-  do                                                                                                                             \
-  {                                                                                                                              \
-    if(darktable.unmuted_signal_dbg_acts & DT_DEBUG_SIGNAL_ACT_DISCONNECT)                                                       \
-    {                                                                                                                            \
-      dt_print(DT_DEBUG_SIGNAL, "[signal] %s:%d, function: %s() disconnect handler %s\n", __FILE__, __LINE__, __FUNCTION__, #cb);\
-    }                                                                                                                            \
-    dt_control_signal_disconnect(darktable.signals, G_CALLBACK(cb), user_data);                                                  \
+#define DT_CONTROL_SIGNAL_DISCONNECT(cb, user_data)                                                                        \
+  do                                                                                                                       \
+  {                                                                                                                        \
+    if(darktable.unmuted_signal_dbg_acts & DT_DEBUG_SIGNAL_ACT_DISCONNECT)                                                 \
+    {                                                                                                                      \
+      dt_print(DT_DEBUG_SIGNAL, "[signal] disconnect %s; %s:%d, function: %s()\n", #cb, __FILE__, __LINE__, __FUNCTION__); \
+    }                                                                                                                      \
+    dt_control_signal_disconnect(darktable.signals, G_CALLBACK(cb), user_data);                                            \
   } while (0)
 
 G_END_DECLS

--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -307,17 +307,17 @@ void dt_control_signal_block_by_func(const struct dt_control_signal_t *ctlsig, G
 /* unblocks a callback */
 void dt_control_signal_unblock_by_func(const struct dt_control_signal_t *ctlsig, GCallback cb, gpointer user_data);
 
-#define DT_DEBUG_CONTROL_SIGNAL_RAISE(ctlsig, signal, ...)                                                                       \
+#define DT_CONTROL_SIGNAL_RAISE(signal, ...)                                                                                     \
   do                                                                                                                             \
   {                                                                                                                              \
-    if((darktable.unmuted_signal_dbg_acts & DT_DEBUG_SIGNAL_ACT_RAISE) && darktable.unmuted_signal_dbg[signal])                 \
+    if((darktable.unmuted_signal_dbg_acts & DT_DEBUG_SIGNAL_ACT_RAISE) && darktable.unmuted_signal_dbg[signal])                  \
     {                                                                                                                            \
       dt_print(DT_DEBUG_SIGNAL, "[signal] %s:%d, function %s(): raise signal %s\n", __FILE__, __LINE__, __FUNCTION__, #signal);  \
     }                                                                                                                            \
-    dt_control_signal_raise(ctlsig, signal, ##__VA_ARGS__);                                                                      \
+    dt_control_signal_raise(darktable.signals, signal, ##__VA_ARGS__);                                                           \
   } while (0)
 
-#define DT_DEBUG_CONTROL_SIGNAL_CONNECT(ctlsig, signal, cb, user_data)                                                           \
+#define DT_CONTROL_SIGNAL_CONNECT(signal, cb, user_data)                                                                         \
   do                                                                                                                             \
   {                                                                                                                              \
     if((darktable.unmuted_signal_dbg_acts & DT_DEBUG_SIGNAL_ACT_CONNECT) && darktable.unmuted_signal_dbg[signal])                \
@@ -325,17 +325,17 @@ void dt_control_signal_unblock_by_func(const struct dt_control_signal_t *ctlsig,
       dt_print(DT_DEBUG_SIGNAL, "[signal] %s:%d, function: %s() connect handler %s to signal %s\n", __FILE__, __LINE__,          \
                __FUNCTION__, #cb, #signal);                                                                                      \
     }                                                                                                                            \
-    dt_control_signal_connect(ctlsig, signal, cb, user_data);                                                                    \
+    dt_control_signal_connect(darktable.signals, signal, G_CALLBACK(cb), user_data);                                             \
   } while (0)
 
-#define DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(ctlsig, cb, user_data)                                                                \
+#define DT_CONTROL_SIGNAL_DISCONNECT(cb, user_data)                                                                              \
   do                                                                                                                             \
   {                                                                                                                              \
     if(darktable.unmuted_signal_dbg_acts & DT_DEBUG_SIGNAL_ACT_DISCONNECT)                                                       \
     {                                                                                                                            \
       dt_print(DT_DEBUG_SIGNAL, "[signal] %s:%d, function: %s() disconnect handler %s\n", __FILE__, __LINE__, __FUNCTION__, #cb);\
     }                                                                                                                            \
-    dt_control_signal_disconnect(ctlsig, cb, user_data);                                                                         \
+    dt_control_signal_disconnect(darktable.signals, G_CALLBACK(cb), user_data);                                                  \
   } while (0)
 
 G_END_DECLS

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -477,7 +477,7 @@ restart:
   dt_pthread_mutex_unlock(&pipe->mutex);
 
   if(dev->gui_attached && !dev->gui_leaving && signal != -1)
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, signal);
+    DT_CONTROL_SIGNAL_RAISE(signal);
 
   if(port) return;
 
@@ -1030,7 +1030,7 @@ static void _dev_add_history_item(dt_develop_t *dev,
   {
     /* signal that history has changed */
     if(tag_change)
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
 
     /* redraw */
     dt_control_queue_redraw_center();
@@ -3183,8 +3183,7 @@ void dt_dev_module_remove(dt_develop_t *dev,
     /* signal that history has changed */
     dt_dev_undo_end_record(dev);
 
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                  DT_SIGNAL_DEVELOP_MODULE_REMOVE, module);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_MODULE_REMOVE, module);
     /* redraw */
     dt_control_queue_redraw_center();
   }
@@ -3436,8 +3435,7 @@ void dt_dev_undo_start_record(dt_develop_t *dev)
 {
   /* record current history state : before change (needed for undo) */
   if(dev->gui_attached && dt_view_get_current() == DT_VIEW_DARKROOM)
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                  DT_SIGNAL_DEVELOP_HISTORY_WILL_CHANGE);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_HISTORY_WILL_CHANGE);
 
   dev->gui_previous_target = NULL;
 }
@@ -3446,7 +3444,7 @@ void dt_dev_undo_end_record(dt_develop_t *dev)
 {
   /* record current history state : after change (needed for undo) */
   if(dev->gui_attached && dt_view_get_current() == DT_VIEW_DARKROOM)
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_CHANGE);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_HISTORY_CHANGE);
 }
 
 void dt_dev_image(const dt_imgid_t imgid,

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -518,7 +518,7 @@ static void _gui_delete_callback(GtkButton *button, dt_iop_module_t *module)
   if(!next) return; // what happened ???
 
   if(dev->gui_attached)
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_WILL_CHANGE);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_HISTORY_WILL_CHANGE);
 
   // we must pay attention if priority is 0
   const gboolean is_zero = (module->multi_priority == 0);
@@ -573,7 +573,7 @@ static void _gui_delete_callback(GtkButton *button, dt_iop_module_t *module)
 
   // we save the current state of history (with the new multi_priorities)
   if(dev->gui_attached)
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_CHANGE);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_HISTORY_CHANGE);
 
   // rebuild the accelerators (to point to an extant module)
   dt_iop_connect_accels_multi(module->so);
@@ -675,7 +675,7 @@ static void _gui_movedown_callback(GtkButton *button, dt_iop_module_t *module)
 
   dt_dev_pixelpipe_rebuild(module->dev);
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_MODULE_MOVED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_MODULE_MOVED);
 }
 
 static void _gui_moveup_callback(GtkButton *button, dt_iop_module_t *module)
@@ -711,7 +711,7 @@ static void _gui_moveup_callback(GtkButton *button, dt_iop_module_t *module)
 
   dt_dev_pixelpipe_rebuild(next->dev);
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_MODULE_MOVED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_MODULE_MOVED);
 }
 
 dt_iop_module_t *dt_iop_gui_duplicate(dt_iop_module_t *base,
@@ -1074,7 +1074,7 @@ static gboolean _gui_off_button_press(GtkButton *w,
 {
   if(module->operation_tags() & IOP_TAG_DISTORT)
   {
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_DISTORT);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_DISTORT);
   }
 
   if(!darktable.gui->reset && dt_modifier_is(e->state, GDK_CONTROL_MASK))
@@ -1291,8 +1291,8 @@ void dt_iop_set_module_trouble_message(dt_iop_module_t *const module,
   if(!dt_iop_is_hidden(module)
      && module->gui_data
      && dt_conf_get_bool("plugins/darkroom/show_warnings"))
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TROUBLE_MESSAGE,
-                                  module, trouble_msg, trouble_tooltip);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TROUBLE_MESSAGE,
+                            module, trouble_msg, trouble_tooltip);
 }
 
 void dt_iop_gui_init(dt_iop_module_t *module)
@@ -1735,9 +1735,7 @@ void dt_iop_load_modules_so(void)
     ("/plugins", sizeof(dt_iop_module_so_t),
      dt_iop_load_module_so, _init_module_so, NULL);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
-                                  G_CALLBACK(_iop_preferences_changed),
-                                  (gpointer)(darktable.iop));
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_PREFERENCES_CHANGE, _iop_preferences_changed, darktable.iop);
 }
 
 gboolean dt_iop_load_module(dt_iop_module_t *module,
@@ -1816,9 +1814,7 @@ void dt_iop_cleanup_module(dt_iop_module_t *module)
 
 void dt_iop_unload_modules_so()
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_iop_preferences_changed),
-                                     (gpointer)(darktable.iop));
+  DT_CONTROL_SIGNAL_DISCONNECT(_iop_preferences_changed, darktable.iop);
 
   while(darktable.iop)
   {
@@ -2238,7 +2234,7 @@ void dt_iop_gui_update(dt_iop_module_t *module)
        && !darktable.develop->gui_synch
        && module->operation_tags() & IOP_TAG_DISTORT)
     {
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_DISTORT);
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_DISTORT);
     }
   }
   --darktable.gui->reset;
@@ -3048,7 +3044,7 @@ static gboolean _on_drag_motion(GtkWidget *widget, GdkDragContext *dc, gint x, g
 
     dt_dev_pixelpipe_rebuild(src->dev);
 
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_MODULE_MOVED);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_MODULE_MOVED);
   }
 
   return TRUE;

--- a/src/develop/lightroom.c
+++ b/src/develop/lightroom.c
@@ -922,7 +922,7 @@ static void _lrop(const dt_develop_t *dev, const xmlDocPtr doc, const dt_imgid_t
       }
       tagNode = tagNode->next;
     }
-    if(tag_change) DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+    if(tag_change) DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
   }
   else if(dev != NULL && !xmlStrcmp(name, (const xmlChar *)"RetouchInfo"))
   {
@@ -1592,7 +1592,7 @@ gboolean dt_lightroom_import(dt_imgid_t imgid, dt_develop_t *dev, gboolean iauto
     dt_image_set_location(imgid, &geoloc, FALSE, FALSE);
     GList *imgs = NULL;
     imgs = g_list_prepend(imgs, GINT_TO_POINTER(imgid));
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED, imgs, 0);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_GEOTAG_CHANGED, imgs, 0);
 
     if(imported[0]) g_strlcat(imported, ", ", sizeof(imported));
     g_strlcat(imported, _("geotagging"), sizeof(imported));
@@ -1619,7 +1619,7 @@ gboolean dt_lightroom_import(dt_imgid_t imgid, dt_develop_t *dev, gboolean iauto
       dt_dev_modulegroups_set(darktable.develop, dt_dev_modulegroups_get(darktable.develop));
       /* update xmp file */
       dt_image_synch_xmp(imgid);
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_CHANGE);
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_HISTORY_CHANGE);
     }
   }
   return TRUE;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1258,8 +1258,7 @@ static gboolean _pixelpipe_process_on_CPU(
                       module->picked_output_color_max,
                       pipe->dsc.cst, PIXELPIPE_PICKER_OUTPUT);
 
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                  DT_SIGNAL_CONTROL_PICKERDATA_READY, module, pipe);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_PICKERDATA_READY, module, pipe);
   }
 
   if(dt_atomic_get_int(&pipe->shutdown))
@@ -1959,8 +1958,7 @@ static gboolean _dev_pixelpipe_process_rec(
                                *output, outbufsize, pipe->dsc.cst,
                                PIXELPIPE_PICKER_OUTPUT);
 
-          DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                        DT_SIGNAL_CONTROL_PICKERDATA_READY, module, pipe);
+          DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_PICKERDATA_READY, module, pipe);
         }
 
         if(dt_atomic_get_int(&pipe->shutdown))
@@ -2111,8 +2109,7 @@ static gboolean _dev_pixelpipe_process_rec(
                             pipe->dsc.cst,
                             PIXELPIPE_PICKER_OUTPUT);
 
-          DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                        DT_SIGNAL_CONTROL_PICKERDATA_READY, module, pipe);
+          DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_PICKERDATA_READY, module, pipe);
         }
 
         if(dt_atomic_get_int(&pipe->shutdown))

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -936,21 +936,11 @@ dt_culling_t *dt_culling_new(dt_culling_mode_t mode)
                    G_CALLBACK(_event_button_release), table);
 
   // we register globals signals
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE,
-                                  G_CALLBACK(_dt_mouse_over_image_callback), table);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
-                                  G_CALLBACK(_dt_profile_change_callback), table);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_PREFERENCES_CHANGE,
-                                  G_CALLBACK(_dt_pref_change_callback),
-                                  table);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE,
-                                  G_CALLBACK(_dt_filmstrip_change), table);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_SELECTION_CHANGED,
-                                  G_CALLBACK(_dt_selection_changed_callback), table);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE, _dt_mouse_over_image_callback, table);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED, _dt_profile_change_callback, table);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_PREFERENCES_CHANGE, _dt_pref_change_callback, table);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, _dt_filmstrip_change, table);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_SELECTION_CHANGED, _dt_selection_changed_callback, table);
 
   g_object_ref(table->widget);
 
@@ -1762,7 +1752,7 @@ void dt_culling_update_active_images_list(dt_culling_t *table)
                      GINT_TO_POINTER(thumb->imgid));
   }
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_ACTIVE_IMAGES_CHANGE);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_ACTIVE_IMAGES_CHANGE);
 }
 
 // recreate the list of thumbs if needed and recomputes sizes and positions if needed
@@ -1829,7 +1819,7 @@ void dt_culling_full_redraw(dt_culling_t *table, const gboolean force)
                          GINT_TO_POINTER(thumb->imgid));
   }
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_ACTIVE_IMAGES_CHANGE);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_ACTIVE_IMAGES_CHANGE);
 
   // if the selection should follow active images
   if(table->selection_sync)

--- a/src/dtgtk/range.c
+++ b/src/dtgtk/range.c
@@ -149,7 +149,7 @@ static void _range_select_destroy(GtkWidget *widget)
 
   GtkDarktableRangeSelect *range = DTGTK_RANGE_SELECT(widget);
 
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_dt_pref_changed), range);
+  DT_CONTROL_SIGNAL_DISCONNECT(_dt_pref_changed, range);
 
   if(!g_list_is_empty(range->markers))
     g_list_free_full(range->markers, g_free);
@@ -1749,8 +1749,7 @@ GtkWidget *dtgtk_range_select_new(const gchar *property, const gboolean show_ent
 
   if(type == DT_RANGE_TYPE_DATETIME) _popup_date_init(range);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE, G_CALLBACK(_dt_pref_changed),
-                                  range);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_PREFERENCES_CHANGE, _dt_pref_changed, range);
   gtk_widget_set_name((GtkWidget *)range, "dt-range");
 
   return (GtkWidget *)range;

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -1365,19 +1365,12 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb,
                      G_CALLBACK(_event_main_drag_motion), thumb);
 
     g_object_set_data(G_OBJECT(thumb->w_main), "thumb", thumb);
-    DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_ACTIVE_IMAGES_CHANGE,
-                              G_CALLBACK(_dt_active_images_callback), thumb);
-    DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_SELECTION_CHANGED,
-                              G_CALLBACK(_dt_selection_changed_callback), thumb);
-    DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_MIPMAP_UPDATED,
-                              G_CALLBACK(_dt_mipmaps_updated_callback), thumb);
-    DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                    DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
-                              G_CALLBACK(_dt_preview_updated_callback), thumb);
-    DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_IMAGE_INFO_CHANGED,
-                              G_CALLBACK(_dt_image_info_changed_callback), thumb);
-    DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
-                              G_CALLBACK(_dt_collection_changed_callback), thumb);
+    DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_ACTIVE_IMAGES_CHANGE, _dt_active_images_callback, thumb);
+    DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_SELECTION_CHANGED, _dt_selection_changed_callback, thumb);
+    DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, _dt_mipmaps_updated_callback, thumb);
+    DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED, _dt_preview_updated_callback, thumb);
+    DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_IMAGE_INFO_CHANGED, _dt_image_info_changed_callback, thumb);
+    DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_COLLECTION_CHANGED, _dt_collection_changed_callback, thumb);
 
     // the background
     thumb->w_back = gtk_event_box_new();
@@ -1721,18 +1714,12 @@ void dt_thumbnail_destroy(dt_thumbnail_t *thumb)
   if(thumb->expose_again_timeout_id != 0)
     g_source_remove(thumb->expose_again_timeout_id);
 
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_dt_selection_changed_callback), thumb);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_dt_active_images_callback), thumb);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_dt_mipmaps_updated_callback), thumb);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_dt_preview_updated_callback), thumb);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_dt_image_info_changed_callback), thumb);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_dt_collection_changed_callback), thumb);
+  DT_CONTROL_SIGNAL_DISCONNECT(_dt_selection_changed_callback, thumb);
+  DT_CONTROL_SIGNAL_DISCONNECT(_dt_active_images_callback, thumb);
+  DT_CONTROL_SIGNAL_DISCONNECT(_dt_mipmaps_updated_callback, thumb);
+  DT_CONTROL_SIGNAL_DISCONNECT(_dt_preview_updated_callback, thumb);
+  DT_CONTROL_SIGNAL_DISCONNECT(_dt_image_info_changed_callback, thumb);
+  DT_CONTROL_SIGNAL_DISCONNECT(_dt_collection_changed_callback, thumb);
   dt_thumbnail_surface_destroy(thumb);
   if(thumb->w_main) gtk_widget_destroy(thumb->w_main);
   if(thumb->filename) g_free(thumb->filename);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1047,9 +1047,9 @@ void dt_thumbtable_zoom_changed(dt_thumbtable_t *table,
 static gboolean _event_scroll_compressed(gpointer user_data)
 {
   if (!user_data) return FALSE;
-  dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
+  dt_thumbtable_t *table = user_data;
 
-  if (table->scroll_value != 0)
+  if(table->scroll_value != 0)
   {
     float delta = table->scroll_value;
 
@@ -1103,10 +1103,9 @@ static gboolean _event_scroll_compressed(gpointer user_data)
 
 static gboolean _event_scroll(GtkWidget *widget,
                               GdkEvent *event,
-                              gpointer user_data)
+                              dt_thumbtable_t *table)
 {
   GdkEventScroll *e = (GdkEventScroll *)event;
-  dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
   int delta_x, delta_y;
 
   // file manager can either scroll fractionally and smoothly for precision
@@ -1318,7 +1317,7 @@ static void _lighttable_expose_empty(cairo_t *cr,
 
 static gboolean _event_draw(GtkWidget *widget,
                             cairo_t *cr,
-                            gpointer user_data)
+                            dt_thumbtable_t *table)
 {
   if(!GTK_IS_CONTAINER(gtk_widget_get_parent(widget)))
     return TRUE;
@@ -1330,7 +1329,6 @@ static gboolean _event_draw(GtkWidget *widget,
 
   // but we don't really want to draw something, this is just to know
   // when the widget is really ready
-  dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
   table->manual_button.width = -1;
   if(!darktable.collection
      || (dt_collection_get_count(darktable.collection) == 0))
@@ -1348,9 +1346,8 @@ static gboolean _event_draw(GtkWidget *widget,
 
 static gboolean _event_leave_notify(GtkWidget *widget,
                                     GdkEventCrossing *event,
-                                    gpointer user_data)
+                                    dt_thumbtable_t *table)
 {
-  dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
   // if the leaving cause is the hide of the widget, no mouseover change
   if(!gtk_widget_is_visible(widget))
   {
@@ -1373,7 +1370,7 @@ static gboolean _event_leave_notify(GtkWidget *widget,
 
 static gboolean _event_enter_notify(GtkWidget *widget,
                                     GdkEventCrossing *event,
-                                    gpointer user_data)
+                                    dt_thumbtable_t *table)
 {
   dt_set_backthumb_time(0.0);
 
@@ -1388,7 +1385,7 @@ static gboolean _event_enter_notify(GtkWidget *widget,
 
 static gboolean _do_select_single(gpointer user_data)
 {
-  dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
+  dt_thumbtable_t *table = user_data;
 
   // always keep the edited picture selected
   dt_selection_clear(darktable.selection);
@@ -1401,11 +1398,10 @@ static gboolean _do_select_single(gpointer user_data)
 
 static gboolean _event_button_press(GtkWidget *widget,
                                     GdkEventButton *event,
-                                    gpointer user_data)
+                                    dt_thumbtable_t *table)
 {
   dt_set_backthumb_time(0.0);
 
-  dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
   const dt_imgid_t id = dt_control_get_mouse_over_id();
 
   if(dt_is_valid_imgid(id)
@@ -1489,11 +1485,10 @@ static gboolean _event_button_press(GtkWidget *widget,
 
 static gboolean _event_motion_notify(GtkWidget *widget,
                                      GdkEventMotion *event,
-                                     gpointer user_data)
+                                     dt_thumbtable_t *table)
 {
   dt_set_backthumb_time(0.0);
 
-  dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
   table->mouse_inside = TRUE;
 
   gboolean ret = FALSE;
@@ -1521,7 +1516,7 @@ static gboolean _event_motion_notify(GtkWidget *widget,
 
 static gboolean _event_button_release(GtkWidget *widget,
                                       GdkEventButton *event,
-                                      gpointer user_data)
+                                      dt_thumbtable_t *table)
 {
   // we select only in LIGHTTABLE, DARKROOM & MAP mode
   const dt_view_type_flags_t cv = dt_view_get_current();
@@ -1533,8 +1528,6 @@ static gboolean _event_button_release(GtkWidget *widget,
 
   dt_set_backthumb_time(0.0);
   const dt_imgid_t id = dt_control_get_mouse_over_id();
-
-  dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
 
   if(dt_is_valid_imgid(id)
      && event->button == 1
@@ -1730,15 +1723,14 @@ static void _thumbs_ask_for_discard(dt_thumbtable_t *table)
 }
 
 // called each time the preference change, to update specific parts
-static void _dt_pref_change_callback(gpointer instance, gpointer user_data)
+static void _dt_pref_change_callback(gpointer instance, dt_thumbtable_t *table)
 {
-  if(!user_data)
+  if(!table)
     return;
 
   dt_get_sysresource_level();
   dt_opencl_update_settings();
   dt_configure_ppd_dpi(darktable.gui);
-  dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
 
   /* let's idle the backthumb crawler now to avoid fighting
       updating vs removal of thumbs
@@ -1768,12 +1760,10 @@ static void _dt_pref_change_callback(gpointer instance, gpointer user_data)
 
 static void _dt_profile_change_callback(gpointer instance,
                                         const int type,
-                                        gpointer user_data)
+                                        dt_thumbtable_t *table)
 {
-  if(!user_data)
+  if(!table)
     return;
-
-  dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
 
   for(const GList *l = table->list; l; l = g_list_next(l))
   {
@@ -1783,14 +1773,12 @@ static void _dt_profile_change_callback(gpointer instance,
 }
 
 // this is called each time the list of active images change
-static void _dt_active_images_callback(gpointer instance, gpointer user_data)
+static void _dt_active_images_callback(gpointer instance, dt_thumbtable_t *table)
 {
   // we only ensure here that the active image is the offset one
   // everything else (css, etc...) is handled in dt_thumbnail_t
-  if(!user_data)
+  if(!table)
     return;
-
-  dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
 
   if(!darktable.view_manager->active_images) return;
   const int activeid = GPOINTER_TO_INT(darktable.view_manager->active_images->data);
@@ -1798,12 +1786,10 @@ static void _dt_active_images_callback(gpointer instance, gpointer user_data)
 }
 
 // this is called each time mouse_over id change
-static void _dt_mouse_over_image_callback(gpointer instance, gpointer user_data)
+static void _dt_mouse_over_image_callback(gpointer instance, dt_thumbtable_t *table)
 {
-  if(!user_data)
+  if(!table)
     return;
-
-  dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
 
   const dt_imgid_t imgid = dt_control_get_mouse_over_id();
 
@@ -1938,12 +1924,10 @@ static void _dt_collection_changed_callback(gpointer instance,
                                             dt_collection_properties_t changed_property,
                                             gpointer imgs,
                                             const dt_imgid_t next,
-                                            gpointer user_data)
+                                            dt_thumbtable_t *table)
 {
-  if(!user_data)
+  if(!table)
     return;
-
-  dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
 
   dt_collection_history_save();
 
@@ -2170,9 +2154,8 @@ static void _event_dnd_get(GtkWidget *widget,
                            GtkSelectionData *selection_data,
                            const guint target_type,
                            const guint time,
-                           gpointer user_data)
+                           dt_thumbtable_t *table)
 {
-  dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
   g_assert(selection_data != NULL);
 
   switch(target_type)
@@ -2263,11 +2246,9 @@ static void _event_dnd_get(GtkWidget *widget,
 
 static void _event_dnd_begin(GtkWidget *widget,
                              GdkDragContext *context,
-                             gpointer user_data)
+                             dt_thumbtable_t *table)
 {
   const int ts = DT_PIXEL_APPLY_DPI(128);
-
-  dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
 
   darktable.control->last_clicked_filmstrip_id =
     dt_control_get_mouse_over_id();
@@ -2341,7 +2322,7 @@ void dt_thumbtable_event_dnd_received(GtkWidget *widget,
                                       GtkSelectionData *selection_data,
                                       guint target_type,
                                       guint time,
-                                      gpointer user_data)
+                                      dt_thumbtable_t *table)
 {
   gboolean success = FALSE;
 
@@ -2372,7 +2353,6 @@ void dt_thumbtable_event_dnd_received(GtkWidget *widget,
           && (selection_data != NULL)
           && (gtk_selection_data_get_length(selection_data) >= 0))
   {
-    dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
     if(table->drag_list)
     {
       if(darktable.collection->params.sorts[DT_COLLECTION_SORT_CUSTOM_ORDER]
@@ -2398,9 +2378,8 @@ void dt_thumbtable_event_dnd_received(GtkWidget *widget,
 
 static void _event_dnd_end(GtkWidget *widget,
                            GdkDragContext *context,
-                           gpointer user_data)
+                           dt_thumbtable_t *table)
 {
-  dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
   if(table->drag_list)
   {
     g_list_free(table->drag_list);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1435,8 +1435,7 @@ static gboolean _event_button_press(GtkWidget *widget,
             dt_selection_deselect(darktable.selection,
                                   darktable.develop->image_storage.id);
             dt_selection_select(darktable.selection, id);
-            DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                          DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, id);
+            DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, id);
             return FALSE;
           }
         default:
@@ -2479,16 +2478,11 @@ dt_thumbtable_t *dt_thumbtable_new()
                    G_CALLBACK(_event_button_release), table);
 
   // we register globals signals
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
-                            G_CALLBACK(_dt_collection_changed_callback), table);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE,
-                            G_CALLBACK(_dt_mouse_over_image_callback), table);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_ACTIVE_IMAGES_CHANGE,
-                            G_CALLBACK(_dt_active_images_callback), table);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
-                            G_CALLBACK(_dt_profile_change_callback), table);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
-                            G_CALLBACK(_dt_pref_change_callback), table);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_COLLECTION_CHANGED, _dt_collection_changed_callback, table);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE, _dt_mouse_over_image_callback, table);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_ACTIVE_IMAGES_CHANGE, _dt_active_images_callback, table);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED, _dt_profile_change_callback, table);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_PREFERENCES_CHANGE, _dt_pref_change_callback, table);
   gtk_widget_show(table->widget);
 
   g_object_ref(table->widget);
@@ -2726,7 +2720,7 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table,
       }
       g_slist_free(darktable.view_manager->active_images);
       darktable.view_manager->active_images = NULL;
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_ACTIVE_IMAGES_CHANGE);
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_ACTIVE_IMAGES_CHANGE);
     }
 
     dt_print(DT_DEBUG_LIGHTTABLE,
@@ -2924,7 +2918,7 @@ static void _accel_duplicate(dt_action_t *action)
   dt_collection_update_query(darktable.collection,
                              DT_COLLECTION_CHANGE_RELOAD,
                              DT_COLLECTION_PROP_UNDEF, NULL);
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
 }
 
 static void _accel_select_all(dt_action_t *action)

--- a/src/dtgtk/thumbtable.h
+++ b/src/dtgtk/thumbtable.h
@@ -131,7 +131,7 @@ gboolean dt_thumbtable_ensure_imgid_visibility(dt_thumbtable_t *table, dt_imgid_
 gboolean dt_thumbtable_check_imgid_visibility(dt_thumbtable_t *table, dt_imgid_t imgid);
 
 // drag & drop receive function - handles dropping of files in the center view (files are added to the library)
-void dt_thumbtable_event_dnd_received(GtkWidget *widget, GdkDragContext *context, gint x, gint y, GtkSelectionData *selection_data, guint target_type, guint time, gpointer user_data);
+void dt_thumbtable_event_dnd_received(GtkWidget *widget, GdkDragContext *context, gint x, gint y, GtkSelectionData *selection_data, guint target_type, guint time, dt_thumbtable_t *table);
 
 // move by key actions.
 // this key accels are not managed here but inside view

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -373,25 +373,15 @@ static void _color_picker_proxy_preview_pipe_callback(gpointer instance,
 void dt_iop_color_picker_init(void)
 {
   // we have incoming iop picker data
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_CONTROL_PICKERDATA_READY,
-                                  G_CALLBACK(_iop_color_picker_pickerdata_ready_callback),
-                                  NULL);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_CONTROL_PICKERDATA_READY, _iop_color_picker_pickerdata_ready_callback, NULL);
   // we have new primary picker data as preview pipe has run to conclusion
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
-                                  G_CALLBACK(_color_picker_proxy_preview_pipe_callback),
-                                  NULL);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED, _color_picker_proxy_preview_pipe_callback, NULL);
 }
 
 void dt_iop_color_picker_cleanup(void)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT
-    (darktable.signals,
-     G_CALLBACK(_iop_color_picker_pickerdata_ready_callback), NULL);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT
-    (darktable.signals,
-     G_CALLBACK(_color_picker_proxy_preview_pipe_callback), NULL);
+  DT_CONTROL_SIGNAL_DISCONNECT(_iop_color_picker_pickerdata_ready_callback, NULL);
+  DT_CONTROL_SIGNAL_DISCONNECT(_color_picker_proxy_preview_pipe_callback, NULL);
 }
 
 static GtkWidget *_color_picker_new(dt_iop_module_t *module,

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -220,7 +220,7 @@ static void _focuspeaking_switch_button_callback(GtkWidget *button,
   dt_dev_reprocess_center(darktable.develop);
 
   // we inform that all thumbnails need to be redraw
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, -1);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, -1);
 }
 
 static gchar *_panels_get_view_path(char *suffix)
@@ -1650,8 +1650,7 @@ static void _init_widgets(dt_gui_gtk_t *gui)
   gtk_container_add(GTK_CONTAINER(container), widget);
 
   /* connect to signal redraw all */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_CONTROL_REDRAW_ALL,
-                            G_CALLBACK(_ui_widget_redraw_callback), gui->ui->main_window);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_CONTROL_REDRAW_ALL, _ui_widget_redraw_callback, gui->ui->main_window);
 
   container = widget;
 
@@ -1809,19 +1808,16 @@ static void _init_main_table(GtkWidget *container)
   gtk_overlay_add_overlay(GTK_OVERLAY(ocda), eb);
 
   /* center should redraw when signal redraw center is raised*/
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_CONTROL_REDRAW_CENTER,
-                                  G_CALLBACK(_ui_widget_redraw_callback),
-                                  darktable.gui->ui->center);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_CONTROL_REDRAW_CENTER, _ui_widget_redraw_callback,
+                            darktable.gui->ui->center);
 
   /* update log message label */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_CONTROL_LOG_REDRAW,
-                                  G_CALLBACK(_ui_log_redraw_callback),
-                                  darktable.gui->ui->log_msg);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_CONTROL_LOG_REDRAW, _ui_log_redraw_callback,
+                            darktable.gui->ui->log_msg);
 
   /* update toast message label */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_CONTROL_TOAST_REDRAW,
-                                  G_CALLBACK(_ui_toast_redraw_callback),
-                                  darktable.gui->ui->toast_msg);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_CONTROL_TOAST_REDRAW, _ui_toast_redraw_callback,
+                            darktable.gui->ui->toast_msg);
 
   // Adding the scrollbars
   GtkWidget *vscrollBar = gtk_scrollbar_new(GTK_ORIENTATION_VERTICAL, NULL);

--- a/src/gui/import_metadata.c
+++ b/src/gui/import_metadata.c
@@ -500,20 +500,17 @@ void dt_import_metadata_init(dt_import_metadata_t *metadata)
   _apply_metadata_toggled(metadata->apply_metadata, grid);
 
   // connect changed signal
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
-                            G_CALLBACK(_metadata_prefs_changed), metadata);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_METADATA_CHANGED,
-                            G_CALLBACK(_metadata_list_changed), metadata);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_PRESETS_CHANGED,
-                            G_CALLBACK(_metadata_presets_changed), metadata);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_PREFERENCES_CHANGE, _metadata_prefs_changed, metadata);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_METADATA_CHANGED, _metadata_list_changed, metadata);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_PRESETS_CHANGED, _metadata_presets_changed, metadata);
   _update_layout(metadata);
 }
 
 void dt_import_metadata_cleanup(dt_import_metadata_t *metadata)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_metadata_prefs_changed), metadata);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_metadata_list_changed), metadata);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_metadata_presets_changed), metadata);
+  DT_CONTROL_SIGNAL_DISCONNECT(_metadata_prefs_changed, metadata);
+  DT_CONTROL_SIGNAL_DISCONNECT(_metadata_list_changed, metadata);
+  DT_CONTROL_SIGNAL_DISCONNECT(_metadata_presets_changed, metadata);
 }
 
 void dt_import_metadata_update(dt_import_metadata_t *metadata)

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -571,7 +571,7 @@ void dt_gui_preferences_show()
   if(restart_required)
     dt_control_log(_("darktable needs to be restarted for settings to take effect"));
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_PREFERENCES_CHANGE);
 }
 
 static void cairo_destroy_from_pixbuf(guchar *pixels, gpointer data)

--- a/src/imageio/imageio.c
+++ b/src/imageio/imageio.c
@@ -1500,9 +1500,8 @@ gboolean dt_imageio_export_with_flags(const dt_imgid_t imgid,
     dt_lua_unlock();
 #endif
 
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                  DT_SIGNAL_IMAGE_EXPORT_TMPFILE, imgid, filename, format,
-                                  format_params, storage, storage_params);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_IMAGE_EXPORT_TMPFILE, imgid, filename, format,
+                            format_params, storage, storage_params);
   }
 
   if(!thumbnail_export)
@@ -1550,7 +1549,7 @@ void dt_imageio_update_monochrome_workflow_tag(const int32_t id, const int mask)
   else
     dt_tag_detach_by_string("darktable|mode|monochrome", id, FALSE, FALSE);
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
 }
 
 void dt_imageio_set_hdr_tag(dt_image_t *img)

--- a/src/imageio/imageio_module.c
+++ b/src/imageio/imageio_module.c
@@ -394,13 +394,13 @@ void dt_imageio_insert_storage(dt_imageio_module_storage_t *storage)
 {
   darktable.imageio->plugins_storage
       = g_list_insert_sorted(darktable.imageio->plugins_storage, storage, dt_imageio_sort_modules_storage);
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGEIO_STORAGE_CHANGE);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_IMAGEIO_STORAGE_CHANGE);
 }
 
 void dt_imageio_remove_storage(dt_imageio_module_storage_t *storage)
 {
   darktable.imageio->plugins_storage  = g_list_remove(darktable.imageio->plugins_storage, storage);
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGEIO_STORAGE_CHANGE);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_IMAGEIO_STORAGE_CHANGE);
 }
 
 gchar *dt_imageio_resizing_factor_get_and_parsing(double *num, double *denum)

--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -601,7 +601,7 @@ static void _piwigo_authenticate(dt_storage_piwigo_gui_data_t *ui)
     _piwigo_ctx_destroy(&ui->api);
   }
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGEIO_STORAGE_EXPORT_ENABLE);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_IMAGEIO_STORAGE_EXPORT_ENABLE);
 }
 
 static void _piwigo_entry_changed(GtkEntry *entry,
@@ -614,7 +614,7 @@ static void _piwigo_entry_changed(GtkEntry *entry,
 
   if(ui->api) _piwigo_ctx_destroy(&ui->api);
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGEIO_STORAGE_EXPORT_ENABLE);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_IMAGEIO_STORAGE_EXPORT_ENABLE);
 }
 
 static void _piwigo_server_entry_changed(GtkEntry *entry,
@@ -629,7 +629,7 @@ static void _piwigo_server_entry_changed(GtkEntry *entry,
     gtk_widget_set_sensitive(GTK_WIDGET(ui->album_list), FALSE);
   }
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGEIO_STORAGE_EXPORT_ENABLE);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_IMAGEIO_STORAGE_EXPORT_ENABLE);
 }
 
 static void _piwigo_account_changed(GtkComboBox *cb,

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -6167,9 +6167,7 @@ void gui_init(struct dt_iop_module_t *self)
                        N_("auto"), g->structure_auto, &dt_action_def_toggle);
 
   /* add signal handler for preview pipe finish to redraw the overlay */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
-                                  G_CALLBACK(_event_process_after_preview_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED, _event_process_after_preview_callback, self);
 
   darktable.develop->proxy.rotate = self;
 }
@@ -6179,9 +6177,7 @@ void gui_cleanup(struct dt_iop_module_t *self)
   if(darktable.develop->proxy.rotate == self)
     darktable.develop->proxy.rotate = NULL;
 
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_event_process_after_preview_callback),
-                                     self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_event_process_after_preview_callback, self);
 
   dt_iop_ashift_gui_data_t *g = self->gui_data;
   if(g->lines) free(g->lines);

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -676,17 +676,15 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->sl_clip, _("adjusts clipping value for auto exposure calculation"));
 
   // add signal handler for preview pipe finish
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
-                            G_CALLBACK(_develop_ui_pipe_finished_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED, _develop_ui_pipe_finished_callback, self);
   // and profile change
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
-                            G_CALLBACK(_signal_profile_user_changed), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED, _signal_profile_user_changed, self);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_develop_ui_pipe_finished_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_signal_profile_user_changed), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_develop_ui_pipe_finished_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_signal_profile_user_changed, self);
 
   IOP_GUI_FREE;
 }

--- a/src/iop/channelmixerrgb.c
+++ b/src/iop/channelmixerrgb.c
@@ -4440,12 +4440,8 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->XYZ[0] = NAN;
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,
-                                  G_CALLBACK(_develop_ui_pipe_finished_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
-                                  G_CALLBACK(_preview_pipe_finished_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED, _develop_ui_pipe_finished_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED, _preview_pipe_finished_callback, self);
 
   // Init GTK notebook
   static dt_action_def_t notebook_def = { };
@@ -4790,12 +4786,8 @@ void gui_cleanup(struct dt_iop_module_t *self)
   }
 
   self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT
-    (darktable.signals,
-     G_CALLBACK(_develop_ui_pipe_finished_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT
-    (darktable.signals,
-     G_CALLBACK(_preview_pipe_finished_callback), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_develop_ui_pipe_finished_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_preview_pipe_finished_callback, self);
 
   dt_iop_channelmixer_rgb_gui_data_t *g = self->gui_data;
   dt_conf_set_int("plugins/darkroom/channelmixerrgb/gui_page",

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1357,7 +1357,7 @@ static void _event_preview_updated_callback(gpointer instance, dt_iop_module_t *
   dt_iop_clipping_gui_data_t *g = self->gui_data;
   g->preview_ready = TRUE;
 
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_event_preview_updated_callback), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_event_preview_updated_callback, self);
   // force max size to be recomputed
   g->clip_max_pipe_hash = 0;
 }
@@ -1371,8 +1371,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
   {
     if(in)
     {
-      DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
-                                      G_CALLBACK(_event_preview_updated_callback), self);
+      DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED, _event_preview_updated_callback, self);
 
       // got focus, grab stuff to gui:
       // need to get gui stuff for the first time for this image,
@@ -1383,8 +1382,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
     }
     else
     {
-      DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
-                                      G_CALLBACK(_event_preview_updated_callback), self);
+      DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED, _event_preview_updated_callback, self);
 
       // lost focus, commit current params:
       // if the keystone setting is not finished, we discard it

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -2070,13 +2070,12 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->main_box), TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->optimizer_box), TRUE, TRUE, 0);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
-                                  G_CALLBACK(_configure_slider_blocks), (gpointer)self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_PREFERENCES_CHANGE, _configure_slider_blocks, self);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_configure_slider_blocks), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_configure_slider_blocks, self);
 
   IOP_GUI_FREE;
 }

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -520,9 +520,8 @@ static void _profile_changed(GtkWidget *widget, dt_iop_module_t *self)
       memcpy(p->filename, pp->filename, sizeof(p->filename));
       dt_dev_add_history_item(darktable.develop, self, TRUE);
 
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                    DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
-                                    DT_COLORSPACES_PROFILE_TYPE_INPUT);
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
+                              DT_COLORSPACES_PROFILE_TYPE_INPUT);
       return;
     }
   }
@@ -577,9 +576,8 @@ static void _workicc_changed(GtkWidget *widget, dt_iop_module_t *self)
     }
     dt_dev_add_history_item(darktable.develop, self, TRUE);
 
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                  DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
-                                  DT_COLORSPACES_PROFILE_TYPE_WORK);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
+                            DT_COLORSPACES_PROFILE_TYPE_WORK);
 
     dt_dev_pixelpipe_rebuild(self->dev);
   }

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -1035,8 +1035,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->equalization, "%");
 
   /* add signal handler for preview pipe finished: process clusters if requested */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
-                            G_CALLBACK(process_clusters), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED, process_clusters, self);
 
   FILE *f = g_fopen("/tmp/dt_colormapping_loaded", "rb");
   if(f)
@@ -1050,7 +1049,7 @@ void gui_cleanup(struct dt_iop_module_t *self)
 {
   dt_iop_colormapping_gui_data_t *g = self->gui_data;
 
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(process_clusters), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(process_clusters, self);
 
   cmsDeleteTransform(g->xform);
   dt_free_align(g->buffer);

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -268,7 +268,7 @@ static void output_profile_changed(GtkWidget *widget, dt_iop_module_t *self)
       g_strlcpy(p->filename, pp->filename, sizeof(p->filename));
       dt_dev_add_history_item(darktable.develop, self, TRUE);
 
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED, DT_COLORSPACES_PROFILE_TYPE_EXPORT);
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED, DT_COLORSPACES_PROFILE_TYPE_EXPORT);
       return;
     }
   }
@@ -872,17 +872,15 @@ void gui_init(struct dt_iop_module_t *self)
                    G_CALLBACK(output_profile_changed), (gpointer)self);
 
   // reload the profiles when the display or softproof profile changed!
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_CHANGED,
-                            G_CALLBACK(_signal_profile_changed), self->dev);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_CONTROL_PROFILE_CHANGED, _signal_profile_changed, self->dev);
   // update the gui when the preferences changed (i.e. show intent when using lcms2)
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
-                            G_CALLBACK(_preference_changed), (gpointer)self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_PREFERENCES_CHANGE, _preference_changed, self);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_signal_profile_changed), self->dev);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_preference_changed), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_signal_profile_changed, self->dev);
+  DT_CONTROL_SIGNAL_DISCONNECT(_preference_changed, self);
 
   IOP_GUI_FREE;
 }

--- a/src/iop/crop.c
+++ b/src/iop/crop.c
@@ -456,8 +456,7 @@ static void _event_preview_updated_callback(gpointer instance, dt_iop_module_t *
   dt_iop_crop_gui_data_t *g = self->gui_data;
   if(!g) return; // seems that sometimes, g can be undefined for some reason...
   g->preview_ready = TRUE;
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_event_preview_updated_callback), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_event_preview_updated_callback, self);
 
   // force max size to be recomputed
   g->clip_max_pipe_hash = 0;
@@ -473,9 +472,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
   if(self->enabled)
   {
     // once the pipe is recomputed, we want to update final sizes
-    DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                    DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
-                                    G_CALLBACK(_event_preview_updated_callback), self);
+    DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED, _event_preview_updated_callback, self);
     if(in)
     {
       // got focus, grab stuff to gui:

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -4442,10 +4442,7 @@ void gui_init(struct dt_iop_module_t *self)
 {
   dt_iop_lens_gui_data_t *g = IOP_GUI_ALLOC(lens);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,
-                                  G_CALLBACK(_develop_ui_pipe_finished_callback),
-                                  self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED, _develop_ui_pipe_finished_callback, self);
 
   dt_iop_gui_enter_critical_section(self); // not actually needed,
                                            // we're the only one with
@@ -4691,9 +4688,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   /* add signal handler for preview pipe finish to update message on
      corrections done */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
-                                  G_CALLBACK(_have_corrections_done), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED, _have_corrections_done, self);
 }
 
 void gui_focus(struct dt_iop_module_t *self,
@@ -4784,12 +4779,8 @@ void gui_update(struct dt_iop_module_t *self)
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT
-    (darktable.signals,
-     G_CALLBACK(_have_corrections_done), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT
-    (darktable.signals,
-     G_CALLBACK(_develop_ui_pipe_finished_callback), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_have_corrections_done, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_develop_ui_pipe_finished_callback, self);
 
   IOP_GUI_FREE;
 }

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -1737,13 +1737,12 @@ void gui_init(dt_iop_module_t *self)
   g->interpolation = dt_bauhaus_combobox_from_params(self, N_("interpolation"));
   gtk_widget_set_tooltip_text(g->interpolation, _("select the interpolation method"));
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_MODULE_MOVED,
-                            G_CALLBACK(module_moved_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_MODULE_MOVED, module_moved_callback, self);
 }
 
 void gui_cleanup(dt_iop_module_t *self)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(module_moved_callback), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(module_moved_callback, self);
 
   IOP_GUI_FREE;
 }

--- a/src/iop/overlay.c
+++ b/src/iop/overlay.c
@@ -1158,22 +1158,17 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->scale, _("the scale of the overlay"));
   gtk_widget_set_tooltip_text(g->rotate, _("the rotation of the overlay"));
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_MODULE_REMOVE,
-                                  G_CALLBACK(_module_remove_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_MODULE_REMOVE, _module_remove_callback, self);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_IMAGE_CHANGED,
-                                  G_CALLBACK(_signal_image_changed), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_IMAGE_CHANGED, _signal_image_changed, self);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
   IOP_GUI_FREE;
 
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_module_remove_callback), self);
-
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_signal_image_changed), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_module_remove_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_signal_image_changed, self);
 }
 
 // clang-format off

--- a/src/iop/primaries.c
+++ b/src/iop/primaries.c
@@ -411,20 +411,15 @@ void gui_init(dt_iop_module_t *self)
   g->painted_work_profile = NULL;
   g->painted_display_profile = NULL;
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
-                                  G_CALLBACK(_signal_profile_user_changed), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_CHANGED,
-                                  G_CALLBACK(_signal_profile_changed), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,
-                                  G_CALLBACK(_signal_profile_changed), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED, _signal_profile_user_changed, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_CONTROL_PROFILE_CHANGED, _signal_profile_changed, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED, _signal_profile_changed, self);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_signal_profile_user_changed), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_signal_profile_changed), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_signal_profile_user_changed, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_signal_profile_changed, self);
 
   IOP_GUI_FREE;
 }

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -750,7 +750,7 @@ void commit_params(
     d->apply_gainmaps = FALSE;
 
   if(_image_set_rawcrops(self, pipe->image.id, d->left, d->right, d->top, d->bottom))
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_METADATA_UPDATE);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_METADATA_UPDATE);
 
   if(!(dt_image_is_rawprepare_supported(&piece->pipe->image))
      || _image_is_normalized(&piece->pipe->image))

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2773,9 +2773,8 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), g->sl_mask_opacity, TRUE, TRUE, 0);
 
   /* add signal handler for preview pipe finish to redraw the preview */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT
-    (darktable.signals, DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,
-     G_CALLBACK(rt_develop_ui_pipe_finished_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,
+                            rt_develop_ui_pipe_finished_callback, self);
 }
 
 void gui_reset(struct dt_iop_module_t *self)
@@ -2796,9 +2795,7 @@ void reload_defaults(dt_iop_module_t *self)
 
 void gui_cleanup(dt_iop_module_t *self)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT
-    (darktable.signals,
-     G_CALLBACK(rt_develop_ui_pipe_finished_callback), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(rt_develop_ui_pipe_finished_callback, self);
 
   IOP_GUI_FREE;
 }

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -1134,15 +1134,12 @@ void gui_init(dt_iop_module_t *self)
                               _("method to preserve colors when applying contrast"));
 
   // add signal handler for preview pipe finish
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
-                                  G_CALLBACK(_develop_ui_pipe_finished_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED, _develop_ui_pipe_finished_callback, self);
 }
 
 void gui_cleanup(dt_iop_module_t *self)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_develop_ui_pipe_finished_callback), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_develop_ui_pipe_finished_callback, self);
 
   IOP_GUI_FREE;
 }

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -2223,8 +2223,7 @@ void gui_init(struct dt_iop_module_t *self)
                    G_CALLBACK(_preset_tune_callback), self);
 
   // update the gui when the preferences changed (i.e. colored sliders stuff)
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
-                                  G_CALLBACK(_preference_changed), (gpointer)self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_PREFERENCES_CHANGE, _preference_changed, self);
 
   // start building top level widget
   self->widget = gtk_stack_new();
@@ -2241,8 +2240,7 @@ void gui_init(struct dt_iop_module_t *self)
 void gui_cleanup(struct dt_iop_module_t *self)
 {
   self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_preference_changed), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_preference_changed, self);
 
   IOP_GUI_FREE;
 }

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -2540,10 +2540,7 @@ static void _set_distort_signal(dt_iop_module_t *self)
   dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
   if(self->enabled && !g->distort_signal_actif)
   {
-    DT_DEBUG_CONTROL_SIGNAL_CONNECT
-      (darktable.signals,
-       DT_SIGNAL_DEVELOP_DISTORT,
-       G_CALLBACK(_develop_distort_callback), self);
+    DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_DISTORT, _develop_distort_callback, self);
     g->distort_signal_actif = TRUE;
   }
 }
@@ -2553,9 +2550,7 @@ static void _unset_distort_signal(dt_iop_module_t *self)
   dt_iop_toneequalizer_gui_data_t *g = self->gui_data;
   if(g->distort_signal_actif)
   {
-    DT_DEBUG_CONTROL_SIGNAL_DISCONNECT
-      (darktable.signals,
-       G_CALLBACK(_develop_distort_callback), self);
+    DT_CONTROL_SIGNAL_DISCONNECT(_develop_distort_callback, self);
     g->distort_signal_actif = FALSE;
   }
 }
@@ -3530,20 +3525,9 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 0);
 
   // Force UI redraws when pipe starts/finishes computing and switch cursors
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT
-    (darktable.signals,
-     DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
-     G_CALLBACK(_develop_preview_pipe_finished_callback), self);
-
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT
-    (darktable.signals,
-     DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,
-     G_CALLBACK(_develop_ui_pipe_finished_callback), self);
-
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT
-    (darktable.signals,
-     DT_SIGNAL_DEVELOP_HISTORY_CHANGE,
-     G_CALLBACK(_develop_ui_pipe_started_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED, _develop_preview_pipe_finished_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED, _develop_ui_pipe_finished_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_HISTORY_CHANGE, _develop_ui_pipe_started_callback, self);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)
@@ -3554,15 +3538,9 @@ void gui_cleanup(struct dt_iop_module_t *self)
   dt_conf_set_int("plugins/darkroom/toneequal/gui_page",
                   gtk_notebook_get_current_page (g->notebook));
 
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_develop_ui_pipe_finished_callback),
-                                     self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_develop_ui_pipe_started_callback),
-                                     self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_develop_preview_pipe_finished_callback),
-                                     self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_develop_ui_pipe_finished_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_develop_ui_pipe_started_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_develop_preview_pipe_finished_callback, self);
   _unset_distort_signal(self);
 
   dt_free_align(g->thumb_preview_buf);

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -481,8 +481,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), g->zones, TRUE, TRUE, 0);
 
   /* add signal handler for preview pipe finish to redraw the preview */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
-                            G_CALLBACK(_iop_zonesystem_redraw_preview_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED, _iop_zonesystem_redraw_preview_callback, self);
 
 
   g->image = NULL;
@@ -493,7 +492,7 @@ void gui_init(struct dt_iop_module_t *self)
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_iop_zonesystem_redraw_preview_callback), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_iop_zonesystem_redraw_preview_callback, self);
 
   dt_iop_zonesystem_gui_data_t *g = self->gui_data;
   g_free(g->in_preview_buffer);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -501,7 +501,7 @@ static void view_popup_menu_onSearchFilmroll(GtkWidget *menuitem,
       /* update collection to view missing filmroll */
       _lib_folders_update_collection(new_path);
 
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED);
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_FILMROLLS_CHANGED);
     }
     else
       goto error;
@@ -1092,10 +1092,9 @@ static void _lib_folders_update_collection(const gchar *filmroll)
   if(!darktable.collection->clone)
   {
     dt_collection_memory_update();
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                  DT_SIGNAL_COLLECTION_CHANGED,
-                                  DT_COLLECTION_CHANGE_NEW_QUERY,
-                                  DT_COLLECTION_PROP_UNDEF, (GList *)NULL, -1);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_COLLECTION_CHANGED,
+                            DT_COLLECTION_CHANGE_NEW_QUERY,
+                            DT_COLLECTION_PROP_UNDEF, (GList *)NULL, -1);
   }
 }
 
@@ -2693,8 +2692,7 @@ static void combo_changed(GtkWidget *combo,
 
   set_properties(d);
   c->view_rule = -1;
-  if(order) DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                          DT_SIGNAL_IMAGES_ORDER_CHANGE, order);
+  if(order) DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_IMAGES_ORDER_CHANGE, order);
   dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_NEW_QUERY,
                              DT_COLLECTION_PROP_UNDEF, NULL);
 }
@@ -2835,8 +2833,7 @@ static void row_activated_with_event(GtkTreeView *view,
   dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(collection_updated),
                                   darktable.view_manager->proxy.module_collect.module);
   if(order)
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                  DT_SIGNAL_IMAGES_ORDER_CHANGE, order);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_IMAGES_ORDER_CHANGE, order);
 
   dt_collection_update_query(darktable.collection,
                              DT_COLLECTION_CHANGE_NEW_QUERY,
@@ -3499,8 +3496,7 @@ static void _history_apply(GtkWidget *widget,
       dt_collection_set_tag_id((dt_collection_t *)darktable.collection, 0);
     }
     if(order)
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                    DT_SIGNAL_IMAGES_ORDER_CHANGE, order);
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_IMAGES_ORDER_CHANGE, order);
   }
 }
 
@@ -3809,48 +3805,15 @@ void gui_init(dt_lib_module_t *self)
                                DT_COLLECTION_CHANGE_RELOAD,
                                DT_COLLECTION_PROP_MODULE, NULL);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_COLLECTION_CHANGED,
-                                  G_CALLBACK(collection_updated),
-                                  self);
-
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_FILMROLLS_CHANGED,
-                                  G_CALLBACK(filmrolls_updated),
-                                  self);
-
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_PREFERENCES_CHANGE,
-                                  G_CALLBACK(preferences_changed),
-                                  self);
-
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_FILMROLLS_IMPORTED,
-                                  G_CALLBACK(filmrolls_imported),
-                                  self);
-
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_FILMROLLS_REMOVED,
-                                  G_CALLBACK(filmrolls_removed),
-                                  self);
-
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_TAG_CHANGED,
-                                  G_CALLBACK(tag_changed),
-                                  self);
-
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_GEOTAG_CHANGED,
-                                  G_CALLBACK(_geotag_changed),
-                                  self);
-
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_METADATA_CHANGED,
-                                  G_CALLBACK(metadata_changed), self);
-
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_PREFERENCES_CHANGE,
-                                  G_CALLBACK(view_set_click), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_COLLECTION_CHANGED, collection_updated, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_FILMROLLS_CHANGED, filmrolls_updated, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_PREFERENCES_CHANGE, preferences_changed, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_FILMROLLS_IMPORTED, filmrolls_imported, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_FILMROLLS_REMOVED, filmrolls_removed, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_TAG_CHANGED, tag_changed, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_GEOTAG_CHANGED, _geotag_changed, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_METADATA_CHANGED, metadata_changed, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_PREFERENCES_CHANGE, view_set_click, self);
 
   dt_action_register(DT_ACTION(self), N_("jump back to previous collection"),
                      _history_previous, GDK_KEY_k,
@@ -3861,22 +3824,14 @@ void gui_cleanup(dt_lib_module_t *self)
 {
   dt_lib_collect_t *d = self->data;
 
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(collection_updated), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(filmrolls_updated), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(filmrolls_imported), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(preferences_changed), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(filmrolls_removed), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(tag_changed), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_geotag_changed), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(view_set_click), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(collection_updated, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(filmrolls_updated, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(filmrolls_imported, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(preferences_changed, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(filmrolls_removed, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(tag_changed, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_geotag_changed, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(view_set_click, self);
   darktable.view_manager->proxy.module_collect.module = NULL;
   free(d->params);
 

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -182,8 +182,8 @@ static void load_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
       dt_collection_update_query(darktable.collection,
                                  DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
                                  g_list_copy((GList *)imgs));
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED,
-                                    g_list_copy((GList *)imgs), 0);
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_GEOTAG_CHANGED,
+                              g_list_copy((GList *)imgs), 0);
       dt_control_queue_redraw_center();
     }
     if(!act_on_one)
@@ -386,22 +386,16 @@ void gui_init(dt_lib_module_t *self)
      _("write history stack and tags to XMP sidecar files"), 0, 0);
   gtk_grid_attach(grid, d->write_button, 3, line, 3, 1);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_SELECTION_CHANGED,
-                            G_CALLBACK(_image_selection_changed_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE,
-                            G_CALLBACK(_mouse_over_image_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
-                            G_CALLBACK(_collection_updated_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_SELECTION_CHANGED, _image_selection_changed_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE, _mouse_over_image_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_COLLECTION_CHANGED, _collection_updated_callback, self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_image_selection_changed_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_mouse_over_image_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_collection_updated_callback), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_image_selection_changed_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_mouse_over_image_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_collection_updated_callback, self);
 
   free(self->data);
   self->data = NULL;

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -106,11 +106,10 @@ static void _lib_duplicate_new_clicked_callback(GtkWidget *widget,
   if(!dt_is_valid_imgid(newid))
     return;
   dt_history_delete_on_image(newid);
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
   dt_collection_update_query(darktable.collection,
                              DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF, NULL);
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, newid);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, newid);
 }
 static void _lib_duplicate_duplicate_clicked_callback(GtkWidget *widget,
                                                       GdkEventButton *event,
@@ -123,8 +122,7 @@ static void _lib_duplicate_duplicate_clicked_callback(GtkWidget *widget,
   dt_history_copy_and_paste_on_image(imgid, newid, FALSE, NULL, TRUE, TRUE, TRUE);
   dt_collection_update_query(darktable.collection,
                              DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF, NULL);
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, newid);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, newid);
 }
 
 static void _lib_duplicate_delete(GtkButton *button, dt_lib_module_t *self)
@@ -144,10 +142,9 @@ static void _lib_duplicate_delete(GtkButton *button, dt_lib_module_t *self)
         if(!l2) l2 = g_list_previous(l);
         if(l2)
         {
-          dt_thumbnail_t *th2 = l2->data;
-          DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                        DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE,
-                                        th2->imgid);
+          dt_thumbnail_t *th2 = (dt_thumbnail_t *)l2->data;
+          DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE,
+                                  th2->imgid);
           break;
         }
       }
@@ -179,8 +176,7 @@ static void _lib_duplicate_thumb_press_callback(GtkWidget *widget,
     else if(event->type == GDK_2BUTTON_PRESS)
     {
       // let's switch to the new image
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                    DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, imgid);
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, imgid);
     }
   }
 }
@@ -427,39 +423,18 @@ void gui_init(dt_lib_module_t *self)
 
   gtk_widget_show_all(self->widget);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_DEVELOP_IMAGE_CHANGED,
-                                  G_CALLBACK(_lib_duplicate_init_callback),
-                                  self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_DEVELOP_INITIALIZE,
-                                  G_CALLBACK(_lib_duplicate_init_callback),
-                                  self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_COLLECTION_CHANGED,
-                                  G_CALLBACK(_lib_duplicate_collection_changed),
-                                  self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_DEVELOP_MIPMAP_UPDATED,
-                                  G_CALLBACK(_lib_duplicate_mipmap_updated_callback),
-                                  (gpointer)self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
-                                  G_CALLBACK(_lib_duplicate_preview_updated_callback),
-                                  self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_IMAGE_CHANGED, _lib_duplicate_init_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_INITIALIZE, _lib_duplicate_init_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_COLLECTION_CHANGED, _lib_duplicate_collection_changed, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, _lib_duplicate_mipmap_updated_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED, _lib_duplicate_preview_updated_callback, self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_lib_duplicate_init_callback),
-                                     self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_lib_duplicate_mipmap_updated_callback),
-                                     self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_lib_duplicate_preview_updated_callback),
-                                     self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_lib_duplicate_init_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_lib_duplicate_mipmap_updated_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_lib_duplicate_preview_updated_callback, self);
   g_free(self->data);
   self->data = NULL;
 }

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -1223,8 +1223,7 @@ void gui_init(dt_lib_module_t *self)
   }
 
   // postponed so we can do the two steps in one loop
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_IMAGEIO_STORAGE_CHANGE,
-                            G_CALLBACK(_on_storage_list_changed), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_IMAGEIO_STORAGE_CHANGE, _on_storage_list_changed, self);
   g_signal_connect(G_OBJECT(d->storage), "value-changed",
                    G_CALLBACK(_storage_changed), self);
 
@@ -1547,28 +1546,20 @@ void gui_init(dt_lib_module_t *self)
   // export metadata presets
   d->metadata_export = dt_lib_export_metadata_get_conf();
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_SELECTION_CHANGED,
-                            G_CALLBACK(_image_selection_changed_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE,
-                            G_CALLBACK(_mouse_over_image_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
-                            G_CALLBACK(_collection_updated_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_IMAGEIO_STORAGE_EXPORT_ENABLE,
-                            G_CALLBACK(_export_enable_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_SELECTION_CHANGED, _image_selection_changed_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE, _mouse_over_image_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_COLLECTION_CHANGED, _collection_updated_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_IMAGEIO_STORAGE_EXPORT_ENABLE, _export_enable_callback, self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
 {
   dt_lib_export_t *d = self->data;
 
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_on_storage_list_changed), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_image_selection_changed_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_mouse_over_image_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_collection_updated_callback), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_on_storage_list_changed, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_image_selection_changed_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_mouse_over_image_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_collection_updated_callback, self);
 
   for(const GList *it = darktable.imageio->plugins_storage; it; it = g_list_next(it))
   {

--- a/src/libs/filtering.c
+++ b/src/libs/filtering.c
@@ -2296,10 +2296,8 @@ void gui_init(dt_lib_module_t *self)
   // otherwise, the filter toolbar module will do it in it's gui_init()
   if(darktable.view_manager->proxy.filter.module) _filtering_gui_update(self);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
-                                  G_CALLBACK(_dt_collection_updated), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_IMAGES_ORDER_CHANGE,
-                                  G_CALLBACK(_dt_images_order_change), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_COLLECTION_CHANGED, _dt_collection_updated, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_IMAGES_ORDER_CHANGE, _dt_images_order_change, self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
@@ -2311,7 +2309,7 @@ void gui_cleanup(dt_lib_module_t *self)
     d->rule[i].cleaning = TRUE;
   }
 
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_dt_collection_updated), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_dt_collection_updated, self);
   darktable.view_manager->proxy.module_filtering.module = NULL;
   free(d->params);
 

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -1959,19 +1959,13 @@ void gui_init(dt_lib_module_t *self)
     g_signal_connect(d->dt.widget[i], "key-press-event", G_CALLBACK(_datetime_key_pressed), self);
     g_signal_connect(d->dt.widget[i], "scroll-event", G_CALLBACK(_datetime_scroll_over), self);
   }
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_SELECTION_CHANGED,
-                            G_CALLBACK(_selection_changed_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE,
-                            G_CALLBACK(_mouse_over_image_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_IMAGE_INFO_CHANGED,
-                            G_CALLBACK(_image_info_changed), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
-                            G_CALLBACK(_dt_pref_change_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_SELECTION_CHANGED, _selection_changed_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE, _mouse_over_image_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_IMAGE_INFO_CHANGED, _image_info_changed, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_PREFERENCES_CHANGE, _dt_pref_change_callback, self);
 #ifdef HAVE_MAP
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_VIEWMANAGER_VIEW_CHANGED,
-                            G_CALLBACK(_view_changed), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED,
-                            G_CALLBACK(_geotag_changed), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_VIEWMANAGER_VIEW_CHANGED, _view_changed, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_GEOTAG_CHANGED, _geotag_changed, self);
 #endif
 
   _show_milliseconds(d);
@@ -1989,9 +1983,9 @@ void gui_cleanup(dt_lib_module_t *self)
     g_date_time_unref(d->datetime);
   if(d->datetime0)
     g_date_time_unref(d->datetime0);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_selection_changed_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_mouse_over_image_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_image_info_changed), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_selection_changed_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_mouse_over_image_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_image_info_changed, self);
   if(d->imgs)
   {
 #ifdef HAVE_MAP
@@ -2003,8 +1997,8 @@ void gui_cleanup(dt_lib_module_t *self)
   d->imgs = 0;
 #ifdef HAVE_MAP
   _remove_tracks_from_map(self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_view_changed), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_geotag_changed), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_view_changed, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_geotag_changed, self);
 #endif
   free(self->data);
   self->data = NULL;

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -2446,9 +2446,8 @@ void view_enter(struct dt_lib_module_t *self,
   dt_lib_histogram_t *d = self->data;
   if(new_view->view(new_view) == DT_VIEW_DARKROOM)
   {
-    DT_DEBUG_CONTROL_SIGNAL_CONNECT
-      (darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
-       G_CALLBACK(_lib_histogram_preview_updated_callback), self);
+    DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
+                              _lib_histogram_preview_updated_callback, self);
   }
   // button box should be hidden when enter view, unless mouse is over
   // histogram, in which case gtk kindly generates enter events
@@ -2463,9 +2462,7 @@ void view_leave(struct dt_lib_module_t *self,
                 struct dt_view_t *old_view,
                 struct dt_view_t *new_view)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                               G_CALLBACK(_lib_histogram_preview_updated_callback),
-                               self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_lib_histogram_preview_updated_callback, self);
 }
 
 void gui_init(dt_lib_module_t *self)
@@ -2821,8 +2818,7 @@ void gui_init(dt_lib_module_t *self)
 
   gtk_widget_show_all(self->widget);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_IMAGE_CHANGED,
-                                  G_CALLBACK(_signal_image_changed), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_IMAGE_CHANGED, _signal_image_changed, self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
@@ -2844,8 +2840,7 @@ void gui_cleanup(dt_lib_module_t *self)
   dt_free_align(self->data);
   self->data = NULL;
 
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_signal_image_changed), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_signal_image_changed, self);
 }
 
 // clang-format off

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -167,22 +167,16 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_show_all(self->widget);
 
   /* connect to history change signal for updating the history view */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_WILL_CHANGE,
-                            G_CALLBACK(_lib_history_will_change_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_CHANGE,
-                            G_CALLBACK(_lib_history_change_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_MODULE_REMOVE,
-                            G_CALLBACK(_lib_history_module_remove_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_HISTORY_WILL_CHANGE, _lib_history_will_change_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_HISTORY_CHANGE, _lib_history_change_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_MODULE_REMOVE, _lib_history_module_remove_callback, self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_lib_history_change_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_lib_history_will_change_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_lib_history_module_remove_callback), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_lib_history_change_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_lib_history_will_change_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_lib_history_module_remove_callback, self);
   g_free(self->data);
   self->data = NULL;
 }
@@ -1235,7 +1229,7 @@ static void _lib_history_truncate(const gboolean compress)
 
   dt_dev_modulegroups_set(darktable.develop, dt_dev_modulegroups_get(darktable.develop));
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_INVALIDATED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_HISTORY_INVALIDATED);
 }
 
 

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -361,7 +361,7 @@ static void _execute_metadata(dt_lib_module_t *self, const int action)
     {
       GList *metadata = (action == DT_MA_CLEAR) ? NULL : dt_metadata_get_list_id(imageid);
       dt_metadata_set_list_id(imgs, metadata, action != DT_MA_MERGE, TRUE);
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
       g_list_free_full(metadata, g_free);
     }
     if(geotag_flag)
@@ -372,8 +372,8 @@ static void _execute_metadata(dt_lib_module_t *self, const int action)
       else
         dt_image_get_location(imageid, geoloc);
       dt_image_set_locations(imgs, geoloc, TRUE);
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED,
-                                    g_list_copy((GList *)imgs), 0);
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_GEOTAG_CHANGED,
+                              g_list_copy((GList *)imgs), 0);
       g_free(geoloc);
     }
     if(dttag_flag)
@@ -381,7 +381,7 @@ static void _execute_metadata(dt_lib_module_t *self, const int action)
       // affect only user tags (not dt tags)
       GList *tags = (action == DT_MA_CLEAR) ? NULL : dt_tag_get_tags(imageid, TRUE);
       if(dt_tag_set_tags(tags, imgs, TRUE, action != DT_MA_MERGE, TRUE))
-        DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+        DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
       g_list_free(tags);
     }
 
@@ -694,14 +694,10 @@ void gui_init(dt_lib_module_t *self)
                                              _("set selection as color images"), 0, 0);
   gtk_grid_attach(grid, d->set_color_button, 3, line++, 3, 1);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
-                            G_CALLBACK(_image_preference_changed), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_SELECTION_CHANGED,
-                            G_CALLBACK(_image_selection_changed_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE,
-                            G_CALLBACK(_mouse_over_image_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
-                            G_CALLBACK(_collection_updated_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_PREFERENCES_CHANGE, _image_preference_changed, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_SELECTION_CHANGED, _image_selection_changed_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE, _mouse_over_image_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_COLLECTION_CHANGED, _collection_updated_callback, self);
 
   dt_action_register(DT_ACTION(self), N_("duplicate virgin"),
                      _duplicate_virgin, GDK_KEY_d, GDK_CONTROL_MASK | GDK_SHIFT_MASK);
@@ -720,14 +716,10 @@ void gui_reset(dt_lib_module_t *self)
 
 void gui_cleanup(dt_lib_module_t *self)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_image_preference_changed), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_image_selection_changed_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_mouse_over_image_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_collection_updated_callback), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_image_preference_changed, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_image_selection_changed_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_mouse_over_image_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_collection_updated_callback, self);
 
   free(self->data);
   self->data = NULL;

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -2465,9 +2465,7 @@ void gui_init(dt_lib_module_t *self)
 
   _lib_import_ui_devices_update(self);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_CAMERA_DETECTED, G_CALLBACK(_camera_detected),
-                                  self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_CAMERA_DETECTED, _camera_detected, self);
 #endif
 
   // collapsible section
@@ -2506,8 +2504,7 @@ void gui_cleanup(dt_lib_module_t *self)
 {
   dt_lib_import_t *d = self->data;
 #ifdef HAVE_GPHOTO2
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_camera_detected), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_camera_detected, self);
 #endif
 #ifdef USE_LUA
   detach_lua_widgets(d->extra_lua_widgets);

--- a/src/libs/ioporder.c
+++ b/src/libs/ioporder.c
@@ -137,24 +137,18 @@ void gui_init(dt_lib_module_t *self)
   d->current_mode = -1;
   d->last_custom_iop_order = NULL;
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_IMAGE_CHANGED,
-                            G_CALLBACK(_image_loaded_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_INITIALIZE,
-                            G_CALLBACK(_image_loaded_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_CHANGE,
-                            G_CALLBACK(_image_loaded_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_IMAGE_CHANGED, _image_loaded_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_INITIALIZE, _image_loaded_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_HISTORY_CHANGE, _image_loaded_callback, self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
 {
   free(self->data);
   self->data = NULL;
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_image_loaded_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_image_loaded_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_image_loaded_callback), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_image_loaded_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_image_loaded_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_image_loaded_callback, self);
 }
 
 void gui_reset(dt_lib_module_t *self)

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -172,8 +172,8 @@ static void menuitem_update_preset(GtkMenuItem *menuitem,
     DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 4, name, -1, SQLITE_TRANSIENT);
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_PRESETS_CHANGED,
-                                  g_strdup(minfo->plugin_name));
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_PRESETS_CHANGED,
+                            g_strdup(minfo->plugin_name));
   }
 }
 
@@ -238,8 +238,8 @@ static void menuitem_delete_preset(GtkMenuItem *menuitem,
 
     dt_lib_presets_remove(name, minfo->plugin_name, minfo->version);
 
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_PRESETS_CHANGED,
-                                  g_strdup(minfo->plugin_name));
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_PRESETS_CHANGED,
+                            g_strdup(minfo->plugin_name));
   }
   g_free(name);
 }
@@ -819,8 +819,8 @@ void dt_lib_init_presets(dt_lib_module_t *module)
   if(module->init_presets)
     module->init_presets(module);
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_PRESETS_CHANGED,
-                                g_strdup(module->plugin_name));
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_PRESETS_CHANGED,
+                          g_strdup(module->plugin_name));
 
   sqlite3_stmt *stmt;
   // clang-format off
@@ -1349,15 +1349,12 @@ void dt_lib_init(dt_lib_t *lib)
                                                   dt_lib_load_module,
                                                   dt_lib_init_module,
                                                   dt_lib_sort_plugins);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_PREFERENCES_CHANGE,
-                                  G_CALLBACK(_preferences_changed), lib);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_PREFERENCES_CHANGE, _preferences_changed, lib);
 }
 
 void dt_lib_cleanup(dt_lib_t *lib)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_preferences_changed), lib);
+  DT_CONTROL_SIGNAL_DISCONNECT(_preferences_changed, lib);
   while(lib->plugins)
   {
     dt_lib_module_t *module = lib->plugins->data;

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -329,10 +329,10 @@ static void _show_location(dt_lib_location_t *lib,
   lib->marker_type = p->marker_type;
   lib->selected_location = p;
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_LOCATION_CHANGED,
-                                p->marker_type == MAP_DISPLAY_POLYGON
-                                ? p->marker_points
-                                : NULL);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_LOCATION_CHANGED,
+                          p->marker_type == MAP_DISPLAY_POLYGON
+                          ? p->marker_points
+                          : NULL);
 }
 
 /* called when search job has been processed and

--- a/src/libs/map_locations.c
+++ b/src/libs/map_locations.c
@@ -460,7 +460,7 @@ static void _view_map_location_changed(gpointer instance, GList *polygons, dt_li
 static void _signal_location_change(dt_lib_module_t *self)
 {
   dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(_view_map_geotag_changed), self);
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED, (GList *)NULL, 0);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_GEOTAG_CHANGED, (GList *)NULL, 0);
   dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(_view_map_geotag_changed), self);
 }
 
@@ -976,11 +976,9 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(selection), "changed", G_CALLBACK(_selection_changed), self);
 
   // connect geotag changed signal
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_GEOTAG_CHANGED,
-                                  G_CALLBACK(_view_map_geotag_changed), (gpointer)self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_GEOTAG_CHANGED, _view_map_geotag_changed, self);
   // connect location changed signal
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_LOCATION_CHANGED,
-                                  G_CALLBACK(_view_map_location_changed), (gpointer)self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_LOCATION_CHANGED, _view_map_location_changed, self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
@@ -988,8 +986,8 @@ void gui_cleanup(dt_lib_module_t *self)
   free(self->data);
   self->data = NULL;
 
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_view_map_geotag_changed), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_view_map_location_changed), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_view_map_geotag_changed, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_view_map_location_changed, self);
 }
 
 // clang-format off

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -291,10 +291,8 @@ static void _write_metadata(dt_lib_module_t *self)
     for(GList *l = key_value; l; l = l->next->next) g_free(l->next->data);
     g_list_free(key_value);
 
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                  DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                  DT_SIGNAL_METADATA_CHANGED, DT_METADATA_SIGNAL_NEW_VALUE);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_METADATA_CHANGED, DT_METADATA_SIGNAL_NEW_VALUE);
 
     dt_image_synch_xmps(d->last_act_on);
     dt_gui_cursor_clear_busy();
@@ -609,10 +607,10 @@ static void _menuitem_preferences(GtkMenuItem *menuitem,
       valid = gtk_tree_model_iter_next(model, &iter);
     }
     if(meta_signal)
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_METADATA_CHANGED,
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_METADATA_CHANGED,
                               meta_remove
-                                    ? DT_METADATA_SIGNAL_HIDDEN
-                                    : DT_METADATA_SIGNAL_SHOWN);
+                              ? DT_METADATA_SIGNAL_HIDDEN
+                              : DT_METADATA_SIGNAL_SHOWN);
   }
   _update_layout(self);
   gtk_widget_destroy(dialog);
@@ -751,14 +749,11 @@ void gui_init(dt_lib_module_t *self)
   gtk_grid_attach(grid, d->button_box, 0, DT_METADATA_NUMBER, 2, 1);
 
   /* lets signup for mouse over image change signals */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE,
-                                  G_CALLBACK(_image_selection_changed_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE, _image_selection_changed_callback, self);
 
   // and 2 other interesting signals:
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_SELECTION_CHANGED,
-                                  G_CALLBACK(_image_selection_changed_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
-                                  G_CALLBACK(_collection_updated_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_SELECTION_CHANGED, _image_selection_changed_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_COLLECTION_CHANGED, _collection_updated_callback, self);
 
   gtk_widget_show_all(self->widget);
   gtk_widget_set_no_show_all(self->widget, TRUE);
@@ -768,9 +763,9 @@ void gui_init(dt_lib_module_t *self)
 void gui_cleanup(dt_lib_module_t *self)
 {
   dt_lib_metadata_t *d = self->data;
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_image_selection_changed_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_image_selection_changed_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_collection_updated_callback), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_image_selection_changed_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_image_selection_changed_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_collection_updated_callback, self);
 
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
   {
@@ -969,7 +964,7 @@ int set_params(dt_lib_module_t *self,
 
   g_list_free(key_value);
 
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
   dt_image_synch_xmps(imgs);
   g_list_free(imgs);
   // force the ui refresh to update the info from preset

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -1438,28 +1438,22 @@ void gui_init(dt_lib_module_t *self)
   _apply_preferences(pref, self);
 
   /* lets signup for mouse over image change signals */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE,
-                            G_CALLBACK(_mouse_over_image_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE, _mouse_over_image_callback, self);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_SELECTION_CHANGED,
-                                  G_CALLBACK(_mouse_over_image_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_SELECTION_CHANGED, _mouse_over_image_callback, self);
 
   /* lets signup for develop image changed signals */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_IMAGE_CHANGED,
-                            G_CALLBACK(_mouse_over_image_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_IMAGE_CHANGED, _mouse_over_image_callback, self);
 
   /* signup for develop initialize to update info of current
      image in darkroom when enter */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_INITIALIZE,
-                            G_CALLBACK(_mouse_over_image_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_INITIALIZE, _mouse_over_image_callback, self);
 
   /* signup for tags changes */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_TAG_CHANGED,
-                            G_CALLBACK(_mouse_over_image_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_TAG_CHANGED, _mouse_over_image_callback, self);
 
   /* signup for metadata changes */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_METADATA_UPDATE,
-                            G_CALLBACK(_mouse_over_image_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_METADATA_UPDATE, _mouse_over_image_callback, self);
 
   dt_action_register(DT_ACTION(self), N_("jump to film roll"), _jump_to_accel, GDK_KEY_j, GDK_CONTROL_MASK);
 }
@@ -1473,8 +1467,8 @@ static void _free_metadata_queue(dt_lib_metadata_info_t *m)
 
 void gui_cleanup(dt_lib_module_t *self)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_mouse_over_image_callback), self);
   dt_lib_metadata_view_t *d = self->data;
+  DT_CONTROL_SIGNAL_DISCONNECT(_mouse_over_image_callback, self);
   g_list_free_full(d->metadata,  (GDestroyNotify)_free_metadata_queue);
   g_free(self->data);
   self->data = NULL;

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -2944,16 +2944,13 @@ void gui_init(dt_lib_module_t *self)
   darktable.develop->proxy.modulegroups.basics_module_toggle = _lib_modulegroups_basics_module_toggle;
 
   // check for autoapplypresets on image change
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_IMAGE_CHANGED,
-                                  G_CALLBACK(_dt_dev_image_changed_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_INITIALIZE,
-                                  G_CALLBACK(_dt_dev_image_changed_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_IMAGE_CHANGED, _dt_dev_image_changed_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_INITIALIZE, _dt_dev_image_changed_callback, self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_dt_dev_image_changed_callback), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_dt_dev_image_changed_callback, self);
 
   darktable.develop->proxy.modulegroups.module = NULL;
   darktable.develop->proxy.modulegroups.set = NULL;

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -178,13 +178,10 @@ void gui_init(dt_lib_module_t *self)
                      GDK_KEY_N, GDK_CONTROL_MASK | GDK_SHIFT_MASK);
 
   /* connect a redraw callback to control draw all and preview pipe finish signals */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
-                                  G_CALLBACK(_lib_navigation_control_redraw_callback),
-                                  self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_CONTROL_NAVIGATION_REDRAW,
-                                  G_CALLBACK(_lib_navigation_control_redraw_callback),
-                                  self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
+                            _lib_navigation_control_redraw_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_CONTROL_NAVIGATION_REDRAW, 
+                            _lib_navigation_control_redraw_callback, self);
 
   DT_BAUHAUS_COMBOBOX_NEW_FULL(d->zoom, darktable.view_manager->proxy.darkroom.view,
                                NULL, N_("zoom"), _("image zoom level"),
@@ -223,9 +220,7 @@ void gui_init(dt_lib_module_t *self)
 void gui_cleanup(dt_lib_module_t *self)
 {
   /* disconnect from signal */
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_lib_navigation_control_redraw_callback),
-                                     self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_lib_navigation_control_redraw_callback, self);
 
   g_free(self->data);
   self->data = NULL;

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -609,7 +609,7 @@ static int _print_job_run(dt_job_t *job)
   {
     if(dt_is_valid_imgid(params->imgs.box[k].imgid))
       if(dt_tag_attach(tagid, params->imgs.box[k].imgid, FALSE, FALSE))
-        DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+        DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
 
     /* register print timestamp in cache */
     dt_image_cache_set_print_timestamp(darktable.image_cache, params->imgs.box[k].imgid);
@@ -1429,17 +1429,11 @@ void view_enter(struct dt_lib_module_t *self,
 
   // user activated a new image via the filmstrip or user entered view
   // mode which activates an image: get image_id and orientation
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE,
-                                  G_CALLBACK(_print_settings_activate_callback),
-                                  self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, _print_settings_activate_callback, self);
 
   // when an updated mipmap, we may have new orientation information
   // about the current image.
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_DEVELOP_MIPMAP_UPDATED,
-                                  G_CALLBACK(_print_settings_update_callback),
-                                  self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, _print_settings_update_callback, self);
 
   // NOTE: it would be proper to set image_id here to -1, but this
   // seems to make no difference
@@ -1449,12 +1443,8 @@ void view_leave(struct dt_lib_module_t *self,
                 struct dt_view_t *old_view,
                 struct dt_view_t *new_view)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_print_settings_activate_callback),
-                                     self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_print_settings_update_callback),
-                                     self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_print_settings_activate_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_print_settings_update_callback, self);
 }
 
 static gboolean _expose_again(gpointer user_data)

--- a/src/libs/recentcollect.c
+++ b/src/libs/recentcollect.c
@@ -344,8 +344,7 @@ void gui_init(dt_lib_module_t *self)
   _lib_recentcollection_updated(NULL, DT_COLLECTION_CHANGE_NEW_QUERY, DT_COLLECTION_PROP_UNDEF, NULL, -1, self);
 
   /* connect collection changed signal */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
-                                  G_CALLBACK(_lib_recentcollection_updated), (gpointer)self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_COLLECTION_CHANGED, _lib_recentcollection_updated, self);
 
   darktable.view_manager->proxy.module_recentcollect.module = self;
 }
@@ -354,7 +353,7 @@ void gui_cleanup(dt_lib_module_t *self)
 {
   const int curr_pos = dt_ui_thumbtable(darktable.gui->ui)->offset;
   dt_conf_set_int("plugins/lighttable/collect/history_pos0", curr_pos);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_lib_recentcollection_updated), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_lib_recentcollection_updated, self);
   free(self->data);
   self->data = NULL;
 }

--- a/src/libs/select.c
+++ b/src/libs/select.c
@@ -163,16 +163,14 @@ void gui_init(dt_lib_module_t *self)
   gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(d->select_none_button))), PANGO_ELLIPSIZE_START);
   gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(d->select_film_roll_button))), PANGO_ELLIPSIZE_START);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_SELECTION_CHANGED,
-                            G_CALLBACK(_image_selection_changed_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
-                            G_CALLBACK(_collection_updated_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_SELECTION_CHANGED, _image_selection_changed_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_COLLECTION_CHANGED, _collection_updated_callback, self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_image_selection_changed_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_collection_updated_callback), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_image_selection_changed_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_collection_updated_callback, self);
   free(self->data);
   self->data = NULL;
 }

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -808,12 +808,9 @@ void gui_init(dt_lib_module_t *self)
   dt_action_register(DT_ACTION(self), N_("toggle last snapshot"),
                      _lib_snapshots_toggle_last, 0, 0);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
-                                  G_CALLBACK(_signal_profile_changed), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_IMAGE_CHANGED,
-                                  G_CALLBACK(_signal_image_changed), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_IMAGE_REMOVED,
-                                  G_CALLBACK(_signal_image_removed), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED, _signal_profile_changed, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_IMAGE_CHANGED, _signal_image_changed, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_IMAGE_REMOVED, _signal_image_removed, self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -411,7 +411,7 @@ static void _delete_clicked(GtkWidget *w, gpointer user_data)
     if(!single_raise) {
       // raise signal at the end of processing all styles if we have more than 1 to delete
       // this also calls _gui_styles_update_view
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_STYLE_CHANGED);
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_STYLE_CHANGED);
     }
     dt_database_release_transaction(darktable.db);
   }
@@ -939,27 +939,19 @@ void gui_init(dt_lib_module_t *self)
   /* update filtered list */
   _gui_styles_update_view(d);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_STYLE_CHANGED,
-                                  G_CALLBACK(_styles_changed_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_STYLE_CHANGED, _styles_changed_callback, self);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_SELECTION_CHANGED,
-                            G_CALLBACK(_image_selection_changed_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE,
-                            G_CALLBACK(_mouse_over_image_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
-                            G_CALLBACK(_collection_updated_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_SELECTION_CHANGED, _image_selection_changed_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE, _mouse_over_image_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_COLLECTION_CHANGED, _collection_updated_callback, self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_styles_changed_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_image_selection_changed_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_mouse_over_image_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_collection_updated_callback), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_styles_changed_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_image_selection_changed_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_mouse_over_image_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_collection_updated_callback, self);
 
   free(self->data);
   self->data = NULL;
@@ -987,7 +979,7 @@ void gui_reset(dt_lib_module_t *self)
       dt_style_t *style = result->data;
       dt_styles_delete_by_name_adv((char*)style->name, FALSE);
     }
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_STYLE_CHANGED);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_STYLE_CHANGED);
   }
   g_list_free_full(all_styles, dt_style_free);
   dt_database_release_transaction(darktable.db);

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -642,7 +642,7 @@ static void _raise_signal_tag_changed(dt_lib_module_t *self)
     // raises change only for other modules
     dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(_collection_updated_callback), self);
     dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(_lib_tagging_tags_changed_callback), self);
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
     dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(_lib_tagging_tags_changed_callback), self);
     dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(_collection_updated_callback), self);
   }
@@ -3342,14 +3342,10 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(box, GTK_WIDGET(hbox), FALSE, TRUE, 0);
 
   /* connect to mouse over id */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE,
-                            G_CALLBACK(_lib_tagging_redraw_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_TAG_CHANGED,
-                            G_CALLBACK(_lib_tagging_tags_changed_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_SELECTION_CHANGED,
-                            G_CALLBACK(_lib_selection_changed_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
-                            G_CALLBACK(_collection_updated_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE, _lib_tagging_redraw_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_TAG_CHANGED, _lib_tagging_tags_changed_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_SELECTION_CHANGED, _lib_selection_changed_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_COLLECTION_CHANGED, _collection_updated_callback, self);
 
   d->collection = g_malloc(4096);
   _update_layout(self);
@@ -3365,10 +3361,10 @@ void gui_cleanup(dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = self->data;
 
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_lib_tagging_redraw_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_lib_tagging_tags_changed_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_lib_selection_changed_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_collection_updated_callback), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_lib_tagging_redraw_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_lib_tagging_tags_changed_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_lib_selection_changed_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_collection_updated_callback, self);
   g_free(d->collection);
   if(d->drag.tagname) g_free(d->drag.tagname);
   if(d->drag.path) gtk_tree_path_free(d->drag.path);

--- a/src/libs/tools/image_infos.c
+++ b/src/libs/tools/image_infos.c
@@ -137,25 +137,21 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_show_all(self->widget);
 
   /* lets signup for develop image changed signals */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_IMAGE_CHANGED,
-                            G_CALLBACK(_lib_imageinfo_update_message), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_IMAGE_CHANGED, _lib_imageinfo_update_message, self);
 
   /* signup for develop initialize to update info of current
      image in darkroom when enter */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_INITIALIZE,
-                            G_CALLBACK(_lib_imageinfo_update_message), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_INITIALIZE, _lib_imageinfo_update_message, self);
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_IMAGE_INFO_CHANGED,
-                                  G_CALLBACK(_lib_imageinfo_update_message2), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
-                                  G_CALLBACK(_lib_imageinfo_update_message3), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_IMAGE_INFO_CHANGED, _lib_imageinfo_update_message2, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_COLLECTION_CHANGED, _lib_imageinfo_update_message3, self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_lib_imageinfo_update_message), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_lib_imageinfo_update_message2), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_lib_imageinfo_update_message3), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_lib_imageinfo_update_message, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_lib_imageinfo_update_message2, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_lib_imageinfo_update_message3, self);
 
   g_free(self->data);
   self->data = NULL;

--- a/src/libs/tools/timeline.c
+++ b/src/libs/tools/timeline.c
@@ -1420,8 +1420,7 @@ void gui_init(dt_lib_module_t *self)
   /* initialize view manager proxy */
   darktable.view_manager->proxy.timeline.module = self;
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
-                            G_CALLBACK(_lib_timeline_collection_changed), (gpointer)self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_COLLECTION_CHANGED, _lib_timeline_collection_changed, self);
 
   dt_action_register(DT_ACTION(self), N_("start selection"), _selection_start, GDK_KEY_bracketleft, 0);
   dt_action_register(DT_ACTION(self), N_("stop selection"), _selection_stop, GDK_KEY_bracketright, 0);
@@ -1432,7 +1431,7 @@ void gui_cleanup(dt_lib_module_t *self)
   /* cleanup */
   dt_lib_timeline_t *strip = self->data;
   if(strip->blocks) g_list_free_full(strip->blocks, _block_free);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_lib_timeline_collection_changed), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_lib_timeline_collection_changed, self);
   /* unset viewmanager proxy */
   darktable.view_manager->proxy.timeline.module = NULL;
   free(self->data);

--- a/src/libs/tools/viewswitcher.c
+++ b/src/libs/tools/viewswitcher.c
@@ -159,16 +159,14 @@ void gui_init(dt_lib_module_t *self)
   if(model) g_object_unref(model);
 
   /* connect callback to view change signal */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_VIEWMANAGER_VIEW_CHANGED,
-                            G_CALLBACK(_lib_viewswitcher_view_changed_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_VIEWMANAGER_VIEW_CANNOT_CHANGE,
-                                  G_CALLBACK(_lib_viewswitcher_view_cannot_change_callback), self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_VIEWMANAGER_VIEW_CHANGED, _lib_viewswitcher_view_changed_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_VIEWMANAGER_VIEW_CANNOT_CHANGE, _lib_viewswitcher_view_cannot_change_callback, self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_lib_viewswitcher_view_changed_callback), self);
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_lib_viewswitcher_view_cannot_change_callback), self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_lib_viewswitcher_view_changed_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_lib_viewswitcher_view_cannot_change_callback, self);
   g_free(self->data);
   self->data = NULL;
 }

--- a/src/lua/database.c
+++ b/src/lua/database.c
@@ -180,7 +180,7 @@ static int import_images(lua_State *L)
     // force refresh of thumbtable view
     dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, DT_COLLECTION_PROP_UNDEF,
                                g_list_prepend(NULL, GINT_TO_POINTER(result)));
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_FILMROLLS_CHANGED);
     dt_control_queue_redraw_center();
 
   }
@@ -326,8 +326,7 @@ int dt_lua_init_database(lua_State *L)
   lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
   lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
   dt_lua_event_add(L, "post-import-film");
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_FILMROLLS_IMPORTED, G_CALLBACK(on_film_imported),
-                            NULL);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_FILMROLLS_IMPORTED, on_film_imported, NULL);
 
   lua_pushcfunction(L, dt_lua_event_multiinstance_register);
   lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);

--- a/src/lua/gui.c
+++ b/src/lua/gui.c
@@ -487,7 +487,7 @@ int dt_lua_init_gui(lua_State *L)
     lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
     lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
     dt_lua_event_add(L, "mouse-over-image-changed");
-    DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE, G_CALLBACK(_on_mouse_over_image_changed), NULL);
+    DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE, _on_mouse_over_image_changed, NULL);
   }
   return 0;
 }

--- a/src/lua/image.c
+++ b/src/lua/image.c
@@ -90,7 +90,7 @@ static int history_delete(lua_State *L)
   dt_lua_image_t imgid = NO_IMGID;
   luaA_to(L, dt_lua_image_t, &imgid, -1);
   dt_history_delete_on_image(imgid);
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
   return 0;
 }
 

--- a/src/lua/styles.c
+++ b/src/lua/styles.c
@@ -264,7 +264,7 @@ int dt_lua_style_apply(lua_State *L)
   else
   {
     dt_styles_apply_to_image(style.name, FALSE, FALSE, imgid);
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
   }
   return 1;
 }

--- a/src/lua/tags.c
+++ b/src/lua/tags.c
@@ -181,7 +181,7 @@ static int tag_delete(lua_State *L)
   sqlite3_finalize(stmt);
 
   if(dt_tag_remove(tagid, TRUE))
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
 
   for(const GList *list_iter = tagged_images; list_iter; list_iter = g_list_next(list_iter))
   {
@@ -209,7 +209,7 @@ int dt_lua_tag_attach(lua_State *L)
   }
   if(dt_tag_attach(tagid, imgid, TRUE, TRUE))
   {
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
     dt_image_synch_xmp(imgid);
   }
   return 0;
@@ -232,7 +232,7 @@ int dt_lua_tag_detach(lua_State *L)
   if(dt_tag_detach(tagid, imgid, TRUE, TRUE))
   {
     dt_image_synch_xmp(imgid);
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_TAG_CHANGED);
   }
   return 0;
 }

--- a/src/lua/view.c
+++ b/src/lua/view.c
@@ -83,8 +83,7 @@ int dt_lua_init_view(lua_State *L)
   lua_pushcfunction(L, dt_lua_event_multiinstance_destroy);
   lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
   dt_lua_event_add(L, "view-changed");
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_VIEWMANAGER_VIEW_CHANGED,
-                            G_CALLBACK(on_view_changed), NULL);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_VIEWMANAGER_VIEW_CHANGED, on_view_changed, NULL);
   return 0;
 }
 // clang-format off

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -867,7 +867,7 @@ static void _dev_change_image(dt_develop_t *dev, const dt_imgid_t imgid)
   // change active image
   g_slist_free(darktable.view_manager->active_images);
   darktable.view_manager->active_images = g_slist_prepend(NULL, GINT_TO_POINTER(imgid));
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_ACTIVE_IMAGES_CHANGE);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_ACTIVE_IMAGES_CHANGE);
 
   // if the previous shown image is selected and the selection is unique
   // then we change the selected image to the new one
@@ -1178,7 +1178,7 @@ static gboolean _dev_load_requested_image(gpointer user_data)
   }
 
   // Signal develop initialize
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_IMAGE_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_IMAGE_CHANGED);
 
   // release pixel pipe mutices
   dt_pthread_mutex_BAD_unlock(&dev->preview2.pipe->mutex);
@@ -1703,7 +1703,7 @@ static void _softproof_profile_callback(GtkWidget *combo, gpointer user_data)
 end:
   if(profile_changed)
   {
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED, DT_COLORSPACES_PROFILE_TYPE_SOFTPROOF);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED, DT_COLORSPACES_PROFILE_TYPE_SOFTPROOF);
     dt_dev_reprocess_all(d);
   }
 }
@@ -1745,7 +1745,7 @@ end:
     pthread_rwlock_rdlock(&darktable.color_profiles->xprofile_lock);
     dt_colorspaces_update_display_transforms();
     pthread_rwlock_unlock(&darktable.color_profiles->xprofile_lock);
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED, DT_COLORSPACES_PROFILE_TYPE_DISPLAY);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED, DT_COLORSPACES_PROFILE_TYPE_DISPLAY);
     dt_dev_reprocess_all(d);
   }
 }
@@ -1787,7 +1787,7 @@ end:
     pthread_rwlock_rdlock(&darktable.color_profiles->xprofile_lock);
     dt_colorspaces_update_display2_transforms();
     pthread_rwlock_unlock(&darktable.color_profiles->xprofile_lock);
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
                             DT_COLORSPACES_PROFILE_TYPE_DISPLAY2);
     dt_dev_reprocess_all(d);
   }
@@ -1834,7 +1834,7 @@ static void _histogram_profile_callback(GtkWidget *combo, gpointer user_data)
 end:
   if(profile_changed)
   {
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED, DT_COLORSPACES_PROFILE_TYPE_HISTOGRAM);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED, DT_COLORSPACES_PROFILE_TYPE_HISTOGRAM);
     dt_dev_reprocess_all(d);
   }
 }
@@ -2572,15 +2572,11 @@ void gui_init(dt_view_t *self)
     _update_softproof_gamut_checking(dev);
 
     // update the gui when the preferences changed (i.e. show intent when using lcms2)
-    DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
-                              G_CALLBACK(_preference_changed), (gpointer)display_intent);
-    DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
-                              G_CALLBACK(_preference_changed), (gpointer)display2_intent);
+    DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_PREFERENCES_CHANGE, _preference_changed, display_intent);
+    DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_PREFERENCES_CHANGE, _preference_changed, display2_intent);
     // and when profiles change
-    DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
-                              G_CALLBACK(_display_profile_changed), (gpointer)display_profile);
-    DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
-                              G_CALLBACK(_display2_profile_changed), (gpointer)display2_profile);
+    DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED, _display_profile_changed, display_profile);
+    DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED, _display2_profile_changed, display2_profile);
 
     gtk_widget_show_all(vbox);
   }
@@ -2601,8 +2597,7 @@ void gui_init(dt_view_t *self)
     dt_view_manager_module_toolbox_add(darktable.view_manager, darktable.view_manager->guides_toggle,
                                        DT_VIEW_DARKROOM | DT_VIEW_TETHERING);
     // we want to update button state each time the view change
-    DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_VIEWMANAGER_VIEW_CHANGED,
-                                    G_CALLBACK(_guides_view_changed), dev);
+    DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_VIEWMANAGER_VIEW_CHANGED, _guides_view_changed, dev);
   }
 
   darktable.view_manager->proxy.darkroom.get_layout = _lib_darkroom_get_layout;
@@ -2674,15 +2669,9 @@ void enter(dt_view_t *self)
   dt_undo_clear(darktable.undo, DT_UNDO_DEVELOP);
 
   /* connect to ui pipe finished signal for redraw */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,
-                            G_CALLBACK(_darkroom_ui_pipe_finish_signal_callback), (gpointer)self);
-
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW2_PIPE_FINISHED,
-                            G_CALLBACK(_darkroom_ui_preview2_pipe_finish_signal_callback), (gpointer)self);
-
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_TROUBLE_MESSAGE,
-                                  G_CALLBACK(_display_module_trouble_message_callback),
-                                  (gpointer)self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED, _darkroom_ui_pipe_finish_signal_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_PREVIEW2_PIPE_FINISHED, _darkroom_ui_preview2_pipe_finish_signal_callback, self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_TROUBLE_MESSAGE, _display_module_trouble_message_callback, self);
 
   dt_print(DT_DEBUG_CONTROL, "[run_job+] 11 %f in darkroom mode\n", dt_get_wtime());
   dt_develop_t *dev = self->data;
@@ -2741,9 +2730,9 @@ void enter(dt_view_t *self)
   }
 
   /* signal that darktable.develop is initialized and ready to be used */
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_INITIALIZE);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_INITIALIZE);
   /* signal that there is a new image to be developed */
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_IMAGE_CHANGED);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_DEVELOP_IMAGE_CHANGED);
 
   // synch gui and flag pipe as dirty
   // this is done here and not in dt_read_history, as it would else be triggered before module->gui_init.
@@ -2768,9 +2757,8 @@ void enter(dt_view_t *self)
   dt_dev_zoom_move(&dev->full, DT_ZOOM_MOVE, -1.f, TRUE, 0.0f, 0.0f, TRUE);
 
   /* connect signal for filmstrip image activate */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE,
-                            G_CALLBACK(_view_darkroom_filmstrip_activate_callback), self);
-
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE,
+                            _view_darkroom_filmstrip_activate_callback, self);
   dt_collection_hint_message(darktable.collection);
 
   dt_ui_scrollbars_show(darktable.gui->ui, dt_conf_get_bool("darkroom/ui/scrollbars"));
@@ -2795,9 +2783,7 @@ void enter(dt_view_t *self)
   dt_dev_modulegroups_set(dev, dt_conf_get_int("plugins/darkroom/groups"));
 
   // connect to preference change for module header button hiding
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
-                                  G_CALLBACK(_preference_changed_button_hide), dev);
-
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_PREFERENCES_CHANGE, _preference_changed_button_hide, dev);
   dt_iop_color_picker_init();
 
   dt_image_check_camera_missing_sample(&dev->image_storage);
@@ -2817,20 +2803,12 @@ void leave(dt_view_t *self)
     dt_iop_color_picker_reset(darktable.lib->proxy.colorpicker.picker_proxy->module, FALSE);
 
   /* disconnect from filmstrip image activate */
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_view_darkroom_filmstrip_activate_callback),
-                               (gpointer)self);
-
+  DT_CONTROL_SIGNAL_DISCONNECT(_view_darkroom_filmstrip_activate_callback, self);
   /* disconnect from pipe finish signal */
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_darkroom_ui_pipe_finish_signal_callback),
-                               (gpointer)self);
-
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_darkroom_ui_preview2_pipe_finish_signal_callback),
-                               (gpointer)self);
-
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_display_module_trouble_message_callback),
-                                     (gpointer)self);
-
+  DT_CONTROL_SIGNAL_DISCONNECT(_darkroom_ui_pipe_finish_signal_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_darkroom_ui_preview2_pipe_finish_signal_callback, self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_display_module_trouble_message_callback, self);
+  
   // store groups for next time:
   dt_conf_set_int("plugins/darkroom/groups", dt_dev_modulegroups_get(darktable.develop));
 
@@ -2842,8 +2820,7 @@ void leave(dt_view_t *self)
 
   dt_develop_t *dev = self->data;
 
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_preference_changed_button_hide), dev);
+  DT_CONTROL_SIGNAL_DISCONNECT(_preference_changed_button_hide, dev);
 
   // reset color assessment mode
   if(dev->full.iso_12646)

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -515,7 +515,7 @@ static void _preview_enter(dt_view_t *self, gboolean sticky, gboolean focus)
   // set the active image
   g_slist_free(darktable.view_manager->active_images);
   darktable.view_manager->active_images = g_slist_prepend(NULL, GINT_TO_POINTER(lib->preview->offset_imgid));
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_ACTIVE_IMAGES_CHANGE);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_ACTIVE_IMAGES_CHANGE);
 
   // restore panels
   dt_ui_restore_panels(darktable.gui->ui);
@@ -574,7 +574,7 @@ void leave(dt_view_t *self)
   {
     g_slist_free(darktable.view_manager->active_images);
     darktable.view_manager->active_images = NULL;
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_ACTIVE_IMAGES_CHANGE);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_ACTIVE_IMAGES_CHANGE);
   }
 
   // we hide culling and preview too
@@ -1032,7 +1032,7 @@ end:
     pthread_rwlock_rdlock(&darktable.color_profiles->xprofile_lock);
     dt_colorspaces_update_display_transforms();
     pthread_rwlock_unlock(&darktable.color_profiles->xprofile_lock);
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
                             DT_COLORSPACES_PROFILE_TYPE_DISPLAY);
     dt_control_queue_redraw_center();
   }
@@ -1074,7 +1074,7 @@ end:
     pthread_rwlock_rdlock(&darktable.color_profiles->xprofile_lock);
     dt_colorspaces_update_display2_transforms();
     pthread_rwlock_unlock(&darktable.color_profiles->xprofile_lock);
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
                             DT_COLORSPACES_PROFILE_TYPE_DISPLAY2);
     dt_control_queue_redraw_center();
   }
@@ -1236,10 +1236,8 @@ void gui_init(dt_view_t *self)
                    NULL);
 
   // update the gui when profiles change
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
-                            G_CALLBACK(_profile_display_changed), (gpointer)display_profile);
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
-                            G_CALLBACK(_profile_display2_changed), (gpointer)display2_profile);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED, _profile_display_changed, display_profile);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED, _profile_display2_changed, display2_profile);
 
   dt_action_t *sa = &self->actions, *ac = NULL;
 

--- a/src/views/print.c
+++ b/src/views/print.c
@@ -355,9 +355,8 @@ void enter(dt_view_t *self)
     dt_view_active_images_add(prt->imgs->imgid_to_load, TRUE);
   }
 
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_MIPMAP_UPDATED,
-                            G_CALLBACK(_print_mipmaps_updated_signal_callback),
-                            (gpointer)self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_MIPMAP_UPDATED,
+                            _print_mipmaps_updated_signal_callback, self);
 
   gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));
 
@@ -377,9 +376,7 @@ void leave(dt_view_t *self)
   GtkWidget *widget = dt_ui_center(darktable.gui->ui);
 
   /* disconnect from mipmap updated signal */
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_print_mipmaps_updated_signal_callback),
-                                     (gpointer)self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_print_mipmaps_updated_signal_callback, self);
 
   dt_printing_clear_boxes(prt->imgs);
 

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -581,16 +581,13 @@ void enter(dt_view_t *self)
   }
 
   /* connect signal for mipmap update for a redraw */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_MIPMAP_UPDATED,
-                                  G_CALLBACK(_capture_mipmaps_updated_signal_callback),
-                                  (gpointer)self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_DEVELOP_MIPMAP_UPDATED,
+                            _capture_mipmaps_updated_signal_callback, self);
 
 
   /* connect signal for fimlstrip image activate */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals,
-                                  DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE,
-                                  G_CALLBACK(_view_capture_filmstrip_activate_callback),
-                                  self);
+  DT_CONTROL_SIGNAL_CONNECT(DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE,
+                            _view_capture_filmstrip_activate_callback, self);
 
   // register listener
   lib->listener = g_malloc0(sizeof(dt_camctl_listener_t));
@@ -616,14 +613,10 @@ void leave(dt_view_t *self)
   dt_import_session_destroy(cv->session);
 
   /* disconnect from mipmap updated signal */
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_capture_mipmaps_updated_signal_callback),
-                                     (gpointer)self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_capture_mipmaps_updated_signal_callback, self);
 
   /* disconnect from filmstrip image activate */
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
-                                     G_CALLBACK(_view_capture_filmstrip_activate_callback),
-                                     (gpointer)self);
+  DT_CONTROL_SIGNAL_DISCONNECT(_view_capture_filmstrip_activate_callback, self);
 }
 
 void reset(dt_view_t *self)

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -303,9 +303,8 @@ gboolean dt_view_manager_switch_by_view(dt_view_manager_t *vm,
     const gboolean error = new_view->try_enter(new_view);
     if(error)
     {
-      DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                    DT_SIGNAL_VIEWMANAGER_VIEW_CANNOT_CHANGE,
-                                    old_view, new_view);
+      DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_VIEWMANAGER_VIEW_CANNOT_CHANGE,
+                              old_view, new_view);
       return error;
     }
   }
@@ -433,14 +432,13 @@ gboolean dt_view_manager_switch_by_view(dt_view_manager_t *vm,
   if(vm->accels_window.window && vm->accels_window.sticky) dt_view_accels_refresh(vm);
 
   /* raise view changed signal */
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals,
-                                DT_SIGNAL_VIEWMANAGER_VIEW_CHANGED, old_view, new_view);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_VIEWMANAGER_VIEW_CHANGED, old_view, new_view);
 
   // update log visibility
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_LOG_REDRAW);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_LOG_REDRAW);
 
   // update toast visibility
-  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_CONTROL_TOAST_REDRAW);
+  DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_CONTROL_TOAST_REDRAW);
   return FALSE;
 }
 
@@ -1091,14 +1089,14 @@ void dt_view_active_images_reset(const gboolean raise)
   darktable.view_manager->active_images = NULL;
 
   if(raise)
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_ACTIVE_IMAGES_CHANGE);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_ACTIVE_IMAGES_CHANGE);
 }
 void dt_view_active_images_add(dt_imgid_t imgid, gboolean raise)
 {
   darktable.view_manager->active_images =
     g_slist_append(darktable.view_manager->active_images, GINT_TO_POINTER(imgid));
   if(raise)
-    DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_ACTIVE_IMAGES_CHANGE);
+    DT_CONTROL_SIGNAL_RAISE(DT_SIGNAL_ACTIVE_IMAGES_CHANGE);
 }
 GSList *dt_view_active_images_get()
 {


### PR DESCRIPTION
1. First two commits are @dterrahe work making signal related code more readable/dense.
2. Third commit avoids casting `userdata` to `dt_thumbtable_t *table` again for code readability