### PR TITLE
17622: Check image - overlay usage recursively, to prevent loops

### DIFF
--- a/po/en@truecase.po
+++ b/po/en@truecase.po
@@ -19763,10 +19763,10 @@ msgstr ""
 #, c-format
 msgid ""
 "cannot use image %d as an overlay as it is using the current image as an "
-"overlay itself"
+"overlay, directly or indirectly"
 msgstr ""
 "Cannot use image %d as an overlay as it is using the current image as an "
-"overlay itself"
+"overlay, directly or indirectly"
 
 #: ../src/iop/overlay.c:1105 ../src/iop/watermark.c:1364
 msgctxt "section"

--- a/src/common/overlay.c
+++ b/src/common/overlay.c
@@ -126,18 +126,25 @@ GList *dt_overlay_get_used_in_imgs(const dt_imgid_t overlay_id,
   return res;
 }
 
-gboolean dt_overlay_used_by(const dt_imgid_t imgid, const dt_imgid_t overlay_id)
+gboolean dt_overlay_used_by(const dt_imgid_t imgid_intended_overlay, const dt_imgid_t imgid_target_image)
 {
   sqlite3_stmt *stmt;
 
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "SELECT 1"
-                              " FROM overlay"
-                              " WHERE imgid = ?1"
-                              "   AND overlay_id = ?2",
+                              "WITH RECURSIVE cte_overlay (imgid, overlay_id) AS ("
+                              " SELECT imgid, overlay_id"
+                              " FROM overlay o"
+                              " WHERE o.imgid = ?1" // ID of the image we want to use as an overlay; we want to query its overlay tree
+                              " UNION"
+                              " SELECT o.imgid, o.overlay_id"
+                              " FROM overlay o"
+                              " JOIN cte_overlay c ON c.overlay_id = o.imgid" // the overlays of the image
+                              ")"
+                              " SELECT 1 FROM cte_overlay"
+                              " WHERE overlay_id = ?2", // ID of the image for which we want to set the other as overlay; it must not appear in the overlay tree
                               -1, &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, overlay_id);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid_intended_overlay);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, imgid_target_image);
 
   gboolean result = FALSE;
 

--- a/src/common/overlay.h
+++ b/src/common/overlay.h
@@ -53,8 +53,8 @@ GList *dt_overlay_get_imgs(const dt_imgid_t imgid);
 GList *dt_overlay_get_used_in_imgs(const dt_imgid_t overlay_id,
                                    const gboolean except_self);
 
-/* Return TRUE is overlay_id is used by imgid */
-gboolean dt_overlay_used_by(const dt_imgid_t imgid, const dt_imgid_t overlay_id);
+/* Return TRUE if imgid_target_image appears in the overlay tree of (is used by) imgid_intended_overlay */
+gboolean dt_overlay_used_by(const dt_imgid_t imgid_intended_overlay, const dt_imgid_t imgid_target_image);
 
 G_END_DECLS
 

--- a/src/iop/overlay.c
+++ b/src/iop/overlay.c
@@ -1004,7 +1004,7 @@ static void _drag_and_drop_received(GtkWidget *widget,
       {
         dt_control_log
           (_("cannot use image %d as an overlay"
-             " as it is using the current image as an overlay itself"),
+             " as it is using the current image as an overlay, directly or indirectly"),
            imgid);
       }
       else


### PR DESCRIPTION
Query image -> overlay dependencies recursively, preventing indirect loops (1 -> 2 -> 3 -> 1).
Changed some variable names and the error message; please let me know if I did something wrong.