### PR TITLE
po/local copy color - use documented color, fix size of preserved border

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -2221,11 +2221,11 @@ Details :
 
 .dt_group_right #thumb-localcopy
 {
-  border-right: 0.14em solid rgb(255, 187, 0); /* to not overlay thumb borders */
+  border-right: 0.07em solid rgb(255, 187, 0); /* to not overlay thumb borders */
 }
 .dt_group_top #thumb-localcopy
 {
-  border-top: 0.14em solid rgb(255, 187, 0); /* to not overlay thumb borders */
+  border-top: 0.07em solid rgb(255, 187, 0); /* to not overlay thumb borders */
 }
 
 /*---------------------------------------------------------


### PR DESCRIPTION

Before:

![image](https://github.com/user-attachments/assets/8b4d348e-f4a0-4e3e-b82b-631b3336331f)

![image](https://github.com/user-attachments/assets/1ba59f68-e461-4f04-aac6-8289f2e5101e)

After:

![image](https://github.com/user-attachments/assets/2d0e824e-1030-4b30-9b81-12cec742558e)

![image](https://github.com/user-attachments/assets/7ba19239-9e55-4692-a5b4-cd054b2fedc9)
