### PR TITLE
Various OpenCL fixes and maintenance

### DIFF
--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -295,7 +295,8 @@ void dt_iop_clip_and_zoom_mosaic_half_size(uint16_t *const out,
   }
 }
 
-void dt_iop_clip_and_zoom_mosaic_half_size_f(float *const out, const float *const in,
+void dt_iop_clip_and_zoom_mosaic_half_size_f(float *const out,
+                                             const float *const in,
                                              const dt_iop_roi_t *const roi_out,
                                              const dt_iop_roi_t *const roi_in,
                                              const int32_t out_stride,
@@ -485,10 +486,13 @@ void dt_iop_clip_and_zoom_mosaic_half_size_f(float *const out, const float *cons
  * downscales and clips a Fujifilm X-Trans mosaiced buffer (in) to the given region of interest (r_*)
  * and writes it to out.
  */
-void dt_iop_clip_and_zoom_mosaic_third_size_xtrans(uint16_t *const out, const uint16_t *const in,
+void dt_iop_clip_and_zoom_mosaic_third_size_xtrans(uint16_t *const out,
+                                                   const uint16_t *const in,
                                                    const dt_iop_roi_t *const roi_out,
-                                                   const dt_iop_roi_t *const roi_in, const int32_t out_stride,
-                                                   const int32_t in_stride, const uint8_t (*const xtrans)[6])
+                                                   const dt_iop_roi_t *const roi_in,
+                                                   const int32_t out_stride,
+                                                   const int32_t in_stride,
+                                                   const uint8_t (*const xtrans)[6])
 {
   const float px_footprint = 1.f / roi_out->scale;
   // Use box filter of width px_footprint*2+1 centered on the current
@@ -565,13 +569,12 @@ void dt_iop_clip_and_zoom_mosaic_third_size_xtrans_f(float *const out,
   }
 }
 
-void dt_iop_clip_and_zoom_demosaic_passthrough_monochrome_f
-  (float *out,
-   const float *const in,
-   const dt_iop_roi_t *const roi_out,
-   const dt_iop_roi_t *const roi_in,
-   const int32_t out_stride,
-   const int32_t in_stride)
+void dt_iop_clip_and_zoom_demosaic_passthrough_monochrome_f(float *out,
+                                                            const float *const in,
+                                                            const dt_iop_roi_t *const roi_out,
+                                                            const dt_iop_roi_t *const roi_in,
+                                                            const int32_t out_stride,
+                                                            const int32_t in_stride)
 {
   // adjust to pixel region and don't sample more than scale/2 nbs!
   // pixel footprint on input buffer, radius:
@@ -706,7 +709,8 @@ void dt_iop_clip_and_zoom_demosaic_passthrough_monochrome_f
   }
 }
 
-void dt_iop_clip_and_zoom_demosaic_half_size_f(float *out, const float *const in,
+void dt_iop_clip_and_zoom_demosaic_half_size_f(float *out,
+                                               const float *const in,
                                                const dt_iop_roi_t *const roi_out,
                                                const dt_iop_roi_t *const roi_in,
                                                const int32_t out_stride,
@@ -883,7 +887,8 @@ void dt_iop_clip_and_zoom_demosaic_half_size_f(float *out, const float *const in
 }
 
 
-void dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f(float *out, const float *const in,
+void dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f(float *out,
+                                                       const float *const in,
                                                        const dt_iop_roi_t *const roi_out,
                                                        const dt_iop_roi_t *const roi_in,
                                                        const int32_t out_stride,

--- a/src/iop/demosaicing/basics.c
+++ b/src/iop/demosaicing/basics.c
@@ -267,7 +267,10 @@ static int color_smoothing_cl(
                                   .sizex = 1 << 8, .sizey = 1 << 8 };
 
   if(!dt_opencl_local_buffer_opt(devid, gd->kernel_color_smoothing, &locopt))
+  {
+    err = CL_INVALID_WORK_DIMENSION;
     goto error;
+  }
 
   // two buffer references for our ping-pong
   cl_mem dev_t1 = dev_out;
@@ -642,8 +645,10 @@ static int process_default_cl(
     }
 
     if(piece->pipe->want_detail_mask)
+    {
       err = dt_dev_write_scharr_mask_cl(piece, dev_aux, roi_in, TRUE);
-    if(err != CL_SUCCESS) goto error;
+      if(err != CL_SUCCESS) goto error;
+    }
 
     if(scaled)
     {

--- a/src/iop/demosaicing/xtrans.c
+++ b/src/iop/demosaicing/xtrans.c
@@ -40,13 +40,12 @@ static inline const short *_hexmap(
 /*
    Frank Markesteijn's algorithm for Fuji X-Trans sensors
 */
-static void xtrans_markesteijn_interpolate(
-        float *out,
-        const float *const in,
-        const dt_iop_roi_t *const roi_out,
-        const dt_iop_roi_t *const roi_in,
-        const uint8_t (*const xtrans)[6],
-        const int passes)
+static void xtrans_markesteijn_interpolate(float *out,
+                                           const float *const in,
+                                           const dt_iop_roi_t *const roi_out,
+                                           const dt_iop_roi_t *const roi_in,
+                                           const uint8_t (*const xtrans)[6],
+                                           const int passes)
 {
   static const short orth[12] = { 1, 0, 0, 1, -1, 0, 0, -1, 1, 0, 0, 1 },
                      patt[2][16] = { { 0, 1, 0, -1, 2, 0, -1, 0, 1, 1, 1, -1, 0, 0, 0, 0 },
@@ -517,13 +516,12 @@ static void xtrans_markesteijn_interpolate(
 #undef TS
 
 #define TS 122
-static void xtrans_fdc_interpolate(
-        struct dt_iop_module_t *self,
-        float *out,
-        const float *const in,
-        const dt_iop_roi_t *const roi_out,
-        const dt_iop_roi_t *const roi_in,
-        const uint8_t (*const xtrans)[6])
+static void xtrans_fdc_interpolate(dt_iop_module_t *self,
+                                   float *out,
+                                   const float *const in,
+                                   const dt_iop_roi_t *const roi_out,
+                                   const dt_iop_roi_t *const roi_in,
+                                   const uint8_t (*const xtrans)[6])
 {
   static const short orth[12] = { 1, 0, 0, 1, -1, 0, 0, -1, 1, 0, 0, 1 },
                      patt[2][16] = { { 0, 1, 0, -1, 2, 0, -1, 0, 1, 1, 1, -1, 0, 0, 0, 0 },
@@ -1637,14 +1635,13 @@ static void xtrans_fdc_interpolate(
 #undef TS
 
 #ifdef HAVE_OPENCL
-static int process_markesteijn_cl(
-        struct dt_iop_module_t *self,
-        dt_dev_pixelpipe_iop_t *piece,
-        cl_mem dev_in,
-        cl_mem dev_out,
-        const dt_iop_roi_t *const roi_in,
-        const dt_iop_roi_t *const roi_out,
-        const gboolean smooth)
+static int process_markesteijn_cl(dt_iop_module_t *self,
+                                  dt_dev_pixelpipe_iop_t *piece,
+                                  cl_mem dev_in,
+                                  cl_mem dev_out,
+                                  const dt_iop_roi_t *const roi_in,
+                                  const dt_iop_roi_t *const roi_out,
+                                  const gboolean smooth)
 {
   dt_iop_demosaic_data_t *data = piece->data;
   dt_iop_demosaic_global_data_t *gd = self->global_data;
@@ -2047,12 +2044,10 @@ static int process_markesteijn_cl(
       if(err != CL_SUCCESS) goto error;
     }
 
-    {
-      // adjust maximum value
-      err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_markesteijn_homo_max_corr, width, height,
+    // adjust maximum value
+    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_markesteijn_homo_max_corr, width, height,
         CLARG(dev_aux), CLARG(width), CLARG(height), CLARG(pad_tile));
-      if(err != CL_SUCCESS) goto error;
-    }
+    if(err != CL_SUCCESS) goto error;
 
     // for Markesteijn-3: use only one of two directions if there is a difference in homogeneity
     for(int d = 0; d < ndir - 4; d++)
@@ -2062,16 +2057,14 @@ static int process_markesteijn_cl(
       if(err != CL_SUCCESS) goto error;
     }
 
-    {
-      // initialize output buffer to zero
-      err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_markesteijn_zero, width, height,
+    // initialize output buffer to zero
+    err = dt_opencl_enqueue_kernel_2d_args(devid, gd->kernel_markesteijn_zero, width, height,
         CLARG(dev_tmp), CLARG(width), CLARG(height), CLARG(pad_tile));
-      if(err != CL_SUCCESS) goto error;
-    }
+    if(err != CL_SUCCESS) goto error;
 
-    // need to get another temp buffer for the output image (may use the space of dev_drv[] freed earlier)
+    // need to get another temp image for the output image
     err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
-    dev_tmptmp = dt_opencl_alloc_device(devid, (size_t)width, height, sizeof(float) * 4);
+    dev_tmptmp = dt_opencl_alloc_device(devid, width, height, sizeof(float) * 4);
     if(dev_tmptmp == NULL) goto error;
 
     cl_mem dev_t1 = dev_tmp;
@@ -2111,16 +2104,8 @@ static int process_markesteijn_cl(
     {
       dt_opencl_release_mem_object(dev_rgbv[n]);
       dev_rgbv[n] = NULL;
-    }
-
-    for(int n = 0; n < 8; n++)
-    {
       dt_opencl_release_mem_object(dev_homo[n]);
       dev_homo[n] = NULL;
-    }
-
-    for(int n = 0; n < 8; n++)
-    {
       dt_opencl_release_mem_object(dev_homosum[n]);
       dev_homosum[n] = NULL;
     }
@@ -2181,7 +2166,7 @@ static int process_markesteijn_cl(
       if(err != CL_SUCCESS) goto error;
 
       // VNG processing
-      err = process_vng_cl(self, piece, dev_edge_in, dev_edge_out, &roi, &roi, smooth, qual_flags & DT_DEMOSAIC_ONLY_VNG_LINEAR);
+      err = process_vng_cl(self, piece, dev_edge_in, dev_edge_out, &roi, &roi, smooth, qual_flags & DT_DEMOSAIC_ONLY_VNG_LINEAR, FALSE);
       if(err != CL_SUCCESS) goto error;
 
       // adjust for "good" part, dropping linear border where possible
@@ -2203,8 +2188,10 @@ static int process_markesteijn_cl(
     }
 
     if(piece->pipe->want_detail_mask)
+    {
       err = dt_dev_write_scharr_mask_cl(piece, dev_tmp, roi_in, TRUE);
-    if(err != CL_SUCCESS) goto error;
+      if(err != CL_SUCCESS) goto error;
+    }
 
     if(scaled)
     {

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2315,7 +2315,10 @@ static int process_wavelets_cl(struct dt_iop_module_t *self,
                                   .sizey = 1u << 4 };
 
   if(!dt_opencl_local_buffer_opt(devid, gd->kernel_denoiseprofile_reduce_first, &flocopt))
+  {
+    err = CL_INVALID_WORK_DIMENSION;
     goto error;
+  }
 
   const size_t bwidth = ROUNDUP(width, flocopt.sizex);
   const size_t bheight = ROUNDUP(height, flocopt.sizey);
@@ -2333,7 +2336,10 @@ static int process_wavelets_cl(struct dt_iop_module_t *self,
                                   .sizey = 1 };
 
   if(!dt_opencl_local_buffer_opt(devid, gd->kernel_denoiseprofile_reduce_first, &slocopt))
+  {
+    err = CL_INVALID_WORK_DIMENSION;
     goto error;
+  }
 
   const int reducesize = MIN(REDUCESIZE, ROUNDUP(bufsize, slocopt.sizex) / slocopt.sizex);
   err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
@@ -2870,7 +2876,7 @@ void reload_defaults(dt_iop_module_t *module)
 void init_global(dt_iop_module_so_t *module)
 {
   const int program = 11; // denoiseprofile.cl, from programs.conf
-  dt_iop_denoiseprofile_global_data_t *gd = 
+  dt_iop_denoiseprofile_global_data_t *gd =
       malloc(sizeof(dt_iop_denoiseprofile_global_data_t));
 
   module->data = gd;


### PR DESCRIPTION
1. When using OpenCL markesteijn demosaicer we avoid false-writing of scharr masks. The bug was in OpenCL vng demosaicer, we now call it with an extra flag requesting a scharr write.
2. If dt_opencl_local_buffer_opt() fails we either have to properly fix that (as done in gaussian for example) or we have to report the error and fallback to CPU. Fixes have been done in denoiseprofile, globaltonemap, demosaic color smoothing. In all these modules that could have lead to OpenCL problems resulting in garbled results or even crashes, there have been yet unexplained reports on smaller/older CL devices/drivers.
3. Fixed a missing OpenCL mem allocation check and fixed a few error codes for exactness.
4. To track down pixelpipe cache related performance issues we now report cache invalidating.
5. While checking above done some code maintenance: formatting, removing struct from function parameters if possible, some casting.
6. Added a few comments
