### PR TITLE
[GUI] Replace 'picture' by 'image' to unify terminology

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -978,7 +978,7 @@
     <name>ui_last/import_select_new</name>
     <type>bool</type>
     <default>true</default>
-    <shortdescription>select only new pictures</shortdescription>
+    <shortdescription>select only new images</shortdescription>
     <longdescription>only select images that have not already been imported</longdescription>
   </dtconfig>
   <dtconfig ui="yes">

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -222,7 +222,7 @@
     <name>slideshow_delay</name>
     <type>int</type>
     <default>5</default>
-    <shortdescription>waiting time between each picture in slideshow</shortdescription>
+    <shortdescription>waiting time between each image in slideshow</shortdescription>
   </dtconfig>
 <!-- be sure to keep the code in sync when changing this enum, see common/darktable.c void dt_get_sysresource_level() -->
   <dtconfig prefs="processing" section="cpugpu">

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -316,7 +316,7 @@ const char *aliases()
 
 const char **description(struct dt_iop_module_t *self)
 {
-  return dt_iop_set_description(self, _("add solid borders or margins around the picture"),
+  return dt_iop_set_description(self, _("add solid borders or margins around the image"),
                                       _("creative"),
                                       _("linear or non-linear, RGB, display-referred"),
                                       _("geometric, RGB"),
@@ -1000,7 +1000,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->frame_offset, 4);
   dt_bauhaus_slider_set_format(g->frame_offset, "%");
   gtk_widget_set_tooltip_text(g->frame_offset,
-                              _("offset of the frame line beginning on picture side"));
+                              _("offset of the frame line beginning on image side"));
 
   GdkRGBA color = (GdkRGBA){.red   = dp->color[0],
                             .green = dp->color[1],

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    Copyright (C) 2012-2023 darktable developers.
+    Copyright (C) 2012-2024 darktable developers.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -3842,7 +3842,7 @@ void gui_init(dt_iop_module_t *self)
                               _("controls the way parameters are autoset\n"
                                 "increase if shadows are not denoised enough\n"
                                 "or if chroma noise remains.\n"
-                                "this can happen if your picture is underexposed."));
+                                "this can happen if your image is underexposed."));
   gtk_widget_set_tooltip_text(g->shadows,
                               _("finetune shadows denoising.\n"
                                 "decrease to denoise more aggressively\n"

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1532,7 +1532,7 @@ void gui_init(dt_iop_module_t *self)
                       g->auto_button);
   gtk_widget_set_tooltip_text(g->auto_button, _("try to optimize the settings with some guessing.\n"
                                                 "this will fit the luminance range inside the histogram bounds.\n"
-                                                "works better for landscapes and evenly-lit pictures\nbut fails for high-keys and low-keys." ));
+                                                "works better for landscapes and evenly-lit images\nbut fails for high-keys and low-keys." ));
   gtk_box_pack_start(GTK_BOX(self->widget), g->auto_button, TRUE, TRUE, 0);
 
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(C_("section", "filmic S curve")), FALSE, FALSE, 0);

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -4430,8 +4430,8 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->auto_button, NULL, N_("auto tune levels"));
   gtk_widget_set_tooltip_text(g->auto_button, _("try to optimize the settings with some statistical assumptions.\n"
                                                 "this will fit the luminance range inside the histogram bounds.\n"
-                                                "works better for landscapes and evenly-lit pictures\n"
-                                                "but fails for high-keys, low-keys and high-ISO pictures.\n"
+                                                "works better for landscapes and evenly-lit images\n"
+                                                "but fails for high-keys, low-keys and high-ISO images.\n"
                                                 "this is not an artificial intelligence, but a simple guess.\n"
                                                 "ensure you understand its assumptions before using it."));
   gtk_box_pack_start(GTK_BOX(self->widget), g->auto_button, FALSE, FALSE, 0);
@@ -4623,8 +4623,8 @@ void gui_init(dt_iop_module_t *self)
   g->noise_level = dt_bauhaus_slider_from_params(self, "noise_level");
   gtk_widget_set_tooltip_text(g->noise_level, _("add statistical noise in reconstructed highlights.\n"
                                                 "this avoids highlights to look too smooth\n"
-                                                "when the picture is noisy overall,\n"
-                                                "so they blend with the rest of the picture."));
+                                                "when the image is noisy overall,\n"
+                                                "so they blend with the rest of the image."));
 
   // Noise distribution
   g->noise_distribution = dt_bauhaus_combobox_from_params(self, "noise_distribution");

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -109,7 +109,7 @@ const char *aliases()
 
 const char **description(struct dt_iop_module_t *self)
 {
-  return dt_iop_set_description(self, _("remove fog and atmospheric hazing from pictures"),
+  return dt_iop_set_description(self, _("remove fog and atmospheric hazing from images"),
                                       _("corrective"),
                                       _("linear, RGB, scene-referred"),
                                       _("frequential, RGB"),

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -139,7 +139,7 @@ const char *name()
 
 const char **description(struct dt_iop_module_t *self)
 {
-  return dt_iop_set_description(self, _("denoise the raw picture early in the pipeline"),
+  return dt_iop_set_description(self, _("denoise the raw image early in the pipeline"),
                                       _("corrective"),
                                       _("linear, raw, scene-referred"),
                                       _("linear, raw"),

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -414,7 +414,7 @@ const char *name()
 
 const char **description(struct dt_iop_module_t *self)
 {
-  return dt_iop_set_description(self, _("overlay an SVG watermark like a signature on the picture"),
+  return dt_iop_set_description(self, _("overlay an SVG watermark like a signature on the image"),
                                       _("creative"),
                                       _("non-linear, RGB, display-referred"),
                                       _("non-linear, RGB"),

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -88,7 +88,7 @@ typedef enum dt_import_cols_t
   DT_IMPORT_UI_FILENAME,        // displayed filename
   DT_IMPORT_FILENAME,           // filename
   DT_IMPORT_UI_DATETIME,        // displayed datetime
-  DT_IMPORT_UI_EXISTS,          // whether the picture is already imported
+  DT_IMPORT_UI_EXISTS,          // whether the image is already imported
   DT_IMPORT_DATETIME,           // file datetime
   DT_IMPORT_NUM_COLS
 } dt_import_cols_t;
@@ -459,7 +459,7 @@ static GdkPixbuf *_import_get_thumbnail(const gchar *filename)
     no_preview_fallback = TRUE;
   }
 
-  // Step 1: try to check whether the picture contains embedded thumbnail
+  // Step 1: try to check whether the image contains embedded thumbnail
   // In case it has, we'll use that thumbnail to show on the dialog
   if(!no_preview_fallback)
   {
@@ -1901,7 +1901,7 @@ static void _set_files_list(GtkWidget *rbox, dt_lib_module_t* self)
   gtk_tree_view_column_set_alignment(column, 0.5);
   gtk_tree_view_column_set_min_width(column, DT_PIXEL_APPLY_DPI(25));
   GtkWidget *header = gtk_tree_view_column_get_button(column);
-  gtk_widget_set_tooltip_text(header, _("mark already imported pictures"));
+  gtk_widget_set_tooltip_text(header, _("mark already imported images"));
 
   renderer = gtk_cell_renderer_text_new();
   column = gtk_tree_view_column_new_with_attributes(_("name"), renderer, "text",


### PR DESCRIPTION
In fact, the term "image" is used almost always in darktable, but there are a few instances of the term "picture" (about 2% of the total usage of the term "image"). This PR unifies the terminology.

Two exceptions where we refer to external names:
- One of the standard places in the import dialog. Here we are referring to the name of a subdirectory in the user's home directory called Pictures.
- An option in the image hint of the WebP encoder called picture.