### PR TITLE
keep yes/no dialog on top

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2981,6 +2981,7 @@ gboolean dt_gui_show_standalone_yes_no_dialog(const char *title,
   }
 
   gtk_widget_show_all(window);
+  gtk_window_set_keep_above(GTK_WINDOW(window), TRUE);
   gtk_main();
 
   return result.result == RESULT_YES;


### PR DESCRIPTION
With the splash screen being the topmost window we may run into the situation that the yes/no dialog may be completely hidden behind the splash screen, waiting forever for a user response.

![Bildschirmfoto 2024-10-18 um 12 57 36](https://github.com/user-attachments/assets/63106018-07a6-4561-a7e0-fce601b36b6b)

This PR sets the yes/no dialog as the topmost window so it will always be in front of the splash screen.

![Bildschirmfoto 2024-10-18 um 12 58 55](https://github.com/user-attachments/assets/50f96615-44a2-442e-b1c9-a3d40bc766c9)
