### PR TITLE
[imageio] Radically speed up PFM loading

### DIFF
--- a/src/imageio/imageio_pfm.c
+++ b/src/imageio/imageio_pfm.c
@@ -99,7 +99,7 @@ DT_OMP_FOR(collapse(2))
         dt_aligned_pixel_t pix = {0.0f, 0.0f, 0.0f, 0.0f};
         for_three_channels(c)
         {
-        value.f = readbuf[3 * (j * img->width + i) + c];
+        value.f = readbuf[3 * ((img->height - 1 - j) * img->width + i) + c];
         if(swap_byte_order) value.i = GUINT32_SWAP_LE_BE(value.i);
         pix[c] = value.f;
         }
@@ -114,25 +114,13 @@ DT_OMP_FOR(collapse(2))
     for(size_t j = 0; j < img->height; j++)
       for(size_t i = 0; i < img->width; i++)
       {
-        value.f = readbuf[(j * img->width + i)];
+        value.f = readbuf[((img->height - 1 - j) * img->width + i)];
         if(swap_byte_order) value.i = GUINT32_SWAP_LE_BE(value.i);
         buf[4 * (img->width * j + i) + 2] = buf[4 * (img->width * j + i) + 1]
             = buf[4 * (img->width * j + i) + 0] = value.f;
       }
   }
 
-  float *line = (float *)calloc(4 * img->width, sizeof(float));
-  if(line == NULL) goto error_cache_full;
-
-  for(size_t j = 0; j < img->height / 2; j++)
-  {
-    memcpy(line, buf + img->width * j * 4, sizeof(float) * 4 * img->width);
-    memcpy(buf + img->width * j * 4, buf + img->width * (img->height - 1 - j) * 4,
-           sizeof(float) * 4 * img->width);
-    memcpy(buf + img->width * (img->height - 1 - j) * 4, line, sizeof(float) * 4 * img->width);
-  }
-
-  free(line);
   fclose(f);
   dt_free_align(readbuf);
 

--- a/src/imageio/imageio_pfm.c
+++ b/src/imageio/imageio_pfm.c
@@ -92,6 +92,7 @@ dt_imageio_retval_t dt_imageio_open_pfm(dt_image_t *img, const char *filename, d
   {
     ret = fread(readbuf, 3 * sizeof(float), npixels, f);
 
+DT_OMP_FOR(collapse(2))
     for(size_t j = 0; j < img->height; j++)
       for(size_t i = 0; i < img->width; i++)
       {
@@ -109,6 +110,7 @@ dt_imageio_retval_t dt_imageio_open_pfm(dt_image_t *img, const char *filename, d
   {
     ret = fread(readbuf, sizeof(float), npixels, f);
 
+DT_OMP_FOR(collapse(2))
     for(size_t j = 0; j < img->height; j++)
       for(size_t i = 0; i < img->width; i++)
       {

--- a/src/imageio/imageio_pfm.c
+++ b/src/imageio/imageio_pfm.c
@@ -34,21 +34,32 @@
 #include <time.h>
 #include <unistd.h>
 
-dt_imageio_retval_t dt_imageio_open_pfm(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *mbuf)
+dt_imageio_retval_t dt_imageio_open_pfm(dt_image_t *img,
+                                        const char *filename,
+                                        dt_mipmap_buffer_t *mbuf)
 {
   const char *ext = filename + strlen(filename);
-  while(*ext != '.' && ext > filename) ext--;
-  if(strcasecmp(ext, ".pfm")) return DT_IMAGEIO_LOAD_FAILED;
+
+  while(*ext != '.' && ext > filename)
+    ext--;
+
+  if(strcasecmp(ext, ".pfm"))
+    return DT_IMAGEIO_LOAD_FAILED;
 
   FILE *f = g_fopen(filename, "rb");
-  if(!f) return DT_IMAGEIO_FILE_NOT_FOUND;
+  if(!f)
+    return DT_IMAGEIO_FILE_NOT_FOUND;
 
   int ret = 0;
   int cols = 3;
   float scale_factor;
   char head[2] = { 'X', 'X' };
+
   ret = fscanf(f, "%c%c\n", head, head + 1);
-  if(ret != 2 || head[0] != 'P') goto error_corrupt;
+
+  if(ret != 2 || head[0] != 'P')
+    goto error_corrupt;
+
   if(head[1] == 'F')
     cols = 3;
   else if(head[1] == 'f')
@@ -59,18 +70,25 @@ dt_imageio_retval_t dt_imageio_open_pfm(dt_image_t *img, const char *filename, d
   char width_string[10] = { 0 };
   char height_string[10] = { 0 };
   char scale_factor_string[64] = { 0 };
+
   ret = fscanf(f, "%9s %9s %63s%*[^\n]", width_string, height_string, scale_factor_string);
-  if(ret != 3) goto error_corrupt;
+
+  if(ret != 3)
+    goto error_corrupt;
 
   errno = 0;
   img->width = strtol(width_string, NULL, 0);
   img->height = strtol(height_string, NULL, 0);
   scale_factor = g_ascii_strtod(scale_factor_string, NULL);
-  if(errno != 0) goto error_corrupt;
-  if(img->width <= 0 || img->height <= 0 ) goto error_corrupt;
+
+  if(errno != 0)
+    goto error_corrupt;
+  if(img->width <= 0 || img->height <= 0 )
+    goto error_corrupt;
 
   ret = fread(&ret, sizeof(char), 1, f);
-  if(ret != 1) goto error_corrupt;
+  if(ret != 1)
+    goto error_corrupt;
   ret = 0;
 
   int swap_byte_order = (scale_factor >= 0.0) ^ (G_BYTE_ORDER == G_BIG_ENDIAN);
@@ -78,7 +96,8 @@ dt_imageio_retval_t dt_imageio_open_pfm(dt_image_t *img, const char *filename, d
   img->buf_dsc.channels = 4;
   img->buf_dsc.datatype = TYPE_FLOAT;
   float *buf = (float *)dt_mipmap_cache_alloc(mbuf, img);
-  if(!buf) goto error_cache_full;
+  if(!buf)
+    goto error_cache_full;
 
   const size_t npixels = (size_t)img->width * img->height;
 


### PR DESCRIPTION
The original code used a clever trick to allow format conversion (3float -> 4float) in-place (it went _sequentially_(!) from the end of the data buffer to the beginning thus ensuring that the data would not be overwritten). Unfortunately, this made the code OpenMP-incompatible. The use of two buffers (input data and output for darktable) made it possible to parallelize the format conversion loops.

Also, the code contained a separate loop for reordering image rows (bottom-top to top-bottom) using a temporary row buffer. In effect, this meant copying the entire array of image data twice more. For large images it took quite a significant amount of time.

We managed to get rid of these rows reordering by copying the rows to the correct address directly in the format conversion loop.

As a result, for example, a PFM file converted from a 45 megapixel Nikon Z7 camera image on a computer with an AMD Ryzen 7 5800HS CPU was loaded with the original code in 0.45 seconds, after changes in this PR in 0.09 seconds (<ins>fivefold</ins> speed up!).
